### PR TITLE
fix(ui): new-session composer grows before scrolling

### DIFF
--- a/ui/src/e2e/new-session-page.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.e2e.test.ts
@@ -109,6 +109,71 @@ describeControlUiE2e("Control UI new-session page mocked Gateway E2E", () => {
     await server?.close();
   });
 
+  it("grows the first prompt through ten lines before using a narrow scrollbar", async () => {
+    const context = await browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page);
+    try {
+      await page.goto(`${server.baseUrl}new`);
+      const message = page.locator(".new-session-page__message");
+      await message.waitFor();
+
+      const initial = await message.evaluate((element) => ({
+        height: element.clientHeight,
+        overflowY: getComputedStyle(element).overflowY,
+      }));
+      await message.fill(Array.from({ length: 10 }, (_, index) => `line ${index + 1}`).join("\n"));
+      const tenLines = await message.evaluate((element) => {
+        const style = getComputedStyle(element);
+        return {
+          height: element.clientHeight,
+          lineHeight: Number.parseFloat(style.lineHeight),
+          overflowY: style.overflowY,
+          padding: Number.parseFloat(style.paddingTop) + Number.parseFloat(style.paddingBottom),
+          scrollbarWidth: style.scrollbarWidth,
+          webkitScrollbarWidth: getComputedStyle(element, "::-webkit-scrollbar").width,
+        };
+      });
+
+      expect(tenLines.height).toBeGreaterThan(initial.height);
+      expect(tenLines.height).toBeGreaterThanOrEqual(
+        Math.floor(tenLines.lineHeight * 10 + tenLines.padding) - 1,
+      );
+      expect(tenLines.overflowY).toBe("hidden");
+      expect(tenLines.scrollbarWidth).toBe("thin");
+      expect(Number.parseFloat(tenLines.webkitScrollbarWidth)).toBeLessThanOrEqual(6);
+      await captureUiProof(page, "new-session-composer-ten-lines.png");
+
+      const longPrompt = Array.from({ length: 14 }, (_, index) => `line ${index + 1}`).join("\n");
+      await message.fill(longPrompt);
+      const capped = await message.evaluate((element) => ({
+        clientHeight: element.clientHeight,
+        overflowY: getComputedStyle(element).overflowY,
+        scrollHeight: element.scrollHeight,
+      }));
+      expect(capped.clientHeight).toBeLessThan(capped.scrollHeight);
+      expect(capped.overflowY).toBe("auto");
+      await captureUiProof(page, "new-session-composer-capped-scrollbar.png");
+      const start = page.getByRole("button", { name: "Start thread" });
+      await expect(start.isVisible()).resolves.toBe(true);
+      await expect(start.isEnabled()).resolves.toBe(true);
+      await start.focus();
+      await expect(start.evaluate((element) => document.activeElement === element)).resolves.toBe(
+        true,
+      );
+      await start.press("Enter");
+      await expect(gateway.waitForRequest("sessions.create")).resolves.toMatchObject({
+        params: { message: longPrompt },
+      });
+    } finally {
+      await context.close();
+    }
+  });
+
   it("pastes an image into the draft and forwards it with the initial turn", async () => {
     const context = await browser.newContext({
       locale: "en-US",

--- a/ui/src/pages/chat/components/chat-composer-dom.ts
+++ b/ui/src/pages/chat/components/chat-composer-dom.ts
@@ -32,7 +32,11 @@ export function adjustTextareaHeight(el: HTMLTextAreaElement) {
   // final CSS-constrained height actually clips the draft.
   el.style.overflowY = "hidden";
   el.style.height = "auto";
-  el.style.height = `${Math.min(el.scrollHeight, 150)}px`;
+  // The owning surface declares its cap in CSS. Retain the historical fallback
+  // for detached/test controls whose computed max-height is not a pixel value.
+  const computedMaxHeight = Number.parseFloat(getComputedStyle(el).maxHeight);
+  const maxHeight = Number.isFinite(computedMaxHeight) ? computedMaxHeight : 150;
+  el.style.height = `${Math.min(el.scrollHeight, maxHeight)}px`;
   updateTextareaOverflow(el);
 }
 

--- a/ui/src/pages/chat/components/chat-composer-dom.ts
+++ b/ui/src/pages/chat/components/chat-composer-dom.ts
@@ -34,8 +34,9 @@ export function adjustTextareaHeight(el: HTMLTextAreaElement) {
   el.style.height = "auto";
   // The owning surface declares its cap in CSS. Retain the historical fallback
   // for detached/test controls whose computed max-height is not a pixel value.
-  const computedMaxHeight = Number.parseFloat(getComputedStyle(el).maxHeight);
-  const maxHeight = Number.isFinite(computedMaxHeight) ? computedMaxHeight : 150;
+  const computedMaxHeight = getComputedStyle(el).maxHeight.trim();
+  const pixelMaxHeight = /^(\d+(?:\.\d+)?)px$/u.exec(computedMaxHeight);
+  const maxHeight = pixelMaxHeight ? Number(pixelMaxHeight[1]) : 150;
   el.style.height = `${Math.min(el.scrollHeight, maxHeight)}px`;
   updateTextareaOverflow(el);
 }

--- a/ui/src/pages/new-session/composer.test.ts
+++ b/ui/src/pages/new-session/composer.test.ts
@@ -3,6 +3,7 @@
 import { render } from "lit";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { waitForFast } from "../../test-helpers/wait-for.ts";
+import { adjustTextareaHeight } from "../chat/components/chat-composer-dom.ts";
 import { NewSessionAttachmentDraft } from "./attachment-draft.ts";
 import { NewSessionComposerTextareaController, renderNewSessionDraftComposer } from "./composer.ts";
 import type { NewSessionVisibility } from "./create-params.ts";
@@ -81,6 +82,18 @@ afterEach(() => {
 });
 
 describe("new-session composer sizing lifecycle", () => {
+  it("keeps the shared fallback for non-pixel CSS caps", () => {
+    const textarea = document.createElement("textarea");
+    Object.defineProperty(textarea, "scrollHeight", { configurable: true, value: 500 });
+    vi.spyOn(window, "getComputedStyle").mockReturnValue({
+      maxHeight: "50vh",
+    } as CSSStyleDeclaration);
+
+    adjustTextareaHeight(textarea);
+
+    expect(textarea.style.height).toBe("150px");
+  });
+
   it("keeps one observer across controlled updates and remeasures programmatic drafts", async () => {
     const observe = vi.fn();
     const disconnect = vi.fn();

--- a/ui/src/pages/new-session/composer.test.ts
+++ b/ui/src/pages/new-session/composer.test.ts
@@ -4,11 +4,12 @@ import { render } from "lit";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { waitForFast } from "../../test-helpers/wait-for.ts";
 import { NewSessionAttachmentDraft } from "./attachment-draft.ts";
-import { renderNewSessionDraftComposer } from "./composer.ts";
+import { NewSessionComposerTextareaController, renderNewSessionDraftComposer } from "./composer.ts";
 import type { NewSessionVisibility } from "./create-params.ts";
 import { NewSessionModelControl } from "./model-control.ts";
 
 const attachmentDrafts: NewSessionAttachmentDraft[] = [];
+const textareaControllers: NewSessionComposerTextareaController[] = [];
 
 function renderComposer(
   overrides: {
@@ -17,11 +18,19 @@ function renderComposer(
     visibility?: NewSessionVisibility;
     draftAvailable?: boolean;
     onVisibilityChange?: (visibility: NewSessionVisibility) => void;
+    message?: string;
+    onInput?: (message: string) => void;
+    textareaController?: NewSessionComposerTextareaController;
   } = {},
 ) {
   const container = document.createElement("div");
   const attachmentDraft = new NewSessionAttachmentDraft(() => undefined);
   attachmentDrafts.push(attachmentDraft);
+  const textareaController =
+    overrides.textareaController ?? new NewSessionComposerTextareaController();
+  if (!textareaControllers.includes(textareaController)) {
+    textareaControllers.push(textareaController);
+  }
   render(
     renderNewSessionDraftComposer({
       agentId: "main",
@@ -29,14 +38,15 @@ function renderComposer(
       canSubmit: true,
       context: undefined,
       isCatalogTarget: true,
-      message: "",
+      message: overrides.message ?? "",
       visibility: overrides.visibility,
       draftAvailable: overrides.draftAvailable,
       modelControl: new NewSessionModelControl(() => undefined),
       requiresModifier: false,
       submitting: overrides.submitting ?? false,
+      textareaController,
       messageLocked: overrides.messageLocked,
-      onInput: () => undefined,
+      onInput: overrides.onInput ?? (() => undefined),
       onVisibilityChange: overrides.onVisibilityChange,
       onSubmit: () => undefined,
     }),
@@ -46,7 +56,7 @@ function renderComposer(
   if (!composer) {
     throw new Error("Expected new-session composer");
   }
-  return { attachmentDraft, composer };
+  return { attachmentDraft, composer, container, textareaController };
 }
 
 function createDragEvent(type: string, files: File[] = [], types = ["Files"]): Event {
@@ -62,7 +72,101 @@ afterEach(() => {
     attachmentDraft.reset({ release: true });
   }
   attachmentDrafts.length = 0;
+  for (const textareaController of textareaControllers) {
+    textareaController.disconnect();
+  }
+  textareaControllers.length = 0;
+  vi.unstubAllGlobals();
   vi.restoreAllMocks();
+});
+
+describe("new-session composer sizing lifecycle", () => {
+  it("keeps one observer across controlled updates and remeasures programmatic drafts", async () => {
+    const observe = vi.fn();
+    const disconnect = vi.fn();
+    const resizeObserverConstructed = vi.fn();
+    class TestResizeObserver {
+      constructor() {
+        resizeObserverConstructed();
+      }
+      observe = observe;
+      disconnect = disconnect;
+    }
+    vi.stubGlobal("ResizeObserver", TestResizeObserver);
+    const textareaController = new NewSessionComposerTextareaController();
+    const onInput = vi.fn();
+    const first = renderComposer({ textareaController, onInput });
+    document.body.append(first.container);
+    const textarea = first.composer.querySelector<HTMLTextAreaElement>("textarea");
+    if (!textarea) {
+      throw new Error("Expected composer textarea");
+    }
+    let scrollHeightReads = 0;
+    Object.defineProperty(textarea, "scrollHeight", {
+      configurable: true,
+      get: () => {
+        scrollHeightReads += 1;
+        return 42;
+      },
+    });
+    await Promise.resolve();
+    const readsAfterAttach = scrollHeightReads;
+
+    textarea.value = "typed";
+    textarea.dispatchEvent(new InputEvent("input", { bubbles: true }));
+    expect(onInput).toHaveBeenCalledWith("typed");
+    const readsAfterInput = scrollHeightReads;
+    render(
+      renderNewSessionDraftComposer({
+        agentId: "main",
+        attachmentDraft: first.attachmentDraft,
+        canSubmit: true,
+        context: undefined,
+        isCatalogTarget: true,
+        message: "typed",
+        modelControl: new NewSessionModelControl(() => undefined),
+        requiresModifier: false,
+        submitting: false,
+        textareaController,
+        onInput,
+        onSubmit: () => undefined,
+      }),
+      first.container,
+    );
+    await Promise.resolve();
+
+    expect(first.container.querySelector("textarea")).toBe(textarea);
+    expect(resizeObserverConstructed).toHaveBeenCalledOnce();
+    expect(disconnect).not.toHaveBeenCalled();
+    expect(scrollHeightReads).toBe(readsAfterInput);
+
+    render(
+      renderNewSessionDraftComposer({
+        agentId: "main",
+        attachmentDraft: first.attachmentDraft,
+        canSubmit: true,
+        context: undefined,
+        isCatalogTarget: true,
+        message: "restored programmatically",
+        modelControl: new NewSessionModelControl(() => undefined),
+        requiresModifier: false,
+        submitting: false,
+        textareaController,
+        onInput,
+        onSubmit: () => undefined,
+      }),
+      first.container,
+    );
+    await Promise.resolve();
+
+    expect(scrollHeightReads).toBeGreaterThan(readsAfterInput);
+    expect(readsAfterAttach).toBeGreaterThan(0);
+    expect(resizeObserverConstructed).toHaveBeenCalledOnce();
+    expect(disconnect).not.toHaveBeenCalled();
+    textareaController.disconnect();
+    expect(disconnect).toHaveBeenCalledOnce();
+    first.container.remove();
+  });
 });
 
 describe("new-session composer attachment drops", () => {

--- a/ui/src/pages/new-session/composer.ts
+++ b/ui/src/pages/new-session/composer.ts
@@ -1,4 +1,5 @@
 import { html, nothing, type TemplateResult } from "lit";
+import { ref } from "lit/directives/ref.js";
 import { icons } from "../../components/icons.ts";
 import "../../components/tooltip.ts";
 import { t } from "../../i18n/index.ts";
@@ -12,6 +13,12 @@ import {
   renderChatAttachmentInputs,
   renderChatAttachmentMenu,
 } from "../chat/components/chat-attachments.ts";
+import {
+  adjustTextareaHeight,
+  disconnectTextareaOverflowObserver,
+  observeTextareaOverflow,
+  scheduleTextareaHeightAdjustment,
+} from "../chat/components/chat-composer-dom.ts";
 import type { NewSessionAttachmentDraft } from "./attachment-draft.ts";
 import type { NewSessionVisibility } from "./create-params.ts";
 import type { NewSessionModelControl } from "./model-control.ts";
@@ -26,6 +33,7 @@ type NewSessionComposerOptions = {
   readSignal: AbortSignal;
   requiresModifier: boolean;
   submitting: boolean;
+  textareaController: NewSessionComposerTextareaController;
   messageLocked?: boolean;
   visibility?: NewSessionVisibility;
   draftAvailable?: boolean;
@@ -35,6 +43,37 @@ type NewSessionComposerOptions = {
   onVisibilityChange?: (visibility: NewSessionVisibility) => void;
   onSubmit: () => void;
 };
+
+export class NewSessionComposerTextareaController {
+  private textarea: HTMLTextAreaElement | null = null;
+
+  readonly ref = (element?: Element) => {
+    const nextTextarea = element instanceof HTMLTextAreaElement ? element : null;
+    if (this.textarea && this.textarea !== nextTextarea) {
+      disconnectTextareaOverflowObserver(this.textarea);
+    }
+    this.textarea = nextTextarea;
+    if (nextTextarea) {
+      observeTextareaOverflow(nextTextarea);
+      scheduleTextareaHeightAdjustment(nextTextarea);
+    }
+  };
+
+  syncDraft(message: string) {
+    // The stable ref measures attachment only. Programmatic restores and
+    // resets still need a post-render measurement after Lit commits .value.
+    if (this.textarea?.isConnected && this.textarea.value !== message) {
+      scheduleTextareaHeightAdjustment(this.textarea);
+    }
+  }
+
+  disconnect() {
+    if (this.textarea) {
+      disconnectTextareaOverflowObserver(this.textarea);
+      this.textarea = null;
+    }
+  }
+}
 
 /** Mutually exclusive visibility pills: selecting one clears the other, re-click returns to normal. */
 function renderVisibilityPill(params: {
@@ -100,6 +139,7 @@ function renderNewSessionComposer(options: NewSessionComposerOptions) {
     readSignal: options.readSignal,
   };
   const enabled = !options.submitting && !options.messageLocked;
+  options.textareaController.syncDraft(options.message);
   // Nested dragenter/dragleave events must stay balanced so crossing composer
   // children does not flicker the file drop affordance.
   let attachmentDragDepth = 0;
@@ -168,13 +208,17 @@ function renderNewSessionComposer(options: NewSessionComposerOptions) {
           ${renderChatAttachmentMenu(attachmentProps)}
           <div class="agent-chat__composer-combobox">
             <textarea
+              ${ref(options.textareaController.ref)}
               class="new-session-page__message"
               rows="1"
               ?disabled=${options.submitting || options.messageLocked}
               placeholder=${t("newSession.messagePlaceholder")}
               .value=${options.message}
-              @input=${(event: Event) =>
-                options.onInput((event.target as HTMLTextAreaElement).value)}
+              @input=${(event: Event) => {
+                const target = event.target as HTMLTextAreaElement;
+                adjustTextareaHeight(target);
+                options.onInput(target.value);
+              }}
               @keydown=${(event: KeyboardEvent) => handleComposerKeydown(event, options)}
               @paste=${(event: ClipboardEvent) => {
                 if (!options.submitting && !options.messageLocked) {
@@ -241,6 +285,7 @@ export function renderNewSessionDraftComposer(options: {
   visibility?: NewSessionVisibility;
   draftAvailable?: boolean;
   modelControl: NewSessionModelControl;
+  textareaController: NewSessionComposerTextareaController;
   requiresModifier: boolean;
   submitting: boolean;
   messageLocked?: boolean;
@@ -268,6 +313,7 @@ export function renderNewSessionDraftComposer(options: {
     readSignal,
     requiresModifier: options.requiresModifier,
     submitting: options.submitting,
+    textareaController: options.textareaController,
     messageLocked: options.messageLocked,
     onAttachmentsChange: (attachments) => {
       if (!options.submitting && !options.messageLocked) {

--- a/ui/src/pages/new-session/new-session-page.ts
+++ b/ui/src/pages/new-session/new-session-page.ts
@@ -28,7 +28,11 @@ import * as catalog from "./catalog-target.ts";
 import { CloudProfileDiscovery, selectProfiles } from "./cloud-profile-discovery.ts";
 import { PendingCloudRecoveryState, resolveScope } from "./cloud-recovery-state.ts";
 import { advanceCloudDraftSession } from "./cloud-submit.ts";
-import { renderDraftError, renderNewSessionDraftComposer } from "./composer.ts";
+import {
+  NewSessionComposerTextareaController,
+  renderDraftError,
+  renderNewSessionDraftComposer,
+} from "./composer.ts";
 import {
   buildDraftSessionCreateParams,
   canStartSessionAsDraft,
@@ -127,6 +131,7 @@ class NewSessionPage extends OpenClawLightDomElement {
   private baseRefEditGeneration = 0;
   private browserRequestToken = 0;
   private readonly attachmentDraft = new NewSessionAttachmentDraft(() => this.requestUpdate());
+  private readonly composerTextarea = new NewSessionComposerTextareaController();
   private readonly modelControl = new NewSessionModelControl(() => this.requestUpdate());
   private gatewaySource: ApplicationContext["gateway"] | null = null;
   private gatewayClient: ApplicationContext["gateway"]["snapshot"]["client"] = null;
@@ -346,6 +351,7 @@ class NewSessionPage extends OpenClawLightDomElement {
     globalThis.clearTimeout(this.catalogRetryTimer);
     this.catalogRetryTimer = undefined;
     this.attachmentDraft.reset({ release: true });
+    this.composerTextarea.disconnect();
     this.cloudProfileDiscovery.stop();
     super.disconnectedCallback();
   }
@@ -1403,6 +1409,7 @@ class NewSessionPage extends OpenClawLightDomElement {
           modelControl: this.modelControl,
           requiresModifier: loadSettings().chatSendShortcut === "modifier-enter",
           submitting: this.submitting,
+          textareaController: this.composerTextarea,
           messageLocked: Boolean(this.pendingCloud.sessionKey),
           onInput: (message) => {
             if (!this.submitting && !this.pendingCloud.sessionKey) {

--- a/ui/src/styles/new-session.css
+++ b/ui/src/styles/new-session.css
@@ -338,6 +338,19 @@ wa-popover.new-session-page__place-popover::part(body) {
   border-radius: var(--radius-md);
 }
 
+/* Keep a long first prompt visible before scrolling. The shared auto-height
+   controller measures content; this surface owns its ten-line visual cap. */
+.new-session-page__composer .new-session-page__message {
+  max-height: calc(10lh + var(--chat-box-inset) + var(--chat-box-inset));
+  --scrollbar-size: 6px;
+  scrollbar-width: thin;
+  scrollbar-color: color-mix(in srgb, var(--muted) 42%, transparent) transparent;
+}
+
+.new-session-page__composer .new-session-page__message::-webkit-scrollbar-thumb {
+  background: color-mix(in srgb, var(--muted) 42%, transparent);
+}
+
 .new-session-page__composer::after {
   content: "";
   position: absolute;


### PR DESCRIPTION
Closes #113826

## What Problem This Solves

Fixes an issue where longer new-session prompts exposed only about two lines behind a large scrollbar thumb, forcing awkward early scrolling.

## Why This Change Was Made

The new-session textarea now auto-grows through the shared composer sizing helper up to a CSS-owned ten-line cap, then uses a narrow scrollbar. A stable observer remeasures programmatic drafts and width changes without being recreated on every keystroke.

## User Impact

Users can see up to ten prompt lines while composing. Longer prompts scroll only after reaching that cap, and the scrollbar is visually unobtrusive.

## Evidence

| Before: only the final two lines visible | After: ten lines visible before scrolling |
| --- | --- |
| ![Before: two-line composer with oversized scrollbar thumb](https://tmpfiles.org/dl/1785016666.280c0c7028bc56b9/w0wQz3TZg5TN/new-session-composer-before.png) | ![After: composer grows to ten lines](https://tmpfiles.org/dl/1785016683.553603ba5b9bc8ec/w8wYzXTOgW3d/new-session-composer-ten-lines.png) |

After the cap, the same ten-line viewport uses a narrow scrollbar:

![After: capped composer with narrow scrollbar](https://tmpfiles.org/dl/1785016691.378dc8d0a8c26c91/wYwwzfTGgY1f/new-session-composer-capped-scrollbar.png)

- `node scripts/run-vitest.mjs ui/src/pages/new-session/composer.test.ts` — 9 passed.
- Focused mocked-browser ten-line and capped-overflow scenario passed.
- Branch-wide Autoreview: clean, no accepted/actionable findings.

Raw mock screenshots: [before](https://tmpfiles.org/w0wQz3TZg5TN/new-session-composer-before.png), [ten lines](https://tmpfiles.org/w8wYzXTOgW3d/new-session-composer-ten-lines.png), [capped overflow](https://tmpfiles.org/wYwwzfTGgY1f/new-session-composer-capped-scrollbar.png).
