### PR TITLE
build(ui): raise control-ui startup baseline for landed sidebar work

### DIFF
--- a/config/control-ui-startup-budget-baseline.json
+++ b/config/control-ui-startup-budget-baseline.json
@@ -1,5 +1,5 @@
 {
-  "startupJsGzipBytes": 320262,
-  "reason": "sidebar session-section ordering pref",
+  "startupJsGzipBytes": 320696,
+  "reason": "sidebar group drag, archived-session composer, stylelint template adoption",
   "updatedAt": "2026-07-26"
 }


### PR DESCRIPTION
## What Problem This Solves

The Control UI startup JS budget check is failing on `main`, blocking unrelated PRs at the merge
gate. On PR #113979 — a branch containing **zero** `ui/` files — QA Smoke profiles reported startup
JS at 321300–321330 B against a 321286 B ceiling.

The ceiling is `startupJsGzipBytes` (320262) + a 1024 B tolerance. Seven Control UI commits landed
after the last baseline update without raising it:

- `3807591ff4a` stylelint adoption for Control UI css templates (#113971)
- `f90cef67c81` drag custom sidebar groups between built-in session zones (#113948)
- `98542bc55b1` inline stroke attributes via shared strokeIcon shell (#113952)
- `a328e900fd6` archived-session sidebar selection + archived composer notice (#113882)
- `c7fcfd34829` gate chat sidebar mutations (#113947)
- `25495ad0be8` focus scoped windows for notification clicks (#113951)
- `d1aec7d65f4` drop stale Create PR row after merge, PR chips mid-turn (#113944)

## Why This Change Was Made

A clean `origin/main` production build measures startup JS at **320696 B gzip** — genuinely 434 B
above the recorded 320262 B baseline. The growth is real and attributable to the landed work above,
so the baseline is stale rather than the code being wrong.

The new value comes from the repo's own sanctioned path, not a hand-edit:

    node scripts/check-control-ui-performance.mjs --update-baseline --reason "..."

Baseline moves 320262 -> 320696, so the ceiling becomes 321720 B. That clears the 321300–321330 B
range CI observes with roughly 400 B of headroom. The 434 B move is well inside the 4096 B
`STARTUP_JS_BASELINE_RATCHET_BYTES` guard, so the ratchet still constrains future growth.

Note the local build measures ~600 B lower than CI's Linux build of the same source, which is why
`main` looks green locally while CI sits just over the line. That gap is why the overage presented as
an unrelated-PR failure rather than an obvious `main` breakage — and why one of four QA profiles
passed while three failed.

## User Impact

None. This is a build guard threshold; no product code changes.

## Evidence

Local production build on clean `origin/main`:

    startup JS: 9 requests, 313.2 KiB gzip, 289.2 KiB br (limits: 18 requests, 317.0 KiB gzip)
    startup JS gzip vs baseline: 320696 B (baseline 320262 B + tolerance 1024 B, ceiling 324608 B)

`node scripts/ui.js build` exit 0; `node scripts/check-control-ui-performance.mjs` exit 0 after the
update. See PR checks for CI confirmation.
