### PR TITLE
refactor: drop the retired redaction remediation from the policy plugin

### DIFF
--- a/docs/cli/policy.md
+++ b/docs/cli/policy.md
@@ -411,7 +411,7 @@ allowlist such as `["all"]`.
 
 | Policy field                                        | Observed state                                                                                     | Use when                                                               |
 | --------------------------------------------------- | -------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
-| `dataHandling.sensitiveLogging.requireRedaction`    | `logging.redactSensitive`                                                                          | Set to `true` to reject `logging.redactSensitive: "off"`.              |
+| `dataHandling.sensitiveLogging.requireRedaction`    | Sensitive log redaction, which is always on                                                        | Set to `true` to record the requirement; OpenClaw always satisfies it. |
 | `dataHandling.telemetry.denyContentCapture`         | `diagnostics.otel.captureContent`                                                                  | Set to `true` to reject telemetry content capture.                     |
 | `dataHandling.retention.requireSessionMaintenance`  | `session.maintenance.mode`                                                                         | Set to `true` to require effective session maintenance mode `enforce`. |
 | `dataHandling.memory.denySessionTranscriptIndexing` | `memory.qmd.sessions.enabled`, `memory.search.experimental.sessionMemory`, and per-agent overrides | Set to `true` to reject session transcript indexing into memory.       |
@@ -1005,16 +1005,16 @@ workspace config:
   denies open group ingress
 - set reported channel ingress `requireMention` paths to `true` when policy
   requires group mentions
-- set `logging.redactSensitive=tools` when policy requires sensitive logging
-  redaction
 - set `diagnostics.otel.captureContent=false`, or
   `diagnostics.otel.captureContent.enabled=false` for object-form telemetry
   capture settings, when policy denies telemetry content capture
 
 Scoped elevated-tools repairs are detect-only. Scoped data-handling repairs are
-also skipped when the finding reports shared logging or telemetry config,
-because changing the shared setting would affect more than the scoped policy
-target.
+also skipped when the finding reports shared telemetry config, because changing
+the shared setting would affect more than the scoped policy target.
+
+`dataHandling.sensitiveLogging.requireRedaction` has no repair. Sensitive log
+redaction is unconditional, so the check only validates the policy declaration.
 
 Scoped required-deny repairs are skipped when the finding reports inherited
 root `tools.deny`, because adding the required tool to root config would affect

--- a/extensions/policy/src/doctor/automatic-repairs.ts
+++ b/extensions/policy/src/doctor/automatic-repairs.ts
@@ -25,7 +25,6 @@ const AUTOMATIC_REPAIR_CHECK_IDS = new Set<PolicyCheckId>([
   CHECK_IDS.policyGatewayRemoteEnabled,
   CHECK_IDS.policyIngressOpenGroupsDenied,
   CHECK_IDS.policyIngressGroupMentionRequired,
-  CHECK_IDS.policyDataHandlingRedactionDisabled,
   CHECK_IDS.policyDataHandlingTelemetryContentCapture,
 ]);
 
@@ -104,14 +103,6 @@ function applyAutomaticPatch(
       return setFindingConfigValues(cfg, findings, "groupPolicy", "allowlist");
     case CHECK_IDS.policyIngressGroupMentionRequired:
       return setFindingConfigValues(cfg, findings, "requireMention", true);
-    case CHECK_IDS.policyDataHandlingRedactionDisabled:
-      if (hasScopedPolicyRequirement(findings)) {
-        return skippedUnsafeScopedRepair(
-          cfg,
-          "Skipped scoped data-handling repair. The finding reports shared logging config, so changing it would affect more than the scoped policy target.",
-        );
-      }
-      return enableSensitiveLoggingRedaction(cfg);
     case CHECK_IDS.policyDataHandlingTelemetryContentCapture:
       if (hasScopedPolicyRequirement(findings)) {
         return skippedUnsafeScopedRepair(
@@ -225,19 +216,6 @@ function disableRemoteGatewayMode(
   return changes.length > 0
     ? { config: next as OpenClawConfig, changes }
     : { config: cfg, changes };
-}
-
-function enableSensitiveLoggingRedaction(cfg: OpenClawConfig): RepairPatch {
-  const next = cloneConfig(cfg);
-  const logging = ensureRecord(next, "logging");
-  if (logging.redactSensitive !== "off") {
-    return { config: cfg, changes: [] };
-  }
-  logging.redactSensitive = "tools";
-  return {
-    config: next as OpenClawConfig,
-    changes: ["Set logging.redactSensitive=tools for policy conformance."],
-  };
 }
 
 function disableTelemetryContentCapture(cfg: OpenClawConfig): RepairPatch {

--- a/extensions/policy/src/doctor/data-auth-findings.ts
+++ b/extensions/policy/src/doctor/data-auth-findings.ts
@@ -120,7 +120,7 @@ function dataHandlingFindingsForRule(
             checkId: CHECK_IDS.policyDataHandlingRedactionDisabled,
             message: "Sensitive logging redaction is disabled.",
             requirement: `oc://${policyDocName}/${requirementBase}/sensitiveLogging/requireRedaction`,
-            fixHint: "Set logging.redactSensitive to tools or update policy after review.",
+            fixHint: "Sensitive log redaction is always enabled; update policy after review.",
           }),
         ),
     );

--- a/extensions/policy/src/doctor/fix-metadata.ts
+++ b/extensions/policy/src/doctor/fix-metadata.ts
@@ -327,14 +327,14 @@ const POLICY_FIX_METADATA = [
       configTargets: ["agents.sandbox.browser"],
     },
   ),
+  // Sensitive log redaction is an unconditional runtime invariant (src/logging/redact.ts),
+  // so this requirement has no config target to patch. Adding one would emit a retired
+  // config key that strict validation rejects.
   m(
     CHECK_IDS.policyDataHandlingRedactionDisabled,
-    "automatic",
-    "Set sensitive logging to a redacting mode.",
-    {
-      policyPath: ["dataHandling", "sensitiveLogging", "requireRedaction"],
-      configTargets: ["logging.redactSensitive"],
-    },
+    "validateOnly",
+    "Update the policy requirement; sensitive log redaction is always enabled.",
+    { policyPath: ["dataHandling", "sensitiveLogging", "requireRedaction"] },
   ),
   m(
     CHECK_IDS.policyDataHandlingTelemetryContentCapture,

--- a/extensions/policy/src/doctor/metadata.test.ts
+++ b/extensions/policy/src/doctor/metadata.test.ts
@@ -207,16 +207,14 @@ describe("policy doctor metadata", () => {
         .get("unsupported")
         ?.map((rule) => rule.checkId)
         .toSorted(),
-      validateOnly:
-        grouped
-          .get("validateOnly")
-          ?.map((rule) => rule.checkId)
-          .toSorted() ?? [],
+      validateOnly: grouped
+        .get("validateOnly")
+        ?.map((rule) => rule.checkId)
+        .toSorted(),
     }).toEqual({
       automatic: [
         "policy/agents-tool-not-denied",
         "policy/channels-denied-provider",
-        "policy/data-handling-redaction-disabled",
         "policy/data-handling-telemetry-content-capture",
         "policy/gateway-control-ui-insecure",
         "policy/gateway-http-endpoint-enabled",
@@ -287,7 +285,7 @@ describe("policy doctor metadata", () => {
         "policy/tools-profile-unapproved",
       ],
       unsupported: ["policy/sandbox-container-posture-unobservable"],
-      validateOnly: [],
+      validateOnly: ["policy/data-handling-redaction-disabled"],
     });
   });
 });

--- a/extensions/policy/src/doctor/scopes/data-auth.ts
+++ b/extensions/policy/src/doctor/scopes/data-auth.ts
@@ -18,13 +18,6 @@ export function createPolicyDataAuthChecks(deps: PolicyDoctorCheckDeps): readonl
         CHECK_IDS.policyDataHandlingRedactionDisabled,
       );
     },
-    repair(ctx, findings) {
-      return repairPolicyAutomaticNarrower(
-        ctx,
-        findings,
-        CHECK_IDS.policyDataHandlingRedactionDisabled,
-      );
-    },
   };
   const policyDataHandlingTelemetryContentCaptureCheck: HealthCheck = {
     id: CHECK_IDS.policyDataHandlingTelemetryContentCapture,

--- a/src/logging/redact.ts
+++ b/src/logging/redact.ts
@@ -1122,9 +1122,9 @@ function resolveToolPayloadRedaction(
   return { mode: "tools", patterns };
 }
 
-// Forces tools-mode regardless of `logging.redactSensitive` (which governs log
-// output, not UI surfaces), and merges user `logging.redactPatterns` with the
-// built-in defaults so both apply.
+// Forces tools-mode so UI/tool payloads never inherit a caller-supplied "off"
+// mode, and merges user `logging.redactPatterns` with the built-in defaults so
+// both apply.
 export function redactToolPayloadText(text: string): string {
   return redactToolPayloadTextWithConfig(text, readLoggingConfig());
 }


### PR DESCRIPTION
## What Problem This Solves

The policy plugin carried an automatic doctor repair for
`dataHandling.sensitiveLogging.requireRedaction` that wrote `logging.redactSensitive`. That
key is retired: it is absent from the root schema, listed in `dead-config-keys.test.ts`, and
stripped by an existing doctor migration. Since the root config object is strict, the repair
would have written a config the Gateway refuses to load, and its advertised `configTargets`
pointed operators at the same dead key.

Worth stating plainly for reviewers judging risk: the repair is currently unreachable. The
redaction evidence is hardcoded to `value: true` in `policy-state-data.ts`, and the finding
builder filters on `value !== true`, so the finding that would trigger the repair can never
fire. `git log -L` traces that to PR #111527 (config-surface reduction tranche 3), which
flipped the evidence to an invariant but left the repair, the config target, and the docs
behind. This is leftover debris from that change rather than a live defect.

## Why This Change Was Made

Redaction is unconditional now. `resolveConfigRedaction()` hardcodes tools-mode and reads
only `redactPatterns`, so config can never yield an "off" state. A remediation whose entire
job was to turn redaction on has nothing left to do, which makes removal the right answer
rather than retargeting it at some other key.

The check and the `dataHandling.sensitiveLogging.requireRedaction` policy key are kept. That
key is a public `policy.jsonc` contract still validated by `data-auth-shapes.ts`, so
retiring it would be a contract change rather than debris removal.

The metadata entry moves from `automatic` to `validateOnly`, which is the previously unused
member of that enum and describes this case exactly.

## User Impact

No user-visible behavior change, since the repair could not fire. Operators no longer see a
policy that advertises a config fix targeting a key the schema rejects, and
`docs/cli/policy.md` no longer documents a `--fix` behavior that does not exist.

One thing reviewers should decide separately: because the evidence is now a hardcoded
invariant, `policy/data-handling-redaction-disabled` can never produce a finding at all.
Deleting the check outright would be the leaner end state, but that retires a documented
public check id and stops evaluating a public policy key. That reads as a product decision,
so this PR leaves the check reporting-capable and flags it rather than deciding unilaterally.

## Evidence

- `node scripts/run-vitest.mjs extensions/policy` - 10 files, 363 tests passing.
- `node scripts/run-vitest.mjs src/logging/redact` - 148 tests passing.
- `run-tsgo.mjs` clean on `tsconfig.extensions.json` and the extensions test tsconfig.
- `oxfmt --check` clean on all six changed TypeScript files; `run-oxlint.mjs` exit 0 for both
  the extensions and core tsconfigs.
- Autoreview (Codex `gpt-5.6-sol`, xhigh): clean, no accepted or actionable findings.

Sibling check: no other remediation in the repo writes a retired key. The `logging.redact_off`
security audit finding was already removed from production, with a test asserting it is never
emitted. `scripts/lib/policy-config-coverage.jsonc` still lists the key, but that is a
report-only maintainer inventory that legitimately supports non-schema paths and already
reports pre-existing drift on an unrelated entry, so it is left alone as a different class.

A stale comment in `src/logging/redact.ts` that explained behavior "regardless of
`logging.redactSensitive`" now describes the real contract.

LOC delta: +21 / -52 across 7 files, production code net -38.
