### PR TITLE
fix(browser): clean up failed guarded navigation routes

### DIFF
--- a/extensions/browser/src/browser/pw-session-navigation.ts
+++ b/extensions/browser/src/browser/pw-session-navigation.ts
@@ -449,28 +449,42 @@ export async function gotoPageWithNavigationGuard(
     await continueRouteSafely(route);
   };
 
-  await opts.page.route("**", handler);
   try {
-    const response = await opts.page.goto(opts.url, { timeout: opts.timeoutMs });
-    if (blockedError) {
-      throw toErrorObject(blockedError, "Non-Error thrown");
-    }
-    return response;
+    await opts.page.route("**", handler);
   } catch (err) {
-    if (blockedError) {
-      throw toErrorObject(blockedError, "Non-Error thrown");
-    }
+    // Playwright registers the client route before browser-side setup can fail.
+    // Remove this exact handler without replacing the original setup error.
+    await removePageNavigationRequestGuard(opts.page, handler);
     throw err;
-  } finally {
-    await opts.page.unroute("**", handler).catch(() => {});
-    if (blockedError) {
-      await closeBlockedNavigationTarget({
-        cdpUrl: opts.cdpUrl,
-        page: opts.page,
-        targetId: opts.targetId,
-      });
-    }
   }
+  let response: Response | null = null;
+  let navigationFailed = false;
+  let navigationError: unknown;
+  try {
+    response = await opts.page.goto(opts.url, { timeout: opts.timeoutMs });
+  } catch (err) {
+    navigationFailed = true;
+    navigationError = err;
+  }
+
+  const cleanupError = await removePageNavigationRequestGuard(opts.page, handler);
+  if (blockedError) {
+    await closeBlockedNavigationTarget({
+      cdpUrl: opts.cdpUrl,
+      page: opts.page,
+      targetId: opts.targetId,
+    });
+    throw toErrorObject(blockedError, "Non-Error thrown");
+  }
+  // A live-page cleanup failure is observable, but the original navigation
+  // error owns the result and must not lose its precedence.
+  if (navigationFailed) {
+    throw navigationError;
+  }
+  if (cleanupError !== undefined) {
+    throw toErrorObject(cleanupError, "Non-Error thrown");
+  }
+  return response;
 }
 
 /** Resolve a browser snapshot ref into a Playwright locator. */

--- a/extensions/browser/src/browser/pw-session.create-page.navigation-guard.test.ts
+++ b/extensions/browser/src/browser/pw-session.create-page.navigation-guard.test.ts
@@ -743,6 +743,72 @@ describe("pw-session createPageViaPlaywright navigation guard", () => {
   });
 });
 
+describe("pw-session guarded browser navigation route cleanup", () => {
+  function navigate(page: import("playwright-core").Page) {
+    return gotoPageWithNavigationGuard({
+      cdpUrl: "http://127.0.0.1:18792",
+      page,
+      url: "https://93.184.216.34/start",
+      timeoutMs: 1000,
+    });
+  }
+
+  it("rolls back its exact navigation route when Playwright setup rejects", async () => {
+    const { getRouteHandler, page, pageGoto, pageRoute, pageUnroute } = installBrowserMocks();
+    const installRoute = pageRoute.getMockImplementation();
+    const setupError = new Error("navigation route setup failed");
+    pageRoute.mockImplementationOnce(async (...args) => {
+      await installRoute?.(...args);
+      throw setupError;
+    });
+
+    await expect(navigate(page)).rejects.toBe(setupError);
+
+    expect(pageUnroute).toHaveBeenCalledWith("**", pageRoute.mock.calls[0]?.[1]);
+    expect(getRouteHandler()).toBeNull();
+    expect(pageGoto).not.toHaveBeenCalled();
+  });
+
+  it("surfaces navigation route cleanup failure while the page remains open", async () => {
+    const { page, pageUnroute } = installBrowserMocks();
+    Object.assign(page, { isClosed: () => false });
+    const cleanupError = new Error("navigation route cleanup failed");
+    pageUnroute.mockRejectedValueOnce(cleanupError);
+
+    await expect(navigate(page)).rejects.toBe(cleanupError);
+  });
+
+  it("preserves the original navigation failure when route cleanup also fails", async () => {
+    const { page, pageGoto, pageUnroute } = installBrowserMocks();
+    Object.assign(page, { isClosed: () => false });
+    const navigationError = new Error("browser navigation failed");
+    pageGoto.mockRejectedValueOnce(navigationError);
+    pageUnroute.mockRejectedValueOnce(new Error("navigation route cleanup failed"));
+
+    await expect(navigate(page)).rejects.toBe(navigationError);
+  });
+
+  it("ignores navigation route cleanup failure after the page closes", async () => {
+    const { page, pageUnroute } = installBrowserMocks();
+    Object.assign(page, { isClosed: () => true });
+    pageUnroute.mockRejectedValueOnce(new Error("Target page has been closed"));
+
+    await expect(navigate(page)).resolves.toBeNull();
+  });
+
+  it("preserves blocked-page quarantine when navigation route cleanup fails", async () => {
+    const { getRouteHandler, mainFrame, page, pageClose, pageGoto, pageUnroute } =
+      installBrowserMocks();
+    Object.assign(page, { isClosed: () => false });
+    mockBlockedRedirectNavigation({ pageGoto, getRouteHandler, mainFrame });
+    pageUnroute.mockRejectedValueOnce(new Error("navigation route cleanup failed"));
+
+    await expect(navigate(page)).rejects.toBeInstanceOf(SsrFBlockedError);
+
+    expect(pageClose).toHaveBeenCalledOnce();
+  });
+});
+
 describe("pw-session selected-page interaction request guard", () => {
   const strictPolicy = { dangerouslyAllowPrivateNetwork: false } as const;
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where browser users could be left with a stale request-interception route after Playwright failed to set up guarded navigation. It also fixes successful navigations silently ignoring route-removal failures while the target page remains open, causing later browser requests on that tab to run with inconsistent interception state.

The issue is real for the pinned `playwright-core@1.61.1`: its `Page.route` registers the exact client-side handler before awaiting fallible browser interception setup.

## Why This Change Was Made

Reuse the already existing `removePageNavigationRequestGuard` owner helper and the established sibling post-cleanup decision pattern. Roll back only the failed navigation’s exact route, preserve the original setup or navigation failure, report cleanup failures for live pages, ignore expected cleanup failures after a page closes, and maintain blocked-navigation quarantine and policy precedence.

All result decisions occur after cleanup; no value is returned and no error is thrown from a `finally` block. There are no changes to browser security policy, Chrome or IME code, config, consent, dependencies, persistence, or protocols.

## User Impact

A failed browser navigation no longer leaves behind a hidden interception handler affecting subsequent requests on the same tab. Open-page interception cleanup failures are accurately returned; closed-tab cleanup remains harmless; and blocked targets are still quarantined and closed.

## Evidence

- Base: exact current main `1bfd207a5405c38d04b052c8eb7291cadabce99e`; only the canonical browser-navigation owner and its existing owner test are changed.
- Independently verified the pinned Playwright `1.61.1` upstream source at [`39e3553a4f283a41134d75d7e404484bd9e6865a`](https://github.com/microsoft/playwright/blob/39e3553a4f283a41134d75d7e404484bd9e6865a/packages/playwright-core/src/client/page.ts): `Page.route` registers its handler before the fallible interception-pattern update, and `Page.unroute` removes only the matching handler.
- True isolated regression reproduction against unchanged main: the existing browser owner test suite reports **2 failed, 40 passed**. The failures demonstrate the missing exact-handler rollback after route setup rejection and the swallowed open-page cleanup failure.
- Five real owner regressions verify failed setup rollback, open-page cleanup errors, original navigation-error precedence, closed-page cleanup, and SSRF-blocked target quarantine.
- Final isolated remote proof: **292/292 actual tests passed across 14 browser owner and sibling suites**, including guarded navigation, snapshots, existing-session actions, CDP connections, tab creation, and remote-profile operations.
- Complete exact-branch changed gate: `node scripts/check-changed.mjs --base HEAD -- extensions/browser/src/browser/pw-session-navigation.ts extensions/browser/src/browser/pw-session.create-page.navigation-guard.test.ts`; passed production/test typechecks, formatting, exact-owner lint, dependency/plugin boundaries, and all required guards. Authoritative remote timing: **278,833 ms; exit code 0**.
- Fresh independent final-code autoreview: **0 actionable findings; confidence 0.98**.

```sh
pnpm test \
  extensions/browser/src/browser/pw-session.create-page.navigation-guard.test.ts \
  extensions/browser/src/browser/navigation-guard.test.ts \
  extensions/browser/src/browser/pw-session.assert-navigation-safety.test.ts \
  extensions/browser/src/browser/pw-tools-core.interactions.navigation-guard.test.ts \
  extensions/browser/src/browser/pw-tools-core.snapshot.navigate-guard.test.ts \
  extensions/browser/src/browser/routes/agent.act.existing-session-navigation-guard.test.ts \
  extensions/browser/src/browser/pw-session.termination-cdp-ssrf.test.ts \
  extensions/browser/src/browser/server-context.remote-profile-tab-ops.playwright.test.ts \
  extensions/browser/src/browser/server-context.remote-profile-tab-ops.fallback.test.ts \
  extensions/browser/src/browser/pw-session.connections.test.ts \
  extensions/browser/src/browser/pw-session.test.ts \
  extensions/browser/src/browser/pw-session.page-cdp.test.ts \
  extensions/browser/src/browser/pw-tools-core.browser-ssrf-guard.test.ts \
  extensions/browser/src/browser/pw-tools-core.snapshot.test.ts

node scripts/check-changed.mjs --base HEAD -- \
  extensions/browser/src/browser/pw-session-navigation.ts \
  extensions/browser/src/browser/pw-session.create-page.navigation-guard.test.ts
```

AI-assisted; true-red reproduction, pinned upstream dependency contract, sibling owner semantics, and final cleanup/error precedence independently reviewed.
