### PR TITLE
test(ui): restore current Control UI browser flows

### DIFF
--- a/ui/src/e2e/build-info-unicode.e2e.test.ts
+++ b/ui/src/e2e/build-info-unicode.e2e.test.ts
@@ -47,9 +47,12 @@ function containsBrokenSurrogate(value: string): boolean {
 }
 
 async function openBuildDetails(page: Page) {
-  const buildLink = page
-    .locator("openclaw-app-sidebar")
-    .getByRole("link", { name: "Control UI build details", exact: true });
+  const sidebar = page.locator("openclaw-app-sidebar");
+  await sidebar.locator(".sidebar-identity-card").click();
+  const buildLink = sidebar.getByRole("link", {
+    name: "Control UI build details",
+    exact: true,
+  });
   await buildLink.waitFor();
   const compactText = (await buildLink.textContent()) ?? "";
   expect(compactText).toContain(`${COMPACT_BRANCH}@0123456`);

--- a/ui/src/e2e/chat-flow.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.e2e.test.ts
@@ -2721,6 +2721,12 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
         message: queuedPrompt,
         sessionKey: "main",
       });
+      await queue.getByText("Steered").waitFor({ timeout: 10_000 });
+      await gateway.emitChatFinal({
+        runId: String(requireRecord(steerRequest.params).idempotencyKey),
+        sessionKey: "main",
+        text: "The restored queued message was steered.",
+      });
       await queue.getByText(queuedPrompt).waitFor({ state: "detached", timeout: 10_000 });
     } finally {
       await closeBrowserContext(context);
@@ -3691,7 +3697,7 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
           timeout: 10_000,
         });
       await expect.poll(() => sidebarSessionOrder(page)).toEqual(createdOrder.slice(0, 11));
-      await page.getByRole("button", { name: "Load more" }).click();
+      await page.getByRole("button", { name: "Show more" }).click();
       await expect.poll(() => sidebarSessionOrder(page)).toEqual(createdOrder);
 
       await page


### PR DESCRIPTION
## What Problem This Solves

Resolves three stale Control UI end-to-end expectations independently reproduced in real Chromium: build metadata now lives inside the identity menu, the translated session pagination action is “Show more,” and an acknowledged steer remains visible until its matching terminal Gateway event. These are intentionally changed product contracts, not three user-facing product defects.

## Why This Change Was Made

Update only the two affected browser tests to exercise the canonical visible identity-menu interaction, the actual English accessible name, and the real acknowledgement-to-final steering lifecycle. No production, config, baseline, owner, snapshot, or Gateway code changes.

## User Impact

No user-visible behavior change. Maintainers regain reliable real-browser coverage of Unicode build details, authenticated chat, pagination, session ordering, steering, reconnection, and interactive terminal rendering.

## Evidence

- Before: actual Chromium on the current unchanged owner surfaces reproduced 57 passing and 3 failing tests.
- After: actual system Chromium against source revision `9defe24ec2fdcedb3be2e88825328c89c24d9999`, Linux Node 24.18.0: **4 browser files, 60/60 tests passing**, including all three previous failures.
- Browser screenshot was generated and independently verified as nonempty (27,009 bytes); proof artifacts are not committed.
- Terminal and Gateway focused checks: **57/57 passing** and **4 concurrent isolated terminal-resize worker processes, 0 failures**.
- Genuine local/Gateway PTY acceptance: **43/43 passing**, including real Gateway reconnect, streamed follow-ups, cancellation, and the previously landed Ctrl+D regressions.
- Formatting: both modified files clean; `git show --check` clean.
- Fresh structured independent Codex high-reasoning autoreview: **no accepted/actionable findings**.
- Blacksmith Testbox authoritative complete run: `tbx_01kydtrmc7c2qpzht60cp8ntfh`, `exitCode=0`.
- Exactly **2 test files**; no product-bug count or QA campaign ledger increment.
- AI-assisted; all source, browser, PTY, concurrency, and review evidence was independently inspected.

Browser command:

```sh
OPENCLAW_CAPTURE_UI_PROOF=1   OPENCLAW_TERMINAL_REPAINT_SCREENSHOT=.artifacts/control-ui-e2e/autoqa-ui-current-9defe24/terminal-repaint.png   node scripts/run-vitest.mjs run   --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner   ui/src/e2e/build-info-unicode.e2e.test.ts   ui/src/e2e/chat-flow.e2e.test.ts   ui/src/e2e/plan-replay-reconnect.e2e.test.ts   ui/src/e2e/terminal-repaint.e2e.test.ts
```
