### PR TITLE
fix(ui): keep chat table labels readable and summaries separated

### DIFF
--- a/test/scripts/check-openclaw-package-tarball-control-ui.test.ts
+++ b/test/scripts/check-openclaw-package-tarball-control-ui.test.ts
@@ -2,6 +2,7 @@ import { spawnSync } from "node:child_process";
 import { copyFileSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import { WORKSPACE_TEMPLATE_PACK_PATHS } from "../../scripts/lib/workspace-bootstrap-smoke.mjs";
 
@@ -13,6 +14,9 @@ const CONTROL_UI_ASSETS = [
 ] as const;
 const CONTROL_UI_FILES = [CONTROL_UI_INDEX, ...CONTROL_UI_ASSETS];
 const CHECK_SCRIPT = resolve("scripts/check-openclaw-package-tarball.mjs");
+const TYPESCRIPT_PACKAGE_ROOT = fileURLToPath(
+  new URL("../../node_modules/typescript", import.meta.url),
+);
 
 function writeFixtureFile(packageRoot: string, relativePath: string, content: string): void {
   const filePath = join(packageRoot, relativePath);
@@ -72,6 +76,7 @@ function withPackedPackage(
     }
     for (const relativePath of [
       "scripts/postinstall-bundled-plugins.mjs",
+      "scripts/lib/guard-inventory-utils.mjs",
       "scripts/lib/package-dist-imports.mjs",
     ]) {
       const destination = join(packageRoot, relativePath);
@@ -119,6 +124,7 @@ function installPackedPackage(root: string, tarball: string) {
       "--no-audit",
       "--no-fund",
       "--offline",
+      TYPESCRIPT_PACKAGE_ROOT,
       tarball,
     ],
     {

--- a/ui/src/e2e/route-css.e2e.test.ts
+++ b/ui/src/e2e/route-css.e2e.test.ts
@@ -31,7 +31,7 @@ describeControlUiE2e("Control UI route CSS mocked Gateway E2E", () => {
     await server?.close();
   });
 
-  it("loads shared Markdown and session-link styles on direct Cron and Skills routes", async () => {
+  it("loads shared Markdown and session-link styles on direct Cron, Skills, and Chat routes", async () => {
     const context = await browser.newContext({
       locale: "en-US",
       serviceWorkers: "block",
@@ -143,6 +143,55 @@ describeControlUiE2e("Control UI route CSS mocked Gateway E2E", () => {
       expect(skillsStyles.preOverflow).toBe("auto");
       expect(skillsStyles.tableDisplay).toBe("block");
       expect(skillsStyles.taskListStyle).toBe("none");
+
+      const chatResponse = await page.goto(`${server.baseUrl}chat`);
+      expect(chatResponse?.status()).toBe(200);
+      await page.locator(".chat-page").waitFor();
+
+      const chatMarkdownStyles = await page.evaluate(() => {
+        const probe = document.createElement("div");
+        probe.className = "chat-text";
+        probe.style.width = "900px";
+        probe.innerHTML = `
+          <table>
+            <thead><tr><th>Dimension</th><th>Sentiment signal</th></tr></thead>
+            <tbody><tr><td>Demographics</td><td>Experience-dependent sentiment.</td></tr></tbody>
+          </table>
+          <ol><li>One central pattern</li><li>Another central pattern</li></ol>
+          <p><strong>Overall characterization:</strong> Pragmatic adoption under suspicion.</p>
+        `;
+        document.body.append(probe);
+        const dimension = probe.querySelector("th:first-child");
+        const demographics = probe.querySelector("td:first-child");
+        const list = probe.querySelector("ol");
+        const summary = probe.querySelector("ol + p");
+        if (!dimension || !demographics || !list || !summary) {
+          throw new Error("Chat Markdown style probe did not render");
+        }
+        const lineCount = (element: Element) => {
+          const range = document.createRange();
+          range.selectNodeContents(element);
+          return new Set(Array.from(range.getClientRects(), (rect) => Math.round(rect.top))).size;
+        };
+        const result = {
+          demographicsLineCount: lineCount(demographics),
+          dimensionLineCount: lineCount(dimension),
+          firstColumnWidth: dimension.getBoundingClientRect().width,
+          postListGap: summary.getBoundingClientRect().top - list.getBoundingClientRect().bottom,
+          postListMargin: Number.parseFloat(getComputedStyle(summary).marginTop),
+          summaryFontSize: Number.parseFloat(getComputedStyle(summary).fontSize),
+        };
+        probe.remove();
+        return result;
+      });
+      expect(chatMarkdownStyles.dimensionLineCount).toBe(1);
+      expect(chatMarkdownStyles.demographicsLineCount).toBe(1);
+      expect(chatMarkdownStyles.firstColumnWidth).toBeGreaterThanOrEqual(128);
+      expect(chatMarkdownStyles.postListGap).toBeGreaterThan(0);
+      expect(chatMarkdownStyles.postListMargin / chatMarkdownStyles.summaryFontSize).toBeCloseTo(
+        0.75,
+        2,
+      );
     } finally {
       await context.close();
     }

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -79,6 +79,12 @@
   vertical-align: top;
 }
 
+.chat-text :where(th:first-child, td:first-child) {
+  min-width: 8rem;
+  overflow-wrap: normal;
+  word-break: normal;
+}
+
 .chat-text :where(th) {
   font-family: var(--mono);
   font-weight: 500;
@@ -231,7 +237,7 @@
 
 /* Order contract: stays below the nested-blockquote margin rule so a nested
    quote that follows a paragraph gets paragraph rhythm, not the 8px gap. */
-.chat-text :where(p + p, p + ul, p + ol, p + pre, p + blockquote) {
+.chat-text :where(p + p, p + ul, p + ol, p + pre, p + blockquote, ul + p, ol + p) {
   margin-top: 0.75em;
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where chat Markdown tables could split first-column labels inside words when the table was narrow, and where a summary paragraph immediately after a list had no visual separation.

This landing also repairs a current-main CI merge race: #113856 added a minimal packaged-Control-UI fixture while #113821 concurrently made postinstall load TypeScript and guard-inventory-utils.mjs. The merged fixture omitted both runtime requirements, leaving checks-node-compact-small-4 red on main and on this PR.

## Why This Change Was Made

The chat Markdown stylesheet now gives the first table column an 8rem minimum width with normal word wrapping, while preserving horizontal table overflow on narrow screens. Paragraphs following ordered or unordered lists now use the existing 0.75em block rhythm. A focused route-level browser test covers both behaviors.

The package fixture now copies the shipped guard helper and installs the existing local TypeScript package into its offline npm sandbox before exercising the real postinstall lifecycle. This is the smallest fixture-only repair for the unrelated red-main gate.

## User Impact

Chat responses with comparison tables keep row labels readable, and prose summaries after lists are visually separated at desktop and mobile widths. The package-install regression lane is green again without changing shipped package behavior.

## Evidence

- Focused Playwright route test passed: ui/src/e2e/route-css.e2e.test.ts, loads shared Markdown and session-link styles on direct Cron, Skills, and Chat routes.
- Browser-computed assertions verify a first-column width of at least 128px, one-line Dimension and Demographics labels, and a 0.75em post-list paragraph margin.
- Chromium screenshots were inspected at desktop and narrow mobile widths; both show intact table labels and visible spacing before Overall characterization.
- Focused package fixture test passed: test/scripts/check-openclaw-package-tarball-control-ui.test.ts, 7 tests.
- git diff --check passed.
- Fresh structured autoreview passed on the combined branch with no accepted or actionable findings (confidence 0.89).

AI-assisted change; the author reviewed and understands the CSS, regression test, and package-fixture repair.