### PR TITLE
fix(tui): preserve case-sensitive Matrix and Signal conversations

### DIFF
--- a/src/tui/tui-pty-harness.e2e.test.ts
+++ b/src/tui/tui-pty-harness.e2e.test.ts
@@ -930,7 +930,8 @@ describe.sequential("TUI PTY harness", () => {
     async ({ sessionKey, message }) => {
       await fixture.run.write(`/session ${sessionKey}\r`, { delay: false });
       await fixture.waitForLogEntry(
-        (entry) => entry.method === "loadHistory" && objectFieldEquals(entry, "sessionKey", sessionKey),
+        (entry) =>
+          entry.method === "loadHistory" && objectFieldEquals(entry, "sessionKey", sessionKey),
       );
 
       await fixture.run.write(`${message}\r`, { delay: false });

--- a/src/tui/tui-pty-harness.e2e.test.ts
+++ b/src/tui/tui-pty-harness.e2e.test.ts
@@ -916,6 +916,33 @@ describe.sequential("TUI PTY harness", () => {
     TEST_TIMEOUT_MS,
   );
 
+  it.each([
+    {
+      sessionKey: "agent:main:matrix:channel:!MixedRoomAbCdEf:example.org",
+      message: "mixed-case matrix session identity proof",
+    },
+    {
+      sessionKey: "agent:main:signal:group:AbC123=",
+      message: "mixed-case signal session identity proof",
+    },
+  ])(
+    "preserves provider-owned identity when selecting $sessionKey in the terminal",
+    async ({ sessionKey, message }) => {
+      await fixture.run.write(`/session ${sessionKey}\r`, { delay: false });
+      await fixture.waitForLogEntry(
+        (entry) => entry.method === "loadHistory" && objectFieldEquals(entry, "sessionKey", sessionKey),
+      );
+
+      await fixture.run.write(`${message}\r`, { delay: false });
+      const sent = await fixture.waitForLogEntry(
+        (entry) => entry.method === "sendChat" && objectFieldEquals(entry, "message", message),
+      );
+
+      expect(sent.payload).toMatchObject({ sessionKey, message });
+    },
+    TEST_TIMEOUT_MS,
+  );
+
   it(
     "creates a backend session from /new and adopts its canonical key",
     async () => {

--- a/src/tui/tui.test.ts
+++ b/src/tui/tui.test.ts
@@ -204,6 +204,10 @@ describe("resolveTuiSessionKey", () => {
       expected: "agent:main:signal:group:AbC123=",
     },
     {
+      raw: "Agent:Ops:Signal:Group:AbC123=",
+      expected: "agent:ops:signal:group:AbC123=",
+    },
+    {
       raw: "Signal:Group:AbC123=",
       expected: "agent:main:signal:group:AbC123=",
     },

--- a/src/tui/tui.test.ts
+++ b/src/tui/tui.test.ts
@@ -186,6 +186,42 @@ describe("resolveTuiSessionKey", () => {
     ).toBe("agent:ops:incident");
   });
 
+  it.each([
+    {
+      raw: "agent:main:matrix:channel:!MixedRoomAbCdEf:example.org",
+      expected: "agent:main:matrix:channel:!MixedRoomAbCdEf:example.org",
+    },
+    {
+      raw: "Matrix:Channel:!MixedRoomAbCdEf:example.org",
+      expected: "agent:main:matrix:channel:!MixedRoomAbCdEf:example.org",
+    },
+    {
+      raw: "Agent:Main:Matrix:Channel:!MixedRoomAbCdEf:example.org:Thread:$EventAbCdEf",
+      expected: "agent:main:matrix:channel:!MixedRoomAbCdEf:example.org:thread:$EventAbCdEf",
+    },
+    {
+      raw: "agent:main:signal:group:AbC123=",
+      expected: "agent:main:signal:group:AbC123=",
+    },
+    {
+      raw: "Signal:Group:AbC123=",
+      expected: "agent:main:signal:group:AbC123=",
+    },
+    {
+      raw: "Telegram:Group:MixedHandle",
+      expected: "agent:main:telegram:group:mixedhandle",
+    },
+  ])("preserves canonical provider-owned session identity for $raw", ({ raw, expected }) => {
+    expect(
+      resolveTuiSessionKey({
+        raw,
+        sessionScope: "per-sender",
+        currentAgentId: "main",
+        sessionMainKey: "main",
+      }),
+    ).toBe(expected);
+  });
+
   it("lowercases session keys with uppercase characters", () => {
     // Uppercase in agent-prefixed form
     expect(

--- a/src/tui/tui.test.ts
+++ b/src/tui/tui.test.ts
@@ -200,6 +200,10 @@ describe("resolveTuiSessionKey", () => {
       expected: "agent:main:matrix:channel:!MixedRoomAbCdEf:example.org:thread:$EventAbCdEf",
     },
     {
+      raw: "Agent:Ops:Matrix:Channel:!MixedRoomAbCdEf:example.org",
+      expected: "agent:ops:matrix:channel:!MixedRoomAbCdEf:example.org",
+    },
+    {
       raw: "agent:main:signal:group:AbC123=",
       expected: "agent:main:signal:group:AbC123=",
     },

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -13,7 +13,6 @@ import {
   Text,
   TUI,
 } from "@earendil-works/pi-tui";
-import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import type { CommandEntry } from "../../packages/gateway-protocol/src/index.js";
 import { resolveAgentIdByWorkspacePath, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { normalizeThinkLevel } from "../auto-reply/thinking.shared.js";
@@ -35,6 +34,7 @@ import {
   normalizeAgentId,
   normalizeMainKey,
   parseAgentSessionKey,
+  toAgentStoreSessionKey,
 } from "../routing/session-key.js";
 import { getSlashCommands, shouldSubmitExactArgumentCompletion } from "./commands.js";
 import { ChatLog } from "./components/chat-log.js";
@@ -213,10 +213,11 @@ export function resolveTuiSessionKey(params: {
   if (trimmed === "global" || trimmed === "unknown") {
     return trimmed;
   }
-  if (trimmed.startsWith("agent:")) {
-    return normalizeLowercaseStringOrEmpty(trimmed);
-  }
-  return `agent:${params.currentAgentId}:${normalizeLowercaseStringOrEmpty(trimmed)}`;
+  return toAgentStoreSessionKey({
+    agentId: params.currentAgentId,
+    requestKey: trimmed,
+    mainKey: params.sessionMainKey,
+  });
 }
 
 export function resolveInitialTuiAgentId(params: {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users switching to an existing Matrix room, Matrix thread, or Signal group in the terminal would silently open and send subsequent messages to the wrong conversation because case-sensitive provider-owned session identities were lowercased. Mixed-case explicit cross-agent session keys could also be prefixed a second time.

## Why This Change Was Made

Use OpenClaw's existing canonical agent-session routing owner rather than maintaining a second, incompatible TUI-specific session normalizer. Preserve Matrix room and thread IDs, Signal group IDs, cross-agent ownership, normal lowercase channels, main-session aliases, and the explicit global and unknown session sentinels without introducing a new configuration, provider, storage, migration, protocol, or compatibility path.

## User Impact

Terminal users can select and resume the intended Matrix or Signal conversation, including its correct agent and thread, and outgoing prompts continue using exactly that conversation's provider-owned session identity.

## Evidence

- Exact current-main baseline `a1cc41acbcdd285a7cdb423bdfe45ef06b2f97cb`: reproduced six failing resolver regressions and two failing actual typed-terminal Matrix/Signal scenarios; verified all 141 existing canonical opaque-identity/routing controls and the previously landed verbose/reasoning terminal behaviors remain green.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.tui.config.ts`: **717/717**, all 32 TUI owner suites.
- `pnpm test src/sessions/session-key-case-preservation.test.ts src/routing/session-key.test.ts`: **43/43 provider-identity** and **98/98 routing** controls.
- `OPENCLAW_TUI_PTY_INCLUDE_LOCAL=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts`: **37/37 actual terminal, embedded-backend, and real-Gateway scenarios**, including both typed Matrix/Signal history and outgoing-message identities, cross-agent controls, real Gateway restart and followup queues, and the existing verbose/reasoning completions.
- `pnpm check:changed --base a1cc41acbcdd285a7cdb423bdfe45ef06b2f97cb`: **passed**, including full production/test typechecks, every core and script lint shard, formatting, dependency, architecture, session/storage, schema, and security guards.
- Trusted remote proof: Blacksmith Testbox `tbx_01kyd7t7yx0bqb73hh5knbz7wn`; combined full proof completed with `exitCode=0`.
- AI-assisted; exact committed three-file head independently reviewed clean with high reasoning and the official TruffleHog secret scan.
