### PR TITLE
fix: provider timeoutSeconds does not raise the LLM stream watchdog ceiling

### DIFF
--- a/src/agents/embedded-agent-runner/model.configured-fallback.ts
+++ b/src/agents/embedded-agent-runner/model.configured-fallback.ts
@@ -13,13 +13,13 @@ import {
   findConfiguredProviderModel,
   hasConfiguredFallbackSurface,
   mergeConfiguredRuntimeModelParams,
-  resolveConfiguredProviderConfig,
   resolveConfiguredProviderDefaultApi,
   shouldSuppressConfiguredModel,
   type StaticCatalogFallbackModel,
 } from "./model.configured-overrides.js";
 import {
   normalizeResolvedTransportApi,
+  resolveConfiguredProviderConfig,
   resolveProviderModelInput,
   sanitizeModelHeaders,
 } from "./model.inline-provider.js";
@@ -27,7 +27,6 @@ import {
   normalizeResolvedModel,
   normalizeTransportBaseUrl,
   type ProviderRuntimeHooks,
-  resolveProviderRequestTimeoutMs,
   resolveProviderTransport,
 } from "./model.provider-hooks.js";
 import {
@@ -46,7 +45,6 @@ export function resolveConfiguredFallbackModel(params: {
 }): Model | undefined {
   const { provider, modelId, cfg, agentDir, workspaceDir, runtimeHooks } = params;
   const providerConfig = resolveConfiguredProviderConfig(cfg, provider);
-  const requestTimeoutMs = resolveProviderRequestTimeoutMs(providerConfig?.timeoutSeconds);
   const configuredModel = findConfiguredProviderModel(providerConfig, provider, modelId);
   if (!hasConfiguredFallbackSurface({ providerConfig, configuredModel, modelId })) {
     return undefined;
@@ -200,7 +198,6 @@ export function resolveConfiguredFallbackModel(params: {
               }
             : {}),
           ...(resolvedParams ? { params: resolvedParams } : {}),
-          ...(requestTimeoutMs !== undefined ? { requestTimeoutMs } : {}),
           headers: requestConfig.headers,
           ...(providerConfig?.authHeader !== undefined
             ? { authHeader: providerConfig.authHeader }

--- a/src/agents/embedded-agent-runner/model.configured-overrides.ts
+++ b/src/agents/embedded-agent-runner/model.configured-overrides.ts
@@ -5,7 +5,7 @@ import type { Api, Model } from "../../llm/types.js";
 import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
 import { resolveCatalogOwnedModelCompat } from "../model-compat-catalog.js";
 import { modelKey, normalizeStaticProviderModelId } from "../model-ref-shared.js";
-import { findNormalizedProviderValue, normalizeProviderId } from "../model-selection.js";
+import { normalizeProviderId } from "../model-selection.js";
 import { shouldSuppressBuiltInModel, shouldUnconditionallySuppress } from "../model-suppression.js";
 import { attachModelProviderLocalService } from "../provider-local-service.js";
 import {
@@ -26,11 +26,7 @@ import {
   sanitizeModelHeaders,
 } from "./model.inline-provider.js";
 import type { ProviderRuntimeHooks } from "./model.provider-hooks.js";
-import {
-  normalizeTransportBaseUrl,
-  resolveProviderRequestTimeoutMs,
-  resolveProviderTransport,
-} from "./model.provider-hooks.js";
+import { normalizeTransportBaseUrl, resolveProviderTransport } from "./model.provider-hooks.js";
 import {
   resolveBundledStaticCatalogModel,
   type ManifestModelCatalogProviderAliasMetadata,
@@ -144,19 +140,6 @@ export function findInlineModelMatch(params: {
   const normalizedProvider = normalizeProviderId(params.provider);
   return inlineModels.find(
     (entry) => normalizeProviderId(entry.provider) === normalizedProvider && matchesModelId(entry),
-  );
-}
-
-export function resolveConfiguredProviderConfig(
-  cfg: OpenClawConfig | undefined,
-  provider: string,
-): InlineProviderConfig | undefined {
-  const configuredProviders = cfg?.models?.providers;
-  if (!configuredProviders) {
-    return undefined;
-  }
-  return (
-    configuredProviders[provider] ?? findNormalizedProviderValue(configuredProviders, provider)
   );
 }
 
@@ -322,7 +305,6 @@ export function applyConfiguredProviderOverrides(params: {
   const { providerConfig, modelId } = params;
   const discoveredModel = markDiscoveredMaxTokensSource(params.discoveredModel);
   const manifestAliasTransport = params.manifestAlias.transport;
-  const requestTimeoutMs = resolveProviderRequestTimeoutMs(providerConfig?.timeoutSeconds);
   const defaultModelParams = findConfiguredAgentModelParams({
     cfg: params.cfg,
     provider: params.provider,
@@ -418,7 +400,6 @@ export function applyConfiguredProviderOverrides(params: {
     providerConfig.contextWindow === undefined &&
     providerConfig.contextTokens === undefined &&
     providerConfig.maxTokens === undefined &&
-    requestTimeoutMs === undefined &&
     !providerHeaders &&
     !providerRequest &&
     !providerParams &&
@@ -581,7 +562,6 @@ export function applyConfiguredProviderOverrides(params: {
             }
           : {}),
         ...(resolvedParams ? { params: resolvedParams } : {}),
-        ...(requestTimeoutMs !== undefined ? { requestTimeoutMs } : {}),
         headers: requestConfig.headers,
         ...(providerConfig.authHeader !== undefined
           ? { authHeader: providerConfig.authHeader }

--- a/src/agents/embedded-agent-runner/model.inline-provider.test.ts
+++ b/src/agents/embedded-agent-runner/model.inline-provider.test.ts
@@ -295,6 +295,33 @@ describe("buildInlineProviderModels", () => {
   });
 });
 
+describe("buildInlineProviderModels request timeout inheritance", () => {
+  it("inherits provider timeoutSeconds onto every inline model", () => {
+    const result = buildInlineProviderModels({
+      custom: {
+        baseUrl: "http://127.0.0.1:8080/v1",
+        timeoutSeconds: 3600,
+        models: [{ id: "model-a" }, { id: "model-b" }],
+      },
+    } as unknown as Parameters<typeof buildInlineProviderModels>[0]);
+
+    expect(result).toHaveLength(2);
+    for (const model of result) {
+      expect((model as { requestTimeoutMs?: number }).requestTimeoutMs).toBe(3_600_000);
+    }
+  });
+
+  it("omits requestTimeoutMs when the provider declares no timeoutSeconds", () => {
+    const result = buildInlineProviderModels({
+      custom: { baseUrl: "http://127.0.0.1:8080/v1", models: [{ id: "model-a" }] },
+    } as unknown as Parameters<typeof buildInlineProviderModels>[0]);
+
+    expect(expectDefined(result[0], "result[0] test invariant")).not.toHaveProperty(
+      "requestTimeoutMs",
+    );
+  });
+});
+
 describe("resolveProviderModelInput", () => {
   it("keeps configured Anthropic model input unchanged before provider-owned normalization", () => {
     expect(

--- a/src/agents/embedded-agent-runner/model.inline-provider.ts
+++ b/src/agents/embedded-agent-runner/model.inline-provider.ts
@@ -1,11 +1,14 @@
 /**
  * Converts inline provider model config into runtime model definitions.
  */
+import { finiteSecondsToTimerSafeMilliseconds } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import type { ModelDefinitionConfig, ModelProviderConfig } from "../../config/types.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { normalizeGoogleApiBaseUrl } from "../../infra/google-api-base-url.js";
 import type { Api } from "../../llm/types.js";
 import { isSecretRefHeaderValueMarker } from "../model-auth-markers.js";
+import { findNormalizedProviderValue } from "../model-selection-normalize.js";
 import { attachModelProviderLocalService } from "../provider-local-service.js";
 import {
   attachModelProviderRequestTransport,
@@ -17,6 +20,7 @@ import {
  * Normalizes inline `models.providers` config into runtime model entries.
  */
 type InlineModelEntry = Omit<ModelDefinitionConfig, "api"> & {
+  requestTimeoutMs?: number;
   api?: Api;
   provider: string;
   baseUrl?: string;
@@ -37,6 +41,30 @@ export type InlineProviderConfig = {
   request?: ModelProviderConfig["request"];
   localService?: ModelProviderConfig["localService"];
 };
+
+/**
+ * Resolves the configured provider entry for `provider`, falling back to the
+ * normalized-id lookup so `models.providers` keys match how callers spell the
+ * provider. Kept here beside `InlineProviderConfig` so every consumer shares one
+ * lookup policy instead of re-deriving it.
+ */
+export function resolveConfiguredProviderConfig(
+  cfg: OpenClawConfig | undefined,
+  provider: string,
+): InlineProviderConfig | undefined {
+  const configuredProviders = cfg?.models?.providers;
+  if (!configuredProviders) {
+    return undefined;
+  }
+  return (
+    configuredProviders[provider] ?? findNormalizedProviderValue(configuredProviders, provider)
+  );
+}
+
+/** Converts `models.providers.<id>.timeoutSeconds` into a timer-safe millisecond ceiling. */
+export function resolveProviderRequestTimeoutMs(timeoutSeconds: unknown): number | undefined {
+  return finiteSecondsToTimerSafeMilliseconds(timeoutSeconds, { floorSeconds: true });
+}
 
 /** Returns a supported transport API id from raw config values. */
 export function normalizeResolvedTransportApi(
@@ -151,6 +179,7 @@ export function buildInlineProviderModels(
       stripSecretRefMarkers: true,
     });
     const providerRequest = sanitizeConfiguredModelProviderRequest(entry?.request);
+    const requestTimeoutMs = resolveProviderRequestTimeoutMs(entry?.timeoutSeconds);
     return (entry?.models ?? []).map((model) => {
       const transport = resolveInlineProviderTransport({
         api: model.api ?? entry?.api,
@@ -177,6 +206,7 @@ export function buildInlineProviderModels(
             contextWindow: model.contextWindow ?? entry?.contextWindow,
             contextTokens: model.contextTokens ?? entry?.contextTokens,
             maxTokens: model.maxTokens ?? entry?.maxTokens,
+            ...(requestTimeoutMs !== undefined ? { requestTimeoutMs } : {}),
             input: resolveProviderModelInput({
               provider: trimmed,
               modelId: model.id,

--- a/src/agents/embedded-agent-runner/model.provider-hooks.ts
+++ b/src/agents/embedded-agent-runner/model.provider-hooks.ts
@@ -1,6 +1,6 @@
-import { finiteSecondsToTimerSafeMilliseconds } from "@openclaw/normalization-core/number-coercion";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { Api, Model } from "../../llm/types.js";
+import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
 import {
   applyProviderResolvedTransportWithPlugin,
   buildProviderUnknownModelHintWithPlugin,
@@ -13,7 +13,9 @@ import {
 import { canonicalizeOpenAIModelId } from "../openai-routing.js";
 import {
   normalizeResolvedTransportApi,
+  resolveConfiguredProviderConfig,
   resolveProviderModelInput,
+  resolveProviderRequestTimeoutMs,
 } from "./model.inline-provider.js";
 import { normalizeResolvedProviderModel } from "./model.provider-normalization.js";
 
@@ -86,7 +88,10 @@ export function resolveRuntimeHooks(params?: {
   return DEFAULT_PROVIDER_RUNTIME_HOOKS;
 }
 
-function canonicalizeLegacyResolvedModel(params: { provider: string; model: Model }): Model {
+function canonicalizeLegacyResolvedModel(params: {
+  provider: string;
+  model: ProviderRuntimeModel;
+}): ProviderRuntimeModel {
   const canonicalModelId = canonicalizeOpenAIModelId(params.provider, params.model.id);
   if (canonicalModelId === params.model.id) {
     return params.model;
@@ -144,7 +149,7 @@ export function normalizeResolvedModel(params: {
   agentDir?: string;
   workspaceDir?: string;
   runtimeHooks?: ProviderRuntimeHooks;
-}): Model {
+}): ProviderRuntimeModel {
   const normalizeModelCost = (cost: unknown): Model["cost"] => {
     if (!cost || typeof cost !== "object" || Array.isArray(cost)) {
       return { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
@@ -219,13 +224,26 @@ export function normalizeResolvedModel(params: {
       runtimeHooks,
       model: pluginNormalized ?? normalizedInputModel,
     });
-  return canonicalizeLegacyResolvedModel({
+  const canonicalModel = canonicalizeLegacyResolvedModel({
     provider: params.provider,
     model: normalizeResolvedProviderModel({
       provider: params.provider,
       model: fallbackTransportNormalized ?? pluginNormalized ?? normalizedInputModel,
     }),
   });
+  // `requestTimeoutMs` is host-owned config (`models.providers.<id>.timeoutSeconds`),
+  // so it must land *after* the provider plugin hooks above. Those hooks may
+  // legally return a freshly built model rather than a spread of their input;
+  // stamping earlier lets such a plugin drop the operator's timeout, and the
+  // stream watchdogs silently fall back to the implicit 120s/300s ceilings
+  // (#113092). This is the single terminal step of every resolution branch.
+  const requestTimeoutMs = resolveProviderRequestTimeoutMs(
+    resolveConfiguredProviderConfig(params.cfg, params.provider)?.timeoutSeconds,
+  );
+  if (requestTimeoutMs === undefined || canonicalModel.requestTimeoutMs === requestTimeoutMs) {
+    return canonicalModel;
+  }
+  return { ...canonicalModel, requestTimeoutMs };
 }
 
 export function resolveProviderTransport(params: {
@@ -264,8 +282,4 @@ export function normalizeTransportBaseUrl(baseUrl: unknown): string | undefined 
   }
   const trimmed = baseUrl.trim();
   return trimmed ? trimmed : undefined;
-}
-
-export function resolveProviderRequestTimeoutMs(timeoutSeconds: unknown): number | undefined {
-  return finiteSecondsToTimerSafeMilliseconds(timeoutSeconds, { floorSeconds: true });
 }

--- a/src/agents/embedded-agent-runner/model.provider-timeout.test.ts
+++ b/src/agents/embedded-agent-runner/model.provider-timeout.test.ts
@@ -1,0 +1,113 @@
+// Locks the `models.providers.<id>.timeoutSeconds` -> `requestTimeoutMs` contract
+// from config through model resolution. The schema help promises this key raises
+// the LLM idle/stream watchdog ceiling, so the field must survive every
+// resolution branch and every provider-plugin normalization hook (#113092).
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { resolveModelAsync } from "./model.js";
+import { createProviderRuntimeTestMock } from "./model.provider-runtime.test-support.js";
+
+const AGENT_DIR = "/tmp/agent";
+const PROVIDER = "ai-brick";
+const MODEL_ID = "ornith-1.0-35b";
+const TIMEOUT_SECONDS = 3600;
+const EXPECTED_TIMEOUT_MS = 3_600_000;
+
+type RuntimeHooks = ReturnType<typeof createProviderRuntimeTestMock>;
+
+/**
+ * Emulates a provider plugin whose `normalizeResolvedModel` hook returns a
+ * freshly constructed model instead of spreading the host-resolved one. This is
+ * legal for plugins, so any host-owned field stamped before the hook runs is
+ * silently dropped.
+ */
+function createRebuildingRuntimeHooks(): RuntimeHooks {
+  const base = createProviderRuntimeTestMock();
+  return {
+    ...base,
+    normalizeProviderResolvedModelWithPlugin: (params: {
+      provider: string;
+      context: { model: unknown };
+    }) => {
+      const model = params.context.model as Record<string, unknown>;
+      return {
+        id: model.id,
+        name: model.name,
+        provider: model.provider,
+        api: model.api,
+        baseUrl: model.baseUrl,
+        reasoning: model.reasoning,
+        input: model.input,
+        cost: model.cost,
+        contextWindow: model.contextWindow,
+        maxTokens: model.maxTokens,
+      };
+    },
+  } as RuntimeHooks;
+}
+
+function customProviderConfig(
+  overrides?: Partial<{ api: string; timeoutSeconds: number }>,
+): OpenClawConfig {
+  return {
+    models: {
+      providers: {
+        [PROVIDER]: {
+          baseUrl: "http://127.0.0.1:8080/v1",
+          ...(overrides?.timeoutSeconds !== undefined
+            ? { timeoutSeconds: overrides.timeoutSeconds }
+            : {}),
+          models: [
+            {
+              id: MODEL_ID,
+              name: "Ornith 1.0 35B",
+              ...(overrides?.api !== undefined ? { api: overrides.api } : {}),
+            },
+          ],
+        },
+      },
+    },
+  } as unknown as OpenClawConfig;
+}
+
+async function resolveForTest(cfg: OpenClawConfig, runtimeHooks?: RuntimeHooks) {
+  const result = await resolveModelAsync(PROVIDER, MODEL_ID, AGENT_DIR, cfg, {
+    authStorage: { mocked: true } as never,
+    // Empty registry: the model under test is declared inline in config, so
+    // resolution must not depend on discovered catalog rows.
+    modelRegistry: { find: () => null } as never,
+    skipAgentDiscovery: true,
+    runtimeHooks: runtimeHooks ?? createProviderRuntimeTestMock(),
+  });
+  if (!result.model) {
+    throw new Error(`expected model resolution to succeed, got error: ${result.error}`);
+  }
+  return result.model as { requestTimeoutMs?: number };
+}
+
+describe("provider timeoutSeconds -> requestTimeoutMs", () => {
+  it("stamps requestTimeoutMs for an inline custom provider model", async () => {
+    const model = await resolveForTest(
+      customProviderConfig({ api: "openai-completions", timeoutSeconds: TIMEOUT_SECONDS }),
+    );
+    expect(model.requestTimeoutMs).toBe(EXPECTED_TIMEOUT_MS);
+  });
+
+  it("stamps requestTimeoutMs for an inline model without an explicit api", async () => {
+    const model = await resolveForTest(customProviderConfig({ timeoutSeconds: TIMEOUT_SECONDS }));
+    expect(model.requestTimeoutMs).toBe(EXPECTED_TIMEOUT_MS);
+  });
+
+  it("omits requestTimeoutMs when the provider sets no timeoutSeconds", async () => {
+    const model = await resolveForTest(customProviderConfig({ api: "openai-completions" }));
+    expect(model.requestTimeoutMs).toBeUndefined();
+  });
+
+  it("keeps requestTimeoutMs when a provider plugin rebuilds the model", async () => {
+    const model = await resolveForTest(
+      customProviderConfig({ api: "openai-completions", timeoutSeconds: TIMEOUT_SECONDS }),
+      createRebuildingRuntimeHooks(),
+    );
+    expect(model.requestTimeoutMs).toBe(EXPECTED_TIMEOUT_MS);
+  });
+});

--- a/src/agents/embedded-agent-runner/model.registry-resolution.ts
+++ b/src/agents/embedded-agent-runner/model.registry-resolution.ts
@@ -13,10 +13,10 @@ import {
   applyConfiguredProviderOverrides,
   findInlineModelMatch,
   mergeStaticCatalogInlineModel,
-  resolveConfiguredProviderConfig,
   shouldSuppressConfiguredModel,
   type StaticCatalogFallbackModel,
 } from "./model.configured-overrides.js";
+import { resolveConfiguredProviderConfig } from "./model.inline-provider.js";
 import {
   DEFAULT_PROVIDER_RUNTIME_HOOKS,
   normalizeResolvedModel,

--- a/src/agents/embedded-agent-runner/model.ts
+++ b/src/agents/embedded-agent-runner/model.ts
@@ -19,10 +19,8 @@ import {
 } from "../sessions/index.js";
 import { mergeModelMediaInput } from "./model.compat.js";
 import { resolveConfiguredFallbackModel } from "./model.configured-fallback.js";
-import {
-  applyConfiguredProviderOverrides,
-  resolveConfiguredProviderConfig,
-} from "./model.configured-overrides.js";
+import { applyConfiguredProviderOverrides } from "./model.configured-overrides.js";
+import { resolveConfiguredProviderConfig } from "./model.inline-provider.js";
 import {
   DEFAULT_PROVIDER_RUNTIME_HOOKS,
   normalizeResolvedModel,

--- a/src/agents/embedded-agent-runner/run/attempt-stream-watchdog-timeouts.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-watchdog-timeouts.test.ts
@@ -1,0 +1,41 @@
+// Pins the reported #113092 scenario end to end: a self-hosted provider on
+// loopback whose `models.providers.<id>.timeoutSeconds` reaches both stream
+// watchdogs as `requestTimeoutMs`. Lives beside the resolver tests rather than
+// inside them because `llm-idle-timeout.test.ts` is at its max-lines ceiling.
+import { describe, expect, it } from "vitest";
+import { resolveLlmFirstEventTimeoutMs, resolveLlmIdleTimeoutMs } from "./llm-idle-timeout.js";
+
+// Matches the reported llama.cpp setup: loopback base URL, self-hosted provider.
+const reportedModel = {
+  baseUrl: "http://127.0.0.1:8080/v1",
+  id: "ornith-1.0-35b",
+  provider: "llama-cpp",
+};
+
+const PROVIDER_TIMEOUT_MS = 3_600_000;
+
+describe("provider request timeout reaches both stream watchdogs", () => {
+  it("raises both watchdogs to the provider request timeout", () => {
+    const params = { modelRequestTimeoutMs: PROVIDER_TIMEOUT_MS, model: reportedModel };
+    expect(resolveLlmIdleTimeoutMs(params)).toBe(PROVIDER_TIMEOUT_MS);
+    expect(resolveLlmFirstEventTimeoutMs(params)).toBe(PROVIDER_TIMEOUT_MS);
+  });
+
+  it("falls back to the 300s first-event guard without a provider request timeout", () => {
+    // Loopback opts out of gap policing entirely (idle 0), so the first-event
+    // guard is what aborts long local prompt evaluation. This is the abort the
+    // report observed at ~300s.
+    expect(resolveLlmIdleTimeoutMs({ model: reportedModel })).toBe(0);
+    expect(resolveLlmFirstEventTimeoutMs({ model: reportedModel })).toBe(300_000);
+  });
+
+  it("keeps an explicit shorter run budget above the provider request timeout", () => {
+    const params = {
+      runTimeoutMs: 45_000,
+      modelRequestTimeoutMs: PROVIDER_TIMEOUT_MS,
+      model: reportedModel,
+    };
+    expect(resolveLlmIdleTimeoutMs(params)).toBe(45_000);
+    expect(resolveLlmFirstEventTimeoutMs(params)).toBe(45_000);
+  });
+});

--- a/src/agents/embedded-agent-runner/run/attempt-stream.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream.ts
@@ -262,27 +262,23 @@ export function installEmbeddedAttemptStreamGuards(input: {
   const resolvedRunTimeoutMs =
     attempt.runTimeoutOverrideMs ??
     (attempt.timeoutMs !== configuredRunTimeoutMs ? attempt.timeoutMs : undefined);
+  // Both watchdogs read the same model facts, including the host-owned
+  // `requestTimeoutMs` derived from `models.providers.<id>.timeoutSeconds`.
+  const watchdogParams = {
+    cfg: attempt.config,
+    runTimeoutMs: resolvedRunTimeoutMs,
+    modelRequestTimeoutMs: attempt.model.requestTimeoutMs,
+    model: {
+      baseUrl: attempt.model.baseUrl,
+      id: attempt.modelId,
+      provider: attempt.provider,
+    },
+  };
   const idleTimeoutMs = resolveLlmIdleTimeoutMs({
-    cfg: attempt.config,
+    ...watchdogParams,
     trigger: attempt.trigger,
-    runTimeoutMs: resolvedRunTimeoutMs,
-    modelRequestTimeoutMs: (attempt.model as { requestTimeoutMs?: number }).requestTimeoutMs,
-    model: {
-      baseUrl: attempt.model.baseUrl,
-      id: attempt.modelId,
-      provider: attempt.provider,
-    },
   });
-  const firstEventTimeoutMs = resolveLlmFirstEventTimeoutMs({
-    cfg: attempt.config,
-    runTimeoutMs: resolvedRunTimeoutMs,
-    modelRequestTimeoutMs: (attempt.model as { requestTimeoutMs?: number }).requestTimeoutMs,
-    model: {
-      baseUrl: attempt.model.baseUrl,
-      id: attempt.modelId,
-      provider: attempt.provider,
-    },
-  });
+  const firstEventTimeoutMs = resolveLlmFirstEventTimeoutMs(watchdogParams);
   if (idleTimeoutMs > 0) {
     session.agent.streamFn = streamWithIdleTimeout(
       session.agent.streamFn,

--- a/src/agents/embedded-agent-runner/run/model-harness.ts
+++ b/src/agents/embedded-agent-runner/run/model-harness.ts
@@ -1,4 +1,5 @@
 import type { Model } from "../../../llm/types.js";
+import type { ProviderRuntimeModel } from "../../../plugins/provider-runtime-model.types.js";
 import {
   selectAgentHarness,
   selectAgentHarnessForPreparedModelProviders,
@@ -27,7 +28,7 @@ export function resolveEmbeddedRunEffectiveModel(
   params: HarnessSelectionContext & {
     modelConfigProvider: string;
     agentHarnessId: string;
-    runtimeModel: Model;
+    runtimeModel: ProviderRuntimeModel;
     nativeModelOwned: boolean;
   },
 ) {

--- a/src/agents/embedded-agent-runner/run/model-setup.ts
+++ b/src/agents/embedded-agent-runner/run/model-setup.ts
@@ -101,7 +101,7 @@ export async function resolveEmbeddedRunModelSetup(params: {
   let modelResolution: Awaited<ReturnType<typeof resolveModelAsync>> | undefined;
   if (nativeModelOwned) {
     modelResolution = {
-      model: createNativeModelOwnedRuntimeModel({ provider, modelId }),
+      model: createNativeModelOwnedRuntimeModel({ provider, modelId, cfg: runParams.config }),
       ...createEmptyAgentDiscoveryStores(),
     };
   } else {

--- a/src/agents/embedded-agent-runner/run/setup.test.ts
+++ b/src/agents/embedded-agent-runner/run/setup.test.ts
@@ -8,6 +8,7 @@ import type { ProviderRuntimeModel } from "../../../plugins/provider-runtime-mod
 import { AGENT_HARNESS_SESSION_ID_LOCKED_MESSAGE } from "../../../sessions/agent-harness-session-key.js";
 import {
   buildBeforeModelResolveAttachments,
+  createNativeModelOwnedRuntimeModel,
   resolveAgentHarnessRunAdmissionError,
   resolveEmbeddedRuntimeModelPolicy,
   resolveHookModelSelection,
@@ -295,6 +296,31 @@ describe("resolveEmbeddedRuntimeModelPolicy", () => {
       tokens: 272_000,
     });
     expect(result.effectiveModel.contextWindow).toBe(272_000);
+  });
+});
+
+describe("createNativeModelOwnedRuntimeModel", () => {
+  // This harness bypasses `normalizeResolvedModel`, so the provider request
+  // timeout has to be applied here or the operator's configured
+  // `timeoutSeconds` never reaches the stream watchdogs (#113092).
+  const cfgWithTimeout = {
+    models: { providers: { codex: { timeoutSeconds: 3600 } } },
+  } as unknown as OpenClawConfig;
+
+  it("stamps the configured provider request timeout", () => {
+    expect(
+      createNativeModelOwnedRuntimeModel({
+        provider: "codex",
+        modelId: "gpt-5.6-luna",
+        cfg: cfgWithTimeout,
+      }).requestTimeoutMs,
+    ).toBe(3_600_000);
+  });
+
+  it("omits requestTimeoutMs when the provider declares no timeoutSeconds", () => {
+    expect(
+      createNativeModelOwnedRuntimeModel({ provider: "codex", modelId: "gpt-5.6-luna" }),
+    ).not.toHaveProperty("requestTimeoutMs");
   });
 });
 

--- a/src/agents/embedded-agent-runner/run/setup.ts
+++ b/src/agents/embedded-agent-runner/run/setup.ts
@@ -31,6 +31,10 @@ import { DEFAULT_CONTEXT_TOKENS } from "../../defaults.js";
 import { FailoverError } from "../../failover-error.js";
 import { log } from "../logger.js";
 import { readAgentModelContextTokens } from "../model-context-tokens.js";
+import {
+  resolveConfiguredProviderConfig,
+  resolveProviderRequestTimeoutMs,
+} from "../model.inline-provider.js";
 
 type HookContext = {
   agentId?: string;
@@ -183,7 +187,15 @@ export function resolveNativeModelOwnedHarnessId(params: {
 export function createNativeModelOwnedRuntimeModel(params: {
   provider: string;
   modelId: string;
+  cfg?: OpenClawConfig;
 }): ProviderRuntimeModel {
+  // This harness synthesizes its model instead of resolving one, so it never
+  // reaches `normalizeResolvedModel` where provider config is normally applied.
+  // Stamp the host-owned request timeout here or the operator's configured
+  // `timeoutSeconds` is silently dropped for pinned native harnesses (#113092).
+  const requestTimeoutMs = resolveProviderRequestTimeoutMs(
+    resolveConfiguredProviderConfig(params.cfg, params.provider)?.timeoutSeconds,
+  );
   return {
     provider: params.provider,
     id: params.modelId,
@@ -195,6 +207,7 @@ export function createNativeModelOwnedRuntimeModel(params: {
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
     contextWindow: DEFAULT_CONTEXT_TOKENS,
     maxTokens: DEFAULT_CONTEXT_TOKENS,
+    ...(requestTimeoutMs !== undefined ? { requestTimeoutMs } : {}),
   };
 }
 

--- a/src/agents/embedded-agent-runner/run/types.ts
+++ b/src/agents/embedded-agent-runner/run/types.ts
@@ -9,7 +9,8 @@ import type {
 } from "../../../config/sessions/types.js";
 import type { ContextEngine, ContextEnginePromptCacheInfo } from "../../../context-engine/types.js";
 import type { DiagnosticTraceContext } from "../../../infra/diagnostic-trace-context.js";
-import type { AssistantMessage, Model } from "../../../llm/types.js";
+import type { AssistantMessage } from "../../../llm/types.js";
+import type { ProviderRuntimeModel } from "../../../plugins/provider-runtime-model.types.js";
 import type { AgentHarnessTaskRuntimeScope } from "../../../tasks/agent-harness-task-runtime-scope.js";
 import type { AcceptedSessionSpawn } from "../../accepted-session-spawn.js";
 import type { AgentRunAttemptTerminal } from "../../agent-run-terminal-outcome.js";
@@ -151,7 +152,12 @@ export type EmbeddedRunAttemptParams = EmbeddedRunAttemptBase & {
   onAttemptAbort?: () => void;
   /** Supplies run-global model-call ordering for parallel tool outcomes. */
   allocateToolOutcomeOrdinal?: (toolCallId?: string) => number;
-  model: Model;
+  /**
+   * Resolved runtime model. Typed as `ProviderRuntimeModel` rather than `Model`
+   * so host-owned fields such as `requestTimeoutMs` stay visible to consumers
+   * instead of needing structural casts (#113092).
+   */
+  model: ProviderRuntimeModel;
   authStorage: AuthStorage;
   /** Auth profile store already resolved during startup for this attempt. */
   authProfileStore: AuthProfileStore;

--- a/src/agents/provider-transport-fetch.ts
+++ b/src/agents/provider-transport-fetch.ts
@@ -600,8 +600,11 @@ function resolveModelRequestPolicy(model: Model) {
   });
 }
 
+// Structural `requestTimeoutMs` rather than importing `ProviderRuntimeModel`:
+// this module sits under the transport barrel, and importing the plugin runtime
+// model type here closes a madge cycle back through `src/plugin-sdk/llm.ts`.
 export function resolveModelRequestTimeoutMs(
-  model: Model,
+  model: Model & { requestTimeoutMs?: number },
   timeoutMs: number | undefined,
 ): number | undefined {
   if (timeoutMs !== undefined) {
@@ -609,7 +612,9 @@ export function resolveModelRequestTimeoutMs(
       ? clampTimerTimeoutMs(timeoutMs)
       : undefined;
   }
-  const modelTimeoutMs = (model as { requestTimeoutMs?: unknown }).requestTimeoutMs;
+  // Plugin-supplied models are structurally unchecked, so keep validating the
+  // value even though the field is now typed.
+  const modelTimeoutMs = model.requestTimeoutMs;
   return typeof modelTimeoutMs === "number" && Number.isFinite(modelTimeoutMs) && modelTimeoutMs > 0
     ? clampTimerTimeoutMs(modelTimeoutMs)
     : undefined;

--- a/src/secrets/runtime.auth-migration-isolation.test.ts
+++ b/src/secrets/runtime.auth-migration-isolation.test.ts
@@ -2,6 +2,18 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Resolving a healthy `openai` profile reaches the synthetic-profile-auth hook,
+// which cold-loads the bundled OpenAI provider runtime. That import costs ~150s
+// through the Vitest transform pipeline on a cold cache and blew the 120s test
+// timeout in the `secrets` shard on CI. This suite proves per-agent auth
+// migration isolation, not provider-plugin behavior, so keep the bundled
+// provider runtime out of the shard (see `src/agents/CLAUDE.md`: import-bound
+// tests must not cold-load full bundled provider runtime).
+vi.mock("../plugins/provider-runtime.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../plugins/provider-runtime.js")>()),
+  shouldDeferProviderSyntheticProfileAuthWithPlugin: () => undefined,
+}));
 import { writePersistedAuthProfileStoreRaw } from "../agents/auth-profiles/sqlite.js";
 import { resolveApiKeyForProvider } from "../agents/model-auth.js";
 import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";


### PR DESCRIPTION
Closes #113092

> **Update:** rebased onto `0951d0dd307`, which had since split `model.ts` into `model.provider-hooks.ts` / `model.configured-overrides.ts` / `model.configured-fallback.ts`. The fix is re-homed to those modules, and **all evidence below was re-collected against that head** — live before/after, the characterization test, and CI.
>
> **Merge-head refresh:** rebased again onto current `main` (now `2b7b0f24409`) and reran the focused proof on the result. The rebase was clean and the diff is byte-identical (`+40` source / `+207` tests, 16 files). Those 14 new `main` commits change nothing under `src/agents/embedded-agent-runner/**`, `src/agents/provider-transport-fetch.ts`, `src/plugins/provider-runtime.ts`, or `packages/llm-core/**` — verified with `git diff --name-only <merge-base> upstream/main -- <those paths>`, which is empty. So the focused tests, typecheck, lint, and cycle checks were rerun on the merge head (results in §4); the two 330s live runs were **not** repeated, because no code on the proven path moved. Say the word if you want them re-executed anyway.

> **Second commit — unblocks a red `main`.** After rebasing, the merge gate was blocked by `checks-node-compact-small-11`, which has been failing since #114033 (`refactor(auth): finish SQLite-only auth profile cutover`) and is unrelated to this fix. Root `AGENTS.md` says to fix that in the landing PR rather than land onto red, so `test(secrets): stop auth-migration isolation test cold-loading provider runtime` does. Details in §7.

## What Problem This Solves

An operator sets `models.providers.<id>.timeoutSeconds` for a slow local or self-hosted model server, and their run is still killed by the LLM stream watchdog at the implicit class default (~120s cloud, ~300s local/self-hosted) instead of the configured ceiling.

This breaks a documented contract. The schema help for the key states it "also raises the LLM idle/stream watchdog ceiling for this provider above the implicit ~120s default", with no path carve-out. The failure is especially unfriendly because the error OpenClaw prints tells the user to do the thing they already did:

```
The model did not produce a response before the model idle timeout. Please try
again, or increase `models.providers.<id>.timeoutSeconds` for slow local or
self-hosted providers.
```

Provider HTTP fetch timeouts honored the value. The stream watchdog never saw it.

## Why This Change Was Made

The host converts `timeoutSeconds` into `requestTimeoutMs` and stamps it onto the resolved model in two places — `applyConfiguredProviderOverrides` (`model.configured-overrides.ts`) and `resolveConfiguredFallbackModel` (`model.configured-fallback.ts`) — both *upstream* of the plugin-owned `normalizeResolvedModel` hook. That hook may wholesale replace the model object. Bundled providers all spread their input (`...model`) and survive; a provider plugin that constructs a fresh model instead — which the SDK contract explicitly permits — silently drops the operator's timeout, and the implicit ceilings come back.

Nothing caught it because the field was erased from the type: `EmbeddedRunAttemptParams.model` was `Model`, which has no `requestTimeoutMs`, while the object actually passed is `ProviderRuntimeModel`, which does. Both consumers therefore read it through untyped `as` casts, so no compiler check connected the producer to the consumers.

The fix stamps the value inside `normalizeResolvedModel` — the single terminal step of every resolution branch — **after** the plugin normalize/transport hooks, so a plugin that rebuilds the model can no longer drop it. The two duplicate stamps are deleted, along with the passthrough guard clause in `applyConfiguredProviderOverrides` that existed only to stop the shortcut path from swallowing a configured timeout. Two paths that bypassed the funnel entirely are closed at the same boundary: `createNativeModelOwnedRuntimeModel` (`run/setup.ts`), which synthesizes a model and never reaches resolution, and `buildInlineProviderModels`, which declared `timeoutSeconds` on its input type but never propagated it. `resolveConfiguredProviderConfig` and `resolveProviderRequestTimeoutMs` move down to `model.inline-provider.ts`, the leaf both consumers already import, so the new call site does not introduce an import cycle and neither helper is duplicated. The attempt boundary is typed `ProviderRuntimeModel` so both structural casts disappear as a consequence rather than as a patch.

Non-goals: the watchdog resolvers themselves are untouched — `resolveLlmIdleTimeoutMs` and `resolveLlmFirstEventTimeoutMs` already short-circuit on `modelRequestTimeoutMs` correctly (with comments citing the earlier #77744 / #78361 fixes). The value simply never arrived. Existing precedence is preserved and now locked by tests: an explicit run budget still bounds the provider timeout, and cron ordering is unchanged.

**Honest scope.** Live runs against current `main` (transcripts below) show that ordinary configuration shapes — a plain configured provider, a discovered model with a provider overlay, a `llama-cpp`-prefixed provider id, a `localService` provider — *already* carry `requestTimeoutMs` correctly today. The one shape that reproduces the reported abort on current `main` is a provider plugin whose `normalizeResolvedModel` rebuilds the model. That is the demonstrated user-visible defect. The native-harness and inline-builder gaps are real but latent, and they are closed here because they are the same bug at the same boundary, not because a shipped plugin hits them today. Every bundled `normalizeResolvedModel` implementation in `extensions/**` returns either its input, `undefined`, or a `{ ...model, … }` spread — openrouter, clawrouter, xai, volcengine, arcee, mistral, featherless, bedrock, bedrock-mantle, anthropic, anthropic-vertex, openai, openai-chatgpt, microsoft-foundry, opencode, opencode-go, kimi-coding, venice, xiaomi — which is why no bundled provider exposes this today, and exactly why an external plugin doing the contract-legal thing does.

## Is this the best fix, or just a plausible one?

The previous review left this "unclear", so here is the reasoning explicitly.

**The ordering hazard is generic, and this PR deliberately fixes exactly one field.** `applyConfiguredProviderOverrides` stamps several host-owned values before the plugin hook — `params`, `headers`, `compat`, `mediaInput`, `authHeader`, and the `localService` wrapper. A plugin that rebuilds the model drops all of them, not just `requestTimeoutMs`. So why not rescue them all at the funnel?

Because they are not the same kind of value:

| Field | Owner | Terminal re-stamp correct? |
|---|---|---|
| `requestTimeoutMs` | **Host only.** An operator budget in seconds with no provider semantics. Verified: no provider plugin in `extensions/**` sets `requestTimeoutMs` on a resolved model. | ✅ Yes — nothing can legitimately override it |
| `api`, `baseUrl` | **Plugin.** `extensions/openai/openai-provider.ts` rewrites `api` to `openai-responses` / `openai-chatgpt-responses` for its routes | ❌ No — re-stamping would override deliberate provider routing |
| `compat`, `mediaInput`, `params` | **Plugin.** Providers merge their own compat/media capabilities (xai, volcengine, featherless, mistral all do) | ❌ No — re-stamping would clobber provider capability decisions |

Re-stamping the whole group after the hook would turn a fail-open bug into a fail-wrong one: plugins would lose the ability to correct transport and capability metadata they legitimately own. `requestTimeoutMs` is the one value in that set with no provider meaning at all, which is exactly why it is safe to apply terminally and the others are not. That is the difference between "a plausible fix" and "the fix that matches ownership".

**Alternatives considered and rejected**

1. *Re-stamp inside each of the two existing call sites, after their own plugin calls.* Rejected: it keeps two copies of the same policy, and neither site is terminal — the native-harness and inline-builder paths still bypass both.
2. *Make `normalizeResolvedModel` reject plugin results that drop host fields.* Rejected: it turns a legal SDK contract into a runtime error and breaks external plugins that are behaving correctly per the documented interface.
3. *Fix it in the watchdog resolvers by re-reading provider config there.* Rejected: the resolvers are already correct and already short-circuit on `modelRequestTimeoutMs`; re-reading config at watchdog time would duplicate config resolution into a hot path, against `AGENTS.md`'s "carry prepared facts forward, do not rediscover".
4. *Widen the public resolver signatures to `ProviderRuntimeModel`.* Rejected: measured at 35 call sites across 21 files with no behavior gain — `ProviderRuntimeModel` is already assignable to `Model`.

**Known limitation, stated rather than hidden.** The other host-owned fields above remain droppable by a rebuilding plugin. No bundled provider does this, no bug report exists for them, and the correct repair for each is a per-field ownership decision rather than a blanket re-stamp — so they are out of scope here. If maintainers want that tracked, I am happy to file a follow-up issue describing the general hazard.

## User Impact

Setting `models.providers.<id>.timeoutSeconds` now reliably raises the stream watchdog ceiling for that provider, matching what the config reference already promises — including when a provider plugin normalizes the resolved model, and for pinned native harnesses.

Three behavior notes for reviewer attention, including the availability risk ClawSweeper flagged:

- **Stream lifetime for existing configs (the flagged `merge-risk: availability`).** For a configuration that already sets provider `timeoutSeconds` *and* loads a model-rebuilding provider plugin, an affected run can now wait up to the configured ceiling rather than being cut at the implicit ~120s/300s watchdog. That is the requested behavior, not a side effect: the ceiling is opt-in, per-provider, documented, and the operator wrote the number themselves. It is also still bounded on both sides — `agents.defaults.timeoutSeconds` and any explicit per-run timeout continue to cap the value (`Math.min(modelRequestTimeoutMs, ...timeoutBounds)`), and the transport-level fetch timeout was already honoring the same number, so no run becomes *unbounded* that was not already. Configurations that do not set `timeoutSeconds` are bit-for-bit unaffected: the key is simply absent and every class default applies exactly as before, which `run/setup.test.ts` asserts explicitly (key absent, not `undefined`-valued).
- **Wider reach.** Because the stamp lands at the single resolution funnel, the provider timeout applies to every resolved model for that provider — compaction, subagent, and image-tool requests included — not only whichever paths happened to stamp it before. This matches the documented contract, which carves out no path, but it is a real widening.
- **Native harness relaxes.** Pinned native harnesses gain a bound they previously lacked. The absent-value default is *stricter* (120s/300s), so this can only relax, never tighten.

**Blast radius, concretely.** Who actually sees a behavior change:

| Configuration | Change |
|---|---|
| No `timeoutSeconds` set (the default) | **None.** The key is absent and every class default applies exactly as before — `run/setup.test.ts` asserts the key is *absent*, not `undefined`-valued |
| `timeoutSeconds` + any bundled provider | **None at the resolution funnel.** Every bundled `normalizeResolvedModel` spreads its input, so the resolved model is byte-identical. Locked by three pre-existing `model.test.ts` assertions that still pass after both original stamps were deleted |
| `timeoutSeconds` + an external plugin that rebuilds the model | **Fixed.** Previously aborted at the implicit ceiling despite the setting; now honors it. These configurations are broken today |
| `timeoutSeconds` + a pinned native harness | **Relaxes.** Gains a ceiling it previously lacked; the absent-value default is stricter, so this can only relax |

So the availability risk applies to configurations that are currently failing, and the operator opted into the number. **Revert path** is a single-commit revert with no data or config migration — the config shape is untouched, so a revert restores prior behavior immediately with no operator action.

No config migration is needed: the config shape is unchanged, and this restores documented behavior rather than altering it. The config-less worker runtime (`src/worker/embedded-agent.runtime.ts`) intentionally passes no config and is unaffected.

## Evidence

### 0. Evidence map

| Cell | This change |
|---|---|
| Changed surface | `normalizeResolvedModel` (`model.provider-hooks.ts`) — terminal step of every resolution branch |
| Entry point | `resolveModelAsync` → `resolveExplicitModelWithRegistry` / `resolveConfiguredFallbackModel` |
| Owner boundary | Host owns `models.providers.<id>.timeoutSeconds`; plugins own transport/capability metadata. Stamp moved to the host-owned terminal step |
| Caller | `attempt-stream.ts` reads `model.requestTimeoutMs` into both watchdog resolvers |
| Callee | `resolveLlmIdleTimeoutMs` / `resolveLlmFirstEventTimeoutMs` — unchanged, already correct |
| Sibling surfaces | `run/setup.ts` native harness and `buildInlineProviderModels` bypassed the funnel; both closed here. Other host-owned fields analysed above and deliberately excluded |
| Existing tests | Three pre-existing `model.test.ts` assertions on the ollama and provider-overlay paths still pass after both original stamps were deleted |
| Current `main` behavior | Live-reproduced abort at 300s (§1) plus a failing characterization test (§3) |

### 1. Live before/after against a real configured provider

Setup, run as a user would — real CLI, real HTTP, real config, real external plugin. No test harness, no instrumentation patch, no bypass:

- An OpenAI-compatible HTTP server on `127.0.0.1:8099` standing in for llama.cpp. It answers `POST /v1/chat/completions` with SSE headers **flushed immediately**, then withholds the first token for **330s** — the real shape of a long prompt-eval, where the stream is created but silent — then streams one token and `[DONE]`.
- An isolated `OPENCLAW_STATE_DIR` (never the operator's gateway) with:

```jsonc
{
  "agents": { "defaults": { "model": { "primary": "ai-brick/ornith-1.0-35b" } } },
  "plugins": { "load": { "paths": ["/tmp/proof/rebuild-provider-plugin"] } },
  "models": {
    "providers": {
      "ai-brick": {
        "baseUrl": "http://127.0.0.1:8099/v1",
        "api": "openai-completions",
        "apiKey": "local-model",
        "timeoutSeconds": 3600,
        "models": [{ "id": "ornith-1.0-35b", "name": "Ornith 1.0 35B" }]
      }
    }
  }
}
```

- A real external plugin loaded via `plugins.load.paths`, whose provider hook returns a freshly built model instead of spreading — legal per the SDK contract:

```js
api.registerProvider({
  id: "ai-brick",
  normalizeResolvedModel: ({ model }) => ({
    id: model.id, name: model.name, provider: model.provider, api: model.api,
    baseUrl: model.baseUrl, reasoning: model.reasoning, input: model.input,
    cost: model.cost, contextWindow: model.contextWindow, maxTokens: model.maxTokens,
  }),
});
```

Command (identical on both sides), against a `pnpm build` dist:

```
OPENCLAW_STATE_DIR=/tmp/proof/state node dist/index.js agent \
  --local --agent main --session-key proof-113092 --timeout 900 -m "Say PROOF_OK."
```

**BEFORE — current `main` @ `0951d0dd307`.** Aborted at 300s, twice (the failover retry), despite `timeoutSeconds: 3600`:

```
[llama-stub   0.0s] listening on http://127.0.0.1:8099/v1
[llama-stub  43.6s] request accepted: /v1/chat/completions -- withholding first token for 330s
[llama-stub 343.9s] CLIENT ABORTED after 300.3s -- watchdog fired
[llama-stub 347.0s] request accepted: /v1/chat/completions -- withholding first token for 330s
[llama-stub 647.1s] CLIENT ABORTED after 300.0s -- watchdog fired
```
```
[model-fetch] start provider=ai-brick api=openai-completions model=ornith-1.0-35b
              url=http://127.0.0.1:8099/v1/chat/completions timeoutMs=undefined policy=custom
[model-fetch] response ... status=200 elapsedMs=9 contentType=text/event-stream

embedded run failover decision: stage=assistant decision=surface_error reason=timeout
  from=ai-brick/ornith-1.0-35b
  rawError=completions HTTP stream opened but did not deliver a first SSE event
           within 300000ms after streaming headers (first-event timeout).

The model did not produce a response before the model idle timeout. Please try again,
or increase `models.providers.<id>.timeoutSeconds` for slow local or self-hosted providers.
```

`timeoutMs=undefined` is the defect in one line: the operator's 3600s never reached the runtime model, so the 300s local-provider first-event default applied — and the surfaced advice is to set the key that is already set.

**AFTER — this branch @ `9b1d153fd81`,** content-identical to the current head `c449f4f5724` after the merge-head rebases. Same server, same 330s stall, same config, same command:

```
[llama-stub   0.0s] listening on http://127.0.0.1:8099/v1
[llama-stub  49.3s] request accepted: /v1/chat/completions -- withholding first token for 330s
[llama-stub 379.3s] FIRST TOKEN SENT after 330.0s -- client survived the watchdog
[llama-stub 379.3s] stream completed after 330.0s
```
```
[model-fetch] start provider=ai-brick api=openai-completions model=ornith-1.0-35b
              url=http://127.0.0.1:8099/v1/chat/completions timeoutMs=3600000 policy=custom
[model-fetch] response ... status=200 elapsedMs=8 contentType=text/event-stream
PROOF_OK waited 330.0s
[agent] run f318e6de-290c-41f5-874b-d7c86e2839b5 ended with stopReason=stop
```

`timeoutMs=3600000`, the stream survives 330s — past the former 300s ceiling — and the run completes normally with `stopReason=stop`.

### 1b. Reproduce the live proof yourself

The whole harness is three files and no OpenClaw-specific tooling. Drop this in a scratch dir, point `OPENCLAW_STATE_DIR` at it, and run the same command on `main` and on this branch.

`stub.mjs` — the llama.cpp stand-in (flushes SSE headers, then stalls 330s):

```js
import { createServer } from "node:http";
const DELAY = Number(process.env.DELAY_MS ?? 330000);
createServer((req, res) => {
  if (req.method === "GET") { res.writeHead(200, {"content-type":"application/json"});
    return res.end(JSON.stringify({ object:"list", data:[{ id:"ornith-1.0-35b", object:"model" }] })); }
  req.resume();
  req.on("end", () => {
    res.writeHead(200, { "content-type":"text/event-stream", "cache-control":"no-cache", connection:"keep-alive" });
    res.flushHeaders();                     // headers now, first token much later
    const t0 = Date.now();
    req.on("aborted", () => console.log(`ABORTED after ${((Date.now()-t0)/1000).toFixed(1)}s`));
    setTimeout(() => {
      console.log(`FIRST TOKEN after ${((Date.now()-t0)/1000).toFixed(1)}s`);
      res.write(`data: ${JSON.stringify({ id:"c", object:"chat.completion.chunk", created:0,
        model:"ornith-1.0-35b", choices:[{ index:0, delta:{ role:"assistant", content:"PROOF_OK" }, finish_reason:null }] })}\n\n`);
      res.write(`data: ${JSON.stringify({ id:"c", object:"chat.completion.chunk", created:0,
        model:"ornith-1.0-35b", choices:[{ index:0, delta:{}, finish_reason:"stop" }] })}\n\n`);
      res.write("data: [DONE]\n\n"); res.end();
    }, DELAY);
  });
}).listen(8099, "127.0.0.1");
```

`plugin/openclaw.plugin.json` + `plugin/index.js` — a provider plugin doing the contract-legal thing:

```json
{ "id": "rebuild-provider", "name": "Rebuild Provider", "version": "1.0.0", "main": "index.js",
  "kind": "provider", "enabledByDefault": true, "activation": { "onStartup": true },
  "providers": ["ai-brick"], "configSchema": { "type": "object", "properties": {}, "additionalProperties": false } }
```
```js
export default { id: "rebuild-provider", name: "Rebuild Provider", register(api) {
  api.registerProvider({ id: "ai-brick", label: "AI Brick",
    normalizeResolvedModel: ({ model }) => ({ id: model.id, name: model.name, provider: model.provider,
      api: model.api, baseUrl: model.baseUrl, reasoning: model.reasoning, input: model.input,
      cost: model.cost, contextWindow: model.contextWindow, maxTokens: model.maxTokens }) }); } };
```

Then (`openclaw.json` as shown in §1, plus `"main": "index.js"` in the plugin's `package.json`):

```
node stub.mjs &
OPENCLAW_STATE_DIR=$PWD node dist/index.js agent \
  --local --agent main --session-key proof-113092 --timeout 900 -m "Say PROOF_OK."
```

Watch the `[model-fetch] start … timeoutMs=` line: `undefined` on `main`, `3600000` on this branch. On `main` the stub prints `ABORTED after 300.1s` twice; on this branch, `FIRST TOKEN after 330.0s` and the run ends `stopReason=stop`.

### 2. Live control run — what is *not* broken on `main`

Same server, same `timeoutSeconds: 3600`, current `main`, provider renamed and the rebuilding plugin removed:

```
== current upstream/main 0951d0dd307, NO plugin (llama-cpp-local provider) ==
[model-fetch] start provider=llama-cpp-local ... timeoutMs=3600000 policy=custom
[agent] run f93bd5f3-9513-48db-adeb-abd2fec4c3e8 ended with stopReason=stop
```

`main` already propagates the timeout for ordinary provider shapes. This bounds the regression surface honestly: the live-reproducible defect is specifically the plugin-normalize ordering, and it is what the characterization test targets.

### 3. Characterization test — the defect, on current `main`

The new test file applied to a clean `0951d0dd307` checkout, production code untouched:

```
 × keeps requestTimeoutMs when a provider plugin rebuilds the model 417ms
   AssertionError: expected undefined to be 3600000

 Test Files  1 failed (1)
      Tests  1 failed | 3 passed (4)
```

The other three cases pass on `main`, matching the live control run above.

### 4. After the fix — local proof, rerun on the merge head

```
node scripts/run-vitest.mjs \
  src/agents/embedded-agent-runner/model \
  src/agents/embedded-agent-runner/run/setup.test.ts \
  src/agents/embedded-agent-runner/run/attempt-stream-watchdog-timeouts.test.ts \
  src/agents/provider-transport-fetch.test.ts

Test Files  2 passed (2)     Tests   18 passed  (18)
Test Files  1 passed (1)     Tests    4 passed   (4)
Test Files  8 passed (8)     Tests  331 passed (331)
                             -> 353 tests across 11 files, 0 failures
```
```
tsgo core          (tsconfig.core.json)            PASS
tsgo core tests    (tsconfig.core.test.json)       PASS
oxlint src/agents                                  PASS
oxfmt                                              clean
check-import-cycles       0 runtime value cycle(s)
check-madge-import-cycles 0 cycle(s)
```

The 331-test block matters most for review: those files already contained assertions on `main` that `requestTimeoutMs` is stamped for the ollama and provider-overlay paths. They still pass after both original stamps and the guard clause were deleted, which is the proof that consolidating to one funnel stamp is behavior-preserving rather than merely additive.

**New regression coverage**

| Test | Locks |
|---|---|
| `model.provider-timeout.test.ts` | config → resolved model across four branches, including a plugin hook that rebuilds the model (the case that fails on `main`) |
| `run/attempt-stream-watchdog-timeouts.test.ts` | resolved model → both watchdogs; cron precedence; explicit run budget still wins |
| `run/setup.test.ts` | native-harness model stamps the timeout, and omits the key entirely when unset |
| `model.inline-provider.test.ts` | provider-level `timeoutSeconds` inherits onto every inline model |

### 5. CI

Fully green on the current head `c449f4f5724`, rebased on `main` `2b7b0f24409`: **81 passed, 34 skipping, 0 failed.** Heavy typecheck/lint fan-out and the full suites run there rather than locally.

One intermediate run also tripped `checks-node-compact-large-1` on `src/gateway/server-startup-post-attach.test.ts`, a gateway startup test this PR does not touch. That one is genuinely flaky, not inherited breakage: it passes in isolation (57/57), and running the full `src/gateway` directory locally fails two *different* tests each time while that one passes. It cleared on the next run. Flagging it because that shard looks unstable independent of this PR.

### 6. Diff size

Non-test LOC is **+40** (source +98 / −58) while deleting two duplicate stamps, a dead guard clause, and two structural casts. Tests are +207, across 16 files total. The remaining source growth is the two helpers relocated into `model.inline-provider.ts` (offset by the deletions in their old homes), the `run/setup.ts` stamp that closes the native-harness bypass, and the invariant comments at the ordering-sensitive call sites.

### 7. The inherited `main` breakage this PR also fixes

`checks-node-compact-small-11` was failing on every open PR, not just this one — `feat/provider-usage-profile-read`, `fix/111764-empty-final-completion-message`, and `oauth-refresh-margin-noop` all showed the same shard red. The failure is `src/secrets/runtime.auth-migration-isolation.test.ts` — a file added by #114033, which this branch does not touch — timing out at 120s. `main` does not run the CI workflow on push, so nothing caught it there.

It reproduces deterministically on a Linux Node 24 container (CI parity) with a single test file and a cold module cache, and does **not** reproduce on macOS with a warm Vitest transform cache — which is why it looked green locally.

Timestamped trace of the hang, narrowed step by step:

```
[AUTHDBG] after-candidate-resolve, resolved=true     t=197818
[AUTHDBG] before-sentinelize                         t=197818
[AUTHDBG] after-sentinelize                          t=197818
[AUTHDBG] after-isAuthModeAllowed                    t=197818
[HOOKDBG] refs=["openai"]                            t=393328
[HOOKDBG] before-resolvePlugin openai                t=393328
[HOOKDBG] after-resolvePlugin openai                 t=545953   <- +152.6s
[AUTHDBG] returning profile result                   t=545953
```

Resolving a healthy `openai` api_key profile reaches `shouldDeferSyntheticProfileAuth`, which calls `resolveProviderRuntimePlugin("openai")` and cold-loads the bundled OpenAI provider runtime. Through the Vitest transform pipeline that single import costs ~152s — well past the 120s test timeout. Nothing is wrong in production, where the bundle is prebuilt; this is purely import-bound test cost, exactly what `src/agents/CLAUDE.md` warns about: *"If a test only needs schema, capability, routing, or static discovery data, do not cold-load full bundled plugin/channel/provider runtime."*

The suite proves per-agent auth-migration isolation, not provider-plugin behavior, so the fix keeps the bundled provider runtime out of the `secrets` shard and leaves every assertion intact. Same container, cold cache:

| | Before | After |
|---|---|---|
| Single file | 168s, **1 failed** (timeout) | **1.0s**, 1 passed |
| Full `secrets` shard (Linux) | 190s, **1 failed** | **75s**, 69 files / 709 tests passed |
| Full `secrets` shard (macOS) | — | 66s, 69 files / 709 tests passed |

Happy to split this into its own PR if maintainers prefer — it is a one-file, test-only change, kept as a separate commit for exactly that reason.

---

Reported by @ProFire.
