### PR TITLE
fix(qa): prevent leaked channel drivers during concurrent lifecycle changes

### DIFF
--- a/extensions/qa-lab/src/channel-driver-lifecycle.test.ts
+++ b/extensions/qa-lab/src/channel-driver-lifecycle.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   createQaChannelDriverLifecycle,
   runQaChannelDriverLifecycleScenarios,
+  type QaChannelDriverRuntime,
 } from "./channel-driver-lifecycle.js";
 import type { QaTransportAdapter } from "./qa-transport.js";
 
@@ -66,5 +67,107 @@ describe("QA channel driver lifecycle", () => {
     await lifecycle.start();
     await expect(lifecycle.stop()).rejects.toThrow("cleanup failed");
     expect(lifecycle.state).toEqual({ runtime, status: "running" });
+  });
+
+  it("shares one adapter between concurrent starts", async () => {
+    const runtime: QaChannelDriverRuntime = {
+      adapter: { id: "shared" } as QaTransportAdapter,
+      cleanupBeforeGatewayStop: vi.fn(async () => {}),
+      cleanupAfterGatewayStop: vi.fn(async () => {}),
+      cleanupWithoutGateway: vi.fn(async () => {}),
+    };
+    const createAdapter = vi.fn(async () => runtime);
+    const lifecycle = createQaChannelDriverLifecycle(
+      { channelId: "matrix", driver: "live", outputDir: "/tmp/matrix-lifecycle" },
+      { createAdapter, listAdapterFactories: () => [] },
+    );
+
+    const runtimes = await Promise.all([lifecycle.start(), lifecycle.start(), lifecycle.start()]);
+
+    expect(runtimes).toEqual([runtime, runtime, runtime]);
+    expect(createAdapter).toHaveBeenCalledOnce();
+    expect(lifecycle.state).toEqual({ runtime, status: "running" });
+  });
+
+  it("cleans an adapter when stop arrives during startup", async () => {
+    const runtime: QaChannelDriverRuntime = {
+      adapter: { id: "pending" } as QaTransportAdapter,
+      cleanupBeforeGatewayStop: vi.fn(async () => {}),
+      cleanupAfterGatewayStop: vi.fn(async () => {}),
+      cleanupWithoutGateway: vi.fn(async () => {}),
+    };
+    let resolveStartup: (runtime: QaChannelDriverRuntime) => void = () => {};
+    const startup = new Promise<QaChannelDriverRuntime>((resolve) => {
+      resolveStartup = resolve;
+    });
+    const createAdapter = vi.fn(() => startup);
+    const lifecycle = createQaChannelDriverLifecycle(
+      { channelId: "matrix", driver: "live", outputDir: "/tmp/matrix-lifecycle" },
+      { createAdapter, listAdapterFactories: () => [] },
+    );
+
+    const starting = lifecycle.start();
+    await vi.waitFor(() => expect(createAdapter).toHaveBeenCalledOnce());
+    const stopping = lifecycle.stop();
+    resolveStartup(runtime);
+
+    await expect(starting).resolves.toBe(runtime);
+    await expect(stopping).resolves.toBeUndefined();
+    expect(runtime.cleanupWithoutGateway).toHaveBeenCalledOnce();
+    expect(lifecycle.state).toEqual({ status: "stopped" });
+  });
+
+  it("retries startup after a failed lifecycle transition", async () => {
+    const runtime: QaChannelDriverRuntime = {
+      adapter: { id: "recovered" } as QaTransportAdapter,
+      cleanupBeforeGatewayStop: vi.fn(async () => {}),
+      cleanupAfterGatewayStop: vi.fn(async () => {}),
+      cleanupWithoutGateway: vi.fn(async () => {}),
+    };
+    const createAdapter = vi
+      .fn<() => Promise<QaChannelDriverRuntime>>()
+      .mockRejectedValueOnce(new Error("adapter startup failed"))
+      .mockResolvedValueOnce(runtime);
+    const lifecycle = createQaChannelDriverLifecycle(
+      { channelId: "matrix", driver: "live", outputDir: "/tmp/matrix-lifecycle" },
+      { createAdapter, listAdapterFactories: () => [] },
+    );
+
+    await expect(lifecycle.start()).rejects.toThrow("adapter startup failed");
+    await expect(lifecycle.start()).resolves.toBe(runtime);
+    expect(createAdapter).toHaveBeenCalledTimes(2);
+    expect(lifecycle.state).toEqual({ runtime, status: "running" });
+  });
+
+  it("finishes each restart before starting the next transition", async () => {
+    const events: string[] = [];
+    let nextId = 0;
+    const createAdapter = vi.fn(async (): Promise<QaChannelDriverRuntime> => {
+      const id = String(++nextId);
+      events.push(`start:${id}`);
+      return {
+        adapter: { id } as QaTransportAdapter,
+        cleanupBeforeGatewayStop: vi.fn(async () => {}),
+        cleanupAfterGatewayStop: vi.fn(async () => {}),
+        cleanupWithoutGateway: vi.fn(async () => {
+          events.push(`stop:${id}`);
+        }),
+      };
+    });
+    const lifecycle = createQaChannelDriverLifecycle(
+      { channelId: "matrix", driver: "live", outputDir: "/tmp/matrix-lifecycle" },
+      { createAdapter, listAdapterFactories: () => [] },
+    );
+    await lifecycle.start();
+
+    const [firstRestart, secondRestart] = await Promise.all([
+      lifecycle.restart(),
+      lifecycle.restart(),
+    ]);
+
+    expect(firstRestart.adapter.id).toBe("2");
+    expect(secondRestart.adapter.id).toBe("3");
+    expect(events).toEqual(["start:1", "stop:1", "start:2", "stop:2", "start:3"]);
+    expect(lifecycle.state).toEqual({ runtime: secondRestart, status: "running" });
   });
 });

--- a/extensions/qa-lab/src/channel-driver-lifecycle.ts
+++ b/extensions/qa-lab/src/channel-driver-lifecycle.ts
@@ -49,36 +49,57 @@ export function createQaChannelDriverLifecycle(
   const createAdapter = deps.createAdapter ?? createQaTransportAdapter;
   const discoverAdapterFactories = deps.listAdapterFactories ?? listAdapterFactories;
   let state: QaChannelDriverLifecycleState = { status: "stopped" };
+  let transition = Promise.resolve();
+
+  // Serialize adapter ownership so overlapping lifecycle calls cannot leak a
+  // late-started runtime or clean the same live transport twice.
+  const enqueueTransition = <T>(operation: () => Promise<T>): Promise<T> => {
+    const result = transition.then(operation);
+    transition = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
+  };
+
+  const startRuntime = async (): Promise<QaChannelDriverRuntime> => {
+    if (state.status === "running") {
+      return state.runtime;
+    }
+    const runtime = await createAdapter(
+      {
+        ...params,
+        state: createQaBusState(),
+      },
+      await discoverAdapterFactories(),
+    );
+    state = { runtime, status: "running" };
+    return runtime;
+  };
+
+  const stopRuntime = async (): Promise<void> => {
+    if (state.status === "stopped") {
+      return;
+    }
+    await state.runtime.cleanupWithoutGateway();
+    state = { status: "stopped" };
+  };
 
   const lifecycle: QaChannelDriverLifecycle = {
     get state() {
       return state;
     },
-    async restart() {
-      await lifecycle.stop();
-      return await lifecycle.start();
+    restart() {
+      return enqueueTransition(async () => {
+        await stopRuntime();
+        return await startRuntime();
+      });
     },
-    async start() {
-      if (state.status === "running") {
-        return state.runtime;
-      }
-      const runtime = await createAdapter(
-        {
-          ...params,
-          state: createQaBusState(),
-        },
-        await discoverAdapterFactories(),
-      );
-      state = { runtime, status: "running" };
-      return runtime;
+    start() {
+      return enqueueTransition(startRuntime);
     },
-    async stop() {
-      if (state.status === "stopped") {
-        return;
-      }
-      const runtime = state.runtime;
-      await runtime.cleanupWithoutGateway();
-      state = { status: "stopped" };
+    stop() {
+      return enqueueTransition(stopRuntime);
     },
   };
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where concurrent QA channel lifecycle operations could start duplicate Matrix or Crabline adapters, leave a late-started adapter running after an operator requested a stop, or clean an old adapter twice during overlapping restarts.

## Why This Change Was Made

Keep adapter creation, cleanup, and state ownership in the canonical QA channel driver lifecycle. Serialize start, stop, and restart through one failure-resilient transition chain so restart is atomic, cleanup failures preserve the running adapter, and later operations can recover after a rejected transition. No public configuration, Gateway protocol, persistent state, or production channel behavior changes.

## User Impact

QA operators and live Matrix or Crabline driver runs now receive exactly one owned adapter, a completed stop actually cleans a startup already in flight, and concurrent restarts cannot leak live transports or corrupt lifecycle evidence.

## Evidence

- Frozen baseline: `d8f099ebede31734980e18afb916e21bd4486ba2`.
- Regression-first remote proof: three deterministic failures on unmodified main demonstrated triplicate adapter creation, zero cleanup after stop during startup, and duplicate old-adapter cleanup during racing restarts.
- Final remote regression and sibling proof: 17 QA test files; **555 passed, 0 failed**. Includes lifecycle, transport registry, QA channel transport, scenario catalog, scenario lanes, provider 503/mock OpenAI, scorecard/evidence, CLI, Multipass, unified native runners, and the merged fail-fast path.
- Real isolated source-checkout mock Gateway: `provider-http-503-visible-failure` and `dm-chat-baseline`; **2 passed, 0 failed**.
- Real isolated source-checkout OpenAI Gateway: `live-frontier`, `openai/gpt-5.4`, `dm-chat-baseline`; **1 passed, 0 failed**.
- Complete remote `pnpm check:changed`: **passed**, including extension and test typechecking, formatting, zero lint findings, API/boundary guards, and zero runtime import cycles.
- Fresh independent high-effort Codex review: **patch is correct**, confidence **0.94**, no actionable findings; TruffleHog clean.
- Risk: low; two source-only private QA lifecycle files, no operator Gateway or soak process touched.