### PR TITLE
fix(gateway): unblock approvals after first successful delivery

### DIFF
--- a/src/gateway/server-methods/approval-request-delivery.test.ts
+++ b/src/gateway/server-methods/approval-request-delivery.test.ts
@@ -2,12 +2,184 @@ import { describe, expect, it, vi } from "vitest";
 import { ExecApprovalManager } from "../exec-approval-manager.js";
 import { runApprovalRequestDeliveries } from "./approval-request-delivery.js";
 
+const approvalDeliveryCallers = [
+  {
+    name: "exec approvals",
+    approvalKind: "exec",
+    id: "approval-first-exec-delivery",
+    request: { command: "echo ok" },
+  },
+  {
+    name: "plugin approvals",
+    approvalKind: "plugin",
+    id: "plugin:approval-first-plugin-delivery",
+    request: { pluginId: "example", title: "Sensitive action", description: "Approve action" },
+  },
+  {
+    name: "plugin node policies",
+    approvalKind: "plugin",
+    id: "plugin:approval-first-node-policy-delivery",
+    request: {
+      pluginId: "example",
+      title: "Sensitive node action",
+      description: "Approve node action",
+      severity: "warning",
+    },
+  },
+] as const;
+
+async function expectPromptDelivery(delivery: boolean | Promise<boolean>): Promise<void> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    const timedDelivery = Promise.race([
+      Promise.resolve(delivery),
+      new Promise<boolean>((resolve) => {
+        timeout = setTimeout(() => resolve(false), 100);
+      }),
+    ]);
+    await expect(timedDelivery).resolves.toBe(true);
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+  }
+}
+
 describe("runApprovalRequestDeliveries", () => {
   it("returns false synchronously when no external routes exist", () => {
     const manager = new ExecApprovalManager();
     const record = manager.create({ command: "echo ok" }, 60_000, "approval-no-delivery");
 
     expect(runApprovalRequestDeliveries({ context: {}, record })).toBe(false);
+  });
+
+  it.each(approvalDeliveryCallers)(
+    "immediately reports a successful $name forward while iOS push remains pending",
+    async ({ approvalKind, id, request }) => {
+      const manager = new ExecApprovalManager<typeof request>({ approvalKind });
+      const record = manager.create(request, 60_000, id);
+      const started: string[] = [];
+
+      const delivery = runApprovalRequestDeliveries({
+        context: {},
+        record,
+        forward: [
+          async () => {
+            started.push("forward");
+            return true;
+          },
+          "forward failed",
+        ],
+        iosPush: [
+          async () => {
+            started.push("push");
+            return await new Promise<boolean>(() => {});
+          },
+          "push failed",
+        ],
+      });
+
+      expect(started).toEqual(["forward", "push"]);
+      await expectPromptDelivery(delivery);
+    },
+  );
+
+  it.each(approvalDeliveryCallers)(
+    "immediately reports a successful $name iOS push while forwarding remains pending",
+    async ({ approvalKind, id, request }) => {
+      const manager = new ExecApprovalManager<typeof request>({ approvalKind });
+      const record = manager.create(request, 60_000, id);
+      const started: string[] = [];
+
+      const delivery = runApprovalRequestDeliveries({
+        context: {},
+        record,
+        forward: [
+          async () => {
+            started.push("forward");
+            return await new Promise<boolean>(() => {});
+          },
+          "forward failed",
+        ],
+        iosPush: [
+          async () => {
+            started.push("push");
+            return true;
+          },
+          "push failed",
+        ],
+      });
+
+      expect(started).toEqual(["forward", "push"]);
+      await expectPromptDelivery(delivery);
+    },
+  );
+
+  it.each([
+    { name: "both routes decline", forwardRejects: false, pushRejects: false },
+    { name: "forwarding rejects", forwardRejects: true, pushRejects: false },
+    { name: "iOS push rejects", forwardRejects: false, pushRejects: true },
+    { name: "both routes reject", forwardRejects: true, pushRejects: true },
+  ])("reports false after $name", async ({ forwardRejects, pushRejects }) => {
+    const manager = new ExecApprovalManager();
+    const record = manager.create({ command: "echo ok" }, 60_000, "approval-all-deliveries-fail");
+    const error = vi.fn();
+
+    const delivery = runApprovalRequestDeliveries({
+      context: { logGateway: { error } },
+      record,
+      forward: [
+        async () => {
+          if (forwardRejects) {
+            throw new Error("forward offline");
+          }
+          return false;
+        },
+        "forward failed",
+      ],
+      iosPush: [
+        async () => {
+          if (pushRejects) {
+            throw new Error("push offline");
+          }
+          return false;
+        },
+        "push failed",
+      ],
+    });
+
+    await expect(delivery).resolves.toBe(false);
+    expect(error).toHaveBeenCalledTimes(Number(forwardRejects) + Number(pushRejects));
+    if (forwardRejects) {
+      expect(error).toHaveBeenCalledWith("forward failed: Error: forward offline");
+    }
+    if (pushRejects) {
+      expect(error).toHaveBeenCalledWith("push failed: Error: push offline");
+    }
+  });
+
+  it("continues handling a late route rejection after another route succeeds", async () => {
+    const manager = new ExecApprovalManager();
+    const record = manager.create({ command: "echo ok" }, 60_000, "approval-late-push-failure");
+    const error = vi.fn();
+    let rejectPush: ((reason: Error) => void) | undefined;
+    const pendingPush = new Promise<boolean>((_resolve, reject) => {
+      rejectPush = reject;
+    });
+
+    const delivery = runApprovalRequestDeliveries({
+      context: { logGateway: { error } },
+      record,
+      forward: [async () => true, "forward failed"],
+      iosPush: [async () => await pendingPush, "push failed"],
+    });
+
+    await expectPromptDelivery(delivery);
+    expect(error).not.toHaveBeenCalled();
+    rejectPush?.(new Error("offline after delivery"));
+    await vi.waitFor(() => {
+      expect(error).toHaveBeenCalledWith("push failed: Error: offline after delivery");
+    });
   });
 
   it.each([

--- a/src/gateway/server-methods/approval-request-delivery.ts
+++ b/src/gateway/server-methods/approval-request-delivery.ts
@@ -17,6 +17,26 @@ type ApprovalRequestDelivery = readonly [
 
 type ApprovalDeliveryLogContext = { logGateway?: { error?: (message: string) => void } };
 
+function resolveFirstSuccessfulApprovalDelivery(
+  deliveryTasks: readonly Promise<boolean>[],
+): Promise<boolean> {
+  return new Promise<boolean>((resolve) => {
+    let remaining = deliveryTasks.length;
+    for (const delivery of deliveryTasks) {
+      void delivery.then((delivered) => {
+        if (delivered) {
+          resolve(true);
+          return;
+        }
+        remaining -= 1;
+        if (remaining === 0) {
+          resolve(false);
+        }
+      });
+    }
+  });
+}
+
 /** Runs external approval deliveries concurrently and reports whether any route accepted. */
 export function runApprovalRequestDeliveries<TPayload>(params: {
   context: ApprovalDeliveryLogContext;
@@ -50,5 +70,7 @@ export function runApprovalRequestDeliveries<TPayload>(params: {
   if (deliveryTasks.length === 0) {
     return false;
   }
-  return Promise.all(deliveryTasks).then((results) => results.some(Boolean));
+  // A delivered route must unblock approval while other started routes keep
+  // their error handlers and can finish without delaying the requester.
+  return resolveFirstSuccessfulApprovalDelivery(deliveryTasks);
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users waiting for an exec approval, plugin approval, or plugin-node approval can remain blocked after the approval notification was successfully forwarded because the other configured iOS or forwarding route is still pending.

## Why This Change Was Made

Keep the existing concurrently started approval-delivery routes, visibility filtering, approval decisions, failure logging, and iOS cleanup, but unblock the requester as soon as the first route confirms successful delivery. Still report failure only after every configured route declines or fails.

## User Impact

A working approval-forwarding or iOS push route promptly makes exec, plugin, and plugin-node approvals available even if the other route is slow or offline. No authentication, approval policy, operator scopes, protocol, persistent state, or configuration changes.

## Evidence

- Independently reproduced the exact current-main production defect on a trusted Linux Testbox: 7 failing and 7 passing focused owner cases; both delivery orders fail for exec, plugin, and plugin-node approvals, and late rejection handling also fails.
- The exact fixed source and test blobs pass 212/212 cases across eight real gateway, iOS, plugin-node, approval manager, visibility, and forwarding suites.
- Full remote `pnpm check:changed` passes with exit 0, including production and test `tsgo`, changed-file lint/format, package/plugin/API boundaries, native state-schema, database, import-cycle, webhook, and pairing guards.
- Fresh independent official Codex `gpt-5.6-sol` high-effort structured autoreview: no findings; patch correct, confidence 0.94.
- Reviewed local head: `69450742a3437c0c95ac04ed53349827083fe2c2`; current-main parent: `3f27d76ea7dc31d75b818fb63691e594f054e76b`.
- Remote synthetic Testbox heads are intentionally not claimed as the PR head; both production and regression Git source blobs were independently checked before every proof.
- AI-assisted; separately verified against all three approval request callers and the actual iOS/shared visibility owners.
