### PR TITLE
fix(macos): prevent model setup progress from freezing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -319,6 +319,7 @@ Docs: https://docs.openclaw.ai
 - **Signal native quote replies:** preserve the active inbound message as a native quote across agent, explicit, durable, and chunked sends while keeping reply-mode policy inside the Signal plugin. (#105347) Thanks @jesse-merhi.
 - **Media-store remote downloads:** bound response-header waits and stalled bodies, close abandoned redirect and error responses, and remove partial temp files so hung sources cannot pin callers. (#104624) Thanks @hugenshen.
 - **Cron llama.cpp tool schemas:** keep the model-facing cron declaration schema compatible with llama.cpp while retaining gateway and runtime nonblank validation. Fixes #107449. (#108360) Thanks @lee-xydt.
+- **macOS model setup progress:** keep polling gateway-executed download steps until completion so long local-model downloads continue updating and the setup sheet closes when ready. Fixes #113612. Thanks @jackjin1997.
 
 ## 2026.7.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -319,6 +319,7 @@ Docs: https://docs.openclaw.ai
 - **Signal native quote replies:** preserve the active inbound message as a native quote across agent, explicit, durable, and chunked sends while keeping reply-mode policy inside the Signal plugin. (#105347) Thanks @jesse-merhi.
 - **Media-store remote downloads:** bound response-header waits and stalled bodies, close abandoned redirect and error responses, and remove partial temp files so hung sources cannot pin callers. (#104624) Thanks @hugenshen.
 - **Cron llama.cpp tool schemas:** keep the model-facing cron declaration schema compatible with llama.cpp while retaining gateway and runtime nonblank validation. Fixes #107449. (#108360) Thanks @lee-xydt.
+
 ## 2026.7.1
 
 OpenClaw v2026.7.1 brings major Control UI and onboarding overhauls, major updates to the official iOS, Android, and macOS apps, expanded model and provider support including GPT-5.6 compatibility, Tencent Hy3, and Meta Muse Spark 1.1, and stronger Codex and connected coding-agent workflows. Telegram, Slack, Discord, and Apple Messages each receive substantial updates, while Gateway crash loops, scheduled work, remote browser control, workspace terminals, sessions, and goals also improve. There are also many general fixes and refinements throughout OpenClaw.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -319,8 +319,6 @@ Docs: https://docs.openclaw.ai
 - **Signal native quote replies:** preserve the active inbound message as a native quote across agent, explicit, durable, and chunked sends while keeping reply-mode policy inside the Signal plugin. (#105347) Thanks @jesse-merhi.
 - **Media-store remote downloads:** bound response-header waits and stalled bodies, close abandoned redirect and error responses, and remove partial temp files so hung sources cannot pin callers. (#104624) Thanks @hugenshen.
 - **Cron llama.cpp tool schemas:** keep the model-facing cron declaration schema compatible with llama.cpp while retaining gateway and runtime nonblank validation. Fixes #107449. (#108360) Thanks @lee-xydt.
-- **macOS model setup progress:** keep polling gateway-executed download steps until completion so long local-model downloads continue updating and the setup sheet closes when ready. Fixes #113612. Thanks @jackjin1997.
-
 ## 2026.7.1
 
 OpenClaw v2026.7.1 brings major Control UI and onboarding overhauls, major updates to the official iOS, Android, and macOS apps, expanded model and provider support including GPT-5.6 compatibility, Tencent Hy3, and Meta Muse Spark 1.1, and stronger Codex and connected coding-agent workflows. Telegram, Slack, Discord, and Apple Messages each receive substantial updates, while Gateway crash loops, scheduled work, remote browser control, workspace terminals, sessions, and goals also improve. There are also many general fixes and refinements throughout OpenClaw.

--- a/apps/macos/Sources/OpenClaw/OnboardingAISetup.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingAISetup.swift
@@ -1344,6 +1344,11 @@ extension OnboardingAISetupModel {
         self.authSelection = max(0, options.firstIndex {
             anyCodableEqual($0.value, step?.initialvalue)
         } ?? 0)
+        // Gateway-executed progress steps have no user input to advance them.
+        // Reuse the existing guarded long-poll until the wizard reaches a terminal result.
+        if anyCodableString(step?.executor) == "gateway" {
+            self.advanceProviderAuth(stepID: nil, value: nil)
+        }
     }
 
     private func reconcileProviderAuthAfterUnknownOutcome(

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
@@ -372,12 +372,26 @@ private func wizardStartResponse(id: String, sessionID: String) -> Data {
         """.utf8)
 }
 
-private func wizardProgressResponse(id: String, sessionID: String) -> Data {
+private func wizardProgressResponse(id: String, sessionID: String, message: String) -> Data {
     Data(
         """
         {"type":"res","id":"\(id)","ok":true,"payload":{
           "sessionId":"\(sessionID)","done":false,"status":"running",
-          "step":{"id":"download","type":"progress","message":"Downloading model: 25%"}
+          "step":{
+            "id":"download",
+            "type":"progress",
+            "message":"\(message)",
+            "executor":"gateway"
+          }
+        }}
+        """.utf8)
+}
+
+private func wizardDoneResponse(id: String, sessionID: String) -> Data {
+    Data(
+        """
+        {"type":"res","id":"\(id)","ok":true,"payload":{
+          "sessionId":"\(sessionID)","done":true,"status":"done"
         }}
         """.utf8)
 }
@@ -637,7 +651,7 @@ struct OnboardingAISetupTests {
             "openclaw.setup.prepare.start")
     }
 
-    @Test func `prepare action starts shared wizard with the local auth choice`() async throws {
+    @Test func `prepare action polls gateway progress through completion`() async throws {
         let recorder = AISetupRequestRecorder()
         let session = GatewayTestWebSocketSession(taskFactory: {
             GatewayTestWebSocketTask(
@@ -657,9 +671,18 @@ struct OnboardingAISetupTests {
                             sessionID: sessionID)))
                     case "wizard.next":
                         let sessionID = request.params["sessionId"] as? String ?? "prepare-session"
-                        task.emitReceiveSuccess(.data(wizardProgressResponse(
-                            id: request.id,
-                            sessionID: sessionID)))
+                        let snapshot = await recorder.snapshot()
+                        let progressIndex = snapshot.methods.count { $0 == "wizard.next" }
+                        if progressIndex < 4 {
+                            task.emitReceiveSuccess(.data(wizardProgressResponse(
+                                id: request.id,
+                                sessionID: sessionID,
+                                message: "Downloading model: \(progressIndex * 25)%")))
+                        } else {
+                            task.emitReceiveSuccess(.data(wizardDoneResponse(
+                                id: request.id,
+                                sessionID: sessionID)))
+                        }
                     default:
                         break
                     }
@@ -685,19 +708,22 @@ struct OnboardingAISetupTests {
         await model.detectAndAutoConnect()
         let option = try #require(model.prepareOptions.first { $0.id == "llama-cpp" })
         model.startProviderPrepare(option)
-        let requests = await waitForAISetupRequests(recorder, count: 3)
+        let requests = await waitForAISetupRequests(recorder, count: 6)
+        for _ in 0..<200 where model.isPreparingModel {
+            try? await Task.sleep(nanoseconds: 5_000_000)
+        }
 
-        #expect(requests.methods == [
+        #expect(Array(requests.methods.prefix(6)) == [
             "openclaw.setup.detect",
             "openclaw.setup.prepare.start",
             "wizard.next",
+            "wizard.next",
+            "wizard.next",
+            "wizard.next",
         ])
         #expect(requests.authChoices == ["llama-cpp"])
-        #expect(model.isPreparingModel)
-        for _ in 0..<200 where model.authStep.map(wizardStepType) != "progress" {
-            try? await Task.sleep(nanoseconds: 5_000_000)
-        }
-        #expect(model.authStep.map(wizardStepType) == "progress")
+        #expect(!model.isPreparingModel)
+        #expect(model.authStep == nil)
     }
 
     @Test func `provider auth opens only safe external links`() {


### PR DESCRIPTION
Fixes #113612

## What Problem This Solves

Fixes an issue where users preparing a local model from macOS onboarding would see the setup sheet freeze on the first download progress update while the Gateway continued the download in the background.

## Why This Change Was Made

The macOS client now immediately requests the next wizard result whenever the current step is executed by the Gateway, matching the existing Control UI behavior. It reuses the existing server-lease, attempt-token, and auth-attempt guards instead of adding a separate timer or polling path.

## User Impact

Long local-model downloads keep updating in the macOS setup sheet, and the sheet reaches its terminal completion state automatically when preparation finishes.

## Evidence

- TDD regression proof: before the implementation, the focused test issued one `wizard.next` request and remained stuck at 25%; after the change it consumes three progress frames and the terminal result.
- `swift test --package-path apps/macos --filter OnboardingAISetupTests` — 85 tests passed after rebasing onto current `main`.
- Native macOS behavior proof: an Apple Development-signed native app using the production `OnboardingAISetupModel` completed a real 5.0 GB Gemma 4 E4B llama.cpp setup through an isolated local Gateway. Redacted live output showed successive Gateway-executed progress updates and automatic terminal completion:

  ```text
  [pr113853-proof] step executor=gateway message=Downloading Gemma 4 E4B… 0% (...)
  [pr113853-proof] step executor=gateway message=Downloading Gemma 4 E4B… 20% (...)
  [pr113853-proof] step executor=gateway message=Downloading Gemma 4 E4B… 49% (...)
  [pr113853-proof] step executor=gateway message=Downloading Gemma 4 E4B… 62% (...)
  [pr113853-proof] step executor=gateway message=Downloading Gemma 4 E4B… 81% (...)
  [pr113853-proof] step executor=gateway message=Downloading Gemma 4 E4B… 100% (...)
  [pr113853-proof] step executor=gateway message=Gemma 4 E4B model downloaded
  [pr113853-proof] PASS progress reached terminal result sheetClosed=true
  ```

- `pnpm build` — passed on Node 24.15.0, including all 142 public Plugin SDK subpaths and the Control UI build.
- Production/script/test-root typechecks, lint, formatting, and runtime policy guards passed. The aggregate local `pnpm check` stopped only on the existing npm-shrinkwrap baseline mismatch; no baseline files were modified.
- Full `swift test --package-path apps/macos` ran 1,484 tests; its only failure (`GatewayProcessManagerTests/startup install forces the recovered control channel refresh`) reproduced on a clean `origin/main` worktree.
- Full `pnpm test` completed all 295 Vitest shards and reported unrelated current-main/platform failures; a representative OpenCode catalog failure reproduced on clean `origin/main`.
- `scripts/package-mac-app.sh` compiled and linked the main OpenClaw app product. Final bundling stopped in the unrelated MLX TTS helper because current `mlx-swift` requires Swift tools 6.3 while the installed Xcode toolchain provides Swift 6.2.4.
- Independent `codex review --commit HEAD` reported no actionable findings.
