### PR TITLE
fix(ui): prevent previous-agent sessions appearing after agent switches

### DIFF
--- a/ui/src/components/session-data-controller-catalog.ts
+++ b/ui/src/components/session-data-controller-catalog.ts
@@ -68,13 +68,12 @@ export function synchronizeSessionCatalogAgent(
   owner.sessionCatalogGeneration += 1;
   owner.sessionCatalogRevision += 1;
   owner.sessionCatalogLive.clear();
+  // Catalog rows, page cursors, and revision tokens all belong to one agent.
+  // Carrying any of them across the switch can expose or replay stale sessions.
+  owner.sessionCatalogs = [];
   owner.loadingMoreSessionCatalogIds = new Set();
-  if (owner.sessionCatalogs.some((catalog) => catalog.capabilities.createSession)) {
-    owner.sessionCatalogs = owner.sessionCatalogs.map((catalog) => {
-      const { createSession: _createSession, ...capabilities } = catalog.capabilities;
-      return { ...catalog, capabilities };
-    });
-  }
+  owner.sessionCatalogPageDepths.clear();
+  owner.sessionCatalogRevisions.clear();
   owner.requestSessionDataUpdate();
 }
 

--- a/ui/src/e2e/codex-sessions.e2e.test.ts
+++ b/ui/src/e2e/codex-sessions.e2e.test.ts
@@ -2,7 +2,10 @@ import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { chromium, type Browser, type Page } from "playwright";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import type { SessionsCatalogHostEvent } from "../../../packages/gateway-protocol/src/index.ts";
+import type {
+  SessionsCatalogHostEvent,
+  SessionsCatalogListResult,
+} from "../../../packages/gateway-protocol/src/index.ts";
 import {
   canRunPlaywrightChromium,
   installMockGateway,
@@ -97,6 +100,193 @@ suite("Codex native session catalog", () => {
     expect(await page.locator('[data-session-section="catalog:codex"]').count()).toBe(0);
     expect(await page.locator('[data-session-section="catalog:claude"]').count()).toBe(0);
     await page.close();
+  });
+
+  it("clears the previous agent's native sessions before its replacement catalog resolves", async () => {
+    const page = await browser.newPage({ viewport: { height: 900, width: 1280 } });
+    const agentsList = {
+      agents: [
+        { id: "main", identity: { name: "Main" }, name: "Main" },
+        { id: "research", identity: { name: "Research" }, name: "Research" },
+      ],
+      defaultId: "main",
+      mainKey: "main",
+      scope: "agent",
+    };
+    const catalogPage = (
+      name: string,
+      threadId: string,
+      nextCursor?: string,
+    ): SessionsCatalogListResult => ({
+      catalogs: [
+        {
+          id: "codex",
+          label: "Codex",
+          capabilities: { continueSession: true, archive: true },
+          hosts: [
+            {
+              hostId: "gateway:local",
+              label: "Local Codex",
+              kind: "gateway",
+              connected: true,
+              sessions: [
+                {
+                  threadId,
+                  name,
+                  status: "idle",
+                  archived: false,
+                  canContinue: true,
+                  canArchive: true,
+                },
+              ],
+              ...(nextCursor ? { nextCursor } : {}),
+            },
+          ],
+        },
+      ],
+    });
+    const mainPage = catalogPage("Main agent session", "main-thread", "main-page-2");
+    const mainOlderPage = catalogPage("Older main agent session", "main-older-thread");
+    const researchPage = catalogPage(
+      "Research agent session",
+      "research-thread",
+      "research-page-2",
+    );
+    const researchOlderPage = catalogPage("Older research agent session", "research-older-thread");
+    const gateway = await installMockGateway(page, {
+      featureMethods: ["chat.metadata", "chat.startup", "sessions.catalog.list"],
+      methodResponses: {
+        "agents.list": agentsList,
+        "chat.startup": {
+          agentsList,
+          messages: [],
+          metadata: { models: [] },
+          sessionId: "control-ui-e2e-session",
+          thinkingLevel: null,
+        },
+        "sessions.catalog.list": {
+          cases: [
+            {
+              match: { agentId: "main", catalogId: "codex" },
+              response: mainOlderPage,
+            },
+            { match: { agentId: "main" }, response: mainPage },
+            {
+              match: { agentId: "research", catalogId: "codex" },
+              response: researchOlderPage,
+            },
+            { match: { agentId: "research" }, response: researchPage },
+          ],
+        },
+      },
+    });
+
+    try {
+      await page.goto(`${server.baseUrl}chat`);
+      await expandCodingSection(page);
+      await page.getByText("Main agent session", { exact: true }).waitFor();
+      const mainRequest = (await gateway.getRequests("sessions.catalog.list")).find(
+        (request) =>
+          (request.params as { agentId?: string; catalogId?: string } | undefined)?.agentId ===
+            "main" && !(request.params as { catalogId?: string } | undefined)?.catalogId,
+      );
+      const mainProgressId = (mainRequest?.params as { progressId?: string } | undefined)
+        ?.progressId;
+      expect(mainProgressId).toEqual(expect.any(String));
+      const loadMore = page.locator('[data-session-catalog-load-more="codex"]');
+      await loadMore.waitFor({ state: "visible" });
+      await loadMore.click();
+      await page.getByText("Older main agent session", { exact: true }).waitFor();
+
+      await gateway.deferNext("sessions.catalog.list");
+      const sidebar = page.locator("openclaw-app-sidebar");
+      await sidebar.getByRole("button", { name: /Agent menu|Switch agent/ }).click();
+      await sidebar
+        .locator("wa-dropdown.sidebar-agent-menu")
+        .getByRole("menuitemradio", { name: "Research" })
+        .click();
+      await expect
+        .poll(async () =>
+          (await gateway.getRequests("sessions.catalog.list")).some(
+            (request) =>
+              (request.params as { agentId?: string } | undefined)?.agentId === "research",
+          ),
+        )
+        .toBe(true);
+      await expect
+        .poll(() => new URL(page.url()).searchParams.get("session"))
+        .toBe("agent:research:main");
+
+      if (captureUiProofEnabled) {
+        await mkdir(uiProofArtifactDir, { recursive: true });
+        await page.screenshot({
+          animations: "disabled",
+          fullPage: true,
+          path: path.join(uiProofArtifactDir, "06-agent-switch-pending-catalog.png"),
+        });
+      }
+      await expect
+        .poll(() => page.getByText("Main agent session", { exact: true }).count())
+        .toBe(0);
+      await expect
+        .poll(() => page.getByText("Older main agent session", { exact: true }).count())
+        .toBe(0);
+
+      const researchRequest = (await gateway.getRequests("sessions.catalog.list")).find(
+        (request) =>
+          (request.params as { agentId?: string; catalogId?: string } | undefined)?.agentId ===
+            "research" && !(request.params as { catalogId?: string } | undefined)?.catalogId,
+      );
+      const researchProgressId = (researchRequest?.params as { progressId?: string } | undefined)
+        ?.progressId;
+      const mainCatalog = mainPage.catalogs[0];
+      const researchCatalog = researchPage.catalogs[0];
+      if (!mainProgressId || !researchProgressId || !mainCatalog || !researchCatalog) {
+        throw new Error("Agent-switch catalog progress fixture is incomplete");
+      }
+      await gateway.emitGatewayEvent("sessions.catalog.host", {
+        progressId: mainProgressId,
+        agentId: "main",
+        catalog: mainCatalog,
+      } satisfies SessionsCatalogHostEvent);
+      expect(await page.getByText("Main agent session", { exact: true }).count()).toBe(0);
+      await gateway.emitGatewayEvent("sessions.catalog.host", {
+        progressId: researchProgressId,
+        agentId: "research",
+        catalog: researchCatalog,
+      } satisfies SessionsCatalogHostEvent);
+      await page.getByText("Research agent session", { exact: true }).waitFor();
+      await gateway.resolveDeferred("sessions.catalog.list", researchPage);
+      await page.getByText("Research agent session", { exact: true }).waitFor();
+      const researchRequests = (await gateway.getRequests("sessions.catalog.list")).filter(
+        (request) => (request.params as { agentId?: string } | undefined)?.agentId === "research",
+      );
+      expect(researchRequests).toHaveLength(1);
+      await loadMore.waitFor({ state: "visible" });
+      await loadMore.click();
+      await page.getByText("Older research agent session", { exact: true }).waitFor();
+      expect(
+        (await gateway.getRequests("sessions.catalog.list")).find(
+          (request) =>
+            (request.params as { agentId?: string; catalogId?: string } | undefined)?.agentId ===
+              "research" &&
+            (request.params as { catalogId?: string } | undefined)?.catalogId === "codex",
+        )?.params,
+      ).toMatchObject({
+        agentId: "research",
+        catalogId: "codex",
+        cursors: { "gateway:local": "research-page-2" },
+      });
+      if (captureUiProofEnabled) {
+        await page.screenshot({
+          animations: "disabled",
+          fullPage: true,
+          path: path.join(uiProofArtifactDir, "07-agent-switch-resolved-catalog.png"),
+        });
+      }
+    } finally {
+      await page.close();
+    }
   });
 
   it("shows a completed host while the aggregate catalog request is still pending", async () => {
@@ -282,8 +472,7 @@ suite("Codex native session catalog", () => {
       expect(await section.getByText("Worktree fix session", { exact: true }).count()).toBe(1);
       const toggle = section.locator(".sidebar-session-group-toggle");
       expect(await toggle.getAttribute("title")).toBeNull();
-      // Counts only render while a section is collapsed.
-      expect(await section.locator(".sidebar-session-group-count").count()).toBe(0);
+      expect(await toggle.locator(".sidebar-session-group-count").textContent()).toBe("4");
 
       const groupingToggle = section.locator('[data-session-catalog-grouping-toggle="codex"]');
       await groupingToggle.click();
@@ -475,6 +664,7 @@ suite("Codex native session catalog", () => {
       }
 
       await page.goto(`${server.baseUrl}settings/automation?section=plugins`);
+      await page.getByRole("button", { name: "Show advanced" }).last().click();
       const expandPluginSetting = async (pluginLabel: string) => {
         const pluginGroup = page
           .getByText(pluginLabel, { exact: true })


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users switching agents in the Control UI would briefly see, paginate, or receive streamed updates for the previous agent's native coding sessions while the newly selected agent's session catalog was loading.

## Why This Change Was Made

The sidebar catalog controller owns the current agent's catalog rows, pagination-depth map, in-flight loading markers, progressive host state, and revision tokens. Clear that complete agent-owned state together at the existing agent-transition boundary, while retaining the generation and progress guards that reject late responses from the old agent. Keep Gateway protocol, provider configuration, persisted data, and Codex cursor semantics unchanged.

The existing native-session Chromium suite also contains two independently obsolete UI assertions; align them with the already-shipped catalog count renderer and explicit advanced-settings control so the complete owner suite can actually prove current behavior. These are test expectation repairs, not additional product fixes.

## User Impact

Switching between agents immediately hides the previous agent's coding sessions. The replacement agent receives only its own progressive catalog results, sessions, and opaque Load More cursor. Same-agent catalog refresh, native session adoption, streamed host results, Claude and external catalog behavior, and existing Gateway compatibility remain intact.

## Evidence

- Exact immutable baseline: e2790760102aee5d99504bce640a5b3160df5331.
- Actual Chromium + mocked Gateway before the fix: switching to the Research agent retained one Main-agent row; the new regression fails at `ui/src/e2e/codex-sessions.e2e.test.ts:230` with `expected 1 to be +0`.
- Actual Chromium + mocked Gateway after the fix: complete native Codex session-catalog suite passes **7/7 twice**, covering immediate row removal, rejecting a delayed previous-agent `sessions.catalog.host` event, accepting new-agent progress, resolving the correct catalog, and paginating with the new agent's cursor.
- The external OpenCode/Pi session-catalog Chromium flow also passes.
- Full immutable-baseline changed gate passes on the remotely hydrated Blacksmith Testbox: `pnpm check:changed`; UI and core-test tsgo, UI i18n, changed-file formatter, lint, and architecture/ownership guards; remote Testbox `tbx_01kyd3qep6syd28kxyk33erqr6`, workflow run 30166877302, final `exitCode=0`.
- Fresh independent exact-head structured review: no actionable findings; clean secret scan.
- Upstream Codex contract inspected directly: `codex-rs/app-server-protocol/src/protocol/v2/thread.rs` (`ThreadListParams`/`ThreadListResponse`) and `codex-rs/app-server/src/request_processors/thread_processor.rs` (`thread_list_response_inner`).

## Actual Gateway + actual Chromium proof

Validated the immutable PR head `b178e300b01e227c592bb2165ab0bbf19db10c5c` on Blacksmith Testbox `tbx_01kyd9k2ev2w4sdwbgqnej4hct` using a real isolated loopback Gateway, the actual built Control UI, an official Playwright Chromium binary, the real Codex app-server, and the native browser WebSocket. No mocked Gateway, intercepted response, live provider key, personal thread, or operator Gateway was used.

- The real Codex app-server persisted and listed **15 interactive `vscode` threads** with actual rollout paths; the native Gateway catalog returned 15 rows for `gateway:local`.
- Selecting Research changed the browser route from `agent:main:main` to `agent:research:main` and emitted the real `sessions.catalog.list` request with `agentId: "research"` and a real progress identifier.
- A passive observer of the unchanged native WebSocket recorded **zero visible previous-agent rows before the first actual `sessions.catalog.host` research event entered the application**; the event and the final response were both scoped to Research.
- The precise timing is intentionally not overstated: the synchronous click still observes the previous render until Lit commits the cleared state. Both agents then legitimately display the same native thread IDs because Codex user-home discovery is shared. The proof verifies the empty transition before the first incoming Research event rather than incorrectly treating these valid shared-home results as stale rows.
- Real before/after screenshots and the redacted wire/event/DOM timeline are recorded as `01-main-agent-actual-gateway-native-codex.png`, `02-research-agent-actual-gateway-native-codex.png`, and `redacted-actual-gateway-native-codex-proof.json` under the Testbox proof directory.

This PR remains for maintainer/user review; this evidence does not change its branch or merge it.
