### PR TITLE
fix(infra): keep valid exec approvals under same-process lock contention

### DIFF
--- a/src/infra/exec-approvals-file-io.ts
+++ b/src/infra/exec-approvals-file-io.ts
@@ -411,6 +411,10 @@ export function hardenUnchangedExecApprovals(filePath: string): boolean {
   return true;
 }
 
+// Contract: approvals mutations must stay fully synchronous (no fs.promises).
+// loadExecApprovals reads locklessly when a same-process async holder owns the
+// lock, which is only safe because no write can be mid-flight in the thread
+// pool while synchronous JS runs. An async writer here would break that.
 export function writeExecApprovalsRaw(filePath: string, raw: string) {
   const dir = ensureDir(filePath);
   assertSafeExecApprovalsDestination(filePath);

--- a/src/infra/exec-approvals-lock.ts
+++ b/src/infra/exec-approvals-lock.ts
@@ -144,6 +144,10 @@ function acquireExecApprovalsLockSync(filePath: string): ExecApprovalsSyncLock {
       throw Object.assign(new Error(`Exec approvals are locked: ${lockPath}`), {
         code: "file_lock_timeout",
         lockPath,
+        // A same-process async holder can never release while sync code spins
+        // (single event loop), so callers may safely read the committed file
+        // instead of failing: the holder is suspended and cannot be mid-write.
+        heldByCurrentProcess: state.ownerPid === process.pid,
       });
     }
     let stat: fs.Stats;

--- a/src/infra/exec-approvals-store.test.ts
+++ b/src/infra/exec-approvals-store.test.ts
@@ -823,6 +823,65 @@ describe("exec approvals store helpers", () => {
     expect(loadExecApprovals().defaults).toMatchObject({ security: "deny", ask: "off" });
   });
 
+  it("returns the persisted policy when the sync lock is held by this process", () => {
+    // A same-process async lock holder makes the sync lock fail instantly;
+    // that contention must not degrade a valid yolo policy to deny.
+    const dir = createHomeDir();
+    const approvalsPath = approvalsFilePath(dir);
+    fs.mkdirSync(path.dirname(approvalsPath), { recursive: true });
+    fs.writeFileSync(
+      approvalsPath,
+      '{"version":1,"defaults":{"security":"full","ask":"off"},"agents":{}}\n',
+      "utf8",
+    );
+    const lockPath = `${approvalsPath}.lock`;
+    fs.writeFileSync(lockPath, `${JSON.stringify({ pid: process.pid })}\n`, { mode: 0o600 });
+    try {
+      expect(loadExecApprovals().defaults).toMatchObject({ security: "full", ask: "off" });
+    } finally {
+      fs.rmSync(lockPath, { force: true });
+    }
+  });
+
+  it("stays fail-closed when the sync lock is held by another process", async () => {
+    // A foreign holder may be mid-revocation; deny is the only assertable state.
+    const dir = createHomeDir();
+    const approvalsPath = approvalsFilePath(dir);
+    fs.mkdirSync(path.dirname(approvalsPath), { recursive: true });
+    fs.writeFileSync(
+      approvalsPath,
+      '{"version":1,"defaults":{"security":"full","ask":"off"},"agents":{}}\n',
+      "utf8",
+    );
+    const lockPath = `${approvalsPath}.lock`;
+    // A live child guarantees a foreign pid even when the runner is PID 1.
+    const child = spawn(process.execPath, ["-e", "setTimeout(() => {}, 30_000)"], {
+      stdio: "ignore",
+    });
+    fs.writeFileSync(lockPath, `${JSON.stringify({ pid: child.pid })}\n`, { mode: 0o600 });
+    try {
+      expect(loadExecApprovals().defaults).toMatchObject({ security: "deny", ask: "off" });
+    } finally {
+      fs.rmSync(lockPath, { force: true });
+      child.kill("SIGKILL");
+      await once(child, "exit");
+    }
+  });
+
+  it("stays fail-closed for malformed persisted policy while the sync lock is held", () => {
+    const dir = createHomeDir();
+    const approvalsPath = approvalsFilePath(dir);
+    fs.mkdirSync(path.dirname(approvalsPath), { recursive: true });
+    fs.writeFileSync(approvalsPath, "{invalid", "utf8");
+    const lockPath = `${approvalsPath}.lock`;
+    fs.writeFileSync(lockPath, `${JSON.stringify({ pid: process.pid })}\n`, { mode: 0o600 });
+    try {
+      expect(loadExecApprovals().defaults).toMatchObject({ security: "deny", ask: "off" });
+    } finally {
+      fs.rmSync(lockPath, { force: true });
+    }
+  });
+
   it("keeps synchronous and locked resolution fail-closed for malformed persisted policy", async () => {
     const dir = createHomeDir();
     const approvalsPath = approvalsFilePath(dir);

--- a/src/infra/exec-approvals-store.ts
+++ b/src/infra/exec-approvals-store.ts
@@ -52,12 +52,36 @@ function loadExecApprovalsUnlocked(): ExecApprovalsFile {
   }
 }
 
+function loadExecApprovalsHeldByCurrentProcess(): ExecApprovalsFile {
+  // The sync lock fails instantly when a same-process async holder owns it —
+  // spinning would deadlock the event loop. That failure must not degrade a
+  // valid persisted policy to the fail-closed deny fallback: all approvals
+  // mutations go through the fully synchronous writeExecApprovalsRaw /
+  // hardenUnchangedExecApprovals (no fs.promises anywhere in this store), so
+  // while this sync code runs no same-process write can be in flight — the
+  // file on disk IS the current committed policy. A missing file stays deny —
+  // the holder may be committing the first policy.
+  try {
+    const snapshot = readExecApprovalsSnapshotFromPath(resolveExecApprovalsPath());
+    if (snapshot.exists) {
+      return snapshot.file;
+    }
+  } catch {
+    // Unreadable state keeps the fail-closed fallback below.
+  }
+  return createFailClosedExecApprovalsFallback();
+}
+
 export function loadExecApprovals(): ExecApprovalsFile {
   try {
     return withExecApprovalsReadLockSync(resolveExecApprovalsPath(), loadExecApprovalsUnlocked);
-  } catch {
-    // A busy, malformed, or unreadable approvals store must never restore the
-    // permissive defaults while another process is revoking access.
+  } catch (err) {
+    // Cross-process contention stays fail-closed: a foreign writer may be
+    // mid-revocation, and deny is the only state we can assert. Only the
+    // provably race-free same-process case reads the committed file.
+    if ((err as { heldByCurrentProcess?: boolean }).heldByCurrentProcess === true) {
+      return loadExecApprovalsHeldByCurrentProcess();
+    }
     return createFailClosedExecApprovalsFallback();
   }
 }
@@ -68,8 +92,8 @@ export async function loadExecApprovalsAsync(): Promise<ExecApprovalsFile> {
       loadExecApprovalsUnlocked(),
     );
   } catch {
-    // Match the synchronous reader's fail-closed contract while allowing
-    // same-process async writers to finish instead of rejecting valid state.
+    // Match the synchronous reader's fail-closed contract; the async lock
+    // already waits for same-process holders via the process-local queue.
     return createFailClosedExecApprovalsFallback();
   }
 }


### PR DESCRIPTION
# What Problem This Solves

On a gateway configured fully permissive (no `tools.exec` config, Codex `appServer.mode: "yolo"`, a valid `exec-approvals.json` with empty defaults), agent runs intermittently die before replying with:

```
Codex app-server local execution is not available when tools.exec.mode=deny
```

Observed live on team.openclaw.ai (`openclaw-team`, dev channel, `ddd3d4fdb32`): 11 occurrences on 2026-07-25, across `lane=main` and dashboard session lanes, often two lanes failing in the same second under concurrent load. Nothing in that deployment configures deny anywhere: global config, agent config, session store, and `exec-approvals.json` are all permissive.

# Why This Change Was Made

Root cause is in `loadExecApprovals()` (`src/infra/exec-approvals-store.ts`):

1. Reading the approvals file takes an exclusive `.lock` sidecar via `withExecApprovalsReadLockSync`. The sync acquisition **fails instantly** when the lock is held by an async holder in the *same process* (`ownerPid === process.pid` short-circuits the retry loop — spinning would deadlock the event loop, since the async holder can never progress while sync code blocks it). It can also time out after ~200ms of cross-process contention.
2. On any lock failure, `loadExecApprovals()` silently returns `createFailClosedExecApprovalsFallback()` — a file with `defaults.security: "deny"`.
3. The Codex app-server connection path (`extensions/codex/src/app-server/run-attempt-connection.ts` → `resolveOpenClawExecPolicyForCodexAppServer`) applies that file as approval *floors*, clamping the configured `full` policy down to `deny` (`touched: true`), and `assertCodexAppServerAllowedForOpenClawExecMode` then hard-fails the entire run as if `tools.exec.mode=deny` had been configured.

So transient lock contention (e.g. one lane persisting an allow-always decision or ensuring the approvals socket while another lane starts a Codex run) is misreported as a permanent policy configuration and kills the whole agent turn.

The fix is scoped to the one provably race-free case: when the sync lock is held **by this same process**, read the committed file directly instead of fabricating deny. While sync code runs, the async holder is suspended on the single event loop and cannot commit a write, so the file on disk *is* the current committed policy — there is no staleness and no revocation window (writers persist with sync temp+rename; any hypothetical interleaved thread-pool write is torn-read-protected because `parsePersistedExecApprovals` fail-closes malformed bytes). The lock error now carries `heldByCurrentProcess` so the store can distinguish this case.

Everything else keeps the exact fail-closed posture: cross-process contention (a foreign writer may be mid-revocation) stays deny, malformed content stays deny, symlink/non-file refusals stay deny, and a **missing** file under a held lock stays deny — the holder may be committing the first policy, so absence proves nothing. `loadExecApprovalsAsync` is unchanged in behavior; its process-local queue already waits for same-process holders properly.

# User Impact

Agents on permissive hosts no longer intermittently fail whole runs with a misleading `tools.exec.mode=deny` error under concurrent load. No behavior change for genuinely configured deny/allowlist policies, malformed approvals files, or revocation flows — a contended read now observes the same persisted policy a moment-earlier read would have.

# Evidence

## Live contended before/after proof (real lock, real production path)

In-process repro that holds the **real** async `withExecApprovalsLock` (no forged lock files) and, while it is genuinely held, runs the exact production chain a Codex run startup uses — `loadExecApprovals` → `resolveOpenClawExecPolicyForCodexAppServer` → `resolveEffectiveOpenClawExecModeForCodexAppServer` → `assertCodexAppServerAllowedForOpenClawExecMode` — against an isolated `OPENCLAW_STATE_DIR` seeded with the team.openclaw.ai deployment's approvals shape (`{"version":1,"defaults":{},"agents":{}}` + socket) and a config with no `tools.exec` (yolo posture), agent `roboclaw`.

Before the fix (`src/infra/exec-approvals-{store,lock}.ts` at the parent commit):

```
lock sidecar exists while holder active: true
loadExecApprovals under same-process async holder -> defaults={"security":"deny","ask":"off","askFallback":"deny","autoAllowSkills":false}
resolved codex exec policy={"mode":"deny","security":"deny","ask":"off","touched":true} effectiveMode=deny
RESULT: codex app-server exec gate THREW: Codex app-server local execution is not available when tools.exec.mode=deny
```

— byte-identical to the production failure on `openclaw-team`.

After the fix (this PR's head):

```
lock sidecar exists while holder active: true
loadExecApprovals under same-process async holder -> defaults={}
resolved codex exec policy={"security":"full","ask":"off","touched":false} effectiveMode=undefined
RESULT: codex app-server exec gate PASSED (run would proceed)
```

## Codex source-contract check

Direct check of the sibling `codex` checkout (`634a998d8a`): the app-server sandbox contract OpenClaw maps into is `codex-rs/app-server-protocol/src/protocol/v2/permissions.rs:529` (`SandboxPolicy::{DangerFullAccess, ReadOnly, ExternalSandbox, WorkspaceWrite}`), consumed by `codexSandboxPolicyForTurn` in `extensions/codex/src/app-server/config-runtime.ts`. This PR does not change that mapping or any codex-rs-facing behavior; `assertCodexAppServerAllowedForOpenClawExecMode` is an OpenClaw-owned pre-spawn policy gate, and the change only fixes which approvals snapshot feeds it.

## Notes for review flags

- "Stored data model" flag: the serialized-state hits are test fixtures writing `exec-approvals.json` shapes already produced by shipped code; no schema or migration surface changes.
- This is a maintainer-directed change: the repository owner observed the failure live and directed diagnosis + fix + landing.

- Live diagnosis on `openclaw-team`: gateway log `openclaw-2026-07-25.log` shows `lane task error: lane=session:agent:roboclaw:dashboard:a81b4475-… error="Error: Codex app-server local execution is not available when tools.exec.mode=deny"` while `openclaw.json` has no `tools.exec`, Codex `appServer.mode: "yolo"`, and `exec-approvals.json` is `{"version":1,"defaults":{},"agents":{}}` (plus socket). The only deny producer on that path is the fail-closed lock fallback.
- New regression tests in `src/infra/exec-approvals-store.test.ts`:
  - a lock held by this process (async-holder simulation) no longer degrades a valid `security: "full"` policy to deny;
  - a lock held by another live process stays fail-closed deny (revocation posture unchanged);
  - malformed persisted policy stays fail-closed deny even while the lock is held.
- Autoreview (Codex `gpt-5.6-sol`) on the first iteration flagged that an unconditional lockless fallback could authorize from a pre-revocation policy during a cross-process write; the final shape scopes the fallback to same-process holders where that scenario is structurally impossible, and keeps cross-process contention deny.
- Focused run: `node scripts/run-vitest.mjs src/infra/exec-approvals-store.test.ts` — 80/80 passed (the interim fix without the missing-file guard correctly failed the existing "writer locks the store before creating the policy file" test, confirming that contract stays covered).
- `check:changed` classification delegated to a one-shot Blacksmith Testbox and passed; `oxfmt --check` and `git diff --check` clean locally.
