### PR TITLE
fix(ui): keep sidebar selection on archived sessions and replace the composer with an archived notice

### DIFF
--- a/ui/src/components/app-sidebar-child-session-data.ts
+++ b/ui/src/components/app-sidebar-child-session-data.ts
@@ -1,5 +1,7 @@
 import type { GatewayBrowserClient } from "../api/gateway.ts";
-import type { GatewaySessionRow } from "../api/types.ts";
+import type { GatewaySessionRow, SessionsListResult } from "../api/types.ts";
+import type { SessionCapability } from "../lib/sessions/index.ts";
+import { areUiSessionKeysEquivalent } from "../lib/sessions/session-key.ts";
 export { fetchChildSessionRows } from "../lib/sessions/child-session-data.ts";
 
 const MAX_SESSION_LINEAGE_DEPTH = 16;
@@ -86,4 +88,65 @@ export function mergeChildSessionRows(
     merged[parentKey] = children;
   }
   return merged;
+}
+
+export function publishActiveSessionLineage(
+  owner: {
+    activeSessionLineageRoot: GatewaySessionRow | null;
+    childSessionRowsByParent: Readonly<Record<string, readonly GatewaySessionRow[]>>;
+    context?: { sessions: Pick<SessionCapability, "reconcile"> };
+    sessionsResult: SessionsListResult | null;
+  },
+  sessionKey: string,
+  lineage: NonNullable<Awaited<ReturnType<typeof fetchSessionLineage>>>,
+): void {
+  owner.childSessionRowsByParent = mergeChildSessionRows(
+    owner.childSessionRowsByParent,
+    lineage.rowsByParent,
+  );
+  owner.activeSessionLineageRoot = lineage.topmostRow;
+  // Prefer the fetched lineage on ties, but keep a newer child-list snapshot
+  // so a delayed describe cannot regress already-settled run state.
+  const selectedRow = [
+    lineage.topmostRow,
+    ...Object.values(lineage.rowsByParent).flat(),
+    ...collectKnownSessionRows(
+      owner.sessionsResult?.sessions ?? [],
+      owner.childSessionRowsByParent,
+    ).values(),
+  ]
+    .filter(
+      (row): row is GatewaySessionRow =>
+        row != null && areUiSessionKeysEquivalent(row.key, sessionKey),
+    )
+    .reduce<GatewaySessionRow | undefined>((freshest, row) => {
+      return !freshest || (row.updatedAt ?? 0) > (freshest.updatedAt ?? 0) ? row : freshest;
+    }, undefined);
+  if (selectedRow) {
+    // The active list intentionally omits archived rows. Publish the routed
+    // descriptor so the chat pane and header share the sidebar's cold-load truth.
+    owner.context?.sessions.reconcile(selectedRow, owner.sessionsResult?.defaults, {
+      archivedFilter: "all",
+    });
+  }
+}
+
+export function evictArchivedSessionLineage(
+  owner: Parameters<typeof publishActiveSessionLineage>[0],
+  sessionKey: string | null,
+): void {
+  if (!sessionKey) {
+    return;
+  }
+  const selectedRow =
+    owner.sessionsResult?.sessions.find((row) => areUiSessionKeysEquivalent(row.key, sessionKey)) ??
+    [owner.activeSessionLineageRoot, ...Object.values(owner.childSessionRowsByParent).flat()].find(
+      (row): row is GatewaySessionRow =>
+        row != null && areUiSessionKeysEquivalent(row.key, sessionKey),
+    );
+  if (selectedRow?.archived === true) {
+    owner.context?.sessions.reconcile(selectedRow, owner.sessionsResult?.defaults, {
+      archivedFilter: "active",
+    });
+  }
 }

--- a/ui/src/components/app-sidebar-child-session-data.ts
+++ b/ui/src/components/app-sidebar-child-session-data.ts
@@ -71,7 +71,7 @@ export async function fetchSessionLineage(params: {
   return { rowsByParent, topmostRow, lookupFailed };
 }
 
-export function mergeChildSessionRows(
+function mergeChildSessionRows(
   current: Readonly<Record<string, readonly GatewaySessionRow[]>>,
   additions: Readonly<Record<string, readonly GatewaySessionRow[]>>,
 ): Record<string, GatewaySessionRow[]> {

--- a/ui/src/components/app-sidebar-session-navigation-logic.ts
+++ b/ui/src/components/app-sidebar-session-navigation-logic.ts
@@ -71,6 +71,7 @@ export function buildSidebarSessionNavigationState(input: {
   context: ApplicationContext<RouteId> | undefined;
   routeSessionKey: string;
   sessionsResult: SessionsListResult | null;
+  activeSession?: GatewaySessionRow | null;
   sessionsAgentId: string | null;
   showCron: boolean;
   statusFilter: SidebarSessionStatusFilter;
@@ -85,6 +86,7 @@ export function buildSidebarSessionNavigationState(input: {
   const { context } = input;
   const navigation = resolveSessionNavigation({
     result: input.sessionsResult,
+    activeSession: input.activeSession,
     resultAgentId: input.sessionsAgentId,
     sessionKey: input.routeSessionKey,
     assistantAgentId:

--- a/ui/src/components/app-sidebar-session-navigation.ts
+++ b/ui/src/components/app-sidebar-session-navigation.ts
@@ -242,7 +242,10 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
     return [
       this.sessionData.activeSessionLineageRoot,
       ...Object.values(this.sessionData.childSessionRowsByParent).flat(),
-    ].find((row) => row != null && areUiSessionKeysEquivalent(row.key, sessionKey));
+    ].find(
+      (row): row is GatewaySessionRow =>
+        row != null && areUiSessionKeysEquivalent(row.key, sessionKey),
+    );
   }
 
   outboxCountForSessionKey(sessionKey: string): number {
@@ -630,20 +633,22 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
       knownSessionAttention: this.attention.knownSessionAttention(),
       toSidebarSession: navigationState.toSidebarSession,
     });
-    const projectedRows = [...projected];
-    let selectedAlreadyProjected = false;
-    while (selectedFallback && projectedRows.length > 0) {
-      const row = projectedRows.pop();
-      if (row?.key === selectedFallback.key) {
-        selectedAlreadyProjected = true;
-        break;
+    if (selectedFallback) {
+      const projectedRows = [...projected];
+      let selectedAlreadyProjected = false;
+      while (projectedRows.length > 0) {
+        const row = projectedRows.pop();
+        if (row?.key === selectedFallback.key) {
+          selectedAlreadyProjected = true;
+          break;
+        }
+        if (row) {
+          projectedRows.push(...row.children);
+        }
       }
-      if (row) {
-        projectedRows.push(...row.children);
+      if (!selectedAlreadyProjected) {
+        projected.unshift(selectedFallback);
       }
-    }
-    if (selectedFallback && !selectedAlreadyProjected) {
-      projected.unshift(selectedFallback);
     }
     const creatorFacet =
       rows === this.sessionData.sessionsResult?.sessions

--- a/ui/src/components/app-sidebar-session-navigation.ts
+++ b/ui/src/components/app-sidebar-session-navigation.ts
@@ -238,15 +238,24 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
     return this.sessionKey.trim() || this.context?.gateway.snapshot.sessionKey.trim() || "";
   }
 
+  private activeLineageRow(sessionKey: string): GatewaySessionRow | undefined {
+    return [
+      this.sessionData.activeSessionLineageRoot,
+      ...Object.values(this.sessionData.childSessionRowsByParent).flat(),
+    ].find((row) => row != null && areUiSessionKeysEquivalent(row.key, sessionKey));
+  }
+
   outboxCountForSessionKey(sessionKey: string): number {
     return this.outboxCountForSession(sessionKey);
   }
 
   getSessionNavigationState(): SidebarSessionNavigationState {
+    const routeSessionKey = this.getRouteSessionKey();
     return buildSidebarSessionNavigationState({
       context: this.context,
-      routeSessionKey: this.getRouteSessionKey(),
+      routeSessionKey,
       sessionsResult: this.sessionData.sessionsResult,
+      activeSession: this.activeLineageRow(routeSessionKey),
       sessionsAgentId: this.sessionData.sessionsAgentId,
       showCron: this.sessionsShowCron,
       statusFilter: this.sessionsStatusFilter,
@@ -549,6 +558,16 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
     // Children index under the gateway row's literal key, which may be an
     // equivalent alias (e.g. "main"), so promotion tracks every removed key.
     const mainSessionKey = this.selectedAgentMainSessionKey(selected);
+    const lineageRoot = this.sessionData.activeSessionLineageRoot;
+    const lineageAgentId = normalizeAgentId(
+      parseAgentSessionKey(lineageRoot?.key ?? "")?.agentId ?? "",
+    );
+    const selectedFallback =
+      selected === routeAgentId || lineageAgentId === selected
+        ? navigationState.visibleSessions.find(
+            (session) => session.active && !areUiSessionKeysEquivalent(session.key, mainSessionKey),
+          )
+        : undefined;
     const mainSessionKeys = new Set<string>([mainSessionKey]);
     const scopedRootRows = rootRows.filter((row) => {
       if (areUiSessionKeysEquivalent(row.key, mainSessionKey)) {
@@ -557,17 +576,15 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
       }
       return true;
     });
-    const lineageRoot = this.sessionData.activeSessionLineageRoot;
-    const lineageAgentId = normalizeAgentId(
-      parseAgentSessionKey(lineageRoot?.key ?? "")?.agentId ?? "",
-    );
     const lineageRouteAgentId = normalizeAgentId(
       parseAgentSessionKey(navigationState.routeSessionKey)?.agentId ?? "",
     );
+    const lineageSelected = Boolean(
+      lineageRoot && areUiSessionKeysEquivalent(lineageRoot.key, navigationState.routeSessionKey),
+    );
     if (
       lineageRoot &&
-      lineageRoot.archived !== true &&
-      sessionMatchesArchivedFilter(lineageRoot, this.sessionsStatusFilter) &&
+      (lineageSelected || sessionMatchesArchivedFilter(lineageRoot, this.sessionsStatusFilter)) &&
       (lineageAgentId === selected || lineageRouteAgentId === selected) &&
       !adopted.has(lineageRoot.key) &&
       !areUiSessionKeysEquivalent(lineageRoot.key, mainSessionKey) &&
@@ -613,6 +630,21 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
       knownSessionAttention: this.attention.knownSessionAttention(),
       toSidebarSession: navigationState.toSidebarSession,
     });
+    const projectedRows = [...projected];
+    let selectedAlreadyProjected = false;
+    while (selectedFallback && projectedRows.length > 0) {
+      const row = projectedRows.pop();
+      if (row?.key === selectedFallback.key) {
+        selectedAlreadyProjected = true;
+        break;
+      }
+      if (row) {
+        projectedRows.push(...row.children);
+      }
+    }
+    if (selectedFallback && !selectedAlreadyProjected) {
+      projected.unshift(selectedFallback);
+    }
     const creatorFacet =
       rows === this.sessionData.sessionsResult?.sessions
         ? this.sessionData.sessionsResult.creators

--- a/ui/src/components/session-data-controller.ts
+++ b/ui/src/components/session-data-controller.ts
@@ -18,9 +18,10 @@ import { normalizeAgentId } from "../lib/sessions/session-key.ts";
 import { SubscriptionsController } from "../lit/subscriptions-controller.ts";
 import {
   collectKnownSessionRows,
+  evictArchivedSessionLineage,
   fetchChildSessionRows,
   fetchSessionLineage,
-  mergeChildSessionRows,
+  publishActiveSessionLineage,
 } from "./app-sidebar-child-session-data.ts";
 import { SessionCatalogLiveState } from "./app-sidebar-session-catalog-live.ts";
 import { bindAdoptedCatalogSession } from "./app-sidebar-session-catalogs.ts";
@@ -605,6 +606,7 @@ export class SessionDataController implements ReactiveController, SessionCatalog
   async loadActiveSessionLineage(sessionKey: string): Promise<void> {
     const normalizedKey = sessionKey.trim();
     if (normalizedKey !== this.activeSessionLineageRouteKey) {
+      evictArchivedSessionLineage(this, this.activeSessionLineageRouteKey);
       this.activeSessionLineageRouteKey = normalizedKey;
       this.activeSessionLineageLoaded = false;
       this.activeSessionLineageRequestToken = null;
@@ -649,11 +651,7 @@ export class SessionDataController implements ReactiveController, SessionCatalog
     if (!lineage || !isCurrent()) {
       return;
     }
-    this.childSessionRowsByParent = mergeChildSessionRows(
-      this.childSessionRowsByParent,
-      lineage.rowsByParent,
-    );
-    this.activeSessionLineageRoot = lineage.topmostRow;
+    publishActiveSessionLineage(this, normalizedKey, lineage);
     this.notify();
     this.activeSessionLineageRequestToken = null;
     if (lineage.lookupFailed) {

--- a/ui/src/components/session-organizer-operations.runtime.ts
+++ b/ui/src/components/session-organizer-operations.runtime.ts
@@ -80,18 +80,6 @@ export async function patchSession(
         return "stale";
       }
     }
-    if (patch.archived !== true || !session.active) {
-      return "completed";
-    }
-    host.replaceCurrentSession(
-      buildAgentMainSessionKey({
-        agentId,
-        mainKey: resolveUiConfiguredMainKey({
-          agentsList: scope.context.agents.state.agentsList,
-          hello: scope.gateway.snapshot.hello,
-        }),
-      }),
-    );
     return "completed";
   } catch (error) {
     if (!host.sessionData.isSessionMutationScopeCurrent(scope)) {
@@ -231,7 +219,6 @@ async function restoreArchivedSessions(
   if (!host.sessionData.isSessionMutationScopeCurrent(scope)) {
     return;
   }
-  let restoredActiveKey: string | null = null;
   for (const { session, pinned } of archived) {
     const result = await patchSession(
       host,
@@ -243,18 +230,12 @@ async function restoreArchivedSessions(
     if (result === "stale") {
       return;
     }
-    if (result === "completed" && session.active) {
-      restoredActiveKey = session.key;
-    }
   }
-  const refreshed = await refreshSessionsAfterBatch(
+  await refreshSessionsAfterBatch(
     host,
     scope,
     archived.map((entry) => entry.session),
   );
-  if (restoredActiveKey && refreshed !== "stale") {
-    host.replaceCurrentSession(restoredActiveKey);
-  }
 }
 
 /** One confirm and one preserved-worktrees alert for the whole selection. */

--- a/ui/src/e2e/session-management.e2e.test.ts
+++ b/ui/src/e2e/session-management.e2e.test.ts
@@ -799,6 +799,122 @@ describeControlUiE2e("Control UI session management mocked Gateway E2E", () => {
     }
   });
 
+  it("keeps the selected session through archive refreshes and restores the composer", async () => {
+    const context = await browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const baseTime = Date.parse("2026-07-01T16:00:00.000Z");
+    const sessionRows = Array.from({ length: 15 }, (_, index) =>
+      sessionRow(
+        `agent:main:archive-refresh-${index}`,
+        `Archive refresh ${index}`,
+        baseTime - (index + 1) * 1_000,
+      ),
+    );
+    const selected = sessionRows[2]!;
+    const batchRows = [sessionRows[0]!, sessionRows[1]!, sessionRows[3]!];
+    const gateway = await installMockGateway(page, {
+      methodResponses: {
+        "sessions.list": sessionsListResponse([
+          sessionRow("agent:main:main", "Main", baseTime),
+          ...sessionRows,
+        ]),
+        "sessions.patch": {},
+      },
+      sessionArchiveFiltering: true,
+      sessionKey: "agent:main:main",
+    });
+
+    const assertSelectedRoute = async () => {
+      await expect.poll(() => page.url()).toContain(`session=${encodeURIComponent(selected.key)}`);
+      const row = page.locator(`.sidebar-recent-session[data-session-key="${selected.key}"]`);
+      await row.waitFor({ state: "visible", timeout: 10_000 });
+      await expect
+        .poll(() => row.getAttribute("class"))
+        .toContain("sidebar-recent-session--active");
+    };
+
+    try {
+      await page.goto(`${server.baseUrl}chat`);
+      const sidebar = page.locator("openclaw-app-sidebar");
+      const rowFor = (key: string) =>
+        sidebar.locator(`.sidebar-recent-session[data-session-key="${key}"]`);
+      await rowFor(selected.key).waitFor({ state: "visible", timeout: 10_000 });
+      await rowFor(selected.key).locator("a").first().click();
+      await assertSelectedRoute();
+      await page.locator(".agent-chat__input textarea").waitFor({ state: "visible" });
+
+      for (const row of batchRows) {
+        await rowFor(row.key).click({ modifiers: ["Meta"] });
+      }
+      await rowFor(batchRows[0]!.key).click({ button: "right" });
+      const batchMenu = page.locator("openclaw-session-menu");
+      await activateMenuItem(
+        batchMenu.getByRole("menuitem", { name: `Archive ${batchRows.length}` }),
+      );
+      for (const row of batchRows) {
+        await waitForPatch(gateway, (params) => params.key === row.key && params.archived === true);
+        await gateway.emitGatewayEvent("sessions.changed", {
+          ...row,
+          archived: true,
+          reason: "update",
+          sessionKey: row.key,
+        });
+        await assertSelectedRoute();
+      }
+
+      await gateway.setMethodResponse("sessions.describe", {
+        session: { ...selected, archived: true },
+      });
+      const selectedRow = rowFor(selected.key);
+      await selectedRow.hover();
+      await selectedRow.getByRole("button", { name: "Open thread menu" }).click();
+      await activateMenuItem(
+        page.locator("openclaw-session-menu").getByRole("menuitem", {
+          name: "Archive thread",
+        }),
+      );
+      await waitForPatch(
+        gateway,
+        (params) => params.key === selected.key && params.archived === true,
+      );
+      await gateway.emitGatewayEvent("sessions.changed", {
+        ...selected,
+        archived: true,
+        reason: "update",
+        sessionKey: selected.key,
+      });
+
+      await assertSelectedRoute();
+      await selectedRow.locator(".sidebar-session__archive-glyph").waitFor({ state: "visible" });
+      const archivedNotice = page.locator(".agent-chat__disabled-banner");
+      await archivedNotice.waitFor({ state: "visible", timeout: 10_000 });
+      await expect.poll(() => archivedNotice.textContent()).toContain("This session is archived.");
+      await expect.poll(() => page.locator(".agent-chat__input").count()).toBe(0);
+
+      await archivedNotice.getByRole("button", { name: "Unarchive" }).click();
+      await waitForPatch(
+        gateway,
+        (params) => params.key === selected.key && params.archived === false,
+      );
+      await gateway.emitGatewayEvent("sessions.changed", {
+        ...selected,
+        archived: false,
+        reason: "update",
+        sessionKey: selected.key,
+      });
+
+      await assertSelectedRoute();
+      await archivedNotice.waitFor({ state: "detached", timeout: 10_000 });
+      await page.locator(".agent-chat__input textarea").waitFor({ state: "visible" });
+    } finally {
+      await context.close();
+    }
+  });
+
   it("keeps a session row when the Gateway reports no deletion", async () => {
     const context = await browser.newContext({
       locale: "en-US",
@@ -1159,7 +1275,7 @@ describeControlUiE2e("Control UI session management mocked Gateway E2E", () => {
       viewport: { height: 900, width: 1280 },
     });
     const page = await context.newPage();
-    const sessions = Array.from({ length: 12 }, (_, index) =>
+    const sessions = Array.from({ length: 13 }, (_, index) =>
       sessionRow(`agent:main:session-${index}`, `Session ${index}`, baseTime - index * 60_000, {
         ...(index === 0 ? { category: "Alpha" } : {}),
         ...(index === 1 ? { category: "Beta" } : {}),
@@ -1178,9 +1294,11 @@ describeControlUiE2e("Control UI session management mocked Gateway E2E", () => {
     try {
       await page.goto(`${server.baseUrl}chat`);
       const sidebarRows = page.locator(".sidebar-recent-session");
-      await expect.poll(() => sidebarRows.count()).toBe(10);
-      await page.getByRole("button", { name: "Load more" }).click();
+      // Category sections page independently: Alpha and Beta stay visible
+      // alongside the first ten rows in the ungrouped section.
       await expect.poll(() => sidebarRows.count()).toBe(12);
+      await page.getByRole("button", { name: "Show more" }).click();
+      await expect.poll(() => sidebarRows.count()).toBe(13);
       await expect.poll(() => page.getByText("All threads", { exact: true }).count()).toBe(0);
       await captureUiProof(page, "sidebar-all-sessions.png");
 
@@ -1254,7 +1372,7 @@ describeControlUiE2e("Control UI session management mocked Gateway E2E", () => {
       });
       await expect
         .poll(() => ungrouped.locator(".sidebar-recent-session").count(), { timeout: 10_000 })
-        .toBe(9);
+        .toBe(10);
 
       const alpha = page.locator('[data-session-section="category:Alpha"]');
       const alphaToggle = alpha.getByRole("button", { name: "Alpha", exact: true });
@@ -1377,11 +1495,28 @@ describeControlUiE2e("Control UI session management mocked Gateway E2E", () => {
         .toEqual(["Pinned only"]);
       await expect.poll(() => chatsGroup.locator(".sidebar-recent-session").count()).toBe(0);
       await expect.poll(() => page.locator(".sidebar-recent-session--active").count()).toBe(1);
-      // The empty Threads section only materializes once the drag is in
-      // flight, so target the whole sessions surface (its drop handler unpins).
-      await pinnedEntry
-        .locator(".sidebar-recent-session")
-        .dragTo(page.locator(".sidebar-sessions"));
+      // The empty Threads section only materializes after dragstart. Move the
+      // real pointer first so Playwright does not wait for a hidden target.
+      const pinnedRow = pinnedEntry.locator(".sidebar-recent-session");
+      const sourceBox = await pinnedRow.boundingBox();
+      if (!sourceBox) {
+        throw new Error("expected pinned session bounds");
+      }
+      await page.mouse.move(sourceBox.x + sourceBox.width / 2, sourceBox.y + sourceBox.height / 2);
+      await page.mouse.down();
+      await page.mouse.move(sourceBox.x + sourceBox.width / 2 + 12, sourceBox.y + 12, {
+        steps: 4,
+      });
+      const sessionList = page.locator(".sidebar-sessions");
+      await sessionList.waitFor({ state: "visible" });
+      const targetBox = await sessionList.boundingBox();
+      if (!targetBox) {
+        throw new Error("expected session list bounds");
+      }
+      await page.mouse.move(targetBox.x + targetBox.width / 2, targetBox.y + targetBox.height / 2, {
+        steps: 8,
+      });
+      await page.mouse.up();
       const unpinPatch = await waitForPatch(
         gateway,
         (params) => params.key === "agent:main:pinned" && params.pinned === false,

--- a/ui/src/e2e/session-management.e2e.test.ts
+++ b/ui/src/e2e/session-management.e2e.test.ts
@@ -915,6 +915,71 @@ describeControlUiE2e("Control UI session management mocked Gateway E2E", () => {
     }
   });
 
+  it("shows the archived notice when an archived session is cold-loaded outside the active list", async () => {
+    const context = await browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const archived = sessionRow(
+      "agent:main:dashboard:cold-archive",
+      "Archived planning",
+      Date.parse("2026-07-01T16:00:00.000Z"),
+      { archived: true },
+    );
+    const gateway = await installMockGateway(page, {
+      methodResponses: {
+        "sessions.describe": { session: archived },
+        "sessions.list": sessionsListResponse([
+          sessionRow("agent:main:main", "Main", archived.updatedAt + 1),
+        ]),
+        "sessions.patch": {},
+      },
+      sessionArchiveFiltering: true,
+      sessionKey: archived.key,
+    });
+
+    try {
+      await page.goto(`${server.baseUrl}chat?session=${encodeURIComponent(archived.key)}`);
+
+      const selectedRow = page.locator(
+        `.sidebar-recent-session[data-session-key="${archived.key}"]`,
+      );
+      await selectedRow.waitFor({ state: "visible", timeout: 10_000 });
+      await expect
+        .poll(() => selectedRow.getAttribute("class"))
+        .toContain("sidebar-recent-session--active");
+      await selectedRow.locator(".sidebar-session__archive-glyph").waitFor({ state: "visible" });
+      await expect.poll(() => page.getByText("Archived planning", { exact: true }).count()).toBe(2);
+
+      const archivedNotice = page.locator(".agent-chat__disabled-banner");
+      await archivedNotice.waitFor({ state: "visible", timeout: 10_000 });
+      await expect.poll(() => archivedNotice.textContent()).toContain("This session is archived.");
+      await expect.poll(() => page.locator(".agent-chat__input").count()).toBe(0);
+
+      await gateway.setMethodResponse("sessions.describe", {
+        session: { ...archived, archived: false },
+      });
+      await archivedNotice.getByRole("button", { name: "Unarchive" }).click();
+      await waitForPatch(
+        gateway,
+        (params) => params.key === archived.key && params.archived === false,
+      );
+      await gateway.emitGatewayEvent("sessions.changed", {
+        ...archived,
+        archived: false,
+        reason: "update",
+        sessionKey: archived.key,
+      });
+
+      await archivedNotice.waitFor({ state: "detached", timeout: 10_000 });
+      await page.locator(".agent-chat__input textarea").waitFor({ state: "visible" });
+    } finally {
+      await context.close();
+    }
+  });
+
   it("keeps a session row when the Gateway reports no deletion", async () => {
     const context = await browser.newContext({
       locale: "en-US",

--- a/ui/src/lib/sessions/navigation.test.ts
+++ b/ui/src/lib/sessions/navigation.test.ts
@@ -116,6 +116,36 @@ describe("resolveSessionNavigation", () => {
     );
   });
 
+  it("keeps the selected archived session ahead of an active-filtered result", () => {
+    const selectedSession = {
+      key: "agent:main:archived",
+      kind: "direct" as const,
+      archived: true,
+      updatedAt: 50,
+    };
+    const navigation = resolveSessionNavigation({
+      result: sessionsResult([{ key: "agent:main:recent", kind: "direct", updatedAt: 100 }]),
+      activeSession: selectedSession,
+      resultAgentId: "main",
+      sessionKey: selectedSession.key,
+      archivedFilter: "active",
+    });
+
+    expect(navigation.visibleSessions.map((row) => row.key)).toEqual([
+      selectedSession.key,
+      "agent:main:recent",
+    ]);
+    expect(navigation.visibleSessions[0]).toMatchObject({
+      key: selectedSession.key,
+      archived: true,
+    });
+    expect(navigation.activeRowKey).toBe(selectedSession.key);
+    expect(navigation.selectedSession).toMatchObject({
+      key: selectedSession.key,
+      archived: true,
+    });
+  });
+
   it("keeps the selected session in place in a long list", () => {
     const rows = Array.from({ length: 12 }, (_, index) => ({
       key: `agent:main:recent-${index}`,

--- a/ui/src/lib/sessions/navigation.ts
+++ b/ui/src/lib/sessions/navigation.ts
@@ -26,6 +26,7 @@ export type SessionArchivedFilter = "active" | "archived" | "all";
 
 type SessionNavigationInput = {
   result: SessionsListResult | null;
+  activeSession?: GatewaySessionRow | null;
   resultAgentId?: string | null;
   sessionKey: string;
   assistantAgentId?: string | null;
@@ -296,7 +297,11 @@ export function resolveSessionNavigation(input: SessionNavigationInput): Session
   const matchesCurrentSession = (row: GatewaySessionRow) =>
     areUiSessionKeysEquivalent(row.key, currentSessionKey) ||
     (resultScopeMatches && uiSessionRowMatchesSelectedChat(input, row.key, currentSessionKey));
-  const selectedSession = input.result?.sessions.find(matchesCurrentSession);
+  const selectedSession =
+    input.result?.sessions.find(matchesCurrentSession) ??
+    (input.activeSession && matchesCurrentSession(input.activeSession)
+      ? input.activeSession
+      : undefined);
   // Catalog sessions select their own sidebar rows; synthesizing a session row
   // here would surface the raw catalog key as a phantom chat entry.
   const activeSession =

--- a/ui/src/pages/chat/chat-composer.test.ts
+++ b/ui/src/pages/chat/chat-composer.test.ts
@@ -196,11 +196,15 @@ describe("renderChatComposer controls", () => {
     expect(online.container.querySelector(".agent-chat__offline-hint")).toBeNull();
   });
 
-  it("renders and invokes the archived-session banner action", () => {
+  it("replaces the composer with the archived-session notice", () => {
     const onAction = vi.fn();
+    const onAbort = vi.fn();
     const { container } = renderComposer({
       canSend: false,
+      canAbort: true,
+      onAbort,
       disabledBanner: {
+        kind: "composer-replacement",
         text: "This session is archived. Unarchive it to continue the conversation.",
         actionLabel: "Unarchive",
         onAction,
@@ -209,8 +213,23 @@ describe("renderChatComposer controls", () => {
 
     const banner = container.querySelector(".agent-chat__disabled-banner");
     expect(banner?.textContent).toContain("This session is archived.");
+    expect(container.querySelector(".agent-chat__input")).toBeNull();
+    expect(container.querySelector("textarea")).toBeNull();
     banner?.querySelector<HTMLButtonElement>("button")?.click();
     expect(onAction).toHaveBeenCalledOnce();
+    button(container, t("chat.runControls.stopGenerating")).click();
+    expect(onAbort).toHaveBeenCalledOnce();
+  });
+
+  it("keeps the disabled composer mounted for a catalog read-only state", () => {
+    const { container } = renderComposer({
+      canSend: false,
+      disabledReason: "This catalog session is read-only.",
+    });
+
+    expect(container.querySelector(".agent-chat__disabled-banner")).toBeNull();
+    expect(container.querySelector(".agent-chat__input")).not.toBeNull();
+    expect(container.querySelector<HTMLTextAreaElement>("textarea")?.disabled).toBe(true);
   });
 
   it("switches the primary action between voice, send, queue, and stop", () => {

--- a/ui/src/pages/chat/chat-pane-render.ts
+++ b/ui/src/pages/chat/chat-pane-render.ts
@@ -311,6 +311,7 @@ export class ChatPaneRender extends ChatPaneHeaderRender {
       disabledBanner:
         selectedSessionArchived && !catalogDisabledReason
           ? {
+              kind: "composer-replacement",
               text: t("chat.archivedSessionDisabled"),
               actionLabel: t("common.unarchive"),
               onAction: () => void this.restoreArchivedSession(state.sessionKey),

--- a/ui/src/pages/chat/chat-pane-state.test.ts
+++ b/ui/src/pages/chat/chat-pane-state.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it } from "vitest";
+import type { SessionsListResult } from "../../api/types.ts";
+import { reconcileSessionHistory } from "../../lib/sessions/reconcile.ts";
+import { areUiSessionKeysEquivalent } from "../../lib/sessions/session-key.ts";
 import { applySelectedSessionProjection, SessionParticipationTracker } from "./chat-pane-state.ts";
 
 function projectionState(): Parameters<typeof applySelectedSessionProjection>[0] {
@@ -39,6 +42,41 @@ describe("applySelectedSessionProjection", () => {
       chatQueueModeOverride: "followup",
       selectedChatSessionArchived: false,
     });
+  });
+
+  it("adopts an archived routed row published after the active list omitted it", () => {
+    const routedKey = "agent:main:dashboard:cold-archive";
+    const activeResult: SessionsListResult = {
+      count: 1,
+      defaults: { contextTokens: null, model: null, modelProvider: null },
+      path: "",
+      sessions: [{ key: "agent:main:main", kind: "direct", updatedAt: 2 }],
+      ts: 2,
+    };
+    const published = reconcileSessionHistory(
+      activeResult,
+      {
+        archived: true,
+        key: routedKey,
+        kind: "direct",
+        label: "Archived planning",
+        updatedAt: 1,
+      },
+      undefined,
+      { archivedFilter: "all" },
+    );
+    const state = { ...projectionState(), selectedChatSessionArchived: false };
+    const selected = published?.sessions.find((row) =>
+      areUiSessionKeysEquivalent(row.key, routedKey),
+    );
+
+    expect(applySelectedSessionProjection(state, selected)).toBe(true);
+    expect(state.selectedChatSessionArchived).toBe(true);
+
+    const afterNavigation = reconcileSessionHistory(published, selected, undefined, {
+      archivedFilter: "active",
+    });
+    expect(afterNavigation?.sessions.map((row) => row.key)).toEqual(["agent:main:main"]);
   });
 });
 

--- a/ui/src/pages/chat/chat-view.ts
+++ b/ui/src/pages/chat/chat-view.ts
@@ -40,6 +40,7 @@ import {
   renderBackgroundTasksRail,
   type BackgroundTasksProps,
 } from "./components/chat-background-tasks.ts";
+import type { ChatComposerDisabledBanner } from "./components/chat-composer-types.ts";
 import { isChatRunWorking, renderChatComposer } from "./components/chat-composer.ts";
 import {
   inlineChatImageFromEvent,
@@ -153,7 +154,7 @@ export type ChatProps = {
   onTypingChange?: (typing: boolean) => void;
   canSend: boolean;
   disabledReason: string | null;
-  disabledBanner?: { text: string; actionLabel: string; onAction: () => void };
+  disabledBanner?: ChatComposerDisabledBanner;
   error: string | null;
   runError?: { summary: string } | null;
   inlineApproval?: ExecApprovalRequest | null;

--- a/ui/src/pages/chat/components/chat-composer-types.ts
+++ b/ui/src/pages/chat/components/chat-composer-types.ts
@@ -16,6 +16,15 @@ import type { RealtimeTalkStatus } from "../realtime-talk.ts";
 import type { ChatRunUiStatus } from "../run-lifecycle.ts";
 import type { CompactionStatus, FallbackStatus, PlanStatus } from "../tool-stream.ts";
 
+type ChatComposerDisabledBannerContent = {
+  text: string;
+  actionLabel: string;
+  onAction: () => void;
+};
+
+export type ChatComposerDisabledBanner = ChatComposerDisabledBannerContent &
+  ({ kind: "above-composer" } | { kind: "composer-replacement" });
+
 export type ChatComposerProps = {
   paneId: string;
   sessionKey: string;
@@ -25,7 +34,7 @@ export type ChatComposerProps = {
   queuedOutboxCount?: number;
   canSend: boolean;
   disabledReason: string | null;
-  disabledBanner?: { text: string; actionLabel: string; onAction: () => void };
+  disabledBanner?: ChatComposerDisabledBanner;
   runError?: { summary: string } | null;
   sending: boolean;
   canAbort?: boolean;

--- a/ui/src/pages/chat/components/chat-composer-view.ts
+++ b/ui/src/pages/chat/components/chat-composer-view.ts
@@ -102,6 +102,20 @@ export function renderChatComposerView(context: ChatComposerViewContext) {
     composerRunStatus,
   } = context;
   let questionDock: HTMLElement | null = null;
+  const disabledBanner = props.disabledBanner
+    ? html`
+        <div class="agent-chat__disabled-banner callout info callout--action" role="status">
+          <span class="callout__content">${props.disabledBanner.text}</span>
+          <button type="button" class="btn btn--xs" @click=${props.disabledBanner.onAction}>
+            ${props.disabledBanner.actionLabel}
+          </button>
+          ${props.disabledBanner.kind === "composer-replacement" && showAbortableUi
+            ? renderChatPrimaryActions(runControlsProps)
+            : nothing}
+        </div>
+      `
+    : nothing;
+  const showComposerInput = showComposer && props.disabledBanner?.kind !== "composer-replacement";
 
   return html`
     ${renderChatQueue({
@@ -141,17 +155,8 @@ export function renderChatComposerView(context: ChatComposerViewContext) {
             </div>
           `
         : nothing}
-      ${props.disabledBanner
-        ? html`
-            <div class="agent-chat__disabled-banner callout info callout--action" role="status">
-              <span class="callout__content">${props.disabledBanner.text}</span>
-              <button type="button" class="btn btn--xs" @click=${props.disabledBanner.onAction}>
-                ${props.disabledBanner.actionLabel}
-              </button>
-            </div>
-          `
-        : nothing}
-      ${showComposer
+      ${disabledBanner}
+      ${showComposerInput
         ? html`<div
             class="agent-chat__input ${props.offline ? "agent-chat__input--offline" : ""}"
             @click=${(event: MouseEvent) => focusComposerFromChrome(event, canCompose)}

--- a/ui/src/pages/sessions/sessions-page.test.ts
+++ b/ui/src/pages/sessions/sessions-page.test.ts
@@ -382,7 +382,7 @@ describe("sessions page lifecycle", () => {
     await toast.updateComplete;
     toast.querySelector<HTMLButtonElement>(".app-toast__action")?.click();
     await vi.waitFor(() => expect(patch).toHaveBeenCalledTimes(2));
-    await vi.waitFor(() => expect(mutableGateway.setSessionKey).toHaveBeenLastCalledWith(key));
+    expect(mutableGateway.setSessionKey).not.toHaveBeenCalled();
 
     expect(patch).toHaveBeenNthCalledWith(1, key, { archived: true }, { agentId: undefined });
     expect(patch).toHaveBeenNthCalledWith(

--- a/ui/src/pages/sessions/sessions-page.ts
+++ b/ui/src/pages/sessions/sessions-page.ts
@@ -904,23 +904,6 @@ class SessionsPage extends OpenClawLightDomElement {
       const selectedKeys = new Set(this.selectedKeys);
       selectedKeys.delete(key);
       this.selectedKeys = selectedKeys;
-      if (
-        patch.archived === true &&
-        areUiSessionKeysEquivalent(key, scope.gateway.snapshot.sessionKey)
-      ) {
-        scope.gateway.setSessionKey(
-          buildAgentMainSessionKey({
-            agentId:
-              parseAgentSessionKey(key)?.agentId ??
-              scope.context.agentSelection.state.selectedId ??
-              "main",
-            mainKey: resolveUiConfiguredMainKey({
-              agentsList: scope.context.agents.state.agentsList,
-              hello: scope.gateway.snapshot.hello,
-            }),
-          }),
-        );
-      }
       return "completed";
     } catch (error) {
       if (this.isRequestScopeCurrent(scope)) {
@@ -936,7 +919,6 @@ class SessionsPage extends OpenClawLightDomElement {
     if (!scope) {
       return;
     }
-    const wasActive = areUiSessionKeysEquivalent(row.key, scope.gateway.snapshot.sessionKey);
     const result = await this.patchSession(row.key, { archived: true }, scope);
     if (result !== "completed" || !this.isRequestScopeCurrent(scope)) {
       return;
@@ -949,14 +931,11 @@ class SessionsPage extends OpenClawLightDomElement {
           if (!this.isRequestScopeCurrent(scope)) {
             return;
           }
-          const restored = await this.patchSession(
+          await this.patchSession(
             row.key,
             { archived: false, ...(row.pinned === true ? { pinned: true } : {}) },
             scope,
           );
-          if (restored === "completed" && wasActive && this.isRequestScopeCurrent(scope)) {
-            scope.gateway.setSessionKey(row.key);
-          }
         })();
       },
     });

--- a/ui/src/test-helpers/app-sidebar-cases/child-sessions.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/child-sessions.ts
@@ -474,7 +474,6 @@ describe("AppSidebar agent chip", () => {
         .querySelector('[data-session-key="agent:worker:child"]')
         ?.classList.contains("sidebar-recent-session--active"),
     ).toBe(true);
-
     const toggle = sidebar.querySelector<HTMLButtonElement>(
       '[data-child-session-toggle="agent:main:parent"]',
     );
@@ -489,6 +488,52 @@ describe("AppSidebar agent chip", () => {
     await waitForFast(() =>
       expect(sidebar.querySelector('[data-session-key="agent:worker:child"]')).not.toBeNull(),
     );
+  });
+
+  it("keeps the selected archived child when its archived parent is filtered out", async () => {
+    const request = vi.fn(async (_method: string, params: { key: string }) => ({
+      session:
+        params.key === "agent:worker:child"
+          ? {
+              key: "agent:worker:child",
+              parentSessionKey: "agent:main:parent",
+              kind: "direct" as const,
+              label: "Selected child",
+              archived: true,
+              updatedAt: 2,
+            }
+          : {
+              key: "agent:main:parent",
+              kind: "direct" as const,
+              label: "Archived parent",
+              archived: true,
+              updatedAt: 1,
+              childSessions: ["agent:worker:child"],
+            },
+    }));
+    const gateway = createGateway({ request } as unknown as GatewayBrowserClient);
+    const harness = createSessionsHarness("main", []);
+    const { sidebar, context } = await mountSidebar(gateway, harness.sessions);
+    context.agentSelection.state.selectedId = "main";
+    context.agentSelection.state.scopeId = "main";
+    (sidebar as unknown as { activeRouteId: string }).activeRouteId = "chat";
+    sidebar.sessionKey = "agent:worker:child";
+
+    await waitForFast(() => expect(request).toHaveBeenCalledTimes(2));
+    await waitForFast(() =>
+      expect(sidebar.querySelector('[data-session-key="agent:worker:child"]')).not.toBeNull(),
+    );
+    expect(sidebar.querySelector('[data-session-key="agent:main:parent"]')).toBeNull();
+    expect(
+      sidebar.querySelector(
+        '[data-session-key="agent:worker:child"] .sidebar-session__archive-glyph',
+      ),
+    ).not.toBeNull();
+    expect(
+      sidebar
+        .querySelector('[data-session-key="agent:worker:child"]')
+        ?.classList.contains("sidebar-recent-session--active"),
+    ).toBe(true);
   });
 
   it("retries a failed child load after collapsing and reopening the parent", async () => {

--- a/ui/src/test-helpers/app-sidebar-cases/sessions.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/sessions.ts
@@ -479,16 +479,14 @@ describe("AppSidebar session mutation feedback", () => {
     toast.querySelector<HTMLButtonElement>(".app-toast__action")?.click();
 
     await vi.waitFor(() => expect(harness.patch).toHaveBeenCalledTimes(2));
-    await vi.waitFor(() => expect(setSessionKey).toHaveBeenLastCalledWith(archivedRow.key));
+    expect(setSessionKey).not.toHaveBeenCalled();
     // Undo restores through the batch helper, which refreshes once at the end.
     expect(harness.patch).toHaveBeenLastCalledWith(
       archivedRow.key,
       { archived: false, pinned: true },
       { agentId: "main", deferListRefresh: true },
     );
-    expect(navigate).toHaveBeenLastCalledWith("chat", {
-      search: "?session=agent%3Amain%3Aa",
-    });
+    expect(navigate).not.toHaveBeenCalled();
   });
 
   it("patches a session icon from the picker", async () => {

--- a/ui/src/test-helpers/app-sidebar.ts
+++ b/ui/src/test-helpers/app-sidebar.ts
@@ -21,6 +21,7 @@ import type {
 import type { SessionDataController } from "../components/session-data-controller.ts";
 import type { SessionOrganizerController } from "../components/session-organizer-controller.ts";
 import type { SessionCapability } from "../lib/sessions/index.ts";
+import { reconcileSessionHistory } from "../lib/sessions/reconcile.ts";
 import { createApplicationContextProvider } from "./application-context.ts";
 import { createStorageMock } from "./storage.ts";
 
@@ -210,6 +211,17 @@ export function createSessionsHarness(agentId: string, keys: string[]) {
   const list = vi.fn((_options?: Parameters<SessionCapability["list"]>[0]) =>
     Promise.resolve<SessionsListResult | null>(null),
   );
+  const reconcile = vi.fn<SessionCapability["reconcile"]>((row, defaults, options) => {
+    const result = reconcileSessionHistory(state.result, row, defaults, options);
+    if (result === state.result) {
+      return false;
+    }
+    state = { ...state, result };
+    for (const listener of listeners) {
+      listener(state);
+    }
+    return true;
+  });
   const sessions = {
     get state() {
       return state;
@@ -242,6 +254,7 @@ export function createSessionsHarness(agentId: string, keys: string[]) {
     delete: deleteSession,
     deleteMany,
     list,
+    reconcile,
     setCreatorFilter,
     refresh,
     refreshReplacement,
@@ -264,6 +277,7 @@ export function createSessionsHarness(agentId: string, keys: string[]) {
     deleteSession,
     deleteMany,
     list,
+    reconcile,
     setCreatorFilter,
     refresh,
     refreshReplacement,


### PR DESCRIPTION
## What Problem This Solves

Archiving the currently open session force-jumped the sidebar selection to the agent main session (both from the sidebar thread menu / multi-select batch and from the Sessions page). Combined with the list reloads that archiving triggers, this read as the UI "randomly losing the sidebar selection". The archived session also kept rendering a live-looking (but disabled) composer under the archived banner.

## Why This Change Was Made

Selection is route/state owned and should never move because an entry changed archive state. The sidebar projection already synthesizes a visible row for a selected session that falls out of the active-filtered list, so the right fix is to delete the navigation-on-archive code paths and make the archived state explicit at the composer seam instead.

- `patchSession` and the Sessions page no longer navigate to the agent main session on archive; the undo paths no longer re-select (nothing moved).
- The sidebar per-agent projection now admits the selected lineage root even when it is archived, and promotes the selected fallback row so the archived entry stays rendered and selectable under the default "active" filter.
- When the selected session is archived, the archived notice (with Unarchive) now **replaces** the composer via a typed `ChatComposerDisabledBanner` placement variant instead of stacking above a disabled input; Stop stays available while a run is still draining. Other disabled states (read-only share, catalog view-only, offline, question takeover) are unchanged.

## User Impact

Archiving a session — including the one you are looking at — never moves your selection. The archived entry remains in the sidebar with the archive glyph, stays selectable, and the chat shows "This session is archived. Unarchive it to continue the conversation." in place of the composer. Unarchiving restores the composer in place.

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/sidebar-archived-selection/before-archived-selected.png) | ![after](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/sidebar-archived-selection/after-archived-selected.png) |

## Evidence

- New load-shaped E2E: 15 sessions, batch-archive several rows with a `sessions.changed` refresh after each patch, then archive the selected session — asserts the selected route and active sidebar row never change, the composer is replaced by the archived notice, and unarchive restores it (`ui/src/e2e/session-management.e2e.test.ts`).
- Unit coverage: selected archived session absent from an active-filtered list still resolves as the active row (`ui/src/lib/sessions/navigation.test.ts`); sidebar archive + undo never call `setSessionKey`/navigate (`ui/src/test-helpers/app-sidebar-cases/sessions.ts`, `ui/src/pages/sessions/sessions-page.test.ts`); composer replacement + unarchive action (`ui/src/pages/chat/chat-composer.test.ts`); archived cross-agent children and filtered archived parents (`ui/src/test-helpers/app-sidebar-cases/child-sessions.ts`).
- Local proof: `node scripts/run-vitest.mjs ui/src/lib/sessions/navigation.test.ts ui/src/components/app-sidebar.test.ts ui/src/pages/chat/chat-composer.test.ts ui/src/pages/sessions/sessions-page.test.ts ui/src/e2e/session-management.e2e.test.ts` — 2 shards, all passed (navigation 14, sidebar 170, composer 30, sessions page 22, e2e 20).
- Autoreview (Codex `gpt-5.6-sol`, xhigh): clean, no accepted findings.
- Screenshots above captured from the mocked-gateway e2e harness (deterministic fixtures, no real data).


## Real-Setup Proof (live scratch gateway)

Verified against a **real gateway** run from this branch head (`ee85007295c`): isolated `OPENCLAW_STATE_DIR`, token auth on loopback port 19790, gateway-served production UI build, 15 real sessions created via `sessions.create`/`sessions.patch` RPC.

Live flow exercised in the browser: selected "Load test 11", archived several **other** sessions one by one (each triggering `sessions.changed` list reloads) — selection never moved; then archived the **selected** session via its thread menu — the row stayed selected in the sidebar with the archive glyph and the composer was replaced by the archived notice; Unarchive restored the composer in place.

This live testing surfaced a cold-load gap (fixed in `ee85007295c`): a fresh page load deep-linked to an archived session rendered a live composer because the session is absent from the active-filtered list and neither history `sessionInfo` nor list rows carried `archived`. The sidebar's existing `sessions.describe` lineage row is now published through the sessions store's reconcile seam, so the chat pane and header share the sidebar's cold-load truth; navigating away evicts the injected row via the normal active filter.

| Live: cold-load of archived selected session | Live: after clicking Unarchive |
| --- | --- |
| ![live archived](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/sidebar-archived-selection/live-archived-selected.png) | ![live restored](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/sidebar-archived-selection/live-unarchived-restored.png) |

Additional evidence for the new commit: cold-load unit coverage in `ui/src/pages/chat/chat-pane-state.test.ts`, new cold-load E2E scenario in `ui/src/e2e/session-management.e2e.test.ts` (21/21 on the archive scenarios), fresh clean autoreview. The `pages sidebar sessions and supports complete drag-managed groups` E2E test is flaky on the local runner independent of this branch — the origin/main version of the file fails the same test (plus one more) on the same machine; the e2e lane is not part of PR CI.
