### PR TITLE
fix(ui): new sessions remember valid workspace and model choices

### DIFF
--- a/ui/src/e2e/new-session-page.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.e2e.test.ts
@@ -753,7 +753,7 @@ describeControlUiE2e("Control UI new-session page mocked Gateway E2E", () => {
     }
   });
 
-  it("restores the last valid place, worktree, model, and reasoning in a new draft", async () => {
+  it("restores valid preferences and repairs a worktree rejected by workspace metadata", async () => {
     const context = await browser.newContext({
       locale: "en-US",
       serviceWorkers: "block",
@@ -843,6 +843,53 @@ describeControlUiE2e("Control UI new-session page mocked Gateway E2E", () => {
 
       const branchRequests = await gateway.getRequests("worktrees.branches");
       expect(branchRequests.at(-1)?.params).toMatchObject({ repoRoot: PICKED });
+
+      await page.evaluate((workspace) => {
+        const key = Array.from({ length: localStorage.length }, (_, index) =>
+          localStorage.key(index),
+        ).find((candidate) => candidate?.startsWith("openclaw.new-session.preferences.v1:"));
+        if (!key) {
+          throw new Error("missing new-session preference");
+        }
+        const value = JSON.parse(localStorage.getItem(key) ?? "null") as {
+          agents?: Record<string, { folder?: string; workspace?: string }>;
+        };
+        const main = value.agents?.main;
+        if (!main) {
+          throw new Error("missing main-agent preference");
+        }
+        main.folder = workspace;
+        main.workspace = workspace;
+        localStorage.setItem(key, JSON.stringify(value));
+      }, WORKSPACE);
+      await gateway.setMethodResponse("agents.list", {
+        agents: [
+          {
+            id: "main",
+            identity: { name: "Main" },
+            name: "Main",
+            workspace: WORKSPACE,
+            workspaceGit: false,
+          },
+        ],
+        defaultId: "main",
+        mainKey: "main",
+        scope: "agent",
+      });
+      await page.reload();
+      await expect.poll(() => placeTrigger.getAttribute("data-worktree")).toBe("false");
+      const storedWorktree = await page.evaluate(() => {
+        const key = Array.from({ length: localStorage.length }, (_, index) =>
+          localStorage.key(index),
+        ).find((candidate) => candidate?.startsWith("openclaw.new-session.preferences.v1:"));
+        const value = key
+          ? (JSON.parse(localStorage.getItem(key) ?? "null") as {
+              agents?: Record<string, { worktree?: boolean }>;
+            } | null)
+          : null;
+        return value?.agents?.main?.worktree;
+      });
+      expect(storedWorktree).toBe(false);
     } finally {
       await context.close();
     }

--- a/ui/src/e2e/new-session-page.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.e2e.test.ts
@@ -986,8 +986,11 @@ describeControlUiE2e("Control UI new-session page mocked Gateway E2E", () => {
         code: "UNAVAILABLE",
         message: "branch lookup unavailable",
       });
-      await expect.poll(() => start.isDisabled()).toBe(true);
-      await expect.poll(() => placeTrigger.getAttribute("data-worktree")).toBe("true");
+      // A failed lookup disables the worktree toggle, so restoring the stored
+      // choice would strand the draft behind a control the user cannot clear.
+      // The draft drops it and stays submittable; storage keeps the preference.
+      await expect.poll(() => placeTrigger.getAttribute("data-worktree")).toBe("false");
+      await expect.poll(() => start.isDisabled()).toBe(false);
 
       await page.reload();
       await page.locator(".new-session-page__message").fill("keep both remembered choices");

--- a/ui/src/e2e/new-session-page.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.e2e.test.ts
@@ -3872,6 +3872,13 @@ describeControlUiE2e("Control UI new-session page mocked Gateway E2E", () => {
               workspace: WORKSPACE,
               workspaceGit: true,
             },
+            {
+              id: "research",
+              identity: { name: "Research" },
+              name: "Research",
+              workspace: "/home/peter/research",
+              workspaceGit: true,
+            },
           ],
           defaultId: "main",
           mainKey: "main",
@@ -3982,11 +3989,22 @@ describeControlUiE2e("Control UI new-session page mocked Gateway E2E", () => {
       // Using a node folder retargets the draft to that node.
       await expect.poll(() => placeLabel.textContent()).toBe("Projects · MacBook");
 
+      // A node cwd belongs to the selected agent's draft and must not leak
+      // across an agent change, even though the execution node stays selected.
+      const agentPicker = page.locator(".new-session-page__select--agent openclaw-agent-select");
+      await agentPicker.locator(".agent-select__trigger").click();
+      await agentPicker
+        .locator("wa-dropdown-item[data-agent-option]")
+        .filter({ hasText: "Research" })
+        .click();
+      await page.getByRole("heading", { name: "Research" }).waitFor();
+      await expect.poll(() => placeLabel.textContent()).toBe("Agent workspace · MacBook");
+
       // Clearing the path applies the node's default directory (empty folder),
       // the state the replaced clearable folder textbox could express.
       await placeTrigger.click();
       await placeSelect.getByRole("button", { name: "Browse folders" }).click();
-      await expect.poll(() => pathInput.inputValue()).toBe(NODE_PICKED);
+      await expect.poll(() => pathInput.inputValue()).toBe(NODE_HOME);
       await pathInput.fill("");
       await page.getByRole("button", { name: "Use this folder" }).click();
       await expect.poll(() => placeLabel.textContent()).toBe("Agent workspace · MacBook");
@@ -4018,7 +4036,7 @@ describeControlUiE2e("Control UI new-session page mocked Gateway E2E", () => {
       await page.getByRole("button", { name: "Start thread" }).click();
       const createRequest = await gateway.waitForRequest("sessions.create");
       expect(createRequest.params).toMatchObject({
-        agentId: "main",
+        agentId: "research",
         message: "inspect the remote checkout",
         execNode: "old-node",
         cwd: EXEC_ONLY_PICKED,

--- a/ui/src/e2e/new-session-page.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.e2e.test.ts
@@ -919,6 +919,30 @@ describeControlUiE2e("Control UI new-session page mocked Gateway E2E", () => {
       await expect
         .poll(() => placeTrigger.locator(".new-session-page__trigger-label").textContent())
         .toBe("openclaw");
+
+      const pickedListRequests = (await gateway.getRequests("fs.listDir")).filter(
+        (request) => request.params?.path === PICKED,
+      ).length;
+      await navigateInApp(page, "chat");
+      await page.waitForURL((url) => url.pathname.endsWith("/chat"));
+      await navigateInApp(page, "new-session");
+      await expect
+        .poll(() => placeTrigger.locator(".new-session-page__trigger-label").textContent())
+        .toBe("openclaw");
+      await expect.poll(() => placeTrigger.getAttribute("data-worktree")).toBe("false");
+      await expect
+        .poll(
+          async () =>
+            (await gateway.getRequests("fs.listDir")).filter(
+              (request) => request.params?.path === PICKED,
+            ).length,
+        )
+        .toBe(pickedListRequests);
+
+      await message.fill("use the repaired preference");
+      await expect
+        .poll(() => page.getByRole("button", { name: "Start thread" }).isDisabled())
+        .toBe(false);
       await page.getByRole("button", { name: "Start thread" }).click();
       const create = await gateway.waitForRequest("sessions.create");
       expect(create.params).not.toHaveProperty("cwd");

--- a/ui/src/e2e/new-session-page.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.e2e.test.ts
@@ -38,6 +38,7 @@ const PICKED = "/home/peter/openclaw/packages";
 const SOURCE_REPO = "/tmp/source-repo";
 const TARGET_REPO = "/tmp/target-repo";
 const REFRESHED_RESEARCH_WORKSPACE = "/home/peter/research-next";
+const MOVED_WORKSPACE = "/home/peter/openclaw-next";
 const NODE_HOME = "/Users/peter";
 const NODE_PICKED = "/Users/peter/Projects";
 const NODE_UNC = "\\\\server\\share\\repo";
@@ -843,6 +844,103 @@ describeControlUiE2e("Control UI new-session page mocked Gateway E2E", () => {
 
       const branchRequests = await gateway.getRequests("worktrees.branches");
       expect(branchRequests.at(-1)?.params).toMatchObject({ repoRoot: PICKED });
+    } finally {
+      await context.close();
+    }
+  });
+
+  it("repairs a remembered default folder when the agent workspace moves", async () => {
+    const context = await browser.newContext({ locale: "en-US", serviceWorkers: "block" });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      workspaceGit: true,
+      models: [
+        { id: "gpt-5.5", name: "GPT 5.5", provider: "openai", reasoning: true },
+        {
+          id: "claude-sonnet-4-6",
+          name: "Claude Sonnet 4.6",
+          provider: "anthropic",
+          reasoning: true,
+        },
+      ],
+      methodResponses: {
+        "agents.list": {
+          agents: [
+            {
+              id: "main",
+              identity: { name: "Main" },
+              name: "Main",
+              workspace: WORKSPACE,
+              workspaceGit: true,
+            },
+          ],
+          defaultId: "main",
+          mainKey: "main",
+          scope: "agent",
+        },
+        "worktrees.branches": {
+          branches: [{ kind: "local", name: "main" }],
+          defaultBranch: "main",
+          repositoryStatus: "git",
+        },
+        "fs.listDir": {
+          path: WORKSPACE,
+          parent: "/home/peter",
+          home: "/home/peter",
+          entries: [],
+        },
+      },
+    });
+    try {
+      await page.goto(`${server.baseUrl}new`);
+      const placeTrigger = page.locator("#new-session-place-trigger");
+      await placeTrigger.click();
+      await page.getByRole("button", { name: "Browse folders" }).click();
+      await page.getByRole("button", { name: "Use this folder" }).click();
+      await navigateInApp(page, "chat");
+      await page.waitForURL((url) => url.pathname.endsWith("/chat"));
+
+      await gateway.setMethodResponse("agents.list", {
+        agents: [
+          {
+            id: "main",
+            identity: { name: "Main" },
+            name: "Main",
+            workspace: MOVED_WORKSPACE,
+            workspaceGit: true,
+          },
+        ],
+        defaultId: "main",
+        mainKey: "main",
+        scope: "agent",
+      });
+      await page.reload();
+      await navigateInApp(page, "new-session");
+      await expect
+        .poll(() => placeTrigger.locator(".new-session-page__trigger-label").textContent())
+        .toBe("openclaw-next");
+
+      const modelSelect = page.locator('[data-chat-model-select="true"]');
+      await modelSelect.click();
+      await page.locator('[data-chat-model-provider="anthropic"]').click();
+      await page.locator('[data-chat-model-option="anthropic/claude-sonnet-4-6"]').click();
+      const storedPreference = await page.evaluate(() => {
+        const key = Array.from({ length: localStorage.length }, (_, index) =>
+          localStorage.key(index),
+        ).find((candidate) => candidate?.startsWith("openclaw.new-session.preferences.v1:"));
+        if (!key) {
+          return null;
+        }
+        const value = JSON.parse(localStorage.getItem(key) ?? "null") as {
+          agents?: Record<string, unknown>;
+        } | null;
+        return value?.agents?.main ?? null;
+      });
+      expect(storedPreference).toMatchObject({
+        workspace: MOVED_WORKSPACE,
+        folder: MOVED_WORKSPACE,
+        model: "anthropic/claude-sonnet-4-6",
+      });
     } finally {
       await context.close();
     }

--- a/ui/src/e2e/new-session-page.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.e2e.test.ts
@@ -112,6 +112,24 @@ async function navigateInApp(page: Page, routeId: string, search = "") {
   );
 }
 
+/**
+ * The chat route pushes its base path and then commits the session path. A
+ * navigation issued inside that window is replaced by the committed route and
+ * rejected as notFound, so wait for the path to settle before leaving again.
+ */
+async function waitForCommittedChatRoute(page: Page) {
+  await page.waitForURL((url) => url.pathname.startsWith("/chat"));
+  let previous = "";
+  await expect
+    .poll(() => {
+      const current = new URL(page.url()).pathname;
+      const settled = current === previous;
+      previous = current;
+      return settled;
+    })
+    .toBe(true);
+}
+
 async function choosePackagesFolder(page: Page) {
   await page.locator("#new-session-place-trigger").click();
   await page.getByRole("button", { name: "Browse folders" }).click();
@@ -963,7 +981,7 @@ describeControlUiE2e("Control UI new-session page mocked Gateway E2E", () => {
       await page.locator('[data-chat-model-option="anthropic/claude-sonnet-4-6"]').click();
 
       await navigateInApp(page, "chat");
-      await page.waitForURL((url) => url.pathname.endsWith("/chat"));
+      await waitForCommittedChatRoute(page);
       const metadataRequests = (await gateway.getRequests("chat.metadata")).length;
       const branchRequests = (await gateway.getRequests("worktrees.branches")).length;
       await gateway.deferNext("chat.metadata");
@@ -1159,7 +1177,7 @@ describeControlUiE2e("Control UI new-session page mocked Gateway E2E", () => {
       await choosePackagesFolder(page);
 
       await navigateInApp(page, "chat");
-      await page.waitForURL((url) => url.pathname.endsWith("/chat"));
+      await waitForCommittedChatRoute(page);
       const validationRequests = (await gateway.getRequests("fs.listDir")).length;
       await gateway.deferNext("fs.listDir");
       await navigateInApp(page, "new-session");
@@ -1189,7 +1207,7 @@ describeControlUiE2e("Control UI new-session page mocked Gateway E2E", () => {
           request.params.path === PICKED,
       ).length;
       await navigateInApp(page, "chat");
-      await page.waitForURL((url) => url.pathname.endsWith("/chat"));
+      await waitForCommittedChatRoute(page);
       await navigateInApp(page, "new-session");
       await expect
         .poll(() => placeTrigger.locator(".new-session-page__trigger-label").textContent())
@@ -1270,7 +1288,7 @@ describeControlUiE2e("Control UI new-session page mocked Gateway E2E", () => {
       await choosePackagesFolder(page);
 
       await navigateInApp(page, "chat");
-      await page.waitForURL((url) => url.pathname.endsWith("/chat"));
+      await waitForCommittedChatRoute(page);
       const validationRequests = (await gateway.getRequests("fs.listDir")).length;
       await gateway.deferNext("fs.listDir");
       await navigateInApp(page, "new-session");

--- a/ui/src/e2e/new-session-page.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.e2e.test.ts
@@ -1306,6 +1306,19 @@ describeControlUiE2e("Control UI new-session page mocked Gateway E2E", () => {
       await expect
         .poll(() => trigger.locator(".new-session-page__trigger-label").textContent())
         .toContain("target-repo");
+      const storedPreference = await page.evaluate(() => {
+        const key = Array.from({ length: localStorage.length }, (_, index) =>
+          localStorage.key(index),
+        ).find((candidate) => candidate?.startsWith("openclaw.new-session.preferences.v1:"));
+        if (!key) {
+          return null;
+        }
+        const value = JSON.parse(localStorage.getItem(key) ?? "null") as {
+          agents?: Record<string, unknown>;
+        } | null;
+        return value?.agents?.main ?? null;
+      });
+      expect(storedPreference).toMatchObject({ folder: TARGET_REPO });
     } finally {
       await context.close();
     }

--- a/ui/src/e2e/new-session-page.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.e2e.test.ts
@@ -763,12 +763,11 @@ describeControlUiE2e("Control UI new-session page mocked Gateway E2E", () => {
     const gateway = await installMockGateway(page, {
       workspaceGit: true,
       models: [
-        { id: "gpt-5.5", name: "GPT 5.5", provider: "openai", reasoning: true },
+        { id: "gpt-5.5", name: "GPT 5.5", provider: "openai" },
         {
           id: "claude-sonnet-4-6",
           name: "Claude Sonnet 4.6",
           provider: "anthropic",
-          reasoning: true,
         },
       ],
       methodResponses: {
@@ -853,12 +852,11 @@ describeControlUiE2e("Control UI new-session page mocked Gateway E2E", () => {
     const context = await browser.newContext({ locale: "en-US", serviceWorkers: "block" });
     const page = await context.newPage();
     const models = [
-      { id: "gpt-5.5", name: "GPT 5.5", provider: "openai", reasoning: true },
+      { id: "gpt-5.5", name: "GPT 5.5", provider: "openai" },
       {
         id: "claude-sonnet-4-6",
         name: "Claude Sonnet 4.6",
         provider: "anthropic",
-        reasoning: true,
       },
     ];
     const branches = {
@@ -971,12 +969,11 @@ describeControlUiE2e("Control UI new-session page mocked Gateway E2E", () => {
     const gateway = await installMockGateway(page, {
       workspaceGit: true,
       models: [
-        { id: "gpt-5.5", name: "GPT 5.5", provider: "openai", reasoning: true },
+        { id: "gpt-5.5", name: "GPT 5.5", provider: "openai" },
         {
           id: "claude-sonnet-4-6",
           name: "Claude Sonnet 4.6",
           provider: "anthropic",
-          reasoning: true,
         },
       ],
       methodResponses: {
@@ -1135,7 +1132,8 @@ describeControlUiE2e("Control UI new-session page mocked Gateway E2E", () => {
         .toBe("openclaw");
 
       const pickedListRequests = (await gateway.getRequests("fs.listDir")).filter(
-        (request) => request.params?.path === PICKED,
+        (request) =>
+          request.params != null && "path" in request.params && request.params.path === PICKED,
       ).length;
       await navigateInApp(page, "chat");
       await page.waitForURL((url) => url.pathname.endsWith("/chat"));
@@ -1148,7 +1146,10 @@ describeControlUiE2e("Control UI new-session page mocked Gateway E2E", () => {
         .poll(
           async () =>
             (await gateway.getRequests("fs.listDir")).filter(
-              (request) => request.params?.path === PICKED,
+              (request) =>
+                request.params != null &&
+                "path" in request.params &&
+                request.params.path === PICKED,
             ).length,
         )
         .toBe(pickedListRequests);

--- a/ui/src/e2e/new-session-page.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.e2e.test.ts
@@ -849,6 +849,122 @@ describeControlUiE2e("Control UI new-session page mocked Gateway E2E", () => {
     }
   });
 
+  it("blocks an immediate submit until remembered model and worktree choices validate", async () => {
+    const context = await browser.newContext({ locale: "en-US", serviceWorkers: "block" });
+    const page = await context.newPage();
+    const models = [
+      { id: "gpt-5.5", name: "GPT 5.5", provider: "openai", reasoning: true },
+      {
+        id: "claude-sonnet-4-6",
+        name: "Claude Sonnet 4.6",
+        provider: "anthropic",
+        reasoning: true,
+      },
+    ];
+    const branches = {
+      branches: [{ kind: "local", name: "main" }],
+      defaultBranch: "main",
+      repositoryStatus: "git",
+    };
+    const gateway = await installMockGateway(page, {
+      workspaceGit: true,
+      models,
+      methodResponses: {
+        "agents.list": {
+          agents: [
+            {
+              id: "main",
+              identity: { name: "Main" },
+              name: "Main",
+              workspace: WORKSPACE,
+              workspaceGit: true,
+            },
+          ],
+          defaultId: "main",
+          mainKey: "main",
+          scope: "agent",
+        },
+        "worktrees.branches": branches,
+        "fs.listDir": {
+          cases: [
+            {
+              match: { path: WORKSPACE },
+              response: {
+                path: WORKSPACE,
+                parent: "/home/peter",
+                home: "/home/peter",
+                entries: [{ name: "packages", path: PICKED }],
+              },
+            },
+            {
+              match: { path: PICKED },
+              response: { path: PICKED, parent: WORKSPACE, home: "/home/peter", entries: [] },
+            },
+          ],
+        },
+        "sessions.create": { key: "agent:main:restored-fast-submit", runStarted: true },
+      },
+    });
+    try {
+      await page.goto(`${server.baseUrl}new`);
+      await choosePackagesFolder(page);
+      const placeTrigger = page.locator("#new-session-place-trigger");
+      await placeTrigger.click();
+      await page.getByRole("button", { name: "Worktree" }).click();
+      await page.keyboard.press("Escape");
+      const modelSelect = page.locator('[data-chat-model-select="true"]');
+      await modelSelect.click();
+      await page.locator('[data-chat-model-provider="anthropic"]').click();
+      await page.locator('[data-chat-model-option="anthropic/claude-sonnet-4-6"]').click();
+
+      await navigateInApp(page, "chat");
+      await page.waitForURL((url) => url.pathname.endsWith("/chat"));
+      const metadataRequests = (await gateway.getRequests("chat.metadata")).length;
+      const branchRequests = (await gateway.getRequests("worktrees.branches")).length;
+      await gateway.deferNext("chat.metadata");
+      await gateway.deferNext("worktrees.branches");
+      await navigateInApp(page, "new-session");
+      await expect
+        .poll(async () => (await gateway.getRequests("chat.metadata")).length)
+        .toBe(metadataRequests + 1);
+      await expect
+        .poll(async () => (await gateway.getRequests("worktrees.branches")).length)
+        .toBe(branchRequests + 1);
+
+      await page.locator(".new-session-page__message").fill("keep both remembered choices");
+      const start = page.getByRole("button", { name: "Start thread" });
+      await expect.poll(() => start.isDisabled()).toBe(true);
+
+      await gateway.resolveDeferred("chat.metadata", { models });
+      await expect.poll(() => start.isDisabled()).toBe(true);
+      await gateway.rejectDeferred("worktrees.branches", {
+        code: "UNAVAILABLE",
+        message: "branch lookup unavailable",
+      });
+      await expect.poll(() => start.isDisabled()).toBe(true);
+      await expect.poll(() => placeTrigger.getAttribute("data-worktree")).toBe("true");
+
+      await page.reload();
+      await page.locator(".new-session-page__message").fill("keep both remembered choices");
+      await expect
+        .poll(() => modelSelect.getAttribute("data-chat-select-value"))
+        .toBe("anthropic/claude-sonnet-4-6");
+      await expect.poll(() => placeTrigger.getAttribute("data-worktree")).toBe("true");
+      await expect.poll(() => start.isDisabled()).toBe(false);
+      await start.click();
+
+      const create = await gateway.waitForRequest("sessions.create");
+      expect(create.params).toMatchObject({
+        cwd: PICKED,
+        message: "keep both remembered choices",
+        model: "anthropic/claude-sonnet-4-6",
+        worktree: true,
+      });
+    } finally {
+      await context.close();
+    }
+  });
+
   it("repairs a remembered default folder when the agent workspace moves", async () => {
     const context = await browser.newContext({ locale: "en-US", serviceWorkers: "block" });
     const page = await context.newPage();
@@ -1126,6 +1242,69 @@ describeControlUiE2e("Control UI new-session page mocked Gateway E2E", () => {
       await page.getByRole("button", { name: "Start thread" }).click();
       const create = await gateway.waitForRequest("sessions.create");
       expect(create.params).not.toHaveProperty("cwd");
+    } finally {
+      await context.close();
+    }
+  });
+
+  it("keeps a folder chosen before the agent roster finishes loading submit-ready", async () => {
+    const context = await browser.newContext({ locale: "en-US", serviceWorkers: "block" });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      deferredMethods: ["agents.list"],
+      workspaceGit: true,
+      methodResponses: {
+        "agents.list": {
+          agents: [
+            {
+              id: "main",
+              identity: { name: "Main" },
+              name: "Main",
+              workspace: WORKSPACE,
+              workspaceGit: true,
+            },
+          ],
+          defaultId: "main",
+          mainKey: "main",
+          scope: "agent",
+        },
+        "fs.listDir": { path: TARGET_REPO, home: "/home/peter", entries: [] },
+        "worktrees.branches": {
+          branches: [{ kind: "local", name: "main" }],
+          defaultBranch: "main",
+          repositoryStatus: "git",
+        },
+      },
+    });
+    try {
+      await page.goto(`${server.baseUrl}new`);
+      const trigger = page.locator("#new-session-place-trigger");
+      await trigger.click();
+      await page.getByRole("button", { name: "Browse folders" }).click();
+      await page.locator("input.new-session-page__browser-path").fill(TARGET_REPO);
+      await page.getByRole("button", { name: "Use this folder" }).click();
+      await gateway.resolveDeferred("agents.list", {
+        agents: [
+          {
+            id: "main",
+            identity: { name: "Main" },
+            name: "Main",
+            workspace: WORKSPACE,
+            workspaceGit: true,
+          },
+        ],
+        defaultId: "main",
+        mainKey: "main",
+        scope: "agent",
+      });
+
+      await page.locator(".new-session-page__message").fill("keep my early folder choice");
+      await expect
+        .poll(() => page.getByRole("button", { name: "Start thread" }).isDisabled())
+        .toBe(false);
+      await expect
+        .poll(() => trigger.locator(".new-session-page__trigger-label").textContent())
+        .toContain("target-repo");
     } finally {
       await context.close();
     }
@@ -3160,6 +3339,18 @@ describeControlUiE2e("Control UI new-session page mocked Gateway E2E", () => {
         .toBe(branchRequests + 1);
 
       await expect.poll(() => trigger.getAttribute("data-worktree")).toBe("false");
+      const storedWorktree = await page.evaluate(() => {
+        const key = Array.from({ length: localStorage.length }, (_, index) =>
+          localStorage.key(index),
+        ).find((candidate) => candidate?.startsWith("openclaw.new-session.preferences.v1:"));
+        const value = key
+          ? (JSON.parse(localStorage.getItem(key) ?? "null") as {
+              agents?: Record<string, { worktree?: boolean }>;
+            } | null)
+          : null;
+        return value?.agents?.main?.worktree;
+      });
+      expect(storedWorktree).toBe(false);
       await trigger.click();
       expect(await place.getByRole("button", { name: "Worktree" }).count()).toBe(0);
       await page.keyboard.press("Escape");

--- a/ui/src/e2e/new-session-page.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.e2e.test.ts
@@ -1180,7 +1180,10 @@ describeControlUiE2e("Control UI new-session page mocked Gateway E2E", () => {
 
       const pickedListRequests = (await gateway.getRequests("fs.listDir")).filter(
         (request) =>
-          request.params != null && "path" in request.params && request.params.path === PICKED,
+          typeof request.params === "object" &&
+          request.params != null &&
+          "path" in request.params &&
+          request.params.path === PICKED,
       ).length;
       await navigateInApp(page, "chat");
       await page.waitForURL((url) => url.pathname.endsWith("/chat"));
@@ -1194,6 +1197,7 @@ describeControlUiE2e("Control UI new-session page mocked Gateway E2E", () => {
           async () =>
             (await gateway.getRequests("fs.listDir")).filter(
               (request) =>
+                typeof request.params === "object" &&
                 request.params != null &&
                 "path" in request.params &&
                 request.params.path === PICKED,

--- a/ui/src/e2e/new-session-page.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.e2e.test.ts
@@ -92,6 +92,32 @@ async function replaceGatewayClient(page: Page) {
   });
 }
 
+async function navigateInApp(page: Page, routeId: string, search = "") {
+  await page.evaluate(
+    ({ targetRouteId, targetSearch }) => {
+      const app = document.querySelector("openclaw-app") as HTMLElement & {
+        runtime?: {
+          context: {
+            navigate: (routeId: string, options?: { search?: string }) => void;
+          };
+        };
+      };
+      if (!app.runtime) {
+        throw new Error("OpenClaw application runtime is unavailable");
+      }
+      app.runtime.context.navigate(targetRouteId, { search: targetSearch });
+    },
+    { targetRouteId: routeId, targetSearch: search },
+  );
+}
+
+async function choosePackagesFolder(page: Page) {
+  await page.locator("#new-session-place-trigger").click();
+  await page.getByRole("button", { name: "Browse folders" }).click();
+  await page.locator(".new-session-page__browser-entry", { hasText: "packages" }).click();
+  await page.getByRole("button", { name: "Use this folder" }).click();
+}
+
 let browser: Browser;
 let server: ControlUiE2eServer;
 
@@ -721,6 +747,263 @@ describeControlUiE2e("Control UI new-session page mocked Gateway E2E", () => {
         message: "use this model",
         model: "anthropic/claude-sonnet-4-6",
       });
+    } finally {
+      await context.close();
+    }
+  });
+
+  it("restores the last valid place, worktree, model, and reasoning in a new draft", async () => {
+    const context = await browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      workspaceGit: true,
+      models: [
+        { id: "gpt-5.5", name: "GPT 5.5", provider: "openai", reasoning: true },
+        {
+          id: "claude-sonnet-4-6",
+          name: "Claude Sonnet 4.6",
+          provider: "anthropic",
+          reasoning: true,
+        },
+      ],
+      methodResponses: {
+        "agents.list": {
+          agents: [
+            {
+              id: "main",
+              identity: { name: "Main" },
+              name: "Main",
+              workspace: WORKSPACE,
+              workspaceGit: true,
+            },
+          ],
+          defaultId: "main",
+          mainKey: "main",
+          scope: "agent",
+        },
+        "worktrees.branches": {
+          branches: [{ kind: "local", name: "main" }],
+          defaultBranch: "main",
+          repositoryStatus: "git",
+        },
+        "fs.listDir": {
+          cases: [
+            {
+              match: { path: WORKSPACE },
+              response: {
+                path: WORKSPACE,
+                parent: "/home/peter",
+                home: "/home/peter",
+                entries: [{ name: "packages", path: PICKED }],
+              },
+            },
+            {
+              match: { path: PICKED },
+              response: {
+                path: PICKED,
+                parent: WORKSPACE,
+                home: "/home/peter",
+                entries: [],
+              },
+            },
+          ],
+        },
+      },
+    });
+    try {
+      await page.goto(`${server.baseUrl}new`);
+      const placeTrigger = page.locator("#new-session-place-trigger");
+      await choosePackagesFolder(page);
+      await placeTrigger.click();
+      await page.getByRole("button", { name: "Worktree" }).click();
+      await page.keyboard.press("Escape");
+
+      const modelSelect = page.locator('[data-chat-model-select="true"]');
+      await modelSelect.click();
+      await page.locator('[data-chat-model-provider="anthropic"]').click();
+      await page.locator('[data-chat-model-option="anthropic/claude-sonnet-4-6"]').click();
+      const thinkingSlider = page.locator('[data-chat-thinking-slider="true"]');
+      await thinkingSlider.press("End");
+      await expect.poll(() => modelSelect.getAttribute("data-chat-thinking-value")).toBe("high");
+
+      await page.goto(`${server.baseUrl}new`);
+      await expect
+        .poll(() => placeTrigger.locator(".new-session-page__trigger-label").textContent())
+        .toBe("packages");
+      await expect.poll(() => placeTrigger.getAttribute("data-worktree")).toBe("true");
+      await expect
+        .poll(() => modelSelect.getAttribute("data-chat-select-value"))
+        .toBe("anthropic/claude-sonnet-4-6");
+      await expect.poll(() => modelSelect.getAttribute("data-chat-thinking-value")).toBe("high");
+      await captureUiProof(page, "new-session-preferences-restored.png");
+
+      const branchRequests = await gateway.getRequests("worktrees.branches");
+      expect(branchRequests.at(-1)?.params).toMatchObject({ repoRoot: PICKED });
+    } finally {
+      await context.close();
+    }
+  });
+
+  it("falls back to the current workspace when the remembered folder is gone", async () => {
+    const context = await browser.newContext({ locale: "en-US", serviceWorkers: "block" });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      workspaceGit: true,
+      methodResponses: {
+        "agents.list": {
+          agents: [
+            {
+              id: "main",
+              identity: { name: "Main" },
+              name: "Main",
+              workspace: WORKSPACE,
+              workspaceGit: true,
+            },
+          ],
+          defaultId: "main",
+          mainKey: "main",
+          scope: "agent",
+        },
+        "worktrees.branches": {
+          branches: [{ kind: "local", name: "main" }],
+          defaultBranch: "main",
+          repositoryStatus: "git",
+        },
+        "fs.listDir": {
+          cases: [
+            {
+              match: { path: WORKSPACE },
+              response: {
+                path: WORKSPACE,
+                parent: "/home/peter",
+                home: "/home/peter",
+                entries: [{ name: "packages", path: PICKED }],
+              },
+            },
+            {
+              match: { path: PICKED },
+              response: { path: PICKED, parent: WORKSPACE, home: "/home/peter", entries: [] },
+            },
+          ],
+        },
+        "sessions.create": { key: "agent:main:stale-folder-fallback", runStarted: true },
+      },
+    });
+    try {
+      await page.goto(`${server.baseUrl}new`);
+      await choosePackagesFolder(page);
+
+      await navigateInApp(page, "chat");
+      await page.waitForURL((url) => url.pathname.endsWith("/chat"));
+      const validationRequests = (await gateway.getRequests("fs.listDir")).length;
+      await gateway.deferNext("fs.listDir");
+      await navigateInApp(page, "new-session");
+      await expect
+        .poll(async () => (await gateway.getRequests("fs.listDir")).length)
+        .toBeGreaterThan(validationRequests);
+      const message = page.locator(".new-session-page__message");
+      await message.fill("use a safe folder");
+      await expect
+        .poll(() => page.getByRole("button", { name: "Start thread" }).isDisabled())
+        .toBe(true);
+
+      await gateway.rejectDeferred("fs.listDir", {
+        code: "INVALID_REQUEST",
+        message: `Error: ENOENT: no such file or directory, scandir '${PICKED}'`,
+      });
+      const placeTrigger = page.locator("#new-session-place-trigger");
+      await expect
+        .poll(() => placeTrigger.locator(".new-session-page__trigger-label").textContent())
+        .toBe("openclaw");
+      await page.getByRole("button", { name: "Start thread" }).click();
+      const create = await gateway.waitForRequest("sessions.create");
+      expect(create.params).not.toHaveProperty("cwd");
+    } finally {
+      await context.close();
+    }
+  });
+
+  it("keeps a newer folder choice when remembered-folder validation finishes late", async () => {
+    const context = await browser.newContext({ locale: "en-US", serviceWorkers: "block" });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      workspaceGit: true,
+      methodResponses: {
+        "agents.list": {
+          agents: [
+            {
+              id: "main",
+              identity: { name: "Main" },
+              name: "Main",
+              workspace: WORKSPACE,
+              workspaceGit: true,
+            },
+          ],
+          defaultId: "main",
+          mainKey: "main",
+          scope: "agent",
+        },
+        "worktrees.branches": {
+          branches: [{ kind: "local", name: "main" }],
+          defaultBranch: "main",
+          repositoryStatus: "git",
+        },
+        "fs.listDir": {
+          cases: [
+            {
+              match: { path: WORKSPACE },
+              response: {
+                path: WORKSPACE,
+                parent: "/home/peter",
+                home: "/home/peter",
+                entries: [{ name: "packages", path: PICKED }],
+              },
+            },
+            {
+              match: { path: PICKED },
+              response: { path: PICKED, parent: WORKSPACE, home: "/home/peter", entries: [] },
+            },
+          ],
+        },
+        "sessions.create": { key: "agent:main:newer-folder-wins", runStarted: true },
+      },
+    });
+    try {
+      await page.goto(`${server.baseUrl}new`);
+      await choosePackagesFolder(page);
+
+      await navigateInApp(page, "chat");
+      await page.waitForURL((url) => url.pathname.endsWith("/chat"));
+      const validationRequests = (await gateway.getRequests("fs.listDir")).length;
+      await gateway.deferNext("fs.listDir");
+      await navigateInApp(page, "new-session");
+      await expect
+        .poll(async () => (await gateway.getRequests("fs.listDir")).length)
+        .toBeGreaterThan(validationRequests);
+
+      const placeTrigger = page.locator("#new-session-place-trigger");
+      await placeTrigger.click();
+      await page
+        .locator('wa-popover.new-session-page__place-popover [data-value="workspace"]')
+        .click();
+      await gateway.resolveDeferred("fs.listDir", {
+        path: PICKED,
+        parent: WORKSPACE,
+        home: "/home/peter",
+        entries: [],
+      });
+      await expect
+        .poll(() => placeTrigger.locator(".new-session-page__trigger-label").textContent())
+        .toBe("openclaw");
+
+      await page.locator(".new-session-page__message").fill("keep the newer choice");
+      await page.getByRole("button", { name: "Start thread" }).click();
+      const create = await gateway.waitForRequest("sessions.create");
+      expect(create.params).not.toHaveProperty("cwd");
     } finally {
       await context.close();
     }

--- a/ui/src/pages/new-session/folder-validation.test.ts
+++ b/ui/src/pages/new-session/folder-validation.test.ts
@@ -3,7 +3,7 @@ import { GatewayRequestError } from "../../api/gateway.ts";
 import { isMissingRestoredFolderError } from "./folder-validation.ts";
 
 describe("restored new-session folder validation", () => {
-  it.each(["ENOENT: no such file or directory", "ENOTDIR: not a directory"])(
+  it.each(["ENOENT: no such file or directory", "Error: ENOTDIR: not a directory"])(
     "recognizes a definitive stale path from %s",
     (message) => {
       expect(
@@ -21,6 +21,14 @@ describe("restored new-session folder validation", () => {
     expect(
       isMissingRestoredFolderError(
         new GatewayRequestError({ code: "INVALID_REQUEST", message: "EACCES: permission denied" }),
+      ),
+    ).toBe(false);
+    expect(
+      isMissingRestoredFolderError(
+        new GatewayRequestError({
+          code: "INVALID_REQUEST",
+          message: "Error: EACCES: permission denied, scandir '/work/ENOENT/project'",
+        }),
       ),
     ).toBe(false);
   });

--- a/ui/src/pages/new-session/folder-validation.test.ts
+++ b/ui/src/pages/new-session/folder-validation.test.ts
@@ -27,7 +27,7 @@ describe("restored new-session folder validation", () => {
       isMissingRestoredFolderError(
         new GatewayRequestError({
           code: "INVALID_REQUEST",
-          message: "Error: EACCES: permission denied, scandir '/work/ENOENT/project'",
+          message: "Error: EACCES: permission denied, scandir '/work/: ENOENT:/project'",
         }),
       ),
     ).toBe(false);

--- a/ui/src/pages/new-session/folder-validation.test.ts
+++ b/ui/src/pages/new-session/folder-validation.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { GatewayRequestError } from "../../api/gateway.ts";
+import { isMissingRestoredFolderError } from "./folder-validation.ts";
+
+describe("restored new-session folder validation", () => {
+  it.each(["ENOENT: no such file or directory", "ENOTDIR: not a directory"])(
+    "recognizes a definitive stale path from %s",
+    (message) => {
+      expect(
+        isMissingRestoredFolderError(new GatewayRequestError({ code: "INVALID_REQUEST", message })),
+      ).toBe(true);
+    },
+  );
+
+  it("keeps transient and unrelated request failures recoverable", () => {
+    expect(
+      isMissingRestoredFolderError(
+        new GatewayRequestError({ code: "UNAVAILABLE", message: "gateway restarting" }),
+      ),
+    ).toBe(false);
+    expect(
+      isMissingRestoredFolderError(
+        new GatewayRequestError({ code: "INVALID_REQUEST", message: "EACCES: permission denied" }),
+      ),
+    ).toBe(false);
+  });
+});

--- a/ui/src/pages/new-session/folder-validation.ts
+++ b/ui/src/pages/new-session/folder-validation.ts
@@ -5,6 +5,6 @@ export function isMissingRestoredFolderError(error: unknown): boolean {
   return (
     error instanceof GatewayRequestError &&
     error.gatewayCode === "INVALID_REQUEST" &&
-    /(?:^|:\s)(?:ENOENT|ENOTDIR):/u.test(error.message)
+    /^(?:Error:\s+)?(?:ENOENT|ENOTDIR):/u.test(error.message)
   );
 }

--- a/ui/src/pages/new-session/folder-validation.ts
+++ b/ui/src/pages/new-session/folder-validation.ts
@@ -1,0 +1,10 @@
+import { GatewayRequestError } from "../../api/gateway.ts";
+
+/** fs.listDir uses INVALID_REQUEST for host filesystem errors; only stable errno markers prove stale input. */
+export function isMissingRestoredFolderError(error: unknown): boolean {
+  return (
+    error instanceof GatewayRequestError &&
+    error.gatewayCode === "INVALID_REQUEST" &&
+    /\b(?:ENOENT|ENOTDIR)\b/u.test(error.message)
+  );
+}

--- a/ui/src/pages/new-session/folder-validation.ts
+++ b/ui/src/pages/new-session/folder-validation.ts
@@ -5,6 +5,6 @@ export function isMissingRestoredFolderError(error: unknown): boolean {
   return (
     error instanceof GatewayRequestError &&
     error.gatewayCode === "INVALID_REQUEST" &&
-    /\b(?:ENOENT|ENOTDIR)\b/u.test(error.message)
+    /(?:^|:\s)(?:ENOENT|ENOTDIR):/u.test(error.message)
   );
 }

--- a/ui/src/pages/new-session/model-control.test.ts
+++ b/ui/src/pages/new-session/model-control.test.ts
@@ -28,6 +28,42 @@ function contextWith(models: ModelCatalogEntry[], runtime = "openclaw") {
 }
 
 describe("new-session model runtime", () => {
+  it("restores a browser preference only after the model and thinking level validate", async () => {
+    const { context } = contextWith([
+      {
+        id: "gpt-5.6-sol",
+        name: "GPT-5.6 Sol",
+        provider: "openai",
+        reasoning: true,
+      },
+    ]);
+    const control = new NewSessionModelControl(() => undefined);
+
+    control.load(context, "main", true, {
+      preference: { model: "openai/gpt-5.6-sol", thinkingLevel: "high" },
+    });
+
+    await vi.waitFor(() => expect(control.selected).toBe("openai/gpt-5.6-sol"));
+    expect(control.thinkingLevel).toBe("high");
+  });
+
+  it("drops a stored model and its reasoning override when the model is unavailable", async () => {
+    const { context, request } = contextWith([
+      { id: "gpt-5.6-sol", name: "GPT-5.6 Sol", provider: "openai", reasoning: true },
+    ]);
+    const notify = vi.fn();
+    const control = new NewSessionModelControl(notify);
+
+    control.load(context, "main", true, {
+      preference: { model: "anthropic/retired-model", thinkingLevel: "high" },
+    });
+
+    await vi.waitFor(() => expect(request).toHaveBeenCalled());
+    await vi.waitFor(() => expect(notify).toHaveBeenCalledTimes(2));
+    expect(control.selected).toBe("");
+    expect(control.thinkingLevel).toBe("");
+  });
+
   it("uses model catalog runtime metadata for an explicit cloud target", async () => {
     const { context, request } = contextWith([
       {

--- a/ui/src/pages/new-session/model-control.test.ts
+++ b/ui/src/pages/new-session/model-control.test.ts
@@ -43,7 +43,59 @@ describe("new-session model runtime", () => {
       preference: { model: "openai/gpt-5.6-sol", thinkingLevel: "high" },
     });
 
+    expect(control.isRestoringPreference()).toBe(true);
     await vi.waitFor(() => expect(control.selected).toBe("openai/gpt-5.6-sol"));
+    expect(control.isRestoringPreference()).toBe(false);
+    expect(control.thinkingLevel).toBe("high");
+  });
+
+  it("does not mark ordinary catalog loading as preference restoration", async () => {
+    const { context, request } = contextWith([
+      { id: "gpt-5.6-sol", name: "GPT-5.6 Sol", provider: "openai", reasoning: true },
+    ]);
+    const control = new NewSessionModelControl(() => undefined);
+
+    control.load(context, "main", true);
+
+    expect(control.isRestoringPreference()).toBe(false);
+    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+  });
+
+  it("preserves the remembered pair when metadata validation fails", async () => {
+    const { context, request } = contextWith([]);
+    request.mockRejectedValueOnce(new Error("metadata unavailable"));
+    const control = new NewSessionModelControl(() => undefined);
+
+    control.load(context, "main", true, {
+      preference: { model: "anthropic/claude-sonnet-4-6", thinkingLevel: "high" },
+    });
+
+    expect(control.isRestoringPreference()).toBe(true);
+    await vi.waitFor(() => expect(control.isRestoringPreference()).toBe(false));
+    expect(control.selected).toBe("anthropic/claude-sonnet-4-6");
+    expect(control.thinkingLevel).toBe("high");
+  });
+
+  it("preserves a live selection when an ordinary metadata refresh fails", async () => {
+    const { context, request } = contextWith([]);
+    const notify = vi.fn();
+    const control = new NewSessionModelControl(notify);
+    control.load(context, "main", true);
+    await vi.waitFor(() => {
+      expect(request).toHaveBeenCalledOnce();
+      expect(notify).toHaveBeenCalledTimes(2);
+    });
+    control.selected = "anthropic/claude-sonnet-4-6";
+    control.thinkingLevel = "high";
+    request.mockRejectedValueOnce(new Error("metadata unavailable"));
+
+    control.load(context, "main", true);
+
+    await vi.waitFor(() => {
+      expect(request).toHaveBeenCalledTimes(2);
+      expect(notify).toHaveBeenCalledTimes(4);
+    });
+    expect(control.selected).toBe("anthropic/claude-sonnet-4-6");
     expect(control.thinkingLevel).toBe("high");
   });
 
@@ -52,7 +104,8 @@ describe("new-session model runtime", () => {
       { id: "gpt-5.6-sol", name: "GPT-5.6 Sol", provider: "openai", reasoning: true },
     ]);
     const notify = vi.fn();
-    const control = new NewSessionModelControl(notify);
+    const onSelectionChange = vi.fn();
+    const control = new NewSessionModelControl(notify, onSelectionChange);
 
     control.load(context, "main", true, {
       preference: { model: "openai/gpt-5.6-sol", thinkingLevel: "high" },
@@ -67,13 +120,15 @@ describe("new-session model runtime", () => {
     await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2));
     await vi.waitFor(() => expect(control.selected).toBe(""));
     expect(control.thinkingLevel).toBe("");
+    expect(onSelectionChange).toHaveBeenLastCalledWith({ model: "", thinkingLevel: "" });
   });
 
   it("drops a stored reasoning override when its option is no longer available", async () => {
     const { context, request } = contextWith([
       { id: "gpt-5.6-sol", name: "GPT-5.6 Sol", provider: "openai", reasoning: true },
     ]);
-    const control = new NewSessionModelControl(() => undefined);
+    const onSelectionChange = vi.fn();
+    const control = new NewSessionModelControl(() => undefined, onSelectionChange);
 
     control.load(context, "main", true, {
       preference: { model: "openai/gpt-5.6-sol", thinkingLevel: "high" },
@@ -87,6 +142,10 @@ describe("new-session model runtime", () => {
     await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2));
     await vi.waitFor(() => expect(control.thinkingLevel).toBe(""));
     expect(control.selected).toBe("openai/gpt-5.6-sol");
+    expect(onSelectionChange).toHaveBeenLastCalledWith({
+      model: "openai/gpt-5.6-sol",
+      thinkingLevel: "",
+    });
   });
 
   it("uses model catalog runtime metadata for an explicit cloud target", async () => {

--- a/ui/src/pages/new-session/model-control.test.ts
+++ b/ui/src/pages/new-session/model-control.test.ts
@@ -55,13 +55,38 @@ describe("new-session model runtime", () => {
     const control = new NewSessionModelControl(notify);
 
     control.load(context, "main", true, {
+      preference: { model: "openai/gpt-5.6-sol", thinkingLevel: "high" },
+    });
+    await vi.waitFor(() => expect(control.selected).toBe("openai/gpt-5.6-sol"));
+    expect(control.thinkingLevel).toBe("high");
+
+    control.load(context, "main", true, {
       preference: { model: "anthropic/retired-model", thinkingLevel: "high" },
     });
 
-    await vi.waitFor(() => expect(request).toHaveBeenCalled());
-    await vi.waitFor(() => expect(notify).toHaveBeenCalledTimes(2));
-    expect(control.selected).toBe("");
+    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2));
+    await vi.waitFor(() => expect(control.selected).toBe(""));
     expect(control.thinkingLevel).toBe("");
+  });
+
+  it("drops a stored reasoning override when its option is no longer available", async () => {
+    const { context, request } = contextWith([
+      { id: "gpt-5.6-sol", name: "GPT-5.6 Sol", provider: "openai", reasoning: true },
+    ]);
+    const control = new NewSessionModelControl(() => undefined);
+
+    control.load(context, "main", true, {
+      preference: { model: "openai/gpt-5.6-sol", thinkingLevel: "high" },
+    });
+    await vi.waitFor(() => expect(control.thinkingLevel).toBe("high"));
+
+    control.load(context, "main", true, {
+      preference: { model: "openai/gpt-5.6-sol", thinkingLevel: "retired" },
+    });
+
+    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2));
+    await vi.waitFor(() => expect(control.thinkingLevel).toBe(""));
+    expect(control.selected).toBe("openai/gpt-5.6-sol");
   });
 
   it("uses model catalog runtime metadata for an explicit cloud target", async () => {

--- a/ui/src/pages/new-session/model-control.ts
+++ b/ui/src/pages/new-session/model-control.ts
@@ -5,8 +5,10 @@ import {
   normalizeChatModelProviderId,
   resolvePreferredServerChatModelValue,
 } from "../../lib/chat/model-ref.ts";
+import { resolveChatThinkingSelectState } from "../../lib/chat/thinking.ts";
 import { normalizeAgentId } from "../../lib/sessions/session-key.ts";
 import { renderChatModelControls } from "../chat/components/chat-model-controls.ts";
+import type { NewSessionPreference } from "./preferences.ts";
 
 type DraftModelTarget = {
   entry?: ModelCatalogEntry;
@@ -50,18 +52,27 @@ function resolveDraftModelTarget(
 
 export class NewSessionModelControl {
   private requestToken = 0;
+  private selectionGeneration = 0;
+  private agentId = "";
   private catalog: ModelCatalogEntry[] = [];
   private loading = false;
   selected = "";
   thinkingLevel = "";
 
-  constructor(private readonly notify: () => void) {}
+  constructor(
+    private readonly notify: () => void,
+    private readonly onSelectionChange: (selection: {
+      model: string;
+      thinkingLevel: string;
+    }) => void = () => undefined,
+  ) {}
 
   invalidate(resetSelection = false) {
     this.requestToken += 1;
     this.loading = false;
     this.catalog = [];
     if (resetSelection) {
+      this.agentId = "";
       this.selected = "";
       this.thinkingLevel = "";
     }
@@ -72,11 +83,22 @@ export class NewSessionModelControl {
     this.notify();
   }
 
-  load(context: ApplicationContext | undefined, agentId: string, enabled: boolean) {
+  load(
+    context: ApplicationContext | undefined,
+    agentId: string,
+    enabled: boolean,
+    options: { agent?: GatewayAgentRow; preference?: NewSessionPreference | null } = {},
+  ) {
     const snapshot = context?.gateway.snapshot;
     const client = snapshot?.client;
     const normalizedAgentId = normalizeAgentId(agentId);
+    if (this.agentId !== normalizedAgentId) {
+      this.agentId = normalizedAgentId;
+      this.selected = "";
+      this.thinkingLevel = "";
+    }
     const requestId = ++this.requestToken;
+    const selectionGeneration = this.selectionGeneration;
     this.catalog = [];
     if (snapshot?.phase !== "connected" || !client || !normalizedAgentId || !enabled) {
       this.loading = false;
@@ -92,6 +114,9 @@ export class NewSessionModelControl {
       .then((result) => {
         if (requestId === this.requestToken) {
           this.catalog = Array.isArray(result.models) ? result.models : [];
+          if (selectionGeneration === this.selectionGeneration) {
+            this.restorePreference(options.preference, options.agent, context);
+          }
         }
       })
       .catch(() => {
@@ -105,6 +130,66 @@ export class NewSessionModelControl {
           this.notify();
         }
       });
+  }
+
+  private restorePreference(
+    preference: NewSessionPreference | null | undefined,
+    agent: GatewayAgentRow | undefined,
+    context: ApplicationContext | undefined,
+  ) {
+    if (!preference) {
+      return;
+    }
+    const preferredTarget = preference.model
+      ? resolveDraftModelTarget(preference.model, undefined, this.catalog)
+      : null;
+    if (
+      preference.model &&
+      (!preferredTarget?.entry || preferredTarget.entry.available === false)
+    ) {
+      return;
+    }
+    this.selected = preferredTarget?.entry
+      ? buildQualifiedChatModelValue(preferredTarget.entry.id, preferredTarget.entry.provider)
+      : "";
+    if (!preference.thinkingLevel) {
+      return;
+    }
+    const sourceResult = context?.sessions.state.result ?? null;
+    const agentDefaultModel = agent?.model?.primary;
+    const defaultTarget = resolveDraftModelTarget(
+      agentDefaultModel ?? sourceResult?.defaults.model,
+      agentDefaultModel ? undefined : sourceResult?.defaults.modelProvider,
+      this.catalog,
+    );
+    const selectedTarget = resolveDraftModelTarget(this.selected, undefined, this.catalog);
+    const draftRow: GatewaySessionRow = {
+      key: "new-session:preference",
+      kind: "direct",
+      updatedAt: null,
+      ...(selectedTarget
+        ? { model: selectedTarget.model, modelProvider: selectedTarget.provider ?? undefined }
+        : {}),
+    };
+    const thinking = resolveChatThinkingSelectState({
+      catalog: this.catalog,
+      defaults: {
+        ...sourceResult?.defaults,
+        modelProvider: defaultTarget?.provider ?? sourceResult?.defaults.modelProvider ?? null,
+        model: defaultTarget?.model ?? sourceResult?.defaults.model ?? null,
+        contextTokens: sourceResult?.defaults.contextTokens ?? null,
+        agentRuntime: agent?.agentRuntime ?? sourceResult?.defaults.agentRuntime,
+        thinkingLevels: agent?.thinkingLevels ?? sourceResult?.defaults.thinkingLevels,
+        thinkingOptions: agent?.thinkingOptions ?? sourceResult?.defaults.thinkingOptions,
+        thinkingDefault: agent?.thinkingDefault ?? sourceResult?.defaults.thinkingDefault,
+      },
+      session: draftRow,
+      sessionKey: draftRow.key,
+      sessionsResult: sourceResult,
+    });
+    if (thinking.options.some((entry) => entry.value === preference.thinkingLevel)) {
+      this.thinkingLevel = preference.thinkingLevel;
+    }
   }
 
   resolveAgentRuntimeId(options: {
@@ -189,6 +274,7 @@ export class NewSessionModelControl {
       thinkingDefaults,
       thinkingSession: draftRow,
       onModelSelect: (value) => {
+        this.selectionGeneration += 1;
         this.selected = value;
         const target = resolveDraftModelTarget(
           value || agentDefaultModel || sourceResult?.defaults.model,
@@ -198,9 +284,12 @@ export class NewSessionModelControl {
         if (target?.entry?.reasoning === false) {
           this.thinkingLevel = "";
         }
+        this.onSelectionChange({ model: this.selected, thinkingLevel: this.thinkingLevel });
       },
       onThinkingSelect: (value) => {
+        this.selectionGeneration += 1;
         this.thinkingLevel = value;
+        this.onSelectionChange({ model: this.selected, thinkingLevel: this.thinkingLevel });
       },
       onRequestUpdate: this.notify,
     });

--- a/ui/src/pages/new-session/model-control.ts
+++ b/ui/src/pages/new-session/model-control.ts
@@ -56,6 +56,7 @@ export class NewSessionModelControl {
   private agentId = "";
   private catalog: ModelCatalogEntry[] = [];
   private loading = false;
+  private restoringPreference = false;
   selected = "";
   thinkingLevel = "";
 
@@ -70,6 +71,7 @@ export class NewSessionModelControl {
   invalidate(resetSelection = false) {
     this.requestToken += 1;
     this.loading = false;
+    this.restoringPreference = false;
     this.catalog = [];
     if (resetSelection) {
       this.agentId = "";
@@ -102,10 +104,14 @@ export class NewSessionModelControl {
     this.catalog = [];
     if (snapshot?.phase !== "connected" || !client || !normalizedAgentId || !enabled) {
       this.loading = false;
+      this.restoringPreference = false;
       this.notify();
       return;
     }
     this.loading = true;
+    this.restoringPreference = Boolean(
+      options.preference?.model || options.preference?.thinkingLevel,
+    );
     this.notify();
     void client
       .request<{ models?: ModelCatalogEntry[] }>("chat.metadata", {
@@ -122,14 +128,29 @@ export class NewSessionModelControl {
       .catch(() => {
         if (requestId === this.requestToken) {
           this.catalog = [];
+          if (
+            selectionGeneration === this.selectionGeneration &&
+            (options.preference?.model || options.preference?.thinkingLevel)
+          ) {
+            // A transport failure says nothing about current availability.
+            // Preserve the requested pair so sessions.create remains the
+            // authoritative validator instead of silently using defaults.
+            this.selected = options.preference?.model ?? "";
+            this.thinkingLevel = options.preference?.thinkingLevel ?? "";
+          }
         }
       })
       .finally(() => {
         if (requestId === this.requestToken) {
           this.loading = false;
+          this.restoringPreference = false;
           this.notify();
         }
       });
+  }
+
+  isRestoringPreference(): boolean {
+    return this.restoringPreference;
   }
 
   private restorePreference(
@@ -151,6 +172,7 @@ export class NewSessionModelControl {
       preference.model &&
       (!preferredTarget?.entry || preferredTarget.entry.available === false)
     ) {
+      this.onSelectionChange({ model: "", thinkingLevel: "" });
       return;
     }
     this.selected = preferredTarget?.entry
@@ -193,6 +215,8 @@ export class NewSessionModelControl {
     });
     if (thinking.options.some((entry) => entry.value === preference.thinkingLevel)) {
       this.thinkingLevel = preference.thinkingLevel;
+    } else {
+      this.onSelectionChange({ model: this.selected, thinkingLevel: "" });
     }
   }
 
@@ -279,6 +303,7 @@ export class NewSessionModelControl {
       thinkingSession: draftRow,
       onModelSelect: (value) => {
         this.selectionGeneration += 1;
+        this.restoringPreference = false;
         this.selected = value;
         const target = resolveDraftModelTarget(
           value || agentDefaultModel || sourceResult?.defaults.model,
@@ -292,6 +317,7 @@ export class NewSessionModelControl {
       },
       onThinkingSelect: (value) => {
         this.selectionGeneration += 1;
+        this.restoringPreference = false;
         this.thinkingLevel = value;
         this.onSelectionChange({ model: this.selected, thinkingLevel: this.thinkingLevel });
       },

--- a/ui/src/pages/new-session/model-control.ts
+++ b/ui/src/pages/new-session/model-control.ts
@@ -140,6 +140,10 @@ export class NewSessionModelControl {
     if (!preference) {
       return;
     }
+    // A same-agent metadata refresh revalidates the stored pair. Clear the
+    // previous restoration first so retired catalog entries cannot survive.
+    this.selected = "";
+    this.thinkingLevel = "";
     const preferredTarget = preference.model
       ? resolveDraftModelTarget(preference.model, undefined, this.catalog)
       : null;

--- a/ui/src/pages/new-session/new-session-page.ts
+++ b/ui/src/pages/new-session/new-session-page.ts
@@ -549,21 +549,20 @@ class NewSessionPage extends OpenClawLightDomElement {
     // shows its staged repo; neither may be replaced by a workspace refresh.
     if (!this.execNode && !keepSelectedFolder && !this.pendingCloud.sessionKey) {
       const workspace = this.workspacePath();
-      const storedWorkspaceMoved =
-        preference !== null &&
-        Boolean(preference.folder) &&
-        preference.folder === preference.workspace &&
-        preference.workspace !== workspace;
+      const storedFolder = preference?.folder ?? "";
       // An old agent workspace path is not a custom folder. If the configured
       // workspace moved, use the current value instead of reviving the stale path.
-      this.folder =
-        preference?.folder &&
-        (preference.folder === workspace || this.isAdmin()) &&
-        (!preference.workspace ||
-          preference.folder !== preference.workspace ||
-          preference.workspace === workspace)
-          ? preference.folder
-          : workspace;
+      const storedWorkspaceMoved =
+        Boolean(storedFolder) &&
+        storedFolder === preference?.workspace &&
+        preference.workspace !== workspace;
+      // Only an admin can browse outside the workspace, so any other stored
+      // folder is unreachable for this viewer.
+      const storedFolderUsable =
+        Boolean(storedFolder) &&
+        !storedWorkspaceMoved &&
+        (storedFolder === workspace || this.isAdmin());
+      this.folder = storedFolderUsable ? storedFolder : workspace;
       this.folderSelectedByUser = false;
       this.preferredWorktreeRestore = preference?.worktree === true;
       this.worktreeSelectedByUser = false;
@@ -773,15 +772,17 @@ class NewSessionPage extends OpenClawLightDomElement {
             if (!this.cloudProfileId) {
               this.worktree = false;
             }
-            this.preferredWorktreeRestore = false;
             if (rejectedWorktree) {
               this.persistPreference({ worktree: false });
             }
-          } else if (restoreWorktree && !this.worktreeSelectedByUser) {
-            // An inconclusive lookup cannot disprove a stored worktree choice.
-            // Keep it visible and pending until retry or explicit user override.
+          } else if (restoreWorktree && !this.worktreeSelectedByUser && this.worktreeAvailable()) {
+            // An inconclusive lookup cannot disprove a stored worktree choice, but
+            // it may only be restored while the toggle stays usable: an unavailable
+            // repository disables that control, and a box the user cannot clear
+            // would strand the draft behind a permanently disabled submit.
             this.worktree = true;
           }
+          this.preferredWorktreeRestore = false;
           return;
         }
         this.repository = {
@@ -806,9 +807,10 @@ class NewSessionPage extends OpenClawLightDomElement {
           return;
         }
         this.repository = { kind: "unavailable", repoRoot };
-        if (restoreWorktree && !this.worktreeSelectedByUser) {
+        if (restoreWorktree && !this.worktreeSelectedByUser && this.worktreeAvailable()) {
           this.worktree = true;
         }
+        this.preferredWorktreeRestore = false;
       });
   }
 

--- a/ui/src/pages/new-session/new-session-page.ts
+++ b/ui/src/pages/new-session/new-session-page.ts
@@ -548,19 +548,27 @@ class NewSessionPage extends OpenClawLightDomElement {
     // A node cwd belongs to node discovery, and a locked cloud-recovery draft
     // shows its staged repo; neither may be replaced by a workspace refresh.
     if (!this.execNode && !keepSelectedFolder && !this.pendingCloud.sessionKey) {
+      const workspace = this.workspacePath();
+      const storedWorkspaceMoved =
+        Boolean(preference?.folder) &&
+        preference?.folder === preference.workspace &&
+        preference.workspace !== workspace;
       // An old agent workspace path is not a custom folder. If the configured
       // workspace moved, use the current value instead of reviving the stale path.
       this.folder =
         preference?.folder &&
-        (preference.folder === this.workspacePath() || this.isAdmin()) &&
+        (preference.folder === workspace || this.isAdmin()) &&
         (!preference.workspace ||
           preference.folder !== preference.workspace ||
-          preference.workspace === this.workspacePath())
+          preference.workspace === workspace)
           ? preference.folder
-          : this.workspacePath();
+          : workspace;
       this.folderSelectedByUser = false;
       this.preferredWorktreeRestore = preference?.worktree === true;
       this.worktreeSelectedByUser = false;
+      if (storedWorkspaceMoved) {
+        this.persistPreference({ folder: workspace });
+      }
     }
     void this.loadNodes();
     this.modelControl.load(this.context, this.agentId, !catalog.isTarget(this.data), {

--- a/ui/src/pages/new-session/new-session-page.ts
+++ b/ui/src/pages/new-session/new-session-page.ts
@@ -737,10 +737,14 @@ class NewSessionPage extends OpenClawLightDomElement {
     }
     if (usesWorkspace && agent?.workspaceGit !== true) {
       this.repository = { kind: "direct", repoRoot };
+      const rejectedWorktree = !this.cloudProfileId && (this.worktree || restoreWorktree);
       if (!this.cloudProfileId) {
         this.worktree = false;
       }
       this.preferredWorktreeRestore = false;
+      if (rejectedWorktree) {
+        this.persistPreference({ worktree: false });
+      }
       return;
     }
     const snapshot = this.context?.gateway.snapshot;

--- a/ui/src/pages/new-session/new-session-page.ts
+++ b/ui/src/pages/new-session/new-session-page.ts
@@ -46,11 +46,17 @@ import {
   type DraftRepositoryState,
   readDraftNodes,
 } from "./discovery.ts";
+import { isMissingRestoredFolderError } from "./folder-validation.ts";
 import { GatewayNameDiscovery } from "./gateway-name-discovery.ts";
 import type { NewSessionRouteData } from "./location.ts";
 import { NewSessionModelControl } from "./model-control.ts";
 import { isAbsolutePath } from "./path.ts";
 import { renderPlaceSelect } from "./place-picker.ts";
+import {
+  loadNewSessionPreference,
+  patchNewSessionPreference,
+  type NewSessionPreference,
+} from "./preferences.ts";
 import { retainRejectedInitialTurn } from "./rejected-initial-turn.ts";
 import { renderAgentSelect } from "./target-controls.ts";
 
@@ -88,6 +94,7 @@ class NewSessionPage extends OpenClawLightDomElement {
   @state() private placePopoverHiding = false;
   // Live head input; absolute paths stay applicable even without fs.listDir.
   @state() private browserPathDraft = "";
+  @state() private restoredFolderValidation: "none" | "checking" | "failed" = "none";
 
   private openedFor: string | null = null;
   private agentsHydrated = false;
@@ -95,6 +102,8 @@ class NewSessionPage extends OpenClawLightDomElement {
   // Discovery retry provenance separates user choices from Gateway-derived defaults.
   private agentSelectedByUser = false;
   private folderSelectedByUser = false;
+  private preferredWorktreeRestore = false;
+  private worktreeSelectedByUser = false;
   private submitRequestToken = 0;
   private nodesRequestToken = 0;
   private readonly gatewayNameDiscovery = new GatewayNameDiscovery(
@@ -130,9 +139,13 @@ class NewSessionPage extends OpenClawLightDomElement {
   private branchesRequestToken = 0;
   private baseRefEditGeneration = 0;
   private browserRequestToken = 0;
+  private restoredFolderValidationToken = 0;
   private readonly attachmentDraft = new NewSessionAttachmentDraft(() => this.requestUpdate());
   private readonly composerTextarea = new NewSessionComposerTextareaController();
-  private readonly modelControl = new NewSessionModelControl(() => this.requestUpdate());
+  private readonly modelControl = new NewSessionModelControl(
+    () => this.requestUpdate(),
+    (selection) => this.persistPreference(selection),
+  );
   private gatewaySource: ApplicationContext["gateway"] | null = null;
   private gatewayClient: ApplicationContext["gateway"]["snapshot"]["client"] = null;
   private gatewayUrl = "";
@@ -230,6 +243,7 @@ class NewSessionPage extends OpenClawLightDomElement {
     this.modelControl.invalidate(resetHostSelection);
     this.attachmentDraft.abortReads();
     this.closeBrowser();
+    this.cancelRestoredFolderValidation();
     this.invalidateSubmission(true); // Transport loss makes an in-flight create outcome unknowable.
     if (!resetHostSelection) {
       return;
@@ -245,6 +259,8 @@ class NewSessionPage extends OpenClawLightDomElement {
     this.agentSelectedByUser = false;
     this.folder = "";
     this.folderSelectedByUser = false;
+    this.preferredWorktreeRestore = false;
+    this.worktreeSelectedByUser = false;
     this.worktree = false;
     this.visibility = "normal";
     this.worktreeName = "";
@@ -441,6 +457,76 @@ class NewSessionPage extends OpenClawLightDomElement {
     return Boolean(folder) && folder !== this.workspacePath();
   }
 
+  private preference(): NewSessionPreference | null {
+    if (catalog.isTarget(this.data) || this.pendingCloud.sessionKey) {
+      return null;
+    }
+    return loadNewSessionPreference(this.gatewayUrl, this.agentId);
+  }
+
+  private persistPreference(patch: NewSessionPreference) {
+    if (catalog.isTarget(this.data) || this.pendingCloud.sessionKey) {
+      return;
+    }
+    patchNewSessionPreference(this.gatewayUrl, this.agentId, {
+      workspace: this.workspacePath(),
+      ...patch,
+    });
+  }
+
+  private cancelRestoredFolderValidation() {
+    this.restoredFolderValidationToken += 1;
+    this.restoredFolderValidation = "none";
+  }
+
+  private validateRestoredFolder(folder: string) {
+    const snapshot = this.context?.gateway.snapshot;
+    const client = snapshot?.client;
+    if (snapshot?.phase !== "connected" || !client || !this.isAdmin()) {
+      this.restoredFolderValidation = "checking";
+      return;
+    }
+    const requestId = ++this.restoredFolderValidationToken;
+    this.restoredFolderValidation = "checking";
+    void client
+      .request<FsListDirResult>("fs.listDir", { path: folder })
+      .then(() => {
+        if (
+          requestId !== this.restoredFolderValidationToken ||
+          this.folderSelectedByUser ||
+          this.folder !== folder
+        ) {
+          return;
+        }
+        this.restoredFolderValidation = "none";
+        if (this.error === t("newSession.browserLoadFailed")) {
+          this.error = null;
+        }
+        this.maybeLoadBranches();
+      })
+      .catch((error: unknown) => {
+        if (
+          requestId !== this.restoredFolderValidationToken ||
+          this.folderSelectedByUser ||
+          this.folder !== folder
+        ) {
+          return;
+        }
+        if (isMissingRestoredFolderError(error)) {
+          this.restoredFolderValidation = "none";
+          if (this.error === t("newSession.browserLoadFailed")) {
+            this.error = null;
+          }
+          this.folder = this.workspacePath();
+          this.worktree = false;
+          this.maybeLoadBranches();
+          return;
+        }
+        this.restoredFolderValidation = "failed";
+        this.error = t("newSession.browserLoadFailed");
+      });
+  }
+
   private adoptAgentDefaults(
     options: { preserveSelectedAgent?: boolean; preserveSelectedFolder?: boolean } = {},
   ) {
@@ -455,16 +541,36 @@ class NewSessionPage extends OpenClawLightDomElement {
       this.agentId = catalog.resolveAgentId(this.data, agents, fallback);
       this.agentSelectedByUser = false;
     }
+    const preference = this.preference();
     const keepSelectedFolder = options.preserveSelectedFolder && this.folderSelectedByUser;
     // A node cwd belongs to node discovery, and a locked cloud-recovery draft
     // shows its staged repo; neither may be replaced by a workspace refresh.
     if (!this.execNode && !keepSelectedFolder && !this.pendingCloud.sessionKey) {
-      this.folder = this.workspacePath();
+      // An old agent workspace path is not a custom folder. If the configured
+      // workspace moved, use the current value instead of reviving the stale path.
+      this.folder =
+        preference?.folder &&
+        (preference.folder === this.workspacePath() || this.isAdmin()) &&
+        (!preference.workspace ||
+          preference.folder !== preference.workspace ||
+          preference.workspace === this.workspacePath())
+          ? preference.folder
+          : this.workspacePath();
       this.folderSelectedByUser = false;
+      this.preferredWorktreeRestore = preference?.worktree === true;
+      this.worktreeSelectedByUser = false;
     }
     void this.loadNodes();
-    this.modelControl.load(this.context, this.agentId, !catalog.isTarget(this.data));
-    this.maybeLoadBranches();
+    this.modelControl.load(this.context, this.agentId, !catalog.isTarget(this.data), {
+      agent: this.selectedAgent(),
+      preference,
+    });
+    if (this.folder !== this.workspacePath() && !this.execNode && !this.pendingCloud.sessionKey) {
+      this.validateRestoredFolder(this.folder);
+    } else {
+      this.cancelRestoredFolderValidation();
+      this.maybeLoadBranches();
+    }
   }
 
   private resetDraft() {
@@ -474,6 +580,9 @@ class NewSessionPage extends OpenClawLightDomElement {
     this.agentSelectedByUser = false;
     this.folder = "";
     this.folderSelectedByUser = false;
+    this.cancelRestoredFolderValidation();
+    this.preferredWorktreeRestore = false;
+    this.worktreeSelectedByUser = false;
     this.worktree = false;
     this.visibility = "normal";
     this.worktreeName = "";
@@ -590,16 +699,19 @@ class NewSessionPage extends OpenClawLightDomElement {
     // Repository capability and branch data belong to one Gateway folder.
     // Reset them together so a previous checkout can never leak into create params.
     const requestId = ++this.branchesRequestToken;
+    const restoreWorktree = this.preferredWorktreeRestore && !this.worktreeSelectedByUser;
     const baseRefEditGeneration = this.baseRefEditGeneration;
     this.repository = { kind: "idle" };
     this.baseRef = "";
     if (this.execNode) {
+      this.preferredWorktreeRestore = false;
       return;
     }
     const repoRoot = this.folder.trim() || this.workspacePath();
     const agent = this.selectedAgent();
     const usesWorkspace = repoRoot === this.workspacePath();
     if (!repoRoot) {
+      this.preferredWorktreeRestore = false;
       return;
     }
     if (usesWorkspace && agent?.workspaceGit !== true) {
@@ -607,11 +719,13 @@ class NewSessionPage extends OpenClawLightDomElement {
       if (!this.cloudProfileId) {
         this.worktree = false;
       }
+      this.preferredWorktreeRestore = false;
       return;
     }
     const snapshot = this.context?.gateway.snapshot;
     const client = snapshot?.client;
     if (snapshot?.phase !== "connected" || !client) {
+      this.preferredWorktreeRestore = false;
       return;
     }
     this.repository = { kind: "checking", repoRoot };
@@ -632,6 +746,7 @@ class NewSessionPage extends OpenClawLightDomElement {
           if (result?.repositoryStatus === "not_git" && !this.cloudProfileId) {
             this.worktree = false;
           }
+          this.preferredWorktreeRestore = false;
           return;
         }
         this.repository = {
@@ -641,6 +756,10 @@ class NewSessionPage extends OpenClawLightDomElement {
           ...(result.defaultBranch ? { defaultBranch: result.defaultBranch } : {}),
           ...(result.headBranch ? { headBranch: result.headBranch } : {}),
         };
+        if (restoreWorktree && !this.worktreeSelectedByUser && !this.execNode) {
+          this.worktree = true;
+        }
+        this.preferredWorktreeRestore = false;
         // Discovery supplies a default only while the field is untouched;
         // a user edit made during the request remains authoritative.
         if (baseRefEditGeneration === this.baseRefEditGeneration) {
@@ -652,6 +771,7 @@ class NewSessionPage extends OpenClawLightDomElement {
           return;
         }
         this.repository = { kind: "unavailable", repoRoot };
+        this.preferredWorktreeRestore = false;
       });
   }
 
@@ -713,6 +833,9 @@ class NewSessionPage extends OpenClawLightDomElement {
       gateway?.snapshot.phase !== "connected" ||
       !gateway.snapshot.client
     ) {
+      return false;
+    }
+    if (this.restoredFolderValidation !== "none") {
       return false;
     }
     if (pendingCloud) {
@@ -1040,17 +1163,18 @@ class NewSessionPage extends OpenClawLightDomElement {
       return;
     }
     this.agentId = normalizeAgentId(agentId);
+    this.cancelRestoredFolderValidation();
     this.modelControl.reset();
     this.error = null;
     this.agentSelectedByUser = true;
-    this.folder = this.execNode ? "" : this.workspacePath();
     this.folderSelectedByUser = false;
+    this.preferredWorktreeRestore = false;
+    this.worktreeSelectedByUser = false;
     this.cloudProfileId = "";
     this.worktree = false;
     this.worktreeName = "";
     this.closeBrowser();
-    this.modelControl.load(this.context, this.agentId, true);
-    this.maybeLoadBranches();
+    this.adoptAgentDefaults({ preserveSelectedAgent: true });
   }
 
   /**
@@ -1071,6 +1195,7 @@ class NewSessionPage extends OpenClawLightDomElement {
       return;
     }
     this.execNode = execNode;
+    this.cancelRestoredFolderValidation();
     if (execNode) {
       // Node sessions run on that device; a cloud worker cannot sync a node path.
       this.cloudProfileId = "";
@@ -1078,6 +1203,8 @@ class NewSessionPage extends OpenClawLightDomElement {
     this.error = null;
     this.folder = folder.trim();
     this.folderSelectedByUser = true;
+    this.preferredWorktreeRestore = false;
+    this.worktreeSelectedByUser = true;
     if (this.execNode) {
       this.worktree = false;
     } else if (!this.cloudProfileId) {
@@ -1086,6 +1213,9 @@ class NewSessionPage extends OpenClawLightDomElement {
       this.worktree = false;
     }
     this.worktreeName = "";
+    if (!this.execNode) {
+      this.persistPreference({ folder: this.folder, worktree: this.worktree });
+    }
     this.maybeLoadBranches();
   }
 
@@ -1099,6 +1229,7 @@ class NewSessionPage extends OpenClawLightDomElement {
     // Turning a cloud selection back into a plain Gateway session keeps the
     // picked repo; only a host change retires the folder path.
     const keepGatewayFolder = !execNode && !this.execNode;
+    this.cancelRestoredFolderValidation();
     const keepWorktree = keepGatewayFolder && this.worktree && this.worktreeAvailable();
     this.execNode = execNode;
     this.cloudProfileId = "";
@@ -1356,6 +1487,12 @@ class NewSessionPage extends OpenClawLightDomElement {
           return;
         }
         this.worktree = !this.worktree;
+        this.preferredWorktreeRestore = false;
+        this.worktreeSelectedByUser = true;
+        this.persistPreference({
+          folder: this.folder.trim() || this.workspacePath(),
+          worktree: this.worktree,
+        });
         if (this.worktree) {
           this.maybeLoadBranches();
         }

--- a/ui/src/pages/new-session/new-session-page.ts
+++ b/ui/src/pages/new-session/new-session-page.ts
@@ -519,6 +519,8 @@ class NewSessionPage extends OpenClawLightDomElement {
           }
           this.folder = this.workspacePath();
           this.worktree = false;
+          this.preferredWorktreeRestore = false;
+          this.persistPreference({ folder: this.folder, worktree: false });
           this.maybeLoadBranches();
           return;
         }

--- a/ui/src/pages/new-session/new-session-page.ts
+++ b/ui/src/pages/new-session/new-session-page.ts
@@ -571,6 +571,11 @@ class NewSessionPage extends OpenClawLightDomElement {
         this.persistPreference({ folder: workspace });
       }
     }
+    if (keepSelectedFolder && !this.execNode && !this.pendingCloud.sessionKey && this.agentId) {
+      // A folder picked before agents.list resolves has no stable preference
+      // owner. Persist it only after the final agent id is known.
+      this.persistPreference({ folder: this.folder, worktree: this.worktree });
+    }
     void this.loadNodes();
     this.modelControl.load(this.context, this.agentId, !catalog.isTarget(this.data), {
       agent: this.selectedAgent(),
@@ -1252,7 +1257,7 @@ class NewSessionPage extends OpenClawLightDomElement {
       this.worktree = false;
     }
     this.worktreeName = "";
-    if (!this.execNode) {
+    if (!this.execNode && this.agentsHydrated) {
       this.persistPreference({ folder: this.folder, worktree: this.worktree });
     }
     this.maybeLoadBranches();

--- a/ui/src/pages/new-session/new-session-page.ts
+++ b/ui/src/pages/new-session/new-session-page.ts
@@ -1176,6 +1176,11 @@ class NewSessionPage extends OpenClawLightDomElement {
     this.worktree = false;
     this.worktreeName = "";
     this.closeBrowser();
+    if (this.execNode) {
+      // Node cwd choices are agent-scoped draft state; switching agents must
+      // not carry the previous agent's remote path into the next session.
+      this.folder = "";
+    }
     this.adoptAgentDefaults({ preserveSelectedAgent: true });
   }
 

--- a/ui/src/pages/new-session/new-session-page.ts
+++ b/ui/src/pages/new-session/new-session-page.ts
@@ -550,8 +550,9 @@ class NewSessionPage extends OpenClawLightDomElement {
     if (!this.execNode && !keepSelectedFolder && !this.pendingCloud.sessionKey) {
       const workspace = this.workspacePath();
       const storedWorkspaceMoved =
-        Boolean(preference?.folder) &&
-        preference?.folder === preference.workspace &&
+        preference !== null &&
+        Boolean(preference.folder) &&
+        preference.folder === preference.workspace &&
         preference.workspace !== workspace;
       // An old agent workspace path is not a custom folder. If the configured
       // workspace moved, use the current value instead of reviving the stale path.

--- a/ui/src/pages/new-session/new-session-page.ts
+++ b/ui/src/pages/new-session/new-session-page.ts
@@ -575,7 +575,12 @@ class NewSessionPage extends OpenClawLightDomElement {
       agent: this.selectedAgent(),
       preference,
     });
-    if (this.folder !== this.workspacePath() && !this.execNode && !this.pendingCloud.sessionKey) {
+    if (
+      !this.folderSelectedByUser &&
+      this.folder !== this.workspacePath() &&
+      !this.execNode &&
+      !this.pendingCloud.sessionKey
+    ) {
       this.validateRestoredFolder(this.folder);
     } else {
       this.cancelRestoredFolderValidation();
@@ -753,10 +758,20 @@ class NewSessionPage extends OpenClawLightDomElement {
             kind: result?.repositoryStatus === "not_git" ? "direct" : "unavailable",
             repoRoot,
           };
-          if (result?.repositoryStatus === "not_git" && !this.cloudProfileId) {
-            this.worktree = false;
+          if (result?.repositoryStatus === "not_git") {
+            const rejectedWorktree = !this.cloudProfileId && (this.worktree || restoreWorktree);
+            if (!this.cloudProfileId) {
+              this.worktree = false;
+            }
+            this.preferredWorktreeRestore = false;
+            if (rejectedWorktree) {
+              this.persistPreference({ worktree: false });
+            }
+          } else if (restoreWorktree && !this.worktreeSelectedByUser) {
+            // An inconclusive lookup cannot disprove a stored worktree choice.
+            // Keep it visible and pending until retry or explicit user override.
+            this.worktree = true;
           }
-          this.preferredWorktreeRestore = false;
           return;
         }
         this.repository = {
@@ -781,7 +796,9 @@ class NewSessionPage extends OpenClawLightDomElement {
           return;
         }
         this.repository = { kind: "unavailable", repoRoot };
-        this.preferredWorktreeRestore = false;
+        if (restoreWorktree && !this.worktreeSelectedByUser) {
+          this.worktree = true;
+        }
       });
   }
 
@@ -846,6 +863,12 @@ class NewSessionPage extends OpenClawLightDomElement {
       return false;
     }
     if (this.restoredFolderValidation !== "none") {
+      return false;
+    }
+    // Stored model and worktree choices are provisional until their current
+    // Gateway metadata confirms they still exist. Do not let a fast submit
+    // silently replace either preference with the server default.
+    if (this.modelControl.isRestoringPreference() || this.preferredWorktreeRestore) {
       return false;
     }
     if (pendingCloud) {

--- a/ui/src/pages/new-session/preferences.test.ts
+++ b/ui/src/pages/new-session/preferences.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createStorageMock } from "../../test-helpers/storage.ts";
+import { loadNewSessionPreference, patchNewSessionPreference } from "./preferences.ts";
+
+describe("new-session browser preferences", () => {
+  beforeEach(() => {
+    vi.stubGlobal("localStorage", createStorageMock());
+  });
+
+  it("keeps selections isolated by Gateway and agent", () => {
+    patchNewSessionPreference("ws://one.example", "Main", {
+      workspace: "/workspace",
+      folder: "/workspace/project",
+      worktree: true,
+      model: "openai/gpt-5.6-sol",
+      thinkingLevel: "high",
+    });
+
+    expect(loadNewSessionPreference("ws://one.example", "main")).toEqual({
+      workspace: "/workspace",
+      folder: "/workspace/project",
+      worktree: true,
+      model: "openai/gpt-5.6-sol",
+      thinkingLevel: "high",
+    });
+    expect(loadNewSessionPreference("ws://one.example", "research")).toBeNull();
+    expect(loadNewSessionPreference("ws://two.example", "main")).toBeNull();
+  });
+
+  it("merges changes and drops malformed persisted fields", () => {
+    patchNewSessionPreference("ws://one.example", "main", { folder: "/first" });
+    patchNewSessionPreference("ws://one.example", "main", { worktree: false });
+
+    expect(loadNewSessionPreference("ws://one.example", "main")).toEqual({
+      folder: "/first",
+      worktree: false,
+    });
+
+    const key = localStorage.key(0);
+    expect(key).not.toBeNull();
+    localStorage.setItem(
+      key ?? "",
+      JSON.stringify({ agents: { main: { folder: 42, model: [], worktree: "yes" } } }),
+    );
+    expect(loadNewSessionPreference("ws://one.example", "main")).toBeNull();
+  });
+});

--- a/ui/src/pages/new-session/preferences.ts
+++ b/ui/src/pages/new-session/preferences.ts
@@ -1,0 +1,97 @@
+import { normalizeGatewayTokenScope } from "../../app/gateway-scope.ts";
+import { normalizeAgentId } from "../../lib/sessions/session-key.ts";
+import { normalizeOptionalString } from "../../lib/string-coerce.ts";
+import { getSafeLocalStorage } from "../../local-storage.ts";
+
+const STORAGE_KEY_PREFIX = "openclaw.new-session.preferences.v1:";
+
+export type NewSessionPreference = {
+  workspace?: string;
+  folder?: string;
+  worktree?: boolean;
+  model?: string;
+  thinkingLevel?: string;
+};
+
+type PersistedPreferences = {
+  agents?: Record<string, NewSessionPreference>;
+};
+
+function storageKey(gatewayUrl: string): string {
+  return `${STORAGE_KEY_PREFIX}${normalizeGatewayTokenScope(gatewayUrl)}`;
+}
+
+function normalizePreference(value: unknown): NewSessionPreference | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  const record = value as Record<string, unknown>;
+  const workspace = normalizeOptionalString(record.workspace);
+  const folder = normalizeOptionalString(record.folder);
+  const model = normalizeOptionalString(record.model);
+  const thinkingLevel = normalizeOptionalString(record.thinkingLevel);
+  const worktree = typeof record.worktree === "boolean" ? record.worktree : undefined;
+  if (!workspace && !folder && worktree === undefined && !model && !thinkingLevel) {
+    return null;
+  }
+  return {
+    ...(workspace ? { workspace } : {}),
+    ...(folder ? { folder } : {}),
+    ...(worktree !== undefined ? { worktree } : {}),
+    ...(model ? { model } : {}),
+    ...(thinkingLevel ? { thinkingLevel } : {}),
+  };
+}
+
+function readStore(storage: Storage, gatewayUrl: string): PersistedPreferences {
+  try {
+    const parsed = JSON.parse(storage.getItem(storageKey(gatewayUrl)) ?? "null") as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return {};
+    }
+    return parsed as PersistedPreferences;
+  } catch {
+    return {};
+  }
+}
+
+export function loadNewSessionPreference(
+  gatewayUrl: string,
+  agentId: string,
+): NewSessionPreference | null {
+  const storage = getSafeLocalStorage();
+  const normalizedAgentId = normalizeAgentId(agentId);
+  if (!storage || !gatewayUrl || !normalizedAgentId) {
+    return null;
+  }
+  return normalizePreference(readStore(storage, gatewayUrl).agents?.[normalizedAgentId]);
+}
+
+export function patchNewSessionPreference(
+  gatewayUrl: string,
+  agentId: string,
+  patch: NewSessionPreference,
+): void {
+  const storage = getSafeLocalStorage();
+  const normalizedAgentId = normalizeAgentId(agentId);
+  if (!storage || !gatewayUrl || !normalizedAgentId) {
+    return;
+  }
+  const store = readStore(storage, gatewayUrl);
+  const current = normalizePreference(store.agents?.[normalizedAgentId]) ?? {};
+  const next = normalizePreference({ ...current, ...patch });
+  if (!next) {
+    return;
+  }
+  try {
+    storage.setItem(
+      storageKey(gatewayUrl),
+      JSON.stringify({
+        ...store,
+        agents: { ...store.agents, [normalizedAgentId]: next },
+      } satisfies PersistedPreferences),
+    );
+  } catch {
+    // Browser storage can be disabled or full; preferences are best effort.
+  }
+}


### PR DESCRIPTION
Closes #113823

## What Problem This Solves

Fixes an issue where users opening a new session would lose their last workspace, worktree, model, and reasoning choices, and could restore stale folders or unavailable models unreliably.

## Why This Change Was Made

Stores per-Gateway, per-agent draft preferences in safe browser local storage. Folder and model values are revalidated against current Gateway metadata before reuse; cloud and execution-node placement is intentionally not persisted.

## User Impact

New sessions reopen with the last valid workspace/worktree and model/reasoning choices for that browser user. Deleted folders, moved agent workspaces, unavailable models, and retired reasoning options safely fall back to current defaults.

## Evidence

| Before: new drafts return to defaults | After: valid choices restore |
| --- | --- |
| ![Before: default workspace and model](https://tmpfiles.org/dl/1785016666.280c0c7028bc56b9/w0wQz3TZg5TN/new-session-composer-before.png) | ![After: packages worktree, Claude model, and High reasoning restored](https://tmpfiles.org/dl/1785016674.5c280d9f89824070/wdw1zkTFgRyV/new-session-preferences-restored.png) |

- `node scripts/run-vitest.mjs ui/src/pages/new-session/preferences.test.ts ui/src/pages/new-session/model-control.test.ts ui/src/pages/new-session/folder-validation.test.ts` — 12 passed before review fixes; targeted model and folder suites rerun after each fix (8 and 3 passed).
- Focused mocked-browser scenarios passed for missing-folder repair, late validation, node-agent switching, and moved-workspace repair.
- Branch-wide Autoreview: clean, no accepted/actionable findings.

Raw mock screenshots: [before](https://tmpfiles.org/w0wQz3TZg5TN/new-session-composer-before.png), [after](https://tmpfiles.org/wdw1zkTFgRyV/new-session-preferences-restored.png).
