### PR TITLE
fix(browser): keep stale copilot events out of active chat turns

### DIFF
--- a/extensions/browser/chrome-extension/modules/copilot-background.js
+++ b/extensions/browser/chrome-extension/modules/copilot-background.js
@@ -674,6 +674,11 @@ export function createCopilotController({
       if (entry?.sessionKey !== sessionKey || !subscribedKeys.has(sessionKey)) {
         continue;
       }
+      // A session stays subscribed across turns; only its persisted active run
+      // may stream or unlock the panel after a delayed earlier Gateway event.
+      if (event.event === "chat" && event.payload?.runId !== entry.activeRunId) {
+        continue;
+      }
       for (const port of ports) {
         post(port, { type: "panel.event", event });
       }

--- a/extensions/browser/chrome-extension/sidepanel.e2e-support.ts
+++ b/extensions/browser/chrome-extension/sidepanel.e2e-support.ts
@@ -1,6 +1,116 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import type { expect as VitestExpect } from "vitest";
+import type { RawData } from "ws";
+
+type CopilotTurnIsolationGateway = {
+  chatSends: Array<Record<string, unknown>>;
+  requests: Array<{ method: string }>;
+  emitEvent: (event: string, payload: Record<string, unknown>) => void;
+};
+
+type CopilotTurnIsolationPanel = {
+  allText: (selector: string) => Promise<string[]>;
+  click: (selector: string) => Promise<void>;
+  disabled: (selector: string) => Promise<boolean>;
+  fill: (selector: string, value: string) => Promise<void>;
+};
+
+export function textValue(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+export function rawDataText(data: RawData): string {
+  if (Array.isArray(data)) {
+    return Buffer.concat(data).toString("utf8");
+  }
+  return data instanceof ArrayBuffer
+    ? Buffer.from(new Uint8Array(data)).toString("utf8")
+    : data.toString("utf8");
+}
+
+export async function assertCopilotStaleRunIsolation(params: {
+  expect: typeof VitestExpect;
+  gateway: CopilotTurnIsolationGateway;
+  panel: CopilotTurnIsolationPanel;
+}): Promise<void> {
+  const { expect, gateway, panel } = params;
+  const initialSendCount = gateway.chatSends.length;
+
+  await panel.fill("#message-input", "completed turn marker");
+  await panel.click("#send-button");
+  await expect.poll(() => gateway.chatSends.length, { timeout: 10_000 }).toBe(initialSendCount + 1);
+  await expect
+    .poll(() => panel.allText(".message.assistant"), { timeout: 10_000 })
+    .toContain("Isolated reply: completed turn marker");
+  await expect.poll(() => panel.disabled("#message-input"), { timeout: 10_000 }).toBe(false);
+
+  const completedRun = gateway.chatSends[initialSendCount];
+  const completedRunId = textValue(completedRun?.idempotencyKey);
+  const sessionKey = textValue(completedRun?.sessionKey);
+  expect(completedRunId).not.toBe("");
+  expect(sessionKey).not.toBe("");
+  const originalAssistantMessages = await panel.allText(".message.assistant");
+  const originalSystemMessages = await panel.allText(".message.system");
+
+  await panel.fill("#message-input", "active turn linger marker");
+  await panel.click("#send-button");
+  await expect.poll(() => gateway.chatSends.length, { timeout: 10_000 }).toBe(initialSendCount + 2);
+  const activeRun = gateway.chatSends[initialSendCount + 1];
+  const activeRunId = textValue(activeRun?.idempotencyKey);
+  expect(activeRunId).not.toBe("");
+  expect(activeRunId).not.toBe(completedRunId);
+  expect(await panel.disabled("#message-input")).toBe(true);
+
+  const historyRequestsBeforeStaleEvents = gateway.requests.filter(
+    (request) => request.method === "chat.history",
+  ).length;
+  gateway.emitEvent("chat", {
+    sessionKey,
+    runId: completedRunId,
+    state: "delta",
+    deltaText: "Stale text from the completed turn",
+  });
+  gateway.emitEvent("chat", {
+    sessionKey,
+    runId: completedRunId,
+    state: "error",
+    errorMessage: "Stale error from the completed turn",
+  });
+  gateway.emitEvent("chat", { sessionKey, runId: completedRunId, state: "aborted" });
+  gateway.emitEvent("chat", { sessionKey, runId: completedRunId, state: "final" });
+  // The ordered history event proves preceding stale frames were consumed
+  // before checking that the active run still owns the composer.
+  gateway.emitEvent("session.message", { sessionKey });
+  await expect
+    .poll(() => gateway.requests.filter((request) => request.method === "chat.history").length, {
+      timeout: 10_000,
+    })
+    .toBeGreaterThan(historyRequestsBeforeStaleEvents);
+  expect(await panel.disabled("#message-input")).toBe(true);
+  expect(await panel.allText(".message.assistant")).toEqual(originalAssistantMessages);
+  expect(await panel.allText(".message.system")).toEqual(originalSystemMessages);
+
+  gateway.emitEvent("chat", {
+    sessionKey,
+    runId: activeRunId,
+    state: "delta",
+    deltaText: "Current turn remains live",
+  });
+  await expect
+    .poll(() => panel.allText(".message.assistant"), { timeout: 10_000 })
+    .toEqual([...originalAssistantMessages, "Current turn remains live"]);
+  gateway.emitEvent("chat", { sessionKey, runId: activeRunId, state: "final" });
+  await expect.poll(() => panel.disabled("#message-input"), { timeout: 10_000 }).toBe(false);
+
+  await panel.fill("#message-input", "next normal turn marker");
+  await panel.click("#send-button");
+  await expect.poll(() => gateway.chatSends.length, { timeout: 10_000 }).toBe(initialSendCount + 3);
+  await expect
+    .poll(() => panel.allText(".message.assistant"), { timeout: 10_000 })
+    .toContain("Isolated reply: next normal turn marker");
+}
 
 export function isSidePanelTarget(target: { url: string }): boolean {
   try {

--- a/extensions/browser/chrome-extension/sidepanel.e2e.test.ts
+++ b/extensions/browser/chrome-extension/sidepanel.e2e.test.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { chromium, type CDPSession, type Page, type Worker } from "playwright-core";
 import { afterEach, describe, expect, it } from "vitest";
-import { WebSocketServer, type RawData, type WebSocket } from "ws";
+import { WebSocketServer, type WebSocket } from "ws";
 import {
   GATEWAY_CLIENT_CAPS,
   GATEWAY_CLIENT_IDS,
@@ -12,9 +12,12 @@ import {
 import { PROTOCOL_VERSION } from "../../../packages/gateway-protocol/src/version.js";
 import { useAutoCleanupTempDirTracker } from "../test-support.js";
 import {
+  assertCopilotStaleRunIsolation,
   copyCopilotSidepanelExtension,
   isSidePanelTarget,
+  rawDataText,
   resolveChromiumExecutable,
+  textValue,
 } from "./sidepanel.e2e-support.js";
 
 declare const chrome: {
@@ -56,6 +59,7 @@ type GatewayHarness = {
   requests: RequestFrame[];
   close: () => Promise<void>;
   disconnectClients: () => void;
+  emitEvent: (event: string, payload: Record<string, unknown>) => void;
   failNextAbort: () => void;
   holdNextSubscription: () => () => void;
 };
@@ -87,19 +91,6 @@ type PanelTarget = {
   text: (selector: string) => Promise<string>;
   wakeBackground: () => Promise<void>;
 };
-
-function textValue(value: unknown): string {
-  return typeof value === "string" ? value : "";
-}
-
-function rawDataText(data: RawData): string {
-  if (Array.isArray(data)) {
-    return Buffer.concat(data).toString("utf8");
-  }
-  return data instanceof ArrayBuffer
-    ? Buffer.from(new Uint8Array(data)).toString("utf8")
-    : data.toString("utf8");
-}
 
 const cleanups: Array<() => Promise<void>> = [];
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -319,6 +310,11 @@ async function createGatewayHarness(): Promise<GatewayHarness> {
     disconnectClients: () => {
       for (const client of wss.clients) {
         client.terminate();
+      }
+    },
+    emitEvent: (event, payload) => {
+      for (const client of wss.clients) {
+        client.send(JSON.stringify({ type: "event", event, payload }));
       }
     },
     failNextAbort: () => {
@@ -1037,5 +1033,7 @@ describe.runIf(runE2E)("browser copilot Chromium side panel", () => {
         timeout: 15_000,
       })
       .toBe(true);
-  }, 75_000);
+
+    await assertCopilotStaleRunIsolation({ expect, gateway, panel: reopenedBetaPanel });
+  }, 120_000);
 });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Chrome copilot users could see text or an error from a completed conversation turn appear in the next turn, or could have the composer re-enabled while the next response was still running, when an earlier Gateway chat event arrived late.

## Why This Change Was Made

Chrome keeps a tab's isolated session subscribed across turns. The background controller already persists the authoritative active run ID for that session, and the Gateway protocol requires a run ID on every chat event. Filter chat events at that existing owner boundary before forwarding them to the panel. Session-message events, tab consent, debugger custody, Gateway reconnection, service-worker recovery, permissions, and archival are unchanged.

## User Impact

The browser copilot displays only the active conversation turn. Out-of-order output, completion, failure, and cancellation from a previous turn cannot corrupt the current response or prematurely unlock the message composer. Subsequent turns remain available as soon as the actual active response completes.

## Evidence

- Reproduced against clean `main` commit `e2790760102aee5d99504bce640a5b3160df5331` using the actual unpacked Chrome MV3 plugin, persistent Chromium, real extension side panel, real service worker, and WebSocket Gateway: a late event from a completed turn incorrectly enables the current turn's composer (`expected true, received false`).
- The regression now verifies late `delta`, `error`, `aborted`, and `final` events are all ignored; current-turn streaming and completion, unchanged non-chat session events, and the next normal conversation turn all work.
- The complete real-Chromium copilot suite passes both canonical persistent-Chromium scenarios. The complete stale-turn regression runs inside the real tab lifecycle after service-worker restart, alongside per-tab session isolation, share consent, Gateway disconnection, browser-relay recovery, session cancellation, and archival.
- Rebased onto current `main` commit `a1cc41acbcdd285a7cdb423bdfe45ef06b2f97cb`; the combined real-browser lifecycle has its full 120-second timeout. Existing E2E helpers and stale-turn assertions are owned by `sidepanel.e2e-support.ts`, keeping the canonical E2E below the actual 1,000-effective-line limit without changing a baseline or suppressing lint.
- All seven Chrome-plugin sibling suites pass, covering **at least 49 tests across background, relay, Gateway, session registry, page sharing, and panel rendering**.
- The complete plugin-contract suite passes: **965 tests across 40 files**, including all **445 extension runtime dependency contract tests**. Test assertions are injected by the E2E rather than imported as a plugin runtime dependency.
- Independently ran all **1,996** browser-plugin tests on both the unchanged archived `main` commit and this patch on the same Testbox. Both results are identical: **1,994 passed, one skipped, and the same pre-existing unrelated `chrome.internal.test.ts` executable-discovery failure**. No tests were disabled or assertions weakened.
- The final clean committed branch is independently secret-scanned and reviewed against the exact base before publication.
- The complete changed-file gate passes on the remote Testbox, including extension production and test typechecking, the real max-lines suppression ratchet, formatting, lint, plugin boundaries, SDK contracts, runtime import cycles, and all other selected guards. No guard was disabled and the pre-existing full-browser-suite failure is not presented as passing.
