### PR TITLE
fix(models): read Anthropic token limits in live discovery

### DIFF
--- a/src/plugin-sdk/provider-catalog-live-normalize.internal.ts
+++ b/src/plugin-sdk/provider-catalog-live-normalize.internal.ts
@@ -228,6 +228,10 @@ function buildOpenAICompatibleLiveModel(
         "max_context_length",
         "maxModelLen",
         "max_model_len",
+        // Anthropic names the context window by its input side. Appended so a
+        // provider already matching an earlier key keeps its current value.
+        "max_input_tokens",
+        "maxInputTokens",
       ],
     ) ??
     fallback.contextWindow ??
@@ -243,6 +247,11 @@ function buildOpenAICompatibleLiveModel(
         "maxOutputTokens",
         "output_token_limit",
         "outputTokenLimit",
+        // Anthropic reports the output cap as max_tokens. Kept last so the
+        // unambiguous completion-specific names above still win where both
+        // appear, and no provider's existing resolution changes.
+        "max_tokens",
+        "maxTokens",
       ],
     ) ??
     fallback.maxTokens ??

--- a/src/plugin-sdk/provider-catalog-live-normalize.tokens.test.ts
+++ b/src/plugin-sdk/provider-catalog-live-normalize.tokens.test.ts
@@ -1,0 +1,57 @@
+// Plugin SDK tests cover vendor token-limit field mapping in live discovery.
+import { describe, expect, it } from "vitest";
+import { buildOpenAICompatibleLiveModels } from "./provider-catalog-live-normalize.internal.js";
+import type { ModelProviderConfig } from "./provider-model-shared.js";
+
+/** Seed with no context/output hints so resolution comes from the row alone. */
+const fallback = {
+  baseUrl: "https://api.example.com",
+  api: "anthropic-messages",
+  models: [],
+} as unknown as ModelProviderConfig;
+
+function firstModel(row: Record<string, unknown>) {
+  const [model] = buildOpenAICompatibleLiveModels([{ object: "model", ...row }], fallback);
+  return model;
+}
+
+describe("live discovery vendor token-limit fields", () => {
+  it("reads Anthropic's max_input_tokens and max_tokens", () => {
+    // Anthropic names the context window by its input side and the output cap
+    // as max_tokens; before this mapping both fell back to generic defaults.
+    const model = firstModel({
+      id: "claude-future-1",
+      max_input_tokens: 1_000_000,
+      max_tokens: 128_000,
+    });
+    expect(model?.contextWindow).toBe(1_000_000);
+    expect(model?.maxTokens).toBe(128_000);
+  });
+
+  it("still prefers completion-specific output names when a row carries both", () => {
+    const model = firstModel({
+      id: "dual-field-model",
+      context_length: 200_000,
+      max_completion_tokens: 16_000,
+      max_tokens: 999_999,
+    });
+    expect(model?.contextWindow).toBe(200_000);
+    expect(model?.maxTokens).toBe(16_000);
+  });
+
+  it("leaves OpenAI-shaped rows resolving exactly as before", () => {
+    const model = firstModel({
+      id: "openai-shaped-model",
+      context_window: 128_000,
+      max_output_tokens: 32_000,
+    });
+    expect(model?.contextWindow).toBe(128_000);
+    expect(model?.maxTokens).toBe(32_000);
+  });
+
+  it("keeps the previous defaults when a row advertises no limits", () => {
+    const model = firstModel({ id: "bare-model" });
+    expect(model?.contextWindow).toBe(128_000);
+    expect(model?.maxTokens).toBe(8192);
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Live model discovery cannot read Anthropic's token limits, so every discovered Claude model that is not already in the shipped catalog gets a wrong context window and output cap.

`buildOpenAICompatibleLiveModel` resolves limits from an OpenAI/OpenRouter-shaped key list — `context_length`, `context_window`, `max_completion_tokens`, `max_output_tokens`, and friends. Anthropic's `/v1/models` reports `max_input_tokens` for the context window and `max_tokens` for the output cap. Neither string appeared anywhere in the normalizer, so both lookups missed and the row fell through to `fallback.contextWindow ?? template?.contextWindow ?? 128_000` and `Math.min(contextWindow, 8192)`.

The practical effect is that discovery is silently lossy for exactly the case it exists to serve: a newly published snapshot of an already-supported Claude family is admitted, then published as a 128k/8k model when it is really 1M/128k. Models the shipped catalog already describes are unaffected — they return their manifest entry verbatim — so this was never visible on the models OpenClaw ships metadata for.

Found while explaining why the live catalog had not spared us the manual Claude Opus 5 rollout; it is one of the reasons, and the only one that is a plain bug rather than a scope limit.

## Why This Change Was Made

Adds Anthropic's field names to the two existing lookup lists, **appended** rather than inserted:

- context window: `max_input_tokens`, `maxInputTokens`
- output cap: `max_tokens`, `maxTokens`

Appending is what makes this safe. `readLiveModelPositiveInteger` returns the first key that matches within a record, so putting the new names last guarantees that any provider already matching an earlier key resolves to exactly the same value as before. Only rows that previously matched *nothing* — Anthropic's — begin resolving.

Ordering matters for the output cap in particular: `max_tokens` is a generic name that some vendors use loosely, so the completion-specific names (`max_completion_tokens`, `max_output_tokens`, `output_token_limit`) still win whenever a row carries both.

## User Impact

Newly discovered Claude models are published with their real context window and output limit instead of the 128k/8k fallback, which in turn feeds context management and compaction thresholds correctly. No change for models the shipped catalog already describes, and no change for any other provider.

## Evidence

- `node scripts/run-vitest.mjs src/plugin-sdk/provider-catalog-live-normalize.tokens.test.ts` — 4 new tests: an Anthropic-shaped row resolves 1M/128k; a row carrying **both** `max_completion_tokens` and `max_tokens` still prefers the completion-specific value (precedence guard); an OpenAI-shaped row resolves exactly as before; a row with no limits keeps the previous 128k/8192 defaults.
- Regression sweep across the providers that share this normalizer — `provider-catalog-live-runtime`, `provider-catalog-shared`, `extensions/anthropic`, `extensions/openrouter`, `extensions/xai` — **728 passed**.
- `$autoreview` (Codex `gpt-5.6-sol`, high): clean — no accepted/actionable findings; "patch is correct (0.99)", explicitly noting the additions preserve existing key precedence.

Follows #113757, which added the contract-coverage gate. Both are stage-1 work under #113411; stage 2 (capability-driven contracts) remains open there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
