### PR TITLE
fix(ui): stabilize drag-managed group e2e

### DIFF
--- a/ui/src/e2e/session-management.e2e.test.ts
+++ b/ui/src/e2e/session-management.e2e.test.ts
@@ -1387,10 +1387,20 @@ describeControlUiE2e("Control UI session management mocked Gateway E2E", () => {
           .indexOf(element),
       );
       expect(moveToGroupIndex).toBeGreaterThanOrEqual(0);
+      // Submenu ARIA is ready before Web Awesome finishes opening the dropdown.
+      // Wait for its focus contract so navigation keys cannot outrun the menu.
+      await expect
+        .poll(() =>
+          page.locator("openclaw-session-menu > wa-dropdown > wa-dropdown-item:focus").count(),
+        )
+        .toBe(1);
       await page.keyboard.press("Home");
       for (let index = 0; index < moveToGroupIndex; index += 1) {
         await page.keyboard.press("ArrowDown");
       }
+      await expect
+        .poll(() => moveToGroup.evaluate((element) => element === document.activeElement))
+        .toBe(true);
       await page.keyboard.press("ArrowRight");
       await expect.poll(() => moveToGroup.getAttribute("aria-expanded")).toBe("true");
       page.once("dialog", (dialog) => void dialog.accept("Gamma"));


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where maintainers running the Control UI session-management E2E locally on macOS could intermittently time out while opening the Move to group submenu with the keyboard.

## Why This Change Was Made

The test now waits for Web Awesome's actual menu-focus contract before sending navigation keys, then verifies that keyboard navigation reached Move to group before pressing ArrowRight. This keeps the keyboard coverage while removing the race between early submenu ARIA setup and the dropdown's asynchronous focus lifecycle.

## User Impact

No shipped product behavior changes. Local Control UI proof runs are deterministic for this interaction.

## Evidence

- Five consecutive macOS runs on current main plus this patch: `node scripts/run-vitest.mjs ui/src/e2e/session-management.e2e.test.ts`
- Result: 5/5 files passed, 21/21 tests per run, 105/105 tests total. Both the drag-managed-groups case and the pinned-only-session case passed every run.
- `git diff --check`
- `oxfmt --check ui/src/e2e/session-management.e2e.test.ts`
- Fresh Codex autoreview: no accepted/actionable findings, 0.94 confidence.

AI-assisted: yes. I reviewed the dependency lifecycle and the final change.
