### PR TITLE
fix(ui): find plugins by their npm package name

### DIFF
--- a/ui/src/pages/plugins/plugins.e2e.test.ts
+++ b/ui/src/pages/plugins/plugins.e2e.test.ts
@@ -39,6 +39,7 @@ const pluginMethods = [
 const workboardDisabled = {
   id: "workboard",
   name: "Workboard",
+  packageName: "@openclaw/workboard",
   description: "Dashboard workboard for agent-owned issues and sessions.",
   version: "2026.7.9",
   kind: ["productivity"],
@@ -324,6 +325,46 @@ describeControlUiE2e("Control UI Plugins mocked Gateway E2E", () => {
     await browser?.close();
     await server?.close();
   });
+
+  it.each(["installed", "discover"] as const)(
+    "finds an existing plugin by scoped package identity in the %s catalog",
+    async (tab) => {
+      const context = await newContext();
+      const page = await context.newPage();
+      const gateway = await installMockGateway(page, {
+        featureMethods: pluginMethods,
+        methodResponses: {
+          ...pluginMethodResponses(),
+          "plugins.search": { results: [] },
+        },
+      });
+
+      try {
+        await page.goto(`${server.baseUrl}settings/plugins`);
+        const workboardCard = page.locator('[data-plugin-id="workboard"]');
+        await workboardCard.waitFor({ state: "visible" });
+
+        if (tab === "discover") {
+          await page.getByRole("tab", { name: /^Discover/u }).click();
+          await workboardCard.waitFor({ state: "visible" });
+        }
+
+        await page.getByRole("searchbox", { name: "Search plugins" }).fill("@openclaw/workboard");
+        await workboardCard.waitFor({ state: "visible", timeout: 5_000 });
+        await captureScreenshot(page, `08-scoped-package-${tab}.png`);
+
+        if (tab === "discover") {
+          const searchRequest = await gateway.waitForRequest("plugins.search");
+          expect(requestParams(searchRequest)).toEqual({
+            query: "@openclaw/workboard",
+            limit: 20,
+          });
+        }
+      } finally {
+        await context.close();
+      }
+    },
+  );
 
   it("browses the catalog, installs from ClawHub, enables Workboard, and refreshes authoritative state", async () => {
     const context = await newContext();

--- a/ui/src/pages/plugins/view.test.ts
+++ b/ui/src/pages/plugins/view.test.ts
@@ -235,6 +235,44 @@ describe("renderPlugins", () => {
     expect(onFilterChange).toHaveBeenCalledWith("issues");
   });
 
+  it.each(["@openclaw/workboard", "  @OPENCLAW/WORKBOARD  "])(
+    "finds an installed plugin by its scoped package name %s",
+    (query) => {
+      const plugin = createPlugin({ packageName: "@openclaw/workboard" });
+      const container = mount(createProps({ query, result: createResult([plugin]) }));
+
+      expect(container.querySelector('[data-plugin-id="workboard"]')).not.toBeNull();
+      expect(normalizedText(container)).toContain("@openclaw/workboard");
+    },
+  );
+
+  it.each([
+    { shelf: "featured", featured: true },
+    { shelf: "official", featured: false },
+  ])("finds an official $shelf plugin by its scoped package name", ({ featured }) => {
+    const plugin = createPlugin({
+      id: "calendar-runtime",
+      name: "Shared Calendar",
+      packageName: "@openclaw/calendar-runtime",
+      description: "Schedule team events.",
+      origin: "official",
+      installed: false,
+      enabled: false,
+      state: "not-installed",
+      featured,
+      install: { source: "official", pluginId: "calendar-runtime" },
+    });
+    const container = mount(
+      createProps({
+        activeTab: "discover",
+        query: "@openclaw/calendar-runtime",
+        result: createResult([plugin]),
+      }),
+    );
+
+    expect(container.querySelector('[data-plugin-id="calendar-runtime"]')).not.toBeNull();
+  });
+
   it("offers enable and remove through direct row actions", () => {
     const onSetEnabled = vi.fn();
     const onRequestUninstall = vi.fn();

--- a/ui/src/pages/plugins/view.ts
+++ b/ui/src/pages/plugins/view.ts
@@ -148,6 +148,7 @@ function matchesPlugin(plugin: PluginCatalogItem, query: string): boolean {
   return [
     plugin.name,
     plugin.id,
+    plugin.packageName,
     plugin.description,
     plugin.origin,
     plugin.category,


### PR DESCRIPTION
## What Problem This Solves

Users searching Installed or Discover plugins by their actual scoped npm package name cannot find the real plugin even though its package identity is returned by the live Gateway and visibly belongs to both catalogs.

## Why This Change Was Made

Include the existing canonical `packageName` in the one shared plugin filter. This repairs Installed, Featured and Discover together without changing installation, ClawHub trust, authentication, configuration, remote search or plugin ownership.

## User Impact

Typing a real identity such as `@openclaw/workboard` reliably keeps the real Workboard card visible on both Installed and Discover, including current case-insensitive and whitespace-normalized search.

## Independently Verified Real Production Proof

An independently built production Control UI connects to a real authenticated packaged Gateway; no mocked Gateway is involved. Chromium 144, `/healthz=200`, `/readyz=200`, the actual 157-plugin `plugins.list`, and actual `plugins.search` WebSocket frames are recorded. The live bundled Workboard has `id=workboard`, `packageName=@openclaw/workboard`, `installed=true`, and `featured=true`.

Current main has the exact same production owner blob as PR parent `34ee065bf38efacbc40f07710437bdf0b0dec4e3`. All three changed owner/test Git blobs were independently verified against immutable PR head `6d8361e1df46313a827fd09badd2272aafd6a620`.

Literal genuine browser result:

```text
AUTOQA_PR113933_REAL_BASELINE_INSTALLED  visibleBefore=true visibleAfter=false
AUTOQA_PR113933_REAL_BASELINE_DISCOVER   visibleBefore=true visibleAfter=false
AUTOQA_PR113933_REAL_BASELINE_DISCOVER_REQUEST plugins.search query=@openclaw/workboard limit=20
AUTOQA_PR113933_REAL_CANDIDATE_INSTALLED visibleBefore=true visibleAfter=true
AUTOQA_PR113933_REAL_CANDIDATE_DISCOVER  visibleBefore=true visibleAfter=true
AUTOQA_PR113933_REAL_CANDIDATE_DISCOVER_REQUEST plugins.search query=@openclaw/workboard limit=20
AUTOQA_PR113933_STABILIZED_REAL_GATEWAY_VISUAL_ALL_PASS
exitCode=0
```

## Actual Four-Image Visual Verification

Four independently preserved authentic 1440×1000 Chromium before/after screenshots are available in the operator's `OpenClaw-AutoQA-Evidence/control-ui/pr113933-6d8361e1/stabilized/` evidence. Capture waited for real `document.fonts.ready`, two animation frames and a settled paint. Every screenshot was decoded inside the real browser and seven widely separated actual pixels verified; **all four have `opaqueBlackSampleCount=0`**. Live computed `html/body=rgb(250,249,247)`, `main=rgb(244,241,236)`, five loaded stylesheets and light color scheme verify that the application was genuinely painted.

| Phase | Real scoped-package result | PNG SHA-256 |
| --- | --- | --- |
| baseline Installed | Workboard incorrectly hidden | `dbbbcb2675e229f8145f4b9f928223b794678e76fe90b61f3b600269e01397c9` |
| baseline Discover | Workboard incorrectly hidden; actual Gateway search dispatched | `111f4c1d8946ba5cef54812f4af1879ca35ee8abd5795ed1421734b971dc84d7` |
| fixed Installed | real Workboard card visibly retained | `8b13a9f9013468da0e55c86997b9e92818a9bb55c5165824e509c9d9e0fd5a7a` |
| fixed Discover | real Workboard card visibly retained; actual Gateway search dispatched | `6a508050bf70d05fbe5fd43290097f7e39f91b30961dd1bfed127028f1445c25` |

Authoritative stabilized full visual/source manifest SHA-256: `ceb7ea16aa34749db6e319092e5b0ddc756177213f1f6a90003b3e47ee626ee1`; full redacted baseline WebSocket/DOM manifest `9ecce7a1d7d20486e956bd3abaf4673fe9c10ce9c59cc1769a7dd3c99a0b5186`; candidate manifest `342ba52460259a3450df103acfb45fca075b0d05710f3452e3c709da7fe17c32`.

An earlier instantaneous capture could race Chromium compositor paint; its original evidence was retained separately instead of being represented as a stable screenshot. The settled four-image run above independently disproves a product theme/black-background regression. Existing Teams/Zoom plugin-icon 401/404 responses are faithfully recorded in both phases and are not claimed fixed by this unrelated search PR.

## Additional Validation

- Personally reviewed the full plugin view, both test owners, real Chromium lifecycle, actual Gateway catalog and all Installed/Discover callers.
- Shared renderer regression and real Chromium plugin journeys pass.
- Full production build and all 142 public plugin SDK exports pass.
- Exact-head full remote changed gate, package validation and fresh high-effort independent review pass.
- Separate official SMS/IRC catalog trust remains a user-review-only investigation.