### PR TITLE
refactor(plugins): share provider alias matching

### DIFF
--- a/src/plugins/provider-hook-runtime.ts
+++ b/src/plugins/provider-hook-runtime.ts
@@ -1,8 +1,5 @@
 // Runtime bridge for invoking provider hooks supplied by plugins.
-import {
-  findNormalizedProviderValue,
-  normalizeProviderId,
-} from "@openclaw/model-catalog-core/provider-id";
+import { findNormalizedProviderValue } from "@openclaw/model-catalog-core/provider-id";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
@@ -18,6 +15,7 @@ import {
 import { resolvePluginControlPlaneFingerprint } from "./plugin-control-plane-context.js";
 import type { PluginMetadataRegistryView } from "./plugin-metadata-snapshot.types.js";
 import { resolveProviderConfigApiOwnerHint } from "./provider-config-owner.js";
+import { matchesProviderPluginRef } from "./provider-registry-shared.js";
 import { isPluginProvidersLoadInFlight, resolvePluginProviders } from "./providers.runtime.js";
 import type { PluginRegistry } from "./registry-types.js";
 import {
@@ -60,19 +58,6 @@ type ProviderRuntimePluginHandleParams = ProviderRuntimePluginLookupParams & {
 export function clearProviderRuntimePluginCacheForTest(): void {
   providerRuntimePluginCache = new WeakMap();
   defaultProviderRuntimePluginCache.clear();
-}
-
-function matchesProviderId(provider: ProviderPlugin, providerId: string): boolean {
-  const normalized = normalizeProviderId(providerId);
-  if (!normalized) {
-    return false;
-  }
-  if (normalizeProviderId(provider.id) === normalized) {
-    return true;
-  }
-  return [...(provider.aliases ?? []), ...(provider.hookAliases ?? [])].some(
-    (alias) => normalizeProviderId(alias) === normalized,
-  );
 }
 
 function resolveProviderRuntimePluginCacheKey(
@@ -186,10 +171,10 @@ function findProviderRuntimePluginInRegistry(params: {
       if (params.apiOwnerHint) {
         return (
           matchesProviderLiteralId(plugin, params.provider) ||
-          matchesProviderId(plugin, params.apiOwnerHint)
+          matchesProviderPluginRef(plugin, params.apiOwnerHint)
         );
       }
-      return matchesProviderId(plugin, params.provider);
+      return matchesProviderPluginRef(plugin, params.provider);
     });
 }
 
@@ -276,10 +261,10 @@ export function resolveProviderRuntimePlugin(
         if (apiOwnerHint) {
           return (
             matchesProviderLiteralId(plugin, params.provider) ||
-            matchesProviderId(plugin, apiOwnerHint)
+            matchesProviderPluginRef(plugin, apiOwnerHint)
           );
         }
-        return matchesProviderId(plugin, params.provider);
+        return matchesProviderPluginRef(plugin, params.provider);
       }) ?? null
     );
   };
@@ -335,7 +320,7 @@ export function resolveProviderHookPlugin(params: {
     config: params.config,
     workspaceDir: params.workspaceDir,
     env: params.env,
-  }).find((candidate) => matchesProviderId(candidate, params.provider));
+  }).find((candidate) => matchesProviderPluginRef(candidate, params.provider));
 }
 
 export function resolveProviderRuntimePluginHandle(

--- a/src/plugins/provider-registry-shared.ts
+++ b/src/plugins/provider-registry-shared.ts
@@ -1,4 +1,5 @@
 // Shares provider registry normalization helpers across plugin paths.
+import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import { isBlockedObjectKey } from "../infra/prototype-keys.js";
 
@@ -6,6 +7,20 @@ import { isBlockedObjectKey } from "../infra/prototype-keys.js";
 export function normalizeCapabilityProviderId(providerId: string | undefined): string | undefined {
   const normalized = normalizeOptionalLowercaseString(providerId);
   return normalized && !isBlockedObjectKey(normalized) ? normalized : undefined;
+}
+
+export function matchesProviderPluginRef(
+  provider: { id: string; aliases?: readonly string[]; hookAliases?: readonly string[] },
+  providerId: string,
+): boolean {
+  const normalized = normalizeProviderId(providerId);
+  return Boolean(
+    normalized &&
+    (normalizeProviderId(provider.id) === normalized ||
+      [...(provider.aliases ?? []), ...(provider.hookAliases ?? [])].some(
+        (alias) => normalizeProviderId(alias) === normalized,
+      )),
+  );
 }
 
 /** Builds canonical and alias lookup maps for capability providers. */

--- a/src/plugins/provider-runtime.ts
+++ b/src/plugins/provider-runtime.ts
@@ -41,6 +41,7 @@ import {
   wrapProviderStreamFn,
 } from "./provider-hook-runtime.js";
 import { resolveBundledProviderPolicySurface } from "./provider-public-artifacts.js";
+import { matchesProviderPluginRef } from "./provider-registry-shared.js";
 import type { ProviderRuntimeModel } from "./provider-runtime-model.types.js";
 import type { ProviderThinkingProfile } from "./provider-thinking.types.js";
 import {
@@ -93,19 +94,6 @@ import type {
   ProviderValidateReplayTurnsContext,
   PluginTextTransforms,
 } from "./types.js";
-
-function matchesProviderPluginRef(provider: ProviderPlugin, providerId: string): boolean {
-  const normalized = normalizeProviderId(providerId);
-  if (!normalized) {
-    return false;
-  }
-  if (normalizeProviderId(provider.id) === normalized) {
-    return true;
-  }
-  return [...(provider.aliases ?? []), ...(provider.hookAliases ?? [])].some(
-    (alias) => normalizeProviderId(alias) === normalized,
-  );
-}
 
 function resolveProviderHookRefs(
   provider: string,

--- a/src/plugins/provider-thinking-active.ts
+++ b/src/plugins/provider-thinking-active.ts
@@ -1,5 +1,5 @@
 // Reads provider thinking policy from the active runtime registry only.
-import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
+import { matchesProviderPluginRef } from "./provider-registry-shared.js";
 import type {
   ProviderDefaultThinkingPolicyContext,
   ProviderThinkingProfile,
@@ -28,19 +28,6 @@ type ThinkingHookParams<TContext> = {
   context: TContext;
 };
 
-function matchesProviderId(provider: ActiveThinkingProvider, providerId: string): boolean {
-  const normalized = normalizeProviderId(providerId);
-  if (!normalized) {
-    return false;
-  }
-  if (normalizeProviderId(provider.id) === normalized) {
-    return true;
-  }
-  return [...(provider.aliases ?? []), ...(provider.hookAliases ?? [])].some(
-    (alias) => normalizeProviderId(alias) === normalized,
-  );
-}
-
 function resolveActiveThinkingProvider(providerId: string): ActiveThinkingProvider | undefined {
   const state = (
     globalThis as typeof globalThis & {
@@ -48,7 +35,7 @@ function resolveActiveThinkingProvider(providerId: string): ActiveThinkingProvid
     }
   )[PLUGIN_REGISTRY_STATE];
   return state?.activeRegistry?.providers?.find((entry) =>
-    matchesProviderId(entry.provider, providerId),
+    matchesProviderPluginRef(entry.provider, providerId),
   )?.provider;
 }
 


### PR DESCRIPTION
## What Problem This Solves

Resolves a maintenance risk where provider hook lookup, general provider runtime, and active thinking policy each implemented the same normalized ID/alias/hook-alias matching rule.

## Why This Change Was Made

This adds one structural matcher to the provider-registry shared helpers and routes the three runtime surfaces through it. Canonical IDs, provider aliases, hook-only aliases, normalization, and empty-input rejection are unchanged.

## User Impact

No user-visible behavior changes. Provider plugins continue to resolve through the same aliases with one canonical runtime rule.

## Evidence

- `node scripts/run-vitest.mjs src/plugins/provider-runtime.test.ts src/plugins/provider-thinking.external-policy.test.ts src/plugins/provider-registry-shared.test.ts` — 64 provider-runtime/thinking and 3 registry-helper tests passed.
- `node scripts/check-changed.mjs` — all selected core typecheck, targeted lint, boundary, and architecture lanes passed on Blacksmith Testbox run 30184228600 (`exitCode: 0`).
- `$HOME/.claude/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — clean, no accepted/actionable findings.
- `git diff --check origin/main...HEAD` — passed.

AI-assisted; the implementation was reviewed against all three callers, provider alias contracts, sibling setup/auth matchers, and adjacent tests.
