### PR TITLE
fix(install): reject commit-less git checkouts

### DIFF
--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -1187,7 +1187,7 @@ install_openclaw_from_git() {
   ensure_pnpm_binary_for_scripts
 
   if [[ -d "$repo_dir/.git" ]] &&
-    ! git -C "$repo_dir" rev-parse --verify --quiet HEAD >/dev/null 2>&1; then
+    ! git --git-dir="$repo_dir/.git" --work-tree="$repo_dir" rev-parse --verify --quiet HEAD >/dev/null 2>&1; then
     fail "Git checkout has no commit: ${repo_dir}. Move or remove this incomplete checkout, then retry."
   fi
 

--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -1187,7 +1187,7 @@ install_openclaw_from_git() {
   ensure_pnpm_binary_for_scripts
 
   if [[ -d "$repo_dir/.git" ]] &&
-    ! git --git-dir="$repo_dir/.git" --work-tree="$repo_dir" rev-parse --verify --quiet HEAD >/dev/null 2>&1; then
+    ! git --git-dir="$repo_dir/.git" --work-tree="$repo_dir" rev-parse --verify --quiet 'HEAD^{commit}' >/dev/null 2>&1; then
     fail "Git checkout has no commit: ${repo_dir}. Move or remove this incomplete checkout, then retry."
   fi
 

--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -1186,6 +1186,12 @@ install_openclaw_from_git() {
   ensure_pnpm
   ensure_pnpm_binary_for_scripts
 
+  if [[ -d "$repo_dir/.git" ]] &&
+    ! git -C "$repo_dir" rev-parse --verify --quiet HEAD >/dev/null 2>&1; then
+    fail "Git checkout has no commit: ${repo_dir}. Move or remove this incomplete checkout, then retry."
+    return 1
+  fi
+
   if [[ -d "$repo_dir/.git" ]]; then
     :
   elif [[ -d "$repo_dir" ]]; then

--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -1189,7 +1189,6 @@ install_openclaw_from_git() {
   if [[ -d "$repo_dir/.git" ]] &&
     ! git -C "$repo_dir" rev-parse --verify --quiet HEAD >/dev/null 2>&1; then
     fail "Git checkout has no commit: ${repo_dir}. Move or remove this incomplete checkout, then retry."
-    return 1
   fi
 
   if [[ -d "$repo_dir/.git" ]]; then

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1469,7 +1469,7 @@ function Assert-GitCheckoutHasCommit {
 
     $hasHead = $false
     try {
-        git "--git-dir=$gitDir" "--work-tree=$RepoDir" rev-parse --verify --quiet HEAD 2>$null | Out-Null
+        git "--git-dir=$gitDir" "--work-tree=$RepoDir" rev-parse --verify --quiet "HEAD^{commit}" 2>$null | Out-Null
         $hasHead = ($LASTEXITCODE -eq 0)
     } catch {}
     if (-not $hasHead) {

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1459,6 +1459,24 @@ function Install-OpenClaw {
 }
 
 # Install OpenClaw from GitHub
+function Assert-GitCheckoutHasCommit {
+    param([string]$RepoDir)
+
+    $gitDir = Join-Path $RepoDir ".git"
+    if (-not (Test-Path -LiteralPath $gitDir -PathType Container)) {
+        return
+    }
+
+    $hasHead = $false
+    try {
+        git -C $RepoDir rev-parse --verify --quiet HEAD 2>$null | Out-Null
+        $hasHead = ($LASTEXITCODE -eq 0)
+    } catch {}
+    if (-not $hasHead) {
+        throw "Git checkout has no commit: $RepoDir. Move or remove this incomplete checkout, then retry."
+    }
+}
+
 function Install-OpenClawFromGit {
     param(
         [string]$RepoDir,
@@ -1471,6 +1489,7 @@ function Install-OpenClawFromGit {
     $repoUrl = "https://github.com/openclaw/openclaw.git"
     Write-Host "[*] Installing OpenClaw from GitHub ($repoUrl)..." -ForegroundColor Yellow
 
+    Assert-GitCheckoutHasCommit -RepoDir $RepoDir
     if (-not (Test-Path $RepoDir)) {
         git clone $repoUrl $RepoDir
     }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1469,7 +1469,7 @@ function Assert-GitCheckoutHasCommit {
 
     $hasHead = $false
     try {
-        git -C $RepoDir rev-parse --verify --quiet HEAD 2>$null | Out-Null
+        git "--git-dir=$gitDir" "--work-tree=$RepoDir" rev-parse --verify --quiet HEAD 2>$null | Out-Null
         $hasHead = ($LASTEXITCODE -eq 0)
     } catch {}
     if (-not $hasHead) {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2424,7 +2424,7 @@ validate_git_checkout_head() {
     if [[ ! -d "$repo_dir/.git" ]]; then
         return 0
     fi
-    if git -C "$repo_dir" rev-parse --verify --quiet HEAD >/dev/null 2>&1; then
+    if git --git-dir="$repo_dir/.git" --work-tree="$repo_dir" rev-parse --verify --quiet HEAD >/dev/null 2>&1; then
         return 0
     fi
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2424,7 +2424,7 @@ validate_git_checkout_head() {
     if [[ ! -d "$repo_dir/.git" ]]; then
         return 0
     fi
-    if git --git-dir="$repo_dir/.git" --work-tree="$repo_dir" rev-parse --verify --quiet HEAD >/dev/null 2>&1; then
+    if git --git-dir="$repo_dir/.git" --work-tree="$repo_dir" rev-parse --verify --quiet 'HEAD^{commit}' >/dev/null 2>&1; then
         return 0
     fi
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2418,6 +2418,21 @@ checkout_git_openclaw_ref() {
     return 1
 }
 
+validate_git_checkout_head() {
+    local repo_dir="$1"
+
+    if [[ ! -d "$repo_dir/.git" ]]; then
+        return 0
+    fi
+    if git -C "$repo_dir" rev-parse --verify --quiet HEAD >/dev/null 2>&1; then
+        return 0
+    fi
+
+    ui_error "Git checkout has no commit: ${repo_dir}"
+    ui_info "Move or remove this incomplete checkout, then retry the installer."
+    return 1
+}
+
 git_install_lockfile_flag() {
     local repo_dir="$1"
     local ref="$2"
@@ -2873,6 +2888,7 @@ install_openclaw_from_git() {
     ensure_pnpm
     ensure_pnpm_binary_for_scripts
 
+    validate_git_checkout_head "$repo_dir" || return 1
     if [[ ! -d "$repo_dir" ]]; then
         mkdir -p "$(dirname "$repo_dir")"
         run_quiet_step "Cloning OpenClaw" git clone "$repo_url" "$repo_dir"

--- a/test/scripts/install-cli.test.ts
+++ b/test/scripts/install-cli.test.ts
@@ -52,7 +52,9 @@ describe("install-cli.sh", () => {
       ensure_pnpm() { :; }
       ensure_pnpm_binary_for_scripts() { :; }
       git() {
-        [[ "$1" == "-C" ]] && return 1
+        [[ "$1" == "--git-dir=$repo/.git" ]] &&
+          [[ "$2" == "--work-tree=$repo" ]] &&
+          return 1
         return 99
       }
 

--- a/test/scripts/install-cli.test.ts
+++ b/test/scripts/install-cli.test.ts
@@ -54,6 +54,10 @@ describe("install-cli.sh", () => {
       git() {
         [[ "$1" == "--git-dir=$repo/.git" ]] &&
           [[ "$2" == "--work-tree=$repo" ]] &&
+          [[ "$3" == "rev-parse" ]] &&
+          [[ "$4" == "--verify" ]] &&
+          [[ "$5" == "--quiet" ]] &&
+          [[ "$6" == "HEAD^{commit}" ]] &&
           return 1
         return 99
       }

--- a/test/scripts/install-cli.test.ts
+++ b/test/scripts/install-cli.test.ts
@@ -41,6 +41,33 @@ function linkRequiredShellTools(bin: string) {
 describe("install-cli.sh", () => {
   const script = readFileSync(SCRIPT_PATH, "utf8");
 
+  it("rejects a git checkout without a commit before updating it", () => {
+    const result = runInstallCliShell(`
+      set -euo pipefail
+      source "${SCRIPT_PATH}"
+      tmp="$(mktemp -d)"
+      repo="$tmp/repo"
+      mkdir -p "$repo/.git"
+      ensure_git() { :; }
+      ensure_pnpm() { :; }
+      ensure_pnpm_binary_for_scripts() { :; }
+      fail() { return 23; }
+      git() {
+        [[ "$1" == "-C" ]] && return 1
+        return 99
+      }
+
+      set +e
+      install_openclaw_from_git "$repo"
+      status="$?"
+      set -e
+      [[ "$status" -eq 1 ]]
+      [[ -d "$repo/.git" ]]
+    `);
+
+    expect(result.status).toBe(0);
+  });
+
   it("bounds stalled curl downloads and propagates timeout failures", () => {
     const result = runInstallCliShell(`
       set -euo pipefail

--- a/test/scripts/install-cli.test.ts
+++ b/test/scripts/install-cli.test.ts
@@ -51,14 +51,13 @@ describe("install-cli.sh", () => {
       ensure_git() { :; }
       ensure_pnpm() { :; }
       ensure_pnpm_binary_for_scripts() { :; }
-      fail() { return 23; }
       git() {
         [[ "$1" == "-C" ]] && return 1
         return 99
       }
 
       set +e
-      install_openclaw_from_git "$repo"
+      (install_openclaw_from_git "$repo")
       status="$?"
       set -e
       [[ "$status" -eq 1 ]]

--- a/test/scripts/install-ps1.test.ts
+++ b/test/scripts/install-ps1.test.ts
@@ -661,6 +661,8 @@ describe("install.ps1 failure handling", () => {
     const guardBody = extractFunctionBody(source, "Assert-GitCheckoutHasCommit");
     const gitInstallBody = extractFunctionBody(source, "Install-OpenClawFromGit");
 
+    expect(guardBody).toContain('"--git-dir=$gitDir"');
+    expect(guardBody).toContain('"--work-tree=$RepoDir"');
     expect(guardBody).toContain("rev-parse --verify --quiet HEAD");
     expect(guardBody).toContain("Git checkout has no commit");
     expect(guardBody).not.toContain("Remove-Item");

--- a/test/scripts/install-ps1.test.ts
+++ b/test/scripts/install-ps1.test.ts
@@ -663,7 +663,7 @@ describe("install.ps1 failure handling", () => {
 
     expect(guardBody).toContain('"--git-dir=$gitDir"');
     expect(guardBody).toContain('"--work-tree=$RepoDir"');
-    expect(guardBody).toContain("rev-parse --verify --quiet HEAD");
+    expect(guardBody).toContain('rev-parse --verify --quiet "HEAD^{commit}"');
     expect(guardBody).toContain("Git checkout has no commit");
     expect(guardBody).not.toContain("Remove-Item");
     expect(guardBody).not.toContain("Move-Item");

--- a/test/scripts/install-ps1.test.ts
+++ b/test/scripts/install-ps1.test.ts
@@ -657,6 +657,17 @@ describe("install.ps1 failure handling", () => {
     expect(gitInstallBody).not.toContain("NPM_CONFIG_SCRIPT_SHELL");
   });
 
+  it("rejects a git checkout without a commit before updating it", () => {
+    const guardBody = extractFunctionBody(source, "Assert-GitCheckoutHasCommit");
+    const gitInstallBody = extractFunctionBody(source, "Install-OpenClawFromGit");
+
+    expect(guardBody).toContain("rev-parse --verify --quiet HEAD");
+    expect(guardBody).toContain("Git checkout has no commit");
+    expect(guardBody).not.toContain("Remove-Item");
+    expect(guardBody).not.toContain("Move-Item");
+    expect(gitInstallBody).toContain("Assert-GitCheckoutHasCommit -RepoDir $RepoDir");
+  });
+
   it("runs Windows command shims from a Windows-local cwd", () => {
     const commandSafeBody = extractFunctionBody(source, "Invoke-CommandFromWindowsSafeDirectory");
     const npmCommandBody = extractFunctionBody(source, "Invoke-NpmCommand");

--- a/test/scripts/install-sh.test.ts
+++ b/test/scripts/install-sh.test.ts
@@ -323,7 +323,7 @@ NODE
       ui_success() { :; }
       ui_error() { printf 'error:%s\\n' "$*"; }
       git() {
-        if [[ "$1" == "--git-dir=$repo/.git" && "$2" == "--work-tree=$repo" && "$3" == "rev-parse" ]]; then
+        if [[ "$1" == "--git-dir=$repo/.git" && "$2" == "--work-tree=$repo" && "$3" == "rev-parse" && "$6" == "HEAD^{commit}" ]]; then
           return 0
         fi
         if [[ "$1" == "-C" && "$3" == "status" ]]; then
@@ -360,7 +360,11 @@ NODE
       touch "$parent/seed"
       git -C "$parent" add seed
       git -C "$parent" commit -qm seed
-      mkdir -p "$repo/.git"
+      mkdir -p "$repo"
+      git -C "$repo" init -q
+      printf 'ref: refs/heads/main\\n' > "$repo/.git/HEAD"
+      mkdir -p "$repo/.git/refs/heads"
+      printf '1111111111111111111111111111111111111111\\n' > "$repo/.git/refs/heads/main"
       printf 'keep\\n' > "$repo/local.txt"
       ui_info() { :; }
       ui_error() { :; }

--- a/test/scripts/install-sh.test.ts
+++ b/test/scripts/install-sh.test.ts
@@ -352,7 +352,14 @@ NODE
       set -euo pipefail
       source "${SCRIPT_PATH}"
       tmp="$(mktemp -d)"
-      repo="$tmp/repo"
+      parent="$tmp/parent"
+      repo="$parent/repo"
+      git -C "$tmp" init -q parent
+      git -C "$parent" config user.email test@example.invalid
+      git -C "$parent" config user.name test
+      touch "$parent/seed"
+      git -C "$parent" add seed
+      git -C "$parent" commit -qm seed
       mkdir -p "$repo/.git"
       printf 'keep\\n' > "$repo/local.txt"
       ui_info() { :; }

--- a/test/scripts/install-sh.test.ts
+++ b/test/scripts/install-sh.test.ts
@@ -323,6 +323,9 @@ NODE
       ui_success() { :; }
       ui_error() { printf 'error:%s\\n' "$*"; }
       git() {
+        if [[ "$1" == "-C" && "$3" == "rev-parse" ]]; then
+          return 0
+        fi
         if [[ "$1" == "-C" && "$3" == "status" ]]; then
           return 0
         fi

--- a/test/scripts/install-sh.test.ts
+++ b/test/scripts/install-sh.test.ts
@@ -323,7 +323,7 @@ NODE
       ui_success() { :; }
       ui_error() { printf 'error:%s\\n' "$*"; }
       git() {
-        if [[ "$1" == "-C" && "$3" == "rev-parse" ]]; then
+        if [[ "$1" == "--git-dir=$repo/.git" && "$2" == "--work-tree=$repo" && "$3" == "rev-parse" ]]; then
           return 0
         fi
         if [[ "$1" == "-C" && "$3" == "status" ]]; then

--- a/test/scripts/install-sh.test.ts
+++ b/test/scripts/install-sh.test.ts
@@ -344,6 +344,29 @@ NODE
     expect(result.stdout).toContain("/repo/dist/entry.js --version");
   });
 
+  it("rejects a git checkout without a commit without modifying it", () => {
+    const result = runInstallShell(`
+      set -euo pipefail
+      source "${SCRIPT_PATH}"
+      tmp="$(mktemp -d)"
+      repo="$tmp/repo"
+      mkdir -p "$repo/.git"
+      printf 'keep\\n' > "$repo/local.txt"
+      ui_info() { :; }
+      ui_error() { :; }
+
+      set +e
+      validate_git_checkout_head "$repo"
+      status="$?"
+      set -e
+      [[ "$status" -eq 1 ]]
+      [[ -f "$repo/local.txt" ]]
+      [[ -d "$repo/.git" ]]
+    `);
+
+    expect(result.status).toBe(0);
+  });
+
   it("accepts GNU and musl Linux shells in OS detection", () => {
     expect(script).toContain('[[ "$OSTYPE" == "linux"* ]]');
     expect(script).not.toContain('[[ "$OSTYPE" == "linux-gnu"* ]]');


### PR DESCRIPTION
## What Problem This Solves

Git install destinations that contain `.git` but whose `HEAD` does not resolve to an existing commit object are currently accepted as reusable checkouts. Interrupted or damaged clones can therefore continue into update and build operations and fail later with misleading errors.

Fixes #113808.

## Why This Change Was Made

All three official Git install paths now validate the selected checkout before update, checkout, or build work:

- `scripts/install.sh`
- `scripts/install-cli.sh`
- `scripts/install.ps1`

The validation pins `--git-dir` and `--work-tree` so Git cannot walk into a parent repository, and resolves `HEAD^{commit}` so a dangling ref or missing object is rejected. The installers stop with recovery guidance and do not delete or move the checkout because it may contain recoverable objects, refs, or user files.

## User Impact

Users retrying a Git installation after an interrupted or damaged clone receive the actual cause immediately while their existing directory is preserved. Valid Git checkouts and first-time destinations are unchanged.

## Evidence

Final head: `3b2147f2dfc35c34b600246ab31fe2093a4cb67f`, rebased without conflicts onto `17a8961a6a36e0bab0a56a248e9c79372ddff402`.

### Real behavior

The probes used real Git repositories. The invalid fixture was nested inside a valid parent repository and had a syntactically valid branch ref whose commit object was absent. Each guard rejected the nested damaged checkout without touching its marker file; valid controls remained accepted.

```text
scripts/install.sh:     invalid=1 valid=0 marker=kept
scripts/install-cli.sh: invalid=1         marker=kept
scripts/install.ps1:    invalid=1 valid=0 marker=kept
```

The PowerShell result was produced by parsing and invoking the exact `Assert-GitCheckoutHasCommit` function from `scripts/install.ps1`, not a rewritten copy.

A direct Git control demonstrates why the final peel is required:

```text
git rev-parse --verify --quiet HEAD          -> exit 0
git rev-parse --verify --quiet HEAD^{commit} -> exit 1
```

### Focused tests

```text
node scripts/run-vitest.mjs test/scripts/install-ps1.test.ts
Test Files  1 passed (1)
Tests       31 passed (31)
```

```text
oxfmt --check test/scripts/install-cli.test.ts test/scripts/install-sh.test.ts test/scripts/install-ps1.test.ts
All matched files use the correct format.
```

Both changed shell installers also pass `bash -n`, and `git diff --check` is clean.

### Canonical hosted delivery path

The repository copies changed by this PR are the canonical installer sources. [`.github/workflows/website-installer-sync.yml`](https://github.com/openclaw/openclaw/blob/3b2147f2dfc35c34b600246ab31fe2093a4cb67f/.github/workflows/website-installer-sync.yml#L3-L16) is triggered whenever any of these three files changes. After its static, Linux Docker, macOS, and Windows jobs pass, the `sync-website` job runs on pushes to `main` and copies these exact sources into the hosted repository:

```text
cp openclaw/scripts/install.sh     openclaw.ai/public/install.sh
cp openclaw/scripts/install-cli.sh openclaw.ai/public/install-cli.sh
cp openclaw/scripts/install.ps1    openclaw.ai/public/install.ps1
```

The workflow then validates the synced website assets, builds the website, commits them, and pushes `openclaw.ai/main` ([sync implementation](https://github.com/openclaw/openclaw/blob/3b2147f2dfc35c34b600246ab31fe2093a4cb67f/.github/workflows/website-installer-sync.yml#L125-L210)). Therefore a separate contributor patch to `openclaw/openclaw.ai` would duplicate generated output and race the canonical sync.

Current [Website Installer Sync run 30462223171](https://github.com/openclaw/openclaw/actions/runs/30462223171):

```text
static:            success
linux-docker:      success
macos-installer:   success
windows-installer: success
sync-website:      skipped on pull_request (runs after merge on push to main)
```
### Review

Final-patch autoreview reported:

```text
trufflehog: clean
findings: []
overall: patch is correct (0.91)
```

The clean review ran immediately before the current-main rebase. `git range-diff` reports all five commits as exact (`=`) matches after the rebase, and the focused tests were rerun on the final head.