### PR TITLE
refactor(agents): remove test-only scope exports

### DIFF
--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -17,11 +17,9 @@ import {
   resolveAgentEffectiveModelPrimary,
   resolveAgentExplicitModelPrimary,
   resolveAgentSkillsFilter,
-  resolveFallbackAgentId,
   resolveEffectiveModelFallbacks,
   resolveAgentModelFallbacksOverride,
   resolveRunModelFallbacksOverride,
-  resolveSubagentModelConfigSelection,
   resolveSubagentModelFallbacksOverride,
   resolveAgentWorkspaceDir,
   resolveAutoFallbackPrimaryProbe,
@@ -421,23 +419,6 @@ describe("resolveAgentConfig", () => {
       primary: "google/gemini-3-pro",
       fallbacks: ["anthropic/claude-sonnet-4-6"],
     });
-  });
-
-  it("resolves fallback agent id from explicit agent id first", () => {
-    expect(
-      resolveFallbackAgentId({
-        agentId: "Support",
-        sessionKey: "agent:main:session",
-      }),
-    ).toBe("support");
-  });
-
-  it("resolves fallback agent id from session key when explicit id is missing", () => {
-    expect(
-      resolveFallbackAgentId({
-        sessionKey: "agent:worker:session",
-      }),
-    ).toBe("worker");
   });
 
   it("resolves run fallback overrides via shared helper", () => {
@@ -969,57 +950,6 @@ describe("resolveAgentConfig", () => {
         modelOverrideSource: "auto",
       }),
     ).toEqual(["zai/glm-5"]);
-  });
-
-  it("resolves the subagent model config selected for isolated runs", () => {
-    const cfg: OpenClawConfig = {
-      agents: {
-        defaults: {
-          subagents: { model: "openai/gpt-5.4" },
-        },
-        list: [
-          {
-            id: "agent-model",
-            model: {
-              primary: "anthropic/claude-sonnet-4-6",
-              fallbacks: ["google/gemini-3-pro"],
-            },
-          },
-          {
-            id: "subagent-model",
-            model: "anthropic/claude-sonnet-4-6",
-            subagents: {
-              model: {
-                primary: "kimi/kimi-code",
-                fallbacks: ["openai/gpt-5.4"],
-              },
-            },
-          },
-          {
-            id: "fallback-only-subagent",
-            model: "anthropic/claude-sonnet-4-6",
-            subagents: {
-              model: { fallbacks: [] },
-            },
-          },
-        ],
-      },
-    };
-
-    expect(resolveSubagentModelConfigSelection({ cfg, agentId: "agent-model" })).toEqual({
-      primary: "anthropic/claude-sonnet-4-6",
-      fallbacks: ["google/gemini-3-pro"],
-    });
-    expect(resolveSubagentModelConfigSelection({ cfg, agentId: "subagent-model" })).toEqual({
-      primary: "kimi/kimi-code",
-      fallbacks: ["openai/gpt-5.4"],
-    });
-    expect(resolveSubagentModelConfigSelection({ cfg, agentId: "fallback-only-subagent" })).toBe(
-      "anthropic/claude-sonnet-4-6",
-    );
-    expect(resolveSubagentModelConfigSelection({ cfg, agentId: "default-subagent" })).toBe(
-      "openai/gpt-5.4",
-    );
   });
 
   it("should return agent-specific sandbox config", () => {

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -476,14 +476,6 @@ export function resolveSubagentModelConfigSelectionResult(params: {
   return candidates.find((candidate) => resolvePrimaryStringValue(candidate.raw));
 }
 
-export function resolveSubagentModelConfigSelection(params: {
-  cfg: OpenClawConfig;
-  agentId?: string;
-  agentConfigOverride?: Pick<AgentConfig, "model" | "subagents">;
-}): AgentModelConfig | undefined {
-  return resolveSubagentModelConfigSelectionResult(params)?.raw;
-}
-
 export function resolveSubagentModelFallbacksOverride(
   cfg: OpenClawConfig,
   agentId: string,
@@ -513,17 +505,6 @@ function resolveSubagentSpawnModelFallbacksOverride(
     cfg.agents?.defaults?.subagents?.model,
     agentConfig?.model,
   ]);
-}
-
-export function resolveFallbackAgentId(params: {
-  agentId?: string | null;
-  sessionKey?: string | null;
-}): string {
-  const explicitAgentId = normalizeOptionalString(params.agentId) ?? "";
-  if (explicitAgentId) {
-    return normalizeAgentId(explicitAgentId);
-  }
-  return resolveAgentIdFromSessionKey(params.sessionKey);
 }
 
 export function resolveRunModelFallbacksOverride(params: {


### PR DESCRIPTION
## What Problem This Solves

Resolves dead public surface where two agent-scope helpers had no production callers and were kept alive only by tests written against those helpers.

## Why This Change Was Made

This deletes `resolveSubagentModelConfigSelection` and `resolveFallbackAgentId` plus their internal-only tests. The production `resolveSubagentModelConfigSelectionResult` path and direct session-key resolver remain unchanged.

## User Impact

No user-visible behavior changes. Internal agent model selection and fallback behavior continue through their production-owned paths.

## Evidence

- Repository-wide reference scan found no production callers for either removed export; only the deleted `agent-scope.test.ts` cases referenced them.
- `node scripts/run-vitest.mjs src/agents/agent-scope.test.ts src/cron/isolated-agent.model-formatting.test.ts` — 40 agent-scope and 38 cron model-selection tests passed.
- `node scripts/check-changed.mjs` — blocked by unrelated red main at `3807591ff4a`: the dependency pin guard rejects four caret-ranged stylelint devDependencies introduced by #113971 before this PR's type lanes run. Main CI run 30184222154 is also red in all QA Smoke profiles on an unrelated Control UI gzip baseline regression. This PR does not touch those surfaces.
- `$HOME/.claude/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — clean, no accepted/actionable findings.
- `git diff --check origin/main...HEAD` — passed.

AI-assisted; the deletion was reviewed against repository-wide callers, the retained production selection API, direct session routing, and adjacent tests.
