### PR TITLE
fix(browser): prevent IME composition from sending copilot messages

### DIFF
--- a/extensions/browser/chrome-extension/sidepanel.e2e-support.ts
+++ b/extensions/browser/chrome-extension/sidepanel.e2e-support.ts
@@ -2,6 +2,30 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+export function isSidePanelTarget(target: { url: string }): boolean {
+  try {
+    return new URL(target.url).pathname.endsWith("/sidepanel.html");
+  } catch {
+    return false;
+  }
+}
+
+export async function resolveChromiumExecutable(): Promise<string | undefined> {
+  const override = process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH?.trim();
+  const candidates = [override, "/usr/bin/chromium-browser", "/usr/bin/chromium"].filter(
+    (candidate): candidate is string => Boolean(candidate),
+  );
+  for (const candidate of candidates) {
+    try {
+      await fs.access(candidate);
+      return candidate;
+    } catch {
+      // Continue to Playwright's managed Chromium.
+    }
+  }
+  return undefined;
+}
+
 export async function copyCopilotSidepanelExtension(tempDirs: {
   make: (prefix: string) => string;
 }): Promise<string> {

--- a/extensions/browser/chrome-extension/sidepanel.e2e.test.ts
+++ b/extensions/browser/chrome-extension/sidepanel.e2e.test.ts
@@ -11,7 +11,11 @@ import {
 } from "../../../packages/gateway-protocol/src/client-info.js";
 import { PROTOCOL_VERSION } from "../../../packages/gateway-protocol/src/version.js";
 import { useAutoCleanupTempDirTracker } from "../test-support.js";
-import { copyCopilotSidepanelExtension } from "./sidepanel.e2e-support.js";
+import {
+  copyCopilotSidepanelExtension,
+  isSidePanelTarget,
+  resolveChromiumExecutable,
+} from "./sidepanel.e2e-support.js";
 
 declare const chrome: {
   runtime: {
@@ -72,18 +76,17 @@ type PanelTarget = {
   disabled: (selector: string) => Promise<boolean>;
   fill: (selector: string, value: string) => Promise<void>;
   hidden: (selector: string) => Promise<boolean>;
+  pressEnter: (
+    selector: string,
+    isComposing: boolean,
+  ) => Promise<{
+    defaultPrevented: boolean;
+    value: string;
+  }>;
   screenshot: (targetPath: string) => Promise<void>;
   text: (selector: string) => Promise<string>;
   wakeBackground: () => Promise<void>;
 };
-
-function isSidePanelTarget(target: TargetInfo): boolean {
-  try {
-    return new URL(target.url).pathname.endsWith("/sidepanel.html");
-  } catch {
-    return false;
-  }
-}
 
 function textValue(value: unknown): string {
   return typeof value === "string" ? value : "";
@@ -360,22 +363,6 @@ async function createFixtureServer(): Promise<{ baseUrl: string; close: () => Pr
   };
 }
 
-async function resolveChromiumExecutable(): Promise<string | undefined> {
-  const override = process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH?.trim();
-  const candidates = [override, "/usr/bin/chromium-browser", "/usr/bin/chromium"].filter(
-    (candidate): candidate is string => Boolean(candidate),
-  );
-  for (const candidate of candidates) {
-    try {
-      await fs.access(candidate);
-      return candidate;
-    } catch {
-      // Continue to Playwright's managed Chromium.
-    }
-  }
-  return undefined;
-}
-
 async function restartServiceWorker(
   browserCdp: CDPSession,
   worker: Worker,
@@ -480,6 +467,15 @@ function createPanelTarget(root: CDPSession, sessionId: string): PanelTarget {
       await evaluate<boolean>(
         `document.querySelector(${selectorExpression(selector)})?.classList.contains("hidden") === true`,
       ),
+    pressEnter: async (selector, isComposing) =>
+      await evaluate<{ defaultPrevented: boolean; value: string }>(`(() => {
+        const input = document.querySelector(${selectorExpression(selector)});
+        const event = new KeyboardEvent("keydown", {
+          key: "Enter", bubbles: true, cancelable: true, isComposing: ${isComposing},
+        });
+        input.dispatchEvent(event);
+        return { defaultPrevented: event.defaultPrevented, value: input.value };
+      })()`),
     screenshot: async (targetPath) => {
       await send("Page.enable");
       const result = await send("Page.captureScreenshot", { format: "png", fromSurface: true });
@@ -723,9 +719,19 @@ describe.runIf(runE2E)("browser copilot Chromium side panel", () => {
         timeout: 15_000,
       })
       .toBe(true);
+    await alphaPanel.fill("#message-input", "にほん");
+    expect(await alphaPanel.pressEnter("#message-input", true)).toEqual({
+      defaultPrevented: false,
+      value: "にほん",
+    });
+    expect(gateway.chatSends).toHaveLength(0);
+    expect(await alphaPanel.allText(".message.user")).toEqual([]);
     await alphaPanel.fill("#message-input", "alpha marker");
     await expect.poll(async () => !(await alphaPanel.disabled("#send-button"))).toBe(true);
-    await alphaPanel.click("#send-button");
+    expect(await alphaPanel.pressEnter("#message-input", false)).toEqual({
+      defaultPrevented: true,
+      value: "",
+    });
     await expect
       .poll(
         async () => ({

--- a/extensions/browser/chrome-extension/sidepanel.js
+++ b/extensions/browser/chrome-extension/sidepanel.js
@@ -244,6 +244,9 @@ input.addEventListener("input", () => {
   setComposerEnabled(panelReady);
 });
 input.addEventListener("keydown", (event) => {
+  if (event.isComposing) {
+    return;
+  }
   if (event.key === "Enter" && !event.shiftKey) {
     event.preventDefault();
     void send();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users typing Japanese, Chinese, Korean, or other composed text in the browser copilot sidebar would accidentally send an unfinished chat message when pressing Enter to confirm an input-method candidate.

## Why This Change Was Made

Ignore keyboard events while Chromium reports an active IME composition, before preventing Enter’s default action or invoking the copilot send handler. Preserve ordinary Enter submission, Shift+Enter, button submission, tab bindings, and existing browser-side consent and session ownership. Move the existing Chromium-executable and side-panel-target helpers into the canonical browser E2E fixture to respect repository size limits without changing their behavior.

## User Impact

IME users can confirm and continue composing text without clearing the field or submitting a message. Regular Enter still sends immediately; the previously merged removed-tab popup regression and complete two-tab consent, gateway, archive, and reconnection flow remain green.

## Evidence

- Direct latest-main base: `1bfd207a5405c38d04b052c8eb7291cadabce99e`; focused head: `f44459233f183709588f5c53ba508d4803ba253b`.
- Independently reproduced before the fix in genuine Chromium with a bound `SIDE_PANEL`, actual copilot Gateway, and `KeyboardEvent({ key: "Enter", isComposing: true, bubbles: true, cancelable: true })`: composing `にほん` incorrectly prevented default and produced one real `chat.send` containing unfinished Japanese text.
- After the fix, the genuine side-panel E2E asserts `defaultPrevented: false`, retained `にほん`, zero Gateway chat sends, and no user chat bubble. The same actual panel then sends `alpha marker` using ordinary Enter with `defaultPrevented: true`.
- Existing complete Chromium side-panel suite: **2/2 passed twice**, including the merged removed-tab popup regression, both tab sessions, sharing and consent, gateway reconnect, abort, archive, and service-worker restart.
- Browser background, copilot controller, session registry, and panel core: **33/33 passed**.
- All three changed files pass `oxfmt`, both extension `tsgo` lanes, ESLint/max-lines, SDK and plugin boundaries, database-first, sidecar, and runtime cycle guards.
- Exact-base complete production/test gate: `CI=1 OPENCLAW_TESTBOX=1 OPENCLAW_TESTBOX_REMOTE_RUN=1 pnpm check:changed --base 1bfd207a5405c38d04b052c8eb7291cadabce99e -- extensions/browser/chrome-extension/sidepanel.js extensions/browser/chrome-extension/sidepanel.e2e.test.ts extensions/browser/chrome-extension/sidepanel.e2e-support.ts`.
- [Checkout-owned complete Blacksmith Testbox proof](https://github.com/openclaw/openclaw/actions/runs/30164567149), lease `tbx_01kyczs544c8rcb9js1rg8jr4v`; authoritative Crabbox timing JSON reports `"exitCode":0`.
- Fresh independent high-effort Codex review and TruffleHog scan: **zero actionable findings**, review confidence **0.98**.
- No permissions, manifest, consent, credentials, configuration, database, schema, protocol, or dependencies changed.
- AI-assisted.