### PR TITLE
fix(goals): count tokens from post-creation baseline

### DIFF
--- a/src/agents/command/session-store.test.ts
+++ b/src/agents/command/session-store.test.ts
@@ -1527,6 +1527,7 @@ describe("updateSessionStoreAfterAgentRun", () => {
         tokenCursor: 33_107,
         tokensUsed: 0,
       });
+      expect(sessionStore[sessionKey]?.totalTokensVersion).toBe(SESSION_TOTAL_TOKENS_VERSION);
 
       await run(33_124);
       expect(sessionStore[sessionKey]?.goal).toMatchObject({
@@ -1537,6 +1538,9 @@ describe("updateSessionStoreAfterAgentRun", () => {
         tokenCursor: 33_124,
         tokensUsed: 17,
       });
+      expect(loadPersistedSessionEntry(storePath, sessionKey)?.totalTokensVersion).toBe(
+        SESSION_TOTAL_TOKENS_VERSION,
+      );
     });
   });
 

--- a/src/agents/command/session-store.test.ts
+++ b/src/agents/command/session-store.test.ts
@@ -1497,7 +1497,6 @@ describe("updateSessionStoreAfterAgentRun", () => {
       const run = async (promptTokens: number) => {
         await updateSessionStoreAfterAgentRun({
           cfg,
-          contextTokensOverride: 1_000_000,
           sessionId,
           sessionKey,
           storePath,
@@ -1599,7 +1598,6 @@ describe("updateSessionStoreAfterAgentRun", () => {
 
       await updateSessionStoreAfterAgentRun({
         cfg,
-        contextTokensOverride: 1_000_000,
         sessionId,
         sessionKey,
         storePath,
@@ -1680,7 +1678,6 @@ describe("updateSessionStoreAfterAgentRun", () => {
       const finalize = async (sessionStore: Record<string, SessionEntry>, promptTokens: number) => {
         await updateSessionStoreAfterAgentRun({
           cfg,
-          contextTokensOverride: 1_000_000,
           sessionId,
           sessionKey,
           storePath,
@@ -1740,7 +1737,6 @@ describe("updateSessionStoreAfterAgentRun", () => {
 
       await updateSessionStoreAfterAgentRun({
         cfg,
-        contextTokensOverride: 1_000_000,
         sessionId,
         sessionKey,
         storePath,
@@ -1814,7 +1810,6 @@ describe("updateSessionStoreAfterAgentRun", () => {
 
       await updateSessionStoreAfterAgentRun({
         cfg,
-        contextTokensOverride: 1_000_000,
         sessionId,
         sessionKey,
         storePath,
@@ -3244,7 +3239,7 @@ describe("recordCliCompactionInStore", () => {
       );
 
       await recordCliCompactionInStore({
-        provider: "codex",
+        compactionKind: "native-harness",
         sessionKey,
         sessionStore,
         storePath,

--- a/src/agents/command/session-store.test.ts
+++ b/src/agents/command/session-store.test.ts
@@ -1641,6 +1641,79 @@ describe("updateSessionStoreAfterAgentRun", () => {
     });
   });
 
+  it("keeps the goal cursor monotonic when finalizers complete out of order", async () => {
+    await withTempSessionStore(async ({ storePath }) => {
+      const cfg = {
+        agents: {
+          defaults: {
+            cliBackends: {
+              "claude-cli": { command: "claude" },
+            },
+          },
+        },
+      } as OpenClawConfig;
+      const sessionKey = "agent:main:explicit:test-cli-goal-finalizer-order";
+      const sessionId = "test-cli-goal-finalizer-order-session";
+      const initial: SessionEntry = {
+        sessionId,
+        updatedAt: 1,
+        totalTokens: 100,
+        totalTokensFresh: true,
+        totalTokensVersion: SESSION_TOTAL_TOKENS_VERSION,
+        goal: {
+          schemaVersion: 1,
+          id: "goal-1",
+          objective: "Count concurrent CLI usage once",
+          status: "active",
+          createdAt: 1,
+          updatedAt: 1,
+          tokenStart: 100,
+          tokenStartFresh: true,
+          tokenCursor: 100,
+          tokensUsed: 0,
+          tokenBudget: 30_000,
+          continuationTurns: 0,
+        },
+      };
+      await seedSessionStore(storePath, { [sessionKey]: initial });
+
+      const finalize = async (sessionStore: Record<string, SessionEntry>, promptTokens: number) => {
+        await updateSessionStoreAfterAgentRun({
+          cfg,
+          contextTokensOverride: 1_000_000,
+          sessionId,
+          sessionKey,
+          storePath,
+          sessionStore,
+          defaultProvider: "claude-cli",
+          defaultModel: "claude-opus-4-7",
+          result: {
+            meta: {
+              durationMs: 1,
+              executionTrace: { runner: "cli" },
+              agentMeta: {
+                sessionId,
+                provider: "claude-cli",
+                model: "claude-opus-4-7",
+                promptTokens,
+                usage: { input: promptTokens, output: 5 },
+                lastCallUsage: { input: promptTokens, output: 5 },
+              },
+            },
+          } as EmbeddedAgentRunResult,
+        });
+      };
+
+      await finalize({ [sessionKey]: structuredClone(initial) }, 150);
+      await finalize({ [sessionKey]: structuredClone(initial) }, 120);
+
+      expect(loadPersistedSessionEntry(storePath, sessionKey)?.goal).toMatchObject({
+        tokenCursor: 150,
+        tokensUsed: 50,
+      });
+    });
+  });
+
   it("adopts the final fresh CLI snapshot for a goal created during the active run", async () => {
     await withTempSessionStore(async ({ storePath }) => {
       const cfg = {

--- a/src/agents/command/session-store.test.ts
+++ b/src/agents/command/session-store.test.ts
@@ -1458,6 +1458,174 @@ describe("updateSessionStoreAfterAgentRun", () => {
     });
   });
 
+  it("advances goal accounting from CLI context snapshots", async () => {
+    await withTempSessionStore(async ({ storePath }) => {
+      const cfg = {
+        agents: {
+          defaults: {
+            cliBackends: {
+              "claude-cli": { command: "claude" },
+            },
+          },
+        },
+      } as OpenClawConfig;
+      const sessionKey = "agent:main:explicit:test-cli-goal-accounting";
+      const sessionId = "test-cli-goal-accounting-session";
+      const sessionStore: Record<string, SessionEntry> = {
+        [sessionKey]: {
+          sessionId,
+          updatedAt: 1,
+          goal: {
+            schemaVersion: 1,
+            id: "goal-1",
+            objective: "Count only post-goal CLI usage",
+            status: "active",
+            createdAt: 1,
+            updatedAt: 1,
+            tokenStart: 0,
+            tokenStartFresh: false,
+            tokensUsed: 0,
+            tokenBudget: 30_000,
+            continuationTurns: 0,
+          },
+        },
+      };
+      await seedSessionStore(storePath, sessionStore);
+
+      const run = async (promptTokens: number) => {
+        await updateSessionStoreAfterAgentRun({
+          cfg,
+          contextTokensOverride: 1_000_000,
+          sessionId,
+          sessionKey,
+          storePath,
+          sessionStore,
+          defaultProvider: "claude-cli",
+          defaultModel: "claude-opus-4-7",
+          result: {
+            meta: {
+              durationMs: 1,
+              executionTrace: { runner: "cli" },
+              agentMeta: {
+                sessionId,
+                provider: "claude-cli",
+                model: "claude-opus-4-7",
+                promptTokens,
+                usage: { input: promptTokens, output: 5 },
+                lastCallUsage: { input: promptTokens, output: 5 },
+              },
+            },
+          } as EmbeddedAgentRunResult,
+        });
+      };
+
+      await run(33_107);
+      expect(sessionStore[sessionKey]?.goal).toMatchObject({
+        tokenStart: 33_107,
+        tokenStartFresh: true,
+        tokenCursor: 33_107,
+        tokensUsed: 0,
+      });
+
+      await run(33_124);
+      expect(sessionStore[sessionKey]?.goal).toMatchObject({
+        tokenCursor: 33_124,
+        tokensUsed: 17,
+      });
+      expect(loadPersistedSessionEntry(storePath, sessionKey)?.goal).toMatchObject({
+        tokenCursor: 33_124,
+        tokensUsed: 17,
+      });
+    });
+  });
+
+  it("preserves a concurrently changed goal while projecting CLI token metadata", async () => {
+    await withTempSessionStore(async ({ storePath }) => {
+      const cfg = {
+        agents: {
+          defaults: {
+            cliBackends: {
+              "claude-cli": { command: "claude" },
+            },
+          },
+        },
+      } as OpenClawConfig;
+      const sessionKey = "agent:main:explicit:test-cli-goal-race";
+      const sessionId = "test-cli-goal-race-session";
+      const staleGoal: NonNullable<SessionEntry["goal"]> = {
+        schemaVersion: 1,
+        id: "goal-1",
+        objective: "Original objective",
+        status: "active",
+        createdAt: 1,
+        updatedAt: 1,
+        tokenStart: 100,
+        tokenStartFresh: true,
+        tokenCursor: 100,
+        tokensUsed: 0,
+        tokenBudget: 30_000,
+        continuationTurns: 0,
+      };
+      const sessionStore: Record<string, SessionEntry> = {
+        [sessionKey]: {
+          sessionId,
+          updatedAt: 1,
+          totalTokens: 100,
+          totalTokensFresh: true,
+          goal: staleGoal,
+        },
+      };
+      const concurrentGoal: NonNullable<SessionEntry["goal"]> = {
+        ...staleGoal,
+        objective: "Changed while the CLI run was active",
+        status: "complete",
+        updatedAt: 2,
+        completedAt: 2,
+      };
+      await replaceSessionEntry(
+        { storePath, sessionKey },
+        {
+          ...sessionStore[sessionKey],
+          updatedAt: 2,
+          goal: concurrentGoal,
+        },
+      );
+
+      await updateSessionStoreAfterAgentRun({
+        cfg,
+        contextTokensOverride: 1_000_000,
+        sessionId,
+        sessionKey,
+        storePath,
+        sessionStore,
+        defaultProvider: "claude-cli",
+        defaultModel: "claude-opus-4-7",
+        result: {
+          meta: {
+            durationMs: 1,
+            executionTrace: { runner: "cli" },
+            agentMeta: {
+              sessionId,
+              provider: "claude-cli",
+              model: "claude-opus-4-7",
+              promptTokens: 125,
+              usage: { input: 125, output: 5 },
+              lastCallUsage: { input: 125, output: 5 },
+            },
+          },
+        } as EmbeddedAgentRunResult,
+      });
+
+      expect(sessionStore[sessionKey]?.totalTokens).toBe(125);
+      expect(sessionStore[sessionKey]?.goal).toEqual(concurrentGoal);
+      expect(loadPersistedSessionEntry(storePath, sessionKey)).toMatchObject({
+        totalTokens: 125,
+        totalTokensFresh: true,
+        goal: concurrentGoal,
+      });
+    });
+  });
+
   it("persists compaction tokensAfter when provider usage is unavailable", async () => {
     await withTempSessionStore(async ({ storePath }) => {
       const cfg = {} as OpenClawConfig;

--- a/src/agents/command/session-store.test.ts
+++ b/src/agents/command/session-store.test.ts
@@ -1585,7 +1585,7 @@ describe("updateSessionStoreAfterAgentRun", () => {
       await replaceSessionEntry(
         { storePath, sessionKey },
         {
-          ...sessionStore[sessionKey],
+          ...sessionStore[sessionKey]!,
           updatedAt: 2,
           goal: concurrentGoal,
         },

--- a/src/agents/command/session-store.test.ts
+++ b/src/agents/command/session-store.test.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
 import {
+  SESSION_TOTAL_TOKENS_VERSION,
   resolveFreshSessionTotalTokens,
   type InternalSessionEntry as SessionEntry,
 } from "../../config/sessions.js";
@@ -1622,11 +1623,20 @@ describe("updateSessionStoreAfterAgentRun", () => {
       });
 
       expect(sessionStore[sessionKey]?.totalTokens).toBe(125);
-      expect(sessionStore[sessionKey]?.goal).toEqual(concurrentGoal);
+      expect(sessionStore[sessionKey]?.goal).toEqual({
+        ...concurrentGoal,
+        tokenCursor: 125,
+        tokensUsed: 25,
+      });
       expect(loadPersistedSessionEntry(storePath, sessionKey)).toMatchObject({
         totalTokens: 125,
         totalTokensFresh: true,
-        goal: concurrentGoal,
+        totalTokensVersion: SESSION_TOTAL_TOKENS_VERSION,
+        goal: {
+          ...concurrentGoal,
+          tokenCursor: 125,
+          tokensUsed: 25,
+        },
       });
     });
   });

--- a/src/agents/command/session-store.test.ts
+++ b/src/agents/command/session-store.test.ts
@@ -9,7 +9,7 @@ import {
   resolveFreshSessionTotalTokens,
   type InternalSessionEntry as SessionEntry,
 } from "../../config/sessions.js";
-import { createSessionGoal } from "../../config/sessions/goals.js";
+import { clearSessionGoal, createSessionGoal } from "../../config/sessions/goals.js";
 import {
   listSessionEntriesCore,
   loadSessionEntry,
@@ -1677,6 +1677,82 @@ describe("updateSessionStoreAfterAgentRun", () => {
       });
 
       expect(sessionStore[sessionKey]?.goal).toMatchObject({
+        tokenStart: 125,
+        tokenStartFresh: true,
+        tokenCursor: 125,
+        tokensUsed: 0,
+      });
+    });
+  });
+
+  it("rebases a replacement goal created during the active CLI run", async () => {
+    await withTempSessionStore(async ({ storePath }) => {
+      const cfg = {
+        agents: { defaults: { cliBackends: { "claude-cli": { command: "claude" } } } },
+      } as OpenClawConfig;
+      const sessionKey = "agent:main:explicit:test-cli-goal-replaced-mid-run";
+      const sessionId = "test-cli-goal-replaced-mid-run-session";
+      const initialGoal: NonNullable<SessionEntry["goal"]> = {
+        schemaVersion: 1,
+        id: "goal-before-run",
+        objective: "Original objective",
+        status: "active",
+        createdAt: 1,
+        updatedAt: 1,
+        tokenStart: 100,
+        tokenStartFresh: true,
+        tokenCursor: 100,
+        tokensUsed: 0,
+        tokenBudget: 30_000,
+        continuationTurns: 0,
+      };
+      const sessionStore: Record<string, SessionEntry> = {
+        [sessionKey]: {
+          sessionId,
+          updatedAt: 1,
+          totalTokens: 100,
+          totalTokensFresh: true,
+          goal: initialGoal,
+        },
+      };
+      await seedSessionStore(storePath, sessionStore);
+      await clearSessionGoal({ sessionKey, storePath });
+      const replacementGoal = await createSessionGoal({
+        sessionKey,
+        storePath,
+        objective: "Replacement objective",
+        tokenBudget: 30_000,
+        now: 2,
+      });
+
+      await updateSessionStoreAfterAgentRun({
+        cfg,
+        contextTokensOverride: 1_000_000,
+        sessionId,
+        sessionKey,
+        storePath,
+        sessionStore,
+        defaultProvider: "claude-cli",
+        defaultModel: "claude-opus-4-7",
+        result: {
+          meta: {
+            durationMs: 1,
+            executionTrace: { runner: "cli" },
+            agentMeta: {
+              sessionId,
+              provider: "claude-cli",
+              model: "claude-opus-4-7",
+              promptTokens: 125,
+              usage: { input: 125, output: 5 },
+              lastCallUsage: { input: 125, output: 5 },
+            },
+          },
+        } as EmbeddedAgentRunResult,
+      });
+
+      expect(sessionStore[sessionKey]?.goal).toMatchObject({
+        id: replacementGoal.id,
+        objective: "Replacement objective",
         tokenStart: 125,
         tokenStartFresh: true,
         tokenCursor: 125,

--- a/src/agents/command/session-store.test.ts
+++ b/src/agents/command/session-store.test.ts
@@ -9,6 +9,7 @@ import {
   resolveFreshSessionTotalTokens,
   type InternalSessionEntry as SessionEntry,
 } from "../../config/sessions.js";
+import { createSessionGoal } from "../../config/sessions/goals.js";
 import {
   listSessionEntriesCore,
   loadSessionEntry,
@@ -1626,6 +1627,64 @@ describe("updateSessionStoreAfterAgentRun", () => {
     });
   });
 
+  it("adopts the final fresh CLI snapshot for a goal created during the active run", async () => {
+    await withTempSessionStore(async ({ storePath }) => {
+      const cfg = {
+        agents: { defaults: { cliBackends: { "claude-cli": { command: "claude" } } } },
+      } as OpenClawConfig;
+      const sessionKey = "agent:main:explicit:test-cli-goal-created-mid-run";
+      const sessionId = "test-cli-goal-created-mid-run-session";
+      const sessionStore: Record<string, SessionEntry> = {
+        [sessionKey]: {
+          sessionId,
+          updatedAt: 1,
+          totalTokens: 100,
+          totalTokensFresh: true,
+        },
+      };
+      await seedSessionStore(storePath, sessionStore);
+      await createSessionGoal({
+        sessionKey,
+        storePath,
+        objective: "Count only usage after creation",
+        tokenBudget: 30_000,
+        now: 2,
+      });
+
+      await updateSessionStoreAfterAgentRun({
+        cfg,
+        contextTokensOverride: 1_000_000,
+        sessionId,
+        sessionKey,
+        storePath,
+        sessionStore,
+        defaultProvider: "claude-cli",
+        defaultModel: "claude-opus-4-7",
+        result: {
+          meta: {
+            durationMs: 1,
+            executionTrace: { runner: "cli" },
+            agentMeta: {
+              sessionId,
+              provider: "claude-cli",
+              model: "claude-opus-4-7",
+              promptTokens: 125,
+              usage: { input: 125, output: 5 },
+              lastCallUsage: { input: 125, output: 5 },
+            },
+          },
+        } as EmbeddedAgentRunResult,
+      });
+
+      expect(sessionStore[sessionKey]?.goal).toMatchObject({
+        tokenStart: 125,
+        tokenStartFresh: true,
+        tokenCursor: 125,
+        tokensUsed: 0,
+      });
+    });
+  });
+
   it("persists compaction tokensAfter when provider usage is unavailable", async () => {
     await withTempSessionStore(async ({ storePath }) => {
       const cfg = {} as OpenClawConfig;
@@ -2976,6 +3035,66 @@ describe("recordCliCompactionInStore", () => {
         sessionId: "stale-cli-session",
       });
       expect(persisted[sessionKey]?.cliSessionIds?.codex).toBe("stale-cli-session");
+    });
+  });
+
+  it("rebases the durable goal to the fresh CLI compaction snapshot", async () => {
+    await withTempSessionStore(async ({ storePath }) => {
+      const sessionKey = "agent:main:explicit:test-record-cli-compaction-goal";
+      const sessionId = "test-record-cli-compaction-goal-session";
+      const goal: NonNullable<SessionEntry["goal"]> = {
+        schemaVersion: 1,
+        id: "goal-1",
+        objective: "Keep charging after compaction",
+        status: "active",
+        createdAt: 1,
+        updatedAt: 1,
+        tokenStart: 10_000,
+        tokenStartFresh: true,
+        tokenCursor: 12_000,
+        tokensUsed: 2_000,
+        tokenBudget: 30_000,
+        continuationTurns: 0,
+      };
+      const sessionStore: Record<string, SessionEntry> = {
+        [sessionKey]: {
+          sessionId,
+          updatedAt: 1,
+          totalTokens: 12_000,
+          totalTokensFresh: true,
+          goal,
+        },
+      };
+      await seedSessionStore(storePath, sessionStore);
+      await replaceSessionEntry(
+        { storePath, sessionKey },
+        {
+          ...sessionStore[sessionKey]!,
+          goal: {
+            ...goal,
+            objective: "Changed while compaction was active",
+            status: "paused",
+            updatedAt: 2,
+            pausedAt: 2,
+          },
+        },
+      );
+
+      await recordCliCompactionInStore({
+        provider: "codex",
+        sessionKey,
+        sessionStore,
+        storePath,
+        tokensAfter: 3_000,
+      });
+
+      expect(sessionStore[sessionKey]?.goal).toMatchObject({
+        objective: "Changed while compaction was active",
+        status: "paused",
+        tokenStart: 10_000,
+        tokenCursor: 3_000,
+        tokensUsed: 2_000,
+      });
     });
   });
 

--- a/src/agents/command/session-store.ts
+++ b/src/agents/command/session-store.ts
@@ -328,7 +328,12 @@ export async function updateSessionStoreAfterAgentRun(params: {
         snapshotPatch.goal =
           entry.goal?.id === currentEntry.goal.id
             ? resolveSessionGoalDisplayState(
-                { goal: currentEntry.goal, totalTokens: next.totalTokens, totalTokensFresh: true },
+                {
+                  goal: currentEntry.goal,
+                  totalTokens: next.totalTokens,
+                  totalTokensFresh: true,
+                  totalTokensVersion: SESSION_TOTAL_TOKENS_VERSION,
+                },
                 now,
               )
             : rebaseSessionGoalTokenCursor(currentEntry.goal, next.totalTokens, {

--- a/src/agents/command/session-store.ts
+++ b/src/agents/command/session-store.ts
@@ -8,7 +8,10 @@ import {
   setSessionRuntimeModel,
   type SessionEntry,
 } from "../../config/sessions.js";
-import { resolveSessionGoalDisplayState } from "../../config/sessions/goals.js";
+import {
+  rebaseSessionGoalTokenCursor,
+  resolveSessionGoalDisplayState,
+} from "../../config/sessions/goals.js";
 import { patchSessionEntryCore } from "../../config/sessions/session-accessor.js";
 import { projectSessionSnapshotChanges } from "../../config/sessions/session-snapshot-merge.js";
 import { resolveMaintenanceConfigFromInput } from "../../config/sessions/store-maintenance.js";
@@ -308,14 +311,28 @@ export async function updateSessionStoreAfterAgentRun(params: {
         // recreate rows that were reset/deleted while the run was active.
         return null;
       }
-      return preserveUserFacingRunState
-        ? metadataPatch
-        : projectSessionSnapshotChanges({
-            initial: entry,
-            next,
-            current: currentEntry,
-            reassertAbortedLastRun: result.meta.aborted === true,
-          });
+      if (preserveUserFacingRunState) {
+        return metadataPatch;
+      }
+      const snapshotPatch = projectSessionSnapshotChanges({
+        initial: entry,
+        next,
+        current: currentEntry,
+        reassertAbortedLastRun: result.meta.aborted === true,
+      });
+      if (
+        currentEntry.goal &&
+        typeof next.totalTokens === "number" &&
+        next.totalTokensFresh === true
+      ) {
+        snapshotPatch.goal = entry.goal
+          ? resolveSessionGoalDisplayState(
+              { goal: currentEntry.goal, totalTokens: next.totalTokens, totalTokensFresh: true },
+              now,
+            )
+          : rebaseSessionGoalTokenCursor(currentEntry.goal, next.totalTokens, { resetStart: true });
+      }
+      return snapshotPatch;
     },
     {
       ...(preserveUserFacingRunState ? {} : { fallbackEntry: entry }),
@@ -556,7 +573,15 @@ export async function recordCliCompactionInStore(params: {
       ) {
         return null;
       }
-      return next;
+      return {
+        ...next,
+        // The durable row owns concurrent Goal edits. Rebase that exact Goal to the new token
+        // epoch instead of restoring the caller's stale in-memory snapshot.
+        goal:
+          tokensAfterCompaction !== undefined && currentEntry.goal
+            ? rebaseSessionGoalTokenCursor(currentEntry.goal, Math.floor(tokensAfterCompaction))
+            : currentEntry.goal,
+      };
     },
     { fallbackEntry: entry },
   );

--- a/src/agents/command/session-store.ts
+++ b/src/agents/command/session-store.ts
@@ -335,17 +335,26 @@ export async function updateSessionStoreAfterAgentRun(params: {
         typeof next.totalTokens === "number" &&
         next.totalTokensFresh === true
       ) {
+        const currentGoalCursor = currentEntry.goal.tokenCursor;
+        const isOlderFinalizerSnapshot =
+          compactionTokensAfter === undefined &&
+          typeof currentGoalCursor === "number" &&
+          Number.isSafeInteger(currentGoalCursor) &&
+          currentGoalCursor >= 0 &&
+          next.totalTokens < currentGoalCursor;
         snapshotPatch.goal =
           entry.goal?.id === currentEntry.goal.id
-            ? resolveSessionGoalDisplayState(
-                {
-                  goal: currentEntry.goal,
-                  totalTokens: next.totalTokens,
-                  totalTokensFresh: true,
-                  totalTokensVersion: SESSION_TOTAL_TOKENS_VERSION,
-                },
-                now,
-              )
+            ? isOlderFinalizerSnapshot
+              ? currentEntry.goal
+              : resolveSessionGoalDisplayState(
+                  {
+                    goal: currentEntry.goal,
+                    totalTokens: next.totalTokens,
+                    totalTokensFresh: true,
+                    totalTokensVersion: SESSION_TOTAL_TOKENS_VERSION,
+                  },
+                  now,
+                )
             : rebaseSessionGoalTokenCursor(currentEntry.goal, next.totalTokens, {
                 resetStart: true,
               });

--- a/src/agents/command/session-store.ts
+++ b/src/agents/command/session-store.ts
@@ -8,6 +8,7 @@ import {
   setSessionRuntimeModel,
   type SessionEntry,
 } from "../../config/sessions.js";
+import { resolveSessionGoalDisplayState } from "../../config/sessions/goals.js";
 import { patchSessionEntryCore } from "../../config/sessions/session-accessor.js";
 import { projectSessionSnapshotChanges } from "../../config/sessions/session-snapshot-merge.js";
 import { resolveMaintenanceConfigFromInput } from "../../config/sessions/store-maintenance.js";
@@ -275,6 +276,12 @@ export async function updateSessionStoreAfterAgentRun(params: {
   }
   if (compactionsThisRun > 0 && !preserveUserFacingRunState) {
     next.compactionCount = (entry.compactionCount ?? 0) + compactionsThisRun;
+  }
+  if (!preserveUserFacingRunState) {
+    const accountedGoal = resolveSessionGoalDisplayState(next, now);
+    if (accountedGoal) {
+      next.goal = accountedGoal;
+    }
   }
   const metadataPatch = preserveUserFacingRunState
     ? {

--- a/src/agents/command/session-store.ts
+++ b/src/agents/command/session-store.ts
@@ -8,10 +8,7 @@ import {
   setSessionRuntimeModel,
   type SessionEntry,
 } from "../../config/sessions.js";
-import {
-  rebaseSessionGoalTokenCursor,
-  resolveSessionGoalDisplayState,
-} from "../../config/sessions/goals.js";
+import { resolveSessionGoalDisplayState } from "../../config/sessions/goals.js";
 import { patchSessionEntryCore } from "../../config/sessions/session-accessor.js";
 import { projectSessionSnapshotChanges } from "../../config/sessions/session-snapshot-merge.js";
 import { resolveMaintenanceConfigFromInput } from "../../config/sessions/store-maintenance.js";
@@ -34,6 +31,19 @@ type RunResult = Awaited<ReturnType<(typeof import("../embedded-agent.js"))["run
 
 const usageFormatModuleLoader = createLazyImportLoader(() => import("../../utils/usage-format.js"));
 const contextModuleLoader = createLazyImportLoader(() => import("../context.js"));
+
+function rebaseSessionGoalTokenCursor(
+  goal: NonNullable<SessionEntry["goal"]>,
+  totalTokens: number,
+  options?: { resetStart?: boolean },
+): NonNullable<SessionEntry["goal"]> {
+  return {
+    ...goal,
+    ...(options?.resetStart ? { tokenStart: totalTokens } : {}),
+    tokenStartFresh: true,
+    tokenCursor: totalTokens,
+  };
+}
 
 async function getUsageFormatModule() {
   return await usageFormatModuleLoader.load();

--- a/src/agents/command/session-store.ts
+++ b/src/agents/command/session-store.ts
@@ -325,12 +325,15 @@ export async function updateSessionStoreAfterAgentRun(params: {
         typeof next.totalTokens === "number" &&
         next.totalTokensFresh === true
       ) {
-        snapshotPatch.goal = entry.goal
-          ? resolveSessionGoalDisplayState(
-              { goal: currentEntry.goal, totalTokens: next.totalTokens, totalTokensFresh: true },
-              now,
-            )
-          : rebaseSessionGoalTokenCursor(currentEntry.goal, next.totalTokens, { resetStart: true });
+        snapshotPatch.goal =
+          entry.goal?.id === currentEntry.goal.id
+            ? resolveSessionGoalDisplayState(
+                { goal: currentEntry.goal, totalTokens: next.totalTokens, totalTokensFresh: true },
+                now,
+              )
+            : rebaseSessionGoalTokenCursor(currentEntry.goal, next.totalTokens, {
+                resetStart: true,
+              });
       }
       return snapshotPatch;
     },

--- a/src/agents/tools/goal-tools.test.ts
+++ b/src/agents/tools/goal-tools.test.ts
@@ -148,7 +148,7 @@ describe("goal tools", () => {
       config,
     });
 
-    const storePath = resolveStorePath(template, { agentId: "research" });
+    const storePath = resolveSessionStorePathCore(template, { agentId: "research" });
     await upsertSessionEntry({
       storePath,
       sessionKey: "global",

--- a/src/agents/tools/goal-tools.test.ts
+++ b/src/agents/tools/goal-tools.test.ts
@@ -133,11 +133,36 @@ describe("goal tools", () => {
           objective: "ship global work",
           token_budget: tokenBudget,
         }),
-      ).rejects.toThrow("token_budget must be a positive integer");
+      ).rejects.toThrow("token_budget must be a positive safe integer");
 
       expect(getSessionEntry({ storePath, sessionKey: "global" })?.goal).toBeUndefined();
     },
   );
+
+  it("rejects unsafe token budgets instead of silently creating an unlimited goal", async () => {
+    const { config, template } = await createStoreConfig();
+    const tool = createCreateGoalTool({
+      agentSessionKey: "global",
+      runSessionKey: "global",
+      sessionAgentId: "research",
+      config,
+    });
+
+    const storePath = resolveStorePath(template, { agentId: "research" });
+    await upsertSessionEntry({
+      storePath,
+      sessionKey: "global",
+      entry: { sessionId: "sess-global", updatedAt: 1 },
+    });
+    await expect(
+      tool.execute("call-unsafe-budget", {
+        objective: "ship safely",
+        token_budget: Number.MAX_SAFE_INTEGER + 1,
+      }),
+    ).rejects.toThrow("token_budget must be a positive safe integer");
+
+    expect(getSessionEntry({ storePath, sessionKey: "global" })?.goal).toBeUndefined();
+  });
 
   it("prefers scoped run session keys over the fallback session agent", async () => {
     const { config, template } = await createStoreConfig();

--- a/src/agents/tools/goal-tools.ts
+++ b/src/agents/tools/goal-tools.ts
@@ -105,7 +105,7 @@ export function createCreateGoalTool(options: GoalToolOptions): AnyAgentTool {
       const params = args as Record<string, unknown>;
       const objective = readToolStringParam(params, "objective", { required: true });
       const tokenBudget = readPositiveIntegerParam(params, "token_budget", {
-        message: "token_budget must be a positive integer",
+        message: "token_budget must be a positive safe integer",
       });
       const scope = resolveGoalSessionScope(options);
       const goal = await createSessionGoal({

--- a/src/config/sessions/goals.test.ts
+++ b/src/config/sessions/goals.test.ts
@@ -78,9 +78,24 @@ describe("session goals", () => {
     expect(goal.objective).toBe("land the PR");
     expect(goal.status).toBe("active");
     expect(goal.tokenStart).toBe(100);
-    expect(goal.tokenStartFresh).toBe(true);
+    expect(goal.tokenStartFresh).toBe(false);
     expect(goal.tokenBudget).toBe(50);
     expect(getSessionEntry({ storePath: fixture.storePath(), sessionKey })?.goal?.id).toBe(goal.id);
+  });
+
+  it("rejects an explicitly invalid token budget instead of silently creating an unlimited goal", async () => {
+    await writeSession(0);
+
+    await expect(
+      createSessionGoal({
+        storePath: fixture.storePath(),
+        sessionKey,
+        objective: "finish task",
+        tokenBudget: Number.MAX_SAFE_INTEGER + 1,
+        now: 10,
+      }),
+    ).rejects.toThrow(/positive safe integer/);
+    expect(getSessionEntry({ storePath: fixture.storePath(), sessionKey })?.goal).toBeUndefined();
   });
 
   it("can create a goal from a fallback session entry", async () => {
@@ -104,28 +119,139 @@ describe("session goals", () => {
     );
   });
 
-  it("accounts usage from session token snapshots and enforces budget", async () => {
-    await writeSession(100);
-    await createSessionGoal({
+  it("synchronizes the first post-creation snapshot before charging goal-relative growth", async () => {
+    await writeSession(10_000);
+    const created = await createSessionGoal({
       storePath: fixture.storePath(),
       sessionKey,
       objective: "finish task",
-      tokenBudget: 20,
+      tokenBudget: 30_000,
       now: 10,
     });
+
+    expect(created.tokensUsed).toBe(0);
+    expect(created.status).toBe("active");
+
     await upsertSessionEntry({
       storePath: fixture.storePath(),
       sessionKey,
       entry: {
         ...getSessionEntry({ storePath: fixture.storePath(), sessionKey })!,
-        totalTokens: 125,
+        totalTokens: 56_200,
+      },
+    });
+    const synchronized = await getSessionGoal({
+      storePath: fixture.storePath(),
+      sessionKey,
+      now: 20,
+    });
+
+    expect(synchronized.goal?.tokensUsed).toBe(0);
+    expect(synchronized.goal?.status).toBe("active");
+
+    await upsertSessionEntry({
+      storePath: fixture.storePath(),
+      sessionKey,
+      entry: {
+        ...getSessionEntry({ storePath: fixture.storePath(), sessionKey })!,
+        totalTokens: 56_450,
+      },
+    });
+    const afterGrowth = await getSessionGoal({
+      storePath: fixture.storePath(),
+      sessionKey,
+      now: 30,
+    });
+
+    expect(afterGrowth.goal?.tokensUsed).toBe(250);
+    expect(afterGrowth.goal?.status).toBe("active");
+  });
+
+  it("accounts each comparable snapshot once and rebases without losing usage after a reset", async () => {
+    await writeSession(1_000);
+    await createSessionGoal({
+      storePath: fixture.storePath(),
+      sessionKey,
+      objective: "finish task",
+      tokenBudget: 1_000,
+      now: 10,
+    });
+
+    await getSessionGoal({ storePath: fixture.storePath(), sessionKey, now: 20 });
+    await upsertSessionEntry({
+      storePath: fixture.storePath(),
+      sessionKey,
+      entry: {
+        ...getSessionEntry({ storePath: fixture.storePath(), sessionKey })!,
+        totalTokens: 1_200,
+      },
+    });
+    const afterGrowth = await getSessionGoal({
+      storePath: fixture.storePath(),
+      sessionKey,
+      now: 30,
+    });
+    const repeated = await getSessionGoal({
+      storePath: fixture.storePath(),
+      sessionKey,
+      now: 40,
+    });
+
+    expect(afterGrowth.goal?.tokensUsed).toBe(200);
+    expect(repeated.goal?.tokensUsed).toBe(200);
+
+    await upsertSessionEntry({
+      storePath: fixture.storePath(),
+      sessionKey,
+      entry: {
+        ...getSessionEntry({ storePath: fixture.storePath(), sessionKey })!,
+        totalTokens: 400,
+      },
+    });
+    const afterReset = await getSessionGoal({
+      storePath: fixture.storePath(),
+      sessionKey,
+      now: 50,
+    });
+    expect(afterReset.goal?.tokensUsed).toBe(200);
+
+    await upsertSessionEntry({
+      storePath: fixture.storePath(),
+      sessionKey,
+      entry: {
+        ...getSessionEntry({ storePath: fixture.storePath(), sessionKey })!,
+        totalTokens: 450,
+      },
+    });
+    const afterResetGrowth = await getSessionGoal({
+      storePath: fixture.storePath(),
+      sessionKey,
+      now: 60,
+    });
+    expect(afterResetGrowth.goal?.tokensUsed).toBe(250);
+  });
+
+  it("does not charge already-accounted legacy usage again when adding a cursor", () => {
+    const goal = resolveSessionGoalDisplayState({
+      totalTokens: 125,
+      totalTokensFresh: true,
+      goal: {
+        schemaVersion: 1,
+        id: "goal-1",
+        objective: "finish",
+        status: "active",
+        createdAt: 1,
+        updatedAt: 1,
+        tokenStart: 100,
+        tokenStartFresh: true,
+        tokensUsed: 25,
+        tokenBudget: 100,
+        continuationTurns: 0,
       },
     });
 
-    const snapshot = await getSessionGoal({ storePath: fixture.storePath(), sessionKey, now: 20 });
-
-    expect(snapshot.goal?.tokensUsed).toBe(25);
-    expect(snapshot.goal?.status).toBe("budget_limited");
+    expect(goal?.tokenCursor).toBe(125);
+    expect(goal?.tokensUsed).toBe(25);
   });
 
   it("resumes budget-limited goals with a fresh budget window", async () => {
@@ -157,9 +283,29 @@ describe("session goals", () => {
 
     expect(resumed.status).toBe("active");
     expect(resumed.tokenStart).toBe(125);
+    expect(resumed.tokenStartFresh).toBe(true);
+    expect(resumed.tokenCursor).toBe(125);
     expect(resumed.tokensUsed).toBe(0);
     expect(snapshot.goal?.status).toBe("active");
     expect(snapshot.goal?.tokensUsed).toBe(0);
+
+    await upsertSessionEntry({
+      storePath: fixture.storePath(),
+      sessionKey,
+      entry: {
+        ...getSessionEntry({ storePath: fixture.storePath(), sessionKey })!,
+        totalTokens: 150,
+      },
+    });
+    const afterFirstResumedRun = await getSessionGoal({
+      storePath: fixture.storePath(),
+      sessionKey,
+      now: 50,
+    });
+
+    expect(afterFirstResumedRun.goal?.tokenCursor).toBe(150);
+    expect(afterFirstResumedRun.goal?.tokensUsed).toBe(25);
+    expect(afterFirstResumedRun.goal?.status).toBe("budget_limited");
   });
 
   it("ignores stale token snapshots for budget accounting", async () => {
@@ -235,7 +381,7 @@ describe("session goals", () => {
     expect(snapshot.goal?.status).toBe("active");
   });
 
-  it("accounts token snapshots with current context provenance", async () => {
+  it("still synchronizes snapshots whose freshness is implicit", async () => {
     await upsertSessionEntry({
       storePath: fixture.storePath(),
       sessionKey,
@@ -266,8 +412,9 @@ describe("session goals", () => {
 
     const snapshot = await getSessionGoal({ storePath: fixture.storePath(), sessionKey, now: 20 });
 
-    expect(snapshot.goal?.tokenStart).toBe(100);
-    expect(snapshot.goal?.tokensUsed).toBe(25);
+    expect(snapshot.goal?.tokenStart).toBe(125);
+    expect(snapshot.goal?.tokenStartFresh).toBe(true);
+    expect(snapshot.goal?.tokensUsed).toBe(0);
   });
 
   it("lets model tools complete or block but keeps existing terminal state", async () => {

--- a/src/config/sessions/goals.test.ts
+++ b/src/config/sessions/goals.test.ts
@@ -14,7 +14,7 @@ import {
   upsertSessionEntryCore as upsertAccessorSessionEntry,
 } from "./session-accessor.js";
 import { useTempSessionsFixture } from "./test-helpers.js";
-import type { SessionEntry } from "./types.js";
+import { SESSION_TOTAL_TOKENS_VERSION, type SessionEntry } from "./types.js";
 
 // The goal APIs read/write session entries through the SQLite-backed accessor,
 // so fixtures must seed and assert through the same accessor rather than the
@@ -222,6 +222,7 @@ describe("session goals", () => {
     const goal = resolveSessionGoalDisplayState({
       totalTokens: 125,
       totalTokensFresh: true,
+      totalTokensVersion: SESSION_TOTAL_TOKENS_VERSION,
       goal: {
         schemaVersion: 1,
         id: "goal-1",

--- a/src/config/sessions/goals.test.ts
+++ b/src/config/sessions/goals.test.ts
@@ -78,7 +78,8 @@ describe("session goals", () => {
     expect(goal.objective).toBe("land the PR");
     expect(goal.status).toBe("active");
     expect(goal.tokenStart).toBe(100);
-    expect(goal.tokenStartFresh).toBe(false);
+    expect(goal.tokenStartFresh).toBe(true);
+    expect(goal.tokenCursor).toBe(100);
     expect(goal.tokenBudget).toBe(50);
     expect(getSessionEntry({ storePath: fixture.storePath(), sessionKey })?.goal?.id).toBe(goal.id);
   });
@@ -119,8 +120,8 @@ describe("session goals", () => {
     );
   });
 
-  it("synchronizes the first post-creation snapshot before charging goal-relative growth", async () => {
-    await writeSession(10_000);
+  it("charges the first finalization from a fresh creation-time cursor", async () => {
+    await writeSession(33_110);
     const created = await createSessionGoal({
       storePath: fixture.storePath(),
       sessionKey,
@@ -129,6 +130,7 @@ describe("session goals", () => {
       now: 10,
     });
 
+    expect(created.tokenCursor).toBe(33_110);
     expect(created.tokensUsed).toBe(0);
     expect(created.status).toBe("active");
 
@@ -137,34 +139,19 @@ describe("session goals", () => {
       sessionKey,
       entry: {
         ...getSessionEntry({ storePath: fixture.storePath(), sessionKey })!,
-        totalTokens: 56_200,
+        totalTokens: 33_133,
+        totalTokensFresh: true,
       },
     });
-    const synchronized = await getSessionGoal({
+    const finalized = await getSessionGoal({
       storePath: fixture.storePath(),
       sessionKey,
       now: 20,
     });
 
-    expect(synchronized.goal?.tokensUsed).toBe(0);
-    expect(synchronized.goal?.status).toBe("active");
-
-    await upsertSessionEntry({
-      storePath: fixture.storePath(),
-      sessionKey,
-      entry: {
-        ...getSessionEntry({ storePath: fixture.storePath(), sessionKey })!,
-        totalTokens: 56_450,
-      },
-    });
-    const afterGrowth = await getSessionGoal({
-      storePath: fixture.storePath(),
-      sessionKey,
-      now: 30,
-    });
-
-    expect(afterGrowth.goal?.tokensUsed).toBe(250);
-    expect(afterGrowth.goal?.status).toBe("active");
+    expect(finalized.goal?.tokenCursor).toBe(33_133);
+    expect(finalized.goal?.tokensUsed).toBe(23);
+    expect(finalized.goal?.status).toBe("active");
   });
 
   it("accounts each comparable snapshot once and rebases without losing usage after a reset", async () => {
@@ -381,7 +368,7 @@ describe("session goals", () => {
     expect(snapshot.goal?.status).toBe("active");
   });
 
-  it("still synchronizes snapshots whose freshness is implicit", async () => {
+  it("charges growth when creation-time freshness is implicit", async () => {
     await upsertSessionEntry({
       storePath: fixture.storePath(),
       sessionKey,
@@ -412,9 +399,10 @@ describe("session goals", () => {
 
     const snapshot = await getSessionGoal({ storePath: fixture.storePath(), sessionKey, now: 20 });
 
-    expect(snapshot.goal?.tokenStart).toBe(125);
+    expect(snapshot.goal?.tokenStart).toBe(100);
     expect(snapshot.goal?.tokenStartFresh).toBe(true);
-    expect(snapshot.goal?.tokensUsed).toBe(0);
+    expect(snapshot.goal?.tokenCursor).toBe(125);
+    expect(snapshot.goal?.tokensUsed).toBe(25);
   });
 
   it("lets model tools complete or block but keeps existing terminal state", async () => {

--- a/src/config/sessions/goals.ts
+++ b/src/config/sessions/goals.ts
@@ -133,6 +133,9 @@ function accountGoalUsage(
   const nextTokensUsed = addTokenCounts(tokensUsed, delta);
   const next: SessionGoal = {
     ...goal,
+    // Preserve the legacy projection contract where an omitted freshness flag meant a trusted
+    // baseline. A cursor likewise proves that a comparable baseline has been established.
+    ...(cursor !== undefined ? { tokenStartFresh: true } : {}),
     ...(shouldAdoptFreshBaseline ? { tokenStart: totalTokens, tokenStartFresh: true } : {}),
     ...(totalTokens !== undefined && !shouldHoldPendingBaseline
       ? { tokenCursor: totalTokens }

--- a/src/config/sessions/goals.ts
+++ b/src/config/sessions/goals.ts
@@ -43,9 +43,12 @@ function nowMs(value: number | undefined): number {
 }
 
 function normalizeTokenCount(value: number | undefined): number | undefined {
-  return typeof value === "number" && Number.isFinite(value) && value >= 0
-    ? Math.floor(value)
-    : undefined;
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0 ? value : undefined;
+}
+
+function addTokenCounts(left: number, right: number): number {
+  const sum = left + right;
+  return Number.isSafeInteger(sum) ? sum : Number.MAX_SAFE_INTEGER;
 }
 
 function resolveEntryFreshTotalTokens(
@@ -61,8 +64,14 @@ function resolveEntryGoalStartTokens(
 }
 
 function normalizeTokenBudget(value: number | undefined): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
   const normalized = normalizeTokenCount(value);
-  return normalized && normalized > 0 ? normalized : undefined;
+  if (normalized === undefined || normalized <= 0) {
+    throw new Error("token budget must be a positive safe integer");
+  }
+  return normalized;
 }
 
 function cloneGoal(goal: SessionGoal): SessionGoal {
@@ -103,29 +112,37 @@ function accountGoalUsage(
     return undefined;
   }
   const totalTokens = resolveEntryFreshTotalTokens(entry);
-  const hasFreshStart = goal.tokenStartFresh !== false;
-  // Old entries may have a stale token baseline; display-only reads can hold it, while persisted
-  // reads adopt the fresh total so future budget checks use current accounting.
-  const shouldHoldStaleStart = !hasFreshStart && options?.adoptFreshBaseline === false;
-  const shouldAdoptFreshStart =
-    !shouldHoldStaleStart && totalTokens !== undefined && !hasFreshStart;
-  const tokenStart = shouldAdoptFreshStart
-    ? totalTokens
-    : (normalizeTokenCount(goal.tokenStart) ?? totalTokens ?? 0);
-  const tokensUsed =
-    totalTokens === undefined || shouldAdoptFreshStart || shouldHoldStaleStart
-      ? goal.tokensUsed
-      : Math.max(goal.tokensUsed, Math.max(0, totalTokens - tokenStart));
+  const storedCursor = normalizeTokenCount(goal.tokenCursor);
+  const tokenStart = normalizeTokenCount(goal.tokenStart);
+  const tokensUsed = normalizeTokenCount(goal.tokensUsed) ?? Number.MAX_SAFE_INTEGER;
+  // Before tokenCursor existed, tokensUsed was the monotonic distance from tokenStart. Reconstruct
+  // the last-accounted snapshot so upgrading an already-accounted goal does not charge it twice.
+  const legacyCursor =
+    storedCursor === undefined && goal.tokenStartFresh !== false && tokenStart !== undefined
+      ? addTokenCounts(tokenStart, tokensUsed)
+      : undefined;
+  const cursor = storedCursor ?? legacyCursor;
+  // A newly-created or explicitly stale goal has no comparable snapshot epoch yet. Read-only
+  // projections hold that pending baseline; persisted accounting adopts the first fresh snapshot
+  // without charging it, preventing pre-goal history from entering the new budget window.
+  const shouldHoldPendingBaseline = cursor === undefined && options?.adoptFreshBaseline === false;
+  const shouldAdoptFreshBaseline =
+    !shouldHoldPendingBaseline && totalTokens !== undefined && cursor === undefined;
+  const delta =
+    totalTokens === undefined || cursor === undefined ? 0 : Math.max(0, totalTokens - cursor);
+  const nextTokensUsed = addTokenCounts(tokensUsed, delta);
   const next: SessionGoal = {
     ...goal,
-    tokenStart,
-    tokenStartFresh: hasFreshStart || shouldAdoptFreshStart,
-    tokensUsed,
+    ...(shouldAdoptFreshBaseline ? { tokenStart: totalTokens, tokenStartFresh: true } : {}),
+    ...(totalTokens !== undefined && !shouldHoldPendingBaseline
+      ? { tokenCursor: totalTokens }
+      : {}),
+    tokensUsed: nextTokensUsed,
   };
   if (
     next.status === "active" &&
     next.tokenBudget !== undefined &&
-    tokensUsed >= next.tokenBudget
+    nextTokensUsed >= next.tokenBudget
   ) {
     next.status = "budget_limited";
     next.budgetLimitedAt = now;
@@ -222,7 +239,6 @@ export async function createSessionGoal(options: CreateSessionGoalOptions): Prom
         throw new Error("goal already exists");
       }
       const tokenBudget = normalizeTokenBudget(options.tokenBudget);
-      const tokenStartFresh = resolveEntryFreshTotalTokens(entry) !== undefined;
       created = {
         schemaVersion: 1,
         id: crypto.randomUUID(),
@@ -231,7 +247,9 @@ export async function createSessionGoal(options: CreateSessionGoalOptions): Prom
         createdAt: now,
         updatedAt: now,
         tokenStart: resolveEntryGoalStartTokens(entry),
-        tokenStartFresh,
+        // Freshness alone does not prove the next snapshot uses the same accounting epoch.
+        // Synchronize conservatively on the first persisted post-creation observation.
+        tokenStartFresh: false,
         tokensUsed: 0,
         ...(tokenBudget ? { tokenBudget } : {}),
         continuationTurns: 0,
@@ -283,6 +301,11 @@ export async function updateSessionGoalStatus(
       if (resetsBudgetWindow) {
         next.tokenStart = freshTokenStart ?? 0;
         next.tokenStartFresh = freshTokenStart !== undefined;
+        if (freshTokenStart !== undefined) {
+          next.tokenCursor = freshTokenStart;
+        } else {
+          delete next.tokenCursor;
+        }
         next.tokensUsed = 0;
         delete next.budgetLimitedAt;
         delete next.usageLimitedAt;

--- a/src/config/sessions/goals.ts
+++ b/src/config/sessions/goals.ts
@@ -242,6 +242,7 @@ export async function createSessionGoal(options: CreateSessionGoalOptions): Prom
         throw new Error("goal already exists");
       }
       const tokenBudget = normalizeTokenBudget(options.tokenBudget);
+      const freshTokenStart = resolveEntryFreshTotalTokens(entry);
       created = {
         schemaVersion: 1,
         id: crypto.randomUUID(),
@@ -249,10 +250,9 @@ export async function createSessionGoal(options: CreateSessionGoalOptions): Prom
         status: "active",
         createdAt: now,
         updatedAt: now,
-        tokenStart: resolveEntryGoalStartTokens(entry),
-        // Freshness alone does not prove the next snapshot uses the same accounting epoch.
-        // Synchronize conservatively on the first persisted post-creation observation.
-        tokenStartFresh: false,
+        tokenStart: freshTokenStart ?? resolveEntryGoalStartTokens(entry),
+        tokenStartFresh: freshTokenStart !== undefined,
+        ...(freshTokenStart !== undefined ? { tokenCursor: freshTokenStart } : {}),
         tokensUsed: 0,
         ...(tokenBudget ? { tokenBudget } : {}),
         continuationTurns: 0,

--- a/src/config/sessions/goals.ts
+++ b/src/config/sessions/goals.ts
@@ -100,24 +100,6 @@ export function resolveSessionGoalDisplayState(
   return accountGoalUsage(entry, nowMs(now), options);
 }
 
-/** Rebases a goal cursor when a lifecycle owner publishes a new token-count epoch. */
-export function rebaseSessionGoalTokenCursor(
-  goal: SessionGoal,
-  totalTokens: number,
-  options?: { resetStart?: boolean },
-): SessionGoal {
-  const normalizedTotal = normalizeTokenCount(totalTokens);
-  if (normalizedTotal === undefined) {
-    return cloneGoal(goal);
-  }
-  return {
-    ...goal,
-    ...(options?.resetStart ? { tokenStart: normalizedTotal } : {}),
-    tokenStartFresh: true,
-    tokenCursor: normalizedTotal,
-  };
-}
-
 function accountGoalUsage(
   entry: Pick<SessionEntry, "goal" | "totalTokens" | "totalTokensFresh" | "totalTokensVersion">,
   now: number,

--- a/src/config/sessions/goals.ts
+++ b/src/config/sessions/goals.ts
@@ -100,6 +100,24 @@ export function resolveSessionGoalDisplayState(
   return accountGoalUsage(entry, nowMs(now), options);
 }
 
+/** Rebases a goal cursor when a lifecycle owner publishes a new token-count epoch. */
+export function rebaseSessionGoalTokenCursor(
+  goal: SessionGoal,
+  totalTokens: number,
+  options?: { resetStart?: boolean },
+): SessionGoal {
+  const normalizedTotal = normalizeTokenCount(totalTokens);
+  if (normalizedTotal === undefined) {
+    return cloneGoal(goal);
+  }
+  return {
+    ...goal,
+    ...(options?.resetStart ? { tokenStart: normalizedTotal } : {}),
+    tokenStartFresh: true,
+    tokenCursor: normalizedTotal,
+  };
+}
+
 function accountGoalUsage(
   entry: Pick<SessionEntry, "goal" | "totalTokens" | "totalTokensFresh" | "totalTokensVersion">,
   now: number,

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -290,6 +290,8 @@ export type SessionGoal = {
   updatedAt: number;
   tokenStart: number;
   tokenStartFresh?: boolean;
+  /** Latest comparable prompt/context snapshot used for incremental budget accounting. */
+  tokenCursor?: number;
   tokensUsed: number;
   tokenBudget?: number;
   continuationTurns: number;

--- a/src/tui/embedded-backend.test.ts
+++ b/src/tui/embedded-backend.test.ts
@@ -1126,7 +1126,6 @@ describe("EmbeddedTuiBackend", () => {
     expect(getSessionGoalMock).toHaveBeenCalledWith({
       sessionKey: "global",
       storePath: "/tmp/openclaw-work-sessions.json",
-      persist: false,
     });
   });
 

--- a/src/tui/embedded-backend.test.ts
+++ b/src/tui/embedded-backend.test.ts
@@ -1126,6 +1126,7 @@ describe("EmbeddedTuiBackend", () => {
     expect(getSessionGoalMock).toHaveBeenCalledWith({
       sessionKey: "global",
       storePath: "/tmp/openclaw-work-sessions.json",
+      persist: false,
     });
   });
 


### PR DESCRIPTION
## Summary

- start Goal token-budget accounting from the first fresh post-creation token snapshot instead of importing earlier session usage
- accumulate subsequent usage from a persisted cursor, rebasing safely across counter resets and saturating at safe-integer bounds
- advance Goal accounting from CLI session finalization while preserving concurrent durable Goal changes
- keep `/goal status` and `get_goal` projections read-only and align scoped/global session-store routing
- reject token budgets that are not positive safe integers

## What Problem This Solves

A new Goal could inherit cumulative token usage from before Goal creation. For example, a fresh post-creation snapshot could be compared with an older or stale creation-time value and immediately exhaust a new budget.

The session token total is a snapshot that can cross accounting epochs (including compaction/reset), so repeatedly subtracting one absolute `tokenStart` is not reliable.

## Approach

`SessionGoal` now carries an optional `tokenCursor`:

1. The first persisted fresh snapshot after Goal creation establishes `tokenStart` and `tokenCursor` with zero charged usage.
2. Later fresh snapshots add only positive deltas from the cursor.
3. Equal snapshots are idempotent; lower snapshots rebase the cursor without reducing accumulated usage.
4. Legacy Goals reconstruct a cursor from `tokenStart + tokensUsed` where safe.
5. Goal resume/reset opens a new accounting window at the current fresh snapshot when one is available.

CLI session finalization projects accounting after fresh usage metadata is assembled and before concurrent snapshot reconciliation, allowing compatible token metadata to advance without overwriting concurrent Goal edits, completion, replacement, or clearing.

## Regression coverage

- stale/missing creation baseline followed by fresh snapshots
- incremental charging (33,107 → 33,124 charges exactly 17)
- duplicate and decreasing snapshots
- safe-integer validation and saturation
- legacy Goal migration and resume charging
- read-only status/tool projections
- global and scoped session-store routing
- CLI persistence and concurrent durable Goal changes

## Evidence

- `src/agents/command/session-store.test.ts` + `src/agents/tools/goal-tools.test.ts`: 67 passed
- `src/config/sessions/goals.test.ts`: 19 passed
- `src/tui/embedded-backend.test.ts`: 60 passed
- `src/auto-reply/reply/commands-goal.test.ts`: 10 passed
- `oxfmt --check`: passed
- type-aware `oxlint --deny-warnings`: 0 warnings/errors
- core `tsgo`: passed
- `git diff --check`: passed

## Scope

This is intentionally limited to Goal accounting and its persistence/status surfaces. It does not change global context/token limits or redesign session usage accounting.

## Redacted live behavior proof

An isolated live session was exercised against a deployed patched OpenClaw `2026.7.1-2` runtime implementing this accounting path. Identifiers, local paths, endpoints, and deployment hashes are omitted. This demonstrates the after-fix behavior; it does not claim that this PR head is already shipped upstream.

```text
Goal created after the session already had historical usage:
  session totalTokens: 32987 (fresh)
  Goal tokenStart: 0
  Goal tokenStartFresh: false
  Goal tokensUsed: 0
  Goal tokenBudget: 30000

First fresh post-creation snapshot:
  session totalTokens: 33110
  Goal tokenStart: 33110
  Goal tokenCursor: 33110
  Goal tokensUsed: 0

Next fresh snapshot:
  session totalTokens: 33133
  Goal tokenCursor: 33133
  Goal tokensUsed: 23
  observed charge: 33133 - 33110 = 23

Later fresh process readback:
  session totalTokens: 33339
  Goal tokenStart: 33110
  Goal tokenCursor: 33339
  Goal tokensUsed: 229
  cumulative charge: 33339 - 33110 = 229
```

The same acceptance also verified:

- `/goal status` and `get_goal` returned the same accounting state.
- Direct read-only status calls left the persisted Goal unchanged before vs. after the calls.
- A separate process reread the same persisted `tokenStart`, `tokenCursor`, and `tokensUsed` values.
- Focused regression tests cover legacy cursor reconstruction/resume behavior and concurrent durable Goal replacement/completion/clear preservation; the live transcript above specifically proves post-creation baselining and later delta charging.

