### PR TITLE
fix(ui): show configured primary model in general settings

### DIFF
--- a/ui/src/e2e/config-quick-thinking-persistence.e2e.test.ts
+++ b/ui/src/e2e/config-quick-thinking-persistence.e2e.test.ts
@@ -53,6 +53,70 @@ describeControlUiE2e("Control UI General settings thinking persistence mocked Ga
     await server?.close();
   });
 
+  it.each([
+    {
+      name: "a string model",
+      model: "openai/gpt-5.4",
+      expected: "openai/gpt-5.4",
+    },
+    {
+      name: "an object model with fallbacks",
+      model: {
+        primary: "openai/gpt-5.4",
+        fallbacks: ["anthropic/claude-sonnet-4-6"],
+      },
+      expected: "openai/gpt-5.4",
+    },
+    {
+      name: "an object model without fallbacks",
+      model: { primary: "anthropic/claude-sonnet-4-6" },
+      expected: "anthropic/claude-sonnet-4-6",
+    },
+    {
+      name: "a fallbacks-only model",
+      model: { fallbacks: ["anthropic/claude-sonnet-4-6"] },
+      expected: "default",
+    },
+    {
+      name: "a model without a valid primary",
+      model: { primary: 42, fallbacks: ["anthropic/claude-sonnet-4-6"] },
+      expected: "default",
+    },
+  ])("displays the configured primary for $name", async ({ model, expected }) => {
+    const context = await browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const config = { agents: { defaults: { model, thinkingDefault: "low" } } };
+    const gateway = await installMockGateway(page, {
+      methodResponses: {
+        "config.get": {
+          config,
+          hash: "general-model-primary-hash",
+          issues: [],
+          raw: JSON.stringify(config),
+          valid: true,
+        },
+      },
+    });
+
+    try {
+      const response = await page.goto(`${server.baseUrl}settings/general`);
+      expect(response?.status()).toBe(200);
+
+      const modelValue = page
+        .locator("#settings-general-model .settings-row")
+        .filter({ hasText: "Model" })
+        .locator(".settings-row__value");
+      await expect.poll(async () => modelValue.textContent()).toBe(expected);
+      expect(await gateway.getRequests("config.set")).toHaveLength(0);
+    } finally {
+      await context.close();
+    }
+  });
+
   it("reads and writes only agents.defaults.thinkingDefault", async () => {
     const context = await browser.newContext({
       locale: "en-US",

--- a/ui/src/pages/config/config-page.ts
+++ b/ui/src/pages/config/config-page.ts
@@ -28,6 +28,7 @@ import { startThemeTransition } from "../../app/theme-transition.ts";
 import { resolveTheme, type ThemeMode, type ThemeName } from "../../app/theme.ts";
 import { renderSettingsWorkspace } from "../../components/settings-workspace.ts";
 import { i18n, isSupportedLocale, t, type Locale } from "../../i18n/index.ts";
+import { resolveModelPrimary } from "../../lib/agents/display.ts";
 import { resolveControlUiServerQueueMode } from "../../lib/chat/follow-up-mode.ts";
 import { isMissingOperatorReadScopeError } from "../../lib/gateway-errors.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
@@ -1054,7 +1055,7 @@ export class ConfigPage extends OpenClawLightDomElement {
   private renderQuickConfig(configObject: Record<string, unknown>) {
     const runtimeConfig = this.context.runtimeConfig;
     const agentsDefaults = asConfigRecord(asConfigRecord(configObject.agents)?.defaults);
-    const model = typeof agentsDefaults?.model === "string" ? agentsDefaults.model : "default";
+    const model = resolveModelPrimary(agentsDefaults?.model) ?? "default";
     const thinkingLevel =
       typeof agentsDefaults?.thinkingDefault === "string" ? agentsDefaults.thinkingDefault : "off";
     const fastMode = agentsDefaults?.fastMode;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users with the documented primary-and-fallback model configuration saw `default` in Control UI → Settings → General instead of their actual primary model.

## Why This Change Was Made

The Gateway supports both a plain model string and an object containing `primary` and optional `fallbacks`. General Settings now uses the existing shared Control UI primary-model resolver, just as the agent settings already do. This is a presentation-only correction: it does not change configuration, model routing, fallback behavior, provider selection, Gateway protocol, or persistence.

## User Impact

General Settings correctly shows the active configured primary for either documented configuration shape. Fallback-only, missing, and malformed primary values continue to display `default`; simply viewing the page does not write configuration. Existing thinking-level autosave remains unchanged.

## Evidence

- Actual Linux Chromium and mocked Gateway reproduction on immutable `e2790760102aee5d99504bce640a5b3160df5331`: both valid object-model cases failed with `expected "openai/gpt-5.4", received "default"` and `expected "anthropic/claude-sonnet-4-6", received "default"`; canonical string, fallback-only, malformed-primary, and existing autosave controls passed.
- After the shared-owner fix: all 6 General Settings real-browser scenarios pass, including both formerly failing configurations, no-write assertions, and persisted thinking changes.
- All 11 real-browser model-provider, General Settings, advanced-schema, and security-visual regressions pass across 4 Chromium/Gateway suites.
- All 179 configuration-capability, General Settings, renderer, model-resolution, session-observer, and provider regressions pass across 9 additional owner and sibling suites.
- The separate `agents-set-default-persistence.e2e.test.ts` browser fixture already fails on untouched clean `e2790760102aee5d99504bce640a5b3160df5331`; independently reproduced from a fresh `git archive` on the same Testbox. It is not modified or represented as passing.
- Contract checked directly against `src/config/types.agents-shared.ts`, `src/config/zod-schema.agent-model.ts`, `ui/src/lib/agents/display.ts`, `docs/concepts/models.md`, and `docs/gateway/config-agents.md`.
