### PR TITLE
fix: preserve streamed attachment MIME types from response filenames

### DIFF
--- a/src/media/fetch.test.ts
+++ b/src/media/fetch.test.ts
@@ -846,6 +846,134 @@ describe("readRemoteMediaBuffer", () => {
     await expect(fs.readFile(saved.path)).resolves.toStrictEqual(Buffer.from([1, 2, 3, 4]));
   });
 
+  it("preserves content-disposition CSV detection for streamed downloads", async () => {
+    const csv = Buffer.from("name,value\nopenclaw,1\n");
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(makeStream([csv.subarray(0, 8), csv.subarray(8)]), {
+          status: 200,
+          headers: {
+            "content-disposition": 'attachment; filename="report.csv"',
+            "content-type": "application/octet-stream",
+          },
+        }),
+    );
+
+    const saved = await saveRemoteMedia({
+      url: "https://example.com/download",
+      fetchImpl,
+      lookupFn: makeLookupFn(),
+      maxBytes: 64,
+    });
+
+    expect(saved.fileName).toBe("report.csv");
+    expect(saved.contentType).toBe("text/csv");
+    expect(saved.path).toMatch(/[a-f0-9-]{36}\.csv$/);
+    expect(saved.path).not.toMatch(/report---/);
+    await expect(fs.readFile(saved.path)).resolves.toStrictEqual(csv);
+  });
+
+  it("preserves content-disposition CSV detection for provided response streams", async () => {
+    const csv = Buffer.from("name,value\nopenclaw,1\n");
+    const response = new Response(makeStream([csv.subarray(0, 8), csv.subarray(8)]), {
+      status: 200,
+      headers: {
+        "content-disposition": 'attachment; filename="report.csv"',
+        "content-type": "application/octet-stream",
+      },
+    });
+
+    const saved = await saveResponseMedia(response, {
+      sourceUrl: "https://example.com/download",
+      maxBytes: 64,
+    });
+
+    expect(saved.fileName).toBe("report.csv");
+    expect(saved.contentType).toBe("text/csv");
+    expect(saved.path).toMatch(/[a-f0-9-]{36}\.csv$/);
+    await expect(fs.readFile(saved.path)).resolves.toStrictEqual(csv);
+  });
+
+  it("preserves content-disposition CSV detection for buffered downloads", async () => {
+    const csv = Buffer.from("name,value\nopenclaw,1\n");
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(makeStream([csv.subarray(0, 8), csv.subarray(8)]), {
+          status: 200,
+          headers: {
+            "content-disposition": 'attachment; filename="report.csv"',
+            "content-type": "application/octet-stream",
+          },
+        }),
+    );
+
+    const media = await readRemoteMediaBuffer({
+      url: "https://example.com/download",
+      fetchImpl,
+      lookupFn: makeLookupFn(),
+      maxBytes: 64,
+    });
+
+    expect(media.fileName).toBe("report.csv");
+    expect(media.contentType).toBe("text/csv");
+    expect(media.buffer).toStrictEqual(csv);
+  });
+
+  it("keeps explicit stream detection hints ahead of content-disposition filenames", async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(makeStream([new Uint8Array([1, 2, 3])]), {
+          status: 200,
+          headers: {
+            "content-disposition": 'attachment; filename="report.csv"',
+            "content-type": "application/octet-stream",
+          },
+        }),
+    );
+
+    const saved = await saveRemoteMedia({
+      url: "https://example.com/download",
+      fetchImpl,
+      lookupFn: makeLookupFn(),
+      filePathHint: "document.docx",
+      maxBytes: 8,
+    });
+
+    expect(saved.fileName).toBe("report.csv");
+    expect(saved.contentType).toBe(
+      "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    );
+    expect(saved.path).toMatch(/[a-f0-9-]{36}\.docx$/);
+    expect(saved.path).not.toMatch(/\.csv$/);
+  });
+
+  it("keeps byte-sniffed images ahead of content-disposition stream hints", async () => {
+    const jpeg = Buffer.from([0xff, 0xd8, 0xff, 0x00]);
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(makeStream([jpeg]), {
+          status: 200,
+          headers: {
+            "content-disposition": 'attachment; filename="report.csv"',
+            "content-type": "application/octet-stream",
+          },
+        }),
+    );
+
+    const saved = await saveRemoteMedia({
+      url: "https://example.com/download",
+      fetchImpl,
+      lookupFn: makeLookupFn(),
+      maxBytes: 8,
+    });
+
+    expect(saved.fileName).toBe("report.csv");
+    expect(saved.contentType).toBe("image/jpeg");
+    expect(saved.path).toMatch(/[a-f0-9-]{36}\.jpg$/);
+    expect(saved.path).not.toMatch(/\.csv$/);
+    await expect(fs.readFile(saved.path)).resolves.toStrictEqual(jpeg);
+  });
+
   it("keeps saving a healthy streaming body after the response-header deadline", async () => {
     vi.useFakeTimers();
     try {

--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -478,7 +478,7 @@ async function saveOkMediaResponse(params: {
     fallbackContentType: params.fallbackContentType,
   });
   const detectionFilePathHint = isGenericResponseContentType(contentType)
-    ? params.filePathHint
+    ? (params.filePathHint ?? fileName)
     : undefined;
   try {
     const saved = params.res.body


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users receiving streamed file attachments would have a valid `Content-Disposition` filename such as `report.csv` but still see `application/octet-stream` and an extensionless stored file when the server provides a generic content type. The same attachment already works correctly through the buffered download path. Both guarded remote URL downloads and caller-provided streamed `Response` objects are affected.

## Why This Change Was Made

Pass the already-canonical, safely parsed response filename to the existing media-store MIME detector only when the response content type is generic and the caller did not supply an explicit detection hint. This fixes both streaming entry points at their existing common owner without changing fetch guards, storage paths, provider configuration, or transport-specific plugins.

The pinned upstream `file-type` contract explicitly detects binary signatures and does not detect text-based formats such as CSV, so the canonical filename is required for correct text attachment detection. Existing binary sniffing continues to take precedence over potentially misleading filenames.

## User Impact

Streamed CSV and similarly named text attachments are saved and exposed with their correct MIME type and extension across actual Slack, Discord, Telegram, and Microsoft Teams media callers. Explicit caller-supplied hints remain authoritative; actual JPEG bytes disguised as `report.csv` continue to be stored as JPEG.

## Evidence

- Reproduced against immutable current `main` `e2790760102aee5d99504bce640a5b3160df5331`: the actual guarded streamed URL and direct-`Response` regression tests fail while the other **53** owner cases pass. Both failures observe `application/octet-stream` instead of `text/csv`.
- The fixed owner suite passes **55/55**, covering streamed URL, direct `Response`, buffered parity, explicit hint precedence, and JPEG magic-byte precedence.
- A fresh Linux Blacksmith Testbox passes **717/717** actual regressions across **20** files and **7** Vitest shards, including core media persistence, MIME detection, SSRF and pinned DNS, redirects, timeouts, input-file guards, and actual Slack, Discord, Telegram, and Microsoft Teams caller suites.
- The complete current-head `pnpm check:changed` passes on the same fresh remote Testbox (`exitCode: 0`), including production and test typechecking, exact-file formatting and lint, the media-download-helper guard, import cycles, plugin ownership boundaries, dependency pins, and all compatibility ratchets.
- A fresh independent Codex structured autoreview of the exact committed two-file diff reports **no accepted or actionable findings**, `patch is correct`, confidence **0.94**; the official TruffleHog scan of that exact diff is clean.
- Confirmed the exact pinned upstream [`file-type` 22.0.1 detection contract](https://github.com/sindresorhus/file-type/blob/v22.0.1/readme.md): binary magic-byte detection does not infer `.csv` or other text formats.

AI-assisted; independently reproduced, source- and dependency-reviewed, and remotely validated.
