### PR TITLE
fix(update): keep managed gateway updates in the correct profile

### DIFF
--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -65,7 +65,8 @@ const pathExists = vi.fn();
 const syncPluginsForUpdateChannel = vi.fn();
 const updateNpmInstalledPlugins = vi.fn();
 const loadInstalledPluginIndexInstallRecords = vi.fn(
-  async (params: { config?: OpenClawConfig } = {}) => params.config?.plugins?.installs ?? {},
+  async (params: { config?: OpenClawConfig; env?: NodeJS.ProcessEnv } = {}) =>
+    params.config?.plugins?.installs ?? {},
 );
 const readPersistedInstalledPluginIndex = vi.fn(async () => null);
 const restorePersistedInstalledPluginIndex = vi.fn(async () => undefined);
@@ -1603,6 +1604,214 @@ describe("update-cli", () => {
       suppressFutureVersionWarning: true,
     });
     expectNoSideEffects(updateNpmInstalledPlugins, runDaemonInstall, runDaemonRestart);
+  });
+
+  it("keeps stopped owned-service config and plugin state through fresh post-core handoff", async () => {
+    const { root, entrypoints } = setupUpdatedRootRefresh();
+    mockOwnedGitService();
+    mockGitUpdateAfterMutation(
+      makeOkUpdateResult({
+        mode: "git",
+        root,
+        before: { sha: "old-managed-sha", version: "2026.4.26" },
+        after: { sha: "new-managed-sha", version: "2026.4.27" },
+      }),
+    );
+    pathExists.mockImplementation(
+      async (candidate: string) =>
+        candidate === path.join(process.cwd(), "package.json") ||
+        candidate === path.join(root, "package.json") ||
+        entrypoints.includes(candidate),
+    );
+    const managedState = "/tmp/openclaw-update-tests/managed-profile";
+    const managedConfig = {
+      ...baseConfig,
+      update: { channel: "beta" as const },
+    };
+    const managedSnapshot = {
+      ...baseSnapshot,
+      path: path.join(managedState, "openclaw.json"),
+      parsed: managedConfig,
+      sourceConfig: managedConfig,
+      resolved: managedConfig,
+      config: managedConfig,
+      runtimeConfig: managedConfig,
+    };
+    const managedRecords = {
+      telegram: { source: "npm", spec: "@openclaw/telegram@beta" },
+    } satisfies Record<string, PluginInstallRecord>;
+    serviceReadCommand.mockResolvedValue({
+      programArguments: ["node", path.join(process.cwd(), "dist", "index.js"), "gateway", "run"],
+      environment: {
+        OPENCLAW_PROFILE: "work",
+        OPENCLAW_STATE_DIR: managedState,
+        OPENCLAW_CONFIG_PATH: path.join(managedState, "openclaw.json"),
+        OPENCLAW_GATEWAY_PORT: "19222",
+        OPENCLAW_SERVICE_MARKER: "openclaw",
+        OPENCLAW_SERVICE_KIND: "gateway",
+        [GATEWAY_SERVICE_RUNTIME_PID_ENV]: "7777",
+      },
+    });
+    serviceLoaded.mockResolvedValue(true);
+    serviceReadRuntime.mockResolvedValue({ status: "running", pid: 4242, state: "running" });
+    vi.mocked(readConfigFileSnapshot).mockImplementation(async () =>
+      process.env.OPENCLAW_PROFILE === "work" ? managedSnapshot : baseSnapshot,
+    );
+    loadInstalledPluginIndexInstallRecords.mockImplementation(async (options = {}) =>
+      options.env?.OPENCLAW_PROFILE === "work" ? managedRecords : {},
+    );
+    let handedConfig: unknown;
+    let handedRecords: unknown;
+    spawn.mockImplementationOnce((_node, _argv, options) => {
+      const env = (options as { env?: NodeJS.ProcessEnv }).env;
+      handedConfig = JSON.parse(
+        fsSync.readFileSync(env?.OPENCLAW_UPDATE_POST_CORE_SOURCE_CONFIG_PATH ?? "", "utf-8"),
+      );
+      handedRecords = JSON.parse(
+        fsSync.readFileSync(env?.OPENCLAW_UPDATE_POST_CORE_INSTALL_RECORDS_PATH ?? "", "utf-8"),
+      );
+      const child = new EventEmitter() as EventEmitter & { once: EventEmitter["once"] };
+      queueMicrotask(() => child.emit("exit", 0, null));
+      return child;
+    });
+
+    await withEnvAsync(
+      {
+        OPENCLAW_PROFILE: "personal",
+        OPENCLAW_STATE_DIR: "/tmp/openclaw-update-tests/personal-profile",
+        OPENCLAW_CONFIG_PATH: "/tmp/openclaw-update-tests/personal-profile/openclaw.json",
+        OPENCLAW_GATEWAY_PORT: "19111",
+      },
+      async () => {
+        await updateCommand({ yes: true });
+      },
+    );
+
+    expect(serviceStop).toHaveBeenCalledOnce();
+    expect(spawnCall()?.[2]?.env).toMatchObject({
+      OPENCLAW_PROFILE: "work",
+      OPENCLAW_STATE_DIR: managedState,
+      OPENCLAW_CONFIG_PATH: path.join(managedState, "openclaw.json"),
+      OPENCLAW_GATEWAY_PORT: "19222",
+    });
+    expect(spawnCall()?.[2]?.env?.OPENCLAW_SERVICE_MARKER).toBeUndefined();
+    expect(spawnCall()?.[2]?.env?.[GATEWAY_SERVICE_RUNTIME_PID_ENV]).toBeUndefined();
+    expect(handedConfig).toEqual({ sourceConfig: managedConfig, authoredConfig: managedConfig });
+    expect(handedRecords).toEqual(managedRecords);
+  });
+
+  it("keeps foreign-service updates in the caller profile", async () => {
+    const { root, entrypoints } = setupUpdatedRootRefresh();
+    const foreignRoot = await createTrackedTempDir("openclaw-update-foreign-profile-");
+    const foreignEntrypoint = path.join(foreignRoot, "dist", "index.js");
+    await fs.mkdir(path.dirname(foreignEntrypoint), { recursive: true });
+    await fs.writeFile(
+      path.join(foreignRoot, "package.json"),
+      JSON.stringify({ name: "openclaw", version: "2026.4.21" }),
+      "utf-8",
+    );
+    await fs.writeFile(foreignEntrypoint, "export {};\n", "utf-8");
+    mockGitUpdateAfterMutation(
+      makeOkUpdateResult({
+        mode: "git",
+        root,
+        before: { sha: "old-caller-sha", version: "2026.4.26" },
+        after: { sha: "new-caller-sha", version: "2026.4.27" },
+      }),
+    );
+    serviceReadCommand.mockResolvedValue({
+      programArguments: ["node", foreignEntrypoint, "gateway", "run"],
+      environment: {
+        OPENCLAW_PROFILE: "foreign",
+        OPENCLAW_STATE_DIR: "/tmp/openclaw-update-tests/foreign-profile",
+        OPENCLAW_GATEWAY_PORT: "19333",
+      },
+    });
+    serviceLoaded.mockResolvedValue(true);
+    serviceReadRuntime.mockResolvedValue({ status: "running", pid: 4242, state: "running" });
+    pathExists.mockImplementation(
+      async (candidate: string) =>
+        entrypoints.includes(candidate) || candidate.endsWith("package.json"),
+    );
+
+    await withEnvAsync(
+      {
+        OPENCLAW_PROFILE: "personal",
+        OPENCLAW_STATE_DIR: "/tmp/openclaw-update-tests/personal-profile",
+        OPENCLAW_GATEWAY_PORT: "19111",
+      },
+      async () => {
+        await updateCommand({ yes: true });
+      },
+    );
+
+    expect(serviceStop).not.toHaveBeenCalled();
+    expect(spawnCall()?.[2]?.env).toMatchObject({
+      OPENCLAW_PROFILE: "personal",
+      OPENCLAW_STATE_DIR: "/tmp/openclaw-update-tests/personal-profile",
+      OPENCLAW_GATEWAY_PORT: "19111",
+    });
+  });
+
+  it("keeps forced post-core fallback and fresh validation in the stopped service profile", async () => {
+    const { root } = setupUpdatedRootRefresh();
+    mockOwnedGitService();
+    mockGitUpdateAfterMutation(
+      makeOkUpdateResult({
+        mode: "git",
+        root,
+        before: { sha: "old-managed-sha", version: "2026.4.26" },
+        after: { sha: "new-managed-sha", version: "2026.4.27" },
+      }),
+    );
+    const managedState = "/tmp/openclaw-update-tests/fallback-managed";
+    serviceReadCommand.mockResolvedValue({
+      programArguments: ["node", path.join(process.cwd(), "dist", "index.js"), "gateway", "run"],
+      environment: {
+        OPENCLAW_PROFILE: "work",
+        OPENCLAW_STATE_DIR: managedState,
+        OPENCLAW_CONFIG_PATH: path.join(managedState, "openclaw.json"),
+        OPENCLAW_GATEWAY_PORT: "19222",
+      },
+    });
+    serviceLoaded.mockResolvedValue(true);
+    serviceReadRuntime.mockResolvedValue({ status: "running", pid: 4242, state: "running" });
+    vi.mocked(resolveGatewayInstallEntrypoint).mockResolvedValueOnce(undefined);
+    vi.mocked(resolveGatewayInstallEntrypoint).mockResolvedValueOnce(
+      "/tmp/openclaw-updated-entry.mjs",
+    );
+    const convergenceProfiles: Array<string | undefined> = [];
+    syncPluginsForUpdateChannel.mockImplementation(async () => {
+      convergenceProfiles.push(process.env.OPENCLAW_PROFILE);
+      return pluginSyncResult(baseConfig);
+    });
+
+    await withEnvAsync(
+      {
+        OPENCLAW_PROFILE: "personal",
+        OPENCLAW_STATE_DIR: "/tmp/openclaw-update-tests/fallback-personal",
+        OPENCLAW_GATEWAY_PORT: "19111",
+      },
+      async () => {
+        await updateCommand({ yes: true });
+        expect(process.env.OPENCLAW_PROFILE).toBe("personal");
+      },
+    );
+
+    expect(convergenceProfiles).toEqual(["work"]);
+    const freshCalls = vi
+      .mocked(runExec)
+      .mock.calls.filter(([, args]) => ["doctor", "config"].includes(args[1] ?? ""));
+    expect(freshCalls).toHaveLength(2);
+    for (const call of freshCalls) {
+      const options = call[2];
+      const baseEnv = typeof options === "number" ? undefined : options?.baseEnv;
+      expect(baseEnv).toMatchObject({
+        OPENCLAW_PROFILE: "work",
+        OPENCLAW_STATE_DIR: managedState,
+        OPENCLAW_GATEWAY_PORT: "19222",
+      });
+    }
   });
 
   it("routes JSON post-core child output to stderr", async () => {
@@ -4771,6 +4980,7 @@ describe("update-cli", () => {
       runtimeConfig: baseConfig,
     };
     vi.mocked(readConfigFileSnapshot)
+      .mockResolvedValueOnce(baseSnapshot)
       .mockResolvedValueOnce(baseSnapshot)
       .mockResolvedValueOnce(invalidPostUpdateSnapshot);
     mockRunningManagedGateway(["node", serviceEntrypoint, "gateway", "run"]);

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -1857,7 +1857,7 @@ describe("update-cli", () => {
     expect(runDaemonRestart).toHaveBeenCalledOnce();
     const completionCall = vi
       .mocked(spawnSync)
-      .mock.calls.find(([, args]) => args[1] === "completion");
+      .mock.calls.find(([, args]) => args?.[1] === "completion");
     expect(completionCall?.[2]?.env?.OPENCLAW_PROFILE).toBe("personal");
   });
 

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -1814,6 +1814,53 @@ describe("update-cli", () => {
     }
   });
 
+  it("keeps post-restart doctor in the stopped service profile", async () => {
+    mockOwnedGitService();
+    mockGitUpdateAfterMutation();
+    pathExists.mockImplementation(
+      async (candidate: string) =>
+        candidate === path.join(process.cwd(), "package.json") ||
+        candidate === path.join(process.cwd(), "openclaw.mjs"),
+    );
+    const managedState = "/tmp/openclaw-update-tests/restart-doctor-managed";
+    serviceReadCommand.mockResolvedValue({
+      programArguments: ["node", path.join(process.cwd(), "dist", "index.js"), "gateway", "run"],
+      environment: {
+        OPENCLAW_PROFILE: "work",
+        OPENCLAW_STATE_DIR: managedState,
+        OPENCLAW_CONFIG_PATH: path.join(managedState, "openclaw.json"),
+        OPENCLAW_GATEWAY_PORT: "19222",
+      },
+    });
+    serviceLoaded.mockResolvedValue(true);
+    serviceReadRuntime.mockResolvedValue({ status: "running", pid: 4242, state: "running" });
+    prepareRestartScript.mockResolvedValue(null);
+    vi.mocked(runDaemonRestart).mockResolvedValue(true);
+    let doctorProfile: string | undefined;
+    vi.mocked(doctorCommand).mockImplementationOnce(async () => {
+      doctorProfile = process.env.OPENCLAW_PROFILE;
+    });
+
+    await withEnvAsync(
+      {
+        OPENCLAW_PROFILE: "personal",
+        OPENCLAW_STATE_DIR: "/tmp/openclaw-update-tests/restart-doctor-personal",
+        OPENCLAW_GATEWAY_PORT: "19111",
+      },
+      async () => {
+        await updateCommand({});
+        expect(process.env.OPENCLAW_PROFILE).toBe("personal");
+      },
+    );
+
+    expect(doctorProfile).toBe("work");
+    expect(runDaemonRestart).toHaveBeenCalledOnce();
+    const completionCall = vi
+      .mocked(spawnSync)
+      .mock.calls.find(([, args]) => args[1] === "completion");
+    expect(completionCall?.[2]?.env?.OPENCLAW_PROFILE).toBe("personal");
+  });
+
   it("routes JSON post-core child output to stderr", async () => {
     const { entrypoints } = setupUpdatedRootRefresh();
     const stdoutPipe = vi.fn();

--- a/src/cli/update-cli/update-command-execution.ts
+++ b/src/cli/update-cli/update-command-execution.ts
@@ -13,6 +13,10 @@ import {
   hasSchemaRefusal,
   runGitUpdate,
 } from "./update-command-git.js";
+import {
+  captureOwnedManagedUpdateContext,
+  type OwnedManagedUpdateContext,
+} from "./update-command-managed-context.js";
 import { runPackageInstallUpdate } from "./update-command-package.js";
 import {
   createAggregateErrorWithCause,
@@ -31,6 +35,7 @@ const CLI_NAME = resolveCliName();
 type MutableUpdateExecutionResult = {
   result: UpdateRunResult;
   preManagedServiceStop: PreManagedServiceStop | undefined;
+  ownedManagedUpdateContext: OwnedManagedUpdateContext | undefined;
 };
 
 export async function executeMutableUpdate(params: {
@@ -60,6 +65,7 @@ export async function executeMutableUpdate(params: {
   recoveryState: UpdateCommandRecoveryState;
 }): Promise<MutableUpdateExecutionResult | null> {
   let preManagedServiceStop: PreManagedServiceStop | undefined;
+  let ownedManagedUpdateContext: OwnedManagedUpdateContext | undefined;
   let schemaRefusalAfterStop = false;
   const gitMutationRoots =
     params.updateInstallKind === "git"
@@ -103,6 +109,23 @@ export async function executeMutableUpdate(params: {
       }
       params.stop();
       defaultRuntime.error(`Failed to stop managed gateway service before update: ${String(err)}`);
+      defaultRuntime.exit(1);
+      throw new UpdateCommandAbort();
+    }
+
+    try {
+      ownedManagedUpdateContext = await captureOwnedManagedUpdateContext({
+        stopState: preManagedServiceStop,
+        processEnv: process.env,
+        invocationCwd: params.invocationCwd,
+      });
+    } catch (err) {
+      params.stop();
+      defaultRuntime.error(`Failed to capture managed gateway update state: ${String(err)}`);
+      await maybeRestartServiceAfterFailedMutableUpdate({
+        preManagedServiceStop,
+        jsonMode: Boolean(params.opts.json),
+      });
       defaultRuntime.exit(1);
       throw new UpdateCommandAbort();
     }
@@ -251,5 +274,5 @@ export async function executeMutableUpdate(params: {
     throw err;
   }
 
-  return { result, preManagedServiceStop };
+  return { result, preManagedServiceStop, ownedManagedUpdateContext };
 }

--- a/src/cli/update-cli/update-command-managed-context.ts
+++ b/src/cli/update-cli/update-command-managed-context.ts
@@ -1,0 +1,75 @@
+import { readConfigFileSnapshot } from "../../config/config.js";
+import type { ConfigFileSnapshot } from "../../config/types.openclaw.js";
+import type { PluginInstallRecord } from "../../config/types.plugins.js";
+import {
+  loadInstalledPluginIndexInstallRecords,
+  type InstalledPluginIndexRecordStoreOptions,
+} from "../../plugins/installed-plugin-index-records.js";
+import { resolveOwnedManagedUpdateEnv } from "./update-command-service-env.js";
+import {
+  stripGatewayServiceMarkerEnv,
+  type PreManagedServiceStop,
+} from "./update-command-service.js";
+
+export type OwnedManagedUpdateContext = {
+  env: NodeJS.ProcessEnv;
+  configSnapshot: ConfigFileSnapshot;
+  pluginInstallRecords: Record<string, PluginInstallRecord>;
+};
+
+/** Run one update phase under the stopped managed Gateway's authoritative environment. */
+export async function withOwnedManagedUpdateEnv<T>(
+  env: NodeJS.ProcessEnv | undefined,
+  run: () => Promise<T>,
+): Promise<T> {
+  if (!env) {
+    return await run();
+  }
+  // Update finalization is a single serialized CLI phase. Some plugin/config owners still read
+  // process.env, so switch the complete phase atomically and restore the caller before restart.
+  const previousEnv = { ...process.env };
+  for (const key of Object.keys(process.env)) {
+    delete process.env[key];
+  }
+  Object.assign(process.env, env);
+  try {
+    return await run();
+  } finally {
+    for (const key of Object.keys(process.env)) {
+      delete process.env[key];
+    }
+    Object.assign(process.env, previousEnv);
+  }
+}
+
+export async function captureOwnedManagedUpdateContext(params: {
+  stopState: PreManagedServiceStop | undefined;
+  processEnv?: NodeJS.ProcessEnv;
+  invocationCwd?: string;
+}): Promise<OwnedManagedUpdateContext | undefined> {
+  const stopState = params.stopState;
+  if (
+    stopState?.stopped !== true ||
+    stopState.serviceMatchesMutationRoot !== true ||
+    !stopState.serviceEnv
+  ) {
+    return undefined;
+  }
+  const env = stripGatewayServiceMarkerEnv(
+    resolveOwnedManagedUpdateEnv({
+      processEnv: params.processEnv,
+      serviceEnv: stopState.serviceEnv,
+      serviceDefinitionEnv: stopState.serviceDefinitionEnv,
+      invocationCwd: params.invocationCwd,
+    }),
+  );
+  // Every later schema, doctor, recovery, and restart step consumes serviceEnv. Promote the
+  // normalized owned environment before I/O so even capture failure recovery targets its owner.
+  stopState.serviceEnv = env;
+  return await withOwnedManagedUpdateEnv(env, async () => {
+    const configSnapshot = await readConfigFileSnapshot({ skipPluginValidation: true });
+    const pluginStoreOptions: InstalledPluginIndexRecordStoreOptions = { env };
+    const pluginInstallRecords = await loadInstalledPluginIndexInstallRecords(pluginStoreOptions);
+    return { env, configSnapshot, pluginInstallRecords };
+  });
+}

--- a/src/cli/update-cli/update-command-managed-context.ts
+++ b/src/cli/update-cli/update-command-managed-context.ts
@@ -1,10 +1,7 @@
 import { readConfigFileSnapshot } from "../../config/config.js";
 import type { ConfigFileSnapshot } from "../../config/types.openclaw.js";
 import type { PluginInstallRecord } from "../../config/types.plugins.js";
-import {
-  loadInstalledPluginIndexInstallRecords,
-  type InstalledPluginIndexRecordStoreOptions,
-} from "../../plugins/installed-plugin-index-records.js";
+import { loadInstalledPluginIndexInstallRecords } from "../../plugins/installed-plugin-index-records.js";
 import { resolveOwnedManagedUpdateEnv } from "./update-command-service-env.js";
 import {
   stripGatewayServiceMarkerEnv,
@@ -26,7 +23,7 @@ export async function withOwnedManagedUpdateEnv<T>(
     return await run();
   }
   // Update finalization is a single serialized CLI phase. Some plugin/config owners still read
-  // process.env, so switch the complete phase atomically and restore the caller before restart.
+  // process.env, so switch the complete phase atomically and restore the caller afterward.
   const previousEnv = { ...process.env };
   for (const key of Object.keys(process.env)) {
     delete process.env[key];
@@ -68,8 +65,7 @@ export async function captureOwnedManagedUpdateContext(params: {
   stopState.serviceEnv = env;
   return await withOwnedManagedUpdateEnv(env, async () => {
     const configSnapshot = await readConfigFileSnapshot({ skipPluginValidation: true });
-    const pluginStoreOptions: InstalledPluginIndexRecordStoreOptions = { env };
-    const pluginInstallRecords = await loadInstalledPluginIndexInstallRecords(pluginStoreOptions);
+    const pluginInstallRecords = await loadInstalledPluginIndexInstallRecords({ env });
     return { env, configSnapshot, pluginInstallRecords };
   });
 }

--- a/src/cli/update-cli/update-command-package.ts
+++ b/src/cli/update-cli/update-command-package.ts
@@ -42,7 +42,7 @@ import {
   runUpdateStep,
 } from "./shared.js";
 import { createUpdateConfigSnapshot } from "./update-command-config.js";
-import { resolvePostInstallDoctorEnv } from "./update-command-service.js";
+import { resolvePostInstallDoctorEnv } from "./update-command-service-env.js";
 
 const CLI_NAME = resolveCliName();
 

--- a/src/cli/update-cli/update-command-post-update.ts
+++ b/src/cli/update-cli/update-command-post-update.ts
@@ -28,7 +28,14 @@ import {
   restoreDroppedPreUpdateChannels,
 } from "./update-command-config.js";
 import { completePostCorePluginUpdate } from "./update-command-fresh-doctor.js";
-import { updatePluginsAfterCoreUpdate } from "./update-command-plugins.js";
+import {
+  withOwnedManagedUpdateEnv,
+  type OwnedManagedUpdateContext,
+} from "./update-command-managed-context.js";
+import {
+  updatePluginsAfterCoreUpdate,
+  type PostCorePluginUpdateResult,
+} from "./update-command-plugins.js";
 import {
   continuePostCoreUpdateInFreshProcess,
   didCoreUpdateChangeInstall,
@@ -95,6 +102,7 @@ export async function finishUpdate(params: {
   opts: UpdateCommandOptions;
   showProgress: boolean;
   preManagedServiceStop?: PreManagedServiceStop;
+  ownedManagedUpdateContext?: OwnedManagedUpdateContext;
   controlPlaneUpdateSentinelMeta: Awaited<ReturnType<typeof readControlPlaneUpdateSentinelMeta>>;
   preUpdatePluginInstallRecords: Awaited<ReturnType<typeof loadInstalledPluginIndexInstallRecords>>;
   startedAt: number;
@@ -200,110 +208,126 @@ export async function finishUpdate(params: {
 
   const postUpdateRoot = params.result.root ?? params.root;
 
-  let postCorePluginUpdate;
+  const preUpdateConfigSnapshot =
+    params.ownedManagedUpdateContext?.configSnapshot ?? params.configSnapshot;
+  const preUpdatePluginInstallRecords =
+    params.ownedManagedUpdateContext?.pluginInstallRecords ?? params.preUpdatePluginInstallRecords;
+  let postCorePluginUpdate: PostCorePluginUpdateResult | undefined;
   let pluginsUpdatedInFreshProcess = false;
-  if (shouldResumePostCoreInFreshProcess) {
-    const freshProcessResult = await continuePostCoreUpdateInFreshProcess({
-      root: postUpdateRoot,
-      channel: params.channel,
-      requestedChannel: params.requestedChannel,
-      opts: params.opts,
-      pluginInstallRecords: params.preUpdatePluginInstallRecords,
-      updateStartedAtMs: params.startedAt,
-      nodeRunner: params.packageUpdateNodeRunner,
-      preUpdateConfig: params.configSnapshot.valid
-        ? {
-            sourceConfig: params.configSnapshot.sourceConfig,
-            authoredConfig: isRecord(params.configSnapshot.parsed)
-              ? (params.configSnapshot.parsed as OpenClawConfig)
-              : params.configSnapshot.sourceConfig,
-          }
-        : undefined,
-    });
-    if (freshProcessResult.exitCode !== undefined) {
-      if (!(await restoreWindowsTaskAutoStartOrExit(params.preManagedServiceStop))) {
-        return;
-      }
-      defaultRuntime.exit(freshProcessResult.exitCode);
-      throw new Error(`post-update process exited with code ${freshProcessResult.exitCode}`);
-    }
-    pluginsUpdatedInFreshProcess = freshProcessResult.resumed;
-    postCorePluginUpdate = freshProcessResult.pluginUpdate;
-  }
-
-  if (!pluginsUpdatedInFreshProcess) {
-    await withPluginLifecycleLease({}, async () => {
-      postUpdateConfigSnapshot = await readConfigFileSnapshot({
-        skipPluginValidation: true,
-        suppressFutureVersionWarning: shouldResumePostCoreInFreshProcess,
-      });
-      postUpdateConfigSnapshot = await persistRequestedUpdateChannel({
-        configSnapshot: postUpdateConfigSnapshot,
+  let abortFinishUpdate = false;
+  await withOwnedManagedUpdateEnv(params.ownedManagedUpdateContext?.env, async () => {
+    if (shouldResumePostCoreInFreshProcess) {
+      const freshProcessResult = await continuePostCoreUpdateInFreshProcess({
+        root: postUpdateRoot,
+        channel: params.channel,
         requestedChannel: params.requestedChannel,
-      });
-      const restoredConfig = restoreDroppedPreUpdateChannels(
-        postUpdateConfigSnapshot,
-        params.configSnapshot.valid
+        opts: params.opts,
+        pluginInstallRecords: preUpdatePluginInstallRecords,
+        updateStartedAtMs: params.startedAt,
+        nodeRunner: params.packageUpdateNodeRunner,
+        preUpdateConfig: preUpdateConfigSnapshot.valid
           ? {
-              sourceConfig: params.configSnapshot.sourceConfig,
-              authoredConfig: isRecord(params.configSnapshot.parsed)
-                ? (params.configSnapshot.parsed as OpenClawConfig)
-                : params.configSnapshot.sourceConfig,
+              sourceConfig: preUpdateConfigSnapshot.sourceConfig,
+              authoredConfig: isRecord(preUpdateConfigSnapshot.parsed)
+                ? (preUpdateConfigSnapshot.parsed as OpenClawConfig)
+                : preUpdateConfigSnapshot.sourceConfig,
             }
           : undefined,
-      );
-      postUpdateConfigSnapshot = restoredConfig.snapshot;
-      // Current-process post-core convergence still reports the pre-update
-      // VERSION. During downgrades, pin compatibility checks to the installed
-      // target so incompatible newer plugins are disabled before restart.
-      const postUpdateInstalledVersion = await readPackageVersion(postUpdateRoot);
-      const versionComparison =
-        postUpdateInstalledVersion && VERSION
-          ? compareSemverStrings(VERSION, postUpdateInstalledVersion)
-          : null;
-      const compatibilityDowngradeTarget =
-        versionComparison != null && versionComparison > 0 ? postUpdateInstalledVersion : null;
-      const previousCompatibilityHostVersion = process.env.OPENCLAW_COMPATIBILITY_HOST_VERSION;
-      if (compatibilityDowngradeTarget) {
-        process.env.OPENCLAW_COMPATIBILITY_HOST_VERSION = compatibilityDowngradeTarget;
-      }
-      try {
-        const initialPluginUpdate = await updatePluginsAfterCoreUpdate({
-          root: postUpdateRoot,
-          channel: params.channel,
-          configSnapshot: postUpdateConfigSnapshot,
-          configChanged: restoredConfig.changed,
-          restoredAuthoredChannels: restoredConfig.authoredChannels,
-          opts: params.opts,
-          timeoutMs: params.updateStepTimeoutMs,
-          pluginInstallRecords: params.preUpdatePluginInstallRecords,
-        });
-        const completedPluginUpdate = await completePostCorePluginUpdate({
-          root: postUpdateRoot,
-          pluginUpdate: initialPluginUpdate,
-          // A plugin-only update can replace its migration owner without replacing core.
-          // Downgrades and resume fallbacks can also leave an updated core on disk in this process.
-          freshDoctorRequired:
-            didCoreUpdateChangeInstall(params.result) ||
-            initialPluginUpdate.sync.changed ||
-            initialPluginUpdate.npm.changed,
-          yes: params.opts.yes === true,
-          json: params.opts.json === true,
-          timeoutMs: params.updateStepTimeoutMs,
-          ...(params.packageUpdateNodeRunner ? { nodeRunner: params.packageUpdateNodeRunner } : {}),
-        });
-        postCorePluginUpdate = completedPluginUpdate.pluginUpdate;
-        postUpdateConfigSnapshot = completedPluginUpdate.configSnapshot;
-      } finally {
-        if (compatibilityDowngradeTarget) {
-          if (previousCompatibilityHostVersion === undefined) {
-            delete process.env.OPENCLAW_COMPATIBILITY_HOST_VERSION;
-          } else {
-            process.env.OPENCLAW_COMPATIBILITY_HOST_VERSION = previousCompatibilityHostVersion;
-          }
+      });
+      if (freshProcessResult.exitCode !== undefined) {
+        if (!(await restoreWindowsTaskAutoStartOrExit(params.preManagedServiceStop))) {
+          abortFinishUpdate = true;
+          return;
         }
+        defaultRuntime.exit(freshProcessResult.exitCode);
+        throw new Error(`post-update process exited with code ${freshProcessResult.exitCode}`);
       }
-    });
+      pluginsUpdatedInFreshProcess = freshProcessResult.resumed;
+      postCorePluginUpdate = freshProcessResult.pluginUpdate;
+    }
+
+    if (!pluginsUpdatedInFreshProcess) {
+      await withPluginLifecycleLease(
+        params.ownedManagedUpdateContext?.env ? { env: params.ownedManagedUpdateContext.env } : {},
+        async () => {
+          postUpdateConfigSnapshot = await readConfigFileSnapshot({
+            skipPluginValidation: true,
+            suppressFutureVersionWarning: shouldResumePostCoreInFreshProcess,
+          });
+          postUpdateConfigSnapshot = await persistRequestedUpdateChannel({
+            configSnapshot: postUpdateConfigSnapshot,
+            requestedChannel: params.requestedChannel,
+          });
+          const restoredConfig = restoreDroppedPreUpdateChannels(
+            postUpdateConfigSnapshot,
+            preUpdateConfigSnapshot.valid
+              ? {
+                  sourceConfig: preUpdateConfigSnapshot.sourceConfig,
+                  authoredConfig: isRecord(preUpdateConfigSnapshot.parsed)
+                    ? (preUpdateConfigSnapshot.parsed as OpenClawConfig)
+                    : preUpdateConfigSnapshot.sourceConfig,
+                }
+              : undefined,
+          );
+          postUpdateConfigSnapshot = restoredConfig.snapshot;
+          // Current-process post-core convergence still reports the pre-update
+          // VERSION. During downgrades, pin compatibility checks to the installed
+          // target so incompatible newer plugins are disabled before restart.
+          const postUpdateInstalledVersion = await readPackageVersion(postUpdateRoot);
+          const versionComparison =
+            postUpdateInstalledVersion && VERSION
+              ? compareSemverStrings(VERSION, postUpdateInstalledVersion)
+              : null;
+          const compatibilityDowngradeTarget =
+            versionComparison != null && versionComparison > 0 ? postUpdateInstalledVersion : null;
+          const previousCompatibilityHostVersion = process.env.OPENCLAW_COMPATIBILITY_HOST_VERSION;
+          if (compatibilityDowngradeTarget) {
+            process.env.OPENCLAW_COMPATIBILITY_HOST_VERSION = compatibilityDowngradeTarget;
+          }
+          try {
+            const initialPluginUpdate = await updatePluginsAfterCoreUpdate({
+              root: postUpdateRoot,
+              channel: params.channel,
+              configSnapshot: postUpdateConfigSnapshot,
+              configChanged: restoredConfig.changed,
+              restoredAuthoredChannels: restoredConfig.authoredChannels,
+              opts: params.opts,
+              timeoutMs: params.updateStepTimeoutMs,
+              pluginInstallRecords: preUpdatePluginInstallRecords,
+            });
+            const completedPluginUpdate = await completePostCorePluginUpdate({
+              root: postUpdateRoot,
+              pluginUpdate: initialPluginUpdate,
+              // A plugin-only update can replace its migration owner without replacing core.
+              // Downgrades and resume fallbacks can also leave an updated core on disk in this process.
+              freshDoctorRequired:
+                didCoreUpdateChangeInstall(params.result) ||
+                initialPluginUpdate.sync.changed ||
+                initialPluginUpdate.npm.changed,
+              yes: params.opts.yes === true,
+              json: params.opts.json === true,
+              timeoutMs: params.updateStepTimeoutMs,
+              ...(params.packageUpdateNodeRunner
+                ? { nodeRunner: params.packageUpdateNodeRunner }
+                : {}),
+            });
+            postCorePluginUpdate = completedPluginUpdate.pluginUpdate;
+            postUpdateConfigSnapshot = completedPluginUpdate.configSnapshot;
+          } finally {
+            if (compatibilityDowngradeTarget) {
+              if (previousCompatibilityHostVersion === undefined) {
+                delete process.env.OPENCLAW_COMPATIBILITY_HOST_VERSION;
+              } else {
+                process.env.OPENCLAW_COMPATIBILITY_HOST_VERSION = previousCompatibilityHostVersion;
+              }
+            }
+          }
+        },
+      );
+    }
+  });
+  if (abortFinishUpdate) {
+    return;
   }
 
   const resultWithPostUpdate: UpdateRunResult = postCorePluginUpdate
@@ -346,10 +370,12 @@ export async function finishUpdate(params: {
 
   const restartConfigSnapshot =
     postUpdateConfigSnapshot ??
-    (await readConfigFileSnapshot({
-      skipPluginValidation: true,
-      suppressFutureVersionWarning: shouldResumePostCoreInFreshProcess,
-    }));
+    (await withOwnedManagedUpdateEnv(params.ownedManagedUpdateContext?.env, async () =>
+      readConfigFileSnapshot({
+        skipPluginValidation: true,
+        suppressFutureVersionWarning: shouldResumePostCoreInFreshProcess,
+      }),
+    ));
   let restartScriptPath: string | null = null;
   let refreshGatewayServiceEnv = false;
   let gatewayServiceEnv: NodeJS.ProcessEnv | undefined;
@@ -372,6 +398,7 @@ export async function finishUpdate(params: {
   let gatewayPort = resolveUpdatedGatewayRestartPort({
     config: restartConfigSnapshot.valid ? restartConfigSnapshot.config : undefined,
     processEnv: process.env,
+    serviceEnv: params.ownedManagedUpdateContext?.env,
   });
   if (params.shouldRestart && serviceMutationAllowed) {
     try {

--- a/src/cli/update-cli/update-command-post-update.ts
+++ b/src/cli/update-cli/update-command-post-update.ts
@@ -28,14 +28,8 @@ import {
   restoreDroppedPreUpdateChannels,
 } from "./update-command-config.js";
 import { completePostCorePluginUpdate } from "./update-command-fresh-doctor.js";
-import {
-  withOwnedManagedUpdateEnv,
-  type OwnedManagedUpdateContext,
-} from "./update-command-managed-context.js";
-import {
-  updatePluginsAfterCoreUpdate,
-  type PostCorePluginUpdateResult,
-} from "./update-command-plugins.js";
+import { withOwnedManagedUpdateEnv } from "./update-command-managed-context.js";
+import { updatePluginsAfterCoreUpdate } from "./update-command-plugins.js";
 import {
   continuePostCoreUpdateInFreshProcess,
   didCoreUpdateChangeInstall,
@@ -102,7 +96,7 @@ export async function finishUpdate(params: {
   opts: UpdateCommandOptions;
   showProgress: boolean;
   preManagedServiceStop?: PreManagedServiceStop;
-  ownedManagedUpdateContext?: OwnedManagedUpdateContext;
+  ownedManagedUpdateEnv?: NodeJS.ProcessEnv;
   controlPlaneUpdateSentinelMeta: Awaited<ReturnType<typeof readControlPlaneUpdateSentinelMeta>>;
   preUpdatePluginInstallRecords: Awaited<ReturnType<typeof loadInstalledPluginIndexInstallRecords>>;
   startedAt: number;
@@ -208,126 +202,118 @@ export async function finishUpdate(params: {
 
   const postUpdateRoot = params.result.root ?? params.root;
 
-  const preUpdateConfigSnapshot =
-    params.ownedManagedUpdateContext?.configSnapshot ?? params.configSnapshot;
-  const preUpdatePluginInstallRecords =
-    params.ownedManagedUpdateContext?.pluginInstallRecords ?? params.preUpdatePluginInstallRecords;
-  let postCorePluginUpdate: PostCorePluginUpdateResult | undefined;
+  let postCorePluginUpdate;
   let pluginsUpdatedInFreshProcess = false;
-  let abortFinishUpdate = false;
-  await withOwnedManagedUpdateEnv(params.ownedManagedUpdateContext?.env, async () => {
-    if (shouldResumePostCoreInFreshProcess) {
-      const freshProcessResult = await continuePostCoreUpdateInFreshProcess({
-        root: postUpdateRoot,
-        channel: params.channel,
-        requestedChannel: params.requestedChannel,
-        opts: params.opts,
-        pluginInstallRecords: preUpdatePluginInstallRecords,
-        updateStartedAtMs: params.startedAt,
-        nodeRunner: params.packageUpdateNodeRunner,
-        preUpdateConfig: preUpdateConfigSnapshot.valid
-          ? {
-              sourceConfig: preUpdateConfigSnapshot.sourceConfig,
-              authoredConfig: isRecord(preUpdateConfigSnapshot.parsed)
-                ? (preUpdateConfigSnapshot.parsed as OpenClawConfig)
-                : preUpdateConfigSnapshot.sourceConfig,
-            }
-          : undefined,
-      });
-      if (freshProcessResult.exitCode !== undefined) {
-        if (!(await restoreWindowsTaskAutoStartOrExit(params.preManagedServiceStop))) {
-          abortFinishUpdate = true;
-          return;
-        }
-        defaultRuntime.exit(freshProcessResult.exitCode);
-        throw new Error(`post-update process exited with code ${freshProcessResult.exitCode}`);
-      }
-      pluginsUpdatedInFreshProcess = freshProcessResult.resumed;
-      postCorePluginUpdate = freshProcessResult.pluginUpdate;
-    }
-
-    if (!pluginsUpdatedInFreshProcess) {
-      await withPluginLifecycleLease(
-        params.ownedManagedUpdateContext?.env ? { env: params.ownedManagedUpdateContext.env } : {},
-        async () => {
-          postUpdateConfigSnapshot = await readConfigFileSnapshot({
-            skipPluginValidation: true,
-            suppressFutureVersionWarning: shouldResumePostCoreInFreshProcess,
-          });
-          postUpdateConfigSnapshot = await persistRequestedUpdateChannel({
-            configSnapshot: postUpdateConfigSnapshot,
-            requestedChannel: params.requestedChannel,
-          });
-          const restoredConfig = restoreDroppedPreUpdateChannels(
-            postUpdateConfigSnapshot,
-            preUpdateConfigSnapshot.valid
-              ? {
-                  sourceConfig: preUpdateConfigSnapshot.sourceConfig,
-                  authoredConfig: isRecord(preUpdateConfigSnapshot.parsed)
-                    ? (preUpdateConfigSnapshot.parsed as OpenClawConfig)
-                    : preUpdateConfigSnapshot.sourceConfig,
-                }
-              : undefined,
-          );
-          postUpdateConfigSnapshot = restoredConfig.snapshot;
-          // Current-process post-core convergence still reports the pre-update
-          // VERSION. During downgrades, pin compatibility checks to the installed
-          // target so incompatible newer plugins are disabled before restart.
-          const postUpdateInstalledVersion = await readPackageVersion(postUpdateRoot);
-          const versionComparison =
-            postUpdateInstalledVersion && VERSION
-              ? compareSemverStrings(VERSION, postUpdateInstalledVersion)
-              : null;
-          const compatibilityDowngradeTarget =
-            versionComparison != null && versionComparison > 0 ? postUpdateInstalledVersion : null;
-          const previousCompatibilityHostVersion = process.env.OPENCLAW_COMPATIBILITY_HOST_VERSION;
-          if (compatibilityDowngradeTarget) {
-            process.env.OPENCLAW_COMPATIBILITY_HOST_VERSION = compatibilityDowngradeTarget;
-          }
-          try {
-            const initialPluginUpdate = await updatePluginsAfterCoreUpdate({
-              root: postUpdateRoot,
-              channel: params.channel,
-              configSnapshot: postUpdateConfigSnapshot,
-              configChanged: restoredConfig.changed,
-              restoredAuthoredChannels: restoredConfig.authoredChannels,
-              opts: params.opts,
-              timeoutMs: params.updateStepTimeoutMs,
-              pluginInstallRecords: preUpdatePluginInstallRecords,
-            });
-            const completedPluginUpdate = await completePostCorePluginUpdate({
-              root: postUpdateRoot,
-              pluginUpdate: initialPluginUpdate,
-              // A plugin-only update can replace its migration owner without replacing core.
-              // Downgrades and resume fallbacks can also leave an updated core on disk in this process.
-              freshDoctorRequired:
-                didCoreUpdateChangeInstall(params.result) ||
-                initialPluginUpdate.sync.changed ||
-                initialPluginUpdate.npm.changed,
-              yes: params.opts.yes === true,
-              json: params.opts.json === true,
-              timeoutMs: params.updateStepTimeoutMs,
-              ...(params.packageUpdateNodeRunner
-                ? { nodeRunner: params.packageUpdateNodeRunner }
-                : {}),
-            });
-            postCorePluginUpdate = completedPluginUpdate.pluginUpdate;
-            postUpdateConfigSnapshot = completedPluginUpdate.configSnapshot;
-          } finally {
-            if (compatibilityDowngradeTarget) {
-              if (previousCompatibilityHostVersion === undefined) {
-                delete process.env.OPENCLAW_COMPATIBILITY_HOST_VERSION;
-              } else {
-                process.env.OPENCLAW_COMPATIBILITY_HOST_VERSION = previousCompatibilityHostVersion;
+  if (shouldResumePostCoreInFreshProcess) {
+    const freshProcessResult = await withOwnedManagedUpdateEnv(
+      params.ownedManagedUpdateEnv,
+      async () =>
+        await continuePostCoreUpdateInFreshProcess({
+          root: postUpdateRoot,
+          channel: params.channel,
+          requestedChannel: params.requestedChannel,
+          opts: params.opts,
+          pluginInstallRecords: params.preUpdatePluginInstallRecords,
+          updateStartedAtMs: params.startedAt,
+          nodeRunner: params.packageUpdateNodeRunner,
+          preUpdateConfig: params.configSnapshot.valid
+            ? {
+                sourceConfig: params.configSnapshot.sourceConfig,
+                authoredConfig: isRecord(params.configSnapshot.parsed)
+                  ? (params.configSnapshot.parsed as OpenClawConfig)
+                  : params.configSnapshot.sourceConfig,
               }
+            : undefined,
+        }),
+    );
+    if (freshProcessResult.exitCode !== undefined) {
+      if (!(await restoreWindowsTaskAutoStartOrExit(params.preManagedServiceStop))) {
+        return;
+      }
+      defaultRuntime.exit(freshProcessResult.exitCode);
+      throw new Error(`post-update process exited with code ${freshProcessResult.exitCode}`);
+    }
+    pluginsUpdatedInFreshProcess = freshProcessResult.resumed;
+    postCorePluginUpdate = freshProcessResult.pluginUpdate;
+  }
+
+  if (!pluginsUpdatedInFreshProcess) {
+    await withOwnedManagedUpdateEnv(params.ownedManagedUpdateEnv, async () => {
+      await withPluginLifecycleLease({}, async () => {
+        postUpdateConfigSnapshot = await readConfigFileSnapshot({
+          skipPluginValidation: true,
+          suppressFutureVersionWarning: shouldResumePostCoreInFreshProcess,
+        });
+        postUpdateConfigSnapshot = await persistRequestedUpdateChannel({
+          configSnapshot: postUpdateConfigSnapshot,
+          requestedChannel: params.requestedChannel,
+        });
+        const restoredConfig = restoreDroppedPreUpdateChannels(
+          postUpdateConfigSnapshot,
+          params.configSnapshot.valid
+            ? {
+                sourceConfig: params.configSnapshot.sourceConfig,
+                authoredConfig: isRecord(params.configSnapshot.parsed)
+                  ? (params.configSnapshot.parsed as OpenClawConfig)
+                  : params.configSnapshot.sourceConfig,
+              }
+            : undefined,
+        );
+        postUpdateConfigSnapshot = restoredConfig.snapshot;
+        // Current-process post-core convergence still reports the pre-update
+        // VERSION. During downgrades, pin compatibility checks to the installed
+        // target so incompatible newer plugins are disabled before restart.
+        const postUpdateInstalledVersion = await readPackageVersion(postUpdateRoot);
+        const versionComparison =
+          postUpdateInstalledVersion && VERSION
+            ? compareSemverStrings(VERSION, postUpdateInstalledVersion)
+            : null;
+        const compatibilityDowngradeTarget =
+          versionComparison != null && versionComparison > 0 ? postUpdateInstalledVersion : null;
+        const previousCompatibilityHostVersion = process.env.OPENCLAW_COMPATIBILITY_HOST_VERSION;
+        if (compatibilityDowngradeTarget) {
+          process.env.OPENCLAW_COMPATIBILITY_HOST_VERSION = compatibilityDowngradeTarget;
+        }
+        try {
+          const initialPluginUpdate = await updatePluginsAfterCoreUpdate({
+            root: postUpdateRoot,
+            channel: params.channel,
+            configSnapshot: postUpdateConfigSnapshot,
+            configChanged: restoredConfig.changed,
+            restoredAuthoredChannels: restoredConfig.authoredChannels,
+            opts: params.opts,
+            timeoutMs: params.updateStepTimeoutMs,
+            pluginInstallRecords: params.preUpdatePluginInstallRecords,
+          });
+          const completedPluginUpdate = await completePostCorePluginUpdate({
+            root: postUpdateRoot,
+            pluginUpdate: initialPluginUpdate,
+            // A plugin-only update can replace its migration owner without replacing core.
+            // Downgrades and resume fallbacks can also leave an updated core on disk in this process.
+            freshDoctorRequired:
+              didCoreUpdateChangeInstall(params.result) ||
+              initialPluginUpdate.sync.changed ||
+              initialPluginUpdate.npm.changed,
+            yes: params.opts.yes === true,
+            json: params.opts.json === true,
+            timeoutMs: params.updateStepTimeoutMs,
+            ...(params.packageUpdateNodeRunner
+              ? { nodeRunner: params.packageUpdateNodeRunner }
+              : {}),
+          });
+          postCorePluginUpdate = completedPluginUpdate.pluginUpdate;
+          postUpdateConfigSnapshot = completedPluginUpdate.configSnapshot;
+        } finally {
+          if (compatibilityDowngradeTarget) {
+            if (previousCompatibilityHostVersion === undefined) {
+              delete process.env.OPENCLAW_COMPATIBILITY_HOST_VERSION;
+            } else {
+              process.env.OPENCLAW_COMPATIBILITY_HOST_VERSION = previousCompatibilityHostVersion;
             }
           }
-        },
-      );
-    }
-  });
-  if (abortFinishUpdate) {
-    return;
+        }
+      });
+    });
   }
 
   const resultWithPostUpdate: UpdateRunResult = postCorePluginUpdate
@@ -370,7 +356,7 @@ export async function finishUpdate(params: {
 
   const restartConfigSnapshot =
     postUpdateConfigSnapshot ??
-    (await withOwnedManagedUpdateEnv(params.ownedManagedUpdateContext?.env, async () =>
+    (await withOwnedManagedUpdateEnv(params.ownedManagedUpdateEnv, async () =>
       readConfigFileSnapshot({
         skipPluginValidation: true,
         suppressFutureVersionWarning: shouldResumePostCoreInFreshProcess,
@@ -398,7 +384,7 @@ export async function finishUpdate(params: {
   let gatewayPort = resolveUpdatedGatewayRestartPort({
     config: restartConfigSnapshot.valid ? restartConfigSnapshot.config : undefined,
     processEnv: process.env,
-    serviceEnv: params.ownedManagedUpdateContext?.env,
+    serviceEnv: params.ownedManagedUpdateEnv,
   });
   if (params.shouldRestart && serviceMutationAllowed) {
     try {
@@ -477,22 +463,24 @@ export async function finishUpdate(params: {
   if (!(await restoreWindowsTaskAutoStartOrExit(params.preManagedServiceStop))) {
     return;
   }
-  const restartOk = await maybeRestartService({
-    shouldRestart: params.shouldRestart && serviceMutationAllowed,
-    result: resultWithPostUpdate,
-    opts: params.opts,
-    refreshServiceEnv: refreshGatewayServiceEnv,
-    serviceEnv: gatewayServiceEnv,
-    gatewayPort,
-    restartScriptPath,
-    invocationCwd: params.invocationCwd,
-    nodeRunner: params.packageUpdateNodeRunner,
-    skipLegacyServiceRestart,
-    requireRunningServiceAfterRestart:
-      resultWithPostUpdate.mode === "git" && params.preManagedServiceStop?.stopped === true,
-    serviceMutationSkipMessage,
-    timeoutMs: params.updateStepTimeoutMs,
-  });
+  const restartOk = await withOwnedManagedUpdateEnv(params.ownedManagedUpdateEnv, async () =>
+    maybeRestartService({
+      shouldRestart: params.shouldRestart && serviceMutationAllowed,
+      result: resultWithPostUpdate,
+      opts: params.opts,
+      refreshServiceEnv: refreshGatewayServiceEnv,
+      serviceEnv: gatewayServiceEnv,
+      gatewayPort,
+      restartScriptPath,
+      invocationCwd: params.invocationCwd,
+      nodeRunner: params.packageUpdateNodeRunner,
+      skipLegacyServiceRestart,
+      requireRunningServiceAfterRestart:
+        resultWithPostUpdate.mode === "git" && params.preManagedServiceStop?.stopped === true,
+      serviceMutationSkipMessage,
+      timeoutMs: params.updateStepTimeoutMs,
+    }),
+  );
   if (!restartOk) {
     await markControlPlaneUpdateRestartSentinelFailureBestEffort({
       meta: params.controlPlaneUpdateSentinelMeta,

--- a/src/cli/update-cli/update-command-service-env.ts
+++ b/src/cli/update-cli/update-command-service-env.ts
@@ -6,6 +6,12 @@ const SERVICE_REFRESH_PATH_ENV_KEYS = [
   "OPENCLAW_CONFIG_PATH",
 ] as const;
 
+const MANAGED_UPDATE_SELECTOR_ENV_KEYS = [
+  ...SERVICE_REFRESH_PATH_ENV_KEYS,
+  "OPENCLAW_PROFILE",
+  "OPENCLAW_GATEWAY_PORT",
+] as const;
+
 function resolveServiceRefreshEnv(
   env: NodeJS.ProcessEnv,
   invocationCwd?: string,
@@ -54,6 +60,22 @@ export function resolveUpdatedInstallCommandEnv(params?: {
     ...processEnv,
     ...serviceEnv,
   });
+}
+
+export function resolveOwnedManagedUpdateEnv(params: {
+  processEnv?: NodeJS.ProcessEnv;
+  serviceEnv: NodeJS.ProcessEnv;
+  serviceDefinitionEnv?: NodeJS.ProcessEnv;
+  invocationCwd?: string;
+}): NodeJS.ProcessEnv {
+  const resolved = resolveUpdatedInstallCommandEnv(params);
+  const definitionEnv = params.serviceDefinitionEnv ?? params.serviceEnv;
+  for (const key of MANAGED_UPDATE_SELECTOR_ENV_KEYS) {
+    if (!definitionEnv[key]?.trim()) {
+      delete resolved[key];
+    }
+  }
+  return resolved;
 }
 
 export function resolveUpdatedServicePathEnv(

--- a/src/cli/update-cli/update-command-service-env.ts
+++ b/src/cli/update-cli/update-command-service-env.ts
@@ -6,11 +6,28 @@ const SERVICE_REFRESH_PATH_ENV_KEYS = [
   "OPENCLAW_CONFIG_PATH",
 ] as const;
 
-const MANAGED_UPDATE_SELECTOR_ENV_KEYS = [
+const MANAGED_SERVICE_SELECTOR_ENV_KEYS = [
   ...SERVICE_REFRESH_PATH_ENV_KEYS,
   "OPENCLAW_PROFILE",
   "OPENCLAW_GATEWAY_PORT",
 ] as const;
+
+function applyManagedServiceSelectorEnv(params: {
+  baseEnv: NodeJS.ProcessEnv;
+  serviceEnv: NodeJS.ProcessEnv;
+  selectorEnv?: NodeJS.ProcessEnv;
+}): NodeJS.ProcessEnv {
+  const resolved = { ...params.baseEnv };
+  const selectorEnv = params.selectorEnv ?? params.serviceEnv;
+  for (const key of MANAGED_SERVICE_SELECTOR_ENV_KEYS) {
+    if (selectorEnv[key]?.trim()) {
+      resolved[key] = params.serviceEnv[key];
+    } else {
+      delete resolved[key];
+    }
+  }
+  return resolved;
+}
 
 function resolveServiceRefreshEnv(
   env: NodeJS.ProcessEnv,
@@ -70,17 +87,22 @@ export function resolveOwnedManagedUpdateEnv(params: {
 }): NodeJS.ProcessEnv {
   const resolved = resolveUpdatedInstallCommandEnv(params);
   const definitionEnv = params.serviceDefinitionEnv ?? params.serviceEnv;
-  for (const key of MANAGED_UPDATE_SELECTOR_ENV_KEYS) {
-    if (!definitionEnv[key]?.trim()) {
-      delete resolved[key];
-    }
-  }
-  return resolved;
+  return applyManagedServiceSelectorEnv({
+    baseEnv: resolved,
+    serviceEnv: resolved,
+    selectorEnv: definitionEnv,
+  });
 }
 
-export function resolveUpdatedServicePathEnv(
-  env: NodeJS.ProcessEnv,
-  invocationCwd?: string,
-): NodeJS.ProcessEnv {
-  return resolveServiceRefreshEnv(env, invocationCwd);
+export function resolvePostInstallDoctorEnv(params?: {
+  baseEnv?: NodeJS.ProcessEnv;
+  serviceEnv?: NodeJS.ProcessEnv;
+  invocationCwd?: string;
+}): NodeJS.ProcessEnv {
+  const resolvedEnv = disableUpdatedPackageCompileCacheEnv(params?.baseEnv ?? process.env);
+  if (!params?.serviceEnv) {
+    return resolvedEnv;
+  }
+  const serviceEnv = resolveServiceRefreshEnv(params.serviceEnv, params.invocationCwd);
+  return applyManagedServiceSelectorEnv({ baseEnv: resolvedEnv, serviceEnv });
 }

--- a/src/cli/update-cli/update-command-service.ts
+++ b/src/cli/update-cli/update-command-service.ts
@@ -79,6 +79,7 @@ const POST_INSTALL_DOCTOR_SERVICE_ENV_KEYS = [
   "OPENCLAW_STATE_DIR",
   "OPENCLAW_CONFIG_PATH",
   "OPENCLAW_PROFILE",
+  "OPENCLAW_GATEWAY_PORT",
 ] as const;
 const JSON_MODE_SERVICE_STDOUT = new Writable({
   write(_chunk, _encoding, callback) {
@@ -119,6 +120,7 @@ export type PreManagedServiceStop = {
   serviceMatchesMutationRoot?: boolean;
   blockMessage?: string;
   serviceEnv?: NodeJS.ProcessEnv;
+  serviceDefinitionEnv?: NodeJS.ProcessEnv;
   windowsTaskAutoStartRecovery?: WindowsTaskAutoStartRecovery;
 };
 
@@ -566,6 +568,7 @@ export async function maybeStopManagedServiceBeforeMutableUpdate(params: {
     running: true,
     ...serviceOwnership,
     serviceEnv: serviceState.env,
+    serviceDefinitionEnv: serviceState.command?.environment,
     ...(windowsTaskAutoStartRecovery ? { windowsTaskAutoStartRecovery } : {}),
   };
 }
@@ -774,6 +777,8 @@ export function resolvePostInstallDoctorEnv(params?: {
     const value = serviceEnv[key]?.trim();
     if (value) {
       resolvedEnv[key] = serviceEnv[key];
+    } else {
+      delete resolvedEnv[key];
     }
   }
   return resolvedEnv;

--- a/src/cli/update-cli/update-command-service.ts
+++ b/src/cli/update-cli/update-command-service.ts
@@ -55,10 +55,7 @@ import {
 import { runRestartScript } from "./restart-helper.js";
 import { resolveNodeRunner, type UpdateCommandOptions } from "./shared.js";
 import { createUpdateConfigSnapshot } from "./update-command-config.js";
-import {
-  disableUpdatedPackageCompileCacheEnv,
-  resolveUpdatedInstallCommandEnv,
-} from "./update-command-service-env.js";
+import { resolveUpdatedInstallCommandEnv } from "./update-command-service-env.js";
 import {
   formatPostUpdateGatewayRecoveryInstructions,
   hasLoadedLaunchdKeepAliveSupervisor,

--- a/src/cli/update-cli/update-command-service.ts
+++ b/src/cli/update-cli/update-command-service.ts
@@ -58,7 +58,6 @@ import { createUpdateConfigSnapshot } from "./update-command-config.js";
 import {
   disableUpdatedPackageCompileCacheEnv,
   resolveUpdatedInstallCommandEnv,
-  resolveUpdatedServicePathEnv,
 } from "./update-command-service-env.js";
 import {
   formatPostUpdateGatewayRecoveryInstructions,
@@ -74,13 +73,6 @@ const CLI_NAME = resolveCliName();
 const SERVICE_REFRESH_TIMEOUT_MS = 60_000;
 const POST_REFRESH_ALREADY_HEALTHY_ATTEMPTS = 10;
 const POST_REFRESH_ALREADY_HEALTHY_DELAY_MS = 500;
-const POST_INSTALL_DOCTOR_SERVICE_ENV_KEYS = [
-  "OPENCLAW_HOME",
-  "OPENCLAW_STATE_DIR",
-  "OPENCLAW_CONFIG_PATH",
-  "OPENCLAW_PROFILE",
-  "OPENCLAW_GATEWAY_PORT",
-] as const;
 const JSON_MODE_SERVICE_STDOUT = new Writable({
   write(_chunk, _encoding, callback) {
     callback();
@@ -757,30 +749,6 @@ export function stripGatewayServiceMarkerEnv(env: NodeJS.ProcessEnv): NodeJS.Pro
   delete resolvedEnv.OPENCLAW_SERVICE_MARKER;
   delete resolvedEnv.OPENCLAW_SERVICE_KIND;
   delete resolvedEnv[GATEWAY_SERVICE_RUNTIME_PID_ENV];
-  return resolvedEnv;
-}
-
-export function resolvePostInstallDoctorEnv(params?: {
-  baseEnv?: NodeJS.ProcessEnv;
-  serviceEnv?: NodeJS.ProcessEnv;
-  invocationCwd?: string;
-}): NodeJS.ProcessEnv {
-  const resolvedEnv: NodeJS.ProcessEnv = {
-    ...disableUpdatedPackageCompileCacheEnv(params?.baseEnv ?? process.env),
-  };
-  if (!params?.serviceEnv) {
-    return resolvedEnv;
-  }
-
-  const serviceEnv = resolveUpdatedServicePathEnv(params.serviceEnv, params.invocationCwd);
-  for (const key of POST_INSTALL_DOCTOR_SERVICE_ENV_KEYS) {
-    const value = serviceEnv[key]?.trim();
-    if (value) {
-      resolvedEnv[key] = serviceEnv[key];
-    } else {
-      delete resolvedEnv[key];
-    }
-  }
   return resolvedEnv;
 }
 

--- a/src/cli/update-cli/update-command.test.ts
+++ b/src/cli/update-cli/update-command.test.ts
@@ -14,7 +14,10 @@ import {
 import { testing as updateCommandPluginsTesting } from "./update-command-plugins.test-support.js";
 import { resolvePostCoreUpdateChildStdio } from "./update-command-post-core.js";
 import { applyPostPluginConfigValidation } from "./update-command-post-plugin-validation.js";
-import { resolveUpdatedInstallCommandEnv } from "./update-command-service-env.js";
+import {
+  resolveOwnedManagedUpdateEnv,
+  resolveUpdatedInstallCommandEnv,
+} from "./update-command-service-env.js";
 import {
   resolvePostInstallDoctorEnv,
   resolvePostUpdateServiceStateReadEnv,
@@ -312,6 +315,32 @@ describe("resolveUpdatedInstallCommandEnv", () => {
     expect(env.OPENCLAW_STATE_DIR).toBe(path.join("/srv/openclaw", "daemon-state"));
     expect(env.PATH).toBe("/daemon/bin");
     expect(env.NODE_DISABLE_COMPILE_CACHE).toBe("1");
+  });
+
+  it("clears caller selectors omitted by the managed service definition", () => {
+    const env = resolveOwnedManagedUpdateEnv({
+      processEnv: {
+        HOME: "/home/operator",
+        OPENCLAW_PROFILE: "personal",
+        OPENCLAW_STATE_DIR: "/home/operator/.openclaw-personal",
+        OPENCLAW_CONFIG_PATH: "/home/operator/.openclaw-personal/openclaw.json",
+        OPENCLAW_GATEWAY_PORT: "19111",
+      },
+      serviceEnv: {
+        HOME: "/home/operator",
+        OPENCLAW_PROFILE: "personal",
+        OPENCLAW_STATE_DIR: "/home/operator/.openclaw-personal",
+        OPENCLAW_CONFIG_PATH: "/home/operator/.openclaw-personal/openclaw.json",
+        OPENCLAW_GATEWAY_PORT: "19111",
+      },
+      serviceDefinitionEnv: {},
+    });
+
+    expect(env.HOME).toBe("/home/operator");
+    expect(env.OPENCLAW_PROFILE).toBeUndefined();
+    expect(env.OPENCLAW_STATE_DIR).toBeUndefined();
+    expect(env.OPENCLAW_CONFIG_PATH).toBeUndefined();
+    expect(env.OPENCLAW_GATEWAY_PORT).toBeUndefined();
   });
 });
 

--- a/src/cli/update-cli/update-command.test.ts
+++ b/src/cli/update-cli/update-command.test.ts
@@ -15,11 +15,11 @@ import { testing as updateCommandPluginsTesting } from "./update-command-plugins
 import { resolvePostCoreUpdateChildStdio } from "./update-command-post-core.js";
 import { applyPostPluginConfigValidation } from "./update-command-post-plugin-validation.js";
 import {
+  resolvePostInstallDoctorEnv,
   resolveOwnedManagedUpdateEnv,
   resolveUpdatedInstallCommandEnv,
 } from "./update-command-service-env.js";
 import {
-  resolvePostInstallDoctorEnv,
   resolvePostUpdateServiceStateReadEnv,
   resolveUpdatedGatewayRestartPort,
   maybeRestartService,

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -583,7 +583,7 @@ async function updateCommandInternal(
   if (!execution) {
     return;
   }
-  const { result, preManagedServiceStop } = execution;
+  const { result, preManagedServiceStop, ownedManagedUpdateContext } = execution;
   stop();
   await finishUpdate({
     result,
@@ -598,6 +598,7 @@ async function updateCommandInternal(
     opts,
     showProgress,
     preManagedServiceStop,
+    ownedManagedUpdateContext,
     controlPlaneUpdateSentinelMeta,
     preUpdatePluginInstallRecords,
     startedAt,

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -584,12 +584,15 @@ async function updateCommandInternal(
     return;
   }
   const { result, preManagedServiceStop, ownedManagedUpdateContext } = execution;
+  const finalizationConfigSnapshot = ownedManagedUpdateContext?.configSnapshot ?? configSnapshot;
+  const finalizationPluginInstallRecords =
+    ownedManagedUpdateContext?.pluginInstallRecords ?? preUpdatePluginInstallRecords;
   stop();
   await finishUpdate({
     result,
     root,
     installKindChanged: switchToGit || switchToPackage,
-    configSnapshot,
+    configSnapshot: finalizationConfigSnapshot,
     requestedChannel,
     storedChannel,
     channel,
@@ -598,9 +601,9 @@ async function updateCommandInternal(
     opts,
     showProgress,
     preManagedServiceStop,
-    ownedManagedUpdateContext,
+    ownedManagedUpdateEnv: ownedManagedUpdateContext?.env,
     controlPlaneUpdateSentinelMeta,
-    preUpdatePluginInstallRecords,
+    preUpdatePluginInstallRecords: finalizationPluginInstallRecords,
     startedAt,
     packageUpdateNodeRunner,
     updateStepTimeoutMs,


### PR DESCRIPTION
## What Problem This Solves

Updating an owned managed Gateway from a shell that uses another OpenClaw profile could finalize the update against the shell's config and plugin state. The fresh child inherited `process.env`, the fallback path read and mutated the caller profile, pre-update plugin records were loaded before service ownership was known, and the post-restart doctor could validate the caller profile.

A personal shell could therefore converge, validate, or repair a stopped work Gateway using personal state, config, and port.

## Why This Change Was Made

The update lifecycle now captures one owner context only after the updater has positively matched and stopped the managed service. That context contains the normalized service environment, the owning profile's pre-update config snapshot, and its plugin install records.

Fresh-process handoff, source-config restoration, lifecycle leasing, fallback plugin convergence, doctor/config validation, schema checks, recovery, restart config, service preparation, restart, and post-restart doctor consume that same owner context. The invoking environment is restored afterward.

The scope is intentionally narrow: shell-completion cache/profile work remains caller-owned, so a managed service's `HOME`, `SHELL`, `ZDOTDIR`, or `XDG_CONFIG_HOME` cannot redirect interactive shell writes. Foreign, ambiguous, unmanaged, and non-stopped services retain caller context. Persisted service-definition selectors are authoritative: an omitted profile, state/config override, or port clears a conflicting caller value instead of inheriting it. Service marker and runtime PID variables are stripped before child or fallback work.

This is an internal lifecycle-context repair. It adds no config key, environment variable, default, command, protocol, storage schema, migration, or public/plugin API.

## User Impact

An update launched from another profile now preserves the stopped managed Gateway's config, plugin state, validation target, and restart port through the complete service finalization flow. Foreign and unmanaged services remain caller-scoped and are not stopped or adopted. Interactive completion refresh continues to use the invoking user's shell profile.

## Evidence

- Current-main bug: `src/cli/update-cli/update-command-post-core.ts` built the post-core child from `process.env`; `src/cli/update-cli/update-command.ts` loaded plugin records before managed-service ownership was known; the post-restart doctor in `src/cli/update-cli/update-command-service.ts` also consumed ambient caller env.
- Original red direction, with owner-context capture disabled: 2 tests failed. The fresh child received personal state/config/port instead of work, and forced fallback convergence observed `personal` instead of `work`.
- Final-doctor red direction, with owner restart scope disabled: the owned restart/doctor regression failed before observing the work profile.
- Final green direction: `node scripts/run-vitest.mjs src/cli/update-cli.test.ts src/cli/update-cli/update-command.test.ts` — 2 files passed, 269 tests passed. The regression proves doctor sees `work`, completion refresh sees `personal`, and the caller env is restored.
- Final current-base changed gate passed on Testbox `tbx_01kzkkvza76djvt51fgm933hgm` (`exitCode=0`), including production/test typechecks, lint, formatting, SDK/plugin boundaries, storage/schema, cycles, webhook, and pairing guards: https://github.com/openclaw/openclaw/actions/runs/31322486390
- Final full-branch Codex autoreview: TruffleHog clean, one complete pass, no accepted/actionable findings, correctness 0.98.
- Production LOC before audit: +257/-104 (net +153). Final production LOC: +273/-146 (net +127), a 26-line net reduction while completing the final doctor owner boundary. Tests: +288/-2.
- Ownership-boundary justification: after stop and positive root ownership, config, plugin, and restart owners still derive canonical roots from ambient `process.env`, so one closed owner context and narrowly scoped env transactions are required.

### ClawSweeper rank-up moves

- Gate managed environment propagation on stopped service ownership: applied, with foreign-service coverage.
- Capture pre-update config and plugin install records under the same managed profile: applied before mutation continues.
- Preserve managed profile in forced fallback convergence: applied and covered.
- Preserve managed profile through fresh doctor, restart preparation, restart, and post-restart doctor: applied and covered.
- Preserve caller-owned shell completion behavior: explicitly kept outside managed scope and covered.
- Resolve compatibility risk without adding config/default/API surfaces: applied through the existing internal service environment and config/plugin owners.

A live self-update/restart trace is intentionally not run on the shared maintainer host because it would replace and restart that host's installed Gateway. The deterministic update-orchestrator tests exercise the real stop/ownership/handoff/fallback/restart/doctor code with isolated service, config, plugin-index, child-process, and completion boundaries; the delegated changed gate and exact-head CI provide packaged static/runtime coverage without mutating a real operator service.
