### PR TITLE
fix(agents): trust caller-supplied run default in live session switch check

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-recovery.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-recovery.ts
@@ -1,6 +1,5 @@
 import { formatErrorMessage, toErrorObject } from "../../../infra/errors.js";
 import { projectAgentRunAttemptTerminal } from "../../agent-run-terminal-outcome.js";
-import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../../defaults.js";
 import type { FailoverReason } from "../../embedded-agent-helpers.js";
 import { LiveSessionModelSwitchError } from "../../live-model-switch-error.js";
 import { shouldSwitchToLiveModel, clearLiveModelSwitchPending } from "../../live-model-switch.js";
@@ -138,8 +137,11 @@ export async function recoverEmbeddedRunAttempt(input: {
     cfg: params.config,
     sessionKey: runInput.resolvedSessionKey,
     agentId: params.agentId,
-    defaultProvider: DEFAULT_PROVIDER,
-    defaultModel: DEFAULT_MODEL,
+    // Run defaults, not product constants: heartbeat/cron runs pass their own
+    // model, and comparing the persisted selection against a re-derived agent
+    // primary raised spurious live-switch restarts for those runs.
+    defaultProvider: runInput.provider,
+    defaultModel: runInput.modelId,
     currentProvider: preparedRuntime.provider,
     currentModel: preparedRuntime.modelId,
     currentAgentRuntimeOverride: params.agentHarnessRuntimeOverride,

--- a/src/agents/live-model-switch.test.ts
+++ b/src/agents/live-model-switch.test.ts
@@ -179,10 +179,6 @@ describe("live model switch", () => {
       authProfileId: "profile-gpt",
       authProfileIdSource: "user",
     });
-    expect(state.resolveDefaultModelForAgentMock).toHaveBeenCalledWith({
-      cfg: { session: { store: "/tmp/custom-store.json" } },
-      agentId: "reply",
-    });
     expect(state.resolveStorePathMock).toHaveBeenCalledWith("/tmp/custom-store.json", {
       agentId: "reply",
     });
@@ -374,6 +370,37 @@ describe("live model switch", () => {
         authProfileId: undefined,
         authProfileIdSource: undefined,
       });
+    });
+
+    it("trusts the caller-supplied run default instead of re-resolving the agent primary", async () => {
+      // Heartbeat/cron shape: the run passes its own model as the default and
+      // is currently executing it. Re-resolving the agent primary (mocked as
+      // anthropic/claude-opus-4-6) used to make the persisted selection differ
+      // and raised a spurious live-switch restart on every heartbeat tick.
+      state.loadSessionStoreMock.mockReturnValue({
+        main: { liveModelSwitchPending: true },
+      });
+
+      const { shouldSwitchToLiveModel } = await loadModule();
+
+      expect(
+        shouldSwitchToLiveModel(
+          makeShouldSwitchParams({
+            defaultProvider: "google",
+            defaultModel: "gemini-2.5-flash",
+            currentProvider: "google",
+            currentModel: "gemini-2.5-flash",
+          }),
+        ),
+      ).toBeUndefined();
+      expect(state.resolvePersistedSelectedModelRefMock).toHaveBeenCalledWith({
+        defaultProvider: "google",
+        runtimeProvider: undefined,
+        runtimeModel: undefined,
+        overrideProvider: undefined,
+        overrideModel: undefined,
+      });
+      expect(state.resolveDefaultModelForAgentMock).not.toHaveBeenCalled();
     });
 
     it("returns undefined when liveModelSwitchPending is false", async () => {

--- a/src/agents/live-model-switch.ts
+++ b/src/agents/live-model-switch.ts
@@ -12,7 +12,6 @@ import {
 import type { SessionEntry } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveSessionAgentId } from "./agent-scope.js";
-import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "./defaults.js";
 import {
   normalizeStoredOverrideModel,
   resolveDefaultModelForAgent,
@@ -56,7 +55,6 @@ function resolveLiveSessionModelSelection(params: {
   return resolveSelectionFromSessionEntry({
     cfg,
     entry,
-    agentId,
     defaultProvider: params.defaultProvider,
     defaultModel: params.defaultModel,
   });
@@ -69,18 +67,16 @@ function resolveLiveSessionModelSelection(params: {
 function resolveSelectionFromSessionEntry(params: {
   cfg: OpenClawConfig;
   entry: SessionEntry | undefined;
-  agentId?: string;
   defaultProvider: string;
   defaultModel: string;
 }): LiveSessionModelSelection {
   const { cfg, entry } = params;
-  const agentId = normalizeOptionalString(params.agentId);
-  const defaultModelRef = agentId
-    ? resolveDefaultModelForAgent({
-        cfg,
-        agentId,
-      })
-    : { provider: params.defaultProvider, model: params.defaultModel };
+  // Trust the caller-supplied run defaults instead of re-resolving the agent
+  // primary here. Heartbeat and cron runs pass their own model (e.g. haiku) as
+  // the default; re-resolving the agent primary made the persisted selection
+  // diverge from those runs and raised a spurious LiveSessionModelSwitchError
+  // that restarted heartbeats onto the wrong model.
+  const defaultModelRef = { provider: params.defaultProvider, model: params.defaultModel };
   const normalizedSelection = normalizeStoredOverrideModel({
     providerOverride: entry?.providerOverride,
     modelOverride: entry?.modelOverride,
@@ -280,12 +276,14 @@ export async function consolidateLiveModelSwitchAfterRun(params: {
       if (!entry.liveModelSwitchPending) {
         return null;
       }
+      // Consolidation compares against the agent's own default: CLI harness
+      // runs execute the agent primary unless the session overrides it.
+      const agentDefault = resolveDefaultModelForAgent({ cfg, agentId });
       const persisted = resolveSelectionFromSessionEntry({
         cfg,
         entry,
-        agentId,
-        defaultProvider: DEFAULT_PROVIDER,
-        defaultModel: DEFAULT_MODEL,
+        defaultProvider: agentDefault.provider,
+        defaultModel: agentDefault.model,
       });
       const selectionApplied =
         (providerUsed === persisted.provider && modelUsed === persisted.model) ||


### PR DESCRIPTION
## What Problem This Solves

Heartbeat and cron runs pass their own model (e.g. a cheap haiku-class model) as the run default, but the live session switch check re-resolves the agent primary model whenever an `agentId` is present. With a pending `liveModelSwitchPending` flag on the session, the persisted selection resolves to the agent primary, diverges from the heartbeat's current model, and raises a spurious `LiveSessionModelSwitchError` that restarts heartbeat runs onto the agent primary instead of their configured model.

This is a rebased successor of #75528 (closed for inactivity in May); the runner has since been restructured, so this lands the same contract at the new seam.

## Why This Change Was Made

- `src/agents/live-model-switch.ts`: `resolveSelectionFromSessionEntry` now trusts the caller-supplied run defaults; the `agentId`-based re-resolution branch is deleted (one canonical rule instead of a caller/agent heuristic). `consolidateLiveModelSwitchAfterRun` keeps its current behavior by resolving the agent default explicitly at its callsite — CLI harness runs execute the agent primary unless the session overrides it.
- `src/agents/embedded-agent-runner/run/attempt-recovery.ts`: passes the run's requested provider/model (`runInput.provider`/`modelId`, from `resolveInitialEmbeddedRunModel`) into `shouldSwitchToLiveModel` instead of the `DEFAULT_PROVIDER`/`DEFAULT_MODEL` product constants. For normal runs these equal the agent primary, so behavior is unchanged; for heartbeat/cron runs they carry the caller's model override.

AI-assisted: implementation and structured review with Codex; the author reviewed the resulting code and tests.

## User Impact

Heartbeats and cron jobs configured with their own (typically cheaper) model no longer get restarted onto the agent's primary model when a live model switch flag is pending on the session; UI-driven `/model` switches still take effect because session overrides continue to win over defaults.

## Evidence

- The fix has been carried on the author's production patch stack since 2026-05-01 (originally #75528) through v2026.7.1 with daily heartbeat/cron traffic.
- `node scripts/run-vitest.mjs src/agents/live-model-switch.test.ts` — 30 tests passed, including a new heartbeat-shaped regression: pending flag + matching caller default → no switch reported, agent primary never re-resolved.
- Related suites green: `src/sessions/model-overrides.test.ts`, `src/cron/isolated-agent/run.live-session-model-switch.test.ts`, `src/cron/isolated-agent/session.test.ts`, auto-reply runner execution/directive/status suites (109 tests).
- `pnpm tsgo`, `scripts/run-oxlint.mjs` (changed files), `oxfmt` — green locally.
- Repository `autoreview --mode branch --base upstream/main` (Codex, thinking=high) — result reported in PR comments after run.
- Full repository gates were not run locally; GitHub CI is the broader proof lane.
