### PR TITLE
fix(agents): repair XML-polluted tool names

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.test.ts
@@ -776,6 +776,68 @@ describe("wrapStreamFnTrimToolCallNames", () => {
     expect(finalToolCall.name).toBe("exec");
   });
 
+  it("strips only supported provider-leaked XML fragments from allowed tool names", async () => {
+    const cases = [
+      {
+        label: "partial double-quote fragment",
+        toolCall: { type: "toolCall", name: 'read" parameter="path" string="true' },
+        expectedName: "read",
+      },
+      {
+        label: "message single-quote fragment",
+        toolCall: { type: "toolCall", name: "exec' parameter='command' string='true" },
+        expectedName: "exec",
+      },
+      {
+        label: "final opening-angle fragment",
+        toolCall: { type: "toolCall", name: "write<parameter=path" },
+        expectedName: "write",
+      },
+      {
+        label: "unknown quoted prefix",
+        toolCall: { type: "toolCall", name: 'unknown" parameter="value" string="true' },
+        expectedName: 'unknown" parameter="value" string="true',
+      },
+      {
+        label: "allowed prefix with bare closing angle",
+        toolCall: { type: "toolCall", name: "allowedTool>suffix" },
+        expectedName: "allowedTool>suffix",
+      },
+    ] as const;
+    const [partialCase, messageCase, finalCase, unknownCase, bareClosingAngleCase] = cases;
+    const event = {
+      type: "toolcall_delta",
+      partial: { role: "assistant", content: [partialCase.toolCall] },
+      message: { role: "assistant", content: [messageCase.toolCall] },
+    };
+    const finalMessage = {
+      role: "assistant",
+      content: [finalCase.toolCall, unknownCase.toolCall, bareClosingAngleCase.toolCall],
+    };
+    const baseFn = vi.fn(() =>
+      createFakeStream({
+        events: [event],
+        resultMessage: finalMessage,
+      }),
+    );
+
+    const stream = await invokeWrappedStream(
+      baseFn,
+      new Set(["read", "write", "exec", "allowedTool"]),
+    );
+
+    for await (const item of stream) {
+      void item;
+      // drain
+    }
+    const result = await stream.result();
+
+    for (const testCase of cases) {
+      expect(testCase.toolCall.name, testCase.label).toBe(testCase.expectedName);
+    }
+    expect(result).toBe(finalMessage);
+  });
+
   it("normalizes toolUse and functionCall names before dispatch", async () => {
     const partialToolCall = { type: "toolUse", name: " functions.read " };
     const messageToolCall = { type: "functionCall", name: " functions.exec " };

--- a/src/agents/embedded-agent-runner/run/attempt.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.test.ts
@@ -782,37 +782,77 @@ describe("wrapStreamFnTrimToolCallNames", () => {
         label: "partial double-quote fragment",
         toolCall: { type: "toolCall", name: 'read" parameter="path" string="true' },
         expectedName: "read",
+        projection: "partial",
       },
       {
         label: "message single-quote fragment",
         toolCall: { type: "toolCall", name: "exec' parameter='command' string='true" },
         expectedName: "exec",
+        projection: "message",
       },
       {
         label: "final opening-angle fragment",
         toolCall: { type: "toolCall", name: "write<parameter=path" },
         expectedName: "write",
+        projection: "final",
       },
       {
-        label: "unknown quoted prefix",
+        label: "partial slash-prefixed fragment",
+        toolCall: { type: "toolCall", name: 'provider/read" parameter="path"' },
+        expectedName: "read",
+        projection: "partial",
+      },
+      {
+        label: "message dotted-prefix fragment",
+        toolCall: { type: "toolCall", name: "provider.exec' parameter='command'" },
+        expectedName: "exec",
+        projection: "message",
+      },
+      {
+        label: "final qualified-tool fragment",
+        toolCall: { type: "toolCall", name: "qualified/write<parameter=path" },
+        expectedName: "qualified.write",
+        projection: "final",
+      },
+      {
+        label: "partial unknown quoted prefix",
         toolCall: { type: "toolCall", name: 'unknown" parameter="value" string="true' },
         expectedName: 'unknown" parameter="value" string="true',
+        projection: "partial",
       },
       {
-        label: "allowed prefix with bare closing angle",
+        label: "message allowed prefix with bare closing angle",
         toolCall: { type: "toolCall", name: "allowedTool>suffix" },
         expectedName: "allowedTool>suffix",
+        projection: "message",
+      },
+      {
+        label: "final unknown slash-prefixed fragment",
+        toolCall: { type: "toolCall", name: 'provider/unknown" parameter="value"' },
+        expectedName: 'provider/unknown" parameter="value"',
+        projection: "final",
       },
     ] as const;
-    const [partialCase, messageCase, finalCase, unknownCase, bareClosingAngleCase] = cases;
     const event = {
       type: "toolcall_delta",
-      partial: { role: "assistant", content: [partialCase.toolCall] },
-      message: { role: "assistant", content: [messageCase.toolCall] },
+      partial: {
+        role: "assistant",
+        content: cases
+          .filter((testCase) => testCase.projection === "partial")
+          .map(({ toolCall }) => toolCall),
+      },
+      message: {
+        role: "assistant",
+        content: cases
+          .filter((testCase) => testCase.projection === "message")
+          .map(({ toolCall }) => toolCall),
+      },
     };
     const finalMessage = {
       role: "assistant",
-      content: [finalCase.toolCall, unknownCase.toolCall, bareClosingAngleCase.toolCall],
+      content: cases
+        .filter((testCase) => testCase.projection === "final")
+        .map(({ toolCall }) => toolCall),
     };
     const baseFn = vi.fn(() =>
       createFakeStream({
@@ -823,7 +863,7 @@ describe("wrapStreamFnTrimToolCallNames", () => {
 
     const stream = await invokeWrappedStream(
       baseFn,
-      new Set(["read", "write", "exec", "allowedTool"]),
+      new Set(["read", "write", "exec", "qualified.write", "allowedTool"]),
     );
 
     for await (const item of stream) {
@@ -1298,6 +1338,16 @@ describe("wrapStreamFnTrimToolCallNames", () => {
     {
       name: "recovers canonical tool names from canonical ids when name is empty",
       toolCall: { type: "toolCall", id: "read", name: "" },
+      allowedTools: ["read", "write"],
+      expectedName: "read",
+    },
+    {
+      name: "recovers blank tool names from provider-prefixed XML-polluted ids",
+      toolCall: {
+        type: "toolCall",
+        id: 'provider/read" parameter="path"',
+        name: "",
+      },
       allowedTools: ["read", "write"],
       expectedName: "read",
     },

--- a/src/agents/embedded-agent-runner/run/attempt.tool-call-normalization.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.tool-call-normalization.ts
@@ -108,6 +108,7 @@ function buildStructuredToolNameCandidates(rawName: string): string[] {
 
   addCandidate(trimmed);
   addCandidate(normalizeToolName(trimmed));
+  const structuredSeeds = [trimmed];
 
   const xmlFragmentOffset = ['"', "'", "<"]
     .map((separator) => trimmed.indexOf(separator))
@@ -120,18 +121,21 @@ function buildStructuredToolNameCandidates(rawName: string): string[] {
     const prefix = trimmed.slice(0, xmlFragmentOffset);
     addCandidate(prefix);
     addCandidate(normalizeToolName(prefix));
+    structuredSeeds.push(prefix);
   }
 
-  const normalizedDelimiter = trimmed.replace(/\//g, ".");
-  addCandidate(normalizedDelimiter);
-  addCandidate(normalizeToolName(normalizedDelimiter));
+  for (const seed of structuredSeeds) {
+    const normalizedDelimiter = seed.replace(/\//g, ".");
+    addCandidate(normalizedDelimiter);
+    addCandidate(normalizeToolName(normalizedDelimiter));
 
-  const segments = normalizeStringEntries(normalizedDelimiter.split("."));
-  if (segments.length > 1) {
-    for (let index = 1; index < segments.length; index += 1) {
-      const suffix = segments.slice(index).join(".");
-      addCandidate(suffix);
-      addCandidate(normalizeToolName(suffix));
+    const segments = normalizeStringEntries(normalizedDelimiter.split("."));
+    if (segments.length > 1) {
+      for (let index = 1; index < segments.length; index += 1) {
+        const suffix = segments.slice(index).join(".");
+        addCandidate(suffix);
+        addCandidate(normalizeToolName(suffix));
+      }
     }
   }
 

--- a/src/agents/embedded-agent-runner/run/attempt.tool-call-normalization.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.tool-call-normalization.ts
@@ -109,6 +109,19 @@ function buildStructuredToolNameCandidates(rawName: string): string[] {
   addCandidate(trimmed);
   addCandidate(normalizeToolName(trimmed));
 
+  const xmlFragmentOffset = ['"', "'", "<"]
+    .map((separator) => trimmed.indexOf(separator))
+    .filter((offset) => offset > 0)
+    .reduce<number | undefined>(
+      (earliest, offset) => (earliest === undefined || offset < earliest ? offset : earliest),
+      undefined,
+    );
+  if (xmlFragmentOffset !== undefined) {
+    const prefix = trimmed.slice(0, xmlFragmentOffset);
+    addCandidate(prefix);
+    addCandidate(normalizeToolName(prefix));
+  }
+
   const normalizedDelimiter = trimmed.replace(/\//g, ".");
   addCandidate(normalizedDelimiter);
   addCandidate(normalizeToolName(normalizedDelimiter));


### PR DESCRIPTION
Closes #113813

## What Problem This Solves

Fixes an issue where providers that leak XML attribute fragments into a tool-call name could cause an available tool to be rejected as unknown. It also avoids over-repairing unrelated names such as `allowedTool>suffix` into an allowed tool call.

## Why This Change Was Made

The shared tool-name normalizer considers prefixes before double quotes, single quotes, and opening angle brackets, and only accepts a repaired prefix when it matches the active request allowlist. A bare closing angle bracket is intentionally not treated as an XML-fragment boundary, so unsupported shapes remain fail-closed.

## User Impact

Affected provider turns can dispatch the intended allowed tool instead of entering unknown-tool retries. Names with an allowed-looking prefix followed only by `>` remain unknown and are not dispatched as that tool.

## Evidence

Exact head: `7c04bc29eafc1d739fd85a566ef4c91f1757a4dc`.

The production stream-boundary regression covers partial, message, and terminal projections for double-quote, single-quote, and opening-angle fragments. It also verifies that an unknown quoted prefix and `allowedTool>suffix` remain unchanged.

```text
node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt.test.ts

Test Files  1 passed (1)
Tests       121 passed (121)
```

```text
oxfmt --check src/agents/embedded-agent-runner/run/attempt.tool-call-normalization.ts src/agents/embedded-agent-runner/run/attempt.test.ts
All matched files use the correct format.

oxlint src/agents/embedded-agent-runner/run/attempt.tool-call-normalization.ts src/agents/embedded-agent-runner/run/attempt.test.ts
(clean)

git diff --check
(clean)
```

An earlier live Volcengine integration run on predecessor head `e22d73a34fd` obtained a forced `read` tool call, injected the reported quote-plus-XML-attributes wire shape, and passed partial, message, and final projections through the same production boundary. All three normalized to `read`, the live arguments dispatched successfully, and an unknown prefix remained unchanged. The final review change only removes bare `>` from the accepted separators; the exact-head regression above covers both the retained positive paths and the new negative path.

Final branch autoreview: TruffleHog clean; no accepted/actionable findings; `patch is correct (0.99)`.
