### PR TITLE
refactor(config): remove retired diagnostics shapes

### DIFF
--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -1285,23 +1285,11 @@ writer is best-effort, not a lossless compliance archive.
       logsExporter: "otlp",
       sampleRate: 1.0,
       flushIntervalMs: 5000,
-      captureContent: {
-        enabled: false,
-        inputMessages: false,
-        outputMessages: false,
-        toolInputs: false,
-        toolOutputs: false,
-        systemPrompt: false,
-        toolDefinitions: false,
-      },
+      captureContent: false,
     },
 
     cacheTrace: {
       enabled: false,
-      filePath: "~/.openclaw/logs/cache-trace.jsonl",
-      includeMessages: true,
-      includePrompt: true,
-      includeSystem: true,
     },
   },
 }
@@ -1319,13 +1307,11 @@ writer is best-effort, not a lossless compliance archive.
 - `otel.logsExporter`: log export sink: `"otlp"` (default), `"stdout"` for one JSON object per stdout line, or `"both"`.
 - `otel.sampleRate`: trace sampling rate `0`-`1`.
 - `otel.flushIntervalMs`: periodic telemetry flush interval in ms.
-- `otel.captureContent`: opt-in raw content capture for OTEL span attributes. Defaults to off. Boolean `true` captures non-system message/tool content; the object form lets you enable `inputMessages`, `outputMessages`, `toolInputs`, `toolOutputs`, `systemPrompt`, and `toolDefinitions` explicitly.
+- `otel.captureContent`: opt-in raw content capture for OTEL span attributes. Defaults to off. `true` captures non-system message, tool, and tool-definition content plus OTLP log bodies.
 - `OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental`: environment toggle for latest experimental GenAI inference span shape, including `{gen_ai.operation.name} {gen_ai.request.model}` span names, `CLIENT` span kind, and `gen_ai.provider.name` instead of legacy `gen_ai.system`. By default spans keep `openclaw.model.call` and `gen_ai.system` for compatibility; GenAI metrics use bounded semantic attributes.
 - `OPENCLAW_OTEL_PRELOADED=1`: environment toggle for hosts that already registered a global OpenTelemetry SDK. OpenClaw then skips plugin-owned SDK startup/shutdown while keeping diagnostic listeners active.
 - `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`, `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`, and `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT`: signal-specific endpoint env vars used when the matching config key is unset.
 - `cacheTrace.enabled`: log cache trace snapshots for embedded runs (default: `false`).
-- `cacheTrace.filePath`: output path for cache trace JSONL (default: `$OPENCLAW_STATE_DIR/logs/cache-trace.jsonl`).
-- `cacheTrace.includeMessages` / `includePrompt` / `includeSystem`: control what is included in cache trace output (all default: `true`).
 
 ---
 

--- a/docs/gateway/opentelemetry.md
+++ b/docs/gateway/opentelemetry.md
@@ -97,15 +97,7 @@ stdout, or `both` for both.
       logsExporter: "otlp", // otlp | stdout | both
       sampleRate: 0.2, // root-span sampler, 0.0..1.0
       flushIntervalMs: 60000, // metric export interval (min 1000ms)
-      captureContent: {
-        enabled: false,
-        inputMessages: false,
-        outputMessages: false,
-        toolInputs: false,
-        toolOutputs: false,
-        systemPrompt: false,
-        toolDefinitions: false,
-      },
+      captureContent: false,
     },
   },
 }
@@ -132,8 +124,7 @@ Values that look like scoped agent session keys (for example starting with
 `agent:`) are replaced with `unknown` on low-cardinality attributes. OTLP log
 records keep severity, logger, code location, trusted trace context, and
 sanitized attributes by default; the raw log message body is exported only
-when `diagnostics.otel.captureContent` is boolean `true`. Granular
-`captureContent.*` subkeys never enable log bodies. Talk metrics export only
+when `diagnostics.otel.captureContent` is `true`. Talk metrics export only
 bounded event metadata (mode, transport, provider, event type) - no
 transcripts, audio payloads, session ids, turn ids, call ids, room ids, or
 handoff tokens.
@@ -143,23 +134,11 @@ from OpenClaw-owned diagnostic trace context for the active model call.
 Existing caller-supplied `traceparent` headers are replaced, so plugins or
 custom provider options cannot spoof cross-service trace ancestry.
 
-Set `diagnostics.otel.captureContent.*` to `true` only when your collector
-and retention policy are approved for prompt, response, tool, or
-system-prompt text. Each subkey is independent:
-
-- `inputMessages` - user prompt content.
-- `outputMessages` - model response content.
-- `toolInputs` - tool argument payloads.
-- `toolOutputs` - tool result payloads.
-- `systemPrompt` - assembled system/developer prompt.
-- `toolDefinitions` - model tool names, descriptions, and schemas.
-
-When any subkey is enabled, model and tool spans get bounded, redacted
-`openclaw.content.*` attributes for that class only.
-
-<Note>
-Boolean `captureContent: true` enables `inputMessages`, `outputMessages`, `toolInputs`, `toolOutputs`, `toolDefinitions`, and OTLP log bodies together, but **not** `systemPrompt` - set `captureContent.systemPrompt: true` explicitly if you also need the assembled system prompt.
-</Note>
+Set `diagnostics.otel.captureContent` to `true` only when your collector and
+retention policy are approved for prompt, response, tool, and tool-definition
+text. This enables bounded, redacted input messages, output messages, tool
+inputs, tool outputs, tool definitions, and OTLP log bodies. System prompts
+remain excluded.
 
 `toolInputs`/`toolOutputs` content is captured for the built-in agent
 runtime's tool executions (`openclaw.content.tool_input` and
@@ -278,12 +257,11 @@ CLI boundary:
 - `openclaw.model_call.time_to_first_byte_ms` is time to the first observable
   Claude CLI stdout or stderr output. It is not network TTFB.
 
-With the matching granular `captureContent` fields enabled, the span exports
-the effective prompt OpenClaw sends to Claude Code, OpenClaw's appended system
-prompt, and visible assistant text/reasoning/tool-call identity through
-`gen_ai.input.messages`, `gen_ai.output.messages`, and
-`gen_ai.system_instructions`. Tool arguments, opaque thinking signatures, and
-tool results are omitted from the Claude assistant envelope. OpenClaw does not
+With `captureContent` enabled, the span exports the effective prompt OpenClaw
+sends to Claude Code and visible assistant text/reasoning/tool-call identity
+through `gen_ai.input.messages` and `gen_ai.output.messages`. Tool arguments,
+opaque thinking signatures, tool results, and system prompts are omitted from
+the Claude assistant envelope. OpenClaw does not
 claim access to Claude Code's private system prompt, hidden resumed or
 compacted request payload, native internal tool schemas, raw Anthropic HTTP
 request, internal retries, upstream request id, or true network TTFB. Because

--- a/extensions/diagnostics-otel/src/service-content-normalization.ts
+++ b/extensions/diagnostics-otel/src/service-content-normalization.ts
@@ -43,34 +43,17 @@ export function normalizeOtelErrorMessage(value: string | undefined): string | u
 }
 
 export function resolveContentCapturePolicy(value: unknown): OtelContentCapturePolicy {
-  if (value === true) {
-    return {
-      inputMessages: true,
-      outputMessages: true,
-      toolInputs: true,
-      toolOutputs: true,
-      systemPrompt: false,
-      toolDefinitions: true,
-      logBodies: true,
-    };
-  }
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return NO_CONTENT_CAPTURE;
-  }
-
-  const config = value as Record<string, unknown>;
-  if (config.enabled !== true) {
-    return NO_CONTENT_CAPTURE;
-  }
-  return {
-    inputMessages: config.inputMessages === true,
-    outputMessages: config.outputMessages === true,
-    toolInputs: config.toolInputs === true,
-    toolOutputs: config.toolOutputs === true,
-    systemPrompt: config.systemPrompt === true,
-    toolDefinitions: config.toolDefinitions === true,
-    logBodies: false,
-  };
+  return value === true
+    ? {
+        inputMessages: true,
+        outputMessages: true,
+        toolInputs: true,
+        toolOutputs: true,
+        systemPrompt: false,
+        toolDefinitions: true,
+        logBodies: true,
+      }
+    : NO_CONTENT_CAPTURE;
 }
 
 export function hasPreloadedOtelSdk(): boolean {

--- a/extensions/diagnostics-otel/src/service.test-helpers.ts
+++ b/extensions/diagnostics-otel/src/service.test-helpers.ts
@@ -23,19 +23,6 @@ export const MODEL_FIXTURE = {
 } as const;
 export const RUN_FIXTURE = { runId: "run-1", ...MODEL_FIXTURE } as const;
 export const MODEL_CALL_FIXTURE = { ...RUN_FIXTURE, callId: "call-1" } as const;
-export const MODEL_CONTENT_CAPTURE = {
-  enabled: true,
-  inputMessages: true,
-  outputMessages: true,
-  systemPrompt: true,
-  toolDefinitions: true,
-} as const;
-export const INPUT_ONLY_CAPTURE = {
-  enabled: true,
-  inputMessages: true,
-  outputMessages: false,
-} as const;
-
 type OtelConfig = NonNullable<
   NonNullable<OpenClawPluginServiceContext["config"]["diagnostics"]>["otel"]
 >;

--- a/extensions/diagnostics-otel/src/service.test.ts
+++ b/extensions/diagnostics-otel/src/service.test.ts
@@ -197,10 +197,8 @@ import {
   createOtelContext,
   createTestTrace,
   GRANDCHILD_SPAN_ID,
-  INPUT_ONLY_CAPTURE,
   MODEL_CALL_SPAN_ID,
   MODEL_CALL_FIXTURE,
-  MODEL_CONTENT_CAPTURE,
   MODEL_FIXTURE,
   MODEL_USAGE_SPAN_ID,
   type OtelContextFlags,
@@ -1970,18 +1968,6 @@ describe("diagnostics-otel service", () => {
       level: "INFO",
       message: "model replied OTEL-QA-OK",
     });
-
-    expect(emitCall?.body).toBe("log");
-  });
-
-  test("keeps granular content capture from enabling OTLP log bodies", async () => {
-    const emitCall = await emitAndCaptureLog(
-      {
-        level: "INFO",
-        message: "model replied OTEL-QA-OK",
-      },
-      { captureContent: { enabled: true, inputMessages: true } },
-    );
 
     expect(emitCall?.body).toBe("log");
   });
@@ -4142,18 +4128,11 @@ describe("diagnostics-otel service", () => {
     expect(toolOptions?.startTime).toBeTypeOf("number");
   });
 
-  test("exports bounded redacted content when capture fields are opted in", async () => {
+  test("exports bounded redacted content when capture is enabled", async () => {
     await startOtelService({
       traces: true,
       metrics: true,
-      captureContent: {
-        enabled: true,
-        inputMessages: true,
-        outputMessages: true,
-        toolInputs: true,
-        toolOutputs: true,
-        systemPrompt: true,
-      },
+      captureContent: true,
     });
 
     emitTrustedModelCallCompletedWithContent(
@@ -4188,7 +4167,7 @@ describe("diagnostics-otel service", () => {
     const toolAttrs = startedSpanOptions("openclaw.tool.execution")?.attributes;
 
     expect(modelAttrs?.["openclaw.content.output_messages"]).toBe("model reply");
-    expect(modelAttrs?.["openclaw.content.system_prompt"]).toBe("system prompt");
+    expect(Object.hasOwn(modelAttrs ?? {}, "openclaw.content.system_prompt")).toBe(false);
     expect(String(modelAttrs?.["openclaw.content.input_messages"])).not.toContain(
       "sk-1234567890abcdef1234567890abcdef", // pragma: allowlist secret
     );
@@ -4208,10 +4187,10 @@ describe("diagnostics-otel service", () => {
     );
   });
 
-  test("omits absent model content fields when capture fields are opted in", async () => {
+  test("omits absent model content fields when capture is enabled", async () => {
     await startOtelService({
       traces: true,
-      captureContent: MODEL_CONTENT_CAPTURE,
+      captureContent: true,
     });
 
     emitTrustedModelCallCompletedWithContent(
@@ -4239,7 +4218,7 @@ describe("diagnostics-otel service", () => {
   test("exports Phoenix-readable GenAI prompt, output, and tool definition attributes", async () => {
     await startOtelService({
       traces: true,
-      captureContent: MODEL_CONTENT_CAPTURE,
+      captureContent: true,
     });
 
     emitTrustedModelCallCompletedWithContent(
@@ -4277,9 +4256,7 @@ describe("diagnostics-otel service", () => {
     await flushDiagnosticEvents();
 
     const attrs = startedSpanOptions("openclaw.model.call")?.attributes;
-    expect(attrs?.["gen_ai.system_instructions"]).toBe(
-      JSON.stringify([{ type: "text", content: "be exact" }]),
-    );
+    expect(Object.hasOwn(attrs ?? {}, "gen_ai.system_instructions")).toBe(false);
     expect(JSON.parse(stringAttribute(attrs, "gen_ai.input.messages"))).toEqual([
       { role: "user", parts: [{ type: "text", content: "what changed?" }] },
       {
@@ -4320,7 +4297,7 @@ describe("diagnostics-otel service", () => {
   test("exports Claude CLI turn content through the existing Phoenix GenAI keys", async () => {
     await startOtelService({
       traces: true,
-      captureContent: MODEL_CONTENT_CAPTURE,
+      captureContent: true,
     });
 
     emitTrustedModelCallCompletedWithContent(
@@ -4368,16 +4345,14 @@ describe("diagnostics-otel service", () => {
         finish_reason: "end_turn",
       },
     ]);
-    expect(JSON.parse(stringAttribute(attrs, "gen_ai.system_instructions"))).toEqual([
-      { type: "text", content: "OpenClaw appended instructions" },
-    ]);
+    expect(Object.hasOwn(attrs ?? {}, "gen_ai.system_instructions")).toBe(false);
     expect(Object.hasOwn(attrs ?? {}, "gen_ai.tool.definitions")).toBe(false);
   });
 
   test("emits semconv response text for tool response parts", async () => {
     await startOtelService({
       traces: true,
-      captureContent: INPUT_ONLY_CAPTURE,
+      captureContent: true,
     });
 
     emitTrustedModelCallCompletedWithContent(
@@ -4444,7 +4419,7 @@ describe("diagnostics-otel service", () => {
   test("flattens oversized pure-text tool results with a truncation marker", async () => {
     await startOtelService({
       traces: true,
-      captureContent: INPUT_ONLY_CAPTURE,
+      captureContent: true,
     });
 
     const textParts = Array.from({ length: 201 }, (_, index) => ({
@@ -4479,7 +4454,7 @@ describe("diagnostics-otel service", () => {
   test("normalizes snake_case tool_call parts the same as camelCase toolCall parts", async () => {
     await startOtelService({
       traces: true,
-      captureContent: INPUT_ONLY_CAPTURE,
+      captureContent: true,
     });
 
     emitTrustedModelCallCompletedWithContent(
@@ -4523,7 +4498,7 @@ describe("diagnostics-otel service", () => {
   test("truncates oversized GenAI input messages instead of silently dropping them", async () => {
     await startOtelService({
       traces: true,
-      captureContent: INPUT_ONLY_CAPTURE,
+      captureContent: true,
     });
 
     // Build messages that exceed MAX_OTEL_CONTENT_ATTRIBUTE_CHARS (128KB) in total.
@@ -4561,12 +4536,7 @@ describe("diagnostics-otel service", () => {
   test("keeps single oversized GenAI messages and tool definitions parseable", async () => {
     await startOtelService({
       traces: true,
-      captureContent: {
-        enabled: true,
-        inputMessages: true,
-        outputMessages: false,
-        toolDefinitions: true,
-      },
+      captureContent: true,
     });
 
     // The 8,192-character candidate budget leaves an 8,178-character text prefix;
@@ -4632,54 +4602,6 @@ describe("diagnostics-otel service", () => {
         type: "object",
       },
     });
-  });
-
-  test("exports tool definitions without requiring input message capture", async () => {
-    await startOtelService({
-      traces: true,
-      captureContent: {
-        enabled: true,
-        inputMessages: false,
-        toolDefinitions: true,
-      },
-    });
-
-    emitTrustedModelCallCompletedWithContent(
-      {
-        runId: "run-1",
-        callId: "call-1",
-        provider: "openai",
-        model: "gpt-5.4",
-        durationMs: 80,
-      },
-      {
-        inputMessages: [{ role: "user", content: "do not export this prompt" }],
-        toolDefinitions: [
-          { name: "lookup", description: "Lookup data", parameters: { type: "object" } },
-        ],
-      },
-    );
-    await flushDiagnosticEvents();
-
-    const attrs = startedSpanOptions("openclaw.model.call")?.attributes;
-    expect(Object.hasOwn(attrs ?? {}, "gen_ai.input.messages")).toBe(false);
-    expect(Object.hasOwn(attrs ?? {}, "input.value")).toBe(false);
-    expect(Object.hasOwn(attrs ?? {}, "openclaw.content.input_messages")).toBe(false);
-    expect(JSON.parse(stringAttribute(attrs, "gen_ai.tool.definitions"))).toEqual([
-      {
-        type: "function",
-        name: "lookup",
-        description: "Lookup data",
-        parameters: { type: "object" },
-      },
-    ]);
-    expect(JSON.parse(String(attrs?.["openclaw.content.tool_definitions"]))).toEqual([
-      {
-        name: "lookup",
-        description: "Lookup data",
-        parameters: { type: "object" },
-      },
-    ]);
   });
 
   test("ignores invalid diagnostic event trace parents", async () => {

--- a/src/agents/cache-trace.test.ts
+++ b/src/agents/cache-trace.test.ts
@@ -78,8 +78,6 @@ describe("createCacheTrace", () => {
         diagnostics: {
           cacheTrace: {
             enabled: true,
-            includePrompt: true,
-            includeSystem: true,
           },
         },
       },
@@ -118,7 +116,6 @@ describe("createCacheTrace", () => {
         diagnostics: {
           cacheTrace: {
             enabled: true,
-            includeSystem: true,
           },
         },
       },

--- a/src/config/config-misc.test.ts
+++ b/src/config/config-misc.test.ts
@@ -491,7 +491,7 @@ describe("diagnostics.otel.captureContent", () => {
     expect(invalid.success).toBe(false);
   });
 
-  it("accepts boolean and granular OTEL content capture config", () => {
+  it("accepts boolean OTEL content capture config", () => {
     for (const captureContent of [true, false]) {
       const result = OpenClawSchema.safeParse({
         diagnostics: {

--- a/src/config/types.base.ts
+++ b/src/config/types.base.ts
@@ -305,35 +305,13 @@ export type DiagnosticsOtelConfig = {
   sampleRate?: number;
   /** Metric export interval (ms). */
   flushIntervalMs?: number;
-  /**
-   * Opt-in raw content capture for OTEL span attributes.
-   * Boolean `true` captures non-system message/tool content; the object form
-   * can enable each content class explicitly.
-   */
-  captureContent?:
-    | boolean
-    | {
-        enabled?: boolean;
-        inputMessages?: boolean;
-        outputMessages?: boolean;
-        toolInputs?: boolean;
-        toolOutputs?: boolean;
-        systemPrompt?: boolean;
-        toolDefinitions?: boolean;
-      };
+  /** Opt in to raw non-system message/tool content in OTEL span attributes. */
+  captureContent?: boolean;
 };
 
 export type DiagnosticsCacheTraceConfig = {
   /** Write prompt-cache trace artifacts for debugging deterministic cache input. */
   enabled?: boolean;
-  /** @deprecated Doctor-only legacy input. */
-  filePath?: string;
-  /** @deprecated Doctor-only legacy input. */
-  includeMessages?: boolean;
-  /** @deprecated Doctor-only legacy input. */
-  includePrompt?: boolean;
-  /** @deprecated Doctor-only legacy input. */
-  includeSystem?: boolean;
 };
 
 export type AuditConfig = {


### PR DESCRIPTION
## What Problem This Solves

Resolves a maintenance problem where the public TypeScript config and diagnostics documentation still advertised retired granular OTEL content-capture and cache-trace fields even though the canonical schema accepts only the current boolean/enablement forms.

## Why This Change Was Made

This removes the obsolete type and runtime branches, keeps doctor as the sole migration owner for older config files, and updates the public docs and focused tests to describe only the canonical config. Runtime content capture now enables only on literal `true`, so malformed or unmigrated values cannot accidentally expose content.

Release-note context: diagnostics configuration docs now reflect the canonical boolean-only `diagnostics.otel.captureContent` and `diagnostics.cacheTrace.enabled` surfaces.

## User Impact

Operators see one accurate configuration shape. Existing retired shapes remain repairable through `openclaw doctor --fix`; steady-state runtime code no longer treats those shapes as supported configuration.

## Evidence

- `node scripts/run-vitest.mjs src/config/config-misc.test.ts src/commands/doctor/shared/legacy-config-migrate.e2e.test.ts extensions/diagnostics-otel/src/service.test.ts` — 91 config, 3 migration, and 109 plugin tests passed.
- `node scripts/run-vitest.mjs src/agents/cache-trace.test.ts src/config/config-misc.test.ts` — 10 cache-trace and 91 config tests passed.
- `node scripts/check-changed.mjs` — all selected core, extension, docs, typecheck, lint, boundary, and architecture lanes passed on Blacksmith Testbox (run 30181301645; `exitCode: 0`).
- Real upgrade proof on Blacksmith Testbox run 30182662018: an isolated released-style legacy config used granular `diagnostics.otel.captureContent` and retired cache-trace detail fields; `openclaw doctor --fix --non-interactive` reported both migrations, produced `{"enabled":true,"otel":{"enabled":true,"captureContent":false},"cacheTrace":{"enabled":true}}`, and `openclaw config validate --json` returned `{"valid":true,"warnings":[]}` (`exitCode: 0`). This applies ClawSweeper's requested rank-up move.
- `$HOME/.claude/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — clean on the patch; one later rebase-only run's claim that the schema still accepted granular objects was rejected by direct inspection of the existing `z.boolean().optional()` schema and boolean-only config test.
- `git diff --check origin/main...HEAD` — passed.

AI-assisted; implementation and findings were reviewed against the affected runtime, schema, migration, tests, and docs.
