### PR TITLE
fix(ci): retain frozen-candidate QA runtime scratch

### DIFF
--- a/.github/workflows/openclaw-release-telegram-qa.yml
+++ b/.github/workflows/openclaw-release-telegram-qa.yml
@@ -1230,6 +1230,11 @@ jobs:
           sudo chown -R root:root "$CANDIDATE_ROOT"
           sudo chmod -R go-w "$CANDIDATE_ROOT"
           sudo chmod -R a+rX "$CANDIDATE_ROOT"
+          # Older candidates stage their QA plugin runtime under .artifacts/qa-runtime.
+          # Preserve the frozen tree while granting the isolated SUT this one scratch directory.
+          candidate_artifacts_dir="${CANDIDATE_ROOT}/.artifacts"
+          sudo install -d -o "$sut_uid" -g "$sut_gid" -m 0700 "$candidate_artifacts_dir"
+          [[ "$(stat -c '%F:%a:%u:%g' "$candidate_artifacts_dir")" == "directory:700:${sut_uid}:${sut_gid}" ]]
           evidence_relative=".trusted-qa-evidence/release-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           evidence_root="${CANDIDATE_ROOT}/${evidence_relative}"
           boundary_evidence_dir="${evidence_root}/process-boundary"
@@ -1277,6 +1282,7 @@ jobs:
             printf 'RUNNER_HOME=%q\n' "$runner_home"
             printf 'RUNNER_TEMP_DIR=%q\n' "$runner_temp"
             printf 'CANDIDATE_ROOT=%q\n' "$CANDIDATE_ROOT"
+            printf 'CANDIDATE_ARTIFACTS_DIR=%q\n' "$candidate_artifacts_dir"
             printf 'RUNTIME_ROOT=%q\n' "$runtime_root"
             printf 'NODE_BIN=%q\n' "$node_bin"
             printf 'PRELOAD_PATH=%q\n' "$preload"
@@ -2045,6 +2051,7 @@ jobs:
                           ! -w "$CANDIDATE_ROOT/dist/index.js" &&
                           -r "${OPENCLAW_CONFIG_PATH:?}" &&
                           ! -w "$OPENCLAW_CONFIG_PATH" ]]
+                    [[ -d "${CANDIDATE_ARTIFACTS_DIR:?}" && -w "$CANDIDATE_ARTIFACTS_DIR" ]]
                     for writable_path in \
                       "${OPENCLAW_QA_TEMP_ROOT:?}/workspace" \
                       "${OPENCLAW_HOME:?}" \
@@ -2077,6 +2084,7 @@ jobs:
                     runtime_sandbox_payload_b64="$sandbox_payload_b64"
                     unset \
                       CANDIDATE_ROOT \
+                      CANDIDATE_ARTIFACTS_DIR \
                       EVIDENCE_ROOT \
                       NODE_BIN \
                       PRELOAD_PATH \

--- a/.github/workflows/openclaw-release-telegram-qa.yml
+++ b/.github/workflows/openclaw-release-telegram-qa.yml
@@ -1230,7 +1230,7 @@ jobs:
           sudo chown -R root:root "$CANDIDATE_ROOT"
           sudo chmod -R go-w "$CANDIDATE_ROOT"
           sudo chmod -R a+rX "$CANDIDATE_ROOT"
-          # Older candidates stage their QA plugin runtime under .artifacts/qa-runtime.
+          # QA plugin runtime staging uses .artifacts/qa-runtime below its repo root.
           # Preserve the frozen tree while granting the isolated SUT this one scratch directory.
           candidate_artifacts_dir="${CANDIDATE_ROOT}/.artifacts"
           sudo install -d -o "$sut_uid" -g "$sut_gid" -m 0700 "$candidate_artifacts_dir"

--- a/test/scripts/openclaw-release-telegram-qa-workflow.test.ts
+++ b/test/scripts/openclaw-release-telegram-qa-workflow.test.ts
@@ -849,6 +849,18 @@ describe("release Telegram QA workflow", () => {
     expect(source).not.toMatch(/^\s+node_bin="\$\(realpath -e "\$\(command -v node\)"\)"$/mu);
     expect(source).toContain('temp_root="$(realpath -e "${OPENCLAW_QA_TEMP_ROOT:?}")"');
     expect(source).toContain("sudo install -d -o root -g root -m 0700 /tmp/openclaw");
+    expect(source).toContain('candidate_artifacts_dir="${CANDIDATE_ROOT}/.artifacts"');
+    expect(source).toContain(
+      'sudo install -d -o "$sut_uid" -g "$sut_gid" -m 0700 "$candidate_artifacts_dir"',
+    );
+    expect(source).toContain(
+      '[[ "$(stat -c \'%F:%a:%u:%g\' "$candidate_artifacts_dir")" == "directory:700:${sut_uid}:${sut_gid}" ]]',
+    );
+    expect(source).toContain("printf 'CANDIDATE_ARTIFACTS_DIR=%q\\n' \"$candidate_artifacts_dir\"");
+    expect(source).toContain(
+      '[[ -d "${CANDIDATE_ARTIFACTS_DIR:?}" && -w "$CANDIDATE_ARTIFACTS_DIR" ]]',
+    );
+    expect(source).toContain("CANDIDATE_ARTIFACTS_DIR \\");
     expect(source).toContain(
       '-m 0711 \\\n            "${runtime_root}/tmp/openclaw-${runner_uid}"',
     );


### PR DESCRIPTION
## What Problem This Solves

Resolves a release-validation failure where a frozen extended-stable candidate cannot run Telegram QA because its legacy QA runtime creates `.artifacts/qa-runtime` inside the intentionally read-only candidate tree.

## Why This Change Was Made

The trusted harness keeps the candidate source tree root-owned and non-writable, but creates one SUT-owned, mode-`0700` `.artifacts` scratch directory required by older candidates' QA runtime staging. The launcher verifies that narrow writable exception before running the candidate and removes its control variable before executing the CLI.

## User Impact

Release operators can validate frozen maintenance candidates without weakening the read-only boundary for their source, dependencies, or built CLI. No application runtime behavior changes.

## Evidence

- Reproduced in [Full Release Validation #30156808871](https://github.com/openclaw/openclaw/actions/runs/30156808871), Telegram child [#30157025151](https://github.com/openclaw/openclaw/actions/runs/30157025151): both attempts failed with `EACCES: permission denied, mkdir .../.artifacts`.
- `git diff --check` and targeted `oxfmt` pass.
- Focused workflow test was attempted but the disposable worktree lacks dependencies (`ERR_MODULE_NOT_FOUND: p-map`); hosted PR CI is the authoritative validation.
- Fresh autoreview reported no actionable findings.

AI-assisted.
