### PR TITLE
fix(tools): hide UTF-8 BOM from file reads

### DIFF
--- a/src/agents/sessions/tools/read.test.ts
+++ b/src/agents/sessions/tools/read.test.ts
@@ -248,6 +248,26 @@ describe("read tool", () => {
     expect(textContent(result)).toBe(bytes.toString("utf8"));
   });
 
+  it("strips one leading UTF-8 BOM without changing embedded markers", async () => {
+    const tool = createReadToolDefinition("/workspace", {
+      operations: {
+        access: async () => {},
+        detectImageMimeType: async () => null,
+        readFile: async () => Buffer.from("\uFEFFimport value\nconst marker = '\uFEFF';"),
+      },
+    });
+
+    const result = await tool.execute(
+      "call-1",
+      { path: "source.ts" },
+      undefined,
+      undefined,
+      {} as never,
+    );
+
+    expect(textContent(result)).toBe("import value\nconst marker = '\uFEFF';");
+  });
+
   it("uses an injected backend decoder when declared", async () => {
     const bytes = Buffer.from([0xc4, 0xe3, 0xba, 0xc3]);
     const tool = createReadToolDefinition("/workspace", {

--- a/src/agents/sessions/tools/read.ts
+++ b/src/agents/sessions/tools/read.ts
@@ -408,8 +408,11 @@ export function createReadToolDefinition(
             } else {
               // Read text content.
               const buffer = await ops.readFile(absolutePath);
-              const textContent =
+              const decodedText =
                 ops.decodeText?.({ buffer, absolutePath }) ?? buffer.toString("utf8");
+              const textContent = decodedText.startsWith("\uFEFF")
+                ? decodedText.slice(1)
+                : decodedText;
               const allLines = textContent.split("\n");
               const totalFileLines = allLines.length;
               // Apply offset if specified. Convert from 1-indexed input to 0-indexed array access.


### PR DESCRIPTION
Closes #113828

## What Problem This Solves

Fixes an issue where users reading UTF-8 BOM-prefixed source or configuration files through POSIX or custom/remote read backends would expose a hidden `U+FEFF` character to the model before the first source token.

## Why This Change Was Made

The read tool now treats exactly one leading decoded `U+FEFF` as file-encoding metadata. Embedded `U+FEFF` characters remain untouched, and image reads, decoding ownership, offsets, and truncation behavior are unchanged.

## User Impact

Models receive the logical first line of BOM-prefixed files consistently across local and injected backends, so exact first-line reasoning and edits are not disrupted by an invisible prefix.

## Evidence

- Added a production-path regression that supplies a leading BOM and an embedded marker through injected `ReadOperations`.
- The regression asserts that only the leading marker is removed.
- Focused suite:

```text
.\node_modules\.bin\vitest.cmd run src/agents/sessions/tools/read.test.ts
Test Files  2 passed (2)
Tests       30 passed (30)
```

- Formatting: `oxfmt --check` passed for both changed files.
- `git diff --check`: passed.
- Branch-mode autoreview: clean, no accepted/actionable findings; correctness score 0.98.

### Real Windows production-path proof

Executed the exact PR head `6941a0ed28732b6c166b4feef066a2324eea696c` on Windows 11 with Node `v22.22.3`. The probe wrote a real UTF-8 file through `node:fs`, then invoked the production `createReadToolDefinition` with its default filesystem operations (no injected read backend).

```text
RAW_PREFIX_HEX=efbbbf
OUTPUT_FIRST_CODEPOINT=U+0069
OUTPUT_EMBEDDED_BOM_COUNT=1
OUTPUT_ESCAPED="import value\nconst marker = '<U+FEFF>';"
```

This proves the source file contained a leading UTF-8 BOM, the model-visible output began with `i` rather than `U+FEFF`, and the embedded marker remained intact. The focused production tests were rerun at the same head: 2 files passed, 30 tests passed.

