### PR TITLE
fix(gateway): report failed OpenAI streams instead of false success

### DIFF
--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -2264,6 +2264,90 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
     }
   });
 
+  it.each(
+    [
+      { label: "without an assistant delta", phases: ["error"], streamedText: undefined },
+      { label: "after an assistant delta", phases: ["error"], streamedText: "partial answer" },
+      { label: "after an end lifecycle", phases: ["end", "error"], streamedText: "partial answer" },
+      {
+        label: "before an end lifecycle",
+        phases: ["error", "end"],
+        streamedText: "partial answer",
+      },
+    ].flatMap((testCase) =>
+      [false, true].map((includeUsage) => ({
+        label: testCase.label,
+        phases: testCase.phases,
+        streamedText: testCase.streamedText,
+        includeUsage,
+      })),
+    ),
+  )(
+    "emits a protocol error when a resolved run reports an error $label (include_usage=$includeUsage)",
+    async ({ phases, streamedText, includeUsage }) => {
+      const idleRootCount = getActiveGatewayRootWorkCount();
+      agentCommand.mockClear();
+      agentCommand.mockImplementationOnce((async (opts: unknown) => {
+        const runId = (opts as { runId?: string }).runId;
+        if (!runId) {
+          throw new Error("expected a streaming chat completion run ID");
+        }
+        if (streamedText) {
+          emitAgentEvent({
+            runId,
+            stream: "assistant",
+            data: { delta: streamedText },
+          });
+        }
+        for (const phase of phases) {
+          emitAgentEvent({
+            runId,
+            stream: "lifecycle",
+            data: { phase, ...(phase === "error" ? { error: "provider stream failed" } : {}) },
+          });
+        }
+        return {
+          payloads: [{ text: "provider fallback that must not be published" }],
+          meta: { agentMeta: { usage: { input: 11, output: 7, total: 18 } } },
+        };
+      }) as never);
+
+      const response = await postChatCompletions(enabledPort, {
+        stream: true,
+        ...(includeUsage ? { stream_options: { include_usage: true } } : {}),
+        model: "openclaw",
+        messages: [{ role: "user", content: "hi" }],
+      });
+      expect(response.status).toBe(200);
+
+      const data = parseSseDataLines(await response.text());
+      expect(data.filter((value) => value === "[DONE]")).toHaveLength(1);
+      expect(data.at(-1)).toBe("[DONE]");
+
+      const chunks = data
+        .filter((value) => value !== "[DONE]")
+        .map((value) => JSON.parse(value) as Record<string, unknown>);
+      const errorChunks = chunks.filter((chunk) => "error" in chunk);
+      expect(errorChunks).toHaveLength(1);
+      expect(errorChunks[0]?.error).toEqual({ message: "internal error", type: "api_error" });
+      expect(chunks.some((chunk) => "usage" in chunk)).toBe(false);
+      expect(
+        chunks
+          .flatMap((chunk) => (chunk.choices as Array<Record<string, unknown>> | undefined) ?? [])
+          .some((choice) => choice.finish_reason !== null && choice.finish_reason !== undefined),
+      ).toBe(false);
+      const publishedText = chunks
+        .flatMap((chunk) => (chunk.choices as Array<Record<string, unknown>> | undefined) ?? [])
+        .map((choice) => (choice.delta as { content?: unknown } | undefined)?.content)
+        .filter((content): content is string => typeof content === "string")
+        .join("");
+      expect(publishedText).toBe(streamedText ?? "");
+      expect(publishedText).not.toContain("provider fallback");
+      expect(agentCommand).toHaveBeenCalledTimes(1);
+      await vi.waitFor(() => expect(getActiveGatewayRootWorkCount()).toBe(idleRootCount));
+    },
+  );
+
   it(
     "sends an initial SSE chunk before a streaming agent run settles",
     { timeout: 15_000 },

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -1188,14 +1188,21 @@ export async function handleOpenAiHttpRequest(
   let finalizeRequested = false;
   let finalizeFinishReason: "stop" | "tool_calls" = "stop";
   let resultResolved = false;
+  let lifecycleFailed = false;
   let closed = false;
   let stopWatchingDisconnect = () => {};
 
   const maybeFinalize = () => {
-    if (closed || !finalizeRequested) {
+    if (closed || !finalizeRequested || !resultResolved) {
       return;
     }
-    if (!resultResolved) {
+    if (lifecycleFailed) {
+      closed = true;
+      stopWatchingDisconnect();
+      unsubscribe();
+      writeSse(res, { error: { message: "internal error", type: "api_error" } });
+      writeDone(res);
+      res.end();
       return;
     }
     if (streamIncludeUsage && !finalUsage) {
@@ -1275,6 +1282,8 @@ export async function handleOpenAiHttpRequest(
     if (evt.stream === "lifecycle") {
       const phase = evt.data?.phase;
       if (phase === "end" || phase === "error") {
+        // A resolved agent run can report its failure only through lifecycle.
+        lifecycleFailed ||= phase === "error";
         requestFinalize();
       }
     }
@@ -1302,6 +1311,11 @@ export async function handleOpenAiHttpRequest(
       }
 
       finalUsage = resolveChatCompletionUsage(result);
+      if (lifecycleFailed) {
+        maybeFinalize();
+        return;
+      }
+
       const meta = (result as { meta?: unknown } | null)?.meta;
       const { stopReason, pendingToolCalls } = resolveStopReasonAndPendingToolCalls(meta);
 

--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -1072,6 +1072,83 @@ describe("OpenResponses HTTP API (e2e)", () => {
     expect(agentCommand).toHaveBeenCalledTimes(1);
   });
 
+  it.each([
+    { label: "without an assistant delta", phases: ["error"], streamedText: undefined },
+    { label: "after an assistant delta", phases: ["error"], streamedText: "partial answer" },
+    { label: "after an end lifecycle", phases: ["end", "error"], streamedText: "partial answer" },
+    { label: "before an end lifecycle", phases: ["error", "end"], streamedText: "partial answer" },
+  ] as const)(
+    "emits a failed terminal when a resolved run reports an error $label",
+    async ({ phases, streamedText }) => {
+      const idleRootCount = getActiveGatewayRootWorkCount();
+      agentCommand.mockClear();
+      agentCommand.mockImplementationOnce((async (opts: unknown) => {
+        const runId = (opts as { runId?: string }).runId;
+        if (!runId) {
+          throw new Error("expected a streaming response run ID");
+        }
+        if (streamedText) {
+          emitAgentEvent({
+            runId,
+            stream: "assistant",
+            data: { delta: streamedText },
+          });
+        }
+        for (const phase of phases) {
+          emitAgentEvent({
+            runId,
+            stream: "lifecycle",
+            data: { phase, ...(phase === "error" ? { error: "provider stream failed" } : {}) },
+          });
+        }
+        return {
+          payloads: [{ text: "provider fallback that must not be published" }],
+          meta: { agentMeta: { usage: { input: 11, output: 7, total: 18 } } },
+        };
+      }) as never);
+
+      const response = await postResponses(
+        enabledPort,
+        { stream: true, model: "openclaw", input: "hi" },
+        undefined,
+        AbortSignal.timeout(5_000),
+      );
+      expect(response.status).toBe(200);
+
+      const events = parseSseEvents(await response.text());
+      expect(events.filter((event) => event.event === "response.failed")).toHaveLength(1);
+      expect(events.filter((event) => event.event === "response.completed")).toHaveLength(0);
+      expect(events.filter((event) => event.event === "response.output_text.done")).toHaveLength(0);
+      expect(events.filter((event) => event.event === "response.content_part.done")).toHaveLength(
+        0,
+      );
+      expect(events.filter((event) => event.event === "response.output_item.done")).toHaveLength(0);
+      expect(events.filter((event) => event.data === "[DONE]")).toHaveLength(1);
+      expect(events.at(-1)?.data).toBe("[DONE]");
+
+      const failedResponse = (
+        parseSseData(findSseEvent(events, "response.failed")) as {
+          response?: {
+            status?: string;
+            output?: unknown[];
+            error?: { code?: string; message?: string };
+            usage?: { input_tokens?: number; output_tokens?: number; total_tokens?: number };
+          };
+        }
+      ).response;
+      expect(failedResponse?.status).toBe("failed");
+      expect(failedResponse?.output).toEqual([]);
+      expect(failedResponse?.error).toEqual({ code: "server_error", message: "internal error" });
+      expect(failedResponse?.usage).toEqual({
+        input_tokens: 11,
+        output_tokens: 7,
+        total_tokens: 18,
+      });
+      expect(agentCommand).toHaveBeenCalledTimes(1);
+      await vi.waitFor(() => expect(getActiveGatewayRootWorkCount()).toBe(idleRootCount));
+    },
+  );
+
   it.each(
     STREAM_FAILURE_CASES.flatMap((failure) =>
       [false, true].map((emitErrorLifecycle) => ({

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -926,76 +926,9 @@ export async function handleOpenResponsesHttpRequest(
   let unsubscribe = () => {};
   let stopWatchingDisconnect = () => {};
   let finalUsage: Usage | undefined;
-  let finalizeStatus: ResponseResource["status"] | null = null;
-  let finalizeRequested: { status: ResponseResource["status"]; text: string } | null = null;
-
-  const maybeFinalize = () => {
-    if (closed) {
-      return;
-    }
-    if (!finalizeRequested) {
-      return;
-    }
-    if (!finalUsage) {
-      return;
-    }
-    const usage = finalUsage;
-
-    closed = true;
-    stopWatchingDisconnect();
-    unsubscribe();
-
-    writeSseEvent(res, {
-      type: "response.output_text.done",
-      item_id: outputItemId,
-      output_index: 0,
-      content_index: 0,
-      text: finalizeRequested.text,
-    });
-
-    writeSseEvent(res, {
-      type: "response.content_part.done",
-      item_id: outputItemId,
-      output_index: 0,
-      content_index: 0,
-      part: { type: "output_text", text: finalizeRequested.text },
-    });
-
-    const completedItem = createAssistantOutputItem({
-      id: outputItemId,
-      text: finalizeRequested.text,
-      phase: finalizeRequested.status === "completed" ? "final_answer" : "commentary",
-      status: "completed",
-    });
-
-    writeSseEvent(res, {
-      type: "response.output_item.done",
-      output_index: 0,
-      item: completedItem,
-    });
-
-    const finalResponse = createResponseResource({
-      id: responseId,
-      model,
-      status: finalizeRequested.status,
-      output: [completedItem],
-      usage,
-    });
-
-    rememberResponseSession();
-    writeSseEvent(res, { type: "response.completed", response: finalResponse });
-    writeDone(res);
-    res.end();
-  };
-
-  const requestFinalize = (status: ResponseResource["status"], text: string) => {
-    if (finalizeRequested) {
-      return;
-    }
-    finalizeStatus = status;
-    finalizeRequested = { status, text };
-    maybeFinalize();
-  };
+  const finalization: {
+    requested: { status: ResponseResource["status"]; text: string } | null;
+  } = { requested: null };
 
   const finalizeFailedResponse = (response: ResponseResource) => {
     if (closed) {
@@ -1008,6 +941,92 @@ export async function handleOpenResponsesHttpRequest(
     writeSseEvent(res, { type: "response.failed", response });
     writeDone(res);
     res.end();
+  };
+
+  const maybeFinalize = () => {
+    if (closed) {
+      return;
+    }
+    const requested = finalization.requested;
+    if (!requested) {
+      return;
+    }
+    if (!finalUsage) {
+      return;
+    }
+    const usage = finalUsage;
+
+    if (requested.status === "failed") {
+      const failedResponse = createResponseResource({
+        id: responseId,
+        model,
+        status: "failed",
+        output: [],
+        error: { code: "server_error", message: "internal error" },
+        usage,
+      });
+      rememberResponseSession();
+      finalizeFailedResponse(failedResponse);
+      return;
+    }
+
+    closed = true;
+    stopWatchingDisconnect();
+    unsubscribe();
+
+    writeSseEvent(res, {
+      type: "response.output_text.done",
+      item_id: outputItemId,
+      output_index: 0,
+      content_index: 0,
+      text: requested.text,
+    });
+
+    writeSseEvent(res, {
+      type: "response.content_part.done",
+      item_id: outputItemId,
+      output_index: 0,
+      content_index: 0,
+      part: { type: "output_text", text: requested.text },
+    });
+
+    const completedItem = createAssistantOutputItem({
+      id: outputItemId,
+      text: requested.text,
+      phase: requested.status === "completed" ? "final_answer" : "commentary",
+      status: "completed",
+    });
+
+    writeSseEvent(res, {
+      type: "response.output_item.done",
+      output_index: 0,
+      item: completedItem,
+    });
+
+    const finalResponse = createResponseResource({
+      id: responseId,
+      model,
+      status: requested.status,
+      output: [completedItem],
+      usage,
+    });
+
+    rememberResponseSession();
+    writeSseEvent(res, { type: "response.completed", response: finalResponse });
+    writeDone(res);
+    res.end();
+  };
+
+  const requestFinalize = (status: ResponseResource["status"], text: string) => {
+    // A later failure supersedes an end observed before the resolved result and usage.
+    if (
+      finalization.requested &&
+      (finalization.requested.status === "failed" || status !== "failed")
+    ) {
+      return;
+    }
+    finalization.requested = { status, text };
+    maybeFinalize();
   };
 
   // Send initial events
@@ -1149,6 +1168,11 @@ export async function handleOpenResponsesHttpRequest(
       });
 
       finalUsage = extractUsageFromResult(result);
+
+      if (finalization.requested?.status === "failed") {
+        maybeFinalize();
+        return;
+      }
 
       // Check for pending client tool calls BEFORE maybeFinalize() because the
       // lifecycle:end event may already have requested finalization.
@@ -1300,8 +1324,8 @@ export async function handleOpenResponsesHttpRequest(
 
         accumulatedText = content;
         sawAssistantDelta = true;
-        if (finalizeStatus !== null) {
-          finalizeRequested = { status: finalizeStatus, text: content };
+        if (finalization.requested) {
+          finalization.requested = { ...finalization.requested, text: content };
         }
 
         writeSseEvent(res, {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users consuming OpenAI-compatible streaming Chat Completions or Responses would receive a successful stop or completed event after an agent reported a real lifecycle failure but returned a normally resolved result. This incorrectly made exhausted model fallback and other failed agent turns look successful, could publish fallback text, and violated the OpenAI streaming contracts.

## Why This Change Was Made

Both Gateway SSE owners now make a lifecycle failure a sticky terminal outcome, including either ordering of error and end. Responses emit exactly one `response.failed` with the official OpenAI `server_error` and the run's actual token usage; Chat Completions emit the existing OpenAI-compatible top-level error frame without inventing a successful finish or usage chunk. Already streamed text remains intact, and cleanup and the single `[DONE]` remain unchanged.

The contracts were verified directly against the repository-pinned OpenAI SDK: [Responses failure code and event](https://github.com/openai/openai-node/blob/v6.48.0/src/resources/responses/responses.ts#L2743-L2826) and [Chat streaming error consumption](https://github.com/openai/openai-node/blob/v6.48.0/src/core/streaming.ts#L43-L73).

## User Impact

OpenAI-compatible clients can reliably distinguish failed generation from a completed model response, retain genuine partial output and Responses token accounting, and avoid incorrectly accepting failed agent runs as successful.

## Evidence

- Exact clean-main red: all four new real-Gateway Responses cases and all eight Chat cases failed before the production fix, including missing or partial streamed text, both lifecycle event orderings, and both Chat `include_usage` settings.
- Final remote proof on Blacksmith Testbox: **429/429 passing** across 17 existing Gateway, provider, streaming, usage, agent lifecycle, parity, authentication, tool-call, and cleanup suites.
- Live official OpenAI `gpt-5.4`: **3/3 passing** for provider resolution, real Responses-stream completion and token usage, and real interleaved reasoning/tool-call streaming.
- Full clean-worktree `pnpm check:changed` through the canonical remote wrapper: **passed**, including both `tsgo` lanes, all 245 lint rules, format, ownership, database, runtime, import-cycle, and security guards.
- Fresh independent AI-assisted review and TruffleHog scan: **clean**, zero actionable findings.
- No schema, authentication, provider, configuration, persistence, or protocol-version changes.

## Direct observed Gateway failure-path proof

Protected Gateway behavior; this evidence does not replace explicit Gateway-owner/user approval. Independently reran the actual Gateway servers at reviewed PR head `b960ef0f4130162b516068d9058cd08b85e29952` on a fresh Blacksmith Testbox. The real `startGatewayServer` listeners received loopback HTTP requests; the existing agent command deliberately emitted its genuine run-bound lifecycle `error` before or after `end`, with and without an already published assistant delta, and then resolved normally with provider usage. A source-free, secret-safe Node fetch observer independently cloned and inspected the actual SSE HTTP response; no branch, test, fixture, Gateway code, credential, or request header was modified.

**Exact outcome: 12/12 passed** (8 Chat cases across both `include_usage` settings; 4 Responses cases). Both servers returned HTTP 200 with exactly one final `[DONE]`. The output below is the observer's actual wire-derived JSON with request identifiers removed, not an expected fixture or manually constructed event:

```text
[AUTOQA_OBSERVED_GATEWAY_SSE] {"endpoint":"/v1/chat/completions","httpStatus":200,"partialText":"","error":{"message":"internal error","type":"api_error"},"usageFrameCount":0,"successfulFinishCount":0,"doneCount":1,"lastFrame":"[DONE]"}
[AUTOQA_OBSERVED_GATEWAY_SSE] {"endpoint":"/v1/chat/completions","httpStatus":200,"partialText":"partial answer","error":{"message":"internal error","type":"api_error"},"usageFrameCount":0,"successfulFinishCount":0,"doneCount":1,"lastFrame":"[DONE]"}
[AUTOQA_OBSERVED_GATEWAY_SSE] {"endpoint":"/v1/responses","httpStatus":200,"partialText":"","terminalEvent":"response.failed","response":{"status":"failed","error":{"code":"server_error","message":"internal error"},"usage":{"input_tokens":11,"output_tokens":7,"total_tokens":18},"output":[]},"completedEventCount":0,"doneCount":1,"lastFrame":"[DONE]"}
[AUTOQA_OBSERVED_GATEWAY_SSE] {"endpoint":"/v1/responses","httpStatus":200,"partialText":"partial answer","terminalEvent":"response.failed","response":{"status":"failed","error":{"code":"server_error","message":"internal error"},"usage":{"input_tokens":11,"output_tokens":7,"total_tokens":18},"output":[]},"completedEventCount":0,"doneCount":1,"lastFrame":"[DONE]"}

Test Files  2 passed (2)
Tests       12 passed | 65 skipped by deliberate failure-path filter (77)
Blacksmith  {"provider":"blacksmith-testbox","leaseId":"tbx_01kyd9tnw84teadnrbwez18feq","exitCode":0}
```

The filtered cases exercise `src/gateway/openai-http.test.ts` and `src/gateway/openresponses-http.test.ts` through their actual running Gateway HTTP servers, including error-only, partial-text, end-then-error, and error-then-end cases. Chat never sends a synthetic success finish or usage frame; Responses retains real `11/7/18` terminal usage and never emits `response.completed`. This PR remains subject to protected Gateway-owner review and is not being merged automatically.
