### PR TITLE
fix: refresh control UI startup baseline

### DIFF
--- a/config/control-ui-startup-budget-baseline.json
+++ b/config/control-ui-startup-budget-baseline.json
@@ -1,5 +1,5 @@
 {
-  "startupJsGzipBytes": 320262,
-  "reason": "sidebar session-section ordering pref",
+  "startupJsGzipBytes": 321311,
+  "reason": "stylelint adoption startup bundle drift",
   "updatedAt": "2026-07-26"
 }


### PR DESCRIPTION
## What Problem This Solves

The current `main` build can exceed the checked-in Control UI startup JS gzip baseline after the stylelint adoption work. That blocks unrelated PR validation in `build-artifacts` even when those PRs do not touch Control UI bundles.

## Summary

- raise the Control UI startup gzip baseline to the current main build output observed in `build-artifacts`
- keep the change limited to the checked-in startup budget baseline

## Evidence

- Upstream `build-artifacts` previously reported `startup JS gzip vs baseline: 321311 B exceeds baseline 320262 B + tolerance 1024 B` on current main-derived validation.
- After this baseline refresh, `build-artifacts` passed on this PR head and reported `startup JS gzip vs baseline: 321324 B (baseline 321311 B + tolerance 1024 B, ceiling 324608 B)` in job `89747898016`.
- `jq empty config/control-ui-startup-budget-baseline.json` passed locally.
- Local `node scripts/ui.js build` could not complete because this environment has Node 24.14.1 and the repository preinstall requires >=24.15.0.

Tracks xrow-public/helm-openclaw#51
