### PR TITLE
fix(slack): resolve thread freshness owner

### DIFF
--- a/extensions/slack/src/monitor/message-handler/prepare-thread-context.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare-thread-context.ts
@@ -1,4 +1,5 @@
 // Slack plugin module implements prepare thread context behavior.
+import { resolveDefaultAgentId } from "openclaw/plugin-sdk/agent-runtime";
 import {
   formatInboundEnvelope,
   resolveInboundSupplementalSenderAllowed,
@@ -49,6 +50,7 @@ type SlackSessionResetFreshness = {
 type SlackSessionFreshnessRuntime = {
   session?: {
     resolveEntryResetFreshness?: (params: {
+      defaultAgentId?: string;
       storePath?: string;
       sessionKey: string;
       sessionCfg?: OpenClawConfig["session"];
@@ -67,6 +69,7 @@ function resolveSlackThreadSessionFreshness(params: {
   // intentionally keeps non-context helpers untyped for external plugins.
   const runtime = params.ctx.channelRuntime as SlackSessionFreshnessRuntime | undefined;
   return runtime?.session?.resolveEntryResetFreshness?.({
+    defaultAgentId: resolveDefaultAgentId(params.ctx.cfg),
     storePath: params.storePath,
     sessionKey: params.sessionKey,
     sessionCfg: params.ctx.cfg.session,

--- a/src/config/sessions/entry-freshness.test.ts
+++ b/src/config/sessions/entry-freshness.test.ts
@@ -43,6 +43,32 @@ describe("resolveSessionEntryResetFreshness", () => {
     });
   });
 
+  it("uses the configured default agent for an unqualified session key", async () => {
+    const sessionKey = "global";
+    const now = new Date("2026-01-02T12:00:00Z").getTime();
+    await upsertSessionEntry(
+      { agentId: "ops", defaultAgentId: "ops", sessionKey, storePath },
+      {
+        sessionId: "session-global-ops",
+        updatedAt: now,
+        sessionStartedAt: now,
+        lastInteractionAt: now,
+      },
+    );
+
+    const result = resolveSessionEntryResetFreshness({
+      defaultAgentId: "ops",
+      sessionKey,
+      storePath,
+      sessionCfg: {},
+      resetType: "direct",
+      now,
+    });
+
+    expect(result.state).toBe("fresh");
+    expect(result.entry?.sessionId).toBe("session-global-ops");
+  });
+
   it("resolves stale daily freshness from lifecycle timestamps instead of activity", async () => {
     const sessionKey = "agent:main:main:thread:100.000";
     const now = new Date("2026-01-02T12:00:00Z").getTime();

--- a/src/config/sessions/entry-freshness.ts
+++ b/src/config/sessions/entry-freshness.ts
@@ -54,7 +54,8 @@ export function hasProviderOwnedSession(entry: SessionEntry | undefined): boolea
 export function resolveSessionEntryResetFreshness(
   params: ResolveSessionEntryResetFreshnessParams,
 ): ResolvedSessionEntryResetFreshness {
-  const agentId = params.agentId ?? resolveAgentIdFromSessionKey(params.sessionKey);
+  const agentId =
+    params.agentId ?? resolveAgentIdFromSessionKey(params.sessionKey, params.defaultAgentId);
   const sessionCfg = params.sessionCfg;
   const storePath =
     params.storePath ??


### PR DESCRIPTION
Related: #112678

## What Problem This Solves

Fixes an issue where Slack thread-context preparation could fail for global or legacy unqualified session keys after session ownership resolution became strict.

## Why This Change Was Made

The shared session freshness helper now honors the `defaultAgentId` already carried by its access scope, and Slack supplies the configured default from its runtime config. Agent-qualified keys continue to retain their encoded owner.

## User Impact

Slack threads using legacy or global session aliases can seed and refresh thread context under the configured default agent instead of failing before history preparation.

## Evidence

- Release failure: https://github.com/openclaw/openclaw/actions/runs/30186809481/job/89752923863
- `node scripts/run-vitest.mjs src/config/sessions/entry-freshness.test.ts extensions/slack/src/monitor/message-handler/prepare-thread-context.test.ts` passed 23 tests.
- `tsgo -b extensions/slack/tsconfig.json --pretty false`
- `git diff --check`
- Autoreview: clean, no accepted/actionable findings
