### PR TITLE
fix(doctor): report the WhatsApp ack migration that drops an unrepresentable ack scope

### DIFF
--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.retired.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.retired.ts
@@ -363,27 +363,35 @@ function migrateFinalLayoutKills(raw: Record<string, unknown>, changes: string[]
             ? identityEmoji
             : "👀";
     }
-    if (messages.ackReactionScope === undefined) {
-      const direct = ack.direct !== false;
-      const group = ack.group ?? "mentions";
-      const scope =
-        direct && group === "always"
-          ? "all"
-          : direct && group === "never"
-            ? "direct"
-            : !direct && group === "always"
-              ? "group-all"
-              : !direct && group === "mentions"
-                ? "group-mentions"
-                : !direct && group === "never"
-                  ? "off"
-                  : undefined;
-      if (scope) {
-        messages.ackReactionScope = scope;
-      }
+    const direct = ack.direct !== false;
+    const group = ack.group ?? "mentions";
+    const scope =
+      direct && group === "always"
+        ? "all"
+        : direct && group === "never"
+          ? "direct"
+          : !direct && group === "always"
+            ? "group-all"
+            : !direct && group === "mentions"
+              ? "group-mentions"
+              : !direct && group === "never"
+                ? "off"
+                : undefined;
+    const keptScope = messages.ackReactionScope;
+    if (keptScope === undefined && scope) {
+      messages.ackReactionScope = scope;
     }
     delete entry.ackReaction;
     changes.push(`Moved translatable ${path}.ackReaction settings to messages ack settings.`);
+    if (!scope && direct && group === "mentions") {
+      const applied =
+        keptScope === undefined
+          ? `The default "group-mentions" scope now applies and stops acknowledging direct messages.`
+          : `The existing messages.ackReactionScope value ${JSON.stringify(keptScope)} was kept, so it decides WhatsApp acknowledgements instead of the deleted legacy pair.`;
+      changes.push(
+        `${path}.ackReaction acknowledged direct messages plus mentioned groups, and messages.ackReactionScope has no value for that combination. ${applied} No scope keeps both: "direct" acknowledges direct messages but stops acknowledging mentioned groups, and "all" acknowledges direct messages but also acknowledges every group message. messages.ackReactionScope is the global fallback, so changing it also changes acknowledgements on every other channel that has no acknowledgement scope of its own.`,
+      );
+    }
   });
 
   visitChannelEntries(raw, "slack", (entry, path) => {

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.retired.whatsapp-ack.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.retired.whatsapp-ack.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import { LEGACY_CONFIG_MIGRATIONS_RUNTIME_RETIRED } from "./legacy-config-migrations.runtime.retired.js";
+
+function applyRetired(raw: Record<string, unknown>) {
+  const changes: string[] = [];
+  for (const migration of LEGACY_CONFIG_MIGRATIONS_RUNTIME_RETIRED) {
+    migration.apply(raw, changes);
+  }
+  return { raw, changes };
+}
+
+const MOVED_CHANGE =
+  "Moved translatable channels.whatsapp.ackReaction settings to messages ack settings.";
+
+const UNREPRESENTABLE_PREFIX =
+  "channels.whatsapp.ackReaction acknowledged direct messages plus mentioned groups, and messages.ackReactionScope has no value for that combination.";
+
+const UNREPRESENTABLE_SUFFIX =
+  'No scope keeps both: "direct" acknowledges direct messages but stops acknowledging mentioned groups, and "all" acknowledges direct messages but also acknowledges every group message. messages.ackReactionScope is the global fallback, so changing it also changes acknowledgements on every other channel that has no acknowledgement scope of its own.';
+
+const DEFAULT_SCOPE_CHANGE = `${UNREPRESENTABLE_PREFIX} The default "group-mentions" scope now applies and stops acknowledging direct messages. ${UNREPRESENTABLE_SUFFIX}`;
+
+function keptScopeChange(scope: string) {
+  return `${UNREPRESENTABLE_PREFIX} The existing messages.ackReactionScope value "${scope}" was kept, so it decides WhatsApp acknowledgements instead of the deleted legacy pair. ${UNREPRESENTABLE_SUFFIX}`;
+}
+
+describe("retired WhatsApp ack reaction migration", () => {
+  it("flags the legacy ack combination no canonical scope represents", () => {
+    const result = applyRetired({
+      channels: {
+        whatsapp: { ackReaction: { emoji: "👀", direct: true, group: "mentions" } },
+      },
+    });
+
+    expect(result.raw).not.toHaveProperty("channels.whatsapp.ackReaction");
+    expect(result.raw).toHaveProperty("messages.ackReaction", "👀");
+    expect(result.raw).not.toHaveProperty("messages.ackReactionScope");
+    expect(result.changes).toStrictEqual([MOVED_CHANGE, DEFAULT_SCOPE_CHANGE]);
+  });
+
+  it("flags the emoji-only legacy ack object that inherits both defaults", () => {
+    const result = applyRetired({
+      channels: { whatsapp: { ackReaction: { emoji: "👀" } } },
+    });
+
+    expect(result.raw).not.toHaveProperty("messages.ackReactionScope");
+    expect(result.changes).toContain(DEFAULT_SCOPE_CHANGE);
+  });
+
+  it("names both lossy recovery scopes and the fallback reach of the shared scope", () => {
+    const result = applyRetired({
+      channels: {
+        whatsapp: { ackReaction: { emoji: "👀", direct: true, group: "mentions" } },
+      },
+    });
+    const warning = result.changes.at(-1) ?? "";
+
+    expect(warning).toContain(
+      '"direct" acknowledges direct messages but stops acknowledging mentioned groups',
+    );
+    expect(warning).toContain(
+      '"all" acknowledges direct messages but also acknowledges every group message',
+    );
+    expect(warning).toContain(
+      "messages.ackReactionScope is the global fallback, so changing it also changes acknowledgements on every other channel that has no acknowledgement scope of its own",
+    );
+  });
+
+  it("migrates representable legacy ack scopes without extra notes", () => {
+    const result = applyRetired({
+      channels: {
+        whatsapp: { ackReaction: { emoji: "👀", direct: true, group: "never" } },
+      },
+    });
+
+    expect(result.raw).toHaveProperty("messages.ackReactionScope", "direct");
+    expect(result.changes).toStrictEqual([MOVED_CHANGE]);
+  });
+
+  it.each(["all", "direct", "group-mentions", "off"])(
+    "reports the retained %s scope instead of claiming a lossless move",
+    (scope) => {
+      const result = applyRetired({
+        messages: { ackReactionScope: scope },
+        channels: {
+          whatsapp: { ackReaction: { emoji: "👀", direct: true, group: "mentions" } },
+        },
+      });
+
+      expect(result.raw).toHaveProperty("messages.ackReactionScope", scope);
+      expect(result.changes).toStrictEqual([MOVED_CHANGE, keptScopeChange(scope)]);
+    },
+  );
+
+  it("keeps a canonical scope quiet when the legacy pair is representable", () => {
+    const result = applyRetired({
+      messages: { ackReactionScope: "all" },
+      channels: {
+        whatsapp: { ackReaction: { emoji: "👀", direct: false, group: "always" } },
+      },
+    });
+
+    expect(result.raw).toHaveProperty("messages.ackReactionScope", "all");
+    expect(result.changes).toStrictEqual([MOVED_CHANGE]);
+  });
+});


### PR DESCRIPTION
Closes #112796

## What Problem This Solves

Fixes an issue where operators whose config still carries the legacy `channels.whatsapp.ackReaction` object lose acknowledgement behavior after doctor migrates it, with nothing in the doctor output saying so. The legacy pair `direct: true` with `group: "mentions"` means "acknowledge DMs plus mentioned groups", and `messages.ackReactionScope` has no value that means that. Doctor deletes the legacy object anyway and reports a clean move.

Two operator-visible outcomes follow from the same gap:

- No canonical scope set: nothing is written, the runtime default `"group-mentions"` applies, and WhatsApp DMs silently stop getting the ack reaction. That legacy pair is also the legacy default, so a plain `ackReaction: { "emoji": "..." }` entry hits it too.
- A canonical `messages.ackReactionScope` already set: canonical-wins keeps it, the legacy pair is deleted, and the report still claims a clean move even though the retained scope means something different from the legacy intent.

Either way the original intent is gone from the config and gone from the output.

## Why This Change Was Made

`src/commands/doctor/shared/legacy-config-migrations.runtime.retired.ts` maps the legacy `{direct, group}` pair onto `messages.ackReactionScope`, but the ladder covers five of the six legacy combinations and falls through to `undefined` for `direct: true` plus `group: "mentions"`.

The fall-through is not an oversight in the enum lookup: `messages.ackReactionScope` genuinely has no value that means "direct messages plus mentioned groups". `all` also acknowledges every group message, `direct` drops group acknowledgements, and `group-mentions` excludes DMs by design (`src/channels/ack-reactions.ts:51`). So the legacy combination cannot be migrated losslessly, and `messages.ackReactionScope` is the shared fallback that every channel without its own acknowledgement scope reads, so remapping it here would silently change ack behavior for those channels on the same config.

This change therefore keeps the migrated shape exactly as it is and makes doctor report the one thing it was hiding, on both branches of the ladder. The `direct`/`group` read and the scope ladder move out of the `messages.ackReactionScope === undefined` guard, the assignment stays behind it so canonical-wins is unchanged, and the report names which scope actually decides:

```ts
const keptScope = messages.ackReactionScope;
if (keptScope === undefined && scope) {
  messages.ackReactionScope = scope;
}
delete entry.ackReaction;
changes.push(`Moved translatable ${path}.ackReaction settings to messages ack settings.`);
if (!scope && direct && group === "mentions") {
  const applied =
    keptScope === undefined
      ? `The default "group-mentions" scope now applies and stops acknowledging direct messages.`
      : `The existing messages.ackReactionScope value ${JSON.stringify(keptScope)} was kept, so it decides WhatsApp acknowledgements instead of the deleted legacy pair.`;
  changes.push(`${path}.ackReaction acknowledged direct messages plus mentioned groups, and messages.ackReactionScope has no value for that combination. ${applied} No scope keeps both: ...`);
}
```

`JSON.stringify(keptScope)` rather than string interpolation because `messages` is a raw pre-validation record, so a non-string value there still renders honestly instead of reading as a quoted scope name.

The closing sentence stays scoped to the fallback, not to every channel. Discord resolves `channels.discord.<account>.ackReactionScope` before the shared value (`extensions/discord/src/monitor/message-dispatcher.ts:74`), and Matrix resolves account then channel scope before it (`extensions/matrix/src/matrix/monitor/ack-config.ts:23`), so an operator who already set a per-channel scope there is not affected by the recovery value this note suggests.

No config key, enum value, or runtime shim is added. The five representable combinations migrate exactly as before and stay quiet, including when a canonical scope shadows them. The whatsapp block is the only legacy `ackReaction` migration in the doctor retired-migration set, so there is no sibling channel surface with the same unrepresentable-scope gap.

Production delta is +26/-18, net +8 lines, all of it the report path and the guard restructure that makes one report cover both branches.

## User Impact

Operators upgrading from the legacy WhatsApp ack object now see, in the doctor changes block, that the legacy "DMs plus mentioned groups" pair has no shared equivalent, which scope actually took effect and where it came from, which two values are the closest recoveries, what each of those two values costs, and how far the shared setting reaches. Nothing about the resulting config or the runtime ack behavior changes, so no existing setup shifts behavior because of this PR.

## Evidence

Real environment tested: head `49016073cd55f30c48eb7b2665597af09fb23947` rebased onto `main` `fd353ee5d772385d107cbaaef9e7be683c62ef32`, macOS 15 (arm64), Node 26.0.0.

Behavior addressed: doctor migrates the legacy `channels.whatsapp.ackReaction` combination `{direct: true, group: "mentions"}` and reports a clean move, both when it supplies the default scope and when it retains an existing canonical scope, while neither outcome reproduces the legacy acknowledgement behavior.

Exact steps or command run after this patch: the production migration runner doctor calls, `applyLegacyDoctorMigrations` from `src/commands/doctor/shared/legacy-config-compat.ts`, which is also what every config load goes through via `src/config/io.context.ts`, driven against an isolated `OPENCLAW_STATE_DIR` holding each config file below, once on the pristine tree at `fd353ee5d77` and once with this patch applied, identical input both times. The resulting acknowledgement behavior was read out of the real runtime gate `shouldAckReaction` from `src/channels/ack-reactions.ts`.

Input config files on disk, scenario A then scenario B:

```json
{
  "channels": {
    "whatsapp": {
      "ackReaction": { "direct": true, "group": "mentions", "emoji": "👀" }
    }
  }
}
```

```json
{
  "messages": { "ackReactionScope": "all" },
  "channels": {
    "whatsapp": {
      "ackReaction": { "direct": true, "group": "mentions", "emoji": "👀" }
    }
  }
}
```

Evidence before fix (pristine tree at `fd353ee5d77`):

```
--- scenario A. legacy direct-plus-mentions pair, no canonical messages.ackReactionScope
doctor migration changes reported to the operator:
  - Moved translatable channels.whatsapp.ackReaction settings to messages ack settings.
config on disk after doctor migration:
{
  "channels": {
    "whatsapp": {}
  },
  "messages": {
    "ackReaction": "👀"
  }
}
effective messages.ackReactionScope after migration: undefined (runtime default group-mentions)
inbound WhatsApp messages the runtime gate acknowledges: group message mentioning the agent
  with scope "direct": direct message
  with scope "all": direct message, group message mentioning the agent, group message not mentioning the agent

--- scenario B. same legacy pair, canonical messages.ackReactionScope already set to "all"
doctor migration changes reported to the operator:
  - Moved translatable channels.whatsapp.ackReaction settings to messages ack settings.
config on disk after doctor migration:
{
  "messages": {
    "ackReactionScope": "all",
    "ackReaction": "👀"
  },
  "channels": {
    "whatsapp": {}
  }
}
effective messages.ackReactionScope after migration: "all"
inbound WhatsApp messages the runtime gate acknowledges: direct message, group message mentioning the agent, group message not mentioning the agent
  with scope "direct": direct message
  with scope "all": direct message, group message mentioning the agent, group message not mentioning the agent
```

Observed result before fix: both scenarios tell the operator only that the setting moved. In A the migrated config carries no `messages.ackReactionScope`, so the runtime gate acknowledges group mentions and silently stops acknowledging direct messages. In B the retained `"all"` scope acknowledges every group message, which the legacy pair never did, and the deleted legacy intent is unrecoverable from the output. Nothing in either report says a value was dropped or which value now decides.

Evidence after fix:

```
--- scenario A. legacy direct-plus-mentions pair, no canonical messages.ackReactionScope
doctor migration changes reported to the operator:
  - Moved translatable channels.whatsapp.ackReaction settings to messages ack settings.
  - channels.whatsapp.ackReaction acknowledged direct messages plus mentioned groups, and messages.ackReactionScope has no value for that combination. The default "group-mentions" scope now applies and stops acknowledging direct messages. No scope keeps both: "direct" acknowledges direct messages but stops acknowledging mentioned groups, and "all" acknowledges direct messages but also acknowledges every group message. messages.ackReactionScope is the global fallback, so changing it also changes acknowledgements on every other channel that has no acknowledgement scope of its own.
config on disk after doctor migration:
{
  "channels": {
    "whatsapp": {}
  },
  "messages": {
    "ackReaction": "👀"
  }
}
effective messages.ackReactionScope after migration: undefined (runtime default group-mentions)
inbound WhatsApp messages the runtime gate acknowledges: group message mentioning the agent
  with scope "direct": direct message
  with scope "all": direct message, group message mentioning the agent, group message not mentioning the agent

--- scenario B. same legacy pair, canonical messages.ackReactionScope already set to "all"
doctor migration changes reported to the operator:
  - Moved translatable channels.whatsapp.ackReaction settings to messages ack settings.
  - channels.whatsapp.ackReaction acknowledged direct messages plus mentioned groups, and messages.ackReactionScope has no value for that combination. The existing messages.ackReactionScope value "all" was kept, so it decides WhatsApp acknowledgements instead of the deleted legacy pair. No scope keeps both: "direct" acknowledges direct messages but stops acknowledging mentioned groups, and "all" acknowledges direct messages but also acknowledges every group message. messages.ackReactionScope is the global fallback, so changing it also changes acknowledgements on every other channel that has no acknowledgement scope of its own.
config on disk after doctor migration:
{
  "messages": {
    "ackReactionScope": "all",
    "ackReaction": "👀"
  },
  "channels": {
    "whatsapp": {}
  }
}
effective messages.ackReactionScope after migration: "all"
inbound WhatsApp messages the runtime gate acknowledges: direct message, group message mentioning the agent, group message not mentioning the agent
  with scope "direct": direct message
  with scope "all": direct message, group message mentioning the agent, group message not mentioning the agent
```

Observed result after fix: both migrated config files are byte-identical to the pristine run, so no operator's effective configuration changes and canonical-wins is preserved. The reported changes now name the dropped legacy pair in both branches and say which scope decides, the supplied default in A and the retained `"all"` in B. The runtime gate rows confirm each claim in that sentence: `direct` acknowledges only the direct message, `all` acknowledges the direct message plus both group cases, and neither reproduces the legacy "DMs plus mentioned groups" pair.

What was not tested: no live WhatsApp session was connected, so the reaction send itself was not observed on a real account; the acknowledgement decision was read from the production gate rather than from a delivered reaction. A full build was not run; this change adds no module boundary, dynamic import, or published surface.

### Focused checks on this branch

- `node scripts/run-vitest.mjs src/commands/doctor/shared/legacy-config-migrations.runtime.retired.whatsapp-ack.test.ts src/commands/doctor/shared/legacy-config-migrations.runtime.retired.test.ts`: 108 passed, run after the rebase onto `fd353ee5d77`. The 7 new and rewritten cases in the topic file fail against the pristine production file for the intended reason.
- `oxlint` and `oxfmt --check` on the changed files: clean.
- `node scripts/run-tsgo.mjs -p tsconfig.core.json`: clean, exit 0.
- The regression coverage lives in a topic-scoped sibling file, `legacy-config-migrations.runtime.retired.whatsapp-ack.test.ts`. Adding the cases to the shared `legacy-config-migrations.runtime.retired.test.ts` pushed it past the repo's 1000-line cap for spec files, and the repo already splits that suite by topic.

### Overlap note

#119501 rewrites the `Moved translatable ...` change line in the same whatsapp block for the different case where canonical `messages` keys shadow a **representable** legacy mapping, and its own body states it deliberately does not touch this unrepresentable branch. This PR adds a second `changes.push` after that line and never edits it, so the two compose; whichever lands second needs a mechanical rebase of that one region.
