### PR TITLE
fix: Doctor migrates every configured agent workspace

### DIFF
--- a/src/agents/workspace-dirs.ts
+++ b/src/agents/workspace-dirs.ts
@@ -5,18 +5,14 @@
  * plus the default agent workspace without duplicating agent-scope logic.
  */
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { listAgentEntries } from "./agent-scope-config.js";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "./agent-scope.js";
 
 /** Lists unique workspace directories for configured agents and the default agent. */
 export function listAgentWorkspaceDirs(cfg: OpenClawConfig): string[] {
   const dirs = new Set<string>();
-  const list = cfg.agents?.list;
-  if (Array.isArray(list)) {
-    for (const entry of list) {
-      if (entry && typeof entry === "object" && typeof entry.id === "string") {
-        dirs.add(resolveAgentWorkspaceDir(cfg, entry.id));
-      }
-    }
+  for (const entry of listAgentEntries(cfg)) {
+    dirs.add(resolveAgentWorkspaceDir(cfg, entry.id));
   }
   dirs.add(resolveAgentWorkspaceDir(cfg, resolveDefaultAgentId(cfg)));
   return [...dirs];

--- a/src/infra/state-migrations.workspace-setup.test.ts
+++ b/src/infra/state-migrations.workspace-setup.test.ts
@@ -110,6 +110,40 @@ describe("legacy workspace Doctor migration", () => {
     });
   });
 
+  it("detects setup state for every canonical agents.entries workspace", async () => {
+    const context = setup();
+    const secondWorkspaceDir = path.join(context.homeDir, "workspace-second");
+    await fsp.mkdir(secondWorkspaceDir, { recursive: true });
+    const entriesContext = {
+      ...context,
+      cfg: {
+        agents: {
+          defaults: { workspace: context.workspaceDir },
+          entries: {
+            hex: { default: true },
+            june: { workspace: secondWorkspaceDir },
+          },
+        },
+      } satisfies OpenClawConfig,
+    };
+    const setupPaths = [context.workspaceDir, secondWorkspaceDir].map((workspaceDir) =>
+      path.join(
+        resolveWorkspaceStateIdentity(workspaceDir).workspacePath,
+        "openclaw-workspace-state.json",
+      ),
+    );
+    for (const setupPath of setupPaths) {
+      await fsp.writeFile(setupPath, JSON.stringify({ version: 1 }), "utf8");
+    }
+
+    expect(detect(entriesContext)).toMatchObject({
+      hasLegacy: true,
+      sources: expect.arrayContaining(
+        setupPaths.map((sourcePath) => expect.objectContaining({ kind: "setup", sourcePath })),
+      ),
+    });
+  });
+
   it("imports setup and attestation state, records receipts, and removes files", async () => {
     const context = setup();
     const identity = resolveWorkspaceStateIdentity(context.workspaceDir);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users with multiple configured agent workspaces could run `openclaw doctor --fix` yet retain legacy setup-state markers in non-default workspaces. Those agents stopped before producing a model response, so connected Discord bots appeared online but did not reply.

## Why This Change Was Made

Doctor now uses the canonical configured-agent enumerator, which supports keyed `agents.entries` while retaining legacy list support. A regression test covers discovery of setup state in both the default and a secondary configured workspace.

## User Impact

`openclaw doctor --fix` migrates every configured agent workspace, allowing affected non-default agents to resume responding after the migration.

## Evidence

- `node scripts/run-vitest.mjs src/infra/state-migrations.workspace-setup.test.ts` - 30 passed.
- `git diff --check` - passed.
- `autoreview --mode uncommitted` - TruffleHog clean; no accepted or actionable findings.
- Local recovery exercised Doctor migration for configured non-default workspaces and verified successful isolated agent responses.

AI-assisted; reviewed and validated manually.
