### PR TITLE
fix(openai): reject truncated OAuth image response streams

### DIFF
--- a/extensions/openai/image-generation-provider.test.ts
+++ b/extensions/openai/image-generation-provider.test.ts
@@ -159,6 +159,14 @@ function mockCodexRawStream(body: string) {
   }));
 }
 
+function mockCodexImageEvents(
+  events: readonly Record<string, unknown>[],
+  options: { sendDone?: boolean } = {},
+) {
+  const body = events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("");
+  mockCodexRawStream(`${body}${options.sendDone ? "data: [DONE]\n\n" : ""}`);
+}
+
 function mockCodexAuthOnly() {
   resolveApiKeyForProviderMock.mockImplementation(async (params?: { provider?: string }) => {
     if (params?.provider === "openai") {
@@ -1631,6 +1639,110 @@ describe("openai image generation provider", () => {
 
   it.each([
     {
+      name: "an empty response stream",
+      events: [],
+    },
+    {
+      name: "a created-only response",
+      events: [{ type: "response.created", response: { id: "resp_image_created" } }],
+    },
+    {
+      name: "an image output item without a completed response",
+      events: [
+        {
+          type: "response.output_item.done",
+          item: {
+            type: "image_generation_call",
+            result: Buffer.from("partial-image").toString("base64"),
+          },
+        },
+      ],
+    },
+    {
+      name: "an SSE DONE marker without a completed response",
+      events: [{ type: "response.created", response: { id: "resp_image_done" } }],
+      sendDone: true,
+    },
+  ])("rejects $name", async ({ events, sendDone }) => {
+    mockCodexAuthOnly();
+    mockCodexImageEvents(events, { sendDone });
+
+    const provider = buildOpenAIImageGenerationProvider();
+    await expect(
+      provider.generateImage({
+        provider: "openai",
+        model: "gpt-image-2",
+        prompt: "Draw an image over a truncated Responses stream",
+        cfg: {},
+      }),
+    ).rejects.toThrow("OpenAI Codex image generation stream ended before a completed response");
+  });
+
+  it("preserves the provider reason for an incomplete Codex image response", async () => {
+    mockCodexAuthOnly();
+    mockCodexImageEvents([
+      {
+        type: "response.incomplete",
+        response: {
+          id: "resp_image_incomplete",
+          incomplete_details: { reason: "max_output_tokens" },
+        },
+      },
+    ]);
+
+    const provider = buildOpenAIImageGenerationProvider();
+    await expect(
+      provider.generateImage({
+        provider: "openai",
+        model: "gpt-image-2",
+        prompt: "Draw an image over an incomplete Responses stream",
+        cfg: {},
+      }),
+    ).rejects.toThrow("OpenAI Codex image generation incomplete: max_output_tokens");
+  });
+
+  it("preserves a nested Codex image response failure", async () => {
+    mockCodexAuthOnly();
+    mockCodexImageEvents([
+      {
+        type: "response.failed",
+        response: {
+          id: "resp_image_failed",
+          error: { code: "server_error", message: "image generation backend unavailable" },
+        },
+      },
+    ]);
+
+    const provider = buildOpenAIImageGenerationProvider();
+    await expect(
+      provider.generateImage({
+        provider: "openai",
+        model: "gpt-image-2",
+        prompt: "Draw an image over a failed Responses stream",
+        cfg: {},
+      }),
+    ).rejects.toThrow("server_error: image generation backend unavailable");
+  });
+
+  it("rejects completed Codex image responses without image output", async () => {
+    mockCodexAuthOnly();
+    mockCodexImageEvents([
+      { type: "response.completed", response: { id: "resp_image_empty", output: [] } },
+    ]);
+
+    const provider = buildOpenAIImageGenerationProvider();
+    await expect(
+      provider.generateImage({
+        provider: "openai",
+        model: "gpt-image-2",
+        prompt: "Draw an image from an empty completed Responses stream",
+        cfg: {},
+      }),
+    ).rejects.toThrow("OpenAI Codex image generation response missing image data");
+  });
+
+  it.each([
+    {
       name: "invalid alphabet from output item",
       event: {
         type: "response.output_item.done",
@@ -1669,7 +1781,11 @@ describe("openai image generation provider", () => {
     },
   ])("rejects malformed Codex image base64 from $name events", async ({ event }) => {
     mockCodexAuthOnly();
-    mockCodexRawStream(`data: ${JSON.stringify(event)}\n\n`);
+    mockCodexImageEvents(
+      event.type === "response.completed"
+        ? [event]
+        : [event, { type: "response.completed", response: { output: [] } }],
+    );
 
     const provider = buildOpenAIImageGenerationProvider();
     await expect(
@@ -1684,12 +1800,13 @@ describe("openai image generation provider", () => {
 
   it("accepts Codex-compatible surrounding Unicode whitespace", async () => {
     mockCodexAuthOnly();
-    mockCodexRawStream(
-      `data: ${JSON.stringify({
+    mockCodexImageEvents([
+      {
         type: "response.output_item.done",
         item: { type: "image_generation_call", result: "\u0085aGVsbG8=\u0085" },
-      })}\n\n`,
-    );
+      },
+      { type: "response.completed", response: { output: [] } },
+    ]);
 
     const provider = buildOpenAIImageGenerationProvider();
     const result = await provider.generateImage({

--- a/extensions/openai/image-generation-provider.ts
+++ b/extensions/openai/image-generation-provider.ts
@@ -482,6 +482,13 @@ type OpenAICodexImageGenerationEvent = {
       result?: string;
       revised_prompt?: string;
     }>;
+    error?: {
+      code?: string;
+      message?: string;
+    };
+    incomplete_details?: {
+      reason?: string;
+    };
     usage?: unknown;
     tool_usage?: unknown;
   };
@@ -619,13 +626,25 @@ function extractCodexImageGenerationResult(params: {
     (event) => event.type === "response.failed" || event.type === "error",
   );
   if (failure) {
+    const responseError = failure.response?.error;
+    const error = responseError ?? failure.error;
     const message =
-      failure.error?.message ??
+      (responseError?.code && responseError.message
+        ? `${responseError.code}: ${responseError.message}`
+        : error?.message) ??
       failure.message ??
-      (failure.error?.code ? `OpenAI Codex image generation failed (${failure.error.code})` : "");
+      (error?.code ? `OpenAI Codex image generation failed (${error.code})` : "");
     throw new Error(message || "OpenAI Codex image generation failed");
   }
+  const incompleteResponse = events.find((event) => event.type === "response.incomplete");
+  if (incompleteResponse) {
+    const reason = incompleteResponse.response?.incomplete_details?.reason ?? "unknown";
+    throw new Error(`OpenAI Codex image generation incomplete: ${reason}`);
+  }
   const completedResponse = events.find((event) => event.type === "response.completed");
+  if (!completedResponse?.response) {
+    throw new Error("OpenAI Codex image generation stream ended before a completed response");
+  }
   const outputItemImages = events
     .filter(
       (event) =>
@@ -645,6 +664,9 @@ function extractCodexImageGenerationResult(params: {
     .map((entry, index) => toCodexImage(entry, index, params.outputFormat))
     .filter((image): image is NonNullable<typeof image> => image !== null);
   const images = outputItemImages.length > 0 ? outputItemImages : completedOutputImages;
+  if (images.length === 0) {
+    throw new Error("OpenAI Codex image generation response missing image data");
+  }
 
   return {
     images,


### PR DESCRIPTION
> **USER REVIEW REQUIRED — DRAFT.** This changes the publicly observable OpenAI OAuth image-stream failure contract. Do not mark ready, enable automerge, or merge without maintainer review.

## What Problem This Solves

Fixes an issue where users generating an image through OpenAI OAuth could receive a silently successful empty result or a prematurely accepted partial image when the Responses SSE connection closed before the provider completed the response. Genuine incomplete responses also appeared successful, and nested provider failure details were replaced by a generic error.

## Why This Change Was Made

Validate image output only after the actual `response.completed` terminal event, preserve the provider's `response.incomplete` reason and canonical nested `response.failed.response.error`, and reject completed responses without usable image data. Keep this exclusively in the OpenAI provider plugin; do not change authentication, provider selection, SSRF policy, core transport, Gateway protocol, persistence, or configuration.

The terminal contract was checked directly against upstream Codex at commit `4c43465133428898aa84f0bfc02c306ed65fb66a`:

- [SSE Responses event parser and nested failed/incomplete handling](https://github.com/openai/codex/blob/4c43465133428898aa84f0bfc02c306ed65fb66a/codex-rs/codex-api/src/sse/responses.rs).
- [Actual integration regression requiring a retry after an output-item-only stream](https://github.com/openai/codex/blob/4c43465133428898aa84f0bfc02c306ed65fb66a/codex-rs/core/tests/suite/stream_no_completed.rs).
- [Runtime rejection of streams that end before `response.completed`](https://github.com/openai/codex/blob/4c43465133428898aa84f0bfc02c306ed65fb66a/codex-rs/core/src/session/turn.rs).
- [Canonical `image_generation_call` protocol model](https://github.com/openai/codex/blob/4c43465133428898aa84f0bfc02c306ed65fb66a/codex-rs/protocol/src/models.rs).

## User Impact

OpenAI OAuth image generation now fails clearly when the image stream is incomplete, reports actual provider failures, and never claims a successful response without an image. Normal OpenAI API-key image generation/editing, valid OAuth completed-stream images, metadata, canonical base64 validation, Unicode handling, and existing auth/routing continue to work.

## Evidence

- Baseline on clean released main: **7/7 real regression cases failed**, while the **75 existing image tests passed**. Reproduced empty SSE, created-only SSE, output item followed by EOF, `[DONE]` without a completed response, provider-incomplete reason, nested provider failure, and a completed response containing no images.
- Fixed provider and neighboring contracts: **163/163 passed** across the OpenAI image, provider, runtime-contract, transport-policy, and media-understanding suites on a fresh Linux Blacksmith Testbox.
- Real OpenAI API-key image provider: **actual `gpt-image-2` image generation and reference-image editing both passed** through the registered plugin.
- Real OpenAI `gpt-5.4`: **3/3 passed**, including model resolution, completed Responses streaming with token usage, and interleaved reasoning/tool calls.
- Complete exact-base remote `pnpm check:changed`: **passed**, including extension and extension-test typechecks, **245 lint rules with zero warnings**, formatting, SDK/package/plugin boundary checks, database and sidecar guards, and runtime import-cycle detection. Authoritative remote timing reported `exitCode=0`.
- Fresh isolated high-effort independent review and TruffleHog: **clean, no actionable findings**.
- Both commit author and committer: `Peter Steinberger <steipete@gmail.com>`.
- AI-assisted. **Draft intentionally retained for human review; no auto-merge.**
