### PR TITLE
fix(tasks): preserve restored flow controller provenance

### DIFF
--- a/src/commands/doctor-state-migrations.test.ts
+++ b/src/commands/doctor-state-migrations.test.ts
@@ -3454,8 +3454,45 @@ describe("doctor legacy state migrations", () => {
         flowId: "legacy-flow",
         ownerKey: "agent:main:legacy-flow",
         syncMode: "managed",
-        controllerId: "core/legacy-restored",
         revision: 0,
+      });
+      expect(flowState.flows.get("legacy-flow")?.controllerId).toBeUndefined();
+      const persistedFlow = openOpenClawStateDatabase()
+        .db.prepare("SELECT controller_id FROM flow_runs WHERE flow_id = ?")
+        .get("legacy-flow") as { controller_id: string | null } | undefined;
+      expect(persistedFlow?.controller_id).toBeNull();
+    });
+  });
+
+  it("preserves an authentic controller while migrating a historical flow sidecar", async () => {
+    const root = await makeTempRoot();
+    const { flowRunsPath } = writeLegacyTaskStateSidecars(root);
+    const legacyDatabase = new (requireNodeSqlite().DatabaseSync)(flowRunsPath);
+    try {
+      legacyDatabase.exec("ALTER TABLE flow_runs ADD COLUMN controller_id TEXT");
+      legacyDatabase
+        .prepare("UPDATE flow_runs SET controller_id = ? WHERE flow_id = ?")
+        .run("plugin/authentic-controller", "legacy-flow");
+    } finally {
+      legacyDatabase.close();
+    }
+
+    const detected = await detectLegacyStateMigrations({
+      cfg: {},
+      env: { OPENCLAW_STATE_DIR: root } as NodeJS.ProcessEnv,
+    });
+    const result = await runLegacyStateMigrations({ detected });
+
+    expect(result.warnings).toStrictEqual([]);
+    expect(result.changes).toContain("Migrated 1 task flow sidecar row → shared SQLite state");
+
+    await withStateDir(root, async () => {
+      const restored = loadTaskFlowRegistryStateFromSqlite().flows.get("legacy-flow");
+      expect(restored).toMatchObject({
+        flowId: "legacy-flow",
+        ownerKey: "agent:main:legacy-flow",
+        syncMode: "managed",
+        controllerId: "plugin/authentic-controller",
       });
     });
   });

--- a/src/commands/flows.test.ts
+++ b/src/commands/flows.test.ts
@@ -1,6 +1,9 @@
 // Flows command tests cover task creation, task execution, and runtime command output.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
 import type { RuntimeEnv } from "../runtime.js";
+import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
+import { openOpenClawStateDatabase } from "../state/openclaw-state-db.js";
 import { createRunningTaskRun as createRunningTaskRunOrNull } from "../tasks/task-executor.js";
 import { createManagedTaskFlow as createManagedTaskFlowOrNull } from "../tasks/task-flow-registry.js";
 import type { TaskFlowRecord } from "../tasks/task-flow-registry.types.js";
@@ -203,6 +206,55 @@ describe("flows commands", () => {
         .join("\n");
       expect(output).toContain(`${"x".repeat(18)}…`);
       expect(output).not.toContain("\uD83D");
+    });
+  });
+
+  it("lists and cancels a restored SQLite flow without inventing its controller", async () => {
+    await withTaskFlowCommandStateDir(async () => {
+      const flow = createManagedTaskFlow({
+        ownerKey: "agent:main:main",
+        controllerId: "tests/original-flow-controller",
+        goal: "Inspect historical flow provenance",
+        status: "running",
+        createdAt: 100,
+        updatedAt: 100,
+      });
+      const database = openOpenClawStateDatabase();
+      const db = getNodeSqliteKysely<Pick<OpenClawStateKyselyDatabase, "flow_runs">>(database.db);
+      executeSqliteQuerySync(
+        database.db,
+        db.updateTable("flow_runs").set({ controller_id: null }).where("flow_id", "=", flow.flowId),
+      );
+      resetTaskFlowRegistryForTests({ persist: false });
+
+      const jsonRuntime = createRuntime();
+      await flowsListCommand({ json: true }, jsonRuntime);
+      const payload = jsonRoundTrip(vi.mocked(jsonRuntime.writeJson).mock.calls[0]?.[0]);
+
+      expect(payload).toMatchObject({
+        count: 1,
+        flows: [{ flowId: flow.flowId, syncMode: "managed", status: "running" }],
+      });
+      expect(payload.flows[0]).not.toHaveProperty("controllerId");
+
+      const textRuntime = createRuntime();
+      await flowsListCommand({}, textRuntime);
+      const output = vi
+        .mocked(textRuntime.log)
+        .mock.calls.map(([line]) => String(line))
+        .join("\n");
+
+      expect(output).toContain("n/a");
+      expect(output).not.toContain("core/legacy-restored");
+
+      const cancelRuntime = createRuntime();
+      await flowsCancelCommand({ lookup: flow.flowId }, cancelRuntime);
+
+      expect(cancelRuntime.error).not.toHaveBeenCalled();
+      expect(cancelRuntime.exit).not.toHaveBeenCalled();
+      expect(cancelRuntime.log).toHaveBeenCalledWith(
+        `Cancelled ${flow.flowId} (managed) with status cancelled.`,
+      );
     });
   });
 

--- a/src/infra/state-migrations.storage.ts
+++ b/src/infra/state-migrations.storage.ts
@@ -545,10 +545,8 @@ function normalizeLegacyFlowRow(row: Record<string, unknown>): SqliteBindRow {
         ? row.owner_session_key.trim()
         : "";
   const controllerId =
-    syncMode === "managed"
-      ? typeof row.controller_id === "string" && row.controller_id.trim()
-        ? row.controller_id.trim()
-        : "core/legacy-restored"
+    syncMode === "managed" && typeof row.controller_id === "string"
+      ? row.controller_id.trim() || null
       : null;
   return {
     flow_id: legacyBindValue(row.flow_id ?? ""),

--- a/src/tasks/task-flow-registry.store.test.ts
+++ b/src/tasks/task-flow-registry.store.test.ts
@@ -260,6 +260,71 @@ describe("task-flow-registry store runtime", () => {
     });
   });
 
+  it("preserves unknown managed-flow provenance across SQLite restore and cancellation", async () => {
+    await withFlowRegistryTempDir(async () => {
+      const created = createManagedTaskFlow({
+        ownerKey: "agent:main:main",
+        controllerId: "tests/original-flow-controller",
+        goal: "Restore an unknown historical flow controller",
+        status: "running",
+      });
+
+      const database = openOpenClawStateDatabase();
+      const db = getNodeSqliteKysely<TaskFlowRegistryTestDatabase>(database.db);
+      executeSqliteQuerySync(
+        database.db,
+        db
+          .updateTable("flow_runs")
+          .set({ controller_id: null })
+          .where("flow_id", "=", created.flowId),
+      );
+
+      resetTaskFlowRegistryForTests({ persist: false });
+
+      const restored = getTaskFlowById(created.flowId);
+      expect(restored).toMatchObject({
+        flowId: created.flowId,
+        syncMode: "managed",
+        status: "running",
+      });
+      expect(restored?.controllerId).toBeUndefined();
+
+      const cancellation = requestFlowCancel({
+        flowId: created.flowId,
+        expectedRevision: created.revision,
+        cancelRequestedAt: 444,
+      });
+
+      expect(cancellation).toMatchObject({
+        applied: true,
+        flow: {
+          flowId: created.flowId,
+          revision: created.revision + 1,
+          cancelRequestedAt: 444,
+        },
+      });
+      if (cancellation.applied) {
+        expect(cancellation.flow.controllerId).toBeUndefined();
+      }
+
+      const persistedDatabase = openOpenClawStateDatabase();
+      const persistedDb = getNodeSqliteKysely<TaskFlowRegistryTestDatabase>(persistedDatabase.db);
+      const persisted = executeSqliteQuerySync(
+        persistedDatabase.db,
+        persistedDb
+          .selectFrom("flow_runs")
+          .select(["controller_id", "cancel_requested_at", "revision"])
+          .where("flow_id", "=", created.flowId),
+      ).rows[0];
+
+      expect(persisted).toMatchObject({
+        controller_id: null,
+        cancel_requested_at: 444,
+        revision: created.revision + 1,
+      });
+    });
+  });
+
   it("round-trips explicit json null through sqlite", async () => {
     await withFlowRegistryTempDir(async () => {
       resetTaskFlowRegistryForTests();

--- a/src/tasks/task-flow-registry.test.ts
+++ b/src/tasks/task-flow-registry.test.ts
@@ -418,7 +418,7 @@ describe("task-flow-registry", () => {
     expect(getTaskFlowById(created.flowId)?.flowId).toBe(created.flowId);
   });
 
-  it("normalizes restored managed flows without a controller id", () => {
+  it("preserves unknown controller provenance when restoring a managed flow", () => {
     configureTaskFlowRegistryRuntime({
       store: {
         loadSnapshot: () => ({
@@ -446,7 +446,25 @@ describe("task-flow-registry", () => {
     const restored = getTaskFlowById("legacy-managed");
     expect(restored?.flowId).toBe("legacy-managed");
     expect(restored?.syncMode).toBe("managed");
-    expect(restored?.controllerId).toBe("core/legacy-restored");
+    expect(restored?.controllerId).toBeUndefined();
+
+    const cancelRequested = requestFlowCancel({
+      flowId: "legacy-managed",
+      expectedRevision: 0,
+      cancelRequestedAt: 20,
+    });
+
+    expect(cancelRequested).toMatchObject({
+      applied: true,
+      flow: {
+        flowId: "legacy-managed",
+        revision: 1,
+        cancelRequestedAt: 20,
+      },
+    });
+    if (cancelRequested.applied) {
+      expect(cancelRequested.flow.controllerId).toBeUndefined();
+    }
   });
 
   it("mirrors one-task flow state from tasks and leaves managed flows alone", async () => {

--- a/src/tasks/task-flow-registry.ts
+++ b/src/tasks/task-flow-registry.ts
@@ -129,13 +129,12 @@ function cloneFlowRecord(record: TaskFlowRecord): TaskFlowRecord {
 }
 
 function normalizeRestoredFlowRecord(record: TaskFlowRecord): TaskFlowRecord {
+  const { controllerId: persistedControllerId, ...restoredRecord } = record;
   const syncMode = record.syncMode === "task_mirrored" ? "task_mirrored" : "managed";
   const controllerId =
-    syncMode === "managed"
-      ? (normalizeOptionalString(record.controllerId) ?? "core/legacy-restored")
-      : undefined;
+    syncMode === "managed" ? normalizeOptionalString(persistedControllerId) : undefined;
   return {
-    ...record,
+    ...restoredRecord,
     syncMode,
     ownerKey: assertFlowOwnerKey(record.ownerKey),
     ...(record.requesterOrigin
@@ -421,7 +420,8 @@ function applyFlowPatch(current: TaskFlowRecord, patch: FlowRecordPatch): TaskFl
     patch.controllerId === undefined
       ? current.controllerId
       : normalizeOptionalString(patch.controllerId);
-  if (current.syncMode === "managed") {
+  // Historical managed flows may have no recorded controller; lifecycle updates must not invent one.
+  if (current.syncMode === "managed" && patch.controllerId !== undefined) {
     assertControllerId(controllerId);
   }
   return {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users restoring or migrating historical managed task flows would see the fabricated `core/legacy-restored` controller in `openclaw tasks flow list` and JSON output even when the original SQLite record never contained a controller. That invented identity could also be written into the canonical state database and mistaken for real plugin or core ownership.

This pull request is intentionally a **draft for maintainer review** because it changes the interpretation of shipped historical state. It must not be automatically merged.

## Why This Change Was Made

The canonical `flow_runs.controller_id` column already permits SQL `NULL`, and the public task-flow record already treats `controllerId` as optional. Preserve actual stored controller IDs; represent genuinely unknown historical provenance as SQL `NULL` and an absent runtime/JSON field instead of inventing an owner. Apply the same rule in both the shipped doctor sidecar importer and cold registry restore.

Historical ownerless flows remain listable, revision-updatable, and cancellable without acquiring a false controller. Newly created managed flows still require a genuine controller, and clearing an existing controller is still rejected. This does not introduce a schema version change, migration, compatibility alias, new state file, or fallback identifier.

## User Impact

Operators see the existing `n/a` display for genuinely unknown historical flow ownership instead of a nonexistent core controller. Real plugin and core controller IDs remain intact. Operators can still cancel restored historical flows, and authentic stored provenance is never overwritten during normal lifecycle updates.

## Evidence

- Reproduced all four failures on the exact unmodified baseline `31190d6469f5a58729b39b799cbd065b95a76443`, using isolated real SQLite databases and the actual CLI and doctor command implementations: the shipped doctor migration, a real canonical SQLite cold restore, `openclaw tasks flow list` JSON/text, and managed-flow cancellation all exposed fabricated provenance.
- Verified the repository's historical release tags: restoration fabrication is present in shipped `v2026.4.7` and later; the doctor-import fabrication is present in `v2026.7.2-beta.1` through `v2026.7.2-beta.5`.
- Proved that the operator's real state database was never modified. A strictly immutable, read-only inspection confirmed its task and flow tables contain no records, so regression proof uses only isolated fixtures rather than claiming an existing user-data reproduction.
- Focused actual doctor migration, canonical SQLite cold-restore, SQL `NULL` persistence, authentic plugin-controller preservation, CLI JSON/text, and cancellation tests: **119/119 passed**.
- Broader task registry, task executor, owner access, task audits and maintenance, canonical persistence, CLI, doctor, and Gateway tests: **359/359 passed across 14 test files and four Vitest configurations**, with all six changed files passing the repository formatter.
- Fresh independent high-reasoning review and verified secret scanning report no actionable findings.
- AI-assisted; implementation, persisted-data tradeoffs, shipped-state compatibility, and before/after proofs were reviewed against the actual canonical schema and user-facing command paths.
