### PR TITLE
refactor(agents): split subagent-spawn and drop its max-lines baseline entry

### DIFF
--- a/config/max-lines-baseline.txt
+++ b/config/max-lines-baseline.txt
@@ -495,7 +495,6 @@ src/agents/subagent-registry-run-manager.ts
 src/agents/subagent-registry.steer-restart.test.ts
 src/agents/subagent-registry.test.ts
 src/agents/subagent-spawn.test.ts
-src/agents/subagent-spawn.ts
 src/agents/system-prompt.test.ts
 src/agents/system-prompt.ts
 src/agents/tool-display-common.ts

--- a/src/agents/subagent-spawn-child-plan.ts
+++ b/src/agents/subagent-spawn-child-plan.ts
@@ -45,7 +45,7 @@ type ResolvedSubagentChildPlan = {
   resolvedModelMetadata: ReturnType<typeof buildResolvedSubagentModelMetadata>;
 };
 
-export type ResolveSubagentChildPlanResult =
+type ResolveSubagentChildPlanResult =
   | { ok: false; result: SpawnSubagentResult }
   | { ok: true; resolved: ResolvedSubagentChildPlan };
 

--- a/src/agents/subagent-spawn-child-plan.ts
+++ b/src/agents/subagent-spawn-child-plan.ts
@@ -1,0 +1,212 @@
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { isIncognitoSessionKey } from "../routing/session-key.js";
+import { resolveUserPath } from "../utils.js";
+import { resolveAgentDir } from "./agent-scope-config.js";
+import { resolveSpawnSandboxError, mintSpawnSessionKey } from "./spawn-plan.js";
+import { resolveRequesterOriginForChild } from "./spawn-requester-origin.js";
+import {
+  mapToolContextToSpawnedRunMetadata,
+  resolveSpawnedWorkspaceInheritance,
+} from "./spawned-context.js";
+import type { SubagentLaunchAuthorization } from "./subagent-launch-authorization.js";
+import type {
+  SpawnSubagentContext,
+  SpawnSubagentParams,
+  SpawnSubagentResult,
+} from "./subagent-spawn-contract.js";
+import {
+  buildResolvedSubagentModelMetadata,
+  resolveCollectorOutputModelError,
+} from "./subagent-spawn-model.js";
+import { resolveSubagentModelAndThinkingPlan, splitModelRef } from "./subagent-spawn-plan.js";
+import {
+  readRequesterFastMode,
+  readRequesterThinkingLevel,
+} from "./subagent-spawn-requester-prefs.js";
+import {
+  normalizeDeliveryContext,
+  resolveAgentConfig,
+  resolveSandboxRuntimeStatus,
+} from "./subagent-spawn.runtime.js";
+
+type ResolvedSubagentChildPlan = {
+  spawnedCwd?: string;
+  toolSpawnMetadata: ReturnType<typeof mapToolContextToSpawnedRunMetadata>;
+  spawnedWorkspaceDir?: string;
+  requesterOrigin: ReturnType<typeof normalizeDeliveryContext>;
+  childSessionOrigin: ReturnType<typeof resolveRequesterOriginForChild>;
+  incognito: boolean;
+  childSessionKey: string;
+  childRuntimeSandboxed: boolean;
+  targetAgentDir: string;
+  modelPlan: Extract<ReturnType<typeof resolveSubagentModelAndThinkingPlan>, { status: "ok" }>;
+  launchAuthorization?: SubagentLaunchAuthorization;
+  resolvedModelMetadata: ReturnType<typeof buildResolvedSubagentModelMetadata>;
+};
+
+export type ResolveSubagentChildPlanResult =
+  | { ok: false; result: SpawnSubagentResult }
+  | { ok: true; resolved: ResolvedSubagentChildPlan };
+
+export async function resolveSubagentChildPlan(params: {
+  request: SpawnSubagentParams;
+  ctx: SpawnSubagentContext;
+  cfg: OpenClawConfig;
+  requesterInternalKey: string;
+  requesterAgentId: string;
+  targetAgentId: string;
+  sandboxMode: "require" | "inherit";
+  swarmEnabled: boolean;
+}): Promise<ResolveSubagentChildPlanResult> {
+  const requestedCwd = normalizeOptionalString(params.request.cwd);
+  const spawnedCwd = requestedCwd ? resolveUserPath(requestedCwd) : undefined;
+  const toolSpawnMetadata = mapToolContextToSpawnedRunMetadata({
+    agentGroupId: params.ctx.agentGroupId,
+    agentGroupChannel: params.ctx.agentGroupChannel,
+    agentGroupSpace: params.ctx.agentGroupSpace,
+    workspaceDir: params.ctx.workspaceDir,
+  });
+  const inheritedWorkspaceDir =
+    params.targetAgentId !== params.requesterAgentId ? undefined : toolSpawnMetadata.workspaceDir;
+  const spawnedWorkspaceDir = resolveSpawnedWorkspaceInheritance({
+    config: params.cfg,
+    targetAgentId: params.targetAgentId,
+    explicitWorkspaceDir: inheritedWorkspaceDir,
+  });
+  const requesterOrigin = normalizeDeliveryContext({
+    channel: params.ctx.agentChannel,
+    accountId: params.ctx.agentAccountId,
+    to: params.ctx.agentTo,
+    ...(params.ctx.agentThreadId != null && params.ctx.agentThreadId !== ""
+      ? { threadId: params.ctx.agentThreadId }
+      : {}),
+  });
+  const childSessionOrigin = resolveRequesterOriginForChild({
+    cfg: params.cfg,
+    targetAgentId: params.targetAgentId,
+    requesterAgentId: params.requesterAgentId,
+    requesterChannel: params.ctx.agentChannel,
+    requesterAccountId: params.ctx.agentAccountId,
+    requesterTo: params.ctx.agentTo,
+    requesterThreadId: params.ctx.agentThreadId,
+    requesterGroupSpace: params.ctx.agentGroupSpace,
+    requesterMemberRoleIds: params.ctx.agentMemberRoleIds,
+  });
+  const incognito = isIncognitoSessionKey(params.requesterInternalKey);
+  const mintedChildSessionKey = mintSpawnSessionKey({
+    targetAgentId: params.targetAgentId,
+    backend: "subagent",
+  });
+  const childSessionKey = incognito
+    ? mintedChildSessionKey.replace(":subagent:", ":subagent:incognito-")
+    : mintedChildSessionKey;
+  const requesterRuntime = resolveSandboxRuntimeStatus({
+    cfg: params.cfg,
+    sessionKey: params.requesterInternalKey,
+  });
+  const childRuntime = resolveSandboxRuntimeStatus({
+    cfg: params.cfg,
+    sessionKey: childSessionKey,
+  });
+  const sandboxError = resolveSpawnSandboxError({
+    backend: "subagent",
+    requesterSandboxed: requesterRuntime.sandboxed,
+    childSandboxed: childRuntime.sandboxed,
+    sandbox: params.sandboxMode,
+  });
+  if (sandboxError) {
+    return { ok: false, result: { status: "forbidden", error: sandboxError } };
+  }
+  const spawnedWorkspaceCwd = spawnedWorkspaceDir
+    ? resolveUserPath(spawnedWorkspaceDir)
+    : undefined;
+  if (childRuntime.sandboxed && spawnedCwd && spawnedCwd !== spawnedWorkspaceCwd) {
+    return {
+      ok: false,
+      result: {
+        status: "forbidden",
+        error:
+          "cwd override is not supported for sandboxed subagent runs; omit cwd or use the target agent workspace as cwd",
+      },
+    };
+  }
+  const targetAgentDir = resolveAgentDir(params.cfg, params.targetAgentId);
+  const requesterAgentConfig = resolveAgentConfig(params.cfg, params.requesterAgentId);
+  const targetAgentConfig = resolveAgentConfig(params.cfg, params.targetAgentId);
+  const callerThinkingRaw = readRequesterThinkingLevel({
+    cfg: params.cfg,
+    requesterInternalKey: params.requesterInternalKey,
+    requesterAgentId: params.requesterAgentId,
+  });
+  const inheritedFastMode =
+    params.swarmEnabled && params.request.fastMode === undefined
+      ? readRequesterFastMode({
+          cfg: params.cfg,
+          requesterInternalKey: params.requesterInternalKey,
+          requesterAgentId: params.requesterAgentId,
+        })
+      : params.request.fastMode;
+  const modelPlan = resolveSubagentModelAndThinkingPlan({
+    cfg: params.cfg,
+    targetAgentId: params.targetAgentId,
+    requesterAgentConfig,
+    targetAgentConfig,
+    modelOverride: params.request.model,
+    thinkingOverrideRaw: params.request.thinking,
+    callerThinkingRaw,
+    fastMode: inheritedFastMode,
+  });
+  if (modelPlan.status === "error") {
+    return {
+      ok: false,
+      result: {
+        status: "error",
+        error: modelPlan.error,
+      },
+    };
+  }
+  const { resolvedModel } = modelPlan;
+  const resolvedLaunchModel = splitModelRef(resolvedModel);
+  const launchAuthorization: SubagentLaunchAuthorization | undefined =
+    params.request.model?.trim() && resolvedLaunchModel.model
+      ? {
+          modelOverride: {
+            ...(resolvedLaunchModel.provider ? { provider: resolvedLaunchModel.provider } : {}),
+            model: resolvedLaunchModel.model,
+          },
+        }
+      : undefined;
+  if (params.request.outputSchema) {
+    const outputModelError = await resolveCollectorOutputModelError({
+      cfg: params.cfg,
+      targetAgentId: params.targetAgentId,
+      targetAgentDir,
+      workspaceDir: spawnedWorkspaceDir,
+      resolvedModel,
+    });
+    if (outputModelError) {
+      return {
+        ok: false,
+        result: { status: "error", error: outputModelError, childSessionKey },
+      };
+    }
+  }
+  return {
+    ok: true,
+    resolved: {
+      spawnedCwd,
+      toolSpawnMetadata,
+      spawnedWorkspaceDir,
+      requesterOrigin,
+      childSessionOrigin,
+      incognito,
+      childSessionKey,
+      childRuntimeSandboxed: childRuntime.sandboxed,
+      targetAgentDir,
+      modelPlan,
+      launchAuthorization,
+      resolvedModelMetadata: buildResolvedSubagentModelMetadata(resolvedModel),
+    },
+  };
+}

--- a/src/agents/subagent-spawn-cleanup.ts
+++ b/src/agents/subagent-spawn-cleanup.ts
@@ -1,0 +1,104 @@
+import { promises as fs } from "node:fs";
+import { isFastTestRuntimeEnv } from "../infra/env.js";
+import { callSubagentGateway } from "./subagent-spawn-gateway.js";
+
+const SUBAGENT_CONTROL_GATEWAY_TIMEOUT_MS = 60_000;
+
+export async function cleanupProvisionalSession(
+  childSessionKey: string,
+  options?: {
+    emitLifecycleHooks?: boolean;
+    deleteTranscript?: boolean;
+  },
+): Promise<boolean> {
+  try {
+    await callSubagentGateway({
+      method: "sessions.delete",
+      params: {
+        key: childSessionKey,
+        emitLifecycleHooks: options?.emitLifecycleHooks === true,
+        deleteTranscript: options?.deleteTranscript === true,
+      },
+      timeoutMs: SUBAGENT_CONTROL_GATEWAY_TIMEOUT_MS,
+    });
+    return true;
+  } catch {
+    // Best-effort cleanup only.
+    return false;
+  }
+}
+
+async function waitForProvisionalSessionDeletion(
+  childSessionKey: string,
+  options?: {
+    emitLifecycleHooks?: boolean;
+    deleteTranscript?: boolean;
+  },
+): Promise<void> {
+  for (;;) {
+    if (await cleanupProvisionalSession(childSessionKey, options)) {
+      return;
+    }
+    await new Promise<void>((resolve) => {
+      const timer = setTimeout(resolve, isFastTestRuntimeEnv() ? 1 : 1_000);
+      timer.unref?.();
+    });
+  }
+}
+
+export async function cleanupFailedSpawnBeforeAgentStart(params: {
+  childSessionKey: string;
+  attachmentAbsDir?: string;
+  emitLifecycleHooks?: boolean;
+  deleteTranscript?: boolean;
+  waitForSessionDeletion?: boolean;
+}): Promise<{ attachmentsRemoved: boolean; sessionDeleted: boolean }> {
+  let attachmentsRemoved = true;
+  if (params.attachmentAbsDir) {
+    try {
+      await fs.rm(params.attachmentAbsDir, { recursive: true, force: true });
+    } catch {
+      attachmentsRemoved = false;
+    }
+  }
+  const sessionCleanupOptions = {
+    emitLifecycleHooks: params.emitLifecycleHooks,
+    deleteTranscript: params.deleteTranscript,
+  };
+  if (params.waitForSessionDeletion) {
+    await waitForProvisionalSessionDeletion(params.childSessionKey, sessionCleanupOptions);
+    return { attachmentsRemoved, sessionDeleted: true };
+  }
+  return {
+    attachmentsRemoved,
+    sessionDeleted: await cleanupProvisionalSession(params.childSessionKey, sessionCleanupOptions),
+  };
+}
+
+export async function terminateAcceptedCollectorRun(params: {
+  childSessionKey: string;
+  gatewayRunId: string;
+}): Promise<void> {
+  for (;;) {
+    try {
+      await callSubagentGateway({
+        method: "chat.abort",
+        params: { sessionKey: params.childSessionKey, runId: params.gatewayRunId },
+        timeoutMs: SUBAGENT_CONTROL_GATEWAY_TIMEOUT_MS,
+      });
+      return;
+    } catch {
+      if (
+        await cleanupProvisionalSession(params.childSessionKey, {
+          deleteTranscript: true,
+        })
+      ) {
+        return;
+      }
+    }
+    await new Promise<void>((resolve) => {
+      const timer = setTimeout(resolve, isFastTestRuntimeEnv() ? 1 : 1_000);
+      timer.unref?.();
+    });
+  }
+}

--- a/src/agents/subagent-spawn-context.ts
+++ b/src/agents/subagent-spawn-context.ts
@@ -8,7 +8,7 @@ import { getSubagentSpawnDeps } from "./subagent-spawn-deps.js";
 import { resolveGatewaySessionStoreTarget } from "./subagent-spawn.runtime.js";
 import type { SpawnSubagentContextMode } from "./subagent-spawn.types.js";
 
-export type PreparedSpawnContext =
+type PreparedSpawnContext =
   | {
       status: "ok";
       mode: "isolated";

--- a/src/agents/subagent-spawn-context.ts
+++ b/src/agents/subagent-spawn-context.ts
@@ -1,0 +1,202 @@
+import { finiteSecondsToTimerSafeMilliseconds } from "@openclaw/normalization-core/number-coercion";
+import { resolveThreadBindingSpawnPolicy } from "../channels/thread-bindings-policy.js";
+import type { SessionEntry } from "../config/sessions/types.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { SubagentSpawnPreparation } from "../context-engine/types.js";
+import { summarizeSpawnError } from "./spawn-pipeline.js";
+import { getSubagentSpawnDeps } from "./subagent-spawn-deps.js";
+import { resolveGatewaySessionStoreTarget } from "./subagent-spawn.runtime.js";
+import type { SpawnSubagentContextMode } from "./subagent-spawn.types.js";
+
+export type PreparedSpawnContext =
+  | {
+      status: "ok";
+      mode: "isolated";
+      parentEntry?: SessionEntry;
+      childEntry?: SessionEntry;
+      forkFallbackNote?: string;
+    }
+  | {
+      status: "ok";
+      mode: "fork";
+      parentEntry: SessionEntry;
+      childEntry?: SessionEntry;
+      forked: { sessionId: string; sessionFile: string };
+      forkFallbackNote?: never;
+    }
+  | { status: "error"; error: string };
+
+export async function prepareSubagentSessionContext(params: {
+  cfg: OpenClawConfig;
+  contextMode: SpawnSubagentContextMode;
+  requesterAgentId: string;
+  targetAgentId: string;
+  requesterInternalKey: string;
+  childSessionKey: string;
+}): Promise<PreparedSpawnContext> {
+  if (params.contextMode === "isolated") {
+    return { status: "ok", mode: "isolated" };
+  }
+  const childTarget = resolveGatewaySessionStoreTarget({
+    cfg: params.cfg,
+    key: params.childSessionKey,
+  });
+  const parentTarget = resolveGatewaySessionStoreTarget({
+    cfg: params.cfg,
+    key: params.requesterInternalKey,
+  });
+
+  let parentEntry: SessionEntry | undefined;
+  let childEntry: SessionEntry | undefined;
+  let forkFallbackNote: string | undefined;
+
+  try {
+    if (params.targetAgentId !== params.requesterAgentId) {
+      throw new Error(
+        'context="fork" currently requires the same target agent as the requester; use context="isolated" for cross-agent spawns.',
+      );
+    }
+
+    const forkedResult = await getSubagentSpawnDeps().forkSessionEntryFromParent({
+      storePath: childTarget.storePath,
+      parentSessionKey: parentTarget.canonicalKey,
+      parentStoreKeys: parentTarget.storeKeys,
+      sessionKey: childTarget.canonicalKey,
+      sessionStoreKeys: childTarget.storeKeys,
+      fallbackEntry: { sessionId: "", updatedAt: Date.now() },
+      agentId: params.requesterAgentId,
+    });
+    if (forkedResult.status === "missing-parent") {
+      throw new Error(
+        'context="fork" requested but the requester session transcript is not available.',
+      );
+    }
+    if (forkedResult.status === "failed" || forkedResult.status === "missing-entry") {
+      throw new Error(
+        'context="fork" requested but OpenClaw could not fork the requester transcript.',
+      );
+    }
+    parentEntry = forkedResult.parentEntry;
+    childEntry = forkedResult.sessionEntry;
+    if (forkedResult.status === "skipped") {
+      forkFallbackNote =
+        forkedResult.decision?.status === "skip" ? forkedResult.decision.message : undefined;
+    }
+    const forked =
+      forkedResult.status === "forked"
+        ? {
+            sessionId: forkedResult.fork.sessionId,
+            sessionFile: forkedResult.fork.sessionFile,
+          }
+        : null;
+
+    if (params.contextMode === "fork") {
+      if (!parentEntry || !forked) {
+        if (forkFallbackNote) {
+          return {
+            status: "ok",
+            mode: "isolated",
+            parentEntry,
+            childEntry,
+            forkFallbackNote,
+          };
+        }
+        return {
+          status: "error",
+          error: 'context="fork" requested but OpenClaw could not prepare forked context.',
+        };
+      }
+      return {
+        status: "ok",
+        mode: "fork",
+        parentEntry,
+        childEntry,
+        forked,
+      };
+    }
+    return {
+      status: "ok",
+      mode: "isolated",
+      parentEntry,
+      childEntry,
+      ...(forkFallbackNote ? { forkFallbackNote } : {}),
+    };
+  } catch (err) {
+    return { status: "error", error: summarizeSpawnError(err) };
+  }
+}
+
+export async function prepareContextEngineSubagentSpawn(params: {
+  cfg: OpenClawConfig;
+  context: PreparedSpawnContext & { status: "ok" };
+  requesterInternalKey: string;
+  childSessionKey: string;
+  runTimeoutSeconds: number;
+}): Promise<
+  { status: "ok"; preparation?: SubagentSpawnPreparation } | { status: "error"; error: string }
+> {
+  try {
+    const deps = getSubagentSpawnDeps();
+    deps.ensureContextEnginesInitialized();
+    const engine = await deps.resolveContextEngine(params.cfg);
+    const preparation = await engine.prepareSubagentSpawn?.({
+      parentSessionKey: params.requesterInternalKey,
+      childSessionKey: params.childSessionKey,
+      contextMode: params.context.mode,
+      parentSessionId: params.context.parentEntry?.sessionId,
+      parentSessionFile: params.context.parentEntry?.sessionFile,
+      childSessionId:
+        params.context.mode === "fork"
+          ? params.context.forked.sessionId
+          : params.context.childEntry?.sessionId,
+      childSessionFile:
+        params.context.mode === "fork"
+          ? params.context.forked.sessionFile
+          : params.context.childEntry?.sessionFile,
+      ttlMs: finiteSecondsToTimerSafeMilliseconds(params.runTimeoutSeconds, {
+        floorSeconds: true,
+      }),
+    });
+    return { status: "ok", preparation };
+  } catch (err) {
+    return {
+      status: "error",
+      error: `Context engine subagent preparation failed: ${summarizeSpawnError(err)}`,
+    };
+  }
+}
+
+export async function rollbackPreparedContextEngine(
+  preparation?: SubagentSpawnPreparation,
+): Promise<boolean> {
+  try {
+    await preparation?.rollback();
+    return true;
+  } catch {
+    // Best-effort cleanup only.
+    return false;
+  }
+}
+
+export function resolveSubagentContextMode(params: {
+  requestedContext?: SpawnSubagentContextMode;
+  threadRequested: boolean;
+  cfg: OpenClawConfig;
+  requester: {
+    channel?: string;
+    accountId?: string;
+  };
+}): SpawnSubagentContextMode {
+  if (params.requestedContext === "fork" || params.requestedContext === "isolated") {
+    return params.requestedContext;
+  }
+  if (!params.threadRequested || !params.requester.channel) {
+    return "isolated";
+  }
+  return resolveThreadBindingSpawnPolicy({
+    cfg: params.cfg,
+    channel: params.requester.channel,
+    accountId: params.requester.accountId,
+    kind: "subagent",
+  }).defaultSpawnContext;
+}

--- a/src/agents/subagent-spawn-contract.ts
+++ b/src/agents/subagent-spawn-contract.ts
@@ -1,0 +1,85 @@
+import type { FastMode } from "../shared/fast-mode.js";
+import type {
+  SpawnSubagentContextMode,
+  SpawnSubagentMode,
+  SpawnSubagentSandboxMode,
+} from "./subagent-spawn.types.js";
+
+export type SpawnSubagentParams = {
+  task: string;
+  label?: string;
+  agentId?: string;
+  model?: string;
+  taskName?: string;
+  thinking?: string;
+  fastMode?: FastMode;
+  collect?: boolean;
+  outputSchema?: Record<string, unknown>;
+  groupId?: string;
+  /** Host bridge identity used to recover a replay-safe collector launch. */
+  swarmLaunchReplayKey?: string;
+  /** Canonical request hash checked before reusing a host-reserved collector. */
+  swarmLaunchRequestFingerprint?: string;
+  cwd?: string;
+  runTimeoutSeconds?: number;
+  thread?: boolean;
+  mode?: SpawnSubagentMode;
+  cleanup?: "delete" | "keep";
+  sandbox?: SpawnSubagentSandboxMode;
+  context?: SpawnSubagentContextMode;
+  lightContext?: boolean;
+  expectsCompletionMessage?: boolean;
+  attachments?: Array<{
+    name: string;
+    content: string;
+    encoding?: "utf8" | "base64";
+    mimeType?: string;
+  }>;
+  attachMountPath?: string;
+};
+
+export type SpawnSubagentContext = {
+  agentSessionKey?: string;
+  requesterTurnRunId?: string;
+  /** Separate key used only for completion routing, not sandbox policy. */
+  completionOwnerKey?: string;
+  agentChannel?: string;
+  agentAccountId?: string;
+  agentTo?: string;
+  agentThreadId?: string | number;
+  currentMessagingTarget?: string;
+  currentChannelId?: string;
+  currentMessageId?: string | number;
+  agentGroupId?: string | null;
+  agentGroupChannel?: string | null;
+  agentGroupSpace?: string | null;
+  agentMemberRoleIds?: string[];
+  requesterAgentIdOverride?: string;
+  /** Explicit workspace directory for subagent to inherit (optional). */
+  workspaceDir?: string;
+  inheritedToolAllowlist?: string[];
+  inheritedToolDenylist?: string[];
+  requesterRunId?: string;
+};
+
+export type SpawnSubagentResult = {
+  status: "accepted" | "forbidden" | "error";
+  childSessionKey?: string;
+  sessionKey?: string;
+  runId?: string;
+  mode?: SpawnSubagentMode;
+  taskName?: string;
+  note?: string;
+  /** Fully resolved model ref applied to the spawned child session. */
+  resolvedModel?: string;
+  /** Provider prefix parsed from resolvedModel when the ref includes one. */
+  resolvedProvider?: string;
+  modelApplied?: boolean;
+  error?: string;
+  attachments?: {
+    count: number;
+    totalBytes: number;
+    files: Array<{ name: string; bytes: number; sha256: string }>;
+    relDir: string;
+  };
+};

--- a/src/agents/subagent-spawn-deps.ts
+++ b/src/agents/subagent-spawn-deps.ts
@@ -1,0 +1,51 @@
+import type { SubagentLifecycleHookRunner } from "../plugins/hooks.js";
+import {
+  callGateway,
+  dispatchGatewayMethodInProcess,
+  ensureContextEnginesInitialized,
+  forkSessionEntryFromParent,
+  getGlobalHookRunner,
+  getRuntimeConfig,
+  hasInProcessGatewayContext,
+  loadPreparedModelCatalog,
+  resolveContextEngine,
+} from "./subagent-spawn.runtime.js";
+
+export type SubagentSpawnDeps = {
+  callGateway: typeof callGateway;
+  dispatchGatewayMethodInProcess: typeof dispatchGatewayMethodInProcess;
+  forkSessionEntryFromParent: typeof forkSessionEntryFromParent;
+  getGlobalHookRunner: () => SubagentLifecycleHookRunner | null;
+  getRuntimeConfig: typeof getRuntimeConfig;
+  hasInProcessGatewayContext: typeof hasInProcessGatewayContext;
+  ensureContextEnginesInitialized: typeof ensureContextEnginesInitialized;
+  loadPreparedModelCatalog: typeof loadPreparedModelCatalog;
+  resolveContextEngine: typeof resolveContextEngine;
+};
+
+const defaultSubagentSpawnDeps: SubagentSpawnDeps = {
+  callGateway,
+  dispatchGatewayMethodInProcess,
+  forkSessionEntryFromParent,
+  getGlobalHookRunner,
+  getRuntimeConfig,
+  hasInProcessGatewayContext,
+  ensureContextEnginesInitialized,
+  loadPreparedModelCatalog,
+  resolveContextEngine,
+};
+
+let subagentSpawnDeps = defaultSubagentSpawnDeps;
+
+export function getSubagentSpawnDeps(): SubagentSpawnDeps {
+  return subagentSpawnDeps;
+}
+
+export function setSubagentSpawnDepsForTest(overrides?: Partial<SubagentSpawnDeps>): void {
+  subagentSpawnDeps = overrides
+    ? {
+        ...defaultSubagentSpawnDeps,
+        ...overrides,
+      }
+    : defaultSubagentSpawnDeps;
+}

--- a/src/agents/subagent-spawn-deps.ts
+++ b/src/agents/subagent-spawn-deps.ts
@@ -11,7 +11,7 @@ import {
   resolveContextEngine,
 } from "./subagent-spawn.runtime.js";
 
-export type SubagentSpawnDeps = {
+type SubagentSpawnDeps = {
   callGateway: typeof callGateway;
   dispatchGatewayMethodInProcess: typeof dispatchGatewayMethodInProcess;
   forkSessionEntryFromParent: typeof forkSessionEntryFromParent;

--- a/src/agents/subagent-spawn-gateway.ts
+++ b/src/agents/subagent-spawn-gateway.ts
@@ -1,0 +1,95 @@
+import type { SubagentLaunchAuthorization } from "./subagent-launch-authorization.js";
+import { applySubagentLaunchAuthorization } from "./subagent-launch-authorization.js";
+import { resolveSubagentRunTimerDelayMs } from "./subagent-run-timeout.js";
+import { getSubagentSpawnDeps } from "./subagent-spawn-deps.js";
+import {
+  ADMIN_SCOPE,
+  callGateway,
+  resolveLeastPrivilegeOperatorScopesForMethod,
+} from "./subagent-spawn.runtime.js";
+
+const DEFAULT_SUBAGENT_AGENT_GATEWAY_TIMEOUT_MS = 60_000;
+const MAX_SUBAGENT_AGENT_GATEWAY_TIMEOUT_MS = 300_000;
+
+export async function callSubagentGateway(
+  params: Parameters<typeof callGateway>[0],
+  authorization?: SubagentLaunchAuthorization,
+): Promise<Awaited<ReturnType<typeof callGateway>>> {
+  // Subagent lifecycle requires methods spanning multiple scope tiers
+  // (sessions.delete → admin, agent → write). When each call
+  // independently negotiates least-privilege scopes the first connection pairs
+  // at a lower tier and every subsequent higher-tier call triggers a
+  // scope-upgrade handshake that headless gateway-client connections cannot
+  // complete interactively, causing close(1008) "pairing required" (#59428).
+  //
+  // Only admin-requiring calls are pinned to ADMIN_SCOPE; other methods (e.g.
+  // "agent" -> write) keep their least-privilege scope. Apply the trusted
+  // launch authorization before resolving the request's required scope.
+  const authorizedParams =
+    params.params != null && typeof params.params === "object" && !Array.isArray(params.params)
+      ? applySubagentLaunchAuthorization(params.params as Record<string, unknown>, authorization)
+      : params.params;
+  const leastPrivilegeScopes = resolveLeastPrivilegeOperatorScopesForMethod(
+    params.method,
+    authorizedParams,
+  );
+  const allowModelOverride = authorization !== undefined;
+  const deps = getSubagentSpawnDeps();
+  const hasInProcessGateway = deps.hasInProcessGatewayContext();
+  const needsOutOfProcessModelOverrideAuth = allowModelOverride && !hasInProcessGateway;
+  const scopes =
+    params.scopes ??
+    (leastPrivilegeScopes.includes(ADMIN_SCOPE) || needsOutOfProcessModelOverrideAuth
+      ? [ADMIN_SCOPE]
+      : undefined);
+  const request = {
+    ...params,
+    params: authorizedParams,
+    ...(scopes != null ? { scopes } : {}),
+  };
+  if (
+    hasInProcessGateway &&
+    request.params != null &&
+    typeof request.params === "object" &&
+    !Array.isArray(request.params)
+  ) {
+    // Spawn is already running in the gateway process for channel/tool calls.
+    // Direct dispatch avoids self-connecting over WS while the same event loop is busy.
+    // Agent launches are host-owned even when the parent request came from CLI/HTTP.
+    // Reusing that external identity makes collector preflight treat the launch as spoofed.
+    const forceSyntheticClient = request.method === "agent" || scopes != null;
+    return await deps.dispatchGatewayMethodInProcess(
+      request.method,
+      request.params as Record<string, unknown>,
+      {
+        expectFinal: request.expectFinal,
+        ...(allowModelOverride ? { allowSyntheticModelOverride: true } : {}),
+        ...(forceSyntheticClient ? { forceSyntheticClient: true } : {}),
+        ...(typeof request.timeoutMs === "number" ? { timeoutMs: request.timeoutMs } : {}),
+        ...(scopes != null ? { syntheticScopes: scopes } : {}),
+      },
+    );
+  }
+  return await deps.callGateway(request);
+}
+
+export function readGatewayRunId(
+  response: Awaited<ReturnType<typeof callGateway>>,
+): string | undefined {
+  if (!response || typeof response !== "object") {
+    return undefined;
+  }
+  const { runId } = response as { runId?: unknown };
+  return typeof runId === "string" && runId ? runId : undefined;
+}
+
+export function resolveSubagentAgentGatewayTimeoutMs(runTimeoutSeconds: number): number {
+  const runTimeoutMs = resolveSubagentRunTimerDelayMs(runTimeoutSeconds) ?? 0;
+  if (runTimeoutMs <= 0) {
+    return DEFAULT_SUBAGENT_AGENT_GATEWAY_TIMEOUT_MS;
+  }
+  return Math.min(
+    MAX_SUBAGENT_AGENT_GATEWAY_TIMEOUT_MS,
+    Math.max(DEFAULT_SUBAGENT_AGENT_GATEWAY_TIMEOUT_MS, runTimeoutMs + 5_000),
+  );
+}

--- a/src/agents/subagent-spawn-launch-request.ts
+++ b/src/agents/subagent-spawn-launch-request.ts
@@ -1,0 +1,152 @@
+import { stringifyRouteThreadId } from "../plugin-sdk/channel-route.js";
+import type { BootstrapContextMode } from "./bootstrap-files.js";
+import { normalizeSpawnedRunMetadata } from "./spawned-context.js";
+import { buildSubagentInitialUserMessage } from "./subagent-initial-user-message.js";
+import type { SubagentLaunchAuthorization } from "./subagent-launch-authorization.js";
+import { resolveSubagentAgentGatewayTimeoutMs } from "./subagent-spawn-gateway.js";
+import { AGENT_LANE_SUBAGENT } from "./subagent-spawn.runtime.js";
+import type { SpawnSubagentMode } from "./subagent-spawn.types.js";
+
+export function buildSubagentLaunchRequest(params: {
+  childDepth: number;
+  maxSpawnDepth: number;
+  spawnMode: SpawnSubagentMode;
+  task: string;
+  spawnedByKey: string;
+  toolSpawnMetadata: Parameters<typeof normalizeSpawnedRunMetadata>[0];
+  spawnedWorkspaceDir?: string;
+  childSessionKey: string;
+  collect: boolean;
+  childSessionOrigin?: {
+    channel?: string;
+    to?: string;
+    accountId?: string;
+    threadId?: string | number;
+  };
+  childIdem: string;
+  deliverInitialChildRunDirectly: boolean;
+  outputSchema?: Record<string, unknown>;
+  childSystemPrompt: string;
+  thinkingOverride?: string;
+  runTimeoutSeconds: number;
+  label?: string;
+  lightContext: boolean;
+  expectsCompletionMessage: boolean;
+  requesterOrigin?: {
+    channel?: string;
+    accountId?: string;
+    to?: string;
+    threadId?: string | number;
+  };
+  currentMessagingTarget?: string;
+  currentChannelId?: string;
+  currentMessageId?: string | number;
+  launchAuthorization?: SubagentLaunchAuthorization;
+  swarmSchedulerGroupKey?: string;
+  swarmMaxConcurrent: number;
+}): {
+  childLaunch: {
+    request: Record<string, unknown>;
+    authorization?: SubagentLaunchAuthorization;
+    timeoutMs: number;
+  };
+  queuedLaunch?: {
+    request: Record<string, unknown>;
+    authorization?: SubagentLaunchAuthorization;
+    timeoutMs: number;
+    schedulerGroupKey: string;
+    maxConcurrent: number;
+  };
+  progressOrigin: {
+    channel?: string;
+    accountId?: string;
+    to?: string;
+    threadId?: string | number;
+    channelId?: string;
+    messageId?: string | number;
+  };
+  shouldAnnounceCompletion: boolean;
+  spawnedMetadata: ReturnType<typeof normalizeSpawnedRunMetadata>;
+} {
+  const bootstrapContextMode: BootstrapContextMode | undefined = params.lightContext
+    ? "lightweight"
+    : undefined;
+  const childTaskMessage = buildSubagentInitialUserMessage({
+    childDepth: params.childDepth,
+    maxSpawnDepth: params.maxSpawnDepth,
+    persistentSession: params.spawnMode === "session",
+    task: params.task,
+  });
+  const spawnedMetadata = normalizeSpawnedRunMetadata({
+    spawnedBy: params.spawnedByKey,
+    ...params.toolSpawnMetadata,
+    workspaceDir: params.spawnedWorkspaceDir,
+  });
+  const {
+    spawnedBy: _spawnedBy,
+    workspaceDir: _workspaceDir,
+    ...publicSpawnedMetadata
+  } = spawnedMetadata;
+  const request: Record<string, unknown> = {
+    message: childTaskMessage,
+    sessionKey: params.childSessionKey,
+    ...(params.collect
+      ? {}
+      : {
+          channel: params.childSessionOrigin?.channel,
+          to: params.childSessionOrigin?.to ?? undefined,
+          accountId: params.childSessionOrigin?.accountId ?? undefined,
+          threadId:
+            params.childSessionOrigin?.threadId != null
+              ? stringifyRouteThreadId(params.childSessionOrigin.threadId)
+              : undefined,
+        }),
+    idempotencyKey: params.childIdem,
+    deliver: params.deliverInitialChildRunDirectly,
+    lane: AGENT_LANE_SUBAGENT,
+    disableMessageTool: true,
+    swarmCollector: params.collect,
+    swarmOutputSchema: params.outputSchema,
+    cleanupBundleMcpOnRunEnd: params.spawnMode !== "session",
+    extraSystemPrompt: params.childSystemPrompt,
+    thinking: params.thinkingOverride,
+    timeout: params.runTimeoutSeconds,
+    label: params.label,
+    ...(bootstrapContextMode
+      ? {
+          bootstrapContextMode,
+          bootstrapContextRunKind: "default" as const,
+        }
+      : {}),
+    ...publicSpawnedMetadata,
+  };
+  const childLaunch = {
+    request,
+    ...(params.launchAuthorization ? { authorization: params.launchAuthorization } : {}),
+    timeoutMs: resolveSubagentAgentGatewayTimeoutMs(params.runTimeoutSeconds),
+  };
+  const queuedLaunch =
+    params.collect && params.swarmSchedulerGroupKey
+      ? {
+          ...childLaunch,
+          schedulerGroupKey: params.swarmSchedulerGroupKey,
+          maxConcurrent: params.swarmMaxConcurrent,
+        }
+      : undefined;
+  return {
+    childLaunch,
+    queuedLaunch,
+    progressOrigin: {
+      channel: params.requesterOrigin?.channel,
+      accountId: params.requesterOrigin?.accountId,
+      to: params.currentMessagingTarget ?? params.requesterOrigin?.to,
+      threadId: params.requesterOrigin?.threadId,
+      channelId: params.currentChannelId,
+      messageId: params.currentMessageId,
+    },
+    shouldAnnounceCompletion: params.deliverInitialChildRunDirectly
+      ? false
+      : params.expectsCompletionMessage,
+    spawnedMetadata,
+  };
+}

--- a/src/agents/subagent-spawn-lifecycle.ts
+++ b/src/agents/subagent-spawn-lifecycle.ts
@@ -1,0 +1,78 @@
+import type { SubagentLifecycleHookRunner } from "../plugins/hooks.js";
+import type { DeliveryContext } from "../utils/delivery-context.types.js";
+import type { SpawnSubagentMode } from "./subagent-spawn.types.js";
+
+export function createSubagentSpawnLifecycleEmitter(params: {
+  hookRunner: SubagentLifecycleHookRunner | null;
+  childSessionKey: string;
+  requesterInternalKey: string;
+  progressOrigin: {
+    channel?: string;
+    accountId?: string;
+    to?: string;
+    threadId?: string | number;
+    channelId?: string;
+    messageId?: string | number;
+  };
+  targetAgentId: string;
+  label?: string;
+  requesterOrigin?: DeliveryContext;
+  requestThreadBinding: boolean;
+  spawnMode: SpawnSubagentMode;
+  resolvedModelMetadata: {
+    resolvedModel?: string;
+    resolvedProvider?: string;
+  };
+}): (hookRunId: string) => Promise<void> {
+  // "spawned"/"started" hooks mean an accepted Gateway run. Direct runs emit
+  // after the shared pipeline; queued collectors emit from the scheduler start.
+  return async (hookRunId: string) => {
+    if (params.hookRunner?.hasHooks("subagent_progress")) {
+      try {
+        await params.hookRunner.runSubagentProgress(
+          {
+            phase: "started",
+            runId: hookRunId,
+            childSessionKey: params.childSessionKey,
+            requester: params.progressOrigin,
+          },
+          {
+            runId: hookRunId,
+            childSessionKey: params.childSessionKey,
+            requesterSessionKey: params.requesterInternalKey,
+          },
+        );
+      } catch {
+        // Presentation hooks are best-effort after durable registration.
+      }
+    }
+    if (params.hookRunner?.hasHooks("subagent_spawned")) {
+      try {
+        await params.hookRunner.runSubagentSpawned(
+          {
+            runId: hookRunId,
+            childSessionKey: params.childSessionKey,
+            agentId: params.targetAgentId,
+            label: params.label,
+            requester: {
+              channel: params.requesterOrigin?.channel,
+              accountId: params.requesterOrigin?.accountId,
+              to: params.requesterOrigin?.to,
+              threadId: params.requesterOrigin?.threadId,
+            },
+            threadRequested: params.requestThreadBinding,
+            mode: params.spawnMode,
+            ...params.resolvedModelMetadata,
+          },
+          {
+            runId: hookRunId,
+            childSessionKey: params.childSessionKey,
+            requesterSessionKey: params.requesterInternalKey,
+          },
+        );
+      } catch {
+        // Spawn stays accepted if lifecycle presentation fails.
+      }
+    }
+  };
+}

--- a/src/agents/subagent-spawn-model.ts
+++ b/src/agents/subagent-spawn-model.ts
@@ -1,0 +1,57 @@
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { findModelCatalogEntry } from "./model-catalog-lookup.js";
+import { resolveDefaultModelForAgent } from "./model-selection.js";
+import { supportsModelTools } from "./model-tool-support.js";
+import { summarizeSpawnError } from "./spawn-pipeline.js";
+import { getSubagentSpawnDeps } from "./subagent-spawn-deps.js";
+import { splitModelRef } from "./subagent-spawn-plan.js";
+import { loadPreparedModelCatalog } from "./subagent-spawn.runtime.js";
+
+export function buildResolvedSubagentModelMetadata(resolvedModel?: string): {
+  resolvedModel?: string;
+  resolvedProvider?: string;
+} {
+  const modelRef = resolvedModel?.trim();
+  if (!modelRef) {
+    return {};
+  }
+  const { provider } = splitModelRef(modelRef);
+  return {
+    resolvedModel: modelRef,
+    ...(provider ? { resolvedProvider: provider } : {}),
+  };
+}
+
+export async function resolveCollectorOutputModelError(params: {
+  cfg: OpenClawConfig;
+  targetAgentId: string;
+  targetAgentDir: string;
+  workspaceDir?: string;
+  resolvedModel?: string;
+}): Promise<string | undefined> {
+  const selected = splitModelRef(params.resolvedModel);
+  const fallback = resolveDefaultModelForAgent({
+    cfg: params.cfg,
+    agentId: params.targetAgentId,
+  });
+  const provider = selected.provider ?? fallback.provider;
+  const model = selected.model ?? fallback.model;
+  if (!provider || !model) {
+    return undefined;
+  }
+  let catalog: Awaited<ReturnType<typeof loadPreparedModelCatalog>>;
+  try {
+    catalog = await getSubagentSpawnDeps().loadPreparedModelCatalog({
+      config: params.cfg,
+      agentDir: params.targetAgentDir,
+      workspaceDir: params.workspaceDir,
+    });
+  } catch (error) {
+    return `sessions_spawn could not verify outputSchema model capabilities: ${summarizeSpawnError(error)}`;
+  }
+  const entry = findModelCatalogEntry(catalog, { provider, modelId: model });
+  if (!entry || supportsModelTools(entry)) {
+    return undefined;
+  }
+  return `sessions_spawn outputSchema requires a tool-capable target model; "${provider}/${model}" declares compat.supportsTools=false.`;
+}

--- a/src/agents/subagent-spawn-request.ts
+++ b/src/agents/subagent-spawn-request.ts
@@ -62,6 +62,10 @@ export type ResolveSubagentSpawnRequestResult =
 export function resolveSubagentSpawnRequest(
   params: SpawnSubagentParams,
   ctx: SpawnSubagentContext,
+  requestedAgent: {
+    initial?: string;
+    applyDefault: (agentId?: string) => string | undefined;
+  },
 ): ResolveSubagentSpawnRequestResult {
   const taskNameResult = normalizeSubagentTaskName(params.taskName);
   if (taskNameResult.error) {
@@ -74,7 +78,7 @@ export function resolveSubagentSpawnRequest(
     };
   }
   const taskName = taskNameResult.taskName;
-  let requestedAgentId = params.agentId?.trim();
+  const requestedAgentId = requestedAgent.initial;
 
   // Reject malformed agentId before normalizeAgentId can mangle it.
   // Without this gate, error-message strings like "Agent not found: xyz" pass
@@ -196,19 +200,23 @@ export function resolveSubagentSpawnRequest(
 
   const usingDefaultAgentId =
     params.collect === true && !requestedAgentId && Boolean(swarmConfig.defaultAgentId);
+  const effectiveRequestedAgentId = usingDefaultAgentId
+    ? requestedAgent.applyDefault(swarmConfig.defaultAgentId)
+    : requestedAgentId;
   if (usingDefaultAgentId) {
-    requestedAgentId = swarmConfig.defaultAgentId;
-    if (!isValidAgentId(requestedAgentId)) {
+    if (!isValidAgentId(effectiveRequestedAgentId)) {
       return {
         ok: false,
         result: {
           status: "error",
-          error: `tools.swarm.defaultAgentId contains invalid agentId "${requestedAgentId}".`,
+          error: `tools.swarm.defaultAgentId contains invalid agentId "${effectiveRequestedAgentId}".`,
         },
       };
     }
   }
-  const targetAgentId = requestedAgentId ? normalizeAgentId(requestedAgentId) : requesterAgentId;
+  const targetAgentId = effectiveRequestedAgentId
+    ? normalizeAgentId(effectiveRequestedAgentId)
+    : requesterAgentId;
   const configuredAgentIds = resolveConfiguredAgentIds(cfg);
   const explicitSwarmGroupId = normalizeOptionalString(params.groupId);
   const requesterRunId = normalizeOptionalString(ctx.requesterRunId);
@@ -238,7 +246,7 @@ export function resolveSubagentSpawnRequest(
       requesterSessionKey: requesterInternalKey,
       requesterAgentId,
       targetAgentId,
-      requestedAgentId,
+      requestedAgentId: effectiveRequestedAgentId,
       configuredAgentIds,
     });
   };

--- a/src/agents/subagent-spawn-request.ts
+++ b/src/agents/subagent-spawn-request.ts
@@ -55,7 +55,7 @@ type ResolvedSubagentSpawnRequest = {
   childIdem: string;
 };
 
-export type ResolveSubagentSpawnRequestResult =
+type ResolveSubagentSpawnRequestResult =
   | { ok: false; result: SpawnSubagentResult }
   | { ok: true; resolved: ResolvedSubagentSpawnRequest };
 

--- a/src/agents/subagent-spawn-request.ts
+++ b/src/agents/subagent-spawn-request.ts
@@ -1,0 +1,333 @@
+import crypto from "node:crypto";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { SubagentLifecycleHookRunner } from "../plugins/hooks.js";
+import { isValidAgentId, normalizeAgentId, parseAgentSessionKey } from "../routing/session-key.js";
+import { resolveSpawnAdmission, resolveSpawnMode } from "./spawn-plan.js";
+import { listSwarmRunsForGroup } from "./subagent-registry.js";
+import { resolveSubagentContextMode } from "./subagent-spawn-context.js";
+import type {
+  SpawnSubagentContext,
+  SpawnSubagentParams,
+  SpawnSubagentResult,
+} from "./subagent-spawn-contract.js";
+import { getSubagentSpawnDeps } from "./subagent-spawn-deps.js";
+import { resolveSubagentSpawnOwnership } from "./subagent-spawn-ownership.js";
+import { resolveConfiguredSubagentRunTimeoutSeconds } from "./subagent-spawn-plan.js";
+import { loadSubagentConfig } from "./subagent-spawn-session-patch.js";
+import { resolveConfiguredAgentIds } from "./subagent-spawn-validation.js";
+import { resolveInternalSessionKey, resolveMainSessionAlias } from "./subagent-spawn.runtime.js";
+import { normalizeSubagentTaskName } from "./subagent-task-name.js";
+import { resolveSwarmConfig } from "./swarm-config.js";
+import { validateStructuredOutputSchema } from "./swarm-output-schema.js";
+import { reserveSwarmRun } from "./swarm-scheduler.js";
+
+type ResolvedSubagentSpawnRequest = {
+  request: {
+    taskName?: string;
+    spawnMode: ReturnType<typeof resolveSpawnMode>;
+    cleanup: "delete" | "keep";
+    expectsCompletionMessage: boolean;
+  };
+  runtime: {
+    hookRunner: SubagentLifecycleHookRunner | null;
+    cfg: OpenClawConfig;
+    runTimeoutSeconds: number;
+    contextMode: ReturnType<typeof resolveSubagentContextMode>;
+    requesterInternalKey: string;
+    ownership: ReturnType<typeof resolveSubagentSpawnOwnership>;
+    requesterAgentId: string;
+    targetAgentId: string;
+  };
+  swarm: {
+    config: ReturnType<typeof resolveSwarmConfig>;
+    groupId?: string;
+    schedulerGroupKey?: string;
+    launchReplayKey?: string;
+    reservationPending: boolean;
+  };
+  admission: {
+    resolve: () => ReturnType<typeof resolveSpawnAdmission>;
+    initial: ReturnType<typeof resolveSpawnAdmission> & { ok: true };
+    childDepth: number;
+    maxSpawnDepth: number;
+  };
+  childIdem: string;
+};
+
+export type ResolveSubagentSpawnRequestResult =
+  | { ok: false; result: SpawnSubagentResult }
+  | { ok: true; resolved: ResolvedSubagentSpawnRequest };
+
+export function resolveSubagentSpawnRequest(
+  params: SpawnSubagentParams,
+  ctx: SpawnSubagentContext,
+): ResolveSubagentSpawnRequestResult {
+  const taskNameResult = normalizeSubagentTaskName(params.taskName);
+  if (taskNameResult.error) {
+    return {
+      ok: false,
+      result: {
+        status: "error",
+        error: taskNameResult.error,
+      },
+    };
+  }
+  const taskName = taskNameResult.taskName;
+  let requestedAgentId = params.agentId?.trim();
+
+  // Reject malformed agentId before normalizeAgentId can mangle it.
+  // Without this gate, error-message strings like "Agent not found: xyz" pass
+  // through normalizeAgentId and become "agent-not-found--xyz", which later
+  // creates ghost workspace directories and triggers cascading cron loops (#31311).
+  if (requestedAgentId && !isValidAgentId(requestedAgentId)) {
+    return {
+      ok: false,
+      result: {
+        status: "error",
+        error: `Invalid agentId "${requestedAgentId}". Agent IDs must match [a-z0-9][a-z0-9_-]{0,63}. Use agents_list to discover valid targets.`,
+      },
+    };
+  }
+  const requestThreadBinding = params.thread === true;
+  const spawnMode = resolveSpawnMode({
+    requestedMode: params.mode,
+    threadRequested: requestThreadBinding,
+  });
+  if (params.collect && (requestThreadBinding || spawnMode === "session")) {
+    return {
+      ok: false,
+      result: {
+        status: "error",
+        error: "sessions_spawn collect=true requires mode=run and thread=false.",
+      },
+    };
+  }
+  if (spawnMode === "session" && !requestThreadBinding) {
+    return {
+      ok: false,
+      result: {
+        status: "error",
+        error:
+          'sessions_spawn(mode="session") requires thread=true so the subagent can stay bound to a channel thread. ' +
+          'Retry with { mode: "session", thread: true } on a channel that supports threads, use mode="run" for one-shot work, or use sessions_send(sessionKey=...) to keep talking to a persistent session without thread binding.',
+      },
+    };
+  }
+  const cleanup =
+    spawnMode === "session"
+      ? "keep"
+      : params.cleanup === "keep" || params.cleanup === "delete"
+        ? params.cleanup
+        : "keep";
+  const expectsCompletionMessage = params.collect
+    ? false
+    : params.expectsCompletionMessage !== false;
+  const hookRunner = getSubagentSpawnDeps().getGlobalHookRunner();
+  const cfg = loadSubagentConfig();
+
+  // When agent omits runTimeoutSeconds, use the config default.
+  // Falls back to 0 (no timeout) if config key is also unset,
+  // preserving current behavior for existing deployments.
+  const runTimeoutSeconds = resolveConfiguredSubagentRunTimeoutSeconds({
+    cfg,
+    runTimeoutSeconds: params.runTimeoutSeconds,
+  });
+  const contextMode = resolveSubagentContextMode({
+    requestedContext: params.context,
+    threadRequested: requestThreadBinding,
+    cfg,
+    requester: {
+      channel: ctx.agentChannel,
+      accountId: ctx.agentAccountId,
+    },
+  });
+  const { mainKey, alias } = resolveMainSessionAlias(cfg);
+  const requesterSessionKey = ctx.agentSessionKey;
+  const requesterInternalKey = requesterSessionKey
+    ? resolveInternalSessionKey({
+        key: requesterSessionKey,
+        alias,
+        mainKey,
+      })
+    : alias;
+  const ownership = resolveSubagentSpawnOwnership({
+    cfg,
+    agentSessionKey: ctx.agentSessionKey,
+    completionOwnerKey: ctx.completionOwnerKey,
+  });
+
+  const requesterAgentId = normalizeAgentId(
+    ctx.requesterAgentIdOverride ?? parseAgentSessionKey(requesterInternalKey)?.agentId,
+  );
+  const swarmConfig = resolveSwarmConfig(cfg, requesterAgentId);
+  const hasSwarmParams =
+    params.collect !== undefined ||
+    params.outputSchema !== undefined ||
+    params.fastMode !== undefined ||
+    params.groupId !== undefined;
+  if (hasSwarmParams && !swarmConfig.enabled) {
+    return {
+      ok: false,
+      result: {
+        status: "forbidden",
+        error: "sessions_spawn swarm parameters require tools.swarm.enabled=true.",
+      },
+    };
+  }
+  if (params.outputSchema && !params.collect) {
+    return {
+      ok: false,
+      result: { status: "error", error: "sessions_spawn outputSchema requires collect=true." },
+    };
+  }
+  if (params.groupId !== undefined && !params.collect) {
+    return {
+      ok: false,
+      result: { status: "error", error: "sessions_spawn groupId requires collect=true." },
+    };
+  }
+  if (params.outputSchema) {
+    const schemaError = validateStructuredOutputSchema(params.outputSchema);
+    if (schemaError) {
+      return { ok: false, result: { status: "error", error: schemaError } };
+    }
+  }
+
+  const usingDefaultAgentId =
+    params.collect === true && !requestedAgentId && Boolean(swarmConfig.defaultAgentId);
+  if (usingDefaultAgentId) {
+    requestedAgentId = swarmConfig.defaultAgentId;
+    if (!isValidAgentId(requestedAgentId)) {
+      return {
+        ok: false,
+        result: {
+          status: "error",
+          error: `tools.swarm.defaultAgentId contains invalid agentId "${requestedAgentId}".`,
+        },
+      };
+    }
+  }
+  const targetAgentId = requestedAgentId ? normalizeAgentId(requestedAgentId) : requesterAgentId;
+  const configuredAgentIds = resolveConfiguredAgentIds(cfg);
+  const explicitSwarmGroupId = normalizeOptionalString(params.groupId);
+  const requesterRunId = normalizeOptionalString(ctx.requesterRunId);
+  const swarmGroupId = params.collect
+    ? (explicitSwarmGroupId ??
+      (requesterRunId ? `swarm:${requesterInternalKey}:${requesterRunId}` : undefined))
+    : undefined;
+  const swarmSchedulerGroupKey = swarmGroupId
+    ? JSON.stringify([requesterInternalKey, swarmGroupId])
+    : undefined;
+  const resolveAdmission = () => {
+    const collectorRuns = params.collect
+      ? swarmGroupId
+        ? listSwarmRunsForGroup(swarmGroupId, requesterInternalKey)
+        : []
+      : undefined;
+    return resolveSpawnAdmission({
+      cfg,
+      collector: collectorRuns
+        ? {
+            liveChildren: collectorRuns.filter((entry) => !entry.collectorCompletion).length,
+            totalChildren: collectorRuns.length,
+            maxChildrenPerGroup: swarmConfig.maxChildrenPerGroup,
+            maxTotalPerGroup: swarmConfig.maxTotalPerGroup,
+          }
+        : undefined,
+      requesterSessionKey: requesterInternalKey,
+      requesterAgentId,
+      targetAgentId,
+      requestedAgentId,
+      configuredAgentIds,
+    });
+  };
+  const admission = resolveAdmission();
+  if (!admission.ok) {
+    return {
+      ok: false,
+      result: {
+        status: "forbidden",
+        error:
+          usingDefaultAgentId && !admission.governingCap?.startsWith("tools.swarm.")
+            ? `tools.swarm.defaultAgentId is unavailable: ${admission.error}`
+            : admission.error,
+      },
+    };
+  }
+  if (params.collect && !swarmGroupId) {
+    return {
+      ok: false,
+      result: {
+        status: "error",
+        error: "sessions_spawn collect=true requires a requesting run id when groupId is omitted.",
+      },
+    };
+  }
+  const childDepth = admission.childSessionPatch?.spawnDepth ?? 1;
+  const maxSpawnDepth = admission.maxSpawnDepth ?? childDepth;
+  const swarmLaunchReplayKey = normalizeOptionalString(params.swarmLaunchReplayKey);
+  // Registry and Gateway identities are global, while host replay keys are requester-scoped.
+  const childIdem = swarmLaunchReplayKey
+    ? `swarm_${crypto
+        .createHash("sha256")
+        .update(JSON.stringify([requesterInternalKey, swarmLaunchReplayKey]))
+        .digest("hex")
+        .slice(0, 32)}`
+    : crypto.randomUUID();
+  let reservationPending = false;
+  if (params.collect && swarmGroupId && swarmSchedulerGroupKey) {
+    const groupRuns = listSwarmRunsForGroup(swarmGroupId, requesterInternalKey);
+    if (
+      !reserveSwarmRun({
+        groupId: swarmSchedulerGroupKey,
+        runId: childIdem,
+        maxConcurrent: swarmConfig.maxConcurrent,
+        activeRunIds: groupRuns
+          .filter((entry) => entry.execution?.status === "running")
+          .map((entry) => entry.schedulerSlotId ?? entry.runId),
+      })
+    ) {
+      return {
+        ok: false,
+        result: { status: "error", error: "sessions_spawn could not reserve swarm FIFO order." },
+      };
+    }
+    reservationPending = true;
+  }
+  return {
+    ok: true,
+    resolved: {
+      request: {
+        taskName,
+        spawnMode,
+        cleanup,
+        expectsCompletionMessage,
+      },
+      runtime: {
+        hookRunner,
+        cfg,
+        runTimeoutSeconds,
+        contextMode,
+        requesterInternalKey,
+        ownership,
+        requesterAgentId,
+        targetAgentId,
+      },
+      swarm: {
+        config: swarmConfig,
+        groupId: swarmGroupId,
+        schedulerGroupKey: swarmSchedulerGroupKey,
+        launchReplayKey: swarmLaunchReplayKey,
+        reservationPending,
+      },
+      admission: {
+        resolve: resolveAdmission,
+        initial: admission,
+        childDepth,
+        maxSpawnDepth,
+      },
+      childIdem,
+    },
+  };
+}

--- a/src/agents/subagent-spawn-requester-prefs.ts
+++ b/src/agents/subagent-spawn-requester-prefs.ts
@@ -1,0 +1,121 @@
+import type { SessionEntry } from "../config/sessions/types.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { FastMode } from "../shared/fast-mode.js";
+import { resolveFastModeState } from "./fast-mode.js";
+import {
+  normalizeStoredOverrideModel,
+  resolveDefaultModelForAgent,
+  resolvePersistedSelectedModelRef,
+} from "./model-selection.js";
+import { resolveThinkingDefault } from "./model-thinking-default.js";
+import {
+  loadSessionEntry,
+  resolveAgentConfig,
+  resolveGatewaySessionStoreTarget,
+} from "./subagent-spawn.runtime.js";
+
+export function readRequesterThinkingLevel(params: {
+  cfg: OpenClawConfig;
+  requesterInternalKey: string;
+  requesterAgentId?: string;
+}): string | undefined {
+  let entry: SessionEntry | undefined;
+  try {
+    const target = resolveGatewaySessionStoreTarget({
+      cfg: params.cfg,
+      key: params.requesterInternalKey,
+    });
+    entry = loadSessionEntry({
+      storePath: target.storePath,
+      sessionKey: target.canonicalKey,
+      clone: false,
+    });
+  } catch {
+    entry = undefined;
+  }
+  if (typeof entry?.thinkingLevel === "string" && entry.thinkingLevel.trim()) {
+    return entry.thinkingLevel.trim();
+  }
+  const requesterAgentThinking = params.requesterAgentId
+    ? resolveAgentConfig(params.cfg, params.requesterAgentId)?.thinkingDefault
+    : undefined;
+  if (requesterAgentThinking) {
+    return requesterAgentThinking;
+  }
+  const defaultModel = resolveDefaultModelForAgent({
+    cfg: params.cfg,
+    agentId: params.requesterAgentId,
+  });
+  if (entry) {
+    const normalizedOverride = normalizeStoredOverrideModel({
+      providerOverride: entry.providerOverride,
+      modelOverride: entry.modelOverride,
+    });
+    const persistedModel = resolvePersistedSelectedModelRef({
+      defaultProvider: defaultModel.provider,
+      runtimeProvider: entry.modelProvider,
+      runtimeModel: entry.model,
+      overrideProvider: normalizedOverride.providerOverride,
+      overrideModel: normalizedOverride.modelOverride,
+    });
+    if (persistedModel) {
+      return resolveThinkingDefault({
+        cfg: params.cfg,
+        provider: persistedModel.provider,
+        model: persistedModel.model,
+      });
+    }
+  }
+  return resolveThinkingDefault({
+    cfg: params.cfg,
+    provider: defaultModel.provider,
+    model: defaultModel.model,
+  });
+}
+
+export function readRequesterFastMode(params: {
+  cfg: OpenClawConfig;
+  requesterInternalKey: string;
+  requesterAgentId?: string;
+}): FastMode {
+  let entry: SessionEntry | undefined;
+  try {
+    const target = resolveGatewaySessionStoreTarget({
+      cfg: params.cfg,
+      key: params.requesterInternalKey,
+    });
+    entry = loadSessionEntry({
+      storePath: target.storePath,
+      sessionKey: target.canonicalKey,
+      clone: false,
+    });
+  } catch {
+    entry = undefined;
+  }
+  const defaultModel = resolveDefaultModelForAgent({
+    cfg: params.cfg,
+    agentId: params.requesterAgentId,
+  });
+  const normalizedOverride = entry
+    ? normalizeStoredOverrideModel({
+        providerOverride: entry.providerOverride,
+        modelOverride: entry.modelOverride,
+      })
+    : {};
+  const selectedModel = entry
+    ? resolvePersistedSelectedModelRef({
+        defaultProvider: defaultModel.provider,
+        runtimeProvider: entry.modelProvider,
+        runtimeModel: entry.model,
+        overrideProvider: normalizedOverride.providerOverride,
+        overrideModel: normalizedOverride.modelOverride,
+      })
+    : undefined;
+  return resolveFastModeState({
+    cfg: params.cfg,
+    provider: selectedModel?.provider ?? defaultModel.provider,
+    model: selectedModel?.model ?? defaultModel.model,
+    agentId: params.requesterAgentId,
+    sessionEntry: entry,
+  }).mode;
+}

--- a/src/agents/subagent-spawn-session-patch.ts
+++ b/src/agents/subagent-spawn-session-patch.ts
@@ -13,9 +13,7 @@ import { getSubagentSpawnDeps } from "./subagent-spawn-deps.js";
 import { splitModelRef } from "./subagent-spawn-plan.js";
 import { resolveGatewaySessionStoreTarget, upsertSessionEntry } from "./subagent-spawn.runtime.js";
 
-export function buildDirectChildSessionPatch(
-  patch: Record<string, unknown>,
-): Partial<SessionEntry> {
+function buildDirectChildSessionPatch(patch: Record<string, unknown>): Partial<SessionEntry> {
   const entry: Partial<SessionEntry> = {};
   const spawnDepth = patch.spawnDepth;
   if (typeof spawnDepth === "number" && Number.isFinite(spawnDepth) && spawnDepth >= 0) {

--- a/src/agents/subagent-spawn-session-patch.ts
+++ b/src/agents/subagent-spawn-session-patch.ts
@@ -1,0 +1,199 @@
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { buildSessionCreationStamp } from "../config/sessions/session-entry-provenance.js";
+import type { SessionEntry } from "../config/sessions/types.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveIncognitoOpenClawAgentSqlitePath } from "../state/openclaw-agent-db.js";
+import {
+  inheritedToolAllowPatch,
+  inheritedToolDenyPatch,
+  normalizeInheritedToolAllowlist,
+  normalizeInheritedToolDenylist,
+} from "./inherited-tool-deny.js";
+import { getSubagentSpawnDeps } from "./subagent-spawn-deps.js";
+import { splitModelRef } from "./subagent-spawn-plan.js";
+import { resolveGatewaySessionStoreTarget, upsertSessionEntry } from "./subagent-spawn.runtime.js";
+
+export function buildDirectChildSessionPatch(
+  patch: Record<string, unknown>,
+): Partial<SessionEntry> {
+  const entry: Partial<SessionEntry> = {};
+  const spawnDepth = patch.spawnDepth;
+  if (typeof spawnDepth === "number" && Number.isFinite(spawnDepth) && spawnDepth >= 0) {
+    entry.spawnDepth = Math.floor(spawnDepth);
+  }
+  if (patch.subagentRole === "orchestrator" || patch.subagentRole === "leaf") {
+    entry.subagentRole = patch.subagentRole;
+  }
+  if (patch.subagentControlScope === "children" || patch.subagentControlScope === "none") {
+    entry.subagentControlScope = patch.subagentControlScope;
+  }
+  if (patch.inheritedToolPolicyVersion === 1) {
+    entry.inheritedToolPolicyVersion = 1;
+  }
+  if (patch.incognito === true) {
+    entry.incognito = true;
+  }
+  if (typeof patch.spawnedBy === "string" && patch.spawnedBy.trim()) {
+    entry.spawnedBy = patch.spawnedBy.trim();
+  }
+  if (
+    typeof patch.completionOwnerSessionKey === "string" &&
+    patch.completionOwnerSessionKey.trim()
+  ) {
+    entry.completionOwnerSessionKey = patch.completionOwnerSessionKey.trim();
+  }
+  if (typeof patch.parentSessionKey === "string" && patch.parentSessionKey.trim()) {
+    entry.parentSessionKey = patch.parentSessionKey.trim();
+  }
+  if (typeof patch.spawnedWorkspaceDir === "string" && patch.spawnedWorkspaceDir.trim()) {
+    entry.spawnedWorkspaceDir = patch.spawnedWorkspaceDir.trim();
+  }
+  if (typeof patch.spawnedCwd === "string" && patch.spawnedCwd.trim()) {
+    entry.spawnedCwd = patch.spawnedCwd.trim();
+  }
+  const inheritedToolDeny = normalizeInheritedToolDenylist(patch.inheritedToolDeny);
+  if (inheritedToolDeny.length > 0) {
+    entry.inheritedToolDeny = inheritedToolDeny;
+  }
+  const inheritedToolAllow = normalizeInheritedToolAllowlist(patch.inheritedToolAllow);
+  if (inheritedToolAllow.length > 0) {
+    entry.inheritedToolAllow = inheritedToolAllow;
+  }
+  if (typeof patch.thinkingLevel === "string" && patch.thinkingLevel.trim()) {
+    entry.thinkingLevel = patch.thinkingLevel.trim();
+  }
+  if (patch.fastMode === true || patch.fastMode === false || patch.fastMode === "auto") {
+    entry.fastMode = patch.fastMode;
+  }
+  if (typeof patch.swarmGroupId === "string" && patch.swarmGroupId.trim()) {
+    entry.swarmGroupId = patch.swarmGroupId.trim();
+  }
+  if (patch.swarmCollector === true) {
+    entry.swarmCollector = true;
+  }
+  if (patch.swarmOutputSchema && typeof patch.swarmOutputSchema === "object") {
+    entry.swarmOutputSchema = patch.swarmOutputSchema as Record<string, unknown>;
+  }
+  if (typeof patch.model === "string" && patch.model.trim()) {
+    const { provider, model } = splitModelRef(patch.model.trim());
+    if (model) {
+      entry.model = model;
+      entry.modelOverride = model;
+      entry.modelOverrideSource = patch.modelOverrideSource === "auto" ? "auto" : "user";
+      const fallbackOriginProvider = normalizeOptionalString(
+        patch.modelOverrideFallbackOriginProvider,
+      );
+      const fallbackOriginModel = normalizeOptionalString(patch.modelOverrideFallbackOriginModel);
+      if (fallbackOriginProvider && fallbackOriginModel) {
+        entry.modelOverrideFallbackOriginProvider = fallbackOriginProvider;
+        entry.modelOverrideFallbackOriginModel = fallbackOriginModel;
+      }
+      if (provider) {
+        entry.modelProvider = provider;
+        entry.providerOverride = provider;
+      }
+    }
+  }
+  return entry;
+}
+
+export function loadSubagentConfig() {
+  return getSubagentSpawnDeps().getRuntimeConfig();
+}
+
+export async function createInitialSubagentSession(params: {
+  cfg: OpenClawConfig;
+  targetAgentId: string;
+  childSessionKey: string;
+  incognito: boolean;
+  requesterInternalKey: string;
+  completionOwnerSessionKey: string;
+  spawnedWorkspaceDir?: string;
+  spawnedCwd?: string;
+  admissionPatch?: Record<string, unknown>;
+  inheritedToolAllowlist?: string[];
+  inheritedToolDenylist?: string[];
+  modelPatch: Record<string, unknown>;
+  swarmGroupId?: string;
+  collect: boolean;
+  outputSchema?: Record<string, unknown>;
+}): Promise<{ status: "ok"; entry?: SessionEntry } | { status: "error"; error: string }> {
+  const initialChildSessionPatch: Record<string, unknown> = {
+    spawnedBy: params.requesterInternalKey,
+    completionOwnerSessionKey: params.completionOwnerSessionKey,
+    // Navigation and control lineage commit with the creation stamp so a
+    // launch failure cannot leave a durable but parentless child row.
+    parentSessionKey: params.requesterInternalKey,
+    ...(params.spawnedWorkspaceDir ? { spawnedWorkspaceDir: params.spawnedWorkspaceDir } : {}),
+    ...(params.spawnedCwd ? { spawnedCwd: params.spawnedCwd } : {}),
+    ...params.admissionPatch,
+    inheritedToolPolicyVersion: 1,
+    ...inheritedToolAllowPatch(params.inheritedToolAllowlist),
+    ...inheritedToolDenyPatch(params.inheritedToolDenylist),
+    ...params.modelPatch,
+    ...(params.swarmGroupId ? { swarmGroupId: params.swarmGroupId } : {}),
+    ...(params.collect ? { swarmCollector: true } : {}),
+    ...(params.outputSchema ? { swarmOutputSchema: params.outputSchema } : {}),
+    ...(params.incognito ? { incognito: true } : {}),
+  };
+  try {
+    const target = params.incognito
+      ? {
+          agentId: params.targetAgentId,
+          canonicalKey: params.childSessionKey,
+          storeKeys: [params.childSessionKey],
+          storePath: resolveIncognitoOpenClawAgentSqlitePath({ agentId: params.targetAgentId }),
+        }
+      : resolveGatewaySessionStoreTarget({
+          cfg: params.cfg,
+          key: params.childSessionKey,
+        });
+    const entry = await upsertSessionEntry(
+      {
+        storePath: target.storePath,
+        sessionKey: target.canonicalKey,
+      },
+      {
+        ...buildDirectChildSessionPatch(initialChildSessionPatch),
+        ...buildSessionCreationStamp({
+          via: "spawn",
+          actor: { type: "agent", id: params.requesterInternalKey },
+        }),
+      },
+    );
+    return { status: "ok", entry: entry ?? undefined };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : typeof err === "string" ? err : "error";
+    return { status: "error", error: `child session patch failed: ${message}` };
+  }
+}
+
+export async function persistInitialChildSessionRuntimeModel(params: {
+  cfg: OpenClawConfig;
+  childSessionKey: string;
+  resolvedModel?: string;
+}): Promise<string | undefined> {
+  const { provider, model } = splitModelRef(params.resolvedModel);
+  if (!model) {
+    return undefined;
+  }
+  try {
+    const target = resolveGatewaySessionStoreTarget({
+      cfg: params.cfg,
+      key: params.childSessionKey,
+    });
+    await upsertSessionEntry(
+      {
+        storePath: target.storePath,
+        sessionKey: target.canonicalKey,
+      },
+      {
+        model,
+        ...(provider ? { modelProvider: provider } : {}),
+      },
+    );
+    return undefined;
+  } catch (err) {
+    return err instanceof Error ? err.message : typeof err === "string" ? err : "error";
+  }
+}

--- a/src/agents/subagent-spawn-thread-binding.ts
+++ b/src/agents/subagent-spawn-thread-binding.ts
@@ -1,0 +1,116 @@
+import { routeFromBindingRecord, routeToDeliveryFields } from "../channels/route-projection.js";
+import {
+  resolveThreadBindingIntroText,
+  resolveThreadBindingThreadName,
+} from "../channels/thread-bindings-messages.js";
+import {
+  resolveThreadBindingIdleTimeoutMsForChannel,
+  resolveThreadBindingMaxAgeMsForChannel,
+} from "../channels/thread-bindings-policy.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { DeliveryContext } from "../utils/delivery-context.types.js";
+import { summarizeSpawnError } from "./spawn-pipeline.js";
+import { prepareSpawnThreadBinding } from "./spawn-plan.js";
+import { getSessionBindingService } from "./subagent-spawn.runtime.js";
+import type { SpawnSubagentMode } from "./subagent-spawn.types.js";
+
+export async function bindThreadForSubagentSpawn(params: {
+  cfg: OpenClawConfig;
+  childSessionKey: string;
+  agentId: string;
+  label?: string;
+  mode: SpawnSubagentMode;
+  requesterSessionKey?: string;
+  requester: {
+    channel?: string;
+    accountId?: string;
+    to?: string;
+    threadId?: string | number;
+  };
+}): Promise<
+  | { status: "ok"; deliveryOrigin?: DeliveryContext }
+  | {
+      status: "error";
+      error: string;
+    }
+> {
+  const prepared = prepareSpawnThreadBinding({
+    cfg: params.cfg,
+    kind: "subagent",
+    mode: params.mode,
+    bindingService: getSessionBindingService(),
+    requesterSessionKey: params.requesterSessionKey,
+    channel: params.requester.channel,
+    accountId: params.requester.accountId,
+    to: params.requester.to,
+    threadId: params.requester.threadId,
+  });
+  if (!prepared.ok) {
+    return {
+      status: "error",
+      error: prepared.error,
+    };
+  }
+
+  try {
+    const binding = await getSessionBindingService().bind({
+      targetSessionKey: params.childSessionKey,
+      targetKind: "subagent",
+      conversation: {
+        channel: prepared.binding.channel,
+        accountId: prepared.binding.accountId,
+        conversationId: prepared.binding.conversationId,
+        ...(prepared.binding.parentConversationId
+          ? { parentConversationId: prepared.binding.parentConversationId }
+          : {}),
+      },
+      placement: prepared.binding.placement,
+      metadata: {
+        threadName: resolveThreadBindingThreadName({
+          agentId: params.agentId,
+          label: params.label || params.agentId,
+        }),
+        agentId: params.agentId,
+        label: params.label || undefined,
+        boundBy: "system",
+        introText: resolveThreadBindingIntroText({
+          agentId: params.agentId,
+          label: params.label || undefined,
+          idleTimeoutMs: resolveThreadBindingIdleTimeoutMsForChannel({
+            cfg: params.cfg,
+            channel: prepared.binding.channel,
+            accountId: prepared.binding.accountId,
+          }),
+          maxAgeMs: resolveThreadBindingMaxAgeMsForChannel({
+            cfg: params.cfg,
+            channel: prepared.binding.channel,
+            accountId: prepared.binding.accountId,
+          }),
+        }),
+      },
+    });
+    if (!binding.conversation.conversationId) {
+      return {
+        status: "error",
+        error:
+          "Unable to create or bind a thread for this subagent session. Session mode is unavailable for this target.",
+      };
+    }
+    const deliveryOrigin = routeToDeliveryFields(routeFromBindingRecord(binding)).deliveryContext;
+    return {
+      status: "ok",
+      ...(deliveryOrigin ? { deliveryOrigin } : {}),
+    };
+  } catch (err) {
+    return {
+      status: "error",
+      error: `Thread bind failed: ${summarizeSpawnError(err)}`,
+    };
+  }
+}
+
+export function hasRoutableDeliveryOrigin(
+  origin?: DeliveryContext,
+): origin is DeliveryContext & { channel: string; to: string } {
+  return Boolean(origin?.channel && origin.to);
+}

--- a/src/agents/subagent-spawn-validation.ts
+++ b/src/agents/subagent-spawn-validation.ts
@@ -1,0 +1,31 @@
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { listAgentIds } from "./agent-scope-config.js";
+
+export function resolveConfiguredAgentIds(cfg: OpenClawConfig): string[] {
+  return listAgentIds(cfg);
+}
+
+export function sanitizeMountPathHint(value?: string): string | undefined {
+  const trimmed = normalizeOptionalString(value);
+  if (!trimmed) {
+    return undefined;
+  }
+  if (hasPromptUnsafeControlCharacter(trimmed)) {
+    return undefined;
+  }
+  if (!/^[A-Za-z0-9._\-/:]+$/.test(trimmed)) {
+    return undefined;
+  }
+  return trimmed;
+}
+
+function hasPromptUnsafeControlCharacter(value: string): boolean {
+  for (const char of value) {
+    const code = char.charCodeAt(0);
+    if (code <= 0x1f || code === 0x7f || code === 0x85 || code === 0x2028 || code === 0x2029) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -3,1417 +3,163 @@
  *
  * Validates spawn requests, prepares child sessions, stages attachments, binds delivery context, and registers runs.
  */
-import crypto from "node:crypto";
 import { promises as fs } from "node:fs";
-import { finiteSecondsToTimerSafeMilliseconds } from "@openclaw/normalization-core/number-coercion";
-import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { isAcpRuntimeSpawnAvailable } from "../acp/runtime/availability.js";
-import { routeFromBindingRecord, routeToDeliveryFields } from "../channels/route-projection.js";
-import {
-  resolveThreadBindingIntroText,
-  resolveThreadBindingThreadName,
-} from "../channels/thread-bindings-messages.js";
-import {
-  resolveThreadBindingIdleTimeoutMsForChannel,
-  resolveThreadBindingMaxAgeMsForChannel,
-  resolveThreadBindingSpawnPolicy,
-} from "../channels/thread-bindings-policy.js";
-import { buildSessionCreationStamp } from "../config/sessions/session-entry-provenance.js";
-import type { SessionEntry } from "../config/sessions/types.js";
-import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { SubagentSpawnPreparation } from "../context-engine/types.js";
 import { isFastTestRuntimeEnv } from "../infra/env.js";
-import { stringifyRouteThreadId } from "../plugin-sdk/channel-route.js";
 import { listRegisteredPluginAgentPromptGuidance } from "../plugins/command-registry-state.js";
-import type { SubagentLifecycleHookRunner } from "../plugins/hooks.js";
 import {
   GatewayDrainingError,
   runWithGatewayIndependentRootWorkContinuation,
 } from "../process/gateway-work-admission.js";
-import {
-  isIncognitoSessionKey,
-  isValidAgentId,
-  normalizeAgentId,
-  parseAgentSessionKey,
-} from "../routing/session-key.js";
 import { recordSessionCreated, recordSubagentSpawned } from "../sessions/session-state-events.js";
-import type { FastMode } from "../shared/fast-mode.js";
-import { resolveIncognitoOpenClawAgentSqlitePath } from "../state/openclaw-agent-db.js";
-import { resolveUserPath } from "../utils.js";
-import type { DeliveryContext } from "../utils/delivery-context.types.js";
-import { listAgentIds, resolveAgentDir } from "./agent-scope-config.js";
-import type { BootstrapContextMode } from "./bootstrap-files.js";
-import { resolveFastModeState } from "./fast-mode.js";
-import {
-  inheritedToolAllowPatch,
-  inheritedToolDenyPatch,
-  normalizeInheritedToolAllowlist,
-  normalizeInheritedToolDenylist,
-} from "./inherited-tool-deny.js";
-import { findModelCatalogEntry } from "./model-catalog-lookup.js";
-import {
-  normalizeStoredOverrideModel,
-  resolveDefaultModelForAgent,
-  resolvePersistedSelectedModelRef,
-} from "./model-selection.js";
-import { resolveThinkingDefault } from "./model-thinking-default.js";
-import { supportsModelTools } from "./model-tool-support.js";
 import {
   runSpawnPipeline,
   type SpawnBackendAdapter,
   summarizeSpawnError,
 } from "./spawn-pipeline.js";
 import {
-  mintSpawnSessionKey,
-  prepareSpawnThreadBinding,
-  resolveSpawnAdmission,
-  resolveSpawnMode,
-  resolveSpawnSandboxError,
-} from "./spawn-plan.js";
-import { resolveRequesterOriginForChild } from "./spawn-requester-origin.js";
-import {
-  mapToolContextToSpawnedRunMetadata,
-  normalizeSpawnedRunMetadata,
-  resolveSpawnedWorkspaceInheritance,
-} from "./spawned-context.js";
-import {
   materializeSubagentAttachments,
   type SubagentAttachmentReceiptFile,
 } from "./subagent-attachments.js";
-import { buildSubagentInitialUserMessage } from "./subagent-initial-user-message.js";
-import {
-  applySubagentLaunchAuthorization,
-  type SubagentLaunchAuthorization,
-} from "./subagent-launch-authorization.js";
 import {
   completeCollectorLaunchCleanup,
-  listSwarmRunsForGroup,
   settleFailedQueuedSubagentLaunch,
   startQueuedSubagentRun,
 } from "./subagent-registry.js";
-import { resolveSubagentRunTimerDelayMs } from "./subagent-run-timeout.js";
 import { resolveSubagentSpawnAcceptedNote } from "./subagent-spawn-accepted-note.js";
-import { resolveSubagentSpawnOwnership } from "./subagent-spawn-ownership.js";
+import { resolveSubagentChildPlan } from "./subagent-spawn-child-plan.js";
 import {
-  resolveConfiguredSubagentRunTimeoutSeconds,
-  resolveSubagentModelAndThinkingPlan,
-  splitModelRef,
-} from "./subagent-spawn-plan.js";
+  cleanupFailedSpawnBeforeAgentStart,
+  cleanupProvisionalSession,
+  terminateAcceptedCollectorRun,
+} from "./subagent-spawn-cleanup.js";
 import {
-  ADMIN_SCOPE,
-  AGENT_LANE_SUBAGENT,
-  buildSubagentSystemPrompt,
-  callGateway,
-  dispatchGatewayMethodInProcess,
-  emitSessionLifecycleEvent,
-  forkSessionEntryFromParent,
-  getGlobalHookRunner,
-  getSessionBindingService,
-  getRuntimeConfig,
-  hasInProcessGatewayContext,
-  mergeDeliveryContext,
-  normalizeDeliveryContext,
-  ensureContextEnginesInitialized,
-  loadPreparedModelCatalog,
-  resolveAgentConfig,
-  resolveContextEngine,
-  resolveGatewaySessionStoreTarget,
-  resolveInternalSessionKey,
-  resolveMainSessionAlias,
-  resolveSandboxRuntimeStatus,
-  loadSessionEntry,
-  upsertSessionEntry,
-  resolveLeastPrivilegeOperatorScopesForMethod,
-} from "./subagent-spawn.runtime.js";
+  prepareContextEngineSubagentSpawn,
+  prepareSubagentSessionContext,
+  rollbackPreparedContextEngine,
+} from "./subagent-spawn-context.js";
 import type {
-  SpawnSubagentContextMode,
-  SpawnSubagentMode,
-  SpawnSubagentSandboxMode,
-} from "./subagent-spawn.types.js";
-import { normalizeSubagentTaskName } from "./subagent-task-name.js";
-import { resolveSwarmConfig } from "./swarm-config.js";
-import { validateStructuredOutputSchema } from "./swarm-output-schema.js";
-import { activateSwarmRun, removeQueuedSwarmRun, reserveSwarmRun } from "./swarm-scheduler.js";
+  SpawnSubagentContext,
+  SpawnSubagentParams,
+  SpawnSubagentResult,
+} from "./subagent-spawn-contract.js";
+import { setSubagentSpawnDepsForTest } from "./subagent-spawn-deps.js";
+import { callSubagentGateway, readGatewayRunId } from "./subagent-spawn-gateway.js";
+import { buildSubagentLaunchRequest } from "./subagent-spawn-launch-request.js";
+import { createSubagentSpawnLifecycleEmitter } from "./subagent-spawn-lifecycle.js";
+import { resolveSubagentSpawnRequest } from "./subagent-spawn-request.js";
+import {
+  createInitialSubagentSession,
+  persistInitialChildSessionRuntimeModel,
+} from "./subagent-spawn-session-patch.js";
+import {
+  bindThreadForSubagentSpawn,
+  hasRoutableDeliveryOrigin,
+} from "./subagent-spawn-thread-binding.js";
+import { sanitizeMountPathHint } from "./subagent-spawn-validation.js";
+import {
+  buildSubagentSystemPrompt,
+  emitSessionLifecycleEvent,
+  mergeDeliveryContext,
+} from "./subagent-spawn.runtime.js";
+import { activateSwarmRun, removeQueuedSwarmRun } from "./swarm-scheduler.js";
 
 export { SUBAGENT_SPAWN_CONTEXT_MODES, SUBAGENT_SPAWN_MODES } from "./subagent-spawn.types.js";
 
-function resolveConfiguredAgentIds(cfg: OpenClawConfig): string[] {
-  return listAgentIds(cfg);
-}
-
-type SubagentSpawnDeps = {
-  callGateway: typeof callGateway;
-  dispatchGatewayMethodInProcess: typeof dispatchGatewayMethodInProcess;
-  forkSessionEntryFromParent: typeof forkSessionEntryFromParent;
-  getGlobalHookRunner: () => SubagentLifecycleHookRunner | null;
-  getRuntimeConfig: typeof getRuntimeConfig;
-  hasInProcessGatewayContext: typeof hasInProcessGatewayContext;
-  ensureContextEnginesInitialized: typeof ensureContextEnginesInitialized;
-  loadPreparedModelCatalog: typeof loadPreparedModelCatalog;
-  resolveContextEngine: typeof resolveContextEngine;
-};
-
-const defaultSubagentSpawnDeps: SubagentSpawnDeps = {
-  callGateway,
-  dispatchGatewayMethodInProcess,
-  forkSessionEntryFromParent,
-  getGlobalHookRunner,
-  getRuntimeConfig,
-  hasInProcessGatewayContext,
-  ensureContextEnginesInitialized,
-  loadPreparedModelCatalog,
-  resolveContextEngine,
-};
-
-let subagentSpawnDeps: SubagentSpawnDeps = defaultSubagentSpawnDeps;
 const SUBAGENT_CONTROL_GATEWAY_TIMEOUT_MS = 60_000;
-const DEFAULT_SUBAGENT_AGENT_GATEWAY_TIMEOUT_MS = 60_000;
-const MAX_SUBAGENT_AGENT_GATEWAY_TIMEOUT_MS = 300_000;
-
-type SpawnSubagentParams = {
-  task: string;
-  label?: string;
-  agentId?: string;
-  model?: string;
-  taskName?: string;
-  thinking?: string;
-  fastMode?: FastMode;
-  collect?: boolean;
-  outputSchema?: Record<string, unknown>;
-  groupId?: string;
-  /** Host bridge identity used to recover a replay-safe collector launch. */
-  swarmLaunchReplayKey?: string;
-  /** Canonical request hash checked before reusing a host-reserved collector. */
-  swarmLaunchRequestFingerprint?: string;
-  cwd?: string;
-  runTimeoutSeconds?: number;
-  thread?: boolean;
-  mode?: SpawnSubagentMode;
-  cleanup?: "delete" | "keep";
-  sandbox?: SpawnSubagentSandboxMode;
-  context?: SpawnSubagentContextMode;
-  lightContext?: boolean;
-  expectsCompletionMessage?: boolean;
-  attachments?: Array<{
-    name: string;
-    content: string;
-    encoding?: "utf8" | "base64";
-    mimeType?: string;
-  }>;
-  attachMountPath?: string;
-};
-
-type SpawnSubagentContext = {
-  agentSessionKey?: string;
-  requesterTurnRunId?: string;
-  /** Separate key used only for completion routing, not sandbox policy. */
-  completionOwnerKey?: string;
-  agentChannel?: string;
-  agentAccountId?: string;
-  agentTo?: string;
-  agentThreadId?: string | number;
-  currentMessagingTarget?: string;
-  currentChannelId?: string;
-  currentMessageId?: string | number;
-  agentGroupId?: string | null;
-  agentGroupChannel?: string | null;
-  agentGroupSpace?: string | null;
-  agentMemberRoleIds?: string[];
-  requesterAgentIdOverride?: string;
-  /** Explicit workspace directory for subagent to inherit (optional). */
-  workspaceDir?: string;
-  inheritedToolAllowlist?: string[];
-  inheritedToolDenylist?: string[];
-  requesterRunId?: string;
-};
-
-type SpawnSubagentResult = {
-  status: "accepted" | "forbidden" | "error";
-  childSessionKey?: string;
-  sessionKey?: string;
-  runId?: string;
-  mode?: SpawnSubagentMode;
-  taskName?: string;
-  note?: string;
-  /** Fully resolved model ref applied to the spawned child session. */
-  resolvedModel?: string;
-  /** Provider prefix parsed from resolvedModel when the ref includes one. */
-  resolvedProvider?: string;
-  modelApplied?: boolean;
-  error?: string;
-  attachments?: {
-    count: number;
-    totalBytes: number;
-    files: Array<{ name: string; bytes: number; sha256: string }>;
-    relDir: string;
-  };
-};
-
-async function callSubagentGateway(
-  params: Parameters<typeof callGateway>[0],
-  authorization?: SubagentLaunchAuthorization,
-): Promise<Awaited<ReturnType<typeof callGateway>>> {
-  // Subagent lifecycle requires methods spanning multiple scope tiers
-  // (sessions.delete → admin, agent → write). When each call
-  // independently negotiates least-privilege scopes the first connection pairs
-  // at a lower tier and every subsequent higher-tier call triggers a
-  // scope-upgrade handshake that headless gateway-client connections cannot
-  // complete interactively, causing close(1008) "pairing required" (#59428).
-  //
-  // Only admin-requiring calls are pinned to ADMIN_SCOPE; other methods (e.g.
-  // "agent" -> write) keep their least-privilege scope. Apply the trusted
-  // launch authorization before resolving the request's required scope.
-  const authorizedParams =
-    params.params != null && typeof params.params === "object" && !Array.isArray(params.params)
-      ? applySubagentLaunchAuthorization(params.params as Record<string, unknown>, authorization)
-      : params.params;
-  const leastPrivilegeScopes = resolveLeastPrivilegeOperatorScopesForMethod(
-    params.method,
-    authorizedParams,
-  );
-  const allowModelOverride = authorization !== undefined;
-  const hasInProcessGateway = subagentSpawnDeps.hasInProcessGatewayContext();
-  const needsOutOfProcessModelOverrideAuth = allowModelOverride && !hasInProcessGateway;
-  const scopes =
-    params.scopes ??
-    (leastPrivilegeScopes.includes(ADMIN_SCOPE) || needsOutOfProcessModelOverrideAuth
-      ? [ADMIN_SCOPE]
-      : undefined);
-  const request = {
-    ...params,
-    params: authorizedParams,
-    ...(scopes != null ? { scopes } : {}),
-  };
-  if (
-    hasInProcessGateway &&
-    request.params != null &&
-    typeof request.params === "object" &&
-    !Array.isArray(request.params)
-  ) {
-    // Spawn is already running in the gateway process for channel/tool calls.
-    // Direct dispatch avoids self-connecting over WS while the same event loop is busy.
-    // Agent launches are host-owned even when the parent request came from CLI/HTTP.
-    // Reusing that external identity makes collector preflight treat the launch as spoofed.
-    const forceSyntheticClient = request.method === "agent" || scopes != null;
-    return await subagentSpawnDeps.dispatchGatewayMethodInProcess(
-      request.method,
-      request.params as Record<string, unknown>,
-      {
-        expectFinal: request.expectFinal,
-        ...(allowModelOverride ? { allowSyntheticModelOverride: true } : {}),
-        ...(forceSyntheticClient ? { forceSyntheticClient: true } : {}),
-        ...(typeof request.timeoutMs === "number" ? { timeoutMs: request.timeoutMs } : {}),
-        ...(scopes != null ? { syntheticScopes: scopes } : {}),
-      },
-    );
-  }
-  return await subagentSpawnDeps.callGateway(request);
-}
-
-function readGatewayRunId(response: Awaited<ReturnType<typeof callGateway>>): string | undefined {
-  if (!response || typeof response !== "object") {
-    return undefined;
-  }
-  const { runId } = response as { runId?: unknown };
-  return typeof runId === "string" && runId ? runId : undefined;
-}
-
-function buildResolvedSubagentModelMetadata(
-  resolvedModel?: string,
-): Pick<SpawnSubagentResult, "resolvedModel" | "resolvedProvider"> {
-  const modelRef = resolvedModel?.trim();
-  if (!modelRef) {
-    return {};
-  }
-  const { provider } = splitModelRef(modelRef);
-  return {
-    resolvedModel: modelRef,
-    ...(provider ? { resolvedProvider: provider } : {}),
-  };
-}
-
-async function resolveCollectorOutputModelError(params: {
-  cfg: OpenClawConfig;
-  targetAgentId: string;
-  targetAgentDir: string;
-  workspaceDir?: string;
-  resolvedModel?: string;
-}): Promise<string | undefined> {
-  const selected = splitModelRef(params.resolvedModel);
-  const fallback = resolveDefaultModelForAgent({
-    cfg: params.cfg,
-    agentId: params.targetAgentId,
-  });
-  const provider = selected.provider ?? fallback.provider;
-  const model = selected.model ?? fallback.model;
-  if (!provider || !model) {
-    return undefined;
-  }
-  let catalog: Awaited<ReturnType<typeof loadPreparedModelCatalog>>;
-  try {
-    catalog = await subagentSpawnDeps.loadPreparedModelCatalog({
-      config: params.cfg,
-      agentDir: params.targetAgentDir,
-      workspaceDir: params.workspaceDir,
-    });
-  } catch (error) {
-    return `sessions_spawn could not verify outputSchema model capabilities: ${summarizeSpawnError(error)}`;
-  }
-  const entry = findModelCatalogEntry(catalog, { provider, modelId: model });
-  if (!entry || supportsModelTools(entry)) {
-    return undefined;
-  }
-  return `sessions_spawn outputSchema requires a tool-capable target model; "${provider}/${model}" declares compat.supportsTools=false.`;
-}
-
-function resolveSubagentAgentGatewayTimeoutMs(runTimeoutSeconds: number): number {
-  const runTimeoutMs = resolveSubagentRunTimerDelayMs(runTimeoutSeconds) ?? 0;
-  if (runTimeoutMs <= 0) {
-    return DEFAULT_SUBAGENT_AGENT_GATEWAY_TIMEOUT_MS;
-  }
-  return Math.min(
-    MAX_SUBAGENT_AGENT_GATEWAY_TIMEOUT_MS,
-    Math.max(DEFAULT_SUBAGENT_AGENT_GATEWAY_TIMEOUT_MS, runTimeoutMs + 5_000),
-  );
-}
-
-function buildDirectChildSessionPatch(patch: Record<string, unknown>): Partial<SessionEntry> {
-  const entry: Partial<SessionEntry> = {};
-  const spawnDepth = patch.spawnDepth;
-  if (typeof spawnDepth === "number" && Number.isFinite(spawnDepth) && spawnDepth >= 0) {
-    entry.spawnDepth = Math.floor(spawnDepth);
-  }
-  if (patch.subagentRole === "orchestrator" || patch.subagentRole === "leaf") {
-    entry.subagentRole = patch.subagentRole;
-  }
-  if (patch.subagentControlScope === "children" || patch.subagentControlScope === "none") {
-    entry.subagentControlScope = patch.subagentControlScope;
-  }
-  if (patch.inheritedToolPolicyVersion === 1) {
-    entry.inheritedToolPolicyVersion = 1;
-  }
-  if (patch.incognito === true) {
-    entry.incognito = true;
-  }
-  if (typeof patch.spawnedBy === "string" && patch.spawnedBy.trim()) {
-    entry.spawnedBy = patch.spawnedBy.trim();
-  }
-  if (
-    typeof patch.completionOwnerSessionKey === "string" &&
-    patch.completionOwnerSessionKey.trim()
-  ) {
-    entry.completionOwnerSessionKey = patch.completionOwnerSessionKey.trim();
-  }
-  if (typeof patch.parentSessionKey === "string" && patch.parentSessionKey.trim()) {
-    entry.parentSessionKey = patch.parentSessionKey.trim();
-  }
-  if (typeof patch.spawnedWorkspaceDir === "string" && patch.spawnedWorkspaceDir.trim()) {
-    entry.spawnedWorkspaceDir = patch.spawnedWorkspaceDir.trim();
-  }
-  if (typeof patch.spawnedCwd === "string" && patch.spawnedCwd.trim()) {
-    entry.spawnedCwd = patch.spawnedCwd.trim();
-  }
-  const inheritedToolDeny = normalizeInheritedToolDenylist(patch.inheritedToolDeny);
-  if (inheritedToolDeny.length > 0) {
-    entry.inheritedToolDeny = inheritedToolDeny;
-  }
-  const inheritedToolAllow = normalizeInheritedToolAllowlist(patch.inheritedToolAllow);
-  if (inheritedToolAllow.length > 0) {
-    entry.inheritedToolAllow = inheritedToolAllow;
-  }
-  if (typeof patch.thinkingLevel === "string" && patch.thinkingLevel.trim()) {
-    entry.thinkingLevel = patch.thinkingLevel.trim();
-  }
-  if (patch.fastMode === true || patch.fastMode === false || patch.fastMode === "auto") {
-    entry.fastMode = patch.fastMode;
-  }
-  if (typeof patch.swarmGroupId === "string" && patch.swarmGroupId.trim()) {
-    entry.swarmGroupId = patch.swarmGroupId.trim();
-  }
-  if (patch.swarmCollector === true) {
-    entry.swarmCollector = true;
-  }
-  if (patch.swarmOutputSchema && typeof patch.swarmOutputSchema === "object") {
-    entry.swarmOutputSchema = patch.swarmOutputSchema as Record<string, unknown>;
-  }
-  if (typeof patch.model === "string" && patch.model.trim()) {
-    const { provider, model } = splitModelRef(patch.model.trim());
-    if (model) {
-      entry.model = model;
-      entry.modelOverride = model;
-      entry.modelOverrideSource = patch.modelOverrideSource === "auto" ? "auto" : "user";
-      const fallbackOriginProvider = normalizeOptionalString(
-        patch.modelOverrideFallbackOriginProvider,
-      );
-      const fallbackOriginModel = normalizeOptionalString(patch.modelOverrideFallbackOriginModel);
-      if (fallbackOriginProvider && fallbackOriginModel) {
-        entry.modelOverrideFallbackOriginProvider = fallbackOriginProvider;
-        entry.modelOverrideFallbackOriginModel = fallbackOriginModel;
-      }
-      if (provider) {
-        entry.modelProvider = provider;
-        entry.providerOverride = provider;
-      }
-    }
-  }
-  return entry;
-}
-
-function loadSubagentConfig() {
-  return subagentSpawnDeps.getRuntimeConfig();
-}
-
-async function persistInitialChildSessionRuntimeModel(params: {
-  cfg: OpenClawConfig;
-  childSessionKey: string;
-  resolvedModel?: string;
-}): Promise<string | undefined> {
-  const { provider, model } = splitModelRef(params.resolvedModel);
-  if (!model) {
-    return undefined;
-  }
-  try {
-    const target = resolveGatewaySessionStoreTarget({
-      cfg: params.cfg,
-      key: params.childSessionKey,
-    });
-    await upsertSessionEntry(
-      {
-        storePath: target.storePath,
-        sessionKey: target.canonicalKey,
-      },
-      {
-        model,
-        ...(provider ? { modelProvider: provider } : {}),
-      },
-    );
-    return undefined;
-  } catch (err) {
-    return err instanceof Error ? err.message : typeof err === "string" ? err : "error";
-  }
-}
-
-function readRequesterThinkingLevel(params: {
-  cfg: OpenClawConfig;
-  requesterInternalKey: string;
-  requesterAgentId?: string;
-}): string | undefined {
-  let entry: SessionEntry | undefined;
-  try {
-    const target = resolveGatewaySessionStoreTarget({
-      cfg: params.cfg,
-      key: params.requesterInternalKey,
-    });
-    entry = loadSessionEntry({
-      storePath: target.storePath,
-      sessionKey: target.canonicalKey,
-      clone: false,
-    });
-  } catch {
-    entry = undefined;
-  }
-  if (typeof entry?.thinkingLevel === "string" && entry.thinkingLevel.trim()) {
-    return entry.thinkingLevel.trim();
-  }
-  const requesterAgentThinking = params.requesterAgentId
-    ? resolveAgentConfig(params.cfg, params.requesterAgentId)?.thinkingDefault
-    : undefined;
-  if (requesterAgentThinking) {
-    return requesterAgentThinking;
-  }
-  const defaultModel = resolveDefaultModelForAgent({
-    cfg: params.cfg,
-    agentId: params.requesterAgentId,
-  });
-  if (entry) {
-    const normalizedOverride = normalizeStoredOverrideModel({
-      providerOverride: entry.providerOverride,
-      modelOverride: entry.modelOverride,
-    });
-    const persistedModel = resolvePersistedSelectedModelRef({
-      defaultProvider: defaultModel.provider,
-      runtimeProvider: entry.modelProvider,
-      runtimeModel: entry.model,
-      overrideProvider: normalizedOverride.providerOverride,
-      overrideModel: normalizedOverride.modelOverride,
-    });
-    if (persistedModel) {
-      return resolveThinkingDefault({
-        cfg: params.cfg,
-        provider: persistedModel.provider,
-        model: persistedModel.model,
-      });
-    }
-  }
-  return resolveThinkingDefault({
-    cfg: params.cfg,
-    provider: defaultModel.provider,
-    model: defaultModel.model,
-  });
-}
-
-function readRequesterFastMode(params: {
-  cfg: OpenClawConfig;
-  requesterInternalKey: string;
-  requesterAgentId?: string;
-}): FastMode {
-  let entry: SessionEntry | undefined;
-  try {
-    const target = resolveGatewaySessionStoreTarget({
-      cfg: params.cfg,
-      key: params.requesterInternalKey,
-    });
-    entry = loadSessionEntry({
-      storePath: target.storePath,
-      sessionKey: target.canonicalKey,
-      clone: false,
-    });
-  } catch {
-    entry = undefined;
-  }
-  const defaultModel = resolveDefaultModelForAgent({
-    cfg: params.cfg,
-    agentId: params.requesterAgentId,
-  });
-  const normalizedOverride = entry
-    ? normalizeStoredOverrideModel({
-        providerOverride: entry.providerOverride,
-        modelOverride: entry.modelOverride,
-      })
-    : {};
-  const selectedModel = entry
-    ? resolvePersistedSelectedModelRef({
-        defaultProvider: defaultModel.provider,
-        runtimeProvider: entry.modelProvider,
-        runtimeModel: entry.model,
-        overrideProvider: normalizedOverride.providerOverride,
-        overrideModel: normalizedOverride.modelOverride,
-      })
-    : undefined;
-  return resolveFastModeState({
-    cfg: params.cfg,
-    provider: selectedModel?.provider ?? defaultModel.provider,
-    model: selectedModel?.model ?? defaultModel.model,
-    agentId: params.requesterAgentId,
-    sessionEntry: entry,
-  }).mode;
-}
-
-type PreparedSpawnContext =
-  | {
-      status: "ok";
-      mode: "isolated";
-      parentEntry?: SessionEntry;
-      childEntry?: SessionEntry;
-      forkFallbackNote?: string;
-    }
-  | {
-      status: "ok";
-      mode: "fork";
-      parentEntry: SessionEntry;
-      childEntry?: SessionEntry;
-      forked: { sessionId: string; sessionFile: string };
-      forkFallbackNote?: never;
-    }
-  | { status: "error"; error: string };
-
-async function prepareSubagentSessionContext(params: {
-  cfg: OpenClawConfig;
-  contextMode: SpawnSubagentContextMode;
-  requesterAgentId: string;
-  targetAgentId: string;
-  requesterInternalKey: string;
-  childSessionKey: string;
-}): Promise<PreparedSpawnContext> {
-  if (params.contextMode === "isolated") {
-    return { status: "ok", mode: "isolated" };
-  }
-  const childTarget = resolveGatewaySessionStoreTarget({
-    cfg: params.cfg,
-    key: params.childSessionKey,
-  });
-  const parentTarget = resolveGatewaySessionStoreTarget({
-    cfg: params.cfg,
-    key: params.requesterInternalKey,
-  });
-
-  let parentEntry: SessionEntry | undefined;
-  let childEntry: SessionEntry | undefined;
-  let forkFallbackNote: string | undefined;
-
-  try {
-    if (params.targetAgentId !== params.requesterAgentId) {
-      throw new Error(
-        'context="fork" currently requires the same target agent as the requester; use context="isolated" for cross-agent spawns.',
-      );
-    }
-
-    const forkedResult = await subagentSpawnDeps.forkSessionEntryFromParent({
-      storePath: childTarget.storePath,
-      parentSessionKey: parentTarget.canonicalKey,
-      parentStoreKeys: parentTarget.storeKeys,
-      sessionKey: childTarget.canonicalKey,
-      sessionStoreKeys: childTarget.storeKeys,
-      fallbackEntry: { sessionId: "", updatedAt: Date.now() },
-      agentId: params.requesterAgentId,
-    });
-    if (forkedResult.status === "missing-parent") {
-      throw new Error(
-        'context="fork" requested but the requester session transcript is not available.',
-      );
-    }
-    if (forkedResult.status === "failed" || forkedResult.status === "missing-entry") {
-      throw new Error(
-        'context="fork" requested but OpenClaw could not fork the requester transcript.',
-      );
-    }
-    parentEntry = forkedResult.parentEntry;
-    childEntry = forkedResult.sessionEntry;
-    if (forkedResult.status === "skipped") {
-      forkFallbackNote =
-        forkedResult.decision?.status === "skip" ? forkedResult.decision.message : undefined;
-    }
-    const forked =
-      forkedResult.status === "forked"
-        ? {
-            sessionId: forkedResult.fork.sessionId,
-            sessionFile: forkedResult.fork.sessionFile,
-          }
-        : null;
-
-    if (params.contextMode === "fork") {
-      if (!parentEntry || !forked) {
-        if (forkFallbackNote) {
-          return {
-            status: "ok",
-            mode: "isolated",
-            parentEntry,
-            childEntry,
-            forkFallbackNote,
-          };
-        }
-        return {
-          status: "error",
-          error: 'context="fork" requested but OpenClaw could not prepare forked context.',
-        };
-      }
-      return {
-        status: "ok",
-        mode: "fork",
-        parentEntry,
-        childEntry,
-        forked,
-      };
-    }
-    return {
-      status: "ok",
-      mode: "isolated",
-      parentEntry,
-      childEntry,
-      ...(forkFallbackNote ? { forkFallbackNote } : {}),
-    };
-  } catch (err) {
-    return { status: "error", error: summarizeSpawnError(err) };
-  }
-}
-
-async function prepareContextEngineSubagentSpawn(params: {
-  cfg: OpenClawConfig;
-  context: PreparedSpawnContext & { status: "ok" };
-  requesterInternalKey: string;
-  childSessionKey: string;
-  runTimeoutSeconds: number;
-}): Promise<
-  { status: "ok"; preparation?: SubagentSpawnPreparation } | { status: "error"; error: string }
-> {
-  try {
-    subagentSpawnDeps.ensureContextEnginesInitialized();
-    const engine = await subagentSpawnDeps.resolveContextEngine(params.cfg);
-    const preparation = await engine.prepareSubagentSpawn?.({
-      parentSessionKey: params.requesterInternalKey,
-      childSessionKey: params.childSessionKey,
-      contextMode: params.context.mode,
-      parentSessionId: params.context.parentEntry?.sessionId,
-      parentSessionFile: params.context.parentEntry?.sessionFile,
-      childSessionId:
-        params.context.mode === "fork"
-          ? params.context.forked.sessionId
-          : params.context.childEntry?.sessionId,
-      childSessionFile:
-        params.context.mode === "fork"
-          ? params.context.forked.sessionFile
-          : params.context.childEntry?.sessionFile,
-      ttlMs: finiteSecondsToTimerSafeMilliseconds(params.runTimeoutSeconds, {
-        floorSeconds: true,
-      }),
-    });
-    return { status: "ok", preparation };
-  } catch (err) {
-    return {
-      status: "error",
-      error: `Context engine subagent preparation failed: ${summarizeSpawnError(err)}`,
-    };
-  }
-}
-
-async function rollbackPreparedContextEngine(
-  preparation?: SubagentSpawnPreparation,
-): Promise<boolean> {
-  try {
-    await preparation?.rollback();
-    return true;
-  } catch {
-    // Best-effort cleanup only.
-    return false;
-  }
-}
-
-function sanitizeMountPathHint(value?: string): string | undefined {
-  const trimmed = normalizeOptionalString(value);
-  if (!trimmed) {
-    return undefined;
-  }
-  if (hasPromptUnsafeControlCharacter(trimmed)) {
-    return undefined;
-  }
-  if (!/^[A-Za-z0-9._\-/:]+$/.test(trimmed)) {
-    return undefined;
-  }
-  return trimmed;
-}
-
-function hasPromptUnsafeControlCharacter(value: string): boolean {
-  for (const char of value) {
-    const code = char.charCodeAt(0);
-    if (code <= 0x1f || code === 0x7f || code === 0x85 || code === 0x2028 || code === 0x2029) {
-      return true;
-    }
-  }
-  return false;
-}
-
-async function cleanupProvisionalSession(
-  childSessionKey: string,
-  options?: {
-    emitLifecycleHooks?: boolean;
-    deleteTranscript?: boolean;
-  },
-): Promise<boolean> {
-  try {
-    await callSubagentGateway({
-      method: "sessions.delete",
-      params: {
-        key: childSessionKey,
-        emitLifecycleHooks: options?.emitLifecycleHooks === true,
-        deleteTranscript: options?.deleteTranscript === true,
-      },
-      timeoutMs: SUBAGENT_CONTROL_GATEWAY_TIMEOUT_MS,
-    });
-    return true;
-  } catch {
-    // Best-effort cleanup only.
-    return false;
-  }
-}
-
-async function waitForProvisionalSessionDeletion(
-  childSessionKey: string,
-  options?: {
-    emitLifecycleHooks?: boolean;
-    deleteTranscript?: boolean;
-  },
-): Promise<void> {
-  for (;;) {
-    if (await cleanupProvisionalSession(childSessionKey, options)) {
-      return;
-    }
-    await new Promise<void>((resolve) => {
-      const timer = setTimeout(resolve, isFastTestRuntimeEnv() ? 1 : 1_000);
-      timer.unref?.();
-    });
-  }
-}
-
-async function cleanupFailedSpawnBeforeAgentStart(params: {
-  childSessionKey: string;
-  attachmentAbsDir?: string;
-  emitLifecycleHooks?: boolean;
-  deleteTranscript?: boolean;
-  waitForSessionDeletion?: boolean;
-}): Promise<{ attachmentsRemoved: boolean; sessionDeleted: boolean }> {
-  let attachmentsRemoved = true;
-  if (params.attachmentAbsDir) {
-    try {
-      await fs.rm(params.attachmentAbsDir, { recursive: true, force: true });
-    } catch {
-      attachmentsRemoved = false;
-    }
-  }
-  const sessionCleanupOptions = {
-    emitLifecycleHooks: params.emitLifecycleHooks,
-    deleteTranscript: params.deleteTranscript,
-  };
-  if (params.waitForSessionDeletion) {
-    await waitForProvisionalSessionDeletion(params.childSessionKey, sessionCleanupOptions);
-    return { attachmentsRemoved, sessionDeleted: true };
-  }
-  return {
-    attachmentsRemoved,
-    sessionDeleted: await cleanupProvisionalSession(params.childSessionKey, sessionCleanupOptions),
-  };
-}
-
-async function terminateAcceptedCollectorRun(params: {
-  childSessionKey: string;
-  gatewayRunId: string;
-}): Promise<void> {
-  for (;;) {
-    try {
-      await callSubagentGateway({
-        method: "chat.abort",
-        params: { sessionKey: params.childSessionKey, runId: params.gatewayRunId },
-        timeoutMs: SUBAGENT_CONTROL_GATEWAY_TIMEOUT_MS,
-      });
-      return;
-    } catch {
-      if (
-        await cleanupProvisionalSession(params.childSessionKey, {
-          deleteTranscript: true,
-        })
-      ) {
-        return;
-      }
-    }
-    await new Promise<void>((resolve) => {
-      const timer = setTimeout(resolve, isFastTestRuntimeEnv() ? 1 : 1_000);
-      timer.unref?.();
-    });
-  }
-}
-
-function resolveSubagentContextMode(params: {
-  requestedContext?: SpawnSubagentContextMode;
-  threadRequested: boolean;
-  cfg: OpenClawConfig;
-  requester: {
-    channel?: string;
-    accountId?: string;
-  };
-}): SpawnSubagentContextMode {
-  if (params.requestedContext === "fork" || params.requestedContext === "isolated") {
-    return params.requestedContext;
-  }
-  if (!params.threadRequested || !params.requester.channel) {
-    return "isolated";
-  }
-  return resolveThreadBindingSpawnPolicy({
-    cfg: params.cfg,
-    channel: params.requester.channel,
-    accountId: params.requester.accountId,
-    kind: "subagent",
-  }).defaultSpawnContext;
-}
-
-async function bindThreadForSubagentSpawn(params: {
-  cfg: OpenClawConfig;
-  childSessionKey: string;
-  agentId: string;
-  label?: string;
-  mode: SpawnSubagentMode;
-  requesterSessionKey?: string;
-  requester: {
-    channel?: string;
-    accountId?: string;
-    to?: string;
-    threadId?: string | number;
-  };
-}): Promise<
-  | { status: "ok"; deliveryOrigin?: DeliveryContext }
-  | {
-      status: "error";
-      error: string;
-    }
-> {
-  const prepared = prepareSpawnThreadBinding({
-    cfg: params.cfg,
-    kind: "subagent",
-    mode: params.mode,
-    bindingService: getSessionBindingService(),
-    requesterSessionKey: params.requesterSessionKey,
-    channel: params.requester.channel,
-    accountId: params.requester.accountId,
-    to: params.requester.to,
-    threadId: params.requester.threadId,
-  });
-  if (!prepared.ok) {
-    return {
-      status: "error",
-      error: prepared.error,
-    };
-  }
-
-  try {
-    const binding = await getSessionBindingService().bind({
-      targetSessionKey: params.childSessionKey,
-      targetKind: "subagent",
-      conversation: {
-        channel: prepared.binding.channel,
-        accountId: prepared.binding.accountId,
-        conversationId: prepared.binding.conversationId,
-        ...(prepared.binding.parentConversationId
-          ? { parentConversationId: prepared.binding.parentConversationId }
-          : {}),
-      },
-      placement: prepared.binding.placement,
-      metadata: {
-        threadName: resolveThreadBindingThreadName({
-          agentId: params.agentId,
-          label: params.label || params.agentId,
-        }),
-        agentId: params.agentId,
-        label: params.label || undefined,
-        boundBy: "system",
-        introText: resolveThreadBindingIntroText({
-          agentId: params.agentId,
-          label: params.label || undefined,
-          idleTimeoutMs: resolveThreadBindingIdleTimeoutMsForChannel({
-            cfg: params.cfg,
-            channel: prepared.binding.channel,
-            accountId: prepared.binding.accountId,
-          }),
-          maxAgeMs: resolveThreadBindingMaxAgeMsForChannel({
-            cfg: params.cfg,
-            channel: prepared.binding.channel,
-            accountId: prepared.binding.accountId,
-          }),
-        }),
-      },
-    });
-    if (!binding.conversation.conversationId) {
-      return {
-        status: "error",
-        error:
-          "Unable to create or bind a thread for this subagent session. Session mode is unavailable for this target.",
-      };
-    }
-    const deliveryOrigin = routeToDeliveryFields(routeFromBindingRecord(binding)).deliveryContext;
-    return {
-      status: "ok",
-      ...(deliveryOrigin ? { deliveryOrigin } : {}),
-    };
-  } catch (err) {
-    return {
-      status: "error",
-      error: `Thread bind failed: ${summarizeSpawnError(err)}`,
-    };
-  }
-}
-
-function hasRoutableDeliveryOrigin(
-  origin?: DeliveryContext,
-): origin is DeliveryContext & { channel: string; to: string } {
-  return Boolean(origin?.channel && origin.to);
-}
 
 export async function spawnSubagentDirect(
   params: SpawnSubagentParams,
   ctx: SpawnSubagentContext,
 ): Promise<SpawnSubagentResult> {
   const task = params.task;
-  const taskNameResult = normalizeSubagentTaskName(params.taskName);
-  if (taskNameResult.error) {
-    return {
-      status: "error",
-      error: taskNameResult.error,
-    };
-  }
-  const taskName = taskNameResult.taskName;
   const label = params.label?.trim() || "";
-  let requestedAgentId = params.agentId?.trim();
-
-  // Reject malformed agentId before normalizeAgentId can mangle it.
-  // Without this gate, error-message strings like "Agent not found: xyz" pass
-  // through normalizeAgentId and become "agent-not-found--xyz", which later
-  // creates ghost workspace directories and triggers cascading cron loops (#31311).
-  if (requestedAgentId && !isValidAgentId(requestedAgentId)) {
-    return {
-      status: "error",
-      error: `Invalid agentId "${requestedAgentId}". Agent IDs must match [a-z0-9][a-z0-9_-]{0,63}. Use agents_list to discover valid targets.`,
-    };
-  }
-  const modelOverride = params.model;
-  const thinkingOverrideRaw = params.thinking;
   const requestThreadBinding = params.thread === true;
   const sandboxMode = params.sandbox === "require" ? "require" : "inherit";
-  const spawnMode = resolveSpawnMode({
-    requestedMode: params.mode,
-    threadRequested: requestThreadBinding,
-  });
-  if (params.collect && (requestThreadBinding || spawnMode === "session")) {
-    return {
-      status: "error",
-      error: "sessions_spawn collect=true requires mode=run and thread=false.",
-    };
+  const requesterSessionKey = ctx.agentSessionKey;
+  const requestResolution = resolveSubagentSpawnRequest(params, ctx);
+  if (!requestResolution.ok) {
+    return requestResolution.result;
   }
-  if (spawnMode === "session" && !requestThreadBinding) {
-    return {
-      status: "error",
-      error:
-        'sessions_spawn(mode="session") requires thread=true so the subagent can stay bound to a channel thread. ' +
-        'Retry with { mode: "session", thread: true } on a channel that supports threads, use mode="run" for one-shot work, or use sessions_send(sessionKey=...) to keep talking to a persistent session without thread binding.',
-    };
-  }
-  const cleanup =
-    spawnMode === "session"
-      ? "keep"
-      : params.cleanup === "keep" || params.cleanup === "delete"
-        ? params.cleanup
-        : "keep";
-  const expectsCompletionMessage = params.collect
-    ? false
-    : params.expectsCompletionMessage !== false;
-  const hookRunner = subagentSpawnDeps.getGlobalHookRunner();
-  const cfg = loadSubagentConfig();
-
-  // When agent omits runTimeoutSeconds, use the config default.
-  // Falls back to 0 (no timeout) if config key is also unset,
-  // preserving current behavior for existing deployments.
-  const runTimeoutSeconds = resolveConfiguredSubagentRunTimeoutSeconds({
-    cfg,
-    runTimeoutSeconds: params.runTimeoutSeconds,
-  });
+  const {
+    request: { taskName, spawnMode, cleanup, expectsCompletionMessage },
+    runtime: {
+      hookRunner,
+      cfg,
+      runTimeoutSeconds,
+      contextMode,
+      requesterInternalKey,
+      ownership,
+      requesterAgentId,
+      targetAgentId,
+    },
+    swarm: {
+      config: swarmConfig,
+      groupId: swarmGroupId,
+      schedulerGroupKey: swarmSchedulerGroupKey,
+      launchReplayKey: swarmLaunchReplayKey,
+      reservationPending,
+    },
+    admission: { resolve: resolveAdmission, initial: admission, childDepth, maxSpawnDepth },
+    childIdem,
+  } = requestResolution.resolved;
   let modelApplied = false;
   let threadBindingReady = false;
   let hasBoundThreadDeliveryOrigin = false;
-  const contextMode = resolveSubagentContextMode({
-    requestedContext: params.context,
-    threadRequested: requestThreadBinding,
-    cfg,
-    requester: {
-      channel: ctx.agentChannel,
-      accountId: ctx.agentAccountId,
-    },
-  });
-  const { mainKey, alias } = resolveMainSessionAlias(cfg);
-  const requesterSessionKey = ctx.agentSessionKey;
-  const requesterInternalKey = requesterSessionKey
-    ? resolveInternalSessionKey({
-        key: requesterSessionKey,
-        alias,
-        mainKey,
-      })
-    : alias;
-  const ownership = resolveSubagentSpawnOwnership({
-    cfg,
-    agentSessionKey: ctx.agentSessionKey,
-    completionOwnerKey: ctx.completionOwnerKey,
-  });
-
-  const requesterAgentId = normalizeAgentId(
-    ctx.requesterAgentIdOverride ?? parseAgentSessionKey(requesterInternalKey)?.agentId,
-  );
-  const swarmConfig = resolveSwarmConfig(cfg, requesterAgentId);
-  const hasSwarmParams =
-    params.collect !== undefined ||
-    params.outputSchema !== undefined ||
-    params.fastMode !== undefined ||
-    params.groupId !== undefined;
-  if (hasSwarmParams && !swarmConfig.enabled) {
-    return {
-      status: "forbidden",
-      error: "sessions_spawn swarm parameters require tools.swarm.enabled=true.",
-    };
-  }
-  if (params.outputSchema && !params.collect) {
-    return { status: "error", error: "sessions_spawn outputSchema requires collect=true." };
-  }
-  if (params.groupId !== undefined && !params.collect) {
-    return { status: "error", error: "sessions_spawn groupId requires collect=true." };
-  }
-  if (params.outputSchema) {
-    const schemaError = validateStructuredOutputSchema(params.outputSchema);
-    if (schemaError) {
-      return { status: "error", error: schemaError };
-    }
-  }
-
-  const usingDefaultAgentId =
-    params.collect === true && !requestedAgentId && Boolean(swarmConfig.defaultAgentId);
-  if (usingDefaultAgentId) {
-    requestedAgentId = swarmConfig.defaultAgentId;
-    if (!isValidAgentId(requestedAgentId)) {
-      return {
-        status: "error",
-        error: `tools.swarm.defaultAgentId contains invalid agentId "${requestedAgentId}".`,
-      };
-    }
-  }
-  const targetAgentId = requestedAgentId ? normalizeAgentId(requestedAgentId) : requesterAgentId;
-  const configuredAgentIds = resolveConfiguredAgentIds(cfg);
-  const explicitSwarmGroupId = normalizeOptionalString(params.groupId);
-  const requesterRunId = normalizeOptionalString(ctx.requesterRunId);
-  const swarmGroupId = params.collect
-    ? (explicitSwarmGroupId ??
-      (requesterRunId ? `swarm:${requesterInternalKey}:${requesterRunId}` : undefined))
-    : undefined;
-  const swarmSchedulerGroupKey = swarmGroupId
-    ? JSON.stringify([requesterInternalKey, swarmGroupId])
-    : undefined;
-  const resolveAdmission = () => {
-    const collectorRuns = params.collect
-      ? swarmGroupId
-        ? listSwarmRunsForGroup(swarmGroupId, requesterInternalKey)
-        : []
-      : undefined;
-    return resolveSpawnAdmission({
-      cfg,
-      collector: collectorRuns
-        ? {
-            liveChildren: collectorRuns.filter((entry) => !entry.collectorCompletion).length,
-            totalChildren: collectorRuns.length,
-            maxChildrenPerGroup: swarmConfig.maxChildrenPerGroup,
-            maxTotalPerGroup: swarmConfig.maxTotalPerGroup,
-          }
-        : undefined,
-      requesterSessionKey: requesterInternalKey,
-      requesterAgentId,
-      targetAgentId,
-      requestedAgentId,
-      configuredAgentIds,
-    });
-  };
-  const admission = resolveAdmission();
-  if (!admission.ok) {
-    return {
-      status: "forbidden",
-      error:
-        usingDefaultAgentId && !admission.governingCap?.startsWith("tools.swarm.")
-          ? `tools.swarm.defaultAgentId is unavailable: ${admission.error}`
-          : admission.error,
-    };
-  }
-  if (params.collect && !swarmGroupId) {
-    return {
-      status: "error",
-      error: "sessions_spawn collect=true requires a requesting run id when groupId is omitted.",
-    };
-  }
-  const childDepth = admission.childSessionPatch?.spawnDepth ?? 1;
-  const maxSpawnDepth = admission.maxSpawnDepth ?? childDepth;
-  const swarmLaunchReplayKey = normalizeOptionalString(params.swarmLaunchReplayKey);
-  // Registry and Gateway identities are global, while host replay keys are requester-scoped.
-  const childIdem = swarmLaunchReplayKey
-    ? `swarm_${crypto
-        .createHash("sha256")
-        .update(JSON.stringify([requesterInternalKey, swarmLaunchReplayKey]))
-        .digest("hex")
-        .slice(0, 32)}`
-    : crypto.randomUUID();
   let childRunId: string = childIdem;
-  let swarmReservationPending = false;
-  if (params.collect && swarmGroupId && swarmSchedulerGroupKey) {
-    const groupRuns = listSwarmRunsForGroup(swarmGroupId, requesterInternalKey);
-    if (
-      !reserveSwarmRun({
-        groupId: swarmSchedulerGroupKey,
-        runId: childRunId,
-        maxConcurrent: swarmConfig.maxConcurrent,
-        activeRunIds: groupRuns
-          .filter((entry) => entry.execution?.status === "running")
-          .map((entry) => entry.schedulerSlotId ?? entry.runId),
-      })
-    ) {
-      return { status: "error", error: "sessions_spawn could not reserve swarm FIFO order." };
-    }
-    swarmReservationPending = true;
-  }
+  let swarmReservationPending = reservationPending;
   try {
-    const requestedCwd = normalizeOptionalString(params.cwd);
-    const spawnedCwd = requestedCwd ? resolveUserPath(requestedCwd) : undefined;
-    const toolSpawnMetadata = mapToolContextToSpawnedRunMetadata({
-      agentGroupId: ctx.agentGroupId,
-      agentGroupChannel: ctx.agentGroupChannel,
-      agentGroupSpace: ctx.agentGroupSpace,
-      workspaceDir: ctx.workspaceDir,
-    });
-    const inheritedWorkspaceDir =
-      targetAgentId !== requesterAgentId ? undefined : toolSpawnMetadata.workspaceDir;
-    const spawnedWorkspaceDir = resolveSpawnedWorkspaceInheritance({
-      config: cfg,
-      targetAgentId,
-      explicitWorkspaceDir: inheritedWorkspaceDir,
-    });
-    const requesterOrigin = normalizeDeliveryContext({
-      channel: ctx.agentChannel,
-      accountId: ctx.agentAccountId,
-      to: ctx.agentTo,
-      ...(ctx.agentThreadId != null && ctx.agentThreadId !== ""
-        ? { threadId: ctx.agentThreadId }
-        : {}),
-    });
-    let childSessionOrigin = resolveRequesterOriginForChild({
-      cfg,
-      targetAgentId,
-      requesterAgentId,
-      requesterChannel: ctx.agentChannel,
-      requesterAccountId: ctx.agentAccountId,
-      requesterTo: ctx.agentTo,
-      requesterThreadId: ctx.agentThreadId,
-      requesterGroupSpace: ctx.agentGroupSpace,
-      requesterMemberRoleIds: ctx.agentMemberRoleIds,
-    });
-    const incognito = isIncognitoSessionKey(requesterInternalKey);
-    const mintedChildSessionKey = mintSpawnSessionKey({ targetAgentId, backend: "subagent" });
-    const childSessionKey = incognito
-      ? mintedChildSessionKey.replace(":subagent:", ":subagent:incognito-")
-      : mintedChildSessionKey;
-    const requesterRuntime = resolveSandboxRuntimeStatus({
-      cfg,
-      sessionKey: requesterInternalKey,
-    });
-    const childRuntime = resolveSandboxRuntimeStatus({
-      cfg,
-      sessionKey: childSessionKey,
-    });
-    const sandboxError = resolveSpawnSandboxError({
-      backend: "subagent",
-      requesterSandboxed: requesterRuntime.sandboxed,
-      childSandboxed: childRuntime.sandboxed,
-      sandbox: sandboxMode,
-    });
-    if (sandboxError) {
-      return { status: "forbidden", error: sandboxError };
-    }
-    const spawnedWorkspaceCwd = spawnedWorkspaceDir
-      ? resolveUserPath(spawnedWorkspaceDir)
-      : undefined;
-    if (childRuntime.sandboxed && spawnedCwd && spawnedCwd !== spawnedWorkspaceCwd) {
-      return {
-        status: "forbidden",
-        error:
-          "cwd override is not supported for sandboxed subagent runs; omit cwd or use the target agent workspace as cwd",
-      };
-    }
-    const spawnedByKey = requesterInternalKey;
-    const targetAgentDir = resolveAgentDir(cfg, targetAgentId);
-    const requesterAgentConfig = resolveAgentConfig(cfg, requesterAgentId);
-    const targetAgentConfig = resolveAgentConfig(cfg, targetAgentId);
-    const callerThinkingRaw = readRequesterThinkingLevel({
+    const childPlan = await resolveSubagentChildPlan({
+      request: params,
+      ctx,
       cfg,
       requesterInternalKey,
       requesterAgentId,
+      targetAgentId,
+      sandboxMode,
+      swarmEnabled: swarmConfig.enabled,
     });
-    const inheritedFastMode =
-      swarmConfig.enabled && params.fastMode === undefined
-        ? readRequesterFastMode({
-            cfg,
-            requesterInternalKey,
-            requesterAgentId,
-          })
-        : params.fastMode;
-    const plan = resolveSubagentModelAndThinkingPlan({
+    if (!childPlan.ok) {
+      return childPlan.result;
+    }
+    const {
+      spawnedCwd,
+      toolSpawnMetadata,
+      spawnedWorkspaceDir,
+      requesterOrigin,
+      incognito,
+      childSessionKey,
+      childRuntimeSandboxed,
+      targetAgentDir,
+      modelPlan: plan,
+      launchAuthorization,
+      resolvedModelMetadata,
+    } = childPlan.resolved;
+    let { childSessionOrigin } = childPlan.resolved;
+    const spawnedByKey = requesterInternalKey;
+    const { resolvedModel, thinkingOverride } = plan;
+    const initialSession = await createInitialSubagentSession({
       cfg,
       targetAgentId,
-      requesterAgentConfig,
-      targetAgentConfig,
-      modelOverride,
-      thinkingOverrideRaw,
-      callerThinkingRaw,
-      fastMode: inheritedFastMode,
-    });
-    if (plan.status === "error") {
-      return {
-        status: "error",
-        error: plan.error,
-      };
-    }
-    const { resolvedModel, thinkingOverride } = plan;
-    const resolvedLaunchModel = splitModelRef(resolvedModel);
-    const launchAuthorization: SubagentLaunchAuthorization | undefined =
-      modelOverride?.trim() && resolvedLaunchModel.model
-        ? {
-            modelOverride: {
-              ...(resolvedLaunchModel.provider ? { provider: resolvedLaunchModel.provider } : {}),
-              model: resolvedLaunchModel.model,
-            },
-          }
-        : undefined;
-    if (params.outputSchema) {
-      const outputModelError = await resolveCollectorOutputModelError({
-        cfg,
-        targetAgentId,
-        targetAgentDir,
-        workspaceDir: spawnedWorkspaceDir,
-        resolvedModel,
-      });
-      if (outputModelError) {
-        return { status: "error", error: outputModelError, childSessionKey };
-      }
-    }
-    const resolvedModelMetadata = buildResolvedSubagentModelMetadata(resolvedModel);
-    let childCreationEntry: SessionEntry | undefined;
-    const patchChildSession = async (
-      patch: Record<string, unknown>,
-      creationStamp?: ReturnType<typeof buildSessionCreationStamp>,
-    ): Promise<string | undefined> => {
-      try {
-        const target = incognito
-          ? {
-              agentId: targetAgentId,
-              canonicalKey: childSessionKey,
-              storeKeys: [childSessionKey],
-              storePath: resolveIncognitoOpenClawAgentSqlitePath({ agentId: targetAgentId }),
-            }
-          : resolveGatewaySessionStoreTarget({
-              cfg,
-              key: childSessionKey,
-            });
-        const updatedEntry = await upsertSessionEntry(
-          {
-            storePath: target.storePath,
-            sessionKey: target.canonicalKey,
-          },
-          { ...buildDirectChildSessionPatch(patch), ...creationStamp },
-        );
-        childCreationEntry ??= updatedEntry ?? undefined;
-        return undefined;
-      } catch (err) {
-        const message =
-          err instanceof Error ? err.message : typeof err === "string" ? err : "error";
-        return `child session patch failed: ${message}`;
-      }
-    };
-
-    const initialChildSessionPatch: Record<string, unknown> = {
-      spawnedBy: spawnedByKey,
+      childSessionKey,
+      incognito,
+      requesterInternalKey,
       completionOwnerSessionKey: ownership.completionRequesterSessionKey,
-      // Navigation and control lineage commit with the creation stamp so a
-      // launch failure cannot leave a durable but parentless child row.
-      parentSessionKey: spawnedByKey,
-      ...(spawnedWorkspaceDir ? { spawnedWorkspaceDir } : {}),
-      ...(spawnedCwd ? { spawnedCwd } : {}),
-      ...admission.childSessionPatch,
-      inheritedToolPolicyVersion: 1,
-      ...inheritedToolAllowPatch(ctx.inheritedToolAllowlist),
-      ...inheritedToolDenyPatch(ctx.inheritedToolDenylist),
-      ...plan.initialSessionPatch,
-      ...(swarmGroupId ? { swarmGroupId } : {}),
-      ...(params.collect ? { swarmCollector: true } : {}),
-      ...(params.outputSchema ? { swarmOutputSchema: params.outputSchema } : {}),
-      ...(incognito ? { incognito: true } : {}),
-    };
-
-    const initialPatchError = await patchChildSession(
-      initialChildSessionPatch,
-      buildSessionCreationStamp({
-        via: "spawn",
-        actor: { type: "agent", id: requesterInternalKey },
-      }),
-    );
-    if (initialPatchError) {
+      spawnedWorkspaceDir,
+      spawnedCwd,
+      admissionPatch: admission.childSessionPatch,
+      inheritedToolAllowlist: ctx.inheritedToolAllowlist,
+      inheritedToolDenylist: ctx.inheritedToolDenylist,
+      modelPatch: plan.initialSessionPatch,
+      swarmGroupId,
+      collect: params.collect === true,
+      outputSchema: params.outputSchema,
+    });
+    if (initialSession.status === "error") {
       return {
         status: "error",
-        error: initialPatchError,
+        error: initialSession.error,
         childSessionKey,
       };
     }
@@ -1506,7 +252,7 @@ export async function spawnSubagentDirect(
       task,
       acpEnabled: isAcpRuntimeSpawnAvailable({
         config: cfg,
-        sandboxed: childRuntime.sandboxed,
+        sandboxed: childRuntimeSandboxed,
       }),
       nativeCommandGuidanceLines: listRegisteredPluginAgentPromptGuidance({
         surface: "subagent",
@@ -1555,27 +301,42 @@ export async function spawnSubagentDirect(
       childSystemPrompt = `${childSystemPrompt}\n\n${materializedAttachments.systemPromptSuffix}`;
     }
 
-    const bootstrapContextMode: BootstrapContextMode | undefined = params.lightContext
-      ? "lightweight"
-      : undefined;
-
-    const childTaskMessage = buildSubagentInitialUserMessage({
-      childDepth,
-      maxSpawnDepth,
-      persistentSession: spawnMode === "session",
-      task,
-    });
-    const spawnedMetadata = normalizeSpawnedRunMetadata({
-      spawnedBy: spawnedByKey,
-      ...toolSpawnMetadata,
-      workspaceDir: spawnedWorkspaceDir,
-    });
-
-    if (childCreationEntry) {
+    const deliverInitialChildRunDirectly =
+      requestThreadBinding && spawnMode === "session" && hasBoundThreadDeliveryOrigin;
+    const { childLaunch, queuedLaunch, progressOrigin, shouldAnnounceCompletion, spawnedMetadata } =
+      buildSubagentLaunchRequest({
+        childDepth,
+        maxSpawnDepth,
+        spawnMode,
+        task,
+        spawnedByKey,
+        toolSpawnMetadata,
+        spawnedWorkspaceDir,
+        childSessionKey,
+        collect: params.collect === true,
+        childSessionOrigin,
+        childIdem,
+        deliverInitialChildRunDirectly,
+        outputSchema: params.outputSchema,
+        childSystemPrompt,
+        thinkingOverride,
+        runTimeoutSeconds,
+        label: label || undefined,
+        lightContext: params.lightContext === true,
+        expectsCompletionMessage,
+        requesterOrigin,
+        currentMessagingTarget: ctx.currentMessagingTarget,
+        currentChannelId: ctx.currentChannelId,
+        currentMessageId: ctx.currentMessageId,
+        launchAuthorization,
+        swarmSchedulerGroupKey,
+        swarmMaxConcurrent: swarmConfig.maxConcurrent,
+      });
+    if (initialSession.entry) {
       recordSessionCreated({
         sessionKey: childSessionKey,
         agentId: targetAgentId,
-        entry: childCreationEntry,
+        entry: initialSession.entry,
       });
     }
     recordSubagentSpawned({
@@ -1584,70 +345,6 @@ export async function spawnSubagentDirect(
       requesterSessionKey: requesterInternalKey,
       agentId: targetAgentId,
     });
-    const deliverInitialChildRunDirectly =
-      requestThreadBinding && spawnMode === "session" && hasBoundThreadDeliveryOrigin;
-    const shouldAnnounceCompletion = deliverInitialChildRunDirectly
-      ? false
-      : expectsCompletionMessage;
-    const progressOrigin = {
-      channel: requesterOrigin?.channel,
-      accountId: requesterOrigin?.accountId,
-      to: ctx.currentMessagingTarget ?? requesterOrigin?.to,
-      threadId: requesterOrigin?.threadId,
-      channelId: ctx.currentChannelId,
-      messageId: ctx.currentMessageId,
-    };
-    const {
-      spawnedBy: _spawnedBy,
-      workspaceDir: _workspaceDir,
-      ...publicSpawnedMetadata
-    } = spawnedMetadata;
-    const childLaunchRequest: Record<string, unknown> = {
-      message: childTaskMessage,
-      sessionKey: childSessionKey,
-      ...(params.collect
-        ? {}
-        : {
-            channel: childSessionOrigin?.channel,
-            to: childSessionOrigin?.to ?? undefined,
-            accountId: childSessionOrigin?.accountId ?? undefined,
-            threadId:
-              childSessionOrigin?.threadId != null
-                ? stringifyRouteThreadId(childSessionOrigin.threadId)
-                : undefined,
-          }),
-      idempotencyKey: childIdem,
-      deliver: deliverInitialChildRunDirectly,
-      lane: AGENT_LANE_SUBAGENT,
-      disableMessageTool: true,
-      swarmCollector: params.collect === true,
-      swarmOutputSchema: params.outputSchema,
-      cleanupBundleMcpOnRunEnd: spawnMode !== "session",
-      extraSystemPrompt: childSystemPrompt,
-      thinking: thinkingOverride,
-      timeout: runTimeoutSeconds,
-      label: label || undefined,
-      ...(bootstrapContextMode
-        ? {
-            bootstrapContextMode,
-            bootstrapContextRunKind: "default" as const,
-          }
-        : {}),
-      ...publicSpawnedMetadata,
-    };
-    const childLaunch = {
-      request: childLaunchRequest,
-      ...(launchAuthorization ? { authorization: launchAuthorization } : {}),
-      timeoutMs: resolveSubagentAgentGatewayTimeoutMs(runTimeoutSeconds),
-    };
-    const queuedLaunch =
-      params.collect && swarmSchedulerGroupKey
-        ? {
-            ...childLaunch,
-            schedulerGroupKey: swarmSchedulerGroupKey,
-            maxConcurrent: swarmConfig.maxConcurrent,
-          }
-        : undefined;
     const launchChildRun = async () =>
       await callSubagentGateway(
         {
@@ -1658,57 +355,18 @@ export async function spawnSubagentDirect(
         childLaunch.authorization,
       );
 
-    // "spawned"/"started" hooks mean an accepted Gateway run. Direct runs emit
-    // after the shared pipeline; queued collectors emit from the scheduler start.
-    const emitSpawnLifecycleHooks = async (hookRunId: string) => {
-      if (hookRunner?.hasHooks("subagent_progress")) {
-        try {
-          await hookRunner.runSubagentProgress(
-            {
-              phase: "started",
-              runId: hookRunId,
-              childSessionKey,
-              requester: progressOrigin,
-            },
-            {
-              runId: hookRunId,
-              childSessionKey,
-              requesterSessionKey: requesterInternalKey,
-            },
-          );
-        } catch {
-          // Presentation hooks are best-effort after durable registration.
-        }
-      }
-      if (hookRunner?.hasHooks("subagent_spawned")) {
-        try {
-          await hookRunner.runSubagentSpawned(
-            {
-              runId: hookRunId,
-              childSessionKey,
-              agentId: targetAgentId,
-              label: label || undefined,
-              requester: {
-                channel: requesterOrigin?.channel,
-                accountId: requesterOrigin?.accountId,
-                to: requesterOrigin?.to,
-                threadId: requesterOrigin?.threadId,
-              },
-              threadRequested: requestThreadBinding,
-              mode: spawnMode,
-              ...resolvedModelMetadata,
-            },
-            {
-              runId: hookRunId,
-              childSessionKey,
-              requesterSessionKey: requesterInternalKey,
-            },
-          );
-        } catch {
-          // Spawn stays accepted if lifecycle presentation fails.
-        }
-      }
-    };
+    const emitSpawnLifecycleHooks = createSubagentSpawnLifecycleEmitter({
+      hookRunner,
+      childSessionKey,
+      requesterInternalKey,
+      progressOrigin,
+      targetAgentId,
+      label: label || undefined,
+      requesterOrigin,
+      requestThreadBinding,
+      spawnMode,
+      resolvedModelMetadata,
+    });
     type SubagentBackendState = { contextEnginePreparation?: SubagentSpawnPreparation };
     const adapter: SpawnBackendAdapter<SubagentBackendState> = {
       async initialize() {
@@ -1986,17 +644,11 @@ export async function spawnSubagentDirect(
 }
 
 const testing = {
-  setDepsForTest(overrides?: Partial<SubagentSpawnDeps>) {
-    subagentSpawnDeps = overrides
-      ? {
-          ...defaultSubagentSpawnDeps,
-          ...overrides,
-        }
-      : defaultSubagentSpawnDeps;
+  setDepsForTest(overrides?: Parameters<typeof setSubagentSpawnDepsForTest>[0]) {
+    setSubagentSpawnDepsForTest(overrides);
   },
 };
 if (process.env.VITEST || process.env.NODE_ENV === "test") {
   (globalThis as Record<PropertyKey, unknown>)[Symbol.for("openclaw.subagentSpawnTestApi")] =
     testing;
 }
-/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -78,7 +78,14 @@ export async function spawnSubagentDirect(
   const requestThreadBinding = params.thread === true;
   const sandboxMode = params.sandbox === "require" ? "require" : "inherit";
   const requesterSessionKey = ctx.agentSessionKey;
-  const requestResolution = resolveSubagentSpawnRequest(params, ctx);
+  let requestedAgentId = params.agentId?.trim();
+  const requestResolution = resolveSubagentSpawnRequest(params, ctx, {
+    initial: requestedAgentId,
+    applyDefault(agentId) {
+      requestedAgentId = agentId;
+      return requestedAgentId;
+    },
+  });
   if (!requestResolution.ok) {
     return requestResolution.result;
   }


### PR DESCRIPTION
## What Problem This Solves

`src/agents/subagent-spawn.ts` sat in `config/max-lines-baseline.txt` at ~1898 effective lines
against the 700 budget for `src/**/*.ts`. Root `AGENTS.md`: grandfathered entries are TODOs, the
ratchet may only shrink.

This is the sibling of #113979, which brought `acp-spawn.ts` from 1412 to 684 effective lines by
relocating helpers. That approach alone could not work here: module-level helpers were ~960 effective
lines and the exported `spawnSubagentDirect` was ~930 on its own, so removing every helper still left
the file above budget. Part of the function had to move too.

## Why This Change Was Made

Two moves, both behavior-neutral.

First, module-level helpers relocated into focused siblings following #113979's shape — gateway,
model metadata, session patch, requester prefs, context preparation, cleanup, thread binding,
validation, deps, lifecycle, contract types.

Second, the ~210-line validation/normalization preamble of `spawnSubagentDirect` moved into
`subagent-spawn-request.ts` behind a closed discriminated union:

    type ResolveSubagentSpawnRequestResult =
      | { ok: false; result: SpawnSubagentResult }
      | { ok: true; resolved: { request; runtime; swarm; admission; childIdem } }

Each early return in the preamble became `{ ok: false, result }` with an unchanged result shape, and
the 22 resolved values are grouped by concern rather than flattened into a mega-object.

The constraint that shaped this: **mutable lifecycle state stays caller-owned**. Every `let` that
later phases mutate — `modelApplied`, thread-binding state, child run id, swarm reservation state —
remains in `spawnSubagentDirect`. The one reassignment inside the preamble (`requestedAgentId` taking
the swarm default) is handled by a small caller-owned `requestedAgent.applyDefault(...)` handle
rather than by moving the variable. The `runSpawnPipeline` adapter closures
(initialize / dispatchTurn / cleanupOnFailure) were not touched; `spawn-pipeline.ts` already owns the
shared spawn spine and this PR deliberately adds no second layer.

`subagent-spawn.ts` is now **642 effective lines**; every new module is between 28 and 327. The
baseline entry is removed, so the ratchet shrinks.

## User Impact

None. No behavior change, no signature change on the exported entry point, no altered error text, no
reordered side effects.

## Evidence

Behavior-neutrality was checked by diffing every string literal between the pre-change file and the
new module set, not by reading the diff alone. Three differed, all benign:

- `"resolvedModel"` / `"resolvedProvider"` were type-level literals in a `Pick<SpawnSubagentResult,
  ...>` that is unnecessary now `subagent-spawn-contract.ts` declares those properties directly.
- The swarm error is byte-identical; only the interpolated variable is renamed to the caller-owned
  equivalent holding the same value.

Local proof, with real exit codes (not a pipeline's status):

    node scripts/run-vitest.mjs src/agents/subagent-spawn.test.ts        51 passed
    node scripts/run-vitest.mjs src/agents/subagent-spawn                102 passed across 9 files
    node scripts/run-vitest.mjs src/agents/openclaw-tools.subagents*.test.ts   58 passed across 6 files
    node scripts/run-vitest.mjs src/agents/sessions-spawn-hooks.test.ts   9 passed
    node scripts/run-tsgo.mjs -p tsconfig.core.json                       exit 0
    node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json    exit 0
    node scripts/check-max-lines-ratchet.mjs                              OK, 1058 suppressions

Five symbols were also audited out of the public surface before CI: `ResolveSubagentChildPlanResult`,
`PreparedSpawnContext`, `SubagentSpawnDeps`, `ResolveSubagentSpawnRequestResult`, and
`buildDirectChildSessionPatch` are used only inside their own modules and are now module-private.
#113979's first CI run failed Knip for exactly this class, so it was checked up front this time.
