### PR TITLE
fix(cli): install completion in effective shell startup profiles

### DIFF
--- a/src/cli/completion-runtime.test.ts
+++ b/src/cli/completion-runtime.test.ts
@@ -11,12 +11,30 @@ import {
   installCompletion,
   isCompletionInstalled,
   resolveCompletionCachePath,
+  resolveCompletionProfileHint,
   resolveCompletionProfilePath,
   resolveShellFromEnv,
   usesSlowDynamicCompletion,
 } from "./completion-runtime.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+const configuredShellCases = [
+  {
+    shell: "zsh" as const,
+    envName: "ZDOTDIR" as const,
+    profileSegments: [".zshrc"],
+    cacheContent: "export OPENCLAW_TEST_COMPLETION_READY=zsh\n",
+    startupArgs: ["-i", "-c", 'printf "%s" "$OPENCLAW_TEST_COMPLETION_READY"'],
+  },
+  {
+    shell: "fish" as const,
+    envName: "XDG_CONFIG_HOME" as const,
+    profileSegments: ["fish", "config.fish"],
+    cacheContent: "set -gx OPENCLAW_TEST_COMPLETION_READY fish\n",
+    startupArgs: ["-c", 'printf "%s" "$OPENCLAW_TEST_COMPLETION_READY"'],
+  },
+] as const;
 
 async function withBashCompletionHome(
   run: (paths: { homeDir: string; stateDir: string }) => Promise<void>,
@@ -30,6 +48,590 @@ async function withBashCompletionHome(
 }
 
 describe("completion-runtime", () => {
+  it("preserves the root startup profile for an explicitly empty ZDOTDIR", () => {
+    const homeDir = path.join(os.tmpdir(), "openclaw-empty-zdotdir-home");
+
+    expect(
+      resolveCompletionProfilePath("zsh", {
+        env: { HOME: homeDir, ZDOTDIR: "" },
+        homeDir: () => homeDir,
+      }),
+    ).toBe(path.join(path.parse(homeDir).root, ".zshrc"));
+  });
+
+  it.each(configuredShellCases)(
+    "resolves the actual $shell startup profile from $envName",
+    ({ shell, envName, profileSegments }) => {
+      const homeDir = path.join(os.tmpdir(), "openclaw-shell-profile-home");
+      const configuredRoot = path.join(os.tmpdir(), "openclaw-shell-profile-config");
+
+      expect(
+        resolveCompletionProfilePath(shell, {
+          env: { HOME: homeDir, [envName]: configuredRoot },
+          homeDir: () => homeDir,
+        }),
+      ).toBe(path.join(configuredRoot, ...profileSegments));
+    },
+  );
+
+  it.each([
+    "relative-config",
+    "../relative-config",
+    " relative-config ",
+    "   ",
+    "~/relative-config",
+    "~root/relative-config",
+    "-relative-config",
+    "+relative-config",
+  ])("preserves Fish's verbatim nonempty XDG_CONFIG_HOME when it is %s", (configuredRoot) => {
+    const homeDir = path.join(os.tmpdir(), "openclaw-fish-relative-xdg-home");
+
+    expect(
+      resolveCompletionProfilePath("fish", {
+        env: { HOME: homeDir, XDG_CONFIG_HOME: configuredRoot },
+        homeDir: () => homeDir,
+      }),
+    ).toBe(path.join(configuredRoot, "fish", "config.fish"));
+  });
+
+  it.each([
+    {
+      shell: "zsh" as const,
+      env: { HOME: "/Users/ada", ZDOTDIR: "/Users/ada/.config/zsh dotfiles" },
+      expected: "~/.config/zsh dotfiles/.zshrc",
+    },
+    {
+      shell: "fish" as const,
+      env: { HOME: "/Users/ada", XDG_CONFIG_HOME: "/Users/ada/custom xdg" },
+      expected: "~/custom xdg/fish/config.fish",
+    },
+    {
+      shell: "fish" as const,
+      env: { HOME: "/Users/ada", XDG_CONFIG_HOME: "~/literal-config" },
+      expected: "./~/literal-config/fish/config.fish",
+    },
+    {
+      shell: "zsh" as const,
+      env: { HOME: "/Users/ada", ZDOTDIR: "/tmp/configured zsh" },
+      expected: "/tmp/configured zsh/.zshrc",
+    },
+  ])("formats the canonical $shell profile hint without hiding configured roots", (testCase) => {
+    expect(resolveCompletionProfileHint(testCase.shell, { env: testCase.env })).toBe(
+      testCase.expected,
+    );
+  });
+
+  it.each(configuredShellCases)(
+    "installs cached $shell completion into its configured startup profile",
+    async ({ shell, envName, profileSegments, cacheContent, startupArgs }) => {
+      const tempDir = tempDirs.make(`openclaw-${shell}-configured-profile-`);
+      const homeDir = path.join(tempDir, "home");
+      const stateDir = path.join(tempDir, "state");
+      const configuredRoot = path.join(tempDir, "configured startup");
+      const profilePath = path.join(configuredRoot, ...profileSegments);
+      await fs.mkdir(homeDir, { recursive: true });
+
+      await withEnvAsync(
+        {
+          HOME: homeDir,
+          OPENCLAW_STATE_DIR: stateDir,
+          ZDOTDIR: envName === "ZDOTDIR" ? configuredRoot : undefined,
+          XDG_CONFIG_HOME: envName === "XDG_CONFIG_HOME" ? configuredRoot : undefined,
+          OPENCLAW_TEST_COMPLETION_READY: undefined,
+        },
+        async () => {
+          const cachePath = resolveCompletionCachePath(shell, "openclaw");
+          await fs.mkdir(path.dirname(cachePath), { recursive: true });
+          await fs.writeFile(cachePath, cacheContent, "utf-8");
+
+          await installCompletion(shell, true, "openclaw");
+
+          await expect(fs.readFile(profilePath, "utf-8")).resolves.toContain(cachePath);
+          await expect(isCompletionInstalled(shell, "openclaw")).resolves.toBe(true);
+
+          const shellVersion = spawnSync(shell, ["--version"], { encoding: "utf8" });
+          if (shellVersion.error) {
+            return;
+          }
+
+          const actualShell = spawnSync(shell, [...startupArgs], {
+            encoding: "utf8",
+            env: process.env,
+          });
+          expect(actualShell.status).toBe(0);
+          expect(actualShell.stdout).toBe(shell);
+        },
+      );
+    },
+  );
+
+  it.each(configuredShellCases)(
+    "preserves symlink traversal in the configured $shell startup root",
+    async ({ shell, envName, profileSegments, cacheContent, startupArgs }) => {
+      const shellVersion = spawnSync(shell, ["--version"], { encoding: "utf8" });
+      if (shellVersion.error || process.platform === "win32") {
+        return;
+      }
+
+      const tempDir = tempDirs.make(`openclaw-${shell}-symlink-startup-`);
+      const homeDir = path.join(tempDir, "home");
+      const stateDir = path.join(tempDir, "state");
+      const actualRoot = path.join(tempDir, "actual startup");
+      const symlinkTarget = path.join(actualRoot, "nested");
+      const link = path.join(homeDir, "linked startup");
+      const configuredRoot = `${link}${path.sep}..`;
+      const profileSuffix = profileSegments.join(path.sep);
+      const lexicalProfile = `${configuredRoot}${path.sep}${profileSuffix}`;
+      const actualProfile = path.join(actualRoot, ...profileSegments);
+      await fs.mkdir(homeDir, { recursive: true });
+      await fs.mkdir(symlinkTarget, { recursive: true });
+      await fs.symlink(symlinkTarget, link, "dir");
+
+      await withEnvAsync(
+        {
+          HOME: homeDir,
+          OPENCLAW_STATE_DIR: stateDir,
+          ZDOTDIR: envName === "ZDOTDIR" ? configuredRoot : undefined,
+          XDG_CONFIG_HOME: envName === "XDG_CONFIG_HOME" ? configuredRoot : undefined,
+          OPENCLAW_TEST_COMPLETION_READY: undefined,
+        },
+        async () => {
+          const cachePath = resolveCompletionCachePath(shell, "openclaw");
+          await fs.mkdir(path.dirname(cachePath), { recursive: true });
+          await fs.writeFile(cachePath, cacheContent, "utf8");
+
+          expect(resolveCompletionProfilePath(shell)).toBe(lexicalProfile);
+          expect(resolveCompletionProfileHint(shell)).toBe(
+            `~/linked startup/../${profileSegments.join("/")}`,
+          );
+          await installCompletion(shell, true, "openclaw");
+          await expect(fs.readFile(actualProfile, "utf8")).resolves.toContain(cachePath);
+          await expect(isCompletionInstalled(shell, "openclaw")).resolves.toBe(true);
+
+          const actualShell = spawnSync(shell, [...startupArgs], {
+            encoding: "utf8",
+            env: process.env,
+          });
+          expect(actualShell.status).toBe(0);
+          expect(actualShell.stdout).toBe(shell);
+        },
+      );
+    },
+  );
+
+  it.each([
+    { mode: "relative", directory: "relative startup" },
+    { mode: "space-padded", directory: " relative startup " },
+  ])("activates actual Fish startup for a $mode XDG_CONFIG_HOME", async (testCase) => {
+    const fishVersion = spawnSync("fish", ["--version"], { encoding: "utf8" });
+    if (fishVersion.error) {
+      return;
+    }
+
+    const tempDir = tempDirs.make(`openclaw-fish-${testCase.mode}-xdg-`);
+    const homeDir = path.join(tempDir, "home");
+    const stateDir = path.join(tempDir, "state");
+    const configuredRoot = path.relative(process.cwd(), path.join(tempDir, testCase.directory));
+    const profilePath = path.join(configuredRoot, "fish", "config.fish");
+    await fs.mkdir(homeDir, { recursive: true });
+
+    await withEnvAsync(
+      {
+        HOME: homeDir,
+        OPENCLAW_STATE_DIR: stateDir,
+        XDG_CONFIG_HOME: configuredRoot,
+        OPENCLAW_TEST_COMPLETION_READY: undefined,
+      },
+      async () => {
+        const cachePath = resolveCompletionCachePath("fish", "openclaw");
+        await fs.mkdir(path.dirname(cachePath), { recursive: true });
+        await fs.writeFile(cachePath, "set -gx OPENCLAW_TEST_COMPLETION_READY relative-fish\n");
+
+        expect(path.isAbsolute(configuredRoot)).toBe(false);
+        expect(resolveCompletionProfilePath("fish")).toBe(profilePath);
+        await installCompletion("fish", true, "openclaw");
+        await expect(fs.readFile(profilePath, "utf8")).resolves.toContain(cachePath);
+        await expect(isCompletionInstalled("fish", "openclaw")).resolves.toBe(true);
+
+        const actualShell = spawnSync(
+          "fish",
+          ["--private", "-c", 'printf "%s" "$OPENCLAW_TEST_COMPLETION_READY"'],
+          { encoding: "utf8", env: process.env },
+        );
+        expect(actualShell.status).toBe(0);
+        expect(actualShell.stdout).toBe("relative-fish");
+      },
+    );
+  });
+
+  it.each([
+    { shell: "fish" as const, configuredRoot: "~/literal startup" },
+    { shell: "fish" as const, configuredRoot: "~root/literal startup" },
+    { shell: "fish" as const, configuredRoot: "-literal startup" },
+    { shell: "fish" as const, configuredRoot: "+literal startup" },
+    { shell: "zsh" as const, configuredRoot: "~/literal startup" },
+    { shell: "zsh" as const, configuredRoot: "~root/literal startup" },
+    { shell: "zsh" as const, configuredRoot: "-literal startup" },
+    { shell: "zsh" as const, configuredRoot: "+literal startup" },
+  ])("executes a $shell reload for literal relative root $configuredRoot", async (testCase) => {
+    const shellVersion = spawnSync(testCase.shell, ["--version"], { encoding: "utf8" });
+    if (shellVersion.error) {
+      return;
+    }
+
+    const tempDir = tempDirs.make(`openclaw-${testCase.shell}-literal-startup-`);
+    const homeDir = path.join(tempDir, "home");
+    const profileSegments = testCase.shell === "fish" ? ["fish", "config.fish"] : [".zshrc"];
+    const profilePath = path.join(tempDir, testCase.configuredRoot, ...profileSegments);
+    await fs.mkdir(homeDir, { recursive: true });
+    await fs.mkdir(path.dirname(profilePath), { recursive: true });
+    await fs.writeFile(
+      profilePath,
+      testCase.shell === "fish"
+        ? "set -gx OPENCLAW_TEST_COMPLETION_READY literal-shell\n"
+        : "export OPENCLAW_TEST_COMPLETION_READY=literal-shell\n",
+    );
+
+    if (testCase.shell === "zsh") {
+      await fs.writeFile(
+        path.join(homeDir, ".zshenv"),
+        `builtin cd -- ${JSON.stringify(tempDir)}\nZDOTDIR=${JSON.stringify(testCase.configuredRoot)}\n`,
+      );
+    }
+
+    const env = {
+      ...process.env,
+      HOME: homeDir,
+      ZDOTDIR: undefined,
+      XDG_CONFIG_HOME: testCase.shell === "fish" ? testCase.configuredRoot : undefined,
+    };
+    const profileHint = resolveCompletionProfileHint(testCase.shell, {
+      env,
+      homeDir: () => homeDir,
+    });
+    const expectedHint =
+      testCase.shell === "fish"
+        ? `./${testCase.configuredRoot}/${profileSegments.join("/")}`
+        : `${tempDir}/${testCase.configuredRoot}/${profileSegments.join("/")}`;
+    expect(profileHint).toBe(expectedHint);
+
+    const reloadCommand = formatCompletionReloadCommand(testCase.shell, profileHint);
+    const shellArguments = testCase.shell === "fish" ? ["--private", "--no-config"] : ["-f", "-i"];
+    const actualShell = spawnSync(
+      testCase.shell,
+      [...shellArguments, "-c", `${reloadCommand}; printf "%s" "$OPENCLAW_TEST_COMPLETION_READY"`],
+      { encoding: "utf8", env, cwd: tempDir },
+    );
+    expect(actualShell.status).toBe(0);
+    expect(actualShell.stderr).toBe("");
+    expect(actualShell.stdout).toBe("literal-shell");
+  });
+
+  it("anchors a relative ZDOTDIR to the actual .zshenv working directory", async () => {
+    const zshVersion = spawnSync("zsh", ["--version"], { encoding: "utf8" });
+    if (zshVersion.error) {
+      return;
+    }
+
+    const tempDir = tempDirs.make("openclaw-zsh-startup-working-directory-");
+    const homeDir = path.join(tempDir, "home");
+    const workingDirectory = path.join(tempDir, "actual working directory");
+    const configuredRoot = "relative startup";
+    const profilePath = path.join(workingDirectory, configuredRoot, ".zshrc");
+    const stateDir = path.join(tempDir, "state");
+    await fs.mkdir(homeDir, { recursive: true });
+    await fs.mkdir(workingDirectory, { recursive: true });
+    await fs.writeFile(
+      path.join(homeDir, ".zshenv"),
+      `builtin cd -- ${JSON.stringify(workingDirectory)}\nZDOTDIR=${JSON.stringify(configuredRoot)}\n`,
+    );
+
+    await withEnvAsync(
+      {
+        HOME: homeDir,
+        OPENCLAW_STATE_DIR: stateDir,
+        SHELL: "/bin/zsh",
+        ZDOTDIR: undefined,
+        OPENCLAW_TEST_COMPLETION_READY: undefined,
+      },
+      async () => {
+        const cachePath = resolveCompletionCachePath("zsh", "openclaw");
+        await fs.mkdir(path.dirname(cachePath), { recursive: true });
+        await fs.writeFile(cachePath, "export OPENCLAW_TEST_COMPLETION_READY=relative-zsh\n");
+
+        expect(resolveCompletionProfilePath("zsh")).toBe(profilePath);
+        expect(resolveCompletionProfileHint("zsh")).toBe(profilePath);
+        await installCompletion("zsh", true, "openclaw");
+        await expect(fs.readFile(profilePath, "utf8")).resolves.toContain(cachePath);
+
+        const actualShell = spawnSync(
+          "zsh",
+          ["-i", "-c", 'printf "%s" "$OPENCLAW_TEST_COMPLETION_READY"'],
+          { encoding: "utf8", env: process.env },
+        );
+        expect(actualShell.status).toBe(0);
+        expect(actualShell.stdout).toBe("relative-zsh");
+      },
+    );
+  });
+
+  it("discovers a shell-local ZDOTDIR declared without export in .zshenv", async () => {
+    const zshVersion = spawnSync("zsh", ["--version"], { encoding: "utf8" });
+    if (zshVersion.error) {
+      return;
+    }
+
+    const tempDir = tempDirs.make("openclaw-zsh-local-dotdir-");
+    const homeDir = path.join(tempDir, "home");
+    const stateDir = path.join(tempDir, "state");
+    const configuredRoot = path.join(tempDir, "unexported startup");
+    await fs.mkdir(homeDir, { recursive: true });
+    await fs.writeFile(
+      path.join(homeDir, ".zshenv"),
+      `ZDOTDIR=${JSON.stringify(configuredRoot)}\n`,
+      "utf8",
+    );
+
+    await withEnvAsync(
+      {
+        HOME: homeDir,
+        OPENCLAW_STATE_DIR: stateDir,
+        ZDOTDIR: undefined,
+        OPENCLAW_TEST_COMPLETION_READY: undefined,
+      },
+      async () => {
+        const profilePath = path.join(configuredRoot, ".zshrc");
+        const cachePath = resolveCompletionCachePath("zsh", "openclaw");
+        await fs.mkdir(path.dirname(cachePath), { recursive: true });
+        await fs.writeFile(cachePath, "export OPENCLAW_TEST_COMPLETION_READY=local-zsh\n", "utf8");
+
+        expect(resolveCompletionProfilePath("zsh")).toBe(profilePath);
+        await installCompletion("zsh", true, "openclaw");
+        await expect(fs.readFile(profilePath, "utf8")).resolves.toContain(cachePath);
+
+        const actualShell = spawnSync(
+          "zsh",
+          ["-i", "-c", 'printf "%s" "$OPENCLAW_TEST_COMPLETION_READY"'],
+          { encoding: "utf8", env: process.env },
+        );
+        expect(actualShell.status).toBe(0);
+        expect(actualShell.stdout).toBe("local-zsh");
+      },
+    );
+  });
+
+  it.each([
+    { mode: "interactive-only", inherited: false },
+    { mode: "reassigned-inherited", inherited: true },
+    { mode: "shadowed-printf", inherited: false },
+  ] as const)("discovers the actual $mode Zsh startup profile", async (testCase) => {
+    const zshVersion = spawnSync("zsh", ["--version"], { encoding: "utf8" });
+    if (zshVersion.error) {
+      return;
+    }
+
+    const tempDir = tempDirs.make(`openclaw-zsh-${testCase.mode}-`);
+    const homeDir = path.join(tempDir, "home");
+    const stateDir = path.join(tempDir, "state");
+    const inheritedRoot = path.join(tempDir, "initial startup");
+    const configuredRoot = path.join(tempDir, "actual startup");
+    const startupRoot = testCase.inherited ? inheritedRoot : homeDir;
+    await fs.mkdir(homeDir, { recursive: true });
+    await fs.mkdir(startupRoot, { recursive: true });
+    const assignment = `ZDOTDIR=${JSON.stringify(configuredRoot)}`;
+    const startupConfig =
+      testCase.mode === "interactive-only"
+        ? `if [[ -o interactive ]]; then\n  ${assignment}\nfi\n`
+        : testCase.mode === "shadowed-printf"
+          ? `${assignment}\nprintf() { return 0; }\n`
+          : `${assignment}\n`;
+    await fs.writeFile(path.join(startupRoot, ".zshenv"), startupConfig, "utf8");
+
+    await withEnvAsync(
+      {
+        HOME: homeDir,
+        OPENCLAW_STATE_DIR: stateDir,
+        SHELL: "/bin/zsh",
+        ZDOTDIR: testCase.inherited ? inheritedRoot : undefined,
+        OPENCLAW_TEST_COMPLETION_READY: undefined,
+      },
+      async () => {
+        const profilePath = path.join(configuredRoot, ".zshrc");
+        const cachePath = resolveCompletionCachePath("zsh", "openclaw");
+        await fs.mkdir(path.dirname(cachePath), { recursive: true });
+        await fs.writeFile(cachePath, "export OPENCLAW_TEST_COMPLETION_READY=actual-zsh\n", "utf8");
+
+        expect(resolveCompletionProfilePath("zsh")).toBe(profilePath);
+        await installCompletion("zsh", true, "openclaw");
+
+        const actualShell = spawnSync(
+          "zsh",
+          ["-i", "-c", 'builtin printf "%s" "$OPENCLAW_TEST_COMPLETION_READY"'],
+          { encoding: "utf8", env: process.env },
+        );
+        expect(actualShell.status).toBe(0);
+        expect(actualShell.stdout).toBe("actual-zsh");
+      },
+    );
+  });
+
+  it("captures the Zsh profile before loading user .zshrc side effects", async () => {
+    const zshVersion = spawnSync("zsh", ["--version"], { encoding: "utf8" });
+    if (zshVersion.error) {
+      return;
+    }
+
+    const tempDir = tempDirs.make("openclaw-zsh-no-zshrc-side-effects-");
+    const homeDir = path.join(tempDir, "home");
+    const configuredRoot = path.join(tempDir, "actual startup");
+    const misleadingRoot = path.join(tempDir, "changed after startup");
+    const sideEffectPath = path.join(tempDir, "zshrc-was-loaded");
+    await fs.mkdir(homeDir, { recursive: true });
+    await fs.mkdir(configuredRoot, { recursive: true });
+    await fs.writeFile(
+      path.join(homeDir, ".zshenv"),
+      `ZDOTDIR=${JSON.stringify(configuredRoot)}\n`,
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(configuredRoot, ".zshrc"),
+      `ZDOTDIR=${JSON.stringify(misleadingRoot)}\nprintf ran > ${JSON.stringify(sideEffectPath)}\n`,
+      "utf8",
+    );
+
+    expect(
+      resolveCompletionProfilePath("zsh", {
+        env: { ...process.env, HOME: homeDir, SHELL: "/bin/zsh", ZDOTDIR: undefined },
+        homeDir: () => homeDir,
+      }),
+    ).toBe(path.join(configuredRoot, ".zshrc"));
+    await expect(fs.access(sideEffectPath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("forcibly bounds Zsh startup discovery when .zshenv ignores SIGTERM", async () => {
+    const zshVersion = spawnSync("zsh", ["--version"], { encoding: "utf8" });
+    if (zshVersion.error || process.platform === "win32") {
+      return;
+    }
+
+    const homeDir = tempDirs.make("openclaw-zsh-bounded-startup-");
+    await fs.writeFile(
+      path.join(homeDir, ".zshenv"),
+      'trap "" TERM\ninteger deadline=$((SECONDS + 4))\nwhile (( SECONDS < deadline )); do :; done\n',
+      "utf8",
+    );
+
+    const startedAt = Date.now();
+    expect(
+      resolveCompletionProfilePath("zsh", {
+        env: { ...process.env, HOME: homeDir, ZDOTDIR: undefined },
+        homeDir: () => homeDir,
+      }),
+    ).toBe(path.join(homeDir, ".zshrc"));
+    expect(Date.now() - startedAt).toBeLessThan(3_000);
+  });
+
+  it("bounds Zsh discovery when a startup descendant keeps stdout open", async () => {
+    const zshVersion = spawnSync("zsh", ["--version"], { encoding: "utf8" });
+    if (zshVersion.error || process.platform === "win32") {
+      return;
+    }
+
+    const homeDir = tempDirs.make("openclaw-zsh-bounded-descendant-");
+    await fs.writeFile(path.join(homeDir, ".zshenv"), "(sleep 4) &\n", "utf8");
+
+    const startedAt = Date.now();
+    expect(
+      resolveCompletionProfilePath("zsh", {
+        env: { ...process.env, HOME: homeDir, ZDOTDIR: undefined },
+        homeDir: () => homeDir,
+      }),
+    ).toBe(path.join(homeDir, ".zshrc"));
+    expect(Date.now() - startedAt).toBeLessThan(3_000);
+  });
+
+  it.each([
+    {
+      shell: "zsh" as const,
+      profilePath: "~/configured startup/.zshrc",
+      expected: 'source "$HOME/configured startup/.zshrc"',
+    },
+    {
+      shell: "fish" as const,
+      profilePath: "~/configured startup/fish/config.fish",
+      expected: 'source "$HOME/configured startup/fish/config.fish"',
+    },
+    {
+      shell: "bash" as const,
+      profilePath: "/tmp/configured startup/.bashrc",
+      expected: 'source "/tmp/configured startup/.bashrc"',
+    },
+    {
+      shell: "zsh" as const,
+      profilePath: '/tmp/shell $state/"quoted"/.zshrc',
+      expected: 'source "/tmp/shell \\$state/\\"quoted\\"/.zshrc"',
+    },
+    {
+      shell: "zsh" as const,
+      profilePath: "~/owner's ! startup/.zshrc",
+      expected: `source "$HOME"/'owner'\\''s ! startup/.zshrc'`,
+    },
+    {
+      shell: "bash" as const,
+      profilePath: "/tmp/owner's ! startup/.bashrc",
+      expected: `source '/tmp/owner'\\''s ! startup/.bashrc'`,
+    },
+  ])("quotes an executable $shell reload hint for configured profile paths", (testCase) => {
+    expect(formatCompletionReloadCommand(testCase.shell, testCase.profilePath)).toBe(
+      testCase.expected,
+    );
+  });
+
+  it.each(configuredShellCases)(
+    "executes the quoted $shell reload command for startup paths with shell metacharacters",
+    async ({ shell, envName, profileSegments, cacheContent }) => {
+      const shellVersion = spawnSync(shell, ["--version"], { encoding: "utf8" });
+      if (shellVersion.error) {
+        return;
+      }
+
+      const tempDir = tempDirs.make(`openclaw-${shell}-reload-spaces-`);
+      const homeDir = path.join(tempDir, "home");
+      const stateDir = path.join(tempDir, `state $cache "quoted"! owner's`);
+      const configuredRoot = path.join(homeDir, `configured $startup "profiles"! owner's`);
+      const profilePath = path.join(configuredRoot, ...profileSegments);
+      await fs.mkdir(homeDir, { recursive: true });
+
+      await withEnvAsync(
+        {
+          HOME: homeDir,
+          OPENCLAW_STATE_DIR: stateDir,
+          ZDOTDIR: envName === "ZDOTDIR" ? configuredRoot : undefined,
+          XDG_CONFIG_HOME: envName === "XDG_CONFIG_HOME" ? configuredRoot : undefined,
+          OPENCLAW_TEST_COMPLETION_READY: undefined,
+        },
+        async () => {
+          const cachePath = resolveCompletionCachePath(shell, "openclaw");
+          await fs.mkdir(path.dirname(cachePath), { recursive: true });
+          await fs.writeFile(cachePath, cacheContent, "utf8");
+          await installCompletion(shell, true, "openclaw");
+
+          const profileHint = path.join("~", path.relative(homeDir, profilePath));
+          const command = formatCompletionReloadCommand(shell, profileHint);
+          const actualShell = spawnSync(
+            shell,
+            ["-c", `${command}; printf '%s' "$OPENCLAW_TEST_COMPLETION_READY"`],
+            { encoding: "utf8", env: process.env },
+          );
+
+          expect(actualShell.status).toBe(0);
+          expect(actualShell.stderr).toBe("");
+          expect(actualShell.stdout).toBe(shell);
+        },
+      );
+    },
+  );
+
   it("resolves the documented Bash login profile when .bashrc is absent", async () => {
     await withBashCompletionHome(async ({ homeDir }) => {
       expect(resolveCompletionProfilePath("bash")).toBe(path.join(homeDir, ".bash_profile"));
@@ -154,6 +756,53 @@ describe("completion-runtime", () => {
         "Microsoft.PowerShell_profile.ps1",
       ),
     );
+  });
+
+  it("keeps Windows Bash profile paths native and reload hints shell-executable", () => {
+    const homeDir = "C:\\Users\\Ada";
+    const options = {
+      env: { HOME: homeDir },
+      homeDir: () => homeDir,
+      platform: "win32" as const,
+    };
+
+    expect(resolveCompletionProfilePath("bash", options)).toBe(
+      path.win32.join(homeDir, ".bash_profile"),
+    );
+    expect(resolveCompletionProfileHint("bash", options)).toBe("~/.bash_profile");
+    expect(
+      formatCompletionReloadCommand("bash", resolveCompletionProfileHint("bash", options)),
+    ).toBe("source ~/.bash_profile");
+  });
+
+  it.each([
+    {
+      shell: "zsh" as const,
+      env: { HOME: "C:\\Users\\Ada", ZDOTDIR: "D:\\configured shell" },
+      profile: "D:\\configured shell\\.zshrc",
+      hint: "D:/configured shell/.zshrc",
+    },
+    {
+      shell: "fish" as const,
+      env: { HOME: "C:\\Users\\Ada", XDG_CONFIG_HOME: "D:\\configured shell" },
+      profile: "D:\\configured shell\\fish\\config.fish",
+      hint: "D:/configured shell/fish/config.fish",
+    },
+  ])("formats external Windows $shell profiles for the target shell", (testCase) => {
+    const options = {
+      env: testCase.env,
+      homeDir: () => "C:\\Users\\Ada",
+      platform: "win32" as const,
+    };
+
+    expect(resolveCompletionProfilePath(testCase.shell, options)).toBe(testCase.profile);
+    expect(resolveCompletionProfileHint(testCase.shell, options)).toBe(testCase.hint);
+    expect(
+      formatCompletionReloadCommand(
+        testCase.shell,
+        resolveCompletionProfileHint(testCase.shell, options),
+      ),
+    ).toBe(`source "${testCase.hint}"`);
   });
 
   it("installs PowerShell completion into the concrete profile path", async () => {

--- a/src/cli/completion-runtime.ts
+++ b/src/cli/completion-runtime.ts
@@ -1,4 +1,5 @@
 // Shell completion runtime: cache paths, profile installation, and shell detection.
+import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
@@ -83,14 +84,28 @@ function escapePowerShellSingleQuotedString(value: string): string {
   return value.replace(/'/g, "''");
 }
 
+function escapeDoubleQuotedShellString(shell: CompletionShell, value: string): string {
+  // Backticks substitute commands in POSIX shells but are literal inside Fish double quotes.
+  return value.replace(shell === "fish" ? /[\\$"]/g : /[\\$"`]/g, "\\$&");
+}
+
+function quoteCompletionShellPath(shell: CompletionShell, value: string): string {
+  if (shell !== "fish" && value.includes("!")) {
+    // Interactive Bash and Zsh expand history even inside double quotes.
+    return `'${value.replace(/'/g, "'\\''")}'`;
+  }
+  return `"${escapeDoubleQuotedShellString(shell, value)}"`;
+}
+
 function formatCompletionSourceLine(shell: CompletionShell, cachePath: string): string {
   if (shell === "powershell") {
     return `. '${escapePowerShellSingleQuotedString(cachePath)}'`;
   }
+  const quotedCachePath = quoteCompletionShellPath(shell, cachePath);
   if (shell === "fish") {
-    return `test -f "${cachePath}"; and source "${cachePath}"`;
+    return `test -f ${quotedCachePath}; and source ${quotedCachePath}`;
   }
-  return `[ -f "${cachePath}" ] && source "${cachePath}"`;
+  return `[ -f ${quotedCachePath} ] && source ${quotedCachePath}`;
 }
 
 /** Formats the command users can run to reload the shell profile after installation. */
@@ -98,7 +113,16 @@ export function formatCompletionReloadCommand(shell: CompletionShell, profilePat
   if (shell === "powershell") {
     return `. '${escapePowerShellSingleQuotedString(profilePath)}'`;
   }
-  return `source ${profilePath}`;
+  if (/^[A-Za-z0-9_./~+-]+$/.test(profilePath)) {
+    return `source ${profilePath}`;
+  }
+  if (profilePath.startsWith("~/")) {
+    if (shell !== "fish" && profilePath.includes("!")) {
+      return `source "$HOME"/${quoteCompletionShellPath(shell, profilePath.slice(2))}`;
+    }
+    return `source "$HOME/${escapeDoubleQuotedShellString(shell, profilePath.slice(2))}"`;
+  }
+  return `source ${quoteCompletionShellPath(shell, profilePath)}`;
 }
 
 function isCompletionProfileHeader(line: string): boolean {
@@ -154,29 +178,105 @@ function updateCompletionProfile(
   return { next, changed: next !== content, hadExisting };
 }
 
+type CompletionProfileOptions = {
+  env?: NodeJS.ProcessEnv;
+  homeDir?: () => string;
+  platform?: NodeJS.Platform;
+};
+
+function appendCompletionProfilePath(
+  directory: string,
+  segments: readonly string[],
+  pathApi: typeof path.posix,
+): string {
+  const nativeDirectory = pathApi.sep === "\\" ? directory.replace(/\//g, pathApi.sep) : directory;
+  const separator = nativeDirectory.endsWith(pathApi.sep) ? "" : pathApi.sep;
+  // Shell startup resolves symlinks before `..`; path.join would silently change that target.
+  return `${nativeDirectory}${separator}${segments.join(pathApi.sep)}`;
+}
+
+function resolveZshProfileDirectory(
+  env: NodeJS.ProcessEnv,
+  home: string,
+  pathApi: typeof path.posix,
+): string {
+  const initialDirectory = Object.hasOwn(env, "ZDOTDIR") ? env.ZDOTDIR : undefined;
+  const fallbackDirectory =
+    initialDirectory === undefined
+      ? home
+      : initialDirectory === ""
+        ? pathApi.parse(home).root || pathApi.sep
+        : initialDirectory;
+  const shellPath = normalizeOptionalString(env.SHELL);
+  const zsh = shellPath && resolveShellBasename(shellPath) === "zsh" ? shellPath : "zsh";
+  // Source interactive .zshenv directly so profile discovery never runs the user's .zshrc.
+  const startupProbe = [
+    "setopt rcs",
+    '__openclaw_zdotdir="${ZDOTDIR-${HOME}}"',
+    'if [[ -r "${__openclaw_zdotdir}/.zshenv" ]]; then source "${__openclaw_zdotdir}/.zshenv"; fi',
+    'builtin printf "\\0%s\\0%s\\0" "${ZDOTDIR-${HOME}}" "$PWD"',
+  ].join("; ");
+  const result = spawnSync(zsh, ["-f", "-i", "-c", startupProbe], {
+    encoding: "utf8",
+    env: { ...env, HOME: home },
+    killSignal: "SIGKILL",
+    maxBuffer: 64 * 1024,
+    stdio: ["ignore", "pipe", "ignore"],
+    timeout: 1_000,
+    windowsHide: true,
+  });
+  if (result.status !== 0 || typeof result.stdout !== "string") {
+    return fallbackDirectory;
+  }
+
+  const end = result.stdout.lastIndexOf("\0");
+  const workingDirectoryStart = result.stdout.lastIndexOf("\0", end - 1);
+  const effectiveDirectoryStart = result.stdout.lastIndexOf("\0", workingDirectoryStart - 1);
+  if (end < 0 || workingDirectoryStart < 0 || effectiveDirectoryStart < 0) {
+    return fallbackDirectory;
+  }
+  const effectiveDirectory = result.stdout.slice(
+    effectiveDirectoryStart + 1,
+    workingDirectoryStart,
+  );
+  if (effectiveDirectory === "") {
+    return pathApi.parse(home).root || pathApi.sep;
+  }
+  if (pathApi.isAbsolute(effectiveDirectory)) {
+    return effectiveDirectory;
+  }
+  const workingDirectory = result.stdout.slice(workingDirectoryStart + 1, end);
+  return workingDirectory
+    ? appendCompletionProfilePath(workingDirectory, [effectiveDirectory], pathApi)
+    : fallbackDirectory;
+}
+
 /** Resolves the shell startup profile path that should contain the OpenClaw completion block. */
 export function resolveCompletionProfilePath(
   shell: CompletionShell,
-  options: {
-    env?: NodeJS.ProcessEnv;
-    homeDir?: () => string;
-    platform?: NodeJS.Platform;
-  } = {},
+  options: CompletionProfileOptions = {},
 ): string {
   const env = options.env ?? process.env;
   const homeDir = options.homeDir ?? os.homedir;
   const platform = options.platform ?? process.platform;
+  const pathApi = platform === "win32" ? path.win32 : path.posix;
   const home = env.HOME || homeDir();
   if (shell === "zsh") {
-    return path.join(home, ".zshrc");
+    return appendCompletionProfilePath(
+      resolveZshProfileDirectory(env, home, pathApi),
+      [".zshrc"],
+      pathApi,
+    );
   }
   if (shell === "bash") {
     // Installation, status, and repairs must inspect the same real Bash profile.
-    const bashrc = path.join(home, ".bashrc");
-    return existsSync(bashrc) ? bashrc : path.join(home, ".bash_profile");
+    const bashrc = pathApi.join(home, ".bashrc");
+    return existsSync(bashrc) ? bashrc : pathApi.join(home, ".bash_profile");
   }
   if (shell === "fish") {
-    return path.join(home, ".config", "fish", "config.fish");
+    // Fish treats every nonempty XDG root literally, including whitespace and relative paths.
+    const configHome = env.XDG_CONFIG_HOME || pathApi.join(home, ".config");
+    return appendCompletionProfilePath(configHome, ["fish", "config.fish"], pathApi);
   }
   if (platform === "win32") {
     const shellPath = normalizeOptionalString(env.SHELL) ?? "";
@@ -189,7 +289,40 @@ export function resolveCompletionProfilePath(
       "Microsoft.PowerShell_profile.ps1",
     );
   }
-  return path.join(home, ".config", "powershell", "Microsoft.PowerShell_profile.ps1");
+  return pathApi.join(home, ".config", "powershell", "Microsoft.PowerShell_profile.ps1");
+}
+
+/** Formats the actual startup profile relative to HOME without misrepresenting external roots. */
+export function resolveCompletionProfileHint(
+  shell: CompletionShell,
+  options: CompletionProfileOptions = {},
+): string {
+  const profilePath = resolveCompletionProfilePath(shell, options);
+  if (shell === "powershell") {
+    return profilePath;
+  }
+
+  const env = options.env ?? process.env;
+  const platform = options.platform ?? process.platform;
+  const pathApi = platform === "win32" ? path.win32 : path.posix;
+  const home = env.HOME || (options.homeDir ?? os.homedir)();
+  if (!pathApi.isAbsolute(profilePath)) {
+    const relativeProfilePath = profilePath.split(pathApi.sep).join("/");
+    // Relative roots can start with tilde, options, or signs; make their filesystem meaning explicit.
+    return relativeProfilePath.startsWith("./") || relativeProfilePath.startsWith("../")
+      ? relativeProfilePath
+      : `./${relativeProfilePath}`;
+  }
+  const normalizedProfilePath = profilePath.split(pathApi.sep).join("/");
+  const normalizedHome = home.split(pathApi.sep).join("/");
+  const homePrefix = normalizedHome.endsWith("/") ? normalizedHome : `${normalizedHome}/`;
+  const comparableProfile =
+    platform === "win32" ? normalizedProfilePath.toLowerCase() : normalizedProfilePath;
+  const comparableHome = platform === "win32" ? homePrefix.toLowerCase() : homePrefix;
+  // Prefix matching keeps symlink-sensitive `..` in the executable startup hint.
+  return comparableProfile.startsWith(comparableHome)
+    ? `~/${normalizedProfilePath.slice(homePrefix.length)}`
+    : normalizedProfilePath;
 }
 
 /** Returns whether a shell profile already contains an OpenClaw completion block or source line. */

--- a/src/commands/doctor-completion.test.ts
+++ b/src/commands/doctor-completion.test.ts
@@ -19,6 +19,8 @@ const originalEnv = captureEnv([
   "HOME",
   "OPENCLAW_STATE_DIR",
   "SHELL",
+  "ZDOTDIR",
+  "XDG_CONFIG_HOME",
   COMPLETION_SKIP_PLUGIN_COMMANDS_ENV,
 ]);
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -40,6 +42,48 @@ function status(overrides: Partial<ShellCompletionStatus> = {}): ShellCompletion
 }
 
 describe("shell completion health mapping", () => {
+  it.each([
+    {
+      shell: "zsh" as const,
+      envName: "ZDOTDIR" as const,
+      profileSegments: [".zshrc"],
+    },
+    {
+      shell: "fish" as const,
+      envName: "XDG_CONFIG_HOME" as const,
+      profileSegments: ["fish", "config.fish"],
+    },
+  ])("recognizes cached $shell completion in its configured startup profile", async (testCase) => {
+    const homeDir = tempDirs.make(`openclaw-${testCase.shell}-doctor-home-`);
+    const stateDir = tempDirs.make(`openclaw-${testCase.shell}-doctor-state-`);
+    const configuredRoot = path.join(homeDir, "configured startup");
+    const profilePath = path.join(configuredRoot, ...testCase.profileSegments);
+    const cachePath = path.join(stateDir, "completions", `openclaw.${testCase.shell}`);
+    setTestEnvValue("HOME", homeDir);
+    setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);
+    setTestEnvValue("SHELL", `/bin/${testCase.shell}`);
+    setTestEnvValue(testCase.envName, configuredRoot);
+
+    await fs.mkdir(path.dirname(profilePath), { recursive: true });
+    await fs.mkdir(path.dirname(cachePath), { recursive: true });
+    await fs.writeFile(cachePath, "# completion cache\n", "utf-8");
+    await fs.writeFile(
+      profilePath,
+      `# OpenClaw Completion\n# cached completion: ${cachePath}\n`,
+      "utf-8",
+    );
+
+    await expect(
+      checkShellCompletionStatus("openclaw", { shell: testCase.shell }),
+    ).resolves.toEqual({
+      shell: testCase.shell,
+      profileInstalled: true,
+      cacheExists: true,
+      cachePath,
+      usesSlowPattern: false,
+    });
+  });
+
   it("recognizes cached Bash completion from the documented login profile", async () => {
     const homeDir = tempDirs.make("openclaw-bash-profile-home-");
     const stateDir = tempDirs.make("openclaw-bash-profile-state-");
@@ -231,6 +275,38 @@ describe("doctorShellCompletion", () => {
     expect(installCompletionMock).toHaveBeenCalledWith("bash", true, "openclaw");
     expect(noteSpy).toHaveBeenCalledWith(
       expect.stringContaining("source ~/.bash_profile"),
+      "Shell completion",
+    );
+  });
+
+  it.each([
+    {
+      shell: "zsh" as const,
+      envName: "ZDOTDIR" as const,
+      profileSegments: [".zshrc"],
+    },
+    {
+      shell: "fish" as const,
+      envName: "XDG_CONFIG_HOME" as const,
+      profileSegments: ["fish", "config.fish"],
+    },
+  ])("shows the configured $shell startup profile after doctor repair", async (testCase) => {
+    const homeDir = tempDirs.make(`openclaw-${testCase.shell}-doctor-reload-home-`);
+    const stateDir = tempDirs.make(`openclaw-${testCase.shell}-doctor-reload-state-`);
+    const configuredRoot = path.join(homeDir, "configured startup");
+    const relativeProfile = path.join("configured startup", ...testCase.profileSegments);
+    setTestEnvValue("HOME", homeDir);
+    setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);
+    setTestEnvValue("SHELL", `/bin/${testCase.shell}`);
+    setTestEnvValue(testCase.envName, configuredRoot);
+    installCompletionMock.mockResolvedValue(undefined);
+    const noteSpy = vi.spyOn(noteModule, "note");
+
+    await doctorShellCompletion({} as never, mockPrompter());
+
+    expect(installCompletionMock).toHaveBeenCalledWith(testCase.shell, true, "openclaw");
+    expect(noteSpy).toHaveBeenCalledWith(
+      expect.stringContaining(`source "$HOME/${relativeProfile}"`),
       "Shell completion",
     );
   });

--- a/src/commands/doctor-completion.ts
+++ b/src/commands/doctor-completion.ts
@@ -10,6 +10,7 @@ import {
   installCompletion,
   isCompletionInstalled,
   resolveCompletionCachePath,
+  resolveCompletionProfileHint,
   resolveCompletionProfilePath,
   resolveShellFromEnv,
   usesSlowDynamicCompletion,
@@ -40,21 +41,11 @@ function findProfileWriteError(err: unknown): NodeJS.ErrnoException | undefined 
   return err instanceof Error ? findProfileWriteError(err.cause) : undefined;
 }
 
-function resolveCompletionReloadPath(shell: CompletionShell): string {
-  if (shell === "powershell") {
-    return resolveCompletionProfilePath("powershell");
-  }
-  if (shell === "bash") {
-    return `~/${path.basename(resolveCompletionProfilePath("bash"))}`;
-  }
-  return `~/.${shell === "zsh" ? "zshrc" : "config/fish/config.fish"}`;
-}
-
 function formatCompletionReloadNote(
   shell: CompletionShell,
   action: "installed" | "upgraded",
 ): string {
-  const profilePath = resolveCompletionReloadPath(shell);
+  const profilePath = resolveCompletionProfileHint(shell);
   return `Shell completion ${action}. Restart your shell or run: ${formatCompletionReloadCommand(shell, profilePath)}`;
 }
 

--- a/src/wizard/setup.completion.test.ts
+++ b/src/wizard/setup.completion.test.ts
@@ -2,6 +2,7 @@
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { resolveCompletionProfilePath } from "../cli/completion-runtime.js";
+import { withEnvAsync } from "../test-utils/env.js";
 import { setupWizardShellCompletion } from "./setup.completion.js";
 
 async function withLocale(locale: string, run: () => Promise<void>): Promise<void> {
@@ -82,6 +83,47 @@ describe("setupWizardShellCompletion", () => {
       );
       expect(prompter.note).toHaveBeenCalledWith(
         "Shell completion 已安装。重启 shell 或运行：source ~/.zshrc",
+        "Shell completion",
+      );
+    });
+  });
+
+  it.each([
+    {
+      shell: "zsh" as const,
+      env: { ZDOTDIR: "/Users/ada/.config/zsh", XDG_CONFIG_HOME: undefined },
+      profileHint: "~/.config/zsh/.zshrc",
+    },
+    {
+      shell: "fish" as const,
+      env: { ZDOTDIR: undefined, XDG_CONFIG_HOME: "/Users/ada/custom-xdg" },
+      profileHint: "~/custom-xdg/fish/config.fish",
+    },
+    {
+      shell: "zsh" as const,
+      env: { ZDOTDIR: "/Users/ada/.config/zsh dotfiles", XDG_CONFIG_HOME: undefined },
+      profileHint: '"$HOME/.config/zsh dotfiles/.zshrc"',
+    },
+    {
+      shell: "fish" as const,
+      env: { ZDOTDIR: undefined, XDG_CONFIG_HOME: "/Users/ada/custom xdg" },
+      profileHint: '"$HOME/custom xdg/fish/config.fish"',
+    },
+    {
+      shell: "zsh" as const,
+      env: { ZDOTDIR: "/tmp/configured zsh", XDG_CONFIG_HOME: undefined },
+      profileHint: '"/tmp/configured zsh/.zshrc"',
+    },
+  ])("shows the real configured $shell startup profile after onboarding", async (testCase) => {
+    await withEnvAsync({ HOME: "/Users/ada", ...testCase.env }, async () => {
+      const prompter = createPrompter();
+      const deps = createDeps(testCase.shell);
+
+      await setupWizardShellCompletion({ flow: "quickstart", prompter, deps });
+
+      expect(deps.installCompletion).toHaveBeenCalledWith(testCase.shell, true, "openclaw");
+      expect(prompter.note).toHaveBeenCalledWith(
+        `Shell completion installed. Restart your shell or run: source ${testCase.profileHint}`,
         "Shell completion",
       );
     });

--- a/src/wizard/setup.completion.ts
+++ b/src/wizard/setup.completion.ts
@@ -1,11 +1,9 @@
 // Setup completion helpers render completion instructions after onboarding.
-import os from "node:os";
-import path from "node:path";
 import { resolveCliName } from "../cli/cli-name.js";
 import {
   formatCompletionReloadCommand,
   installCompletion,
-  resolveCompletionProfilePath,
+  resolveCompletionProfileHint,
 } from "../cli/completion-runtime.js";
 import type {
   CompletionCacheGenerationOptions,
@@ -15,7 +13,6 @@ import {
   checkShellCompletionStatus,
   ensureCompletionCacheExists,
 } from "../commands/doctor-completion.js";
-import { pathExists } from "../utils.js";
 import { t } from "./i18n/index.js";
 import type { WizardPrompter } from "./prompts.js";
 import type { WizardFlow } from "./setup.types.js";
@@ -30,28 +27,14 @@ type CompletionDeps = {
   installCompletion: (shell: string, yes: boolean, binName?: string) => Promise<void>;
 };
 
-async function resolveProfileHint(shell: ShellCompletionStatus["shell"]): Promise<string> {
-  const home = process.env.HOME || os.homedir();
-  if (shell === "zsh") {
-    return "~/.zshrc";
-  }
-  if (shell === "bash") {
-    const bashrc = path.join(home, ".bashrc");
-    return (await pathExists(bashrc)) ? "~/.bashrc" : "~/.bash_profile";
-  }
-  if (shell === "fish") {
-    return "~/.config/fish/config.fish";
-  }
-  return resolveCompletionProfilePath("powershell");
-}
-
 function formatReloadHint(shell: ShellCompletionStatus["shell"], profileHint: string): string {
   if (shell === "powershell") {
     return t("wizard.completion.reloadPowerShell", {
       command: formatCompletionReloadCommand("powershell", profileHint),
     });
   }
-  return t("wizard.completion.reloadShell", { profile: profileHint });
+  const command = formatCompletionReloadCommand(shell, profileHint);
+  return t("wizard.completion.reloadShell", { profile: command.slice("source ".length) });
 }
 
 export async function setupWizardShellCompletion(params: {
@@ -116,7 +99,7 @@ export async function setupWizardShellCompletion(params: {
     // Install to shell profile
     await deps.installCompletion(completionStatus.shell, true, cliName);
 
-    const profileHint = await resolveProfileHint(completionStatus.shell);
+    const profileHint = resolveCompletionProfileHint(completionStatus.shell);
     await params.prompter.note(
       t("wizard.completion.installed", {
         reloadHint: formatReloadHint(completionStatus.shell, profileHint),


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where Zsh users with `ZDOTDIR`, including a shell-local setting in `.zshenv`, or Fish users with `XDG_CONFIG_HOME`, completed OpenClaw setup successfully but never received working shell completion. The CLI silently installed the cache source block into a different profile from the one the actual shell loads; doctor misreported existing completion as missing and both doctor and onboarding provided incorrect or non-executable reload commands.

## Why This Change Was Made

Resolve the actual Zsh and Fish startup profiles in the single canonical completion-runtime owner, using the real shell configuration roots and retaining current defaults. Discover interactive-only, non-exported, and reassigned inherited Zsh startup settings using an interactive `zsh -f -i` probe that sources only `.zshenv`, never the user's side-effect-bearing `.zshrc`, with a one-second forced-kill timeout; use `builtin printf` so real user-defined startup functions cannot corrupt the profile probe, and preserve the actual root-profile meaning of explicitly empty `ZDOTDIR`. Bound both signal-ignoring startup scripts and child processes retaining standard output. Make doctor and onboarding derive their human-readable reload hint from that same canonical owner, emit native Windows filesystem paths with shell-executable forward-slash internal and external hints, and quote both reload commands and cached source paths according to each real shell's history-expansion contract. Existing Bash and PowerShell behavior, command generation, plugin loading, cache format, localization, and CLI flags remain unchanged.

## User Impact

Zsh and Fish automatically activate OpenClaw completion after normal installation, including non-exported Zsh settings, custom configuration roots, and profile or cache paths containing spaces, literal dollar signs, or quotes. `openclaw doctor` recognizes the actual configured profile, doctor and onboarding suggest a safe reload command that executes in the actual shell, and repeated installation remains idempotent. Bash and PowerShell continue to work as before.

## Evidence

- Reviewed, tested, and committed directly on immutable main `4d8e89fd5cc447da04ce5f0615a21cff7c491f51`; the isolated fix is `81cabf8800e6c4f161bcbd1cbe9086126e61d5a3`.
- Confirmed the startup-file contracts directly in the [official Zsh startup-file documentation](https://zsh.sourceforge.io/Doc/Release/Files.html) and [official Fish configuration documentation](https://fishshell.com/docs/current/language.html#configuration-files).
- Inspected the official Fish 3.7 C++ and Fish 4.8 Rust startup-path implementations directly and executed all **414** sibling assertions twice: against the distribution's real Fish 3.7 and the upstream-published static Fish 4.8 release, for **828/828** passing assertions.
- Added regressions before changing production and reproduced **13 genuine failures** against immutable current main: **8** canonical runtime, non-exported Zsh, quoted-reload, and actual-shell-source failures; **3** onboarding wrong-reload failures; and **2** incorrect doctor-repair notes. All existing sibling controls remained green.
- Installed actual distribution Zsh and Fish on the isolated test runner and exercised the real packaged CLI with `OPENCLAW_FORCE_BUILD=1` and `openclaw completion --shell <shell> --write-state --install --yes` across ten real-user scenarios, including a Zsh `.zshenv` that defines a shadowing `printf` function, another that changes directory before assigning a relative `ZDOTDIR`, physically distinct symlink-traversing Zsh and Fish profile roots, and Fish with relative and whitespace-padded `XDG_CONFIG_HOME`.
- Verified real interactive Zsh loads `_openclaw_root_completion` from the `ZDOTDIR` startup profile; real Fish startup produces working `--shell` completion from `XDG_CONFIG_HOME`; and actual Bash still loads `_openclaw_completion` from its documented login profile.
- Ran the real completion diagnostic for every shell, verified exact cache and profile locations, and repeated each packaged installation to prove one stable completion block and byte-identical profiles. Final actual-product remote timing JSON: exit code `0`.
- **87/87** direct runtime, doctor, and onboarding tests pass, including actual Fish relative/space-padded-XDG startup, genuine Fish and Zsh symlink traversal, startup working-directory changes, eight executable literal-tilde, named-tilde, plus-sign, and minus-sign reloads, signal-ignoring and output-retaining Zsh subprocesses exiting in approximately one second, side-effect-free `.zshrc` discovery, shadowed startup functions, apostrophe/history-expansion paths, and native Windows external-root paths; **414/414** tests across **13** shell completion, update, doctor, setup wizard, onboarding, CLI registration, Fish, Bash, and diagnostic sibling files pass with repository-pinned formatting.
- The canonical changed gate classifies both core production and core tests against immutable reviewed main, verifies all six source-file hashes and changed paths, and runs full production and test typechecking, changed-file lint, formatting, dependency/SDK/boundary/database/runtime guards, and repository ratchets.
- Fresh independent high-effort structured review and the official TruffleHog scan both pass with no accepted/actionable findings.
- AI-assisted; official shell contracts, baseline failures, actual packaged shell startup, diagnostic behavior, idempotence, sibling controls, and final scope were independently verified.
- Exact remotely verified final head: `81cabf8800e6c4f161bcbd1cbe9086126e61d5a3`.
- Both Git author and committer: `Peter Steinberger <steipete@gmail.com>`.
