### PR TITLE
refactor(agents): split acp-spawn helpers and drop max-lines suppression

### DIFF
--- a/config/max-lines-baseline.txt
+++ b/config/max-lines-baseline.txt
@@ -351,7 +351,6 @@ src/acp/translator.ts
 src/agents/acp-spawn-parent-stream.test.ts
 src/agents/acp-spawn-parent-stream.ts
 src/agents/acp-spawn.test.ts
-src/agents/acp-spawn.ts
 src/agents/agent-bundle-mcp-runtime.test.ts
 src/agents/agent-bundle-mcp-runtime.ts
 src/agents/agent-command.live-model-switch.test.ts

--- a/src/agents/acp-spawn-admission.ts
+++ b/src/agents/acp-spawn-admission.ts
@@ -1,0 +1,40 @@
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { listTasksForOwnerKey } from "../tasks/runtime-internal.js";
+import { getSubagentRunByChildSessionKey } from "./subagent-registry.js";
+
+export function isActiveTaskStatus(status: string | undefined): boolean {
+  return status === "queued" || status === "running";
+}
+
+export function countUntrackedActiveAcpRunsForOwner(ownerKey: string | undefined): number {
+  const normalizedOwnerKey = normalizeOptionalString(ownerKey);
+  if (!normalizedOwnerKey) {
+    return 0;
+  }
+  const tasks = listTasksForOwnerKey(normalizedOwnerKey);
+  const trackedChildSessionKeys = new Set(
+    tasks
+      .filter(
+        (task) =>
+          task.runtime === "subagent" &&
+          isActiveTaskStatus(task.status) &&
+          normalizeOptionalString(task.childSessionKey),
+      )
+      .map((task) => normalizeOptionalString(task.childSessionKey) as string),
+  );
+  const activeAcpChildSessionKeys = new Set(
+    tasks.flatMap((task) => {
+      const childSessionKey = normalizeOptionalString(task.childSessionKey);
+      const trackedRun = childSessionKey ? getSubagentRunByChildSessionKey(childSessionKey) : null;
+      const hasActiveRegistryRun = Boolean(trackedRun && typeof trackedRun.endedAt !== "number");
+      return task.runtime === "acp" &&
+        isActiveTaskStatus(task.status) &&
+        childSessionKey !== undefined &&
+        !hasActiveRegistryRun &&
+        !trackedChildSessionKeys.has(childSessionKey)
+        ? [childSessionKey]
+        : [];
+    }),
+  );
+  return activeAcpChildSessionKeys.size;
+}

--- a/src/agents/acp-spawn-admission.ts
+++ b/src/agents/acp-spawn-admission.ts
@@ -2,7 +2,7 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import { listTasksForOwnerKey } from "../tasks/runtime-internal.js";
 import { getSubagentRunByChildSessionKey } from "./subagent-registry.js";
 
-export function isActiveTaskStatus(status: string | undefined): boolean {
+function isActiveTaskStatus(status: string | undefined): boolean {
   return status === "queued" || status === "running";
 }
 

--- a/src/agents/acp-spawn-bootstrap-delivery.ts
+++ b/src/agents/acp-spawn-bootstrap-delivery.ts
@@ -1,0 +1,119 @@
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import type { AcpTurnAttachment } from "../acp/control-plane/manager.types.js";
+import {
+  formatConversationTarget,
+  routeFromBindingRecord,
+  routeToDeliveryFields,
+} from "../channels/route-projection.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { SessionBindingRecord } from "../infra/outbound/session-binding-service.js";
+import type { AcpSpawnRequesterState } from "./acp-spawn-requester.js";
+import {
+  resolveConversationRefForThreadBinding,
+  resolveSpawnChannelAccountId,
+} from "./spawn-plan.js";
+
+type GatewayImageAttachmentInput = {
+  type: "image";
+  source: {
+    type: "base64";
+    media_type: string;
+    data: string;
+  };
+};
+
+export function toGatewayImageAttachments(
+  attachments: AcpTurnAttachment[] | undefined,
+): GatewayImageAttachmentInput[] | undefined {
+  if (!attachments || attachments.length === 0) {
+    return undefined;
+  }
+  return attachments.map((attachment) => ({
+    type: "image",
+    source: {
+      type: "base64",
+      media_type: attachment.mediaType,
+      data: attachment.data,
+    },
+  }));
+}
+
+export type AcpSpawnBootstrapDeliveryPlan = {
+  useInlineDelivery: boolean;
+  channel?: string;
+  accountId?: string;
+  to?: string;
+  threadId?: string;
+};
+
+export function resolveAcpSpawnBootstrapDeliveryPlan(params: {
+  cfg: OpenClawConfig;
+  spawnMode: "run" | "session";
+  requestThreadBinding: boolean;
+  effectiveStreamToParent: boolean;
+  requester: AcpSpawnRequesterState;
+  binding: SessionBindingRecord | null;
+}): AcpSpawnBootstrapDeliveryPlan {
+  // Child-thread ACP spawns deliver bootstrap output to the new thread; current-conversation
+  // binds deliver back to the originating target.
+  const boundThreadIdRaw = params.binding?.conversation.conversationId;
+  const boundThreadId = boundThreadIdRaw ? normalizeOptionalString(boundThreadIdRaw) : undefined;
+  const fallbackThreadIdRaw = params.requester.origin?.threadId;
+  const fallbackThreadId =
+    fallbackThreadIdRaw != null ? normalizeOptionalString(String(fallbackThreadIdRaw)) : undefined;
+  const deliveryThreadId = boundThreadId ?? fallbackThreadId;
+  const requesterConversationRef = resolveConversationRefForThreadBinding({
+    cfg: params.cfg,
+    channel: params.requester.origin?.channel,
+    accountId: params.requester.origin?.accountId,
+    threadId: fallbackThreadId,
+    to: params.requester.origin?.to,
+  });
+  const requesterAccountId = resolveSpawnChannelAccountId({
+    cfg: params.cfg,
+    channel: params.requester.origin?.channel,
+    accountId: params.requester.origin?.accountId,
+  });
+  const bindingMatchesRequesterConversation = Boolean(
+    params.requester.origin?.channel &&
+    params.binding?.conversation.channel === params.requester.origin.channel &&
+    params.binding?.conversation.accountId === requesterAccountId &&
+    requesterConversationRef?.conversationId &&
+    params.binding?.conversation.conversationId === requesterConversationRef.conversationId &&
+    (params.binding?.conversation.parentConversationId ?? undefined) ===
+      (requesterConversationRef.parentConversationId ?? undefined),
+  );
+  const boundDeliveryTarget = routeToDeliveryFields(routeFromBindingRecord(params.binding));
+  const inferredDeliveryTo =
+    (bindingMatchesRequesterConversation
+      ? normalizeOptionalString(params.requester.origin?.to)
+      : undefined) ??
+    boundDeliveryTarget.to ??
+    normalizeOptionalString(params.requester.origin?.to) ??
+    formatConversationTarget({
+      channel: params.requester.origin?.channel,
+      conversationId: deliveryThreadId,
+    });
+  const resolvedDeliveryThreadId = bindingMatchesRequesterConversation
+    ? fallbackThreadId
+    : (boundDeliveryTarget.threadId ?? deliveryThreadId);
+  const hasDeliveryTarget = Boolean(params.requester.origin?.channel && inferredDeliveryTo);
+
+  // Thread-bound session spawns always deliver inline to their bound thread.
+  // Background run-mode spawns should stay internal and report back through
+  // the parent task lifecycle notifier instead of letting the child ACP
+  // session write raw output directly into the originating channel.
+  const useInlineDelivery =
+    hasDeliveryTarget && !params.effectiveStreamToParent && params.spawnMode === "session";
+
+  return {
+    useInlineDelivery,
+    channel: useInlineDelivery ? params.requester.origin?.channel : undefined,
+    accountId: useInlineDelivery ? requesterAccountId : undefined,
+    to: useInlineDelivery ? inferredDeliveryTo : undefined,
+    threadId:
+      useInlineDelivery && resolvedDeliveryThreadId != null
+        ? normalizeOptionalString(String(resolvedDeliveryThreadId))
+        : undefined,
+  };
+}

--- a/src/agents/acp-spawn-heartbeat.ts
+++ b/src/agents/acp-spawn-heartbeat.ts
@@ -48,7 +48,7 @@ export function isHeartbeatEnabledForSessionAgent(params: {
   }
 }
 
-export function resolveHeartbeatConfigForAgent(params: {
+function resolveHeartbeatConfigForAgent(params: {
   cfg: OpenClawConfig;
   agentId: string;
 }): NonNullable<NonNullable<OpenClawConfig["agents"]>["defaults"]>["heartbeat"] {

--- a/src/agents/acp-spawn-heartbeat.ts
+++ b/src/agents/acp-spawn-heartbeat.ts
@@ -1,0 +1,103 @@
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { DEFAULT_HEARTBEAT_EVERY } from "../auto-reply/heartbeat.js";
+import { parseDurationMs } from "../cli/parse-duration.js";
+import { resolveStorePath } from "../config/sessions/paths.js";
+import { loadSessionEntryReadOnly } from "../config/sessions/session-accessor.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { areHeartbeatsEnabled } from "../infra/heartbeat-wake.js";
+import { normalizeAgentId, parseAgentSessionKey } from "../routing/session-key.js";
+import { deliveryContextFromSession } from "../utils/delivery-context.js";
+import { listAgentEntries } from "./agent-scope-config.js";
+import { resolveAgentConfig, resolveDefaultAgentId } from "./agent-scope.js";
+
+export function isHeartbeatEnabledForSessionAgent(params: {
+  cfg: OpenClawConfig;
+  sessionKey?: string;
+}): boolean {
+  if (!areHeartbeatsEnabled()) {
+    return false;
+  }
+  const requesterAgentId = parseAgentSessionKey(params.sessionKey)?.agentId;
+  if (!requesterAgentId) {
+    return true;
+  }
+
+  const agentEntries = listAgentEntries(params.cfg);
+  const hasExplicitHeartbeatAgents = agentEntries.some((entry) => Boolean(entry?.heartbeat));
+  const enabledByPolicy = hasExplicitHeartbeatAgents
+    ? agentEntries.some(
+        (entry) => Boolean(entry?.heartbeat) && normalizeAgentId(entry?.id) === requesterAgentId,
+      )
+    : requesterAgentId === resolveDefaultAgentId(params.cfg);
+  if (!enabledByPolicy) {
+    return false;
+  }
+
+  const heartbeatEvery =
+    resolveAgentConfig(params.cfg, requesterAgentId)?.heartbeat?.every ??
+    params.cfg.agents?.defaults?.heartbeat?.every ??
+    DEFAULT_HEARTBEAT_EVERY;
+  const trimmedEvery = normalizeOptionalString(heartbeatEvery) ?? "";
+  if (!trimmedEvery) {
+    return false;
+  }
+  try {
+    return parseDurationMs(trimmedEvery, { defaultUnit: "m" }) > 0;
+  } catch {
+    return false;
+  }
+}
+
+export function resolveHeartbeatConfigForAgent(params: {
+  cfg: OpenClawConfig;
+  agentId: string;
+}): NonNullable<NonNullable<OpenClawConfig["agents"]>["defaults"]>["heartbeat"] {
+  const defaults = params.cfg.agents?.defaults?.heartbeat;
+  const overrides = resolveAgentConfig(params.cfg, params.agentId)?.heartbeat;
+  if (!defaults && !overrides) {
+    return undefined;
+  }
+  return {
+    ...defaults,
+    ...overrides,
+  };
+}
+
+export function hasSessionLocalHeartbeatRelayRoute(params: {
+  cfg: OpenClawConfig;
+  parentSessionKey: string;
+  requesterAgentId: string;
+}): boolean {
+  const scope = params.cfg.session?.scope ?? "per-sender";
+  if (scope === "global") {
+    return false;
+  }
+
+  const heartbeat = resolveHeartbeatConfigForAgent({
+    cfg: params.cfg,
+    agentId: params.requesterAgentId,
+  });
+  if ((heartbeat?.target ?? "none") !== "last") {
+    return false;
+  }
+
+  // Explicit delivery overrides are not session-local and can route updates
+  // to unrelated destinations (for example a pinned ops channel).
+  if (normalizeOptionalString(heartbeat?.to)) {
+    return false;
+  }
+  if (normalizeOptionalString(heartbeat?.accountId)) {
+    return false;
+  }
+
+  const storePath = resolveStorePath(params.cfg.session?.store, {
+    agentId: params.requesterAgentId,
+  });
+  const parentEntry = loadSessionEntryReadOnly({
+    storePath,
+    sessionKey: params.parentSessionKey,
+    clone: false,
+  });
+  const parentDeliveryContext = deliveryContextFromSession(parentEntry);
+  return Boolean(parentDeliveryContext?.channel && parentDeliveryContext.to);
+}

--- a/src/agents/acp-spawn-requester.ts
+++ b/src/agents/acp-spawn-requester.ts
@@ -42,7 +42,7 @@ export type AcpSpawnRequesterState = {
   origin: ReturnType<typeof normalizeDeliveryContext>;
 };
 
-export type AcpSpawnStreamPlan = {
+type AcpSpawnStreamPlan = {
   implicitStreamToParent: boolean;
   effectiveStreamToParent: boolean;
 };
@@ -176,7 +176,7 @@ export function resolveAcpSpawnStreamPlan(params: {
   };
 }
 
-export function sessionEntryMatchesAcpResumeSessionId(
+function sessionEntryMatchesAcpResumeSessionId(
   acp: SessionAcpMeta | undefined,
   resumeSessionId: string,
 ): boolean {
@@ -187,7 +187,7 @@ export function sessionEntryMatchesAcpResumeSessionId(
   );
 }
 
-export function sessionEntryIsOwnedByRequester(params: {
+function sessionEntryIsOwnedByRequester(params: {
   sessionKey: string;
   entry: SessionEntry | undefined;
   requesterSessionKey: string;

--- a/src/agents/acp-spawn-requester.ts
+++ b/src/agents/acp-spawn-requester.ts
@@ -1,0 +1,243 @@
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { readAcpSessionMeta } from "../acp/runtime/session-meta.js";
+import { resolveStorePath } from "../config/sessions/paths.js";
+import {
+  listSessionEntriesReadOnly,
+  loadSessionEntryReadOnly,
+  resolveSessionTranscriptRuntimeTarget,
+} from "../config/sessions/session-accessor.js";
+import type { SessionAcpMeta, SessionEntry } from "../config/sessions/types.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { formatErrorMessage } from "../infra/errors.js";
+import { getSessionBindingService } from "../infra/outbound/session-binding-service.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import { isSubagentSessionKey, parseAgentSessionKey } from "../routing/session-key.js";
+import { normalizeDeliveryContext } from "../utils/delivery-context.js";
+import {
+  hasSessionLocalHeartbeatRelayRoute,
+  isHeartbeatEnabledForSessionAgent,
+} from "./acp-spawn-heartbeat.js";
+import { resolveRequesterOriginForChild } from "./spawn-requester-origin.js";
+import type { SessionCapabilityStore } from "./subagent-capabilities.js";
+import { resolveInternalSessionKey, resolveMainSessionAlias } from "./tools/sessions-helpers.js";
+
+const log = createSubsystemLogger("agents/acp-spawn");
+
+type AcpSpawnRequesterContext = {
+  agentChannel?: string;
+  agentAccountId?: string;
+  agentTo?: string;
+  agentThreadId?: string | number;
+  agentGroupSpace?: string | null;
+  agentMemberRoleIds?: string[];
+};
+
+export type AcpSpawnRequesterState = {
+  parentSessionKey?: string;
+  isSubagentSession: boolean;
+  hasActiveSubagentBinding: boolean;
+  hasThreadContext: boolean;
+  heartbeatEnabled: boolean;
+  heartbeatRelayRouteUsable: boolean;
+  origin: ReturnType<typeof normalizeDeliveryContext>;
+};
+
+export type AcpSpawnStreamPlan = {
+  implicitStreamToParent: boolean;
+  effectiveStreamToParent: boolean;
+};
+
+export function resolveRequesterInternalSessionKey(params: {
+  cfg: OpenClawConfig;
+  requesterSessionKey?: string;
+}): string {
+  const { mainKey, alias } = resolveMainSessionAlias(params.cfg);
+  const requesterSessionKey = normalizeOptionalString(params.requesterSessionKey);
+  return requesterSessionKey
+    ? resolveInternalSessionKey({
+        key: requesterSessionKey,
+        alias,
+        mainKey,
+      })
+    : alias;
+}
+
+export async function persistAcpSpawnSessionFileBestEffort(params: {
+  sessionId: string;
+  sessionKey: string;
+  sessionEntry: SessionEntry | undefined;
+  storePath: string;
+  agentId: string;
+  threadId?: string | number;
+  stage: "spawn" | "thread-bind";
+}): Promise<SessionEntry | undefined> {
+  try {
+    const resolvedSessionFile = await resolveSessionTranscriptRuntimeTarget({
+      sessionId: params.sessionId,
+      sessionKey: params.sessionKey,
+      storePath: params.storePath,
+      agentId: params.agentId,
+      threadId: params.threadId,
+    });
+    return (
+      loadSessionEntryReadOnly({
+        storePath: params.storePath,
+        sessionKey: resolvedSessionFile.sessionKey,
+        clone: false,
+      }) ?? params.sessionEntry
+    );
+  } catch (error) {
+    log.warn(
+      `ACP session-file persistence failed during ${params.stage} for ${params.sessionKey}: ${formatErrorMessage(error)}`,
+    );
+    return params.sessionEntry;
+  }
+}
+
+export function resolveAcpSpawnRequesterState(params: {
+  cfg: OpenClawConfig;
+  parentSessionKey?: string;
+  requesterAgentId: string;
+  targetAgentId: string;
+  ctx: AcpSpawnRequesterContext;
+  subagentStore?: SessionCapabilityStore;
+}): AcpSpawnRequesterState {
+  const bindingService = getSessionBindingService();
+  const requesterParsedSession = parseAgentSessionKey(params.parentSessionKey);
+  const isSubagentSession =
+    Boolean(requesterParsedSession) && isSubagentSessionKey(params.parentSessionKey);
+  const hasActiveSubagentBinding =
+    isSubagentSession && params.parentSessionKey
+      ? bindingService
+          .listBySession(params.parentSessionKey)
+          .some((record) => record.targetKind === "subagent" && record.status !== "ended")
+      : false;
+  const hasThreadContext =
+    typeof params.ctx.agentThreadId === "string"
+      ? Boolean(normalizeOptionalString(params.ctx.agentThreadId))
+      : params.ctx.agentThreadId != null;
+  return {
+    parentSessionKey: params.parentSessionKey,
+    isSubagentSession,
+    hasActiveSubagentBinding,
+    hasThreadContext,
+    heartbeatEnabled: isHeartbeatEnabledForSessionAgent({
+      cfg: params.cfg,
+      sessionKey: params.parentSessionKey,
+    }),
+    heartbeatRelayRouteUsable:
+      params.parentSessionKey && params.requesterAgentId
+        ? hasSessionLocalHeartbeatRelayRoute({
+            cfg: params.cfg,
+            parentSessionKey: params.parentSessionKey,
+            requesterAgentId: params.requesterAgentId,
+          })
+        : false,
+    origin: resolveRequesterOriginForChild({
+      cfg: params.cfg,
+      targetAgentId: params.targetAgentId,
+      requesterAgentId: params.requesterAgentId,
+      requesterChannel: params.ctx.agentChannel,
+      requesterAccountId: params.ctx.agentAccountId,
+      requesterTo: params.ctx.agentTo,
+      requesterThreadId: params.ctx.agentThreadId,
+      requesterGroupSpace: params.ctx.agentGroupSpace,
+      requesterMemberRoleIds: params.ctx.agentMemberRoleIds,
+    }),
+  };
+}
+
+export function resolveAcpSpawnStreamPlan(params: {
+  spawnMode: "run" | "session";
+  requestThreadBinding: boolean;
+  streamToParentRequested: boolean;
+  requester: AcpSpawnRequesterState;
+}): AcpSpawnStreamPlan {
+  // For mode=run without thread binding, implicitly route output to parent
+  // only for spawned subagent orchestrator sessions with heartbeat enabled
+  // AND a session-local heartbeat delivery route (target=last + usable last route).
+  // Skip requester sessions that are thread-bound (or carrying thread context)
+  // so user-facing threads do not receive unsolicited ACP progress chatter
+  // unless streamTo="parent" is explicitly requested. Use resolved spawnMode
+  // (not params.mode) so default mode selection works.
+  const implicitStreamToParent =
+    !params.streamToParentRequested &&
+    params.spawnMode === "run" &&
+    !params.requestThreadBinding &&
+    params.requester.isSubagentSession &&
+    !params.requester.hasActiveSubagentBinding &&
+    !params.requester.hasThreadContext &&
+    params.requester.heartbeatEnabled &&
+    params.requester.heartbeatRelayRouteUsable;
+
+  return {
+    implicitStreamToParent,
+    effectiveStreamToParent: params.streamToParentRequested || implicitStreamToParent,
+  };
+}
+
+export function sessionEntryMatchesAcpResumeSessionId(
+  acp: SessionAcpMeta | undefined,
+  resumeSessionId: string,
+): boolean {
+  const identity = acp?.identity;
+  return (
+    normalizeOptionalString(identity?.agentSessionId) === resumeSessionId ||
+    normalizeOptionalString(identity?.acpxSessionId) === resumeSessionId
+  );
+}
+
+export function sessionEntryIsOwnedByRequester(params: {
+  sessionKey: string;
+  entry: SessionEntry | undefined;
+  requesterSessionKey: string;
+}): boolean {
+  return (
+    params.sessionKey === params.requesterSessionKey ||
+    normalizeOptionalString(params.entry?.spawnedBy) === params.requesterSessionKey ||
+    normalizeOptionalString(params.entry?.parentSessionKey) === params.requesterSessionKey
+  );
+}
+
+export function validateAcpResumeSessionOwnership(params: {
+  cfg: OpenClawConfig;
+  targetAgentId: string;
+  requesterSessionKey?: string;
+  resumeSessionId?: string;
+}): { ok: true } | { ok: false; error: string } {
+  const resumeSessionId = normalizeOptionalString(params.resumeSessionId);
+  if (!resumeSessionId) {
+    return { ok: true };
+  }
+  const requesterSessionKey = normalizeOptionalString(params.requesterSessionKey);
+  if (!requesterSessionKey) {
+    return {
+      ok: false,
+      error: "sessions_spawn resumeSessionId requires an active requester session context.",
+    };
+  }
+
+  const storePath = resolveStorePath(params.cfg.session?.store, { agentId: params.targetAgentId });
+  for (const { sessionKey, entry } of listSessionEntriesReadOnly({ storePath, clone: false })) {
+    const acp = readAcpSessionMeta({ sessionKey, cfg: params.cfg });
+    if (!sessionEntryMatchesAcpResumeSessionId(acp, resumeSessionId)) {
+      continue;
+    }
+    if (
+      sessionEntryIsOwnedByRequester({
+        sessionKey,
+        entry,
+        requesterSessionKey,
+      })
+    ) {
+      return { ok: true };
+    }
+    break;
+  }
+
+  return {
+    ok: false,
+    error:
+      "sessions_spawn resumeSessionId is only allowed for ACP sessions previously recorded for this requester. Omit resumeSessionId to start a fresh ACP session.",
+  };
+}

--- a/src/agents/acp-spawn-runtime.ts
+++ b/src/agents/acp-spawn-runtime.ts
@@ -1,0 +1,278 @@
+import {
+  resolveAcpSessionCwd,
+  resolveAcpThreadSessionDetailLines,
+} from "@openclaw/acp-core/runtime/session-identifiers";
+import type { AcpRuntimeSessionMode } from "@openclaw/acp-core/runtime/types";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { getAcpSessionManager } from "../acp/control-plane/manager.js";
+import type { AcpSpawnRuntimeCloseHandle } from "../acp/control-plane/spawn.js";
+import { formatThinkingLevels } from "../auto-reply/thinking.js";
+import {
+  resolveThreadBindingIntroText,
+  resolveThreadBindingThreadName,
+} from "../channels/thread-bindings-messages.js";
+import {
+  resolveThreadBindingIdleTimeoutMsForChannel,
+  resolveThreadBindingMaxAgeMsForChannel,
+} from "../channels/thread-bindings-policy.js";
+import { resolveStorePath } from "../config/sessions/paths.js";
+import { loadSessionEntry } from "../config/sessions/session-accessor.js";
+import type { SessionEntry } from "../config/sessions/types.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import {
+  getSessionBindingService,
+  type SessionBindingRecord,
+} from "../infra/outbound/session-binding-service.js";
+import { persistAcpSpawnSessionFileBestEffort } from "./acp-spawn-requester.js";
+import { resolveAgentConfig } from "./agent-scope.js";
+import {
+  resolveConfiguredSubagentSpawnModelSelection,
+  resolveThinkingDefault,
+} from "./model-selection.js";
+import type { PreparedSpawnThreadBinding } from "./spawn-plan.js";
+import { splitModelRef } from "./subagent-spawn-plan.js";
+import { resolveSubagentThinkingOverride } from "./subagent-spawn-thinking.js";
+
+const ACP_RUNTIME_TIMEOUT_MAX_SECONDS = 24 * 60 * 60;
+
+export function resolveAcpSessionMode(mode: "run" | "session"): AcpRuntimeSessionMode {
+  return mode === "session" ? "persistent" : "oneshot";
+}
+
+function isMissingPathError(error: unknown): boolean {
+  const code = error instanceof Error ? (error as NodeJS.ErrnoException).code : undefined;
+  return code === "ENOENT" || code === "ENOTDIR";
+}
+
+export async function resolveRuntimeCwdForAcpSpawn(params: {
+  resolvedCwd?: string;
+  explicitCwd?: string;
+}): Promise<string | undefined> {
+  if (!params.resolvedCwd) {
+    return undefined;
+  }
+  if (normalizeOptionalString(params.explicitCwd)) {
+    return params.resolvedCwd;
+  }
+  try {
+    await fs.access(params.resolvedCwd);
+    return params.resolvedCwd;
+  } catch (error) {
+    if (isMissingPathError(error)) {
+      return undefined;
+    }
+    throw error;
+  }
+}
+
+type AcpSpawnInitializedSession = Awaited<
+  ReturnType<ReturnType<typeof getAcpSessionManager>["initializeSession"]>
+>;
+
+export type AcpSpawnInitializedRuntime = {
+  initialized: AcpSpawnInitializedSession;
+  runtimeCloseHandle: AcpSpawnRuntimeCloseHandle;
+  sessionId?: string;
+  sessionEntry: SessionEntry | undefined;
+  storePath: string;
+};
+
+export type AcpSpawnRuntimeOptions = {
+  model?: string;
+  thinking?: string;
+  timeoutSeconds?: number;
+};
+
+export function resolveAcpRuntimeTimeoutSeconds(runTimeoutSeconds?: number): number | undefined {
+  if (!runTimeoutSeconds) {
+    return undefined;
+  }
+  return Math.min(runTimeoutSeconds, ACP_RUNTIME_TIMEOUT_MAX_SECONDS);
+}
+
+export function resolveAcpSpawnRuntimeOptions(params: {
+  cfg: OpenClawConfig;
+  targetAgentId: string;
+  configAgentId?: string;
+  model?: string;
+  thinking?: string;
+  runTimeoutSeconds?: number;
+}):
+  | { ok: true; runtimeOptions?: AcpSpawnRuntimeOptions; modelExplicit: boolean }
+  | { ok: false; error: string } {
+  const policyAgentId = params.configAgentId ?? params.targetAgentId;
+  const modelExplicit = normalizeOptionalString(params.model) !== undefined;
+  const model = resolveConfiguredSubagentSpawnModelSelection({
+    cfg: params.cfg,
+    agentId: policyAgentId,
+    modelOverride: params.model,
+  });
+  const targetAgentConfig = resolveAgentConfig(params.cfg, policyAgentId);
+  const thinkingPlan = resolveSubagentThinkingOverride({
+    cfg: params.cfg,
+    targetAgentConfig,
+    thinkingOverrideRaw: params.thinking,
+  });
+  if (thinkingPlan.status === "error") {
+    const { provider, model: modelId } = splitModelRef(model);
+    return {
+      ok: false,
+      error: `Invalid thinking level "${thinkingPlan.thinkingCandidateRaw}". Use one of: ${formatThinkingLevels(provider, modelId)}.`,
+    };
+  }
+
+  let thinking = thinkingPlan.thinkingOverride;
+  if (!thinking && model) {
+    const { provider, model: modelId } = splitModelRef(model);
+    if (provider && modelId) {
+      thinking = resolveThinkingDefault({
+        cfg: params.cfg,
+        provider,
+        model: modelId,
+      });
+    }
+  }
+
+  const timeoutSeconds = resolveAcpRuntimeTimeoutSeconds(params.runTimeoutSeconds);
+  const runtimeOptions =
+    model || thinking || timeoutSeconds
+      ? {
+          ...(model ? { model } : {}),
+          ...(thinking ? { thinking } : {}),
+          ...(timeoutSeconds ? { timeoutSeconds } : {}),
+        }
+      : undefined;
+  return { ok: true, runtimeOptions, modelExplicit };
+}
+
+export async function initializeAcpSpawnRuntime(params: {
+  cfg: OpenClawConfig;
+  sessionKey: string;
+  targetAgentId: string;
+  runtimeMode: AcpRuntimeSessionMode;
+  resumeSessionId?: string;
+  runtimeOptions?: AcpSpawnRuntimeOptions;
+  modelExplicit?: boolean;
+  cwd?: string;
+}): Promise<AcpSpawnInitializedRuntime> {
+  const storePath = resolveStorePath(params.cfg.session?.store, { agentId: params.targetAgentId });
+  let sessionEntry = loadSessionEntry({
+    storePath,
+    sessionKey: params.sessionKey,
+    clone: false,
+  });
+  const sessionId = sessionEntry?.sessionId;
+  if (sessionId) {
+    sessionEntry = await persistAcpSpawnSessionFileBestEffort({
+      sessionId,
+      sessionKey: params.sessionKey,
+      storePath,
+      sessionEntry,
+      agentId: params.targetAgentId,
+      stage: "spawn",
+    });
+  }
+
+  const initialized = await getAcpSessionManager().initializeSession({
+    cfg: params.cfg,
+    sessionKey: params.sessionKey,
+    agent: params.targetAgentId,
+    mode: params.runtimeMode,
+    resumeSessionId: params.resumeSessionId,
+    runtimeOptions: params.runtimeOptions,
+    modelExplicit: params.modelExplicit,
+    cwd: params.cwd,
+    backendId: params.cfg.acp?.backend,
+  });
+
+  return {
+    initialized,
+    runtimeCloseHandle: {
+      runtime: initialized.runtime,
+      handle: initialized.handle,
+    },
+    sessionId,
+    sessionEntry,
+    storePath,
+  };
+}
+
+export async function bindPreparedAcpThread(params: {
+  cfg: OpenClawConfig;
+  sessionKey: string;
+  targetAgentId: string;
+  label?: string;
+  preparedBinding: PreparedSpawnThreadBinding;
+  initializedRuntime: AcpSpawnInitializedRuntime;
+}): Promise<{
+  binding: SessionBindingRecord;
+  sessionEntry: SessionEntry | undefined;
+}> {
+  const binding = await getSessionBindingService().bind({
+    targetSessionKey: params.sessionKey,
+    targetKind: "session",
+    conversation: {
+      channel: params.preparedBinding.channel,
+      accountId: params.preparedBinding.accountId,
+      conversationId: params.preparedBinding.conversationId,
+      ...(params.preparedBinding.parentConversationId
+        ? { parentConversationId: params.preparedBinding.parentConversationId }
+        : {}),
+    },
+    placement: params.preparedBinding.placement,
+    metadata: {
+      threadName: resolveThreadBindingThreadName({
+        agentId: params.targetAgentId,
+        label: params.label || params.targetAgentId,
+      }),
+      agentId: params.targetAgentId,
+      label: params.label || undefined,
+      boundBy: "system",
+      introText: resolveThreadBindingIntroText({
+        agentId: params.targetAgentId,
+        label: params.label || undefined,
+        idleTimeoutMs: resolveThreadBindingIdleTimeoutMsForChannel({
+          cfg: params.cfg,
+          channel: params.preparedBinding.channel,
+          accountId: params.preparedBinding.accountId,
+        }),
+        maxAgeMs: resolveThreadBindingMaxAgeMsForChannel({
+          cfg: params.cfg,
+          channel: params.preparedBinding.channel,
+          accountId: params.preparedBinding.accountId,
+        }),
+        sessionCwd: resolveAcpSessionCwd(params.initializedRuntime.initialized.meta),
+        sessionDetails: resolveAcpThreadSessionDetailLines({
+          sessionKey: params.sessionKey,
+          meta: params.initializedRuntime.initialized.meta,
+        }),
+      }),
+    },
+  });
+  if (!binding.conversation.conversationId) {
+    throw new Error(
+      params.preparedBinding.placement === "child"
+        ? `Failed to create and bind a ${params.preparedBinding.channel} thread for this ACP session.`
+        : `Failed to bind the current ${params.preparedBinding.channel} conversation for this ACP session.`,
+    );
+  }
+
+  let sessionEntry = params.initializedRuntime.sessionEntry;
+  if (params.initializedRuntime.sessionId && params.preparedBinding.placement === "child") {
+    const boundThreadId = normalizeOptionalString(binding.conversation.conversationId);
+    if (boundThreadId) {
+      sessionEntry = await persistAcpSpawnSessionFileBestEffort({
+        sessionId: params.initializedRuntime.sessionId,
+        sessionKey: params.sessionKey,
+        storePath: params.initializedRuntime.storePath,
+        sessionEntry,
+        agentId: params.targetAgentId,
+        threadId: boundThreadId,
+        stage: "thread-bind",
+      });
+    }
+  }
+
+  return { binding, sessionEntry };
+}
+import fs from "node:fs/promises";

--- a/src/agents/acp-spawn-runtime.ts
+++ b/src/agents/acp-spawn-runtime.ts
@@ -77,13 +77,13 @@ export type AcpSpawnInitializedRuntime = {
   storePath: string;
 };
 
-export type AcpSpawnRuntimeOptions = {
+type AcpSpawnRuntimeOptions = {
   model?: string;
   thinking?: string;
   timeoutSeconds?: number;
 };
 
-export function resolveAcpRuntimeTimeoutSeconds(runTimeoutSeconds?: number): number | undefined {
+function resolveAcpRuntimeTimeoutSeconds(runTimeoutSeconds?: number): number | undefined {
   if (!runTimeoutSeconds) {
     return undefined;
   }

--- a/src/agents/acp-spawn-target.ts
+++ b/src/agents/acp-spawn-target.ts
@@ -1,0 +1,85 @@
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { normalizeOptionalAgentId } from "../routing/session-key.js";
+import { listAgentEntries } from "./agent-scope-config.js";
+import { listAgentIds } from "./agent-scope.js";
+
+export function resolveTargetAcpAgentId(params: {
+  requestedAgentId?: string;
+  cfg: OpenClawConfig;
+}): { ok: true; agentId: string; configAgentId?: string } | { ok: false; error: string } {
+  const requested = normalizeOptionalAgentId(params.requestedAgentId);
+  if (requested) {
+    const configuredAgent = listAgentEntries(params.cfg).find(
+      (agent) => normalizeOptionalAgentId(agent.id) === requested,
+    );
+    if (configuredAgent?.runtime?.type === "acp") {
+      return {
+        ok: true,
+        agentId: normalizeOptionalAgentId(configuredAgent.runtime.acp?.agent) ?? requested,
+        configAgentId: requested,
+      };
+    }
+    if (configuredAgent && !isExplicitlyAllowedAcpAgent(params.cfg, requested)) {
+      return {
+        ok: false,
+        error:
+          `agentId "${requested}" is an OpenClaw config agent, not an ACP harness. ` +
+          'Use runtime="subagent" or omit runtime for OpenClaw config agents. ' +
+          'Use runtime="acp" only with external ACP harness ids such as codex, claude, droid, gemini, or opencode, or configure agents.entries.*.runtime.type="acp" with runtime.acp.agent.',
+      };
+    }
+    return {
+      ok: true,
+      agentId: requested,
+      ...(configuredAgent ? { configAgentId: requested } : {}),
+    };
+  }
+
+  const configuredDefault = normalizeOptionalAgentId(params.cfg.acp?.defaultAgent);
+  if (configuredDefault) {
+    return { ok: true, agentId: configuredDefault };
+  }
+
+  return {
+    ok: false,
+    error:
+      "ACP target agent is not configured. Pass `agentId` in `sessions_spawn` or set `acp.defaultAgent` in config.",
+  };
+}
+
+export function isExplicitlyAllowedAcpAgent(cfg: OpenClawConfig, agentId: string): boolean {
+  return (cfg.acp?.allowedAgents ?? []).some((entry) => {
+    if (entry.trim() === "*") {
+      return true;
+    }
+    const normalized = normalizeOptionalAgentId(entry);
+    return normalized === agentId;
+  });
+}
+
+export function resolveConfiguredAcpSubagentTargetIds(cfg: OpenClawConfig): string[] {
+  const ids = new Set<string>(listAgentIds(cfg));
+  for (const agent of listAgentEntries(cfg)) {
+    if (agent.runtime?.type !== "acp") {
+      continue;
+    }
+    const acpAgent = normalizeOptionalAgentId(agent.runtime.acp?.agent);
+    if (acpAgent) {
+      ids.add(acpAgent);
+    }
+  }
+  const defaultAgent = normalizeOptionalAgentId(cfg.acp?.defaultAgent);
+  if (defaultAgent) {
+    ids.add(defaultAgent);
+  }
+  for (const entry of cfg.acp?.allowedAgents ?? []) {
+    if (entry.trim() === "*") {
+      continue;
+    }
+    const id = normalizeOptionalAgentId(entry);
+    if (id) {
+      ids.add(id);
+    }
+  }
+  return Array.from(ids);
+}

--- a/src/agents/acp-spawn-target.ts
+++ b/src/agents/acp-spawn-target.ts
@@ -47,7 +47,7 @@ export function resolveTargetAcpAgentId(params: {
   };
 }
 
-export function isExplicitlyAllowedAcpAgent(cfg: OpenClawConfig, agentId: string): boolean {
+function isExplicitlyAllowedAcpAgent(cfg: OpenClawConfig, agentId: string): boolean {
   return (cfg.acp?.allowedAgents ?? []).some((entry) => {
     if (entry.trim() === "*") {
       return true;

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -1,75 +1,67 @@
 /** Implements ACP subagent/session spawning, binding, limits, and parent-stream setup. */
 import crypto from "node:crypto";
-import fs from "node:fs/promises";
-import {
-  resolveAcpSessionCwd,
-  resolveAcpThreadSessionDetailLines,
-} from "@openclaw/acp-core/runtime/session-identifiers";
-import type { AcpRuntimeSessionMode } from "@openclaw/acp-core/runtime/types";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import { getAcpSessionManager } from "../acp/control-plane/manager.js";
 import type { AcpTurnAttachment } from "../acp/control-plane/manager.types.js";
 import {
   cleanupFailedAcpSpawn,
   type AcpSpawnRuntimeCloseHandle,
 } from "../acp/control-plane/spawn.js";
 import { isAcpEnabledByPolicy, resolveAcpAgentPolicyError } from "../acp/policy.js";
-import { readAcpSessionMeta } from "../acp/runtime/session-meta.js";
-import { DEFAULT_HEARTBEAT_EVERY } from "../auto-reply/heartbeat.js";
-import { formatThinkingLevels } from "../auto-reply/thinking.js";
-import {
-  formatConversationTarget,
-  routeFromBindingRecord,
-  routeToDeliveryFields,
-} from "../channels/route-projection.js";
-import {
-  resolveThreadBindingIntroText,
-  resolveThreadBindingThreadName,
-} from "../channels/thread-bindings-messages.js";
-import {
-  resolveThreadBindingIdleTimeoutMsForChannel,
-  resolveThreadBindingMaxAgeMsForChannel,
-} from "../channels/thread-bindings-policy.js";
-import { parseDurationMs } from "../cli/parse-duration.js";
 import { getRuntimeConfig } from "../config/config.js";
 import { resolveStorePath } from "../config/sessions/paths.js";
 import {
-  listSessionEntriesReadOnly,
-  loadSessionEntry,
   loadSessionEntryReadOnly,
-  resolveSessionTranscriptRuntimeTarget,
   upsertSessionEntry,
 } from "../config/sessions/session-accessor.js";
 import { buildSessionCreationStamp } from "../config/sessions/session-entry-provenance.js";
-import type { SessionAcpMeta, SessionEntry } from "../config/sessions/types.js";
+import type { SessionEntry } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { callGateway } from "../gateway/call.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { resolveEventSessionRoutingPolicy } from "../infra/event-session-routing.js";
-import { areHeartbeatsEnabled } from "../infra/heartbeat-wake.js";
 import {
   getSessionBindingService,
   isSessionBindingError,
   type SessionBindingRecord,
 } from "../infra/outbound/session-binding-service.js";
-import { createSubsystemLogger } from "../logging/subsystem.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import {
-  isSubagentSessionKey,
   normalizeAgentId,
   normalizeOptionalAgentId,
   parseAgentSessionKey,
   resolveAgentIdFromSessionKey,
 } from "../routing/session-key.js";
 import { recordSessionCreated, recordSubagentSpawned } from "../sessions/session-state-events.js";
-import { listTasksForOwnerKey } from "../tasks/runtime-internal.js";
-import { deliveryContextFromSession, normalizeDeliveryContext } from "../utils/delivery-context.js";
+import { deliveryContextFromSession } from "../utils/delivery-context.js";
+import { countUntrackedActiveAcpRunsForOwner } from "./acp-spawn-admission.js";
+import {
+  resolveAcpSpawnBootstrapDeliveryPlan,
+  toGatewayImageAttachments,
+  type AcpSpawnBootstrapDeliveryPlan,
+} from "./acp-spawn-bootstrap-delivery.js";
 import {
   type AcpSpawnParentRelayHandle,
   startAcpSpawnParentStreamRelay,
 } from "./acp-spawn-parent-stream.js";
-import { listAgentEntries } from "./agent-scope-config.js";
-import { listAgentIds, resolveAgentConfig, resolveDefaultAgentId } from "./agent-scope.js";
+import {
+  resolveAcpSpawnRequesterState,
+  resolveAcpSpawnStreamPlan,
+  resolveRequesterInternalSessionKey,
+  validateAcpResumeSessionOwnership,
+} from "./acp-spawn-requester.js";
+import {
+  bindPreparedAcpThread,
+  initializeAcpSpawnRuntime,
+  resolveAcpSessionMode,
+  resolveAcpSpawnRuntimeOptions,
+  resolveRuntimeCwdForAcpSpawn,
+  type AcpSpawnInitializedRuntime,
+} from "./acp-spawn-runtime.js";
+import {
+  resolveConfiguredAcpSubagentTargetIds,
+  resolveTargetAcpAgentId,
+} from "./acp-spawn-target.js";
+import { resolveDefaultAgentId } from "./agent-scope.js";
 import {
   findAcpUnsupportedInheritedToolAllow,
   findAcpUnsupportedInheritedToolDeny,
@@ -79,10 +71,6 @@ import {
   inheritedToolDenyPatch,
 } from "./inherited-tool-deny.js";
 import { AGENT_LANE_SUBAGENT } from "./lanes.js";
-import {
-  resolveConfiguredSubagentSpawnModelSelection,
-  resolveThinkingDefault,
-} from "./model-selection.js";
 import { resolveSandboxRuntimeStatus } from "./sandbox/runtime-status.js";
 import {
   runSpawnPipeline,
@@ -92,32 +80,18 @@ import {
 import {
   mintSpawnSessionKey,
   prepareSpawnThreadBinding,
-  resolveConversationRefForThreadBinding,
   resolveSpawnAdmission,
-  resolveSpawnChannelAccountId,
   resolveSpawnMode,
   resolveSpawnSandboxError,
   type PreparedSpawnThreadBinding,
 } from "./spawn-plan.js";
-import { resolveRequesterOriginForChild } from "./spawn-requester-origin.js";
 import { resolveSpawnedWorkspaceInheritance } from "./spawned-context.js";
 import {
   isSubagentEnvelopeSession,
   resolveSubagentCapabilityStore,
-  type SessionCapabilityStore,
 } from "./subagent-capabilities.js";
-import { getSubagentRunByChildSessionKey } from "./subagent-registry.js";
 import { resolveSubagentSpawnOwnership } from "./subagent-spawn-ownership.js";
-import {
-  resolveConfiguredSubagentRunTimeoutSeconds,
-  splitModelRef,
-} from "./subagent-spawn-plan.js";
-import { resolveSubagentThinkingOverride } from "./subagent-spawn-thinking.js";
-import { resolveInternalSessionKey, resolveMainSessionAlias } from "./tools/sessions-helpers.js";
-
-const log = createSubsystemLogger("agents/acp-spawn");
-
-const ACP_RUNTIME_TIMEOUT_MAX_SECONDS = 24 * 60 * 60;
+import { resolveConfiguredSubagentRunTimeoutSeconds } from "./subagent-spawn-plan.js";
 
 export const ACP_SPAWN_MODES = ["run", "session"] as const;
 type SpawnAcpMode = (typeof ACP_SPAWN_MODES)[number];
@@ -144,31 +118,6 @@ type SpawnAcpParams = {
   streamTo?: SpawnAcpStreamTarget;
   attachments?: AcpTurnAttachment[];
 };
-
-type GatewayImageAttachmentInput = {
-  type: "image";
-  source: {
-    type: "base64";
-    media_type: string;
-    data: string;
-  };
-};
-
-function toGatewayImageAttachments(
-  attachments: AcpTurnAttachment[] | undefined,
-): GatewayImageAttachmentInput[] | undefined {
-  if (!attachments || attachments.length === 0) {
-    return undefined;
-  }
-  return attachments.map((attachment) => ({
-    type: "image",
-    source: {
-      type: "base64",
-      media_type: attachment.mediaType,
-      data: attachment.data,
-    },
-  }));
-}
 
 export type SpawnAcpContext = {
   agentSessionKey?: string;
@@ -262,259 +211,6 @@ export function resolveAcpSpawnRuntimePolicyError(params: {
   });
 }
 
-type AcpSpawnInitializedSession = Awaited<
-  ReturnType<ReturnType<typeof getAcpSessionManager>["initializeSession"]>
->;
-
-type AcpSpawnInitializedRuntime = {
-  initialized: AcpSpawnInitializedSession;
-  runtimeCloseHandle: AcpSpawnRuntimeCloseHandle;
-  sessionId?: string;
-  sessionEntry: SessionEntry | undefined;
-  storePath: string;
-};
-
-type AcpSpawnRequesterState = {
-  parentSessionKey?: string;
-  isSubagentSession: boolean;
-  hasActiveSubagentBinding: boolean;
-  hasThreadContext: boolean;
-  heartbeatEnabled: boolean;
-  heartbeatRelayRouteUsable: boolean;
-  origin: ReturnType<typeof normalizeDeliveryContext>;
-};
-
-type AcpSpawnStreamPlan = {
-  implicitStreamToParent: boolean;
-  effectiveStreamToParent: boolean;
-};
-
-function isActiveTaskStatus(status: string | undefined): boolean {
-  return status === "queued" || status === "running";
-}
-
-function countUntrackedActiveAcpRunsForOwner(ownerKey: string | undefined): number {
-  const normalizedOwnerKey = normalizeOptionalString(ownerKey);
-  if (!normalizedOwnerKey) {
-    return 0;
-  }
-  const tasks = listTasksForOwnerKey(normalizedOwnerKey);
-  const trackedChildSessionKeys = new Set(
-    tasks
-      .filter(
-        (task) =>
-          task.runtime === "subagent" &&
-          isActiveTaskStatus(task.status) &&
-          normalizeOptionalString(task.childSessionKey),
-      )
-      .map((task) => normalizeOptionalString(task.childSessionKey) as string),
-  );
-  const activeAcpChildSessionKeys = new Set(
-    tasks.flatMap((task) => {
-      const childSessionKey = normalizeOptionalString(task.childSessionKey);
-      const trackedRun = childSessionKey ? getSubagentRunByChildSessionKey(childSessionKey) : null;
-      const hasActiveRegistryRun = Boolean(trackedRun && typeof trackedRun.endedAt !== "number");
-      return task.runtime === "acp" &&
-        isActiveTaskStatus(task.status) &&
-        childSessionKey !== undefined &&
-        !hasActiveRegistryRun &&
-        !trackedChildSessionKeys.has(childSessionKey)
-        ? [childSessionKey]
-        : [];
-    }),
-  );
-  return activeAcpChildSessionKeys.size;
-}
-
-type AcpSpawnBootstrapDeliveryPlan = {
-  useInlineDelivery: boolean;
-  channel?: string;
-  accountId?: string;
-  to?: string;
-  threadId?: string;
-};
-
-function resolveAcpSessionMode(mode: SpawnAcpMode): AcpRuntimeSessionMode {
-  return mode === "session" ? "persistent" : "oneshot";
-}
-
-function isHeartbeatEnabledForSessionAgent(params: {
-  cfg: OpenClawConfig;
-  sessionKey?: string;
-}): boolean {
-  if (!areHeartbeatsEnabled()) {
-    return false;
-  }
-  const requesterAgentId = parseAgentSessionKey(params.sessionKey)?.agentId;
-  if (!requesterAgentId) {
-    return true;
-  }
-
-  const agentEntries = listAgentEntries(params.cfg);
-  const hasExplicitHeartbeatAgents = agentEntries.some((entry) => Boolean(entry?.heartbeat));
-  const enabledByPolicy = hasExplicitHeartbeatAgents
-    ? agentEntries.some(
-        (entry) => Boolean(entry?.heartbeat) && normalizeAgentId(entry?.id) === requesterAgentId,
-      )
-    : requesterAgentId === resolveDefaultAgentId(params.cfg);
-  if (!enabledByPolicy) {
-    return false;
-  }
-
-  const heartbeatEvery =
-    resolveAgentConfig(params.cfg, requesterAgentId)?.heartbeat?.every ??
-    params.cfg.agents?.defaults?.heartbeat?.every ??
-    DEFAULT_HEARTBEAT_EVERY;
-  const trimmedEvery = normalizeOptionalString(heartbeatEvery) ?? "";
-  if (!trimmedEvery) {
-    return false;
-  }
-  try {
-    return parseDurationMs(trimmedEvery, { defaultUnit: "m" }) > 0;
-  } catch {
-    return false;
-  }
-}
-
-function resolveHeartbeatConfigForAgent(params: {
-  cfg: OpenClawConfig;
-  agentId: string;
-}): NonNullable<NonNullable<OpenClawConfig["agents"]>["defaults"]>["heartbeat"] {
-  const defaults = params.cfg.agents?.defaults?.heartbeat;
-  const overrides = resolveAgentConfig(params.cfg, params.agentId)?.heartbeat;
-  if (!defaults && !overrides) {
-    return undefined;
-  }
-  return {
-    ...defaults,
-    ...overrides,
-  };
-}
-
-function hasSessionLocalHeartbeatRelayRoute(params: {
-  cfg: OpenClawConfig;
-  parentSessionKey: string;
-  requesterAgentId: string;
-}): boolean {
-  const scope = params.cfg.session?.scope ?? "per-sender";
-  if (scope === "global") {
-    return false;
-  }
-
-  const heartbeat = resolveHeartbeatConfigForAgent({
-    cfg: params.cfg,
-    agentId: params.requesterAgentId,
-  });
-  if ((heartbeat?.target ?? "none") !== "last") {
-    return false;
-  }
-
-  // Explicit delivery overrides are not session-local and can route updates
-  // to unrelated destinations (for example a pinned ops channel).
-  if (normalizeOptionalString(heartbeat?.to)) {
-    return false;
-  }
-  if (normalizeOptionalString(heartbeat?.accountId)) {
-    return false;
-  }
-
-  const storePath = resolveStorePath(params.cfg.session?.store, {
-    agentId: params.requesterAgentId,
-  });
-  const parentEntry = loadSessionEntryReadOnly({
-    storePath,
-    sessionKey: params.parentSessionKey,
-    clone: false,
-  });
-  const parentDeliveryContext = deliveryContextFromSession(parentEntry);
-  return Boolean(parentDeliveryContext?.channel && parentDeliveryContext.to);
-}
-
-function resolveTargetAcpAgentId(params: {
-  requestedAgentId?: string;
-  cfg: OpenClawConfig;
-}): { ok: true; agentId: string; configAgentId?: string } | { ok: false; error: string } {
-  const requested = normalizeOptionalAgentId(params.requestedAgentId);
-  if (requested) {
-    const configuredAgent = listAgentEntries(params.cfg).find(
-      (agent) => normalizeOptionalAgentId(agent.id) === requested,
-    );
-    if (configuredAgent?.runtime?.type === "acp") {
-      return {
-        ok: true,
-        agentId: normalizeOptionalAgentId(configuredAgent.runtime.acp?.agent) ?? requested,
-        configAgentId: requested,
-      };
-    }
-    if (configuredAgent && !isExplicitlyAllowedAcpAgent(params.cfg, requested)) {
-      return {
-        ok: false,
-        error:
-          `agentId "${requested}" is an OpenClaw config agent, not an ACP harness. ` +
-          'Use runtime="subagent" or omit runtime for OpenClaw config agents. ' +
-          'Use runtime="acp" only with external ACP harness ids such as codex, claude, droid, gemini, or opencode, or configure agents.entries.*.runtime.type="acp" with runtime.acp.agent.',
-      };
-    }
-    return {
-      ok: true,
-      agentId: requested,
-      ...(configuredAgent ? { configAgentId: requested } : {}),
-    };
-  }
-
-  const configuredDefault = normalizeOptionalAgentId(params.cfg.acp?.defaultAgent);
-  if (configuredDefault) {
-    return { ok: true, agentId: configuredDefault };
-  }
-
-  return {
-    ok: false,
-    error:
-      "ACP target agent is not configured. Pass `agentId` in `sessions_spawn` or set `acp.defaultAgent` in config.",
-  };
-}
-
-function isExplicitlyAllowedAcpAgent(cfg: OpenClawConfig, agentId: string): boolean {
-  return (cfg.acp?.allowedAgents ?? []).some((entry) => {
-    if (entry.trim() === "*") {
-      return true;
-    }
-    const normalized = normalizeOptionalAgentId(entry);
-    return normalized === agentId;
-  });
-}
-
-function resolveConfiguredAcpSubagentTargetIds(cfg: OpenClawConfig): string[] {
-  const ids = new Set<string>(listAgentIds(cfg));
-  for (const agent of listAgentEntries(cfg)) {
-    if (agent.runtime?.type !== "acp") {
-      continue;
-    }
-    const acpAgent = normalizeOptionalAgentId(agent.runtime.acp?.agent);
-    if (acpAgent) {
-      ids.add(acpAgent);
-    }
-  }
-  const defaultAgent = normalizeOptionalAgentId(cfg.acp?.defaultAgent);
-  if (defaultAgent) {
-    ids.add(defaultAgent);
-  }
-  for (const entry of cfg.acp?.allowedAgents ?? []) {
-    if (entry.trim() === "*") {
-      continue;
-    }
-    const id = normalizeOptionalAgentId(entry);
-    if (id) {
-      ids.add(id);
-    }
-  }
-  return Array.from(ids);
-}
-
-function summarizeError(err: unknown): string {
-  return formatErrorMessage(err);
-}
-
 function createAcpSpawnFailure(params: {
   status: "forbidden" | "error";
   errorCode: SpawnAcpErrorCode;
@@ -531,497 +227,7 @@ function createAcpSpawnFailure(params: {
   };
 }
 
-function isMissingPathError(error: unknown): boolean {
-  const code = error instanceof Error ? (error as NodeJS.ErrnoException).code : undefined;
-  return code === "ENOENT" || code === "ENOTDIR";
-}
-
-export async function resolveRuntimeCwdForAcpSpawn(params: {
-  resolvedCwd?: string;
-  explicitCwd?: string;
-}): Promise<string | undefined> {
-  if (!params.resolvedCwd) {
-    return undefined;
-  }
-  if (normalizeOptionalString(params.explicitCwd)) {
-    return params.resolvedCwd;
-  }
-  try {
-    await fs.access(params.resolvedCwd);
-    return params.resolvedCwd;
-  } catch (error) {
-    if (isMissingPathError(error)) {
-      return undefined;
-    }
-    throw error;
-  }
-}
-
-function resolveRequesterInternalSessionKey(params: {
-  cfg: OpenClawConfig;
-  requesterSessionKey?: string;
-}): string {
-  const { mainKey, alias } = resolveMainSessionAlias(params.cfg);
-  const requesterSessionKey = normalizeOptionalString(params.requesterSessionKey);
-  return requesterSessionKey
-    ? resolveInternalSessionKey({
-        key: requesterSessionKey,
-        alias,
-        mainKey,
-      })
-    : alias;
-}
-
-async function persistAcpSpawnSessionFileBestEffort(params: {
-  sessionId: string;
-  sessionKey: string;
-  sessionEntry: SessionEntry | undefined;
-  storePath: string;
-  agentId: string;
-  threadId?: string | number;
-  stage: "spawn" | "thread-bind";
-}): Promise<SessionEntry | undefined> {
-  try {
-    const resolvedSessionFile = await resolveSessionTranscriptRuntimeTarget({
-      sessionId: params.sessionId,
-      sessionKey: params.sessionKey,
-      storePath: params.storePath,
-      agentId: params.agentId,
-      threadId: params.threadId,
-    });
-    return (
-      loadSessionEntryReadOnly({
-        storePath: params.storePath,
-        sessionKey: resolvedSessionFile.sessionKey,
-        clone: false,
-      }) ?? params.sessionEntry
-    );
-  } catch (error) {
-    log.warn(
-      `ACP session-file persistence failed during ${params.stage} for ${params.sessionKey}: ${summarizeError(error)}`,
-    );
-    return params.sessionEntry;
-  }
-}
-
-function resolveAcpSpawnRequesterState(params: {
-  cfg: OpenClawConfig;
-  parentSessionKey?: string;
-  requesterAgentId: string;
-  targetAgentId: string;
-  ctx: SpawnAcpContext;
-  subagentStore?: SessionCapabilityStore;
-}): AcpSpawnRequesterState {
-  const bindingService = getSessionBindingService();
-  const requesterParsedSession = parseAgentSessionKey(params.parentSessionKey);
-  const isSubagentSession =
-    Boolean(requesterParsedSession) && isSubagentSessionKey(params.parentSessionKey);
-  const hasActiveSubagentBinding =
-    isSubagentSession && params.parentSessionKey
-      ? bindingService
-          .listBySession(params.parentSessionKey)
-          .some((record) => record.targetKind === "subagent" && record.status !== "ended")
-      : false;
-  const hasThreadContext =
-    typeof params.ctx.agentThreadId === "string"
-      ? Boolean(normalizeOptionalString(params.ctx.agentThreadId))
-      : params.ctx.agentThreadId != null;
-  return {
-    parentSessionKey: params.parentSessionKey,
-    isSubagentSession,
-    hasActiveSubagentBinding,
-    hasThreadContext,
-    heartbeatEnabled: isHeartbeatEnabledForSessionAgent({
-      cfg: params.cfg,
-      sessionKey: params.parentSessionKey,
-    }),
-    heartbeatRelayRouteUsable:
-      params.parentSessionKey && params.requesterAgentId
-        ? hasSessionLocalHeartbeatRelayRoute({
-            cfg: params.cfg,
-            parentSessionKey: params.parentSessionKey,
-            requesterAgentId: params.requesterAgentId,
-          })
-        : false,
-    origin: resolveRequesterOriginForChild({
-      cfg: params.cfg,
-      targetAgentId: params.targetAgentId,
-      requesterAgentId: params.requesterAgentId,
-      requesterChannel: params.ctx.agentChannel,
-      requesterAccountId: params.ctx.agentAccountId,
-      requesterTo: params.ctx.agentTo,
-      requesterThreadId: params.ctx.agentThreadId,
-      requesterGroupSpace: params.ctx.agentGroupSpace,
-      requesterMemberRoleIds: params.ctx.agentMemberRoleIds,
-    }),
-  };
-}
-
-function resolveAcpSpawnStreamPlan(params: {
-  spawnMode: SpawnAcpMode;
-  requestThreadBinding: boolean;
-  streamToParentRequested: boolean;
-  requester: AcpSpawnRequesterState;
-}): AcpSpawnStreamPlan {
-  // For mode=run without thread binding, implicitly route output to parent
-  // only for spawned subagent orchestrator sessions with heartbeat enabled
-  // AND a session-local heartbeat delivery route (target=last + usable last route).
-  // Skip requester sessions that are thread-bound (or carrying thread context)
-  // so user-facing threads do not receive unsolicited ACP progress chatter
-  // unless streamTo="parent" is explicitly requested. Use resolved spawnMode
-  // (not params.mode) so default mode selection works.
-  const implicitStreamToParent =
-    !params.streamToParentRequested &&
-    params.spawnMode === "run" &&
-    !params.requestThreadBinding &&
-    params.requester.isSubagentSession &&
-    !params.requester.hasActiveSubagentBinding &&
-    !params.requester.hasThreadContext &&
-    params.requester.heartbeatEnabled &&
-    params.requester.heartbeatRelayRouteUsable;
-
-  return {
-    implicitStreamToParent,
-    effectiveStreamToParent: params.streamToParentRequested || implicitStreamToParent,
-  };
-}
-
-function sessionEntryMatchesAcpResumeSessionId(
-  acp: SessionAcpMeta | undefined,
-  resumeSessionId: string,
-): boolean {
-  const identity = acp?.identity;
-  return (
-    normalizeOptionalString(identity?.agentSessionId) === resumeSessionId ||
-    normalizeOptionalString(identity?.acpxSessionId) === resumeSessionId
-  );
-}
-
-function sessionEntryIsOwnedByRequester(params: {
-  sessionKey: string;
-  entry: SessionEntry | undefined;
-  requesterSessionKey: string;
-}): boolean {
-  return (
-    params.sessionKey === params.requesterSessionKey ||
-    normalizeOptionalString(params.entry?.spawnedBy) === params.requesterSessionKey ||
-    normalizeOptionalString(params.entry?.parentSessionKey) === params.requesterSessionKey
-  );
-}
-
-function validateAcpResumeSessionOwnership(params: {
-  cfg: OpenClawConfig;
-  targetAgentId: string;
-  requesterSessionKey?: string;
-  resumeSessionId?: string;
-}): { ok: true } | { ok: false; error: string } {
-  const resumeSessionId = normalizeOptionalString(params.resumeSessionId);
-  if (!resumeSessionId) {
-    return { ok: true };
-  }
-  const requesterSessionKey = normalizeOptionalString(params.requesterSessionKey);
-  if (!requesterSessionKey) {
-    return {
-      ok: false,
-      error: "sessions_spawn resumeSessionId requires an active requester session context.",
-    };
-  }
-
-  const storePath = resolveStorePath(params.cfg.session?.store, { agentId: params.targetAgentId });
-  for (const { sessionKey, entry } of listSessionEntriesReadOnly({ storePath, clone: false })) {
-    const acp = readAcpSessionMeta({ sessionKey, cfg: params.cfg });
-    if (!sessionEntryMatchesAcpResumeSessionId(acp, resumeSessionId)) {
-      continue;
-    }
-    if (
-      sessionEntryIsOwnedByRequester({
-        sessionKey,
-        entry,
-        requesterSessionKey,
-      })
-    ) {
-      return { ok: true };
-    }
-    break;
-  }
-
-  return {
-    ok: false,
-    error:
-      "sessions_spawn resumeSessionId is only allowed for ACP sessions previously recorded for this requester. Omit resumeSessionId to start a fresh ACP session.",
-  };
-}
-
-type AcpSpawnRuntimeOptions = {
-  model?: string;
-  thinking?: string;
-  timeoutSeconds?: number;
-};
-
-function resolveAcpRuntimeTimeoutSeconds(runTimeoutSeconds?: number): number | undefined {
-  if (!runTimeoutSeconds) {
-    return undefined;
-  }
-  return Math.min(runTimeoutSeconds, ACP_RUNTIME_TIMEOUT_MAX_SECONDS);
-}
-
-function resolveAcpSpawnRuntimeOptions(params: {
-  cfg: OpenClawConfig;
-  targetAgentId: string;
-  configAgentId?: string;
-  model?: string;
-  thinking?: string;
-  runTimeoutSeconds?: number;
-}):
-  | { ok: true; runtimeOptions?: AcpSpawnRuntimeOptions; modelExplicit: boolean }
-  | { ok: false; error: string } {
-  const policyAgentId = params.configAgentId ?? params.targetAgentId;
-  const modelExplicit = normalizeOptionalString(params.model) !== undefined;
-  const model = resolveConfiguredSubagentSpawnModelSelection({
-    cfg: params.cfg,
-    agentId: policyAgentId,
-    modelOverride: params.model,
-  });
-  const targetAgentConfig = resolveAgentConfig(params.cfg, policyAgentId);
-  const thinkingPlan = resolveSubagentThinkingOverride({
-    cfg: params.cfg,
-    targetAgentConfig,
-    thinkingOverrideRaw: params.thinking,
-  });
-  if (thinkingPlan.status === "error") {
-    const { provider, model: modelId } = splitModelRef(model);
-    return {
-      ok: false,
-      error: `Invalid thinking level "${thinkingPlan.thinkingCandidateRaw}". Use one of: ${formatThinkingLevels(provider, modelId)}.`,
-    };
-  }
-
-  let thinking = thinkingPlan.thinkingOverride;
-  if (!thinking && model) {
-    const { provider, model: modelId } = splitModelRef(model);
-    if (provider && modelId) {
-      thinking = resolveThinkingDefault({
-        cfg: params.cfg,
-        provider,
-        model: modelId,
-      });
-    }
-  }
-
-  const timeoutSeconds = resolveAcpRuntimeTimeoutSeconds(params.runTimeoutSeconds);
-  const runtimeOptions =
-    model || thinking || timeoutSeconds
-      ? {
-          ...(model ? { model } : {}),
-          ...(thinking ? { thinking } : {}),
-          ...(timeoutSeconds ? { timeoutSeconds } : {}),
-        }
-      : undefined;
-  return { ok: true, runtimeOptions, modelExplicit };
-}
-
-async function initializeAcpSpawnRuntime(params: {
-  cfg: OpenClawConfig;
-  sessionKey: string;
-  targetAgentId: string;
-  runtimeMode: AcpRuntimeSessionMode;
-  resumeSessionId?: string;
-  runtimeOptions?: AcpSpawnRuntimeOptions;
-  modelExplicit?: boolean;
-  cwd?: string;
-}): Promise<AcpSpawnInitializedRuntime> {
-  const storePath = resolveStorePath(params.cfg.session?.store, { agentId: params.targetAgentId });
-  let sessionEntry = loadSessionEntry({
-    storePath,
-    sessionKey: params.sessionKey,
-    clone: false,
-  });
-  const sessionId = sessionEntry?.sessionId;
-  if (sessionId) {
-    sessionEntry = await persistAcpSpawnSessionFileBestEffort({
-      sessionId,
-      sessionKey: params.sessionKey,
-      storePath,
-      sessionEntry,
-      agentId: params.targetAgentId,
-      stage: "spawn",
-    });
-  }
-
-  const initialized = await getAcpSessionManager().initializeSession({
-    cfg: params.cfg,
-    sessionKey: params.sessionKey,
-    agent: params.targetAgentId,
-    mode: params.runtimeMode,
-    resumeSessionId: params.resumeSessionId,
-    runtimeOptions: params.runtimeOptions,
-    modelExplicit: params.modelExplicit,
-    cwd: params.cwd,
-    backendId: params.cfg.acp?.backend,
-  });
-
-  return {
-    initialized,
-    runtimeCloseHandle: {
-      runtime: initialized.runtime,
-      handle: initialized.handle,
-    },
-    sessionId,
-    sessionEntry,
-    storePath,
-  };
-}
-
-async function bindPreparedAcpThread(params: {
-  cfg: OpenClawConfig;
-  sessionKey: string;
-  targetAgentId: string;
-  label?: string;
-  preparedBinding: PreparedSpawnThreadBinding;
-  initializedRuntime: AcpSpawnInitializedRuntime;
-}): Promise<{
-  binding: SessionBindingRecord;
-  sessionEntry: SessionEntry | undefined;
-}> {
-  const binding = await getSessionBindingService().bind({
-    targetSessionKey: params.sessionKey,
-    targetKind: "session",
-    conversation: {
-      channel: params.preparedBinding.channel,
-      accountId: params.preparedBinding.accountId,
-      conversationId: params.preparedBinding.conversationId,
-      ...(params.preparedBinding.parentConversationId
-        ? { parentConversationId: params.preparedBinding.parentConversationId }
-        : {}),
-    },
-    placement: params.preparedBinding.placement,
-    metadata: {
-      threadName: resolveThreadBindingThreadName({
-        agentId: params.targetAgentId,
-        label: params.label || params.targetAgentId,
-      }),
-      agentId: params.targetAgentId,
-      label: params.label || undefined,
-      boundBy: "system",
-      introText: resolveThreadBindingIntroText({
-        agentId: params.targetAgentId,
-        label: params.label || undefined,
-        idleTimeoutMs: resolveThreadBindingIdleTimeoutMsForChannel({
-          cfg: params.cfg,
-          channel: params.preparedBinding.channel,
-          accountId: params.preparedBinding.accountId,
-        }),
-        maxAgeMs: resolveThreadBindingMaxAgeMsForChannel({
-          cfg: params.cfg,
-          channel: params.preparedBinding.channel,
-          accountId: params.preparedBinding.accountId,
-        }),
-        sessionCwd: resolveAcpSessionCwd(params.initializedRuntime.initialized.meta),
-        sessionDetails: resolveAcpThreadSessionDetailLines({
-          sessionKey: params.sessionKey,
-          meta: params.initializedRuntime.initialized.meta,
-        }),
-      }),
-    },
-  });
-  if (!binding.conversation.conversationId) {
-    throw new Error(
-      params.preparedBinding.placement === "child"
-        ? `Failed to create and bind a ${params.preparedBinding.channel} thread for this ACP session.`
-        : `Failed to bind the current ${params.preparedBinding.channel} conversation for this ACP session.`,
-    );
-  }
-
-  let sessionEntry = params.initializedRuntime.sessionEntry;
-  if (params.initializedRuntime.sessionId && params.preparedBinding.placement === "child") {
-    const boundThreadId = normalizeOptionalString(binding.conversation.conversationId);
-    if (boundThreadId) {
-      sessionEntry = await persistAcpSpawnSessionFileBestEffort({
-        sessionId: params.initializedRuntime.sessionId,
-        sessionKey: params.sessionKey,
-        storePath: params.initializedRuntime.storePath,
-        sessionEntry,
-        agentId: params.targetAgentId,
-        threadId: boundThreadId,
-        stage: "thread-bind",
-      });
-    }
-  }
-
-  return { binding, sessionEntry };
-}
-
-function resolveAcpSpawnBootstrapDeliveryPlan(params: {
-  cfg: OpenClawConfig;
-  spawnMode: SpawnAcpMode;
-  requestThreadBinding: boolean;
-  effectiveStreamToParent: boolean;
-  requester: AcpSpawnRequesterState;
-  binding: SessionBindingRecord | null;
-}): AcpSpawnBootstrapDeliveryPlan {
-  // Child-thread ACP spawns deliver bootstrap output to the new thread; current-conversation
-  // binds deliver back to the originating target.
-  const boundThreadIdRaw = params.binding?.conversation.conversationId;
-  const boundThreadId = boundThreadIdRaw ? normalizeOptionalString(boundThreadIdRaw) : undefined;
-  const fallbackThreadIdRaw = params.requester.origin?.threadId;
-  const fallbackThreadId =
-    fallbackThreadIdRaw != null ? normalizeOptionalString(String(fallbackThreadIdRaw)) : undefined;
-  const deliveryThreadId = boundThreadId ?? fallbackThreadId;
-  const requesterConversationRef = resolveConversationRefForThreadBinding({
-    cfg: params.cfg,
-    channel: params.requester.origin?.channel,
-    accountId: params.requester.origin?.accountId,
-    threadId: fallbackThreadId,
-    to: params.requester.origin?.to,
-  });
-  const requesterAccountId = resolveSpawnChannelAccountId({
-    cfg: params.cfg,
-    channel: params.requester.origin?.channel,
-    accountId: params.requester.origin?.accountId,
-  });
-  const bindingMatchesRequesterConversation = Boolean(
-    params.requester.origin?.channel &&
-    params.binding?.conversation.channel === params.requester.origin.channel &&
-    params.binding?.conversation.accountId === requesterAccountId &&
-    requesterConversationRef?.conversationId &&
-    params.binding?.conversation.conversationId === requesterConversationRef.conversationId &&
-    (params.binding?.conversation.parentConversationId ?? undefined) ===
-      (requesterConversationRef.parentConversationId ?? undefined),
-  );
-  const boundDeliveryTarget = routeToDeliveryFields(routeFromBindingRecord(params.binding));
-  const inferredDeliveryTo =
-    (bindingMatchesRequesterConversation
-      ? normalizeOptionalString(params.requester.origin?.to)
-      : undefined) ??
-    boundDeliveryTarget.to ??
-    normalizeOptionalString(params.requester.origin?.to) ??
-    formatConversationTarget({
-      channel: params.requester.origin?.channel,
-      conversationId: deliveryThreadId,
-    });
-  const resolvedDeliveryThreadId = bindingMatchesRequesterConversation
-    ? fallbackThreadId
-    : (boundDeliveryTarget.threadId ?? deliveryThreadId);
-  const hasDeliveryTarget = Boolean(params.requester.origin?.channel && inferredDeliveryTo);
-
-  // Thread-bound session spawns always deliver inline to their bound thread.
-  // Background run-mode spawns should stay internal and report back through
-  // the parent task lifecycle notifier instead of letting the child ACP
-  // session write raw output directly into the originating channel.
-  const useInlineDelivery =
-    hasDeliveryTarget && !params.effectiveStreamToParent && params.spawnMode === "session";
-
-  return {
-    useInlineDelivery,
-    channel: useInlineDelivery ? params.requester.origin?.channel : undefined,
-    accountId: useInlineDelivery ? requesterAccountId : undefined,
-    to: useInlineDelivery ? inferredDeliveryTo : undefined,
-    threadId:
-      useInlineDelivery && resolvedDeliveryThreadId != null
-        ? normalizeOptionalString(String(resolvedDeliveryThreadId))
-        : undefined,
-  };
-}
+export { resolveRuntimeCwdForAcpSpawn } from "./acp-spawn-runtime.js";
 
 export async function spawnAcpDirect(
   params: SpawnAcpParams,
@@ -1215,7 +421,7 @@ export async function spawnAcpDirect(
     return createAcpSpawnFailure({
       status: "error",
       errorCode: "cwd_resolution_failed",
-      error: summarizeError(error),
+      error: formatErrorMessage(error),
     });
   }
 
@@ -1507,4 +713,3 @@ export async function spawnAcpDirect(
     note: spawnMode === "session" ? ACP_SPAWN_SESSION_ACCEPTED_NOTE : ACP_SPAWN_ACCEPTED_NOTE,
   };
 }
-/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -357,7 +357,7 @@ async function resolveCollectorOutputModelError(params: {
       workspaceDir: params.workspaceDir,
     });
   } catch (error) {
-    return `sessions_spawn could not verify outputSchema model capabilities: ${summarizeError(error)}`;
+    return `sessions_spawn could not verify outputSchema model capabilities: ${summarizeSpawnError(error)}`;
   }
   const entry = findModelCatalogEntry(catalog, { provider, modelId: model });
   if (!entry || supportsModelTools(entry)) {
@@ -713,7 +713,7 @@ async function prepareSubagentSessionContext(params: {
       ...(forkFallbackNote ? { forkFallbackNote } : {}),
     };
   } catch (err) {
-    return { status: "error", error: summarizeError(err) };
+    return { status: "error", error: summarizeSpawnError(err) };
   }
 }
 
@@ -751,7 +751,7 @@ async function prepareContextEngineSubagentSpawn(params: {
   } catch (err) {
     return {
       status: "error",
-      error: `Context engine subagent preparation failed: ${summarizeError(err)}`,
+      error: `Context engine subagent preparation failed: ${summarizeSpawnError(err)}`,
     };
   }
 }
@@ -914,16 +914,6 @@ function resolveSubagentContextMode(params: {
   }).defaultSpawnContext;
 }
 
-function summarizeError(err: unknown): string {
-  if (err instanceof Error) {
-    return err.message;
-  }
-  if (typeof err === "string") {
-    return err;
-  }
-  return "error";
-}
-
 async function bindThreadForSubagentSpawn(params: {
   cfg: OpenClawConfig;
   childSessionKey: string;
@@ -1014,7 +1004,7 @@ async function bindThreadForSubagentSpawn(params: {
   } catch (err) {
     return {
       status: "error",
-      error: `Thread bind failed: ${summarizeError(err)}`,
+      error: `Thread bind failed: ${summarizeSpawnError(err)}`,
     };
   }
 }
@@ -1892,7 +1882,7 @@ export async function spawnSubagentDirect(
           if (error instanceof GatewayDrainingError) {
             return false;
           }
-          const launchError = summarizeError(error);
+          const launchError = summarizeSpawnError(error);
           const [contextRollback, sessionCleanup] = await Promise.allSettled([
             rollbackPreparedContextEngine(pipelineResult.state.contextEnginePreparation),
             cleanupFailedSpawnBeforeAgentStart({


### PR DESCRIPTION
## What Problem This Solves

`src/agents/acp-spawn.ts` carried `/* oxlint-disable max-lines -- TODO: split this grandfathered
oversized file. */` plus an entry in `config/max-lines-baseline.txt`. Root `AGENTS.md` is explicit:
"Never add a max-lines suppression. Existing suppressions are grandfathered TODOs; split the file and
remove its suppression plus baseline entry", and the ratchet may only shrink.

The file measured 1412 effective lines against the 700 budget for `src/**/*.ts`, but its exported
entry point `spawnAcpDirect` was only ~450. The bulk was helper clusters that had accumulated around
it, so the budget was reachable by relocation alone.

Separately, `subagent-spawn.ts` defined a local `summarizeError` whose body was byte-equivalent to
the `summarizeSpawnError` already exported from `spawn-pipeline.ts` — which that same file already
imported and used at two other call sites. Two names, one behavior, one file.

## Why This Change Was Made

Pure relocation. `spawnAcpDirect` is untouched; no signature changed, no side effect reordered.
Helpers moved into siblings by concern:

- `acp-spawn-heartbeat.ts` — heartbeat enablement, config, session-local relay routing
- `acp-spawn-target.ts` — target agent id resolution and allowlist checks
- `acp-spawn-requester.ts` — requester state, stream plan, resume-session ownership validation
- `acp-spawn-runtime.ts` — runtime options, initialization, prepared-thread binding
- `acp-spawn-admission.ts` — active-run accounting for owner admission
- `acp-spawn-bootstrap-delivery.ts` — bootstrap delivery planning

Every inline comment moved with the code it explains; several encode real invariants and none were
reworded. Three helpers beyond the initial plan (runtime cwd/session mode, gateway attachment
conversion) were also relocated because the first pass landed at 733 effective lines — still over
budget — and decomposing `spawnAcpDirect` to close that gap was explicitly out of scope.

`acp-spawn.ts` is now **684 effective lines**; every new file is between 38 and 261. The suppression
and the baseline entry are both gone, so the ratchet shrinks rather than holds.

The duplicated `summarizeError` in `subagent-spawn.ts` is deleted and its five call sites routed to
`summarizeSpawnError`. ACP's own one-line `summarizeError` alias was a wrapper around
`formatErrorMessage` with genuinely different semantics; rather than collapse it into the ternary
helper and change behavior, its two call sites now call `formatErrorMessage` directly and the alias
is gone.

## User Impact

None. No behavior change, no public surface change, no config or protocol change. This is file
organization plus removal of one grandfathered lint suppression.

Note on LOC: production lines go up by roughly 60, entirely from import headers across six new
files. That is the expected cost of a file split, and the payoff is named rather than implied — a
grandfathered TODO retired, a file brought under the enforced budget, and the ratchet reduced.

## Evidence

See the PR checks. Local proof: `acp-spawn.test.ts` 67 passed, `acp-spawn-parent-stream.test.ts` 35
passed, `subagent-spawn.test.ts` 51 passed, `src/acp` 1340 tests across 167 files passed,
`node scripts/check-max-lines-ratchet.mjs` OK, and the changed-surface gate passed on hosted Testbox.
