### PR TITLE
feat(providers): refresh onboarding defaults to current models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
-- **Provider onboarding defaults:** fresh DeepSeek, Together, and Venice setup now selects each vendor's current recommended model instead of the previous fast, legacy, or superseded default.
 - **Control UI cloud workspace conflicts:** surface staged-ref guidance, bounded conflicted paths, structured transcript events, and sidebar attention for cloud worker results that kept local versions.
 - **Control UI update recovery:** the "A new version is available" Reload button now waits out the gateway restart that stranded the chunk and reloads as soon as it answers, instead of silently doing nothing and leaving a manual hard reload as the only way out.
 - **Control UI sender identity polish:** attributed user messages show the author's real avatar in an always-visible gutter on identity-resolving gateways, sender labels drop the opaque profile-UUID suffix (new and historical transcripts), and profile-id senders resolve avatars through the canonical gateway route.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- **Provider onboarding defaults:** fresh DeepSeek, Together, and Venice setup now selects each vendor's current recommended model instead of the previous fast, legacy, or superseded default.
 - **Control UI cloud workspace conflicts:** surface staged-ref guidance, bounded conflicted paths, structured transcript events, and sidebar attention for cloud worker results that kept local versions.
 - **Control UI update recovery:** the "A new version is available" Reload button now waits out the gateway restart that stranded the chunk and reloads as soon as it answers, instead of silently doing nothing and leaving a manual hard reload as the only way out.
 - **Control UI sender identity polish:** attributed user messages show the author's real avatar in an always-visible gutter on identity-resolving gateways, sender labels drop the opaque profile-UUID suffix (new and historical transcripts), and profile-id senders resolve avatars through the canonical gateway route.

--- a/docs/providers/deepseek.md
+++ b/docs/providers/deepseek.md
@@ -35,7 +35,7 @@ openclaw gateway restart
     openclaw onboard --auth-choice deepseek-api-key
     ```
 
-    Prompts for your API key and sets `deepseek/deepseek-v4-flash` as the default model.
+    Prompts for your API key and sets `deepseek/deepseek-v4-pro` as the default model.
 
   </Step>
   <Step title="Verify models are available">
@@ -76,10 +76,10 @@ available to that process (for example, in `~/.openclaw/.env` or via
 
 ## Built-in catalog
 
-| Model ref                    | Name              | Input | Context   | Max output | Notes                                      |
-| ---------------------------- | ----------------- | ----- | --------- | ---------- | ------------------------------------------ |
-| `deepseek/deepseek-v4-flash` | DeepSeek V4 Flash | text  | 1,000,000 | 384,000    | Default model; V4 thinking-capable surface |
-| `deepseek/deepseek-v4-pro`   | DeepSeek V4 Pro   | text  | 1,000,000 | 384,000    | V4 thinking-capable surface                |
+| Model ref                    | Name              | Input | Context   | Max output | Notes                            |
+| ---------------------------- | ----------------- | ----- | --------- | ---------- | -------------------------------- |
+| `deepseek/deepseek-v4-flash` | DeepSeek V4 Flash | text  | 1,000,000 | 384,000    | Fast V4 thinking-capable surface |
+| `deepseek/deepseek-v4-pro`   | DeepSeek V4 Pro   | text  | 1,000,000 | 384,000    | Default; strongest V4 model      |
 
 <Warning>
 DeepSeek retired `deepseek-chat` and `deepseek-reasoner` on July 24, 2026 at
@@ -114,9 +114,9 @@ When thinking is disabled (including the UI **None** selection), OpenClaw
 sends `thinking: { type: "disabled" }` and strips replayed `reasoning_content`
 from outgoing history, keeping the session on the non-thinking DeepSeek path.
 
-Use `deepseek/deepseek-v4-flash` for the default fast path. Use
-`deepseek/deepseek-v4-pro` for the stronger model when you can accept higher
-cost or latency.
+Fresh onboarding selects the stronger `deepseek/deepseek-v4-pro` model. Use
+`deepseek/deepseek-v4-flash` when lower cost or latency matters more than
+maximum capability.
 
 ## Live testing
 
@@ -138,7 +138,7 @@ preserve the replay payload DeepSeek requires.
   env: { DEEPSEEK_API_KEY: "sk-..." },
   agents: {
     defaults: {
-      model: { primary: "deepseek/deepseek-v4-flash" },
+      model: { primary: "deepseek/deepseek-v4-pro" },
     },
   },
 }

--- a/docs/providers/together.md
+++ b/docs/providers/together.md
@@ -35,7 +35,7 @@ OpenClaw bundles it as the `together` provider.
       agents: {
         defaults: {
           model: {
-            primary: "together/meta-llama/Llama-3.3-70B-Instruct-Turbo",
+            primary: "together/moonshotai/Kimi-K2.6",
           },
         },
       },
@@ -54,8 +54,8 @@ openclaw onboard --non-interactive \
 ```
 
 <Note>
-Onboarding sets `together/meta-llama/Llama-3.3-70B-Instruct-Turbo` as the
-default model.
+Onboarding sets Together's recommended chat model,
+`together/moonshotai/Kimi-K2.6`, as the default.
 </Note>
 
 ## Built-in catalog
@@ -64,8 +64,8 @@ Cost is USD per million tokens.
 
 | Model ref                                          | Name                         | Input       | Context | Max output | Cost (in/out) | Notes           |
 | -------------------------------------------------- | ---------------------------- | ----------- | ------- | ---------- | ------------- | --------------- |
-| `together/meta-llama/Llama-3.3-70B-Instruct-Turbo` | Llama 3.3 70B Instruct Turbo | text        | 131,072 | 8,192      | 1.04 / 1.04   | Default model   |
-| `together/moonshotai/Kimi-K2.6`                    | Kimi K2.6 FP4                | text, image | 262,144 | 32,768     | 1.20 / 4.50   | Reasoning model |
+| `together/meta-llama/Llama-3.3-70B-Instruct-Turbo` | Llama 3.3 70B Instruct Turbo | text        | 131,072 | 8,192      | 1.04 / 1.04   | General model   |
+| `together/moonshotai/Kimi-K2.6`                    | Kimi K2.6 FP4                | text, image | 262,144 | 32,768     | 1.20 / 4.50   | Default model   |
 | `together/deepseek-ai/DeepSeek-V4-Pro`             | DeepSeek V4 Pro              | text        | 512,000 | 384,000    | 1.74 / 3.48   | Reasoning model |
 | `together/zai-org/GLM-5.2`                         | GLM 5.2 FP4                  | text        | 262,144 | 131,072    | 1.40 / 4.40   | Reasoning model |
 

--- a/docs/providers/venice.md
+++ b/docs/providers/venice.md
@@ -60,18 +60,18 @@ Anonymized models are not fully private. Venice strips metadata before forwardin
   </Step>
   <Step title="Verify setup">
     ```bash
-    openclaw agent --model venice/kimi-k2-6 --message "Hello, are you working?"
+    openclaw agent --model venice/zai-org-glm-4.7 --message "Hello, are you working?"
     ```
   </Step>
 </Steps>
 
 ## Model selection
 
-- **Default**: `venice/kimi-k2-6` (private, reasoning, vision).
+- **Default**: `venice/zai-org-glm-4.7` (private reasoning).
 - **Strongest anonymized option**: `venice/claude-opus-5`.
 
 ```bash
-openclaw models set venice/kimi-k2-6
+openclaw models set venice/zai-org-glm-4.7
 openclaw models list --all --provider venice
 ```
 
@@ -80,7 +80,7 @@ You can also run `openclaw configure` and pick **Model/auth provider > Venice AI
 <Tip>
 | Use case              | Model                                        | Why                                    |
 | --------------------- | -------------------------------------------- | -------------------------------------- |
-| General chat (default) | `kimi-k2-6`                                  | Current promoted private Kimi model    |
+| General chat (default) | `zai-org-glm-4.7`                             | Venice live default trait              |
 | Best overall quality   | `claude-opus-5`                              | Current promoted anonymized Opus model |
 | Privacy + coding       | `qwen3-coder-480b-a35b-instruct-turbo`       | Private coding model with large context |
 | Fast + cheap           | `google-gemma-4-31b-it`                      | Low-cost promoted private vision model |
@@ -168,7 +168,7 @@ direct API pricing plus a small Venice fee. See
 
 ```bash
 # Default private model
-openclaw agent --model venice/kimi-k2-6 --message "Quick health check"
+openclaw agent --model venice/zai-org-glm-4.7 --message "Quick health check"
 
 # Claude Opus via Venice (anonymized)
 openclaw agent --model venice/claude-opus-5 --message "Summarize this task"
@@ -217,7 +217,7 @@ More help: [Troubleshooting](/help/troubleshooting) and [FAQ](/help/faq).
     ```json5
     {
       env: { VENICE_API_KEY: "vapi_..." },
-      agents: { defaults: { model: { primary: "venice/kimi-k2-6" } } },
+      agents: { defaults: { model: { primary: "venice/zai-org-glm-4.7" } } },
       models: {
         mode: "merge",
         providers: {
@@ -227,13 +227,13 @@ More help: [Troubleshooting](/help/troubleshooting) and [FAQ](/help/faq).
             api: "openai-completions",
             models: [
               {
-                id: "kimi-k2-6",
-                name: "Kimi K2.6",
+                id: "zai-org-glm-4.7",
+                name: "GLM 4.7",
                 reasoning: true,
-                input: ["text", "image"],
-                cost: { input: 0.75, output: 3.5, cacheRead: 0.16, cacheWrite: 0 },
-                contextWindow: 256000,
-                maxTokens: 65536,
+                input: ["text"],
+                cost: { input: 0.55, output: 2.65, cacheRead: 0.11, cacheWrite: 0 },
+                contextWindow: 198000,
+                maxTokens: 16384,
               },
             ],
           },

--- a/extensions/deepseek/onboard.test.ts
+++ b/extensions/deepseek/onboard.test.ts
@@ -13,6 +13,7 @@ describe("DeepSeek onboarding", () => {
     expect(resolveAgentModelPrimaryValue(config.agents?.defaults?.model)).toBe(
       DEEPSEEK_DEFAULT_MODEL_REF,
     );
+    expect(DEEPSEEK_DEFAULT_MODEL_REF).toBe("deepseek/deepseek-v4-pro");
     expect(config.agents?.defaults?.models).toEqual({
       [DEEPSEEK_DEFAULT_MODEL_REF]: { alias: "DeepSeek" },
     });

--- a/extensions/deepseek/openclaw.plugin.json
+++ b/extensions/deepseek/openclaw.plugin.json
@@ -28,7 +28,7 @@
       "deepseek": {
         "baseUrl": "https://api.deepseek.com",
         "api": "openai-completions",
-        "defaultModel": "deepseek-v4-flash",
+        "defaultModel": "deepseek-v4-pro",
         "models": [
           {
             "id": "deepseek-v4-flash",

--- a/extensions/together/onboard.test.ts
+++ b/extensions/together/onboard.test.ts
@@ -17,6 +17,7 @@ describe("Together onboarding", () => {
     expect(TOGETHER_DEFAULT_MODEL_REF).toBe(
       `together/${manifest.modelCatalog.providers.together.defaultModel}`,
     );
+    expect(TOGETHER_DEFAULT_MODEL_REF).toBe("together/moonshotai/Kimi-K2.6");
     expect(config.agents?.defaults?.models?.[TOGETHER_DEFAULT_MODEL_REF]).toEqual({
       alias: "Together AI",
     });

--- a/extensions/together/openclaw.plugin.json
+++ b/extensions/together/openclaw.plugin.json
@@ -44,7 +44,7 @@
       "together": {
         "baseUrl": "https://api.together.xyz/v1",
         "api": "openai-completions",
-        "defaultModel": "meta-llama/Llama-3.3-70B-Instruct-Turbo",
+        "defaultModel": "moonshotai/Kimi-K2.6",
         "models": [
           {
             "id": "moonshotai/Kimi-K2.6",

--- a/extensions/venice/onboard.test.ts
+++ b/extensions/venice/onboard.test.ts
@@ -14,8 +14,9 @@ describe("Venice onboarding", () => {
     expect(resolveAgentModelPrimaryValue(config.agents?.defaults?.model)).toBe(
       VENICE_DEFAULT_MODEL_REF,
     );
+    expect(VENICE_DEFAULT_MODEL_REF).toBe("venice/zai-org-glm-4.7");
     expect(config.agents?.defaults?.models).toEqual({
-      [VENICE_DEFAULT_MODEL_REF]: { alias: "Kimi K2.6" },
+      [VENICE_DEFAULT_MODEL_REF]: { alias: "GLM 4.7" },
     });
   });
 });

--- a/extensions/venice/onboard.ts
+++ b/extensions/venice/onboard.ts
@@ -12,7 +12,7 @@ const venicePresetAppliers = createModelCatalogPresetAppliers({
     api: "openai-completions",
     baseUrl: VENICE_BASE_URL,
     catalogModels: structuredClone(VENICE_MODEL_CATALOG),
-    aliases: [{ modelRef: VENICE_DEFAULT_MODEL_REF, alias: "Kimi K2.6" }],
+    aliases: [{ modelRef: VENICE_DEFAULT_MODEL_REF, alias: "GLM 4.7" }],
   }),
 });
 

--- a/extensions/venice/openclaw.plugin.json
+++ b/extensions/venice/openclaw.plugin.json
@@ -43,7 +43,7 @@
       "venice": {
         "baseUrl": "https://api.venice.ai/api/v1",
         "api": "openai-completions",
-        "defaultModel": "kimi-k2-6",
+        "defaultModel": "zai-org-glm-4.7",
         "models": [
           {
             "id": "zai-org-glm-5-2",


### PR DESCRIPTION
## What Problem This Solves

Fresh-setup onboarding defaults should be each provider's best current-generation model. #113870 refreshed the first batch (venice, zai, cerebras, fireworks, moonshot); this completes the owner directive with a fleet-wide verification sweep of every manifest `defaultModel` and fixes the three remaining stale picks.

## Why This Change Was Made

Owner directive: no deprecated/hidden/retiring onboarding defaults — the default must be the vendor-recommended current model and a visible row in our curated catalog. Every provider's manifest default was verified against current official vendor sources (table with citations in the audit trail; each pick cross-checked against vendor docs or live APIs).

## User Impact

Intentional product change for FRESH setups only (existing configs keep their configured models): deepseek defaults to `deepseek-v4-pro` (quality tier, per DeepSeek's V4 positioning) instead of `deepseek-v4-flash`; together defaults to `moonshotai/Kimi-K2.6` (Together's current recommended model) instead of `meta-llama/Llama-3.3-70B-Instruct-Turbo`; venice defaults to `zai-org-glm-4.7` — the model Venice's own live `default` trait selects — instead of `kimi-k2-6`. Sixteen other providers verified current with no change. Docs updated to match.

Release-note context: `feat(providers): fresh-setup default models refreshed to vendors' current recommendations (deepseek, together, venice)`.

## Evidence

- Verification table covers all 19 manifest defaults with vendor citations; every retained and changed pick is a visible (non-deprecated) curated catalog row (owner re-verified).
- Tests: deepseek 30, together 10, venice 22 — green; `plugin-sdk:surface:check` untouched/green.
- Autoreview (Codex, gpt-5.6-sol): clean, 0.99. CHANGELOG edit dropped (release generation owns it).
