### PR TITLE
fix(ui): give running tasks priority in the background-tasks rail

### DIFF
--- a/ui/src/pages/chat/background-tasks.e2e.test.ts
+++ b/ui/src/pages/chat/background-tasks.e2e.test.ts
@@ -160,6 +160,12 @@ describeControlUiE2e("Control UI chat background-tasks rail mocked Gateway E2E",
       const rail = page.locator(".chat-tasks-rail");
       await rail.locator('[data-task-id="task-subagent"]').waitFor({ state: "visible" });
       await rail.locator('[data-task-id="task-cron"]').waitFor({ state: "visible" });
+      // Finished history starts collapsed: only the section header with the
+      // count renders until it is expanded.
+      const finishedToggle = rail.getByRole("button", { name: "Finished (1)" });
+      await finishedToggle.waitFor({ state: "visible" });
+      expect(await rail.locator('[data-task-id="task-cli"]').count()).toBe(0);
+      await finishedToggle.click();
       await rail.locator('[data-task-id="task-cli"]').waitFor({ state: "visible" });
       const railText = await rail.textContent();
       expect(railText).toContain("Reading provider catalogs");

--- a/ui/src/pages/chat/components/chat-background-tasks.test.ts
+++ b/ui/src/pages/chat/components/chat-background-tasks.test.ts
@@ -87,6 +87,7 @@ describe("background tasks rail state", () => {
 
     const props = createBackgroundTasksProps(host, openSession);
     expect(props.collapsed).toBe(true);
+    expect(props.finishedCollapsed).toBe(true);
     expect(request).toHaveBeenCalledTimes(2);
     expect(props.tasks?.map((task) => task.id)).toEqual(["task-1"]);
   });
@@ -201,9 +202,10 @@ describe("background tasks rail state", () => {
       );
     };
     host.requestUpdate = renderRail;
+    // finishedCollapsed defaults to true; back-navigation from a finished
+    // detail must expand the section so the returned-to row stays visible.
     const initialProps = createBackgroundTasksProps(host, openSession);
     initialProps.onToggleCollapsed();
-    initialProps.onToggleFinished();
     renderRail();
 
     const disclosure = container.querySelector<HTMLButtonElement>(

--- a/ui/src/pages/chat/components/chat-background-tasks.ts
+++ b/ui/src/pages/chat/components/chat-background-tasks.ts
@@ -82,7 +82,9 @@ function getBackgroundTasksState(host: BackgroundTasksHost): BackgroundTasksStat
     // agent switches and only reload the task list for the new scope.
     collapsed: current?.collapsed ?? true,
     error: null,
-    finishedCollapsed: current?.finishedCollapsed ?? false,
+    // Finished history starts collapsed so active work owns the rail; the
+    // section header still shows the count for discoverability.
+    finishedCollapsed: current?.finishedCollapsed ?? true,
     loadedClient: null,
     loading: false,
     pendingReload: false,
@@ -588,7 +590,7 @@ export function renderBackgroundTasksRail(
             ${empty
               ? html`<div class="chat-tasks-rail__state">${t("chat.backgroundTasks.empty")}</div>`
               : nothing}
-            <div class="chat-tasks-rail__scroll">
+            <div class="chat-tasks-rail__scroll chat-tasks-rail__scroll--split">
               ${active.length > 0
                 ? html`
                     <section class="chat-tasks-rail__section" data-tasks-section="running">

--- a/ui/src/styles/chat/sidebar.css
+++ b/ui/src/styles/chat/sidebar.css
@@ -39,13 +39,13 @@
    rules sit after the collapse/dock modifiers so the extra column wins at
    equal specificity. */
 .chat-workbench--tasks-open {
-  grid-template-columns: minmax(0, 1fr) minmax(230px, 280px);
+  grid-template-columns: minmax(0, 1fr) minmax(270px, 330px);
 }
 
 .chat-workbench--tasks-open:not(.chat-workbench--workspace-collapsed):not(
   .chat-workbench--dock-bottom
 ) {
-  grid-template-columns: minmax(0, 1fr) minmax(230px, 280px) minmax(230px, 280px);
+  grid-template-columns: minmax(0, 1fr) minmax(230px, 280px) minmax(270px, 330px);
 }
 
 /* Compact icon button shared by the pane header actions. Sizing only — chrome
@@ -714,6 +714,13 @@
   overflow: auto;
 }
 
+/* List mode splits scrolling per section: running work owns the rail and the
+   finished history pins to the bottom, so a long history can never clip the
+   active tasks (each section scrolls on its own instead of the container). */
+.chat-tasks-rail__scroll--split {
+  overflow: hidden;
+}
+
 .chat-tasks-rail__section {
   display: flex;
   flex: 0 1 auto;
@@ -721,6 +728,16 @@
   min-height: 0;
   overflow-y: auto;
   padding-top: 8px;
+}
+
+.chat-tasks-rail__scroll--split > [data-tasks-section="running"] {
+  flex: 1 1 auto;
+}
+
+/* Cap only when running work is present; alone, finished may fill the rail. */
+.chat-tasks-rail__scroll--split > [data-tasks-section="running"] + [data-tasks-section="finished"] {
+  max-height: 50%;
+  border-top: 1px solid color-mix(in srgb, var(--border) 42%, transparent);
 }
 
 .chat-tasks-rail__section-title {
@@ -1708,6 +1725,10 @@ openclaw-session-discussion {
   flex: 1 0 260px;
   min-width: 0;
   overflow-y: auto;
+  /* Undo the vertical split's bottom-pin cap: strip sections are full-height
+     columns and separate with border-left instead. */
+  max-height: none;
+  border-top: none;
 }
 
 .chat-workbench--tasks-dock-bottom


### PR DESCRIPTION
## What Problem This Solves

The chat pane's background-tasks rail treated running and finished tasks as equals: both sections shared one scroll container, the finished list was expanded by default, and the rail was narrow enough that task titles and status lines wrapped. With a long task history, finished entries consumed most of the rail while the running tasks — the thing the rail exists to show — got clipped into a small scroll window.

## Why This Change Was Made

Running work is the primary content of the rail; history is secondary. Three targeted changes:

- **Finished starts collapsed** (`finishedCollapsed` defaults to `true`). The section header still shows the count, and returning from a finished task's detail view still auto-expands it so the row you came back from stays visible.
- **Running owns the space, finished pins to the bottom.** In list mode the scroll container no longer scrolls as one unit; the running section flexes to fill the rail and scrolls internally, while the finished section sits at the bottom capped at 50% of the rail with its own scrollbar. When there is no running work, finished may use the full rail. The bottom-dock strip layout (sections side by side) is unaffected.
- **Wider rail**: the tasks column grows from `minmax(230px, 280px)` to `minmax(270px, 330px)`, so titles and status rows stop wrapping. The workspace rail keeps its previous width.

## User Impact

Opening the background-tasks rail now always shows running tasks first and in full; finished history is one click away at the bottom instead of dominating the panel.

Before / after (mock-gateway e2e fixture, 2 running + 1 finished):

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/tasks-rail-priority/before-rail-open.png) | ![after](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/tasks-rail-priority/after-rail-open.png) |

After returning from a finished task detail (section auto-expands, pinned at bottom):

![after back-to-list](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/tasks-rail-priority/after-back-to-list.png)

## Evidence

- `node scripts/run-vitest.mjs ui/src/pages/chat/components/chat-background-tasks.test.ts` — 26 passed, including a new default-collapsed assertion and the back-navigation re-expand path.
- `node scripts/run-vitest.mjs ui/src/pages/chat/background-tasks.e2e.test.ts` — 2 passed; the e2e now proves finished rows are absent until the section toggle is clicked, then visible.
- Screenshots above are the e2e artifacts from those runs (before = same suite on the pre-change baseline).
- Codex autoreview (`gpt-5.6-sol`, high): clean, no actionable findings.
