### PR TITLE
chore: stabilize Codex realtime lease validation

### DIFF
--- a/extensions/codex/realtime-voice-api.test.ts
+++ b/extensions/codex/realtime-voice-api.test.ts
@@ -21,6 +21,9 @@ describe("Codex realtime voice runtime artifact", () => {
   });
 
   it("keeps the owner runtime until every registration lease is released", async () => {
+    // Extension shards are non-isolated, so another plugin registration may
+    // already own the process-global runtime when this test starts.
+    const initialFallback = getCodexRealtimeBrowserSessionFallback();
     const first = createRuntime();
     const second = createRuntime();
 
@@ -34,7 +37,10 @@ describe("Codex realtime voice runtime artifact", () => {
 
     await second.cleanup();
 
-    expect(getCodexRealtimeBrowserSessionFallback()).toBeUndefined();
+    expect(getCodexRealtimeBrowserSessionFallback()).toBe(initialFallback);
+    if (initialFallback) {
+      return;
+    }
     const replacement = createRuntime();
     expect(replacement.broker).not.toBe(first.broker);
   });


### PR DESCRIPTION
## What Problem This Solves

Resolves a release-validation failure where the Codex realtime lease test expected an empty process-global registry even though Plugin Prerelease intentionally runs extension tests in a shared, non-isolated process.

## Why This Change Was Made

The test now records the fallback that already owns the process-global runtime and verifies that releasing its own leases restores that owner. When the registry really starts empty, it retains the stronger assertion that a later registration receives a new broker.

## User Impact

No runtime behavior changes. Release and plugin validation no longer fail based on legitimate test ordering.

## Evidence

- Failure: https://github.com/openclaw/openclaw/actions/runs/30182344710/job/89741021717
- `node scripts/run-vitest.mjs extensions/codex/realtime-voice-api.test.ts`
- `git diff --check`
- Autoreview: clean, no accepted/actionable findings
