### PR TITLE
fix(cron): fail originating media cron on detached errors

### DIFF
--- a/src/agents/tools/media-generate-background-shared.test.ts
+++ b/src/agents/tools/media-generate-background-shared.test.ts
@@ -6,7 +6,10 @@ import {
   withOwnedSessionTranscriptWrites,
 } from "../../config/sessions/transcript-write-context.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
-import { registerDetachedMediaCronFailureRecorder } from "../../cron/detached-media-failure-recorder.js";
+import {
+  getDetachedMediaCronFailureRecorder,
+  registerDetachedMediaCronFailureRecorder,
+} from "../../cron/detached-media-failure-recorder.js";
 import { resetGeneratedMediaTaskActivityForTests } from "../../tasks/task-runtime.test-helpers.js";
 import { hasPendingGeneratedMediaTaskForSessionKey } from "../../tasks/task-status-access.js";
 import { normalizeSessionDeliveryState } from "../../utils/delivery-context.shared.js";
@@ -68,7 +71,6 @@ import {
 } from "./media-generate-background-shared.js";
 
 beforeEach(() => {
-  registerDetachedMediaCronFailureRecorder(() => {})();
   resetGeneratedMediaTaskActivityForTests();
   subagentAnnounceDeliveryMocks.deliverSubagentAnnouncement.mockReset();
   subagentAnnounceDeliveryMocks.loadRequesterSessionEntry.mockReset();
@@ -854,8 +856,12 @@ describe("scheduleMediaGenerationTaskCompletion", () => {
       }),
     };
     const recordCronFailure = vi.fn(async () => {});
-    const unregisterCronFailureRecorder =
-      registerDetachedMediaCronFailureRecorder(recordCronFailure);
+    const unregisterCronFailureRecorder = registerDetachedMediaCronFailureRecorder(
+      "store-1",
+      recordCronFailure,
+    );
+    const replacementCronFailure = vi.fn(async () => {});
+    let unregisterReplacementCronFailureRecorder: (() => void) | undefined;
 
     try {
       scheduleMediaGenerationTaskCompletion({
@@ -892,12 +898,19 @@ describe("scheduleMediaGenerationTaskCompletion", () => {
       const backgroundWork = scheduled[0]?.();
       await vi.waitFor(() => expect(lifecycle.wakeTaskCompletion).toHaveBeenCalled());
       expect(lifecycle.failTaskRun).not.toHaveBeenCalled();
+      unregisterCronFailureRecorder();
+      unregisterReplacementCronFailureRecorder = registerDetachedMediaCronFailureRecorder(
+        "store-1",
+        replacementCronFailure,
+      );
       releaseWake?.();
       await backgroundWork;
     } finally {
       unregisterCronFailureRecorder();
+      unregisterReplacementCronFailureRecorder?.();
     }
 
+    expect(getDetachedMediaCronFailureRecorder("store-1")).toBeUndefined();
     expect(lifecycle.failTaskRun).toHaveBeenCalledWith(
       expect.objectContaining({
         error: generationError,
@@ -917,6 +930,7 @@ describe("scheduleMediaGenerationTaskCompletion", () => {
         error: "Detached Image generation failed: provider returned no images",
       }),
     );
+    expect(replacementCronFailure).not.toHaveBeenCalled();
   });
 });
 

--- a/src/agents/tools/media-generate-background-shared.test.ts
+++ b/src/agents/tools/media-generate-background-shared.test.ts
@@ -838,12 +838,16 @@ describe("scheduleMediaGenerationTaskCompletion", () => {
     expect(lifecycle.failTaskRun).not.toHaveBeenCalled();
   });
 
-  it("fails the media task when generation itself fails", async () => {
+  it("records the originating cron failure before a pending requester wake", async () => {
     const scheduled: Array<() => Promise<void>> = [];
     const generationError = new Error("provider returned no images");
+    const order: string[] = [];
     let releaseWake: (() => void) | undefined;
     const wakePending = new Promise<void>((resolve) => {
       releaseWake = resolve;
+    });
+    const recordCronFailure = vi.fn(async () => {
+      order.push("record-cron-failure");
     });
     const lifecycle = {
       createTaskRun: vi.fn(),
@@ -851,11 +855,12 @@ describe("scheduleMediaGenerationTaskCompletion", () => {
       completeTaskRun: vi.fn(),
       failTaskRun: vi.fn(),
       wakeTaskCompletion: vi.fn(async () => {
+        order.push("wake");
+        expect(recordCronFailure).toHaveBeenCalledOnce();
         await wakePending;
         return { status: "delivered" as const };
       }),
     };
-    const recordCronFailure = vi.fn(async () => {});
     const unregisterCronFailureRecorder = registerDetachedMediaCronFailureRecorder(
       "store-1",
       recordCronFailure,
@@ -897,6 +902,7 @@ describe("scheduleMediaGenerationTaskCompletion", () => {
 
       const backgroundWork = scheduled[0]?.();
       await vi.waitFor(() => expect(lifecycle.wakeTaskCompletion).toHaveBeenCalled());
+      expect(order).toEqual(["record-cron-failure", "wake"]);
       expect(lifecycle.failTaskRun).not.toHaveBeenCalled();
       unregisterCronFailureRecorder();
       unregisterReplacementCronFailureRecorder = registerDetachedMediaCronFailureRecorder(

--- a/src/agents/tools/media-generate-background-shared.test.ts
+++ b/src/agents/tools/media-generate-background-shared.test.ts
@@ -36,6 +36,9 @@ const cronContinuationCleanupMocks = vi.hoisted(() => ({
 const sessionMocks = vi.hoisted(() => ({
   loadSessionEntry: vi.fn<() => SessionEntry | undefined>(() => undefined),
 }));
+const agentRunRegistryMocks = vi.hoisted(() => ({
+  getAgentRunTaskRunId: vi.fn<(runId: string) => string | undefined>(() => undefined),
+}));
 
 vi.mock("../subagents/announce/subagent-announce-delivery.js", () => subagentAnnounceDeliveryMocks);
 vi.mock("../../config/sessions/session-accessor.js", async () => ({
@@ -48,6 +51,12 @@ vi.mock("../../config/sessions/session-accessor.js", async () => ({
 vi.mock("../../tasks/detached-task-runtime.js", () => detachedTaskRuntimeMocks);
 vi.mock("../../tasks/task-registry-delivery-runtime.js", () => taskRegistryDeliveryRuntimeMocks);
 vi.mock("../../tasks/cron-run-continuation-cleanup.js", () => cronContinuationCleanupMocks);
+vi.mock("../../infra/agent-run-registry.js", async () => ({
+  ...(await vi.importActual<typeof import("../../infra/agent-run-registry.js")>(
+    "../../infra/agent-run-registry.js",
+  )),
+  getAgentRunTaskRunId: agentRunRegistryMocks.getAgentRunTaskRunId,
+}));
 
 import {
   createMediaGenerationTaskLifecycle,
@@ -67,6 +76,7 @@ beforeEach(() => {
   taskRegistryDeliveryRuntimeMocks.sendMessage.mockReset();
   cronContinuationCleanupMocks.removeCronRunContinuationSessionIfIdle.mockClear();
   sessionMocks.loadSessionEntry.mockReset().mockReturnValue(undefined);
+  agentRunRegistryMocks.getAgentRunTaskRunId.mockReset().mockReturnValue(undefined);
 });
 
 function createImageMediaLifecycle() {
@@ -880,6 +890,22 @@ describe("scheduleMediaGenerationTaskCompletion", () => {
 });
 
 describe("createMediaGenerationTaskLifecycle", () => {
+  it("pins the owner-issued cron task run id when detached media starts", () => {
+    agentRunRegistryMocks.getAgentRunTaskRunId.mockReturnValue("cron-task-run-exact");
+    const lifecycle = createImageMediaLifecycle();
+
+    const handle = lifecycle.createTaskRun({
+      sessionKey: "agent:main:cron:daily-media:run:cron-session-123",
+      prompt: "proof image",
+    });
+
+    expect(agentRunRegistryMocks.getAgentRunTaskRunId).toHaveBeenCalledWith("cron-session-123");
+    expect(handle).toMatchObject({
+      requesterSessionKey: "agent:main:cron:daily-media:run:cron-session-123",
+      originatingCronTaskRunId: "cron-task-run-exact",
+    });
+  });
+
   it("tracks pending media when the detached runtime does not mirror core tasks", () => {
     const sessionKey = "agent:main:cron:daily-media:run:run-123";
     const lifecycle = createImageMediaLifecycle();

--- a/src/agents/tools/media-generate-background-shared.test.ts
+++ b/src/agents/tools/media-generate-background-shared.test.ts
@@ -6,6 +6,7 @@ import {
   withOwnedSessionTranscriptWrites,
 } from "../../config/sessions/transcript-write-context.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
+import { registerDetachedMediaCronFailureRecorder } from "../../cron/detached-media-failure-recorder.js";
 import { resetGeneratedMediaTaskActivityForTests } from "../../tasks/task-runtime.test-helpers.js";
 import { hasPendingGeneratedMediaTaskForSessionKey } from "../../tasks/task-status-access.js";
 import { normalizeSessionDeliveryState } from "../../utils/delivery-context.shared.js";
@@ -67,6 +68,7 @@ import {
 } from "./media-generate-background-shared.js";
 
 beforeEach(() => {
+  registerDetachedMediaCronFailureRecorder(() => {})();
   resetGeneratedMediaTaskActivityForTests();
   subagentAnnounceDeliveryMocks.deliverSubagentAnnouncement.mockReset();
   subagentAnnounceDeliveryMocks.loadRequesterSessionEntry.mockReset();
@@ -851,31 +853,50 @@ describe("scheduleMediaGenerationTaskCompletion", () => {
         return { status: "delivered" as const };
       }),
     };
+    const recordCronFailure = vi.fn(async () => {});
+    const unregisterCronFailureRecorder =
+      registerDetachedMediaCronFailureRecorder(recordCronFailure);
 
-    scheduleMediaGenerationTaskCompletion({
-      lifecycle,
-      handle: {
-        taskId: "task-image-generation-error",
-        runId: "tool:image_generate:generation-error",
-        requesterSessionKey: "agent:main:discord:channel:123",
-        taskLabel: "proof image",
-      },
-      scheduleBackgroundWork: (work) => {
-        scheduled.push(work);
-      },
-      progressSummary: "Generating image",
-      toolName: "Image generation",
-      onWakeFailure: vi.fn(),
-      run: async () => {
-        throw generationError;
-      },
-    });
+    try {
+      scheduleMediaGenerationTaskCompletion({
+        lifecycle,
+        handle: {
+          taskId: "task-image-generation-error",
+          runId: "tool:image_generate:generation-error",
+          requesterSessionKey:
+            "agent:main:cron:daily-media:run:550e8400-e29b-41d4-a716-446655440003",
+          originatingCronTaskRunId: "cron-task-run-1",
+          originatingCronRunReceipt: {
+            receiptId: "receipt-1",
+            storeKey: "store-1",
+            jobId: "daily-media",
+            configRevision: "revision-1",
+            agentId: "main",
+            ownerPid: 123,
+            ownerStartTime: 456,
+            startedAtMs: 789,
+          },
+          taskLabel: "proof image",
+        },
+        scheduleBackgroundWork: (work) => {
+          scheduled.push(work);
+        },
+        progressSummary: "Generating image",
+        toolName: "Image generation",
+        onWakeFailure: vi.fn(),
+        run: async () => {
+          throw generationError;
+        },
+      });
 
-    const backgroundWork = scheduled[0]?.();
-    await vi.waitFor(() => expect(lifecycle.wakeTaskCompletion).toHaveBeenCalled());
-    expect(lifecycle.failTaskRun).not.toHaveBeenCalled();
-    releaseWake?.();
-    await backgroundWork;
+      const backgroundWork = scheduled[0]?.();
+      await vi.waitFor(() => expect(lifecycle.wakeTaskCompletion).toHaveBeenCalled());
+      expect(lifecycle.failTaskRun).not.toHaveBeenCalled();
+      releaseWake?.();
+      await backgroundWork;
+    } finally {
+      unregisterCronFailureRecorder();
+    }
 
     expect(lifecycle.failTaskRun).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -889,6 +910,13 @@ describe("scheduleMediaGenerationTaskCompletion", () => {
       }),
     );
     expect(lifecycle.completeTaskRun).not.toHaveBeenCalled();
+    expect(recordCronFailure).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cronTaskRunId: "cron-task-run-1",
+        taskId: "task-image-generation-error",
+        error: "Detached Image generation failed: provider returned no images",
+      }),
+    );
   });
 });
 

--- a/src/agents/tools/media-generate-background-shared.test.ts
+++ b/src/agents/tools/media-generate-background-shared.test.ts
@@ -38,6 +38,7 @@ const sessionMocks = vi.hoisted(() => ({
 }));
 const agentRunRegistryMocks = vi.hoisted(() => ({
   getAgentRunTaskRunId: vi.fn<(runId: string) => string | undefined>(() => undefined),
+  getAgentRunCronReceipt: vi.fn<(runId: string) => object | undefined>(() => undefined),
 }));
 
 vi.mock("../subagents/announce/subagent-announce-delivery.js", () => subagentAnnounceDeliveryMocks);
@@ -56,6 +57,7 @@ vi.mock("../../infra/agent-run-registry.js", async () => ({
     "../../infra/agent-run-registry.js",
   )),
   getAgentRunTaskRunId: agentRunRegistryMocks.getAgentRunTaskRunId,
+  getAgentRunCronReceipt: agentRunRegistryMocks.getAgentRunCronReceipt,
 }));
 
 import {
@@ -77,6 +79,7 @@ beforeEach(() => {
   cronContinuationCleanupMocks.removeCronRunContinuationSessionIfIdle.mockClear();
   sessionMocks.loadSessionEntry.mockReset().mockReturnValue(undefined);
   agentRunRegistryMocks.getAgentRunTaskRunId.mockReset().mockReturnValue(undefined);
+  agentRunRegistryMocks.getAgentRunCronReceipt.mockReset().mockReturnValue(undefined);
 });
 
 function createImageMediaLifecycle() {
@@ -891,7 +894,18 @@ describe("scheduleMediaGenerationTaskCompletion", () => {
 
 describe("createMediaGenerationTaskLifecycle", () => {
   it("pins the owner-issued cron task run id when detached media starts", () => {
+    const receipt = {
+      receiptId: "receipt-exact",
+      storeKey: "store-exact",
+      jobId: "daily-media",
+      configRevision: "revision-exact",
+      agentId: "main",
+      ownerPid: 123,
+      ownerStartTime: 456,
+      startedAtMs: 789,
+    };
     agentRunRegistryMocks.getAgentRunTaskRunId.mockReturnValue("cron-task-run-exact");
+    agentRunRegistryMocks.getAgentRunCronReceipt.mockReturnValue(receipt);
     const lifecycle = createImageMediaLifecycle();
 
     const handle = lifecycle.createTaskRun({
@@ -900,9 +914,11 @@ describe("createMediaGenerationTaskLifecycle", () => {
     });
 
     expect(agentRunRegistryMocks.getAgentRunTaskRunId).toHaveBeenCalledWith("cron-session-123");
+    expect(agentRunRegistryMocks.getAgentRunCronReceipt).toHaveBeenCalledWith("cron-session-123");
     expect(handle).toMatchObject({
       requesterSessionKey: "agent:main:cron:daily-media:run:cron-session-123",
       originatingCronTaskRunId: "cron-task-run-exact",
+      originatingCronRunReceipt: receipt,
     });
   });
 

--- a/src/agents/tools/media-generate-background-shared.ts
+++ b/src/agents/tools/media-generate-background-shared.ts
@@ -50,6 +50,7 @@ import {
   type MediaGenerationCompletionWakeOutcome,
   wakeMediaGenerationTaskCompletionWithRetry,
 } from "./media-generate-completion-retry.js";
+import { markOriginatingCronRunFailedFromMediaGeneration } from "./media-generate-cron-failure-state.js";
 
 const log = createSubsystemLogger("agents/tools/media-generate-background-shared");
 const MEDIA_GENERATION_TASK_KEEPALIVE_INTERVAL_MS = 60_000;
@@ -505,6 +506,11 @@ export function scheduleMediaGenerationTaskCompletion<
           error: wakeError,
         });
       }
+      await markOriginatingCronRunFailedFromMediaGeneration({
+        handle: params.handle,
+        error,
+        toolName: params.toolName,
+      });
       params.lifecycle.failTaskRun({ handle: params.handle, error });
       return;
     }

--- a/src/agents/tools/media-generate-background-shared.ts
+++ b/src/agents/tools/media-generate-background-shared.ts
@@ -489,6 +489,15 @@ export function scheduleMediaGenerationTaskCompletion<
         run: params.run,
       });
     } catch (error) {
+      // Persist the originating cron failure before requester delivery can
+      // retry. A later cron run may start while that wake is pending, and the
+      // old receipt must never be applied across that newer run.
+      await markOriginatingCronRunFailedFromMediaGeneration({
+        handle: params.handle,
+        error,
+        toolName: params.toolName,
+        recorder: cronFailureRecorder,
+      });
       try {
         const wakeOutcome = await wakeMediaGenerationTaskCompletionWithRetry({
           wake: async () =>
@@ -513,12 +522,6 @@ export function scheduleMediaGenerationTaskCompletion<
           error: wakeError,
         });
       }
-      await markOriginatingCronRunFailedFromMediaGeneration({
-        handle: params.handle,
-        error,
-        toolName: params.toolName,
-        recorder: cronFailureRecorder,
-      });
       params.lifecycle.failTaskRun({ handle: params.handle, error });
       return;
     }

--- a/src/agents/tools/media-generate-background-shared.ts
+++ b/src/agents/tools/media-generate-background-shared.ts
@@ -8,7 +8,11 @@ import { getCliSessionBinding } from "../../config/sessions/cli-session-binding.
 import { loadSessionEntryReadOnly } from "../../config/sessions/session-accessor.js";
 import { runWithoutOwnedSessionTranscriptWrites } from "../../config/sessions/transcript-write-context.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { clearAgentRunContext, registerAgentRunContext } from "../../infra/agent-run-registry.js";
+import {
+  clearAgentRunContext,
+  getAgentRunTaskRunId,
+  registerAgentRunContext,
+} from "../../infra/agent-run-registry.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { parseCronRunScopeSuffix } from "../../sessions/session-key-utils.js";
@@ -51,6 +55,7 @@ export type MediaGenerationTaskHandle = {
   taskId: string;
   runId: string;
   requesterSessionKey: string;
+  originatingCronTaskRunId?: string;
   requesterAgentId?: string;
   requesterOrigin?: DeliveryContext;
   taskLabel: string;
@@ -219,6 +224,8 @@ function createMediaGenerationTaskRun(params: {
   if (!sessionKey) {
     return null;
   }
+  const cronRunId = parseCronRunScopeSuffix(sessionKey).runId;
+  const originatingCronTaskRunId = cronRunId ? getAgentRunTaskRunId(cronRunId) : undefined;
   const runId = `tool:${params.toolName}:${crypto.randomUUID()}`;
   try {
     // Pin the complete requester route when detached work starts. Completion-time
@@ -253,6 +260,7 @@ function createMediaGenerationTaskRun(params: {
       taskId: task.taskId,
       runId,
       requesterSessionKey: sessionKey,
+      ...(originatingCronTaskRunId ? { originatingCronTaskRunId } : {}),
       requesterAgentId: params.requesterAgentId,
       requesterOrigin,
       taskLabel: params.prompt,

--- a/src/agents/tools/media-generate-background-shared.ts
+++ b/src/agents/tools/media-generate-background-shared.ts
@@ -8,8 +8,10 @@ import { getCliSessionBinding } from "../../config/sessions/cli-session-binding.
 import { loadSessionEntryReadOnly } from "../../config/sessions/session-accessor.js";
 import { runWithoutOwnedSessionTranscriptWrites } from "../../config/sessions/transcript-write-context.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type { AgentRunCronReceipt } from "../../infra/agent-run-registry-claim-values.js";
 import {
   clearAgentRunContext,
+  getAgentRunCronReceipt,
   getAgentRunTaskRunId,
   registerAgentRunContext,
 } from "../../infra/agent-run-registry.js";
@@ -44,11 +46,13 @@ import {
   loadRequesterSessionEntry,
 } from "../subagents/announce/subagent-announce-delivery.js";
 import { resolveAnnounceOrigin } from "../subagents/announce/subagent-announce-origin.js";
+import {
+  type MediaGenerationCompletionWakeOutcome,
+  wakeMediaGenerationTaskCompletionWithRetry,
+} from "./media-generate-completion-retry.js";
 
 const log = createSubsystemLogger("agents/tools/media-generate-background-shared");
 const MEDIA_GENERATION_TASK_KEEPALIVE_INTERVAL_MS = 60_000;
-const MEDIA_GENERATION_COMPLETION_HANDOFF_RETRY_DELAYS_MS = [250, 500, 1_000, 2_000] as const;
-const MEDIA_GENERATION_COMPLETION_HANDOFF_TIMEOUT_MS = 120_000;
 
 /** Handle for a detached media generation task registered in the task ledger. */
 export type MediaGenerationTaskHandle = {
@@ -56,6 +60,7 @@ export type MediaGenerationTaskHandle = {
   runId: string;
   requesterSessionKey: string;
   originatingCronTaskRunId?: string;
+  originatingCronRunReceipt?: AgentRunCronReceipt;
   requesterAgentId?: string;
   requesterOrigin?: DeliveryContext;
   taskLabel: string;
@@ -152,11 +157,6 @@ type WakeMediaGenerationTaskCompletionParams = {
   statsLine?: string;
 };
 
-type MediaGenerationCompletionWakeOutcome =
-  | { status: "delivered" }
-  | { status: "pending" }
-  | { status: "permanent_failure" };
-
 type MediaGenerationTaskLifecycle = {
   createTaskRun: (params: CreateMediaGenerationTaskRunParams) => MediaGenerationTaskHandle | null;
   recordTaskProgress: (params: RecordMediaGenerationTaskProgressParams) => void;
@@ -166,39 +166,6 @@ type MediaGenerationTaskLifecycle = {
     params: WakeMediaGenerationTaskCompletionParams,
   ) => Promise<MediaGenerationCompletionWakeOutcome>;
 };
-
-function waitForMediaGenerationCompletionHandoffRetry(delayMs: number): Promise<void> {
-  return new Promise((resolve) => {
-    const timer = setTimeout(resolve, delayMs);
-    timer.unref?.();
-  });
-}
-
-async function wakeMediaGenerationTaskCompletionWithRetry(params: {
-  wake: () => Promise<MediaGenerationCompletionWakeOutcome>;
-  beforeRetry?: () => void;
-}): Promise<MediaGenerationCompletionWakeOutcome> {
-  const deadline = Date.now() + MEDIA_GENERATION_COMPLETION_HANDOFF_TIMEOUT_MS;
-  let outcome = await params.wake();
-  let retryIndex = 0;
-  while (outcome.status === "pending") {
-    const remainingMs = deadline - Date.now();
-    if (remainingMs <= 0) {
-      throw new Error("cron continuation did not become ready before the handoff deadline");
-    }
-    // Pending means the original cron run still owns the continuation. Keep the
-    // task live and cap backoff until delivery, unavailability, or the deadline.
-    const delayMs =
-      MEDIA_GENERATION_COMPLETION_HANDOFF_RETRY_DELAYS_MS[
-        Math.min(retryIndex, MEDIA_GENERATION_COMPLETION_HANDOFF_RETRY_DELAYS_MS.length - 1)
-      ] ?? 2_000;
-    await waitForMediaGenerationCompletionHandoffRetry(Math.min(delayMs, remainingMs));
-    params.beforeRetry?.();
-    outcome = await params.wake();
-    retryIndex += 1;
-  }
-  return outcome;
-}
 
 function touchMediaGenerationTaskRunContext(handle: MediaGenerationTaskHandle) {
   registerGeneratedMediaTaskActivity(handle.runId, handle.requesterSessionKey);
@@ -226,6 +193,7 @@ function createMediaGenerationTaskRun(params: {
   }
   const cronRunId = parseCronRunScopeSuffix(sessionKey).runId;
   const originatingCronTaskRunId = cronRunId ? getAgentRunTaskRunId(cronRunId) : undefined;
+  const originatingCronRunReceipt = cronRunId ? getAgentRunCronReceipt(cronRunId) : undefined;
   const runId = `tool:${params.toolName}:${crypto.randomUUID()}`;
   try {
     // Pin the complete requester route when detached work starts. Completion-time
@@ -261,6 +229,7 @@ function createMediaGenerationTaskRun(params: {
       runId,
       requesterSessionKey: sessionKey,
       ...(originatingCronTaskRunId ? { originatingCronTaskRunId } : {}),
+      ...(originatingCronRunReceipt ? { originatingCronRunReceipt } : {}),
       requesterAgentId: params.requesterAgentId,
       requesterOrigin,
       taskLabel: params.prompt,

--- a/src/agents/tools/media-generate-background-shared.ts
+++ b/src/agents/tools/media-generate-background-shared.ts
@@ -8,6 +8,7 @@ import { getCliSessionBinding } from "../../config/sessions/cli-session-binding.
 import { loadSessionEntryReadOnly } from "../../config/sessions/session-accessor.js";
 import { runWithoutOwnedSessionTranscriptWrites } from "../../config/sessions/transcript-write-context.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { getDetachedMediaCronFailureRecorder } from "../../cron/detached-media-failure-recorder.js";
 import type { AgentRunCronReceipt } from "../../infra/agent-run-registry-claim-values.js";
 import {
   clearAgentRunContext,
@@ -473,6 +474,12 @@ export function scheduleMediaGenerationTaskCompletion<
   run: () => Promise<T>;
   onWakeFailure: (message: string, meta?: Record<string, unknown>) => void;
 }) {
+  const receipt = params.handle?.originatingCronRunReceipt;
+  // Pin the originating writer before work detaches so a config reload cannot
+  // reroute its late failure to a replacement cron store.
+  const cronFailureRecorder = receipt
+    ? getDetachedMediaCronFailureRecorder(receipt.storeKey)
+    : undefined;
   const runBackgroundWork = async () => {
     let executed: T;
     try {
@@ -510,6 +517,7 @@ export function scheduleMediaGenerationTaskCompletion<
         handle: params.handle,
         error,
         toolName: params.toolName,
+        recorder: cronFailureRecorder,
       });
       params.lifecycle.failTaskRun({ handle: params.handle, error });
       return;

--- a/src/agents/tools/media-generate-completion-retry.ts
+++ b/src/agents/tools/media-generate-completion-retry.ts
@@ -1,0 +1,38 @@
+const COMPLETION_HANDOFF_RETRY_DELAYS_MS = [250, 500, 1_000, 2_000] as const;
+const COMPLETION_HANDOFF_TIMEOUT_MS = 120_000;
+
+export type MediaGenerationCompletionWakeOutcome =
+  | { status: "delivered" }
+  | { status: "pending" }
+  | { status: "permanent_failure" };
+
+function waitForRetry(delayMs: number): Promise<void> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(resolve, delayMs);
+    timer.unref?.();
+  });
+}
+
+export async function wakeMediaGenerationTaskCompletionWithRetry(params: {
+  wake: () => Promise<MediaGenerationCompletionWakeOutcome>;
+  beforeRetry?: () => void;
+}): Promise<MediaGenerationCompletionWakeOutcome> {
+  const deadline = Date.now() + COMPLETION_HANDOFF_TIMEOUT_MS;
+  let outcome = await params.wake();
+  let retryIndex = 0;
+  while (outcome.status === "pending") {
+    const remainingMs = deadline - Date.now();
+    if (remainingMs <= 0) {
+      throw new Error("cron continuation did not become ready before the handoff deadline");
+    }
+    const delayMs =
+      COMPLETION_HANDOFF_RETRY_DELAYS_MS[
+        Math.min(retryIndex, COMPLETION_HANDOFF_RETRY_DELAYS_MS.length - 1)
+      ] ?? 2_000;
+    await waitForRetry(Math.min(delayMs, remainingMs));
+    params.beforeRetry?.();
+    outcome = await params.wake();
+    retryIndex += 1;
+  }
+  return outcome;
+}

--- a/src/agents/tools/media-generate-cron-failure-state.ts
+++ b/src/agents/tools/media-generate-cron-failure-state.ts
@@ -1,0 +1,42 @@
+import {
+  getDetachedMediaCronFailureRecorder,
+  type DetachedMediaCronFailureRecordRequest,
+} from "../../cron/detached-media-failure-recorder.js";
+import { formatErrorMessage } from "../../infra/errors.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
+import type { MediaGenerationTaskHandle } from "./media-generate-background-shared.js";
+
+const log = createSubsystemLogger("agents/tools/media-generate-cron-failure-state");
+
+export async function markOriginatingCronRunFailedFromMediaGeneration(params: {
+  handle: MediaGenerationTaskHandle | null;
+  error: unknown;
+  toolName: string;
+}): Promise<void> {
+  const receipt = params.handle?.originatingCronRunReceipt;
+  const recorder = getDetachedMediaCronFailureRecorder();
+  if (!params.handle || !receipt || !recorder) {
+    return;
+  }
+  const request: DetachedMediaCronFailureRecordRequest = {
+    cronRunReceipt: receipt,
+    ...(params.handle.originatingCronTaskRunId
+      ? { cronTaskRunId: params.handle.originatingCronTaskRunId }
+      : {}),
+    requesterSessionKey: params.handle.requesterSessionKey,
+    taskId: params.handle.taskId,
+    runId: params.handle.runId,
+    toolName: params.toolName,
+    error: `Detached ${params.toolName} failed: ${formatErrorMessage(params.error)}`,
+  };
+  try {
+    await recorder(request);
+  } catch (error) {
+    log.warn("Failed to record detached media failure on its originating cron run", {
+      jobId: receipt.jobId,
+      taskId: params.handle.taskId,
+      runId: params.handle.runId,
+      error,
+    });
+  }
+}

--- a/src/agents/tools/media-generate-cron-failure-state.ts
+++ b/src/agents/tools/media-generate-cron-failure-state.ts
@@ -1,5 +1,6 @@
 import {
   getDetachedMediaCronFailureRecorder,
+  type DetachedMediaCronFailureRecorder,
   type DetachedMediaCronFailureRecordRequest,
 } from "../../cron/detached-media-failure-recorder.js";
 import { formatErrorMessage } from "../../infra/errors.js";
@@ -12,10 +13,14 @@ export async function markOriginatingCronRunFailedFromMediaGeneration(params: {
   handle: MediaGenerationTaskHandle | null;
   error: unknown;
   toolName: string;
+  recorder?: DetachedMediaCronFailureRecorder;
 }): Promise<void> {
   const receipt = params.handle?.originatingCronRunReceipt;
-  const recorder = getDetachedMediaCronFailureRecorder();
-  if (!params.handle || !receipt || !recorder) {
+  if (!params.handle || !receipt) {
+    return;
+  }
+  const recorder = params.recorder ?? getDetachedMediaCronFailureRecorder(receipt.storeKey);
+  if (!recorder) {
     return;
   }
   const request: DetachedMediaCronFailureRecordRequest = {

--- a/src/cron/detached-media-failure-recorder.ts
+++ b/src/cron/detached-media-failure-recorder.ts
@@ -11,25 +11,28 @@ export type DetachedMediaCronFailureRecordRequest = {
   error: string;
 };
 
-type DetachedMediaCronFailureRecorder = (
+export type DetachedMediaCronFailureRecorder = (
   request: DetachedMediaCronFailureRecordRequest,
 ) => Promise<void> | void;
 
-let recorder: DetachedMediaCronFailureRecorder | undefined;
+const recordersByStoreKey = new Map<string, DetachedMediaCronFailureRecorder>();
 
 export function registerDetachedMediaCronFailureRecorder(
+  storeKey: string,
   next: DetachedMediaCronFailureRecorder,
 ): () => void {
-  recorder = next;
+  // Same-store successors replace the writer; different stores remain
+  // independently addressable by each receipt's durable key.
+  recordersByStoreKey.set(storeKey, next);
   return () => {
-    if (recorder === next) {
-      recorder = undefined;
+    if (recordersByStoreKey.get(storeKey) === next) {
+      recordersByStoreKey.delete(storeKey);
     }
   };
 }
 
-export function getDetachedMediaCronFailureRecorder():
-  | DetachedMediaCronFailureRecorder
-  | undefined {
-  return recorder;
+export function getDetachedMediaCronFailureRecorder(
+  storeKey: string,
+): DetachedMediaCronFailureRecorder | undefined {
+  return recordersByStoreKey.get(storeKey);
 }

--- a/src/cron/detached-media-failure-recorder.ts
+++ b/src/cron/detached-media-failure-recorder.ts
@@ -1,0 +1,35 @@
+import type { AgentRunCronReceipt } from "../infra/agent-run-registry-claim-values.js";
+
+/** Exact detached-media failure fact accepted only by the live Gateway cron owner. */
+export type DetachedMediaCronFailureRecordRequest = {
+  cronRunReceipt: AgentRunCronReceipt;
+  cronTaskRunId?: string;
+  requesterSessionKey: string;
+  taskId: string;
+  runId: string;
+  toolName: string;
+  error: string;
+};
+
+type DetachedMediaCronFailureRecorder = (
+  request: DetachedMediaCronFailureRecordRequest,
+) => Promise<void> | void;
+
+let recorder: DetachedMediaCronFailureRecorder | undefined;
+
+export function registerDetachedMediaCronFailureRecorder(
+  next: DetachedMediaCronFailureRecorder,
+): () => void {
+  recorder = next;
+  return () => {
+    if (recorder === next) {
+      recorder = undefined;
+    }
+  };
+}
+
+export function getDetachedMediaCronFailureRecorder():
+  | DetachedMediaCronFailureRecorder
+  | undefined {
+  return recorder;
+}

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -9,6 +9,7 @@ import {
   withAgentRunLifecycleGeneration,
 } from "../../infra/agent-events.js";
 import {
+  bindAgentRunCronReceipt,
   bindAgentRunTaskRunId,
   claimAgentRunContext,
   consumeCronNextCheckProposal,
@@ -25,7 +26,7 @@ import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import { removeCronRunContinuationSessionIfIdle } from "../../tasks/cron-run-continuation-cleanup.js";
 import { createCronRunDiagnosticsFromError, mergeCronRunDiagnostics } from "../run-diagnostics.js";
 import { resolveCronAbortReasonText } from "../service/execution-errors.js";
-import { getActiveCronTaskRunId } from "../service/task-runs.js";
+import { getActiveCronRunReceipt, getActiveCronTaskRunId } from "../service/task-runs.js";
 import type {
   CronAgentExecutionPhaseUpdate,
   CronAgentExecutionStarted,
@@ -205,6 +206,10 @@ export async function runCronIsolatedAgentTurn(params: {
       const taskRunId = getActiveCronTaskRunId();
       if (taskRunId) {
         bindAgentRunTaskRunId(initialSessionId, runContextOwnerToken, taskRunId);
+      }
+      const cronRunReceipt = getActiveCronRunReceipt();
+      if (cronRunReceipt) {
+        bindAgentRunCronReceipt(initialSessionId, runContextOwnerToken, cronRunReceipt);
       }
     }
     const { executeCronRun } = await cronExecutorRuntimeLoader.load();

--- a/src/cron/service.detached-media-failure.test.ts
+++ b/src/cron/service.detached-media-failure.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
+import { CronService } from "./service.js";
+import { setupCronServiceSuite } from "./service.test-harness.js";
+import { inspectActiveCronRunReceipt } from "./store/run-receipt-store.js";
+import type { CronJobCreate } from "./types.js";
+
+const { logger, makeStorePath } = setupCronServiceSuite({
+  prefix: "cron-detached-media-failure-",
+});
+
+function detachedMediaJob(id: string, name = "detached media owner"): CronJobCreate {
+  return {
+    id,
+    name,
+    enabled: true,
+    schedule: { kind: "every", everyMs: 3_600_000 },
+    sessionTarget: "isolated",
+    wakeMode: "now",
+    payload: { kind: "agentTurn", message: "generate a track" },
+  };
+}
+
+async function runAndCaptureReceipt(params: {
+  cron: CronService;
+  storePath: string;
+  jobId: string;
+  runDone: ReturnType<typeof createDeferred<{ status: "ok"; summary: string }>>;
+}) {
+  const runPromise = params.cron.run(params.jobId, "force");
+  let receipt = inspectActiveCronRunReceipt({
+    storePath: params.storePath,
+    jobId: params.jobId,
+  });
+  await vi.waitFor(() => {
+    receipt = inspectActiveCronRunReceipt({
+      storePath: params.storePath,
+      jobId: params.jobId,
+    });
+    expect(receipt).toBeDefined();
+  });
+  params.runDone.resolve({ status: "ok", summary: "generation started" });
+  await expect(runPromise).resolves.toMatchObject({ ok: true });
+  if (!receipt) {
+    throw new Error("expected active cron run receipt");
+  }
+  return receipt;
+}
+
+describe("detached media cron failure ownership", () => {
+  it("reclassifies the exact originating run after detached generation fails", async () => {
+    const { storePath } = await makeStorePath();
+    const runDone = createDeferred<{ status: "ok"; summary: string }>();
+    const cron = new CronService({
+      storePath,
+      cronEnabled: true,
+      log: logger,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => await runDone.promise),
+    });
+    await cron.start();
+    try {
+      const job = await cron.add(detachedMediaJob("detached-media-owner"));
+      const receipt = await runAndCaptureReceipt({ cron, storePath, jobId: job.id, runDone });
+      expect(cron.getJob(job.id)?.state).toMatchObject({
+        lastRunAtMs: receipt.startedAtMs,
+        lastRunStatus: "ok",
+      });
+
+      await expect(
+        cron.recordDetachedMediaFailure({
+          cronRunReceipt: receipt,
+          cronTaskRunId: "cron-task-run-1",
+          requesterSessionKey:
+            "agent:main:cron:detached-media-owner:run:550e8400-e29b-41d4-a716-446655440000",
+          taskId: "media-task-1",
+          runId: "tool:music_generate:1",
+          toolName: "music_generate",
+          error: "Detached music_generate failed: provider exhausted",
+        }),
+      ).resolves.toBe(true);
+
+      expect(cron.getJob(job.id)?.state).toMatchObject({
+        lastRunAtMs: receipt.startedAtMs,
+        lastRunStatus: "error",
+        lastError: "Detached music_generate failed: provider exhausted",
+        consecutiveErrors: 1,
+      });
+    } finally {
+      cron.stop();
+    }
+  });
+
+  it("ignores a late failure after the originating job is deleted and recreated", async () => {
+    const { storePath } = await makeStorePath();
+    const runDone = createDeferred<{ status: "ok"; summary: string }>();
+    const cron = new CronService({
+      storePath,
+      cronEnabled: true,
+      log: logger,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => await runDone.promise),
+    });
+    await cron.start();
+    try {
+      const original = await cron.add(detachedMediaJob("replace-detached-media-owner"));
+      const receipt = await runAndCaptureReceipt({
+        cron,
+        storePath,
+        jobId: original.id,
+        runDone,
+      });
+      await cron.remove(original.id);
+      const replacement = await cron.add(
+        detachedMediaJob(original.id, "replacement detached media owner"),
+      );
+
+      await expect(
+        cron.recordDetachedMediaFailure({
+          cronRunReceipt: receipt,
+          requesterSessionKey:
+            "agent:main:cron:replace-detached-media-owner:run:550e8400-e29b-41d4-a716-446655440001",
+          taskId: "media-task-stale",
+          runId: "tool:music_generate:stale",
+          toolName: "music_generate",
+          error: "Detached music_generate failed: stale provider failure",
+        }),
+      ).resolves.toBe(false);
+      expect(cron.getJob(replacement.id)?.state.lastRunStatus).toBeUndefined();
+      expect(cron.getJob(replacement.id)?.state.lastError).toBeUndefined();
+    } finally {
+      cron.stop();
+    }
+  });
+
+  it("keeps a fast detached failure when it arrives before the parent run finalizes", async () => {
+    const { storePath } = await makeStorePath();
+    const runDone = createDeferred<{ status: "ok"; summary: string }>();
+    const cron = new CronService({
+      storePath,
+      cronEnabled: true,
+      log: logger,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => await runDone.promise),
+    });
+    await cron.start();
+    try {
+      const job = await cron.add(detachedMediaJob("fast-detached-media-failure"));
+      const runPromise = cron.run(job.id, "force");
+      let receipt = inspectActiveCronRunReceipt({ storePath, jobId: job.id });
+      await vi.waitFor(() => {
+        receipt = inspectActiveCronRunReceipt({ storePath, jobId: job.id });
+        expect(receipt).toBeDefined();
+      });
+      if (!receipt) {
+        throw new Error("expected active cron run receipt");
+      }
+
+      await expect(
+        cron.recordDetachedMediaFailure({
+          cronRunReceipt: receipt,
+          requesterSessionKey:
+            "agent:main:cron:fast-detached-media-failure:run:550e8400-e29b-41d4-a716-446655440002",
+          taskId: "media-task-fast",
+          runId: "tool:music_generate:fast",
+          toolName: "music_generate",
+          error: "Detached music_generate failed: immediate provider failure",
+        }),
+      ).resolves.toBe(true);
+      runDone.resolve({ status: "ok", summary: "generation started" });
+      await runPromise;
+
+      expect(cron.getJob(job.id)?.state).toMatchObject({
+        lastRunAtMs: receipt.startedAtMs,
+        lastRunStatus: "error",
+        lastError: "Detached music_generate failed: immediate provider failure",
+      });
+    } finally {
+      runDone.resolve({ status: "ok", summary: "generation started" });
+      cron.stop();
+    }
+  });
+});

--- a/src/cron/service.detached-media-failure.test.ts
+++ b/src/cron/service.detached-media-failure.test.ts
@@ -246,4 +246,68 @@ describe("detached media cron failure ownership", () => {
       cron.stop();
     }
   });
+
+  it("does not apply an old detached failure across a newer active run", async () => {
+    const { storePath } = await makeStorePath();
+    const firstRunDone = createDeferred<{ status: "ok"; summary: string }>();
+    const newerRunDone = createDeferred<{ status: "ok"; summary: string }>();
+    const cron = new CronService({
+      storePath,
+      cronEnabled: true,
+      log: logger,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob: vi
+        .fn()
+        .mockImplementationOnce(async () => await firstRunDone.promise)
+        .mockImplementationOnce(async () => await newerRunDone.promise),
+    });
+    await cron.start();
+    try {
+      const job = await cron.add(detachedMediaJob("newer-active-run"));
+      const receipt = await runAndCaptureReceipt({
+        cron,
+        storePath,
+        jobId: job.id,
+        runDone: firstRunDone,
+      });
+      await vi.advanceTimersByTimeAsync(1);
+
+      const newerRunPromise = cron.run(job.id, "force");
+      let newerStartedAtMs: number | undefined;
+      await vi.waitFor(() => {
+        newerStartedAtMs = cron.getJob(job.id)?.state.runningAtMs;
+        expect(newerStartedAtMs).toBeDefined();
+        expect(newerStartedAtMs).not.toBe(receipt.startedAtMs);
+      });
+
+      await expect(
+        cron.recordDetachedMediaFailure({
+          cronRunReceipt: receipt,
+          requesterSessionKey:
+            "agent:main:cron:newer-active-run:run:550e8400-e29b-41d4-a716-446655440004",
+          taskId: "media-task-old-run",
+          runId: "tool:music_generate:old-run",
+          toolName: "music_generate",
+          error: "Detached music_generate failed after a newer run started",
+        }),
+      ).resolves.toBe(false);
+      expect(cron.getJob(job.id)?.state).toMatchObject({
+        runningAtMs: newerStartedAtMs,
+        lastRunAtMs: receipt.startedAtMs,
+        lastRunStatus: "ok",
+      });
+
+      newerRunDone.resolve({ status: "ok", summary: "newer generation started" });
+      await newerRunPromise;
+      expect(cron.getJob(job.id)?.state).toMatchObject({
+        lastRunAtMs: newerStartedAtMs,
+        lastRunStatus: "ok",
+      });
+    } finally {
+      firstRunDone.resolve({ status: "ok", summary: "generation started" });
+      newerRunDone.resolve({ status: "ok", summary: "newer generation started" });
+      cron.stop();
+    }
+  });
 });

--- a/src/cron/service.detached-media-failure.test.ts
+++ b/src/cron/service.detached-media-failure.test.ts
@@ -310,4 +310,72 @@ describe("detached media cron failure ownership", () => {
       cron.stop();
     }
   });
+
+  it("does not apply an old detached failure to a same-millisecond successor receipt", async () => {
+    const { storePath } = await makeStorePath();
+    const nowMs = Date.now();
+    const firstRunDone = createDeferred<{ status: "ok"; summary: string }>();
+    const successorRunDone = createDeferred<{ status: "ok"; summary: string }>();
+    const cron = new CronService({
+      storePath,
+      cronEnabled: true,
+      nowMs: () => nowMs,
+      log: logger,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob: vi
+        .fn()
+        .mockImplementationOnce(async () => await firstRunDone.promise)
+        .mockImplementationOnce(async () => await successorRunDone.promise),
+    });
+    await cron.start();
+    try {
+      const job = await cron.add(detachedMediaJob("same-millisecond-successor"));
+      const receipt = await runAndCaptureReceipt({
+        cron,
+        storePath,
+        jobId: job.id,
+        runDone: firstRunDone,
+      });
+
+      const successorRunPromise = cron.run(job.id, "force");
+      let successor = inspectActiveCronRunReceipt({ storePath, jobId: job.id });
+      await vi.waitFor(() => {
+        successor = inspectActiveCronRunReceipt({ storePath, jobId: job.id });
+        expect(successor?.receiptId).not.toBe(receipt.receiptId);
+        expect(successor?.startedAtMs).toBe(receipt.startedAtMs);
+      });
+
+      await expect(
+        cron.recordDetachedMediaFailure({
+          cronRunReceipt: receipt,
+          requesterSessionKey:
+            "agent:main:cron:same-millisecond-successor:run:550e8400-e29b-41d4-a716-446655440005",
+          taskId: "media-task-old-same-millisecond-run",
+          runId: "tool:music_generate:old-same-millisecond-run",
+          toolName: "music_generate",
+          error: "Detached music_generate failed after a same-millisecond successor started",
+        }),
+      ).resolves.toBe(false);
+      expect(inspectActiveCronRunReceipt({ storePath, jobId: job.id })?.receiptId).toBe(
+        successor?.receiptId,
+      );
+      expect(cron.getJob(job.id)?.state).toMatchObject({
+        runningAtMs: receipt.startedAtMs,
+        lastRunAtMs: receipt.startedAtMs,
+        lastRunStatus: "ok",
+      });
+
+      successorRunDone.resolve({ status: "ok", summary: "successor generation started" });
+      await successorRunPromise;
+      expect(cron.getJob(job.id)?.state).toMatchObject({
+        lastRunAtMs: receipt.startedAtMs,
+        lastRunStatus: "ok",
+      });
+    } finally {
+      firstRunDone.resolve({ status: "ok", summary: "generation started" });
+      successorRunDone.resolve({ status: "ok", summary: "successor generation started" });
+      cron.stop();
+    }
+  });
 });

--- a/src/cron/service.detached-media-failure.test.ts
+++ b/src/cron/service.detached-media-failure.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
+import { openOpenClawStateDatabase } from "../state/openclaw-state-db.js";
+import * as taskExecutor from "../tasks/task-executor.js";
 import { CronService } from "./service.js";
 import { setupCronServiceSuite } from "./service.test-harness.js";
+import { loadCronStore } from "./store.js";
+import { cronStoreKey } from "./store/key.js";
 import { inspectActiveCronRunReceipt } from "./store/run-receipt-store.js";
 import type { CronJobCreate } from "./types.js";
 
@@ -88,6 +92,62 @@ describe("detached media cron failure ownership", () => {
         consecutiveErrors: 1,
       });
     } finally {
+      cron.stop();
+    }
+  });
+
+  it("does not finalize the task or emit when detached failure persistence rolls back", async () => {
+    const { storePath } = await makeStorePath();
+    const runDone = createDeferred<{ status: "ok"; summary: string }>();
+    const onEvent = vi.fn();
+    const cron = new CronService({
+      storePath,
+      cronEnabled: true,
+      log: logger,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => await runDone.promise),
+      onEvent,
+    });
+    await cron.start();
+    const database = openOpenClawStateDatabase().db;
+    const finalizeTaskRun = vi.spyOn(taskExecutor, "finalizeTaskRunByRunIdCore");
+    try {
+      const job = await cron.add(detachedMediaJob("detached-media-rollback"));
+      const receipt = await runAndCaptureReceipt({ cron, storePath, jobId: job.id, runDone });
+      onEvent.mockClear();
+      finalizeTaskRun.mockClear();
+      database.exec(`
+        CREATE TEMP TRIGGER reject_detached_media_failure_write
+        BEFORE UPDATE ON cron_jobs
+        WHEN NEW.store_key = '${cronStoreKey(storePath)}' AND NEW.job_id = '${job.id}'
+        BEGIN
+          SELECT RAISE(ABORT, 'detached failure write failed');
+        END;
+      `);
+
+      await expect(
+        cron.recordDetachedMediaFailure({
+          cronRunReceipt: receipt,
+          cronTaskRunId: "cron-task-run-rollback",
+          requesterSessionKey:
+            "agent:main:cron:detached-media-rollback:run:550e8400-e29b-41d4-a716-446655440099",
+          taskId: "media-task-rollback",
+          runId: "tool:music_generate:rollback",
+          toolName: "music_generate",
+          error: "Detached music_generate failed: provider rollback",
+        }),
+      ).rejects.toThrow("detached failure write failed");
+
+      expect(finalizeTaskRun).not.toHaveBeenCalled();
+      expect(onEvent).not.toHaveBeenCalled();
+      expect((await loadCronStore(storePath)).jobs[0]?.state).toMatchObject({
+        lastRunAtMs: receipt.startedAtMs,
+        lastRunStatus: "ok",
+      });
+    } finally {
+      database.exec("DROP TRIGGER IF EXISTS reject_detached_media_failure_write");
+      finalizeTaskRun.mockRestore();
       cron.stop();
     }
   });

--- a/src/cron/service.detached-media-failure.test.ts
+++ b/src/cron/service.detached-media-failure.test.ts
@@ -183,4 +183,67 @@ describe("detached media cron failure ownership", () => {
       cron.stop();
     }
   });
+
+  it("records only the first detached failure for one cron receipt", async () => {
+    const { storePath } = await makeStorePath();
+    const runDone = createDeferred<{ status: "ok"; summary: string }>();
+    const cron = new CronService({
+      storePath,
+      cronEnabled: true,
+      log: logger,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => await runDone.promise),
+    });
+    await cron.start();
+    try {
+      const job = await cron.add(detachedMediaJob("duplicate-detached-media-failure"));
+      const runPromise = cron.run(job.id, "force");
+      let receipt = inspectActiveCronRunReceipt({ storePath, jobId: job.id });
+      await vi.waitFor(() => {
+        receipt = inspectActiveCronRunReceipt({ storePath, jobId: job.id });
+        expect(receipt).toBeDefined();
+      });
+      if (!receipt) {
+        throw new Error("expected active cron run receipt");
+      }
+
+      const request = {
+        cronRunReceipt: receipt,
+        requesterSessionKey:
+          "agent:main:cron:duplicate-detached-media-failure:run:550e8400-e29b-41d4-a716-446655440003",
+        taskId: "media-task-first",
+        runId: "tool:music_generate:first",
+        toolName: "music_generate",
+        error: "Detached music_generate failed: first provider failure",
+      };
+      await expect(cron.recordDetachedMediaFailure(request)).resolves.toBe(true);
+      await expect(
+        cron.recordDetachedMediaFailure({
+          ...request,
+          taskId: "media-task-second",
+          runId: "tool:music_generate:second",
+          error: "Detached music_generate failed: second provider failure",
+        }),
+      ).resolves.toBe(false);
+
+      expect(cron.getJob(job.id)?.state).toMatchObject({
+        lastRunAtMs: receipt.startedAtMs,
+        lastRunStatus: "error",
+        lastError: "Detached music_generate failed: first provider failure",
+        consecutiveErrors: 1,
+      });
+
+      runDone.resolve({ status: "ok", summary: "generation started" });
+      await runPromise;
+      expect(cron.getJob(job.id)?.state).toMatchObject({
+        lastRunStatus: "error",
+        lastError: "Detached music_generate failed: first provider failure",
+        consecutiveErrors: 1,
+      });
+    } finally {
+      runDone.resolve({ status: "ok", summary: "generation started" });
+      cron.stop();
+    }
+  });
 });

--- a/src/cron/service.ts
+++ b/src/cron/service.ts
@@ -4,6 +4,7 @@ import type {
   CronServiceRunOptions,
   CronServiceRunResult,
 } from "./service-contract.js";
+import * as detachedMediaFailureOps from "./service/detached-media-failure.js";
 import type { CronListPageOptions } from "./service/list-page-types.js";
 import * as lifecycleOps from "./service/ops-lifecycle.js";
 import * as mutationOps from "./service/ops-mutations.js";
@@ -196,6 +197,12 @@ export class CronService implements CronServiceContract {
     source?: { scheduleKey: string; identity: string },
   ): Promise<void> {
     await readOps.recordExternalFailure(this.state, id, error, statePatch, source);
+  }
+
+  async recordDetachedMediaFailure(
+    request: import("./detached-media-failure-recorder.js").DetachedMediaCronFailureRecordRequest,
+  ): Promise<boolean> {
+    return await detachedMediaFailureOps.recordDetachedMediaFailure(this.state, request);
   }
 
   async updateExternalState(

--- a/src/cron/service/detached-media-failure.ts
+++ b/src/cron/service/detached-media-failure.ts
@@ -11,7 +11,7 @@ import { failureNotificationDeliveryFromJobState } from "./failure-alerts.js";
 import { locked } from "./locked.js";
 import { emitCronRunFinished } from "./ops-run-preparation.js";
 import { applyCronRuntimeRowsToState, commitCronRuntimeRows } from "./runtime-store.js";
-import type { CronServiceState, DeferredCronNotifications } from "./state.js";
+import type { CronEvent, CronServiceState, DeferredCronNotifications } from "./state.js";
 import { ensureLoaded, runPostPersistCronNotifications } from "./store.js";
 import { applyJobResult, armTimer } from "./timer.js";
 
@@ -29,7 +29,7 @@ export async function recordDetachedMediaFailure(
       toolName: request.toolName,
     });
     const postPersistNotifications: DeferredCronNotifications = [];
-    const committedJob = commitCronRuntimeRows({
+    const committed = commitCronRuntimeRows({
       state,
       jobIds: [receipt.jobId],
       operationLabel: "cron.detached-media-failure",
@@ -80,29 +80,31 @@ export async function recordDetachedMediaFailure(
           },
           { scheduleMode: "preserve", deferredNotifications: postPersistNotifications },
         );
-        emitCronRunFinished(state, {
-          jobId: job.id,
+        const committedJob = structuredClone(job);
+        const event: CronEvent & { action: "finished" } = {
+          jobId: committedJob.id,
           action: "finished",
-          job,
+          job: committedJob,
           status: "error",
           error: request.error,
           diagnostics,
           runId: request.cronTaskRunId ?? request.runId,
           sessionKey: request.requesterSessionKey,
           runAtMs: receipt.startedAtMs,
-          durationMs: job.state.lastDurationMs,
-          nextRunAtMs: job.state.nextRunAtMs,
-          deliveryStatus: job.state.lastDeliveryStatus,
-          failureNotificationDelivery: failureNotificationDeliveryFromJobState(job),
-        });
-        return { upsertJobIds: [job.id], value: job };
+          durationMs: committedJob.state.lastDurationMs,
+          nextRunAtMs: committedJob.state.nextRunAtMs,
+          deliveryStatus: committedJob.state.lastDeliveryStatus,
+          failureNotificationDelivery: failureNotificationDeliveryFromJobState(committedJob),
+        };
+        return { upsertJobIds: [job.id], value: { event, job: committedJob } };
       },
     });
-    if (!committedJob) {
+    if (!committed) {
       return false;
     }
+    applyCronRuntimeRowsToState(state, [committed.job]);
+    emitCronRunFinished(state, committed.event);
     runPostPersistCronNotifications(state, postPersistNotifications);
-    applyCronRuntimeRowsToState(state, [committedJob]);
     armTimer(state);
     return true;
   });

--- a/src/cron/service/detached-media-failure.ts
+++ b/src/cron/service/detached-media-failure.ts
@@ -1,0 +1,99 @@
+import { resolveCronJobConfigRevision } from "../config-revision.js";
+import type { DetachedMediaCronFailureRecordRequest } from "../detached-media-failure-recorder.js";
+import { createCronRunDiagnosticsFromError } from "../run-diagnostics.js";
+import {
+  canRecordDetachedFailureForCronRunReceiptInDatabase,
+  recordDetachedFailureForCronRunReceiptInDatabase,
+  releaseLocalCronRunReceiptOwnership,
+} from "../store/run-receipt-store.js";
+import { failureNotificationDeliveryFromJobState } from "./failure-alerts.js";
+import { locked } from "./locked.js";
+import { emitCronRunFinished } from "./ops-run-preparation.js";
+import { applyCronRuntimeRowsToState, commitCronRuntimeRows } from "./runtime-store.js";
+import type { CronServiceState, DeferredCronNotifications } from "./state.js";
+import { ensureLoaded, runPostPersistCronNotifications } from "./store.js";
+import { applyJobResult, armTimer } from "./timer.js";
+
+/** Records a detached failure only while its exact scheduler receipt still owns the job result. */
+export async function recordDetachedMediaFailure(
+  state: CronServiceState,
+  request: DetachedMediaCronFailureRecordRequest,
+): Promise<boolean> {
+  return await locked(state, async () => {
+    await ensureLoaded(state, { skipRecompute: true });
+    const receipt = request.cronRunReceipt;
+    const endedAt = state.deps.nowMs();
+    const diagnostics = createCronRunDiagnosticsFromError("tool", request.error, {
+      nowMs: state.deps.nowMs,
+      toolName: request.toolName,
+    });
+    const postPersistNotifications: DeferredCronNotifications = [];
+    const committedJob = commitCronRuntimeRows({
+      state,
+      jobIds: [receipt.jobId],
+      operationLabel: "cron.detached-media-failure",
+      transactionHooks: {
+        afterWrite: (database) => {
+          recordDetachedFailureForCronRunReceiptInDatabase({
+            database,
+            handle: receipt,
+            finishedAtMs: endedAt,
+            error: request.error,
+          });
+        },
+        afterCommit: () => releaseLocalCronRunReceiptOwnership(receipt),
+      },
+      mutate: ({ database, jobs }) => {
+        const job = jobs.get(receipt.jobId);
+        const activeThisRun = job?.state.runningAtMs === receipt.startedAtMs;
+        const completedThisRun = job?.state.lastRunAtMs === receipt.startedAtMs;
+        if (
+          !job ||
+          resolveCronJobConfigRevision(job) !== receipt.configRevision ||
+          (!activeThisRun && !completedThisRun) ||
+          (!activeThisRun && completedThisRun && job.state.lastRunStatus === "error") ||
+          !canRecordDetachedFailureForCronRunReceiptInDatabase({ database, handle: receipt })
+        ) {
+          return { runHooks: false, value: undefined };
+        }
+        applyJobResult(
+          state,
+          job,
+          {
+            status: "error",
+            error: request.error,
+            diagnostics,
+            executionStarted: true,
+            sessionKey: request.requesterSessionKey,
+            startedAt: receipt.startedAtMs,
+            endedAt,
+          },
+          { scheduleMode: "preserve", deferredNotifications: postPersistNotifications },
+        );
+        emitCronRunFinished(state, {
+          jobId: job.id,
+          action: "finished",
+          job,
+          status: "error",
+          error: request.error,
+          diagnostics,
+          runId: request.cronTaskRunId ?? request.runId,
+          sessionKey: request.requesterSessionKey,
+          runAtMs: receipt.startedAtMs,
+          durationMs: job.state.lastDurationMs,
+          nextRunAtMs: job.state.nextRunAtMs,
+          deliveryStatus: job.state.lastDeliveryStatus,
+          failureNotificationDelivery: failureNotificationDeliveryFromJobState(job),
+        });
+        return { upsertJobIds: [job.id], value: job };
+      },
+    });
+    if (!committedJob) {
+      return false;
+    }
+    runPostPersistCronNotifications(state, postPersistNotifications);
+    applyCronRuntimeRowsToState(state, [committedJob]);
+    armTimer(state);
+    return true;
+  });
+}

--- a/src/cron/service/detached-media-failure.ts
+++ b/src/cron/service/detached-media-failure.ts
@@ -47,9 +47,11 @@ export async function recordDetachedMediaFailure(
         const job = jobs.get(receipt.jobId);
         const activeThisRun = job?.state.runningAtMs === receipt.startedAtMs;
         const completedThisRun = job?.state.lastRunAtMs === receipt.startedAtMs;
+        const anotherRunActive = job?.state.runningAtMs != null && !activeThisRun;
         if (
           !job ||
           resolveCronJobConfigRevision(job) !== receipt.configRevision ||
+          anotherRunActive ||
           (!activeThisRun && !completedThisRun) ||
           (!activeThisRun && completedThisRun && job.state.lastRunStatus === "error") ||
           !canRecordDetachedFailureForCronRunReceiptInDatabase({ database, handle: receipt })

--- a/src/cron/service/detached-media-failure.ts
+++ b/src/cron/service/detached-media-failure.ts
@@ -3,6 +3,7 @@ import type { DetachedMediaCronFailureRecordRequest } from "../detached-media-fa
 import { createCronRunDiagnosticsFromError } from "../run-diagnostics.js";
 import {
   canRecordDetachedFailureForCronRunReceiptInDatabase,
+  findActiveCronRunReceiptInDatabase,
   recordDetachedFailureForCronRunReceiptInDatabase,
   releaseLocalCronRunReceiptOwnership,
 } from "../store/run-receipt-store.js";
@@ -45,7 +46,14 @@ export async function recordDetachedMediaFailure(
       },
       mutate: ({ database, jobs }) => {
         const job = jobs.get(receipt.jobId);
-        const activeThisRun = job?.state.runningAtMs === receipt.startedAtMs;
+        const activeReceipt = findActiveCronRunReceiptInDatabase({
+          database,
+          storePath: state.deps.storePath,
+          jobId: receipt.jobId,
+        });
+        const activeThisRun =
+          job?.state.runningAtMs === receipt.startedAtMs &&
+          activeReceipt?.receiptId === receipt.receiptId;
         const completedThisRun = job?.state.lastRunAtMs === receipt.startedAtMs;
         const anotherRunActive = job?.state.runningAtMs != null && !activeThisRun;
         if (

--- a/src/cron/service/task-runs.ts
+++ b/src/cron/service/task-runs.ts
@@ -29,6 +29,7 @@ import type { JsonValue, TaskRecord, TaskStatus } from "../../tasks/task-registr
 import { createCronExecutionId } from "../run-id.js";
 import type { CronRunLogEntry } from "../run-log-types.js";
 import { cronStoreKey } from "../store/key.js";
+import type { CronRunReceiptHandle } from "../store/run-receipt-store.js";
 import {
   cronRunLogEntryToTaskDetail,
   cronRunStatusToTaskStatus,
@@ -46,6 +47,7 @@ import type { CronEvent, CronServiceState } from "./state.js";
 import { CRON_TASK_RUNNING_PROGRESS_SUMMARY } from "./task-ledger.js";
 
 const activeCronTaskRunId = new AsyncLocalStorage<string>();
+const activeCronRunReceipt = new AsyncLocalStorage<CronRunReceiptHandle>();
 
 /** Keeps the detached task id on the async execution that owns it. */
 export function withCronTaskRunId<T>(taskRunId: string | undefined, run: () => T): T {
@@ -55,6 +57,15 @@ export function withCronTaskRunId<T>(taskRunId: string | undefined, run: () => T
 
 export function getActiveCronTaskRunId(): string | undefined {
   return activeCronTaskRunId.getStore();
+}
+
+/** Keeps the scheduler-issued receipt on the async execution that owns it. */
+export function withCronRunReceipt<T>(receipt: CronRunReceiptHandle | undefined, run: () => T): T {
+  return receipt ? activeCronRunReceipt.run(receipt, run) : run();
+}
+
+export function getActiveCronRunReceipt(): CronRunReceiptHandle | undefined {
+  return activeCronRunReceipt.getStore();
 }
 
 /** Converts cron ids into bounded session-key path segments with a fallback for empty input. */

--- a/src/cron/service/timer-job-runner.ts
+++ b/src/cron/service/timer-job-runner.ts
@@ -23,7 +23,7 @@ import {
   trackServiceCronRunReceiptSettlement,
 } from "./run-receipts.js";
 import type { CronServiceState } from "./state.js";
-import { tryUpdateCronTaskRunSession, withCronTaskRunId } from "./task-runs.js";
+import { tryUpdateCronTaskRunSession, withCronRunReceipt, withCronTaskRunId } from "./task-runs.js";
 import { resolveCronJobTimeoutMs } from "./timeout-policy.js";
 import {
   type IsolatedAgentSetupTimeoutSignal,
@@ -266,8 +266,10 @@ export async function executeJobCoreWithTimeout(
         onExecutionPhase: accumulateExecution,
         assertRunCurrent,
       };
-      const corePromise = withCronTaskRunId(opts?.runId, () =>
-        executeJobCore(state, job, runAbortController.signal, coreOptions),
+      const corePromise = withCronRunReceipt(opts?.runReceipt, () =>
+        withCronTaskRunId(opts?.runId, () =>
+          executeJobCore(state, job, runAbortController.signal, coreOptions),
+        ),
       );
       const runPromise = corePromise.then(async (result) => {
         progress.completedCoreResult = result;
@@ -353,8 +355,10 @@ export async function executeJobCoreWithTimeout(
       onLaneWait: deferTimeoutUntilExecutionStart ? noteLaneState : undefined,
       assertRunCurrent,
     };
-    const corePromise = withCronTaskRunId(opts?.runId, () =>
-      executeJobCore(state, job, runAbortController.signal, coreOptions),
+    const corePromise = withCronRunReceipt(opts?.runReceipt, () =>
+      withCronTaskRunId(opts?.runId, () =>
+        executeJobCore(state, job, runAbortController.signal, coreOptions),
+      ),
     );
     watchdog.start();
     const runPromise = corePromise.then(async (result) => {

--- a/src/cron/store/run-receipt-store.ts
+++ b/src/cron/store/run-receipt-store.ts
@@ -683,6 +683,63 @@ export function releaseLocalCronRunReceiptOwnership(handle: CronRunReceiptHandle
   locallyOwnedReceipts.delete(handle.receiptId);
 }
 
+function rowMatchesCronRunReceiptHandle(
+  row: CronRunReceiptRow,
+  handle: CronRunReceiptHandle,
+): boolean {
+  return (
+    row.receipt_id === handle.receiptId &&
+    row.store_key === handle.storeKey &&
+    row.job_id === handle.jobId &&
+    row.config_revision === handle.configRevision &&
+    row.agent_id === handle.agentId &&
+    row.owner_pid === handle.ownerPid &&
+    row.owner_start_time === handle.ownerStartTime &&
+    row.started_at_ms === handle.startedAtMs
+  );
+}
+
+/** Checks whether the exact originating receipt can still accept a detached failure. */
+export function canRecordDetachedFailureForCronRunReceiptInDatabase(params: {
+  database: DatabaseSync;
+  handle: CronRunReceiptHandle;
+}): boolean {
+  const row = executeSqliteQueryTakeFirstSync(
+    params.database,
+    query(params.database)
+      .selectFrom("cron_run_receipts")
+      .selectAll()
+      .where("receipt_id", "=", params.handle.receiptId),
+  );
+  return Boolean(
+    row &&
+    rowMatchesCronRunReceiptHandle(row, params.handle) &&
+    (row.status === "running" || row.status === "ok" || row.status === "error"),
+  );
+}
+
+/** Reclassifies only the exact originating receipt after its detached work fails. */
+export function recordDetachedFailureForCronRunReceiptInDatabase(params: {
+  database: DatabaseSync;
+  handle: CronRunReceiptHandle;
+  finishedAtMs: number;
+  error: string;
+}): void {
+  if (!canRecordDetachedFailureForCronRunReceiptInDatabase(params)) {
+    throw new CronRunReceiptRevisionError(
+      params.handle.receiptId,
+      "cron run receipt no longer accepts detached failure state",
+    );
+  }
+  executeSqliteQuerySync(
+    params.database,
+    query(params.database)
+      .updateTable("cron_run_receipts")
+      .set({ status: "error", finished_at_ms: params.finishedAtMs, error_text: params.error })
+      .where("receipt_id", "=", params.handle.receiptId),
+  );
+}
+
 /** Completes the exact active receipt inside its caller's cron-state transaction. */
 export function finishCronRunReceiptInDatabase(params: {
   database: DatabaseSync;

--- a/src/cron/store/run-receipt-store.ts
+++ b/src/cron/store/run-receipt-store.ts
@@ -714,7 +714,7 @@ export function canRecordDetachedFailureForCronRunReceiptInDatabase(params: {
   return Boolean(
     row &&
     rowMatchesCronRunReceiptHandle(row, params.handle) &&
-    (row.status === "running" || row.status === "ok" || row.status === "error"),
+    (row.status === "running" || row.status === "ok"),
   );
 }
 
@@ -731,13 +731,17 @@ export function recordDetachedFailureForCronRunReceiptInDatabase(params: {
       "cron run receipt no longer accepts detached failure state",
     );
   }
-  executeSqliteQuerySync(
+  const result = executeSqliteQuerySync(
     params.database,
     query(params.database)
       .updateTable("cron_run_receipts")
       .set({ status: "error", finished_at_ms: params.finishedAtMs, error_text: params.error })
-      .where("receipt_id", "=", params.handle.receiptId),
+      .where("receipt_id", "=", params.handle.receiptId)
+      .where("status", "in", ["running", "ok"]),
   );
+  if (result.numAffectedRows !== 1n) {
+    throw new CronRunReceiptRevisionError(params.handle.receiptId, "receipt already failed");
+  }
 }
 
 /** Completes the exact active receipt inside its caller's cron-state transaction. */

--- a/src/gateway/server-cron.test.ts
+++ b/src/gateway/server-cron.test.ts
@@ -590,27 +590,59 @@ describe("buildGatewayCronService", () => {
     }
   });
 
-  it("restores detached-media failure recording after cron stop and start", async () => {
+  it("keeps detached-media failure recording active between cron owners", async () => {
     const cfg = createCronConfig("server-cron-restart-detached-media-recorder");
     loadConfigMock.mockReturnValue(cfg);
-    const state = buildGatewayCronService({
+    const initial = buildGatewayCronService({
       cfg,
       deps: {} as CliDeps,
       broadcast: () => {},
     });
+    let replacement: ReturnType<typeof buildGatewayCronService> | undefined;
 
     try {
       expect(getDetachedMediaCronFailureRecorder()).toBeUndefined();
-      await state.cron.start();
-      expect(getDetachedMediaCronFailureRecorder()).toBeTypeOf("function");
+      await initial.cron.start();
+      const recorderBeforeStop = getDetachedMediaCronFailureRecorder();
+      expect(recorderBeforeStop).toBeTypeOf("function");
 
-      state.cron.stop();
-      expect(getDetachedMediaCronFailureRecorder()).toBeUndefined();
+      initial.cron.stop();
+      replacement = buildGatewayCronService({
+        cfg,
+        deps: {} as CliDeps,
+        broadcast: () => {},
+      });
+      const recorderBetweenOwners = getDetachedMediaCronFailureRecorder();
+      expect(recorderBetweenOwners).toBe(recorderBeforeStop);
+      if (!recorderBetweenOwners) {
+        throw new Error("expected detached-media recorder between cron owners");
+      }
+      await expect(
+        recorderBetweenOwners({
+          cronRunReceipt: {
+            receiptId: "receipt-during-restart",
+            storeKey: "store-during-restart",
+            jobId: "job-during-restart",
+            configRevision: "revision-during-restart",
+            agentId: "main",
+            ownerPid: process.pid,
+            ownerStartTime: null,
+            startedAtMs: 1,
+          },
+          requesterSessionKey: "agent:main:cron:job-during-restart:run:1",
+          taskId: "media-task-during-restart",
+          runId: "tool:music_generate:during-restart",
+          toolName: "music_generate",
+          error: "Detached music_generate failed during restart",
+        }),
+      ).resolves.toBeUndefined();
 
-      await state.cron.start();
-      expect(getDetachedMediaCronFailureRecorder()).toBeTypeOf("function");
+      await replacement.cron.start();
+      expect(getDetachedMediaCronFailureRecorder()).not.toBe(recorderBeforeStop);
     } finally {
-      state.cron.stop();
+      initial.cron.stop();
+      replacement?.cron.stop();
+      registerDetachedMediaCronFailureRecorder(() => {})();
       expect(getDetachedMediaCronFailureRecorder()).toBeUndefined();
     }
   });

--- a/src/gateway/server-cron.test.ts
+++ b/src/gateway/server-cron.test.ts
@@ -10,10 +10,9 @@ import { AgentDeletionCommitUncertainError } from "../agents/agent-lifecycle-reg
 import type { CliDeps } from "../cli/deps.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { retainLegacyDefaultAgentId } from "../config/legacy.default-agent-owner.js";
-import {
-  getDetachedMediaCronFailureRecorder,
-  registerDetachedMediaCronFailureRecorder,
-} from "../cron/detached-media-failure-recorder.js";
+import { getDetachedMediaCronFailureRecorder } from "../cron/detached-media-failure-recorder.js";
+import { cronStoreKey } from "../cron/store/key.js";
+import { inspectActiveCronRunReceipt } from "../cron/store/run-receipt-store.js";
 import { resolveSystemEventOptionsOwnerAgentId } from "../infra/system-event-ownership.js";
 import {
   getActiveGatewayRootWorkCount,
@@ -311,7 +310,6 @@ function expectIsolatedRunFields(fields: Record<string, unknown>) {
 
 describe("buildGatewayCronService", () => {
   beforeEach(() => {
-    registerDetachedMediaCronFailureRecorder(() => {})();
     resetActiveCronTaskRunsForTests();
     enqueueSystemEventMock.mockClear();
     systemEventReceiptRemoveMock.mockClear();
@@ -590,8 +588,13 @@ describe("buildGatewayCronService", () => {
     }
   });
 
-  it("keeps detached-media failure recording active between cron owners", async () => {
+  it("routes a detached-media failure to its original store across cron reload", async () => {
     const cfg = createCronConfig("server-cron-restart-detached-media-recorder");
+    const replacementCfg = createCronConfig(
+      "server-cron-restart-detached-media-recorder-replacement",
+    );
+    const runDone = createDeferred<{ status: "ok"; summary: string }>();
+    runCronIsolatedAgentTurnMock.mockImplementationOnce(async () => await runDone.promise);
     loadConfigMock.mockReturnValue(cfg);
     const initial = buildGatewayCronService({
       cfg,
@@ -601,34 +604,56 @@ describe("buildGatewayCronService", () => {
     let replacement: ReturnType<typeof buildGatewayCronService> | undefined;
 
     try {
-      expect(getDetachedMediaCronFailureRecorder()).toBeUndefined();
+      expect(getDetachedMediaCronFailureRecorder(cronStoreKey(initial.storePath))).toBeUndefined();
       await initial.cron.start();
-      const recorderBeforeStop = getDetachedMediaCronFailureRecorder();
-      expect(recorderBeforeStop).toBeTypeOf("function");
+      const job = await initial.cron.add({
+        id: "job-during-restart",
+        name: "detached media across store reload",
+        enabled: true,
+        schedule: { kind: "every", everyMs: 3_600_000 },
+        payload: { kind: "agentTurn", message: "generate music" },
+        sessionTarget: "isolated",
+        wakeMode: "now",
+      });
+      const runPromise = initial.cron.run(job.id, "force");
+      let receipt = inspectActiveCronRunReceipt({
+        storePath: initial.storePath,
+        jobId: job.id,
+      });
+      await vi.waitFor(() => {
+        receipt = inspectActiveCronRunReceipt({
+          storePath: initial.storePath,
+          jobId: job.id,
+        });
+        expect(receipt).toBeDefined();
+      });
+      runDone.resolve({ status: "ok", summary: "generation started" });
+      await runPromise;
+      if (!receipt) {
+        throw new Error("expected detached-media cron receipt");
+      }
+      expect(initial.cron.getJob(job.id)?.state.lastRunStatus).toBe("ok");
+      const recorderForTask = getDetachedMediaCronFailureRecorder(receipt.storeKey);
+      expect(recorderForTask).toBeTypeOf("function");
+      if (!recorderForTask) {
+        throw new Error("expected originating detached-media recorder");
+      }
 
       initial.cron.stop();
+      loadConfigMock.mockReturnValue(replacementCfg);
       replacement = buildGatewayCronService({
-        cfg,
+        cfg: replacementCfg,
         deps: {} as CliDeps,
         broadcast: () => {},
       });
-      const recorderBetweenOwners = getDetachedMediaCronFailureRecorder();
-      expect(recorderBetweenOwners).toBe(recorderBeforeStop);
-      if (!recorderBetweenOwners) {
-        throw new Error("expected detached-media recorder between cron owners");
-      }
+      await replacement.cron.start();
+      expect(getDetachedMediaCronFailureRecorder(receipt.storeKey)).toBeUndefined();
+      expect(getDetachedMediaCronFailureRecorder(cronStoreKey(replacement.storePath))).toBeTypeOf(
+        "function",
+      );
       await expect(
-        recorderBetweenOwners({
-          cronRunReceipt: {
-            receiptId: "receipt-during-restart",
-            storeKey: "store-during-restart",
-            jobId: "job-during-restart",
-            configRevision: "revision-during-restart",
-            agentId: "main",
-            ownerPid: process.pid,
-            ownerStartTime: null,
-            startedAtMs: 1,
-          },
+        recorderForTask({
+          cronRunReceipt: receipt,
           requesterSessionKey: "agent:main:cron:job-during-restart:run:1",
           taskId: "media-task-during-restart",
           runId: "tool:music_generate:during-restart",
@@ -636,14 +661,22 @@ describe("buildGatewayCronService", () => {
           error: "Detached music_generate failed during restart",
         }),
       ).resolves.toBeUndefined();
-
-      await replacement.cron.start();
-      expect(getDetachedMediaCronFailureRecorder()).not.toBe(recorderBeforeStop);
+      expect(initial.cron.getJob(job.id)?.state).toMatchObject({
+        lastRunAtMs: receipt.startedAtMs,
+        lastRunStatus: "error",
+        lastError: "Detached music_generate failed during restart",
+      });
+      expect(replacement.cron.getJob(job.id)).toBeUndefined();
     } finally {
+      runDone.resolve({ status: "ok", summary: "generation started" });
       initial.cron.stop();
       replacement?.cron.stop();
-      registerDetachedMediaCronFailureRecorder(() => {})();
-      expect(getDetachedMediaCronFailureRecorder()).toBeUndefined();
+      expect(getDetachedMediaCronFailureRecorder(cronStoreKey(initial.storePath))).toBeUndefined();
+      if (replacement) {
+        expect(
+          getDetachedMediaCronFailureRecorder(cronStoreKey(replacement.storePath)),
+        ).toBeUndefined();
+      }
     }
   });
 

--- a/src/gateway/server-cron.test.ts
+++ b/src/gateway/server-cron.test.ts
@@ -10,6 +10,10 @@ import { AgentDeletionCommitUncertainError } from "../agents/agent-lifecycle-reg
 import type { CliDeps } from "../cli/deps.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { retainLegacyDefaultAgentId } from "../config/legacy.default-agent-owner.js";
+import {
+  getDetachedMediaCronFailureRecorder,
+  registerDetachedMediaCronFailureRecorder,
+} from "../cron/detached-media-failure-recorder.js";
 import { resolveSystemEventOptionsOwnerAgentId } from "../infra/system-event-ownership.js";
 import {
   getActiveGatewayRootWorkCount,
@@ -307,6 +311,7 @@ function expectIsolatedRunFields(fields: Record<string, unknown>) {
 
 describe("buildGatewayCronService", () => {
   beforeEach(() => {
+    registerDetachedMediaCronFailureRecorder(() => {})();
     resetActiveCronTaskRunsForTests();
     enqueueSystemEventMock.mockClear();
     systemEventReceiptRemoveMock.mockClear();
@@ -582,6 +587,31 @@ describe("buildGatewayCronService", () => {
       await vi.waitFor(() => expect(spawn).toHaveBeenCalledTimes(2));
     } finally {
       state.cron.stop();
+    }
+  });
+
+  it("restores detached-media failure recording after cron stop and start", async () => {
+    const cfg = createCronConfig("server-cron-restart-detached-media-recorder");
+    loadConfigMock.mockReturnValue(cfg);
+    const state = buildGatewayCronService({
+      cfg,
+      deps: {} as CliDeps,
+      broadcast: () => {},
+    });
+
+    try {
+      expect(getDetachedMediaCronFailureRecorder()).toBeUndefined();
+      await state.cron.start();
+      expect(getDetachedMediaCronFailureRecorder()).toBeTypeOf("function");
+
+      state.cron.stop();
+      expect(getDetachedMediaCronFailureRecorder()).toBeUndefined();
+
+      await state.cron.start();
+      expect(getDetachedMediaCronFailureRecorder()).toBeTypeOf("function");
+    } finally {
+      state.cron.stop();
+      expect(getDetachedMediaCronFailureRecorder()).toBeUndefined();
     }
   });
 

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -49,6 +49,7 @@ import {
   resolveCronSessionTargetSessionKey,
 } from "../cron/session-target.js";
 import { resolveCronJobsStorePathFromConfig } from "../cron/store.js";
+import { cronStoreKey } from "../cron/store/key.js";
 import { cronStreamScheduleKey } from "../cron/stream-schedule.js";
 import { createCronScriptRuntime } from "../cron/trigger-script.js";
 import type {
@@ -1385,12 +1386,12 @@ export function buildGatewayCronService(params: {
     getDefaultAgentId: () => cron.getDefaultAgentId(),
   };
   const automationEpoch = claimSessionAutomationEpoch();
+  const cronFailureRecorderStoreKey = cronStoreKey(storePath);
   let unregisterDetachedMediaCronFailureRecorder: (() => void) | undefined;
   const registerDetachedMediaFailureRecorder = () => {
-    // Keep the previous receipt-valid writer through reload startup, then
-    // replace it only after the successor scheduler has started successfully.
     unregisterDetachedMediaCronFailureRecorder?.();
     unregisterDetachedMediaCronFailureRecorder = registerDetachedMediaCronFailureRecorder(
+      cronFailureRecorderStoreKey,
       async (request) => {
         await cron.recordDetachedMediaFailure(request);
       },
@@ -1409,6 +1410,10 @@ export function buildGatewayCronService(params: {
         );
       });
     } finally {
+      // In-flight detached tasks retain this store writer until settlement;
+      // otherwise stopping the owner removes it immediately.
+      unregisterDetachedMediaCronFailureRecorder?.();
+      unregisterDetachedMediaCronFailureRecorder = undefined;
       // Session rows must stop reporting automation from a stopped scheduler,
       // but a reload's replacement service may already own the registration.
       unregisterSessionAutomationSource(automationSource);

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -33,6 +33,7 @@ import {
 import { runCronCommandJob } from "../cron/command-runner.js";
 import { resolveCronStoredDeliveryContext } from "../cron/delivery-context.js";
 import { resolveCronDeliveryPlan, sendCronAnnouncePayloadStrict } from "../cron/delivery.js";
+import { registerDetachedMediaCronFailureRecorder } from "../cron/detached-media-failure-recorder.js";
 import { runCronIsolatedAgentTurn } from "../cron/isolated-agent.js";
 import { resolveCronJobBoundSessionKeys } from "../cron/job-session-bindings.js";
 import { toPublicCronJob } from "../cron/public-job.js";
@@ -1384,9 +1385,23 @@ export function buildGatewayCronService(params: {
     getDefaultAgentId: () => cron.getDefaultAgentId(),
   };
   const automationEpoch = claimSessionAutomationEpoch();
+  let unregisterDetachedMediaCronFailureRecorder: (() => void) | undefined;
+  const registerDetachedMediaFailureRecorder = () => {
+    unregisterDetachedMediaCronFailureRecorder?.();
+    unregisterDetachedMediaCronFailureRecorder = registerDetachedMediaCronFailureRecorder(
+      async (request) => {
+        await cron.recordDetachedMediaFailure(request);
+      },
+    );
+  };
+  const unregisterDetachedMediaFailureRecorder = () => {
+    unregisterDetachedMediaCronFailureRecorder?.();
+    unregisterDetachedMediaCronFailureRecorder = undefined;
+  };
   const stopCron = cron.stop.bind(cron);
   cron.stop = () => {
     try {
+      unregisterDetachedMediaFailureRecorder();
       stopCron();
       stopExitWatchers();
       stopHeartbeatReconcileRetry();
@@ -1470,6 +1485,7 @@ export function buildGatewayCronService(params: {
     if (generation !== streamWatcherGeneration) {
       return;
     }
+    registerDetachedMediaFailureRecorder();
     exitWatchersStopped = false;
     streamWatchersStopped = false;
     // A reload restart owns a fresh watcher lifecycle; the next stop must run.

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -1387,6 +1387,8 @@ export function buildGatewayCronService(params: {
   const automationEpoch = claimSessionAutomationEpoch();
   let unregisterDetachedMediaCronFailureRecorder: (() => void) | undefined;
   const registerDetachedMediaFailureRecorder = () => {
+    // Keep the previous receipt-valid writer through reload startup, then
+    // replace it only after the successor scheduler has started successfully.
     unregisterDetachedMediaCronFailureRecorder?.();
     unregisterDetachedMediaCronFailureRecorder = registerDetachedMediaCronFailureRecorder(
       async (request) => {
@@ -1394,14 +1396,9 @@ export function buildGatewayCronService(params: {
       },
     );
   };
-  const unregisterDetachedMediaFailureRecorder = () => {
-    unregisterDetachedMediaCronFailureRecorder?.();
-    unregisterDetachedMediaCronFailureRecorder = undefined;
-  };
   const stopCron = cron.stop.bind(cron);
   cron.stop = () => {
     try {
-      unregisterDetachedMediaFailureRecorder();
       stopCron();
       stopExitWatchers();
       stopHeartbeatReconcileRetry();

--- a/src/infra/agent-run-registry-claim-values.ts
+++ b/src/infra/agent-run-registry-claim-values.ts
@@ -1,0 +1,70 @@
+/** Opaque cron execution identity retained without importing scheduler implementation types. */
+export type AgentRunCronReceipt = Readonly<{
+  receiptId: string;
+  storeKey: string;
+  jobId: string;
+  configRevision: string;
+  agentId: string;
+  ownerPid: number;
+  ownerStartTime: number | null;
+  startedAtMs: number;
+}>;
+
+export type AgentRunClaimOwnership = {
+  lifecycleGeneration: string;
+  claimIds: Set<string>;
+  /** Detached task ids exist only for the exact execution claims that own them. */
+  taskRunIds?: Map<string, string>;
+  /** Live execution claims are lifecycle-owned and must not be expired by the projection sweeper. */
+  sweepProtectedClaimIds: Set<string>;
+  preserveAfterRelease: boolean;
+  clearRequested: boolean;
+  exclusiveClaimId?: string;
+  clearListeners?: Map<string, (claimId: string) => void>;
+};
+
+const cronReceiptsByRunId = new Map<string, Map<string, AgentRunCronReceipt>>();
+
+export function bindAgentRunCronReceiptValue(
+  runId: string,
+  claimId: string,
+  receipt: AgentRunCronReceipt,
+  activeClaimIds: ReadonlySet<string> | undefined,
+): boolean {
+  if (!receipt.receiptId.trim() || !activeClaimIds?.has(claimId)) {
+    return false;
+  }
+  const receipts = cronReceiptsByRunId.get(runId) ?? new Map();
+  receipts.set(claimId, { ...receipt });
+  cronReceiptsByRunId.set(runId, receipts);
+  return true;
+}
+
+export function getAgentRunCronReceiptValue(
+  runId: string,
+  activeClaimIds: ReadonlySet<string> | undefined,
+): AgentRunCronReceipt | undefined {
+  const receipts = cronReceiptsByRunId.get(runId);
+  const unique = new Map(
+    [...(receipts ?? [])]
+      .filter(([claimId]) => activeClaimIds?.has(claimId))
+      .map(([, receipt]) => [receipt.receiptId, receipt]),
+  );
+  return unique.size === 1 ? unique.values().next().value : undefined;
+}
+
+export function releaseAgentRunCronReceiptValue(runId: string, claimId: string): void {
+  const receipts = cronReceiptsByRunId.get(runId);
+  receipts?.delete(claimId);
+  if (receipts?.size === 0) {
+    cronReceiptsByRunId.delete(runId);
+  }
+}
+
+export function clearAgentRunCronReceiptValues(runId: string): void {
+  cronReceiptsByRunId.delete(runId);
+}
+
+export function resetAgentRunCronReceiptValuesForTest(): void {
+  cronReceiptsByRunId.clear();
+}

--- a/src/infra/agent-run-registry.task-ownership.test.ts
+++ b/src/infra/agent-run-registry.task-ownership.test.ts
@@ -1,7 +1,9 @@
 import { beforeEach, describe, expect, test } from "vitest";
 import {
+  bindAgentRunCronReceipt,
   bindAgentRunTaskRunId,
   claimAgentRunContext,
+  getAgentRunCronReceipt,
   getAgentRunContext,
   getAgentRunTaskRunId,
   releaseAgentRunContext,
@@ -43,5 +45,47 @@ describe("agent run task ownership", () => {
     releaseAgentRunContext("shared-task-run", firstClaim);
     expect(getAgentRunTaskRunId("shared-task-run")).toBeUndefined();
     expect(getAgentRunContext("shared-task-run")).toBeUndefined();
+  });
+
+  test("binds exact cron receipts to active claims and rejects ambiguous owners", () => {
+    const firstClaim = claimAgentRunContext(
+      "shared-cron-run",
+      { sessionKey: "agent:main:cron:job:run:session" },
+      { trackOwner: true, ownsContext: true },
+    );
+    const secondClaim = claimAgentRunContext(
+      "shared-cron-run",
+      {},
+      { trackOwner: true, ownsContext: true },
+    );
+    expect(firstClaim).toBeTruthy();
+    expect(secondClaim).toBeTruthy();
+    if (!firstClaim || !secondClaim) {
+      throw new Error("expected tracked agent run claims");
+    }
+
+    const firstReceipt = {
+      receiptId: "receipt-a",
+      storeKey: "store-a",
+      jobId: "job-a",
+      configRevision: "revision-a",
+      agentId: "main",
+      ownerPid: 100,
+      ownerStartTime: 200,
+      startedAtMs: 300,
+    };
+    const secondReceipt = { ...firstReceipt, receiptId: "receipt-b" };
+
+    expect(bindAgentRunCronReceipt("shared-cron-run", "missing-claim", firstReceipt)).toBe(false);
+    expect(bindAgentRunCronReceipt("shared-cron-run", firstClaim, firstReceipt)).toBe(true);
+    expect(getAgentRunCronReceipt("shared-cron-run")).toEqual(firstReceipt);
+
+    expect(bindAgentRunCronReceipt("shared-cron-run", secondClaim, secondReceipt)).toBe(true);
+    expect(getAgentRunCronReceipt("shared-cron-run")).toBeUndefined();
+
+    releaseAgentRunContext("shared-cron-run", secondClaim);
+    expect(getAgentRunCronReceipt("shared-cron-run")).toEqual(firstReceipt);
+    releaseAgentRunContext("shared-cron-run", firstClaim);
+    expect(getAgentRunCronReceipt("shared-cron-run")).toBeUndefined();
   });
 });

--- a/src/infra/agent-run-registry.ts
+++ b/src/infra/agent-run-registry.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "node:crypto";
 import type { VerboseLevel } from "../auto-reply/thinking.js";
 import { normalizeAgentId, parseAgentSessionKey } from "../routing/session-key.js";
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
+import * as cronReceiptValues from "./agent-run-registry-claim-values.js";
 import { clearAgentRunUsage, resetAgentRunUsageForTest } from "./agent-run-usage.js";
 
 /** Per-run metadata used to stamp events and gate Control UI visibility. */
@@ -39,22 +40,9 @@ export type AgentRunDelegatedAuthority = Readonly<{
   claimId: string;
 }>;
 
-type AgentRunContextOwnership = {
-  lifecycleGeneration: string;
-  claimIds: Set<string>;
-  /** Detached task ids exist only for the exact execution claims that own them. */
-  taskRunIds?: Map<string, string>;
-  /** Live execution claims are lifecycle-owned and must not be expired by the projection sweeper. */
-  sweepProtectedClaimIds: Set<string>;
-  preserveAfterRelease: boolean;
-  clearRequested: boolean;
-  exclusiveClaimId?: string;
-  clearListeners?: Map<string, (claimId: string) => void>;
-};
-
 type AgentRunRegistryState = {
   contexts: Map<string, AgentRunContext>;
-  owners: Map<string, AgentRunContextOwnership>;
+  owners: Map<string, cronReceiptValues.AgentRunClaimOwnership>;
   queuedRunContextLeases?: WeakMap<AgentRunContext, number>;
   lifecycleGeneration: string;
   sequenceResetHandler?: (runId: string) => void;
@@ -67,7 +55,7 @@ const AGENT_RUN_REGISTRY_STATE_KEY = Symbol.for("openclaw.agentRunRegistry.state
 function getAgentRunRegistryState(): AgentRunRegistryState {
   return resolveGlobalSingleton<AgentRunRegistryState>(AGENT_RUN_REGISTRY_STATE_KEY, () => ({
     contexts: new Map<string, AgentRunContext>(),
-    owners: new Map<string, AgentRunContextOwnership>(),
+    owners: new Map<string, cronReceiptValues.AgentRunClaimOwnership>(),
     lifecycleGeneration: randomUUID(),
     version: 0,
   }));
@@ -265,6 +253,7 @@ export function claimAgentRunContext(
         currentOwners.clearListeners.set(claimId, options.onClearRequested);
       }
     } else {
+      cronReceiptValues.clearAgentRunCronReceiptValues(runId);
       state.owners.set(runId, {
         lifecycleGeneration,
         claimIds: new Set([claimId]),
@@ -282,6 +271,7 @@ export function claimAgentRunContext(
     // Same-generation untracked claims refresh metadata inside the tracked
     // execution. A new lifecycle replaces that ownership outright.
     state.owners.delete(runId);
+    cronReceiptValues.clearAgentRunCronReceiptValues(runId);
   }
   if (existing?.lifecycleGeneration === lifecycleGeneration) {
     const versionBeforeRegister = readAgentRunIndexVersion();
@@ -332,6 +322,26 @@ export function getAgentRunTaskRunId(runId: string): string | undefined {
   return taskRunIds.size === 1 ? taskRunIds.values().next().value : undefined;
 }
 
+export function bindAgentRunCronReceipt(
+  runId: string,
+  claimId: string,
+  receipt: cronReceiptValues.AgentRunCronReceipt,
+): boolean {
+  return cronReceiptValues.bindAgentRunCronReceiptValue(
+    runId,
+    claimId,
+    receipt,
+    getAgentRunRegistryState().owners.get(runId)?.claimIds,
+  );
+}
+
+export function getAgentRunCronReceipt(runId: string) {
+  return cronReceiptValues.getAgentRunCronReceiptValue(
+    runId,
+    getAgentRunRegistryState().owners.get(runId)?.claimIds,
+  );
+}
+
 /** Holds an existing run context only while its current execution awaits lane admission. */
 export function retainQueuedAgentRunContext(
   runId: string,
@@ -375,7 +385,7 @@ export function retainQueuedAgentRunContext(
   };
 }
 
-export function getAgentRunContextOwnership(runId: string): AgentRunContextOwnership | undefined {
+export function getAgentRunContextOwnership(runId: string) {
   return getAgentRunRegistryState().owners.get(runId);
 }
 
@@ -695,6 +705,7 @@ export function releaseAgentRunContext(runId: string, claimId: string | undefine
   owners.sweepProtectedClaimIds.delete(claimId);
   const versionBeforeRelease = readAgentRunIndexVersion();
   owners.taskRunIds?.delete(claimId);
+  cronReceiptValues.releaseAgentRunCronReceiptValue(runId, claimId);
   owners.clearListeners?.delete(claimId);
   if (owners.exclusiveClaimId === claimId) {
     owners.exclusiveClaimId = undefined;
@@ -741,6 +752,7 @@ export function sweepStaleRunContexts(maxAgeMs = 30 * 60 * 1000): number {
       state.sequenceResetHandler?.(runId);
       clearAgentRunUsage(runId, context.lifecycleGeneration);
       state.owners.delete(runId);
+      cronReceiptValues.clearAgentRunCronReceiptValues(runId);
       swept += 1;
     }
   }
@@ -754,6 +766,7 @@ export function resetAgentRunRegistryForTest(): void {
   const state = getAgentRunRegistryState();
   const hadRunContexts = state.contexts.size > 0;
   resetAgentRunUsageForTest();
+  cronReceiptValues.resetAgentRunCronReceiptValuesForTest();
   state.contexts.clear();
   state.owners.clear();
   state.queuedRunContextLeases = undefined;


### PR DESCRIPTION
## What Problem This Solves

Detached media generation can fail after the initiating cron run has already returned success. The task ledger records that media failure, but without an owner-bound return path the originating cron job can remain green, hiding provider failures from cron health and heartbeat audits.

## Summary

- carry the scheduler-issued cron receipt and exact task-run identity through isolated-run context into the detached media task handle
- capture a Gateway-private, origin-store failure writer synchronously before media work detaches
- persist the originating cron failure before requester completion delivery can retry
- atomically reclassify only the receipt's original run/current job revision; reject replaced jobs, duplicate terminal failures, stale replay, and any old receipt crossing a newer active run
- retain the captured origin writer across a configured `cron.store` reload without routing the old receipt into the successor store
- cover normal failure, fast failure, duplicate detached failures, pending requester wake, newer active/successful run, delete/recreate replacement, owner restart, same-store writer replacement, and store-A→store-B reload behavior

## Evidence

- Current exact head: `07c9921f4f1fc14f6598a70d7a941649d1ebb4c8`, rebased conflict-free onto upstream `d5c194f4eade6b0c6bb9af43261a23c1a7b1374d` after repairing the exact-head same-millisecond successor finding.
- Ordering regression red proof: with the production write moved back behind requester wake, the focused media test failed with `received ["wake", "record-cron-failure"]` instead of `expected ["record-cron-failure", "wake"]`.
- Newer-run fencing red proof: with the active-newer-run guard removed, the real `CronService` regression failed because the stale origin receipt returned `true` instead of `false` and cleared the newer run.
- Same-millisecond receipt red proof: with the timestamp-only guard, a stale origin failure returned `true` against a successor whose distinct active receipt shared the same `startedAtMs`; the exact active-receipt fence now returns `false` and leaves that successor running.
- 143/143 focused tests pass across Gateway cron, detached-failure persistence, receipt recovery, task ownership, and media lifecycle shards on the rebased exact head.
- `corepack pnpm tsgo:core:test`, focused oxfmt/oxlint, and `git diff --check` pass on the rebased exact head.

### Prior ordering runtime bridge (2026-08-14)

This redacted disposable-state probe ran on the prior reviewed head through the production `scheduleMediaGenerationTaskCompletion(...)` boundary, production detached-failure recorder registry, and a real `CronService`. It completes the origin parent run, fails the provider, holds requester wake pending, starts a newer cron run, attempts stale replay, then releases wake and completes the newer run.

```text
$ OPENCLAW_STATE_DIR=<disposable> node --import tsx .tmp-pr113750-ordering-proof.mts
head=2dea1b55da844f17d1f7823893fa18cb23b28ce6
originFailureBeforeWake=true
originError="Detached music_generate failed: provider exhausted"
staleReplayAccepted=false
newerRunPreservedWhileWakePending=true
mediaTaskFailed=true
newerRunCompletedOk=true
result=PASS
```

### Configured-store reload boundary

The focused Gateway regression uses real configured stores A and B plus the production store-keyed writer registry. It proves a task admitted under A calls only its captured origin writer after replacement by B, reclassifies only A's originating job, and never creates or mutates that job in B.

### Earlier runtime behavior

The original production symptom was observed on hourly music runs whose detached provider requests failed with high-demand 503s while cron health remained green with `consecutiveErrors: 0`. The current exact-head regression plus the prior runtime proof cover ordering, one-shot receipt, same-millisecond successor identity, replacement-job, configured-store ownership, and current-main merge boundaries.
