### PR TITLE
fix(browser): restore Chrome page sharing on default gateways

### DIFF
--- a/extensions/browser/index.test.ts
+++ b/extensions/browser/index.test.ts
@@ -15,20 +15,30 @@ import { BrowserToolOutputSchema } from "./src/browser-tool.schema.js";
 
 type BrowserAutoEnableProbe = Parameters<OpenClawPluginApi["registerAutoEnableProbe"]>[0];
 
-const runtimeApiMocks = vi.hoisted(() => ({
-  createBrowserPluginService: vi.fn(() => ({ id: "browser-control", start: vi.fn() })),
-  createBrowserTool: vi.fn(() => ({
-    name: "browser",
-    description: "browser",
-    parameters: { type: "object", properties: {} },
-    execute: vi.fn(async () => ({ type: "json", value: { ok: true } })),
-  })),
-  collectBrowserSecurityAuditFindings: vi.fn(() => []),
-  handleBrowserGatewayRequest: vi.fn(),
-  registerBrowserCli: vi.fn(),
-  runBrowserProxyCommand: vi.fn(async () => "ok"),
-  stopBrowserControlService: vi.fn(async () => undefined),
-}));
+const runtimeApiMocks = vi.hoisted(() => {
+  const startBrowserPluginService = vi.fn(async () => undefined);
+  const stopBrowserPluginService = vi.fn(async () => undefined);
+  return {
+    createBrowserPluginService: vi.fn(() => ({
+      id: "browser-control",
+      start: startBrowserPluginService,
+      stop: stopBrowserPluginService,
+    })),
+    startBrowserPluginService,
+    stopBrowserPluginService,
+    createBrowserTool: vi.fn(() => ({
+      name: "browser",
+      description: "browser",
+      parameters: { type: "object", properties: {} },
+      execute: vi.fn(async () => ({ type: "json", value: { ok: true } })),
+    })),
+    collectBrowserSecurityAuditFindings: vi.fn(() => []),
+    handleBrowserGatewayRequest: vi.fn(),
+    registerBrowserCli: vi.fn(),
+    runBrowserProxyCommand: vi.fn(async () => "ok"),
+    stopBrowserControlService: vi.fn(async () => undefined),
+  };
+});
 
 vi.mock("./register.runtime.js", async () => {
   const actual =
@@ -49,6 +59,10 @@ vi.mock("./src/cli/browser-cli.js", () => ({
 
 vi.mock("./src/control-service.js", () => ({
   stopBrowserControlService: runtimeApiMocks.stopBrowserControlService,
+}));
+
+vi.mock("./src/plugin-service.js", () => ({
+  createBrowserPluginService: runtimeApiMocks.createBrowserPluginService,
 }));
 
 beforeAll(async () => {
@@ -406,7 +420,7 @@ describe("browser plugin", () => {
     expect(runtimeApiMocks.collectBrowserSecurityAuditFindings).toHaveBeenCalled();
   });
 
-  it("registers a lazy browser control service", async () => {
+  it("starts the page-share lifecycle without eagerly loading browser control", async () => {
     const { api, registerService } = createApi();
     registerBrowserPlugin(api);
 
@@ -420,11 +434,14 @@ describe("browser plugin", () => {
     expect(typeof service?.stop).toBe("function");
     expect(runtimeApiMocks.createBrowserPluginService).not.toHaveBeenCalled();
 
-    await service.start({ config: {}, stateDir: "/tmp/openclaw", logger: { warn: vi.fn() } });
-    expect(runtimeApiMocks.createBrowserPluginService).not.toHaveBeenCalled();
+    const context = { config: {}, stateDir: "/tmp/openclaw", logger: { warn: vi.fn() } };
+    await service.start(context);
+    expect(runtimeApiMocks.createBrowserPluginService).toHaveBeenCalledOnce();
+    expect(runtimeApiMocks.startBrowserPluginService).toHaveBeenCalledExactlyOnceWith(context);
 
-    await service.stop({ config: {}, stateDir: "/tmp/openclaw", logger: { warn: vi.fn() } });
-    expect(runtimeApiMocks.stopBrowserControlService).toHaveBeenCalledOnce();
+    await service.stop(context);
+    expect(runtimeApiMocks.stopBrowserPluginService).toHaveBeenCalledExactlyOnceWith(context);
+    expect(runtimeApiMocks.stopBrowserControlService).not.toHaveBeenCalled();
   });
 
   it("eager-loads the browser control service when explicitly requested", async () => {
@@ -437,12 +454,14 @@ describe("browser plugin", () => {
       start: (...args: unknown[]) => unknown;
     };
 
-    await service.start({ config: {}, stateDir: "/tmp/openclaw", logger: { warn: vi.fn() } });
+    const context = { config: {}, stateDir: "/tmp/openclaw", logger: { warn: vi.fn() } };
+    await service.start(context);
     expect(runtimeApiMocks.createBrowserPluginService).toHaveBeenCalledOnce();
+    expect(runtimeApiMocks.startBrowserPluginService).toHaveBeenCalledExactlyOnceWith(context);
   });
 
   for (const value of ["false", "", "disabled"]) {
-    it(`keeps browser control service env value ${JSON.stringify(value)} lazy`, async () => {
+    it(`starts page sharing when eager browser control is ${JSON.stringify(value)}`, async () => {
       vi.stubEnv("OPENCLAW_EAGER_BROWSER_CONTROL_SERVER", value);
       const { api, registerService } = createApi();
       registerBrowserPlugin(api);
@@ -452,10 +471,25 @@ describe("browser plugin", () => {
         start: (...args: unknown[]) => unknown;
       };
 
-      await service.start({ config: {}, stateDir: "/tmp/openclaw", logger: { warn: vi.fn() } });
-      expect(runtimeApiMocks.createBrowserPluginService).not.toHaveBeenCalled();
+      const context = { config: {}, stateDir: "/tmp/openclaw", logger: { warn: vi.fn() } };
+      await service.start(context);
+      expect(runtimeApiMocks.createBrowserPluginService).toHaveBeenCalledOnce();
+      expect(runtimeApiMocks.startBrowserPluginService).toHaveBeenCalledExactlyOnceWith(context);
     });
   }
+
+  it("stops on-demand browser control when the registered service never started", async () => {
+    const { api, registerService } = createApi();
+    registerBrowserPlugin(api);
+
+    const service = mockCallArg(registerService) as {
+      stop: (...args: unknown[]) => unknown;
+    };
+    await service.stop({ config: {}, stateDir: "/tmp/openclaw", logger: { warn: vi.fn() } });
+
+    expect(runtimeApiMocks.createBrowserPluginService).not.toHaveBeenCalled();
+    expect(runtimeApiMocks.stopBrowserControlService).toHaveBeenCalledOnce();
+  });
 
   it("declares setup auto-enable reasons for browser config surfaces", () => {
     const probe = registerBrowserAutoEnableProbe();

--- a/extensions/browser/plugin-registration.ts
+++ b/extensions/browser/plugin-registration.ts
@@ -14,7 +14,7 @@ import type {
   OpenClawPluginToolContext,
   OpenClawPluginToolFactory,
 } from "openclaw/plugin-sdk/plugin-entry";
-import { createSubsystemLogger, isTruthyEnvValue } from "openclaw/plugin-sdk/runtime-env";
+import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import { isBrowserMachineOutput } from "./cli-output-mode.js";
 import {
   BROWSER_REQUEST_GATEWAY_METHOD,
@@ -33,7 +33,6 @@ import {
   type SystemProfileImportState,
 } from "./src/browser/system-profile-import-state.js";
 
-const EAGER_BROWSER_CONTROL_SERVICE_ENV = "OPENCLAW_EAGER_BROWSER_CONTROL_SERVER";
 const logger = createSubsystemLogger("browser");
 
 const loadBrowserRegistrationRuntimeModule = createLazyRuntimeModule(
@@ -205,7 +204,7 @@ function createLazyBrowserPluginService(): OpenClawPluginService {
   let service: OpenClawPluginService | null = null;
   const loadService = async () => {
     if (!service) {
-      const { createBrowserPluginService } = await loadBrowserRegistrationRuntimeModule();
+      const { createBrowserPluginService } = await import("./src/plugin-service.js");
       service = createBrowserPluginService();
     }
     return service;
@@ -213,9 +212,7 @@ function createLazyBrowserPluginService(): OpenClawPluginService {
   return {
     id: "browser-control",
     start: async (ctx) => {
-      if (!isTruthyEnvValue(process.env[EAGER_BROWSER_CONTROL_SERVICE_ENV])) {
-        return;
-      }
+      // Page sharing needs its Gateway sink even while browser control stays lazy.
       const loaded = await loadService();
       await loaded.start(ctx);
     },


### PR DESCRIPTION
## What Problem This Solves

Default Gateways registered the Browser service but returned before starting it unless eager browser control was enabled. The lightweight Gateway page-share sink therefore never existed, so an already paired Chrome extension could not deliver a shared page.

## Why This Change Was Made

The Browser plugin service is already the canonical split owner: it installs and clears the Gateway-only page-share sink on every service lifecycle, then independently checks the existing eager-control setting before loading browser automation. This rewrite deletes the duplicate outer eager guard and imports only that narrow service owner. Browser control remains lazy, node-host relays remain unable to synthesize a Gateway sink, and stop-before-start cleanup is preserved.

The stale Chrome E2E hunk was discarded. Current `main` already has newer focused-window/active-tab handling that matches Chrome and CDP contracts, and that extension-only test does not prove Gateway service startup.

## User Impact

After maintainer approval, Chrome page sharing on a default Gateway will reach the main session without enabling eager browser control. This is an intentional user-visible default-path behavior repair, so the branch is preserved for decision but must not merge under this work order’s decision gate.

## Evidence

- Current-main bug: `extensions/browser/plugin-registration.ts:216-217` returned before starting the only owner that installs the Gateway page-share sink.
- Fail-first command: `node scripts/run-vitest.mjs extensions/browser/index.test.ts` -> 4 failed, 15 passed; every default/non-truthy startup case showed `createBrowserPluginService` called zero times.
- Fixed owner-boundary proof:
  - `node scripts/run-vitest.mjs extensions/browser/index.test.ts` -> 19 passed.
  - `node scripts/run-vitest.mjs extensions/browser/src/plugin-service.test.ts extensions/browser/src/browser/extension-relay/page-share.test.ts extensions/browser/src/browser/extension-relay/relay-bridge.test.ts` -> 44 passed.
- Targeted `oxfmt` and `git diff --check` passed.
- Isolated Codex autoreview completed in one round with no accepted/actionable findings and 0.99 confidence.
- Production delta: +3/-6 (net -3). Test delta: +57/-23.
- Latest ClawSweeper has no patch finding. Its rank-up move—exact-head real-profile Gateway-startup-to-page-share proof while control remains lazy—remains intentionally pending the maintainer decision and authorization for a disposable/default Gateway pairing target. No operator Gateway was restarted and no Chrome pairing or shared-tab state was changed.
