### PR TITLE
fix(gateway): suppress ambient plugins before auto-enable

### DIFF
--- a/src/gateway/server-startup-bootstrap.ts
+++ b/src/gateway/server-startup-bootstrap.ts
@@ -152,6 +152,7 @@ export async function prepareGatewayServerBootstrap(input: {
       minimalTestGateway,
       log,
       measure: (name, run) => startupTrace.measure(name, run),
+      ambientEnvTriggers,
       ...(opts.startupConfigSnapshotRead
         ? { initialSnapshotRead: opts.startupConfigSnapshotRead }
         : {}),

--- a/src/gateway/server-startup-config-helpers.ts
+++ b/src/gateway/server-startup-config-helpers.ts
@@ -1,4 +1,5 @@
 // Shared validation, auth-surface, and config-load helpers for Gateway startup.
+import type { AmbientEnvTriggerPolicy } from "../channels/config-presence.js";
 import {
   formatInvalidConfigRecoveryHint,
   formatPluginPackagingRuntimeOutputRecoveryHint,
@@ -81,6 +82,7 @@ export async function loadGatewayStartupConfigSnapshot(params: {
   log: GatewayStartupLog;
   measure?: GatewayStartupConfigMeasure;
   initialSnapshotRead?: ReadConfigFileSnapshotWithPluginMetadataResult;
+  ambientEnvTriggers?: AmbientEnvTriggerPolicy;
 }): Promise<GatewayStartupConfigSnapshotLoadResult> {
   const measure = params.measure ?? (async (_name, run) => await run());
   const snapshotRead =
@@ -112,6 +114,9 @@ export async function loadGatewayStartupConfigSnapshot(params: {
             ? { manifestRegistry: pluginMetadataSnapshot.manifestRegistry }
             : {}),
           discovery: pluginMetadataSnapshot?.discovery,
+          ...(params.ambientEnvTriggers !== undefined
+            ? { ambientEnvTriggers: params.ambientEnvTriggers }
+            : {}),
         }),
       );
   if (autoEnable.changes.length === 0) {

--- a/src/gateway/server-startup-config.recovery.test.ts
+++ b/src/gateway/server-startup-config.recovery.test.ts
@@ -264,6 +264,7 @@ function testStartupLog() {
 function loadTestStartup(params: {
   minimalTestGateway?: boolean;
   log?: ReturnType<typeof testStartupLog>;
+  ambientEnvTriggers?: "allow" | "suppress";
   initialSnapshotRead?: Parameters<
     typeof loadGatewayStartupConfigSnapshot
   >[0]["initialSnapshotRead"];
@@ -272,6 +273,9 @@ function loadTestStartup(params: {
     minimalTestGateway: params.minimalTestGateway ?? true,
     log: params.log ?? testStartupLog(),
     initialSnapshotRead: params.initialSnapshotRead,
+    ...(params.ambientEnvTriggers !== undefined
+      ? { ambientEnvTriggers: params.ambientEnvTriggers }
+      : {}),
   });
 }
 
@@ -358,6 +362,23 @@ describe("gateway startup config validation", () => {
     expectPluginAutoEnableFor(sourceConfig);
     expect(configMutate.replaceConfigFile).not.toHaveBeenCalled();
     expect(log.info).not.toHaveBeenCalled();
+  });
+
+  it("suppresses ambient channel auto-enable during the initial dev startup snapshot", async () => {
+    const snapshot = buildRuntimeSnapshot(validConfig);
+    mockStartupSnapshot(snapshot);
+
+    await loadTestStartup({
+      minimalTestGateway: false,
+      ambientEnvTriggers: "suppress",
+    });
+
+    expect(applyPluginAutoEnable).toHaveBeenCalledWith({
+      config: validConfig,
+      env: process.env,
+      manifestRegistry: pluginManifestRegistry,
+      ambientEnvTriggers: "suppress",
+    });
   });
 
   it("reuses a CLI preflight snapshot without rereading config", async () => {


### PR DESCRIPTION
## What Problem This Solves

A dev gateway promises to suppress ambient channel credentials unless `--dev-ambient-channels` is explicitly set. The initial config snapshot nevertheless auto-enabled Telegram from `TELEGRAM_BOT_TOKEN` before the suppression-aware plugin bootstrap ran. That converted env-only presence into runtime plugin config, so Telegram started, made a real `getMe` call, and entered its restart loop.

## Summary

- pass the dev ambient-channel policy into the initial gateway config snapshot load
- prevent env-only channel credentials from auto-enabling plugins before suppression is computed
- add a regression test for the earliest startup stage

## Evidence

- independently reproduced three times with an empty synthetic HOME and a fake Telegram token, including canonical `gateway run --dev` syntax
- before the fix, startup logged `Telegram configured, enabled automatically`, then attempted `getMe`, received 401, and scheduled channel restarts
- `node scripts/run-vitest.mjs src/gateway/server-startup-config.recovery.test.ts` — 13/13 passed
- `node scripts/run-vitest.mjs src/gateway/server-startup-plugins.test.ts src/gateway/server-channels.test.ts` — 74/74 passed
- `oxfmt --check` — passed
- `oxlint` — 0 warnings/errors

## Root Cause

`loadGatewayStartupConfigSnapshot` called `applyPluginAutoEnable` without `ambientEnvTriggers`. The later presence check could no longer classify Telegram as ambient-only after runtime auto-enable.

No Plugin SDK boundary changes.