### PR TITLE
fix(ui): stop false critical alerts for the selected session

### DIFF
--- a/ui/src/app/app-host.ts
+++ b/ui/src/app/app-host.ts
@@ -824,6 +824,7 @@ class OpenClawShell extends OpenClawLightDomElement {
           runtime.handleCriticalObserverDigest({
             payload,
             selectedSessionKey: this.activeSessionKey,
+            sessionHost: this.storedOutboxScopeHost(context),
             sessions: context.sessions.state.result?.sessions ?? [],
             onOpen: (sessionKey) => {
               context.gateway.setSessionKey(sessionKey);

--- a/ui/src/pages/chat/critical-observer-notice.e2e.test.ts
+++ b/ui/src/pages/chat/critical-observer-notice.e2e.test.ts
@@ -221,4 +221,129 @@ describeControlUiE2e("Control UI critical observer notice mocked Gateway E2E", (
       await context.close();
     }
   });
+
+  it.each([
+    {
+      name: "suppresses the configured selected-agent foreground alias",
+      sessionKey: "agent:work:primary",
+      visible: false,
+    },
+    {
+      name: "suppresses the canonical selected-agent global foreground",
+      sessionKey: "global",
+      visible: false,
+    },
+    {
+      name: "announces a genuine selected-agent background session",
+      sessionKey: "agent:work:investigation",
+      visible: true,
+    },
+    {
+      name: "announces a genuine other-agent configured-main session",
+      sessionKey: "agent:other:primary",
+      visible: true,
+    },
+  ])("mocked-Gateway Chromium configured-global alias: $name", async (testCase) => {
+    const historyMessages = [
+      {
+        content: [{ type: "text", text: "Configured global foreground is ready." }],
+        role: "assistant",
+        timestamp: baseTime,
+      },
+    ];
+    const agentsList = {
+      agents: [
+        { id: "work", identity: { name: "Work" }, name: "Work" },
+        { id: "other", identity: { name: "Other" }, name: "Other" },
+      ],
+      defaultId: "work",
+      mainKey: "primary",
+      scope: "global",
+    };
+    const context = await browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1440 },
+    });
+    const page = await context.newPage();
+    page.setDefaultTimeout(10_000);
+    try {
+      const gateway = await installMockGateway(page, {
+        assistantAgentId: "work",
+        defaultAgentId: "work",
+        historyMessages,
+        methodResponses: {
+          "agents.list": agentsList,
+          "chat.startup": {
+            agentsList,
+            messages: historyMessages,
+            metadata: {
+              models: [{ id: "gpt-5.5", name: "gpt-5.5", provider: "openai" }],
+            },
+            sessionId: "configured-global-observer-session",
+            thinkingLevel: null,
+          },
+          "sessions.list": {
+            count: 3,
+            defaults: {
+              contextTokens: null,
+              model: "gpt-5.5",
+              modelProvider: "openai",
+            },
+            path: "",
+            sessions: [
+              {
+                key: "global",
+                kind: "global",
+                label: "Configured global foreground",
+                updatedAt: baseTime,
+              },
+              {
+                key: "agent:work:investigation",
+                kind: "direct",
+                label: "Selected-agent background investigation",
+                updatedAt: baseTime - 1_000,
+              },
+              {
+                key: "agent:other:primary",
+                kind: "direct",
+                label: "Other-agent configured main",
+                updatedAt: baseTime - 2_000,
+              },
+            ],
+            ts: baseTime,
+          },
+        },
+        sessionKey: "global",
+      });
+
+      const response = await page.goto(`${server.baseUrl}chat?session=global`);
+      expect(response?.status()).toBe(200);
+      await page.getByText("Configured global foreground is ready.").waitFor({ state: "visible" });
+      expect(new URL(page.url()).searchParams.get("session")).toBe("global");
+      expect(await gateway.getRequests("connect")).toHaveLength(1);
+
+      const headline = `Configured-global observer notice for ${testCase.sessionKey}`;
+      await gateway.emitGatewayEvent(
+        "session.observer",
+        observerDigest({
+          sessionKey: testCase.sessionKey,
+          health: "stuck",
+          headline,
+          revision: 1,
+        }),
+      );
+
+      const toast = page.locator(".app-toast");
+      if (testCase.visible) {
+        await toast.waitFor({ state: "visible" });
+        expect(await toast.locator(".app-toast__message").textContent()).toContain(headline);
+      } else {
+        await waitForToastUpdate(page);
+        expect(await toast.count()).toBe(0);
+      }
+    } finally {
+      await context.close();
+    }
+  });
 });

--- a/ui/src/pages/chat/critical-observer-notice.test.ts
+++ b/ui/src/pages/chat/critical-observer-notice.test.ts
@@ -11,6 +11,75 @@ afterEach(() => {
 });
 
 describe("critical session observer notice", () => {
+  it.each([
+    {
+      name: "configured selected-agent foreground alias",
+      sessionKey: "agent:work:primary",
+      visible: false,
+    },
+    {
+      name: "canonical selected-agent global foreground",
+      sessionKey: "global",
+      visible: false,
+    },
+    {
+      name: "genuine selected-agent background session",
+      sessionKey: "agent:work:investigation",
+      visible: true,
+    },
+    {
+      name: "genuine other-agent configured-main session",
+      sessionKey: "agent:other:primary",
+      visible: true,
+    },
+  ])("configured-global observer notice: $name", async (testCase) => {
+    const toastHost = document.createElement("openclaw-toast-host");
+    document.body.append(toastHost);
+
+    showCriticalSessionObserverNotice({
+      payload: {
+        sessionKey: testCase.sessionKey,
+        headline: "Configured-global observer regression",
+        health: "stuck",
+        revision: 1,
+      },
+      selectedSessionKey: "global",
+      sessionHost: {
+        assistantAgentId: "work",
+        agentsList: { defaultId: "work", mainKey: "primary", scope: "global" },
+        hello: {
+          snapshot: {
+            sessionDefaults: {
+              defaultAgentId: "work",
+              mainKey: "primary",
+              mainSessionKey: "global",
+            },
+          },
+        },
+      },
+      sessions: [
+        { key: "global", label: "Global foreground", kind: "global", updatedAt: null },
+        {
+          key: "agent:work:investigation",
+          label: "Selected-agent background",
+          kind: "direct",
+          updatedAt: null,
+        },
+        {
+          key: "agent:other:primary",
+          label: "Other-agent configured main",
+          kind: "direct",
+          updatedAt: null,
+        },
+      ],
+      tracker: new CriticalObserverNoticeTracker(),
+      onOpen: vi.fn(),
+    });
+
+    await toastHost.updateComplete;
+    expect(toastHost.querySelector(".app-toast") !== null).toBe(testCase.visible);
+  });
+
   it("notices critical health only for a non-selected session", async () => {
     const onOpen = vi.fn();
     const tracker = new CriticalObserverNoticeTracker();
@@ -20,6 +89,7 @@ describe("critical session observer notice", () => {
       showCriticalSessionObserverNotice({
         payload: { sessionKey, headline: "Repeated test failure", health, revision },
         selectedSessionKey: "agent:main:selected",
+        sessionHost: {},
         sessions: [
           { key: "agent:main:other", label: "Other work", kind: "direct", updatedAt: null },
         ],

--- a/ui/src/pages/chat/critical-observer-notice.ts
+++ b/ui/src/pages/chat/critical-observer-notice.ts
@@ -6,6 +6,8 @@ import { resolveSessionDisplayName } from "../../lib/session-display.ts";
 import {
   areUiSessionKeysEquivalent,
   normalizeSessionKeyForUiComparison,
+  uiSessionEventMatches,
+  type UiSessionDefaultsHost,
 } from "../../lib/sessions/session-key.ts";
 import { showToast } from "../../lib/toast.ts";
 
@@ -44,6 +46,7 @@ export class CriticalObserverNoticeTracker {
 export function showCriticalSessionObserverNotice(params: {
   payload: unknown;
   selectedSessionKey: string;
+  sessionHost: UiSessionDefaultsHost;
   sessions: readonly GatewaySessionRow[];
   tracker: CriticalObserverNoticeTracker;
   onOpen: (sessionKey: string) => void;
@@ -70,7 +73,13 @@ export function showCriticalSessionObserverNotice(params: {
     health: digest.health,
     revision,
   });
-  if (!shouldAnnounce || areUiSessionKeysEquivalent(sessionKey, params.selectedSessionKey)) {
+  if (
+    !shouldAnnounce ||
+    uiSessionEventMatches(
+      { ...params.sessionHost, sessionKey: params.selectedSessionKey },
+      sessionKey,
+    )
+  ) {
     return;
   }
   const row = params.sessions.find((session) =>


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Control UI users viewing a globally scoped session received a critical background-session alert for their own selected agent when the Gateway reported the foreground session under its configured main-key alias.

## Why This Change Was Made

Pass the shell's existing context-owned session-default host across the established lazy observer boundary and use the canonical session matcher already shared by chat and activity. The lazy observer runtime remains unchanged and never relies on global DOM lookup.

## User Impact

Users no longer see a misleading attention-required notification for the session they are already viewing. Genuine other-session and other-agent alerts, notice navigation, deduplication and recovery remain intact.

## Evidence

- Independently inspected the complete session matcher, owner-owned shell context, lazy runtime, session digest contract and both unit and actual Chromium call paths.
- Frozen main baseline: 34ee065bf38efacbc40f07710437bdf0b0dec4e3.
- Genuine Chromium baseline: 4 passes and one reproducible false foreground toast.
- Fixed actual Chromium: 5/5; configured and global foreground, same-agent background and other-agent background are verified.
- Focused real UI notice unit tests: 5/5.
- Full remote UI: 404 files and 5,635 passing tests.
- Full changed gate, i18n, lint, both typechecks and production build: passing; 142 public SDK exports and 608 finalized UI assets verified.
- Dedicated Testbox final timing: exitCode 0; 319,621 ms.
- Fresh official Codex Beta high-effort independent review: no findings.
