### PR TITLE
fix(clickclack): resolve global discussion owner

### DIFF
--- a/extensions/clickclack/src/discussions/service-open.ts
+++ b/extensions/clickclack/src/discussions/service-open.ts
@@ -1,3 +1,4 @@
+import { resolveDefaultAgentId } from "openclaw/plugin-sdk/agent-runtime";
 import type { PluginRuntime } from "openclaw/plugin-sdk/core";
 import { resolveAgentIdFromSessionKey } from "openclaw/plugin-sdk/routing";
 import {
@@ -381,7 +382,10 @@ export async function openClickClackDiscussionBinding(
     }
     const nextBinding: ClickClackDiscussionBinding = {
       accountId: account.accountId,
-      agentId: resolveAgentIdFromSessionKey(sessionKey),
+      agentId: resolveAgentIdFromSessionKey(
+        sessionKey,
+        resolveDefaultAgentId(runtime.config.current()),
+      ),
       sessionId: entry.sessionId,
       serverBaseUrl,
       credentialFingerprint,

--- a/extensions/clickclack/src/discussions/service-open.ts
+++ b/extensions/clickclack/src/discussions/service-open.ts
@@ -6,7 +6,7 @@ import {
   isClickClackChannelNameConflict,
   type ClickClackClient,
 } from "../http-client.js";
-import type { ResolvedClickClackAccount } from "../types.js";
+import type { CoreConfig, ResolvedClickClackAccount } from "../types.js";
 import {
   clearDiscussionBindingGeneration,
   listPendingDiscussionOpens,
@@ -384,7 +384,7 @@ export async function openClickClackDiscussionBinding(
       accountId: account.accountId,
       agentId: resolveAgentIdFromSessionKey(
         sessionKey,
-        resolveDefaultAgentId(runtime.config.current()),
+        resolveDefaultAgentId(runtime.config.current() as CoreConfig),
       ),
       sessionId: entry.sessionId,
       serverBaseUrl,

--- a/extensions/clickclack/src/discussions/service.test.ts
+++ b/extensions/clickclack/src/discussions/service.test.ts
@@ -45,11 +45,19 @@ describe("ClickClack discussion service", () => {
     });
   });
 
-  it("pins an owning agent for an unqualified global session key", async () => {
-    const harness = createHarness({ label: "Global session" });
+  it("pins the configured default for global keys and preserves qualified owners", async () => {
+    const globalHarness = createHarness({ label: "Global session" });
+    globalHarness.config.agents = { list: [{ id: "ops", default: true }] };
 
-    expect(await harness.service.open("global")).toMatchObject({ state: "open" });
-    expect(harness.store.lookup("global")).toMatchObject({ agentId: "main" });
+    expect(await globalHarness.service.open("global")).toMatchObject({ state: "open" });
+    expect(globalHarness.store.lookup("global")).toMatchObject({ agentId: "ops" });
+
+    const qualifiedHarness = createHarness({ label: "Qualified session" });
+    qualifiedHarness.config.agents = { list: [{ id: "ops", default: true }] };
+    const qualifiedKey = "agent:worker:qualified";
+
+    expect(await qualifiedHarness.service.open(qualifiedKey)).toMatchObject({ state: "open" });
+    expect(qualifiedHarness.store.lookup(qualifiedKey)).toMatchObject({ agentId: "worker" });
   });
 
   it("builds control links from URL path and query components", async () => {


### PR DESCRIPTION
Related: #112678

## What Problem This Solves

Fixes an issue where users opening a ClickClack discussion for a global or legacy unqualified session key would hit an error after implicit default-agent resolution became strict.

## Why This Change Was Made

The ClickClack owner boundary now resolves the current configured default agent through the public agent-runtime SDK and passes it explicitly to the session-key resolver. Agent-qualified session keys keep their encoded owner unchanged.

## User Impact

Global ClickClack discussions can open and persist their real configured owning agent instead of failing or assuming a hard-coded agent id.

## Evidence

- Release failure: https://github.com/openclaw/openclaw/actions/runs/30185237231/job/89748636212
- `node scripts/run-vitest.mjs extensions/clickclack/src/discussions` passed 74 tests.
- Configured-owner behavior proof: the service-open path persists `ops` for the unqualified `global` key when `ops` is the configured default, while a separate `agent:worker:qualified` control persists `worker`. The focused terminal run passed 27/27 tests.
- `tsgo -b extensions/clickclack/tsconfig.json --pretty false`
- `git diff --check`
- Autoreview: clean, no accepted/actionable findings
