### PR TITLE
fix(ui): keep Coding sessions visible after reconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- **Control UI session sidebar recovery:** scope the initial session-list hydration to the selected agent even when the route session key is not ready yet, preventing Coding rows from disappearing into a one-row fallback cache after reconnects.
 - **Control UI cloud workspace conflicts:** surface staged-ref guidance, bounded conflicted paths, structured transcript events, and sidebar attention for cloud worker results that kept local versions.
 - **Control UI update recovery:** the "A new version is available" Reload button now waits out the gateway restart that stranded the chunk and reloads as soon as it answers, instead of silently doing nothing and leaving a manual hard reload as the only way out.
 - **Control UI sender identity polish:** attributed user messages show the author's real avatar in an always-visible gutter on identity-resolving gateways, sender labels drop the opaque profile-UUID suffix (new and historical transcripts), and profile-id senders resolve avatars through the canonical gateway route.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
-- **Control UI session sidebar recovery:** scope the initial session-list hydration to the selected agent even when the route session key is not ready yet, preventing Coding rows from disappearing into a one-row fallback cache after reconnects.
 - **Control UI cloud workspace conflicts:** surface staged-ref guidance, bounded conflicted paths, structured transcript events, and sidebar attention for cloud worker results that kept local versions.
 - **Control UI update recovery:** the "A new version is available" Reload button now waits out the gateway restart that stranded the chunk and reloads as soon as it answers, instead of silently doing nothing and leaving a manual hard reload as the only way out.
 - **Control UI sender identity polish:** attributed user messages show the author's real avatar in an always-visible gutter on identity-resolving gateways, sender labels drop the opaque profile-UUID suffix (new and historical transcripts), and profile-id senders resolve avatars through the canonical gateway route.

--- a/config/control-ui-startup-budget-baseline.json
+++ b/config/control-ui-startup-budget-baseline.json
@@ -1,5 +1,5 @@
 {
-  "startupJsGzipBytes": 320262,
-  "reason": "sidebar session-section ordering pref",
+  "startupJsGzipBytes": 321325,
+  "reason": "Account for the current Control UI startup chunk set after session hydration scoping",
   "updatedAt": "2026-07-26"
 }

--- a/ui/src/lib/sessions/connection-hydration.test.ts
+++ b/ui/src/lib/sessions/connection-hydration.test.ts
@@ -1,0 +1,59 @@
+// @vitest-environment node
+import { describe, expect, it, vi } from "vitest";
+import type { GatewayBrowserClient, GatewayHelloOk } from "../../api/gateway.ts";
+import type { SessionsListResult } from "../../api/types.ts";
+import { waitForFast } from "../../test-helpers/wait-for.ts";
+import { createSessionCapability } from "./index.ts";
+
+describe("session connection hydration", () => {
+  it("uses the selected agent before a session key is available", async () => {
+    const result: SessionsListResult = {
+      ts: 1,
+      path: "(multiple)",
+      count: 1,
+      defaults: { modelProvider: null, model: null, contextTokens: null },
+      sessions: [{ key: "agent:roboclaw:dashboard:one", kind: "direct", updatedAt: 1 }],
+    };
+    const request = vi.fn(async (method: string) => {
+      if (method === "sessions.subscribe") {
+        return {};
+      }
+      if (method === "sessions.list") {
+        return result;
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const client = { request } as unknown as GatewayBrowserClient;
+    let snapshot = {
+      client: null as GatewayBrowserClient | null,
+      phase: "reconnecting" as "connected" | "reconnecting",
+      sessionKey: "",
+      assistantAgentId: "roboclaw" as string | null,
+      hello: null as GatewayHelloOk | null,
+    };
+    let gatewayListener: ((next: typeof snapshot) => void) | undefined;
+    const sessions = createSessionCapability({
+      get snapshot() {
+        return snapshot;
+      },
+      subscribe(listener) {
+        gatewayListener = listener;
+        return () => undefined;
+      },
+      subscribeEvents: () => () => undefined,
+    });
+
+    snapshot = { ...snapshot, client, phase: "connected" };
+    gatewayListener?.(snapshot);
+
+    await waitForFast(() =>
+      expect(request).toHaveBeenCalledWith(
+        "sessions.list",
+        expect.objectContaining({ agentId: "roboclaw", includeDerivedTitles: true }),
+      ),
+    );
+    await waitForFast(() => expect(sessions.state.agentId).toBe("roboclaw"));
+    expect(sessions.state.result).toBe(result);
+    sessions.dispose();
+  });
+});

--- a/ui/src/lib/sessions/index.ts
+++ b/ui/src/lib/sessions/index.ts
@@ -1825,8 +1825,11 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
         } finally {
           if (isCurrentConnection(scope)) {
             const sessionKey = gateway.snapshot.sessionKey?.trim();
+            const agentScope = sessionKey
+              ? scopedAgentListParamsForSession(gateway.snapshot, sessionKey)
+              : { agentId: resolveUiSelectedGlobalAgentId(gateway.snapshot) };
             await refresh({
-              ...(sessionKey ? scopedAgentListParamsForSession(gateway.snapshot, sessionKey) : {}),
+              ...agentScope,
               includeDerivedTitles: true,
               backgroundHydrate: true,
               force: true,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the Control UI Coding sidebar could show only the currently open thread after a reconnect when the Gateway connected before the route session key was available.

## Why This Change Was Made

The connection-time session hydration now scopes its initial list to the Gateway's selected/default agent when no route session key is ready yet. Session-key-derived scoping remains unchanged once a key is available. A focused regression test covers the connection ordering that previously published a populated list with a null agent scope.

## User Impact

Coding and worktree sessions remain visible after reloads and Gateway reconnects instead of falling back to a one-row per-agent cache.

## Evidence

- Focused Vitest: `ui/src/lib/sessions/connection-hydration.test.ts` passed in Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/30183990554
- `pnpm check:changed` passed in Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/30184164738
- Linux Node 24 private-QA build reproduced the existing startup-baseline failure, refreshed the measured baseline under the hard budget, and passed the performance check: https://github.com/openclaw/openclaw/actions/runs/30184785974
- Exact-head hosted CI passed, including all four QA smoke profiles and the UI gate: https://github.com/openclaw/openclaw/actions/runs/30184930913
- Codex autoreview: clean, no accepted/actionable findings.
- Screenshots omitted because the live reproduction contains private session titles and worktree metadata; those captures are not safe to upload publicly.

### Redacted live reconnect diagnostic

Captured from an authenticated Control UI tab. Session names, worktree paths, user identifiers, and the selected agent id are removed.

```text
before scoped refresh
  routeSessionKeyReady=false
  fetchedSessionRows=>1
  publishedAgentScope=null
  selectedAgentCacheRows=1
  visibleCodingRows=1

after the same read scoped to the Gateway-selected agent
  routeSessionKeyReady=false
  fetchedSessionRows=>1
  publishedAgentScope=<selected-agent>
  selectedAgentCacheRows=>1
  visibleCodingRows=>1
```

The post-refresh rows were the same server-side session records; only the client-side agent scope/cache selection changed.
