### PR TITLE
fix(native): preserve active chat while another run finishes

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+TransportEvents.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+TransportEvents.swift
@@ -192,15 +192,21 @@ extension OpenClawChatViewModel {
         }
         if chat.state == "final" || chat.state == "aborted" || chat.state == "error" {
             self.invalidateHistorySnapshots()
-            self.updateActiveSessionRunWithoutChatSnapshot(false)
+            if isOurRun || self.pendingRuns.isEmpty {
+                self.updateActiveSessionRunWithoutChatSnapshot(false)
+            }
         }
         self.invalidateRunSnapshots()
         if !isOurRun {
             // Keep multiple clients in sync: if another client finishes a run for our session, refresh history.
             switch chat.state {
             case "final", "aborted", "error":
-                self.updateStreamingAssistantText(nil)
-                self.pendingToolCallsById = [:]
+                // An older external turn must not erase the stream or tools
+                // owned by the run this client is still actively following.
+                if self.pendingRuns.isEmpty {
+                    self.updateStreamingAssistantText(nil)
+                    self.pendingToolCallsById = [:]
+                }
                 if let runId = chat.runId {
                     self.clearPlan(for: runId)
                 }

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift
@@ -4055,6 +4055,61 @@ struct ChatViewModelTests {
         ])
     }
 
+    @Test(arguments: ["final", "aborted", "error"])
+    func `terminal event for another run preserves active streaming and tools`(state: String) async throws {
+        let activeRunId = "active-run"
+        let initialHistory = historyPayload()
+        let activeHistory = historyPayload(
+            inFlightRun: OpenClawChatInFlightRun(
+                runId: activeRunId,
+                text: "Still working",
+                plan: OpenClawChatPlanSnapshot(
+                    steps: [OpenClawChatPlanStep(step: "Keep working", status: .inProgress)])))
+        let (transport, vm) = await makeViewModel(
+            historyResponses: [initialHistory, activeHistory, activeHistory],
+            sendMessageHook: { _ in
+                OpenClawChatSendResponse(runId: activeRunId, status: "pending")
+            })
+        try await loadAndWaitBootstrap(vm: vm, sessionId: "sess-main")
+
+        await sendUserMessage(vm, text: "keep active stream")
+        try await waitUntil("remote run is adopted") {
+            await MainActor.run { vm.pendingRunCount == 1 && !vm.isSending }
+        }
+        emitAssistantText(transport: transport, runId: activeRunId, text: "Still working")
+        emitToolStart(transport: transport, runId: activeRunId)
+        emitPlan(
+            transport: transport,
+            runId: activeRunId,
+            steps: [planStep("Keep working", status: "in_progress")])
+        try await waitUntil("active run owns streaming, tools, and plan") {
+            await MainActor.run {
+                vm.streamingAssistantText == "Still working" &&
+                    vm.pendingToolCalls.count == 1 &&
+                    vm.planSteps.first?.step == "Keep working"
+            }
+        }
+
+        transport.emit(
+            .chat(
+                OpenClawChatEventPayload(
+                    runId: "older-run",
+                    sessionKey: "main",
+                    state: state,
+                    message: nil,
+                    errorMessage: state == "error" ? "Other run failed" : nil)))
+
+        try await Task.sleep(for: .milliseconds(100))
+
+        #expect(await MainActor.run { vm.pendingRunCount } == 1)
+        #expect(await MainActor.run { vm.streamingAssistantText } == "Still working")
+        #expect(await MainActor.run { vm.pendingToolCalls.count } == 1)
+        #expect(await MainActor.run { vm.planSteps } == [
+            OpenClawChatPlanStep(step: "Keep working", status: .inProgress),
+        ])
+        #expect(await MainActor.run { vm.errorText } == nil)
+    }
+
     @Test func `pending run blocks second main send`() async throws {
         let sessionId = "sess-main"
         let history = historyPayload(sessionId: sessionId, messages: [])


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where macOS and iOS users watching an active assistant response would lose its streaming text, pending tool activity, and active-run indicator when another client delivered a delayed terminal event for a different run in the same chat.

## Why This Change Was Made

The shared native chat model now applies terminal cleanup only to the run that owns the current presentation. External completions still refresh authoritative history; their transient cleanup still works when no local run is pending. Existing plan ownership, current-run cleanup, canonical session matching, and external-only final/error behavior are preserved. The change stays inside the shared native owner and introduces no configuration, protocol, storage, localization, or public API changes.

## User Impact

An active macOS or iOS assistant response continues streaming, keeps its tool progress and plan visible, and stays marked active when an older response finishes or another connected client completes a run.

## Evidence

- True latest-main red/green regression: replay each foreign `final`, `aborted`, and `error` event while another run owns the stream, tools, and plan; all three cases fail on unmodified `main` and pass with this fix.
- Complete real shared-native suite: **1,156 tests in 90 suites passed**, including existing own-run terminal cleanup, external-only final/error cleanup, history refresh, durable outbox, image, audio, and session/run controls.
- Remote canonical native localization proof: `pnpm native:i18n:baseline` reports **5,290 entries, `changed=false`**; `git diff --exit-code -- apps/.i18n/native-source.json` and `pnpm native:i18n:verify` both pass.
- Remote full changed gate: `pnpm check:changed -- apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+TransportEvents.swift apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift`.
- Pinned Swift formatting: `swiftformat --lint` reports **0/2 files require formatting**.
- Fresh independent, high-effort, full-branch review against the exact latest `main`; no actionable findings.
