### PR TITLE
fix(package): prevent installs from deleting the Control UI

### DIFF
--- a/scripts/check-openclaw-package-tarball.mjs
+++ b/scripts/check-openclaw-package-tarball.mjs
@@ -445,9 +445,10 @@ for (const requiredPrefix of REQUIRED_TARBALL_ENTRY_PREFIXES) {
   }
 }
 let packageVersion = "";
+let packageJson = null;
 if (entrySet.has("package.json")) {
   try {
-    const packageJson = JSON.parse(readTarEntry("package.json"));
+    packageJson = JSON.parse(readTarEntry("package.json"));
     packageVersion = typeof packageJson.version === "string" ? packageJson.version : "";
     errors.push(...collectWorkspaceProtocolDependencyErrors(packageJson, "package.json"));
     if (cliArgs.requireBundledWorkspaceDeps) {
@@ -548,6 +549,23 @@ if (entrySet.has("dist/postinstall-inventory.json")) {
         errors.push(
           `package dist inventory must omit install guard ${PACKAGE_INSTALL_GUARD_RELATIVE_PATH}`,
         );
+      }
+      if (typeof packageJson?.scripts?.postinstall === "string") {
+        // Postinstall prunes every uninventoried dist file, including dashboard
+        // assets that cannot be recovered from the JavaScript import graph.
+        const requiredControlUiInventoryEntries = new Set([
+          ...REQUIRED_TARBALL_ENTRIES.filter((entry) => entry.startsWith("dist/")),
+          ...normalized.filter(
+            (entry) =>
+              REQUIRED_TARBALL_ENTRY_PREFIXES.some((prefix) => entry.startsWith(prefix)) &&
+              fs.statSync(path.join(extractedPackageRoot, entry)).isFile(),
+          ),
+        ]);
+        for (const requiredEntry of requiredControlUiInventoryEntries) {
+          if (!normalizedInventorySet.has(requiredEntry)) {
+            errors.push(`postinstall inventory omits Control UI file ${requiredEntry}`);
+          }
+        }
       }
       packageDistImports = runPhase("dist import graph", () =>
         collectPackageDistImports({

--- a/test/scripts/check-openclaw-package-tarball-control-ui.test.ts
+++ b/test/scripts/check-openclaw-package-tarball-control-ui.test.ts
@@ -1,0 +1,203 @@
+import { spawnSync } from "node:child_process";
+import { copyFileSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { WORKSPACE_TEMPLATE_PACK_PATHS } from "../../scripts/lib/workspace-bootstrap-smoke.mjs";
+
+const CONTROL_UI_INDEX = "dist/control-ui/index.html";
+const CONTROL_UI_ASSETS = [
+  "dist/control-ui/assets/app.js",
+  "dist/control-ui/assets/app.js.br",
+  "dist/control-ui/assets/app.js.gz",
+] as const;
+const CONTROL_UI_FILES = [CONTROL_UI_INDEX, ...CONTROL_UI_ASSETS];
+const CHECK_SCRIPT = resolve("scripts/check-openclaw-package-tarball.mjs");
+
+function writeFixtureFile(packageRoot: string, relativePath: string, content: string): void {
+  const filePath = join(packageRoot, relativePath);
+  mkdirSync(dirname(filePath), { recursive: true });
+  writeFileSync(filePath, content);
+}
+
+function withPackedPackage(
+  inventory: readonly string[],
+  run: (fixture: { root: string; tarball: string }) => void,
+  options: { postinstall?: boolean } = {},
+): void {
+  const root = mkdtempSync(join(tmpdir(), "openclaw-control-ui-package-inventory-"));
+  const packageRoot = join(root, "package");
+  try {
+    mkdirSync(packageRoot, { recursive: true });
+    const version = "2026.7.2";
+    writeFixtureFile(
+      packageRoot,
+      "package.json",
+      JSON.stringify({
+        name: "openclaw",
+        version,
+        type: "module",
+        ...(options.postinstall === false
+          ? {}
+          : { scripts: { postinstall: "node scripts/postinstall-bundled-plugins.mjs" } }),
+      }),
+    );
+    writeFixtureFile(
+      packageRoot,
+      "npm-shrinkwrap.json",
+      JSON.stringify({
+        name: "openclaw",
+        version,
+        lockfileVersion: 3,
+        packages: { "": { name: "openclaw", version } },
+      }),
+    );
+    writeFixtureFile(packageRoot, "dist/postinstall-inventory.json", JSON.stringify(inventory));
+    writeFixtureFile(packageRoot, "dist/index.js", "export {};\n");
+    writeFixtureFile(
+      packageRoot,
+      CONTROL_UI_INDEX,
+      '<!doctype html><script type="module" src="./assets/app.js"></script>\n',
+    );
+    for (const assetPath of CONTROL_UI_ASSETS) {
+      writeFixtureFile(packageRoot, assetPath, "shipped Control UI asset\n");
+    }
+    writeFixtureFile(
+      packageRoot,
+      "dist/openclaw-install-guard",
+      "OpenClaw package preinstall has not completed.\n",
+    );
+    for (const relativePath of WORKSPACE_TEMPLATE_PACK_PATHS) {
+      writeFixtureFile(packageRoot, relativePath, `# ${relativePath}\n`);
+    }
+    for (const relativePath of [
+      "scripts/postinstall-bundled-plugins.mjs",
+      "scripts/lib/package-dist-imports.mjs",
+    ]) {
+      const destination = join(packageRoot, relativePath);
+      mkdirSync(dirname(destination), { recursive: true });
+      copyFileSync(resolve(relativePath), destination);
+    }
+
+    const packed = spawnSync(
+      "npm",
+      ["pack", "--ignore-scripts", "--json", "--pack-destination", root],
+      { cwd: packageRoot, encoding: "utf8", timeout: 30_000 },
+    );
+    expect(packed.status, packed.stderr || packed.error?.message).toBe(0);
+    const [{ filename }] = JSON.parse(packed.stdout) as [{ filename: string }];
+    const tarball = join(root, filename);
+    expect(existsSync(tarball)).toBe(true);
+    run({ root, tarball });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function checkPackedPackage(tarball: string) {
+  return spawnSync(process.execPath, [CHECK_SCRIPT, tarball], {
+    encoding: "utf8",
+    timeout: 30_000,
+  });
+}
+
+function installPackedPackage(root: string, tarball: string) {
+  const home = join(root, "home");
+  const state = join(root, "state");
+  const temporary = join(root, "tmp");
+  for (const directory of [home, state, temporary]) {
+    mkdirSync(directory, { recursive: true });
+  }
+  const installRoot = join(root, "installed");
+  const result = spawnSync(
+    "npm",
+    [
+      "install",
+      "--foreground-scripts",
+      "--prefix",
+      installRoot,
+      "--no-audit",
+      "--no-fund",
+      "--offline",
+      tarball,
+    ],
+    {
+      encoding: "utf8",
+      timeout: 30_000,
+      env: {
+        ...process.env,
+        HOME: home,
+        OPENCLAW_HOME: home,
+        OPENCLAW_STATE_DIR: state,
+        OPENCLAW_CONFIG_PATH: join(state, "openclaw.json"),
+        TMPDIR: temporary,
+        TMP: temporary,
+        TEMP: temporary,
+      },
+    },
+  );
+  expect(result.status, result.stderr || result.error?.message).toBe(0);
+  expect(result.stdout).toContain("scripts/postinstall-bundled-plugins.mjs");
+  return join(installRoot, "node_modules", "openclaw");
+}
+
+describe("packaged Control UI postinstall inventory", () => {
+  it.each(CONTROL_UI_FILES)(
+    "rejects a real npm package when postinstall would delete %s",
+    (omittedFile) => {
+      const inventory = ["dist/index.js", ...CONTROL_UI_FILES].filter(
+        (relativePath) => relativePath !== omittedFile,
+      );
+      withPackedPackage(inventory, ({ tarball }) => {
+        const result = checkPackedPackage(tarball);
+
+        expect(result.status, result.stdout).not.toBe(0);
+        expect(result.stderr).toContain(
+          `postinstall inventory omits Control UI file ${omittedFile}`,
+        );
+      });
+    },
+  );
+
+  it("proves actual npm postinstall deletes an omitted dashboard from a falsely accepted package", () => {
+    withPackedPackage(["dist/index.js"], ({ root, tarball }) => {
+      const validation = checkPackedPackage(tarball);
+      const installedPackageRoot = installPackedPackage(root, tarball);
+      expect(existsSync(join(installedPackageRoot, "dist/index.js"))).toBe(true);
+      for (const relativePath of CONTROL_UI_FILES) {
+        expect(existsSync(join(installedPackageRoot, relativePath))).toBe(false);
+      }
+
+      expect(validation.status, validation.stdout).not.toBe(0);
+      expect(validation.stderr).toContain(
+        "postinstall inventory omits Control UI file dist/control-ui/index.html",
+      );
+    });
+  });
+
+  it("accepts a packaged dashboard whose complete UI survives postinstall", () => {
+    withPackedPackage(["dist/index.js", ...CONTROL_UI_FILES], ({ root, tarball }) => {
+      const result = checkPackedPackage(tarball);
+
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.stdout).toContain("OpenClaw package tarball integrity passed.");
+
+      const installedPackageRoot = installPackedPackage(root, tarball);
+      for (const relativePath of CONTROL_UI_FILES) {
+        expect(existsSync(join(installedPackageRoot, relativePath))).toBe(true);
+      }
+    });
+  });
+
+  it("does not impose postinstall inventory rules on lifecycle-free archived fixtures", () => {
+    withPackedPackage(
+      ["dist/index.js"],
+      ({ tarball }) => {
+        const result = checkPackedPackage(tarball);
+
+        expect(result.status, result.stderr).toBe(0);
+      },
+      { postinstall: false },
+    );
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users installing or updating a built OpenClaw package can lose the Control UI because installation deletes the dashboard HTML, JavaScript, Brotli, or gzip assets even though the release tarball passed its integrity checks.

## Why This Change Was Made

Validate that every existing required dashboard artifact is present in the canonical postinstall inventory before accepting a package that actually declares a postinstall lifecycle. Reuse the existing package artifact contracts and preserve import-closure validation, installation guard exclusions, and historical packages without a postinstall lifecycle.

## User Impact

Users retain a complete working Control UI after installation and updates. Invalid release tarballs are rejected before distribution instead of silently deleting dashboard assets during installation.

## Evidence

- Independently reproduced on current `main` with a real npm package: the old checker accepted physically present Control UI HTML, JavaScript, Brotli, and gzip assets omitted from the inventory, and real postinstall deleted them.
- Seven dedicated regressions exercise actual `npm pack`, actual offline `npm install --foreground-scripts`, each corrupt asset class, a healthy real install, and historical lifecycle-free packages.
- 130 focused tests pass across the new regression, existing tarball checker, packaged postinstall, package inventory, prepack, and Docker package suites; three platform/condition-specific Docker cases are expected skips.
- The complete changed gate passes, including all package guards, 241 script declaration contracts, root-test typechecking, formatting, and script lint.
- A complete production build and canonical verified release tarball pass. Two real foreground npm installs, with the Node compile cache both disabled and enabled, each retain and inventory all 903 dashboard files, including Brotli and gzip assets, while preserving four unrelated cache sentinels. The installed CLI reports `OpenClaw 2026.7.2 (d8f099e)`.
- Independent blind reproduction; fresh structured high-effort independent review found no actionable issues; secret scan clean.
- AI-assisted.
