### PR TITLE
fix(cron): keep paused jobs off descending next-run pages

### DIFF
--- a/src/cron/service.list-page-sort-guards.test.ts
+++ b/src/cron/service.list-page-sort-guards.test.ts
@@ -55,6 +55,37 @@ describe("cron listPage sort guards", () => {
     expect(page.jobs).toHaveLength(2);
   });
 
+  it.each([
+    { sortDir: "asc" as const, scheduledIds: ["earlier", "later"] },
+    { sortDir: "desc" as const, scheduledIds: ["later", "earlier"] },
+  ])(
+    "keeps unscheduled jobs after the scheduled $sortDir page",
+    async ({ sortDir, scheduledIds }) => {
+      const jobs = [
+        createBaseJob({ id: "paused-z", enabled: false, state: {} }),
+        createBaseJob({ id: "later", state: { nextRunAtMs: 200 } }),
+        createBaseJob({ id: "paused-a", enabled: false, state: {} }),
+        createBaseJob({ id: "earlier", state: { nextRunAtMs: 100 } }),
+      ];
+      const state = createMockCronStateForJobs({ jobs });
+      const options = {
+        enabled: "all" as const,
+        sortBy: "nextRunAtMs" as const,
+        sortDir,
+        limit: 2,
+      };
+
+      const firstPage = await listPage(state, { ...options, offset: 0 });
+      const secondPage = await listPage(state, { ...options, offset: 2 });
+
+      expect(firstPage.jobs.map((job) => job.id)).toEqual(scheduledIds);
+      expect(firstPage.hasMore).toBe(true);
+      expect(secondPage.jobs.map((job) => job.id)).toEqual(["paused-a", "paused-z"]);
+      expect(secondPage.hasMore).toBe(false);
+      expect(secondPage.snapshotRevision).toBe(firstPage.snapshotRevision);
+    },
+  );
+
   it("normalizes requested agent ids before filtering", async () => {
     const jobs = [
       createBaseJob({ id: "job-main", agentId: "main", name: "main" }),

--- a/src/cron/service/list-page-sort.ts
+++ b/src/cron/service/list-page-sort.ts
@@ -21,9 +21,11 @@ export function sortCronJobs(
       if (typeof aNext === "number" && typeof bNext === "number") {
         cmp = aNext - bNext;
       } else if (typeof aNext === "number") {
-        cmp = -1;
+        // Missing run times are not directional sort keys. Keep paused jobs
+        // after runnable jobs so descending pages do not hide scheduled work.
+        return -1;
       } else if (typeof bNext === "number") {
-        cmp = 1;
+        return 1;
       } else {
         cmp = 0;
       }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users sorting automations by descending next-run time would see paused jobs before scheduled jobs when both were included. If the page was full, every runnable job could disappear onto a later page.

## Why This Change Was Made

Treat a missing next-run timestamp as a fixed last-place bucket. Apply ascending or descending direction only to actual timestamps, preserving the existing deterministic job-ID tiebreaker, filtering, page boundaries, and snapshot revision.

## User Impact

The Control UI, public Gateway `cron.list`, and other cron-list callers show scheduled jobs first in either next-run sort direction. Paused jobs remain available on later pages without hiding work that will actually run.

## Evidence

- Based on verified fresh `main` `4032ae5247a4735c25dd38e8477dd397a83b8997`.
- Red-first remote regression: the real paginated service returned `["paused-a", "paused-z"]` instead of `["later", "earlier"]` for the first descending page; the ascending regression and 11 existing tests remained green.
- After the fix, 289 remote tests passed: 53 cron-service and pagination tests, 158 Gateway cron API tests, and 78 Control UI cron tests.
- The new table-driven regression checks ascending and descending ordering, the actual first and second pages, `hasMore`, deterministic paused-job order, and matching page snapshot revisions.
- Full remote changed-files gate: `pnpm check:changed -- src/cron/service/list-page-sort.ts src/cron/service.list-page-sort-guards.test.ts`.
- Fresh independent Codex autoreview and TruffleHog secret scan: clean, zero actionable findings, 0.98 reviewer confidence.

AI-assisted; all reported regressions and validation were independently executed.
