### PR TITLE
fix(tui): prevent terminal session-switch race after chat replies

### DIFF
--- a/src/tui/tui-pty-harness.e2e.test.ts
+++ b/src/tui/tui-pty-harness.e2e.test.ts
@@ -940,6 +940,7 @@ describe.sequential("TUI PTY harness", () => {
       );
 
       expect(sent.payload).toMatchObject({ sessionKey, message });
+      await fixture.run.waitForOutput(`PTY_RESPONSE: ${message}`);
     },
     TEST_TIMEOUT_MS,
   );


### PR DESCRIPTION
Related: #113805

## What Problem This Solves

Fixes an issue where the shared terminal end-to-end suite could start `/new` before the preceding Matrix or Signal conversation had actually finished. The correctly protected session rollover would then refuse the active run and make an unrelated pull request fail nondeterministically.

## Why This Change Was Made

Wait for the exact visible response of each case-sensitive conversation before returning from its test. That output is emitted only after the real TUI consumes the matching `chat.final` and clears the active run. This preserves actual production rollover safety without sleeps, retries, timeout changes, test removal, or production behavior changes.

## User Impact

Restores reliable coverage for Matrix and Signal conversation identity and canonical `/new` session creation; no production behavior changes.

## Evidence

- Personally reproduced the precise hosted failure in [CI job 89712434505](https://github.com/openclaw/openclaw/actions/runs/30171136370/job/89712434505): Matrix and Signal tests completed in 3 ms and 2 ms while final responses were scheduled after 20 ms; the immediately following `/new` test timed out.
- Ran the complete 27-case real-terminal PTY suite 10 consecutive times: **270 out of 270 passed**, including both provider-owned identities, canonical `/new`, event-gap approval, active-reset protection, and rapid session switching.
- Ran the complete real-local and restarted-Gateway PTY lane: **39 out of 39 passed**, including all 27 terminal scenarios and all 12 real-backend scenarios covering actual Gateway reconnect/restart, canonical `/new`, active `/reset`, streaming, cancellation, and queued followups.
- Remote proof: Blacksmith Testbox `tbx_01kydb51t1demmb3we99e1sfrs`; final `exitCode=0`; [Testbox evidence run](https://github.com/openclaw/openclaw/actions/runs/30171188321).
- Fresh official Codex autoreview: clean; independent secret scan: clean.
- `git diff --check`: clean.
- AI-assisted; reviewed against complete TUI finalization and session rollover owners.
