### PR TITLE
fix(browser): show page-share failures immediately when the relay disconnects

### DIFF
--- a/extensions/browser/chrome-extension/background.js
+++ b/extensions/browser/chrome-extension/background.js
@@ -4,6 +4,7 @@ import {
   capturePageShare,
   waitForCondition,
 } from "./modules/page-share-core.js";
+import { createPageShareRelay } from "./modules/page-share-relay.js";
 // OpenClaw extension service worker.
 //
 // Thin transport between the OpenClaw extension relay (loopback WebSocket) and
@@ -55,10 +56,19 @@ const attachingTabs = new Map();
 const copilotRevocations = new Map();
 /** Debounce handle for tab-list refreshes. */
 let tabsSyncTimer = null;
-let nextPageShareRequestId = 1;
 let pageShareBadgeTimer = null;
-/** @type {Map<number, {resolve: (value: void) => void, reject: (error: Error) => void, timer: ReturnType<typeof setTimeout>}>} */
-const pendingPageShares = new Map();
+const pageShareRelay = createPageShareRelay();
+
+function closeRelaySocket() {
+  const socket = relayWs;
+  if (!socket) {
+    return;
+  }
+  // Chrome completes close asynchronously; fail pending requests before the
+  // handshake so pairing and unpairing never leave a popup stuck on Sending.
+  pageShareRelay.rejectSocket(socket);
+  socket.close();
+}
 
 function setBadge(kind) {
   relayState = kind;
@@ -463,21 +473,13 @@ async function connectRelay() {
       return;
     }
     if (msg?.type === "pageShareResult") {
-      const pending = pendingPageShares.get(msg.requestId);
-      if (pending) {
-        pendingPageShares.delete(msg.requestId);
-        clearTimeout(pending.timer);
-        if (msg.ok) {
-          pending.resolve();
-        } else {
-          pending.reject(new Error(msg.error || "Page share failed."));
-        }
-      }
+      pageShareRelay.settle(ws, msg);
       return;
     }
     void handleRelayCommand(msg);
   });
   ws.addEventListener("close", () => {
+    pageShareRelay.rejectSocket(ws);
     if (relayWs === ws) {
       clearRelayOpeningDeadline();
       relayWs = null;
@@ -489,24 +491,11 @@ async function connectRelay() {
 }
 
 async function sendPageShareRequest(payload) {
-  if (!relayWs || relayWs.readyState !== WebSocket.OPEN) {
+  const socket = relayWs;
+  if (!socket || socket.readyState !== WebSocket.OPEN) {
     throw new Error("Relay not connected.");
   }
-  const requestId = nextPageShareRequestId++;
-  return await new Promise((resolve, reject) => {
-    const timer = setTimeout(() => {
-      pendingPageShares.delete(requestId);
-      reject(new Error("Timed out waiting for OpenClaw."));
-    }, 10_000);
-    pendingPageShares.set(requestId, { resolve, reject, timer });
-    try {
-      relayWs.send(JSON.stringify({ type: "pageShare", requestId, payload }));
-    } catch (error) {
-      pendingPageShares.delete(requestId);
-      clearTimeout(timer);
-      reject(error instanceof Error ? error : new Error(String(error)));
-    }
-  });
+  await pageShareRelay.send(socket, payload);
 }
 
 async function ensureRelayReady() {
@@ -659,7 +648,7 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
         });
         reconnectAttempt = 0;
         clearRelayOpeningDeadline();
-        relayWs?.close();
+        closeRelaySocket();
         relayWs = null;
         await chrome.storage.local.set({ gatewayUrl: parsed.gatewayUrl ?? "" });
         await connectRelay();
@@ -670,7 +659,7 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
       case "unpair": {
         await chrome.storage.local.remove(["relayUrl", "gatewayUrl", "token"]);
         clearRelayOpeningDeadline();
-        relayWs?.close();
+        closeRelaySocket();
         relayWs = null;
         setBadge("off");
         await copilot.refreshConfig();

--- a/extensions/browser/chrome-extension/background.test.ts
+++ b/extensions/browser/chrome-extension/background.test.ts
@@ -7,12 +7,18 @@ const START_TIME_MS = Date.parse("2026-07-16T08:00:00.000Z");
 type SocketEvent = { data?: unknown };
 type SocketListener = (event: SocketEvent) => void;
 type RuntimeMessageListener = (
-  message: { type: string; tabId?: number },
+  message: { type: string; tabId?: number; note?: string; pairingString?: string },
   sender: unknown,
   sendResponse: (response: unknown) => void,
 ) => boolean;
+type PageCaptureResult = {
+  content: string;
+  selection: string;
+  title: string;
+  url: string;
+};
 
-async function loadBackground() {
+async function loadBackground({ deferSocketClose = false }: { deferSocketClose?: boolean } = {}) {
   const sockets: FakeWebSocket[] = [];
   let alarmListener: ((alarm: { name: string }) => void) | undefined;
   let messageListener: RuntimeMessageListener | undefined;
@@ -26,6 +32,10 @@ async function loadBackground() {
     readyState = FakeWebSocket.CONNECTING;
     readonly send = vi.fn();
     readonly close = vi.fn(() => {
+      if (deferSocketClose) {
+        this.readyState = FakeWebSocket.CLOSING;
+        return;
+      }
       this.readyState = FakeWebSocket.CLOSED;
       this.emit("close");
     });
@@ -47,6 +57,10 @@ async function loadBackground() {
     open() {
       this.readyState = FakeWebSocket.OPEN;
       this.emit("open");
+    }
+
+    receive(message: unknown) {
+      this.emit("message", { data: JSON.stringify(message) });
     }
 
     private emit(type: string, event: SocketEvent = {}) {
@@ -112,7 +126,9 @@ async function loadBackground() {
         set: vi.fn(async () => undefined),
       },
     },
-    scripting: { executeScript: vi.fn(async () => []) },
+    scripting: {
+      executeScript: vi.fn(async (): Promise<Array<{ result: PageCaptureResult }>> => []),
+    },
     tabGroups: {
       query: vi.fn(async () => []),
       update: vi.fn(async () => undefined),
@@ -153,11 +169,46 @@ async function loadBackground() {
     alarmListener,
     clearAlarm,
     createAlarm,
+    executeScript: chromeMock.scripting.executeScript,
     messageListener,
     setBadgeText,
     sockets,
     tabsGet: chromeMock.tabs.get,
   };
+}
+
+async function startPendingPageShare(
+  harness: Awaited<ReturnType<typeof loadBackground>>,
+  socket = harness.sockets.at(-1),
+) {
+  if (!socket) {
+    throw new Error("expected the page-share relay socket");
+  }
+  if (socket.readyState !== 1) {
+    socket.open();
+  }
+  harness.executeScript.mockResolvedValueOnce([
+    {
+      result: {
+        url: "https://example.com/article",
+        title: "Example article",
+        selection: "",
+        content: "Article body",
+      },
+    },
+  ]);
+  const response = vi.fn();
+  expect(harness.messageListener({ type: "sendPageToOpenClaw", tabId: 1 }, {}, response)).toBe(
+    true,
+  );
+  await vi.waitFor(() => {
+    expect(socket.send.mock.calls.some(([raw]) => JSON.parse(raw).type === "pageShare")).toBe(true);
+  });
+  const raw = socket.send.mock.calls.find(([frame]) => JSON.parse(frame).type === "pageShare")?.[0];
+  if (typeof raw !== "string") {
+    throw new Error("expected a sent page-share request");
+  }
+  return { socket, response, requestId: (JSON.parse(raw) as { requestId: number }).requestId };
 }
 
 describe("relay opening deadline", () => {
@@ -255,5 +306,149 @@ describe("copilot panel messaging", () => {
       ok: true,
       path: expect.stringMatching(/^sidepanel\.html\?binding=/),
     });
+  });
+});
+
+describe("page-share relay request lifecycle", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("immediately rejects a page share when its owning relay disconnects", async () => {
+    const harness = await loadBackground();
+    const pending = await startPendingPageShare(harness);
+
+    pending.socket.close();
+
+    await vi.waitFor(() => {
+      expect(pending.response).toHaveBeenCalledWith({
+        ok: false,
+        error: "Browser relay disconnected before OpenClaw acknowledged the page share.",
+      });
+    });
+    expect(pending.response).toHaveBeenCalledOnce();
+  });
+
+  it("immediately rejects a page share when the user unpairs the relay", async () => {
+    const harness = await loadBackground({ deferSocketClose: true });
+    const pending = await startPendingPageShare(harness);
+    const unpairResponse = vi.fn();
+
+    expect(harness.messageListener({ type: "unpair" }, {}, unpairResponse)).toBe(true);
+
+    await vi.waitFor(() => {
+      expect(unpairResponse).toHaveBeenCalledWith({ ok: true });
+      expect(pending.response).toHaveBeenCalledWith({
+        ok: false,
+        error: "Browser relay disconnected before OpenClaw acknowledged the page share.",
+      });
+    });
+    expect(pending.socket.close).toHaveBeenCalledOnce();
+    expect(pending.socket.readyState).toBe(2);
+    expect(pending.response).toHaveBeenCalledOnce();
+  });
+
+  it("rejects old page shares before a replacement relay finishes closing", async () => {
+    const harness = await loadBackground({ deferSocketClose: true });
+    const pending = await startPendingPageShare(harness);
+    const pairResponse = vi.fn();
+
+    expect(
+      harness.messageListener(
+        {
+          type: "pair",
+          pairingString: "ws://127.0.0.1:18798/extension#replacement-token-placeholder",
+        },
+        {},
+        pairResponse,
+      ),
+    ).toBe(true);
+
+    await vi.waitFor(() => {
+      expect(pairResponse).toHaveBeenCalledWith({ ok: true });
+      expect(pending.response).toHaveBeenCalledWith({
+        ok: false,
+        error: "Browser relay disconnected before OpenClaw acknowledged the page share.",
+      });
+    });
+    expect(pending.socket.close).toHaveBeenCalledOnce();
+    expect(pending.socket.readyState).toBe(2);
+    expect(harness.sockets).toHaveLength(2);
+    expect(pending.response).toHaveBeenCalledOnce();
+  });
+
+  it("preserves the acknowledgement from the page share's own relay", async () => {
+    const harness = await loadBackground();
+    const pending = await startPendingPageShare(harness);
+
+    pending.socket.receive({ type: "pageShareResult", requestId: pending.requestId, ok: true });
+
+    await vi.waitFor(() => {
+      expect(pending.response).toHaveBeenCalledWith({ ok: true });
+    });
+    pending.socket.close();
+    expect(pending.response).toHaveBeenCalledOnce();
+  });
+
+  it("preserves the delivery error returned by the page share's own relay", async () => {
+    const harness = await loadBackground();
+    const pending = await startPendingPageShare(harness);
+
+    pending.socket.receive({
+      type: "pageShareResult",
+      requestId: pending.requestId,
+      ok: false,
+      error: "Gateway page-share queue unavailable.",
+    });
+
+    await vi.waitFor(() => {
+      expect(pending.response).toHaveBeenCalledWith({
+        ok: false,
+        error: "Gateway page-share queue unavailable.",
+      });
+    });
+    pending.socket.close();
+    expect(pending.response).toHaveBeenCalledOnce();
+  });
+
+  it("does not let a stale socket reject a share on the reconnected relay", async () => {
+    const harness = await loadBackground();
+    const original = await startPendingPageShare(harness);
+
+    original.socket.close();
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(harness.sockets).toHaveLength(2);
+    const replacement = await startPendingPageShare(harness);
+
+    original.socket.receive({
+      type: "pageShareResult",
+      requestId: replacement.requestId,
+      ok: false,
+      error: "Stale relay response.",
+    });
+    original.socket.close();
+    expect(replacement.response).not.toHaveBeenCalled();
+
+    replacement.socket.receive({
+      type: "pageShareResult",
+      requestId: replacement.requestId,
+      ok: true,
+    });
+
+    await vi.waitFor(() => {
+      expect(original.response).toHaveBeenCalledWith({
+        ok: false,
+        error: "Browser relay disconnected before OpenClaw acknowledged the page share.",
+      });
+      expect(replacement.response).toHaveBeenCalledWith({ ok: true });
+    });
+    expect(original.response).toHaveBeenCalledOnce();
+    expect(replacement.response).toHaveBeenCalledOnce();
   });
 });

--- a/extensions/browser/chrome-extension/modules/page-share-relay.d.ts
+++ b/extensions/browser/chrome-extension/modules/page-share-relay.d.ts
@@ -1,0 +1,15 @@
+import type { PageSharePayload } from "./page-share-core.js";
+
+export type PageShareRelayResult = {
+  requestId: number;
+  ok: boolean;
+  error?: string;
+};
+
+export type PageShareRelay = {
+  rejectSocket(socket: WebSocket): void;
+  send(socket: WebSocket, payload: PageSharePayload): Promise<void>;
+  settle(socket: WebSocket, result: PageShareRelayResult): void;
+};
+
+export function createPageShareRelay(): PageShareRelay;

--- a/extensions/browser/chrome-extension/modules/page-share-relay.js
+++ b/extensions/browser/chrome-extension/modules/page-share-relay.js
@@ -1,0 +1,56 @@
+const PAGE_SHARE_TIMEOUT_MS = 10_000;
+const PAGE_SHARE_DISCONNECTED_ERROR =
+  "Browser relay disconnected before OpenClaw acknowledged the page share.";
+
+export function createPageShareRelay() {
+  let nextRequestId = 1;
+  /** @type {Map<number, {socket: WebSocket, resolve: (value: void) => void, reject: (error: Error) => void, timer: ReturnType<typeof setTimeout>}>} */
+  const pending = new Map();
+
+  function rejectSocket(socket) {
+    // Socket ownership prevents a late close from rejecting a request that
+    // belongs to a relay connection that has already replaced it.
+    for (const [requestId, request] of pending) {
+      if (request.socket !== socket) {
+        continue;
+      }
+      pending.delete(requestId);
+      clearTimeout(request.timer);
+      request.reject(new Error(PAGE_SHARE_DISCONNECTED_ERROR));
+    }
+  }
+
+  function settle(socket, result) {
+    const request = pending.get(result.requestId);
+    if (!request || request.socket !== socket) {
+      return;
+    }
+    pending.delete(result.requestId);
+    clearTimeout(request.timer);
+    if (result.ok) {
+      request.resolve();
+    } else {
+      request.reject(new Error(result.error || "Page share failed."));
+    }
+  }
+
+  function send(socket, payload) {
+    const requestId = nextRequestId++;
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        pending.delete(requestId);
+        reject(new Error("Timed out waiting for OpenClaw."));
+      }, PAGE_SHARE_TIMEOUT_MS);
+      pending.set(requestId, { socket, resolve, reject, timer });
+      try {
+        socket.send(JSON.stringify({ type: "pageShare", requestId, payload }));
+      } catch (error) {
+        pending.delete(requestId);
+        clearTimeout(timer);
+        reject(error instanceof Error ? error : new Error(String(error)));
+      }
+    });
+  }
+
+  return { rejectSocket, send, settle };
+}

--- a/extensions/browser/chrome-extension/page-share.e2e.test.ts
+++ b/extensions/browser/chrome-extension/page-share.e2e.test.ts
@@ -1,0 +1,306 @@
+import { createServer, type Server } from "node:http";
+import { chromium, type CDPSession } from "playwright-core";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  startExtensionRelayServer,
+  type ExtensionRelayHandle,
+} from "../src/browser/extension-relay/relay-server.js";
+import { useAutoCleanupTempDirTracker } from "../test-support.js";
+import { copyCopilotSidepanelExtension } from "./sidepanel.e2e-support.js";
+
+declare const chrome: {
+  runtime: {
+    sendMessage(message: Record<string, unknown>): Promise<{
+      ok?: boolean;
+      error?: string;
+    }>;
+  };
+  tabs: {
+    query(query: Record<string, unknown>): Promise<Array<{ id?: number; url?: string }>>;
+  };
+};
+
+const runE2E = process.env.OPENCLAW_BROWSER_COPILOT_E2E === "1";
+const cleanups: Array<() => Promise<void>> = [];
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+let nextPopupCommandId = 0;
+
+type ChromeTarget = { targetId: string; type: string; url: string };
+
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0).toReversed()) {
+    await cleanup().catch(() => undefined);
+  }
+});
+
+async function listen(server: Server): Promise<number> {
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("page-share test server did not bind a TCP port");
+  }
+  return address.port;
+}
+
+async function evaluateToolbarPopup<T>(
+  browserCdp: CDPSession,
+  sessionId: string,
+  expression: string,
+): Promise<T> {
+  const id = ++nextPopupCommandId;
+  let listener: ((event: { message: string; sessionId: string }) => void) | undefined;
+  const response = new Promise<Record<string, unknown>>((resolve, reject) => {
+    listener = (event) => {
+      if (event.sessionId !== sessionId) {
+        return;
+      }
+      const message = JSON.parse(event.message) as {
+        error?: { message?: string };
+        id?: number;
+        result?: Record<string, unknown>;
+      };
+      if (message.id !== id) {
+        return;
+      }
+      if (message.error) {
+        reject(new Error(message.error.message ?? "Chrome toolbar popup evaluation failed."));
+        return;
+      }
+      resolve(message.result ?? {});
+    };
+    browserCdp.on("Target.receivedMessageFromTarget", listener);
+  });
+
+  try {
+    await browserCdp.send("Target.sendMessageToTarget", {
+      sessionId,
+      message: JSON.stringify({
+        id,
+        method: "Runtime.evaluate",
+        params: { expression, awaitPromise: true, returnByValue: true },
+      }),
+    });
+    const result = await response;
+    const exception = result.exceptionDetails as { text?: string } | undefined;
+    if (exception) {
+      throw new Error(exception.text ?? "Chrome toolbar popup evaluation failed.");
+    }
+    return (result.result as { value?: T } | undefined)?.value as T;
+  } finally {
+    if (listener) {
+      browserCdp.off("Target.receivedMessageFromTarget", listener);
+    }
+  }
+}
+
+describe.runIf(runE2E)("Chrome page sharing with a real Gateway extension relay", () => {
+  it.each([
+    { label: "relay disconnection", unpair: false },
+    { label: "user unpair", unpair: true },
+  ])("immediately reports $label instead of leaving the popup sending", async ({ unpair }) => {
+    const receivedShares: Array<{ url: string; content: string }> = [];
+    let releaseDelivery: () => void = () => {};
+    const delivery = new Promise<void>((resolve) => {
+      releaseDelivery = resolve;
+    });
+    const relay = await startExtensionRelayServer({
+      port: 0,
+      token: "openclaw-autoqa-page-share-relay-placeholder",
+      onPageShare: async (payload) => {
+        receivedShares.push({ url: payload.url, content: payload.content });
+        await delivery;
+      },
+    });
+    let relayClosed = false;
+    const closeRelay = async (handle: ExtensionRelayHandle) => {
+      if (!relayClosed) {
+        relayClosed = true;
+        await handle.close();
+      }
+    };
+    cleanups.push(async () => {
+      releaseDelivery();
+      await closeRelay(relay);
+    });
+
+    const fixture = createServer((_request, response) => {
+      response.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
+      response.end(
+        "<!doctype html><title>Page-share relay article</title><main>Page-share relay article body.</main>",
+      );
+    });
+    const fixturePort = await listen(fixture);
+    cleanups.push(
+      async () =>
+        await new Promise<void>((resolve, reject) => {
+          fixture.close((error) => (error ? reject(error) : resolve()));
+        }),
+    );
+
+    const unpackedExtension = await copyCopilotSidepanelExtension(tempDirs);
+    const context = await chromium.launchPersistentContext(
+      tempDirs.make("openclaw-page-share-disconnect-profile-"),
+      {
+        channel: "chromium",
+        headless: true,
+        args: [
+          "--enable-unsafe-extension-debugging",
+          `--disable-extensions-except=${unpackedExtension}`,
+          `--load-extension=${unpackedExtension}`,
+        ],
+      },
+    );
+    cleanups.push(async () => await context.close());
+
+    const browser = context.browser();
+    if (!browser) {
+      throw new Error("Chromium browser connection unavailable");
+    }
+    const browserCdp = await browser.newBrowserCDPSession();
+    const worker = context.serviceWorkers()[0] ?? (await context.waitForEvent("serviceworker"));
+    const extensionId = new URL(worker.url()).hostname;
+    const pairingPage = context.pages()[0] ?? (await context.newPage());
+    await pairingPage.goto(`chrome-extension://${extensionId}/popup.html`);
+
+    const pairing = await pairingPage.evaluate(
+      async (pairingString) => await chrome.runtime.sendMessage({ type: "pair", pairingString }),
+      `ws://127.0.0.1:${relay.port}/extension#${relay.token}`,
+    );
+    expect(pairing).toEqual({ ok: true });
+    await expect.poll(() => relay.bridge.extensionConnected, { timeout: 10_000 }).toBe(true);
+
+    const article = await context.newPage();
+    await article.goto(`http://127.0.0.1:${fixturePort}/article`);
+    const articleTabId = await worker.evaluate(async (expectedUrl) => {
+      const tabs = await chrome.tabs.query({});
+      const articleTab = tabs.find((tab) => tab.url === expectedUrl);
+      if (typeof articleTab?.id !== "number") {
+        throw new Error("Chrome did not expose the page-share article tab");
+      }
+      return articleTab.id;
+    }, article.url());
+
+    await article.bringToFront();
+    const prior = (await browserCdp.send("Target.getTargets", {
+      filter: [{}],
+    })) as { targetInfos: ChromeTarget[] };
+    const articleTarget = prior.targetInfos.find(
+      (target) => target.type === "tab" && target.url === article.url(),
+    );
+    if (!articleTarget) {
+      throw new Error("Chromium did not expose the actual page-share article tab target");
+    }
+    const priorTargetIds = new Set(prior.targetInfos.map((target) => target.targetId));
+
+    // CDP invokes the actual toolbar action, including Chrome's activeTab
+    // consent grant; navigating popup.html directly cannot grant page access.
+    await browserCdp.send("Extensions.triggerAction", {
+      id: extensionId,
+      targetId: articleTarget.targetId,
+    });
+
+    await expect
+      .poll(
+        async () => {
+          const targets = (await browserCdp.send("Target.getTargets", {
+            filter: [{}],
+          })) as { targetInfos: ChromeTarget[] };
+          return targets.targetInfos.find(
+            (target) =>
+              !priorTargetIds.has(target.targetId) &&
+              target.url === `chrome-extension://${extensionId}/popup.html`,
+          );
+        },
+        { timeout: 10_000 },
+      )
+      .toBeTruthy();
+
+    const targets = (await browserCdp.send("Target.getTargets", {
+      filter: [{}],
+    })) as { targetInfos: ChromeTarget[] };
+    const popupTarget = targets.targetInfos.find(
+      (target) =>
+        !priorTargetIds.has(target.targetId) &&
+        target.url === `chrome-extension://${extensionId}/popup.html`,
+    );
+    if (!popupTarget) {
+      throw new Error("Chromium did not open the actual OpenClaw toolbar popup");
+    }
+    const attached = (await browserCdp.send("Target.attachToTarget", {
+      targetId: popupTarget.targetId,
+      flatten: false,
+    })) as { sessionId: string };
+
+    await expect
+      .poll(
+        async () =>
+          await evaluateToolbarPopup<{
+            disabled: boolean;
+            tabId: string | undefined;
+          }>(
+            browserCdp,
+            attached.sessionId,
+            '({ disabled: document.querySelector("#sendPageButton")?.disabled, tabId: document.querySelector("#sendPageButton")?.dataset.tabId })',
+          ),
+        { timeout: 10_000 },
+      )
+      .toEqual({ disabled: false, tabId: String(articleTabId) });
+
+    await evaluateToolbarPopup<void>(
+      browserCdp,
+      attached.sessionId,
+      'document.querySelector("#sendPageButton").click()',
+    );
+
+    await expect
+      .poll(
+        async () => ({
+          receivedShares: receivedShares.length,
+          popupStatus: await evaluateToolbarPopup<string>(
+            browserCdp,
+            attached.sessionId,
+            'document.querySelector("#pageShareStatus")?.textContent',
+          ),
+        }),
+        { timeout: 10_000 },
+      )
+      .toEqual({ receivedShares: 1, popupStatus: "Sending…" });
+    expect(receivedShares[0]).toEqual({
+      url: article.url(),
+      content: "Page-share relay article body.",
+    });
+
+    if (unpair) {
+      await evaluateToolbarPopup<void>(
+        browserCdp,
+        attached.sessionId,
+        'document.querySelector("#unpairButton").click()',
+      );
+    } else {
+      await closeRelay(relay);
+    }
+
+    await expect
+      .poll(
+        async () =>
+          await evaluateToolbarPopup<string>(
+            browserCdp,
+            attached.sessionId,
+            'document.querySelector("#pageShareStatus")?.textContent',
+          ),
+        { timeout: 1_500, interval: 25 },
+      )
+      .toBe("Browser relay disconnected before OpenClaw acknowledged the page share.");
+    expect(
+      await evaluateToolbarPopup<boolean>(
+        browserCdp,
+        attached.sessionId,
+        'document.querySelector("#pageShareStatus")?.classList.contains("error")',
+      ),
+    ).toBe(true);
+    releaseDelivery();
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users sending a page to OpenClaw from the Chrome extension would remain stuck on `Sending…` when the authenticated browser relay disconnected, was unpaired, or was replaced before acknowledging the share. A stale relay could also incorrectly settle a page share started on its replacement.

## Why This Change Was Made

Give page-share requests one canonical socket-owned lifecycle. Bind every pending request and timeout to the exact WebSocket that sent it, reject its requests before asynchronous pair/unpair closure and on remote disconnect, and ignore acknowledgments or close events from stale sockets. Extract the lifecycle into a small, typed browser-extension module so the existing background worker becomes smaller rather than growing or requiring a max-lines suppression.

## User Impact

The real extension toolbar promptly displays the existing actionable disconnect error instead of continuing to show `Sending…`. Normal page delivery, gateway-provided rejection messages, relay reconnection, copilot sidepanel behavior, extension permissions, and the shipped manifest remain unchanged.

## Evidence

- Reproduced the failure on exact `main` commit `a1cc41acbcdd285a7cdb423bdfe45ef06b2f97cb`, using the repository-pinned Playwright and real Chrome for Testing 149.0.7827.55 with an installed unpacked Manifest V3 extension and persistent browser profile.
- Triggered Chrome's genuine extension toolbar action and `activeTab` grant, extracted an actual served article, observed the actual page-share frame arrive at the authenticated production Gateway relay, and then disconnected the real relay socket. Before the fix the real popup remained at `Sending…`; after the fix it immediately reports `Browser relay disconnected before OpenClaw acknowledged the page share.`
- Independently reproduced actual asynchronous `WebSocket.CLOSING` failures for both re-pair and user-initiated unpair before fixing the socket lifecycle at its owner boundary.
- **117/117 tests passed** across 16 browser-extension and production Gateway relay files, including **4/4 actual persistent-Chromium E2E tests** covering native-toolbar relay disconnect, native-toolbar user unpair, missing-tab sidepanel handling, and multi-tab copilot consent/session isolation.
- Full remote repo-native changed gate passed for all five changed files: formatting, production and test `tsgo`, lint, max-lines ratchet, SDK and plugin-boundary guards, DB-first guards, and zero runtime import cycles.
- AI-assisted; fresh independent repository-native review reports no actionable findings, and the secret scan is clean.
- No changes to the manifest, permissions, sidepanel production code, configuration, database, or fallback behavior.
