### PR TITLE
fix(crabbox): restore sanitized PR validation

### DIFF
--- a/scripts/crabbox-untrusted-bootstrap.sh
+++ b/scripts/crabbox-untrusted-bootstrap.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 node_version="24.15.0"
-pnpm_spec="pnpm@11.2.2+sha512.36e6621fad506178936455e70247b8808ef4ec25797a9f437a93281a020484e2607f6a469a22e982987c3dbb8866e3071514ab10a4a1749e06edcd1ec118436f"
+pnpm_spec="pnpm@11.15.1+sha512.81350b07e53c9538a02f1f2303b4290fa2d7be04e56e2a970c4cc4b417dc761de196edabd49d55c7dc9580db81007c44143e4e3d7e462b3000d23c255122d065"
 
 if [[ $# -lt 2 ]]; then
   echo "usage: $0 <expected-head-sha> <command> [args...]" >&2

--- a/test/scripts/crabbox-untrusted-bootstrap.test.ts
+++ b/test/scripts/crabbox-untrusted-bootstrap.test.ts
@@ -3,6 +3,16 @@ import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
 describe("scripts/crabbox-untrusted-bootstrap.sh", () => {
+  it("pins the package manager required by the trusted checkout", () => {
+    const script = readFileSync("scripts/crabbox-untrusted-bootstrap.sh", "utf8");
+    const packageJson = JSON.parse(readFileSync("package.json", "utf8")) as {
+      packageManager?: string;
+    };
+    const pnpmSpec = script.match(/^pnpm_spec="([^"]+)"$/mu)?.[1];
+
+    expect(pnpmSpec).toBe(packageJson.packageManager);
+  });
+
   it("bounds both IMDSv2 identity requests", () => {
     const script = readFileSync("scripts/crabbox-untrusted-bootstrap.sh", "utf8");
     const imdsRequests = script.match(


### PR DESCRIPTION
Related: #113306

## What Problem This Solves

Fixes an issue where maintainers validating untrusted contributor or fork PRs in sanitized AWS Crabbox would be rejected before installation because the trusted bootstrap pinned pnpm 11.2.2 while the repository requires pnpm 11.15.1.

## Why This Change Was Made

The trusted bootstrap now pins the repository's current package-manager specification. A regression test compares that trusted pin with `package.json` so future pnpm upgrades cannot silently disable sanitized PR validation again.

## User Impact

Maintainers can run the repository's credential-isolated untrusted-PR validation path again. There is no runtime product behavior change.

## Evidence

- Blacksmith Testbox `tbx_01kycv23an2sxpfsw0enggxmvy`: focused bootstrap suite passed, 2 tests.
- Blacksmith Actions run: https://github.com/openclaw/openclaw/actions/runs/30161831458
- Exact changed-file `pnpm check:changed` passed the tooling and root-test lanes.
- `bash -n scripts/crabbox-untrusted-bootstrap.sh` passed.
- Fresh Codex autoreview: clean, no accepted/actionable findings.
