### PR TITLE
fix(browser): keep shared pages and selections within Chrome field limits

### DIFF
--- a/extensions/browser/chrome-extension/modules/page-share-core.js
+++ b/extensions/browser/chrome-extension/modules/page-share-core.js
@@ -22,7 +22,14 @@ function truncateShareText(text, maxChars) {
   if (value.length <= maxChars) {
     return value;
   }
-  return `${value.slice(0, maxChars)}\n\n[Truncated: original was ${value.length} characters]`;
+  const marker = `\n\n[Truncated: original was ${value.length} characters]`;
+  let truncated = value.slice(0, maxChars - marker.length);
+  const lastCodeUnit = truncated.charCodeAt(truncated.length - 1);
+  // Keep the complete marker inside the field cap without splitting an emoji.
+  if (lastCodeUnit >= 0xd800 && lastCodeUnit <= 0xdbff) {
+    truncated = truncated.slice(0, -1);
+  }
+  return `${truncated}${marker}`;
 }
 
 export async function waitForCondition(condition, timeoutMs) {

--- a/extensions/browser/chrome-extension/modules/page-share-core.test.ts
+++ b/extensions/browser/chrome-extension/modules/page-share-core.test.ts
@@ -48,12 +48,93 @@ describe("page share core", () => {
       content: "x".repeat(PAGE_SHARE_MAX_CONTENT_CHARS + 1),
     });
     expect(atBoundary.content).toHaveLength(PAGE_SHARE_MAX_CONTENT_CHARS);
+    expect(beyondBoundary.content).toHaveLength(PAGE_SHARE_MAX_CONTENT_CHARS);
     expect(
       beyondBoundary.content.endsWith(
         `[Truncated: original was ${PAGE_SHARE_MAX_CONTENT_CHARS + 1} characters]`,
       ),
     ).toBe(true);
   });
+
+  it.each(["content", "selection"] as const)(
+    "preserves exact-boundary %s without truncating it",
+    (field) => {
+      const text = "x".repeat(PAGE_SHARE_MAX_CONTENT_CHARS);
+      const payload = buildPageSharePayload({
+        url: "https://example.com",
+        title: "Example",
+        content: field === "content" ? text : "",
+        ...(field === "selection" ? { selection: text } : {}),
+      });
+      const sharedText = field === "selection" ? payload.selection : payload.content;
+
+      expect(sharedText).toBe(text);
+      expect(sharedText).toHaveLength(PAGE_SHARE_MAX_CONTENT_CHARS);
+    },
+  );
+
+  it("keeps oversized selected text and its truncation marker within the producer field cap", () => {
+    const selection = "x".repeat(PAGE_SHARE_MAX_CONTENT_CHARS + 1);
+    const payload = buildPageSharePayload({
+      url: "https://example.com",
+      title: "Example",
+      content: "",
+      selection,
+    });
+
+    expect(payload.selection).toHaveLength(PAGE_SHARE_MAX_CONTENT_CHARS);
+    expect(
+      payload.selection?.endsWith(`[Truncated: original was ${selection.length} characters]`),
+    ).toBe(true);
+  });
+
+  it.each(["content", "selection"] as const)(
+    "never leaves a split Unicode surrogate while truncating %s",
+    (field) => {
+      const originalLength = PAGE_SHARE_MAX_CONTENT_CHARS + 1;
+      const marker = `\n\n[Truncated: original was ${originalLength} characters]`;
+      const text =
+        `${"x".repeat(PAGE_SHARE_MAX_CONTENT_CHARS - marker.length - 1)}😀` +
+        "x".repeat(marker.length);
+      expect(text).toHaveLength(originalLength);
+
+      const payload = buildPageSharePayload({
+        url: "https://example.com",
+        title: "Example",
+        content: field === "content" ? text : "",
+        ...(field === "selection" ? { selection: text } : {}),
+      });
+      const sharedText = field === "selection" ? payload.selection : payload.content;
+
+      expect(sharedText?.length).toBeLessThanOrEqual(PAGE_SHARE_MAX_CONTENT_CHARS);
+      expect(sharedText?.endsWith(marker)).toBe(true);
+      expect(sharedText?.slice(0, -marker.length)).not.toMatch(/[\uD800-\uDBFF]$/u);
+    },
+  );
+
+  it.each(["content", "selection"] as const)(
+    "preserves a newline after a non-terminal surrogate while truncating %s",
+    (field) => {
+      const originalLength = PAGE_SHARE_MAX_CONTENT_CHARS + 1;
+      const marker = `\n\n[Truncated: original was ${originalLength} characters]`;
+      const text =
+        `${"x".repeat(PAGE_SHARE_MAX_CONTENT_CHARS - marker.length - 2)}\uD83D\n` +
+        "x".repeat(marker.length + 1);
+      expect(text).toHaveLength(originalLength);
+
+      const payload = buildPageSharePayload({
+        url: "https://example.com",
+        title: "Example",
+        content: field === "content" ? text : "",
+        ...(field === "selection" ? { selection: text } : {}),
+      });
+      const sharedText = field === "selection" ? payload.selection : payload.content;
+
+      expect(sharedText).toHaveLength(PAGE_SHARE_MAX_CONTENT_CHARS);
+      expect(sharedText?.endsWith(marker)).toBe(true);
+      expect(sharedText?.slice(0, -marker.length).endsWith("\uD83D\n")).toBe(true);
+    },
+  );
 
   it("trims fields, preserves newlines, applies caps, and drops empty optionals", () => {
     const payload = buildPageSharePayload({


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users sharing a large web page or highlighted selection from the Chrome plugin produced text larger than the plugin's documented 120,000 UTF-16-code-unit per-field bound. A 120,001-code-unit input produced a 120,045-code-unit field because the truncation marker was appended after the cap, and a boundary-crossing emoji could leave an unpaired surrogate in the shared text.

## Why This Change Was Made

Use the existing shared Chrome page-share truncation owner for both page content and highlighted selections. Reserve space for the complete original-length marker before slicing, and remove a terminal high surrogate only when the cut actually splits a Unicode character. Preserve exact-boundary text and non-terminal surrogate/newline content. This changes neither the relay's separate 300,000-code-unit combined limit nor permissions, consent, configuration, manifests, or plugin ownership.

## User Impact

Large pages and selected passages arrive within the Chrome plugin's promised field size, keep their accurate original-length truncation marker, and do not corrupt an emoji at the boundary. Normal-sized shares and exact-boundary shares remain unchanged.

## Evidence

- Reproduced directly against current base `e2790760102aee5d99504bce640a5b3160df5331`: both 120,001-code-unit page content and selection emitted 120,045 code units, and a boundary emoji left a split surrogate. The fixed production helper emits 120,000 code units for both fields while preserving both exact-boundary values, the complete marker, and valid Unicode cuts.
- Executed 34 additional real production-helper boundary and Unicode-cut inputs: 102/102 assertions passed.
- Fresh, synced Blacksmith Testbox `tbx_01kyd3z2trvc2477n83yzfz680`: 107/107 tests passed across all 14 relevant Chrome plugin, popup/background, page-share producer, relay, Gateway, and plugin-service regression files.
- Actual persistent Chromium with the Chrome MV3 plugin, Gateway/WebSocket, side-panel authorization and session isolation: 2/2 end-to-end tests passed with `OPENCLAW_BROWSER_COPILOT_E2E=1`; none skipped.
- Full canonical remote `pnpm check:changed`: passed all extension/test typechecking, formatting, lint, SDK/plugin-boundary, import-cycle, dependency, and ratchet gates; authoritative wrapper timing `exitCode=0`.
- Fresh independent official Codex autoreview and verified TruffleHog scan against exact published commit `279f2f1a7d711650f31e3a4ae69e4d7b2dac901b`: zero findings; patch correct, confidence 0.97.