### PR TITLE
fix(state): preserve live SQLite WAL files during verification

### DIFF
--- a/src/state/openclaw-database-verify.impl.ts
+++ b/src/state/openclaw-database-verify.impl.ts
@@ -1,7 +1,7 @@
+import { fork, type ChildProcess } from "node:child_process";
 import { existsSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
-import { Worker } from "node:worker_threads";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
   confirmOpenClawAgentDatabaseIntegrity,
@@ -56,13 +56,18 @@ function isVerifyResult(value: unknown): value is OpenClawDatabaseVerifyResult {
 
 export function runDatabaseVerifyWorker(
   targets: readonly OpenClawDatabaseVerifyTarget[],
-  options: { onWorker?: (worker: Worker | undefined) => void; workerUrl?: URL } = {},
+  options: { onWorker?: (worker: ChildProcess | undefined) => void; workerUrl?: URL } = {},
 ): Promise<OpenClawDatabaseVerifyResult[]> {
   const workerUrl = options.workerUrl ?? resolveDatabaseVerifyWorkerUrl();
   const execArgv = workerUrl.pathname.endsWith(".ts") ? ["--import", "tsx"] : undefined;
-  let worker: Worker;
+  let worker: ChildProcess;
   try {
-    worker = new Worker(workerUrl, { workerData: targets, execArgv });
+    // Snapshot preparation opens and closes raw source descriptors. Isolate it
+    // because POSIX close() can release the Gateway's process-owned SQLite locks.
+    worker = fork(fileURLToPath(workerUrl), [], {
+      execArgv,
+      stdio: ["ignore", "ignore", "ignore", "ipc"],
+    });
   } catch (error) {
     return Promise.reject(toError(error));
   }
@@ -70,6 +75,10 @@ export function runDatabaseVerifyWorker(
 
   return new Promise((resolve, reject) => {
     let settled = false;
+    let result: OpenClawDatabaseVerifyResult[] | undefined;
+    let protocolError: Error | undefined;
+    let exit: { code: number | null; signal: NodeJS.Signals | null } | undefined;
+    let disconnected = !worker.connected;
     const settle = (finish: () => void) => {
       if (settled) {
         return;
@@ -79,23 +88,68 @@ export function runDatabaseVerifyWorker(
       options.onWorker?.(undefined);
       finish();
     };
-    worker.once("message", (message: unknown) => {
+    const settleAfterExitAndDisconnect = () => {
+      const completedExit = exit;
+      if (!completedExit || !disconnected) {
+        return;
+      }
       settle(() => {
-        if (!Array.isArray(message) || !message.every(isVerifyResult)) {
-          reject(new Error("database verification worker returned invalid results"));
-          return;
+        if (protocolError) {
+          reject(protocolError);
+        } else if (completedExit.code !== 0) {
+          reject(
+            new Error(
+              `database verification worker exited with ${
+                completedExit.signal
+                  ? `signal ${completedExit.signal}`
+                  : `code ${completedExit.code}`
+              }`,
+            ),
+          );
+        } else if (!result) {
+          reject(new Error("database verification worker exited without results"));
+        } else {
+          resolve(result);
         }
-        resolve(message);
       });
+    };
+    worker.once("message", (message: unknown) => {
+      if (!Array.isArray(message) || !message.every(isVerifyResult)) {
+        protocolError = new Error("database verification worker returned invalid results");
+        worker.kill();
+        return;
+      }
+      result = message;
     });
     worker.once("error", (error) => settle(() => reject(toError(error))));
-    worker.once("exit", (code) => {
-      if (code !== 0) {
-        settle(() => reject(new Error(`database verification worker exited with code ${code}`)));
-      } else {
-        settle(() => reject(new Error("database verification worker exited without results")));
-      }
+    worker.once("disconnect", () => {
+      disconnected = true;
+      settleAfterExitAndDisconnect();
     });
+    worker.once("exit", (code, signal) => {
+      exit = { code, signal };
+      disconnected ||= !worker.connected;
+      settleAfterExitAndDisconnect();
+    });
+    worker.send(targets, (error) => {
+      if (!error) {
+        return;
+      }
+      worker.kill();
+      settle(() => reject(toError(error)));
+    });
+  });
+}
+
+export async function terminateDatabaseVerifyWorker(worker: ChildProcess): Promise<void> {
+  if (worker.exitCode !== null || worker.signalCode !== null) {
+    return;
+  }
+  await new Promise<void>((resolve) => {
+    worker.once("exit", () => resolve());
+    if (!worker.kill()) {
+      resolve();
+    }
   });
 }
 

--- a/src/state/openclaw-database-verify.impl.ts
+++ b/src/state/openclaw-database-verify.impl.ts
@@ -23,6 +23,7 @@ export const OPENCLAW_DATABASE_VERIFY_INITIAL_DELAY_MS = 5 * 60_000;
 export const OPENCLAW_DATABASE_VERIFY_INTERVAL_MS = 24 * 60 * 60_000;
 
 const log = createSubsystemLogger("state/database-verify");
+const DATABASE_VERIFY_CHILD_ARG = "--openclaw-database-verify-child";
 
 function toError(error: unknown): Error {
   return error instanceof Error ? error : new Error(String(error));
@@ -64,7 +65,7 @@ export function runDatabaseVerifyWorker(
   try {
     // Snapshot preparation opens and closes raw source descriptors. Isolate it
     // because POSIX close() can release the Gateway's process-owned SQLite locks.
-    worker = fork(fileURLToPath(workerUrl), [], {
+    worker = fork(fileURLToPath(workerUrl), [DATABASE_VERIFY_CHILD_ARG], {
       execArgv,
       stdio: ["ignore", "ignore", "ignore", "ipc"],
     });

--- a/src/state/openclaw-database-verify.process.test.ts
+++ b/src/state/openclaw-database-verify.process.test.ts
@@ -1,0 +1,59 @@
+import { fork } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+async function importVerifierInUnrelatedFork(): Promise<unknown[]> {
+  const fixtureDir = tempDirs.make("openclaw-database-verify-process-");
+  const fixturePath = path.join(fixtureDir, "unrelated-child.mjs");
+  const verifierUrl = pathToFileURL(
+    path.resolve("src/state/openclaw-database-verify.worker.ts"),
+  ).href;
+  fs.writeFileSync(
+    fixturePath,
+    `
+      await import(${JSON.stringify(verifierUrl)});
+      process.once("message", (message) => {
+        process.send?.({ echo: message }, () => process.disconnect?.());
+      });
+    `,
+  );
+
+  const child = fork(fixturePath, [], {
+    execArgv: ["--import", "tsx"],
+    stdio: ["ignore", "ignore", "ignore", "ipc"],
+  });
+  return await new Promise((resolve, reject) => {
+    const messages: unknown[] = [];
+    const timer = setTimeout(() => {
+      child.kill();
+      reject(new Error("unrelated verifier import did not exit"));
+    }, 10_000);
+    child.on("message", (message: unknown) => messages.push(message));
+    child.once("error", (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+    child.once("exit", (code, signal) => {
+      clearTimeout(timer);
+      if (code === 0) {
+        resolve(messages);
+      } else {
+        reject(new Error(`unrelated verifier import exited with ${signal ?? code}`));
+      }
+    });
+    child.send({ type: "unrelated" });
+  });
+}
+
+describe("database verifier child process entrypoint", () => {
+  it("does not consume an unrelated fork's IPC messages", async () => {
+    await expect(importVerifierInUnrelatedFork()).resolves.toEqual([
+      { echo: { type: "unrelated" } },
+    ]);
+  });
+});

--- a/src/state/openclaw-database-verify.test.ts
+++ b/src/state/openclaw-database-verify.test.ts
@@ -102,6 +102,18 @@ function quarantineStorePath(stateDir: string): string {
   return path.join(stateDir, "state", "openclaw-quarantine.sqlite");
 }
 
+function readLinuxPosixLocksForPath(pathname: string): string[] {
+  if (process.platform !== "linux") {
+    return [];
+  }
+  const inode = fs.statSync(pathname, { bigint: true }).ino;
+  const lockInode = new RegExp(`\\b[0-9a-f]+:[0-9a-f]+:${inode}\\b`, "u");
+  return fs
+    .readFileSync("/proc/locks", "utf8")
+    .split("\n")
+    .filter((line) => line.includes(" POSIX ") && lockInode.test(line));
+}
+
 describe("OpenClaw database integrity verifier", () => {
   it.skipIf(process.platform === "win32")(
     "preserves live WAL ownership while snapshotting an open database",
@@ -116,6 +128,10 @@ describe("OpenClaw database integrity verifier", () => {
         .run("verifier-lock-owner", JSON.stringify({ preserved: true }), 1);
       const walBefore = fs.statSync(`${agent.path}-wal`);
       const shmBefore = fs.statSync(`${agent.path}-shm`);
+      const baseLocksBefore = readLinuxPosixLocksForPath(agent.path);
+      if (process.platform === "linux") {
+        expect(baseLocksBefore.length).toBeGreaterThan(0);
+      }
       const targets: OpenClawDatabaseVerifyTarget[] = [
         { kind: "agent", label: "OpenClaw agent database worker-1", path: agent.path },
       ];
@@ -123,6 +139,11 @@ describe("OpenClaw database integrity verifier", () => {
       await expect(runDatabaseVerifyWorker(targets)).resolves.toEqual([
         { path: agent.path, ok: true },
       ]);
+      if (process.platform === "linux") {
+        // SQLite 3.51 can preserve visible WAL files after a lock is lost, so
+        // assert the kernel lock itself rather than relying on that symptom.
+        expect(readLinuxPosixLocksForPath(agent.path).length).toBeGreaterThan(0);
+      }
       const reader = spawnSync(
         process.execPath,
         [

--- a/src/state/openclaw-database-verify.test.ts
+++ b/src/state/openclaw-database-verify.test.ts
@@ -103,6 +103,56 @@ function quarantineStorePath(stateDir: string): string {
 }
 
 describe("OpenClaw database integrity verifier", () => {
+  it.skipIf(process.platform === "win32")(
+    "preserves live WAL ownership while snapshotting an open database",
+    async () => {
+      const stateDir = makeTempDir(tempDirs, "openclaw-database-verify-live-locks-");
+      const env = { OPENCLAW_STATE_DIR: stateDir };
+      const agent = openOpenClawAgentDatabase({ agentId: "worker-1", env });
+      agent.db
+        .prepare(
+          "INSERT INTO auth_profile_state (state_key, state_json, updated_at) VALUES (?, ?, ?)",
+        )
+        .run("verifier-lock-owner", JSON.stringify({ preserved: true }), 1);
+      const walBefore = fs.statSync(`${agent.path}-wal`);
+      const shmBefore = fs.statSync(`${agent.path}-shm`);
+      const targets: OpenClawDatabaseVerifyTarget[] = [
+        { kind: "agent", label: "OpenClaw agent database worker-1", path: agent.path },
+      ];
+
+      await expect(runDatabaseVerifyWorker(targets)).resolves.toEqual([
+        { path: agent.path, ok: true },
+      ]);
+      const reader = spawnSync(
+        process.execPath,
+        [
+          "--input-type=module",
+          "-e",
+          `
+            import { DatabaseSync } from "node:sqlite";
+            const database = new DatabaseSync(process.env.OPENCLAW_VERIFY_TEST_PATH);
+            database.prepare("PRAGMA schema_version;").get();
+            database.close();
+          `,
+        ],
+        {
+          env: { ...process.env, OPENCLAW_VERIFY_TEST_PATH: agent.path },
+          encoding: "utf8",
+        },
+      );
+
+      expect(reader.stderr).toBe("");
+      expect(reader.status).toBe(0);
+      expect(fs.statSync(`${agent.path}-wal`).ino).toBe(walBefore.ino);
+      expect(fs.statSync(`${agent.path}-shm`).ino).toBe(shmBefore.ino);
+      expect(() =>
+        agent.db
+          .prepare("UPDATE auth_profile_state SET updated_at = ? WHERE state_key = ?")
+          .run(2, "verifier-lock-owner"),
+      ).not.toThrow();
+    },
+  );
+
   it("detects corruption off-thread, quarantines it, and latches later opens", async () => {
     const stateDir = makeTempDir(tempDirs, "openclaw-database-verify-");
     const env = { OPENCLAW_STATE_DIR: stateDir };

--- a/src/state/openclaw-database-verify.ts
+++ b/src/state/openclaw-database-verify.ts
@@ -1,4 +1,4 @@
-import type { Worker } from "node:worker_threads";
+import type { ChildProcess } from "node:child_process";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
   applyOpenClawDatabaseVerificationResults,
@@ -6,6 +6,7 @@ import {
   OPENCLAW_DATABASE_VERIFY_INITIAL_DELAY_MS,
   OPENCLAW_DATABASE_VERIFY_INTERVAL_MS,
   runDatabaseVerifyWorker,
+  terminateDatabaseVerifyWorker,
 } from "./openclaw-database-verify.impl.js";
 
 const log = createSubsystemLogger("state/database-verify");
@@ -14,7 +15,7 @@ const log = createSubsystemLogger("state/database-verify");
 export function startOpenClawDatabaseIntegrityVerifier(options: { env: NodeJS.ProcessEnv }): {
   stop: () => Promise<void>;
 } {
-  let activeWorker: Worker | undefined;
+  let activeWorker: ChildProcess | undefined;
   let stopped = false;
   let timer: ReturnType<typeof setTimeout> | undefined;
 
@@ -56,7 +57,9 @@ export function startOpenClawDatabaseIntegrityVerifier(options: { env: NodeJS.Pr
         clearTimeout(timer);
         timer = undefined;
       }
-      await activeWorker?.terminate();
+      if (activeWorker) {
+        await terminateDatabaseVerifyWorker(activeWorker);
+      }
       activeWorker = undefined;
     },
   };

--- a/src/state/openclaw-database-verify.worker.ts
+++ b/src/state/openclaw-database-verify.worker.ts
@@ -1,4 +1,3 @@
-import { parentPort, workerData } from "node:worker_threads";
 import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
 import {
   assertSqliteIntegrity,
@@ -89,7 +88,27 @@ export async function verifyOpenClawDatabases(
   return results;
 }
 
-if (parentPort) {
-  const targets = Array.isArray(workerData) ? workerData.filter(isVerifyTarget) : [];
-  parentPort.postMessage(await verifyOpenClawDatabases(targets), []);
+const sendToParent = process.send?.bind(process);
+if (sendToParent) {
+  process.once("message", (message: unknown) => {
+    void (async () => {
+      try {
+        const targets = Array.isArray(message) ? message.filter(isVerifyTarget) : [];
+        const results = await verifyOpenClawDatabases(targets);
+        await new Promise<void>((resolve, reject) => {
+          sendToParent(results, (error) => {
+            if (error) {
+              reject(error);
+            } else {
+              resolve();
+            }
+          });
+        });
+      } catch {
+        process.exitCode = 1;
+      } finally {
+        process.disconnect?.();
+      }
+    })();
+  });
 }

--- a/src/state/openclaw-database-verify.worker.ts
+++ b/src/state/openclaw-database-verify.worker.ts
@@ -6,6 +6,8 @@ import {
 import { prepareSqliteReadOnlyLocation } from "../infra/sqlite-readonly-location.js";
 import { OPENCLAW_SQLITE_BUSY_TIMEOUT_MS } from "./openclaw-state-db.js";
 
+const DATABASE_VERIFY_CHILD_ARG = "--openclaw-database-verify-child";
+
 export type OpenClawDatabaseVerifyTarget = {
   path: string;
   kind: "agent" | "state";
@@ -88,7 +90,10 @@ export async function verifyOpenClawDatabases(
   return results;
 }
 
-const sendToParent = process.send?.bind(process);
+// This module is also imported for its verifier function. Only the dedicated
+// child may consume and disconnect the process-wide IPC channel.
+const sendToParent =
+  process.argv[2] === DATABASE_VERIFY_CHILD_ARG ? process.send?.bind(process) : undefined;
 if (sendToParent) {
   process.once("message", (message: unknown) => {
     void (async () => {


### PR DESCRIPTION
## Summary

### High Level TLDR

OpenClaw's delayed database verifier could silently release the Gateway process's POSIX SQLite lock while taking a read-only snapshot. A later external reader could then unlink the still-live WAL/SHM files, leaving the Gateway writing through deleted file handles and eventually producing SQLite I/O failures. This change runs snapshot verification in a separate Node process so its descriptor closes cannot affect the Gateway's locks.

AI-assisted: yes. The implementation and proof were reviewed with the repository's `autoreview` workflow.

## What Problem This Solves

Fixes an issue where a healthy long-running Gateway on POSIX systems could lose its visible SQLite WAL/SHM files shortly after the delayed integrity verifier ran. The live process retained deleted sidecar handles, and later database operations could fail with I/O errors until a careful restart/recovery.

## Root Cause

Concrete before behavior on Linux using the real verifier path from current `main`:

1. A Gateway-style Node SQLite owner opened a WAL database and held the expected base-file and SHM POSIX locks.
2. The existing `worker_threads` verifier returned `{ ok: true }`.
3. Immediately afterward, the base-file POSIX lock had disappeared while the SHM lock remained.
4. One ordinary external `sqlite3` reader then removed the visible `-wal` and `-shm` paths.
5. The original owner still held both files as `(deleted)` handles.

The verifier ran in a worker thread, which shares the Gateway's OS process. Snapshot preparation opens and closes raw source descriptors. POSIX record locks are process-owned and can be released when that process closes another descriptor for the same inode, bypassing SQLite's descriptor bookkeeping. The five-minute delayed verifier therefore removed the lock that protected the live WAL generation; a later reader only triggered the now-permitted cleanup.

## Why This Change Was Made

Database verification now runs in a forked Node process. Snapshot descriptor closes are isolated to that process, while the parent retains result validation, lifecycle cancellation, and error handling. Parent completion waits for both process exit and IPC disconnect so a successful result cannot race child exit before message delivery.

No database schema, stored data shape, verifier schedule, or quarantine behavior changes.

## User Impact

Gateways can keep running the delayed/daily integrity verifier without risking their live SQLite WAL ownership. Independent readers no longer cause the verifier's source database sidecars to be unlinked beneath an active writer.

## Verification

Environment: Linux, Node v25.9.0, Node SQLite 3.51.3, system SQLite 3.45.1. Tested base `e866148c73e62a8f025508f3ea6ed69c685750c3`; rebased head `9269b82e359c5288fea7a3a4a4e21e6d09cef3eb`.

- `node scripts/run-vitest.mjs src/state/openclaw-database-verify.test.ts`
  - `Test Files 1 passed (1)`
  - `Tests 19 passed (19)`
- `node scripts/check-changed.mjs --timed` using the documented trusted-source local fallback flags because both remote backends were unavailable
  - all selected `core, coreTests` checks passed, including core/core-test typecheck, changed-file lint, database-first guard, runtime sidecar loader guard, and import-cycle guard
  - one warning-only suggestion requested migrating this existing test file's temp-dir helper; cleanup remains covered by the file's existing `afterEach`/`afterAll` lifecycle
- `CI=1 PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false OPENCLAW_LOCAL_CHECK=1 pnpm build`
  - packaged build completed successfully; `dist/state/openclaw-database-verify.worker.js` emitted
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output`
  - first pass found an IPC exit/message race; fixed against the Node child-process contract
  - final pass: `autoreview clean: no accepted/actionable findings reported`

The focused test, complete changed gate, packaged build, and packaged behavior probe were rerun after rebasing onto `e866148c73e`.

## Real behavior proof

The regression keeps a Node SQLite WAL owner open, runs the real verifier, opens/closes an independent reader, checks the exact WAL/SHM inodes remain, then writes again through the original owner.

Packaged-artifact manual steps:

1. Open a temporary WAL database with Node `DatabaseSync` and write one row.
2. Fork `dist/state/openclaw-database-verify.worker.js` and require an `{ ok: true }` result plus exit code 0.
3. Read the same database through the system `sqlite3` binary.
4. Assert the WAL and SHM inode numbers are unchanged.
5. Write a second row through the original connection.

Copied result:

```json
{"childExit":0,"verifierOk":true,"externalReader":"sqlite3","sidecarsPreserved":true,"ownerWriteAfter":true}
```


### Production deployment proof

The patch was deployed on the live Linux Gateway from current `main` plus the open-PR overlays using the normal data-backup, build, doctor, daemon reinstall, RPC, health, and restart-log gates.

Observed after startup:

1. The managed replacement process owned the configured listener; deep RPC and verbose health both passed.
2. The five-minute delayed verifier logged `database integrity verification passed` for the live main agent database.
3. An independent system `sqlite3` reader opened and closed that database.
4. The base, WAL, and SHM inodes remained unchanged; the Gateway retained its base POSIX lock and had no deleted SQLite descriptors.
5. A real Gateway agent turn returned `db-verifier-runtime-ok`; the database still passed `PRAGMA quick_check` afterward.

Copied redacted result:

```json
{"delayedVerifier":"passed","externalReader":"sqlite3","baseLockBefore":1,"baseLockAfter":1,"sidecarInodesUnchanged":true,"deletedSqliteFds":0,"agentTurn":"db-verifier-runtime-ok","quickCheck":"ok"}
```

## Evidence

The new non-Windows regression covers the exact failure sequence and the original owner's post-verification write. The focused suite, complete changed gate, packaged build, built-artifact probe, and final independent autoreview all pass.

## What was not tested

- Windows-specific locking behavior is intentionally skipped because this regression is POSIX-specific.
- Blacksmith Testbox was unavailable because the host lacked Blacksmith authentication; AWS Crabbox was unavailable because the host lacked broker login. Per repository policy for trusted source, proof fell back to the local Linux host and that limitation is stated here.
