### PR TITLE
feat: announce critical session health beyond the rail and teach companion delegation

### DIFF
--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -354,6 +354,33 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).not.toContain('[embed content_type="html" title="Status"]...[/embed]');
   });
 
+  it("teaches direct status answers only on the full Control UI surface", () => {
+    const defaultPrompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      toolNames: ["sessions_spawn"],
+    });
+    const webchatPrompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      toolNames: ["sessions_spawn"],
+      runtimeInfo: { channel: "webchat" },
+    });
+    const minimalWebchatPrompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      toolNames: ["sessions_spawn"],
+      runtimeInfo: { channel: "webchat" },
+      promptMode: "minimal",
+    });
+
+    expect(defaultPrompt).not.toContain("## Control UI Session Companion");
+    expect(webchatPrompt).toContain("## Control UI Session Companion");
+    expect(webchatPrompt).toContain("read-only rail companion");
+    expect(webchatPrompt).toContain("do not spawn sub-agents or burn main-thread turns");
+    expect(webchatPrompt).toContain(
+      "Reserve `sessions_spawn` for delegated work with its own deliverable",
+    );
+    expect(minimalWebchatPrompt).not.toContain("## Control UI Session Companion");
+  });
+
   it("guides subagent workflows to avoid polling loops", () => {
     const prompt = buildAgentSystemPrompt({
       workspaceDir: "/tmp/openclaw",

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -467,6 +467,22 @@ function buildWebchatCanvasSection(params: {
   ];
 }
 
+function buildControlUiSessionCompanionSection(params: {
+  isMinimal: boolean;
+  runtimeChannel?: string;
+}) {
+  if (params.isMinimal || params.runtimeChannel !== "webchat") {
+    return [];
+  }
+  return [
+    "## Control UI Session Companion",
+    "- Operator has a read-only rail companion for this session's status and explanations.",
+    "- On request, do not spawn sub-agents or burn main-thread turns merely to summarize status or re-explain recent work.",
+    "- Reserve `sessions_spawn` for delegated work with its own deliverable.",
+    "",
+  ];
+}
+
 function buildExecutionBiasSection(params: { isMinimal: boolean }) {
   if (params.isMinimal) {
     return [];
@@ -1327,6 +1343,10 @@ export function buildAgentSystemPrompt(params: {
       isMinimal,
       runtimeChannel,
       sourceMessageToolOnly,
+    }),
+    ...buildControlUiSessionCompanionSection({
+      isMinimal,
+      runtimeChannel,
     }),
     ...buildMessagingSection({
       isMinimal,

--- a/src/gateway/session-observer-audience.ts
+++ b/src/gateway/session-observer-audience.ts
@@ -32,5 +32,15 @@ export function createSessionObserverAudience(params: {
       }
       return recipients;
     },
+
+    criticalRecipients(sessionKey: string): ReadonlySet<string> {
+      const recipients = new Set(params.subscribers.get(sessionKey));
+      // sessions.subscribe is operator.read-gated. Critical fanout drops only
+      // Control UI visibility, preserving the existing subscription boundary.
+      for (const connId of params.sessionEventSubscribers?.getAll() ?? []) {
+        recipients.add(connId);
+      }
+      return recipients;
+    },
   };
 }

--- a/src/gateway/session-observer.test.ts
+++ b/src/gateway/session-observer.test.ts
@@ -641,6 +641,45 @@ describe("session observer", () => {
     harness.observer.dispose();
   });
 
+  it("widens only critical health transitions to hidden session-list subscribers", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const healths = ["stuck", "stuck", "on-track", "stuck", "done", "failed"] as const;
+    const completeModel = vi.fn(async () => {
+      const health = healths[completeModel.mock.calls.length - 1] ?? "on-track";
+      return modelMessage({ headline: `Health: ${health}`, health });
+    });
+    const harness = createHarness({ completeModel });
+    harness.sessionEventSubscribers.subscribe("conn-background");
+
+    const publishNext = async (initial = false) => {
+      if (initial) {
+        startAndAddToolNotes(harness.observer);
+      } else {
+        for (let index = 0; index < 4; index += 1) {
+          harness.observer.handleEvent(
+            event({
+              stream: "tool",
+              data: { phase: "start", name: "read", args: { index } },
+            }),
+          );
+        }
+      }
+      await vi.advanceTimersByTimeAsync(12_000);
+      await flushObserver();
+      return harness.broadcastToConnIds.mock.calls.at(-1)?.[2] as ReadonlySet<string>;
+    };
+
+    expect(await publishNext(true)).toEqual(new Set(["conn-1", "conn-background"]));
+    expect(await publishNext()).toEqual(new Set(["conn-1"]));
+    expect(await publishNext()).toEqual(new Set(["conn-1"]));
+    expect(await publishNext()).toEqual(new Set(["conn-1", "conn-background"]));
+    expect(await publishNext()).toEqual(new Set(["conn-1"]));
+    expect(await publishNext()).toEqual(new Set(["conn-1"]));
+    expect(completeModel).toHaveBeenCalledTimes(6);
+    harness.observer.dispose();
+  });
+
   it("suspends when the last visible connection is removed", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(0);

--- a/src/gateway/session-observer.ts
+++ b/src/gateway/session-observer.ts
@@ -380,10 +380,17 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
             ? { planProgress: state.planProgress ?? modelDigest.planProgress }
             : {}),
         };
+        const previous = state.previousDigest?.health;
+        const next = digest.health;
+        const criticalTransition =
+          (next === "stuck" || next === "waiting-on-user") && previous !== next;
         state.previousDigest = digest;
-        deps.broadcastToConnIds("session.observer", digest, audience.recipients(state.sessionKey), {
-          dropIfSlow: true,
-        });
+        // The existing gateway.controlUi.sessionObserver=false gate prevents this
+        // run entirely, so the wider critical announce inherits the same opt-out.
+        const recipients = criticalTransition
+          ? audience.criticalRecipients(state.sessionKey)
+          : audience.recipients(state.sessionKey);
+        deps.broadcastToConnIds("session.observer", digest, recipients, { dropIfSlow: true });
         await persistAcceptedDigest(state, digest, final);
         if (final) {
           dormantRuns.delete(state.runId);

--- a/ui/src/app/app-host.ts
+++ b/ui/src/app/app-host.ts
@@ -70,10 +70,6 @@ import {
 import { isTerminalAvailable } from "../lib/terminal-availability.ts";
 import { OpenClawLightDomElement } from "../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../lit/subscriptions-controller.ts";
-import {
-  CriticalObserverNoticeTracker,
-  showCriticalSessionObserverNotice,
-} from "../pages/chat/critical-observer-notice.ts";
 import { findSettingsSearchBlocks } from "../pages/config/settings-search.ts";
 import { newSessionSearch, type NewSessionTarget } from "../pages/new-session/location.ts";
 import { renderDevicePairSetup } from "../pages/nodes/view-pairing.ts";
@@ -562,7 +558,11 @@ class OpenClawShell extends OpenClawLightDomElement {
     EventTarget,
     ReturnType<typeof globalThis.setTimeout>
   >();
-  private readonly observerNoticeTracker = new CriticalObserverNoticeTracker();
+  // Lazy: the critical-notice module stays out of the startup chunk (perf
+  // budget); loaded on the first session.observer digest after boot.
+  private criticalNoticeRuntime: Promise<
+    typeof import("../pages/chat/critical-observer-notice.runtime.ts")
+  > | null = null;
   private readonly subscriptions = new SubscriptionsController(this);
 
   private get context(): ApplicationContext<RouteId> | undefined {
@@ -791,7 +791,7 @@ class OpenClawShell extends OpenClawLightDomElement {
     this.navDrawerTrigger = null;
     this.lastWorkspaceLocation = null;
     this.activeSessionKey = "";
-    this.observerNoticeTracker.clear();
+    void this.criticalNoticeRuntime?.then((runtime) => runtime.resetCriticalObserverTracker());
     this.settingsSearchQuery = "";
     this.commandPaletteTarget = undefined;
     this.agentsListClient = null;
@@ -816,16 +816,21 @@ class OpenClawShell extends OpenClawLightDomElement {
     if (event.event === "session.observer") {
       const context = this.context;
       if (context) {
-        showCriticalSessionObserverNotice({
-          payload: event.payload,
-          selectedSessionKey: this.activeSessionKey,
-          sessions: context.sessions.state.result?.sessions ?? [],
-          tracker: this.observerNoticeTracker,
-          onOpen: (sessionKey) => {
-            context.gateway.setSessionKey(sessionKey);
-            this.navigate("chat", { search: searchForSession(sessionKey) });
-          },
-        });
+        // All digests flow through (not just critical ones): the runtime
+        // tracker must see recovery transitions for its re-announce dedupe.
+        this.criticalNoticeRuntime ??= import("../pages/chat/critical-observer-notice.runtime.ts");
+        const payload = event.payload;
+        void this.criticalNoticeRuntime.then((runtime) =>
+          runtime.handleCriticalObserverDigest({
+            payload,
+            selectedSessionKey: this.activeSessionKey,
+            sessions: context.sessions.state.result?.sessions ?? [],
+            onOpen: (sessionKey) => {
+              context.gateway.setSessionKey(sessionKey);
+              this.navigate("chat", { search: searchForSession(sessionKey) });
+            },
+          }),
+        );
       }
       return;
     }

--- a/ui/src/app/app-host.ts
+++ b/ui/src/app/app-host.ts
@@ -67,10 +67,13 @@ import {
   resolveUiConfiguredMainKey,
   resolveUiKnownSelectedGlobalAgentId,
 } from "../lib/sessions/session-key.ts";
-import "../lib/toast.ts";
 import { isTerminalAvailable } from "../lib/terminal-availability.ts";
 import { OpenClawLightDomElement } from "../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../lit/subscriptions-controller.ts";
+import {
+  CriticalObserverNoticeTracker,
+  showCriticalSessionObserverNotice,
+} from "../pages/chat/critical-observer-notice.ts";
 import { findSettingsSearchBlocks } from "../pages/config/settings-search.ts";
 import { newSessionSearch, type NewSessionTarget } from "../pages/new-session/location.ts";
 import { renderDevicePairSetup } from "../pages/nodes/view-pairing.ts";
@@ -559,6 +562,7 @@ class OpenClawShell extends OpenClawLightDomElement {
     EventTarget,
     ReturnType<typeof globalThis.setTimeout>
   >();
+  private readonly observerNoticeTracker = new CriticalObserverNoticeTracker();
   private readonly subscriptions = new SubscriptionsController(this);
 
   private get context(): ApplicationContext<RouteId> | undefined {
@@ -787,6 +791,7 @@ class OpenClawShell extends OpenClawLightDomElement {
     this.navDrawerTrigger = null;
     this.lastWorkspaceLocation = null;
     this.activeSessionKey = "";
+    this.observerNoticeTracker.clear();
     this.settingsSearchQuery = "";
     this.commandPaletteTarget = undefined;
     this.agentsListClient = null;
@@ -808,6 +813,22 @@ class OpenClawShell extends OpenClawLightDomElement {
 
   private readonly handleGatewayEvent = (event: GatewayEventFrame) => {
     this.sidebarWorkboardRuntime?.handleGatewayEvent(event.event);
+    if (event.event === "session.observer") {
+      const context = this.context;
+      if (context) {
+        showCriticalSessionObserverNotice({
+          payload: event.payload,
+          selectedSessionKey: this.activeSessionKey,
+          sessions: context.sessions.state.result?.sessions ?? [],
+          tracker: this.observerNoticeTracker,
+          onOpen: (sessionKey) => {
+            context.gateway.setSessionKey(sessionKey);
+            this.navigate("chat", { search: searchForSession(sessionKey) });
+          },
+        });
+      }
+      return;
+    }
     if (event.event === "config.changed") {
       // Another writer (agent-approved config_set, other device, CLI) changed
       // openclaw.json; refresh the snapshot so ui.prefs reconcile live. A

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -700,6 +700,7 @@ export const en: TranslationMap = {
     runErrorTimedOut: "Timed out",
     runErrorUnknown: "Unknown error",
     attentionRequired: "Session needs attention",
+    openSession: "Open thread",
     model: "Model",
     provider: "Provider",
     runtime: "Runtime",

--- a/ui/src/lib/observer-digest.test.ts
+++ b/ui/src/lib/observer-digest.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, it } from "vitest";
 import type { SessionObserverDigest } from "../../../packages/gateway-protocol/src/schema/sessions.js";
-import { ObserverDigestHistory } from "./observer-digest.ts";
+import { isCriticalObserverHealth, ObserverDigestHistory } from "./observer-digest.ts";
+
+describe("isCriticalObserverHealth", () => {
+  it("recognizes only health states that require operator attention", () => {
+    expect(isCriticalObserverHealth("stuck")).toBe(true);
+    expect(isCriticalObserverHealth("waiting-on-user")).toBe(true);
+    expect(isCriticalObserverHealth("done")).toBe(false);
+    expect(isCriticalObserverHealth("failed")).toBe(false);
+  });
+});
 
 const HISTORY_LIMIT = 50;
 

--- a/ui/src/lib/observer-digest.ts
+++ b/ui/src/lib/observer-digest.ts
@@ -13,6 +13,10 @@ type ProjectedObserverDigest = Pick<
   "runId" | "headline" | "health" | "updatedAt" | "revision"
 >;
 
+export function isCriticalObserverHealth(health: unknown): health is "stuck" | "waiting-on-user" {
+  return health === "stuck" || health === "waiting-on-user";
+}
+
 /** Local live run id wins; otherwise the row's server-reported active runs
  * identify the run, preferring the one the digest belongs to. */
 export function resolveChatPaneObserverRunId(params: {

--- a/ui/src/pages/chat/critical-observer-notice.e2e.test.ts
+++ b/ui/src/pages/chat/critical-observer-notice.e2e.test.ts
@@ -1,0 +1,220 @@
+import { mkdir, rm } from "node:fs/promises";
+import path from "node:path";
+import { chromium, type Browser, type Page } from "playwright";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  canRunPlaywrightChromium,
+  installMockGateway,
+  resolvePlaywrightChromiumExecutablePath,
+  startControlUiE2eServer,
+  type ControlUiE2eServer,
+} from "../../test-helpers/control-ui-e2e.ts";
+
+const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
+const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
+const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
+const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const artifactDir = path.resolve(
+  process.cwd(),
+  ".artifacts/control-ui-e2e/critical-observer-notice",
+);
+const selectedSessionKey = "agent:main:main";
+const backgroundSessionKey = "agent:main:other";
+const baseTime = Date.parse("2026-07-25T18:00:00.000Z");
+
+let server: ControlUiE2eServer;
+let browser: Browser;
+
+function sessionsListResponse() {
+  return {
+    count: 2,
+    defaults: {
+      contextTokens: null,
+      model: "gpt-5.5",
+      modelProvider: "openai",
+    },
+    path: "",
+    sessions: [
+      {
+        key: selectedSessionKey,
+        kind: "direct",
+        label: "Main session",
+        updatedAt: baseTime,
+      },
+      {
+        key: backgroundSessionKey,
+        kind: "direct",
+        label: "Background investigation",
+        updatedAt: baseTime - 1_000,
+      },
+    ],
+    ts: baseTime,
+  };
+}
+
+function observerDigest(params: {
+  sessionKey: string;
+  health: "on-track" | "stuck";
+  revision: number;
+  headline: string;
+}) {
+  return {
+    ...params,
+    runId: `observer-run-${params.sessionKey}`,
+    updatedAt: baseTime + params.revision,
+  };
+}
+
+async function waitForToastUpdate(page: Page): Promise<void> {
+  await page.locator("openclaw-toast-host").evaluate(async (element) => {
+    await (element as HTMLElement & { updateComplete: Promise<unknown> }).updateComplete;
+  });
+}
+
+describeControlUiE2e("Control UI critical observer notice mocked Gateway E2E", () => {
+  beforeAll(async () => {
+    if (!chromiumAvailable) {
+      throw new Error(
+        `Playwright Chromium is not installed at ${chromiumExecutablePath}. Run \`pnpm --dir ui exec playwright install chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
+      );
+    }
+    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
+    try {
+      server = await startControlUiE2eServer();
+    } catch (error) {
+      await browser.close().catch(() => {});
+      throw error;
+    }
+  });
+
+  afterAll(async () => {
+    await browser?.close().catch(() => {});
+    await server?.close();
+  });
+
+  it("announces critical background sessions, navigates, and dedupes after dismissal", async () => {
+    await rm(artifactDir, { force: true, recursive: true });
+    await mkdir(artifactDir, { recursive: true });
+    const context = await browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1440 },
+    });
+    const page = await context.newPage();
+    page.setDefaultTimeout(10_000);
+    try {
+      const gateway = await installMockGateway(page, {
+        historyMessages: [
+          {
+            content: [{ type: "text", text: "Selected session A is ready." }],
+            role: "assistant",
+            timestamp: baseTime,
+          },
+        ],
+        methodResponses: {
+          "sessions.list": sessionsListResponse(),
+        },
+        sessionKey: selectedSessionKey,
+      });
+
+      const response = await page.goto(
+        `${server.baseUrl}chat?session=${encodeURIComponent(selectedSessionKey)}`,
+      );
+      expect(response?.status()).toBe(200);
+      await page.getByText("Selected session A is ready.").waitFor({ state: "visible" });
+      expect(new URL(page.url()).searchParams.get("session")).toBe(selectedSessionKey);
+
+      const toast = page.locator(".app-toast");
+      await gateway.emitGatewayEvent(
+        "session.observer",
+        observerDigest({
+          sessionKey: backgroundSessionKey,
+          health: "on-track",
+          headline: "Background session is healthy",
+          revision: 1,
+        }),
+      );
+      await waitForToastUpdate(page);
+      expect(await toast.count()).toBe(0);
+
+      await gateway.emitGatewayEvent(
+        "session.observer",
+        observerDigest({
+          sessionKey: selectedSessionKey,
+          health: "stuck",
+          headline: "Selected session needs attention",
+          revision: 1,
+        }),
+      );
+      await waitForToastUpdate(page);
+      expect(await toast.count()).toBe(0);
+
+      const firstHeadline = "Background verification is stuck";
+      await gateway.emitGatewayEvent(
+        "session.observer",
+        observerDigest({
+          sessionKey: backgroundSessionKey,
+          health: "stuck",
+          headline: firstHeadline,
+          revision: 2,
+        }),
+      );
+      await toast.waitFor({ state: "visible" });
+      expect(await toast.locator(".app-toast__message").textContent()).toContain(firstHeadline);
+      await page.screenshot({
+        fullPage: true,
+        path: path.join(artifactDir, "01-critical-background-session.png"),
+      });
+
+      await toast.locator(".app-toast__action").click();
+      await expect
+        .poll(() => new URL(page.url()).searchParams.get("session"))
+        .toBe(backgroundSessionKey);
+      expect(await toast.count()).toBe(0);
+
+      await page.locator("a.nav-item--home").click();
+      await expect
+        .poll(() => new URL(page.url()).searchParams.get("session"))
+        .toBe(selectedSessionKey);
+
+      await gateway.emitGatewayEvent(
+        "session.observer",
+        observerDigest({
+          sessionKey: backgroundSessionKey,
+          health: "on-track",
+          headline: "Background verification recovered",
+          revision: 3,
+        }),
+      );
+      await waitForToastUpdate(page);
+      expect(await toast.count()).toBe(0);
+
+      await gateway.emitGatewayEvent(
+        "session.observer",
+        observerDigest({
+          sessionKey: backgroundSessionKey,
+          health: "stuck",
+          headline: "Background verification is stuck again",
+          revision: 4,
+        }),
+      );
+      await toast.waitFor({ state: "visible" });
+      await toast.locator(".app-toast__dismiss").click();
+      expect(await toast.count()).toBe(0);
+
+      await gateway.emitGatewayEvent(
+        "session.observer",
+        observerDigest({
+          sessionKey: backgroundSessionKey,
+          health: "stuck",
+          headline: "Repeated stuck update remains deduped",
+          revision: 5,
+        }),
+      );
+      await waitForToastUpdate(page);
+      expect(await toast.count()).toBe(0);
+    } finally {
+      await context.close();
+    }
+  });
+});

--- a/ui/src/pages/chat/critical-observer-notice.e2e.test.ts
+++ b/ui/src/pages/chat/critical-observer-notice.e2e.test.ts
@@ -171,6 +171,10 @@ describeControlUiE2e("Control UI critical observer notice mocked Gateway E2E", (
         .poll(() => new URL(page.url()).searchParams.get("session"))
         .toBe(backgroundSessionKey);
       expect(await toast.count()).toBe(0);
+      await page.screenshot({
+        fullPage: true,
+        path: path.join(artifactDir, "02-after-open-thread-navigation.png"),
+      });
 
       await page.locator("a.nav-item--home").click();
       await expect

--- a/ui/src/pages/chat/critical-observer-notice.runtime.ts
+++ b/ui/src/pages/chat/critical-observer-notice.runtime.ts
@@ -1,0 +1,20 @@
+// Lazy boundary: keeps the critical-notice module (toast host, i18n strings,
+// transition tracker) out of the Control UI startup chunk. Loaded by app-host
+// on the first session.observer digest; the tracker singleton lives here so
+// recovery transitions stay visible to the dedupe contract across loads.
+import {
+  CriticalObserverNoticeTracker,
+  showCriticalSessionObserverNotice,
+} from "./critical-observer-notice.ts";
+
+const tracker = new CriticalObserverNoticeTracker();
+
+type HandleParams = Omit<Parameters<typeof showCriticalSessionObserverNotice>[0], "tracker">;
+
+export function handleCriticalObserverDigest(params: HandleParams): void {
+  showCriticalSessionObserverNotice({ ...params, tracker });
+}
+
+export function resetCriticalObserverTracker(): void {
+  tracker.clear();
+}

--- a/ui/src/pages/chat/critical-observer-notice.test.ts
+++ b/ui/src/pages/chat/critical-observer-notice.test.ts
@@ -1,0 +1,52 @@
+/* @vitest-environment jsdom */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  CriticalObserverNoticeTracker,
+  showCriticalSessionObserverNotice,
+} from "./critical-observer-notice.ts";
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+describe("critical session observer notice", () => {
+  it("notices critical health only for a non-selected session", async () => {
+    const onOpen = vi.fn();
+    const tracker = new CriticalObserverNoticeTracker();
+    const toastHost = document.createElement("openclaw-toast-host");
+    document.body.append(toastHost);
+    const show = (sessionKey: string, health: string, revision: number) =>
+      showCriticalSessionObserverNotice({
+        payload: { sessionKey, headline: "Repeated test failure", health, revision },
+        selectedSessionKey: "agent:main:selected",
+        sessions: [{ key: "agent:main:other", label: "Other work" }],
+        tracker,
+        onOpen,
+      });
+
+    show("agent:main:selected", "waiting-on-user", 1);
+    show("agent:main:other", "on-track", 1);
+    await toastHost.updateComplete;
+    expect(toastHost.querySelector(".app-toast")).toBeNull();
+
+    show("agent:main:other", "stuck", 2);
+    await toastHost.updateComplete;
+    expect(toastHost.querySelector(".app-toast__message")?.textContent).toContain(
+      "Other work — Repeated test failure",
+    );
+
+    toastHost.querySelector<HTMLButtonElement>(".app-toast__action")?.click();
+    expect(onOpen).toHaveBeenCalledExactlyOnceWith("agent:main:other");
+
+    show("agent:main:other", "stuck", 3);
+    await toastHost.updateComplete;
+    expect(toastHost.querySelector(".app-toast")).toBeNull();
+
+    // Broad-only recipients miss recovery digests. A revision gap distinguishes
+    // the next critical transition from an exact subscriber's repeat update.
+    show("agent:main:other", "stuck", 5);
+    await toastHost.updateComplete;
+    expect(toastHost.querySelector(".app-toast")).not.toBeNull();
+  });
+});

--- a/ui/src/pages/chat/critical-observer-notice.test.ts
+++ b/ui/src/pages/chat/critical-observer-notice.test.ts
@@ -20,7 +20,7 @@ describe("critical session observer notice", () => {
       showCriticalSessionObserverNotice({
         payload: { sessionKey, headline: "Repeated test failure", health, revision },
         selectedSessionKey: "agent:main:selected",
-        sessions: [{ key: "agent:main:other", label: "Other work" }],
+        sessions: [{ key: "agent:main:other", label: "Other work", kind: "direct", updatedAt: null }],
         tracker,
         onOpen,
       });

--- a/ui/src/pages/chat/critical-observer-notice.test.ts
+++ b/ui/src/pages/chat/critical-observer-notice.test.ts
@@ -20,7 +20,9 @@ describe("critical session observer notice", () => {
       showCriticalSessionObserverNotice({
         payload: { sessionKey, headline: "Repeated test failure", health, revision },
         selectedSessionKey: "agent:main:selected",
-        sessions: [{ key: "agent:main:other", label: "Other work", kind: "direct", updatedAt: null }],
+        sessions: [
+          { key: "agent:main:other", label: "Other work", kind: "direct", updatedAt: null },
+        ],
         tracker,
         onOpen,
       });

--- a/ui/src/pages/chat/critical-observer-notice.ts
+++ b/ui/src/pages/chat/critical-observer-notice.ts
@@ -1,0 +1,85 @@
+import type { SessionObserverDigest } from "@openclaw/gateway-protocol";
+import type { GatewaySessionRow } from "../../api/types.ts";
+import { t } from "../../i18n/index.ts";
+import { isCriticalObserverHealth } from "../../lib/observer-digest.ts";
+import { resolveSessionDisplayName } from "../../lib/session-display.ts";
+import {
+  areUiSessionKeysEquivalent,
+  normalizeSessionKeyForUiComparison,
+} from "../../lib/sessions/session-key.ts";
+import { showToast } from "../../lib/toast.ts";
+
+const NOTICE_TRACKER_LIMIT = 256;
+
+export class CriticalObserverNoticeTracker {
+  private readonly seen = new Map<string, { health: string; revision: number }>();
+
+  clear(): void {
+    this.seen.clear();
+  }
+
+  record(params: { sessionKey: string; health: string; revision: number }): boolean {
+    const key = normalizeSessionKeyForUiComparison(params.sessionKey);
+    const previous = this.seen.get(key);
+    // Gateway revision floors keep revisions session-monotonic across run
+    // rollover, so a gap reliably means this connection missed digest state.
+    if (previous && params.revision <= previous.revision) {
+      return false;
+    }
+    const shouldAnnounce =
+      isCriticalObserverHealth(params.health) &&
+      (!previous || previous.health !== params.health || params.revision > previous.revision + 1);
+    if (!previous && this.seen.size >= NOTICE_TRACKER_LIMIT) {
+      const oldest = this.seen.keys().next().value;
+      if (oldest !== undefined) {
+        this.seen.delete(oldest);
+      }
+    }
+    this.seen.delete(key);
+    this.seen.set(key, { health: params.health, revision: params.revision });
+    return shouldAnnounce;
+  }
+}
+
+export function showCriticalSessionObserverNotice(params: {
+  payload: unknown;
+  selectedSessionKey: string;
+  sessions: readonly GatewaySessionRow[];
+  tracker: CriticalObserverNoticeTracker;
+  onOpen: (sessionKey: string) => void;
+}): void {
+  if (!params.payload || typeof params.payload !== "object") {
+    return;
+  }
+  const digest = params.payload as Partial<SessionObserverDigest>;
+  const sessionKey = typeof digest.sessionKey === "string" ? digest.sessionKey.trim() : "";
+  const headline = typeof digest.headline === "string" ? digest.headline.trim() : "";
+  const revision = digest.revision;
+  if (
+    !sessionKey ||
+    !headline ||
+    typeof digest.health !== "string" ||
+    revision === undefined ||
+    !Number.isInteger(revision) ||
+    revision < 1
+  ) {
+    return;
+  }
+  const shouldAnnounce = params.tracker.record({
+    sessionKey,
+    health: digest.health,
+    revision,
+  });
+  if (!shouldAnnounce || areUiSessionKeysEquivalent(sessionKey, params.selectedSessionKey)) {
+    return;
+  }
+  const row = params.sessions.find((session) =>
+    areUiSessionKeysEquivalent(session.key, sessionKey),
+  );
+  const label = resolveSessionDisplayName(sessionKey, row);
+  showToast({
+    message: `${t("chat.attentionRequired")}: ${label} — ${headline}`,
+    actionLabel: t("sessionsView.openSession"),
+    onAction: () => params.onOpen(sessionKey),
+  });
+}

--- a/ui/src/pages/chat/critical-observer-notice.ts
+++ b/ui/src/pages/chat/critical-observer-notice.ts
@@ -78,7 +78,7 @@ export function showCriticalSessionObserverNotice(params: {
   );
   const label = resolveSessionDisplayName(sessionKey, row);
   showToast({
-    message: `${t("chat.attentionRequired")}: ${label} — ${headline}`,
+    message: `${t("sessionsView.attentionRequired")}: ${label} — ${headline}`,
     actionLabel: t("sessionsView.openSession"),
     onAction: () => params.onOpen(sessionKey),
   });


### PR DESCRIPTION
## What Problem This Solves

Resolves a gap where a session that goes **stuck** or starts **waiting on user input** is only visible if the operator happens to be looking at that session's rail: the observer's health digests were broadcast solely to connections with that session visible, so a background session could sit blocked indefinitely. Separately, agents on the Control UI had no guidance about the session-rail companion, so operators could burn main-thread turns (or agents could spawn sub-agents) just to answer status questions the read-only companion already serves.

## Why This Change Was Made

- **Critical-health announce (gateway)** — at the observer digest seam, a transition *into* `stuck` or `waiting-on-user` broadcasts the same `session.observer` digest to all operator-scoped session-event subscribers, not just rail-visible ones (`criticalRecipients` drops only the visibility filter; the `sessions.subscribe` operator.read boundary is unchanged). No new event name, no schema change, no new config: the existing `gateway.controlUi.sessionObserver=false` opt-out gates the whole path. Transition semantics: fires once per transition; contiguous same-health revisions are suppressed; recovery then re-degradation announces again; terminal healths never announce.
- **Control UI notice** — a dismissible notice renders when a critical digest arrives for a session other than the selected one, with an "Open thread" action navigating to it. The selected session keeps its existing rail auto-expand; no duplicate surfacing. A sidebar badge was deliberately skipped: broad-only subscribers don't receive narrow recovery digests, so durable badge state could go stale — the transient notice is the honest surface.
- **Delegation teaching (system prompt)** — a new Control-UI-gated section (same surface-gating pattern as the existing webchat canvas section) tells agents the operator has a read-only companion for status/explanation questions and to reserve `sessions_spawn` for real delegated work.
- Out of scope by design (tabled): injecting observer output into the agent's own context, push notifications, system-authored session suggestions.

## User Impact

Operators get told when a background session needs them — a one-click "Open thread" jump from wherever they are in the Control UI — and agents stop spending turns on status questions the rail companion answers. No new configuration; disabling the session observer disables announces with it.

## Evidence

- Permanent Playwright e2e (`ui/src/pages/chat/critical-observer-notice.e2e.test.ts`) covering: stuck digest for a background session renders the notice with headline; on-track digests and selected-session digests do not; click navigates to the session; dismissal + contiguous-revision dedupe; recovery re-announce. Screenshot: https://artifacts.openclaw.ai/companion-followups-2026-07-25/critical-notice-e2e.png
- The e2e caught and this PR fixes an i18n regression in the notice (raw keys rendered; now wired to `sessionsView.attentionRequired` + new `sessionsView.openSession` with regenerated keyless baseline).
- Gateway transition tests: first-fire, same-health suppression, re-fire after recovery, terminal-health exclusion. Focused Vitest: 178 gateway/UI tests + 157 unit + 1 e2e passing.
- `check-changed` classification core/coreTests/ui with Testbox typecheck + lint green; Codex autoreview of the branch: clean (0.98).

### Authorization contract for the widened fanout (source-verified)

`criticalRecipients` adds only connections from the `sessionEventSubscribers` registry. That registry is populated exclusively by the `sessions.subscribe` handler (`src/gateway/server-methods/sessions-subscriptions.ts:35`), whose method descriptor is dispatch-layer gated at `scope: "operator.read"` (`src/gateway/methods/core-descriptors.ts:214`). The normal digest audience path (`params.subscribers`) is unchanged. The critical fanout therefore never widens beyond operator.read-authorized connections, and the payload is the same digest those connections could already receive by opening the session — the change removes only the Control-UI-visibility filter for the critical transition, exactly as the inline comment at `session-observer-audience.ts` states.

### Inspectable e2e transcript (text, environment-independent)

`node scripts/run-vitest.mjs ui/src/pages/chat/critical-observer-notice.e2e.test.ts` — 1/1 passed. The single flow asserts, in order: stuck digest for background session B renders the toast with its headline while session A is selected; on-track digests and selected-session digests render nothing; clicking "Open thread" navigates until `?session=` equals B and the toast unmounts; navigating home restores A; a recovery (on-track) digest then a re-degradation announces again; dismissal plus a contiguous same-health revision stays suppressed. Screenshots (public artifact host): notice visible — https://artifacts.openclaw.ai/companion-followups-2026-07-25/critical-notice-e2e.png ; post-click navigation result on session B — https://artifacts.openclaw.ai/companion-followups-2026-07-25/02-after-open-thread-navigation.png

CI is green on the reviewed head's successor (the only deltas: this e2e artifact capture, a test-literal type fix, and moving the notice module behind a lazy boundary to restore the Control UI startup-JS budget).
