### PR TITLE
fix(ui): restore automatic agent fast-mode settings

### DIFF
--- a/ui/src/components/config-form.analyze.ts
+++ b/ui/src/components/config-form.analyze.ts
@@ -37,6 +37,185 @@ function uniqueValues(values: unknown[]): unknown[] {
   return unique;
 }
 
+type FiniteUnionValues = {
+  values: unknown[];
+  nullable: boolean;
+};
+
+function isFiniteJsonScalar(value: unknown): boolean {
+  return (
+    value === null ||
+    typeof value === "boolean" ||
+    typeof value === "string" ||
+    (typeof value === "number" && Number.isFinite(value))
+  );
+}
+
+function equalFiniteJsonScalars(left: unknown, right: unknown): boolean {
+  return isFiniteJsonScalar(left) && isFiniteJsonScalar(right) && left === right;
+}
+
+function equalJsonSchemaValues(left: unknown, right: unknown): boolean {
+  if (isFiniteJsonScalar(left) || isFiniteJsonScalar(right)) {
+    return equalFiniteJsonScalars(left, right);
+  }
+  if (Array.isArray(left) || Array.isArray(right)) {
+    return (
+      Array.isArray(left) &&
+      Array.isArray(right) &&
+      left.length === right.length &&
+      left.every((entry, index) => equalJsonSchemaValues(entry, right[index]))
+    );
+  }
+  if (typeof left !== "object" || left === null || typeof right !== "object" || right === null) {
+    return false;
+  }
+  const leftEntries = Object.entries(left);
+  const rightEntries = Object.entries(right);
+  return (
+    leftEntries.length === rightEntries.length &&
+    leftEntries.every(
+      ([key, value]) =>
+        Object.hasOwn(right, key) &&
+        equalJsonSchemaValues(value, (right as Record<string, unknown>)[key]),
+    )
+  );
+}
+
+function isJsonSchemaValue(value: unknown): boolean {
+  if (isFiniteJsonScalar(value)) {
+    return true;
+  }
+  if (Array.isArray(value)) {
+    return value.every(isJsonSchemaValue);
+  }
+  return (
+    typeof value === "object" && value !== null && Object.values(value).every(isJsonSchemaValue)
+  );
+}
+
+function uniqueJsonSchemaValues(values: unknown[]): unknown[] {
+  const unique: unknown[] = [];
+  for (const value of values) {
+    if (!unique.some((existing) => equalJsonSchemaValues(existing, value))) {
+      unique.push(value);
+    }
+  }
+  return unique;
+}
+
+function matchesFiniteSchemaType(value: unknown, type: JsonSchema["type"]): boolean {
+  if (type === undefined) {
+    return true;
+  }
+  const types = Array.isArray(type) ? type : [type];
+  return types.some((candidate) => {
+    switch (candidate) {
+      case "null":
+        return value === null;
+      case "boolean":
+        return typeof value === "boolean";
+      case "string":
+        return typeof value === "string";
+      case "number":
+        return typeof value === "number" && Number.isFinite(value);
+      case "integer":
+        return typeof value === "number" && Number.isInteger(value);
+      case "object":
+        return typeof value === "object" && value !== null && !Array.isArray(value);
+      case "array":
+        return Array.isArray(value);
+      default:
+        return false;
+    }
+  });
+}
+
+function matchesFiniteSchemaConstraints(value: unknown, schema: JsonSchema): boolean {
+  return (
+    (matchesFiniteSchemaType(value, schema.type) || (value === null && Boolean(schema.nullable))) &&
+    (!Array.isArray(schema.enum) ||
+      schema.enum.some((candidate) => equalJsonSchemaValues(candidate, value))) &&
+    (!("const" in schema) || equalJsonSchemaValues(schema.const, value))
+  );
+}
+
+function hasUnsupportedFiniteSchemaAssertions(
+  schema: JsonSchema,
+  options: { allowUnion: boolean },
+): boolean {
+  return Object.keys(schema).some(
+    (key) =>
+      key !== "type" &&
+      key !== "enum" &&
+      key !== "const" &&
+      !(options.allowUnion && (key === "anyOf" || key === "oneOf")) &&
+      !META_KEYS.has(key) &&
+      key !== "$comment" &&
+      key !== "deprecated" &&
+      key !== "examples" &&
+      key !== "readOnly" &&
+      key !== "writeOnly",
+  );
+}
+
+function finiteUnionValues(
+  schema: JsonSchema,
+  variants: JsonSchema[],
+  options: { exclusive: boolean },
+): FiniteUnionValues | null {
+  if (hasUnsupportedFiniteSchemaAssertions(schema, { allowUnion: true })) {
+    return null;
+  }
+  const branches: unknown[][] = [];
+  for (const variant of variants) {
+    // Assertion keywords such as `not` can narrow a boolean or enum branch.
+    // Decline those variants rather than offering values the Gateway rejects.
+    if (hasUnsupportedFiniteSchemaAssertions(variant, { allowUnion: false })) {
+      return null;
+    }
+    let branch: unknown[];
+    if (Array.isArray(variant.enum)) {
+      if (variant.enum.some((value) => !isJsonSchemaValue(value))) {
+        return null;
+      }
+      branch = variant.enum.filter((value) => matchesFiniteSchemaConstraints(value, variant));
+    } else if ("const" in variant) {
+      if (!isJsonSchemaValue(variant.const)) {
+        return null;
+      }
+      branch = matchesFiniteSchemaConstraints(variant.const, variant) ? [variant.const] : [];
+    } else if (variant.type === "null") {
+      branch = [null];
+    } else if (variant.type === "boolean") {
+      branch = [true, false];
+    } else {
+      return null;
+    }
+    if (
+      variant.nullable &&
+      !branch.some((value) => value === null) &&
+      matchesFiniteSchemaConstraints(null, variant)
+    ) {
+      branch.push(null);
+    }
+    branches.push(uniqueJsonSchemaValues(branch));
+  }
+
+  const values = uniqueJsonSchemaValues(branches.flat()).filter(
+    (value) =>
+      matchesFiniteSchemaConstraints(value, schema) &&
+      (!options.exclusive ||
+        branches.filter((branch) =>
+          branch.some((candidate) => equalJsonSchemaValues(candidate, value)),
+        ).length === 1),
+  );
+  return {
+    values: values.filter((value) => value !== null),
+    nullable: values.some((value) => value === null),
+  };
+}
+
 export function analyzeConfigSchema(raw: unknown): ConfigSchemaAnalysis {
   if (!raw || typeof raw !== "object") {
     return { schema: null, unsupportedPaths: ["<root>"] };
@@ -193,7 +372,7 @@ function normalizeUnion(
   schema: JsonSchema,
   path: Array<string | number>,
 ): ConfigSchemaAnalysis | null {
-  if (schema.allOf) {
+  if (schema.allOf || (schema.anyOf && schema.oneOf)) {
     return null;
   }
   const union = schema.anyOf ?? schema.oneOf;
@@ -239,12 +418,18 @@ function normalizeUnion(
     return secretInput;
   }
 
-  if (literals.length > 0 && remaining.length === 0) {
+  // Boolean branches are finite, too. Keep their two values alongside literal
+  // modes so generated settings such as true | false | "auto" remain editable.
+  const finiteValues =
+    literals.length > 0 || nullable
+      ? finiteUnionValues(schema, union, { exclusive: Boolean(schema.oneOf) })
+      : null;
+  if (finiteValues && (finiteValues.values.length > 0 || finiteValues.nullable)) {
     return {
       schema: {
         ...schema,
-        enum: uniqueValues(literals),
-        nullable,
+        enum: finiteValues.values,
+        nullable: finiteValues.nullable,
         anyOf: undefined,
         oneOf: undefined,
         allOf: undefined,
@@ -256,6 +441,24 @@ function normalizeUnion(
   if (remaining.length === 1) {
     const remainingSchema = remaining[0];
     if (!remainingSchema) {
+      return null;
+    }
+    // Parent assertions can eliminate literal branches entirely. Only live
+    // branches can overlap or prevent a broad primitive from being editable.
+    const compatibleLiterals = literals.filter(
+      (value) => isJsonSchemaValue(value) && matchesFiniteSchemaConstraints(value, schema),
+    );
+    if (
+      literals.length > 0 &&
+      (literals.some((value) => !isJsonSchemaValue(value)) ||
+        (Boolean(schema.oneOf) && compatibleLiterals.length > 0) ||
+        (compatibleLiterals.length > 0 && remainingSchema.type === undefined) ||
+        hasUnsupportedFiniteSchemaAssertions(schema, { allowUnion: true }) ||
+        hasUnsupportedFiniteSchemaAssertions(remainingSchema, { allowUnion: false }) ||
+        !compatibleLiterals.every((value) =>
+          matchesFiniteSchemaConstraints(value, remainingSchema),
+        ))
+    ) {
       return null;
     }
     return normalizeSchemaNode(

--- a/ui/src/components/config-form.browser.test.ts
+++ b/ui/src/components/config-form.browser.test.ts
@@ -577,6 +577,259 @@ describe("config form renderer", () => {
     expect(onPatch).toHaveBeenCalledWith(["models", "providers", "openai", "apiKey"], "new-key");
   });
 
+  it("preserves every value in generated boolean-and-literal settings", () => {
+    const fastModeSchema = {
+      anyOf: [{ type: "boolean" }, { const: "auto" }],
+    };
+    const analysis = analyzeConfigSchema({
+      type: "object",
+      properties: {
+        agents: {
+          type: "object",
+          properties: {
+            defaults: {
+              type: "object",
+              properties: { fastModeDefault: fastModeSchema },
+            },
+            entries: {
+              type: "object",
+              additionalProperties: {
+                type: "object",
+                properties: { fastModeDefault: fastModeSchema },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(analysis.unsupportedPaths).toEqual([]);
+    expect(
+      analysis.schema?.properties?.agents?.properties?.defaults?.properties?.fastModeDefault,
+    ).toMatchObject({ enum: [true, false, "auto"] });
+    expect(
+      analysis.schema?.properties?.agents?.properties?.entries?.additionalProperties,
+    ).toMatchObject({
+      properties: { fastModeDefault: { enum: [true, false, "auto"] } },
+    });
+  });
+
+  it("lets default and per-agent fast-mode settings select automatic mode", () => {
+    const onPatch = vi.fn();
+    const fastModeSchema = {
+      anyOf: [{ type: "boolean" }, { const: "auto" }],
+    };
+    const analysis = analyzeConfigSchema({
+      type: "object",
+      properties: {
+        agents: {
+          type: "object",
+          properties: {
+            defaults: {
+              type: "object",
+              properties: { fastModeDefault: fastModeSchema },
+            },
+            entries: {
+              type: "object",
+              additionalProperties: {
+                type: "object",
+                properties: { fastModeDefault: fastModeSchema },
+              },
+            },
+          },
+        },
+      },
+    });
+    const container = document.createElement("div");
+    render(
+      renderConfigForm({
+        schema: analysis.schema,
+        uiHints: {},
+        unsupportedPaths: analysis.unsupportedPaths,
+        value: {
+          agents: {
+            defaults: { fastModeDefault: "auto" },
+            entries: { work: { fastModeDefault: true } },
+          },
+        },
+        onPatch,
+      }),
+      container,
+    );
+
+    const automaticButtons = Array.from(
+      container.querySelectorAll<HTMLElement>(".settings-segmented__btn"),
+    ).filter((button) => button.textContent?.trim() === "auto");
+    expect(automaticButtons).toHaveLength(2);
+    expect(container.querySelector("wa-switch.settings-toggle")).toBeNull();
+
+    selectSegmented(expectElement(automaticButtons[1], "per-agent automatic fast mode"));
+    expect(onPatch).toHaveBeenCalledWith(["agents", "entries", "work", "fastModeDefault"], "auto");
+  });
+
+  it.each([
+    {
+      label: "rejects narrowed boolean branches it cannot prove",
+      schema: { anyOf: [{ type: "boolean", not: { const: true } }, { const: "auto" }] },
+      expected: null,
+    },
+    {
+      label: "preserves exclusive boolean-and-literal choices",
+      schema: {
+        oneOf: [{ type: "boolean" }, { const: true }, { const: "auto" }, { type: "null" }],
+      },
+      expected: { enum: [false, "auto"], nullable: true },
+    },
+    {
+      label: "excludes null accepted by multiple exclusive branches",
+      schema: {
+        oneOf: [{ type: "boolean" }, { const: "auto" }, { const: null }, { type: "null" }],
+      },
+      expected: { enum: [true, false, "auto"], nullable: false },
+    },
+    {
+      label: "intersects nullable branches with their enum",
+      schema: { anyOf: [{ type: "boolean", enum: [true], nullable: true }, { const: "auto" }] },
+      expected: { enum: [true, "auto"], nullable: false },
+    },
+    {
+      label: "intersects nullable branches with their const",
+      schema: { anyOf: [{ type: "boolean", const: true, nullable: true }, { const: "auto" }] },
+      expected: { enum: [true, "auto"], nullable: false },
+    },
+    {
+      label: "intersects parent nullability with its enum",
+      schema: {
+        nullable: true,
+        enum: [true, "auto"],
+        anyOf: [{ type: "boolean" }, { const: "auto" }],
+      },
+      expected: { enum: [true, "auto"], nullable: false },
+    },
+    {
+      label: "intersects parent nullability with its const",
+      schema: {
+        nullable: true,
+        const: false,
+        anyOf: [{ type: "boolean" }, { const: "auto" }],
+      },
+      expected: { enum: [false], nullable: false },
+    },
+    {
+      label: "rejects null not accepted by any union branch",
+      schema: { nullable: true, anyOf: [{ type: "boolean" }, { const: "auto" }] },
+      expected: { enum: [true, false, "auto"], nullable: false },
+    },
+    {
+      label: "intersects finite unions with the parent type",
+      schema: { type: "boolean", anyOf: [{ type: "boolean" }, { const: "auto" }] },
+      expected: { enum: [true, false], nullable: false },
+    },
+    {
+      label: "intersects finite unions with the parent enum",
+      schema: { enum: [false, "auto"], anyOf: [{ type: "boolean" }, { const: "auto" }] },
+      expected: { enum: [false, "auto"] },
+    },
+    {
+      label: "intersects finite unions with the parent const",
+      schema: { const: false, anyOf: [{ type: "boolean" }, { const: "auto" }] },
+      expected: { enum: [false] },
+    },
+    {
+      label: "rejects unhandled parent assertion keywords",
+      schema: { anyOf: [{ type: "boolean" }, { const: "auto" }], not: { const: true } },
+      expected: null,
+    },
+    {
+      label: "excludes overlapping exclusive structural literals",
+      schema: {
+        oneOf: [{ type: "boolean" }, { const: { mode: "auto" } }, { const: { mode: "auto" } }],
+      },
+      expected: { enum: [true, false] },
+    },
+    {
+      label: "preserves null-only unions",
+      schema: { anyOf: [{ const: null }] },
+      expected: { enum: [], nullable: true },
+    },
+    {
+      label: "intersects enum and const within the same branch",
+      schema: { anyOf: [{ enum: [true, false], const: false }, { const: "auto" }] },
+      expected: { enum: [false, "auto"] },
+    },
+    {
+      label: "preserves distinct non-exclusive structural literals",
+      schema: { anyOf: [{ const: { mode: "auto" } }, { const: { mode: "manual" } }] },
+      expected: { enum: [{ mode: "auto" }, { mode: "manual" }] },
+    },
+    {
+      label: "preserves distinct exclusive structural literals",
+      schema: { oneOf: [{ const: { mode: "auto" } }, { const: { mode: "manual" } }] },
+      expected: { enum: [{ mode: "auto" }, { mode: "manual" }] },
+    },
+    {
+      label: "intersects structural literals with the parent type",
+      schema: {
+        type: "object",
+        anyOf: [{ const: { mode: "auto" } }, { const: { mode: "manual" } }],
+      },
+      expected: { enum: [{ mode: "auto" }, { mode: "manual" }] },
+    },
+    {
+      label: "intersects structural literals with the parent enum",
+      schema: {
+        enum: [{ mode: "manual" }],
+        anyOf: [{ const: { mode: "auto" } }, { const: { mode: "manual" } }],
+      },
+      expected: { enum: [{ mode: "manual" }] },
+    },
+    {
+      label: "intersects structural literals with the parent const",
+      schema: {
+        const: { mode: "manual" },
+        anyOf: [{ const: { mode: "auto" } }, { const: { mode: "manual" } }],
+      },
+      expected: { enum: [{ mode: "manual" }] },
+    },
+    {
+      label: "keeps literals covered by a broad primitive branch editable",
+      schema: { anyOf: [{ type: "string" }, { const: "auto" }] },
+      expected: { type: "string" },
+    },
+    {
+      label: "keeps literals covered by a broad structural branch editable",
+      schema: { anyOf: [{ type: "object" }, { const: { mode: "auto" } }] },
+      expected: { type: "object" },
+    },
+    {
+      label: "ignores parent-excluded literals in a broad anyOf",
+      schema: { type: "string", anyOf: [{ type: "string" }, { const: 1 }] },
+      expected: { type: "string" },
+    },
+    {
+      label: "ignores parent-excluded literals in a broad oneOf",
+      schema: { type: "string", oneOf: [{ type: "string" }, { const: 1 }] },
+      expected: { type: "string" },
+    },
+    {
+      label: "rejects independent anyOf and oneOf constraints it cannot intersect",
+      schema: {
+        anyOf: [{ type: "boolean" }, { const: "auto" }],
+        oneOf: [{ const: true }, { const: 1 }],
+      },
+      expected: null,
+    },
+  ])("$label", ({ schema, expected }) => {
+    const analysis = analyzeConfigSchema({ type: "object", properties: { mode: schema } });
+    if (expected === null) {
+      expect(analysis.unsupportedPaths).toEqual(["mode"]);
+      expect(analysis.schema?.properties?.mode?.enum).toBeUndefined();
+      return;
+    }
+    expect(analysis.unsupportedPaths).toEqual([]);
+    expect(analysis.schema?.properties?.mode).toMatchObject(expected);
+  });
+
   it("accepts renderable unions", () => {
     const renderableUnionSchema = {
       type: "object",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users editing agent defaults or per-agent settings in the Control UI could not select a valid `auto` fast-mode policy. The generated settings form incorrectly showed an on/off switch even though the Gateway accepts three choices: `true`, `false`, and `auto`.

## Why This Change Was Made

Preserve every branch when a generated configuration schema combines boolean values with literal modes. Normalize finite boolean-and-literal unions into one typed set of options, so the existing form control can present and submit every valid value without changing the Gateway, configuration shape, or agent runtime.

## User Impact

Users can select `auto`, enable fast mode, or disable it from the generated agent settings form. Global agent defaults and individual agent entries expose the same choices and retain their correct boolean or string values.

## Evidence

- Confirmed the bug on current `main` with a real Control UI browser and a live two-agent OpenAI-backed Gateway: the documented `Default Agent Fast Mode` setting appeared as a binary switch and did not offer `auto`.
- Added two regressions and observed both fail on the unmodified owner: the normalized global and per-agent schemas dropped `auto`, and neither generated form rendered an automatic option.
- Confirmed the fixed browser renders all three genuine `true`, `false`, and `auto` controls against the actual Gateway `config.schema` for global and per-agent settings, with no visible errors or browser-console errors.
- Clicked all three actual global settings and all three actual work-agent settings in Chromium; verified each typed value with consecutive `config.get` rereads, preserved the other agent and default-agent roster, and restored the disposable Gateway's optional values afterward.
- Submitted invalid global and work-agent values to the real Gateway and verified both were rejected without changing their configuration hashes.
- Added a compact, table-driven regression matrix covering constrained booleans; parent-nullability and nullable branch enum and const assertions; parent and branch `type`/`enum`/`const` intersections; null-only unions; exclusive `oneOf` overlap; duplicate nullable branches; distinct, overlapping, parent-constrained, and broad-branch structural literals; parent-excluded primitive branches; and independent `anyOf`/`oneOf` constraints.
- Focused UI browser coverage: `node scripts/run-vitest.mjs ui/src/components/config-form.browser.test.ts ui/src/components/form-controls.browser.test.ts ui/src/pages/config/view.browser.test.ts` — **89 passed**.
- Remote fixed-base changed gate: `pnpm check:changed --base 4d8e89fd5cc447da04ce5f0615a21cff7c491f51` — Blacksmith `tbx_01kydp3msd1bp9dqy5jps9aawb`, exit 0, including formatting, Control UI i18n, core/UI typechecking, and changed lint.
- Fresh, independently executed high-effort structured review — **clean**, with no actionable findings.
- AI-assisted; manually verified against current source, actual Gateway schemas, and real browser behavior.
- Exact independently verified pushed head: `1c75bb21cc1db089f75803b625ca9c1edcd148c3`.
- Author and committer: `Peter Steinberger <steipete@gmail.com>`.
- No change to Gateway protocol, SQLite schema, state migrations, or any user service.
