### PR TITLE
fix(infra): copy text through PowerShell clipboard fallback

### DIFF
--- a/src/infra/clipboard.test.ts
+++ b/src/infra/clipboard.test.ts
@@ -80,6 +80,29 @@ describe("copyToClipboard", () => {
     ]);
   });
 
+  it("passes PowerShell clipboard text as UTF-8 base64 on stdin", async () => {
+    runCommandWithTimeoutMock
+      .mockRejectedValueOnce(new Error("missing pbcopy"))
+      .mockRejectedValueOnce(new Error("missing xclip"))
+      .mockRejectedValueOnce(new Error("missing wl-copy"))
+      .mockRejectedValueOnce(new Error("missing clip.exe"))
+      .mockResolvedValueOnce({ code: 0, killed: false });
+
+    const value = "\u4f60\u597d\u4e16\u754c \ud83c\udf89 caf\u00e9";
+    await expect(copyToClipboard(value)).resolves.toBe(true);
+
+    const [argv, options] = runCommandWithTimeoutMock.mock.calls[4] as [
+      string[],
+      { timeoutMs: number; input: string },
+    ];
+    expect(argv.slice(0, 4)).toEqual(["powershell", "-NoProfile", "-NonInteractive", "-Command"]);
+    expect(argv.join("\0")).not.toContain(value);
+    expect(options).toEqual({
+      timeoutMs: 3000,
+      input: Buffer.from(value, "utf8").toString("base64"),
+    });
+  });
+
   it("returns false when every clipboard backend fails or is killed", async () => {
     runCommandWithTimeoutMock
       .mockResolvedValueOnce({ code: 0, killed: true })

--- a/src/infra/clipboard.ts
+++ b/src/infra/clipboard.ts
@@ -1,25 +1,36 @@
 // Reads and writes clipboard text through platform command helpers.
+import { Buffer } from "node:buffer";
 import { runCommandWithTimeout } from "../process/exec.js";
 import { isWSL2Sync } from "./wsl.js";
 
 // WSL interop needs a shell to launch Windows PE binaries; exec keeps the
 // clipboard process as the timeout-owned child while values stay on stdin.
 const WSL_CLIPBOARD_ARGV = ["/bin/sh", "-c", "exec /mnt/c/Windows/System32/clip.exe"];
+const POWERSHELL_CLIPBOARD_ARGV = [
+  "powershell",
+  "-NoProfile",
+  "-NonInteractive",
+  "-Command",
+  "$encoded = [Console]::In.ReadToEnd(); $bytes = [Convert]::FromBase64String($encoded); Set-Clipboard -Value ([Text.Encoding]::UTF8.GetString($bytes))",
+];
 
 export async function copyToClipboard(value: string): Promise<boolean> {
-  const attempts: Array<{ argv: string[] }> = [
-    ...(isWSL2Sync() ? [{ argv: WSL_CLIPBOARD_ARGV }] : []),
-    { argv: ["pbcopy"] },
-    { argv: ["xclip", "-selection", "clipboard"] },
-    { argv: ["wl-copy"] },
-    { argv: ["clip.exe"] },
-    { argv: ["powershell", "-NoProfile", "-Command", "Set-Clipboard"] },
+  const attempts: Array<{ argv: string[]; input: string }> = [
+    ...(isWSL2Sync() ? [{ argv: WSL_CLIPBOARD_ARGV, input: value }] : []),
+    { argv: ["pbcopy"], input: value },
+    { argv: ["xclip", "-selection", "clipboard"], input: value },
+    { argv: ["wl-copy"], input: value },
+    { argv: ["clip.exe"], input: value },
+    {
+      argv: POWERSHELL_CLIPBOARD_ARGV,
+      input: Buffer.from(value, "utf8").toString("base64"),
+    },
   ];
   for (const attempt of attempts) {
     try {
       const result = await runCommandWithTimeout(attempt.argv, {
         timeoutMs: 3_000,
-        input: value,
+        input: attempt.input,
       });
       if (result.code === 0 && !result.killed) {
         return true;


### PR DESCRIPTION
Closes #113833

## What Problem This Solves

Fixes an issue where Windows users whose copy operation reached the PowerShell fallback would get a successful result while the clipboard remained empty.

## Why This Change Was Made

The fallback now sends an ASCII Base64 representation on stdin, explicitly reads it in PowerShell, decodes UTF-8, and passes the resulting string to `Set-Clipboard`. This keeps clipboard values out of argv and leaves backend order and all other backends unchanged.

## User Impact

Dashboard URLs, tokens, paths, and multilingual text are actually copied when the PowerShell fallback is selected, including CJK, emoji, and accented text.

## Evidence

Real Windows CP936 host, before the fix:

```text
exit code: 0
clipboard codepoints: <empty>
equal to input: false
```

The same round trip after the fix:

```text
exit code: 0
clipboard codepoints: 4f60 597d 4e16 754c 20 1f389 20 63 61 66 e9
equal to input: true
```

Focused validation:

```text
src/infra/clipboard.test.ts: 6 passed, 0 failed
oxfmt: clean
git diff --check: clean
autoreview: clean (0.98 overall correctness confidence)
```
