### PR TITLE
fix(memory): avoid false Copilot index mismatch before provider init

### DIFF
--- a/extensions/github-copilot/embeddings.test.ts
+++ b/extensions/github-copilot/embeddings.test.ts
@@ -150,6 +150,7 @@ describe("githubCopilotMemoryEmbeddingProviderAdapter", () => {
 
   it("registers the expected adapter metadata", () => {
     expect(githubCopilotMemoryEmbeddingProviderAdapter.id).toBe("github-copilot");
+    expect(githubCopilotMemoryEmbeddingProviderAdapter.defaultModel).toBeUndefined();
     expect(githubCopilotMemoryEmbeddingProviderAdapter.transport).toBe("remote");
     expect(githubCopilotMemoryEmbeddingProviderAdapter.autoSelectPriority).toBe(15);
     expect(githubCopilotMemoryEmbeddingProviderAdapter.allowExplicitWhenConfiguredAuto).toBe(true);

--- a/extensions/memory-core/src/memory/manager-reindex-state.test.ts
+++ b/extensions/memory-core/src/memory/manager-reindex-state.test.ts
@@ -35,6 +35,7 @@ function createIdentityParams(
     provider?: { id: string; model: string } | null;
     providerKey?: string;
     providerAliases?: Array<{ model: string; providerKey: string }>;
+    providerModelKnown?: boolean;
     providerKeyKnown?: boolean;
     configuredSources?: MemorySource[];
     configuredScopeHash?: string;
@@ -144,6 +145,49 @@ describe("memory reindex state", () => {
         }),
       ),
     ).toEqual({ status: "valid" });
+  });
+
+  it("can defer a dynamic provider model until provider initialization", () => {
+    expect(
+      resolveMemoryIndexIdentityState(
+        createIdentityParams({
+          provider: { id: "openai", model: "fts-only" },
+          providerKey: undefined,
+          providerModelKnown: false,
+          providerKeyKnown: false,
+        }),
+      ),
+    ).toEqual({ status: "valid" });
+  });
+
+  it("keeps provider identity strict while its dynamic model is unresolved", () => {
+    expect(
+      resolveMemoryIndexIdentityState(
+        createIdentityParams({
+          provider: { id: "github-copilot", model: "fts-only" },
+          providerKey: undefined,
+          providerModelKnown: false,
+          providerKeyKnown: false,
+        }),
+      ),
+    ).toEqual({
+      status: "mismatched",
+      reason: "index was built for provider openai, expected github-copilot",
+    });
+  });
+
+  it("compares the discovered dynamic model after provider initialization", () => {
+    expect(
+      resolveMemoryIndexIdentityState(
+        createIdentityParams({
+          provider: { id: "openai", model: "text-embedding-3-large" },
+          providerKey: "provider-key-large",
+        }),
+      ),
+    ).toEqual({
+      status: "mismatched",
+      reason: "index was built for model mock-embed-v1, expected text-embedding-3-large",
+    });
   });
 
   it("keeps model identity strict when paths share a basename", () => {

--- a/extensions/memory-core/src/memory/manager-reindex-state.ts
+++ b/extensions/memory-core/src/memory/manager-reindex-state.ts
@@ -138,6 +138,7 @@ export function resolveMemoryIndexIdentityState(params: {
   provider: { id: string; model: string } | null;
   providerKey?: string;
   providerAliases?: Array<Pick<MemoryIndexProviderIdentity, "model" | "providerKey">>;
+  providerModelKnown?: boolean;
   providerKeyKnown?: boolean;
   configuredSources: MemorySource[];
   configuredScopeHash: string;
@@ -168,7 +169,7 @@ export function resolveMemoryIndexIdentityState(params: {
     { model: expectedModel, providerKey: params.providerKey },
     ...(params.providerAliases ?? []),
   ].filter((identity) => identity.model === meta.model);
-  if (matchingModelIdentities.length === 0) {
+  if (params.providerModelKnown !== false && matchingModelIdentities.length === 0) {
     return {
       status: "mismatched",
       reason: `index was built for model ${meta.model}, expected ${expectedModel}`,
@@ -182,6 +183,7 @@ export function resolveMemoryIndexIdentityState(params: {
     };
   }
   if (
+    params.providerModelKnown !== false &&
     params.providerKeyKnown !== false &&
     !matchingModelIdentities.some((identity) => identity.providerKey === meta.providerKey)
   ) {

--- a/extensions/memory-core/src/memory/manager-sync-base.ts
+++ b/extensions/memory-core/src/memory/manager-sync-base.ts
@@ -46,6 +46,7 @@ import {
 } from "./manager-reindex-state.js";
 import {
   markMemoryVectorRebuildRequired,
+  memoryTableExists,
   requiresMemoryVectorRebuild,
 } from "./manager-vector-rebuild-state.js";
 import type { MemoryWatchSettleQueue } from "./watch-settle.js";
@@ -99,11 +100,6 @@ const EMBEDDING_CACHE_SEED_BATCH_SIZE = 1_000;
 const VECTOR_LOAD_TIMEOUT_MS = 30_000;
 const log = createSubsystemLogger("memory");
 
-function memoryTableExists(db: DatabaseSync, tableName: string): boolean {
-  return Boolean(
-    db.prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?").get(tableName),
-  );
-}
 export abstract class MemoryManagerSyncBase {
   protected readonly acquireLocalService?: MemoryCoreAcquireLocalService;
   protected abstract readonly cfg: OpenClawConfig;
@@ -370,36 +366,37 @@ export abstract class MemoryManagerSyncBase {
     hasIndexedChunks?: boolean;
   }): MemoryIndexIdentityState {
     const hasProviderOverride = params && "provider" in params;
+    const configuredProviderId = this.settings.provider;
     const configuredIndexIdentity =
-      !hasProviderOverride && !this.provider && this.settings.provider !== "none"
+      !hasProviderOverride && !this.provider && configuredProviderId !== "none"
         ? resolveEmbeddingProviderIndexIdentity({
             config: this.cfg,
             agentDir: resolveAgentDir(this.cfg, this.agentId),
             ...resolveMemoryPrimaryProviderRequest({ settings: this.settings }),
           })
         : undefined;
-    // Plain status can compare identity before provider init. Mirror provider
-    // init's empty-model fallback so adapter defaults do not look mismatched.
+    const configuredModel =
+      configuredProviderId === "none"
+        ? ""
+        : this.settings.model.trim() ||
+          resolveEmbeddingProviderFallbackModel(configuredProviderId, "", this.cfg);
     const configuredProvider =
-      this.settings.provider === "none"
+      configuredProviderId === "none"
         ? null
         : (configuredIndexIdentity?.provider ?? {
             id:
-              resolveEmbeddingProviderAdapterId(this.settings.provider, this.cfg) ??
-              this.settings.provider,
-            model:
-              this.settings.model.trim() ||
-              resolveEmbeddingProviderFallbackModel(this.settings.provider, "fts-only", this.cfg),
+              resolveEmbeddingProviderAdapterId(configuredProviderId, this.cfg) ??
+              configuredProviderId,
+            model: configuredModel || "fts-only",
           });
     const provider = hasProviderOverride
       ? params.provider!
       : this.provider
         ? { id: this.provider.id, model: this.provider.model }
         : configuredProvider;
-    const vectorReady =
-      params && "vectorReady" in params
-        ? Boolean(params.vectorReady)
-        : this.vector.available === true;
+    const vectorReady = Boolean(
+      params && "vectorReady" in params ? params.vectorReady : this.vector.available,
+    );
     const initializedProviderIdentities =
       provider &&
       this.provider &&
@@ -419,6 +416,9 @@ export abstract class MemoryManagerSyncBase {
         ? initializedProviderIdentities
         : configuredProviderIdentities;
     const configuredProviderKeyKnown = configuredProviderIdentities.length > 0;
+    const configuredProviderModelKnown =
+      configuredProviderId === "none" ||
+      Boolean(this.provider || configuredIndexIdentity || configuredModel);
     return resolveMemoryIndexIdentityState({
       meta: params && "meta" in params ? params.meta! : this.readMeta(),
       provider,
@@ -428,6 +428,7 @@ export abstract class MemoryManagerSyncBase {
           ? undefined
           : (this.providerKey ?? undefined),
       providerAliases: providerIdentities.slice(1),
+      providerModelKnown: hasProviderOverride ? true : configuredProviderModelKnown,
       providerKeyKnown: configuredProviderKeyKnown ? true : params?.providerKeyKnown,
       configuredSources: resolveConfiguredSourcesForMeta(this.sources),
       configuredScopeHash: resolveConfiguredScopeHash({

--- a/extensions/memory-core/src/memory/manager-vector-rebuild-state.ts
+++ b/extensions/memory-core/src/memory/manager-vector-rebuild-state.ts
@@ -7,7 +7,7 @@ import {
 
 const VECTOR_REBUILD_META_KEY = "memory_vector_rebuild_v1";
 
-function vectorTableExists(db: DatabaseSync, tableName: string): boolean {
+export function memoryTableExists(db: DatabaseSync, tableName: string): boolean {
   return Boolean(
     db.prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?").get(tableName),
   );
@@ -49,7 +49,7 @@ export function resolvePersistedMemoryVectorIndexState(params: {
   if (row?.value === "1") {
     return { state: "incomplete" };
   }
-  if (!vectorTableExists(params.db, params.vectorTable)) {
+  if (!memoryTableExists(params.db, params.vectorTable)) {
     return params.metaVectorDims && params.hasSemanticChunks
       ? { state: "incomplete" }
       : { state: "empty" };

--- a/extensions/memory-core/src/memory/manager.fts-only-reindex.test.ts
+++ b/extensions/memory-core/src/memory/manager.fts-only-reindex.test.ts
@@ -4,12 +4,18 @@ import os from "node:os";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
+import { MEMORY_CHUNKING_VERSION } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import { resetPluginStateStoreForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { resolveOpenClawAgentSqlitePath } from "openclaw/plugin-sdk/sqlite-runtime";
 import { closeOpenClawAgentDatabasesForTest } from "openclaw/plugin-sdk/sqlite-runtime-testing";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { closeAllMemorySearchManagers, getMemorySearchManager } from "./index.js";
-import type { MemoryIndexMeta } from "./manager-reindex-state.js";
+import {
+  MEMORY_INDEX_PROVENANCE_VERSION,
+  resolveConfiguredScopeHash,
+  resolveConfiguredSourcesForMeta,
+  type MemoryIndexMeta,
+} from "./manager-reindex-state.js";
 import { closeAllMemoryIndexManagers, type MemoryIndexManager } from "./manager.js";
 import "./test-runtime-mocks.js";
 
@@ -70,7 +76,8 @@ vi.mock("./embeddings.js", () => ({
   resolveEmbeddingProviderAdapterTransport: (providerId: string) =>
     providerId === "local" ? "local" : "remote",
   resolveEmbeddingProviderIndexIdentity: () => undefined,
-  resolveEmbeddingProviderFallbackModel: () => "fts-only",
+  resolveEmbeddingProviderFallbackModel: (_providerId: string, fallbackModel: string) =>
+    fallbackModel,
 }));
 
 describe("memory manager FTS-only reindex", () => {
@@ -119,7 +126,11 @@ describe("memory manager FTS-only reindex", () => {
   });
 
   async function createManager(
-    params: { provider?: string; vectorEnabled?: boolean } = {},
+    params: {
+      provider?: string;
+      purpose?: "default" | "status";
+      vectorEnabled?: boolean;
+    } = {},
   ): Promise<MemoryIndexManager> {
     const store =
       params.vectorEnabled === undefined
@@ -146,7 +157,11 @@ describe("memory manager FTS-only reindex", () => {
         list: [{ id: "main", default: true }],
       },
     } as OpenClawConfig;
-    const result = await getMemorySearchManager({ cfg, agentId: "main" });
+    const result = await getMemorySearchManager({
+      cfg,
+      agentId: "main",
+      purpose: params.purpose,
+    });
     if (!result.manager) {
       throw new Error(result.error ?? "manager missing");
     }
@@ -178,6 +193,57 @@ describe("memory manager FTS-only reindex", () => {
       sources: ["memory"],
     });
   }
+
+  it("defers a persisted dynamic model identity before provider initialization", async () => {
+    const persistedModel = "text-embedding-3-large";
+    const memoryManager = await createManager({
+      provider: "github-copilot",
+      purpose: "status",
+    });
+    const settings = Reflect.get(memoryManager, "settings") as {
+      chunking: { tokens: number; overlap: number };
+      extraPaths: string[];
+      multimodal: { enabled: boolean; modalities: string[]; maxFileBytes: number };
+      store: { fts: { tokenizer: string } };
+    };
+    const sources = Reflect.get(memoryManager, "sources") as Set<"memory" | "sessions">;
+    const metaWriter = memoryManager as unknown as {
+      writeMeta(meta: MemoryIndexMeta): void;
+    };
+    metaWriter.writeMeta({
+      model: persistedModel,
+      provider: "github-copilot",
+      providerKey: "persisted-copilot-key",
+      sources: resolveConfiguredSourcesForMeta(sources),
+      scopeHash: resolveConfiguredScopeHash({
+        workspaceDir,
+        extraPaths: settings.extraPaths,
+        multimodal: settings.multimodal,
+      }),
+      chunkTokens: settings.chunking.tokens,
+      chunkOverlap: settings.chunking.overlap,
+      chunkingVersion: MEMORY_CHUNKING_VERSION,
+      ftsTokenizer: settings.store.fts.tokenizer,
+      provenanceVersion: MEMORY_INDEX_PROVENANCE_VERSION,
+    });
+    const db = Reflect.get(memoryManager, "db") as DatabaseSync;
+    db.prepare(
+      `INSERT INTO memory_index_chunks
+       (id, path, source, start_line, end_line, hash, model, text, embedding, updated_at)
+       VALUES (?, ?, 'memory', 1, 1, ?, ?, ?, ?, ?)`,
+    ).run(
+      "persisted-copilot-chunk",
+      "memory/copilot.md",
+      "persisted-copilot-hash",
+      persistedModel,
+      "Persisted Copilot semantic chunk.",
+      "[1,0]",
+      Date.now(),
+    );
+
+    expect(Reflect.get(memoryManager, "providerInitialized")).toBe(false);
+    expect(memoryManager.status().custom?.indexIdentity).toEqual({ status: "valid" });
+  });
 
   it("preserves indexed chunks across forced reindex in FTS-only mode", async () => {
     const memoryManager = await createManager();


### PR DESCRIPTION
Closes #113553

## What Problem This Solves

Plain Memory Core status runs before a discovery-owned embedding provider is initialized. GitHub Copilot has no unconditional embedding-model default, so a persisted Copilot semantic index was compared to `fts-only` and falsely reported as mismatched.

The repair carries the fact that the configured model is unknown into the shared identity resolver. It defers only model and provider-key comparison in that state. Provider identity, sources, scope, chunking, vector metadata, and tokenizer checks remain strict. Explicit models and discovered runtime models remain strict.

The follow-up also preserves the explicit FTS-only boundary: status for `memory.search.provider: "none"` must not consult the embedding-provider adapter registry. The shared SQLite table-existence helper avoids duplicating that boundary logic.

## Evidence

- Current base: `9bc772ba5068615c8c04c7226fd01a6970a89baa`
- Current head: `5435f2a7356ce049347223a7dcacbbbb8fb11518`
- Environment: macOS arm64, Node 22.23.0, isolated temporary `OPENCLAW_STATE_DIR`, production source modules, real SQLite index database
- Copilot scenario: a persisted `github-copilot/text-embedding-3-large` semantic index with an indexed vector chunk; plain status has no configured model and does not initialize the provider.

The baseline production `MemoryIndexManager.status()` path reports:

```text
providerInitialized=false
indexIdentity={ status: mismatched, reason: index was built for model text-embedding-3-large, expected fts-only }
```

The same production path on the repair reports:

```text
providerInitialized=false
indexIdentity={ status: valid }
```

The baseline was reproduced on `747a49e7a7abc0e868e1d1a219b43ef9416bc9cf`; the six touched files have no upstream changes between that commit and the current base `9bc772ba5068615c8c04c7226fd01a6970a89baa`. No GitHub credential, provider mock, or external embedding request is involved in this before/after proof.

## Coverage And Validation

- Focused regression set: 3 test files / 53 tests passed (Copilot adapter metadata, generic identity, and persisted real-SQLite status).
- Full affected Memory Core adjacency set plus focused coverage: 14 test files / 161 tests passed across the repository's Memory Core and provider Vitest projects.
- Regressions cover the unresolved dynamic model, strict provider mismatch while unresolved, strict model comparison once known, explicit FTS-only behavior, and legacy migration cleanup.
- Targeted type-aware Oxlint on all six changed files: passed.
- `pnpm format:check` (29,757 files), `git diff HEAD^ --check`, and TruffleHog exact-commit scan: passed; 0 verified and 0 unverified secrets.

The branch changes three production files and three focused regression files. It is rebased directly on current main and is ready for exact-head CI and maintainer review.
