### PR TITLE
fix(policy): config coverage fails after auth retirement

### DIFF
--- a/docs/cli/policy.md
+++ b/docs/cli/policy.md
@@ -365,17 +365,17 @@ private messages.
 
 #### Gateway
 
-| Policy field                            | Observed state                                 | Use when                                                                             |
-| --------------------------------------- | ---------------------------------------------- | ------------------------------------------------------------------------------------ |
-| `gateway.exposure.allowNonLoopbackBind` | `gateway.bind`                                 | Set to `false` to require loopback Gateway binding.                                  |
-| `gateway.exposure.allowTailscaleFunnel` | Tailscale serve/funnel Gateway posture         | Set to `false` to deny Tailscale Funnel exposure.                                    |
-| `gateway.auth.requireAuth`              | `gateway.auth.mode`                            | Set to `true` to reject disabled Gateway auth.                                       |
-| `gateway.auth.requireExplicitRateLimit` | `gateway.auth.rateLimit`                       | Set to `true` to require explicit auth rate-limit config.                            |
-| `gateway.controlUi.allowInsecure`       | Control UI insecure auth/device/origin toggles | Set to `false` to deny insecure Control UI exposure toggles.                         |
-| `gateway.remote.allow`                  | Remote Gateway mode/config                     | Set to `false` to deny remote Gateway mode.                                          |
-| `gateway.http.denyEndpoints`            | Gateway HTTP API endpoints                     | Deny endpoint ids such as `chatCompletions` or `responses`.                          |
-| `gateway.http.requireUrlAllowlists`     | Gateway HTTP URL-fetch inputs                  | Set to `true` to require URL allowlists on URL-fetch inputs.                         |
-| `gateway.nodes.denyCommands`            | `gateway.nodes.commands.deny`                  | Require exact node command ids such as `system.run` to be denied in OpenClaw config. |
+| Policy field                            | Observed state                                | Use when                                                                             |
+| --------------------------------------- | --------------------------------------------- | ------------------------------------------------------------------------------------ |
+| `gateway.exposure.allowNonLoopbackBind` | `gateway.bind`                                | Set to `false` to require loopback Gateway binding.                                  |
+| `gateway.exposure.allowTailscaleFunnel` | Tailscale serve/funnel Gateway posture        | Set to `false` to deny Tailscale Funnel exposure.                                    |
+| `gateway.auth.requireAuth`              | `gateway.auth.mode`                           | Set to `true` to reject disabled Gateway auth.                                       |
+| `gateway.auth.requireExplicitRateLimit` | `gateway.auth.rateLimit`                      | Set to `true` to require explicit auth rate-limit config.                            |
+| `gateway.controlUi.allowInsecure`       | Device-identity invariant and origin fallback | Set to `false` to require device identity and deny Host-header origin fallback.      |
+| `gateway.remote.allow`                  | Remote Gateway mode/config                    | Set to `false` to deny remote Gateway mode.                                          |
+| `gateway.http.denyEndpoints`            | Gateway HTTP API endpoints                    | Deny endpoint ids such as `chatCompletions` or `responses`.                          |
+| `gateway.http.requireUrlAllowlists`     | Gateway HTTP URL-fetch inputs                 | Set to `true` to require URL allowlists on URL-fetch inputs.                         |
+| `gateway.nodes.denyCommands`            | `gateway.nodes.commands.deny`                 | Require exact node command ids such as `system.run` to be denied in OpenClaw config. |
 
 `gateway.nodes.denyCommands` is an exact, case-sensitive policy deny-superset rule.
 Use it when policy must prove that privileged node commands are explicitly

--- a/extensions/policy/src/doctor/automatic-repairs.ts
+++ b/extensions/policy/src/doctor/automatic-repairs.ts
@@ -177,7 +177,6 @@ function disableInsecureControlUi(
   const controlUi = ensureRecord(gateway, "controlUi");
   const changes: string[] = [];
   const fields = [
-    ["allowInsecureAuth", "oc://openclaw.config/gateway/controlUi/allowInsecureAuth"],
     [
       "dangerouslyDisableDeviceAuth",
       "oc://openclaw.config/gateway/controlUi/dangerouslyDisableDeviceAuth",

--- a/scripts/lib/policy-config-coverage.jsonc
+++ b/scripts/lib/policy-config-coverage.jsonc
@@ -18,7 +18,6 @@
     "gateway.auth.mode",
     "gateway.auth.rateLimit.*",
     "gateway.bind",
-    "gateway.controlUi.allowInsecureAuth",
     "gateway.controlUi.dangerouslyAllowHostHeaderOriginFallback",
     "gateway.controlUi.dangerouslyDisableDeviceAuth",
     "gateway.customBindHost",
@@ -341,13 +340,6 @@
       "area": "gateway",
       "policy": "gateway.auth.requireExplicitRateLimit",
       "reason": "Policy observes whether Gateway auth rate limiting is explicitly configured.",
-    },
-    {
-      "pattern": "gateway.controlUi.allowInsecureAuth",
-      "status": "observed",
-      "area": "gateway",
-      "policy": "gateway.controlUi.allowInsecure",
-      "reason": "Policy observes the Control UI insecure auth toggle.",
     },
     {
       "pattern": "gateway.controlUi.dangerouslyDisableDeviceAuth",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where maintainers running `pnpm policy:config-coverage` on current `main` received `ok: false` because the coverage manifest still tracked the retired `gateway.controlUi.allowInsecureAuth` key.

## Why This Change Was Made

The stale monitored pattern, classification, and unreachable automatic-repair target are removed because the config schema now rejects this key. The Policy docs now describe the surviving contract accurately: Control UI device identity is a runtime invariant, while the remaining configurable insecure posture is Host-header origin fallback.

## User Impact

There is no runtime behavior change. Maintainers get a clean policy config-coverage report, and Policy users no longer see documentation implying that insecure Control UI auth remains configurable.

## Evidence

- Before: `node --import tsx scripts/check-policy-config-coverage.ts --json` reported the key in both `unmatchedMonitored` and `stale` with `ok: false`.
- After: the same command reports `ok: true`, with empty `unclassified`, `unmatchedMonitored`, and `stale` arrays.
- `node scripts/run-vitest.mjs extensions/policy/src/doctor/register.test.ts` — 296 passed.
- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs src/config/dead-config-keys.test.ts` — 215 passed.
- Targeted Oxfmt check and `git diff --check` pass.
- Codex autoreview: clean, no accepted/actionable findings.

AI-assisted; implementation and current config-contract behavior verified against the schema, dead-key regression, policy scanner, and focused tests.
