### PR TITLE
improve(memory-wiki): batch automation operations

### DIFF
--- a/docs/cli/wiki.md
+++ b/docs/cli/wiki.md
@@ -1,5 +1,5 @@
 ---
-summary: "CLI reference for `openclaw wiki` (memory-wiki vault status, search, compile, lint, apply, bridge, ChatGPT import, and Obsidian helpers)"
+summary: "CLI reference for `openclaw wiki` (memory-wiki vault status, search, compile, lint, apply, batch automation, bridge, ChatGPT import, and Obsidian helpers)"
 read_when:
   - You want to use the memory-wiki CLI
   - You are documenting or changing `openclaw wiki`
@@ -39,6 +39,9 @@ openclaw wiki apply metadata entity.alpha \
   --source-id source.alpha \
   --status review \
   --question "Still active?"
+
+openclaw wiki apply-batch --input ./wiki-apply-batch.json --dry-run --json
+openclaw wiki search-batch --input ./wiki-search-batch.json --json
 
 openclaw wiki bridge import
 openclaw wiki unsafe-local import
@@ -102,7 +105,7 @@ Create the wiki vault layout and starter pages, including top-level indexes and 
 
 Import a local markdown or text file into the wiki `sources/` folder as a source page. `<path>` must be a local file path; there is no URL ingest today. Rejects binary files.
 
-Imported source pages carry provenance frontmatter (`sourceType: local-file`, `sourcePath`, `ingestedAt`). Ingest always recompiles the vault afterward.
+Imported source pages carry provenance frontmatter (`sourceType: local-file`, `sourcePath`, `ingestedAt`). Regular ingest always recompiles the vault so it can repair stale derived state, but an unchanged generated source page is not rewritten. Batch ingest defers compilation to the enclosing batch and skips it when every operation is unchanged.
 
 Flags: `--title <title>` overrides the source title (default: derived from the filename).
 
@@ -188,6 +191,33 @@ Apply narrow mutations without freeform page surgery:
 
 Both accept `--source-id`, `--contradiction`, `--question` (each repeatable), `--confidence <n>` (0-1), and `--status <status>`. `apply metadata` also accepts `--clear-confidence` to remove a stored confidence value. This is the supported way to evolve wiki pages so managed generated blocks stay intact.
 
+A semantic no-op preserves the page, audit log, and compiled snapshot and skips compilation. A changed mutation invalidates the previous compiled snapshot before rebuilding it, so a failed rebuild cannot leave old derived state looking current.
+
+### `wiki apply-batch`
+
+Apply bounded machine-oriented source and synthesis operations from a version 1 JSON file:
+
+```bash
+openclaw wiki apply-batch --input ./wiki-apply-batch.json --dry-run --json
+openclaw wiki apply-batch --input ./wiki-apply-batch.json --json
+```
+
+The input accepts at most 16 ordered operations. Supported operation kinds are `ingest-source` and `upsert-synthesis`; a synthesis can refer to an earlier source operation with `sourceRefs`. The command validates the complete input before mutation, applies operations under one vault lease, preserves existing timestamps on semantic no-ops, invalidates the prior compiled snapshot on the first write, and compiles at most once after all changed operations. `--dry-run` performs validation and change detection without writes.
+
+Inputs are capped at 256 KiB, referenced source files at 8 MiB, and synthesis bodies at 1 MiB. JSON output contains bounded operation results and compile counts; it does not include the full compiled page inventory.
+
+### `wiki search-batch`
+
+Verify up to six wiki-only queries from one prepared digest and bounded target-page snapshot:
+
+```bash
+openclaw wiki search-batch --input ./wiki-search-batch.json --json
+```
+
+Each version 1 query declares an `id`, `query`, and at least one `expectedPaths` or `expectedIds` value. `expectedPageTypes`, `mode`, `maxResults`, and `required` are optional. Expected paths must stay under a wiki page directory. The command exits non-zero if any required query fails to retrieve its exact path/id with the expected page type. Results contain the candidate-page count and at most five bounded hits per query.
+
+Batch search deliberately avoids shared-memory lookup and imported-source synchronization. Use regular `wiki search` when those freshness semantics are required.
+
 ### `wiki bridge import`
 
 Import public memory artifacts from the active memory plugin into bridge-backed source pages. Use this in `bridge` mode to pull the latest exported memory artifacts into the wiki vault.
@@ -231,6 +261,7 @@ available.
 
 - Use `wiki search` + `wiki get` when provenance and page identity matter.
 - Use `wiki apply` instead of hand-editing managed generated sections.
+- Use `wiki apply-batch` and `wiki search-batch` for bounded automation that must avoid repeated plugin startup, compile, and page loading.
 - Use `wiki lint` before trusting contradictory or low-confidence content.
 - Use `wiki compile` after bulk imports or source changes when you want fresh dashboards and compiled digests immediately.
 - Use `wiki okf import` when a data catalog, documentation export, or agent enrichment pipeline already emits OKF markdown bundles.

--- a/docs/plugins/memory-wiki.md
+++ b/docs/plugins/memory-wiki.md
@@ -517,12 +517,15 @@ openclaw wiki lint
 openclaw wiki search "alpha"
 openclaw wiki get entity.alpha
 openclaw wiki apply synthesis "Alpha Summary" --body "..." --source-id source.alpha
+openclaw wiki apply-batch --input ./wiki-apply-batch.json --dry-run --json
+openclaw wiki search-batch --input ./wiki-search-batch.json --json
 openclaw wiki bridge import
 openclaw wiki obsidian status
 ```
 
 See [CLI: wiki](/cli/wiki) for the full command reference, including
-`wiki okf import`, `wiki apply metadata`, `wiki unsafe-local import`,
+`wiki okf import`, `wiki apply metadata`, bounded `wiki apply-batch` and
+`wiki search-batch` automation, `wiki unsafe-local import`,
 `wiki chatgpt import` / `wiki chatgpt rollback`, and the full `wiki obsidian`
 subcommand set.
 

--- a/extensions/memory-wiki/src/apply.test.ts
+++ b/extensions/memory-wiki/src/apply.test.ts
@@ -3,6 +3,9 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { applyMemoryWikiMutation, normalizeMemoryWikiMutationInput } from "./apply.js";
+import { compileMemoryWikiVault } from "./compile.js";
+import { loadMemoryWikiCompiledCache } from "./compiled-cache.js";
+import { loadMemoryWikiVaultIdentity } from "./log.js";
 import { parseWikiMarkdown, renderWikiMarkdown } from "./markdown.js";
 import { createMemoryWikiTestHarness } from "./test-helpers.js";
 
@@ -98,7 +101,7 @@ describe("applyMemoryWikiMutation", () => {
     expect(result.changed).toBe(true);
     expect(result.pagePath).toBe("syntheses/alpha-synthesis.md");
     expect(result.pageId).toBe("synthesis.alpha-synthesis");
-    expect(result.compile.pageCounts.synthesis).toBe(1);
+    expect(result.compile?.pageCounts.synthesis).toBe(1);
 
     const page = await fs.readFile(path.join(rootDir, result.pagePath), "utf8");
     const parsed = parseWikiMarkdown(page);
@@ -172,9 +175,9 @@ describe("applyMemoryWikiMutation", () => {
     });
 
     expect(result.changed).toBe(true);
-    expect(result.compile.pageCounts.source).toBe(0);
-    expect(result.compile.pageCounts.synthesis).toBe(1);
-    expect(result.compile.frontmatterErrors).toEqual([
+    expect(result.compile?.pageCounts.source).toBe(0);
+    expect(result.compile?.pageCounts.synthesis).toBe(1);
+    expect(result.compile?.frontmatterErrors).toEqual([
       expect.objectContaining({ relativePath: "sources/broken.md" }),
     ]);
     await expect(fs.readFile(brokenPath, "utf8")).resolves.toBe(brokenPage);
@@ -281,7 +284,7 @@ keep this note
 
     expect(result.changed).toBe(true);
     expect(result.pagePath).toBe("entities/alpha.md");
-    expect(result.compile.pageCounts.entity).toBe(1);
+    expect(result.compile?.pageCounts.entity).toBe(1);
 
     const updated = await fs.readFile(targetPath, "utf8");
     const parsed = parseWikiMarkdown(updated);
@@ -376,5 +379,65 @@ keep this note
       confidence: 0.9,
       status: "review",
     });
+  });
+
+  it("preserves page, log, and compiled-cache identity for a semantic no-op", async () => {
+    const { rootDir, config } = await createVault({ prefix: "memory-wiki-apply-no-op-" });
+    const mutation = {
+      op: "create_synthesis" as const,
+      title: "Stable Synthesis",
+      body: "Stable summary body.",
+      sourceIds: ["source.stable"],
+    };
+    const first = await applyMemoryWikiMutation({ config, mutation });
+    const pagePath = path.join(rootDir, first.pagePath);
+    const logPath = path.join(rootDir, ".openclaw-wiki", "log.jsonl");
+    const pageBefore = await fs.readFile(pagePath, "utf8");
+    const pageStatBefore = await fs.stat(pagePath);
+    const logBefore = await fs.readFile(logPath, "utf8");
+    const identityBefore = await loadMemoryWikiVaultIdentity(rootDir);
+    const cacheBefore = await loadMemoryWikiCompiledCache(config);
+
+    const repeated = await applyMemoryWikiMutation({ config, mutation });
+
+    expect(repeated.changed).toBe(false);
+    expect(repeated.compile).toBeUndefined();
+    await expect(fs.readFile(pagePath, "utf8")).resolves.toBe(pageBefore);
+    expect((await fs.stat(pagePath)).mtimeMs).toBe(pageStatBefore.mtimeMs);
+    await expect(fs.readFile(logPath, "utf8")).resolves.toBe(logBefore);
+    await expect(loadMemoryWikiVaultIdentity(rootDir)).resolves.toEqual(identityBefore);
+    await expect(loadMemoryWikiCompiledCache(config)).resolves.toEqual(cacheBefore);
+  });
+
+  it("invalidates the compiled snapshot before returning a changed deferred apply", async () => {
+    const { config } = await createVault({ prefix: "memory-wiki-apply-deferred-" });
+    await applyMemoryWikiMutation({
+      config,
+      mutation: {
+        op: "create_synthesis",
+        title: "Deferred Synthesis",
+        body: "Original summary.",
+        sourceIds: ["source.deferred"],
+      },
+    });
+    expect(await loadMemoryWikiCompiledCache(config)).not.toBeNull();
+
+    const changed = await applyMemoryWikiMutation({
+      config,
+      mutation: {
+        op: "create_synthesis",
+        title: "Deferred Synthesis",
+        body: "Updated summary.",
+        sourceIds: ["source.deferred"],
+      },
+      compile: false,
+    });
+
+    expect(changed.changed).toBe(true);
+    expect(changed.compile).toBeUndefined();
+    await expect(loadMemoryWikiCompiledCache(config)).resolves.toBeNull();
+
+    await compileMemoryWikiVault(config);
+    await expect(loadMemoryWikiCompiledCache(config)).resolves.not.toBeNull();
   });
 });

--- a/extensions/memory-wiki/src/apply.ts
+++ b/extensions/memory-wiki/src/apply.ts
@@ -8,6 +8,7 @@ import { readFiniteNumberParam } from "openclaw/plugin-sdk/param-readers";
 import { FsSafeError, root as fsRoot } from "openclaw/plugin-sdk/security-runtime";
 import { normalizeStringEntries, uniqueStrings } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { compileMemoryWikiVault, type CompileMemoryWikiResult } from "./compile.js";
+import { invalidateMemoryWikiCompiledCache } from "./compiled-cache.js";
 import type { ResolvedMemoryWikiConfig } from "./config.js";
 import {
   parseWikiMarkdown,
@@ -24,6 +25,7 @@ import {
   resolveQueryableWikiPageByLookup,
   type QueryableWikiPage,
 } from "./query.js";
+import { resolveMemoryWikiTimestamp } from "./time.js";
 import { initializeMemoryWikiVault } from "./vault.js";
 
 const GENERATED_START = "<!-- openclaw:wiki:generated:start -->";
@@ -63,7 +65,16 @@ type ApplyMemoryWikiMutationResult = {
   operation: ApplyMemoryWikiMutation["op"];
   pagePath: string;
   pageId?: string;
-  compile: CompileMemoryWikiResult;
+  compile?: CompileMemoryWikiResult;
+};
+
+type ApplyMemoryWikiMutationParams = {
+  config: ResolvedMemoryWikiConfig;
+  mutation: ApplyMemoryWikiMutation;
+  compile?: boolean;
+  dryRun?: boolean;
+  initialize?: boolean;
+  nowMs?: number;
 };
 
 function normalizeMutationConfidence(
@@ -216,6 +227,7 @@ async function writeWikiPage(params: {
   relativePath: string;
   frontmatter: Record<string, unknown>;
   body: string;
+  dryRun?: boolean;
 }): Promise<boolean> {
   const root = await fsRoot(params.rootDir);
   const rendered = withTrailingNewline(
@@ -228,7 +240,9 @@ async function writeWikiPage(params: {
   if (existing === rendered) {
     return false;
   }
-  await root.write(params.relativePath, rendered);
+  if (!params.dryRun) {
+    await root.write(params.relativePath, rendered);
+  }
   return true;
 }
 
@@ -243,6 +257,8 @@ async function resolveWritablePage(params: {
 async function applyCreateSynthesisMutation(params: {
   config: ResolvedMemoryWikiConfig;
   mutation: CreateSynthesisMemoryWikiMutation;
+  dryRun?: boolean;
+  nowMs?: number;
 }): Promise<{ changed: boolean; pagePath: string; pageId: string }> {
   const slug = slugifyWikiSegment(params.mutation.title);
   const pageStem = slugifyWikiPageStem(params.mutation.title);
@@ -253,44 +269,61 @@ async function applyCreateSynthesisMutation(params: {
   const pageId =
     (typeof parsed.frontmatter.id === "string" && parsed.frontmatter.id.trim()) ||
     `synthesis.${slug}`;
+  const timestamp = resolveMemoryWikiTimestamp(params.nowMs);
+  const priorUpdatedAt =
+    (typeof parsed.frontmatter.updatedAt === "string" && parsed.frontmatter.updatedAt.trim()) ||
+    timestamp;
+  const body = buildSynthesisBody({
+    title: params.mutation.title,
+    originalBody: parsed.body,
+    generatedBody: params.mutation.body.trim(),
+  });
+  const buildFrontmatter = (updatedAt: string) => ({
+    ...parsed.frontmatter,
+    pageType: "synthesis",
+    id: pageId,
+    title: params.mutation.title,
+    sourceIds: normalizeSourceIds(params.mutation.sourceIds),
+    ...(params.mutation.claims ? { claims: normalizeWikiClaims(params.mutation.claims) } : {}),
+    ...(normalizeUniqueStrings(params.mutation.contradictions)
+      ? { contradictions: normalizeUniqueStrings(params.mutation.contradictions) }
+      : {}),
+    ...(normalizeUniqueStrings(params.mutation.questions)
+      ? { questions: normalizeUniqueStrings(params.mutation.questions) }
+      : {}),
+    ...(typeof params.mutation.confidence === "number"
+      ? { confidence: params.mutation.confidence }
+      : {}),
+    status: params.mutation.status?.trim() || "active",
+    updatedAt,
+  });
   const changed = await writeWikiPage({
     rootDir: params.config.vault.path,
     relativePath: pagePath,
-    frontmatter: {
-      ...parsed.frontmatter,
-      pageType: "synthesis",
-      id: pageId,
-      title: params.mutation.title,
-      sourceIds: normalizeSourceIds(params.mutation.sourceIds),
-      ...(params.mutation.claims ? { claims: normalizeWikiClaims(params.mutation.claims) } : {}),
-      ...(normalizeUniqueStrings(params.mutation.contradictions)
-        ? { contradictions: normalizeUniqueStrings(params.mutation.contradictions) }
-        : {}),
-      ...(normalizeUniqueStrings(params.mutation.questions)
-        ? { questions: normalizeUniqueStrings(params.mutation.questions) }
-        : {}),
-      ...(typeof params.mutation.confidence === "number"
-        ? { confidence: params.mutation.confidence }
-        : {}),
-      status: params.mutation.status?.trim() || "active",
-      updatedAt: new Date().toISOString(),
-    },
-    body: buildSynthesisBody({
-      title: params.mutation.title,
-      originalBody: parsed.body,
-      generatedBody: params.mutation.body.trim(),
-    }),
+    frontmatter: buildFrontmatter(priorUpdatedAt),
+    body,
+    dryRun: true,
   });
+  if (changed) {
+    await writeWikiPage({
+      rootDir: params.config.vault.path,
+      relativePath: pagePath,
+      frontmatter: buildFrontmatter(timestamp),
+      body,
+      dryRun: params.dryRun,
+    });
+  }
   return { changed, pagePath, pageId };
 }
 
 function buildUpdatedFrontmatter(params: {
   original: Record<string, unknown>;
   mutation: UpdateMetadataMemoryWikiMutation;
+  updatedAt: string;
 }): Record<string, unknown> {
   const frontmatter: Record<string, unknown> = {
     ...params.original,
-    updatedAt: new Date().toISOString(),
+    updatedAt: params.updatedAt,
   };
   if (params.mutation.sourceIds) {
     frontmatter.sourceIds = normalizeSourceIds(params.mutation.sourceIds);
@@ -333,6 +366,8 @@ function buildUpdatedFrontmatter(params: {
 async function applyUpdateMetadataMutation(params: {
   config: ResolvedMemoryWikiConfig;
   mutation: UpdateMetadataMemoryWikiMutation;
+  dryRun?: boolean;
+  nowMs?: number;
 }): Promise<{ changed: boolean; pagePath: string; pageId?: string }> {
   const page = await resolveWritablePage({
     config: params.config,
@@ -342,15 +377,34 @@ async function applyUpdateMetadataMutation(params: {
     throw new Error(`Wiki page not found: ${params.mutation.lookup}`);
   }
   const parsed = parseWikiMarkdown(page.raw);
+  const timestamp = resolveMemoryWikiTimestamp(params.nowMs);
+  const priorUpdatedAt =
+    (typeof parsed.frontmatter.updatedAt === "string" && parsed.frontmatter.updatedAt.trim()) ||
+    timestamp;
   const changed = await writeWikiPage({
     rootDir: params.config.vault.path,
     relativePath: page.relativePath,
     frontmatter: buildUpdatedFrontmatter({
       original: parsed.frontmatter,
       mutation: params.mutation,
+      updatedAt: priorUpdatedAt,
     }),
     body: parsed.body,
+    dryRun: true,
   });
+  if (changed) {
+    await writeWikiPage({
+      rootDir: params.config.vault.path,
+      relativePath: page.relativePath,
+      frontmatter: buildUpdatedFrontmatter({
+        original: parsed.frontmatter,
+        mutation: params.mutation,
+        updatedAt: timestamp,
+      }),
+      body: parsed.body,
+      dryRun: params.dryRun,
+    });
+  }
   return {
     changed,
     pagePath: page.relativePath,
@@ -358,35 +412,52 @@ async function applyUpdateMetadataMutation(params: {
   };
 }
 
-async function applyMemoryWikiMutationUnlocked(params: {
-  config: ResolvedMemoryWikiConfig;
-  mutation: ApplyMemoryWikiMutation;
-}): Promise<ApplyMemoryWikiMutationResult> {
-  await initializeMemoryWikiVault(params.config);
+async function applyMemoryWikiMutationUnlocked(
+  params: ApplyMemoryWikiMutationParams,
+): Promise<ApplyMemoryWikiMutationResult> {
+  let initialized = false;
+  if (!params.dryRun && params.initialize !== false) {
+    const initialization = await initializeMemoryWikiVault(params.config, {
+      nowMs: params.nowMs,
+    });
+    initialized = initialization.created;
+  }
   const result =
     params.mutation.op === "create_synthesis"
       ? await applyCreateSynthesisMutation({
           config: params.config,
           mutation: params.mutation,
+          dryRun: params.dryRun,
+          nowMs: params.nowMs,
         })
       : await applyUpdateMetadataMutation({
           config: params.config,
           mutation: params.mutation,
+          dryRun: params.dryRun,
+          nowMs: params.nowMs,
         });
-  const compile = await compileMemoryWikiVault(params.config);
+  const changed = initialized || result.changed;
+  let compile: CompileMemoryWikiResult | undefined;
+  if (changed && !params.dryRun) {
+    // A write must make the prior snapshot unreadable before any later fallible work.
+    // Batch callers then rebuild once; standalone callers rebuild immediately.
+    await invalidateMemoryWikiCompiledCache(params.config);
+    if (params.compile !== false) {
+      compile = await compileMemoryWikiVault(params.config);
+    }
+  }
   return {
-    changed: result.changed,
+    changed,
     operation: params.mutation.op,
     pagePath: result.pagePath,
     ...(result.pageId ? { pageId: result.pageId } : {}),
-    compile,
+    ...(compile ? { compile } : {}),
   };
 }
 
-export async function applyMemoryWikiMutation(params: {
-  config: ResolvedMemoryWikiConfig;
-  mutation: ApplyMemoryWikiMutation;
-}): Promise<ApplyMemoryWikiMutationResult> {
+export async function applyMemoryWikiMutation(
+  params: ApplyMemoryWikiMutationParams,
+): Promise<ApplyMemoryWikiMutationResult> {
   return await withMemoryWikiVaultMutation(params.config.vault.path, () =>
     applyMemoryWikiMutationUnlocked(params),
   );

--- a/extensions/memory-wiki/src/batch-cli.ts
+++ b/extensions/memory-wiki/src/batch-cli.ts
@@ -1,0 +1,60 @@
+// Memory Wiki helper registers bounded machine-oriented batch commands.
+import type { Command } from "commander";
+import { runMemoryWikiApplyBatch, runMemoryWikiSearchBatch } from "./batch.js";
+import type { ResolvedMemoryWikiConfig } from "./config.js";
+
+type WikiApplyBatchCommandOptions = {
+  json?: boolean;
+  dryRun?: boolean;
+  input: string;
+};
+
+type WikiSearchBatchCommandOptions = {
+  json?: boolean;
+  input: string;
+};
+
+function writeOutput(output: string) {
+  process.stdout.write(output.endsWith("\n") ? output : `${output}\n`);
+}
+
+export function registerMemoryWikiBatchCli(
+  wiki: Command,
+  resolveConfig: () => ResolvedMemoryWikiConfig,
+) {
+  wiki
+    .command("apply-batch")
+    .description("Apply bounded native wiki operations with at most one compile")
+    .requiredOption("--input <path>", "Version 1 batch JSON file")
+    .option("--dry-run", "Validate and report changes without writing")
+    .option("--json", "Print JSON")
+    .action(async (opts: WikiApplyBatchCommandOptions) => {
+      const result = await runMemoryWikiApplyBatch({
+        config: resolveConfig(),
+        inputPath: opts.input,
+        dryRun: opts.dryRun,
+      });
+      writeOutput(
+        opts.json
+          ? JSON.stringify(result, null, 2)
+          : `${result.dryRun ? "Planned" : "Applied"} ${result.operationCount} wiki operation${result.operationCount === 1 ? "" : "s"}; changed=${result.changed}; duration=${result.durationMs}ms.`,
+      );
+    });
+
+  wiki
+    .command("search-batch")
+    .description("Verify bounded wiki-only queries from one prepared search snapshot")
+    .requiredOption("--input <path>", "Version 1 batch JSON file")
+    .option("--json", "Print JSON")
+    .action(async (opts: WikiSearchBatchCommandOptions) => {
+      const result = await runMemoryWikiSearchBatch({
+        config: resolveConfig(),
+        inputPath: opts.input,
+      });
+      writeOutput(
+        opts.json
+          ? JSON.stringify(result, null, 2)
+          : `Verified ${result.queryCount} wiki quer${result.queryCount === 1 ? "y" : "ies"} in ${result.durationMs}ms.`,
+      );
+    });
+}

--- a/extensions/memory-wiki/src/batch.test.ts
+++ b/extensions/memory-wiki/src/batch.test.ts
@@ -1,0 +1,385 @@
+// Memory Wiki tests cover bounded batch behavior.
+import fs from "node:fs/promises";
+import path from "node:path";
+import { KeyedAsyncQueue } from "openclaw/plugin-sdk/keyed-async-queue";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { runMemoryWikiApplyBatch, runMemoryWikiSearchBatch } from "./batch.js";
+import { createMemoryWikiTestHarness } from "./test-helpers.js";
+
+const { createTempDir, createVault } = createMemoryWikiTestHarness();
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+async function writeJson(filePath: string, value: unknown): Promise<void> {
+  await fs.writeFile(filePath, `${JSON.stringify(value)}\n`, "utf8");
+}
+
+describe("memory-wiki batch operations", () => {
+  it("preflights without writes, compiles once, and becomes a no-op", async () => {
+    const tempDir = await createTempDir("memory-wiki-batch-");
+    const sourcePath = path.join(tempDir, "alpha.txt");
+    const applyPath = path.join(tempDir, "apply.json");
+    await fs.writeFile(sourcePath, "Alpha source evidence.\n", "utf8");
+    const { rootDir, config } = await createVault({
+      rootDir: path.join(tempDir, "vault"),
+      initialize: true,
+    });
+    await writeJson(applyPath, {
+      version: 1,
+      operations: [
+        {
+          id: "source",
+          kind: "ingest-source",
+          inputPath: sourcePath,
+          title: "Alpha Reference",
+          evidence: {
+            sourceType: "evidence-primary-document",
+            type: "primary_document",
+            kind: "primary_document",
+            origin: "test-fixture",
+            directness: "primary",
+            weight: 1,
+          },
+        },
+        {
+          id: "synthesis",
+          kind: "upsert-synthesis",
+          title: "Alpha Synthesis",
+          body: "Alpha explanatory summary.",
+          sourceRefs: ["source"],
+          confidence: 0.8,
+          status: "active",
+        },
+      ],
+    });
+
+    const planned = await runMemoryWikiApplyBatch({ config, inputPath: applyPath, dryRun: true });
+    expect(planned.changed).toBe(true);
+    await expect(fs.stat(path.join(rootDir, "sources", "alpha-reference.md"))).rejects.toThrow();
+
+    const applied = await runMemoryWikiApplyBatch({ config, inputPath: applyPath });
+    expect(applied.changed).toBe(true);
+    expect(applied.operationCount).toBe(2);
+    expect(applied.compile?.pageCounts.source).toBe(1);
+    expect(applied.compile?.pageCounts.synthesis).toBe(1);
+
+    const repeated = await runMemoryWikiApplyBatch({ config, inputPath: applyPath, dryRun: true });
+    expect(repeated.changed).toBe(false);
+    expect(repeated.compile).toBeNull();
+
+    const indexPath = path.join(rootDir, "index.md");
+    await fs.rm(indexPath);
+    const repaired = await runMemoryWikiApplyBatch({ config, inputPath: applyPath });
+    expect(repaired.changed).toBe(true);
+    expect(repaired.operations.every((operation) => operation.changed === false)).toBe(true);
+    expect(repaired.compile).not.toBeNull();
+    await expect(fs.readFile(indexPath, "utf8")).resolves.toContain(
+      "[Alpha Reference](sources/alpha-reference.md)",
+    );
+  });
+
+  it("verifies exact, explanatory, and evidence queries from one batch", async () => {
+    const tempDir = await createTempDir("memory-wiki-search-batch-");
+    const sourcePath = path.join(tempDir, "alpha.txt");
+    const applyPath = path.join(tempDir, "apply.json");
+    const searchPath = path.join(tempDir, "search.json");
+    await fs.writeFile(sourcePath, "Alpha source evidence.\n", "utf8");
+    const { config } = await createVault({
+      rootDir: path.join(tempDir, "vault"),
+      initialize: true,
+    });
+    await writeJson(applyPath, {
+      version: 1,
+      operations: [
+        {
+          id: "source",
+          kind: "ingest-source",
+          inputPath: sourcePath,
+          title: "Alpha Reference",
+        },
+        {
+          id: "synthesis",
+          kind: "upsert-synthesis",
+          title: "Alpha Synthesis",
+          body: "Alpha explanatory summary.",
+          sourceRefs: ["source"],
+        },
+      ],
+    });
+    await runMemoryWikiApplyBatch({ config, inputPath: applyPath });
+    await writeJson(searchPath, {
+      version: 1,
+      queries: [
+        {
+          id: "exact-document",
+          query: "Alpha Reference",
+          expectedPaths: ["sources/alpha-reference.md"],
+          expectedPageTypes: ["source"],
+        },
+        {
+          id: "explanatory",
+          query: "Alpha explanatory summary",
+          expectedIds: ["synthesis.alpha-synthesis"],
+          expectedPageTypes: ["synthesis"],
+        },
+        {
+          id: "evidence",
+          query: "Alpha source evidence",
+          mode: "source-evidence",
+          expectedIds: ["source.alpha-reference"],
+          expectedPageTypes: ["source"],
+        },
+      ],
+    });
+
+    const result = await runMemoryWikiSearchBatch({ config, inputPath: searchPath });
+    expect(result.ok).toBe(true);
+    expect(result.results).toHaveLength(3);
+    expect(result.results.every((item) => item.ok)).toBe(true);
+    expect(result.results.every((item) => item.candidatePageCount <= 2)).toBe(true);
+  });
+
+  it("keeps ordered operations and one compile under one vault lease", async () => {
+    const tempDir = await createTempDir("memory-wiki-batch-lease-");
+    const sourcePath = path.join(tempDir, "ordered.txt");
+    const applyPath = path.join(tempDir, "apply.json");
+    await fs.writeFile(sourcePath, "Ordered source evidence.\n", "utf8");
+    const { rootDir, config } = await createVault({
+      rootDir: path.join(tempDir, "vault"),
+      initialize: true,
+    });
+    await writeJson(applyPath, {
+      version: 1,
+      operations: [
+        {
+          id: "source-first",
+          kind: "ingest-source",
+          inputPath: sourcePath,
+          title: "Ordered Reference",
+        },
+        {
+          id: "synthesis-second",
+          kind: "upsert-synthesis",
+          title: "Ordered Synthesis",
+          body: "Built from the earlier source operation.",
+          sourceRefs: ["source-first"],
+        },
+      ],
+    });
+    const enqueue = vi.spyOn(KeyedAsyncQueue.prototype, "enqueue");
+
+    const result = await runMemoryWikiApplyBatch({ config, inputPath: applyPath });
+
+    expect(result.operations.map((operation) => operation.id)).toEqual([
+      "source-first",
+      "synthesis-second",
+    ]);
+    expect(enqueue).toHaveBeenCalledTimes(1);
+    const log = await fs.readFile(path.join(rootDir, ".openclaw-wiki", "log.jsonl"), "utf8");
+    expect(log.match(/"pageCounts"/g)).toHaveLength(1);
+  });
+
+  it("rejects expected paths outside the wiki page directories", async () => {
+    const tempDir = await createTempDir("memory-wiki-search-path-");
+    const searchPath = path.join(tempDir, "search.json");
+    const { config } = await createVault({
+      rootDir: path.join(tempDir, "vault"),
+      initialize: true,
+    });
+    await writeJson(searchPath, {
+      version: 1,
+      queries: [
+        {
+          id: "escape",
+          query: "secret",
+          expectedPaths: ["../secret.md"],
+          expectedPageTypes: ["source"],
+        },
+      ],
+    });
+
+    await expect(runMemoryWikiSearchBatch({ config, inputPath: searchPath })).rejects.toThrow(
+      "invalid wiki path",
+    );
+  });
+
+  it("matches exact paths case-sensitively", async () => {
+    const tempDir = await createTempDir("memory-wiki-search-path-case-");
+    const sourcePath = path.join(tempDir, "alpha.txt");
+    const applyPath = path.join(tempDir, "apply.json");
+    const searchPath = path.join(tempDir, "search.json");
+    await fs.writeFile(sourcePath, "Alpha source evidence.\n", "utf8");
+    const { config } = await createVault({
+      rootDir: path.join(tempDir, "vault"),
+      initialize: true,
+    });
+    await writeJson(applyPath, {
+      version: 1,
+      operations: [
+        {
+          id: "source",
+          kind: "ingest-source",
+          inputPath: sourcePath,
+          title: "Alpha Reference",
+        },
+      ],
+    });
+    await runMemoryWikiApplyBatch({ config, inputPath: applyPath });
+    await writeJson(searchPath, {
+      version: 1,
+      queries: [
+        {
+          id: "wrong-case",
+          query: "Alpha Reference",
+          expectedPaths: ["sources/ALPHA-reference.md"],
+          expectedPageTypes: ["source"],
+          required: false,
+        },
+      ],
+    });
+
+    const result = await runMemoryWikiSearchBatch({ config, inputPath: searchPath });
+    expect(result.results[0]).toMatchObject({
+      id: "wrong-case",
+      ok: false,
+      matchedPath: null,
+      resultCount: 1,
+    });
+  });
+
+  it("reports a missing optional target without aborting the batch", async () => {
+    const tempDir = await createTempDir("memory-wiki-search-optional-");
+    const searchPath = path.join(tempDir, "search.json");
+    const { config } = await createVault({
+      rootDir: path.join(tempDir, "vault"),
+      initialize: true,
+    });
+    await writeJson(searchPath, {
+      version: 1,
+      queries: [
+        {
+          id: "optional-missing",
+          query: "Missing reference",
+          expectedPaths: ["sources/missing-reference.md"],
+          required: false,
+        },
+      ],
+    });
+
+    const result = await runMemoryWikiSearchBatch({ config, inputPath: searchPath });
+    expect(result.ok).toBe(true);
+    expect(result.results[0]).toMatchObject({
+      id: "optional-missing",
+      ok: false,
+      required: false,
+      candidatePageCount: 0,
+    });
+  });
+
+  it("rejects every invalid source before writing an earlier operation", async () => {
+    const tempDir = await createTempDir("memory-wiki-batch-preflight-");
+    const validSourcePath = path.join(tempDir, "valid.txt");
+    const binarySourcePath = path.join(tempDir, "binary.dat");
+    const applyPath = path.join(tempDir, "apply.json");
+    await fs.writeFile(validSourcePath, "valid source\n", "utf8");
+    await fs.writeFile(binarySourcePath, Buffer.from([0, 1, 2, 3]));
+    const { rootDir, config } = await createVault({
+      rootDir: path.join(tempDir, "vault"),
+      initialize: true,
+    });
+    await writeJson(applyPath, {
+      version: 1,
+      operations: [
+        { id: "valid", kind: "ingest-source", inputPath: validSourcePath, title: "Valid" },
+        { id: "binary", kind: "ingest-source", inputPath: binarySourcePath, title: "Binary" },
+      ],
+    });
+
+    await expect(runMemoryWikiApplyBatch({ config, inputPath: applyPath })).rejects.toThrow(
+      "Cannot ingest binary file",
+    );
+    await expect(fs.stat(path.join(rootDir, "sources", "valid.md"))).rejects.toThrow();
+  });
+
+  it("rejects negative evidence weight during preflight", async () => {
+    const tempDir = await createTempDir("memory-wiki-batch-evidence-");
+    const sourcePath = path.join(tempDir, "source.txt");
+    const applyPath = path.join(tempDir, "apply.json");
+    await fs.writeFile(sourcePath, "source\n", "utf8");
+    const { rootDir, config } = await createVault({
+      rootDir: path.join(tempDir, "vault"),
+      initialize: true,
+    });
+    await writeJson(applyPath, {
+      version: 1,
+      operations: [
+        {
+          id: "source",
+          kind: "ingest-source",
+          inputPath: sourcePath,
+          title: "Source",
+          evidence: {
+            sourceType: "evidence-primary-document",
+            type: "primary_document",
+            kind: "primary_document",
+            origin: "test-fixture",
+            directness: "primary",
+            weight: -1,
+          },
+        },
+      ],
+    });
+
+    await expect(runMemoryWikiApplyBatch({ config, inputPath: applyPath })).rejects.toThrow(
+      "non-negative finite numeric weight",
+    );
+    await expect(fs.stat(path.join(rootDir, "sources", "source.md"))).rejects.toThrow();
+  });
+
+  it.each([
+    {
+      name: "source",
+      operations: (sourcePath: string) => [
+        { id: "first", kind: "ingest-source", inputPath: sourcePath, title: "Duplicate" },
+        { id: "second", kind: "ingest-source", inputPath: sourcePath, title: "duplicate" },
+      ],
+    },
+    {
+      name: "synthesis",
+      operations: (sourcePath: string) => [
+        { id: "source", kind: "ingest-source", inputPath: sourcePath, title: "Evidence" },
+        {
+          id: "first",
+          kind: "upsert-synthesis",
+          title: "Duplicate",
+          body: "first",
+          sourceRefs: ["source"],
+        },
+        {
+          id: "second",
+          kind: "upsert-synthesis",
+          title: "duplicate",
+          body: "second",
+          sourceRefs: ["source"],
+        },
+      ],
+    },
+  ])("rejects duplicate $name page targets during preflight", async ({ operations }) => {
+    const tempDir = await createTempDir("memory-wiki-batch-target-");
+    const sourcePath = path.join(tempDir, "source.txt");
+    const applyPath = path.join(tempDir, "apply.json");
+    await fs.writeFile(sourcePath, "source\n", "utf8");
+    const { rootDir, config } = await createVault({
+      rootDir: path.join(tempDir, "vault"),
+      initialize: true,
+    });
+    await writeJson(applyPath, { version: 1, operations: operations(sourcePath) });
+
+    await expect(runMemoryWikiApplyBatch({ config, inputPath: applyPath })).rejects.toThrow(
+      "target the same page",
+    );
+    await expect(fs.stat(path.join(rootDir, "sources", "evidence.md"))).rejects.toThrow();
+  });
+});

--- a/extensions/memory-wiki/src/batch.ts
+++ b/extensions/memory-wiki/src/batch.ts
@@ -1,0 +1,497 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { applyMemoryWikiMutation } from "./apply.js";
+import { compileMemoryWikiVault, type CompileMemoryWikiResult } from "./compile.js";
+import type { ResolvedMemoryWikiConfig } from "./config.js";
+import {
+  assertMemoryWikiSourceBuffer,
+  ingestMemoryWikiSourceBatchOperation,
+  type IngestMemoryWikiEvidence,
+} from "./ingest.js";
+import { slugifyWikiPageStem } from "./markdown.js";
+import { withMemoryWikiVaultMutation } from "./mutation-coordinator.js";
+import {
+  boundedWikiBatchHit,
+  searchMemoryWikiBatch,
+  type WikiBatchSearchQuery,
+} from "./query-batch.js";
+import { WIKI_SEARCH_MODES, type WikiSearchMode } from "./query.js";
+import { initializeMemoryWikiVault } from "./vault.js";
+
+const BATCH_INPUT_MAX_BYTES = 256 * 1024;
+const BATCH_SOURCE_MAX_BYTES = 8 * 1024 * 1024;
+const BATCH_SOURCES_TOTAL_MAX_BYTES = 32 * 1024 * 1024;
+const BATCH_SYNTHESIS_MAX_BYTES = 1024 * 1024;
+const BATCH_MAX_OPERATIONS = 16;
+const BATCH_MAX_QUERIES = 6;
+const BATCH_MAX_RESULTS = 10;
+const BATCH_REPORT_HITS = 5;
+const BATCH_UPDATED_FILES_MAX = 50;
+const BATCH_ERRORS_MAX = 20;
+const BATCH_PAGE_TYPES = new Set(["source", "synthesis", "entity", "concept", "report"]);
+const BATCH_PAGE_DIRS = new Set(["sources", "syntheses", "entities", "concepts", "reports"]);
+
+type JsonRecord = Record<string, unknown>;
+
+type IngestSourceOperation = {
+  id: string;
+  kind: "ingest-source";
+  inputPath: string;
+  sourceBuffer: Buffer;
+  title: string;
+  evidence?: IngestMemoryWikiEvidence;
+};
+
+type UpsertSynthesisOperation = {
+  id: string;
+  kind: "upsert-synthesis";
+  title: string;
+  body: string;
+  sourceRefs: string[];
+  sourceIds: string[];
+  confidence?: number;
+  status?: string;
+};
+
+type ApplyBatchOperation = IngestSourceOperation | UpsertSynthesisOperation;
+
+type SearchBatchItem = WikiBatchSearchQuery & {
+  expectedPaths: string[];
+  expectedIds: string[];
+  expectedPageTypes: string[];
+  required: boolean;
+};
+
+function requiredString(record: JsonRecord, key: string): string {
+  const value = typeof record[key] === "string" ? record[key].trim() : "";
+  if (!value) {
+    throw new Error(`wiki batch requires non-empty ${key}.`);
+  }
+  return value;
+}
+
+function optionalString(record: JsonRecord, key: string): string | undefined {
+  const value = typeof record[key] === "string" ? record[key].trim() : "";
+  return value || undefined;
+}
+
+function requiredNonNegativeFiniteNumber(record: JsonRecord, key: string): number {
+  const value = record[key];
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    throw new Error(`wiki batch requires non-negative finite numeric ${key}.`);
+  }
+  return value;
+}
+
+function stringList(record: JsonRecord, key: string): string[] {
+  const raw = record[key];
+  if (raw === undefined) {
+    return [];
+  }
+  if (!Array.isArray(raw)) {
+    throw new Error(`wiki batch ${key} must be an array.`);
+  }
+  return [...new Set(raw.map((value) => String(value).trim()).filter(Boolean))];
+}
+
+function expectedWikiPathList(record: JsonRecord): string[] {
+  return stringList(record, "expectedPaths").map((value) => {
+    const normalized = path.posix.normalize(value.replace(/\\/g, "/"));
+    const pageDir = normalized.split("/", 1)[0];
+    if (
+      path.posix.isAbsolute(normalized) ||
+      normalized === ".." ||
+      normalized.startsWith("../") ||
+      !normalized.endsWith(".md") ||
+      !pageDir ||
+      !BATCH_PAGE_DIRS.has(pageDir)
+    ) {
+      throw new Error(`wiki search-batch expectedPaths contains an invalid wiki path: ${value}`);
+    }
+    return normalized;
+  });
+}
+
+function registerTarget(targets: Set<string>, directory: string, title: string): void {
+  const target = `${directory}/${slugifyWikiPageStem(title)}.md`;
+  if (targets.has(target)) {
+    throw new Error(`wiki apply-batch operations target the same page: ${target}`);
+  }
+  targets.add(target);
+}
+
+function boundedInteger(value: unknown, fallback: number): number {
+  if (value === undefined) {
+    return fallback;
+  }
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 1) {
+    throw new Error("wiki batch maxResults must be a positive integer.");
+  }
+  return Math.min(value, BATCH_MAX_RESULTS);
+}
+
+async function readBatchInput(inputPath: string): Promise<JsonRecord> {
+  const resolved = path.resolve(inputPath);
+  const stat = await fs.stat(resolved);
+  if (!stat.isFile()) {
+    throw new Error("wiki batch input must be a regular file.");
+  }
+  if (stat.size > BATCH_INPUT_MAX_BYTES) {
+    throw new Error(`wiki batch input exceeds ${BATCH_INPUT_MAX_BYTES} bytes.`);
+  }
+  const parsed = JSON.parse(await fs.readFile(resolved, "utf8")) as unknown;
+  if (!isRecord(parsed) || parsed.version !== 1) {
+    throw new Error("wiki batch input must be a version 1 JSON object.");
+  }
+  return parsed;
+}
+
+function normalizeEvidence(value: unknown): IngestMemoryWikiEvidence | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!isRecord(value)) {
+    throw new Error("wiki batch evidence must be an object.");
+  }
+  return {
+    sourceType: requiredString(value, "sourceType"),
+    type: requiredString(value, "type"),
+    kind: requiredString(value, "kind"),
+    origin: requiredString(value, "origin"),
+    directness: requiredString(value, "directness"),
+    weight: requiredNonNegativeFiniteNumber(value, "weight"),
+  };
+}
+
+async function normalizeApplyOperations(input: JsonRecord): Promise<ApplyBatchOperation[]> {
+  if (!Array.isArray(input.operations) || input.operations.length === 0) {
+    throw new Error("wiki apply-batch requires at least one operation.");
+  }
+  if (input.operations.length > BATCH_MAX_OPERATIONS) {
+    throw new Error(`wiki apply-batch accepts at most ${BATCH_MAX_OPERATIONS} operations.`);
+  }
+  const ids = new Set<string>();
+  const operations: ApplyBatchOperation[] = [];
+  const targets = new Set<string>();
+  let sourceBytes = 0;
+  for (const raw of input.operations) {
+    if (!isRecord(raw)) {
+      throw new Error("wiki apply-batch operations must be objects.");
+    }
+    const id = requiredString(raw, "id");
+    if (ids.has(id)) {
+      throw new Error(`wiki apply-batch operation id is duplicated: ${id}`);
+    }
+    ids.add(id);
+    const kind = requiredString(raw, "kind");
+    if (kind === "ingest-source") {
+      const title = requiredString(raw, "title");
+      registerTarget(targets, "sources", title);
+      const inputPath = path.resolve(requiredString(raw, "inputPath"));
+      const sourceStat = await fs.stat(inputPath);
+      if (!sourceStat.isFile()) {
+        throw new Error("ingest-source inputPath must be a regular file.");
+      }
+      if (sourceStat.size > BATCH_SOURCE_MAX_BYTES) {
+        throw new Error(`ingest-source input exceeds ${BATCH_SOURCE_MAX_BYTES} bytes.`);
+      }
+      const sourceBuffer = await fs.readFile(inputPath);
+      if (sourceBuffer.byteLength > BATCH_SOURCE_MAX_BYTES) {
+        throw new Error(`ingest-source input exceeds ${BATCH_SOURCE_MAX_BYTES} bytes.`);
+      }
+      assertMemoryWikiSourceBuffer(sourceBuffer, inputPath);
+      sourceBytes += sourceBuffer.byteLength;
+      if (sourceBytes > BATCH_SOURCES_TOTAL_MAX_BYTES) {
+        throw new Error(
+          `ingest-source inputs exceed ${BATCH_SOURCES_TOTAL_MAX_BYTES} total bytes.`,
+        );
+      }
+      operations.push({
+        id,
+        kind,
+        inputPath,
+        sourceBuffer,
+        title,
+        ...(raw.evidence !== undefined ? { evidence: normalizeEvidence(raw.evidence) } : {}),
+      });
+      continue;
+    }
+    if (kind !== "upsert-synthesis") {
+      throw new Error(`wiki apply-batch operation kind is unsupported: ${kind}`);
+    }
+    const title = requiredString(raw, "title");
+    registerTarget(targets, "syntheses", title);
+    const body = optionalString(raw, "body");
+    const bodyFile = optionalString(raw, "bodyFile");
+    if (Boolean(body) === Boolean(bodyFile)) {
+      throw new Error("upsert-synthesis requires exactly one of body or bodyFile.");
+    }
+    let resolvedBody = body;
+    if (bodyFile) {
+      const bodyPath = path.resolve(bodyFile);
+      const bodyStat = await fs.stat(bodyPath);
+      if (!bodyStat.isFile()) {
+        throw new Error("upsert-synthesis bodyFile must be a regular file.");
+      }
+      if (bodyStat.size > BATCH_SYNTHESIS_MAX_BYTES) {
+        throw new Error(`upsert-synthesis body exceeds ${BATCH_SYNTHESIS_MAX_BYTES} bytes.`);
+      }
+      resolvedBody = await fs.readFile(bodyPath, "utf8");
+    }
+    if (Buffer.byteLength(resolvedBody as string) > BATCH_SYNTHESIS_MAX_BYTES) {
+      throw new Error(`upsert-synthesis body exceeds ${BATCH_SYNTHESIS_MAX_BYTES} bytes.`);
+    }
+    const sourceRefs = stringList(raw, "sourceRefs");
+    const sourceIds = stringList(raw, "sourceIds");
+    if (sourceRefs.length === 0 && sourceIds.length === 0) {
+      throw new Error("upsert-synthesis requires sourceRefs or sourceIds.");
+    }
+    const confidence = raw.confidence;
+    if (
+      confidence !== undefined &&
+      (typeof confidence !== "number" ||
+        !Number.isFinite(confidence) ||
+        confidence < 0 ||
+        confidence > 1)
+    ) {
+      throw new Error("upsert-synthesis confidence must be between 0 and 1.");
+    }
+    const status = optionalString(raw, "status");
+    operations.push({
+      id,
+      kind,
+      title,
+      body: resolvedBody as string,
+      sourceRefs,
+      sourceIds,
+      ...(typeof confidence === "number" ? { confidence } : {}),
+      ...(status ? { status } : {}),
+    });
+  }
+  const availableSourceRefs = new Set<string>();
+  for (const operation of operations) {
+    if (operation.kind === "ingest-source") {
+      availableSourceRefs.add(operation.id);
+      continue;
+    }
+    for (const sourceRef of operation.sourceRefs) {
+      if (!availableSourceRefs.has(sourceRef)) {
+        throw new Error(
+          `upsert-synthesis sourceRef must name an earlier ingest-source: ${sourceRef}`,
+        );
+      }
+    }
+  }
+  return operations;
+}
+
+function summarizeCompile(
+  config: ResolvedMemoryWikiConfig,
+  compile: CompileMemoryWikiResult | undefined,
+) {
+  if (!compile) {
+    return null;
+  }
+  return {
+    pageCounts: compile.pageCounts,
+    pageCount: compile.pages.length,
+    claimCount: compile.claimCount,
+    updatedFileCount: compile.updatedFiles.length,
+    updatedFiles: compile.updatedFiles
+      .slice(0, BATCH_UPDATED_FILES_MAX)
+      .map((filePath) => path.relative(config.vault.path, filePath).replace(/\\/g, "/")),
+    frontmatterErrorCount: compile.frontmatterErrors.length,
+    frontmatterErrors: compile.frontmatterErrors.slice(0, BATCH_ERRORS_MAX),
+  };
+}
+
+export async function runMemoryWikiApplyBatch(params: {
+  config: ResolvedMemoryWikiConfig;
+  inputPath: string;
+  dryRun?: boolean;
+}) {
+  const startedAt = performance.now();
+  const input = await readBatchInput(params.inputPath);
+  const operations = await normalizeApplyOperations(input);
+  return await withMemoryWikiVaultMutation(params.config.vault.path, async () => {
+    let changed = false;
+    if (!params.dryRun) {
+      const initialization = await initializeMemoryWikiVault(params.config);
+      changed = initialization.created;
+    }
+    const sourceIdsByRef = new Map<string, string>();
+    const results: Array<Record<string, unknown>> = [];
+    for (const operation of operations) {
+      if (operation.kind === "ingest-source") {
+        const result = await ingestMemoryWikiSourceBatchOperation({
+          config: params.config,
+          inputPath: operation.inputPath,
+          sourceBuffer: operation.sourceBuffer,
+          title: operation.title,
+          evidence: operation.evidence,
+          dryRun: params.dryRun,
+        });
+        sourceIdsByRef.set(operation.id, result.pageId);
+        changed ||= result.changed;
+        results.push({
+          id: operation.id,
+          kind: operation.kind,
+          changed: result.changed,
+          created: result.created,
+          pageId: result.pageId,
+          pagePath: result.pagePath,
+          bytes: result.bytes,
+        });
+        continue;
+      }
+      const resolvedSourceIds = [
+        ...operation.sourceIds,
+        ...operation.sourceRefs.map((ref) => {
+          const sourceId = sourceIdsByRef.get(ref);
+          if (!sourceId) {
+            throw new Error(
+              `upsert-synthesis sourceRef must name an earlier ingest-source: ${ref}`,
+            );
+          }
+          return sourceId;
+        }),
+      ];
+      const result = await applyMemoryWikiMutation({
+        config: params.config,
+        mutation: {
+          op: "create_synthesis",
+          title: operation.title,
+          body: operation.body,
+          sourceIds: [...new Set(resolvedSourceIds)],
+          ...(typeof operation.confidence === "number" ? { confidence: operation.confidence } : {}),
+          ...(operation.status ? { status: operation.status } : {}),
+        },
+        compile: false,
+        dryRun: params.dryRun,
+        initialize: false,
+      });
+      changed ||= result.changed;
+      results.push({
+        id: operation.id,
+        kind: operation.kind,
+        changed: result.changed,
+        pageId: result.pageId,
+        pagePath: result.pagePath,
+      });
+    }
+    const compile =
+      changed && !params.dryRun ? await compileMemoryWikiVault(params.config) : undefined;
+    return {
+      version: 1,
+      dryRun: params.dryRun === true,
+      changed,
+      operationCount: operations.length,
+      operations: results,
+      compile: summarizeCompile(params.config, compile),
+      durationMs: Math.round(performance.now() - startedAt),
+    };
+  });
+}
+
+function normalizeSearchQueries(input: JsonRecord): SearchBatchItem[] {
+  if (!Array.isArray(input.queries) || input.queries.length === 0) {
+    throw new Error("wiki search-batch requires at least one query.");
+  }
+  if (input.queries.length > BATCH_MAX_QUERIES) {
+    throw new Error(`wiki search-batch accepts at most ${BATCH_MAX_QUERIES} queries.`);
+  }
+  const ids = new Set<string>();
+  return input.queries.map((raw) => {
+    if (!isRecord(raw)) {
+      throw new Error("wiki search-batch queries must be objects.");
+    }
+    const id = requiredString(raw, "id");
+    if (ids.has(id)) {
+      throw new Error(`wiki search-batch query id is duplicated: ${id}`);
+    }
+    ids.add(id);
+    const mode = (optionalString(raw, "mode") ?? "auto") as WikiSearchMode;
+    if (!(WIKI_SEARCH_MODES as readonly string[]).includes(mode)) {
+      throw new Error(`wiki search-batch mode is unsupported: ${mode}`);
+    }
+    const expectedPaths = expectedWikiPathList(raw);
+    const expectedIds = stringList(raw, "expectedIds");
+    if (expectedPaths.length === 0 && expectedIds.length === 0) {
+      throw new Error(`wiki search-batch query requires an expected path or id: ${id}`);
+    }
+    const expectedPageTypes = stringList(raw, "expectedPageTypes");
+    if (expectedPageTypes.some((pageType) => !BATCH_PAGE_TYPES.has(pageType))) {
+      throw new Error(`wiki search-batch expectedPageTypes is invalid: ${id}`);
+    }
+    return {
+      id,
+      query: requiredString(raw, "query"),
+      maxResults: boundedInteger(raw.maxResults, BATCH_MAX_RESULTS),
+      mode,
+      expectedPaths,
+      expectedIds,
+      expectedPageTypes,
+      required: raw.required !== false,
+    };
+  });
+}
+
+export async function runMemoryWikiSearchBatch(params: {
+  config: ResolvedMemoryWikiConfig;
+  inputPath: string;
+}) {
+  const startedAt = performance.now();
+  const input = await readBatchInput(params.inputPath);
+  const queries = normalizeSearchQueries(input);
+  const searched = await searchMemoryWikiBatch({
+    config: params.config,
+    queries: queries.map(({ id, query, maxResults, mode, expectedPaths, expectedIds }) => ({
+      id,
+      query,
+      maxResults,
+      mode,
+      expectedPaths,
+      expectedIds,
+    })),
+  });
+  const byId = new Map(searched.map((item) => [item.id, item] as const));
+  const results = queries.map((query) => {
+    const item = byId.get(query.id);
+    const hits = item?.results ?? [];
+    const expectedPaths = new Set(query.expectedPaths);
+    const expectedIds = new Set(query.expectedIds.map((value) => value.toLowerCase()));
+    const expectedPageTypes = new Set(query.expectedPageTypes.map((value) => value.toLowerCase()));
+    const match = hits.find((hit) => {
+      const targetMatches =
+        expectedPaths.has(hit.path) || Boolean(hit.id && expectedIds.has(hit.id.toLowerCase()));
+      const pageTypeMatches =
+        expectedPageTypes.size === 0 || expectedPageTypes.has(hit.kind.toLowerCase());
+      return targetMatches && pageTypeMatches;
+    });
+    return {
+      id: query.id,
+      query: query.query,
+      required: query.required,
+      ok: Boolean(match),
+      matchedPath: match?.path ?? null,
+      matchedId: match?.id ?? null,
+      candidatePageCount: item?.candidatePageCount ?? 0,
+      resultCount: hits.length,
+      hits: hits.slice(0, BATCH_REPORT_HITS).map(boundedWikiBatchHit),
+    };
+  });
+  const failed = results.filter((result) => result.required && !result.ok);
+  if (failed.length > 0) {
+    throw new Error(
+      `wiki search-batch required verification failed: ${failed.map((item) => item.id).join(", ")}`,
+    );
+  }
+  return {
+    version: 1,
+    queryCount: queries.length,
+    ok: true,
+    results,
+    durationMs: Math.round(performance.now() - startedAt),
+  };
+}

--- a/extensions/memory-wiki/src/cli.test.ts
+++ b/extensions/memory-wiki/src/cli.test.ts
@@ -218,6 +218,21 @@ describe("memory-wiki cli", () => {
     await expect(fs.readFile(path.join(rootDir, "index.md"), "utf8")).resolves.toContain(
       "[CLI Alpha](syntheses/cli-alpha.md)",
     );
+
+    const repeated = await runRegisteredWikiCommand(config, [
+      "apply",
+      "synthesis",
+      "CLI Alpha",
+      "--body",
+      "Alpha from CLI.",
+      "--source-id",
+      "source.alpha",
+      "--source-id",
+      "source.beta",
+    ]);
+    expect(repeated).toContain(
+      "No changes for syntheses/cli-alpha.md via create_synthesis. Index compilation skipped.",
+    );
   });
 
   it("resolves --agent for local commands and requires it with multiple agent vaults", async () => {
@@ -245,6 +260,69 @@ describe("memory-wiki cli", () => {
     await expect(
       missingAgentProgram.parseAsync(["wiki", "status", "--json"], { from: "user" }),
     ).rejects.toThrow("agentId is required for memory-wiki when vault.scope=agent.");
+  });
+
+  it("uses the selected agent vault for batch apply and search", async () => {
+    const { rootDir, config } = await createCliVault({
+      config: { vault: { scope: "agent" } },
+    });
+    const appConfig = {
+      agents: { list: [{ id: "support", default: true }, { id: "marketing" }] },
+    };
+    const inputPath = path.join(rootDir, "source.txt");
+    const applyPath = path.join(rootDir, "apply.json");
+    const searchPath = path.join(rootDir, "search.json");
+    await fs.mkdir(rootDir, { recursive: true });
+    await fs.writeFile(inputPath, "Marketing source evidence.\n", "utf8");
+    await fs.writeFile(
+      applyPath,
+      JSON.stringify({
+        version: 1,
+        operations: [
+          {
+            id: "source",
+            kind: "ingest-source",
+            inputPath,
+            title: "Marketing Reference",
+          },
+        ],
+      }),
+      "utf8",
+    );
+    await fs.writeFile(
+      searchPath,
+      JSON.stringify({
+        version: 1,
+        queries: [
+          {
+            id: "source",
+            query: "Marketing source evidence",
+            expectedPaths: ["sources/marketing-reference.md"],
+          },
+        ],
+      }),
+      "utf8",
+    );
+    const program = new Command();
+    program.name("test");
+    registerWikiCli(program, { config, getAppConfig: () => appConfig });
+
+    await program.parseAsync(
+      ["wiki", "--agent", "marketing", "apply-batch", "--input", applyPath, "--json"],
+      { from: "user" },
+    );
+    await expect(
+      fs.stat(path.join(rootDir, "marketing", "sources", "marketing-reference.md")),
+    ).resolves.toBeDefined();
+    await program.parseAsync(
+      ["wiki", "--agent", "marketing", "search-batch", "--input", searchPath, "--json"],
+      { from: "user" },
+    );
+
+    const searchResult = JSON.parse(String(stdoutWriteMock.mock.calls.at(-1)?.[0] ?? "")) as {
+      ok: boolean;
+    };
+    expect(searchResult.ok).toBe(true);
   });
 
   it("forwards --agent through every bridge Gateway call", async () => {

--- a/extensions/memory-wiki/src/cli.ts
+++ b/extensions/memory-wiki/src/cli.ts
@@ -11,6 +11,7 @@ import {
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { OpenClawConfig } from "../api.js";
 import { applyMemoryWikiMutation } from "./apply.js";
+import { registerMemoryWikiBatchCli } from "./batch-cli.js";
 import {
   importChatGptConversations,
   rollbackChatGptImportRun,
@@ -65,13 +66,9 @@ const ANSI_ESCAPE_SEQUENCE_PATTERN = new RegExp(
 const TERMINAL_CONTROL_CHARACTER_PATTERN = new RegExp(String.raw`[\x00-\x1F\x7F-\x9F]+`, "g");
 const UNICODE_FORMAT_CONTROL_PATTERN = /[\u061C\u200B-\u200F\u202A-\u202E\u2060-\u206F\uFEFF]/g;
 
-type WikiStatusCommandOptions = {
-  json?: boolean;
-};
+type WikiStatusCommandOptions = { json?: boolean };
 
-type WikiDoctorCommandOptions = {
-  json?: boolean;
-};
+type WikiDoctorCommandOptions = { json?: boolean };
 
 type WikiInitCommandOptions = {
   json?: boolean;
@@ -391,7 +388,10 @@ function formatMemoryWikiMutationSummary(result: MemoryWikiMutationResult, json?
   if (json) {
     return JSON.stringify(result, null, 2);
   }
-  return `${result.changed ? "Updated" : "No changes for"} ${result.pagePath} via ${result.operation}. ${result.compile.updatedFiles.length > 0 ? `Refreshed ${result.compile.updatedFiles.length} index file${result.compile.updatedFiles.length === 1 ? "" : "s"}.` : "Indexes unchanged."}`;
+  if (!result.compile) {
+    return `No changes for ${result.pagePath} via ${result.operation}. Index compilation skipped.`;
+  }
+  return `Updated ${result.pagePath} via ${result.operation}. ${result.compile.updatedFiles.length > 0 ? `Refreshed ${result.compile.updatedFiles.length} index file${result.compile.updatedFiles.length === 1 ? "" : "s"}.` : "Indexes unchanged."}`;
 }
 
 function formatJsonOrText<T>(
@@ -1053,6 +1053,7 @@ export function registerWikiCli(program: Command, registration: MemoryWikiCliReg
       await runWikiIngest({ config, inputPath, title: opts.title, json: opts.json });
     });
 
+  registerMemoryWikiBatchCli(wiki, () => requireCommandContext().config);
   const okf = wiki.command("okf").description("Import Open Knowledge Format bundles");
   okf
     .command("import")

--- a/extensions/memory-wiki/src/ingest.test.ts
+++ b/extensions/memory-wiki/src/ingest.test.ts
@@ -3,7 +3,8 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { KeyedAsyncQueue } from "openclaw/plugin-sdk/keyed-async-queue";
 import { describe, expect, it, vi } from "vitest";
-import { ingestMemoryWikiSource } from "./ingest.js";
+import { loadMemoryWikiCompiledCache } from "./compiled-cache.js";
+import { ingestMemoryWikiSource, ingestMemoryWikiSourceBatchOperation } from "./ingest.js";
 import { withMemoryWikiVaultMutation } from "./mutation-coordinator.js";
 import { createMemoryWikiTestHarness } from "./test-helpers.js";
 
@@ -126,5 +127,94 @@ hello from source
       enqueueSpy.mockRestore();
       await Promise.allSettled([holder, ...(ingest ? [ingest] : [])]);
     }
+  });
+
+  it("recompiles an unchanged source and repairs stale derived state", async () => {
+    const rootDir = await createTempDir("memory-wiki-ingest-recompile-");
+    const inputPath = path.join(rootDir, "stable.txt");
+    await fs.writeFile(inputPath, "stable source\n", "utf8");
+    const { config } = await createVault({ rootDir: path.join(rootDir, "vault") });
+
+    const first = await ingestMemoryWikiSource({
+      config,
+      inputPath,
+      title: "Stable Reference",
+      nowMs: Date.UTC(2026, 3, 5, 12, 0, 0),
+    });
+    const pagePath = path.join(config.vault.path, first.pagePath);
+    const before = await fs.readFile(pagePath, "utf8");
+    const indexPath = path.join(config.vault.path, "index.md");
+    await fs.writeFile(indexPath, "# Stale index\n", "utf8");
+    const second = await ingestMemoryWikiSource({
+      config,
+      inputPath,
+      title: "Stable Reference",
+      nowMs: Date.UTC(2026, 3, 6, 12, 0, 0),
+    });
+
+    expect(first.changed).toBe(true);
+    expect(second.changed).toBe(false);
+    expect(second.indexUpdatedFiles).toContain(indexPath);
+    await expect(fs.readFile(pagePath, "utf8")).resolves.toBe(before);
+    await expect(fs.readFile(pagePath, "utf8")).resolves.toContain(
+      "ingestedAt: 2026-04-05T12:00:00.000Z",
+    );
+    await expect(fs.readFile(pagePath, "utf8")).resolves.toContain(
+      "updatedAt: 2026-04-05T12:00:00.000Z",
+    );
+    await expect(fs.readFile(indexPath, "utf8")).resolves.toContain(
+      "[Stable Reference](sources/stable-reference.md)",
+    );
+  });
+
+  it("clears stale evidence fields when regular ingest replaces an evidenced source", async () => {
+    const rootDir = await createTempDir("memory-wiki-ingest-evidence-");
+    const inputPath = path.join(rootDir, "source.txt");
+    await fs.writeFile(inputPath, "source body\n", "utf8");
+    const { config } = await createVault({
+      rootDir: path.join(rootDir, "vault"),
+      initialize: true,
+    });
+
+    await ingestMemoryWikiSourceBatchOperation({
+      config,
+      inputPath,
+      sourceBuffer: await fs.readFile(inputPath),
+      title: "Source",
+      evidence: {
+        sourceType: "evidence-primary-document",
+        type: "primary_document",
+        kind: "primary_document",
+        origin: "test-fixture",
+        directness: "primary",
+        weight: 1,
+      },
+    });
+    const replaced = await ingestMemoryWikiSource({ config, inputPath, title: "Source" });
+    const page = await fs.readFile(path.join(config.vault.path, replaced.pagePath), "utf8");
+
+    expect(page).toContain("sourceType: local-file");
+    expect(page).not.toContain("evidenceType:");
+    expect(page).not.toContain("evidenceOrigin:");
+  });
+
+  it("invalidates the compiled snapshot after a deferred batch ingest write", async () => {
+    const rootDir = await createTempDir("memory-wiki-ingest-deferred-");
+    const inputPath = path.join(rootDir, "source.txt");
+    await fs.writeFile(inputPath, "original source\n", "utf8");
+    const { config } = await createVault({ rootDir: path.join(rootDir, "vault") });
+    await ingestMemoryWikiSource({ config, inputPath, title: "Deferred Source" });
+    expect(await loadMemoryWikiCompiledCache(config)).not.toBeNull();
+
+    await fs.writeFile(inputPath, "updated source\n", "utf8");
+    const changed = await ingestMemoryWikiSourceBatchOperation({
+      config,
+      inputPath,
+      sourceBuffer: await fs.readFile(inputPath),
+      title: "Deferred Source",
+    });
+
+    expect(changed.changed).toBe(true);
+    await expect(loadMemoryWikiCompiledCache(config)).resolves.toBeNull();
   });
 });

--- a/extensions/memory-wiki/src/ingest.ts
+++ b/extensions/memory-wiki/src/ingest.ts
@@ -1,16 +1,21 @@
 // Memory Wiki plugin module implements ingest behavior.
 import fs from "node:fs/promises";
 import path from "node:path";
+import { replaceManagedMarkdownBlock } from "openclaw/plugin-sdk/memory-host-markdown";
 import { pathExists } from "openclaw/plugin-sdk/security-runtime";
 import { compileMemoryWikiVault } from "./compile.js";
+import { invalidateMemoryWikiCompiledCache } from "./compiled-cache.js";
 import type { ResolvedMemoryWikiConfig } from "./config.js";
 import { appendMemoryWikiLog } from "./log.js";
 import {
+  parseWikiMarkdown,
   preserveHumanNotesBlock,
   renderMarkdownFence,
   renderWikiMarkdown,
   slugifyWikiPageStem,
   slugifyWikiSegment,
+  WIKI_RELATED_END_MARKER,
+  WIKI_RELATED_START_MARKER,
 } from "./markdown.js";
 import { withMemoryWikiVaultMutation } from "./mutation-coordinator.js";
 import { resolveMemoryWikiTimestamp } from "./time.js";
@@ -23,8 +28,41 @@ type IngestMemoryWikiSourceResult = {
   title: string;
   bytes: number;
   created: boolean;
+  changed: boolean;
   indexUpdatedFiles: string[];
 };
+
+export type IngestMemoryWikiEvidence = {
+  sourceType: string;
+  type: string;
+  kind: string;
+  origin: string;
+  directness: string;
+  weight: number;
+};
+
+const EVIDENCE_FRONTMATTER_KEYS = [
+  "evidenceType",
+  "evidenceKind",
+  "evidenceOrigin",
+  "evidenceDirectness",
+  "evidenceWeight",
+] as const;
+
+function preserveGeneratedRelatedBlock(rendered: string, existing: string): string {
+  const start = existing.indexOf(WIKI_RELATED_START_MARKER);
+  const end = existing.indexOf(WIKI_RELATED_END_MARKER, start + WIKI_RELATED_START_MARKER.length);
+  if (start < 0 || end < 0) {
+    return rendered;
+  }
+  return replaceManagedMarkdownBlock({
+    original: rendered,
+    heading: "## Related",
+    startMarker: WIKI_RELATED_START_MARKER,
+    endMarker: WIKI_RELATED_END_MARKER,
+    body: existing.slice(start + WIKI_RELATED_START_MARKER.length, end).trim(),
+  });
+}
 
 function resolveSourceTitle(sourcePath: string, explicitTitle?: string): string {
   if (explicitTitle?.trim()) {
@@ -33,7 +71,7 @@ function resolveSourceTitle(sourcePath: string, explicitTitle?: string): string 
   return path.basename(sourcePath, path.extname(sourcePath)).replace(/[-_]+/g, " ").trim();
 }
 
-function assertUtf8Text(buffer: Buffer, sourcePath: string): string {
+export function assertMemoryWikiSourceBuffer(buffer: Buffer, sourcePath: string): string {
   const preview = buffer.subarray(0, Math.min(buffer.length, 4096));
   if (preview.includes(0)) {
     throw new Error(`Cannot ingest binary file as markdown source: ${sourcePath}`);
@@ -68,13 +106,20 @@ async function readExistingSourcePage(pagePath: string): Promise<string> {
 async function ingestMemoryWikiSourceUnlocked(params: {
   config: ResolvedMemoryWikiConfig;
   inputPath: string;
+  sourceBuffer?: Buffer;
   title?: string;
   nowMs?: number;
+  compile?: boolean;
+  dryRun?: boolean;
+  initialize?: boolean;
+  evidence?: IngestMemoryWikiEvidence;
 }): Promise<IngestMemoryWikiSourceResult> {
-  await initializeMemoryWikiVault(params.config, { nowMs: params.nowMs });
+  if (!params.dryRun && params.initialize !== false) {
+    await initializeMemoryWikiVault(params.config, { nowMs: params.nowMs });
+  }
   const sourcePath = path.resolve(params.inputPath);
-  const buffer = await fs.readFile(sourcePath);
-  const content = assertUtf8Text(buffer, sourcePath);
+  const buffer = params.sourceBuffer ?? (await fs.readFile(sourcePath));
+  const content = assertMemoryWikiSourceBuffer(buffer, sourcePath);
   const title = resolveSourceTitle(sourcePath, params.title);
   const slug = slugifyWikiSegment(title);
   const pageStem = slugifyWikiPageStem(title);
@@ -82,56 +127,94 @@ async function ingestMemoryWikiSourceUnlocked(params: {
   const pageRelativePath = path.join("sources", `${pageStem}.md`);
   const pagePath = path.join(params.config.vault.path, pageRelativePath);
   const created = !(await pathExists(pagePath));
-  const timestamp = resolveMemoryWikiTimestamp(params.nowMs);
-
-  const markdown = renderWikiMarkdown({
-    frontmatter: {
-      pageType: "source",
-      id: pageId,
-      title,
-      sourceType: "local-file",
-      sourcePath,
-      ingestedAt: timestamp,
-      updatedAt: timestamp,
-      status: "active",
-    },
-    body: [
-      `# ${title}`,
-      "",
-      "## Source",
-      `- Type: \`local-file\``,
-      `- Path: \`${sourcePath}\``,
-      `- Bytes: ${buffer.byteLength}`,
-      `- Updated: ${timestamp}`,
-      "",
-      "## Content",
-      renderMarkdownFence(content, "text"),
-      "",
-      "## Notes",
-      "<!-- openclaw:human:start -->",
-      "<!-- openclaw:human:end -->",
-      "",
-    ].join("\n"),
-  });
-
   const existing = created ? "" : await readExistingSourcePage(pagePath);
-  await fs.writeFile(
-    pagePath,
-    existing ? preserveHumanNotesBlock(markdown, existing) : markdown,
-    "utf8",
-  );
-  await appendMemoryWikiLog(params.config.vault.path, {
-    type: "ingest",
-    timestamp,
-    details: {
-      inputPath: sourcePath,
-      pageId,
-      pagePath: pageRelativePath.split(path.sep).join("/"),
-      bytes: buffer.byteLength,
-      created,
-    },
-  });
-  const compile = await compileMemoryWikiVault(params.config);
+  const parsed = parseWikiMarkdown(existing);
+  const timestamp = resolveMemoryWikiTimestamp(params.nowMs);
+  const ingestedAt =
+    (typeof parsed.frontmatter.ingestedAt === "string" && parsed.frontmatter.ingestedAt.trim()) ||
+    timestamp;
+  const priorUpdatedAt =
+    (typeof parsed.frontmatter.updatedAt === "string" && parsed.frontmatter.updatedAt.trim()) ||
+    timestamp;
+  const baseFrontmatter = { ...parsed.frontmatter };
+  if (!params.evidence) {
+    for (const key of EVIDENCE_FRONTMATTER_KEYS) {
+      delete baseFrontmatter[key];
+    }
+  }
+  const renderPage = (updatedAt: string) => {
+    const sourceType = params.evidence?.sourceType || "local-file";
+    const markdown = renderWikiMarkdown({
+      frontmatter: {
+        ...baseFrontmatter,
+        pageType: "source",
+        id: pageId,
+        title,
+        sourceType,
+        sourcePath,
+        ...(params.evidence
+          ? {
+              evidenceType: params.evidence.type,
+              evidenceKind: params.evidence.kind,
+              evidenceOrigin: params.evidence.origin,
+              evidenceDirectness: params.evidence.directness,
+              evidenceWeight: params.evidence.weight,
+            }
+          : {}),
+        ingestedAt,
+        updatedAt,
+        status: "active",
+      },
+      body: [
+        `# ${title}`,
+        "",
+        "## Source",
+        `- Type: \`${sourceType}\``,
+        ...(params.evidence
+          ? [`- Evidence: \`${params.evidence.type}\` from \`${params.evidence.origin}\``]
+          : []),
+        `- Path: \`${sourcePath}\``,
+        `- Bytes: ${buffer.byteLength}`,
+        `- Updated: ${updatedAt}`,
+        "",
+        "## Content",
+        renderMarkdownFence(content, "text"),
+        "",
+        "## Notes",
+        "<!-- openclaw:human:start -->",
+        "<!-- openclaw:human:end -->",
+        "",
+      ].join("\n"),
+    });
+    if (!existing) {
+      return markdown;
+    }
+    return preserveGeneratedRelatedBlock(preserveHumanNotesBlock(markdown, existing), existing);
+  };
+  const unchangedCandidate = renderPage(priorUpdatedAt);
+  const changed = existing !== unchangedCandidate;
+  const finalMarkdown = changed ? renderPage(timestamp) : unchangedCandidate;
+
+  if (changed && !params.dryRun) {
+    await fs.writeFile(pagePath, finalMarkdown, "utf8");
+    // If logging or compilation fails, readers must not keep using the pre-write snapshot.
+    await invalidateMemoryWikiCompiledCache(params.config);
+    await appendMemoryWikiLog(params.config.vault.path, {
+      type: "ingest",
+      timestamp,
+      details: {
+        inputPath: sourcePath,
+        pageId,
+        pagePath: pageRelativePath.split(path.sep).join("/"),
+        bytes: buffer.byteLength,
+        created,
+      },
+    });
+  }
+  const compile =
+    !params.dryRun && params.compile !== false
+      ? await compileMemoryWikiVault(params.config)
+      : undefined;
 
   return {
     sourcePath,
@@ -140,8 +223,26 @@ async function ingestMemoryWikiSourceUnlocked(params: {
     title,
     bytes: buffer.byteLength,
     created,
-    indexUpdatedFiles: compile.updatedFiles,
+    changed,
+    indexUpdatedFiles: compile?.updatedFiles ?? [],
   };
+}
+
+export async function ingestMemoryWikiSourceBatchOperation(params: {
+  config: ResolvedMemoryWikiConfig;
+  inputPath: string;
+  sourceBuffer: Buffer;
+  title: string;
+  dryRun?: boolean;
+  evidence?: IngestMemoryWikiEvidence;
+}): Promise<IngestMemoryWikiSourceResult> {
+  return await withMemoryWikiVaultMutation(params.config.vault.path, () =>
+    ingestMemoryWikiSourceUnlocked({
+      ...params,
+      compile: false,
+      initialize: false,
+    }),
+  );
 }
 
 export async function ingestMemoryWikiSource(params: {

--- a/extensions/memory-wiki/src/query-batch.ts
+++ b/extensions/memory-wiki/src/query-batch.ts
@@ -1,0 +1,140 @@
+// Memory Wiki helper prepares bounded wiki-only batch search snapshots.
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { ResolvedMemoryWikiConfig } from "./config.js";
+import {
+  buildDigestCandidatePaths,
+  normalizePositiveInteger,
+  readQueryDigestBundle,
+  readQueryableWikiPages,
+  readQueryableWikiPagesByPaths,
+  sortWikiSearchResults,
+  toWikiSearchResult,
+  type QueryableWikiPage,
+  type WikiSearchMode,
+  type WikiSearchResult,
+} from "./query.js";
+import { initializeMemoryWikiVault } from "./vault.js";
+
+const BATCH_SNIPPET_MAX_CHARS = 500;
+
+async function existingWikiPaths(vaultPath: string, relativePaths: string[]): Promise<string[]> {
+  const paths = await Promise.all(
+    relativePaths.map(async (relativePath) => {
+      try {
+        return (await fs.stat(path.join(vaultPath, relativePath))).isFile() ? relativePath : null;
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+          return null;
+        }
+        throw error;
+      }
+    }),
+  );
+  return paths.filter((value): value is string => value !== null);
+}
+
+export type WikiBatchSearchQuery = {
+  id: string;
+  query: string;
+  maxResults?: number;
+  mode?: WikiSearchMode;
+  expectedPaths?: string[];
+  expectedIds?: string[];
+};
+
+type WikiBatchSearchResult = {
+  id: string;
+  query: string;
+  candidatePageCount: number;
+  results: WikiSearchResult[];
+};
+
+export function boundedWikiBatchHit(result: WikiSearchResult) {
+  return {
+    path: result.path,
+    ...(result.id ? { id: result.id } : {}),
+    title: result.title,
+    pageType: result.kind,
+    score: result.score,
+    snippet:
+      result.snippet.length > BATCH_SNIPPET_MAX_CHARS
+        ? `${result.snippet.slice(0, BATCH_SNIPPET_MAX_CHARS - 3)}...`
+        : result.snippet,
+  };
+}
+
+/**
+ * Search several wiki-only queries from one prepared digest/page snapshot.
+ * Call regular search when imported-source sync or shared-memory lookup is required.
+ */
+export async function searchMemoryWikiBatch(params: {
+  config: ResolvedMemoryWikiConfig;
+  queries: WikiBatchSearchQuery[];
+}): Promise<WikiBatchSearchResult[]> {
+  await initializeMemoryWikiVault(params.config);
+  const digest = await readQueryDigestBundle(params.config);
+  const candidatePaths = new Map<string, string[]>();
+  const allCandidatePaths = new Set<string>();
+  for (const item of params.queries) {
+    const maxResults = normalizePositiveInteger(item.maxResults, 10);
+    const mode = item.mode ?? "auto";
+    const expectedIds = new Set((item.expectedIds ?? []).map((value) => value.toLowerCase()));
+    const paths = digest
+      ? [
+          ...new Set([
+            ...buildDigestCandidatePaths({
+              digest,
+              query: item.query,
+              maxResults,
+              mode,
+            }),
+            ...(item.expectedPaths ?? []),
+            ...digest.pages
+              .filter((page) => page.id && expectedIds.has(page.id.toLowerCase()))
+              .map((page) => page.path),
+          ]),
+        ]
+      : [];
+    candidatePaths.set(item.id, paths);
+    for (const pagePath of paths) {
+      allCandidatePaths.add(pagePath);
+    }
+  }
+
+  const preparedCandidates =
+    allCandidatePaths.size > 0
+      ? await readQueryableWikiPagesByPaths(
+          params.config.vault.path,
+          await existingWikiPaths(params.config.vault.path, [...allCandidatePaths]),
+        )
+      : [];
+  const preparedByPath = new Map(
+    preparedCandidates.map((page) => [page.relativePath, page] as const),
+  );
+  let allPagesPromise: Promise<QueryableWikiPage[]> | undefined;
+  const getAllPages = () => (allPagesPromise ??= readQueryableWikiPages(params.config.vault.path));
+
+  return await Promise.all(
+    params.queries.map(async (item) => {
+      const maxResults = normalizePositiveInteger(item.maxResults, 10);
+      const mode = item.mode ?? "auto";
+      const paths = candidatePaths.get(item.id) ?? [];
+      const candidatePages = paths
+        .map((pagePath) => preparedByPath.get(pagePath))
+        .filter((page): page is QueryableWikiPage => Boolean(page));
+      const pages = digest ? candidatePages : await getAllPages();
+      const results = sortWikiSearchResults(
+        pages
+          .map((page) => toWikiSearchResult(page, item.query, mode))
+          .filter((page) => page.score > 0),
+      );
+      return {
+        id: item.id,
+        query: item.query,
+        candidatePageCount: pages.length,
+        results: results.slice(0, maxResults),
+      };
+    }),
+  );
+}

--- a/extensions/memory-wiki/src/query.ts
+++ b/extensions/memory-wiki/src/query.ts
@@ -91,7 +91,7 @@ const ROUTE_QUESTION_STOP_WORDS = new Set([
   "would",
 ]);
 
-function normalizePositiveInteger(value: number | undefined, fallback: number): number {
+export function normalizePositiveInteger(value: number | undefined, fallback: number): number {
   return typeof value === "number" && Number.isFinite(value)
     ? Math.max(1, Math.floor(value))
     : fallback;
@@ -115,7 +115,7 @@ type QueryDigestBundle = {
   claims: QueryDigestClaim[];
 };
 
-type WikiSearchResult = {
+export type WikiSearchResult = {
   corpus: "wiki" | "memory";
   path: string;
   title: string;
@@ -171,7 +171,7 @@ type QuerySearchOverrides = {
   searchCorpus?: WikiSearchCorpus;
 };
 
-function sortWikiSearchResults(results: WikiSearchResult[]): WikiSearchResult[] {
+export function sortWikiSearchResults(results: WikiSearchResult[]): WikiSearchResult[] {
   return results.toSorted((left, right) => {
     if (left.score !== right.score) {
       return right.score - left.score;
@@ -232,7 +232,7 @@ export async function readQueryableWikiPages(rootDir: string): Promise<Queryable
   return readQueryableWikiPagesByPaths(rootDir, files);
 }
 
-async function readQueryableWikiPagesByPaths(
+export async function readQueryableWikiPagesByPaths(
   rootDir: string,
   files: string[],
 ): Promise<QueryableWikiPage[]> {
@@ -248,7 +248,7 @@ async function readQueryableWikiPagesByPaths(
   );
 }
 
-async function readQueryDigestBundle(
+export async function readQueryDigestBundle(
   config: ResolvedMemoryWikiConfig,
 ): Promise<QueryDigestBundle | null> {
   const snapshot = await loadMemoryWikiCompiledCache(config);
@@ -712,7 +712,7 @@ function scoreDigestSearchModeBoost(params: {
   return 0;
 }
 
-function buildDigestCandidatePaths(params: {
+export function buildDigestCandidatePaths(params: {
   digest: QueryDigestBundle;
   query: string;
   maxResults: number;
@@ -1155,7 +1155,7 @@ function buildClaimResultMetadata(claim: WikiClaim | undefined): Partial<WikiSea
   };
 }
 
-function toWikiSearchResult(
+export function toWikiSearchResult(
   page: QueryableWikiPage,
   query: string,
   mode: WikiSearchMode,

--- a/extensions/memory-wiki/src/tool.test.ts
+++ b/extensions/memory-wiki/src/tool.test.ts
@@ -65,6 +65,25 @@ describe("memory-wiki tools", () => {
     expect(evidenceProperties.confidence).toEqual({ type: "number", minimum: 0, maximum: 1 });
   });
 
+  it("reports a semantic wiki_apply no-op without requiring a compile result", async () => {
+    const { config } = await harness.createVault({ initialize: true });
+    const tool = createWikiApplyTool(config);
+    const mutation = {
+      op: "create_synthesis",
+      title: "Stable Tool Synthesis",
+      body: "Stable tool summary.",
+      sourceIds: ["source.stable-tool"],
+    };
+    await tool.execute("apply-first", mutation);
+
+    const repeated = await tool.execute("apply-repeated", mutation);
+    const text = repeated.content.find((part) => part.type === "text")?.text ?? "";
+
+    expect(text).toContain("No changes for syntheses/stable-tool-synthesis.md");
+    expect(text).toContain("Index compilation skipped.");
+    expect(asSchemaObject(repeated.details)).not.toHaveProperty("compile");
+  });
+
   it("returns tool-safe relative report paths from wiki_lint", async () => {
     const { rootDir, config } = await harness.createVault({ initialize: true });
     await fs.mkdir(path.join(rootDir, "syntheses"), { recursive: true });

--- a/extensions/memory-wiki/src/tool.ts
+++ b/extensions/memory-wiki/src/tool.ts
@@ -245,8 +245,9 @@ export function createWikiApplyTool(
       await syncImportedSourcesIfNeeded(config, appConfig);
       const result = await applyMemoryWikiMutation({ config, mutation });
       const action = result.changed ? "Updated" : "No changes for";
-      const compileSummary =
-        result.compile.updatedFiles.length > 0
+      const compileSummary = !result.compile
+        ? "Index compilation skipped."
+        : result.compile.updatedFiles.length > 0
           ? `Refreshed ${result.compile.updatedFiles.length} index file${result.compile.updatedFiles.length === 1 ? "" : "s"}.`
           : "Indexes unchanged.";
       return {


### PR DESCRIPTION
Closes #113706

AI-assisted with OpenAI Codex. I reviewed and understand the implementation and addressed every actionable independent-review and CI finding identified on this branch.

## What Problem This Solves

Memory Wiki automation currently pays CLI startup, vault preparation, mutation, compilation, and search setup costs for every individual durable-reference operation. Repeating that work can occupy gateway capacity and make an ingest workflow appear stalled.

## Change

This adds bounded `wiki apply-batch` and `wiki search-batch` commands:

- `apply-batch` preflights the complete manifest, holds one mutation lease, preserves semantic no-ops, and compiles at most once.
- `search-batch` prepares one compiled digest/page snapshot and verifies several explicit expected paths or IDs.
- Existing single-operation CLI and plugin APIs remain available.

The public surface is deliberately constrained: versioned JSON input, at most 16 apply operations, at most 6 search queries, 256 KiB manifests, 8 MiB per source, 32 MiB aggregate source data, 1 MiB synthesis bodies, bounded output, exact case-sensitive path checks, and nonnegative evidence weights.

## Mutation and cache compatibility

Regular `wiki ingest` retains its safety behavior: an unchanged generated source page is not rewritten and its timestamps are preserved, but the vault is still recompiled so out-of-band changes cannot leave derived indexes stale. The focused regression test corrupts `index.md`, re-ingests an unchanged source, and verifies that the index is repaired without rewriting the source page.

A standalone `wiki apply` now treats a true semantic no-op separately: it returns `changed: false`, preserves page, audit-log, and compiled-cache publication identity, and skips the full compile. A changed write invalidates the prior compiled snapshot before logging or compilation, so a failed or deliberately deferred compile cannot leave stale derived state readable. Explicit `wiki compile` rebuilds the snapshot.

Inside `apply-batch`, per-operation compilation remains disabled. The enclosing batch runs ordered mutations under one outer vault lease and compiles once when an operation changes or initialization repairs missing scaffold state. The first changed source or synthesis write invalidates the prior snapshot; subsequent writes remain safe if a later operation fails. The batch does not compile when both the scaffold and every operation are unchanged.

Focused regressions cover no-op page/log/cache identity, changed deferred-apply invalidation plus explicit rebuild, deferred batch-ingest invalidation, CLI/tool no-op output, and manifest ordering with one mutation-queue acquisition and one completed compile.

There is no persistent data-model migration. Manifest version 1 is a transient CLI input contract; stored wiki pages remain the existing Markdown/frontmatter format. A batch search against a vault created entirely through legacy single-operation commands passed all six required queries.

## Evidence

The proof used an isolated synthetic vault containing six sources, three syntheses, and six required searches. It ran one discarded warm-up and three measured trials for each method. Legacy used 15 CLI launches and 9 compiles; batch used 2 CLI launches and 1 compile. GNU `time` captured wall time and peak RSS per process.

| Method | Trial | Wall (ms) | Peak RSS (KiB) | CLI launches | Compiles | Required checks |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| Legacy | 1 | 51,368 | 732,184 | 15 | 9 | 6/6 |
| Legacy | 2 | 50,177 | 731,212 | 15 | 9 | 6/6 |
| Legacy | 3 | 50,689 | 736,896 | 15 | 9 | 6/6 |
| Batch | 1 | 7,239 | 708,312 | 2 | 1 | 6/6 |
| Batch | 2 | 7,169 | 725,788 | 2 | 1 | 6/6 |
| Batch | 3 | 7,126 | 719,088 | 2 | 1 | 6/6 |

Median wall time fell from 50,689 ms to 7,169 ms: **7.07x faster**. Median per-process peak RSS was 732,184 KiB for legacy and 719,088 KiB for batch; this is a small difference, so the claim is reduced repeated work and launch/compile overhead, not a material memory-footprint reduction.

All trials returned the same source/synthesis page inventory and passed 6/6 required retrieval checks. The repeated identical apply batch returned `changed: false` and `compile: null`. Gateway connectivity was healthy before and after the isolated run.

[Inspect the complete redacted terminal output](https://github.com/openclaw/openclaw/pull/113746#issuecomment-5081811745), including fresh apply-batch JSON, no-op JSON, search-batch JSON, and the legacy-created-vault compatibility output.

The live exercise used OpenClaw 2026.7.1-2 with the candidate batch implementation deployed. The later source changes refine single-apply/cache and missing-scaffold invariants without changing the measured batch command contract; those deltas are covered by focused regression tests and exact-head GitHub CI.

## Product-direction recommendation

Author recommendation: support these two bounded, versioned commands as documented bundled Memory Wiki CLI contracts. They are designed for automation that already invokes the CLI, while preserving the existing single-operation path. Explicit maintainer sponsorship is still requested because only maintainers can decide the long-term bundled-plugin surface.

## Verification

- Complete redacted real-run output is linked above.
- Candidate head: `ba334e3809d6fa1f1bb1dccd2f0a036fe2ed9455`.
- [Exact-head GitHub CI](https://github.com/openclaw/openclaw/actions/runs/30723306633) completed with 51 successful jobs, including `check-docs`, build artifacts, extension-boundary checks, and the relevant plugin checks. Two unrelated test jobs failed: `check-sqlite-session-flip-proof` timed out during a Gateway opening handshake, while the same job passed on the contemporaneous current-main run; `checks-node-compact-large-8` stalled twice in the agent-core subagent shard and exited 143 after the no-output watchdog. The aggregate `openclaw/ci-gate` therefore reported failure. Neither failed job exercises the Memory Wiki or documentation surface. The contributor account could not request a rerun.
- Exact-head real-behavior-proof, CodeQL, workflow sanity, security-sensitive guard, dependency/label dispatch, and platform dead-code workflows passed.
- Final independent static Codex review reported no actionable correctness regressions.
- No UI or visual surface changed, so screenshots are not applicable.
