### PR TITLE
fix(state): release leases when CLI exits

### DIFF
--- a/src/state/openclaw-state-lease.test.ts
+++ b/src/state/openclaw-state-lease.test.ts
@@ -1,3 +1,6 @@
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
@@ -17,6 +20,59 @@ afterEach(() => {
 });
 
 describe("OpenClaw state lease", () => {
+  it("releases ownership when a CLI exits from inside the leased operation", async () => {
+    await withOpenClawTestState({ label: "core-state-lease-process-exit" }, async (state) => {
+      const leaseModuleUrl = pathToFileURL(path.resolve("src/state/openclaw-state-lease.ts")).href;
+      const childScript = await state.writeText(
+        "lease-process-exit-child.mts",
+        `
+          import { withOpenClawStateLease } from ${JSON.stringify(leaseModuleUrl)};
+          const stateDir = process.argv[2];
+          await withOpenClawStateLease({
+            scope: "core:test",
+            key: "process-exit",
+            database: { scope: "shared", options: { env: { ...process.env, OPENCLAW_STATE_DIR: stateDir } } },
+            leaseMs: 300_000,
+            waitMs: 0,
+          }, async () => process.exit(23));
+        `,
+      );
+
+      const exitCode = await new Promise<number | null>((resolve, reject) => {
+        const child = spawn(process.execPath, ["--import", "tsx", childScript, state.stateDir], {
+          stdio: ["ignore", "pipe", "pipe"],
+        });
+        let output = "";
+        child.stdout.on("data", (chunk) => (output += chunk));
+        child.stderr.on("data", (chunk) => (output += chunk));
+        child.on("error", reject);
+        child.on("close", (code) => {
+          if (code !== 23) {
+            reject(new Error(`lease child exited ${code}: ${output}`));
+            return;
+          }
+          resolve(code);
+        });
+      });
+      expect(exitCode).toBe(23);
+
+      let reacquired = false;
+      await withOpenClawStateLease(
+        {
+          scope: "core:test",
+          key: "process-exit",
+          database: { scope: "shared", options: { env: state.env } },
+          leaseMs: 1_000,
+          waitMs: 0,
+        },
+        async () => {
+          reacquired = true;
+        },
+      );
+      expect(reacquired).toBe(true);
+    });
+  });
+
   it("rechecks exact ownership inside the caller's write transaction", async () => {
     await withOpenClawTestState({ label: "core-state-lease" }, async () => {
       await expect(

--- a/src/state/openclaw-state-lease.ts
+++ b/src/state/openclaw-state-lease.ts
@@ -76,6 +76,35 @@ const ACQUIRE_BACKOFF = {
 const MIN_LEASE_MS = 1_000;
 const LEASE_DB_BUSY_TIMEOUT_MS = 0;
 const RELEASE_RETRY_TIMEOUT_MS = 2_000;
+const processExitLeaseCleanups = new Set<() => void>();
+let processExitListenerInstalled = false;
+
+function runProcessExitLeaseCleanups(): void {
+  processExitListenerInstalled = false;
+  for (const cleanup of processExitLeaseCleanups) {
+    try {
+      cleanup();
+    } catch {
+      // Expiry still recovers a lease when synchronous process-exit cleanup loses a DB race.
+    }
+  }
+  processExitLeaseCleanups.clear();
+}
+
+function registerProcessExitLeaseCleanup(cleanup: () => void): () => void {
+  processExitLeaseCleanups.add(cleanup);
+  if (!processExitListenerInstalled) {
+    process.once("exit", runProcessExitLeaseCleanups);
+    processExitListenerInstalled = true;
+  }
+  return () => {
+    processExitLeaseCleanups.delete(cleanup);
+    if (processExitLeaseCleanups.size === 0 && processExitListenerInstalled) {
+      process.removeListener("exit", runProcessExitLeaseCleanups);
+      processExitListenerInstalled = false;
+    }
+  };
+}
 
 function leaseError(
   code: OpenClawStateLeaseErrorCode,
@@ -480,6 +509,15 @@ export async function withOpenClawStateLease<T>(
     owner,
     leaseLabel: validated.leaseLabel,
   };
+  // `process.exit()` skips async `finally` blocks. Release synchronously so a normal CLI error
+  // cannot strand the lease until its TTL and block the next lifecycle command.
+  const unregisterProcessExitCleanup = registerProcessExitLeaseCleanup(() => {
+    release({
+      ...identity,
+      database: validated.database,
+      operationLabel: validated.operationLabel,
+    });
+  });
   const leaseLost = new AbortController();
   const operationSignal = validated.signal
     ? AbortSignal.any([validated.signal, leaseLost.signal])
@@ -580,6 +618,7 @@ export async function withOpenClawStateLease<T>(
     verifyLeaseOwnership({ ...identity, database: validated.database });
     return result;
   } finally {
+    unregisterProcessExitCleanup();
     clearInterval(heartbeat);
     if (expiryTimer) {
       clearTimeout(expiryTimer);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a CLI command that exits while holding a shared state lease can leave the lease active until its TTL, causing the next lifecycle command to stall or time out. Release package validation reproduced this when an expected malformed-plugin rejection was immediately followed by a git plugin install.

## Why This Change Was Made

The shared lease owner now registers one process-exit cleanup while leases are active and synchronously releases each lease by its exact identity. Normal completion unregisters the cleanup, and lease expiry remains the recovery path if exit-time SQLite cleanup loses a database race.

## User Impact

Plugin and other lease-backed CLI operations no longer poison the next command for up to five minutes after a normal error exit.

## Evidence

- Before: `plugins-offline` timed out consistently in run https://github.com/openclaw/openclaw/actions/runs/30171877696 and traced Testbox run https://github.com/openclaw/openclaw/actions/runs/30172556032. The trace stops before git-install config loading, immediately after the prior expected rejection exits.
- Regression: `node scripts/run-vitest.mjs src/state/openclaw-state-lease.test.ts` passes. The test forks a real child, calls `process.exit(23)` inside a five-minute lease, and proves immediate reacquisition.
- Static: `git diff --check` and targeted `oxfmt --check` pass.
- Review: autoreview clean; no accepted or actionable findings.
- Exact patched Docker lane: https://github.com/openclaw/openclaw/actions/runs/30172805656 passed. The complete `plugins-offline` sweep finished in 136 seconds; the pre-fix trace timed out during git install after 252 seconds.

AI-assisted: yes. The implementation and proof were reviewed against the state-lease and plugin lifecycle ownership paths.

Release-note context: plugin lifecycle commands no longer stall after a preceding command exits with an expected error.
