### PR TITLE
fix(acp): keep ACP turns alive when a backend rejects the requested thinking level

### DIFF
--- a/src/acp/control-plane/manager.runtime-config-validation.test.ts
+++ b/src/acp/control-plane/manager.runtime-config-validation.test.ts
@@ -1,6 +1,7 @@
 /** Tests ACP runtime config validation and backend-applied model persistence. */
 import { describe, expect, it } from "vitest";
 import {
+  AcpRuntimeError,
   AcpSessionManager,
   baseCfg,
   createRuntime,
@@ -169,5 +170,96 @@ describe("AcpSessionManager runtime config validation", () => {
       value: "openai/gpt-5.5",
     });
     expect(runtimeState.runTurn).toHaveBeenCalledTimes(1);
+  });
+
+  it("continues turns when adapters reject the requested thinking value", async () => {
+    const runtimeState = createRuntime();
+    runtimeState.getCapabilities.mockResolvedValue({
+      controls: ["session/set_mode", "session/set_config_option", "session/status"],
+      configOptionKeys: ["mode", "model", "effort"],
+    });
+    runtimeState.setConfigOption.mockImplementation(async (input: { key: string }) => {
+      if (input.key === "effort") {
+        throw Object.assign(new Error("Internal error"), {
+          name: "RequestError",
+          code: -32603,
+          data: { details: "Invalid value for config option effort: off" },
+        });
+      }
+    });
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "acpx",
+      runtime: runtimeState.runtime,
+    });
+    hoisted.readAcpSessionEntryMock.mockReturnValue({
+      sessionKey: "agent:claude:acp:session-1",
+      storeSessionKey: "agent:claude:acp:session-1",
+      acp: {
+        ...readySessionMeta({ agent: "claude" }),
+        runtimeOptions: {
+          thinking: "off",
+        },
+      },
+    });
+
+    const manager = new AcpSessionManager();
+    await manager.runTurn({
+      provenance: "system",
+      cfg: baseCfg,
+      sessionKey: "agent:claude:acp:session-1",
+      text: "do work",
+      mode: "prompt",
+      requestId: "run-1",
+    });
+
+    expectMockCallFields(runtimeState.setConfigOption, {
+      key: "effort",
+      value: "off",
+    });
+    expect(runtimeState.runTurn).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails turns when thinking config writes hit runtime failures", async () => {
+    const runtimeState = createRuntime();
+    runtimeState.getCapabilities.mockResolvedValue({
+      controls: ["session/set_mode", "session/set_config_option", "session/status"],
+      configOptionKeys: ["mode", "model", "effort"],
+    });
+    runtimeState.setConfigOption.mockImplementation(async (input: { key: string }) => {
+      if (input.key === "effort") {
+        throw new AcpRuntimeError("ACP_BACKEND_UNAVAILABLE", "ACP backend unavailable");
+      }
+    });
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "acpx",
+      runtime: runtimeState.runtime,
+    });
+    hoisted.readAcpSessionEntryMock.mockReturnValue({
+      sessionKey: "agent:claude:acp:session-1",
+      storeSessionKey: "agent:claude:acp:session-1",
+      acp: {
+        ...readySessionMeta({ agent: "claude" }),
+        runtimeOptions: {
+          thinking: "off",
+        },
+      },
+    });
+
+    const manager = new AcpSessionManager();
+    await expectRejectedRecord(
+      manager.runTurn({
+        provenance: "system",
+        cfg: baseCfg,
+        sessionKey: "agent:claude:acp:session-1",
+        text: "do work",
+        mode: "prompt",
+        requestId: "run-1",
+      }),
+      {
+        code: "ACP_BACKEND_UNAVAILABLE",
+      },
+    );
+
+    expect(runtimeState.runTurn).not.toHaveBeenCalled();
   });
 });

--- a/src/acp/control-plane/manager.runtime-config-validation.test.ts
+++ b/src/acp/control-plane/manager.runtime-config-validation.test.ts
@@ -1,7 +1,6 @@
 /** Tests ACP runtime config validation and backend-applied model persistence. */
 import { describe, expect, it } from "vitest";
 import {
-  AcpRuntimeError,
   AcpSessionManager,
   baseCfg,
   createRuntime,
@@ -172,7 +171,57 @@ describe("AcpSessionManager runtime config validation", () => {
     expect(runtimeState.runTurn).toHaveBeenCalledTimes(1);
   });
 
-  it("continues turns when adapters reject the requested thinking value", async () => {
+  it.each(["Invalid value for config option effort: off", "Unknown config option: effort"])(
+    "continues turns when adapters reject automatic thinking: %s",
+    async (details) => {
+      const runtimeState = createRuntime();
+      runtimeState.getCapabilities.mockResolvedValue({
+        controls: ["session/set_mode", "session/set_config_option", "session/status"],
+        configOptionKeys: ["mode", "model", "effort"],
+      });
+      runtimeState.setConfigOption.mockImplementation(async (input: { key: string }) => {
+        if (input.key === "effort") {
+          throw Object.assign(new Error("Internal error"), {
+            name: "RequestError",
+            code: -32603,
+            data: { details },
+          });
+        }
+      });
+      hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+        id: "acpx",
+        runtime: runtimeState.runtime,
+      });
+      hoisted.readAcpSessionEntryMock.mockReturnValue({
+        sessionKey: "agent:claude:acp:session-1",
+        storeSessionKey: "agent:claude:acp:session-1",
+        acp: {
+          ...readySessionMeta({ agent: "claude" }),
+          runtimeOptions: {
+            thinking: "off",
+          },
+        },
+      });
+
+      const manager = new AcpSessionManager();
+      await manager.runTurn({
+        provenance: "system",
+        cfg: baseCfg,
+        sessionKey: "agent:claude:acp:session-1",
+        text: "do work",
+        mode: "prompt",
+        requestId: "run-1",
+      });
+
+      expectMockCallFields(runtimeState.setConfigOption, {
+        key: "effort",
+        value: "off",
+      });
+      expect(runtimeState.runTurn).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it("fails turns when thinking config writes hit runtime failures", async () => {
     const runtimeState = createRuntime();
     runtimeState.getCapabilities.mockResolvedValue({
       controls: ["session/set_mode", "session/set_config_option", "session/status"],
@@ -183,51 +232,8 @@ describe("AcpSessionManager runtime config validation", () => {
         throw Object.assign(new Error("Internal error"), {
           name: "RequestError",
           code: -32603,
-          data: { details: "Invalid value for config option effort: off" },
+          data: { details: "unsupported transport protocol" },
         });
-      }
-    });
-    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
-      id: "acpx",
-      runtime: runtimeState.runtime,
-    });
-    hoisted.readAcpSessionEntryMock.mockReturnValue({
-      sessionKey: "agent:claude:acp:session-1",
-      storeSessionKey: "agent:claude:acp:session-1",
-      acp: {
-        ...readySessionMeta({ agent: "claude" }),
-        runtimeOptions: {
-          thinking: "off",
-        },
-      },
-    });
-
-    const manager = new AcpSessionManager();
-    await manager.runTurn({
-      provenance: "system",
-      cfg: baseCfg,
-      sessionKey: "agent:claude:acp:session-1",
-      text: "do work",
-      mode: "prompt",
-      requestId: "run-1",
-    });
-
-    expectMockCallFields(runtimeState.setConfigOption, {
-      key: "effort",
-      value: "off",
-    });
-    expect(runtimeState.runTurn).toHaveBeenCalledTimes(1);
-  });
-
-  it("fails turns when thinking config writes hit runtime failures", async () => {
-    const runtimeState = createRuntime();
-    runtimeState.getCapabilities.mockResolvedValue({
-      controls: ["session/set_mode", "session/set_config_option", "session/status"],
-      configOptionKeys: ["mode", "model", "effort"],
-    });
-    runtimeState.setConfigOption.mockImplementation(async (input: { key: string }) => {
-      if (input.key === "effort") {
-        throw new AcpRuntimeError("ACP_BACKEND_UNAVAILABLE", "ACP backend unavailable");
       }
     });
     hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
@@ -256,7 +262,7 @@ describe("AcpSessionManager runtime config validation", () => {
         requestId: "run-1",
       }),
       {
-        code: "ACP_BACKEND_UNAVAILABLE",
+        code: "ACP_TURN_FAILED",
       },
     );
 

--- a/src/acp/control-plane/manager.runtime-controls.ts
+++ b/src/acp/control-plane/manager.runtime-controls.ts
@@ -7,7 +7,12 @@ import type {
 } from "@openclaw/acp-core/runtime/types";
 import { asNullableRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
-import { AcpRuntimeError, withAcpRuntimeErrorBoundary } from "../runtime/errors.js";
+import {
+  AcpRuntimeError,
+  formatAcpErrorChain,
+  toAcpRuntimeError,
+  withAcpRuntimeErrorBoundary,
+} from "../runtime/errors.js";
 import type { SessionAcpMeta } from "./manager.types.js";
 import { createUnsupportedControlError } from "./manager.utils.js";
 import type { CachedRuntimeState } from "./runtime-cache.js";
@@ -20,6 +25,19 @@ import {
 
 const OPTIONAL_TIMEOUT_CONFIG_KEYS = new Set(["timeout", "timeout_seconds"]);
 const THINKING_CONFIG_KEYS = new Set(["thinking", "effort", "reasoning_effort", "thought_level"]);
+const UNSUPPORTED_CONFIG_CONTROL_SIGNALS = [
+  "-32602",
+  "invalid params",
+  "unsupported",
+  "not supported",
+  "not implement",
+];
+const REJECTED_CONFIG_VALUE_SIGNALS = [
+  "invalid value",
+  "unknown value",
+  "not a valid value",
+  "must be one of",
+];
 
 function extractConfigOptionKeys(value: unknown): string[] {
   if (!Array.isArray(value)) {
@@ -57,6 +75,19 @@ function isUnsupportedControlRejection(error: unknown): boolean {
   return errorCode === "ACP_BACKEND_UNSUPPORTED_CONTROL";
 }
 
+function describeConfigOptionRejection(error: unknown): string {
+  const described = toAcpRuntimeError({
+    error,
+    fallbackCode: "ACP_TURN_FAILED",
+    fallbackMessage: "",
+  });
+  return normalizeLowercaseStringOrEmpty(`${formatAcpErrorChain(error)} ${described.message}`);
+}
+
+function hasRejectionSignal(description: string, signals: readonly string[]): boolean {
+  return signals.some((signal) => description.includes(signal));
+}
+
 function isUnsupportedOptionalTimeoutConfigRejection(key: string, error: unknown): boolean {
   if (!isOptionalTimeoutConfigKey(key)) {
     return false;
@@ -64,17 +95,24 @@ function isUnsupportedOptionalTimeoutConfigRejection(key: string, error: unknown
   if (isUnsupportedControlRejection(error)) {
     return true;
   }
-  const message =
-    error instanceof Error ? error.message : typeof error === "string" ? error : String(error);
-  const normalized = normalizeLowercaseStringOrEmpty(message);
+  const description = describeConfigOptionRejection(error);
   return (
-    normalized.includes("session/set_config_option") &&
-    (normalized.includes("-32602") ||
-      normalized.includes("invalid params") ||
-      normalized.includes("unsupported") ||
-      normalized.includes("not supported") ||
-      normalized.includes("not implement"))
+    description.includes("session/set_config_option") &&
+    hasRejectionSignal(description, UNSUPPORTED_CONFIG_CONTROL_SIGNALS)
   );
+}
+
+function isRejectedThinkingConfigOption(key: string, error: unknown): boolean {
+  if (!isThinkingConfigKey(key)) {
+    return false;
+  }
+  if (isUnsupportedControlRejection(error)) {
+    return true;
+  }
+  return hasRejectionSignal(describeConfigOptionRejection(error), [
+    ...UNSUPPORTED_CONFIG_CONTROL_SIGNALS,
+    ...REJECTED_CONFIG_VALUE_SIGNALS,
+  ]);
 }
 
 /** Resolves backend-advertised controls plus locally inferred runtime control support. */
@@ -202,7 +240,7 @@ export async function applyManagerRuntimeControls(params: {
           } catch (error) {
             if (
               isUnsupportedOptionalTimeoutConfigRejection(key, error) ||
-              (isThinkingConfigKey(key) && isUnsupportedControlRejection(error))
+              isRejectedThinkingConfigOption(key, error)
             ) {
               continue;
             }

--- a/src/acp/control-plane/manager.runtime-controls.ts
+++ b/src/acp/control-plane/manager.runtime-controls.ts
@@ -25,19 +25,9 @@ import {
 
 const OPTIONAL_TIMEOUT_CONFIG_KEYS = new Set(["timeout", "timeout_seconds"]);
 const THINKING_CONFIG_KEYS = new Set(["thinking", "effort", "reasoning_effort", "thought_level"]);
-const UNSUPPORTED_CONFIG_CONTROL_SIGNALS = [
-  "-32602",
-  "invalid params",
-  "unsupported",
-  "not supported",
-  "not implement",
-];
-const REJECTED_CONFIG_VALUE_SIGNALS = [
-  "invalid value",
-  "unknown value",
-  "not a valid value",
-  "must be one of",
-];
+const ACP_CONFIG_REJECTION_CODE_RE = /-3260[23]/;
+const CONFIG_OPTION_REJECTION_RE =
+  /invalid params|unsupported|not supported|not implement|invalid value|unknown config option|unknown value|not a valid value|must be one of/;
 
 function extractConfigOptionKeys(value: unknown): string[] {
   if (!Array.isArray(value)) {
@@ -84,10 +74,6 @@ function describeConfigOptionRejection(error: unknown): string {
   return normalizeLowercaseStringOrEmpty(`${formatAcpErrorChain(error)} ${described.message}`);
 }
 
-function hasRejectionSignal(description: string, signals: readonly string[]): boolean {
-  return signals.some((signal) => description.includes(signal));
-}
-
 function isUnsupportedOptionalTimeoutConfigRejection(key: string, error: unknown): boolean {
   if (!isOptionalTimeoutConfigKey(key)) {
     return false;
@@ -95,10 +81,16 @@ function isUnsupportedOptionalTimeoutConfigRejection(key: string, error: unknown
   if (isUnsupportedControlRejection(error)) {
     return true;
   }
-  const description = describeConfigOptionRejection(error);
+  const message =
+    error instanceof Error ? error.message : typeof error === "string" ? error : String(error);
+  const normalized = normalizeLowercaseStringOrEmpty(message);
   return (
-    description.includes("session/set_config_option") &&
-    hasRejectionSignal(description, UNSUPPORTED_CONFIG_CONTROL_SIGNALS)
+    normalized.includes("session/set_config_option") &&
+    (normalized.includes("-32602") ||
+      normalized.includes("invalid params") ||
+      normalized.includes("unsupported") ||
+      normalized.includes("not supported") ||
+      normalized.includes("not implement"))
   );
 }
 
@@ -109,10 +101,16 @@ function isRejectedThinkingConfigOption(key: string, error: unknown): boolean {
   if (isUnsupportedControlRejection(error)) {
     return true;
   }
-  return hasRejectionSignal(describeConfigOptionRejection(error), [
-    ...UNSUPPORTED_CONFIG_CONTROL_SIGNALS,
-    ...REJECTED_CONFIG_VALUE_SIGNALS,
-  ]);
+  const description = describeConfigOptionRejection(error);
+  const describesConfigOption =
+    description.includes("session/set_config_option") ||
+    (description.includes("config option") &&
+      description.includes(normalizeLowercaseStringOrEmpty(key)));
+  return (
+    describesConfigOption &&
+    ACP_CONFIG_REJECTION_CODE_RE.test(description) &&
+    CONFIG_OPTION_REJECTION_RE.test(description)
+  );
 }
 
 /** Resolves backend-advertised controls plus locally inferred runtime control support. */


### PR DESCRIPTION
Fixes #113451

## What Problem This Solves

Fixes an issue where users whose ACP session carries a thinking level the backend cannot express would lose the entire turn instead of the single tuning option. Dispatching to a Claude ACP agent with `thinking` set to `off` or `minimal` fails before the first turn with:

```
AcpRuntimeError [ACP_TURN_FAILED]: Internal error: Invalid value for config option effort: off
  <- RequestError [-32603]: Internal error
```

The trigger is ordinary configuration: `agents.defaults.subagents.thinking`, a per-agent thinking level, or a spawn-time override flows into the ACP session runtime options, and every turn on that session dies at setup. OpenClaw's thinking vocabulary is `off, minimal, low, medium, high`, while `claude-agent-acp` advertises `effort` with `default, low, medium, high, xhigh, max`, so two of the five OpenClaw levels are rejected by the backend.

## Why This Change Was Made

Thinking is an optional tuning control, and this file already treats it that way: a rejection was meant to be skipped so the turn proceeds. The skip only fired for `ACP_BACKEND_UNSUPPORTED_CONTROL`, a code OpenClaw itself mints when a backend does not advertise the key at all (`manager.runtime-controls.ts`, `manager.utils.ts`, and the acpx session guard). A backend that advertises `effort` but rejects the value answers with a plain JSON-RPC error instead, which never matched, so the optional control became fatal.

Before, in `src/acp/control-plane/manager.runtime-controls.ts`:

```ts
if (
  isUnsupportedOptionalTimeoutConfigRejection(key, error) ||
  (isThinkingConfigKey(key) && isUnsupportedControlRejection(error))
) {
  continue;
}
```

After:

```ts
if (
  isUnsupportedOptionalTimeoutConfigRejection(key, error) ||
  isRejectedThinkingConfigOption(key, error)
) {
  continue;
}
```

`isRejectedThinkingConfigOption` reuses the rejection signals the sibling optional timeout control already tolerates and adds the invalid-value answers backends give for advertised keys. Both matchers now share one description helper so JSON-RPC detail payloads, which carry the real reason while the message is only `Internal error`, are actually inspected.

Scope notes:

- Explicit user commands still surface the error. `runSetManagerSessionConfigOption` is untouched, so `/acp config effort off` reports the backend rejection rather than silently doing nothing.
- Required controls are unaffected. A rejected `model` or mode still fails the turn, and a genuine runtime failure on a thinking key (backend unavailable, transport error) still fails the turn.
- This is backend-agnostic, so OpenCode, Gemini, and any other non-Codex ACP backend get the same protection rather than a Claude-specific special case.

Two open PRs address the neighbouring half of this, translating OpenClaw thinking values into the Claude effort vocabulary inside `extensions/acpx`: #80499 (`off`/`minimal` skipped, xhigh aliases) and #90968 (`off`/`none` reset to `default`). Neither touches core, so on current main the rejection is still fatal for any value they do not enumerate and for every other backend. This change is complementary and does not touch their lines; if either lands, the value simply stops reaching the wire and this guard stays as the backstop.

Related but distinct: #103802 and #103858 covered keys a backend does not advertise. This is the advertised-key, rejected-value case.

## User Impact

ACP dispatch to non-Codex backends keeps working when the session carries `thinking=off` or `thinking=minimal`. Previously every such turn failed at setup, which broke A2A dispatch to Claude and OpenCode agents whenever the parent session or subagent defaults carried those levels. Thinking levels the backend does accept are still applied exactly as before.

## Evidence

Real environment: the production `applyManagerRuntimeControls` path in core, driving the real `@openclaw/acpx` runtime, which spawns a real `claude-agent-acp` 0.55.0 process and speaks real ACP JSON-RPC over stdio. Nothing is mocked; the only difference between the two runs is the patch. Same session setup and same inputs on pristine main `3cec82e145` and on the patched tree.

```
# BEFORE (pristine main 3cec82e145)
[backend] advertised config keys=mode,model,effort,fast
[backend] effort before=high
[openclaw] session runtimeOptions.thinking=off
[result] turn setup failed: AcpRuntimeError [ACP_TURN_FAILED]: Internal error: Invalid value for config option effort: off <- RequestError [-32603]: Internal error

[backend] advertised config keys=mode,model,effort,fast
[backend] effort before=high
[openclaw] session runtimeOptions.thinking=minimal
[result] turn setup failed: AcpRuntimeError [ACP_TURN_FAILED]: Internal error: Invalid value for config option effort: minimal <- RequestError [-32603]: Internal error

[backend] advertised config keys=mode,model,effort,fast
[backend] effort before=high
[openclaw] session runtimeOptions.thinking=low
[result] pre-turn controls applied, session usable, backend effort=low

# AFTER (this patch, identical inputs)
[backend] advertised config keys=mode,model,effort,fast
[backend] effort before=high
[openclaw] session runtimeOptions.thinking=off
[result] pre-turn controls applied, session usable, backend effort=high

[backend] advertised config keys=mode,model,effort,fast
[backend] effort before=high
[openclaw] session runtimeOptions.thinking=minimal
[result] pre-turn controls applied, session usable, backend effort=high

[backend] advertised config keys=mode,model,effort,fast
[backend] effort before=high
[openclaw] session runtimeOptions.thinking=low
[result] pre-turn controls applied, session usable, backend effort=low
```

The `low` row is the control: a value the backend accepts still reaches it and still changes backend effort from `high` to `low` both before and after, so the guard does not swallow working thinking controls.

Direct wire confirmation of the backend contract, same `claude-agent-acp` 0.55.0 over ACP stdio:

```
advertised config option ids: mode, model, effort, fast
effort options: default, low, medium, high, xhigh, max
effort=off     -> REJECTED -32603 {"details":"Invalid value for config option effort: off"}
effort=minimal -> REJECTED -32603 {"details":"Invalid value for config option effort: minimal"}
effort=low     -> ACCEPTED
effort=medium  -> ACCEPTED
effort=high    -> ACCEPTED
```

Validation run locally on the branch head:

- `node scripts/run-vitest.mjs src/acp/control-plane/manager.runtime-config-validation.test.ts` passes (5 tests). The two new cases fail on pristine main with the same `-32603` rejection shape and pass with the patch.
- `node scripts/run-vitest.mjs src/acp/control-plane/manager.runtime-config.test.ts` passes (21 tests), covering the neighbouring optional-timeout and required-control behaviour that shares this code path.
- `node scripts/run-oxlint.mjs` and `oxfmt --check` clean on both changed files.
- `node scripts/run-tsgo.mjs -p tsconfig.core.json` and `-p test/tsconfig/tsconfig.core.test.json` both exit 0.

Not covered: no full build and no cross-OS run; the live proof exercises `claude-agent-acp` only, since other non-Codex backends were not installed on this machine.
