### PR TITLE
fix(agents): let harness-owned compaction proceed without ambient auth

### DIFF
--- a/src/agents/harness/compaction.ts
+++ b/src/agents/harness/compaction.ts
@@ -2,6 +2,7 @@ import type { Model } from "openclaw/plugin-sdk/llm";
 /**
  * Routes compaction through selected native agent harnesses when supported.
  */
+import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { parseAgentSessionKey } from "../../routing/session-key.js";
 import { resolveUserPath } from "../../utils.js";
 import { isDefaultAgentRuntimeId, normalizeOptionalAgentRuntimeId } from "../agent-runtime-id.js";
@@ -70,6 +71,8 @@ type InternalAgentHarnessCompactionCapability = {
 
 type InternalAgentHarness = AgentHarness & InternalAgentHarnessCompactionCapability;
 type HarnessCompactionResolvedAuth = { apiKey?: string };
+
+const log = createSubsystemLogger("agents/harness-compaction");
 
 function runtimePlanRequiresHostApiKey(plan?: AgentRuntimeAuthPlan): boolean {
   return plan?.modelRoute?.authRequirement === "api-key";
@@ -153,12 +156,14 @@ async function resolveHarnessCompactApiKey(params: {
     runtimeModel?: Model,
     runtimeAuthPlan?: AgentRuntimeAuthPlan,
   ) => {
-    if (harness.authBootstrap === "harness" && !runtimeAuthPlan) {
+    const apiKey = compactParams.resolvedApiKey?.trim() || undefined;
+    if (harness.authBootstrap === "harness" && !runtimeAuthPlan && apiKey) {
+      // Ambient keys need a verified route before crossing into harness-owned auth.
+      // With no key, the harness can safely use its own native auth store.
       throw new Error(
         `Unable to prepare a route-locked native compaction attempt for ${provider}/${modelId}; refusing harness-owned ambient auth.`,
       );
     }
-    const apiKey = compactParams.resolvedApiKey?.trim() || undefined;
     return {
       harness,
       ...(apiKey ? { apiKey } : {}),
@@ -221,7 +226,10 @@ async function resolveHarnessCompactApiKey(params: {
           workspaceDir,
         })
       ).model;
-    } catch {
+    } catch (error) {
+      log.warn(
+        `native compaction model resolution failed for ${provider}/${modelId}: ${error instanceof Error ? error.message : String(error)}`,
+      );
       return fallbackResolution(initialHarness);
     }
   }
@@ -262,7 +270,10 @@ async function resolveHarnessCompactApiKey(params: {
   } else {
     try {
       preparation = prepareRuntimeAuth(initialHarness);
-    } catch {
+    } catch (error) {
+      log.warn(
+        `native compaction auth preparation failed for ${provider}/${modelId}: ${error instanceof Error ? error.message : String(error)}`,
+      );
       return fallbackResolution(initialHarness, model);
     }
   }
@@ -272,7 +283,10 @@ async function resolveHarnessCompactApiKey(params: {
   if (!params.pinnedHarnessId && !reusableRuntimeAuthPlan && harness.id !== initialHarness.id) {
     try {
       preparation = prepareRuntimeAuth(harness);
-    } catch {
+    } catch (error) {
+      log.warn(
+        `native compaction auth preparation failed for ${provider}/${modelId}: ${error instanceof Error ? error.message : String(error)}`,
+      );
       return fallbackResolution(harness, model);
     }
     const confirmedHarness = selectPreparedHarness(preparation.attempts, model);
@@ -346,7 +360,10 @@ async function resolveHarnessCompactApiKey(params: {
       },
       errorMessage: `Prepared native compaction auth attempts could not be resolved for ${provider}/${modelId}.`,
     });
-  } catch {
+  } catch (error) {
+    log.warn(
+      `native compaction prepared auth resolution failed for ${provider}/${modelId}: ${error instanceof Error ? error.message : String(error)}`,
+    );
     return fallbackResolution(harness, model, preparation.plan);
   }
   return {
@@ -493,7 +510,8 @@ export async function maybeCompactAgentHarnessSession(
   const harnessOwnsAuth =
     harness.authBootstrap === "harness" && !runtimePlanRequiresHostApiKey(resolvedRuntimeAuthPlan);
   const resolvedApiKey = harnessOwnsAuth ? undefined : resolved.apiKey;
-  const runtimeModel = resolved.runtimeModel;
+  const runtimeModel =
+    harnessOwnsAuth && !resolvedRuntimeAuthPlan ? undefined : resolved.runtimeModel;
   const compactParamsWithResolvedAuth = resolvedRuntimeAuthPlan
     ? {
         ...compactParams,

--- a/src/agents/harness/selection.test.ts
+++ b/src/agents/harness/selection.test.ts
@@ -44,6 +44,7 @@ const compactAuthMocks = vi.hoisted(() => ({
   ensureAuthProfileStore: vi.fn(),
   ensureAuthProfileStoreWithoutExternalProfiles: vi.fn(),
   getApiKeyForModel: vi.fn(),
+  prepareAgentRuntimeAuth: vi.fn(),
   resolveModelAsync: vi.fn(),
 }));
 const providerOwnerMocks = vi.hoisted(() => ({
@@ -81,6 +82,14 @@ vi.mock("../model-auth.js", async (importOriginal) => ({
 vi.mock("../embedded-agent-runner/model.js", () => ({
   resolveModelAsync: compactAuthMocks.resolveModelAsync,
 }));
+vi.mock("../runtime-plan/prepare-auth.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../runtime-plan/prepare-auth.js")>();
+  compactAuthMocks.prepareAgentRuntimeAuth.mockImplementation(actual.prepareAgentRuntimeAuth);
+  return {
+    ...actual,
+    prepareAgentRuntimeAuth: compactAuthMocks.prepareAgentRuntimeAuth,
+  };
+});
 vi.mock("../../plugins/providers.js", () => ({
   resolveProviderRefOwnership: providerOwnerMocks.resolveProviderRefOwnership,
 }));
@@ -129,6 +138,7 @@ afterEach(() => {
   clearAgentHarnesses();
   cliBackendsTesting.resetDepsForTest();
   agentRunAttempt.mockClear();
+  compactAuthMocks.prepareAgentRuntimeAuth.mockClear();
   compactAuthMocks.resolveModelAsync.mockReset();
   compactAuthMocks.getApiKeyForModel.mockReset();
   compactAuthMocks.ensureAuthProfileStore.mockReset();
@@ -2500,6 +2510,45 @@ describe("selectAgentHarness", () => {
       ),
     ).rejects.toThrow("refusing harness-owned ambient auth");
     expect(compact).not.toHaveBeenCalled();
+  });
+
+  it("lets harness-owned compaction proceed without ambient auth when model lookup fails", async () => {
+    compactAuthMocks.resolveModelAsync.mockRejectedValue(new Error("model lookup unavailable"));
+    const result = { ok: true, compacted: false, reason: "harness result" } as const;
+    const compact = registerTestCompactor({ authBootstrap: "harness", result });
+
+    await expect(
+      maybeCompactAgentHarnessSession(createCompactionParams({ agentHarnessId: "codex" })),
+    ).resolves.toEqual(result);
+    expect(compact).toHaveBeenCalledTimes(1);
+    expect(compact.mock.calls[0]?.[0]).not.toHaveProperty("resolvedApiKey");
+    expect(compact.mock.calls[0]?.[0]).not.toHaveProperty("runtimeModel");
+  });
+
+  it("lets harness-owned compaction proceed without ambient auth when auth preparation fails", async () => {
+    // Model resolution must succeed so this test exercises the auth-preparation
+    // catch, not the model-resolution fallback covered above.
+    compactAuthMocks.resolveModelAsync.mockResolvedValue({
+      model: {
+        id: "proxy-model",
+        provider: "local-proxy",
+        api: "openai-responses",
+        baseUrl: "https://proxy.example/v1",
+      },
+    });
+    compactAuthMocks.prepareAgentRuntimeAuth.mockImplementationOnce(() => {
+      throw new Error("auth preparation unavailable");
+    });
+    const result = { ok: true, compacted: false, reason: "harness result" } as const;
+    const compact = registerTestCompactor({ authBootstrap: "harness", result });
+
+    await expect(
+      maybeCompactAgentHarnessSession(createCompactionParams({ agentHarnessId: "codex" })),
+    ).resolves.toEqual(result);
+    expect(compactAuthMocks.prepareAgentRuntimeAuth).toHaveBeenCalled();
+    expect(compact).toHaveBeenCalledTimes(1);
+    expect(compact.mock.calls[0]?.[0]).not.toHaveProperty("resolvedApiKey");
+    expect(compact.mock.calls[0]?.[0]).not.toHaveProperty("runtimeModel");
   });
 
   it("passes runtime model and default credentials to compaction when auth profile id is absent", async () => {


### PR DESCRIPTION
## What Problem This Solves

On team.openclaw.ai, codex app-server sessions (openai/gpt-5.6-sol, codex `auth.json` in API-key mode, no host-side auth profiles) failed whole runs during post-turn CLI compaction with:

`CLI native harness compaction failed for openai/gpt-5.6-sol: Unable to prepare a route-locked native compaction attempt for openai/gpt-5.6-sol; refusing harness-owned ambient auth.`

The turn itself succeeded; the run then died in `runCliTurnCompactionLifecycle` because host-side auth preparation for the native compaction attempt failed and the guard in `resolveHarnessCompactApiKey` fails closed for harness-owned runtimes — even when there is no ambient credential the guard could be protecting.

## Why This Change Was Made

The fail-closed guard exists so an ambient `resolvedApiKey` never crosses into a harness-owned runtime on an unverified route. But when `resolvedApiKey` is absent there is nothing to protect: the codex app-server authenticates itself from `$CODEX_HOME/auth.json` (verified in the codex source: `codex-rs/login/src/auth/storage.rs` `get_auth_file` → `auth.json`; `AuthMode::ApiKey` in `login/src/auth/manager.rs`). The guard now throws only when an ambient key is actually present; otherwise the flow proceeds harness-owned with auth inputs (and the unverified `runtimeModel`) stripped before the handoff. For non-manual triggers the codex plugin then returns its intentional "codex app-server owns automatic compaction" skip, which cli-compaction converts into the context-engine fallback — the run continues instead of failing.

Separately, every catch in `resolveHarnessCompactApiKey` silently swallowed the underlying error, which made the production failure undiagnosable from logs. Each fallthrough now logs one warn with provider/model and the inner error (never key material).

## User Impact

Codex app-server sessions running on API-key auth no longer fail runs when context compaction triggers and host-side route/auth preparation cannot be built. Failures in this path are now visible in gateway logs with their root cause.

## Evidence

- New regression tests in `src/agents/harness/selection.test.ts`: harness-owned compaction proceeds without `resolvedApiKey`/`runtimeModel` when (a) model resolution fails, (b) auth preparation throws (asserted to exercise the prepare path); the shipped fail-closed test with an ambient key present stays green.
- `node scripts/run-vitest.mjs src/agents/harness/selection.test.ts src/agents/command/cli-compaction.test.ts`: 124 passed; after the test-fidelity tightening, selection.test.ts re-run: 103 passed.
- Codex contract verified in sibling checkout: `codex-rs/login/src/auth/storage.rs:150-151,191-199` (auth.json is the app-server's own credential source), `codex-rs/login/src/auth/manager.rs:258-263` (ApiKey mode). OpenClaw-side flow: `extensions/codex/harness.ts:77,197-203` (harness-owned auth + compact hook), `extensions/codex/src/app-server/compact.ts:475-500` (auto-compaction skip), `src/agents/command/cli-compaction.ts` (skip → context-engine fallback).
- Codex autoreview (gpt-5.6-sol, xhigh): clean — "patch is correct".
- Diagnosed live on the team box: gateway log showed the exact error at 11:18/19:19/21:17/21:22 UTC on 2026-07-25 for agent roboclaw dashboard sessions.
