### PR TITLE
fix(release): ClawHub CLI materialization fails on npm 12

### DIFF
--- a/scripts/materialize-clawhub-cli.sh
+++ b/scripts/materialize-clawhub-cli.sh
@@ -38,12 +38,16 @@ clawhub_integrity="$(
   exit 1
 }
 
-npm ci \
-  --prefix "${destination}" \
-  --ignore-scripts \
-  --no-audit \
-  --no-fund \
-  --omit=dev
+# npm 12 misvalidates the lockfile root when this project is selected with --prefix.
+# Running inside the copied project keeps its committed root metadata authoritative.
+(
+  cd "${destination}"
+  npm ci \
+    --ignore-scripts \
+    --no-audit \
+    --no-fund \
+    --omit=dev
+)
 
 clawhub_version="$(
   CLAWHUB_CLI_ROOT="${destination}" \

--- a/test/scripts/plugin-clawhub-new-workflow.test.ts
+++ b/test/scripts/plugin-clawhub-new-workflow.test.ts
@@ -334,6 +334,8 @@ describe("Plugin ClawHub New workflow", () => {
       version: "0.23.1",
     });
     expect(materializerSource).toContain("npm ci");
+    expect(materializerSource).toContain('cd "${destination}"');
+    expect(materializerSource).not.toContain('--prefix "${destination}"');
     expect(materializerSource).toContain("--ignore-scripts");
     expect(materializerSource).toContain("--omit=dev");
     expect(materializerSource).toContain(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where OpenClaw release automation could not materialize its pinned ClawHub CLI when the workflow ran with npm 12. The clean install rejected the committed package lock as missing a synthetic destination-root package.

## Why This Change Was Made

The materializer now runs `npm ci` with the copied destination project as its working directory instead of selecting it through `--prefix`. The pinned lock SHA-256, ClawHub package integrity, version, lifecycle-script suppression, and absolute CLI path checks remain unchanged.

## User Impact

Release operators can run the pinned ClawHub materializer on Node 26 with npm 12 without regenerating or weakening the committed lockfile. There is no change to the selected ClawHub version or package graph.

## Evidence

- Reproduced before the fix on Node 26.5.0 and npm 12.0.1: `npm ci` failed with `Missing: clawhub-cli@1.0.0 from lock file`.
- Re-ran the complete script after the fix on Node 26.5.0 and npm 12.0.1: it installed ClawHub CLI 0.23.1 and emitted the unchanged lock SHA-256 and package integrity.
- Focused Testbox proof: 11/11 tests passed in `test/scripts/plugin-clawhub-new-workflow.test.ts`.
- `pnpm check:changed` passed on Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/30187019919
- Codex autoreview reported no accepted or actionable findings.
