### PR TITLE
fix(browser): keep tab listing responsive on established connections when a shared tab wedges [AI]

### DIFF
--- a/extensions/browser/chrome-extension/background.js
+++ b/extensions/browser/chrome-extension/background.js
@@ -118,22 +118,15 @@ async function getCopilotConfig() {
 // Tab group management (the consent boundary)
 // ---------------------------------------------------------------------------
 
-async function findOpenClawGroups() {
-  try {
-    return await chrome.tabGroups.query({ title: OPENCLAW_TAB_GROUP_TITLE });
-  } catch {
-    return [];
-  }
+function findOpenClawGroups(options = {}) {
+  const query = chrome.tabGroups.query({ title: OPENCLAW_TAB_GROUP_TITLE });
+  return options.throwOnError ? query : query.catch(() => []);
 }
 
-async function listSharedTabs() {
-  const groups = await findOpenClawGroups();
-  const tabs = [];
-  for (const group of groups) {
-    const groupTabs = await chrome.tabs.query({ groupId: group.id });
-    tabs.push(...groupTabs);
-  }
-  return tabs.filter((tab) => typeof tab.id === "number");
+async function listSharedTabs(options) {
+  const groups = await findOpenClawGroups(options);
+  const tabs = await Promise.all(groups.map((group) => chrome.tabs.query({ groupId: group.id })));
+  return tabs.flat().filter((tab) => typeof tab.id === "number");
 }
 
 async function addTabToOpenClawGroup(tabId) {
@@ -343,9 +336,9 @@ chrome.debugger.onDetach.addListener((source, reason) => {
 // Relay connection
 // ---------------------------------------------------------------------------
 
-function send(message) {
-  if (relayWs && relayWs.readyState === WebSocket.OPEN) {
-    relayWs.send(JSON.stringify(message));
+function send(message, socket = relayWs) {
+  if (socket && socket.readyState === WebSocket.OPEN) {
+    socket.send(JSON.stringify(message));
   }
 }
 
@@ -359,21 +352,26 @@ function armRelayOpeningDeadline() {
   chrome.alarms.create(RELAY_OPENING_DEADLINE_ALARM, { when: relayOpeningDeadlineAt });
 }
 
-async function handleRelayCommand(msg) {
+async function handleRelayCommand(msg, socket) {
   const { seq } = msg;
   try {
     switch (msg.type) {
       case "ping":
-        send({ type: "pong" });
+        send({ type: "pong" }, socket);
         return;
+      case "probe": {
+        const shared = await listSharedTabs({ throwOnError: true });
+        send({ type: "result", seq, result: { sharedTabCount: shared.length } }, socket);
+        return;
+      }
       case "attach": {
         const result = await attachDebugger(msg.tabId);
-        send({ type: "result", seq, result });
+        send({ type: "result", seq, result }, socket);
         return;
       }
       case "detach": {
         await detachDebugger(msg.tabId);
-        send({ type: "result", seq, result: {} });
+        send({ type: "result", seq, result: {} }, socket);
         return;
       }
       case "cdp": {
@@ -381,7 +379,7 @@ async function handleRelayCommand(msg) {
           ? { tabId: msg.tabId, sessionId: msg.sessionId }
           : { tabId: msg.tabId };
         const result = await chrome.debugger.sendCommand(target, msg.method, msg.params ?? {});
-        send({ type: "result", seq, result: result ?? {} });
+        send({ type: "result", seq, result: result ?? {} }, socket);
         return;
       }
       case "createTab": {
@@ -391,30 +389,31 @@ async function handleRelayCommand(msg) {
           await focusWindowForTab(tab);
         }
         scheduleTabsSync();
-        send({ type: "result", seq, result: { tabId: tab.id } });
+        send({ type: "result", seq, result: { tabId: tab.id } }, socket);
         return;
       }
       case "closeTab": {
         await detachDebugger(msg.tabId);
         await chrome.tabs.remove(msg.tabId);
-        send({ type: "result", seq, result: {} });
+        send({ type: "result", seq, result: {} }, socket);
         return;
       }
       case "activateTab": {
         const tab = await chrome.tabs.get(msg.tabId);
         await chrome.tabs.update(msg.tabId, { active: true });
         await focusWindowForTab(tab);
-        send({ type: "result", seq, result: {} });
+        send({ type: "result", seq, result: {} }, socket);
         return;
       }
       default:
         if (typeof seq === "number") {
-          send({ type: "error", seq, message: `unknown relay command: ${msg.type}` });
+          send({ type: "error", seq, message: `unknown relay command: ${msg.type}` }, socket);
         }
     }
   } catch (err) {
     if (typeof seq === "number") {
-      send({ type: "error", seq, message: err instanceof Error ? err.message : String(err) });
+      const message = err instanceof Error ? err.message : String(err);
+      send({ type: "error", seq, message }, socket);
     }
   }
 }
@@ -428,6 +427,7 @@ async function sendHello() {
     browserVersion: uaMatch ? uaMatch[0] : "Chrome/unknown",
     extensionVersion: chrome.runtime.getManifest().version,
     tabs: shared.map(toRelayTabInfo),
+    capabilities: ["probe-v1"],
   });
 }
 
@@ -476,7 +476,7 @@ async function connectRelay() {
       pageShareRelay.settle(ws, msg);
       return;
     }
-    void handleRelayCommand(msg);
+    void handleRelayCommand(msg, ws);
   });
   ws.addEventListener("close", () => {
     pageShareRelay.rejectSocket(ws);

--- a/extensions/browser/chrome-extension/background.test.ts
+++ b/extensions/browser/chrome-extension/background.test.ts
@@ -173,6 +173,7 @@ async function loadBackground({ deferSocketClose = false }: { deferSocketClose?:
     messageListener,
     setBadgeText,
     sockets,
+    tabGroupsQuery: chromeMock.tabGroups.query,
     tabsGet: chromeMock.tabs.get,
   };
 }
@@ -259,6 +260,35 @@ describe("relay opening deadline", () => {
     vi.setSystemTime(START_TIME_MS + 60_000);
     harness.alarmListener({ name: RELAY_OPENING_DEADLINE_ALARM });
     expect(socket?.close).not.toHaveBeenCalled();
+  });
+
+  it("does not deliver a delayed probe reply through a replacement socket", async () => {
+    const harness = await loadBackground();
+    const first = harness.sockets[0];
+    expect(first).toBeDefined();
+    first?.open();
+    await vi.waitFor(() => expect(first?.send).toHaveBeenCalled());
+
+    let resolveProbe!: (groups: []) => void;
+    harness.tabGroupsQuery.mockReturnValueOnce(
+      new Promise<[]>((resolve) => {
+        resolveProbe = resolve;
+      }),
+    );
+    first?.receive({ type: "probe", seq: 77 });
+    first?.close();
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    const replacement = harness.sockets[1];
+    expect(replacement).toBeDefined();
+    replacement?.open();
+    await vi.waitFor(() => expect(replacement?.send).toHaveBeenCalled());
+
+    resolveProbe([]);
+    await vi.advanceTimersByTimeAsync(0);
+
+    const replacementMessages = replacement?.send.mock.calls.map(([raw]) => String(raw)) ?? [];
+    expect(replacementMessages.some((raw) => raw.includes('"seq":77'))).toBe(false);
   });
 });
 

--- a/extensions/browser/src/browser/extension-relay/relay-bridge.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-bridge.ts
@@ -11,6 +11,7 @@ import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { resolveCreateTargetParams } from "./create-target-params.js";
 import { PAGE_SHARE_GATEWAY_REQUIRED_ERROR } from "./page-share.js";
 import {
+  EXTENSION_RELAY_CAPABILITY_PROBE_V1,
   type ExtensionToRelayMessage,
   PAGE_SHARE_MAX_NOTE_CHARS,
   PAGE_SHARE_MAX_TITLE_CHARS,
@@ -27,6 +28,8 @@ const log = createSubsystemLogger("browser").child("extension-relay");
 
 /** Default timeout for commands forwarded to the extension. */
 const EXTENSION_COMMAND_TIMEOUT_MS = 15_000;
+/** Leave response overhead inside the extension profile's default 1.5s HTTP budget. */
+const EXTENSION_PROBE_TIMEOUT_MS = 1_000;
 /** App-level keepalive interval; message traffic keeps the MV3 worker alive. */
 const EXTENSION_PING_INTERVAL_MS = 20_000;
 const PAGE_SHARE_MAX_BODY_CHARS = 300_000;
@@ -80,6 +83,7 @@ type ExtensionIdentity = {
   userAgent: string;
   browserVersion: string;
   extensionVersion: string;
+  capabilities: ReadonlySet<string>;
 };
 
 function toErrorPayload(
@@ -143,6 +147,32 @@ export class ExtensionRelayBridge {
     return this.clients.size;
   }
 
+  /**
+   * Verify the MV3 worker can still query Chrome, rather than treating a
+   * half-open socket or the relay's synthetic CDP replies as browser health.
+   * Pre-capability extensions retain their shipped hello-based readiness.
+   */
+  async probeExtension(): Promise<boolean> {
+    if (!this.extension) {
+      return false;
+    }
+    if (!this.extension.identity.capabilities.has(EXTENSION_RELAY_CAPABILITY_PROBE_V1)) {
+      return true;
+    }
+    try {
+      const result = (await this.callExtension({ type: "probe" }, EXTENSION_PROBE_TIMEOUT_MS)) as {
+        sharedTabCount?: unknown;
+      } | null;
+      return (
+        typeof result?.sharedTabCount === "number" &&
+        Number.isSafeInteger(result.sharedTabCount) &&
+        result.sharedTabCount >= 0
+      );
+    } catch {
+      return false;
+    }
+  }
+
   // ---------------------------------------------------------------------
   // Extension side
   // ---------------------------------------------------------------------
@@ -178,6 +208,11 @@ export class ExtensionRelayBridge {
             userAgent: msg.userAgent,
             browserVersion: msg.browserVersion,
             extensionVersion: msg.extensionVersion,
+            capabilities: new Set(
+              Array.isArray(msg.capabilities)
+                ? msg.capabilities.filter((capability) => typeof capability === "string")
+                : [],
+            ),
           },
         };
         this.syncTabs(msg.tabs);

--- a/extensions/browser/src/browser/extension-relay/relay-protocol.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-protocol.ts
@@ -13,6 +13,9 @@ export type RelayTabInfo = {
   active: boolean;
 };
 
+/** Additive hello capability for the sequenced worker/tab-query health probe. */
+export const EXTENSION_RELAY_CAPABILITY_PROBE_V1 = "probe-v1";
+
 export const PAGE_SHARE_MAX_NOTE_CHARS = 2_000;
 export const PAGE_SHARE_MAX_TITLE_CHARS = 500;
 export const PAGE_SHARE_MAX_URL_CHARS = 2_000;
@@ -37,6 +40,7 @@ type ExtensionHelloMessage = {
   browserVersion: string;
   extensionVersion: string;
   tabs: RelayTabInfo[];
+  capabilities?: string[];
 };
 
 /** Full refresh of shared tabs; sent on any group membership or tab change. */
@@ -101,6 +105,8 @@ export type ExtensionToRelayMessage =
  * correlate the extension's result/error reply.
  */
 export type RelayCommandBody =
+  /** Verify the extension worker and shared-tab query are responsive. */
+  | { type: "probe" }
   /** Forward a CDP command into an attached tab (or one of its child sessions). */
   | { type: "cdp"; tabId: number; sessionId?: string; method: string; params?: unknown }
   /** Attach chrome.debugger to a shared tab. Result: { targetId: string }. */

--- a/extensions/browser/src/browser/extension-relay/relay-server.test.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-server.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, it } from "vitest";
+import type { RelayToExtensionMessage } from "./relay-protocol.js";
+import { type ExtensionRelayHandle, startExtensionRelayServer } from "./relay-server.js";
+
+const TOKEN = "a".repeat(64);
+const handles: ExtensionRelayHandle[] = [];
+
+function sendHello(handlers: { onMessage: (raw: string) => void }, advertiseProbe = true): void {
+  handlers.onMessage(
+    JSON.stringify({
+      type: "hello",
+      userAgent: "Mozilla/5.0 Chrome/144.0.0.0",
+      browserVersion: "Chrome/144.0.0.0",
+      extensionVersion: "2.0.0",
+      tabs: [],
+      ...(advertiseProbe ? { capabilities: ["probe-v1"] } : {}),
+    }),
+  );
+}
+
+async function startRelay(
+  probeResponseDelayMs: number | null,
+  advertiseProbe = true,
+): Promise<ExtensionRelayHandle> {
+  const handle = await startExtensionRelayServer({ port: 0, token: TOKEN });
+  handles.push(handle);
+  const socket: { send: (raw: string) => void; close: () => void } = {
+    send: () => {},
+    close: () => {},
+  };
+  const handlers = handle.bridge.attachExtensionSocket(socket);
+  socket.send = (raw) => {
+    const message = JSON.parse(raw) as RelayToExtensionMessage;
+    if (message.type === "probe" && probeResponseDelayMs !== null) {
+      setTimeout(() => {
+        handlers.onMessage(
+          JSON.stringify({
+            type: "result",
+            seq: message.seq,
+            result: { sharedTabCount: 0 },
+          }),
+        );
+      }, probeResponseDelayMs);
+    }
+  };
+  sendHello(handlers, advertiseProbe);
+  return handle;
+}
+
+async function fetchVersion(handle: ExtensionRelayHandle): Promise<Response> {
+  const authorization = Buffer.from(`openclaw:${TOKEN}`).toString("base64");
+  return await fetch(`http://127.0.0.1:${handle.port}/json/version`, {
+    headers: { Authorization: `Basic ${authorization}` },
+  });
+}
+
+afterEach(async () => {
+  await Promise.all(handles.splice(0).map(async (handle) => await handle.close()));
+});
+
+describe("extension relay health", () => {
+  it("reports a responsive extension with zero shared tabs as available", async () => {
+    const response = await fetchVersion(await startRelay(300));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      Browser: "Chrome/144.0.0.0",
+    });
+  });
+
+  it("reports a hello-but-unresponsive extension as unavailable", async () => {
+    const response = await fetchVersion(await startRelay(null));
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toMatchObject({
+      error: expect.stringContaining("not responding"),
+    });
+  });
+
+  it("keeps a pre-probe extension available through its legacy hello handshake", async () => {
+    const response = await fetchVersion(await startRelay(null, false));
+
+    expect(response.status).toBe(200);
+  });
+});

--- a/extensions/browser/src/browser/extension-relay/relay-server.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-server.ts
@@ -154,16 +154,28 @@ export async function startExtensionRelayServer(params: {
         );
         return;
       }
-      const identity = bridge.identity;
-      res.writeHead(200, { "Content-Type": "application/json" });
-      res.end(
-        JSON.stringify({
-          Browser: identity?.browserVersion ?? "Chrome/unknown",
-          "Protocol-Version": "1.3",
-          "User-Agent": identity?.userAgent ?? "unknown",
-          webSocketDebuggerUrl: `ws://127.0.0.1:${resolvedPort()}/cdp`,
-        }),
-      );
+      void bridge.probeExtension().then((responsive) => {
+        if (!responsive) {
+          res.writeHead(503, { "Content-Type": "application/json" });
+          res.end(
+            JSON.stringify({
+              error:
+                "OpenClaw Chrome extension is connected but not responding. Reload the extension and try again.",
+            }),
+          );
+          return;
+        }
+        const identity = bridge.identity;
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(
+          JSON.stringify({
+            Browser: identity?.browserVersion ?? "Chrome/unknown",
+            "Protocol-Version": "1.3",
+            "User-Agent": identity?.userAgent ?? "unknown",
+            webSocketDebuggerUrl: `ws://127.0.0.1:${resolvedPort()}/cdp`,
+          }),
+        );
+      });
       return;
     }
     if (req.method === "GET" && (path === "/json" || path === "/json/list")) {

--- a/extensions/browser/src/browser/pw-session-actions.ts
+++ b/extensions/browser/src/browser/pw-session-actions.ts
@@ -29,6 +29,7 @@ import {
   isBlockedPageRef,
   isBlockedTarget,
   isRecoverablePlaywrightDisconnectError,
+  pageTargetInfo,
   pageTargetId,
   retirePlaywrightBrowserConnectionExact,
   takeCachedPlaywrightBrowserConnection,
@@ -347,24 +348,18 @@ async function readPagesViaPlaywright(
         if (isBlockedPageRef(opts.cdpUrl, page)) {
           continue;
         }
-        let tid: string | null;
+        let targetInfo: { targetId: string | null; title: string } | null;
         try {
-          tid = await pageTargetId(page);
+          targetInfo = await pageTargetInfo(page);
         } catch (err) {
           if (isRecoverablePlaywrightDisconnectError(err)) {
             throw err;
           }
-          tid = null;
+          targetInfo = null;
         }
+        const tid = targetInfo?.targetId;
+        const title = targetInfo?.title ?? "";
         if (tid && !isBlockedTarget(opts.cdpUrl, tid)) {
-          let title = "";
-          try {
-            title = await page.title();
-          } catch (err) {
-            if (isRecoverablePlaywrightDisconnectError(err)) {
-              throw err;
-            }
-          }
           let url = "";
           try {
             url = page.url();
@@ -375,6 +370,8 @@ async function readPagesViaPlaywright(
           }
           results.push({
             targetId: tid,
+            // Target metadata is already available from CDP and does not require
+            // a Runtime command, which can remain pending forever on a wedged tab.
             title,
             url,
             type: "page",

--- a/extensions/browser/src/browser/pw-session-connection.ts
+++ b/extensions/browser/src/browser/pw-session-connection.ts
@@ -40,6 +40,14 @@ import {
 
 const { chromium } = playwrightCore;
 
+type PageTargetInfo = { targetId: string | null; title: string };
+
+// Keep one target-info read per Page while Playwright is still detaching its
+// temporary CDP session. A wedged renderer can leave detach pending forever;
+// reusing the resolved metadata prevents every later tool call from attaching
+// another stuck session to the same page.
+const pageTargetInfoReads = new WeakMap<Page, Promise<PageTargetInfo>>();
+
 function resolveCdpConnectRetryDelayMs(attempt: number): number {
   return 250 + attempt * 250;
 }
@@ -522,15 +530,49 @@ async function partitionAccessiblePages(opts: { cdpUrl: string; pages: Page[] })
   return { accessible, blockedCount };
 }
 
-export async function pageTargetId(page: Page): Promise<string | null> {
-  const session = await page.context().newCDPSession(page);
-  try {
-    const info = (await session.send("Target.getTargetInfo")) as TargetInfoResponse;
-    const targetId = normalizeOptionalString(info?.targetInfo?.targetId) ?? "";
-    return targetId || null;
-  } finally {
-    await session.detach().catch(() => {});
+export async function pageTargetInfo(page: Page): Promise<PageTargetInfo> {
+  const cached = pageTargetInfoReads.get(page);
+  if (cached) {
+    return await cached;
   }
+
+  let detachScheduled = false;
+  const read: Promise<PageTargetInfo> = (async () => {
+    const session = await page.context().newCDPSession(page);
+    try {
+      const info = (await session.send("Target.getTargetInfo")) as TargetInfoResponse;
+      const targetId = normalizeOptionalString(info?.targetInfo?.targetId) ?? "";
+      const title = typeof info?.targetInfo?.title === "string" ? info.targetInfo.title : "";
+      return { targetId: targetId || null, title };
+    } finally {
+      // Playwright first sends Runtime.runIfWaitingForDebugger while detaching.
+      // Do not make target discovery depend on a renderer that may be wedged.
+      detachScheduled = true;
+      void session
+        .detach()
+        .catch(() => {})
+        .finally(() => {
+          if (pageTargetInfoReads.get(page) === read) {
+            pageTargetInfoReads.delete(page);
+          }
+        });
+    }
+  })();
+  pageTargetInfoReads.set(page, read);
+  try {
+    return await read;
+  } catch (err) {
+    // Once a session exists, keep even a rejected read cached until its detach
+    // settles. This caps a wedged page at one auxiliary session per connection.
+    if (!detachScheduled && pageTargetInfoReads.get(page) === read) {
+      pageTargetInfoReads.delete(page);
+    }
+    throw err;
+  }
+}
+
+export async function pageTargetId(page: Page): Promise<string | null> {
+  return (await pageTargetInfo(page)).targetId;
 }
 
 async function getPageForTargetIdOnce(opts: {

--- a/extensions/browser/src/browser/pw-session-contracts.ts
+++ b/extensions/browser/src/browser/pw-session-contracts.ts
@@ -83,6 +83,7 @@ export type ArmedDialogResponse = {
 export type TargetInfoResponse = {
   targetInfo?: {
     targetId?: string;
+    title?: string;
   };
 };
 

--- a/extensions/browser/src/browser/pw-session.connections.test.ts
+++ b/extensions/browser/src/browser/pw-session.connections.test.ts
@@ -21,6 +21,10 @@ type BrowserMockBundle = {
   browserClose: ReturnType<typeof vi.fn>;
 };
 
+type BrowserWithPagesMockBundle = BrowserMockBundle & {
+  newCdpSession: ReturnType<typeof vi.fn>;
+};
+
 function makeBrowserWithPages(
   entries: Array<{
     targetId: string;
@@ -30,32 +34,33 @@ function makeBrowserWithPages(
     targetRead?: () => Promise<unknown>;
     targetTitle?: string;
   }>,
-): BrowserMockBundle {
+): BrowserWithPagesMockBundle {
   const browserClose = vi.fn(async () => {});
   const pages: import("playwright-core").Page[] = [];
   const targetInfoByPage = new Map<
     import("playwright-core").Page,
     { targetId: string; title: string }
   >();
+  const newCdpSession = vi.fn(async (page: import("playwright-core").Page) => {
+    const entry = entries.find(
+      (candidate) => candidate.targetId === targetInfoByPage.get(page)?.targetId,
+    );
+    return {
+      send: vi.fn(async (method: string) => {
+        if (method !== "Target.getTargetInfo") {
+          return {};
+        }
+        return entry?.targetRead
+          ? await entry.targetRead()
+          : { targetInfo: targetInfoByPage.get(page) };
+      }),
+      detach: vi.fn(entry?.sessionDetach ?? (async () => {})),
+    };
+  });
   const context: import("playwright-core").BrowserContext = {
     pages: () => pages,
     on: vi.fn(),
-    newCDPSession: vi.fn(async (page: import("playwright-core").Page) => {
-      const entry = entries.find(
-        (candidate) => candidate.targetId === targetInfoByPage.get(page)?.targetId,
-      );
-      return {
-        send: vi.fn(async (method: string) => {
-          if (method !== "Target.getTargetInfo") {
-            return {};
-          }
-          return entry?.targetRead
-            ? await entry.targetRead()
-            : { targetInfo: targetInfoByPage.get(page) };
-        }),
-        detach: vi.fn(entry?.sessionDetach ?? (async () => {})),
-      };
-    }),
+    newCDPSession: newCdpSession,
   } as unknown as import("playwright-core").BrowserContext;
   for (const entry of entries) {
     const page = {
@@ -78,7 +83,7 @@ function makeBrowserWithPages(
     close: browserClose,
   } as unknown as import("playwright-core").Browser;
 
-  return { browser, browserClose };
+  return { browser, browserClose, newCdpSession };
 }
 
 function makeBrowser(targetId: string, url: string): BrowserMockBundle {
@@ -581,7 +586,7 @@ describe("pw-session connection scoping", () => {
       }),
     ).resolves.toEqual(pages);
     expect(stuckSessionDetach).toHaveBeenCalledOnce();
-    expect(browser.browser.contexts()[0]?.newCDPSession).toHaveBeenCalledTimes(3);
+    expect(browser.newCdpSession).toHaveBeenCalledTimes(3);
   });
 
   it("selects a healthy target after a page whose session detach stays stuck", async () => {
@@ -640,7 +645,7 @@ describe("pw-session connection scoping", () => {
 
     expect(targetRead).toHaveBeenCalledOnce();
     expect(sessionDetach).toHaveBeenCalledOnce();
-    expect(browser.browser.contexts()[0]?.newCDPSession).toHaveBeenCalledOnce();
+    expect(browser.newCdpSession).toHaveBeenCalledOnce();
   });
 
   it("times out stuck page enumeration and evicts the scoped connection", async () => {

--- a/extensions/browser/src/browser/pw-session.connections.test.ts
+++ b/extensions/browser/src/browser/pw-session.connections.test.ts
@@ -21,25 +21,55 @@ type BrowserMockBundle = {
   browserClose: ReturnType<typeof vi.fn>;
 };
 
-function makeBrowser(targetId: string, url: string): BrowserMockBundle {
+function makeBrowserWithPages(
+  entries: Array<{
+    targetId: string;
+    url: string;
+    pageTitle?: () => Promise<string>;
+    sessionDetach?: () => Promise<void>;
+    targetRead?: () => Promise<unknown>;
+    targetTitle?: string;
+  }>,
+): BrowserMockBundle {
   const browserClose = vi.fn(async () => {});
-  const page = {
-    on: vi.fn(),
-    context: () => context,
-    title: vi.fn(async () => `title:${targetId}`),
-    url: vi.fn(() => url),
-  } as unknown as import("playwright-core").Page;
-
+  const pages: import("playwright-core").Page[] = [];
+  const targetInfoByPage = new Map<
+    import("playwright-core").Page,
+    { targetId: string; title: string }
+  >();
   const context: import("playwright-core").BrowserContext = {
-    pages: () => [page],
+    pages: () => pages,
     on: vi.fn(),
-    newCDPSession: vi.fn(async () => ({
-      send: vi.fn(async (method: string) =>
-        method === "Target.getTargetInfo" ? { targetInfo: { targetId } } : {},
-      ),
-      detach: vi.fn(async () => {}),
-    })),
+    newCDPSession: vi.fn(async (page: import("playwright-core").Page) => {
+      const entry = entries.find(
+        (candidate) => candidate.targetId === targetInfoByPage.get(page)?.targetId,
+      );
+      return {
+        send: vi.fn(async (method: string) => {
+          if (method !== "Target.getTargetInfo") {
+            return {};
+          }
+          return entry?.targetRead
+            ? await entry.targetRead()
+            : { targetInfo: targetInfoByPage.get(page) };
+        }),
+        detach: vi.fn(entry?.sessionDetach ?? (async () => {})),
+      };
+    }),
   } as unknown as import("playwright-core").BrowserContext;
+  for (const entry of entries) {
+    const page = {
+      on: vi.fn(),
+      context: () => context,
+      title: vi.fn(entry.pageTitle ?? (async () => `runtime-title:${entry.targetId}`)),
+      url: vi.fn(() => entry.url),
+    } as unknown as import("playwright-core").Page;
+    targetInfoByPage.set(page, {
+      targetId: entry.targetId,
+      title: entry.targetTitle ?? `title:${entry.targetId}`,
+    });
+    pages.push(page);
+  }
 
   const browser = {
     contexts: () => [context],
@@ -49,6 +79,10 @@ function makeBrowser(targetId: string, url: string): BrowserMockBundle {
   } as unknown as import("playwright-core").Browser;
 
   return { browser, browserClose };
+}
+
+function makeBrowser(targetId: string, url: string): BrowserMockBundle {
+  return makeBrowserWithPages([{ targetId, url }]);
 }
 
 function makeEmptyBrowser(): BrowserMockBundle {
@@ -492,6 +526,121 @@ describe("pw-session connection scoping", () => {
     expect(connectOverCdpSpy).toHaveBeenCalledTimes(2);
     await vi.waitFor(() => expect(stale.browserClose).toHaveBeenCalledTimes(1));
     expect(refreshed.browserClose).not.toHaveBeenCalled();
+  });
+
+  it("enumerates target metadata without waiting for a stuck page Runtime or detach", async () => {
+    const stuckPageTitle = vi.fn(() => new Promise<string>(() => {}));
+    const stuckSessionDetach = vi.fn(() => new Promise<void>(() => {}));
+    const healthyPageTitle = vi.fn(async () => "Runtime Healthy");
+    const browser = makeBrowserWithPages([
+      {
+        targetId: "STUCK",
+        url: "https://stuck.example",
+        pageTitle: stuckPageTitle,
+        sessionDetach: stuckSessionDetach,
+        targetTitle: "",
+      },
+      {
+        targetId: "HEALTHY",
+        url: "https://healthy.example",
+        pageTitle: healthyPageTitle,
+        targetTitle: "Healthy",
+      },
+    ]);
+    connectOverCdpSpy.mockResolvedValue(browser.browser);
+    getChromeWebSocketUrlSpy.mockResolvedValue(null);
+
+    const pages = await listPagesViaPlaywright({
+      cdpUrl: "http://127.0.0.1:9222",
+      timeoutMs: 250,
+    });
+
+    expect(pages).toEqual([
+      {
+        targetId: "STUCK",
+        title: "",
+        url: "https://stuck.example",
+        type: "page",
+      },
+      {
+        targetId: "HEALTHY",
+        title: "Healthy",
+        url: "https://healthy.example",
+        type: "page",
+      },
+    ]);
+    expect(stuckPageTitle).not.toHaveBeenCalled();
+    expect(healthyPageTitle).not.toHaveBeenCalled();
+    expect(stuckSessionDetach).toHaveBeenCalledOnce();
+    expect(browser.browserClose).not.toHaveBeenCalled();
+
+    await expect(
+      listPagesViaPlaywright({
+        cdpUrl: "http://127.0.0.1:9222",
+        timeoutMs: 250,
+      }),
+    ).resolves.toEqual(pages);
+    expect(stuckSessionDetach).toHaveBeenCalledOnce();
+    expect(browser.browser.contexts()[0]?.newCDPSession).toHaveBeenCalledTimes(3);
+  });
+
+  it("selects a healthy target after a page whose session detach stays stuck", async () => {
+    const stuckSessionDetach = vi.fn(() => new Promise<void>(() => {}));
+    const browser = makeBrowserWithPages([
+      {
+        targetId: "STUCK",
+        url: "https://stuck.example",
+        sessionDetach: stuckSessionDetach,
+      },
+      {
+        targetId: "HEALTHY",
+        url: "https://healthy.example",
+      },
+    ]);
+    connectOverCdpSpy.mockResolvedValue(browser.browser);
+    getChromeWebSocketUrlSpy.mockResolvedValue(null);
+
+    const page = await getPageForTargetId({
+      cdpUrl: "http://127.0.0.1:9222",
+      targetId: "HEALTHY",
+    });
+
+    expect(page.url()).toBe("https://healthy.example");
+    expect(stuckSessionDetach).toHaveBeenCalledOnce();
+  });
+
+  it("does not accumulate sessions when target metadata fails and detach stays stuck", async () => {
+    const targetRead = vi.fn(async () => {
+      throw new Error("Target metadata unavailable");
+    });
+    const sessionDetach = vi.fn(() => new Promise<void>(() => {}));
+    const browser = makeBrowserWithPages([
+      {
+        targetId: "STUCK",
+        url: "https://stuck.example",
+        targetRead,
+        sessionDetach,
+      },
+    ]);
+    connectOverCdpSpy.mockResolvedValue(browser.browser);
+    getChromeWebSocketUrlSpy.mockResolvedValue(null);
+
+    await expect(
+      listPagesViaPlaywright({
+        cdpUrl: "http://127.0.0.1:9222",
+        timeoutMs: 250,
+      }),
+    ).resolves.toEqual([]);
+    await expect(
+      listPagesViaPlaywright({
+        cdpUrl: "http://127.0.0.1:9222",
+        timeoutMs: 250,
+      }),
+    ).resolves.toEqual([]);
+
+    expect(targetRead).toHaveBeenCalledOnce();
+    expect(sessionDetach).toHaveBeenCalledOnce();
+    expect(browser.browser.contexts()[0]?.newCDPSession).toHaveBeenCalledOnce();
   });
 
   it("times out stuck page enumeration and evicts the scoped connection", async () => {


### PR DESCRIPTION
Related: #113787

## What Problem This Solves

On an established Playwright connection through the Chrome extension relay, one shared tab that becomes unresponsive can hang `tabs`. Because `open` and `snapshot` use the same enumeration, their target selection also waits.

## Why This Change Was Made

Page enumeration now reads titles from CDP target metadata instead of the page Runtime. Target-info reads no longer wait for Playwright’s Runtime-dependent session detach. Each Page keeps at most one target-info session while detach is pending.

Extension health now includes a capability-gated worker probe alongside its existing checks. Command replies stay on the extension socket that received them.

This does not fix cold connect. If a tab is already wedged before `connectOverCDP` starts, Playwright waits for every announced page to initialize before returning. That case remains open in #113787.

## User Impact

On an established Playwright connection through the Chrome extension relay, one wedged tab no longer prevents healthy shared tabs from being listed or selected. Repeated calls do not accumulate stuck auxiliary sessions for the affected Page. A connected but unresponsive extension now fails its health check quickly with an actionable error.

## Evidence

- Rebased production build (`CI=true node scripts/build-all.mjs`): passed
- `node scripts/check.mjs --timed`: 16 guards passed; the npm shrinkwrap guard remained stalled in two attempts and was stopped after 180 seconds and 436 seconds
- Focused regressions after rebase: 34/34 passed
- Independent adjacent-browser review after rebase: 126/126 tests passed; no findings remained within the scope of this fix
- Browser extension lane after rebase: 2,034 passed, 1 skipped, and 1 unrelated profile-qualified doctor expectation failed (`openclaw --profile craig doctor --fix` versus the unqualified expected string)
- Browser TypeScript checks, changed-file formatting and lint, and `git diff --check`: passed
- Live established-connection reproduction: listing completed in 6 ms and then 1 ms, with healthy target selection preserved
- Live cold-connect reproduction: timed out after 8 seconds; this case remains tracked in #113787
- TruffleHog scan: clean
- AI autoreview secret scan: passed. Its isolated model pass could not authenticate (401). Independent source reviews found the Runtime-dependent detach and socket-generation issues fixed in this revision.

AI-assisted: Codex helped diagnose, implement, test, and review this change. I understand its behavior and compatibility boundaries.