### PR TITLE
[AI-assisted] docs(senseaudio): fix broken Docs URL to docs.senseaudio.cn

### DIFF
--- a/docs/providers/senseaudio.md
+++ b/docs/providers/senseaudio.md
@@ -17,7 +17,7 @@ SenseAudio transcribes inbound audio and voice-note attachments through OpenClaw
 | Default model | `senseaudio-asr-pro-1.5-260319`                  |
 | Default URL   | `https://api.senseaudio.cn/v1`                   |
 | Website       | [senseaudio.cn](https://senseaudio.cn)           |
-| Docs          | [senseaudio.cn/docs](https://senseaudio.cn/docs) |
+| Docs          | [docs.senseaudio.cn](https://docs.senseaudio.cn) |
 
 ## Getting started
 


### PR DESCRIPTION
## What Problem This Solves

The SenseAudio provider guide (`docs/providers/senseaudio.md`) links its **Docs** row to `https://senseaudio.cn/docs`, which returns **404 Not Found**. Users following the provider guide to read the SenseAudio API/platform docs hit a dead page.

## Why This Change Was Made

- The old URL `https://senseaudio.cn/docs` currently responds `404`.
- The SenseAudio platform homepage (`https://senseaudio.cn`) itself links to the docs site at `https://docs.senseaudio.cn` (responds `200`, page title "SenseAudio 平台介绍 - SenseAudio 开放平台").
- This points the Docs row to the real, currently-working documentation site, matching the convention used by the other provider guides (a live docs URL in the Docs row).

## User Impact

Anyone opening the SenseAudio provider guide and clicking **Docs** now lands on a working documentation page instead of a 404.

## Evidence

Before (broken):

```
$ curl -s -o /dev/null -L -A "Mozilla/5.0" -w "%{http_code}\n" https://senseaudio.cn/docs
404
```

After (fixed target):

```
$ curl -s -o /dev/null -L -A "Mozilla/5.0" -w "%{http_code} %{url_effective}\n" https://docs.senseaudio.cn
200 https://docs.senseaudio.cn/
```

The SenseAudio homepage (`https://senseaudio.cn`) references `https://docs.senseaudio.cn/` as its documentation link, confirming the correct destination.

### Sibling-surface check

`grep -rn "senseaudio.cn/docs"` across `docs/**`, source, and config surfaces only the single line fixed here — no other occurrence to update.

### Diff

```diff
-| Docs          | [senseaudio.cn/docs](https://senseaudio.cn/docs) |
+| Docs          | [docs.senseaudio.cn](https://docs.senseaudio.cn) |
```

## AI Use

This PR was prepared with AI assistance. The change is a single docs URL correction; I verified both the broken link (404) and the replacement target (200) against the live site and confirmed the homepage links to the replacement.

- [x] Marked as AI-assisted in the PR title
- [x] Evidence included above
- [x] I understand what this change does (corrects one dead Docs link in the SenseAudio provider guide)
