### PR TITLE
fix(release): align extension validation contracts

### DIFF
--- a/extensions/memory-core/src/session-search-visibility.ts
+++ b/extensions/memory-core/src/session-search-visibility.ts
@@ -227,7 +227,13 @@ export async function filterMemorySearchHitsBySessionVisibility(params: {
 
   const isSessionKeyAllowed = (key: string): boolean => {
     if (!conversationRecall || !anchorSessionKey || !recallAgentId) {
-      return guard?.check(key).allowed === true;
+      // A bare global key is local to the selected agent store. Reattach that
+      // owner before applying visibility or non-default agents look cross-agent.
+      const visibilityKey =
+        scopedAgentId && isGlobalSessionKeyForSharedScope(params.cfg, key)
+          ? `agent:${scopedAgentId}:global`
+          : key;
+      return guard?.check(visibilityKey).allowed === true;
     }
     const candidateEntry = combinedSessionStore[key];
     // Canonical and legacy alias keys can identify one transcript. Exclude the

--- a/extensions/nvidia/provider-catalog.test.ts
+++ b/extensions/nvidia/provider-catalog.test.ts
@@ -143,18 +143,18 @@ describe("nvidia provider catalog", () => {
       { id: "z-ai/glm-5.2", input: ["text"], reasoning: true },
       {
         id: "moonshotai/kimi-k2.6",
-        input: ["text", "image", "video"],
+        input: ["text", "image"],
         reasoning: true,
       },
       {
         id: "minimaxai/minimax-m3",
-        input: ["text", "image", "video"],
+        input: ["text", "image"],
         reasoning: true,
       },
       { id: "deepseek-ai/deepseek-v4-pro", input: ["text"], reasoning: true },
       {
         id: "qwen/qwen3.5-397b-a17b",
-        input: ["text", "image", "video"],
+        input: ["text", "image"],
         reasoning: true,
       },
     ]);
@@ -183,7 +183,7 @@ describe("nvidia provider catalog", () => {
       { id: "minimaxai/minimax-m2.7", replacedBy: "minimaxai/minimax-m3" },
     ]);
     expect(provider.models.find((model) => model.id === "moonshotai/kimi-k2.5")).toMatchObject({
-      input: ["text", "image", "video"],
+      input: ["text", "image"],
       reasoning: true,
       contextWindow: 262_144,
       maxTokens: 32_768,

--- a/extensions/telegram/src/doctor.test.ts
+++ b/extensions/telegram/src/doctor.test.ts
@@ -639,7 +639,7 @@ describe("telegram doctor", () => {
           channels: {
             telegram: {
               replyToMode: "first",
-              streaming: false,
+              streaming: { mode: "off" },
             },
           },
         } as unknown as OpenClawConfig)


### PR DESCRIPTION
## What Problem This Solves

Resolves three beta validation failures: non-default agents lose their own global-scope session search hits, NVIDIA catalog fixtures advertise unsupported video inputs, and Telegram doctor fixtures use the retired boolean streaming shape.

## Why This Change Was Made

Reattach the selected agent owner before the existing session visibility guard evaluates a bare global key. Keep the guard and agent-to-agent policy intact. Align the NVIDIA and Telegram fixtures with their canonical manifest and config contracts.

## User Impact

Non-default agents using global session scope can search their own session transcript without being misclassified as cross-agent access. NVIDIA and Telegram runtime behavior is unchanged; their release validation now reflects the shipped contracts.

## Evidence

- Plugin Prerelease 30179864700 reproduced the NVIDIA, Telegram, and memory failures in extension shards 5, 2, and 8.
- `node scripts/run-vitest.mjs extensions/nvidia/provider-catalog.test.ts extensions/telegram/src/doctor.test.ts extensions/memory-core/src/session-search-visibility.cross-agent.test.ts` — 46 tests passed.
- `node scripts/run-vitest.mjs extensions/memory-core/src/session-search-visibility.test.ts extensions/memory-core/src/session-search-visibility.qmd.test.ts` — 38 tests passed.
- `git diff --check` — passed.
- Autoreview — clean, no accepted/actionable findings.

AI-assisted: yes.
