### PR TITLE
fix(android): connect to pasted manual gateway host and port

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -3539,7 +3539,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 453,
+      "line": 493,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt",
       "source": "Secure connection is required for this host.",
       "surface": "android",
@@ -3547,7 +3547,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 455,
+      "line": 495,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt",
       "source": "Use only on a trusted private network.",
       "surface": "android",

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt
@@ -381,6 +381,40 @@ internal fun resolveDefaultManualGatewayPort(
   return if (tls && host.endsWith(".ts.net")) tailnetTlsGatewayPort else defaultManualGatewayPort
 }
 
+/** Parses manual authorities before formatting so host:port is not mistaken for IPv6. */
+private fun resolveGatewayManualAuthority(hostInput: String): URI? {
+  val authority = hostInput.trim().trimEnd('/')
+  if (authority.isEmpty() || authority.contains('/')) return null
+
+  val normalizedAuthority =
+    if (!authority.startsWith("[") && authority.count { it == ':' } > 1) {
+      "[$authority]"
+    } else {
+      authority
+    }
+  val uri = runCatching { URI("http://$normalizedAuthority") }.getOrNull() ?: return null
+  // This field owns only a host and optional port. Dropping user-info or
+  // query/fragment components could quietly connect credentials to another host.
+  if (
+    uri.host.isNullOrEmpty() ||
+      uri.rawUserInfo != null ||
+      uri.rawQuery != null ||
+      uri.rawFragment != null ||
+      uri.rawPath.isNotEmpty()
+  ) {
+    return null
+  }
+
+  val hasExplicitPort =
+    if (normalizedAuthority.startsWith("[")) {
+      normalizedAuthority.substringAfter(']', "").startsWith(':')
+    } else {
+      normalizedAuthority.contains(':')
+    }
+  if (hasExplicitPort && uri.port !in 1..65535) return null
+  return uri
+}
+
 /** Builds a URL from manual host/port/tls fields for shared endpoint parsing. */
 internal fun composeGatewayManualUrl(
   hostInput: String,
@@ -395,14 +429,18 @@ internal fun composeGatewayManualUrl(
     val parsed = parseGatewayEndpointResult(host)
     return host.takeUnless { parsed.error == GatewayEndpointValidationError.INVALID_URL }
   }
-  val bareHost = host.trimEnd('/')
-  if (bareHost.isEmpty() || bareHost.contains('/')) return null
-  val portTrimmed = portInput.trim()
+  val authority = resolveGatewayManualAuthority(host) ?: return null
+  val bareHost = authority.host.trim('[', ']')
   val port =
-    if (portTrimmed.isEmpty()) {
-      resolveDefaultManualGatewayPort(bareHost, tls)
+    if (authority.port != -1) {
+      authority.port
     } else {
-      portTrimmed.toIntOrNull() ?: return null
+      val portTrimmed = portInput.trim()
+      if (portTrimmed.isEmpty()) {
+        resolveDefaultManualGatewayPort(bareHost, tls)
+      } else {
+        portTrimmed.toIntOrNull() ?: return null
+      }
     }
   if (port !in 1..65535) return null
   val scheme = if (tls) "https" else "http"
@@ -432,7 +470,9 @@ internal fun gatewayManualTransportPresentation(
     }
   }
 
-  val normalizedHost = host.trimEnd('/')
+  val normalizedHost =
+    resolveGatewayManualAuthority(host)?.host?.trim('[', ']')
+      ?: host.trimEnd('/')
   val requiresTls = !isLocalCleartextGatewayHost(normalizedHost)
   val effectiveTls = requestedTls || requiresTls
   return gatewayManualTransportPresentation(

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt
@@ -397,10 +397,10 @@ private fun resolveGatewayManualAuthority(hostInput: String): URI? {
   // query/fragment components could quietly connect credentials to another host.
   if (
     uri.host.isNullOrEmpty() ||
-      uri.rawUserInfo != null ||
-      uri.rawQuery != null ||
-      uri.rawFragment != null ||
-      uri.rawPath.isNotEmpty()
+    uri.rawUserInfo != null ||
+    uri.rawQuery != null ||
+    uri.rawFragment != null ||
+    uri.rawPath.isNotEmpty()
   ) {
     return null
   }

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/GatewayConfigResolverTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/GatewayConfigResolverTest.kt
@@ -64,6 +64,41 @@ class GatewayConfigResolverTest {
   }
 
   @Test
+  fun manualTransportClassifiesTheHostFromPastedAuthorities() {
+    val cases =
+      listOf(
+        "192.168.1.20:18790" to false,
+        "gateway.local:18790" to false,
+        "GATEWAY.LOCAL.:18790" to false,
+        "[::1]:18790" to false,
+        "gateway.example:443" to true,
+        "gateway.local.evil.com:18790" to true,
+        "100.64.0.9:18790" to true,
+        "[2001:db8::1]:443" to true,
+      )
+
+    for ((hostInput, requiresTls) in cases) {
+      val presentation =
+        gatewayManualTransportPresentation(
+          hostInput = hostInput,
+          requestedTls = false,
+        )
+
+      assertEquals(hostInput, requiresTls, presentation.requiresTls)
+      assertEquals(hostInput, requiresTls, presentation.effectiveTls)
+      assertEquals(
+        hostInput,
+        if (requiresTls) {
+          "Secure connection is required for this host."
+        } else {
+          "Use only on a trusted private network."
+        },
+        presentation.helperText,
+      )
+    }
+  }
+
+  @Test
   fun parseGatewayEndpointUsesDefaultTlsPortForBareWssUrls() {
     val parsed = parseGatewayEndpoint("wss://gateway.example")
 
@@ -813,6 +848,29 @@ class GatewayConfigResolverTest {
   }
 
   @Test
+  fun composeGatewayManualUrlPreservesAllCompleteEndpointSchemes() {
+    val cases =
+      listOf(
+        "ws://gateway.local:18790" to true,
+        "http://192.168.1.20:18790/gateway?mode=manual" to true,
+        "wss://gateway.example:8443" to false,
+        "https://gateway.example/gateway?mode=manual" to false,
+        "HTTPS://gateway.example:443" to false,
+        "WS://GATEWAY.LOCAL.:18790" to true,
+        "ws://[::1]:18790" to true,
+        "wss://[2001:db8::1]:443" to false,
+      )
+
+    for ((hostInput, staleTls) in cases) {
+      assertEquals(
+        hostInput,
+        hostInput,
+        composeGatewayManualUrl(hostInput, "not-a-port", tls = staleTls),
+      )
+    }
+  }
+
+  @Test
   fun composeGatewayManualUrlPreservesCompleteEndpointValidationError() {
     val url = composeGatewayManualUrl("ws://gateway.example:18789", "18789", tls = false)
 
@@ -836,6 +894,143 @@ class GatewayConfigResolverTest {
     assertEquals("192.168.178.57", resolved?.host)
     assertEquals(18790, resolved?.port)
     assertEquals(false, resolved?.tls)
+  }
+
+  @Test
+  fun composeGatewayManualUrlPreservesPastedManualAuthorities() {
+    for (case in pastedManualAuthorityCases) {
+      val url = composeGatewayManualUrl(case.hostInput, case.portInput, case.tls)
+
+      assertEquals(case.hostInput, case.expectedUrl, url)
+      assertEquals(case.hostInput, case.expectedEndpoint, url?.let(::parseGatewayEndpoint))
+    }
+  }
+
+  @Test
+  fun resolveGatewayConnectConfigPreservesPastedManualAuthorities() {
+    for (case in pastedManualAuthorityCases) {
+      val resolved =
+        resolveGatewayConnectConfig(
+          useSetupCode = false,
+          setupCode = "",
+          manualHostInput = case.hostInput,
+          manualPortInput = case.portInput,
+          manualTlsInput = case.tls,
+          bootstrapTokenInput = "",
+          tokenInput = "",
+          passwordInput = "",
+        )
+
+      assertEquals(
+        case.hostInput,
+        GatewayConnectConfig(
+          host = case.expectedHost,
+          port = case.expectedPort,
+          tls = case.tls,
+          bootstrapToken = "",
+          token = "",
+          password = "",
+        ),
+        resolved,
+      )
+    }
+  }
+
+  @Test
+  fun resolveGatewayConnectPlanPreservesSavedAuthForPastedManualAuthorities() {
+    for (case in pastedManualAuthorityCases) {
+      val plan =
+        resolveGatewayConnectPlan(
+          useSetupCode = false,
+          setupCode = "",
+          savedManualHost = case.expectedHost,
+          savedManualPort = case.expectedPort.toString(),
+          savedManualTls = case.tls,
+          manualHostInput = case.hostInput,
+          manualPortInput = case.portInput,
+          manualTlsInput = case.tls,
+          bootstrapTokenInput = "",
+          tokenInput = "",
+          passwordInput = "",
+        )
+
+      assertEquals(case.hostInput, GatewaySavedAuthAction.PRESERVE, plan?.savedAuthAction)
+    }
+  }
+
+  @Test
+  fun composeGatewayManualUrlRejectsInvalidPastedAuthorityPorts() {
+    val hosts =
+      listOf(
+        "192.168.1.20:",
+        "192.168.1.20:0",
+        "192.168.1.20:-1",
+        "192.168.1.20:65536",
+        "192.168.1.20:99999999999999999999",
+        "gateway.local:",
+        "gateway.local:not-a-port",
+        "gateway.local:65536",
+        "[::1]:",
+        "[::1]:0",
+        "[::1]:65536",
+        "[::1]:99999999999999999999",
+        "[::1]:not-a-port",
+      )
+
+    for (hostInput in hosts) {
+      assertNull(hostInput, composeGatewayManualUrl(hostInput, "18789", tls = false))
+      assertNull(
+        hostInput,
+        resolveGatewayConnectConfig(
+          useSetupCode = false,
+          setupCode = "",
+          manualHostInput = hostInput,
+          manualPortInput = "18789",
+          manualTlsInput = false,
+          bootstrapTokenInput = "",
+          tokenInput = "",
+          passwordInput = "",
+        ),
+      )
+    }
+  }
+
+  @Test
+  fun composeGatewayManualUrlRejectsPastedAuthorityUserInfoQueriesAndFragments() {
+    val hosts =
+      listOf(
+        "gateway.local@evil.example:443",
+        "gateway.local:18789@evil.example:443",
+        "user:password@gateway.local:18789",
+        "gateway.local:18789?redirect=evil.example",
+        "gateway.local:18789#evil.example",
+        "[::1]:18789?redirect=evil.example",
+        "[::1]:18789#evil.example",
+      )
+
+    for (hostInput in hosts) {
+      assertNull(hostInput, composeGatewayManualUrl(hostInput, "18789", tls = true))
+      assertNull(
+        hostInput,
+        resolveGatewayConnectConfig(
+          useSetupCode = false,
+          setupCode = "",
+          manualHostInput = hostInput,
+          manualPortInput = "18789",
+          manualTlsInput = true,
+          bootstrapTokenInput = "",
+          tokenInput = "",
+          passwordInput = "",
+        ),
+      )
+    }
+  }
+
+  @Test
+  fun composeGatewayManualUrlRejectsInvalidSeparatelyEnteredPorts() {
+    for (portInput in listOf("0", "-1", "65536", "99999999999999999999", "not-a-port")) {
+      assertNull(portInput, composeGatewayManualUrl("gateway.local", portInput, tls = false))
+    }
   }
 
   @Test
@@ -890,18 +1085,72 @@ class GatewayConfigResolverTest {
 
   @Test
   fun composeGatewayManualUrl_bracketsIpv6ForEndpointParsing() {
-    for (hostInput in listOf("::1", "[::1]")) {
+    val cases =
+      listOf(
+        ManualAuthorityCase(
+          hostInput = "::1",
+          expectedHost = "::1",
+          expectedPort = 18789,
+          portInput = "18789",
+        ),
+        ManualAuthorityCase(
+          hostInput = "[::1]",
+          expectedHost = "::1",
+          expectedPort = 18789,
+          portInput = "18789",
+        ),
+        ManualAuthorityCase(
+          hostInput = "::ffff:127.0.0.1",
+          expectedHost = "::ffff:127.0.0.1",
+          expectedPort = 18789,
+          portInput = "18789",
+        ),
+        ManualAuthorityCase(
+          hostInput = "[::ffff:127.0.0.1]",
+          expectedHost = "::ffff:127.0.0.1",
+          expectedPort = 18789,
+          portInput = "18789",
+        ),
+        ManualAuthorityCase(
+          hostInput = "2001:db8::1",
+          expectedHost = "2001:db8::1",
+          expectedPort = 18789,
+          tls = true,
+          portInput = "18789",
+        ),
+        ManualAuthorityCase(
+          hostInput = "[2001:db8::1]",
+          expectedHost = "2001:db8::1",
+          expectedPort = 18789,
+          tls = true,
+          portInput = "18789",
+        ),
+      )
+
+    for (case in cases) {
+      val url = composeGatewayManualUrl(case.hostInput, case.portInput, case.tls)
+
+      assertEquals(case.hostInput, case.expectedUrl, url)
+      assertEquals(case.hostInput, case.expectedEndpoint, url?.let(::parseGatewayEndpoint))
+    }
+  }
+
+  @Test
+  fun composeGatewayManualUrlPreservesIpv6ZoneValidationErrors() {
+    val hosts =
+      listOf(
+        "fe80::1%25eth0",
+        "[fe80::1%25eth0]",
+        "[fe80::1%25eth0]:18789",
+      )
+
+    for (hostInput in hosts) {
       val url = composeGatewayManualUrl(hostInput, "18789", tls = false)
 
-      assertEquals("http://[::1]:18789", url)
       assertEquals(
-        GatewayEndpointConfig(
-          host = "::1",
-          port = 18789,
-          tls = false,
-          displayUrl = "http://[::1]:18789",
-        ),
-        parseGatewayEndpoint(url!!),
+        hostInput,
+        GatewayEndpointValidationError.IPV6_ZONE_ID_UNSUPPORTED,
+        url?.let(::parseGatewayEndpointResult)?.error,
       )
     }
   }
@@ -923,6 +1172,90 @@ class GatewayConfigResolverTest {
     assertEquals("mydevice.tail1234.ts.net", resolved?.host)
     assertEquals(443, resolved?.port)
     assertEquals(true, resolved?.tls)
+  }
+
+  private val pastedManualAuthorityCases =
+    listOf(
+      ManualAuthorityCase(
+        hostInput = "192.168.178.57:18790",
+        expectedHost = "192.168.178.57",
+        expectedPort = 18790,
+      ),
+      ManualAuthorityCase(
+        hostInput = "192.168.178.57:1",
+        expectedHost = "192.168.178.57",
+        expectedPort = 1,
+      ),
+      ManualAuthorityCase(
+        hostInput = "gateway.local:18790",
+        expectedHost = "gateway.local",
+        expectedPort = 18790,
+      ),
+      ManualAuthorityCase(
+        hostInput = "gateway.local:65535",
+        expectedHost = "gateway.local",
+        expectedPort = 65535,
+      ),
+      ManualAuthorityCase(
+        hostInput = "GATEWAY.LOCAL.:18790",
+        expectedHost = "GATEWAY.LOCAL.",
+        expectedPort = 18790,
+        portInput = "65536",
+      ),
+      ManualAuthorityCase(
+        hostInput = "gateway.example:443",
+        expectedHost = "gateway.example",
+        expectedPort = 443,
+        tls = true,
+      ),
+      ManualAuthorityCase(
+        hostInput = "gateway.example:8443",
+        expectedHost = "gateway.example",
+        expectedPort = 8443,
+        tls = true,
+      ),
+      ManualAuthorityCase(
+        hostInput = "mydevice.tail1234.ts.net:8443",
+        expectedHost = "mydevice.tail1234.ts.net",
+        expectedPort = 8443,
+        tls = true,
+        portInput = "",
+      ),
+      ManualAuthorityCase(
+        hostInput = "[::1]:18790",
+        expectedHost = "::1",
+        expectedPort = 18790,
+      ),
+      ManualAuthorityCase(
+        hostInput = "[2001:db8::1]:8443",
+        expectedHost = "2001:db8::1",
+        expectedPort = 8443,
+        tls = true,
+      ),
+    )
+
+  private data class ManualAuthorityCase(
+    val hostInput: String,
+    val expectedHost: String,
+    val expectedPort: Int,
+    val tls: Boolean = false,
+    val portInput: String = "not-a-port",
+  ) {
+    val expectedUrl: String
+      get() {
+        val scheme = if (tls) "https" else "http"
+        val formattedHost = if (expectedHost.contains(':')) "[$expectedHost]" else expectedHost
+        return "$scheme://$formattedHost:$expectedPort"
+      }
+
+    val expectedEndpoint: GatewayEndpointConfig
+      get() =
+        GatewayEndpointConfig(
+          host = expectedHost,
+          port = expectedPort,
+          tls = tls,
+          displayUrl = if (tls && expectedPort == 443) expectedUrl.removeSuffix(":443") else expectedUrl,
+        )
   }
 
   private fun encodeSetupCode(payloadJson: String): String = Base64.getUrlEncoder().withoutPadding().encodeToString(payloadJson.toByteArray(Charsets.UTF_8))


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Android users pasting a valid gateway authority such as gateway.local:18790, 192.168.1.20:18790, or [::1]:18790 into manual connection settings could lose the intended port, receive the wrong transport security warning, fail onboarding, or unnecessarily replace credentials already saved for the same gateway. Malformed user-info, query, fragment, and invalid port inputs must not redirect a connection or expose credentials.

## Why This Change Was Made

Parse host-only and host-with-port authorities once at the existing Android gateway configuration owner using the actual java.net.URI contract. Preserve pasted authority ports over stale separate form fields, normalize IPv6 without double brackets, retain the existing LAN and TLS security owner, and propagate the same parsed endpoint through settings, onboarding, connection planning, diagnostics, and saved-credential comparison. Complete ws, wss, http, and https endpoints keep their existing parser.

## User Impact

Manual Android gateway setup reliably connects to the exact pasted host and port, displays the correct secure-transport guidance, preserves existing credentials for an unchanged gateway, and consistently rejects malformed or ambiguous authorities.

## Evidence

- Exact current reviewed and tested commit: 912b21c850412932c8e989ab01ea0623dc553cb6. Initial production/regression review and hosted Android application tests ran on parent c626c9d2e361e06a8edbf612ee03add1e4852db5; the follow-up changes only four ktlint-required indentation lines and two generated native-inventory line references.
- Independently verified initial production blob 41de4deba6007bc6ba6484690ee1ebc3d4a0155d and unchanged regression blob 101cab8eb3a5910f4129a91fb0cd169846ebc960 against the actual tested files.
- Re-ran the real Android Gradle application tests after the formatting and inventory fix: 120/120 passed, 0 failures, 0 errors, 0 skipped; 77 gateway resolver tests, 35 connection tests, 4 network monitor tests, and 4 fleet tests. Independently parsed all four freshly generated JUnit XML suites and verified testcase counts and zero failures.
- Ran the actual scoped Kotlin formatter and the complete hosted-equivalent Android formatting gate: :app:ktlintCheck, :benchmark:ktlintCheck, :wear:ktlintCheck, and :wear-shared:ktlintCheck all pass. No formatting suppression or unrelated source change.
- On dedicated Blacksmith Testbox tbx_01kycv5wpnjkghgmpj7p4d722k with Node 24.18, reproduced the original native:i18n:verify failure, ran the canonical pnpm native:i18n:baseline, and independently reran pnpm native:i18n:baseline and pnpm native:i18n:verify to success; canonical baseline reports changed=false.
- Programmatically compared all 5,290 generated inventory entries against the committed baseline: every translation ID, source string, kind, owner path, surface, and ordering is unchanged. The entire generated diff is exactly two existing GatewayConfigResolver source-line references, 453 to 493 and 455 to 495; no translation or language catalog was changed.
- Fresh independent full-repository review of the original Android change: no findings, confidence 0.97; personally inspected the installed JDK 21 URI implementation, complete production and test modules, and all onboarding, settings, diagnostics, host-security, runtime, saved-auth, and migration siblings. Separate independent exact-original-commit review: no findings, confidence 0.94.
- Fresh independent high-effort review of the exact native-i18n and formatter repair: no findings, confidence 0.99.
- No Android schema, migration, persisted preference format, authentication contract, dependencies, build configuration, or protocol change.
- AI-assisted. Current-head hosted Android and repository CI must pass before native maintainer landing.
