### PR TITLE
fix(qwen): enforce Token Plan constraints for direct model refs

### DIFF
--- a/extensions/qwen/models.ts
+++ b/extensions/qwen/models.ts
@@ -127,11 +127,6 @@ export const QWEN_TOKEN_PLAN_MODEL_CATALOG: ReadonlyArray<ModelDefinitionConfig>
   },
 ];
 
-export function isQwenTokenPlanModelId(modelId: string): boolean {
-  const normalized = modelId.trim().toLowerCase();
-  return QWEN_TOKEN_PLAN_MODEL_CATALOG.some((model) => model.id.toLowerCase() === normalized);
-}
-
 export const QWEN_MODEL_CATALOG: ReadonlyArray<ModelDefinitionConfig> = [
   {
     id: "qwen3.5-plus",

--- a/extensions/qwen/stream.ts
+++ b/extensions/qwen/stream.ts
@@ -12,7 +12,6 @@ import {
   isQwenTokenPlanDeepSeekV4ModelId,
   isQwenTokenPlanGlmModelId,
   isQwenTokenPlanKimiModelId,
-  isQwenTokenPlanModelId,
   isQwenTokenPlanThinkingOnlyModelId,
   QWEN_TOKEN_PLAN_LEGACY_PROVIDER_ID,
   QWEN_TOKEN_PLAN_PROVIDER_ID,
@@ -404,9 +403,11 @@ export function wrapQwenProviderStream(ctx: ProviderWrapStreamFnContext): Stream
     ? undefined
     : resolveQwenTokenPlanThinkingContract(ctx.provider, ctx.modelId);
   const tokenPlanProvider = isQwenTokenPlanProviderId(ctx.provider);
-  const tokenPlanModel =
-    tokenPlanProvider && isQwenTokenPlanModelId(ctx.modelId) && !explicitLegacyThinkingFormat;
-  const forceThinking = tokenPlanModel && isQwenTokenPlanThinkingOnlyModelId(ctx.modelId);
+  // The picker catalog is intentionally curated; direct Token Plan refs still
+  // need provider constraints unless an explicit transport format owns them.
+  const useTokenPlanConstraints =
+    tokenPlanProvider && !explicitLegacyThinkingFormat && thinkingFormat === undefined;
+  const forceThinking = useTokenPlanConstraints && isQwenTokenPlanThinkingOnlyModelId(ctx.modelId);
   let streamFn = createQwenThinkingWrapper(
     ctx.streamFn,
     ctx.thinkingLevel,
@@ -414,7 +415,7 @@ export function wrapQwenProviderStream(ctx: ProviderWrapStreamFnContext): Stream
     forceThinking,
     tokenPlanContract,
   );
-  if (tokenPlanModel) {
+  if (useTokenPlanConstraints) {
     // Config and request extra_body hooks run outside plugin wrappers. Reapply
     // model wire constraints after those hooks so invalid fields cannot escape.
     streamFn = createQwenTokenPlanConstraintWrapper(


### PR DESCRIPTION
Related: #113681

## What Problem This Solves

Fixes an issue where users selecting supported Qwen Token Plan models by exact reference could lose the provider's required thinking, tool-choice, replay, and tool-stream payload constraints when that model was no longer listed in the curated picker catalog.

## Why This Change Was Made

Runtime wire behavior now follows the Token Plan provider boundary instead of the deliberately curated picker catalog. Explicit legacy or model-owned transport formats still retain ownership, and non-reasoning custom models remain untouched.

## User Impact

Direct Token Plan references such as `kimi-k2.7-code`, `glm-5.2`, and `deepseek-v4-pro` keep their supported request behavior even when they are omitted from the recommended model picker.

## Evidence

- Release failure: https://github.com/openclaw/openclaw/actions/runs/30183453564/job/89743964536
- Before: `extensions/qwen/stream.test.ts` failed 14 tests in isolation and 28 assertions in the shared Plugin Prerelease shard.
- After: `node scripts/run-vitest.mjs extensions/qwen/stream.test.ts extensions/qwen/index.test.ts extensions/qwen/provider-catalog.test.ts` passed 79 tests.
- Live after-fix proof: an isolated embedded run against the omitted exact ref `qwen-token-plan/kimi-k2.7-code` reached the Global Token Plan chat-completions endpoint, received HTTP 200 SSE responses, returned `QWEN_TOKEN_PLAN_OK`, and recorded `fallbackUsed: false` with Qwen Token Plan/Kimi as the winning provider/model.
- Explicit-format control: the same green suite covers `preserves explicit qwen-chat-template transport` for both the canonical Token Plan provider and the legacy custom provider.
- `git diff --check`
- Autoreview: clean, no accepted/actionable findings
