### PR TITLE
test(plugins): isolate policy fixtures from checkout modes

### DIFF
--- a/src/plugins/install.test.ts
+++ b/src/plugins/install.test.ts
@@ -1,6 +1,7 @@
 // Covers plugin install flows, manifests, and install records.
 import fs from "node:fs";
 import fsPromises from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -76,7 +77,7 @@ const archiveFixturePathCache = new Map<string, string>();
 const dynamicArchiveTemplatePathCache = new Map<string, string>();
 let installPluginFromDirTemplateDir = "";
 let manifestInstallTemplateDir = "";
-const suiteTempRootTracker = createSuiteTempRootTracker("openclaw-plugin-install");
+const suiteTempRootTracker = createSuiteTempRootTracker("openclaw-plugin-install", os.tmpdir());
 const setupBundleInstallFixture = createBundleInstallFixtureFactory(
   suiteTempRootTracker.makeTempDir,
 );


### PR DESCRIPTION
## What Problem This Solves

Plugin installer policy tests currently depend on repository ancestor permissions. In a group-writable checkout, the security scanner correctly rejects policy fixtures below the repository `.tmp` directory before the intended policy behavior runs, producing unrelated test failures.

## Summary

- place plugin installer temp fixtures under the OS temp directory
- keep security-sensitive policy scripts independent of checkout ancestor permissions

## Evidence

- before the fix, ten assertions received `SECURITY_SCAN_FAILED` because the checkout and `.tmp` ancestors were mode 0775
- after the fix, `node scripts/run-vitest.mjs src/plugins/install.test.ts` passed 104/104
- `oxfmt --check src/plugins/install.test.ts` — passed
- `oxlint src/plugins/install.test.ts` — 0 warnings/errors
- the separate lifecycle-lease candidate passed 5/5 on rerun and was rejected as transient

## Root Cause

`createSuiteTempRootTracker("openclaw-plugin-install")` used the repository `.tmp` root. Security-sensitive policy fixtures therefore inherited unrelated checkout ancestry. Using `os.tmpdir()` preserves production scanner behavior while isolating the tests.

This changes test isolation only; installer runtime and Plugin SDK boundaries are untouched.