### PR TITLE
feat(ui): person grouping and people filter in the sidebar catalog view menu

### DIFF
--- a/ui/src/components/app-sidebar-session-catalogs.ts
+++ b/ui/src/components/app-sidebar-session-catalogs.ts
@@ -16,6 +16,7 @@ import type {
 } from "../lib/sessions/catalog-key.ts";
 import { buildCatalogSessionKey } from "../lib/sessions/catalog-key.ts";
 import {
+  groupCatalogSessionsByPerson,
   groupCatalogSessionsByProject,
   type CatalogProjectGrouping,
 } from "../lib/sessions/catalog-project-grouping.ts";
@@ -105,6 +106,7 @@ type SessionCatalogGroupsParams = {
   renderLiveRow: (row: GatewaySessionRow, display: CatalogBackingSessionDisplay) => unknown;
   onToggleSection: (sectionId: string) => void;
   viewMenuOpenCatalogId: string | null;
+  creatorFilterActive: boolean;
   onOpenViewMenu: (trigger: HTMLElement) => void;
   onLoadMore: (catalogId: string) => void;
   onOpenNewSession?: (agentId: string, target?: NewSessionTarget) => void;
@@ -232,7 +234,9 @@ export function renderSessionCatalogGroups(params: SessionCatalogGroupsParams) {
           </button>
           <button
             type="button"
-            class="sidebar-session-group-actions sidebar-session-sort sidebar-session-catalog-grouping"
+            class="sidebar-session-group-actions sidebar-session-sort sidebar-session-catalog-grouping ${params.creatorFilterActive
+              ? "sidebar-session-sort--filtered"
+              : ""}"
             data-session-catalog-view-menu=${catalog.id}
             title=${t("chat.sidebar.catalogViewOptions")}
             aria-label=${t("chat.sidebar.catalogViewOptions")}
@@ -293,7 +297,11 @@ function renderCatalogHostGroup(
 ) {
   const errorHelp = host.error ? `[${host.error.code}] ${host.error.message}` : undefined;
   const projectGroups =
-    params.projectGrouping === "project" ? groupCatalogSessionsByProject(host.sessions) : null;
+    params.projectGrouping === "project"
+      ? groupCatalogSessionsByProject(host.sessions)
+      : params.projectGrouping === "person"
+        ? groupCatalogSessionsByPerson(host.sessions)
+        : null;
   // Gateway errors stay on the catalog header; node headings remain so remote rows keep their owner.
   const showHostHeading = host.kind !== "gateway";
   return html`

--- a/ui/src/components/app-sidebar-session-list-render.ts
+++ b/ui/src/components/app-sidebar-session-list-render.ts
@@ -333,6 +333,7 @@ function renderSessionCatalogs(params: {
       ? (host.sidebarMenus.catalogViewMenuTrigger?.getAttribute("data-session-catalog-view-menu") ??
         null)
       : null,
+    creatorFilterActive: host.sessionCreatorFilterActive,
     onOpenViewMenu: (trigger) => host.sidebarMenus.toggleCatalogViewMenu(trigger),
     onLoadMore: (catalogId) => void host.sessionData.loadMoreSessionCatalog(catalogId),
     onOpenNewSession: host.onOpenNewSession,

--- a/ui/src/components/app-sidebar-session-menu-renderers.ts
+++ b/ui/src/components/app-sidebar-session-menu-renderers.ts
@@ -94,7 +94,10 @@ export function renderSidebarCatalogViewMenu(params: {
   position: { x: number; y: number } | null;
   trigger: HTMLElement | null;
   grouping: CatalogProjectGrouping;
+  creators: readonly SessionCreatorOption[];
+  creatorFilterId: string | null;
   onGroupingChange: (grouping: CatalogProjectGrouping) => void;
+  onCreatorFilterChange: (creatorId: string | null) => void;
   onClose: (restoreFocus: boolean) => void;
 }) {
   const position = params.position;
@@ -103,6 +106,7 @@ export function renderSidebarCatalogViewMenu(params: {
   }
   const groupingOptions = [
     { grouping: "project", label: t("chat.sidebar.catalogGroupByProject") },
+    { grouping: "person", label: t("chat.sidebar.catalogGroupByPerson") },
     { grouping: "none", label: t("sessionsView.groupByNone") },
   ] as const satisfies ReadonlyArray<{ grouping: CatalogProjectGrouping; label: string }>;
   return keyed(
@@ -120,6 +124,8 @@ export function renderSidebarCatalogViewMenu(params: {
             const value = event.detail.item.value;
             if (value?.startsWith("grouping:")) {
               params.onGroupingChange(value.slice("grouping:".length) as CatalogProjectGrouping);
+            } else if (value?.startsWith("creator:")) {
+              params.onCreatorFilterChange(value.slice("creator:".length) || null);
             }
           }}
           @keydown=${(event: KeyboardEvent) =>
@@ -154,6 +160,45 @@ export function renderSidebarCatalogViewMenu(params: {
               </wa-dropdown-item>
             `,
           )}
+          ${params.creators.length >= 2
+            ? html`
+                <div class="session-menu__separator" role="separator"></div>
+                <div class="sidebar-session-sort-menu__title">${t("sessionsView.people")}</div>
+                <wa-dropdown-item
+                  class="sidebar-session-sort-menu__item"
+                  value="creator:"
+                  role="menuitemradio"
+                  aria-checked=${String(params.creatorFilterId === null)}
+                  ${ref((element) =>
+                    syncDropdownItemRadio(element, params.creatorFilterId === null),
+                  )}
+                >
+                  <span slot="details" class="session-menu__check" aria-hidden="true"
+                    >${params.creatorFilterId === null ? icons.check : nothing}</span
+                  >
+                  <span class="session-menu__text">${t("sessionsView.allCreators")}</span>
+                </wa-dropdown-item>
+                ${params.creators.map(
+                  (creator) => html`
+                    <wa-dropdown-item
+                      class="sidebar-session-sort-menu__item"
+                      value=${`creator:${creator.id}`}
+                      role="menuitemradio"
+                      aria-checked=${String(params.creatorFilterId === creator.id)}
+                      ${ref((element) =>
+                        syncDropdownItemRadio(element, params.creatorFilterId === creator.id),
+                      )}
+                    >
+                      <span slot="details" class="session-menu__check" aria-hidden="true"
+                        >${params.creatorFilterId === creator.id ? icons.check : nothing}</span
+                      >
+                      ${renderSessionOwnerChip(creator, "row")}
+                      <span class="session-menu__text">${creator.label ?? creator.id}</span>
+                    </wa-dropdown-item>
+                  `,
+                )}
+              `
+            : nothing}
         </wa-dropdown>
       </openclaw-menu-surface>
     `,

--- a/ui/src/components/sidebar-menus-render.ts
+++ b/ui/src/components/sidebar-menus-render.ts
@@ -327,8 +327,15 @@ export function renderSidebarCatalogViewMenuForController(controller: SidebarMen
     position,
     trigger: controller.catalogViewMenuTrigger,
     grouping: host.catalogProjectGrouping,
+    creators: host.sessionOwnershipVisible ? host.sessionCreatorOptions : [],
+    creatorFilterId: host.sessionCreatorFilterActive ? host.sessionCreatorFilterId : null,
     onGroupingChange: (grouping) => {
       host.setCatalogProjectGrouping(grouping);
+      controller.closeCatalogViewMenu({ restoreFocus: true });
+    },
+    onCreatorFilterChange: (creatorId) => {
+      host.sessionCreatorFilterId = creatorId;
+      void host.sessionDataContext?.sessions.setCreatorFilter(creatorId);
       controller.closeCatalogViewMenu({ restoreFocus: true });
     },
     onClose: (restoreFocus) => {

--- a/ui/src/e2e/codex-sessions.e2e.test.ts
+++ b/ui/src/e2e/codex-sessions.e2e.test.ts
@@ -292,6 +292,7 @@ suite("Codex native session catalog", () => {
                       archived: false,
                       canContinue: true,
                       canArchive: true,
+                      createdActor: { type: "human", id: "profile-ada", label: "Ada" },
                     },
                     {
                       threadId: "thread-worktree",
@@ -301,6 +302,7 @@ suite("Codex native session catalog", () => {
                       archived: false,
                       canContinue: true,
                       canArchive: true,
+                      createdActor: { type: "human", id: "profile-zoe", label: "Zoe" },
                     },
                     {
                       threadId: "thread-other",
@@ -406,6 +408,30 @@ suite("Codex native session catalog", () => {
           path: path.join(uiProofArtifactDir, "04-flat-session-hosts.png"),
         });
       }
+
+      // Person mode groups adopted (attributed) sessions and leaves native
+      // threads without a creator in the flat tail.
+      await catalogHead.hover();
+      await viewMenuButton.click();
+      await page
+        .getByRole("menuitemradio", { name: "Person" })
+        .evaluate((element) => (element as HTMLElement).click());
+      await expect.poll(() => projectHeads.count()).toBe(2);
+      expect(
+        await section
+          .locator('[data-session-catalog-project="person:profile-ada"]')
+          .locator(".sidebar-session-catalog-project__label")
+          .textContent(),
+      ).toBe("Ada");
+      expect(
+        await section
+          .locator('[data-session-catalog-project="person:profile-zoe"]')
+          .locator(".sidebar-session-catalog-project__label")
+          .textContent(),
+      ).toBe("Zoe");
+      expect(
+        await page.evaluate((key) => localStorage.getItem(key), catalogGroupingStorageKey),
+      ).toBe("person");
 
       await catalogHead.hover();
       await viewMenuButton.click();

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -4034,6 +4034,7 @@ export const en: TranslationMap = {
       coding: "Coding",
       catalogViewOptions: "View options",
       catalogGroupByProject: "Project",
+      catalogGroupByPerson: "Person",
       openSessionMenu: "Open thread menu",
       sortBy: "Sort by",
       sortCreated: "Created",

--- a/ui/src/lib/sessions/catalog-project-grouping.test.ts
+++ b/ui/src/lib/sessions/catalog-project-grouping.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { SessionCatalogSession } from "../../../../packages/gateway-protocol/src/index.ts";
 import {
+  groupCatalogSessionsByPerson,
   groupCatalogSessionsByProject,
   normalizeCatalogProjectGrouping,
 } from "./catalog-project-grouping.ts";
@@ -8,6 +9,7 @@ import {
 describe("normalizeCatalogProjectGrouping", () => {
   it.each([
     ["project", "project"],
+    ["person", "person"],
     ["none", "none"],
     [undefined, "project"],
     [null, "project"],
@@ -87,6 +89,42 @@ describe("groupCatalogSessionsByProject", () => {
       label: expectedLabel,
       title: expectedKey,
     });
+  });
+});
+
+describe("groupCatalogSessionsByPerson", () => {
+  it("groups attributed sessions by creator, sorted by label, and keeps session order", () => {
+    const result = groupCatalogSessionsByPerson([
+      { ...session("z-1"), createdActor: { type: "human", id: "profile-zoe", label: "Zoe" } },
+      { ...session("a-1"), createdActor: { type: "human", id: "profile-ada", label: "Ada" } },
+      { ...session("z-2"), createdActor: { type: "human", id: "profile-zoe", label: "Zoe" } },
+    ]);
+
+    expect(result.groups.map((group) => group.key)).toEqual([
+      "person:profile-ada",
+      "person:profile-zoe",
+    ]);
+    expect(result.groups.map((group) => group.label)).toEqual(["Ada", "Zoe"]);
+    expect(result.groups[1]?.sessions.map((item) => item.threadId)).toEqual(["z-1", "z-2"]);
+    expect(result.groups[0]?.title).toBe("Created by Ada");
+  });
+
+  it("falls back to the actor id when the label is missing or blank", () => {
+    const result = groupCatalogSessionsByPerson([
+      { ...session("one"), createdActor: { type: "human", id: "profile-ada", label: "  " } },
+    ]);
+
+    expect(result.groups[0]).toMatchObject({ key: "person:profile-ada", label: "profile-ada" });
+  });
+
+  it("leaves unattributed sessions in the flat ungrouped tail", () => {
+    const result = groupCatalogSessionsByPerson([
+      session("native"),
+      { ...session("adopted"), createdActor: { type: "human", id: "profile-ada", label: "Ada" } },
+    ]);
+
+    expect(result.groups).toHaveLength(1);
+    expect(result.ungrouped.map((item) => item.threadId)).toEqual(["native"]);
   });
 });
 

--- a/ui/src/lib/sessions/catalog-project-grouping.ts
+++ b/ui/src/lib/sessions/catalog-project-grouping.ts
@@ -1,9 +1,9 @@
 import type { SessionCatalogSession } from "../../../../packages/gateway-protocol/src/index.ts";
 
-export type CatalogProjectGrouping = "project" | "none";
+export type CatalogProjectGrouping = "project" | "person" | "none";
 
 export function normalizeCatalogProjectGrouping(raw: unknown): CatalogProjectGrouping {
-  return raw === "none" ? "none" : "project";
+  return raw === "none" || raw === "person" ? raw : "project";
 }
 
 type CatalogProjectGroup = {
@@ -73,4 +73,35 @@ export function groupCatalogSessionsByProject(sessions: readonly SessionCatalogS
   }
 
   return { groups: [...customGroups, ...projectGroups], ungrouped };
+}
+
+/** Groups adopted sessions by their creator identity. Native threads only carry
+    `createdActor` once adopted (the gateway strips provider-supplied actors), so
+    unattributed sessions intentionally fall to the flat ungrouped tail. */
+export function groupCatalogSessionsByPerson(sessions: readonly SessionCatalogSession[]): {
+  groups: CatalogProjectGroup[];
+  ungrouped: SessionCatalogSession[];
+} {
+  const groupsById = new Map<string, CatalogProjectGroup>();
+  const ungrouped: SessionCatalogSession[] = [];
+
+  for (const session of sessions) {
+    const actor = session.createdActor;
+    if (!actor?.id) {
+      ungrouped.push(session);
+      continue;
+    }
+    const key = `person:${actor.id}`;
+    let group = groupsById.get(key);
+    if (!group) {
+      const label = actor.label?.trim() || actor.id;
+      group = { key, label, title: `Created by ${label}`, sessions: [] };
+      groupsById.set(key, group);
+    }
+    group.sessions.push(session);
+  }
+
+  // Label order keeps the section stable regardless of roster sort.
+  const groups = [...groupsById.values()].toSorted((a, b) => a.label.localeCompare(b.label));
+  return { groups, ungrouped };
 }


### PR DESCRIPTION
## What Problem This Solves

Filtering or grouping the Coding zone by person is not discoverable: the People creator filter only exists inside the Threads header's hover-revealed sort menu (and only when ≥2 creators are attributed), even though it already filters catalog sessions. There is no way at all to group catalog sessions by who created them.

## Why This Change Was Made

Follow-up to #113798, which converted the catalog grouping toggle into a "View options" menu precisely so new view states could extend a radio list. This adds the two person/identity features to that menu:

- **Group by: Person** — a third `CatalogProjectGrouping` mode bucketing catalog sessions by `createdActor` (sorted by label). Native threads only carry an actor once adopted (the gateway intentionally strips provider-supplied actors in `src/gateway/server-methods/session-catalog.ts`), so unattributed threads fall to the flat tail — same shape as Project mode's ungrouped tail, honest about the data.
- **People filter section** — the same global creator filter as the Threads sort menu (shared `sessionCreatorFilterId`, owner chips, "All people" reset), now reachable from each catalog header. The view button shows the existing filtered-state dot when a person filter is active.

## User Impact

- The catalog "View options" menu now offers `Group by: Project | Person | None` plus a People section (when ≥2 creators are attributed).
- Selecting a person filters Threads, Coding work rows, and catalogs together — one filter, now discoverable from Coding.
- Grouping preference persists under the existing storage key; `person` round-trips through the normalizer.

### Screenshots

| View menu with People section | Grouped by person |
| --- | --- |
| ![menu](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/catalog-person-grouping/v2-menu.png) | ![person grouped](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/catalog-person-grouping/v2-person-grouped.png) |

## Evidence

- `node scripts/run-vitest.mjs ui/src/lib/sessions/catalog-project-grouping.test.ts` — new `groupCatalogSessionsByPerson` coverage (label sort, id fallback, unattributed tail) plus `person` normalization.
- `node scripts/run-vitest.mjs ui/src/components/app-sidebar.test.ts` — 169 passed.
- `node scripts/run-vitest.mjs ui/src/e2e/codex-sessions.e2e.test.ts -t "groups sessions by host"` — extended to select Person via the menu and assert Ada/Zoe groups + persisted `person` value; passes locally.
- `pnpm ui:i18n:baseline` — clean (1 new key `catalogGroupByPerson`).
- Codex autoreview (gpt-5.6-sol): clean, "patch is correct (0.99)".
- Screenshots from the deterministic e2e mock fixture (no real data).
