### PR TITLE
fix(ui): restore chat settings for default-session aliases

### DIFF
--- a/ui/src/e2e/chat-composer-redesign.e2e.test.ts
+++ b/ui/src/e2e/chat-composer-redesign.e2e.test.ts
@@ -541,6 +541,123 @@ describeControlUiE2e("Control UI chat composer redesign", () => {
     }
   });
 
+  it.each([
+    {
+      title: "short main resolves the canonical main session",
+      selected: "main",
+      active: "agent:main:main",
+      other: "agent:work:main",
+      conflictingAliasFirst: false,
+    },
+    {
+      title: "canonical main resolves the short main session",
+      selected: "agent:main:main",
+      active: "main",
+      other: "agent:work:main",
+      conflictingAliasFirst: false,
+    },
+    {
+      title: "a second agent never inherits the main session",
+      selected: "agent:work:main",
+      active: "agent:work:main",
+      other: "agent:main:main",
+      conflictingAliasFirst: false,
+    },
+    {
+      title: "the exact main session precedes an earlier conflicting alias",
+      selected: "main",
+      active: "main",
+      other: "agent:main:main",
+      conflictingAliasFirst: true,
+    },
+  ])(
+    "restores persisted model, reasoning, speed, and context when $title",
+    async ({ selected, active, other, conflictingAliasFirst }) => {
+      const context = await browser.newContext({ viewport: { width: 1280, height: 900 } });
+      const page = await context.newPage();
+      const now = Date.now();
+      const activeSession = {
+        contextTokens: 200_000,
+        effectiveFastMode: true,
+        fastMode: true,
+        key: active,
+        kind: "direct",
+        model: "gpt-5.4-pro",
+        modelProvider: "openai",
+        status: "done",
+        thinkingLevel: "low",
+        totalTokens: 42_000,
+        totalTokensFresh: true,
+        updatedAt: now,
+      };
+      const otherSession = {
+        contextTokens: 200_000,
+        effectiveFastMode: false,
+        fastMode: false,
+        key: other,
+        kind: "direct",
+        model: "gpt-5.5",
+        modelProvider: "openai",
+        status: "done",
+        thinkingLevel: "high",
+        totalTokens: 8_000,
+        totalTokensFresh: true,
+        updatedAt: now,
+      };
+      const gateway = await installMockGateway(page, {
+        sessionKey: selected,
+        models: [
+          { id: "gpt-5.5", name: "GPT-5.5", provider: "openai" },
+          { id: "gpt-5.4-pro", name: "GPT-5.4 Pro", provider: "openai" },
+        ],
+        methodResponses: {
+          "sessions.list": {
+            count: 2,
+            defaults: {
+              contextTokens: 200_000,
+              model: "gpt-5.5",
+              modelProvider: "openai",
+              thinkingDefault: "high",
+              thinkingLevels: [
+                { id: "off", label: "off" },
+                { id: "low", label: "low" },
+                { id: "medium", label: "medium" },
+                { id: "high", label: "high" },
+              ],
+            },
+            path: "",
+            sessions: conflictingAliasFirst
+              ? [otherSession, activeSession]
+              : [activeSession, otherSession],
+            ts: now,
+          },
+        },
+      });
+
+      try {
+        await page.goto(`${server.baseUrl}chat?session=${encodeURIComponent(selected)}`);
+        await gateway.waitForRequest("chat.metadata");
+        const composer = page.locator(".agent-chat__input");
+        const model = composer.locator('[data-chat-model-select="true"]');
+        await expect.poll(() => model.isVisible()).toBe(true);
+        await expect
+          .poll(() => model.locator(".chat-controls__inline-select-label").textContent())
+          .toBe("GPT-5.4 Pro · Low");
+        await expect.poll(() => model.getAttribute("data-chat-thinking-value")).toBe("low");
+        await expect
+          .poll(() => composer.locator(".context-ring").getAttribute("aria-label"))
+          .toBe("Thread context usage: 42k of 200k (21%)");
+
+        await model.click();
+        const speed = composer.locator("[data-chat-speed-toggle]");
+        await expect.poll(() => speed.getAttribute("aria-checked")).toBe("true");
+        await expect.poll(async () => (await speed.textContent())?.trim()).toBe("Fast");
+      } finally {
+        await context.close();
+      }
+    },
+  );
+
   it("refreshes the configured usable catalog after advertised chat metadata", async () => {
     const context = await browser.newContext({ viewport: { width: 1280, height: 900 } });
     const page = await context.newPage();

--- a/ui/src/lib/chat/model-select-state.test.ts
+++ b/ui/src/lib/chat/model-select-state.test.ts
@@ -144,6 +144,114 @@ describe("chat-model-select-state", () => {
     expect(resolveChatModelOverrideValue(state)).toBe("openai/gpt-5-mini");
   });
 
+  it.each([
+    { selected: "main", row: "agent:main:main" },
+    { selected: "agent:main:main", row: "main" },
+  ])("resolves the persisted model for equivalent session keys %#", ({ selected, row }) => {
+    const sessionsResult = createSessionsListResult({
+      model: "gpt-5-mini",
+      modelProvider: "openai",
+    });
+    const session = expectDefined(sessionsResult.sessions[0], "aliased session fixture");
+    sessionsResult.sessions[0] = { ...session, key: row };
+
+    expect(
+      resolveChatModelOverrideValue({
+        ...createChatModelState({ sessionsResult }),
+        sessionKey: selected,
+      }),
+    ).toBe("openai/gpt-5-mini");
+  });
+
+  it("prefers the exact session row over an earlier equivalent main alias", () => {
+    const sessionsResult = createSessionsListResult({
+      model: "gpt-5-mini",
+      modelProvider: "openai",
+    });
+    const session = expectDefined(sessionsResult.sessions[0], "exact session fixture");
+    sessionsResult.sessions = [
+      { ...session, key: "agent:main:main", model: "gpt-5" },
+      { ...session, key: "main", model: "gpt-5-mini" },
+    ];
+    sessionsResult.count = sessionsResult.sessions.length;
+
+    expect(resolveChatModelOverrideValue(createChatModelState({ sessionsResult }))).toBe(
+      "openai/gpt-5-mini",
+    );
+  });
+
+  it("resolves cached model overrides through canonical main-session aliases", () => {
+    const state = {
+      ...createChatModelState({
+        chatModelCatalog: createModelCatalog(...DEFAULT_CHAT_MODEL_CATALOG),
+        modelOverrides: { "agent:main:main": "gpt-5-mini" },
+      }),
+      sessionKey: "main",
+    };
+
+    expect(resolveChatModelSelectState(state).currentOverride).toBe("openai/gpt-5-mini");
+  });
+
+  it("prefers an exact cached model override over an equivalent main alias", () => {
+    const state = createChatModelState({
+      chatModelCatalog: createModelCatalog(...DEFAULT_CHAT_MODEL_CATALOG),
+      modelOverrides: {
+        "agent:main:main": "gpt-5",
+        main: "gpt-5-mini",
+      },
+    });
+
+    expect(resolveChatModelSelectState(state).currentOverride).toBe("openai/gpt-5-mini");
+  });
+
+  it("never resolves another agent's model as a main-session alias", () => {
+    const sessionsResult = createSessionsListResult({
+      model: "gpt-5-mini",
+      modelProvider: "openai",
+    });
+    const session = expectDefined(sessionsResult.sessions[0], "other-agent session fixture");
+    sessionsResult.sessions[0] = { ...session, key: "agent:work:main" };
+
+    expect(
+      resolveChatModelOverrideValue({
+        ...createChatModelState({
+          modelOverrides: { "agent:work:main": "openai/gpt-5-mini" },
+          sessionsResult,
+        }),
+        sessionKey: "main",
+      }),
+    ).toBe("");
+  });
+
+  it("resolves fast-mode overrides from an equivalent main-session row", () => {
+    const sessionsResult = createSessionsListResult({
+      model: "gpt-5-mini",
+      modelProvider: "openai",
+    });
+    const session = expectDefined(sessionsResult.sessions[0], "fast-mode alias fixture");
+    sessionsResult.sessions[0] = {
+      ...session,
+      key: "agent:main:main",
+      effectiveFastMode: true,
+      fastMode: true,
+    };
+
+    expect(
+      resolveChatFastModeSelectState({
+        activeRunId: null,
+        catalog: createModelCatalog(...DEFAULT_CHAT_MODEL_CATALOG),
+        connected: true,
+        currentModelOverride: "openai/gpt-5-mini",
+        gatewayAvailable: true,
+        loading: false,
+        sending: false,
+        sessionKey: "main",
+        sessionsResult,
+        stream: null,
+      }),
+    ).toMatchObject({ active: true, currentOverride: "on", label: "Fast" });
+  });
+
   it("normalizes cached bare overrides to the matching catalog option", () => {
     const state = createChatModelState({
       modelOverrides: { main: "gpt-5-mini" },

--- a/ui/src/lib/chat/model-select-state.ts
+++ b/ui/src/lib/chat/model-select-state.ts
@@ -7,6 +7,7 @@ import type {
   SessionsListResult,
 } from "../../api/types.ts";
 import { pushUniqueTrimmedSelectOption } from "../select-options.ts";
+import { areUiSessionKeysEquivalent, findUiSessionRow } from "../sessions/session-key.ts";
 import {
   buildCatalogDisplayLookup,
   buildChatModelOptionFromLookup,
@@ -74,15 +75,18 @@ type ChatFastModeSelectStateInput = {
 const FAST_MODE_PROVIDER_IDS = new Set(["anthropic", "minimax", "minimax-portal", "openai", "xai"]);
 
 function resolveActiveSessionRow(state: ChatModelSelectStateInput) {
-  return state.sessionsResult?.sessions?.find((row) => row.key === state.sessionKey);
+  return findUiSessionRow(state.sessionsResult?.sessions, state.sessionKey);
 }
 
 export function resolveChatModelOverrideValue(state: ChatModelSelectStateInput): string {
   const catalog = state.chatModelCatalog ?? [];
 
   const sharedOverrides = state.modelOverrides;
-  if (Object.hasOwn(sharedOverrides, state.sessionKey)) {
-    const shared = sharedOverrides[state.sessionKey];
+  const overrideKey = Object.hasOwn(sharedOverrides, state.sessionKey)
+    ? state.sessionKey
+    : Object.keys(sharedOverrides).find((key) => areUiSessionKeysEquivalent(key, state.sessionKey));
+  if (overrideKey !== undefined) {
+    const shared = sharedOverrides[overrideKey];
     return shared == null
       ? ""
       : normalizeChatModelOverrideValue(createChatModelOverride(shared), catalog);
@@ -322,7 +326,7 @@ function hasCatalogProviderMetadata(value: string, catalog: ModelCatalogEntry[])
 export function resolveChatFastModeSelectState(
   input: ChatFastModeSelectStateInput,
 ): ChatFastModeSelectState {
-  const activeRow = input.sessionsResult?.sessions?.find((row) => row.key === input.sessionKey);
+  const activeRow = findUiSessionRow(input.sessionsResult?.sessions, input.sessionKey);
   const activeProvider = normalizeChatModelProviderId(activeRow?.modelProvider ?? "") || null;
   const defaultProvider =
     normalizeChatModelProviderId(input.sessionsResult?.defaults?.modelProvider ?? "") || null;

--- a/ui/src/lib/chat/thinking.test.ts
+++ b/ui/src/lib/chat/thinking.test.ts
@@ -8,6 +8,77 @@ import {
 } from "./thinking.ts";
 
 describe("chat thinking helpers", () => {
+  it.each([
+    { selected: "main", row: "agent:main:main" },
+    { selected: "agent:main:main", row: "main" },
+  ])("resolves persisted reasoning for equivalent session keys %#", ({ selected, row }) => {
+    const state = resolveChatThinkingSelectState({
+      catalog: [{ id: "gpt-5.6-luna", provider: "openai", reasoning: true }],
+      sessionKey: selected,
+      sessionsResult: {
+        ts: 1,
+        path: "",
+        count: 1,
+        defaults: {
+          modelProvider: "openai",
+          model: "gpt-5.6-luna",
+          contextTokens: null,
+          thinkingDefault: "high",
+        },
+        sessions: [
+          {
+            key: row,
+            kind: "direct",
+            updatedAt: 1,
+            modelProvider: "openai",
+            model: "gpt-5.6-luna",
+            thinkingLevel: "low",
+          },
+        ],
+      },
+    });
+
+    expect(state.currentOverride).toBe("low");
+  });
+
+  it("prefers exact persisted reasoning over an earlier equivalent main alias", () => {
+    const state = resolveChatThinkingSelectState({
+      catalog: [{ id: "gpt-5.6-luna", provider: "openai", reasoning: true }],
+      sessionKey: "main",
+      sessionsResult: {
+        ts: 1,
+        path: "",
+        count: 2,
+        defaults: {
+          modelProvider: "openai",
+          model: "gpt-5.6-luna",
+          contextTokens: null,
+          thinkingDefault: "high",
+        },
+        sessions: [
+          {
+            key: "agent:main:main",
+            kind: "direct",
+            updatedAt: 1,
+            modelProvider: "openai",
+            model: "gpt-5.6-luna",
+            thinkingLevel: "high",
+          },
+          {
+            key: "main",
+            kind: "direct",
+            updatedAt: 1,
+            modelProvider: "openai",
+            model: "gpt-5.6-luna",
+            thinkingLevel: "low",
+          },
+        ],
+      },
+    });
+
+    expect(state.currentOverride).toBe("low");
+  });
+
   it("keeps literal Ultra distinct from the legacy ultrathink alias", () => {
     expect(normalizeThinkLevel("ultra")).toBe("ultra");
     expect(normalizeThinkLevel("Ultra")).toBe("ultra");

--- a/ui/src/lib/chat/thinking.ts
+++ b/ui/src/lib/chat/thinking.ts
@@ -7,6 +7,7 @@ import type {
 } from "../../api/types.ts";
 import { pushUniqueTrimmedSelectOption } from "../select-options.ts";
 import { sessionModelMatchesDefaults } from "../session-model-defaults.ts";
+import { findUiSessionRow } from "../sessions/session-key.ts";
 import { normalizeLowercaseStringOrEmpty } from "../string-coerce.ts";
 
 type ThinkingCatalogEntry = {
@@ -262,7 +263,7 @@ export function resolveChatThinkingSelectState(params: {
   sessionsResult: SessionsListResult | null;
 }): ChatThinkingSelectState {
   const session =
-    params.session ?? params.sessionsResult?.sessions?.find((row) => row.key === params.sessionKey);
+    params.session ?? findUiSessionRow(params.sessionsResult?.sessions, params.sessionKey);
   const persisted = session?.thinkingLevel;
   const currentOverride =
     typeof persisted === "string" && persisted.trim()

--- a/ui/src/lib/sessions/session-key.ts
+++ b/ui/src/lib/sessions/session-key.ts
@@ -344,6 +344,17 @@ export function areUiSessionKeysEquivalent(
   return Boolean(normalizedLeft && normalizedRight && normalizedLeft === normalizedRight);
 }
 
+/** Resolve a selected session through the same canonical aliases as the chat pane. */
+export function findUiSessionRow<Row extends { key: string }>(
+  rows: readonly Row[] | null | undefined,
+  sessionKey: string | undefined | null,
+): Row | undefined {
+  return (
+    rows?.find((row) => row.key === sessionKey) ??
+    rows?.find((row) => areUiSessionKeysEquivalent(row.key, sessionKey))
+  );
+}
+
 export function resolveAgentIdFromSessionKey(sessionKey: string | undefined | null): string {
   const parsed = parseAgentSessionKey(sessionKey);
   return normalizeAgentId(parsed?.agentId ?? DEFAULT_AGENT_ID);

--- a/ui/src/pages/chat/chat-session.ts
+++ b/ui/src/pages/chat/chat-session.ts
@@ -15,6 +15,7 @@ import {
 } from "../../lib/sessions/index.ts";
 import {
   areUiSessionKeysEquivalent,
+  findUiSessionRow,
   isUiGlobalSessionKey,
   resolveUiGlobalAliasAgentId,
 } from "../../lib/sessions/session-key.ts";
@@ -268,10 +269,14 @@ function patchSessionRow(
   if (!current) {
     return;
   }
+  const activeRow = findUiSessionRow(current.sessions, sessionKey);
+  if (!activeRow) {
+    return;
+  }
   host.sessionsResult = {
     ...current,
     sessions: current.sessions.map((row) =>
-      row.key === sessionKey ? Object.assign({}, row, patch) : row,
+      row === activeRow ? Object.assign({}, row, patch) : row,
     ),
   };
 }
@@ -284,7 +289,7 @@ export function switchChatFastMode(
   if (!host.client || !host.connected) {
     return Promise.resolve(false);
   }
-  const activeRow = host.sessionsResult?.sessions?.find((row) => row.key === targetSessionKey);
+  const activeRow = findUiSessionRow(host.sessionsResult?.sessions, targetSessionKey);
   const previousFastMode = activeRow?.fastMode;
   const previousEffectiveFastMode = activeRow?.effectiveFastMode;
   const next: FastMode | undefined =
@@ -343,9 +348,7 @@ export async function switchChatModel(
   if (!host.client || !host.connected) {
     return false;
   }
-  const activeRow = host.sessionsResult?.sessions.find((row) =>
-    areUiSessionKeysEquivalent(row.key, targetSessionKey),
-  );
+  const activeRow = findUiSessionRow(host.sessionsResult?.sessions, targetSessionKey);
   if (activeRow?.modelSelectionLocked === true) {
     return false;
   }
@@ -414,7 +417,7 @@ export function switchChatThinkingLevel(
   if (!host.client || !host.connected) {
     return Promise.resolve(false);
   }
-  const activeRow = host.sessionsResult?.sessions?.find((row) => row.key === targetSessionKey);
+  const activeRow = findUiSessionRow(host.sessionsResult?.sessions, targetSessionKey);
   const previousThinkingLevel = activeRow?.thinkingLevel;
   const normalizedNext =
     (normalizeThinkLevel(nextThinkingLevel) ?? nextThinkingLevel.trim()) || undefined;

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -4865,6 +4865,132 @@ describe("chat model controls", () => {
     expect(host.chatThinkingLevel).toBe("high");
   });
 
+  it.each([
+    { selected: "main", row: "agent:main:main", other: "agent:work:main" },
+    { selected: "agent:main:main", row: "main", other: "agent:work:main" },
+    { selected: "main", row: "main", other: "agent:main:main" },
+  ])(
+    "optimistically updates reasoning and speed for equivalent session keys %#",
+    async ({ selected, row, other }) => {
+      const sessions = {
+        patch: vi.fn(
+          async (
+            _key: string,
+            _patch: Record<string, unknown>,
+            _options?: SessionPatchOptions,
+          ) => ({
+            ok: true,
+            path: "",
+            key: row,
+            entry: { sessionId: row },
+          }),
+        ),
+        refresh: async () => {},
+      };
+      const host = {
+        client: {},
+        connected: true,
+        sessionKey: selected,
+        chatModelCatalog: [],
+        chatThinkingLevel: "low",
+        sessionsResult: createSessionsResultFromRows([
+          {
+            key: row,
+            kind: "direct",
+            updatedAt: 1,
+            thinkingLevel: "low",
+            fastMode: false,
+            effectiveFastMode: false,
+          },
+          {
+            key: other,
+            kind: "direct",
+            updatedAt: 1,
+            thinkingLevel: "high",
+            fastMode: false,
+            effectiveFastMode: false,
+          },
+        ]),
+        sessions,
+      } as unknown as Parameters<typeof switchChatThinkingLevel>[0];
+
+      const thinkingPatch = switchChatThinkingLevel(host, "medium");
+      expect(host.sessionsResult?.sessions[0]?.thinkingLevel).toBe("medium");
+      expect(host.sessionsResult?.sessions[1]?.thinkingLevel).toBe("high");
+      await expect(thinkingPatch).resolves.toBe(true);
+
+      const speedPatch = switchChatFastMode(host, "on");
+      expect(host.sessionsResult?.sessions[0]?.fastMode).toBe(true);
+      expect(host.sessionsResult?.sessions[0]?.effectiveFastMode).toBe(true);
+      expect(host.sessionsResult?.sessions[1]?.fastMode).toBe(false);
+      await expect(speedPatch).resolves.toBe(true);
+
+      expect(sessions.patch).toHaveBeenCalledTimes(2);
+      expect(sessions.patch.mock.calls.map(([key, patch]) => ({ key, patch }))).toEqual([
+        { key: selected, patch: { thinkingLevel: "medium" } },
+        { key: selected, patch: { fastMode: true } },
+      ]);
+    },
+  );
+
+  it.each([
+    { selected: "main", row: "agent:main:main", other: "agent:work:main" },
+    { selected: "agent:main:main", row: "main", other: "agent:work:main" },
+    { selected: "main", row: "main", other: "agent:main:main" },
+  ])(
+    "rolls back rejected settings for equivalent session keys %#",
+    async ({ selected, row, other }) => {
+      const sessions = {
+        patch: vi.fn(
+          async (_key: string, _patch: Record<string, unknown>, _options?: SessionPatchOptions) =>
+            null,
+        ),
+        refresh: async () => {},
+      };
+      const host = {
+        client: {},
+        connected: true,
+        sessionKey: selected,
+        chatModelCatalog: [],
+        chatThinkingLevel: "low",
+        sessionsResult: createSessionsResultFromRows([
+          {
+            key: row,
+            kind: "direct",
+            updatedAt: 1,
+            thinkingLevel: "low",
+            fastMode: false,
+            effectiveFastMode: false,
+          },
+          {
+            key: other,
+            kind: "direct",
+            updatedAt: 1,
+            thinkingLevel: "high",
+            fastMode: false,
+            effectiveFastMode: false,
+          },
+        ]),
+        sessions,
+      } as unknown as Parameters<typeof switchChatThinkingLevel>[0];
+
+      const thinkingPatch = switchChatThinkingLevel(host, "medium");
+      expect(host.sessionsResult?.sessions[0]?.thinkingLevel).toBe("medium");
+      await expect(thinkingPatch).resolves.toBe(false);
+      expect(host.sessionsResult?.sessions[0]?.thinkingLevel).toBe("low");
+      expect(host.sessionsResult?.sessions[1]?.thinkingLevel).toBe("high");
+      expect(host.chatThinkingLevel).toBe("low");
+
+      const speedPatch = switchChatFastMode(host, "on");
+      expect(host.sessionsResult?.sessions[0]?.fastMode).toBe(true);
+      expect(host.sessionsResult?.sessions[0]?.effectiveFastMode).toBe(true);
+      await expect(speedPatch).resolves.toBe(false);
+      expect(host.sessionsResult?.sessions[0]?.fastMode).toBe(false);
+      expect(host.sessionsResult?.sessions[0]?.effectiveFastMode).toBe(false);
+      expect(host.sessionsResult?.sessions[1]?.fastMode).toBe(false);
+    },
+  );
+
   it("keeps the newest speed selection when an older patch fails late", async () => {
     const pendingPatches: Array<{ resolve: () => void; reject: (error: Error) => void }> = [];
     // Minimal host: the factory's mock gateway rebuilds session rows on every

--- a/ui/src/pages/chat/components/chat-composer.ts
+++ b/ui/src/pages/chat/components/chat-composer.ts
@@ -3,7 +3,7 @@ import { nothing } from "lit";
 import { loadSettings, normalizeChatSendShortcut, patchSettings } from "../../../app/settings.ts";
 import "../../../components/tooltip.ts";
 import { t } from "../../../i18n/index.ts";
-import { areUiSessionKeysEquivalent } from "../../../lib/sessions/session-key.ts";
+import { areUiSessionKeysEquivalent, findUiSessionRow } from "../../../lib/sessions/session-key.ts";
 import { ComposerDictationController, insertComposerDictation } from "../composer-dictation.ts";
 import { discoverRealtimeTalkInputs } from "../realtime-talk-input.ts";
 import { isLargePastedTextAttachment } from "./chat-attachments.ts";
@@ -105,7 +105,7 @@ export function renderChatComposer(props: ChatComposerProps) {
       : props.runStatus;
   const compactBusy =
     props.compactionStatus?.phase === "active" || props.compactionStatus?.phase === "retrying";
-  const activeSession = props.sessions?.sessions?.find((row) => row.key === props.sessionKey);
+  const activeSession = findUiSessionRow(props.sessions?.sessions, props.sessionKey);
   const draftKey = composerDraftKey(props);
   if (state.dictationDraftKey !== null && state.dictationDraftKey !== draftKey) {
     state.dictation?.dispose();

--- a/ui/src/pages/chat/components/chat-model-controls.ts
+++ b/ui/src/pages/chat/components/chat-model-controls.ts
@@ -26,7 +26,7 @@ import {
   formatThinkingOverrideLabel,
   resolveChatThinkingSelectState,
 } from "../../../lib/chat/thinking.ts";
-import { areUiSessionKeysEquivalent } from "../../../lib/sessions/session-key.ts";
+import { findUiSessionRow } from "../../../lib/sessions/session-key.ts";
 import { selectChatModelProvider } from "./chat-model-provider-menu.ts";
 
 export type ChatModelControlsProps = {
@@ -176,9 +176,7 @@ export function renderChatModelControls(props: ChatModelControlsProps) {
   // the previous model while a switch is pending; keep both locked until the
   // refreshed session list lands so stale levels cannot be committed.
   const fastMode = props.modelSwitching ? { ...fastModeSelect, disabled: true } : fastModeSelect;
-  const activeSession = props.sessionsResult?.sessions.find((row) =>
-    areUiSessionKeysEquivalent(row.key, props.sessionKey),
-  );
+  const activeSession = findUiSessionRow(props.sessionsResult?.sessions, props.sessionKey);
   const currentProviderHint = activeSession?.modelProvider ?? "";
   const defaultProviderHint = props.sessionsResult?.defaults?.modelProvider ?? "";
   const canonicalDefaultLabel = resolveChatModelPickerLabel(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening the default chat through the `main` or `agent:main:main` session alias would see the Gateway-default model, reasoning, speed, and context usage instead of their saved session settings. Changing reasoning or speed could also fail to update or safely roll back the visible session. A different agent must never inherit the default agent's settings.

## Why This Change Was Made

Resolve the selected session through one existing canonical UI session-identity contract, always preferring the literal selected row before its default-main alias. Use that same selected row across model and provider selection, reasoning, speed, and composer context. Apply and roll back optimistic changes only to that resolved row so a competing alias and other agents remain unchanged. Preserve the selected Gateway wire key, existing session settings lane, and all config and protocol contracts.

## User Impact

Persisted model, reasoning, speed, and context consistently survive either default-session route. Users can change settings immediately and recover cleanly when a Gateway update is rejected; switching agents remains isolated even when exact and aliased rows coexist.

## Evidence

- Baseline Chromium regression, using a real browser and an explicitly mocked Gateway: both default alias directions fail with `GPT-5.5 · High` instead of the persisted `GPT-5.4 Pro · Low`; the independent work-agent control passes. The regression reproduces on clean immutable main `fe4972b12b813bd92c18ae9532f66e613b449996`; all touched source paths are unchanged at this PR's immutable base `a1cc41acbcdd285a7cdb423bdfe45ef06b2f97cb`.
- Fixed Chromium regression: **4/4** for both default alias directions, a separate work agent, and an earlier conflicting alias; each verifies model, reasoning, speed, and context using the real Chromium UI with the mocked Gateway.
- Real Chromium provider sibling suite: **3/3**.
- Focused UI owners and sibling tests: **258/258**, including literal-key precedence, cached override precedence, competing-row isolation, successful optimistic updates, rejected rollback, and existing settings-lane race regressions.
- Gateway source contract owner: **134/134** in `src/gateway/session-utils.test.ts`, including canonical default-main store-key coverage.
- Complete native repository gate: `pnpm check:changed` **PASS**, including canonical formatting, UI i18n, UI and core-test type checks, architecture/ownership guards, and exhaustive clean core lint; Blacksmith Testbox `tbx_01kyd81cnj7xwysw342q2prt6h`, timing `exitCode=0`.
- Fresh official independent structured review of exact head `bd61bb3cd4d86b59534f97f228880bce96c45d95`: **patch correct, zero actionable findings, 0.97 confidence; secret scan clean**.

### Real Chromium and live Gateway proof — corrected 2026-07-25

**Correction and retraction:** the earlier cross-agent claim against `ws://127.0.0.1:54938/` was invalid. That Gateway did not have a configured `work` agent; its earlier work screenshot showed `GatewayRequestError: Unknown agent id "work"`. Do not use that screenshot, the empty work-session list, or that run's claimed zero-error state as cross-agent proof. The actual successful main-alias updates and the independent existing main-agent session/context observation on port `54938` remain valid, but prove same-agent behavior only.

For genuine cross-agent proof, started a **separate, fresh, fully isolated fifth Gateway** on `ws://127.0.0.1:55019/`, without modifying or restarting any of the four existing soak Gateways. The Gateway runs the actual build `31190d6469f5a58729b39b799cbd065b95a76443`, has independently isolated state, uses the real configured `openai/gpt-5.4` provider, and explicitly configures both `main` and `work` through canonical `agents.entries`. Served the exact PR-source Control UI at `bd61bb3cd4d86b59534f97f228880bce96c45d95` and drove it with real Chromium. No mock Gateway, request interception, synthesized response, direct store writes, or invented agent.

The real Chromium client's actual `agents.list` response, independently requested over the connected production Gateway WebSocket, was:

```json
{
  "defaultId": "main",
  "agents": [
    { "id": "main", "name": "Auto QA Main" },
    { "id": "work", "name": "Auto QA Work" }
  ]
}
```

1. Selected `main`, observed real `chat.startup` and `sessions.list` resolve `agent:main:main`, and used the actual composer slider and speed toggle. The Gateway acknowledged both canonical wire updates:

   ```json
   {"method":"sessions.patch","agentId":"main","key":"agent:main:main","thinkingLevel":"minimal"}
   {"method":"sessions.patch","agentId":"main","key":"agent:main:main","fastMode":true}
   ```

2. Selected the **actually configured** `agent:work:main` and used the real work-agent reasoning slider. The Gateway acknowledged the independent scoped wire update:

   ```json
   {"method":"sessions.patch","agentId":"work","key":"agent:work:main","thinkingLevel":"low"}
   ```

   Production `sessions.list` scoped to `main` returned only the main row; scoped to `work`, it returned only the work row. Their observed persisted settings were:

   ```json
   [
     {
       "key": "agent:main:main",
       "model": "gpt-5.4",
       "modelProvider": "openai",
       "thinkingLevel": "minimal",
       "fastMode": true,
       "effectiveFastMode": true
     },
     {
       "key": "agent:work:main",
       "model": "gpt-5.4",
       "modelProvider": "openai",
       "thinkingLevel": "low",
       "fastMode": null,
       "effectiveFastMode": false
     }
   ]
   ```

3. Started separate fresh Chromium contexts for both `?session=main` and `?session=agent%3Amain%3Amain`; each reloaded the actual main row and displayed GPT-5.4, Minimal, and Fast. A fresh `agent:work:main` context displayed the real Auto QA Work identity, GPT-5.4, Low, and Standard. The work screenshot was visually inspected; it contains no unknown-agent banner.
4. Sent an actual live GPT-5.4 request through the real composer for each configured agent. Each agent emitted its own real `chat.send`, streamed real `chat.event` deltas, reached `state: "final"`, and visibly rendered its own exact OpenAI response: `AUTOQA-MAIN-113797` or `AUTOQA-WORK-113797`. No mocked model responses.
5. Verified actual composer context from real persisted session rows: the main context was observed at `21.3k` and the genuinely configured work-agent context at `19.3k of 200k (10%)`. The separate existing same-agent session on port `54938` independently showed `28.7k of 1.1M (3%)`. Additional completed live runs on the fifth Gateway sometimes return `totalTokens: null`, so this evidence does not claim that token usage is monotonically increasing or present after every subsequent refresh.
6. Every accepted fifth-Gateway Chromium run checked the real page for `Unknown agent id`, `GatewayRequestError`, and `INVALID_REQUEST`, captured browser console/page errors, checked actual `agents.list`, `sessions.list`, `sessions.patch`, `chat.metadata`, and `chat.send` failures, and required all three error collections to be empty. Screenshots and recorded real Chromium video were captured for the configured main and work agents.

Exact-first competing literal/alias rows and rejected optimistic-update rollback remain separately covered by the identified deterministic owner tests above; they are not mislabeled as live multi-agent proof.
