### PR TITLE
fix(browser): recover remote node after failed startup

### DIFF
--- a/extensions/browser/src/node-host/invoke-browser.test.ts
+++ b/extensions/browser/src/node-host/invoke-browser.test.ts
@@ -200,6 +200,82 @@ describe("runBrowserProxyCommand", () => {
     ({ runBrowserProxyCommand } = await import("./invoke-browser.js"));
   });
 
+  it("retries browser control startup after a rejected attempt", async () => {
+    controlServiceMocks.startBrowserControlServiceFromConfig.mockRejectedValueOnce(
+      new Error("browser startup failed"),
+    );
+    dispatcherMocks.dispatch.mockResolvedValue({ status: 200, body: { ok: true } });
+    const request = JSON.stringify({ method: "GET", path: "/snapshot" });
+
+    await expect(runBrowserProxyCommand(request)).rejects.toThrow("browser startup failed");
+    await expect(runBrowserProxyCommand(request)).resolves.toBe(
+      JSON.stringify({ result: { ok: true } }),
+    );
+
+    expect(controlServiceMocks.startBrowserControlServiceFromConfig).toHaveBeenCalledTimes(2);
+    expect(dispatcherMocks.dispatch).toHaveBeenCalledOnce();
+  });
+
+  it("retries browser control startup after the service returns disabled", async () => {
+    controlServiceMocks.startBrowserControlServiceFromConfig.mockResolvedValueOnce(false);
+    dispatcherMocks.dispatch.mockResolvedValue({ status: 200, body: { ok: true } });
+    const request = JSON.stringify({ method: "GET", path: "/snapshot" });
+
+    await expect(runBrowserProxyCommand(request)).rejects.toThrow("browser control disabled");
+    await expect(runBrowserProxyCommand(request)).resolves.toBe(
+      JSON.stringify({ result: { ok: true } }),
+    );
+
+    expect(controlServiceMocks.startBrowserControlServiceFromConfig).toHaveBeenCalledTimes(2);
+    expect(dispatcherMocks.dispatch).toHaveBeenCalledOnce();
+  });
+
+  it("shares a retried browser control startup across concurrent requests", async () => {
+    let rejectFailedStartup!: (reason?: unknown) => void;
+    const failedStartup = new Promise<boolean>((_resolve, reject) => {
+      rejectFailedStartup = reject;
+    });
+    let resolveSuccessfulStartup!: (value: boolean) => void;
+    const successfulStartup = new Promise<boolean>((resolve) => {
+      resolveSuccessfulStartup = resolve;
+    });
+    controlServiceMocks.startBrowserControlServiceFromConfig
+      .mockReturnValueOnce(failedStartup)
+      .mockReturnValueOnce(successfulStartup);
+    dispatcherMocks.dispatch.mockResolvedValue({ status: 200, body: { ok: true } });
+    const request = JSON.stringify({ method: "GET", path: "/snapshot" });
+
+    const failedRequests = Promise.allSettled([
+      runBrowserProxyCommand(request),
+      runBrowserProxyCommand(request),
+    ]);
+    expect(controlServiceMocks.startBrowserControlServiceFromConfig).toHaveBeenCalledOnce();
+    rejectFailedStartup(new Error("browser startup failed"));
+
+    await expect(failedRequests).resolves.toEqual([
+      { status: "rejected", reason: expect.any(Error) },
+      { status: "rejected", reason: expect.any(Error) },
+    ]);
+    expect(dispatcherMocks.dispatch).not.toHaveBeenCalled();
+
+    const retriedRequests = Promise.allSettled([
+      runBrowserProxyCommand(request),
+      runBrowserProxyCommand(request),
+    ]);
+    expect(controlServiceMocks.startBrowserControlServiceFromConfig).toHaveBeenCalledTimes(2);
+    resolveSuccessfulStartup(true);
+
+    await expect(retriedRequests).resolves.toEqual([
+      { status: "fulfilled", value: JSON.stringify({ result: { ok: true } }) },
+      { status: "fulfilled", value: JSON.stringify({ result: { ok: true } }) },
+    ]);
+    await expect(runBrowserProxyCommand(request)).resolves.toBe(
+      JSON.stringify({ result: { ok: true } }),
+    );
+    expect(controlServiceMocks.startBrowserControlServiceFromConfig).toHaveBeenCalledTimes(2);
+    expect(dispatcherMocks.dispatch).toHaveBeenCalledTimes(3);
+  });
+
   it("serializes plural action downloads without reading nested page paths", async () => {
     const tempDir = await fs.mkdtemp(nodePath.join(os.tmpdir(), "openclaw-browser-proxy-action-"));
     const firstPath = nodePath.join(tempDir, "first.txt");

--- a/extensions/browser/src/node-host/invoke-browser.ts
+++ b/extensions/browser/src/node-host/invoke-browser.ts
@@ -64,7 +64,7 @@ async function ensureBrowserControlService(): Promise<void> {
   if (browserControlReady) {
     return browserControlReady;
   }
-  browserControlReady = (async () => {
+  const startup = (async () => {
     const cfg = loadBrowserConfigForRuntimeRefresh();
     const resolved = resolveBrowserConfig(cfg.browser, cfg);
     if (!resolved.enabled) {
@@ -75,7 +75,15 @@ async function ensureBrowserControlService(): Promise<void> {
       throw new Error("browser control disabled");
     }
   })();
-  return browserControlReady;
+  const sharedStartup = startup.catch((error: unknown) => {
+    // A failed attempt must not poison later calls or clear a newer shared startup.
+    if (browserControlReady === sharedStartup) {
+      browserControlReady = null;
+    }
+    throw error;
+  });
+  browserControlReady = sharedStartup;
+  return sharedStartup;
 }
 
 function isProfileAllowed(params: { allowProfiles: string[]; profile?: string | null }) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users routing browser requests through a real remote browser node kept receiving a transient startup failure forever, even after the actual browser service could start successfully.

## Why This Change Was Made

Keep browser-control startup single-flight while clearing a failed cached promise only if that exact attempt still owns the cache. Successful attempts remain shared, simultaneous retries do not start competing browser services, and profile policy, node capabilities, pairing, file access and service-stop ownership remain unchanged.

## User Impact

A genuinely signed, approved remote Browser node recovers on the next request after a real transient startup failure, without restarting the node. Real Chromium then starts normally. Simultaneous callers retain single-flight behavior.

## Evidence

- Root personally inspected both complete Browser node-host owners, all 680 existing/new test lines, production control-service startup, Gateway request ownership, node approval, profile/file restrictions and canonical sibling single-flight behavior.
- Immutable candidate `a16a47d32a71ec3850a0aa2641b54ccb371377a6`; both changed production/test owner files remain byte-identical from its parent through official latest `977c8e9d375129b0ea4d24faf71e4f35773581b7`.
- Production package was built from the exact candidate and installed into a private npm prefix: `OpenClaw 2026.7.2 (a16a47d)`; actual tarball SHA-256 `9f7a3c0b4b4be57aef16d170b242117fe02dc7a12b2e9616319f32c30d4489e9`.
- Real installed Gateway; actual separate device and Browser-capability node approvals; genuinely signed connected node; real, physical malformed relay-secret startup failure; removal without restarting that node; successful retry; and actual `/usr/bin/chromium` confirmed running.
- Exact owner suite: 24 cases including rejected/disabled startup, two concurrent failed callers, single shared retry and reuse after success.
- Complete remote changed gate, core/test typecheck, formatting, lint, cycle checks and build: exit 0. Fresh independent high-effort review: no findings.

Actual complete redacted installed-product runtime output:

```text
PR113926_REAL_SIGNED_NODE_PAIRING=approved-browser-capability-surface
PR113926_REAL_SIGNED_NODE=connected command=browser.proxy nodeIdPrefix=31a05efd0f51
PR113926_REAL_NODE_COMMANDS={"caps":["browser","file","local-inference","mcp","system","teams-meetings","zoom-meetings"],"commands":["browser.proxy","fs.listDir","mcp.tools.call.v1","ollama.chat","ollama.models","system.execApprovals.get","system.execApprovals.set","system.run","system.run.prepare","system.which","terminal.upload"]}
PR113926_REAL_TRANSIENT_FAILURE=malformed-node-relay-secret
PR113926_REAL_STARTUP_ATTEMPT_1=FAILED GatewayClientRequestError: INVALID_REQUEST: Error: extension relay secret exists but is unreadable/malformed
PR113926_REAL_TRANSIENT_FAILURE=cleared-without-restarting-node
PR113926_REAL_STARTUP_ATTEMPT_2=SUCCESS profiles=openclaw,user,chrome
PR113926_REAL_CHROMIUM=started profile=openclaw
PR113926_REAL_CHROMIUM_STATUS=running
PR113926_REAL_PROOF=PASS head=a16a47d32a71ec3850a0aa2641b54ccb371377a6 signed_node=connected failure_observed=true retry_succeeded=true chromium_running=true
PR113926_REAL_GATEWAY_NODE_CLEANUP=complete
PR113926_REAL_PROCESS_FINALIZER=PASS child_processes_stopped
```

Authoritative remote timing: `commandMs=19400`, `totalMs=19441`, `exitCode=0`. The runner uses no mocked node, no mocked Chrome, no synthetic success and no changes to a production Gateway. The campaign-owned Testbox was independently stopped after the passing command.