### PR TITLE
refactor(agents): finish exec pipeline split

### DIFF
--- a/src/agents/bash-tools.exec-run.ts
+++ b/src/agents/bash-tools.exec-run.ts
@@ -15,18 +15,12 @@ import {
 import { rejectUnsafeExecControlShellCommand } from "../infra/exec-control-command-guard.js";
 import { resolveExecSafeBinRuntimePolicy } from "../infra/exec-safe-bin-runtime-policy.js";
 import { logInfo } from "../logger.js";
-import {
-  normalizeAgentId,
-  parseAgentSessionKey,
-  resolveAgentIdFromSessionKey,
-} from "../routing/session-key.js";
+import { parseAgentSessionKey, resolveAgentIdFromSessionKey } from "../routing/session-key.js";
 import { normalizeDeliveryContext } from "../utils/delivery-context.js";
-import { resolveAgentConfig } from "./agent-scope-config.js";
 import { markBackgrounded } from "./bash-process-registry.js";
 import { describeExecTool } from "./bash-tools.descriptions.js";
 import { processGatewayAllowlist } from "./bash-tools.exec-host-gateway.js";
 import { executeNodeHostCommand } from "./bash-tools.exec-host-node.js";
-import { renderExecOutputText } from "./bash-tools.exec-output.js";
 import {
   createExecRequestPreparation,
   type ExecToolArgs,
@@ -37,7 +31,6 @@ import {
   DEFAULT_MAX_OUTPUT,
   DEFAULT_PENDING_MAX_OUTPUT,
   type ExecProcessHandle,
-  type ExecProcessOutcome,
   normalizePathPrepend,
   resolveExecTarget,
   resolveApprovalRunningNoticeMs,
@@ -50,6 +43,11 @@ import {
   validateScriptFileForShellBleed,
 } from "./bash-tools.exec-script-preflight.js";
 import {
+  buildExecForegroundResult,
+  createExecHostResolver,
+  resolveExecReviewerDefaults,
+} from "./bash-tools.exec-support.js";
+import {
   type BackgroundExecTaskHandle,
   createBackgroundExecTask,
   finalizeBackgroundExecTask,
@@ -58,51 +56,8 @@ import type { ExecToolDefaults, ExecToolDetails } from "./bash-tools.exec-types.
 import { formatUnavailableWorkdirFailure, resolveExecWorkdir } from "./bash-tools.exec-workdir.js";
 import { clampWithDefault, readEnvInt, truncateMiddle } from "./bash-tools.shared.js";
 import { createModelExecAutoReviewer } from "./exec-auto-reviewer.js";
-import type { AgentToolResult } from "./runtime/index.js";
 import { EXEC_TOOL_DISPLAY_SUMMARY } from "./tool-description-presets.js";
-import { type AgentToolWithMeta, failedTextResult, textResult } from "./tools/common.js";
-
-function buildExecForegroundResult(params: {
-  outcome: ExecProcessOutcome;
-  cwd?: string;
-  warningText?: string;
-}): AgentToolResult<ExecToolDetails> {
-  const warningText = params.warningText?.trim() ? `${params.warningText}\n\n` : "";
-  if (params.outcome.status === "failed") {
-    return failedTextResult(`${warningText}${params.outcome.reason}`, {
-      status: "failed",
-      exitCode: params.outcome.exitCode ?? null,
-      exitSignal: params.outcome.exitSignal,
-      failureKind: params.outcome.failureKind,
-      exitReason: params.outcome.exitReason,
-      durationMs: params.outcome.durationMs,
-      aggregated: params.outcome.aggregated,
-      timedOut: params.outcome.timedOut,
-      noOutputTimedOut: params.outcome.noOutputTimedOut,
-      cwd: params.cwd,
-    });
-  }
-  return textResult(`${warningText}${renderExecOutputText(params.outcome.aggregated)}`, {
-    status: "completed",
-    exitCode: params.outcome.exitCode,
-    exitSignal: params.outcome.exitSignal,
-    exitReason: params.outcome.exitReason,
-    durationMs: params.outcome.durationMs,
-    aggregated: params.outcome.aggregated,
-    noOutputTimedOut: params.outcome.noOutputTimedOut,
-    cwd: params.cwd,
-  });
-}
-
-function resolveExecReviewerDefaults(params: { defaults?: ExecToolDefaults; agentId?: string }) {
-  if (params.defaults?.reviewer) {
-    return params.defaults.reviewer;
-  }
-  const cfg = params.defaults?.config;
-  const agentId = params.agentId ? normalizeAgentId(params.agentId) : undefined;
-  const agentExec = agentId && cfg ? resolveAgentConfig(cfg, agentId)?.tools?.exec : undefined;
-  return agentExec?.reviewer ?? cfg?.tools?.exec?.reviewer;
-}
+import type { AgentToolWithMeta } from "./tools/common.js";
 
 /** Creates an exec tool instance with runtime defaults and approval policy wiring. */
 export function createExecTool(
@@ -163,34 +118,7 @@ export function createExecTool(
   const agentId =
     defaults?.agentId ??
     (parsedAgentSession ? resolveAgentIdFromSessionKey(defaults?.sessionKey) : undefined);
-  const resolveHostForParams = (params: ExecToolArgs): ExecHost => {
-    const elevatedDefaults = defaults?.elevated;
-    const elevatedAllowed = Boolean(elevatedDefaults?.enabled && elevatedDefaults.allowed);
-    const elevatedDefaultMode =
-      elevatedDefaults?.defaultLevel === "full"
-        ? "full"
-        : elevatedDefaults?.defaultLevel === "ask"
-          ? "ask"
-          : elevatedDefaults?.defaultLevel === "on"
-            ? "ask"
-            : "off";
-    const effectiveDefaultMode = elevatedAllowed ? elevatedDefaultMode : "off";
-    const elevatedMode =
-      typeof params.elevated === "boolean"
-        ? params.elevated
-          ? elevatedDefaultMode === "full"
-            ? "full"
-            : "ask"
-          : "off"
-        : effectiveDefaultMode;
-    const requestedTarget = requireValidExecTarget(params.host);
-    return resolveExecTarget({
-      configuredTarget: defaults?.host,
-      requestedTarget,
-      elevatedRequested: elevatedMode !== "off",
-      sandboxAvailable: Boolean(defaults?.sandbox),
-    }).effectiveHost;
-  };
+  const resolveHostForParams = createExecHostResolver(defaults);
   const buildUnavailableWorkdirResult = (params: {
     cwd: string;
     startedAt?: number;

--- a/src/agents/bash-tools.exec-run.ts
+++ b/src/agents/bash-tools.exec-run.ts
@@ -31,6 +31,7 @@ import {
   DEFAULT_MAX_OUTPUT,
   DEFAULT_PENDING_MAX_OUTPUT,
   type ExecProcessHandle,
+  type ExecProcessOutcome,
   normalizePathPrepend,
   resolveExecTarget,
   resolveApprovalRunningNoticeMs,
@@ -56,6 +57,7 @@ import type { ExecToolDefaults, ExecToolDetails } from "./bash-tools.exec-types.
 import { formatUnavailableWorkdirFailure, resolveExecWorkdir } from "./bash-tools.exec-workdir.js";
 import { clampWithDefault, readEnvInt, truncateMiddle } from "./bash-tools.shared.js";
 import { createModelExecAutoReviewer } from "./exec-auto-reviewer.js";
+import type { AgentToolResult } from "./runtime/index.js";
 import { EXEC_TOOL_DISPLAY_SUMMARY } from "./tool-description-presets.js";
 import type { AgentToolWithMeta } from "./tools/common.js";
 

--- a/src/agents/bash-tools.exec-support.ts
+++ b/src/agents/bash-tools.exec-support.ts
@@ -1,0 +1,86 @@
+import type { ExecHost } from "../infra/exec-approvals.js";
+import { requireValidExecTarget } from "../infra/exec-approvals.js";
+import { normalizeAgentId } from "../routing/session-key.js";
+import { resolveAgentConfig } from "./agent-scope-config.js";
+import { renderExecOutputText } from "./bash-tools.exec-output.js";
+import type { ExecToolArgs } from "./bash-tools.exec-request-preparation.js";
+import { type ExecProcessOutcome, resolveExecTarget } from "./bash-tools.exec-runtime.js";
+import type { ExecToolDefaults, ExecToolDetails } from "./bash-tools.exec-types.js";
+import type { AgentToolResult } from "./runtime/index.js";
+import { failedTextResult, textResult } from "./tools/common.js";
+
+export function buildExecForegroundResult(params: {
+  outcome: ExecProcessOutcome;
+  cwd?: string;
+  warningText?: string;
+}): AgentToolResult<ExecToolDetails> {
+  const warningText = params.warningText?.trim() ? `${params.warningText}\n\n` : "";
+  if (params.outcome.status === "failed") {
+    return failedTextResult(`${warningText}${params.outcome.reason}`, {
+      status: "failed",
+      exitCode: params.outcome.exitCode ?? null,
+      exitSignal: params.outcome.exitSignal,
+      failureKind: params.outcome.failureKind,
+      exitReason: params.outcome.exitReason,
+      durationMs: params.outcome.durationMs,
+      aggregated: params.outcome.aggregated,
+      timedOut: params.outcome.timedOut,
+      noOutputTimedOut: params.outcome.noOutputTimedOut,
+      cwd: params.cwd,
+    });
+  }
+  return textResult(`${warningText}${renderExecOutputText(params.outcome.aggregated)}`, {
+    status: "completed",
+    exitCode: params.outcome.exitCode,
+    exitSignal: params.outcome.exitSignal,
+    exitReason: params.outcome.exitReason,
+    durationMs: params.outcome.durationMs,
+    aggregated: params.outcome.aggregated,
+    noOutputTimedOut: params.outcome.noOutputTimedOut,
+    cwd: params.cwd,
+  });
+}
+
+export function resolveExecReviewerDefaults(params: {
+  defaults?: ExecToolDefaults;
+  agentId?: string;
+}) {
+  if (params.defaults?.reviewer) {
+    return params.defaults.reviewer;
+  }
+  const cfg = params.defaults?.config;
+  const agentId = params.agentId ? normalizeAgentId(params.agentId) : undefined;
+  const agentExec = agentId && cfg ? resolveAgentConfig(cfg, agentId)?.tools?.exec : undefined;
+  return agentExec?.reviewer ?? cfg?.tools?.exec?.reviewer;
+}
+
+export function createExecHostResolver(defaults?: ExecToolDefaults) {
+  return (params: ExecToolArgs): ExecHost => {
+    const elevatedDefaults = defaults?.elevated;
+    const elevatedAllowed = Boolean(elevatedDefaults?.enabled && elevatedDefaults.allowed);
+    const elevatedDefaultMode =
+      elevatedDefaults?.defaultLevel === "full"
+        ? "full"
+        : elevatedDefaults?.defaultLevel === "ask"
+          ? "ask"
+          : elevatedDefaults?.defaultLevel === "on"
+            ? "ask"
+            : "off";
+    const effectiveDefaultMode = elevatedAllowed ? elevatedDefaultMode : "off";
+    const elevatedMode =
+      typeof params.elevated === "boolean"
+        ? params.elevated
+          ? elevatedDefaultMode === "full"
+            ? "full"
+            : "ask"
+          : "off"
+        : effectiveDefaultMode;
+    const requestedTarget = requireValidExecTarget(params.host);
+    return resolveExecTarget({
+      configuredTarget: defaults?.host,
+      requestedTarget,
+      elevatedRequested: elevatedMode !== "off",
+      sandboxAvailable: Boolean(defaults?.sandbox),
+    }).effectiveHost;
+  };
+}


### PR DESCRIPTION
## What Problem This Solves

PR #113807 completed the maintainer-requested `bash-tools.exec.ts` split, but left the main execution pipeline module at 740 lines. This small follow-up finishes that split comfortably below the batch target without changing approval or execution behavior.

## Why This Change Was Made

Foreground result shaping, reviewer-default lookup, and host-resolution closure construction move unchanged into a focused support module. Approval policy calculation, approval checks, their ordering comments, environment handling, dispatch, and process lifecycle remain together in `bash-tools.exec-run.ts`, which drops to 668 lines.

AI-assisted by Codex. I reviewed the complete extraction and the security-sensitive approval path.

## User Impact

No user-visible behavior changes. The landed exec pipeline split is easier to review and all resulting production modules are below 700 lines.

## Evidence

- `node scripts/run-vitest.mjs src/agents/bash-tools.exec.security-floor.test.ts src/agents/bash-tools.exec-foreground-failures.test.ts src/agents/bash-tools.exec.resolve-env-hook.test.ts` — 3 files, 51 tests passed.
- Hosted changed gate plus dead-export scan on Testbox `tbx_01kydncwwjs5ttwv446ztvkm7v`, run https://github.com/openclaw/openclaw/actions/runs/30177132090 — exit 0; core/core-test types, formatting, lint, import cycles, and dead exports clean.
- `$HOME/.claude/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — clean.
