### PR TITLE
fix(cerebras): prefer current Gemma 4 onboarding default

### DIFF
--- a/docs/providers/cerebras.md
+++ b/docs/providers/cerebras.md
@@ -17,7 +17,7 @@ read_when:
 | Direct CLI flag | `--cerebras-api-key <key>`                                |
 | API             | OpenAI-compatible (`openai-completions`)                  |
 | Base URL        | `https://api.cerebras.ai/v1`                              |
-| Default model   | `cerebras/gpt-oss-120b`                                   |
+| Default model   | `cerebras/gemma-4-31b`                                    |
 
 ## Install plugin
 
@@ -78,8 +78,10 @@ All three models have a 131,072-token context window and a 40,960-token max outp
 | Model ref               | Name         | Reasoning | Notes                                     |
 | ----------------------- | ------------ | --------- | ----------------------------------------- |
 | `cerebras/zai-glm-4.7`  | Z.ai GLM 4.7 | yes       | Scheduled for deprecation August 17, 2026 |
-| `cerebras/gpt-oss-120b` | GPT OSS 120B | yes       | Default production reasoning model        |
-| `cerebras/gemma-4-31b`  | Gemma 4 31B  | yes       | Preview; text-and-image input             |
+| `cerebras/gpt-oss-120b` | GPT OSS 120B | yes       | Production reasoning model                |
+| `cerebras/gemma-4-31b`  | Gemma 4 31B  | yes       | Default; preview; text-and-image input    |
+
+Fresh onboarding follows Cerebras's current [Gemma 4 recommendation](https://www.cerebras.ai/blog/gemma-4-on-cerebras-the-fastest-inference-is-now-multimodal). Cerebras describes Gemma 4 31B as its reference medium-size model for equal-or-higher intelligence than GPT OSS, with multimodal agentic support. It is a public-preview model and may change or be discontinued on shorter notice than the production GPT OSS endpoint; existing OpenClaw configurations keep their selected model.
 
 ## Manual config
 
@@ -90,7 +92,7 @@ Most setups only need the API key. Use explicit `models.providers.cerebras` conf
   env: { CEREBRAS_API_KEY: "csk-..." },
   agents: {
     defaults: {
-      model: { primary: "cerebras/gpt-oss-120b" },
+      model: { primary: "cerebras/gemma-4-31b" },
     },
   },
   models: {

--- a/extensions/cerebras/index.ts
+++ b/extensions/cerebras/index.ts
@@ -24,6 +24,7 @@ export default defineSingleProviderPluginEntry({
         envVar: "CEREBRAS_API_KEY",
         promptMessage: "Enter Cerebras API key",
         defaultModel: CEREBRAS_DEFAULT_MODEL_REF,
+        preserveExistingPrimary: true,
         applyConfig: (cfg) => applyCerebrasConfig(cfg),
         noteMessage: [
           "Cerebras provides high-speed OpenAI-compatible inference for GPT OSS and GLM models.",

--- a/extensions/cerebras/onboard.test.ts
+++ b/extensions/cerebras/onboard.test.ts
@@ -14,7 +14,7 @@ describe("Cerebras onboarding", () => {
       CEREBRAS_DEFAULT_MODEL_REF,
     );
     expect(config.agents?.defaults?.models).toEqual({
-      [CEREBRAS_DEFAULT_MODEL_REF]: { alias: "Cerebras GPT OSS 120B" },
+      [CEREBRAS_DEFAULT_MODEL_REF]: { alias: "Cerebras Gemma 4 31B" },
     });
   });
 });

--- a/extensions/cerebras/onboard.test.ts
+++ b/extensions/cerebras/onboard.test.ts
@@ -1,5 +1,7 @@
+import { registerSingleProviderPlugin } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { resolveAgentModelPrimaryValue } from "openclaw/plugin-sdk/provider-onboard";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import plugin from "./index.js";
 import { applyCerebrasConfig, CEREBRAS_DEFAULT_MODEL_REF } from "./onboard.js";
 import manifest from "./openclaw.plugin.json" with { type: "json" };
 
@@ -14,6 +16,38 @@ describe("Cerebras onboarding", () => {
       CEREBRAS_DEFAULT_MODEL_REF,
     );
     expect(config.agents?.defaults?.models).toEqual({
+      [CEREBRAS_DEFAULT_MODEL_REF]: { alias: "Cerebras Gemma 4 31B" },
+    });
+  });
+
+  it("preserves an existing primary during non-interactive auth setup", async () => {
+    const provider = await registerSingleProviderPlugin(plugin);
+    const method = provider.auth?.[0];
+    if (!method?.runNonInteractive) {
+      throw new Error("expected Cerebras non-interactive auth method");
+    }
+
+    const result = await method.runNonInteractive({
+      authChoice: "cerebras-api-key",
+      config: {
+        agents: {
+          defaults: {
+            model: { primary: "anthropic/claude-sonnet-4-6" },
+            models: { "anthropic/claude-sonnet-4-6": { alias: "Existing" } },
+          },
+        },
+      },
+      opts: {},
+      runtime: { error: vi.fn(), exit: vi.fn(), log: vi.fn() },
+      resolveApiKey: vi.fn(async () => ({ key: "fixture-value", source: "profile" })),
+      toApiKeyCredential: vi.fn(() => null),
+    } as never);
+
+    expect(resolveAgentModelPrimaryValue(result?.agents?.defaults?.model)).toBe(
+      "anthropic/claude-sonnet-4-6",
+    );
+    expect(result?.agents?.defaults?.models).toEqual({
+      "anthropic/claude-sonnet-4-6": { alias: "Existing" },
       [CEREBRAS_DEFAULT_MODEL_REF]: { alias: "Cerebras Gemma 4 31B" },
     });
   });

--- a/extensions/cerebras/onboard.ts
+++ b/extensions/cerebras/onboard.ts
@@ -18,7 +18,7 @@ const cerebrasPresetAppliers = createModelCatalogPresetAppliers({
     api: "openai-completions",
     baseUrl: CEREBRAS_BASE_URL,
     catalogModels: buildCerebrasCatalogModels(),
-    aliases: [{ modelRef: CEREBRAS_DEFAULT_MODEL_REF, alias: "Cerebras GPT OSS 120B" }],
+    aliases: [{ modelRef: CEREBRAS_DEFAULT_MODEL_REF, alias: "Cerebras Gemma 4 31B" }],
   }),
 });
 

--- a/extensions/cerebras/openclaw.plugin.json
+++ b/extensions/cerebras/openclaw.plugin.json
@@ -23,7 +23,7 @@
       "cerebras": {
         "baseUrl": "https://api.cerebras.ai/v1",
         "api": "openai-completions",
-        "defaultModel": "gpt-oss-120b",
+        "defaultModel": "gemma-4-31b",
         "models": [
           {
             "id": "zai-glm-4.7",


### PR DESCRIPTION
Related: #113870, #113973

## What Problem This Solves

Fixes an issue where fresh Cerebras setup selects the older GPT OSS 120B production endpoint even though Cerebras now recommends Gemma 4 31B as its current reference model for equal-or-higher intelligence, multimodal input, and agentic workflows.

## Why This Change Was Made

Set the manifest-owned Cerebras default to the existing curated `gemma-4-31b` row and keep the onboarding alias, regression tests, and provider guide aligned. Non-interactive Cerebras auth now explicitly preserves an existing primary model, keeping this a fresh/defaultless-setup change. The other provider defaults were rechecked against current vendor sources; no stronger in-catalog replacement was found for them.

## User Impact

Fresh Cerebras onboarding now selects `cerebras/gemma-4-31b`. Existing configurations keep their selected model while registering Gemma as an available Cerebras choice. Gemma 4 is a public-preview endpoint, so the provider guide explicitly notes that it has shorter availability guarantees than the production GPT OSS endpoint.

Maintainer decision: adopt the public-preview Gemma 4 tradeoff as the generic fresh Cerebras default because it is Cerebras's current recommended reference model and provides the stronger multimodal agent experience.

Release-note context: fresh Cerebras setups now default to the newer multimodal Gemma 4 31B model instead of GPT OSS 120B.

## Evidence

- Cerebras launched Gemma 4 31B on June 29, 2026 and explicitly recommends it as the reference medium-size model over GPT OSS for equal-or-higher intelligence: https://www.cerebras.ai/blog/gemma-4-on-cerebras-the-fastest-inference-is-now-multimodal
- Current public catalog and model contract confirm `gemma-4-31b`, multimodal input, agentic/tool use, preview status, and the existing manifest metadata: https://inference-docs.cerebras.ai/models/overview and https://inference-docs.cerebras.ai/models/gemma-4-31b
- Real CLI proof on Blacksmith Testbox `tbx_01kyeb9k6c3r0085c6bhym0psf`: an isolated non-interactive fresh onboarding wrote primary `cerebras/gemma-4-31b`, alias `Cerebras Gemma 4 31B`, and all three curated model IDs. Re-running the same actual CLI path against a config with primary `anthropic/claude-sonnet-4-6` preserved that primary and added the Cerebras Gemma alias. The fixture key and temporary state were non-secret and deleted after the run.
- Blacksmith Testbox `tbx_01kyeax2bt2dy8e6xe5vev511n`: two focused onboarding regressions and the full `check:changed` plan passed, including docs formatting, extension/test typechecks, extension lint, and boundary guards.
- Autoreview (Codex, gpt-5.6-sol): clean after the compatibility fix; no accepted/actionable findings.
- `git diff --check` clean.

AI-assisted: yes.
