### PR TITLE
fix(openai): drop transient reasoning replay state

### DIFF
--- a/packages/ai/src/transports/openai-responses-replay-messages-internal.ts
+++ b/packages/ai/src/transports/openai-responses-replay-messages-internal.ts
@@ -32,11 +32,24 @@ import {
   type ReplayableResponseReasoningItem,
 } from "./openai-responses-contracts.js";
 import { resolveReplayableResponsesMessageId } from "./openai-responses-replay.js";
+import { usesNativeOpenAICodexResponsesBackend } from "./openai-transport-params.js";
 import { providerReplayContextMatches } from "./provider-replay-context.js";
 import {
   sanitizeNonEmptyTransportPayloadText,
   sanitizeTransportPayloadText,
 } from "./transport-stream-shared.js";
+
+export function isTransientOpenAICodexReasoningItem(
+  model: Model,
+  item: { type?: unknown; id?: unknown },
+): boolean {
+  return (
+    usesNativeOpenAICodexResponsesBackend(model) &&
+    item.type === "reasoning" &&
+    typeof item.id === "string" &&
+    item.id.startsWith("rs_tmp_")
+  );
+}
 
 export function stripEncryptedReasoningContentFields(value: unknown): {
   value: unknown;
@@ -397,6 +410,10 @@ function convertResponsesMessagesWithStyle(
               continue;
             }
             if (!isRecord(reasoningItem) || reasoningItem.type !== "reasoning") {
+              continue;
+            }
+            if (isTransientOpenAICodexReasoningItem(model, reasoningItem)) {
+              previousReplayItemWasReasoning = false;
               continue;
             }
             const replayableReasoningItem = prepareOpenAIResponsesReasoningItemForReplay(

--- a/packages/ai/src/transports/openai-responses-stream-internal.ts
+++ b/packages/ai/src/transports/openai-responses-stream-internal.ts
@@ -24,6 +24,7 @@ import { createCompactionTracker } from "./openai-responses-compaction-replay.js
 import { OPENAI_RESPONSES_REASONING_REPLAY_BLOCK_META_KEY } from "./openai-responses-contracts.js";
 import { normalizeResponsesFailedEvent, ResponsesStreamFailure } from "./openai-responses-debug.js";
 import { encodeTextSignatureV1 } from "./openai-responses-replay-internal.js";
+import { isTransientOpenAICodexReasoningItem } from "./openai-responses-replay-messages-internal.js";
 import { adaptResponsesStream } from "./openai-responses-stream-observer-internal.js";
 import {
   appendResponsesPendingTextDelta,
@@ -523,17 +524,19 @@ export async function processResponsesStream<TApi extends Api>(
           const summaryText = item.summary?.map((s) => s.text).join("\n\n") || "";
           const contentText = item.content?.map((c) => c.text).join("\n\n") || "";
           outputSlot.block.thinking = summaryText || contentText || outputSlot.block.thinking;
-          outputSlot.block.thinkingSignature = JSON.stringify(item);
+          if (!isTransientOpenAICodexReasoningItem(model, item)) {
+            outputSlot.block.thinkingSignature = JSON.stringify(item);
+            if (item.encrypted_content && options?.reasoningReplayMetadata) {
+              outputSlot.block[OPENAI_RESPONSES_REASONING_REPLAY_BLOCK_META_KEY] =
+                options.reasoningReplayMetadata;
+            }
+          }
           outputs.set(
             item,
             outputSlot.contentIndex,
             readResponsesOutputIndex(event) ?? outputSlot.outputIndex,
             true,
           );
-          if (item.encrypted_content && options?.reasoningReplayMetadata) {
-            outputSlot.block[OPENAI_RESPONSES_REASONING_REPLAY_BLOCK_META_KEY] =
-              options.reasoningReplayMetadata;
-          }
           stream.push({
             type: "thinking_end",
             contentIndex: outputSlot.contentIndex,

--- a/packages/ai/src/transports/openai-responses-transient-reasoning.test.ts
+++ b/packages/ai/src/transports/openai-responses-transient-reasoning.test.ts
@@ -1,0 +1,161 @@
+import type { AssistantMessage, Context, Model } from "@openclaw/llm-core";
+import { describe, expect, it } from "vitest";
+import { buildOpenAIResponsesReasoningReplayMetadata } from "./openai-responses-compaction-replay.js";
+import {
+  convertProviderResponsesMessages,
+  convertResponsesMessages,
+} from "./openai-responses-replay-messages-internal.js";
+import {
+  processResponsesStream,
+  type OpenAIResponsesStreamEvent,
+} from "./openai-responses-stream-internal.js";
+
+const nativeCodexModel = {
+  id: "gpt-5.4",
+  name: "Codex",
+  api: "openai-chatgpt-responses",
+  provider: "openai",
+  baseUrl: "https://chatgpt.com/backend-api/codex",
+  reasoning: true,
+  input: ["text"],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 200_000,
+  maxTokens: 8192,
+} satisfies Model<"openai-chatgpt-responses">;
+
+const proxiedCodexModel = {
+  ...nativeCodexModel,
+  baseUrl: "https://responses.example.test/v1",
+} satisfies Model<"openai-chatgpt-responses">;
+const replayConverters = [
+  { name: "transport", convert: convertResponsesMessages },
+  { name: "provider", convert: convertProviderResponsesMessages },
+] as const;
+
+function createOutput(model: Model): AssistantMessage {
+  return {
+    role: "assistant",
+    content: [],
+    api: model.api,
+    provider: model.provider,
+    model: model.id,
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: "stop",
+    timestamp: 0,
+  };
+}
+
+async function* events(
+  values: readonly Record<string, unknown>[],
+): AsyncGenerator<OpenAIResponsesStreamEvent> {
+  for (const value of values) {
+    yield value as OpenAIResponsesStreamEvent;
+  }
+}
+
+function reasoningBlock(id: string) {
+  return {
+    type: "thinking" as const,
+    thinking: "visible summary",
+    thinkingSignature: JSON.stringify({
+      type: "reasoning",
+      id,
+      encrypted_content: "ciphertext",
+      summary: [],
+    }),
+  };
+}
+
+describe("OpenAI Responses transient reasoning", () => {
+  it.each([
+    { name: "native temporary", model: nativeCodexModel, id: "rs_tmp_123", persists: false },
+    { name: "native stable", model: nativeCodexModel, id: "rs_123", persists: true },
+    {
+      name: "proxied temporary-shaped",
+      model: proxiedCodexModel,
+      id: "rs_tmp_123",
+      persists: true,
+    },
+  ])("scopes streamed replay state for $name items", async ({ model, id, persists }) => {
+    const output = createOutput(model);
+    await processResponsesStream(
+      events([
+        { type: "response.output_item.added", item: { type: "reasoning" } },
+        {
+          type: "response.output_item.done",
+          item: {
+            type: "reasoning",
+            id,
+            encrypted_content: "ciphertext",
+            summary: [{ type: "summary_text", text: "visible summary" }],
+          },
+        },
+        { type: "response.completed", response: { id: "resp_done", status: "completed" } },
+      ]),
+      output,
+      { push: () => undefined },
+      model,
+      {
+        reasoningReplayMetadata: buildOpenAIResponsesReasoningReplayMetadata(model, {
+          sessionId: "session-a",
+          authProfileId: "profile-a",
+        }),
+      },
+    );
+
+    const block = output.content[0];
+    expect(block).toMatchObject({ type: "thinking", thinking: "visible summary" });
+    if (persists) {
+      expect(block).toMatchObject({
+        thinkingSignature: expect.stringContaining(id),
+        openclawReasoningReplay: expect.objectContaining({ provider: "openai" }),
+      });
+    } else {
+      expect(block).not.toHaveProperty("thinkingSignature");
+      expect(block).not.toHaveProperty("openclawReasoningReplay");
+    }
+  });
+
+  it.each(replayConverters)(
+    "$name replay clears signed-message pairing when a temporary reasoning item is skipped",
+    ({ convert }) => {
+      const context: Context = {
+        messages: [
+          {
+            ...createOutput(nativeCodexModel),
+            content: [
+              reasoningBlock("rs_stable"),
+              reasoningBlock("rs_tmp_transient"),
+              {
+                type: "text",
+                text: "final",
+                textSignature: JSON.stringify({
+                  v: 1,
+                  id: "msg_requires_adjacent_reasoning",
+                  phase: "final_answer",
+                }),
+              },
+            ],
+          },
+        ],
+      };
+
+      const input = convert(nativeCodexModel, context, new Set(["openai"]));
+      const reasoningIds = input
+        .filter((item) => item.type === "reasoning")
+        .map((item) => ("id" in item ? item.id : undefined));
+      const message = input.find((item) => item.type === "message");
+
+      expect(reasoningIds).toEqual(["rs_stable"]);
+      expect(message).toMatchObject({ type: "message", role: "assistant" });
+      expect(message).not.toHaveProperty("id");
+    },
+  );
+});


### PR DESCRIPTION
Closes #113868

## What Problem This Solves

Native Codex Responses can emit temporary reasoning items whose IDs start with `rs_tmp_`. OpenClaw persisted those items in assistant `thinkingSignature` fields and replayed them on later turns even though the IDs are not durable replay state. A follow-up request could then fail with `invalid_encrypted_content`.

## Why This Change Was Made

This current-main rewrite places the rule at the two canonical owners:

- the stream writer keeps the human-readable reasoning summary but omits replay signature and provenance metadata for temporary native Codex reasoning;
- the consolidated replay converter drops matching signatures already present in older transcripts and clears adjacency state, so a later signed text item cannot inherit pairing from an earlier stable reasoning item.

The check is intentionally limited to the native Codex Responses backend. Stable `rs_*` items and temporary-shaped IDs from compatible proxy endpoints retain the existing behavior.

The old branch changed a duplicate provider conversion path that was later consolidated by #123762. This rewrite removes that obsolete surface instead of rebasing it.

## User Impact

Multi-turn native Codex Responses sessions no longer carry temporary encrypted reasoning state into later requests. Visible reasoning summaries and valid stable reasoning replay remain unchanged.

## Evidence

Exact head: `d54dd8160fa40ac3d090502891ebf5ef6ac170de`, based on current `upstream/main` `ed6e3aabf0`.

- Pre-fix owner regression: `node scripts/run-vitest.mjs run packages/ai/src/transports/openai-responses-transient-reasoning.test.ts` failed in exactly two places: native `rs_tmp_*` state was persisted, and the same item was replayed after a stable reasoning item. Stable native reasoning and proxy behavior passed.
- Exact-head focused and sibling tests: `node scripts/run-vitest.mjs run packages/ai/src/transports/openai-responses-transient-reasoning.test.ts packages/ai/src/transports/openai-responses-stream-parity.test.ts packages/ai/src/transports/openai-responses-prompt-role.test.ts src/agents/openai-responses.reasoning-replay.test.ts` -> 43/43 passed.
- Both consolidated replay facades are covered by the stable -> temporary -> signed-text ordering regression. The temporary item is absent and the text ID is not replayed.
- `node scripts/run-oxlint.mjs --type-aware ...` -> passed for all three changed files.
- `oxfmt --check` and `git diff --check` -> passed.
- `node --import ./scripts/tsx.mjs scripts/check-import-cycles.ts` -> 0 runtime value cycles.
- Scope: two production files, +25/-5 (net +20), plus one focused 161-line test file. The previous implementation was four files with production net +39 and edited an owner removed by #123762.

Direct dependency-contract check:

- OpenAI Codex source at `90854393966b21e9ebfd21b122334eb09a20c93d` models reasoning as a first-class Responses item carrying an optional provider item ID and encrypted content: https://github.com/openai/codex/blob/90854393966b21e9ebfd21b122334eb09a20c93d/codex-rs/protocol/src/models.rs#L950-L999
- Server item IDs are deliberately read as opaque/permissive values: https://github.com/openai/codex/blob/90854393966b21e9ebfd21b122334eb09a20c93d/codex-rs/protocol/src/response_item_id.rs#L17-L34
- Codex forwards reasoning items as model request input rather than normalizing their provider lifetime: https://github.com/openai/codex/blob/90854393966b21e9ebfd21b122334eb09a20c93d/codex-rs/core/src/client_common.rs#L53-L90
- The OpenAI Responses contract documents encrypted reasoning as state to replay for stateless multi-turn use, which is why excluding only observed temporary native items must happen before persistence/replay: https://developers.openai.com/api/reference/cli/resources/responses/methods/create

Known proof gap: this machine does not yet have a redacted exact-head two-turn native provider trace showing a real `rs_tmp_*` response followed by a request that omits it. No live-provider claim is made. No additional AutoReview was run.
