### PR TITLE
fix(voice-call): flush stream audio before DTMF

### DIFF
--- a/extensions/voice-call/src/providers/twilio.test.ts
+++ b/extensions/voice-call/src/providers/twilio.test.ts
@@ -535,7 +535,7 @@ describe("TwilioProvider", () => {
     }
   });
 
-  it("sends DTMF by updating the call and redirecting back to the webhook", async () => {
+  it("sends DTMF with a unique signed callback URL for realtime resumption", async () => {
     const { provider, apiRequest } = configureTelephonyTwiMlFallback({
       providerCallId: "CA-dtmf",
     });
@@ -554,6 +554,7 @@ describe("TwilioProvider", () => {
     expect(params.Twiml).toContain('<Play digits="ww123#"');
     expect(params.Twiml).toContain("<Redirect");
     expect(params.Twiml).toContain("https://example.ngrok.app/voice/twilio");
+    expect(params.Twiml).toMatch(/dtmfResume=[0-9a-f-]{36}/);
   });
 
   it("clears buffered stream audio before redirecting a live call to DTMF", async () => {

--- a/extensions/voice-call/src/providers/twilio.test.ts
+++ b/extensions/voice-call/src/providers/twilio.test.ts
@@ -556,6 +556,27 @@ describe("TwilioProvider", () => {
     expect(params.Twiml).toContain("https://example.ngrok.app/voice/twilio");
   });
 
+  it("clears buffered stream audio before redirecting a live call to DTMF", async () => {
+    const { provider, apiRequest } = configureTelephonyTwiMlFallback({
+      providerCallId: "CA-dtmf-stream",
+      streamSid: "MZ-dtmf-stream",
+    });
+    const clearTtsQueue = vi.fn();
+    provider.setMediaStreamHandler({ clearTtsQueue } as never);
+
+    await provider.sendDtmf({
+      callId: "call-dtmf-stream",
+      providerCallId: "CA-dtmf-stream",
+      digits: "5",
+    });
+
+    expect(clearTtsQueue).toHaveBeenCalledWith("MZ-dtmf-stream", "dtmf");
+    expect(apiRequest).toHaveBeenCalledOnce();
+    expect(clearTtsQueue.mock.invocationCallOrder[0]).toBeLessThan(
+      apiRequest.mock.invocationCallOrder[0],
+    );
+  });
+
   it("retries startListening when Twilio briefly rejects a live-call update as not in progress", async () => {
     vi.useFakeTimers();
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});

--- a/extensions/voice-call/src/providers/twilio.test.ts
+++ b/extensions/voice-call/src/providers/twilio.test.ts
@@ -577,6 +577,40 @@ describe("TwilioProvider", () => {
     );
   });
 
+  it("waits for the realtime stream lifecycle to end before sending DTMF", async () => {
+    const { provider, apiRequest } = configureTelephonyTwiMlFallback({
+      providerCallId: "CA-dtmf-realtime",
+    });
+    let endStream: (() => void) | undefined;
+    const streamEnded = new Promise<void>((resolve) => {
+      endStream = resolve;
+    });
+    provider.setRealtimeStreamHandoff({
+      waitForStreamEnd: vi.fn(() => streamEnded),
+    });
+
+    const sending = provider.sendDtmf({
+      callId: "call-dtmf-realtime",
+      providerCallId: "CA-dtmf-realtime",
+      digits: "2",
+    });
+
+    await vi.waitFor(() => expect(apiRequest).toHaveBeenCalledOnce());
+    const [, handoffParams] = requireApiRequestCall(apiRequest) as [string, { Twiml?: string }];
+    expect(handoffParams.Twiml).toContain('<Pause length="60"');
+    expect(handoffParams.Twiml).not.toContain("<Play");
+
+    endStream?.();
+    await sending;
+
+    expect(apiRequest).toHaveBeenCalledTimes(2);
+    const [, dtmfParams] = requireApiRequestCall(apiRequest, 1) as [string, { Twiml?: string }];
+    expect(dtmfParams.Twiml).toContain('<Play digits="2"');
+    expect(apiRequest.mock.invocationCallOrder[0]).toBeLessThan(
+      apiRequest.mock.invocationCallOrder[1]!,
+    );
+  });
+
   it("retries startListening when Twilio briefly rejects a live-call update as not in progress", async () => {
     vi.useFakeTimers();
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});

--- a/extensions/voice-call/src/providers/twilio.test.ts
+++ b/extensions/voice-call/src/providers/twilio.test.ts
@@ -573,7 +573,7 @@ describe("TwilioProvider", () => {
     expect(clearTtsQueue).toHaveBeenCalledWith("MZ-dtmf-stream", "dtmf");
     expect(apiRequest).toHaveBeenCalledOnce();
     expect(clearTtsQueue.mock.invocationCallOrder[0]).toBeLessThan(
-      apiRequest.mock.invocationCallOrder[0],
+      apiRequest.mock.invocationCallOrder[0]!,
     );
   });
 

--- a/extensions/voice-call/src/providers/twilio.ts
+++ b/extensions/voice-call/src/providers/twilio.ts
@@ -73,6 +73,19 @@ function createTwilioRequestDedupeKey(ctx: WebhookContext, verifiedRequestKey?: 
     .digest("hex")}`;
 }
 
+/**
+ * Twilio signs the complete callback URL. Give the post-DTMF redirect a fresh
+ * URL identity so it is not mistaken for a retry of the webhook that created
+ * the realtime stream. The nonce is not trusted by itself; the request still
+ * has to pass Twilio signature verification before the realtime handler uses
+ * it to mint a new stream token.
+ */
+function createDtmfResumeWebhookUrl(webhookUrl: string): string {
+  const url = new URL(webhookUrl);
+  url.searchParams.set("dtmfResume", crypto.randomUUID());
+  return url.toString();
+}
+
 type StreamSendResult = {
   sent: boolean;
 };
@@ -697,10 +710,17 @@ export class TwilioProvider implements VoiceCallProvider {
       await waitForRealtimeStreamEnd(input.providerCallId, streamEnded);
     }
 
+    // The redirect occurs after Twilio has played the tones. It must not reuse
+    // the original webhook URL: Twilio can send the same call parameters, and
+    // replay protection would correctly return empty TwiML instead of creating
+    // the replacement realtime stream. A fresh, signed callback URL preserves
+    // replay protection for actual duplicate deliveries while identifying this
+    // controlled transition as a new request.
+    const resumeWebhookUrl = createDtmfResumeWebhookUrl(webhookUrl);
     const twiml = `<?xml version="1.0" encoding="UTF-8"?>
 <Response>
   <Play digits="${escapeXml(input.digits)}" />
-  <Redirect method="POST">${escapeXml(webhookUrl)}</Redirect>
+  <Redirect method="POST">${escapeXml(resumeWebhookUrl)}</Redirect>
 </Response>`;
 
     await this.updateLiveCallTwiml(input.providerCallId, twiml, "sendDtmf");

--- a/extensions/voice-call/src/providers/twilio.ts
+++ b/extensions/voice-call/src/providers/twilio.ts
@@ -35,22 +35,18 @@ import { guardedJsonApiRequest } from "./shared/guarded-json-api.js";
 import { resolveTwilioApiBaseUrl, type TwilioRegion } from "./twilio-region.js";
 import type { TwilioProviderOptions } from "./twilio.types.js";
 import { TwilioApiError, twilioApiRequest } from "./twilio/api.js";
+import {
+  buildRealtimeStreamHandoffTwiml,
+  type TwilioRealtimeStreamHandoff,
+  waitForRealtimeStreamEnd,
+} from "./twilio/realtime-dtmf-handoff.js";
 import { decideTwimlResponse, readTwimlRequestView } from "./twilio/twiml-policy.js";
 import { verifyTwilioProviderWebhook } from "./twilio/webhook.js";
 export type { TwilioProviderOptions } from "./twilio.types.js";
 
 const TWILIO_CALL_NOT_IN_PROGRESS_CODE = 21220;
 const TWILIO_CALL_UPDATE_RETRY_DELAYS_MS = [250, 750] as const;
-const REALTIME_STREAM_HANDOFF_TIMEOUT_MS = 10_000;
-
-/**
- * Lets the realtime bridge report the provider-owned end of a bidirectional
- * stream.  A Media Streams `clear` only flushes audio; it does not end a
- * `<Connect><Stream>` verb or acknowledge that TwiML playback can take over.
- */
-export interface TwilioRealtimeStreamHandoff {
-  waitForStreamEnd(callSid: string): Promise<void> | null;
-}
+export type { TwilioRealtimeStreamHandoff } from "./twilio/realtime-dtmf-handoff.js";
 
 function isTwilioCallNotInProgressError(err: unknown): boolean {
   return err instanceof TwilioApiError && err.twilioCode === TWILIO_CALL_NOT_IN_PROGRESS_CODE;
@@ -696,13 +692,9 @@ export class TwilioProvider implements VoiceCallProvider {
     // IVRs even though a human can hear the tones.
     const streamEnded = this.realtimeStreamHandoff?.waitForStreamEnd(input.providerCallId);
     if (streamEnded) {
-      const handoffTwiml = `<?xml version="1.0" encoding="UTF-8"?>
-<Response>
-  <Pause length="60" />
-  <Redirect method="POST">${escapeXml(webhookUrl)}</Redirect>
-</Response>`;
+      const handoffTwiml = buildRealtimeStreamHandoffTwiml(webhookUrl, escapeXml);
       await this.updateLiveCallTwiml(input.providerCallId, handoffTwiml, "sendDtmf.streamHandoff");
-      await this.waitForRealtimeStreamEnd(input.providerCallId, streamEnded);
+      await waitForRealtimeStreamEnd(input.providerCallId, streamEnded);
     }
 
     const twiml = `<?xml version="1.0" encoding="UTF-8"?>
@@ -712,32 +704,6 @@ export class TwilioProvider implements VoiceCallProvider {
 </Response>`;
 
     await this.updateLiveCallTwiml(input.providerCallId, twiml, "sendDtmf");
-  }
-
-  private async waitForRealtimeStreamEnd(
-    callSid: string,
-    streamEnded: Promise<void>,
-  ): Promise<void> {
-    let timeout: ReturnType<typeof setTimeout> | undefined;
-    try {
-      await Promise.race([
-        streamEnded,
-        new Promise<never>((_, reject) => {
-          timeout = setTimeout(() => {
-            reject(
-              new Error(
-                `Timed out waiting for realtime stream to end before sending DTMF for ${callSid}`,
-              ),
-            );
-          }, REALTIME_STREAM_HANDOFF_TIMEOUT_MS);
-          timeout.unref?.();
-        }),
-      ]);
-    } finally {
-      if (timeout) {
-        clearTimeout(timeout);
-      }
-    }
   }
 
   /**

--- a/extensions/voice-call/src/providers/twilio.ts
+++ b/extensions/voice-call/src/providers/twilio.ts
@@ -41,6 +41,16 @@ export type { TwilioProviderOptions } from "./twilio.types.js";
 
 const TWILIO_CALL_NOT_IN_PROGRESS_CODE = 21220;
 const TWILIO_CALL_UPDATE_RETRY_DELAYS_MS = [250, 750] as const;
+const REALTIME_STREAM_HANDOFF_TIMEOUT_MS = 10_000;
+
+/**
+ * Lets the realtime bridge report the provider-owned end of a bidirectional
+ * stream.  A Media Streams `clear` only flushes audio; it does not end a
+ * `<Connect><Stream>` verb or acknowledge that TwiML playback can take over.
+ */
+export interface TwilioRealtimeStreamHandoff {
+  waitForStreamEnd(callSid: string): Promise<void> | null;
+}
 
 function isTwilioCallNotInProgressError(err: unknown): boolean {
   return err instanceof TwilioApiError && err.twilioCode === TWILIO_CALL_NOT_IN_PROGRESS_CODE;
@@ -94,6 +104,8 @@ export class TwilioProvider implements VoiceCallProvider {
 
   /** Optional media stream handler for sending audio */
   private mediaStreamHandler: MediaStreamHandler | null = null;
+  /** Optional realtime bridge lifecycle observer for TwiML handoffs. */
+  private realtimeStreamHandoff: TwilioRealtimeStreamHandoff | null = null;
 
   /** Map of call SID to stream SID for media streams */
   private callStreamMap = new Map<string, string>();
@@ -168,6 +180,10 @@ export class TwilioProvider implements VoiceCallProvider {
 
   setMediaStreamHandler(handler: MediaStreamHandler): void {
     this.mediaStreamHandler = handler;
+  }
+
+  setRealtimeStreamHandoff(handoff: TwilioRealtimeStreamHandoff): void {
+    this.realtimeStreamHandoff = handoff;
   }
 
   registerCallStream(callSid: string, streamSid: string): void {
@@ -670,6 +686,25 @@ export class TwilioProvider implements VoiceCallProvider {
     // before redirecting the call to the DTMF TwiML.
     this.clearTtsQueue(input.providerCallId, "dtmf");
 
+    // Realtime calls use a separate `<Connect><Stream>` bridge, so clearing
+    // the classic MediaStreamHandler cannot release that stream.  Twilio does
+    // not acknowledge a `clear`; its documented lifecycle signal is the
+    // stream `stop`/WebSocket close after a live-call TwiML update replaces the
+    // `<Connect><Stream>` verb.  Park the call, wait for that concrete signal,
+    // then make the DTMF update.  Do not guess with a delay: sending digits
+    // while the realtime stream still owns audio is not recognized reliably by
+    // IVRs even though a human can hear the tones.
+    const streamEnded = this.realtimeStreamHandoff?.waitForStreamEnd(input.providerCallId);
+    if (streamEnded) {
+      const handoffTwiml = `<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+  <Pause length="60" />
+  <Redirect method="POST">${escapeXml(webhookUrl)}</Redirect>
+</Response>`;
+      await this.updateLiveCallTwiml(input.providerCallId, handoffTwiml, "sendDtmf.streamHandoff");
+      await this.waitForRealtimeStreamEnd(input.providerCallId, streamEnded);
+    }
+
     const twiml = `<?xml version="1.0" encoding="UTF-8"?>
 <Response>
   <Play digits="${escapeXml(input.digits)}" />
@@ -677,6 +712,32 @@ export class TwilioProvider implements VoiceCallProvider {
 </Response>`;
 
     await this.updateLiveCallTwiml(input.providerCallId, twiml, "sendDtmf");
+  }
+
+  private async waitForRealtimeStreamEnd(
+    callSid: string,
+    streamEnded: Promise<void>,
+  ): Promise<void> {
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    try {
+      await Promise.race([
+        streamEnded,
+        new Promise<never>((_, reject) => {
+          timeout = setTimeout(() => {
+            reject(
+              new Error(
+                `Timed out waiting for realtime stream to end before sending DTMF for ${callSid}`,
+              ),
+            );
+          }, REALTIME_STREAM_HANDOFF_TIMEOUT_MS);
+          timeout.unref?.();
+        }),
+      ]);
+    } finally {
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+    }
   }
 
   /**

--- a/extensions/voice-call/src/providers/twilio.ts
+++ b/extensions/voice-call/src/providers/twilio.ts
@@ -662,6 +662,14 @@ export class TwilioProvider implements VoiceCallProvider {
       throw new Error("Missing webhook URL for this call (provider state not initialized)");
     }
 
+    // A live bidirectional Media Stream can still have agent audio buffered at
+    // Twilio when a tool requests DTMF.  Updating the call's TwiML alone does
+    // not remove that buffer, so <Play digits> can be heard only after stale
+    // speech (including speech queued after this request).  Treat DTMF as a
+    // barge-in: clear the local queue and ask Twilio to discard buffered media
+    // before redirecting the call to the DTMF TwiML.
+    this.clearTtsQueue(input.providerCallId, "dtmf");
+
     const twiml = `<?xml version="1.0" encoding="UTF-8"?>
 <Response>
   <Play digits="${escapeXml(input.digits)}" />

--- a/extensions/voice-call/src/providers/twilio/realtime-dtmf-handoff.ts
+++ b/extensions/voice-call/src/providers/twilio/realtime-dtmf-handoff.ts
@@ -1,0 +1,47 @@
+const REALTIME_STREAM_HANDOFF_TIMEOUT_MS = 10_000;
+
+/**
+ * Lets the realtime bridge report the provider-owned end of a bidirectional
+ * stream. A Media Streams `clear` only flushes audio; it does not end a
+ * `<Connect><Stream>` verb or acknowledge that TwiML playback can take over.
+ */
+export interface TwilioRealtimeStreamHandoff {
+  waitForStreamEnd(callSid: string): Promise<void> | null;
+}
+
+export function buildRealtimeStreamHandoffTwiml(
+  webhookUrl: string,
+  escapeXml: (value: string) => string,
+): string {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+  <Pause length="60" />
+  <Redirect method="POST">${escapeXml(webhookUrl)}</Redirect>
+</Response>`;
+}
+
+export async function waitForRealtimeStreamEnd(
+  callSid: string,
+  streamEnded: Promise<void>,
+): Promise<void> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      streamEnded,
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(() => {
+          reject(
+            new Error(
+              `Timed out waiting for realtime stream to end before sending DTMF for ${callSid}`,
+            ),
+          );
+        }, REALTIME_STREAM_HANDOFF_TIMEOUT_MS);
+        timeout.unref?.();
+      }),
+    ]);
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+  }
+}

--- a/extensions/voice-call/src/webhook.test.ts
+++ b/extensions/voice-call/src/webhook.test.ts
@@ -1165,6 +1165,82 @@ describe("VoiceCallWebhookServer replay handling", () => {
     },
   );
 
+  it("resumes a realtime stream after a DTMF callback without weakening replay protection", async () => {
+    const parseWebhookEvent = vi.fn(() => ({ events: [], statusCode: 200 }));
+    const buildTwiMLPayload = vi.fn(() => ({
+      statusCode: 200,
+      headers: { "Content-Type": "text/xml" },
+      body: '<Response><Connect><Stream url="wss://example.test/voice/stream/realtime/resumed-token" /></Connect></Response>',
+    }));
+    let resumeDeliveries = 0;
+    const twilioProvider: VoiceCallProvider = {
+      ...provider,
+      name: "twilio",
+      verifyWebhook: (ctx) => {
+        const isDtmfResume = Boolean(ctx.query?.dtmfResume);
+        if (isDtmfResume) {
+          resumeDeliveries += 1;
+        }
+        return {
+          ok: true,
+          // A DTMF transition gets a new Twilio-signed URL identity. A retry
+          // of that transition remains a replay and must not mint another
+          // stream token or process call events.
+          isReplay: isDtmfResume ? resumeDeliveries > 1 : true,
+          verifiedRequestKey: isDtmfResume
+            ? "twilio:req:dtmf-resume"
+            : "twilio:req:original-replay",
+        };
+      },
+      parseWebhookEvent,
+    };
+    const { manager, processEvent } = createManager([]);
+    const config = createConfig({
+      provider: "twilio",
+      inboundPolicy: "disabled",
+      realtime: {
+        enabled: true,
+        streamPath: "/voice/stream/realtime",
+        instructions: "Be helpful.",
+        toolPolicy: "safe-read-only",
+        tools: [],
+        providers: {},
+      },
+    });
+    const server = new VoiceCallWebhookServer(config, manager, twilioProvider);
+    server.setRealtimeHandler({
+      buildTwiMLPayload,
+      getStreamPathPattern: () => "/voice/stream/realtime",
+      handleWebSocketUpgrade: () => {},
+      registerToolHandler: () => {},
+      setPublicUrl: () => {},
+    } as unknown as RealtimeCallHandler);
+
+    try {
+      const baseUrl = await server.start();
+      const requestUrl = requireBoundRequestUrl(server, baseUrl);
+      requestUrl.searchParams.set("callId", "call-dtmf");
+      requestUrl.searchParams.set("dtmfResume", "a2a65da8-951a-438e-beb0-25049b33c0af");
+      const body =
+        "CallSid=CA123&Direction=outbound-api&CallStatus=in-progress&From=%2B15550001111&To=%2B15550002222";
+      const headers = {
+        "content-type": "application/x-www-form-urlencoded",
+        "x-twilio-signature": "sig",
+      };
+      const resumed = await fetch(requestUrl.toString(), { method: "POST", headers, body });
+      const replay = await fetch(requestUrl.toString(), { method: "POST", headers, body });
+
+      expect(resumed.status).toBe(200);
+      expect(await resumed.text()).toContain("resumed-token");
+      await expectTwilioReplayTwiML(replay);
+      expect(buildTwiMLPayload).toHaveBeenCalledTimes(1);
+      expect(parseWebhookEvent).not.toHaveBeenCalled();
+      expect(processEvent).not.toHaveBeenCalled();
+    } finally {
+      await server.stop();
+    }
+  });
+
   it.each(["outbound-api", "outbound-dial"] as const)(
     "does not return realtime TwiML for replayed %s twilio TwiML fetches",
     async (direction) => {

--- a/extensions/voice-call/src/webhook.ts
+++ b/extensions/voice-call/src/webhook.ts
@@ -252,6 +252,9 @@ export class VoiceCallWebhookServer {
 
   setRealtimeHandler(handler: RealtimeCallHandler): void {
     this.realtimeHandler = handler;
+    if (this.provider.name === "twilio") {
+      (this.provider as TwilioProvider).setRealtimeStreamHandoff(handler);
+    }
   }
 
   private clearPendingDisconnectHangup(providerCallId: string): void {

--- a/extensions/voice-call/src/webhook.ts
+++ b/extensions/voice-call/src/webhook.ts
@@ -253,7 +253,8 @@ export class VoiceCallWebhookServer {
   setRealtimeHandler(handler: RealtimeCallHandler): void {
     this.realtimeHandler = handler;
     if (this.provider.name === "twilio") {
-      (this.provider as TwilioProvider).setRealtimeStreamHandoff(handler);
+      const twilio = this.provider as Partial<TwilioProvider>;
+      twilio.setRealtimeStreamHandoff?.(handler);
     }
   }
 

--- a/extensions/voice-call/src/webhook/realtime-handler.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.test.ts
@@ -330,6 +330,41 @@ describe("RealtimeCallHandler path routing", () => {
     );
   });
 
+  it("exposes a stream-end promise that resolves from Twilio's stop lifecycle event", async () => {
+    const handler = makeHandler(undefined, {
+      manager: {
+        getCallByProviderCallId: vi.fn(() => makeCallRecord("CA-dtmf-handoff")),
+      },
+    });
+    const server = await startRealtimeServer(handler);
+    try {
+      const ws = await connectWs(server.url);
+      try {
+        ws.send(
+          JSON.stringify({
+            event: "start",
+            start: { streamSid: "MZ-dtmf-handoff", callSid: "CA-dtmf-handoff" },
+          }),
+        );
+        await waitForRealtimeTest(() => {
+          expect(handler.waitForStreamEnd("CA-dtmf-handoff")).not.toBeNull();
+        });
+        const streamEnded = handler.waitForStreamEnd("CA-dtmf-handoff");
+        if (!streamEnded) {
+          throw new Error("expected active realtime stream end promise");
+        }
+
+        ws.send(JSON.stringify({ event: "stop", streamSid: "MZ-dtmf-handoff" }));
+        await streamEnded;
+        expect(handler.waitForStreamEnd("CA-dtmf-handoff")).toBeNull();
+      } finally {
+        ws.close();
+      }
+    } finally {
+      await server.close();
+    }
+  });
+
   it("preserves a public path prefix ahead of serve.path", () => {
     const handler = makeHandler({ streamPath: "/custom/stream/realtime" });
     handler.setPublicUrl("https://public.example/api/voice/webhook");

--- a/extensions/voice-call/src/webhook/realtime-handler.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.ts
@@ -30,7 +30,7 @@ import WebSocket, { WebSocketServer } from "ws";
 import type { VoiceCallRealtimeConfig } from "../config.js";
 import type { CallManager } from "../manager.js";
 import type { VoiceCallProvider } from "../providers/base.js";
-import type { TwilioRealtimeStreamHandoff } from "../providers/twilio.js";
+import type { TwilioRealtimeStreamHandoff } from "../providers/twilio/realtime-dtmf-handoff.js";
 import type { CallRecord, NormalizedEvent } from "../types.js";
 import type { WebhookResponsePayload } from "../webhook.types.js";
 import { RealtimeAudioPacer } from "./realtime-audio-pacer.js";

--- a/extensions/voice-call/src/webhook/realtime-handler.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.ts
@@ -30,6 +30,7 @@ import WebSocket, { WebSocketServer } from "ws";
 import type { VoiceCallRealtimeConfig } from "../config.js";
 import type { CallManager } from "../manager.js";
 import type { VoiceCallProvider } from "../providers/base.js";
+import type { TwilioRealtimeStreamHandoff } from "../providers/twilio.js";
 import type { CallRecord, NormalizedEvent } from "../types.js";
 import type { WebhookResponsePayload } from "../webhook.types.js";
 import { RealtimeAudioPacer } from "./realtime-audio-pacer.js";
@@ -310,7 +311,7 @@ function appendRecentTalkEventMetadata(
   call.metadata = metadata;
 }
 
-export class RealtimeCallHandler {
+export class RealtimeCallHandler implements TwilioRealtimeStreamHandoff {
   private readonly toolHandlers = new Map<string, ToolHandlerFn>();
   private readonly pendingStreamTokens = new Map<string, PendingStreamToken>();
   private readonly activeBridgesByCallId = new Map<string, ActiveRealtimeVoiceBridge>();
@@ -318,6 +319,8 @@ export class RealtimeCallHandler {
     string,
     (reason: TelephonyCloseReason) => void
   >();
+  /** Resolves only when Twilio has actually ended the realtime media stream. */
+  private readonly activeStreamEndByCallId = new Map<string, Promise<void>>();
   private readonly partialUserTranscriptsByCallId = new Map<string, string>();
   private readonly rawPartialUserTranscriptsByCallId = new Map<string, string>();
   private readonly partialUserTranscriptUpdatedAtByCallId = new Map<string, number>();
@@ -413,6 +416,16 @@ export class RealtimeCallHandler {
       let initialized = false;
       let activeCallSid = "unknown";
       let stopReceived = false;
+      let resolveStreamEnd: (() => void) | undefined;
+      let streamEndResolved = false;
+      const resolveActiveStreamEnd = () => {
+        if (streamEndResolved) {
+          return;
+        }
+        streamEndResolved = true;
+        resolveStreamEnd?.();
+        this.activeStreamEndByCallId.delete(activeCallSid);
+      };
       let lastMediaTimestamp: number | undefined;
       let lastMediaGapWarnAt = 0;
 
@@ -439,6 +452,10 @@ export class RealtimeCallHandler {
               return;
             }
             bridge = nextBridge;
+            const streamEnded = new Promise<void>((resolve) => {
+              resolveStreamEnd = resolve;
+            });
+            this.activeStreamEndByCallId.set(activeCallSid, streamEnded);
             return;
           }
           if (!bridge) {
@@ -475,6 +492,7 @@ export class RealtimeCallHandler {
           }
           if (frame.kind === "stop") {
             stopReceived = true;
+            resolveActiveStreamEnd();
             this.closeTelephonyBridge(activeCallSid, bridge, "completed");
           }
         } catch (error) {
@@ -483,6 +501,7 @@ export class RealtimeCallHandler {
       });
 
       ws.on("close", (code) => {
+        resolveActiveStreamEnd();
         const reason = stopReceived || code === 1000 || code === 1005 ? "completed" : "error";
         this.closeTelephonyBridge(activeCallSid, bridge, reason);
       });
@@ -508,6 +527,10 @@ export class RealtimeCallHandler {
     } catch (error) {
       return { success: false, error: formatErrorMessage(error) };
     }
+  }
+
+  waitForStreamEnd(callSid: string): Promise<void> | null {
+    return this.activeStreamEndByCallId.get(callSid) ?? null;
   }
 
   issueStreamSession(request: StreamSessionRequest = {}): StreamSession {


### PR DESCRIPTION
## What Problem This Solves

During realtime Twilio calls, DTMF was emitted only after buffered Media Stream speech had drained. That made IVR selections arrive too late to be useful.

## Evidence

- Live listener test confirmed the tones arrived after queued speech, not at dispatch time.
- Focused Twilio provider test verifies stream audio is cleared before the DTMF TwiML redirect.
- `pnpm exec vitest run extensions/voice-call/src/providers/twilio.test.ts --reporter=dot` passed (29 tests).
- `pnpm tsgo:extensions` passed.