### PR TITLE
fix(native): keep images and voice notes visible in chat and exports

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -40003,7 +40003,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 635,
+      "line": 628,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Voice note",
       "surface": "apple",
@@ -40011,7 +40011,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 692,
+      "line": 685,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Writing",
       "surface": "apple",
@@ -40019,7 +40019,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 726,
+      "line": 719,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Preparing audio…",
       "surface": "apple",
@@ -40027,7 +40027,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 729,
+      "line": 722,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Speaking…",
       "surface": "apple",
@@ -40035,7 +40035,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 737,
+      "line": 730,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Preparing audio, tap to cancel",
       "surface": "apple",
@@ -40043,7 +40043,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 738,
+      "line": 731,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Speaking, tap to stop",
       "surface": "apple",
@@ -41219,7 +41219,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 125,
+      "line": 122,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatTranscriptExporter.swift",
       "source": "Message",
       "surface": "apple",
@@ -41275,7 +41275,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1145,
+      "line": 1138,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Copy Message",
       "surface": "apple",
@@ -41283,7 +41283,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1168,
+      "line": 1161,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Open Full Message",
       "surface": "apple",
@@ -41291,7 +41291,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1187,
+      "line": 1180,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Rewind to Here",
       "surface": "apple",
@@ -41299,7 +41299,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1207,
+      "line": 1200,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Fork from Here",
       "surface": "apple",
@@ -41307,7 +41307,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1233,
+      "line": 1226,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Reply",
       "surface": "apple",
@@ -41315,7 +41315,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1243,
+      "line": 1236,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "You",
       "surface": "apple",
@@ -41323,7 +41323,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1245,
+      "line": 1238,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Assistant",
       "surface": "apple",
@@ -41331,7 +41331,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1311,
+      "line": 1304,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Loading chat",
       "surface": "apple",
@@ -41339,7 +41339,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 1391,
+      "line": 1384,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Dismiss",
       "surface": "apple",

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift
@@ -501,14 +501,7 @@ private struct ChatMessageBody: View {
     }
 
     private var inlineAttachments: [OpenClawChatMessageContent] {
-        self.message.content.filter { content in
-            switch content.type ?? "text" {
-            case "file", "attachment":
-                true
-            default:
-                false
-            }
-        }
+        self.message.content.filter(\.isInlineAttachment)
     }
 
     private var inlineWidgets: [OpenClawChatCanvasPreview] {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatModels.swift
@@ -127,6 +127,16 @@ public struct OpenClawChatMessageContent: Codable, Hashable, Sendable {
     public let details: AnyCodable?
     public let isError: Bool?
 
+    /// Gateway media and historical file attachments must stay visible in both chat and exports.
+    var isInlineAttachment: Bool {
+        switch self.type?.lowercased() {
+        case "file", "attachment", "image", "audio":
+            true
+        default:
+            false
+        }
+    }
+
     public init(
         type: String?,
         text: String?,

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatTranscriptExporter.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatTranscriptExporter.swift
@@ -109,10 +109,7 @@ public enum ChatTranscriptExporter {
     }
 
     private static func attachments(in message: OpenClawChatMessage) -> [OpenClawChatMessageContent] {
-        message.content.filter { content in
-            let kind = (content.type ?? "text").lowercased()
-            return kind == "file" || kind == "attachment"
-        }
+        message.content.filter(\.isInlineAttachment)
     }
 
     private static func displayRole(_ role: String) -> String {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift
@@ -1090,14 +1090,7 @@ extension OpenClawChatView {
     }
 
     private func hasInlineAttachments(in message: OpenClawChatMessage) -> Bool {
-        message.content.contains { content in
-            switch content.type ?? "text" {
-            case "file", "attachment":
-                true
-            default:
-                false
-            }
-        }
+        message.content.contains(where: \.isInlineAttachment)
     }
 
     private func toolCalls(in message: OpenClawChatMessage) -> [OpenClawChatMessageContent] {

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatTranscriptExporterTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatTranscriptExporterTests.swift
@@ -64,6 +64,131 @@ struct ChatTranscriptExporterTests {
         """)
     }
 
+    @Test(arguments: ["file", "attachment", "image", "audio", "FILE", "ATTACHMENT", "IMAGE", "AuDiO"])
+    func `classifies gateway media and historical file attachments consistently`(type: String) {
+        let content = OpenClawChatMessageContent(
+            type: type,
+            text: nil,
+            mimeType: nil,
+            fileName: nil,
+            content: nil)
+
+        #expect(content.isInlineAttachment)
+    }
+
+    @Test(arguments: ["text", "canvas", "toolCall", "tool_result"])
+    func `does not classify unrelated content as an attachment`(type: String) {
+        let content = OpenClawChatMessageContent(
+            type: type,
+            text: nil,
+            mimeType: "image/png",
+            fileName: "not-an-attachment.png",
+            content: nil)
+
+        #expect(!content.isInlineAttachment)
+    }
+
+    @Test func `does not classify content without a type as an attachment`() {
+        let content = OpenClawChatMessageContent(
+            type: nil,
+            text: nil,
+            mimeType: "image/png",
+            fileName: "not-an-attachment.png",
+            content: nil)
+
+        #expect(!content.isInlineAttachment)
+    }
+
+    @Test(arguments: ["user", "assistant"], ["image", "audio", "IMAGE", "AuDiO"])
+    func `exports canonical media-only messages`(role: String, type: String) {
+        let isAudio = type.lowercased() == "audio"
+        let filename = isAudio ? "voice-note.m4a" : "photo.png"
+        let message = OpenClawChatMessage(
+            role: role,
+            content: [
+                OpenClawChatMessageContent(
+                    type: type,
+                    text: nil,
+                    mimeType: isAudio ? "audio/mp4" : "image/png",
+                    fileName: filename,
+                    content: nil),
+            ],
+            timestamp: 0)
+
+        let markdown = ChatTranscriptExporter.markdown(
+            sessionTitle: "Media chat",
+            sessionKey: "agent:main",
+            messages: [message])
+
+        #expect(markdown == """
+        # Media chat
+
+        ### \(role == "user" ? "User" : "Assistant") — 1970-01-01T00:00:00Z
+
+        _[attachment: \(filename)]_
+
+        """)
+    }
+
+    @Test(arguments: ["image", "audio", "IMAGE", "AuDiO"])
+    func `preserves canonical media alongside message text`(type: String) {
+        let isAudio = type.lowercased() == "audio"
+        let filename = isAudio ? "voice-note.m4a" : "photo.png"
+        let message = OpenClawChatMessage(
+            role: "user",
+            content: [
+                OpenClawChatMessageContent(
+                    type: "text",
+                    text: "Here is the attachment.",
+                    mimeType: nil,
+                    fileName: nil,
+                    content: nil),
+                OpenClawChatMessageContent(
+                    type: type,
+                    text: nil,
+                    mimeType: isAudio ? "audio/mp4" : "image/png",
+                    fileName: filename,
+                    content: nil),
+            ],
+            timestamp: 0)
+
+        let markdown = ChatTranscriptExporter.markdown(
+            sessionTitle: "Media chat",
+            sessionKey: "agent:main",
+            messages: [message])
+
+        #expect(markdown == """
+        # Media chat
+
+        ### User — 1970-01-01T00:00:00Z
+
+        Here is the attachment.
+
+        _[attachment: \(filename)]_
+
+        """)
+    }
+
+    @Test(arguments: ["canvas", "toolCall", "tool_result"])
+    func `does not export non-attachment content as media`(type: String) {
+        let message = OpenClawChatMessage(
+            role: "assistant",
+            content: [
+                OpenClawChatMessageContent(
+                    type: type,
+                    text: nil,
+                    mimeType: "image/png",
+                    fileName: "not-an-attachment.png",
+                    content: nil),
+            ],
+            timestamp: 0)
+
+        #expect(ChatTranscriptExporter.markdown(
+            sessionTitle: "Media chat",
+            sessionKey: "agent:main",
+            messages: [message]) == "# Media chat\n")
+    }
+
     @Test func `sanitizes filename`() {
         #expect(
             ChatTranscriptExporter.filename(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users viewing or exporting native iOS and macOS conversations would lose image and voice-note messages when the Gateway or a restored outbox used the canonical image or audio content type. Media-only messages disappeared entirely; messages containing text silently lost their attachment in exported Markdown.

## Why This Change Was Made

Define native attachment classification once, inside the existing chat content owner, and reuse it for both native message-rendering paths and transcript export. Preserve historical file and attachment content, match content types case-insensitively, and explicitly exclude text, canvas, tool results, and missing types. Refresh only the canonical native source inventory because removing duplicated Swift branches changes the line numbers of 16 existing Apple localization entries; translation content and stable IDs are unchanged. The classifier is internal; no public API, protocol, configuration, persistence, or security contract changes.

## User Impact

Image and audio messages remain visible in native conversation history and are retained when users export a transcript on iOS or macOS. Existing file attachments, tool rendering, canvas widgets, hidden system messages, and all native translations keep their current behavior.

## Evidence

- Reproduced against exact main baseline e2790760102aee5d99504bce640a5b3160df5331: all 12 image and audio media-only and mixed-text cases failed, while existing and non-media controls passed.
- Verified actual Gateway image history and send contracts against the managed-image and session-creation production regressions.
- Full native Apple Swift package rerun on the final head: 1,161 tests in 90 suites passed, including image upload, voice note, durable outbox, Gateway, transcript, and history reconciliation.
- Focused native exporter suite: 9 tests passed, including 28 parameterized classification, media, and negative-control cases.
- Native optional-trait contract: no speech dependency in the disabled-default-traits graph; the no-Talk OpenClawKit target builds.
- Official repository-pinned SwiftFormat 0.62.1: all five changed Swift files pass.
- Trusted remote Testbox tbx_01kyd4bqe393nnc79mr6h6vmzn: repository-native native:i18n:baseline and native:i18n:verify both pass. The 5,290-entry inventory is byte-for-byte identical locally and remotely; only 16 existing Apple source line numbers change. Android source counts 1,623, 4, and 85; macOS source count 1,206.
- Fresh isolated structured Codex branch review: TruffleHog clean, zero findings, patch correct, 0.99 confidence on the final six-file head.
- Exact-head hosted macOS, iOS, Android, and native-i18n CI run 30167389805.
- AI-assisted; behavior, production ownership, regression proof, localization generator output, and Gateway contracts were independently verified.