### PR TITLE
fix(doctor): prevent external channel config corruption during upgrade

### DIFF
--- a/src/commands/doctor/shared/allowfrom-fallback-migration.test.ts
+++ b/src/commands/doctor/shared/allowfrom-fallback-migration.test.ts
@@ -130,4 +130,21 @@ describe("doctor group allowFrom fallback migration", () => {
 
     expect(maybeRepairGroupAllowFromFallback(cfg)).toEqual({ config: cfg, changes: [] });
   });
+
+  it("skips external channels whose config schema core cannot verify", () => {
+    // email is provided by an external plugin (ClawMail) and is absent from the bundled
+    // generated metadata; injecting groupAllowFrom there breaks gateway startup on upgrade.
+    const cfg = {
+      channels: {
+        email: {
+          allowFrom: ["*"],
+          accounts: {
+            default: { allowFrom: ["*"] },
+          },
+        },
+      },
+    };
+
+    expect(maybeRepairGroupAllowFromFallback(cfg)).toEqual({ config: cfg, changes: [] });
+  });
 });

--- a/src/commands/doctor/shared/allowfrom-fallback-migration.ts
+++ b/src/commands/doctor/shared/allowfrom-fallback-migration.ts
@@ -107,7 +107,13 @@ function schemaAllowsConfigPath(schema: unknown, path: SchemaPath): boolean {
 
 function generatedSchemaAllowsGroupAllowFrom(channelName: string, path: SchemaPath): boolean {
   const schema = findGeneratedChannelConfigSchema(channelName);
-  return !schema || schemaAllowsConfigPath(schema, path);
+  if (!schema) {
+    // External channel plugins (e.g. ClawMail email) aren't in the bundled generated
+    // metadata, so core can't verify their schema accepts groupAllowFrom. Fail closed:
+    // writing it into a schema that forbids it breaks gateway startup on upgrade.
+    return false;
+  }
+  return schemaAllowsConfigPath(schema, path);
 }
 
 function migrateRecord(params: {


### PR DESCRIPTION
Closes #95515.

Supersedes #95518 and revives the focused patch from #95540.

## What Problem This Solves

Fixes an issue where users upgrading OpenClaw with a strict external channel plugin could have core doctor inject an unsupported `groupAllowFrom` field into that plugin's config. Schema validation then fails and can prevent the Gateway from starting.

## Why This Change Was Made

Core doctor currently treats a missing bundled schema as permission to write. External plugins are intentionally absent from bundled schema metadata, so core cannot safely prove they accept `groupAllowFrom`.

The migration now fails closed when no bundled schema is available. Bundled channels whose schemas explicitly permit the field continue migrating normally.

This is a current-main revival of ZengWen-DT's patch from #95540. ZengWen-DT remains the Git author of the sole patch commit; the source and focused regression-test behavior are unchanged.

## User Impact

Upgrades no longer corrupt strict external-channel configurations by introducing an unsupported `groupAllowFrom` field. Existing bundled-channel migrations remain unchanged.

## Evidence

Validated on exact current-main base `731a5d1e45455bafe9a11b90cb0cd47e9ad5bb08`, with patch head `bdf3d1073eecca65cb459d75d0071b597781d10d`.

Before — current `main` mutates the schemaless external channel and its account:

```json
{"changes":["channels.email.groupAllowFrom: copied 1 sender entry from allowFrom for explicit group allowlist.","channels.email.accounts.default.groupAllowFrom: copied 1 sender entry from allowFrom for explicit group allowlist."],"channelGroupAllowFrom":["*"],"accountGroupAllowFrom":["*"]}
```

After — the same external config is untouched, while a bundled Telegram config still migrates:

```json
{"externalChanges":[],"bundledChanges":["channels.telegram.groupAllowFrom: copied 1 sender entry from allowFrom for explicit group allowlist."],"bundledGroupAllowFrom":["123"]}
```

- Focused regression: `7/7` passed
- `oxfmt --check`: clean
- `oxlint`: clean
- `git diff --check`: clean

The linked issue also contains repeated live ClawMail upgrade evidence and an independent external RCS reproduction. This pass did not repeat a packaged ClawMail upgrade.

Pre-PR wrapper skipped under the approved low-capacity VPS exception; hosted CI remains the broader gate.

AI-assisted current-main revival and validation; original patch authored by ZengWen-DT in #95540.
