### PR TITLE
fix(browser): preserve lazy tool output schema

### DIFF
--- a/extensions/browser/index.test.ts
+++ b/extensions/browser/index.test.ts
@@ -11,6 +11,7 @@ import {
 } from "./plugin-registration.js";
 import type { OpenClawPluginApi } from "./runtime-api.js";
 import setupPlugin from "./setup-api.js";
+import { BrowserToolOutputSchema } from "./src/browser-tool.schema.js";
 
 type BrowserAutoEnableProbe = Parameters<OpenClawPluginApi["registerAutoEnableProbe"]>[0];
 
@@ -215,6 +216,7 @@ describe("browser plugin", () => {
     expect(tool.name).toBe("browser");
     expect(tool.description).toContain("action=profiles");
     expect(tool.description).not.toContain('profile="user"');
+    expect(tool.outputSchema).toBe(BrowserToolOutputSchema);
     expect(runtimeApiMocks.createBrowserTool).not.toHaveBeenCalled();
     await tool.execute("call-1", { action: "status" });
     expect(runtimeApiMocks.createBrowserTool).toHaveBeenCalledWith({

--- a/extensions/browser/plugin-registration.ts
+++ b/extensions/browser/plugin-registration.ts
@@ -20,7 +20,7 @@ import {
 } from "./src/browser-gateway-contract.js";
 import { parseBrowserTabToolBinding } from "./src/browser-tool-binding.js";
 import { describeBrowserTool } from "./src/browser-tool-description.js";
-import { BrowserToolSchema } from "./src/browser-tool.schema.js";
+import { BrowserToolOutputSchema, BrowserToolSchema } from "./src/browser-tool.schema.js";
 import { initializeBrowserSessionTabStore } from "./src/browser/session-tab-store.js";
 import {
   configureSystemProfileImportStateStore,
@@ -92,6 +92,7 @@ function createLazyBrowserTool(opts?: {
     name: "browser",
     description: describeBrowserTool({ targetDefault, hostHint }),
     parameters: BrowserToolSchema,
+    outputSchema: BrowserToolOutputSchema,
     execute: async (toolCallId, args, signal, onUpdate) => {
       const { createBrowserTool } = await loadBrowserRegistrationRuntimeModule();
       const tool = createBrowserTool(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where agents discovering the bundled Browser tool through its registered lazy plugin could not see or validate the actual browser result contract. The directly created Browser tool already exposed this contract, but the user-facing registered tool silently dropped it.

## Why This Change Was Made

Keep browser startup lazy and attach the existing canonical BrowserToolOutputSchema to the registered Browser tool. The registered and directly created tools now expose the same owner-defined result contract; no capabilities, node permissions, browser startup, storage, or configuration are changed.

## User Impact

Browser tool discovery and strict structured-result validation consistently describe and validate actual Browser responses before the lazy browser runtime is started.

## Evidence

- Independently inspected the complete Browser registration owner, canonical output schema, real Browser tool, plugin SDK descriptor contract and existing plugin lifecycle regressions.
- Dedicated remote Browser suite: 164 files, 2,041 passing tests and one pre-existing skip; strict tool-description and validation suite: 79 passing cases; hint-contract suite: 12 passing cases.
- Full production/UI build and complete changed gate reported successful command exit; the associated delegated portal workflow was cancelled after command completion and is not represented as a successful hosted check.
- Fresh official high-effort independent review: no findings.
- Independently verified exact Browser production, canonical-schema, loader and plugin SDK owners are unchanged from candidate parent `e3fc8527ce021ec47c5a34092c5419e1f9772b45` through current official `908e181f3fc0c61a363cf90a6b090b1a20ef9864`; a provider-public-artifacts test changed separately and is not part of this Browser contract.
- An actual isolated remote Node 24 product process loaded the real bundled Browser using production `loadOpenClawPlugins`, registered its real factory with the actual headless tool-search catalog, executed real `ToolSearchRuntime.describe("browser")`, and validated an actual structured result against the strict canonical owner schema. Node module-load hooks independently proved no Browser runtime/control module loaded before execution. Jiti and TSX module instances are correctly compared by canonical structural schema, while identity is asserted between the actual registered factory result and actual catalog descriptor.

Actual complete redacted runtime stdout on the exact candidate:

```text
SOURCE {"candidate":"03442299ac909a03c8320c81922ba60e53b5be3c","parent":"e3fc8527ce021ec47c5a34092c5419e1f9772b45"}
BASELINE {"immutableParent":"e3fc8527ce021ec47c5a34092c5419e1f9772b45","registeredBrowserOutputSchema":false}
PLUGIN {"id":"browser","status":"loaded","origin":"bundled","registeredFactory":"browser","canonicalOutputSchema":true}
TOOLS.DESCRIBE {"id":"openclaw:browser:browser","outputSchemaType":"object","catalogPreservesRegisteredSchema":true,"canonicalOutputProperties":["aborted","cdpPort","cdpUrl","chars","driver","enabled","format","model","newElements","ok","pid","profile","refs","results","running","snapshot","stats","tabCount","tabs","targetId","transport","truncated","url"]}
STRICT.RESULT {"ok":true,"validated":{"ok":true,"running":false,"profile":"openclaw","tabCount":0}}
LAZY.BEFORE.EXECUTE {"browserRuntimeOrControlModulesLoaded":[],"toolExecuted":false}
```

The actual remote command completed with `exitCode: 0` after 162,666 ms. It uses no mocked plugin loader, no mocked search runtime, no browser execution, no credentials and no changes to a user Gateway.