### PR TITLE
fix(ui): restore Control UI theme colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Control UI theme colors:** replace undefined CSS theme variables with the canonical foreground, muted, border, panel, and background tokens so affected text, controls, and cards render consistently in light and dark themes.
 - **Cron local-provider preflight:** report the guarded-fetch deadline as a bounded preflight timeout, preserve concrete nested non-timeout errors, and carry the failure reason into fallback warnings. Thanks @shakkernerd.
 - **ClickClack split-origin setup codes:** consume versioned exact claim endpoints without appending a second claim path, validate the returned canonical API base, preserve private API transport overrides, and keep legacy setup URLs working. Fixes #111919. Thanks @shakkernerd.
 - **Standalone plugin files:** let manifestless files explicitly listed in `plugins.load.paths` pass config validation and load independently when several files share a directory.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Control UI theme colors:** replace undefined CSS theme variables with the canonical foreground, muted, border, panel, and background tokens so affected text, controls, and cards render consistently in light and dark themes.
 - **Cron local-provider preflight:** report the guarded-fetch deadline as a bounded preflight timeout, preserve concrete nested non-timeout errors, and carry the failure reason into fallback warnings. Thanks @shakkernerd.
 - **ClickClack split-origin setup codes:** consume versioned exact claim endpoints without appending a second claim path, validate the returned canonical API base, preserve private API transport overrides, and keep legacy setup URLs working. Fixes #111919. Thanks @shakkernerd.
 - **Standalone plugin files:** let manifestless files explicitly listed in `plugins.load.paths` pass config validation and load independently when several files share a directory.

--- a/ui/src/styles/base-theme-tokens.node.test.ts
+++ b/ui/src/styles/base-theme-tokens.node.test.ts
@@ -1,0 +1,56 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const stylesDir = path.dirname(fileURLToPath(import.meta.url));
+const undefinedTokenMappings = {
+  "bg-subtle": "bg-muted",
+  "border-subtle": "border",
+  fg: "text",
+  foreground: "text",
+  surface: "panel",
+  "text-muted": "muted",
+} as const;
+
+function collectCssFiles(directory: string): string[] {
+  return fs.readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const entryPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      return collectCssFiles(entryPath);
+    }
+    return entry.isFile() && entry.name.endsWith(".css") ? [entryPath] : [];
+  });
+}
+
+describe("Control UI base theme tokens", () => {
+  it("defines every canonical replacement", () => {
+    const baseCss = fs.readFileSync(path.join(stylesDir, "base.css"), "utf8");
+
+    for (const token of new Set(Object.values(undefinedTokenMappings))) {
+      expect(baseCss, `missing --${token} in base.css`).toMatch(
+        new RegExp(`^\\s*--${token}\\s*:`, "mu"),
+      );
+    }
+  });
+
+  it("does not reference undefined theme token names", () => {
+    const undefinedTokens = Object.keys(undefinedTokenMappings);
+    const referencePattern = new RegExp(
+      `var\\(--(?:${undefinedTokens.join("|")})(?:\\s*\\)|\\s*,)`,
+      "u",
+    );
+    const violations = collectCssFiles(stylesDir).flatMap((filePath) =>
+      fs
+        .readFileSync(filePath, "utf8")
+        .split("\n")
+        .flatMap((line, index) =>
+          referencePattern.test(line)
+            ? [`${path.relative(stylesDir, filePath)}:${index + 1}: ${line.trim()}`]
+            : [],
+        ),
+    );
+
+    expect(violations).toEqual([]);
+  });
+});

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -238,7 +238,7 @@
   overflow: hidden;
   border: 1px solid color-mix(in srgb, var(--border) 68%, transparent);
   border-radius: 50%;
-  box-shadow: 0 1px 2px color-mix(in srgb, var(--fg) 9%, transparent);
+  box-shadow: 0 1px 2px color-mix(in srgb, var(--text) 9%, transparent);
   vertical-align: middle;
 }
 
@@ -625,7 +625,7 @@ img.chat-avatar {
 
 .chat-group.user .chat-duplicate-count {
   background: color-mix(in srgb, var(--primary) 12%, transparent);
-  color: color-mix(in srgb, var(--foreground) 80%, var(--primary) 20%);
+  color: color-mix(in srgb, var(--text) 80%, var(--primary) 20%);
 }
 
 .chat-reply-attribution {
@@ -858,7 +858,7 @@ img.chat-avatar {
 .msg-meta__summary:hover .chat-group-timestamp,
 .msg-meta__summary:focus-visible .chat-group-timestamp,
 .msg-meta[open] .msg-meta__summary .chat-group-timestamp {
-  color: var(--fg);
+  color: var(--text);
   opacity: 0.9;
   text-decoration-color: color-mix(in srgb, currentColor 45%, transparent);
 }
@@ -963,7 +963,7 @@ details.msg-meta:not([open]) .msg-meta__details {
   margin: 0 0 8px;
   font-size: 13px;
   font-weight: 500;
-  color: var(--fg, #fff);
+  color: var(--text);
 }
 
 .chat-delete-confirm__remember {

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -158,7 +158,7 @@ openclaw-chat-page {
 .chat-workspace-conflict-notice__content p,
 .chat-workspace-conflict-event p {
   margin: 0;
-  color: var(--text-muted);
+  color: var(--muted);
 }
 
 .chat-workspace-conflict-notice__title,
@@ -1215,7 +1215,7 @@ openclaw-chat-page {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  color: var(--fg);
+  color: var(--text);
 }
 
 .chat-reply-preview__dismiss {
@@ -1233,8 +1233,8 @@ openclaw-chat-page {
 }
 
 .chat-reply-preview__dismiss:hover {
-  color: var(--fg);
-  background: color-mix(in srgb, var(--fg) 10%, transparent);
+  color: var(--text);
+  background: color-mix(in srgb, var(--text) 10%, transparent);
 }
 
 .chat-reply-preview__dismiss svg {
@@ -1265,7 +1265,7 @@ openclaw-chat-page {
   padding: 8px 12px;
   border: none;
   background: none;
-  color: var(--fg);
+  color: var(--text);
   border-radius: 6px;
   text-align: left;
 }
@@ -1296,7 +1296,7 @@ openclaw-chat-page {
   padding: 6px 10px;
   border: none;
   background: none;
-  color: var(--fg);
+  color: var(--text);
   border-radius: 6px;
   font-size: 12px;
   white-space: nowrap;
@@ -4193,7 +4193,7 @@ openclaw-chat-page {
 
 .chat-controls__model-reset:hover:not(:disabled) {
   background: color-mix(in srgb, var(--border) 45%, transparent);
-  color: var(--fg);
+  color: var(--text);
 }
 
 .chat-controls__model-reset svg {
@@ -4714,7 +4714,7 @@ openclaw-chat-page {
   font-size: 24px;
   font-weight: 600;
   margin: 0;
-  color: var(--foreground);
+  color: var(--text);
 }
 
 .agent-chat__welcome-avatar {
@@ -4773,7 +4773,7 @@ openclaw-chat-page {
   border-radius: var(--radius-lg);
   background: var(--secondary);
   border: 1px solid var(--border);
-  color: var(--foreground);
+  color: var(--text);
   display: grid;
   place-items: center;
   font-size: 28px;
@@ -4808,7 +4808,7 @@ openclaw-chat-page {
   border-radius: var(--radius-md);
   border: 1px solid transparent;
   background: transparent;
-  color: var(--foreground);
+  color: var(--text);
   font-size: 13px;
   text-align: left;
   transition:
@@ -4877,7 +4877,7 @@ openclaw-chat-page {
   border-radius: var(--radius-md);
   border: 1px solid var(--border);
   background: var(--panel);
-  color: var(--foreground);
+  color: var(--text);
   /* Localized labels wrap to multiple lines; balance keeps the split even and
      break-word stops long words from pushing past the chip border. */
   text-wrap: balance;

--- a/ui/src/styles/chat/question-card.css
+++ b/ui/src/styles/chat/question-card.css
@@ -209,7 +209,7 @@ openclaw-chat-question-panel {
   gap: 9px;
   width: 100%;
   padding: 10px 11px;
-  border: 1px solid var(--border-subtle);
+  border: 1px solid var(--border);
   border-radius: var(--radius-sm);
   background: color-mix(in srgb, var(--panel) 72%, transparent);
   color: var(--text);
@@ -326,7 +326,7 @@ openclaw-chat-question-panel {
 }
 
 .chat-question-panel__skip {
-  border-color: var(--border-subtle);
+  border-color: var(--border);
   background: transparent;
   color: var(--muted);
 }

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -217,7 +217,7 @@ openclaw-session-owner-chip {
 .login-gate__failure-title {
   font-size: 14px;
   font-weight: 700;
-  color: var(--fg);
+  color: var(--text);
 }
 
 .login-gate__failure-summary {
@@ -267,7 +267,7 @@ openclaw-session-owner-chip {
 .login-gate__help-title {
   font-weight: 600;
   font-size: 12px;
-  color: var(--fg);
+  color: var(--text);
 }
 
 .login-gate__steps {
@@ -295,7 +295,7 @@ openclaw-session-owner-chip {
   background: var(--bg);
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  color: var(--fg);
+  color: var(--text);
   user-select: all;
 }
 
@@ -308,7 +308,7 @@ openclaw-session-owner-chip {
   background: var(--bg);
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  color: var(--fg);
+  color: var(--text);
   cursor: copy;
 }
 
@@ -2918,7 +2918,7 @@ td.data-table-key-col {
   min-height: 30px;
   padding: 3px 5px 3px 10px;
   border-radius: var(--radius-md);
-  background: color-mix(in srgb, var(--fg) 5%, transparent);
+  background: color-mix(in srgb, var(--text) 5%, transparent);
   color: var(--muted);
 }
 
@@ -2974,7 +2974,7 @@ td.data-table-key-col {
   flex-shrink: 0;
   padding: 1px 7px;
   border-radius: 999px;
-  background: color-mix(in srgb, var(--fg) 12%, transparent);
+  background: color-mix(in srgb, var(--text) 12%, transparent);
   color: var(--muted);
   font-size: 11px;
   font-weight: 600;
@@ -3071,8 +3071,8 @@ td.data-table-key-col {
 }
 
 .chat-queue__remove:hover {
-  color: var(--fg);
-  background: color-mix(in srgb, var(--fg) 10%, transparent);
+  color: var(--text);
+  background: color-mix(in srgb, var(--text) 10%, transparent);
 }
 
 .chat-queue__remove svg {
@@ -3255,7 +3255,7 @@ td.data-table-key-col {
   border-radius: 3px;
   padding: 0 2px;
   background: color-mix(in srgb, #f97316 34%, transparent);
-  color: var(--fg);
+  color: var(--text);
 }
 
 .exec-approval-meta {

--- a/ui/src/styles/custodian.css
+++ b/ui/src/styles/custodian.css
@@ -14,7 +14,7 @@
   justify-content: space-between;
   gap: 18px;
   padding-bottom: 16px;
-  border-bottom: 1px solid var(--border-subtle);
+  border-bottom: 1px solid var(--border);
 }
 
 .custodian__header-actions {
@@ -42,7 +42,7 @@
 
 .custodian__identity p {
   margin-top: 2px;
-  color: var(--text-muted);
+  color: var(--muted);
   font-size: 12px;
 }
 
@@ -107,7 +107,7 @@
   flex: 0 0 auto;
   place-items: center;
   border-radius: 50%;
-  color: var(--text-muted);
+  color: var(--muted);
   cursor: pointer;
 }
 
@@ -141,7 +141,7 @@
   width: 5px;
   height: 5px;
   border-radius: 50%;
-  background: var(--text-muted);
+  background: var(--muted);
   animation: custodian-thinking 900ms ease-in-out infinite alternate;
 }
 
@@ -192,7 +192,7 @@
 
 .custodian__history-heading span,
 .custodian__history-state {
-  color: var(--text-muted);
+  color: var(--muted);
   font-size: 12px;
 }
 
@@ -207,7 +207,7 @@
 
 .custodian__change-card {
   padding: 11px 12px;
-  border: 1px solid var(--border-subtle);
+  border: 1px solid var(--border);
   border-radius: var(--radius-md);
   background: var(--bg);
 }
@@ -222,7 +222,7 @@
   align-items: center;
   justify-content: space-between;
   gap: 10px;
-  color: var(--text-muted);
+  color: var(--muted);
   font-size: 11px;
 }
 
@@ -243,7 +243,7 @@
 .custodian__change-warning,
 .custodian__change-note {
   margin-top: 6px;
-  color: var(--text-muted);
+  color: var(--muted);
   font-size: 12px;
 }
 
@@ -254,7 +254,7 @@
 
 .custodian__change-paths {
   margin-top: 7px;
-  color: var(--text-muted);
+  color: var(--muted);
   font-size: 12px;
 }
 

--- a/ui/src/styles/dreams.css
+++ b/ui/src/styles/dreams.css
@@ -628,7 +628,7 @@
   padding: 3px;
   border-radius: 999px;
   border: 1px solid color-mix(in oklab, var(--border) 62%, transparent);
-  background: color-mix(in oklab, var(--surface) 92%, transparent);
+  background: color-mix(in oklab, var(--panel) 92%, transparent);
 }
 
 .dreams-advanced__sort-btn {

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -2001,7 +2001,7 @@ html.openclaw-native-macos
 
 .viewer-facepile-trigger:hover,
 .viewer-facepile-trigger:focus-visible {
-  background: color-mix(in srgb, var(--fg) 8%, transparent);
+  background: color-mix(in srgb, var(--text) 8%, transparent);
 }
 
 .sidebar-recent-session__name {

--- a/ui/src/styles/nodes.css
+++ b/ui/src/styles/nodes.css
@@ -46,7 +46,7 @@
 }
 
 .nodes-entry__details > summary:hover {
-  color: var(--fg);
+  color: var(--text);
 }
 
 .nodes-entry__details > .muted {
@@ -87,7 +87,7 @@
 }
 
 .nodes-group__dups > summary:hover {
-  color: var(--fg);
+  color: var(--text);
 }
 
 .nodes-group__dups .settings-row {

--- a/ui/src/styles/onboarding-memory-import.css
+++ b/ui/src/styles/onboarding-memory-import.css
@@ -45,7 +45,7 @@
   padding: 14px;
   border: 1px solid var(--border);
   border-radius: 12px;
-  background: var(--bg-subtle);
+  background: var(--bg-muted);
 }
 
 .onboarding-memory-import__provider label {

--- a/ui/src/styles/option-card.css
+++ b/ui/src/styles/option-card.css
@@ -11,9 +11,9 @@
 .option-card__chip {
   justify-self: start;
   padding: 4px 8px;
-  border: 1px solid var(--border-subtle);
+  border: 1px solid var(--border);
   border-radius: var(--radius-full);
-  color: var(--text-muted);
+  color: var(--muted);
   font-size: 11px;
   font-weight: 700;
   letter-spacing: 0.05em;
@@ -80,7 +80,7 @@
 }
 
 .option-card__description {
-  color: var(--text-muted);
+  color: var(--muted);
   font-size: 12px;
   line-height: 1.45;
 }
@@ -102,7 +102,7 @@
   padding: 2px 0;
   border: 0;
   background: transparent;
-  color: var(--text-muted);
+  color: var(--muted);
   font-size: 12px;
   text-decoration: underline;
   text-underline-offset: 3px;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Control UI text, borders, hover states, and card backgrounds could silently inherit the wrong color or disappear because their CSS referenced theme variables that are not defined by the canonical palette. The affected rules span Custodian, Nodes, Dreams/Memory, onboarding memory import, and shared Chat/UI surfaces.

## Why This Change Was Made

Every reference to the six undefined names now uses the matching token from `base.css`: `--text`, `--muted`, `--border`, `--panel`, or `--bg-muted`. The Dreams segmented control uses `--panel` because it sits inside the panel-backed advanced section and matches the existing diary subtabs. A focused source-level test verifies the canonical replacements remain defined and the undefined names do not return anywhere under `ui/src/styles`.

The separate `--success` / `--warning` cleanup is intentionally outside this change.

## User Impact

Affected Control UI copy, dividers, thinking indicators, segmented controls, provider rows, queue backgrounds, and hover states now preserve their intended visual hierarchy in both light and dark themes instead of falling back to inherited/default rendering.

## Evidence

- `node scripts/check-changed.mjs -- <touched files>`: passed on Blacksmith Testbox ([run](https://github.com/openclaw/openclaw/actions/runs/30161083656)); formatting, UI/core typechecks, lint, i18n, and changed guards clean.
- `pnpm test ui/src/styles/base-theme-tokens.node.test.ts`: 2 tests passed on Blacksmith Testbox ([run](https://github.com/openclaw/openclaw/actions/runs/30161652006)).
- `pnpm ui:build`: production Vite build, precompressed-asset verification, and Control UI performance budgets passed on Blacksmith Testbox ([run](https://github.com/openclaw/openclaw/actions/runs/30161788081)).
- Existing-Chrome dark/light walkthrough against a sanitized fixture using the production styles: corrected borders and muted colors computed in both themes; Dreams, onboarding provider, and chat queue backgrounds became non-transparent; Nodes hover changed from muted to normal foreground; light-mode results persisted across reload; no console warnings/errors/issues.
- Fresh Codex autoreview: clean, no accepted/actionable findings (0.98 confidence).
