### PR TITLE
fix(ui): add spacing between coding session groups

### DIFF
--- a/ui/src/e2e/codex-sessions.e2e.test.ts
+++ b/ui/src/e2e/codex-sessions.e2e.test.ts
@@ -99,6 +99,106 @@ suite("Codex native session catalog", () => {
     await page.close();
   });
 
+  it("separates native catalogs from live Coding rows", async () => {
+    const page = await browser.newPage({
+      deviceScaleFactor: 2,
+      viewport: { height: 900, width: 1280 },
+    });
+    await page.addInitScript(
+      (key) => localStorage.removeItem(key),
+      collapsedSessionSectionsStorageKey,
+    );
+    await installMockGateway(page, {
+      featureMethods: ["chat.metadata", "chat.startup", "sessions.catalog.list"],
+      methodResponses: {
+        "sessions.list": {
+          count: 1,
+          defaults: {
+            contextTokens: null,
+            model: "gpt-5.5",
+            modelProvider: "openai",
+          },
+          path: "",
+          sessions: [
+            {
+              contextTokens: null,
+              displayName: "Understanding Startup Phases and Delays",
+              hasActiveRun: true,
+              key: "agent:main:startup-phases",
+              kind: "direct",
+              label: "Understanding Startup Phases and Delays",
+              model: "gpt-5.5",
+              modelProvider: "openai",
+              status: "running",
+              totalTokens: 0,
+              updatedAt: Date.now(),
+              worktree: {
+                id: "startup-phases",
+                branch: "startup-phases",
+                repoRoot: "/workspace/openclaw",
+              },
+            },
+          ],
+          ts: Date.now(),
+        },
+        "sessions.catalog.list": {
+          catalogs: [
+            {
+              id: "codex",
+              label: "Codex",
+              capabilities: { continueSession: true, archive: true, createSession: true },
+              hosts: [
+                {
+                  hostId: "gateway:local",
+                  label: "Local Codex",
+                  kind: "gateway",
+                  connected: true,
+                  sessions: [
+                    {
+                      threadId: "thread-startup",
+                      name: "Trace startup labels to code paths",
+                      cwd: "/workspace/openclaw",
+                      status: "idle",
+                      archived: false,
+                      canContinue: true,
+                      canArchive: true,
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    });
+
+    try {
+      await page.goto(`${server.baseUrl}chat`);
+      await page.evaluate(() => document.documentElement.setAttribute("data-theme-mode", "dark"));
+      await expandCodingSection(page);
+      const workSection = page.locator('[data-session-section="work"]');
+      const liveRows = workSection.locator(":scope > .sidebar-recent-sessions__list");
+      const catalog = workSection.locator(':scope > [data-session-section="catalog:codex"]');
+      await catalog.waitFor({ state: "visible" });
+      const [liveRowsBox, catalogBox] = await Promise.all([
+        liveRows.boundingBox(),
+        catalog.boundingBox(),
+      ]);
+      expect(liveRowsBox).not.toBeNull();
+      expect(catalogBox).not.toBeNull();
+      expect(Math.round(catalogBox!.y - (liveRowsBox!.y + liveRowsBox!.height))).toBe(10);
+      if (captureUiProofEnabled) {
+        await mkdir(uiProofArtifactDir, { recursive: true });
+        await workSection.screenshot({
+          animations: "disabled",
+          path: path.join(uiProofArtifactDir, "06-coding-catalog-spacing.png"),
+        });
+      }
+    } finally {
+      await page.close();
+    }
+  });
+
   it("shows a completed host while the aggregate catalog request is still pending", async () => {
     const page = await browser.newPage({ viewport: { height: 900, width: 1280 } });
     const gateway = await installMockGateway(page, {

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1250,6 +1250,12 @@ html.openclaw-native-macos
     box-shadow var(--duration-fast) ease;
 }
 
+/* Catalog sections are nested inside Coding, so add to its 2px item gap to
+   match the 10px rhythm between top-level session groups. */
+.sidebar-recent-sessions__group--zone-coding > .sidebar-recent-sessions__group {
+  margin-top: 8px;
+}
+
 .sidebar-recent-sessions__group--session-drop {
   background: color-mix(in srgb, var(--accent) 10%, transparent);
   box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 55%, transparent);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users viewing active Coding sessions alongside native session catalogs would see the groups crowded together in the Control UI sidebar.

## Why This Change Was Made

Nested catalog sections now add 8px to the existing 2px list gap, matching the 10px rhythm used between top-level session groups. A focused browser test locks in the resulting spacing.

## User Impact

Coding session groups are easier to scan because live sessions and Codex/Claude catalog sections have clear visual separation.

## Evidence

### Before

![Before: tight spacing between Coding and Codex groups](https://gist.githubusercontent.com/clawsweeper/ab6526cc6da3373f11db211a019ee3c1/raw/74ca84f0bdf150fb26865ed93d7d96d5e9c34dea/before.svg)

### After

![After: 10px spacing between Coding and Codex groups](https://gist.githubusercontent.com/clawsweeper/ab6526cc6da3373f11db211a019ee3c1/raw/892b597c29bf527a2484c5b98afffc7f1781b13f/after.svg)

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/codex-sessions.e2e.test.ts -t 'separates native catalogs from live Coding rows'`
- `git diff --check origin/main...HEAD`
- Autoreview: clean, no accepted/actionable findings (0.96 confidence)

AI-assisted: yes. I reviewed the CSS ownership, rendering hierarchy, test fixture, and generated visual evidence.
