### PR TITLE
fix(ai): reject truncated OpenAI Responses streams

### DIFF
--- a/packages/ai/src/providers/openai-responses-shared.test.ts
+++ b/packages/ai/src/providers/openai-responses-shared.test.ts
@@ -1653,6 +1653,26 @@ describe("processResponsesStream", () => {
     expect(output.usage.input).toBe(7);
   });
 
+  it("preserves cancellation when the SDK swallows the abort and ends iteration", async () => {
+    const abort = new AbortController();
+    const output = createAssistantOutput();
+    async function* silentlyAbortedStream() {
+      yield { type: "response.created", response: { id: "resp_aborted" } };
+      abort.abort();
+    }
+
+    await expect(
+      processResponsesStream(
+        silentlyAbortedStream(),
+        output,
+        new AssistantMessageEventStream(),
+        nativeOpenAIModel,
+        { signal: abort.signal },
+      ),
+    ).rejects.toThrow("Request was aborted");
+    expect(output.responseId).toBe("resp_aborted");
+  });
+
   it.each([
     ["omits arguments", undefined],
     ["sends empty arguments", ""],

--- a/packages/ai/src/transports/openai-responses-stream-internal.ts
+++ b/packages/ai/src/transports/openai-responses-stream-internal.ts
@@ -48,6 +48,7 @@ import {
   type ResponsesThinkingBlock,
   type TextBlockReference,
 } from "./openai-responses-stream-terminal-internal.js";
+import { transportAbortError } from "./transport-stream-shared.js";
 
 type ResponsesConsumedEventType =
   | "error"
@@ -712,6 +713,11 @@ export async function processResponsesStream<TApi extends Api>(
         }
         throw new ResponsesStreamFailure(failure, event.response);
       }
+    }
+    // openai-node turns an aborted SSE iterator into normal completion; preserve
+    // the caller's authoritative reason before classifying terminal stream state.
+    if (options?.signal?.aborted) {
+      throw transportAbortError(options.signal);
     }
     if (streamingToolCalls.hasActive()) {
       throw new Error("Responses stream ended with unresolved tool calls");


### PR DESCRIPTION
## What Problem This Solves

OpenAI Responses cancellations can be reported as `OpenAI Responses stream ended before a terminal response event` instead of the authoritative cancellation outcome. Current main already rejects an ordinary EOF without a semantic terminal event; this PR addresses only the remaining cancellation gap.

## Why This Change Was Made

The repository pins openai-node 6.49.0. Its SSE iterator intentionally catches `AbortError` and completes iteration normally, so an abort can arrive without another yielded event. The Responses processor previously checked the signal only while consuming events, then ran unresolved-tool and missing-terminal guards after iterator completion.

The fix checks the caller signal once more at that terminal boundary and uses the existing `transportAbortError` helper. Default or otherwise uncoded abort reasons retain the canonical `Request was aborted` message; coded `Error` reasons remain preserved for downstream attribution. Ordinary truncated-stream handling, terminal-event precedence, provider routing, and public contracts are unchanged.

## User Impact

Intentional cancellation is now reported as cancellation rather than a misleading truncated-stream failure. Genuine premature EOF still fails with the existing explicit terminal-event error.

## Evidence

- Regression before the production fix: `node scripts/run-vitest.mjs packages/ai/src/providers/openai-responses-shared.test.ts` failed exactly 1 of 82 tests; expected `Request was aborted`, received `OpenAI Responses stream ended before a terminal response event`.
- Same focused command after the fix and after rebasing onto current main: 82 of 82 tests passed.
- Direct max-lines ratchet: `max-lines ratchet OK: 980 grandfathered suppressions.`
- `git diff --check`: passed.
- Exact two-file changed gate: Blacksmith Testbox `tbx_01kzk11rssxg575ydwhqztmbes`, Actions run https://github.com/openclaw/openclaw/actions/runs/31308401011, authoritative `exitCode=0`; production/test typechecks, 245-rule lint, formatting, dependency, boundary, database, cycle, and security guards passed.
- Exact-head pull-request CI: https://github.com/openclaw/openclaw/actions/runs/31308866063 completed green; `openclaw/ci-gate` job 93234461280 succeeded.
- Codex-backed autoreview: clean in one round, no accepted or actionable findings; TruffleHog clean.
- Upstream contract checked directly against openai-node 6.49.0 `src/core/streaming.ts` lines 91-97.
- Sibling Codex contract inspected directly at commit `57f42a81131ccf5933e7ec5dc659c381eeb5d72b`: `codex-rs/core/src/session/turn.rs:2227-2245` distinguishes cancellation from EOF before `response.completed`, `:2500-2544` owns semantic completion, and `codex-rs/async-utils/src/lib.rs:25-29` selects cancellation.
- ClawSweeper rank-up moves are addressed: the post-EOF abort safeguard is carried into the current transport and the rebased regression distinguishes cancellation from genuine nonterminal EOF.
- Production LOC: +6/-0. Tests: +20/-0.
- No authentication, configuration, schema, protocol, persistence, provider-routing, or public API changes.
