### PR TITLE
fix(cron): fail originating media cron on detached errors

### DIFF
--- a/src/agents/tools/media-generate-background-shared.test.ts
+++ b/src/agents/tools/media-generate-background-shared.test.ts
@@ -32,6 +32,11 @@ const cronContinuationCleanupMocks = vi.hoisted(() => ({
 const sessionMocks = vi.hoisted(() => ({
   loadSessionEntry: vi.fn<() => SessionEntry | undefined>(() => undefined),
 }));
+const cronStoreMocks = vi.hoisted(() => ({
+  loadCronStore: vi.fn(),
+  resolveCronJobsStorePath: vi.fn(),
+  saveCronStore: vi.fn(),
+}));
 
 vi.mock("../subagent-announce-delivery.js", () => subagentAnnounceDeliveryMocks);
 vi.mock("../../config/sessions/session-accessor.js", async () => ({
@@ -44,6 +49,7 @@ vi.mock("../../config/sessions/session-accessor.js", async () => ({
 vi.mock("../../tasks/detached-task-runtime.js", () => detachedTaskRuntimeMocks);
 vi.mock("../../tasks/task-registry-delivery-runtime.js", () => taskRegistryDeliveryRuntimeMocks);
 vi.mock("../../tasks/cron-run-continuation-cleanup.js", () => cronContinuationCleanupMocks);
+vi.mock("../../cron/store.js", () => cronStoreMocks);
 
 import {
   createMediaGenerationTaskLifecycle,
@@ -63,6 +69,10 @@ beforeEach(() => {
   taskRegistryDeliveryRuntimeMocks.sendMessage.mockReset();
   cronContinuationCleanupMocks.removeCronRunContinuationSessionIfIdle.mockClear();
   sessionMocks.loadSessionEntry.mockReset().mockReturnValue(undefined);
+  cronStoreMocks.loadCronStore.mockReset();
+  cronStoreMocks.resolveCronJobsStorePath.mockReset();
+  cronStoreMocks.resolveCronJobsStorePath.mockReturnValue("/tmp/openclaw-cron.json");
+  cronStoreMocks.saveCronStore.mockReset();
 });
 
 function createImageMediaLifecycle() {
@@ -797,6 +807,86 @@ describe("scheduleMediaGenerationTaskCompletion", () => {
       }),
     );
     expect(lifecycle.completeTaskRun).not.toHaveBeenCalled();
+  });
+
+  it("marks the originating cron job failed when detached generation fails", async () => {
+    const scheduled: Array<() => Promise<void>> = [];
+    const generationError = new Error("provider high-demand 503");
+    const cronJob = {
+      id: "hourly-music-track",
+      name: "Hourly music",
+      enabled: true,
+      createdAtMs: 1,
+      updatedAtMs: 100,
+      schedule: { kind: "every", everyMs: 3_600_000 },
+      sessionTarget: "isolated",
+      wakeMode: "now",
+      payload: { kind: "agentTurn", message: "Generate music" },
+      delivery: { mode: "none" },
+      state: {
+        lastRunAtMs: 1_784_982_758_437,
+        lastRunStatus: "ok",
+        lastStatus: "ok",
+        consecutiveErrors: 0,
+      },
+    };
+    cronStoreMocks.loadCronStore.mockResolvedValueOnce({
+      version: 1,
+      jobs: [cronJob],
+    });
+    const lifecycle = {
+      createTaskRun: vi.fn(),
+      recordTaskProgress: vi.fn(),
+      completeTaskRun: vi.fn(),
+      failTaskRun: vi.fn(),
+      wakeTaskCompletion: vi.fn(async () => true),
+    };
+
+    scheduleMediaGenerationTaskCompletion({
+      lifecycle,
+      handle: {
+        taskId: "task-music-generation-error",
+        runId: "tool:music_generate:generation-error",
+        requesterSessionKey: "agent:main:cron:hourly-music-track:run:1784982758437",
+        taskLabel: "proof music",
+      },
+      scheduleBackgroundWork: (work) => {
+        scheduled.push(work);
+      },
+      progressSummary: "Generating music",
+      config: { cron: { store: "/tmp/custom-cron.json" } },
+      toolName: "Music generation",
+      onWakeFailure: vi.fn(),
+      run: async () => {
+        throw generationError;
+      },
+    });
+
+    await scheduled[0]?.();
+
+    expect(cronStoreMocks.resolveCronJobsStorePath).toHaveBeenCalledWith("/tmp/custom-cron.json");
+    expect(cronStoreMocks.saveCronStore).toHaveBeenCalledWith(
+      "/tmp/openclaw-cron.json",
+      expect.objectContaining({
+        jobs: [
+          expect.objectContaining({
+            state: expect.objectContaining({
+              lastRunStatus: "error",
+              lastStatus: "error",
+              lastError: "Detached Music generation failed: provider high-demand 503",
+              consecutiveErrors: 1,
+            }),
+          }),
+        ],
+      }),
+      { stateOnly: true },
+    );
+    expect(lifecycle.wakeTaskCompletion).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "error",
+        result: "provider high-demand 503",
+      }),
+    );
   });
 });
 

--- a/src/agents/tools/media-generate-background-shared.ts
+++ b/src/agents/tools/media-generate-background-shared.ts
@@ -7,6 +7,7 @@ import crypto from "node:crypto";
 import { getCliSessionBinding } from "../../config/sessions/cli-session-binding.js";
 import { loadSessionEntryReadOnly } from "../../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { loadCronStore, resolveCronJobsStorePath, saveCronStore } from "../../cron/store.js";
 import { clearAgentRunContext, registerAgentRunContext } from "../../infra/agent-events.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
@@ -44,6 +45,8 @@ const log = createSubsystemLogger("agents/tools/media-generate-background-shared
 const MEDIA_GENERATION_TASK_KEEPALIVE_INTERVAL_MS = 60_000;
 const MEDIA_GENERATION_COMPLETION_HANDOFF_RETRY_DELAYS_MS = [250, 500, 1_000, 2_000] as const;
 const MEDIA_GENERATION_COMPLETION_HANDOFF_TIMEOUT_MS = 120_000;
+const CRON_RUN_SESSION_KEY_RE =
+  /^agent:(?<agentId>[^:]+):cron:(?<jobSegment>[^:]+):run:(?<runSegment>[^:]+)/;
 
 /** Handle for a detached media generation task registered in the task ledger. */
 export type MediaGenerationTaskHandle = {
@@ -377,6 +380,89 @@ function failMediaGenerationTaskRun(params: {
   }
 }
 
+function normalizeCronJobIdSegment(value: string | undefined, fallback: string): string {
+  const normalized = value
+    ?.trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 64);
+  return normalized || fallback;
+}
+
+function resolveOriginatingCronRun(params: { requesterSessionKey: string }) {
+  const match = CRON_RUN_SESSION_KEY_RE.exec(params.requesterSessionKey.trim());
+  const groups = match?.groups;
+  if (!groups?.jobSegment || !groups.runSegment) {
+    return null;
+  }
+  const runStartedAtMs = Number.parseInt(groups.runSegment, 10);
+  return {
+    jobSegment: groups.jobSegment,
+    runStartedAtMs: Number.isFinite(runStartedAtMs) ? runStartedAtMs : undefined,
+  };
+}
+
+async function markOriginatingCronRunFailedFromMediaGeneration(params: {
+  config?: OpenClawConfig;
+  handle: MediaGenerationTaskHandle | null;
+  error: unknown;
+  toolName: string;
+}) {
+  if (!params.handle) {
+    return;
+  }
+  const origin = resolveOriginatingCronRun({
+    requesterSessionKey: params.handle.requesterSessionKey,
+  });
+  if (!origin) {
+    return;
+  }
+  const storePath = resolveCronJobsStorePath(params.config?.cron?.store);
+  try {
+    const store = await loadCronStore(storePath);
+    const job = store.jobs.find(
+      (candidate) =>
+        candidate.id === origin.jobSegment ||
+        normalizeCronJobIdSegment(candidate.id, "job") === origin.jobSegment,
+    );
+    if (!job) {
+      return;
+    }
+    const existingLastRunAtMs = job.state.lastRunAtMs;
+    if (
+      origin.runStartedAtMs !== undefined &&
+      typeof existingLastRunAtMs === "number" &&
+      existingLastRunAtMs > origin.runStartedAtMs
+    ) {
+      return;
+    }
+    const endedAt = Date.now();
+    const errorText = `Detached ${params.toolName} failed: ${formatErrorMessage(params.error)}`;
+    job.state.runningAtMs = undefined;
+    job.state.lastRunAtMs = origin.runStartedAtMs ?? existingLastRunAtMs ?? endedAt;
+    job.state.lastRunStatus = "error";
+    job.state.lastStatus = "error";
+    job.state.lastError = errorText;
+    job.state.lastDurationMs = Math.max(0, endedAt - (job.state.lastRunAtMs ?? endedAt));
+    job.state.consecutiveErrors =
+      typeof job.state.consecutiveErrors === "number" &&
+      Number.isFinite(job.state.consecutiveErrors)
+        ? Math.max(0, Math.floor(job.state.consecutiveErrors)) + 1
+        : 1;
+    job.state.consecutiveSkipped = 0;
+    job.updatedAtMs = endedAt;
+    await saveCronStore(storePath, store, { stateOnly: true });
+  } catch (error) {
+    log.warn("Failed to mark originating cron run failed after detached media generation failure", {
+      requesterSessionKey: params.handle.requesterSessionKey,
+      taskId: params.handle.taskId,
+      runId: params.handle.runId,
+      error,
+    });
+  }
+}
+
 function buildMediaGenerationReplyInstruction(params: {
   status: "ok" | "error";
   completionLabel: string;
@@ -517,7 +603,16 @@ export function scheduleMediaGenerationTaskCompletion<
           error: wakeError,
         });
       }
-      params.lifecycle.failTaskRun({ handle: params.handle, error });
+      params.lifecycle.failTaskRun({
+        handle: params.handle,
+        error,
+      });
+      await markOriginatingCronRunFailedFromMediaGeneration({
+        config: params.config,
+        handle: params.handle,
+        error,
+        toolName: params.toolName,
+      });
       return;
     }
 


### PR DESCRIPTION
## What Problem This Solves
Detached media generation can fail after the initiating cron run has already returned success. In that case the task ledger records the media failure, but the originating cron job can remain green, hiding provider failures from cron health and heartbeat audits.

## Summary
- mark originating cron jobs failed when detached media generation later throws
- resolve the cron job from the requester cron run session key and persist state-only cron updates
- add regression coverage for detached media failures propagating back to cron state

## Evidence
- Local live observation: hourly music runs HV-1091 and HV-1092 failed with provider high-demand 503 while the installed cron still reported green/consecutiveErrors 0 before this fix path existed.
- ./node_modules/.bin/oxfmt --write --threads=1 src/agents/tools/media-generate-background-shared.ts src/agents/tools/media-generate-background-shared.test.ts
- ./node_modules/.bin/vitest run src/agents/tools/media-generate-background-shared.test.ts currently cannot complete locally on current main because this shell has Node 24.13.0 / SQLite 3.50.4; OpenClaw now requires Node >=24.15.0 (or another allowed runtime) for WAL safety.
