### PR TITLE
fix(chat): preserve Markdown image examples in native chat

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMarkdownPreprocessor.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMarkdownPreprocessor.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Markdown
 
 enum ChatMarkdownPreprocessor {
     /// Provenance marker appended to every OpenClaw-injected inbound context header.
@@ -22,8 +23,105 @@ enum ChatMarkdownPreprocessor {
         "Zalo Personal",
     ]
 
-    private static let markdownImagePattern = #"!\[([^\]]*)\]\(([^)]+)\)"#
     private static let messageIdHintPattern = #"^\s*\[message_id:\s*[^\]]+\]\s*$"#
+    private static let markdownLiteralPunctuation = CharacterSet(
+        charactersIn: "!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~")
+
+    private struct MarkdownImageOccurrence {
+        let range: Range<String.Index>
+        let label: String
+        let source: String
+    }
+
+    /// Maps swift-markdown's 1-based UTF-8 source locations back into the
+    /// original String without normalizing line endings or Unicode first.
+    private struct MarkdownSourceMap {
+        private let markdown: String
+        private let lineStarts: [String.Index]
+
+        init(_ markdown: String) {
+            self.markdown = markdown
+            var lineStarts = [markdown.startIndex]
+            let bytes = markdown.utf8
+            for byteIndex in bytes.indices {
+                let byte = bytes[byteIndex]
+                guard byte == 0x0A || byte == 0x0D else { continue }
+
+                let nextByteIndex = bytes.index(after: byteIndex)
+                // CommonMark counts CRLF as one line ending. Record the next
+                // line at LF, not at the midpoint of the two-byte sequence.
+                if byte == 0x0D,
+                   nextByteIndex < bytes.endIndex,
+                   bytes[nextByteIndex] == 0x0A
+                {
+                    continue
+                }
+                if let lineStart = String.Index(nextByteIndex, within: markdown) {
+                    lineStarts.append(lineStart)
+                }
+            }
+            self.lineStarts = lineStarts
+        }
+
+        func range(for sourceRange: SourceRange) -> Range<String.Index>? {
+            guard let lowerBound = self.index(for: sourceRange.lowerBound),
+                  let upperBound = self.index(for: sourceRange.upperBound),
+                  lowerBound <= upperBound
+            else {
+                return nil
+            }
+            return lowerBound..<upperBound
+        }
+
+        private func index(for location: SourceLocation) -> String.Index? {
+            guard location.line > 0,
+                  location.column > 0,
+                  self.lineStarts.indices.contains(location.line - 1)
+            else {
+                return nil
+            }
+
+            let bytes = self.markdown.utf8
+            guard let lineStart = self.lineStarts[location.line - 1].samePosition(in: bytes),
+                  let byteIndex = bytes.index(
+                      lineStart,
+                      offsetBy: location.column - 1,
+                      limitedBy: bytes.endIndex),
+                  let stringIndex = String.Index(byteIndex, within: self.markdown)
+            else {
+                return nil
+            }
+
+            // A malformed dependency range must not spill into the next line.
+            if self.lineStarts.indices.contains(location.line),
+               stringIndex >= self.lineStarts[location.line]
+            {
+                return nil
+            }
+            return stringIndex
+        }
+    }
+
+    private struct MarkdownImageCollector: MarkupWalker {
+        private let sourceMap: MarkdownSourceMap
+        private(set) var images: [MarkdownImageOccurrence] = []
+
+        init(markdown: String) {
+            self.sourceMap = MarkdownSourceMap(markdown)
+        }
+
+        mutating func visitImage(_ image: Markdown.Image) {
+            guard let sourceRange = image.range,
+                  let range = self.sourceMap.range(for: sourceRange)
+            else {
+                return
+            }
+            self.images.append(MarkdownImageOccurrence(
+                range: range,
+                label: image.plainText,
+                source: image.source ?? ""))
+        }
+    }
 
     struct InlineImage: Identifiable {
         let id = UUID()
@@ -41,29 +139,36 @@ enum ChatMarkdownPreprocessor {
         let withoutMessageIdHints = self.stripMessageIdHints(withoutEnvelope)
         let withoutContextBlocks = self.stripInboundContextBlocks(withoutMessageIdHints)
         let withoutTimestamps = self.stripPrefixedTimestamps(withoutContextBlocks)
-        guard let re = try? NSRegularExpression(pattern: self.markdownImagePattern) else {
-            return Result(cleaned: self.normalize(withoutTimestamps), images: [])
+        // cmark replaces NUL with U+FFFD before computing UTF-8 source columns.
+        // Use those same bytes for range mapping and the downstream renderer.
+        let markdown = withoutTimestamps.replacingOccurrences(of: "\0", with: "\u{FFFD}")
+        guard markdown.contains("![") else {
+            return Result(cleaned: self.normalize(markdown), images: [])
         }
 
-        let ns = withoutTimestamps as NSString
-        let matches = re.matches(
-            in: withoutTimestamps,
-            range: NSRange(location: 0, length: ns.length))
-        if matches.isEmpty { return Result(cleaned: self.normalize(withoutTimestamps), images: []) }
+        // Only structural CommonMark images are renderable. A document-wide
+        // regex also matches examples inside code and escaped user text.
+        var collector = MarkdownImageCollector(markdown: markdown)
+        collector.visit(Document(parsing: markdown))
+        guard !collector.images.isEmpty else {
+            return Result(cleaned: self.normalize(markdown), images: [])
+        }
 
         var images: [InlineImage] = []
-        let cleaned = NSMutableString(string: withoutTimestamps)
+        let cleaned = NSMutableString(string: markdown)
 
-        for match in matches.reversed() {
-            guard match.numberOfRanges >= 3 else { continue }
-            let label = ns.substring(with: match.range(at: 1))
-            let source = ns.substring(with: match.range(at: 2))
-
-            if let inlineImage = self.inlineImage(label: label, source: source) {
+        for occurrence in collector.images.reversed() {
+            let range = NSRange(occurrence.range, in: markdown)
+            if let inlineImage = self.inlineImage(
+                label: occurrence.label,
+                source: occurrence.source)
+            {
                 images.append(inlineImage)
-                cleaned.replaceCharacters(in: match.range, with: "")
+                cleaned.replaceCharacters(in: range, with: "")
             } else {
-                cleaned.replaceCharacters(in: match.range, with: self.fallbackImageLabel(label))
+                cleaned.replaceCharacters(
+                    in: range,
+                    with: self.fallbackImageLabel(occurrence.label))
             }
         }
 
@@ -87,7 +192,19 @@ enum ChatMarkdownPreprocessor {
 
     private static func fallbackImageLabel(_ label: String) -> String {
         let trimmed = label.trimmingCharacters(in: .whitespacesAndNewlines)
-        return trimmed.isEmpty ? "image" : trimmed
+        return self.markdownEscapedLiteral(trimmed.isEmpty ? "image" : trimmed)
+    }
+
+    private static func markdownEscapedLiteral(_ value: String) -> String {
+        var escaped = ""
+        escaped.reserveCapacity(value.utf8.count)
+        for scalar in value.unicodeScalars {
+            if self.markdownLiteralPunctuation.contains(scalar) {
+                escaped.append("\\")
+            }
+            escaped.unicodeScalars.append(scalar)
+        }
+        return escaped
     }
 
     private static func stripEnvelope(_ raw: String) -> String {

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatMarkdownPreprocessorTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatMarkdownPreprocessorTests.swift
@@ -55,6 +55,170 @@ struct ChatMarkdownPreprocessorTests {
         #expect(result.images.isEmpty)
     }
 
+    @Test func flattensRemoteImagesAfterCRLFLineEndings() {
+        let markdown = "Visible\r\n![Leak](https://example.com/image.png)"
+
+        let result = ChatMarkdownPreprocessor.preprocess(markdown: markdown)
+
+        #expect(result.cleaned == "Visible\nLeak")
+        #expect(result.images.isEmpty)
+    }
+
+    @Test func flattensRemoteImagesAfterCarriageReturnLineEndings() {
+        let markdown = "Visible\r![Leak](https://example.com/image.png)"
+
+        let result = ChatMarkdownPreprocessor.preprocess(markdown: markdown)
+
+        #expect(result.cleaned == "Visible\rLeak")
+        #expect(result.images.isEmpty)
+    }
+
+    @Test func flattensRemoteImagesAfterUnicodeLineSeparators() {
+        // swift-cmark treats only CR/LF as source-position line endings;
+        // U+2028 stays on the same CommonMark source line.
+        let markdown = "Visible\u{2028}![Leak](https://example.com/image.png)"
+
+        let result = ChatMarkdownPreprocessor.preprocess(markdown: markdown)
+
+        #expect(result.cleaned == "Visible\u{2028}Leak")
+        #expect(result.images.isEmpty)
+    }
+
+    @Test func extractsDataURLImagesAfterCRLFLineEndings() {
+        let base64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIHWP4////GQAJ+wP/2hN8NwAAAABJRU5ErkJggg=="
+        let markdown = "Visible\r\n![Pixel](data:image/png;base64,\(base64))"
+
+        let result = ChatMarkdownPreprocessor.preprocess(markdown: markdown)
+
+        #expect(result.cleaned == "Visible")
+        #expect(result.images.map(\.label) == ["Pixel"])
+        #expect(result.images.first?.image != nil)
+    }
+
+    @Test func preservesImageSyntaxInsideFencedCode() {
+        let markdown = """
+        Example:
+
+        ```markdown
+        ![Logo](https://example.com/logo.png)
+        ```
+        """
+
+        let result = ChatMarkdownPreprocessor.preprocess(markdown: markdown)
+
+        #expect(result.cleaned == markdown)
+        #expect(result.images.isEmpty)
+    }
+
+    @Test func preservesImageSyntaxInsideInlineCode() {
+        let markdown = "Use `![Logo](https://example.com/logo.png)` verbatim."
+
+        let result = ChatMarkdownPreprocessor.preprocess(markdown: markdown)
+
+        #expect(result.cleaned == markdown)
+        #expect(result.images.isEmpty)
+    }
+
+    @Test func preservesImageSyntaxInsideIndentedCode() {
+        let markdown = "Example:\n\n    ![Logo](https://example.com/logo.png)"
+
+        let result = ChatMarkdownPreprocessor.preprocess(markdown: markdown)
+
+        #expect(result.cleaned == markdown)
+        #expect(result.images.isEmpty)
+    }
+
+    @Test func preservesEscapedMarkdownImageSyntax() {
+        let markdown = #"Escaped: \![Logo](https://example.com/logo.png)"#
+
+        let result = ChatMarkdownPreprocessor.preprocess(markdown: markdown)
+
+        #expect(result.cleaned == markdown)
+        #expect(result.images.isEmpty)
+    }
+
+    @Test func extractsRealImagesInDocumentOrderAroundRemoteImages() {
+        let base64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIHWP4////GQAJ+wP/2hN8NwAAAABJRU5ErkJggg=="
+        let markdown = """
+        ![First](data:image/png;base64,\(base64))
+        ![Remote](https://example.com/image.png)
+        ![Second](data:image/png;base64,\(base64))
+        """
+
+        let result = ChatMarkdownPreprocessor.preprocess(markdown: markdown)
+
+        #expect(result.cleaned == "Remote")
+        #expect(result.images.map(\.label) == ["First", "Second"])
+        #expect(result.images.allSatisfy { $0.image != nil })
+    }
+
+    @Test func processesOnlyRealImagesAlongsideUnicodeAndCode() {
+        let markdown = """
+        # Examples
+
+        - 🙂 ![Visible](https://example.com/image.png)
+        - `![Literal](https://example.com/code.png)`
+
+        ```markdown
+        ![Fenced](https://example.com/fenced.png)
+        ```
+        """
+
+        let result = ChatMarkdownPreprocessor.preprocess(markdown: markdown)
+
+        #expect(result.cleaned == """
+        # Examples
+
+        - 🙂 Visible
+        - `![Literal](https://example.com/code.png)`
+
+        ```markdown
+        ![Fenced](https://example.com/fenced.png)
+        ```
+        """)
+        #expect(result.images.isEmpty)
+    }
+
+    @Test func handlesBalancedParenthesesAndTitlesInImageDestinations() {
+        let markdown = #"![Diagram](https://example.com/image_(2).png "Preview")"#
+
+        let result = ChatMarkdownPreprocessor.preprocess(markdown: markdown)
+
+        #expect(result.cleaned == "Diagram")
+        #expect(result.images.isEmpty)
+    }
+
+    @Test func flattensImagesWithEmptyDestinations() {
+        let markdown = #"![Diagram](<> "Preview") and ![](<>)."#
+
+        let result = ChatMarkdownPreprocessor.preprocess(markdown: markdown)
+
+        #expect(result.cleaned == "Diagram and image.")
+        #expect(result.images.isEmpty)
+    }
+
+    @Test func normalizesNULBeforeMappingRemoteImages() {
+        let markdown = "Before\0![Leak](https://example.com/image.png)"
+
+        let result = ChatMarkdownPreprocessor.preprocess(markdown: markdown)
+
+        #expect(result.cleaned == "Before\u{FFFD}Leak")
+        #expect(result.images.isEmpty)
+    }
+
+    @Test func escapesDecodedFallbackLabelsBeforeMarkdownIsParsedAgain() {
+        let markdown = "![&#33;&#91;Leak&#93;&#40;https://tracker.example/x&#41;](https://example.com/outer.png)"
+
+        let result = ChatMarkdownPreprocessor.preprocess(markdown: markdown)
+        let reparsed = ChatMarkdownPreprocessor.preprocess(markdown: result.cleaned)
+
+        #expect(!result.cleaned.contains("!["))
+        #expect(result.cleaned.contains("Leak"))
+        #expect(result.images.isEmpty)
+        #expect(reparsed.cleaned == result.cleaned)
+        #expect(reparsed.images.isEmpty)
+    }
+
     @Test func stripsInboundUntrustedContextBlocks() {
         let markdown = """
         Conversation info: \(Self.ctx)


### PR DESCRIPTION
## What Problem This Solves

Native iOS/macOS chat already supports inline data-image rendering and safely flattens remote Markdown images into alt text. The remaining implementation used a document-wide regular expression, so image examples inside fenced code, inline code, indented code, and escaped Markdown were still mistaken for real images. That changed rendered text and the sanitized user-history copy.

## Why This Change Was Made

This rewrite keeps the landed image feature and the current provenance-marker metadata sanitizer intact. It replaces only image recognition with the repository-pinned `swift-markdown` 0.8.0 CommonMark AST, then maps structural image source ranges back to the original UTF-8 text.

The mapping follows the dependency contract directly:

- `SourceLocation.column` is 1-based UTF-8 bytes.
- ranges are end-exclusive after swift-markdown adjusts cmark's inclusive end column.
- swift-cmark treats only CR/LF as source-position line endings and replaces NUL with U+FFFD before calculating columns.
- empty image destinations surface as `nil`, so they are still collected and safely flattened.

Unsupported/remote image alt text is emitted as escaped literal Markdown. Decoded entities therefore cannot synthesize a second image or link when native chat parses the cleaned text again.

## User Impact

- Real inline data images continue to render in document order.
- Real remote images remain non-fetching alt text.
- Literal image examples remain byte-preserved in fenced, inline, indented, and escaped code/text.
- CRLF, CR, Unicode, empty destinations, balanced destination parentheses, optional titles, and NUL input follow the same safe behavior.

## Evidence

Exact rewritten head: `d141b3e16281e14af56da734619f537ea3dcf840`.

- Direct dependency inspection: `swift-markdown` 0.8.0 revision `3c6f9523da3a1ec2fd829673e472d95b8097a3b8` and transitive `swift-cmark` 0.8.0 revision `924936d0427cb25a61169739a7660230bffa6ea6`.
- Regression coverage now includes actual data/remote images, document ordering, Unicode, LF/CRLF/CR, Unicode separators, fenced/inline/indented code, escaped syntax, balanced parentheses, titles, empty destinations, NUL normalization, and decoded-alt recursive parsing.
- `scripts/format-swift.sh macos`: 0 files require formatting.
- `git diff --check`: passed.
- Final Codex autoreview (`gpt-5.6-sol`, high): clean, no accepted/actionable findings.
- Source-blind behavior contract: all 4 user tasks and all 4 anti-cheat groups passed from the exact-head native log.
- Exact-head CI: [run 30393194911, attempt 2](https://github.com/openclaw/openclaw/actions/runs/30393194911) passed.
  - `macos-swift`: Swift lint, release build, OpenClawKit tests, and macOS app tests passed.
  - `ChatMarkdownPreprocessor` passed; OpenClawKit finished with 1,239 tests in 95 suites, and the macOS app/shared run finished with 1,522 tests in 166 suites.
  - `ios-build`, native i18n, macOS Node, Android builds/tests/lint, security, and the aggregate `openclaw/ci-gate` passed.

The first CI attempt had one unrelated Android coroutine test timeout after 5 seconds; all other 1,939 Play tests passed. The permitted single retry passed without code changes.

## Provenance

The over-broad regex came from #38895 (`4bf902de5851304cae53c57889b5ae90fa7367a8`, follow-up `d25b493c7f79d13e7dca0278f66aeeb6c05f4d72`), authored and merged by @obviyus on 2026-03-07. That PR correctly established remote-image flattening; this change preserves that security behavior while moving recognition to the CommonMark owner boundary.
