### PR TITLE
fix(ui): align pin-editor menu checkmarks into a leading check column

### DIFF
--- a/ui/src/components/app-sidebar-nav-menus.ts
+++ b/ui/src/components/app-sidebar-nav-menus.ts
@@ -252,7 +252,7 @@ export function renderSidebarCustomizeMenu(params: SidebarCustomizeMenuParams) {
   return html`
     <openclaw-menu-surface>
       <wa-dropdown
-        class="sidebar-customize-menu"
+        class="sidebar-customize-menu sidebar-pin-editor-menu"
         .open=${true}
         placement="bottom-start"
         .distance=${0}

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -2274,24 +2274,18 @@ wa-dropdown.sidebar-customize-menu::part(menu) {
   text-decoration: none;
 }
 
-.sidebar-customize-menu__check {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 14px;
-  height: 14px;
-  flex-shrink: 0;
-  color: var(--accent);
+/* Pin-editor rows: wa-dropdown flags every row [checkbox-adjacent] when the menu
+   holds checkbox items and tucks the shadow checkmark into a 2em start inset via
+   a -1.5em margin. Our compact `padding: 0 8px` above removes that inset, so
+   rebuild the check column here or the checkmark lands outside the row edge. */
+.sidebar-pin-editor-menu .sidebar-customize-menu__item[checkbox-adjacent] {
+  padding-inline-start: 30px; /* 8px edge + 14px check column + 8px flex gap */
 }
 
-.sidebar-customize-menu__check svg {
+.sidebar-pin-editor-menu .sidebar-customize-menu__item::part(checkmark) {
   width: 14px;
-  height: 14px;
-  stroke: currentColor;
-  fill: none;
-  stroke-width: 2px;
-  stroke-linecap: round;
-  stroke-linejoin: round;
+  min-width: 14px;
+  margin-inline: -22px 0; /* pull back into the padding; the 8px flex gap spaces the icon */
 }
 
 .sidebar-customize-menu__text {


### PR DESCRIPTION
## What Problem This Solves

In the sidebar's "Edit pinned items" menu, the checkmarks for pinned entries render crammed against (and partially clipped by) the menu's left border instead of sitting in a proper leading column.

Web Awesome's `wa-dropdown` marks every row `checkbox-adjacent` when a menu contains checkbox items and lays the shadow checkmark into a `2em` host start inset via a `-1.5em` negative margin. Our compact `.sidebar-customize-menu__item { padding: 0 8px }` document style overrides that `:host` inset, so the checkmark's negative margin pushed it outside the row edge.

## Why This Change Was Made

Rebuild the check column with the menu's own metrics instead of relying on Web Awesome's `em`-based inset that our padding override removes:

- The pin-editor dropdown gets a scoping class (`sidebar-pin-editor-menu`) so the geometry only applies there — the agent-switch menus also contain `type="checkbox"` rows (for radio semantics) but draw their check on the right via `slot="details"`, and must not pick up the extra start padding.
- `[checkbox-adjacent]` rows get `padding-inline-start: 30px` (8px edge + 14px check column + 8px flex gap), and `::part(checkmark)` is pulled back into that padding, so icons align across checked, unchecked, and non-checkbox rows (Reset pinned items, workboard boards).
- Deletes the dead `.sidebar-customize-menu__check` rules left over from the pre-Web-Awesome hand-rolled checkmark (no TS references).

## User Impact

The pin editor's checkmarks sit in a clean leading column inside the menu padding; row icons stay aligned in one vertical line.

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/pin-editor-check-column/pin-menu-before.png) | ![after](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/pin-editor-check-column/pin-menu-after.png) |

## Evidence

- Verified live in the Control UI mock harness (`pnpm dev:ui:mock`): opened the sidebar pin editor and captured the before/after shots above (checked + unchecked + reset rows all align; agent menu unaffected).
- `node scripts/check-changed.mjs -- ui/src/components/app-sidebar-nav-menus.ts ui/src/styles/layout.css` (delegated to Blacksmith Testbox).
- Codex autoreview (`--mode uncommitted`): clean.
