### PR TITLE
fix(ui): new worktree sessions stay in Coding during creation

### DIFF
--- a/ui/src/components/app-sidebar-session-navigation-logic.test.ts
+++ b/ui/src/components/app-sidebar-session-navigation-logic.test.ts
@@ -84,6 +84,7 @@ it("keeps a prepared worktree session in Coding before canonical metadata arrive
   const key = "agent:main:new-worktree";
   const context = {
     basePath: "",
+    agents: { state: { agentsList: { mainKey: "main" } } },
     agentSelection: { state: { selectedId: "main" } },
     gateway: { snapshot: { assistantAgentId: "main", hello: null } },
     sessions: {

--- a/ui/src/components/app-sidebar-session-navigation-logic.test.ts
+++ b/ui/src/components/app-sidebar-session-navigation-logic.test.ts
@@ -17,7 +17,10 @@ function projectDraftOwnership(
         selfUser: selfUserId ? { id: selfUserId } : undefined,
       },
     },
-    sessions: { pullRequestSummary: () => undefined },
+    sessions: {
+      isPreparedWorkSession: () => false,
+      pullRequestSummary: () => undefined,
+    },
   } as unknown as Parameters<typeof buildSidebarSessionNavigationState>[0]["context"];
   const navigation = buildSidebarSessionNavigationState({
     context,
@@ -75,4 +78,41 @@ describe("sidebar draft ownership presentation", () => {
       ),
     ).toBe(false);
   });
+});
+
+it("keeps a prepared worktree session in Coding before canonical metadata arrives", () => {
+  const key = "agent:main:new-worktree";
+  const context = {
+    basePath: "",
+    agentSelection: { state: { selectedId: "main" } },
+    gateway: { snapshot: { assistantAgentId: "main", hello: null } },
+    sessions: {
+      isPreparedWorkSession: (candidate: string) => candidate === key,
+      pullRequestSummary: () => undefined,
+    },
+  } as unknown as Parameters<typeof buildSidebarSessionNavigationState>[0]["context"];
+  const navigation = buildSidebarSessionNavigationState({
+    context,
+    routeSessionKey: key,
+    sessionsResult: {
+      ts: 1,
+      path: "(multiple)",
+      count: 1,
+      defaults: { modelProvider: null, model: null, contextTokens: null },
+      sessions: [{ key, kind: "direct", updatedAt: 1 }],
+    },
+    sessionsAgentId: null,
+    showCron: false,
+    statusFilter: "active",
+    compareSessions: () => 0,
+    highlightCurrentSession: true,
+    runtimeSampledAtByRow: new WeakMap(),
+    loadingChildSessionKeys: new Set(),
+    outboxCountForSessionKey: () => 0,
+    resolveAttention: () => ({ kind: "none" }),
+    resolveAgentStatusNote: () => undefined,
+  });
+
+  expect(navigation.visibleSessions).toHaveLength(1);
+  expect(navigation.visibleSessions[0]?.workSession).toBe(true);
 });

--- a/ui/src/components/app-sidebar-session-navigation-logic.ts
+++ b/ui/src/components/app-sidebar-session-navigation-logic.ts
@@ -144,7 +144,9 @@ export function buildSidebarSessionNavigationState(input: {
       category: normalizeOptionalString(row.category),
       channel: channelInfo.channel,
       channelSession: channelInfo.channelSession,
-      workSession: Boolean(row.worktree || row.execNode),
+      workSession:
+        Boolean(row.worktree || row.execNode) ||
+        context?.sessions.isPreparedWorkSession(row.key) === true,
       acpSession: isAcpSessionKey(row.key),
       worktreeId: row.worktree?.id,
       placementState: row.placement?.state,

--- a/ui/src/lib/sessions/index.create-background.test.ts
+++ b/ui/src/lib/sessions/index.create-background.test.ts
@@ -4,7 +4,7 @@ import type { SessionsListResult } from "../../api/types.ts";
 import { waitForFast } from "../../test-helpers/wait-for.ts";
 import { createSessionCapability } from "./index.ts";
 
-it("returns a created session before background list reconciliation finishes", async () => {
+it("carries submitted work placement and model through background list reconciliation", async () => {
   let resolveList: (result: SessionsListResult) => void = () => undefined;
   const pendingList = new Promise<SessionsListResult>((resolve) => {
     resolveList = resolve;
@@ -35,17 +35,63 @@ it("returns a created session before background list reconciliation finishes", a
   sessions.subscribeCreated(created);
 
   await expect(
-    sessions.createResult({ agentId: "main" }, { reconciliation: "background" }),
+    sessions.createResult(
+      { agentId: "main", model: "openai/gpt-5.6-sol", worktree: true },
+      { reconciliation: "background" },
+    ),
   ).resolves.toMatchObject({ key });
   expect(created).not.toHaveBeenCalled();
+  expect(sessions.isPreparedWorkSession(key)).toBe(true);
+  expect(sessions.state.modelOverrides[key]).toBe("openai/gpt-5.6-sol");
 
   resolveList({
     ts: 2,
     path: "(multiple)",
     count: 1,
     defaults: { modelProvider: null, model: null, contextTokens: null },
-    sessions: [{ key, kind: "direct", updatedAt: 2 }],
+    sessions: [
+      {
+        key,
+        kind: "direct",
+        updatedAt: 2,
+        worktree: { id: "wt-1", branch: "openclaw/task", repoRoot: "/repo" },
+      },
+    ],
   });
   await waitForFast(() => expect(created).toHaveBeenCalledWith(key));
+  expect(sessions.isPreparedWorkSession(key)).toBe(false);
+  sessions.dispose();
+});
+
+it("does not prepare rejected worktree or model selections", async () => {
+  const key = "agent:main:rejected-worktree";
+  const client = {
+    request: vi.fn(async (method: string) => {
+      if (method === "sessions.create") {
+        throw new Error("agent workspace is not a git checkout");
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    }),
+  } as unknown as GatewayBrowserClient;
+  const sessions = createSessionCapability({
+    snapshot: {
+      client,
+      phase: "connected" as const,
+      hello: null,
+      assistantAgentId: "main",
+      sessionKey: "agent:main:main",
+    },
+    subscribe: () => () => undefined,
+    subscribeEvents: () => () => undefined,
+  });
+
+  await expect(
+    sessions.createResult(
+      { key, model: "openai/gpt-5.6-sol", worktree: true },
+      { reconciliation: "background" },
+    ),
+  ).resolves.toBeNull();
+  expect(sessions.isPreparedWorkSession(key)).toBe(false);
+  expect(sessions.state.modelOverrides[key]).toBeUndefined();
   sessions.dispose();
 });

--- a/ui/src/lib/sessions/index.create-background.test.ts
+++ b/ui/src/lib/sessions/index.create-background.test.ts
@@ -63,6 +63,52 @@ it("carries submitted work placement and model through background list reconcili
   sessions.dispose();
 });
 
+it("retires prepared work placement when the session is deleted", async () => {
+  const key = "agent:main:deleted-worktree";
+  const emptyList: SessionsListResult = {
+    ts: 2,
+    path: "(multiple)",
+    count: 0,
+    defaults: { modelProvider: null, model: null, contextTokens: null },
+    sessions: [],
+  };
+  const client = {
+    request: vi.fn(async (method: string) => {
+      if (method === "sessions.create") {
+        return { key };
+      }
+      if (method === "sessions.delete") {
+        return { deleted: true };
+      }
+      if (method === "sessions.list") {
+        return emptyList;
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    }),
+  } as unknown as GatewayBrowserClient;
+  const sessions = createSessionCapability({
+    snapshot: {
+      client,
+      phase: "connected" as const,
+      hello: null,
+      assistantAgentId: "main",
+      sessionKey: "agent:main:main",
+    },
+    subscribe: () => () => undefined,
+    subscribeEvents: () => () => undefined,
+  });
+
+  await expect(
+    sessions.createResult({ agentId: "main", worktree: true }, { reconciliation: "background" }),
+  ).resolves.toMatchObject({ key });
+  expect(sessions.isPreparedWorkSession(key)).toBe(true);
+
+  await expect(sessions.delete(key)).resolves.toMatchObject({ deleted: true });
+  // The key can be reused by a later ordinary thread, so it must not stay Coding.
+  expect(sessions.isPreparedWorkSession(key)).toBe(false);
+  sessions.dispose();
+});
+
 it("does not prepare rejected worktree or model selections", async () => {
   const key = "agent:main:rejected-worktree";
   const client = {

--- a/ui/src/lib/sessions/index.ts
+++ b/ui/src/lib/sessions/index.ts
@@ -212,6 +212,8 @@ export type SessionCapability = {
   create: (params?: SessionCreateParams) => Promise<string | null>;
   patch: SessionPatchRoute;
   setModelOverride: (key: string, value: string | null | undefined) => void;
+  /** True while a just-created work session is waiting for its canonical placement row. */
+  isPreparedWorkSession: (key: string) => boolean;
   pullRequestSummary: (key: string) => SessionCatalogPullRequestSummary | undefined;
   capturePullRequestEpoch: (key: string) => symbol;
   setPullRequestSummary: (
@@ -839,6 +841,7 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
     string,
     { token: symbol; previous: string | null | undefined }
   >();
+  const preparedWorkSessionKeys = new Set<string>();
   const swarmActivity = new SwarmActivityTracker();
   const pullRequestSummaries = new Map<string, SessionCatalogPullRequestSummary>();
   const pullRequestEpochs = new Map<string, symbol>();
@@ -1015,6 +1018,11 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
         }
       }
       nextResult = swarmActivity.decorate(nextResult);
+      for (const row of nextResult?.sessions ?? []) {
+        if (row.worktree || row.execNode) {
+          preparedWorkSessionKeys.delete(row.key);
+        }
+      }
       canonicalListRevision += 1;
       publish({
         result: nextResult,
@@ -1105,6 +1113,16 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
       });
       if (!isCurrentConnection(scope)) {
         return null;
+      }
+      // The create response precedes list reconciliation. Carry submitted facts
+      // across that gap so a partial history row cannot briefly lose its zone/model.
+      if (requestParams.worktree === true || Boolean(requestParams.execNode?.trim())) {
+        preparedWorkSessionKeys.add(result.key);
+      }
+      if (requestParams.model?.trim()) {
+        setModelOverride(result.key, requestParams.model);
+      } else if (preparedWorkSessionKeys.has(result.key)) {
+        publish({ ...state });
       }
       const reconcileCreatedSession = async () => {
         await refreshReplacement(params.agentId);
@@ -1808,6 +1826,7 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
       inFlight = null;
       queuedRefresh = null;
       rollbackPendingModelPatches();
+      preparedWorkSessionKeys.clear();
       pullRequestSummaries.clear();
       pullRequestEpochs.clear();
       // A connected client replacement needs its own invalidation publish;
@@ -1926,6 +1945,9 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
     create,
     patch,
     setModelOverride,
+    isPreparedWorkSession(key) {
+      return preparedWorkSessionKeys.has(key.trim());
+    },
     pullRequestSummary,
     capturePullRequestEpoch,
     setPullRequestSummary,
@@ -1970,6 +1992,7 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
       queuedRefresh = null;
       subscribedClient = null;
       pendingModelPatches.clear();
+      preparedWorkSessionKeys.clear();
       swarmActivity.clear();
       pullRequestSummaries.clear();
       pullRequestEpochs.clear();

--- a/ui/src/lib/sessions/index.ts
+++ b/ui/src/lib/sessions/index.ts
@@ -904,6 +904,12 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
     pullRequestSummaries.delete(normalizedKey);
   };
 
+  // A deleted key stays reusable for a later ordinary thread, so a leftover
+  // prepared entry would keep classifying that new session as Coding forever.
+  const retirePreparedWorkSession = (key: string) => {
+    preparedWorkSessionKeys.delete(key.trim());
+  };
+
   const setPullRequestSummary = (
     key: string,
     summary: SessionCatalogPullRequestSummary | undefined,
@@ -1117,7 +1123,7 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
       // The create response precedes list reconciliation. Carry submitted facts
       // across that gap so a partial history row cannot briefly lose its zone/model.
       if (requestParams.worktree === true || Boolean(requestParams.execNode?.trim())) {
-        preparedWorkSessionKeys.add(result.key);
+        preparedWorkSessionKeys.add(result.key.trim());
       }
       if (requestParams.model?.trim()) {
         setModelOverride(result.key, requestParams.model);
@@ -1515,6 +1521,7 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
         return { deleted: false };
       }
       retirePullRequestSummary(key);
+      retirePreparedWorkSession(key);
       publish({ ...state, deletedSessions: [{ key, agentId: options.agentId }] });
       setModelOverride(key, undefined);
       await refreshReplacement(options.agentId);
@@ -1564,6 +1571,7 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
     if (deleted.length > 0 && isCurrentConnection(scope)) {
       for (const key of deleted) {
         retirePullRequestSummary(key);
+        retirePreparedWorkSession(key);
       }
       publish({
         ...state,

--- a/ui/src/test-helpers/app-sidebar.ts
+++ b/ui/src/test-helpers/app-sidebar.ts
@@ -236,6 +236,7 @@ export function createSessionsHarness(agentId: string, keys: string[]) {
       return () => listeners.delete(listener);
     },
     subscribeCreated: () => () => undefined,
+    isPreparedWorkSession: () => false,
     pullRequestSummary: (key: string) => pullRequestSummaries.get(key),
     setPullRequestSummary(key: string, summary: SessionCatalogPullRequestSummary | undefined) {
       if (summary) {


### PR DESCRIPTION
Closes #113825

## What Problem This Solves

Fixes an issue where a newly created worktree session could first appear under Threads, then jump to Coding after asynchronous session-list reconciliation. The selected model could also disappear during that gap.

## Why This Change Was Made

Carries the submitted worktree and model facts into the optimistic session state until the canonical `sessions.list` row arrives, then removes the prepared state. Rejected creations and lifecycle teardown clear it immediately.

## User Impact

New worktree sessions appear in Coding immediately and keep the chosen model while Gateway metadata catches up, eliminating the visible group jump and unreliable selection gap.

## Evidence

- Before: optimistic rows lacked worktree/model facts, so the sidebar temporarily classified them as ordinary Threads.
- After: submitted facts classify the optimistic row as Coding immediately; canonical metadata replaces them on reconciliation.
- `node scripts/run-vitest.mjs ui/src/lib/sessions/index.create-background.test.ts ui/src/components/app-sidebar-session-navigation-logic.test.ts` — 6 passed.
- Branch-wide Autoreview: clean, no accepted/actionable findings (0.93 confidence).
- Codex contract checked at `20dafe201d91`: `thread/start` accepts an optional explicit `model`, passes it through typed `ConfigOverrides`, and only substitutes a provider default when `allowProviderModelFallback` is explicitly enabled ([protocol](https://github.com/openai/codex/blob/20dafe201d91d4405eef05ecd1db0257f13a9ac8/codex-rs/app-server-protocol/src/protocol/v2/thread.rs#L56-L67), [request processor](https://github.com/openai/codex/blob/20dafe201d91d4405eef05ecd1db0257f13a9ac8/codex-rs/app-server/src/request_processors/thread_processor.rs#L944-L990), [fallback gate](https://github.com/openai/codex/blob/20dafe201d91d4405eef05ecd1db0257f13a9ac8/codex-rs/core/src/session/mod.rs#L610-L639)).

This is a timing-only state transition; static before/after screenshots cannot reliably capture the race, so the evidence asserts both the pre-reconciliation and post-reconciliation states deterministically.
