### PR TITLE
Recover interrupted and unfinished local-model turns

### DIFF
--- a/src/agents/bash-process-registry.test.ts
+++ b/src/agents/bash-process-registry.test.ts
@@ -151,7 +151,7 @@ describe("bash process registry", () => {
     expect(drainSession(session).stdout).toBe("bc");
   });
 
-  it("only persists finished sessions when backgrounded", () => {
+  it("retains a session backgrounded immediately after process exit", () => {
     const session = createRegistrySession({
       maxOutputChars: 100,
       pendingMaxOutputChars: 30_000,
@@ -163,7 +163,6 @@ describe("bash process registry", () => {
     expect(listFinishedSessions()).toHaveLength(0);
 
     markBackgrounded(session);
-    markExited(session, 0, null, "completed");
     const finishedSessions = listFinishedSessions();
     const endedAt = finishedSessions[0]?.endedAt;
     expect(endedAt).toEqual(expect.any(Number));

--- a/src/agents/bash-process-registry.ts
+++ b/src/agents/bash-process-registry.ts
@@ -81,6 +81,7 @@ export interface ProcessSession {
   exitSignal?: NodeJS.Signals | number | null;
   exitReason?: TerminationReason;
   noOutputTimedOut?: boolean;
+  status?: ProcessStatus;
   exited: boolean;
   /** Process exit observed; backend cleanup still owns the terminal transition. */
   finalizing?: boolean;
@@ -207,6 +208,7 @@ export function markExited(
   session.exitSignal = exitSignal;
   session.exitReason = exitReason;
   session.noOutputTimedOut = noOutputTimedOut;
+  session.status = status;
   session.tail = tail(session.aggregated, 2000);
   moveToFinished(session, status);
 }
@@ -214,9 +216,15 @@ export function markExited(
 /** Marks a running session as reconnectable after the exec call returns. */
 export function markBackgrounded(session: ProcessSession) {
   session.backgrounded = true;
-  if (!session.exited) {
-    activeBackgroundExecSessionIds.add(session.id);
+  if (session.exited) {
+    // The process can settle in the narrow window after the yield timer starts
+    // but before exec marks the session backgrounded. markExited() cannot retain
+    // that session because it was still foreground at the time. Promote the
+    // already-finished record now so the process tool can recover its output.
+    moveToFinished(session, session.status ?? "failed");
+    return;
   }
+  activeBackgroundExecSessionIds.add(session.id);
 }
 
 /** Returns the number of live background exec sessions without exposing process details. */

--- a/src/agents/embedded-agent-runner/run-loop.ts
+++ b/src/agents/embedded-agent-runner/run-loop.ts
@@ -26,7 +26,10 @@ import {
 } from "./post-compaction-loop-guard.js";
 import { clearProviderPromptState } from "./provider-prompt-state.js";
 import { createEmbeddedRunReplayState } from "./replay-state.js";
-import { handleEmbeddedAssistantFailure } from "./run/assistant-failure.js";
+import {
+  handleEmbeddedAssistantFailure,
+  TRANSIENT_TRANSPORT_CONTINUATION_INSTRUCTION,
+} from "./run/assistant-failure.js";
 import { prepareAndDispatchEmbeddedRunAttempt } from "./run/attempt-dispatch-preparation.js";
 import { normalizeEmbeddedRunAttempt } from "./run/attempt-normalization.js";
 import { recoverEmbeddedRunAttempt } from "./run/attempt-recovery.js";
@@ -477,6 +480,7 @@ export async function runPreparedEmbeddedLoop(
         rateLimitProfileRotations: failoverRetryController.rateLimitProfileRotations,
         rateLimitProfileRotationLimit: failoverRetryController.rateLimitProfileRotationLimit,
         sameModelIdleTimeoutRetries,
+        terminalRetryState,
         previousRetryFailoverReason: lastRetryFailoverReason,
         maybeMarkAuthProfileFailure: failoverRetryController.maybeMarkAuthProfileFailure,
         maybeEscalateRateLimitProfileFallback:
@@ -502,6 +506,12 @@ export async function runPreparedEmbeddedLoop(
         failoverRetryController.resetSameModelRateLimitRetries();
       }
       if (assistantFailureOutcome.action === "retry") {
+        if (assistantFailureOutcome.continueFromPersistedTranscript) {
+          sessionPromptState.activateInternalPrompt(
+            TRANSIENT_TRANSPORT_CONTINUATION_INSTRUCTION,
+            true,
+          );
+        }
         continue;
       }
       let assistantProfileFailureReason = assistantFailureOutcome.assistantProfileFailureReason;

--- a/src/agents/embedded-agent-runner/run.before-agent-finalize.test.ts
+++ b/src/agents/embedded-agent-runner/run.before-agent-finalize.test.ts
@@ -79,7 +79,7 @@ describe("runEmbeddedAgent before_agent_finalize", () => {
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledWith(
       expect.objectContaining({
         beforeAgentFinalizeRevisionAttempts: 0,
-        maxBeforeAgentFinalizeRevisions: 3,
+        maxBeforeAgentFinalizeRevisions: 5,
       }),
     );
   });

--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
@@ -47,6 +47,8 @@ const EMPTY_RESPONSE_RETRY_INSTRUCTION =
   "The previous attempt did not produce a user-visible answer. Continue from the current state and produce the visible answer now. Do not restart from scratch.";
 const SETTLED_TOOL_TERMINAL_CONTINUATION_INSTRUCTION =
   "The previous assistant turn completed its tool calls but did not produce a user-visible answer. Continue from the current transcript and produce the final user-visible answer now. Do not repeat completed tool calls or restart from scratch.";
+const RECOVERABLE_TOOL_ERROR_RETRY_PROMPT_PREFIX =
+  "The previous tool call failed, but that failure is evidence to recover from rather than a final answer. Continue from the persisted transcript. Inspect the exact error, change the approach, and finish the original request. Do not repeat an unchanged failing command and do not replay completed side effects.";
 
 let runEmbeddedAgent: typeof import("./run.js").runEmbeddedAgent;
 
@@ -137,6 +139,67 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       tools: ["bash"],
       failures: 2,
     });
+  });
+
+  it("continues after a failed tool and lets the model change approach", async () => {
+    const failedAttempt = makeAttemptResult({
+      assistantTexts: [],
+      toolMetas: [{ toolName: "exec", meta: "exit=1", isError: true }],
+      lastToolError: { toolName: "exec", error: "command exited with code 1" },
+    });
+    mockedClassifyFailoverReason.mockReturnValue(null);
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(failedAttempt);
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: ["Recovered with a different command."],
+      }),
+    );
+    mockedBuildEmbeddedRunPayloads
+      .mockReturnValueOnce([])
+      .mockReturnValueOnce([{ text: "Recovered with a different command." }]);
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      provider: "openai",
+      model: "gpt-5.5",
+      runId: "run-tool-error-continuation",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    expect(result.payloads?.[0]?.text).toBe("Recovered with a different command.");
+    const secondCall = runAttemptCall(1);
+    expect(secondCall.prompt).toBe(
+      `${RECOVERABLE_TOOL_ERROR_RETRY_PROMPT_PREFIX}\n\nTool error: command exited with code 1`,
+    );
+    expect(secondCall.disableTools).not.toBe(true);
+    expect(secondCall.suppressNextUserMessagePersistence).toBe(true);
+    expect(secondCall.skipPreparedUserTurnMessage).toBe(true);
+    expectWarnMessageWith("recoverable tool error requested one more pass");
+  });
+
+  it("bounds repeated failed-tool continuations to two", async () => {
+    const failedAttempt = makeAttemptResult({
+      assistantTexts: [],
+      toolMetas: [{ toolName: "exec", meta: "exit=1", isError: true }],
+      lastToolError: { toolName: "exec", error: "command exited with code 1" },
+    });
+    mockedClassifyFailoverReason.mockReturnValue(null);
+    mockedRunEmbeddedAttempt.mockResolvedValue(failedAttempt);
+    mockedBuildEmbeddedRunPayloads.mockReturnValue([]);
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      provider: "openai",
+      model: "gpt-5.5",
+      runId: "run-tool-error-continuation-exhausted",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(3);
+    expect(result.payloads?.[0]).toMatchObject({ isError: true });
+    expect(result.payloads?.[0]?.text).toContain(
+      "some tool actions may have already been executed",
+    );
+    expectWarnMessageWith("attempt=2/2");
   });
 
   it("emits the before_agent_run hook block message as the agent payload", async () => {

--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
@@ -47,9 +47,6 @@ const EMPTY_RESPONSE_RETRY_INSTRUCTION =
   "The previous attempt did not produce a user-visible answer. Continue from the current state and produce the visible answer now. Do not restart from scratch.";
 const SETTLED_TOOL_TERMINAL_CONTINUATION_INSTRUCTION =
   "The previous assistant turn completed its tool calls but did not produce a user-visible answer. Continue from the current transcript and produce the final user-visible answer now. Do not repeat completed tool calls or restart from scratch.";
-const RECOVERABLE_TOOL_ERROR_RETRY_PROMPT_PREFIX =
-  "The previous tool call failed, but that failure is evidence to recover from rather than a final answer. Continue from the persisted transcript. Inspect the exact error, change the approach, and finish the original request. Do not repeat an unchanged failing command and do not replay completed side effects.";
-
 let runEmbeddedAgent: typeof import("./run.js").runEmbeddedAgent;
 
 function resolveIncompleteTurnPayloadText(
@@ -141,43 +138,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     });
   });
 
-  it("continues after a failed tool and lets the model change approach", async () => {
-    const failedAttempt = makeAttemptResult({
-      assistantTexts: [],
-      toolMetas: [{ toolName: "exec", meta: "exit=1", isError: true }],
-      lastToolError: { toolName: "exec", error: "command exited with code 1" },
-    });
-    mockedClassifyFailoverReason.mockReturnValue(null);
-    mockedRunEmbeddedAttempt.mockResolvedValueOnce(failedAttempt);
-    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
-      makeAttemptResult({
-        assistantTexts: ["Recovered with a different command."],
-      }),
-    );
-    mockedBuildEmbeddedRunPayloads
-      .mockReturnValueOnce([])
-      .mockReturnValueOnce([{ text: "Recovered with a different command." }]);
-
-    const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
-      provider: "openai",
-      model: "gpt-5.5",
-      runId: "run-tool-error-continuation",
-    });
-
-    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
-    expect(result.payloads?.[0]?.text).toBe("Recovered with a different command.");
-    const secondCall = runAttemptCall(1);
-    expect(secondCall.prompt).toBe(
-      `${RECOVERABLE_TOOL_ERROR_RETRY_PROMPT_PREFIX}\n\nTool error: command exited with code 1`,
-    );
-    expect(secondCall.disableTools).not.toBe(true);
-    expect(secondCall.suppressNextUserMessagePersistence).toBe(true);
-    expect(secondCall.skipPreparedUserTurnMessage).toBe(true);
-    expectWarnMessageWith("recoverable tool error requested one more pass");
-  });
-
-  it("bounds repeated failed-tool continuations to two", async () => {
+  it("does not automatically continue after a failed tool", async () => {
     const failedAttempt = makeAttemptResult({
       assistantTexts: [],
       toolMetas: [{ toolName: "exec", meta: "exit=1", isError: true }],
@@ -191,15 +152,14 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       ...overflowBaseRunParams,
       provider: "openai",
       model: "gpt-5.5",
-      runId: "run-tool-error-continuation-exhausted",
+      runId: "run-tool-error-is-terminal",
     });
 
-    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(3);
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
     expect(result.payloads?.[0]).toMatchObject({ isError: true });
     expect(result.payloads?.[0]?.text).toContain(
       "some tool actions may have already been executed",
     );
-    expectWarnMessageWith("attempt=2/2");
   });
 
   it("emits the before_agent_run hook block message as the agent payload", async () => {

--- a/src/agents/embedded-agent-runner/run/assistant-failure.test.ts
+++ b/src/agents/embedded-agent-runner/run/assistant-failure.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import type { AssistantMessage } from "../../../llm/types.js";
+import {
+  shouldContinueTransientAssistantError,
+  TRANSIENT_TRANSPORT_CONTINUATION_INSTRUCTION,
+} from "./assistant-failure.js";
+import type { EmbeddedRunAttemptResult } from "./types.js";
+
+function assistant(): AssistantMessage {
+  return {
+    role: "assistant",
+    stopReason: "error",
+    provider: "openai",
+    model: "qwen3.6-27b-fp8",
+    errorMessage: "terminated",
+    content: [{ type: "text", text: "Let me run a proper permissions check:" }],
+  } as unknown as AssistantMessage;
+}
+
+function attempt(overrides: Partial<EmbeddedRunAttemptResult> = {}): EmbeddedRunAttemptResult {
+  return {
+    assistantTexts: ["Let me run a proper permissions check:"],
+    clientToolCalls: undefined,
+    yieldDetected: false,
+    didSendDeterministicApprovalPrompt: false,
+    heartbeatToolResponse: undefined,
+    toolMediaUrls: [],
+    toolAudioAsVoice: false,
+    toolTrustedLocalMedia: false,
+    hasToolMediaBlockReply: false,
+    didDeliverSourceReplyViaMessageTool: false,
+    messagingToolSourceReplyPayloads: [],
+    messagingToolSentTexts: [],
+    messagingToolSentMediaUrls: [],
+    messagingToolSentTargets: [],
+    acceptedSessionSpawns: [],
+    successfulCronAdds: 0,
+    toolMetas: [],
+    ...overrides,
+  } as unknown as EmbeddedRunAttemptResult;
+}
+
+function eligibleParams(
+  overrides: {
+    attempt?: EmbeddedRunAttemptResult;
+    assistant?: AssistantMessage;
+    timedOut?: boolean;
+  } = {},
+) {
+  return {
+    attempt: overrides.attempt ?? attempt(),
+    assistant: overrides.assistant ?? assistant(),
+    failoverReason: "timeout" as const,
+    authFailure: false,
+    rateLimitFailure: false,
+    billingFailure: false,
+    cloudCodeAssistFormatError: false,
+    imageDimensionError: false,
+    terminalInterrupted: false,
+    promptError: undefined,
+    timedOut: overrides.timedOut ?? false,
+    externalAbort: false,
+    signalOwnedInterruption: false,
+  };
+}
+
+describe("transient assistant stream recovery", () => {
+  it("continues from partial progress after a transport termination", () => {
+    expect(shouldContinueTransientAssistantError(eligibleParams())).toBe(true);
+    expect(TRANSIENT_TRANSPORT_CONTINUATION_INSTRUCTION).toContain(
+      "Continue from the persisted transcript",
+    );
+  });
+
+  it("does not continue after committed delivery or a real run timeout", () => {
+    expect(
+      shouldContinueTransientAssistantError(
+        eligibleParams({
+          attempt: attempt({ messagingToolSentTexts: ["Already delivered."] }),
+        }),
+      ),
+    ).toBe(false);
+    expect(shouldContinueTransientAssistantError(eligibleParams({ timedOut: true }))).toBe(false);
+  });
+});

--- a/src/agents/embedded-agent-runner/run/assistant-failure.ts
+++ b/src/agents/embedded-agent-runner/run/assistant-failure.ts
@@ -22,12 +22,16 @@ import type { TraceAttempt } from "../types.js";
 import { handleAssistantFailover, isShortWindowRateLimitMessage } from "./assistant-failover.js";
 import { createFailoverDecisionLogger } from "./failover-observation.js";
 import { resolveRunFailoverDecision } from "./failover-policy.js";
-import { shouldRetrySilentErrorAssistantTurn } from "./incomplete-turn.js";
+import { hasAttemptTerminalState, shouldRetrySilentErrorAssistantTurn } from "./incomplete-turn.js";
 import type { RunEmbeddedAgentParams } from "./params.js";
+import type { EmbeddedRunTerminalRetryState } from "./terminal-retry-state.js";
 import type { EmbeddedRunAttemptResult } from "./types.js";
 
 const MAX_EMPTY_ERROR_RETRIES = 3;
 const MAX_SAME_MODEL_IDLE_TIMEOUT_RETRIES = 1;
+const MAX_TRANSIENT_TRANSPORT_CONTINUATIONS = 2;
+export const TRANSIENT_TRANSPORT_CONTINUATION_INSTRUCTION =
+  "The previous model stream ended unexpectedly after partial progress. Continue from the persisted transcript and finish the original request. Do not repeat completed tool calls or side effects. Inspect prior results, verify current state as needed, change approach if necessary, and produce the final user-visible answer. A transient transport failure is not a reason to stop.";
 
 type EmbeddedRunAssistantFailureOutcome = {
   action: "retry" | "proceed";
@@ -39,7 +43,48 @@ type EmbeddedRunAssistantFailureOutcome = {
   lastRetryFailoverReason: FailoverReason | null;
   preserveSameModelRateLimitRetryCount: boolean;
   assistantProfileFailureReason: AuthProfileFailureReason | null;
+  continueFromPersistedTranscript: boolean;
 };
+
+export function shouldContinueTransientAssistantError(params: {
+  attempt: EmbeddedRunAttemptResult;
+  assistant?: AssistantMessage;
+  failoverReason: FailoverReason | null;
+  authFailure: boolean;
+  rateLimitFailure: boolean;
+  billingFailure: boolean;
+  cloudCodeAssistFormatError: boolean;
+  imageDimensionError: boolean;
+  terminalInterrupted: boolean;
+  promptError: unknown;
+  timedOut: boolean;
+  externalAbort: boolean;
+  signalOwnedInterruption: boolean;
+}): boolean {
+  const transientReason =
+    params.failoverReason === "timeout" ||
+    params.failoverReason === "server_error" ||
+    params.failoverReason === "unknown" ||
+    params.failoverReason === "no_error_details" ||
+    params.failoverReason === "unclassified" ||
+    params.failoverReason === null;
+  return (
+    params.assistant?.stopReason === "error" &&
+    params.attempt.assistantTexts.some((text) => text.trim().length > 0) &&
+    !hasAttemptTerminalState(params.attempt) &&
+    transientReason &&
+    !params.authFailure &&
+    !params.rateLimitFailure &&
+    !params.billingFailure &&
+    !params.cloudCodeAssistFormatError &&
+    !params.imageDimensionError &&
+    !params.terminalInterrupted &&
+    !params.promptError &&
+    !params.timedOut &&
+    !params.externalAbort &&
+    !params.signalOwnedInterruption
+  );
+}
 
 export async function handleEmbeddedAssistantFailure(input: {
   runParams: RunEmbeddedAgentParams;
@@ -82,6 +127,7 @@ export async function handleEmbeddedAssistantFailure(input: {
   rateLimitProfileRotations: number;
   rateLimitProfileRotationLimit: number;
   sameModelIdleTimeoutRetries: number;
+  terminalRetryState: EmbeddedRunTerminalRetryState;
   previousRetryFailoverReason: FailoverReason | null;
   maybeMarkAuthProfileFailure: (failure: {
     profileId?: string;
@@ -174,6 +220,49 @@ export async function handleEmbeddedAssistantFailure(input: {
     return buildOutcome(input, {
       action: "retry",
       emptyErrorRetries,
+      preserveSameModelRateLimitRetryCount: true,
+      assistantProfileFailureReason,
+    });
+  }
+
+  if (
+    shouldContinueTransientAssistantError({
+      attempt: input.attempt,
+      assistant: input.attemptAssistant,
+      failoverReason: assistantFailoverReason,
+      authFailure,
+      rateLimitFailure,
+      billingFailure,
+      cloudCodeAssistFormatError,
+      imageDimensionError: Boolean(imageDimensionError),
+      terminalInterrupted: input.terminalInterrupted,
+      promptError: input.promptError,
+      timedOut: input.timedOut,
+      externalAbort: input.externalAbort,
+      signalOwnedInterruption: input.signalOwnedInterruption,
+    }) &&
+    input.terminalRetryState.transientTransportContinuationAttempts <
+      MAX_TRANSIENT_TRANSPORT_CONTINUATIONS
+  ) {
+    input.terminalRetryState.transientTransportContinuationAttempts += 1;
+    const continuationAttempt = input.terminalRetryState.transientTransportContinuationAttempts;
+    log.warn(
+      `[transient-transport-continuation] stopReason=error after partial progress; ` +
+        `continuing persisted turn attempt=${continuationAttempt}/${MAX_TRANSIENT_TRANSPORT_CONTINUATIONS} ` +
+        `provider=${input.attemptAssistant?.provider ?? input.provider} ` +
+        `model=${input.attemptAssistant?.model ?? input.model} ` +
+        `sessionKey=${input.runParams.sessionKey ?? input.runParams.sessionId}`,
+    );
+    input.traceAttempts.push({
+      provider: input.activeErrorContext.provider,
+      model: input.activeErrorContext.model,
+      result: assistantFailoverReason === "timeout" ? "timeout" : "error",
+      ...(assistantFailoverReason ? { reason: assistantFailoverReason } : {}),
+      stage: "assistant",
+    });
+    return buildOutcome(input, {
+      action: "retry",
+      continueFromPersistedTranscript: true,
       preserveSameModelRateLimitRetryCount: true,
       assistantProfileFailureReason,
     });
@@ -369,5 +458,6 @@ function buildOutcome(
     lastRetryFailoverReason: override.lastRetryFailoverReason ?? input.previousRetryFailoverReason,
     preserveSameModelRateLimitRetryCount: override.preserveSameModelRateLimitRetryCount ?? false,
     assistantProfileFailureReason: override.assistantProfileFailureReason,
+    continueFromPersistedTranscript: override.continueFromPersistedTranscript ?? false,
   };
 }

--- a/src/agents/embedded-agent-runner/run/attempt-stream-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-prepare.ts
@@ -144,18 +144,6 @@ export function prepareEmbeddedAttemptStream(input: {
           model: attempt.modelId,
           assistant: lastAssistant,
         });
-        const maxRevisionAttempts = attempt.maxBeforeAgentFinalizeRevisions ?? 0;
-        if (
-          maxRevisionAttempts > 0 &&
-          (attempt.beforeAgentFinalizeRevisionAttempts ?? 0) >= maxRevisionAttempts
-        ) {
-          log.warn(
-            `before_agent_finalize revision limit reached; finalizing ` +
-              `runId=${attempt.runId} sessionId=${attempt.sessionId} ` +
-              `attempts=${attempt.beforeAgentFinalizeRevisionAttempts ?? 0}/${maxRevisionAttempts}`,
-          );
-          return;
-        }
         const outcome = await runAgentHarnessBeforeAgentFinalizeHook({
           event: {
             runId: attempt.runId,
@@ -191,7 +179,7 @@ export function prepareEmbeddedAttemptStream(input: {
           },
           hookRunner,
         });
-        if (outcome.action !== "revise") {
+        if (outcome.action !== "revise" && outcome.action !== "exhausted") {
           return;
         }
         if (event.hadDeterministicSideEffect) {
@@ -202,6 +190,30 @@ export function prepareEmbeddedAttemptStream(input: {
           return;
         }
         beforeAgentFinalizeRevisionReason = outcome.reason;
+        if (outcome.action === "exhausted") {
+          log.warn(
+            `before_agent_finalize retry metadata exhausted; refusing unfinished success ` +
+              `runId=${attempt.runId} sessionId=${attempt.sessionId} ` +
+              `attempts=${attempt.beforeAgentFinalizeRevisionAttempts ?? 0}`,
+          );
+          return { suppressTerminalDelivery: true };
+        }
+        const maxRevisionAttempts = attempt.maxBeforeAgentFinalizeRevisions ?? 0;
+        if (
+          maxRevisionAttempts > 0 &&
+          (attempt.beforeAgentFinalizeRevisionAttempts ?? 0) >= maxRevisionAttempts
+        ) {
+          // Keep the revision reason and suppress the rejected terminal fragment
+          // so terminal resolution can replace it with a visible fail-closed
+          // error. Releasing the same unfinished answer here turns an exhausted
+          // follow-through guard into a false success.
+          log.warn(
+            `before_agent_finalize revision limit reached; refusing unfinished success ` +
+              `runId=${attempt.runId} sessionId=${attempt.sessionId} ` +
+              `attempts=${attempt.beforeAgentFinalizeRevisionAttempts ?? 0}/${maxRevisionAttempts}`,
+          );
+          return { suppressTerminalDelivery: true };
+        }
         return { suppressTerminalDelivery: true };
       }
     : undefined;

--- a/src/agents/embedded-agent-runner/run/attempt-trajectory-status.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-trajectory-status.test.ts
@@ -75,6 +75,32 @@ describe("attempt trajectory status", () => {
     });
   });
 
+  it("does not treat progress fragments as success after a provider stream error", () => {
+    expect(
+      resolveAttemptTrajectoryTerminal(
+        baseParams({
+          assistantTexts: ["Working on it.", "I found the likely cause."],
+          synthesizedPayloadCount: 2,
+          lastAssistantStopReason: "error",
+        }),
+      ),
+    ).toEqual({
+      status: "error",
+      terminalError: NON_DELIVERABLE_TERMINAL_TURN_REASON,
+    });
+  });
+
+  it("keeps committed delivery successful when the provider errors afterward", () => {
+    expect(
+      resolveAttemptTrajectoryTerminal(
+        baseParams({
+          messagingToolSentTexts: ["Already delivered."],
+          lastAssistantStopReason: "error",
+        }),
+      ),
+    ).toEqual({ status: "success" });
+  });
+
   it("keeps length-limited turns successful when terminal output was delivered", () => {
     expect(
       resolveAttemptTrajectoryTerminal(
@@ -143,6 +169,20 @@ describe("attempt trajectory status", () => {
       resolveAttemptTrajectoryTerminal(
         baseParams({
           toolMetas: [{ toolName: "read" }],
+        }),
+      ),
+    ).toEqual({
+      status: "error",
+      terminalError: NON_DELIVERABLE_TERMINAL_TURN_REASON,
+    });
+  });
+
+  it("does not treat a failed tool as terminal delivery", () => {
+    expect(
+      resolveAttemptTrajectoryTerminal(
+        baseParams({
+          toolMetas: [{ toolName: "exec", isError: true }],
+          lastToolError: { toolName: "exec", error: "command failed" },
         }),
       ),
     ).toEqual({

--- a/src/agents/embedded-agent-runner/run/attempt-trajectory-status.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-trajectory-status.ts
@@ -107,7 +107,6 @@ export function resolveAttemptTrajectoryTerminal(
   if (params.failed) {
     return { status: "error" };
   }
-
   // Messaging/tool-use attempts may not have assistant text; only committed
   // delivery evidence or durable side effects can make those terminal turns
   // successful.
@@ -120,8 +119,18 @@ export function resolveAttemptTrajectoryTerminal(
     params.heartbeatToolResponse !== undefined ||
     (params.clientToolCalls?.length ?? 0) > 0 ||
     params.yieldDetected === true ||
-    params.lastToolError !== undefined ||
     hasAsyncStartedToolActivity(params.toolMetas);
+
+  // Fail closed when the provider's final assistant event is explicitly an
+  // error. Earlier progress fragments and synthesized streaming payloads are
+  // not proof that the user received a completed answer, but a separately
+  // committed delivery remains valid.
+  if (params.lastAssistantStopReason === "error" && !hasExplicitTerminalDelivery) {
+    return {
+      status: "error",
+      terminalError: NON_DELIVERABLE_TERMINAL_TURN_REASON,
+    };
+  }
 
   if (params.lastAssistantStopReason === "toolUse" && !hasExplicitTerminalDelivery) {
     return {

--- a/src/agents/embedded-agent-runner/run/incomplete-turn.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn.ts
@@ -204,7 +204,6 @@ export function hasAttemptTerminalState(attempt: TerminalAttemptState): boolean 
     attempt.yieldDetected ||
     attempt.didSendDeterministicApprovalPrompt ||
     attempt.heartbeatToolResponse ||
-    attempt.lastToolError ||
     attempt.toolMediaUrls?.some((url) => url.trim().length > 0) ||
     attempt.toolAudioAsVoice ||
     attempt.toolTrustedLocalMedia ||
@@ -261,8 +260,7 @@ export function resolveIncompleteTurnPayloadText(params: {
     params.timedOut ||
     params.attempt.clientToolCalls ||
     params.attempt.yieldDetected ||
-    params.attempt.didSendDeterministicApprovalPrompt ||
-    params.attempt.lastToolError
+    params.attempt.didSendDeterministicApprovalPrompt
   ) {
     return null;
   }
@@ -570,6 +568,12 @@ export function shouldRetrySilentErrorAssistantTurn(params: {
   assistant: EmbeddedRunAttemptResult["lastAssistant"] | null | undefined;
 }): boolean {
   if (joinAssistantTexts(params.attempt.assistantTexts).length > 0) {
+    return false;
+  }
+  // A tool failure needs the dedicated transcript-continuation path. It is
+  // not evidence of completed delivery and must not replay the original
+  // provider prompt through the silent-error retry family.
+  if (params.attempt.lastToolError) {
     return false;
   }
   if (hasAttemptTerminalState(params.attempt)) {

--- a/src/agents/embedded-agent-runner/run/terminal-resolution.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-resolution.ts
@@ -34,6 +34,7 @@ import {
 } from "./incomplete-turn.js";
 import type { RunEmbeddedAgentParams } from "./params.js";
 import {
+  hasExhaustedBeforeAgentFinalizeRevisions,
   MAX_BEFORE_AGENT_FINALIZE_REVISIONS,
   type EmbeddedRunTerminalRetryState,
 } from "./terminal-retry-state.js";
@@ -415,6 +416,26 @@ export async function resolveEmbeddedRunTerminal(input: {
   }
 
   const beforeFinalizeRevisionReason = attempt.beforeAgentFinalizeRevisionReason;
+  if (
+    hasExhaustedBeforeAgentFinalizeRevisions({
+      revisionReason: beforeFinalizeRevisionReason,
+      revisionAttempts: retryState.beforeFinalizeRevisionAttempts,
+    })
+  ) {
+    const text =
+      "⚠️ Agent repeatedly stopped before completing the request. The unfinished turn was not accepted as success; completed tool actions were preserved.";
+    log.warn(
+      `before_agent_finalize revisions exhausted: ` +
+        `runId=${runParams.runId} sessionId=${runParams.sessionId} ` +
+        `attempts=${retryState.beforeFinalizeRevisionAttempts}/${MAX_BEFORE_AGENT_FINALIZE_REVISIONS} — surfacing incomplete-turn error`,
+    );
+    return surfaceIncompleteTurn({
+      ...input,
+      text,
+      payloadCount,
+      incompleteTurnFallbackSafe: false,
+    });
+  }
   if (
     beforeFinalizeRevisionReason &&
     !settledTurnFinalizationAttempted &&

--- a/src/agents/embedded-agent-runner/run/terminal-resolution.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-resolution.ts
@@ -40,10 +40,18 @@ import {
 import type { EmbeddedRunAttemptResult } from "./types.js";
 
 const MAX_MISSING_ASSISTANT_RETRIES = 1;
+const MAX_RECOVERABLE_TOOL_ERROR_CONTINUATIONS = 2;
 const COMPACTION_CONTINUATION_RETRY_INSTRUCTION =
   "The previous attempt compacted the conversation context before producing a final user-visible answer. Continue from the compacted transcript and produce the final answer now. Do not restart from scratch, do not repeat completed work, and do not rerun tools unless the transcript clearly lacks required evidence.";
 const BEFORE_AGENT_FINALIZE_RETRY_PROMPT_PREFIX =
   "Before accepting the previous final answer, apply this revision request and produce the revised final answer. Do not repeat completed work or rerun tools unless the request explicitly requires it.";
+const RECOVERABLE_TOOL_ERROR_RETRY_PROMPT_PREFIX =
+  "The previous tool call failed, but that failure is evidence to recover from rather than a final answer. Continue from the persisted transcript. Inspect the exact error, change the approach, and finish the original request. Do not repeat an unchanged failing command and do not replay completed side effects.";
+
+function isExternallyConsequentialToolError(toolName?: string): boolean {
+  const normalized = toolName?.trim().toLowerCase().replaceAll("-", "_") ?? "";
+  return /^(?:message|sessions_send|email|mail|cron|whatsapp|signal)$/.test(normalized);
+}
 
 type TerminalRunParams = RunEmbeddedAgentParams & {
   authProfileStateMode?: "read-write" | "read-only";
@@ -277,6 +285,36 @@ export async function resolveEmbeddedRunTerminal(input: {
       `empty response detected: runId=${runParams.runId} sessionId=${runParams.sessionId} ` +
         `provider=${input.activeErrorContext.provider}/${input.activeErrorContext.model} — retrying ${retryState.emptyResponseAttempts}/${input.maxEmptyResponseRetryAttempts} ` +
         `with visible-answer continuation`,
+    );
+    return { action: "retry" };
+  }
+  if (
+    !emptyAssistantReplyIsSilent &&
+    !settledTurnFinalizationAttempted &&
+    attempt.lastToolError &&
+    attempt.toolMetas.at(-1)?.isError === true &&
+    !input.finalAssistantVisibleText?.trim() &&
+    !isExternallyConsequentialToolError(attempt.lastToolError.toolName) &&
+    !input.terminalAborted &&
+    !input.terminalTimedOut &&
+    !input.terminalInterrupted &&
+    !input.promptError &&
+    !attempt.clientToolCalls &&
+    !attempt.yieldDetected &&
+    !attempt.didSendDeterministicApprovalPrompt &&
+    retryState.recoverableToolErrorContinuationAttempts < MAX_RECOVERABLE_TOOL_ERROR_CONTINUATIONS
+  ) {
+    retryState.recoverableToolErrorContinuationAttempts += 1;
+    const detail = attempt.lastToolError.error
+      ? `\n\nTool error: ${attempt.lastToolError.error}`
+      : "";
+    input.activateInternalPrompt(`${RECOVERABLE_TOOL_ERROR_RETRY_PROMPT_PREFIX}${detail}`, true);
+    retryState.compactionContinuationInstruction = null;
+    log.warn(
+      `recoverable tool error requested one more pass: ` +
+        `runId=${runParams.runId} sessionId=${runParams.sessionId} ` +
+        `tool=${attempt.lastToolError.toolName || "unknown"} ` +
+        `attempt=${retryState.recoverableToolErrorContinuationAttempts}/${MAX_RECOVERABLE_TOOL_ERROR_CONTINUATIONS}`,
     );
     return { action: "retry" };
   }

--- a/src/agents/embedded-agent-runner/run/terminal-resolution.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-resolution.ts
@@ -41,19 +41,10 @@ import {
 import type { EmbeddedRunAttemptResult } from "./types.js";
 
 const MAX_MISSING_ASSISTANT_RETRIES = 1;
-const MAX_RECOVERABLE_TOOL_ERROR_CONTINUATIONS = 2;
 const COMPACTION_CONTINUATION_RETRY_INSTRUCTION =
   "The previous attempt compacted the conversation context before producing a final user-visible answer. Continue from the compacted transcript and produce the final answer now. Do not restart from scratch, do not repeat completed work, and do not rerun tools unless the transcript clearly lacks required evidence.";
 const BEFORE_AGENT_FINALIZE_RETRY_PROMPT_PREFIX =
   "Before accepting the previous final answer, apply this revision request and produce the revised final answer. Do not repeat completed work or rerun tools unless the request explicitly requires it.";
-const RECOVERABLE_TOOL_ERROR_RETRY_PROMPT_PREFIX =
-  "The previous tool call failed, but that failure is evidence to recover from rather than a final answer. Continue from the persisted transcript. Inspect the exact error, change the approach, and finish the original request. Do not repeat an unchanged failing command and do not replay completed side effects.";
-
-function isExternallyConsequentialToolError(toolName?: string): boolean {
-  const normalized = toolName?.trim().toLowerCase().replaceAll("-", "_") ?? "";
-  return /^(?:message|sessions_send|email|mail|cron|whatsapp|signal)$/.test(normalized);
-}
-
 type TerminalRunParams = RunEmbeddedAgentParams & {
   authProfileStateMode?: "read-write" | "read-only";
   onSuccessfulAuthBinding?: (binding: AgentExecutionAuthBinding) => void;
@@ -286,36 +277,6 @@ export async function resolveEmbeddedRunTerminal(input: {
       `empty response detected: runId=${runParams.runId} sessionId=${runParams.sessionId} ` +
         `provider=${input.activeErrorContext.provider}/${input.activeErrorContext.model} — retrying ${retryState.emptyResponseAttempts}/${input.maxEmptyResponseRetryAttempts} ` +
         `with visible-answer continuation`,
-    );
-    return { action: "retry" };
-  }
-  if (
-    !emptyAssistantReplyIsSilent &&
-    !settledTurnFinalizationAttempted &&
-    attempt.lastToolError &&
-    attempt.toolMetas.at(-1)?.isError === true &&
-    !input.finalAssistantVisibleText?.trim() &&
-    !isExternallyConsequentialToolError(attempt.lastToolError.toolName) &&
-    !input.terminalAborted &&
-    !input.terminalTimedOut &&
-    !input.terminalInterrupted &&
-    !input.promptError &&
-    !attempt.clientToolCalls &&
-    !attempt.yieldDetected &&
-    !attempt.didSendDeterministicApprovalPrompt &&
-    retryState.recoverableToolErrorContinuationAttempts < MAX_RECOVERABLE_TOOL_ERROR_CONTINUATIONS
-  ) {
-    retryState.recoverableToolErrorContinuationAttempts += 1;
-    const detail = attempt.lastToolError.error
-      ? `\n\nTool error: ${attempt.lastToolError.error}`
-      : "";
-    input.activateInternalPrompt(`${RECOVERABLE_TOOL_ERROR_RETRY_PROMPT_PREFIX}${detail}`, true);
-    retryState.compactionContinuationInstruction = null;
-    log.warn(
-      `recoverable tool error requested one more pass: ` +
-        `runId=${runParams.runId} sessionId=${runParams.sessionId} ` +
-        `tool=${attempt.lastToolError.toolName || "unknown"} ` +
-        `attempt=${retryState.recoverableToolErrorContinuationAttempts}/${MAX_RECOVERABLE_TOOL_ERROR_CONTINUATIONS}`,
     );
     return { action: "retry" };
   }

--- a/src/agents/embedded-agent-runner/run/terminal-retry-state.test.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-retry-state.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import {
+  hasExhaustedBeforeAgentFinalizeRevisions,
+  MAX_BEFORE_AGENT_FINALIZE_REVISIONS,
+} from "./terminal-retry-state.js";
+
+describe("before_agent_finalize retry state", () => {
+  it("fails closed only after the configured revision budget is exhausted", () => {
+    expect(
+      hasExhaustedBeforeAgentFinalizeRevisions({
+        revisionReason: "unfinished",
+        revisionAttempts: MAX_BEFORE_AGENT_FINALIZE_REVISIONS - 1,
+      }),
+    ).toBe(false);
+    expect(
+      hasExhaustedBeforeAgentFinalizeRevisions({
+        revisionReason: "unfinished",
+        revisionAttempts: MAX_BEFORE_AGENT_FINALIZE_REVISIONS,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not treat an ordinary final answer as exhausted", () => {
+    expect(
+      hasExhaustedBeforeAgentFinalizeRevisions({
+        revisionAttempts: MAX_BEFORE_AGENT_FINALIZE_REVISIONS,
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/agents/embedded-agent-runner/run/terminal-retry-state.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-retry-state.ts
@@ -1,4 +1,17 @@
-export const MAX_BEFORE_AGENT_FINALIZE_REVISIONS = 3;
+export const MAX_BEFORE_AGENT_FINALIZE_REVISIONS = 5;
+
+export function hasExhaustedBeforeAgentFinalizeRevisions(params: {
+  revisionReason?: string;
+  revisionAttempts: number;
+  maxRevisionAttempts?: number;
+}): boolean {
+  const maxRevisionAttempts = params.maxRevisionAttempts ?? MAX_BEFORE_AGENT_FINALIZE_REVISIONS;
+  return Boolean(
+    params.revisionReason &&
+    maxRevisionAttempts > 0 &&
+    params.revisionAttempts >= maxRevisionAttempts,
+  );
+}
 
 export type EmbeddedRunTerminalRetryState = {
   reasoningOnlyAttempts: number;

--- a/src/agents/embedded-agent-runner/run/terminal-retry-state.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-retry-state.ts
@@ -7,6 +7,8 @@ export type EmbeddedRunTerminalRetryState = {
   compactionContinuationAttempts: number;
   compactionContinuationInstruction: string | null;
   beforeFinalizeRevisionAttempts: number;
+  recoverableToolErrorContinuationAttempts: number;
+  transientTransportContinuationAttempts: number;
 };
 
 export function createEmbeddedRunTerminalRetryState(): EmbeddedRunTerminalRetryState {
@@ -17,5 +19,7 @@ export function createEmbeddedRunTerminalRetryState(): EmbeddedRunTerminalRetryS
     compactionContinuationAttempts: 0,
     compactionContinuationInstruction: null,
     beforeFinalizeRevisionAttempts: 0,
+    recoverableToolErrorContinuationAttempts: 0,
+    transientTransportContinuationAttempts: 0,
   };
 }

--- a/src/agents/embedded-agent-runner/run/terminal-retry-state.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-retry-state.ts
@@ -20,7 +20,6 @@ export type EmbeddedRunTerminalRetryState = {
   compactionContinuationAttempts: number;
   compactionContinuationInstruction: string | null;
   beforeFinalizeRevisionAttempts: number;
-  recoverableToolErrorContinuationAttempts: number;
   transientTransportContinuationAttempts: number;
 };
 
@@ -32,7 +31,6 @@ export function createEmbeddedRunTerminalRetryState(): EmbeddedRunTerminalRetryS
     compactionContinuationAttempts: 0,
     compactionContinuationInstruction: null,
     beforeFinalizeRevisionAttempts: 0,
-    recoverableToolErrorContinuationAttempts: 0,
     transientTransportContinuationAttempts: 0,
   };
 }

--- a/src/agents/harness/lifecycle-hook-helpers.test.ts
+++ b/src/agents/harness/lifecycle-hook-helpers.test.ts
@@ -156,7 +156,7 @@ describe("agent harness lifecycle hook helpers", () => {
         ctx: { runId: "run-from-context", sessionKey: "agent:main:shared-session" },
         hookRunner: hookRunner as never,
       }),
-    ).resolves.toEqual({ action: "continue" });
+    ).resolves.toEqual({ action: "exhausted", reason: "revise from context run" });
   });
 
   it("preserves merged revise reasons when retry metadata is present", async () => {
@@ -263,7 +263,7 @@ describe("agent harness lifecycle hook helpers", () => {
         ctx: { runId: "run-1", sessionKey: "agent:main:session-1" },
         hookRunner: hookRunner as never,
       }),
-    ).resolves.toEqual({ action: "continue" });
+    ).resolves.toEqual({ action: "exhausted", reason: "retry with a safe key" });
   });
 
   it("does not collide fallback retry keys for long instructions with shared prefixes", async () => {

--- a/src/agents/harness/lifecycle-hook-helpers.ts
+++ b/src/agents/harness/lifecycle-hook-helpers.ts
@@ -138,6 +138,7 @@ export async function awaitAgentHarnessAgentEndHook(params: {
 type AgentHarnessBeforeAgentFinalizeOutcome =
   | { action: "continue" }
   | { action: "revise"; reason: string }
+  | { action: "exhausted"; reason: string }
   | { action: "finalize"; reason?: string };
 
 /** Runs before-finalize hooks and normalizes finalize/revise/continue decisions. */
@@ -183,6 +184,7 @@ function normalizeBeforeAgentFinalizeResult(
     const retryCandidates = readBeforeAgentFinalizeRetryCandidates(result);
     if (retryCandidates.length > 0) {
       const reason = normalizeTrimmedString(result.reason);
+      let exhaustedReason: string | undefined;
       for (const retry of retryCandidates) {
         const retryInstruction = normalizeTrimmedString(retry.instruction);
         if (!retryInstruction) {
@@ -207,6 +209,7 @@ function normalizeBeforeAgentFinalizeResult(
         budget.set(retryRunId, runBudget);
         pruneFinalizeRetryBudget(budget);
         if (nextCount > maxAttempts) {
+          exhaustedReason ??= reason ?? retryInstruction;
           continue;
         }
         const revisedReason =
@@ -214,6 +217,9 @@ function normalizeBeforeAgentFinalizeResult(
             ? reason
             : [reason, retryInstruction].filter(Boolean).join("\n\n");
         return { action: "revise", reason: revisedReason };
+      }
+      if (exhaustedReason) {
+        return { action: "exhausted", reason: exhaustedReason };
       }
       return { action: "continue" };
     }


### PR DESCRIPTION
## What Problem This Solves

OpenAI-compatible local-model streams can terminate after partial progress. This PR keeps the existing recovery scoped to eligible transient stream/socket termination, while making terminal failures explicit instead of accepting partial work as a successful answer.

This follow-up also removes automatic continuation after **any** failed tool call. A tool can side-effect before returning an error, and a name-based denylist cannot safely identify every consequential or plugin-provided tool. A failed tool therefore remains terminal: the caller receives the existing explicit incomplete-turn error and can decide whether to inspect or retry safely.

The PR also retains the original fixes for exhausted `before_agent_finalize` follow-through, explicit final `stopReason: error`, and the narrow foreground-to-background process-output race.

## Evidence

### Current safety update (`976469686b`)

- Added a regression case, `does not automatically continue after a failed tool`, which asserts that a failed `exec` result produces an error payload after exactly one embedded-agent attempt.
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/terminal-retry-state.test.ts`: **2/2 passed**.
- `oxfmt --check` passed on all three changed files; `git diff --check` passed.
- The focused `run.incomplete-turn.test.ts` agent shard was started on Windows/Node 26 but exceeded a five-minute local process allowance without producing a Vitest verdict. It was terminated; this is not claimed as a pass and should be rerun by CI.

### Prior branch behavior evidence

1. A local vLLM backend recycle severed an active OpenAI-compatible stream with `UND_ERR_SOCKET` / `terminated`. The session ended with `stopReason: error`, but terminal resolution reported success because earlier assistant fragments existed.
2. A permissions-check turn repeatedly stopped at progress sentences. The follow-through hook rejected them, but hook retry normalization silently converted the exhausted `revise` decision to `continue`, allowing the unfinished sentence to be accepted as success.
3. A command could finish just before exec's yield transition; `markExited()` removed the foreground record, then `markBackgrounded()` could no longer retain it, causing a false `Tool process not found` result.

The earlier branch validation covered the stream-recovery, process-race, hook-normalization, and TypeScript paths. This update deliberately does not run a live side-effecting tool canary: failed tools are now fail-closed rather than automatically retried.