### PR TITLE
feat(memory): expose QMD rerank candidate limit

### DIFF
--- a/docs/reference/memory-config.md
+++ b/docs/reference/memory-config.md
@@ -576,6 +576,7 @@ QMD model overrides stay on the QMD side, not OpenClaw config. If you need to ov
     | Key                       | Type     | Default | Description                |
     | --------------------------- | -------- | ------- | ------------------------------ |
     | `limits.maxResults`       | `number` | `4`     | Max search results         |
+    | `limits.candidateLimit`   | `number` | --      | Max QMD query candidates sent to the reranker; passed as `-C` / `--candidate-limit` in direct CLI mode and `candidateLimit` in QMD's MCP query tool |
     | `limits.maxSnippetChars`  | `number` | `450`   | Clamp snippet length       |
     | `limits.maxInjectedChars` | `number` | `2200`  | Clamp total injected chars |
     | `limits.timeoutMs`        | `number` | `4000`  | QMD command timeout during QMD-backed search, including `memory_search`; setup, sync, builtin fallback, and supplemental work keep the default tool deadline |
@@ -623,7 +624,7 @@ QMD initializes lazily when memory is first used; its adapter owns refresh and e
     qmd: {
       includeDefaultMemory: true,
       update: { interval: "5m", debounceMs: 15000 },
-      limits: { maxResults: 4, timeoutMs: 4000 },
+      limits: { maxResults: 4, candidateLimit: 12, timeoutMs: 4000 },
       scope: {
         default: "deny",
         rules: [{ action: "allow", match: { chatType: "direct" } }],

--- a/extensions/memory-core/src/memory/qmd-command-client.ts
+++ b/extensions/memory-core/src/memory/qmd-command-client.ts
@@ -187,6 +187,9 @@ export class QmdCommandClient {
       ? {
           searches: this.buildV2Searches(params.query, params.searchCommand),
           limit: params.limit,
+          ...(typeof this.qmd.limits.candidateLimit === "number"
+            ? { candidateLimit: this.qmd.limits.candidateLimit }
+            : {}),
           ...(params.searchCommand === "search" || params.searchCommand === "vsearch"
             ? { rerank: false }
             : {}),

--- a/extensions/memory-core/src/memory/qmd-manager-search-support.ts
+++ b/extensions/memory-core/src/memory/qmd-manager-search-support.ts
@@ -463,6 +463,9 @@ export abstract class QmdManagerSearchSupport extends QmdManagerLifecycle {
     const normalizedQuery = command === "search" ? normalizeHanBm25Query(query) : query;
     if (command === "query") {
       const args = ["query", normalizedQuery, "--json", "-n", String(limit)];
+      if (this.qmd.searchMode === "query" && this.qmd.limits.candidateLimit !== undefined) {
+        args.push("-C", String(this.qmd.limits.candidateLimit));
+      }
       if (this.qmd.searchMode === "query" && this.qmd.rerank === false) {
         args.push("--no-rerank");
       }

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -3043,6 +3043,36 @@ describe("QmdMemoryManager", () => {
     await manager.close();
   });
 
+  it("passes the configured reranker candidate limit to direct qmd query", async () => {
+    configureQmd({ searchMode: "query", limits: { candidateLimit: 12 } });
+    spawnMock.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === "query") {
+        const child = createMockChild({ autoClose: false });
+        emitAndClose(child, "stdout", "[]");
+        return child;
+      }
+      return createMockChild();
+    });
+
+    const { manager, resolved } = await createManager();
+    const maxResults = resolved.qmd?.limits.maxResults;
+    if (!maxResults) {
+      throw new Error("qmd maxResults missing");
+    }
+
+    await expect(
+      manager.search("test", { sessionKey: "agent:main:slack:dm:u123" }),
+    ).resolves.toStrictEqual([]);
+
+    const queryCalls = spawnMock.mock.calls
+      .map((call: unknown[]) => call[1] as string[])
+      .filter((args: string[]) => args[0] === "query");
+    expect(queryCalls).toEqual([
+      ["query", "test", "--json", "-n", String(maxResults), "-C", "12", "-c", "workspace-main"],
+    ]);
+    await manager.close();
+  });
+
   const abortSearchScenarios = [
     {
       name: "aborts the in-flight qmd search subprocess when the caller signal aborts",
@@ -3430,6 +3460,40 @@ describe("QmdMemoryManager", () => {
           limit: expect.any(Number),
           collections: ["workspace-main"],
           rerank: false,
+        });
+        emitAndClose(child, "stdout", JSON.stringify({ results: [] }));
+        return child;
+      }
+      emitAndClose(child, "stdout", "[]");
+      return child;
+    });
+
+    const { manager } = await createManager();
+    await manager.search("hello", { sessionKey: "agent:main:slack:dm:u123" });
+    await manager.close();
+  });
+
+  it("passes the configured reranker candidate limit to the QMD query tool via mcporter", async () => {
+    configureQmd({
+      searchMode: "query",
+      limits: { candidateLimit: 12 },
+      mcporter: { enabled: true, serverName: "qmd", startDaemon: false },
+    });
+
+    spawnMock.mockImplementation((cmd: string, args: string[]) => {
+      const child = createMockChild({ autoClose: false });
+      if (isMcporterCommand(cmd) && args[0] === "call") {
+        expect(args[1]).toBe("qmd.query");
+        const callArgs = JSON.parse(requireArgAfter(args, "--args"));
+        expect(callArgs).toMatchObject({
+          searches: [
+            { type: "lex", query: "hello" },
+            { type: "vec", query: "hello" },
+            { type: "hyde", query: "hello" },
+          ],
+          limit: expect.any(Number),
+          candidateLimit: 12,
+          collections: ["workspace-main"],
         });
         emitAndClose(child, "stdout", JSON.stringify({ results: [] }));
         return child;

--- a/packages/memory-host-sdk/src/host/backend-config.test.ts
+++ b/packages/memory-host-sdk/src/host/backend-config.test.ts
@@ -548,6 +548,7 @@ describe("resolveMemoryBackendConfig", () => {
           },
           limits: {
             maxResults: 0.5,
+            candidateLimit: 0.5,
             maxSnippetChars: 0.5,
             maxInjectedChars: 0.5,
             timeoutMs: 0.5,
@@ -565,6 +566,7 @@ describe("resolveMemoryBackendConfig", () => {
     expect(qmd.update.embedTimeoutMs).toBe(120_000);
     expect(qmd.limits).toMatchObject({
       maxResults: 1,
+      candidateLimit: 1,
       maxSnippetChars: 1,
       maxInjectedChars: 1,
       timeoutMs: 1,
@@ -588,6 +590,7 @@ describe("resolveMemoryBackendConfig", () => {
           },
           limits: {
             maxResults: Number.NaN,
+            candidateLimit: Number.POSITIVE_INFINITY,
             maxSnippetChars: Number.POSITIVE_INFINITY,
             maxInjectedChars: Number.NEGATIVE_INFINITY,
             timeoutMs: Number.NaN,
@@ -605,6 +608,7 @@ describe("resolveMemoryBackendConfig", () => {
     expect(qmd.update.embedTimeoutMs).toBe(120_000);
     expect(qmd.limits).toMatchObject({
       maxResults: 4,
+      candidateLimit: undefined,
       maxSnippetChars: 450,
       maxInjectedChars: 2_200,
       timeoutMs: 4_000,
@@ -660,6 +664,22 @@ describe("resolveMemoryBackendConfig", () => {
     const qmd = requireQmdConfig(resolved);
     expect(qmd.searchMode).toBe("query");
     expect(qmd.rerank).toBe(false);
+  });
+
+  it("resolves qmd reranker candidate limit override", () => {
+    const cfg = {
+      agents: { defaults: { workspace: "/tmp/memory-test" } },
+      memory: {
+        backend: "qmd",
+        qmd: {
+          limits: {
+            candidateLimit: 12,
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const resolved = resolveMemoryBackendConfig({ cfg, agentId: "main" });
+    expect(requireQmdConfig(resolved).limits.candidateLimit).toBe(12);
   });
 
   it("resolves qmd mcporter search tool override", () => {

--- a/packages/memory-host-sdk/src/host/backend-config.ts
+++ b/packages/memory-host-sdk/src/host/backend-config.ts
@@ -85,6 +85,7 @@ export type ResolvedMemoryBackendConfig = {
 
 /** @public */ export type ResolvedQmdLimitsConfig = {
   maxResults: number;
+  candidateLimit?: number;
   maxSnippetChars: number;
   maxInjectedChars: number;
   timeoutMs: number;
@@ -274,6 +275,7 @@ function resolveStartupDelayMs(raw: number | undefined): number {
 function resolveLimits(raw?: MemoryQmdConfig["limits"]): ResolvedQmdLimitsConfig {
   return {
     maxResults: resolvePositiveIntegerConfig(raw?.maxResults, DEFAULT_QMD_LIMITS.maxResults),
+    candidateLimit: resolvePositiveIntegerConfig(raw?.candidateLimit),
     maxSnippetChars: resolvePositiveIntegerConfig(
       raw?.maxSnippetChars,
       DEFAULT_QMD_LIMITS.maxSnippetChars,

--- a/packages/memory-host-sdk/src/host/config-utils.ts
+++ b/packages/memory-host-sdk/src/host/config-utils.ts
@@ -65,6 +65,7 @@ type MemoryQmdSessionConfig = {
 /** Search and injection limits for QMD memory results. */
 type MemoryQmdLimitsConfig = {
   maxResults?: number;
+  candidateLimit?: number;
   maxSnippetChars?: number;
   maxInjectedChars?: number;
   timeoutMs?: number;

--- a/src/config/schema.help.models.ts
+++ b/src/config/schema.help.models.ts
@@ -293,6 +293,8 @@ export const MODEL_FIELD_HELP: Record<string, string> = {
     "Defines how long exported session files are kept before automatic pruning, in days (default: unlimited). Set a finite value for storage hygiene or compliance retention policies.",
   "memory.qmd.limits.maxResults":
     "Limits how many QMD hits are returned into the agent loop for each recall request (default: 6). Increase for broader recall context, or lower to keep prompts tighter and faster.",
+  "memory.qmd.limits.candidateLimit":
+    "Limits how many QMD query candidates are sent to the reranker. Lower this to keep query-mode reranking responsive on CPU-only or large indexes while still preserving reranking.",
   "memory.qmd.limits.maxSnippetChars":
     "Caps per-result snippet length extracted from QMD hits in characters (default: 700). Lower this when prompts bloat quickly, and raise only if answers consistently miss key details.",
   "memory.qmd.limits.maxInjectedChars":

--- a/src/config/schema.help.quality.test-fixtures.ts
+++ b/src/config/schema.help.quality.test-fixtures.ts
@@ -54,6 +54,7 @@ export const TARGET_KEYS = [
   "memory.qmd.sessions.exportDir",
   "memory.qmd.sessions.retentionDays",
   "memory.qmd.limits.maxResults",
+  "memory.qmd.limits.candidateLimit",
   "memory.qmd.limits.maxSnippetChars",
   "memory.qmd.limits.maxInjectedChars",
   "memory.qmd.limits.timeoutMs",

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -478,6 +478,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "memory.qmd.sessions.exportDir": "QMD Session Export Directory",
   "memory.qmd.sessions.retentionDays": "QMD Session Retention (days)",
   "memory.qmd.limits.maxResults": "QMD Max Results",
+  "memory.qmd.limits.candidateLimit": "QMD Rerank Candidate Limit",
   "memory.qmd.limits.maxSnippetChars": "QMD Max Snippet Chars",
   "memory.qmd.limits.maxInjectedChars": "QMD Max Injected Chars",
   "memory.qmd.limits.timeoutMs": "QMD Search Timeout (ms)",

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -180,6 +180,34 @@ describe("config schema", () => {
     expect(result.success).toBe(true);
   });
 
+  it("accepts qmd reranker candidate limit override", () => {
+    const result = OpenClawSchema.safeParse({
+      memory: {
+        backend: "qmd",
+        qmd: {
+          limits: {
+            candidateLimit: 8,
+          },
+        },
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects non-positive qmd reranker candidate limit override", () => {
+    const result = OpenClawSchema.safeParse({
+      memory: {
+        backend: "qmd",
+        qmd: {
+          limits: {
+            candidateLimit: 0,
+          },
+        },
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+
   it("rejects retired status reaction emoji overrides", () => {
     const result = OpenClawSchema.safeParse({
       messages: {

--- a/src/config/types.memory.ts
+++ b/src/config/types.memory.ts
@@ -140,6 +140,7 @@ export type MemoryQmdSessionConfig = {
 /** Retrieval and injection limits for QMD memory results. */
 export type MemoryQmdLimitsConfig = {
   maxResults?: number;
+  candidateLimit?: number;
   maxSnippetChars?: number;
   maxInjectedChars?: number;
   timeoutMs?: number;

--- a/src/config/zod-schema.root-support.ts
+++ b/src/config/zod-schema.root-support.ts
@@ -110,6 +110,7 @@ const MemoryQmdSessionSchema = z.strictObject({
 
 const MemoryQmdLimitsSchema = z.strictObject({
   maxResults: z.number().int().positive().optional(),
+  candidateLimit: z.number().int().positive().optional(),
   maxSnippetChars: z.number().int().positive().optional(),
   maxInjectedChars: z.number().int().positive().optional(),
   timeoutMs: z.number().int().nonnegative().optional(),


### PR DESCRIPTION
Closes #113851

AI-assisted PR.

## What Problem This Solves

QMD-backed `memory_search` users can currently disable query reranking with `memory.qmd.rerank: false`, or increase `memory.qmd.limits.timeoutMs`, but they cannot keep reranking enabled while bounding how many QMD candidates enter the reranker. On CPU-only hosts or larger indexes, that makes query-mode recall slower than it needs to be.

## Why This Change Was Made

This adds a validated optional `memory.qmd.limits.candidateLimit` positive integer. When set, OpenClaw passes it to direct QMD CLI `query` calls as `-C <n>` and to the mcporter-backed `qmd.query` tool as `candidateLimit`. The setting is unset by default, so existing QMD defaults and search behavior remain unchanged.

## User Impact

Operators using QMD query-mode memory search can now preserve reranking quality while reducing reranker latency by limiting the candidate set. Users who do not configure the new setting see no behavior change.

## Evidence

- `node scripts/run-vitest.mjs src/config/schema.test.ts packages/memory-host-sdk/src/host/backend-config.test.ts extensions/memory-core/src/memory/qmd-manager.test.ts`: passed 3 Vitest shards, 257 tests.
- `git diff --check FETCH_HEAD...HEAD`: passed.
- QMD contract check: local `qmd 2.1.0` reports `-C, --candidate-limit <n> - Max candidates to rerank (default 40, lower = faster)` in `qmd query --help`.
- Local timing fixture: named QMD index `qmd-candidate-limit-cron` with 120 indexed Markdown files, typed lexical query to isolate reranker behavior:
  - `qmd --index qmd-candidate-limit-cron query $'lex: candidate' --json -n 20 -C 12 -c qmd-fixture`: `Reranking 12 chunks...`, 12 results, `real 2.49s`.
  - `qmd --index qmd-candidate-limit-cron query $'lex: candidate' --json -n 20 -C 40 -c qmd-fixture`: `Reranking 20 chunks...`, 20 results, `real 3.99s`.
