### PR TITLE
fix(release): handle large preparation diffs

### DIFF
--- a/scripts/release-prepare.ts
+++ b/scripts/release-prepare.ts
@@ -40,6 +40,7 @@ type WorktreeState = {
 
 const DEFAULT_JOBS = 4;
 const MAX_JOBS = 16;
+const GIT_OUTPUT_MAX_BUFFER_BYTES = 64 * 1024 * 1024;
 
 export function parseReleasePrepareArgs(argv: string[]): ReleasePrepareArgs {
   let android = false;
@@ -298,7 +299,7 @@ export function runReleasePrepareStep(
   return result.status ?? 1;
 }
 
-function readWorktreeState(rootDir: string): WorktreeState {
+export function readWorktreeState(rootDir: string): WorktreeState {
   const head = git(rootDir, ["rev-parse", "HEAD"]);
   const status = git(rootDir, ["status", "--porcelain=v1", "--untracked-files=all"]);
   const diff = git(rootDir, ["diff", "--binary", "HEAD"]);
@@ -334,6 +335,9 @@ function git(cwd: string, args: string[]): string {
     cwd,
     encoding: "utf8",
     env: process.env,
+    // Version preparation can legitimately create multi-megabyte generated diffs.
+    // Keep the fingerprint capture bounded without inheriting Node's 1 MiB default.
+    maxBuffer: GIT_OUTPUT_MAX_BUFFER_BYTES,
     stdio: ["ignore", "pipe", "pipe"],
   });
   if (result.status !== 0) {

--- a/test/scripts/release-prepare.test.ts
+++ b/test/scripts/release-prepare.test.ts
@@ -1,3 +1,7 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 // Release prepare tests cover shadow planning, cutover commands, and candidate manifests.
 import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it, vi } from "vitest";
@@ -5,6 +9,7 @@ import {
   buildReleasePreparationManifest,
   createReleasePrepareSteps,
   parseReleasePrepareArgs,
+  readWorktreeState,
   runReleasePrepareStep,
   runReleasePrepareSteps,
 } from "../../scripts/release-prepare.ts";
@@ -159,6 +164,29 @@ describe("release preparation plan", () => {
 });
 
 describe("release preparation manifest", () => {
+  it("fingerprints generated diffs larger than Node's default child buffer", () => {
+    const rootDir = mkdtempSync(path.join(tmpdir(), "openclaw-release-prepare-"));
+    try {
+      execFileSync("git", ["init", "-q"], { cwd: rootDir });
+      execFileSync("git", ["config", "user.email", "release-test@openclaw.invalid"], {
+        cwd: rootDir,
+      });
+      execFileSync("git", ["config", "user.name", "OpenClaw Release Test"], { cwd: rootDir });
+      writeFileSync(path.join(rootDir, "package.json"), '{"version":"2026.7.2"}\n');
+      writeFileSync(path.join(rootDir, "generated.txt"), `${"a".repeat(2 * 1024 * 1024)}\n`);
+      execFileSync("git", ["add", "."], { cwd: rootDir });
+      execFileSync("git", ["commit", "-q", "-m", "test fixture"], { cwd: rootDir });
+      writeFileSync(path.join(rootDir, "generated.txt"), `${"b".repeat(2 * 1024 * 1024)}\n`);
+
+      const state = readWorktreeState(rootDir);
+
+      expect(state.changedFiles).toEqual(["generated.txt"]);
+      expect(state.fingerprint).toMatch(/^[0-9a-f]{64}$/u);
+    } finally {
+      rmSync(rootDir, { force: true, recursive: true });
+    }
+  });
+
   it("binds the plan to the exact source and worktree fingerprint", () => {
     const steps = runReleasePrepareSteps({
       cwd: "/repo",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `release:prepare` cannot fingerprint its own legitimate multi-megabyte generated diff because Node's default synchronous child-process buffer is only 1 MiB.

## Why This Change Was Made

Raise only the bounded Git-output capture used by the release candidate fingerprint to 64 MiB and add a regression test with a 2 MiB generated diff. No release policy or product behavior changes.

## User Impact

Release preparation can complete after large generated version or localization updates instead of aborting with `git diff --binary HEAD failed`.

## Evidence

- `fnm exec --using 24 node scripts/run-vitest.mjs test/scripts/release-prepare.test.ts` — 8 tests passed.
- A full beta.5 `release:prepare --write` and clean-commit `--check` both passed with the fix.
- Codex autoreview — clean, no accepted/actionable findings.
