### PR TITLE
fix(ui): add empty sidebar drop targets

### DIFF
--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -4224,6 +4224,8 @@ export const en: TranslationMap = {
       detail: "Details",
       close: "Close {panel}",
       drag: "Drag {panel}",
+      dropOnEmptyLeft: "Move {panel} to the empty left sidebar",
+      dropOnEmptyRight: "Move {panel} to the empty right sidebar",
       resize: "Resize {panel}",
     },
     thread: {

--- a/ui/src/pages/chat/components/chat-sidebar-region.runtime.ts
+++ b/ui/src/pages/chat/components/chat-sidebar-region.runtime.ts
@@ -62,8 +62,9 @@ class ChatSidebarRegion extends OpenClawLightDomElement {
     this.draggedPanelId = "";
   }
 
-  private draggedPanel(): string {
-    return this.draggedPanelId;
+  private draggedPanel(): SidebarPanel | undefined {
+    const panel = panelsOf(this.layout).find((candidate) => candidate.id === this.draggedPanelId);
+    return panel && this.canMutatePanel(panel.slot) ? panel : undefined;
   }
 
   private allowPanelDrop(event: DragEvent) {
@@ -77,8 +78,8 @@ class ChatSidebarRegion extends OpenClawLightDomElement {
   }
 
   private dropOnHeader(event: DragEvent, column: SidebarColumn) {
-    const panelId = this.draggedPanel();
-    if (!panelId) {
+    const draggedPanel = this.draggedPanel();
+    if (!draggedPanel) {
       return;
     }
     event.preventDefault();
@@ -96,7 +97,7 @@ class ChatSidebarRegion extends OpenClawLightDomElement {
       const zone = resolveSplitDropZone(rect, event.clientX, event.clientY);
       panelIndex = targetIndex + (zone.kind === "edge" && zone.edge === "left" ? 0 : 1);
     }
-    this.callbacks?.mergePanel(panelId, column.id, panelIndex);
+    this.callbacks?.mergePanel(draggedPanel.id, column.id, panelIndex);
     this.endDrag();
   }
 
@@ -106,8 +107,8 @@ class ChatSidebarRegion extends OpenClawLightDomElement {
     columnIndex: number,
     element: Element | undefined,
   ) {
-    const panelId = this.draggedPanel();
-    if (!panelId || !(element instanceof HTMLElement)) {
+    const panel = this.draggedPanel();
+    if (!panel || !(element instanceof HTMLElement)) {
       return;
     }
     const rect = element.getBoundingClientRect();
@@ -116,7 +117,7 @@ class ChatSidebarRegion extends OpenClawLightDomElement {
       return;
     }
     event.preventDefault();
-    this.callbacks?.detachPanel(panelId, side, columnIndex);
+    this.callbacks?.detachPanel(panel.id, side, columnIndex);
     this.endDrag();
   }
 
@@ -126,6 +127,36 @@ class ChatSidebarRegion extends OpenClawLightDomElement {
 
   private canMutatePanel(slot: SidebarSlotId): boolean {
     return this.panelMutationEnabled[slot] !== false;
+  }
+
+  private renderEmptySideDropZone(side: SidebarSide) {
+    const panel = this.draggedPanel();
+    if (!panel || this.layout.columns.some((column) => column.side === side)) {
+      return nothing;
+    }
+    const label = t(
+      side === "left"
+        ? "chat.sidebarColumns.dropOnEmptyLeft"
+        : "chat.sidebarColumns.dropOnEmptyRight",
+      { panel: panelTitle(panel.slot) },
+    );
+    return html`<div
+      class="sidebar-empty-side-drop-zone sidebar-empty-side-drop-zone--${side}"
+      role="region"
+      aria-label=${label}
+      @dragover=${(event: DragEvent) => this.allowPanelDrop(event)}
+      @drop=${(event: DragEvent) =>
+        this.dropOnBoundary(
+          event,
+          side,
+          0,
+          (event.currentTarget as HTMLElement).querySelector(
+            ".sidebar-empty-side-drop-zone__boundary",
+          ) ?? undefined,
+        )}
+    >
+      <span class="sidebar-empty-side-drop-zone__boundary" aria-hidden="true"></span>
+    </div>`;
   }
 
   private renderHeader(column: SidebarColumn, activePanelId: string, narrow: boolean) {
@@ -387,11 +418,11 @@ class ChatSidebarRegion extends OpenClawLightDomElement {
     const left = this.layout.columns.filter((column) => column.side === "left");
     return html`${collapsed
       ? nothing
-      : left.map(
+      : html`${this.renderEmptySideDropZone("left")}${left.map(
           (column, index) => html`
             ${this.renderColumn(column)} ${this.renderDivider(column, "left", index + 1)}
           `,
-        )}`;
+        )}${this.renderEmptySideDropZone("right")}`}`;
   }
 }
 

--- a/ui/src/pages/chat/components/chat-sidebar-region.test.ts
+++ b/ui/src/pages/chat/components/chat-sidebar-region.test.ts
@@ -3,7 +3,12 @@
 import { html } from "lit";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import "../../../components/resizable-divider.ts";
-import { mergePanelIntoColumn, openSlot, type SidebarSlotId } from "../sidebar-layout.ts";
+import {
+  mergePanelIntoColumn,
+  openSlot,
+  type SidebarSide,
+  type SidebarSlotId,
+} from "../sidebar-layout.ts";
 import "./chat-sidebar-region.runtime.ts";
 
 type Region = HTMLElementTagNameMap["openclaw-chat-sidebar-region"] & {
@@ -51,6 +56,30 @@ async function createRegion(
 
 function regionRoot(region: Region): HTMLElement {
   return region.parentElement!;
+}
+
+function startPanelDrag(source: HTMLElement) {
+  const values = new Map<string, string>();
+  const dataTransfer = {
+    effectAllowed: "none",
+    dropEffect: "none",
+    getData: (type: string) => values.get(type) ?? "",
+    setData: (type: string, value: string) => values.set(type, value),
+  };
+  const start = new Event("dragstart", { bubbles: true }) as DragEvent;
+  Object.defineProperty(start, "dataTransfer", { value: dataTransfer });
+  source.dispatchEvent(start);
+  return dataTransfer;
+}
+
+function dropPanel(target: HTMLElement, dataTransfer: object, clientX: number) {
+  const drop = new Event("drop", { bubbles: true }) as DragEvent;
+  Object.defineProperties(drop, {
+    clientX: { value: clientX },
+    clientY: { value: 50 },
+    dataTransfer: { value: dataTransfer },
+  });
+  target.dispatchEvent(drop);
 }
 
 afterEach(() => {
@@ -191,6 +220,84 @@ describe("chat sidebar region", () => {
     expect(tab("Chat")?.draggable).toBe(true);
     expect(tab("Details")?.draggable).toBe(true);
     expect(tab("Discussion")?.draggable).toBe(true);
+  });
+
+  it.each([
+    { sourceSide: "left", targetSide: "right", boundaryX: 100, dropX: 124 },
+    { sourceSide: "right", targetSide: "left", boundaryX: 48, dropX: 24 },
+  ] satisfies Array<{
+    sourceSide: SidebarSide;
+    targetSide: SidebarSide;
+    boundaryX: number;
+    dropX: number;
+  }>)(
+    "detaches a panel into the empty $targetSide side at index zero",
+    async ({ sourceSide, targetSide, boundaryX, dropX }) => {
+      const region = await createRegion(false);
+      region.layout = openSlot({ columns: [] }, "detail", sourceSide);
+      await region.updateComplete;
+      const source = regionRoot(region).querySelector<HTMLElement>(".sidebar-column__tab")!;
+      const dataTransfer = startPanelDrag(source);
+      await region.updateComplete;
+      const target = regionRoot(region).querySelector<HTMLElement>(
+        `.sidebar-empty-side-drop-zone--${targetSide}`,
+      );
+      expect(target).not.toBeNull();
+      expect(target?.getAttribute("aria-label")).toBe(
+        `Move Details to the empty ${targetSide} sidebar`,
+      );
+      const boundary = target!.querySelector<HTMLElement>(
+        ".sidebar-empty-side-drop-zone__boundary",
+      )!;
+      boundary.getBoundingClientRect = () =>
+        ({ left: boundaryX, top: 0, width: 1, height: 100 }) as DOMRect;
+
+      dropPanel(target!, dataTransfer, dropX);
+
+      expect(region.callbacks?.detachPanel).toHaveBeenCalledWith(
+        region.layout.columns[0]?.panels[0]?.id,
+        targetSide,
+        0,
+      );
+    },
+  );
+
+  it("shows empty-side drop zones only for the lifetime of a panel drag", async () => {
+    const region = await createRegion(false);
+    region.layout = openSlot({ columns: [] }, "detail", "right");
+    await region.updateComplete;
+    const dropZones = () => regionRoot(region).querySelectorAll(".sidebar-empty-side-drop-zone");
+    const source = regionRoot(region).querySelector<HTMLElement>(".sidebar-column__tab")!;
+
+    expect(dropZones()).toHaveLength(0);
+    startPanelDrag(source);
+    await region.updateComplete;
+    expect(dropZones()).toHaveLength(1);
+
+    source.dispatchEvent(new Event("dragend", { bubbles: true }));
+    await region.updateComplete;
+    expect(dropZones()).toHaveLength(0);
+  });
+
+  it("removes the empty-side target when Chat mutation becomes unavailable", async () => {
+    const region = await createRegion(false, { chat: true });
+    region.layout = openSlot({ columns: [] }, "chat", "right");
+    await region.updateComplete;
+    const source = regionRoot(region).querySelector<HTMLElement>(".sidebar-column__tab")!;
+    const dataTransfer = startPanelDrag(source);
+    await region.updateComplete;
+    const target = regionRoot(region).querySelector<HTMLElement>(
+      ".sidebar-empty-side-drop-zone--left",
+    );
+    expect(target).not.toBeNull();
+
+    region.panelMutationEnabled = { chat: false };
+    await region.updateComplete;
+    expect(regionRoot(region).querySelector(".sidebar-empty-side-drop-zone--left")).toBeNull();
+    const boundary = target!.querySelector<HTMLElement>(".sidebar-empty-side-drop-zone__boundary")!;
+    boundary.getBoundingClientRect = () => ({ left: 48, top: 0, width: 1, height: 100 }) as DOMRect;
+    dropPanel(target!, dataTransfer, 24);
+    expect(region.callbacks?.detachPanel).not.toHaveBeenCalled();
   });
 
   it("routes boundary drops through the detach callback", async () => {

--- a/ui/src/styles/chat/sidebar.css
+++ b/ui/src/styles/chat/sidebar.css
@@ -333,6 +333,39 @@ openclaw-chat-sidebar-region,
   z-index: 2;
 }
 
+.sidebar-empty-side-drop-zone {
+  position: absolute;
+  z-index: 3;
+  top: 0;
+  bottom: 0;
+  width: 48px;
+  background: color-mix(in srgb, var(--accent) 14%, transparent);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 60%, transparent);
+}
+
+.sidebar-empty-side-drop-zone--left {
+  left: 0;
+}
+
+.sidebar-empty-side-drop-zone--right {
+  right: 0;
+}
+
+.sidebar-empty-side-drop-zone__boundary {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 1px;
+}
+
+.sidebar-empty-side-drop-zone--left .sidebar-empty-side-drop-zone__boundary {
+  right: 0;
+}
+
+.sidebar-empty-side-drop-zone--right .sidebar-empty-side-drop-zone__boundary {
+  left: 0;
+}
+
 .sidebar-region--narrow {
   display: grid;
   grid-template-columns: minmax(0, 1fr);


### PR DESCRIPTION
## What Problem This Solves

The flexible chat sidebar layout could move a panel between existing columns, but it had no drop target when the opposite side contained no columns. That made the model-supported cross-side move unreachable from the UI for left-only and right-only layouts.

## Why This Change Was Made

This follows #113712 and reuses the Chat mutation capability introduced by #113947. During an eligible wide-layout panel drag, the region now renders an absolutely positioned target at each empty primary edge. A valid drop routes through the existing split-zone resolver and calls the existing detach callback at side index zero. The targets consume no flex space, disappear when the drag ends, and are withheld when the dragged panel cannot mutate.

The sidebar layout model, slot ranks, default widths, and detach semantics are unchanged.

## User Impact

Users can drag the first sidebar panel across the primary chat surface to create the first column on the empty opposite side. Idle layouts gain no permanent chrome, narrow layouts remain non-draggable, and read-only Chat panels do not expose the move.

## Evidence

- Red-before-green: both left-to-right and right-to-left empty-side detach cases failed before the runtime change because the target was absent; the drag-lifetime case failed because no target appeared; and the Chat-gating case failed at its mutation-enabled control because the target was absent. The unchanged runtime had 4 focused failures and 16 passes.
- `node scripts/run-vitest.mjs ui/src/pages/chat/components/chat-sidebar-region.test.ts`: 20 tests passed on the final pushed head.
- `node scripts/run-vitest.mjs ui/src/pages/chat`: 78 files passed, 1 skipped; 1,878 tests passed, 9 skipped.
- `pnpm ui:i18n:baseline`: raw-copy baseline entries 106; English source keys 4,023. No baseline or foreign-locale file changed.
- `node scripts/check-changed.mjs`: green on Blacksmith Testbox `tbx_01kye6veb1q89dxc0qk0qspk9w`; formatting, i18n verification, core/UI test types, and all lint shards passed. Actions run: https://github.com/openclaw/openclaw/actions/runs/30185937625
- Codex autoreview: clean in branch mode against `origin/main`; no accepted/actionable findings.
- Existing-Chrome proof of the real component verified idle, active-drag, and non-mutable Chat states. A sanitized screenshot and accessibility observations are attached in a PR comment.
