### PR TITLE
fix(meta): prevent catalog scan failures from unsupported inputs

### DIFF
--- a/docs/providers/meta.md
+++ b/docs/providers/meta.md
@@ -68,13 +68,13 @@ openclaw onboard --non-interactive --accept-risk \
 
 ## Built-in catalog
 
-| Model ref             | Name           | Input                          | Reasoning | Context window | Max output | Input / cached input / output per 1M tokens |
-| --------------------- | -------------- | ------------------------------ | --------- | -------------- | ---------- | ------------------------------------------- |
-| `meta/muse-spark-1.1` | Muse Spark 1.1 | text, image, video, audio, PDF | yes       | 1,048,576      | 131,072    | $1.25 / $0.15 / $4.25                       |
+| Model ref             | Name           | Input       | Reasoning | Context window | Max output | Input / cached input / output per 1M tokens |
+| --------------------- | -------------- | ----------- | --------- | -------------- | ---------- | ------------------------------------------- |
+| `meta/muse-spark-1.1` | Muse Spark 1.1 | text, image | yes       | 1,048,576      | 131,072    | $1.25 / $0.15 / $4.25                       |
 
 Capabilities:
 
-- Text, image, video, audio, and PDF input
+- Text and image input
 - Tool calling and streaming
 - Reasoning effort: `minimal`, `low`, `medium`, `high`, `xhigh` (default: `high`)
 - Stateless encrypted reasoning replay (`store: false`, `include: ["reasoning.encrypted_content"]`)

--- a/extensions/meta/index.test.ts
+++ b/extensions/meta/index.test.ts
@@ -44,7 +44,7 @@ describe("meta provider", () => {
     expect(model.contextWindow).toBe(1048576);
     expect(model.maxTokens).toBe(131072);
     expect(model.reasoning).toBe(true);
-    expect(model.input).toEqual(["text", "image", "video", "audio", "document"]);
+    expect(model.input).toEqual(["text", "image"]);
     expect(model.cost).toEqual({
       input: 1.25,
       output: 4.25,

--- a/extensions/meta/openclaw.plugin.json
+++ b/extensions/meta/openclaw.plugin.json
@@ -34,8 +34,7 @@
             "reasoning": true,
             "input": [
               "text",
-              "image",
-              "document"
+              "image"
             ],
             "contextWindow": 1048576,
             "maxTokens": 131072,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where local agent runs aborted during plugin catalog loading because the bundled Meta provider advertised a `document` model input that the runtime provider-config contract explicitly rejects.

This made the beta.5 release performance gate fail before any provider request with `Manifest modelCatalog row muse-spark-1.1 uses unsupported runtime input document`.

Regression from #113681.

## Why This Change Was Made

Keep the fix at the Meta plugin owner boundary: advertise only the text and image modalities that the runtime model definition can consume, and align the provider test and public docs. The core runtime contract remains strict, so future unsupported manifest capabilities still fail closed instead of being silently dropped.

## User Impact

Agent runs no longer abort while loading the Meta catalog, and Meta's documented model capabilities match the inputs OpenClaw can currently route at runtime.

## Evidence

- Release failure: https://github.com/openclaw/openclaw/actions/runs/30165674296/job/89698173936
- Exact error reproduced in all three Kova agent-turn attempts before any mock-provider request.
- `fnm exec --using 24 node scripts/run-vitest.mjs extensions/meta/index.test.ts` — 3 tests passed.
- `git diff --check` — clean.
- Codex autoreview — clean, no accepted/actionable findings.
