### PR TITLE
fix(ios): expose expandable chat agent identity

### DIFF
--- a/apps/ios/Sources/Design/ChatProTab.swift
+++ b/apps/ios/Sources/Design/ChatProTab.swift
@@ -285,12 +285,12 @@ struct ChatProTab: View {
     }
 
     private var headerAgentIdentity: some View {
-        HStack {
-            self.headerAgentIdentityControl
-        }
-        .frame(minHeight: 44)
-        .accessibilityIdentifier("chat-agent-identity")
-        .animation(.snappy(duration: 0.24), value: self.showsExpandedGatewayStatus)
+        HStack { self.headerAgentIdentityControl }
+            .frame(minHeight: 44)
+            .accessibilityElement(children: .contain) // Keep the parent reachable and its child actionable.
+            .accessibilityIdentifier("chat-agent-identity")
+            .accessibilityValue(self.showsExpandedGatewayStatus ? "Expanded" : "Collapsed")
+            .animation(.snappy(duration: 0.24), value: self.showsExpandedGatewayStatus)
     }
 
     @ViewBuilder

--- a/apps/ios/UITests/OpenClawSnapshotUITests.swift
+++ b/apps/ios/UITests/OpenClawSnapshotUITests.swift
@@ -181,10 +181,13 @@ final class OpenClawSnapshotUITests: XCTestCase {
 
     func testSidebarEdgeDragPreservesPushedScreenBackGesture() throws {
         try XCTSkipIf(UIDevice.current.userInterfaceIdiom != .phone, "Phone sidebar only")
-        self.launchApp(for: ScreenshotTarget(
-            initialTab: "settings",
-            initialDestination: "settings",
-            name: "sidebar-pushed-screen-back-gesture"), appearance: nil, screenshotMode: false)
+        self.launchApp(
+            for: ScreenshotTarget(
+                initialTab: "settings",
+                initialDestination: "settings",
+                name: "sidebar-pushed-screen-back-gesture"),
+            appearance: nil,
+            screenshotMode: false)
 
         if self.app?.buttons["Close"].waitForExistence(timeout: 2) == true {
             self.app?.buttons["Close"].tap()
@@ -473,12 +476,9 @@ final class OpenClawSnapshotUITests: XCTestCase {
         XCTAssertLessThanOrEqual(dictationButton.frame.maxX, composerSurface.frame.maxX)
         XCTAssertGreaterThanOrEqual(talkButton.frame.minX, composerSurface.frame.minX)
         XCTAssertLessThanOrEqual(talkButton.frame.maxX, composerSurface.frame.maxX)
-        XCTAssertGreaterThanOrEqual(attachmentButton.frame.width, 44)
-        XCTAssertGreaterThanOrEqual(attachmentButton.frame.height, 44)
-        XCTAssertGreaterThanOrEqual(dictationButton.frame.width, 44)
-        XCTAssertGreaterThanOrEqual(dictationButton.frame.height, 44)
-        XCTAssertGreaterThanOrEqual(talkButton.frame.width, 44)
-        XCTAssertGreaterThanOrEqual(talkButton.frame.height, 44)
+        self.assertMinimumTouchTarget(attachmentButton)
+        self.assertMinimumTouchTarget(dictationButton)
+        self.assertMinimumTouchTarget(talkButton)
         let compactHeight = textField.frame.height
         XCTAssertLessThanOrEqual(compactHeight, 44)
         XCTAssertLessThanOrEqual(abs(attachmentButton.frame.midY - dictationButton.frame.midY), 1)
@@ -499,8 +499,7 @@ final class OpenClawSnapshotUITests: XCTestCase {
         wait(for: [composerGrew], timeout: 4)
         XCTAssertTrue(sendButton.waitForExistence(timeout: 3))
         XCTAssertTrue(talkButton.waitForNonExistence(timeout: 3))
-        XCTAssertGreaterThanOrEqual(sendButton.frame.width, 44)
-        XCTAssertGreaterThanOrEqual(sendButton.frame.height, 44)
+        self.assertMinimumTouchTarget(sendButton)
         self.attachScreenshot(named: "chat-composer-expanded")
 
         self.app?.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.2)).tap()
@@ -939,7 +938,9 @@ final class OpenClawSnapshotUITests: XCTestCase {
         XCTAssertTrue(self.app?.staticTexts["Apple Health"].exists == true)
         self.attachScreenshot(named: "apple-health-disclosure")
     }
+}
 
+extension OpenClawSnapshotUITests {
     private func launchApp(
         for target: ScreenshotTarget,
         appearance: String? = "dark",
@@ -1037,6 +1038,19 @@ final class OpenClawSnapshotUITests: XCTestCase {
         timeout: TimeInterval = 3)
     {
         XCTAssertTrue(self.element(element, hasValue: value, timeout: timeout))
+    }
+
+    private func assertMinimumTouchTarget(
+        _ element: XCUIElement,
+        file: StaticString = #filePath,
+        line: UInt = #line)
+    {
+        let minimum: CGFloat = 44
+        // XCUI converts screen coordinates through floating-point transforms.
+        // Permit rounding noise without accepting a genuinely undersized target.
+        let tolerance = minimum.ulp * 16
+        XCTAssertGreaterThanOrEqual(element.frame.width + tolerance, minimum, file: file, line: line)
+        XCTAssertGreaterThanOrEqual(element.frame.height + tolerance, minimum, file: file, line: line)
     }
 
     private func element(_ element: XCUIElement, hasValue value: String, timeout: TimeInterval) -> Bool {


### PR DESCRIPTION
## What Problem This Solves

The iOS chat agent identity is visually present, but its SwiftUI parent is not an accessibility element. VoiceOver and real XCTest journeys cannot discover or expand the connected Gateway identity. The same UI suite also rejects genuine 44-point controls when XCTest reports floating-point transformed coordinates such as 43.99999999999994.

## Why This Change Was Made

Make the existing identity parent an explicit containing accessibility element, keep the nested control independently actionable, and publish its actual Expanded or Collapsed accessibility state. Centralize the minimum touch target check with a strictly bounded 16-ULP coordinate tolerance; genuine undersized targets still fail.

## User Impact

VoiceOver users can locate the current chat agent and expand Gateway status. Real snapshot journeys stop falsely rejecting valid 44-point composer buttons. No personal device, Gateway configuration, schema, protocol, dependency, or generated localization file changes.

## Evidence

- Exact tested main: 9defe24ec2fdcedb3be2e88825328c89c24d9999.
- The latest official main, 3cec82e1457969dd005f8ac3f88283ecaeeed5d7, has zero overlap with either changed owner.
- Real campaign-owned iPhone 17 / iOS 27: xcodebuild test and official xcresult report 12 passed, 0 failed, 0 skipped.
- The actually installed signed simulator app reports OpenClawGitCommit=9defe24ec2fdcedb3be2e88825328c89c24d9999 and build 72081.
- All 12 genuine UI screenshot scenes and the 12-scene contact sheet were exported under the campaign Desktop evidence directory.
- The remote native:i18n:verify command completed successfully with 5,304 source entries unchanged. Its externally cancelled portal workflow is not described as successful hosted CI.
- Exact pinned SwiftFormat and SwiftLint: 0 violations.
- Fresh independent high-reasoning code review: no actionable findings.
- Exactly two iOS-owned files; author and committer Peter Steinberger <steipete@gmail.com>.
- Exact remote head: 7738eca9a3193c5ca4d330ffcb78fe13f8803a28.

## Risk

Low. The production change is limited to the existing iOS chat identity accessibility container. The tolerance is confined to XCTest and is approximately 1.14e-13 points. Hosted checks on this pull request must complete before merge.