### PR TITLE
feat(feishu): pull referenced-message attachments from quoted/root/thread history

### DIFF
--- a/extensions/feishu/src/bot-content.ts
+++ b/extensions/feishu/src/bot-content.ts
@@ -2,9 +2,9 @@
 import { parseStrictNonNegativeInteger } from "openclaw/plugin-sdk/number-runtime";
 import type { ClawdbotConfig } from "../runtime-api.js";
 import { buildFeishuConversationId } from "./conversation-id.js";
-import { normalizeFeishuExternalKey } from "./external-keys.js";
 import { saveMessageResourceFeishu } from "./media.js";
 import { isFeishuBroadcastMention } from "./mention.js";
+import { parseFeishuMediaKeys } from "./message-media-keys.js";
 import { parsePostContent } from "./post.js";
 import { getFeishuRuntime } from "./runtime.js";
 import type { FeishuChatType, FeishuMediaInfo } from "./types.js";
@@ -309,37 +309,11 @@ export function normalizeFeishuCommandProbeBody(text: string): string {
     .trim();
 }
 
-function parseMediaKeys(
-  content: string,
-  messageType: string,
-): { imageKey?: string; fileKey?: string; fileName?: string } {
-  try {
-    const parsed = JSON.parse(content);
-    const imageKey = normalizeFeishuExternalKey(parsed.image_key);
-    const fileKey = normalizeFeishuExternalKey(parsed.file_key);
-    switch (messageType) {
-      case "image":
-        return { imageKey, fileName: parsed.file_name };
-      case "file":
-      case "audio":
-      case "sticker":
-        return { fileKey, fileName: parsed.file_name };
-      case "video":
-      case "media":
-        return { fileKey, imageKey, fileName: parsed.file_name };
-      default:
-        return {};
-    }
-  } catch {
-    return {};
-  }
-}
-
-function toMessageResourceType(messageType: string): "image" | "file" {
+export function toMessageResourceType(messageType: string): "image" | "file" {
   return messageType === "image" ? "image" : "file";
 }
 
-async function resolveSavedFeishuMedia(params: {
+export async function resolveSavedFeishuMedia(params: {
   result:
     | Awaited<ReturnType<typeof saveMessageResourceFeishu>>
     | { buffer: Buffer; contentType?: string; fileName?: string };
@@ -361,7 +335,7 @@ async function resolveSavedFeishuMedia(params: {
   );
 }
 
-function resolveFeishuMediaKind(messageType: string): FeishuMediaInfo["kind"] {
+export function resolveFeishuMediaKind(messageType: string): FeishuMediaInfo["kind"] {
   switch (messageType) {
     case "image":
       return "image";
@@ -460,7 +434,7 @@ export async function resolveFeishuMediaList(params: {
     return out;
   }
 
-  const mediaKeys = parseMediaKeys(content, messageType);
+  const mediaKeys = parseFeishuMediaKeys(content, messageType);
   if (!mediaKeys.imageKey && !mediaKeys.fileKey) {
     return [{ kind: resolveFeishuMediaKind(messageType) }];
   }

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -396,6 +396,9 @@ vi.mock("./reasoning-preview.js", () => ({
 vi.mock("./send.js", () => ({
   sendMessageFeishu: mockSendMessageFeishu,
   getMessageFeishu: mockGetMessageFeishu,
+}));
+
+vi.mock("./thread-history.js", () => ({
   listFeishuThreadMessages: mockListFeishuThreadMessages,
 }));
 
@@ -1391,6 +1394,170 @@ describe("handleFeishuMessage command authorization", () => {
     expect(context.ReplyToId).toBe("om_parent_001");
     expect(context.RootMessageId).toBe("om_root_001");
     expect(context.SupplementalContext?.quote?.body).toBe("quoted content");
+  });
+
+  it("passes referenced message media into the agent context", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+    mockGetMessageFeishu.mockResolvedValueOnce({
+      messageId: "om_parent_media",
+      chatId: "oc-dm",
+      content: "[image message]",
+      contentType: "image",
+      mediaKeys: { imageKey: "img_parent_media" },
+    });
+    mockDownloadMessageResourceFeishu.mockResolvedValueOnce({
+      buffer: Buffer.from("quoted-image"),
+      contentType: "image/png",
+      fileName: "quoted.png",
+    });
+    mockSaveMediaBuffer.mockResolvedValueOnce({
+      id: "quoted.png",
+      path: "/tmp/quoted.png",
+      size: Buffer.byteLength("quoted-image"),
+      contentType: "image/png",
+    });
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          dmPolicy: "open",
+          mediaMaxMb: 2,
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: {
+        sender_id: {
+          open_id: "ou-replier",
+        },
+      },
+      message: {
+        message_id: "om_reply_media",
+        parent_id: "om_parent_media",
+        chat_id: "oc-dm",
+        chat_type: "p2p",
+        message_type: "text",
+        content: JSON.stringify({ text: "what is in the image?" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event });
+
+    const downloadRequest = mockCallArg<{
+      fileKey?: string;
+      maxBytes?: number;
+      messageId?: string;
+    }>(mockDownloadMessageResourceFeishu, 0, 0);
+    expect(downloadRequest.messageId).toBe("om_parent_media");
+    expect(downloadRequest.fileKey).toBe("img_parent_media");
+    expect(downloadRequest.maxBytes).toBe(2 * 1024 * 1024);
+    const context = mockCallArg<{ MediaPaths?: string[]; MediaTypes?: string[] }>(
+      mockFinalizeInboundContext,
+      0,
+      0,
+    );
+    expect(context.MediaPaths).toEqual(["/tmp/quoted.png"]);
+    expect(context.MediaTypes).toEqual(["image/png"]);
+  });
+
+  it("resolves shared thread-history media once for broadcast agents", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+    mockResolveAgentRoute.mockReturnValue({
+      agentId: "main",
+      channel: "feishu",
+      accountId: "default",
+      sessionKey: "agent:main:feishu:group:oc-group:topic:om_topic_root",
+      mainSessionKey: "agent:main:main",
+      lastRoutePolicy: "session",
+      matchedBy: "default",
+    } as ResolvedAgentRoute);
+    mockListFeishuThreadMessages.mockResolvedValue([
+      {
+        messageId: "om_history_media",
+        senderId: "ou-allowed",
+        senderType: "user",
+        content: "[image message]",
+        contentType: "image",
+        createTime: 1710000000000,
+        mediaKeys: { imageKey: "img_history_shared" },
+      },
+    ]);
+    mockDownloadMessageResourceFeishu.mockResolvedValueOnce({
+      buffer: Buffer.from("history-image"),
+      contentType: "image/png",
+      fileName: "history.png",
+    });
+    mockSaveMediaBuffer.mockResolvedValueOnce({
+      id: "history.png",
+      path: "/tmp/history.png",
+      size: Buffer.byteLength("history-image"),
+      contentType: "image/png",
+    });
+
+    const cfg: ClawdbotConfig = {
+      agents: {
+        list: [
+          { id: "main", workspace: "/workspace/main" },
+          { id: "observer", workspace: "/workspace/observer" },
+        ],
+      },
+      broadcast: {
+        "oc-group": ["main", "observer"],
+      },
+      channels: {
+        feishu: {
+          groupPolicy: "open",
+          groupSenderAllowFrom: ["ou-allowed"],
+          mediaMaxMb: 2,
+          groups: {
+            "oc-group": {
+              requireMention: false,
+              groupSessionScope: "group_topic",
+            },
+          },
+        },
+      },
+    } as ClawdbotConfig;
+
+    await dispatchMessage({
+      cfg,
+      event: {
+        sender: { sender_id: { open_id: "ou-allowed" } },
+        message: {
+          message_id: "om_broadcast_topic_media",
+          root_id: "om_topic_root",
+          thread_id: "omt_topic_1",
+          chat_id: "oc-group",
+          chat_type: "group",
+          message_type: "text",
+          content: JSON.stringify({ text: "current turn" }),
+        },
+      },
+    });
+
+    expect(mockDownloadMessageResourceFeishu).toHaveBeenCalledTimes(1);
+    expect(mockSaveMediaBuffer).toHaveBeenCalledTimes(1);
+    const contexts = mockFinalizeInboundContext.mock.calls.map(
+      (call) =>
+        call[0] as {
+          MediaPaths?: string[];
+          MediaTypes?: string[];
+          SessionKey?: string;
+        },
+    );
+    const sessionKeys = contexts
+      .map((context) => context.SessionKey)
+      .filter((sessionKey): sessionKey is string => typeof sessionKey === "string")
+      .toSorted((left, right) => left.localeCompare(right));
+    expect(sessionKeys).toEqual([
+      "agent:main:feishu:group:oc-group:topic:om_topic_root",
+      "agent:observer:feishu:group:oc-group:topic:om_topic_root",
+    ]);
+    for (const context of contexts) {
+      expect(context.MediaPaths).toEqual(["/tmp/history.png"]);
+      expect(context.MediaTypes).toEqual(["image/png"]);
+    }
   });
 
   it("uses message create_time as Timestamp instead of Date.now()", async () => {

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -81,10 +81,12 @@ import {
   resolveFeishuReplyPolicy,
 } from "./policy.js";
 import { resolveFeishuReasoningPreviewEnabled } from "./reasoning-preview.js";
+import { resolveFeishuReferencedMessageMedia } from "./referenced-media.js";
 import { createFeishuReplyDispatcher } from "./reply-dispatcher.js";
 import { getFeishuRuntime } from "./runtime.js";
-import { getMessageFeishu, listFeishuThreadMessages, sendMessageFeishu } from "./send.js";
+import { getMessageFeishu, sendMessageFeishu } from "./send.js";
 import { getFeishuSyntheticDirectPreDispatchTarget } from "./synthetic-event-target.js";
+import { listFeishuThreadMessages } from "./thread-history.js";
 export type { FeishuBotAddedEvent, FeishuMessageEvent } from "./event-types.js";
 import type { FeishuMessageEvent } from "./event-types.js";
 import type { FeishuIngressLifecycle } from "./feishu-ingress.js";
@@ -93,6 +95,7 @@ import {
   type FeishuMessageContext,
   type FeishuMediaInfo,
   type FeishuMessageInfo,
+  type FeishuMessageMediaKeys,
 } from "./types.js";
 
 // Cache permission errors to avoid spamming the user with repeated notifications.
@@ -126,6 +129,19 @@ function isFeishuTopicSessionScope(
   scope: ReturnType<typeof resolveConfiguredFeishuGroupSessionScope>,
 ): boolean {
   return scope === "group_topic" || scope === "group_topic_sender";
+}
+
+function buildReferencedMediaFingerprint(mediaKeys: FeishuMessageMediaKeys): string {
+  return [
+    mediaKeys.imageKey ? `image:${mediaKeys.imageKey}` : undefined,
+    mediaKeys.fileKey ? `file:${mediaKeys.fileKey}` : undefined,
+    ...(mediaKeys.imageKeys ?? []).map((imageKey) => `image:${imageKey}`),
+    ...(mediaKeys.mediaKeys ?? []).map((media) =>
+      media.fileKey ? `file:${media.fileKey}` : undefined,
+    ),
+  ]
+    .filter((key): key is string => Boolean(key))
+    .join("|");
 }
 
 async function resolveFeishuAudioPreflightTranscript(params: {
@@ -1037,6 +1053,123 @@ export async function handleFeishuMessage(params: {
       return;
     }
 
+    // Per-turn budget for media delivered from referenced messages
+    // (quoted/root/topic-history): 5× mediaMaxMb — generous enough for a
+    // 20-message thread of typical-sized attachments without runaway cost on a
+    // hot topic. Fresh downloads and cache hits both charge their saved size,
+    // so a warm cache cannot attach unbounded files to a single agent turn.
+    const historyMediaMaxBytes = mediaMaxBytes * 5;
+    // Failed downloads never charge the byte budget (only delivered bytes do),
+    // but each attempt still spends wire bytes and API quota before the size
+    // check rejects it. Cap failed attempts per turn so stacked oversized or
+    // expired attachments cannot bypass the aggregate budget.
+    const HISTORY_MEDIA_MAX_FAILED_DOWNLOADS = 3;
+    let historyMediaBudgetUsed = 0;
+    let historyMediaFailedDownloads = 0;
+    let historyMediaBudgetWarned = false;
+    let referencedMediaDownloadQueue: Promise<void> = Promise.resolve();
+    const referencedMediaPromises = new Map<string, Promise<FeishuMediaInfo[]>>();
+    const referencedMediaPaths = new Set<string>();
+    const enqueueReferencedMediaDownload = <T>(run: () => Promise<T>): Promise<T> => {
+      const queued = referencedMediaDownloadQueue.then(run, run);
+      referencedMediaDownloadQueue = queued.then(
+        () => undefined,
+        () => undefined,
+      );
+      return queued;
+    };
+    const tryDownloadReferencedMessageMedia = async (downloadParams: {
+      messageInfo: { messageId: string; contentType: string; mediaKeys?: FeishuMessageMediaKeys };
+      fallbackMessageId?: string;
+      label: string;
+    }): Promise<FeishuMediaInfo[]> => {
+      const { messageInfo, fallbackMessageId, label } = downloadParams;
+      const mediaKeys = messageInfo.mediaKeys;
+      if (!mediaKeys) {
+        return [];
+      }
+      const mediaFingerprint = buildReferencedMediaFingerprint(mediaKeys);
+      if (!mediaFingerprint) {
+        return [];
+      }
+      // Include the message type: the same file key referenced from different
+      // message types must not share one promise, or the second reference
+      // would inherit media entries with the first message's kind.
+      const appendKey = `${account.accountId}:${messageInfo.contentType}:${mediaFingerprint}`;
+      const existingPromise = referencedMediaPromises.get(appendKey);
+      if (existingPromise) {
+        return existingPromise;
+      }
+      // Broadcast agents build context in parallel; serialize referenced-media
+      // side effects so each key is appended once and the shared byte budget
+      // cannot be raced by multiple per-agent context builders.
+      const promise = enqueueReferencedMediaDownload(async () => {
+        // Only byte exhaustion skips the resolver wholesale: after the failure
+        // cap the resolver still runs with zero download allowance so it can
+        // keep serving already-cached attachments.
+        const remainingHistoryMediaBytes = historyMediaMaxBytes - historyMediaBudgetUsed;
+        if (remainingHistoryMediaBytes <= 0) {
+          if (!historyMediaBudgetWarned) {
+            historyMediaBudgetWarned = true;
+            log(
+              `feishu[${account.accountId}]: history media budget exhausted (${historyMediaBudgetUsed}/${historyMediaMaxBytes}B, failedDownloads=${historyMediaFailedDownloads}) — skipping remaining ${label} attachments; history text keeps its media stub`,
+            );
+          }
+          return [];
+        }
+        const { entries, failedDownloads } = await resolveFeishuReferencedMessageMedia({
+          cfg,
+          messageId: messageInfo.messageId || fallbackMessageId || "",
+          messageType: messageInfo.contentType,
+          mediaKeys,
+          maxBytes: Math.min(mediaMaxBytes, remainingHistoryMediaBytes),
+          maxFailedDownloads: Math.max(
+            0,
+            HISTORY_MEDIA_MAX_FAILED_DOWNLOADS - historyMediaFailedDownloads,
+          ),
+          log,
+          accountId: account.accountId,
+          label,
+        });
+        historyMediaFailedDownloads += failedDownloads;
+        const freshMedia: FeishuMediaInfo[] = [];
+        for (const entry of entries) {
+          if (!entry.media.path) {
+            continue;
+          }
+          // Key on kind+path: the same saved file can be legitimately
+          // referenced as different kinds (e.g. file then video) and dropping
+          // the second entry would keep the first classification only.
+          const appendedKey = `${entry.media.kind}:${entry.media.path}`;
+          if (referencedMediaPaths.has(appendedKey)) {
+            continue;
+          }
+          referencedMediaPaths.add(appendedKey);
+          freshMedia.push(entry.media);
+          // Charge only media actually appended: overlapping fingerprints can
+          // resolve the same saved file twice, and charging a discarded
+          // duplicate would starve later unique attachments.
+          historyMediaBudgetUsed += entry.size;
+        }
+        if (freshMedia.length > 0) {
+          mediaList.push(...freshMedia);
+        }
+        return freshMedia;
+      });
+      referencedMediaPromises.set(appendKey, promise);
+      return promise;
+    };
+
+    let quotedMediaDownloadAttempted = false;
+    if (quotedContent && quotedMessageInfo?.mediaKeys) {
+      quotedMediaDownloadAttempted = true;
+      await tryDownloadReferencedMessageMedia({
+        messageInfo: quotedMessageInfo,
+        fallbackMessageId: ctx.parentId,
+        label: "quoted",
+      });
+    }
+
     const audioTranscript = await resolveFeishuAudioPreflightTranscript({
       cfg: effectiveCfg,
       mediaList,
@@ -1051,9 +1184,12 @@ export async function handleFeishuMessage(params: {
         : mediaList.findIndex(
             (media) => media.kind === "audio" || media.contentType?.startsWith("audio/"),
           );
-    const inboundMedia = toInboundMediaFacts(mediaList, {
-      transcribed: (_media, index) => index === preflightAudioIndex,
-    });
+    // Deferred: referenced-message media can still be appended to mediaList
+    // before dispatch, so inbound media facts must be built at send time.
+    const buildInboundMedia = () =>
+      toInboundMediaFacts(mediaList, {
+        transcribed: (_media, index) => index === preflightAudioIndex,
+      });
     const requiredMentionTargets =
       isGroup && ctx.senderType === "bot" && ctx.senderOpenId
         ? [
@@ -1224,6 +1360,19 @@ export async function handleFeishuMessage(params: {
             `feishu[${account.accountId}]: skipped thread starter from sender ${rootMessageInfo.senderId ?? "unknown"} (mode=${contextVisibilityMode})`,
           );
           rootMessageInfo = null;
+        } else if (
+          rootMessageInfo?.mediaKeys &&
+          // Avoid double-downloading when the root message is also the quoted
+          // target — its media has already been pulled into mediaList above.
+          // The per-key cache would also short-circuit it, but skipping early
+          // keeps logs clean.
+          !(quotedMediaDownloadAttempted && ctx.rootId === ctx.parentId)
+        ) {
+          await tryDownloadReferencedMessageMedia({
+            messageInfo: rootMessageInfo,
+            fallbackMessageId: ctx.rootId,
+            label: "root",
+          });
         }
       }
       return rootMessageInfo ?? null;
@@ -1327,6 +1476,25 @@ export async function handleFeishuMessage(params: {
         const historyMessages = includeStarterInHistory
           ? relevantMessages
           : relevantMessages.slice(1);
+
+        // Pull attachments from all context-bearing messages so the agent can
+        // answer questions about earlier images/files in the topic. Iterate
+        // relevantMessages, not historyMessages: when the thread starter is
+        // sliced out of the textual history it still feeds ThreadStarterBody,
+        // so its attachments must resolve too. Sequential, with a per-turn
+        // byte budget enforced by tryDownloadReferencedMessageMedia and a
+        // process-wide per-key cache so a hot topic doesn't pay the download
+        // cost more than once per attachment per process.
+        for (const msg of relevantMessages) {
+          if (!msg.mediaKeys) {
+            continue;
+          }
+          await tryDownloadReferencedMessageMedia({
+            messageInfo: msg,
+            label: "thread-history",
+          });
+        }
+
         const historyParts = historyMessages.map((msg) => {
           const role = msg.senderType === "app" ? "assistant" : "user";
           return formatAgentEnvelope({
@@ -1374,7 +1542,7 @@ export async function handleFeishuMessage(params: {
             ? normalizeOptionalString(groupConfig?.systemPrompt)
             : undefined,
         },
-        media: inboundMedia,
+        media: buildInboundMedia(),
         messageId: ctx.messageId,
         timestamp: messageCreateTimeMs,
         from: feishuFrom,

--- a/extensions/feishu/src/lifecycle.test-support.ts
+++ b/extensions/feishu/src/lifecycle.test-support.ts
@@ -179,8 +179,11 @@ vi.mock("./reply-dispatcher.js", () => ({
 vi.mock("./send.js", () => ({
   sendCardFeishu: sendCardFeishuMock,
   getMessageFeishu: getMessageFeishuMock,
-  listFeishuThreadMessages: listFeishuThreadMessagesMock,
   sendMessageFeishu: sendMessageFeishuMock,
+}));
+
+vi.mock("./thread-history.js", () => ({
+  listFeishuThreadMessages: listFeishuThreadMessagesMock,
 }));
 
 vi.mock("openclaw/plugin-sdk/conversation-runtime", async () => {

--- a/extensions/feishu/src/message-media-keys.ts
+++ b/extensions/feishu/src/message-media-keys.ts
@@ -1,0 +1,88 @@
+// Feishu plugin module parses media keys and stubs from raw message bodies.
+// Keep this module dependency-light (post parsing + types only): send.ts and
+// bot-content.ts both import it, and heavier imports here re-create the
+// media.ts -> send.ts import cycle.
+import { normalizeFeishuExternalKey } from "./external-keys.js";
+import { parsePostContent } from "./post.js";
+import type { FeishuMessageMediaKeys } from "./types.js";
+
+export function parseFeishuMediaKeys(
+  content: string,
+  messageType: string,
+): { imageKey?: string; fileKey?: string; fileName?: string } {
+  try {
+    const parsed = JSON.parse(content);
+    const imageKey = normalizeFeishuExternalKey(parsed.image_key);
+    const fileKey = normalizeFeishuExternalKey(parsed.file_key);
+    switch (messageType) {
+      case "image":
+        return { imageKey, fileName: parsed.file_name };
+      case "file":
+      case "audio":
+      case "sticker":
+        return { fileKey, fileName: parsed.file_name };
+      case "video":
+      case "media":
+        return { fileKey, imageKey, fileName: parsed.file_name };
+      default:
+        return {};
+    }
+  } catch {
+    return {};
+  }
+}
+
+const FEISHU_MEDIA_MSG_TYPES = new Set(["image", "file", "audio", "video", "media", "sticker"]);
+
+export function isFeishuMediaMessageType(msgType: string): boolean {
+  return FEISHU_MEDIA_MSG_TYPES.has(msgType);
+}
+
+/**
+ * Text stub for a referenced media message. History/quoted media render as a
+ * stub; the actual file_key/image_key is surfaced via
+ * FeishuMessageInfo.mediaKeys so callers can download the bytes when needed.
+ */
+export function formatFeishuMediaMessageStub(parsed: unknown, msgType: string): string {
+  const body = (parsed ?? {}) as { speech_to_text?: unknown; file_name?: unknown };
+  if (msgType === "audio" && typeof body.speech_to_text === "string") {
+    const speechToText = body.speech_to_text.trim();
+    if (speechToText) {
+      return speechToText;
+    }
+  }
+  const fileName = typeof body.file_name === "string" ? body.file_name.trim() : "";
+  const stub = `[${msgType} message]`;
+  return fileName ? `${stub} (${fileName})` : stub;
+}
+
+/**
+ * Extract raw image_key/file_key references from a message body so callers can
+ * later download the attachment the referenced message carries.
+ */
+export function extractFeishuMessageMediaKeys(
+  rawContent: string,
+  msgType: string,
+): FeishuMessageMediaKeys | undefined {
+  if (!rawContent) {
+    return undefined;
+  }
+  if (msgType === "post") {
+    const { imageKeys, mediaKeys } = parsePostContent(rawContent);
+    if (imageKeys.length === 0 && mediaKeys.length === 0) {
+      return undefined;
+    }
+    return {
+      ...(imageKeys.length > 0 ? { imageKeys } : {}),
+      ...(mediaKeys.length > 0 ? { mediaKeys } : {}),
+    };
+  }
+  if (!FEISHU_MEDIA_MSG_TYPES.has(msgType)) {
+    return undefined;
+  }
+  const keys = parseFeishuMediaKeys(rawContent, msgType);
+  if (!keys.imageKey && !keys.fileKey) {
+    return undefined;
+  }
+  return keys;
+}

--- a/extensions/feishu/src/referenced-media.test.ts
+++ b/extensions/feishu/src/referenced-media.test.ts
@@ -1,0 +1,463 @@
+import {
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  statSync,
+  unlinkSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ClawdbotConfig } from "../runtime-api.js";
+
+const saveMessageResourceFeishuMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./media.js", () => ({
+  saveMessageResourceFeishu: saveMessageResourceFeishuMock,
+}));
+
+let resolveFeishuReferencedMessageMedia: typeof import("./referenced-media.js").resolveFeishuReferencedMessageMedia;
+let clearFeishuReferencedMediaCacheForTests: typeof import("./referenced-media.js").clearFeishuReferencedMediaCacheForTests;
+
+// recallReferencedMedia verifies cached paths still exist on disk, so mocked
+// save results must point at real files. macOS tmpdir is a symlink; realpath
+// keeps assertions canonical.
+let mediaDir: string;
+
+function makeSavedFile(name: string, contents = "bytes"): string {
+  const filePath = path.join(mediaDir, name);
+  writeFileSync(filePath, contents);
+  return filePath;
+}
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  ({ resolveFeishuReferencedMessageMedia, clearFeishuReferencedMediaCacheForTests } =
+    await import("./referenced-media.js"));
+  clearFeishuReferencedMediaCacheForTests();
+  mediaDir = realpathSync(mkdtempSync(path.join(os.tmpdir(), "feishu-ref-media-")));
+});
+
+afterEach(() => {
+  clearFeishuReferencedMediaCacheForTests();
+  rmSync(mediaDir, { recursive: true, force: true });
+});
+
+describe("resolveFeishuReferencedMessageMedia", () => {
+  it("downloads, saves, and reports byte count for a fresh image_key", async () => {
+    const buf = Buffer.from("img-bytes");
+    const savedPath = makeSavedFile("uuid-1.png");
+    saveMessageResourceFeishuMock.mockResolvedValueOnce({
+      saved: {
+        path: savedPath,
+        contentType: "image/png",
+        size: buf.byteLength,
+      },
+      contentType: "image/png",
+    });
+
+    const out = await resolveFeishuReferencedMessageMedia({
+      cfg: {} as ClawdbotConfig,
+      messageId: "om_quoted_1",
+      messageType: "image",
+      mediaKeys: { imageKey: "img_v2_abc" },
+      maxBytes: 1024 * 1024,
+      accountId: "acct_a",
+    });
+
+    expect(out.entries).toEqual([
+      {
+        media: { path: savedPath, contentType: "image/png", kind: "image" },
+        size: buf.byteLength,
+      },
+    ]);
+    expect(out.failedDownloads).toBe(0);
+    expect(saveMessageResourceFeishuMock).toHaveBeenCalledTimes(1);
+    expect(saveMessageResourceFeishuMock).toHaveBeenCalledWith(
+      expect.objectContaining({ maxBytes: 1024 * 1024 }),
+    );
+  });
+
+  it("downloads every embedded post image and media resource within the shared budget", async () => {
+    const imageBuffer = Buffer.from("img");
+    const videoBuffer = Buffer.from("vid");
+    const imagePath = makeSavedFile("img.png");
+    const clipPath = makeSavedFile("clip.mp4");
+    saveMessageResourceFeishuMock
+      .mockResolvedValueOnce({
+        saved: {
+          path: imagePath,
+          contentType: "image/png",
+          size: imageBuffer.byteLength,
+        },
+        contentType: "image/png",
+      })
+      .mockResolvedValueOnce({
+        saved: {
+          path: clipPath,
+          contentType: "video/mp4",
+          size: videoBuffer.byteLength,
+        },
+        contentType: "video/mp4",
+      });
+
+    const out = await resolveFeishuReferencedMessageMedia({
+      cfg: {} as ClawdbotConfig,
+      messageId: "om_post_1",
+      messageType: "post",
+      mediaKeys: {
+        imageKeys: ["img_post_1"],
+        mediaKeys: [{ fileKey: "file_post_1", fileName: "clip.mp4" }],
+      },
+      maxBytes: 10,
+      accountId: "acct_a",
+    });
+
+    expect(out.entries).toEqual([
+      {
+        media: { path: imagePath, contentType: "image/png", kind: "image" },
+        size: imageBuffer.byteLength,
+      },
+      {
+        media: { path: clipPath, contentType: "video/mp4", kind: "video" },
+        size: videoBuffer.byteLength,
+      },
+    ]);
+    expect(saveMessageResourceFeishuMock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        fileKey: "img_post_1",
+        type: "image",
+        maxBytes: 10,
+      }),
+    );
+    expect(saveMessageResourceFeishuMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        fileKey: "file_post_1",
+        type: "file",
+        maxBytes: 7,
+        originalFilename: "clip.mp4",
+      }),
+    );
+  });
+
+  it("returns the cached media on a repeat call for the same image_key without re-downloading", async () => {
+    const buf = Buffer.from("img-bytes");
+    saveMessageResourceFeishuMock.mockResolvedValueOnce({
+      saved: {
+        path: makeSavedFile("uuid-cached.png"),
+        contentType: "image/png",
+        size: buf.byteLength,
+      },
+    });
+
+    const first = await resolveFeishuReferencedMessageMedia({
+      cfg: {} as ClawdbotConfig,
+      messageId: "om_quoted_1",
+      messageType: "image",
+      mediaKeys: { imageKey: "img_shared" },
+      maxBytes: 1024 * 1024,
+      accountId: "acct_a",
+    });
+    const second = await resolveFeishuReferencedMessageMedia({
+      cfg: {} as ClawdbotConfig,
+      // Same key referenced from a different message later in the topic.
+      messageId: "om_history_2",
+      messageType: "image",
+      mediaKeys: { imageKey: "img_shared" },
+      maxBytes: 1024 * 1024,
+      accountId: "acct_a",
+    });
+
+    expect(first.entries).toEqual(second.entries);
+    // Cache hits report their saved size too: the caller's budget bounds
+    // delivered media per turn, not just wire downloads.
+    expect(second.entries[0]?.size).toBe(buf.byteLength);
+    expect(saveMessageResourceFeishuMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("scopes the cache by accountId so two accounts don't cross-pollute", async () => {
+    saveMessageResourceFeishuMock
+      .mockResolvedValueOnce({
+        saved: { path: makeSavedFile("a.png"), contentType: "image/png", size: 1 },
+      })
+      .mockResolvedValueOnce({
+        saved: { path: makeSavedFile("b.png"), contentType: "image/png", size: 1 },
+      });
+
+    await resolveFeishuReferencedMessageMedia({
+      cfg: {} as ClawdbotConfig,
+      messageId: "om_1",
+      messageType: "image",
+      mediaKeys: { imageKey: "shared_key" },
+      maxBytes: 1024 * 1024,
+      accountId: "acct_a",
+    });
+    await resolveFeishuReferencedMessageMedia({
+      cfg: {} as ClawdbotConfig,
+      messageId: "om_2",
+      messageType: "image",
+      mediaKeys: { imageKey: "shared_key" },
+      maxBytes: 1024 * 1024,
+      accountId: "acct_b",
+    });
+
+    expect(saveMessageResourceFeishuMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not cache failures so transient API errors can be retried", async () => {
+    saveMessageResourceFeishuMock
+      .mockRejectedValueOnce(new Error("transient 503"))
+      .mockResolvedValueOnce({
+        saved: { path: makeSavedFile("retry.png"), contentType: "image/png", size: 1 },
+      });
+
+    const failed = await resolveFeishuReferencedMessageMedia({
+      cfg: {} as ClawdbotConfig,
+      messageId: "om_1",
+      messageType: "image",
+      mediaKeys: { imageKey: "k" },
+      maxBytes: 1024 * 1024,
+      accountId: "acct_a",
+    });
+    const recovered = await resolveFeishuReferencedMessageMedia({
+      cfg: {} as ClawdbotConfig,
+      messageId: "om_1",
+      messageType: "image",
+      mediaKeys: { imageKey: "k" },
+      maxBytes: 1024 * 1024,
+      accountId: "acct_a",
+    });
+
+    expect(failed.entries).toEqual([]);
+    expect(failed.failedDownloads).toBe(1);
+    expect(recovered.entries).toHaveLength(1);
+    expect(recovered.failedDownloads).toBe(0);
+    expect(saveMessageResourceFeishuMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("re-downloads when the cached file was pruned from disk", async () => {
+    const prunedPath = makeSavedFile("pruned.png");
+    const freshPath = makeSavedFile("fresh.png");
+    saveMessageResourceFeishuMock
+      .mockResolvedValueOnce({
+        saved: { path: prunedPath, contentType: "image/png", size: 1 },
+      })
+      .mockResolvedValueOnce({
+        saved: { path: freshPath, contentType: "image/png", size: 1 },
+      });
+
+    const first = await resolveFeishuReferencedMessageMedia({
+      cfg: {} as ClawdbotConfig,
+      messageId: "om_1",
+      messageType: "image",
+      mediaKeys: { imageKey: "pruned_key" },
+      maxBytes: 1024 * 1024,
+      accountId: "acct_a",
+    });
+    // Simulate the media store TTL sweep removing the inbound file.
+    unlinkSync(prunedPath);
+    const second = await resolveFeishuReferencedMessageMedia({
+      cfg: {} as ClawdbotConfig,
+      messageId: "om_2",
+      messageType: "image",
+      mediaKeys: { imageKey: "pruned_key" },
+      maxBytes: 1024 * 1024,
+      accountId: "acct_a",
+    });
+
+    expect(first.entries[0]?.media.path).toBe(prunedPath);
+    expect(second.entries[0]?.media.path).toBe(freshPath);
+    expect(saveMessageResourceFeishuMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("classifies a video poster image_key as an image, not a video", async () => {
+    const posterPath = makeSavedFile("poster.png");
+    const videoPath = makeSavedFile("clip.mp4");
+    saveMessageResourceFeishuMock
+      .mockResolvedValueOnce({
+        saved: { path: posterPath, contentType: "image/png", size: 1 },
+      })
+      .mockResolvedValueOnce({
+        saved: { path: videoPath, contentType: "video/mp4", size: 1 },
+      });
+
+    const out = await resolveFeishuReferencedMessageMedia({
+      cfg: {} as ClawdbotConfig,
+      messageId: "om_video",
+      messageType: "media",
+      mediaKeys: { imageKey: "poster_key", fileKey: "video_key" },
+      maxBytes: 1024 * 1024,
+      accountId: "acct_a",
+    });
+
+    expect(out.entries.map((entry) => entry.media)).toEqual([
+      { path: posterPath, contentType: "image/png", kind: "image" },
+      { path: videoPath, contentType: "video/mp4", kind: "video" },
+    ]);
+    expect(saveMessageResourceFeishuMock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ fileKey: "poster_key", type: "image" }),
+    );
+    expect(saveMessageResourceFeishuMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ fileKey: "video_key", type: "file" }),
+    );
+  });
+
+  it("stops attempting resources once maxFailedDownloads is reached", async () => {
+    saveMessageResourceFeishuMock.mockRejectedValue(new Error("expired key"));
+
+    const out = await resolveFeishuReferencedMessageMedia({
+      cfg: {} as ClawdbotConfig,
+      messageId: "om_post_bad",
+      messageType: "post",
+      mediaKeys: {
+        imageKeys: ["bad_1", "bad_2", "bad_3", "bad_4", "bad_5"],
+      },
+      maxBytes: 1024 * 1024,
+      maxFailedDownloads: 2,
+      accountId: "acct_a",
+    });
+
+    expect(out.entries).toEqual([]);
+    expect(out.failedDownloads).toBe(2);
+    expect(saveMessageResourceFeishuMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("refreshes the cached file's mtime on recall so the prune TTL restarts", async () => {
+    const cachedPath = makeSavedFile("touched.png");
+    saveMessageResourceFeishuMock.mockResolvedValueOnce({
+      saved: { path: cachedPath, contentType: "image/png", size: 1 },
+    });
+    await resolveFeishuReferencedMessageMedia({
+      cfg: {} as ClawdbotConfig,
+      messageId: "om_1",
+      messageType: "image",
+      mediaKeys: { imageKey: "touch_key" },
+      maxBytes: 1024 * 1024,
+      accountId: "acct_a",
+    });
+    // Age the file to the brink of the media-store prune TTL.
+    const past = Date.now() - 10 * 60 * 1000;
+    utimesSync(cachedPath, past / 1000, past / 1000);
+
+    const recalled = await resolveFeishuReferencedMessageMedia({
+      cfg: {} as ClawdbotConfig,
+      messageId: "om_2",
+      messageType: "image",
+      mediaKeys: { imageKey: "touch_key" },
+      maxBytes: 1024 * 1024,
+      accountId: "acct_a",
+    });
+
+    expect(recalled.entries[0]?.media.path).toBe(cachedPath);
+    expect(saveMessageResourceFeishuMock).toHaveBeenCalledTimes(1);
+    expect(statSync(cachedPath).mtimeMs).toBeGreaterThan(Date.now() - 60 * 1000);
+  });
+
+  it("re-applies the current message's kind when recalling a cached file key", async () => {
+    saveMessageResourceFeishuMock.mockResolvedValueOnce({
+      saved: { path: makeSavedFile("shared.bin"), contentType: "video/mp4", size: 1 },
+    });
+
+    const asFile = await resolveFeishuReferencedMessageMedia({
+      cfg: {} as ClawdbotConfig,
+      messageId: "om_file_msg",
+      messageType: "file",
+      mediaKeys: { fileKey: "shared_file_key" },
+      maxBytes: 1024 * 1024,
+      accountId: "acct_a",
+    });
+    const asVideo = await resolveFeishuReferencedMessageMedia({
+      cfg: {} as ClawdbotConfig,
+      messageId: "om_video_msg",
+      messageType: "media",
+      mediaKeys: { fileKey: "shared_file_key" },
+      maxBytes: 1024 * 1024,
+      accountId: "acct_a",
+    });
+
+    expect(asFile.entries[0]?.media.kind).toBe("document");
+    expect(asVideo.entries[0]?.media.kind).toBe("video");
+    expect(asVideo.entries[0]?.media.path).toBe(asFile.entries[0]?.media.path);
+    expect(saveMessageResourceFeishuMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("serves cache hits even after the failed-download quota is exhausted", async () => {
+    const cachedPath = makeSavedFile("cached-after-failures.png");
+    saveMessageResourceFeishuMock.mockResolvedValueOnce({
+      saved: { path: cachedPath, contentType: "image/png", size: 1 },
+    });
+    await resolveFeishuReferencedMessageMedia({
+      cfg: {} as ClawdbotConfig,
+      messageId: "om_warm",
+      messageType: "post",
+      mediaKeys: { imageKeys: ["good_key"] },
+      maxBytes: 1024 * 1024,
+      accountId: "acct_a",
+    });
+
+    saveMessageResourceFeishuMock.mockRejectedValue(new Error("expired key"));
+    const out = await resolveFeishuReferencedMessageMedia({
+      cfg: {} as ClawdbotConfig,
+      messageId: "om_mixed",
+      messageType: "post",
+      mediaKeys: { imageKeys: ["bad_1", "bad_2", "good_key"] },
+      maxBytes: 1024 * 1024,
+      maxFailedDownloads: 2,
+      accountId: "acct_a",
+    });
+
+    expect(out.failedDownloads).toBe(2);
+    expect(out.entries).toEqual([
+      expect.objectContaining({
+        media: expect.objectContaining({ path: cachedPath, kind: "image" }),
+      }),
+    ]);
+  });
+
+  it("stops serving cached media once the delivered-bytes budget is spent", async () => {
+    const bigPath = makeSavedFile("big.bin");
+    saveMessageResourceFeishuMock.mockResolvedValueOnce({
+      saved: { path: bigPath, contentType: "application/octet-stream", size: 10 },
+    });
+    await resolveFeishuReferencedMessageMedia({
+      cfg: {} as ClawdbotConfig,
+      messageId: "om_warm",
+      messageType: "file",
+      mediaKeys: { fileKey: "big_key" },
+      maxBytes: 1024,
+      accountId: "acct_a",
+    });
+
+    const out = await resolveFeishuReferencedMessageMedia({
+      cfg: {} as ClawdbotConfig,
+      messageId: "om_broke",
+      messageType: "file",
+      mediaKeys: { fileKey: "big_key" },
+      maxBytes: 5,
+      accountId: "acct_a",
+    });
+
+    expect(out.entries).toEqual([]);
+    expect(saveMessageResourceFeishuMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns empty when neither image_key nor file_key is present", async () => {
+    const out = await resolveFeishuReferencedMessageMedia({
+      cfg: {} as ClawdbotConfig,
+      messageId: "om_1",
+      messageType: "text",
+      mediaKeys: {},
+      maxBytes: 1024 * 1024,
+    });
+
+    expect(out.entries).toEqual([]);
+    expect(out.failedDownloads).toBe(0);
+    expect(saveMessageResourceFeishuMock).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/feishu/src/referenced-media.ts
+++ b/extensions/feishu/src/referenced-media.ts
@@ -1,0 +1,268 @@
+// Feishu plugin module resolves attachments referenced from quoted/root/thread-history messages.
+import { utimesSync } from "node:fs";
+import type { ClawdbotConfig } from "../runtime-api.js";
+import {
+  resolveFeishuMediaKind,
+  resolveSavedFeishuMedia,
+  toMessageResourceType,
+} from "./bot-content.js";
+import { saveMessageResourceFeishu } from "./media.js";
+import type { FeishuMediaInfo, FeishuMessageMediaKeys } from "./types.js";
+
+/**
+ * Process-wide cache for already-resolved referenced-message attachments. Keyed
+ * by `${accountId}:${imageKey|fileKey}` so the same Feishu resource downloaded
+ * for one inbound message is reused when another inbound's quoted/root/thread
+ * history references it again.
+ *
+ * Why this exists: long-running monitoring scenarios re-read the same topic
+ * history on every new message in the topic. Without a per-key cache an active
+ * 20-message thread re-downloads every prior attachment for every new message
+ * (O(n²) per topic) and quickly approaches per-turn byte budgets / Feishu API
+ * rate limits.
+ *
+ * Scope: in-process only. Process restart re-warms the cache; that is fine —
+ * downloads on a fresh process are bounded by the per-turn budget and resumed
+ * naturally as new messages arrive. We do not negative-cache failures because
+ * those are typically transient (token refresh, transient 5xx).
+ *
+ * Bounded with a simple FIFO/LRU. Cap is generous because each entry is just
+ * a small object holding a string path; 1000 entries ≈ a few hundred KB.
+ */
+const REFERENCED_MEDIA_CACHE_MAX_ENTRIES = 1000;
+type ReferencedMediaCacheEntry = { info: FeishuMediaInfo; size: number };
+const referencedMediaCache = new Map<string, ReferencedMediaCacheEntry>();
+
+type ReferencedMediaResource = {
+  fileKey: string;
+  type: "image" | "file";
+  kind: FeishuMediaInfo["kind"];
+  fileName?: string;
+};
+
+function addReferencedMediaResource(
+  resources: ReferencedMediaResource[],
+  seen: Set<string>,
+  resource: ReferencedMediaResource,
+): void {
+  if (!resource.fileKey) {
+    return;
+  }
+  const key = `${resource.type}:${resource.fileKey}`;
+  if (seen.has(key)) {
+    return;
+  }
+  seen.add(key);
+  resources.push(resource);
+}
+
+function collectReferencedMediaResources(
+  messageType: string,
+  mediaKeys: FeishuMessageMediaKeys,
+): ReferencedMediaResource[] {
+  const resources: ReferencedMediaResource[] = [];
+  const seen = new Set<string>();
+
+  if (messageType === "post") {
+    for (const imageKey of mediaKeys.imageKeys ?? []) {
+      addReferencedMediaResource(resources, seen, {
+        fileKey: imageKey,
+        type: "image",
+        kind: "image",
+      });
+    }
+    for (const media of mediaKeys.mediaKeys ?? []) {
+      addReferencedMediaResource(resources, seen, {
+        fileKey: media.fileKey,
+        type: "file",
+        kind: "video",
+        fileName: media.fileName,
+      });
+    }
+    return resources;
+  }
+
+  if (mediaKeys.imageKey) {
+    addReferencedMediaResource(resources, seen, {
+      fileKey: mediaKeys.imageKey,
+      type: "image",
+      // Always an image: for video/media messages the image_key is the
+      // poster/thumbnail, not the video bytes, so kind must not follow the
+      // message type or inbound media facts would label an image as video.
+      kind: "image",
+      fileName: mediaKeys.fileName,
+    });
+  }
+  if (mediaKeys.fileKey) {
+    addReferencedMediaResource(resources, seen, {
+      fileKey: mediaKeys.fileKey,
+      type: toMessageResourceType(messageType),
+      kind: resolveFeishuMediaKind(messageType),
+      fileName: mediaKeys.fileName,
+    });
+  }
+
+  return resources;
+}
+
+function rememberReferencedMedia(key: string, value: ReferencedMediaCacheEntry): void {
+  if (referencedMediaCache.has(key)) {
+    referencedMediaCache.delete(key);
+  } else if (referencedMediaCache.size >= REFERENCED_MEDIA_CACHE_MAX_ENTRIES) {
+    const oldest = referencedMediaCache.keys().next().value;
+    if (oldest !== undefined) {
+      referencedMediaCache.delete(oldest);
+    }
+  }
+  referencedMediaCache.set(key, value);
+}
+
+function recallReferencedMedia(key: string): ReferencedMediaCacheEntry | undefined {
+  const cached = referencedMediaCache.get(key);
+  if (!cached) {
+    return undefined;
+  }
+  // The media store prunes inbound files by mtime on a short TTL
+  // (DEFAULT_TTL_MS in src/media/store.ts is minutes, not hours). A cache hit
+  // must therefore both verify the file still exists and touch it so the
+  // recalled path gets a full retention window again — otherwise the next
+  // sweep could remove it between context build and agent read. Evict and
+  // re-download when the file is already gone.
+  if (!cached.info.path) {
+    referencedMediaCache.delete(key);
+    return undefined;
+  }
+  try {
+    const now = new Date();
+    utimesSync(cached.info.path, now, now);
+  } catch {
+    referencedMediaCache.delete(key);
+    return undefined;
+  }
+  referencedMediaCache.delete(key);
+  referencedMediaCache.set(key, cached);
+  return cached;
+}
+
+/** Test-only: drop all cached referenced-media entries. */
+export function clearFeishuReferencedMediaCacheForTests(): void {
+  referencedMediaCache.clear();
+}
+
+/**
+ * Resolve attachments from a referenced (quoted/root/history) message into
+ * FeishuMediaInfo entries. The Feishu file resource API requires the
+ * message_id of the message that owns the resource, so callers must pass the
+ * referenced message's id, not the inbound message's id.
+ *
+ * Used to pull image/file attachments from quoted/root/topic-history messages
+ * into the agent's MediaPaths so an inbound that references earlier media is
+ * answered from the actual bytes instead of a `[image message]`-style stub.
+ *
+ * Caching: results are memoized per `(accountId, resource type, key)`. A repeat
+ * call with the same key returns the previously saved media without hitting
+ * the Feishu API or rewriting the on-disk buffer.
+ *
+ * Budget: `maxBytes` bounds the bytes charged per call — fresh downloads and
+ * cache hits both charge their saved size, so callers can cap the total media
+ * delivered into one agent turn, not just wire cost. Entries carry their saved
+ * size so callers that de-duplicate across calls can charge only what they
+ * actually append. `failedDownloads` counts only real download attempts;
+ * cache hits are never blocked by the failure cap.
+ */
+export async function resolveFeishuReferencedMessageMedia(params: {
+  cfg: ClawdbotConfig;
+  messageId: string;
+  messageType: string;
+  mediaKeys: FeishuMessageMediaKeys;
+  maxBytes: number;
+  /** Stop after this many failed downloads (rich-text posts can carry many keys). */
+  maxFailedDownloads?: number;
+  log?: (msg: string) => void;
+  accountId?: string;
+  label?: string;
+}): Promise<{
+  entries: Array<{ media: FeishuMediaInfo; size: number }>;
+  failedDownloads: number;
+}> {
+  const { cfg, messageId, messageType, mediaKeys, maxBytes, log, accountId, label } = params;
+  const maxFailedDownloads = params.maxFailedDownloads ?? Number.POSITIVE_INFINITY;
+  const resources = collectReferencedMediaResources(messageType, mediaKeys);
+  if (resources.length === 0) {
+    return { entries: [], failedDownloads: 0 };
+  }
+  const labelPrefix = label ? `${label} ` : "";
+  const entries: Array<{ media: FeishuMediaInfo; size: number }> = [];
+  let chargedBytes = 0;
+  let failedDownloads = 0;
+
+  for (const resource of resources) {
+    // The byte budget bounds delivered media per call: a warm cache must not
+    // let one turn attach unbounded previously-downloaded files.
+    const remainingBytes = maxBytes - chargedBytes;
+    if (remainingBytes <= 0) {
+      break;
+    }
+    const cacheKey = `${accountId ?? "default"}:${resource.type}:${resource.fileKey}`;
+    const cached = recallReferencedMedia(cacheKey);
+    if (cached) {
+      if (cached.size > remainingBytes) {
+        continue;
+      }
+      log?.(
+        `feishu: reused cached ${labelPrefix}${messageType} media for key=${resource.fileKey} -> ${cached.info.path}`,
+      );
+      // Kind is message-specific, not file-specific: the same file key can be
+      // referenced as file/audio/video across messages. Cached path/contentType
+      // are immutable; re-apply the current resource's kind on every recall.
+      entries.push({ media: { ...cached.info, kind: resource.kind }, size: cached.size });
+      chargedBytes += cached.size;
+      continue;
+    }
+
+    // The failure cap gates only real download attempts; cache hits above stay
+    // served even after expired/oversized keys exhaust the download quota.
+    if (failedDownloads >= maxFailedDownloads) {
+      continue;
+    }
+
+    try {
+      const result = await saveMessageResourceFeishu({
+        cfg,
+        messageId,
+        fileKey: resource.fileKey,
+        type: resource.type,
+        accountId,
+        maxBytes: remainingBytes,
+        originalFilename: resource.fileName,
+      });
+      const saved = await resolveSavedFeishuMedia({
+        result,
+        maxBytes: remainingBytes,
+        originalFilename: resource.fileName,
+      });
+      const info: FeishuMediaInfo = {
+        path: saved.path,
+        contentType: saved.contentType ?? result.contentType,
+        kind: resource.kind,
+      };
+      rememberReferencedMedia(cacheKey, { info, size: saved.size });
+      entries.push({ media: info, size: saved.size });
+      chargedBytes += saved.size;
+      log?.(
+        `feishu: downloaded ${labelPrefix}${messageType} media for message=${messageId}, saved to ${saved.path} (${saved.size}B)`,
+      );
+    } catch (err) {
+      // Failed attempts still cost wire bytes before save-time size checks
+      // reject them, and only saved bytes reach `downloadedBytes`. Count the
+      // failure so callers can stop after a few and bound per-turn cost even
+      // when a sender stacks oversized attachments.
+      failedDownloads++;
+      log?.(
+        `feishu: failed to download ${labelPrefix}${messageType} media for message=${messageId}: ${String(err)}`,
+      );
+    }
+  }
+
+  return { entries, failedDownloads };
+}

--- a/extensions/feishu/src/send.test.ts
+++ b/extensions/feishu/src/send.test.ts
@@ -58,7 +58,7 @@ vi.mock("./runtime.js", () => ({
 
 let editMessageFeishu: typeof import("./send.js").editMessageFeishu;
 let getMessageFeishu: typeof import("./send.js").getMessageFeishu;
-let listFeishuThreadMessages: typeof import("./send.js").listFeishuThreadMessages;
+let listFeishuThreadMessages: typeof import("./thread-history.js").listFeishuThreadMessages;
 let resolveFeishuCardTemplate: typeof import("./send.js").resolveFeishuCardTemplate;
 let sendMarkdownCardFeishu: typeof import("./send.js").sendMarkdownCardFeishu;
 let sendMessageFeishu: typeof import("./send.js").sendMessageFeishu;
@@ -69,12 +69,12 @@ describe("getMessageFeishu", () => {
     ({
       editMessageFeishu,
       getMessageFeishu,
-      listFeishuThreadMessages,
       resolveFeishuCardTemplate,
       sendMarkdownCardFeishu,
       sendMessageFeishu,
       sendStructuredCardFeishu,
     } = await import("./send.js"));
+    ({ listFeishuThreadMessages } = await import("./thread-history.js"));
   });
 
   afterAll(() => {
@@ -508,7 +508,54 @@ describe("getMessageFeishu", () => {
     });
   });
 
-  it("returns text placeholder instead of raw JSON for unsupported message types", async () => {
+  it("surfaces embedded media keys from post messages", async () => {
+    mockClientGet.mockResolvedValueOnce({
+      code: 0,
+      data: {
+        items: [
+          {
+            message_id: "om_post_media",
+            chat_id: "oc_post_media",
+            msg_type: "post",
+            body: {
+              content: JSON.stringify({
+                zh_cn: {
+                  title: "Summary",
+                  content: [
+                    [
+                      { tag: "text", text: "post body" },
+                      { tag: "img", image_key: "img_post_1" },
+                      { tag: "media", file_key: "file_post_1", file_name: "clip.mp4" },
+                    ],
+                  ],
+                },
+              }),
+            },
+          },
+        ],
+      },
+    });
+
+    const result = await getMessageFeishu({
+      cfg: {} as ClawdbotConfig,
+      messageId: "om_post_media",
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        messageId: "om_post_media",
+        chatId: "oc_post_media",
+        contentType: "post",
+        content: "Summary\n\npost body![image][media]",
+        mediaKeys: {
+          imageKeys: ["img_post_1"],
+          mediaKeys: [{ fileKey: "file_post_1", fileName: "clip.mp4" }],
+        },
+      }),
+    );
+  });
+
+  it("returns a file stub and surfaces mediaKeys for file messages", async () => {
     mockClientGet.mockResolvedValueOnce({
       code: 0,
       data: {
@@ -518,7 +565,7 @@ describe("getMessageFeishu", () => {
             chat_id: "oc_file",
             msg_type: "file",
             body: {
-              content: JSON.stringify({ file_key: "file_v3_123" }),
+              content: JSON.stringify({ file_key: "file_v3_123", file_name: "report.pdf" }),
             },
           },
         ],
@@ -530,18 +577,46 @@ describe("getMessageFeishu", () => {
       messageId: "om_file",
     });
 
-    expect(result).toEqual({
-      messageId: "om_file",
-      chatId: "oc_file",
-      chatType: undefined,
-      senderId: undefined,
-      senderOpenId: undefined,
-      senderType: undefined,
-      content: "[file message]",
-      contentType: "file",
-      createTime: undefined,
-      threadId: undefined,
+    expect(result).toEqual(
+      expect.objectContaining({
+        messageId: "om_file",
+        chatId: "oc_file",
+        contentType: "file",
+        content: "[file message] (report.pdf)",
+        mediaKeys: { fileKey: "file_v3_123", fileName: "report.pdf" },
+      }),
+    );
+  });
+
+  it("surfaces image_key on image messages and uses the image stub", async () => {
+    mockClientGet.mockResolvedValueOnce({
+      code: 0,
+      data: {
+        items: [
+          {
+            message_id: "om_image",
+            chat_id: "oc_image",
+            msg_type: "image",
+            body: {
+              content: JSON.stringify({ image_key: "img_v2_abc" }),
+            },
+          },
+        ],
+      },
     });
+
+    const result = await getMessageFeishu({
+      cfg: {} as ClawdbotConfig,
+      messageId: "om_image",
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        contentType: "image",
+        content: "[image message]",
+        mediaKeys: { imageKey: "img_v2_abc" },
+      }),
+    );
   });
 
   it("supports single-object response shape from Feishu API", async () => {
@@ -636,22 +711,22 @@ describe("getMessageFeishu", () => {
       },
     });
     expect(result).toEqual([
-      {
+      expect.objectContaining({
         messageId: "om_file",
         senderId: "ou_1",
         senderType: "user",
         contentType: "file",
         content: "[file message]",
-        createTime: 1710000001000,
-      },
-      {
+        mediaKeys: { fileKey: "file_v3_123" },
+      }),
+      expect.objectContaining({
         messageId: "om_card",
         senderId: "app_1",
         senderType: "app",
         contentType: "interactive",
         content: "hello from card 2.0",
         createTime: 1710000000000,
-      },
+      }),
     ]);
   });
 

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -17,6 +17,11 @@ import {
 } from "./markdown.js";
 import type { MentionTarget } from "./mention-target.types.js";
 import { buildMentionedCardContent } from "./mention.js";
+import {
+  extractFeishuMessageMediaKeys,
+  formatFeishuMediaMessageStub,
+  isFeishuMediaMessageType,
+} from "./message-media-keys.js";
 import { resolveFeishuCardTemplate } from "./native-card.js";
 import { parsePostContent } from "./post.js";
 import {
@@ -87,7 +92,7 @@ type FeishuMessageSender = {
   sender_type?: string;
 };
 
-type FeishuMessageGetItem = {
+export type FeishuMessageGetItem = {
   message_id?: string;
   chat_id?: string;
   chat_type?: FeishuChatType;
@@ -343,6 +348,10 @@ function parseFeishuMessageContent(rawContent: string, msgType: string): string 
     return parseInteractiveCardContent(parsed);
   }
 
+  if (isFeishuMediaMessageType(msgType)) {
+    return formatFeishuMediaMessageStub(parsed, msgType);
+  }
+
   if (typeof parsed === "string") {
     return parsed;
   }
@@ -359,12 +368,13 @@ function parseFeishuMessageContent(rawContent: string, msgType: string): string 
   return `[${msgType || "unknown"} message]`;
 }
 
-function parseFeishuMessageItem(
+export function parseFeishuMessageItem(
   item: FeishuMessageGetItem,
   fallbackMessageId?: string,
 ): FeishuMessageInfo {
   const msgType = item.msg_type ?? "text";
   const rawContent = item.body?.content ?? "";
+  const mediaKeys = extractFeishuMessageMediaKeys(rawContent, msgType);
 
   return {
     messageId: item.message_id ?? fallbackMessageId ?? "",
@@ -383,6 +393,7 @@ function parseFeishuMessageItem(
     contentType: msgType,
     createTime: parseStrictNonNegativeInteger(item.create_time),
     threadId: item.thread_id || undefined,
+    ...(mediaKeys ? { mediaKeys } : {}),
   };
 }
 
@@ -428,99 +439,6 @@ export async function getMessageFeishu(params: {
   } catch {
     return null;
   }
-}
-
-type FeishuThreadMessageInfo = {
-  messageId: string;
-  senderId?: string;
-  senderType?: string;
-  content: string;
-  contentType: string;
-  createTime?: number;
-};
-
-/**
- * List messages in a Feishu thread (topic).
- * Uses container_id_type=thread to directly query thread messages,
- * which includes both the root message and all replies (including bot replies).
- */
-export async function listFeishuThreadMessages(params: {
-  cfg: ClawdbotConfig;
-  threadId: string;
-  currentMessageId?: string;
-  /** Exclude the root message (already provided separately as ThreadStarterBody). */
-  rootMessageId?: string;
-  limit?: number;
-  accountId?: string;
-}): Promise<FeishuThreadMessageInfo[]> {
-  const { cfg, threadId, currentMessageId, rootMessageId, limit = 20, accountId } = params;
-  const account = resolveFeishuRuntimeAccount({ cfg, accountId });
-  if (!account.configured) {
-    throw new Error(`Feishu account "${account.accountId}" not configured`);
-  }
-
-  const client = createFeishuClient(account);
-
-  const response = (await client.im.message.list({
-    params: {
-      container_id_type: "thread",
-      container_id: threadId,
-      // Fetch newest messages first so long threads keep the most recent turns.
-      // Results are reversed below to restore chronological order.
-      sort_type: "ByCreateTimeDesc",
-      page_size: Math.min(limit + 1, 50),
-      card_msg_content_type: "user_card_content",
-    },
-  })) as {
-    code?: number;
-    msg?: string;
-    data?: {
-      items?: Array<
-        {
-          message_id?: string;
-          root_id?: string;
-          parent_id?: string;
-        } & FeishuMessageGetItem
-      >;
-    };
-  };
-
-  if (response.code !== 0) {
-    throw new Error(
-      `Feishu thread list failed: code=${response.code} msg=${response.msg ?? "unknown"}`,
-    );
-  }
-
-  const items = response.data?.items ?? [];
-  const results: FeishuThreadMessageInfo[] = [];
-
-  for (const item of items) {
-    if (currentMessageId && item.message_id === currentMessageId) {
-      continue;
-    }
-    if (rootMessageId && item.message_id === rootMessageId) {
-      continue;
-    }
-
-    const parsed = parseFeishuMessageItem(item);
-
-    results.push({
-      messageId: parsed.messageId,
-      senderId: parsed.senderId,
-      senderType: parsed.senderType,
-      content: parsed.content,
-      contentType: parsed.contentType,
-      createTime: parsed.createTime,
-    });
-
-    if (results.length >= limit) {
-      break;
-    }
-  }
-
-  // Restore chronological order (oldest first) since we fetched newest-first.
-  results.reverse();
-  return results;
 }
 
 type SendFeishuMessageParams = {

--- a/extensions/feishu/src/thread-history.ts
+++ b/extensions/feishu/src/thread-history.ts
@@ -1,0 +1,101 @@
+// Feishu plugin module lists topic-thread history messages.
+import type { ClawdbotConfig } from "../runtime-api.js";
+import { resolveFeishuRuntimeAccount } from "./accounts.js";
+import { createFeishuClient } from "./client.js";
+import { type FeishuMessageGetItem, parseFeishuMessageItem } from "./send.js";
+import type { FeishuMessageMediaKeys } from "./types.js";
+
+type FeishuThreadMessageInfo = {
+  messageId: string;
+  senderId?: string;
+  senderType?: string;
+  content: string;
+  contentType: string;
+  createTime?: number;
+  mediaKeys?: FeishuMessageMediaKeys;
+};
+
+/**
+ * List messages in a Feishu thread (topic).
+ * Uses container_id_type=thread to directly query thread messages,
+ * which includes both the root message and all replies (including bot replies).
+ */
+export async function listFeishuThreadMessages(params: {
+  cfg: ClawdbotConfig;
+  threadId: string;
+  currentMessageId?: string;
+  /** Exclude the root message (already provided separately as ThreadStarterBody). */
+  rootMessageId?: string;
+  limit?: number;
+  accountId?: string;
+}): Promise<FeishuThreadMessageInfo[]> {
+  const { cfg, threadId, currentMessageId, rootMessageId, limit = 20, accountId } = params;
+  const account = resolveFeishuRuntimeAccount({ cfg, accountId });
+  if (!account.configured) {
+    throw new Error(`Feishu account "${account.accountId}" not configured`);
+  }
+
+  const client = createFeishuClient(account);
+
+  const response = (await client.im.message.list({
+    params: {
+      container_id_type: "thread",
+      container_id: threadId,
+      // Fetch newest messages first so long threads keep the most recent turns.
+      // Results are reversed below to restore chronological order.
+      sort_type: "ByCreateTimeDesc",
+      page_size: Math.min(limit + 1, 50),
+      card_msg_content_type: "user_card_content",
+    },
+  })) as {
+    code?: number;
+    msg?: string;
+    data?: {
+      items?: Array<
+        {
+          message_id?: string;
+          root_id?: string;
+          parent_id?: string;
+        } & FeishuMessageGetItem
+      >;
+    };
+  };
+
+  if (response.code !== 0) {
+    throw new Error(
+      `Feishu thread list failed: code=${response.code} msg=${response.msg ?? "unknown"}`,
+    );
+  }
+
+  const items = response.data?.items ?? [];
+  const results: FeishuThreadMessageInfo[] = [];
+
+  for (const item of items) {
+    if (currentMessageId && item.message_id === currentMessageId) {
+      continue;
+    }
+    if (rootMessageId && item.message_id === rootMessageId) {
+      continue;
+    }
+
+    const parsed = parseFeishuMessageItem(item);
+
+    results.push({
+      messageId: parsed.messageId,
+      senderId: parsed.senderId,
+      senderType: parsed.senderType,
+      content: parsed.content,
+      contentType: parsed.contentType,
+      createTime: parsed.createTime,
+      ...(parsed.mediaKeys ? { mediaKeys: parsed.mediaKeys } : {}),
+    });
+
+    if (results.length >= limit) {
+      break;
+    }
+  }
+
+  // Restore chronological order (oldest first) since we fetched newest-first.
+  results.reverse();
+  return results;
+}

--- a/extensions/feishu/src/types.ts
+++ b/extensions/feishu/src/types.ts
@@ -66,6 +66,14 @@ export function isFeishuGroupChatType(chatType: FeishuChatType | undefined): boo
   return chatType === "group" || chatType === "topic_group";
 }
 
+export type FeishuMessageMediaKeys = {
+  imageKey?: string;
+  fileKey?: string;
+  fileName?: string;
+  imageKeys?: string[];
+  mediaKeys?: Array<{ fileKey: string; fileName?: string }>;
+};
+
 export type FeishuMessageInfo = {
   messageId: string;
   chatId: string;
@@ -78,6 +86,13 @@ export type FeishuMessageInfo = {
   createTime?: number;
   /** Feishu thread ID (omt_xxx) — present when the message belongs to a topic thread. */
   threadId?: string;
+  /**
+   * Raw image_key/file_key values extracted from media and rich-text post
+   * message bodies. Allows callers to download the actual attachment when
+   * surfacing quoted/root/historical messages instead of falling back to a
+   * text stub only.
+   */
+  mediaKeys?: FeishuMessageMediaKeys;
 };
 
 export interface FeishuProbeResult extends BaseProbeResult {


### PR DESCRIPTION
## What Problem This Solves

When the Feishu bot is @-mentioned mid-thread (or answers a quoted reply), it only resolves attachments from the inbound message itself. Images/files/audio/video referenced from the quoted message, the topic root, or earlier thread-history messages reach the agent as text stubs like `[image message]` — the agent never receives the bytes and hallucinates answers about attachments it cannot see. This is the common "someone posted a screenshot earlier in the topic, then @-mentions the bot to ask about it" flow.

## Why This Change Was Made

- `extensions/feishu/src/message-media-keys.ts` (new, dependency-light): `parseFeishuMediaKeys` moves here from `bot-content.ts`; adds `extractFeishuMessageMediaKeys`, `isFeishuMediaMessageType`, and `formatFeishuMediaMessageStub` shared by `send.ts` and `bot-content.ts` without re-creating the `media.ts -> send.ts` import cycle.
- `extensions/feishu/src/referenced-media.ts` (new): `resolveFeishuReferencedMessageMedia` downloads referenced attachments with a process-wide LRU cache (1000 entries, keyed by account+resource key). Long-running topics re-read the same history on every message and would otherwise re-download every attachment O(n²). Cache hits re-verify the saved file still exists because the media store prunes inbound files on a short TTL.
- `extensions/feishu/src/bot.ts`: wires the resolver into the quoted/root/thread-history branches with a per-turn byte budget (5× `mediaMaxMb`, no new config surface) plus a failed-download cap, and serializes downloads so parallel broadcast-agent context builds share one download per key.
- `extensions/feishu/src/send.ts`: surfaces structured `mediaKeys` on `FeishuMessageInfo`, uses `speech_to_text` directly for referenced audio, and appends file names to media stubs. `listFeishuThreadMessages` moves to `thread-history.ts` (send.ts was over the 700-line lint cap) and propagates `mediaKeys`.

No new config or env surface: the history budget derives from the existing `mediaMaxMb`.

AI-assisted: implementation and structured review with Codex; the author reviewed the resulting code and tests.

## User Impact

Feishu/Lark users can @-mention the bot anywhere in a topic and ask about images/files posted earlier by anyone in the thread; the agent answers from the actual bytes instead of guessing from `[image message]` stubs. Download cost is bounded per turn and cached per process, so busy topics do not re-pay downloads or hammer Feishu API quota.

## Evidence

- Precursor of this patch has run on the author's production gateway since 2026-05 (rebased through v2026.7.1) with daily Feishu group/topic traffic; e.g. redacted production log: `feishu[default] downloaded thread-history file media for message=om_…, saved to <media-dir>/inbound/feedback---….md (15904B)`.
- `node scripts/run-vitest.mjs extensions/feishu` — 89 files, 1344 tests passed, including new coverage: resolver cache hit/miss, stale-path eviction after media-store pruning, per-call budget, failure retry + failedDownloads accounting, video-poster kind classification, `mediaKeys` extraction in `getMessageFeishu`/thread history, quoted-media agent context, and broadcast agents sharing one download.
- `pnpm tsgo:extensions`, `pnpm check:test-types`, `scripts/run-oxlint.mjs` (feishu files), `pnpm check:import-cycles` (0 cycles), `oxfmt` — all green locally.
- Repository `autoreview --mode branch --base upstream/main` (Codex, thinking=high) ran iteratively until clean; the review surfaced and this diff fixes, each with a regression test: failed-download budget bypass (incl. multi-resource posts), stale cached paths after media-store TTL pruning (cache hits now verify + touch the file), message-specific kind staleness on shared file keys (recall re-applies kind; video posters are images), cache/budget integration (delivered bytes are charged, cache hits are not blocked by the failure cap, only appended entries charge the turn budget), and thread-starter media resolution when the starter is sliced out of textual history. Final pass: clean, "patch is correct".
- Full repository gates were not run locally; GitHub CI is the broader proof lane.
