### PR TITLE
fix(models): authenticate Anthropic discovery with OAuth tokens

### DIFF
--- a/extensions/anthropic/live-discovery-auth.test.ts
+++ b/extensions/anthropic/live-discovery-auth.test.ts
@@ -1,0 +1,74 @@
+// Anthropic tests cover live model discovery request auth.
+import { clearLiveCatalogCacheForTests } from "openclaw/plugin-sdk/provider-catalog-live-runtime";
+import type { ProviderCatalogContext } from "openclaw/plugin-sdk/provider-catalog-shared";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { buildAnthropicProvider } from "./register.runtime.js";
+
+const guardedFetchCalls = vi.hoisted(
+  () =>
+    [] as Array<
+      Parameters<typeof import("openclaw/plugin-sdk/ssrf-runtime").fetchWithSsrFGuard>[0]
+    >,
+);
+
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/ssrf-runtime")>();
+  return {
+    ...actual,
+    fetchWithSsrFGuard: (params: Parameters<typeof actual.fetchWithSsrFGuard>[0]) => {
+      guardedFetchCalls.push(params);
+      return Promise.resolve({
+        response: new Response(JSON.stringify({ data: [] })),
+        finalUrl: "https://api.anthropic.com/v1/models",
+        release: async () => undefined,
+      });
+    },
+  };
+});
+
+function buildCatalogContext(apiKey: string): ProviderCatalogContext {
+  return {
+    config: {},
+    env: {},
+    resolveProviderApiKey: () => ({ apiKey }),
+  } as unknown as ProviderCatalogContext;
+}
+
+async function readDiscoveryHeaders(apiKey: string): Promise<Headers> {
+  const provider = buildAnthropicProvider();
+  await provider.catalog?.run?.(buildCatalogContext(apiKey));
+  const request = guardedFetchCalls.at(-1);
+  expect(request).toBeDefined();
+  return new Headers(request?.init?.headers);
+}
+
+describe("anthropic live model discovery auth", () => {
+  beforeEach(() => {
+    guardedFetchCalls.length = 0;
+    clearLiveCatalogCacheForTests();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("sends an API key as x-api-key", async () => {
+    const headers = await readDiscoveryHeaders("sk-ant-api03-test-key");
+    expect(headers.get("x-api-key")).toBe("sk-ant-api03-test-key");
+    expect(headers.get("authorization")).toBeNull();
+    expect(headers.get("anthropic-version")).toBe("2023-06-01");
+  });
+
+  it("sends a subscription OAuth token as a bearer credential", async () => {
+    const headers = await readDiscoveryHeaders("sk-ant-oat01-test-token");
+    expect(headers.get("authorization")).toBe("Bearer sk-ant-oat01-test-token");
+    expect(headers.get("anthropic-version")).toBe("2023-06-01");
+  });
+
+  it("never pairs an OAuth bearer credential with x-api-key", async () => {
+    // Anthropic rejects the request outright when both auth headers are present,
+    // so the OAuth branch must replace x-api-key rather than add to it.
+    const headers = await readDiscoveryHeaders("sk-ant-oat01-test-token");
+    expect(headers.get("x-api-key")).toBeNull();
+  });
+});

--- a/extensions/anthropic/live-discovery-auth.test.ts
+++ b/extensions/anthropic/live-discovery-auth.test.ts
@@ -11,6 +11,8 @@ const guardedFetchCalls = vi.hoisted(
     >,
 );
 
+const discoveryRows = vi.hoisted(() => ({ value: [] as unknown[] }));
+
 vi.mock("openclaw/plugin-sdk/ssrf-runtime", async (importOriginal) => {
   const actual = await importOriginal<typeof import("openclaw/plugin-sdk/ssrf-runtime")>();
   return {
@@ -18,7 +20,7 @@ vi.mock("openclaw/plugin-sdk/ssrf-runtime", async (importOriginal) => {
     fetchWithSsrFGuard: (params: Parameters<typeof actual.fetchWithSsrFGuard>[0]) => {
       guardedFetchCalls.push(params);
       return Promise.resolve({
-        response: new Response(JSON.stringify({ data: [] })),
+        response: new Response(JSON.stringify({ data: discoveryRows.value })),
         finalUrl: "https://api.anthropic.com/v1/models",
         release: async () => undefined,
       });
@@ -45,6 +47,7 @@ async function readDiscoveryHeaders(apiKey: string): Promise<Headers> {
 describe("anthropic live model discovery auth", () => {
   beforeEach(() => {
     guardedFetchCalls.length = 0;
+    discoveryRows.value = [];
     clearLiveCatalogCacheForTests();
   });
 
@@ -70,5 +73,41 @@ describe("anthropic live model discovery auth", () => {
     // so the OAuth branch must replace x-api-key rather than add to it.
     const headers = await readDiscoveryHeaders("sk-ant-oat01-test-token");
     expect(headers.get("x-api-key")).toBeNull();
+  });
+
+  it("keeps shipped models Anthropic does not publish while adding discovered ones", async () => {
+    // Discovery replaces the seed catalog, so a shipped model with no live row
+    // would silently vanish from the provider listing once discovery succeeds.
+    discoveryRows.value = [
+      {
+        id: "claude-opus-5",
+        type: "model",
+        max_input_tokens: 1_000_000,
+        max_tokens: 128_000,
+      },
+      {
+        id: "claude-brand-new-9",
+        type: "model",
+        max_input_tokens: 1_000_000,
+        max_tokens: 128_000,
+        capabilities: {
+          // Advertises the Claude 5 contract our predicates do not yet grant an
+          // unrecognized id, so the gate must keep it hidden.
+          thinking: { types: { adaptive: { supported: true } } },
+          effort: { xhigh: { supported: true }, max: { supported: true } },
+        },
+      },
+    ];
+    const provider = buildAnthropicProvider();
+    const result = await provider.catalog?.run?.(buildCatalogContext("sk-ant-oat01-test-token"));
+    const ids = new Set(
+      result && "provider" in result ? (result.provider.models ?? []).map((model) => model.id) : [],
+    );
+
+    expect(ids.has("claude-opus-5")).toBe(true);
+    // Shipped but absent from the live response: must survive discovery.
+    expect(ids.has("claude-mythos-5")).toBe(true);
+    // Unknown id whose advertised capabilities disagree with our contracts stays gated out.
+    expect(ids.has("claude-brand-new-9")).toBe(false);
   });
 });

--- a/extensions/anthropic/register.runtime.ts
+++ b/extensions/anthropic/register.runtime.ts
@@ -26,7 +26,10 @@ import {
   validateAnthropicSetupToken,
 } from "openclaw/plugin-sdk/provider-auth";
 import { buildOpenAICompatibleProviderCatalog } from "openclaw/plugin-sdk/provider-catalog-live-runtime";
-import { buildManifestModelProviderConfig } from "openclaw/plugin-sdk/provider-catalog-shared";
+import {
+  buildManifestModelProviderConfig,
+  type ProviderCatalogResult,
+} from "openclaw/plugin-sdk/provider-catalog-shared";
 import {
   buildProviderReplayFamilyHooks,
   cloneFirstTemplateModel,
@@ -145,6 +148,37 @@ function buildAnthropicDiscoveryAuthHeaders(key: string | undefined): Record<str
     return {};
   }
   return isAnthropicOAuthApiKey(key) ? { authorization: `Bearer ${key}` } : { "x-api-key": key };
+}
+
+/**
+ * Live discovery replaces the seed catalog with whatever `/v1/models` returns.
+ * Anthropic does not publish every model it serves, so replacement alone would
+ * hide shipped entries that have no live row. Re-add the manifest models the
+ * live response omitted; discovered rows still win on shared ids.
+ */
+function restoreUnpublishedAnthropicModels(result: ProviderCatalogResult): ProviderCatalogResult {
+  if (!result || !("provider" in result)) {
+    return result;
+  }
+  const discovered = result.provider.models ?? [];
+  if (discovered.length === 0) {
+    return result;
+  }
+  const discoveredIds = new Set(discovered.map((model) => model.id));
+  const unpublished = (buildAnthropicCatalogProvider().models ?? []).filter(
+    (model) => !discoveredIds.has(model.id),
+  );
+  if (unpublished.length === 0) {
+    return result;
+  }
+  // Discovered rows arrive id-sorted; keep the appended tail sorted too so the
+  // catalog stays byte-stable for prompt caching.
+  return {
+    provider: {
+      ...result.provider,
+      models: [...discovered, ...unpublished.toSorted((a, b) => a.id.localeCompare(b.id))],
+    },
+  };
 }
 
 function resolveAnthropicSonnet5Cost(nowMs: number = Date.now()) {
@@ -950,20 +984,22 @@ export function buildAnthropicProvider(): ProviderPlugin {
     ],
     catalog: {
       order: "simple",
-      run: (ctx) =>
-        buildOpenAICompatibleProviderCatalog({
-          ctx,
-          providerId,
-          buildProvider: buildAnthropicCatalogProvider,
-          modelDiscovery: {
-            endpointPath: "v1/models",
-            buildRequestHeaders: ({ apiKey, discoveryApiKey }) => ({
-              "anthropic-version": "2023-06-01",
-              ...buildAnthropicDiscoveryAuthHeaders(discoveryApiKey ?? apiKey),
-            }),
-            acceptUnknownModel: acceptsAnthropicLiveModelContract,
-          },
-        }),
+      run: async (ctx) =>
+        restoreUnpublishedAnthropicModels(
+          await buildOpenAICompatibleProviderCatalog({
+            ctx,
+            providerId,
+            buildProvider: buildAnthropicCatalogProvider,
+            modelDiscovery: {
+              endpointPath: "v1/models",
+              buildRequestHeaders: ({ apiKey, discoveryApiKey }) => ({
+                "anthropic-version": "2023-06-01",
+                ...buildAnthropicDiscoveryAuthHeaders(discoveryApiKey ?? apiKey),
+              }),
+              acceptUnknownModel: acceptsAnthropicLiveModelContract,
+            },
+          }),
+        ),
     },
     staticCatalog: {
       order: "simple",

--- a/extensions/anthropic/register.runtime.ts
+++ b/extensions/anthropic/register.runtime.ts
@@ -64,7 +64,7 @@ import manifest from "./openclaw.plugin.json" with { type: "json" };
 import { resolveClaudeCliSyntheticAuth } from "./provider-discovery.js";
 import { createClaudeSessionNodeInvokePolicies } from "./session-catalog-node-commands.js";
 import { registerClaudeSessionDiscovery } from "./session-catalog-registration.js";
-import { wrapAnthropicProviderStream } from "./stream-wrappers.js";
+import { isAnthropicOAuthApiKey, wrapAnthropicProviderStream } from "./stream-wrappers.js";
 import { fetchAnthropicUsage, resolveAnthropicUsageAuth } from "./usage.js";
 
 type ProviderAuthMethodNonInteractiveValidationContext = Parameters<
@@ -132,6 +132,19 @@ function buildAnthropicCatalogProvider() {
     providerId: PROVIDER_ID,
     catalog: manifest.modelCatalog.providers.anthropic,
   });
+}
+
+/**
+ * Discovery credentials arrive as either an API key or a Claude subscription
+ * OAuth access token. Anthropic rejects an OAuth token sent as `x-api-key`, and
+ * rejects the request outright when both auth headers are present, so the two
+ * shapes must select mutually exclusive headers.
+ */
+function buildAnthropicDiscoveryAuthHeaders(key: string | undefined): Record<string, string> {
+  if (!key) {
+    return {};
+  }
+  return isAnthropicOAuthApiKey(key) ? { authorization: `Bearer ${key}` } : { "x-api-key": key };
 }
 
 function resolveAnthropicSonnet5Cost(nowMs: number = Date.now()) {
@@ -944,13 +957,10 @@ export function buildAnthropicProvider(): ProviderPlugin {
           buildProvider: buildAnthropicCatalogProvider,
           modelDiscovery: {
             endpointPath: "v1/models",
-            buildRequestHeaders: ({ apiKey, discoveryApiKey }) => {
-              const key = discoveryApiKey ?? apiKey;
-              return {
-                "anthropic-version": "2023-06-01",
-                ...(key ? { "x-api-key": key } : {}),
-              };
-            },
+            buildRequestHeaders: ({ apiKey, discoveryApiKey }) => ({
+              "anthropic-version": "2023-06-01",
+              ...buildAnthropicDiscoveryAuthHeaders(discoveryApiKey ?? apiKey),
+            }),
             acceptUnknownModel: acceptsAnthropicLiveModelContract,
           },
         }),

--- a/extensions/anthropic/stream-wrappers.ts
+++ b/extensions/anthropic/stream-wrappers.ts
@@ -73,7 +73,12 @@ function mergeAnthropicBetaHeader(
   return merged;
 }
 
-function isAnthropicOAuthApiKey(apiKey: unknown): boolean {
+/**
+ * Claude subscription credentials are OAuth access tokens rather than API keys.
+ * Anthropic authenticates them through `Authorization: Bearer`, so every caller
+ * that builds request auth must branch on this instead of assuming `x-api-key`.
+ */
+export function isAnthropicOAuthApiKey(apiKey: unknown): boolean {
   return typeof apiKey === "string" && apiKey.includes("sk-ant-oat");
 }
 


### PR DESCRIPTION
## What Problem This Solves

Live Anthropic model discovery never worked for anyone signed in with a Claude subscription. It sent every credential as `x-api-key`, but subscription credentials are OAuth access tokens (`sk-ant-oat…`), which Anthropic rejects in that header. Discovery 401'd on every attempt, the error was swallowed by the advisory `catch` in `buildOpenAICompatibleLiveModelProviderConfig`, and the provider silently fell back to the shipped catalog. Nothing appeared in the logs, so the failure was invisible.

The runtime path already handles this correctly — `packages/ai/src/providers/anthropic.ts` detects the `sk-ant-oat` shape and switches to `Authorization: Bearer` before building the client. Discovery simply never got the same treatment, so the same credential that successfully streams completions could not read `/v1/models`.

Found while investigating why the live catalog had not spared us the manual Claude Opus 5 rollout. The contract gate (#113757) and token-limit reads (#113784) were both correct; they just never ran, because discovery could not authenticate.

## Why This Change Was Made

The auth header is now selected from the detected credential shape rather than assumed:

- API key → `x-api-key` (unchanged)
- OAuth access token → `Authorization: Bearer`

The two are mutually exclusive by necessity, not style: Anthropic returns `401` when a request carries a bearer token *and* an `x-api-key` header, so the OAuth branch must replace the API-key header rather than add to it. That is asserted directly in the new tests.

Detection reuses the existing `isAnthropicOAuthApiKey` predicate from `extensions/anthropic/stream-wrappers.ts` (now exported) instead of adding a fourth copy of the `sk-ant-oat` check. Discovery credentials are safe to inspect directly: `normalizeLiveModelCatalogRequestApiKey` filters non-secret markers, so the header builder only ever sees a real secret or `undefined`.

No beta header is added. `anthropic-beta: oauth-2025-04-20` turns out to be unnecessary for `/v1/models` — verified that the response is byte-identical with and without it — so the change stays minimal.

## User Impact

Live model discovery starts working for Claude subscription users. Newly published Claude models become visible without waiting for an OpenClaw release, and the discovery-side contract gate and token-limit reads finally take effect for this population.

The change is strictly additive to the model listing. Live discovery replaces the seed catalog with whatever `/v1/models` returns, and Anthropic does not publish every model it serves — so simply fixing auth would have dropped shipped-but-unpublished entries such as `claude-mythos-5` the moment discovery started working. The second commit re-adds manifest models the live response omits, so discovery can only ever add models, never remove them. Discovered rows still win on shared ids, and the contract gate still hides unknown models whose advertised capabilities disagree with our request shaping.

That preservation is deliberately scoped to the Anthropic plugin. Merge-vs-replace in the shared SDK affects every provider and is a separate policy question; this PR does not change it.

## Evidence

**Live API, rosita's real subscription credential** — the two header shapes against `https://api.anthropic.com/v1/models`:

| Request | Result |
|---|---|
| `x-api-key` (previous behavior) | **401** `authentication_error: invalid x-api-key` |
| `Authorization: Bearer` (new behavior) | **200**, 11 models, `claude-opus-5` first |
| Bearer **and** `x-api-key` together | **401** — hence the mutual exclusion |

**End-to-end on a real gateway**, same machine and credential, `openclaw models list --provider anthropic --all`:

```
BEFORE (main)                        AFTER (this branch)
  claude-fable-5                       claude-fable-5
  claude-haiku-4-5                     claude-haiku-4-5
  claude-haiku-4-5-20251001            claude-haiku-4-5-20251001
  claude-mythos-5                      claude-mythos-5        <- preserved
  claude-opus-4-6                    + claude-opus-4-1-20250805
  claude-opus-4-7                    + claude-opus-4-5-20251101
  claude-opus-4-8                      claude-opus-4-6
  claude-opus-5                        claude-opus-4-7
  claude-sonnet-4-6                    claude-opus-4-8
  claude-sonnet-5                      claude-opus-5
                                     + claude-sonnet-4-5-20250929
                                       claude-sonnet-4-6
                                       claude-sonnet-5
```

Every model present before the change is still present after it, plus three new ones. The three added ids are published by `/v1/models` but appear in neither the shipped manifest nor local config, so they can only have come from live discovery. Before the fix, discovery contributed nothing at all.

**Sibling surfaces** — checked every other path that builds provider auth, to confirm this is not a one-sided fix:

- `extensions/openai/openai-provider.ts` discovery already sends `Authorization: Bearer`, which is correct for both API keys and OAuth, so it has never had this bug.
- `extensions/anthropic/usage.ts` resolves OAuth through its own `resolveOAuthToken()` branch; its `x-api-key` use is the separate admin-key path.
- `extensions/anthropic-vertex` registers no `modelDiscovery`, so there is nothing to fix there.

Anthropic discovery was the only `x-api-key`-only auth builder, and is the one this PR fixes.

**Tests** — `extensions/anthropic/live-discovery-auth.test.ts`, four cases driving the real discovery pipeline through the plugin's own `catalog.run` with only the SSRF fetch guard mocked: an API key still sends `x-api-key` and no `authorization`; an OAuth token sends `Bearer`; the OAuth request never carries `x-api-key`; and a live response that omits a shipped model still lists it while a capability-mismatched unknown id stays gated out.

Both fixes are verified as genuine regression guards by reverting them independently. Reverting the header builder fails the two OAuth cases (`expected null to be 'Bearer …'`, `expected 'sk-ant-oat01-…' to be null`) while the API-key case stays green, confirming no behavior change for API keys. Bypassing the preservation step fails the shipped-model case (`claude-mythos-5`: `expected false to be true`).

- `node scripts/run-vitest.mjs extensions/anthropic` — **247 passed** (13 files)
- `node scripts/run-vitest.mjs src/plugin-sdk/provider-catalog-live-runtime.test.ts src/plugins/provider-catalog.test.ts` — **30 passed**
- `pnpm check:test-types` clean; `oxfmt` + `run-oxlint.mjs extensions/anthropic` clean; `git diff --check` clean
- `$autoreview` (Codex `gpt-5.6-sol`, high): clean, no accepted/actionable findings — "patch is correct (0.99)"

ClawSweeper flagged the catalog-replacement consequence as P1 on the first head; the second commit resolves it rather than accepting it. Non-test diff is +51/−15. Follows #113757 and #113784; all three are stage-1 work under #113411.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
