### PR TITLE
fix(cron): deliver globally configured failure alerts

### DIFF
--- a/src/cron/service.failure-alert.test.ts
+++ b/src/cron/service.failure-alert.test.ts
@@ -358,6 +358,181 @@ describe("CronService failure alerts", () => {
     await store.cleanup();
   });
 
+  it.each([
+    {
+      name: "uses a globally configured failure webhook destination",
+      globalAlert: {
+        enabled: true,
+        after: 1,
+        mode: "webhook" as const,
+        to: "https://alerts.example.test/cron-failures",
+      },
+      jobAlert: undefined,
+      expected: {
+        mode: "webhook",
+        to: "https://alerts.example.test/cron-failures",
+      },
+    },
+    {
+      name: "uses a globally configured failure announcement channel and target",
+      globalAlert: {
+        enabled: true,
+        after: 1,
+        mode: "announce" as const,
+        channel: "slack",
+        to: "slack:cron-alerts",
+      },
+      jobAlert: undefined,
+      expected: {
+        mode: "announce",
+        channel: "slack",
+        to: "slack:cron-alerts",
+      },
+    },
+    {
+      name: "preserves an explicit job failure webhook over the global destination",
+      globalAlert: {
+        enabled: true,
+        after: 1,
+        mode: "webhook" as const,
+        to: "https://alerts.example.test/global-failures",
+      },
+      jobAlert: {
+        mode: "webhook" as const,
+        to: "https://alerts.example.test/job-failures",
+      },
+      expected: {
+        mode: "webhook",
+        to: "https://alerts.example.test/job-failures",
+      },
+    },
+    {
+      name: "never reuses a global webhook URL as an overridden job chat target",
+      globalAlert: {
+        enabled: true,
+        after: 1,
+        mode: "webhook" as const,
+        to: "https://alerts.example.test/global-failures",
+      },
+      jobAlert: {
+        mode: "announce" as const,
+      },
+      expected: {
+        mode: "announce",
+        channel: "telegram",
+        to: "telegram:19098680",
+      },
+    },
+    {
+      name: "never reuses a global chat target after a job changes the failure channel",
+      globalAlert: {
+        enabled: true,
+        after: 1,
+        mode: "announce" as const,
+        channel: "slack",
+        to: "slack:cron-alerts",
+      },
+      jobAlert: {
+        mode: "announce" as const,
+        channel: "telegram",
+      },
+      expected: {
+        mode: "announce",
+        channel: "telegram",
+        to: "telegram:19098680",
+      },
+    },
+    {
+      name: "never reuses a global webhook channel after a job switches to chat",
+      globalAlert: {
+        enabled: true,
+        after: 1,
+        mode: "webhook" as const,
+        channel: "slack",
+        to: "https://alerts.example.test/global-failures",
+      },
+      jobAlert: {
+        mode: "announce" as const,
+      },
+      expected: {
+        mode: "announce",
+        channel: "telegram",
+        to: "telegram:19098680",
+      },
+    },
+    {
+      name: "never reuses a job chat target for a global channel-only alert",
+      globalAlert: {
+        enabled: true,
+        after: 1,
+        mode: "announce" as const,
+        channel: "slack",
+      },
+      jobAlert: undefined,
+      expected: {
+        mode: "announce",
+        channel: "slack",
+        to: undefined,
+      },
+    },
+    {
+      name: "preserves a global webhook URL when an unused job channel is set",
+      globalAlert: {
+        enabled: true,
+        after: 1,
+        mode: "webhook" as const,
+        to: "https://alerts.example.test/global-failures",
+      },
+      jobAlert: {
+        channel: "telegram",
+      },
+      expected: {
+        mode: "webhook",
+        to: "https://alerts.example.test/global-failures",
+      },
+    },
+  ])("$name", async ({ globalAlert, jobAlert, expected }) => {
+    const store = await makeStorePath();
+    const sendCronFailureAlert = vi.fn(async () => undefined);
+    const cron = createFailureAlertCron({
+      storePath: store.storePath,
+      cronConfig: { failureAlert: globalAlert },
+      runIsolatedAgentJob: vi.fn(async () => ({
+        status: "error" as const,
+        error: "temporary upstream error",
+      })),
+      sendCronFailureAlert,
+    });
+
+    await cron.start();
+    const job = await cron.add({
+      name: "globally routed failure alert",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "run report" },
+      delivery: {
+        mode: "announce",
+        channel: "telegram",
+        to: "telegram:19098680",
+      },
+      ...(jobAlert ? { failureAlert: jobAlert } : {}),
+    });
+
+    await cron.run(job.id, "force");
+
+    expect(sendCronFailureAlert).toHaveBeenCalledOnce();
+    expectAlertFields(sendCronFailureAlert, expected);
+    expectAlertTextContaining(
+      sendCronFailureAlert,
+      'Cron job "globally routed failure alert" failed 1 times',
+    );
+
+    cron.stop();
+    await store.cleanup();
+  });
+
   it("alerts for repeated skipped runs only when opted in", async () => {
     const store = await makeStorePath();
     const sendCronFailureAlert = vi.fn(async () => undefined);

--- a/src/cron/service.failure-alert.test.ts
+++ b/src/cron/service.failure-alert.test.ts
@@ -533,6 +533,177 @@ describe("CronService failure alerts", () => {
     await store.cleanup();
   });
 
+  it.each([
+    {
+      name: "channel-shaped failure destination",
+      failureDestination: { channel: "slack", to: "#alerts" },
+    },
+    {
+      name: "webhook failure destination",
+      failureDestination: {
+        mode: "webhook" as const,
+        to: "https://alerts.example.test/job-failures",
+      },
+    },
+    {
+      name: "clear-only failure destination opt-out",
+      failureDestination: {
+        channel: undefined,
+        to: undefined,
+        accountId: undefined,
+        mode: undefined,
+      },
+    },
+  ])("does not duplicate an explicitly owned $name", async ({ failureDestination }) => {
+    const store = await makeStorePath();
+    const sendCronFailureAlert = vi.fn(async () => undefined);
+    const cron = createFailureAlertCron({
+      storePath: store.storePath,
+      cronConfig: {
+        failureAlert: {
+          enabled: true,
+          after: 1,
+          mode: "webhook",
+          to: "https://alerts.example.test/global-failures",
+        },
+      },
+      runIsolatedAgentJob: vi.fn(async () => ({
+        status: "error" as const,
+        error: "temporary upstream error",
+      })),
+      sendCronFailureAlert,
+    });
+
+    await cron.start();
+    const job = await cron.add({
+      name: "explicitly routed failure destination",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "run report" },
+      delivery: { mode: "none", failureDestination },
+    });
+
+    expect(job.delivery?.failureDestination).toBeDefined();
+    await cron.run(job.id, "force");
+
+    expect(sendCronFailureAlert).not.toHaveBeenCalled();
+
+    cron.stop();
+    await store.cleanup();
+  });
+
+  it("preserves explicit job alerts alongside an owned failure destination", async () => {
+    const store = await makeStorePath();
+    const sendCronFailureAlert = vi.fn(async () => undefined);
+    const cron = createFailureAlertCron({
+      storePath: store.storePath,
+      cronConfig: {
+        failureAlert: {
+          enabled: true,
+          after: 1,
+          mode: "webhook",
+          to: "https://alerts.example.test/global-failures",
+        },
+      },
+      runIsolatedAgentJob: vi.fn(async () => ({
+        status: "error" as const,
+        error: "temporary upstream error",
+      })),
+      sendCronFailureAlert,
+    });
+
+    await cron.start();
+    const job = await cron.add({
+      name: "explicit job alert with a failure destination",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "run report" },
+      delivery: {
+        mode: "none",
+        failureDestination: { channel: "slack", to: "#alerts" },
+      },
+      failureAlert: {
+        after: 1,
+        mode: "announce",
+        channel: "telegram",
+        to: "telegram:19098680",
+      },
+    });
+
+    await cron.run(job.id, "force");
+
+    expect(sendCronFailureAlert).toHaveBeenCalledOnce();
+    expectAlertFields(sendCronFailureAlert, {
+      mode: "announce",
+      channel: "telegram",
+      to: "telegram:19098680",
+    });
+    expectAlertTextContaining(
+      sendCronFailureAlert,
+      'Cron job "explicit job alert with a failure destination" failed 1 times',
+    );
+
+    cron.stop();
+    await store.cleanup();
+  });
+
+  it("preserves global skipped alerts alongside an owned failure destination", async () => {
+    const store = await makeStorePath();
+    const sendCronFailureAlert = vi.fn(async () => undefined);
+    const cron = createFailureAlertCron({
+      storePath: store.storePath,
+      cronConfig: {
+        failureAlert: {
+          enabled: true,
+          after: 1,
+          includeSkipped: true,
+          mode: "announce",
+          channel: "telegram",
+          to: "telegram:19098680",
+        },
+      },
+      runIsolatedAgentJob: vi.fn(async () => ({
+        status: "skipped" as const,
+        error: "requests-in-flight",
+      })),
+      sendCronFailureAlert,
+    });
+
+    await cron.start();
+    const job = await cron.add({
+      name: "skipped job with a failure destination",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "run report" },
+      delivery: {
+        mode: "none",
+        failureDestination: { channel: "slack", to: "#alerts" },
+      },
+    });
+
+    await cron.run(job.id, "force");
+
+    expect(sendCronFailureAlert).toHaveBeenCalledOnce();
+    expectAlertFields(sendCronFailureAlert, {
+      mode: "announce",
+      channel: "telegram",
+      to: "telegram:19098680",
+    });
+    expectAlertTextContaining(
+      sendCronFailureAlert,
+      'Cron job "skipped job with a failure destination" skipped 1 times',
+    );
+
+    cron.stop();
+    await store.cleanup();
+  });
+
   it("alerts for repeated skipped runs only when opted in", async () => {
     const store = await makeStorePath();
     const sendCronFailureAlert = vi.fn(async () => undefined);

--- a/src/cron/service/failure-alerts.ts
+++ b/src/cron/service/failure-alerts.ts
@@ -199,6 +199,15 @@ export function maybeEmitFailureAlert(
   if (!params.alertConfig || params.consecutiveCount < params.alertConfig.after) {
     return;
   }
+  if (
+    params.status === "error" &&
+    !params.job.failureAlert &&
+    params.job.delivery?.failureDestination
+  ) {
+    // Completion delivery owns explicit failure routes and clear-only opt-outs.
+    // Suppress failed-run duplicates without disabling global skipped alerts.
+    return;
+  }
   const isBestEffort = params.job.delivery?.bestEffort === true;
   if (isBestEffort) {
     return;

--- a/src/cron/service/failure-alerts.ts
+++ b/src/cron/service/failure-alerts.ts
@@ -2,6 +2,7 @@
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { FailoverReason } from "../../agents/embedded-agent-helpers/types.js";
+import { resolveTargetPrefixedChannel } from "../../infra/outbound/channel-target-prefix.js";
 import type { CronFailureNotificationDelivery, CronJob, CronMessageChannel } from "../types.js";
 import type { CronServiceState } from "./state.js";
 
@@ -36,6 +37,14 @@ export function failureNotificationDeliveryFromJobState(
 function normalizeCronMessageChannel(input: unknown): CronMessageChannel | undefined {
   const channel = normalizeOptionalLowercaseString(input);
   return channel ? (channel as CronMessageChannel) : undefined;
+}
+
+function resolveFailureAlertChannel(channel: unknown, to?: string): CronMessageChannel | undefined {
+  const normalized = normalizeCronMessageChannel(channel);
+  if (normalized && normalized !== "last") {
+    return normalized;
+  }
+  return normalizeCronMessageChannel(resolveTargetPrefixedChannel(to)) ?? normalized;
 }
 
 function normalizeTo(input: unknown): string | undefined {
@@ -78,7 +87,28 @@ export function resolveFailureAlert(
   }
 
   const mode = jobConfig?.mode ?? globalConfig?.mode;
-  const explicitTo = normalizeTo(jobConfig?.to);
+  const inheritsGlobalMode =
+    !jobConfig?.mode || jobConfig.mode === (globalConfig?.mode ?? "announce");
+  const jobTo = normalizeTo(jobConfig?.to);
+  const jobChannel = resolveFailureAlertChannel(jobConfig?.channel, jobTo);
+  const configuredGlobalTo = inheritsGlobalMode ? normalizeTo(globalConfig?.to) : undefined;
+  const globalChannel = inheritsGlobalMode
+    ? resolveFailureAlertChannel(globalConfig?.channel, configuredGlobalTo)
+    : undefined;
+  // Webhook destinations have no chat-channel identity. Announce destinations
+  // must stay on their original channel when a job overrides its route.
+  const globalTo =
+    mode === "webhook" || !jobChannel || jobChannel === globalChannel
+      ? configuredGlobalTo
+      : undefined;
+  const deliveryTo = normalizeTo(job.delivery?.to);
+  const deliveryChannel = resolveFailureAlertChannel(job.delivery?.channel, deliveryTo);
+  const channel = jobChannel ?? globalChannel ?? deliveryChannel ?? "last";
+  const compatibleDeliveryTo =
+    channel === deliveryChannel || (channel === "last" && !deliveryChannel)
+      ? deliveryTo
+      : undefined;
+  const explicitTo = jobTo ?? globalTo;
 
   // Announce alerts inherit the job delivery target; webhook alerts require an
   // explicit alert target so chat recipients are not reused as URLs.
@@ -88,11 +118,8 @@ export function resolveFailureAlert(
       jobConfig?.cooldownMs ?? globalConfig?.cooldownMs,
       DEFAULT_FAILURE_ALERT_COOLDOWN_MS,
     ),
-    channel:
-      normalizeCronMessageChannel(jobConfig?.channel) ??
-      normalizeCronMessageChannel(job.delivery?.channel) ??
-      "last",
-    to: mode === "webhook" ? explicitTo : (explicitTo ?? normalizeTo(job.delivery?.to)),
+    channel,
+    to: mode === "webhook" ? explicitTo : (explicitTo ?? compatibleDeliveryTo),
     mode,
     accountId: jobConfig?.accountId ?? globalConfig?.accountId,
     includeSkipped: jobConfig?.includeSkipped ?? globalConfig?.includeSkipped ?? false,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users configuring global cron failure alerts received no webhook notification, or had alerts sent to a scheduled job’s unrelated chat channel, because the canonical thresholded alert owner ignored the existing global `cron.failureAlert.to` and `cron.failureAlert.channel` settings.

Also fixes the real Gateway regression exposed by the original PR’s hosted `checks-node-compact-small-13` failure: when a failed job already owns a channel-shaped or webhook `delivery.failureDestination`, the inherited global failure alert was dispatched a second time. The existing Gateway regression for #102235 requires exactly one explicitly addressed Slack announcement and **no** global webhook request. A clear-only failure-destination object must likewise remain an opt-out.

## Why This Change Was Made

Resolve global destinations inside the existing canonical cron failure-alert owner, then suppress inherited global duplicate delivery **only for `status === "error"`** when the job already owns its completion failure destination. Keep destination ownership at the existing Gateway completion boundary; do not disable globally configured `includeSkipped` alerts, explicit per-job failure alerts, or the existing threshold, cooldown, best-effort, account, and compatible-channel inheritance behavior.

No configuration, schema, Gateway protocol, SQLite schema, package dependency, or unrelated baseline changes are introduced.

## User Impact

Globally configured webhook and chat alerts now reach their configured destinations without leaking webhook URLs or chat recipients across incompatible channels. Explicit channel and webhook failure destinations produce exactly one failure notification; clear-only destinations still opt out; explicitly configured job alerts continue to work; and opted-in skipped-job alerts are still delivered even when the job has a failure destination.

## Evidence

Validated exact PR head: `eace7160be194b610c43d4b9a2f5c4d463130f11`.

- Original live service reproductions: globally configured webhook delivery previously received `undefined`; a globally configured Slack alert was incorrectly routed to the failed job’s Telegram channel. The original eight real `CronService` cases verify global webhook/announce routing, per-job webhook and chat overrides, stale webhook-channel rejection, compatible channel-only inheritance, and rendered alert text.
- True Gateway red → green: the existing complete `src/gateway/server.cron.test.ts` reproduced the original hosted failure for **#102235** and now passes **22/22**, including `announces channel-shaped failure destinations without mode under a global webhook default (#102235)`; the correction proves exactly one channel announcement and zero extra webhook requests.
- Five additional real forced-run `CronService` regression scenarios verify explicit channel destinations, explicit webhook destinations, object-present all-undefined opt-outs, preserved explicit job alerts, and preserved global `includeSkipped` delivery. The skipped-alert case was independently reproduced red against the incorrect status-blind resolver guard (**1 failed, 24 passed**) and is green with the final error-only correction.
- Final isolated remote proof: **292/292 tests passed across 10 real owner and sibling suites**: **191/191 Gateway and RPC tests**, and **101/101 cron tests**. No mocks or replacement copies of the actual test files were used.
- Independently verified the relevant owner and Gateway sibling source blobs against immutable current-main `4032ae5247a4735c25dd38e8477dd397a83b8997`.
- Complete exact-branch changed-file gate passed: `node scripts/check-changed.mjs --base HEAD -- src/cron/service/failure-alerts.ts src/cron/service.failure-alert.test.ts`, including both production and test typechecking, exact-file formatting and lint, ratchets, plugin/dependency boundaries, database-first and native-state safeguards, and import cycles. Authoritative remote timing: **301,865 ms; exit code 0**.
- Fresh, independent, status-aware AI-assisted autoreview: **0 accepted/actionable findings; confidence 0.93**.
- Exact-head hosted CI: **115 passed, 0 pending, 0 failed**; required [`openclaw/ci-gate`](https://github.com/openclaw/openclaw/actions/runs/30163950745/job/89694382888) **SUCCESS**, including the previously failing `checks-node-compact-small-13`.

```sh
pnpm test \
  src/gateway/server.cron.test.ts \
  src/cron/service.failure-alert.test.ts \
  src/cron/delivery.test.ts \
  src/cron/delivery.failure-notify.test.ts \
  src/cron/service.persists-delivered-status.test.ts \
  src/cron/service.stream-validation.test.ts \
  src/cron/store/failure-alert-codec.test.ts \
  src/cron/service/jobs.apply-patch.test.ts \
  src/gateway/server-cron-notifications.test.ts \
  src/gateway/server-methods/cron.validation.test.ts

node scripts/check-changed.mjs --base HEAD -- \
  src/cron/service/failure-alerts.ts \
  src/cron/service.failure-alert.test.ts
```

AI-assisted; implementation, pinned current-main owner boundaries, real regression reproductions, and corrected error-versus-skipped behavior independently reviewed.
