### PR TITLE
fix(ci): keep Telegram release scratch in isolated runtime

### DIFF
--- a/.github/workflows/openclaw-release-telegram-qa.yml
+++ b/.github/workflows/openclaw-release-telegram-qa.yml
@@ -1894,7 +1894,7 @@ jobs:
             unset "$key"
           done
           export SUT_UID SUT_GID RUNNER_UID RUNNER_GID RUNNER_HOME RUNNER_TEMP_DIR
-          export CANDIDATE_ROOT RUNTIME_ROOT NODE_BIN
+          export CANDIDATE_ROOT CANDIDATE_ARTIFACTS_DIR RUNTIME_ROOT NODE_BIN
           export PRELOAD_PATH RUNNER_SENTINEL TRUSTED_WORKSPACE EVIDENCE_ROOT
           export boundary_mode generation command_file identity_file sandbox_file
           export command_sha256 expected_env_keys_b64 sandbox_payload_b64

--- a/test/scripts/openclaw-release-telegram-qa-workflow.test.ts
+++ b/test/scripts/openclaw-release-telegram-qa-workflow.test.ts
@@ -858,6 +858,9 @@ describe("release Telegram QA workflow", () => {
     );
     expect(source).toContain("printf 'CANDIDATE_ARTIFACTS_DIR=%q\\n' \"$candidate_artifacts_dir\"");
     expect(source).toContain(
+      "export CANDIDATE_ROOT CANDIDATE_ARTIFACTS_DIR RUNTIME_ROOT NODE_BIN",
+    );
+    expect(source).toContain(
       '[[ -d "${CANDIDATE_ARTIFACTS_DIR:?}" && -w "$CANDIDATE_ARTIFACTS_DIR" ]]',
     );
     expect(source).toContain("CANDIDATE_ARTIFACTS_DIR \\");

--- a/test/scripts/openclaw-release-telegram-qa-workflow.test.ts
+++ b/test/scripts/openclaw-release-telegram-qa-workflow.test.ts
@@ -857,9 +857,7 @@ describe("release Telegram QA workflow", () => {
       '[[ "$(stat -c \'%F:%a:%u:%g\' "$candidate_artifacts_dir")" == "directory:700:${sut_uid}:${sut_gid}" ]]',
     );
     expect(source).toContain("printf 'CANDIDATE_ARTIFACTS_DIR=%q\\n' \"$candidate_artifacts_dir\"");
-    expect(source).toContain(
-      "export CANDIDATE_ROOT CANDIDATE_ARTIFACTS_DIR RUNTIME_ROOT NODE_BIN",
-    );
+    expect(source).toContain("export CANDIDATE_ROOT CANDIDATE_ARTIFACTS_DIR RUNTIME_ROOT NODE_BIN");
     expect(source).toContain(
       '[[ -d "${CANDIDATE_ARTIFACTS_DIR:?}" && -w "$CANDIDATE_ARTIFACTS_DIR" ]]',
     );


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the live Telegram release gate failed before Gateway startup after the frozen candidate gained a dedicated writable artifact directory.

## Why This Change Was Made

The trusted launcher already created and validated the candidate artifact directory, but did not export its path across the mount-namespace boundary. Exporting the existing value keeps the frozen candidate read-only except for that single scratch directory and preserves the existing fail-closed runtime checks.

## User Impact

No product behavior changes. Release maintainers can run the isolated Telegram candidate gate without the launcher aborting on a missing scratch-directory variable.

## Evidence

- Failure: [Full Release Validation 30187698559](https://github.com/openclaw/openclaw/actions/runs/30187698559), [Telegram child 30188027676](https://github.com/openclaw/openclaw/actions/runs/30188027676), job `Run isolated Telegram candidate`: `CANDIDATE_ARTIFACTS_DIR: parameter null or not set`.
- `node scripts/run-vitest.mjs test/scripts/openclaw-release-telegram-qa-workflow.test.ts`: 22 passed, 2 platform skips.
- `node scripts/check-workflows.mjs`: actionlint and zizmor passed.
- `git diff --check` passed.
- Autoreview: clean, no accepted/actionable findings.

AI-assisted: yes.
