### PR TITLE
fix(ci): restore Browser and Codex prerelease coverage

### DIFF
--- a/extensions/browser/src/browser/chrome.internal.test.ts
+++ b/extensions/browser/src/browser/chrome.internal.test.ts
@@ -333,6 +333,13 @@ async function withMockChromeCdpServer(params: {
 describe("chrome.ts internal", () => {
   beforeEach(() => {
     vi.useRealTimers();
+    vi.spyOn(fs, "accessSync").mockImplementation(() => undefined);
+    vi.spyOn(fs, "statSync").mockImplementation((candidate) => {
+      if (!fs.existsSync(candidate)) {
+        throw new Error("ENOENT");
+      }
+      return { isFile: () => true } as fs.Stats;
+    });
   });
 
   afterEach(() => {

--- a/extensions/codex/src/app-server/client.test.ts
+++ b/extensions/codex/src/app-server/client.test.ts
@@ -1,5 +1,6 @@
 // Codex tests cover client plugin behavior.
 import { embeddedAgentLog, OPENCLAW_VERSION } from "openclaw/plugin-sdk/agent-harness-runtime";
+import { inc as incrementSemver } from "semver";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   CodexAppServerClient,
@@ -387,10 +388,14 @@ describe("CodexAppServerClient", () => {
   });
 
   it("blocks stable Codex app-server versions newer than generated schemas", async () => {
+    const newerVersion = incrementSemver(MAX_CODEX_APP_SERVER_VERSION, "patch");
+    if (!newerVersion) {
+      throw new Error(`invalid maximum Codex app-server version: ${MAX_CODEX_APP_SERVER_VERSION}`);
+    }
     const { harness, initializing, outbound } = startInitialize();
     harness.send({
       id: outbound.id,
-      result: { userAgent: "openclaw/0.145.0 (macOS; test)" },
+      result: { userAgent: `openclaw/${newerVersion} (macOS; test)` },
     });
 
     await expect(initializing).rejects.toThrow(

--- a/extensions/codex/src/app-server/dynamic-tool-build.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.test.ts
@@ -459,6 +459,7 @@ describe("Codex app-server dynamic tool build", () => {
       sourceSessionKey: "agent:main:subagent:codex-child",
       sourceTool: "subagent_announce",
     };
+    params.config = {};
     params.trustedInternalHandoff = true;
     params.scheduledToolPolicy = {
       version: 1,

--- a/extensions/codex/src/command-handler-bindings.ts
+++ b/extensions/codex/src/command-handler-bindings.ts
@@ -43,7 +43,8 @@ export function isCurrentSessionModelSelectionLocked(ctx: PluginCommandContext):
   }
   // SessionEntry is the durable authority even when a native binding is absent or stale.
   // Never infer this lock from binding model metadata such as preserveNativeModel.
-  const storePath = resolveStorePath(ctx.config.session?.store, { agentId: ctx.agentId });
+  const { agentId } = resolveCodexConversationControlScope(ctx);
+  const storePath = resolveStorePath(ctx.config.session?.store, { agentId });
   return isModelSelectionLocked(
     getSessionEntry({
       storePath,


### PR DESCRIPTION
## What Problem This Solves

Fixes Plugin Prerelease failures where the Codex command path could reject a valid default-agent session store and three Browser/Codex release-only tests no longer matched their current executable, policy, and version contracts.

## Why This Change Was Made

Resolve model-lock state through the same effective agent scope used by the rest of Codex conversation control. Update the affected fixtures to model executable access, trusted-handoff configuration, and a version strictly newer than the current generated-schema ceiling.

The Codex protocol contract was checked directly in `openai/codex`: `codex-rs/app-server-protocol/src/protocol/v1.rs` defines the initialize `userAgent`, `codex-rs/app-server/src/request_processors/initialize_processor.rs` supplies the running Codex package version, and `codex-rs/app-server/README.md` defines returned thread IDs as the identity used for resume/binding.

## User Impact

Codex commands with a valid session key no longer fail solely because the command context omitted a redundant explicit agent id. Plugin Prerelease can exercise the current Browser and Codex contracts again.

## Evidence

- Before: https://github.com/openclaw/openclaw/actions/runs/30171124424
- Reproduced all four failures locally under Node 24.
- `node scripts/run-vitest.mjs extensions/browser/src/browser/chrome.internal.test.ts extensions/codex/src/commands.test.ts extensions/codex/src/app-server/client.test.ts extensions/codex/src/app-server/dynamic-tool-build.test.ts`: 290 passed.
- `git diff --check`: passed.
- Autoreview: clean.

Maintainer proof decision: accept the focused command/runtime evidence for this provider-independent path. The omitted-agent-id case reproduced the exact production store-resolution error before the fix and now passes through the real `resolveStorePath`/`getSessionEntry` path; explicit-agent behavior remains covered by the existing command suite. A live channel/model run would add provider and transport variables without strengthening this local ownership contract.

AI-assisted; the maintainer reviewed the code paths, upstream Codex contract, exact diff, and proof above.
