### PR TITLE
refactor(ui): inline stroke attributes via shared strokeIcon shell

### DIFF
--- a/ui/src/components/icons-tools.ts
+++ b/ui/src/components/icons-tools.ts
@@ -1,255 +1,151 @@
 // Control UI tool icon set, split from icons.ts to keep both under the max-lines cap.
-import { html } from "lit";
+import { html, svg, type SVGTemplateResult, type TemplateResult } from "lit";
+
+// Shared Lucide icon shell. Inline presentation attributes keep icons visible
+// inside shadow roots that global stylesheet icon rules cannot reach; CSS
+// rules still override them where a surface wants a different stroke width.
+// Bodies must be svg`` fragments: html`` would parse the shapes outside the
+// SVG namespace and they would silently render as nothing.
+export function strokeIcon(body: SVGTemplateResult): TemplateResult {
+  return html`
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      ${body}
+    </svg>
+  `;
+}
 
 export const toolIcons = {
-  wrench: html`
-    <svg viewBox="0 0 24 24">
-      <path
-        d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"
-      />
-    </svg>
-  `,
-  fileCode: html`
-    <svg viewBox="0 0 24 24">
-      <path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z" />
-      <polyline points="14 2 14 8 20 8" />
-      <path d="m10 13-2 2 2 2" />
-      <path d="m14 17 2-2-2-2" />
-    </svg>
-  `,
-  edit: html`
-    <svg viewBox="0 0 24 24">
-      <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
-      <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
-    </svg>
-  `,
-  home: html`
-    <svg viewBox="0 0 24 24">
-      <path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
-      <polyline points="9 22 9 12 15 12 15 22" />
-    </svg>
-  `,
-  penLine: html`
-    <svg viewBox="0 0 24 24">
-      <path d="M12 20h9" />
-      <path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z" />
-    </svg>
-  `,
-  paperclip: html`
-    <svg viewBox="0 0 24 24">
-      <path
-        d="m21.44 11.05-9.19 9.19a6 6 0 0 1-8.49-8.49l8.57-8.57A4 4 0 1 1 18 8.84l-8.59 8.57a2 2 0 0 1-2.83-2.83l8.49-8.48"
-      />
-    </svg>
-  `,
-  globe: html`
-    <svg viewBox="0 0 24 24">
-      <circle cx="12" cy="12" r="10" />
-      <path d="M12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 0-20" />
-      <path d="M2 12h20" />
-    </svg>
-  `,
-  image: html`
-    <svg viewBox="0 0 24 24">
-      <rect width="18" height="18" x="3" y="3" rx="2" ry="2" />
-      <circle cx="9" cy="9" r="2" />
-      <path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21" />
-    </svg>
-  `,
-  camera: html`
-    <svg viewBox="0 0 24 24">
-      <path
-        d="M14.5 4 16 7h3a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V9a2 2 0 0 1 2-2h3l1.5-3z"
-      />
-      <circle cx="12" cy="13" r="3" />
-    </svg>
-  `,
-  cameraOff: html`
-    <svg viewBox="0 0 24 24">
-      <path d="M14.564 14.558a3 3 0 1 1-4.122-4.121" />
-      <path d="m2 2 20 20" />
-      <path d="M20 20H4a2 2 0 0 1-2-2V9a2 2 0 0 1 2-2h1.997a2 2 0 0 0 .819-.175" />
-      <path
-        d="M9.695 4.024A2 2 0 0 1 10.004 4h3.993a2 2 0 0 1 1.76 1.05l.486.9A2 2 0 0 0 18.003 7H20a2 2 0 0 1 2 2v7.344"
-      />
-    </svg>
-  `,
-  smartphone: html`
-    <svg viewBox="0 0 24 24">
-      <rect width="14" height="20" x="5" y="2" rx="2" ry="2" />
-      <path d="M12 18h.01" />
-    </svg>
-  `,
-  circleQuestionMark: html`
-    <svg viewBox="0 0 24 24">
-      <circle cx="12" cy="12" r="10" />
-      <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3" />
-      <path d="M12 17h.01" />
-    </svg>
-  `,
-  plug: html`
-    <svg viewBox="0 0 24 24">
-      <path d="M12 22v-5" />
-      <path d="M9 8V2" />
-      <path d="M15 8V2" />
-      <path d="M18 8v5a4 4 0 0 1-4 4h-4a4 4 0 0 1-4-4V8Z" />
-    </svg>
-  `,
-  circle: html` <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="10" /></svg> `,
-  puzzle: html`
-    <svg viewBox="0 0 24 24">
-      <path
-        d="M19.439 7.85c-.049.322.059.648.289.878l1.568 1.568c.47.47.706 1.087.706 1.704s-.235 1.233-.706 1.704l-1.611 1.611a.98.98 0 0 1-.837.276c-.47-.07-.802-.48-.968-.925a2.501 2.501 0 1 0-3.214 3.214c.446.166.855.497.925.968a.979.979 0 0 1-.276.837l-1.61 1.61a2.404 2.404 0 0 1-1.705.707 2.402 2.402 0 0 1-1.704-.706l-1.568-1.568a1.026 1.026 0 0 0-.877-.29c-.493.074-.84.504-1.02.968a2.5 2.5 0 1 1-3.237-3.237c.464-.18.894-.527.967-1.02a1.026 1.026 0 0 0-.289-.877l-1.568-1.568A2.402 2.402 0 0 1 1.998 12c0-.617.236-1.234.706-1.704L4.23 8.77c.24-.24.581-.353.917-.303.515.076.874.54 1.02 1.02a2.5 2.5 0 1 0 3.237-3.237c-.48-.146-.944-.505-1.02-1.02a.98.98 0 0 1 .303-.917l1.526-1.526A2.402 2.402 0 0 1 11.998 2c.617 0 1.234.236 1.704.706l1.568 1.568c.23.23.556.338.877.29.493-.074.84-.504 1.02-.968a2.5 2.5 0 1 1 3.236 3.236c-.464.18-.894.527-.967 1.02Z"
-      />
-    </svg>
-  `,
-  panelLeft: html`
-    <svg viewBox="0 0 24 24">
-      <rect x="3" y="3" width="18" height="18" rx="2" />
-      <path d="M9 3v18" stroke-linecap="round" />
-    </svg>
-  `,
-  panelLeftClose: html`
-    <svg viewBox="0 0 24 24">
-      <rect x="3" y="3" width="18" height="18" rx="2" />
-      <path d="M9 3v18" stroke-linecap="round" />
-      <path d="M16 10l-3 2 3 2" stroke-linecap="round" stroke-linejoin="round" />
-    </svg>
-  `,
-  panelLeftOpen: html`
-    <svg viewBox="0 0 24 24">
-      <rect x="3" y="3" width="18" height="18" rx="2" />
-      <path d="M9 3v18" stroke-linecap="round" />
-      <path d="M14 10l3 2-3 2" stroke-linecap="round" stroke-linejoin="round" />
-    </svg>
-  `,
-  chevronDown: html`
-    <svg viewBox="0 0 24 24">
-      <path d="M6 9l6 6 6-6" stroke-linecap="round" stroke-linejoin="round" />
-    </svg>
-  `,
-  chevronRight: html`
-    <svg viewBox="0 0 24 24">
-      <path d="M9 18l6-6-6-6" stroke-linecap="round" stroke-linejoin="round" />
-    </svg>
-  `,
-  chevronLeft: html`
-    <svg viewBox="0 0 24 24">
-      <path d="M15 18l-6-6 6-6" stroke-linecap="round" stroke-linejoin="round" />
-    </svg>
-  `,
-  externalLink: html`
-    <svg viewBox="0 0 24 24">
-      <path
-        d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6"
-        stroke-linecap="round"
-        stroke-linejoin="round"
-      />
-      <path d="M15 3h6v6M10 14L21 3" stroke-linecap="round" stroke-linejoin="round" />
-    </svg>
-  `,
-  send: html`
-    <svg viewBox="0 0 24 24">
-      <path d="m22 2-7 20-4-9-9-4Z" />
-      <path d="M22 2 11 13" />
-    </svg>
-  `,
-  stop: html` <svg viewBox="0 0 24 24"><rect width="14" height="14" x="5" y="5" rx="1" /></svg> `,
-  pin: html`
-    <svg viewBox="0 0 24 24">
-      <line x1="12" x2="12" y1="17" y2="22" />
-      <path
-        d="M5 17h14v-1.76a2 2 0 0 0-1.11-1.79l-1.78-.9A2 2 0 0 1 15 10.76V6h1a2 2 0 0 0 0-4H8a2 2 0 0 0 0 4h1v4.76a2 2 0 0 1-1.11 1.79l-1.78.9A2 2 0 0 0 5 15.24Z"
-      />
-    </svg>
-  `,
-  pinOff: html`
-    <svg viewBox="0 0 24 24">
-      <line x1="2" x2="22" y1="2" y2="22" />
-      <line x1="12" x2="12" y1="17" y2="22" />
-      <path
-        d="M9 9v1.76a2 2 0 0 1-1.11 1.79l-1.78.9A2 2 0 0 0 5 15.24V17h14v-1.76a2 2 0 0 0-1.11-1.79l-1.78-.9A2 2 0 0 1 15 10.76V6h1a2 2 0 0 0 0-4H8a2 2 0 0 0-.39.04"
-      />
-    </svg>
-  `,
-  download: html`
-    <svg viewBox="0 0 24 24">
-      <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
-      <polyline points="7 10 12 15 17 10" />
-      <line x1="12" x2="12" y1="15" y2="3" />
-    </svg>
-  `,
-  mic: html`
-    <svg viewBox="0 0 24 24">
-      <path d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3Z" />
-      <path d="M19 10v2a7 7 0 0 1-14 0v-2" />
-      <line x1="12" x2="12" y1="19" y2="22" />
-    </svg>
-  `,
-  volume2: html`
-    <svg viewBox="0 0 24 24">
-      <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5" />
-      <path d="M15.54 8.46a5 5 0 0 1 0 7.07" />
-      <path d="M19.07 4.93a10 10 0 0 1 0 14.14" />
-    </svg>
-  `,
-  bookmark: html`
-    <svg viewBox="0 0 24 24"><path d="m19 21-7-4-7 4V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2v16z" /></svg>
-  `,
-  plus: html`
-    <svg viewBox="0 0 24 24">
-      <path d="M5 12h14" />
-      <path d="M12 5v14" />
-    </svg>
-  `,
-  gitBranch: html`
-    <svg viewBox="0 0 24 24">
-      <circle cx="6" cy="5" r="2" />
-      <circle cx="18" cy="6" r="2" />
-      <circle cx="6" cy="19" r="2" />
-      <path d="M6 7v10" />
-      <path d="M8 9h5a5 5 0 0 0 5-5" />
-    </svg>
-  `,
-  gitPullRequest: html`
-    <svg viewBox="0 0 24 24">
-      <circle cx="6" cy="6" r="3" />
-      <circle cx="18" cy="18" r="3" />
-      <path d="M13 6h3a2 2 0 0 1 2 2v7" />
-      <path d="M6 9v12" />
-    </svg>
-  `,
-  gitMerge: html`
-    <svg viewBox="0 0 24 24">
-      <circle cx="6" cy="6" r="3" />
-      <circle cx="18" cy="18" r="3" />
-      <path d="M6 21V9a9 9 0 0 0 9 9" />
-    </svg>
-  `,
-  terminal: html`
-    <svg viewBox="0 0 24 24">
-      <polyline points="4 17 10 11 4 5" />
-      <line x1="12" x2="20" y1="19" y2="19" />
-    </svg>
-  `,
-  claw: html`
-    <svg viewBox="0 0 24 24">
-      <path
-        d="M9.6 9.2 A5.6 5.6 0 1 0 9.6 20.4 A5.6 5.6 0 0 0 9.6 9.2 Z M10 20 C14 20.9 17.9 19.5 20.1 16.1 C20.6 15.4 20.05 14.5 19.25 14.65 C17.1 15 14.9 14.4 13.2 13 L10.6 16 Z"
-      />
-      <path
-        class="claw-icon__jaw"
-        d="M6 10.6 C6.6 4.4 12.4 0.8 17.6 2.8 C20.8 4 22.8 6.8 23 9.8 C23.07 10.9 21.9 11.4 21.1 10.7 C19.4 9.2 16.9 8.7 14.7 9.5 C13.4 10 12.3 10.9 11.6 12.1 L7.2 12.4 Z"
-      />
-    </svg>
-  `,
-  spark: html`
-    <svg viewBox="0 0 24 24">
-      <path
-        d="M9.937 15.5A2 2 0 0 0 8.5 14.063l-6.135-1.582a.5.5 0 0 1 0-.962L8.5 9.936A2 2 0 0 0 9.937 8.5l1.582-6.135a.5.5 0 0 1 .963 0L14.063 8.5A2 2 0 0 0 15.5 9.937l6.135 1.581a.5.5 0 0 1 0 .964L15.5 14.063a2 2 0 0 0-1.437 1.437l-1.582 6.135a.5.5 0 0 1-.963 0z"
-      />
-    </svg>
-  `,
+  wrench: strokeIcon(svg` <path
+    d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"
+  />`),
+  fileCode: strokeIcon(svg` <path
+      d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z"
+    />
+    <polyline points="14 2 14 8 20 8" />
+    <path d="m10 13-2 2 2 2" />
+    <path d="m14 17 2-2-2-2" />`),
+  edit: strokeIcon(svg` <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
+    <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />`),
+  home: strokeIcon(svg` <path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
+    <polyline points="9 22 9 12 15 12 15 22" />`),
+  penLine: strokeIcon(svg` <path d="M12 20h9" />
+    <path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z" />`),
+  paperclip: strokeIcon(svg` <path
+    d="m21.44 11.05-9.19 9.19a6 6 0 0 1-8.49-8.49l8.57-8.57A4 4 0 1 1 18 8.84l-8.59 8.57a2 2 0 0 1-2.83-2.83l8.49-8.48"
+  />`),
+  globe: strokeIcon(svg` <circle cx="12" cy="12" r="10" />
+    <path d="M12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 0-20" />
+    <path d="M2 12h20" />`),
+  image: strokeIcon(svg` <rect width="18" height="18" x="3" y="3" rx="2" ry="2" />
+    <circle cx="9" cy="9" r="2" />
+    <path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21" />`),
+  camera: strokeIcon(svg` <path
+      d="M14.5 4 16 7h3a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V9a2 2 0 0 1 2-2h3l1.5-3z"
+    />
+    <circle cx="12" cy="13" r="3" />`),
+  cameraOff: strokeIcon(svg` <path d="M14.564 14.558a3 3 0 1 1-4.122-4.121" />
+    <path d="m2 2 20 20" />
+    <path d="M20 20H4a2 2 0 0 1-2-2V9a2 2 0 0 1 2-2h1.997a2 2 0 0 0 .819-.175" />
+    <path
+      d="M9.695 4.024A2 2 0 0 1 10.004 4h3.993a2 2 0 0 1 1.76 1.05l.486.9A2 2 0 0 0 18.003 7H20a2 2 0 0 1 2 2v7.344"
+    />`),
+  smartphone: strokeIcon(svg` <rect width="14" height="20" x="5" y="2" rx="2" ry="2" />
+    <path d="M12 18h.01" />`),
+  circleQuestionMark: strokeIcon(svg` <circle cx="12" cy="12" r="10" />
+    <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3" />
+    <path d="M12 17h.01" />`),
+  plug: strokeIcon(svg` <path d="M12 22v-5" />
+    <path d="M9 8V2" />
+    <path d="M15 8V2" />
+    <path d="M18 8v5a4 4 0 0 1-4 4h-4a4 4 0 0 1-4-4V8Z" />`),
+  circle: strokeIcon(svg`<circle cx="12" cy="12" r="10" />`),
+  puzzle: strokeIcon(svg` <path
+    d="M19.439 7.85c-.049.322.059.648.289.878l1.568 1.568c.47.47.706 1.087.706 1.704s-.235 1.233-.706 1.704l-1.611 1.611a.98.98 0 0 1-.837.276c-.47-.07-.802-.48-.968-.925a2.501 2.501 0 1 0-3.214 3.214c.446.166.855.497.925.968a.979.979 0 0 1-.276.837l-1.61 1.61a2.404 2.404 0 0 1-1.705.707 2.402 2.402 0 0 1-1.704-.706l-1.568-1.568a1.026 1.026 0 0 0-.877-.29c-.493.074-.84.504-1.02.968a2.5 2.5 0 1 1-3.237-3.237c.464-.18.894-.527.967-1.02a1.026 1.026 0 0 0-.289-.877l-1.568-1.568A2.402 2.402 0 0 1 1.998 12c0-.617.236-1.234.706-1.704L4.23 8.77c.24-.24.581-.353.917-.303.515.076.874.54 1.02 1.02a2.5 2.5 0 1 0 3.237-3.237c-.48-.146-.944-.505-1.02-1.02a.98.98 0 0 1 .303-.917l1.526-1.526A2.402 2.402 0 0 1 11.998 2c.617 0 1.234.236 1.704.706l1.568 1.568c.23.23.556.338.877.29.493-.074.84-.504 1.02-.968a2.5 2.5 0 1 1 3.236 3.236c-.464.18-.894.527-.967 1.02Z"
+  />`),
+  panelLeft: strokeIcon(svg` <rect x="3" y="3" width="18" height="18" rx="2" />
+    <path d="M9 3v18" stroke-linecap="round" />`),
+  panelLeftClose: strokeIcon(svg` <rect x="3" y="3" width="18" height="18" rx="2" />
+    <path d="M9 3v18" stroke-linecap="round" />
+    <path d="M16 10l-3 2 3 2" stroke-linecap="round" stroke-linejoin="round" />`),
+  panelLeftOpen: strokeIcon(svg` <rect x="3" y="3" width="18" height="18" rx="2" />
+    <path d="M9 3v18" stroke-linecap="round" />
+    <path d="M14 10l3 2-3 2" stroke-linecap="round" stroke-linejoin="round" />`),
+  chevronDown: strokeIcon(svg` <path
+    d="M6 9l6 6 6-6"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />`),
+  chevronRight: strokeIcon(svg` <path
+    d="M9 18l6-6-6-6"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />`),
+  chevronLeft: strokeIcon(svg` <path
+    d="M15 18l-6-6 6-6"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />`),
+  externalLink: strokeIcon(svg` <path
+      d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+    <path d="M15 3h6v6M10 14L21 3" stroke-linecap="round" stroke-linejoin="round" />`),
+  send: strokeIcon(svg` <path d="m22 2-7 20-4-9-9-4Z" />
+    <path d="M22 2 11 13" />`),
+  stop: strokeIcon(svg`<rect width="14" height="14" x="5" y="5" rx="1" />`),
+  pin: strokeIcon(svg` <line x1="12" x2="12" y1="17" y2="22" />
+    <path
+      d="M5 17h14v-1.76a2 2 0 0 0-1.11-1.79l-1.78-.9A2 2 0 0 1 15 10.76V6h1a2 2 0 0 0 0-4H8a2 2 0 0 0 0 4h1v4.76a2 2 0 0 1-1.11 1.79l-1.78.9A2 2 0 0 0 5 15.24Z"
+    />`),
+  pinOff: strokeIcon(svg` <line x1="2" x2="22" y1="2" y2="22" />
+    <line x1="12" x2="12" y1="17" y2="22" />
+    <path
+      d="M9 9v1.76a2 2 0 0 1-1.11 1.79l-1.78.9A2 2 0 0 0 5 15.24V17h14v-1.76a2 2 0 0 0-1.11-1.79l-1.78-.9A2 2 0 0 1 15 10.76V6h1a2 2 0 0 0 0-4H8a2 2 0 0 0-.39.04"
+    />`),
+  download: strokeIcon(svg` <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+    <polyline points="7 10 12 15 17 10" />
+    <line x1="12" x2="12" y1="15" y2="3" />`),
+  mic: strokeIcon(svg` <path d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3Z" />
+    <path d="M19 10v2a7 7 0 0 1-14 0v-2" />
+    <line x1="12" x2="12" y1="19" y2="22" />`),
+  volume2: strokeIcon(svg` <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5" />
+    <path d="M15.54 8.46a5 5 0 0 1 0 7.07" />
+    <path d="M19.07 4.93a10 10 0 0 1 0 14.14" />`),
+  bookmark: strokeIcon(svg`<path d="m19 21-7-4-7 4V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2v16z" />`),
+  plus: strokeIcon(svg` <path d="M5 12h14" />
+    <path d="M12 5v14" />`),
+  gitBranch: strokeIcon(svg` <circle cx="6" cy="5" r="2" />
+    <circle cx="18" cy="6" r="2" />
+    <circle cx="6" cy="19" r="2" />
+    <path d="M6 7v10" />
+    <path d="M8 9h5a5 5 0 0 0 5-5" />`),
+  gitPullRequest: strokeIcon(svg` <circle cx="6" cy="6" r="3" />
+    <circle cx="18" cy="18" r="3" />
+    <path d="M13 6h3a2 2 0 0 1 2 2v7" />
+    <path d="M6 9v12" />`),
+  gitMerge: strokeIcon(svg` <circle cx="6" cy="6" r="3" />
+    <circle cx="18" cy="18" r="3" />
+    <path d="M6 21V9a9 9 0 0 0 9 9" />`),
+  terminal: strokeIcon(svg` <polyline points="4 17 10 11 4 5" />
+    <line x1="12" x2="20" y1="19" y2="19" />`),
+  claw: strokeIcon(svg` <path
+      d="M9.6 9.2 A5.6 5.6 0 1 0 9.6 20.4 A5.6 5.6 0 0 0 9.6 9.2 Z M10 20 C14 20.9 17.9 19.5 20.1 16.1 C20.6 15.4 20.05 14.5 19.25 14.65 C17.1 15 14.9 14.4 13.2 13 L10.6 16 Z"
+    />
+    <path
+      class="claw-icon__jaw"
+      d="M6 10.6 C6.6 4.4 12.4 0.8 17.6 2.8 C20.8 4 22.8 6.8 23 9.8 C23.07 10.9 21.9 11.4 21.1 10.7 C19.4 9.2 16.9 8.7 14.7 9.5 C13.4 10 12.3 10.9 11.6 12.1 L7.2 12.4 Z"
+    />`),
+  spark: strokeIcon(svg` <path
+    d="M9.937 15.5A2 2 0 0 0 8.5 14.063l-6.135-1.582a.5.5 0 0 1 0-.962L8.5 9.936A2 2 0 0 0 9.937 8.5l1.582-6.135a.5.5 0 0 1 .963 0L14.063 8.5A2 2 0 0 0 15.5 9.937l6.135 1.581a.5.5 0 0 1 0 .964L15.5 14.063a2 2 0 0 0-1.437 1.437l-1.582 6.135a.5.5 0 0 1-.963 0z"
+  />`),
   lobster: html`
     <svg viewBox="0 0 120 120" fill="none">
       <defs>
@@ -275,147 +171,75 @@ export const toolIcons = {
       <circle cx="76" cy="34" r="2.5" fill="#00e5cc" />
     </svg>
   `,
-  circleUser: html`
-    <svg viewBox="0 0 24 24">
-      <path d="M18 20a6 6 0 0 0-12 0" />
-      <circle cx="12" cy="10" r="4" />
-      <circle cx="12" cy="12" r="10" />
-    </svg>
-  `,
-  bell: html`
-    <svg viewBox="0 0 24 24">
-      <path d="M10.268 21a2 2 0 0 0 3.464 0" />
-      <path
-        d="M3.262 15.326A1 1 0 0 0 4 17h16a1 1 0 0 0 .74-1.673C19.41 13.956 18 12.499 18 8A6 6 0 0 0 6 8c0 4.499-1.411 5.956-2.738 7.326"
-      />
-    </svg>
-  `,
-  palette: html`
-    <svg viewBox="0 0 24 24">
-      <path
-        d="M12 22a1 1 0 0 1 0-20 10 9 0 0 1 10 9 5 5 0 0 1-5 5h-2.25a1.75 1.75 0 0 0-1.4 2.8l.3.4a1.75 1.75 0 0 1-1.4 2.8z"
-      />
-      <circle cx="13.5" cy="6.5" r=".5" fill="currentColor" />
-      <circle cx="17.5" cy="10.5" r=".5" fill="currentColor" />
-      <circle cx="6.5" cy="12.5" r=".5" fill="currentColor" />
-      <circle cx="8.5" cy="7.5" r=".5" fill="currentColor" />
-    </svg>
-  `,
-  flaskConical: html`
-    <svg viewBox="0 0 24 24">
-      <path
-        d="M14 2v6a2 2 0 0 0 .245.96l5.51 10.08A2 2 0 0 1 18 22H6a2 2 0 0 1-1.755-2.96l5.51-10.08A2 2 0 0 0 10 8V2"
-      />
-      <path d="M6.453 15h11.094" />
-      <path d="M8.5 2h7" />
-    </svg>
-  `,
-  badgeCheck: html`
-    <svg viewBox="0 0 24 24">
-      <path
-        d="M3.85 8.62a4 4 0 0 1 4.78-4.77 4 4 0 0 1 6.74 0 4 4 0 0 1 4.78 4.78 4 4 0 0 1 0 6.74 4 4 0 0 1-4.77 4.78 4 4 0 0 1-6.75 0 4 4 0 0 1-4.78-4.77 4 4 0 0 1 0-6.76Z"
-      />
-      <path d="m9 12 2 2 4-4" />
-    </svg>
-  `,
-  refresh: html`
-    <svg viewBox="0 0 24 24">
-      <path d="M21 12a9 9 0 1 1-9-9c2.52 0 4.93 1 6.74 2.74L21 8" />
-      <path d="M21 3v5h-5" />
-    </svg>
-  `,
-  trash: html`
-    <svg viewBox="0 0 24 24">
-      <path d="M3 6h18" />
-      <path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6" />
-      <path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2" />
-      <line x1="10" x2="10" y1="11" y2="17" />
-      <line x1="14" x2="14" y1="11" y2="17" />
-    </svg>
-  `,
-  eye: html`
-    <svg viewBox="0 0 24 24">
-      <path
-        d="M2.062 12.348a1 1 0 0 1 0-.696 10.75 10.75 0 0 1 19.876 0 1 1 0 0 1 0 .696 10.75 10.75 0 0 1-19.876 0"
-      />
-      <circle cx="12" cy="12" r="3" />
-    </svg>
-  `,
-  eyeOff: html`
-    <svg viewBox="0 0 24 24">
-      <path
-        d="M10.733 5.076a10.744 10.744 0 0 1 11.205 6.575 1 1 0 0 1 0 .696 10.747 10.747 0 0 1-1.444 2.49"
-      />
-      <path d="M14.084 14.158a3 3 0 0 1-4.242-4.242" />
-      <path
-        d="M17.479 17.499a10.75 10.75 0 0 1-15.417-5.151 1 1 0 0 1 0-.696 10.75 10.75 0 0 1 4.446-5.143"
-      />
-      <path d="m2 2 20 20" />
-    </svg>
-  `,
-  moreHorizontal: html`
-    <svg viewBox="0 0 24 24">
-      <circle cx="12" cy="12" r="1.5" />
-      <circle cx="6" cy="12" r="1.5" />
-      <circle cx="18" cy="12" r="1.5" />
-    </svg>
-  `,
-  arrowUpDown: html`
-    <svg viewBox="0 0 24 24">
-      <path d="m21 16-4 4-4-4" />
-      <path d="M17 20V4" />
-      <path d="m3 8 4-4 4 4" />
-      <path d="M7 4v16" />
-    </svg>
-  `,
-  panelRightOpen: html`
-    <svg viewBox="0 0 24 24">
-      <rect x="3" y="3" width="18" height="18" rx="2" />
-      <path d="M15 3v18" stroke-linecap="round" />
-      <path d="M10 10l-3 2 3 2" stroke-linecap="round" stroke-linejoin="round" />
-    </svg>
-  `,
-  panelRightClose: html`
-    <svg viewBox="0 0 24 24">
-      <rect x="3" y="3" width="18" height="18" rx="2" />
-      <path d="M15 3v18" stroke-linecap="round" />
-      <path d="M8 10l3 2-3 2" stroke-linecap="round" stroke-linejoin="round" />
-    </svg>
-  `,
-  columns2: html`
-    <svg viewBox="0 0 24 24">
-      <rect x="3" y="3" width="18" height="18" rx="2" />
-      <path d="M12 3v18" stroke-linecap="round" />
-    </svg>
-  `,
-  panelBottomOpen: html`
-    <svg viewBox="0 0 24 24">
-      <rect x="3" y="3" width="18" height="18" rx="2" />
-      <path d="M3 15h18" stroke-linecap="round" />
-      <path d="m10 8 2 3 2-3" stroke-linecap="round" stroke-linejoin="round" />
-    </svg>
-  `,
-  panelBottomClose: html`
-    <svg viewBox="0 0 24 24">
-      <rect x="3" y="3" width="18" height="18" rx="2" />
-      <path d="M3 15h18" stroke-linecap="round" />
-      <path d="m10 11 2-3 2 3" stroke-linecap="round" stroke-linejoin="round" />
-    </svg>
-  `,
-  maximize: html`
-    <svg viewBox="0 0 24 24">
-      <polyline points="15 3 21 3 21 9" />
-      <polyline points="9 21 3 21 3 15" />
-      <line x1="21" x2="14" y1="3" y2="10" />
-      <line x1="3" x2="10" y1="21" y2="14" />
-    </svg>
-  `,
-  minimize: html`
-    <svg viewBox="0 0 24 24">
-      <polyline points="4 14 10 14 10 20" />
-      <polyline points="20 10 14 10 14 4" />
-      <line x1="14" x2="21" y1="10" y2="3" />
-      <line x1="3" x2="10" y1="21" y2="14" />
-    </svg>
-  `,
+  circleUser: strokeIcon(svg` <path d="M18 20a6 6 0 0 0-12 0" />
+    <circle cx="12" cy="10" r="4" />
+    <circle cx="12" cy="12" r="10" />`),
+  bell: strokeIcon(svg` <path d="M10.268 21a2 2 0 0 0 3.464 0" />
+    <path
+      d="M3.262 15.326A1 1 0 0 0 4 17h16a1 1 0 0 0 .74-1.673C19.41 13.956 18 12.499 18 8A6 6 0 0 0 6 8c0 4.499-1.411 5.956-2.738 7.326"
+    />`),
+  palette: strokeIcon(svg` <path
+      d="M12 22a1 1 0 0 1 0-20 10 9 0 0 1 10 9 5 5 0 0 1-5 5h-2.25a1.75 1.75 0 0 0-1.4 2.8l.3.4a1.75 1.75 0 0 1-1.4 2.8z"
+    />
+    <circle cx="13.5" cy="6.5" r=".5" fill="currentColor" />
+    <circle cx="17.5" cy="10.5" r=".5" fill="currentColor" />
+    <circle cx="6.5" cy="12.5" r=".5" fill="currentColor" />
+    <circle cx="8.5" cy="7.5" r=".5" fill="currentColor" />`),
+  flaskConical: strokeIcon(svg` <path
+      d="M14 2v6a2 2 0 0 0 .245.96l5.51 10.08A2 2 0 0 1 18 22H6a2 2 0 0 1-1.755-2.96l5.51-10.08A2 2 0 0 0 10 8V2"
+    />
+    <path d="M6.453 15h11.094" />
+    <path d="M8.5 2h7" />`),
+  badgeCheck: strokeIcon(svg` <path
+      d="M3.85 8.62a4 4 0 0 1 4.78-4.77 4 4 0 0 1 6.74 0 4 4 0 0 1 4.78 4.78 4 4 0 0 1 0 6.74 4 4 0 0 1-4.77 4.78 4 4 0 0 1-6.75 0 4 4 0 0 1-4.78-4.77 4 4 0 0 1 0-6.76Z"
+    />
+    <path d="m9 12 2 2 4-4" />`),
+  refresh: strokeIcon(svg` <path d="M21 12a9 9 0 1 1-9-9c2.52 0 4.93 1 6.74 2.74L21 8" />
+    <path d="M21 3v5h-5" />`),
+  trash: strokeIcon(svg` <path d="M3 6h18" />
+    <path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6" />
+    <path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2" />
+    <line x1="10" x2="10" y1="11" y2="17" />
+    <line x1="14" x2="14" y1="11" y2="17" />`),
+  eye: strokeIcon(svg` <path
+      d="M2.062 12.348a1 1 0 0 1 0-.696 10.75 10.75 0 0 1 19.876 0 1 1 0 0 1 0 .696 10.75 10.75 0 0 1-19.876 0"
+    />
+    <circle cx="12" cy="12" r="3" />`),
+  eyeOff: strokeIcon(svg` <path
+      d="M10.733 5.076a10.744 10.744 0 0 1 11.205 6.575 1 1 0 0 1 0 .696 10.747 10.747 0 0 1-1.444 2.49"
+    />
+    <path d="M14.084 14.158a3 3 0 0 1-4.242-4.242" />
+    <path
+      d="M17.479 17.499a10.75 10.75 0 0 1-15.417-5.151 1 1 0 0 1 0-.696 10.75 10.75 0 0 1 4.446-5.143"
+    />
+    <path d="m2 2 20 20" />`),
+  moreHorizontal: strokeIcon(svg` <circle cx="12" cy="12" r="1.5" />
+    <circle cx="6" cy="12" r="1.5" />
+    <circle cx="18" cy="12" r="1.5" />`),
+  arrowUpDown: strokeIcon(svg` <path d="m21 16-4 4-4-4" />
+    <path d="M17 20V4" />
+    <path d="m3 8 4-4 4 4" />
+    <path d="M7 4v16" />`),
+  panelRightOpen: strokeIcon(svg` <rect x="3" y="3" width="18" height="18" rx="2" />
+    <path d="M15 3v18" stroke-linecap="round" />
+    <path d="M10 10l-3 2 3 2" stroke-linecap="round" stroke-linejoin="round" />`),
+  panelRightClose: strokeIcon(svg` <rect x="3" y="3" width="18" height="18" rx="2" />
+    <path d="M15 3v18" stroke-linecap="round" />
+    <path d="M8 10l3 2-3 2" stroke-linecap="round" stroke-linejoin="round" />`),
+  columns2: strokeIcon(svg` <rect x="3" y="3" width="18" height="18" rx="2" />
+    <path d="M12 3v18" stroke-linecap="round" />`),
+  panelBottomOpen: strokeIcon(svg` <rect x="3" y="3" width="18" height="18" rx="2" />
+    <path d="M3 15h18" stroke-linecap="round" />
+    <path d="m10 8 2 3 2-3" stroke-linecap="round" stroke-linejoin="round" />`),
+  panelBottomClose: strokeIcon(svg` <rect x="3" y="3" width="18" height="18" rx="2" />
+    <path d="M3 15h18" stroke-linecap="round" />
+    <path d="m10 11 2-3 2 3" stroke-linecap="round" stroke-linejoin="round" />`),
+  maximize: strokeIcon(svg` <polyline points="15 3 21 3 21 9" />
+    <polyline points="9 21 3 21 3 15" />
+    <line x1="21" x2="14" y1="3" y2="10" />
+    <line x1="3" x2="10" y1="21" y2="14" />`),
+  minimize: strokeIcon(svg` <polyline points="4 14 10 14 10 20" />
+    <polyline points="20 10 14 10 14 4" />
+    <line x1="14" x2="21" y1="10" y2="3" />
+    <line x1="3" x2="10" y1="21" y2="14" />`),
 } as const;

--- a/ui/src/components/icons.ts
+++ b/ui/src/components/icons.ts
@@ -1,400 +1,216 @@
 // Control UI module implements icons behavior.
-import { html, type TemplateResult } from "lit";
-import { toolIcons } from "./icons-tools.ts";
+import { svg, type TemplateResult } from "lit";
+import { strokeIcon, toolIcons } from "./icons-tools.ts";
 
-// Lucide-style SVG icons
-// All icons use currentColor for stroke
+// Lucide-style SVG icons rendered through the shared strokeIcon() shell,
+// which carries the stroke presentation attributes inline (see icons-tools.ts).
 
 export const icons = {
   // Navigation icons
-  messageSquare: html`
-    <svg viewBox="0 0 24 24">
-      <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
-    </svg>
-  `,
-  layoutGrid: html`
-    <svg viewBox="0 0 24 24">
-      <rect width="7" height="7" x="3" y="3" rx="1" />
-      <rect width="7" height="7" x="14" y="3" rx="1" />
-      <rect width="7" height="7" x="14" y="14" rx="1" />
-      <rect width="7" height="7" x="3" y="14" rx="1" />
-    </svg>
-  `,
-  barChart: html`
-    <svg viewBox="0 0 24 24">
-      <line x1="12" x2="12" y1="20" y2="10" />
-      <line x1="18" x2="18" y1="20" y2="4" />
-      <line x1="6" x2="6" y1="20" y2="16" />
-    </svg>
-  `,
-  layoutDashboard: html`
-    <svg viewBox="0 0 24 24">
-      <rect width="7" height="9" x="3" y="3" rx="1" />
-      <rect width="7" height="5" x="14" y="3" rx="1" />
-      <rect width="7" height="9" x="14" y="12" rx="1" />
-      <rect width="7" height="5" x="3" y="16" rx="1" />
-    </svg>
-  `,
-  coins: html`
-    <svg viewBox="0 0 24 24">
-      <circle cx="8" cy="8" r="6" />
-      <path d="M18.09 10.37A6 6 0 1 1 10.34 18" />
-      <path d="M7 6h1v4" />
-      <path d="m16.71 13.88.7.71-2.82 2.82" />
-    </svg>
-  `,
-  activity: html`
-    <svg viewBox="0 0 24 24">
-      <path d="M22 12h-4l-3 9L9 3l-3 9H2" />
-    </svg>
-  `,
-  clock: html`
-    <svg viewBox="0 0 24 24">
-      <circle cx="12" cy="12" r="10" />
-      <polyline points="12 6 12 12 16 14" />
-    </svg>
-  `,
-  link: html`
-    <svg viewBox="0 0 24 24">
-      <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
-      <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
-    </svg>
-  `,
-  radio: html`
-    <svg viewBox="0 0 24 24">
-      <circle cx="12" cy="12" r="2" />
-      <path
-        d="M16.24 7.76a6 6 0 0 1 0 8.49m-8.48-.01a6 6 0 0 1 0-8.49m11.31-2.82a10 10 0 0 1 0 14.14m-14.14 0a10 10 0 0 1 0-14.14"
-      />
-    </svg>
-  `,
-  fileText: html`
-    <svg viewBox="0 0 24 24">
-      <path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z" />
-      <polyline points="14 2 14 8 20 8" />
-      <line x1="16" x2="8" y1="13" y2="13" />
-      <line x1="16" x2="8" y1="17" y2="17" />
-      <line x1="10" x2="8" y1="9" y2="9" />
-    </svg>
-  `,
-  zap: html`
-    <svg viewBox="0 0 24 24"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2" /></svg>
-  `,
-  monitor: html`
-    <svg viewBox="0 0 24 24">
-      <rect width="20" height="14" x="2" y="3" rx="2" />
-      <line x1="8" x2="16" y1="21" y2="21" />
-      <line x1="12" x2="12" y1="17" y2="21" />
-    </svg>
-  `,
-  monitorSmartphone: html`
-    <svg viewBox="0 0 24 24">
-      <path d="M18 8V6a2 2 0 0 0-2-2H4a2 2 0 0 0-2 2v7a2 2 0 0 0 2 2h8" />
-      <path d="M10 19v-3.96 3.15" />
-      <path d="M7 19h5" />
-      <rect width="6" height="10" x="16" y="12" rx="2" />
-    </svg>
-  `,
-  server: html`
-    <svg viewBox="0 0 24 24">
-      <rect width="20" height="8" x="2" y="2" rx="2" ry="2" />
-      <rect width="20" height="8" x="2" y="14" rx="2" ry="2" />
-      <line x1="6" x2="6.01" y1="6" y2="6" />
-      <line x1="6" x2="6.01" y1="18" y2="18" />
-    </svg>
-  `,
-  sun: html`
-    <svg viewBox="0 0 24 24">
-      <circle cx="12" cy="12" r="4" />
-      <path d="M12 2v2" />
-      <path d="M12 20v2" />
-      <path d="m4.93 4.93 1.41 1.41" />
-      <path d="m17.66 17.66 1.41 1.41" />
-      <path d="M2 12h2" />
-      <path d="M20 12h2" />
-      <path d="m6.34 17.66-1.41 1.41" />
-      <path d="m19.07 4.93-1.41 1.41" />
-    </svg>
-  `,
-  moon: html`
-    <svg viewBox="0 0 24 24">
-      <path d="M12 3a6.5 6.5 0 0 0 9 9 9 9 0 1 1-9-9Z" />
-    </svg>
-  `,
-  settings: html`
-    <svg viewBox="0 0 24 24">
-      <path
-        d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"
-      />
-      <circle cx="12" cy="12" r="3" />
-    </svg>
-  `,
-  bug: html`
-    <svg viewBox="0 0 24 24">
-      <path d="m8 2 1.88 1.88" />
-      <path d="M14.12 3.88 16 2" />
-      <path d="M9 7.13v-1a3.003 3.003 0 1 1 6 0v1" />
-      <path d="M12 20c-3.3 0-6-2.7-6-6v-3a4 4 0 0 1 4-4h4a4 4 0 0 1 4 4v3c0 3.3-2.7 6-6 6" />
-      <path d="M12 20v-9" />
-      <path d="M6.53 9C4.6 8.8 3 7.1 3 5" />
-      <path d="M6 13H2" />
-      <path d="M3 21c0-2.1 1.7-3.9 3.8-4" />
-      <path d="M20.97 5c0 2.1-1.6 3.8-3.5 4" />
-      <path d="M22 13h-4" />
-      <path d="M17.2 17c2.1.1 3.8 1.9 3.8 4" />
-    </svg>
-  `,
-  scrollText: html`
-    <svg viewBox="0 0 24 24">
-      <path d="M8 21h12a2 2 0 0 0 2-2v-2H10v2a2 2 0 1 1-4 0V5a2 2 0 1 0-4 0v3h4" />
-      <path d="M19 17V5a2 2 0 0 0-2-2H4" />
-      <path d="M15 8h-5" />
-      <path d="M15 12h-5" />
-    </svg>
-  `,
-  folder: html`
-    <svg viewBox="0 0 24 24">
-      <path
-        d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z"
-      />
-    </svg>
-  `,
-  kanban: html`
-    <svg viewBox="0 0 24 24">
-      <rect width="18" height="18" x="3" y="3" rx="2" />
-      <path d="M8 7v7" />
-      <path d="M12 7v4" />
-      <path d="M16 7v9" />
-    </svg>
-  `,
-  bot: html`
-    <svg viewBox="0 0 24 24">
-      <path d="M12 8V4H8" />
-      <rect width="16" height="12" x="4" y="8" rx="2" />
-      <path d="M2 14h2" />
-      <path d="M20 14h2" />
-      <path d="M15 13v2" />
-      <path d="M9 13v2" />
-    </svg>
-  `,
-  users: html`
-    <svg viewBox="0 0 24 24">
-      <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
-      <circle cx="9" cy="7" r="4" />
-      <path d="M22 21v-2a4 4 0 0 0-3-3.87" />
-      <path d="M16 3.13a4 4 0 0 1 0 7.75" />
-    </svg>
-  `,
-  shieldCheck: html`
-    <svg viewBox="0 0 24 24">
-      <path d="M20 13c0 5-3.5 7.5-8 9-4.5-1.5-8-4-8-9V5l8-3 8 3z" />
-      <path d="m9 12 2 2 4-4" />
-    </svg>
-  `,
+  messageSquare: strokeIcon(svg` <path
+    d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"
+  />`),
+  layoutGrid: strokeIcon(svg` <rect width="7" height="7" x="3" y="3" rx="1" />
+    <rect width="7" height="7" x="14" y="3" rx="1" />
+    <rect width="7" height="7" x="14" y="14" rx="1" />
+    <rect width="7" height="7" x="3" y="14" rx="1" />`),
+  barChart: strokeIcon(svg` <line x1="12" x2="12" y1="20" y2="10" />
+    <line x1="18" x2="18" y1="20" y2="4" />
+    <line x1="6" x2="6" y1="20" y2="16" />`),
+  layoutDashboard: strokeIcon(svg` <rect width="7" height="9" x="3" y="3" rx="1" />
+    <rect width="7" height="5" x="14" y="3" rx="1" />
+    <rect width="7" height="9" x="14" y="12" rx="1" />
+    <rect width="7" height="5" x="3" y="16" rx="1" />`),
+  coins: strokeIcon(svg` <circle cx="8" cy="8" r="6" />
+    <path d="M18.09 10.37A6 6 0 1 1 10.34 18" />
+    <path d="M7 6h1v4" />
+    <path d="m16.71 13.88.7.71-2.82 2.82" />`),
+  activity: strokeIcon(svg` <path d="M22 12h-4l-3 9L9 3l-3 9H2" />`),
+  clock: strokeIcon(svg` <circle cx="12" cy="12" r="10" />
+    <polyline points="12 6 12 12 16 14" />`),
+  link: strokeIcon(svg` <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+    <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />`),
+  radio: strokeIcon(svg` <circle cx="12" cy="12" r="2" />
+    <path
+      d="M16.24 7.76a6 6 0 0 1 0 8.49m-8.48-.01a6 6 0 0 1 0-8.49m11.31-2.82a10 10 0 0 1 0 14.14m-14.14 0a10 10 0 0 1 0-14.14"
+    />`),
+  fileText: strokeIcon(svg` <path
+      d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z"
+    />
+    <polyline points="14 2 14 8 20 8" />
+    <line x1="16" x2="8" y1="13" y2="13" />
+    <line x1="16" x2="8" y1="17" y2="17" />
+    <line x1="10" x2="8" y1="9" y2="9" />`),
+  zap: strokeIcon(svg`<polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2" />`),
+  monitor: strokeIcon(svg` <rect width="20" height="14" x="2" y="3" rx="2" />
+    <line x1="8" x2="16" y1="21" y2="21" />
+    <line x1="12" x2="12" y1="17" y2="21" />`),
+  monitorSmartphone: strokeIcon(svg` <path
+      d="M18 8V6a2 2 0 0 0-2-2H4a2 2 0 0 0-2 2v7a2 2 0 0 0 2 2h8"
+    />
+    <path d="M10 19v-3.96 3.15" />
+    <path d="M7 19h5" />
+    <rect width="6" height="10" x="16" y="12" rx="2" />`),
+  server: strokeIcon(svg` <rect width="20" height="8" x="2" y="2" rx="2" ry="2" />
+    <rect width="20" height="8" x="2" y="14" rx="2" ry="2" />
+    <line x1="6" x2="6.01" y1="6" y2="6" />
+    <line x1="6" x2="6.01" y1="18" y2="18" />`),
+  sun: strokeIcon(svg` <circle cx="12" cy="12" r="4" />
+    <path d="M12 2v2" />
+    <path d="M12 20v2" />
+    <path d="m4.93 4.93 1.41 1.41" />
+    <path d="m17.66 17.66 1.41 1.41" />
+    <path d="M2 12h2" />
+    <path d="M20 12h2" />
+    <path d="m6.34 17.66-1.41 1.41" />
+    <path d="m19.07 4.93-1.41 1.41" />`),
+  moon: strokeIcon(svg` <path d="M12 3a6.5 6.5 0 0 0 9 9 9 9 0 1 1-9-9Z" />`),
+  settings: strokeIcon(svg` <path
+      d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"
+    />
+    <circle cx="12" cy="12" r="3" />`),
+  bug: strokeIcon(svg` <path d="m8 2 1.88 1.88" />
+    <path d="M14.12 3.88 16 2" />
+    <path d="M9 7.13v-1a3.003 3.003 0 1 1 6 0v1" />
+    <path d="M12 20c-3.3 0-6-2.7-6-6v-3a4 4 0 0 1 4-4h4a4 4 0 0 1 4 4v3c0 3.3-2.7 6-6 6" />
+    <path d="M12 20v-9" />
+    <path d="M6.53 9C4.6 8.8 3 7.1 3 5" />
+    <path d="M6 13H2" />
+    <path d="M3 21c0-2.1 1.7-3.9 3.8-4" />
+    <path d="M20.97 5c0 2.1-1.6 3.8-3.5 4" />
+    <path d="M22 13h-4" />
+    <path d="M17.2 17c2.1.1 3.8 1.9 3.8 4" />`),
+  scrollText: strokeIcon(svg` <path
+      d="M8 21h12a2 2 0 0 0 2-2v-2H10v2a2 2 0 1 1-4 0V5a2 2 0 1 0-4 0v3h4"
+    />
+    <path d="M19 17V5a2 2 0 0 0-2-2H4" />
+    <path d="M15 8h-5" />
+    <path d="M15 12h-5" />`),
+  folder: strokeIcon(svg` <path
+    d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z"
+  />`),
+  kanban: strokeIcon(svg` <rect width="18" height="18" x="3" y="3" rx="2" />
+    <path d="M8 7v7" />
+    <path d="M12 7v4" />
+    <path d="M16 7v9" />`),
+  bot: strokeIcon(svg` <path d="M12 8V4H8" />
+    <rect width="16" height="12" x="4" y="8" rx="2" />
+    <path d="M2 14h2" />
+    <path d="M20 14h2" />
+    <path d="M15 13v2" />
+    <path d="M9 13v2" />`),
+  users: strokeIcon(svg` <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
+    <circle cx="9" cy="7" r="4" />
+    <path d="M22 21v-2a4 4 0 0 0-3-3.87" />
+    <path d="M16 3.13a4 4 0 0 1 0 7.75" />`),
+  shieldCheck: strokeIcon(svg` <path d="M20 13c0 5-3.5 7.5-8 9-4.5-1.5-8-4-8-9V5l8-3 8 3z" />
+    <path d="m9 12 2 2 4-4" />`),
 
   // UI icons
-  menu: html`
-    <svg viewBox="0 0 24 24">
-      <line x1="4" x2="20" y1="12" y2="12" />
-      <line x1="4" x2="20" y1="6" y2="6" />
-      <line x1="4" x2="20" y1="18" y2="18" />
-    </svg>
-  `,
-  x: html`
-    <svg viewBox="0 0 24 24">
-      <path d="M18 6 6 18" />
-      <path d="m6 6 12 12" />
-    </svg>
-  `,
-  check: html` <svg viewBox="0 0 24 24"><path d="M20 6 9 17l-5-5" /></svg> `,
-  play: html` <svg viewBox="0 0 24 24"><polygon points="6 3 20 12 6 21 6 3" /></svg> `,
-  pause: html`
-    <svg viewBox="0 0 24 24">
-      <rect x="14" y="4" width="4" height="16" rx="1" />
-      <rect x="6" y="4" width="4" height="16" rx="1" />
-    </svg>
-  `,
-  target: html`
-    <svg viewBox="0 0 24 24">
-      <circle cx="12" cy="12" r="10" />
-      <circle cx="12" cy="12" r="6" />
-      <circle cx="12" cy="12" r="2" />
-    </svg>
-  `,
-  switchCamera: html`
-    <svg viewBox="0 0 24 24">
-      <path d="M11 19H6.5a4.5 4.5 0 0 1 0-9H8" />
-      <path d="m8 16 3 3-3 3" />
-      <path d="M13 5h4.5a4.5 4.5 0 0 1 0 9H16" />
-      <path d="m16 8-3-3 3-3" />
-    </svg>
-  `,
-  archive: html`
-    <svg viewBox="0 0 24 24">
-      <rect width="20" height="5" x="2" y="3" rx="1" />
-      <path d="M4 8v11a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8" />
-      <path d="M10 12h4" />
-    </svg>
-  `,
-  archiveRestore: html`
-    <svg viewBox="0 0 24 24">
-      <rect width="20" height="5" x="2" y="3" rx="1" />
-      <path d="M4 8v11a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8" />
-      <path d="m9 15 3-3 3 3" />
-      <path d="M12 12v6" />
-    </svg>
-  `,
-  alertTriangle: html`
-    <svg viewBox="0 0 24 24">
-      <path d="m21.73 18-8-14a2 2 0 0 0-3.46 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3" />
-      <path d="M12 9v4" />
-      <path d="M12 17h.01" />
-    </svg>
-  `,
-  hand: html`
-    <svg viewBox="0 0 24 24">
-      <path d="M18 11V6a2 2 0 0 0-4 0v5" />
-      <path d="M14 10V4a2 2 0 0 0-4 0v6" />
-      <path d="M10 10.5V6a2 2 0 0 0-4 0v8" />
-      <path d="M6 14v-2a2 2 0 0 0-4 0v4c0 4.4 3.6 8 8 8h2c4.4 0 8-3.6 8-8v-5a2 2 0 0 0-4 0v2" />
-    </svg>
-  `,
-  key: html`
-    <svg viewBox="0 0 24 24">
-      <circle cx="7.5" cy="15.5" r="5.5" />
-      <path d="m21 2-9.6 9.6" />
-      <path d="m15.5 7.5 3 3L22 7l-3-3" />
-    </svg>
-  `,
-  flag: html`
-    <svg viewBox="0 0 24 24">
-      <path d="M5 22V4" />
-      <path d="M5 4c5-4 9 4 14 0v11c-5 4-9-4-14 0" />
-    </svg>
-  `,
-  lock: html`
-    <svg viewBox="0 0 24 24">
-      <rect width="18" height="11" x="3" y="11" rx="2" />
-      <path d="M7 11V7a5 5 0 0 1 10 0v4" />
-    </svg>
-  `,
-  hourglass: html`
-    <svg viewBox="0 0 24 24">
-      <path d="M5 22h14" />
-      <path d="M5 2h14" />
-      <path d="M17 22v-4.2a4 4 0 0 0-1.2-2.8L12 11l-3.8 4A4 4 0 0 0 7 17.8V22" />
-      <path d="M7 2v4.2A4 4 0 0 0 8.2 9l3.8 4 3.8-4A4 4 0 0 0 17 6.2V2" />
-    </svg>
-  `,
-  layoutComfortable: html`
-    <svg viewBox="0 0 24 24">
-      <rect width="16" height="5" x="4" y="4" rx="1.5" />
-      <rect width="16" height="5" x="4" y="15" rx="1.5" />
-      <line x1="7" x2="16" y1="7" y2="7" />
-      <line x1="7" x2="16" y1="18" y2="18" />
-    </svg>
-  `,
-  layoutCompact: html`
-    <svg viewBox="0 0 24 24">
-      <rect width="16" height="3" x="4" y="4" rx="1" />
-      <rect width="16" height="3" x="4" y="9" rx="1" />
-      <rect width="16" height="3" x="4" y="14" rx="1" />
-      <rect width="16" height="3" x="4" y="19" rx="1" />
-    </svg>
-  `,
-  listFilter: html`
-    <svg viewBox="0 0 24 24">
-      <path d="M3 6h18" />
-      <path d="M7 12h10" />
-      <path d="M10 18h4" />
-    </svg>
-  `,
-  arrowDown: html` <svg viewBox="0 0 24 24"><path d="M12 5v14m7-7-7 7-7-7" /></svg> `,
-  arrowUp: html` <svg viewBox="0 0 24 24"><path d="M12 19V5m-7 7 7-7 7 7" /></svg> `,
-  chevronUp: html` <svg viewBox="0 0 24 24"><path d="m18 15-6-6-6 6" /></svg> `,
-  arrowLeft: html`
-    <svg viewBox="0 0 24 24">
-      <path d="m12 19-7-7 7-7" />
-      <path d="M19 12H5" />
-    </svg>
-  `,
-  cornerDownLeft: html`
-    <svg viewBox="0 0 24 24">
-      <polyline points="9 10 4 15 9 20" />
-      <path d="M20 4v7a4 4 0 0 1-4 4H4" />
-    </svg>
-  `,
-  cornerDownRight: html`
-    <svg viewBox="0 0 24 24">
-      <polyline points="15 10 20 15 15 20" />
-      <path d="M4 4v7a4 4 0 0 0 4 4h12" />
-    </svg>
-  `,
-  copy: html`
-    <svg viewBox="0 0 24 24">
-      <rect width="14" height="14" x="8" y="8" rx="2" ry="2" />
-      <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" />
-    </svg>
-  `,
-  search: html`
-    <svg viewBox="0 0 24 24">
-      <circle cx="11" cy="11" r="8" />
-      <path d="m21 21-4.3-4.3" />
-    </svg>
-  `,
-  brain: html`
-    <svg viewBox="0 0 24 24">
-      <path
-        d="M12 5a3 3 0 1 0-5.997.125 4 4 0 0 0-2.526 5.77 4 4 0 0 0 .556 6.588A4 4 0 1 0 12 18Z"
-      />
-      <path
-        d="M12 5a3 3 0 1 1 5.997.125 4 4 0 0 1 2.526 5.77 4 4 0 0 1-.556 6.588A4 4 0 1 1 12 18Z"
-      />
-      <path d="M15 13a4.5 4.5 0 0 1-3-4 4.5 4.5 0 0 1-3 4" />
-      <path d="M17.599 6.5a3 3 0 0 0 .399-1.375" />
-      <path d="M6.003 5.125A3 3 0 0 0 6.401 6.5" />
-      <path d="M3.477 10.896a4 4 0 0 1 .585-.396" />
-      <path d="M19.938 10.5a4 4 0 0 1 .585.396" />
-      <path d="M6 18a4 4 0 0 1-1.967-.516" />
-      <path d="M19.967 17.484A4 4 0 0 1 18 18" />
-    </svg>
-  `,
-  book: html`
-    <svg viewBox="0 0 24 24">
-      <path d="M4 19.5v-15A2.5 2.5 0 0 1 6.5 2H20v20H6.5a2.5 2.5 0 0 1 0-5H20" />
-    </svg>
-  `,
-  loader: html`
-    <svg viewBox="0 0 24 24">
-      <path d="M12 2v4" />
-      <path d="m16.2 7.8 2.9-2.9" />
-      <path d="M18 12h4" />
-      <path d="m16.2 16.2 2.9 2.9" />
-      <path d="M12 18v4" />
-      <path d="m4.9 19.1 2.9-2.9" />
-      <path d="M2 12h4" />
-      <path d="m4.9 4.9 2.9 2.9" />
-    </svg>
-  `,
-  calendarClock: html`
-    <svg viewBox="0 0 24 24">
-      <path d="M21 7.5V6a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h3.5" />
-      <path d="M16 2v4" />
-      <path d="M8 2v4" />
-      <path d="M3 10h5" />
-      <path d="M17.5 17.5 16 16.3V14" />
-      <circle cx="16" cy="16" r="6" />
-    </svg>
-  `,
-  listChecks: html`
-    <svg viewBox="0 0 24 24">
-      <path d="m3 17 2 2 4-4" />
-      <path d="m3 7 2 2 4-4" />
-      <path d="M13 6h8" />
-      <path d="M13 12h8" />
-      <path d="M13 18h8" />
-    </svg>
-  `,
+  menu: strokeIcon(svg` <line x1="4" x2="20" y1="12" y2="12" />
+    <line x1="4" x2="20" y1="6" y2="6" />
+    <line x1="4" x2="20" y1="18" y2="18" />`),
+  x: strokeIcon(svg` <path d="M18 6 6 18" />
+    <path d="m6 6 12 12" />`),
+  check: strokeIcon(svg`<path d="M20 6 9 17l-5-5" />`),
+  play: strokeIcon(svg`<polygon points="6 3 20 12 6 21 6 3" />`),
+  pause: strokeIcon(svg` <rect x="14" y="4" width="4" height="16" rx="1" />
+    <rect x="6" y="4" width="4" height="16" rx="1" />`),
+  target: strokeIcon(svg` <circle cx="12" cy="12" r="10" />
+    <circle cx="12" cy="12" r="6" />
+    <circle cx="12" cy="12" r="2" />`),
+  switchCamera: strokeIcon(svg` <path d="M11 19H6.5a4.5 4.5 0 0 1 0-9H8" />
+    <path d="m8 16 3 3-3 3" />
+    <path d="M13 5h4.5a4.5 4.5 0 0 1 0 9H16" />
+    <path d="m16 8-3-3 3-3" />`),
+  archive: strokeIcon(svg` <rect width="20" height="5" x="2" y="3" rx="1" />
+    <path d="M4 8v11a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8" />
+    <path d="M10 12h4" />`),
+  archiveRestore: strokeIcon(svg` <rect width="20" height="5" x="2" y="3" rx="1" />
+    <path d="M4 8v11a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8" />
+    <path d="m9 15 3-3 3 3" />
+    <path d="M12 12v6" />`),
+  alertTriangle: strokeIcon(svg` <path
+      d="m21.73 18-8-14a2 2 0 0 0-3.46 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3"
+    />
+    <path d="M12 9v4" />
+    <path d="M12 17h.01" />`),
+  hand: strokeIcon(svg` <path d="M18 11V6a2 2 0 0 0-4 0v5" />
+    <path d="M14 10V4a2 2 0 0 0-4 0v6" />
+    <path d="M10 10.5V6a2 2 0 0 0-4 0v8" />
+    <path d="M6 14v-2a2 2 0 0 0-4 0v4c0 4.4 3.6 8 8 8h2c4.4 0 8-3.6 8-8v-5a2 2 0 0 0-4 0v2" />`),
+  key: strokeIcon(svg` <circle cx="7.5" cy="15.5" r="5.5" />
+    <path d="m21 2-9.6 9.6" />
+    <path d="m15.5 7.5 3 3L22 7l-3-3" />`),
+  flag: strokeIcon(svg` <path d="M5 22V4" />
+    <path d="M5 4c5-4 9 4 14 0v11c-5 4-9-4-14 0" />`),
+  lock: strokeIcon(svg` <rect width="18" height="11" x="3" y="11" rx="2" />
+    <path d="M7 11V7a5 5 0 0 1 10 0v4" />`),
+  hourglass: strokeIcon(svg` <path d="M5 22h14" />
+    <path d="M5 2h14" />
+    <path d="M17 22v-4.2a4 4 0 0 0-1.2-2.8L12 11l-3.8 4A4 4 0 0 0 7 17.8V22" />
+    <path d="M7 2v4.2A4 4 0 0 0 8.2 9l3.8 4 3.8-4A4 4 0 0 0 17 6.2V2" />`),
+  layoutComfortable: strokeIcon(svg` <rect width="16" height="5" x="4" y="4" rx="1.5" />
+    <rect width="16" height="5" x="4" y="15" rx="1.5" />
+    <line x1="7" x2="16" y1="7" y2="7" />
+    <line x1="7" x2="16" y1="18" y2="18" />`),
+  layoutCompact: strokeIcon(svg` <rect width="16" height="3" x="4" y="4" rx="1" />
+    <rect width="16" height="3" x="4" y="9" rx="1" />
+    <rect width="16" height="3" x="4" y="14" rx="1" />
+    <rect width="16" height="3" x="4" y="19" rx="1" />`),
+  listFilter: strokeIcon(svg` <path d="M3 6h18" />
+    <path d="M7 12h10" />
+    <path d="M10 18h4" />`),
+  arrowDown: strokeIcon(svg`<path d="M12 5v14m7-7-7 7-7-7" />`),
+  arrowUp: strokeIcon(svg`<path d="M12 19V5m-7 7 7-7 7 7" />`),
+  chevronUp: strokeIcon(svg`<path d="m18 15-6-6-6 6" />`),
+  arrowLeft: strokeIcon(svg` <path d="m12 19-7-7 7-7" />
+    <path d="M19 12H5" />`),
+  cornerDownLeft: strokeIcon(svg` <polyline points="9 10 4 15 9 20" />
+    <path d="M20 4v7a4 4 0 0 1-4 4H4" />`),
+  cornerDownRight: strokeIcon(svg` <polyline points="15 10 20 15 15 20" />
+    <path d="M4 4v7a4 4 0 0 0 4 4h12" />`),
+  copy: strokeIcon(svg` <rect width="14" height="14" x="8" y="8" rx="2" ry="2" />
+    <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" />`),
+  search: strokeIcon(svg` <circle cx="11" cy="11" r="8" />
+    <path d="m21 21-4.3-4.3" />`),
+  brain: strokeIcon(svg` <path
+      d="M12 5a3 3 0 1 0-5.997.125 4 4 0 0 0-2.526 5.77 4 4 0 0 0 .556 6.588A4 4 0 1 0 12 18Z"
+    />
+    <path
+      d="M12 5a3 3 0 1 1 5.997.125 4 4 0 0 1 2.526 5.77 4 4 0 0 1-.556 6.588A4 4 0 1 1 12 18Z"
+    />
+    <path d="M15 13a4.5 4.5 0 0 1-3-4 4.5 4.5 0 0 1-3 4" />
+    <path d="M17.599 6.5a3 3 0 0 0 .399-1.375" />
+    <path d="M6.003 5.125A3 3 0 0 0 6.401 6.5" />
+    <path d="M3.477 10.896a4 4 0 0 1 .585-.396" />
+    <path d="M19.938 10.5a4 4 0 0 1 .585.396" />
+    <path d="M6 18a4 4 0 0 1-1.967-.516" />
+    <path d="M19.967 17.484A4 4 0 0 1 18 18" />`),
+  book: strokeIcon(
+    svg` <path d="M4 19.5v-15A2.5 2.5 0 0 1 6.5 2H20v20H6.5a2.5 2.5 0 0 1 0-5H20" />`,
+  ),
+  loader: strokeIcon(svg` <path d="M12 2v4" />
+    <path d="m16.2 7.8 2.9-2.9" />
+    <path d="M18 12h4" />
+    <path d="m16.2 16.2 2.9 2.9" />
+    <path d="M12 18v4" />
+    <path d="m4.9 19.1 2.9-2.9" />
+    <path d="M2 12h4" />
+    <path d="m4.9 4.9 2.9 2.9" />`),
+  calendarClock: strokeIcon(svg` <path
+      d="M21 7.5V6a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h3.5"
+    />
+    <path d="M16 2v4" />
+    <path d="M8 2v4" />
+    <path d="M3 10h5" />
+    <path d="M17.5 17.5 16 16.3V14" />
+    <circle cx="16" cy="16" r="6" />`),
+  listChecks: strokeIcon(svg` <path d="m3 17 2 2 4-4" />
+    <path d="m3 7 2 2 4-4" />
+    <path d="M13 6h8" />
+    <path d="M13 12h8" />
+    <path d="M13 18h8" />`),
 
   ...toolIcons,
 } as const;


### PR DESCRIPTION
## What Problem This Solves

Shared Lucide icon templates in `ui/src/components/icons.ts` / `icons-tools.ts` carried no SVG stroke presentation attributes — they relied entirely on global stylesheet rules (`fill: none; stroke: currentColor; ...`). Any icon rendered inside a shadow-DOM Lit component silently painted nothing, because global CSS cannot pierce shadow roots. That bug class already bit twice: the image lightbox close button (#113913) and `file-preview-modal.ts`, each patched with component-local CSS.

## Why This Change Was Made

Real Lucide SVGs ship `fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"` inline; the repo's copies had stripped them. This PR restores those defaults once, via a shared `strokeIcon()` shell in `icons-tools.ts` that wraps every 24x24 icon body. Icon bodies use Lit's `svg` template tag (an `html` fragment would parse the shapes outside the SVG namespace and render nothing — verified live during development). CSS rules override presentation attributes, so every existing surface that sets its own stroke width (e.g. 1.5/1.8px contexts) keeps winning exactly as before.

The multicolor lobster art icon (120x120 viewBox, gradient fills) intentionally stays outside the shell.

## User Impact

No visual change on light-DOM surfaces (verified by before/after screenshots). Icons are now self-contained: any future shadow-DOM component gets visible icons without needing to know about global stylesheet coupling — the invisible-icon bug class is gone. Net −360 LOC.

| Home (before) | Home (after) |
| --- | --- |
| ![before](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/icon-inline-stroke/icons-before-home.png) | ![after](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/icon-inline-stroke/icons-after-home.png) |

Shadow-DOM lightbox still correct: ![lightbox](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/icon-inline-stroke/icons-after-lightbox.png)

## Evidence

- Before/after screenshots via `pnpm dev:ui:mock` + Playwright; icon rendering verified identical (only dynamic mock content differs), and DOM inspection confirmed paths render as proper SVG-namespace siblings with the new attributes.
- `node scripts/run-vitest.mjs ui/src/pages/chat/chat-composer.test.ts ui/src/components/image-lightbox.test.ts` — 35/35 pass.
- `oxlint` + `oxfmt` clean on both files.
- Codex autoreview (gpt-5.6-sol, xhigh): clean — "patch is correct (0.96)".
- Blacksmith Testbox backend timed out during `check-changed` classification; typecheck/lint fan-out is proven by hosted PR CI instead.
