### PR TITLE
refactor(gateway): extract session-PR landing resolution and batch ancestry checks

### DIFF
--- a/src/gateway/control-ui-session-prs-landing.test.ts
+++ b/src/gateway/control-ui-session-prs-landing.test.ts
@@ -1,0 +1,114 @@
+import { execFile } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { resolveBranchLanding } from "./control-ui-session-prs-landing.js";
+
+const execFileAsync = promisify(execFile);
+
+describe("resolveBranchLanding", () => {
+  let root: string;
+
+  const git = (...args: string[]) =>
+    execFileAsync("git", ["-c", "user.email=test@openclaw.ai", "-c", "user.name=Test", ...args], {
+      cwd: root,
+    });
+  const sha = async (ref: string) => (await git("rev-parse", ref)).stdout.trim();
+
+  beforeEach(async () => {
+    root = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-prs-landing-")));
+    await git("init", "--initial-branch=main", ".");
+    await fs.writeFile(path.join(root, "a.txt"), "one\n");
+    await git("add", "a.txt");
+    await git("commit", "-m", "base");
+    await git("update-ref", "refs/remotes/origin/main", "HEAD");
+  });
+
+  afterEach(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  it("marks a squash-landed tip and bases stats on the merged head", async () => {
+    await git("checkout", "-b", "feature");
+    await fs.appendFile(path.join(root, "a.txt"), "two\n");
+    await git("add", "a.txt");
+    await git("commit", "-m", "feature work");
+    await git("update-ref", "refs/remotes/origin/feature", "HEAD");
+    const mergedHead = await sha("HEAD");
+
+    const landing = await resolveBranchLanding(root, {
+      branch: "feature",
+      defaultBranch: "main",
+      mergedHeads: [{ sha: mergedHead, baseRef: "main" }],
+    });
+
+    expect(landing).toEqual({
+      pushedSha: mergedHead,
+      statsBase: mergedHead,
+      hasLandedPullRequest: true,
+      provenNewPushedWork: false,
+    });
+  });
+
+  it("proves new pushed work once the merge base contains the landing", async () => {
+    await git("checkout", "-b", "feature");
+    await fs.appendFile(path.join(root, "a.txt"), "two\n");
+    await git("add", "a.txt");
+    await git("commit", "-m", "feature work");
+    const mergedHead = await sha("HEAD");
+    await git("checkout", "main");
+    await fs.appendFile(path.join(root, "a.txt"), "two\n");
+    await git("add", "a.txt");
+    await git("commit", "-m", "squash land");
+    const mergeCommit = await sha("HEAD");
+    await git("update-ref", "refs/remotes/origin/main", "HEAD");
+    await git("checkout", "feature");
+    await git("reset", "--hard", "refs/remotes/origin/main");
+    await fs.writeFile(path.join(root, "b.txt"), "second\n");
+    await git("add", "b.txt");
+    await git("commit", "-m", "second PR work");
+    await git("update-ref", "refs/remotes/origin/feature", "HEAD");
+
+    const landing = await resolveBranchLanding(root, {
+      branch: "feature",
+      defaultBranch: "main",
+      mergedHeads: [{ sha: mergedHead, baseRef: "main", mergeCommitSha: mergeCommit }],
+    });
+
+    expect(landing.provenNewPushedWork).toBe(true);
+    // The rebase incorporated the landing, so the merge base is the baseline.
+    expect(landing.statsBase).toBe(mergeCommit);
+  });
+
+  it("selects the newest of three related baselines via the batched path", async () => {
+    // Linear chain: fork point (merge base) -> merged head 1 -> merged head 2
+    // -> HEAD; the maximal published baseline is merged head 2.
+    await git("checkout", "-b", "feature");
+    await fs.appendFile(path.join(root, "a.txt"), "two\n");
+    await git("add", "a.txt");
+    await git("commit", "-m", "pr1 work");
+    const head1 = await sha("HEAD");
+    await fs.appendFile(path.join(root, "a.txt"), "three\n");
+    await git("add", "a.txt");
+    await git("commit", "-m", "pr2 work");
+    const head2 = await sha("HEAD");
+    await fs.writeFile(path.join(root, "c.txt"), "wip\n");
+    await git("add", "c.txt");
+    await git("commit", "-m", "follow-up");
+    await git("update-ref", "refs/remotes/origin/feature", "HEAD");
+
+    const landing = await resolveBranchLanding(root, {
+      branch: "feature",
+      defaultBranch: "main",
+      mergedHeads: [
+        { sha: head1, baseRef: "main" },
+        { sha: head2, baseRef: "main" },
+      ],
+    });
+
+    expect(landing.statsBase).toBe(head2);
+    expect(landing.hasLandedPullRequest).toBe(true);
+  });
+});

--- a/src/gateway/control-ui-session-prs-landing.ts
+++ b/src/gateway/control-ui-session-prs-landing.ts
@@ -8,7 +8,7 @@ import { runGit } from "../agents/worktrees/git.js";
 /** Lowercased merged-PR head, the base it merged into, and its merge commit. */
 export type MergedPullHead = { sha: string; baseRef?: string; mergeCommitSha?: string };
 
-export type BranchLanding = {
+type BranchLanding = {
   /** origin/<branch> tip when the remote-tracking ref resolves. */
   pushedSha: string | null;
   /** Newest known-published commit to diff the working tree against. */
@@ -48,11 +48,15 @@ async function isAncestor(root: string, ancestor: string, descendant: string): P
 async function maximalCommit(root: string, candidates: readonly string[]): Promise<string | null> {
   const unique = [...new Set(candidates)];
   const first = unique[0];
-  if (unique.length <= 1) {
-    return first ?? null;
+  if (first === undefined) {
+    return null;
   }
-  if (unique.length === 2) {
-    return (await isAncestor(root, first, unique[1])) ? unique[1] : first;
+  if (unique.length === 1) {
+    return first;
+  }
+  const second = unique[1];
+  if (unique.length === 2 && second !== undefined) {
+    return (await isAncestor(root, first, second)) ? second : first;
   }
   // Candidates are verified local objects, so a failed call is unexpected;
   // fall back to the merge base rather than guessing.

--- a/src/gateway/control-ui-session-prs-landing.ts
+++ b/src/gateway/control-ui-session-prs-landing.ts
@@ -1,0 +1,163 @@
+// Landing resolution for a session's working branch: which merged PRs count
+// as landed on the checkout's default branch, the newest known-published
+// baseline for working-tree stats, and whether new pushed work is provable
+// (the Create PR gate). Pure local-git reasoning; GitHub facts come in as
+// MergedPullHead records.
+import { runGit } from "../agents/worktrees/git.js";
+
+/** Lowercased merged-PR head, the base it merged into, and its merge commit. */
+export type MergedPullHead = { sha: string; baseRef?: string; mergeCommitSha?: string };
+
+export type BranchLanding = {
+  /** origin/<branch> tip when the remote-tracking ref resolves. */
+  pushedSha: string | null;
+  /** Newest known-published commit to diff the working tree against. */
+  statsBase: string | null;
+  /** At least one merged PR provably landed on the default branch. */
+  hasLandedPullRequest: boolean;
+  /** The merge base contains every known landing, so Create PR is safe. */
+  provenNewPushedWork: boolean;
+};
+
+export async function gitOutput(cwd: string, args: string[]): Promise<string | null> {
+  try {
+    const result = await runGit(cwd, args);
+    return result.code === 0 ? result.stdout.trim() || null : null;
+  } catch {
+    return null;
+  }
+}
+
+async function isAncestor(root: string, ancestor: string, descendant: string): Promise<boolean> {
+  try {
+    const result = await runGit(root, ["merge-base", "--is-ancestor", ancestor, descendant]);
+    return result.code === 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Picks the newest of the known-published baseline candidates. Two candidates
+ * (the dominant case) stay a single ancestry call; larger sets batch through
+ * one `merge-base --independent`. Among incomparable maxima, a candidate
+ * containing the first entry (the merge base) is preferred — any such pick is
+ * sound because it covers everything the merge base covers — and otherwise
+ * the earliest candidate wins, keeping the merge base as the safe default.
+ */
+async function maximalCommit(root: string, candidates: readonly string[]): Promise<string | null> {
+  const unique = [...new Set(candidates)];
+  const first = unique[0];
+  if (unique.length <= 1) {
+    return first ?? null;
+  }
+  if (unique.length === 2) {
+    return (await isAncestor(root, first, unique[1])) ? unique[1] : first;
+  }
+  // Candidates are verified local objects, so a failed call is unexpected;
+  // fall back to the merge base rather than guessing.
+  const out = await gitOutput(root, ["merge-base", "--independent", ...unique]);
+  if (!out) {
+    return first;
+  }
+  const independent = new Set(
+    out
+      .split("\n")
+      .map((line) => line.trim())
+      .filter(Boolean),
+  );
+  if (independent.has(first)) {
+    return first;
+  }
+  for (const candidate of unique.slice(1)) {
+    if (independent.has(candidate) && (await isAncestor(root, first, candidate))) {
+      return candidate;
+    }
+  }
+  return unique.find((candidate) => independent.has(candidate)) ?? first;
+}
+
+export async function resolveBranchLanding(
+  root: string,
+  params: {
+    branch: string;
+    defaultBranch?: string;
+    mergedHeads: readonly MergedPullHead[];
+  },
+): Promise<BranchLanding> {
+  const pushedSha = await gitOutput(root, [
+    "rev-parse",
+    "--verify",
+    "--quiet",
+    `refs/remotes/origin/${params.branch}`,
+  ]);
+  const headSha = await gitOutput(root, ["rev-parse", "HEAD"]);
+  // Only merges whose content reached this checkout's default branch prove
+  // the tip landed there: a direct default-base merge, or a landing through
+  // another branch (feature -> release -> main) whose merge commit is now
+  // contained in the default branch. A PR merged into an unpropagated
+  // release/staging branch must not hide Create PR. Filtered here, not in
+  // the snapshot cache, because the cache key has no default branch.
+  const defaultRef = params.defaultBranch ? `refs/remotes/origin/${params.defaultBranch}` : null;
+  const landedHeads: MergedPullHead[] = [];
+  for (const head of params.mergedHeads) {
+    if (head.baseRef === params.defaultBranch) {
+      landedHeads.push(head);
+    } else if (
+      defaultRef &&
+      head.mergeCommitSha &&
+      (await isAncestor(root, head.mergeCommitSha, defaultRef))
+    ) {
+      landedHeads.push(head);
+    }
+  }
+  const landedShas = landedHeads.map((head) => head.sha);
+  const mergeBase = defaultRef ? await gitOutput(root, ["merge-base", defaultRef, "HEAD"]) : null;
+  // The stats base is the newest commit whose content is known-published:
+  // the ordinary default-branch merge base, or a merged PR head related to
+  // HEAD by ancestry (a HEAD trailing the merged tip is fully landed, so
+  // HEAD itself is the baseline). Diffing against anything older would
+  // replay landed work as pending — squash-merged commits are never
+  // ancestors of the default branch, so the merge base alone cannot see
+  // them. Ancestry is best-effort: a merged head never fetched locally
+  // cannot be proven related and falls back to the merge base.
+  const baselines: string[] = mergeBase ? [mergeBase] : [];
+  if (headSha) {
+    for (const merged of landedShas) {
+      if (await isAncestor(root, merged, headSha)) {
+        baselines.push(merged);
+      } else if (await isAncestor(root, headSha, merged)) {
+        baselines.push(headSha);
+      }
+    }
+  }
+  const statsBase = await maximalCommit(root, baselines);
+  // Squash merges leave origin/<branch> "ahead" of the default branch
+  // forever, so local git alone would keep offering Create PR after the work
+  // landed. Once merged PRs exist, the link returns only when the merge base
+  // provably contains EVERY known landing — a squash landing is visible via
+  // its merge commit (checked first: the common case), a merge-commit landing
+  // via the head itself, and an older landing must not vouch for a newer one
+  // whose diff a new PR would replay. A tip merely descending from a squashed
+  // head or a fetch-stale tracking ref proves nothing, so those states keep
+  // the row stats-only until a rebase or fetch.
+  let provenNewPushedWork = false;
+  if (pushedSha && mergeBase && !landedShas.includes(pushedSha.toLowerCase())) {
+    provenNewPushedWork = landedHeads.length > 0;
+    for (const head of landedHeads) {
+      const incorporated =
+        (head.mergeCommitSha ? await isAncestor(root, head.mergeCommitSha, mergeBase) : false) ||
+        (await isAncestor(root, head.sha, mergeBase));
+      if (!incorporated) {
+        provenNewPushedWork = false;
+        break;
+      }
+    }
+  }
+  return {
+    pushedSha,
+    statsBase,
+    hasLandedPullRequest: landedHeads.length > 0,
+    provenNewPushedWork,
+  };
+}

--- a/src/gateway/control-ui-session-prs.ts
+++ b/src/gateway/control-ui-session-prs.ts
@@ -65,9 +65,6 @@ type PullListItem = {
   mergeCommitSha?: string;
 };
 
-/** Lowercased merged-PR head, the base it merged into, and its merge commit. */
-type MergedPullHead = { sha: string; baseRef?: string; mergeCommitSha?: string };
-
 /**
  * Cached GitHub snapshot plus the merged PRs' heads. The heads stay
  * gateway-internal (stripped before responding): they only exist so branch

--- a/src/gateway/control-ui-session-prs.ts
+++ b/src/gateway/control-ui-session-prs.ts
@@ -20,6 +20,11 @@ import {
   optionalNumber,
   optionalString,
 } from "./control-ui-github-api.js";
+import {
+  gitOutput,
+  resolveBranchLanding,
+  type MergedPullHead,
+} from "./control-ui-session-prs-landing.js";
 import { parseGitHubRemoteUrl } from "./github-remote.js";
 import { loadSessionEntryReadOnly } from "./session-utils.js";
 
@@ -101,24 +106,6 @@ export function parseControlUiSessionPullRequestsParams(
     ...(agentId ? { agentId } : {}),
     ...(value.refresh === true ? { refresh: true } : {}),
   };
-}
-
-async function gitOutput(cwd: string, args: string[]): Promise<string | null> {
-  try {
-    const result = await runGit(cwd, args);
-    return result.code === 0 ? result.stdout.trim() || null : null;
-  } catch {
-    return null;
-  }
-}
-
-async function isAncestor(root: string, ancestor: string, descendant: string): Promise<boolean> {
-  try {
-    const result = await runGit(root, ["merge-base", "--is-ancestor", ancestor, descendant]);
-    return result.code === 0;
-  } catch {
-    return false;
-  }
 }
 
 /**
@@ -309,86 +296,15 @@ async function resolveSessionBranch(
       createUrl: branchCreateUrl(context),
     };
   }
-  const pushedSha = await gitOutput(root, [
-    "rev-parse",
-    "--verify",
-    "--quiet",
-    `refs/remotes/origin/${context.branch}`,
-  ]);
-  const headSha = await gitOutput(root, ["rev-parse", "HEAD"]);
-  // Only merges whose content reached this checkout's default branch prove
-  // the tip landed there: a direct default-base merge, or a landing through
-  // another branch (feature -> release -> main) whose merge commit is now
-  // contained in the default branch. A PR merged into an unpropagated
-  // release/staging branch must not hide Create PR. Filtered here, not in
-  // the cache, because the cache key has no default branch.
-  const defaultRef = context.defaultBranch ? `refs/remotes/origin/${context.defaultBranch}` : null;
-  const landedHeads: MergedPullHead[] = [];
-  for (const head of mergedHeads) {
-    if (head.baseRef === context.defaultBranch) {
-      landedHeads.push(head);
-    } else if (
-      defaultRef &&
-      head.mergeCommitSha &&
-      (await isAncestor(root, head.mergeCommitSha, defaultRef))
-    ) {
-      landedHeads.push(head);
-    }
-  }
-  const mergedHeadShas = landedHeads.map((head) => head.sha);
-  const mergeBase = context.defaultBranch
-    ? await gitOutput(root, ["merge-base", `refs/remotes/origin/${context.defaultBranch}`, "HEAD"])
-    : null;
-  // The stats base is the newest commit whose content is known-published:
-  // the ordinary default-branch merge base, or a merged PR head related to
-  // HEAD by ancestry (a HEAD trailing the merged tip is fully landed, so
-  // HEAD itself is the baseline). Diffing against anything older would
-  // replay landed work as pending — the squash-merged commits are never
-  // ancestors of the default branch, so the merge base alone cannot see
-  // them. Ancestry is best-effort: a merged head never fetched locally
-  // cannot be proven related and falls back to the merge base.
-  const baselines: string[] = mergeBase ? [mergeBase] : [];
-  if (headSha) {
-    for (const merged of mergedHeadShas) {
-      if (await isAncestor(root, merged, headSha)) {
-        baselines.push(merged);
-      } else if (await isAncestor(root, headSha, merged)) {
-        baselines.push(headSha);
-      }
-    }
-  }
-  let statsBase: string | null = null;
-  for (const candidate of baselines) {
-    if (!statsBase || (await isAncestor(root, statsBase, candidate))) {
-      statsBase = candidate;
-    }
-  }
-  // Squash merges leave origin/<branch> "ahead" of the default branch
-  // forever, so local git alone would keep offering Create PR after the work
-  // landed. Once merged PRs exist, the link returns only when the merge base
-  // provably contains EVERY known landing — a merge-commit landing leaves the
-  // head itself as an ancestor, a squash landing is visible only via its
-  // merge commit, and an older landing must not vouch for a newer one whose
-  // diff a new PR would replay. A tip merely descending from a squashed head
-  // or a fetch-stale tracking ref proves nothing, so those states keep the
-  // row stats-only until a rebase or fetch.
-  let provenNewPushedWork = false;
-  if (pushedSha && mergeBase && !mergedHeadShas.includes(pushedSha.toLowerCase())) {
-    provenNewPushedWork = landedHeads.length > 0;
-    for (const head of landedHeads) {
-      const incorporated =
-        (await isAncestor(root, head.sha, mergeBase)) ||
-        (head.mergeCommitSha ? await isAncestor(root, head.mergeCommitSha, mergeBase) : false);
-      if (!incorporated) {
-        provenNewPushedWork = false;
-        break;
-      }
-    }
-  }
+  const landing = await resolveBranchLanding(root, {
+    branch: context.branch,
+    defaultBranch: context.defaultBranch,
+    mergedHeads,
+  });
   const creatable =
-    (mergedHeadShas.length === 0 || provenNewPushedWork) &&
-    (await branchHasCreatablePullRequest(root, context, pushedSha));
-  const stats = statsBase ? await diffStatsAgainst(root, statsBase) : null;
+    (!landing.hasLandedPullRequest || landing.provenNewPushedWork) &&
+    (await branchHasCreatablePullRequest(root, context, landing.pushedSha));
+  const stats = landing.statsBase ? await diffStatsAgainst(root, landing.statsBase) : null;
   // No createUrl until GitHub can compare, but local changes still get a row.
   if (!creatable && !(stats && stats.changedFiles > 0)) {
     return undefined;


### PR DESCRIPTION
## What Problem This Solves

Follow-up to #113944. The merged-PR landing logic lived inline in `resolveSessionBranch`, making `control-ui-session-prs.ts` the densest ~100 lines of the file (779 lines total, brushing the split guideline), and the ancestry reasoning spawned one `git merge-base --is-ancestor` process per comparison on every 60-second chat poll.

## Why This Change Was Made

- **Extract** the landing resolution (which merged PRs count as landed on the default branch, the newest known-published stats baseline, the proven-new-pushed-work gate) into `src/gateway/control-ui-session-prs-landing.ts` with a closed `BranchLanding` result shape. `resolveSessionBranch` shrinks to stub-path + landing + creatable + stats + row shaping; the parent file drops ~84 lines and the graph logic gets direct unit tests instead of only end-to-end fixtures.
- **Batch** the maximal-baseline selection: two candidates (the dominant case) stay a single `--is-ancestor` call, three or more collapse into one `git merge-base --independent` instead of a pairwise scan. Among incomparable maxima the pick prefers a candidate containing the merge base (any such pick is sound) and otherwise keeps the merge base as the safe default. The proven-work witness order also flips to check `merge_commit_sha` first, saving one git spawn per squash landing (the common case).

Behavior-neutral by design; all 36 existing end-to-end git-fixture tests pass unchanged.

## User Impact

None visible — same chips, same Create PR gating. Slightly fewer git subprocesses per session-PR poll.

## Evidence

- `node scripts/run-vitest.mjs src/gateway/control-ui-session-prs-landing.test.ts src/gateway/control-ui-session-prs-branch.test.ts src/gateway/control-ui-session-prs.test.ts` → 39 passed (36 pre-existing behavior fixtures unchanged + 3 new direct unit tests: squash-landed tip, proven-new-work after rebase, three-baseline batched maximal selection).
- Codex autoreview (gpt-5.6-sol, xhigh): clean, "patch is correct (0.9), extraction preserves existing landing/creatability/stats-baseline behavior".
- `git diff --numstat`: `control-ui-session-prs.ts` −84 net; the new module owns what it deletes.
- **Real behavior proof (after-refactor, live GitHub + real checkout):** reran the same live run used to prove #113944 — `loadControlUiSessionPullRequests` (now routed through the extracted landing module) against a real checkout of merged PR #113840's branch `fix/sidebar-group-spacing` with the real GitHub API:

  ```json
  {
    "pullRequests": [
      {
        "number": 113840,
        "owner": "openclaw",
        "repo": "openclaw",
        "branch": "fix/sidebar-group-spacing",
        "title": "fix(ui): add spacing between coding session groups",
        "url": "https://github.com/openclaw/openclaw/pull/113840",
        "state": "merged"
      }
    ],
    "rateLimited": false
  }
  ```

  Byte-identical to the pre-refactor run: merged chip present, no `branch` payload (no Create PR row) — behavior-neutral in the real scenario, not just fixtures.
