### PR TITLE
fix(tui): prevent reset from destroying active conversations

### DIFF
--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -1069,6 +1069,45 @@ describe("tui command handlers", () => {
     expect(addSystem).toHaveBeenCalledWith("abort the current run before /new");
   });
 
+  it.each([
+    {
+      activeChatRunId: "active-run",
+      pendingSubmit: null,
+      activityStatus: "running",
+    },
+    {
+      activeChatRunId: null,
+      pendingSubmit: {
+        phase: "accepted" as const,
+        runId: "pending-run",
+        draftText: null,
+      },
+      activityStatus: "sending",
+    },
+    {
+      activeChatRunId: null,
+      pendingSubmit: {
+        phase: "sending" as const,
+        runId: "pending-run",
+        draftText: "pending",
+      },
+      activityStatus: "sending",
+    },
+    {
+      activeChatRunId: null,
+      pendingSubmit: null,
+      activityStatus: "finishing context",
+    },
+  ])("blocks /reset while the current session lifecycle is unfinished", async (runState) => {
+    const resetSession = vi.fn();
+    const { handleCommand, addSystem } = createHarness({ resetSession, ...runState });
+
+    await handleCommand("/reset");
+
+    expect(resetSession).not.toHaveBeenCalled();
+    expect(addSystem).toHaveBeenCalledWith("abort the current run before /reset");
+  });
+
   it("serializes input until /new adopts the created session", async () => {
     let resolveCreate: ((value: { ok: true; key: string }) => void) | undefined;
     const createSession = vi.fn().mockImplementation(

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -179,6 +179,17 @@ export function createCommandHandlers(context: CommandHandlerContext) {
   const hasUnsafeSessionRollover = () =>
     hasTrackedAbortTarget() || state.activityStatus === "finishing context";
 
+  const rejectUnsafeSessionRollover = (command: "new" | "reset") => {
+    if (!hasUnsafeSessionRollover()) {
+      return false;
+    }
+    // Reset interrupts admitted Gateway work, so both rollover commands must
+    // reject active, queued, and finishing runs before mutating the session.
+    chatLog.addSystem(`abort the current run before /${command}`);
+    tui.requestRender();
+    return true;
+  };
+
   const currentSessionPatchTarget = () => ({
     key: state.currentSessionKey,
     ...(state.currentSessionKey === "global" ? { agentId: state.currentAgentId } : {}),
@@ -736,9 +747,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
         break;
       }
       case "new":
-        if (hasUnsafeSessionRollover()) {
-          chatLog.addSystem("abort the current run before /new");
-          tui.requestRender();
+        if (rejectUnsafeSessionRollover("new")) {
           break;
         }
         sessionCreationInFlight = true;
@@ -769,6 +778,9 @@ export function createCommandHandlers(context: CommandHandlerContext) {
         }
         break;
       case "reset":
+        if (rejectUnsafeSessionRollover("reset")) {
+          break;
+        }
         try {
           // Clear token counts immediately to avoid stale display (#1523)
           state.sessionInfo.inputTokens = null;

--- a/src/tui/tui-pty-harness.e2e.test.ts
+++ b/src/tui/tui-pty-harness.e2e.test.ts
@@ -232,7 +232,11 @@ async function writeTuiPtyFixtureScript(dir: string) {
             return { runId };
           }
           const responseDelayMs =
-            opts.message === "slow prompt" || opts.message === "streaming prompt" ? 500 : 20;
+            opts.message === "slow prompt" ||
+            opts.message === "slow reset proof" ||
+            opts.message === "streaming prompt"
+              ? 500
+              : 20;
           if (opts.message === "streaming prompt") {
             setTimeout(() => {
               this.onEvent?.({
@@ -830,6 +834,30 @@ describe.sequential("TUI PTY harness", () => {
       expect(slowPromptCalls).toHaveLength(1);
       expect(slowPromptCalls[0]?.payload).toMatchObject({ message: "slow prompt" });
       await fixture.run.write("\x15", { delay: false });
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "keeps an active session intact when /reset is submitted from the terminal",
+    async () => {
+      const priorResetCount = (await readFixtureLog(fixture.logPath)).filter(
+        (entry) => entry.method === "resetSession",
+      ).length;
+
+      await fixture.run.write("slow reset proof\r");
+      await fixture.waitForLogEntry(
+        (entry) =>
+          entry.method === "sendChat" && objectFieldEquals(entry, "message", "slow reset proof"),
+      );
+      await fixture.run.write("/reset\r", { delay: false });
+      await fixture.run.waitForOutput("abort the current run before /reset");
+
+      const resetCalls = (await readFixtureLog(fixture.logPath)).filter(
+        (entry) => entry.method === "resetSession",
+      );
+      expect(resetCalls).toHaveLength(priorResetCount);
+      await fixture.run.waitForOutput("PTY_RESPONSE: slow reset proof");
     },
     TEST_TIMEOUT_MS,
   );

--- a/src/tui/tui-pty-local.e2e.test.ts
+++ b/src/tui/tui-pty-local.e2e.test.ts
@@ -67,6 +67,14 @@ const GATEWAY_SCENARIOS = {
     holdFirstResponse: true,
     followupReplyText: "FOLLOWUP_RUN_COMPLETE",
   },
+  reset: {
+    agentId: "tui-pty-reset",
+    modelId: "tui-pty-reset",
+    toolsProfile: "minimal",
+    replyText: "FIRST_RUN_ACTIVE",
+    holdFirstResponse: true,
+    followupReplyText: "FOLLOWUP_RUN_COMPLETE",
+  },
   emptyReply: {
     agentId: "tui-pty-empty-reply",
     modelId: "tui-pty-empty-reply",
@@ -1118,6 +1126,50 @@ describe("TUI PTY real backends", () => {
         const freshRequest = JSON.stringify(fixture.mockModel.requests()[1]?.body);
         expect(freshRequest).toContain("send after gateway new");
         expect(freshRequest).not.toContain("seed gateway session");
+
+        await fixture.run.write("/exit\r", { delay: false });
+        expect((await fixture.run.waitForExit()).exitCode).toBe(0);
+      } finally {
+        await fixture.cleanup();
+      }
+    },
+    LOCAL_TEST_TIMEOUT_MS,
+  );
+
+  registerGatewayTest(
+    "preserves a running session when /reset is typed against the real Gateway",
+    async ({ onTestFinished }) => {
+      const fixture = await startGatewayModeTui("reset", onTestFinished);
+      try {
+        await fixture.run.waitForOutput("gateway connected", LOCAL_STARTUP_TIMEOUT_MS);
+        await fixture.run.write("keep the active Gateway turn\r");
+        await waitFor({
+          timeoutMs: LOCAL_OUTPUT_TIMEOUT_MS,
+          read: () => (fixture.mockModel.requests().length === 1 ? true : null),
+          onTimeout: () =>
+            new Error(`active Gateway turn did not reach the model\n${fixture.run.output()}`),
+        });
+
+        await fixture.run.write("/reset\r", { delay: false });
+        await fixture.run.waitForOutput("abort the current run before /reset", 5_000);
+        expect(fixture.mockModel.requests()).toHaveLength(1);
+
+        fixture.mockModel.releaseFirstResponse();
+        await fixture.run.waitForOutput("FIRST_RUN_ACTIVE");
+
+        await fixture.run.write("continue the preserved Gateway session\r");
+        await waitFor({
+          timeoutMs: LOCAL_OUTPUT_TIMEOUT_MS,
+          read: () => (fixture.mockModel.requests().length === 2 ? true : null),
+          onTimeout: () =>
+            new Error(
+              `preserved Gateway session did not accept its next turn\n${fixture.gateway.logs()}\n${fixture.run.output()}`,
+            ),
+        });
+        const preservedRequest = JSON.stringify(fixture.mockModel.requests()[1]?.body);
+        expect(preservedRequest).toContain("keep the active Gateway turn");
+        expect(preservedRequest).toContain("continue the preserved Gateway session");
+        await fixture.run.waitForOutput("FOLLOWUP_RUN_COMPLETE");
 
         await fixture.run.write("/exit\r", { delay: false });
         expect((await fixture.run.waitForExit()).exitCode).toBe(0);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users who typed `/reset` while an agent run was active, queued, still being admitted, or finishing would silently abort that run and replace its conversation. This could destroy the response and transcript of an in-progress real Gateway session even though the sibling `/new` command already protected the same lifecycle.

## Why This Change Was Made

Route `/new` and `/reset` through the same canonical session-rollover guard before either command mutates session state. Protect tracked runs, both pending-admission states, and final context processing; preserve normal idle and selected-global reset behavior. Add regression proof at the command owner, the actual typed terminal, and a real Gateway with a held model request and a follow-up that confirms transcript continuity. No compatibility shim, storage, configuration, protocol, timeout, or dependency changes.

## User Impact

An accidental `/reset` can no longer cancel an in-progress response or erase the active conversation. The terminal clearly asks the user to abort the run first. Idle session reset remains unchanged.

## Evidence

- Independently reproduced the unmodified failure against clean main: four failing command-owner lifecycle cases, a real typed terminal resetting an active session, and an actual Gateway rendering `run aborted` while rotating the active session.
- Verified the complete fix on exact latest main `54df949aaa08d4e4c7a4c5f7c8b316ab691893c7`: **721/721** TUI-owner tests; **141/141** Matrix, Signal, case-sensitive session, and routing controls; **39/39** real terminal, actual local backend, and restarted-Gateway scenarios, including a held active model response, typed reset rejection, successful original completion, and a second request containing the preserved transcript.
- Complete official `pnpm check:changed --base origin/main`: clean, including core and test `tsgo`, full lint, formatting, plugin SDK, SQLite, import-cycle, and architecture guards.
- [Fresh Blacksmith Testbox proof](https://github.com/openclaw/openclaw/actions/runs/30172595800), lease `tbx_01kyddkmbpj5mdwv70dya880rj`: final structured result `exitCode=0`. The wrapper stopped its one-shot lease automatically after success.
- Fresh official high-effort independent autoreview: no actionable findings; independent secret scan clean; both commit identities verified.
- AI-assisted; no overlap with the separately merged terminal event-order fix.
