### PR TITLE
fix(ui): remove stale harness names from session setting

### DIFF
--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -3921,7 +3921,7 @@ export const en: TranslationMap = {
     followUpModeUsingServer: "Using server default ({mode})",
     followUpModeOverriding: "Overriding server default ({mode})",
     followUpModeReset: "Reset to server default",
-    catalogOpenTarget: "Open Codex/Claude threads in",
+    catalogOpenTarget: "Open external sessions in",
     catalogOpenTargetViewer: "OpenClaw viewer",
     catalogOpenTargetTerminal: "Terminal",
     onboardingDisabled: "Disabled during setup",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users configuring how external session catalogs open would see a label that named only Codex and Claude, even though the same setting also applies to OpenCode and Pi.

## Why This Change Was Made

The label now says "Open external sessions in", matching the catalog-agnostic viewer or terminal behavior without enumerating harnesses. Generated locale artifacts stay isolated per the repository's locale workflow and will be refreshed in the follow-up generated PR.

## User Impact

The Appearance setting accurately describes all supported external session catalogs and will remain correct as catalog providers change.

## Evidence

- `node scripts/check-changed.mjs` passed on Blacksmith Testbox (`tbx_01kyd1rnejncd6807k486vd1hb`, run 30165736777), including Control UI catalog verification, formatting, typechecks, and lint.
- Codex autoreview passed with no accepted or actionable findings.
- `git diff --check` passed.
