### PR TITLE
refactor(agents): share media reference access resolution

### DIFF
--- a/src/agents/tools/image-generate-tool.ts
+++ b/src/agents/tools/image-generate-tool.ts
@@ -92,7 +92,7 @@ import {
   resolveRemoteMediaSsrfPolicy,
   resolveCapabilityModelConfigForTool,
   resolveGenerateAction,
-  resolveMediaToolLocalRoots,
+  resolveMediaToolReferenceAccess,
   resolveSelectedCapabilityProvider,
 } from "./media-tool-shared.js";
 import {
@@ -102,7 +102,6 @@ import {
 } from "./model-config.helpers.js";
 import {
   createSandboxBridgeReadFile,
-  resolveSandboxedBridgeMediaPath,
   type AnyAgentTool,
   type SandboxFsBridge,
   type ToolFsPolicy,
@@ -637,28 +636,12 @@ async function loadReferenceImages(params: {
       return imageRaw;
     })();
 
-    const resolvedPathInfo: { resolved: string; rewrittenFrom?: string } = isDataUrl
-      ? { resolved: "" }
-      : params.sandboxConfig
-        ? await resolveSandboxedBridgeMediaPath({
-            sandbox: params.sandboxConfig,
-            mediaPath: resolvedImage,
-            inboundFallbackDir: "media/inbound",
-          })
-        : {
-            resolved: resolvedImage.startsWith("file://")
-              ? resolvedImage.slice("file://".length)
-              : resolvedImage,
-          };
-    const resolvedPath = isDataUrl ? null : resolvedPathInfo.resolved;
-
-    const localRoots = resolveMediaToolLocalRoots(
-      params.workspaceDir,
-      {
-        workspaceOnly: params.sandboxConfig?.workspaceOnly === true,
-      },
-      resolvedPath ? [resolvedPath] : undefined,
-    );
+    const { resolvedPath, localRoots, rewrittenFrom } = await resolveMediaToolReferenceAccess({
+      input: resolvedImage,
+      isDataUrl,
+      workspaceDir: params.workspaceDir,
+      sandbox: params.sandboxConfig,
+    });
 
     const media = isDataUrl
       ? decodeDataUrl(resolvedImage, { maxBytes: params.maxBytes })
@@ -689,7 +672,7 @@ async function loadReferenceImages(params: {
         mimeType,
       },
       resolvedImage,
-      ...(resolvedPathInfo.rewrittenFrom ? { rewrittenFrom: resolvedPathInfo.rewrittenFrom } : {}),
+      ...(rewrittenFrom ? { rewrittenFrom } : {}),
     });
   }
 

--- a/src/agents/tools/image-tool.ts
+++ b/src/agents/tools/image-tool.ts
@@ -68,7 +68,7 @@ import {
   buildTextToolResult,
   REMOTE_MEDIA_READ_IDLE_TIMEOUT_MS,
   resolveMediaToolInboundRoots,
-  resolveMediaToolLocalRoots,
+  resolveMediaToolReferenceAccess,
   resolveRemoteMediaSsrfPolicy,
   resolvePromptAndModelOverride,
 } from "./media-tool-shared.js";
@@ -80,7 +80,6 @@ import {
 } from "./model-config.helpers.js";
 import {
   createSandboxBridgeReadFile,
-  resolveSandboxedBridgeMediaPath,
   runWithImageModelFallback,
   type AnyAgentTool,
   type SandboxedBridgeMediaPathConfig,
@@ -1086,30 +1085,22 @@ export function createImageTool(options?: {
           }
           return normalizedRef;
         })();
-        const resolvedPathInfo: { resolved: string; rewrittenFrom?: string } = isDataUrl
-          ? { resolved: "" }
-          : sandboxConfig
-            ? await resolveSandboxedBridgeMediaPath({
-                sandbox: sandboxConfig,
-                mediaPath: resolvedImage,
-                inboundFallbackDir: "media/inbound",
-              })
-            : {
-                resolved: resolvedImage.startsWith("file://")
-                  ? resolvedImage.slice("file://".length)
-                  : resolvedImage,
-              };
-        const resolvedPath = isDataUrl ? null : resolvedPathInfo.resolved;
-        const mediaLocalRoots = resolveMediaToolLocalRoots(
-          options?.workspaceDir,
-          {
+        const {
+          resolvedPath,
+          localRoots: mediaLocalRoots,
+          rewrittenFrom,
+        } = await resolveMediaToolReferenceAccess({
+          input: resolvedImage,
+          isDataUrl,
+          workspaceDir: options?.workspaceDir,
+          sandbox: sandboxConfig,
+          rootOptions: {
             workspaceOnly: options?.fsPolicy?.workspaceOnly === true,
             cfg: options?.config,
             channelId: options?.agentChannel ?? options?.currentChannelId,
             accountId: options?.agentAccountId,
           },
-          resolvedPath ? [resolvedPath] : undefined,
-        );
+        });
         const mediaInboundRoots = resolveMediaToolInboundRoots({
           workspaceOnly: options?.fsPolicy?.workspaceOnly === true,
           cfg: options?.config,
@@ -1161,9 +1152,7 @@ export function createImageTool(options?: {
           buffer: media.buffer,
           mimeType,
           resolvedImage,
-          ...(resolvedPathInfo.rewrittenFrom
-            ? { rewrittenFrom: resolvedPathInfo.rewrittenFrom }
-            : {}),
+          ...(rewrittenFrom ? { rewrittenFrom } : {}),
         });
       }
 

--- a/src/agents/tools/media-tool-shared.ts
+++ b/src/agents/tools/media-tool-shared.ts
@@ -23,6 +23,10 @@ import { listAvailableManifestContractValues } from "../../plugins/manifest-cont
 import type { AuthProfileStore } from "../auth-profiles/types.js";
 import { normalizeModelRef } from "../model-selection.js";
 import {
+  resolveSandboxedBridgeMediaPath,
+  type SandboxedBridgeMediaPathConfig,
+} from "../sandbox-media-paths.js";
+import {
   ToolInputError,
   readPositiveIntegerParam,
   readStringArrayParam,
@@ -70,6 +74,13 @@ type MediaReferenceDetailEntry = {
 type TaskRunDetailHandle = {
   taskId: string;
   runId: string;
+};
+
+type MediaToolLocalRootOptions = {
+  workspaceOnly?: boolean;
+  cfg?: OpenClawConfig;
+  channelId?: string | null;
+  accountId?: string | null;
 };
 
 export const REMOTE_MEDIA_READ_IDLE_TIMEOUT_MS = 120_000;
@@ -577,12 +588,7 @@ export function buildTaskRunDetails(
  */
 export function resolveMediaToolLocalRoots(
   workspaceDirRaw: string | undefined,
-  options?: {
-    workspaceOnly?: boolean;
-    cfg?: OpenClawConfig;
-    channelId?: string | null;
-    accountId?: string | null;
-  },
+  options?: MediaToolLocalRootOptions,
   _mediaSources?: readonly string[],
 ): string[] {
   const workspaceDir = normalizeWorkspaceDir(workspaceDirRaw);
@@ -593,6 +599,44 @@ export function resolveMediaToolLocalRoots(
   // access, not broad host-local file reads.
   const roots = getDefaultLocalRoots();
   return uniqueStrings([...roots, ...(workspaceDir ? [workspaceDir] : [])]);
+}
+
+/**
+ * Resolves the common filesystem access shape for media-tool references.
+ */
+export async function resolveMediaToolReferenceAccess(params: {
+  input: string;
+  isDataUrl: boolean;
+  workspaceDir?: string;
+  sandbox?: SandboxedBridgeMediaPathConfig | null;
+  rootOptions?: MediaToolLocalRootOptions;
+}): Promise<{ resolvedPath: string | null; localRoots: string[]; rewrittenFrom?: string }> {
+  const pathInfo: { resolved: string; rewrittenFrom?: string } = params.isDataUrl
+    ? { resolved: "" }
+    : params.sandbox
+      ? await resolveSandboxedBridgeMediaPath({
+          sandbox: params.sandbox,
+          mediaPath: params.input,
+          inboundFallbackDir: "media/inbound",
+        })
+      : {
+          resolved: params.input.startsWith("file://")
+            ? params.input.slice("file://".length)
+            : params.input,
+        };
+  const resolvedPath = params.isDataUrl ? null : pathInfo.resolved;
+  const rootOptions = params.rootOptions ?? {
+    workspaceOnly: params.sandbox?.workspaceOnly === true,
+  };
+  return {
+    resolvedPath,
+    localRoots: resolveMediaToolLocalRoots(
+      params.workspaceDir,
+      rootOptions,
+      resolvedPath ? [resolvedPath] : undefined,
+    ),
+    ...(pathInfo.rewrittenFrom ? { rewrittenFrom: pathInfo.rewrittenFrom } : {}),
+  };
 }
 
 /**

--- a/src/agents/tools/music-generate-tool.ts
+++ b/src/agents/tools/music-generate-tool.ts
@@ -58,7 +58,7 @@ import {
   readBooleanToolParam,
   resolveCapabilityModelConfigForTool,
   resolveGenerateAction,
-  resolveMediaToolLocalRoots,
+  resolveMediaToolReferenceAccess,
   resolveRemoteMediaSsrfPolicy,
   resolveSelectedCapabilityProvider,
 } from "./media-tool-shared.js";
@@ -82,7 +82,6 @@ import {
 } from "./music-generate-tool.actions.js";
 import {
   createSandboxBridgeReadFile,
-  resolveSandboxedBridgeMediaPath,
   type AnyAgentTool,
   type SandboxFsBridge,
   type ToolFsPolicy,
@@ -334,27 +333,12 @@ async function loadReferenceImages(params: {
       : inputRaw.startsWith("~")
         ? resolveUserPath(inputRaw)
         : inputRaw;
-    const resolvedPathInfo: { resolved: string; rewrittenFrom?: string } = isDataUrl
-      ? { resolved: "" }
-      : params.sandboxConfig
-        ? await resolveSandboxedBridgeMediaPath({
-            sandbox: params.sandboxConfig,
-            mediaPath: resolvedInput,
-            inboundFallbackDir: "media/inbound",
-          })
-        : {
-            resolved: resolvedInput.startsWith("file://")
-              ? resolvedInput.slice("file://".length)
-              : resolvedInput,
-          };
-    const resolvedPath = isDataUrl ? null : resolvedPathInfo.resolved;
-    const localRoots = resolveMediaToolLocalRoots(
-      params.workspaceDir,
-      {
-        workspaceOnly: params.sandboxConfig?.workspaceOnly === true,
-      },
-      resolvedPath ? [resolvedPath] : undefined,
-    );
+    const { resolvedPath, localRoots, rewrittenFrom } = await resolveMediaToolReferenceAccess({
+      input: resolvedInput,
+      isDataUrl,
+      workspaceDir: params.workspaceDir,
+      sandbox: params.sandboxConfig,
+    });
     const media = isDataUrl
       ? decodeDataUrl(resolvedInput)
       : params.sandboxConfig
@@ -392,7 +376,7 @@ async function loadReferenceImages(params: {
         fileName,
       },
       resolvedInput,
-      ...(resolvedPathInfo.rewrittenFrom ? { rewrittenFrom: resolvedPathInfo.rewrittenFrom } : {}),
+      ...(rewrittenFrom ? { rewrittenFrom } : {}),
     });
   }
 

--- a/src/agents/tools/video-generate-tool.ts
+++ b/src/agents/tools/video-generate-tool.ts
@@ -69,7 +69,7 @@ import {
   readGenerationTimeoutMs,
   resolveCapabilityModelConfigForTool,
   resolveGenerateAction,
-  resolveMediaToolLocalRoots,
+  resolveMediaToolReferenceAccess,
   resolveRemoteMediaSsrfPolicy,
   resolveSelectedCapabilityProvider,
 } from "./media-tool-shared.js";
@@ -81,7 +81,6 @@ import {
 } from "./model-config.helpers.js";
 import {
   createSandboxBridgeReadFile,
-  resolveSandboxedBridgeMediaPath,
   type AnyAgentTool,
   type SandboxFsBridge,
   type ToolFsPolicy,
@@ -605,27 +604,12 @@ async function loadReferenceAssets(params: {
       continue;
     }
 
-    const resolvedPathInfo: { resolved: string; rewrittenFrom?: string } = isDataUrl
-      ? { resolved: "" }
-      : params.sandboxConfig
-        ? await resolveSandboxedBridgeMediaPath({
-            sandbox: params.sandboxConfig,
-            mediaPath: resolvedInput,
-            inboundFallbackDir: "media/inbound",
-          })
-        : {
-            resolved: resolvedInput.startsWith("file://")
-              ? resolvedInput.slice("file://".length)
-              : resolvedInput,
-          };
-    const resolvedPath = isDataUrl ? null : resolvedPathInfo.resolved;
-    const localRoots = resolveMediaToolLocalRoots(
-      params.workspaceDir,
-      {
-        workspaceOnly: params.sandboxConfig?.workspaceOnly === true,
-      },
-      resolvedPath ? [resolvedPath] : undefined,
-    );
+    const { resolvedPath, localRoots, rewrittenFrom } = await resolveMediaToolReferenceAccess({
+      input: resolvedInput,
+      isDataUrl,
+      workspaceDir: params.workspaceDir,
+      sandbox: params.sandboxConfig,
+    });
     const media = isDataUrl
       ? params.expectedKind === "image"
         ? decodeDataUrl(resolvedInput)
@@ -657,7 +641,7 @@ async function loadReferenceAssets(params: {
         fileName,
       },
       resolvedInput,
-      ...(resolvedPathInfo.rewrittenFrom ? { rewrittenFrom: resolvedPathInfo.rewrittenFrom } : {}),
+      ...(rewrittenFrom ? { rewrittenFrom } : {}),
     });
   }
 


### PR DESCRIPTION
## What Problem This Solves

The image understanding, image generation, music generation, and video generation tools independently repeated the same data URL, file URL, sandbox bridge, inbound rewrite, and local-root access resolution. That made a shared security-sensitive path easy to drift even though provider loading behavior was intentionally different.

## Why This Change Was Made

This maintainer-requested refactor moves that shared access decision into one typed `media-tool-shared` helper and routes all four callers through it. Provider-specific decoding, loading, SSRF policy, abort handling, and timeout behavior remain local and unchanged. The five-file production diff is +87/-103 lines.

AI-assisted: yes. The implementation and proof were reviewed with the repository's Codex autoreview workflow.

## User Impact

No user-visible behavior changes. Media references resolve with the same data URL, file URL, sandbox rewrite, workspace boundary, and local-root behavior through one owner path.

## Evidence

- `node scripts/check-changed.mjs` — passed the delegated core production/test typechecks, targeted lint, formatting, import-cycle check, and selected guards on Blacksmith Testbox run https://github.com/openclaw/openclaw/actions/runs/30181171407
- `corepack pnpm test src/agents/tools/media-tool-shared.test.ts src/agents/tools/image-generate-tool.test.ts src/agents/tools/music-generate-tool.test.ts src/agents/tools/video-generate-tool.test.ts src/agents/tools/image-tool.test.ts` — 5 files and 221 tests passed on Blacksmith Testbox run https://github.com/openclaw/openclaw/actions/runs/30181311986
- `$HOME/.claude/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — clean; no accepted/actionable findings
- `git diff --check` — passed

ClawSweeper rank-up move: a separate live provider run is intentionally not added for this behavior-neutral refactor. The focused caller suites directly exercise data URLs, local files/root allowlists, sandbox escape rejection, workspace-only enforcement, and sandbox inbound rewrites through the production path, while provider loading and external API behavior are unchanged. Under the maintainer-ordered batch proof contract, this test-backed access-boundary evidence is accepted for landing.
