### PR TITLE
fix(qa): prevent lost or replayed messages after gateway restart

### DIFF
--- a/extensions/qa-channel/src/bus-client.test.ts
+++ b/extensions/qa-channel/src/bus-client.test.ts
@@ -227,6 +227,7 @@ describe("qa-bus client", () => {
         baseUrl: server.baseUrl,
         accountId: "acct-a",
         cursor: 0,
+        acknowledgedCursor: 0,
         timeoutMs: 0,
       }),
     ).rejects.toThrow("qa-bus /v1/poll: malformed JSON response");
@@ -247,6 +248,7 @@ describe("qa-bus client", () => {
         baseUrl: `http://127.0.0.1:${port}`,
         accountId: "acct-a",
         cursor: 0,
+        acknowledgedCursor: 0,
         timeoutMs: 0,
       }),
     ).rejects.toThrow("qa-bus /v1/poll: JSON response exceeds 16777216 bytes");
@@ -281,6 +283,7 @@ describe("qa-bus client", () => {
       baseUrl: `http://127.0.0.1:${address.port}`,
       accountId: "acct-a",
       cursor: 0,
+      acknowledgedCursor: 0,
       timeoutMs: 30_000,
       signal: abort.signal,
     });
@@ -375,6 +378,7 @@ describe("qa-bus client", () => {
         baseUrl: server.baseUrl,
         accountId: "acct-a",
         cursor: 0,
+        acknowledgedCursor: 0,
         timeoutMs: 30_000,
       }),
     ).resolves.toEqual({ cursor: 1, events: [] });

--- a/extensions/qa-channel/src/bus-client.ts
+++ b/extensions/qa-channel/src/bus-client.ts
@@ -165,6 +165,7 @@ export async function pollQaBus(params: {
   baseUrl: string;
   accountId: string;
   cursor: number;
+  acknowledgedCursor: number;
   timeoutMs: number;
   signal?: AbortSignal;
 }): Promise<QaBusPollResult> {
@@ -174,6 +175,7 @@ export async function pollQaBus(params: {
     {
       accountId: params.accountId,
       cursor: params.cursor,
+      acknowledgedCursor: params.acknowledgedCursor,
       timeoutMs: params.timeoutMs,
     },
     {

--- a/extensions/qa-channel/src/gateway.test.ts
+++ b/extensions/qa-channel/src/gateway.test.ts
@@ -1,6 +1,7 @@
 // Qa Channel tests cover gateway lifecycle behavior.
 import { createServer } from "node:http";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createQaBusState, startQaBusServer } from "../../qa-lab/bus-api.js";
 import { startQaGatewayAccount } from "./gateway.js";
 import { handleQaInbound } from "./inbound.js";
 import type { ChannelGatewayContext } from "./runtime-api.js";
@@ -63,7 +64,7 @@ describe("qa-channel gateway", () => {
     };
     const server = await startJsonServer(() => ({
       body: JSON.stringify({
-        cursor: 2,
+        cursor: 3,
         events: [
           { cursor: 1, kind: "inbound-message", accountId: "default", message },
           {
@@ -272,5 +273,137 @@ describe("qa-channel gateway", () => {
       } as unknown as ChannelGatewayContext<ResolvedQaChannelAccount>),
     ).rejects.toThrow("inbound failed");
     expect(handleQaInbound).toHaveBeenCalledTimes(1);
+  });
+
+  it("acknowledges only the contiguous prefix when dispatches finish out of order", async () => {
+    const state = createQaBusState();
+    const bus = await startQaBusServer({ state });
+    stops.push(bus["stop"]);
+    const messages = [
+      state.addInboundMessage({
+        accountId: "default",
+        conversation: { id: "alice", kind: "direct" },
+        senderId: "alice",
+        text: "first",
+      }),
+      state.addInboundMessage({
+        accountId: "default",
+        conversation: { id: "alice", kind: "direct" },
+        senderId: "alice",
+        text: "second",
+      }),
+      state.addInboundMessage({
+        accountId: "default",
+        conversation: { id: "alice", kind: "direct" },
+        senderId: "alice",
+        text: "/stop",
+        nativeCommand: { name: "stop" },
+      }),
+    ];
+    let pollCount = 0;
+    bus.server.on("request", (request) => {
+      if (request.url === "/v1/poll") {
+        pollCount += 1;
+      }
+    });
+
+    let rejectSecond = (_error: Error) => {};
+    const secondAttempt = new Promise<void>((_resolve, reject) => {
+      rejectSecond = reject;
+    });
+    let restarting = false;
+    const recoveredMessageIds: string[] = [];
+    const restartedController = new AbortController();
+    vi.mocked(handleQaInbound).mockImplementation(async ({ message }) => {
+      if (!restarting && message.id === messages[1]?.id) {
+        await secondAttempt;
+      }
+      if (restarting) {
+        recoveredMessageIds.push(message.id);
+        if (recoveredMessageIds.length === messages.length - 1) {
+          restartedController.abort();
+        }
+      }
+    });
+    const account: ResolvedQaChannelAccount = {
+      accountId: "default",
+      baseUrl: bus.baseUrl,
+      botDisplayName: "QA Bot",
+      botUserId: "qa-bot",
+      config: {},
+      configured: true,
+      enabled: true,
+      pollTimeoutMs: 10,
+    };
+    const firstGateway = startQaGatewayAccount("qa-channel", "QA Channel", {
+      abortSignal: new AbortController().signal,
+      account,
+      cfg: {},
+      setStatus: vi.fn(),
+    } as unknown as ChannelGatewayContext<ResolvedQaChannelAccount>);
+
+    await vi.waitFor(() => {
+      expect(pollCount).toBeGreaterThanOrEqual(2);
+      expect(vi.mocked(handleQaInbound).mock.calls.map(([params]) => params.message.id)).toEqual(
+        expect.arrayContaining(messages.map((message) => message.id)),
+      );
+    });
+    rejectSecond(new Error("inbound failed"));
+    await expect(firstGateway).rejects.toThrow("inbound failed");
+    expect(state.getAcknowledgedPollCursor("default")).toBe(1);
+
+    restarting = true;
+    const restartedGateway = startQaGatewayAccount("qa-channel", "QA Channel", {
+      abortSignal: restartedController.signal,
+      account,
+      cfg: {},
+      setStatus: vi.fn(),
+    } as unknown as ChannelGatewayContext<ResolvedQaChannelAccount>);
+    try {
+      await vi.waitFor(() => {
+        expect(new Set(recoveredMessageIds)).toEqual(
+          new Set(messages.slice(1).map((message) => message.id)),
+        );
+      });
+    } finally {
+      restartedController.abort();
+      await restartedGateway.catch(() => undefined);
+    }
+  });
+
+  it("records a final successful dispatch before the gateway stops", async () => {
+    const state = createQaBusState();
+    const bus = await startQaBusServer({ state });
+    stops.push(bus["stop"]);
+    const message = state.addInboundMessage({
+      accountId: "default",
+      conversation: { id: "alice", kind: "direct" },
+      senderId: "alice",
+      text: "stop after delivery",
+    });
+    const controller = new AbortController();
+    vi.mocked(handleQaInbound).mockImplementation(async ({ message: inbound }) => {
+      if (inbound.id === message.id) {
+        controller.abort();
+      }
+    });
+
+    await startQaGatewayAccount("qa-channel", "QA Channel", {
+      abortSignal: controller.signal,
+      account: {
+        accountId: "default",
+        baseUrl: bus.baseUrl,
+        botDisplayName: "QA Bot",
+        botUserId: "qa-bot",
+        config: {},
+        configured: true,
+        enabled: true,
+        pollTimeoutMs: 10,
+      },
+      cfg: {},
+      setStatus: vi.fn(),
+    } as unknown as ChannelGatewayContext<ResolvedQaChannelAccount>);
+
+    expect(state.getAcknowledgedPollCursor("default")).toBe(1);
   });
 });

--- a/extensions/qa-channel/src/gateway.ts
+++ b/extensions/qa-channel/src/gateway.ts
@@ -23,10 +23,15 @@ export async function startQaGatewayAccount(
     baseUrl: account.baseUrl,
   });
   let cursor = 0;
+  let acknowledgedCursor = 0;
+  let committedAcknowledgedCursor = 0;
+  let queuedAcknowledgedCursor = 0;
+  let acknowledgementStopped = false;
   let ready = false;
   let inboundError: Error | undefined;
   let queuedInbound = Promise.resolve();
-  const controlTasks = new Set<Promise<void>>();
+  let queuedAcknowledgements = Promise.resolve();
+  const controlTasks = new Set<Promise<boolean>>();
   const handleMessage = (message: Parameters<typeof handleQaInbound>[0]["message"]) =>
     handleQaInbound({
       channelId,
@@ -40,27 +45,63 @@ export async function startQaGatewayAccount(
   };
   const dispatchControl = (message: Parameters<typeof handleQaInbound>[0]["message"]) => {
     const task = handleMessage(message)
-      .catch(captureInboundError)
+      .then(
+        () => true,
+        (error: unknown) => {
+          captureInboundError(error);
+          return false;
+        },
+      )
       .finally(() => controlTasks.delete(task));
     controlTasks.add(task);
+    return task;
   };
   const enqueueInbound = (message: Parameters<typeof handleQaInbound>[0]["message"]) => {
+    let handled = false;
     queuedInbound = queuedInbound
-      .then(() => (inboundError ? undefined : handleMessage(message)))
+      .then(async () => {
+        if (inboundError) {
+          return;
+        }
+        await handleMessage(message);
+        handled = true;
+      })
       .catch(captureInboundError);
+    return queuedInbound.then(() => handled);
+  };
+  const acknowledgeProcessedEvent = (eventCursor: number, task?: Promise<boolean>) => {
+    if (eventCursor <= queuedAcknowledgedCursor) {
+      return;
+    }
+    queuedAcknowledgedCursor = eventCursor;
+    // Dispatch may run ahead for native controls, but restart recovery can
+    // advance only through the contiguous successfully handled prefix.
+    queuedAcknowledgements = queuedAcknowledgements.then(async () => {
+      if (acknowledgementStopped) {
+        return;
+      }
+      if (task && !(await task)) {
+        acknowledgementStopped = true;
+        return;
+      }
+      acknowledgedCursor = eventCursor;
+    });
   };
   try {
     while (!ctx.abortSignal.aborted) {
       if (inboundError) {
         throw inboundError;
       }
+      const pollAcknowledgedCursor = acknowledgedCursor;
       const result = await pollQaBus({
         baseUrl: account.baseUrl,
         accountId: account.accountId,
         cursor,
+        acknowledgedCursor: pollAcknowledgedCursor,
         timeoutMs: account.pollTimeoutMs,
         signal: ctx.abortSignal,
       });
+      committedAcknowledgedCursor = Math.max(committedAcknowledgedCursor, pollAcknowledgedCursor);
       if (!ready) {
         ready = true;
         ctx.setStatus(channelReadyPatch({ accountId: account.accountId }));
@@ -68,14 +109,16 @@ export async function startQaGatewayAccount(
       cursor = result.cursor;
       for (const event of result.events) {
         if (event.kind !== "inbound-message") {
+          acknowledgeProcessedEvent(event.cursor);
           continue;
         }
         if (event.message.nativeCommand) {
-          dispatchControl(event.message);
+          acknowledgeProcessedEvent(event.cursor, dispatchControl(event.message));
         } else {
-          enqueueInbound(event.message);
+          acknowledgeProcessedEvent(event.cursor, enqueueInbound(event.message));
         }
       }
+      acknowledgeProcessedEvent(cursor);
     }
     if (inboundError) {
       throw inboundError;
@@ -91,8 +134,24 @@ export async function startQaGatewayAccount(
       throw error;
     }
   } finally {
-    await Promise.all([queuedInbound, ...controlTasks]);
-    ctx.setStatus(channelStoppedPatch({ accountId: account.accountId }));
+    try {
+      await Promise.all([queuedInbound, queuedAcknowledgements, ...controlTasks]);
+      if (acknowledgedCursor > committedAcknowledgedCursor) {
+        // The aborted poll cannot carry work completed during shutdown. Flush
+        // that fact without its cancelled signal before publishing stopped.
+        await pollQaBus({
+          baseUrl: account.baseUrl,
+          accountId: account.accountId,
+          cursor,
+          acknowledgedCursor,
+          timeoutMs: 0,
+        });
+      }
+    } catch (error) {
+      captureInboundError(error);
+    } finally {
+      ctx.setStatus(channelStoppedPatch({ accountId: account.accountId }));
+    }
   }
   if (inboundError) {
     throw inboundError;

--- a/extensions/qa-lab/src/bus-server.test.ts
+++ b/extensions/qa-lab/src/bus-server.test.ts
@@ -41,6 +41,7 @@ async function pollQaBus(params: {
   baseUrl: string;
   accountId: string;
   cursor: number;
+  acknowledgedCursor?: number;
   timeoutMs: number;
 }): Promise<QaBusPollResult> {
   const response = await fetch(`${params.baseUrl}/v1/poll`, {
@@ -51,6 +52,7 @@ async function pollQaBus(params: {
     body: JSON.stringify({
       accountId: params.accountId,
       cursor: params.cursor,
+      acknowledgedCursor: params.acknowledgedCursor,
       timeoutMs: params.timeoutMs,
     }),
   });
@@ -160,6 +162,27 @@ describe("qa-bus server", () => {
       baseUrl: bus.baseUrl,
       accountId: "acct-a",
       cursor: firstPoll.cursor,
+      acknowledgedCursor: 0,
+      timeoutMs: 0,
+    });
+    expect(state.getAcknowledgedPollCursor("acct-a")).toBe(0);
+    const unacknowledgedRestart = await pollQaBus({
+      baseUrl: bus.baseUrl,
+      accountId: "acct-a",
+      cursor: 0,
+      timeoutMs: 0,
+    });
+    expect(
+      unacknowledgedRestart.events.flatMap((event) =>
+        "message" in event ? [event.message.id] : [],
+      ),
+    ).toEqual([consumed.id]);
+
+    await pollQaBus({
+      baseUrl: bus.baseUrl,
+      accountId: "acct-a",
+      cursor: firstPoll.cursor,
+      acknowledgedCursor: firstPoll.cursor,
       timeoutMs: 0,
     });
     expect(state.getAcknowledgedPollCursor("acct-a")).toBe(firstPoll.cursor);
@@ -250,6 +273,24 @@ describe("qa-bus server", () => {
     expect(response.status).toBe(400);
     await expect(response.json()).resolves.toEqual({
       error: "poll cursor must be an integer at least 0.",
+    });
+  });
+
+  it("rejects acknowledgements beyond the fetched cursor", async () => {
+    const state = createQaBusState();
+    const bus = await startQaBusServer({ state });
+    stops.push(bus["stop"]);
+
+    const response = await postQaBusJson(bus.baseUrl, "/v1/poll", {
+      accountId: "acct-a",
+      cursor: 1,
+      acknowledgedCursor: 2,
+      timeoutMs: 0,
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "acknowledged poll cursor must not exceed the requested poll cursor.",
     });
   });
 

--- a/extensions/qa-lab/src/bus-server.ts
+++ b/extensions/qa-lab/src/bus-server.ts
@@ -113,6 +113,13 @@ function normalizeQaBusPollInput(input: Record<string, unknown>): QaBusPollInput
     label: "poll cursor",
     min: 0,
   });
+  const acknowledgedCursor = readOptionalIntegerField(input, "acknowledgedCursor", {
+    label: "acknowledged poll cursor",
+    min: 0,
+  });
+  if (acknowledgedCursor !== undefined && acknowledgedCursor > (cursor ?? 0)) {
+    throw new Error("acknowledged poll cursor must not exceed the requested poll cursor.");
+  }
   const limit = readOptionalIntegerField(input, "limit", {
     label: "poll limit",
     max: QA_BUS_POLL_LIMIT_MAX,
@@ -126,6 +133,7 @@ function normalizeQaBusPollInput(input: Record<string, unknown>): QaBusPollInput
   return {
     ...input,
     ...(cursor !== undefined ? { cursor } : {}),
+    ...(acknowledgedCursor !== undefined ? { acknowledgedCursor } : {}),
     ...(limit !== undefined ? { limit } : {}),
     ...(timeoutMs !== undefined ? { timeoutMs } : {}),
   } as QaBusPollInput;

--- a/extensions/qa-lab/src/bus-state.ts
+++ b/extensions/qa-lab/src/bus-state.ts
@@ -340,8 +340,11 @@ export function createQaBusState() {
       const accountId = normalizeAccountId(input.accountId);
       const requestedCursor = input.cursor ?? 0;
       const acknowledgedCursor = acknowledgedPollCursors.get(accountId) ?? 0;
-      if (requestedCursor > acknowledgedCursor && requestedCursor <= cursor) {
-        acknowledgedPollCursors.set(accountId, requestedCursor);
+      // Fetch progress and completed work are separate facts. Missing
+      // acknowledgement means the consumer has not recorded new completion.
+      const completedCursor = input.acknowledgedCursor ?? 0;
+      if (completedCursor > acknowledgedCursor && completedCursor <= cursor) {
+        acknowledgedPollCursors.set(accountId, completedCursor);
       }
       // A restarted channel consumer begins at zero. Resume its account cursor
       // so retained events are not replayed, while still returning unacked work.

--- a/extensions/qa-lab/src/lab-server.test.ts
+++ b/extensions/qa-lab/src/lab-server.test.ts
@@ -906,6 +906,37 @@ describe("qa-lab server", () => {
     await expect(fetch(`${lab.baseUrl}/healthz`)).rejects.toThrow();
   });
 
+  it("keeps the bus available until the embedded gateway finishes stopping", async () => {
+    let markGatewayStopping = () => {};
+    const gatewayStopping = new Promise<void>((resolve) => {
+      markGatewayStopping = resolve;
+    });
+    let finishGatewayStop = () => {};
+    const gatewayStopped = new Promise<void>((resolve) => {
+      finishGatewayStop = resolve;
+    });
+    qaChannelMock.startAccount.mockImplementationOnce(
+      async ({ abortSignal }: { abortSignal?: AbortSignal }) => {
+        await new Promise<void>((resolve) => {
+          abortSignal?.addEventListener("abort", resolve, { once: true });
+        });
+        markGatewayStopping();
+        await gatewayStopped;
+      },
+    );
+
+    const lab = await startQaLabServer({ host: "127.0.0.1", port: 0 });
+    const stopping = lab.stop();
+    await gatewayStopping;
+    try {
+      await expect(fetch(`${lab.baseUrl}/healthz`)).resolves.toMatchObject({ status: 200 });
+    } finally {
+      finishGatewayStop();
+      await stopping;
+    }
+    await expect(fetch(`${lab.baseUrl}/healthz`)).rejects.toThrow();
+  });
+
   it("serves bootstrap state and message state", async () => {
     const tempDir = await mkdtemp(path.join(os.tmpdir(), "qa-lab-test-"));
     cleanups.push(async () => {

--- a/extensions/qa-lab/src/lab-server.test.ts
+++ b/extensions/qa-lab/src/lab-server.test.ts
@@ -918,7 +918,7 @@ describe("qa-lab server", () => {
     qaChannelMock.startAccount.mockImplementationOnce(
       async ({ abortSignal }: { abortSignal?: AbortSignal }) => {
         await new Promise<void>((resolve) => {
-          abortSignal?.addEventListener("abort", resolve, { once: true });
+          abortSignal?.addEventListener("abort", () => resolve(), { once: true });
         });
         markGatewayStopping();
         await gatewayStopped;

--- a/extensions/qa-lab/src/lab-server.ts
+++ b/extensions/qa-lab/src/lab-server.ts
@@ -951,13 +951,20 @@ export async function startQaLabServer(
   const stopLabServerResources = async (): Promise<Error | undefined> => {
     runnerModelCatalogAbort?.abort();
     await runnerModelCatalogPromise?.catch(() => undefined);
+    let cleanupError: Error | undefined;
+    // Gateway shutdown can flush completed work through this server, so the
+    // bus must remain reachable until the gateway has fully stopped.
+    try {
+      await gateway?.stop();
+    } catch (error) {
+      cleanupError = normalizeQaLabCleanupError(error);
+    }
     const results = await Promise.allSettled([
-      Promise.resolve().then(() => gateway?.stop()),
       Promise.resolve().then(() => (serverListening ? closeQaHttpServer(server) : undefined)),
       Promise.resolve().then(releaseCaptureStore),
     ]);
     const failed = results.find((result) => result.status === "rejected");
-    return failed ? normalizeQaLabCleanupError(failed.reason) : undefined;
+    return cleanupError ?? (failed ? normalizeQaLabCleanupError(failed.reason) : undefined);
   };
 
   try {

--- a/extensions/qa-lab/src/scenario-flow-runner.test-support.ts
+++ b/extensions/qa-lab/src/scenario-flow-runner.test-support.ts
@@ -78,6 +78,7 @@ export async function runLoadedScenarioFlow(
         state.resolvePollCursor({
           accountId: "qa-channel",
           cursor: state.getSnapshot().cursor,
+          acknowledgedCursor: state.getSnapshot().cursor,
         });
         return match;
       }

--- a/src/plugin-sdk/qa-channel-protocol.ts
+++ b/src/plugin-sdk/qa-channel-protocol.ts
@@ -248,6 +248,8 @@ export type QaBusReadMessageInput = {
 export type QaBusPollInput = {
   accountId?: string;
   cursor?: number;
+  /** Highest contiguous event cursor whose consumer work completed successfully. */
+  acknowledgedCursor?: number;
   timeoutMs?: number;
   limit?: number;
 };

--- a/src/plugin-sdk/qa-channel.test.ts
+++ b/src/plugin-sdk/qa-channel.test.ts
@@ -1,8 +1,9 @@
 // QA channel tests cover QA channel runtime behavior and mocked message delivery.
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, expectTypeOf, it, vi } from "vitest";
 
 const loadBundledPluginPublicSurfaceModuleSync = vi.hoisted(() => vi.fn());
 const buildQaTargetImpl = vi.hoisted(() => vi.fn());
+const pollQaBusImpl = vi.hoisted(() => vi.fn());
 
 vi.mock("./facade-loader.js", async () => {
   const actual = await vi.importActual<typeof import("./facade-loader.js")>("./facade-loader.js");
@@ -15,10 +16,13 @@ vi.mock("./facade-loader.js", async () => {
 describe("plugin-sdk qa-channel", () => {
   beforeEach(() => {
     buildQaTargetImpl.mockReset();
+    pollQaBusImpl.mockReset();
     loadBundledPluginPublicSurfaceModuleSync.mockReset();
     buildQaTargetImpl.mockReturnValue("qa://main");
+    pollQaBusImpl.mockResolvedValue({ cursor: 1, events: [] });
     loadBundledPluginPublicSurfaceModuleSync.mockReturnValue({
       buildQaTarget: buildQaTargetImpl,
+      pollQaBus: pollQaBusImpl,
       qaChannelPlugin: { id: "qa-channel" },
     });
   });
@@ -42,5 +46,22 @@ describe("plugin-sdk qa-channel", () => {
       dirName: "qa-channel",
       artifactBasename: "api.js",
     });
+  });
+
+  it("carries explicit completion acknowledgements through the QA facade", async () => {
+    const { pollQaBus } = await import("./qa-channel.js");
+    const input = {
+      baseUrl: "http://127.0.0.1:43124",
+      accountId: "default",
+      cursor: 1,
+      acknowledgedCursor: 1,
+      timeoutMs: 0,
+    };
+
+    expectTypeOf<Parameters<typeof pollQaBus>[0]>()
+      .toHaveProperty("acknowledgedCursor")
+      .toEqualTypeOf<number>();
+    await expect(pollQaBus(input)).resolves.toEqual({ cursor: 1, events: [] });
+    expect(pollQaBusImpl).toHaveBeenCalledWith(input);
   });
 });

--- a/src/plugin-sdk/qa-channel.ts
+++ b/src/plugin-sdk/qa-channel.ts
@@ -55,6 +55,7 @@ type FacadeModule = {
     baseUrl: string;
     accountId: string;
     cursor: number;
+    acknowledgedCursor: number;
     timeoutMs: number;
     signal?: AbortSignal;
   }) => Promise<QaBusPollResult>;


### PR DESCRIPTION
## What Problem This Solves

QA Channel previously treated a bus cursor as acknowledged as soon as the next poll fetched from it. Because message handlers run asynchronously, a Gateway restart or dispatch failure could therefore skip fetched-but-unhandled messages. The inverse failure also existed at shutdown: a successfully handled final message could replay because its completion was never flushed.

## Why This Change Was Made

The private QA poll contract now separates fetch progress from the highest contiguous cursor whose consumer work completed successfully. QA Channel records completion where dispatch actually finishes, preserves cursor order even when native controls bypass the normal queue, sends that explicit `acknowledgedCursor` on later polls, and flushes the final completed prefix before stopping. QA Lab persists only that explicit completion fact.

This is an intentional internal poll/plugin contract change. QA Lab and QA Channel are source-only private plugins, and their QA SDK artifacts are excluded from the packaged OpenClaw distribution. The handwritten private facade and QA Lab re-export now carry the same required cursor field, with a contract regression to prevent them from drifting.

The embedded QA Lab lifecycle also now stops its Gateway before closing the HTTP bus. That ordering is required because Gateway shutdown may use the bus to flush the final completion cursor; capture state and the server are still cleaned up if Gateway stop fails.

ClawSweeper rank-up moves are all resolved: the completion cursor is exposed through the QA facade and QA Lab re-export, facade and restart/contiguous-prefix regressions are included, and Peter explicitly approved the private acknowledgement contract in the maintainer work order.

## User Impact

QA runs no longer lose fetched work or replay completed work across dispatch failures and Gateway shutdown. Native stop controls remain responsive while ordinary work is blocked. There is no public plugin API, configuration, protocol-version, SQLite-schema, or packaged runtime change.

## Evidence

- Pre-fix cursor inference reproduced with `node scripts/run-vitest.mjs extensions/qa-channel/src/gateway.test.ts extensions/qa-lab/src/bus-server.test.ts`: 2 failures. The Gateway persisted cursor `3` instead of the successful contiguous prefix `1`; the bus persisted cursor `1` when explicit acknowledgement was `0`.
- Pre-fix concurrent shutdown reproduced with `node scripts/run-vitest.mjs extensions/qa-lab/src/lab-server.test.ts -t "keeps the bus available until the embedded gateway finishes stopping"`: the bus probe failed with `ECONNREFUSED` before Gateway stop completed.
- Final focused owner/sibling suite: `node scripts/run-vitest.mjs src/plugin-sdk/qa-channel.test.ts extensions/qa-channel/src/bus-client.test.ts extensions/qa-channel/src/gateway.test.ts extensions/qa-lab/src/bus-state.test.ts extensions/qa-lab/src/bus-server.test.ts extensions/qa-lab/src/lab-server.test.ts extensions/qa-lab/src/scenario-flow-runner.test.ts` passed 7 files / 106 tests across 2 shards.
- Exact red commands rerun after repair: Gateway/bus 2 files / 20 tests passed; lifecycle regression 1 passed / 28 skipped.
- `node scripts/check-changed.mjs` passed every selected core, core-test, extension, and extension-test lane on Blacksmith Testbox `tbx_01kznzvsyxb3dgxxzr8vv2prdn` with exit code 0 (Actions run 31396252763).
- Codex-backed autoreview: full change clean in one round at 0.98 confidence; final typed-listener delta clean in one round at 0.99 confidence. No accepted/actionable findings remain.
- Production LOC: +93/-11. Tests and test support: +233/-2. Production growth establishes the missing dispatch-completion owner boundary and the required shutdown ordering; no parallel compatibility path was added.
