### PR TITLE
fix(microsoft-foundry): honor Azure device-code lifetime

### DIFF
--- a/extensions/microsoft-foundry/cli.ts
+++ b/extensions/microsoft-foundry/cli.ts
@@ -144,7 +144,8 @@ export async function getAccessTokenResultAsync(
   ) as AzAccessToken;
 }
 
-const AZ_LOGIN_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
+// Entra device codes default to 15 minutes; keep one minute for az to finish.
+const AZ_LOGIN_TIMEOUT_MS = 16 * 60 * 1000;
 
 export async function azLoginDeviceCode(): Promise<void> {
   return azLoginDeviceCodeWithOptions({});
@@ -188,7 +189,7 @@ export async function azLoginDeviceCodeWithOptions(params: {
   appendOutput("stdout", decoders.stdout.end());
   appendOutput("stderr", decoders.stderr.end());
   if (result.termination === "timeout") {
-    throw new Error("az login timed out after 5 minutes");
+    throw new Error("az login timed out after 16 minutes");
   }
   if (result.code === 0) {
     return;

--- a/extensions/microsoft-foundry/cli.ts
+++ b/extensions/microsoft-foundry/cli.ts
@@ -144,8 +144,8 @@ export async function getAccessTokenResultAsync(
   ) as AzAccessToken;
 }
 
-// Entra device codes default to 15 minutes; keep one minute for az to finish.
-const AZ_LOGIN_TIMEOUT_MS = 16 * 60 * 1000;
+// Entra device codes default to 15 minutes; keep five minutes for az to finish.
+const AZ_LOGIN_TIMEOUT_MS = 20 * 60 * 1000;
 
 export async function azLoginDeviceCode(): Promise<void> {
   return azLoginDeviceCodeWithOptions({});
@@ -189,7 +189,7 @@ export async function azLoginDeviceCodeWithOptions(params: {
   appendOutput("stdout", decoders.stdout.end());
   appendOutput("stderr", decoders.stderr.end());
   if (result.termination === "timeout") {
-    throw new Error("az login timed out after 16 minutes");
+    throw new Error("az login timed out after 20 minutes");
   }
   if (result.code === 0) {
     return;

--- a/extensions/microsoft-foundry/index.test.ts
+++ b/extensions/microsoft-foundry/index.test.ts
@@ -2107,7 +2107,7 @@ describe("azLoginDeviceCodeWithOptions utf-8 chunk boundary", () => {
     expect(stderrWriteSpy).toHaveBeenCalledWith("😊");
   });
 
-  it("requests process-tree termination and rejects when az login exceeds 5 minutes", async () => {
+  it("requests process-tree termination after the 15-minute device-code lifetime", async () => {
     runCommandWithTimeoutMock.mockResolvedValueOnce({
       stdout: "",
       stderr: "",
@@ -2120,13 +2120,13 @@ describe("azLoginDeviceCodeWithOptions utf-8 chunk boundary", () => {
 
     const err = await azLoginDeviceCodeWithOptions({}).catch((e: unknown) => e);
     expect(err).toBeInstanceOf(Error);
-    expect((err as Error).message).toBe("az login timed out after 5 minutes");
+    expect((err as Error).message).toBe("az login timed out after 16 minutes");
     expect(runCommandWithTimeoutMock).toHaveBeenCalledWith(
       ["az", "login", "--use-device-code"],
       expect.objectContaining({
         killProcessTree: true,
         outputCapture: "discard",
-        timeoutMs: 5 * 60 * 1000,
+        timeoutMs: 16 * 60 * 1000,
       }),
     );
   });

--- a/extensions/microsoft-foundry/index.test.ts
+++ b/extensions/microsoft-foundry/index.test.ts
@@ -2107,7 +2107,7 @@ describe("azLoginDeviceCodeWithOptions utf-8 chunk boundary", () => {
     expect(stderrWriteSpy).toHaveBeenCalledWith("😊");
   });
 
-  it("requests process-tree termination after the 15-minute device-code lifetime", async () => {
+  it("allows post-auth work after the 15-minute device-code lifetime", async () => {
     runCommandWithTimeoutMock.mockResolvedValueOnce({
       stdout: "",
       stderr: "",
@@ -2120,13 +2120,13 @@ describe("azLoginDeviceCodeWithOptions utf-8 chunk boundary", () => {
 
     const err = await azLoginDeviceCodeWithOptions({}).catch((e: unknown) => e);
     expect(err).toBeInstanceOf(Error);
-    expect((err as Error).message).toBe("az login timed out after 16 minutes");
+    expect((err as Error).message).toBe("az login timed out after 20 minutes");
     expect(runCommandWithTimeoutMock).toHaveBeenCalledWith(
       ["az", "login", "--use-device-code"],
       expect.objectContaining({
         killProcessTree: true,
         outputCapture: "discard",
-        timeoutMs: 16 * 60 * 1000,
+        timeoutMs: 20 * 60 * 1000,
       }),
     );
   });


### PR DESCRIPTION
Related: #112369

## What Problem This Solves

Fixes an issue where Microsoft Foundry users completing Azure device-code login after five minutes would have their still-valid login process killed during onboarding. Microsoft Entra device codes remain valid for 15 minutes by default, so browser and MFA completion at six or seven minutes should still succeed.

## Why This Change Was Made

Keep the process-tree hang protection added in #112369, but move its outer bound to 20 minutes: the documented 15-minute device-code lifetime plus five minutes for Azure CLI to issue the code, finish token processing and tenant/subscription discovery, and exit. This follow-up was identified by the post-merge adversarial audit of #112369; thanks to @wangmiao0668000666 for the original bounded-process work.

## User Impact

Azure device-code login can use its full valid authentication window and a bounded completion window without OpenClaw terminating it early, while genuinely stuck `az login` processes are still bounded and killed after 20 minutes.

## Evidence

- [Microsoft identity platform device authorization grant flow](https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-device-code) documents: “From the moment the request is sent, the user has 15 minutes to sign in.”
- Live Entra device authorization request on 2026-07-25 returned `expires_in: 900` and a five-second polling interval; device and user codes were redacted.
- Azure CLI calls MSAL `acquire_token_by_device_flow`, whose default polling loop runs until the flow's `expires_at` deadline.
- Before the production fix, the updated regression failed 1/96: production still returned `az login timed out after 5 minutes` and passed a five-minute timeout to the process runner.
- The first independent refuter rejected a 16-minute cap because Azure CLI performs tenant/subscription discovery after authentication; the final 20-minute cap preserves five minutes for command completion after the 15-minute device-code lifetime.
- After the fix: `node scripts/run-vitest.mjs extensions/microsoft-foundry/index.test.ts` — 96/96 passed.
- `node scripts/check-changed.mjs -- extensions/microsoft-foundry/cli.ts extensions/microsoft-foundry/index.test.ts` — passed on Blacksmith Testbox, including extension production/test typechecks, lint, formatting, guards, boundaries, and import cycles.
- Pre-commit Codex autoreview: no accepted/actionable findings (0.98 confidence).

No config, public API, dependency, protocol, docs, or changelog changes.
