### PR TITLE
refactor(agents): share restart recovery state snapshot

### DIFF
--- a/src/agents/main-session-restart-recovery-checkpoint.ts
+++ b/src/agents/main-session-restart-recovery-checkpoint.ts
@@ -4,7 +4,6 @@ import { buildRestartRecoveryClaimCleanupPatch } from "../config/sessions/restar
 import {
   applySessionEntryReplacements,
   persistSessionTranscriptTurn,
-  type SessionTranscriptTurnExpectedState,
   type SessionTranscriptTurnLifecyclePatch,
   updateSessionEntry,
 } from "../config/sessions/session-accessor.js";
@@ -21,7 +20,7 @@ import {
 } from "./embedded-agent-runner/message-visibility.js";
 import { buildMainSessionRecoveryClearPatch } from "./main-session-recovery-clear.js";
 import { isRestartAbortTailArtifact } from "./main-session-restart-recovery-resume-policy.js";
-import { log } from "./main-session-restart-recovery-shared.js";
+import { buildRestartRecoveryExpectedState, log } from "./main-session-restart-recovery-shared.js";
 
 export function hasOnlyAnnounceRecoveryRuns(entry: SessionEntry): boolean {
   const runs = entry.restartRecoveryRuns;
@@ -433,25 +432,7 @@ export async function markSessionCompletedAfterRecoveryCheckpoint(params: {
     recoveryToolResultIdempotencyKey &&
     successfulToolResultIndex === undefined
   ) {
-    const expectedSessionState: SessionTranscriptTurnExpectedState = {
-      abortedLastRun: params.entry.abortedLastRun,
-      restartRecoveryBeforeAgentReplyState: params.entry.restartRecoveryBeforeAgentReplyState,
-      restartRecoveryDeliveryReceiptState: params.entry.restartRecoveryDeliveryReceiptState,
-      restartRecoveryDeliveryToolCallId: params.entry.restartRecoveryDeliveryToolCallId,
-      restartRecoveryDeliveryRequestFingerprint:
-        params.entry.restartRecoveryDeliveryRequestFingerprint,
-      restartRecoveryDeliveryRunId: params.entry.restartRecoveryDeliveryRunId,
-      restartRecoveryDeliverySourceRunId: params.entry.restartRecoveryDeliverySourceRunId,
-      restartRecoveryRequesterAccountId: params.entry.restartRecoveryRequesterAccountId,
-      restartRecoveryRequesterSenderId: params.entry.restartRecoveryRequesterSenderId,
-      restartRecoverySameChannelThreadRequired:
-        params.entry.restartRecoverySameChannelThreadRequired,
-      restartRecoverySourceIngress: params.entry.restartRecoverySourceIngress,
-      restartRecoverySourceReplyDeliveryMode: params.entry.restartRecoverySourceReplyDeliveryMode,
-      restartRecoveryTerminalRunIds: params.entry.restartRecoveryTerminalRunIds,
-      status: params.entry.status,
-      updatedAt: params.entry.updatedAt,
-    };
+    const expectedSessionState = buildRestartRecoveryExpectedState(params.entry);
     const persisted = await persistSessionTranscriptTurn(
       {
         agentId: params.agentId,

--- a/src/agents/main-session-restart-recovery-failure.ts
+++ b/src/agents/main-session-restart-recovery-failure.ts
@@ -14,6 +14,7 @@ import {
 import { commitMainSessionRecovery } from "./main-session-recovery-store.js";
 import { buildUnresumableSessionNoticeIdempotencyKey } from "./main-session-restart-claim.js";
 import { resolveRestartRecoveryDeliveryContext } from "./main-session-restart-dispatch.js";
+import { buildRestartRecoveryExpectedState } from "./main-session-restart-recovery-shared.js";
 
 const log = createSubsystemLogger("main-session-restart-recovery");
 const TOMBSTONED_SESSION_NOTICE =
@@ -176,27 +177,7 @@ async function writeUnresumableSessionNotice(params: {
     agentId: resolveAgentIdFromSessionKey(params.sessionKey),
     sessionKey: params.sessionKey,
     expectedSessionId: params.entry.sessionId,
-    expectedSessionState: {
-      abortedLastRun: params.entry.abortedLastRun,
-      mainRestartRecoveryCycleId: params.observation.cycleId,
-      mainRestartRecoveryRevision: params.observation.revision,
-      restartRecoveryBeforeAgentReplyState: params.entry.restartRecoveryBeforeAgentReplyState,
-      restartRecoveryDeliveryReceiptState: params.entry.restartRecoveryDeliveryReceiptState,
-      restartRecoveryDeliveryToolCallId: params.entry.restartRecoveryDeliveryToolCallId,
-      restartRecoveryDeliveryRequestFingerprint:
-        params.entry.restartRecoveryDeliveryRequestFingerprint,
-      restartRecoveryDeliveryRunId: params.entry.restartRecoveryDeliveryRunId,
-      restartRecoveryDeliverySourceRunId: params.entry.restartRecoveryDeliverySourceRunId,
-      restartRecoveryRequesterAccountId: params.entry.restartRecoveryRequesterAccountId,
-      restartRecoveryRequesterSenderId: params.entry.restartRecoveryRequesterSenderId,
-      restartRecoverySameChannelThreadRequired:
-        params.entry.restartRecoverySameChannelThreadRequired,
-      restartRecoverySourceIngress: params.entry.restartRecoverySourceIngress,
-      restartRecoverySourceReplyDeliveryMode: params.entry.restartRecoverySourceReplyDeliveryMode,
-      restartRecoveryTerminalRunIds: params.entry.restartRecoveryTerminalRunIds,
-      status: params.entry.status,
-      updatedAt: params.entry.updatedAt,
-    },
+    expectedSessionState: buildRestartRecoveryExpectedState(params.entry, params.observation),
     sessionLifecyclePatch: {
       abortedLastRun: false,
       endedAt: now,

--- a/src/agents/main-session-restart-recovery-notice.ts
+++ b/src/agents/main-session-restart-recovery-notice.ts
@@ -10,7 +10,11 @@ import type { MainSessionRecoveryObservation } from "./main-session-recovery-sta
 import { commitMainSessionRecovery } from "./main-session-recovery-store.js";
 import { buildUnresumableSessionNoticeIdempotencyKey } from "./main-session-restart-claim.js";
 import { resolveRestartRecoveryDeliveryContext } from "./main-session-restart-dispatch.js";
-import { log, UNRESUMABLE_SESSION_NOTICE } from "./main-session-restart-recovery-shared.js";
+import {
+  buildRestartRecoveryExpectedState,
+  log,
+  UNRESUMABLE_SESSION_NOTICE,
+} from "./main-session-restart-recovery-shared.js";
 
 async function markSessionFailed(params: {
   observation: MainSessionRecoveryObservation;
@@ -84,25 +88,7 @@ async function writeUnresumableSessionNotice(params: {
     agentId: params.agentId,
     sessionKey: params.sessionKey,
     expectedSessionId: params.entry.sessionId,
-    expectedSessionState: {
-      abortedLastRun: params.entry.abortedLastRun,
-      restartRecoveryBeforeAgentReplyState: params.entry.restartRecoveryBeforeAgentReplyState,
-      restartRecoveryDeliveryReceiptState: params.entry.restartRecoveryDeliveryReceiptState,
-      restartRecoveryDeliveryToolCallId: params.entry.restartRecoveryDeliveryToolCallId,
-      restartRecoveryDeliveryRequestFingerprint:
-        params.entry.restartRecoveryDeliveryRequestFingerprint,
-      restartRecoveryDeliveryRunId: params.entry.restartRecoveryDeliveryRunId,
-      restartRecoveryDeliverySourceRunId: params.entry.restartRecoveryDeliverySourceRunId,
-      restartRecoveryRequesterAccountId: params.entry.restartRecoveryRequesterAccountId,
-      restartRecoveryRequesterSenderId: params.entry.restartRecoveryRequesterSenderId,
-      restartRecoverySameChannelThreadRequired:
-        params.entry.restartRecoverySameChannelThreadRequired,
-      restartRecoverySourceIngress: params.entry.restartRecoverySourceIngress,
-      restartRecoverySourceReplyDeliveryMode: params.entry.restartRecoverySourceReplyDeliveryMode,
-      restartRecoveryTerminalRunIds: params.entry.restartRecoveryTerminalRunIds,
-      status: params.entry.status,
-      updatedAt: params.entry.updatedAt,
-    },
+    expectedSessionState: buildRestartRecoveryExpectedState(params.entry),
     storePath: params.storePath,
     text: UNRESUMABLE_SESSION_NOTICE,
     idempotencyKey: buildUnresumableSessionNoticeIdempotencyKey(params.entry),

--- a/src/agents/main-session-restart-recovery-shared.ts
+++ b/src/agents/main-session-restart-recovery-shared.ts
@@ -4,6 +4,7 @@ import {
   type InternalSessionEntry as SessionEntry,
   resolveAllAgentSessionStoreTargetsSync,
 } from "../config/sessions.js";
+import type { SessionTranscriptTurnExpectedState } from "../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { isMainRestartRecoveryCandidate } from "./main-session-recovery-state.js";
@@ -26,6 +27,35 @@ export type ExpectedRestartRecoveryTarget = {
 export type ExhaustedRestartRecoveryTarget = ExpectedRestartRecoveryTarget & {
   storePath: string;
 };
+
+export function buildRestartRecoveryExpectedState(
+  entry: SessionEntry,
+  mainRestartRecovery?: { cycleId: string; revision: number },
+): SessionTranscriptTurnExpectedState {
+  return {
+    abortedLastRun: entry.abortedLastRun,
+    ...(mainRestartRecovery
+      ? {
+          mainRestartRecoveryCycleId: mainRestartRecovery.cycleId,
+          mainRestartRecoveryRevision: mainRestartRecovery.revision,
+        }
+      : {}),
+    restartRecoveryBeforeAgentReplyState: entry.restartRecoveryBeforeAgentReplyState,
+    restartRecoveryDeliveryReceiptState: entry.restartRecoveryDeliveryReceiptState,
+    restartRecoveryDeliveryToolCallId: entry.restartRecoveryDeliveryToolCallId,
+    restartRecoveryDeliveryRequestFingerprint: entry.restartRecoveryDeliveryRequestFingerprint,
+    restartRecoveryDeliveryRunId: entry.restartRecoveryDeliveryRunId,
+    restartRecoveryDeliverySourceRunId: entry.restartRecoveryDeliverySourceRunId,
+    restartRecoveryRequesterAccountId: entry.restartRecoveryRequesterAccountId,
+    restartRecoveryRequesterSenderId: entry.restartRecoveryRequesterSenderId,
+    restartRecoverySameChannelThreadRequired: entry.restartRecoverySameChannelThreadRequired,
+    restartRecoverySourceIngress: entry.restartRecoverySourceIngress,
+    restartRecoverySourceReplyDeliveryMode: entry.restartRecoverySourceReplyDeliveryMode,
+    restartRecoveryTerminalRunIds: entry.restartRecoveryTerminalRunIds,
+    status: entry.status,
+    updatedAt: entry.updatedAt,
+  };
+}
 
 export function shouldSkipMainRecovery(entry: SessionEntry, sessionKey: string): boolean {
   return !isMainRestartRecoveryCandidate(entry, sessionKey);


### PR DESCRIPTION
## What Problem This Solves

Resolves a maintenance risk where three restart-recovery transcript paths independently reconstructed the same compare-and-swap expected-state snapshot, allowing fields to drift when recovery state evolves.

## Why This Change Was Made

This adds one restart-recovery-owned snapshot builder and routes checkpoint, failure, and notice writes through it. The failure path still inserts its cycle and revision fences in the same property order, so the emitted expected-state objects remain equivalent.

## User Impact

No user-visible behavior changes. Restart recovery keeps the same atomic transcript admission checks with one canonical field list.

## Evidence

- `node scripts/run-vitest.mjs src/agents/main-session-restart-recovery.test.ts src/agents/agent-command-restart-recovery.test.ts` — 136 restart-recovery and 15 command tests passed.
- `node scripts/check-changed.mjs` — all selected core typecheck, targeted lint, boundary, and architecture lanes passed on Blacksmith Testbox run 30183103697 (`exitCode: 0`).
- `$HOME/.claude/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — clean, no accepted/actionable findings.
- `git diff --check origin/main...HEAD` — passed.

AI-assisted; the implementation was reviewed against all three callers, the expected-state contract, its comparison callee, and adjacent restart-recovery tests.
