### PR TITLE
fix(subagents): steer spawn labels toward task titles and persist them at run start

### DIFF
--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -192,7 +192,7 @@ Per-agent override: `agents.entries.*.subagents.delegationMode`.
   Optional stable handle for identifying a specific child in later status output. Must match `[a-z][a-z0-9_-]{0,63}` and cannot be a reserved target such as `last` or `all`.
 </ParamField>
 <ParamField path="label" type="string">
-  Optional human-readable label.
+  Optional short task title shown in UI lists (task ledger, session sidebar). Name the work being done, not the agent; it is set on the child session at run start.
 </ParamField>
 <ParamField path="agentId" type="string">
   Spawn under another configured agent id when allowed by `subagents.allowAgents`.

--- a/src/agents/subagent-announce.format.e2e.test.ts
+++ b/src/agents/subagent-announce.format.e2e.test.ts
@@ -388,9 +388,6 @@ describe("subagent announce formatting", () => {
       if (typed.method === "chat.history") {
         return await chatHistoryMock(typed.params?.sessionKey);
       }
-      if (typed.method === "sessions.patch") {
-        return {};
-      }
       if (typed.method === "sessions.delete") {
         sessionsDeleteSpy(typed);
         return {};
@@ -601,7 +598,7 @@ describe("subagent announce formatting", () => {
           ],
         };
       }
-      if (typed.method === "sessions.patch" || typed.method === "sessions.delete") {
+      if (typed.method === "sessions.delete") {
         return {};
       }
       return {};

--- a/src/agents/subagent-announce.test.ts
+++ b/src/agents/subagent-announce.test.ts
@@ -260,9 +260,6 @@ describe("subagent announce seam flow", () => {
       if (typed.method === "chat.history") {
         return { messages: [] as Array<unknown> };
       }
-      if (typed.method === "sessions.patch") {
-        return {};
-      }
       if (typed.method === "sessions.delete") {
         sessionsDeleteSpy(typed);
         return {};

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -610,18 +610,8 @@ export async function runSubagentAnnounceFlow(params: {
     defaultRuntime.error?.(`Subagent announce failed: ${String(err)}`);
     // Best-effort follow-ups; ignore failures to avoid breaking the caller response.
   } finally {
-    // Patch label after all writes complete
-    if (params.label) {
-      try {
-        await subagentAnnounceDeps.callGateway({
-          method: "sessions.patch",
-          params: { key: params.childSessionKey, label: params.label },
-          timeoutMs: 10_000,
-        });
-      } catch {
-        // Best-effort
-      }
-    }
+    // The spawn label is persisted at run start (agent request `label` →
+    // buildAgentSessionPatch), so no post-run label patch is needed here.
     if (shouldDeleteChildSession && (params.onBeforeDeleteChildSession?.() ?? true)) {
       await deleteSubagentSessionForCleanup({
         callGateway: subagentAnnounceDeps.callGateway,

--- a/src/agents/subagent-system-prompt.ts
+++ b/src/agents/subagent-system-prompt.ts
@@ -72,7 +72,7 @@ export function buildSubagentSystemPrompt(params: {
     lines.push(
       "## Sub-Agent Spawning",
       "May `sessions_spawn` for parallel/complex work. Decide local vs child ownership.",
-      "Brief child: objective, output, inputs/files, write scope, verification, blocking status; stable handle needs `taskName`.",
+      "Brief child: objective, output, inputs/files, write scope, verification, blocking status; stable handle needs `taskName`, UI title `label`.",
       "Results auto-announce to you, not main. Continue orchestration; synthesize all expected children before final.",
       "Push-based: never sessions_list/history, exec sleep, or poll loops. Need wait: `sessions_yield`; otherwise await runtime event.",
       "`subagents` only on-demand status/debug. Track expected session keys.",

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -1020,12 +1020,12 @@ describe("buildAgentSystemPrompt", () => {
     expect(messagingPrompt).not.toContain("subagents(action=list)");
 
     expect(spawnOnlyPrompt).toContain(
-      '- Subagents: `sessions_spawn` with objective/output/write-scope/verification; stable handle needs `taskName`; isolated omits `context`, transcript needs `context:"fork"`.',
+      '- Subagents: `sessions_spawn` with objective/output/write-scope/verification; stable handle needs `taskName`, UI title `label`; isolated omits `context`, transcript needs `context:"fork"`.',
     );
     expect(spawnOnlyPrompt).not.toContain("manage already-spawned children");
 
     expect(orchestrationPrompt).toContain(
-      '- Subagents: `sessions_spawn` with objective/output/write-scope/verification; stable handle needs `taskName`; isolated omits `context`, transcript needs `context:"fork"`; `subagents(action=list)` only status/debug.',
+      '- Subagents: `sessions_spawn` with objective/output/write-scope/verification; stable handle needs `taskName`, UI title `label`; isolated omits `context`, transcript needs `context:"fork"`; `subagents(action=list)` only status/debug.',
     );
     expect(orchestrationWaitPrompt).toContain("wait via `sessions_yield`");
   });

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -111,7 +111,7 @@ function buildSubagentDelegationPreferenceSection(params: {
     "- Otherwise use `sessions_spawn`; avoid expensive calls yourself.",
     "- Delegate inspection, shell/web/browser, long reads, debugging, coding, multi-step analysis, comparison, summarization, waits.",
     "- Brief each child: objective, output, inputs/files, write scope, verification, blocking status.",
-    '- Need stable handle: lowercase `taskName` (underscores/hyphens). Default isolated: omit `context`; transcript needed: `context:"fork"`.',
+    '- Need stable handle: lowercase `taskName` (underscores/hyphens); `label`: short task title for UI lists, not a persona. Default isolated: omit `context`; transcript needed: `context:"fork"`.',
     params.hasSessionsYield
       ? "- Need results before reply: `sessions_yield`; never poll."
       : "- Completion is push-based; never poll. Synthesize returned events for user.",
@@ -547,8 +547,8 @@ function buildMessagingSection(params: {
     : `- Completion event requesting update: rewrite in normal voice; send. Never forward raw metadata or default to ${SILENT_REPLY_TOKEN}.`;
   const subagentOrchestrationGuidance = hasSessionsSpawn
     ? hasSubagents
-      ? `- Subagents: \`sessions_spawn\` with objective/output/write-scope/verification; stable handle needs \`taskName\`; isolated omits \`context\`, transcript needs \`context:"fork"\`; ${hasSessionsYield ? "wait via `sessions_yield`; " : ""}\`subagents(action=list)\` only status/debug.`
-      : `- Subagents: \`sessions_spawn\` with objective/output/write-scope/verification; stable handle needs \`taskName\`; isolated omits \`context\`, transcript needs \`context:"fork"\`${hasSessionsYield ? "; wait via `sessions_yield`" : ""}.`
+      ? `- Subagents: \`sessions_spawn\` with objective/output/write-scope/verification; stable handle needs \`taskName\`, UI title \`label\`; isolated omits \`context\`, transcript needs \`context:"fork"\`; ${hasSessionsYield ? "wait via `sessions_yield`; " : ""}\`subagents(action=list)\` only status/debug.`
+      : `- Subagents: \`sessions_spawn\` with objective/output/write-scope/verification; stable handle needs \`taskName\`, UI title \`label\`; isolated omits \`context\`, transcript needs \`context:"fork"\`${hasSessionsYield ? "; wait via `sessions_yield`" : ""}.`
     : hasSubagents
       ? "- Subagents: `subagents(action=list)` only for status/debug visibility."
       : "";

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -140,7 +140,11 @@ function createSessionsSpawnToolSchema(params: {
           "Stable later-target alias; starts lowercase letter; then lowercase/digit/_/-.",
       }),
     ),
-    label: Type.Optional(Type.String()),
+    label: Type.Optional(
+      Type.String({
+        description: "Short task title shown in UI lists; name the work, not the agent.",
+      }),
+    ),
     runtime: optionalStringEnum(
       params.acpAvailable ? SESSIONS_SPAWN_RUNTIMES : (["subagent"] as const),
       { description: 'Runtime; visible=true requires "subagent".' },

--- a/src/gateway/server-methods/agent-session-patch.test.ts
+++ b/src/gateway/server-methods/agent-session-patch.test.ts
@@ -2,16 +2,18 @@ import { describe, expect, it } from "vitest";
 import { resolveSessionResetPolicy, type SessionEntry } from "../../config/sessions.js";
 import { buildAgentSessionPatch } from "./agent-session-patch.js";
 
-function buildPatch(touchInteraction: boolean) {
+function buildPatch(touchInteraction: boolean, opts?: { requestLabel?: string; label?: string }) {
   const now = 1_000;
   const entry: SessionEntry = {
     sessionId: "session",
     updatedAt: now,
     agentStatus: { note: "Need a password", attention: "key", expiresAt: now + 60_000 },
+    ...(opts?.label ? { label: opts.label } : {}),
   };
   return buildAgentSessionPatch({
     freshEntry: entry,
     initialEntry: entry,
+    ...(opts?.requestLabel ? { requestLabel: opts.requestLabel } : {}),
     cfg: {},
     sessionAgentId: "main",
     canonicalSessionKey: "agent:main:main",
@@ -39,5 +41,17 @@ describe("agent session patch", () => {
 
   it("does not clear agent status for lifecycle-only patches", () => {
     expect(Object.hasOwn(buildPatch(false), "agentStatus")).toBe(false);
+  });
+
+  // Subagent spawn labels rely on run-start persistence; there is no post-run
+  // label patch anymore (see subagent-announce.ts).
+  it("persists the request label at run start", () => {
+    expect(buildPatch(false, { requestLabel: "Fix flaky auth test" }).label).toBe(
+      "Fix flaky auth test",
+    );
+  });
+
+  it("keeps the existing label when the request has none", () => {
+    expect(buildPatch(false, { label: "Existing" }).label).toBe("Existing");
   });
 });

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
@@ -191,6 +191,7 @@
           "type": "string"
         },
         "label": {
+          "description": "Short task title shown in UI lists; name the work, not the agent.",
           "type": "string"
         },
         "lightContext": {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
@@ -191,6 +191,7 @@
           "type": "string"
         },
         "label": {
+          "description": "Short task title shown in UI lists; name the work, not the agent.",
           "type": "string"
         },
         "lightContext": {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
@@ -191,6 +191,7 @@
           "type": "string"
         },
         "label": {
+          "description": "Short task title shown in UI lists; name the work, not the agent.",
           "type": "string"
         },
         "lightContext": {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
@@ -221,8 +221,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 59204,
-    "roughTokens": 14801
+    "chars": 59298,
+    "roughTokens": 14825
   },
   "openClawDeveloperInstructions": {
     "chars": 3715,
@@ -233,8 +233,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 7045
   },
   "totalWithDynamicToolsJson": {
-    "chars": 87384,
-    "roughTokens": 21846
+    "chars": 87478,
+    "roughTokens": 21870
   },
   "userInputText": {
     "chars": 1380,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -221,8 +221,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 58896,
-    "roughTokens": 14724
+    "chars": 58990,
+    "roughTokens": 14748
   },
   "openClawDeveloperInstructions": {
     "chars": 2606,
@@ -233,8 +233,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6672
   },
   "totalWithDynamicToolsJson": {
-    "chars": 85586,
-    "roughTokens": 21397
+    "chars": 85680,
+    "roughTokens": 21420
   },
   "userInputText": {
     "chars": 999,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
@@ -222,8 +222,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 60458,
-    "roughTokens": 15115
+    "chars": 60552,
+    "roughTokens": 15138
   },
   "openClawDeveloperInstructions": {
     "chars": 2625,
@@ -234,8 +234,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6784
   },
   "totalWithDynamicToolsJson": {
-    "chars": 87596,
-    "roughTokens": 21899
+    "chars": 87690,
+    "roughTokens": 21923
   },
   "userInputText": {
     "chars": 1354,


### PR DESCRIPTION
## What Problem This Solves

The `sessions_spawn` `label` parameter had no schema description and no system-prompt guidance, so models had no signal that the label is a task title for UI lists (task ledger, session sidebar) rather than an agent persona name. Separately, `subagent-announce.ts` still carried a legacy post-run `sessions.patch` that re-wrote the child session label after the run completed, even though the label has been persisted at run start via the agent request (`agent-run-handler` -> `buildAgentSessionPatch`).

## Why This Change Was Made

- Give the model explicit, cheap guidance that `label` names the work, not the agent: schema description on `label`, one clause in the parent orchestration guidance (both compact variants), and one clause in the child spawn briefing.
- Delete the redundant post-run label patch. Run-start persistence is the canonical path; the announce-time patch was dead weight and implied the label only became visible after completion.
- Align `docs/tools/subagents.md` wording with the schema.

Note on the "serialized state" flag from review tooling: the `sessions-spawn-tool.ts` change is a model-facing tool schema description only — no stored data shape changes, so no migration applies.

## User Impact

Models briefed by the updated prompts produce task-shaped labels, so the Control UI task list and session sidebar read as work items instead of unnamed or persona-named children. No behavior change for when the label becomes visible: it was already set on the child session at run start (proof below).

## Evidence

**Live after-fix behavior proof (real setup):** scratch gateway from this branch (isolated `OPENCLAW_STATE_DIR`, loopback bind, token auth, Anthropic API-key auth profile via `openclaw onboard --non-interactive`), real Control UI session. Sent one chat message asking the agent to `sessions_spawn` with `label` + `taskName`; the model-supplied label is visible in both UI surfaces **while the child run is in flight** — with the post-run `sessions.patch` fallback deleted by this PR:

Session sidebar, child thread named by the spawn label immediately after the spawn tool call (parent turn still streaming):

![sidebar label live](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/pr-113950/sidebar-label-live.png)

Task ledger (`/tasks`), Active section: `Count to 2000 marathon` with a **Running** chip, runtime Subagent — title is the spawn `label` served by `tasks.list` (`formatTaskStatusTitle`, run-start ledger record):

![task ledger running](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/pr-113950/tasks-ledger-running.png)

**Why deleting the completion-time patch is safe for every spawn path:** the removed `sessions.patch` lived in `runSubagentAnnounceFlow`, which only runs for native subagent registry completions; those runs are always launched through the gateway `agent` request built in `subagent-spawn.ts` with `label` in the request (`AgentParamsSchema.label`), persisted at run start by `agent-run-handler` -> `buildAgentSessionPatch`. ACP spawns (`acp-spawn.ts`) and visible spawns (`sessions-spawn-visible.ts`) set the session-entry label at session creation and never used the announce flow for labels.

- New regression tests in `src/gateway/server-methods/agent-session-patch.test.ts` prove `requestLabel` is persisted at run start and an existing label survives label-less requests.
- Focused runs green locally: `system-prompt.test.ts` (4), `agent-session-patch.test.ts` (14 incl. 2 new), `subagent-announce.test.ts` (83), `subagent-announce.format.e2e.test.ts` + `prompt-snapshots.test.ts` (79).
- `node scripts/check-changed.mjs` delegated to Blacksmith Testbox `tbx_01kydxr2t5867qk9aabg8nreka`, exit 0 (https://github.com/openclaw/openclaw/actions/runs/30181508000).
- Prompt snapshots regenerated with `pnpm prompt:snapshots:gen` (7 files; deltas are the new label description and guidance clauses plus size counters).
- Codex autoreview (`gpt-5.6-sol`, xhigh): clean, no accepted findings.
