### PR TITLE
fix(tui): restore full verbose and streaming reasoning controls

### DIFF
--- a/src/tui/commands.test.ts
+++ b/src/tui/commands.test.ts
@@ -1,6 +1,11 @@
 // Verifies TUI command definitions and parser metadata.
 import { beforeAll, describe, expect, it } from "vitest";
-import { getSlashCommands, helpText, parseCommand } from "./commands.js";
+import {
+  getSlashCommands,
+  helpText,
+  parseCommand,
+  shouldSubmitExactArgumentCompletion,
+} from "./commands.js";
 
 describe("parseCommand", () => {
   it("normalizes aliases and keeps command args", () => {
@@ -50,6 +55,21 @@ describe("getSlashCommands", () => {
       { value: "always", label: "always" },
     ]);
   });
+
+  it.each([
+    { commandName: "verbose", level: "full", description: "Set verbose on/off/full" },
+    { commandName: "reasoning", level: "stream", description: "Set reasoning on/off/stream" },
+  ])(
+    "exposes and submits the canonical /$commandName $level completion",
+    ({ commandName, level, description }) => {
+      const commands = getSlashCommands();
+      const command = commands.find((candidate) => candidate.name === commandName);
+
+      expect(command?.description).toBe(description);
+      expect(command?.getArgumentCompletions?.(level)).toEqual([{ value: level, label: level }]);
+      expect(shouldSubmitExactArgumentCompletion(`/${commandName} ${level}`, commands)).toBe(true);
+    },
+  );
 
   it("keeps session status on the shared command path and exposes gateway status separately", () => {
     const commands = getSlashCommands();
@@ -158,6 +178,13 @@ describe("getSlashCommands", () => {
 });
 
 describe("helpText", () => {
+  it.each(["/verbose <on|off|full>", "/reasoning <on|off|stream>"])(
+    "includes the full canonical directive levels for %s",
+    (usage) => {
+      expect(helpText()).toContain(usage);
+    },
+  );
+
   it("includes slash command help for aliases", () => {
     const output = helpText();
     expect(output).toContain("/elevated <on|off|ask|full>");

--- a/src/tui/commands.ts
+++ b/src/tui/commands.ts
@@ -7,13 +7,18 @@ import {
   listChatCommandsForConfig,
   resolveTextCommand,
 } from "../auto-reply/commands-registry.js";
-import { formatThinkingLevels, listThinkingLevelLabels } from "../auto-reply/thinking.js";
+import {
+  formatThinkingLevels,
+  listThinkingLevelLabels,
+  type ReasoningLevel,
+  type VerboseLevel,
+} from "../auto-reply/thinking.js";
 import type { OpenClawConfig } from "../config/types.js";
 
-const VERBOSE_LEVELS = ["on", "off"];
+const VERBOSE_LEVELS = ["on", "off", "full"] satisfies VerboseLevel[];
 const TRACE_LEVELS = ["on", "off"];
 const FAST_LEVELS = ["status", "auto", "on", "off"];
-const REASONING_LEVELS = ["on", "off"];
+const REASONING_LEVELS = ["on", "off", "stream"] satisfies ReasoningLevel[];
 const ELEVATED_LEVELS = ["on", "off", "ask", "full"];
 const ACTIVATION_LEVELS = ["mention", "always"];
 const USAGE_FOOTER_LEVELS = ["off", "tokens", "full", "reset", "inherit", "clear", "default"];
@@ -53,6 +58,12 @@ function createLevelCompletion(
         value,
         label: value,
       }));
+}
+
+/** Keep TUI help and no-argument usage aligned with actual directive completions. */
+export function formatTuiLevelCommandUsage(command: "verbose" | "reasoning"): string {
+  const levels = command === "verbose" ? VERBOSE_LEVELS : REASONING_LEVELS;
+  return `/${command} <${levels.join("|")}>`;
 }
 
 function normalizeSlashCommandName(value: string): string {
@@ -139,7 +150,7 @@ export function getSlashCommands(options: SlashCommandOptions = {}): SlashComman
     },
     {
       name: "verbose",
-      description: "Set verbose on/off",
+      description: `Set verbose ${VERBOSE_LEVELS.join("/")}`,
       getArgumentCompletions: verboseCompletions,
     },
     {
@@ -149,7 +160,7 @@ export function getSlashCommands(options: SlashCommandOptions = {}): SlashComman
     },
     {
       name: "reasoning",
-      description: "Set reasoning on/off",
+      description: `Set reasoning ${REASONING_LEVELS.join("/")}`,
       getArgumentCompletions: reasoningCompletions,
     },
     {
@@ -249,9 +260,9 @@ export function helpText(options: SlashCommandOptions = {}): string {
     "/model <provider/model> (or /models)",
     `/think <${thinkLevels}>`,
     "/fast <status|auto|on|off>",
-    "/verbose <on|off>",
+    formatTuiLevelCommandUsage("verbose"),
     "/trace <on|off>",
-    "/reasoning <on|off>",
+    formatTuiLevelCommandUsage("reasoning"),
     "/usage <off|tokens|full|reset|inherit|clear|default>",
     "/elevated <on|off|ask|full>",
     "/elev <on|off|ask|full>",

--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -1161,6 +1161,18 @@ describe("tui command handlers", () => {
     expect(openclaw.addSystem).toHaveBeenCalledWith(expect.stringContaining("ultra"));
   });
 
+  it.each([
+    { command: "verbose", usage: "usage: /verbose <on|off|full>" },
+    { command: "reasoning", usage: "usage: /reasoning <on|off|stream>" },
+  ])("shows the complete canonical no-argument /$command usage", async ({ command, usage }) => {
+    const { handleCommand, addSystem, patchSession } = createHarness();
+
+    await handleCommand(`/${command}`);
+
+    expect(addSystem).toHaveBeenCalledWith(usage);
+    expect(patchSession).not.toHaveBeenCalled();
+  });
+
   it("hides tools locally for /verbose off without reloading history", async () => {
     const patchResult = { entry: { verboseLevel: "off" } };
     const patchSession = vi.fn().mockResolvedValue(patchResult);
@@ -1196,6 +1208,31 @@ describe("tui command handlers", () => {
 
     await handleCommand("/verbose on");
 
+    expect(loadHistory).toHaveBeenCalledTimes(1);
+    expect(refreshSessionInfo).not.toHaveBeenCalled();
+    expect(clearTools).not.toHaveBeenCalled();
+  });
+
+  it("reloads history for /verbose full so prior full tool output becomes visible", async () => {
+    const patchResult = { entry: { verboseLevel: "full" } };
+    const patchSession = vi.fn().mockResolvedValue(patchResult);
+    const applySessionInfoFromPatch = vi.fn();
+    const loadHistory = vi.fn().mockResolvedValue(undefined);
+    const refreshSessionInfo = vi.fn().mockResolvedValue(undefined);
+    const { handleCommand, clearTools } = createHarness({
+      patchSession,
+      applySessionInfoFromPatch,
+      loadHistory,
+      refreshSessionInfo,
+    });
+
+    await handleCommand("/verbose full");
+
+    expect(patchSession).toHaveBeenCalledWith({
+      key: "agent:main:main",
+      verboseLevel: "full",
+    });
+    expect(applySessionInfoFromPatch).toHaveBeenCalledWith(patchResult);
     expect(loadHistory).toHaveBeenCalledTimes(1);
     expect(refreshSessionInfo).not.toHaveBeenCalled();
     expect(clearTools).not.toHaveBeenCalled();

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -19,7 +19,12 @@ import {
 import { isChatStopCommandText } from "../gateway/chat-abort.js";
 import { formatRelativeTimestamp } from "../infra/format-time/format-relative.ts";
 import { normalizeAgentId } from "../routing/session-key.js";
-import { helpText, isSharedTextCommand, parseCommand } from "./commands.js";
+import {
+  formatTuiLevelCommandUsage,
+  helpText,
+  isSharedTextCommand,
+  parseCommand,
+} from "./commands.js";
 import type { ChatLog } from "./components/chat-log.js";
 import {
   createFilterableSelectList,
@@ -570,7 +575,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
         break;
       case "verbose":
         if (!args) {
-          chatLog.addSystem("usage: /verbose <on|off>");
+          chatLog.addSystem(`usage: ${formatTuiLevelCommandUsage("verbose")}`);
           break;
         }
         try {
@@ -630,7 +635,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
         break;
       case "reasoning":
         if (!args) {
-          chatLog.addSystem("usage: /reasoning <on|off>");
+          chatLog.addSystem(`usage: ${formatTuiLevelCommandUsage("reasoning")}`);
           break;
         }
         try {

--- a/src/tui/tui-pty-harness.e2e.test.ts
+++ b/src/tui/tui-pty-harness.e2e.test.ts
@@ -857,6 +857,8 @@ describe.sequential("TUI PTY harness", () => {
       await fixture.run.write("/help\r", { delay: false });
       await fixture.run.waitForOutput("Slash commands:");
       await fixture.run.waitForOutput("/help");
+      await fixture.run.waitForOutput("/verbose <on|off|full>");
+      await fixture.run.waitForOutput("/reasoning <on|off|stream>");
       await fixture.run.waitForOutput("/exit");
     },
     TEST_TIMEOUT_MS,
@@ -893,6 +895,23 @@ describe.sequential("TUI PTY harness", () => {
       await fixture.run.waitForOutput("→ status");
       await fixture.run.write("\r", { delay: false });
       await fixture.run.waitForOutput("fast mode: off");
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  it.each([
+    { command: "verbose", level: "full", field: "verboseLevel" },
+    { command: "reasoning", level: "stream", field: "reasoningLevel" },
+  ])(
+    "submits the canonical /$command $level terminal completion with one Enter",
+    async ({ command, level, field }) => {
+      await fixture.run.write(`/${command} ${level}`, { delay: false });
+      await fixture.run.waitForOutput(`→ ${level}`);
+      await fixture.run.write("\r", { delay: false });
+
+      await fixture.waitForLogEntry(
+        (entry) => entry.method === "patchSession" && objectFieldEquals(entry, field, level),
+      );
     },
     TEST_TIMEOUT_MS,
   );


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where terminal users could not discover or submit the already-supported `/verbose full` and `/reasoning stream` modes through autocomplete, and `/help` and no-argument usage incorrectly described both commands as on/off-only.

## Why This Change Was Made

Use the canonical typed verbosity and reasoning levels as the single TUI source for completion, command descriptions, help and handler usage. Preserve existing session patching, history reload, permissions and all trace behavior.

## User Impact

Users can discover and apply full tool-output verbosity and streamed reasoning with one Enter in the terminal; help and usage now agree with documented, existing Gateway behavior.

## Evidence

- Proved the bug on immutable main with 6 failing focused regressions and genuine pseudo-terminal failures before the fix.
- Full TUI owner shard: **709 passed across 32 suites**.
- Full genuine terminal shard: **35 passed**, including 24 real fake-backend PTY scenarios and 11 real local/Gateway PTY scenarios covering actual Gateway restart, session creation, streaming, queueing and reconnect. Both supported modes prove the actual completion arrow, one-Enter submission and exact backend patch payload.
- Full changed gate on the tested immutable baseline: `pnpm check:changed --base e2790760102aee5d99504bce640a5b3160df5331` **passed**, including formatting, all ratchets, both core typechecks, lint and ownership/schema guards. Trusted Testbox: `tbx_01kyd3f8z4kjct3bcvvkf55djv`; proof run: https://github.com/openclaw/openclaw/actions/runs/30166717484.
- Rebased onto immutable `1a2252e1a709278fa8fd640215fa398c71465f40`; verified that every TUI owner, both TUI/PTY configurations and the canonical thinking contract are byte-identical to the tested baseline, and all five reviewed files are byte-identical to the tested green head.
- Fresh exact-head isolated independent Codex review and TruffleHog: **clean, zero actionable findings**.
- Infrastructure transparency: a second clean-checkout Testbox run was prevented before execution by Blacksmith's hard two-minute full-checkout sync timeout. No guard was disabled or bypassed; the exact-head hosted required CI is the final full-gate proof.
