### PR TITLE
feat(chat): restore prompt image attachments on rewind/fork

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -579,7 +579,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 473,
+      "line": 476,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Searching…",
       "surface": "android",
@@ -587,7 +587,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 609,
+      "line": 612,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Mic off",
       "surface": "android",
@@ -595,7 +595,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 623,
+      "line": 626,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Off",
       "surface": "android",
@@ -731,7 +731,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 181,
+      "line": 182,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Resolution outcome unknown. Actions stay disabled until the Gateway record is verified.",
       "surface": "android",
@@ -739,7 +739,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 183,
+      "line": 184,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "The Gateway still shows this approval as pending. Review it before trying again.",
       "surface": "android",
@@ -747,7 +747,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 185,
+      "line": 186,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load approval details. Refresh and try again.",
       "surface": "android",
@@ -755,7 +755,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 187,
+      "line": 188,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load approvals.",
       "surface": "android",
@@ -763,7 +763,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 189,
+      "line": 190,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not resolve approval. Refresh and try again.",
       "surface": "android",
@@ -771,7 +771,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 286,
+      "line": 287,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Device approved.",
       "surface": "android",
@@ -779,7 +779,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 287,
+      "line": 288,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Pairing request rejected.",
       "surface": "android",
@@ -787,7 +787,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 288,
+      "line": 289,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Paired device removed.",
       "surface": "android",
@@ -795,7 +795,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 349,
+      "line": 350,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Proposal applied.",
       "surface": "android",
@@ -803,7 +803,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 349,
+      "line": 350,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "apply",
       "surface": "android",
@@ -811,7 +811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 350,
+      "line": 351,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Proposal rejected.",
       "surface": "android",
@@ -819,7 +819,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 350,
+      "line": 351,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "reject",
       "surface": "android",
@@ -827,7 +827,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 351,
+      "line": 352,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Proposal quarantined.",
       "surface": "android",
@@ -835,7 +835,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 351,
+      "line": 352,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "quarantine",
       "surface": "android",
@@ -843,7 +843,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 358,
+      "line": 359,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "unknown",
       "surface": "android",
@@ -851,7 +851,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 359,
+      "line": 360,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway returned status '$statusLabel' after ${action.verb}.",
       "surface": "android",
@@ -859,7 +859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 367,
+      "line": 368,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not ${action.verb} Skill Workshop proposal.",
       "surface": "android",
@@ -867,7 +867,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 549,
+      "line": 550,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connected (node offline)",
       "surface": "android",
@@ -875,7 +875,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 550,
+      "line": 551,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connected (operator offline)",
       "surface": "android",
@@ -883,7 +883,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 552,
+      "line": 553,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Reconnecting…",
       "surface": "android",
@@ -891,7 +891,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 560,
+      "line": 561,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connected (operator: $operator)",
       "surface": "android",
@@ -899,7 +899,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2318,
+      "line": 2319,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This automation already has a queued run.",
       "surface": "android",
@@ -907,7 +907,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2348,
+      "line": 2349,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation run queued.",
       "surface": "android",
@@ -915,7 +915,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2348,
+      "line": 2349,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation started.",
       "surface": "android",
@@ -923,7 +923,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2361,
+      "line": 2362,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway rejected the automation run.",
       "surface": "android",
@@ -931,7 +931,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2392,
+      "line": 2393,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation enabled.",
       "surface": "android",
@@ -939,7 +939,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2392,
+      "line": 2393,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation paused.",
       "surface": "android",
@@ -947,7 +947,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2414,
+      "line": 2415,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This automation changed on the gateway. Review the latest version before saving again.",
       "surface": "android",
@@ -955,7 +955,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2420,
+      "line": 2421,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation updated.",
       "surface": "android",
@@ -963,7 +963,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2435,
+      "line": 2436,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation deleted.",
       "surface": "android",
@@ -971,7 +971,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2685,
+      "line": 2686,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Node offline. Reconnect and retry.",
       "surface": "android",
@@ -979,7 +979,7 @@
     },
     {
       "kind": "ui-named-argument-concatenated",
-      "line": 2696,
+      "line": 2697,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Restore canvas now for session=$sessionKey source=$source. If existing A2UI state exists, replay it immediately. If not, create and render a compact mobile-friendly dashboard in Canvas.",
       "surface": "android",
@@ -987,7 +987,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2717,
+      "line": 2718,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed to request restore. Tap to retry.",
       "surface": "android",
@@ -995,7 +995,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2728,
+      "line": 2729,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "No canvas update yet. Tap to retry.",
       "surface": "android",
@@ -1003,7 +1003,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3821,
+      "line": 3822,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect to a Gateway to save wake words",
       "surface": "android",
@@ -1011,7 +1011,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3849,
+      "line": 3850,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Wake words saved",
       "surface": "android",
@@ -1019,7 +1019,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3858,
+      "line": 3859,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not save wake words",
       "surface": "android",
@@ -1027,7 +1027,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4569,
+      "line": 4570,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: no secure gateway endpoint was detected. Enable gateway TLS or Tailscale Serve, or use a trusted private LAN address with Unencrypted selected.",
       "surface": "android",
@@ -1035,7 +1035,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4573,
+      "line": 4574,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: secure endpoint reached, but TLS fingerprint verification timed out. Check Tailscale Serve or gateway TLS and retry.",
       "surface": "android",
@@ -1043,7 +1043,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4577,
+      "line": 4578,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: couldn't reach the secure gateway endpoint for this host.",
       "surface": "android",
@@ -1051,7 +1051,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 4627,
+      "line": 4628,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connecting…",
       "surface": "android",
@@ -1059,7 +1059,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 4837,
+      "line": 4838,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Offline",
       "surface": "android",
@@ -1067,7 +1067,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5612,
+      "line": 5613,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load provider catalog.",
       "surface": "android",
@@ -1075,7 +1075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5643,
+      "line": 5644,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Update your Gateway to view provider model config.",
       "surface": "android",
@@ -1083,7 +1083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5645,
+      "line": 5646,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load provider model config.",
       "surface": "android",
@@ -1091,7 +1091,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5661,
+      "line": 5662,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Provider models loaded, but readiness is unavailable.",
       "surface": "android",
@@ -1099,7 +1099,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5748,
+      "line": 5749,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load automations.",
       "surface": "android",
@@ -1107,7 +1107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5834,
+      "line": 5835,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to inspect automations.",
       "surface": "android",
@@ -1115,7 +1115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5844,
+      "line": 5845,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway returned an invalid automation.",
       "surface": "android",
@@ -1123,7 +1123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5848,
+      "line": 5849,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load automation.",
       "surface": "android",
@@ -1131,7 +1131,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5860,
+      "line": 5861,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to inspect automation run history.",
       "surface": "android",
@@ -1139,7 +1139,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5891,
+      "line": 5892,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load automation run history.",
       "surface": "android",
@@ -1147,7 +1147,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5908,
+      "line": 5909,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron changes require operator.admin access.",
       "surface": "android",
@@ -1155,7 +1155,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5917,
+      "line": 5918,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to manage automations.",
       "surface": "android",
@@ -1163,7 +1163,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5929,
+      "line": 5930,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Another cron action is still finishing.",
       "surface": "android",
@@ -1171,7 +1171,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5976,
+      "line": 5977,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron action failed.",
       "surface": "android",
@@ -1179,7 +1179,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6103,
+      "line": 6104,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load usage.",
       "surface": "android",
@@ -1187,7 +1187,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6138,
+      "line": 6139,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load skills.",
       "surface": "android",
@@ -1195,7 +1195,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6151,
+      "line": 6152,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to update skills.",
       "surface": "android",
@@ -1203,7 +1203,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6155,
+      "line": 6156,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This gateway connection needs operator.admin to update skills.",
       "surface": "android",
@@ -1211,7 +1211,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6170,
+      "line": 6171,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not disable skill.",
       "surface": "android",
@@ -1219,7 +1219,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6170,
+      "line": 6171,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not enable skill.",
       "surface": "android",
@@ -1227,7 +1227,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6188,
+      "line": 6189,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to search ClawHub skills.",
       "surface": "android",
@@ -1235,7 +1235,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6234,
+      "line": 6235,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not search ClawHub skills.",
       "surface": "android",
@@ -1243,7 +1243,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6247,
+      "line": 6248,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to inspect ClawHub skills.",
       "surface": "android",
@@ -1251,7 +1251,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6280,
+      "line": 6281,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "ClawHub did not return an installable version for ${skill.slug}.",
       "surface": "android",
@@ -1259,7 +1259,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6296,
+      "line": 6297,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load ClawHub details for ${skill.slug}.",
       "surface": "android",
@@ -1267,7 +1267,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6312,
+      "line": 6313,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to install ClawHub skills.",
       "surface": "android",
@@ -1275,7 +1275,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6328,
+      "line": 6329,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This gateway connection needs operator.admin to install ClawHub skills.",
       "surface": "android",
@@ -1283,7 +1283,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6418,
+      "line": 6419,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Installed $slug.",
       "surface": "android",
@@ -1291,7 +1291,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6425,
+      "line": 6426,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not install ${slug} from ClawHub.",
       "surface": "android",
@@ -1299,7 +1299,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6465,
+      "line": 6466,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to load Skill Workshop proposals.",
       "surface": "android",
@@ -1307,7 +1307,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6505,
+      "line": 6506,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load Skill Workshop proposals.",
       "surface": "android",
@@ -1315,7 +1315,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6525,
+      "line": 6526,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to inspect Skill Workshop proposals.",
       "surface": "android",
@@ -1323,7 +1323,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6577,
+      "line": 6578,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not inspect Skill Workshop proposal.",
       "surface": "android",
@@ -1331,7 +1331,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6597,
+      "line": 6598,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Skill Workshop proposal actions require operator.admin scope.",
       "surface": "android",
@@ -1339,7 +1339,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6602,
+      "line": 6603,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to update Skill Workshop proposals.",
       "surface": "android",
@@ -1347,7 +1347,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6792,
+      "line": 6793,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not verify the device pairing change. Refresh and try again.",
       "surface": "android",
@@ -1355,7 +1355,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 6874,
+      "line": 6875,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connected",
       "surface": "android",
@@ -1363,7 +1363,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6904,
+      "line": 6905,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load nodes and devices.",
       "surface": "android",
@@ -1371,7 +1371,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7563,
+      "line": 7564,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load channels.",
       "surface": "android",
@@ -1379,7 +1379,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7593,
+      "line": 7594,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load dreaming.",
       "surface": "android",
@@ -1387,7 +1387,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7630,
+      "line": 7631,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load gateway logs.",
       "surface": "android",
@@ -1395,7 +1395,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8099,
+      "line": 8100,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "One time",
       "surface": "android",
@@ -1403,7 +1403,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8108,
+      "line": 8109,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron",
       "surface": "android",
@@ -1411,7 +1411,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8109,
+      "line": 8110,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Scheduled",
       "surface": "android",
@@ -1419,7 +1419,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8117,
+      "line": 8118,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Every ${days}d",
       "surface": "android",
@@ -1427,7 +1427,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8118,
+      "line": 8119,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Every ${hours}h",
       "surface": "android",
@@ -1435,7 +1435,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8119,
+      "line": 8120,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Every ${minutes}m",
       "surface": "android",
@@ -1443,7 +1443,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8120,
+      "line": 8121,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Repeating",
       "surface": "android",
@@ -1451,7 +1451,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8136,
+      "line": 8137,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "No prompt",
       "surface": "android",
@@ -1459,7 +1459,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8153,
+      "line": 8154,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway",
       "surface": "android",
@@ -1467,7 +1467,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8161,
+      "line": 8162,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connected to $gatewayLabel",
       "surface": "android",
@@ -1475,7 +1475,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8162,
+      "line": 8163,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Your agents are ready",
       "surface": "android",
@@ -1483,7 +1483,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8164,
+      "line": 8165,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This phone stays dormant until the gateway needs it, then wakes, syncs, and goes back to sleep.",
       "surface": "android",
@@ -1491,7 +1491,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8168,
+      "line": 8169,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Selected on this phone",
       "surface": "android",
@@ -1499,7 +1499,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8171,
+      "line": 8172,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "The overview refreshes on reconnect and when this screen opens.",
       "surface": "android",
@@ -1507,7 +1507,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8176,
+      "line": 8177,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Reconnecting",
       "surface": "android",
@@ -1515,7 +1515,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8177,
+      "line": 8178,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "OpenClaw is syncing back up",
       "surface": "android",
@@ -1523,7 +1523,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8179,
+      "line": 8180,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "The gateway session is coming back online. Agent shortcuts should settle automatically in a moment.",
       "surface": "android",
@@ -1531,7 +1531,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8183,
+      "line": 8184,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway session in progress",
       "surface": "android",
@@ -1539,7 +1539,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8186,
+      "line": 8187,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "If the gateway is reachable, reconnect should complete without intervention.",
       "surface": "android",
@@ -1547,7 +1547,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8191,
+      "line": 8192,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Welcome to OpenClaw",
       "surface": "android",
@@ -1555,7 +1555,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8192,
+      "line": 8193,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Your phone stays quiet until it is needed",
       "surface": "android",
@@ -1563,7 +1563,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8194,
+      "line": 8195,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Pair this device to your gateway to wake it only for real work, keep a live agent overview handy, and avoid battery-draining background loops.",
       "surface": "android",
@@ -1571,7 +1571,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8198,
+      "line": 8199,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect to load your agents",
       "surface": "android",
@@ -1579,7 +1579,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8201,
+      "line": 8202,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "When connected, the gateway can wake the phone with a silent push instead of holding an always-on session.",
       "surface": "android",
@@ -1587,7 +1587,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8233,
+      "line": 8234,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Main",
       "surface": "android",
@@ -1595,7 +1595,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8248,
+      "line": 8249,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Active on this phone",
       "surface": "android",
@@ -1603,7 +1603,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8249,
+      "line": 8250,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Default agent",
       "surface": "android",
@@ -1611,7 +1611,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8250,
+      "line": 8251,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Ready",
       "surface": "android",
@@ -1619,7 +1619,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8905,
+      "line": 8906,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Dream",
       "surface": "android",
@@ -1795,7 +1795,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1798,
+      "line": 1806,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Wait for the current response to finish before starting a new chat.",
       "surface": "android",
@@ -1803,7 +1803,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1931,
+      "line": 1939,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Could not update model.",
       "surface": "android",
@@ -1811,7 +1811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1996,
+      "line": 2004,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Could not update thinking level.",
       "surface": "android",
@@ -1819,7 +1819,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2509,
+      "line": 2517,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Chat failed before the run started; try again.",
       "surface": "android",
@@ -1827,7 +1827,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4203,
+      "line": 4211,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Could not stage an attachment for sending.",
       "surface": "android",
@@ -1835,7 +1835,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4236,
+      "line": 4244,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Offline queue is full ($OUTBOX_MAX_QUEUED messages); delete queued items first.",
       "surface": "android",
@@ -1843,7 +1843,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4242,
+      "line": 4250,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Attachments are too large to queue for one message; remove some and try again.",
       "surface": "android",
@@ -1851,7 +1851,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4248,
+      "line": 4256,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Offline attachment storage is full; delete queued items first.",
       "surface": "android",
@@ -1859,7 +1859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4253,
+      "line": 4261,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Gateway health not OK; cannot send",
       "surface": "android",
@@ -1867,7 +1867,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4260,
+      "line": 4268,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Could not queue message for later delivery.",
       "surface": "android",
@@ -1875,7 +1875,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5163,
+      "line": 5171,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Chat failed",
       "surface": "android",
@@ -1883,7 +1883,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5389,
+      "line": 5397,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Event stream interrupted; try refreshing.",
       "surface": "android",
@@ -1891,7 +1891,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5526,
+      "line": 5534,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Timed out waiting for a reply; try again or refresh.",
       "surface": "android",
@@ -1899,7 +1899,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5736,
+      "line": 5744,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Timed out confirming the sent message; refresh to check delivery.",
       "surface": "android",
@@ -12675,7 +12675,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 668,
+      "line": 672,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat needs attention",
       "surface": "android",
@@ -12683,7 +12683,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1004,
+      "line": 1010,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "All",
       "surface": "android",
@@ -12691,7 +12691,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1091,
+      "line": 1097,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Working",
       "surface": "android",
@@ -12699,7 +12699,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1092,
+      "line": 1098,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Ready",
       "surface": "android",
@@ -12707,7 +12707,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1093,
+      "line": 1099,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Offline",
       "surface": "android",
@@ -12715,7 +12715,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1106,
+      "line": 1112,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat actions",
       "surface": "android",
@@ -12723,7 +12723,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1111,
+      "line": 1117,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Refresh chat",
       "surface": "android",
@@ -12731,7 +12731,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1130,
+      "line": 1136,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Dashboard",
       "surface": "android",
@@ -12739,7 +12739,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1138,
+      "line": 1144,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Background tasks",
       "surface": "android",
@@ -12747,7 +12747,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1159,
+      "line": 1165,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat",
       "surface": "android",
@@ -12755,7 +12755,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1336,
+      "line": 1342,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Messages to recover",
       "surface": "android",
@@ -12763,7 +12763,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1338,
+      "line": 1344,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "${item.count} message(s) need recovery. Re-enter anything you want to keep, then delete these rows.",
       "surface": "android",
@@ -12771,7 +12771,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1376,
+      "line": 1382,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Loading thread",
       "surface": "android",
@@ -12779,7 +12779,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1409,
+      "line": 1415,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Jump to latest",
       "surface": "android",
@@ -12787,7 +12787,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1488,
+      "line": 1494,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Ready when you are",
       "surface": "android",
@@ -12795,7 +12795,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1492,
+      "line": 1498,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Start with a prompt, or use voice.",
       "surface": "android",
@@ -12803,7 +12803,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1494,
+      "line": 1500,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Use the recovery options below to reconnect.",
       "surface": "android",
@@ -12811,7 +12811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1496,
+      "line": 1502,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat is checking Gateway health.",
       "surface": "android",
@@ -12819,7 +12819,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1519,
+      "line": 1525,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Fix connection",
       "surface": "android",
@@ -12827,7 +12827,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1520,
+      "line": 1526,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Copy diagnostics",
       "surface": "android",
@@ -12835,7 +12835,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1579,
+      "line": 1585,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Catch me up",
       "surface": "android",
@@ -12843,7 +12843,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1580,
+      "line": 1586,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Summarize recent threads and next steps.",
       "surface": "android",
@@ -12851,7 +12851,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1581,
+      "line": 1587,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Catch me up on my recent OpenClaw threads and suggest next steps.",
       "surface": "android",
@@ -12859,7 +12859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1585,
+      "line": 1591,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Plan the work",
       "surface": "android",
@@ -12867,7 +12867,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1586,
+      "line": 1592,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Turn a goal into an actionable checklist.",
       "surface": "android",
@@ -12875,7 +12875,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1587,
+      "line": 1593,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Help me turn this goal into a practical checklist: ",
       "surface": "android",
@@ -12883,7 +12883,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1591,
+      "line": 1597,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Use this phone",
       "surface": "android",
@@ -12891,7 +12891,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1592,
+      "line": 1598,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Ask OpenClaw to use Android capabilities.",
       "surface": "android",
@@ -12899,7 +12899,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1593,
+      "line": 1599,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "What can you help me do from this phone right now?",
       "surface": "android",
@@ -12907,7 +12907,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1667,
+      "line": 1673,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw · Live",
       "surface": "android",
@@ -12915,7 +12915,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1668,
+      "line": 1674,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "You",
       "surface": "android",
@@ -12923,7 +12923,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1669,
+      "line": 1675,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "System",
       "surface": "android",
@@ -12931,7 +12931,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1670,
+      "line": 1676,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw",
       "surface": "android",
@@ -12939,7 +12939,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1752,
+      "line": 1758,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Preparing audio…",
       "surface": "android",
@@ -12947,7 +12947,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1752,
+      "line": 1758,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Speaking…",
       "surface": "android",
@@ -12955,7 +12955,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1783,
+      "line": 1789,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Close",
       "surface": "android",
@@ -12963,7 +12963,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1783,
+      "line": 1789,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "View all",
       "surface": "android",
@@ -12971,7 +12971,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1813,
+      "line": 1819,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Tools running",
       "surface": "android",
@@ -12979,7 +12979,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1815,
+      "line": 1821,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw is working",
       "surface": "android",
@@ -12987,7 +12987,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1818,
+      "line": 1824,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "+${toolCalls.size - 4} more",
       "surface": "android",
@@ -12995,7 +12995,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1884,
+      "line": 1890,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "$completedCount/${steps.size}",
       "surface": "android",
@@ -13003,7 +13003,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1891,
+      "line": 1897,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Collapse plan checklist",
       "surface": "android",
@@ -13011,7 +13011,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1891,
+      "line": 1897,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Expand plan checklist",
       "surface": "android",
@@ -13019,7 +13019,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2023,
+      "line": 2029,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Dismiss shared-image warning",
       "surface": "android",
@@ -13027,7 +13027,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2126,
+      "line": 2132,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Stop",
       "surface": "android",
@@ -13035,7 +13035,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2213,
+      "line": 2219,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Switch branch",
       "surface": "android",
@@ -13043,7 +13043,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2237,
+      "line": 2243,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Untitled branch",
       "surface": "android",
@@ -13051,7 +13051,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2252,
+      "line": 2258,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Current branch",
       "surface": "android",
@@ -13059,7 +13059,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2264,
+      "line": 2270,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Messages: $count",
       "surface": "android",
@@ -13067,7 +13067,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2272,
+      "line": 2278,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "$count · $updated",
       "surface": "android",
@@ -13075,7 +13075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2301,
+      "line": 2307,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Default",
       "surface": "android",
@@ -13083,7 +13083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2367,
+      "line": 2373,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Pin model",
       "surface": "android",
@@ -13091,7 +13091,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2367,
+      "line": 2373,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Unpin model",
       "surface": "android",
@@ -13099,7 +13099,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2384,
+      "line": 2390,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "No commands found",
       "surface": "android",
@@ -13107,7 +13107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2426,
+      "line": 2432,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Command",
       "surface": "android",
@@ -13115,7 +13115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2446,
+      "line": 2452,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Gateway offline",
       "surface": "android",
@@ -13123,7 +13123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2492,
+      "line": 2498,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Close thinking level selector",
       "surface": "android",
@@ -13131,7 +13131,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2492,
+      "line": 2498,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Open thinking level selector",
       "surface": "android",
@@ -13139,7 +13139,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2557,
+      "line": 2563,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Attach image",
       "surface": "android",
@@ -13147,7 +13147,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2562,
+      "line": 2568,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Attachment",
       "surface": "android",
@@ -13155,7 +13155,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2593,
+      "line": 2599,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Message OpenClaw",
       "surface": "android",
@@ -13163,7 +13163,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2622,
+      "line": 2628,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "End Talk",
       "surface": "android",
@@ -13171,7 +13171,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2622,
+      "line": 2628,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Start Talk",
       "surface": "android",
@@ -13179,7 +13179,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2707,
+      "line": 2713,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Voice note · ${formatVoiceNoteDuration(duration)}",
       "surface": "android",
@@ -13187,7 +13187,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2716,
+      "line": 2722,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Remove attachment",
       "surface": "android",
@@ -13195,7 +13195,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2728,
+      "line": 2734,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "New chat",
       "surface": "android",
@@ -13203,7 +13203,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2737,
+      "line": 2743,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Main",
       "surface": "android",
@@ -13211,7 +13211,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2738,
+      "line": 2744,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Current",
       "surface": "android",
@@ -13219,7 +13219,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2745,
+      "line": 2751,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "$emoji $name",
       "surface": "android",
@@ -13227,7 +13227,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2804,
+      "line": 2810,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Send",
       "surface": "android",
@@ -13235,7 +13235,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2815,
+      "line": 2821,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat is still checking Gateway health.",
       "surface": "android",
@@ -13243,7 +13243,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2816,
+      "line": 2822,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Gateway is offline. Fix the connection below or copy diagnostics.",
       "surface": "android",
@@ -13251,7 +13251,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2817,
+      "line": 2823,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Gateway authentication needs attention.",
       "surface": "android",
@@ -13259,7 +13259,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2836,
+      "line": 2842,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Context ${(it * 100).roundToInt()}%",
       "surface": "android",
@@ -13267,7 +13267,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2837,
+      "line": 2843,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Context --",
       "surface": "android",
@@ -13275,7 +13275,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2838,
+      "line": 2844,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "$contextLabel · ${contextMeterThinkingLabel(thinkingLevel)}",
       "surface": "android",
@@ -13283,7 +13283,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2877,
+      "line": 2883,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Off",
       "surface": "android",
@@ -13291,7 +13291,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2878,
+      "line": 2884,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Minimal",
       "surface": "android",
@@ -13299,7 +13299,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2879,
+      "line": 2885,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Low",
       "surface": "android",
@@ -13307,7 +13307,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2880,
+      "line": 2886,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Medium",
       "surface": "android",
@@ -13315,7 +13315,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2881,
+      "line": 2887,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "High",
       "surface": "android",
@@ -13323,7 +13323,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2882,
+      "line": 2888,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Xhigh",
       "surface": "android",
@@ -13331,7 +13331,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2883,
+      "line": 2889,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Adaptive",
       "surface": "android",
@@ -13339,7 +13339,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2884,
+      "line": 2890,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Max",
       "surface": "android",
@@ -41387,7 +41387,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 74,
+      "line": 91,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Attachments.swift",
       "source": "Remove attachments or wait for delivery to resolve before starting a new chat.",
       "surface": "apple",
@@ -41395,7 +41395,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 112,
+      "line": 129,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Attachments.swift",
       "source": "Could not attach voice note: %@",
       "surface": "apple",
@@ -41403,7 +41403,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 118,
+      "line": 135,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Attachments.swift",
       "source": "Voice note exceeds the 5 MB attachment limit",
       "surface": "apple",
@@ -41411,7 +41411,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 180,
+      "line": 197,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Attachments.swift",
       "source": "Only image attachments are supported right now",
       "surface": "apple",
@@ -41419,7 +41419,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 192,
+      "line": 209,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Attachments.swift",
       "source": "Could not process %1$@: %2$@",
       "surface": "apple",
@@ -41427,7 +41427,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 203,
+      "line": 220,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Attachments.swift",
       "source": "Attachment %@ exceeds 5 MB limit after resizing",
       "surface": "apple",
@@ -41435,7 +41435,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 210,
+      "line": 227,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Attachments.swift",
       "source": "\\(baseName).jpg",
       "surface": "apple",

--- a/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
@@ -17,6 +17,7 @@ import ai.openclaw.app.chat.GatewayDefaultAgentOwner
 import ai.openclaw.app.chat.MessageSpeechState
 import ai.openclaw.app.chat.OutgoingAttachment
 import ai.openclaw.app.chat.SessionBranch
+import ai.openclaw.app.chat.SessionForkResult
 import ai.openclaw.app.chat.SessionRewindResult
 import ai.openclaw.app.chat.defaultChatThinkingLevelSelection
 import ai.openclaw.app.chat.resolveChatComposerOwner
@@ -77,6 +78,8 @@ internal data class ChatDraft(
   val owner: ChatComposerOwner? = null,
   val expectedExistingText: String? = null,
   val acceptsEmptyText: Boolean = false,
+  // Attachment payloads stay in ViewModel heap state; saved drafts persist text only.
+  val attachments: List<PendingAttachment>? = null,
 )
 
 internal fun claimChatDraftForOwner(
@@ -1587,7 +1590,7 @@ class MainViewModel private constructor(
 
   suspend fun rewindChatAtEntry(entryId: String): SessionRewindResult? = ensureRuntime().rewindChatAtEntry(entryId)
 
-  suspend fun forkChatAtEntry(entryId: String): Pair<String, String?>? = ensureRuntime().forkChatAtEntry(entryId)
+  suspend fun forkChatAtEntry(entryId: String): SessionForkResult? = ensureRuntime().forkChatAtEntry(entryId)
 
   suspend fun refreshChatSessionBranches(): Boolean = ensureRuntime().refreshChatSessionBranches()
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -29,6 +29,7 @@ import ai.openclaw.app.chat.MessageSpeechController
 import ai.openclaw.app.chat.MessageSpeechState
 import ai.openclaw.app.chat.OutgoingAttachment
 import ai.openclaw.app.chat.SessionBranch
+import ai.openclaw.app.chat.SessionForkResult
 import ai.openclaw.app.chat.SessionRewindResult
 import ai.openclaw.app.chat.SystemSpeechSpeaker
 import ai.openclaw.app.gateway.DeviceAuthEntry
@@ -5040,7 +5041,7 @@ class NodeRuntime private constructor(
 
   suspend fun rewindChatAtEntry(entryId: String): SessionRewindResult? = chat.rewindSessionAtEntryResult(chatSessionKey.value, entryId)
 
-  suspend fun forkChatAtEntry(entryId: String): Pair<String, String?>? = chat.forkSessionAtEntry(chatSessionKey.value, entryId)
+  suspend fun forkChatAtEntry(entryId: String): SessionForkResult? = chat.forkSessionAtEntry(chatSessionKey.value, entryId)
 
   suspend fun refreshChatSessionBranches(): Boolean = chat.refreshSessionBranches()
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
@@ -55,6 +55,7 @@ import java.util.concurrent.atomic.AtomicLong
 internal const val SESSION_LIST_FETCH_LIMIT = 200
 private val QUESTION_REFRESH_RETRY_DELAYS_MS = longArrayOf(1_000L, 2_000L, 4_000L)
 private val SWARM_REFRESH_RETRY_DELAYS_MS = longArrayOf(1_000L, 2_000L, 4_000L)
+private const val SESSION_EDITOR_MAX_BASE64_CHARS = ((OUTBOX_MAX_COMMAND_ATTACHMENT_BYTES + 2) / 3) * 4
 
 internal fun chatOutboxQueueFailureText(): NativeText = ChatController.queueFailureText()
 
@@ -1128,7 +1129,10 @@ class ChatController internal constructor(
           false
         }
       if (!historyApplied || !branchApplied) recoverOutboxAfterSessionMutationRefreshFailure(snapshot, mutationLease)
-      SessionRewindResult(editorText)
+      SessionRewindResult(
+        editorText = editorText,
+        editorAttachments = parseSessionEditorAttachments(root?.get("editorAttachments")),
+      )
     } catch (err: CancellationException) {
       withContext(NonCancellable) {
         recoverOutboxAfterSessionMutationRefreshFailure(snapshot, mutationLease)
@@ -1152,7 +1156,7 @@ class ChatController internal constructor(
   suspend fun forkSessionAtEntry(
     sessionKey: String,
     entryId: String,
-  ): Pair<String, String?>? {
+  ): SessionForkResult? {
     val entry = entryId.trim().takeIf { it.isNotEmpty() } ?: return null
     val snapshot = currentSessionActionSnapshot(sessionKey) ?: return null
     if (!canPerformMessageSessionAction(snapshot)) return null
@@ -1185,7 +1189,11 @@ class ChatController internal constructor(
         fetchSessionsForCurrentWindow()
         return null
       }
-      createdKey to root?.get("editorText").asStringOrNull()
+      SessionForkResult(
+        sessionKey = createdKey,
+        editorText = root?.get("editorText").asStringOrNull(),
+        editorAttachments = parseSessionEditorAttachments(root?.get("editorAttachments")),
+      )
     } catch (err: CancellationException) {
       withContext(NonCancellable) {
         cancelOutboxSessionMutation(snapshot, mutationLease)
@@ -6657,6 +6665,30 @@ private fun messageContentIdentityKey(message: ChatMessage): String? {
 private fun JsonElement?.asObjectOrNull(): JsonObject? = this as? JsonObject
 
 private fun JsonElement?.asArrayOrNull(): JsonArray? = this as? JsonArray
+
+private fun parseSessionEditorAttachments(value: JsonElement?): List<SessionEditorAttachment> =
+  value.asArrayOrNull()?.mapNotNull { element ->
+    val attachment = element.asObjectOrNull() ?: return@mapNotNull null
+    val mimeType =
+      attachment["mimeType"]
+        .asStringOrNull()
+        ?.trim()
+        ?.takeIf { it.startsWith("image/", ignoreCase = true) }
+        ?: return@mapNotNull null
+    val data =
+      attachment["data"]
+        .asStringOrNull()
+        ?.takeIf { it.isNotEmpty() && it.length.toLong() <= SESSION_EDITOR_MAX_BASE64_CHARS }
+        ?: return@mapNotNull null
+    val decoded =
+      try {
+        Base64.getDecoder().decode(data)
+      } catch (_: IllegalArgumentException) {
+        return@mapNotNull null
+      }
+    if (decoded.isEmpty() || decoded.size.toLong() > OUTBOX_MAX_COMMAND_ATTACHMENT_BYTES) return@mapNotNull null
+    SessionEditorAttachment(mimeType = mimeType, data = data)
+  } ?: emptyList()
 
 private fun JsonElement?.asStringOrNull(): String? =
   when (this) {

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatModels.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatModels.kt
@@ -41,6 +41,18 @@ data class SessionBranch(
 
 data class SessionRewindResult(
   val editorText: String?,
+  val editorAttachments: List<SessionEditorAttachment>,
+)
+
+data class SessionForkResult(
+  val sessionKey: String,
+  val editorText: String?,
+  val editorAttachments: List<SessionEditorAttachment>,
+)
+
+data class SessionEditorAttachment(
+  val mimeType: String,
+  val data: String,
 )
 
 data class ChatTranscriptAnchorState(

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatComposerStateStore.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatComposerStateStore.kt
@@ -194,6 +194,16 @@ internal class ChatComposerStateStore(
       }
     }
 
+  fun replaceAttachments(
+    owner: ChatComposerOwner,
+    candidates: List<PendingAttachment>,
+  ) {
+    synchronized(lock) {
+      val omitted = attachmentStore.replace(owner, candidates)
+      recordAttachmentOmissionLocked(owner, omitted, ChatComposerAttachmentNotice.Image)
+    }
+  }
+
   fun addAuthorizedAttachments(
     owner: ChatComposerOwner,
     mediaAuthorizationId: String,

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
@@ -540,8 +540,12 @@ fun ChatScreen(
         owner = composerOwner,
         mainSessionKey = mainSessionKey,
       ) ?: return@LaunchedEffect
-    inputDrafts[composerOwner] =
+    val merged =
       mergeChatDraft(draft = claimed, currentInput = input, currentOwner = composerOwner) ?: return@LaunchedEffect
+    inputDrafts[composerOwner] = merged
+    // Rewind/fork replace the composer wholesale; an attachment staged during the
+    // in-flight round-trip is accepted collateral rather than a draft revision field.
+    claimed.attachments?.let { composerState.replaceAttachments(composerOwner, it) }
   }
 
   LaunchedEffect(composerOwner, pendingSendAdmissionIds) {
@@ -709,23 +713,25 @@ fun ChatScreen(
               owner = composerOwner,
               expectedExistingText = expectedInput,
               acceptsEmptyText = true,
+              attachments = result.editorAttachments.toPendingAttachments(),
             ),
           )
         }
       },
       onForkMessage = { entryId ->
         scope.launch {
-          val (newKey, editorText) = viewModel.forkChatAtEntry(entryId) ?: return@launch
-          val newOwner = composerOwner.copy(sessionKey = newKey)
+          val result = viewModel.forkChatAtEntry(entryId) ?: return@launch
+          val newOwner = composerOwner.copy(sessionKey = result.sessionKey)
           val expectedInput = inputDrafts[newOwner].orEmpty()
-          viewModel.switchChatSession(newKey, composerOwner.agentId)
+          viewModel.switchChatSession(result.sessionKey, composerOwner.agentId)
           viewModel.setChatDraft(
             ChatDraft(
-              text = editorText.orEmpty(),
+              text = result.editorText.orEmpty(),
               placement = ChatDraftPlacement.Replace,
               owner = newOwner,
               expectedExistingText = expectedInput,
               acceptsEmptyText = true,
+              attachments = result.editorAttachments.toPendingAttachments(),
             ),
           )
         }

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/PendingAttachment.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/PendingAttachment.kt
@@ -2,12 +2,14 @@ package ai.openclaw.app.ui.chat
 
 import ai.openclaw.app.chat.ChatComposerOwner
 import ai.openclaw.app.chat.OutgoingAttachment
+import ai.openclaw.app.chat.SessionEditorAttachment
 import ai.openclaw.app.chat.VOICE_NOTE_MIME_TYPE
 import ai.openclaw.app.chat.VoiceNoteRecording
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import java.util.Base64
+import java.util.UUID
 import java.util.concurrent.atomic.AtomicLong
 
 /** Attachment staged in a composer until the next chat.send call. */
@@ -46,6 +48,16 @@ internal class ChatComposerAttachmentStore(
   ): Int =
     synchronized(lock) {
       addLocked(owner, candidates)
+    }
+
+  fun replace(
+    owner: ChatComposerOwner,
+    candidates: List<PendingAttachment>,
+  ): Int =
+    synchronized(lock) {
+      val admission = admitWithAggregateLimit(owner = owner, current = emptyList(), candidates = candidates)
+      replaceLocked(owner, admission.accepted)
+      admission.omittedCount
     }
 
   fun beginImport(owner: ChatComposerOwner): Long =
@@ -179,6 +191,16 @@ internal fun PendingAttachment.toOutgoingAttachment(): OutgoingAttachment =
     base64 = base64,
     durationMs = durationMs,
   )
+
+internal fun List<SessionEditorAttachment>.toPendingAttachments(): List<PendingAttachment> =
+  mapIndexed { index, attachment ->
+    PendingAttachment(
+      id = "restored:${UUID.randomUUID()}",
+      fileName = "image-${index + 1}",
+      mimeType = attachment.mimeType,
+      base64 = attachment.data,
+    )
+  }
 
 internal fun attachmentTypeForMimeType(mimeType: String): String =
   when {

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerSessionActionsTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerSessionActionsTest.kt
@@ -39,14 +39,23 @@ class ChatControllerSessionActionsTest {
   }
 
   @Test
-  fun rewindReturnsEditorTextAndIssuesAgentScopedParams() =
+  fun rewindReturnsEditorTextAndValidAttachmentsAndIssuesAgentScopedParams() =
     runTest {
       val gateway = ScriptedGateway(json)
-      gateway.respondWith("sessions.rewind", """{"editorText":"restore me"}""")
+      gateway.respondWith(
+        "sessions.rewind",
+        """{"editorText":"restore me","editorAttachments":[{"mimeType":"image/png","data":"aW1hZ2U="},{"mimeType":"image/jpeg","data":"%%%"}]}""",
+      )
       gateway.respondWithBranchHistory()
       val controller = controller(this, gateway)
 
-      assertEquals("restore me", controller.rewindSessionAtEntry("main", "entry-user"))
+      assertEquals(
+        SessionRewindResult(
+          editorText = "restore me",
+          editorAttachments = listOf(SessionEditorAttachment(mimeType = "image/png", data = "aW1hZ2U=")),
+        ),
+        controller.rewindSessionAtEntryResult("main", "entry-user"),
+      )
 
       val params = json.parseToJsonElement(gateway.calls.first { it.method == "sessions.rewind" }.paramsJson!!).jsonObject
       assertEquals("main", params.getValue("sessionKey").jsonPrimitive.content)
@@ -55,13 +64,23 @@ class ChatControllerSessionActionsTest {
     }
 
   @Test
-  fun forkReturnsCreatedKeyAndEditorText() =
+  fun forkReturnsCreatedKeyEditorTextAndAttachments() =
     runTest {
       val gateway = ScriptedGateway(json)
-      gateway.respondWith("sessions.fork", """{"sessionKey":"agent:main:forked","editorText":"continue here"}""")
+      gateway.respondWith(
+        "sessions.fork",
+        """{"sessionKey":"agent:main:forked","editorText":"continue here","editorAttachments":[{"mimeType":"image/webp","data":"Zm9yaw=="}]}""",
+      )
       val controller = controller(this, gateway)
 
-      assertEquals("agent:main:forked" to "continue here", controller.forkSessionAtEntry("main", "entry-user"))
+      assertEquals(
+        SessionForkResult(
+          sessionKey = "agent:main:forked",
+          editorText = "continue here",
+          editorAttachments = listOf(SessionEditorAttachment(mimeType = "image/webp", data = "Zm9yaw==")),
+        ),
+        controller.forkSessionAtEntry("main", "entry-user"),
+      )
 
       val params = json.parseToJsonElement(gateway.calls.single { it.method == "sessions.fork" }.paramsJson!!).jsonObject
       assertEquals("main", params.getValue("agentId").jsonPrimitive.content)

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatComposerDraftTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatComposerDraftTest.kt
@@ -75,6 +75,19 @@ class ChatComposerDraftTest {
   }
 
   @Test
+  fun restoredAttachmentsReplaceTheCurrentComposerSet() {
+    val owner = ChatComposerOwner(gatewayStableId = "gateway-a", agentId = "main", sessionKey = "agent:main:first")
+    val state = ChatComposerStateStore()
+    val existing = PendingAttachment("existing", "existing.jpg", "image/jpeg", "YQ==")
+    val restored = PendingAttachment("restored", "image-1", "image/png", "Yg==")
+    state.addAttachments(owner, listOf(existing))
+
+    state.replaceAttachments(owner, listOf(restored))
+
+    assertEquals(listOf(restored), state.attachments.value[owner])
+  }
+
+  @Test
   fun textDraftSnapshotRestoresEveryOwnerAfterProcessRecreation() {
     var saved = arrayListOf<String>()
     val first = ChatComposerOwner(gatewayStableId = "gateway-a", agentId = "main", sessionKey = "agent:main:first")

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatModels.swift
@@ -572,13 +572,20 @@ public struct OpenClawChatCreateSessionResponse: Codable, Sendable {
     public let sessionId: String?
 }
 
+public struct OpenClawChatEditorAttachment: Codable, Sendable {
+    public let mimeType: String
+    public let data: String
+}
+
 public struct OpenClawChatRewindResponse: Codable, Sendable {
     public let editorText: String?
+    public let editorAttachments: [OpenClawChatEditorAttachment]?
 }
 
 public struct OpenClawChatForkAtMessageResponse: Codable, Sendable {
     public let sessionKey: String
     public let editorText: String?
+    public let editorAttachments: [OpenClawChatEditorAttachment]?
 }
 
 public struct OpenClawChatSessionBranch: Codable, Sendable, Equatable, Identifiable {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Attachments.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Attachments.swift
@@ -56,6 +56,23 @@ extension OpenClawChatViewModel {
         applyDeferredExternalStateIfReady()
     }
 
+    func restoreEditorAttachments(_ editorAttachments: [OpenClawChatEditorAttachment]?) {
+        self.attachments = (editorAttachments ?? []).enumerated().compactMap { index, attachment in
+            guard let data = Data(base64Encoded: attachment.data),
+                  data.count <= Self.maxAttachmentBytes,
+                  let contentType = UTType(mimeType: attachment.mimeType),
+                  contentType.conforms(to: .image)
+            else { return nil }
+            let fileExtension = contentType.preferredFilenameExtension ?? "img"
+            return OpenClawPendingAttachment(
+                url: nil,
+                data: data,
+                fileName: "image-\(index + 1).\(fileExtension)",
+                mimeType: attachment.mimeType,
+                preview: Self.previewImage(data: data))
+        }
+    }
+
     /// True while replacing this model could move an attachment across chats.
     public var isAttachmentOwnerPinned: Bool {
         self.blocksAttachmentOwnerChange

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+SessionActions.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+SessionActions.swift
@@ -400,6 +400,7 @@ extension OpenClawChatViewModel {
             self.runMessageScopesByRunID.removeAll()
             self.provisionalFinalMessagesByID.removeAll()
             self.input = result.editorText ?? ""
+            self.restoreEditorAttachments(result.editorAttachments)
             let historyRequest = self.beginHistoryRequest(for: initiatingSession)
             _ = await self.refreshHistoryAfterRun(historyRequest: historyRequest)
             guard self.isCurrentSession(initiatingSession) else {
@@ -647,6 +648,7 @@ extension OpenClawChatViewModel {
             self.switchSession(to: createdKey)
             guard self.sessionKey == createdKey else { return }
             self.input = result.editorText ?? ""
+            self.restoreEditorAttachments(result.editorAttachments)
         } catch {
             await self.cancelOutboxSessionMutation(initiatingSession)
             self.errorText = error.localizedDescription

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
@@ -26,8 +26,8 @@ public final class OpenClawChatViewModel {
     public internal(set) var replyTarget: OpenClawChatReplyTarget?
     @ObservationIgnored
     var inputHistoriesBySession: [String: ChatInputHistory] = [:]
-    /// Unlike web persistence, native drafts stay in memory. Attachments are excluded because
-    /// the staging guard prevents session switches while they are being prepared.
+    /// Native attachments, including images restored by rewind/fork, stay in memory only.
+    /// The staging guard prevents session switches while attachments are being prepared.
     @ObservationIgnored
     var draftsBySession: [String: String] = [:]
     @ObservationIgnored

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -6658,15 +6658,19 @@ public struct SessionsRewindParams: Codable, Sendable {
 
 public struct SessionsRewindResult: Codable, Sendable {
     public let editortext: String?
+    public let editorattachments: [[String: AnyCodable]]?
 
     public init(
-        editortext: String? = nil)
+        editortext: String? = nil,
+        editorattachments: [[String: AnyCodable]]? = nil)
     {
         self.editortext = editortext
+        self.editorattachments = editorattachments
     }
 
     private enum CodingKeys: String, CodingKey {
         case editortext = "editorText"
+        case editorattachments = "editorAttachments"
     }
 }
 
@@ -6695,18 +6699,22 @@ public struct SessionsForkParams: Codable, Sendable {
 public struct SessionsForkResult: Codable, Sendable {
     public let sessionkey: String
     public let editortext: String?
+    public let editorattachments: [[String: AnyCodable]]?
 
     public init(
         sessionkey: String,
-        editortext: String? = nil)
+        editortext: String? = nil,
+        editorattachments: [[String: AnyCodable]]? = nil)
     {
         self.sessionkey = sessionkey
         self.editortext = editortext
+        self.editorattachments = editorattachments
     }
 
     private enum CodingKeys: String, CodingKey {
         case sessionkey = "sessionKey"
         case editortext = "editorText"
+        case editorattachments = "editorAttachments"
     }
 }
 

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelSessionActionTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelSessionActionTests.swift
@@ -132,8 +132,10 @@ private final class SessionActionTransport: @unchecked Sendable, OpenClawChatTra
     private let branchSwitchGate: SessionActionCompletionGate?
     private let branchListGates: [SessionActionCompletionGate]
     private let rewindEditorText: String?
+    private let rewindEditorAttachments: [OpenClawChatEditorAttachment]?
     private let forkAtMessageSessionKey: String
     private let forkAtMessageEditorText: String?
+    private let forkAtMessageEditorAttachments: [OpenClawChatEditorAttachment]?
     private let branches: [OpenClawChatSessionBranch]
     private let branchListResponses: [[OpenClawChatSessionBranch]]
     private let branchListFailureIndices: Set<Int>
@@ -148,8 +150,10 @@ private final class SessionActionTransport: @unchecked Sendable, OpenClawChatTra
         branchSwitchGate: SessionActionCompletionGate? = nil,
         branchListGates: [SessionActionCompletionGate] = [],
         rewindEditorText: String? = "rewound draft",
+        rewindEditorAttachments: [OpenClawChatEditorAttachment]? = nil,
         forkAtMessageSessionKey: String = "forked-at-message",
         forkAtMessageEditorText: String? = "forked draft",
+        forkAtMessageEditorAttachments: [OpenClawChatEditorAttachment]? = nil,
         branches: [OpenClawChatSessionBranch] = [],
         branchListResponses: [[OpenClawChatSessionBranch]] = [],
         branchListFailureIndices: Set<Int> = [],
@@ -163,8 +167,10 @@ private final class SessionActionTransport: @unchecked Sendable, OpenClawChatTra
         self.branchSwitchGate = branchSwitchGate
         self.branchListGates = branchListGates
         self.rewindEditorText = rewindEditorText
+        self.rewindEditorAttachments = rewindEditorAttachments
         self.forkAtMessageSessionKey = forkAtMessageSessionKey
         self.forkAtMessageEditorText = forkAtMessageEditorText
+        self.forkAtMessageEditorAttachments = forkAtMessageEditorAttachments
         self.branches = branches
         self.branchListResponses = branchListResponses
         self.branchListFailureIndices = branchListFailureIndices
@@ -215,7 +221,9 @@ private final class SessionActionTransport: @unchecked Sendable, OpenClawChatTra
     {
         await self.state.recordRewind(sessionKey: sessionKey, entryID: entryId)
         await self.rewindGate?.suspendCompletion()
-        return OpenClawChatRewindResponse(editorText: self.rewindEditorText)
+        return OpenClawChatRewindResponse(
+            editorText: self.rewindEditorText,
+            editorAttachments: self.rewindEditorAttachments)
     }
 
     func forkSessionAtMessage(
@@ -226,7 +234,8 @@ private final class SessionActionTransport: @unchecked Sendable, OpenClawChatTra
         await self.forkAtMessageGate?.suspendCompletion()
         return OpenClawChatForkAtMessageResponse(
             sessionKey: self.forkAtMessageSessionKey,
-            editorText: self.forkAtMessageEditorText)
+            editorText: self.forkAtMessageEditorText,
+            editorAttachments: self.forkAtMessageEditorAttachments)
     }
 
     func listSessionBranches(
@@ -527,13 +536,30 @@ struct ChatViewModelSessionActionTests {
     }
 
     @Test func `rewind seeds editor and refreshes history`() async {
-        let transport = SessionActionTransport(rewindEditorText: "edit this turn")
+        let imageData = Data("rewound image".utf8)
+        let transport = SessionActionTransport(
+            rewindEditorText: "edit this turn",
+            rewindEditorAttachments: [
+                OpenClawChatEditorAttachment(
+                    mimeType: "image/png",
+                    data: imageData.base64EncodedString()),
+                OpenClawChatEditorAttachment(mimeType: "image/png", data: "%%%"),
+            ])
         let viewModel = OpenClawChatViewModel(sessionKey: "main", transport: transport)
         viewModel.input = "old draft"
+        viewModel.attachments = [OpenClawPendingAttachment(
+            url: nil,
+            data: Data("old image".utf8),
+            fileName: "old.png",
+            mimeType: "image/png",
+            preview: nil)]
 
         await viewModel.rewindToMessage(self.userMessage(entryID: "message-42"))
 
         #expect(viewModel.input == "edit this turn")
+        #expect(viewModel.attachments.count == 1)
+        #expect(viewModel.attachments.first?.data == imageData)
+        #expect(viewModel.attachments.first?.mimeType == "image/png")
         #expect(await transport.rewoundMessages().map { [$0.sessionKey, $0.entryID] } == [["main", "message-42"]])
         #expect(await transport.historySessionKeys() == ["main"])
     }
@@ -969,15 +995,22 @@ struct ChatViewModelSessionActionTests {
     }
 
     @Test func `fork at message switches and seeds editor`() async {
+        let imageData = Data("forked image".utf8)
         let transport = SessionActionTransport(
             forkAtMessageSessionKey: "agent:main:forked",
-            forkAtMessageEditorText: "continue here")
+            forkAtMessageEditorText: "continue here",
+            forkAtMessageEditorAttachments: [OpenClawChatEditorAttachment(
+                mimeType: "image/webp",
+                data: imageData.base64EncodedString())])
         let viewModel = OpenClawChatViewModel(sessionKey: "main", transport: transport)
 
         await viewModel.forkAtMessage(self.userMessage(entryID: "message-42"))
 
         #expect(viewModel.sessionKey == "agent:main:forked")
         #expect(viewModel.input == "continue here")
+        #expect(viewModel.attachments.count == 1)
+        #expect(viewModel.attachments.first?.data == imageData)
+        #expect(viewModel.attachments.first?.mimeType == "image/webp")
         #expect(await transport.forkedMessages().map { [$0.sessionKey, $0.entryID] } == [["main", "message-42"]])
     }
 

--- a/packages/gateway-protocol/src/schema/sessions.ts
+++ b/packages/gateway-protocol/src/schema/sessions.ts
@@ -646,13 +646,20 @@ export const SessionsForkParamsSchema = closedObject({
   entryId: NonEmptyString,
 });
 
+const SessionEditorAttachmentSchema = closedObject({
+  mimeType: Type.String(),
+  data: Type.String(),
+});
+
 export const SessionsRewindResultSchema = closedObject({
   editorText: Type.Optional(Type.String()),
+  editorAttachments: Type.Optional(Type.Array(SessionEditorAttachmentSchema)),
 });
 
 export const SessionsForkResultSchema = closedObject({
   sessionKey: NonEmptyString,
   editorText: Type.Optional(Type.String()),
+  editorAttachments: Type.Optional(Type.Array(SessionEditorAttachmentSchema)),
 });
 
 export const SessionBranchSchema = closedObject({

--- a/src/config/sessions/session-accessor.sqlite-message-cut.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-message-cut.test.ts
@@ -76,7 +76,13 @@ async function createSession(options: { activeLeafTarget?: string } = {}) {
       id: "user-2",
       parentId: "assistant-1",
       timestamp: "2026-07-18T00:00:03.000Z",
-      message: { role: "user", content: [{ type: "text", text: "second prompt" }] },
+      message: {
+        role: "user",
+        content: [
+          { type: "text", text: "second prompt" },
+          { type: "image", data: "aW1hZ2U=", mimeType: "image/png" },
+        ],
+      },
     },
     {
       type: "message",
@@ -203,6 +209,7 @@ describe("SQLite session message cuts", () => {
       status: "created",
       key: sessionKey,
       editorText: "second prompt",
+      editorAttachments: [{ mimeType: "image/png", data: "aW1hZ2U=" }],
     });
     if (result.status !== "created") {
       throw new Error("expected rewind result");
@@ -229,6 +236,20 @@ describe("SQLite session message cuts", () => {
       to: "chat-123",
       accountId: undefined,
     });
+  });
+
+  it("omits editor attachments for a text-only message", async () => {
+    const { env } = await createSession();
+
+    const result = await rewindSessionToMessage({
+      agentId,
+      env,
+      entryId: "user-1",
+      sessionKey,
+    });
+
+    expect(result).toMatchObject({ status: "created", editorText: "first prompt" });
+    expect(result).not.toHaveProperty("editorAttachments");
   });
 
   it("rewinds the stored row when its canonical key differs", async () => {
@@ -269,6 +290,7 @@ describe("SQLite session message cuts", () => {
       status: "created",
       key: targetKey,
       editorText: "second prompt",
+      editorAttachments: [{ mimeType: "image/png", data: "aW1hZ2U=" }],
     });
     if (result.status !== "created") {
       throw new Error("expected fork result");

--- a/src/config/sessions/session-accessor.sqlite-message-cut.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-message-cut.test.ts
@@ -82,6 +82,12 @@ async function createSession(options: { activeLeafTarget?: string } = {}) {
           { type: "text", text: "second prompt" },
           { type: "image", data: "aW1hZ2U=", mimeType: "image/png" },
         ],
+        __openclaw: {
+          media: [
+            { path: "/state/media/inbound/stored-image.png", contentType: "image/png" },
+            { path: "/state/media/inbound/notes.txt", contentType: "text/plain" },
+          ],
+        },
       },
     },
     {
@@ -210,6 +216,9 @@ describe("SQLite session message cuts", () => {
       key: sessionKey,
       editorText: "second prompt",
       editorAttachments: [{ mimeType: "image/png", data: "aW1hZ2U=" }],
+      editorMediaRefs: [
+        { path: "/state/media/inbound/stored-image.png", contentType: "image/png" },
+      ],
     });
     if (result.status !== "created") {
       throw new Error("expected rewind result");
@@ -250,6 +259,7 @@ describe("SQLite session message cuts", () => {
 
     expect(result).toMatchObject({ status: "created", editorText: "first prompt" });
     expect(result).not.toHaveProperty("editorAttachments");
+    expect(result).not.toHaveProperty("editorMediaRefs");
   });
 
   it("rewinds the stored row when its canonical key differs", async () => {
@@ -291,6 +301,9 @@ describe("SQLite session message cuts", () => {
       key: targetKey,
       editorText: "second prompt",
       editorAttachments: [{ mimeType: "image/png", data: "aW1hZ2U=" }],
+      editorMediaRefs: [
+        { path: "/state/media/inbound/stored-image.png", contentType: "image/png" },
+      ],
     });
     if (result.status !== "created") {
       throw new Error("expected fork result");

--- a/src/config/sessions/session-accessor.sqlite-message-cut.ts
+++ b/src/config/sessions/session-accessor.sqlite-message-cut.ts
@@ -50,6 +50,7 @@ import type { SessionEntry } from "./types.js";
 type MessageCut = {
   editorText?: string;
   editorAttachments?: Array<{ mimeType: string; data: string }>;
+  editorMediaRefs?: Array<{ path: string; contentType: string }>;
   parentId: string | null;
   prefix: TranscriptEvent[];
 };
@@ -255,6 +256,9 @@ function mutateSqliteSessionAtMessageInTransaction(
     ...(cut && !("status" in cut) && cut.editorAttachments
       ? { editorAttachments: cut.editorAttachments }
       : {}),
+    ...(cut && !("status" in cut) && cut.editorMediaRefs
+      ? { editorMediaRefs: cut.editorMediaRefs }
+      : {}),
   };
 }
 
@@ -374,9 +378,11 @@ function resolveMessageCut(
     );
   }
   const editorAttachments = extractEditorAttachments(message.content);
+  const editorMediaRefs = extractEditorMediaRefs(message);
   return {
     editorText: extractEditorText(message.content),
     ...(editorAttachments ? { editorAttachments } : {}),
+    ...(editorMediaRefs ? { editorMediaRefs } : {}),
     parentId: target.parentId,
     prefix,
   };
@@ -476,6 +482,24 @@ function extractEditorAttachments(
       : [];
   });
   return attachments.length > 0 ? attachments : undefined;
+}
+
+function extractEditorMediaRefs(
+  message: Record<string, unknown>,
+): Array<{ path: string; contentType: string }> | undefined {
+  const media = asRecord(message.__openclaw)?.media;
+  if (!Array.isArray(media)) {
+    return undefined;
+  }
+  const refs = media.flatMap((entry) => {
+    const record = asRecord(entry);
+    const mediaPath = typeof record?.path === "string" ? record.path.trim() : "";
+    const contentType = record?.contentType;
+    return mediaPath && typeof contentType === "string" && contentType.startsWith("image/")
+      ? [{ path: mediaPath, contentType }]
+      : [];
+  });
+  return refs.length > 0 ? refs : undefined;
 }
 
 function isSessionHeader(event: unknown): boolean {

--- a/src/config/sessions/session-accessor.sqlite-message-cut.ts
+++ b/src/config/sessions/session-accessor.sqlite-message-cut.ts
@@ -465,6 +465,11 @@ function extractEditorText(content: unknown): string | undefined {
   return text || undefined;
 }
 
+// Gateway-written inline images are already size-capped at send time; these bounds
+// only keep a corrupted transcript from ballooning the rewind/fork response.
+const EDITOR_ATTACHMENT_LIMIT = 10;
+const EDITOR_ATTACHMENT_MAX_BASE64_CHARS = Math.ceil((5 * 1024 * 1024) / 3) * 4;
+
 function extractEditorAttachments(
   content: unknown,
 ): Array<{ mimeType: string; data: string }> | undefined {
@@ -476,12 +481,13 @@ function extractEditorAttachments(
     return record?.type === "image" &&
       typeof record.data === "string" &&
       record.data.trim() &&
+      record.data.length <= EDITOR_ATTACHMENT_MAX_BASE64_CHARS &&
       typeof record.mimeType === "string" &&
-      record.mimeType.trim()
+      record.mimeType.startsWith("image/")
       ? [{ mimeType: record.mimeType, data: record.data }]
       : [];
   });
-  return attachments.length > 0 ? attachments : undefined;
+  return attachments.length > 0 ? attachments.slice(0, EDITOR_ATTACHMENT_LIMIT) : undefined;
 }
 
 function extractEditorMediaRefs(

--- a/src/config/sessions/session-accessor.sqlite-message-cut.ts
+++ b/src/config/sessions/session-accessor.sqlite-message-cut.ts
@@ -49,6 +49,7 @@ import type { SessionEntry } from "./types.js";
 
 type MessageCut = {
   editorText?: string;
+  editorAttachments?: Array<{ mimeType: string; data: string }>;
   parentId: string | null;
   prefix: TranscriptEvent[];
 };
@@ -251,6 +252,9 @@ function mutateSqliteSessionAtMessageInTransaction(
     key: params.targetKey,
     entry: nextEntry,
     ...(cut && !("status" in cut) && cut.editorText ? { editorText: cut.editorText } : {}),
+    ...(cut && !("status" in cut) && cut.editorAttachments
+      ? { editorAttachments: cut.editorAttachments }
+      : {}),
   };
 }
 
@@ -369,8 +373,10 @@ function resolveMessageCut(
         : node.entry,
     );
   }
+  const editorAttachments = extractEditorAttachments(message.content);
   return {
     editorText: extractEditorText(message.content),
+    ...(editorAttachments ? { editorAttachments } : {}),
     parentId: target.parentId,
     prefix,
   };
@@ -451,6 +457,25 @@ function extractEditorText(content: unknown): string | undefined {
     })
     .join("");
   return text || undefined;
+}
+
+function extractEditorAttachments(
+  content: unknown,
+): Array<{ mimeType: string; data: string }> | undefined {
+  if (!Array.isArray(content)) {
+    return undefined;
+  }
+  const attachments = content.flatMap((block) => {
+    const record = asRecord(block);
+    return record?.type === "image" &&
+      typeof record.data === "string" &&
+      record.data.trim() &&
+      typeof record.mimeType === "string" &&
+      record.mimeType.trim()
+      ? [{ mimeType: record.mimeType, data: record.data }]
+      : [];
+  });
+  return attachments.length > 0 ? attachments : undefined;
 }
 
 function isSessionHeader(event: unknown): boolean {

--- a/src/config/sessions/session-accessor.sqlite-message-cut.ts
+++ b/src/config/sessions/session-accessor.sqlite-message-cut.ts
@@ -493,7 +493,7 @@ function extractEditorAttachments(
 function extractEditorMediaRefs(
   message: Record<string, unknown>,
 ): Array<{ path: string; contentType: string }> | undefined {
-  const media = asRecord(message.__openclaw)?.media;
+  const media = asRecord(message["__openclaw"])?.media;
   if (!Array.isArray(media)) {
     return undefined;
   }

--- a/src/config/sessions/session-accessor.types.ts
+++ b/src/config/sessions/session-accessor.types.ts
@@ -653,6 +653,7 @@ export type SessionMessageCutMutationResult =
       key: string;
       entry: SessionEntry;
       editorText?: string;
+      editorAttachments?: Array<{ mimeType: string; data: string }>;
     }
   | { status: "missing-session" }
   | { status: "missing-entry" }

--- a/src/config/sessions/session-accessor.types.ts
+++ b/src/config/sessions/session-accessor.types.ts
@@ -654,6 +654,7 @@ export type SessionMessageCutMutationResult =
       entry: SessionEntry;
       editorText?: string;
       editorAttachments?: Array<{ mimeType: string; data: string }>;
+      editorMediaRefs?: Array<{ path: string; contentType: string }>;
     }
   | { status: "missing-session" }
   | { status: "missing-entry" }

--- a/src/gateway/server-methods/sessions-rewind.test.ts
+++ b/src/gateway/server-methods/sessions-rewind.test.ts
@@ -2,6 +2,7 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ErrorCodes } from "../../../packages/gateway-protocol/src/index.js";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { saveMediaBuffer } from "../../media/store.js";
 import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
 import type { GatewayRequestContext, RespondFn } from "./types.js";
@@ -67,6 +68,7 @@ import type { GatewayClient } from "./types.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 const sessionKey = "agent:main:rewind-handler";
+const storedImageData = Buffer.from("stored-image");
 
 beforeEach(async () => {
   mocks.active = false;
@@ -75,6 +77,7 @@ beforeEach(async () => {
   mocks.upstreamFork.mockReset();
   mocks.queueClear.mockReset();
   vi.stubEnv("OPENCLAW_STATE_DIR", tempDirs.make("openclaw-rewind-handler-"));
+  const storedImage = await saveMediaBuffer(storedImageData, "image/png", "inbound");
   await upsertSessionEntry(
     { agentId: "main", sessionKey },
     {
@@ -94,6 +97,12 @@ beforeEach(async () => {
           { type: "text", text: "edit me" },
           { type: "image", data: "aW1hZ2U=", mimeType: "image/png" },
         ],
+        __openclaw: {
+          media: [
+            { path: storedImage.path, contentType: "image/png" },
+            { path: `${storedImage.path}.missing`, contentType: "image/png" },
+          ],
+        },
       },
     },
     {
@@ -252,7 +261,10 @@ describe("session message-cut methods", () => {
       true,
       expect.objectContaining({
         editorText: "edit me",
-        editorAttachments: [{ mimeType: "image/png", data: "aW1hZ2U=" }],
+        editorAttachments: [
+          { mimeType: "image/png", data: "aW1hZ2U=" },
+          { mimeType: "image/png", data: storedImageData.toString("base64") },
+        ],
         sessionKey: expect.any(String),
       }),
       undefined,
@@ -278,7 +290,10 @@ describe("session message-cut methods", () => {
       true,
       {
         editorText: "edit me",
-        editorAttachments: [{ mimeType: "image/png", data: "aW1hZ2U=" }],
+        editorAttachments: [
+          { mimeType: "image/png", data: "aW1hZ2U=" },
+          { mimeType: "image/png", data: storedImageData.toString("base64") },
+        ],
       },
       undefined,
     );

--- a/src/gateway/server-methods/sessions-rewind.test.ts
+++ b/src/gateway/server-methods/sessions-rewind.test.ts
@@ -100,6 +100,8 @@ beforeEach(async () => {
         __openclaw: {
           media: [
             { path: storedImage.path, contentType: "image/png" },
+            // Duplicate ref proves dedupe: the response must carry this image once.
+            { path: storedImage.path, contentType: "image/png" },
             { path: `${storedImage.path}.missing`, contentType: "image/png" },
           ],
         },

--- a/src/gateway/server-methods/sessions-rewind.test.ts
+++ b/src/gateway/server-methods/sessions-rewind.test.ts
@@ -88,7 +88,13 @@ beforeEach(async () => {
       type: "message",
       id: "user-entry",
       parentId: null,
-      message: { role: "user", content: "edit me" },
+      message: {
+        role: "user",
+        content: [
+          { type: "text", text: "edit me" },
+          { type: "image", data: "aW1hZ2U=", mimeType: "image/png" },
+        ],
+      },
     },
     {
       type: "message",
@@ -244,7 +250,11 @@ describe("session message-cut methods", () => {
     } as GatewayClient);
     expect(fork).toHaveBeenCalledWith(
       true,
-      expect.objectContaining({ editorText: "edit me", sessionKey: expect.any(String) }),
+      expect.objectContaining({
+        editorText: "edit me",
+        editorAttachments: [{ mimeType: "image/png", data: "aW1hZ2U=" }],
+        sessionKey: expect.any(String),
+      }),
       undefined,
     );
     const forkKey = (fork.mock.calls[0]?.[1] as { sessionKey?: string } | undefined)?.sessionKey;
@@ -264,7 +274,14 @@ describe("session message-cut methods", () => {
     );
 
     const rewind = await invoke("sessions.rewind", "user-entry");
-    expect(rewind).toHaveBeenCalledWith(true, { editorText: "edit me" }, undefined);
+    expect(rewind).toHaveBeenCalledWith(
+      true,
+      {
+        editorText: "edit me",
+        editorAttachments: [{ mimeType: "image/png", data: "aW1hZ2U=" }],
+      },
+      undefined,
+    );
     expect(mocks.queueClear).toHaveBeenCalledTimes(1);
   });
 

--- a/src/gateway/server-methods/sessions-rewind.ts
+++ b/src/gateway/server-methods/sessions-rewind.ts
@@ -50,26 +50,37 @@ type MessageCutAction = "fork" | "rewind" | "switch";
 const EXTERNAL_CONVERSATION_ERROR =
   "Session history changes are unavailable because this session is owned by an external agent harness.";
 
+// A message realistically carries a handful of images; a corrupt transcript must
+// not turn rewind into a bulk media read.
+const EDITOR_MEDIA_REF_LIMIT = 10;
+
 async function resolveEditorMediaAttachments(
   refs: Array<{ path: string; contentType: string }> | undefined,
 ): Promise<Array<{ mimeType: string; data: string }>> {
   if (!refs) {
     return [];
   }
-  const attachments = await Promise.all(
-    refs.map(async (ref) => {
-      try {
-        // Transcript paths are untrusted hints; read only the basename through the
-        // media store so its traversal guards and byte cap stay authoritative.
-        const id = path.basename(ref.path);
-        const media = await readMediaBuffer(id, "inbound", MEDIA_MAX_BYTES);
-        return { mimeType: ref.contentType, data: media.buffer.toString("base64") };
-      } catch {
-        return undefined;
-      }
-    }),
-  );
-  return attachments.filter((attachment) => attachment !== undefined);
+  const seen = new Set<string>();
+  const attachments: Array<{ mimeType: string; data: string }> = [];
+  for (const ref of refs) {
+    if (seen.has(ref.path)) {
+      continue;
+    }
+    seen.add(ref.path);
+    if (seen.size > EDITOR_MEDIA_REF_LIMIT) {
+      break;
+    }
+    try {
+      // Transcript paths are untrusted hints; read only the basename through the
+      // media store so its traversal guards and byte cap stay authoritative.
+      const id = path.basename(ref.path);
+      const media = await readMediaBuffer(id, "inbound", MEDIA_MAX_BYTES);
+      attachments.push({ mimeType: ref.contentType, data: media.buffer.toString("base64") });
+    } catch {
+      // Skipped refs (missing file, oversized, guard rejection) never fail the cut.
+    }
+  }
+  return attachments;
 }
 
 function resolveUpstreamForkHarness(link: SessionUpstreamLink) {

--- a/src/gateway/server-methods/sessions-rewind.ts
+++ b/src/gateway/server-methods/sessions-rewind.ts
@@ -433,9 +433,19 @@ async function mutateSessionAtMessage(
               ...("editorText" in result && result.editorText
                 ? { editorText: result.editorText }
                 : {}),
+              ...("editorAttachments" in result && result.editorAttachments
+                ? { editorAttachments: result.editorAttachments }
+                : {}),
             }
-          : action === "rewind" && "editorText" in result && result.editorText
-            ? { editorText: result.editorText }
+          : action === "rewind"
+            ? {
+                ...("editorText" in result && result.editorText
+                  ? { editorText: result.editorText }
+                  : {}),
+                ...("editorAttachments" in result && result.editorAttachments
+                  ? { editorAttachments: result.editorAttachments }
+                  : {}),
+              }
             : {},
         undefined,
       );

--- a/src/gateway/server-methods/sessions-rewind.ts
+++ b/src/gateway/server-methods/sessions-rewind.ts
@@ -63,17 +63,18 @@ async function resolveEditorMediaAttachments(
   const seen = new Set<string>();
   const attachments: Array<{ mimeType: string; data: string }> = [];
   for (const ref of refs) {
-    if (seen.has(ref.path)) {
+    // Transcript paths are untrusted hints; only the basename is read through the
+    // media store (its traversal guards and byte cap stay authoritative), so
+    // dedupe on that resolved id — path aliases must not repeat the same read.
+    const id = path.basename(ref.path);
+    if (seen.has(id)) {
       continue;
     }
-    seen.add(ref.path);
+    seen.add(id);
     if (seen.size > EDITOR_MEDIA_REF_LIMIT) {
       break;
     }
     try {
-      // Transcript paths are untrusted hints; read only the basename through the
-      // media store so its traversal guards and byte cap stay authoritative.
-      const id = path.basename(ref.path);
       const media = await readMediaBuffer(id, "inbound", MEDIA_MAX_BYTES);
       attachments.push({ mimeType: ref.contentType, data: media.buffer.toString("base64") });
     } catch {

--- a/src/gateway/server-methods/sessions-rewind.ts
+++ b/src/gateway/server-methods/sessions-rewind.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import {
   ErrorCodes,
   errorShape,
@@ -18,6 +19,7 @@ import {
   type SessionBranchSwitchMutationResult,
   type SessionMessageCutMutationResult,
 } from "../../config/sessions/session-accessor.js";
+import { MEDIA_MAX_BYTES, readMediaBuffer } from "../../media/store.js";
 import {
   isCompetingSessionWorkAdmissionActive,
   runExclusiveSessionLifecycleMutation,
@@ -47,6 +49,28 @@ type MessageCutAction = "fork" | "rewind" | "switch";
 
 const EXTERNAL_CONVERSATION_ERROR =
   "Session history changes are unavailable because this session is owned by an external agent harness.";
+
+async function resolveEditorMediaAttachments(
+  refs: Array<{ path: string; contentType: string }> | undefined,
+): Promise<Array<{ mimeType: string; data: string }>> {
+  if (!refs) {
+    return [];
+  }
+  const attachments = await Promise.all(
+    refs.map(async (ref) => {
+      try {
+        // Transcript paths are untrusted hints; read only the basename through the
+        // media store so its traversal guards and byte cap stay authoritative.
+        const id = path.basename(ref.path);
+        const media = await readMediaBuffer(id, "inbound", MEDIA_MAX_BYTES);
+        return { mimeType: ref.contentType, data: media.buffer.toString("base64") };
+      } catch {
+        return undefined;
+      }
+    }),
+  );
+  return attachments.filter((attachment) => attachment !== undefined);
+}
 
 function resolveUpstreamForkHarness(link: SessionUpstreamLink) {
   const matches = listRegisteredAgentHarnesses().filter((entry) =>
@@ -416,6 +440,15 @@ async function mutateSessionAtMessage(
         respondMessageCutError(result, action, entryId, respond);
         return;
       }
+      const editorAttachments =
+        action === "switch"
+          ? []
+          : [
+              ...("editorAttachments" in result ? (result.editorAttachments ?? []) : []),
+              ...(await resolveEditorMediaAttachments(
+                "editorMediaRefs" in result ? result.editorMediaRefs : undefined,
+              )),
+            ];
       if (action !== "fork") {
         clearSessionQueues(lifecycleIdentities);
       } else {
@@ -433,18 +466,14 @@ async function mutateSessionAtMessage(
               ...("editorText" in result && result.editorText
                 ? { editorText: result.editorText }
                 : {}),
-              ...("editorAttachments" in result && result.editorAttachments
-                ? { editorAttachments: result.editorAttachments }
-                : {}),
+              ...(editorAttachments.length > 0 ? { editorAttachments } : {}),
             }
           : action === "rewind"
             ? {
                 ...("editorText" in result && result.editorText
                   ? { editorText: result.editorText }
                   : {}),
-                ...("editorAttachments" in result && result.editorAttachments
-                  ? { editorAttachments: result.editorAttachments }
-                  : {}),
+                ...(editorAttachments.length > 0 ? { editorAttachments } : {}),
               }
             : {},
         undefined,

--- a/ui/src/lib/sessions/message-cut.test.ts
+++ b/ui/src/lib/sessions/message-cut.test.ts
@@ -51,7 +51,10 @@ function createGatewayHarness(client: GatewayBrowserClient) {
 
 describe("session capability message cuts", () => {
   it("returns a committed rewind result after the connection is replaced", async () => {
-    const committed = deferred<{ editorText?: string }>();
+    const committed = deferred<{
+      editorText?: string;
+      editorAttachments?: Array<{ mimeType: string; data: string }>;
+    }>();
     const request = vi.fn((method: string) => {
       if (method === "sessions.rewind") {
         return committed.promise;
@@ -64,9 +67,15 @@ describe("session capability message cuts", () => {
 
     const pending = sessions.rewind("agent:main:main", "user-entry");
     harness.publish(false);
-    committed.resolve({ editorText: "edit me" });
+    committed.resolve({
+      editorText: "edit me",
+      editorAttachments: [{ mimeType: "image/png", data: "aW1hZ2U=" }],
+    });
 
-    await expect(pending).resolves.toEqual({ editorText: "edit me" });
+    await expect(pending).resolves.toEqual({
+      editorText: "edit me",
+      editorAttachments: [{ mimeType: "image/png", data: "aW1hZ2U=" }],
+    });
     expect(request).toHaveBeenCalledWith("sessions.rewind", {
       sessionKey: "agent:main:main",
       entryId: "user-entry",
@@ -77,7 +86,11 @@ describe("session capability message cuts", () => {
   it("returns a committed fork result when the replacement refresh fails", async () => {
     const request = vi.fn(async (method: string) => {
       if (method === "sessions.fork") {
-        return { sessionKey: "agent:main:dashboard:forked", editorText: "edit me" };
+        return {
+          sessionKey: "agent:main:dashboard:forked",
+          editorText: "edit me",
+          editorAttachments: [{ mimeType: "image/png", data: "aW1hZ2U=" }],
+        };
       }
       if (method === "sessions.list") {
         throw new Error("refresh failed");
@@ -91,6 +104,7 @@ describe("session capability message cuts", () => {
     await expect(sessions.forkAtMessage("agent:main:main", "user-entry")).resolves.toEqual({
       sessionKey: "agent:main:dashboard:forked",
       editorText: "edit me",
+      editorAttachments: [{ mimeType: "image/png", data: "aW1hZ2U=" }],
     });
     expect(request).toHaveBeenCalledWith("sessions.fork", {
       sessionKey: "agent:main:main",

--- a/ui/src/pages/chat/attachment-payload-store.ts
+++ b/ui/src/pages/chat/attachment-payload-store.ts
@@ -83,10 +83,10 @@ export function generateAttachmentId(): string {
 
 // Same admission contract as the Swift/Android restore paths: only well-formed,
 // size-bounded inline images come back; a corrupt transcript entry is skipped,
-// never fatal. 5 MB decoded matches the native restore caps.
+// never fatal. 5 MiB decoded matches the gateway media cap (MEDIA_MAX_BYTES).
 const RESTORED_IMAGE_MIME = /^image\/[\w.+-]+$/u;
 const BASE64_PAYLOAD = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/u;
-const RESTORED_ATTACHMENT_MAX_BASE64_CHARS = Math.ceil(5_000_000 / 3) * 4;
+const RESTORED_ATTACHMENT_MAX_BASE64_CHARS = Math.ceil((5 * 1024 * 1024) / 3) * 4;
 
 export function replaceChatAttachmentsFromEditor(
   current: readonly ChatAttachment[],

--- a/ui/src/pages/chat/attachment-payload-store.ts
+++ b/ui/src/pages/chat/attachment-payload-store.ts
@@ -77,6 +77,38 @@ export function releaseChatAttachmentPayloads(attachments: readonly ChatAttachme
   }
 }
 
+export function generateAttachmentId(): string {
+  return `att-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+}
+
+// Same admission contract as the Swift/Android restore paths: only well-formed,
+// size-bounded inline images come back; a corrupt transcript entry is skipped,
+// never fatal. 5 MB decoded matches the native restore caps.
+const RESTORED_IMAGE_MIME = /^image\/[\w.+-]+$/u;
+const BASE64_PAYLOAD = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/u;
+const RESTORED_ATTACHMENT_MAX_BASE64_CHARS = Math.ceil(5_000_000 / 3) * 4;
+
+export function replaceChatAttachmentsFromEditor(
+  current: readonly ChatAttachment[],
+  restored: readonly { mimeType: string; data: string }[] = [],
+): ChatAttachment[] {
+  releaseChatAttachmentPayloads(current);
+  return restored.flatMap(({ mimeType, data }) =>
+    RESTORED_IMAGE_MIME.test(mimeType) &&
+    data.length > 0 &&
+    data.length <= RESTORED_ATTACHMENT_MAX_BASE64_CHARS &&
+    BASE64_PAYLOAD.test(data)
+      ? [
+          {
+            id: generateAttachmentId(),
+            mimeType,
+            dataUrl: `data:${mimeType};base64,${data}`,
+          },
+        ]
+      : [],
+  );
+}
+
 function discardChatAttachmentDataUrl(id: string): void {
   const payload = payloads.get(id);
   if (!payload) {

--- a/ui/src/pages/chat/chat-history.test.ts
+++ b/ui/src/pages/chat/chat-history.test.ts
@@ -95,8 +95,17 @@ describe("rewindChatHistory", () => {
     state.handleChatDraftChange = vi.fn((next: string) => {
       state.chatMessage = next;
     });
+    state.chatAttachments = [{ id: "old", mimeType: "image/jpeg", dataUrl: "data:old" }];
     state.sessions = {
-      rewind: vi.fn().mockResolvedValue({ editorText: "edit this" }),
+      rewind: vi.fn().mockResolvedValue({
+        editorText: "edit this",
+        editorAttachments: [
+          { mimeType: "image/png", data: "aW1hZ2U=" },
+          { mimeType: "application/pdf", data: "aW1hZ2U=" },
+          { mimeType: "image/png", data: "not base64!!" },
+          { mimeType: "image/png", data: "A" },
+        ],
+      }),
       setModelOverride: vi.fn(),
     };
     cacheChatSessionSnapshot(
@@ -117,8 +126,24 @@ describe("rewindChatHistory", () => {
       "user-entry",
       expect.any(Object),
     );
-    expect(result).toEqual({ editorText: "edit this" });
+    expect(result).toEqual({
+      editorText: "edit this",
+      editorAttachments: [
+        { mimeType: "image/png", data: "aW1hZ2U=" },
+        { mimeType: "application/pdf", data: "aW1hZ2U=" },
+        { mimeType: "image/png", data: "not base64!!" },
+        { mimeType: "image/png", data: "A" },
+      ],
+    });
     expect(state.chatMessage).toBe("edit this");
+    expect(state.chatAttachments).toEqual([
+      {
+        id: expect.stringMatching(/^att-/),
+        mimeType: "image/png",
+        dataUrl: "data:image/png;base64,aW1hZ2U=",
+      },
+    ]);
+    expect(state.chatAttachments[0]?.id).not.toBe("old");
     expect(state.chatMessages).toEqual([{ role: "assistant", content: "kept prefix" }]);
     expect(
       readChatMessagesFromCache(state.chatMessagesBySession, state, {

--- a/ui/src/pages/chat/chat-history.ts
+++ b/ui/src/pages/chat/chat-history.ts
@@ -40,6 +40,7 @@ import {
   resolveUiSelectedSessionAgentId,
 } from "../../lib/sessions/session-key.ts";
 import { normalizeLowercaseStringOrEmpty } from "../../lib/string-coerce.ts";
+import { replaceChatAttachmentsFromEditor } from "./attachment-payload-store.ts";
 import type { ChatHistoryPagination } from "./chat-history-pagination.ts";
 import {
   isRetryableStartupUnavailable,
@@ -868,6 +869,12 @@ export async function rewindChatHistory(
     if (!visibleSessionMatches(state, sessionKey, agentParams.agentId)) {
       return null;
     }
+    // Restored images intentionally stay in this tab's memory; persisted composer drafts remain
+    // text-only so large payloads do not enter local storage.
+    state.chatAttachments = replaceChatAttachmentsFromEditor(
+      state.chatAttachments,
+      result.editorAttachments,
+    );
     state.handleChatDraftChange(editorText);
     return result;
   } catch (error) {

--- a/ui/src/pages/chat/chat-pane-deps.ts
+++ b/ui/src/pages/chat/chat-pane-deps.ts
@@ -156,6 +156,7 @@ export {
 } from "./board-session-surface.ts";
 export { catalogMessageId } from "./catalog-message-id.ts";
 export { refreshChatAvatar } from "./chat-avatar.ts";
+export { replaceChatAttachmentsFromEditor } from "./attachment-payload-store.ts";
 export type { ChatHistoryPagination } from "./chat-history-pagination.ts";
 export {
   applyChatAgentsList,

--- a/ui/src/pages/chat/chat-pane-history.ts
+++ b/ui/src/pages/chat/chat-pane-history.ts
@@ -7,6 +7,7 @@ import {
   parseCatalogSessionKey,
   persistChatComposerState,
   resolveChatHistoryPagination,
+  replaceChatAttachmentsFromEditor,
   rewindChatHistory,
   scheduleChatScroll,
   scopedAgentParamsForSession,
@@ -368,6 +369,12 @@ export abstract class ChatPaneHistory extends ChatPaneSession {
       }
       this.onPaneSessionChange?.(this.paneId, result.sessionKey);
       this.switchPaneSession(result.sessionKey);
+      // Restored images intentionally stay in this tab's memory; persisted composer drafts remain
+      // text-only so large payloads do not enter local storage.
+      state.chatAttachments = replaceChatAttachmentsFromEditor(
+        state.chatAttachments,
+        result.editorAttachments,
+      );
       if (!draftPersisted) {
         state.handleChatDraftChange(editorText);
       }

--- a/ui/src/pages/chat/chat-pane.message-cut.test.ts
+++ b/ui/src/pages/chat/chat-pane.message-cut.test.ts
@@ -12,6 +12,7 @@ type TestChatPane = HTMLElement & {
   forkFromMessage: (entryId: string) => Promise<void>;
   onPaneSessionChange?: (paneId: string, sessionKey: string) => void;
   state: ChatPageHost;
+  switchPaneSession: (sessionKey: string) => void;
 };
 
 function createDeferred<T>() {
@@ -52,7 +53,9 @@ function createTestChatPane(params: { client: GatewayBrowserClient; sessions: Se
     chatError: null,
     chatHistoryPagination: { hasMore: false },
     chatLoading: false,
+    chatMessage: "",
     chatMessages: [],
+    chatAttachments: [],
     chatQueue: [],
     chatRunId: null,
     chatSending: false,
@@ -73,6 +76,7 @@ function createTestChatPane(params: { client: GatewayBrowserClient; sessions: Se
     chatScrollGeneration: 0,
     chatScrollCommitCleanup: null,
     handleChatScroll: vi.fn(),
+    handleChatDraftChange: vi.fn(),
     renderLifecycle: { afterCommit: () => () => {}, invalidate: () => {} },
   } as unknown as ChatPageHost;
   pane.context = createSessionContext(params.client, params.sessions);
@@ -83,6 +87,34 @@ function createTestChatPane(params: { client: GatewayBrowserClient; sessions: Se
 }
 
 describe("chat pane message cuts", () => {
+  it("restores forked prompt attachments into the new session composer", async () => {
+    const sessions = {
+      forkAtMessage: vi.fn().mockResolvedValue({
+        sessionKey: "agent:main:forked",
+        editorText: "edit me",
+        editorAttachments: [{ mimeType: "image/png", data: "aW1hZ2U=" }],
+      }),
+    } as unknown as SessionCapability;
+    const client = {} as GatewayBrowserClient;
+    const { pane, state } = createTestChatPane({ client, sessions });
+    state.chatAttachments = [{ id: "old", mimeType: "image/jpeg", dataUrl: "data:old" }];
+    pane.switchPaneSession = vi.fn((sessionKey: string) => {
+      state.sessionKey = sessionKey;
+      state.chatAttachments = [];
+    });
+
+    await pane.forkFromMessage("user-entry");
+
+    expect(state.sessionKey).toBe("agent:main:forked");
+    expect(state.chatAttachments).toEqual([
+      {
+        id: expect.stringMatching(/^att-/),
+        mimeType: "image/png",
+        dataUrl: "data:image/png;base64,aW1hZ2U=",
+      },
+    ]);
+  });
+
   it("keeps a newer global agent selection when a message fork finishes late", async () => {
     const forked = createDeferred<{ sessionKey: string; editorText?: string }>();
     const sessions = {

--- a/ui/src/pages/chat/components/chat-attachments.ts
+++ b/ui/src/pages/chat/components/chat-attachments.ts
@@ -7,6 +7,7 @@ import "../../../components/web-awesome.ts";
 import { t } from "../../../i18n/index.ts";
 import type { ChatAttachment } from "../../../lib/chat/chat-types.ts";
 import {
+  generateAttachmentId,
   getChatAttachmentDataUrl,
   getChatAttachmentPreviewUrl,
   registerChatAttachmentPayload,
@@ -86,10 +87,6 @@ function clickComposerInput(target: HTMLElement, selector: string) {
     .closest(".agent-chat__composer-shell, .new-session-page__composer")
     ?.querySelector<HTMLInputElement>(selector)
     ?.click();
-}
-
-function generateAttachmentId(): string {
-  return `att-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
 }
 
 function chatAttachmentFromFile(file: File, dataUrl: string): ChatAttachment {


### PR DESCRIPTION
## What Problem This Solves

The "Rewind to here" action on a user prompt (web, iOS, macOS, Android) truncates the conversation and puts the prompt text back into the composer — but any images attached to that prompt were silently dropped. The same gap existed for "Fork from here".

## Why This Change Was Made

Rewinding exists so a prompt can be corrected and resent; losing its images defeats that. Inline images are already stored in the transcript user message as base64 blocks, so the cut layer can return them alongside the existing `editorText`.

## User Impact

Rewinding to (or forking at) a prompt that contained images now restores those images into the composer on all four clients, ready to edit and resend. Restored attachments are validated (image MIME, well-formed base64, 5 MB cap) and invalid transcript entries are skipped rather than failing the rewind. Restored images live in tab/app memory only; persisted drafts remain text-only by design.

## Evidence

- Cut layer: `resolveMessageCut` extracts `{type:"image", data, mimeType}` blocks; additive optional `editorAttachments` on `sessions.rewind`/`sessions.fork` results (no protocol version bump; Swift/Kotlin/schema regenerated via `pnpm protocol:gen*`).
- Web: `rewindChatHistory`/`forkFromMessage` rebuild composer attachments via `replaceChatAttachmentsFromEditor`.
- iOS/macOS: shared `OpenClawChatViewModel` restores `OpenClawPendingAttachment`s with UTType/size validation.
- Android: `ChatController` parses typed results; `ChatDraft` carries heap-only attachments; composer store replace semantics with omission notices.
- Tests: `node scripts/run-vitest.mjs src/config/sessions/session-accessor.sqlite-message-cut.test.ts` (13 passed), `src/gateway/server-methods/sessions-rewind.test.ts` (21 passed), UI suites incl. isolated chat-pane message-cut (all passed); `swift test --filter ChatViewModelSessionActionTests` (34 passed); `./gradlew :app:testPlayDebugUnitTest --tests ...SessionActionsTest --tests ...ComposerDraftTest` (68 passed).
- `pnpm check:changed` delegated to Blacksmith Testbox: exit 0 (run tbx_01kydxfv2y6rshte6k51xjeq3q).
- Codex autoreview (gpt-5.6-sol): clean, no accepted findings.
