### PR TITLE
feat: make working claw tricks rare surprises

### DIFF
--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -1725,8 +1725,8 @@ describe("grouped chat rendering", () => {
     expect(container.querySelector(".chat-reading-indicator")).not.toBeNull();
   });
 
-  it("seeds a stable claw stance per reading-indicator key", () => {
-    const stanceFor = (key: string) => {
+  it("seeds at most one stable claw surprise per reading-indicator key", () => {
+    const surpriseFor = (key: string) => {
       const container = document.createElement("div");
       render(renderStreamGroup([{ kind: "reading-indicator", key, startedAt: 1 }]), container);
       const bubble = container.querySelector(".chat-reading-indicator");
@@ -1735,10 +1735,10 @@ describe("grouped chat rendering", () => {
       );
     };
 
-    const first = stanceFor("stream:agent:main:pending");
-    // Stable across re-renders: same key always claws the same style.
-    expect(stanceFor("stream:agent:main:pending")).toEqual(first);
-    // At most one stance modifier; plain in-place clawing is the unmarked default.
+    const first = surpriseFor("stream:agent:main:pending");
+    // Stable across re-renders: the same key keeps the same surprise decision.
+    expect(surpriseFor("stream:agent:main:pending")).toEqual(first);
+    // At most one surprise modifier; plain in-place clawing is the unmarked default.
     expect(first.length).toBeLessThanOrEqual(1);
     for (const cls of first) {
       expect([

--- a/ui/src/pages/chat/components/chat-working-indicator-surprise.ts
+++ b/ui/src/pages/chat/components/chat-working-indicator-surprise.ts
@@ -1,0 +1,29 @@
+import { fnv1aUtf16 } from "../../../lib/fnv1a.ts";
+
+// One salt per page load keeps each run stable while varying the surprise between visits.
+const SURPRISE_SALT = Math.trunc(Math.random() * 0xffffffff);
+const SURPRISE_CHANCE_PER_THOUSAND = 30;
+const SURPRISE_CLASSES = [
+  "chat-reading-indicator--southpaw",
+  "chat-reading-indicator--flurry",
+  "chat-reading-indicator--spin",
+  "chat-reading-indicator--shadowbox",
+  "chat-reading-indicator--backflip",
+  "chat-reading-indicator--zen",
+  "chat-reading-indicator--drummer",
+  "chat-reading-indicator--peekaboo",
+] as const;
+
+export function selectWorkingClawSurprise(
+  key: string,
+  options: { salt?: number; eligible?: boolean } = {},
+): string {
+  if (options.eligible === false) {
+    return "";
+  }
+  const hash = (fnv1aUtf16(key) ^ (options.salt ?? SURPRISE_SALT)) >>> 0;
+  if (hash % 1000 >= SURPRISE_CHANCE_PER_THOUSAND) {
+    return "";
+  }
+  return SURPRISE_CLASSES[Math.floor(hash / 1000) % SURPRISE_CLASSES.length] ?? "";
+}

--- a/ui/src/pages/chat/components/chat-working-indicator.test.ts
+++ b/ui/src/pages/chat/components/chat-working-indicator.test.ts
@@ -1,0 +1,104 @@
+import { render } from "lit";
+import { describe, expect, it } from "vitest";
+import { selectWorkingClawSurprise } from "./chat-working-indicator-surprise.ts";
+import { renderChatWorkingIndicator } from "./chat-working-indicator.ts";
+
+const SURPRISE_CLASSES = [
+  "chat-reading-indicator--southpaw",
+  "chat-reading-indicator--flurry",
+  "chat-reading-indicator--spin",
+  "chat-reading-indicator--shadowbox",
+  "chat-reading-indicator--backflip",
+  "chat-reading-indicator--zen",
+  "chat-reading-indicator--drummer",
+  "chat-reading-indicator--peekaboo",
+] as const;
+
+// The keyed sample is deterministic for a fixed salt, so the rarity and spread
+// assertions below are exact re-runs, not statistical flakes.
+const SAMPLE_SALT = 0x5eed;
+const sampleDecisions = Array.from({ length: 10_000 }, (_, index) =>
+  selectWorkingClawSurprise(`run:${index}`, { salt: SAMPLE_SALT }),
+);
+
+function findSampleKey(wantSurprise: boolean): string {
+  const index = sampleDecisions.findIndex((decision) => Boolean(decision) === wantSurprise);
+  if (index === -1) {
+    throw new Error(`no sample key with surprise=${String(wantSurprise)}`);
+  }
+  return `run:${index}`;
+}
+
+describe("selectWorkingClawSurprise", () => {
+  it("keeps surprises rare, deterministic, and spread across every move", () => {
+    const surprises = sampleDecisions.filter(Boolean);
+
+    // ~3% target: SURPRISE_CHANCE_PER_THOUSAND=30 over 10k keys lands near 300.
+    expect(surprises.length).toBeGreaterThan(200);
+    expect(surprises.length).toBeLessThan(400);
+    expect(selectWorkingClawSurprise("run:42", { salt: SAMPLE_SALT })).toBe(
+      selectWorkingClawSurprise("run:42", { salt: SAMPLE_SALT }),
+    );
+    expect(new Set(surprises)).toEqual(new Set(SURPRISE_CLASSES));
+
+    // The move pick must not reuse the rarity bits (hash % 1000); if it did,
+    // some moves would cluster while others nearly vanish from the rotation.
+    const counts = new Map<string, number>();
+    for (const surprise of surprises) {
+      counts.set(surprise, (counts.get(surprise) ?? 0) + 1);
+    }
+    for (const surpriseClass of SURPRISE_CLASSES) {
+      expect(counts.get(surpriseClass) ?? 0).toBeGreaterThanOrEqual(10);
+    }
+  });
+
+  it("keeps ineligible keys on the default claw even when they would surprise", () => {
+    const surprisingKey = findSampleKey(true);
+    expect(selectWorkingClawSurprise(surprisingKey, { salt: SAMPLE_SALT })).not.toBe("");
+    expect(selectWorkingClawSurprise(surprisingKey, { salt: SAMPLE_SALT, eligible: false })).toBe(
+      "",
+    );
+  });
+});
+
+describe("renderChatWorkingIndicator", () => {
+  // The render path seeds with the module's per-page-load salt, so probe that
+  // same default salt for keys that do (and do not) surprise this session.
+  function findRenderKey(wantSurprise: boolean): string {
+    for (let index = 0; index < 10_000; index++) {
+      const key = `probe:${index}`;
+      if (Boolean(selectWorkingClawSurprise(key)) === wantSurprise) {
+        return key;
+      }
+    }
+    throw new Error(`no render key with surprise=${String(wantSurprise)}`);
+  }
+
+  function surpriseClassesFor(key: string, waitingApproval: boolean): string[] {
+    const container = document.createElement("div");
+    render(
+      renderChatWorkingIndicator(
+        { kind: "reading-indicator", key, startedAt: 1 },
+        { waitingApproval },
+      ),
+      container,
+    );
+    const bubble = container.querySelector(".chat-reading-indicator");
+    expect(bubble).not.toBeNull();
+    return [...(bubble?.classList ?? [])].filter((name) =>
+      name.startsWith("chat-reading-indicator--"),
+    );
+  }
+
+  it("routes the seeded surprise class onto the claw bubble", () => {
+    const surprisingKey = findRenderKey(true);
+    expect(surpriseClassesFor(surprisingKey, false)).toEqual([
+      selectWorkingClawSurprise(surprisingKey),
+    ]);
+    expect(surpriseClassesFor(findRenderKey(false), false)).toEqual([]);
+  });
+
+  it("keeps approval waits on the default claw even for surprising keys", () => {
+    expect(surpriseClassesFor(findRenderKey(true), true)).toEqual([]);
+  });
+});

--- a/ui/src/pages/chat/components/chat-working-indicator.ts
+++ b/ui/src/pages/chat/components/chat-working-indicator.ts
@@ -4,25 +4,12 @@ import { icons } from "../../../components/icons.ts";
 import "../../../components/working-phrase.ts";
 import { t } from "../../../i18n/index.ts";
 import type { ChatItem } from "../../../lib/chat/chat-types.ts";
-import { fnv1aUtf16 } from "../../../lib/fnv1a.ts";
 import { formatCompactTokenCount, formatDurationCompact } from "../../../lib/format.ts";
 import type { TurnRecap } from "../chat-progress.ts";
 import type { ChatRunStartupPhase } from "../chat-run-startup.ts";
+import { selectWorkingClawSurprise } from "./chat-working-indicator-surprise.ts";
 
-// One salt per page load keeps each run stable while varying the animation between visits.
-// The default stance just claws in place; the busier stances stay rare on purpose.
-const STANCE_SALT = Math.trunc(Math.random() * 0xffffffff);
-const STANCES: Array<[stance: string, weight: number]> = [
-  ["", 63],
-  ["chat-reading-indicator--southpaw", 19],
-  ["chat-reading-indicator--flurry", 5],
-  ["chat-reading-indicator--spin", 4],
-  ["chat-reading-indicator--shadowbox", 3],
-  ["chat-reading-indicator--backflip", 2],
-  ["chat-reading-indicator--zen", 2],
-  ["chat-reading-indicator--drummer", 1],
-  ["chat-reading-indicator--peekaboo", 1],
-];
+// Almost every run uses the default loop; an alternate move fires once, then yields back to it.
 const STARTUP_STATUS_LABEL_KEYS = {
   preparing_workspace: "chat.startupStatus.preparingWorkspace",
   provisioning_environment: "chat.startupStatus.provisioningEnvironment",
@@ -44,18 +31,6 @@ function renderLiveOutputTokens(outputTokens: number | null | undefined) {
       ${t("chat.outputTokens", { count: formatCompactTokenCount(outputTokens) })}
     </span>
   `;
-}
-
-function stanceClass(key: string): string {
-  const total = STANCES.reduce((sum, [, weight]) => sum + weight, 0);
-  let roll = ((((fnv1aUtf16(key) ^ STANCE_SALT) >>> 0) % 1000) / 1000) * total;
-  for (const [stance, weight] of STANCES) {
-    roll -= weight;
-    if (roll <= 0) {
-      return stance;
-    }
-  }
-  return "";
 }
 
 export function renderChatWorkingIndicator(
@@ -81,7 +56,9 @@ export function renderChatWorkingIndicator(
         ? nothing
         : html`
             <div
-              class="chat-bubble chat-reading-indicator ${stanceClass(part.key)}"
+              class="chat-bubble chat-reading-indicator ${selectWorkingClawSurprise(part.key, {
+                eligible: !waitingApproval,
+              })}"
               aria-hidden="true"
             >
               ${icons.claw}

--- a/ui/src/styles/chat/tool-cards.css
+++ b/ui/src/styles/chat/tool-cards.css
@@ -1137,11 +1137,11 @@
    18px because the claw is denser than a star glyph. The row settles into
    stance once, then the solid claw carries the ongoing working signal. The
    default cycle is two jaw snips with a sympathetic body flex — no lateral
-   travel, that read as too busy. The old jab-jab-cross shadowbox combo
-   survives only as the rare --shadowbox stance. --claw-cycle drives every
-   animation so stance variants only retune the tempo. */
+   travel, that read as too busy. Rare surprise moves layer over this loop
+   once after a short delay, then the default loop resumes. */
 .chat-reading-indicator {
   --claw-cycle: 2.4s;
+  --claw-surprise-delay: 4.8s;
 
   position: relative;
   display: inline-flex;
@@ -1203,8 +1203,7 @@
   will-change: transform;
 }
 
-/* Pow star: shadowbox-only, pops at the cross impact (46-58% of the combo
-   cycle). */
+/* Pow star: the one-shot shadowbox surprise pops at the cross impact. */
 .chat-reading-indicator--shadowbox::after {
   content: "✦";
   position: absolute;
@@ -1214,7 +1213,7 @@
   line-height: 1;
   color: var(--accent);
   opacity: 0;
-  animation: chatWorkingClawPow var(--claw-cycle) ease-out infinite;
+  animation: chatWorkingClawPow 1.2s ease-out var(--claw-surprise-delay) 1;
   pointer-events: none;
 }
 
@@ -1401,75 +1400,96 @@
   }
 }
 
-/* Seeded stance variants (see stanceClass in chat-working-indicator.ts): the
-   southpaw claws mirrored, the flurry snips double-time, the spin does a
-   fake-3D turntable revolve while snipping, the shadowbox brings back the
-   full jab-jab-cross combo with the pow star, the backflip throws a single
-   in-place somersault, the zen breathes through one long meditative snip,
-   the drummer rocks a two-beat rhythm, and the rarest peekaboo ducks away
-   and pops back wide open. */
+/* Seeded one-shot surprises (see selectWorkingClawSurprise): the default claw
+   keeps working until one move takes over briefly, then resumes afterward. */
 .chat-reading-indicator--southpaw {
-  transform: scaleX(-1);
+  animation: chatWorkingClawSouthpaw 1.2s ease-in-out var(--claw-surprise-delay) 1;
 }
 
-.chat-reading-indicator--flurry {
-  --claw-cycle: 1.3s;
+.chat-reading-indicator--flurry svg {
+  animation:
+    chatWorkingClawFlex var(--claw-cycle) ease-out infinite,
+    chatWorkingClawFlex 650ms ease-out var(--claw-surprise-delay) 2;
 }
 
-.chat-reading-indicator--spin {
-  --claw-cycle: 3.6s;
+.chat-reading-indicator--flurry svg .claw-icon__jaw {
+  animation:
+    chatWorkingClawSnip var(--claw-cycle) ease-out infinite,
+    chatWorkingClawSnip 650ms ease-out var(--claw-surprise-delay) 2;
 }
 
 /* Fake 3D: perspective() + rotateY reads as a spinning coin at 18px. Linear
-   timing keeps the revolve steady; the jaw keeps its snip cycle on top. */
+   timing keeps the single revolve steady; the jaw keeps its snip cycle. */
 .chat-reading-indicator--spin svg {
-  animation-name: chatWorkingClawSpin;
-  animation-timing-function: linear;
+  animation:
+    chatWorkingClawFlex var(--claw-cycle) ease-out infinite,
+    chatWorkingClawSpin 900ms linear var(--claw-surprise-delay) 1;
 }
 
 .chat-reading-indicator--shadowbox svg {
-  animation-name: chatWorkingClawCombo;
+  animation:
+    chatWorkingClawFlex var(--claw-cycle) ease-out infinite,
+    chatWorkingClawCombo 1.2s ease-out var(--claw-surprise-delay) 1;
 }
 
 .chat-reading-indicator--shadowbox svg .claw-icon__jaw {
-  animation-name: chatWorkingClawJaw;
+  animation:
+    chatWorkingClawSnip var(--claw-cycle) ease-out infinite,
+    chatWorkingClawJaw 1.2s ease-out var(--claw-surprise-delay) 1;
 }
 
 .chat-reading-indicator--backflip svg {
-  animation-name: chatWorkingClawBackflip;
-}
-
-.chat-reading-indicator--zen {
-  --claw-cycle: 6s;
+  animation:
+    chatWorkingClawFlex var(--claw-cycle) ease-out infinite,
+    chatWorkingClawBackflip 900ms ease-out var(--claw-surprise-delay) 1;
 }
 
 .chat-reading-indicator--zen svg {
-  animation-name: chatWorkingClawZenBreath;
-  animation-timing-function: ease-in-out;
+  animation:
+    chatWorkingClawFlex var(--claw-cycle) ease-out infinite,
+    chatWorkingClawZenBreath 2.4s ease-in-out var(--claw-surprise-delay) 1;
 }
 
 .chat-reading-indicator--zen svg .claw-icon__jaw {
-  animation-name: chatWorkingClawZenSnip;
-}
-
-.chat-reading-indicator--drummer {
-  --claw-cycle: 1.2s;
+  animation:
+    chatWorkingClawSnip var(--claw-cycle) ease-out infinite,
+    chatWorkingClawZenSnip 2.4s ease-out var(--claw-surprise-delay) 1;
 }
 
 .chat-reading-indicator--drummer svg {
-  animation-name: chatWorkingClawDrumRock;
+  animation:
+    chatWorkingClawFlex var(--claw-cycle) ease-out infinite,
+    chatWorkingClawDrumRock 1.2s ease-out var(--claw-surprise-delay) 1;
 }
 
 .chat-reading-indicator--drummer svg .claw-icon__jaw {
-  animation-name: chatWorkingClawDrumHit;
+  animation:
+    chatWorkingClawSnip var(--claw-cycle) ease-out infinite,
+    chatWorkingClawDrumHit 1.2s ease-out var(--claw-surprise-delay) 1;
 }
 
 .chat-reading-indicator--peekaboo svg {
-  animation-name: chatWorkingClawPeekaboo;
+  animation:
+    chatWorkingClawFlex var(--claw-cycle) ease-out infinite,
+    chatWorkingClawPeekaboo 1.2s ease-out var(--claw-surprise-delay) 1;
 }
 
 .chat-reading-indicator--peekaboo svg .claw-icon__jaw {
-  animation-name: chatWorkingClawPeekabooJaw;
+  animation:
+    chatWorkingClawSnip var(--claw-cycle) ease-out infinite,
+    chatWorkingClawPeekabooJaw 1.2s ease-out var(--claw-surprise-delay) 1;
+}
+
+@keyframes chatWorkingClawSouthpaw {
+  0%,
+  100% {
+    transform: scaleX(1);
+  }
+
+  20%,
+  80% {
+    transform: scaleX(-1);
+  }
 }
 
 @keyframes chatWorkingClawSpin {
@@ -1647,6 +1667,9 @@
     animation: none;
   }
 
+  /* Includes the bubble itself: the southpaw surprise animates the bubble,
+     not the svg, and must stay still under reduced motion too. */
+  .chat-reading-indicator,
   .chat-reading-indicator svg,
   .chat-reading-indicator svg .claw-icon__jaw {
     animation: none;


### PR DESCRIPTION
Closes #114019

AI-assisted implementation; I understand and verified the behavior and code path.

## What Problem This Solves

The Control UI currently chooses an alternate working-claw stance for 37% of agent runs, then repeats that move for the entire run. Frequent looping moves—especially the backflip—make the indicator feel busy and make the playful tricks stop feeling surprising.

## Why This Change Was Made

The normal claw now remains the dependable working state on 97% of active runs. On the remaining 3%, one deterministic special move starts after 4.8 seconds, plays once, and yields back to the normal claw loop. Approval waits always keep the default claw, and reduced-motion behavior remains unchanged.

## User Impact

Users will normally see the familiar working claw. Long-running turns will very occasionally show one playful move, without repeating it throughout the run or distracting during approval waits.

## Evidence

- `node scripts/run-vitest.mjs ui/src/pages/chat/components/chat-working-indicator.test.ts ui/src/pages/chat/components/chat-message.test.ts` — 131 tests passed.
- `./node_modules/.bin/oxfmt --check ...` — all five touched files correctly formatted.
- `./node_modules/.bin/stylelint --config config/stylelint.config.mjs ui/src/styles/chat/tool-cards.css` — passed.
- `git diff --check` — passed.
- Autoreview (`.agents/skills/autoreview/scripts/autoreview --mode uncommitted`) — clean twice; final focused follow-up review had no accepted/actionable findings (0.97 confidence).
- Mocked Control UI Chromium recording verified the full chat-send path: default claw before the delay, one backflip at 4.8 seconds, then the default claw resumed. Local artifacts: `.artifacts/control-ui-e2e/working-claw-surprise/` (three screenshots and one WebM recording; intentionally not committed).
