### PR TITLE
fix: recognize Bash completion installed in login profiles

### DIFF
--- a/src/cli/completion-runtime.test.ts
+++ b/src/cli/completion-runtime.test.ts
@@ -3,7 +3,8 @@ import { spawnSync } from "node:child_process";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import {
   formatCompletionReloadCommand,
@@ -15,20 +16,17 @@ import {
   usesSlowDynamicCompletion,
 } from "./completion-runtime.js";
 
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
 async function withBashCompletionHome(
   run: (paths: { homeDir: string; stateDir: string }) => Promise<void>,
 ): Promise<void> {
-  const homeDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-bash-completion-home-"));
-  const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-bash-completion-state-"));
+  const homeDir = tempDirs.make("openclaw-bash-completion-home-");
+  const stateDir = tempDirs.make("openclaw-bash-completion-state-");
 
-  try {
-    await withEnvAsync({ HOME: homeDir, OPENCLAW_STATE_DIR: stateDir }, async () => {
-      await run({ homeDir, stateDir });
-    });
-  } finally {
-    await fs.rm(homeDir, { recursive: true, force: true });
-    await fs.rm(stateDir, { recursive: true, force: true });
-  }
+  await withEnvAsync({ HOME: homeDir, OPENCLAW_STATE_DIR: stateDir }, async () => {
+    await run({ homeDir, stateDir });
+  });
 }
 
 describe("completion-runtime", () => {

--- a/src/cli/completion-runtime.test.ts
+++ b/src/cli/completion-runtime.test.ts
@@ -1,4 +1,5 @@
 // Completion runtime tests cover shell completion generation and runtime file writes.
+import { spawnSync } from "node:child_process";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -7,12 +8,102 @@ import { withEnvAsync } from "../test-utils/env.js";
 import {
   formatCompletionReloadCommand,
   installCompletion,
+  isCompletionInstalled,
   resolveCompletionCachePath,
   resolveCompletionProfilePath,
   resolveShellFromEnv,
+  usesSlowDynamicCompletion,
 } from "./completion-runtime.js";
 
+async function withBashCompletionHome(
+  run: (paths: { homeDir: string; stateDir: string }) => Promise<void>,
+): Promise<void> {
+  const homeDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-bash-completion-home-"));
+  const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-bash-completion-state-"));
+
+  try {
+    await withEnvAsync({ HOME: homeDir, OPENCLAW_STATE_DIR: stateDir }, async () => {
+      await run({ homeDir, stateDir });
+    });
+  } finally {
+    await fs.rm(homeDir, { recursive: true, force: true });
+    await fs.rm(stateDir, { recursive: true, force: true });
+  }
+}
+
 describe("completion-runtime", () => {
+  it("resolves the documented Bash login profile when .bashrc is absent", async () => {
+    await withBashCompletionHome(async ({ homeDir }) => {
+      expect(resolveCompletionProfilePath("bash")).toBe(path.join(homeDir, ".bash_profile"));
+    });
+  });
+
+  it("recognizes cached Bash completion installed into the login profile", async () => {
+    await withBashCompletionHome(async ({ homeDir }) => {
+      const cachePath = resolveCompletionCachePath("bash", "openclaw");
+      await fs.mkdir(path.dirname(cachePath), { recursive: true });
+      await fs.writeFile(cachePath, "complete -W 'status' openclaw\n", "utf-8");
+
+      await installCompletion("bash", true, "openclaw");
+
+      const profilePath = path.join(homeDir, ".bash_profile");
+      await expect(fs.readFile(profilePath, "utf-8")).resolves.toContain(cachePath);
+      await expect(isCompletionInstalled("bash", "openclaw")).resolves.toBe(true);
+      await expect(usesSlowDynamicCompletion("bash", "openclaw")).resolves.toBe(false);
+
+      const shell = spawnSync(
+        "bash",
+        [
+          "--noprofile",
+          "--norc",
+          "-c",
+          'source "$1"; complete -p openclaw',
+          "openclaw",
+          profilePath,
+        ],
+        { encoding: "utf8" },
+      );
+      expect(shell.stderr).toBe("");
+      expect(shell.status).toBe(0);
+      expect(shell.stdout).toContain("complete -W 'status' openclaw");
+    });
+  });
+
+  it("detects slow dynamic Bash completion in the login profile", async () => {
+    await withBashCompletionHome(async ({ homeDir }) => {
+      await fs.writeFile(
+        path.join(homeDir, ".bash_profile"),
+        "source <(openclaw completion --shell bash)\n",
+        "utf-8",
+      );
+
+      await expect(isCompletionInstalled("bash", "openclaw")).resolves.toBe(true);
+      await expect(usesSlowDynamicCompletion("bash", "openclaw")).resolves.toBe(true);
+    });
+  });
+
+  it("prefers an existing .bashrc over the Bash login profile", async () => {
+    await withBashCompletionHome(async ({ homeDir }) => {
+      const bashrc = path.join(homeDir, ".bashrc");
+      const bashProfile = path.join(homeDir, ".bash_profile");
+      const cachePath = resolveCompletionCachePath("bash", "openclaw");
+      await fs.writeFile(bashrc, "# existing interactive Bash profile\n", "utf-8");
+      await fs.writeFile(bashProfile, "# existing Bash login profile\n", "utf-8");
+      await fs.mkdir(path.dirname(cachePath), { recursive: true });
+      await fs.writeFile(cachePath, "complete -W 'status' openclaw\n", "utf-8");
+
+      expect(resolveCompletionProfilePath("bash")).toBe(bashrc);
+      await installCompletion("bash", true, "openclaw");
+
+      await expect(fs.readFile(bashrc, "utf-8")).resolves.toContain(cachePath);
+      await expect(fs.readFile(bashProfile, "utf-8")).resolves.toBe(
+        "# existing Bash login profile\n",
+      );
+      await expect(isCompletionInstalled("bash", "openclaw")).resolves.toBe(true);
+      await expect(usesSlowDynamicCompletion("bash", "openclaw")).resolves.toBe(false);
+    });
+  });
+
   it("formats PowerShell reload commands with single-quoted paths", () => {
     expect(formatCompletionReloadCommand("powershell", "C:\\Users\\Ada\\profile.ps1")).toBe(
       ". 'C:\\Users\\Ada\\profile.ps1'",

--- a/src/cli/completion-runtime.ts
+++ b/src/cli/completion-runtime.ts
@@ -1,4 +1,5 @@
 // Shell completion runtime: cache paths, profile installation, and shell detection.
+import { existsSync } from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -170,7 +171,9 @@ export function resolveCompletionProfilePath(
     return path.join(home, ".zshrc");
   }
   if (shell === "bash") {
-    return path.join(home, ".bashrc");
+    // Installation, status, and repairs must inspect the same real Bash profile.
+    const bashrc = path.join(home, ".bashrc");
+    return existsSync(bashrc) ? bashrc : path.join(home, ".bash_profile");
   }
   if (shell === "fish") {
     return path.join(home, ".config", "fish", "config.fish");
@@ -257,12 +260,6 @@ export async function installCompletion(shell: string, yes: boolean, binName = "
       break;
     case "bash":
       profilePath = resolveCompletionProfilePath("bash");
-      try {
-        await fs.access(profilePath);
-      } catch {
-        const home = process.env.HOME || os.homedir();
-        profilePath = path.join(home, ".bash_profile");
-      }
       sourceLine = formatCompletionSourceLine("bash", cachePath);
       break;
     case "fish":

--- a/src/commands/doctor-completion.test.ts
+++ b/src/commands/doctor-completion.test.ts
@@ -40,6 +40,53 @@ function status(overrides: Partial<ShellCompletionStatus> = {}): ShellCompletion
 }
 
 describe("shell completion health mapping", () => {
+  it("recognizes cached Bash completion from the documented login profile", async () => {
+    const homeDir = tempDirs.make("openclaw-bash-profile-home-");
+    const stateDir = tempDirs.make("openclaw-bash-profile-state-");
+    setTestEnvValue("HOME", homeDir);
+    setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);
+    setTestEnvValue("SHELL", "/bin/bash");
+
+    const cachePath = path.join(stateDir, "completions", "openclaw.bash");
+    await fs.mkdir(path.dirname(cachePath), { recursive: true });
+    await fs.writeFile(cachePath, "complete -W 'status' openclaw\n", "utf-8");
+    await fs.writeFile(
+      path.join(homeDir, ".bash_profile"),
+      `# OpenClaw Completion\n[ -f "${cachePath}" ] && source "${cachePath}"\n`,
+      "utf-8",
+    );
+
+    await expect(checkShellCompletionStatus("openclaw", { shell: "bash" })).resolves.toEqual({
+      shell: "bash",
+      profileInstalled: true,
+      cacheExists: true,
+      cachePath,
+      usesSlowPattern: false,
+    });
+  });
+
+  it("reports slow dynamic Bash completion from the documented login profile", async () => {
+    const homeDir = tempDirs.make("openclaw-bash-slow-profile-home-");
+    const stateDir = tempDirs.make("openclaw-bash-slow-profile-state-");
+    setTestEnvValue("HOME", homeDir);
+    setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);
+    setTestEnvValue("SHELL", "/bin/bash");
+
+    await fs.writeFile(
+      path.join(homeDir, ".bash_profile"),
+      "source <(openclaw completion --shell bash)\n",
+      "utf-8",
+    );
+
+    await expect(checkShellCompletionStatus("openclaw", { shell: "bash" })).resolves.toEqual({
+      shell: "bash",
+      profileInstalled: true,
+      cacheExists: false,
+      cachePath: path.join(stateDir, "completions", "openclaw.bash"),
+      usesSlowPattern: true,
+    });
+  });
+
   it("checks an explicit shell instead of the detected environment shell", async () => {
     const homeDir = tempDirs.make("openclaw-completion-home-");
     const stateDir = tempDirs.make("openclaw-completion-state-");
@@ -172,6 +219,20 @@ describe("doctorShellCompletion", () => {
   beforeEach(() => {
     installCompletionMock.mockReset();
     spawnSyncMock.mockClear();
+  });
+
+  it("shows the Bash login profile after installing completion without .bashrc", async () => {
+    await setupDoctorCompletionTest(false);
+    installCompletionMock.mockResolvedValue(undefined);
+    const noteSpy = vi.spyOn(noteModule, "note");
+
+    await doctorShellCompletion({} as never, mockPrompter());
+
+    expect(installCompletionMock).toHaveBeenCalledWith("bash", true, "openclaw");
+    expect(noteSpy).toHaveBeenCalledWith(
+      expect.stringContaining("source ~/.bash_profile"),
+      "Shell completion",
+    );
   });
 
   it.each([

--- a/src/commands/doctor-completion.ts
+++ b/src/commands/doctor-completion.ts
@@ -44,7 +44,10 @@ function resolveCompletionReloadPath(shell: CompletionShell): string {
   if (shell === "powershell") {
     return resolveCompletionProfilePath("powershell");
   }
-  return `~/.${shell === "zsh" ? "zshrc" : shell === "bash" ? "bashrc" : "config/fish/config.fish"}`;
+  if (shell === "bash") {
+    return `~/${path.basename(resolveCompletionProfilePath("bash"))}`;
+  }
+  return `~/.${shell === "zsh" ? "zshrc" : "config/fish/config.fish"}`;
 }
 
 function formatCompletionReloadNote(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Bash users without a `.bashrc` would successfully install OpenClaw completion into their documented `.bash_profile`, but OpenClaw doctor, update, onboarding, and completion-status checks would incorrectly report that completion was not installed. Existing slow dynamic completion in `.bash_profile` was also ignored, and doctor told users to reload the nonexistent `.bashrc`.

## Why This Change Was Made

Make the existing canonical shell-profile resolver prefer `.bashrc` when it exists and otherwise select the documented `.bash_profile`. Reuse that one decision across installation, cache/status detection, slow-completion repair, and doctor's user-facing reload instructions; remove the duplicate Bash-only installer fallback.

The normal `.bashrc` behavior, zsh, fish, PowerShell, cache locations, permission-error handling, and shell option completions remain unchanged.

## User Impact

Bash completion installed into `.bash_profile` is immediately usable by an actual Bash shell, correctly recognized by health, doctor, update, and onboarding, upgraded when it uses slow dynamic completion, and accompanied by the correct `source ~/.bash_profile` instruction. Users who already have `.bashrc` retain the existing preferred behavior.

## Evidence

- Independently reproduced **six** user-visible failures on immutable `main` `fe4972b12b813bd92c18ae9532f66e613b449996`: wrong profile selection; installed completion reported missing; login-profile dynamic completion missed; doctor cache/status falsely reporting missing completion; doctor slow-pattern repair missed; and doctor instructing users to source nonexistent `.bashrc`. Verified that latest `main` `6f1950ec1a1b1fac6744fc6779aa2c81a1b71217` is byte-identical for all four changed files, all fourteen regression owners, the canonical temporary-directory helper, and the public completion contract.
- Verified the existing `.bashrc` preference as a passing control on the same unchanged main source.
- Executed the actual generated profile in `bash --noprofile --norc`; `source` registers the real completion and `complete -p openclaw` succeeds.
- A fresh Linux Blacksmith Testbox passes **500/500** real regressions across **14** files and **6** Vitest shards, including shell-runtime, Bash/fish/PowerShell completion, real doctor health and repair, **202** update scenarios, onboarding, script entry points, and existing CLI/profile behavior.
- The complete canonical `pnpm check:changed` passes on the same remote Testbox against the exact `fe4972b12b813bd92c18ae9532f66e613b449996` baseline with authoritative `exitCode: 0`, covering exact-file formatting and lint, production and test typechecking, dependency and compatibility ratchets, plugin-boundary and database guards, and import cycles. The four final changed files are byte-identical after rebasing onto latest `main` `6f1950ec1a1b1fac6744fc6779aa2c81a1b71217`; new test fixtures use the repository's automatic temporary-directory cleanup tracker, with zero temporary-directory migration warnings.
- A fresh independent Codex structured review of the exact committed four-file patch against current `main` reports no accepted or actionable findings, `patch is correct`, confidence **0.94**; a separate pre-commit review of canonical test-fixture cleanup reports confidence **0.99**, and official TruffleHog scanning is clean.
- Verified against the existing public contract in `docs/cli/completion.md`: Bash uses `.bashrc` and falls back to `.bash_profile` when `.bashrc` is absent.

AI-assisted; independently reproduced, source-reviewed, and remotely validated.
