### PR TITLE
refactor(meetings): converge Google Meet probes and adapter parsing

### DIFF
--- a/extensions/google-meet/index.test.ts
+++ b/extensions/google-meet/index.test.ts
@@ -5272,10 +5272,13 @@ describe("google-meet plugin", () => {
     expect(result.speechOutputTimedOut).toBe(false);
   });
 
-  it("uses the requested bidirectional realtime mode for test speech", async () => {
-    const runtime = meetRuntime({ defaultMode: "agent" }, noopLogger);
+  it.each([
+    ["bidi", "bidi"],
+    ["realtime", "agent"],
+  ] as const)("normalizes the %s test speech mode to %s", async (mode, expectedMode) => {
+    const runtime = meetRuntime({ defaultMode: "bidi" }, noopLogger);
     const session = meetSession({
-      mode: "bidi",
+      mode: expectedMode,
       chrome: {
         audioBackend: "blackhole-2ch",
         launched: true,
@@ -5287,14 +5290,14 @@ describe("google-meet plugin", () => {
 
     await runtime.testSpeech({
       url: MEET_URL,
-      mode: "bidi",
+      mode,
       message: "Say exactly: hello.",
     });
 
     expect(join).toHaveBeenCalledTimes(1);
     const joinArgs = requireRecord(mockCallArg(join, 0), "test speech join args");
     expect(joinArgs.message).toBe("Say exactly: hello.");
-    expect(joinArgs.mode).toBe("bidi");
+    expect(joinArgs.mode).toBe(expectedMode);
   });
 
   it("resets test speech output and loopback baselines when another agent owns the old session", async () => {
@@ -5423,7 +5426,7 @@ describe("google-meet plugin", () => {
     await expect(
       runtime.testListen({
         url: MEET_URL,
-        mode: "agent",
+        mode: "realtime",
       }),
     ).rejects.toThrow("test_listen requires mode: transcribe");
 

--- a/extensions/google-meet/src/runtime-probes.ts
+++ b/extensions/google-meet/src/runtime-probes.ts
@@ -1,33 +1,31 @@
-import { sleep } from "openclaw/plugin-sdk/runtime-env";
+import { MeetingPlatformAdapter } from "openclaw/plugin-sdk/meeting-runtime";
 import type { GoogleMeetConfig, GoogleMeetMode, GoogleMeetTransport } from "./config.js";
 import { normalizeMeetUrl } from "./meet-url.js";
 import type {
+  GoogleMeetChromeHealth,
   GoogleMeetJoinRequest,
   GoogleMeetJoinResult,
   GoogleMeetSession,
 } from "./transports/types.js";
-
-type ResolvedGoogleMeetJoin = {
-  url: string;
-  transport: GoogleMeetTransport;
-  mode: GoogleMeetMode;
-  agentId: string;
-};
 
 export type GoogleMeetRuntimeProbeContext = {
   config: GoogleMeetConfig;
   resolveAgentId(request: GoogleMeetJoinRequest): string;
   list(): GoogleMeetSession[];
   join(request: GoogleMeetJoinRequest): Promise<GoogleMeetJoinResult>;
-  isReusable(session: GoogleMeetSession, resolved: ResolvedGoogleMeetJoin): boolean;
+  isReusable(
+    session: GoogleMeetSession,
+    resolved: {
+      url: string;
+      transport: GoogleMeetTransport;
+      mode: GoogleMeetMode;
+      agentId: string;
+    },
+  ): boolean;
   hasHealthHandle(sessionId: string): boolean;
   refreshHealth(sessionId: string): void;
   refreshCaptionHealth(session: GoogleMeetSession): Promise<void>;
 };
-
-function resolveMode(request: GoogleMeetJoinRequest, config: GoogleMeetConfig) {
-  return request.mode === "realtime" ? "agent" : (request.mode ?? config.defaultMode);
-}
 
 function resolveProbeTimeoutMs(input: number | undefined, fallback: number): number {
   if (input === undefined) {
@@ -39,155 +37,45 @@ function resolveProbeTimeoutMs(input: number | undefined, fallback: number): num
   return Math.min(Math.trunc(input), 120_000);
 }
 
-export async function testGoogleMeetSpeech(
-  context: GoogleMeetRuntimeProbeContext,
-  request: GoogleMeetJoinRequest,
-) {
-  if (request.mode === "transcribe") {
-    throw new Error(
-      "test_speech requires mode: agent or bidi; use join mode: transcribe for observe-only sessions.",
-    );
-  }
-  const requestedMode = request.mode ? resolveMode(request, context.config) : undefined;
-  const mode =
-    requestedMode === "agent" || requestedMode === "bidi"
-      ? requestedMode
-      : context.config.defaultMode === "agent" || context.config.defaultMode === "bidi"
-        ? context.config.defaultMode
-        : "agent";
-  const resolved = {
-    url: normalizeMeetUrl(request.url),
-    transport: request.transport ?? context.config.defaultTransport,
-    mode,
-    agentId: context.resolveAgentId(request),
-  };
-  const beforeSessions = context.list();
-  const before = new Set(beforeSessions.map((session) => session.id));
-  const existing = beforeSessions.find((session) => context.isReusable(session, resolved));
-  const existingBaseline = {
-    outputBytes: existing?.chrome?.health?.lastOutputBytes ?? 0,
-    outputGeneration: existing?.chrome?.health?.outputGeneration ?? 0,
-  };
-  const result = await context.join({
-    ...request,
-    ...resolved,
-    message: request.message ?? "Say exactly: Google Meet speech test complete.",
-  });
-  const baseline =
-    existing?.id === result.session.id ? existingBaseline : { outputBytes: 0, outputGeneration: 0 };
-  let health = result.session.chrome?.health;
-  const verified = () =>
-    (health?.lastOutputBytes ?? 0) > baseline.outputBytes &&
-    (health?.outputGeneration ?? 0) > baseline.outputGeneration &&
-    health?.verifiedOutputGeneration === health?.outputGeneration;
-  const shouldWait =
-    result.spoken === true &&
-    health?.manualActionRequired !== true &&
-    context.hasHealthHandle(result.session.id);
-  if (shouldWait && !verified()) {
-    const deadline = Date.now() + Math.min(context.config.chrome.joinTimeoutMs, 5_000);
-    while (Date.now() < deadline) {
-      await sleep(100);
-      context.refreshHealth(result.session.id);
-      health = result.session.chrome?.health;
-      if (verified()) {
-        break;
-      }
-    }
-  }
-  const speechOutputVerified = verified();
-  return {
-    createdSession: !before.has(result.session.id),
-    inCall: health?.inCall,
-    manualActionRequired: health?.manualActionRequired,
-    manualActionReason: health?.manualActionReason,
-    manualActionMessage: health?.manualActionMessage,
-    spoken: result.spoken ?? false,
-    speechOutputVerified,
-    speechOutputTimedOut: shouldWait && !speechOutputVerified,
-    speechReady: health?.speechReady,
-    speechBlockedReason: health?.speechBlockedReason,
-    speechBlockedMessage: health?.speechBlockedMessage,
-    audioOutputActive: health?.audioOutputActive,
-    lastOutputBytes: health?.lastOutputBytes,
-    outputLoopbackSignalBytes: health?.outputLoopbackSignalBytes,
-    lastOutputLoopbackAt: health?.lastOutputLoopbackAt,
-    lastOutputLoopbackCorrelation: health?.lastOutputLoopbackCorrelation,
-    lastOutputLoopbackRms: health?.lastOutputLoopbackRms,
-    lastOutputLoopbackPeak: health?.lastOutputLoopbackPeak,
-    outputGeneration: health?.outputGeneration,
-    verifiedOutputGeneration: health?.verifiedOutputGeneration,
-    session: result.session,
-  };
-}
-
-export async function testGoogleMeetListening(
-  context: GoogleMeetRuntimeProbeContext,
-  request: GoogleMeetJoinRequest,
-) {
-  const requestedMode = request.mode ? resolveMode(request, context.config) : undefined;
-  if (requestedMode === "agent" || requestedMode === "bidi") {
-    throw new Error(
-      "test_listen requires mode: transcribe; use test_speech for talk-back sessions.",
-    );
-  }
-  const resolved = {
-    url: normalizeMeetUrl(request.url),
-    transport: request.transport ?? context.config.defaultTransport,
-    mode: "transcribe" as const,
-    agentId: context.resolveAgentId(request),
-  };
-  if (resolved.transport === "twilio") {
-    throw new Error("test_listen supports chrome or chrome-node transports");
-  }
-  const beforeSessions = context.list();
-  const before = new Set(beforeSessions.map((session) => session.id));
-  const existing = beforeSessions.find((session) => context.isReusable(session, resolved));
-  const start = {
-    lines: existing?.chrome?.health?.transcriptLines ?? 0,
-    at: existing?.chrome?.health?.lastCaptionAt,
-    text: existing?.chrome?.health?.lastCaptionText,
-  };
-  const result = await context.join({ ...request, ...resolved, message: undefined });
-  let health = result.session.chrome?.health;
-  const advanced = () =>
-    (health?.transcriptLines ?? 0) > (existing?.id === result.session.id ? start.lines : 0) ||
-    Boolean(health?.lastCaptionAt && health.lastCaptionAt !== start.at) ||
-    Boolean(health?.lastCaptionText && health.lastCaptionText !== start.text);
-  const shouldWait =
-    health?.manualActionRequired !== true &&
+const probes = MeetingPlatformAdapter.createRuntimeProbes<
+  GoogleMeetConfig,
+  GoogleMeetMode,
+  GoogleMeetTransport,
+  GoogleMeetChromeHealth,
+  GoogleMeetSession,
+  GoogleMeetJoinRequest
+>({
+  defaultSpeechMessage: "Say exactly: Google Meet speech test complete.",
+  invalidRequest: (message) => new Error(message),
+  resolveTimeoutMs: resolveProbeTimeoutMs,
+  shouldWaitForListening: (session) =>
     Boolean(
-      (result.session.transport === "chrome" || result.session.transport === "chrome-node") &&
-      result.session.chrome?.launched,
-    );
-  if (shouldWait && !advanced()) {
-    const deadline =
-      Date.now() + resolveProbeTimeoutMs(request.timeoutMs, context.config.chrome.joinTimeoutMs);
-    while (Date.now() < deadline) {
-      await sleep(250);
-      await context.refreshCaptionHealth(result.session);
-      health = result.session.chrome?.health;
-      if (health?.manualActionRequired || advanced()) {
-        break;
-      }
+      (session.transport === "chrome" || session.transport === "chrome-node") &&
+      session.chrome?.launched,
+    ),
+  talkBackMode: (mode) => mode === "agent" || mode === "bidi",
+  normalizeUrl: normalizeMeetUrl,
+  resolveRequestMode: (mode) => (mode === "realtime" ? "agent" : mode),
+  defaultTransport: (config) => config.defaultTransport,
+  validateListeningTransport: (transport) => {
+    if (transport === "twilio") {
+      throw new Error("test_listen supports chrome or chrome-node transports");
     }
-  }
-  const listenVerified = advanced();
-  return {
-    createdSession: !before.has(result.session.id),
-    inCall: health?.inCall,
-    manualActionRequired: health?.manualActionRequired,
-    manualActionReason: health?.manualActionReason,
-    manualActionMessage: health?.manualActionMessage,
-    listenVerified,
-    listenTimedOut: shouldWait && !listenVerified && health?.manualActionRequired !== true,
-    captioning: health?.captioning,
-    captionsEnabledAttempted: health?.captionsEnabledAttempted,
-    transcriptLines: health?.transcriptLines,
-    lastCaptionAt: health?.lastCaptionAt,
-    lastCaptionSpeaker: health?.lastCaptionSpeaker,
-    lastCaptionText: health?.lastCaptionText,
-    recentTranscript: health?.recentTranscript,
-    session: result.session,
-  };
-}
+  },
+  resolveSpeechTimeoutMs: (_request, config) => Math.min(config.chrome.joinTimeoutMs, 5_000),
+  refreshCaptionHealth: async (context, session) => await context.refreshCaptionHealth(session),
+  speechModeError:
+    "test_speech requires mode: agent or bidi; use join mode: transcribe for observe-only sessions.",
+  listeningModeError:
+    "test_listen requires mode: transcribe; use test_speech for talk-back sessions.",
+});
+
+export const testGoogleMeetListening: (
+  context: GoogleMeetRuntimeProbeContext,
+  request: GoogleMeetJoinRequest,
+) => ReturnType<typeof probes.testListening> = probes.testListening;
+
+export const testGoogleMeetSpeech: (
+  context: GoogleMeetRuntimeProbeContext,
+  request: GoogleMeetJoinRequest,
+) => ReturnType<typeof probes.testSpeech> = probes.testSpeech;

--- a/extensions/google-meet/src/transports/google-meet-platform-adapter.ts
+++ b/extensions/google-meet/src/transports/google-meet-platform-adapter.ts
@@ -58,18 +58,18 @@ function parsePermissionGrantNotes(result: unknown): string[] {
   return notes;
 }
 
-const manualActionCategories: Record<string, MeetingManualActionCategory> = {
-  "browser-control-unavailable": "browser-control-unavailable",
-  "google-login-required": "login-required",
-  "meet-admission-required": "admission-required",
-  "meet-audio-choice-required": "audio-choice-required",
-  "meet-locale-required": "locale-required",
-  "meet-permission-required": "permission-required",
-  "meet-session-conflict": "session-conflict",
-};
+const manualActionCategories = new Map<string, MeetingManualActionCategory>([
+  ["browser-control-unavailable", "browser-control-unavailable"],
+  ["google-login-required", "login-required"],
+  ["meet-admission-required", "admission-required"],
+  ["meet-audio-choice-required", "audio-choice-required"],
+  ["meet-locale-required", "locale-required"],
+  ["meet-permission-required", "permission-required"],
+  ["meet-session-conflict", "session-conflict"],
+]);
 
 function classifyManualActionReason(reason: string): MeetingManualActionCategory {
-  return Object.hasOwn(manualActionCategories, reason) ? manualActionCategories[reason] : "custom";
+  return manualActionCategories.get(reason) ?? "custom";
 }
 
 export const GOOGLE_MEET_PLATFORM_ADAPTER = MeetingPlatformAdapter.create<

--- a/extensions/google-meet/src/transports/google-meet-platform-adapter.ts
+++ b/extensions/google-meet/src/transports/google-meet-platform-adapter.ts
@@ -69,7 +69,7 @@ const manualActionCategories: Record<string, MeetingManualActionCategory> = {
 };
 
 function classifyManualActionReason(reason: string): MeetingManualActionCategory {
-  return manualActionCategories[reason] ?? "custom";
+  return Object.hasOwn(manualActionCategories, reason) ? manualActionCategories[reason] : "custom";
 }
 
 export const GOOGLE_MEET_PLATFORM_ADAPTER = MeetingPlatformAdapter.create<

--- a/extensions/google-meet/src/transports/google-meet-platform-adapter.ts
+++ b/extensions/google-meet/src/transports/google-meet-platform-adapter.ts
@@ -1,9 +1,9 @@
 // Google Meet adapter: platform URL, DOM, wire-value, and manual-action ownership.
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
-import type {
-  MeetingBrowserJoinSession,
-  MeetingManualActionCategory,
+import {
   MeetingPlatformAdapter,
+  type MeetingBrowserJoinSession,
+  type MeetingManualActionCategory,
 } from "openclaw/plugin-sdk/meeting-runtime";
 import type { PluginRuntime } from "openclaw/plugin-sdk/plugin-runtime";
 import type { GoogleMeetConfig, GoogleMeetMode } from "../config.js";
@@ -46,66 +46,6 @@ export function isGoogleMeetTalkBackMode(mode: GoogleMeetMode): boolean {
   return mode === "agent" || mode === "bidi";
 }
 
-function parseMeetBrowserStatus(result: unknown): GoogleMeetChromeHealth | undefined {
-  const record = result && typeof result === "object" ? (result as Record<string, unknown>) : {};
-  const raw = record.result;
-  if (typeof raw !== "string" || !raw.trim()) {
-    return undefined;
-  }
-  let parsed: {
-    inCall?: boolean;
-    micMuted?: boolean;
-    lobbyWaiting?: boolean;
-    leaveReason?: string;
-    captioning?: boolean;
-    captionsEnabledAttempted?: boolean;
-    transcriptLines?: number;
-    lastCaptionAt?: string;
-    lastCaptionSpeaker?: string;
-    lastCaptionText?: string;
-    recentTranscript?: GoogleMeetChromeHealth["recentTranscript"];
-    audioOutputRouted?: boolean;
-    audioOutputDeviceLabel?: string;
-    audioOutputRouteError?: string;
-    manualActionRequired?: boolean;
-    manualActionReason?: GoogleMeetChromeHealth["manualActionReason"];
-    manualActionMessage?: string;
-    url?: string;
-    title?: string;
-    notes?: string[];
-  };
-  try {
-    parsed = JSON.parse(raw) as typeof parsed;
-  } catch {
-    throw new Error("Google Meet browser status JSON is malformed.");
-  }
-  return {
-    inCall: parsed.inCall,
-    micMuted: parsed.micMuted,
-    lobbyWaiting: parsed.lobbyWaiting,
-    leaveReason: parsed.leaveReason,
-    captioning: parsed.captioning,
-    captionsEnabledAttempted: parsed.captionsEnabledAttempted,
-    transcriptLines: parsed.transcriptLines,
-    lastCaptionAt: parsed.lastCaptionAt,
-    lastCaptionSpeaker: parsed.lastCaptionSpeaker,
-    lastCaptionText: parsed.lastCaptionText,
-    recentTranscript: parsed.recentTranscript,
-    audioOutputRouted: parsed.audioOutputRouted,
-    audioOutputDeviceLabel: parsed.audioOutputDeviceLabel,
-    audioOutputRouteError: parsed.audioOutputRouteError,
-    manualActionRequired: parsed.manualActionRequired,
-    manualActionReason: parsed.manualActionReason,
-    manualActionMessage: parsed.manualActionMessage,
-    browserUrl: parsed.url,
-    browserTitle: parsed.title,
-    status: "browser-control",
-    notes: Array.isArray(parsed.notes)
-      ? parsed.notes.filter((note): note is string => typeof note === "string")
-      : undefined,
-  };
-}
-
 function parsePermissionGrantNotes(result: unknown): string[] {
   const record = result && typeof result === "object" ? (result as Record<string, unknown>) : {};
   const unsupportedPermissions = Array.isArray(record.unsupportedPermissions)
@@ -118,123 +58,30 @@ function parsePermissionGrantNotes(result: unknown): string[] {
   return notes;
 }
 
-function parseMeetTranscriptSnapshot(
-  result: unknown,
-): GoogleMeetTranscriptSnapshot & { sessionMatched?: boolean; urlMatched?: boolean } {
-  const record = result && typeof result === "object" ? (result as Record<string, unknown>) : {};
-  const raw = record.result;
-  if (typeof raw !== "string" || !raw.trim()) {
-    return { droppedLines: 0, lines: [] };
-  }
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw);
-  } catch {
-    throw new Error("Google Meet transcript JSON is malformed.");
-  }
-  if (!parsed || typeof parsed !== "object") {
-    throw new Error("Google Meet transcript payload is invalid.");
-  }
-  const payload = parsed as {
-    droppedLines?: unknown;
-    epoch?: unknown;
-    lines?: unknown;
-    sessionMatched?: unknown;
-    urlMatched?: unknown;
-  };
-  const droppedLines =
-    typeof payload.droppedLines === "number" && Number.isSafeInteger(payload.droppedLines)
-      ? Math.max(0, payload.droppedLines)
-      : 0;
-  const lines = Array.isArray(payload.lines)
-    ? payload.lines.flatMap((value) => {
-        if (!value || typeof value !== "object") {
-          return [];
-        }
-        const line = value as { at?: unknown; speaker?: unknown; text?: unknown };
-        if (typeof line.text !== "string" || !line.text.trim()) {
-          return [];
-        }
-        return [
-          {
-            ...(typeof line.at === "string" ? { at: line.at } : {}),
-            ...(typeof line.speaker === "string" ? { speaker: line.speaker } : {}),
-            text: line.text,
-          },
-        ];
-      })
-    : [];
-  return {
-    droppedLines,
-    ...(typeof payload.epoch === "string" ? { epoch: payload.epoch } : {}),
-    lines,
-    ...(typeof payload.urlMatched === "boolean" ? { urlMatched: payload.urlMatched } : {}),
-    ...(typeof payload.sessionMatched === "boolean"
-      ? { sessionMatched: payload.sessionMatched }
-      : {}),
-  };
+const manualActionCategories: Record<string, MeetingManualActionCategory> = {
+  "browser-control-unavailable": "browser-control-unavailable",
+  "google-login-required": "login-required",
+  "meet-admission-required": "admission-required",
+  "meet-audio-choice-required": "audio-choice-required",
+  "meet-locale-required": "locale-required",
+  "meet-permission-required": "permission-required",
+  "meet-session-conflict": "session-conflict",
+};
+
+function classifyManualActionReason(reason: string): MeetingManualActionCategory {
+  return manualActionCategories[reason] ?? "custom";
 }
 
-function parseMeetLeaveResult(result: unknown): {
-  departed: boolean;
-  leaveAction?: "leave" | "confirm";
-  urlMatched?: boolean;
-} {
-  const record = result && typeof result === "object" ? (result as Record<string, unknown>) : {};
-  const raw = record.result;
-  if (typeof raw !== "string" || !raw.trim()) {
-    return { departed: false };
-  }
-  try {
-    const parsed = JSON.parse(raw) as {
-      departed?: boolean;
-      leaveAction?: string;
-      urlMatched?: boolean;
-    };
-    const leaveAction =
-      parsed.leaveAction === "leave" || parsed.leaveAction === "confirm"
-        ? parsed.leaveAction
-        : undefined;
-    return {
-      departed: parsed.departed === true,
-      ...(leaveAction ? { leaveAction } : {}),
-      ...(typeof parsed.urlMatched === "boolean" ? { urlMatched: parsed.urlMatched } : {}),
-    };
-  } catch {
-    return { departed: false };
-  }
-}
-
-function classifyMeetManualAction(
-  health: GoogleMeetChromeHealth,
-): { category: MeetingManualActionCategory; reason: string; message: string } | undefined {
-  if (!health.manualActionRequired || !health.manualActionReason || !health.manualActionMessage) {
-    return undefined;
-  }
-  const category: MeetingManualActionCategory =
-    health.manualActionReason === "google-login-required"
-      ? "login-required"
-      : health.manualActionReason === "meet-admission-required"
-        ? "admission-required"
-        : health.manualActionReason === "meet-permission-required"
-          ? "permission-required"
-          : health.manualActionReason === "meet-audio-choice-required"
-            ? "audio-choice-required"
-            : health.manualActionReason === "meet-locale-required"
-              ? "locale-required"
-              : health.manualActionReason === "meet-session-conflict"
-                ? "session-conflict"
-                : health.manualActionReason === "browser-control-unavailable"
-                  ? "browser-control-unavailable"
-                  : "custom";
-  return {
-    category,
-    reason: health.manualActionReason,
-    message: health.manualActionMessage,
-  };
-}
-
-export const GOOGLE_MEET_PLATFORM_ADAPTER = {
+export const GOOGLE_MEET_PLATFORM_ADAPTER = MeetingPlatformAdapter.create<
+  MeetingBrowserJoinSession<GoogleMeetMode>,
+  GoogleMeetMode,
+  GoogleMeetChromeHealth,
+  GoogleMeetTranscriptSnapshot,
+  { runtime: PluginRuntime; config: GoogleMeetConfig },
+  Awaited<ReturnType<typeof createMeetWithBrowserProxyOnNode>>,
+  GoogleMeetDialInParams,
+  GoogleMeetDialInPlan
+>({
   id: "google-meet",
   displayName: "Google Meet",
   browserLabel: "Meet",
@@ -296,8 +143,6 @@ export const GOOGLE_MEET_PLATFORM_ADAPTER = {
         guestName: params.guestName,
         readOnly: params.readOnly,
       }),
-    parseStatus: parseMeetBrowserStatus,
-    classifyManualAction: classifyMeetManualAction,
     browserControlUnavailable: () => ({
       category: "browser-control-unavailable",
       reason: "browser-control-unavailable",
@@ -305,14 +150,12 @@ export const GOOGLE_MEET_PLATFORM_ADAPTER = {
         "Open the OpenClaw browser profile, finish Google Meet login, admission, or permission prompts, then retry.",
     }),
     buildLeaveScript: meetLeaveScript,
-    parseLeaveResult: parseMeetLeaveResult,
     captions: {
       // Durable notes observe the caption stream in every mode; live transcript
       // visibility remains gated by MeetingSessionRuntime.
       enabled: (_mode) => true,
       buildTranscriptScript: ({ finalize, meetingSessionId, meetingUrl }) =>
         meetTranscriptScript(meetingUrl, meetingSessionId, finalize),
-      parseTranscript: parseMeetTranscriptSnapshot,
     },
     permissions: ({ allowMicrophone }) =>
       allowMicrophone
@@ -352,13 +195,14 @@ export const GOOGLE_MEET_PLATFORM_ADAPTER = {
       return { number, pin, dtmfSequence };
     },
   },
-} satisfies MeetingPlatformAdapter<
-  MeetingBrowserJoinSession<GoogleMeetMode>,
-  GoogleMeetMode,
-  GoogleMeetChromeHealth,
-  GoogleMeetTranscriptSnapshot,
-  { runtime: PluginRuntime; config: GoogleMeetConfig },
-  Awaited<ReturnType<typeof createMeetWithBrowserProxyOnNode>>,
-  GoogleMeetDialInParams,
-  GoogleMeetDialInPlan
->;
+  parsing: {
+    classifyManualActionReason,
+    displayName: "Meet",
+    invalidTranscriptMessage: "Google Meet transcript payload is invalid.",
+    malformedStatusMessage: "Google Meet browser status JSON is malformed.",
+    malformedTranscriptMessage: "Google Meet transcript JSON is malformed.",
+    statusFields: (parsed) => ({
+      leaveReason: typeof parsed.leaveReason === "string" ? parsed.leaveReason : undefined,
+    }),
+  },
+});

--- a/src/meeting-bot/platform-adapter.ts
+++ b/src/meeting-bot/platform-adapter.ts
@@ -73,6 +73,7 @@ type MeetingPlatformAdapterOptions<
     "captions" | "classifyManualAction" | "parseLeaveResult" | "parseStatus" | "permissionNotes"
   > & {
     captions: Omit<MeetingBrowserAdapter<Mode, Health, Transcript>["captions"], "parseTranscript">;
+    permissionNotes?: MeetingBrowserAdapter<Mode, Health, Transcript>["permissionNotes"];
   };
   parsing: {
     classifyManualActionReason(reason: string): MeetingManualActionCategory;
@@ -328,32 +329,34 @@ function createMeetingPlatformAdapter<
         ...browser.captions,
         parseTranscript: (result) => parseMeetingTranscript(result, parsing),
       },
-      permissionNotes: ({ allowMicrophone, error, result }) => {
-        if (!allowMicrophone) {
-          return [`Observe-only mode does not request ${parsing.displayName} microphone access.`];
-        }
-        if (error) {
-          return [
-            `Could not grant ${parsing.displayName} media permissions automatically: ${formatErrorMessage(error)}`,
+      permissionNotes:
+        browser.permissionNotes ??
+        (({ allowMicrophone, error, result }) => {
+          if (!allowMicrophone) {
+            return [`Observe-only mode does not request ${parsing.displayName} microphone access.`];
+          }
+          if (error) {
+            return [
+              `Could not grant ${parsing.displayName} media permissions automatically: ${formatErrorMessage(error)}`,
+            ];
+          }
+          const record =
+            result && typeof result === "object" ? (result as Record<string, unknown>) : {};
+          const unsupportedPermissions = Array.isArray(record.unsupportedPermissions)
+            ? record.unsupportedPermissions.filter(
+                (value): value is string => typeof value === "string",
+              )
+            : [];
+          const notes = [
+            `Granted ${parsing.displayName} microphone permission through browser control.`,
           ];
-        }
-        const record =
-          result && typeof result === "object" ? (result as Record<string, unknown>) : {};
-        const unsupportedPermissions = Array.isArray(record.unsupportedPermissions)
-          ? record.unsupportedPermissions.filter(
-              (value): value is string => typeof value === "string",
-            )
-          : [];
-        const notes = [
-          `Granted ${parsing.displayName} microphone permission through browser control.`,
-        ];
-        if (unsupportedPermissions.includes("speakerSelection")) {
-          notes.push(
-            `Chrome did not accept the optional ${parsing.displayName} speaker-selection permission.`,
-          );
-        }
-        return notes;
-      },
+          if (unsupportedPermissions.includes("speakerSelection")) {
+            notes.push(
+              `Chrome did not accept the optional ${parsing.displayName} speaker-selection permission.`,
+            );
+          }
+          return notes;
+        }),
     },
   };
 }

--- a/src/meeting-bot/runtime-probes.test.ts
+++ b/src/meeting-bot/runtime-probes.test.ts
@@ -33,16 +33,25 @@ type Config = {
 
 const cases = [
   {
+    name: "Google Meet",
+    invalidRequestName: "Error",
+    session: { id: "google", chrome: { launched: true } } satisfies Session,
+    shouldWaitForListening: (session: Session) => Boolean(session.chrome?.launched),
+    waitsForListening: true,
+  },
+  {
     name: "Teams",
     invalidRequestName: "Error",
     session: { id: "teams", chrome: { launched: true } } satisfies Session,
     shouldWaitForListening: (session: Session) => Boolean(session.chrome?.launched),
+    waitsForListening: true,
   },
   {
     name: "Zoom",
     invalidRequestName: "ZoomInvalidRequest",
     session: { id: "zoom", chrome: { launched: true } } satisfies Session,
     shouldWaitForListening: (session: Session) => Boolean(session.chrome?.browserTab?.targetId),
+    waitsForListening: false,
   },
 ] as const;
 
@@ -102,7 +111,7 @@ describe.each(cases)("$name meeting runtime probe parity", (testCase) => {
       timeoutMs: 5,
     });
 
-    if (testCase.name === "Teams") {
+    if (testCase.waitsForListening) {
       expect(refreshCaptionHealth).toHaveBeenCalled();
     } else {
       expect(refreshCaptionHealth).not.toHaveBeenCalled();

--- a/src/meeting-bot/runtime-probes.ts
+++ b/src/meeting-bot/runtime-probes.ts
@@ -29,10 +29,10 @@ type MeetingProbeSession<Health extends MeetingProbeHealth> = {
   };
 };
 
-type MeetingProbeRequest<Mode extends string, Transport extends string> = {
+type MeetingProbeRequest<Transport extends string> = {
   agentId?: string;
   message?: string;
-  mode?: Mode;
+  mode?: string;
   timeoutMs?: number;
   transport?: Transport;
   url: string;
@@ -50,7 +50,7 @@ type MeetingProbeContext<
   Transport extends string,
   Health extends MeetingProbeHealth,
   Session extends MeetingProbeSession<Health>,
-  Request extends MeetingProbeRequest<Mode, Transport>,
+  Request extends MeetingProbeRequest<Transport>,
 > = {
   config: Config;
   resolveAgentId(request: Request): string;
@@ -62,7 +62,7 @@ type MeetingProbeContext<
   ): boolean;
   hasHealthHandle(sessionId: string): boolean;
   refreshHealth(sessionId: string): void;
-  refreshCaptionHealth(session: Session, timeoutMs: number): Promise<void>;
+  refreshCaptionHealth(session: Session, timeoutMs?: number): Promise<void>;
 };
 
 type MeetingRuntimeProbeOptions<
@@ -83,20 +83,41 @@ export function createMeetingRuntimeProbes<
   Transport extends string,
   Health extends MeetingProbeHealth,
   Session extends MeetingProbeSession<Health>,
-  Request extends MeetingProbeRequest<Mode, Transport>,
->(options: MeetingRuntimeProbeOptions<Mode, Health, Session>) {
+  Request extends MeetingProbeRequest<Transport>,
+>(
+  options: MeetingRuntimeProbeOptions<Mode, Health, Session> & {
+    normalizeUrl?(url: string): string;
+    resolveRequestMode?(mode: Request["mode"], config: Config): Mode | undefined;
+    defaultTransport?(config: Config): Transport;
+    validateListeningTransport?(transport: Transport): void;
+    resolveSpeechTimeoutMs?(request: Request, config: Config): number;
+    refreshCaptionHealth?(
+      context: MeetingProbeContext<Config, Mode, Transport, Health, Session, Request>,
+      session: Session,
+      timeoutMs: number,
+    ): Promise<void>;
+    speechModeError?: string;
+    listeningModeError?: string;
+  },
+) {
   type Context = MeetingProbeContext<Config, Mode, Transport, Health, Session, Request>;
 
   const testSpeech = async (context: Context, request: Request) => {
-    if (request.mode === "transcribe") {
-      throw options.invalidRequest("test_speech requires mode: agent or bidi");
+    const requestMode =
+      options.resolveRequestMode?.(request.mode, context.config) ??
+      (request.mode as Mode | undefined);
+    if (requestMode === "transcribe") {
+      throw options.invalidRequest(
+        options.speechModeError ?? "test_speech requires mode: agent or bidi",
+      );
     }
-    const requestedMode = request.mode ?? context.config.defaultMode;
+    const requestedMode = requestMode ?? context.config.defaultMode;
     const mode = options.talkBackMode(requestedMode) ? requestedMode : ("agent" as Mode);
     const resolved = {
-      url: request.url,
+      url: options.normalizeUrl?.(request.url) ?? request.url,
       transport:
         request.transport ??
+        options.defaultTransport?.(context.config) ??
         (context.config.chromeNode.node ? ("chrome-node" as Transport) : ("chrome" as Transport)),
       mode,
       agentId: context.resolveAgentId(request),
@@ -129,7 +150,8 @@ export function createMeetingRuntimeProbes<
     if (shouldWait && !verified()) {
       const deadline =
         Date.now() +
-        options.resolveTimeoutMs(request.timeoutMs, context.config.chrome.joinTimeoutMs);
+        (options.resolveSpeechTimeoutMs?.(request, context.config) ??
+          options.resolveTimeoutMs(request.timeoutMs, context.config.chrome.joinTimeoutMs));
       while (Date.now() < deadline && !verified()) {
         await sleep(100);
         context.refreshHealth(result.session.id);
@@ -163,17 +185,24 @@ export function createMeetingRuntimeProbes<
   };
 
   const testListening = async (context: Context, request: Request) => {
-    if (request.mode && request.mode !== "transcribe") {
-      throw options.invalidRequest("test_listen requires mode: transcribe");
+    const requestMode =
+      options.resolveRequestMode?.(request.mode, context.config) ??
+      (request.mode as Mode | undefined);
+    if (requestMode && requestMode !== "transcribe") {
+      throw options.invalidRequest(
+        options.listeningModeError ?? "test_listen requires mode: transcribe",
+      );
     }
     const resolved = {
-      url: request.url,
+      url: options.normalizeUrl?.(request.url) ?? request.url,
       transport:
         request.transport ??
+        options.defaultTransport?.(context.config) ??
         (context.config.chromeNode.node ? ("chrome-node" as Transport) : ("chrome" as Transport)),
       mode: "transcribe" as Mode,
       agentId: context.resolveAgentId(request),
     };
+    options.validateListeningTransport?.(resolved.transport);
     const beforeSessions = context.list();
     const before = new Set(beforeSessions.map((session) => session.id));
     const existing = beforeSessions.find((session) => context.isReusable(session, resolved));
@@ -205,7 +234,10 @@ export function createMeetingRuntimeProbes<
           deadlineTimer = setTimeout(() => resolve(false), remainingMs);
         });
         const refreshed = await Promise.race([
-          context.refreshCaptionHealth(result.session, remainingMs).then(() => true),
+          (
+            options.refreshCaptionHealth?.(context, result.session, remainingMs) ??
+            context.refreshCaptionHealth(result.session, remainingMs)
+          ).then(() => true),
           deadlineReached,
         ]).finally(() => {
           if (deadlineTimer !== undefined) {


### PR DESCRIPTION
## What Problem This Solves

Google Meet still carried private copies of the runtime speech/listening probe state machine and the browser status, transcript, and leave-result parsers that Teams and Zoom already share. Those copies made a shared meeting-runtime fix easy to apply to only two of the three platforms.

## Why This Change Was Made

This maintainer-directed refactor continues the meeting convergence established by #112900, #112931, and #112992. Google Meet now uses the shared `MeetingPlatformAdapter` runtime probes and result parsers, with narrow typed hooks preserving its real platform deltas: URL normalization, configured default transport, Twilio listening rejection, fixed five-second speech verification window, one-argument caption refresh, legacy `realtime` mode normalization, Meet-only status fields, and camera-permission wording.

The in-page Google Meet status source remains platform-owned and unchanged; this does not move DOM strings into core or add config, protocol, or SDK exports.

## User Impact

No user-visible behavior changes. Google Meet retains its existing probe modes, timeouts, transport validation, caption refresh, permission messages, status fields, transcript parsing, and leave behavior while sharing the common implementation with Teams and Zoom.

## Evidence

- `node scripts/run-vitest.mjs src/meeting-bot extensions/google-meet extensions/teams-meetings/src/runtime-probes.test.ts extensions/zoom-meetings/src/runtime-probes.test.ts`: 14 core files / 85 tests and 23 extension files / 311 tests passed.
- Final targeted probe/adapter proof: 6 shared runtime parity tests plus 265 Google Meet, Teams, and Zoom tests passed; all three adapter suites separately passed 93 tests after the final parser-map correction.
- `node scripts/check-changed.mjs`: passed all selected core/extension typecheck, lint, Plugin SDK, import-cycle, schema, and boundary gates on Blacksmith Testbox `tbx_01kye0caykcs3k2d83e6394pm6` (Actions run 30182839239).
- Exact-head PR CI: run 30183481269 attempt 2 passed all selected jobs, including `openclaw/ci-gate`; attempt 1 had one unrelated `test-live-shard` descendant-cleanup timeout among 1,622 tooling tests and passed unchanged on retry.
- `autoreview --mode branch --base origin/main`: clean, no accepted/actionable findings after fixing legacy `realtime` alias parity and prototype-safe manual-action classification.
- Net LOC: -221 overall (-233 non-test). `google-meet-page-scripts.ts` and `CHANGELOG.md` are unchanged.
- Maintainer proof decision: accept the focused parity suites and exact-head hosted gates for this internal behavior-neutral refactor. A live meeting run is intentionally skipped because the external Google API and in-page status source are unchanged; the refactored probe/parser branches are covered directly across Google Meet, Teams, and Zoom.

AI-assisted; the shared owner boundary and each Google-specific hook were reviewed against the unchanged three-platform suites.
