### PR TITLE
fix: prevent session-changed errors after reset

### DIFF
--- a/extensions/codex/harness.test.ts
+++ b/extensions/codex/harness.test.ts
@@ -261,6 +261,13 @@ describe("Codex agent harness reset()", () => {
       agentId: "worker",
       sessionId: "session-1",
       sessionKey: "agent:worker:main",
+      lifecycleRevision: "revision-old",
+    });
+    const successor = sessionBindingIdentity({
+      agentId: "worker",
+      sessionId: "session-1",
+      sessionKey: "agent:worker:main",
+      lifecycleRevision: "revision-next",
     });
     await bindingStore.mutate(identity, {
       kind: "set",
@@ -276,26 +283,25 @@ describe("Codex agent harness reset()", () => {
       agentId: "worker",
       sessionId: "session-1",
       sessionKey: "agent:worker:main",
+      lifecycleRevision: "revision-old",
       reason: "reset",
-      resetToken: "reset-session-1",
     });
 
-    await expect(bindingStore.consumeSessionGenerationReset(identity, "wrong-reset")).resolves.toBe(
-      false,
-    );
     await expect(
-      bindingStore.consumeSessionGenerationReset(identity, "reset-session-1"),
+      bindingStore.mutate(successor, {
+        kind: "reclaim-generation",
+        expectedPreviousSessionId: identity.sessionId,
+        expectedPreviousLifecycleRevision: identity.lifecycleRevision,
+      }),
     ).resolves.toBe(true);
     await expect(
-      bindingStore.consumeSessionGenerationReset(identity, "reset-session-1"),
-    ).resolves.toBe(false);
-    await expect(
-      bindingStore.mutate(identity, {
+      bindingStore.mutate(successor, {
         kind: "set",
         binding: { threadId: "thread-2", cwd: "/repo" },
       }),
     ).resolves.toBe(true);
-    await expect(bindingStore.read(identity)).resolves.toMatchObject({ threadId: "thread-2" });
+    await expect(bindingStore.read(identity)).resolves.toBeUndefined();
+    await expect(bindingStore.read(successor)).resolves.toMatchObject({ threadId: "thread-2" });
   });
 });
 

--- a/extensions/codex/harness.test.ts
+++ b/extensions/codex/harness.test.ts
@@ -237,7 +237,25 @@ describe("Codex agent harness supports()", () => {
 });
 
 describe("Codex agent harness reset()", () => {
-  it("retires the physical session generation", async () => {
+  it("is idempotent before the retained session has a binding", async () => {
+    const harness = createCodexAppServerAgentHarness({
+      bindingStore: createCodexTestBindingStore(),
+    });
+    if (!harness.reset) {
+      throw new Error("expected Codex harness reset hook");
+    }
+
+    await expect(
+      harness.reset({
+        agentId: "worker",
+        sessionId: "session-1",
+        sessionKey: "agent:worker:main",
+        reason: "reset",
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("clears a retired physical generation so the retained session can bind again", async () => {
     const bindingStore = createCodexTestBindingStore();
     const identity = sessionBindingIdentity({
       agentId: "worker",
@@ -248,6 +266,7 @@ describe("Codex agent harness reset()", () => {
       kind: "set",
       binding: { threadId: "thread-1", cwd: "/repo" },
     });
+    await bindingStore.retireSessionGeneration(identity);
     const harness = createCodexAppServerAgentHarness({ bindingStore });
     if (!harness.reset) {
       throw new Error("expected Codex harness reset hook");
@@ -258,9 +277,25 @@ describe("Codex agent harness reset()", () => {
       sessionId: "session-1",
       sessionKey: "agent:worker:main",
       reason: "reset",
+      resetToken: "reset-session-1",
     });
 
-    await expect(bindingStore.read(identity)).resolves.toBeUndefined();
+    await expect(bindingStore.consumeSessionGenerationReset(identity, "wrong-reset")).resolves.toBe(
+      false,
+    );
+    await expect(
+      bindingStore.consumeSessionGenerationReset(identity, "reset-session-1"),
+    ).resolves.toBe(true);
+    await expect(
+      bindingStore.consumeSessionGenerationReset(identity, "reset-session-1"),
+    ).resolves.toBe(false);
+    await expect(
+      bindingStore.mutate(identity, {
+        kind: "set",
+        binding: { threadId: "thread-2", cwd: "/repo" },
+      }),
+    ).resolves.toBe(true);
+    await expect(bindingStore.read(identity)).resolves.toMatchObject({ threadId: "thread-2" });
   });
 });
 

--- a/extensions/codex/harness.test.ts
+++ b/extensions/codex/harness.test.ts
@@ -1,6 +1,9 @@
 // Codex tests cover harness plugin behavior.
 import { describe, expect, it, vi } from "vitest";
-import { createCodexAppServerAgentHarness } from "./harness.js";
+import {
+  createCodexAppServerAgentHarness,
+  resetCodexSessionBindingGeneration,
+} from "./harness.js";
 import {
   createCodexTestBindingStore,
   sessionBindingIdentity,
@@ -237,6 +240,27 @@ describe("Codex agent harness supports()", () => {
 });
 
 describe("Codex agent harness reset()", () => {
+  it("accepts a stale reset after the authoritative successor claimed the binding", async () => {
+    const mutate = vi.fn().mockResolvedValueOnce(false).mockResolvedValueOnce(false);
+    const reclaimCurrent = vi.fn().mockResolvedValue(true);
+
+    await expect(
+      resetCodexSessionBindingGeneration({
+        bindingStore: { mutate },
+        identity: sessionBindingIdentity({
+          agentId: "worker",
+          sessionId: "session-1",
+          sessionKey: "agent:worker:main",
+          lifecycleRevision: "revision-old",
+        }),
+        reclaimCurrent,
+      }),
+    ).resolves.toBe(true);
+
+    expect(reclaimCurrent).toHaveBeenCalledOnce();
+    expect(mutate).toHaveBeenCalledTimes(2);
+  });
+
   it("is idempotent before the retained session has a binding", async () => {
     const harness = createCodexAppServerAgentHarness({
       bindingStore: createCodexTestBindingStore(),

--- a/extensions/codex/harness.test.ts
+++ b/extensions/codex/harness.test.ts
@@ -1,9 +1,6 @@
 // Codex tests cover harness plugin behavior.
 import { describe, expect, it, vi } from "vitest";
-import {
-  createCodexAppServerAgentHarness,
-  resetCodexSessionBindingGeneration,
-} from "./harness.js";
+import { createCodexAppServerAgentHarness, resetCodexSessionBindingGeneration } from "./harness.js";
 import {
   createCodexTestBindingStore,
   sessionBindingIdentity,

--- a/extensions/codex/harness.ts
+++ b/extensions/codex/harness.ts
@@ -9,7 +9,10 @@ import type {
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { PluginRuntime } from "openclaw/plugin-sdk/plugin-runtime";
-import type { CodexAppServerBindingStore } from "./src/app-server/session-binding.js";
+import type {
+  CodexAppServerBindingIdentity,
+  CodexAppServerBindingStore,
+} from "./src/app-server/session-binding.js";
 import type { CodexSessionCatalogControl } from "./src/session-catalog-types.js";
 
 // `codex` is legacy input only until Part 2 doctor migration rewrites stored refs.
@@ -39,6 +42,24 @@ async function disposeSharedCodexAppServerClients(): Promise<void> {
     }
   )[SHARED_CODEX_APP_SERVER_CLIENT_DISPOSER];
   await dispose?.();
+}
+
+export async function resetCodexSessionBindingGeneration(params: {
+  bindingStore: Pick<CodexAppServerBindingStore, "mutate">;
+  identity: Extract<CodexAppServerBindingIdentity, { kind: "session" }>;
+  reclaimCurrent: () => Promise<boolean>;
+}): Promise<boolean> {
+  if (await params.bindingStore.mutate(params.identity, { kind: "reset-generation" })) {
+    return true;
+  }
+  if (!(await params.reclaimCurrent())) {
+    return false;
+  }
+  // Reclaim either cleared/adopted the authoritative generation or made this
+  // generation current. A false retry means ownership advanced again, so the
+  // stale reset is already complete and must not fail the successor.
+  await params.bindingStore.mutate(params.identity, { kind: "reset-generation" });
+  return true;
 }
 
 /**
@@ -219,17 +240,16 @@ export function createCodexAppServerAgentHarness(options: {
           sessionKey: params.sessionKey,
           lifecycleRevision: params.lifecycleRevision,
         });
-        let reset = await options.bindingStore.mutate(identity, { kind: "reset-generation" });
-        if (!reset) {
-          const reclaimed = await reclaimCurrentCodexSessionGeneration({
-            bindingStore: options.bindingStore,
-            identity,
-            config: options.resolveConfig?.(),
-          });
-          if (reclaimed) {
-            reset = await options.bindingStore.mutate(identity, { kind: "reset-generation" });
-          }
-        }
+        const reset = await resetCodexSessionBindingGeneration({
+          bindingStore: options.bindingStore,
+          identity,
+          reclaimCurrent: async () =>
+            await reclaimCurrentCodexSessionGeneration({
+              bindingStore: options.bindingStore,
+              identity,
+              config: options.resolveConfig?.(),
+            }),
+        });
         if (!reset) {
           throw new Error(
             `Codex binding generation changed before session ${params.sessionId} could reset`,

--- a/extensions/codex/harness.ts
+++ b/extensions/codex/harness.ts
@@ -217,6 +217,7 @@ export function createCodexAppServerAgentHarness(options: {
           agentId: params.agentId,
           sessionId: params.sessionId,
           sessionKey: params.sessionKey,
+          lifecycleRevision: params.lifecycleRevision,
         });
         let reset = await options.bindingStore.mutate(identity, { kind: "reset-generation" });
         if (!reset) {
@@ -233,10 +234,6 @@ export function createCodexAppServerAgentHarness(options: {
           throw new Error(
             `Codex binding generation changed before session ${params.sessionId} could reset`,
           );
-        }
-        const resetToken = params.resetToken?.trim();
-        if (resetToken) {
-          await options.bindingStore.recordSessionGenerationReset(identity, resetToken);
         }
       }
     },

--- a/extensions/codex/harness.ts
+++ b/extensions/codex/harness.ts
@@ -218,21 +218,25 @@ export function createCodexAppServerAgentHarness(options: {
           sessionId: params.sessionId,
           sessionKey: params.sessionKey,
         });
-        let retired = await options.bindingStore.retireSessionGeneration(identity);
-        if (retired === "conflict") {
+        let reset = await options.bindingStore.mutate(identity, { kind: "reset-generation" });
+        if (!reset) {
           const reclaimed = await reclaimCurrentCodexSessionGeneration({
             bindingStore: options.bindingStore,
             identity,
             config: options.resolveConfig?.(),
           });
           if (reclaimed) {
-            retired = await options.bindingStore.retireSessionGeneration(identity);
+            reset = await options.bindingStore.mutate(identity, { kind: "reset-generation" });
           }
         }
-        if (retired === "conflict") {
+        if (!reset) {
           throw new Error(
             `Codex binding generation changed before session ${params.sessionId} could reset`,
           );
+        }
+        const resetToken = params.resetToken?.trim();
+        if (resetToken) {
+          await options.bindingStore.recordSessionGenerationReset(identity, resetToken);
         }
       }
     },

--- a/extensions/codex/index.test.ts
+++ b/extensions/codex/index.test.ts
@@ -532,43 +532,48 @@ describe("codex plugin", () => {
     await expect(bindingStore.read(failedReset)).resolves.toBeUndefined();
 
     // A successful harness reset records the exact generation. Preserve the
-    // fresh binding even when its delayed same-id end arrives after rebinding.
-    const retained = sessionBindingIdentity({
-      agentId: "worker",
-      sessionId: "retained-1",
-      sessionKey: "agent:worker:retained-1",
-    });
-    await bindingStore.mutate(retained, {
-      kind: "set",
-      binding: { threadId: "thread-before-reset", cwd: "/repo" },
-    });
-    await harness.reset({
-      agentId: "worker",
-      sessionId: "retained-1",
-      sessionKey: "agent:worker:retained-1",
-      reason: "reset",
-      resetToken: "retained-reset-token",
-    });
-    await bindingStore.mutate(retained, {
-      kind: "set",
-      binding: { threadId: "thread-after-reset", cwd: "/repo" },
-    });
-    await expect(
-      bindingStore.consumeSessionGenerationReset(retained, "unrelated-reset-token"),
-    ).resolves.toBe(false);
-    await sessionEnd(
-      {
-        sessionId: "retained-1",
-        sessionKey: "agent:worker:retained-1",
-        reason: "new",
-        nextSessionId: "retained-1",
-        resetToken: "retained-reset-token",
-      },
-      { agentId: "worker", sessionId: "retained-1" },
-    );
-    await expect(bindingStore.read(retained)).resolves.toMatchObject({
-      threadId: "thread-after-reset",
-    });
+    // fresh binding even when any delayed same-id reset end arrives after rebinding.
+    for (const reason of ["new", "reset", "idle", "daily"] as const) {
+      const sessionId = `retained-${reason}`;
+      const sessionKey = `agent:worker:${sessionId}`;
+      const resetToken = `${sessionId}-reset-token`;
+      const retained = sessionBindingIdentity({
+        agentId: "worker",
+        sessionId,
+        sessionKey,
+      });
+      await bindingStore.mutate(retained, {
+        kind: "set",
+        binding: { threadId: `thread-before-${reason}`, cwd: "/repo" },
+      });
+      await harness.reset({
+        agentId: "worker",
+        sessionId,
+        sessionKey,
+        reason,
+        resetToken,
+      });
+      await bindingStore.mutate(retained, {
+        kind: "set",
+        binding: { threadId: `thread-after-${reason}`, cwd: "/repo" },
+      });
+      await expect(
+        bindingStore.consumeSessionGenerationReset(retained, "unrelated-reset-token"),
+      ).resolves.toBe(false);
+      await sessionEnd(
+        {
+          sessionId,
+          sessionKey,
+          reason,
+          nextSessionId: sessionId,
+          resetToken,
+        },
+        { agentId: "worker", sessionId },
+      );
+      await expect(bindingStore.read(retained)).resolves.toMatchObject({
+        threadId: `thread-after-${reason}`,
+      });
+    }
 
     // Repeated delivery of the same reset token remains one logical marker,
     // while a different reset token cannot steal it.

--- a/extensions/codex/index.test.ts
+++ b/extensions/codex/index.test.ts
@@ -465,9 +465,10 @@ describe("codex plugin", () => {
             sessionId: string;
             sessionKey?: string;
             reason?: string;
+            lifecycleRevision?: string;
             nextSessionId?: string;
             nextSessionKey?: string;
-            resetToken?: string;
+            nextLifecycleRevision?: string;
           },
           ctx: { agentId?: string; sessionId: string; sessionKey?: string },
         ) => Promise<void>)
@@ -509,13 +510,21 @@ describe("codex plugin", () => {
       await expect(bindingStore.read(identity)).resolves.toBeUndefined();
     }
 
-    // Same-id equality alone is not proof that the harness reset succeeded.
-    const failedReset = sessionBindingIdentity({
+    // A reset hook failure still retires only the old lifecycle revision. The
+    // authoritative same-id successor can reclaim that row and bind normally.
+    const failedResetOld = sessionBindingIdentity({
       agentId: "worker",
       sessionId: "failed-reset-1",
       sessionKey: "agent:worker:failed-reset-1",
+      lifecycleRevision: "failed-reset-old",
     });
-    await bindingStore.mutate(failedReset, {
+    const failedResetNext = sessionBindingIdentity({
+      agentId: "worker",
+      sessionId: "failed-reset-1",
+      sessionKey: "agent:worker:failed-reset-1",
+      lifecycleRevision: "failed-reset-next",
+    });
+    await bindingStore.mutate(failedResetOld, {
       kind: "set",
       binding: { threadId: "thread-stale", cwd: "/repo" },
     });
@@ -524,25 +533,48 @@ describe("codex plugin", () => {
         sessionId: "failed-reset-1",
         sessionKey: "agent:worker:failed-reset-1",
         reason: "new",
+        lifecycleRevision: "failed-reset-old",
         nextSessionId: "failed-reset-1",
-        resetToken: "failed-reset-token",
+        nextLifecycleRevision: "failed-reset-next",
       },
       { agentId: "worker", sessionId: "failed-reset-1" },
     );
-    await expect(bindingStore.read(failedReset)).resolves.toBeUndefined();
+    await expect(bindingStore.read(failedResetOld)).resolves.toBeUndefined();
+    await expect(
+      bindingStore.mutate(failedResetNext, {
+        kind: "reclaim-generation",
+        expectedPreviousSessionId: failedResetOld.sessionId,
+        expectedPreviousLifecycleRevision: failedResetOld.lifecycleRevision,
+      }),
+    ).resolves.toBe(true);
+    await expect(
+      bindingStore.mutate(failedResetNext, {
+        kind: "set",
+        binding: { threadId: "thread-recovered", cwd: "/repo" },
+      }),
+    ).resolves.toBe(true);
+    await expect(bindingStore.read(failedResetNext)).resolves.toMatchObject({
+      threadId: "thread-recovered",
+    });
 
-    // A successful harness reset records the exact generation. Preserve the
-    // fresh binding even when any delayed same-id reset end arrives after rebinding.
+    // A successful reset clears the exact old revision. A new same-id revision
+    // may bind before the delayed session_end arrives without being retired.
     for (const reason of ["new", "reset", "idle", "daily"] as const) {
       const sessionId = `retained-${reason}`;
       const sessionKey = `agent:worker:${sessionId}`;
-      const resetToken = `${sessionId}-reset-token`;
+      const previous = sessionBindingIdentity({
+        agentId: "worker",
+        sessionId,
+        sessionKey,
+        lifecycleRevision: `${sessionId}-old`,
+      });
       const retained = sessionBindingIdentity({
         agentId: "worker",
         sessionId,
         sessionKey,
+        lifecycleRevision: `${sessionId}-next`,
       });
-      await bindingStore.mutate(retained, {
+      await bindingStore.mutate(previous, {
         kind: "set",
         binding: { threadId: `thread-before-${reason}`, cwd: "/repo" },
       });
@@ -550,23 +582,28 @@ describe("codex plugin", () => {
         agentId: "worker",
         sessionId,
         sessionKey,
+        lifecycleRevision: previous.lifecycleRevision,
         reason,
-        resetToken,
       });
+      await expect(
+        bindingStore.mutate(retained, {
+          kind: "reclaim-generation",
+          expectedPreviousSessionId: previous.sessionId,
+          expectedPreviousLifecycleRevision: previous.lifecycleRevision,
+        }),
+      ).resolves.toBe(true);
       await bindingStore.mutate(retained, {
         kind: "set",
         binding: { threadId: `thread-after-${reason}`, cwd: "/repo" },
       });
-      await expect(
-        bindingStore.consumeSessionGenerationReset(retained, "unrelated-reset-token"),
-      ).resolves.toBe(false);
       await sessionEnd(
         {
           sessionId,
           sessionKey,
           reason,
+          lifecycleRevision: previous.lifecycleRevision,
           nextSessionId: sessionId,
-          resetToken,
+          nextLifecycleRevision: retained.lifecycleRevision,
         },
         { agentId: "worker", sessionId },
       );
@@ -574,42 +611,6 @@ describe("codex plugin", () => {
         threadId: `thread-after-${reason}`,
       });
     }
-
-    // Repeated delivery of the same reset token remains one logical marker,
-    // while a different reset token cannot steal it.
-    const interleaved = sessionBindingIdentity({
-      agentId: "worker",
-      sessionId: "interleaved-1",
-      sessionKey: "agent:worker:interleaved-1",
-    });
-    await bindingStore.recordSessionGenerationReset(interleaved, "exact-reset-token");
-    await bindingStore.recordSessionGenerationReset(interleaved, "exact-reset-token");
-    await expect(
-      bindingStore.consumeSessionGenerationReset(interleaved, "other-reset-token"),
-    ).resolves.toBe(false);
-    await expect(
-      bindingStore.consumeSessionGenerationReset(interleaved, "exact-reset-token"),
-    ).resolves.toBe(true);
-    await expect(
-      bindingStore.consumeSessionGenerationReset(interleaved, "exact-reset-token"),
-    ).resolves.toBe(false);
-
-    // A delayed lifecycle end must remain correlated even when many newer
-    // resets complete first; insertion pressure cannot evict a valid marker.
-    const delayed = sessionBindingIdentity({
-      agentId: "worker",
-      sessionId: "delayed-1",
-      sessionKey: "agent:worker:delayed-1",
-    });
-    await bindingStore.recordSessionGenerationReset(delayed, "oldest-reset-token");
-    await Promise.all(
-      Array.from({ length: 1_024 }, (_, index) =>
-        bindingStore.recordSessionGenerationReset(delayed, `newer-reset-token-${index}`),
-      ),
-    );
-    await expect(
-      bindingStore.consumeSessionGenerationReset(delayed, "oldest-reset-token"),
-    ).resolves.toBe(true);
 
     // Cross-key handoff (e.g. dashboard "New Chat"/fork): the parent's still-live
     // binding must survive because the successor lives under a different key and
@@ -619,46 +620,35 @@ describe("codex plugin", () => {
       agentId: "worker",
       sessionId: "parent-1",
       sessionKey: "agent:worker:parent-1",
+      lifecycleRevision: "parent-revision",
     });
     await bindingStore.mutate(parent, {
       kind: "set",
       binding: { threadId: "thread-parent", cwd: "/repo" },
     });
-    await harness.reset({
-      agentId: "worker",
-      sessionId: "parent-1",
-      sessionKey: "agent:worker:parent-1",
-      reason: "reset",
-      resetToken: "cross-key-reset-token",
-    });
-    await bindingStore.mutate(parent, {
-      kind: "set",
-      binding: { threadId: "thread-parent-after-reset", cwd: "/repo" },
-    });
     await sessionEnd(
       {
         sessionId: "parent-1",
         sessionKey: "agent:worker:parent-1",
         reason: "new",
+        lifecycleRevision: "parent-revision",
         nextSessionId: "child-1",
-        resetToken: "cross-key-reset-token",
         nextSessionKey: "agent:worker:dashboard:child-1",
       },
       { agentId: "worker", sessionId: "parent-1" },
     );
     await expect(bindingStore.read(parent)).resolves.toMatchObject({
-      threadId: "thread-parent-after-reset",
+      threadId: "thread-parent",
     });
 
-    // The cross-key end consumed its token even though it preserved the parent.
-    // A duplicate same-id end therefore cannot reuse that token to skip cleanup.
+    // A same-key end for that exact revision still retires the parent.
     await sessionEnd(
       {
         sessionId: "parent-1",
         sessionKey: "agent:worker:parent-1",
         reason: "new",
+        lifecycleRevision: "parent-revision",
         nextSessionId: "parent-1",
-        resetToken: "cross-key-reset-token",
       },
       { agentId: "worker", sessionId: "parent-1" },
     );

--- a/extensions/codex/index.test.ts
+++ b/extensions/codex/index.test.ts
@@ -442,6 +442,7 @@ describe("codex plugin", () => {
     const stateStore = createCodexTestBindingStateStore();
     const bindingStore = createCodexAppServerBindingStore(stateStore);
     const on = vi.fn();
+    const registerAgentHarness = vi.fn();
     plugin.register(
       createTestPluginApi({
         id: "codex",
@@ -450,7 +451,7 @@ describe("codex plugin", () => {
         config: {},
         pluginConfig: {},
         runtime: createCodexTestRuntime(undefined, stateStore),
-        registerAgentHarness: vi.fn(),
+        registerAgentHarness,
         registerCommand: vi.fn(),
         registerMediaUnderstandingProvider: vi.fn(),
         registerMigrationProvider: vi.fn(),
@@ -466,12 +467,19 @@ describe("codex plugin", () => {
             reason?: string;
             nextSessionId?: string;
             nextSessionKey?: string;
+            resetToken?: string;
           },
           ctx: { agentId?: string; sessionId: string; sessionKey?: string },
         ) => Promise<void>)
       | undefined;
     if (!sessionEnd) {
       throw new Error("missing Codex session_end hook");
+    }
+    const harness = mockCallArg(registerAgentHarness) as ReturnType<
+      typeof createCodexAppServerAgentHarness
+    >;
+    if (!harness.reset) {
+      throw new Error("missing Codex harness reset hook");
     }
     const identity = sessionBindingIdentity({
       agentId: "worker",
@@ -501,6 +509,103 @@ describe("codex plugin", () => {
       await expect(bindingStore.read(identity)).resolves.toBeUndefined();
     }
 
+    // Same-id equality alone is not proof that the harness reset succeeded.
+    const failedReset = sessionBindingIdentity({
+      agentId: "worker",
+      sessionId: "failed-reset-1",
+      sessionKey: "agent:worker:failed-reset-1",
+    });
+    await bindingStore.mutate(failedReset, {
+      kind: "set",
+      binding: { threadId: "thread-stale", cwd: "/repo" },
+    });
+    await sessionEnd(
+      {
+        sessionId: "failed-reset-1",
+        sessionKey: "agent:worker:failed-reset-1",
+        reason: "new",
+        nextSessionId: "failed-reset-1",
+        resetToken: "failed-reset-token",
+      },
+      { agentId: "worker", sessionId: "failed-reset-1" },
+    );
+    await expect(bindingStore.read(failedReset)).resolves.toBeUndefined();
+
+    // A successful harness reset records the exact generation. Preserve the
+    // fresh binding even when its delayed same-id end arrives after rebinding.
+    const retained = sessionBindingIdentity({
+      agentId: "worker",
+      sessionId: "retained-1",
+      sessionKey: "agent:worker:retained-1",
+    });
+    await bindingStore.mutate(retained, {
+      kind: "set",
+      binding: { threadId: "thread-before-reset", cwd: "/repo" },
+    });
+    await harness.reset({
+      agentId: "worker",
+      sessionId: "retained-1",
+      sessionKey: "agent:worker:retained-1",
+      reason: "reset",
+      resetToken: "retained-reset-token",
+    });
+    await bindingStore.mutate(retained, {
+      kind: "set",
+      binding: { threadId: "thread-after-reset", cwd: "/repo" },
+    });
+    await expect(
+      bindingStore.consumeSessionGenerationReset(retained, "unrelated-reset-token"),
+    ).resolves.toBe(false);
+    await sessionEnd(
+      {
+        sessionId: "retained-1",
+        sessionKey: "agent:worker:retained-1",
+        reason: "new",
+        nextSessionId: "retained-1",
+        resetToken: "retained-reset-token",
+      },
+      { agentId: "worker", sessionId: "retained-1" },
+    );
+    await expect(bindingStore.read(retained)).resolves.toMatchObject({
+      threadId: "thread-after-reset",
+    });
+
+    // Repeated delivery of the same reset token remains one logical marker,
+    // while a different reset token cannot steal it.
+    const interleaved = sessionBindingIdentity({
+      agentId: "worker",
+      sessionId: "interleaved-1",
+      sessionKey: "agent:worker:interleaved-1",
+    });
+    await bindingStore.recordSessionGenerationReset(interleaved, "exact-reset-token");
+    await bindingStore.recordSessionGenerationReset(interleaved, "exact-reset-token");
+    await expect(
+      bindingStore.consumeSessionGenerationReset(interleaved, "other-reset-token"),
+    ).resolves.toBe(false);
+    await expect(
+      bindingStore.consumeSessionGenerationReset(interleaved, "exact-reset-token"),
+    ).resolves.toBe(true);
+    await expect(
+      bindingStore.consumeSessionGenerationReset(interleaved, "exact-reset-token"),
+    ).resolves.toBe(false);
+
+    // A delayed lifecycle end must remain correlated even when many newer
+    // resets complete first; insertion pressure cannot evict a valid marker.
+    const delayed = sessionBindingIdentity({
+      agentId: "worker",
+      sessionId: "delayed-1",
+      sessionKey: "agent:worker:delayed-1",
+    });
+    await bindingStore.recordSessionGenerationReset(delayed, "oldest-reset-token");
+    await Promise.all(
+      Array.from({ length: 1_024 }, (_, index) =>
+        bindingStore.recordSessionGenerationReset(delayed, `newer-reset-token-${index}`),
+      ),
+    );
+    await expect(
+      bindingStore.consumeSessionGenerationReset(delayed, "oldest-reset-token"),
+    ).resolves.toBe(true);
+
     // Cross-key handoff (e.g. dashboard "New Chat"/fork): the parent's still-live
     // binding must survive because the successor lives under a different key and
     // owns its own Codex thread. Use a fresh parent key (session-1 above is now
@@ -514,26 +619,41 @@ describe("codex plugin", () => {
       kind: "set",
       binding: { threadId: "thread-parent", cwd: "/repo" },
     });
+    await harness.reset({
+      agentId: "worker",
+      sessionId: "parent-1",
+      sessionKey: "agent:worker:parent-1",
+      reason: "reset",
+      resetToken: "cross-key-reset-token",
+    });
+    await bindingStore.mutate(parent, {
+      kind: "set",
+      binding: { threadId: "thread-parent-after-reset", cwd: "/repo" },
+    });
     await sessionEnd(
       {
         sessionId: "parent-1",
         sessionKey: "agent:worker:parent-1",
         reason: "new",
         nextSessionId: "child-1",
+        resetToken: "cross-key-reset-token",
         nextSessionKey: "agent:worker:dashboard:child-1",
       },
       { agentId: "worker", sessionId: "parent-1" },
     );
-    await expect(bindingStore.read(parent)).resolves.toMatchObject({ threadId: "thread-parent" });
+    await expect(bindingStore.read(parent)).resolves.toMatchObject({
+      threadId: "thread-parent-after-reset",
+    });
 
-    // A same-key replacement that still names the successor id (physical rollover)
-    // has no distinct nextSessionKey, so it retires as before.
+    // The cross-key end consumed its token even though it preserved the parent.
+    // A duplicate same-id end therefore cannot reuse that token to skip cleanup.
     await sessionEnd(
       {
         sessionId: "parent-1",
         sessionKey: "agent:worker:parent-1",
         reason: "new",
-        nextSessionId: "parent-2",
+        nextSessionId: "parent-1",
+        resetToken: "cross-key-reset-token",
       },
       { agentId: "worker", sessionId: "parent-1" },
     );

--- a/extensions/codex/index.test.ts
+++ b/extensions/codex/index.test.ts
@@ -468,7 +468,6 @@ describe("codex plugin", () => {
             lifecycleRevision?: string;
             nextSessionId?: string;
             nextSessionKey?: string;
-            nextLifecycleRevision?: string;
           },
           ctx: { agentId?: string; sessionId: string; sessionKey?: string },
         ) => Promise<void>)
@@ -535,7 +534,6 @@ describe("codex plugin", () => {
         reason: "new",
         lifecycleRevision: "failed-reset-old",
         nextSessionId: "failed-reset-1",
-        nextLifecycleRevision: "failed-reset-next",
       },
       { agentId: "worker", sessionId: "failed-reset-1" },
     );
@@ -603,7 +601,6 @@ describe("codex plugin", () => {
           reason,
           lifecycleRevision: previous.lifecycleRevision,
           nextSessionId: sessionId,
-          nextLifecycleRevision: retained.lifecycleRevision,
         },
         { agentId: "worker", sessionId },
       );

--- a/extensions/codex/index.ts
+++ b/extensions/codex/index.ts
@@ -339,25 +339,36 @@ export default definePluginEntry({
       // key; that child owns its own Codex thread binding (a Codex fork is a new
       // thread, not a transfer of the parent's). Retiring the parent's still-live
       // binding here would strand it, so skip when the successor provably lives
-      // under a different session key. The only cross-key emitter (gateway child
-      // creation) keeps the parent row live; same-key rollovers omit or repeat
-      // the key and still retire, as do unknown-current-key ends (no provable
-      // handoff) and later idle/daily/deleted ends. See #106778.
+      // under a different session key. Durable reset can also retain the same
+      // physical id, but equality alone is not proof that harness cleanup ran:
+      // consume the exact successful reset token before suppressing its delayed
+      // end. A missing or mismatched token remains fail-closed.
+      // Unknown-current-key ends and true physical rollovers still retire. See
+      // #106778.
       const endedSessionKey = sessionKey?.trim();
       const nextSessionKey = event.nextSessionKey?.trim();
+      const config = resolveCurrentConfig();
+      const { sessionBindingIdentity } = await import("./src/app-server/session-binding.js");
+      const identity = sessionBindingIdentity({
+        sessionId: event.sessionId,
+        ...(sessionKey ? { sessionKey } : {}),
+        ...(ctx.agentId ? { agentId: ctx.agentId } : {}),
+        ...(config ? { config } : {}),
+      });
+      const endedSessionId = event.sessionId.trim();
+      const nextSessionId = event.nextSessionId?.trim();
+      const resetToken = event.resetToken?.trim();
+      const matchedReset =
+        (event.reason === "new" || event.reason === "reset") &&
+        resetToken &&
+        (await bindingStore.consumeSessionGenerationReset(identity, resetToken));
       if (endedSessionKey && nextSessionKey && nextSessionKey !== endedSessionKey) {
         return;
       }
-      const config = resolveCurrentConfig();
-      const { sessionBindingIdentity } = await import("./src/app-server/session-binding.js");
-      await bindingStore.retireSessionGeneration(
-        sessionBindingIdentity({
-          sessionId: event.sessionId,
-          ...(sessionKey ? { sessionKey } : {}),
-          ...(ctx.agentId ? { agentId: ctx.agentId } : {}),
-          ...(config ? { config } : {}),
-        }),
-      );
+      if (endedSessionId && nextSessionId === endedSessionId && matchedReset) {
+        return;
+      }
+      await bindingStore.retireSessionGeneration(identity);
     });
   },
 });

--- a/extensions/codex/index.ts
+++ b/extensions/codex/index.ts
@@ -49,12 +49,7 @@ import {
 } from "./src/supervision-tools.js";
 import { createCodexWebSearchProvider } from "./src/web-search-provider.js";
 
-const RESET_SESSION_REASONS: ReadonlySet<string> = new Set([
-  "new",
-  "reset",
-  "idle",
-  "daily",
-]);
+const RESET_SESSION_REASONS: ReadonlySet<string> = new Set(["new", "reset", "idle", "daily"]);
 const ENDED_SESSION_REASONS: ReadonlySet<string> = new Set([
   ...RESET_SESSION_REASONS,
   "deleted",

--- a/extensions/codex/index.ts
+++ b/extensions/codex/index.ts
@@ -49,11 +49,14 @@ import {
 } from "./src/supervision-tools.js";
 import { createCodexWebSearchProvider } from "./src/web-search-provider.js";
 
-const ENDED_SESSION_REASONS: ReadonlySet<string> = new Set([
+const RESET_SESSION_REASONS: ReadonlySet<string> = new Set([
   "new",
   "reset",
   "idle",
   "daily",
+]);
+const ENDED_SESSION_REASONS: ReadonlySet<string> = new Set([
+  ...RESET_SESSION_REASONS,
   "deleted",
 ]);
 
@@ -359,7 +362,7 @@ export default definePluginEntry({
       const nextSessionId = event.nextSessionId?.trim();
       const resetToken = event.resetToken?.trim();
       const matchedReset =
-        (event.reason === "new" || event.reason === "reset") &&
+        RESET_SESSION_REASONS.has(event.reason) &&
         resetToken &&
         (await bindingStore.consumeSessionGenerationReset(identity, resetToken));
       if (endedSessionKey && nextSessionKey && nextSessionKey !== endedSessionKey) {

--- a/extensions/codex/index.ts
+++ b/extensions/codex/index.ts
@@ -50,10 +50,7 @@ import {
 import { createCodexWebSearchProvider } from "./src/web-search-provider.js";
 
 const RESET_SESSION_REASONS: ReadonlySet<string> = new Set(["new", "reset", "idle", "daily"]);
-const ENDED_SESSION_REASONS: ReadonlySet<string> = new Set([
-  ...RESET_SESSION_REASONS,
-  "deleted",
-]);
+const ENDED_SESSION_REASONS: ReadonlySet<string> = new Set([...RESET_SESSION_REASONS, "deleted"]);
 
 export default definePluginEntry({
   id: "codex",

--- a/extensions/codex/index.ts
+++ b/extensions/codex/index.ts
@@ -49,8 +49,13 @@ import {
 } from "./src/supervision-tools.js";
 import { createCodexWebSearchProvider } from "./src/web-search-provider.js";
 
-const RESET_SESSION_REASONS: ReadonlySet<string> = new Set(["new", "reset", "idle", "daily"]);
-const ENDED_SESSION_REASONS: ReadonlySet<string> = new Set([...RESET_SESSION_REASONS, "deleted"]);
+const ENDED_SESSION_REASONS: ReadonlySet<string> = new Set([
+  "new",
+  "reset",
+  "idle",
+  "daily",
+  "deleted",
+]);
 
 export default definePluginEntry({
   id: "codex",
@@ -334,10 +339,8 @@ export default definePluginEntry({
       // key; that child owns its own Codex thread binding (a Codex fork is a new
       // thread, not a transfer of the parent's). Retiring the parent's still-live
       // binding here would strand it, so skip when the successor provably lives
-      // under a different session key. Durable reset can also retain the same
-      // physical id, but equality alone is not proof that harness cleanup ran:
-      // consume the exact successful reset token before suppressing its delayed
-      // end. A missing or mismatched token remains fail-closed.
+      // under a different session key. Same-key resets are fenced by the
+      // persisted lifecycle revision because the physical id may be retained.
       // Unknown-current-key ends and true physical rollovers still retire. See
       // #106778.
       const endedSessionKey = sessionKey?.trim();
@@ -347,20 +350,11 @@ export default definePluginEntry({
       const identity = sessionBindingIdentity({
         sessionId: event.sessionId,
         ...(sessionKey ? { sessionKey } : {}),
+        ...(event.lifecycleRevision ? { lifecycleRevision: event.lifecycleRevision } : {}),
         ...(ctx.agentId ? { agentId: ctx.agentId } : {}),
         ...(config ? { config } : {}),
       });
-      const endedSessionId = event.sessionId.trim();
-      const nextSessionId = event.nextSessionId?.trim();
-      const resetToken = event.resetToken?.trim();
-      const matchedReset =
-        RESET_SESSION_REASONS.has(event.reason) &&
-        resetToken &&
-        (await bindingStore.consumeSessionGenerationReset(identity, resetToken));
       if (endedSessionKey && nextSessionKey && nextSessionKey !== endedSessionKey) {
-        return;
-      }
-      if (endedSessionId && nextSessionId === endedSessionId && matchedReset) {
         return;
       }
       await bindingStore.retireSessionGeneration(identity);

--- a/extensions/codex/src/app-server/session-binding-store.ts
+++ b/extensions/codex/src/app-server/session-binding-store.ts
@@ -30,10 +30,6 @@ export function createLazyCodexAppServerBindingStore(
       (await store()).prepareSessionGenerationReclaim(identity),
     adoptSessionGeneration: async (identity, previousSessionId) =>
       (await store()).adoptSessionGeneration(identity, previousSessionId),
-    recordSessionGenerationReset: async (identity, resetToken) =>
-      (await store()).recordSessionGenerationReset(identity, resetToken),
-    consumeSessionGenerationReset: async (identity, resetToken) =>
-      (await store()).consumeSessionGenerationReset(identity, resetToken),
     retireSessionGeneration: async (identity) => (await store()).retireSessionGeneration(identity),
     withThreadArchiveFence: async (run) => (await store()).withThreadArchiveFence(run),
     withLease: async (identity, run) => (await store()).withLease(identity, run),

--- a/extensions/codex/src/app-server/session-binding-store.ts
+++ b/extensions/codex/src/app-server/session-binding-store.ts
@@ -30,6 +30,10 @@ export function createLazyCodexAppServerBindingStore(
       (await store()).prepareSessionGenerationReclaim(identity),
     adoptSessionGeneration: async (identity, previousSessionId) =>
       (await store()).adoptSessionGeneration(identity, previousSessionId),
+    recordSessionGenerationReset: async (identity, resetToken) =>
+      (await store()).recordSessionGenerationReset(identity, resetToken),
+    consumeSessionGenerationReset: async (identity, resetToken) =>
+      (await store()).consumeSessionGenerationReset(identity, resetToken),
     retireSessionGeneration: async (identity) => (await store()).retireSessionGeneration(identity),
     withThreadArchiveFence: async (run) => (await store()).withThreadArchiveFence(run),
     withLease: async (identity, run) => (await store()).withLease(identity, run),

--- a/extensions/codex/src/app-server/session-binding.test.ts
+++ b/extensions/codex/src/app-server/session-binding.test.ts
@@ -7,7 +7,18 @@ import {
   createPluginStateSyncKeyedStoreForTests,
   resetPluginStateStoreForTests,
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import type { getSessionEntry as getSessionEntryType } from "openclaw/plugin-sdk/session-store-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
+const sessionStoreMocks = vi.hoisted(() => ({
+  getSessionEntry: vi.fn<typeof getSessionEntryType>(),
+}));
+vi.mock("openclaw/plugin-sdk/session-store-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/session-store-runtime")>();
+  return {
+    ...actual,
+    getSessionEntry: sessionStoreMocks.getSessionEntry,
+  };
+});
 import {
   bindingStoreKey,
   CODEX_APP_SERVER_BINDING_MAX_ENTRIES,
@@ -15,6 +26,7 @@ import {
   createStoredCodexAppServerBinding,
   hashCodexAppServerBindingFingerprint,
   readCodexAppServerThreadBinding,
+  reclaimCurrentCodexSessionGeneration,
   type StoredCodexAppServerBinding,
 } from "./session-binding.js";
 
@@ -54,10 +66,50 @@ function createStateStore() {
 
 afterEach(() => {
   vi.useRealTimers();
+  sessionStoreMocks.getSessionEntry.mockReset();
   resetPluginStateStoreForTests();
 });
 
 describe("Codex app-server binding store", () => {
+  it("rechecks session authority after planning before reclaiming a binding generation", async () => {
+    sessionStoreMocks.getSessionEntry
+      .mockReturnValueOnce({
+        sessionId: "retained-session",
+        lifecycleRevision: "revision-1",
+        updatedAt: 1,
+      })
+      .mockReturnValueOnce({
+        sessionId: "retained-session",
+        lifecycleRevision: "revision-2",
+        updatedAt: 2,
+      });
+    const mutate = vi.fn().mockResolvedValue(true);
+    const bindingStore = {
+      prepareSessionGenerationReclaim: vi.fn().mockResolvedValue({
+        kind: "verify" as const,
+        expectedPreviousSessionId: "retained-session",
+        expectedPreviousLifecycleRevision: "revision-2",
+      }),
+      mutate,
+    };
+
+    await expect(
+      reclaimCurrentCodexSessionGeneration({
+        bindingStore,
+        identity: {
+          kind: "session",
+          agentId: "main",
+          sessionId: "retained-session",
+          sessionKey: "agent:main:telegram:chat-1",
+          lifecycleRevision: "revision-1",
+        },
+      }),
+    ).resolves.toBe(false);
+
+    expect(sessionStoreMocks.getSessionEntry).toHaveBeenCalledTimes(2);
+    expect(mutate).not.toHaveBeenCalled();
+  });
+
   it("normalizes the retired approval policy in persisted bindings", () => {
     expect(
       readCodexAppServerThreadBinding({

--- a/extensions/codex/src/app-server/session-binding.test.ts
+++ b/extensions/codex/src/app-server/session-binding.test.ts
@@ -647,6 +647,126 @@ describe("Codex app-server binding store", () => {
     await expect(store.read(third)).resolves.toMatchObject({ threadId: "thread-1" });
   });
 
+  it("fences retained session ids by lifecycle revision across delayed reset and end work", async () => {
+    const { state } = createStateStore();
+    const store = createCodexAppServerBindingStore(state);
+    const previous = {
+      kind: "session" as const,
+      agentId: "main",
+      sessionId: "retained-session",
+      sessionKey: "agent:main:telegram:chat-1",
+      lifecycleRevision: "revision-1",
+    };
+    const current = { ...previous, lifecycleRevision: "revision-2" };
+    await store.mutate(previous, {
+      kind: "set",
+      binding: { threadId: "thread-old", cwd: "/old" },
+    });
+
+    await expect(store.mutate(previous, { kind: "reset-generation" })).resolves.toBe(true);
+    await expect(
+      store.mutate(current, {
+        kind: "reclaim-generation",
+        expectedPreviousSessionId: previous.sessionId,
+        expectedPreviousLifecycleRevision: previous.lifecycleRevision,
+      }),
+    ).resolves.toBe(true);
+    await expect(
+      store.mutate(current, {
+        kind: "set",
+        binding: { threadId: "thread-new", cwd: "/new" },
+      }),
+    ).resolves.toBe(true);
+
+    await expect(store.mutate(previous, { kind: "reset-generation" })).resolves.toBe(false);
+    await expect(store.retireSessionGeneration(previous)).resolves.toBe("conflict");
+    await expect(store.read(current)).resolves.toMatchObject({
+      threadId: "thread-new",
+      cwd: "/new",
+    });
+  });
+
+  it("upgrades an active legacy same-id binding to the authoritative revision in place", async () => {
+    const { state, values } = createStateStore();
+    const store = createCodexAppServerBindingStore(state);
+    const legacy = {
+      kind: "session" as const,
+      agentId: "main",
+      sessionId: "legacy-session",
+      sessionKey: "agent:main:telegram:chat-1",
+    };
+    const current = { ...legacy, lifecycleRevision: "revision-current" };
+    await store.mutate(legacy, {
+      kind: "set",
+      binding: { threadId: "thread-existing", cwd: "/repo" },
+    });
+
+    const plan = await store.prepareSessionGenerationReclaim(current);
+    expect(plan).toEqual({
+      kind: "verify",
+      expectedPreviousSessionId: legacy.sessionId,
+    });
+    if (plan.kind !== "verify") {
+      throw new Error("expected legacy generation verification");
+    }
+    await expect(
+      store.mutate(current, {
+        kind: "reclaim-generation",
+        expectedPreviousSessionId: plan.expectedPreviousSessionId,
+        expectedPreviousLifecycleRevision: plan.expectedPreviousLifecycleRevision,
+      }),
+    ).resolves.toBe(true);
+
+    expect(values.get(bindingStoreKey(current))).toMatchObject({
+      state: "active",
+      sessionId: current.sessionId,
+      lifecycleRevision: current.lifecycleRevision,
+      binding: { threadId: "thread-existing" },
+    });
+    await expect(store.read(current)).resolves.toMatchObject({ threadId: "thread-existing" });
+  });
+
+  it("recovers a retired legacy same-id row for the authoritative revision", async () => {
+    const { state, values } = createStateStore();
+    const store = createCodexAppServerBindingStore(state);
+    const legacy = {
+      kind: "session" as const,
+      agentId: "main",
+      sessionId: "legacy-session",
+      sessionKey: "agent:main:telegram:chat-1",
+    };
+    const current = { ...legacy, lifecycleRevision: "revision-current" };
+    await store.mutate(legacy, {
+      kind: "set",
+      binding: { threadId: "thread-retired", cwd: "/repo" },
+    });
+    await store.retireSessionGeneration(legacy);
+
+    const plan = await store.prepareSessionGenerationReclaim(current);
+    if (plan.kind !== "verify") {
+      throw new Error("expected legacy generation verification");
+    }
+    await expect(
+      store.mutate(current, {
+        kind: "reclaim-generation",
+        expectedPreviousSessionId: plan.expectedPreviousSessionId,
+        expectedPreviousLifecycleRevision: plan.expectedPreviousLifecycleRevision,
+      }),
+    ).resolves.toBe(true);
+    expect(values.get(bindingStoreKey(current))).toEqual({
+      version: 1,
+      state: "cleared",
+      sessionId: current.sessionId,
+      lifecycleRevision: current.lifecycleRevision,
+    });
+    await expect(
+      store.mutate(current, {
+        kind: "set",
+        binding: { threadId: "thread-recovered", cwd: "/repo" },
+      }),
+    ).resolves.toBe(true);
+  });
+
   it("falls back to physical session identity when no stable session key exists", () => {
     const first = { kind: "session" as const, agentId: "main", sessionId: "session-1" };
     const second = { ...first, sessionId: "session-2" };

--- a/extensions/codex/src/app-server/session-binding.test.ts
+++ b/extensions/codex/src/app-server/session-binding.test.ts
@@ -738,6 +738,54 @@ describe("Codex app-server binding store", () => {
     });
   });
 
+  it("stamps the successor revision when reset finds no Codex binding", async () => {
+    const { state, values } = createStateStore();
+    const store = createCodexAppServerBindingStore(state);
+    const previous = {
+      kind: "session" as const,
+      agentId: "main",
+      sessionId: "retained-session",
+      sessionKey: "agent:main:telegram:chat-1",
+      lifecycleRevision: "revision-1",
+    };
+    const current = { ...previous, lifecycleRevision: "revision-2" };
+    const revisionlessRuntimeIdentity = {
+      kind: "session" as const,
+      agentId: current.agentId,
+      sessionId: current.sessionId,
+      sessionKey: current.sessionKey,
+    };
+
+    await expect(store.mutate(previous, { kind: "reset-generation" })).resolves.toBe(true);
+    const plan = await store.prepareSessionGenerationReclaim(current);
+    expect(plan).toEqual({ kind: "verify" });
+    if (plan.kind !== "verify") {
+      throw new Error("expected absent generation verification");
+    }
+    await expect(
+      store.mutate(current, {
+        kind: "reclaim-generation",
+        expectedPreviousSessionId: plan.expectedPreviousSessionId,
+        expectedPreviousLifecycleRevision: plan.expectedPreviousLifecycleRevision,
+      }),
+    ).resolves.toBe(true);
+    await expect(
+      store.mutate(revisionlessRuntimeIdentity, {
+        kind: "set",
+        binding: { threadId: "thread-new", cwd: "/new" },
+      }),
+    ).resolves.toBe(true);
+
+    expect(values.get(bindingStoreKey(current))).toMatchObject({
+      state: "active",
+      sessionId: current.sessionId,
+      lifecycleRevision: current.lifecycleRevision,
+      binding: { threadId: "thread-new" },
+    });
+    await expect(store.retireSessionGeneration(previous)).resolves.toBe("conflict");
+    await expect(store.read(current)).resolves.toMatchObject({ threadId: "thread-new" });
+  });
+
   it("upgrades an active legacy same-id binding to the authoritative revision in place", async () => {
     const { state, values } = createStateStore();
     const store = createCodexAppServerBindingStore(state);

--- a/extensions/codex/src/app-server/session-binding.ts
+++ b/extensions/codex/src/app-server/session-binding.ts
@@ -349,6 +349,10 @@ type CodexAppServerBindingMutation =
       expectedPreviousSessionId: string;
     }
   | {
+      /** Explicit reset may reopen the current physical generation after work has drained. */
+      kind: "reset-generation";
+    }
+  | {
       kind: "clear";
       threadId?: string;
       /** Only failed creation may clear the exact provisional supervision owner. */
@@ -523,6 +527,16 @@ export type CodexAppServerBindingStore = {
     identity: Extract<CodexAppServerBindingIdentity, { kind: "session" }>,
     expectedPreviousSessionId: string,
   ): Promise<CodexSessionGenerationAdoptionResult>;
+  /** Records one successful reset for exact matching with its delayed session_end event. */
+  recordSessionGenerationReset(
+    identity: Extract<CodexAppServerBindingIdentity, { kind: "session" }>,
+    resetToken: string,
+  ): Promise<void>;
+  /** Consumes only the successful reset paired with this exact runtime-local token. */
+  consumeSessionGenerationReset(
+    identity: Extract<CodexAppServerBindingIdentity, { kind: "session" }>,
+    resetToken: string,
+  ): Promise<boolean>;
   retireSessionGeneration(
     identity: Extract<CodexAppServerBindingIdentity, { kind: "session" }>,
   ): Promise<CodexSessionGenerationRetirementResult>;
@@ -584,6 +598,16 @@ export function createCodexAppServerBindingStore(
   let pendingArchives = 0;
   let archiveTail = Promise.resolve();
   let bindingMutationsDrained: (() => void)[] = [];
+  // Gateway reset awaits the harness before emitting session_end in the same
+  // process. Keep exact transient tokens so duplicate or interleaved lifecycle
+  // events cannot consume a marker belonging to another logical reset. A marker
+  // lives until its matching end consumes it (or this runtime is disposed);
+  // evicting by insertion order could retire a valid reset whose end was delayed.
+  const pendingSessionGenerationEnds = new Set<string>();
+  const sessionGenerationEndKey = (
+    identity: Extract<CodexAppServerBindingIdentity, { kind: "session" }>,
+    resetToken: string,
+  ) => `${bindingStoreKey(identity)}\0${identity.sessionId.trim()}\0${resetToken.trim()}`;
 
   const waitForBindingMutations = async (): Promise<void> => {
     if (activeBindingMutations === 0) {
@@ -773,7 +797,7 @@ export function createCodexAppServerBindingStore(
         // clear. Keep provenance so migration cannot resurrect its stale thread.
         const retainLegacyClear =
           mutation.kind === "clear" && key.startsWith("conversation:legacy-");
-        return await transactKey(
+        const result = await transactKey(
           key,
           (current, leaseToken) => {
             const ownsGeneration = ownsStoredSessionGeneration(identity, current);
@@ -798,6 +822,26 @@ export function createCodexAppServerBindingStore(
               // an ordinary empty binding. Supervision adoption has an explicit generation
               // transfer path; every other successor fails closed and preserves this owner.
               if (current.state === "active" && current.binding.connectionScope === "supervision") {
+                return { result: false };
+              }
+              return {
+                result: true,
+                next: {
+                  version: 1,
+                  state: "cleared",
+                  sessionId: identity.sessionId,
+                  ...ownedLease,
+                },
+              };
+            }
+            if (mutation.kind === "reset-generation") {
+              if (identity.kind !== "session") {
+                return { result: false };
+              }
+              if (!current) {
+                return { result: true };
+              }
+              if (!ownsStoredSessionGeneration(identity, current)) {
                 return { result: false };
               }
               return {
@@ -897,10 +941,13 @@ export function createCodexAppServerBindingStore(
           // the key afterwards is fenced by ownsStoredSessionGeneration on read
           // and displaced via reclaim-generation; durable stable-key fences come
           // from retireSessionGeneration, not runtime clears.
-          mutation.kind === "clear" && !retainLegacyClear && !leaseContext.getStore()?.has(key)
+          (mutation.kind === "clear" || mutation.kind === "reset-generation") &&
+            !retainLegacyClear &&
+            !leaseContext.getStore()?.has(key)
             ? 1
             : undefined,
         );
+        return result;
       });
     },
 
@@ -931,6 +978,25 @@ export function createCodexAppServerBindingStore(
           };
         });
       });
+    },
+
+    async recordSessionGenerationReset(identity, resetToken) {
+      if (!resetToken.trim()) {
+        return;
+      }
+      pendingSessionGenerationEnds.add(sessionGenerationEndKey(identity, resetToken));
+    },
+
+    async consumeSessionGenerationReset(identity, resetToken) {
+      if (!resetToken.trim()) {
+        return false;
+      }
+      const key = sessionGenerationEndKey(identity, resetToken);
+      if (!pendingSessionGenerationEnds.has(key)) {
+        return false;
+      }
+      pendingSessionGenerationEnds.delete(key);
+      return true;
     },
 
     async retireSessionGeneration(identity) {

--- a/extensions/codex/src/app-server/session-binding.ts
+++ b/extensions/codex/src/app-server/session-binding.ts
@@ -552,7 +552,7 @@ export type CodexAppServerBindingStore = {
 
 /** Lets the authoritative OpenClaw session generation claim a stale stable binding row. */
 export async function reclaimCurrentCodexSessionGeneration(params: {
-  bindingStore: CodexAppServerBindingStore;
+  bindingStore: Pick<CodexAppServerBindingStore, "prepareSessionGenerationReclaim" | "mutate">;
   identity: Extract<CodexAppServerBindingIdentity, { kind: "session" }>;
   config?: OpenClawConfig;
 }): Promise<boolean> {
@@ -565,17 +565,20 @@ export async function reclaimCurrentCodexSessionGeneration(params: {
   // Resolve it before binding mutation so same-id resets still fence by revision
   // and no session read runs inside the plugin-state transaction.
   let authoritativeIdentity: Extract<CodexAppServerBindingIdentity, { kind: "session" }>;
+  let readAuthoritativeEntry: () => ReturnType<typeof getSessionEntry>;
   try {
     const storePath = resolveStorePath(params.config?.session?.store, {
       agentId: params.identity.agentId,
     });
-    const entry = getSessionEntry({
-      agentId: params.identity.agentId,
-      hydrateSkillPromptRefs: false,
-      readConsistency: "latest",
-      sessionKey,
-      storePath,
-    });
+    readAuthoritativeEntry = () =>
+      getSessionEntry({
+        agentId: params.identity.agentId,
+        hydrateSkillPromptRefs: false,
+        readConsistency: "latest",
+        sessionKey,
+        storePath,
+      });
+    const entry = readAuthoritativeEntry();
     if (entry?.sessionId !== params.identity.sessionId) {
       return false;
     }
@@ -591,8 +594,24 @@ export async function reclaimCurrentCodexSessionGeneration(params: {
   }
 
   const plan = await params.bindingStore.prepareSessionGenerationReclaim(authoritativeIdentity);
+  if (plan.kind === "resolved" && !plan.result) {
+    return false;
+  }
+  try {
+    const currentEntry = readAuthoritativeEntry();
+    // Planning yields before the binding CAS. Recheck the session authority so
+    // a caller that observed R1 cannot use an R2 binding plan to relabel R2.
+    if (
+      currentEntry?.sessionId !== authoritativeIdentity.sessionId ||
+      currentEntry.lifecycleRevision !== authoritativeIdentity.lifecycleRevision
+    ) {
+      return false;
+    }
+  } catch {
+    return false;
+  }
   if (plan.kind === "resolved") {
-    return plan.result;
+    return true;
   }
   return await params.bindingStore.mutate(authoritativeIdentity, {
     kind: "reclaim-generation",

--- a/extensions/codex/src/app-server/session-binding.ts
+++ b/extensions/codex/src/app-server/session-binding.ts
@@ -808,9 +808,7 @@ export function createCodexAppServerBindingStore(
       if (!current) {
         // Stamp the authoritative revision before a revisionless runtime identity
         // creates its first binding, or a delayed end can retire the successor.
-        return identity.lifecycleRevision
-          ? { kind: "verify" }
-          : { kind: "resolved", result: true };
+        return identity.lifecycleRevision ? { kind: "verify" } : { kind: "resolved", result: true };
       }
       if (
         ownsStoredSessionGeneration(identity, current) &&

--- a/extensions/codex/src/app-server/session-binding.ts
+++ b/extensions/codex/src/app-server/session-binding.ts
@@ -54,23 +54,32 @@ export type CodexAppServerAuthProfileLookup = {
 
 /** Stable owner of one Codex thread binding. */
 export type CodexAppServerBindingIdentity =
-  | { kind: "session"; agentId: string; sessionId: string; sessionKey?: string }
+  | {
+      kind: "session";
+      agentId: string;
+      sessionId: string;
+      sessionKey?: string;
+      lifecycleRevision?: string;
+    }
   | { kind: "conversation"; bindingId: string };
 
 /** Resolves the same agent scope OpenClaw uses for transcript/session ownership. */
 export function sessionBindingIdentity(params: {
   sessionId: string;
   sessionKey?: string;
+  lifecycleRevision?: string;
   agentId?: string;
   config?: OpenClawConfig;
 }): Extract<CodexAppServerBindingIdentity, { kind: "session" }> {
   const { sessionAgentId } = resolveSessionAgentIds(params);
   const sessionKey = params.sessionKey?.trim();
+  const lifecycleRevision = params.lifecycleRevision?.trim();
   return {
     kind: "session",
     agentId: sessionAgentId,
     sessionId: params.sessionId,
     ...(sessionKey ? { sessionKey } : {}),
+    ...(lifecycleRevision ? { lifecycleRevision } : {}),
   };
 }
 
@@ -346,7 +355,8 @@ type CodexAppServerBindingMutation =
     }
   | {
       kind: "reclaim-generation";
-      expectedPreviousSessionId: string;
+      expectedPreviousSessionId?: string;
+      expectedPreviousLifecycleRevision?: string;
     }
   | {
       /** Explicit reset may reopen the current physical generation after work has drained. */
@@ -365,7 +375,11 @@ export type CodexSessionGenerationRetirementResult = "applied" | "absent" | "con
 
 export type CodexSessionGenerationReclaimPlan =
   | { kind: "resolved"; result: boolean }
-  | { kind: "verify"; expectedPreviousSessionId: string };
+  | {
+      kind: "verify";
+      expectedPreviousSessionId?: string;
+      expectedPreviousLifecycleRevision?: string;
+    };
 
 const bindingLeaseSchema = z.object({
   token: z.string().refine((value) => Boolean(value.trim())),
@@ -383,12 +397,14 @@ const storedBindingSchema = z.discriminatedUnion("state", [
     state: z.literal("active"),
     binding: threadBindingSchema,
     sessionId: storedSessionIdSchema,
+    lifecycleRevision: storedSessionIdSchema,
     lease: bindingLeaseSchema.optional().catch(undefined),
   }),
   z.object({
     version: z.literal(1),
     state: z.literal("cleared"),
     sessionId: storedSessionIdSchema,
+    lifecycleRevision: storedSessionIdSchema,
     lease: bindingLeaseSchema.optional().catch(undefined),
     retired: z.literal(true).optional().catch(undefined),
   }),
@@ -527,16 +543,6 @@ export type CodexAppServerBindingStore = {
     identity: Extract<CodexAppServerBindingIdentity, { kind: "session" }>,
     expectedPreviousSessionId: string,
   ): Promise<CodexSessionGenerationAdoptionResult>;
-  /** Records one successful reset for exact matching with its delayed session_end event. */
-  recordSessionGenerationReset(
-    identity: Extract<CodexAppServerBindingIdentity, { kind: "session" }>,
-    resetToken: string,
-  ): Promise<void>;
-  /** Consumes only the successful reset paired with this exact runtime-local token. */
-  consumeSessionGenerationReset(
-    identity: Extract<CodexAppServerBindingIdentity, { kind: "session" }>,
-    resetToken: string,
-  ): Promise<boolean>;
   retireSessionGeneration(
     identity: Extract<CodexAppServerBindingIdentity, { kind: "session" }>,
   ): Promise<CodexSessionGenerationRetirementResult>;
@@ -554,13 +560,11 @@ export async function reclaimCurrentCodexSessionGeneration(params: {
   if (!sessionKey) {
     return true;
   }
-  const plan = await params.bindingStore.prepareSessionGenerationReclaim(params.identity);
-  if (plan.kind === "resolved") {
-    return plan.result;
-  }
 
-  // Only a stale stable-key owner needs session-store authority. Resolve it before
-  // the second mutation so the session read never runs inside the binding write transaction.
+  // Stable-key ownership comes from the authoritative OpenClaw session row.
+  // Resolve it before binding mutation so same-id resets still fence by revision
+  // and no session read runs inside the plugin-state transaction.
+  let authoritativeIdentity: Extract<CodexAppServerBindingIdentity, { kind: "session" }>;
   try {
     const storePath = resolveStorePath(params.config?.session?.store, {
       agentId: params.identity.agentId,
@@ -575,12 +579,25 @@ export async function reclaimCurrentCodexSessionGeneration(params: {
     if (entry?.sessionId !== params.identity.sessionId) {
       return false;
     }
+    authoritativeIdentity = sessionBindingIdentity({
+      agentId: params.identity.agentId,
+      sessionId: entry.sessionId,
+      sessionKey,
+      lifecycleRevision: entry.lifecycleRevision,
+      config: params.config,
+    });
   } catch {
     return false;
   }
-  return await params.bindingStore.mutate(params.identity, {
+
+  const plan = await params.bindingStore.prepareSessionGenerationReclaim(authoritativeIdentity);
+  if (plan.kind === "resolved") {
+    return plan.result;
+  }
+  return await params.bindingStore.mutate(authoritativeIdentity, {
     kind: "reclaim-generation",
     expectedPreviousSessionId: plan.expectedPreviousSessionId,
+    expectedPreviousLifecycleRevision: plan.expectedPreviousLifecycleRevision,
   });
 }
 
@@ -598,17 +615,6 @@ export function createCodexAppServerBindingStore(
   let pendingArchives = 0;
   let archiveTail = Promise.resolve();
   let bindingMutationsDrained: (() => void)[] = [];
-  // Gateway reset awaits the harness before emitting session_end in the same
-  // process. Keep exact transient tokens so duplicate or interleaved lifecycle
-  // events cannot consume a marker belonging to another logical reset. A marker
-  // lives until its matching end consumes it (or this runtime is disposed);
-  // evicting by insertion order could retire a valid reset whose end was delayed.
-  const pendingSessionGenerationEnds = new Set<string>();
-  const sessionGenerationEndKey = (
-    identity: Extract<CodexAppServerBindingIdentity, { kind: "session" }>,
-    resetToken: string,
-  ) => `${bindingStoreKey(identity)}\0${identity.sessionId.trim()}\0${resetToken.trim()}`;
-
   const waitForBindingMutations = async (): Promise<void> => {
     if (activeBindingMutations === 0) {
       return;
@@ -762,7 +768,10 @@ export function createCodexAppServerBindingStore(
           currentIdentity !== undefined &&
           key === currentKey &&
           (currentIdentity.kind === "conversation" ||
-            stored.sessionId === currentIdentity.sessionId.trim());
+            (stored.sessionId === currentIdentity.sessionId.trim() &&
+              (!currentIdentity.lifecycleRevision ||
+                !stored.lifecycleRevision ||
+                stored.lifecycleRevision === currentIdentity.lifecycleRevision)));
         if (stored.state !== "active" || stored.binding.threadId !== threadId || isCurrentOwner) {
           return false;
         }
@@ -780,14 +789,22 @@ export function createCodexAppServerBindingStore(
       if (!current) {
         return { kind: "resolved", result: true };
       }
-      const currentSessionId = current.sessionId;
-      if (!currentSessionId || currentSessionId === identity.sessionId) {
+      if (
+        ownsStoredSessionGeneration(identity, current) &&
+        (!identity.lifecycleRevision || current.lifecycleRevision)
+      ) {
         return {
           kind: "resolved",
           result: current.state !== "cleared" || current.retired !== true,
         };
       }
-      return { kind: "verify", expectedPreviousSessionId: currentSessionId };
+      return {
+        kind: "verify",
+        ...(current.sessionId ? { expectedPreviousSessionId: current.sessionId } : {}),
+        ...(current.lifecycleRevision
+          ? { expectedPreviousLifecycleRevision: current.lifecycleRevision }
+          : {}),
+      };
     },
 
     async mutate(identity, mutation) {
@@ -810,13 +827,30 @@ export function createCodexAppServerBindingStore(
               if (!current) {
                 return { result: true };
               }
-              if (ownsGeneration) {
+              if (
+                ownsGeneration &&
+                (!identity.lifecycleRevision || current.lifecycleRevision !== undefined)
+              ) {
                 return {
                   result: current.state !== "cleared" || current.retired !== true,
                 };
               }
-              if (current.sessionId !== mutation.expectedPreviousSessionId) {
+              if (
+                current.sessionId !== mutation.expectedPreviousSessionId ||
+                current.lifecycleRevision !== mutation.expectedPreviousLifecycleRevision
+              ) {
                 return { result: false };
+              }
+              const targetGeneration = storedSessionGeneration(identity, current);
+              const legacyGeneration =
+                current.sessionId === identity.sessionId &&
+                current.lifecycleRevision === undefined &&
+                identity.lifecycleRevision !== undefined;
+              if (legacyGeneration && current.state === "active") {
+                return {
+                  result: true,
+                  next: { ...current, ...targetGeneration },
+                };
               }
               // A stale physical generation must never turn private user-home ownership into
               // an ordinary empty binding. Supervision adoption has an explicit generation
@@ -829,7 +863,7 @@ export function createCodexAppServerBindingStore(
                 next: {
                   version: 1,
                   state: "cleared",
-                  sessionId: identity.sessionId,
+                  ...targetGeneration,
                   ...ownedLease,
                 },
               };
@@ -849,7 +883,7 @@ export function createCodexAppServerBindingStore(
                 next: {
                   version: 1,
                   state: "cleared",
-                  sessionId: identity.sessionId,
+                  ...storedSessionGeneration(identity, current),
                   ...ownedLease,
                 },
               };
@@ -966,37 +1000,34 @@ export function createCodexAppServerBindingStore(
           if (current?.state !== "active") {
             return { result: "absent" as const };
           }
-          if (current.sessionId === targetSessionId) {
+          if (
+            current.sessionId === targetSessionId &&
+            (!identity.lifecycleRevision ||
+              !current.lifecycleRevision ||
+              current.lifecycleRevision === identity.lifecycleRevision)
+          ) {
             return { result: "current" as const };
           }
           if (current.sessionId !== expectedSessionId) {
             return { result: "conflict" as const };
           }
+          const {
+            sessionId: _previousSessionId,
+            lifecycleRevision: _previousLifecycleRevision,
+            ...bindingOwner
+          } = current;
           return {
             result: "adopted" as const,
-            next: { ...current, sessionId: targetSessionId },
+            next: {
+              ...bindingOwner,
+              sessionId: targetSessionId,
+              ...(identity.lifecycleRevision
+                ? { lifecycleRevision: identity.lifecycleRevision }
+                : {}),
+            },
           };
         });
       });
-    },
-
-    async recordSessionGenerationReset(identity, resetToken) {
-      if (!resetToken.trim()) {
-        return;
-      }
-      pendingSessionGenerationEnds.add(sessionGenerationEndKey(identity, resetToken));
-    },
-
-    async consumeSessionGenerationReset(identity, resetToken) {
-      if (!resetToken.trim()) {
-        return false;
-      }
-      const key = sessionGenerationEndKey(identity, resetToken);
-      if (!pendingSessionGenerationEnds.has(key)) {
-        return false;
-      }
-      pendingSessionGenerationEnds.delete(key);
-      return true;
     },
 
     async retireSessionGeneration(identity) {
@@ -1245,19 +1276,32 @@ export function readStoredCodexAppServerBinding(
 function storedSessionGeneration(
   identity: CodexAppServerBindingIdentity,
   current: StoredCodexAppServerBinding | undefined,
-): { sessionId?: string } {
+): { sessionId?: string; lifecycleRevision?: string } {
   if (identity.kind === "session") {
-    return { sessionId: identity.sessionId };
+    return {
+      sessionId: identity.sessionId,
+      ...(identity.lifecycleRevision
+        ? { lifecycleRevision: identity.lifecycleRevision }
+        : current?.lifecycleRevision
+          ? { lifecycleRevision: current.lifecycleRevision }
+          : {}),
+    };
   }
-  return current?.sessionId ? { sessionId: current.sessionId } : {};
+  return {
+    ...(current?.sessionId ? { sessionId: current.sessionId } : {}),
+    ...(current?.lifecycleRevision ? { lifecycleRevision: current.lifecycleRevision } : {}),
+  };
 }
 
 function preservedSessionGeneration(
   identity: CodexAppServerBindingIdentity,
   current: StoredCodexAppServerBinding | undefined,
-): { sessionId?: string } {
+): { sessionId?: string; lifecycleRevision?: string } {
   if (current?.sessionId) {
-    return { sessionId: current.sessionId };
+    return {
+      sessionId: current.sessionId,
+      ...(current.lifecycleRevision ? { lifecycleRevision: current.lifecycleRevision } : {}),
+    };
   }
   return storedSessionGeneration(identity, current);
 }
@@ -1267,7 +1311,12 @@ function ownsStoredSessionGeneration(
   current: StoredCodexAppServerBinding | undefined,
 ): boolean {
   return (
-    identity.kind !== "session" || !current?.sessionId || current.sessionId === identity.sessionId
+    identity.kind !== "session" ||
+    !current?.sessionId ||
+    (current.sessionId === identity.sessionId &&
+      (!identity.lifecycleRevision ||
+        !current.lifecycleRevision ||
+        current.lifecycleRevision === identity.lifecycleRevision))
   );
 }
 

--- a/extensions/codex/src/app-server/session-binding.ts
+++ b/extensions/codex/src/app-server/session-binding.ts
@@ -806,7 +806,11 @@ export function createCodexAppServerBindingStore(
         throw new Error(`Invalid Codex app-server binding row: ${key}`);
       }
       if (!current) {
-        return { kind: "resolved", result: true };
+        // Stamp the authoritative revision before a revisionless runtime identity
+        // creates its first binding, or a delayed end can retire the successor.
+        return identity.lifecycleRevision
+          ? { kind: "verify" }
+          : { kind: "resolved", result: true };
       }
       if (
         ownsStoredSessionGeneration(identity, current) &&
@@ -844,7 +848,14 @@ export function createCodexAppServerBindingStore(
                 return { result: false };
               }
               if (!current) {
-                return { result: true };
+                return {
+                  result: true,
+                  next: {
+                    version: 1,
+                    state: "cleared",
+                    ...storedSessionGeneration(identity, current),
+                  },
+                };
               }
               if (
                 ownsGeneration &&

--- a/src/agents/harness/types.ts
+++ b/src/agents/harness/types.ts
@@ -181,9 +181,9 @@ export type AgentHarnessResetParams = {
   sessionId?: string;
   sessionKey?: string;
   sessionFile?: string;
+  /** Authoritative revision of the physical session generation being reset. */
+  lifecycleRevision?: string;
   reason?: "new" | "reset" | "idle" | "daily" | "compaction" | "deleted" | "unknown";
-  /** Correlates a successful harness reset with its matching delayed session_end hook. */
-  resetToken?: string;
 };
 
 export type AgentHarnessSessionForkFailureCode =

--- a/src/agents/harness/types.ts
+++ b/src/agents/harness/types.ts
@@ -182,6 +182,8 @@ export type AgentHarnessResetParams = {
   sessionKey?: string;
   sessionFile?: string;
   reason?: "new" | "reset" | "idle" | "daily" | "compaction" | "deleted" | "unknown";
+  /** Correlates a successful harness reset with its matching delayed session_end hook. */
+  resetToken?: string;
 };
 
 export type AgentHarnessSessionForkFailureCode =

--- a/src/auto-reply/reply/session-hooks-context.test.ts
+++ b/src/auto-reply/reply/session-hooks-context.test.ts
@@ -417,6 +417,10 @@ describe("session hook context wiring", () => {
         reason: "daily",
         transcriptArchived: false,
       });
+      const resetParams =
+        sessionCleanupMocks.resetRegisteredAgentHarnessSessions.mock.calls[0]?.[0];
+      expect(event?.resetToken).toBeTypeOf("string");
+      expect(resetParams?.resetToken).toBe(event?.resetToken);
       expect(event?.nextSessionId).toBe(startEvent?.sessionId);
       expect(startEvent?.sessionId).toBe("daily-session");
     } finally {
@@ -443,6 +447,10 @@ describe("session hook context wiring", () => {
 
       const [event] = requireHookCall(hookRunnerMocks.runSessionEnd, "session_end");
       expectFields(event, { reason: "idle" });
+      const resetParams =
+        sessionCleanupMocks.resetRegisteredAgentHarnessSessions.mock.calls[0]?.[0];
+      expect(event?.resetToken).toBeTypeOf("string");
+      expect(resetParams?.resetToken).toBe(event?.resetToken);
     } finally {
       vi.useRealTimers();
     }

--- a/src/auto-reply/reply/session-hooks-context.test.ts
+++ b/src/auto-reply/reply/session-hooks-context.test.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AgentHarnessResetParams } from "../../agents/harness/types.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import { replaceSessionEntry } from "../../config/sessions/session-accessor.js";
@@ -29,7 +30,7 @@ const hookRunnerMocks = vi.hoisted(() => ({
 }));
 const sessionCleanupMocks = vi.hoisted(() => ({
   closeTrackedBrowserTabsForSessions: vi.fn(async () => 0),
-  resetRegisteredAgentHarnessSessions: vi.fn(async () => undefined),
+  resetRegisteredAgentHarnessSessions: vi.fn(async (_params: AgentHarnessResetParams) => undefined),
   retireSessionMcpRuntime: vi.fn(async () => false),
 }));
 
@@ -256,6 +257,10 @@ describe("session hook context wiring", () => {
       reason: "new",
       transcriptArchived: false,
     });
+    const resetParams = sessionCleanupMocks.resetRegisteredAgentHarnessSessions.mock.calls[0]?.[0];
+    expect(event?.resetToken).toBeTypeOf("string");
+    expect(event?.resetToken).not.toBe("");
+    expect(resetParams?.resetToken).toBe(event?.resetToken);
     expectFields(context, { sessionKey, agentId: "main", sessionId: event?.sessionId });
 
     const [startEvent, startContext] = requireHookCall(

--- a/src/auto-reply/reply/session-hooks-context.test.ts
+++ b/src/auto-reply/reply/session-hooks-context.test.ts
@@ -258,7 +258,7 @@ describe("session hook context wiring", () => {
       transcriptArchived: false,
     });
     const resetParams = sessionCleanupMocks.resetRegisteredAgentHarnessSessions.mock.calls[0]?.[0];
-    expect(event?.lifecycleRevision).toBeTypeOf("string");
+    expect(event?.lifecycleRevision).toBe("legacy:old-session");
     expect(resetParams?.lifecycleRevision).toBe(event?.lifecycleRevision);
     expectFields(context, { sessionKey, agentId: "main", sessionId: event?.sessionId });
 
@@ -418,7 +418,7 @@ describe("session hook context wiring", () => {
       });
       const resetParams =
         sessionCleanupMocks.resetRegisteredAgentHarnessSessions.mock.calls[0]?.[0];
-      expect(event?.lifecycleRevision).toBeTypeOf("string");
+      expect(event?.lifecycleRevision).toBe("legacy:daily-session");
       expect(resetParams?.lifecycleRevision).toBe(event?.lifecycleRevision);
       expect(event?.nextSessionId).toBe(startEvent?.sessionId);
       expect(startEvent?.sessionId).toBe("daily-session");
@@ -448,7 +448,7 @@ describe("session hook context wiring", () => {
       expectFields(event, { reason: "idle" });
       const resetParams =
         sessionCleanupMocks.resetRegisteredAgentHarnessSessions.mock.calls[0]?.[0];
-      expect(event?.lifecycleRevision).toBeTypeOf("string");
+      expect(event?.lifecycleRevision).toBe("legacy:idle-session");
       expect(resetParams?.lifecycleRevision).toBe(event?.lifecycleRevision);
     } finally {
       vi.useRealTimers();

--- a/src/auto-reply/reply/session-hooks-context.test.ts
+++ b/src/auto-reply/reply/session-hooks-context.test.ts
@@ -269,8 +269,6 @@ describe("session hook context wiring", () => {
     expectFields(startEvent, { resumedFrom: "old-session" });
     expect(event?.nextSessionId).toBe("old-session");
     expect(startEvent?.sessionId).toBe("old-session");
-    expect(event?.nextLifecycleRevision).toBe(startEvent?.lifecycleRevision);
-    expect(event?.nextLifecycleRevision).not.toBe(event?.lifecycleRevision);
     expectFields(startContext, { sessionId: startEvent?.sessionId });
   });
 

--- a/src/auto-reply/reply/session-hooks-context.test.ts
+++ b/src/auto-reply/reply/session-hooks-context.test.ts
@@ -258,9 +258,8 @@ describe("session hook context wiring", () => {
       transcriptArchived: false,
     });
     const resetParams = sessionCleanupMocks.resetRegisteredAgentHarnessSessions.mock.calls[0]?.[0];
-    expect(event?.resetToken).toBeTypeOf("string");
-    expect(event?.resetToken).not.toBe("");
-    expect(resetParams?.resetToken).toBe(event?.resetToken);
+    expect(event?.lifecycleRevision).toBeTypeOf("string");
+    expect(resetParams?.lifecycleRevision).toBe(event?.lifecycleRevision);
     expectFields(context, { sessionKey, agentId: "main", sessionId: event?.sessionId });
 
     const [startEvent, startContext] = requireHookCall(
@@ -270,6 +269,8 @@ describe("session hook context wiring", () => {
     expectFields(startEvent, { resumedFrom: "old-session" });
     expect(event?.nextSessionId).toBe("old-session");
     expect(startEvent?.sessionId).toBe("old-session");
+    expect(event?.nextLifecycleRevision).toBe(startEvent?.lifecycleRevision);
+    expect(event?.nextLifecycleRevision).not.toBe(event?.lifecycleRevision);
     expectFields(startContext, { sessionId: startEvent?.sessionId });
   });
 
@@ -419,8 +420,8 @@ describe("session hook context wiring", () => {
       });
       const resetParams =
         sessionCleanupMocks.resetRegisteredAgentHarnessSessions.mock.calls[0]?.[0];
-      expect(event?.resetToken).toBeTypeOf("string");
-      expect(resetParams?.resetToken).toBe(event?.resetToken);
+      expect(event?.lifecycleRevision).toBeTypeOf("string");
+      expect(resetParams?.lifecycleRevision).toBe(event?.lifecycleRevision);
       expect(event?.nextSessionId).toBe(startEvent?.sessionId);
       expect(startEvent?.sessionId).toBe("daily-session");
     } finally {
@@ -449,8 +450,8 @@ describe("session hook context wiring", () => {
       expectFields(event, { reason: "idle" });
       const resetParams =
         sessionCleanupMocks.resetRegisteredAgentHarnessSessions.mock.calls[0]?.[0];
-      expect(event?.resetToken).toBeTypeOf("string");
-      expect(resetParams?.resetToken).toBe(event?.resetToken);
+      expect(event?.lifecycleRevision).toBeTypeOf("string");
+      expect(resetParams?.lifecycleRevision).toBe(event?.lifecycleRevision);
     } finally {
       vi.useRealTimers();
     }

--- a/src/auto-reply/reply/session-hooks.ts
+++ b/src/auto-reply/reply/session-hooks.ts
@@ -62,6 +62,7 @@ export function buildSessionEndHookPayload(params: {
   transcriptArchived?: boolean;
   nextSessionId?: string;
   nextSessionKey?: string;
+  resetToken?: string;
 }): {
   event: PluginHookSessionEndEvent;
   context: SessionHookContext;
@@ -77,6 +78,7 @@ export function buildSessionEndHookPayload(params: {
       transcriptArchived: params.transcriptArchived,
       nextSessionId: params.nextSessionId,
       nextSessionKey: params.nextSessionKey,
+      resetToken: params.resetToken,
     },
     context: buildSessionHookContext({
       sessionId: params.sessionId,

--- a/src/auto-reply/reply/session-hooks.ts
+++ b/src/auto-reply/reply/session-hooks.ts
@@ -12,17 +12,20 @@ type SessionHookContext = {
   sessionId: string;
   sessionKey: string;
   agentId: string;
+  lifecycleRevision?: string;
 };
 
 function buildSessionHookContext(params: {
   sessionId: string;
   sessionKey: string;
   cfg: OpenClawConfig;
+  lifecycleRevision?: string;
 }): SessionHookContext {
   return {
     sessionId: params.sessionId,
     sessionKey: params.sessionKey,
     agentId: resolveSessionAgentId({ sessionKey: params.sessionKey, config: params.cfg }),
+    lifecycleRevision: params.lifecycleRevision,
   };
 }
 
@@ -31,6 +34,7 @@ export function buildSessionStartHookPayload(params: {
   sessionId: string;
   sessionKey: string;
   cfg: OpenClawConfig;
+  lifecycleRevision?: string;
   resumedFrom?: string;
 }): {
   event: PluginHookSessionStartEvent;
@@ -40,12 +44,14 @@ export function buildSessionStartHookPayload(params: {
     event: {
       sessionId: params.sessionId,
       sessionKey: params.sessionKey,
+      lifecycleRevision: params.lifecycleRevision,
       resumedFrom: params.resumedFrom,
     },
     context: buildSessionHookContext({
       sessionId: params.sessionId,
       sessionKey: params.sessionKey,
       cfg: params.cfg,
+      lifecycleRevision: params.lifecycleRevision,
     }),
   };
 }
@@ -60,9 +66,10 @@ export function buildSessionEndHookPayload(params: {
   reason?: PluginHookSessionEndReason;
   sessionFile?: string;
   transcriptArchived?: boolean;
+  lifecycleRevision?: string;
   nextSessionId?: string;
   nextSessionKey?: string;
-  resetToken?: string;
+  nextLifecycleRevision?: string;
 }): {
   event: PluginHookSessionEndEvent;
   context: SessionHookContext;
@@ -71,6 +78,7 @@ export function buildSessionEndHookPayload(params: {
     event: {
       sessionId: params.sessionId,
       sessionKey: params.sessionKey,
+      lifecycleRevision: params.lifecycleRevision,
       messageCount: params.messageCount ?? 0,
       durationMs: params.durationMs,
       reason: params.reason,
@@ -78,12 +86,13 @@ export function buildSessionEndHookPayload(params: {
       transcriptArchived: params.transcriptArchived,
       nextSessionId: params.nextSessionId,
       nextSessionKey: params.nextSessionKey,
-      resetToken: params.resetToken,
+      nextLifecycleRevision: params.nextLifecycleRevision,
     },
     context: buildSessionHookContext({
       sessionId: params.sessionId,
       sessionKey: params.sessionKey,
       cfg: params.cfg,
+      lifecycleRevision: params.lifecycleRevision,
     }),
   };
 }

--- a/src/auto-reply/reply/session-hooks.ts
+++ b/src/auto-reply/reply/session-hooks.ts
@@ -12,20 +12,17 @@ type SessionHookContext = {
   sessionId: string;
   sessionKey: string;
   agentId: string;
-  lifecycleRevision?: string;
 };
 
 function buildSessionHookContext(params: {
   sessionId: string;
   sessionKey: string;
   cfg: OpenClawConfig;
-  lifecycleRevision?: string;
 }): SessionHookContext {
   return {
     sessionId: params.sessionId,
     sessionKey: params.sessionKey,
     agentId: resolveSessionAgentId({ sessionKey: params.sessionKey, config: params.cfg }),
-    lifecycleRevision: params.lifecycleRevision,
   };
 }
 
@@ -34,7 +31,6 @@ export function buildSessionStartHookPayload(params: {
   sessionId: string;
   sessionKey: string;
   cfg: OpenClawConfig;
-  lifecycleRevision?: string;
   resumedFrom?: string;
 }): {
   event: PluginHookSessionStartEvent;
@@ -44,14 +40,12 @@ export function buildSessionStartHookPayload(params: {
     event: {
       sessionId: params.sessionId,
       sessionKey: params.sessionKey,
-      lifecycleRevision: params.lifecycleRevision,
       resumedFrom: params.resumedFrom,
     },
     context: buildSessionHookContext({
       sessionId: params.sessionId,
       sessionKey: params.sessionKey,
       cfg: params.cfg,
-      lifecycleRevision: params.lifecycleRevision,
     }),
   };
 }
@@ -69,7 +63,6 @@ export function buildSessionEndHookPayload(params: {
   lifecycleRevision?: string;
   nextSessionId?: string;
   nextSessionKey?: string;
-  nextLifecycleRevision?: string;
 }): {
   event: PluginHookSessionEndEvent;
   context: SessionHookContext;
@@ -86,13 +79,11 @@ export function buildSessionEndHookPayload(params: {
       transcriptArchived: params.transcriptArchived,
       nextSessionId: params.nextSessionId,
       nextSessionKey: params.nextSessionKey,
-      nextLifecycleRevision: params.nextLifecycleRevision,
     },
     context: buildSessionHookContext({
       sessionId: params.sessionId,
       sessionKey: params.sessionKey,
       cfg: params.cfg,
-      lifecycleRevision: params.lifecycleRevision,
     }),
   };
 }

--- a/src/auto-reply/reply/session-hooks.ts
+++ b/src/auto-reply/reply/session-hooks.ts
@@ -1,5 +1,6 @@
 // Emits session lifecycle hooks for channel plugins and agent runtimes.
 import { resolveSessionAgentId } from "../../agents/agent-scope.js";
+import { resolveEndedSessionLifecycleRevision } from "../../config/sessions/lifecycle.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type {
   PluginHookSessionEndEvent,
@@ -71,7 +72,7 @@ export function buildSessionEndHookPayload(params: {
     event: {
       sessionId: params.sessionId,
       sessionKey: params.sessionKey,
-      lifecycleRevision: params.lifecycleRevision,
+      lifecycleRevision: resolveEndedSessionLifecycleRevision(params),
       messageCount: params.messageCount ?? 0,
       durationMs: params.durationMs,
       reason: params.reason,

--- a/src/auto-reply/reply/session-updates.lifecycle.test.ts
+++ b/src/auto-reply/reply/session-updates.lifecycle.test.ts
@@ -108,6 +108,7 @@ describe("session-updates lifecycle hooks", () => {
     expect(endEvent?.sessionId).toBe("s1");
     expect(endEvent?.sessionKey).toBe(sessionKey);
     expect(endEvent?.reason).toBe("compaction");
+    expect(endEvent?.lifecycleRevision).toBe("legacy:s1");
     expect(endEvent?.transcriptArchived).toBe(false);
     expect(endEvent?.sessionFile).toBe(await fs.realpath(transcriptPath));
     expect(endContext?.sessionId).toBe("s1");

--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -84,6 +84,7 @@ function emitCompactionSessionLifecycleHooks(params: {
       cfg: params.cfg,
       sessionKey: params.sessionKey,
       sessionId: params.nextEntry.sessionId,
+      lifecycleRevision: params.nextEntry.lifecycleRevision,
       storePath: params.storePath,
       sessionFile: params.nextEntry.sessionFile,
       agentId: resolveAgentIdFromSessionKey(params.sessionKey),
@@ -108,7 +109,9 @@ function emitCompactionSessionLifecycleHooks(params: {
       reason: "compaction",
       sessionFile: transcript.sessionFile,
       transcriptArchived: transcript.transcriptArchived,
+      lifecycleRevision: params.previousEntry.lifecycleRevision,
       nextSessionId: params.nextEntry.sessionId,
+      nextLifecycleRevision: params.nextEntry.lifecycleRevision,
     });
     void runWithGatewayIndependentRootWorkContinuation(async () => {
       await hookRunner.runSessionEnd(payload.event, payload.context);
@@ -122,6 +125,7 @@ function emitCompactionSessionLifecycleHooks(params: {
       sessionId: params.nextEntry.sessionId,
       sessionKey: params.sessionKey,
       cfg: params.cfg,
+      lifecycleRevision: params.nextEntry.lifecycleRevision,
       resumedFrom: params.previousEntry.sessionId,
     });
     void runWithGatewayIndependentRootWorkContinuation(async () => {

--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -111,7 +111,6 @@ function emitCompactionSessionLifecycleHooks(params: {
       transcriptArchived: transcript.transcriptArchived,
       lifecycleRevision: params.previousEntry.lifecycleRevision,
       nextSessionId: params.nextEntry.sessionId,
-      nextLifecycleRevision: params.nextEntry.lifecycleRevision,
     });
     void runWithGatewayIndependentRootWorkContinuation(async () => {
       await hookRunner.runSessionEnd(payload.event, payload.context);
@@ -125,7 +124,6 @@ function emitCompactionSessionLifecycleHooks(params: {
       sessionId: params.nextEntry.sessionId,
       sessionKey: params.sessionKey,
       cfg: params.cfg,
-      lifecycleRevision: params.nextEntry.lifecycleRevision,
       resumedFrom: params.previousEntry.sessionId,
     });
     void runWithGatewayIndependentRootWorkContinuation(async () => {

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -1147,11 +1147,11 @@ async function initSessionStateAttemptLocked(
     sessionStore,
   });
   const previousSessionTranscript = committed.previousSessionTranscript;
-  const retainedSessionReset =
-    previousSessionEntry?.sessionId === sessionId &&
-    previousSessionEndReason !== undefined &&
-    previousSessionEndReason !== "unknown";
-  const resetToken = retainedSessionReset ? crypto.randomUUID() : undefined;
+  // Legacy rows can lack lifecycleRevision. Use one synthetic old-generation
+  // fence for both harness cleanup and session_end before exposing the successor.
+  const endedLifecycleRevision = previousSessionEntry?.sessionId
+    ? (previousSessionEntry.lifecycleRevision ?? crypto.randomUUID())
+    : undefined;
 
   if (previousSessionEntry?.sessionId) {
     await retireSessionMcpRuntime({
@@ -1168,8 +1168,8 @@ async function initSessionStateAttemptLocked(
       sessionId: previousSessionEntry.sessionId,
       sessionKey,
       sessionFile: previousSessionEntry.sessionFile,
+      lifecycleRevision: endedLifecycleRevision,
       reason: previousSessionEndReason ?? "unknown",
-      resetToken,
     });
     // Direct-message browser tabs use a peer-scoped runtime identity even when
     // their transcript aliases main; cleanup must carry both exact keys.
@@ -1214,8 +1214,9 @@ async function initSessionStateAttemptLocked(
           reason: previousSessionEndReason,
           sessionFile: previousSessionTranscript.sessionFile,
           transcriptArchived: previousSessionTranscript.transcriptArchived,
+          lifecycleRevision: endedLifecycleRevision,
           nextSessionId: effectiveSessionId,
-          resetToken,
+          nextLifecycleRevision: sessionEntry.lifecycleRevision,
         });
         void runWithGatewayIndependentRootWorkContinuation(async () => {
           await hookRunner.runSessionEnd(payload.event, payload.context);
@@ -1232,6 +1233,7 @@ async function initSessionStateAttemptLocked(
         cfg,
         sessionKey,
         sessionId: effectiveSessionId,
+        lifecycleRevision: sessionEntry.lifecycleRevision,
         storePath,
         sessionFile: sessionEntry?.sessionFile,
         agentId,
@@ -1242,6 +1244,7 @@ async function initSessionStateAttemptLocked(
         sessionId: effectiveSessionId,
         sessionKey,
         cfg,
+        lifecycleRevision: sessionEntry.lifecycleRevision,
         resumedFrom: previousSessionEntry?.sessionId,
       });
       void runWithGatewayIndependentRootWorkContinuation(async () => {

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -1147,11 +1147,11 @@ async function initSessionStateAttemptLocked(
     sessionStore,
   });
   const previousSessionTranscript = committed.previousSessionTranscript;
-  const resetToken =
-    previousSessionEntry?.sessionId &&
-    (previousSessionEndReason === "new" || previousSessionEndReason === "reset")
-      ? crypto.randomUUID()
-      : undefined;
+  const retainedSessionReset =
+    previousSessionEntry?.sessionId === sessionId &&
+    previousSessionEndReason !== undefined &&
+    previousSessionEndReason !== "unknown";
+  const resetToken = retainedSessionReset ? crypto.randomUUID() : undefined;
 
   if (previousSessionEntry?.sessionId) {
     await retireSessionMcpRuntime({

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -1148,8 +1148,7 @@ async function initSessionStateAttemptLocked(
     sessionStore,
   });
   const previousSessionTranscript = committed.previousSessionTranscript;
-  const endedLifecycleRevision =
-    resolveEndedSessionLifecycleRevision(previousSessionEntry);
+  const endedLifecycleRevision = resolveEndedSessionLifecycleRevision(previousSessionEntry);
 
   if (previousSessionEntry?.sessionId) {
     await retireSessionMcpRuntime({

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -1147,6 +1147,11 @@ async function initSessionStateAttemptLocked(
     sessionStore,
   });
   const previousSessionTranscript = committed.previousSessionTranscript;
+  const resetToken =
+    previousSessionEntry?.sessionId &&
+    (previousSessionEndReason === "new" || previousSessionEndReason === "reset")
+      ? crypto.randomUUID()
+      : undefined;
 
   if (previousSessionEntry?.sessionId) {
     await retireSessionMcpRuntime({
@@ -1164,6 +1169,7 @@ async function initSessionStateAttemptLocked(
       sessionKey,
       sessionFile: previousSessionEntry.sessionFile,
       reason: previousSessionEndReason ?? "unknown",
+      resetToken,
     });
     // Direct-message browser tabs use a peer-scoped runtime identity even when
     // their transcript aliases main; cleanup must carry both exact keys.
@@ -1209,6 +1215,7 @@ async function initSessionStateAttemptLocked(
           sessionFile: previousSessionTranscript.sessionFile,
           transcriptArchived: previousSessionTranscript.transcriptArchived,
           nextSessionId: effectiveSessionId,
+          resetToken,
         });
         void runWithGatewayIndependentRootWorkContinuation(async () => {
           await hookRunner.runSessionEnd(payload.event, payload.context);

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -1216,7 +1216,6 @@ async function initSessionStateAttemptLocked(
           transcriptArchived: previousSessionTranscript.transcriptArchived,
           lifecycleRevision: endedLifecycleRevision,
           nextSessionId: effectiveSessionId,
-          nextLifecycleRevision: sessionEntry.lifecycleRevision,
         });
         void runWithGatewayIndependentRootWorkContinuation(async () => {
           await hookRunner.runSessionEnd(payload.event, payload.context);
@@ -1244,7 +1243,6 @@ async function initSessionStateAttemptLocked(
         sessionId: effectiveSessionId,
         sessionKey,
         cfg,
-        lifecycleRevision: sessionEntry.lifecycleRevision,
         resumedFrom: previousSessionEntry?.sessionId,
       });
       void runWithGatewayIndependentRootWorkContinuation(async () => {

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -15,6 +15,7 @@ import { normalizeChatType } from "../../channels/chat-type.js";
 import { resolveGroupSessionKey } from "../../config/sessions/group.js";
 import {
   hasTerminalMainSessionTranscriptNewerThanRegistry,
+  resolveEndedSessionLifecycleRevision,
   resolveSessionLifecycleTimestamps,
   resolveSessionWorkStartError,
 } from "../../config/sessions/lifecycle.js";
@@ -1147,11 +1148,8 @@ async function initSessionStateAttemptLocked(
     sessionStore,
   });
   const previousSessionTranscript = committed.previousSessionTranscript;
-  // Legacy rows can lack lifecycleRevision. Use one synthetic old-generation
-  // fence for both harness cleanup and session_end before exposing the successor.
-  const endedLifecycleRevision = previousSessionEntry?.sessionId
-    ? (previousSessionEntry.lifecycleRevision ?? crypto.randomUUID())
-    : undefined;
+  const endedLifecycleRevision =
+    resolveEndedSessionLifecycleRevision(previousSessionEntry);
 
   if (previousSessionEntry?.sessionId) {
     await retireSessionMcpRuntime({

--- a/src/config/sessions/lifecycle.test.ts
+++ b/src/config/sessions/lifecycle.test.ts
@@ -10,9 +10,27 @@ import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db
 import {
   hasTerminalMainSessionTranscriptNewerThanRegistry,
   hasTerminalMainSessionTranscriptNewerThanRegistrySync,
+  resolveEndedSessionLifecycleRevision,
 } from "./lifecycle.js";
 import { appendTranscriptEvent, loadSessionEntry, upsertSessionEntry } from "./session-accessor.js";
 import type { SessionEntry } from "./types.js";
+
+describe("ended session lifecycle revision", () => {
+  it("reuses the stored revision and derives a retry-stable legacy fence", () => {
+    expect(
+      resolveEndedSessionLifecycleRevision({
+        sessionId: "session-current",
+        lifecycleRevision: "revision-current",
+      }),
+    ).toBe("revision-current");
+    expect(resolveEndedSessionLifecycleRevision({ sessionId: "session-legacy" })).toBe(
+      "legacy:session-legacy",
+    );
+    expect(resolveEndedSessionLifecycleRevision({ sessionId: "session-legacy" })).toBe(
+      "legacy:session-legacy",
+    );
+  });
+});
 
 describe("terminal main session transcript freshness", () => {
   let stateDir: string;

--- a/src/config/sessions/lifecycle.ts
+++ b/src/config/sessions/lifecycle.ts
@@ -25,6 +25,8 @@ type SessionWorkStartOptions = {
   expectedSessionId?: string;
 };
 
+type EndedSessionLifecycleEntry = Pick<SessionEntry, "lifecycleRevision" | "sessionId">;
+
 /** Stable Gateway error detail for stale session lifecycle requests. */
 export const SESSION_LIFECYCLE_CHANGED_ERROR_REASON = "session-changed";
 const SESSION_WORK_START_INVALIDATED_ERROR_CODE = "SESSION_WORK_START_INVALIDATED";
@@ -48,6 +50,20 @@ export function isSessionWorkStartInvalidatedError(
       "code" in error &&
       error.code === SESSION_WORK_START_INVALIDATED_ERROR_CODE)
   );
+}
+
+/**
+ * Returns one retry-stable owner revision for cleanup of a physical session generation.
+ * Legacy rows predate lifecycleRevision, so their immutable session id is the cleanup fence.
+ */
+export function resolveEndedSessionLifecycleRevision(
+  entry: EndedSessionLifecycleEntry | null | undefined,
+): string | undefined {
+  const sessionId = entry?.sessionId.trim();
+  if (!sessionId) {
+    return undefined;
+  }
+  return entry.lifecycleRevision?.trim() || `legacy:${sessionId}`;
 }
 
 /** Lifecycle-owned initializing and archived sessions reject new work. */

--- a/src/config/sessions/lifecycle.ts
+++ b/src/config/sessions/lifecycle.ts
@@ -63,7 +63,7 @@ export function resolveEndedSessionLifecycleRevision(
   if (!sessionId) {
     return undefined;
   }
-  return entry.lifecycleRevision?.trim() || `legacy:${sessionId}`;
+  return entry?.lifecycleRevision?.trim() || `legacy:${sessionId}`;
 }
 
 /** Lifecycle-owned initializing and archived sessions reject new work. */

--- a/src/gateway/active-sessions-shutdown-tracker.ts
+++ b/src/gateway/active-sessions-shutdown-tracker.ts
@@ -19,6 +19,7 @@ type ActiveSessionForShutdown = {
   cfg: OpenClawConfig;
   sessionKey: string;
   sessionId: string;
+  lifecycleRevision?: string;
   storePath: string;
   sessionFile?: string;
   agentId?: string;

--- a/src/gateway/server-methods/agent-handler-helpers.ts
+++ b/src/gateway/server-methods/agent-handler-helpers.ts
@@ -181,9 +181,11 @@ export function emitAgentSendSessionLifecycleTransition(
         sessionId: string;
         storePath: string;
         sessionFile?: string;
+        lifecycleRevision?: string;
         agentId?: string;
         previousSessionId?: string;
         previousSessionFile?: string;
+        previousLifecycleRevision?: string;
         previousEndReason?: PluginHookSessionEndReason;
       }
     | undefined,
@@ -200,14 +202,17 @@ export function emitAgentSendSessionLifecycleTransition(
       sessionFile: transition.previousSessionFile,
       agentId: transition.agentId,
       reason: transition.previousEndReason ?? "unknown",
+      lifecycleRevision: transition.previousLifecycleRevision,
       nextSessionId: transition.sessionId,
       nextSessionKey: transition.sessionKey,
+      nextLifecycleRevision: transition.lifecycleRevision,
     });
   }
   emitGatewaySessionStartPluginHook({
     cfg: transition.cfg,
     sessionKey: transition.sessionKey,
     sessionId: transition.sessionId,
+    lifecycleRevision: transition.lifecycleRevision,
     resumedFrom: transition.previousSessionId,
     storePath: transition.storePath,
     sessionFile: transition.sessionFile,

--- a/src/gateway/server-methods/agent-handler-helpers.ts
+++ b/src/gateway/server-methods/agent-handler-helpers.ts
@@ -205,7 +205,6 @@ export function emitAgentSendSessionLifecycleTransition(
       lifecycleRevision: transition.previousLifecycleRevision,
       nextSessionId: transition.sessionId,
       nextSessionKey: transition.sessionKey,
-      nextLifecycleRevision: transition.lifecycleRevision,
     });
   }
   emitGatewaySessionStartPluginHook({

--- a/src/gateway/server-methods/agent-session-persist.ts
+++ b/src/gateway/server-methods/agent-session-persist.ts
@@ -467,9 +467,11 @@ export async function persistAgentSessionPhase(params: {
       sessionId: resolvedSessionId,
       storePath: params.storePath,
       sessionFile: sessionEntry?.sessionFile,
+      lifecycleRevision: sessionEntry?.lifecycleRevision,
       agentId: params.sessionAgentId,
       previousSessionId,
       previousSessionFile: previousSessionId ? params.entry?.sessionFile : undefined,
+      previousLifecycleRevision: previousSessionId ? params.entry?.lifecycleRevision : undefined,
       previousEndReason: previousSessionId
         ? (freshness?.staleReason ??
           (usableRequestedSessionId && params.entry?.sessionId !== usableRequestedSessionId

--- a/src/gateway/server-methods/sessions-delete.ts
+++ b/src/gateway/server-methods/sessions-delete.ts
@@ -1,5 +1,4 @@
 // Destructive session deletion and lifecycle cleanup.
-import { randomUUID } from "node:crypto";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import {
   ErrorCodes,
@@ -10,6 +9,7 @@ import { resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import { managedWorktrees } from "../../agents/worktrees/service.js";
 import {
   deleteSessionEntryLifecycle,
+  resolveEndedSessionLifecycleRevision,
   resolveMainSessionKey,
   SESSION_LIFECYCLE_CHANGED_ERROR_REASON,
   type SessionEntry,
@@ -314,9 +314,7 @@ export const sessionDeleteHandlers: GatewayRequestHandlers = {
         ) {
           return undefined;
         }
-        const endedLifecycleRevision = entry?.sessionId
-          ? (entry.lifecycleRevision ?? randomUUID())
-          : undefined;
+        const endedLifecycleRevision = resolveEndedSessionLifecycleRevision(entry);
         const mutationCleanupError = await cleanupSessionBeforeMutation({
           cfg,
           key,

--- a/src/gateway/server-methods/sessions-delete.ts
+++ b/src/gateway/server-methods/sessions-delete.ts
@@ -1,4 +1,5 @@
 // Destructive session deletion and lifecycle cleanup.
+import { randomUUID } from "node:crypto";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import {
   ErrorCodes,
@@ -313,11 +314,15 @@ export const sessionDeleteHandlers: GatewayRequestHandlers = {
         ) {
           return undefined;
         }
+        const endedLifecycleRevision = entry?.sessionId
+          ? (entry.lifecycleRevision ?? randomUUID())
+          : undefined;
         const mutationCleanupError = await cleanupSessionBeforeMutation({
           cfg,
           key,
           target,
           entry,
+          lifecycleRevision: endedLifecycleRevision,
           legacyKey,
           canonicalKey,
           reason: "session-delete",
@@ -385,6 +390,7 @@ export const sessionDeleteHandlers: GatewayRequestHandlers = {
             agentId: target.agentId,
             reason: "deleted",
             archivedTranscripts: result.archivedTranscripts,
+            lifecycleRevision: postCleanupEntry?.lifecycleRevision ?? endedLifecycleRevision,
           });
           await emitSessionUnboundLifecycleEvent({
             targetSessionKey: target.canonicalKey ?? key,

--- a/src/gateway/server.sessions.delete-lifecycle.test.ts
+++ b/src/gateway/server.sessions.delete-lifecycle.test.ts
@@ -920,6 +920,9 @@ test("sessions.delete emits session_end with deleted reason and no replacement",
     "agent:main:discord:group:delete",
   );
   expect((event as { reason?: string } | undefined)?.reason).toBe("deleted");
+  expect((event as { lifecycleRevision?: string } | undefined)?.lifecycleRevision).toBe(
+    "legacy:sess-delete",
+  );
   expect(
     (event as { transcriptArchived?: boolean } | undefined)?.transcriptArchived,
   ).toBeUndefined();

--- a/src/gateway/server.sessions.reset-cleanup.test.ts
+++ b/src/gateway/server.sessions.reset-cleanup.test.ts
@@ -349,9 +349,67 @@ test("sessions.reset forwards the retired generation to registered agent harness
       sessionId: "sess-main",
       sessionKey: "agent:main:main",
       sessionFile: expect.stringMatching(/^sqlite:main:sess-main:/),
-      lifecycleRevision: expect.stringMatching(/\S/),
+      lifecycleRevision: "legacy:sess-main",
       reason: "reset",
     });
+  } finally {
+    restoreRegisteredAgentHarnesses(registeredHarnesses);
+  }
+});
+
+test("sessions.reset reuses a legacy cleanup revision after a partial failure", async () => {
+  const registeredHarnesses = listRegisteredAgentHarnesses();
+  const lifecycleRevisions: Array<string | undefined> = [];
+  let cleanupObserved = false;
+  registerAgentHarness({
+    id: "reset-retry-observer",
+    label: "Reset retry observer",
+    supports: () => ({ supported: false }),
+    runAttempt: async () => {
+      throw new Error("not used");
+    },
+    reset: async (params) => {
+      lifecycleRevisions.push(params.lifecycleRevision);
+      cleanupObserved = true;
+    },
+  });
+  try {
+    await seedWaitingActiveMainSession();
+    const { performGatewaySessionReset } = await import("./session-reset-service.js");
+
+    await expect(
+      performGatewaySessionReset({
+        key: "main",
+        reason: "reset",
+        commandSource: "gateway:agent",
+        assertAuthorizedInstance: () => {
+          if (cleanupObserved) {
+            cleanupObserved = false;
+            throw new Error("partial reset after harness cleanup");
+          }
+        },
+      }),
+    ).rejects.toThrow("partial reset after harness cleanup");
+    const storePath = testState.sessionStorePath;
+    if (!storePath) {
+      throw new Error("expected session store path");
+    }
+    expect(
+      loadSessionEntry({
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        storePath,
+      })?.lifecycleRevision,
+    ).toBeUndefined();
+
+    const retry = await performGatewaySessionReset({
+      key: "main",
+      reason: "reset",
+      commandSource: "gateway:agent",
+    });
+
+    expect(retry.ok).toBe(true);
+    expect(lifecycleRevisions).toEqual(["legacy:sess-main", "legacy:sess-main"]);
   } finally {
     restoreRegisteredAgentHarnesses(registeredHarnesses);
   }

--- a/src/gateway/server.sessions.reset-cleanup.test.ts
+++ b/src/gateway/server.sessions.reset-cleanup.test.ts
@@ -357,64 +357,6 @@ test("sessions.reset forwards the retired generation to registered agent harness
   }
 });
 
-test("sessions.reset reuses a legacy cleanup revision after a partial failure", async () => {
-  const registeredHarnesses = listRegisteredAgentHarnesses();
-  const lifecycleRevisions: Array<string | undefined> = [];
-  let cleanupObserved = false;
-  registerAgentHarness({
-    id: "reset-retry-observer",
-    label: "Reset retry observer",
-    supports: () => ({ supported: false }),
-    runAttempt: async () => {
-      throw new Error("not used");
-    },
-    reset: async (params) => {
-      lifecycleRevisions.push(params.lifecycleRevision);
-      cleanupObserved = true;
-    },
-  });
-  try {
-    await seedWaitingActiveMainSession();
-    const { performGatewaySessionReset } = await import("./session-reset-service.js");
-
-    await expect(
-      performGatewaySessionReset({
-        key: "main",
-        reason: "reset",
-        commandSource: "gateway:agent",
-        assertAuthorizedInstance: () => {
-          if (cleanupObserved) {
-            cleanupObserved = false;
-            throw new Error("partial reset after harness cleanup");
-          }
-        },
-      }),
-    ).rejects.toThrow("partial reset after harness cleanup");
-    const storePath = testState.sessionStorePath;
-    if (!storePath) {
-      throw new Error("expected session store path");
-    }
-    expect(
-      loadSessionEntry({
-        agentId: "main",
-        sessionKey: "agent:main:main",
-        storePath,
-      })?.lifecycleRevision,
-    ).toBeUndefined();
-
-    const retry = await performGatewaySessionReset({
-      key: "main",
-      reason: "reset",
-      commandSource: "gateway:agent",
-    });
-
-    expect(retry.ok).toBe(true);
-    expect(lifecycleRevisions).toEqual(["legacy:sess-main", "legacy:sess-main"]);
-  } finally {
-    restoreRegisteredAgentHarnesses(registeredHarnesses);
-  }
-});
-
 test("sessions.reset interrupts work admitted before runtime registration", async () => {
   const { storePath } = await seedActiveMainSession();
   let interrupted = false;

--- a/src/gateway/server.sessions.reset-cleanup.test.ts
+++ b/src/gateway/server.sessions.reset-cleanup.test.ts
@@ -349,8 +349,8 @@ test("sessions.reset forwards the retired generation to registered agent harness
       sessionId: "sess-main",
       sessionKey: "agent:main:main",
       sessionFile: expect.stringMatching(/^sqlite:main:sess-main:/),
+      lifecycleRevision: expect.stringMatching(/\S/),
       reason: "reset",
-      resetToken: expect.stringMatching(/\S/),
     });
   } finally {
     restoreRegisteredAgentHarnesses(registeredHarnesses);

--- a/src/gateway/server.sessions.reset-cleanup.test.ts
+++ b/src/gateway/server.sessions.reset-cleanup.test.ts
@@ -350,6 +350,7 @@ test("sessions.reset forwards the retired generation to registered agent harness
       sessionKey: "agent:main:main",
       sessionFile: expect.stringMatching(/^sqlite:main:sess-main:/),
       reason: "reset",
+      resetToken: expect.stringMatching(/\S/),
     });
   } finally {
     restoreRegisteredAgentHarnesses(registeredHarnesses);

--- a/src/gateway/server.sessions.reset-hooks.test.ts
+++ b/src/gateway/server.sessions.reset-hooks.test.ts
@@ -562,6 +562,8 @@ test("sessions.reset emits enriched session_end and session_start hooks", async 
   expect(endEvent.sessionFile).toBeUndefined();
   expect(endEvent.nextSessionId).toBe(startEvent.sessionId);
   expect(endEvent.nextSessionId).toBe("sess-main");
+  expect(endEvent.resetToken).toBeTypeOf("string");
+  expect(endEvent.resetToken).not.toBe("");
   expectMainHookContext(endContext, "sess-main");
   expect(startEvent.sessionKey).toBe("agent:main:main");
   expect(startEvent.sessionId).toBe("sess-main");

--- a/src/gateway/server.sessions.reset-hooks.test.ts
+++ b/src/gateway/server.sessions.reset-hooks.test.ts
@@ -562,8 +562,9 @@ test("sessions.reset emits enriched session_end and session_start hooks", async 
   expect(endEvent.sessionFile).toBeUndefined();
   expect(endEvent.nextSessionId).toBe(startEvent.sessionId);
   expect(endEvent.nextSessionId).toBe("sess-main");
-  expect(endEvent.resetToken).toBeTypeOf("string");
-  expect(endEvent.resetToken).not.toBe("");
+  expect(endEvent.lifecycleRevision).toBeTypeOf("string");
+  expect(endEvent.nextLifecycleRevision).toBe(startEvent.lifecycleRevision);
+  expect(endEvent.nextLifecycleRevision).not.toBe(endEvent.lifecycleRevision);
   expectMainHookContext(endContext, "sess-main");
   expect(startEvent.sessionKey).toBe("agent:main:main");
   expect(startEvent.sessionId).toBe("sess-main");

--- a/src/gateway/server.sessions.reset-hooks.test.ts
+++ b/src/gateway/server.sessions.reset-hooks.test.ts
@@ -563,8 +563,6 @@ test("sessions.reset emits enriched session_end and session_start hooks", async 
   expect(endEvent.nextSessionId).toBe(startEvent.sessionId);
   expect(endEvent.nextSessionId).toBe("sess-main");
   expect(endEvent.lifecycleRevision).toBeTypeOf("string");
-  expect(endEvent.nextLifecycleRevision).toBe(startEvent.lifecycleRevision);
-  expect(endEvent.nextLifecycleRevision).not.toBe(endEvent.lifecycleRevision);
   expectMainHookContext(endContext, "sess-main");
   expect(startEvent.sessionKey).toBe("agent:main:main");
   expect(startEvent.sessionId).toBe("sess-main");

--- a/src/gateway/server.sessions.reset-lifecycle-retry.test.ts
+++ b/src/gateway/server.sessions.reset-lifecycle-retry.test.ts
@@ -1,0 +1,78 @@
+// Session reset lifecycle retry tests protect generation identity across
+// partial failures that occur after harness cleanup.
+import { afterEach, expect, test } from "vitest";
+import {
+  listRegisteredAgentHarnesses,
+  registerAgentHarness,
+  restoreRegisteredAgentHarnesses,
+} from "../agents/harness/registry.js";
+import { loadSessionEntry } from "../config/sessions/session-accessor.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { embeddedRunMock, testState } from "./test-helpers.js";
+import { setupGatewaySessionsTestHarness } from "./test/server-sessions.test-helpers.js";
+
+const { seedActiveMainSession } = setupGatewaySessionsTestHarness();
+
+afterEach(() => {
+  closeOpenClawStateDatabaseForTest();
+});
+
+test("sessions.reset reuses a legacy cleanup revision after a partial failure", async () => {
+  const registeredHarnesses = listRegisteredAgentHarnesses();
+  const lifecycleRevisions: Array<string | undefined> = [];
+  let cleanupObserved = false;
+  registerAgentHarness({
+    id: "reset-retry-observer",
+    label: "Reset retry observer",
+    supports: () => ({ supported: false }),
+    runAttempt: async () => {
+      throw new Error("not used");
+    },
+    reset: async (params) => {
+      lifecycleRevisions.push(params.lifecycleRevision);
+      cleanupObserved = true;
+    },
+  });
+  try {
+    await seedActiveMainSession();
+    embeddedRunMock.activeIds.add("sess-main");
+    embeddedRunMock.waitResults.set("sess-main", true);
+    const { performGatewaySessionReset } = await import("./session-reset-service.js");
+
+    await expect(
+      performGatewaySessionReset({
+        key: "main",
+        reason: "reset",
+        commandSource: "gateway:agent",
+        assertAuthorizedInstance: () => {
+          if (cleanupObserved) {
+            cleanupObserved = false;
+            throw new Error("partial reset after harness cleanup");
+          }
+        },
+      }),
+    ).rejects.toThrow("partial reset after harness cleanup");
+    const storePath = testState.sessionStorePath;
+    if (!storePath) {
+      throw new Error("expected session store path");
+    }
+    expect(
+      loadSessionEntry({
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        storePath,
+      })?.lifecycleRevision,
+    ).toBeUndefined();
+
+    const retry = await performGatewaySessionReset({
+      key: "main",
+      reason: "reset",
+      commandSource: "gateway:agent",
+    });
+
+    expect(retry.ok).toBe(true);
+    expect(lifecycleRevisions).toEqual(["legacy:sess-main", "legacy:sess-main"]);
+  } finally {
+    restoreRegisteredAgentHarnesses(registeredHarnesses);
+  }
+});

--- a/src/gateway/session-create-service.ts
+++ b/src/gateway/session-create-service.ts
@@ -1080,14 +1080,17 @@ export async function createGatewaySession(params: {
           sessionFile: parentEntry?.sessionFile,
           agentId: parentSessionTarget.agentId,
           reason: "new",
+          lifecycleRevision: parentEntry?.lifecycleRevision,
           nextSessionId: created.entry.sessionId,
           nextSessionKey: target.canonicalKey,
+          nextLifecycleRevision: created.entry.lifecycleRevision,
         });
       }
       emitGatewaySessionStartPluginHook({
         cfg: params.cfg,
         sessionKey: target.canonicalKey,
         sessionId: created.entry.sessionId,
+        lifecycleRevision: created.entry.lifecycleRevision,
         resumedFrom: parentEntry?.sessionId,
         storePath: target.storePath,
         sessionFile: created.entry.sessionFile,

--- a/src/gateway/session-create-service.ts
+++ b/src/gateway/session-create-service.ts
@@ -1083,7 +1083,6 @@ export async function createGatewaySession(params: {
           lifecycleRevision: parentEntry?.lifecycleRevision,
           nextSessionId: created.entry.sessionId,
           nextSessionKey: target.canonicalKey,
-          nextLifecycleRevision: created.entry.lifecycleRevision,
         });
       }
       emitGatewaySessionStartPluginHook({

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -145,6 +145,7 @@ export function emitGatewaySessionEndPluginHook(params: {
   archivedTranscripts?: ArchivedSessionTranscript[];
   nextSessionId?: string;
   nextSessionKey?: string;
+  resetToken?: string;
 }): void {
   if (!params.sessionId) {
     return;
@@ -173,6 +174,7 @@ export function emitGatewaySessionEndPluginHook(params: {
     transcriptArchived: transcript.transcriptArchived,
     nextSessionId: params.nextSessionId,
     nextSessionKey: params.nextSessionKey,
+    resetToken: params.resetToken,
   });
   void runWithGatewayIndependentRootWorkContinuation(async () => {
     await hookRunner.runSessionEnd(payload.event, payload.context);
@@ -1100,6 +1102,7 @@ export async function performGatewaySessionReset(params: {
         };
       }
       const hadExistingEntry = Boolean(entry);
+      const resetToken = entry?.sessionId ? randomUUID() : undefined;
       const resetLifecycleRevision = entry?.lifecycleRevision;
       const agentId = normalizeAgentId(target.agentId ?? resolveDefaultAgentId(cfg));
       const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
@@ -1180,6 +1183,7 @@ export async function performGatewaySessionReset(params: {
           sessionKey: target.canonicalKey ?? params.key,
           sessionFile: entry.sessionFile,
           reason: "reset",
+          resetToken,
         });
       }
       const beforeResetMessages = getGlobalHookRunner()?.hasHooks("before_reset")
@@ -1244,6 +1248,7 @@ export async function performGatewaySessionReset(params: {
           agentId: target.agentId,
           reason: params.reason,
           archivedTranscripts: [],
+          resetToken,
         });
         await emitSessionUnboundLifecycleEvent({
           targetSessionKey: target.canonicalKey,
@@ -1545,6 +1550,7 @@ export async function performGatewaySessionReset(params: {
           reason: params.reason,
           archivedTranscripts,
           nextSessionId: next.sessionId,
+          resetToken,
         });
         emitGatewaySessionStartPluginHook({
           cfg,

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -31,10 +31,11 @@ import { clearSessionResetRuntimeState } from "../auto-reply/reply/session-reset
 import { cleanupBrowserSessionsForLifecycleEnd } from "../browser-lifecycle-cleanup.js";
 import { getRuntimeConfig } from "../config/io.js";
 import {
+  deleteSessionEntryLifecycle,
+  resolveEndedSessionLifecycleRevision,
+  resetSessionEntryLifecycle,
   resolveSessionWorkStartError,
   type SessionEntry,
-  deleteSessionEntryLifecycle,
-  resetSessionEntryLifecycle,
 } from "../config/sessions.js";
 import { rebindCliSessionReseedReceiptsForReset } from "../config/sessions/cli-session-binding.js";
 import { resolveResetPreservedSelection } from "../config/sessions/reset-preserved-selection.js";
@@ -1107,12 +1108,7 @@ export async function performGatewaySessionReset(params: {
         };
       }
       const hadExistingEntry = Boolean(entry);
-      // Older session rows may predate lifecycleRevision. Mint one fence for
-      // every old-generation cleanup surface so a delayed end cannot target the
-      // same-id successor merely because the legacy row had no revision.
-      const endedLifecycleRevision = entry?.sessionId
-        ? (entry.lifecycleRevision ?? randomUUID())
-        : undefined;
+      const endedLifecycleRevision = resolveEndedSessionLifecycleRevision(entry);
       const resetLifecycleRevision = entry?.lifecycleRevision;
       const agentId = normalizeAgentId(target.agentId ?? resolveDefaultAgentId(cfg));
       const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -143,9 +143,10 @@ export function emitGatewaySessionEndPluginHook(params: {
     | "restart"
     | "unknown";
   archivedTranscripts?: ArchivedSessionTranscript[];
+  lifecycleRevision?: string;
   nextSessionId?: string;
   nextSessionKey?: string;
-  resetToken?: string;
+  nextLifecycleRevision?: string;
 }): void {
   if (!params.sessionId) {
     return;
@@ -172,9 +173,10 @@ export function emitGatewaySessionEndPluginHook(params: {
     reason: params.reason,
     sessionFile: transcript.sessionFile,
     transcriptArchived: transcript.transcriptArchived,
+    lifecycleRevision: params.lifecycleRevision,
     nextSessionId: params.nextSessionId,
     nextSessionKey: params.nextSessionKey,
-    resetToken: params.resetToken,
+    nextLifecycleRevision: params.nextLifecycleRevision,
   });
   void runWithGatewayIndependentRootWorkContinuation(async () => {
     await hookRunner.runSessionEnd(payload.event, payload.context);
@@ -187,6 +189,7 @@ export function emitGatewaySessionStartPluginHook(params: {
   cfg: OpenClawConfig;
   sessionKey: string;
   sessionId?: string;
+  lifecycleRevision?: string;
   resumedFrom?: string;
   storePath?: string;
   sessionFile?: string;
@@ -206,6 +209,7 @@ export function emitGatewaySessionStartPluginHook(params: {
       cfg: params.cfg,
       sessionKey: params.sessionKey,
       sessionId: params.sessionId,
+      lifecycleRevision: params.lifecycleRevision,
       storePath: params.storePath,
       sessionFile: params.sessionFile,
       agentId: params.agentId,
@@ -219,6 +223,7 @@ export function emitGatewaySessionStartPluginHook(params: {
     sessionId: params.sessionId,
     sessionKey: params.sessionKey,
     cfg: params.cfg,
+    lifecycleRevision: params.lifecycleRevision,
     resumedFrom: params.resumedFrom,
   });
   void runWithGatewayIndependentRootWorkContinuation(async () => {
@@ -286,6 +291,7 @@ export async function drainActiveSessionsForShutdown(params: {
           reason: params.reason,
           sessionFile: transcript.sessionFile,
           transcriptArchived: transcript.transcriptArchived,
+          lifecycleRevision: entry.lifecycleRevision,
         });
         await hookRunner.runSessionEnd(payload.event, payload.context);
       } catch (err) {
@@ -764,6 +770,7 @@ export async function cleanupSessionBeforeMutation(params: {
   key: string;
   target: ReturnType<typeof resolveGatewaySessionStoreTarget>;
   entry: SessionEntry | undefined;
+  lifecycleRevision?: string;
   legacyKey?: string;
   canonicalKey?: string;
   reason: "session-reset" | "session-delete";
@@ -824,6 +831,7 @@ export async function cleanupSessionBeforeMutation(params: {
       sessionId: params.entry.sessionId,
       sessionKey: params.target.canonicalKey ?? params.key,
       sessionFile: params.entry.sessionFile,
+      lifecycleRevision: params.lifecycleRevision ?? params.entry.lifecycleRevision,
       reason: params.reason === "session-reset" ? "reset" : "deleted",
     } satisfies Parameters<typeof resetRegisteredAgentHarnessSessions>[0];
     await resetRegisteredAgentHarnessSessions(resetParams);
@@ -1102,7 +1110,12 @@ export async function performGatewaySessionReset(params: {
         };
       }
       const hadExistingEntry = Boolean(entry);
-      const resetToken = entry?.sessionId ? randomUUID() : undefined;
+      // Older session rows may predate lifecycleRevision. Mint one fence for
+      // every old-generation cleanup surface so a delayed end cannot target the
+      // same-id successor merely because the legacy row had no revision.
+      const endedLifecycleRevision = entry?.sessionId
+        ? (entry.lifecycleRevision ?? randomUUID())
+        : undefined;
       const resetLifecycleRevision = entry?.lifecycleRevision;
       const agentId = normalizeAgentId(target.agentId ?? resolveDefaultAgentId(cfg));
       const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
@@ -1182,8 +1195,8 @@ export async function performGatewaySessionReset(params: {
           sessionId: entry.sessionId,
           sessionKey: target.canonicalKey ?? params.key,
           sessionFile: entry.sessionFile,
+          lifecycleRevision: endedLifecycleRevision,
           reason: "reset",
-          resetToken,
         });
       }
       const beforeResetMessages = getGlobalHookRunner()?.hasHooks("before_reset")
@@ -1248,7 +1261,7 @@ export async function performGatewaySessionReset(params: {
           agentId: target.agentId,
           reason: params.reason,
           archivedTranscripts: [],
-          resetToken,
+          lifecycleRevision: endedLifecycleRevision,
         });
         await emitSessionUnboundLifecycleEvent({
           targetSessionKey: target.canonicalKey,
@@ -1549,13 +1562,15 @@ export async function performGatewaySessionReset(params: {
           agentId: target.agentId,
           reason: params.reason,
           archivedTranscripts,
+          lifecycleRevision: lifecycle.previousEntry?.lifecycleRevision ?? endedLifecycleRevision,
           nextSessionId: next.sessionId,
-          resetToken,
+          nextLifecycleRevision: next.lifecycleRevision,
         });
         emitGatewaySessionStartPluginHook({
           cfg,
           sessionKey: target.canonicalKey ?? params.key,
           sessionId: next.sessionId,
+          lifecycleRevision: next.lifecycleRevision,
           resumedFrom: oldSessionId,
           storePath,
           sessionFile: next.sessionFile,

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -146,7 +146,6 @@ export function emitGatewaySessionEndPluginHook(params: {
   lifecycleRevision?: string;
   nextSessionId?: string;
   nextSessionKey?: string;
-  nextLifecycleRevision?: string;
 }): void {
   if (!params.sessionId) {
     return;
@@ -176,7 +175,6 @@ export function emitGatewaySessionEndPluginHook(params: {
     lifecycleRevision: params.lifecycleRevision,
     nextSessionId: params.nextSessionId,
     nextSessionKey: params.nextSessionKey,
-    nextLifecycleRevision: params.nextLifecycleRevision,
   });
   void runWithGatewayIndependentRootWorkContinuation(async () => {
     await hookRunner.runSessionEnd(payload.event, payload.context);
@@ -223,7 +221,6 @@ export function emitGatewaySessionStartPluginHook(params: {
     sessionId: params.sessionId,
     sessionKey: params.sessionKey,
     cfg: params.cfg,
-    lifecycleRevision: params.lifecycleRevision,
     resumedFrom: params.resumedFrom,
   });
   void runWithGatewayIndependentRootWorkContinuation(async () => {
@@ -1564,7 +1561,6 @@ export async function performGatewaySessionReset(params: {
           archivedTranscripts,
           lifecycleRevision: lifecycle.previousEntry?.lifecycleRevision ?? endedLifecycleRevision,
           nextSessionId: next.sessionId,
-          nextLifecycleRevision: next.lifecycleRevision,
         });
         emitGatewaySessionStartPluginHook({
           cfg,

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -724,14 +724,11 @@ export type PluginHookSessionContext = {
   agentId?: string;
   sessionId: string;
   sessionKey?: string;
-  lifecycleRevision?: string;
 };
 
 export type PluginHookSessionStartEvent = {
   sessionId: string;
   sessionKey?: string;
-  /** Authoritative revision of this physical session generation. */
-  lifecycleRevision?: string;
   resumedFrom?: string;
 };
 
@@ -758,8 +755,6 @@ export type PluginHookSessionEndEvent = {
   transcriptArchived?: boolean;
   nextSessionId?: string;
   nextSessionKey?: string;
-  /** Authoritative revision of the successor generation, when one exists. */
-  nextLifecycleRevision?: string;
 };
 
 export type PluginHookSubagentContext = {

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -724,11 +724,14 @@ export type PluginHookSessionContext = {
   agentId?: string;
   sessionId: string;
   sessionKey?: string;
+  lifecycleRevision?: string;
 };
 
 export type PluginHookSessionStartEvent = {
   sessionId: string;
   sessionKey?: string;
+  /** Authoritative revision of this physical session generation. */
+  lifecycleRevision?: string;
   resumedFrom?: string;
 };
 
@@ -746,6 +749,8 @@ export type PluginHookSessionEndReason =
 export type PluginHookSessionEndEvent = {
   sessionId: string;
   sessionKey?: string;
+  /** Authoritative revision of the physical session generation that ended. */
+  lifecycleRevision?: string;
   messageCount: number;
   durationMs?: number;
   reason?: PluginHookSessionEndReason;
@@ -753,8 +758,8 @@ export type PluginHookSessionEndEvent = {
   transcriptArchived?: boolean;
   nextSessionId?: string;
   nextSessionKey?: string;
-  /** Runtime-local token matching the harness reset that preceded this lifecycle event. */
-  resetToken?: string;
+  /** Authoritative revision of the successor generation, when one exists. */
+  nextLifecycleRevision?: string;
 };
 
 export type PluginHookSubagentContext = {

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -753,6 +753,8 @@ export type PluginHookSessionEndEvent = {
   transcriptArchived?: boolean;
   nextSessionId?: string;
   nextSessionKey?: string;
+  /** Runtime-local token matching the harness reset that preceded this lifecycle event. */
+  resetToken?: string;
 };
 
 export type PluginHookSubagentContext = {


### PR DESCRIPTION
<!-- AI-assisted: Codex helped diagnose, implement, test, and review this fix. I reviewed the diff and understand the behavior it changes. -->

Related: #108769
Related: #106778
Supersedes: #113429

## Summary

### High Level TLDR

Codex-backed chats could become permanently unusable after `/new`, `/reset`, or automatic rollover because OpenClaw retained the physical session ID while retiring the Codex binding under that same ID. This change gives cleanup the logical lifecycle revision that actually ended, so delayed old work cannot retire the successor.

The shared API is intentionally narrowed to exactly two optional fields:

1. `AgentHarnessResetParams.lifecycleRevision` — tells a harness which generation reset is cleaning up.
2. `PluginHookSessionEndEvent.lifecycleRevision` — tells end-hook consumers which generation ended.

The previously proposed hook-context revision, session-start revision, and successor revision fields were removed because production had no consumer for them.

These are TypeScript message fields, not OpenClaw configuration options. There is no `openclaw.json`, environment-variable, CLI, SQLite schema/version, provider, model, or auth change.

## What Problem This Solves

After `/new` or `/reset`, each later message could return “This Codex session changed before your message could run.” The successor reused the same physical OpenClaw session ID, while delayed cleanup for the previous logical generation could retire or block the successor's Codex binding.

## Root Cause

Durable reset intentionally retains the OpenClaw session ID so the SQLite transcript remains searchable. Codex binding ownership previously used only that physical ID, so old and successor logical generations were indistinguishable to delayed cleanup.

Review also identified and fixed reachable lifecycle gaps:

- reset before any Codex binding existed did not stamp the successor revision before its first revisionless runtime write;
- legacy rows generated a new random cleanup revision on each retry, so partial reset/delete failure could make cleanup permanently conflict;
- legacy compaction/shutdown end events could be emitted without a stable revision;
- a delayed R1 reset arriving after R2 claimed ownership correctly preserved R2 but still reported a false reset failure.

Direct Codex dependency inspection confirmed that thread start and resume are separate operations and resume is keyed by Codex thread ID:

- `codex-rs/app-server/README.md`
- `codex-rs/app-server/src/request_processors/thread_processor.rs`
- `codex-rs/app-server-protocol/src/protocol/v2/thread.rs`

## Exact Change

- Persist an optional internal `lifecycleRevision` with the Codex plugin binding.
- Include revision in binding ownership checks and delayed cleanup fencing.
- Pass the ended revision only through harness reset and plugin session-end contracts.
- Derive one deterministic legacy cleanup revision across reset, delete, rollover, compaction, and shutdown retries.
- Preserve legacy active-row upgrade and retired-row reclaim behavior.
- Make stale reset cleanup idempotent after the authoritative successor is confirmed.
- Add regressions for delayed old ends, absent first bindings, partial reset retry, legacy event producers, and successor-claimed stale reset.
- Keep the legacy retry regression in a focused test file so the normal max-lines lint gate remains satisfied.

The internal persisted field remains plugin-owned JSON state. It is not user configuration and does not change the SQLite schema.

## Evidence

- Current head: `34b790a498b748534ceeb530244b7b2f6e1d1489`.
- Rebased onto `c66ca2fbb2b038f4796abfa76bd52dcc3b675b02` with no conflicts.
- `git diff --check origin/main...HEAD`: exited 0 with no output.
- Focused stale-reset review: `autoreview clean: no accepted/actionable findings reported`.
- Final branch review raised one adoption-revision suggestion; source tracing showed it is unreachable: the only production adoption caller is `after_compaction`, it skips same-ID events and does not receive a lifecycle revision. Adding another shared field would have no runtime consumer.
- Formatting-only follow-up review: `autoreview clean: no accepted/actionable findings reported` at 0.99 confidence.
- Net shared contract diff contains exactly the two optional fields named above.
- Prior focused proof on the predecessor head: 195 tests passed across 12 lifecycle/Codex files, plus the full changed-surface gate.
- Exact-head fork-safe CI completed green: 57 CI jobs succeeded, 11 were intentionally skipped, and all pull-request workflows (CI, CodeQL, CodeQL Critical Quality, OpenGrep, Workflow Sanity, and platform dead-code scans) succeeded.

## Real behavior proof

Exact-head proof was run on 2026-07-26 after the normal guarded updater reapplied head `34b790a498b748534ceeb530244b7b2f6e1d1489` to base `c66ca2fbb2b038f4796abfa76bd52dcc3b675b02` and rebuilt OpenClaw 2026.7.2 on Linux. The test used the real Gateway and real Codex app-server in an isolated, non-delivered session; all identifiers are redacted.

Steps and copied results:

```text
1. Send: Reply with exactly: PR113796-PRE-OK
   status: ok; summary: completed; text: PR113796-PRE-OK

2. Send: /new
   status: ok; summary: completed; text: New session started.

3. Send on the same OpenClaw session key: Reply with exactly: PR113796-POST-RESET-OK
   status: ok; summary: completed; text: PR113796-POST-RESET-OK
```

Both normal turns reported:

```text
provider: openai
model: gpt-5.6-sol
agentHarnessId: codex
aborted: false
```

Read-only inspection of the canonical per-agent SQLite state after the run showed one retained physical session root, one reset event, a current lifecycle revision, and an active Codex thread binding carrying that same revision. The transcript event sequence was:

```text
session, message, message, reset, message, message
```

No session-changed or generation-changed error occurred. The isolated proof session was then deleted; no user session or external chat was modified.

This satisfies the exact-head runtime proof request. Explicit lifecycle-owner approval for the two optional shared fields remains a separate merge gate.

## Verification

- Shared lifecycle contract: exactly two optional fields, not five.
- No configuration, provider, model, auth, or SQLite schema surface added.
- Exact-head GitHub CI is green on the fork-safe PR path.
- Maintainer edits remain enabled.

## What was not tested

- Telegram transport/UI was not involved; this was an isolated real Gateway/Codex reset-and-reply run with no external delivery.
- Delayed old cleanup was not artificially injected into the production process. The focused automated race regressions cover that path.
- No macOS, Windows, Docker, packaging, or UI validation was run because the change is server-side session and Codex binding lifecycle logic.
- No SQLite migration was tested because the schema is unchanged.
