### PR TITLE
fix(e2e): verify agent deletion against canonical config

### DIFF
--- a/scripts/e2e/lib/fixtures/workspace.mjs
+++ b/scripts/e2e/lib/fixtures/workspace.mjs
@@ -86,13 +86,13 @@ function assertAgentsDeleteResult([outputPath]) {
   );
   assert(fs.existsSync(process.env.SHARED_WORKSPACE), "shared workspace was removed");
   const remaining =
-    readJson(path.join(process.env.OPENCLAW_STATE_DIR, "openclaw.json"))?.agents?.list ?? [];
-  assert(Array.isArray(remaining), "agents list missing after delete");
-  assert(!remaining.some((entry) => entry?.id === "ops"), "deleted agent remained in config");
+    readJson(path.join(process.env.OPENCLAW_STATE_DIR, "openclaw.json"))?.agents?.entries ?? {};
   assert(
-    remaining.some((entry) => entry?.id === "main"),
-    "main agent missing after delete",
+    remaining && typeof remaining === "object" && !Array.isArray(remaining),
+    "agents entries missing after delete",
   );
+  assert(!Object.hasOwn(remaining, "ops"), "deleted agent remained in config");
+  assert(Object.hasOwn(remaining, "main"), "main agent missing after delete");
   console.log("agents delete shared workspace smoke ok");
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes the root Dockerfile release smoke failing after a successful shared-workspace agent deletion because the fixture writes canonical `agents.entries` but still checks the retired internal `agents.list` projection.

## Why This Change Was Made

Read and validate the persisted keyed entries map, then assert the deleted `ops` key is absent and the retained `main` key remains. Product deletion behavior is unchanged.

## User Impact

Release validation once again verifies that deleting an agent preserves a shared workspace and its remaining owner against the current config shape.

## Evidence

- Before: https://github.com/openclaw/openclaw/actions/runs/30171124202/job/89713364707
- `node --check scripts/e2e/lib/fixtures/workspace.mjs`: passed.
- `git diff --check`: passed.
- Targeted root Docker rerun: pending at https://github.com/openclaw/openclaw/actions/runs/30171877696.
- Autoreview: clean.

AI-assisted; the maintainer reviewed the exact fixture/config contract and diff.
