### PR TITLE
fix(doctor): validate bundled provider catalogs

### DIFF
--- a/src/flows/doctor-core-checks.runtime.bundled.test.ts
+++ b/src/flows/doctor-core-checks.runtime.bundled.test.ts
@@ -1,0 +1,42 @@
+// Doctor bundled provider tests ensure every shipped manifest catalog projects into runtime rows.
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { buildManifestModelProviderConfig } from "../plugin-sdk/provider-catalog-shared.js";
+
+const repoRoot = fileURLToPath(new URL("../..", import.meta.url));
+const extensionsDir = path.join(repoRoot, "extensions");
+
+describe("doctor bundled provider catalog validation", () => {
+  it("accepts every bundled manifest provider catalog", () => {
+    const errors: string[] = [];
+
+    for (const extension of fs.readdirSync(extensionsDir, { withFileTypes: true })) {
+      if (!extension.isDirectory()) {
+        continue;
+      }
+      const manifestPath = path.join(extensionsDir, extension.name, "openclaw.plugin.json");
+      if (!fs.existsSync(manifestPath)) {
+        continue;
+      }
+      const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8")) as {
+        id?: string;
+        providers?: string[];
+        modelCatalog?: { providers?: Record<string, unknown> };
+      };
+      for (const [providerId, catalog] of Object.entries(manifest.modelCatalog?.providers ?? {})) {
+        if (!manifest.providers?.includes(providerId)) {
+          continue;
+        }
+        try {
+          buildManifestModelProviderConfig({ providerId, catalog });
+        } catch (error) {
+          errors.push(`${manifest.id ?? extension.name}/${providerId}: ${String(error)}`);
+        }
+      }
+    }
+
+    expect(errors).toEqual([]);
+  });
+});


### PR DESCRIPTION
Related: #113758

## What Problem This Solves

Fixes an issue where bundled provider manifest/runtime mismatches could reach `main` and make `openclaw doctor` reject an enabled provider. PR #113758 repaired the Meta catalog regression from #113681, but the repository still had no fleet-wide test proving every bundled provider-owned manifest catalog projects into the runtime shape doctor validates.

## Why This Change Was Made

Add one doctor-focused contract test that scans every bundled plugin manifest and projects each catalog belonging to a declared runtime provider through the canonical `buildManifestModelProviderConfig` path. CLI-backend-only catalogs are intentionally excluded because they are not runtime provider configs.

## User Impact

There is no direct runtime behavior change. Future bundled catalog rows that doctor cannot consume now fail in CI before they can block operator upgrades or deployments.

## Evidence

- Before #113758, the new test failed with `meta/meta: Error: Manifest modelCatalog row muse-spark-1.1 uses unsupported runtime input document`.
- `node scripts/run-vitest.mjs src/flows/doctor-core-checks.runtime.bundled.test.ts` — 1 test passed.
- Blacksmith Testbox `tbx_01kyd3fmpk74w0qrdtjq7dxjxw`: full build passed, packaged doctor accepted the enabled Meta provider, and the bundled-manifest plus Meta focused tests passed. The subsequent changed gate stopped only on a max-lines baseline made stale by concurrent #113713; current `origin/main` contains that cleanup.
- Codex autoreview on the final one-file branch diff: clean, no accepted/actionable findings.
