### PR TITLE
fix(ui): keep automation run history matched to the latest request

### DIFF
--- a/ui/src/e2e/cron-filters.e2e.test.ts
+++ b/ui/src/e2e/cron-filters.e2e.test.ts
@@ -45,6 +45,17 @@ function cronListResponse(jobs: unknown[], total = jobs.length) {
   };
 }
 
+function cronRunsResponse(entries: unknown[], total = entries.length) {
+  return {
+    entries,
+    total,
+    offset: 0,
+    limit: 50,
+    hasMore: false,
+    nextOffset: null,
+  };
+}
+
 function requireRecord(value: unknown): Record<string, unknown> {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     throw new Error("Expected object value");
@@ -224,6 +235,144 @@ describeControlUiE2e("Control UI cron mocked Gateway E2E", () => {
       });
       await waitForJobTitle(page, gateway, { consoleMessages, pageErrors }, "Nightly cron pending");
       await expect.poll(async () => jobTitle(page, "Digest every minute").count()).toBe(0);
+    } finally {
+      await context.close();
+    }
+  });
+
+  it("keeps the newest visible overview when an older history search resolves last", async () => {
+    const context = await browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1_280 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      methodResponses: {
+        "cron.list": cronListResponse([]),
+        "cron.runs": cronRunsResponse([
+          { ts: 1, jobId: "initial-job", status: "ok", summary: "Initial history" },
+        ]),
+        "cron.status": { enabled: true, jobs: 0, nextWakeAtMs: null },
+      },
+    });
+
+    try {
+      await page.goto(`${server.baseUrl}cron`);
+      await page.getByRole("tab", { name: "Run history", exact: true }).click();
+      await expect
+        .poll(() => page.locator(".cron-run-entry", { hasText: "Initial history" }).count())
+        .toBe(1);
+
+      await gateway.deferNext("cron.runs");
+      const search = page.locator(".cron-run-filter-search input");
+      await search.fill("stale");
+      await expect
+        .poll(async () =>
+          (await gateway.getRequests("cron.runs")).some(
+            (request) => requestParams(request).query === "stale",
+          ),
+        )
+        .toBe(true);
+
+      await gateway.setMethodResponse(
+        "cron.runs",
+        cronRunsResponse([
+          { ts: 3, jobId: "fresh-job", status: "ok", summary: "Newest matching history" },
+        ]),
+      );
+      await search.fill("fresh");
+      await expect
+        .poll(() => page.locator(".cron-run-entry", { hasText: "Newest matching history" }).count())
+        .toBe(1);
+
+      await gateway.resolveDeferred(
+        "cron.runs",
+        cronRunsResponse([
+          { ts: 2, jobId: "stale-job", status: "ok", summary: "Stale matching history" },
+        ]),
+      );
+
+      await expect
+        .poll(() => page.locator(".cron-run-entry", { hasText: "Newest matching history" }).count())
+        .toBe(1);
+      await expect
+        .poll(() => page.locator(".cron-run-entry", { hasText: "Stale matching history" }).count())
+        .toBe(0);
+    } finally {
+      await context.close();
+    }
+  });
+
+  it("keeps selected task history when a deferred overview refresh resolves last", async () => {
+    const selectedJob = cronJob("selected-history-job", "Selected history task", {
+      kind: "every",
+      everyMs: 60_000,
+    });
+    const context = await browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1_280 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      methodResponses: {
+        "cron.list": cronListResponse([selectedJob]),
+        "cron.runs": {
+          cases: [
+            {
+              match: { scope: "job", id: selectedJob.id },
+              response: cronRunsResponse([
+                {
+                  ts: 2,
+                  jobId: selectedJob.id,
+                  status: "ok",
+                  summary: "Selected task history",
+                },
+              ]),
+            },
+            {
+              match: { scope: "all" },
+              response: cronRunsResponse([
+                { ts: 1, jobId: "overview-job", status: "ok", summary: "Overview history" },
+              ]),
+            },
+          ],
+        },
+        "cron.status": { enabled: true, jobs: 1, nextWakeAtMs: null },
+      },
+    });
+
+    try {
+      await page.goto(`${server.baseUrl}cron`);
+      await jobTitle(page, selectedJob.name).waitFor({ timeout: 10_000 });
+
+      const previousHistoryRequestCount = (await gateway.getRequests("cron.runs")).length;
+      await gateway.deferNext("cron.runs");
+      await gateway.emitGatewayEvent("cron", {});
+      await expect
+        .poll(async () => (await gateway.getRequests("cron.runs")).length)
+        .toBeGreaterThan(previousHistoryRequestCount);
+
+      await jobTitle(page, selectedJob.name).click();
+      await page.locator('[data-test-id="cron-detail-tab-history"]').click();
+      await expect
+        .poll(() => page.locator(".cron-run-entry", { hasText: "Selected task history" }).count())
+        .toBe(1);
+
+      await gateway.resolveDeferred(
+        "cron.runs",
+        cronRunsResponse([
+          { ts: 3, jobId: "overview-job", status: "ok", summary: "Late overview history" },
+        ]),
+      );
+
+      await expect
+        .poll(() => page.locator(".cron-run-entry", { hasText: "Selected task history" }).count())
+        .toBe(1);
+      await expect
+        .poll(() => page.locator(".cron-run-entry", { hasText: "Late overview history" }).count())
+        .toBe(0);
     } finally {
       await context.close();
     }

--- a/ui/src/lib/cron/index.test.ts
+++ b/ui/src/lib/cron/index.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment node
 // Control UI tests cover cron behavior.
 import { describe, expect, it, vi } from "vitest";
-import type { CronJob } from "../../api/types.ts";
+import type { CronJob, CronRunsResult } from "../../api/types.ts";
 import { parseCronEveryMs } from "../../lib/cron/decimal.ts";
 import {
   addCronJob,
@@ -19,6 +19,7 @@ import {
   startCronEdit,
   startCronClone,
   updateCronJobsFilter,
+  updateCronRunsFilter,
   validateCronForm,
   type CronState,
 } from "../../lib/cron/index.ts";
@@ -117,6 +118,16 @@ type EmptyCronListResponse = {
   hasMore: boolean;
   nextOffset: null;
 };
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
 
 describe("cron controller", () => {
   it("collects configured model suggestions from defaults and per-agent entries", () => {
@@ -2156,6 +2167,206 @@ describe("cron controller", () => {
     expect(state.cronRuns).toHaveLength(2);
     expect(state.cronRuns[0]?.summary).toBe("newest");
     expect(state.cronRuns[1]?.summary).toBe("older");
+  });
+
+  it("keeps the newest filtered run history when an older overview request finishes last", async () => {
+    const olderOverview = createDeferred<CronRunsResult>();
+    const currentEntry = { ts: 2, jobId: "fresh-job", status: "ok" as const, summary: "fresh" };
+    const request = vi
+      .fn()
+      .mockImplementationOnce(() => olderOverview.promise)
+      .mockResolvedValueOnce({
+        entries: [currentEntry],
+        total: 1,
+        hasMore: false,
+        nextOffset: null,
+      });
+    const state = createState({ client: { request } as unknown as CronState["client"] });
+
+    const olderLoad = loadCronRuns(state, null);
+    updateCronRunsFilter(state, { cronRunsQuery: "fresh" });
+    await expect(loadCronRuns(state, null)).resolves.toBe("ok");
+    expect(state.cronRuns).toEqual([currentEntry]);
+
+    olderOverview.resolve({
+      entries: [{ ts: 1, jobId: "stale-job", status: "ok", summary: "stale" }],
+      total: 8,
+      hasMore: true,
+      nextOffset: 1,
+    });
+
+    await expect(olderLoad).resolves.toBe("skipped");
+    expect(state.cronRuns).toEqual([currentEntry]);
+    expect(state.cronRunsTotal).toBe(1);
+    expect(state.cronRunsHasMore).toBe(false);
+    expect(state.cronRunsNextOffset).toBeNull();
+  });
+
+  it("does not let a deferred overview replace a newly selected job's run history", async () => {
+    const olderOverview = createDeferred<CronRunsResult>();
+    const selectedEntry = {
+      ts: 2,
+      jobId: "selected-job",
+      status: "ok" as const,
+      summary: "selected history",
+    };
+    const request = vi
+      .fn()
+      .mockImplementationOnce(() => olderOverview.promise)
+      .mockResolvedValueOnce({
+        entries: [selectedEntry],
+        total: 1,
+        hasMore: false,
+        nextOffset: null,
+      });
+    const state = createState({ client: { request } as unknown as CronState["client"] });
+
+    const olderLoad = loadCronRuns(state, null);
+    updateCronRunsFilter(state, { cronRunsScope: "job" });
+    state.cronRunsJobId = "selected-job";
+    await expect(loadCronRuns(state, "selected-job")).resolves.toBe("ok");
+
+    olderOverview.resolve({
+      entries: [{ ts: 1, jobId: "other-job", status: "ok", summary: "wrong task" }],
+      total: 1,
+      hasMore: false,
+      nextOffset: null,
+    });
+
+    await expect(olderLoad).resolves.toBe("skipped");
+    expect(state.cronRunsJobId).toBe("selected-job");
+    expect(state.cronRuns).toEqual([selectedEntry]);
+  });
+
+  it("does not let a deferred selected job replace the current overview", async () => {
+    const olderJobHistory = createDeferred<CronRunsResult>();
+    const overviewEntry = {
+      ts: 2,
+      jobId: "overview-job",
+      status: "ok" as const,
+      summary: "current overview",
+    };
+    const request = vi
+      .fn()
+      .mockImplementationOnce(() => olderJobHistory.promise)
+      .mockResolvedValueOnce({
+        entries: [overviewEntry],
+        total: 1,
+        hasMore: false,
+        nextOffset: null,
+      });
+    const state = createState({
+      client: { request } as unknown as CronState["client"],
+      cronRunsScope: "job",
+      cronRunsJobId: "selected-job",
+    });
+
+    const olderLoad = loadCronRuns(state, "selected-job");
+    updateCronRunsFilter(state, { cronRunsScope: "all" });
+    state.cronRunsJobId = null;
+    await expect(loadCronRuns(state, null)).resolves.toBe("ok");
+
+    olderJobHistory.resolve({
+      entries: [{ ts: 1, jobId: "selected-job", status: "ok", summary: "stale task" }],
+      total: 1,
+      hasMore: false,
+      nextOffset: null,
+    });
+
+    await expect(olderLoad).resolves.toBe("skipped");
+    expect(state.cronRunsJobId).toBeNull();
+    expect(state.cronRuns).toEqual([overviewEntry]);
+  });
+
+  it("drops an older paginated response after run-history filters are replaced", async () => {
+    const olderPage = createDeferred<CronRunsResult>();
+    const currentEntry = {
+      ts: 3,
+      jobId: "filtered-job",
+      status: "error" as const,
+      summary: "filtered result",
+    };
+    const request = vi
+      .fn()
+      .mockImplementationOnce(() => olderPage.promise)
+      .mockResolvedValueOnce({
+        entries: [currentEntry],
+        total: 1,
+        hasMore: false,
+        nextOffset: null,
+      });
+    const state = createState({
+      client: { request } as unknown as CronState["client"],
+      cronRuns: [{ ts: 2, jobId: "previous-job", status: "ok", summary: "previous" }],
+      cronRunsHasMore: true,
+      cronRunsNextOffset: 1,
+    });
+
+    const olderLoad = loadCronRuns(state, null, { append: true });
+    expect(state.cronRunsLoadingMore).toBe(true);
+    updateCronRunsFilter(state, { cronRunsStatuses: ["error"] });
+    await expect(loadCronRuns(state, null)).resolves.toBe("ok");
+    expect(state.cronRunsLoadingMore).toBe(false);
+
+    olderPage.resolve({
+      entries: [{ ts: 1, jobId: "stale-job", status: "ok", summary: "stale older page" }],
+      total: 9,
+      hasMore: true,
+      nextOffset: 2,
+    });
+
+    await expect(olderLoad).resolves.toBe("skipped");
+    expect(state.cronRuns).toEqual([currentEntry]);
+    expect(state.cronRunsTotal).toBe(1);
+    expect(state.cronRunsHasMore).toBe(false);
+    expect(state.cronRunsLoadingMore).toBe(false);
+  });
+
+  it("ignores a stale run-history failure after the current request succeeds", async () => {
+    const olderFailure = createDeferred<CronRunsResult>();
+    const currentEntry = { ts: 2, jobId: "fresh-job", status: "ok" as const, summary: "fresh" };
+    const request = vi
+      .fn()
+      .mockImplementationOnce(() => olderFailure.promise)
+      .mockResolvedValueOnce({
+        entries: [currentEntry],
+        total: 1,
+        hasMore: false,
+        nextOffset: null,
+      });
+    const state = createState({ client: { request } as unknown as CronState["client"] });
+
+    const olderLoad = loadCronRuns(state, null);
+    await expect(loadCronRuns(state, null)).resolves.toBe("ok");
+    olderFailure.reject(new Error("stale cron history unavailable"));
+
+    await expect(olderLoad).resolves.toBe("skipped");
+    expect(state.cronRuns).toEqual([currentEntry]);
+    expect(state.cronError).toBeNull();
+  });
+
+  it("preserves the current run-history failure when an older response later succeeds", async () => {
+    const olderOverview = createDeferred<CronRunsResult>();
+    const request = vi
+      .fn()
+      .mockImplementationOnce(() => olderOverview.promise)
+      .mockRejectedValueOnce(new Error("current cron history unavailable"));
+    const state = createState({ client: { request } as unknown as CronState["client"] });
+
+    const olderLoad = loadCronRuns(state, null);
+    await expect(loadCronRuns(state, null)).resolves.toBe("error");
+    expect(state.cronError).toBe("Error: current cron history unavailable");
+
+    olderOverview.resolve({
+      entries: [{ ts: 1, jobId: "stale-job", status: "ok", summary: "stale" }],
+      total: 1,
+      hasMore: false,
+      nextOffset: null,
+    });
+
+    await expect(olderLoad).resolves.toBe("skipped");
+    expect(state.cronRuns).toEqual([]);
+    expect(state.cronError).toBe("Error: current cron history unavailable");
   });
 
   it("scopes jobs and run history requests to the selected agent", async () => {

--- a/ui/src/lib/cron/index.ts
+++ b/ui/src/lib/cron/index.ts
@@ -1187,12 +1187,55 @@ export async function removeCronJob(state: CronState, job: CronJob) {
   });
 }
 
+type CronRunsRequestIdentity = {
+  client: GatewayBrowserClient;
+  agentId: string | null;
+  scope: CronRunScope;
+  jobId: string | null;
+  limit: number;
+  offset: number;
+  statuses: CronRunsStatusValue[];
+  status: CronRunsStatusFilter;
+  deliveryStatuses: CronDeliveryStatus[];
+  query: string;
+  sortDir: CronSortDir;
+  append: boolean;
+};
+
+// The same state owns overview, per-job, filtered, and paginated requests.
+// Only its latest exact request may replace the history, error, or load state.
+const activeCronRunsRequests = new WeakMap<CronState, CronRunsRequestIdentity>();
+
+function ownsCronRunsRequest(state: CronState, request: CronRunsRequestIdentity): boolean {
+  return (
+    activeCronRunsRequests.get(state) === request &&
+    state.connected &&
+    state.client === request.client &&
+    state.cronAgentId === request.agentId &&
+    state.cronRunsScope === request.scope &&
+    (request.scope !== "job" || state.cronRunsJobId === request.jobId) &&
+    state.cronRunsLimit === request.limit &&
+    state.cronRunsStatusFilter === request.status &&
+    state.cronRunsQuery.trim() === request.query &&
+    state.cronRunsSortDir === request.sortDir &&
+    state.cronRunsStatuses.length === request.statuses.length &&
+    state.cronRunsStatuses.every((status, index) => status === request.statuses[index]) &&
+    state.cronRunsDeliveryStatuses.length === request.deliveryStatuses.length &&
+    state.cronRunsDeliveryStatuses.every(
+      (status, index) => status === request.deliveryStatuses[index],
+    ) &&
+    (!request.append ||
+      Math.max(0, state.cronRunsNextOffset ?? state.cronRuns.length) === request.offset)
+  );
+}
+
 export async function loadCronRuns(
   state: CronState,
   jobId: string | null,
   opts?: { append?: boolean },
 ): Promise<CronRunsLoadStatus> {
-  if (!state.client || !state.connected) {
+  const client = state.client;
+  if (!client || !state.connected) {
     return "skipped";
   }
   const scope = state.cronRunsScope;
@@ -1205,37 +1248,40 @@ export async function loadCronRuns(
   if (append && !state.cronRunsHasMore) {
     return "skipped";
   }
+  const request: CronRunsRequestIdentity = {
+    client,
+    agentId: state.cronAgentId,
+    scope,
+    jobId: scope === "job" ? activeJobId : null,
+    limit: state.cronRunsLimit,
+    offset: append ? Math.max(0, state.cronRunsNextOffset ?? state.cronRuns.length) : 0,
+    statuses: [...state.cronRunsStatuses],
+    status: state.cronRunsStatusFilter,
+    deliveryStatuses: [...state.cronRunsDeliveryStatuses],
+    query: state.cronRunsQuery.trim(),
+    sortDir: state.cronRunsSortDir,
+    append,
+  };
+  activeCronRunsRequests.set(state, request);
+  state.cronRunsLoadingMore = append;
   try {
-    if (append) {
-      state.cronRunsLoadingMore = true;
-    }
-    const offset = append ? Math.max(0, state.cronRunsNextOffset ?? state.cronRuns.length) : 0;
-    const res = await state.client.request<CronRunsResult>("cron.runs", {
-      ...(state.cronAgentId ? { agentId: state.cronAgentId } : {}),
-      scope,
-      id: scope === "job" ? (activeJobId ?? undefined) : undefined,
-      limit: state.cronRunsLimit,
-      offset,
-      statuses: state.cronRunsStatuses.length > 0 ? state.cronRunsStatuses : undefined,
-      status: state.cronRunsStatusFilter,
-      deliveryStatuses:
-        state.cronRunsDeliveryStatuses.length > 0 ? state.cronRunsDeliveryStatuses : undefined,
-      query: state.cronRunsQuery.trim() || undefined,
-      sortDir: state.cronRunsSortDir,
+    const res = await client.request<CronRunsResult>("cron.runs", {
+      ...(request.agentId ? { agentId: request.agentId } : {}),
+      scope: request.scope,
+      id: request.jobId ?? undefined,
+      limit: request.limit,
+      offset: request.offset,
+      statuses: request.statuses.length > 0 ? request.statuses : undefined,
+      status: request.status,
+      deliveryStatuses: request.deliveryStatuses.length > 0 ? request.deliveryStatuses : undefined,
+      query: request.query || undefined,
+      sortDir: request.sortDir,
     });
-    // A slower response for a previously selected job (or one arriving after
-    // the pane switched back to all-scope) must not overwrite the current run
-    // pane; callers claim cronRunsJobId/scope before awaiting.
-    const staleJobResponse =
-      scope === "job" && (state.cronRunsScope !== "job" || state.cronRunsJobId !== activeJobId);
-    if (staleJobResponse) {
+    if (!ownsCronRunsRequest(state, request)) {
       return "skipped";
     }
     const entries = Array.isArray(res.entries) ? res.entries : [];
-    state.cronRuns =
-      append && (scope === "all" || state.cronRunsJobId === activeJobId)
-        ? [...state.cronRuns, ...entries]
-        : entries;
+    state.cronRuns = append ? [...state.cronRuns, ...entries] : entries;
     const meta = normalizeCronPageMeta({
       totalRaw: res.total,
       offsetRaw: res.offset,
@@ -1248,10 +1294,13 @@ export async function loadCronRuns(
     state.cronRunsNextOffset = meta.nextOffset;
     return "ok";
   } catch (err) {
+    if (!ownsCronRunsRequest(state, request)) {
+      return "skipped";
+    }
     state.cronError = String(err);
     return "error";
   } finally {
-    if (append) {
+    if (append && activeCronRunsRequests.get(state) === request) {
       state.cronRunsLoadingMore = false;
     }
   }


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users filtering Automations run history, selecting a task, or loading another page would see unrelated or stale run results when an earlier Gateway response arrived after their current request. A stale failure could also replace the current operation's error, and an interrupted page load could leave the loading indicator stuck.

## Why This Change Was Made

Make the existing cron run-history owner responsible for the complete request lifecycle. Snapshot the Gateway client, agent, scope, selected task, every filter, sort order, page size, and cursor; use the Control UI's existing state-scoped `WeakMap` ownership pattern so only the latest matching request may change history rows, pagination, errors, or loading state. This stays within the existing UI owner and adds no configuration, dependency, storage migration, Gateway API, or protocol change.

## User Impact

Automations run history now consistently shows the current search, filter, selected task, and page even when live updates or earlier Gateway requests finish out of order. Existing normal pagination, job-scoped history, Gateway failures, and scheduler actions continue to work.

## Evidence

- Reproduced against immutable `main` `e2790760102aee5d99504bce640a5b3160df5331` on a dedicated Blacksmith Testbox before editing production: **5 failing / 79 passing** owner tests; both actual Chromium/Gateway history scenarios failed while the existing **5** browser scenarios passed.
- After the root-cause fix, the same owner suite passes **84/84**, and the same real Chromium/Gateway suite passes **7/7**, including overview search races and an overview response arriving after task selection.
- **298/298** relevant regressions pass across the complete cron UI controller, page, rendering, Gateway validation, Gateway caller scoping, and SQLite-backed run-history siblings.
- All three changed files pass the repository-pinned formatter and the complete canonical `pnpm check:changed`; the clean-checkout remote wrapper bootstraps the reviewed `e2790760102aee5d99504bce640a5b3160df5331` base and executes both affected check lanes.
- Fresh isolated Codex autoreview and official TruffleHog scan of the exact final patch: clean; independent review confidence **0.98**.
- Dedicated trusted Blacksmith Testbox evidence: workflow run `30166721609`.
- AI-assisted; all reproduction, production behavior, regression results, and final code were independently verified.
