### PR TITLE
fix(qa): stop suite execution after the first failed scenario

### DIFF
--- a/extensions/qa-lab/src/cli.runtime.ts
+++ b/extensions/qa-lab/src/cli.runtime.ts
@@ -1080,6 +1080,7 @@ export async function runQaSuiteCommand(opts: QaSuiteCommandOptions) {
       fastMode: opts.fastMode,
       ...(thinkingDefault ? { thinkingDefault } : {}),
       allowFailures: true,
+      ...(opts.failFast ? { failFast: true } : {}),
       scenarioIds,
       ...(opts.concurrency !== undefined
         ? { concurrency: parseQaPositiveIntegerOption("--concurrency", opts.concurrency) }

--- a/extensions/qa-lab/src/cli.test.ts
+++ b/extensions/qa-lab/src/cli.test.ts
@@ -255,6 +255,23 @@ describe("qa cli registration", () => {
     expect(runQaLabSelfCheckCommand).not.toHaveBeenCalled();
   });
 
+  it("forwards fail-fast to taxonomy-backed QA profile runs", async () => {
+    await program.parseAsync([
+      "node",
+      "openclaw",
+      "qa",
+      "run",
+      "--qa-profile",
+      "smoke-ci",
+      "--fail-fast",
+    ]);
+
+    expect(runQaProfileCommand).toHaveBeenCalledWith(
+      expect.objectContaining({ failFast: true, profile: "smoke-ci" }),
+    );
+    expect(runQaLabSelfCheckCommand).not.toHaveBeenCalled();
+  });
+
   it.each([
     ["--output-dir", [".artifacts/qa-e2e/smoke-ci"]],
     ["--surface", ["agents"]],
@@ -268,6 +285,7 @@ describe("qa cli registration", () => {
     ["--alt-model", ["anthropic/claude-sonnet-4-6"]],
     ["--concurrency", ["2"]],
     ["--allow-failures", []],
+    ["--fail-fast", []],
     ["--fast", []],
   ])("rejects qa run profile-only flag %s without --qa-profile", async (flag, values) => {
     await expect(
@@ -892,6 +910,20 @@ describe("qa cli registration", () => {
     const options = requireQaSuiteOptions();
     expect(options.allowFailures).toBe(true);
     expect(options.providerMode).toBeUndefined();
+  });
+
+  it.each(["host", "multipass"])("forwards --fail-fast to the %s suite runner", async (runner) => {
+    await program.parseAsync([
+      "node",
+      "openclaw",
+      "qa",
+      "suite",
+      "--runner",
+      runner,
+      "--fail-fast",
+    ]);
+
+    expect(requireQaSuiteOptions()).toEqual(expect.objectContaining({ failFast: true, runner }));
   });
 
   it("forwards --pack for suite runs", async () => {

--- a/extensions/qa-lab/src/cli.ts
+++ b/extensions/qa-lab/src/cli.ts
@@ -31,6 +31,7 @@ type QaScenarioRunCliOptions = {
   altModel?: QaSuiteCommandOptions["alternateModel"];
   concurrency?: QaSuiteCommandOptions["concurrency"];
   allowFailures?: QaSuiteCommandOptions["allowFailures"];
+  failFast?: QaSuiteCommandOptions["failFast"];
   fast?: QaSuiteCommandOptions["fastMode"];
 };
 
@@ -57,6 +58,7 @@ const QA_RUN_PROFILE_ONLY_OPTIONS = [
   { optionName: "altModel", flag: "--alt-model" },
   { optionName: "concurrency", flag: "--concurrency" },
   { optionName: "allowFailures", flag: "--allow-failures" },
+  { optionName: "failFast", flag: "--fail-fast" },
   { optionName: "fast", flag: "--fast" },
 ] as const;
 
@@ -433,6 +435,7 @@ export function registerQaLabCli(program: Command) {
       "Write artifacts without setting a failing exit code when scenarios fail",
       false,
     )
+    .option("--fail-fast", "Stop after the first failed QA scenario")
     .option("--fast", "Enable provider fast mode where supported", false);
   qaRun.action(async (opts: QaRunCliOptions, command: Command) => {
     validateQaRunMode(opts, command);
@@ -451,6 +454,7 @@ export function registerQaLabCli(program: Command) {
         alternateModel: opts.altModel,
         concurrency: opts.concurrency,
         allowFailures: opts.allowFailures,
+        ...(opts.failFast ? { failFast: true } : {}),
         fastMode: opts.fast,
       });
       return;
@@ -497,6 +501,7 @@ export function registerQaLabCli(program: Command) {
       "Write artifacts without setting a failing exit code when scenarios fail",
       false,
     )
+    .option("--fail-fast", "Stop after the first failed QA scenario")
     .option("--fast", "Enable provider fast mode where supported", false)
     .option(
       "--thinking <level>",
@@ -535,6 +540,7 @@ export function registerQaLabCli(program: Command) {
         enabledPluginIds: opts.enablePlugin,
         concurrency: opts.concurrency,
         allowFailures: opts.allowFailures,
+        ...(opts.failFast ? { failFast: true } : {}),
         image: opts.image,
         cpus: opts.cpus,
         memory: opts.memory,

--- a/extensions/qa-lab/src/multipass.runtime.test.ts
+++ b/extensions/qa-lab/src/multipass.runtime.test.ts
@@ -154,6 +154,16 @@ describe("qa multipass runtime", () => {
     expect(script).toContain("/workspace/openclaw-host/.artifacts/qa-e2e/multipass-default-test");
   });
 
+  it("forwards fail-fast to the real guest QA suite command", async () => {
+    const script = await renderPersistedGuestScript({
+      outputDirName: "multipass-fail-fast-test",
+      failFast: true,
+      scenarioIds: ["channel-chat-baseline"],
+    });
+
+    expect(script).toContain("'--fail-fast'");
+  });
+
   it("redacts persisted credentials while forwarding them to the executable script", async () => {
     vi.stubEnv("OPENAI_API_KEY", TEST_ENV_VALUE);
     const { executableScript, persistedScript } = await captureGuestScriptsAtTransfer({

--- a/extensions/qa-lab/src/multipass.runtime.ts
+++ b/extensions/qa-lab/src/multipass.runtime.ts
@@ -242,6 +242,7 @@ function createQaMultipassPlan(params: {
   fastMode?: boolean;
   thinkingDefault?: string;
   allowFailures?: boolean;
+  failFast?: boolean;
   scenarioIds?: string[];
   concurrency?: number;
   runtimePair?: [RuntimeId, RuntimeId];
@@ -288,6 +289,7 @@ function createQaMultipassPlan(params: {
       ...(params.fastMode ? ["--fast"] : []),
       ...(params.thinkingDefault ? ["--thinking", params.thinkingDefault] : []),
       ...(params.allowFailures ? ["--allow-failures"] : []),
+      ...(params.failFast ? ["--fail-fast"] : []),
       ...(params.concurrency ? ["--concurrency", String(params.concurrency)] : []),
       ...(params.runtimePair ? ["--runtime-pair", params.runtimePair.join(",")] : []),
       ...(params.channelDriverSelection
@@ -572,6 +574,7 @@ export async function runQaMultipass(params: {
   alternateModel?: string;
   fastMode?: boolean;
   allowFailures?: boolean;
+  failFast?: boolean;
   scenarioIds?: string[];
   concurrency?: number;
   runtimePair?: [RuntimeId, RuntimeId];

--- a/extensions/qa-lab/src/suite-launch.runtime.test.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.test.ts
@@ -2,6 +2,11 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { QaSuiteScenarioResult } from "./suite.js";
+import type {
+  QaTestFileScenario,
+  QaTestFileScenarioRunResult,
+} from "./test-file-scenario-runner.js";
 
 const { crablineRuntimeLoads, runQaFlowSuite, runQaTestFileScenarios } = vi.hoisted(() => ({
   crablineRuntimeLoads: vi.fn(),
@@ -863,6 +868,417 @@ describe("qa suite runtime launcher", () => {
     expect(runQaTestFileScenarios).toHaveBeenCalledTimes(1);
   });
 
+  it("stops unified suite partitions after the first failed flow scenario", async () => {
+    const repoRoot = await makeTempRepo("qa-suite-fail-fast-flow-");
+    const defaultFlowImplementation = runQaFlowSuite.getMockImplementation();
+    if (!defaultFlowImplementation) {
+      throw new Error("expected default QA flow suite mock implementation");
+    }
+    runQaFlowSuite.mockImplementationOnce(async (params) => {
+      const result = await defaultFlowImplementation(params);
+      return {
+        ...result,
+        scenarios: result.scenarios.map((scenario: QaSuiteScenarioResult) =>
+          Object.assign({}, scenario, {
+            status: "fail" as const,
+            details: "first scenario failed",
+          }),
+        ),
+      };
+    });
+
+    const result = await runQaSuite({
+      repoRoot,
+      outputDir: ".artifacts/qa-e2e/fail-fast-flow",
+      concurrency: 8,
+      failFast: true,
+      scenarioIds: [
+        "dm-chat-baseline",
+        "group-visible-reply-tool",
+        "control-ui-chat-flow-playwright",
+        "docker-npm-onboard-channel-agent",
+      ],
+    });
+
+    expect(result.executionKind).toBe("suite");
+    if (result.executionKind !== "suite") {
+      throw new Error("expected unified suite result");
+    }
+    expect(runQaFlowSuite).toHaveBeenCalledTimes(1);
+    expect(runQaFlowSuite).toHaveBeenCalledWith(
+      expect.objectContaining({
+        concurrency: 1,
+        failFast: true,
+        scenarioIds: ["dm-chat-baseline"],
+      }),
+    );
+    expect(runQaTestFileScenarios).not.toHaveBeenCalled();
+    expect(result.result.scenarios).toMatchObject([
+      { name: "dm-chat-baseline", status: "fail", details: "first scenario failed" },
+    ]);
+    const summary = JSON.parse(await fs.readFile(result.result.summaryPath, "utf8")) as {
+      run?: { concurrency?: number; scenarioIds?: string[] };
+      scenarios?: Array<{ name?: string; status?: string }>;
+    };
+    expect(summary.run?.concurrency).toBe(1);
+    expect(summary.run?.scenarioIds).toEqual([
+      "dm-chat-baseline",
+      "group-visible-reply-tool",
+      "control-ui-chat-flow-playwright",
+      "docker-npm-onboard-channel-agent",
+    ]);
+    expect(summary.scenarios).toMatchObject([{ name: "dm-chat-baseline", status: "fail" }]);
+  });
+
+  it("stops pending flow and script partitions after a native scenario fails", async () => {
+    const repoRoot = await makeTempRepo("qa-suite-fail-fast-native-");
+    const defaultTestFileImplementation = runQaTestFileScenarios.getMockImplementation();
+    if (!defaultTestFileImplementation) {
+      throw new Error("expected default QA test-file scenario mock implementation");
+    }
+    runQaTestFileScenarios.mockImplementationOnce(async (params) => {
+      const result = await defaultTestFileImplementation(params);
+      return {
+        ...result,
+        results: result.results.map((scenario: QaTestFileScenarioRunResult["results"][number]) =>
+          Object.assign({}, scenario, {
+            status: "fail" as const,
+            failureMessage: "native scenario failed",
+          }),
+        ),
+      };
+    });
+
+    const result = await runQaSuite({
+      repoRoot,
+      outputDir: ".artifacts/qa-e2e/fail-fast-native",
+      concurrency: 8,
+      failFast: true,
+      scenarioIds: [
+        "dm-chat-baseline",
+        "group-visible-reply-tool",
+        "control-ui-chat-flow-playwright",
+        "docker-npm-onboard-channel-agent",
+      ],
+    });
+
+    expect(result.executionKind).toBe("suite");
+    if (result.executionKind !== "suite") {
+      throw new Error("expected unified suite result");
+    }
+    expect(runQaFlowSuite).toHaveBeenCalledTimes(1);
+    expect(runQaTestFileScenarios).toHaveBeenCalledTimes(1);
+    expect(runQaTestFileScenarios).toHaveBeenCalledWith(
+      expect.objectContaining({
+        failFast: true,
+        scenarios: [expect.objectContaining({ id: "control-ui-chat-flow-playwright" })],
+      }),
+    );
+    expect(result.result.scenarios).toMatchObject([
+      { name: "dm-chat-baseline", status: "pass" },
+      { name: "Control UI chat flow Playwright coverage", status: "fail" },
+    ]);
+  });
+
+  it("fails and stops when a started flow partition omits its scenario result", async () => {
+    const repoRoot = await makeTempRepo("qa-suite-fail-fast-missing-flow-");
+    const defaultFlowImplementation = runQaFlowSuite.getMockImplementation();
+    if (!defaultFlowImplementation) {
+      throw new Error("expected default QA flow suite mock implementation");
+    }
+    runQaFlowSuite.mockImplementationOnce(async (params) => ({
+      ...(await defaultFlowImplementation(params)),
+      scenarios: [],
+    }));
+
+    const result = await runQaSuite({
+      repoRoot,
+      outputDir: ".artifacts/qa-e2e/fail-fast-missing-flow",
+      concurrency: 8,
+      failFast: true,
+      scenarioIds: [
+        "dm-chat-baseline",
+        "group-visible-reply-tool",
+        "control-ui-chat-flow-playwright",
+        "docker-npm-onboard-channel-agent",
+      ],
+    });
+
+    expect(result.executionKind).toBe("suite");
+    if (result.executionKind !== "suite") {
+      throw new Error("expected unified suite result");
+    }
+    expect(runQaFlowSuite).toHaveBeenCalledTimes(1);
+    expect(runQaTestFileScenarios).not.toHaveBeenCalled();
+    expect(result.result.scenarios).toMatchObject([
+      {
+        name: "DM baseline conversation",
+        status: "fail",
+        details: "suite partition returned no scenario result",
+      },
+    ]);
+    const summary = JSON.parse(await fs.readFile(result.result.summaryPath, "utf8")) as {
+      scenarios?: Array<{ details?: string; name?: string; status?: string }>;
+    };
+    expect(summary.scenarios).toMatchObject([
+      {
+        name: "DM baseline conversation",
+        status: "fail",
+        details: "suite partition returned no scenario result",
+      },
+    ]);
+    const evidence = JSON.parse(await fs.readFile(result.result.evidencePath, "utf8")) as {
+      entries?: Array<{
+        result?: { failure?: { reason?: string }; status?: string };
+        test?: { id?: string };
+      }>;
+    };
+    expect(evidence.entries).toMatchObject([
+      {
+        test: { id: "dm-chat-baseline" },
+        result: {
+          status: "fail",
+          failure: { reason: "suite partition returned no scenario result" },
+        },
+      },
+    ]);
+  });
+
+  it("fails and stops when a started native partition omits its scenario result", async () => {
+    const repoRoot = await makeTempRepo("qa-suite-fail-fast-missing-native-");
+    const defaultTestFileImplementation = runQaTestFileScenarios.getMockImplementation();
+    if (!defaultTestFileImplementation) {
+      throw new Error("expected default QA test-file scenario mock implementation");
+    }
+    runQaTestFileScenarios.mockImplementationOnce(async (params) => ({
+      ...(await defaultTestFileImplementation(params)),
+      results: [],
+    }));
+
+    const result = await runQaSuite({
+      repoRoot,
+      outputDir: ".artifacts/qa-e2e/fail-fast-missing-native",
+      concurrency: 8,
+      failFast: true,
+      scenarioIds: [
+        "dm-chat-baseline",
+        "group-visible-reply-tool",
+        "control-ui-chat-flow-playwright",
+        "docker-npm-onboard-channel-agent",
+      ],
+    });
+
+    expect(result.executionKind).toBe("suite");
+    if (result.executionKind !== "suite") {
+      throw new Error("expected unified suite result");
+    }
+    expect(runQaFlowSuite).toHaveBeenCalledTimes(1);
+    expect(runQaTestFileScenarios).toHaveBeenCalledTimes(1);
+    expect(result.result.scenarios).toMatchObject([
+      { name: "dm-chat-baseline", status: "pass" },
+      {
+        name: "Control UI chat flow Playwright coverage",
+        status: "fail",
+        details: "suite partition returned no scenario result",
+      },
+    ]);
+    const evidence = JSON.parse(await fs.readFile(result.result.evidencePath, "utf8")) as {
+      entries?: Array<{
+        result?: { failure?: { reason?: string }; status?: string };
+        test?: { id?: string };
+      }>;
+    };
+    expect(evidence.entries).toMatchObject([
+      {
+        test: { id: "control-ui-chat-flow-playwright" },
+        result: {
+          status: "fail",
+          failure: { reason: "suite partition returned no scenario result" },
+        },
+      },
+    ]);
+  });
+
+  it("stops later native execution kinds after a started kind omits its result", async () => {
+    const repoRoot = await makeTempRepo("qa-suite-fail-fast-missing-native-kind-");
+    const defaultTestFileImplementation = runQaTestFileScenarios.getMockImplementation();
+    if (!defaultTestFileImplementation) {
+      throw new Error("expected default QA test-file scenario mock implementation");
+    }
+    runQaTestFileScenarios.mockImplementationOnce(async (params) => ({
+      ...(await defaultTestFileImplementation(params)),
+      results: [],
+    }));
+
+    const scenarioIds = [
+      "dm-chat-baseline",
+      "control-ui-assistant-media-tickets",
+      "control-ui-chat-flow-playwright",
+      "docker-npm-onboard-channel-agent",
+    ];
+    const result = await runQaSuite({
+      repoRoot,
+      outputDir: ".artifacts/qa-e2e/fail-fast-missing-native-kind",
+      concurrency: 8,
+      failFast: true,
+      scenarioIds,
+    });
+
+    expect(result.executionKind).toBe("suite");
+    if (result.executionKind !== "suite") {
+      throw new Error("expected unified suite result");
+    }
+    expect(runQaFlowSuite).toHaveBeenCalledTimes(1);
+    expect(runQaTestFileScenarios).toHaveBeenCalledTimes(1);
+    expect(runQaTestFileScenarios).toHaveBeenCalledWith(
+      expect.objectContaining({
+        failFast: true,
+        scenarios: [expect.objectContaining({ id: "control-ui-assistant-media-tickets" })],
+      }),
+    );
+    expect(result.result.scenarios).toMatchObject([
+      { name: "dm-chat-baseline", status: "pass" },
+      {
+        name: "Control UI assistant media ticket evidence",
+        status: "fail",
+        details: "suite partition returned no scenario result",
+      },
+    ]);
+    const summary = JSON.parse(await fs.readFile(result.result.summaryPath, "utf8")) as {
+      run?: { scenarioIds?: string[] };
+      scenarios?: Array<{ details?: string; name?: string; status?: string }>;
+    };
+    expect(summary.run?.scenarioIds).toEqual(scenarioIds);
+    expect(summary.scenarios).toMatchObject([
+      { name: "dm-chat-baseline", status: "pass" },
+      {
+        name: "Control UI assistant media ticket evidence",
+        status: "fail",
+        details: "suite partition returned no scenario result",
+      },
+    ]);
+  });
+
+  it("omits a native fail-fast tail after the first missing scenario result", async () => {
+    const repoRoot = await makeTempRepo("qa-suite-fail-fast-missing-native-tail-");
+    const defaultTestFileImplementation = runQaTestFileScenarios.getMockImplementation();
+    if (!defaultTestFileImplementation) {
+      throw new Error("expected default QA test-file scenario mock implementation");
+    }
+    runQaTestFileScenarios.mockImplementationOnce(async (params) => {
+      const result = await defaultTestFileImplementation(params);
+      return {
+        ...result,
+        evidence: {
+          ...result.evidence,
+          entries: params.scenarios.map((scenario: QaTestFileScenario) => ({
+            test: {
+              kind: "qa-scenario",
+              id: scenario.id,
+              title: scenario.title,
+            },
+            coverage: [],
+            result: { status: "pass" as const },
+          })),
+        },
+        results: [result.results[0], result.results[2]].filter(
+          (scenario): scenario is (typeof result.results)[number] => Boolean(scenario),
+        ),
+      };
+    });
+
+    const result = await runQaSuite({
+      repoRoot,
+      outputDir: ".artifacts/qa-e2e/fail-fast-missing-native-tail",
+      concurrency: 8,
+      failFast: true,
+      scenarioIds: [
+        "dm-chat-baseline",
+        "control-ui-assistant-media-tickets",
+        "auth-profile-doctor-migration-safety",
+        "auth-profile-codex-mixed-profiles",
+        "control-ui-chat-flow-playwright",
+      ],
+    });
+
+    expect(result.executionKind).toBe("suite");
+    if (result.executionKind !== "suite") {
+      throw new Error("expected unified suite result");
+    }
+    expect(runQaFlowSuite).toHaveBeenCalledTimes(1);
+    expect(runQaTestFileScenarios).toHaveBeenCalledTimes(1);
+    expect(result.result.scenarios).toMatchObject([
+      { name: "dm-chat-baseline", status: "pass" },
+      { name: "Control UI assistant media ticket evidence", status: "pass" },
+      {
+        name: "Codex doctor migration safety matrix",
+        status: "fail",
+        details: "suite partition returned no scenario result",
+      },
+    ]);
+    expect(result.result.scenarios).toHaveLength(3);
+    const evidence = JSON.parse(await fs.readFile(result.result.evidencePath, "utf8")) as {
+      entries?: Array<{
+        result?: { failure?: { reason?: string }; status?: string };
+        test?: { id?: string };
+      }>;
+    };
+    expect(evidence.entries).toMatchObject([
+      { test: { id: "control-ui-assistant-media-tickets" }, result: { status: "pass" } },
+      {
+        test: { id: "auth-profile-doctor-migration-safety" },
+        result: {
+          status: "fail",
+          failure: { reason: "suite partition returned no scenario result" },
+        },
+      },
+    ]);
+  });
+
+  it("continues every unified partition after a failure when fail-fast is disabled", async () => {
+    const repoRoot = await makeTempRepo("qa-suite-continue-after-failure-");
+    const defaultFlowImplementation = runQaFlowSuite.getMockImplementation();
+    if (!defaultFlowImplementation) {
+      throw new Error("expected default QA flow suite mock implementation");
+    }
+    runQaFlowSuite.mockImplementationOnce(async (params) => {
+      const result = await defaultFlowImplementation(params);
+      return {
+        ...result,
+        scenarios: result.scenarios.map((scenario: QaSuiteScenarioResult) =>
+          Object.assign({}, scenario, {
+            status: "fail" as const,
+          }),
+        ),
+      };
+    });
+
+    const result = await runQaSuite({
+      repoRoot,
+      outputDir: ".artifacts/qa-e2e/continue-after-failure",
+      concurrency: 1,
+      scenarioIds: [
+        "dm-chat-baseline",
+        "group-visible-reply-tool",
+        "control-ui-chat-flow-playwright",
+        "docker-npm-onboard-channel-agent",
+      ],
+    });
+
+    expect(result.executionKind).toBe("suite");
+    if (result.executionKind !== "suite") {
+      throw new Error("expected unified suite result");
+    }
+    expect(runQaFlowSuite).toHaveBeenCalledTimes(2);
+    expect(runQaTestFileScenarios).toHaveBeenCalledTimes(2);
+    expect(result.result.scenarios.map((scenario) => scenario.status)).toEqual([
+      "fail",
+      "pass",
+      "pass",
+      "pass",
+    ]);
+  });
+
   it("runs script scenarios after flow Gateways stop without serializing Playwright", async () => {
     const repoRoot = await makeTempRepo("qa-suite-script-isolation-");
     let releaseFlow!: () => void;
@@ -1225,6 +1641,47 @@ describe("qa suite runtime launcher", () => {
         result: { status: "blocked" },
       });
     }
+  });
+
+  it("omits later credential failures after the first failed flow scenario", async () => {
+    const repoRoot = await makeTempRepo("qa-suite-fail-fast-credential-unavailable-");
+    const poolError = Object.assign(new Error("no WhatsApp credential is available"), {
+      code: "POOL_EXHAUSTED",
+    });
+    runQaFlowSuite.mockRejectedValueOnce(
+      new Error("failed to create QA transport live:whatsapp: credential acquire failed", {
+        cause: new Error("credential acquire timed out", { cause: poolError }),
+      }),
+    );
+
+    const result = await runQaSuite({
+      repoRoot,
+      outputDir: ".artifacts/qa-e2e/fail-fast-credential-unavailable",
+      providerMode: "mock-openai",
+      channelDriver: "live",
+      adapterFactories: [{ id: "whatsapp", matches: () => true, create: vi.fn() }],
+      failFast: true,
+      scenarioIds: [
+        "whatsapp-status-command",
+        "whatsapp-access-control-dm-open",
+        "control-ui-chat-flow-playwright",
+      ],
+    });
+
+    expect(result.executionKind).toBe("suite");
+    if (result.executionKind !== "suite") {
+      throw new Error("expected unified suite result");
+    }
+    expect(runQaFlowSuite).toHaveBeenCalledTimes(1);
+    expect(runQaTestFileScenarios).not.toHaveBeenCalled();
+    expect(result.result.scenarios).toHaveLength(1);
+    expect(result.result.scenarios).toMatchObject([
+      { status: "fail", details: expect.stringContaining("channel credential unavailable") },
+    ]);
+    const evidence = JSON.parse(await fs.readFile(result.result.evidencePath, "utf8")) as {
+      entries?: Array<{ test?: { id?: string } }>;
+    };
+    expect(evidence.entries?.map((entry) => entry.test?.id)).toEqual(["whatsapp-status-command"]);
   });
 
   it("shares ordinary flow scenarios and isolates flow scenarios with config patches", async () => {

--- a/extensions/qa-lab/src/suite-launch.runtime.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.ts
@@ -24,6 +24,7 @@ import {
   type QaSeedScenarioWithSource,
 } from "./scenario-catalog.js";
 import {
+  mapQaSuiteWithConcurrency,
   normalizeQaSuiteConcurrency,
   normalizeQaSuiteScenarioChannel,
   resolveQaSuiteScenarioChannels,
@@ -87,6 +88,8 @@ type QaUnifiedPartitionResult = {
     result: QaSuiteScenarioResult;
     scenarioId: string;
   }>;
+  startedScenarioIds: readonly string[];
+  submittedScenarioIds: readonly string[];
 };
 
 type QaUnifiedPartitionTask = {
@@ -282,6 +285,7 @@ async function runQaTestFileSuiteFromRuntime(params: {
   const primaryModel = runParams?.primaryModel?.trim() || defaultQaModelForMode(providerMode);
   return await runQaTestFileScenarios({
     evidenceMode: runParams?.evidenceMode,
+    ...(runParams?.failFast ? { failFast: true } : {}),
     repoRoot,
     outputDir,
     providerMode,
@@ -616,11 +620,14 @@ async function runUnifiedQaSuite(params: {
     params.runParams?.channelDriver === "crabline" || params.runParams?.channelDriverSelection
       ? 1
       : defaultQaSuiteConcurrencyForTransport(transportId);
-  const concurrency = normalizeQaSuiteConcurrency(
-    params.runParams?.concurrency,
-    params.plan.scenarios.length,
-    defaultConcurrency,
-  );
+  const failFast = params.runParams?.failFast === true;
+  const concurrency = failFast
+    ? 1
+    : normalizeQaSuiteConcurrency(
+        params.runParams?.concurrency,
+        params.plan.scenarios.length,
+        defaultConcurrency,
+      );
   const evidenceSummaries: QaEvidenceSummaryJson[] = [];
   const scenarioResultsById = new Map<string, QaSuiteScenarioResult>();
   const sharedFlowPartitionTasks: QaUnifiedPartitionTask[] = [];
@@ -747,6 +754,8 @@ async function runUnifiedQaSuite(params: {
                 steps: [{ name: "Acquire channel credential", status: "fail", details }],
               },
             })),
+            startedScenarioIds: partition.scenarios.map((scenario) => scenario.id),
+            submittedScenarioIds: partition.scenarios.map((scenario) => scenario.id),
           };
         };
         const task = {
@@ -820,6 +829,8 @@ async function runUnifiedQaSuite(params: {
                 }),
               ],
               scenarioResults,
+              startedScenarioIds: partition.scenarios.map((scenario) => scenario.id),
+              submittedScenarioIds: partition.scenarios.map((scenario) => scenario.id),
             };
           },
         } satisfies QaUnifiedPartitionTask;
@@ -839,6 +850,7 @@ async function runUnifiedQaSuite(params: {
       run: async () => {
         const testFileEvidenceSummaries: QaEvidenceSummaryJson[] = [];
         const testFileScenarioResults: QaUnifiedPartitionResult["scenarioResults"] = [];
+        const testFileStartedScenarioIds: string[] = [];
         for (const [kind, testFileScenarios] of scenariosByKind) {
           const result = await runQaTestFileSuiteFromRuntime({
             runParams: {
@@ -863,10 +875,31 @@ async function runUnifiedQaSuite(params: {
               result: testFileScenarioResultToSuiteScenario(scenarioResult, repoRoot),
             })),
           );
+          const resultsByScenarioId = new Map(
+            result.results.map((scenarioResult) => [scenarioResult.scenario.id, scenarioResult]),
+          );
+          let shouldStopNativeKinds = false;
+          for (const scenario of testFileScenarios) {
+            testFileStartedScenarioIds.push(scenario.id);
+            const scenarioResult = resultsByScenarioId.get(scenario.id);
+            // The first missing or non-pass native result owns the stop; later
+            // scenarios and execution kinds have not started and must stay absent.
+            if (failFast && (!scenarioResult || scenarioResult.status !== "pass")) {
+              shouldStopNativeKinds = true;
+              break;
+            }
+          }
+          if (shouldStopNativeKinds) {
+            break;
+          }
         }
         return {
           evidenceSummaries: testFileEvidenceSummaries,
           scenarioResults: testFileScenarioResults,
+          startedScenarioIds: testFileStartedScenarioIds,
+          submittedScenarioIds: [...scenariosByKind.values()].flatMap((scenarios) =>
+            scenarios.map((scenario) => scenario.id),
+          ),
         };
       },
     }) satisfies QaUnifiedPartitionTask;
@@ -885,13 +918,102 @@ async function runUnifiedQaSuite(params: {
     ...testFilePartitionTasks,
     ...isolatedFlowPartitionTasks,
   ];
-  const concurrentPartitionResults = await runWeightedUnifiedPartitionTasks(
-    concurrentPartitionTasks,
-    concurrency,
+  const scenarioDefinitionsById = new Map(
+    params.plan.scenarios.map((scenario) => [scenario.id, scenario]),
   );
+  const startedScenarioIds = new Set<string>();
+  const runFailFastPartition = async (task: QaUnifiedPartitionTask) => {
+    const partition = await task.run();
+    const resultsByScenarioId = new Map(
+      partition.scenarioResults.map((scenario) => [scenario.scenarioId, scenario]),
+    );
+    const expectedScenarioIds: string[] = [];
+    for (const scenarioId of partition.startedScenarioIds) {
+      expectedScenarioIds.push(scenarioId);
+      const scenarioResult = resultsByScenarioId.get(scenarioId);
+      // A missing started result is itself the failure boundary; including the
+      // remaining submitted partition would invent work that never started.
+      if (!scenarioResult || scenarioResult.result.status !== "pass") {
+        break;
+      }
+    }
+    for (const scenarioId of expectedScenarioIds) {
+      startedScenarioIds.add(scenarioId);
+    }
+    const expectedScenarioIdSet = new Set(expectedScenarioIds);
+    const partitionScenarioIdSet = new Set(partition.submittedScenarioIds);
+    const missingScenarioDefinitions = expectedScenarioIds.flatMap((scenarioId) => {
+      if (resultsByScenarioId.has(scenarioId)) {
+        return [];
+      }
+      const scenario = scenarioDefinitionsById.get(scenarioId);
+      return scenario ? [scenario] : [];
+    });
+    const missingScenarioEvidence =
+      missingScenarioDefinitions.length > 0
+        ? [
+            buildQaSuiteEvidenceSummary({
+              artifactPaths: [],
+              evidenceMode: params.runParams?.evidenceMode,
+              channelDriver: params.runParams?.channelDriver,
+              channelId: transportId,
+              env: process.env,
+              generatedAt: new Date().toISOString(),
+              primaryModel,
+              providerMode,
+              repoRoot,
+              scenarioDefinitions: missingScenarioDefinitions,
+              scenarioResults: missingScenarioDefinitions.map((scenario) => ({
+                name: scenario.title,
+                status: "fail" as const,
+                details: "suite partition returned no scenario result",
+              })),
+            }),
+          ]
+        : [];
+    return {
+      ...partition,
+      evidenceSummaries: [
+        ...partition.evidenceSummaries.map((summary) => ({
+          ...summary,
+          // Preserve producer-owned evidence IDs, but remove scenario evidence
+          // belonging to the submitted partition's unstarted fail-fast tail.
+          entries: summary.entries.filter(
+            (entry) =>
+              !partitionScenarioIdSet.has(entry.test.id) ||
+              (expectedScenarioIdSet.has(entry.test.id) && resultsByScenarioId.has(entry.test.id)),
+          ),
+        })),
+        ...missingScenarioEvidence,
+      ],
+      scenarioResults: partition.scenarioResults.filter((scenario) =>
+        expectedScenarioIdSet.has(scenario.scenarioId),
+      ),
+      startedScenarioIds: expectedScenarioIds,
+    } satisfies QaUnifiedPartitionResult;
+  };
+  const partitionFailed = (partition: QaUnifiedPartitionResult) => {
+    if (partition.scenarioResults.some((scenario) => scenario.result.status === "fail")) {
+      return true;
+    }
+    const returnedScenarioIds = new Set(
+      partition.scenarioResults.map((scenario) => scenario.scenarioId),
+    );
+    return partition.startedScenarioIds.some((scenarioId) => !returnedScenarioIds.has(scenarioId));
+  };
+  const runPartitionTasks = async (tasks: readonly QaUnifiedPartitionTask[], maxWeight: number) =>
+    failFast
+      ? await mapQaSuiteWithConcurrency(tasks, 1, runFailFastPartition, {
+          shouldStop: partitionFailed,
+        })
+      : await runWeightedUnifiedPartitionTasks(tasks, maxWeight);
+  const concurrentPartitionResults = await runPartitionTasks(concurrentPartitionTasks, concurrency);
   // Script scenarios may rebuild the checkout's shared dist tree. Wait until every
   // flow Gateway has stopped so package postbuild cannot invalidate its loaded chunks.
-  const scriptPartitionResults = await runWeightedUnifiedPartitionTasks(scriptPartitionTasks, 1);
+  const scriptPartitionResults =
+    failFast && concurrentPartitionResults.some(partitionFailed)
+      ? []
+      : await runPartitionTasks(scriptPartitionTasks, 1);
   const partitionResults = [...concurrentPartitionResults, ...scriptPartitionResults];
   for (const partitionResult of partitionResults) {
     for (const scenarioResult of partitionResult.scenarioResults) {
@@ -904,23 +1026,28 @@ async function runUnifiedQaSuite(params: {
     evidenceSummaries,
     generatedAt: finishedAt.toISOString(),
   });
-  const scenarios = params.plan.scenarios.map((scenario) => {
+  const scenarios = params.plan.scenarios.flatMap((scenario) => {
     const result = scenarioResultsById.get(scenario.id);
     if (result) {
-      return result;
+      return [result];
     }
-    return {
-      name: scenario.title,
-      status: "fail",
-      details: "suite partition returned no scenario result",
-      steps: [
-        {
-          name: "suite partition",
-          status: "fail",
-          details: "suite partition returned no scenario result",
-        },
-      ],
-    } satisfies QaSuiteScenarioResult;
+    if (failFast && !startedScenarioIds.has(scenario.id)) {
+      return [];
+    }
+    return [
+      {
+        name: scenario.title,
+        status: "fail",
+        details: "suite partition returned no scenario result",
+        steps: [
+          {
+            name: "suite partition",
+            status: "fail",
+            details: "suite partition returned no scenario result",
+          },
+        ],
+      } satisfies QaSuiteScenarioResult,
+    ];
   });
   return await writeUnifiedQaSuiteArtifacts({
     alternateModel,

--- a/extensions/qa-lab/src/test-file-scenario-runner.test.ts
+++ b/extensions/qa-lab/src/test-file-scenario-runner.test.ts
@@ -337,6 +337,51 @@ describe("qa test file scenario runner", () => {
     });
   });
 
+  it.each([
+    { failFast: true, expectedScenarioIds: ["first-native-scenario"] },
+    {
+      failFast: false,
+      expectedScenarioIds: ["first-native-scenario", "later-native-scenario"],
+    },
+    {
+      failFast: undefined,
+      expectedScenarioIds: ["first-native-scenario", "later-native-scenario"],
+    },
+  ])(
+    "honors native scenario fail-fast mode ($failFast)",
+    async ({ failFast, expectedScenarioIds }) => {
+      const repoRoot = await makeTempRepo("qa-vitest-fail-fast-");
+      const runCommand = vi.fn(async () => ({
+        exitCode: 1,
+        stdout: "",
+        stderr: "native scenario failed\n",
+      }));
+      const firstScenario = {
+        ...makeTestFileScenario("vitest", "extensions/qa-lab/src/coverage-report.test.ts"),
+        id: "first-native-scenario",
+      };
+      const laterScenario = {
+        ...makeTestFileScenario("vitest", "extensions/qa-lab/src/cli.test.ts"),
+        id: "later-native-scenario",
+      };
+
+      const result = await runQaTestFileScenarios({
+        repoRoot,
+        outputDir: path.join(repoRoot, ".artifacts", "qa-e2e", "native-fail-fast"),
+        providerMode: "mock-openai",
+        primaryModel: "mock-openai/gpt-5.6-luna",
+        failFast,
+        scenarios: [firstScenario, laterScenario],
+        runCommand,
+      });
+
+      expect(runCommand).toHaveBeenCalledTimes(expectedScenarioIds.length);
+      expect(result.results.map((scenario) => scenario.scenario.id)).toEqual(expectedScenarioIds);
+      expect(result.results.every((scenario) => scenario.status === "fail")).toBe(true);
+      expect(result.evidence.entries.map((entry) => entry.test.id)).toEqual(expectedScenarioIds);
+    },
+  );
+
   it("runs script scenarios and imports producer QA evidence artifacts", async () => {
     const repoRoot = await makeTempRepo("qa-script-scenario-");
     const commands: QaScenarioCommandExecution[] = [];

--- a/extensions/qa-lab/src/test-file-scenario-runner.ts
+++ b/extensions/qa-lab/src/test-file-scenario-runner.ts
@@ -43,6 +43,7 @@ type QaTestFileScenarioRunParams = {
   commandTimeoutMs?: number;
   evidenceMode?: QaScorecardEvidenceMode;
   env?: NodeJS.ProcessEnv;
+  failFast?: boolean;
   outputDir: string;
   primaryModel: string;
   providerMode: QaProviderMode;
@@ -580,16 +581,18 @@ export async function runQaTestFileScenarios(
   };
   const results: QaTestFileScenarioResult[] = [];
   for (const scenario of scenarios) {
-    results.push(
-      await runQaTestFileScenario({
-        env,
-        commandTimeoutMs,
-        outputDir: params.outputDir,
-        repoRoot: params.repoRoot,
-        runCommand,
-        scenario,
-      }),
-    );
+    const result = await runQaTestFileScenario({
+      env,
+      commandTimeoutMs,
+      outputDir: params.outputDir,
+      repoRoot: params.repoRoot,
+      runCommand,
+      scenario,
+    });
+    results.push(result);
+    if (params.failFast && result.status !== "pass") {
+      break;
+    }
   }
   const generatedAt = new Date().toISOString();
   const artifactPaths = buildScenarioArtifactPaths({


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where QA operators running fail-fast suites could not use the flag through the normal host or profile CLI, and mixed flow, native, script, and Multipass runs continued launching work after the first failure. Missing started scenario results could also produce misleading successful or incomplete evidence.

## Why This Change Was Made

Routes fail-fast through the canonical host, profile, Multipass, native runner, and existing stop-aware unified scheduler. Separately tracks submitted, started, and actually returned scenarios so execution, reports, and evidence all stop at the same failure boundary. Synthesizes canonical failed evidence for missing started results, retains producer-owned evidence, and preserves ordinary weighted parallel scheduling when fail-fast is disabled.

## User Impact

QA users can stop unnecessary gateways, browser tests, scripts, and VM work immediately after the first genuine failure. The generated suite report, summary, and evidence accurately distinguish failed started scenarios from work that never ran.

## Evidence

- Regression-first proof reproduces the rejected host/profile flag, missing Multipass guest argument, mixed-partition and native-runner continuation, missing-result false successes, grouped-native execution, credential-failure tails, and evidence-artifact mismatches.
- All 11 QA, Matrix transport, Multipass, scheduler, catalog, CLI, and evidence sibling suites pass: 361 tests.
- Real source-checkout OpenClaw CLI starts a private QA lab, an actual mock provider, and a real isolated Gateway: passing direct-message scenario.
- Real source-checkout CLI starts a separate isolated Gateway against live OpenAI openai/gpt-5.4: passing direct-message scenario.
- Complete remote pnpm check:changed passes both production and test typechecking, formatting, plugin API and ownership guards, all database/runtime guards, import-cycle checks, and a 7,722-file lint scan with zero warnings or errors.
- Fresh independent structured review: patch is correct, confidence 0.91, zero actionable findings.
- Author and committer verified as Peter Steinberger <steipete@gmail.com>.