### PR TITLE
improve(agents): speed up warm turn model preparation

### DIFF
--- a/src/agents/embedded-agent-runner.e2e.test.ts
+++ b/src/agents/embedded-agent-runner.e2e.test.ts
@@ -808,6 +808,7 @@ describe("runEmbeddedAgent", () => {
         skipAgentDiscovery: true,
         allowBundledStaticCatalogFallback: true,
         preferBundledStaticCatalogTransport: true,
+        preparedRuntimeModels: expect.any(Array),
       }),
     );
     expect(ensureOpenClawModelsJsonMock).toHaveBeenCalledTimes(1);

--- a/src/agents/embedded-agent-runner/model.configured-overrides.ts
+++ b/src/agents/embedded-agent-runner/model.configured-overrides.ts
@@ -20,6 +20,7 @@ import {
 } from "./model.compat.js";
 import {
   buildInlineProviderModels,
+  type InlineModelEntry,
   type InlineProviderConfig,
   normalizeResolvedTransportApi,
   resolveProviderModelInput,
@@ -125,6 +126,7 @@ function matchesProviderScopedModelId(params: {
 
 export function findInlineModelMatch(params: {
   providers: Record<string, InlineProviderConfig>;
+  preparedModels?: readonly InlineModelEntry[];
   provider: string;
   modelId: string;
 }) {
@@ -134,7 +136,7 @@ export function findInlineModelMatch(params: {
       provider: entry.provider,
       modelId: params.modelId,
     });
-  const inlineModels = buildInlineProviderModels(params.providers);
+  const inlineModels = params.preparedModels ?? buildInlineProviderModels(params.providers);
   const exact = inlineModels.find(
     (entry) => entry.provider === params.provider && matchesModelId(entry),
   );

--- a/src/agents/embedded-agent-runner/model.inline-provider.test.ts
+++ b/src/agents/embedded-agent-runner/model.inline-provider.test.ts
@@ -295,6 +295,33 @@ describe("buildInlineProviderModels", () => {
   });
 });
 
+describe("buildInlineProviderModels caching", () => {
+  it("reuses the projection for a repeated providers object", () => {
+    // Model resolution calls this several times per agent turn; rebuilding the
+    // projection each time is synchronous work on the gateway event loop.
+    const providers: Parameters<typeof buildInlineProviderModels>[0] = {
+      alpha: { baseUrl: "http://alpha.local", models: [makeModel("alpha-model")] },
+    };
+
+    expect(buildInlineProviderModels(providers)).toBe(buildInlineProviderModels(providers));
+  });
+
+  it("rebuilds when a different providers object is supplied", () => {
+    const first: Parameters<typeof buildInlineProviderModels>[0] = {
+      alpha: { baseUrl: "http://alpha.local", models: [makeModel("alpha-model")] },
+    };
+    const second: Parameters<typeof buildInlineProviderModels>[0] = {
+      alpha: { baseUrl: "http://alpha.local", models: [makeModel("beta-model")] },
+    };
+
+    const firstResult = buildInlineProviderModels(first);
+    const secondResult = buildInlineProviderModels(second);
+
+    expect(secondResult).not.toBe(firstResult);
+    expect(expectDefined(secondResult[0], "secondResult[0] test invariant").id).toBe("beta-model");
+  });
+});
+
 describe("resolveProviderModelInput", () => {
   it("keeps configured Anthropic model input unchanged before provider-owned normalization", () => {
     expect(

--- a/src/agents/embedded-agent-runner/model.inline-provider.test.ts
+++ b/src/agents/embedded-agent-runner/model.inline-provider.test.ts
@@ -6,6 +6,20 @@ import { buildInlineProviderModels, resolveProviderModelInput } from "./model.in
 import { makeModel } from "./model.test-harness.js";
 
 describe("buildInlineProviderModels", () => {
+  it("reflects in-place changes for callers without a prepared snapshot", () => {
+    const providers: Parameters<typeof buildInlineProviderModels>[0] = {
+      alpha: { baseUrl: "http://alpha.local", models: [makeModel("first-model")] },
+    };
+
+    expect(expectDefined(buildInlineProviderModels(providers)[0], "first model").id).toBe(
+      "first-model",
+    );
+    expectDefined(providers.alpha, "alpha provider").models = [makeModel("second-model")];
+    expect(expectDefined(buildInlineProviderModels(providers)[0], "second model").id).toBe(
+      "second-model",
+    );
+  });
+
   it("attaches provider ids to inline models", () => {
     // Provider object keys are the source of truth for inline model provider ids;
     // trim them before runtime lookup stores the model.
@@ -292,33 +306,6 @@ describe("buildInlineProviderModels", () => {
     expect(expectDefined(result[0], "result[0] test invariant").headers).toEqual({
       "X-Static": "tenant-a",
     });
-  });
-});
-
-describe("buildInlineProviderModels caching", () => {
-  it("reuses the projection for a repeated providers object", () => {
-    // Model resolution calls this several times per agent turn; rebuilding the
-    // projection each time is synchronous work on the gateway event loop.
-    const providers: Parameters<typeof buildInlineProviderModels>[0] = {
-      alpha: { baseUrl: "http://alpha.local", models: [makeModel("alpha-model")] },
-    };
-
-    expect(buildInlineProviderModels(providers)).toBe(buildInlineProviderModels(providers));
-  });
-
-  it("rebuilds when a different providers object is supplied", () => {
-    const first: Parameters<typeof buildInlineProviderModels>[0] = {
-      alpha: { baseUrl: "http://alpha.local", models: [makeModel("alpha-model")] },
-    };
-    const second: Parameters<typeof buildInlineProviderModels>[0] = {
-      alpha: { baseUrl: "http://alpha.local", models: [makeModel("beta-model")] },
-    };
-
-    const firstResult = buildInlineProviderModels(first);
-    const secondResult = buildInlineProviderModels(second);
-
-    expect(secondResult).not.toBe(firstResult);
-    expect(expectDefined(secondResult[0], "secondResult[0] test invariant").id).toBe("beta-model");
   });
 });
 

--- a/src/agents/embedded-agent-runner/model.inline-provider.ts
+++ b/src/agents/embedded-agent-runner/model.inline-provider.ts
@@ -16,7 +16,7 @@ import {
 /**
  * Normalizes inline `models.providers` config into runtime model entries.
  */
-type InlineModelEntry = Omit<ModelDefinitionConfig, "api"> & {
+export type InlineModelEntry = Omit<ModelDefinitionConfig, "api"> & {
   api?: Api;
   provider: string;
   baseUrl?: string;
@@ -139,28 +139,7 @@ function resolveInlineProviderTransport(params: { api?: Api | null; baseUrl?: st
 }
 
 /** Builds runtime model records from inline provider config, inheriting provider-level defaults. */
-// Inline entries are a pure projection of `models.providers`, but embedded runs
-// rebuilt them on every model resolution (~4x per agent turn), and the work is
-// synchronous, so it blocked the gateway event loop. Config objects are replaced
-// rather than mutated on reload, so object identity is a safe cache key.
-const inlineProviderModelsCache = new WeakMap<
-  Record<string, InlineProviderConfig>,
-  InlineModelEntry[]
->();
-
 export function buildInlineProviderModels(
-  providers: Record<string, InlineProviderConfig>,
-): InlineModelEntry[] {
-  const cached = inlineProviderModelsCache.get(providers);
-  if (cached) {
-    return cached;
-  }
-  const built = buildInlineProviderModelsUncached(providers);
-  inlineProviderModelsCache.set(providers, built);
-  return built;
-}
-
-function buildInlineProviderModelsUncached(
   providers: Record<string, InlineProviderConfig>,
 ): InlineModelEntry[] {
   return Object.entries(providers).flatMap(([providerId, entry]) => {

--- a/src/agents/embedded-agent-runner/model.inline-provider.ts
+++ b/src/agents/embedded-agent-runner/model.inline-provider.ts
@@ -139,7 +139,28 @@ function resolveInlineProviderTransport(params: { api?: Api | null; baseUrl?: st
 }
 
 /** Builds runtime model records from inline provider config, inheriting provider-level defaults. */
+// Inline entries are a pure projection of `models.providers`, but embedded runs
+// rebuilt them on every model resolution (~4x per agent turn), and the work is
+// synchronous, so it blocked the gateway event loop. Config objects are replaced
+// rather than mutated on reload, so object identity is a safe cache key.
+const inlineProviderModelsCache = new WeakMap<
+  Record<string, InlineProviderConfig>,
+  InlineModelEntry[]
+>();
+
 export function buildInlineProviderModels(
+  providers: Record<string, InlineProviderConfig>,
+): InlineModelEntry[] {
+  const cached = inlineProviderModelsCache.get(providers);
+  if (cached) {
+    return cached;
+  }
+  const built = buildInlineProviderModelsUncached(providers);
+  inlineProviderModelsCache.set(providers, built);
+  return built;
+}
+
+function buildInlineProviderModelsUncached(
   providers: Record<string, InlineProviderConfig>,
 ): InlineModelEntry[] {
   return Object.entries(providers).flatMap(([providerId, entry]) => {

--- a/src/agents/embedded-agent-runner/model.registry-resolution.ts
+++ b/src/agents/embedded-agent-runner/model.registry-resolution.ts
@@ -17,6 +17,7 @@ import {
   shouldSuppressConfiguredModel,
   type StaticCatalogFallbackModel,
 } from "./model.configured-overrides.js";
+import type { InlineModelEntry } from "./model.inline-provider.js";
 import {
   DEFAULT_PROVIDER_RUNTIME_HOOKS,
   normalizeResolvedModel,
@@ -43,11 +44,13 @@ export function resolveExplicitModelWithRegistry(params: {
   manifestAlias: ManifestModelCatalogProviderAliasMetadata;
   workspaceDir?: string;
   runtimeHooks?: ProviderRuntimeHooks;
+  preparedInlineProviderModels?: readonly InlineModelEntry[];
 }): ExplicitModelResolution | undefined {
   const { provider, modelId, modelRegistry, cfg, agentDir, workspaceDir, runtimeHooks } = params;
   const providerConfig = resolveConfiguredProviderConfig(cfg, provider);
   const inlineMatch = findInlineModelMatch({
     providers: cfg?.models?.providers ?? {},
+    preparedModels: params.preparedInlineProviderModels,
     provider,
     modelId,
   });

--- a/src/agents/embedded-agent-runner/model.test.ts
+++ b/src/agents/embedded-agent-runner/model.test.ts
@@ -841,6 +841,50 @@ describe("resolveModel", () => {
     expect(discoverModels).not.toHaveBeenCalled();
   });
 
+  it("reuses a prepared configured static model before request-time catalog resolution", async () => {
+    const preparedModel = {
+      provider: "mistral",
+      id: "mistral-medium-3-5",
+      name: "Mistral Medium 3.5",
+      api: "openai-completions" as const,
+      baseUrl: "https://api.mistral.ai/v1",
+      reasoning: true,
+      input: ["text" as const, "image" as const],
+      cost: { input: 1.5, output: 7.5, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 262144,
+      maxTokens: 8192,
+    };
+
+    const result = await resolveModelAsync(
+      "mistral",
+      "mistral-medium-3-5",
+      "/tmp/agent",
+      undefined,
+      {
+        allowBundledStaticCatalogFallback: true,
+        preparedRuntimeModels: [
+          {
+            provider: "mistral",
+            modelId: "mistral-medium-3-5",
+            model: preparedModel,
+          },
+        ],
+        runtimeHooks: createRuntimeHooks(),
+        skipAgentDiscovery: true,
+      },
+    );
+
+    expectRecordFields(expectResolvedModel(result), {
+      provider: "mistral",
+      id: "mistral-medium-3-5",
+      api: "openai-completions",
+      contextWindow: 262144,
+      maxTokens: 8192,
+    });
+    expect(resolveBundledStaticCatalogModelMock).not.toHaveBeenCalled();
+    expect(resolveBundledProviderStaticCatalogModelMock).not.toHaveBeenCalled();
+  });
+
   it("resolves opt-in provider static catalog rows while skipping agent discovery", async () => {
     resolveBundledProviderStaticCatalogModelMock.mockResolvedValueOnce({
       provider: "google",

--- a/src/agents/embedded-agent-runner/model.test.ts
+++ b/src/agents/embedded-agent-runner/model.test.ts
@@ -38,6 +38,7 @@ const preparedSnapshotState = vi.hoisted(() => ({
   enabled: true,
   getInputs: [] as Array<Record<string, unknown>>,
   snapshots: new Map<string, unknown>(),
+  configuredRuntimeModels: [] as unknown[],
 }));
 
 vi.mock("../model-suppression.js", () => {
@@ -176,6 +177,7 @@ vi.mock("../prepared-model-runtime.js", async () => {
     }
     const snapshot = {
       ...(workspaceDir ? { workspaceDir } : {}),
+      configuredRuntimeModels: preparedSnapshotState.configuredRuntimeModels,
       createStores: () => ({ authStorage, modelRegistry }),
     };
     preparedSnapshotState.snapshots.set(key, snapshot);
@@ -247,6 +249,7 @@ beforeEach(() => {
   preparedSnapshotState.enabled = true;
   preparedSnapshotState.getInputs.length = 0;
   preparedSnapshotState.snapshots.clear();
+  preparedSnapshotState.configuredRuntimeModels = [];
   clearRuntimeAuthProfileStoreSnapshots();
   resetMockDiscoverModels(discoverModels);
   vi.mocked(discoverModels).mockClear();
@@ -841,7 +844,7 @@ describe("resolveModel", () => {
     expect(discoverModels).not.toHaveBeenCalled();
   });
 
-  it("reuses a prepared configured static model before request-time catalog resolution", async () => {
+  it("reuses configured static models from the loaded snapshot", async () => {
     const preparedModel = {
       provider: "mistral",
       id: "mistral-medium-3-5",
@@ -855,6 +858,14 @@ describe("resolveModel", () => {
       maxTokens: 8192,
     };
 
+    preparedSnapshotState.configuredRuntimeModels = [
+      {
+        provider: "mistral",
+        modelId: "mistral-medium-3-5",
+        model: preparedModel,
+      },
+    ];
+
     const result = await resolveModelAsync(
       "mistral",
       "mistral-medium-3-5",
@@ -862,15 +873,7 @@ describe("resolveModel", () => {
       undefined,
       {
         allowBundledStaticCatalogFallback: true,
-        preparedRuntimeModels: [
-          {
-            provider: "mistral",
-            modelId: "mistral-medium-3-5",
-            model: preparedModel,
-          },
-        ],
         runtimeHooks: createRuntimeHooks(),
-        skipAgentDiscovery: true,
       },
     );
 

--- a/src/agents/embedded-agent-runner/model.ts
+++ b/src/agents/embedded-agent-runner/model.ts
@@ -24,6 +24,7 @@ import {
   applyConfiguredProviderOverrides,
   resolveConfiguredProviderConfig,
 } from "./model.configured-overrides.js";
+import type { InlineModelEntry } from "./model.inline-provider.js";
 import {
   DEFAULT_PROVIDER_RUNTIME_HOOKS,
   normalizeResolvedModel,
@@ -65,6 +66,7 @@ type AsyncModelResolutionOptions = CommonModelResolutionOptions & {
   agentRuntimeId?: string;
   skipAgentDiscovery?: boolean;
   preparedRuntimeModels?: readonly PreparedConfiguredRuntimeModel[];
+  preparedInlineProviderModels?: readonly InlineModelEntry[];
 };
 
 /** Creates isolated model/auth stores for harnesses that own model discovery themselves. */
@@ -255,6 +257,8 @@ export async function resolveModelAsync(
     manifestAlias: normalizedRef.manifestAlias,
     workspaceDir,
     runtimeHooks,
+    preparedInlineProviderModels:
+      options?.preparedInlineProviderModels ?? preparedSnapshot?.inlineProviderModels,
   });
   if (explicitModel?.kind === "suppressed") {
     const suppressedRuntimeModel = resolveRuntimePreferredSuppressedModel({

--- a/src/agents/embedded-agent-runner/model.ts
+++ b/src/agents/embedded-agent-runner/model.ts
@@ -11,6 +11,7 @@ import {
   getPreparedModelRuntimeSnapshot,
   loadPreparedModelRuntimeSnapshot,
 } from "../prepared-model-runtime.js";
+import type { PreparedConfiguredRuntimeModel } from "../prepared-model-runtime.owner.js";
 import {
   AuthStorage as AgentAuthStorageClass,
   ModelRegistry as AgentModelRegistryClass,
@@ -41,6 +42,7 @@ import {
   resolveBundledProviderStaticCatalogModel,
   resolveBundledStaticCatalogModel,
 } from "./model.static-catalog.js";
+import { staticModelIdMatches } from "./model.static-id.js";
 
 export { resolveModelWithRegistry } from "./model.registry-resolution.js";
 
@@ -62,6 +64,7 @@ type AsyncModelResolutionOptions = CommonModelResolutionOptions & {
   retryTransientProviderRuntimeMiss?: boolean;
   agentRuntimeId?: string;
   skipAgentDiscovery?: boolean;
+  preparedRuntimeModels?: readonly PreparedConfiguredRuntimeModel[];
 };
 
 /** Creates isolated model/auth stores for harnesses that own model discovery themselves. */
@@ -300,6 +303,17 @@ export async function resolveModelAsync(
       return undefined;
     }
     staticCatalogLookup ??= (async () => {
+      const preparedModel = options.preparedRuntimeModels?.find((candidate) =>
+        staticModelIdMatches({
+          candidateId: candidate.modelId,
+          rowProvider: candidate.provider,
+          provider: normalizedRef.provider,
+          modelId: normalizedRef.model,
+        }),
+      )?.model;
+      if (preparedModel) {
+        return preparedModel;
+      }
       const manifestModel = resolveBundledStaticCatalogModel({
         provider: normalizedRef.provider,
         modelId: normalizedRef.model,

--- a/src/agents/embedded-agent-runner/model.ts
+++ b/src/agents/embedded-agent-runner/model.ts
@@ -307,7 +307,9 @@ export async function resolveModelAsync(
       return undefined;
     }
     staticCatalogLookup ??= (async () => {
-      const preparedModel = options.preparedRuntimeModels?.find((candidate) =>
+      const preparedModel = (
+        options.preparedRuntimeModels ?? preparedSnapshot?.configuredRuntimeModels
+      )?.find((candidate) =>
         staticModelIdMatches({
           candidateId: candidate.modelId,
           rowProvider: candidate.provider,

--- a/src/agents/embedded-agent-runner/run/auth-plan.ts
+++ b/src/agents/embedded-agent-runner/run/auth-plan.ts
@@ -7,6 +7,7 @@ import {
   ensureAuthProfileStoreWithoutExternalProfiles,
 } from "../../model-auth.js";
 import { OPENAI_PROVIDER_ID } from "../../openai-routing.js";
+import type { PreparedModelRuntimeSnapshot } from "../../prepared-model-runtime.js";
 import {
   createPreparedRuntimeModelMaterializer,
   providerUsesCredentialScopedModelMetadata,
@@ -53,6 +54,7 @@ export async function prepareEmbeddedRunAuthPlan(params: {
   nativeModelOwned: boolean;
   authStorage: ModelResolution["authStorage"];
   modelRegistry: ModelResolution["modelRegistry"];
+  preparedModelRuntime?: PreparedModelRuntimeSnapshot;
   getAgentHarness: () => AgentHarness;
   setAgentHarness: (harness: AgentHarness) => void;
   getRuntimeModel: () => RuntimeModel;
@@ -187,6 +189,8 @@ export async function prepareEmbeddedRunAuthPlan(params: {
           skipAgentDiscovery: true,
           allowBundledStaticCatalogFallback: true,
           preferBundledStaticCatalogTransport: true,
+          preparedRuntimeModels: params.preparedModelRuntime?.configuredRuntimeModels,
+          preparedInlineProviderModels: params.preparedModelRuntime?.inlineProviderModels,
           workspaceDir: params.workspaceDir,
           authProfileId,
           authProfileMode,

--- a/src/agents/embedded-agent-runner/run/model-setup.ts
+++ b/src/agents/embedded-agent-runner/run/model-setup.ts
@@ -127,6 +127,7 @@ export async function resolveEmbeddedRunModelSetup(params: {
           skipAgentDiscovery: true,
           allowBundledStaticCatalogFallback: pluginHarnessOwnsTransport,
           preferBundledStaticCatalogTransport: pluginHarnessOwnsTransport,
+          preparedRuntimeModels: params.preparedModelRuntime?.configuredRuntimeModels,
           workspaceDir: params.workspaceDir,
           authProfileId: runParams.authProfileId,
         },
@@ -164,6 +165,7 @@ export async function resolveEmbeddedRunModelSetup(params: {
             workspaceDir: params.workspaceDir,
             authProfileId: runParams.authProfileId,
             allowBundledStaticCatalogFallback: true,
+            preparedRuntimeModels: preparedModelRuntime.configuredRuntimeModels,
           },
         );
         firstModelResolution ??= candidateResolution;

--- a/src/agents/embedded-agent-runner/run/model-setup.ts
+++ b/src/agents/embedded-agent-runner/run/model-setup.ts
@@ -128,6 +128,7 @@ export async function resolveEmbeddedRunModelSetup(params: {
           allowBundledStaticCatalogFallback: pluginHarnessOwnsTransport,
           preferBundledStaticCatalogTransport: pluginHarnessOwnsTransport,
           preparedRuntimeModels: params.preparedModelRuntime?.configuredRuntimeModels,
+          preparedInlineProviderModels: params.preparedModelRuntime?.inlineProviderModels,
           workspaceDir: params.workspaceDir,
           authProfileId: runParams.authProfileId,
         },
@@ -166,6 +167,7 @@ export async function resolveEmbeddedRunModelSetup(params: {
             authProfileId: runParams.authProfileId,
             allowBundledStaticCatalogFallback: true,
             preparedRuntimeModels: preparedModelRuntime.configuredRuntimeModels,
+            preparedInlineProviderModels: preparedModelRuntime.inlineProviderModels,
           },
         );
         firstModelResolution ??= candidateResolution;

--- a/src/agents/embedded-agent-runner/run/runtime-preparation.ts
+++ b/src/agents/embedded-agent-runner/run/runtime-preparation.ts
@@ -162,6 +162,7 @@ export async function prepareEmbeddedRunRuntime(input: {
     nativeModelOwned,
     authStorage,
     modelRegistry,
+    preparedModelRuntime: input.preparedModelRuntime,
     getAgentHarness: () => agentHarness,
     setAgentHarness: (nextHarness) => {
       agentHarness = nextHarness;

--- a/src/agents/prepared-model-runtime.lifecycle.test.ts
+++ b/src/agents/prepared-model-runtime.lifecycle.test.ts
@@ -78,6 +78,7 @@ vi.mock("./runtime-plugins.js", () => ({
 vi.mock("./embedded-agent-runner/model.static-catalog.js", () => ({
   loadBundledProviderStaticCatalogContextModels: (...args: Parameters<LoadStaticCatalog>) =>
     mocks.loadStaticCatalog(...args),
+  resolveBundledStaticCatalogModel: () => undefined,
 }));
 
 vi.mock("../logging/subsystem.js", () => ({

--- a/src/agents/prepared-model-runtime.owner.ts
+++ b/src/agents/prepared-model-runtime.owner.ts
@@ -14,6 +14,7 @@ import {
   getPreparedMessageToolCatalog,
   getPreparedMessageToolCatalogForRegistry,
 } from "../plugins/prepared-message-tool-catalog.js";
+import type { ProviderRuntimeModel } from "../plugins/provider-runtime-model.types.js";
 import { isReservedSystemAgentId } from "../system-agent/agent-id.js";
 import { discoverAuthStorage, discoverModels } from "./agent-model-discovery.js";
 import {
@@ -23,7 +24,11 @@ import {
   resolveDefaultAgentDir,
   resolveDefaultAgentId,
 } from "./agent-scope.js";
-import { loadBundledProviderStaticCatalogContextModels } from "./embedded-agent-runner/model.static-catalog.js";
+import {
+  loadBundledProviderStaticCatalogContextModels,
+  resolveBundledStaticCatalogModel,
+} from "./embedded-agent-runner/model.static-catalog.js";
+import { staticModelIdMatches } from "./embedded-agent-runner/model.static-id.js";
 import { buildPreparedModelCatalogSnapshot, type ModelCatalogEntry } from "./model-catalog.js";
 import type { ModelCatalogSnapshot } from "./model-catalog.types.js";
 import { ensureOpenClawModelsJson } from "./models-config.js";
@@ -47,7 +52,15 @@ export type PreparedModelRuntimeSnapshot = Readonly<{
   messageToolCatalog?: PreparedMessageToolCatalog;
   mediaCapabilityProviders?: ReturnType<typeof prepareMediaCapabilityProviders>;
   modelCatalog: ModelCatalogSnapshot;
+  /** Full static models for configured refs, resolved once at the lifecycle boundary. */
+  configuredRuntimeModels: readonly PreparedConfiguredRuntimeModel[];
   createStores: () => PreparedModelRuntimeStores;
+}>;
+
+export type PreparedConfiguredRuntimeModel = Readonly<{
+  provider: string;
+  modelId: string;
+  model: ProviderRuntimeModel;
 }>;
 
 export type PreparedModelRuntimeStores = {
@@ -292,6 +305,55 @@ function collectPreparedModelRuntimeProviderIds(
   return [...providerIds].toSorted((left, right) => left.localeCompare(right));
 }
 
+function prepareConfiguredRuntimeModels(params: {
+  config: OpenClawConfig;
+  env: NodeJS.ProcessEnv;
+  providerStaticModels: readonly ProviderRuntimeModel[];
+  workspaceDir?: string;
+}): PreparedConfiguredRuntimeModel[] {
+  const prepared: PreparedConfiguredRuntimeModel[] = [];
+  const seen = new Set<string>();
+  for (const { value } of collectConfiguredModelRefs(params.config)) {
+    const separator = value.indexOf("/");
+    if (separator <= 0 || separator >= value.length - 1) {
+      continue;
+    }
+    const provider = normalizeProviderId(value.slice(0, separator));
+    const modelId = value.slice(separator + 1).trim();
+    if (!provider || !modelId) {
+      continue;
+    }
+    const key = `${provider}\0${modelId.toLowerCase()}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    // Match request-time fallback precedence exactly: manifest/runtime-discovery rows win,
+    // and the provider-static catalog fills only models absent from that surface.
+    const model =
+      resolveBundledStaticCatalogModel({
+        provider,
+        modelId,
+        cfg: params.config,
+        env: params.env,
+        workspaceDir: params.workspaceDir,
+        includeRuntimeDiscovery: true,
+      }) ??
+      params.providerStaticModels.find((candidate) =>
+        staticModelIdMatches({
+          candidateId: candidate.id,
+          rowProvider: candidate.provider,
+          provider,
+          modelId,
+        }),
+      );
+    if (model) {
+      prepared.push({ provider, modelId, model });
+    }
+  }
+  return prepared;
+}
+
 export function ownerKey(input: PreparedModelRuntimeInput): string {
   return JSON.stringify({
     agentId: input.agentId,
@@ -460,14 +522,19 @@ async function buildSnapshot(
     ...(input.readOnly ? { readOnly: true } : {}),
     ...(input.workspaceDir ? { workspaceDir: input.workspaceDir } : {}),
   });
-  const staticEntries = (
-    await loadBundledProviderStaticCatalogContextModels({
-      cfg: input.config,
-      env,
-      ...(catalogMode === "static" ? { providerIds } : {}),
-      ...(input.workspaceDir ? { workspaceDir: input.workspaceDir } : {}),
-    })
-  ).map(toStaticCatalogEntry);
+  const providerStaticModels = await loadBundledProviderStaticCatalogContextModels({
+    cfg: input.config,
+    env,
+    ...(catalogMode === "static" ? { providerIds } : {}),
+    ...(input.workspaceDir ? { workspaceDir: input.workspaceDir } : {}),
+  });
+  const staticEntries = providerStaticModels.map(toStaticCatalogEntry);
+  const configuredRuntimeModels = prepareConfiguredRuntimeModels({
+    config: input.config,
+    env,
+    providerStaticModels,
+    ...(input.workspaceDir ? { workspaceDir: input.workspaceDir } : {}),
+  });
   const createStores = (): PreparedModelRuntimeStores => {
     // Runtime API keys and session extensions mutate these objects. Fork them per run while the
     // credential map and parsed catalog remain owned by the lifecycle snapshot.
@@ -484,6 +551,7 @@ async function buildSnapshot(
     messageToolCatalog,
     ...(mediaCapabilityProviders ? { mediaCapabilityProviders } : {}),
     modelCatalog: { ...modelCatalog, staticEntries },
+    configuredRuntimeModels,
     createStores,
   });
 }

--- a/src/agents/prepared-model-runtime.owner.ts
+++ b/src/agents/prepared-model-runtime.owner.ts
@@ -25,6 +25,10 @@ import {
   resolveDefaultAgentId,
 } from "./agent-scope.js";
 import {
+  buildInlineProviderModels,
+  type InlineModelEntry,
+} from "./embedded-agent-runner/model.inline-provider.js";
+import {
   loadBundledProviderStaticCatalogContextModels,
   resolveBundledStaticCatalogModel,
 } from "./embedded-agent-runner/model.static-catalog.js";
@@ -54,6 +58,8 @@ export type PreparedModelRuntimeSnapshot = Readonly<{
   modelCatalog: ModelCatalogSnapshot;
   /** Full static models for configured refs, resolved once at the lifecycle boundary. */
   configuredRuntimeModels: readonly PreparedConfiguredRuntimeModel[];
+  /** Inline provider projection prepared once for all resolutions owned by this snapshot. */
+  inlineProviderModels: readonly InlineModelEntry[];
   createStores: () => PreparedModelRuntimeStores;
 }>;
 
@@ -529,6 +535,9 @@ async function buildSnapshot(
     ...(input.workspaceDir ? { workspaceDir: input.workspaceDir } : {}),
   });
   const staticEntries = providerStaticModels.map(toStaticCatalogEntry);
+  // Config reload publishes a replacement snapshot. Keep the synchronous inline projection
+  // at that lifecycle boundary instead of rebuilding it on every model resolution in a turn.
+  const inlineProviderModels = buildInlineProviderModels(input.config.models?.providers ?? {});
   const configuredRuntimeModels = prepareConfiguredRuntimeModels({
     config: input.config,
     env,
@@ -552,6 +561,7 @@ async function buildSnapshot(
     ...(mediaCapabilityProviders ? { mediaCapabilityProviders } : {}),
     modelCatalog: { ...modelCatalog, staticEntries },
     configuredRuntimeModels,
+    inlineProviderModels,
     createStores,
   });
 }

--- a/src/agents/prepared-model-runtime.startup-static.test.ts
+++ b/src/agents/prepared-model-runtime.startup-static.test.ts
@@ -80,6 +80,7 @@ vi.mock("./runtime-plugins.js", () => ({
 
 vi.mock("./embedded-agent-runner/model.static-catalog.js", () => ({
   loadBundledProviderStaticCatalogContextModels: mocks.loadStaticCatalog,
+  resolveBundledStaticCatalogModel: () => undefined,
 }));
 
 vi.mock("../logging/subsystem.js", () => ({

--- a/src/agents/prepared-model-runtime.test.ts
+++ b/src/agents/prepared-model-runtime.test.ts
@@ -2,6 +2,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 type LoadStaticCatalog =
   typeof import("./embedded-agent-runner/model.static-catalog.js").loadBundledProviderStaticCatalogContextModels;
+type ResolveStaticCatalog =
+  typeof import("./embedded-agent-runner/model.static-catalog.js").resolveBundledStaticCatalogModel;
 
 const mocks = vi.hoisted(() => ({
   authStorage: { getAll: vi.fn(() => ({ custom: { type: "api_key", key: "test-key" } })) },
@@ -21,6 +23,7 @@ const mocks = vi.hoisted(() => ({
   })),
   ensureRuntimePluginsLoaded: vi.fn(),
   loadStaticCatalog: vi.fn<LoadStaticCatalog>(async () => []),
+  resolveBundledStaticCatalogModel: vi.fn<ResolveStaticCatalog>(() => undefined),
   configuredAgentIds: [] as string[],
   mutationListener: undefined as
     | ((event: { agentDir?: string; affectsInheritedStores: boolean }) => void)
@@ -77,6 +80,8 @@ vi.mock("./runtime-plugins.js", () => ({
 vi.mock("./embedded-agent-runner/model.static-catalog.js", () => ({
   loadBundledProviderStaticCatalogContextModels: (...args: Parameters<LoadStaticCatalog>) =>
     mocks.loadStaticCatalog(...args),
+  resolveBundledStaticCatalogModel: (...args: Parameters<ResolveStaticCatalog>) =>
+    mocks.resolveBundledStaticCatalogModel(...args),
 }));
 
 vi.mock("../logging/subsystem.js", () => ({
@@ -112,6 +117,7 @@ describe("prepared model runtime snapshots", () => {
     mocks.buildPreparedModelCatalogSnapshot.mockClear();
     mocks.ensureRuntimePluginsLoaded.mockClear();
     mocks.loadStaticCatalog.mockClear();
+    mocks.resolveBundledStaticCatalogModel.mockClear();
     mocks.modelRegistry.fork.mockClear();
     mocks.configuredAgentIds = [];
   });
@@ -264,6 +270,38 @@ describe("prepared model runtime snapshots", () => {
         reasoning: false,
         input: ["text"],
       },
+    ]);
+  });
+
+  it("retains full configured static models with request-time catalog precedence", async () => {
+    const runtimeModel = {
+      provider: "nvidia",
+      id: "nemotron-static",
+      name: "Nemotron Static",
+      api: "openai-completions" as const,
+      baseUrl: "https://integrate.api.nvidia.com/v1",
+      reasoning: false,
+      input: ["text" as const],
+      cost: { input: 1, output: 2, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 128_000,
+      maxTokens: 8_192,
+    };
+    mocks.loadStaticCatalog.mockResolvedValueOnce([
+      {
+        ...runtimeModel,
+        baseUrl: "https://provider-static.example.test/v1",
+      },
+    ]);
+    mocks.resolveBundledStaticCatalogModel.mockReturnValueOnce(runtimeModel);
+
+    const snapshot = await publishPreparedModelRuntimeSnapshot({
+      config: { agents: { defaults: { model: { primary: "nvidia/nemotron-static" } } } },
+      agentDir: "/tmp/prepared-model-runtime-configured-static",
+      workspaceDir: "/tmp/prepared-model-runtime-configured-static-workspace",
+    });
+
+    expect(snapshot.configuredRuntimeModels).toEqual([
+      { provider: "nvidia", modelId: "nemotron-static", model: runtimeModel },
     ]);
   });
 

--- a/src/agents/prepared-model-runtime.test.ts
+++ b/src/agents/prepared-model-runtime.test.ts
@@ -305,6 +305,42 @@ describe("prepared model runtime snapshots", () => {
     ]);
   });
 
+  it("prepares inline provider models once at the snapshot boundary", async () => {
+    const snapshot = await publishPreparedModelRuntimeSnapshot({
+      config: {
+        models: {
+          providers: {
+            custom: {
+              baseUrl: "https://custom.example.test/v1",
+              api: "openai-responses",
+              models: [
+                {
+                  id: "custom-model",
+                  name: "Custom Model",
+                  reasoning: false,
+                  input: ["text"],
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                  contextWindow: 128_000,
+                  maxTokens: 8_192,
+                },
+              ],
+            },
+          },
+        },
+      },
+      agentDir: "/tmp/prepared-model-runtime-inline",
+    });
+
+    expect(snapshot.inlineProviderModels).toMatchObject([
+      {
+        provider: "custom",
+        id: "custom-model",
+        baseUrl: "https://custom.example.test/v1",
+        api: "openai-responses",
+      },
+    ]);
+  });
+
   it("omits provider runtime APIs outside the catalog contract", async () => {
     mocks.loadStaticCatalog.mockResolvedValueOnce([
       {

--- a/src/gateway/worker-environments/inference-runtime.test.ts
+++ b/src/gateway/worker-environments/inference-runtime.test.ts
@@ -223,6 +223,7 @@ function setup(entry: SessionEntry = sessionEntry) {
           ],
           routeVariants: [],
         },
+        configuredRuntimeModels: [],
         createStores: () => ({ authStorage: {} as never, modelRegistry: {} as never }),
       },
       release: releaseRuntime,

--- a/src/gateway/worker-environments/inference-runtime.test.ts
+++ b/src/gateway/worker-environments/inference-runtime.test.ts
@@ -224,6 +224,7 @@ function setup(entry: SessionEntry = sessionEntry) {
           routeVariants: [],
         },
         configuredRuntimeModels: [],
+        inlineProviderModels: [],
         createStores: () => ({ authStorage: {} as never, modelRegistry: {} as never }),
       },
       release: releaseRuntime,


### PR DESCRIPTION
Refs #75782

## What Problem This Solves

Warm agent turns repeatedly rebuilt configured provider models and re-ran static model-catalog resolution during model setup and auth preparation. On gateways with several configured models this synchronous work blocked the Gateway event loop and added seconds before the model call began.

The original report measured roughly four model resolutions per turn. On a live gateway with 2 configured providers and 39 models, `findInlineModelMatch` alone took about 1.49 seconds per resolution and the non-default agent's `model-resolution` stage reached 6.23 seconds.

## Why This Change Was Made

The Gateway already owns a prepared model-runtime snapshot whose generation is replaced on config reload. This change prepares both the inline-provider projection and configured static models at that lifecycle boundary, then carries those models through initial model setup, auth-plan materialization, and later snapshot-backed resolution.

This replaces the original identity-only `WeakMap` with the lifecycle owner. Callers without a prepared snapshot retain the pure request-time fallback, including correct behavior when a provider object is mutated in place. Dynamic provider hooks and manifest/runtime-discovery precedence still run before static fallback.

## User Impact

Warm turns start materially faster and spend less synchronous CPU on the Gateway event loop. Config reloads publish a fresh projection; model selection, provider overrides, and fallback behavior remain unchanged.

Contributor live before/after proof on the same gateway:

| Measurement | Before | After |
|---|---:|---:|
| `findInlineModelMatch` | 1490 ms | 0 ms |
| `resolveModelAsync` (per call, about 4 per turn) | 1922 ms | 385 ms |
| Default-agent turn | 7547 ms | 1880 ms |
| Non-default-agent turn | 12990 ms | 2456 ms |
| Non-default `model-resolution` stage | 6234 ms | 164 ms |

This addresses the measured model-preparation contributor to #75782; it does not claim to eliminate every remaining auth-initialization cost tracked there.

Release-note context: faster warm agent-turn startup by reusing lifecycle-prepared configured models instead of rebuilding them during each resolution.

## Evidence

- Node 26 V8 CPU profile on Blacksmith Testbox, 2 providers / 39 models / 12 samples under load:
  - request-time projection: 2500.28 ms p50, 2959.38 ms p95
  - prepared lookup: 0.0036 ms p50, 0.0065 ms p95
  - hottest old-path samples were plugin metadata snapshot freezing, `structuredClone`, `lstat`, and garbage collection.
- A rejected candidate that only forwarded prepared stores showed no meaningful win: 405 ms versus 410 ms p50.
- Configured static fallback resolution improved from 696 ms to 505 ms p50; the repeated manifest/static lookup accounted for about 208 ms p50.
- Source-blind CLI validation against the working candidate Gateway returned the exact requested replies on `openai/gpt-5.6-sol` across the same session in 4316 ms, 3587 ms, and 3341 ms. Unique reply tokens on every turn verified real model execution rather than cached output.
- Blacksmith Testbox `tbx_01kyn8xjkebe3cp6gadhfqb0xv` ([run](https://github.com/openclaw/openclaw/actions/runs/30399410402)):
  - inline-provider tests: 14/14
  - prepared-runtime tests: 29/29
  - model-resolution tests: 147/147
  - inference-runtime tests: 21/21
  - embedded-agent E2E: 21/21
  - final `check:changed`: passed; because `main` advanced after the branch was cut, the conservative plan also passed core, UI, extension, script, and test-root typechecks plus the full core lint fanout.
- Final Codex autoreview of the integrated branch: clean, no accepted/actionable findings.
- `git diff --check`: clean.

The PR retains kas's original commit and authorship; the maintainer follow-up moves the optimization to the lifecycle owner and broadens the regression coverage.
