### PR TITLE
fix(ui): hide oversized history markers

### DIFF
--- a/ui/src/e2e/chat-message-actions.e2e.test.ts
+++ b/ui/src/e2e/chat-message-actions.e2e.test.ts
@@ -17,7 +17,6 @@ const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM 
 const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
 const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
 const artifactDir = path.resolve(process.cwd(), ".artifacts/control-ui-e2e/chat-message-actions");
-const transportPreviewLimit = 8_000;
 
 // Neutral filler line repeated to push the fixture past the transport
 // preview limit without embedding stale implementation narrative; the
@@ -167,7 +166,7 @@ describeControlUiE2e("Control UI chat message actions", () => {
     await server?.close();
   });
 
-  it("offers Reply inline and mirrors every assistant action in the context menu", async () => {
+  it("keeps oversized history notices consistent through recovery and message actions", async () => {
     const context = await browser.newContext({
       colorScheme: "dark",
       locale: "en-US",
@@ -185,9 +184,10 @@ describeControlUiE2e("Control UI chat message actions", () => {
     const privateThinking = "private reply reasoning";
     const visibleThinkingAnswer = "Visible reply context only.";
     const fullAssistantContent = realisticFullAssistantContent;
-    const truncatedPreview = `${fullAssistantContent.slice(0, transportPreviewLimit)}\n...(truncated)...`;
-    expect(fullAssistantContent.length).toBeGreaterThan(transportPreviewLimit);
+    const rawOversizedMarker = "[chat.history omitted: message too large]";
+    const oversizedNotice = "This message is too large to display here.";
     const gateway = await installMockGateway(page, {
+      deferredMethods: ["chat.message.get"],
       historyMessages: [
         {
           role: "assistant",
@@ -220,24 +220,38 @@ describeControlUiE2e("Control UI chat message actions", () => {
         },
         {
           role: "assistant",
-          content: [{ type: "text", text: truncatedPreview }],
+          content: [{ type: "text", text: rawOversizedMarker }],
           timestamp: Date.now() + 4,
-          // The Gateway records a display-cap structurally; the sentinel alone is
-          // ordinary Markdown to the UI.
           __openclaw: {
             id: "assistant-full-message",
             seq: 5,
             truncated: true,
-            reason: "display-cap",
+            reason: "oversized",
           },
         },
-      ],
-      methodResponses: {
-        "chat.message.get": {
-          ok: true,
-          message: { role: "assistant", content: fullAssistantContent },
+        {
+          role: "user",
+          content: [{ type: "text", text: rawOversizedMarker }],
+          timestamp: Date.now() + 5,
+          __openclaw: { id: "oversized-user", seq: 6, truncated: true, reason: "oversized" },
         },
-      },
+        {
+          role: "toolResult",
+          toolCallId: "oversized-tool-call-1",
+          toolName: "read_file",
+          content: rawOversizedMarker,
+          timestamp: Date.now() + 6,
+          __openclaw: { id: "oversized-tool-1", seq: 7, truncated: true, reason: "oversized" },
+        },
+        {
+          role: "toolResult",
+          toolCallId: "oversized-tool-call-2",
+          toolName: "run_command",
+          content: rawOversizedMarker,
+          timestamp: Date.now() + 7,
+          __openclaw: { id: "oversized-tool-2", seq: 8, truncated: true, reason: "oversized" },
+        },
+      ],
     });
 
     try {
@@ -417,12 +431,34 @@ describeControlUiE2e("Control UI chat message actions", () => {
         messageId: "assistant-full-message",
         maxChars: 500_000,
       });
+      await expect
+        .poll(() => fullTextBubble.locator(".chat-text").textContent())
+        .toContain(oversizedNotice);
+      expect(await fullTextBubble.getAttribute("data-message-text")).toBe(oversizedNotice);
+      expect(await page.locator("body").textContent()).not.toContain(rawOversizedMarker);
+      await screenshot(page, "07-oversized-pending-dark.png");
+      const fullTextReplyPreview = page.locator(".chat-reply-preview");
+      await fullTextBubble.click({ button: "right" });
+      await menu.getByRole("menuitem", { name: "Copy as markdown" }).click();
+      await expect
+        .poll(() => page.evaluate(() => navigator.clipboard.readText()))
+        .toBe(oversizedNotice);
+      await fullTextBubble.click({ button: "right" });
+      await menu.getByRole("menuitem", { name: "Reply to message" }).click();
+      await expect
+        .poll(() => fullTextReplyPreview.locator(".chat-reply-preview__text").textContent())
+        .toBe(oversizedNotice);
+      await fullTextReplyPreview.getByRole("button", { name: "Cancel reply" }).click();
+      await gateway.resolveDeferred("chat.message.get", {
+        ok: true,
+        message: { role: "assistant", content: fullAssistantContent },
+      });
       const fullTail = fullTextBubble.getByRole("heading", { name: "Final verification" });
       await fullTail.waitFor({ state: "visible" });
       expect(await fullTextBubble.getByRole("button", { name: "Show more" }).count()).toBe(0);
       expect(await fullTextBubble.getByRole("button", { name: "Show less" }).count()).toBe(0);
       await fullTail.scrollIntoViewIfNeeded();
-      await screenshot(page, "07-full-message-dark.png");
+      await screenshot(page, "08-oversized-resolved-dark.png");
 
       await fullTextGroup.hover();
       await fullTextGroup.getByRole("button", { name: "Copy as markdown" }).click();
@@ -430,7 +466,6 @@ describeControlUiE2e("Control UI chat message actions", () => {
         .poll(() => page.evaluate(() => navigator.clipboard.readText()))
         .toBe(fullAssistantContent);
       await fullTextGroup.getByRole("button", { name: "Reply to message" }).click();
-      const fullTextReplyPreview = page.locator(".chat-reply-preview");
       await expect
         .poll(() => fullTextReplyPreview.locator(".chat-reply-preview__text").textContent())
         .toContain("# Deployment report");
@@ -448,9 +483,29 @@ describeControlUiE2e("Control UI chat message actions", () => {
         .toContain("# Deployment report");
       await fullTextReplyPreview.getByRole("button", { name: "Cancel reply" }).click();
 
+      const userOversizedBubble = page.locator('.chat-bubble[data-entry-id="oversized-user"]');
+      expect(await userOversizedBubble.getAttribute("data-message-text")).toBe(oversizedNotice);
+      await expect
+        .poll(() => userOversizedBubble.locator(".chat-text").textContent())
+        .toContain(oversizedNotice);
+
+      const activitySummary = page.locator(".chat-activity-group__summary").last();
+      await activitySummary.click();
+      const groupedToolBubble = page.locator('.chat-bubble[data-entry-id="oversized-tool-1"]');
+      await groupedToolBubble.waitFor({ state: "visible" });
+      expect(await groupedToolBubble.getAttribute("data-message-text")).toBe(oversizedNotice);
+      await groupedToolBubble.click({ button: "right" });
+      expect(await menu.getByRole("menuitem").allTextContents()).toEqual(["Reply"]);
+      await screenshot(page, "09-oversized-tool-actions.png");
+      await menu.getByRole("menuitem", { name: "Reply to message" }).click();
+      await expect
+        .poll(() => fullTextReplyPreview.locator(".chat-reply-preview__text").textContent())
+        .toBe(oversizedNotice);
+      await fullTextReplyPreview.getByRole("button", { name: "Cancel reply" }).click();
+
       await setThemeMode(page, "light");
       await fullTail.scrollIntoViewIfNeeded();
-      await screenshot(page, "08-full-message-light.png");
+      await screenshot(page, "10-oversized-resolved-light.png");
       expect(await gateway.getRequests("chat.message.get")).toHaveLength(1);
     } finally {
       await context.close();

--- a/ui/src/e2e/chat-message-actions.e2e.test.ts
+++ b/ui/src/e2e/chat-message-actions.e2e.test.ts
@@ -444,4 +444,95 @@ describeControlUiE2e("Control UI chat message actions", () => {
       await context.close();
     }
   });
+
+  it("renders oversized history rows as a notice and never leaks the raw placeholder through actions (#111854)", async () => {
+    const context = await browser.newContext({
+      locale: "en-US",
+      recordVideo: captureUiProof
+        ? { dir: path.join(artifactDir, "video"), size: { height: 900, width: 1440 } }
+        : undefined,
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1440 },
+    });
+    await context.grantPermissions(["clipboard-read", "clipboard-write"], {
+      origin: new URL(server.baseUrl).origin,
+    });
+    const page = await context.newPage();
+    const rawPlaceholder = "[chat.history omitted: message too large]";
+    const notice = "This message is too large to display here.";
+    await installMockGateway(page, {
+      historyMessages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: rawPlaceholder }],
+          timestamp: Date.now(),
+          __openclaw: { id: "oversized-user-proof", seq: 1, truncated: true, reason: "oversized" },
+        },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: rawPlaceholder }],
+          timestamp: Date.now() + 1,
+          __openclaw: { id: "oversized-asst-proof", seq: 2, truncated: true, reason: "oversized" },
+        },
+      ],
+    });
+
+    try {
+      await page.goto(`${server.baseUrl}chat`);
+      await page.evaluate(() => document.documentElement.setAttribute("data-theme-mode", "dark"));
+
+      // The raw internal placeholder must never reach the rendered DOM.
+      await expect.poll(() => page.locator(".chat-history-omitted").count()).toBe(2);
+      await expect.poll(() => page.locator("body").innerText()).not.toContain(rawPlaceholder);
+      const noticeTexts = await page.locator(".chat-history-omitted").allTextContents();
+      expect(noticeTexts.every((value) => value.trim() === notice)).toBe(true);
+      await screenshot(page, "10-oversized-notice.png");
+
+      // The data-message-text attribute (context-menu Reply source) must carry the
+      // notice, not the raw placeholder, for both user and assistant oversized rows.
+      const assistantBubble = page.locator('.chat-bubble[data-entry-id="oversized-asst-proof"]');
+      await assistantBubble.waitFor({ state: "visible" });
+      expect(await assistantBubble.getAttribute("data-message-text")).toBe(notice);
+      const userBubble = page.locator('.chat-bubble[data-entry-id="oversized-user-proof"]');
+      expect(await userBubble.getAttribute("data-message-text")).toBe(notice);
+
+      // Inline Reply must route the notice into the reply preview, never the raw marker.
+      const assistantGroup = assistantBubble.locator(
+        "xpath=ancestor::*[contains(concat(' ', normalize-space(@class), ' '), ' chat-group ')]",
+      );
+      await assistantGroup.hover();
+      await assistantGroup.getByRole("button", { name: "Reply to message" }).click();
+      const replyPreview = page.locator(".chat-reply-preview");
+      await replyPreview.waitFor({ state: "visible" });
+      await expect
+        .poll(() => replyPreview.locator(".chat-reply-preview__text").textContent())
+        .toBe(notice);
+      await screenshot(page, "11-oversized-reply-preview.png");
+      await replyPreview.getByRole("button", { name: "Cancel reply" }).click();
+
+      // Copy as markdown must place the notice on the clipboard, never the raw marker.
+      await assistantGroup.hover();
+      await assistantGroup.getByRole("button", { name: "Copy as markdown" }).click();
+      await expect.poll(() => page.evaluate(() => navigator.clipboard.readText())).toBe(notice);
+
+      // Context-menu Reply reads data-message-text, which must be the notice.
+      const menu = page.locator(".chat-reply-context-menu");
+      await assistantBubble.click({ button: "right" });
+      await menu.waitFor({ state: "visible" });
+      expect(await menu.getByRole("menuitem").allTextContents()).toEqual([
+        "Reply",
+        "Hide message",
+        "Copy as markdown",
+      ]);
+      await screenshot(page, "12-oversized-context-menu.png");
+      await menu.getByRole("menuitem", { name: "Reply to message" }).click();
+      await replyPreview.waitFor({ state: "visible" });
+      await expect
+        .poll(() => replyPreview.locator(".chat-reply-preview__text").textContent())
+        .toBe(notice);
+      await replyPreview.getByRole("button", { name: "Cancel reply" }).click();
+    } finally {
+      await context.close();
+    }
+  });
 });

--- a/ui/src/e2e/chat-message-actions.e2e.test.ts
+++ b/ui/src/e2e/chat-message-actions.e2e.test.ts
@@ -483,7 +483,9 @@ describeControlUiE2e("Control UI chat message actions", () => {
 
       // The raw internal placeholder must never reach the rendered DOM.
       await expect.poll(() => page.locator(".chat-history-omitted").count()).toBe(2);
-      await expect.poll(() => page.locator("body").innerText()).not.toContain(rawPlaceholder);
+      await expect
+        .poll(() => page.evaluate(() => document.body.textContent))
+        .not.toContain(rawPlaceholder);
       const noticeTexts = await page.locator(".chat-history-omitted").allTextContents();
       expect(noticeTexts.every((value) => value.trim() === notice)).toBe(true);
       await screenshot(page, "10-oversized-notice.png");

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -5666,6 +5666,7 @@ export const en: TranslationMap = {
       forkUnavailable: "Fork is unavailable while the agent is working",
       showLess: "Show less",
       showMore: "Show more",
+      tooLargeToDisplay: "This message is too large to display here.",
       unknownDate: "Unknown date",
       toolSender: "Tool",
       fullContentLoadExhausted: "Could not load the full message.",

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -4898,6 +4898,7 @@ export const en: TranslationMap = {
       forkUnavailable: "Fork is unavailable while the agent is working",
       showLess: "Show less",
       showMore: "Show more",
+      tooLargeToDisplay: "This message is too large to display here.",
       unknownDate: "Unknown date",
       voiceNote: "Voice note",
       duplicatesCollapsed: "{count} consecutive identical messages collapsed",

--- a/ui/src/pages/chat/components/chat-message-bubble.ts
+++ b/ui/src/pages/chat/components/chat-message-bubble.ts
@@ -41,7 +41,7 @@ import {
   renderAssistantMessageMarkdown,
   renderMarkdownText,
   renderUserMessageMarkdown,
-  resolveNormalizedMessageMarkdown,
+  resolveMessageDisplayMarkdown,
   type AssistantMessageDisclosure,
 } from "./chat-message-markdown.ts";
 import {
@@ -281,8 +281,8 @@ export function renderGroupedMessage(
   const pairingQrExpiryNotices = extractPairingQrExpiryNotices(message);
   const hasPairingQrExpiryNotices = pairingQrExpiryNotices.length > 0;
 
-  const extractedText = resolveNormalizedMessageMarkdown(normalizedMessage);
-  const actionText = opts.actionMarkdown ?? extractedText;
+  const displayMarkdown = resolveMessageDisplayMarkdown(message, normalizedMessage);
+  const actionText = opts.actionMarkdown ?? displayMarkdown;
   const assistantAttachments = normalizedMessage.content.filter(
     (item): item is AttachmentItem => item.type === "attachment",
   );
@@ -293,7 +293,7 @@ export function renderGroupedMessage(
   const extractedThinking =
     opts.showReasoning && role === "assistant" ? extractThinkingCached(message) : null;
   const reasoningMarkdown = extractedThinking ? formatReasoningMarkdown(extractedThinking) : null;
-  const markdown = extractedText?.trim() ? extractedText : null;
+  const markdown = displayMarkdown ? displayMarkdown : null;
   const markdownRenderOptions: MarkdownRenderOptions = {
     assistantTranscriptRoleHeaders: role === "assistant",
     codeBlockChrome: role === "user" ? "none" : "copy",

--- a/ui/src/pages/chat/components/chat-message-bubble.ts
+++ b/ui/src/pages/chat/components/chat-message-bubble.ts
@@ -40,6 +40,7 @@ import { renderAssistantAttachments } from "./chat-message-attachments.ts";
 import { renderMessageImages, resolveRenderableMessageImages } from "./chat-message-images.ts";
 import {
   detectJson,
+  isOversizedHistoryPlaceholder,
   jsonSummaryLabel,
   renderAssistantMessageMarkdown,
   renderMarkdownText,
@@ -224,6 +225,11 @@ export function renderGroupedMessage(
   const hasPairingQrExpiryNotices = pairingQrExpiryNotices.length > 0;
 
   const extractedText = resolveNormalizedMessageMarkdown(normalizedMessage);
+  const isOversized = isOversizedHistoryPlaceholder(message);
+  // `actionText` is the shared display projection from resolveMessageActionDetails:
+  // oversized rows already resolve to the localized notice there, so the
+  // `data-message-text` attribute and reply/copy actions never carry the raw
+  // internal placeholder.
   const actionText = opts.actionMarkdown ?? extractedText;
   const assistantAttachments = normalizedMessage.content.filter(
     (item): item is AttachmentItem => item.type === "attachment",
@@ -235,7 +241,8 @@ export function renderGroupedMessage(
   const extractedThinking =
     opts.showReasoning && role === "assistant" ? extractThinkingCached(message) : null;
   const reasoningMarkdown = extractedThinking ? formatReasoningMarkdown(extractedThinking) : null;
-  const markdown = extractedText?.trim() ? extractedText : null;
+  const oversizedNotice = isOversized ? t("chat.messages.tooLargeToDisplay") : null;
+  const markdown = oversizedNotice ?? (extractedText?.trim() ? extractedText : null);
   const markdownRenderOptions: MarkdownRenderOptions = {
     assistantTranscriptRoleHeaders: role === "assistant",
     codeBlockChrome: role === "user" ? "none" : "copy",
@@ -448,9 +455,13 @@ export function renderGroupedMessage(
                             </summary>
                             <pre class="chat-json-content"><code>${jsonResult.pretty}</code></pre>
                           </details>`
-                        : markdown
-                          ? renderMarkdownText(markdown, opts.isStreaming, markdownRenderOptions)
-                          : nothing}
+                        : oversizedNotice
+                          ? html`<div class="chat-text chat-history-omitted">
+                              ${oversizedNotice}
+                            </div>`
+                          : markdown
+                            ? renderMarkdownText(markdown, opts.isStreaming, markdownRenderOptions)
+                            : nothing}
                       ${hasToolCards
                         ? singleToolCard && !markdown && !hasImages
                           ? renderExpandedToolCardContent(
@@ -502,26 +513,28 @@ export function renderGroupedMessage(
                 </div>`
               : nothing}
             ${assistantViewContent}
-            ${jsonResult
-              ? html`<details class="chat-json-collapse">
-                  <summary class="chat-json-summary">
-                    <span class="chat-json-badge">JSON</span>
-                    <span class="chat-json-label">${jsonSummaryLabel(jsonResult.parsed)}</span>
-                  </summary>
-                  <pre class="chat-json-content"><code>${jsonResult.pretty}</code></pre>
-                </details>`
-              : markdown
-                ? normalizedRole === "user"
-                  ? renderUserMessageMarkdown(markdown, messageKey, opts, markdownRenderOptions)
-                  : normalizedRole === "assistant"
-                    ? renderAssistantMessageMarkdown(
-                        markdown,
-                        opts.isStreaming,
-                        opts.assistantMessageDisclosure,
-                        markdownRenderOptions,
-                      )
-                    : renderMarkdownText(markdown, opts.isStreaming, markdownRenderOptions)
-                : nothing}
+            ${oversizedNotice
+              ? html`<div class="chat-text chat-history-omitted">${oversizedNotice}</div>`
+              : jsonResult
+                ? html`<details class="chat-json-collapse">
+                    <summary class="chat-json-summary">
+                      <span class="chat-json-badge">JSON</span>
+                      <span class="chat-json-label">${jsonSummaryLabel(jsonResult.parsed)}</span>
+                    </summary>
+                    <pre class="chat-json-content"><code>${jsonResult.pretty}</code></pre>
+                  </details>`
+                : markdown
+                  ? normalizedRole === "user"
+                    ? renderUserMessageMarkdown(markdown, messageKey, opts, markdownRenderOptions)
+                    : normalizedRole === "assistant"
+                      ? renderAssistantMessageMarkdown(
+                          markdown,
+                          opts.isStreaming,
+                          opts.assistantMessageDisclosure,
+                          markdownRenderOptions,
+                        )
+                      : renderMarkdownText(markdown, opts.isStreaming, markdownRenderOptions)
+                  : nothing}
             ${hasToolCards
               ? renderInlineToolCards(toolCards, {
                   messageKey,

--- a/ui/src/pages/chat/components/chat-message-markdown.test.ts
+++ b/ui/src/pages/chat/components/chat-message-markdown.test.ts
@@ -51,6 +51,42 @@ describe("resolveMessageActionDetails full-message fetch flag", () => {
     });
     expect(details?.shouldFetchFullMessage).toBe(false);
   });
+
+  it("projects an oversized assistant marker to a notice without disabling recovery", () => {
+    const message = {
+      role: "assistant",
+      content: "[chat.history omitted: message too large]",
+      __openclaw: { id: "msg-oversized", truncated: true, reason: "oversized" },
+    };
+    const details = resolveMessageActionDetails({
+      message,
+      messageId: "msg-oversized",
+      canFetchFullMessage: true,
+      onReply: () => {},
+      senderLabel: "assistant",
+    });
+
+    expect(details?.shouldFetchFullMessage).toBe(true);
+    expect(details?.markdown).toBe("This message is too large to display here.");
+    expect(details?.replyTarget?.text).toBe("This message is too large to display here.");
+
+    const loaded = resolveMessageActionDetails({
+      message,
+      messageId: "msg-oversized",
+      canFetchFullMessage: true,
+      getAssistantMessageExpansion: () => ({
+        status: "loaded",
+        markdown: "Recovered full assistant content.",
+        revision: 1,
+      }),
+      onReply: () => {},
+      senderLabel: "assistant",
+    });
+
+    expect(loaded?.shouldFetchFullMessage).toBe(true);
+    expect(loaded?.markdown).toBe("Recovered full assistant content.");
+    expect(loaded?.replyTarget?.text).toBe("Recovered full assistant content.");
+  });
 });
 
 describe("user message disclosure", () => {

--- a/ui/src/pages/chat/components/chat-message-markdown.ts
+++ b/ui/src/pages/chat/components/chat-message-markdown.ts
@@ -1,3 +1,4 @@
+import { asNullableRecord } from "@openclaw/normalization-core/record-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { html, nothing } from "lit";
 import { ref } from "lit/directives/ref.js";
@@ -82,7 +83,7 @@ export type MessageActionDetails = {
   shouldFetchFullMessage: boolean;
 };
 
-export function resolveNormalizedMessageMarkdown(normalizedMessage: NormalizedMessage): string {
+function resolveNormalizedMessageMarkdown(normalizedMessage: NormalizedMessage): string {
   return normalizedMessage.content
     .reduce<string[]>((lines, item) => {
       if (item.type === "text" && typeof item.text === "string") {
@@ -94,14 +95,24 @@ export function resolveNormalizedMessageMarkdown(normalizedMessage: NormalizedMe
     .trim();
 }
 
+/** Keep internal oversized-history markers out of every user-visible text surface. */
+export function resolveMessageDisplayMarkdown(
+  message: unknown,
+  normalizedMessage: NormalizedMessage,
+): string {
+  const metadata = asNullableRecord(asNullableRecord(message)?.["__openclaw"]);
+  if (metadata?.truncated === true && metadata.reason === "oversized") {
+    return t("chat.messages.tooLargeToDisplay");
+  }
+  const markdown = resolveNormalizedMessageMarkdown(normalizedMessage);
+  return normalizeRoleForGrouping(normalizedMessage.role) === "assistant"
+    ? stripThinkingTags(markdown).trim()
+    : markdown.trim();
+}
+
 export function resolveMessageReplyText(message: unknown): string {
   const normalizedMessage = normalizeMessage(message);
-  const markdown = resolveNormalizedMessageMarkdown(normalizedMessage);
-  const visibleMarkdown =
-    normalizeRoleForGrouping(normalizedMessage.role) === "assistant"
-      ? stripThinkingTags(markdown).trim()
-      : markdown.trim();
-  return visibleMarkdown;
+  return resolveMessageDisplayMarkdown(message, normalizedMessage);
 }
 
 export function resolveMessageActionDetails(params: {

--- a/ui/src/pages/chat/components/chat-message-markdown.ts
+++ b/ui/src/pages/chat/components/chat-message-markdown.ts
@@ -1,3 +1,4 @@
+import { asNullableRecord } from "@openclaw/normalization-core/record-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { html, nothing } from "lit";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
@@ -84,6 +85,45 @@ export function resolveNormalizedMessageMarkdown(normalizedMessage: NormalizedMe
     .trim();
 }
 
+/**
+ * Reads the Gateway transcript metadata (`__openclaw`) as a non-array record,
+ * using the shared canonical guard so oversized/truncation detection cannot be
+ * fooled by array-shaped metadata. Returns null for missing or malformed rows.
+ */
+function resolveTranscriptMetadata(message: unknown): Record<string, unknown> | null {
+  if (!message || typeof message !== "object") {
+    return null;
+  }
+  return asNullableRecord((message as Record<string, unknown>)["__openclaw"]);
+}
+
+/** Oversized rows carry `truncated: true, reason: "oversized"` and must surface a notice. */
+export function isOversizedHistoryPlaceholder(message: unknown): boolean {
+  const metadata = resolveTranscriptMetadata(message);
+  return metadata?.truncated === true && metadata.reason === "oversized";
+}
+
+/**
+ * Shared display projection for a transcript row: oversized rows resolve to the
+ * localized notice instead of the raw internal placeholder, while ordinary rows
+ * keep their normalized markdown (thinking tags stripped for assistants). Every
+ * user-facing surface - bubble text, `data-message-text`, inline Reply,
+ * context-menu Reply, copy, and canvas - reads from this projection so the raw
+ * marker can never leak through an action or attribute path.
+ */
+function resolveMessageDisplayText(params: {
+  message: unknown;
+  normalizedMarkdown: string;
+  role: string;
+}): string {
+  if (isOversizedHistoryPlaceholder(params.message)) {
+    return t("chat.messages.tooLargeToDisplay");
+  }
+  return params.role === "assistant"
+    ? stripThinkingTags(params.normalizedMarkdown).trim()
+    : params.normalizedMarkdown.trim();
+}
+
 export function resolveMessageActionDetails(params: {
   message: unknown;
   messageId: string;
@@ -94,12 +134,8 @@ export function resolveMessageActionDetails(params: {
 }): MessageActionDetails | null {
   const { message, messageId: renderMessageId, canFetchFullMessage, onReply, senderLabel } = params;
   const record = message as Record<string, unknown>;
-  const transcriptMeta =
-    record["__openclaw"] &&
-    typeof record["__openclaw"] === "object" &&
-    !Array.isArray(record["__openclaw"])
-      ? (record["__openclaw"] as Record<string, unknown>)
-      : null;
+  const transcriptMeta = resolveTranscriptMetadata(message);
+  const isOversized = isOversizedHistoryPlaceholder(message);
   const messageId =
     typeof transcriptMeta?.id === "string"
       ? transcriptMeta.id
@@ -109,10 +145,12 @@ export function resolveMessageActionDetails(params: {
   const normalizedMessage = normalizeMessage(message);
   const normalizedMarkdown = resolveNormalizedMessageMarkdown(normalizedMessage);
   const role = normalizeRoleForGrouping(normalizedMessage.role);
-  const previewMarkdown =
-    role === "assistant" ? stripThinkingTags(normalizedMarkdown).trim() : normalizedMarkdown.trim();
+  const previewMarkdown = resolveMessageDisplayText({ message, normalizedMarkdown, role });
   // Loaded text must not erase the preview's truncation fact or collapse its disclosure.
+  // Oversized rows surface only the notice: they are not inline-expandable, so they never
+  // request a full-message fetch or trigger the assistant disclosure.
   const shouldFetchFullMessage = Boolean(
+    !isOversized &&
     canFetchFullMessage &&
     messageId &&
     !record.openclawMessageToolMirror &&
@@ -127,7 +165,10 @@ export function resolveMessageActionDetails(params: {
     expansion?.status === "loaded" && expansion.expanded
       ? stripThinkingTags(expansion.markdown).trim()
       : previewMarkdown;
-  const markdown = role === "assistant" ? visibleMarkdown : undefined;
+  // Oversized rows project the notice for every role so `data-message-text`,
+  // reply, and copy never carry the raw internal placeholder; ordinary user
+  // rows stay non-markdown (no copy action) to preserve main's behavior.
+  const markdown = isOversized || role === "assistant" ? visibleMarkdown : undefined;
   const replyText = onReply ? truncateUtf16Safe(visibleMarkdown, 500) : "";
   if (!markdown && !replyText && !(role === "assistant" && shouldFetchFullMessage)) {
     return null;

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -5903,5 +5903,85 @@ describe("grouped chat rendering", () => {
 
     expect(container.querySelector(".chat-message-disclosure__toggle")).toBeNull();
   });
+
+  it("projects oversized history rows through regular and grouped tool bubbles", () => {
+    const rawMarker = "[chat.history omitted: message too large]";
+    const notice = "This message is too large to display here.";
+    const regularContainer = document.createElement("div");
+    renderGroupedMessage(
+      regularContainer,
+      {
+        role: "user",
+        content: [{ type: "text", text: rawMarker }],
+        __openclaw: { id: "oversized-user", truncated: true, reason: "oversized" },
+      },
+      "user",
+    );
+
+    const regularBubble = expectElement(regularContainer, ".chat-bubble", HTMLElement);
+    expect(regularBubble.textContent).toContain(notice);
+    expect(regularBubble.textContent).not.toContain(rawMarker);
+    expect(regularBubble.dataset.messageText).toBe(notice);
+
+    const groupedContainer = document.createElement("div");
+    const group = createToolGroup("oversized-tool-group", [
+      createMessageEntry(
+        "oversized-tool-1",
+        createToolResultMessage("call-1", "read_file", rawMarker, {
+          __openclaw: { id: "oversized-tool-1", truncated: true, reason: "oversized" },
+        }),
+      ),
+      createMessageEntry(
+        "oversized-tool-2",
+        createToolResultMessage("call-2", "run_command", rawMarker, {
+          __openclaw: { id: "oversized-tool-2", truncated: true, reason: "oversized" },
+        }),
+      ),
+    ]);
+    renderMessageGroups(groupedContainer, [group], {
+      isToolMessageExpanded: (id) => id === "activity:oversized-tool-group",
+    });
+
+    const groupedBubbles = [
+      ...groupedContainer.querySelectorAll<HTMLElement>(
+        ".chat-activity-group__body > .chat-bubble",
+      ),
+    ];
+    expect(groupedBubbles).toHaveLength(2);
+    expect(groupedBubbles.map((bubble) => bubble.dataset.messageText)).toEqual([notice, notice]);
+    expect(groupedContainer.textContent).not.toContain(rawMarker);
+  });
+
+  it("keeps the oversized notice visible when assistant recovery exhausts", () => {
+    const container = document.createElement("div");
+    const onToggleAssistantMessageExpanded = vi.fn();
+    renderAssistantMessage(
+      container,
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "[chat.history omitted: message too large]" }],
+        __openclaw: {
+          id: "oversized-assistant-error",
+          truncated: true,
+          reason: "oversized",
+        },
+      },
+      {
+        sessionKey: "global",
+        loadFullAssistantMessage: async () => null,
+        getAssistantMessageExpansion: () => ({ status: "error", revision: 6 }),
+        onToggleAssistantMessageExpanded,
+      },
+    );
+
+    expect(container.querySelector(".chat-text")?.textContent).toContain(
+      "This message is too large to display here.",
+    );
+    expect(container.textContent).not.toContain("[chat.history omitted");
+    expect(container.querySelector(".chat-message-load-error")?.textContent).toContain(
+      "Could not load the full message.",
+    );
+    expect(onToggleAssistantMessageExpanded).not.toHaveBeenCalled();
+  });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -5447,5 +5447,115 @@ describe("grouped chat rendering", () => {
 
     expect(container.querySelector(".chat-message-disclosure__toggle")).toBeNull();
   });
+
+  it("renders an oversized user history placeholder as a notice and keeps the raw marker out of data-message-text (#111854)", () => {
+    const container = document.createElement("div");
+    renderGroupedMessage(
+      container,
+      {
+        role: "user",
+        content: [{ type: "text", text: "[chat.history omitted: message too large]" }],
+        __openclaw: { id: "oversized-user", seq: 1, truncated: true, reason: "oversized" },
+      },
+      "user",
+    );
+
+    expect(container.textContent).not.toContain("[chat.history omitted: message too large]");
+    const notice = container.querySelector(".chat-history-omitted");
+    expect(notice).not.toBeNull();
+    expect(notice!.textContent?.trim()).toBe("This message is too large to display here.");
+    // The raw internal placeholder must not leak through the DOM attribute that
+    // context-menu Reply reads, or reply would reintroduce the internal string.
+    const bubble = container.querySelector<HTMLElement>(".chat-bubble");
+    expect(bubble?.dataset.messageText).toBe("This message is too large to display here.");
+  });
+
+  it("renders an oversized assistant placeholder as a notice without an inline expand disclosure (#111854)", () => {
+    const container = document.createElement("div");
+    renderAssistantMessage(
+      container,
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "[chat.history omitted: message too large]" }],
+        __openclaw: { id: "oversized-assistant", seq: 1, truncated: true, reason: "oversized" },
+      },
+      {
+        sessionKey: "global",
+        agentId: "work",
+        loadFullAssistantMessage: async () => ({ ok: true, message: { content: [] } }),
+        onToggleAssistantMessageExpanded: vi.fn(),
+      },
+    );
+
+    expect(container.textContent).not.toContain("[chat.history omitted: message too large]");
+    const notice = container.querySelector(".chat-history-omitted");
+    expect(notice).not.toBeNull();
+    expect(notice!.textContent?.trim()).toBe("This message is too large to display here.");
+    // Oversized rows surface only the notice: they are not inline-expandable, so
+    // the assistant Show more disclosure must not appear for them.
+    expect(container.querySelector(".chat-message-disclosure__toggle")).toBeNull();
+    const bubble = container.querySelector<HTMLElement>(".chat-bubble");
+    expect(bubble?.dataset.messageText).toBe("This message is too large to display here.");
+  });
+
+  it("routes oversized reply text through the shared projection so inline Reply carries the notice (#111854)", () => {
+    const container = document.createElement("div");
+    const onReply = vi.fn();
+    renderAssistantMessage(
+      container,
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "[chat.history omitted: message too large]" }],
+        __openclaw: { id: "oversized-reply", seq: 1, truncated: true, reason: "oversized" },
+      },
+      { onReply },
+    );
+
+    const replyButton = container.querySelector<HTMLButtonElement>(".chat-reply-btn");
+    expect(replyButton).toBeInstanceOf(HTMLButtonElement);
+    replyButton!.click();
+    expect(onReply).toHaveBeenCalledTimes(1);
+    const target = requireFirstMockArg(onReply, "reply target");
+    expect(target.text).toBe("This message is too large to display here.");
+    expect(target.text).not.toContain("[chat.history omitted");
+  });
+
+  it("treats array-shaped __openclaw metadata as ordinary text, not an oversized notice (#111854)", () => {
+    const container = document.createElement("div");
+    renderGroupedMessage(
+      container,
+      {
+        role: "user",
+        content: [{ type: "text", text: "a normal message body" }],
+        // Malformed metadata (array) must not satisfy the non-array record guard,
+        // so the row renders its real text instead of the oversized notice.
+        __openclaw: [{ id: "bogus", truncated: true, reason: "oversized" }],
+      },
+      "user",
+    );
+
+    expect(container.querySelector(".chat-history-omitted")).toBeNull();
+    expect(container.textContent).toContain("a normal message body");
+    const bubble = container.querySelector<HTMLElement>(".chat-bubble");
+    expect(bubble?.dataset.messageText).toBe("a normal message body");
+  });
+
+  it("keeps ordinary messages unaffected by the oversized projection (#111854)", () => {
+    const container = document.createElement("div");
+    renderGroupedMessage(
+      container,
+      {
+        role: "user",
+        content: [{ type: "text", text: "plain ordinary message" }],
+        __openclaw: { id: "ordinary-user", seq: 1 },
+      },
+      "user",
+    );
+
+    expect(container.querySelector(".chat-history-omitted")).toBeNull();
+    expect(container.textContent).toContain("plain ordinary message");
+    const bubble = container.querySelector<HTMLElement>(".chat-bubble");
+    expect(bubble?.dataset.messageText).toBe("plain ordinary message");
+  });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -428,6 +428,14 @@
   color: inherit;
 }
 
+/* Oversized transcript rows surface a muted notice instead of the raw
+   internal placeholder. Kept distinct from .chat-text so the notice never
+   inherits markdown block styling. */
+.chat-history-omitted {
+  color: var(--muted);
+  font-style: italic;
+}
+
 /* Avatar Styles */
 .chat-avatar {
   width: 36px;


### PR DESCRIPTION
## What Problem This Solves

Oversized transcript rows carry a structured marker:

`__openclaw: { truncated: true, reason: "oversized" }`

The Control UI rendered the Gateway's internal placeholder as message text. The same placeholder could also reach `data-message-text`, Reply, and Copy. The stale PR head additionally suppressed the existing assistant full-message recovery path.

Fixes #111854

## Why This Change Was Made

- Export one canonical `resolveMessageDisplayMarkdown(message, normalizedMessage)` projection.
- Use the localized notice only for the structured `truncated: true` + `reason: "oversized"` contract.
- Reuse that projection for message bodies, `data-message-text`, Reply, and Copy.
- Keep `shouldFetchFullMessage` unchanged, so assistant rows show the notice while loading or after an error, then replace it with recovered full content.
- Cover regular rows and expanded grouped tool activity without changing group production code, Gateway/protocol/persistence, or collapse semantics.

Production delta: `+12` net across the three allowed production files.

## User Impact

Users see `This message is too large to display here.` instead of an internal marker. Assistant history recovery still performs exactly one `chat.message.get`; successful recovery replaces the notice with the full message. Reply and Copy use the same visible text and never expose the marker.

## Evidence

Exact head: `34ed23db070236746baa165d79e0a1af4226e0d1`

Base validated: `eb0118b417c411cc60dc6ad64731ae7084689fec`

### Red proof

- Current `main`: new display-projection tests returned the raw marker before the rewrite.
- Prior PR head `b35ab5c30e36504e0ca85e85ffddf8597290b0e7`: the assistant recovery regression test expected `onToggleAssistantMessageExpanded("oversized-assistant-recovery")`, but observed zero calls.

### Green proof

- `node scripts/run-vitest.mjs ui/src/pages/chat/components/chat-message-markdown.test.ts`: 8/8 passed.
- `node scripts/run-vitest.mjs ui/src/pages/chat/components/chat-message.test.ts`: 201/201 passed.
- `pnpm ui:i18n:verify`: passed.
- `git diff --check`: passed.
- Max-P1 autoreview: no findings, patch correct, confidence 0.92.
- Blacksmith Testbox changed checks: `tbx_01m0qrjxag0y5p5a0gpr0qt8cd`, including core/UI tsgo and lint, passed on the patch-identical rewrite: https://github.com/openclaw/openclaw/actions/runs/32653018059
- Exact-head Chromium proof: `tbx_01m0r4rea9hdq0cj74vbxgbw0n` passed: https://github.com/openclaw/openclaw/actions/runs/32664335498
- Chromium assertions cover pending/error/loaded recovery, exactly one `chat.message.get`, no obsolete Show more/less disclosure, regular and grouped rows, `data-message-text`, Reply, Copy, and raw-marker absence.

### Exact-head screenshots

Pending notice, dark:

![Pending oversized notice](https://github.com/user-attachments/assets/503dcaf4-d0fc-4f10-93d9-a90932dda206)

Recovered full content, dark:

![Recovered oversized message](https://github.com/user-attachments/assets/8a9a9ede-a23a-4243-9aff-10107807c61f)

Expanded two-message tool activity and Reply context action:

![Expanded tool activity](https://github.com/user-attachments/assets/738cec29-feea-4932-a7b3-e1deff92b084)

Recovered full content, light:

![Recovered oversized message in light theme](https://github.com/user-attachments/assets/83b9c693-9b0e-4619-b338-39549e1699a3)

Punchcard-Session: silver-willow-brook-r7
