### PR TITLE
fix(ui): render close icon in image lightbox header

### DIFF
--- a/ui/src/components/image-lightbox.ts
+++ b/ui/src/components/image-lightbox.ts
@@ -127,6 +127,13 @@ class OpenClawImageLightbox extends OpenClawLitElement {
     .close svg {
       width: 17px;
       height: 17px;
+      /* Shadow DOM: global icon stroke rules don't reach in here; without a
+         stroke the open-path x icon renders invisible. */
+      fill: none;
+      stroke: currentColor;
+      stroke-width: 2;
+      stroke-linecap: round;
+      stroke-linejoin: round;
     }
 
     .stage {


### PR DESCRIPTION
## What Problem This Solves

The image lightbox (opened from chat images in the Control UI) rendered its close button as an empty pill — the X icon was invisible.

## Why This Change Was Made

`openclaw-image-lightbox` is a shadow-DOM Lit component, so the global icon rules in `ui/src/styles/components.css` (`fill: none; stroke: currentColor`) never reach its SVG. The shared `icons.x` template is a pair of open paths with no inline stroke attributes; without a stroke they paint nothing. The fix adds the standard icon stroke properties to the component's own `.close svg` rule, matching the sibling pattern in `ui/src/components/file-preview-modal.ts`.

## User Impact

The lightbox close button shows its X icon again.

Before | After
--- | ---
![before](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/image-lightbox-close-icon/before.png) | ![after](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/image-lightbox-close-icon/after.png)

## Evidence

- Screenshots above captured via `pnpm dev:ui:mock` + Playwright (chromium), before/after the CSS change.
- `node scripts/run-vitest.mjs ui/src/components/image-lightbox.test.ts` — 6/6 pass.
- `oxlint` + `oxfmt --check` clean on the changed file.
- Codex autoreview (`--mode uncommitted`, gpt-5.6-sol): clean, no findings.
