### PR TITLE
refactor(mattermost): normalize websocket error diagnostics

### DIFF
--- a/extensions/mattermost/src/mattermost/monitor-websocket.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor-websocket.test.ts
@@ -227,6 +227,44 @@ describe("mattermost websocket monitor", () => {
     expect(countMatching(patches, (patch) => patch.connected === false)).toBe(2);
   });
 
+  it("reports non-Error websocket errors with object details", async () => {
+    const socket = new FakeWebSocket();
+    const runtime = testRuntime();
+    const runtimeError = expectDefined(
+      runtime.error,
+      "Mattermost runtime error mock",
+    ) as ReturnType<typeof vi.fn>;
+    const patches: Array<Record<string, unknown>> = [];
+    const connectOnce = createMattermostConnectOnce({
+      wsUrl: "wss://example.invalid/api/v4/websocket",
+      botToken: "token",
+      runtime,
+      nextSeq: () => 1,
+      onPosted: async () => {},
+      statusSink: (patch) => {
+        patches.push(patch as Record<string, unknown>);
+      },
+      webSocketFactory: () => socket,
+    });
+
+    queueMicrotask(() => {
+      socket.emitError({ code: "MATTERMOST_WS_REJECTED", retryAfterMs: 250 });
+      socket.emitClose(1006, "connection refused");
+    });
+
+    await expect(connectOnce()).rejects.toMatchObject({ name: "WebSocketClosedBeforeOpenError" });
+
+    const runtimeMessage = String(runtimeError.mock.calls.at(0)?.[0] ?? "");
+    expect(runtimeMessage).toContain("mattermost websocket error:");
+    expect(runtimeMessage).toContain("MATTERMOST_WS_REJECTED");
+    expect(runtimeMessage).toContain("retryAfterMs");
+    expect(runtimeMessage).not.toContain("[object Object]");
+    const lastError = patches.findLast((patch) => typeof patch.lastError === "string")?.lastError;
+    expect(lastError).toContain("MATTERMOST_WS_REJECTED");
+    expect(lastError).toContain("retryAfterMs");
+    expect(lastError).not.toContain("[object Object]");
+  });
+
   it("accepts large valid post envelopes and rejects oversized websocket payloads", async () => {
     const server = new WebSocketServer({ host: "127.0.0.1", port: 0 });
     await once(server, "listening");

--- a/extensions/mattermost/src/mattermost/monitor-websocket.ts
+++ b/extensions/mattermost/src/mattermost/monitor-websocket.ts
@@ -1,5 +1,6 @@
 // Mattermost plugin module implements monitor websocket behavior.
 import { randomUUID } from "node:crypto";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { safeParseJsonWithSchema, safeParseWithSchema } from "openclaw/plugin-sdk/extension-shared";
 import {
   captureWsEvent,
@@ -401,17 +402,18 @@ export function createMattermostConnectOnce(
         });
 
         ws.on("error", (err) => {
+          const message = formatErrorMessage(err);
           captureWsEvent({
             url: opts.wsUrl,
             direction: "local",
             kind: "error",
             flowId,
-            errorText: String(err),
+            errorText: message,
             meta: { subsystem: "mattermost-websocket" },
           });
-          opts.runtime.error?.(`mattermost websocket error: ${String(err)}`);
+          opts.runtime.error?.(`mattermost websocket error: ${message}`);
           opts.statusSink?.({
-            lastError: String(err),
+            lastError: message,
           });
           try {
             ws.close();


### PR DESCRIPTION
## What Problem This Solves

Mattermost websocket diagnostics used direct string coercion instead of the shared plugin error formatter. That made the adapter boundary lossy for injected or custom websocket implementations that report a non-Error value, and left proxy capture, runtime logs, and account status inconsistent with the repository's normal error handling.

The default `ws` client documents its error event as an `Error`; this change is defensive normalization at the adapter boundary and does not claim that stock `ws` emits plain objects.

## Why This Change Was Made

The error callback now formats its `unknown` input once with the existing plugin SDK formatter, then reuses that text for proxy capture, runtime logs, and status updates. Reconnect and close behavior are unchanged.

## User Impact

Standard Mattermost websocket failures behave as before, while nonstandard adapter errors retain useful details instead of becoming `[object Object]`.

## Evidence

- Compatibility proof with the default `ws` implementation: the production `createMattermostConnectOnce` connector authenticated against a local `mattermost/mattermost-team-edition:10.11` server at its real `/api/v4/websocket` endpoint. With the server stopped, the connector surfaced the ordinary `ECONNREFUSED Error`; after the same server restarted, it connected successfully. This verifies that the defensive formatter does not change the normal failure or reconnect path. The one-time local access token was revoked after the run.

```text
# Mattermost server stopped
mode=failure
connected=false
rejected=true
rejectionName=WebSocketClosedBeforeOpenError
runtimeError=mattermost websocket error: connect ECONNREFUSED 127.0.0.1:8065
statusLastError=connect ECONNREFUSED 127.0.0.1:8065
containsObjectObject=false

# Same Mattermost server restarted and healthy
mode=reconnect
connected=true
rejected=false
rejectionName=none
runtimeError=none
statusLastError=none
containsObjectObject=false
```

<details>
<summary>Live Mattermost proof source</summary>

```ts
import { createMattermostConnectOnce } from "./extensions/mattermost/src/mattermost/monitor-websocket.js";

const token = process.env.MATTERMOST_BOT_TOKEN;
if (!token) {
  throw new Error("MATTERMOST_BOT_TOKEN is required");
}

const mode = process.argv[2];
if (mode !== "failure" && mode !== "reconnect") {
  throw new Error("mode must be failure or reconnect");
}

const runtimeErrors: string[] = [];
const statusPatches: Array<Record<string, unknown>> = [];
const abortController = new AbortController();
let connected = false;

const connectOnce = createMattermostConnectOnce({
  wsUrl: "ws://127.0.0.1:8065/api/v4/websocket",
  botToken: token,
  abortSignal: abortController.signal,
  runtime: {
    log() {},
    error(message) {
      runtimeErrors.push(String(message));
    },
  },
  nextSeq: () => 1,
  onPosted: async () => {},
  statusSink(patch) {
    statusPatches.push(patch as Record<string, unknown>);
    if (patch.connected === true) {
      connected = true;
      setTimeout(() => abortController.abort(), 100);
    }
  },
});

let rejected = false;
let rejectionName = "";
try {
  await connectOnce();
} catch (error) {
  rejected = true;
  rejectionName = error instanceof Error ? error.name : typeof error;
}

const lastError = statusPatches.findLast((patch) => typeof patch.lastError === "string")
  ?.lastError;
console.log(`mode=${mode}`);
console.log(`connected=${connected}`);
console.log(`rejected=${rejected}`);
console.log(`rejectionName=${rejectionName || "none"}`);
console.log(`runtimeError=${runtimeErrors.at(-1) ?? "none"}`);
console.log(`statusLastError=${typeof lastError === "string" ? lastError : "none"}`);
console.log(`containsObjectObject=${runtimeErrors.some((message) => message.includes("[object Object]"))}`);
```

</details>

- Defensive adapter-boundary proof: `pnpm exec tsx proof-live.ts` imports the production `createMattermostConnectOnce` connector and uses its existing injected websocket factory to exercise a nonstandard error value.
- Before fix: the pinned base converted the adapter value to `[object Object]` in runtime and status diagnostics.
- After fix: the same production-module boundary preserves its fields in both outputs.

```text
$ pnpm exec tsx proof-live.ts
# pinned base 21694787f0b4905549580b7b4046d82a84f72eb6
boundary=createMattermostConnectOnce
failure=WebSocketClosedBeforeOpenError
runtimeError=mattermost websocket error: [object Object]
statusLastError=[object Object]
runtimeContainsObjectObject=true
statusContainsObjectObject=true

# branch
boundary=createMattermostConnectOnce
failure=WebSocketClosedBeforeOpenError
runtimeError=mattermost websocket error: {"code":"MATTERMOST_WS_REJECTED","retryAfterMs":250}
statusLastError={"code":"MATTERMOST_WS_REJECTED","retryAfterMs":250}
runtimeContainsObjectObject=false
statusContainsObjectObject=false
```

<details>
<summary>proof-live.ts</summary>

```ts
import {
  createMattermostConnectOnce,
  type MattermostWebSocketFactory,
} from "./extensions/mattermost/src/mattermost/monitor-websocket.js";
import type { RuntimeEnv } from "./extensions/mattermost/src/mattermost/runtime-api.js";

class FakeWebSocket implements ReturnType<MattermostWebSocketFactory> {
  private readonly closeListeners: Array<(code: number, reason: Buffer) => void> = [];
  private readonly errorListeners: Array<(err: unknown) => void> = [];

  on(event: "open", listener: () => void): void;
  on(event: "message", listener: (data: Buffer) => void | Promise<void>): void;
  on(event: "pong", listener: (data: Buffer) => void): void;
  on(event: "close", listener: (code: number, reason: Buffer) => void): void;
  on(event: "error", listener: (err: unknown) => void): void;
  on(event: "open" | "message" | "pong" | "close" | "error", listener: unknown): void {
    if (event === "close") {
      this.closeListeners.push(listener as (code: number, reason: Buffer) => void);
    }
    if (event === "error") {
      this.errorListeners.push(listener as (err: unknown) => void);
    }
  }

  ping(): void {}
  send(_data: string): void {}
  close(): void {}
  terminate(): void {}

  emitError(err: unknown): void {
    for (const listener of this.errorListeners) {
      listener(err);
    }
  }

  emitClose(code: number, reason = ""): void {
    const reasonBuffer = Buffer.from(reason, "utf8");
    for (const listener of this.closeListeners) {
      listener(code, reasonBuffer);
    }
  }
}

const socket = new FakeWebSocket();
const runtimeErrors: string[] = [];
const statusPatches: Array<Record<string, unknown>> = [];
const runtime: RuntimeEnv = {
  error: (message) => {
    runtimeErrors.push(String(message));
  },
  log: () => {},
  exit: ((code: number): never => {
    throw new Error(`exit ${code}`);
  }) as RuntimeEnv["exit"],
};

const connectOnce = createMattermostConnectOnce({
  wsUrl: "wss://mattermost.example.test/api/v4/websocket",
  botToken: "redacted-token",
  runtime,
  nextSeq: () => 1,
  onPosted: async () => {},
  statusSink: (patch) => {
    statusPatches.push(patch as Record<string, unknown>);
  },
  webSocketFactory: () => socket,
});

const pending = connectOnce().catch((error: unknown) => error);
socket.emitError({ code: "MATTERMOST_WS_REJECTED", retryAfterMs: 250 });
socket.emitClose(1006, "connection refused");
const failure = await pending;
const runtimeMessage = runtimeErrors.at(0) ?? "<missing>";
const statusLastError =
  statusPatches.findLast((patch) => typeof patch.lastError === "string")?.lastError ?? "<missing>";

console.log(`boundary=createMattermostConnectOnce`);
console.log(`failure=${failure instanceof Error ? failure.name : String(failure)}`);
console.log(`runtimeError=${runtimeMessage}`);
console.log(`statusLastError=${String(statusLastError)}`);
console.log(`runtimeContainsObjectObject=${runtimeMessage.includes("[object Object]")}`);
console.log(`statusContainsObjectObject=${String(statusLastError).includes("[object Object]")}`);
```

</details>

- Focused test: `node scripts/run-vitest.mjs extensions/mattermost/src/mattermost/monitor-websocket.test.ts` passed 16 tests.
- Formatting: `pnpm exec oxfmt --check extensions/mattermost/src/mattermost/monitor-websocket.ts extensions/mattermost/src/mattermost/monitor-websocket.test.ts` passed.
- Lint: `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/mattermost/src/mattermost/monitor-websocket.ts extensions/mattermost/src/mattermost/monitor-websocket.test.ts` passed.

AI-assisted: built with Codex
