### PR TITLE
fix: prevent gateway crash on unreachable pinned addresses

### DIFF
--- a/scripts/resolve-openclaw-package-candidate.mjs
+++ b/scripts/resolve-openclaw-package-candidate.mjs
@@ -1120,12 +1120,17 @@ function createPinnedLookup(hostname, addresses) {
       ? records.filter((record) => record.family === opts.family)
       : records;
     const usable = filtered.length > 0 ? filtered : records;
+    // Keep custom lookup delivery asynchronous so HTTPS owns immediate socket errors.
     if (opts.all) {
-      cb(null, usable);
+      process.nextTick(() => {
+        cb(null, usable);
+      });
       return;
     }
     const chosen = usable[0];
-    cb(null, chosen.address, chosen.family);
+    process.nextTick(() => {
+      cb(null, chosen.address, chosen.family);
+    });
   };
 }
 

--- a/src/infra/net/ssrf.dispatcher.test.ts
+++ b/src/infra/net/ssrf.dispatcher.test.ts
@@ -232,15 +232,18 @@ describe("createPinnedDispatcher", () => {
     });
   });
 
-  it("replaces the pinned lookup when a dispatcher override hostname is provided", () => {
+  it("replaces the pinned lookup when a dispatcher override hostname is provided", async () => {
     const originalLookup = vi.fn() as unknown as PinnedHostname["lookup"];
     const lookup = createDispatcherWithPinnedOverride(originalLookup);
 
     expect(lookup).toBeTypeOf("function");
-    const callback = vi.fn();
-    lookup?.("api.telegram.org", callback);
+    const result = await new Promise<[unknown, string, number]>((resolve) => {
+      lookup?.("api.telegram.org", (err, address, family) => {
+        resolve([err, address as string, family as number]);
+      });
+    });
 
-    expect(callback).toHaveBeenCalledWith(null, "149.154.167.220", 4);
+    expect(result).toEqual([null, "149.154.167.220", 4]);
     expect(originalLookup).not.toHaveBeenCalled();
   });
 

--- a/src/infra/net/ssrf.pinning.test.ts
+++ b/src/infra/net/ssrf.pinning.test.ts
@@ -294,4 +294,46 @@ describe("ssrf pinning", () => {
       }),
     ).rejects.toThrow(SsrFBlockedError);
   });
+
+  describe("asynchronous delivery contract", () => {
+    function createLookup() {
+      return createPinnedLookup({
+        hostname: "api.telegram.org",
+        addresses: ["149.154.167.220", "2001:67c:4e8:f004::9"],
+      });
+    }
+
+    async function flushLookupCallback(): Promise<void> {
+      await new Promise<void>((resolve) => {
+        process.nextTick(resolve);
+      });
+    }
+
+    it("defers callbacks without lookup options", async () => {
+      const callback = vi.fn();
+      createLookup()("api.telegram.org", callback);
+
+      expect(callback).not.toHaveBeenCalled();
+      await flushLookupCallback();
+      expect(callback).toHaveBeenCalledWith(null, "149.154.167.220", 4);
+    });
+
+    it("defers callbacks for all-address lookups", async () => {
+      const callback = vi.fn();
+      createLookup()("api.telegram.org", { all: true }, callback);
+
+      expect(callback).not.toHaveBeenCalled();
+      await flushLookupCallback();
+      expect(callback).toHaveBeenCalledWith(null, [{ address: "149.154.167.220", family: 4 }]);
+    });
+
+    it("defers callbacks for explicit address families", async () => {
+      const callback = vi.fn();
+      createLookup()("api.telegram.org", { family: 6 }, callback);
+
+      expect(callback).not.toHaveBeenCalled();
+      await flushLookupCallback();
+      expect(callback).toHaveBeenCalledWith(null, "2001:67c:4e8:f004::9", 6);
+    });
+  });
 });

--- a/src/infra/net/ssrf.ts
+++ b/src/infra/net/ssrf.ts
@@ -529,8 +529,12 @@ export function createPinnedLookup(params: {
         ? records.filter((entry) => entry.family === requestedFamily)
         : automaticRecords;
     const usable = candidates.length > 0 ? candidates : automaticRecords;
+    // Match dns.lookup's asynchronous callback contract so connection errors
+    // cannot fire before the socket owner attaches its error listener.
     if (opts.all) {
-      cb(null, usable as LookupAddress[]);
+      process.nextTick(() => {
+        cb(null, usable as LookupAddress[]);
+      });
       return;
     }
     const chosen = expectDefined(
@@ -538,7 +542,9 @@ export function createPinnedLookup(params: {
       "usable entry at index % usable.length",
     );
     index += 1;
-    cb(null, chosen.address, chosen.family);
+    process.nextTick(() => {
+      cb(null, chosen.address, chosen.family);
+    });
   }) as typeof dnsLookupCb;
 }
 


### PR DESCRIPTION
Closes #106598

AI-assisted: investigated and implemented with Claude Code and Codex, with independent structured reviews from Claude Opus 5, Fable 5, and Sonnet 5. I understand and verified the callback timing change and its socket ownership implications.

## What Problem This Solves

Fixes an issue where users running Telegram could have the entire gateway process terminate when a pinned fallback address failed immediately with `EHOSTUNREACH` or `ENETUNREACH`.

The synchronous pinned lookup callback allowed the connection attempt to fail while the TLS socket was still being constructed, before undici could attach its socket error listener.

## Why This Change Was Made

Pinned DNS answers are now delivered with `process.nextTick`, matching Node's asynchronous `dns.lookup` callback behavior. Both single-address and `all: true` lookups follow the same contract, while existing address selection, SSRF validation, and transport retry ownership remain unchanged.

## User Impact

Immediate network-unreachable failures from pinned Telegram addresses now reject through the socket owner's normal error path instead of surfacing as an unhandled `TLSSocket` error that terminates the gateway.

## Evidence

Current-main reproduction with synchronous delivery:

```text
connector THREW: Cannot read properties of null (reading 'setServername')
CRASH: unhandled 'ENETUNREACH' — process would die
```

Fixed branch using OpenClaw's actual `createPinnedLookup`:

```text
handled by socket owner: ENETUNREACH
```

Focused regression and acceptance coverage:

```text
node scripts/run-vitest.mjs src/infra/net/ssrf.dispatcher.test.ts src/infra/net/ssrf.pinning.test.ts
40 passed

node scripts/run-vitest.mjs src/gateway/managed-image-attachments.test.ts src/media/store.redirect.test.ts src/media/store.download-timeout.test.ts
62 passed

node scripts/run-vitest.mjs extensions/telegram/src/monitor.test.ts extensions/telegram/src/polling-session.test.ts src/infra/net/fetch-guard.ssrf.test.ts
207 passed
```

Targeted `oxfmt`, `oxlint`, TruffleHog, and `git diff --check` passed.

Structured autoreview results:

- Claude Opus 5 at maximum effort: clean, no actionable findings.
- Claude Fable 5 at maximum effort: clean, confidence 0.87.
- Claude Sonnet 5 at maximum effort: clean, confidence 0.85.
