### PR TITLE
fix(agents): diagnostic content tests use current capture config

### DIFF
--- a/src/agents/agent-tools.before-tool-call.e2e.test.ts
+++ b/src/agents/agent-tools.before-tool-call.e2e.test.ts
@@ -7,6 +7,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { GatewayClientRequestError } from "../gateway/client.js";
 import {
   onInternalDiagnosticEvent,
@@ -2679,22 +2680,17 @@ describe("before_tool_call tool content private-data capture", () => {
     }
   }
 
-  function configWithToolContent(
-    fields: { toolInputs?: boolean; toolOutputs?: boolean } = {
-      toolInputs: true,
-      toolOutputs: true,
-    },
-  ) {
+  function configWithToolContent(): OpenClawConfig {
     return {
       diagnostics: {
         enabled: true,
         otel: {
           enabled: true,
           traces: true,
-          captureContent: { enabled: true, ...fields },
+          captureContent: true,
         },
       },
-    } as unknown as import("../config/types.openclaw.js").OpenClawConfig;
+    };
   }
 
   it("attaches tool input/output to private data when opted in", async () => {
@@ -2741,7 +2737,7 @@ describe("before_tool_call tool content private-data capture", () => {
     });
   });
 
-  it("captures only opted-in fields and clones away from live params", async () => {
+  it("clones captured content away from live params", async () => {
     const liveParams = { path: "/etc/secret" };
     const execute = vi.fn().mockResolvedValue({ content: [{ type: "text", text: "out" }] });
     const tool = wrapToolWithBeforeToolCallHook(asAgentTool({ name: "read", execute }), {
@@ -2749,7 +2745,7 @@ describe("before_tool_call tool content private-data capture", () => {
       sessionKey: "session-key",
       runId: "run-1",
       loopDetection: { enabled: false },
-      config: configWithToolContent({ toolInputs: true, toolOutputs: false }),
+      config: configWithToolContent(),
     });
 
     await withTrustedToolEvents(async (emitted, flush) => {
@@ -2758,7 +2754,9 @@ describe("before_tool_call tool content private-data capture", () => {
 
       const completed = emitted.find((e) => e.event.type === "tool.execution.completed");
       expect(completed?.privateData.toolContent?.toolInput).toEqual({ path: "/etc/secret" });
-      expect(completed?.privateData.toolContent?.toolOutput).toBeUndefined();
+      expect(completed?.privateData.toolContent?.toolOutput).toEqual({
+        content: [{ type: "text", text: "out" }],
+      });
       // Captured snapshot is a clone, not the live params object.
       expect(completed?.privateData.toolContent?.toolInput).not.toBe(liveParams);
     });


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where three private tool-diagnostic content tests failed because their shared fixture still supplied the retired object-valued `captureContent` configuration.

## Why This Change Was Made

The fixture now returns a typed current-shape OpenClaw config with boolean content capture enabled. The clone assertion follows the boolean contract by expecting both tool input and tool output, while the separate doctor migration and malformed-runtime rejection coverage for the legacy object shape remains unchanged.

AI-assisted by Codex. I traced the current schema, runtime policy, doctor migration, and adjacent diagnostic tests before changing the fixture.

## User Impact

No user-visible behavior changes. The diagnostic test suite now exercises the supported configuration shape and no longer masks the private-content assertions behind a retired fixture.

## Evidence

- Blacksmith Testbox `tbx_01kydvn2jzrq4ad5xz41wrcd2s`: [focused affected suite](https://github.com/openclaw/openclaw/actions/runs/30180452486) passed, 1 file and 84 tests.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted`: clean, no accepted/actionable findings (`patch is correct`, 0.98).
- `git diff --check`: passed.
