### PR TITLE
fix(release): install package validation dependencies

### DIFF
--- a/.github/workflows/openclaw-cross-os-release-checks-reusable.yml
+++ b/.github/workflows/openclaw-cross-os-release-checks-reusable.yml
@@ -485,6 +485,13 @@ jobs:
       - name: Ensure pnpm store cache directory exists
         run: mkdir -p "$(pnpm store path --silent)"
 
+      - name: Install workflow validation dependencies
+        if: inputs.candidate_artifact_name != ''
+        working-directory: workflow
+        env:
+          CI: "true"
+        run: pnpm install --frozen-lockfile --prefer-offline --ignore-scripts
+
       - name: Build candidate artifact once
         if: inputs.candidate_artifact_name == ''
         env:

--- a/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
+++ b/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
@@ -1982,12 +1982,26 @@ jobs:
           echo "plan_json=$plan_path" >> "$GITHUB_OUTPUT"
 
       - name: Setup Node environment
-        if: steps.plan.outputs.needs_package == '1'
+        if: steps.plan.outputs.needs_package == '1' && inputs.package_artifact_name == '' && inputs.package_artifact_run_id == ''
         uses: ./.github/actions/setup-node-env
         with:
           node-version: ${{ env.NODE_VERSION }}
-          install-bun: ${{ inputs.package_artifact_name == '' && inputs.package_artifact_run_id == '' && 'true' || 'false' }}
-          install-deps: "true"
+          install-bun: "true"
+
+      - name: Setup artifact package validation environment
+        if: steps.plan.outputs.needs_package == '1' && inputs.package_artifact_id != ''
+        uses: ./.release-harness/.github/actions/setup-node-env
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          install-bun: "false"
+          install-deps: "false"
+          use-actions-cache: "false"
+
+      - name: Install trusted package validation dependencies
+        if: steps.plan.outputs.needs_package == '1' && inputs.package_artifact_id != ''
+        env:
+          CI: "true"
+        run: pnpm --dir .release-harness install --frozen-lockfile --prefer-offline --ignore-scripts
 
       - name: Validate OpenClaw package artifact identity
         id: input_package_artifact
@@ -2125,8 +2139,12 @@ jobs:
             cp "${tgzs[0]}" "$target"
           fi
           echo "Validating Docker E2E package tarball: $target"
+          validator="scripts/check-openclaw-package-tarball.mjs"
+          if [[ -n "${EXPECTED_PACKAGE_FILE_NAME// }" ]]; then
+            validator=".release-harness/scripts/check-openclaw-package-tarball.mjs"
+          fi
           started_at="$(date +%s)"
-          timeout --foreground 5m node scripts/check-openclaw-package-tarball.mjs "$target"
+          timeout --foreground 5m node "$validator" "$target"
           finished_at="$(date +%s)"
           echo "Docker E2E package tarball validation finished in $((finished_at - started_at))s."
           digest="$(sha256sum "$target" | awk '{print $1}')"

--- a/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
+++ b/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
@@ -1982,11 +1982,12 @@ jobs:
           echo "plan_json=$plan_path" >> "$GITHUB_OUTPUT"
 
       - name: Setup Node environment
-        if: steps.plan.outputs.needs_package == '1' && inputs.package_artifact_name == '' && inputs.package_artifact_run_id == ''
+        if: steps.plan.outputs.needs_package == '1'
         uses: ./.github/actions/setup-node-env
         with:
           node-version: ${{ env.NODE_VERSION }}
-          install-bun: "true"
+          install-bun: ${{ inputs.package_artifact_name == '' && inputs.package_artifact_run_id == '' && 'true' || 'false' }}
+          install-deps: "true"
 
       - name: Validate OpenClaw package artifact identity
         id: input_package_artifact

--- a/.github/workflows/package-acceptance.yml
+++ b/.github/workflows/package-acceptance.yml
@@ -466,7 +466,7 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           install-bun: ${{ inputs.source == 'ref' && 'true' || 'false' }}
-          install-deps: "false"
+          install-deps: "true"
 
       - name: Validate package artifact input identity
         id: input_artifact
@@ -780,6 +780,13 @@ jobs:
           ref: ${{ inputs.workflow_ref }}
           fetch-depth: 1
           persist-credentials: false
+
+      - name: Setup package validation dependencies
+        uses: ./.github/actions/setup-node-env
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          install-bun: "false"
+          install-deps: "true"
 
       - name: Download package-under-test artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8

--- a/test/scripts/openclaw-cross-os-release-workflow.test.ts
+++ b/test/scripts/openclaw-cross-os-release-workflow.test.ts
@@ -261,6 +261,10 @@ describe("cross-OS release checks workflow", () => {
     );
 
     const resolve = step(prepare, "Resolve provided candidate package");
+    expect(step(prepare, "Install workflow validation dependencies")).toMatchObject({
+      if: "inputs.candidate_artifact_name != ''",
+      run: "pnpm install --frozen-lockfile --prefer-offline --ignore-scripts",
+    });
     expect(resolve.run).toContain("resolve-openclaw-package-candidate.mjs");
     expect(resolve.run).toContain("--source artifact");
     expect(resolve.run).toContain('--package-sha256 "$INPUT_CANDIDATE_SHA256"');

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -1444,6 +1444,9 @@ describe("package acceptance workflow", () => {
 describe("package artifact reuse", () => {
   it("binds package acceptance input artifacts to the complete producer tuple", () => {
     const resolvePackage = workflowJob(PACKAGE_ACCEPTANCE_WORKFLOW, "resolve_package");
+    expect(workflowStep(resolvePackage, "Setup Node environment").with).toMatchObject({
+      "install-deps": "true",
+    });
     expect(
       workflowStep(resolvePackage, "Checkout package workflow ref").with?.["persist-credentials"],
     ).toBe(false);
@@ -1484,6 +1487,11 @@ describe("package artifact reuse", () => {
     ]);
 
     const packageIntegrity = workflowJob(PACKAGE_ACCEPTANCE_WORKFLOW, "package_integrity");
+    expect(
+      workflowStep(packageIntegrity, "Setup package validation dependencies").with,
+    ).toMatchObject({
+      "install-deps": "true",
+    });
     expect(
       workflowStep(packageIntegrity, "Download package-under-test artifact").with,
     ).toMatchObject({

--- a/test/scripts/release-no-push-workflow.test.ts
+++ b/test/scripts/release-no-push-workflow.test.ts
@@ -666,6 +666,12 @@ describe("release validation no-push transport", () => {
     );
     expect(packDockerArtifact.run).toContain("archive_sha256=");
     const validatePackage = step(dockerProducer, "Validate OpenClaw Docker E2E package");
+    expect(step(dockerProducer, "Setup Node environment")).toMatchObject({
+      if: "steps.plan.outputs.needs_package == '1'",
+      with: {
+        "install-deps": "true",
+      },
+    });
     expect(validatePackage.env).toMatchObject({
       EXPECTED_PACKAGE_FILE_NAME: "${{ inputs.package_file_name }}",
       EXPECTED_PACKAGE_SHA256: "${{ inputs.package_sha256 }}",

--- a/test/scripts/release-no-push-workflow.test.ts
+++ b/test/scripts/release-no-push-workflow.test.ts
@@ -666,11 +666,16 @@ describe("release validation no-push transport", () => {
     );
     expect(packDockerArtifact.run).toContain("archive_sha256=");
     const validatePackage = step(dockerProducer, "Validate OpenClaw Docker E2E package");
-    expect(step(dockerProducer, "Setup Node environment")).toMatchObject({
-      if: "steps.plan.outputs.needs_package == '1'",
+    expect(step(dockerProducer, "Setup artifact package validation environment")).toMatchObject({
+      if: "steps.plan.outputs.needs_package == '1' && inputs.package_artifact_id != ''",
       with: {
-        "install-deps": "true",
+        "install-deps": "false",
+        "use-actions-cache": "false",
       },
+    });
+    expect(step(dockerProducer, "Install trusted package validation dependencies")).toMatchObject({
+      if: "steps.plan.outputs.needs_package == '1' && inputs.package_artifact_id != ''",
+      run: "pnpm --dir .release-harness install --frozen-lockfile --prefer-offline --ignore-scripts",
     });
     expect(validatePackage.env).toMatchObject({
       EXPECTED_PACKAGE_FILE_NAME: "${{ inputs.package_file_name }}",
@@ -684,6 +689,9 @@ describe("release validation no-push transport", () => {
     );
     expect(validatePackage.run).toContain("package/dist/build-info.json");
     expect(validatePackage.run).toContain('[[ "$package_source_sha" == "$SELECTED_SHA" ]]');
+    expect(validatePackage.run).toContain(
+      'validator=".release-harness/scripts/check-openclaw-package-tarball.mjs"',
+    );
     const targetedRun = step(
       job(workflow, "validate_docker_lanes"),
       "Run targeted Docker E2E lanes",


### PR DESCRIPTION
## What Problem This Solves

Resolves a release blocker where artifact-backed Plugin Prerelease, Package Acceptance, and cross-OS validation jobs fail before testing the candidate because the trusted package validator cannot resolve its pinned TypeScript parser dependency.

## Why This Change Was Made

Keep the syntax-aware package closure validator unchanged and install the trusted workflow checkout's pinned dependencies in every artifact-consumer job that executes it. This preserves parser correctness and avoids replacing the AST validator with a partial JavaScript scanner.

## User Impact

No product runtime behavior changes. Release managers regain deterministic package, Docker, and cross-OS validation for prebuilt release artifacts.

## Evidence

- Failure reproduced in Full Release Validation parent 30176826664 through Plugin Prerelease 30177911845 and Release Checks 30177910208: each artifact consumer failed with `ERR_MODULE_NOT_FOUND` for `typescript` before candidate tests ran.
- `node scripts/run-vitest.mjs test/scripts/release-no-push-workflow.test.ts test/scripts/openclaw-cross-os-release-workflow.test.ts test/scripts/package-acceptance-workflow.test.ts` — 111 tests passed.
- `pnpm check:workflows` — passed, including zizmor and composite-input checks.
- `git diff --check` — passed.
- Autoreview — clean, no accepted/actionable findings.

AI-assisted: yes.
