### PR TITLE
perf(sessions): reuse process-held sqlite handles for read-only reads

### DIFF
--- a/src/gateway/server.sessions.list-connection-reuse.test.ts
+++ b/src/gateway/server.sessions.list-connection-reuse.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Read-only session reads reuse a handle this process already holds.
+ * Opening a connection per call made sessions.list cost scale with row count,
+ * because row projection and sharing resolution each read per row.
+ */
+import { expect, test, vi } from "vitest";
+import * as nodeSqlite from "../infra/node-sqlite.js";
+import { writeSessionStore } from "./test-helpers.js";
+import {
+  directSessionReq,
+  sessionStoreEntry,
+  setupGatewaySessionsTestHarness,
+} from "./test/server-sessions.test-helpers.js";
+
+const { createSessionStoreDir } = setupGatewaySessionsTestHarness();
+
+const LIST_PARAMS = {
+  agentId: "main",
+  configuredAgentsOnly: true,
+  includeDerivedTitles: true,
+  includeGlobal: true,
+  includeUnknown: true,
+  limit: 100,
+};
+
+async function countConnectionOpensForRows(rows: number): Promise<number> {
+  await createSessionStoreDir();
+  const entries: Record<string, ReturnType<typeof sessionStoreEntry>> = {
+    main: sessionStoreEntry("sess-main"),
+  };
+  for (let index = 0; index < rows; index++) {
+    entries[`agent:main:row-${index}`] = sessionStoreEntry(`sess-row-${index}`, {
+      updatedAt: 1_781_000_000_000 - index * 1_000,
+    });
+  }
+  await writeSessionStore({ entries });
+  // Warm lazily-initialized module state so only steady-state reads are counted.
+  await directSessionReq("sessions.list", LIST_PARAMS);
+
+  const spy = vi.spyOn(nodeSqlite, "openNodeSqliteDatabase");
+  try {
+    const result = await directSessionReq("sessions.list", LIST_PARAMS);
+    expect(result.ok).toBe(true);
+    return spy.mock.calls.length;
+  } finally {
+    spy.mockRestore();
+  }
+}
+
+test("sessions.list connection opens do not scale with row count", async () => {
+  const small = await countConnectionOpensForRows(5);
+  const large = await countConnectionOpensForRows(40);
+
+  // A connection per read would put `large` roughly 35 opens above `small`.
+  expect(large).toBeLessThanOrEqual(small + 2);
+});

--- a/src/state/openclaw-agent-db-readonly.ts
+++ b/src/state/openclaw-agent-db-readonly.ts
@@ -3,7 +3,10 @@ import type { DatabaseSync } from "node:sqlite";
 import { clearNodeSqliteKyselyCacheForDatabase } from "../infra/kysely-sync.js";
 import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
 import { normalizeAgentId } from "../routing/session-key.js";
-import type { OpenClawAgentDatabaseOptions } from "./openclaw-agent-db-contract.js";
+import type {
+  OpenClawAgentDatabase,
+  OpenClawAgentDatabaseOptions,
+} from "./openclaw-agent-db-contract.js";
 import {
   assertCanonicalAgentMediaPersistenceVersion,
   assertExistingAgentSchemaOwner,
@@ -35,6 +38,23 @@ function isMissingTableError(error: unknown): boolean {
   );
 }
 
+/**
+ * Look up a process-held handle without adopting writer-side failures.
+ *
+ * Read-only reads are meant to survive a latched open failure or an ownership
+ * mismatch that only the writable lifecycle cares about; those callers fall
+ * back to a fresh connection, which reports the precise reason.
+ */
+function findOpenAgentDatabase(
+  options: OpenClawAgentDatabaseOptions,
+): OpenClawAgentDatabase | undefined {
+  try {
+    return getOpenClawAgentDatabaseIfOpen(options);
+  } catch {
+    return undefined;
+  }
+}
+
 /** Read agent state without creating, registering, migrating, or joining its writable lifecycle. */
 export function withOpenClawAgentDatabaseReadOnly<T>(
   operation: (database: OpenClawAgentReadOnlyDatabase) => T,
@@ -49,6 +69,24 @@ export function withOpenClawAgentDatabaseReadOnly<T>(
     return database
       ? { found: true, value: operation(database) }
       : { found: false, reason: "database-missing" };
+  }
+  // Reusing a handle this process already holds is what keeps row loops cheap:
+  // opening and closing a connection per call made reads scale with row count.
+  // An in-flight transaction is skipped so callers never observe uncommitted
+  // rows that a fresh read-only connection could not have seen.
+  const opened = findOpenAgentDatabase({ ...options, agentId });
+  if (opened && !opened.db.isTransaction) {
+    // A newer build can migrate this file while the handle stays open, so the
+    // forward-compatibility gate still runs before any reused read.
+    assertSupportedAgentSchemaVersion(opened.db, pathname);
+    try {
+      return { found: true, value: operation(opened) };
+    } catch (error) {
+      if (isMissingTableError(error)) {
+        return { found: false, reason: "table-missing" };
+      }
+      throw error;
+    }
   }
   if (!fs.existsSync(pathname)) {
     return { found: false, reason: "database-missing" };

--- a/src/state/openclaw-agent-db-registry.ts
+++ b/src/state/openclaw-agent-db-registry.ts
@@ -9,14 +9,8 @@ import {
   statSync,
 } from "node:fs";
 import path from "node:path";
-import {
-  clearNodeSqliteKyselyCacheForDatabase,
-  executeSqliteQuerySync,
-  getNodeSqliteKysely,
-} from "../infra/kysely-sync.js";
-import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
+import { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
 import { resolveSqliteDatabaseFilePaths } from "../infra/sqlite-files.js";
-import { readSqliteUserVersion } from "../infra/sqlite-user-version.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import {
   assertAgentDeletionPathFence,
@@ -26,11 +20,10 @@ import {
   OPENCLAW_AGENT_SCHEMA_VERSION,
   type OpenClawRegisteredAgentDatabase,
 } from "./openclaw-agent-db-contract.js";
+import { withOpenClawStateDatabaseReadOnly } from "./openclaw-state-db-readonly.js";
+import { detectOpenClawStateDatabaseSchemaMigrationsFromDatabase } from "./openclaw-state-db-schema-repair.js";
 import type { DB as OpenClawStateKyselyDatabase } from "./openclaw-state-db.generated.js";
 import {
-  detectOpenClawStateDatabaseSchemaMigrations,
-  OPENCLAW_SQLITE_BUSY_TIMEOUT_MS,
-  OPENCLAW_STATE_SCHEMA_VERSION,
   runOpenClawStateWriteTransaction,
   type OpenClawStateDatabaseOptions,
 } from "./openclaw-state-db.js";
@@ -702,20 +695,13 @@ export function listOpenClawRegisteredAgentDatabases(
     }
     return [];
   }
-  if (detectOpenClawStateDatabaseSchemaMigrations(options).length > 0) {
-    throw new Error(
-      `OpenClaw state database ${pathname} has a legacy agent database registry schema; run openclaw doctor --fix to migrate it.`,
-    );
-  }
-
-  const database = openNodeSqliteDatabase(pathname, {
-    readOnly: true,
-  });
-  try {
-    database.exec(`PRAGMA busy_timeout = ${OPENCLAW_SQLITE_BUSY_TIMEOUT_MS};`);
-    if (readSqliteUserVersion(database) > OPENCLAW_STATE_SCHEMA_VERSION) {
+  // Discovery runs per row in list hot paths, so the legacy-schema gate and the
+  // query share one process-held state handle instead of opening two
+  // connections per call.
+  return withOpenClawStateDatabaseReadOnly(({ db: database }) => {
+    if (detectOpenClawStateDatabaseSchemaMigrationsFromDatabase(database, pathname).length > 0) {
       throw new Error(
-        `OpenClaw state database ${pathname} uses a newer schema than this OpenClaw build.`,
+        `OpenClaw state database ${pathname} has a legacy agent database registry schema; run openclaw doctor --fix to migrate it.`,
       );
     }
     const registryTable = database
@@ -743,8 +729,5 @@ export function listOpenClawRegisteredAgentDatabases(
       lastSeenAt: row.last_seen_at,
       sizeBytes: row.size_bytes,
     }));
-  } finally {
-    clearNodeSqliteKyselyCacheForDatabase(database);
-    database.close();
-  }
+  }, options);
 }

--- a/src/state/openclaw-agent-db.ts
+++ b/src/state/openclaw-agent-db.ts
@@ -182,6 +182,14 @@ export function inspectOpenClawAgentDatabaseOwner(
 ): OpenClawAgentDatabaseOwnerInspection {
   let db: DatabaseSync | undefined;
   try {
+    // A handle this process holds was owner-validated when it was opened, and
+    // ownership never changes afterwards. Answering from it keeps store
+    // resolution off a fresh connection for every row it inspects.
+    const opened = cachedDatabases.get(path.resolve(pathname));
+    if (opened?.db.isOpen) {
+      assertSupportedAgentSchemaVersion(opened.db, pathname);
+      return { status: "owned", agentId: opened.agentId };
+    }
     db = openNodeSqliteDatabase(pathname, { readOnly: true });
     db.exec(`PRAGMA busy_timeout = ${OPENCLAW_SQLITE_BUSY_TIMEOUT_MS};`);
     assertSupportedAgentSchemaVersion(db, pathname);

--- a/src/state/openclaw-state-db-readonly.ts
+++ b/src/state/openclaw-state-db-readonly.ts
@@ -7,6 +7,7 @@ import {
   readSqliteUserVersion,
 } from "../infra/sqlite-user-version.js";
 import {
+  getOpenClawStateDatabaseIfOpen,
   OPENCLAW_SQLITE_BUSY_TIMEOUT_MS,
   OPENCLAW_STATE_SCHEMA_VERSION,
   type OpenClawStateDatabaseOptions,
@@ -43,6 +44,17 @@ export function withOpenClawStateDatabaseReadOnly<T>(
   const pathname = path.resolve(
     options.path ?? resolveOpenClawStateSqlitePath(options.env ?? process.env),
   );
+  // Reusing a handle this process already holds keeps row loops cheap: opening
+  // and closing a connection per call made shared-state reads scale with row
+  // count. An in-flight transaction is skipped so callers never observe
+  // uncommitted rows a fresh read-only connection could not have seen.
+  const opened = getOpenClawStateDatabaseIfOpen(options);
+  if (opened && !opened.db.isTransaction) {
+    // A newer build can migrate this file while the handle stays open, so the
+    // forward-compatibility gate still runs before any reused read.
+    assertSupportedSchemaVersion(opened.db, pathname);
+    return operation(opened);
+  }
   const db = openNodeSqliteDatabase(pathname, { readOnly: true });
   try {
     db.exec(`PRAGMA busy_timeout = ${OPENCLAW_SQLITE_BUSY_TIMEOUT_MS};`);

--- a/src/state/openclaw-state-db-schema-repair.ts
+++ b/src/state/openclaw-state-db-schema-repair.ts
@@ -171,25 +171,36 @@ export function detectOpenClawStateDatabaseSchemaMigrations(
   }
   const db = openNodeSqliteDatabase(pathname, { readOnly: true });
   try {
-    const migrations: OpenClawStateDatabaseSchemaMigration[] = [];
-    const userVersion = readSqliteUserVersion(db);
-    if (!hasCanonicalAgentDatabasesPrimaryKey(db)) {
-      migrations.push({ kind: "agent-databases-composite-primary-key", path: pathname });
-    }
-    if (!hasCanonicalAuditEventsSchema(db)) {
-      migrations.push({ kind: "audit-events-v2", path: pathname });
-    }
-    if (tableExists(db, "audit_events") && userVersion < OPENCLAW_STATE_STRICT_SCHEMA_VERSION) {
-      migrations.push({ kind: "strict-tables-v3", path: pathname });
-    }
-    if (sessionWatchMigration.needsSessionWatchCursorProvenanceMigration(db, userVersion)) {
-      migrations.push({ kind: "session-watch-cursor-provenance-v4", path: pathname });
-    }
-    migrations.push(
-      ...operatorApprovalMigration.detectOperatorApprovalSchemaMigration(db, pathname),
-    );
-    return migrations;
+    return detectOpenClawStateDatabaseSchemaMigrationsFromDatabase(db, pathname);
   } finally {
     db.close();
   }
+}
+
+/**
+ * Detect migrations against a caller-owned handle.
+ *
+ * Registry discovery runs this per lookup while already holding a state
+ * connection; opening a second one there made reads scale with row count.
+ */
+export function detectOpenClawStateDatabaseSchemaMigrationsFromDatabase(
+  db: DatabaseSync,
+  pathname: string,
+): OpenClawStateDatabaseSchemaMigration[] {
+  const migrations: OpenClawStateDatabaseSchemaMigration[] = [];
+  const userVersion = readSqliteUserVersion(db);
+  if (!hasCanonicalAgentDatabasesPrimaryKey(db)) {
+    migrations.push({ kind: "agent-databases-composite-primary-key", path: pathname });
+  }
+  if (!hasCanonicalAuditEventsSchema(db)) {
+    migrations.push({ kind: "audit-events-v2", path: pathname });
+  }
+  if (tableExists(db, "audit_events") && userVersion < OPENCLAW_STATE_STRICT_SCHEMA_VERSION) {
+    migrations.push({ kind: "strict-tables-v3", path: pathname });
+  }
+  if (sessionWatchMigration.needsSessionWatchCursorProvenanceMigration(db, userVersion)) {
+    migrations.push({ kind: "session-watch-cursor-provenance-v4", path: pathname });
+  }
+  migrations.push(...operatorApprovalMigration.detectOperatorApprovalSchemaMigration(db, pathname));
+  return migrations;
 }

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -550,6 +550,19 @@ export function runOpenClawStateWriteTransaction<T>(
   return result;
 }
 
+/**
+ * Return a shared state handle this process already holds open, if any.
+ *
+ * Read-only callers use this to avoid opening a connection per call; it never
+ * creates, repairs, or registers a handle.
+ */
+export function getOpenClawStateDatabaseIfOpen(
+  options: OpenClawStateDatabaseOptions = {},
+): OpenClawStateDatabase | undefined {
+  const cached = cachedDatabases.get(resolveDatabasePath(options));
+  return cached?.db.isOpen ? cached : undefined;
+}
+
 /** Close one cached shared state database handle by exact pathname. */
 export function closeOpenClawStateDatabaseByPath(pathname: string): boolean {
   const resolvedPath = path.resolve(pathname);


### PR DESCRIPTION
## What Problem This Solves

`sessions.list` opened and closed a SQLite connection many times per row, so
listing cost grew with the number of sessions. Four read paths the row loop
calls each opened their own connection per invocation:

- `withOpenClawAgentDatabaseReadOnly` — row projection and ACP thinking metadata
- `withOpenClawStateDatabaseReadOnly` — persisted plugin index
- `listOpenClawRegisteredAgentDatabases` — store discovery, which additionally
  called `detectOpenClawStateDatabaseSchemaMigrations` and so opened a *second*
  connection on every lookup
- `inspectOpenClawAgentDatabaseOwner` — session store target resolution

Measured against a real `sessions.list` RPC round trip with 40 sessions:
**675 connection opens**. In the Control UI this shows up as slow sidebar
refreshes on large stores, and it is what remains of the multi-select archive
stall after PR #113623 collapsed the batch to a single list call.

## Why This Change Was Made

The fix belongs in the read helpers rather than in any one caller. This process
already holds validated handles for the shared state database and for each agent
database, so read-only callers reuse them instead of opening a new connection:

- Both `*ReadOnly` helpers reuse a process-held handle, and skip the reuse while
  that handle is inside a write transaction, so callers never observe
  uncommitted rows a fresh read-only connection could not have seen.
- Reused reads still run the forward-schema compatibility gate, so a newer build
  migrating the file under an open handle is reported rather than queried.
- `detectOpenClawStateDatabaseSchemaMigrations` gained a db-taking core, letting
  the registry listing run its legacy-schema gate and its query on one handle.
- `inspectOpenClawAgentDatabaseOwner` answers from the path-keyed handle cache,
  whose `agentId` was owner-validated at open. It stays inside the existing error
  handling, so a newer-schema file still reports `unreadable`.
- The agent-side lookup does not adopt writer-side failures: a latched open
  failure or ownership mismatch falls through to a fresh read-only connection,
  which is what a read path meant to survive an unhappy writer requires.

Two alternatives were tried and dropped, both for correctness rather than
performance. A `PRAGMA data_version` freshness cache has to retain an open
handle (which blocks database replacement on Windows), its versions are not
comparable across replaced connections, and it mis-handles in-transaction reads.
A memo on the registry listing goes stale when another process registers an
agent, and became pointless once the listing shared the process handle.

## User Impact

Session listing no longer pays per-row connection setup, so large session lists
— including the sidebar refresh after a multi-select archive — return materially
faster. No protocol, config, or storage contract changes.

## Evidence

- New guard test `src/gateway/server.sessions.list-connection-reuse.test.ts`
  spies on `openNodeSqliteDatabase` across a real `sessions.list` RPC and asserts
  opens do not scale with row count (5 rows vs 40).
- Connection opens for a 40-row `sessions.list`: **675 → 0**.
- `node --import tsx scripts/check-import-cycles.ts` — 0 runtime value cycles.
  (An earlier module extraction introduced one; it was removed rather than
  suppressed.)
- `node scripts/run-vitest.mjs src/state` — 283 passed, 6 skipped.
- `node scripts/run-vitest.mjs src/config/sessions` — 688 passed.
- `node scripts/run-vitest.mjs <42 gateway sessions files>` — 586 passed, plus
  29 in the sessions-patch project.
- `oxlint` and `tsgo` clean on the touched files.
- Codex autoreview clean: "no accepted/actionable findings". An earlier round
  correctly caught that the reused-handle path skipped the forward-schema
  compatibility gate; that guard now runs on every reused read.

Note on local runs: this machine was shared with other heavy jobs (load average
~174), which produced non-repeating timeouts in timing-sensitive
`src/config/sessions` cases. Each rerun failed a different test or none, and a
clean run gave 688/688; hosted CI is the authoritative gate.
