### PR TITLE
docs(logging): remove retired redactSensitive guidance

### DIFF
--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -1266,7 +1266,7 @@ writer is best-effort, not a lossless compliance archive.
 - `consoleStyle`: `"pretty"` or `"json"`. The earlier `"compact"` value is retired; [`openclaw doctor --fix`](/cli/doctor) maps it to `"pretty"`.
 - `maxFileBytes`: maximum active log file size in bytes before rotation (positive integer; default: `104857600` = 100 MB). OpenClaw keeps up to five numbered archives beside the active file.
 - `redactPatterns`: regexes for best-effort masking of console output, file logs, OTLP log records, and persisted session transcript text. Setting this **replaces** the built-in default patterns for log and transcript output, so include the defaults you still want; omitting them also turns off form-body and structured auth-header redaction. Tool payload redaction is separate and always merges your patterns with the defaults.
-- Redaction is always on and is no longer configurable. The retired `logging.redactSensitive` switch (including its `"off"` value) is removed by [`openclaw doctor --fix`](/cli/doctor); the runtime always applies `tools`-mode redaction to logs and transcripts. UI, tool, and diagnostic safety surfaces redact secrets independently of this policy.
+- Redaction is always on and is no longer configurable. [`openclaw doctor --fix`](/cli/doctor) removes the retired switch from older config files; the runtime always applies `tools`-mode redaction to logs and transcripts. UI, tool, and diagnostic safety surfaces redact secrets independently of this policy.
 
 ---
 


### PR DESCRIPTION
Related: #113956
Related: #113961

## What Problem This Solves

Resolves the final documentation occurrence that still names the retired logging redaction switch and its old disabled value, even though the setting is rejected by current config and removed by doctor migration.

## Why This Change Was Made

The broader docs and policy cleanup landed concurrently in #113956 and #113961. This follow-up preserves the useful migration guidance in the logging reference while describing the retired setting generically, leaving no public docs reference that looks like a usable config key.

## User Impact

Operators still learn that `openclaw doctor --fix` removes the retired switch from older configs, without being shown an invalid key or obsolete value they might try to configure.

## Evidence

- Confirmed no retired key or audit-check identifier references remain under `docs/`.
- `git diff --check`
- `node scripts/format-docs.mjs --check` — 735 files clean
- `node scripts/check-docs-mdx.mjs docs/gateway/configuration-reference.md`
- `pnpm lint:docs -- docs/gateway/configuration-reference.md` — 0 issues
- `node scripts/docs-link-audit.mjs` — 6,193 internal links, 0 broken
- Codex autoreview: clean, patch correct (0.99)
