### PR TITLE
test(kimi): align K3 public policy fixture

### DIFF
--- a/src/plugins/provider-public-artifacts.test.ts
+++ b/src/plugins/provider-public-artifacts.test.ts
@@ -142,10 +142,16 @@ describe("provider public artifacts", () => {
       }),
     ).toEqual({
       levels: [
-        { id: "off", label: "off" },
-        { id: "max", label: "max" },
+        { id: "off" },
+        { id: "minimal" },
+        { id: "low" },
+        { id: "medium" },
+        { id: "high" },
+        { id: "adaptive" },
+        { id: "xhigh" },
+        { id: "max" },
       ],
-      defaultLevel: "max",
+      defaultLevel: "high",
       preserveWhenCatalogReasoningFalse: true,
     });
   });


### PR DESCRIPTION
## What Problem This Solves

Resolves a beta validation failure where the release-only plugin suite expects Kimi Code K3's retired two-level thinking policy instead of the current adaptive policy.

## Why This Change Was Made

Align the public provider-artifact fixture with the provider-owned K3 policy already covered by its focused policy tests: the full reasoning-level set, `high` default, and catalog-reasoning preservation.

## User Impact

No runtime behavior changes. Release validation now verifies the shipped Kimi K3 thinking policy accurately.

## Evidence

- Plugin Prerelease 30181408177 reproduced the mismatch in `checks-node-agentic-plugins`.
- `node scripts/run-vitest.mjs src/plugins/provider-public-artifacts.test.ts` — 14 tests passed.
- `git diff --check` — passed.
- Autoreview — clean, no accepted/actionable findings.

AI-assisted: yes.
