### PR TITLE
fix(ui): suppress observer alerts for selected global sessions

### DIFF
--- a/ui/src/pages/chat/critical-observer-notice.e2e.test.ts
+++ b/ui/src/pages/chat/critical-observer-notice.e2e.test.ts
@@ -221,4 +221,129 @@ describeControlUiE2e("Control UI critical observer notice mocked Gateway E2E", (
       await context.close();
     }
   });
+
+  it.each([
+    {
+      name: "suppresses the configured selected-agent foreground alias",
+      sessionKey: "agent:work:primary",
+      visible: false,
+    },
+    {
+      name: "suppresses the canonical selected-agent global foreground",
+      sessionKey: "global",
+      visible: false,
+    },
+    {
+      name: "announces a genuine selected-agent background session",
+      sessionKey: "agent:work:investigation",
+      visible: true,
+    },
+    {
+      name: "announces a genuine other-agent configured-main session",
+      sessionKey: "agent:other:primary",
+      visible: true,
+    },
+  ])("mocked-Gateway Chromium configured-global alias: $name", async (testCase) => {
+    const historyMessages = [
+      {
+        content: [{ type: "text", text: "Configured global foreground is ready." }],
+        role: "assistant",
+        timestamp: baseTime,
+      },
+    ];
+    const agentsList = {
+      agents: [
+        { id: "work", identity: { name: "Work" }, name: "Work" },
+        { id: "other", identity: { name: "Other" }, name: "Other" },
+      ],
+      defaultId: "work",
+      mainKey: "primary",
+      scope: "global",
+    };
+    const context = await browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1440 },
+    });
+    const page = await context.newPage();
+    page.setDefaultTimeout(10_000);
+    try {
+      const gateway = await installMockGateway(page, {
+        assistantAgentId: "work",
+        defaultAgentId: "work",
+        historyMessages,
+        methodResponses: {
+          "agents.list": agentsList,
+          "chat.startup": {
+            agentsList,
+            messages: historyMessages,
+            metadata: {
+              models: [{ id: "gpt-5.5", name: "gpt-5.5", provider: "openai" }],
+            },
+            sessionId: "configured-global-observer-session",
+            thinkingLevel: null,
+          },
+          "sessions.list": {
+            count: 3,
+            defaults: {
+              contextTokens: null,
+              model: "gpt-5.5",
+              modelProvider: "openai",
+            },
+            path: "",
+            sessions: [
+              {
+                key: "global",
+                kind: "global",
+                label: "Configured global foreground",
+                updatedAt: baseTime,
+              },
+              {
+                key: "agent:work:investigation",
+                kind: "direct",
+                label: "Selected-agent background investigation",
+                updatedAt: baseTime - 1_000,
+              },
+              {
+                key: "agent:other:primary",
+                kind: "direct",
+                label: "Other-agent configured main",
+                updatedAt: baseTime - 2_000,
+              },
+            ],
+            ts: baseTime,
+          },
+        },
+        sessionKey: "global",
+      });
+
+      const response = await page.goto(`${server.baseUrl}chat?session=global`);
+      expect(response?.status()).toBe(200);
+      await page.getByText("Configured global foreground is ready.").waitFor({ state: "visible" });
+      expect(new URL(page.url()).searchParams.get("session")).toBe("global");
+      expect(await gateway.getRequests("connect")).toHaveLength(1);
+
+      const headline = `Configured-global observer notice for ${testCase.sessionKey}`;
+      await gateway.emitGatewayEvent(
+        "session.observer",
+        observerDigest({
+          sessionKey: testCase.sessionKey,
+          health: "stuck",
+          headline,
+          revision: 1,
+        }),
+      );
+
+      const toast = page.locator(".app-toast");
+      if (testCase.visible) {
+        await toast.waitFor({ state: "visible" });
+        expect(await toast.locator(".app-toast__message").textContent()).toContain(headline);
+      } else {
+        await waitForToastUpdate(page);
+        expect(await toast.count()).toBe(0);
+      }
+    } finally {
+      await context.close();
+    }
+  });
 });

--- a/ui/src/pages/chat/critical-observer-notice.runtime.ts
+++ b/ui/src/pages/chat/critical-observer-notice.runtime.ts
@@ -2,6 +2,7 @@
 // transition tracker) out of the Control UI startup chunk. Loaded by app-host
 // on the first session.observer digest; the tracker singleton lives here so
 // recovery transitions stay visible to the dedupe contract across loads.
+import type { ApplicationRuntime } from "../../app/bootstrap.ts";
 import {
   CriticalObserverNoticeTracker,
   showCriticalSessionObserverNotice,
@@ -12,7 +13,20 @@ const tracker = new CriticalObserverNoticeTracker();
 type HandleParams = Omit<Parameters<typeof showCriticalSessionObserverNotice>[0], "tracker">;
 
 export function handleCriticalObserverDigest(params: HandleParams): void {
-  showCriticalSessionObserverNotice({ ...params, tracker });
+  const context = document.querySelector<HTMLElement & { runtime?: ApplicationRuntime }>(
+    "openclaw-app-shell",
+  )?.runtime?.context;
+  showCriticalSessionObserverNotice({
+    ...params,
+    sessionHost: context
+      ? {
+          assistantAgentId: context.gateway.snapshot.assistantAgentId,
+          agentsList: context.agents.state.agentsList,
+          hello: context.gateway.snapshot.hello,
+        }
+      : undefined,
+    tracker,
+  });
 }
 
 export function resetCriticalObserverTracker(): void {

--- a/ui/src/pages/chat/critical-observer-notice.test.ts
+++ b/ui/src/pages/chat/critical-observer-notice.test.ts
@@ -11,6 +11,75 @@ afterEach(() => {
 });
 
 describe("critical session observer notice", () => {
+  it.each([
+    {
+      name: "configured selected-agent foreground alias",
+      sessionKey: "agent:work:primary",
+      visible: false,
+    },
+    {
+      name: "canonical selected-agent global foreground",
+      sessionKey: "global",
+      visible: false,
+    },
+    {
+      name: "genuine selected-agent background session",
+      sessionKey: "agent:work:investigation",
+      visible: true,
+    },
+    {
+      name: "genuine other-agent configured-main session",
+      sessionKey: "agent:other:primary",
+      visible: true,
+    },
+  ])("configured-global observer notice: $name", async (testCase) => {
+    const toastHost = document.createElement("openclaw-toast-host");
+    document.body.append(toastHost);
+
+    showCriticalSessionObserverNotice({
+      payload: {
+        sessionKey: testCase.sessionKey,
+        headline: "Configured-global observer regression",
+        health: "stuck",
+        revision: 1,
+      },
+      selectedSessionKey: "global",
+      sessionHost: {
+        assistantAgentId: "work",
+        agentsList: { defaultId: "work", mainKey: "primary", scope: "global" },
+        hello: {
+          snapshot: {
+            sessionDefaults: {
+              defaultAgentId: "work",
+              mainKey: "primary",
+              mainSessionKey: "global",
+            },
+          },
+        },
+      },
+      sessions: [
+        { key: "global", label: "Global foreground", kind: "global", updatedAt: null },
+        {
+          key: "agent:work:investigation",
+          label: "Selected-agent background",
+          kind: "direct",
+          updatedAt: null,
+        },
+        {
+          key: "agent:other:primary",
+          label: "Other-agent configured main",
+          kind: "direct",
+          updatedAt: null,
+        },
+      ],
+      tracker: new CriticalObserverNoticeTracker(),
+      onOpen: vi.fn(),
+    });
+
+    await toastHost.updateComplete;
+    expect(toastHost.querySelector(".app-toast") !== null).toBe(testCase.visible);
+  });
+
   it("notices critical health only for a non-selected session", async () => {
     const onOpen = vi.fn();
     const tracker = new CriticalObserverNoticeTracker();

--- a/ui/src/pages/chat/critical-observer-notice.ts
+++ b/ui/src/pages/chat/critical-observer-notice.ts
@@ -6,6 +6,8 @@ import { resolveSessionDisplayName } from "../../lib/session-display.ts";
 import {
   areUiSessionKeysEquivalent,
   normalizeSessionKeyForUiComparison,
+  uiSessionEventMatches,
+  type UiSessionDefaultsHost,
 } from "../../lib/sessions/session-key.ts";
 import { showToast } from "../../lib/toast.ts";
 
@@ -44,6 +46,7 @@ export class CriticalObserverNoticeTracker {
 export function showCriticalSessionObserverNotice(params: {
   payload: unknown;
   selectedSessionKey: string;
+  sessionHost?: UiSessionDefaultsHost;
   sessions: readonly GatewaySessionRow[];
   tracker: CriticalObserverNoticeTracker;
   onOpen: (sessionKey: string) => void;
@@ -70,7 +73,13 @@ export function showCriticalSessionObserverNotice(params: {
     health: digest.health,
     revision,
   });
-  if (!shouldAnnounce || areUiSessionKeysEquivalent(sessionKey, params.selectedSessionKey)) {
+  if (
+    !shouldAnnounce ||
+    uiSessionEventMatches(
+      { ...params.sessionHost, sessionKey: params.selectedSessionKey },
+      sessionKey,
+    )
+  ) {
     return;
   }
   const row = params.sessions.find((session) =>


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users viewing their selected agent’s main or configured global conversation received a critical background-session alert for the very conversation already open. Clicking the misleading alert unnecessarily navigated back to the current foreground conversation.

## Why This Change Was Made

Use the existing host-aware canonical session identity and current session-default context at the critical-observer notice owner, so configured global aliases and the selected agent’s canonical main session match. Preserve critical alerts and navigation for actual background sessions and other agents. Do not change Gateway protocols, provider routing, authentication, session storage or global sidebar behavior.

## User Impact

Users no longer receive misleading background alerts for the selected global/main conversation. Genuine critical events in other sessions and agents continue to produce actionable notices.

## Evidence

- Frozen source independently verified before and after remote proof: `4d8e89fd5cc447da04ce5f0615a21cff7c491f51`. Exact independently verified head: `87065de75fd23abb9307a3b381a55a269f5453ea`; all four candidate blobs rechecked on Linux.
- Genuine installed Chromium and an explicitly mocked Gateway WebSocket: **5/5** full real-browser tests, including global/canonical foreground alias suppression and actual background/other-agent controls. This browser's Gateway is mocked and not claimed live.
- Complete Control UI coverage: **391 passed, 4 existing skipped; 5,510 tests passed and 27 explicitly skipped**.
- Separate real Gateway observer siblings: **38/38**. Notice owner/digest: **15/15**.
- Complete official changed gate exits **0**, including formatting, native UI localization verification, both affected TypeScript lanes and repo safety boundaries.
- Fresh independent high-effort review: zero findings, confidence **0.96**.
- Full marker `EXACT_4D_REAL_BROWSER_AND_FULL_OBSERVER_GATES_PASSED`; Testbox timing exit code 0 and completed lease cleanup.
- Exactly four UI notice-owner files; no configuration, protocol or database changes.
- Author and committer: `Peter Steinberger <steipete@gmail.com>`.
