### PR TITLE
refactor(ui): extract wizard step controls into a shared component

### DIFF
--- a/ui/src/components/wizard-step-controls.ts
+++ b/ui/src/components/wizard-step-controls.ts
@@ -1,0 +1,232 @@
+import { html, nothing, type TemplateResult } from "lit";
+import type { WizardStep } from "../api/types.ts";
+import { t } from "../i18n/index.ts";
+import { copyToClipboard } from "../lib/clipboard.ts";
+import "../styles/wizard-step-controls.css";
+
+type WizardStepOption = NonNullable<WizardStep["options"]>[number];
+
+type WizardStepControlsProps = {
+  step: WizardStep;
+  /** Current draft answer; owned by the caller so it survives re-renders. */
+  value: unknown;
+  /** Disables every control while an answer is in flight. */
+  busy: boolean;
+  // The text step pairs `<label for>` with `<input id>`. The caller owns the id
+  // so two step controls in one document cannot capture each other's label.
+  inputId: string;
+  onValueChange: (value: unknown) => void;
+  onAnswer: (value: unknown, includeValue?: boolean) => void;
+};
+
+function renderMessage(step: WizardStep) {
+  return step.message ? html`<div class="wizard-step__message">${step.message}</div>` : nothing;
+}
+
+function renderOptionBody(option: WizardStepOption) {
+  return html`
+    <span>
+      <strong>${option.label}</strong>
+      ${option.hint ? html`<small>${option.hint}</small>` : nothing}
+    </span>
+  `;
+}
+
+function renderDeviceCode(step: WizardStep) {
+  const deviceCode = step.deviceCode;
+  if (!deviceCode) {
+    return nothing;
+  }
+  return html`
+    <div class="wizard-step__device-code">
+      ${deviceCode.message ? html`<div class="muted">${deviceCode.message}</div>` : nothing}
+      <code>${deviceCode.code}</code>
+      <button
+        type="button"
+        class="btn btn--sm"
+        @click=${() => void copyToClipboard(deviceCode.code)}
+      >
+        ${t("modelSetup.wizard.copy")}
+      </button>
+      ${deviceCode.expiresInMinutes
+        ? html`<div class="muted">
+            ${t("modelSetup.wizard.expires", {
+              count: String(deviceCode.expiresInMinutes),
+            })}
+          </div>`
+        : nothing}
+    </div>
+  `;
+}
+
+function renderContinueStep(props: WizardStepControlsProps) {
+  const step = props.step;
+  return html`
+    ${renderMessage(step)}
+    ${step.externalUrl
+      ? html`<a class="btn btn--sm" href=${step.externalUrl} target="_blank" rel="noreferrer">
+          ${t("modelSetup.wizard.openSignIn")}
+        </a>`
+      : nothing}
+    ${renderDeviceCode(step)}
+    <button
+      type="button"
+      class="btn primary"
+      ?disabled=${props.busy}
+      @click=${() => props.onAnswer(undefined, false)}
+    >
+      ${t("modelSetup.wizard.continue")}
+    </button>
+  `;
+}
+
+function renderTextStep(props: WizardStepControlsProps) {
+  const step = props.step;
+  const value = typeof props.value === "string" ? props.value : "";
+  return html`
+    <form
+      class="wizard-step__form"
+      @submit=${(event: Event) => {
+        event.preventDefault();
+        props.onAnswer(value);
+      }}
+    >
+      ${step.message
+        ? html`<div class="wizard-step__message">
+            <label for=${props.inputId}>${step.message}</label>
+          </div>`
+        : nothing}
+      <input
+        id=${props.inputId}
+        class="input"
+        name="wizard-text"
+        type=${step.sensitive ? "password" : "text"}
+        autocomplete=${step.sensitive ? "off" : "on"}
+        placeholder=${step.placeholder ?? ""}
+        .value=${value}
+        ?disabled=${props.busy}
+        @input=${(event: Event) =>
+          props.onValueChange((event.currentTarget as HTMLInputElement).value)}
+      />
+      <button type="submit" class="btn primary" ?disabled=${props.busy}>
+        ${t("modelSetup.wizard.submit")}
+      </button>
+    </form>
+  `;
+}
+
+function renderSelectStep(props: WizardStepControlsProps) {
+  return html`
+    ${renderMessage(props.step)}
+    <div class="wizard-step__options" role="radiogroup">
+      ${(props.step.options ?? []).map(
+        (option) => html`
+          <label class="wizard-step__option">
+            <input
+              type="radio"
+              name="wizard-option"
+              .checked=${Object.is(props.value, option.value)}
+              @change=${() => props.onValueChange(option.value)}
+            />
+            ${renderOptionBody(option)}
+          </label>
+        `,
+      )}
+    </div>
+    <button
+      type="button"
+      class="btn primary"
+      ?disabled=${props.busy || props.value === undefined}
+      @click=${() => props.onAnswer(props.value)}
+    >
+      ${t("modelSetup.wizard.continue")}
+    </button>
+  `;
+}
+
+function renderConfirmStep(props: WizardStepControlsProps) {
+  return html`
+    ${renderMessage(props.step)}
+    <div class="wizard-step__actions">
+      <button
+        type="button"
+        class="btn"
+        ?disabled=${props.busy}
+        @click=${() => props.onAnswer(false)}
+      >
+        ${t("common.no")}
+      </button>
+      <button
+        type="button"
+        class="btn primary"
+        ?disabled=${props.busy}
+        @click=${() => props.onAnswer(true)}
+      >
+        ${t("common.yes")}
+      </button>
+    </div>
+  `;
+}
+
+function renderMultiselectStep(props: WizardStepControlsProps) {
+  const selected = Array.isArray(props.value) ? props.value : [];
+  return html`
+    ${renderMessage(props.step)}
+    <div class="wizard-step__options">
+      ${(props.step.options ?? []).map(
+        (option) => html`
+          <label class="wizard-step__option">
+            <input
+              type="checkbox"
+              .checked=${selected.some((value) => Object.is(value, option.value))}
+              @change=${(event: Event) => {
+                const checked = (event.currentTarget as HTMLInputElement).checked;
+                props.onValueChange(
+                  checked
+                    ? [...selected, option.value]
+                    : selected.filter((value) => !Object.is(value, option.value)),
+                );
+              }}
+            />
+            ${renderOptionBody(option)}
+          </label>
+        `,
+      )}
+    </div>
+    <button
+      type="button"
+      class="btn primary"
+      ?disabled=${props.busy}
+      @click=${() => props.onAnswer(selected)}
+    >
+      ${t("modelSetup.wizard.continue")}
+    </button>
+  `;
+}
+
+/**
+ * Renders the interactive controls for one `WizardStep`. Container-agnostic on
+ * purpose: no dialog chrome, no cancel row, no page state — callers place the
+ * result wherever the step is being asked (modal, panel, or chat bubble).
+ */
+export function renderWizardStepControls(
+  props: WizardStepControlsProps,
+): TemplateResult | typeof nothing {
+  switch (props.step.type) {
+    case "text":
+      return renderTextStep(props);
+    case "select":
+      return renderSelectStep(props);
+    case "confirm":
+      return renderConfirmStep(props);
+    case "multiselect":
+      return renderMultiselectStep(props);
+    // These carry no input of their own: they show whatever the step supplies
+    // (message, link, device code) behind a single Continue.
+    case "note":
+    case "progress":
+    case "action":
+      return renderContinueStep(props);
+  }
+  return nothing;
+}

--- a/ui/src/pages/model-setup/wizard-view.ts
+++ b/ui/src/pages/model-setup/wizard-view.ts
@@ -1,8 +1,10 @@
 import { html, nothing, type TemplateResult } from "lit";
+import { renderWizardStepControls } from "../../components/wizard-step-controls.ts";
 import { t } from "../../i18n/index.ts";
 import "../../components/modal-dialog.ts";
-import { copyToClipboard } from "../../lib/clipboard.ts";
 import type { ModelSetupWizardState } from "./state.ts";
+
+const WIZARD_TEXT_INPUT_ID = "model-setup-wizard-text-input";
 
 type WizardViewProps = {
   mode: "auth" | "prepare";
@@ -13,224 +15,6 @@ type WizardViewProps = {
   onCancel: () => void;
   onClose: () => void;
 };
-
-function renderDeviceCode(step: Extract<ModelSetupWizardState, { phase: "step" }>["step"]) {
-  if (!step.deviceCode) {
-    return nothing;
-  }
-  return html`
-    <div class="model-setup-wizard__device-code">
-      ${step.deviceCode.message
-        ? html`<div class="muted">${step.deviceCode.message}</div>`
-        : nothing}
-      <code>${step.deviceCode.code}</code>
-      <button
-        type="button"
-        class="btn btn--sm"
-        @click=${() => void copyToClipboard(step.deviceCode!.code)}
-      >
-        ${t("modelSetup.wizard.copy")}
-      </button>
-      ${step.deviceCode.expiresInMinutes
-        ? html`<div class="muted">
-            ${t("modelSetup.wizard.expires", {
-              count: String(step.deviceCode.expiresInMinutes),
-            })}
-          </div>`
-        : nothing}
-    </div>
-  `;
-}
-
-function renderContinueStep(props: WizardViewProps) {
-  if (props.state.phase !== "step") {
-    return nothing;
-  }
-  const step = props.state.step;
-  return html`
-    ${step.message ? html`<div class="model-setup-wizard__message">${step.message}</div>` : nothing}
-    ${step.externalUrl
-      ? html`<a class="btn btn--sm" href=${step.externalUrl} target="_blank" rel="noreferrer">
-          ${t("modelSetup.wizard.openSignIn")}
-        </a>`
-      : nothing}
-    ${renderDeviceCode(step)}
-    <button
-      type="button"
-      class="btn primary"
-      ?disabled=${props.state.busy}
-      @click=${() => props.onAnswer(undefined, false)}
-    >
-      ${t("modelSetup.wizard.continue")}
-    </button>
-  `;
-}
-
-function renderTextStep(props: WizardViewProps) {
-  if (props.state.phase !== "step") {
-    return nothing;
-  }
-  const step = props.state.step;
-  return html`
-    <form
-      @submit=${(event: Event) => {
-        event.preventDefault();
-        props.onAnswer(typeof props.value === "string" ? props.value : "");
-      }}
-    >
-      ${step.message
-        ? html`<div class="model-setup-wizard__message">
-            <label for="model-setup-wizard-text-input">${step.message}</label>
-          </div>`
-        : nothing}
-      <input
-        id="model-setup-wizard-text-input"
-        class="input"
-        name="wizard-text"
-        type=${step.sensitive ? "password" : "text"}
-        autocomplete=${step.sensitive ? "off" : "on"}
-        placeholder=${step.placeholder ?? ""}
-        .value=${typeof props.value === "string" ? props.value : ""}
-        ?disabled=${props.state.busy}
-        @input=${(event: Event) =>
-          props.onValueChange((event.currentTarget as HTMLInputElement).value)}
-      />
-      <button type="submit" class="btn primary" ?disabled=${props.state.busy}>
-        ${t("modelSetup.wizard.submit")}
-      </button>
-    </form>
-  `;
-}
-
-function renderSelectStep(props: WizardViewProps) {
-  if (props.state.phase !== "step") {
-    return nothing;
-  }
-  const step = props.state.step;
-  return html`
-    ${step.message ? html`<div class="model-setup-wizard__message">${step.message}</div>` : nothing}
-    <div class="model-setup-wizard__options" role="radiogroup">
-      ${(step.options ?? []).map(
-        (option) => html`
-          <label class="model-setup-wizard__option">
-            <input
-              type="radio"
-              name="wizard-option"
-              .checked=${Object.is(props.value, option.value)}
-              @change=${() => props.onValueChange(option.value)}
-            />
-            <span>
-              <strong>${option.label}</strong>
-              ${option.hint ? html`<small>${option.hint}</small>` : nothing}
-            </span>
-          </label>
-        `,
-      )}
-    </div>
-    <button
-      type="button"
-      class="btn primary"
-      ?disabled=${props.state.busy || props.value === undefined}
-      @click=${() => props.onAnswer(props.value)}
-    >
-      ${t("modelSetup.wizard.continue")}
-    </button>
-  `;
-}
-
-function renderConfirmStep(props: WizardViewProps) {
-  if (props.state.phase !== "step") {
-    return nothing;
-  }
-  return html`
-    ${props.state.step.message
-      ? html`<div class="model-setup-wizard__message">${props.state.step.message}</div>`
-      : nothing}
-    <div class="model-setup-wizard__actions">
-      <button
-        type="button"
-        class="btn"
-        ?disabled=${props.state.busy}
-        @click=${() => props.onAnswer(false)}
-      >
-        ${t("common.no")}
-      </button>
-      <button
-        type="button"
-        class="btn primary"
-        ?disabled=${props.state.busy}
-        @click=${() => props.onAnswer(true)}
-      >
-        ${t("common.yes")}
-      </button>
-    </div>
-  `;
-}
-
-function renderMultiselectStep(props: WizardViewProps) {
-  if (props.state.phase !== "step") {
-    return nothing;
-  }
-  const selected = Array.isArray(props.value) ? props.value : [];
-  return html`
-    ${props.state.step.message
-      ? html`<div class="model-setup-wizard__message">${props.state.step.message}</div>`
-      : nothing}
-    <div class="model-setup-wizard__options">
-      ${(props.state.step.options ?? []).map(
-        (option) => html`
-          <label class="model-setup-wizard__option">
-            <input
-              type="checkbox"
-              .checked=${selected.some((value) => Object.is(value, option.value))}
-              @change=${(event: Event) => {
-                const checked = (event.currentTarget as HTMLInputElement).checked;
-                props.onValueChange(
-                  checked
-                    ? [...selected, option.value]
-                    : selected.filter((value) => !Object.is(value, option.value)),
-                );
-              }}
-            />
-            <span>
-              <strong>${option.label}</strong>
-              ${option.hint ? html`<small>${option.hint}</small>` : nothing}
-            </span>
-          </label>
-        `,
-      )}
-    </div>
-    <button
-      type="button"
-      class="btn primary"
-      ?disabled=${props.state.busy}
-      @click=${() => props.onAnswer(selected)}
-    >
-      ${t("modelSetup.wizard.continue")}
-    </button>
-  `;
-}
-
-function renderStep(props: WizardViewProps) {
-  if (props.state.phase !== "step") {
-    return nothing;
-  }
-  switch (props.state.step.type) {
-    case "text":
-      return renderTextStep(props);
-    case "select":
-      return renderSelectStep(props);
-    case "confirm":
-      return renderConfirmStep(props);
-    case "multiselect":
-      return renderMultiselectStep(props);
-    case "note":
-    case "progress":
-    case "action":
-      return renderContinueStep(props);
-  }
-  return nothing;
-}
 
 export function renderModelSetupWizard(props: WizardViewProps): TemplateResult | typeof nothing {
   if (props.state.phase === "idle") {
@@ -280,7 +64,14 @@ export function renderModelSetupWizard(props: WizardViewProps): TemplateResult |
                           ${props.state.validationError}
                         </div>`
                       : nothing}
-                    ${renderStep(props)}
+                    ${renderWizardStepControls({
+                      step: props.state.step,
+                      value: props.value,
+                      busy: props.state.busy,
+                      inputId: WIZARD_TEXT_INPUT_ID,
+                      onValueChange: props.onValueChange,
+                      onAnswer: props.onAnswer,
+                    })}
                     ${props.state.busy
                       ? html`<div role="status">${t("modelSetup.wizard.working")}</div>`
                       : nothing}

--- a/ui/src/styles/model-setup.css
+++ b/ui/src/styles/model-setup.css
@@ -217,61 +217,10 @@
   overflow: auto;
 }
 
-.model-setup-wizard__body form {
-  display: grid;
-  gap: 12px;
-}
-
 .model-setup-wizard__footer {
   display: flex;
   justify-content: flex-end;
   border-top: 1px solid var(--border);
-}
-
-.model-setup-wizard__message {
-  white-space: pre-wrap;
-}
-
-.model-setup-wizard__device-code {
-  display: grid;
-  justify-items: start;
-  gap: 8px;
-  padding: 14px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
-  background: var(--bg);
-}
-
-.model-setup-wizard__device-code code {
-  font-size: 18px;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-}
-
-.model-setup-wizard__options {
-  display: grid;
-  gap: 8px;
-}
-
-.model-setup-wizard__option {
-  display: flex;
-  align-items: flex-start;
-  gap: 10px;
-  padding: 10px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
-  cursor: pointer;
-}
-
-.model-setup-wizard__option small {
-  display: block;
-  margin-top: 2px;
-  color: var(--muted);
-}
-
-.model-setup-wizard__actions {
-  display: flex;
-  gap: 8px;
 }
 
 @media (max-width: 640px) {

--- a/ui/src/styles/wizard-step-controls.css
+++ b/ui/src/styles/wizard-step-controls.css
@@ -1,0 +1,50 @@
+.wizard-step__form {
+  display: grid;
+  gap: 12px;
+}
+
+.wizard-step__message {
+  white-space: pre-wrap;
+}
+
+.wizard-step__device-code {
+  display: grid;
+  justify-items: start;
+  gap: 8px;
+  padding: 14px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg);
+}
+
+.wizard-step__device-code code {
+  font-size: 18px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+}
+
+.wizard-step__options {
+  display: grid;
+  gap: 8px;
+}
+
+.wizard-step__option {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+}
+
+.wizard-step__option small {
+  display: block;
+  margin-top: 2px;
+  color: var(--muted);
+}
+
+.wizard-step__actions {
+  display: flex;
+  gap: 8px;
+}


### PR DESCRIPTION
## What Problem This Solves

Nothing changes for users. This is a prefactor that makes the Model Setup
wizard's step renderer reusable, so a later change can give other surfaces real
setup controls.

`WizardStep` is the shape every setup wizard serializes into, and
`ui/src/pages/model-setup/wizard-view.ts` held the one renderer that handles it
losslessly: all seven step types, plus masked input, placeholders, device codes
with copy and expiry, and external sign-in links. That renderer was private to
the Model Setup page. Any other surface that wants to ask a wizard step — the
custodian chat being the immediate case — has to re-derive a lossy card of its
own, which is why setup outside Model Setup ends up without usable controls.

After this PR, `renderWizardStepControls()` can be imported from any UI surface
and will render any `WizardStep` with the same fidelity Model Setup has today.

## Why This Change Was Made

Landing the extraction on its own keeps it reviewable as a pure move, so the
behavior change that follows cannot hide inside a refactor diff.

`ui/src/components/wizard-step-controls.ts` now owns per-step-type rendering. Its
props are deliberately container-agnostic — `step`, `value`, `busy`, `inputId`,
and the two callbacks — so a caller can place the result in a dialog, a panel, or
a chat bubble. It takes a `WizardStep` directly rather than the Model Setup page's
state union, and imports nothing from `ui/src/pages/model-setup/`.

Two decisions worth a reviewer's attention:

- **`inputId` is a prop, not a constant.** The text step pairs `<label for>` with
  `<input id>`, so two step controls in one document would otherwise capture each
  other's label. Model Setup passes its existing `model-setup-wizard-text-input`,
  leaving the rendered id unchanged.
- **The `modelSetup.wizard.*` i18n keys moved unrenamed.** Renaming would churn
  every generated locale bundle for no behavior gain, and `ui/CLAUDE.md` puts
  those bundles off-limits. It leaves a page-flavored namespace on shared code,
  worth revisiting once a second consumer exists.

Modal chrome, the header, the phase branches (starting / done / error /
validation callout / busy status), and the cancel-close row all stay in
`wizard-view.ts`. Step-scoped CSS moved from `ui/src/styles/model-setup.css` to
`ui/src/styles/wizard-step-controls.css` under a `wizard-step__*` prefix with
rule values copied verbatim; the page stylesheet keeps only the dialog chrome.

Deliberately out of scope: no `navigation` / Back support, no change to
`WizardStep` or the gateway protocol schema, and no attempt to unify
`ui/src/pages/channels/wizard-host.ts` / `wizard-controller.ts`, which consume
steps differently.

## User Impact

None. Model Setup renders and behaves exactly as before, at every width. The
benefit is to developers: the lossless wizard-step renderer is importable from
any surface that needs to ask a step.

## Evidence

### Rendering is byte-identical, not merely "looks the same"

The Model Setup wizard was driven to a text step, a masked (`sensitive`) text
step, and a multiselect step at desktop (1280×900) and mobile (390×844), against
the mocked Gateway used by the existing Control UI e2e harness
(`ui/src/test-helpers/control-ui-e2e.ts`). Each state was captured twice from the
same working tree — once with this change applied, once with it stashed back to
the PR base — and compared with `cmp`. All six pairs are equal byte-for-byte:

```
IDENTICAL  desktop-text          IDENTICAL  mobile-text
IDENTICAL  desktop-masked        IDENTICAL  mobile-masked
IDENTICAL  desktop-multiselect   IDENTICAL  mobile-multiselect
```

The images below are from this branch. Because each is byte-identical to the same
capture on `main`, a separate "before" set is omitted — the pairs would be
indistinguishable. They are included to show which states were covered and what
the extraction had to preserve.

![Model Setup wizard text step at desktop width, showing a labelled text input and Submit button](https://github.com/user-attachments/assets/3e142748-55fc-4b20-8e83-d35302ae6b39)

**What this shows:** The `text` step keeps its `<label for>` / `<input id>`
pairing and placeholder passthrough — the accessibility wiring most at risk in a
move like this, now driven by the new `inputId` prop.
**State:** `/settings/model-setup`, mocked Gateway, wizard advanced to a `text`
step, 1280×900.

![Model Setup wizard masked step at desktop width, showing a password input](https://github.com/user-attachments/assets/7553d6ab-f8b6-4eba-901a-97e1f414942f)

**What this shows:** `sensitive: true` still renders `type="password"` with
`autocomplete="off"`. This is the single riskiest detail to lose in an
extraction, since a regression here silently exposes an API key on screen.
**State:** Same route and viewport, wizard advanced to a `sensitive` text step.

![Model Setup wizard multiselect step at desktop width, showing three checkbox options with hints](https://github.com/user-attachments/assets/b748c96d-5220-4e77-a1e9-4fab53b54f73)

**What this shows:** `multiselect` still renders real checkboxes with per-option
hints and a preselected `initialValue`, not a flattened list.
**State:** Same route and viewport, wizard advanced to a `multiselect` step.

![Model Setup wizard text step at mobile width inside the modal](https://github.com/user-attachments/assets/5678978d-7947-46df-9de5-3054b1514283)

![Model Setup wizard masked step at mobile width inside the modal](https://github.com/user-attachments/assets/8bd693a8-e226-4a24-8ead-99af993af4c5)

![Model Setup wizard multiselect step at mobile width, checkboxes stacked in the modal](https://github.com/user-attachments/assets/7a06e1a6-4fa0-4ef3-940d-f3ee0c4e4295)

**What these three show:** The same states at 390×844. Splitting the stylesheet
did not disturb the modal's narrow-width layout — option rows, hints, and the
Continue affordance all still fit and wrap as before.
**State:** Same route and fixtures, 390×844.

### Existing tests pass with no test file touched

That is the load-bearing proof for a behavior-preserving extraction — the diff
contains no test changes at all. The existing suites already pin the contracts
this refactor could plausibly break: `#model-setup-wizard-text-input` and its
`label[for=...]` association, `input.type` flipping to `password` on `sensitive`,
the radio count for select, "Yes"/"No" for confirm, "Continue" for
multiselect/progress/action, and the device-code copy button and expiry text for
note.

```
$ node scripts/run-vitest.mjs ui/src/pages/model-setup
 Test Files  6 passed (6)
      Tests  45 passed (45)
```

### How to verify

1. Check out this branch and run `node scripts/run-vitest.mjs ui/src/pages/model-setup`.
   Confirm it passes and that `git diff main...HEAD -- '*.test.ts'` is empty.
2. Open Model Setup, start a provider sign-in, and step through a text prompt, an
   API-key prompt, and a multiselect. Compare against `main`.
3. To reproduce the byte comparison: capture the three step states at both
   viewports using `startControlUiE2eServer` and `installMockGateway` from
   `ui/src/test-helpers/control-ui-e2e.ts`, stash the change, capture again, and
   `cmp` the pairs.

### Checks

- `pnpm check:changed` on Blacksmith Testbox — exit 0; lanes `coreTests` and
  `ui`, oxlint clean across core, ui, and packages.
- `node scripts/run-tsgo.mjs -p tsconfig.ui.json` and
  `-p test/tsconfig/tsconfig.test.ui.json` — exit 0.
- `node --import tsx scripts/check-import-cycles.ts` — `0 runtime value cycle(s)`.
  Checked explicitly because a shared UI module pulled from two page trees is
  where cycles appear.
- `pnpm build` — exit 0, zero `[INEFFECTIVE_DYNAMIC_IMPORT]`. Startup CSS held at
  1 request / 39.9 KiB gzip, so the new stylesheet folded into the existing core
  bundle instead of adding a request.
- PR CI on `cbf6e20` — 72 success, 68 skipped, 0 failures.

### Merge result against current `main`

The branch is behind `main`, so rather than rebase, the three-way merge result was
checked directly:

- `main` has not touched any of the four files in this PR since the merge base.
- The `WizardStep` contract is unchanged — no wizard-related lines moved in
  `ui/src/api/types.ts`, and neither `packages/gateway-protocol/src/schema/wizard.ts`
  nor `src/wizard/session.ts` was modified.
- The trial merge applies cleanly, and the 45 model-setup tests pass on the
  merged tree.
- `pnpm lint:ui:styles` passes on the merged tree. This stylelint gate did not
  exist at the merge base, and it covers the stylesheet this PR adds, so it is
  worth noting explicitly rather than leaving to post-merge CI.

**Proof gap:** no live Gateway run. The wizard was exercised against the repo's
mocked-Gateway e2e harness rather than a real provider sign-in, matching what the
existing `ui/src/e2e/model-setup.e2e.test.ts` coverage does.

### On diff size

Non-test LOC grows by 22 (271 removed, 293 added) — the cost of the new module
boundary: imports, the props type, and the doc comment. Inside the moved code
duplication went down: one `renderMessage` replaces four inline copies,
`renderOptionBody` replaces two, and the `step.deviceCode!` non-null assertion is
gone.
