### PR TITLE
fix(ui): show and install missing alternative skill binaries

### DIFF
--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -884,13 +884,14 @@ export type SkillStatusEntry = {
   userInvocable?: boolean;
   commandVisible?: boolean;
   requirements: {
-    anyBins?: string[];
+    anyBins: string[];
     bins: string[];
     env: string[];
     config: string[];
     os: string[];
   };
   missing: {
+    anyBins: string[];
     bins: string[];
     env: string[];
     config: string[];

--- a/ui/src/e2e/skills-any-bin-requirements.e2e.test.ts
+++ b/ui/src/e2e/skills-any-bin-requirements.e2e.test.ts
@@ -1,0 +1,147 @@
+// Control UI coverage proves alternative skill binaries remain diagnosable and installable.
+import { chromium, type Browser } from "playwright";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  canRunPlaywrightChromium,
+  installMockGateway,
+  resolvePlaywrightChromiumExecutablePath,
+  startControlUiE2eServer,
+  type ControlUiE2eServer,
+} from "../test-helpers/control-ui-e2e.ts";
+
+const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
+const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
+const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
+const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+
+let browser: Browser;
+let server: ControlUiE2eServer;
+
+function codingAgentSkill(missingAnyBins: string[]) {
+  return {
+    name: "Coding Agent",
+    description: "Delegate coding work to an available coding CLI.",
+    source: "openclaw-bundled",
+    bundled: true,
+    filePath: "/tmp/openclaw-e2e/skills/coding-agent/SKILL.md",
+    baseDir: "/tmp/openclaw-e2e/skills/coding-agent",
+    skillKey: "coding-agent",
+    always: false,
+    disabled: false,
+    blockedByAllowlist: false,
+    blockedByAgentFilter: false,
+    eligible: missingAnyBins.length === 0,
+    platformIncompatible: false,
+    modelVisible: missingAnyBins.length === 0,
+    userInvocable: true,
+    commandVisible: missingAnyBins.length === 0,
+    requirements: {
+      bins: [],
+      anyBins: ["claude", "codex", "opencode"],
+      env: [],
+      config: [],
+      os: [],
+    },
+    missing: {
+      bins: [],
+      anyBins: missingAnyBins,
+      env: [],
+      config: [],
+      os: [],
+    },
+    configChecks: [],
+    install: [
+      {
+        id: "node-codex",
+        kind: "node",
+        label: "Install Codex CLI (npm)",
+        bins: ["codex"],
+      },
+    ],
+  };
+}
+
+describeControlUiE2e("Control UI alternative skill binary requirements", () => {
+  beforeAll(async () => {
+    if (!chromiumAvailable) {
+      throw new Error(`Playwright Chromium is unavailable at ${chromiumExecutablePath}`);
+    }
+    server = await startControlUiE2eServer();
+    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
+  });
+
+  afterAll(async () => {
+    await browser?.close();
+    await server?.close();
+  });
+
+  it("explains alternative missing binaries and installs one through the Gateway", async () => {
+    const context = await browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      methodResponses: {
+        "skills.status": {
+          workspaceDir: "/tmp/openclaw-e2e/workspace",
+          managedSkillsDir: "/tmp/openclaw-e2e/skills",
+          skills: [codingAgentSkill(["claude", "codex", "opencode"])],
+        },
+        "skills.install": { message: "Installed Codex CLI" },
+      },
+    });
+
+    try {
+      const response = await page.goto(`${server.baseUrl}skills`);
+      expect(response?.status()).toBe(200);
+      await page.getByRole("button", { name: "Open Coding Agent details" }).click();
+
+      const dialog = page.locator("openclaw-modal-dialog", { hasText: "Coding Agent" });
+      await expect.poll(async () => await dialog.count()).toBe(1);
+      expect(await dialog.textContent()).toContain("bin:any of (claude, codex, opencode)");
+      await dialog.getByRole("button", { name: "Install Codex CLI (npm)" }).click();
+
+      const request = await gateway.waitForRequest("skills.install");
+      expect(request.params).toMatchObject({
+        name: "Coding Agent",
+        installId: "node-codex",
+        dangerouslyForceUnsafeInstall: false,
+      });
+    } finally {
+      await context.close();
+    }
+  });
+
+  it("does not show missing alternatives or an installer for an eligible skill", async () => {
+    const context = await browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    await installMockGateway(page, {
+      methodResponses: {
+        "skills.status": {
+          workspaceDir: "/tmp/openclaw-e2e/workspace",
+          managedSkillsDir: "/tmp/openclaw-e2e/skills",
+          skills: [codingAgentSkill([])],
+        },
+      },
+    });
+
+    try {
+      const response = await page.goto(`${server.baseUrl}skills`);
+      expect(response?.status()).toBe(200);
+      await page.getByRole("button", { name: "Open Coding Agent details" }).click();
+
+      const dialog = page.locator("openclaw-modal-dialog", { hasText: "Coding Agent" });
+      await expect.poll(async () => await dialog.count()).toBe(1);
+      expect(await dialog.getByText("bin:any of", { exact: false }).count()).toBe(0);
+      expect(await dialog.getByRole("button", { name: "Install Codex CLI (npm)" }).count()).toBe(0);
+    } finally {
+      await context.close();
+    }
+  });
+});

--- a/ui/src/lib/skills-shared.ts
+++ b/ui/src/lib/skills-shared.ts
@@ -6,6 +6,9 @@ import { t } from "../i18n/index.ts";
 export function computeSkillMissing(skill: SkillStatusEntry): string[] {
   return [
     ...skill.missing.bins.map((b) => `bin:${b}`),
+    ...(skill.missing.anyBins.length > 0
+      ? [`bin:any of (${skill.missing.anyBins.join(", ")})`]
+      : []),
     ...skill.missing.env.map((e) => `env:${e}`),
     ...skill.missing.config.map((c) => `config:${c}`),
     ...skill.missing.os.map((o) => `os:${o}`),

--- a/ui/src/lib/skills/index.test.ts
+++ b/ui/src/lib/skills/index.test.ts
@@ -442,8 +442,8 @@ describe("loadSkillCard", () => {
           disabled: false,
           blockedByAllowlist: false,
           eligible: true,
-          requirements: { bins: [], env: [], config: [], os: [] },
-          missing: { bins: [], env: [], config: [], os: [] },
+          requirements: { anyBins: [], bins: [], env: [], config: [], os: [] },
+          missing: { anyBins: [], bins: [], env: [], config: [], os: [] },
           configChecks: [],
           install: [],
           skillCard: {
@@ -495,8 +495,8 @@ describe("loadSkillCard", () => {
           disabled: false,
           blockedByAllowlist: false,
           eligible: true,
-          requirements: { bins: [], env: [], config: [], os: [] },
-          missing: { bins: [], env: [], config: [], os: [] },
+          requirements: { anyBins: [], bins: [], env: [], config: [], os: [] },
+          missing: { anyBins: [], bins: [], env: [], config: [], os: [] },
           configChecks: [],
           install: [],
           clawhub: {

--- a/ui/src/pages/agents/panels-tools-skills.browser.test.ts
+++ b/ui/src/pages/agents/panels-tools-skills.browser.test.ts
@@ -1,7 +1,8 @@
 // Control UI tests cover agents panels tools skills behavior.
 import { render } from "lit";
 import { describe, expect, it } from "vitest";
-import { renderAgentTools } from "./panels-tools-skills.ts";
+import type { SkillStatusEntry } from "../../api/types.ts";
+import { renderAgentSkills, renderAgentTools } from "./panels-tools-skills.ts";
 
 function createBaseParams(overrides: Partial<Parameters<typeof renderAgentTools>[0]> = {}) {
   return {
@@ -425,5 +426,73 @@ describe("agents tools panel (browser)", () => {
     expect(tool.open).toBe(true);
 
     container.remove();
+  });
+});
+
+describe("agents skills panel (browser)", () => {
+  it("explains an unsatisfied one-of binary requirement", async () => {
+    const container = document.createElement("div");
+    const skill: SkillStatusEntry = {
+      name: "Coding Agent",
+      description: "Delegate coding work to an available coding CLI.",
+      source: "openclaw-bundled",
+      bundled: true,
+      filePath: "/tmp/skills/coding-agent/SKILL.md",
+      baseDir: "/tmp/skills/coding-agent",
+      skillKey: "coding-agent",
+      always: false,
+      disabled: false,
+      blockedByAllowlist: false,
+      blockedByAgentFilter: false,
+      eligible: false,
+      requirements: {
+        bins: [],
+        anyBins: ["claude", "codex", "opencode"],
+        env: [],
+        config: [],
+        os: [],
+      },
+      missing: {
+        bins: [],
+        anyBins: ["claude", "codex", "opencode"],
+        env: [],
+        config: [],
+        os: [],
+      },
+      configChecks: [],
+      install: [{ id: "node-codex", kind: "node", label: "Install Codex CLI", bins: ["codex"] }],
+    };
+
+    render(
+      renderAgentSkills({
+        agentId: "main",
+        report: {
+          workspaceDir: "/tmp/workspace",
+          managedSkillsDir: "/tmp/skills",
+          skills: [skill],
+        },
+        loading: false,
+        error: null,
+        activeAgentId: "main",
+        configForm: { agents: { list: [{ id: "main" }] } },
+        configLoading: false,
+        configSaving: false,
+        configDirty: false,
+        filter: "",
+        onFilterChange: () => undefined,
+        onRefresh: () => undefined,
+        onToggle: () => undefined,
+        onClear: () => undefined,
+        onDisableAll: () => undefined,
+        onConfigReload: () => undefined,
+        onConfigSave: () => undefined,
+      }),
+      container,
+    );
+    await Promise.resolve();
+
+    expect(container.querySelector(".agent-skill-row")?.textContent).toContain(
+      "bin:any of (claude, codex, opencode)",
+    );
   });
 });

--- a/ui/src/pages/agents/view.test.ts
+++ b/ui/src/pages/agents/view.test.ts
@@ -21,12 +21,14 @@ function createSkill() {
     blockedByAllowlist: false,
     eligible: true,
     requirements: {
+      anyBins: [],
       bins: [],
       env: [],
       config: [],
       os: [],
     },
     missing: {
+      anyBins: [],
       bins: [],
       env: [],
       config: [],

--- a/ui/src/pages/skills/view.test.ts
+++ b/ui/src/pages/skills/view.test.ts
@@ -34,12 +34,14 @@ function createSkill(overrides: Partial<SkillStatusEntry> = {}): SkillStatusEntr
     blockedByAgentFilter: false,
     eligible: true,
     requirements: {
+      anyBins: [],
       bins: [],
       env: [],
       config: [],
       os: [],
     },
     missing: {
+      anyBins: [],
       bins: [],
       env: [],
       config: [],
@@ -209,6 +211,173 @@ describe("renderSkills", () => {
     );
   });
 
+  it("renders alternative missing binaries and exposes their installer", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    dialogRestores.push(() => container.remove());
+    installDialogMethod("showModal", function (this: HTMLDialogElement) {
+      this.setAttribute("open", "");
+    });
+    const onInstall = vi.fn();
+    const skill = createSkill({
+      skillKey: "coding-agent",
+      name: "Coding Agent",
+      eligible: false,
+      requirements: {
+        bins: [],
+        anyBins: ["claude", "codex", "opencode"],
+        env: [],
+        config: [],
+        os: [],
+      },
+      missing: {
+        bins: [],
+        anyBins: ["claude", "codex", "opencode"],
+        env: [],
+        config: [],
+        os: [],
+      },
+      install: [
+        {
+          id: "node-unrelated",
+          kind: "node",
+          label: "Install unrelated CLI",
+          bins: ["unrelated"],
+        },
+        { id: "node-codex", kind: "node", label: "Install Codex CLI", bins: ["codex"] },
+      ],
+    });
+
+    render(
+      renderSkills(
+        createProps({
+          report: {
+            workspaceDir: "/tmp/workspace",
+            managedSkillsDir: "/tmp/skills",
+            skills: [skill],
+          },
+          detailKey: "coding-agent",
+          onInstall,
+        }),
+      ),
+      container,
+    );
+    await Promise.resolve();
+
+    const warning = container.querySelector(".md-preview-dialog__body .callout");
+    expect(normalizeText(expectDefined(warning, "alternative binary requirement"))).toContain(
+      "bin:any of (claude, codex, opencode)",
+    );
+    const installButton = Array.from(container.querySelectorAll<HTMLButtonElement>("button")).find(
+      (button) => normalizeText(button) === "Install Codex CLI",
+    );
+    expect(installButton).toBeInstanceOf(HTMLButtonElement);
+    installButton?.click();
+    expect(onInstall).toHaveBeenCalledWith("coding-agent", "Coding Agent", "node-codex");
+  });
+
+  it("does not offer an installer that cannot satisfy a missing alternative", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    dialogRestores.push(() => container.remove());
+    installDialogMethod("showModal", function (this: HTMLDialogElement) {
+      this.setAttribute("open", "");
+    });
+    const skill = createSkill({
+      skillKey: "coding-agent",
+      name: "Coding Agent",
+      eligible: false,
+      requirements: {
+        bins: [],
+        anyBins: ["claude", "codex", "opencode"],
+        env: [],
+        config: [],
+        os: [],
+      },
+      missing: {
+        bins: [],
+        anyBins: ["claude", "codex", "opencode"],
+        env: [],
+        config: [],
+        os: [],
+      },
+      install: [
+        {
+          id: "node-unrelated",
+          kind: "node",
+          label: "Install unrelated CLI",
+          bins: ["unrelated"],
+        },
+      ],
+    });
+
+    render(
+      renderSkills(
+        createProps({
+          report: {
+            workspaceDir: "/tmp/workspace",
+            managedSkillsDir: "/tmp/skills",
+            skills: [skill],
+          },
+          detailKey: "coding-agent",
+        }),
+      ),
+      container,
+    );
+    await Promise.resolve();
+
+    expect(normalizeText(container)).toContain("bin:any of (claude, codex, opencode)");
+    expect(
+      Array.from(container.querySelectorAll<HTMLButtonElement>("button")).some(
+        (button) => normalizeText(button) === "Install unrelated CLI",
+      ),
+    ).toBe(false);
+  });
+
+  it("does not offer an installer once an alternative binary is present", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    dialogRestores.push(() => container.remove());
+    installDialogMethod("showModal", function (this: HTMLDialogElement) {
+      this.setAttribute("open", "");
+    });
+    const skill = createSkill({
+      skillKey: "coding-agent",
+      name: "Coding Agent",
+      requirements: {
+        bins: [],
+        anyBins: ["claude", "codex", "opencode"],
+        env: [],
+        config: [],
+        os: [],
+      },
+      missing: { bins: [], anyBins: [], env: [], config: [], os: [] },
+      install: [{ id: "node-codex", kind: "node", label: "Install Codex CLI", bins: ["codex"] }],
+    });
+
+    render(
+      renderSkills(
+        createProps({
+          report: {
+            workspaceDir: "/tmp/workspace",
+            managedSkillsDir: "/tmp/skills",
+            skills: [skill],
+          },
+          detailKey: "coding-agent",
+        }),
+      ),
+      container,
+    );
+    await Promise.resolve();
+
+    expect(normalizeText(container)).not.toContain("bin:any of");
+    expect(
+      Array.from(container.querySelectorAll<HTMLButtonElement>("button")).some(
+        (button) => normalizeText(button) === "Install Codex CLI",
+      ),
+    ).toBe(false);
+  });
+
   it("locks every skill mutation control behind the active mutation", async () => {
     const container = document.createElement("div");
     document.body.append(container);
@@ -219,7 +388,7 @@ describe("renderSkills", () => {
     const calendar = createSkill({
       skillKey: "calendar",
       name: "Calendar",
-      missing: { bins: ["calendar-cli"], env: [], config: [], os: [] },
+      missing: { anyBins: [], bins: ["calendar-cli"], env: [], config: [], os: [] },
       install: [
         { id: "calendar-cli", kind: "brew", label: "Install calendar-cli", bins: ["calendar-cli"] },
       ],

--- a/ui/src/pages/skills/view.ts
+++ b/ui/src/pages/skills/view.ts
@@ -587,8 +587,11 @@ function renderSkillDetail(skill: SkillStatusEntry, props: SkillsProps) {
   const active = activeSkillMutation(props, skill.skillKey);
   const editValue = props.edits[skill.skillKey] ?? "";
   const message = props.messages[skill.skillKey] ?? null;
-  const installOption = skill.install[0];
-  const canInstall = installOption !== undefined && skill.missing.bins.length > 0;
+  const missingBins = new Set([...skill.missing.bins, ...skill.missing.anyBins]);
+  // An installer must provide a currently missing binary, not an unrelated dependency.
+  const installOption = skill.install.find((option) =>
+    option.bins.some((bin) => missingBins.has(bin)),
+  );
   const showBundledBadge = Boolean(skill.bundled && skill.source !== "openclaw-bundled");
   const missing = computeSkillMissing(skill);
   const reasons = computeSkillReasons(skill);
@@ -678,7 +681,7 @@ function renderSkillDetail(skill: SkillStatusEntry, props: SkillsProps) {
             <span style="font-size: 13px; font-weight: 500;">
               ${skill.disabled ? t("skillsPage.disabled") : t("skillsPage.enabled")}
             </span>
-            ${canInstall
+            ${installOption
               ? html`<button
                   class="btn"
                   ?disabled=${locked}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening a skill that accepts any one of several CLI binaries would see a blocked skill without an explanation or an install action. This affects bundled skills including Coding Agent, Spotify Player, and Notion. The same missing explanation also affected the agent-specific skills panel.

## Why This Change Was Made

The Gateway already returns canonical `requirements.anyBins` and `missing.anyBins`, but the Control UI omitted the latter from its skill-status type, diagnostics, and installation eligibility. Align the UI with the existing Gateway contract, render one alternative requirement as one clearly labeled OR group, and select only an installer that actually provides a missing required or alternative binary. Both skill panels share the same canonical diagnostic helper.

## User Impact

Users can see which alternative CLIs satisfy a blocked skill, install a matching CLI directly from the skill detail, and see the same explanation when managing an individual agent. Ready skills and unrelated or ineffective installers do not gain spurious installation actions.

## Evidence

- Reproduced the unchanged baseline with independently failing regressions in both the main skills detail and the per-agent skills panel: 2 failures, 19 passing controls.
- Replayed the committed Chromium regression against a pristine archive of baseline `e2790760102aee5d99504bce640a5b3160df5331`: the missing-binary scenario fails on the actual rendered Coding Agent dialog while the already-ready control passes.
- Real Chromium navigates to the actual Skills route, opens the slotted skills dialog, displays the alternative binary requirement, clicks the matching installer, and verifies the actual `skills.install` Gateway request; a ready-skill control verifies that no installer is shown.
- 113 passing focused regressions across canonical requirements, skill discovery, Gateway protocol, skill operations, the main skills view, the agent skills panel, and agent settings.
- 3 passing Chromium Skills and direct-route regressions, including stylesheet isolation.
- Explicit regressions cover an unrelated first installer, no matching installer, and already satisfied alternatives.
- Full remote `pnpm check:changed` validates changed-file formatting, source internationalization, both TypeScript lanes, repository guards, and lint.
- Fresh independent structured review: clean, with no actionable findings.
- No changes to Gateway protocol, configuration, authentication, providers, localization catalogs, persistence, or security policy.
