### PR TITLE
fix(macos): refresh skills after local node republishes inventory  Fixes #107391

### DIFF
--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeHostWorker.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeHostWorker.swift
@@ -5,6 +5,7 @@ import OSLog
 
 extension Notification.Name {
     static let openclawNodeHostWorkerFailed = Notification.Name("openclaw.node-host-worker.failed")
+    static let openclawMacNodeInventoryPublished = Notification.Name("openclaw.macNode.inventoryPublished")
 }
 
 struct MacNodeHostManifest: Equatable, Sendable {

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeModeCoordinator.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeModeCoordinator.swift
@@ -552,6 +552,7 @@ final class MacNodeModeCoordinator: NSObject {
                     authorityGeneration: attempt.routeAuthorityGeneration) ?? true
                 guard workerRouteInstalled else { return }
                 await self.nodeHostWorker?.publishInventory(ifCurrentRoute: installedRoute)
+                self.notificationCenter.post(name: .openclawMacNodeInventoryPublished, object: nil)
                 await self.cancelReconnectProbe()
                 self.logger.info("mac node connected to gateway")
                 // The node hello owns this route's session defaults. Reusing the operator

--- a/apps/macos/Sources/OpenClaw/SkillsSettings.swift
+++ b/apps/macos/Sources/OpenClaw/SkillsSettings.swift
@@ -767,12 +767,12 @@ final class SkillsSettingsModel {
             let report = try await GatewayConnection.shared.skillsStatus()
             self.skills = report.skills.sorted { $0.name < $1.name }
             self.hasLoaded = true
-        } 
+        }
         catch {
             self.error = error.localizedDescription
         }
         self.isLoading = false
-    }    
+    }
 
     func acceptInstalledSkills(_ skills: [SkillStatus]) {
         self.skills = skills.sorted { $0.name < $1.name }

--- a/apps/macos/Sources/OpenClaw/SkillsSettings.swift
+++ b/apps/macos/Sources/OpenClaw/SkillsSettings.swift
@@ -767,7 +767,8 @@ final class SkillsSettingsModel {
             let report = try await GatewayConnection.shared.skillsStatus()
             self.skills = report.skills.sorted { $0.name < $1.name }
             self.hasLoaded = true
-        } catch {
+        } 
+        catch {
             self.error = error.localizedDescription
         }
         self.isLoading = false

--- a/apps/macos/Sources/OpenClaw/SkillsSettings.swift
+++ b/apps/macos/Sources/OpenClaw/SkillsSettings.swift
@@ -771,7 +771,7 @@ final class SkillsSettingsModel {
             self.error = error.localizedDescription
         }
         self.isLoading = false
-    }
+    }    
 
     func acceptInstalledSkills(_ skills: [SkillStatus]) {
         self.skills = skills.sorted { $0.name < $1.name }


### PR DESCRIPTION
Closes 
#107391.

The macOS app has two independent connections to the Gateway:

ControlChannel — used by the Settings/Skills UI to fetch skills.status.
MacNodeModeCoordinator — runs the local Mac node, which resolves binaries (system.which) and republishes that inventory to the Gateway via node.skills.update.

SkillsSettings only refreshes once, on initial view load (SkillsSettingsModel.refreshIfNeeded()), and nothing re-triggers that fetch when the node (as opposed to the control channel) finishes reconnecting and republishes its binary inventory. If the Skills view is opened before the local node has reconnected, the UI caches the stale eligible: false response and never asks again — even though a fresh skills.status call moments later reports the skill as fully eligible.

Reproduced with the workspace skill paprika (requires the paprika binary), matching the original issue.

Why prior attempts (
#111874, 
#107660) needed rework

Fix

MacNodeHostWorker.swift — add a new notification, openclawMacNodeInventoryPublished, describing this boundary.
MacNodeModeCoordinator.swift — post that notification immediately after publishInventory completes.
SkillsSettings.swift (SkillsSettingsModel) — observe the notification and request a fresh skills.status. If a refresh is already in flight (e.g. the initial load), the request is coalesced behind it via a pendingForcedRefresh flag and drained immediately after that in-flight request completes, so a stale pre-reconnect response can never become the final cached state.