### PR TITLE
fix: list every cron job from one consistent Gateway snapshot

### DIFF
--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -36,6 +36,17 @@ const defaultGatewayMock = async (
   if (method === "cron.status") {
     return { enabled: true };
   }
+  if (method === "cron.list") {
+    return {
+      jobs: [],
+      snapshotRevision: "test-empty-cron-inventory",
+      total: 0,
+      offset: 0,
+      limit: 200,
+      hasMore: false,
+      nextOffset: null,
+    };
+  }
   return { ok: true, params };
 };
 callGatewayFromCli.mockImplementation(defaultGatewayMock);
@@ -899,14 +910,19 @@ describe("cron cli", () => {
     await runCronCommand(["cron", "list"]);
 
     const listCall = callGatewayFromCli.mock.calls.find((call) => call[0] === "cron.list");
-    expect(listCall?.[2]).toEqual({ includeDisabled: false });
+    expect(listCall?.[2]).toEqual({ includeDisabled: false, limit: 200, offset: 0 });
   });
 
   it("sends normalized agent id on cron list --agent", async () => {
     await runCronCommand(["cron", "list", "--agent", " Ops "]);
 
     const listCall = callGatewayFromCli.mock.calls.find((call) => call[0] === "cron.list");
-    expect(listCall?.[2]).toEqual({ includeDisabled: false, agentId: "ops" });
+    expect(listCall?.[2]).toEqual({
+      includeDisabled: false,
+      agentId: "ops",
+      limit: 200,
+      offset: 0,
+    });
   });
 
   it("routes cron get to cron.get with the provided id", async () => {
@@ -938,7 +954,13 @@ describe("cron cli", () => {
           const offset = (params as { offset?: number }).offset ?? 0;
           if (offset === 0) {
             return {
-              jobs: [createCronJob("first-page", "First Page")],
+              jobs: Array.from({ length: 200 }, (_, index) =>
+                createCronJob(`first-page-${index}`, `First Page ${index}`),
+              ),
+              snapshotRevision: "test-stable-cron-show-inventory",
+              total: 201,
+              offset: 0,
+              limit: 200,
               hasMore: true,
               nextOffset: 200,
             };
@@ -947,6 +969,10 @@ describe("cron cli", () => {
           targetJob.state.lastDiagnosticSummary = "exec stderr tail";
           return {
             jobs: [targetJob],
+            snapshotRevision: "test-stable-cron-show-inventory",
+            total: 201,
+            offset: 200,
+            limit: 200,
             hasMore: false,
             nextOffset: null,
             deliveryPreviews: {

--- a/src/cli/cron-cli/cron-pagination.gateway.test.ts
+++ b/src/cli/cron-cli/cron-pagination.gateway.test.ts
@@ -1,0 +1,509 @@
+// Cron CLI pagination exercises real Gateway handlers and canonical cron snapshots.
+import { expectDefined } from "@openclaw/normalization-core";
+import { Command } from "commander";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createMockCronStateForJobs } from "../../cron/service.test-harness.js";
+import { listPage } from "../../cron/service/ops.js";
+import type { CronJob } from "../../cron/types.js";
+import { cronHandlers } from "../../gateway/server-methods/cron.js";
+
+const mocks = vi.hoisted(() => {
+  const runtime = {
+    log: vi.fn(),
+    error: vi.fn(),
+    writeStdout: vi.fn(),
+    writeJson: vi.fn(),
+    exit: vi.fn((code: number) => {
+      throw new Error(`exit ${code}`);
+    }),
+  };
+  return { runtime, callGatewayFromCli: vi.fn() };
+});
+
+vi.mock("../gateway-rpc.js", async () => {
+  const actual = await vi.importActual<typeof import("../gateway-rpc.js")>("../gateway-rpc.js");
+  return {
+    ...actual,
+    callGatewayFromCli: (...args: Parameters<typeof actual.callGatewayFromCli>) =>
+      mocks.callGatewayFromCli(...args),
+  };
+});
+
+vi.mock("../../runtime.js", () => ({ defaultRuntime: mocks.runtime }));
+
+const { registerCronCli } = await import("../cron-cli.js");
+
+function createJob(index: number, overrides: Partial<CronJob> = {}): CronJob {
+  return {
+    id: `job-${String(index).padStart(3, "0")}`,
+    name: `Job ${String(index).padStart(3, "0")}`,
+    enabled: true,
+    createdAtMs: index,
+    updatedAtMs: index,
+    schedule: { kind: "every", everyMs: 60_000 },
+    sessionTarget: "main",
+    wakeMode: "next-heartbeat",
+    payload: { kind: "systemEvent", text: "scheduled check" },
+    state: { nextRunAtMs: index + 1 },
+    ...overrides,
+  };
+}
+
+function installRealCronGateway(
+  jobs: CronJob[],
+  options: {
+    beforeList?: (params: Record<string, unknown>, listCall: number, jobs: CronJob[]) => void;
+    transformListPage?: (page: unknown, listCall: number) => unknown;
+  } = {},
+) {
+  const state = createMockCronStateForJobs({ jobs });
+  let listCalls = 0;
+  const cron = {
+    listPage: async (params: Parameters<typeof listPage>[1]) => {
+      listCalls += 1;
+      options.beforeList?.(
+        params ?? {},
+        listCalls,
+        expectDefined(state.store, "expected loaded canonical cron test store").jobs,
+      );
+      return await listPage(state, params);
+    },
+    readJob: async (id: string) =>
+      expectDefined(state.store, "expected loaded canonical cron test store").jobs.find(
+        (job) => job.id === id,
+      ),
+    getDefaultAgentId: () => "main",
+  };
+
+  mocks.callGatewayFromCli.mockImplementation(
+    async (method: string, _options: unknown, params: Record<string, unknown> = {}) => {
+      const handler = expectDefined(cronHandlers[method], `missing real Gateway method ${method}`);
+      let response:
+        | { ok: boolean; payload?: unknown; error?: { code?: string; message?: string } }
+        | undefined;
+      await handler({
+        req: {} as never,
+        params,
+        respond: (ok: boolean, payload?: unknown, error?: { code?: string; message?: string }) => {
+          response = { ok, payload, error };
+        },
+        context: {
+          cron,
+          getRuntimeConfig: () => ({}),
+        } as never,
+      } as never);
+      const result = expectDefined(response, `${method} returned no Gateway response`);
+      if (!result.ok) {
+        throw Object.assign(new Error(result.error?.message ?? `${method} failed`), {
+          name: "GatewayClientRequestError",
+          gatewayCode: result.error?.code,
+        });
+      }
+      if (method === "cron.list" && options.transformListPage) {
+        return options.transformListPage(result.payload, listCalls);
+      }
+      return result.payload;
+    },
+  );
+  return state;
+}
+
+function disableCronGetForProtocolV4Gateway(): void {
+  const invokeGateway = expectDefined(
+    mocks.callGatewayFromCli.getMockImplementation(),
+    "expected installed real cron Gateway",
+  );
+  mocks.callGatewayFromCli.mockImplementation(async (...args: unknown[]) => {
+    if (args[0] === "cron.get") {
+      throw Object.assign(new Error("unknown method: cron.get"), {
+        name: "GatewayClientRequestError",
+        gatewayCode: "INVALID_REQUEST",
+      });
+    }
+    return await invokeGateway(...args);
+  });
+}
+
+async function runCron(args: string[]): Promise<void> {
+  const program = new Command();
+  program.exitOverride();
+  registerCronCli(program);
+  await program.parseAsync(["cron", ...args], { from: "user" });
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("cron CLI with the real Gateway pagination contract", () => {
+  it("lists all 201 jobs returned across actual bounded Gateway pages", async () => {
+    installRealCronGateway(Array.from({ length: 201 }, (_, index) => createJob(index)));
+
+    await runCron(["list", "--json"]);
+
+    const result = mocks.runtime.writeJson.mock.calls.at(-1)?.[0] as { jobs: CronJob[] };
+    expect(result.jobs).toHaveLength(201);
+    expect(result.jobs.some((job) => job.id === "job-200")).toBe(true);
+    expect(
+      (result as { deliveryPreviews?: Record<string, unknown> }).deliveryPreviews?.["job-200"],
+    ).toEqual(expect.objectContaining({ label: "not requested" }));
+    expect(
+      mocks.callGatewayFromCli.mock.calls.filter(([method]) => method === "cron.list"),
+    ).toHaveLength(2);
+  });
+
+  it("never combines Gateway pages from different cron snapshots", async () => {
+    const original = Array.from({ length: 201 }, (_, index) => createJob(index));
+    installRealCronGateway(original, {
+      beforeList(_params, call, jobs) {
+        if (call === 2) {
+          jobs[0] = createJob(900, { name: "Replacement after snapshot change" });
+        }
+      },
+    });
+
+    await runCron(["list", "--json"]);
+
+    const result = mocks.runtime.writeJson.mock.calls.at(-1)?.[0] as { jobs: CronJob[] };
+    expect(result.jobs).toHaveLength(201);
+    expect(result.jobs.some((job) => job.id === "job-900")).toBe(true);
+    expect(result.jobs.some((job) => job.id === "job-000")).toBe(false);
+    expect(
+      mocks.callGatewayFromCli.mock.calls
+        .filter(([method]) => method === "cron.list")
+        .map((call) => (call[2] as { offset?: number }).offset),
+    ).toEqual([0, 200, 0, 200]);
+  });
+
+  it("restarts when a shrinking Gateway snapshot clamps the requested page offset", async () => {
+    installRealCronGateway(
+      Array.from({ length: 201 }, (_, index) => createJob(index)),
+      {
+        beforeList(_params, call, jobs) {
+          if (call === 2) {
+            jobs.splice(0, 2);
+          }
+        },
+      },
+    );
+
+    await runCron(["list", "--json"]);
+
+    const result = mocks.runtime.writeJson.mock.calls.at(-1)?.[0] as { jobs: CronJob[] };
+    expect(result.jobs).toHaveLength(199);
+    expect(result.jobs.some((job) => job.id === "job-000")).toBe(false);
+    expect(result.jobs.some((job) => job.id === "job-001")).toBe(false);
+    expect(
+      mocks.callGatewayFromCli.mock.calls
+        .filter(([method]) => method === "cron.list")
+        .map((call) => (call[2] as { offset?: number }).offset),
+    ).toEqual([0, 200, 0]);
+  });
+
+  it("detects and lists every job from a paginated protocol-v4 Gateway", async () => {
+    installRealCronGateway(
+      Array.from({ length: 201 }, (_, index) => createJob(index)),
+      {
+        transformListPage(page) {
+          const response = page as Record<string, unknown>;
+          return {
+            jobs: response.jobs,
+            hasMore: response.hasMore,
+            nextOffset: response.nextOffset,
+            deliveryPreviews: response.deliveryPreviews,
+          };
+        },
+      },
+    );
+    disableCronGetForProtocolV4Gateway();
+
+    await runCron(["list", "--json"]);
+
+    const result = mocks.runtime.writeJson.mock.calls.at(-1)?.[0] as { jobs: CronJob[] };
+    expect(result.jobs).toHaveLength(201);
+    expect(result.jobs.some((job) => job.id === "job-200")).toBe(true);
+    expect(mocks.callGatewayFromCli).toHaveBeenCalledWith("cron.get", expect.anything(), {
+      id: "job-000",
+    });
+    expect(
+      mocks.callGatewayFromCli.mock.calls.filter(([method]) => method === "cron.list"),
+    ).toHaveLength(2);
+  });
+
+  it.each([
+    { label: "empty", jobs: [] as CronJob[] },
+    { label: "single-job", jobs: [createJob(0)] },
+  ])("detects a $label terminal protocol-v4 inventory", async ({ jobs }) => {
+    installRealCronGateway(jobs, {
+      transformListPage(page) {
+        const response = page as Record<string, unknown>;
+        return {
+          jobs: response.jobs,
+          hasMore: response.hasMore,
+          nextOffset: response.nextOffset,
+          deliveryPreviews: response.deliveryPreviews,
+        };
+      },
+    });
+    disableCronGetForProtocolV4Gateway();
+
+    await runCron(["list", "--json"]);
+
+    const result = mocks.runtime.writeJson.mock.calls.at(-1)?.[0] as { jobs: CronJob[] };
+    expect(result.jobs).toHaveLength(jobs.length);
+    expect(mocks.callGatewayFromCli).toHaveBeenCalledWith(
+      "cron.get",
+      expect.anything(),
+      expect.objectContaining({ id: expect.any(String) }),
+    );
+  });
+
+  it("never combines protocol-v4 and canonical Gateway inventory pages", async () => {
+    installRealCronGateway(
+      Array.from({ length: 201 }, (_, index) => createJob(index)),
+      {
+        transformListPage(page, call) {
+          if (call % 2 === 0) {
+            return page;
+          }
+          const response = page as Record<string, unknown>;
+          return {
+            jobs: response.jobs,
+            hasMore: response.hasMore,
+            nextOffset: response.nextOffset,
+            deliveryPreviews: response.deliveryPreviews,
+          };
+        },
+      },
+    );
+    disableCronGetForProtocolV4Gateway();
+
+    await expect(runCron(["list", "--json"])).rejects.toThrow("exit 1");
+
+    expect(mocks.runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining("inventory changed repeatedly"),
+    );
+    expect(mocks.runtime.writeJson).not.toHaveBeenCalled();
+    expect(
+      mocks.callGatewayFromCli.mock.calls.filter(([method]) => method === "cron.list"),
+    ).toHaveLength(8);
+  });
+
+  it("renders cron jobs beyond the first Gateway page in normal table output", async () => {
+    installRealCronGateway(Array.from({ length: 201 }, (_, index) => createJob(index)));
+
+    await runCron(["list"]);
+
+    expect(mocks.runtime.log.mock.calls.some(([line]) => line.includes("Job 200"))).toBe(true);
+    expect(mocks.runtime.log).toHaveBeenCalledTimes(202);
+  });
+
+  it("fails closed when every cron inventory snapshot changes", async () => {
+    installRealCronGateway(
+      Array.from({ length: 201 }, (_, index) => createJob(index)),
+      {
+        beforeList(params, _call, jobs) {
+          if (params.offset === 200) {
+            const first = expectDefined(jobs[0], "expected first cron snapshot job");
+            jobs[0] = { ...first, updatedAtMs: first.updatedAtMs + 1 };
+          }
+        },
+      },
+    );
+
+    await expect(runCron(["list", "--json"])).rejects.toThrow("exit 1");
+
+    expect(mocks.runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining("inventory changed repeatedly"),
+    );
+    expect(mocks.runtime.writeJson).not.toHaveBeenCalled();
+    expect(
+      mocks.callGatewayFromCli.mock.calls.filter(([method]) => method === "cron.list"),
+    ).toHaveLength(8);
+  });
+
+  it.each([
+    {
+      label: "missing job rows",
+      corrupt: (page: Record<string, unknown>) => ({ ...page, jobs: undefined }),
+      error: "invalid inventory page",
+    },
+    {
+      label: "missing snapshot revision",
+      corrupt: (page: Record<string, unknown>) => ({ ...page, snapshotRevision: undefined }),
+      error: "invalid inventory page",
+    },
+    {
+      label: "a missing terminal cursor",
+      corrupt: (page: Record<string, unknown>) => ({ ...page, nextOffset: undefined }),
+      error: "invalid inventory page",
+    },
+    {
+      label: "a terminal page exceeding its declared job limit",
+      corrupt: (page: Record<string, unknown>) => ({
+        ...page,
+        jobs: Array.from({ length: 10_001 }, (_, index) => createJob(index)),
+        total: 10_001,
+        limit: 200,
+        hasMore: false,
+        nextOffset: null,
+      }),
+      error: "invalid inventory page",
+    },
+    {
+      label: "a truncated terminal page",
+      corrupt: (page: Record<string, unknown>) => ({ ...page, total: 2 }),
+      error: "inconsistent terminal inventory page",
+    },
+  ])("fails closed for $label", async ({ corrupt, error }) => {
+    installRealCronGateway([createJob(0)], {
+      transformListPage(page) {
+        return corrupt(page as Record<string, unknown>);
+      },
+    });
+
+    await expect(runCron(["list", "--json"])).rejects.toThrow("exit 1");
+
+    expect(mocks.runtime.error).toHaveBeenCalledWith(expect.stringContaining(error));
+    expect(mocks.runtime.writeJson).not.toHaveBeenCalled();
+  });
+
+  it("rejects unversioned multi-page responses from current Gateways", async () => {
+    installRealCronGateway(
+      Array.from({ length: 201 }, (_, index) => createJob(index)),
+      {
+        transformListPage(page) {
+          const response = page as Record<string, unknown>;
+          return {
+            jobs: response.jobs,
+            hasMore: response.hasMore,
+            nextOffset: response.nextOffset,
+          };
+        },
+      },
+    );
+
+    await expect(runCron(["list", "--json"])).rejects.toThrow("exit 1");
+
+    expect(mocks.runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining("invalid inventory page"),
+    );
+    expect(
+      mocks.callGatewayFromCli.mock.calls.filter(([method]) => method === "cron.list"),
+    ).toHaveLength(1);
+    expect(mocks.callGatewayFromCli).toHaveBeenCalledWith("cron.get", expect.anything(), {
+      id: "job-000",
+    });
+    expect(mocks.runtime.writeJson).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { label: "empty", jobs: [] as CronJob[] },
+    { label: "single-job", jobs: [createJob(0)] },
+  ])("rejects a $label unversioned terminal page from a current Gateway", async ({ jobs }) => {
+    installRealCronGateway(jobs, {
+      transformListPage(page) {
+        const response = page as Record<string, unknown>;
+        return {
+          jobs: response.jobs,
+          hasMore: response.hasMore,
+          nextOffset: response.nextOffset,
+        };
+      },
+    });
+
+    await expect(runCron(["list", "--json"])).rejects.toThrow("exit 1");
+
+    expect(mocks.runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining("invalid inventory page"),
+    );
+    expect(mocks.callGatewayFromCli).toHaveBeenCalledWith(
+      "cron.get",
+      expect.anything(),
+      expect.objectContaining({ id: expect.any(String) }),
+    );
+    expect(mocks.runtime.writeJson).not.toHaveBeenCalled();
+  });
+
+  it("stops a stable oversized cron inventory after the canonical page bound", async () => {
+    const jobs = Array.from({ length: 200 }, (_, index) => createJob(index));
+    mocks.callGatewayFromCli.mockImplementation(
+      async (method: string, _options: unknown, params: { offset?: number } = {}) => {
+        if (method !== "cron.list") {
+          throw new Error(`unexpected cron method: ${method}`);
+        }
+        const offset = params.offset ?? 0;
+        return {
+          jobs,
+          snapshotRevision: "stable-oversized-cron-inventory",
+          total: 10_001,
+          offset,
+          limit: 200,
+          hasMore: true,
+          nextOffset: offset + 200,
+        };
+      },
+    );
+
+    await expect(runCron(["list", "--json"])).rejects.toThrow("exit 1");
+
+    expect(mocks.runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining("pagination exceeded maximum pages"),
+    );
+    expect(mocks.callGatewayFromCli).toHaveBeenCalledTimes(50);
+    expect(mocks.runtime.writeJson).not.toHaveBeenCalled();
+  });
+
+  it("prefers a canonical cron.get ID over another job's identical name", async () => {
+    const nameCollision = createJob(0, { id: "name-owner", name: "job-200" });
+    const actualId = createJob(200, { id: "job-200", name: "Actual ID owner" });
+    installRealCronGateway([nameCollision, actualId]);
+
+    await runCron(["show", "job-200", "--json"]);
+
+    const result = mocks.runtime.writeJson.mock.calls.at(-1)?.[0] as CronJob;
+    expect(result.id).toBe("job-200");
+    expect(result.name).toBe("Actual ID owner");
+    expect(mocks.callGatewayFromCli).toHaveBeenCalledWith("cron.get", expect.anything(), {
+      id: "job-200",
+    });
+    expect(mocks.callGatewayFromCli.mock.calls.some(([method]) => method === "cron.list")).toBe(
+      false,
+    );
+  });
+
+  it("finds an exact cron job name beyond the first real Gateway page", async () => {
+    const jobs = Array.from({ length: 201 }, (_, index) => createJob(index));
+    jobs[200] = createJob(200, { name: "Last page exact job" });
+    installRealCronGateway(jobs);
+
+    await runCron(["show", "Last page exact job", "--json"]);
+
+    expect(mocks.runtime.writeJson).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "job-200", name: "Last page exact job" }),
+    );
+  });
+
+  it("never hides Gateway transport errors behind a name-based cron scan", async () => {
+    installRealCronGateway([createJob(0)]);
+    const invokeGateway = expectDefined(
+      mocks.callGatewayFromCli.getMockImplementation(),
+      "expected installed real cron Gateway",
+    );
+    mocks.callGatewayFromCli.mockImplementation(async (...args: unknown[]) => {
+      if (args[0] === "cron.get") {
+        throw new Error("Gateway transport is unavailable");
+      }
+      return await invokeGateway(...args);
+    });
+
+    await expect(runCron(["show", "job-000", "--json"])).rejects.toThrow("exit 1");
+
+    expect(mocks.runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining("Gateway transport is unavailable"),
+    );
+    expect(mocks.callGatewayFromCli.mock.calls.some(([method]) => method === "cron.list")).toBe(
+      false,
+    );
+  });
+});

--- a/src/cli/cron-cli/list-jobs.ts
+++ b/src/cli/cron-cli/list-jobs.ts
@@ -1,0 +1,244 @@
+// Canonical Gateway-backed cron inventory and exact-ID/name lookup.
+import { randomUUID } from "node:crypto";
+import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import type {
+  CronListPageOptions,
+  CronListPageResult,
+} from "../../cron/service/list-page-types.js";
+import type { CronDeliveryPreview, CronJob } from "../../cron/types.js";
+import type { GatewayRpcOpts } from "../gateway-rpc.js";
+import { callGatewayFromCli } from "../gateway-rpc.js";
+
+const CRON_LIST_PAGE_SIZE = 200;
+const CRON_LIST_MAX_PAGES = 50;
+const CRON_LIST_MAX_SNAPSHOT_RESTARTS = 3;
+
+type GatewayCronListPage = Partial<CronListPageResult> & {
+  deliveryPreviews?: Record<string, CronDeliveryPreview>;
+};
+
+export type GatewayCronJobInventory = GatewayCronListPage & {
+  jobs: CronJob[];
+  deliveryPreviews?: Record<string, CronDeliveryPreview>;
+};
+
+/** Recognize the explicit protocol-v4 capability boundary, not transport failures. */
+export function isUnknownCronGetMethodError(error: unknown): error is Error {
+  return (
+    error instanceof Error &&
+    error.name === "GatewayClientRequestError" &&
+    (error as Error & { gatewayCode?: unknown }).gatewayCode === "INVALID_REQUEST" &&
+    error.message.includes("unknown method: cron.get")
+  );
+}
+
+/** Read every bounded Gateway page from one complete cron inventory revision. */
+export async function listCronJobsFromGateway(
+  opts: GatewayRpcOpts,
+  filters: Pick<CronListPageOptions, "includeDisabled" | "agentId" | "query">,
+  options: { allowLegacyUnversionedPagination?: boolean } = {},
+): Promise<GatewayCronJobInventory> {
+  let allowLegacyUnversionedPagination = options.allowLegacyUnversionedPagination === true;
+  for (let restart = 0; restart <= CRON_LIST_MAX_SNAPSHOT_RESTARTS; restart += 1) {
+    let offset = 0;
+    let snapshotRevision: string | undefined;
+    let total: number | undefined;
+    let pageMetadataMode: "canonical" | "legacy" | undefined;
+    let firstPage: GatewayCronListPage | undefined;
+    let snapshotChanged = false;
+    const jobs: CronJob[] = [];
+    const deliveryPreviews: Record<string, CronDeliveryPreview> = {};
+
+    for (let pageNumber = 0; pageNumber < CRON_LIST_MAX_PAGES; pageNumber += 1) {
+      const page = (await callGatewayFromCli("cron.list", opts, {
+        ...filters,
+        limit: CRON_LIST_PAGE_SIZE,
+        offset,
+      })) as GatewayCronListPage | null;
+
+      const hasCanonicalMetadata =
+        page !== null &&
+        typeof page === "object" &&
+        (page.snapshotRevision !== undefined ||
+          page.total !== undefined ||
+          page.offset !== undefined ||
+          page.limit !== undefined);
+      if (
+        !page ||
+        typeof page !== "object" ||
+        !Array.isArray(page.jobs) ||
+        page.jobs.length > CRON_LIST_PAGE_SIZE ||
+        (page.snapshotRevision !== undefined &&
+          (typeof page.snapshotRevision !== "string" || page.snapshotRevision.length === 0)) ||
+        (page.total !== undefined &&
+          (typeof page.total !== "number" ||
+            !Number.isSafeInteger(page.total) ||
+            page.total < 0)) ||
+        (page.offset !== undefined &&
+          (typeof page.offset !== "number" ||
+            !Number.isSafeInteger(page.offset) ||
+            page.offset < 0)) ||
+        (page.limit !== undefined &&
+          (typeof page.limit !== "number" ||
+            !Number.isSafeInteger(page.limit) ||
+            page.limit < 1 ||
+            page.limit > CRON_LIST_PAGE_SIZE ||
+            page.jobs.length > page.limit)) ||
+        (page.hasMore !== undefined && typeof page.hasMore !== "boolean") ||
+        (hasCanonicalMetadata &&
+          (page.snapshotRevision === undefined ||
+            page.total === undefined ||
+            page.offset === undefined ||
+            page.limit === undefined ||
+            page.hasMore === undefined ||
+            page.nextOffset === undefined))
+      ) {
+        throw new Error("cron.list returned an invalid inventory page");
+      }
+
+      const currentMetadataMode = hasCanonicalMetadata ? "canonical" : "legacy";
+      if (pageMetadataMode !== undefined && pageMetadataMode !== currentMetadataMode) {
+        // Mixed-version Gateway routes cannot prove legacy rows belong to a
+        // later canonical snapshot, even when the apparent job total matches.
+        snapshotChanged = true;
+        break;
+      }
+
+      if (
+        (snapshotRevision !== undefined && page.snapshotRevision !== snapshotRevision) ||
+        (total !== undefined && page.total !== total)
+      ) {
+        // Offset pages are snapshots, not a live cursor. Discard the old rows
+        // and restart so scheduler churn cannot mix two different inventories.
+        snapshotChanged = true;
+        break;
+      }
+
+      if (page.offset !== undefined && page.offset !== offset) {
+        throw new Error("cron.list returned an invalid inventory page");
+      }
+
+      if (!hasCanonicalMetadata && !allowLegacyUnversionedPagination) {
+        const probeJob = page.jobs[0];
+        if (probeJob && (typeof probeJob.id !== "string" || probeJob.id.length === 0)) {
+          throw new Error("cron.list returned an invalid inventory page");
+        }
+        // Empty legacy inventories still need an explicit capability proof;
+        // a fresh nonempty ID avoids colliding with actual scheduled jobs.
+        const probeJobId = probeJob?.id ?? randomUUID();
+        try {
+          await callGatewayFromCli("cron.get", opts, { id: probeJobId });
+        } catch (error) {
+          if (isUnknownCronGetMethodError(error)) {
+            // Only an explicitly unsupported cron.get identifies a shipped v4
+            // Gateway; malformed modern pages must keep revision checks.
+            allowLegacyUnversionedPagination = true;
+          } else if (!isMissingCronGetError(error, probeJobId)) {
+            throw error;
+          }
+        }
+        if (!allowLegacyUnversionedPagination) {
+          throw new Error("cron.list returned an invalid inventory page");
+        }
+      }
+
+      pageMetadataMode ??= currentMetadataMode;
+      firstPage ??= page;
+      snapshotRevision ??= page.snapshotRevision;
+      total ??= page.total;
+      jobs.push(...page.jobs);
+      if (page.deliveryPreviews) {
+        Object.assign(deliveryPreviews, page.deliveryPreviews);
+      }
+
+      if (!page.hasMore) {
+        if (
+          (total !== undefined && jobs.length !== total) ||
+          (page.nextOffset !== undefined && page.nextOffset !== null)
+        ) {
+          throw new Error("cron.list returned an inconsistent terminal inventory page");
+        }
+        return {
+          ...firstPage,
+          jobs,
+          ...(Object.keys(deliveryPreviews).length > 0 ? { deliveryPreviews } : {}),
+          ...(total !== undefined ? { total } : {}),
+          ...(snapshotRevision !== undefined ? { snapshotRevision } : {}),
+          ...(firstPage.offset !== undefined ? { offset: firstPage.offset } : {}),
+          ...(firstPage.limit !== undefined ? { limit: firstPage.limit } : {}),
+          ...(firstPage.hasMore !== undefined ? { hasMore: false, nextOffset: null } : {}),
+        };
+      }
+
+      if (
+        typeof page.nextOffset !== "number" ||
+        !Number.isSafeInteger(page.nextOffset) ||
+        page.nextOffset <= offset ||
+        (total !== undefined && page.nextOffset !== offset + page.jobs.length)
+      ) {
+        throw new Error("cron.list pagination did not advance while looking up cron job");
+      }
+      offset = page.nextOffset;
+    }
+
+    if (!snapshotChanged) {
+      throw new Error("cron.list pagination exceeded maximum pages while looking up cron job");
+    }
+    if (restart === CRON_LIST_MAX_SNAPSHOT_RESTARTS) {
+      throw new Error("cron.list inventory changed repeatedly while reading cron jobs");
+    }
+  }
+
+  throw new Error("cron.list inventory changed repeatedly while reading cron jobs");
+}
+
+function isMissingCronGetError(error: unknown, id: string): error is Error {
+  return (
+    isUnknownCronGetMethodError(error) ||
+    (error instanceof Error &&
+      error.name === "GatewayClientRequestError" &&
+      (error as Error & { gatewayCode?: unknown }).gatewayCode === "INVALID_REQUEST" &&
+      error.message.includes(`cron job not found: ${id}`))
+  );
+}
+
+/** Resolve stable IDs before exact names without trusting page order. */
+export async function findCronJobByIdOrName(
+  opts: GatewayRpcOpts,
+  idOrName: string,
+  options: { includeDeliveryPreview?: boolean } = {},
+): Promise<{ job?: CronJob; deliveryPreview?: CronDeliveryPreview }> {
+  let allowLegacyUnversionedPagination = false;
+  try {
+    const directJob = (await callGatewayFromCli("cron.get", opts, { id: idOrName })) as
+      | CronJob
+      | undefined;
+    if (directJob?.id === idOrName) {
+      if (!options.includeDeliveryPreview) {
+        return { job: directJob };
+      }
+      const inventory = await listCronJobsFromGateway(opts, {
+        includeDisabled: true,
+        query: idOrName,
+      });
+      return { job: directJob, deliveryPreview: inventory.deliveryPreviews?.[directJob.id] };
+    }
+  } catch (error) {
+    if (!isMissingCronGetError(error, idOrName)) {
+      throw error;
+    }
+    // Only protocol-v4 Gateways lack both cron.get and revisioned pages.
+    allowLegacyUnversionedPagination = isUnknownCronGetMethodError(error);
+  }
+
+  const inventory = await listCronJobsFromGateway(
+    opts,
+    { includeDisabled: true },
+    { allowLegacyUnversionedPagination },
+  );
+  const needle = normalizeLowercaseStringOrEmpty(idOrName);
+  const job =
+    inventory.jobs.find((candidate) => normalizeLowercaseStringOrEmpty(candidate.id) === needle) ??
+    inventory.jobs.find((candidate) => normalizeLowercaseStringOrEmpty(candidate.name) === needle);
+  return { job, deliveryPreview: job ? inventory.deliveryPreviews?.[job.id] : undefined };
+}

--- a/src/cli/cron-cli/list-jobs.ts
+++ b/src/cli/cron-cli/list-jobs.ts
@@ -17,7 +17,7 @@ type GatewayCronListPage = Partial<CronListPageResult> & {
   deliveryPreviews?: Record<string, CronDeliveryPreview>;
 };
 
-export type GatewayCronJobInventory = GatewayCronListPage & {
+type GatewayCronJobInventory = GatewayCronListPage & {
   jobs: CronJob[];
   deliveryPreviews?: Record<string, CronDeliveryPreview>;
 };

--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -12,6 +12,7 @@ import { defaultRuntime } from "../../runtime.js";
 import type { GatewayRpcOpts } from "../gateway-rpc.js";
 import { addGatewayClientOptions, callGatewayFromCli } from "../gateway-rpc.js";
 import { parseStrictPositiveIntOrUndefined } from "../program/helpers.js";
+import { listCronJobsFromGateway } from "./list-jobs.js";
 import { resolveCronCreateScheduleFromArgs } from "./schedule-options.js";
 import {
   getCronChannelOptions,
@@ -56,14 +57,14 @@ export function registerCronListCommand(cron: Command) {
       .option("--json", "Output JSON", false)
       .action(async (opts) => {
         try {
-          const listParams: Record<string, unknown> = {
+          const listParams: { includeDisabled: boolean; agentId?: string } = {
             includeDisabled: Boolean(opts.all),
           };
           const agentId = normalizeOptionalString(opts.agent);
           if (agentId) {
             listParams.agentId = sanitizeAgentId(agentId);
           }
-          const res = await callGatewayFromCli("cron.list", opts, listParams);
+          const res = await listCronJobsFromGateway(opts, listParams);
           if (opts.json) {
             printCronJson(enrichCronJsonWithStatus(res));
             return;

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -10,7 +10,12 @@ import { danger } from "../../globals.js";
 import { parseStrictPositiveInteger } from "../../infra/parse-finite-number.js";
 import { sanitizeAgentId } from "../../routing/session-key.js";
 import { defaultRuntime } from "../../runtime.js";
-import { addGatewayClientOptions, callGatewayFromCli } from "../gateway-rpc.js";
+import {
+  addGatewayClientOptions,
+  callGatewayFromCli,
+  type GatewayRpcOpts,
+} from "../gateway-rpc.js";
+import { isUnknownCronGetMethodError, listCronJobsFromGateway } from "./list-jobs.js";
 import { resolveCronEditPayloadDeliveryPatch } from "./register.cron-edit-options.js";
 import {
   applyExistingCronSchedulePatch,
@@ -26,45 +31,7 @@ import {
 import { normalizeCronSessionTargetOption } from "./thread-id-shared.js";
 import { readCronTriggerScript } from "./trigger-options.js";
 
-const CRON_EDIT_LOOKUP_PAGE_SIZE = 200;
-const CRON_EDIT_LOOKUP_MAX_PAGES = 50;
-
-function isUnknownCronGetMethodError(error: unknown): error is Error {
-  return (
-    error instanceof Error &&
-    error.name === "GatewayClientRequestError" &&
-    (error as Error & { gatewayCode?: unknown }).gatewayCode === "INVALID_REQUEST" &&
-    error.message.includes("unknown method: cron.get")
-  );
-}
-
-async function loadCronJobForEditViaList(
-  opts: Record<string, unknown>,
-  id: string,
-): Promise<CronJob | undefined> {
-  let offset = 0;
-  for (let page = 0; page < CRON_EDIT_LOOKUP_MAX_PAGES; page += 1) {
-    const listed = (await callGatewayFromCli("cron.list", opts, {
-      includeDisabled: true,
-      limit: CRON_EDIT_LOOKUP_PAGE_SIZE,
-      offset,
-    })) as { jobs?: CronJob[]; hasMore?: boolean; nextOffset?: number | null } | null;
-    const existing = (listed?.jobs ?? []).find((job) => job.id === id);
-    if (existing) {
-      return existing;
-    }
-    if (!listed?.hasMore || typeof listed.nextOffset !== "number") {
-      return undefined;
-    }
-    if (listed.nextOffset <= offset) {
-      throw new Error("cron.list pagination did not advance while looking up cron job");
-    }
-    offset = listed.nextOffset;
-  }
-  throw new Error("cron.list pagination exceeded maximum pages while looking up cron job");
-}
-
-async function readCronJobForEdit(opts: Record<string, unknown>, id: string): Promise<CronJob> {
+async function readCronJobForEdit(opts: GatewayRpcOpts, id: string): Promise<CronJob> {
   try {
     return (await callGatewayFromCli("cron.get", opts, { id })) as CronJob;
   } catch (error) {
@@ -73,7 +40,12 @@ async function readCronJobForEdit(opts: Record<string, unknown>, id: string): Pr
     }
     // Protocol-v4 gateways shipped before cron.get; keep remote edits working
     // without paying the paginated lookup cost on current gateways.
-    const existing = await loadCronJobForEditViaList(opts, id);
+    const inventory = await listCronJobsFromGateway(
+      opts,
+      { includeDisabled: true },
+      { allowLegacyUnversionedPagination: true },
+    );
+    const existing = inventory.jobs.find((job) => job.id === id);
     if (!existing) {
       throw new Error(`unknown cron job id: ${id}`, { cause: error });
     }

--- a/src/cli/cron-cli/register.cron-simple.test.ts
+++ b/src/cli/cron-cli/register.cron-simple.test.ts
@@ -31,6 +31,23 @@ async function runCronToggle(command: "enable" | "disable"): Promise<void> {
   await program.parseAsync([command, "job-1"], { from: "user" });
 }
 
+function mockCronShowPages(readPage: (params: { offset?: number }) => unknown): void {
+  callGatewayFromCli.mockImplementation(
+    async (method: string, _opts: unknown, params?: { id?: string; offset?: number }) => {
+      if (method === "cron.get") {
+        throw Object.assign(new Error(`cron job not found: ${params?.id ?? ""}`), {
+          name: "GatewayClientRequestError",
+          gatewayCode: "INVALID_REQUEST",
+        });
+      }
+      if (method === "cron.list") {
+        return readPage(params ?? {});
+      }
+      throw new Error(`unexpected cron method: ${method}`);
+    },
+  );
+}
+
 function setStderrIsTTY(value: boolean): void {
   Object.defineProperty(process.stderr, "isTTY", {
     value,
@@ -60,48 +77,88 @@ describe("cron show pagination guard (regression for #83856)", () => {
   });
 
   it("throws when nextOffset fails to advance", async () => {
-    callGatewayFromCli.mockResolvedValue({
+    mockCronShowPages(() => ({
       jobs: [],
+      snapshotRevision: "test-stable-cron-inventory",
+      total: 1,
+      offset: 0,
+      limit: 200,
       hasMore: true,
       nextOffset: 0,
-    });
+    }));
     await expect(runCronShow("missing")).rejects.toThrow("exit 1");
     expect(defaultRuntime.error).toHaveBeenCalledWith(
       expect.stringContaining("pagination did not advance"),
     );
-    expect(callGatewayFromCli).toHaveBeenCalledTimes(1);
+    expect(callGatewayFromCli.mock.calls.filter(([method]) => method === "cron.list")).toHaveLength(
+      1,
+    );
   });
 
   it("throws when pagination exceeds the max page count", async () => {
-    let nextOffset = 0;
-    callGatewayFromCli.mockImplementation(async () => {
-      nextOffset += 1;
-      return { jobs: [], hasMore: true, nextOffset };
+    mockCronShowPages(({ offset = 0 }) => {
+      return {
+        jobs: [{ id: `page-${offset}`, name: `Page ${offset}` }],
+        snapshotRevision: "test-stable-cron-inventory",
+        total: 51,
+        offset,
+        limit: 200,
+        hasMore: true,
+        nextOffset: offset + 1,
+      };
     });
     await expect(runCronShow("missing")).rejects.toThrow("exit 1");
     expect(defaultRuntime.error).toHaveBeenCalledWith(
       expect.stringContaining("pagination exceeded maximum pages"),
     );
-    expect(callGatewayFromCli.mock.calls.length).toBeGreaterThan(1);
-    expect(callGatewayFromCli.mock.calls.length).toBeLessThanOrEqual(50);
+    const listCalls = callGatewayFromCli.mock.calls.filter(([method]) => method === "cron.list");
+    expect(listCalls.length).toBeGreaterThan(1);
+    expect(listCalls.length).toBeLessThanOrEqual(50);
   });
 
   it("returns the job when found on a later page", async () => {
     const job: CronJob = { id: "abc", name: "wanted" } as unknown as CronJob;
-    callGatewayFromCli
-      .mockResolvedValueOnce({ jobs: [], hasMore: true, nextOffset: 200 })
-      .mockResolvedValueOnce({ jobs: [job], hasMore: false, nextOffset: null });
+    mockCronShowPages(({ offset }) =>
+      offset
+        ? {
+            jobs: [job],
+            snapshotRevision: "test-stable-cron-inventory",
+            total: 201,
+            offset,
+            limit: 200,
+            hasMore: false,
+            nextOffset: null,
+          }
+        : {
+            jobs: Array.from({ length: 200 }, (_, index) => ({
+              id: `page-${index}`,
+              name: `Page ${index}`,
+            })),
+            snapshotRevision: "test-stable-cron-inventory",
+            total: 201,
+            offset: 0,
+            limit: 200,
+            hasMore: true,
+            nextOffset: 200,
+          },
+    );
     await runCronShow("wanted");
     expect(defaultRuntime.writeJson).toHaveBeenCalledWith(expect.objectContaining({ id: "abc" }));
-    expect(callGatewayFromCli).toHaveBeenCalledTimes(2);
+    expect(callGatewayFromCli.mock.calls.filter(([method]) => method === "cron.list")).toHaveLength(
+      2,
+    );
   });
 
   it("returns empty result when pagination terminates without a match", async () => {
-    callGatewayFromCli.mockResolvedValueOnce({
+    mockCronShowPages(() => ({
       jobs: [],
+      snapshotRevision: "test-empty-cron-inventory",
+      total: 0,
+      offset: 0,
+      limit: 200,
       hasMore: false,
       nextOffset: null,
-    });
+    }));
     await expect(runCronShow("missing")).rejects.toThrow("exit 1");
     expect(defaultRuntime.error).toHaveBeenCalledWith(
       expect.stringContaining("cron job not found: missing"),

--- a/src/cli/cron-cli/register.cron-simple.ts
+++ b/src/cli/cron-cli/register.cron-simple.ts
@@ -3,17 +3,15 @@ import {
   resolvePositiveTimerTimeoutMs,
   resolveTimerTimeoutMs,
 } from "@openclaw/normalization-core/number-coercion";
-import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import type { Command } from "commander";
-import type { CronDeliveryPreview, CronJob } from "../../cron/types.js";
 import { parseStrictPositiveInteger } from "../../infra/parse-finite-number.js";
 import { defaultRuntime } from "../../runtime.js";
 import { sleep } from "../../utils/sleep.js";
 import type { GatewayRpcOpts } from "../gateway-rpc.js";
 import { addGatewayClientOptions, callGatewayFromCli } from "../gateway-rpc.js";
 import { parseDurationMs } from "../parse-duration.js";
+import { findCronJobByIdOrName } from "./list-jobs.js";
 import {
-  coerceCronDeliveryPreviews,
   enrichCronJsonWithStatus,
   handleCronCliError,
   printCronJson,
@@ -21,8 +19,6 @@ import {
   warnIfCronSchedulerDisabled,
 } from "./shared.js";
 
-const CRON_SHOW_PAGE_SIZE = 200;
-const CRON_SHOW_LOOKUP_MAX_PAGES = 50;
 const CRON_RUN_WAIT_TIMEOUT_DEFAULT = "10m";
 const CRON_RUN_WAIT_POLL_INTERVAL_DEFAULT = "2s";
 
@@ -82,47 +78,6 @@ async function waitForCronRunCompletion(params: {
     }
     await sleep(Math.min(params.pollIntervalMs, params.timeoutMs - elapsedMs));
   }
-}
-
-function findCronJobInPage(jobs: CronJob[], idOrName: string): CronJob | undefined {
-  const needle = normalizeLowercaseStringOrEmpty(idOrName);
-  return jobs.find(
-    (job) =>
-      normalizeLowercaseStringOrEmpty(job.id) === needle ||
-      normalizeLowercaseStringOrEmpty(job.name) === needle,
-  );
-}
-
-async function loadCronJobForShow(
-  opts: GatewayRpcOpts,
-  idOrName: string,
-): Promise<{ job?: CronJob; deliveryPreview?: CronDeliveryPreview }> {
-  let offset = 0;
-  for (let page = 0; page < CRON_SHOW_LOOKUP_MAX_PAGES; page += 1) {
-    const res = await callGatewayFromCli("cron.list", opts, {
-      includeDisabled: true,
-      limit: CRON_SHOW_PAGE_SIZE,
-      offset,
-    });
-    const listed = res as {
-      jobs?: CronJob[];
-      hasMore?: boolean;
-      nextOffset?: number | null;
-    };
-    const jobs = listed.jobs ?? [];
-    const job = findCronJobInPage(jobs, idOrName);
-    if (job) {
-      return { job, deliveryPreview: coerceCronDeliveryPreviews(res).get(job.id) };
-    }
-    if (!listed.hasMore || typeof listed.nextOffset !== "number") {
-      return {};
-    }
-    if (listed.nextOffset <= offset) {
-      throw new Error("cron.list pagination did not advance while looking up cron job");
-    }
-    offset = listed.nextOffset;
-  }
-  throw new Error("cron.list pagination exceeded maximum pages while looking up cron job");
 }
 
 function registerCronToggleCommand(params: {
@@ -211,7 +166,9 @@ export function registerCronSimpleCommands(cron: Command) {
       .option("--json", "Output JSON", false)
       .action(async (id, opts) => {
         try {
-          const { job, deliveryPreview } = await loadCronJobForShow(opts, String(id));
+          const { job, deliveryPreview } = await findCronJobByIdOrName(opts, String(id), {
+            includeDeliveryPreview: !opts.json,
+          });
           if (!job) {
             throw new Error(`cron job not found: ${String(id)}`);
           }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users listing more than 200 scheduled jobs would silently lose every job beyond the Gateway's first inventory page. Resolves related cases where `cron show` selected another job whose name happened to equal the requested job ID, or combined pages from different scheduler snapshots while jobs changed.

## Why This Change Was Made

Use one typed, revision-aware, bounded Gateway inventory reader for cron listing, display, and the documented older-Gateway editing fallback. Resolve exact IDs with canonical `cron.get` before matching job names, restart changed or shrinking snapshots instead of combining their pages, reject incomplete or oversized modern pages, and explicitly probe `cron.get` before permitting the shipped protocol-v4 fallback. No flags or protocol changes are needed.

## User Impact

`openclaw cron list` displays all scheduled jobs, including jobs beyond entry 200; normal table and JSON output agree; `openclaw cron show` consistently displays the actual requested job and delivery preview; and concurrent scheduler changes can no longer produce a mixed or truncated inventory. Editing against older Gateways remains supported.

## Evidence

- Real production `cron.list` and `cron.get` Gateway handlers connected to the canonical cron service and 201 valid scheduled jobs. The unchanged released baseline produces **5 reproducible failing regressions and 1 passing control**; the fixed implementation passes all actual-Gateway cases.
- Real snapshot changes, shrinking/clamped snapshots, repeated churn, complete 200 + 1 pagination, explicitly detected protocol-v4 inventory (including empty terminal pages), mixed-version routes, terminal cursor validation, truncated and oversized pages, modern unversioned page rejection, exact ID/name collisions, late-page name lookup, transport failures, and a stable 10,001-job safety bound covered by **21 actual-handler regression tests**. Independent-review findings were reproduced as real-Gateway failing regressions before the implementation was fixed.
- Existing shipped older-Gateway `cron edit` fallback remains green.
- Blacksmith Testbox: **419/419 tests pass across 11 focused CLI, live Gateway server, Gateway method, cron service, protocol/schema, protocol validator, and doctor test files**.
- Five consecutive fresh actual-Gateway churn, compatibility, and malformed-page stress rounds: **105/105 pass**.
- Canonical formatting for all seven changed paths, production TypeScript, and test TypeScript: **pass**.
- Complete canonical `pnpm check:changed`, including all repository ratchets, plugin/API/database boundaries, production/test type-checking, import-cycle guards, and all 245 applicable lint rules: **pass, exit 0**.
- Fresh exact-head independent high-effort code review: **no actionable findings; 0.98 confidence**.
- Base reproduction: `a1cc41acbcdd285a7cdb423bdfe45ef06b2f97cb`.
