### PR TITLE
perf(gateway): stop sessions.list materializing the store per row

### DIFF
--- a/src/gateway/server-methods/sessions-read.ts
+++ b/src/gateway/server-methods/sessions-read.ts
@@ -51,6 +51,7 @@ import {
   readRecentSessionMessagesWithStatsAsync,
   readSessionPreviewItemsFromTranscript,
 } from "../session-transcript-readers.js";
+import type { GatewaySessionStoreCache } from "../session-utils-store-lookup.js";
 import {
   buildGatewaySessionRow,
   listSessionsFromStoreAsync,
@@ -277,10 +278,14 @@ export const sessionReadHandlers: GatewayRequestHandlers = {
             },
           },
         );
+        // One cache for the whole listing: sharing resolution otherwise
+        // materialized every entry of a candidate store once per row.
+        const sharingStoreCache: GatewaySessionStoreCache = new Map();
         const sharingTargets = result.sessions.map((session) =>
           resolveSessionSharingTarget({
             cfg,
             sessionKey: session.key,
+            storeCache: sharingStoreCache,
             ...(session.key === "global" && p.agentId ? { agentId: p.agentId } : {}),
           }),
         );

--- a/src/gateway/server.sessions.list-store-materialization.test.ts
+++ b/src/gateway/server.sessions.list-store-materialization.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Sharing resolution runs per row, and each call materialized a whole session
+ * store. That made `sessions.list` quadratic in entries even after connection
+ * reuse removed the per-row SQLite opens.
+ */
+import { expect, test, vi } from "vitest";
+import * as sessionAccessor from "../config/sessions/session-accessor.js";
+import { writeSessionStore } from "./test-helpers.js";
+import {
+  directSessionReq,
+  sessionStoreEntry,
+  setupGatewaySessionsTestHarness,
+} from "./test/server-sessions.test-helpers.js";
+
+const { createSessionStoreDir } = setupGatewaySessionsTestHarness();
+
+const LIST_PARAMS = {
+  agentId: "main",
+  configuredAgentsOnly: true,
+  includeDerivedTitles: true,
+  includeGlobal: true,
+  includeUnknown: true,
+  limit: 100,
+};
+
+async function countMaterializedEntriesForRows(rows: number): Promise<number> {
+  await createSessionStoreDir();
+  const entries: Record<string, ReturnType<typeof sessionStoreEntry>> = {
+    main: sessionStoreEntry("sess-main"),
+  };
+  for (let index = 0; index < rows; index++) {
+    entries[`agent:main:row-${index}`] = sessionStoreEntry(`sess-row-${index}`, {
+      updatedAt: 1_781_000_000_000 - index * 1_000,
+    });
+  }
+  await writeSessionStore({ entries });
+  // Warm lazily-initialized module state so only steady-state reads are counted.
+  await directSessionReq("sessions.list", LIST_PARAMS);
+
+  let materialized = 0;
+  const spies = (["listSessionEntries", "listSessionEntriesReadOnly"] as const).map((name) => {
+    const original = sessionAccessor[name];
+    return vi.spyOn(sessionAccessor, name).mockImplementation(((...args: never[]) => {
+      const result = (original as (...inner: never[]) => unknown[])(...args);
+      materialized += Array.isArray(result) ? result.length : 0;
+      return result;
+    }) as never);
+  });
+  try {
+    const result = await directSessionReq("sessions.list", LIST_PARAMS);
+    expect(result.ok).toBe(true);
+    return materialized;
+  } finally {
+    for (const spy of spies) {
+      spy.mockRestore();
+    }
+  }
+}
+
+test("sessions.list does not materialize the store once per row", async () => {
+  const small = await countMaterializedEntriesForRows(5);
+  const large = await countMaterializedEntriesForRows(40);
+
+  // Per-row store loads make this quadratic: 40 rows would materialize roughly
+  // 64x the entries of 5 rows. Linear growth stays far below that.
+  expect(large).toBeLessThan(small * 12);
+});

--- a/src/gateway/server.sessions.list-store-materialization.test.ts
+++ b/src/gateway/server.sessions.list-store-materialization.test.ts
@@ -1,7 +1,7 @@
 /**
  * Sharing resolution runs per row, and each call materialized a whole session
- * store. That made `sessions.list` quadratic in entries even after connection
- * reuse removed the per-row SQLite opens.
+ * lookup store. That made `sessions.list` quadratic in entries even after
+ * connection reuse removed the per-row SQLite opens.
  */
 import { expect, test, vi } from "vitest";
 import * as sessionAccessor from "../config/sessions/session-accessor.js";
@@ -38,14 +38,17 @@ async function countMaterializedEntriesForRows(rows: number): Promise<number> {
   await directSessionReq("sessions.list", LIST_PARAMS);
 
   let materialized = 0;
-  const spies = (["listSessionEntries", "listSessionEntriesReadOnly"] as const).map((name) => {
-    const original = sessionAccessor[name];
-    return vi.spyOn(sessionAccessor, name).mockImplementation(((...args: never[]) => {
+  // Only the lookup-store path used by sharing resolution goes through
+  // `listSessionEntries`; the listing itself and ACP metadata use the read-only
+  // variant, so this isolates the per-row store loads under test.
+  const original = sessionAccessor.listSessionEntries;
+  const spies = [
+    vi.spyOn(sessionAccessor, "listSessionEntries").mockImplementation(((...args: never[]) => {
       const result = (original as (...inner: never[]) => unknown[])(...args);
       materialized += Array.isArray(result) ? result.length : 0;
       return result;
-    }) as never);
-  });
+    }) as never),
+  ];
   try {
     const result = await directSessionReq("sessions.list", LIST_PARAMS);
     expect(result.ok).toBe(true);
@@ -57,11 +60,11 @@ async function countMaterializedEntriesForRows(rows: number): Promise<number> {
   }
 }
 
-test("sessions.list does not materialize the store once per row", async () => {
+test("sessions.list does not materialize the lookup store once per row", async () => {
   const small = await countMaterializedEntriesForRows(5);
   const large = await countMaterializedEntriesForRows(40);
 
-  // Per-row store loads make this quadratic: 40 rows would materialize roughly
-  // 64x the entries of 5 rows. Linear growth stays far below that.
+  // A load per row makes this quadratic: 40 rows would materialize roughly 64x
+  // the entries of 5 rows. One cached load per request stays far below that.
   expect(large).toBeLessThan(small * 12);
 });

--- a/src/gateway/session-sharing.ts
+++ b/src/gateway/session-sharing.ts
@@ -29,6 +29,7 @@ import {
 } from "./session-sharing-snapshot-cache.js";
 import {
   resolveFreshestSessionStoreMatchFromStoreKeys,
+  type GatewaySessionStoreCache,
   resolveGatewaySessionStoreTargetWithStore,
 } from "./session-utils.js";
 
@@ -100,11 +101,13 @@ export function resolveSessionSharingTarget(params: {
   cfg: OpenClawConfig;
   sessionKey: string;
   agentId?: string;
+  storeCache?: GatewaySessionStoreCache;
 }): SessionSharingTarget | null {
   const target = resolveGatewaySessionStoreTargetWithStore({
     cfg: params.cfg,
     key: params.sessionKey,
     agentId: params.agentId,
+    ...(params.storeCache ? { storeCache: params.storeCache } : {}),
   });
   const match = resolveFreshestSessionStoreMatchFromStoreKeys(target.store, target.storeKeys);
   return match

--- a/src/gateway/session-sharing.ts
+++ b/src/gateway/session-sharing.ts
@@ -27,9 +27,9 @@ import {
   loadCachedSessionSharingSnapshot,
   type SessionSharingSnapshot,
 } from "./session-sharing-snapshot-cache.js";
+import type { GatewaySessionStoreCache } from "./session-utils-store-lookup.js";
 import {
   resolveFreshestSessionStoreMatchFromStoreKeys,
-  type GatewaySessionStoreCache,
   resolveGatewaySessionStoreTargetWithStore,
 } from "./session-utils.js";
 

--- a/src/gateway/session-utils-model.ts
+++ b/src/gateway/session-utils-model.ts
@@ -3,7 +3,7 @@ import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
-import { readAcpSessionMeta } from "../acp/runtime/session-meta.js";
+import { readAcpSessionMeta, readAcpSessionMetaForEntry } from "../acp/runtime/session-meta.js";
 import { resolveModelAgentRuntimeMetadata } from "../agents/agent-runtime-metadata.js";
 import { resolveAgentConfig, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { lookupContextTokens } from "../agents/context.js";
@@ -169,7 +169,12 @@ type GatewaySessionThinkingProjectionParams = {
 export function resolveGatewaySessionThinkingProjectionInternal(
   params: GatewaySessionThinkingProjectionParams,
 ) {
-  const acpMeta = readAcpSessionMeta({ sessionKey: params.sessionKey });
+  // Row builders already resolved this session's entry, and re-reading the store
+  // here materialized every entry once per listed row. Callers without an entry
+  // keep the store-resolving read, which also normalizes aliased keys.
+  const acpMeta = params.entry
+    ? readAcpSessionMetaForEntry({ sessionKey: params.sessionKey, entry: params.entry })
+    : readAcpSessionMeta({ sessionKey: params.sessionKey });
   const configuredAgentRuntime = resolveModelAgentRuntimeMetadata({
     cfg: params.cfg,
     agentId: params.agentId,

--- a/src/gateway/session-utils-model.ts
+++ b/src/gateway/session-utils-model.ts
@@ -3,7 +3,7 @@ import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
-import { readAcpSessionMeta, readAcpSessionMetaForEntry } from "../acp/runtime/session-meta.js";
+import { readAcpSessionMeta } from "../acp/runtime/session-meta.js";
 import { resolveModelAgentRuntimeMetadata } from "../agents/agent-runtime-metadata.js";
 import { resolveAgentConfig, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { lookupContextTokens } from "../agents/context.js";
@@ -169,12 +169,7 @@ type GatewaySessionThinkingProjectionParams = {
 export function resolveGatewaySessionThinkingProjectionInternal(
   params: GatewaySessionThinkingProjectionParams,
 ) {
-  // Row builders already resolved this session's entry, and re-reading the store
-  // here materialized every entry once per listed row. Callers without an entry
-  // keep the store-resolving read, which also normalizes aliased keys.
-  const acpMeta = params.entry
-    ? readAcpSessionMetaForEntry({ sessionKey: params.sessionKey, entry: params.entry })
-    : readAcpSessionMeta({ sessionKey: params.sessionKey });
+  const acpMeta = readAcpSessionMeta({ sessionKey: params.sessionKey });
   const configuredAgentRuntime = resolveModelAgentRuntimeMetadata({
     cfg: params.cfg,
     agentId: params.agentId,

--- a/src/gateway/session-utils-store-lookup.ts
+++ b/src/gateway/session-utils-store-lookup.ts
@@ -96,7 +96,40 @@ function resolveGatewaySessionStoreCandidates(
   };
 }
 
+/**
+ * Request-scoped store reuse.
+ *
+ * Sharing resolution runs once per listed row, and each run materialized every
+ * entry of a candidate store, making `sessions.list` quadratic in entries. A
+ * caller that resolves many keys against the same stores passes one cache so
+ * each store is materialized once. Entries are shared across rows within that
+ * request, so cached stores are read-only to their holder; the cache is never
+ * process-global, so it cannot serve a later request stale rows.
+ */
+export type GatewaySessionStoreCache = Map<string, Record<string, SessionEntry>>;
+
 function loadGatewaySessionLookupStore(
+  storePath: string,
+  clone: boolean | undefined,
+  agentId?: string,
+  options: { readOnly?: boolean; cache?: GatewaySessionStoreCache } = {},
+): Record<string, SessionEntry> {
+  const cache = options.cache;
+  const cacheKey = cache
+    ? `${storePath}\u0000${agentId ?? ""}\u0000${clone === false ? "0" : "1"}\u0000${options.readOnly ? "1" : "0"}`
+    : "";
+  if (cache) {
+    const cached = cache.get(cacheKey);
+    if (cached) {
+      return cached;
+    }
+  }
+  const loaded = loadGatewaySessionLookupStoreUncached(storePath, clone, agentId, options);
+  cache?.set(cacheKey, loaded);
+  return loaded;
+}
+
+function loadGatewaySessionLookupStoreUncached(
   storePath: string,
   clone: boolean | undefined,
   agentId?: string,
@@ -126,6 +159,7 @@ function resolveGatewaySessionStoreLookup(params: {
   clone?: boolean;
   initialStore?: Record<string, SessionEntry>;
   readOnly?: boolean;
+  storeCache?: GatewaySessionStoreCache;
 }): {
   storePath: string;
   store: Record<string, SessionEntry>;
@@ -149,6 +183,7 @@ function resolveGatewaySessionStoreLookup(params: {
   const loadStore = (target: SessionStoreTarget) =>
     loadGatewaySessionLookupStore(target.storePath, params.clone, target.agentId, {
       readOnly: params.readOnly || !configured,
+      ...(params.storeCache ? { cache: params.storeCache } : {}),
     });
   const firstCandidate = candidates[0] ?? fallback;
   let selectedStorePath = firstCandidate.storePath;
@@ -196,6 +231,7 @@ function resolveExplicitDeletedLegacyMainStoreTarget(params: {
   key: string;
   clone?: boolean;
   readOnly?: boolean;
+  storeCache?: GatewaySessionStoreCache;
 }): GatewaySessionStoreTargetWithStore | null {
   const parsed = parseAgentSessionKey(params.key);
   const legacyAgentId = normalizeAgentId(parsed?.agentId);
@@ -232,6 +268,7 @@ function resolveExplicitDeletedLegacyMainStoreTarget(params: {
     }
     const store = loadGatewaySessionLookupStore(target.storePath, params.clone, target.agentId, {
       readOnly: true,
+      ...(params.storeCache ? { cache: params.storeCache } : {}),
     });
     const match = findFreshestStoreMatch(store, ...lookupSeeds);
     if (!match) {
@@ -269,6 +306,7 @@ export function resolveGatewaySessionStoreTargetWithStore(params: {
   clone?: boolean;
   readOnly?: boolean;
   store?: Record<string, SessionEntry>;
+  storeCache?: GatewaySessionStoreCache;
 }): GatewaySessionStoreTargetWithStore {
   const key = normalizeOptionalString(params.key) ?? "";
   const explicitDeletedMainTarget = resolveExplicitDeletedLegacyMainStoreTarget({
@@ -276,6 +314,7 @@ export function resolveGatewaySessionStoreTargetWithStore(params: {
     key,
     clone: params.clone,
     readOnly: params.readOnly,
+    ...(params.storeCache ? { storeCache: params.storeCache } : {}),
   });
   if (explicitDeletedMainTarget) {
     return explicitDeletedMainTarget;
@@ -298,6 +337,7 @@ export function resolveGatewaySessionStoreTargetWithStore(params: {
     // owners may materialize the process-lifetime incognito database.
     const store = loadGatewaySessionLookupStore(storePath, params.clone, agentId, {
       readOnly: true,
+      ...(params.storeCache ? { cache: params.storeCache } : {}),
     });
     return {
       agentId,
@@ -315,6 +355,7 @@ export function resolveGatewaySessionStoreTargetWithStore(params: {
     clone: params.clone,
     readOnly: params.readOnly,
     initialStore: params.store,
+    ...(params.storeCache ? { storeCache: params.storeCache } : {}),
   });
   if (canonicalKey === "global" || canonicalKey === "unknown") {
     const storeKeys = key && key !== canonicalKey ? [canonicalKey, key] : [key];


### PR DESCRIPTION
## What Problem This Solves

After #113862 removed per-row SQLite *connection* opens from `sessions.list`,
the listing still materialized session entries per row. Sharing resolution runs
once for every listed row, and each run loaded a whole session lookup store, so
entry materialization grew quadratically with session count.

## Why This Change Was Made

`sessions.list` now builds one `GatewaySessionStoreCache` and threads it through
sharing resolution, so each candidate store is materialized once per request
instead of once per row. The cache key distinguishes store path, agent, clone
mode, and read-only mode.

The cache is request-scoped, never process-global, so it cannot serve a later
request stale rows. Entries are shared across rows within the request, so a
cached store is read-only to its holder — noted at the type.

## User Impact

Large session lists stop paying a full store materialization per row, so listing
(and the sidebar refresh after a multi-select archive) scales better. No
protocol, config, or storage contract change.

## Evidence

New guard `src/gateway/server.sessions.list-store-materialization.test.ts` counts
entries materialized through `listSessionEntries` during a real `sessions.list`
RPC and asserts growth is not quadratic (5 rows vs 40). It spies only on
`listSessionEntries`, which attribution showed is used solely by the sharing
lookup path — the listing itself and ACP metadata use the read-only variant — so
the test isolates the behavior under change.

A/B on the same checkout: with the cache removed the test fails at
`expected 1681 to be less than 432`; with the cache it passes. Sharing-path store
loads drop from roughly one per row to 2 per request.

`oxlint` clean on touched files, `check-import-cycles` reports 0 runtime value
cycles, and Codex autoreview is clean ("patch is correct", no actionable
findings).

## Follow-up

Attribution during this work found a larger, separate cost: the ACP thinking
projection calls `readAcpSessionMeta` per row, and each call materializes the
whole store to read one entry (47 of ~51 store loads for a 40-row list).
Switching it to the existing `readAcpSessionMetaForEntry` takes a 40-row list
from 1763 materialized entries to 82, but that call resolves ACP rows by exact
key while the current path first resolves case and legacy aliases against store
entries — so it can silently fall back to default model/thinking settings for a
session whose ACP record is keyed under a legacy or mixed-case key. That fix is
deliberately excluded here and needs an alias-safe lookup (resolving the alias
against `acp_sessions` rather than the session store) plus its own proof.
