### PR TITLE
fix(mcp): reconnect a bundled MCP server instead of wedging on it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- **Bundled MCP server recovery:** a bundled MCP server whose transport closes, or which stops responding, now reconnects on the next request instead of failing every later request until the runtime is evicted or the gateway restarts. Servers that merely answer with errors keep the existing failure cooldown.
 - **Control UI cloud workspace conflicts:** surface staged-ref guidance, bounded conflicted paths, structured transcript events, and sidebar attention for cloud worker results that kept local versions.
 - **Control UI update recovery:** the "A new version is available" Reload button now waits out the gateway restart that stranded the chunk and reloads as soon as it answers, instead of silently doing nothing and leaving a manual hard reload as the only way out.
 - **Control UI sender identity polish:** attributed user messages show the author's real avatar in an always-visible gutter on identity-resolving gateways, sender labels drop the opaque profile-UUID suffix (new and historical transcripts), and profile-id senders resolve avatars through the canonical gateway route.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
-- **Bundled MCP server recovery:** a bundled MCP server whose transport closes, or which stops responding, now reconnects on the next request instead of failing every later request until the runtime is evicted or the gateway restarts. Servers that merely answer with errors keep the existing failure cooldown.
 - **Control UI cloud workspace conflicts:** surface staged-ref guidance, bounded conflicted paths, structured transcript events, and sidebar attention for cloud worker results that kept local versions.
 - **Control UI update recovery:** the "A new version is available" Reload button now waits out the gateway restart that stranded the chunk and reloads as soon as it answers, instead of silently doing nothing and leaving a manual hard reload as the only way out.
 - **Control UI sender identity polish:** attributed user messages show the author's real avatar in an always-visible gutter on identity-resolving gateways, sender labels drop the opaque profile-UUID suffix (new and historical transcripts), and profile-id senders resolve avatars through the canonical gateway route.

--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -322,27 +322,46 @@ async function waitForPredicate(
   throw new Error(`Timed out waiting for ${description}`);
 }
 
-async function waitForErrorMessage(
-  action: () => Promise<unknown>,
-  expectedText: string,
-  timeoutMs: number,
-): Promise<string> {
+/** Retries an action until it stops throwing — for behavior that recovers asynchronously. */
+async function waitForRecovery(action: () => Promise<unknown>, timeoutMs: number): Promise<void> {
   const deadline = Date.now() + timeoutMs;
-  let lastMessage = "";
+  let lastError: unknown;
   while (Date.now() < deadline) {
     try {
       await action();
+      return;
     } catch (error) {
-      lastMessage = error instanceof Error ? error.message : String(error);
-      if (lastMessage.includes(expectedText)) {
-        return lastMessage;
-      }
+      lastError = error;
+      await new Promise((resolve) => {
+        setTimeout(resolve, 10);
+      });
+    }
+  }
+  throw new Error(
+    `Timed out waiting for the runtime to recover; last error: ${
+      lastError instanceof Error ? lastError.message : String(lastError)
+    }`,
+  );
+}
+
+/** Waits for a replacement child to register a pid different from the one that died. */
+async function waitForChangedPid(
+  pidPath: string,
+  previousPid: number,
+  timeoutMs: number,
+): Promise<number> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const raw = await fs.readFile(pidPath, "utf8").catch(() => "");
+    const pid = Number.parseInt(raw.trim(), 10);
+    if (Number.isFinite(pid) && pid !== previousPid) {
+      return pid;
     }
     await new Promise((resolve) => {
       setTimeout(resolve, 10);
     });
   }
-  throw new Error(`Timed out waiting for ${expectedText}; saw ${JSON.stringify(lastMessage)}`);
+  throw new Error(`Timed out waiting for a replacement child pid (still ${previousPid})`);
 }
 
 function makeRuntime(
@@ -1460,7 +1479,7 @@ process.on("SIGINT", shutdown);`,
     }
   });
 
-  it("fails fast with an attributable error after an MCP child process exits", async () => {
+  it("reconnects on the next request after an MCP child process exits", async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "bundle-mcp-child-exit-"));
     const serverPath = path.join(tempDir, "server.mjs");
     const logPath = path.join(tempDir, "server.log");
@@ -1486,14 +1505,29 @@ process.on("SIGINT", shutdown);`,
       });
       await waitForFileText(pidPath, "", LIST_TOOLS_SERVER_LOG_TIMEOUT_MS);
       const pid = Number.parseInt((await fs.readFile(pidPath, "utf8")).trim(), 10);
-      process.kill(pid);
+      // SIGKILL rather than the default SIGTERM: this test is about what happens once the
+      // child is actually gone, so the kill must not race the assertions below.
+      process.kill(pid, "SIGKILL");
 
-      const message = await waitForErrorMessage(
+      // The close invalidates the catalog, so the runtime rebuilds it and starts a
+      // replacement child. Previously the dead session stayed cached behind a memoized
+      // catalog and every later request failed with "is disconnected" until the runtime
+      // was evicted or the process restarted.
+      //
+      // Polled rather than asserted on the immediate next call: a request already in
+      // flight when the transport closes still fails ("Connection closed"), and that is
+      // correct. The guarantee is that the runtime recovers on its own, promptly — not
+      // that one specific call wins the race with the close propagating.
+      await waitForRecovery(
         () => runtime.callTool("child", "slow_tool", {}),
-        "is disconnected",
         LIST_TOOLS_SERVER_LOG_TIMEOUT_MS,
       );
-      expect(message).toBe('bundle-mcp server "child" is disconnected: mcp transport closed');
+      const replacementPid = await waitForChangedPid(
+        pidPath,
+        pid,
+        LIST_TOOLS_SERVER_LOG_TIMEOUT_MS,
+      );
+      expect(replacementPid).not.toBe(pid);
     } finally {
       await runtime.dispose();
       await fs.rm(tempDir, { recursive: true, force: true });
@@ -1537,9 +1571,12 @@ process.on("SIGINT", shutdown);`,
       const refreshedCatalog = await runtime.getCatalog();
       expect(refreshedCatalog.tools).toEqual([]);
       expect(refreshedCatalog.diagnostics?.[0]?.serverName).toBe("child");
-      await expect(runtime.callTool("child", "slow_tool", {})).rejects.toThrow(
-        'bundle-mcp server "child" is not connected',
-      );
+      // The refresh reports the exited server, but the runtime does not stay stuck on it:
+      // the closed transport invalidated the catalog, so the next request rebuilds against
+      // a fresh child instead of failing with "is not connected" indefinitely.
+      await expect(runtime.callTool("child", "slow_tool", {})).resolves.toMatchObject({
+        isError: false,
+      });
     } finally {
       await runtime.dispose();
       await fs.rm(tempDir, { recursive: true, force: true });

--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -1862,7 +1862,7 @@ process.on("SIGINT", shutdown);`,
   });
 
   it("does not recycle a responsive server that returns JSON-RPC code -32001", async () => {
-    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "bundle-mcp-remote-timeout-code-"));
+    const tempDir = tempDirTracker.make("bundle-mcp-remote-timeout-code-");
     const serverPath = path.join(tempDir, "remote-timeout-code.mjs");
     const logPath = path.join(tempDir, "server.log");
     const pidPath = path.join(tempDir, "server.pid");
@@ -1907,7 +1907,7 @@ process.on("SIGINT", shutdown);`,
   });
 
   it("recycles an MCP server after repeated request timeouts", async () => {
-    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "bundle-mcp-timeout-recycle-"));
+    const tempDir = tempDirTracker.make("bundle-mcp-timeout-recycle-");
     const serverPath = path.join(tempDir, "timeout-recycle.mjs");
     const logPath = path.join(tempDir, "server.log");
     const pidPath = path.join(tempDir, "server.pid");
@@ -1970,7 +1970,7 @@ process.on("SIGINT", shutdown);`,
   });
 
   it("gives each paginated resource request its own timeout", async () => {
-    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "bundle-mcp-resource-pages-"));
+    const tempDir = tempDirTracker.make("bundle-mcp-resource-pages-");
     const serverPath = path.join(tempDir, "resource-pages.mjs");
     const logPath = path.join(tempDir, "server.log");
     await writeListToolsMcpServer({

--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -62,6 +62,7 @@ async function writeListToolsMcpServer(params: {
   capabilities?: Record<string, unknown>;
   databasePath?: string;
   pidPath?: string;
+  hangToolCallsUntilRestartMarkerPath?: string;
   notifyListChangedOnInitialized?: boolean;
   notifyListChangedAfterFirstList?: boolean;
   exitOnListCall?: number;
@@ -69,6 +70,9 @@ async function writeListToolsMcpServer(params: {
   listToolsJsonRpcErrorMessage?: string;
   callToolIsError?: boolean;
   callToolJsonRpcError?: boolean;
+  callToolJsonRpcErrorCode?: number;
+  resourcePageDelayMs?: number;
+  resourcePageCount?: number;
   resourceListJsonRpcError?: boolean;
   resourceReadJsonRpcError?: boolean;
 }): Promise<void> {
@@ -84,6 +88,9 @@ const hang = ${params.hang === true};
 const capabilities = ${JSON.stringify(params.capabilities ?? { tools: {} })};
 const databasePath = ${JSON.stringify(params.databasePath)};
 const pidPath = ${JSON.stringify(params.pidPath)};
+const hangToolCallsUntilRestartMarkerPath = ${JSON.stringify(
+      params.hangToolCallsUntilRestartMarkerPath,
+    )};
 const notifyListChangedOnInitialized = ${params.notifyListChangedOnInitialized === true};
 const notifyListChangedAfterFirstList = ${params.notifyListChangedAfterFirstList === true};
 const exitOnListCall = ${params.exitOnListCall ?? 0};
@@ -100,14 +107,19 @@ const tools = ${JSON.stringify(
     )};
 const callToolIsError = ${params.callToolIsError === true};
 const callToolJsonRpcError = ${params.callToolJsonRpcError === true};
+const callToolJsonRpcErrorCode = ${params.callToolJsonRpcErrorCode ?? -32000};
+const resourcePageDelayMs = ${params.resourcePageDelayMs ?? 0};
+const resourcePageCount = ${params.resourcePageCount ?? 1};
 const resourceListJsonRpcError = ${params.resourceListJsonRpcError === true};
 const resourceReadJsonRpcError = ${params.resourceReadJsonRpcError === true};
 
 let buffer = "";
 let listCount = 0;
+let resourceListCount = 0;
 let pendingTimer;
 let keepAlive;
 let database;
+let hangToolCallsUntilRestart = false;
 if (databasePath) {
   const { DatabaseSync } = await import("node:sqlite");
   database = new DatabaseSync(databasePath);
@@ -115,6 +127,15 @@ if (databasePath) {
 }
 if (pidPath) {
   await fs.writeFile(pidPath, String(process.pid), "utf8");
+}
+if (hangToolCallsUntilRestartMarkerPath) {
+  hangToolCallsUntilRestart = !(await fs
+    .access(hangToolCallsUntilRestartMarkerPath)
+    .then(() => true)
+    .catch(() => false));
+  if (hangToolCallsUntilRestart) {
+    await fs.writeFile(hangToolCallsUntilRestartMarkerPath, String(process.pid), "utf8");
+  }
 }
 function log(line) {
   void fs.appendFile(logPath, line + "\\n", "utf8").catch(() => {});
@@ -197,11 +218,16 @@ function handle(message) {
     }, delayMs);
   }
   if (message.method === "tools/call") {
+    if (hangToolCallsUntilRestart) {
+      log("hang tools/call");
+      keepAlive = setInterval(() => {}, 1000);
+      return;
+    }
     if (callToolJsonRpcError) {
       send({
         jsonrpc: "2.0",
         id: message.id,
-        error: { code: -32000, message: "tool request failed" },
+        error: { code: callToolJsonRpcErrorCode, message: "tool request failed" },
       });
       return;
     }
@@ -215,6 +241,7 @@ function handle(message) {
     });
   }
   if (message.method === "resources/list") {
+    resourceListCount += 1;
     if (resourceListJsonRpcError) {
       send({
         jsonrpc: "2.0",
@@ -223,11 +250,18 @@ function handle(message) {
       });
       return;
     }
-    send({
-      jsonrpc: "2.0",
-      id: message.id,
-      result: { resources: [] },
-    });
+    setTimeout(() => {
+      send({
+        jsonrpc: "2.0",
+        id: message.id,
+        result: {
+          resources: [],
+          ...(resourceListCount < resourcePageCount
+            ? { nextCursor: String(resourceListCount) }
+            : {}),
+        },
+      });
+    }, resourcePageDelayMs);
     return;
   }
   if (message.method === "resources/read") {
@@ -306,13 +340,13 @@ async function waitForFileText(
 }
 
 async function waitForPredicate(
-  predicate: () => boolean,
+  predicate: () => boolean | Promise<boolean>,
   description: string,
   timeoutMs: number,
 ): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
-    if (predicate()) {
+    if (await predicate()) {
       return;
     }
     await new Promise((resolve) => {
@@ -320,28 +354,6 @@ async function waitForPredicate(
     });
   }
   throw new Error(`Timed out waiting for ${description}`);
-}
-
-/** Retries an action until it stops throwing — for behavior that recovers asynchronously. */
-async function waitForRecovery(action: () => Promise<unknown>, timeoutMs: number): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  let lastError: unknown;
-  while (Date.now() < deadline) {
-    try {
-      await action();
-      return;
-    } catch (error) {
-      lastError = error;
-      await new Promise((resolve) => {
-        setTimeout(resolve, 10);
-      });
-    }
-  }
-  throw new Error(
-    `Timed out waiting for the runtime to recover; last error: ${
-      lastError instanceof Error ? lastError.message : String(lastError)
-    }`,
-  );
 }
 
 /** Waits for a replacement child to register a pid different from the one that died. */
@@ -1479,12 +1491,20 @@ process.on("SIGINT", shutdown);`,
     }
   });
 
-  it("reconnects on the next request after an MCP child process exits", async () => {
+  it("reconnects after an MCP child process exits", async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "bundle-mcp-child-exit-"));
     const serverPath = path.join(tempDir, "server.mjs");
     const logPath = path.join(tempDir, "server.log");
     const pidPath = path.join(tempDir, "server.pid");
-    await writeListToolsMcpServer({ filePath: serverPath, logPath, pidPath });
+    const healthyServerPath = path.join(tempDir, "healthy.mjs");
+    const healthyLogPath = path.join(tempDir, "healthy.log");
+    await writeListToolsMcpServer({
+      filePath: serverPath,
+      logPath,
+      pidPath,
+      initializeDelayMs: 750,
+    });
+    await writeListToolsMcpServer({ filePath: healthyServerPath, logPath: healthyLogPath });
 
     const runtime = await getOrCreateSessionMcpRuntime({
       sessionId: "session-child-exit",
@@ -1494,6 +1514,7 @@ process.on("SIGINT", shutdown);`,
         mcp: {
           servers: {
             child: { command: process.execPath, args: [serverPath] },
+            healthy: { command: process.execPath, args: [healthyServerPath] },
           },
         },
       },
@@ -1509,17 +1530,29 @@ process.on("SIGINT", shutdown);`,
       // child is actually gone, so the kill must not race the assertions below.
       process.kill(pid, "SIGKILL");
 
-      // The close invalidates the catalog, so the runtime rebuilds it and starts a
-      // replacement child. Previously the dead session stayed cached behind a memoized
-      // catalog and every later request failed with "is disconnected" until the runtime
-      // was evicted or the process restarted.
-      //
-      // Polled rather than asserted on the immediate next call: a request already in
-      // flight when the transport closes still fails ("Connection closed"), and that is
-      // correct. The guarantee is that the runtime recovers on its own, promptly — not
-      // that one specific call wins the race with the close propagating.
-      await waitForRecovery(
-        () => runtime.callTool("child", "slow_tool", {}),
+      await waitForPredicate(
+        () =>
+          runtime.peekCatalog()?.diagnostics?.some((entry) => entry.serverName === "child") ===
+          true,
+        "closed transport to schedule a catalog retry",
+        LIST_TOOLS_SERVER_LOG_TIMEOUT_MS,
+      );
+      await expect(
+        withTestTimeout(
+          runtime.callTool("healthy", "slow_tool", {}),
+          400,
+          "healthy sibling stalled during reconnect",
+        ),
+      ).resolves.toMatchObject({ isError: false });
+      await waitForPredicate(
+        async () => {
+          try {
+            return (await runtime.callTool("child", "slow_tool", {})).isError === false;
+          } catch {
+            return false;
+          }
+        },
+        "child server to reconnect",
         LIST_TOOLS_SERVER_LOG_TIMEOUT_MS,
       );
       const replacementPid = await waitForChangedPid(
@@ -1822,6 +1855,155 @@ process.on("SIGINT", shutdown);`,
       await expect(runtime.callTool("failing", "slow_tool", {})).rejects.toThrow(
         'bundle-mcp server "failing" is paused after repeated tool failures',
       );
+    } finally {
+      await runtime.dispose();
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not recycle a responsive server that returns JSON-RPC code -32001", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "bundle-mcp-remote-timeout-code-"));
+    const serverPath = path.join(tempDir, "remote-timeout-code.mjs");
+    const logPath = path.join(tempDir, "server.log");
+    const pidPath = path.join(tempDir, "server.pid");
+    await writeListToolsMcpServer({
+      filePath: serverPath,
+      logPath,
+      pidPath,
+      callToolJsonRpcError: true,
+      callToolJsonRpcErrorCode: -32001,
+    });
+
+    const runtime = await getOrCreateSessionMcpRuntime({
+      sessionId: "session-remote-timeout-code",
+      sessionKey: "agent:test:session-remote-timeout-code",
+      workspaceDir: "/workspace",
+      cfg: {
+        mcp: {
+          servers: {
+            responsive: { command: process.execPath, args: [serverPath] },
+          },
+        },
+      },
+    });
+
+    try {
+      await runtime.getCatalog();
+      const pid = Number.parseInt((await fs.readFile(pidPath, "utf8")).trim(), 10);
+      for (let attempt = 0; attempt < 3; attempt += 1) {
+        await expect(runtime.callTool("responsive", "slow_tool", {})).rejects.toThrow(
+          "tool request failed",
+        );
+      }
+      await expect(runtime.callTool("responsive", "slow_tool", {})).rejects.toThrow(
+        'bundle-mcp server "responsive" is paused after repeated tool failures',
+      );
+      expect(Number.parseInt((await fs.readFile(pidPath, "utf8")).trim(), 10)).toBe(pid);
+      expect(runtime.peekCatalog()?.diagnostics).toBeUndefined();
+    } finally {
+      await runtime.dispose();
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("recycles an MCP server after repeated request timeouts", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "bundle-mcp-timeout-recycle-"));
+    const serverPath = path.join(tempDir, "timeout-recycle.mjs");
+    const logPath = path.join(tempDir, "server.log");
+    const pidPath = path.join(tempDir, "server.pid");
+    const markerPath = path.join(tempDir, "first-server.marker");
+    await writeListToolsMcpServer({
+      filePath: serverPath,
+      logPath,
+      pidPath,
+      hangToolCallsUntilRestartMarkerPath: markerPath,
+    });
+
+    const runtime = await getOrCreateSessionMcpRuntime({
+      sessionId: "session-timeout-recycle",
+      sessionKey: "agent:test:session-timeout-recycle",
+      workspaceDir: "/workspace",
+      cfg: {
+        mcp: {
+          servers: {
+            hanging: {
+              command: process.execPath,
+              args: [serverPath],
+              requestTimeoutMs: 25,
+            },
+          },
+        },
+      },
+    });
+
+    try {
+      expect((await runtime.getCatalog()).tools).toHaveLength(1);
+      await waitForFileText(pidPath, "", LIST_TOOLS_SERVER_LOG_TIMEOUT_MS);
+      const pid = Number.parseInt((await fs.readFile(pidPath, "utf8")).trim(), 10);
+
+      const results = await Promise.allSettled(
+        Array.from({ length: 6 }, () => runtime.callTool("hanging", "slow_tool", {})),
+      );
+      expect(results.every((result) => result.status === "rejected")).toBe(true);
+      expect(
+        results.filter(
+          (result) =>
+            result.status === "rejected" && String(result.reason).includes("Request timed out"),
+        ).length,
+      ).toBeGreaterThanOrEqual(3);
+      await waitForPredicate(
+        async () => {
+          try {
+            return (await runtime.callTool("hanging", "slow_tool", {})).isError === false;
+          } catch {
+            return false;
+          }
+        },
+        "timed-out server to recover without stale backoff",
+        LIST_TOOLS_SERVER_LOG_TIMEOUT_MS,
+      );
+      expect(await waitForChangedPid(pidPath, pid, LIST_TOOLS_SERVER_LOG_TIMEOUT_MS)).not.toBe(pid);
+    } finally {
+      await runtime.dispose();
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("gives each paginated resource request its own timeout", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "bundle-mcp-resource-pages-"));
+    const serverPath = path.join(tempDir, "resource-pages.mjs");
+    const logPath = path.join(tempDir, "server.log");
+    await writeListToolsMcpServer({
+      filePath: serverPath,
+      logPath,
+      capabilities: { resources: {} },
+      listToolsMethodNotFound: true,
+      resourcePageDelayMs: 100,
+      resourcePageCount: 2,
+    });
+
+    const runtime = await getOrCreateSessionMcpRuntime({
+      sessionId: "session-resource-pages",
+      sessionKey: "agent:test:session-resource-pages",
+      workspaceDir: "/workspace",
+      cfg: {
+        mcp: {
+          servers: {
+            paged: {
+              command: process.execPath,
+              args: [serverPath],
+              requestTimeoutMs: 150,
+            },
+          },
+        },
+      },
+    });
+
+    try {
+      if (!runtime.listResources) {
+        throw new Error("Expected test runtime to expose resource utilities");
+      }
+      await expect(runtime.listResources("paged")).resolves.toEqual([]);
     } finally {
       await runtime.dispose();
       await fs.rm(tempDir, { recursive: true, force: true });

--- a/src/agents/agent-bundle-mcp-runtime.ts
+++ b/src/agents/agent-bundle-mcp-runtime.ts
@@ -455,6 +455,19 @@ export function createSessionMcpRuntime(params: {
     } catch (error) {
       if (tracksFailureBackoff) {
         recordServerToolFailure(serverName, nowMs);
+        // At the threshold, replace the transport rather than parking it — but only when
+        // the server has stopped responding. Parking is the right answer for a server that
+        // is answering with errors. Clearing the backoff entry is part of recycling: the
+        // replacement must not inherit the failure count of the transport it replaces, or
+        // the first request after recycling is refused by a cooldown that belongs to a
+        // process which no longer exists.
+        if (
+          (serverBackoff.get(serverName)?.failures ?? 0) >= BUNDLE_MCP_FAILURE_THRESHOLD &&
+          isUnresponsiveServerFailure(serverName, error)
+        ) {
+          serverBackoff.delete(serverName);
+          recycleServer(serverName, "repeated request failures");
+        }
       }
       throw error;
     }
@@ -510,6 +523,43 @@ export function createSessionMcpRuntime(params: {
     sessions.delete(serverName);
     await disposeSession(session);
     return true;
+  };
+  /**
+   * Tear down one server's transport and invalidate the catalog so the next request
+   * rebuilds it. Used when a server keeps failing: the cooldown alone only delays the
+   * next attempt against the same, still-broken transport, so a server that stops
+   * responding never recovers on its own.
+   *
+   * Best-effort and fire-and-forget — the caller is already throwing, and the
+   * reconnect belongs to the next request rather than to the failing one.
+   */
+  /**
+   * Distinguishes "this server stopped responding" from "this server answered, with an
+   * error". Only the former warrants replacing the transport: a server that returns
+   * JSON-RPC errors is healthy and reachable, and recycling it would throw away a working
+   * connection because a tool was called with bad arguments or its backend is down.
+   */
+  const isUnresponsiveServerFailure = (serverName: string, error: unknown): boolean => {
+    if (isMcpConfigRecord(error) && error.code === ErrorCode.RequestTimeout) {
+      return true;
+    }
+    return sessions.get(serverName)?.connected === false;
+  };
+  const recycleServer = (serverName: string, reason: string) => {
+    const session = sessions.get(serverName);
+    if (disposed || !session || session.retiring) {
+      return;
+    }
+    catalogInvalidationGeneration += 1;
+    catalog = null;
+    catalogRetryAfterMs = undefined;
+    catalogInFlight = undefined;
+    logWarn(`bundle-mcp: recycling server "${serverName}" (${reason}); next request reconnects`);
+    void retireSessionIfCurrent(serverName, session).catch((error: unknown) => {
+      logWarn(
+        `bundle-mcp: failed to retire server "${serverName}" while recycling: ${redactMcpDiagnosticError(error)}`,
+      );
+    });
   };
 
   const loadCatalog = async (retryBaseCatalog?: McpToolCatalog): Promise<McpToolCatalog> => {
@@ -666,8 +716,36 @@ export function createSessionMcpRuntime(params: {
                 // terminal for this client/transport pair.
                 // oxlint-disable-next-line unicorn/prefer-add-event-listener -- MCP Client is not an EventTarget.
                 client.onclose = () => {
+                  const wasConnected = createdSession.connected;
                   createdSession.connected = false;
                   createdSession.disconnectReason = "mcp transport closed";
+                  // Terminal for this pair, but NOT for the server: invalidate the catalog so
+                  // the next request rebuilds and reconnects. Without this the dead session
+                  // stays cached behind a memoized catalog, so every later request fails
+                  // `requireConnectedSession` indefinitely — the server only ever comes back
+                  // via idle eviction, a config-fingerprint change, or a restart.
+                  //
+                  // Deliberately not deleting from `sessions` here: the catalog rebuild retires
+                  // a disconnected session through `disposeSession`, and dropping the entry
+                  // directly would skip that teardown.
+                  //
+                  // Only an ESTABLISHED connection that was lost is interesting. A transport
+                  // that closes while still connecting is the startup-failure path, which the
+                  // catalog builder already handles — invalidating there would discard the
+                  // in-flight build (generation mismatch) and spin up a rebuild loop.
+                  if (!wasConnected || disposed || createdSession.retiring) {
+                    return;
+                  }
+                  if (sessions.get(serverName) !== createdSession) {
+                    return;
+                  }
+                  catalogInvalidationGeneration += 1;
+                  catalog = null;
+                  catalogRetryAfterMs = undefined;
+                  catalogInFlight = undefined;
+                  logWarn(
+                    `bundle-mcp: server "${serverName}" transport closed; catalog invalidated so the next request reconnects`,
+                  );
                 };
                 session = createdSession;
                 sessions.set(serverName, session);

--- a/src/agents/agent-bundle-mcp-runtime.ts
+++ b/src/agents/agent-bundle-mcp-runtime.ts
@@ -4,6 +4,7 @@ import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import {
   ErrorCode,
+  McpError,
   type CallToolResult,
   type ClientCapabilities,
 } from "@modelcontextprotocol/sdk/types.js";
@@ -105,6 +106,7 @@ type McpToolSelection = {
 };
 
 type McpServerBackoffState = {
+  session: BundleMcpSession;
   failures: number;
   retryAfterMs?: number;
 };
@@ -252,24 +254,26 @@ function buildMcpClientOptions(mcpAppsEnabled: boolean): ClientOptions {
   return { capabilities: buildMcpClientCapabilities(mcpAppsEnabled) };
 }
 
-async function listAllResources(client: Client, timeoutMs: number) {
+async function listAllResources(
+  loadPage: (cursor: string | undefined) => ReturnType<Client["listResources"]>,
+) {
   const resources: unknown[] = [];
   let cursor: string | undefined;
   do {
-    const params = cursor ? { cursor } : undefined;
-    const page = await client.listResources(params, { timeout: timeoutMs });
+    const page = await loadPage(cursor);
     resources.push(...page.resources);
     cursor = page.nextCursor;
   } while (cursor);
   return resources;
 }
 
-async function listAllPrompts(client: Client, timeoutMs: number) {
+async function listAllPrompts(
+  loadPage: (cursor: string | undefined) => ReturnType<Client["listPrompts"]>,
+) {
   const prompts: unknown[] = [];
   let cursor: string | undefined;
   do {
-    const params = cursor ? { cursor } : undefined;
-    const page = await client.listPrompts(params, { timeout: timeoutMs });
+    const page = await loadPage(cursor);
     prompts.push(...page.prompts);
     cursor = page.nextCursor;
   } while (cursor);
@@ -420,57 +424,61 @@ export function createSessionMcpRuntime(params: {
   let catalogRetryAfterMs: number | undefined;
   let catalogInFlight: Promise<McpToolCatalog> | undefined;
   let catalogInvalidationGeneration = 0;
+  const invalidateCatalog = () => {
+    catalogInvalidationGeneration += 1;
+    catalog = null;
+    catalogRetryAfterMs = undefined;
+    catalogInFlight = undefined;
+  };
+  const scheduleCatalogServerRetry = (serverName: string, message: string) => {
+    const currentCatalog = catalog;
+    const server = currentCatalog?.servers[serverName];
+    const existing = currentCatalog?.diagnostics?.find(
+      (diagnostic) => diagnostic.serverName === serverName,
+    );
+    if (!currentCatalog || (!server && !existing)) {
+      invalidateCatalog();
+      return;
+    }
+    const diagnostic: McpToolCatalogDiagnostic = existing
+      ? { ...existing, message }
+      : {
+          serverName,
+          safeServerName: server!.safeServerName,
+          launchSummary: server!.launchSummary,
+          message,
+        };
+    catalogInvalidationGeneration += 1;
+    catalog = {
+      ...currentCatalog,
+      diagnostics: [
+        ...(currentCatalog.diagnostics?.filter((entry) => entry.serverName !== serverName) ?? []),
+        diagnostic,
+      ].toSorted((left, right) => left.serverName.localeCompare(right.serverName)),
+    };
+    catalogRetryAfterMs = Date.now();
+    catalogInFlight = undefined;
+  };
   const catalogRetryIsDue = (): boolean =>
     catalogRetryAfterMs !== undefined && Date.now() >= catalogRetryAfterMs;
   const sessions = new Map<string, BundleMcpSession>();
   const serverBackoff = new Map<string, McpServerBackoffState>();
-  const recordServerToolFailure = (serverName: string, nowMs: number) => {
+  const recordServerToolFailure = (
+    serverName: string,
+    session: BundleMcpSession,
+    nowMs: number,
+  ) => {
+    if (sessions.get(serverName) !== session || session.retiring) {
+      return undefined;
+    }
     const previous = serverBackoff.get(serverName);
-    const failures = (previous?.failures ?? 0) + 1;
-    const nextBackoff: McpServerBackoffState = { failures };
+    const failures = (previous?.session === session ? previous.failures : 0) + 1;
+    const nextBackoff: McpServerBackoffState = { session, failures };
     if (failures >= BUNDLE_MCP_FAILURE_THRESHOLD) {
       nextBackoff.retryAfterMs = nowMs + BUNDLE_MCP_FAILURE_COOLDOWN_MS;
     }
     serverBackoff.set(serverName, nextBackoff);
-  };
-  const runGuardedServerRequest = async <T>(
-    serverName: string,
-    request: () => Promise<T>,
-    options?: McpRequestOptions,
-  ): Promise<T> => {
-    const tracksFailureBackoff = options?.failureBackoff !== "ignore";
-    const nowMs = Date.now();
-    const backoff = serverBackoff.get(serverName);
-    if (tracksFailureBackoff && backoff?.retryAfterMs && nowMs < backoff.retryAfterMs) {
-      throw new Error(
-        `bundle-mcp server "${serverName}" is paused after repeated tool failures; retry after ${new Date(backoff.retryAfterMs).toISOString()}`,
-      );
-    }
-    try {
-      const result = await request();
-      if (tracksFailureBackoff) {
-        serverBackoff.delete(serverName);
-      }
-      return result;
-    } catch (error) {
-      if (tracksFailureBackoff) {
-        recordServerToolFailure(serverName, nowMs);
-        // At the threshold, replace the transport rather than parking it — but only when
-        // the server has stopped responding. Parking is the right answer for a server that
-        // is answering with errors. Clearing the backoff entry is part of recycling: the
-        // replacement must not inherit the failure count of the transport it replaces, or
-        // the first request after recycling is refused by a cooldown that belongs to a
-        // process which no longer exists.
-        if (
-          (serverBackoff.get(serverName)?.failures ?? 0) >= BUNDLE_MCP_FAILURE_THRESHOLD &&
-          isUnresponsiveServerFailure(serverName, error)
-        ) {
-          serverBackoff.delete(serverName);
-          recycleServer(serverName, "repeated request failures");
-        }
-      }
-      throw error;
-    }
+    return failures;
   };
   const failIfDisposed = () => {
     if (disposed) {
@@ -524,42 +532,72 @@ export function createSessionMcpRuntime(params: {
     await disposeSession(session);
     return true;
   };
-  /**
-   * Tear down one server's transport and invalidate the catalog so the next request
-   * rebuilds it. Used when a server keeps failing: the cooldown alone only delays the
-   * next attempt against the same, still-broken transport, so a server that stops
-   * responding never recovers on its own.
-   *
-   * Best-effort and fire-and-forget — the caller is already throwing, and the
-   * reconnect belongs to the next request rather than to the failing one.
-   */
-  /**
-   * Distinguishes "this server stopped responding" from "this server answered, with an
-   * error". Only the former warrants replacing the transport: a server that returns
-   * JSON-RPC errors is healthy and reachable, and recycling it would throw away a working
-   * connection because a tool was called with bad arguments or its backend is down.
-   */
-  const isUnresponsiveServerFailure = (serverName: string, error: unknown): boolean => {
-    if (isMcpConfigRecord(error) && error.code === ErrorCode.RequestTimeout) {
-      return true;
-    }
-    return sessions.get(serverName)?.connected === false;
-  };
-  const recycleServer = (serverName: string, reason: string) => {
-    const session = sessions.get(serverName);
-    if (disposed || !session || session.retiring) {
-      return;
-    }
-    catalogInvalidationGeneration += 1;
-    catalog = null;
-    catalogRetryAfterMs = undefined;
-    catalogInFlight = undefined;
-    logWarn(`bundle-mcp: recycling server "${serverName}" (${reason}); next request reconnects`);
-    void retireSessionIfCurrent(serverName, session).catch((error: unknown) => {
-      logWarn(
-        `bundle-mcp: failed to retire server "${serverName}" while recycling: ${redactMcpDiagnosticError(error)}`,
-      );
+  const localRequestTimeouts = new WeakSet<object>();
+  const runMcpRequest = async <T>(
+    session: BundleMcpSession,
+    request: (signal: AbortSignal) => Promise<T>,
+  ): Promise<T> => {
+    const abortController = new AbortController();
+    const timeoutError = new McpError(ErrorCode.RequestTimeout, "Request timed out", {
+      timeout: session.requestTimeoutMs,
     });
+    const timeout = setTimeout(() => {
+      localRequestTimeouts.add(timeoutError);
+      abortController.abort(timeoutError);
+    }, session.requestTimeoutMs);
+    timeout.unref?.();
+    try {
+      return await request(abortController.signal);
+    } finally {
+      clearTimeout(timeout);
+    }
+  };
+  const runGuardedServerRequest = async <T>(
+    serverName: string,
+    session: BundleMcpSession,
+    request: () => Promise<T>,
+    options?: McpRequestOptions,
+  ): Promise<T> => {
+    const tracksFailureBackoff = options?.failureBackoff !== "ignore";
+    const nowMs = Date.now();
+    const backoff = serverBackoff.get(serverName);
+    if (
+      tracksFailureBackoff &&
+      backoff?.session === session &&
+      backoff.retryAfterMs &&
+      nowMs < backoff.retryAfterMs
+    ) {
+      throw new Error(
+        `bundle-mcp server "${serverName}" is paused after repeated tool failures; retry after ${new Date(backoff.retryAfterMs).toISOString()}`,
+      );
+    }
+    if (backoff && backoff.session !== session) {
+      serverBackoff.delete(serverName);
+    }
+    try {
+      const result = await request();
+      if (tracksFailureBackoff && serverBackoff.get(serverName)?.session === session) {
+        serverBackoff.delete(serverName);
+      }
+      return result;
+    } catch (error) {
+      if (tracksFailureBackoff) {
+        const failures = recordServerToolFailure(serverName, session, nowMs);
+        const requestTimedOut =
+          error !== null && typeof error === "object" && localRequestTimeouts.has(error);
+        if (requestTimedOut && failures && failures >= BUNDLE_MCP_FAILURE_THRESHOLD) {
+          serverBackoff.delete(serverName);
+          scheduleCatalogServerRetry(serverName, "repeated request timeouts");
+          logWarn(`bundle-mcp: recycling server "${serverName}" after repeated timeouts`);
+          void retireSessionIfCurrent(serverName, session).catch((retireError: unknown) => {
+            logWarn(
+              `bundle-mcp: failed to retire timed-out server "${serverName}": ${redactMcpDiagnosticError(retireError)}`,
+            );
+          });
+        }
+      }
+      throw error;
+    }
   };
 
   const loadCatalog = async (retryBaseCatalog?: McpToolCatalog): Promise<McpToolCatalog> => {
@@ -583,8 +621,14 @@ export function createSessionMcpRuntime(params: {
 
       // A cooldown retry replaces only diagnostic-bearing servers. Healthy clients
       // keep their SDK tool-metadata snapshot and remain callable during recovery.
-      const servers: Record<string, McpServerCatalog> = { ...retryBaseCatalog?.servers };
-      const tools: McpCatalogTool[] = [...(retryBaseCatalog?.tools ?? [])];
+      const servers: Record<string, McpServerCatalog> = Object.fromEntries(
+        Object.entries(retryBaseCatalog?.servers ?? {}).filter(
+          ([serverName]) => !retryServerNames?.has(serverName),
+        ),
+      );
+      const tools: McpCatalogTool[] = (retryBaseCatalog?.tools ?? []).filter(
+        (tool) => !retryServerNames?.has(tool.serverName),
+      );
       const diagnostics: McpToolCatalogDiagnostic[] = [];
       // Prefer session-wide precomputed assignments; fall back only for isolated runtimes.
       const safeServerNamesByServer =
@@ -690,10 +734,7 @@ export function createSessionMcpRuntime(params: {
                               `bundle-mcp: failed to refresh changed tool list for server "${serverName}": ${redactMcpDiagnosticError(error)}`,
                             );
                           }
-                          catalogInvalidationGeneration += 1;
-                          catalog = null;
-                          catalogRetryAfterMs = undefined;
-                          catalogInFlight = undefined;
+                          invalidateCatalog();
                         },
                       },
                     },
@@ -719,33 +760,17 @@ export function createSessionMcpRuntime(params: {
                   const wasConnected = createdSession.connected;
                   createdSession.connected = false;
                   createdSession.disconnectReason = "mcp transport closed";
-                  // Terminal for this pair, but NOT for the server: invalidate the catalog so
-                  // the next request rebuilds and reconnects. Without this the dead session
-                  // stays cached behind a memoized catalog, so every later request fails
-                  // `requireConnectedSession` indefinitely — the server only ever comes back
-                  // via idle eviction, a config-fingerprint change, or a restart.
-                  //
-                  // Deliberately not deleting from `sessions` here: the catalog rebuild retires
-                  // a disconnected session through `disposeSession`, and dropping the entry
-                  // directly would skip that teardown.
-                  //
-                  // Only an ESTABLISHED connection that was lost is interesting. A transport
-                  // that closes while still connecting is the startup-failure path, which the
-                  // catalog builder already handles — invalidating there would discard the
-                  // in-flight build (generation mismatch) and spin up a rebuild loop.
-                  if (!wasConnected || disposed || createdSession.retiring) {
-                    return;
+                  // Only established current sessions invalidate the catalog. Startup closes
+                  // already belong to catalog loading, and retirement must not start a rebuild.
+                  if (
+                    wasConnected &&
+                    !disposed &&
+                    !createdSession.retiring &&
+                    sessions.get(serverName) === createdSession
+                  ) {
+                    scheduleCatalogServerRetry(serverName, "mcp transport closed");
+                    logWarn(`bundle-mcp: server "${serverName}" closed; next request reconnects`);
                   }
-                  if (sessions.get(serverName) !== createdSession) {
-                    return;
-                  }
-                  catalogInvalidationGeneration += 1;
-                  catalog = null;
-                  catalogRetryAfterMs = undefined;
-                  catalogInFlight = undefined;
-                  logWarn(
-                    `bundle-mcp: server "${serverName}" transport closed; catalog invalidated so the next request reconnects`,
-                  );
                 };
                 session = createdSession;
                 sessions.set(serverName, session);
@@ -1000,14 +1025,17 @@ export function createSessionMcpRuntime(params: {
       const session = requireConnectedSession(serverName);
       return await runGuardedServerRequest(
         serverName,
+        session,
         async () =>
-          (await session.client.callTool(
-            {
-              name: toolName,
-              arguments: isMcpConfigRecord(input) ? input : {},
-            },
-            undefined,
-            { timeout: session.requestTimeoutMs },
+          (await runMcpRequest(session, async (signal) =>
+            session.client.callTool(
+              {
+                name: toolName,
+                arguments: isMcpConfigRecord(input) ? input : {},
+              },
+              undefined,
+              { timeout: session.requestTimeoutMs, signal },
+            ),
           )) as CallToolResult,
       );
     },
@@ -1015,8 +1043,10 @@ export function createSessionMcpRuntime(params: {
       failIfDisposed();
       await getCatalog();
       const session = requireConnectedSession(serverName);
-      return await runGuardedServerRequest(serverName, async () =>
-        session.client.listTools(requestParams, { timeout: session.requestTimeoutMs }),
+      return await runGuardedServerRequest(serverName, session, async () =>
+        runMcpRequest(session, async (signal) =>
+          session.client.listTools(requestParams, { timeout: session.requestTimeoutMs, signal }),
+        ),
       );
     },
     async listResources(serverName, options) {
@@ -1025,7 +1055,16 @@ export function createSessionMcpRuntime(params: {
       const session = requireConnectedSession(serverName);
       return await runGuardedServerRequest(
         serverName,
-        async () => listAllResources(session.client, session.requestTimeoutMs),
+        session,
+        async () =>
+          listAllResources((cursor) =>
+            runMcpRequest(session, async (signal) =>
+              session.client.listResources(cursor ? { cursor } : undefined, {
+                timeout: session.requestTimeoutMs,
+                signal,
+              }),
+            ),
+          ),
         options,
       );
     },
@@ -1035,8 +1074,11 @@ export function createSessionMcpRuntime(params: {
       const session = requireConnectedSession(serverName);
       return await runGuardedServerRequest(
         serverName,
+        session,
         async () =>
-          await session.client.readResource({ uri }, { timeout: session.requestTimeoutMs }),
+          runMcpRequest(session, async (signal) =>
+            session.client.readResource({ uri }, { timeout: session.requestTimeoutMs, signal }),
+          ),
         options,
       );
     },
@@ -1044,31 +1086,41 @@ export function createSessionMcpRuntime(params: {
       failIfDisposed();
       await getCatalog();
       const session = requireConnectedSession(serverName);
-      return await runGuardedServerRequest(serverName, async () =>
-        session.client.listResourceTemplates(requestParams, {
-          timeout: session.requestTimeoutMs,
-        }),
+      return await runGuardedServerRequest(serverName, session, async () =>
+        runMcpRequest(session, async (signal) =>
+          session.client.listResourceTemplates(requestParams, {
+            timeout: session.requestTimeoutMs,
+            signal,
+          }),
+        ),
       );
     },
     async listPrompts(serverName) {
       failIfDisposed();
       await getCatalog();
       const session = requireConnectedSession(serverName);
-      return await runGuardedServerRequest(serverName, async () =>
-        listAllPrompts(session.client, session.requestTimeoutMs),
+      return await runGuardedServerRequest(serverName, session, async () =>
+        listAllPrompts((cursor) =>
+          runMcpRequest(session, async (signal) =>
+            session.client.listPrompts(cursor ? { cursor } : undefined, {
+              timeout: session.requestTimeoutMs,
+              signal,
+            }),
+          ),
+        ),
       );
     },
     async getPrompt(serverName, name, args) {
       failIfDisposed();
       await getCatalog();
       const session = requireConnectedSession(serverName);
-      return await runGuardedServerRequest(
-        serverName,
-        async () =>
-          await session.client.getPrompt(
+      return await runGuardedServerRequest(serverName, session, async () =>
+        runMcpRequest(session, async (signal) =>
+          session.client.getPrompt(
             { name, ...(args ? { arguments: args } : {}) },
-            { timeout: session.requestTimeoutMs },
+            { timeout: session.requestTimeoutMs, signal },
           ),
+        ),
       );
     },
     async dispose() {

--- a/src/agents/agent-bundle-mcp-runtime.ts
+++ b/src/agents/agent-bundle-mcp-runtime.ts
@@ -436,18 +436,24 @@ export function createSessionMcpRuntime(params: {
     const existing = currentCatalog?.diagnostics?.find(
       (diagnostic) => diagnostic.serverName === serverName,
     );
-    if (!currentCatalog || (!server && !existing)) {
+    if (!currentCatalog) {
       invalidateCatalog();
       return;
     }
-    const diagnostic: McpToolCatalogDiagnostic = existing
-      ? { ...existing, message }
-      : {
-          serverName,
-          safeServerName: server!.safeServerName,
-          launchSummary: server!.launchSummary,
-          message,
-        };
+    let diagnostic: McpToolCatalogDiagnostic;
+    if (existing) {
+      diagnostic = { ...existing, message };
+    } else if (server) {
+      diagnostic = {
+        serverName,
+        safeServerName: server.safeServerName ?? serverName,
+        launchSummary: server.launchSummary,
+        message,
+      };
+    } else {
+      invalidateCatalog();
+      return;
+    }
     catalogInvalidationGeneration += 1;
     catalog = {
       ...currentCatalog,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a bundled MCP server that had connected successfully could become permanently unavailable after its transport closed or it repeatedly stopped responding. The session runtime kept a healthy cached catalog pointing at the dead session, so later requests failed until runtime eviction or gateway restart.

This is distinct from #111962: that landed change retries discovery catalogs that already contain diagnostics. Here, discovery succeeded and the transport failed later, so the catalog had no diagnostic to trigger that retry seam.

## Why This Change Was Made

The runtime now routes connection recovery through #111962's existing diagnostic-bearing stale-while-revalidate catalog owner. A closed or repeatedly timed-out server is marked for per-server retry and its exact session generation is retired; healthy siblings retain their warm catalogs and remain callable while recovery runs in the background.

Backoff is scoped to the session identity so late concurrent failures cannot poison a replacement. Only OpenClaw's locally created timeout error triggers recycling; a responsive server returning JSON-RPC `-32001` keeps the existing cooldown. Resource and prompt pagination retain a fresh timeout for every SDK request.

The release-owned `CHANGELOG.md` edit from the original branch was removed.

## User Impact

Bundled MCP servers recover within the same OpenClaw session after a child exits or repeatedly times out. Healthy MCP siblings remain usable during recovery, and ordinary tool/server errors do not cause transport churn.

## Evidence

Current-main defect proof on `71eb9a3ec9d9` (the touched MCP files are unchanged through current `origin/main`):

```text
node scripts/run-vitest.mjs src/agents/agent-bundle-mcp-runtime.test.ts \
  -t 'fails fast with an attributable error after an MCP child process exits'

Test Files  2 passed (2)
Tests       2 passed | 150 skipped (152)
```

That production-shaped stdio test kills the connected child and passes on main only by observing the cached-session error `bundle-mcp server "child" is disconnected: mcp transport closed`.

Final-head behavior proof uses real stdio MCP children and covers: child `SIGKILL` with replacement PID, healthy-sibling availability during delayed reconnect, six concurrent timeout calls followed by replacement recovery, responsive remote JSON-RPC `-32001` staying connected, per-page pagination deadlines, existing diagnostic catalog retry, and combined-catalog refresh.

- Full MCP runtime module: 79/79 passed on Blacksmith Testbox `tbx_01kyh0396ejqbrjr4mt03jmq1f` ([run 30239340038](https://github.com/openclaw/openclaw/actions/runs/30239340038)).
- Final focused lifecycle set: 7/7 passed on Blacksmith Testbox `tbx_01kygztk0yh7d5hywpkdphqdr8` ([run 30239109875](https://github.com/openclaw/openclaw/actions/runs/30239109875)).
- `git diff --check`: passed.
- Final Codex autoreview: clean, no accepted/actionable findings.
- Fresh independent adversarial refuter: `NO-ACTIONABLE-OBJECTION`.

Dependency contract checked directly against `@modelcontextprotocol/sdk` 1.29.0: protocol close clears transport and calls `client.onclose`; local request cancellation preserves the supplied `McpError`; remote JSON-RPC errors create separate error objects.

Contributor credit: implementation and report by @interkelstar; maintainer rewrite commit retains `Co-authored-by: Vlad Gaevsky <kelstar95@gmail.com>`.
