### PR TITLE
refactor(auth): finish SQLite-only auth profile cutover

### DIFF
--- a/docs/concepts/agent-workspace.md
+++ b/docs/concepts/agent-workspace.md
@@ -109,7 +109,7 @@ These live under `~/.openclaw/` and should NOT be committed to the workspace rep
 
 - `~/.openclaw/openclaw.json` (config)
 - `~/.openclaw/state/openclaw.sqlite` (shared workspace setup state and attestations)
-- `~/.openclaw/agents/<agentId>/agent/auth-profiles.json` (model auth profiles: OAuth + API keys)
+- `~/.openclaw/agents/<agentId>/agent/openclaw-agent.sqlite` (model auth profiles, routing state, and other agent-scoped durability)
 - `~/.openclaw/agents/<agentId>/agent/openclaw-agent.sqlite` (session rows, transcripts, and per-agent runtime state)
 - `~/.openclaw/agents/<agentId>/agent/codex-home/` (per-agent Codex runtime account, config, skills, plugins, and native thread state)
 - `~/.openclaw/credentials/` (channel/provider state plus legacy OAuth import data)

--- a/docs/concepts/model-failover.md
+++ b/docs/concepts/model-failover.md
@@ -90,8 +90,10 @@ OpenClaw uses **auth profiles** for both API keys and OAuth tokens.
 
 - Secrets and runtime auth-routing state live in `~/.openclaw/agents/<agentId>/agent/openclaw-agent.sqlite`.
 - Config `auth.profiles` / `auth.order` are **metadata + routing only** (no secrets).
-- Legacy import-only OAuth file: `~/.openclaw/credentials/oauth.json` (imported into the per-agent auth store on first use).
-- Legacy `auth-profiles.json`, `auth-state.json`, and per-agent `auth.json` files are imported by `openclaw doctor --fix`.
+- Legacy `credentials/oauth.json`, `auth-profiles.json`, `auth-state.json`, and
+  per-agent `auth.json` files are imported only by `openclaw doctor --fix`.
+  Runtime fails closed for the affected agent until credential-bearing legacy
+  files are migrated; it never silently imports or falls back to them.
 
 More detail: [OAuth](/concepts/oauth)
 

--- a/docs/concepts/multi-agent.md
+++ b/docs/concepts/multi-agent.md
@@ -21,7 +21,7 @@ Each agent has its own:
 Auth profiles are per-agent, read from:
 
 ```text
-~/.openclaw/agents/<agentId>/agent/auth-profiles.json
+~/.openclaw/agents/<agentId>/agent/openclaw-agent.sqlite
 ```
 
 <Note>

--- a/docs/concepts/oauth.md
+++ b/docs/concepts/oauth.md
@@ -62,20 +62,21 @@ To reduce that, OpenClaw treats the auth profile store as a **token sink**:
 
 ## Storage (where tokens live)
 
-Secrets live per agent, keyed by the logical name `auth-profiles.json` (the
-underlying store is the agent's SQLite database; the JSON name is kept for
-compatibility and tooling display):
+Secrets and auth-routing state live in each agent's canonical SQLite database:
 
-- Auth profiles (OAuth + API keys + optional value-level refs):
-  `~/.openclaw/agents/<agentId>/agent/auth-profiles.json`
-- Legacy compatibility file: `~/.openclaw/agents/<agentId>/agent/auth.json`
-  (static `api_key` entries are scrubbed when discovered)
+- `~/.openclaw/agents/<agentId>/agent/openclaw-agent.sqlite`
+- Credential rows: `auth_profile_store`
+- Order, last-good, cooldown, and usage rows: `auth_profile_state`
 
-Legacy import-only file (still supported, but not the main store):
+Older installations may still contain `auth-profiles.json`, `auth-state.json`,
+per-agent `auth.json`, or shared `credentials/oauth.json`. Run
+`openclaw doctor --fix` once after upgrading. Doctor imports verified values,
+records a migration receipt, and renames the original file to a timestamped
+archive. Runtime never reads these retired files and reports
+`AUTH_PROFILE_MIGRATION_REQUIRED` when a legacy credential source has not been
+migrated.
 
-- `~/.openclaw/credentials/oauth.json` (imported into the auth profile store on first use)
-
-All of the above also respect `$OPENCLAW_STATE_DIR` (state dir override). Full reference: [/gateway/configuration-reference#auth-storage](/gateway/configuration-reference#auth-storage)
+The database and migration sources respect `$OPENCLAW_STATE_DIR`. Full reference: [/gateway/configuration-reference#auth-storage](/gateway/configuration-reference#auth-storage)
 
 For static secret refs and runtime snapshot activation behavior, see [Secrets Management](/gateway/secrets).
 

--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -7583,6 +7583,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: What changed
   - H3: Why
   - H2: Compatibility policy
+  - H3: AuthStorage SQLite migration
   - H3: Published channel setup compatibility
   - H3: Channel setup input field compatibility
   - H4: Verifying readers

--- a/docs/gateway/secrets.md
+++ b/docs/gateway/secrets.md
@@ -15,7 +15,7 @@ Plaintext still works. SecretRefs are opt-in per credential.
 </Note>
 
 <Warning>
-Plaintext credentials remain agent-readable if they sit in files the agent can inspect, including `openclaw.json`, `auth-profiles.json`, `.env`, or generated `agents/*/agent/models.json` files. SecretRefs only reduce that local blast radius once every supported credential is migrated and `openclaw secrets audit --check` reports no plaintext residue.
+Plaintext credentials remain agent-readable when they sit in files the agent can inspect, including `openclaw.json`, `.env`, retired auth-profile JSON archives, or generated `agents/*/agent/models.json` files. SecretRefs reduce that local blast radius once every supported credential is migrated and `openclaw secrets audit --check` reports no plaintext residue.
 </Warning>
 
 ## Runtime model
@@ -52,7 +52,7 @@ SecretRefs stop credentials from being persisted in config and generated model f
 For production deployments where agent-accessible files are in scope, treat migration as complete only when all of these hold:
 
 - Supported credentials use SecretRefs instead of plaintext values.
-- Legacy plaintext residue is scrubbed from `openclaw.json`, `auth-profiles.json`, `.env`, and generated `models.json` files.
+- Legacy plaintext residue is scrubbed from `openclaw.json`, the SQLite auth-profile store, `.env`, and generated `models.json` files. Retired auth JSON is doctor-owned migration input and is never rewritten by `secrets apply`.
 - `openclaw secrets audit --check` is clean after migration.
 - Any remaining unsupported or rotating credentials are protected by OS isolation, container isolation, or an external credential proxy.
 
@@ -586,7 +586,7 @@ Runtime-minted or rotating credentials and OAuth refresh material are intentiona
 Warning and audit signals:
 
 - `SECRETS_REF_OVERRIDES_PLAINTEXT` (runtime warning)
-- `REF_SHADOWED` (audit finding when `auth-profiles.json` credentials take precedence over `openclaw.json` refs)
+- `REF_SHADOWED` (audit finding when SQLite auth-profile credentials take precedence over `openclaw.json` refs)
 
 Google Chat `serviceAccount` accepts inline JSON or a SecretRef. Doctor moves the retired sibling `serviceAccountRef` into this canonical field when it is unset.
 
@@ -682,11 +682,10 @@ If you save a plan instead of applying during `configure`, apply that saved plan
   <Accordion title="secrets audit">
     Findings include:
 
-    - Plaintext values at rest (`openclaw.json`, `auth-profiles.json`, `.env`, and generated `agents/*/agent/models.json`).
+    - Plaintext values at rest (`openclaw.json`, SQLite auth-profile rows, `.env`, and generated `agents/*/agent/models.json`).
     - Plaintext sensitive provider header residues in generated `models.json` entries.
     - Unresolved refs.
-    - Precedence shadowing (`auth-profiles.json` taking priority over `openclaw.json` refs).
-    - Legacy residues (`auth.json`, OAuth reminders).
+    - Precedence shadowing (SQLite auth profiles taking priority over `openclaw.json` refs).
 
     Exec note: by default, audit skips exec SecretRef resolvability checks to avoid command side effects. Use `openclaw secrets audit --allow-exec` to execute exec providers during audit.
 
@@ -697,8 +696,8 @@ If you save a plan instead of applying during `configure`, apply that saved plan
     Interactive helper that:
 
     - Configures `secrets.providers` first (`env`/`file`/`exec`, add/edit/remove).
-    - Lets you select supported secret-bearing fields in `openclaw.json` plus `auth-profiles.json` for one agent scope.
-    - Can create a new `auth-profiles.json` mapping directly in the target picker.
+    - Lets you select supported secret-bearing fields in `openclaw.json` plus the SQLite auth-profile store for one agent scope.
+    - Can create a new auth-profile mapping directly in the target picker.
     - Captures SecretRef details (`source`, `provider`, `id`).
     - Runs preflight resolution and can apply immediately.
 
@@ -712,8 +711,8 @@ If you save a plan instead of applying during `configure`, apply that saved plan
 
     `configure` apply defaults:
 
-    - Scrub matching static credentials from `auth-profiles.json` for targeted providers.
-    - Scrub legacy static `api_key` entries from `auth.json`.
+    - Scrub matching static credentials from SQLite auth-profile rows for targeted providers.
+    - Leave retired `auth.json` untouched; run `openclaw doctor --fix` to migrate and archive it.
     - Scrub matching known secret lines from the effective state and active-config `.env` files (deduplicated when both paths match).
 
   </Accordion>

--- a/docs/plugins/sdk-migration.md
+++ b/docs/plugins/sdk-migration.md
@@ -85,6 +85,25 @@ External-plugin compatibility work follows this order:
 6. Remove only after the announced migration window, usually in a major
    release.
 
+### AuthStorage SQLite migration
+
+`AuthStorage.forAgent(agentDir)` is the canonical provider-keyed session SDK
+facade. It persists provider-default credentials through the agent's
+`openclaw-agent.sqlite` auth-profile rows and never creates `auth.json`.
+
+`AuthStorage.create(authPath)` remains as a named deprecated adapter for
+existing plugins. The path is used only to derive the owning agent directory;
+the adapter reads and writes SQLite, not the named JSON file. Migrate to
+`forAgent(...)` now. The path-taking form emits
+`AUTH_STORAGE_CREATE_DEPRECATED` and is eligible for removal after
+2026-10-01, provided the published-plugin reader sweep is clean.
+
+Direct `FileAuthStorageBackend` imports remain available through the same
+window as a SQLite-backed compatibility adapter. They emit
+`FILE_AUTH_STORAGE_BACKEND_DEPRECATED`; replace backend construction with
+`AuthStorage.forAgent(agentDir)`. Neither deprecated path reads or writes the
+legacy file.
+
 If a manifest field is still accepted, keep using it until docs and
 diagnostics say otherwise. New code should prefer the documented replacement;
 existing plugins should not break during ordinary minor releases.

--- a/extensions/qa-lab/src/auth-profile.fixture.ts
+++ b/extensions/qa-lab/src/auth-profile.fixture.ts
@@ -1,6 +1,5 @@
 // Qa Lab plugin module implements auth profile.fixture behavior.
-import fs from "node:fs/promises";
-import path from "node:path";
+import { readQaAuthProfiles, writeQaAuthProfiles } from "./providers/shared/auth-store.js";
 
 export const QA_CODEX_OAUTH_PROFILE_ID = "openai:qa-oauth";
 export const QA_OPENAI_API_KEY_PROFILE_ID = "openai:media-api";
@@ -45,10 +44,6 @@ export type QaCodexAuthProfileSelection =
     };
 
 const QA_FIXED_OAUTH_EXPIRY_MS = Date.UTC(2036, 0, 1);
-
-function authProfilesPath(agentDir: string) {
-  return path.join(agentDir, "auth-profiles.json");
-}
 
 function buildCodexOAuthProfile(): QaOAuthAuthProfile {
   return {
@@ -133,22 +128,12 @@ export async function seedAuthProfiles(
     version: QA_AUTH_PROFILE_STORE_VERSION,
     profiles: buildProfileMap(shape),
   };
-  await fs.mkdir(agentDir, { recursive: true });
-  await fs.writeFile(authProfilesPath(agentDir), `${JSON.stringify(snapshot, null, 2)}\n`, "utf8");
+  await writeQaAuthProfiles({ agentDir, profiles: snapshot.profiles, replace: true });
   return snapshot;
 }
 
 export async function snapshotAuthProfiles(agentDir: string): Promise<QaAuthProfileSnapshot> {
-  const raw = await fs.readFile(authProfilesPath(agentDir), "utf8").catch((error: unknown) => {
-    if (error && typeof error === "object" && (error as { code?: unknown }).code === "ENOENT") {
-      return null;
-    }
-    throw error;
-  });
-  if (!raw) {
-    return { version: QA_AUTH_PROFILE_STORE_VERSION, profiles: {} };
-  }
-  return normalizeAuthProfileSnapshot(JSON.parse(raw) as unknown);
+  return normalizeAuthProfileSnapshot(readQaAuthProfiles(agentDir));
 }
 
 export function resolveCodexAuthProfile(

--- a/extensions/qa-lab/src/gateway-child.test.ts
+++ b/extensions/qa-lab/src/gateway-child.test.ts
@@ -12,6 +12,7 @@ import {
   resolveQaControlUiRoot,
   startQaGatewayChild,
 } from "./gateway-child.js";
+import { readQaAuthProfiles } from "./providers/shared/auth-store.js";
 import { createTempDirHarness } from "./temp-dir.test-helper.js";
 
 const fetchWithSsrFGuardMock = vi.hoisted(() => vi.fn());
@@ -83,8 +84,8 @@ type SsrFetchCall = {
   auditContext?: string;
 };
 
-function parseAuthProfileStore(raw: string): AuthProfileStore {
-  return JSON.parse(raw) as AuthProfileStore;
+function readAuthProfileStore(stateDir: string, agentId: string): AuthProfileStore {
+  return readQaAuthProfiles(path.join(stateDir, "agents", agentId, "agent"));
 }
 
 function requireAuthProfile(
@@ -724,12 +725,8 @@ describe("buildQaRuntimeEnv", () => {
     const configProfile = requireAuthProfile(cfg.auth?.profiles, "anthropic:qa-setup-token");
     expect(configProfile.provider).toBe("anthropic");
     expect(configProfile.mode).toBe("token");
-    const storeRaw = await readFile(
-      path.join(stateDir, "agents", "main", "agent", "auth-profiles.json"),
-      "utf8",
-    );
     const storeProfile = requireAuthProfile(
-      parseAuthProfileStore(storeRaw).profiles,
+      readAuthProfileStore(stateDir, "main").profiles,
       "anthropic:qa-setup-token",
     );
     expect(storeProfile.type).toBe("token");
@@ -758,12 +755,8 @@ describe("buildQaRuntimeEnv", () => {
     expect(configProfile.displayName).toBe("QA live openai env credential");
 
     for (const agentId of ["main", "qa"]) {
-      const storeRaw = await readFile(
-        path.join(stateDir, "agents", agentId, "agent", "auth-profiles.json"),
-        "utf8",
-      );
       const storeProfile = requireAuthProfile(
-        parseAuthProfileStore(storeRaw).profiles,
+        readAuthProfileStore(stateDir, agentId).profiles,
         "qa-live-openai-env",
       );
       expect(storeProfile.type).toBe("api_key");
@@ -797,11 +790,7 @@ describe("buildQaRuntimeEnv", () => {
     }
 
     for (const agentId of ["main", "qa"]) {
-      const storeRaw = await readFile(
-        path.join(stateDir, "agents", agentId, "agent", "auth-profiles.json"),
-        "utf8",
-      );
-      const storeProfiles = parseAuthProfileStore(storeRaw).profiles;
+      const storeProfiles = readAuthProfileStore(stateDir, agentId).profiles;
       for (const [profileId, provider] of [
         ["qa-live-openai-env", "openai"],
         ["qa-live-openai-env", "openai"],
@@ -829,12 +818,8 @@ describe("buildQaRuntimeEnv", () => {
       },
     });
 
-    const storeRaw = await readFile(
-      path.join(stateDir, "agents", "qa", "agent", "auth-profiles.json"),
-      "utf8",
-    );
     const storeProfile = requireAuthProfile(
-      parseAuthProfileStore(storeRaw).profiles,
+      readAuthProfileStore(stateDir, "qa").profiles,
       "qa-live-openai-env",
     );
     expect(storeProfile.type).toBe("api_key");
@@ -955,12 +940,8 @@ describe("buildQaRuntimeEnv", () => {
     expect(configProfile.provider).toBe("openai");
     expect(configProfile.mode).toBe("api_key");
     for (const agentId of ["main", "qa"]) {
-      const storeRaw = await readFile(
-        path.join(stateDir, "agents", agentId, "agent", "auth-profiles.json"),
-        "utf8",
-      );
       const storeProfile = requireAuthProfile(
-        parseAuthProfileStore(storeRaw).profiles,
+        readAuthProfileStore(stateDir, agentId).profiles,
         "qa-live-openai-env",
       );
       expect(storeProfile.type).toBe("api_key");
@@ -1007,12 +988,8 @@ describe("buildQaRuntimeEnv", () => {
       env,
     });
 
-    const storeRaw = await readFile(
-      path.join(stateDir, "agents", "qa", "agent", "auth-profiles.json"),
-      "utf8",
-    );
     const storeProfile = requireAuthProfile(
-      parseAuthProfileStore(storeRaw).profiles,
+      readAuthProfileStore(stateDir, "qa").profiles,
       "qa-live-openai-env",
     );
     expect(storeProfile.type).toBe("api_key");
@@ -1053,12 +1030,8 @@ describe("buildQaRuntimeEnv", () => {
       },
     });
 
-    const storeRaw = await readFile(
-      path.join(stateDir, "agents", "main", "agent", "auth-profiles.json"),
-      "utf8",
-    );
     const storeProfile = requireAuthProfile(
-      parseAuthProfileStore(storeRaw).profiles,
+      readAuthProfileStore(stateDir, "main").profiles,
       "qa-live-openai-env",
     );
     expect(storeProfile.type).toBe("api_key");
@@ -1124,16 +1097,9 @@ describe("buildQaRuntimeEnv", () => {
     expect(anthropicConfigProfile.mode).toBe("api_key");
     expect(anthropicConfigProfile.displayName).toBe("QA mock anthropic credential");
 
-    // Store side: each agent dir should have its own auth-profiles.json
-    // containing the placeholder credential for each staged provider. This
-    // is what the scenario runner actually reads when it resolves auth
-    // before calling the mock.
+    // Store side: each agent dir has its own canonical SQLite credential rows.
     for (const agentId of ["main", "qa"]) {
-      const storeRaw = await readFile(
-        path.join(stateDir, "agents", agentId, "agent", "auth-profiles.json"),
-        "utf8",
-      );
-      const parsed = parseAuthProfileStore(storeRaw);
+      const parsed = readAuthProfileStore(stateDir, agentId);
       const openaiStoreProfile = requireAuthProfile(parsed.profiles, "qa-mock-openai");
       expect(openaiStoreProfile.type).toBe("api_key");
       expect(openaiStoreProfile.provider).toBe("openai");
@@ -1164,17 +1130,15 @@ describe("buildQaRuntimeEnv", () => {
     // Anthropic should NOT be staged when the caller restricts providers.
     expect(cfg.auth?.profiles?.["qa-mock-anthropic"]).toBeUndefined();
 
-    const qaStore = JSON.parse(
-      await readFile(path.join(stateDir, "agents", "qa", "agent", "auth-profiles.json"), "utf8"),
-    ) as AuthProfileStore;
+    const qaStore = readAuthProfileStore(stateDir, "qa");
     const openaiStoreProfile = requireAuthProfile(qaStore.profiles, "qa-mock-openai");
     expect(openaiStoreProfile.provider).toBe("openai");
     expect(openaiStoreProfile.type).toBe("api_key");
     expect(qaStore.profiles["qa-mock-anthropic"]).toBeUndefined();
 
-    // main/agent should not exist because it wasn't in the agentIds list.
+    // The main agent's canonical database should not exist because it was not requested.
     await expect(
-      readFile(path.join(stateDir, "agents", "main", "agent", "auth-profiles.json"), "utf8"),
+      lstat(path.join(stateDir, "agents", "main", "agent", "openclaw-agent.sqlite")),
     ).rejects.toThrow(/ENOENT/);
   });
 

--- a/extensions/qa-lab/src/providers/shared/auth-store.test.ts
+++ b/extensions/qa-lab/src/providers/shared/auth-store.test.ts
@@ -1,9 +1,13 @@
-// Qa Lab tests cover auth store plugin behavior.
+// Qa Lab tests cover the SQLite-backed auth store plugin behavior.
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { writeQaAuthProfiles } from "./auth-store.js";
+import {
+  loadAuthProfileStoreWithoutExternalProfiles,
+  saveAuthProfileStore,
+} from "openclaw/plugin-sdk/agent-runtime";
+import { readQaAuthProfiles, writeQaAuthProfiles } from "./auth-store.js";
 
 const tempDirs: string[] = [];
 
@@ -20,7 +24,7 @@ describe("QA auth profile store", () => {
     );
   });
 
-  it("writes a new auth profile file when none exists", async () => {
+  it("writes new auth profiles to SQLite without creating legacy JSON", async () => {
     const agentDir = await createTempDir();
 
     await writeQaAuthProfiles({
@@ -34,12 +38,15 @@ describe("QA auth profile store", () => {
       },
     });
 
-    await expect(fs.readFile(path.join(agentDir, "auth-profiles.json"), "utf8")).resolves.toContain(
-      "qa-mock-openai",
-    );
+    expect(readQaAuthProfiles(agentDir).profiles["qa-mock-openai"]).toMatchObject({
+      provider: "openai",
+    });
+    await expect(fs.stat(path.join(agentDir, "auth-profiles.json"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
   });
 
-  it("does not replace corrupt auth profile files", async () => {
+  it("refuses to bypass a pending legacy auth source", async () => {
     const agentDir = await createTempDir();
     const authPath = path.join(agentDir, "auth-profiles.json");
     await fs.writeFile(authPath, "{not-json", "utf8");
@@ -55,164 +62,34 @@ describe("QA auth profile store", () => {
           },
         },
       }),
-    ).rejects.toThrow();
+    ).rejects.toThrow("requires legacy credential migration");
     await expect(fs.readFile(authPath, "utf8")).resolves.toBe("{not-json");
   });
 
-  it("does not merge malformed auth profile shapes", async () => {
+  it("merges canonical API-key, token, and OAuth profile shapes", async () => {
     const agentDir = await createTempDir();
-    const authPath = path.join(agentDir, "auth-profiles.json");
-    const original = JSON.stringify({ version: 1, profiles: { broken: "token" } });
-    await fs.writeFile(authPath, original, "utf8");
-
-    await expect(
-      writeQaAuthProfiles({
-        agentDir,
-        profiles: {
-          "qa-mock-openai": {
-            type: "api_key",
-            provider: "openai",
-            key: "qa-mock-not-a-real-key",
-          },
-        },
-      }),
-    ).rejects.toThrow("Invalid QA auth profiles file");
-    await expect(fs.readFile(authPath, "utf8")).resolves.toBe(original);
-  });
-
-  it("preserves existing ref-backed auth profile shapes", async () => {
-    const agentDir = await createTempDir();
-    const authPath = path.join(agentDir, "auth-profiles.json");
-    await fs.writeFile(
-      authPath,
-      `${JSON.stringify({
-        version: 1,
-        profiles: {
-          existing: {
-            type: "api_key",
-            provider: "openai",
-            keyRef: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
-          },
-        },
-      })}\n`,
-      "utf8",
-    );
-
     await writeQaAuthProfiles({
       agentDir,
       profiles: {
-        "qa-mock-anthropic": {
-          type: "api_key",
-          provider: "anthropic",
-          key: "qa-mock-not-a-real-key",
-        },
-      },
-    });
-
-    const written = JSON.parse(await fs.readFile(authPath, "utf8")) as {
-      profiles?: Record<string, unknown>;
-    };
-    expect(written.profiles?.existing).toEqual({
-      type: "api_key",
-      provider: "openai",
-      keyRef: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
-    });
-    expect(written.profiles?.["qa-mock-anthropic"]).toMatchObject({
-      type: "api_key",
-      provider: "anthropic",
-    });
-  });
-
-  it("preserves existing token and oauth auth profile shapes", async () => {
-    const agentDir = await createTempDir();
-    const authPath = path.join(agentDir, "auth-profiles.json");
-    await fs.writeFile(
-      authPath,
-      `${JSON.stringify({
-        version: 1,
-        profiles: {
-          tokenProfile: {
-            type: "token",
-            provider: "github",
-            token: { source: "file", provider: "vault", id: "github/token" },
-          },
-          oauthProfile: {
-            type: "oauth",
-            provider: "chatgpt",
-            access: "qa-access-token",
-            refresh: "qa-refresh-token",
-            expires: 1_900_000_000_000,
-          },
-          legacyOAuthProfile: {
-            type: "oauth",
-            provider: "openai",
-            expires: 1_900_000_000_000,
-            oauthRef: {
-              source: "openclaw-credentials",
-              provider: "openai",
-              id: "0123456789abcdef0123456789abcdef",
-            },
-          },
-        },
-      })}\n`,
-      "utf8",
-    );
-
-    await writeQaAuthProfiles({
-      agentDir,
-      profiles: {
-        "qa-mock-openai": {
+        existing: {
           type: "api_key",
           provider: "openai",
-          key: "qa-mock-not-a-real-key",
+          keyRef: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+        },
+        tokenProfile: {
+          type: "token",
+          provider: "github",
+          tokenRef: { source: "file", provider: "vault", id: "github/token" },
+        },
+        oauthProfile: {
+          type: "oauth",
+          provider: "chatgpt",
+          access: "qa-access-token",
+          refresh: "qa-refresh-token",
+          expires: 1_900_000_000_000,
         },
       },
     });
-
-    const written = JSON.parse(await fs.readFile(authPath, "utf8")) as {
-      profiles?: Record<string, unknown>;
-    };
-    expect(written.profiles?.tokenProfile).toEqual({
-      type: "token",
-      provider: "github",
-      token: { source: "file", provider: "vault", id: "github/token" },
-    });
-    expect(written.profiles?.oauthProfile).toEqual({
-      type: "oauth",
-      provider: "chatgpt",
-      access: "qa-access-token",
-      refresh: "qa-refresh-token",
-      expires: 1_900_000_000_000,
-    });
-    expect(written.profiles?.legacyOAuthProfile).toEqual({
-      type: "oauth",
-      provider: "openai",
-      expires: 1_900_000_000_000,
-      oauthRef: {
-        source: "openclaw-credentials",
-        provider: "openai",
-        id: "0123456789abcdef0123456789abcdef",
-      },
-    });
-  });
-
-  it("preserves existing providerless secret refs", async () => {
-    const agentDir = await createTempDir();
-    const authPath = path.join(agentDir, "auth-profiles.json");
-    await fs.writeFile(
-      authPath,
-      `${JSON.stringify({
-        version: 1,
-        profiles: {
-          existing: {
-            type: "api_key",
-            provider: "openai",
-            keyRef: { source: "env", id: "OPENAI_API_KEY" },
-          },
-        },
-      })}\n`,
-      "utf8",
-    );
 
     await writeQaAuthProfiles({
       agentDir,
@@ -225,52 +102,44 @@ describe("QA auth profile store", () => {
       },
     });
 
-    const written = JSON.parse(await fs.readFile(authPath, "utf8")) as {
-      profiles?: Record<string, unknown>;
-    };
-    expect(written.profiles?.existing).toEqual({
-      type: "api_key",
-      provider: "openai",
-      keyRef: { source: "env", id: "OPENAI_API_KEY" },
+    expect(readQaAuthProfiles(agentDir).profiles).toMatchObject({
+      existing: { type: "api_key", provider: "openai" },
+      tokenProfile: { type: "token", provider: "github" },
+      oauthProfile: { type: "oauth", provider: "chatgpt" },
+      "qa-mock-anthropic": { type: "api_key", provider: "anthropic" },
     });
   });
 
-  it("preserves existing legacy api key alias profiles", async () => {
+  it("can replace an existing profile set for deterministic fixture seeding", async () => {
     const agentDir = await createTempDir();
-    const authPath = path.join(agentDir, "auth-profiles.json");
-    await fs.writeFile(
-      authPath,
-      `${JSON.stringify({
+    saveAuthProfileStore(
+      {
         version: 1,
         profiles: {
-          existing: {
-            mode: "api_key",
-            provider: "openai",
-            apiKey: "qa-existing-key",
-          },
+          stale: { type: "api_key", provider: "openai", key: "qa-stale-not-a-real-key" },
         },
-      })}\n`,
-      "utf8",
+        order: { openai: ["stale"] },
+        lastGood: { openai: "stale" },
+        usageStats: { stale: { cooldownUntil: Date.now() + 60_000 } },
+      },
+      agentDir,
+      { filterExternalAuthProfiles: false, syncExternalCli: false },
     );
 
     await writeQaAuthProfiles({
       agentDir,
       profiles: {
-        "qa-mock-anthropic": {
-          type: "api_key",
-          provider: "anthropic",
-          key: "qa-mock-not-a-real-key",
-        },
+        current: { type: "api_key", provider: "anthropic", key: "qa-current-not-a-real-key" },
       },
+      replace: true,
     });
 
-    const written = JSON.parse(await fs.readFile(authPath, "utf8")) as {
-      profiles?: Record<string, unknown>;
-    };
-    expect(written.profiles?.existing).toEqual({
-      mode: "api_key",
-      provider: "openai",
-      apiKey: "qa-existing-key",
+    expect(Object.keys(readQaAuthProfiles(agentDir).profiles)).toEqual(["current"]);
+    const replaced = loadAuthProfileStoreWithoutExternalProfiles(agentDir, {
+      inheritedAuthDir: agentDir,
     });
+    expect(replaced.order).toBeUndefined();
+    expect(replaced.lastGood).toBeUndefined();
+    expect(replaced.usageStats).toBeUndefined();
   });
 });

--- a/extensions/qa-lab/src/providers/shared/auth-store.test.ts
+++ b/extensions/qa-lab/src/providers/shared/auth-store.test.ts
@@ -2,11 +2,11 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
 import {
   loadAuthProfileStoreWithoutExternalProfiles,
   saveAuthProfileStore,
 } from "openclaw/plugin-sdk/agent-runtime";
+import { afterEach, describe, expect, it } from "vitest";
 import { readQaAuthProfiles, writeQaAuthProfiles } from "./auth-store.js";
 
 const tempDirs: string[] = [];

--- a/extensions/qa-lab/src/providers/shared/auth-store.ts
+++ b/extensions/qa-lab/src/providers/shared/auth-store.ts
@@ -1,7 +1,10 @@
 // Qa Lab plugin module implements auth store behavior.
-import fs from "node:fs/promises";
 import path from "node:path";
-import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import {
+  loadAuthProfileStoreWithoutExternalProfiles,
+  saveAuthProfileStore,
+  type AuthProfileStore,
+} from "openclaw/plugin-sdk/agent-runtime";
 
 type QaAuthProfileCredential =
   | {
@@ -52,124 +55,34 @@ export function resolveQaAgentAuthDir(params: { stateDir: string; agentId: strin
 export async function writeQaAuthProfiles(params: {
   agentDir: string;
   profiles: Record<string, QaAuthProfileCredential>;
+  replace?: boolean;
 }): Promise<void> {
-  const authPath = path.join(params.agentDir, "auth-profiles.json");
-  const existing = await readExistingQaAuthProfiles(authPath);
-  await fs.mkdir(params.agentDir, { recursive: true });
-  await fs.writeFile(
-    authPath,
-    `${JSON.stringify({ version: 1, profiles: { ...existing.profiles, ...params.profiles } }, null, 2)}\n`,
-    "utf8",
+  const existing = loadAuthProfileStoreWithoutExternalProfiles(params.agentDir, {
+    inheritedAuthDir: params.agentDir,
+  });
+  const nextStore: AuthProfileStore = params.replace
+    ? { version: 1, profiles: params.profiles as AuthProfileStore["profiles"] }
+    : {
+        ...existing,
+        version: 1,
+        profiles: { ...existing.profiles, ...params.profiles } as AuthProfileStore["profiles"],
+      };
+  saveAuthProfileStore(
+    nextStore,
+    params.agentDir,
+    { filterExternalAuthProfiles: false, syncExternalCli: false },
   );
 }
 
-async function readExistingQaAuthProfiles(
-  authPath: string,
-): Promise<{ profiles?: Record<string, QaAuthProfileCredential> }> {
-  try {
-    const raw = await fs.readFile(authPath, "utf8");
-    return parseQaAuthProfiles(raw);
-  } catch (err) {
-    if (err && typeof err === "object" && (err as { code?: unknown }).code === "ENOENT") {
-      return { profiles: {} };
-    }
-    throw err;
-  }
-}
-
-function parseQaAuthProfiles(raw: string): { profiles?: Record<string, QaAuthProfileCredential> } {
-  const parsed = JSON.parse(raw) as unknown;
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-    throw new Error("Invalid QA auth profiles file");
-  }
-  const profiles = (parsed as { profiles?: unknown }).profiles;
-  if (profiles === undefined) {
-    return {};
-  }
-  if (!profiles || typeof profiles !== "object" || Array.isArray(profiles)) {
-    throw new Error("Invalid QA auth profiles file");
-  }
-  for (const value of Object.values(profiles)) {
-    if (!isQaAuthProfileRecord(value)) {
-      throw new Error("Invalid QA auth profiles file");
-    }
-  }
-  return { profiles: profiles as Record<string, QaAuthProfileCredential> };
-}
-
-function isQaAuthProfileRecord(value: unknown): value is QaAuthProfileCredential {
-  if (!isRecord(value) || typeof value.provider !== "string" || !value.provider.trim()) {
-    return false;
-  }
-  const credentialType = typeof value.type === "string" ? value.type : value.mode;
-  switch (credentialType) {
-    case "api_key":
-      return (
-        isQaSecretInput(value.key) &&
-        isQaSecretInput(value.apiKey) &&
-        isOptionalQaSecretRef(value.keyRef)
-      );
-    case "token":
-      return (
-        isQaSecretInput(value.token) &&
-        isOptionalQaSecretRef(value.tokenRef) &&
-        isOptionalFiniteNumber(value.expires)
-      );
-    case "oauth":
-      return (
-        isOptionalString(value.access) &&
-        isOptionalString(value.refresh) &&
-        isOptionalString(value.idToken) &&
-        isOptionalString(value.clientId) &&
-        isOptionalString(value.enterpriseUrl) &&
-        isOptionalString(value.projectId) &&
-        isOptionalString(value.accountId) &&
-        isOptionalString(value.chatgptPlanType) &&
-        isOptionalFiniteNumber(value.expires) &&
-        isOptionalLegacyOAuthRef(value.oauthRef)
-      );
-    default:
-      return false;
-  }
-}
-
-function isOptionalString(value: unknown): boolean {
-  return value === undefined || typeof value === "string";
-}
-
-function isOptionalFiniteNumber(value: unknown): boolean {
-  return value === undefined || (typeof value === "number" && Number.isFinite(value));
-}
-
-function isOptionalQaSecretRef(value: unknown): boolean {
-  return value === undefined || isQaSecretRef(value);
-}
-
-function isQaSecretInput(value: unknown): boolean {
-  return value === undefined || typeof value === "string" || isQaSecretRef(value);
-}
-
-function isQaSecretRef(value: unknown): value is QaSecretRef {
-  return (
-    isRecord(value) &&
-    (value.source === "env" || value.source === "file" || value.source === "exec") &&
-    (value.provider === undefined ||
-      (typeof value.provider === "string" && value.provider.trim().length > 0)) &&
-    typeof value.id === "string" &&
-    value.id.trim().length > 0
-  );
-}
-
-function isOptionalLegacyOAuthRef(value: unknown): boolean {
-  return value === undefined || isQaLegacyOAuthRef(value);
-}
-
-function isQaLegacyOAuthRef(value: unknown): value is QaLegacyOAuthRef {
-  return (
-    isRecord(value) &&
-    value.source === "openclaw-credentials" &&
-    value.provider === "openai" &&
-    typeof value.id === "string" &&
-    /^[a-f0-9]{32}$/.test(value.id)
-  );
+export function readQaAuthProfiles(agentDir: string): {
+  version: number;
+  profiles: Record<string, QaAuthProfileCredential>;
+} {
+  const store = loadAuthProfileStoreWithoutExternalProfiles(agentDir, {
+    inheritedAuthDir: agentDir,
+  });
+  return {
+    version: store.version,
+    profiles: store.profiles as Record<string, QaAuthProfileCredential>,
+  };
 }

--- a/extensions/qa-lab/src/providers/shared/auth-store.ts
+++ b/extensions/qa-lab/src/providers/shared/auth-store.ts
@@ -67,11 +67,10 @@ export async function writeQaAuthProfiles(params: {
         version: 1,
         profiles: { ...existing.profiles, ...params.profiles } as AuthProfileStore["profiles"],
       };
-  saveAuthProfileStore(
-    nextStore,
-    params.agentDir,
-    { filterExternalAuthProfiles: false, syncExternalCli: false },
-  );
+  saveAuthProfileStore(nextStore, params.agentDir, {
+    filterExternalAuthProfiles: false,
+    syncExternalCli: false,
+  });
 }
 
 export function readQaAuthProfiles(agentDir: string): {

--- a/scripts/e2e/lib/upgrade-survivor/assertions.mjs
+++ b/scripts/e2e/lib/upgrade-survivor/assertions.mjs
@@ -20,6 +20,7 @@ const SCENARIOS = new Set([
   "meeting-transcripts-sqlite",
   "versioned-runtime-deps",
   "cron-scheduled-authority",
+  "auth-profile-v2026.7.2-beta.5",
 ]);
 
 const PERSONA_FILES = new Map([
@@ -309,6 +310,22 @@ function seedState() {
   if (scenario === "cron-scheduled-authority") {
     seedLegacyCronScheduledAuthority(stateDir);
   }
+  if (scenario === "auth-profile-v2026.7.2-beta.5") {
+    const fixture = readJson(
+      path.join(
+        process.cwd(),
+        "scripts/e2e/lib/upgrade-survivor/fixtures/auth-profile-v2026.7.2-beta.5.json",
+      ),
+    );
+    assert(fixture.sourceTag === "v2026.7.2-beta.5", "auth profile fixture tag drifted");
+    assert(fixture.sourceCommit === "34aefcf2fefa", "auth profile fixture commit drifted");
+    assert(fixture.agentSchemaVersion === 15, "auth profile fixture schema drifted");
+    const agentDir = path.join(stateDir, "agents", "main", "agent");
+    writeJson(path.join(agentDir, "auth-profiles.json"), fixture.authProfiles);
+    writeJson(path.join(agentDir, "auth-state.json"), fixture.authState);
+    writeJson(path.join(agentDir, "auth.json"), fixture.legacyAuth);
+    writeJson(path.join(stateDir, "credentials", "oauth.json"), fixture.legacyOAuth);
+  }
 
   const runtimeRoot = path.join(stateDir, "plugin-runtime-deps");
   for (const plugin of ["discord", "telegram", "whatsapp"]) {
@@ -551,6 +568,9 @@ function assertStateSurvived() {
   if (scenario === "cron-scheduled-authority") {
     assertCronScheduledAuthorityMigrated(stateDir, stage);
   }
+  if (scenario === "auth-profile-v2026.7.2-beta.5") {
+    assertAuthProfileMigrationSurvived(stateDir, stage);
+  }
   const legacyRuntimeRoot = path.join(stateDir, "plugin-runtime-deps");
   if (stage === "baseline") {
     if (fs.existsSync(legacyRuntimeRoot)) {
@@ -591,6 +611,70 @@ function assertStateSurvived() {
       staleVersionedRoots.length === 0,
       `stale versioned runtime deps survived update/doctor: ${staleVersionedRoots.join(", ")}`,
     );
+  }
+}
+
+function assertAuthProfileMigrationSurvived(stateDir, stage) {
+  const agentDir = path.join(stateDir, "agents", "main", "agent");
+  const sources = [
+    path.join(agentDir, "auth-profiles.json"),
+    path.join(agentDir, "auth-state.json"),
+    path.join(agentDir, "auth.json"),
+    path.join(stateDir, "credentials", "oauth.json"),
+  ];
+  if (stage === "baseline") {
+    assert(
+      sources.every((source) => fs.existsSync(source)),
+      "auth profile fixture source missing",
+    );
+    return;
+  }
+  for (const source of sources) {
+    assert(!fs.existsSync(source), `legacy auth source remained active: ${source}`);
+    const prefix = `${path.basename(source)}.migrated-`;
+    const archives = fs
+      .readdirSync(path.dirname(source))
+      .filter((entry) => entry.startsWith(prefix));
+    assert(archives.length === 1, `expected one legacy auth archive for ${source}`);
+  }
+  const agentDatabase = new DatabaseSync(path.join(agentDir, "openclaw-agent.sqlite"), {
+    readOnly: true,
+  });
+  try {
+    const row = agentDatabase
+      .prepare("SELECT store_json FROM auth_profile_store WHERE store_key = 'primary'")
+      .get();
+    const store = JSON.parse(row?.store_json ?? "null");
+    assert(
+      store?.profiles?.["openai:default"]?.key === "fake-upgrade-openai-key",
+      "openai credential did not migrate",
+    );
+    assert(
+      store?.profiles?.["xai:default"]?.key === "fake-upgrade-xai-key",
+      "legacy xai credential did not migrate",
+    );
+    assert(
+      store?.profiles?.["anthropic:default"]?.refresh === "fake-upgrade-refresh-token",
+      "shared OAuth credential did not migrate",
+    );
+  } finally {
+    agentDatabase.close();
+  }
+  const stateDatabase = new DatabaseSync(path.join(stateDir, "state", "openclaw.sqlite"), {
+    readOnly: true,
+  });
+  try {
+    const receipt = stateDatabase
+      .prepare(
+        "SELECT COUNT(*) AS count FROM migration_sources WHERE migration_kind = ? AND status = 'completed' AND removed_source = 1",
+      )
+      .get("auth-profile-json-to-sqlite-v2");
+    assert(
+      receipt?.count === 4,
+      `expected four completed auth migration receipts, got ${String(receipt?.count)}`,
+    );
+  } finally {
+    stateDatabase.close();
   }
 }
 

--- a/scripts/e2e/lib/upgrade-survivor/assertions.mjs
+++ b/scripts/e2e/lib/upgrade-survivor/assertions.mjs
@@ -20,7 +20,7 @@ const SCENARIOS = new Set([
   "meeting-transcripts-sqlite",
   "versioned-runtime-deps",
   "cron-scheduled-authority",
-  "auth-profile-v2026.7.2-beta.5",
+  "auth-profile-v2026-7-2-beta-5",
 ]);
 
 const PERSONA_FILES = new Map([
@@ -310,7 +310,7 @@ function seedState() {
   if (scenario === "cron-scheduled-authority") {
     seedLegacyCronScheduledAuthority(stateDir);
   }
-  if (scenario === "auth-profile-v2026.7.2-beta.5") {
+  if (scenario === "auth-profile-v2026-7-2-beta-5") {
     const fixture = readJson(
       path.join(
         process.cwd(),
@@ -568,7 +568,7 @@ function assertStateSurvived() {
   if (scenario === "cron-scheduled-authority") {
     assertCronScheduledAuthorityMigrated(stateDir, stage);
   }
-  if (scenario === "auth-profile-v2026.7.2-beta.5") {
+  if (scenario === "auth-profile-v2026-7-2-beta-5") {
     assertAuthProfileMigrationSurvived(stateDir, stage);
   }
   const legacyRuntimeRoot = path.join(stateDir, "plugin-runtime-deps");

--- a/scripts/e2e/lib/upgrade-survivor/fixtures/auth-profile-v2026.7.2-beta.5.json
+++ b/scripts/e2e/lib/upgrade-survivor/fixtures/auth-profile-v2026.7.2-beta.5.json
@@ -1,0 +1,39 @@
+{
+  "sourceTag": "v2026.7.2-beta.5",
+  "sourceCommit": "34aefcf2fefa",
+  "agentSchemaVersion": 15,
+  "authProfiles": {
+    "version": 1,
+    "profiles": {
+      "openai:default": {
+        "type": "api_key",
+        "provider": "openai",
+        "key": "fake-upgrade-openai-key"
+      }
+    }
+  },
+  "authState": {
+    "version": 1,
+    "order": {
+      "openai": ["openai:default"]
+    },
+    "lastGood": {
+      "openai": "openai:default"
+    }
+  },
+  "legacyAuth": {
+    "xai": {
+      "type": "api_key",
+      "provider": "xai",
+      "key": "fake-upgrade-xai-key"
+    }
+  },
+  "legacyOAuth": {
+    "anthropic": {
+      "access": "fake-upgrade-access-token",
+      "refresh": "fake-upgrade-refresh-token",
+      "expires": 1900000000000,
+      "accountId": "fake-upgrade-account"
+    }
+  }
+}

--- a/scripts/lib/docker-e2e-plan.mjs
+++ b/scripts/lib/docker-e2e-plan.mjs
@@ -100,6 +100,10 @@ const UPGRADE_SURVIVOR_SCENARIO_ALIASES = new Map([
 // closed instead of requiring a dependency or reimplementing a JavaScript parser.
 const LEGACY_UPGRADE_SURVIVOR_SCENARIO_CATALOGS = new Map([
   [
+    "837ab1c89821d52519f385e0f3d2067e0b923f730e3a4791e67f578bf5d29f8e",
+    "base acpx-openclaw-tools-bridge feishu-channel bootstrap-persona channel-post-core-restore codex-allowlist-survival plugin-deps-cleanup configured-plugin-installs stale-source-plugin-shadow tilde-log-path meeting-transcripts-sqlite versioned-runtime-deps cron-scheduled-authority auth-profile-v2026-7-2-beta-5",
+  ],
+  [
     "10ea475027d8b320d6a704cd6e4dd0f7e984c57a93b327048db229a7e0132c8a",
     "base acpx-openclaw-tools-bridge feishu-channel bootstrap-persona channel-post-core-restore codex-allowlist-survival plugin-deps-cleanup configured-plugin-installs stale-source-plugin-shadow tilde-log-path meeting-transcripts-sqlite versioned-runtime-deps cron-scheduled-authority",
   ],

--- a/src/agents/auth-profiles.sqlite-store.test.ts
+++ b/src/agents/auth-profiles.sqlite-store.test.ts
@@ -125,9 +125,9 @@ describe("auth profile sqlite store", () => {
         "utf8",
       );
 
-      const loaded = ensureAuthProfileStore(agentDir, { syncExternalCli: false });
-
-      expect(loaded.profiles["openai:default"]).toBeUndefined();
+      expect(() => ensureAuthProfileStore(agentDir, { syncExternalCli: false })).toThrow(
+        "requires legacy credential migration",
+      );
     });
   });
 

--- a/src/agents/auth-profiles.sqlite-store.test.ts
+++ b/src/agents/auth-profiles.sqlite-store.test.ts
@@ -131,6 +131,34 @@ describe("auth profile sqlite store", () => {
     });
   });
 
+  it("fails closed when a credential source appears during a successful SQLite read", async () => {
+    await withAgentDirEnv("openclaw-auth-sqlite-late-legacy-", (agentDir) => {
+      saveAuthProfileStore(apiKeyStore("not-a-real"), agentDir);
+      const legacyPath = path.join(agentDir, "auth.json");
+      const existsSync = fs.existsSync.bind(fs);
+      let legacyChecks = 0;
+      const existsSpy = vi.spyOn(fs, "existsSync").mockImplementation((pathname) => {
+        if (path.resolve(String(pathname)) === path.resolve(legacyPath)) {
+          legacyChecks += 1;
+          if (legacyChecks === 2) {
+            fs.writeFileSync(legacyPath, '{"openai":{"key":"not-a-real"}}\n', "utf8");
+            return true;
+          }
+          return false;
+        }
+        return existsSync(pathname);
+      });
+      try {
+        expect(() => ensureAuthProfileStore(agentDir, { syncExternalCli: false })).toThrow(
+          "requires legacy credential migration",
+        );
+      } finally {
+        existsSpy.mockRestore();
+      }
+      expect(fs.existsSync(legacyPath)).toBe(true);
+    });
+  });
+
   it("does not create sqlite files for missing-store reads", async () => {
     await withAgentDirEnv("openclaw-auth-sqlite-no-create-", (agentDir) => {
       expect(loadPersistedAuthProfileStore(agentDir)).toBeNull();

--- a/src/agents/auth-profiles/legacy-source-diagnostic.ts
+++ b/src/agents/auth-profiles/legacy-source-diagnostic.ts
@@ -6,17 +6,13 @@ import { shortenHomePath } from "../../utils.js";
 import { resolveSharedMainAuthAgentDir } from "./shared-main-dir.js";
 import { resolveAuthProfileDatabasePath } from "./sqlite.js";
 
-export const AUTH_PROFILE_MIGRATION_REQUIRED_CODE = "AUTH_PROFILE_MIGRATION_REQUIRED" as const;
-export const AUTH_PROFILE_MIGRATION_COMMAND = "openclaw doctor --fix" as const;
+const AUTH_PROFILE_MIGRATION_REQUIRED_CODE = "AUTH_PROFILE_MIGRATION_REQUIRED" as const;
+const AUTH_PROFILE_MIGRATION_COMMAND = "openclaw doctor --fix" as const;
 const log = createSubsystemLogger("auth-profiles/persistence");
 
-export type LegacyAuthProfileSourceKind =
-  | "auth-profiles"
-  | "auth-state"
-  | "legacy-auth"
-  | "legacy-oauth";
+type LegacyAuthProfileSourceKind = "auth-profiles" | "auth-state" | "legacy-auth" | "legacy-oauth";
 
-export type LegacyAuthProfileSource = {
+type LegacyAuthProfileSource = {
   kind: LegacyAuthProfileSourceKind;
   path: string;
 };

--- a/src/agents/auth-profiles/legacy-source-diagnostic.ts
+++ b/src/agents/auth-profiles/legacy-source-diagnostic.ts
@@ -1,0 +1,194 @@
+import fs from "node:fs";
+import path from "node:path";
+import { resolveOAuthDir } from "../../config/paths.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { shortenHomePath } from "../../utils.js";
+import { resolveSharedMainAuthAgentDir } from "./shared-main-dir.js";
+import { resolveAuthProfileDatabasePath } from "./sqlite.js";
+
+export const AUTH_PROFILE_MIGRATION_REQUIRED_CODE = "AUTH_PROFILE_MIGRATION_REQUIRED" as const;
+export const AUTH_PROFILE_MIGRATION_COMMAND = "openclaw doctor --fix" as const;
+const log = createSubsystemLogger("auth-profiles/persistence");
+
+export type LegacyAuthProfileSourceKind =
+  | "auth-profiles"
+  | "auth-state"
+  | "legacy-auth"
+  | "legacy-oauth";
+
+export type LegacyAuthProfileSource = {
+  kind: LegacyAuthProfileSourceKind;
+  path: string;
+};
+
+export function resolveLegacyOAuthPath(env: NodeJS.ProcessEnv = process.env): string {
+  return path.join(resolveOAuthDir(env), "oauth.json");
+}
+
+function resolveAgentDir(agentDir?: string): string {
+  return path.dirname(resolveAuthProfileDatabasePath(agentDir));
+}
+
+/** Detects retired auth files by name only; runtime code must never read their contents. */
+export function listLegacyAuthProfileSources(params: {
+  agentDir?: string;
+  env?: NodeJS.ProcessEnv;
+}): LegacyAuthProfileSource[] {
+  const agentDir = resolveAgentDir(params.agentDir);
+  const candidates: LegacyAuthProfileSource[] = [
+    { kind: "auth-profiles", path: path.join(agentDir, "auth-profiles.json") },
+    { kind: "auth-state", path: path.join(agentDir, "auth-state.json") },
+    { kind: "legacy-auth", path: path.join(agentDir, "auth.json") },
+  ];
+  const sharedMainDir = resolveSharedMainAuthAgentDir(params.env);
+  if (path.resolve(agentDir) === path.resolve(sharedMainDir)) {
+    candidates.push({ kind: "legacy-oauth", path: resolveLegacyOAuthPath(params.env) });
+  }
+  return candidates.filter((candidate) => fs.existsSync(candidate.path));
+}
+
+export function listLegacyAuthProfileArchives(params: {
+  agentDirs: readonly string[];
+  env?: NodeJS.ProcessEnv;
+}): LegacyAuthProfileSource[] {
+  const candidates = new Map<string, LegacyAuthProfileSourceKind>();
+  for (const agentDir of params.agentDirs) {
+    candidates.set(path.join(agentDir, "auth-profiles.json"), "auth-profiles");
+    candidates.set(path.join(agentDir, "auth-state.json"), "auth-state");
+    candidates.set(path.join(agentDir, "auth.json"), "legacy-auth");
+  }
+  candidates.set(resolveLegacyOAuthPath(params.env), "legacy-oauth");
+  const archives: LegacyAuthProfileSource[] = [];
+  for (const [sourcePath, kind] of candidates) {
+    const directory = path.dirname(sourcePath);
+    const prefix = `${path.basename(sourcePath)}.migrated-`;
+    let entries: string[];
+    try {
+      entries = fs.readdirSync(directory);
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (entry.startsWith(prefix)) {
+        archives.push({ kind, path: path.join(directory, entry) });
+      }
+    }
+  }
+  return archives;
+}
+
+export function hasLegacyAuthProfileCredentialSource(agentDir?: string): boolean {
+  return listLegacyAuthProfileSources({ agentDir }).some((source) => source.kind !== "auth-state");
+}
+
+export function hasLegacyAuthProfileSourcesForStartup(params: {
+  agentDirs: readonly string[];
+  env?: NodeJS.ProcessEnv;
+}): boolean {
+  const sharedMainDir = resolveSharedMainAuthAgentDir(params.env);
+  const candidates = new Set([...params.agentDirs, sharedMainDir]);
+  let detected = false;
+  for (const agentDir of candidates) {
+    const sources = listLegacyAuthProfileSources({ agentDir, env: params.env });
+    detected ||= sources.length > 0;
+    const credentialSources = sources.filter((source) => source.kind !== "auth-state");
+    if (credentialSources.length > 0) {
+      markAuthProfileMigrationRequired(
+        agentDir,
+        new AuthProfileMigrationRequiredError({ agentDir, sources: credentialSources }),
+      );
+    }
+  }
+  return detected;
+}
+
+export class AuthProfileMigrationRequiredError extends Error {
+  readonly code = AUTH_PROFILE_MIGRATION_REQUIRED_CODE;
+  readonly action = AUTH_PROFILE_MIGRATION_COMMAND;
+  readonly ownerId: string;
+  readonly sourceKinds: LegacyAuthProfileSourceKind[];
+
+  constructor(params: { agentDir?: string; sources: readonly LegacyAuthProfileSource[] }) {
+    const ownerId = shortenHomePath(resolveAuthProfileDatabasePath(params.agentDir));
+    const sourceKinds = [...new Set(params.sources.map((source) => source.kind))].toSorted();
+    super(
+      `Auth profile store ${ownerId} requires legacy credential migration; run ${AUTH_PROFILE_MIGRATION_COMMAND}.`,
+    );
+    this.name = "AuthProfileMigrationRequiredError";
+    this.ownerId = ownerId;
+    this.sourceKinds = sourceKinds;
+  }
+}
+
+export class AuthProfileStoreUnreadableError extends Error {
+  readonly code = "AUTH_PROFILE_STORE_UNREADABLE" as const;
+  readonly action = AUTH_PROFILE_MIGRATION_COMMAND;
+
+  constructor(agentDir?: string) {
+    super(
+      `Auth profile store ${shortenHomePath(resolveAuthProfileDatabasePath(agentDir))} is unreadable; run ${AUTH_PROFILE_MIGRATION_COMMAND}.`,
+    );
+    this.name = "AuthProfileStoreUnreadableError";
+  }
+}
+
+const migrationRequiredByDatabase = new Map<string, AuthProfileMigrationRequiredError>();
+const warnedLegacySourceDatabases = new Set<string>();
+
+export function warnLegacyAuthProfileSourcesIgnored(params: {
+  agentDir?: string;
+  sources: readonly LegacyAuthProfileSource[];
+}): void {
+  if (params.sources.length === 0) {
+    return;
+  }
+  const databasePath = resolveAuthProfileDatabasePath(params.agentDir);
+  if (warnedLegacySourceDatabases.has(databasePath)) {
+    return;
+  }
+  warnedLegacySourceDatabases.add(databasePath);
+  log.warn("retired auth profile files are ignored by runtime; run Doctor to archive them", {
+    code: AUTH_PROFILE_MIGRATION_REQUIRED_CODE,
+    ownerId: shortenHomePath(databasePath),
+    sourceKinds: [...new Set(params.sources.map((source) => source.kind))].toSorted(),
+    action: AUTH_PROFILE_MIGRATION_COMMAND,
+  });
+}
+
+export function markAuthProfileMigrationRequired(
+  agentDir: string | undefined,
+  error: AuthProfileMigrationRequiredError,
+): void {
+  const databasePath = resolveAuthProfileDatabasePath(agentDir);
+  migrationRequiredByDatabase.set(databasePath, error);
+}
+
+export function clearAuthProfileMigrationRequired(agentDir?: string): void {
+  const databasePath = resolveAuthProfileDatabasePath(agentDir);
+  migrationRequiredByDatabase.delete(databasePath);
+}
+
+export function assertAuthProfileMigrationReady(agentDir?: string): void {
+  const databasePath = resolveAuthProfileDatabasePath(agentDir);
+  const error = migrationRequiredByDatabase.get(databasePath);
+  if (error) {
+    // The activated secrets snapshot for this owner is empty. Only an explicit
+    // lifecycle clear/reload may remove the error and publish migrated SQLite rows.
+    throw error;
+  }
+  // Older shipped processes and restores can recreate these three fixed files
+  // after startup, so this credential boundary deliberately rechecks their names.
+  const sources = listLegacyAuthProfileSources({ agentDir }).filter(
+    (source) => source.kind !== "auth-state",
+  );
+  if (sources.length > 0) {
+    const migrationError = new AuthProfileMigrationRequiredError({ agentDir, sources });
+    markAuthProfileMigrationRequired(agentDir, migrationError);
+    throw migrationError;
+  }
+}
+
+export function clearAuthProfileMigrationDiagnostics(): void {
+  migrationRequiredByDatabase.clear();
+  warnedLegacySourceDatabases.clear();
+}

--- a/src/agents/auth-profiles/legacy-source-diagnostic.ts
+++ b/src/agents/auth-profiles/legacy-source-diagnostic.ts
@@ -61,7 +61,9 @@ export function listLegacyAuthProfileArchives(params: {
   const archives: LegacyAuthProfileSource[] = [];
   for (const [sourcePath, kind] of candidates) {
     const directory = path.dirname(sourcePath);
-    const prefix = `${path.basename(sourcePath)}.migrated-`;
+    const baseName = path.basename(sourcePath);
+    const migratedPrefix = `${baseName}.migrated-`;
+    const priorImportPrefix = `${baseName}.sqlite-import.`;
     let entries: string[];
     try {
       entries = fs.readdirSync(directory);
@@ -69,7 +71,10 @@ export function listLegacyAuthProfileArchives(params: {
       continue;
     }
     for (const entry of entries) {
-      if (entry.startsWith(prefix)) {
+      if (
+        entry.startsWith(migratedPrefix) ||
+        (entry.startsWith(priorImportPrefix) && entry.endsWith(".bak"))
+      ) {
         archives.push({ kind, path: path.join(directory, entry) });
       }
     }

--- a/src/agents/auth-profiles/oauth-lock-timeout-classification.test.ts
+++ b/src/agents/auth-profiles/oauth-lock-timeout-classification.test.ts
@@ -9,7 +9,8 @@ import {
   buildRefreshContentionError,
   isGlobalRefreshLockTimeoutError,
 } from "./oauth-refresh-lock-errors.js";
-import { resolveAuthStorePath, resolveOAuthRefreshLockPath } from "./paths.js";
+import { resolveOAuthRefreshLockPath } from "./paths.js";
+import { resolveAuthProfileDatabasePath } from "./sqlite.js";
 
 function createLockTimeoutError(lockPath: string): FileLockTimeoutError {
   return Object.assign(new Error(`file lock timeout for ${lockPath.slice(0, -5)}`), {
@@ -23,7 +24,9 @@ describe("OAuth refresh lock timeout classification", () => {
     const profileId = "openai:default";
     const provider = "openai";
     const refreshLockPath = resolveOAuthRefreshLockPath(provider, profileId);
-    const authStoreLockPath = resolveAuthStorePath("/tmp/openclaw-oauth-lock-timeout/agent");
+    const authStoreLockPath = resolveAuthProfileDatabasePath(
+      "/tmp/openclaw-oauth-lock-timeout/agent",
+    );
 
     expect(
       isGlobalRefreshLockTimeoutError(

--- a/src/agents/auth-profiles/oauth-manager.ts
+++ b/src/agents/auth-profiles/oauth-manager.ts
@@ -26,7 +26,8 @@ import {
   shouldBootstrapFromExternalCliCredential,
   shouldReplaceStoredOAuthCredential,
 } from "./oauth-shared.js";
-import { resolveAuthStorePath, resolveOAuthRefreshLockPath } from "./paths.js";
+import { resolveOAuthRefreshLockPath } from "./paths.js";
+import { resolveAuthProfileDatabasePath } from "./sqlite.js";
 import {
   ensureAuthProfileStoreWithoutExternalProfiles,
   loadAuthProfileStoreWithoutExternalProfiles,
@@ -489,7 +490,7 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
     attemptedCredentials?: OAuthCredential[];
   }): Promise<ResolvedOAuthAccess | null> {
     const ownerAgentDir = resolvePersistedAuthProfileOwnerAgentDir(params);
-    const authPath = resolveAuthStorePath(ownerAgentDir);
+    const authPath = resolveAuthProfileDatabasePath(ownerAgentDir);
     const globalRefreshLockPath = resolveOAuthRefreshLockPath(params.provider, params.profileId);
 
     try {
@@ -650,7 +651,7 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
           }
         }
         if (ownerAgentDir) {
-          const mainPath = resolveAuthStorePath(undefined);
+          const mainPath = resolveAuthProfileDatabasePath(undefined);
           if (mainPath !== authPath) {
             await mirrorRefreshedCredentialIntoMainStore({
               profileId: params.profileId,

--- a/src/agents/auth-profiles/path-constants.ts
+++ b/src/agents/auth-profiles/path-constants.ts
@@ -1,6 +1,0 @@
-/** Canonical JSON auth profile filename retained for direct file compatibility. */
-export const AUTH_PROFILE_FILENAME = "auth-profiles.json";
-/** Canonical JSON auth runtime state filename retained for direct file compatibility. */
-export const AUTH_STATE_FILENAME = "auth-state.json";
-/** Legacy auth filename migrated into the auth profile store. */
-export const LEGACY_AUTH_FILENAME = "auth.json";

--- a/src/agents/auth-profiles/path-resolve.ts
+++ b/src/agents/auth-profiles/path-resolve.ts
@@ -1,40 +1,11 @@
 /**
  * Auth profile path resolution.
- * Centralizes JSON store paths, display paths, legacy store paths, auth-state
- * paths, and cross-agent OAuth refresh lock paths.
+ * Centralizes canonical SQLite display paths and cross-agent OAuth refresh lock paths.
  */
 import path from "node:path";
 import { resolveStateDir } from "../../config/paths.js";
 import { resolveUserPath } from "../../utils.js";
-import {
-  AUTH_PROFILE_FILENAME,
-  AUTH_STATE_FILENAME,
-  LEGACY_AUTH_FILENAME,
-} from "./path-constants.js";
-import { resolveSharedMainAuthAgentDir } from "./shared-main-dir.js";
 import { resolveAuthProfileDatabasePath } from "./sqlite.js";
-
-function resolveAuthAgentDir(agentDir?: string): string {
-  if (agentDir) {
-    return resolveUserPath(agentDir);
-  }
-  return resolveSharedMainAuthAgentDir();
-}
-
-/** Resolve the persisted auth profile store path for an agent dir. */
-export function resolveAuthStorePath(agentDir?: string): string {
-  return path.join(resolveAuthAgentDir(agentDir), AUTH_PROFILE_FILENAME);
-}
-
-/** Resolve the legacy auth store path used by migration code. */
-export function resolveLegacyAuthStorePath(agentDir?: string): string {
-  return path.join(resolveAuthAgentDir(agentDir), LEGACY_AUTH_FILENAME);
-}
-
-/** Resolve the auth-state sidecar path for usage/cooldown metadata. */
-export function resolveAuthStatePath(agentDir?: string): string {
-  return path.join(resolveAuthAgentDir(agentDir), AUTH_STATE_FILENAME);
-}
 
 /** Resolve the user-facing auth profile database path. */
 export function resolveAuthStorePathForDisplay(agentDir?: string): string {

--- a/src/agents/auth-profiles/paths-direct-import.test.ts
+++ b/src/agents/auth-profiles/paths-direct-import.test.ts
@@ -7,14 +7,13 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { withEnv } from "../../test-utils/env.js";
 import {
-  resolveAuthStatePath,
-  resolveAuthStatePathForDisplay,
-  resolveAuthStorePath,
-  resolveAuthStorePathForDisplay,
-  resolveLegacyAuthStorePath,
-} from "./path-resolve.js";
+  resolveLegacyAuthProfilesPath as resolveAuthStorePath,
+  resolveLegacyAuthStatePath as resolveAuthStatePath,
+  resolveLegacyFlatAuthPath as resolveLegacyAuthStorePath,
+} from "../../commands/doctor-auth-legacy-paths.js";
+import { withEnv } from "../../test-utils/env.js";
+import { resolveAuthStatePathForDisplay, resolveAuthStorePathForDisplay } from "./path-resolve.js";
 
 describe("path-resolve helpers (direct-import coverage attribution)", () => {
   let stateDir = "";

--- a/src/agents/auth-profiles/paths.ts
+++ b/src/agents/auth-profiles/paths.ts
@@ -1,13 +1,9 @@
 /**
  * Public path barrel for auth-profile stores.
- * Import through this file so JSON, SQLite, display, and lock paths stay on the
- * shared resolver contract.
+ * Import through this file for canonical SQLite display and lock paths.
  */
 export {
-  resolveAuthStatePath,
   resolveAuthStatePathForDisplay,
-  resolveAuthStorePath,
   resolveAuthStorePathForDisplay,
-  resolveLegacyAuthStorePath,
   resolveOAuthRefreshLockPath,
 } from "./path-resolve.js";

--- a/src/agents/auth-profiles/persisted-boundary.test.ts
+++ b/src/agents/auth-profiles/persisted-boundary.test.ts
@@ -11,8 +11,8 @@ import { AUTH_STORE_VERSION } from "./constants.js";
 import { resolveAuthProfileOrder } from "./order.js";
 import {
   applyLegacyAuthStore,
+  coerceLegacyAuthStore,
   coercePersistedAuthProfileStore,
-  loadLegacyAuthProfileStore,
   mergeAuthProfileStores,
 } from "./persisted.js";
 import type { AuthProfileStore } from "./types.js";
@@ -459,7 +459,9 @@ describe("applyLegacyAuthStore", () => {
         chatgptPlanType: "pro",
       },
     });
-    const legacy = loadLegacyAuthProfileStore(agentDir);
+    const legacy = coerceLegacyAuthStore(
+      JSON.parse(fs.readFileSync(path.join(agentDir, "auth.json"), "utf8")),
+    );
     expect(legacy).not.toBeNull();
 
     const store: AuthProfileStore = { version: AUTH_STORE_VERSION, profiles: {} };
@@ -489,7 +491,9 @@ describe("applyLegacyAuthStore", () => {
         tokenRef: { source: "env", id: "ANTHROPIC_TOKEN" },
       },
     });
-    const legacy = loadLegacyAuthProfileStore(agentDir);
+    const legacy = coerceLegacyAuthStore(
+      JSON.parse(fs.readFileSync(path.join(agentDir, "auth.json"), "utf8")),
+    );
     expect(legacy).not.toBeNull();
 
     const store: AuthProfileStore = { version: AUTH_STORE_VERSION, profiles: {} };

--- a/src/agents/auth-profiles/persisted.ts
+++ b/src/agents/auth-profiles/persisted.ts
@@ -6,9 +6,7 @@
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
-import { resolveOAuthPath } from "../../config/paths.js";
 import { coerceSecretRef } from "../../config/types.secrets.js";
-import { loadJsonFile } from "../../infra/json-file.js";
 import type { OpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
 import { asBoolean } from "../../utils/boolean.js";
 import { AUTH_STORE_VERSION, log } from "./constants.js";
@@ -20,7 +18,6 @@ import {
   normalizeAuthEmailToken,
   normalizeAuthIdentityToken,
 } from "./oauth-shared.js";
-import { resolveLegacyAuthStorePath } from "./paths.js";
 import { readPersistedAuthProfileStoreRaw } from "./sqlite.js";
 import {
   coerceAuthProfileState,
@@ -33,7 +30,6 @@ import type {
   AuthProfileStore,
   RuntimeAuthProfileStore,
   OAuthCredential,
-  OAuthCredentials,
 } from "./types.js";
 
 /** Legacy auth.json store shape before auth-profiles.json/SQLite. */
@@ -187,6 +183,8 @@ function normalizeRawCredentialEntry(raw: Record<string, unknown>): Partial<Auth
       "projectId",
       "accountId",
       "chatgptPlanType",
+      "subscriptionType",
+      "rateLimitTier",
     ] as const) {
       const value = normalizeOptionalCredentialString(entry[field]);
       if (value !== undefined) {
@@ -760,33 +758,6 @@ export function applyLegacyAuthStore(store: AuthProfileStore, legacy: LegacyAuth
   }
 }
 
-/** Imports the legacy oauth.json file into missing default OAuth profiles. */
-export function mergeOAuthFileIntoStore(store: AuthProfileStore): boolean {
-  const oauthPath = resolveOAuthPath();
-  const oauthRaw = loadJsonFile(oauthPath);
-  if (!oauthRaw || typeof oauthRaw !== "object") {
-    return false;
-  }
-  const oauthEntries = oauthRaw as Record<string, OAuthCredentials>;
-  let mutated = false;
-  for (const [provider, creds] of Object.entries(oauthEntries)) {
-    if (!creds || typeof creds !== "object") {
-      continue;
-    }
-    const profileId = `${provider}:default`;
-    if (store.profiles[profileId]) {
-      continue;
-    }
-    store.profiles[profileId] = {
-      type: "oauth",
-      provider,
-      ...creds,
-    };
-    mutated = true;
-  }
-  return mutated;
-}
-
 /** Loads the persisted auth profile store and merges runtime state. */
 export function loadPersistedAuthProfileStore(
   agentDir?: string,
@@ -807,8 +778,4 @@ export function loadPersistedAuthProfileStore(
   return merged;
 }
 
-/** Loads the legacy auth.json auth profile store if present. */
-export function loadLegacyAuthProfileStore(agentDir?: string): LegacyAuthStore | null {
-  return coerceLegacyAuthStore(loadJsonFile(resolveLegacyAuthStorePath(agentDir)));
-}
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/agents/auth-profiles/runtime-snapshots.ts
+++ b/src/agents/auth-profiles/runtime-snapshots.ts
@@ -5,7 +5,7 @@ import path from "node:path";
  */
 import { isDeepStrictEqual } from "node:util";
 import { cloneAuthProfileStore } from "./clone.js";
-import { resolveAuthStorePath } from "./path-resolve.js";
+import { resolveAuthProfileDatabasePath } from "./sqlite.js";
 import type { AuthProfileStore, RuntimeAuthProfileStore } from "./types.js";
 
 const runtimeAuthStoreSnapshots = new Map<string, RuntimeAuthProfileStore>();
@@ -191,10 +191,10 @@ function recordChangedSnapshotRevisions(
   return changed;
 }
 
-// Runtime snapshots are keyed by the resolved auth store path so default-agent
+// Runtime snapshots are keyed by the canonical database path so default-agent
 // and per-agent stores do not overwrite each other.
 function resolveRuntimeStoreKey(agentDir?: string): string {
-  return resolveAuthStorePath(agentDir);
+  return resolveAuthProfileDatabasePath(agentDir);
 }
 
 function notifyRuntimeAuthStoreMutation(agentDir?: string): void {

--- a/src/agents/auth-profiles/source-check.test.ts
+++ b/src/agents/auth-profiles/source-check.test.ts
@@ -4,8 +4,8 @@ import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { clearAuthProfileMigrationDiagnostics } from "./legacy-source-diagnostic.js";
 import { hasAuthProfileStoreSourceForProvider } from "./source-check.js";
-import { writePersistedAuthProfileStoreRaw } from "./sqlite.js";
-import { loadAuthProfileStoreForRuntime } from "./store.js";
+import { readPersistedAuthProfileStoreRaw, writePersistedAuthProfileStoreRaw } from "./sqlite.js";
+import { loadAuthProfileStoreForRuntime, updateAuthProfileStoreWithLock } from "./store.js";
 
 describe("hasAuthProfileStoreSourceForProvider", () => {
   afterEach(() => {
@@ -71,6 +71,17 @@ describe("hasAuthProfileStoreSourceForProvider", () => {
 
     expect(hasAuthProfileStoreSourceForProvider("openai", agentDir)).toBe(true);
     expect(() => loadAuthProfileStoreForRuntime(agentDir)).toThrow("is unreadable");
+  });
+
+  it("rejects structurally unreadable rows inside write transactions", async () => {
+    const { agentDir } = await withAgentStore({});
+    const unreadableStore = { version: 1, profiles: "invalid-profile-map" };
+    writePersistedAuthProfileStoreRaw(unreadableStore, agentDir);
+    const updater = vi.fn(() => true);
+
+    await expect(updateAuthProfileStoreWithLock({ agentDir, updater })).resolves.toBeNull();
+    expect(updater).not.toHaveBeenCalled();
+    expect(readPersistedAuthProfileStoreRaw(agentDir)).toEqual(unreadableStore);
   });
 
   it("detects a legacy credential source that appears after an earlier clean load", async () => {

--- a/src/agents/auth-profiles/source-check.test.ts
+++ b/src/agents/auth-profiles/source-check.test.ts
@@ -2,7 +2,10 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { clearAuthProfileMigrationDiagnostics } from "./legacy-source-diagnostic.js";
 import { hasAuthProfileStoreSourceForProvider } from "./source-check.js";
+import { writePersistedAuthProfileStoreRaw } from "./sqlite.js";
+import { loadAuthProfileStoreForRuntime } from "./store.js";
 
 describe("hasAuthProfileStoreSourceForProvider", () => {
   afterEach(() => {
@@ -16,10 +19,7 @@ describe("hasAuthProfileStoreSourceForProvider", () => {
     await fs.mkdir(agentDir, { recursive: true });
     await fs.mkdir(stateDir, { recursive: true });
     vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
-    await fs.writeFile(
-      path.join(agentDir, "auth-profiles.json"),
-      JSON.stringify({ version: 1, profiles }),
-    );
+    writePersistedAuthProfileStoreRaw({ version: 1, profiles }, agentDir);
     return { agentDir };
   }
 
@@ -48,6 +48,12 @@ describe("hasAuthProfileStoreSourceForProvider", () => {
     });
 
     expect(hasAuthProfileStoreSourceForProvider("openai", agentDir)).toBe(true);
+    expect(() => loadAuthProfileStoreForRuntime(agentDir)).toThrow(
+      "requires legacy credential migration",
+    );
+    await fs.rename(path.join(agentDir, "auth.json"), path.join(agentDir, "auth.json.migrated"));
+    clearAuthProfileMigrationDiagnostics();
+    expect(loadAuthProfileStoreForRuntime(agentDir).profiles).toEqual({});
   });
 
   it("ignores malformed provider fields instead of throwing", async () => {
@@ -57,6 +63,29 @@ describe("hasAuthProfileStoreSourceForProvider", () => {
     });
 
     expect(hasAuthProfileStoreSourceForProvider("openai", agentDir)).toBe(false);
+  });
+
+  it("routes structurally unreadable SQLite rows through the fail-closed loader", async () => {
+    const { agentDir } = await withAgentStore({});
+    writePersistedAuthProfileStoreRaw({ version: 1, profiles: "invalid-profile-map" }, agentDir);
+
+    expect(hasAuthProfileStoreSourceForProvider("openai", agentDir)).toBe(true);
+    expect(() => loadAuthProfileStoreForRuntime(agentDir)).toThrow("is unreadable");
+  });
+
+  it("detects a legacy credential source that appears after an earlier clean load", async () => {
+    const { agentDir } = await withAgentStore({});
+    expect(loadAuthProfileStoreForRuntime(agentDir).profiles).toEqual({});
+
+    await fs.writeFile(
+      path.join(agentDir, "auth.json"),
+      JSON.stringify({ openai: { type: "api_key", key: "fake-late-key" } }),
+    );
+
+    expect(hasAuthProfileStoreSourceForProvider("openai", agentDir)).toBe(true);
+    expect(() => loadAuthProfileStoreForRuntime(agentDir)).toThrow(
+      "requires legacy credential migration",
+    );
   });
 
   it("does not count profile ids that are bound to a different credential provider", async () => {

--- a/src/agents/auth-profiles/source-check.ts
+++ b/src/agents/auth-profiles/source-check.ts
@@ -2,31 +2,19 @@
  * Auth-profile source probes for runtime and persisted stores.
  * These checks intentionally avoid loading secret-bearing credential payloads.
  */
-import fs from "node:fs";
-import { tryReadJsonSync } from "../../infra/json-files.js";
 import { evaluateStoredCredentialEligibility } from "./credential-state.js";
-import {
-  resolveAuthStatePath,
-  resolveAuthStorePath,
-  resolveLegacyAuthStorePath,
-} from "./path-resolve.js";
-import { coerceLegacyAuthStore, coercePersistedAuthProfileStore } from "./persisted.js";
+import { hasLegacyAuthProfileCredentialSource } from "./legacy-source-diagnostic.js";
+import { coercePersistedAuthProfileStore } from "./persisted.js";
 import {
   getRuntimeAuthProfileStoreSnapshot,
   hasAnyRuntimeAuthProfileStoreSource,
 } from "./runtime-snapshots.js";
-import { readPersistedAuthProfileStateRaw, readPersistedAuthProfileStoreRaw } from "./sqlite.js";
+import {
+  inspectPersistedAuthProfileStoreRaw,
+  readPersistedAuthProfileStateRaw,
+  resolveAuthProfileDatabasePath,
+} from "./sqlite.js";
 import type { AuthProfileCredential, AuthProfileStore } from "./types.js";
-
-// Auth-profile source checks look at runtime snapshots, JSON compatibility
-// files, legacy files, and SQLite stores without materializing secret values.
-function hasStoredAuthProfileFiles(agentDir?: string): boolean {
-  return (
-    fs.existsSync(resolveAuthStorePath(agentDir)) ||
-    fs.existsSync(resolveAuthStatePath(agentDir)) ||
-    fs.existsSync(resolveLegacyAuthStorePath(agentDir))
-  );
-}
 
 function normalizeProvider(provider: string): string {
   return provider.trim().toLowerCase();
@@ -55,7 +43,7 @@ function isEligibleProviderCredential(rawCredential: unknown, expectedProvider: 
 }
 
 function coerceRawStoreProfiles(raw: unknown): Record<string, AuthProfileCredential> | null {
-  return coercePersistedAuthProfileStore(raw)?.profiles ?? coerceLegacyAuthStore(raw);
+  return coercePersistedAuthProfileStore(raw)?.profiles ?? null;
 }
 
 function rawStoreHasProviderProfile(
@@ -86,6 +74,23 @@ function runtimeStoreHasProviderProfile(
   return rawStoreHasProviderProfile(store, provider, profileIds);
 }
 
+function canonicalStoreOwnsProviderRoute(
+  agentDir: string | undefined,
+  provider: string,
+  profileIds?: readonly string[],
+): boolean {
+  const inspection = inspectPersistedAuthProfileStoreRaw(agentDir);
+  if (inspection.status === "missing") {
+    return false;
+  }
+  if (inspection.status === "unreadable" || !coercePersistedAuthProfileStore(inspection.raw)) {
+    // A present but unreadable canonical row must route through the loader so
+    // AUTH_PROFILE_STORE_UNREADABLE fails closed before env/config fallback.
+    return true;
+  }
+  return rawStoreHasProviderProfile(inspection.raw, provider, profileIds);
+}
+
 /** Returns true when any local/runtime/main auth profile source exists. */
 export function hasAnyAuthProfileStoreSource(agentDir?: string): boolean {
   if (hasLocalAuthProfileStoreSource(agentDir)) {
@@ -95,13 +100,13 @@ export function hasAnyAuthProfileStoreSource(agentDir?: string): boolean {
     return true;
   }
 
-  const authPath = resolveAuthStorePath(agentDir);
-  const mainAuthPath = resolveAuthStorePath();
+  const authPath = resolveAuthProfileDatabasePath(agentDir);
+  const mainAuthPath = resolveAuthProfileDatabasePath();
   if (
     agentDir &&
     authPath !== mainAuthPath &&
-    (hasStoredAuthProfileFiles(undefined) ||
-      readPersistedAuthProfileStoreRaw(undefined) ||
+    (hasLegacyAuthProfileCredentialSource(undefined) ||
+      inspectPersistedAuthProfileStoreRaw(undefined).status !== "missing" ||
       readPersistedAuthProfileStateRaw(undefined))
   ) {
     return true;
@@ -115,12 +120,13 @@ export function hasLocalAuthProfileStoreSource(agentDir?: string): boolean {
   if (runtimeStore && Object.keys(runtimeStore.profiles).length > 0) {
     return true;
   }
-  if (hasStoredAuthProfileFiles(agentDir)) {
+  if (hasLegacyAuthProfileCredentialSource(agentDir)) {
     return true;
   }
-  return Boolean(
-    readPersistedAuthProfileStoreRaw(agentDir) || readPersistedAuthProfileStateRaw(agentDir),
-  );
+  if (inspectPersistedAuthProfileStoreRaw(agentDir).status !== "missing") {
+    return true;
+  }
+  return Boolean(readPersistedAuthProfileStateRaw(agentDir));
 }
 
 type AuthProfileSourceForProviderOptions = {
@@ -145,27 +151,13 @@ export function hasAuthProfileStoreSourceForProvider(
   if (runtimeStoreHasProviderProfile(localRuntimeStore, provider, profileIds)) {
     return true;
   }
-  if (
-    rawStoreHasProviderProfile(
-      tryReadJsonSync(resolveAuthStorePath(agentDir)),
-      provider,
-      profileIds,
-    )
-  ) {
+  // A retired credential source is intentionally opaque to runtime. Treat it
+  // as potentially owning the provider so the canonical loader can fail closed
+  // with AUTH_PROFILE_MIGRATION_REQUIRED instead of falling through to env auth.
+  if (hasLegacyAuthProfileCredentialSource(agentDir)) {
     return true;
   }
-  if (
-    rawStoreHasProviderProfile(
-      tryReadJsonSync(resolveLegacyAuthStorePath(agentDir)),
-      provider,
-      profileIds,
-    )
-  ) {
-    return true;
-  }
-  if (
-    rawStoreHasProviderProfile(readPersistedAuthProfileStoreRaw(agentDir), provider, profileIds)
-  ) {
+  if (canonicalStoreOwnsProviderRoute(agentDir, provider, profileIds)) {
     return true;
   }
 
@@ -176,13 +168,8 @@ export function hasAuthProfileStoreSourceForProvider(
   if (runtimeStoreHasProviderProfile(mainRuntimeStore, provider, profileIds)) {
     return true;
   }
-  if (rawStoreHasProviderProfile(tryReadJsonSync(resolveAuthStorePath()), provider, profileIds)) {
+  if (hasLegacyAuthProfileCredentialSource()) {
     return true;
   }
-  if (
-    rawStoreHasProviderProfile(tryReadJsonSync(resolveLegacyAuthStorePath()), provider, profileIds)
-  ) {
-    return true;
-  }
-  return rawStoreHasProviderProfile(readPersistedAuthProfileStoreRaw(), provider, profileIds);
+  return canonicalStoreOwnsProviderRoute(undefined, provider, profileIds);
 }

--- a/src/agents/auth-profiles/sqlite.ts
+++ b/src/agents/auth-profiles/sqlite.ts
@@ -101,6 +101,44 @@ function getAuthProfileKysely(db: DatabaseSync) {
   return getNodeSqliteKysely<AuthProfileDatabase>(db);
 }
 
+function inspectAuthProfileJsonCell(
+  db: DatabaseSync,
+  target: "store" | "state",
+): PersistedAuthProfileStoreInspection {
+  const kysely = getAuthProfileKysely(db);
+  let raw: string;
+  if (target === "store") {
+    const row = executeSqliteQueryTakeFirstSync(
+      db,
+      kysely
+        .selectFrom("auth_profile_store")
+        .select("store_json")
+        .where("store_key", "=", PRIMARY_ROW_KEY),
+    );
+    if (!row) {
+      return { status: "missing", reason: "row" };
+    }
+    raw = row.store_json;
+  } else {
+    const row = executeSqliteQueryTakeFirstSync(
+      db,
+      kysely
+        .selectFrom("auth_profile_state")
+        .select("state_json")
+        .where("state_key", "=", PRIMARY_ROW_KEY),
+    );
+    if (!row) {
+      return { status: "missing", reason: "row" };
+    }
+    raw = row.state_json;
+  }
+  try {
+    return { status: "readable", raw: JSON.parse(raw) as unknown };
+  } catch {
+    return { status: "unreadable" };
+  }
+}
+
 function inspectAuthProfileJsonCellReadOnly(
   pathname: string,
   target: "store" | "state",
@@ -127,39 +165,7 @@ function inspectAuthProfileJsonCellReadOnly(
     if (schemaObject.type !== "table") {
       return { status: "unreadable" };
     }
-    const kysely = getAuthProfileKysely(db);
-    if (target === "store") {
-      const row = executeSqliteQueryTakeFirstSync(
-        db,
-        kysely
-          .selectFrom("auth_profile_store")
-          .select("store_json")
-          .where("store_key", "=", PRIMARY_ROW_KEY),
-      );
-      if (!row) {
-        return { status: "missing", reason: "row" };
-      }
-      try {
-        return { status: "readable", raw: JSON.parse(row.store_json) as unknown };
-      } catch {
-        return { status: "unreadable" };
-      }
-    }
-    const row = executeSqliteQueryTakeFirstSync(
-      db,
-      kysely
-        .selectFrom("auth_profile_state")
-        .select("state_json")
-        .where("state_key", "=", PRIMARY_ROW_KEY),
-    );
-    if (!row) {
-      return { status: "missing", reason: "row" };
-    }
-    try {
-      return { status: "readable", raw: JSON.parse(row.state_json) as unknown };
-    } catch {
-      return { status: "unreadable" };
-    }
+    return inspectAuthProfileJsonCell(db, target);
   } catch {
     return { status: "unreadable" };
   } finally {
@@ -178,7 +184,11 @@ function readAuthProfileJsonCellReadOnly(pathname: string, target: "store" | "st
 /** Distinguishes an absent auth row from a present store that could not be read. */
 export function inspectPersistedAuthProfileStoreRaw(
   agentDir?: string,
+  database?: OpenClawAgentDatabase,
 ): PersistedAuthProfileStoreInspection {
+  if (database) {
+    return inspectAuthProfileJsonCell(database.db, "store");
+  }
   const databasePath = resolveAuthProfileDatabasePath(agentDir);
   if (!fs.existsSync(databasePath)) {
     return { status: "missing", reason: "database" };
@@ -189,7 +199,11 @@ export function inspectPersistedAuthProfileStoreRaw(
 /** Distinguishes an absent auth-state row from state that could not be read. */
 export function inspectPersistedAuthProfileStateRaw(
   agentDir?: string,
+  database?: OpenClawAgentDatabase,
 ): PersistedAuthProfileStoreInspection {
+  if (database) {
+    return inspectAuthProfileJsonCell(database.db, "state");
+  }
   const databasePath = resolveAuthProfileDatabasePath(agentDir);
   if (!fs.existsSync(databasePath)) {
     return { status: "missing", reason: "database" };

--- a/src/agents/auth-profiles/store.ts
+++ b/src/agents/auth-profiles/store.ts
@@ -22,16 +22,22 @@ import {
 } from "./external-auth.js";
 import type { ExternalCliAuthDiscovery } from "./external-cli-discovery.js";
 import {
+  AuthProfileMigrationRequiredError,
+  AuthProfileStoreUnreadableError,
+  assertAuthProfileMigrationReady,
+  clearAuthProfileMigrationRequired,
+  listLegacyAuthProfileSources,
+  warnLegacyAuthProfileSourcesIgnored,
+} from "./legacy-source-diagnostic.js";
+import {
   isSafeToAdoptMainStoreOAuthIdentity,
   shouldPersistRuntimeExternalOAuthProfile,
   type RuntimeExternalOAuthProfile,
 } from "./oauth-shared.js";
-import { resolveAuthStorePath } from "./paths.js";
 import {
   buildPersistedAuthProfileSecretsStore,
   loadPersistedAuthProfileStore,
   mergeAuthProfileStores,
-  mergeOAuthFileIntoStore,
 } from "./persisted.js";
 import {
   clearRuntimeAuthProfileStoreSnapshot as clearRuntimeAuthProfileStoreSnapshotImpl,
@@ -45,14 +51,19 @@ import {
 } from "./runtime-snapshots.js";
 import {
   deletePersistedAuthProfileStoreRaw,
+  inspectPersistedAuthProfileStoreRaw,
   readPersistedAuthProfileStoreRaw,
   readPersistedAuthProfileStateRaw,
+  resolveAuthProfileDatabasePath,
   runAuthProfileWriteTransaction,
   writePersistedAuthProfileStateRaw,
   writePersistedAuthProfileStoreRaw,
 } from "./sqlite.js";
 import { buildPersistedAuthProfileState, loadPersistedAuthProfileState } from "./state.js";
 import type { AuthProfileStore, RuntimeAuthProfileStore } from "./types.js";
+
+// Runtime identity is the canonical per-agent database, never a retired JSON filename.
+const resolveAuthStorePath = resolveAuthProfileDatabasePath;
 
 type LoadAuthProfileStoreOptions = {
   allowKeychainPrompt?: boolean;
@@ -968,12 +979,17 @@ function loadAuthProfileStoreForAgent(
   }
   const effectiveAgentDir = resolveRuntimeAuthProfileAgentDir(agentDir);
   const effectiveOptions = resolveRuntimeAuthProfileLoadOptions(options);
-  const readOnly = effectiveOptions?.readOnly === true;
+  assertAuthProfileMigrationReady(effectiveAgentDir);
   const asStore = loadPersistedAuthProfileStore(
     effectiveAgentDir,
     resolvePersistedLoadOptions(effectiveOptions),
   );
   if (asStore) {
+    warnLegacyAuthProfileSourcesIgnored({
+      agentDir: effectiveAgentDir,
+      sources: listLegacyAuthProfileSources({ agentDir: effectiveAgentDir }),
+    });
+    clearAuthProfileMigrationRequired(effectiveAgentDir);
     const synced = maybeSyncPersistedExternalCliAuthProfiles({
       store: asStore,
       agentDir: effectiveAgentDir,
@@ -982,18 +998,26 @@ function loadAuthProfileStoreForAgent(
     return markRuntimePersistedProfiles(synced.store);
   }
 
+  if (!effectiveOptions?.database) {
+    const inspection = inspectPersistedAuthProfileStoreRaw(effectiveAgentDir);
+    if (inspection.status !== "missing") {
+      throw new AuthProfileStoreUnreadableError(effectiveAgentDir);
+    }
+  }
+  const legacySources = listLegacyAuthProfileSources({ agentDir: effectiveAgentDir });
+  const credentialSources = legacySources.filter((source) => source.kind !== "auth-state");
+  if (credentialSources.length > 0) {
+    throw new AuthProfileMigrationRequiredError({
+      agentDir: effectiveAgentDir,
+      sources: credentialSources,
+    });
+  }
+  warnLegacyAuthProfileSourcesIgnored({ agentDir: effectiveAgentDir, sources: legacySources });
+  clearAuthProfileMigrationRequired(effectiveAgentDir);
   const store: AuthProfileStore = {
     version: AUTH_STORE_VERSION,
     profiles: {},
   };
-
-  const mergedOAuth = mergeOAuthFileIntoStore(store);
-  const forceReadOnly = process.env.OPENCLAW_AUTH_STORE_READONLY === "1";
-  const shouldWrite = !readOnly && !forceReadOnly && mergedOAuth;
-  if (shouldWrite) {
-    saveAuthProfileStore(store, effectiveAgentDir);
-  }
-
   const synced = maybeSyncPersistedExternalCliAuthProfiles({
     store,
     agentDir: effectiveAgentDir,

--- a/src/agents/auth-profiles/store.ts
+++ b/src/agents/auth-profiles/store.ts
@@ -27,6 +27,7 @@ import {
   assertAuthProfileMigrationReady,
   clearAuthProfileMigrationRequired,
   listLegacyAuthProfileSources,
+  markAuthProfileMigrationRequired,
   warnLegacyAuthProfileSourcesIgnored,
 } from "./legacy-source-diagnostic.js";
 import {
@@ -985,9 +986,19 @@ function loadAuthProfileStoreForAgent(
     resolvePersistedLoadOptions(effectiveOptions),
   );
   if (asStore) {
+    const legacySources = listLegacyAuthProfileSources({ agentDir: effectiveAgentDir });
+    const credentialSources = legacySources.filter((source) => source.kind !== "auth-state");
+    if (credentialSources.length > 0) {
+      const migrationError = new AuthProfileMigrationRequiredError({
+        agentDir: effectiveAgentDir,
+        sources: credentialSources,
+      });
+      markAuthProfileMigrationRequired(effectiveAgentDir, migrationError);
+      throw migrationError;
+    }
     warnLegacyAuthProfileSourcesIgnored({
       agentDir: effectiveAgentDir,
-      sources: listLegacyAuthProfileSources({ agentDir: effectiveAgentDir }),
+      sources: legacySources,
     });
     clearAuthProfileMigrationRequired(effectiveAgentDir);
     const synced = maybeSyncPersistedExternalCliAuthProfiles({

--- a/src/agents/auth-profiles/store.ts
+++ b/src/agents/auth-profiles/store.ts
@@ -998,11 +998,12 @@ function loadAuthProfileStoreForAgent(
     return markRuntimePersistedProfiles(synced.store);
   }
 
-  if (!effectiveOptions?.database) {
-    const inspection = inspectPersistedAuthProfileStoreRaw(effectiveAgentDir);
-    if (inspection.status !== "missing") {
-      throw new AuthProfileStoreUnreadableError(effectiveAgentDir);
-    }
+  const inspection = inspectPersistedAuthProfileStoreRaw(
+    effectiveAgentDir,
+    effectiveOptions?.database,
+  );
+  if (inspection.status !== "missing") {
+    throw new AuthProfileStoreUnreadableError(effectiveAgentDir);
   }
   const legacySources = listLegacyAuthProfileSources({ agentDir: effectiveAgentDir });
   const credentialSources = legacySources.filter((source) => source.kind !== "auth-state");

--- a/src/agents/auth-profiles/store.ts
+++ b/src/agents/auth-profiles/store.ts
@@ -1390,8 +1390,12 @@ function saveAuthProfileStoreInTransaction(
     if (suppliedRuntimeStore) {
       const existing = getRuntimeAuthProfileStoreSnapshot(agentDir);
       if (existing) {
+        const materialized = preserveResolvedSecretBackedCredentials({
+          next: suppliedRuntimeStore,
+          existing,
+        });
         setRuntimeAuthProfileStoreSnapshot(
-          mergeRuntimeExternalProfileReferences({ next: suppliedRuntimeStore, existing }),
+          mergeRuntimeExternalProfileReferences({ next: materialized, existing }),
           agentDir,
         );
       }

--- a/src/agents/model-auth-provider.ts
+++ b/src/agents/model-auth-provider.ts
@@ -22,6 +22,7 @@ import {
   resolveAuthProfileOrder,
   resolveAuthStorePathForDisplay,
 } from "./auth-profiles.js";
+import { assertAuthProfileMigrationReady } from "./auth-profiles/legacy-source-diagnostic.js";
 import { OAuthRefreshFailureError } from "./auth-profiles/oauth-refresh-failure.js";
 import { isNonSecretApiKeyMarker } from "./model-auth-markers.js";
 import { assertAuthModeAllowedForModel, isAuthModeAllowedForModel } from "./model-auth-openai.js";
@@ -95,10 +96,13 @@ export async function resolveApiKeyForProvider(params: {
   secretSentinels?: boolean;
 }): Promise<ResolvedProviderAuth> {
   const { provider, cfg, profileId, preferredProfile } = params;
+  const agentDir = params.agentDir?.trim() || (cfg ? resolveDefaultAgentDir(cfg) : undefined);
+  // Pending credential files own this agent's auth route until Doctor commits
+  // and archives them; do not fall through to env/config credentials.
+  assertAuthProfileMigrationReady(agentDir);
   // A failed explicit ref owns the provider. Stop before profile/env discovery so requests cannot
   // silently switch credentials while this configured owner is cold.
   assertRuntimeProviderSecretOwnerAvailable({ cfg, provider });
-  const agentDir = params.agentDir?.trim() || (cfg ? resolveDefaultAgentDir(cfg) : undefined);
   let scopedStore: AuthProfileStore | undefined = params.store;
   const getScopedStore = (requestedProfileId?: string) =>
     (scopedStore ??= resolveScopedAuthProfileStore({

--- a/src/agents/models-config.providers.secrets.ts
+++ b/src/agents/models-config.providers.secrets.ts
@@ -78,6 +78,18 @@ export function createProviderApiKeyResolverFromPreparedCredentials(
         discoveryApiKey: toDiscoveryApiKey(credential.access),
       };
     }
+    if (credential.type === "token") {
+      if (
+        !credential.token.trim() ||
+        (credential.expires !== undefined && Date.now() >= credential.expires)
+      ) {
+        return resolveConfiguredOrEnvironment(provider);
+      }
+      return {
+        apiKey: credential.token,
+        discoveryApiKey: toDiscoveryApiKey(credential.token),
+      };
+    }
     if (!credential.key.trim()) {
       return resolveConfiguredOrEnvironment(provider);
     }

--- a/src/agents/sessions/auth-storage.test.ts
+++ b/src/agents/sessions/auth-storage.test.ts
@@ -143,7 +143,7 @@ describe("SQLite auth storage", () => {
     expect(fs.existsSync(legacyPath)).toBe(false);
   });
 
-  it("keeps FileAuthStorageBackend as a deprecated SQLite-backed export", () => {
+  it("keeps FileAuthStorageBackend as a deprecated fail-closed SQLite adapter", async () => {
     const agentDir = makeAgentDir();
     const legacyPath = path.join(agentDir, "auth.json");
     const storage = AuthStorage.fromStorage(new FileAuthStorageBackend(legacyPath));
@@ -153,6 +153,10 @@ describe("SQLite auth storage", () => {
       key: "fake-openai-key",
     });
     expect(fs.existsSync(legacyPath)).toBe(false);
+    fs.writeFileSync(legacyPath, '{"openai":{"key":"fake-late"}}\n');
+    await expect(storage.getApiKey("openai")).rejects.toThrow(
+      "requires legacy credential migration",
+    );
   });
 
   it("reads materialized SecretRefs without persisting their resolved value", async () => {

--- a/src/agents/sessions/auth-storage.test.ts
+++ b/src/agents/sessions/auth-storage.test.ts
@@ -144,6 +144,20 @@ describe("SQLite auth storage", () => {
     expect(fs.existsSync(legacyPath)).toBe(false);
   });
 
+  it("fails closed instead of ignoring credentials at a deprecated custom path", () => {
+    const agentDir = makeAgentDir();
+    const customPath = path.join(agentDir, "plugin-credentials.json");
+    fs.writeFileSync(customPath, '{"openai":{"key":"not-a-real"}}\n', "utf8");
+
+    expect(() => AuthStorage.create(customPath)).toThrow(
+      expect.objectContaining({ code: "AUTH_PROFILE_MIGRATION_REQUIRED" }),
+    );
+    expect(() => new FileAuthStorageBackend(customPath)).toThrow(
+      expect.objectContaining({ code: "AUTH_PROFILE_MIGRATION_REQUIRED" }),
+    );
+    expect(loadPersistedAuthProfileStore(agentDir)).toBeNull();
+  });
+
   it("keeps FileAuthStorageBackend as a deprecated fail-closed SQLite adapter", async () => {
     const agentDir = makeAgentDir();
     const legacyPath = path.join(agentDir, "auth.json");

--- a/src/agents/sessions/auth-storage.test.ts
+++ b/src/agents/sessions/auth-storage.test.ts
@@ -1,145 +1,322 @@
-// Auth storage tests cover durable credential persistence and file permission
-// contracts for agent model authentication.
+// Auth storage tests cover the provider-keyed SDK facade over canonical SQLite auth profiles.
+import fs from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
-import lockfile from "proper-lockfile";
+import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { AuthStorageBackend } from "./auth-storage.js";
+import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
+import { clearAuthProfileMigrationDiagnostics } from "../auth-profiles/legacy-source-diagnostic.js";
+import { loadPersistedAuthProfileStore } from "../auth-profiles/persisted.js";
+import {
+  clearRuntimeAuthProfileStoreSnapshots,
+  replaceRuntimeAuthProfileStoreSnapshots,
+} from "../auth-profiles/runtime-snapshots.js";
+import {
+  readPersistedAuthProfileStoreRaw,
+  writePersistedAuthProfileStoreRaw,
+} from "../auth-profiles/sqlite.js";
+import { getAuthStorageOAuthProviderRegistry } from "./auth-storage-oauth-registry.js";
+import { AuthStorage, FileAuthStorageBackend, type AuthStorageBackend } from "./auth-storage.js";
 
-// auth-storage.ts persists via the named import `writeFileSync` from node:fs,
-// and replaceFileAtomicSync (in @openclaw/fs-safe) writes its temp file via the
-// default import `syncFs.writeFileSync`. A namespace `vi.spyOn(fs, ...)` cannot
-// rebind an already-captured named import, so we mock node:fs and route every
-// writeFileSync (named + default) through a single controllable write-failure hook.
-const writeFailHook = vi.hoisted(() => ({
-  fn: undefined as ((file: unknown, data: unknown, options: unknown) => void) | undefined,
-  // The unwrapped writeFileSync, so the hook can mutate disk state
-  // (e.g. truncate the destination) without re-entering itself.
-  raw: undefined as ((...args: unknown[]) => unknown) | undefined,
-}));
-
-vi.mock("node:fs", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("node:fs")>();
-  writeFailHook.raw = actual.writeFileSync as (...args: unknown[]) => unknown;
-  const writeFileSync: typeof actual.writeFileSync = ((
-    file: unknown,
-    data: unknown,
-    options: unknown,
-  ) => {
-    writeFailHook.fn?.(file, data, options);
-    return (actual.writeFileSync as (...a: unknown[]) => unknown)(file, data, options);
-  }) as typeof actual.writeFileSync;
-  return {
-    ...actual,
-    writeFileSync,
-    default: { ...actual, writeFileSync },
-  };
-});
-
-const fs = await import("node:fs");
-const { AuthStorage, FileAuthStorageBackend } = await import("./auth-storage.js");
-
-describe("file auth storage", () => {
-  let tmpDir: string | undefined;
+describe("SQLite auth storage", () => {
+  const tempDirs: string[] = [];
 
   afterEach(() => {
-    vi.restoreAllMocks();
-    writeFailHook.fn = undefined;
-    if (tmpDir) {
-      fs.rmSync(tmpDir, { recursive: true, force: true });
-      tmpDir = undefined;
+    clearAuthProfileMigrationDiagnostics();
+    clearRuntimeAuthProfileStoreSnapshots();
+    vi.unstubAllEnvs();
+    closeOpenClawAgentDatabasesForTest();
+    for (const dir of tempDirs.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
     }
   });
 
-  it("does not lock out credentials when a write fails mid-flush", async () => {
-    tmpDir = fs.mkdtempSync(join(tmpdir(), "auth-writefail-"));
-    const authPath = join(tmpDir, "auth.json");
+  function makeAgentDir(): string {
+    const agentDir = fs.mkdtempSync(path.join(tmpdir(), "auth-sqlite-"));
+    tempDirs.push(agentDir);
+    return agentDir;
+  }
 
-    // Seed a valid credential that round-trips cleanly.
-    const seed = AuthStorage.create(authPath);
-    seed.set("anthropic", { type: "api_key", key: "sk-test-SEED-12345" });
-    expect(await AuthStorage.create(authPath).getApiKey("anthropic")).toBe("sk-test-SEED-12345");
+  it("persists provider defaults in the canonical agent database", async () => {
+    const agentDir = makeAgentDir();
+    const storage = AuthStorage.forAgent(agentDir);
+    storage.set("anthropic", { type: "api_key", key: "fake-anthropic-key" });
 
-    // Model a write that fails partway during the next persist (a full disk, an
-    // over-quota volume, or a power loss before the flush). Only a *direct* write
-    // to auth.json leaves it corrupt:
-    //   - raw writeFileSync (RED): the persist writes straight to auth.json, so
-    //     the OS has already O_TRUNC-opened the destination. We model the partial
-    //     on-disk state by truncating auth.json, then failing the write.
-    //   - replaceFileAtomicSync (GREEN): the persist writes to a sibling temp
-    //     file (via fs-safe) and renames it into place. It never writes auth.json
-    //     directly, so this hook never fires and the persist completes cleanly --
-    //     which is exactly the write-atomicity we are asserting (auth.json is
-    //     never left partial).
-    writeFailHook.fn = (file) => {
-      if (typeof file === "number") {
-        return;
-      }
-      if (String(file) === authPath) {
-        writeFailHook.raw?.(authPath, "", "utf-8");
-        throw Object.assign(new Error("simulated write failure mid-flush"), {
-          code: "ENOSPC",
-        });
-      }
-    };
-
-    const persisting = AuthStorage.create(authPath);
-    // Raw writeFileSync targets auth.json directly, so the hook truncates it and
-    // throws (RED). The atomic write targets a temp file + rename, so the hook
-    // never fires and set() completes cleanly (GREEN).
-    try {
-      persisting.set("openai", { type: "api_key", key: "sk-test-NEW-67890" });
-    } catch {
-      // raw path throws after truncating auth.json; atomic path does not throw.
-    }
-    writeFailHook.fn = undefined;
-
-    // Next boot: the original credential must still load.
-    // RED (raw writeFileSync): auth.json is now empty -> JSON.parse throws on
-    //   reload -> loadError -> getApiKey returns undefined -> lockout.
-    // GREEN (replaceFileAtomicSync): auth.json was never written directly, so it
-    //   holds the atomically-renamed new content (seed still present).
-    const reopened = AuthStorage.create(authPath);
-    expect(reopened.drainErrors()).toHaveLength(0);
-    expect(await reopened.getApiKey("anthropic")).toBe("sk-test-SEED-12345");
-    expect(fs.existsSync(authPath)).toBe(true);
-    expect(fs.readFileSync(authPath, "utf-8").length).toBeGreaterThan(0);
+    expect(await AuthStorage.forAgent(agentDir).getApiKey("anthropic")).toBe("fake-anthropic-key");
+    expect(loadPersistedAuthProfileStore(agentDir)?.profiles["anthropic:default"]).toMatchObject({
+      type: "api_key",
+      provider: "anthropic",
+      key: "fake-anthropic-key",
+    });
+    expect(fs.existsSync(path.join(agentDir, "auth.json"))).toBe(false);
   });
 
-  it("preserves existing auth directory permissions while replacing the file", () => {
-    // The auth file itself is secret material, but callers may place it in a
-    // directory with broader traversal permissions that must not be tightened.
-    tmpDir = fs.mkdtempSync(join(tmpdir(), "auth-dir-mode-"));
-    fs.chmodSync(tmpDir, 0o755);
-    const authPath = join(tmpDir, "auth.json");
+  it("merges synchronous writes from instances created on the same baseline", () => {
+    const agentDir = makeAgentDir();
+    const left = AuthStorage.forAgent(agentDir);
+    const right = AuthStorage.forAgent(agentDir);
 
-    const storage = AuthStorage.create(authPath);
-    storage.set("anthropic", { type: "api_key", key: "sk-test-SEED-12345" });
+    left.set("openai", { type: "api_key", key: "fake-openai-key" });
+    right.set("anthropic", { type: "api_key", key: "fake-anthropic-key" });
 
-    expect(fs.statSync(tmpDir).mode & 0o777).toBe(0o755);
-    expect(fs.statSync(authPath).mode & 0o777).toBe(0o600);
+    expect(loadPersistedAuthProfileStore(agentDir)?.profiles).toMatchObject({
+      "openai:default": { key: "fake-openai-key" },
+      "anthropic:default": { key: "fake-anthropic-key" },
+    });
   });
 
-  it("propagates async lock release failures", async () => {
-    tmpDir = fs.mkdtempSync(join(tmpdir(), "auth-releasefail-"));
-    const error = new Error("simulated lock release failure");
-    vi.spyOn(lockfile, "lock").mockResolvedValueOnce(() => Promise.reject(error));
-    const storage = new FileAuthStorageBackend(join(tmpDir, "auth.json"));
+  it("never overwrites a store that becomes unreadable before a synchronous write", () => {
+    const agentDir = makeAgentDir();
+    const storage = AuthStorage.forAgent(agentDir);
+    const unreadableStore = { version: 1, profiles: "invalid-profile-map" };
+    writePersistedAuthProfileStoreRaw(unreadableStore, agentDir);
 
-    await expect(storage.withLockAsync(async () => ({ result: undefined }))).rejects.toBe(error);
-  });
-
-  it("throws without changing memory when malformed storage cannot be reloaded", () => {
-    tmpDir = fs.mkdtempSync(join(tmpdir(), "auth-malformed-"));
-    const authPath = join(tmpDir, "auth.json");
-    fs.writeFileSync(authPath, "{invalid-json", "utf-8");
-    const storage = AuthStorage.create(authPath);
-
-    expect(() => storage.set("openai", { type: "api_key", key: "test-token-placeholder" })).toThrow(
-      "Cannot update auth storage because it could not be loaded",
+    expect(() => storage.set("anthropic", { type: "api_key", key: "fake-new-key" })).toThrow(
+      "is unreadable",
     );
-    expect(storage.has("openai")).toBe(false);
-    expect(fs.readFileSync(authPath, "utf-8")).toBe("{invalid-json");
+    expect(readPersistedAuthProfileStoreRaw(agentDir)).toEqual(unreadableStore);
+  });
+
+  it("never overwrites a store that becomes unreadable during an OAuth refresh", async () => {
+    const agentDir = makeAgentDir();
+    writePersistedAuthProfileStoreRaw(
+      {
+        version: 1,
+        profiles: {
+          "test-oauth:default": {
+            type: "oauth",
+            provider: "test-oauth",
+            access: "fake-expired-access",
+            refresh: "fake-refresh",
+            expires: 1,
+          },
+        },
+      },
+      agentDir,
+    );
+    const storage = AuthStorage.forAgent(agentDir);
+    getAuthStorageOAuthProviderRegistry(storage).register({
+      id: "test-oauth",
+      name: "Test OAuth",
+      async login() {
+        throw new Error("not used");
+      },
+      async refreshToken() {
+        return {
+          access: "fake-fresh-access",
+          refresh: "fake-refresh",
+          expires: Date.now() + 60_000,
+        };
+      },
+      getApiKey(credentials: { access: string }) {
+        return credentials.access;
+      },
+    });
+    const unreadableStore = { version: 1, profiles: "invalid-profile-map" };
+    writePersistedAuthProfileStoreRaw(unreadableStore, agentDir);
+
+    await expect(storage.getApiKey("test-oauth")).resolves.toBeUndefined();
+    expect(storage.drainErrors().some((error) => error.message.includes("is unreadable"))).toBe(
+      true,
+    );
+    expect(readPersistedAuthProfileStoreRaw(agentDir)).toEqual(unreadableStore);
+  });
+
+  it("keeps AuthStorage.create(path) as a named SQLite-backed deprecation", () => {
+    const agentDir = makeAgentDir();
+    const legacyPath = path.join(agentDir, "auth.json");
+    const storage = AuthStorage.create(legacyPath);
+    storage.set("openai", { type: "api_key", key: "fake-openai-key" });
+
+    expect(loadPersistedAuthProfileStore(agentDir)?.profiles["openai:default"]).toMatchObject({
+      key: "fake-openai-key",
+    });
+    expect(fs.existsSync(legacyPath)).toBe(false);
+  });
+
+  it("keeps FileAuthStorageBackend as a deprecated SQLite-backed export", () => {
+    const agentDir = makeAgentDir();
+    const legacyPath = path.join(agentDir, "auth.json");
+    const storage = AuthStorage.fromStorage(new FileAuthStorageBackend(legacyPath));
+    storage.set("openai", { type: "api_key", key: "fake-openai-key" });
+
+    expect(loadPersistedAuthProfileStore(agentDir)?.profiles["openai:default"]).toMatchObject({
+      key: "fake-openai-key",
+    });
+    expect(fs.existsSync(legacyPath)).toBe(false);
+  });
+
+  it("reads materialized SecretRefs without persisting their resolved value", async () => {
+    const agentDir = makeAgentDir();
+    const keyRef = { source: "env" as const, provider: "default", id: "OPENAI_API_KEY" };
+    writePersistedAuthProfileStoreRaw(
+      {
+        version: 1,
+        profiles: {
+          "openai:default": { type: "api_key", provider: "openai", keyRef },
+          "xai:default": {
+            type: "token",
+            provider: "xai",
+            tokenRef: { source: "env", provider: "default", id: "XAI_TOKEN" },
+          },
+        },
+      },
+      agentDir,
+    );
+    expect(() => AuthStorage.forAgent(agentDir)).toThrow(
+      "requires the active secrets runtime to materialize SecretRef credentials",
+    );
+    replaceRuntimeAuthProfileStoreSnapshots([
+      {
+        agentDir,
+        store: {
+          version: 1,
+          profiles: {
+            "openai:default": {
+              type: "api_key",
+              provider: "openai",
+              keyRef,
+              key: "fake-materialized-key",
+            },
+            "xai:default": {
+              type: "token",
+              provider: "xai",
+              tokenRef: { source: "env", provider: "default", id: "XAI_TOKEN" },
+              token: "fake-materialized-token",
+            },
+          },
+        },
+      },
+    ]);
+
+    const storage = AuthStorage.forAgent(agentDir);
+    expect(await storage.getApiKey("openai")).toBe("fake-materialized-key");
+    expect(await storage.getApiKey("xai")).toBe("fake-materialized-token");
+    storage.set("anthropic", { type: "api_key", key: "fake-anthropic-key" });
+
+    const persisted = readPersistedAuthProfileStoreRaw(agentDir) as {
+      profiles: Record<string, { key?: string; keyRef?: unknown }>;
+    };
+    expect(persisted).toMatchObject({
+      profiles: {
+        "openai:default": { keyRef },
+      },
+    });
+    expect(persisted.profiles["openai:default"]?.key).toBeUndefined();
+    storage.remove("openai");
+    expect(
+      (readPersistedAuthProfileStoreRaw(agentDir) as { profiles: Record<string, unknown> })
+        .profiles["openai:default"],
+    ).toBeUndefined();
+  });
+
+  it("fails closed before environment fallback when legacy credentials are pending", () => {
+    const agentDir = makeAgentDir();
+    fs.writeFileSync(path.join(agentDir, "auth.json"), '{"openai":{"key":"fake"}}\n');
+
+    expect(() => AuthStorage.forAgent(agentDir)).toThrow("requires legacy credential migration");
+  });
+
+  it("ignores unresolved named profiles outside the provider-default facade", async () => {
+    const agentDir = makeAgentDir();
+    writePersistedAuthProfileStoreRaw(
+      {
+        version: 1,
+        profiles: {
+          "openai:work": {
+            type: "api_key",
+            provider: "openai",
+            keyRef: { source: "env", provider: "default", id: "OPENAI_WORK_KEY" },
+          },
+          "anthropic:default": {
+            type: "api_key",
+            provider: "anthropic",
+            key: "fake-anthropic-key",
+          },
+        },
+      },
+      agentDir,
+    );
+
+    await expect(AuthStorage.forAgent(agentDir).getApiKey("anthropic")).resolves.toBe(
+      "fake-anthropic-key",
+    );
+  });
+
+  it("serializes asynchronous OAuth refreshes across SQLite-backed instances", async () => {
+    const agentDir = makeAgentDir();
+    writePersistedAuthProfileStoreRaw(
+      {
+        version: 1,
+        profiles: {
+          "test-oauth:default": {
+            type: "oauth",
+            provider: "test-oauth",
+            access: "fake-expired-access",
+            refresh: "fake-refresh",
+            expires: 1,
+          },
+        },
+      },
+      agentDir,
+    );
+    const left = AuthStorage.forAgent(agentDir);
+    const right = AuthStorage.forAgent(agentDir);
+    let refreshCalls = 0;
+    let activeRefreshes = 0;
+    let maxActiveRefreshes = 0;
+    const provider = {
+      id: "test-oauth",
+      name: "Test OAuth",
+      async login() {
+        throw new Error("not used");
+      },
+      async refreshToken() {
+        refreshCalls += 1;
+        activeRefreshes += 1;
+        maxActiveRefreshes = Math.max(maxActiveRefreshes, activeRefreshes);
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        activeRefreshes -= 1;
+        return {
+          access: "fake-fresh-access",
+          refresh: "fake-refresh",
+          expires: Date.now() + 60_000,
+        };
+      },
+      getApiKey(credentials: { access: string }) {
+        return credentials.access;
+      },
+    };
+    getAuthStorageOAuthProviderRegistry(left).register(provider);
+    getAuthStorageOAuthProviderRegistry(right).register(provider);
+
+    await expect(
+      Promise.all([left.getApiKey("test-oauth"), right.getApiKey("test-oauth")]),
+    ).resolves.toEqual(["fake-fresh-access", "fake-fresh-access"]);
+    expect(refreshCalls).toBe(1);
+    expect(maxActiveRefreshes).toBe(1);
+  });
+
+  it("falls back to environment auth when a stored token is expired", async () => {
+    const agentDir = makeAgentDir();
+    writePersistedAuthProfileStoreRaw(
+      {
+        version: 1,
+        profiles: {
+          "xai:default": {
+            type: "token",
+            provider: "xai",
+            token: "fake-expired-token",
+            expires: 1,
+          },
+        },
+      },
+      agentDir,
+    );
+    vi.stubEnv("XAI_API_KEY", "fake-environment-key");
+
+    await expect(AuthStorage.forAgent(agentDir).getApiKey("xai")).resolves.toBe(
+      "fake-environment-key",
+    );
   });
 
   it("throws without changing memory when the durable write fails", () => {
@@ -163,7 +340,7 @@ describe("file auth storage", () => {
     };
     const storage = AuthStorage.fromStorage(backend);
 
-    expect(() => storage.set("openai", { type: "api_key", key: "test-token-placeholder" })).toThrow(
+    expect(() => storage.set("openai", { type: "api_key", key: "fake-token" })).toThrow(
       /simulated durable write failure/,
     );
     expect(storage.has("openai")).toBe(false);

--- a/src/agents/sessions/auth-storage.test.ts
+++ b/src/agents/sessions/auth-storage.test.ts
@@ -132,6 +132,51 @@ describe("SQLite auth storage", () => {
     expect(readPersistedAuthProfileStoreRaw(agentDir)).toEqual(unreadableStore);
   });
 
+  it("does not commit a refresh when a legacy source appears during the provider call", async () => {
+    const agentDir = makeAgentDir();
+    writePersistedAuthProfileStoreRaw(
+      {
+        version: 1,
+        profiles: {
+          "test-oauth:default": {
+            type: "oauth",
+            provider: "test-oauth",
+            access: "not-a-real",
+            refresh: "not-a-real",
+            expires: 1,
+          },
+        },
+      },
+      agentDir,
+    );
+    const storage = AuthStorage.forAgent(agentDir);
+    getAuthStorageOAuthProviderRegistry(storage).register({
+      id: "test-oauth",
+      name: "Test OAuth",
+      async login() {
+        throw new Error("not used");
+      },
+      async refreshToken() {
+        fs.writeFileSync(path.join(agentDir, "auth.json"), '{"legacy":true}\n', "utf8");
+        return {
+          access: "not-a-real",
+          refresh: "not-a-real",
+          expires: Date.now() + 60_000,
+        };
+      },
+      getApiKey(credentials: { access: string }) {
+        return credentials.access;
+      },
+    });
+
+    await expect(storage.getApiKey("test-oauth")).rejects.toThrow(
+      "requires legacy credential migration",
+    );
+    expect(loadPersistedAuthProfileStore(agentDir)?.profiles["test-oauth:default"]).toMatchObject({
+      expires: 1,
+    });
+  });
+
   it("keeps AuthStorage.create(path) as a named SQLite-backed deprecation", () => {
     const agentDir = makeAgentDir();
     const legacyPath = path.join(agentDir, "auth.json");

--- a/src/agents/sessions/auth-storage.test.ts
+++ b/src/agents/sessions/auth-storage.test.ts
@@ -226,6 +226,17 @@ describe("SQLite auth storage", () => {
     expect(() => AuthStorage.forAgent(agentDir)).toThrow("requires legacy credential migration");
   });
 
+  it("fails closed when a legacy credential source appears after construction", async () => {
+    const agentDir = makeAgentDir();
+    const storage = AuthStorage.forAgent(agentDir);
+    vi.stubEnv("OPENAI_API_KEY", "fake-environment-key");
+    fs.writeFileSync(path.join(agentDir, "auth.json"), '{"openai":{"key":"fake-late"}}\n');
+
+    await expect(storage.getApiKey("openai")).rejects.toThrow(
+      "requires legacy credential migration",
+    );
+  });
+
   it("ignores unresolved named profiles outside the provider-default facade", async () => {
     const agentDir = makeAgentDir();
     writePersistedAuthProfileStoreRaw(

--- a/src/agents/sessions/auth-storage.test.ts
+++ b/src/agents/sessions/auth-storage.test.ts
@@ -159,6 +159,32 @@ describe("SQLite auth storage", () => {
     );
   });
 
+  it("blocks ambient fallback when the compatibility backend cannot materialize SQLite refs", async () => {
+    const agentDir = makeAgentDir();
+    writePersistedAuthProfileStoreRaw(
+      {
+        version: 1,
+        profiles: {
+          "openai:default": {
+            type: "api_key",
+            provider: "openai",
+            keyRef: { source: "env", provider: "default", id: "OPENAI_STORED_KEY" },
+          },
+        },
+      },
+      agentDir,
+    );
+    vi.stubEnv("OPENAI_API_KEY", "fake-ambient-key");
+
+    const storage = AuthStorage.fromStorage(
+      new FileAuthStorageBackend(path.join(agentDir, "auth.json")),
+    );
+
+    await expect(storage.getApiKey("openai")).rejects.toThrow(
+      "requires the active secrets runtime to materialize SecretRef credentials",
+    );
+  });
+
   it("reads materialized SecretRefs without persisting their resolved value", async () => {
     const agentDir = makeAgentDir();
     const keyRef = { source: "env" as const, provider: "default", id: "OPENAI_API_KEY" };

--- a/src/agents/sessions/auth-storage.test.ts
+++ b/src/agents/sessions/auth-storage.test.ts
@@ -12,6 +12,7 @@ import {
 } from "../auth-profiles/runtime-snapshots.js";
 import {
   readPersistedAuthProfileStoreRaw,
+  writePersistedAuthProfileStateRaw,
   writePersistedAuthProfileStoreRaw,
 } from "../auth-profiles/sqlite.js";
 import { getAuthStorageOAuthProviderRegistry } from "./auth-storage-oauth-registry.js";
@@ -247,6 +248,85 @@ describe("SQLite auth storage", () => {
       (readPersistedAuthProfileStoreRaw(agentDir) as { profiles: Record<string, unknown> })
         .profiles["openai:default"],
     ).toBeUndefined();
+  });
+
+  it("does not reuse a materialized value after its persisted SecretRef changes", async () => {
+    const agentDir = makeAgentDir();
+    const originalRef = { source: "env" as const, provider: "default", id: "QA_AUTH_REF_OLD" };
+    writePersistedAuthProfileStoreRaw(
+      {
+        version: 1,
+        profiles: {
+          "openai:default": { type: "api_key", provider: "openai", keyRef: originalRef },
+        },
+      },
+      agentDir,
+    );
+    replaceRuntimeAuthProfileStoreSnapshots([
+      {
+        agentDir,
+        store: {
+          version: 1,
+          profiles: {
+            "openai:default": {
+              type: "api_key",
+              provider: "openai",
+              keyRef: originalRef,
+              key: "not-a-real",
+            },
+          },
+        },
+      },
+    ]);
+    const storage = AuthStorage.forAgent(agentDir);
+    expect(await storage.getApiKey("openai")).toBe("not-a-real");
+
+    writePersistedAuthProfileStoreRaw(
+      {
+        version: 1,
+        profiles: {
+          "openai:default": {
+            type: "api_key",
+            provider: "openai",
+            keyRef: { source: "env", provider: "default", id: "QA_AUTH_REF_NEW" },
+          },
+        },
+      },
+      agentDir,
+    );
+    clearRuntimeAuthProfileStoreSnapshots();
+    storage.reload();
+
+    await expect(storage.getApiKey("openai")).rejects.toThrow(
+      "requires the active secrets runtime to materialize SecretRef credentials",
+    );
+  });
+
+  it("preserves state-only SQLite rows when adding credentials", () => {
+    const agentDir = makeAgentDir();
+    writePersistedAuthProfileStateRaw(
+      {
+        version: 1,
+        order: { openai: ["openai:default"] },
+        lastGood: { openai: "openai:default" },
+        usageStats: { "openai:default": { cooldownUntil: 1_900_000_000_000 } },
+      },
+      agentDir,
+    );
+
+    AuthStorage.forAgent(agentDir).set("anthropic", {
+      type: "api_key",
+      key: "not-a-real",
+    });
+
+    expect(loadPersistedAuthProfileStore(agentDir)).toMatchObject({
+      profiles: {
+        "anthropic:default": { type: "api_key", provider: "anthropic" },
+      },
+      order: { openai: ["openai:default"] },
+      lastGood: { openai: "openai:default" },
+      usageStats: { "openai:default": { cooldownUntil: 1_900_000_000_000 } },
+    });
   });
 
   it("fails closed before environment fallback when legacy credentials are pending", () => {

--- a/src/agents/sessions/auth-storage.test.ts
+++ b/src/agents/sessions/auth-storage.test.ts
@@ -274,7 +274,9 @@ describe("SQLite auth storage", () => {
         refreshCalls += 1;
         activeRefreshes += 1;
         maxActiveRefreshes = Math.max(maxActiveRefreshes, activeRefreshes);
-        await new Promise((resolve) => setTimeout(resolve, 50));
+        await new Promise((resolve) => {
+          setTimeout(resolve, 50);
+        });
         activeRefreshes -= 1;
         return {
           access: "fake-fresh-access",

--- a/src/agents/sessions/auth-storage.test.ts
+++ b/src/agents/sessions/auth-storage.test.ts
@@ -76,6 +76,16 @@ describe("SQLite auth storage", () => {
     expect(readPersistedAuthProfileStoreRaw(agentDir)).toEqual(unreadableStore);
   });
 
+  it("blocks environment fallback after a canonical store becomes unreadable", async () => {
+    const agentDir = makeAgentDir();
+    const storage = AuthStorage.forAgent(agentDir);
+    writePersistedAuthProfileStoreRaw({ version: 1, profiles: "invalid-profile-map" }, agentDir);
+    vi.stubEnv("OPENAI_API_KEY", "fake-environment-key");
+    storage.reload();
+
+    await expect(storage.getApiKey("openai")).rejects.toThrow("is unreadable");
+  });
+
   it("never overwrites a store that becomes unreadable during an OAuth refresh", async () => {
     const agentDir = makeAgentDir();
     writePersistedAuthProfileStoreRaw(
@@ -114,7 +124,7 @@ describe("SQLite auth storage", () => {
     const unreadableStore = { version: 1, profiles: "invalid-profile-map" };
     writePersistedAuthProfileStoreRaw(unreadableStore, agentDir);
 
-    await expect(storage.getApiKey("test-oauth")).resolves.toBeUndefined();
+    await expect(storage.getApiKey("test-oauth")).rejects.toThrow("is unreadable");
     expect(storage.drainErrors().some((error) => error.message.includes("is unreadable"))).toBe(
       true,
     );

--- a/src/agents/sessions/auth-storage.test.ts
+++ b/src/agents/sessions/auth-storage.test.ts
@@ -316,6 +316,54 @@ describe("SQLite auth storage", () => {
     );
   });
 
+  it("does not reuse prepared materialization when the current snapshot is unresolved", async () => {
+    const agentDir = makeAgentDir();
+    const keyRef = { source: "env" as const, provider: "default", id: "QA_AUTH_REF" };
+    writePersistedAuthProfileStoreRaw(
+      {
+        version: 1,
+        profiles: {
+          "openai:default": { type: "api_key", provider: "openai", keyRef },
+        },
+      },
+      agentDir,
+    );
+    replaceRuntimeAuthProfileStoreSnapshots([
+      {
+        agentDir,
+        store: {
+          version: 1,
+          profiles: {
+            "openai:default": {
+              type: "api_key",
+              provider: "openai",
+              keyRef,
+              key: "not-a-real",
+            },
+          },
+        },
+      },
+    ]);
+    const storage = AuthStorage.forAgent(agentDir);
+    replaceRuntimeAuthProfileStoreSnapshots([
+      {
+        agentDir,
+        store: {
+          version: 1,
+          profiles: {
+            "openai:default": { type: "api_key", provider: "openai", keyRef },
+          },
+        },
+      },
+    ]);
+
+    storage.reload();
+
+    await expect(storage.getApiKey("openai")).rejects.toThrow(
+      "requires the active secrets runtime to materialize SecretRef credentials",
+    );
+  });
+
   it("preserves state-only SQLite rows when adding credentials", () => {
     const agentDir = makeAgentDir();
     writePersistedAuthProfileStateRaw(

--- a/src/agents/sessions/auth-storage.ts
+++ b/src/agents/sessions/auth-storage.ts
@@ -25,10 +25,12 @@ import {
 import { loadPersistedAuthProfileStore } from "../auth-profiles/persisted.js";
 import { getRuntimeAuthProfileStoreSnapshot } from "../auth-profiles/runtime-snapshots.js";
 import {
+  inspectPersistedAuthProfileStateRaw,
   inspectPersistedAuthProfileStoreRaw,
   resolveAuthProfileDatabasePath,
   runAuthProfileWriteTransaction,
 } from "../auth-profiles/sqlite.js";
+import { loadPersistedAuthProfileState } from "../auth-profiles/state.js";
 import {
   loadAuthProfileStoreForSecretsRuntime,
   saveAuthProfileStore,
@@ -141,19 +143,36 @@ function assertAuthStorageSecretRefsMaterialized(store: AuthProfileStore): void 
 
 function projectAuthoritativeAuthStorageData(
   store: AuthProfileStore,
-  runtimeStore: AuthProfileStore | undefined,
+  snapshots: readonly AuthProfileStore[],
 ): AuthStorageData {
-  if (!runtimeStore) {
+  if (snapshots.length === 0) {
     assertAuthStorageSecretRefsMaterialized(store);
     return projectAuthStorageData(store);
   }
   const profiles = Object.fromEntries(
     Object.entries(store.profiles).map(([profileId, credential]) => {
-      const runtimeCredential = runtimeStore.profiles[profileId];
+      const runtimeCredential = snapshots
+        .map((snapshot) => snapshot.profiles[profileId])
+        .find((candidate) =>
+          credential.type === "api_key" && credential.keyRef
+            ? candidate?.type === "api_key" &&
+              Boolean(candidate.key) &&
+              candidate.provider === credential.provider &&
+              isDeepStrictEqual(candidate.keyRef, credential.keyRef)
+            : credential.type === "token" && credential.tokenRef
+              ? candidate?.type === "token" &&
+                Boolean(candidate.token) &&
+                candidate.provider === credential.provider &&
+                isDeepStrictEqual(candidate.tokenRef, credential.tokenRef)
+              : false,
+        );
       const needsMaterializedRef =
         (credential.type === "api_key" && Boolean(credential.keyRef)) ||
         (credential.type === "token" && Boolean(credential.tokenRef));
-      return [profileId, needsMaterializedRef ? (runtimeCredential ?? credential) : credential];
+      return [
+        profileId,
+        needsMaterializedRef && runtimeCredential ? runtimeCredential : credential,
+      ];
     }),
   );
   const materialized = { ...store, profiles };
@@ -211,13 +230,30 @@ function applyAuthStorageData(
   return { ...store, profiles };
 }
 
+function collectStateOnlyAuthProfileIds(store: AuthProfileStore): string[] {
+  const referenced = new Set([
+    ...Object.values(store.order ?? {}).flat(),
+    ...Object.values(store.lastGood ?? {}),
+    ...Object.keys(store.usageStats ?? {}),
+  ]);
+  return [...referenced].filter((profileId) => !store.profiles[profileId]);
+}
+
 function loadSqliteAuthStorageStore(
   agentDir: string,
   database?: OpenClawAgentDatabase,
 ): AuthProfileStore {
   const inspection = inspectPersistedAuthProfileStoreRaw(agentDir, database);
   if (inspection.status === "missing") {
-    return { version: AUTH_STORE_VERSION, profiles: {} };
+    const stateInspection = inspectPersistedAuthProfileStateRaw(agentDir, database);
+    if (stateInspection.status === "unreadable") {
+      throw new AuthProfileStoreUnreadableError(agentDir);
+    }
+    return {
+      version: AUTH_STORE_VERSION,
+      profiles: {},
+      ...loadPersistedAuthProfileState(agentDir, database),
+    };
   }
   const store = loadPersistedAuthProfileStore(agentDir, database ? { database } : undefined);
   if (inspection.status === "unreadable" || !store) {
@@ -229,8 +265,16 @@ function loadSqliteAuthStorageStore(
 class SqliteAuthStorageBackend implements AuthStorageBackend {
   constructor(
     private readonly agentDir: string,
-    private readonly preparedStore?: AuthProfileStore,
+    private preparedStore?: AuthProfileStore,
   ) {}
+
+  private resolveMaterializedRuntimeStores(): AuthProfileStore[] {
+    // A current lifecycle snapshot always wins. The prepared snapshot remains
+    // safe only while its SecretRefs still exactly match persisted rows.
+    return [getRuntimeAuthProfileStoreSnapshot(this.agentDir), this.preparedStore].filter(
+      (store): store is AuthProfileStore => store !== undefined,
+    );
+  }
 
   private readRaw(): AuthProfileStore {
     assertAuthProfileMigrationReady(this.agentDir);
@@ -239,10 +283,10 @@ class SqliteAuthStorageBackend implements AuthStorageBackend {
 
   withLock<T>(fn: (current: string | undefined) => LockResult<T>): T {
     assertAuthProfileMigrationReady(this.agentDir);
-    const runtimeStore = this.preparedStore ?? getRuntimeAuthProfileStoreSnapshot(this.agentDir);
+    const snapshots = this.resolveMaterializedRuntimeStores();
     return runAuthProfileWriteTransaction(this.agentDir, (database) => {
       const store = loadSqliteAuthStorageStore(this.agentDir, database);
-      const materializedData = projectAuthoritativeAuthStorageData(store, runtimeStore);
+      const materializedData = projectAuthoritativeAuthStorageData(store, snapshots);
       const { result, next } = fn(JSON.stringify(materializedData));
       if (next !== undefined) {
         saveAuthProfileStore(
@@ -250,6 +294,7 @@ class SqliteAuthStorageBackend implements AuthStorageBackend {
           this.agentDir,
           {
             filterExternalAuthProfiles: false,
+            preserveStateProfileIds: collectStateOnlyAuthProfileIds(store),
             syncExternalCli: false,
           },
           database,
@@ -268,7 +313,7 @@ class SqliteAuthStorageBackend implements AuthStorageBackend {
         const initialRaw = this.readRaw();
         const initialData = projectAuthoritativeAuthStorageData(
           initialRaw,
-          this.preparedStore ?? getRuntimeAuthProfileStoreSnapshot(this.agentDir),
+          this.resolveMaterializedRuntimeStores(),
         );
         const { result, next } = await fn(JSON.stringify(initialData));
         if (next === undefined) {
@@ -285,7 +330,11 @@ class SqliteAuthStorageBackend implements AuthStorageBackend {
           saveAuthProfileStore(
             applyAuthStorageData(authoritative, JSON.parse(next) as AuthStorageData, initialData),
             this.agentDir,
-            { filterExternalAuthProfiles: false, syncExternalCli: false },
+            {
+              filterExternalAuthProfiles: false,
+              preserveStateProfileIds: collectStateOnlyAuthProfileIds(authoritative),
+              syncExternalCli: false,
+            },
             database,
           );
         });

--- a/src/agents/sessions/auth-storage.ts
+++ b/src/agents/sessions/auth-storage.ts
@@ -428,6 +428,17 @@ export class AuthStorage {
     this.errors.push(normalizedError);
   }
 
+  private getCanonicalLoadError(): Error | null {
+    if (!this.loadError) {
+      return null;
+    }
+    return this.migrationOwnerAgentDir ||
+      this.loadError instanceof AuthProfileMigrationRequiredError ||
+      this.loadError instanceof AuthProfileStoreUnreadableError
+      ? this.loadError
+      : null;
+  }
+
   private parseStorageData(content: string | undefined): AuthStorageData {
     if (!content) {
       return {};
@@ -681,13 +692,11 @@ export class AuthStorage {
       assertAuthProfileMigrationReady(this.migrationOwnerAgentDir);
     }
 
-    if (
-      this.loadError instanceof AuthProfileMigrationRequiredError ||
-      this.loadError instanceof AuthProfileStoreUnreadableError
-    ) {
+    const canonicalLoadError = this.getCanonicalLoadError();
+    if (canonicalLoadError) {
       // Canonical-store ownership blocks implicit env/config fallback. An
       // explicit runtime override above remains the only caller-owned escape.
-      throw this.loadError;
+      throw canonicalLoadError;
     }
 
     const cred = this.data[providerId];
@@ -727,11 +736,8 @@ export class AuthStorage {
             error instanceof AuthProfileMigrationRequiredError ||
             error instanceof AuthProfileStoreUnreadableError
               ? error
-              : this.loadError;
-          if (
-            canonicalStoreError instanceof AuthProfileMigrationRequiredError ||
-            canonicalStoreError instanceof AuthProfileStoreUnreadableError
-          ) {
+              : this.getCanonicalLoadError();
+          if (canonicalStoreError) {
             throw canonicalStoreError;
           }
           const updatedCred = this.data[providerId];

--- a/src/agents/sessions/auth-storage.ts
+++ b/src/agents/sessions/auth-storage.ts
@@ -1,25 +1,41 @@
 /**
- * Credential storage for API keys and OAuth tokens.
- * Handles loading, saving, and refreshing credentials from auth.json.
+ * Credential storage facade for API keys and OAuth tokens.
+ * Canonical persistence is the per-agent SQLite auth-profile store.
  *
- * Uses file locking to prevent race conditions when multiple agent sessions
- * try to refresh tokens simultaneously.
+ * The backend contract keeps the upstream session SDK shape while OpenClaw
+ * projects provider-default profiles into it.
  */
 
-import { chmodSync, existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { dirname } from "node:path";
+import { isDeepStrictEqual } from "node:util";
 import { findEnvKeys, getEnvApiKey } from "@openclaw/ai/internal/runtime";
-import lockfile from "proper-lockfile";
-import { replaceFileAtomicSync } from "../../infra/replace-file.js";
+import { withFileLock } from "../../infra/file-lock.js";
 import type {
   OAuthCredentials,
   OAuthLoginCallbacks,
   OAuthProviderId,
 } from "../../llm/utils/oauth/types.js";
+import type { OpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
+import { AUTH_STORE_VERSION, OAUTH_REFRESH_LOCK_OPTIONS } from "../auth-profiles/constants.js";
+import {
+  assertAuthProfileMigrationReady,
+  AuthProfileStoreUnreadableError,
+} from "../auth-profiles/legacy-source-diagnostic.js";
+import { loadPersistedAuthProfileStore } from "../auth-profiles/persisted.js";
+import { getRuntimeAuthProfileStoreSnapshot } from "../auth-profiles/runtime-snapshots.js";
+import {
+  inspectPersistedAuthProfileStoreRaw,
+  resolveAuthProfileDatabasePath,
+  runAuthProfileWriteTransaction,
+} from "../auth-profiles/sqlite.js";
+import {
+  loadAuthProfileStoreForSecretsRuntime,
+  saveAuthProfileStore,
+} from "../auth-profiles/store.js";
+import type { AuthProfileStore } from "../auth-profiles/types.js";
 import { getAgentDir } from "../config.js";
 import { getAuthStorageOAuthProviderRegistry } from "./auth-storage-oauth-registry.js";
 import { resolveConfigValue } from "./resolve-config-value.js";
-import { acquireLockSyncWithRetry } from "./storage-lock.js";
 
 export type ApiKeyCredential = {
   type: "api_key";
@@ -30,9 +46,29 @@ export type OAuthCredential = {
   type: "oauth";
 } & OAuthCredentials;
 
-export type AuthCredential = ApiKeyCredential | OAuthCredential;
+export type TokenCredential = {
+  type: "token";
+  token: string;
+  expires?: number;
+};
+
+export type AuthCredential = ApiKeyCredential | OAuthCredential | TokenCredential;
 
 export type AuthStorageData = Record<string, AuthCredential>;
+export const AUTH_STORAGE_CREATE_DEPRECATION_CODE = "AUTH_STORAGE_CREATE_DEPRECATED" as const;
+export const FILE_AUTH_STORAGE_BACKEND_DEPRECATION_CODE =
+  "FILE_AUTH_STORAGE_BACKEND_DEPRECATED" as const;
+let authStorageCreateWarningEmitted = false;
+let fileAuthStorageBackendWarningEmitted = false;
+
+function emitAuthStorageDeprecationWarning(params: {
+  message: string;
+  code:
+    | typeof AUTH_STORAGE_CREATE_DEPRECATION_CODE
+    | typeof FILE_AUTH_STORAGE_BACKEND_DEPRECATION_CODE;
+}): void {
+  process.emitWarning(params.message, { code: params.code, type: "DeprecationWarning" });
+}
 
 class AuthStoragePersistenceError extends Error {
   constructor(message: string, cause: unknown) {
@@ -63,88 +99,226 @@ export interface AuthStorageBackend {
   withLockAsync<T>(fn: (current: string | undefined) => Promise<LockResult<T>>): Promise<T>;
 }
 
-export class FileAuthStorageBackend implements AuthStorageBackend {
-  private authPath: string;
-
-  constructor(authPath: string = join(getAgentDir(), "auth.json")) {
-    this.authPath = authPath;
-  }
-
-  private ensureParentDir(): void {
-    const dir = dirname(this.authPath);
-    if (!existsSync(dir)) {
-      mkdirSync(dir, { recursive: true, mode: 0o700 });
+function projectAuthStorageData(store: AuthProfileStore | null): AuthStorageData {
+  const projected: AuthStorageData = {};
+  for (const [profileId, credential] of Object.entries(store?.profiles ?? {})) {
+    if (profileId !== `${credential.provider}:default`) {
+      continue;
+    }
+    if (credential.type === "api_key" && credential.key) {
+      projected[credential.provider] = { type: "api_key", key: credential.key };
+    } else if (credential.type === "token" && credential.token) {
+      projected[credential.provider] = {
+        type: "token",
+        token: credential.token,
+        ...(credential.expires !== undefined ? { expires: credential.expires } : {}),
+      };
+    } else if (credential.type === "oauth") {
+      projected[credential.provider] = { ...credential };
     }
   }
+  return projected;
+}
 
-  private ensureFileExists(): void {
-    if (!existsSync(this.authPath)) {
-      writeFileSync(this.authPath, "{}", "utf-8");
-      chmodSync(this.authPath, 0o600);
+function assertAuthStorageSecretRefsMaterialized(store: AuthProfileStore): void {
+  for (const [profileId, credential] of Object.entries(store.profiles)) {
+    if (profileId !== `${credential.provider}:default`) {
+      continue;
+    }
+    if (
+      (credential.type === "api_key" && credential.keyRef && !credential.key) ||
+      (credential.type === "token" && credential.tokenRef && !credential.token)
+    ) {
+      throw new AuthStoragePersistenceError(
+        "AuthStorage.forAgent requires the active secrets runtime to materialize SecretRef credentials.",
+        undefined,
+      );
     }
   }
+}
 
-  private replaceAuthFileAtomic(content: string): void {
-    const dirMode = statSync(dirname(this.authPath)).mode & 0o7777;
-    replaceFileAtomicSync({
-      filePath: this.authPath,
-      content,
-      dirMode,
-      mode: 0o600,
-      tempPrefix: "auth.json",
-      syncTempFile: true,
-      syncParentDir: true,
-    });
+function projectAuthoritativeAuthStorageData(
+  store: AuthProfileStore,
+  runtimeStore: AuthProfileStore | undefined,
+): AuthStorageData {
+  if (!runtimeStore) {
+    assertAuthStorageSecretRefsMaterialized(store);
+    return projectAuthStorageData(store);
+  }
+  const profiles = Object.fromEntries(
+    Object.entries(store.profiles).map(([profileId, credential]) => {
+      const runtimeCredential = runtimeStore.profiles[profileId];
+      const needsMaterializedRef =
+        (credential.type === "api_key" && Boolean(credential.keyRef)) ||
+        (credential.type === "token" && Boolean(credential.tokenRef));
+      return [profileId, needsMaterializedRef ? (runtimeCredential ?? credential) : credential];
+    }),
+  );
+  const materialized = { ...store, profiles };
+  assertAuthStorageSecretRefsMaterialized(materialized);
+  return projectAuthStorageData(materialized);
+}
+
+function applyAuthStorageData(
+  store: AuthProfileStore,
+  data: AuthStorageData,
+  materializedBaseline: AuthStorageData,
+): AuthProfileStore {
+  const profiles = { ...store.profiles };
+  const projectedProviders = new Set([
+    ...Object.keys(materializedBaseline),
+    ...Object.entries(store.profiles).flatMap(([profileId, credential]) =>
+      profileId === `${credential.provider}:default` ? [credential.provider] : [],
+    ),
+  ]);
+  for (const provider of projectedProviders) {
+    if (!data[provider]) {
+      delete profiles[`${provider}:default`];
+    }
+  }
+  for (const [provider, credential] of Object.entries(data)) {
+    const profileId = `${provider}:default`;
+    const existing = profiles[profileId];
+    if (
+      credential.type === "api_key" &&
+      existing?.type === "api_key" &&
+      existing.keyRef &&
+      materializedBaseline[provider]?.type === "api_key" &&
+      materializedBaseline[provider].key === credential.key
+    ) {
+      profiles[profileId] = existing;
+      continue;
+    }
+    if (
+      credential.type === "token" &&
+      existing?.type === "token" &&
+      existing.tokenRef &&
+      materializedBaseline[provider]?.type === "token" &&
+      materializedBaseline[provider].token === credential.token
+    ) {
+      profiles[profileId] = existing;
+      continue;
+    }
+    profiles[profileId] =
+      credential.type === "api_key"
+        ? { type: "api_key", provider, key: credential.key }
+        : credential.type === "token"
+          ? { type: "token", provider, token: credential.token, expires: credential.expires }
+          : { ...credential, provider };
+  }
+  return { ...store, profiles };
+}
+
+function loadSqliteAuthStorageStore(
+  agentDir: string,
+  database?: OpenClawAgentDatabase,
+): AuthProfileStore {
+  const inspection = inspectPersistedAuthProfileStoreRaw(agentDir, database);
+  if (inspection.status === "missing") {
+    return { version: AUTH_STORE_VERSION, profiles: {} };
+  }
+  const store = loadPersistedAuthProfileStore(agentDir, database ? { database } : undefined);
+  if (inspection.status === "unreadable" || !store) {
+    throw new AuthProfileStoreUnreadableError(agentDir);
+  }
+  return store;
+}
+
+class SqliteAuthStorageBackend implements AuthStorageBackend {
+  constructor(
+    private readonly agentDir: string,
+    private readonly preparedStore?: AuthProfileStore,
+  ) {}
+
+  private readRaw(): AuthProfileStore {
+    assertAuthProfileMigrationReady(this.agentDir);
+    return loadSqliteAuthStorageStore(this.agentDir);
   }
 
   withLock<T>(fn: (current: string | undefined) => LockResult<T>): T {
-    this.ensureParentDir();
-    this.ensureFileExists();
-
-    const release = acquireLockSyncWithRetry(this.authPath);
-    try {
-      const current = existsSync(this.authPath) ? readFileSync(this.authPath, "utf-8") : undefined;
-      const { result, next } = fn(current);
+    assertAuthProfileMigrationReady(this.agentDir);
+    const runtimeStore = this.preparedStore ?? getRuntimeAuthProfileStoreSnapshot(this.agentDir);
+    return runAuthProfileWriteTransaction(this.agentDir, (database) => {
+      const store = loadSqliteAuthStorageStore(this.agentDir, database);
+      const materializedData = projectAuthoritativeAuthStorageData(store, runtimeStore);
+      const { result, next } = fn(JSON.stringify(materializedData));
       if (next !== undefined) {
-        this.replaceAuthFileAtomic(next);
+        saveAuthProfileStore(
+          applyAuthStorageData(store, JSON.parse(next) as AuthStorageData, materializedData),
+          this.agentDir,
+          {
+            filterExternalAuthProfiles: false,
+            syncExternalCli: false,
+          },
+          database,
+        );
       }
       return result;
-    } finally {
-      release();
-    }
+    });
   }
 
   async withLockAsync<T>(fn: (current: string | undefined) => Promise<LockResult<T>>): Promise<T> {
-    this.ensureParentDir();
-    this.ensureFileExists();
+    assertAuthProfileMigrationReady(this.agentDir);
+    return await withFileLock(
+      resolveAuthProfileDatabasePath(this.agentDir),
+      OAUTH_REFRESH_LOCK_OPTIONS,
+      async () => {
+        const initialRaw = this.readRaw();
+        const initialData = projectAuthoritativeAuthStorageData(
+          initialRaw,
+          this.preparedStore ?? getRuntimeAuthProfileStoreSnapshot(this.agentDir),
+        );
+        const { result, next } = await fn(JSON.stringify(initialData));
+        if (next === undefined) {
+          return result;
+        }
+        runAuthProfileWriteTransaction(this.agentDir, (database) => {
+          const authoritative = loadSqliteAuthStorageStore(this.agentDir, database);
+          if (!isDeepStrictEqual(authoritative.profiles, initialRaw.profiles)) {
+            throw new AuthStoragePersistenceError(
+              "Cannot update auth storage because its SQLite credentials changed concurrently.",
+              undefined,
+            );
+          }
+          saveAuthProfileStore(
+            applyAuthStorageData(authoritative, JSON.parse(next) as AuthStorageData, initialData),
+            this.agentDir,
+            { filterExternalAuthProfiles: false, syncExternalCli: false },
+            database,
+          );
+        });
+        return result;
+      },
+    );
+  }
+}
 
-    let lockCompromisedError: Error | undefined;
-    const release = await lockfile.lock(this.authPath, {
-      retries: {
-        minTimeout: 100,
-        maxTimeout: 10000,
-        randomize: true,
-      },
-      stale: 30000,
-      onCompromised: (err) => {
-        lockCompromisedError = err;
-      },
-    });
-    try {
-      const current = existsSync(this.authPath) ? readFileSync(this.authPath, "utf-8") : undefined;
-      const { result, next } = await fn(current);
-      if (lockCompromisedError) {
-        throw lockCompromisedError;
-      }
-      if (next !== undefined) {
-        this.replaceAuthFileAtomic(next);
-      }
-      return result;
-    } finally {
-      if (!lockCompromisedError) {
-        await release();
-      }
+/**
+ * @deprecated Use AuthStorage.forAgent(agentDir). This compatibility adapter
+ * derives the owning agent directory from the old path and persists only to SQLite.
+ * It is eligible for removal after 2026-10-01 and a clean published-plugin sweep.
+ */
+export class FileAuthStorageBackend implements AuthStorageBackend {
+  private readonly delegate: SqliteAuthStorageBackend;
+
+  constructor(authPath?: string) {
+    if (!fileAuthStorageBackendWarningEmitted) {
+      fileAuthStorageBackendWarningEmitted = true;
+      emitAuthStorageDeprecationWarning({
+        code: FILE_AUTH_STORAGE_BACKEND_DEPRECATION_CODE,
+        message:
+          "FileAuthStorageBackend(path) is deprecated; use AuthStorage.forAgent(agentDir). The compatibility adapter persists to SQLite and never reads or writes auth.json.",
+      });
     }
+    this.delegate = new SqliteAuthStorageBackend(authPath ? dirname(authPath) : getAgentDir());
+  }
+
+  withLock<T>(fn: (current: string | undefined) => LockResult<T>): T {
+    return this.delegate.withLock(fn);
+  }
+
+  async withLockAsync<T>(fn: (current: string | undefined) => Promise<LockResult<T>>): Promise<T> {
+    return await this.delegate.withLockAsync(fn);
   }
 }
 
@@ -169,7 +343,7 @@ export class InMemoryAuthStorageBackend implements AuthStorageBackend {
 }
 
 /**
- * Credential storage backed by a JSON file.
+ * Provider-keyed credential facade backed by the canonical auth-profile store.
  */
 export class AuthStorage {
   private data: AuthStorageData = {};
@@ -184,10 +358,30 @@ export class AuthStorage {
     this.reload();
   }
 
+  static forAgent(agentDir: string = getAgentDir()): AuthStorage {
+    assertAuthProfileMigrationReady(agentDir);
+    const preparedStore =
+      getRuntimeAuthProfileStoreSnapshot(agentDir) ??
+      loadAuthProfileStoreForSecretsRuntime(agentDir);
+    assertAuthStorageSecretRefsMaterialized(preparedStore);
+    return new AuthStorage(new SqliteAuthStorageBackend(agentDir, preparedStore));
+  }
+
+  /**
+   * @deprecated Use AuthStorage.forAgent(agentDir). The path-taking compatibility
+   * form is eligible for removal after 2026-10-01 and a clean published-plugin
+   * reader sweep; it no longer reads or writes JSON.
+   */
   static create(authPath?: string): AuthStorage {
-    return new AuthStorage(
-      new FileAuthStorageBackend(authPath ?? join(getAgentDir(), "auth.json")),
-    );
+    if (!authStorageCreateWarningEmitted) {
+      authStorageCreateWarningEmitted = true;
+      emitAuthStorageDeprecationWarning({
+        code: AUTH_STORAGE_CREATE_DEPRECATION_CODE,
+        message:
+          "AuthStorage.create(path) is deprecated; use AuthStorage.forAgent(agentDir). The compatibility adapter persists to SQLite and never reads or writes auth.json.",
+      });
+    }
+    return AuthStorage.forAgent(authPath ? dirname(authPath) : getAgentDir());
   }
 
   static fromStorage(storage: AuthStorageBackend): AuthStorage {
@@ -481,6 +675,12 @@ export class AuthStorage {
 
     if (cred?.type === "api_key") {
       return resolveConfigValue(cred.key);
+    }
+
+    if (cred?.type === "token") {
+      if (cred.expires === undefined || Date.now() < cred.expires) {
+        return resolveConfigValue(cred.token);
+      }
     }
 
     if (cred?.type === "oauth") {

--- a/src/agents/sessions/auth-storage.ts
+++ b/src/agents/sessions/auth-storage.ts
@@ -290,11 +290,10 @@ class SqliteAuthStorageBackend implements AuthStorageBackend {
   ) {}
 
   private resolveMaterializedRuntimeStores(): AuthProfileStore[] {
-    // A current lifecycle snapshot always wins. The prepared snapshot remains
-    // safe only while its SecretRefs still exactly match persisted rows.
-    return [getRuntimeAuthProfileStoreSnapshot(this.agentDir), this.preparedStore].filter(
-      (store): store is AuthProfileStore => store !== undefined,
-    );
+    const current = getRuntimeAuthProfileStoreSnapshot(this.agentDir);
+    // A current lifecycle snapshot is authoritative, including an unresolved
+    // ref after failed/revoked secrets reload. Prepared data is bootstrap-only.
+    return current ? [current] : this.preparedStore ? [this.preparedStore] : [];
   }
 
   private readRaw(): AuthProfileStore {

--- a/src/agents/sessions/auth-storage.ts
+++ b/src/agents/sessions/auth-storage.ts
@@ -19,6 +19,7 @@ import type { OpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
 import { AUTH_STORE_VERSION, OAUTH_REFRESH_LOCK_OPTIONS } from "../auth-profiles/constants.js";
 import {
   assertAuthProfileMigrationReady,
+  AuthProfileMigrationRequiredError,
   AuthProfileStoreUnreadableError,
 } from "../auth-profiles/legacy-source-diagnostic.js";
 import { loadPersistedAuthProfileStore } from "../auth-profiles/persisted.js";
@@ -671,6 +672,15 @@ export class AuthStorage {
       return runtimeKey;
     }
 
+    if (
+      this.loadError instanceof AuthProfileMigrationRequiredError ||
+      this.loadError instanceof AuthProfileStoreUnreadableError
+    ) {
+      // Canonical-store ownership blocks implicit env/config fallback. An
+      // explicit runtime override above remains the only caller-owned escape.
+      throw this.loadError;
+    }
+
     const cred = this.data[providerId];
 
     if (cred?.type === "api_key") {
@@ -704,6 +714,17 @@ export class AuthStorage {
           this.recordError(error);
           // Refresh failed - re-read file to check if another instance succeeded
           this.reload();
+          const canonicalStoreError =
+            error instanceof AuthProfileMigrationRequiredError ||
+            error instanceof AuthProfileStoreUnreadableError
+              ? error
+              : this.loadError;
+          if (
+            canonicalStoreError instanceof AuthProfileMigrationRequiredError ||
+            canonicalStoreError instanceof AuthProfileStoreUnreadableError
+          ) {
+            throw canonicalStoreError;
+          }
           const updatedCred = this.data[providerId];
 
           if (updatedCred?.type === "oauth" && Date.now() < updatedCred.expires) {

--- a/src/agents/sessions/auth-storage.ts
+++ b/src/agents/sessions/auth-storage.ts
@@ -23,6 +23,7 @@ import {
   AuthProfileMigrationRequiredError,
   AuthProfileStoreUnreadableError,
 } from "../auth-profiles/legacy-source-diagnostic.js";
+import { resolveOAuthRefreshLockPath } from "../auth-profiles/paths.js";
 import { loadPersistedAuthProfileStore } from "../auth-profiles/persisted.js";
 import { getRuntimeAuthProfileStoreSnapshot } from "../auth-profiles/runtime-snapshots.js";
 import {
@@ -304,6 +305,7 @@ class SqliteAuthStorageBackend implements AuthStorageBackend {
   withLock<T>(fn: (current: string | undefined) => LockResult<T>): T {
     assertAuthProfileMigrationReady(this.agentDir);
     const snapshots = this.resolveMaterializedRuntimeStores();
+    assertAuthProfileMigrationReady(this.agentDir);
     return runAuthProfileWriteTransaction(this.agentDir, (database) => {
       const store = loadSqliteAuthStorageStore(this.agentDir, database);
       const materializedData = projectAuthoritativeAuthStorageData(store, snapshots);
@@ -339,6 +341,7 @@ class SqliteAuthStorageBackend implements AuthStorageBackend {
         if (next === undefined) {
           return result;
         }
+        assertAuthProfileMigrationReady(this.agentDir);
         runAuthProfileWriteTransaction(this.agentDir, (database) => {
           const authoritative = loadSqliteAuthStorageStore(this.agentDir, database);
           if (!isDeepStrictEqual(authoritative.profiles, initialRaw.profiles)) {
@@ -699,43 +702,52 @@ export class AuthStorage {
       return null;
     }
 
-    const result = await this.storage.withLockAsync(async (current) => {
-      const currentData = this.parseStorageData(current);
-      this.data = currentData;
-      this.loadError = null;
+    const refresh = async () =>
+      await this.storage.withLockAsync(async (current) => {
+        const currentData = this.parseStorageData(current);
+        this.data = currentData;
+        this.loadError = null;
 
-      const cred = currentData[providerId];
-      if (cred?.type !== "oauth") {
-        return { result: null };
-      }
-
-      if (Date.now() < cred.expires) {
-        return { result: { apiKey: provider.getApiKey(cred), newCredentials: cred } };
-      }
-
-      const oauthCreds: Record<string, OAuthCredentials> = {};
-      for (const [key, value] of Object.entries(currentData)) {
-        if (value.type === "oauth") {
-          oauthCreds[key] = value;
+        const cred = currentData[providerId];
+        if (cred?.type !== "oauth") {
+          return { result: null };
         }
-      }
 
-      const refreshed = await getAuthStorageOAuthProviderRegistry(this).getApiKey(
-        providerId,
-        oauthCreds,
-      );
-      if (!refreshed) {
-        return { result: null };
-      }
+        if (Date.now() < cred.expires) {
+          return { result: { apiKey: provider.getApiKey(cred), newCredentials: cred } };
+        }
 
-      const merged: AuthStorageData = {
-        ...currentData,
-        [providerId]: { type: "oauth", ...refreshed.newCredentials },
-      };
-      this.data = merged;
-      this.loadError = null;
-      return { result: refreshed, next: JSON.stringify(merged, null, 2) };
-    });
+        const oauthCreds: Record<string, OAuthCredentials> = {};
+        for (const [key, value] of Object.entries(currentData)) {
+          if (value.type === "oauth") {
+            oauthCreds[key] = value;
+          }
+        }
+
+        const refreshed = await getAuthStorageOAuthProviderRegistry(this).getApiKey(
+          providerId,
+          oauthCreds,
+        );
+        if (!refreshed) {
+          return { result: null };
+        }
+
+        const merged: AuthStorageData = {
+          ...currentData,
+          [providerId]: { type: "oauth", ...refreshed.newCredentials },
+        };
+        this.data = merged;
+        this.loadError = null;
+        return { result: refreshed, next: JSON.stringify(merged, null, 2) };
+      });
+
+    const result = this.migrationOwnerAgentDir
+      ? await withFileLock(
+          resolveOAuthRefreshLockPath(providerId, `${providerId}:default`),
+          OAUTH_REFRESH_LOCK_OPTIONS,
+          refresh,
+        )
+      : await refresh();
 
     return result;
   }

--- a/src/agents/sessions/auth-storage.ts
+++ b/src/agents/sessions/auth-storage.ts
@@ -96,6 +96,7 @@ type LockResult<T> = {
 };
 
 export interface AuthStorageBackend {
+  readonly migrationOwnerAgentDir?: string;
   withLock<T>(fn: (current: string | undefined) => LockResult<T>): T;
   withLockAsync<T>(fn: (current: string | undefined) => Promise<LockResult<T>>): Promise<T>;
 }
@@ -301,6 +302,7 @@ class SqliteAuthStorageBackend implements AuthStorageBackend {
  */
 export class FileAuthStorageBackend implements AuthStorageBackend {
   private readonly delegate: SqliteAuthStorageBackend;
+  readonly migrationOwnerAgentDir: string;
 
   constructor(authPath?: string) {
     if (!fileAuthStorageBackendWarningEmitted) {
@@ -311,7 +313,8 @@ export class FileAuthStorageBackend implements AuthStorageBackend {
           "FileAuthStorageBackend(path) is deprecated; use AuthStorage.forAgent(agentDir). The compatibility adapter persists to SQLite and never reads or writes auth.json.",
       });
     }
-    this.delegate = new SqliteAuthStorageBackend(authPath ? dirname(authPath) : getAgentDir());
+    this.migrationOwnerAgentDir = authPath ? dirname(authPath) : getAgentDir();
+    this.delegate = new SqliteAuthStorageBackend(this.migrationOwnerAgentDir);
   }
 
   withLock<T>(fn: (current: string | undefined) => LockResult<T>): T {
@@ -357,7 +360,7 @@ export class AuthStorage {
 
   private constructor(storage: AuthStorageBackend, migrationOwnerAgentDir?: string) {
     this.storage = storage;
-    this.migrationOwnerAgentDir = migrationOwnerAgentDir;
+    this.migrationOwnerAgentDir = migrationOwnerAgentDir ?? storage.migrationOwnerAgentDir;
     this.reload();
   }
 

--- a/src/agents/sessions/auth-storage.ts
+++ b/src/agents/sessions/auth-storage.ts
@@ -6,6 +6,7 @@
  * projects provider-default profiles into it.
  */
 
+import fs from "node:fs";
 import { dirname } from "node:path";
 import { isDeepStrictEqual } from "node:util";
 import { findEnvKeys, getEnvApiKey } from "@openclaw/ai/internal/runtime";
@@ -77,6 +78,26 @@ class AuthStoragePersistenceError extends Error {
   constructor(message: string, cause: unknown) {
     super(message, { cause });
     this.name = "AuthStoragePersistenceError";
+  }
+}
+
+class AuthStorageLegacyPathMigrationRequiredError extends Error {
+  readonly code = "AUTH_PROFILE_MIGRATION_REQUIRED" as const;
+  readonly action = "migrate to AuthStorage.forAgent(agentDir)" as const;
+
+  constructor() {
+    super(
+      "Deprecated AuthStorage path contains unmigrated credentials; run openclaw doctor --fix for standard agent auth.json or migrate plugin storage to AuthStorage.forAgent(agentDir).",
+    );
+    this.name = "AuthStorageLegacyPathMigrationRequiredError";
+  }
+}
+
+function assertDeprecatedAuthStoragePathAbsent(authPath: string | undefined): void {
+  // Deprecated adapters use this path only to derive the SQLite owner and
+  // never create or write it. An existing file is therefore unmigrated input.
+  if (authPath && fs.existsSync(authPath)) {
+    throw new AuthStorageLegacyPathMigrationRequiredError();
   }
 }
 
@@ -362,6 +383,7 @@ export class FileAuthStorageBackend implements AuthStorageBackend {
           "FileAuthStorageBackend(path) is deprecated; use AuthStorage.forAgent(agentDir). The compatibility adapter persists to SQLite and never reads or writes auth.json.",
       });
     }
+    assertDeprecatedAuthStoragePathAbsent(authPath);
     this.migrationOwnerAgentDir = authPath ? dirname(authPath) : getAgentDir();
     this.delegate = new SqliteAuthStorageBackend(this.migrationOwnerAgentDir);
   }
@@ -436,6 +458,7 @@ export class AuthStorage {
           "AuthStorage.create(path) is deprecated; use AuthStorage.forAgent(agentDir). The compatibility adapter persists to SQLite and never reads or writes auth.json.",
       });
     }
+    assertDeprecatedAuthStoragePathAbsent(authPath);
     return AuthStorage.forAgent(authPath ? dirname(authPath) : getAgentDir());
   }
 

--- a/src/agents/sessions/auth-storage.ts
+++ b/src/agents/sessions/auth-storage.ts
@@ -353,9 +353,11 @@ export class AuthStorage {
   private loadError: Error | null = null;
   private errors: Error[] = [];
   private storage: AuthStorageBackend;
+  private migrationOwnerAgentDir?: string;
 
-  private constructor(storage: AuthStorageBackend) {
+  private constructor(storage: AuthStorageBackend, migrationOwnerAgentDir?: string) {
     this.storage = storage;
+    this.migrationOwnerAgentDir = migrationOwnerAgentDir;
     this.reload();
   }
 
@@ -365,7 +367,7 @@ export class AuthStorage {
       getRuntimeAuthProfileStoreSnapshot(agentDir) ??
       loadAuthProfileStoreForSecretsRuntime(agentDir);
     assertAuthStorageSecretRefsMaterialized(preparedStore);
-    return new AuthStorage(new SqliteAuthStorageBackend(agentDir, preparedStore));
+    return new AuthStorage(new SqliteAuthStorageBackend(agentDir, preparedStore), agentDir);
   }
 
   /**
@@ -670,6 +672,10 @@ export class AuthStorage {
     const runtimeKey = this.runtimeOverrides.get(providerId);
     if (runtimeKey) {
       return runtimeKey;
+    }
+
+    if (this.migrationOwnerAgentDir) {
+      assertAuthProfileMigrationReady(this.migrationOwnerAgentDir);
     }
 
     if (

--- a/src/agents/sessions/sdk.ts
+++ b/src/agents/sessions/sdk.ts
@@ -74,7 +74,7 @@ export interface CreateAgentSessionOptions {
   /** Global config directory. Default: ~/.openclaw/agents/default */
   agentDir?: string;
 
-  /** Auth storage for credentials. Default: AuthStorage.create(agentDir/auth.json) */
+  /** Auth storage for credentials. Default: canonical per-agent SQLite auth profiles. */
   authStorage?: AuthStorage;
   /** Model registry. Default: ModelRegistry.create(authStorage, agentDir/models.json) */
   modelRegistry?: ModelRegistry;
@@ -300,9 +300,8 @@ async function createAgentSessionImpl(
   let resourceLoader = options.resourceLoader;
 
   // Use provided or create AuthStorage and ModelRegistry
-  const authPath = options.agentDir ? join(agentDir, "auth.json") : undefined;
   const modelsPath = options.agentDir ? join(agentDir, "models.json") : undefined;
-  const authStorage = options.authStorage ?? AuthStorage.create(authPath);
+  const authStorage = options.authStorage ?? AuthStorage.forAgent(agentDir);
   const modelRegistry = options.modelRegistry ?? ModelRegistry.create(authStorage, modelsPath);
 
   const settingsManager = options.settingsManager ?? SettingsManager.create(cwd, agentDir);

--- a/src/auto-reply/reply/directive-handling.auth.ts
+++ b/src/auto-reply/reply/directive-handling.auth.ts
@@ -227,7 +227,7 @@ export const resolveAuthLabel = async (
     });
     return {
       label: labels.join(", "),
-      source: `auth-profiles.json: ${formatPath(resolveAuthStorePathForDisplay(agentDir))}`,
+      source: `auth profile store: ${formatPath(resolveAuthStorePathForDisplay(agentDir))}`,
     };
   }
 

--- a/src/auto-reply/reply/directive-handling.model.ts
+++ b/src/auto-reply/reply/directive-handling.model.ts
@@ -511,7 +511,7 @@ export async function maybeHandleModelDirectiveInfo(params: {
     modelRefs.activeDiffers ? `Active: ${modelRefs.active.label} (runtime)` : null,
     `Default: ${defaultLabel}`,
     `Agent: ${params.activeAgentId}`,
-    `Auth file: ${formatPath(resolveAuthStorePathForDisplay(params.agentDir))}`,
+    `Auth store: ${formatPath(resolveAuthStorePathForDisplay(params.agentDir))}`,
   ].filter((line): line is string => Boolean(line));
   if (params.resetModelOverride) {
     lines.push(`(previous selection reset to default)`);

--- a/src/commands/agents.commands.add.ts
+++ b/src/commands/agents.commands.add.ts
@@ -15,8 +15,8 @@ import {
   buildPortableAuthProfileStoreForAgentCopy,
   ensureAuthProfileStore,
 } from "../agents/auth-profiles.js";
-import { resolveAuthStorePath } from "../agents/auth-profiles/paths.js";
 import { loadPersistedAuthProfileStore } from "../agents/auth-profiles/persisted.js";
+import { resolveAuthProfileDatabasePath } from "../agents/auth-profiles/sqlite.js";
 import { saveAuthProfileStore } from "../agents/auth-profiles/store.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import { logConfigUpdated } from "../config/logging.js";
@@ -257,9 +257,9 @@ export async function agentsAddCommand(
     const defaultAgentId = resolveDefaultAgentId(cfg);
     if (defaultAgentId !== agentId) {
       const sourceAgentDir = resolveAgentDir(cfg, defaultAgentId);
-      const sourceAuthPath = resolveAuthStorePath(sourceAgentDir);
-      const destAuthPath = resolveAuthStorePath(agentDir);
-      const mainAuthPath = resolveAuthStorePath();
+      const sourceAuthPath = resolveAuthProfileDatabasePath(sourceAgentDir);
+      const destAuthPath = resolveAuthProfileDatabasePath(agentDir);
+      const mainAuthPath = resolveAuthProfileDatabasePath();
       const sameAuthPath =
         normalizeLowercaseStringOrEmpty(path.resolve(sourceAuthPath)) ===
         normalizeLowercaseStringOrEmpty(path.resolve(destAuthPath));

--- a/src/commands/doctor-auth-flat-profiles.test.ts
+++ b/src/commands/doctor-auth-flat-profiles.test.ts
@@ -233,6 +233,51 @@ describe("maybeMigrateAuthProfileJsonStoresToSqlite", () => {
     });
   });
 
+  it("retries when an absent legacy sibling appears during migration", async () => {
+    const state = await makeTestState();
+    const authPath = await writeLegacyAuthProfilesJson(state, {
+      version: 1,
+      profiles: {
+        "openai:default": {
+          type: "api_key",
+          provider: "openai",
+          key: "not-a-real",
+        },
+      },
+    });
+    const legacyPath = path.join(state.agentDir(), "auth.json");
+    let recreated = false;
+
+    const result = await maybeMigrateAuthProfileJsonStoresToSqlite({
+      cfg: {},
+      prompter: makePrompter(true),
+      env: state.env,
+      deps: {
+        loadPersistedAuthProfileStore(agentDir, options) {
+          if (!recreated && options?.database === undefined) {
+            recreated = true;
+            fs.writeFileSync(
+              legacyPath,
+              `${JSON.stringify({ xai: { type: "api_key", key: "not-a-real" } })}\n`,
+              "utf8",
+            );
+          }
+          return loadPersistedAuthProfileStore(agentDir, options);
+        },
+      },
+    });
+
+    expect(result.changes).toEqual([]);
+    expect(result.warnings).toEqual([
+      expect.stringContaining("legacy auth source set changed during migration"),
+    ]);
+    expect(fs.existsSync(authPath)).toBe(true);
+    expect(fs.existsSync(legacyPath)).toBe(true);
+    expectNoMigratedArchive(authPath);
+    expectNoMigratedArchive(legacyPath);
+    expect(loadPersistedAuthProfileStore(state.agentDir())).toBeNull();
+  });
+
   it("archives restored OAuth bytes without replaying a terminal receipt", async () => {
     const state = await makeTestState();
     const oauthPath = await state.writeJson("credentials/oauth.json", {

--- a/src/commands/doctor-auth-flat-profiles.test.ts
+++ b/src/commands/doctor-auth-flat-profiles.test.ts
@@ -1,14 +1,23 @@
 // Doctor flat auth-profile tests cover legacy flat profile repair and persisted auth-profile loading.
 import fs from "node:fs";
+import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { loadPersistedAuthProfileStore } from "../agents/auth-profiles/persisted.js";
+import {
+  readPersistedAuthProfileStoreRaw,
+  writePersistedAuthProfileStoreRaw,
+} from "../agents/auth-profiles/sqlite.js";
 import {
   clearRuntimeAuthProfileStoreSnapshots,
   saveAuthProfileStore,
 } from "../agents/auth-profiles/store.js";
+import type { AuthProfileStore } from "../agents/auth-profiles/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
-import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../state/openclaw-state-db.js";
 import {
   createOpenClawTestState,
   type OpenClawTestState,
@@ -66,6 +75,22 @@ async function writeLegacyAuthProfilesJson(
   );
 }
 
+function listMigratedArchives(sourcePath: string): string[] {
+  const prefix = `${path.basename(sourcePath)}.migrated-`;
+  return fs
+    .readdirSync(path.dirname(sourcePath))
+    .filter((entry) => entry.startsWith(prefix))
+    .map((entry) => path.join(path.dirname(sourcePath), entry));
+}
+
+function expectMigratedArchive(sourcePath: string): void {
+  expect(listMigratedArchives(sourcePath)).toHaveLength(1);
+}
+
+function expectNoMigratedArchive(sourcePath: string): void {
+  expect(listMigratedArchives(sourcePath)).toHaveLength(0);
+}
+
 afterEach(async () => {
   clearRuntimeAuthProfileStoreSnapshots();
   closeOpenClawAgentDatabasesForTest();
@@ -76,6 +101,149 @@ afterEach(async () => {
 });
 
 describe("maybeMigrateAuthProfileJsonStoresToSqlite", () => {
+  it("imports shared oauth.json into shared-main only and records its archive", async () => {
+    const state = await makeTestState();
+    const oauthPath = await state.writeJson("credentials/oauth.json", {
+      openai: {
+        access: "fake-access-token",
+        refresh: "fake-refresh-token",
+        expires: 1_900_000_000_000,
+        accountId: "fake-account",
+        subscriptionType: "fake-subscription",
+      },
+    });
+    const sourceBytes = fs.readFileSync(oauthPath);
+    const secondaryAgentDir = state.agentDir("secondary");
+
+    const result = await maybeMigrateAuthProfileJsonStoresToSqlite({
+      cfg: {
+        agents: { list: [{ id: "secondary", agentDir: secondaryAgentDir }] },
+      },
+      prompter: makePrompter(true),
+      env: state.env,
+      now: () => Date.parse("2026-07-25T12:00:00.000Z"),
+    });
+
+    expect(result.warnings).toStrictEqual([]);
+    expect(
+      loadPersistedAuthProfileStore(state.agentDir())?.profiles["openai:default"],
+    ).toMatchObject({
+      type: "oauth",
+      provider: "openai",
+      access: "fake-access-token",
+      refresh: "fake-refresh-token",
+      accountId: "fake-account",
+      subscriptionType: "fake-subscription",
+    });
+    expect(loadPersistedAuthProfileStore(secondaryAgentDir)).toBeNull();
+    expect(fs.existsSync(oauthPath)).toBe(false);
+    const archives = listMigratedArchives(oauthPath);
+    expect(archives).toHaveLength(1);
+    expect(fs.readFileSync(archives[0]!)).toEqual(sourceBytes);
+
+    const receipt = openOpenClawStateDatabase({ env: state.env })
+      .db.prepare(
+        "SELECT status, removed_source, target_table FROM migration_sources WHERE migration_kind = ?",
+      )
+      .get("auth-profile-json-to-sqlite-v2") as
+      | { status: string; removed_source: number; target_table: string }
+      | undefined;
+    expect(receipt).toEqual({
+      status: "completed",
+      removed_source: 1,
+      target_table: "auth_profile_store",
+    });
+  });
+
+  it("archives restored OAuth bytes without replaying a terminal receipt", async () => {
+    const state = await makeTestState();
+    const oauthPath = await state.writeJson("credentials/oauth.json", {
+      openai: {
+        access: "fake-stale-access",
+        refresh: "fake-stale-refresh",
+        expires: 1_900_000_000_000,
+      },
+    });
+    const sourceBytes = fs.readFileSync(oauthPath);
+
+    await maybeMigrateAuthProfileJsonStoresToSqlite({
+      cfg: {},
+      prompter: makePrompter(true),
+      env: state.env,
+    });
+    saveAuthProfileStore({ version: 1, profiles: {} }, state.agentDir(), {
+      syncExternalCli: false,
+    });
+    fs.writeFileSync(oauthPath, sourceBytes);
+
+    const replay = await maybeMigrateAuthProfileJsonStoresToSqlite({
+      cfg: {},
+      prompter: makePrompter(true),
+      env: state.env,
+    });
+
+    expect(replay.changes).toEqual([expect.stringContaining("without replaying credentials")]);
+    expect(loadPersistedAuthProfileStore(state.agentDir())?.profiles).toEqual({});
+    expect(fs.existsSync(oauthPath)).toBe(false);
+    expect(listMigratedArchives(oauthPath)).toHaveLength(2);
+  });
+
+  it("marks a partially parsed shared OAuth source for manual recovery", async () => {
+    const state = await makeTestState();
+    const oauthPath = await state.writeJson("credentials/oauth.json", {
+      anthropic: {
+        access: "fake-access-token",
+        refresh: "fake-refresh-token",
+        expires: 1_900_000_000_000,
+      },
+      malformed: 42,
+    });
+
+    const result = await maybeMigrateAuthProfileJsonStoresToSqlite({
+      cfg: {},
+      prompter: makePrompter(true),
+      env: state.env,
+    });
+
+    expect(result.warnings).toContain(
+      "Imported valid shared OAuth entries and archived 1 rejected entry for manual recovery.",
+    );
+    expect(
+      loadPersistedAuthProfileStore(state.agentDir())?.profiles["anthropic:default"],
+    ).toBeDefined();
+    expect(fs.existsSync(oauthPath)).toBe(false);
+    const receipt = openOpenClawStateDatabase({ env: state.env })
+      .db.prepare("SELECT status FROM migration_sources WHERE migration_kind = ?")
+      .get("auth-profile-json-to-sqlite-v2") as { status?: string } | undefined;
+    expect(receipt?.status).toBe("archived-unparsed");
+  });
+
+  it("leaves shared OAuth in place when the canonical SQLite store is unreadable", async () => {
+    const state = await makeTestState();
+    const oauthPath = await state.writeJson("credentials/oauth.json", {
+      openai: {
+        access: "fake-access-token",
+        refresh: "fake-refresh-token",
+        expires: 1_900_000_000_000,
+      },
+    });
+    const unreadableStore = { version: 1, profiles: "invalid-profile-map" };
+    writePersistedAuthProfileStoreRaw(unreadableStore, state.agentDir());
+
+    const result = await maybeMigrateAuthProfileJsonStoresToSqlite({
+      cfg: {},
+      prompter: makePrompter(true),
+      env: state.env,
+    });
+
+    expect(result.warnings).toContain(
+      "Failed to migrate shared legacy OAuth credentials; the source was left in place.",
+    );
+    expect(fs.existsSync(oauthPath)).toBe(true);
+    expectNoMigratedArchive(oauthPath);
+    expect(readPersistedAuthProfileStoreRaw(state.agentDir())).toEqual(unreadableStore);
+  });
+
   it("imports legacy JSON auth profiles and state into the agent sqlite database", async () => {
     const state = await makeTestState();
     const authPath = await writeLegacyAuthProfilesJson(state, {
@@ -87,6 +255,7 @@ describe("maybeMigrateAuthProfileJsonStoresToSqlite", () => {
           key: "sk-migrated",
         },
       },
+      order: { openai: ["openai:default"] },
     });
     const statePath = await state.writeText(
       "agents/main/agent/auth-state.json",
@@ -113,8 +282,42 @@ describe("maybeMigrateAuthProfileJsonStoresToSqlite", () => {
     });
     expect(fs.existsSync(authPath)).toBe(false);
     expect(fs.existsSync(statePath)).toBe(false);
-    expect(fs.existsSync(`${authPath}.sqlite-import.456.bak`)).toBe(true);
-    expect(fs.existsSync(`${statePath}.sqlite-import.456.bak`)).toBe(true);
+    expectMigratedArchive(authPath);
+    expectMigratedArchive(statePath);
+    const combinedReceipt = openOpenClawStateDatabase({ env: state.env })
+      .db.prepare("SELECT report_json FROM migration_sources WHERE source_path = ?")
+      .get(authPath) as { report_json?: string } | undefined;
+    expect(JSON.parse(combinedReceipt?.report_json ?? "null")?.expectedStateSha256).toEqual(
+      expect.any(String),
+    );
+  });
+
+  it("imports a valid legacy auth sibling when auth-profiles.json is malformed", async () => {
+    const state = await makeTestState();
+    const authPath = await state.writeText(
+      "agents/main/agent/auth-profiles.json",
+      "{ malformed-json\n",
+    );
+    const legacyPath = await state.writeText(
+      "agents/main/agent/auth.json",
+      `${JSON.stringify({
+        xai: { type: "api_key", provider: "xai", key: "fake-sibling-key" },
+      })}\n`,
+    );
+
+    const result = await maybeMigrateAuthProfileJsonStoresToSqlite({
+      cfg: {},
+      prompter: makePrompter(true),
+    });
+
+    expect(result.changes).toEqual([expect.stringContaining("Migrated auth profile JSON")]);
+    expect(loadPersistedAuthProfileStore(state.agentDir())?.profiles["xai:default"]).toMatchObject({
+      key: "fake-sibling-key",
+    });
+    expect(fs.existsSync(authPath)).toBe(false);
+    expect(fs.existsSync(legacyPath)).toBe(false);
+    expectMigratedArchive(authPath);
+    expectMigratedArchive(legacyPath);
   });
 
   it("preserves secret refs and OAuth material when migrating a flat auth-profiles.json", async () => {
@@ -163,7 +366,7 @@ describe("maybeMigrateAuthProfileJsonStoresToSqlite", () => {
       },
     });
     expect(fs.existsSync(authPath)).toBe(false);
-    expect(fs.existsSync(`${authPath}.sqlite-import.472.bak`)).toBe(true);
+    expectMigratedArchive(authPath);
   });
 
   it("moves legacy aws-sdk auth markers to config before removing JSON", async () => {
@@ -211,7 +414,7 @@ describe("maybeMigrateAuthProfileJsonStoresToSqlite", () => {
       },
     });
     expect(fs.existsSync(authPath)).toBe(false);
-    expect(fs.existsSync(`${authPath}.sqlite-import.457.bak`)).toBe(true);
+    expectMigratedArchive(authPath);
   });
 
   it("preserves state-only legacy auth state for inherited profiles", async () => {
@@ -251,7 +454,7 @@ describe("maybeMigrateAuthProfileJsonStoresToSqlite", () => {
       },
     });
     expect(fs.existsSync(statePath)).toBe(false);
-    expect(fs.existsSync(`${statePath}.sqlite-import.459.bak`)).toBe(true);
+    expectMigratedArchive(statePath);
     expect(fs.existsSync(authPath)).toBe(false);
   });
 
@@ -286,7 +489,7 @@ describe("maybeMigrateAuthProfileJsonStoresToSqlite", () => {
     ]);
     expect(loadPersistedAuthProfileStore(state.agentDir())).toBeNull();
     expect(fs.existsSync(authPath)).toBe(true);
-    expect(fs.existsSync(`${authPath}.sqlite-import.460.bak`)).toBe(false);
+    expectNoMigratedArchive(authPath);
   });
 
   it("imports valid profiles when one legacy OAuth sidecar ref is unresolved", async () => {
@@ -333,21 +536,14 @@ describe("maybeMigrateAuthProfileJsonStoresToSqlite", () => {
       lastGood: { openai: "openai:default" },
     });
     expect(fs.existsSync(authPath)).toBe(true);
-    expect(fs.existsSync(`${authPath}.sqlite-import.463.bak`)).toBe(true);
+    expectNoMigratedArchive(authPath);
     const remaining = JSON.parse(fs.readFileSync(authPath, "utf8"));
-    expect(remaining.profiles).toEqual({
-      "openai:user@example.com": {
-        type: "oauth",
-        provider: "openai",
-        email: "user@example.com",
-        oauthRef: {
-          id: "0123456789abcdef0123456789abcdef",
-          provider: "openai",
-        },
-      },
+    expect(remaining.profiles).toHaveProperty("openai:default");
+    expect(remaining.profiles).toHaveProperty("openai:user@example.com");
+    expect(remaining.order).toEqual({
+      openai: ["openai:default", "openai:user@example.com"],
     });
-    expect(remaining.order).toEqual({ openai: ["openai:user@example.com"] });
-    expect(remaining.lastGood).toBeUndefined();
+    expect(remaining.lastGood).toEqual({ openai: "openai:default" });
   });
 
   it("keeps existing SQLite credentials when importing stale JSON", async () => {
@@ -390,7 +586,7 @@ describe("maybeMigrateAuthProfileJsonStoresToSqlite", () => {
       key: "sk-fresh-sqlite",
     });
     expect(fs.existsSync(authPath)).toBe(false);
-    expect(fs.existsSync(`${authPath}.sqlite-import.461.bak`)).toBe(true);
+    expectMigratedArchive(authPath);
   });
 
   it("keeps auth-state.json precedence over auth-profiles.json state during import", async () => {
@@ -456,7 +652,7 @@ describe("maybeMigrateAuthProfileJsonStoresToSqlite", () => {
       },
     });
     expect(fs.existsSync(authPath)).toBe(false);
-    expect(fs.existsSync(`${authPath}.sqlite-import.458.bak`)).toBe(true);
+    expectMigratedArchive(authPath);
   });
 
   it("keeps legacy JSON when SQLite verification misses an imported profile", async () => {
@@ -486,10 +682,99 @@ describe("maybeMigrateAuthProfileJsonStoresToSqlite", () => {
 
     expect(result.changes).toStrictEqual([]);
     expect(result.warnings).toStrictEqual([
-      `Left auth profile JSON in place for ${authPath} because SQLite verification did not find imported profile(s): openrouter:default.`,
+      `Left auth profile JSON in place for ${authPath} because SQLite verification failed (imported profile(s): openrouter:default).`,
     ]);
     expect(fs.existsSync(authPath)).toBe(true);
-    expect(fs.existsSync(`${authPath}.sqlite-import.464.bak`)).toBe(false);
+    expectNoMigratedArchive(authPath);
+  });
+
+  it("keeps legacy JSON when the SQLite target changes before the migration transaction", async () => {
+    const state = await makeTestState();
+    const authPath = await writeLegacyAuthProfilesJson(state, {
+      version: 1,
+      profiles: {
+        "openrouter:default": {
+          type: "api_key",
+          provider: "openrouter",
+          key: "fake-imported-key",
+        },
+      },
+    });
+    let loadCount = 0;
+    const emptyStore: AuthProfileStore = { version: 1, profiles: {} };
+    const concurrentStore: AuthProfileStore = {
+      version: 1,
+      profiles: {
+        "anthropic:default": {
+          type: "api_key",
+          provider: "anthropic",
+          key: "fake-concurrent-key",
+        },
+      },
+    };
+
+    const result = await maybeMigrateAuthProfileJsonStoresToSqlite({
+      cfg: {},
+      prompter: makePrompter(true),
+      now: () => 464,
+      deps: {
+        loadPersistedAuthProfileStore: () => {
+          loadCount += 1;
+          return loadCount === 1 ? emptyStore : concurrentStore;
+        },
+      },
+    });
+
+    expect(result.changes).toStrictEqual([]);
+    expect(result.warnings).toEqual([
+      expect.stringContaining("canonical auth profile store changed during legacy migration"),
+    ]);
+    expect(fs.existsSync(authPath)).toBe(true);
+    expectNoMigratedArchive(authPath);
+    expect(loadPersistedAuthProfileStore(state.agentDir())).toBeNull();
+  });
+
+  it("keeps legacy JSON when only SQLite auth state changes before the transaction", async () => {
+    const state = await makeTestState();
+    const authPath = await writeLegacyAuthProfilesJson(state, {
+      version: 1,
+      profiles: {
+        "openrouter:default": {
+          type: "api_key",
+          provider: "openrouter",
+          key: "fake-imported-key",
+        },
+      },
+    });
+    const baseline: AuthProfileStore = {
+      version: 1,
+      profiles: {},
+      lastGood: { openai: "openai:before" },
+    };
+    const concurrent: AuthProfileStore = {
+      version: 1,
+      profiles: {},
+      lastGood: { openai: "openai:after" },
+    };
+    let loadCount = 0;
+
+    const result = await maybeMigrateAuthProfileJsonStoresToSqlite({
+      cfg: {},
+      prompter: makePrompter(true),
+      deps: {
+        loadPersistedAuthProfileStore: () => {
+          loadCount += 1;
+          return loadCount === 1 ? baseline : concurrent;
+        },
+      },
+    });
+
+    expect(result.changes).toStrictEqual([]);
+    expect(result.warnings).toEqual([
+      expect.stringContaining("canonical auth profile store changed during legacy migration"),
+    ]);
+    expect(fs.existsSync(authPath)).toBe(true);
+    expectNoMigratedArchive(authPath);
   });
 
   it("imports default-agent config auth profiles into sqlite when no legacy files exist", async () => {
@@ -574,7 +859,7 @@ describe("maybeMigrateAuthProfileJsonStoresToSqlite", () => {
     ).toBeUndefined();
     expect(loadPersistedAuthProfileStore(state.agentDir())?.order).toBeUndefined();
     expect(fs.existsSync(authPath)).toBe(false);
-    expect(fs.existsSync(`${authPath}.sqlite-import.465.bak`)).toBe(false);
+    expectNoMigratedArchive(authPath);
   });
 
   it("imports default-agent config auth profiles when only legacy state exists", async () => {
@@ -625,9 +910,9 @@ describe("maybeMigrateAuthProfileJsonStoresToSqlite", () => {
       lastGood: { openai: "openai:default" },
     });
     expect(fs.existsSync(statePath)).toBe(false);
-    expect(fs.existsSync(`${statePath}.sqlite-import.467.bak`)).toBe(true);
+    expectMigratedArchive(statePath);
     expect(fs.existsSync(authPath)).toBe(false);
-    expect(fs.existsSync(`${authPath}.sqlite-import.467.bak`)).toBe(false);
+    expectNoMigratedArchive(authPath);
   });
 
   it("infers config credential provider and mode before stripping config", async () => {
@@ -681,7 +966,7 @@ describe("maybeMigrateAuthProfileJsonStoresToSqlite", () => {
         key: "sk-config",
       });
       expect(fs.existsSync(authPath)).toBe(false);
-      expect(fs.existsSync(`${authPath}.sqlite-import.${entry.now}.bak`)).toBe(false);
+      expectNoMigratedArchive(authPath);
     }
   });
 
@@ -765,7 +1050,7 @@ describe("maybeMigrateAuthProfileJsonStoresToSqlite", () => {
       },
     });
     expect(fs.existsSync(authPath)).toBe(false);
-    expect(fs.existsSync(`${authPath}.sqlite-import.471.bak`)).toBe(true);
+    expectMigratedArchive(authPath);
   });
 
   it("imports default-agent config api key alias SecretRefs as key refs", async () => {

--- a/src/commands/doctor-auth-flat-profiles.test.ts
+++ b/src/commands/doctor-auth-flat-profiles.test.ts
@@ -155,6 +155,47 @@ describe("maybeMigrateAuthProfileJsonStoresToSqlite", () => {
     });
   });
 
+  it("defers shared OAuth while a higher-priority main credential remains pending", async () => {
+    const state = await makeTestState();
+    const authPath = await writeLegacyAuthProfilesJson(state, {
+      version: 1,
+      profiles: {
+        "openai:default": {
+          type: "oauth",
+          provider: "openai",
+          oauthRef: {
+            id: "0123456789abcdef0123456789abcdef",
+            provider: "openai",
+          },
+        },
+      },
+    });
+    const oauthPath = await state.writeJson("credentials/oauth.json", {
+      openai: {
+        access: "fake-lower-priority-access",
+        refresh: "fake-lower-priority-refresh",
+        expires: 1_900_000_000_000,
+      },
+    });
+
+    const result = await maybeMigrateAuthProfileJsonStoresToSqlite({
+      cfg: {},
+      prompter: makePrompter(true),
+      env: state.env,
+    });
+
+    expect(result.warnings).toEqual([
+      expect.stringContaining("legacy OAuth sidecar profile"),
+      expect.stringContaining("no importable auth profiles or state"),
+      expect.stringContaining("Deferred shared legacy OAuth migration"),
+    ]);
+    expect(loadPersistedAuthProfileStore(state.agentDir())).toBeNull();
+    expect(fs.existsSync(authPath)).toBe(true);
+    expect(fs.existsSync(oauthPath)).toBe(true);
+    expectNoMigratedArchive(authPath);
+    expectNoMigratedArchive(oauthPath);
+  });
+
   it("archives restored OAuth bytes without replaying a terminal receipt", async () => {
     const state = await makeTestState();
     const oauthPath = await state.writeJson("credentials/oauth.json", {

--- a/src/commands/doctor-auth-flat-profiles.test.ts
+++ b/src/commands/doctor-auth-flat-profiles.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { loadPersistedAuthProfileStore } from "../agents/auth-profiles/persisted.js";
 import {
   readPersistedAuthProfileStoreRaw,
+  writePersistedAuthProfileStateRaw,
   writePersistedAuthProfileStoreRaw,
 } from "../agents/auth-profiles/sqlite.js";
 import {
@@ -194,6 +195,42 @@ describe("maybeMigrateAuthProfileJsonStoresToSqlite", () => {
     expect(fs.existsSync(oauthPath)).toBe(true);
     expectNoMigratedArchive(authPath);
     expectNoMigratedArchive(oauthPath);
+  });
+
+  it("preserves state-only profile IDs while migrating shared OAuth", async () => {
+    const state = await makeTestState();
+    writePersistedAuthProfileStateRaw(
+      {
+        version: 1,
+        order: { openai: ["openai:external"] },
+        lastGood: { openai: "openai:external" },
+        usageStats: { "openai:external": { cooldownUntil: 1_900_000_000_000 } },
+      },
+      state.agentDir(),
+    );
+    await state.writeJson("credentials/oauth.json", {
+      anthropic: {
+        access: "not-a-real",
+        refresh: "not-a-real",
+        expires: 1_900_000_000_000,
+      },
+    });
+
+    const result = await maybeMigrateAuthProfileJsonStoresToSqlite({
+      cfg: {},
+      prompter: makePrompter(true),
+      env: state.env,
+    });
+
+    expect(result.warnings).toEqual([]);
+    expect(loadPersistedAuthProfileStore(state.agentDir())).toMatchObject({
+      profiles: {
+        "anthropic:default": { type: "oauth", provider: "anthropic" },
+      },
+      order: { openai: ["openai:external"] },
+      lastGood: { openai: "openai:external" },
+      usageStats: { "openai:external": { cooldownUntil: 1_900_000_000_000 } },
+    });
   });
 
   it("archives restored OAuth bytes without replaying a terminal receipt", async () => {

--- a/src/commands/doctor-auth-flat-profiles.ts
+++ b/src/commands/doctor-auth-flat-profiles.ts
@@ -1,23 +1,30 @@
 /** Doctor repairs for legacy auth profile JSON stores and OpenAI provider-id migrations. */
 import fs from "node:fs";
 import path from "node:path";
+import { isDeepStrictEqual } from "node:util";
 import { collectConfiguredModelRefs } from "@openclaw/model-catalog-core/configured-model-refs";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { note } from "../../packages/terminal-core/src/note.js";
 import { resolveAgentDir, resolveDefaultAgentDir, listAgentIds } from "../agents/agent-scope.js";
 import { AUTH_STORE_VERSION } from "../agents/auth-profiles/constants.js";
 import {
-  resolveAuthStatePath,
-  resolveAuthStorePath,
-  resolveLegacyAuthStorePath,
-} from "../agents/auth-profiles/paths.js";
+  clearAuthProfileMigrationDiagnostics,
+  resolveLegacyOAuthPath,
+} from "../agents/auth-profiles/legacy-source-diagnostic.js";
 import {
   applyLegacyAuthStore,
+  coerceLegacyAuthStore,
   coercePersistedAuthProfileStore,
-  loadLegacyAuthProfileStore,
   loadPersistedAuthProfileStore,
   parseLegacyCredentialEntry,
 } from "../agents/auth-profiles/persisted.js";
+import { resolveSharedMainAuthAgentDir } from "../agents/auth-profiles/shared-main-dir.js";
+import {
+  inspectPersistedAuthProfileStoreRaw,
+  readPersistedAuthProfileStateRaw,
+  resolveAuthProfileDatabasePath,
+  runAuthProfileWriteTransaction,
+} from "../agents/auth-profiles/sqlite.js";
 import { coerceAuthProfileState } from "../agents/auth-profiles/state.js";
 import {
   clearRuntimeAuthProfileStoreSnapshots,
@@ -35,8 +42,23 @@ import type { AuthProfileConfig } from "../config/types.auth.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { coerceSecretRef } from "../config/types.secrets.js";
 import { loadJsonFile } from "../infra/json-file.js";
-import { writeJsonSync } from "../infra/json-files.js";
+import type { OpenClawAgentDatabase } from "../state/openclaw-agent-db.js";
 import { shortenHomePath } from "../utils.js";
+import {
+  resolveLegacyAuthProfilesPath as resolveAuthStorePath,
+  resolveLegacyAuthStatePath as resolveAuthStatePath,
+  resolveLegacyFlatAuthPath as resolveLegacyAuthStorePath,
+} from "./doctor-auth-legacy-paths.js";
+import {
+  acquireAuthProfileMigrationSourceLocks,
+  archiveAuthProfileMigrationSource,
+  createAuthProfileMigrationSourceReceipt,
+  digestAuthProfileMigrationValue,
+  finalizeAuthProfileMigrationSource,
+  hasTerminalAuthProfileMigrationReceipt,
+  resumePendingAuthProfileMigrationArchives,
+  type AuthProfileMigrationSourceReceipt,
+} from "./doctor-auth-migration-receipts.js";
 import type { DoctorPrompter } from "./doctor-prompter.js";
 
 type AuthProfileRepairCandidate = {
@@ -68,6 +90,13 @@ type AwsSdkAuthProfileMarkerStore = {
   raw: Record<string, unknown>;
   profiles: AwsSdkProfileMarker[];
 };
+
+class AuthProfileMigrationVerificationError extends Error {
+  constructor(readonly detail: string | null) {
+    super("auth profile SQLite verification failed");
+    this.name = "AuthProfileMigrationVerificationError";
+  }
+}
 
 type RawAuthProfileImportStore = {
   version: number;
@@ -724,27 +753,210 @@ function hasLegacyAuthProfileSource(candidate: AuthProfileSqliteMigrationCandida
   );
 }
 
-function backupAuthProfileJson(pathname: string, suffix: string, now: () => number): string {
-  const backupPath = `${pathname}.${suffix}.${now()}.bak`;
-  fs.copyFileSync(pathname, backupPath);
-  return backupPath;
+function prepareAuthProfileSourceReceipt(params: {
+  pathname: string;
+  targetDatabasePath: string;
+  targetTable: AuthProfileMigrationSourceReceipt["targetTable"];
+  now: () => number;
+  env?: NodeJS.ProcessEnv;
+}): AuthProfileMigrationSourceReceipt {
+  const sourceBytes = fs.readFileSync(params.pathname);
+  let sourceRecordCount = 0;
+  try {
+    const parsed = JSON.parse(sourceBytes.toString("utf8")) as unknown;
+    sourceRecordCount = isRecord(parsed) ? Object.keys(parsed).length : 0;
+  } catch {
+    // The migration parser reports malformed input separately; receipts never include its bytes.
+  }
+  return createAuthProfileMigrationSourceReceipt({
+    sourcePath: params.pathname,
+    sourceBytes,
+    sourceRecordCount,
+    targetDatabasePath: params.targetDatabasePath,
+    targetTable: params.targetTable,
+    now: new Date(params.now()),
+    ...(params.env ? { env: params.env } : {}),
+  });
 }
 
-function backupAndRemoveAuthProfileJson(
-  pathname: string,
-  suffix: string,
-  now: () => number,
+function archiveVerifiedAuthProfileSource(
+  receipt: AuthProfileMigrationSourceReceipt,
+  sourceLocked = false,
 ): string {
-  const backupPath = backupAuthProfileJson(pathname, suffix, now);
-  fs.unlinkSync(pathname);
-  return backupPath;
+  finalizeAuthProfileMigrationSource(receipt, "completed", { sourceLocked });
+  return receipt.archivePath;
+}
+
+function archivePreviouslyMigratedAuthProfileSource(
+  receipt: AuthProfileMigrationSourceReceipt,
+  result: LegacyFlatAuthProfileRepairResult,
+): boolean {
+  if (!hasTerminalAuthProfileMigrationReceipt(receipt.sourceKey, receipt.env)) {
+    return false;
+  }
+  archiveAuthProfileMigrationSource(receipt);
+  result.changes.push(
+    `Archived a previously migrated legacy auth source without replaying credentials (${shortenHomePath(receipt.archivePath)}).`,
+  );
+  return true;
+}
+
+function coerceLegacyOAuthFile(raw: unknown): {
+  store: AuthProfileStore | null;
+  rejectedEntries: number;
+} {
+  if (!isRecord(raw)) {
+    return { store: null, rejectedEntries: 1 };
+  }
+  const profiles: AuthProfileStore["profiles"] = {};
+  let rejectedEntries = 0;
+  for (const [provider, value] of Object.entries(raw)) {
+    if (!isRecord(value)) {
+      rejectedEntries += 1;
+      continue;
+    }
+    const credential = parseLegacyCredentialEntry({ ...value, type: "oauth", provider }, provider);
+    if (credential?.type === "oauth") {
+      profiles[`${provider}:default`] = credential;
+    } else {
+      rejectedEntries += 1;
+    }
+  }
+  return {
+    store: Object.keys(profiles).length > 0 ? { version: AUTH_STORE_VERSION, profiles } : null,
+    rejectedEntries,
+  };
+}
+
+function loadAuthProfileMigrationTargetStore(
+  agentDir: string | undefined,
+  loadStore: typeof loadPersistedAuthProfileStore = loadPersistedAuthProfileStore,
+  database?: OpenClawAgentDatabase,
+): AuthProfileStore {
+  const inspection = inspectPersistedAuthProfileStoreRaw(agentDir, database);
+  const store = loadStore(agentDir, database ? { database } : undefined);
+  if (store) {
+    return store;
+  }
+  if (inspection.status !== "missing") {
+    throw new Error("canonical auth profile store is unreadable; legacy source left in place");
+  }
+  return { version: AUTH_STORE_VERSION, profiles: {} };
+}
+
+function migrateLegacyOAuthFile(params: {
+  oauthPath: string;
+  env: NodeJS.ProcessEnv;
+  now: () => number;
+  result: LegacyFlatAuthProfileRepairResult;
+}): void {
+  if (!fs.existsSync(params.oauthPath)) {
+    return;
+  }
+  const releaseSource = acquireAuthProfileMigrationSourceLocks([params.oauthPath]);
+  try {
+    migrateLockedLegacyOAuthFile(params);
+  } finally {
+    releaseSource();
+  }
+}
+
+function migrateLockedLegacyOAuthFile(params: {
+  oauthPath: string;
+  env: NodeJS.ProcessEnv;
+  now: () => number;
+  result: LegacyFlatAuthProfileRepairResult;
+}): void {
+  const mainAgentDir = resolveSharedMainAuthAgentDir(params.env);
+  const targetDatabasePath = resolveAuthProfileDatabasePath(mainAgentDir);
+  const receipt = prepareAuthProfileSourceReceipt({
+    pathname: params.oauthPath,
+    targetDatabasePath,
+    targetTable: "auth_profile_store",
+    now: params.now,
+    env: params.env,
+  });
+  if (archivePreviouslyMigratedAuthProfileSource(receipt, params.result)) {
+    return;
+  }
+  const raw = loadJsonFile(params.oauthPath);
+  const parsed = coerceLegacyOAuthFile(raw);
+  const imported = parsed.store;
+  if (!imported) {
+    finalizeAuthProfileMigrationSource(receipt, "archived-unparsed", { sourceLocked: true });
+    params.result.warnings.push(
+      `Archived an unreadable legacy OAuth source without import; re-authenticate or recover it from ${shortenHomePath(receipt.archivePath)}.`,
+    );
+    return;
+  }
+  const existing = loadAuthProfileMigrationTargetStore(mainAgentDir);
+  const importedProfileIds = new Set(Object.keys(imported.profiles));
+  const next = mergeImportedAuthProfiles({
+    store: existing,
+    profiles: imported.profiles,
+    existingProfileIds: new Set(Object.keys(existing.profiles)),
+  });
+  const loaded = runAuthProfileWriteTransaction(mainAgentDir, (database) => {
+    const authoritative = loadAuthProfileMigrationTargetStore(
+      mainAgentDir,
+      loadPersistedAuthProfileStore,
+      database,
+    );
+    if (!isDeepStrictEqual(authoritative, existing)) {
+      throw new Error("canonical auth profile store changed during legacy OAuth migration");
+    }
+    saveAuthProfileStore(
+      next,
+      mainAgentDir,
+      {
+        filterExternalAuthProfiles: false,
+        syncExternalCli: false,
+      },
+      database,
+    );
+    const verified = loadPersistedAuthProfileStore(mainAgentDir, { database });
+    const verificationFailure = formatMissingAuthProfileSqliteVerification({
+      expected: next,
+      importedProfileIds,
+      loaded: verified,
+    });
+    const mismatched = [...importedProfileIds].filter((profileId) => {
+      if (existing.profiles[profileId]) {
+        return false;
+      }
+      return !isDeepStrictEqual(verified?.profiles[profileId], imported.profiles[profileId]);
+    });
+    if (verificationFailure || mismatched.length > 0 || !verified) {
+      throw new Error("legacy OAuth import verification failed");
+    }
+    return verified;
+  });
+  receipt.expectedProfileSha256 = Object.fromEntries(
+    [...importedProfileIds].map((profileId) => [
+      profileId,
+      digestAuthProfileMigrationValue(loaded.profiles[profileId]),
+    ]),
+  );
+  finalizeAuthProfileMigrationSource(
+    receipt,
+    parsed.rejectedEntries > 0 ? "archived-unparsed" : "completed",
+    { sourceLocked: true },
+  );
+  if (parsed.rejectedEntries > 0) {
+    params.result.warnings.push(
+      `Imported valid shared OAuth entries and archived ${parsed.rejectedEntries} rejected entr${parsed.rejectedEntries === 1 ? "y" : "ies"} for manual recovery.`,
+    );
+  }
+  params.result.changes.push(
+    `Migrated shared legacy OAuth credentials into the shared-main SQLite owner (archive: ${shortenHomePath(receipt.archivePath)}).`,
+  );
 }
 
 /**
  * Imports legacy auth profile JSON and state files into the per-agent SQLite store.
  *
- * JSON files are backed up and removed only after import. OAuth profiles that still depend on
- * unresolved sidecar secrets are kept in JSON so the sidecar migration can run first.
+ * JSON files are verified and atomically renamed to timestamped archives only after import.
+ * OAuth profiles that still depend on unresolved sidecar secrets remain as a migration input.
  */
 export async function maybeMigrateAuthProfileJsonStoresToSqlite(params: {
   cfg: OpenClawConfig;
@@ -759,36 +971,54 @@ export async function maybeMigrateAuthProfileJsonStoresToSqlite(params: {
   const env = params.env ?? process.env;
   const loadMigratedStore =
     params.deps?.loadPersistedAuthProfileStore ?? loadPersistedAuthProfileStore;
+  let resumedChanges: string[] = [];
+  let resumeWarning: string | undefined;
+  try {
+    resumedChanges = resumePendingAuthProfileMigrationArchives(env);
+  } catch {
+    resumeWarning =
+      "Could not finalize an interrupted auth profile archive; legacy sources were left for recovery.";
+  }
   const candidates = listAuthProfileSqliteMigrationCandidates(params.cfg, env);
   const configStore = coerceLegacyConfigAuthProfileStore(params.cfg);
+  const oauthPath = resolveLegacyOAuthPath(env);
+  const hasLegacyOAuth = fs.existsSync(oauthPath);
   const detected = candidates.filter(
     (candidate) =>
       hasLegacyAuthProfileSource(candidate) ||
       (configStore && isDefaultAgentCandidate(candidate, params.cfg, env)),
   );
   const result: LegacyFlatAuthProfileRepairResult = {
-    detected: detected.flatMap((candidate) =>
-      [
-        candidate.authPath,
-        candidate.statePath,
-        candidate.legacyPath,
-        ...(configStore && isDefaultAgentCandidate(candidate, params.cfg, env)
-          ? [candidate.authPath]
-          : []),
-      ]
-        .filter((pathname, index, entries) => entries.indexOf(pathname) === index)
-        .filter(
-          (pathname) =>
-            fs.existsSync(pathname) ||
-            (configStore &&
-              isDefaultAgentCandidate(candidate, params.cfg, env) &&
-              pathname === candidate.authPath),
-        ),
-    ),
-    changes: [],
-    warnings: [],
+    detected: [
+      ...detected.flatMap((candidate) =>
+        [
+          candidate.authPath,
+          candidate.statePath,
+          candidate.legacyPath,
+          ...(configStore && isDefaultAgentCandidate(candidate, params.cfg, env)
+            ? [candidate.authPath]
+            : []),
+        ]
+          .filter((pathname, index, entries) => entries.indexOf(pathname) === index)
+          .filter(
+            (pathname) =>
+              fs.existsSync(pathname) ||
+              (configStore &&
+                isDefaultAgentCandidate(candidate, params.cfg, env) &&
+                pathname === candidate.authPath),
+          ),
+      ),
+      ...(hasLegacyOAuth ? [oauthPath] : []),
+    ],
+    changes: resumedChanges,
+    warnings: resumeWarning ? [resumeWarning] : [],
   };
-  if (detected.length === 0) {
+  if (resumeWarning) {
+    // A pending imported receipt owns its source until recovery succeeds.
+    // Starting a new hash-based run would orphan that crash-recovery record.
+    return result;
+  }
+  if (detected.length === 0 && !hasLegacyOAuth) {
     return result;
   }
 
@@ -798,7 +1028,8 @@ export async function maybeMigrateAuthProfileJsonStoresToSqlite(params: {
         (candidate) =>
           `- ${shortenHomePath(candidate.authPath)} / ${shortenHomePath(candidate.statePath)}`,
       ),
-      `- ${formatCliCommand("openclaw doctor --fix")} imports legacy auth profile JSON into the per-agent SQLite database and removes the old files after backup.`,
+      ...(hasLegacyOAuth ? [`- ${shortenHomePath(oauthPath)} (shared-main owner)`] : []),
+      `- ${formatCliCommand("openclaw doctor --fix")} imports legacy auth profile JSON into SQLite, verifies it, records a receipt, and archives the original bytes.`,
     ].join("\n"),
     "Auth profile SQLite migration",
   );
@@ -812,7 +1043,55 @@ export async function maybeMigrateAuthProfileJsonStoresToSqlite(params: {
   }
 
   for (const candidate of detected) {
+    let releaseSources: (() => void) | undefined;
     try {
+      releaseSources = acquireAuthProfileMigrationSourceLocks(
+        [candidate.authPath, candidate.statePath, candidate.legacyPath].filter((pathname) =>
+          fs.existsSync(pathname),
+        ),
+      );
+      const targetDatabasePath = resolveAuthProfileDatabasePath(candidate.agentDir);
+      let sourceReceipts = [
+        ...(fs.existsSync(candidate.authPath)
+          ? [
+              prepareAuthProfileSourceReceipt({
+                pathname: candidate.authPath,
+                targetDatabasePath,
+                targetTable: "auth_profile_store",
+                now,
+                env,
+              }),
+            ]
+          : []),
+        ...(fs.existsSync(candidate.statePath)
+          ? [
+              prepareAuthProfileSourceReceipt({
+                pathname: candidate.statePath,
+                targetDatabasePath,
+                targetTable: "auth_profile_state",
+                now,
+                env,
+              }),
+            ]
+          : []),
+        ...(fs.existsSync(candidate.legacyPath)
+          ? [
+              prepareAuthProfileSourceReceipt({
+                pathname: candidate.legacyPath,
+                targetDatabasePath,
+                targetTable: "auth_profile_store",
+                now,
+                env,
+              }),
+            ]
+          : []),
+      ];
+      sourceReceipts = sourceReceipts.filter(
+        (receipt) => !archivePreviouslyMigratedAuthProfileSource(receipt, result),
+      );
+      if (sourceReceipts.length === 0 && !configStore) {
+        continue;
+      }
       const rawStore = fs.existsSync(candidate.authPath) ? loadJsonFile(candidate.authPath) : null;
       const unresolvedSidecarProfileIds = new Set(
         collectUnresolvedLegacyOAuthSidecarProfileIds(rawStore),
@@ -858,7 +1137,7 @@ export async function maybeMigrateAuthProfileJsonStoresToSqlite(params: {
         : null;
       const configCanonicalStore =
         configStore && isDefaultAgentCandidate(candidate, params.cfg, env) ? configStore : null;
-      const legacyStore = loadLegacyAuthProfileStore(candidate.agentDir);
+      const legacyStore = coerceLegacyAuthStore(loadJsonFile(candidate.legacyPath));
       const rawState = fs.existsSync(candidate.statePath)
         ? loadJsonFile(candidate.statePath)
         : null;
@@ -870,19 +1149,29 @@ export async function maybeMigrateAuthProfileJsonStoresToSqlite(params: {
         !hasAuthProfileState(state) &&
         !awsSdkMarkerStore
       ) {
+        if (!unresolvedSidecarRawStore && sourceReceipts.length > 0) {
+          const archived = sourceReceipts.map((receipt) => {
+            finalizeAuthProfileMigrationSource(receipt, "archived-unparsed", {
+              sourceLocked: true,
+            });
+            return receipt.archivePath;
+          });
+          result.warnings.push(
+            `Archived unparseable auth profile input without import for ${shortenHomePath(candidate.authPath)} (${archived.map(shortenHomePath).join(", ")}).`,
+          );
+          continue;
+        }
         result.warnings.push(
           `Left auth profile JSON in place for ${shortenHomePath(candidate.authPath)} because no importable auth profiles or state were found.`,
         );
         continue;
       }
 
-      const existing = loadMigratedStore(candidate.agentDir) ?? {
-        version: AUTH_STORE_VERSION,
-        profiles: {},
-      };
+      const existing = loadAuthProfileMigrationTargetStore(candidate.agentDir, loadMigratedStore);
       const existingProfileIds = new Set(Object.keys(existing.profiles));
       const existingState = coerceAuthProfileState(existing);
       let next: AuthProfileStore = { ...existing };
+      let verifiedStore = existing;
       const importedProfileIds = new Set<string>();
       if (legacyStore) {
         const legacyAsStore: AuthProfileStore = { version: AUTH_STORE_VERSION, profiles: {} };
@@ -942,20 +1231,52 @@ export async function maybeMigrateAuthProfileJsonStoresToSqlite(params: {
             ? collectAuthProfileStateProfileIds(coerceAuthProfileState(configCanonicalStore))
             : []),
         ];
-        saveAuthProfileStore(next, candidate.agentDir, {
-          filterExternalAuthProfiles: false,
-          // Imported order/usage state may mention externally-backed profiles not in this store.
-          preserveStateProfileIds: stateProfileIds,
-          syncExternalCli: false,
-        });
-        const verificationFailure = formatMissingAuthProfileSqliteVerification({
-          expected: next,
-          importedProfileIds,
-          loaded: loadMigratedStore(candidate.agentDir),
-        });
-        if (verificationFailure) {
+        try {
+          verifiedStore = runAuthProfileWriteTransaction(candidate.agentDir, (database) => {
+            const authoritative = loadAuthProfileMigrationTargetStore(
+              candidate.agentDir,
+              loadMigratedStore,
+              database,
+            );
+            // This store includes the separately persisted auth_profile_state row,
+            // so state-only concurrent changes abort before either table is written.
+            if (!isDeepStrictEqual(authoritative, existing)) {
+              throw new Error("canonical auth profile store changed during legacy migration");
+            }
+            saveAuthProfileStore(
+              next,
+              candidate.agentDir,
+              {
+                filterExternalAuthProfiles: false,
+                // Imported state may reference external profiles absent from this store.
+                preserveStateProfileIds: stateProfileIds,
+                syncExternalCli: false,
+              },
+              database,
+            );
+            const loaded = loadMigratedStore(candidate.agentDir, { database });
+            const verificationFailure = formatMissingAuthProfileSqliteVerification({
+              expected: next,
+              importedProfileIds,
+              loaded,
+            });
+            const mismatchedCredential = [...importedProfileIds].some((profileId) => {
+              if (existingProfileIds.has(profileId)) {
+                return false;
+              }
+              return !isDeepStrictEqual(loaded?.profiles[profileId], next.profiles[profileId]);
+            });
+            if (verificationFailure || mismatchedCredential || !loaded) {
+              throw new AuthProfileMigrationVerificationError(verificationFailure);
+            }
+            return loaded;
+          });
+        } catch (error) {
+          if (!(error instanceof AuthProfileMigrationVerificationError)) {
+            throw error;
+          }
           result.warnings.push(
-            `Left auth profile JSON in place for ${shortenHomePath(candidate.authPath)} because SQLite verification did not find ${verificationFailure}.`,
+            `Left auth profile JSON in place for ${shortenHomePath(candidate.authPath)} because SQLite verification failed${error.detail ? ` (${error.detail})` : ""}.`,
           );
           continue;
         }
@@ -967,27 +1288,43 @@ export async function maybeMigrateAuthProfileJsonStoresToSqlite(params: {
         }
       }
 
-      const backups: string[] = [];
-      if (fs.existsSync(candidate.authPath)) {
-        if (unresolvedSidecarRawStore) {
-          backups.push(backupAuthProfileJson(candidate.authPath, "sqlite-import", now));
-          writeJsonSync(candidate.authPath, unresolvedSidecarRawStore);
-        } else {
-          backups.push(backupAndRemoveAuthProfileJson(candidate.authPath, "sqlite-import", now));
+      const expectedProfileSha256 = Object.fromEntries(
+        [...importedProfileIds].flatMap((profileId) => {
+          const credential = verifiedStore.profiles[profileId];
+          return credential
+            ? [[profileId, digestAuthProfileMigrationValue(credential)] as const]
+            : [];
+        }),
+      );
+      const expectedStateSha256 = digestAuthProfileMigrationValue(
+        readPersistedAuthProfileStateRaw(candidate.agentDir),
+      );
+      const canonicalSourceCarriesState = canonicalStore
+        ? hasAuthProfileState(coerceAuthProfileState(canonicalStore))
+        : false;
+      for (const receipt of sourceReceipts) {
+        if (receipt.targetTable === "auth_profile_store") {
+          receipt.expectedProfileSha256 = expectedProfileSha256;
+        }
+        if (
+          receipt.targetTable === "auth_profile_state" ||
+          (receipt.sourcePath === candidate.authPath && canonicalSourceCarriesState)
+        ) {
+          receipt.expectedStateSha256 = expectedStateSha256;
         }
       }
-      if (fs.existsSync(candidate.statePath)) {
-        backups.push(backupAndRemoveAuthProfileJson(candidate.statePath, "sqlite-import", now));
-      }
-      if (fs.existsSync(candidate.legacyPath)) {
-        backups.push(backupAndRemoveAuthProfileJson(candidate.legacyPath, "sqlite-import", now));
-      }
-      const backupText =
-        backups.length > 0
-          ? `backup${backups.length === 1 ? "" : "s"}: ${backups.map(shortenHomePath).join(", ")}`
+      const archivalReceipts = unresolvedSidecarRawStore
+        ? sourceReceipts.filter((receipt) => receipt.sourcePath !== candidate.authPath)
+        : sourceReceipts;
+      const archives = archivalReceipts.map((receipt) =>
+        archiveVerifiedAuthProfileSource(receipt, true),
+      );
+      const archiveText =
+        archives.length > 0
+          ? `archive${archives.length === 1 ? "" : "s"}: ${archives.map(shortenHomePath).join(", ")}`
           : "no legacy JSON backup needed";
       result.changes.push(
-        `Migrated auth profile JSON for ${shortenHomePath(candidate.authPath)} into SQLite (${backupText}).`,
+        `Migrated auth profile JSON for ${shortenHomePath(candidate.authPath)} into SQLite (${archiveText}).`,
       );
       if (awsSdkMarkerStore) {
         result.changes.push(
@@ -998,9 +1335,21 @@ export async function maybeMigrateAuthProfileJsonStoresToSqlite(params: {
       result.warnings.push(
         `Failed to migrate auth profile JSON for ${shortenHomePath(candidate.authPath)}: ${String(err)}`,
       );
+    } finally {
+      releaseSources?.();
+    }
+  }
+  if (hasLegacyOAuth) {
+    try {
+      migrateLegacyOAuthFile({ oauthPath, env, now, result });
+    } catch {
+      result.warnings.push(
+        `Failed to migrate shared legacy OAuth credentials; the source was left in place.`,
+      );
     }
   }
   clearRuntimeAuthProfileStoreSnapshots();
+  clearAuthProfileMigrationDiagnostics();
   if (result.changes.length > 0) {
     note(result.changes.map((change) => `- ${change}`).join("\n"), "Doctor changes");
   }

--- a/src/commands/doctor-auth-flat-profiles.ts
+++ b/src/commands/doctor-auth-flat-profiles.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 /** Doctor repairs for legacy auth profile JSON stores and OpenAI provider-id migrations. */
 import fs from "node:fs";
 import path from "node:path";
@@ -788,6 +789,39 @@ function archiveVerifiedAuthProfileSource(
   return receipt.archivePath;
 }
 
+function assertAuthProfileMigrationSourcesUnchanged(
+  candidate: AuthProfileSqliteMigrationCandidate,
+  receipts: readonly AuthProfileMigrationSourceReceipt[],
+): void {
+  const receiptByPath = new Map(receipts.map((receipt) => [receipt.sourcePath, receipt]));
+  for (const pathname of [candidate.authPath, candidate.statePath, candidate.legacyPath]) {
+    const receipt = receiptByPath.get(path.resolve(pathname));
+    if (fs.existsSync(pathname) !== Boolean(receipt)) {
+      throw new Error("legacy auth source set changed during migration; retry Doctor");
+    }
+    if (!receipt) {
+      continue;
+    }
+    const currentSha256 = createHash("sha256").update(fs.readFileSync(pathname)).digest("hex");
+    if (currentSha256 !== receipt.sourceSha256) {
+      throw new Error("legacy auth source changed during migration; retry Doctor");
+    }
+  }
+}
+
+function parseAuthProfileMigrationSource(
+  receipt: AuthProfileMigrationSourceReceipt | undefined,
+): unknown {
+  if (!receipt?.sourceBytes) {
+    return null;
+  }
+  try {
+    return JSON.parse(receipt.sourceBytes.toString("utf8")) as unknown;
+  } catch {
+    return null;
+  }
+}
+
 function archivePreviouslyMigratedAuthProfileSource(
   receipt: AuthProfileMigrationSourceReceipt,
   result: LegacyFlatAuthProfileRepairResult,
@@ -1057,11 +1091,11 @@ export async function maybeMigrateAuthProfileJsonStoresToSqlite(params: {
   for (const candidate of detected) {
     let releaseSources: (() => void) | undefined;
     try {
-      releaseSources = acquireAuthProfileMigrationSourceLocks(
-        [candidate.authPath, candidate.statePath, candidate.legacyPath].filter((pathname) =>
-          fs.existsSync(pathname),
-        ),
-      );
+      const candidateSourcePaths = [candidate.authPath, candidate.statePath, candidate.legacyPath];
+      for (const pathname of candidateSourcePaths) {
+        fs.mkdirSync(path.dirname(pathname), { recursive: true });
+      }
+      releaseSources = acquireAuthProfileMigrationSourceLocks(candidateSourcePaths);
       const targetDatabasePath = resolveAuthProfileDatabasePath(candidate.agentDir);
       let sourceReceipts = [
         ...(fs.existsSync(candidate.authPath)
@@ -1101,10 +1135,16 @@ export async function maybeMigrateAuthProfileJsonStoresToSqlite(params: {
       sourceReceipts = sourceReceipts.filter(
         (receipt) => !archivePreviouslyMigratedAuthProfileSource(receipt, result),
       );
+      assertAuthProfileMigrationSourcesUnchanged(candidate, sourceReceipts);
       if (sourceReceipts.length === 0 && !configStore) {
         continue;
       }
-      const rawStore = fs.existsSync(candidate.authPath) ? loadJsonFile(candidate.authPath) : null;
+      const receiptByPath = new Map(
+        sourceReceipts.map((receipt) => [receipt.sourcePath, receipt] as const),
+      );
+      const rawStore = parseAuthProfileMigrationSource(
+        receiptByPath.get(path.resolve(candidate.authPath)),
+      );
       const unresolvedSidecarProfileIds = new Set(
         collectUnresolvedLegacyOAuthSidecarProfileIds(rawStore),
       );
@@ -1149,10 +1189,12 @@ export async function maybeMigrateAuthProfileJsonStoresToSqlite(params: {
         : null;
       const configCanonicalStore =
         configStore && isDefaultAgentCandidate(candidate, params.cfg, env) ? configStore : null;
-      const legacyStore = coerceLegacyAuthStore(loadJsonFile(candidate.legacyPath));
-      const rawState = fs.existsSync(candidate.statePath)
-        ? loadJsonFile(candidate.statePath)
-        : null;
+      const legacyStore = coerceLegacyAuthStore(
+        parseAuthProfileMigrationSource(receiptByPath.get(path.resolve(candidate.legacyPath))),
+      );
+      const rawState = parseAuthProfileMigrationSource(
+        receiptByPath.get(path.resolve(candidate.statePath)),
+      );
       const state = coerceAuthProfileState(rawState);
       if (
         !canonicalStore &&
@@ -1244,6 +1286,7 @@ export async function maybeMigrateAuthProfileJsonStoresToSqlite(params: {
             : []),
         ];
         try {
+          assertAuthProfileMigrationSourcesUnchanged(candidate, sourceReceipts);
           verifiedStore = runAuthProfileWriteTransaction(candidate.agentDir, (database) => {
             const authoritative = loadAuthProfileMigrationTargetStore(
               candidate.agentDir,
@@ -1328,6 +1371,7 @@ export async function maybeMigrateAuthProfileJsonStoresToSqlite(params: {
       const archivalReceipts = unresolvedSidecarRawStore
         ? sourceReceipts.filter((receipt) => receipt.sourcePath !== candidate.authPath)
         : sourceReceipts;
+      assertAuthProfileMigrationSourcesUnchanged(candidate, sourceReceipts);
       const archives = archivalReceipts.map((receipt) =>
         archiveVerifiedAuthProfileSource(receipt, true),
       );

--- a/src/commands/doctor-auth-flat-profiles.ts
+++ b/src/commands/doctor-auth-flat-profiles.ts
@@ -1339,7 +1339,16 @@ export async function maybeMigrateAuthProfileJsonStoresToSqlite(params: {
       releaseSources?.();
     }
   }
-  if (hasLegacyOAuth) {
+  const sharedMainAgentDir = resolveSharedMainAuthAgentDir(env);
+  const sharedMainCredentialSourceRemains = [
+    resolveAuthStorePath(sharedMainAgentDir),
+    resolveLegacyAuthStorePath(sharedMainAgentDir),
+  ].some((pathname) => fs.existsSync(pathname));
+  if (hasLegacyOAuth && sharedMainCredentialSourceRemains) {
+    result.warnings.push(
+      `Deferred shared legacy OAuth migration until higher-priority shared-main credential sources are resolved by ${formatCliCommand("openclaw doctor --fix")}.`,
+    );
+  } else if (hasLegacyOAuth) {
     try {
       migrateLegacyOAuthFile({ oauthPath, env, now, result });
     } catch {

--- a/src/commands/doctor-auth-flat-profiles.ts
+++ b/src/commands/doctor-auth-flat-profiles.ts
@@ -20,6 +20,7 @@ import {
 } from "../agents/auth-profiles/persisted.js";
 import { resolveSharedMainAuthAgentDir } from "../agents/auth-profiles/shared-main-dir.js";
 import {
+  inspectPersistedAuthProfileStateRaw,
   inspectPersistedAuthProfileStoreRaw,
   readPersistedAuthProfileStateRaw,
   resolveAuthProfileDatabasePath,
@@ -841,7 +842,15 @@ function loadAuthProfileMigrationTargetStore(
   if (inspection.status !== "missing") {
     throw new Error("canonical auth profile store is unreadable; legacy source left in place");
   }
-  return { version: AUTH_STORE_VERSION, profiles: {} };
+  const stateInspection = inspectPersistedAuthProfileStateRaw(agentDir, database);
+  if (stateInspection.status === "unreadable") {
+    throw new Error("canonical auth profile state is unreadable; legacy source left in place");
+  }
+  return {
+    version: AUTH_STORE_VERSION,
+    profiles: {},
+    ...coerceAuthProfileState(readPersistedAuthProfileStateRaw(agentDir, database)),
+  };
 }
 
 function migrateLegacyOAuthFile(params: {
@@ -910,6 +919,9 @@ function migrateLockedLegacyOAuthFile(params: {
       mainAgentDir,
       {
         filterExternalAuthProfiles: false,
+        preserveStateProfileIds: collectAuthProfileStateProfileIds(
+          coerceAuthProfileState(existing),
+        ),
         syncExternalCli: false,
       },
       database,

--- a/src/commands/doctor-auth-flat-profiles.ts
+++ b/src/commands/doctor-auth-flat-profiles.ts
@@ -1290,9 +1290,9 @@ export async function maybeMigrateAuthProfileJsonStoresToSqlite(params: {
 
       const expectedProfileSha256 = Object.fromEntries(
         [...importedProfileIds].flatMap((profileId) => {
-          const credential = verifiedStore.profiles[profileId];
-          return credential
-            ? [[profileId, digestAuthProfileMigrationValue(credential)] as const]
+          const profileValue = verifiedStore.profiles[profileId];
+          return profileValue
+            ? [[profileId, digestAuthProfileMigrationValue(profileValue)] as const]
             : [];
         }),
       );

--- a/src/commands/doctor-auth-legacy-paths.ts
+++ b/src/commands/doctor-auth-legacy-paths.ts
@@ -1,0 +1,19 @@
+import path from "node:path";
+import { resolveSharedMainAuthAgentDir } from "../agents/auth-profiles/shared-main-dir.js";
+import { resolveUserPath } from "../utils.js";
+
+function resolveLegacyAuthAgentDir(agentDir?: string): string {
+  return agentDir ? resolveUserPath(agentDir) : resolveSharedMainAuthAgentDir();
+}
+
+export function resolveLegacyAuthProfilesPath(agentDir?: string): string {
+  return path.join(resolveLegacyAuthAgentDir(agentDir), "auth-profiles.json");
+}
+
+export function resolveLegacyAuthStatePath(agentDir?: string): string {
+  return path.join(resolveLegacyAuthAgentDir(agentDir), "auth-state.json");
+}
+
+export function resolveLegacyFlatAuthPath(agentDir?: string): string {
+  return path.join(resolveLegacyAuthAgentDir(agentDir), "auth.json");
+}

--- a/src/commands/doctor-auth-migration-receipts.test.ts
+++ b/src/commands/doctor-auth-migration-receipts.test.ts
@@ -82,6 +82,17 @@ describe("auth profile migration receipts", () => {
     expect(row).toEqual({ status: "completed", removed_source: 1 });
   });
 
+  it("archives an empty receipt without requiring a target database", async () => {
+    const { state, sourcePath, receipt } = await makeReceipt();
+    receipt.expectedProfileSha256 = {};
+    recordAuthProfileMigrationImported(receipt);
+
+    expect(resumePendingAuthProfileMigrationArchives(state.env)).toHaveLength(1);
+    expect(fs.existsSync(sourcePath)).toBe(false);
+    expect(fs.existsSync(receipt.archivePath)).toBe(true);
+    expect(fs.existsSync(receipt.targetDatabasePath)).toBe(false);
+  });
+
   it("resumes after archive rename but before receipt finalization", async () => {
     const { state, receipt } = await makeReceipt();
     recordAuthProfileMigrationImported(receipt);

--- a/src/commands/doctor-auth-migration-receipts.test.ts
+++ b/src/commands/doctor-auth-migration-receipts.test.ts
@@ -14,10 +14,21 @@ import {
   archiveAuthProfileMigrationSource,
   createAuthProfileMigrationSourceReceipt,
   digestAuthProfileMigrationValue,
-  recordAuthProfileMigrationCompleted,
-  recordAuthProfileMigrationImported,
   resumePendingAuthProfileMigrationArchives,
 } from "./doctor-auth-migration-receipts.js";
+
+type MigrationReceiptTestApi = {
+  recordAuthProfileMigrationImported: (
+    receipt: ReturnType<typeof createAuthProfileMigrationSourceReceipt>,
+  ) => void;
+  recordAuthProfileMigrationCompleted: (
+    receipt: ReturnType<typeof createAuthProfileMigrationSourceReceipt>,
+  ) => void;
+};
+
+const { recordAuthProfileMigrationImported, recordAuthProfileMigrationCompleted } = (
+  globalThis as Record<PropertyKey, unknown>
+)[Symbol.for("openclaw.authProfileMigrationReceiptsTestApi")] as MigrationReceiptTestApi;
 
 describe("auth profile migration receipts", () => {
   const states: OpenClawTestState[] = [];

--- a/src/commands/doctor-auth-migration-receipts.test.ts
+++ b/src/commands/doctor-auth-migration-receipts.test.ts
@@ -24,11 +24,18 @@ type MigrationReceiptTestApi = {
   recordAuthProfileMigrationCompleted: (
     receipt: ReturnType<typeof createAuthProfileMigrationSourceReceipt>,
   ) => void;
+  restoreAuthProfileMigrationArchiveNoClobber: (
+    receipt: ReturnType<typeof createAuthProfileMigrationSourceReceipt>,
+  ) => "restored" | "source-exists";
 };
 
-const { recordAuthProfileMigrationImported, recordAuthProfileMigrationCompleted } = (
-  globalThis as Record<PropertyKey, unknown>
-)[Symbol.for("openclaw.authProfileMigrationReceiptsTestApi")] as MigrationReceiptTestApi;
+const {
+  recordAuthProfileMigrationImported,
+  recordAuthProfileMigrationCompleted,
+  restoreAuthProfileMigrationArchiveNoClobber,
+} = (globalThis as Record<PropertyKey, unknown>)[
+  Symbol.for("openclaw.authProfileMigrationReceiptsTestApi")
+] as MigrationReceiptTestApi;
 
 describe("auth profile migration receipts", () => {
   const states: OpenClawTestState[] = [];
@@ -81,6 +88,46 @@ describe("auth profile migration receipts", () => {
     archiveAuthProfileMigrationSource(receipt);
 
     expect(resumePendingAuthProfileMigrationArchives(state.env)).toHaveLength(1);
+    expect(fs.existsSync(receipt.archivePath)).toBe(true);
+  });
+
+  it("restores an archive for retry when its SQLite target was rolled back", async () => {
+    const { state, sourcePath, receipt } = await makeReceipt();
+    fs.mkdirSync(path.dirname(receipt.targetDatabasePath), { recursive: true });
+    const target = new DatabaseSync(receipt.targetDatabasePath);
+    target.exec(
+      "CREATE TABLE auth_profile_store (store_key TEXT PRIMARY KEY, store_json TEXT NOT NULL, updated_at INTEGER NOT NULL)",
+    );
+    const profileValue = { type: "oauth", provider: "openai", refresh: "not-a-real" };
+    target
+      .prepare("INSERT INTO auth_profile_store VALUES ('primary', ?, 1)")
+      .run(JSON.stringify({ version: 1, profiles: { "openai:default": profileValue } }));
+    receipt.expectedProfileSha256 = {
+      "openai:default": digestAuthProfileMigrationValue(profileValue),
+    };
+    recordAuthProfileMigrationImported(receipt);
+    archiveAuthProfileMigrationSource(receipt);
+    target.prepare("DELETE FROM auth_profile_store").run();
+    target.close();
+
+    expect(resumePendingAuthProfileMigrationArchives(state.env)).toEqual([
+      "Reset an interrupted auth migration receipt for retry.",
+    ]);
+    expect(fs.existsSync(sourcePath)).toBe(true);
+    expect(fs.existsSync(receipt.archivePath)).toBe(false);
+    const row = openOpenClawStateDatabase({ env: state.env })
+      .db.prepare("SELECT status FROM migration_sources WHERE source_key = ?")
+      .get(receipt.sourceKey);
+    expect(row).toEqual({ status: "retryable" });
+  });
+
+  it("does not overwrite a source recreated before archive restoration", async () => {
+    const { sourcePath, receipt } = await makeReceipt();
+    archiveAuthProfileMigrationSource(receipt);
+    fs.writeFileSync(sourcePath, '{"newer":true}\n', "utf8");
+
+    expect(restoreAuthProfileMigrationArchiveNoClobber(receipt)).toBe("source-exists");
+    expect(fs.readFileSync(sourcePath, "utf8")).toBe('{"newer":true}\n');
     expect(fs.existsSync(receipt.archivePath)).toBe(true);
   });
 

--- a/src/commands/doctor-auth-migration-receipts.test.ts
+++ b/src/commands/doctor-auth-migration-receipts.test.ts
@@ -89,11 +89,15 @@ describe("auth profile migration receipts", () => {
     recordAuthProfileMigrationImported(receipt);
     fs.writeFileSync(sourcePath, '{"changed":true}\n', "utf8");
 
-    expect(() => resumePendingAuthProfileMigrationArchives(state.env)).toThrow(
-      "legacy auth source changed after verification",
-    );
+    expect(resumePendingAuthProfileMigrationArchives(state.env)).toEqual([
+      "Retired an interrupted auth migration receipt for a changed source.",
+    ]);
     expect(fs.existsSync(sourcePath)).toBe(true);
     expect(fs.existsSync(receipt.archivePath)).toBe(false);
+    const row = openOpenClawStateDatabase({ env: state.env })
+      .db.prepare("SELECT status FROM migration_sources WHERE source_key = ?")
+      .get(receipt.sourceKey);
+    expect(row).toEqual({ status: "superseded" });
   });
 
   it("revalidates target credentials before resuming an archive", async () => {
@@ -114,10 +118,12 @@ describe("auth profile migration receipts", () => {
     target.prepare("DELETE FROM auth_profile_store").run();
     target.close();
 
-    expect(() => resumePendingAuthProfileMigrationArchives(state.env)).toThrow(
-      "auth profile migration target verification failed",
-    );
+    expect(resumePendingAuthProfileMigrationArchives(state.env)).toEqual([
+      "Reset an interrupted auth migration receipt for retry.",
+    ]);
     expect(fs.existsSync(sourcePath)).toBe(true);
+    const retry = { ...receipt, runId: `${receipt.sourceKey}:retry` };
+    expect(() => recordAuthProfileMigrationImported(retry)).not.toThrow();
   });
 
   it("revalidates target state before resuming an archive", async () => {
@@ -141,9 +147,9 @@ describe("auth profile migration receipts", () => {
     target.prepare("DELETE FROM auth_profile_state").run();
     target.close();
 
-    expect(() => resumePendingAuthProfileMigrationArchives(state.env)).toThrow(
-      "auth profile migration target verification failed",
-    );
+    expect(resumePendingAuthProfileMigrationArchives(state.env)).toEqual([
+      "Reset an interrupted auth migration receipt for retry.",
+    ]);
     expect(fs.existsSync(sourcePath)).toBe(true);
   });
 

--- a/src/commands/doctor-auth-migration-receipts.test.ts
+++ b/src/commands/doctor-auth-migration-receipts.test.ts
@@ -1,0 +1,172 @@
+import fs from "node:fs";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../state/openclaw-state-db.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../test-utils/openclaw-test-state.js";
+import {
+  archiveAuthProfileMigrationSource,
+  createAuthProfileMigrationSourceReceipt,
+  digestAuthProfileMigrationValue,
+  recordAuthProfileMigrationCompleted,
+  recordAuthProfileMigrationImported,
+  resumePendingAuthProfileMigrationArchives,
+} from "./doctor-auth-migration-receipts.js";
+
+describe("auth profile migration receipts", () => {
+  const states: OpenClawTestState[] = [];
+
+  afterEach(async () => {
+    closeOpenClawStateDatabaseForTest();
+    for (const state of states.splice(0)) {
+      await state.cleanup();
+    }
+  });
+
+  async function makeReceipt() {
+    const state = await createOpenClawTestState({
+      layout: "state-only",
+      prefix: "openclaw-auth-receipt-",
+    });
+    states.push(state);
+    const sourcePath = await state.writeText(
+      "credentials/oauth.json",
+      `${JSON.stringify({ openai: { access: "fake", refresh: "fake", expires: 42 } })}\n`,
+    );
+    const receipt = createAuthProfileMigrationSourceReceipt({
+      sourcePath,
+      sourceBytes: fs.readFileSync(sourcePath),
+      sourceRecordCount: 1,
+      targetDatabasePath: path.join(state.agentDir(), "openclaw-agent.sqlite"),
+      targetTable: "auth_profile_store",
+      now: new Date("2026-07-25T12:00:00.000Z"),
+      env: state.env,
+    });
+    return { state, sourcePath, receipt };
+  }
+
+  it("resumes after target commit and receipt but before archive", async () => {
+    const { state, sourcePath, receipt } = await makeReceipt();
+    recordAuthProfileMigrationImported(receipt);
+
+    expect(resumePendingAuthProfileMigrationArchives(state.env)).toHaveLength(1);
+    expect(fs.existsSync(sourcePath)).toBe(false);
+    expect(fs.existsSync(receipt.archivePath)).toBe(true);
+    const row = openOpenClawStateDatabase({ env: state.env })
+      .db.prepare("SELECT status, removed_source FROM migration_sources WHERE source_key = ?")
+      .get(receipt.sourceKey);
+    expect(row).toEqual({ status: "completed", removed_source: 1 });
+  });
+
+  it("resumes after archive rename but before receipt finalization", async () => {
+    const { state, receipt } = await makeReceipt();
+    recordAuthProfileMigrationImported(receipt);
+    archiveAuthProfileMigrationSource(receipt);
+
+    expect(resumePendingAuthProfileMigrationArchives(state.env)).toHaveLength(1);
+    expect(fs.existsSync(receipt.archivePath)).toBe(true);
+  });
+
+  it("does not archive bytes that changed after verification", async () => {
+    const { state, sourcePath, receipt } = await makeReceipt();
+    recordAuthProfileMigrationImported(receipt);
+    fs.writeFileSync(sourcePath, '{"changed":true}\n', "utf8");
+
+    expect(() => resumePendingAuthProfileMigrationArchives(state.env)).toThrow(
+      "legacy auth source changed after verification",
+    );
+    expect(fs.existsSync(sourcePath)).toBe(true);
+    expect(fs.existsSync(receipt.archivePath)).toBe(false);
+  });
+
+  it("revalidates target credentials before resuming an archive", async () => {
+    const { state, sourcePath, receipt } = await makeReceipt();
+    fs.mkdirSync(path.dirname(receipt.targetDatabasePath), { recursive: true });
+    const target = new DatabaseSync(receipt.targetDatabasePath);
+    target.exec(
+      "CREATE TABLE auth_profile_store (store_key TEXT PRIMARY KEY, store_json TEXT NOT NULL, updated_at INTEGER NOT NULL)",
+    );
+    const credential = { type: "oauth", provider: "openai", refresh: "fake" };
+    target
+      .prepare("INSERT INTO auth_profile_store VALUES ('primary', ?, 1)")
+      .run(JSON.stringify({ version: 1, profiles: { "openai:default": credential } }));
+    receipt.expectedProfileSha256 = {
+      "openai:default": digestAuthProfileMigrationValue(credential),
+    };
+    recordAuthProfileMigrationImported(receipt);
+    target.prepare("DELETE FROM auth_profile_store").run();
+    target.close();
+
+    expect(() => resumePendingAuthProfileMigrationArchives(state.env)).toThrow(
+      "auth profile migration target verification failed",
+    );
+    expect(fs.existsSync(sourcePath)).toBe(true);
+  });
+
+  it("revalidates target state before resuming an archive", async () => {
+    const { state, sourcePath, receipt } = await makeReceipt();
+    receipt.targetTable = "auth_profile_state";
+    fs.mkdirSync(path.dirname(receipt.targetDatabasePath), { recursive: true });
+    const target = new DatabaseSync(receipt.targetDatabasePath);
+    target.exec(
+      "CREATE TABLE auth_profile_state (state_key TEXT PRIMARY KEY, state_json TEXT NOT NULL, updated_at INTEGER NOT NULL)",
+    );
+    const persistedState = {
+      version: 1,
+      order: { openai: ["openai:default"] },
+      lastGood: { openai: "openai:default" },
+    };
+    target
+      .prepare("INSERT INTO auth_profile_state VALUES ('primary', ?, 1)")
+      .run(JSON.stringify(persistedState));
+    receipt.expectedStateSha256 = digestAuthProfileMigrationValue(persistedState);
+    recordAuthProfileMigrationImported(receipt);
+    target.prepare("DELETE FROM auth_profile_state").run();
+    target.close();
+
+    expect(() => resumePendingAuthProfileMigrationArchives(state.env)).toThrow(
+      "auth profile migration target verification failed",
+    );
+    expect(fs.existsSync(sourcePath)).toBe(true);
+  });
+
+  it("does not replace a pending receipt owned by another doctor", async () => {
+    const { receipt } = await makeReceipt();
+    recordAuthProfileMigrationImported(receipt);
+    const competing = { ...receipt, runId: `${receipt.sourceKey}:competing` };
+
+    expect(() => recordAuthProfileMigrationImported(competing)).toThrow(
+      "auth profile migration source already owned by imported receipt",
+    );
+  });
+
+  it("does not replace a terminal receipt with a replay run", async () => {
+    const { receipt } = await makeReceipt();
+    recordAuthProfileMigrationImported(receipt);
+    recordAuthProfileMigrationCompleted(receipt);
+    const replay = { ...receipt, runId: `${receipt.sourceKey}:replay` };
+
+    expect(() => recordAuthProfileMigrationImported(replay)).toThrow(
+      "auth profile migration source already owned by completed receipt",
+    );
+  });
+
+  it("preserves archived-unparsed status when resuming after rename", async () => {
+    const { state, receipt } = await makeReceipt();
+    receipt.completionStatus = "archived-unparsed";
+    recordAuthProfileMigrationImported(receipt);
+    archiveAuthProfileMigrationSource(receipt);
+
+    resumePendingAuthProfileMigrationArchives(state.env);
+    const row = openOpenClawStateDatabase({ env: state.env })
+      .db.prepare("SELECT status FROM migration_sources WHERE source_key = ?")
+      .get(receipt.sourceKey);
+    expect(row).toEqual({ status: "archived-unparsed" });
+  });
+});

--- a/src/commands/doctor-auth-migration-receipts.ts
+++ b/src/commands/doctor-auth-migration-receipts.ts
@@ -1,0 +1,376 @@
+import { createHash, randomUUID } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { acquireLockSyncWithRetry } from "../agents/sessions/storage-lock.js";
+import {
+  executeSqliteQuerySync,
+  executeSqliteQueryTakeFirstSync,
+  getNodeSqliteKysely,
+} from "../infra/kysely-sync.js";
+import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
+import type { DB as OpenClawStateDatabase } from "../state/openclaw-state-db.generated.js";
+import {
+  openOpenClawStateDatabase,
+  runOpenClawStateWriteTransaction,
+} from "../state/openclaw-state-db.js";
+
+const MIGRATION_KIND = "auth-profile-json-to-sqlite-v2";
+type MigrationDatabase = Pick<OpenClawStateDatabase, "migration_runs" | "migration_sources">;
+
+export type AuthProfileMigrationSourceReceipt = {
+  sourceKey: string;
+  runId: string;
+  sourcePath: string;
+  sourceSha256: string;
+  sourceSizeBytes: number;
+  sourceRecordCount: number;
+  targetDatabasePath: string;
+  targetTable: "auth_profile_store" | "auth_profile_state";
+  archivePath: string;
+  expectedProfileSha256?: Record<string, string>;
+  expectedStateSha256?: string;
+  completionStatus?: "completed" | "archived-unparsed";
+  env?: NodeJS.ProcessEnv;
+};
+
+function digestBytes(bytes: Buffer): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+export function createAuthProfileMigrationSourceReceipt(params: {
+  sourcePath: string;
+  sourceBytes: Buffer;
+  sourceRecordCount: number;
+  targetDatabasePath: string;
+  targetTable: AuthProfileMigrationSourceReceipt["targetTable"];
+  now?: Date;
+  env?: NodeJS.ProcessEnv;
+}): AuthProfileMigrationSourceReceipt {
+  const sourcePath = path.resolve(params.sourcePath);
+  const sourceSha256 = digestBytes(params.sourceBytes);
+  const sourceKey = `auth-profile-v2:${digestBytes(Buffer.from(`${sourcePath}\0${sourceSha256}`))}`;
+  const stamp = (params.now ?? new Date()).toISOString().replaceAll(":", "-");
+  return {
+    sourceKey,
+    runId: `${sourceKey}:${randomUUID()}`,
+    sourcePath,
+    sourceSha256,
+    sourceSizeBytes: params.sourceBytes.byteLength,
+    sourceRecordCount: params.sourceRecordCount,
+    targetDatabasePath: path.resolve(params.targetDatabasePath),
+    targetTable: params.targetTable,
+    archivePath: `${sourcePath}.migrated-${stamp}-${randomUUID()}`,
+    ...(params.env ? { env: params.env } : {}),
+  };
+}
+
+function reportJson(receipt: AuthProfileMigrationSourceReceipt): string {
+  return JSON.stringify({
+    format: MIGRATION_KIND,
+    archivePath: receipt.archivePath,
+    targetDatabasePath: receipt.targetDatabasePath,
+    targetTable: receipt.targetTable,
+    expectedProfileSha256: receipt.expectedProfileSha256,
+    expectedStateSha256: receipt.expectedStateSha256,
+    completionStatus: receipt.completionStatus ?? "completed",
+  });
+}
+
+export function digestAuthProfileMigrationValue(value: unknown): string {
+  return digestBytes(Buffer.from(JSON.stringify(value) ?? "<undefined>"));
+}
+
+export function recordAuthProfileMigrationImported(
+  receipt: AuthProfileMigrationSourceReceipt,
+  now = Date.now(),
+): void {
+  runOpenClawStateWriteTransaction(
+    ({ db }) => {
+      const kysely = getNodeSqliteKysely<MigrationDatabase>(db);
+      const existing = executeSqliteQueryTakeFirstSync(
+        db,
+        kysely
+          .selectFrom("migration_sources")
+          .select(["last_run_id", "status"])
+          .where("source_key", "=", receipt.sourceKey),
+      );
+      if (existing && existing.last_run_id !== receipt.runId) {
+        throw new Error(
+          `auth profile migration source already owned by ${existing.status} receipt`,
+        );
+      }
+      executeSqliteQuerySync(
+        db,
+        kysely
+          .insertInto("migration_runs")
+          .values({
+            id: receipt.runId,
+            started_at: now,
+            finished_at: null,
+            status: "imported",
+            report_json: reportJson(receipt),
+          })
+          .onConflict((conflict) => conflict.column("id").doNothing()),
+      );
+      executeSqliteQuerySync(
+        db,
+        kysely
+          .insertInto("migration_sources")
+          .values({
+            source_key: receipt.sourceKey,
+            migration_kind: MIGRATION_KIND,
+            source_path: receipt.sourcePath,
+            target_table: receipt.targetTable,
+            source_sha256: receipt.sourceSha256,
+            source_size_bytes: receipt.sourceSizeBytes,
+            source_record_count: receipt.sourceRecordCount,
+            last_run_id: receipt.runId,
+            status: "imported",
+            imported_at: now,
+            removed_source: 0,
+            report_json: reportJson(receipt),
+          })
+          .onConflict((conflict) =>
+            conflict.column("source_key").doUpdateSet({
+              last_run_id: receipt.runId,
+              status: "imported",
+              imported_at: now,
+              removed_source: 0,
+              report_json: reportJson(receipt),
+            }),
+          ),
+      );
+    },
+    { env: receipt.env },
+  );
+}
+
+export function recordAuthProfileMigrationCompleted(
+  receipt: AuthProfileMigrationSourceReceipt,
+  now = Date.now(),
+  status: "completed" | "archived-unparsed" = "completed",
+): void {
+  runOpenClawStateWriteTransaction(
+    ({ db }) => {
+      const kysely = getNodeSqliteKysely<MigrationDatabase>(db);
+      executeSqliteQuerySync(
+        db,
+        kysely
+          .updateTable("migration_runs")
+          .set({ status, finished_at: now })
+          .where("id", "=", receipt.runId),
+      );
+      executeSqliteQuerySync(
+        db,
+        kysely
+          .updateTable("migration_sources")
+          .set({ status, removed_source: 1 })
+          .where("source_key", "=", receipt.sourceKey)
+          .where("last_run_id", "=", receipt.runId),
+      );
+    },
+    { env: receipt.env },
+  );
+}
+
+export function archiveAuthProfileMigrationSource(
+  receipt: AuthProfileMigrationSourceReceipt,
+): void {
+  if (fs.existsSync(receipt.sourcePath)) {
+    const sourceBytes = fs.readFileSync(receipt.sourcePath);
+    if (digestBytes(sourceBytes) !== receipt.sourceSha256) {
+      throw new Error("legacy auth source changed after verification");
+    }
+    fs.renameSync(receipt.sourcePath, receipt.archivePath);
+  }
+  const archiveBytes = fs.readFileSync(receipt.archivePath);
+  if (digestBytes(archiveBytes) !== receipt.sourceSha256) {
+    throw new Error("legacy auth archive verification failed");
+  }
+}
+
+export function acquireAuthProfileMigrationSourceLocks(sourcePaths: readonly string[]): () => void {
+  const releases: Array<() => void> = [];
+  try {
+    for (const sourcePath of [
+      ...new Set(sourcePaths.map((entry) => path.resolve(entry))),
+    ].toSorted()) {
+      releases.push(acquireLockSyncWithRetry(sourcePath));
+    }
+  } catch (error) {
+    for (const release of releases.toReversed()) {
+      release();
+    }
+    throw error;
+  }
+  return () => {
+    for (const release of releases.toReversed()) {
+      release();
+    }
+  };
+}
+
+function verifyAuthProfileMigrationTarget(receipt: AuthProfileMigrationSourceReceipt): void {
+  if (!receipt.expectedProfileSha256 && !receipt.expectedStateSha256) {
+    return;
+  }
+  const db = openNodeSqliteDatabase(receipt.targetDatabasePath, { readOnly: true });
+  try {
+    if (receipt.expectedProfileSha256) {
+      const row = db
+        .prepare("SELECT store_json FROM auth_profile_store WHERE store_key = 'primary'")
+        .get() as { store_json?: unknown } | undefined;
+      const store = typeof row?.store_json === "string" ? JSON.parse(row.store_json) : null;
+      for (const [profileId, expectedSha256] of Object.entries(receipt.expectedProfileSha256)) {
+        if (digestAuthProfileMigrationValue(store?.profiles?.[profileId]) !== expectedSha256) {
+          throw new Error("auth profile migration target verification failed");
+        }
+      }
+    }
+    if (receipt.expectedStateSha256) {
+      const row = db
+        .prepare("SELECT state_json FROM auth_profile_state WHERE state_key = 'primary'")
+        .get() as { state_json?: unknown } | undefined;
+      const state = typeof row?.state_json === "string" ? JSON.parse(row.state_json) : null;
+      if (digestAuthProfileMigrationValue(state) !== receipt.expectedStateSha256) {
+        throw new Error("auth profile migration target verification failed");
+      }
+    }
+  } finally {
+    db.close();
+  }
+}
+
+export function finalizeAuthProfileMigrationSource(
+  receipt: AuthProfileMigrationSourceReceipt,
+  status: "completed" | "archived-unparsed" = "completed",
+  options: { sourceLocked?: boolean } = {},
+): void {
+  receipt.completionStatus = status;
+  const release = options.sourceLocked ? undefined : acquireLockSyncWithRetry(receipt.sourcePath);
+  try {
+    recordAuthProfileMigrationImported(receipt);
+    verifyAuthProfileMigrationTarget(receipt);
+    archiveAuthProfileMigrationSource(receipt);
+    recordAuthProfileMigrationCompleted(receipt, Date.now(), status);
+  } finally {
+    release?.();
+  }
+}
+
+export function resumePendingAuthProfileMigrationArchives(env?: NodeJS.ProcessEnv): string[] {
+  const changes: string[] = [];
+  const database = openOpenClawStateDatabase({ env });
+  const kysely = getNodeSqliteKysely<MigrationDatabase>(database.db);
+  const rows = executeSqliteQuerySync(
+    database.db,
+    kysely
+      .selectFrom("migration_sources as source")
+      .innerJoin("migration_runs as run", "run.id", "source.last_run_id")
+      .select([
+        "source.source_key",
+        "source.source_path",
+        "source.source_sha256",
+        "source.source_size_bytes",
+        "source.source_record_count",
+        "source.target_table",
+        "source.last_run_id",
+        "source.report_json",
+      ])
+      .where("source.migration_kind", "=", MIGRATION_KIND)
+      .where("source.status", "=", "imported")
+      .where("source.removed_source", "=", 0),
+  ).rows;
+  for (const row of rows) {
+    const report = JSON.parse(row.report_json) as Record<string, unknown>;
+    if (
+      typeof row.source_sha256 !== "string" ||
+      typeof row.source_size_bytes !== "number" ||
+      typeof row.source_record_count !== "number" ||
+      typeof report.archivePath !== "string" ||
+      typeof report.targetDatabasePath !== "string" ||
+      (row.target_table !== "auth_profile_store" && row.target_table !== "auth_profile_state")
+    ) {
+      throw new Error("invalid pending auth profile migration receipt");
+    }
+    const receipt: AuthProfileMigrationSourceReceipt = {
+      sourceKey: row.source_key,
+      runId: row.last_run_id,
+      sourcePath: row.source_path,
+      sourceSha256: row.source_sha256,
+      sourceSizeBytes: row.source_size_bytes,
+      sourceRecordCount: row.source_record_count,
+      targetDatabasePath: report.targetDatabasePath,
+      targetTable: row.target_table,
+      archivePath: report.archivePath,
+      ...(isRecordOfStrings(report.expectedProfileSha256)
+        ? { expectedProfileSha256: report.expectedProfileSha256 }
+        : {}),
+      ...(typeof report.expectedStateSha256 === "string"
+        ? { expectedStateSha256: report.expectedStateSha256 }
+        : {}),
+      completionStatus:
+        report.completionStatus === "archived-unparsed" ? "archived-unparsed" : "completed",
+      ...(env ? { env } : {}),
+    };
+    if (!fs.existsSync(receipt.sourcePath) && !fs.existsSync(receipt.archivePath)) {
+      throw new Error("pending auth profile migration has neither source nor archive");
+    }
+    const lockTarget = fs.existsSync(receipt.sourcePath) ? receipt.sourcePath : receipt.archivePath;
+    const release = acquireLockSyncWithRetry(lockTarget);
+    try {
+      if (fs.existsSync(receipt.sourcePath)) {
+        verifyAuthProfileMigrationTarget(receipt);
+      }
+      archiveAuthProfileMigrationSource(receipt);
+      recordAuthProfileMigrationCompleted(
+        receipt,
+        Date.now(),
+        receipt.completionStatus ?? "completed",
+      );
+    } finally {
+      release();
+    }
+    changes.push(`Finalized interrupted auth profile archive -> ${receipt.archivePath}`);
+  }
+  return changes;
+}
+
+function isRecordOfStrings(value: unknown): value is Record<string, string> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    Object.values(value).every((entry) => typeof entry === "string")
+  );
+}
+
+export function hasCompletedAuthProfileMigrationReceipt(
+  sourceKey: string,
+  env?: NodeJS.ProcessEnv,
+): boolean {
+  const database = openOpenClawStateDatabase({ env });
+  const row = executeSqliteQueryTakeFirstSync(
+    database.db,
+    getNodeSqliteKysely<MigrationDatabase>(database.db)
+      .selectFrom("migration_sources")
+      .select("status")
+      .where("source_key", "=", sourceKey),
+  );
+  return row?.status === "completed";
+}
+
+export function hasTerminalAuthProfileMigrationReceipt(
+  sourceKey: string,
+  env?: NodeJS.ProcessEnv,
+): boolean {
+  const database = openOpenClawStateDatabase({ env });
+  const row = executeSqliteQueryTakeFirstSync(
+    database.db,
+    getNodeSqliteKysely<MigrationDatabase>(database.db)
+      .selectFrom("migration_sources")
+      .select("status")
+      .where("source_key", "=", sourceKey),
+  );
+  return row?.status === "completed" || row?.status === "archived-unparsed";
+}

--- a/src/commands/doctor-auth-migration-receipts.ts
+++ b/src/commands/doctor-auth-migration-receipts.ts
@@ -29,6 +29,8 @@ export type AuthProfileMigrationSourceReceipt = {
   sourceSha256: string;
   sourceSizeBytes: number;
   sourceRecordCount: number;
+  /** In-memory migration snapshot; never serialized into the receipt ledger or diagnostics. */
+  sourceBytes?: Buffer;
   targetDatabasePath: string;
   targetTable: "auth_profile_store" | "auth_profile_state";
   archivePath: string;
@@ -62,6 +64,7 @@ export function createAuthProfileMigrationSourceReceipt(params: {
     sourceSha256,
     sourceSizeBytes: params.sourceBytes.byteLength,
     sourceRecordCount: params.sourceRecordCount,
+    sourceBytes: Buffer.from(params.sourceBytes),
     targetDatabasePath: path.resolve(params.targetDatabasePath),
     targetTable: params.targetTable,
     archivePath: `${sourcePath}.migrated-${stamp}-${randomUUID()}`,

--- a/src/commands/doctor-auth-migration-receipts.ts
+++ b/src/commands/doctor-auth-migration-receipts.ts
@@ -99,7 +99,12 @@ function recordAuthProfileMigrationImported(
           .select(["last_run_id", "status"])
           .where("source_key", "=", receipt.sourceKey),
       );
-      if (existing && existing.last_run_id !== receipt.runId) {
+      if (
+        existing &&
+        existing.last_run_id !== receipt.runId &&
+        existing.status !== "retryable" &&
+        existing.status !== "superseded"
+      ) {
         throw new Error(
           `auth profile migration source already owned by ${existing.status} receipt`,
         );
@@ -144,6 +149,36 @@ function recordAuthProfileMigrationImported(
               report_json: reportJson(receipt),
             }),
           ),
+      );
+    },
+    { env: receipt.env },
+  );
+}
+
+function retirePendingAuthProfileMigrationReceipt(
+  receipt: AuthProfileMigrationSourceReceipt,
+  status: "retryable" | "superseded",
+  now = Date.now(),
+): void {
+  runOpenClawStateWriteTransaction(
+    ({ db }) => {
+      const kysely = getNodeSqliteKysely<MigrationDatabase>(db);
+      executeSqliteQuerySync(
+        db,
+        kysely
+          .updateTable("migration_runs")
+          .set({ status, finished_at: now })
+          .where("id", "=", receipt.runId)
+          .where("status", "=", "imported"),
+      );
+      executeSqliteQuerySync(
+        db,
+        kysely
+          .updateTable("migration_sources")
+          .set({ status })
+          .where("source_key", "=", receipt.sourceKey)
+          .where("last_run_id", "=", receipt.runId)
+          .where("status", "=", "imported"),
       );
     },
     { env: receipt.env },
@@ -334,7 +369,23 @@ export function resumePendingAuthProfileMigrationArchives(env?: NodeJS.ProcessEn
     const release = acquireLockSyncWithRetry(lockTarget);
     try {
       if (fs.existsSync(receipt.sourcePath)) {
-        verifyAuthProfileMigrationTarget(receipt);
+        const sourceBytes = fs.readFileSync(receipt.sourcePath);
+        if (digestBytes(sourceBytes) !== receipt.sourceSha256) {
+          // The imported receipt describes different bytes. Retire its claim so
+          // Doctor can process the current source under a new hash-owned run.
+          retirePendingAuthProfileMigrationReceipt(receipt, "superseded");
+          changes.push("Retired an interrupted auth migration receipt for a changed source.");
+          continue;
+        }
+        try {
+          verifyAuthProfileMigrationTarget(receipt);
+        } catch {
+          // The source is still authoritative, so let the normal migration path
+          // rebuild and reverify the target instead of wedging on a stale claim.
+          retirePendingAuthProfileMigrationReceipt(receipt, "retryable");
+          changes.push("Reset an interrupted auth migration receipt for retry.");
+          continue;
+        }
       }
       archiveAuthProfileMigrationSource(receipt);
       recordAuthProfileMigrationCompleted(

--- a/src/commands/doctor-auth-migration-receipts.ts
+++ b/src/commands/doctor-auth-migration-receipts.ts
@@ -8,6 +8,7 @@ import {
   getNodeSqliteKysely,
 } from "../infra/kysely-sync.js";
 import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
+import type { DB as OpenClawAgentKyselyDatabase } from "../state/openclaw-agent-db.generated.js";
 import type { DB as OpenClawStateDatabase } from "../state/openclaw-state-db.generated.js";
 import {
   openOpenClawStateDatabase,
@@ -16,6 +17,10 @@ import {
 
 const MIGRATION_KIND = "auth-profile-json-to-sqlite-v2";
 type MigrationDatabase = Pick<OpenClawStateDatabase, "migration_runs" | "migration_sources">;
+type AuthProfileTargetDatabase = Pick<
+  OpenClawAgentKyselyDatabase,
+  "auth_profile_store" | "auth_profile_state"
+>;
 
 export type AuthProfileMigrationSourceReceipt = {
   sourceKey: string;
@@ -80,7 +85,7 @@ export function digestAuthProfileMigrationValue(value: unknown): string {
   return digestBytes(Buffer.from(JSON.stringify(value) ?? "<undefined>"));
 }
 
-export function recordAuthProfileMigrationImported(
+function recordAuthProfileMigrationImported(
   receipt: AuthProfileMigrationSourceReceipt,
   now = Date.now(),
 ): void {
@@ -145,7 +150,7 @@ export function recordAuthProfileMigrationImported(
   );
 }
 
-export function recordAuthProfileMigrationCompleted(
+function recordAuthProfileMigrationCompleted(
   receipt: AuthProfileMigrationSourceReceipt,
   now = Date.now(),
   status: "completed" | "archived-unparsed" = "completed",
@@ -216,10 +221,15 @@ function verifyAuthProfileMigrationTarget(receipt: AuthProfileMigrationSourceRec
   }
   const db = openNodeSqliteDatabase(receipt.targetDatabasePath, { readOnly: true });
   try {
+    const kysely = getNodeSqliteKysely<AuthProfileTargetDatabase>(db);
     if (receipt.expectedProfileSha256) {
-      const row = db
-        .prepare("SELECT store_json FROM auth_profile_store WHERE store_key = 'primary'")
-        .get() as { store_json?: unknown } | undefined;
+      const row = executeSqliteQueryTakeFirstSync(
+        db,
+        kysely
+          .selectFrom("auth_profile_store")
+          .select("store_json")
+          .where("store_key", "=", "primary"),
+      );
       const store = typeof row?.store_json === "string" ? JSON.parse(row.store_json) : null;
       for (const [profileId, expectedSha256] of Object.entries(receipt.expectedProfileSha256)) {
         if (digestAuthProfileMigrationValue(store?.profiles?.[profileId]) !== expectedSha256) {
@@ -228,9 +238,13 @@ function verifyAuthProfileMigrationTarget(receipt: AuthProfileMigrationSourceRec
       }
     }
     if (receipt.expectedStateSha256) {
-      const row = db
-        .prepare("SELECT state_json FROM auth_profile_state WHERE state_key = 'primary'")
-        .get() as { state_json?: unknown } | undefined;
+      const row = executeSqliteQueryTakeFirstSync(
+        db,
+        kysely
+          .selectFrom("auth_profile_state")
+          .select("state_json")
+          .where("state_key", "=", "primary"),
+      );
       const state = typeof row?.state_json === "string" ? JSON.parse(row.state_json) : null;
       if (digestAuthProfileMigrationValue(state) !== receipt.expectedStateSha256) {
         throw new Error("auth profile migration target verification failed");
@@ -345,21 +359,6 @@ function isRecordOfStrings(value: unknown): value is Record<string, string> {
   );
 }
 
-export function hasCompletedAuthProfileMigrationReceipt(
-  sourceKey: string,
-  env?: NodeJS.ProcessEnv,
-): boolean {
-  const database = openOpenClawStateDatabase({ env });
-  const row = executeSqliteQueryTakeFirstSync(
-    database.db,
-    getNodeSqliteKysely<MigrationDatabase>(database.db)
-      .selectFrom("migration_sources")
-      .select("status")
-      .where("source_key", "=", sourceKey),
-  );
-  return row?.status === "completed";
-}
-
 export function hasTerminalAuthProfileMigrationReceipt(
   sourceKey: string,
   env?: NodeJS.ProcessEnv,
@@ -373,4 +372,13 @@ export function hasTerminalAuthProfileMigrationReceipt(
       .where("source_key", "=", sourceKey),
   );
   return row?.status === "completed" || row?.status === "archived-unparsed";
+}
+
+if (process.env.VITEST || process.env.NODE_ENV === "test") {
+  (globalThis as Record<PropertyKey, unknown>)[
+    Symbol.for("openclaw.authProfileMigrationReceiptsTestApi")
+  ] = {
+    recordAuthProfileMigrationImported,
+    recordAuthProfileMigrationCompleted,
+  };
 }

--- a/src/commands/doctor-auth-migration-receipts.ts
+++ b/src/commands/doctor-auth-migration-receipts.ts
@@ -188,6 +188,21 @@ function retirePendingAuthProfileMigrationReceipt(
   );
 }
 
+function restoreAuthProfileMigrationArchiveNoClobber(
+  receipt: AuthProfileMigrationSourceReceipt,
+): "restored" | "source-exists" {
+  try {
+    fs.linkSync(receipt.archivePath, receipt.sourcePath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "EEXIST") {
+      return "source-exists";
+    }
+    throw error;
+  }
+  fs.unlinkSync(receipt.archivePath);
+  return "restored";
+}
+
 function recordAuthProfileMigrationCompleted(
   receipt: AuthProfileMigrationSourceReceipt,
   now = Date.now(),
@@ -371,7 +386,8 @@ export function resumePendingAuthProfileMigrationArchives(env?: NodeJS.ProcessEn
     const lockTarget = fs.existsSync(receipt.sourcePath) ? receipt.sourcePath : receipt.archivePath;
     const release = acquireLockSyncWithRetry(lockTarget);
     try {
-      if (fs.existsSync(receipt.sourcePath)) {
+      const sourceExists = fs.existsSync(receipt.sourcePath);
+      if (sourceExists) {
         const sourceBytes = fs.readFileSync(receipt.sourcePath);
         if (digestBytes(sourceBytes) !== receipt.sourceSha256) {
           // The imported receipt describes different bytes. Retire its claim so
@@ -380,15 +396,35 @@ export function resumePendingAuthProfileMigrationArchives(env?: NodeJS.ProcessEn
           changes.push("Retired an interrupted auth migration receipt for a changed source.");
           continue;
         }
-        try {
-          verifyAuthProfileMigrationTarget(receipt);
-        } catch {
-          // The source is still authoritative, so let the normal migration path
-          // rebuild and reverify the target instead of wedging on a stale claim.
-          retirePendingAuthProfileMigrationReceipt(receipt, "retryable");
-          changes.push("Reset an interrupted auth migration receipt for retry.");
-          continue;
+      } else {
+        const archiveBytes = fs.readFileSync(receipt.archivePath);
+        if (digestBytes(archiveBytes) !== receipt.sourceSha256) {
+          throw new Error("legacy auth archive verification failed");
         }
+      }
+      try {
+        verifyAuthProfileMigrationTarget(receipt);
+      } catch {
+        if (!sourceExists) {
+          // Restore only hash-verified archive bytes, without replacing a
+          // source recreated by a non-cooperating legacy writer or restore.
+          const restored = restoreAuthProfileMigrationArchiveNoClobber(receipt);
+          if (restored === "source-exists") {
+            const currentBytes = fs.readFileSync(receipt.sourcePath);
+            const status =
+              digestBytes(currentBytes) === receipt.sourceSha256 ? "retryable" : "superseded";
+            retirePendingAuthProfileMigrationReceipt(receipt, status);
+            changes.push(
+              status === "retryable"
+                ? "Reset an interrupted auth migration receipt for retry."
+                : "Retired an interrupted auth migration receipt for a changed source.",
+            );
+            continue;
+          }
+        }
+        retirePendingAuthProfileMigrationReceipt(receipt, "retryable");
+        changes.push("Reset an interrupted auth migration receipt for retry.");
+        continue;
       }
       archiveAuthProfileMigrationSource(receipt);
       recordAuthProfileMigrationCompleted(
@@ -434,5 +470,6 @@ if (process.env.VITEST || process.env.NODE_ENV === "test") {
   ] = {
     recordAuthProfileMigrationImported,
     recordAuthProfileMigrationCompleted,
+    restoreAuthProfileMigrationArchiveNoClobber,
   };
 }

--- a/src/commands/doctor-auth-migration-receipts.ts
+++ b/src/commands/doctor-auth-migration-receipts.ts
@@ -269,13 +269,14 @@ export function acquireAuthProfileMigrationSourceLocks(sourcePaths: readonly str
 }
 
 function verifyAuthProfileMigrationTarget(receipt: AuthProfileMigrationSourceReceipt): void {
-  if (!receipt.expectedProfileSha256 && !receipt.expectedStateSha256) {
+  const hasExpectedProfiles = Object.keys(receipt.expectedProfileSha256 ?? {}).length > 0;
+  if (!hasExpectedProfiles && !receipt.expectedStateSha256) {
     return;
   }
   const db = openNodeSqliteDatabase(receipt.targetDatabasePath, { readOnly: true });
   try {
     const kysely = getNodeSqliteKysely<AuthProfileTargetDatabase>(db);
-    if (receipt.expectedProfileSha256) {
+    if (hasExpectedProfiles && receipt.expectedProfileSha256) {
       const row = executeSqliteQueryTakeFirstSync(
         db,
         kysely

--- a/src/commands/doctor-auth-oauth-sidecar.ts
+++ b/src/commands/doctor-auth-oauth-sidecar.ts
@@ -5,13 +5,13 @@ import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { note } from "../../packages/terminal-core/src/note.js";
 import { listAgentIds, resolveAgentDir, resolveDefaultAgentDir } from "../agents/agent-scope.js";
 import { AUTH_STORE_VERSION } from "../agents/auth-profiles/constants.js";
-import { resolveAuthStorePath } from "../agents/auth-profiles/paths.js";
 import { clearRuntimeAuthProfileStoreSnapshots } from "../agents/auth-profiles/store.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import { resolveOAuthDir, resolveStateDir } from "../config/paths.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { loadJsonFile, saveJsonFile } from "../infra/json-file.js";
 import { shortenHomePath } from "../utils.js";
+import { resolveLegacyAuthProfilesPath as resolveAuthStorePath } from "./doctor-auth-legacy-paths.js";
 import type { DoctorPrompter } from "./doctor-prompter.js";
 import {
   isLegacyOAuthRef,

--- a/src/commands/doctor/shared/stale-auth-order.test.ts
+++ b/src/commands/doctor/shared/stale-auth-order.test.ts
@@ -7,10 +7,6 @@ import { buildAuthHealthSummary } from "../../../agents/auth-health.js";
 import { testing as externalAuthTesting } from "../../../agents/auth-profiles/external-auth.test-support.js";
 import { resolveAuthProfileOrder } from "../../../agents/auth-profiles/order.js";
 import {
-  resolveAuthStorePath,
-  resolveLegacyAuthStorePath,
-} from "../../../agents/auth-profiles/paths.js";
-import {
   resolveAuthProfileDatabasePath,
   resolveAuthProfileDatabaseFilePaths,
   writePersistedAuthProfileStateRaw,
@@ -24,6 +20,10 @@ import {
   openOpenClawAgentDatabase,
 } from "../../../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../../../state/openclaw-state-db.js";
+import {
+  resolveLegacyAuthProfilesPath as resolveAuthStorePath,
+  resolveLegacyFlatAuthPath as resolveLegacyAuthStorePath,
+} from "../../doctor-auth-legacy-paths.js";
 import {
   collectStaleConfiguredAuthOrderWarnings,
   maybeRepairStaleConfiguredAuthOrders,

--- a/src/commands/doctor/shared/stale-auth-order.ts
+++ b/src/commands/doctor/shared/stale-auth-order.ts
@@ -5,11 +5,6 @@ import { listAgentIds, resolveAgentDir } from "../../../agents/agent-scope-confi
 import { listRuntimeExternalAuthProfiles } from "../../../agents/auth-profiles/external-auth.js";
 import { resolveAuthProfileOrder } from "../../../agents/auth-profiles/order.js";
 import {
-  resolveAuthStatePath,
-  resolveAuthStorePath,
-  resolveLegacyAuthStorePath,
-} from "../../../agents/auth-profiles/paths.js";
-import {
   coercePersistedAuthProfileStore,
   mergeAuthProfileStores,
 } from "../../../agents/auth-profiles/persisted.js";
@@ -35,6 +30,11 @@ import {
   listOpenClawRegisteredAgentDatabases,
 } from "../../../state/openclaw-agent-db.js";
 import { isRecord, resolveUserPath } from "../../../utils.js";
+import {
+  resolveLegacyAuthProfilesPath as resolveAuthStorePath,
+  resolveLegacyAuthStatePath as resolveAuthStatePath,
+  resolveLegacyFlatAuthPath as resolveLegacyAuthStorePath,
+} from "../../doctor-auth-legacy-paths.js";
 
 type StaleConfiguredAuthOrder = {
   provider: string;

--- a/src/commands/doctor/shared/stale-oauth-profile-shadows.test.ts
+++ b/src/commands/doctor/shared/stale-oauth-profile-shadows.test.ts
@@ -41,12 +41,15 @@ function storeWith(profileId: string, credential: OAuthCredential): AuthProfileS
   };
 }
 
-async function writeRawAuthStore(
-  agentDir: string,
-  store: unknown,
-  options: { writeLegacy?: boolean } = {},
-): Promise<void> {
-  if (options.writeLegacy) {
+async function writeRawAuthStore(agentDir: string, store: unknown): Promise<void> {
+  const profiles =
+    typeof store === "object" && store !== null && "profiles" in store
+      ? (store.profiles as Record<string, unknown>)
+      : {};
+  const hasLegacySidecarRef = Object.values(profiles).some(
+    (profile) => typeof profile === "object" && profile !== null && "oauthRef" in profile,
+  );
+  if (hasLegacySidecarRef) {
     const authPath = resolveAuthStorePath(agentDir);
     await fs.mkdir(path.dirname(authPath), { recursive: true });
     await fs.writeFile(authPath, `${JSON.stringify(store, null, 2)}\n`, "utf8");
@@ -275,26 +278,22 @@ describe("stale OAuth profile shadow doctor repair", () => {
     const profileId = "openai-codex:default";
     const now = Date.now();
     const childAgentDir = path.join(stateDir, "agents", "telegram", "agent");
-    await writeRawAuthStore(
-      childAgentDir,
-      {
-        version: 1,
-        profiles: {
-          [profileId]: {
-            type: "oauth",
+    await writeRawAuthStore(childAgentDir, {
+      version: 1,
+      profiles: {
+        [profileId]: {
+          type: "oauth",
+          provider: "openai-codex",
+          accountId: "acct-shared",
+          expires: now - 60_000,
+          oauthRef: {
+            source: "openclaw-credentials",
             provider: "openai-codex",
-            accountId: "acct-shared",
-            expires: now - 60_000,
-            oauthRef: {
-              source: "openclaw-credentials",
-              provider: "openai-codex",
-              id: "0123456789abcdef0123456789abcdef",
-            },
+            id: "0123456789abcdef0123456789abcdef",
           },
         },
       },
-      { writeLegacy: true },
-    );
+    });
     saveAuthProfileStore(
       storeWith(
         profileId,

--- a/src/commands/doctor/shared/stale-oauth-profile-shadows.test.ts
+++ b/src/commands/doctor/shared/stale-oauth-profile-shadows.test.ts
@@ -3,7 +3,6 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { resolveAuthStorePath } from "../../../agents/auth-profiles/paths.js";
 import {
   coercePersistedAuthProfileStore,
   loadPersistedAuthProfileStore,
@@ -16,6 +15,7 @@ import {
 import type { AuthProfileStore, OAuthCredential } from "../../../agents/auth-profiles/types.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { captureEnv } from "../../../test-utils/env.js";
+import { resolveLegacyAuthProfilesPath as resolveAuthStorePath } from "../../doctor-auth-legacy-paths.js";
 import {
   collectStaleOAuthProfileShadowWarnings,
   repairStaleOAuthProfileShadows,

--- a/src/commands/doctor/shared/stale-oauth-profile-shadows.test.ts
+++ b/src/commands/doctor/shared/stale-oauth-profile-shadows.test.ts
@@ -41,10 +41,16 @@ function storeWith(profileId: string, credential: OAuthCredential): AuthProfileS
   };
 }
 
-async function writeRawAuthStore(agentDir: string, store: unknown): Promise<void> {
-  const authPath = resolveAuthStorePath(agentDir);
-  await fs.mkdir(path.dirname(authPath), { recursive: true });
-  await fs.writeFile(authPath, `${JSON.stringify(store, null, 2)}\n`, "utf8");
+async function writeRawAuthStore(
+  agentDir: string,
+  store: unknown,
+  options: { writeLegacy?: boolean } = {},
+): Promise<void> {
+  if (options.writeLegacy) {
+    const authPath = resolveAuthStorePath(agentDir);
+    await fs.mkdir(path.dirname(authPath), { recursive: true });
+    await fs.writeFile(authPath, `${JSON.stringify(store, null, 2)}\n`, "utf8");
+  }
   const canonical = coercePersistedAuthProfileStore(store);
   if (canonical) {
     saveAuthProfileStore(canonical, agentDir, {
@@ -269,22 +275,26 @@ describe("stale OAuth profile shadow doctor repair", () => {
     const profileId = "openai-codex:default";
     const now = Date.now();
     const childAgentDir = path.join(stateDir, "agents", "telegram", "agent");
-    await writeRawAuthStore(childAgentDir, {
-      version: 1,
-      profiles: {
-        [profileId]: {
-          type: "oauth",
-          provider: "openai-codex",
-          accountId: "acct-shared",
-          expires: now - 60_000,
-          oauthRef: {
-            source: "openclaw-credentials",
+    await writeRawAuthStore(
+      childAgentDir,
+      {
+        version: 1,
+        profiles: {
+          [profileId]: {
+            type: "oauth",
             provider: "openai-codex",
-            id: "0123456789abcdef0123456789abcdef",
+            accountId: "acct-shared",
+            expires: now - 60_000,
+            oauthRef: {
+              source: "openclaw-credentials",
+              provider: "openai-codex",
+              id: "0123456789abcdef0123456789abcdef",
+            },
           },
         },
       },
-    });
+      { writeLegacy: true },
+    );
     saveAuthProfileStore(
       storeWith(
         profileId,

--- a/src/commands/doctor/shared/stale-oauth-profile-shadows.ts
+++ b/src/commands/doctor/shared/stale-oauth-profile-shadows.ts
@@ -13,7 +13,6 @@ import {
   hasUsableOAuthCredential,
   isSafeToAdoptMainStoreOAuthIdentity,
 } from "../../../agents/auth-profiles/oauth-shared.js";
-import { resolveAuthStorePath } from "../../../agents/auth-profiles/paths.js";
 import { loadPersistedAuthProfileStore } from "../../../agents/auth-profiles/persisted.js";
 import { resolveSharedMainAuthAgentDir } from "../../../agents/auth-profiles/shared-main-dir.js";
 import { updateAuthProfileStoreWithLock } from "../../../agents/auth-profiles/store.js";
@@ -21,6 +20,7 @@ import type { AuthProfileStore, OAuthCredential } from "../../../agents/auth-pro
 import { resolveStateDir } from "../../../config/paths.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { shortenHomePath } from "../../../utils.js";
+import { resolveLegacyAuthProfilesPath as resolveAuthStorePath } from "../../doctor-auth-legacy-paths.js";
 
 type StaleOAuthProfileShadow = {
   agentDir: string;

--- a/src/config/paths.test.ts
+++ b/src/config/paths.test.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { resolveLegacyOAuthPath } from "../agents/auth-profiles/legacy-source-diagnostic.js";
 import { withTempDir } from "../test-helpers/temp-dir.js";
 import {
   CONFIG_PATH,
@@ -15,7 +16,6 @@ import {
   resolveGatewayPort,
   resolveIncludeRoots,
   resolveOAuthDir,
-  resolveOAuthPath,
   resolveStateDir,
   STATE_DIR,
 } from "./paths.js";
@@ -32,7 +32,7 @@ describe("oauth paths", () => {
     } as NodeJS.ProcessEnv;
 
     expect(resolveOAuthDir(env, "/custom/state")).toBe(path.resolve("/custom/oauth"));
-    expect(resolveOAuthPath(env, "/custom/state")).toBe(
+    expect(resolveLegacyOAuthPath(env)).toBe(
       path.join(path.resolve("/custom/oauth"), "oauth.json"),
     );
   });
@@ -43,7 +43,7 @@ describe("oauth paths", () => {
     } as NodeJS.ProcessEnv;
 
     expect(resolveOAuthDir(env, "/custom/state")).toBe(path.join("/custom/state", "credentials"));
-    expect(resolveOAuthPath(env, "/custom/state")).toBe(
+    expect(resolveLegacyOAuthPath(env)).toBe(
       path.join("/custom/state", "credentials", "oauth.json"),
     );
   });

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -303,15 +303,7 @@ export function resolveDeliveryQueueMediaDir(stateDir?: string): string {
   return path.join(stateDir ?? resolveStateDir(), "delivery-queue-media");
 }
 
-const OAUTH_FILENAME = "oauth.json";
-
-/**
- * OAuth credentials storage directory.
- *
- * Precedence:
- * - `OPENCLAW_OAUTH_DIR` (explicit override)
- * - `$*_STATE_DIR/credentials` (canonical server/default)
- */
+/** Resolves the legacy credentials directory retained for Doctor and backup ownership. */
 export function resolveOAuthDir(
   env: NodeJS.ProcessEnv = process.env,
   stateDir: string = resolveStateDir(env, envHomedir(env)),
@@ -321,13 +313,6 @@ export function resolveOAuthDir(
     return resolveUserPath(override, env, envHomedir(env));
   }
   return path.join(stateDir, "credentials");
-}
-
-export function resolveOAuthPath(
-  env: NodeJS.ProcessEnv = process.env,
-  stateDir: string = resolveStateDir(env, envHomedir(env)),
-): string {
-  return path.join(resolveOAuthDir(env, stateDir), OAUTH_FILENAME);
 }
 
 function parseGatewayPortEnvValue(raw: string | undefined): number | null {

--- a/src/gateway/server-startup-config.ts
+++ b/src/gateway/server-startup-config.ts
@@ -1,6 +1,7 @@
 // Gateway startup config loads, repairs, validates, and activates runtime config
 // plus secrets snapshots before the server exposes user-facing surfaces.
 import { isDeepStrictEqual } from "node:util";
+import { hasLegacyAuthProfileSourcesForStartup } from "../agents/auth-profiles/legacy-source-diagnostic.js";
 import { applyConfigOverrides } from "../config/runtime-overrides.js";
 import type { GatewayAuthConfig, GatewayTailscaleConfig } from "../config/types.gateway.js";
 import type { ConfigFileSnapshot, OpenClawConfig } from "../config/types.openclaw.js";
@@ -12,7 +13,10 @@ import {
   isRetryableSecretDegradationReason,
   listSecretResolutionErrorOwners,
 } from "../secrets/runtime-degraded-state.js";
-import { prepareSecretsRuntimeFastPathSnapshot } from "../secrets/runtime-fast-path.js";
+import {
+  collectCandidateAgentDirs,
+  prepareSecretsRuntimeFastPathSnapshot,
+} from "../secrets/runtime-fast-path.js";
 import { registerProviderAuthRuntimeSnapshotActivationOwner } from "../secrets/runtime-provider-auth-activation.js";
 import {
   listProviderAuthDegradedOwners,
@@ -366,10 +370,16 @@ export function createRuntimeSecretsActivator(params: {
           !params.activateRuntimeSecretsSnapshot &&
           assignmentConfig === undefined
         ) {
-          const fastPath = prepareSecretsRuntimeFastPathSnapshot({
-            config: sourceConfig,
-            ...(startupManifestRegistry ? { manifestRegistry: startupManifestRegistry } : {}),
-          });
+          const startupEnv = activationParams.env ?? process.env;
+          const fastPath = hasLegacyAuthProfileSourcesForStartup({
+            agentDirs: collectCandidateAgentDirs(sourceConfig, startupEnv),
+            env: startupEnv,
+          })
+            ? null
+            : prepareSecretsRuntimeFastPathSnapshot({
+                config: sourceConfig,
+                ...(startupManifestRegistry ? { manifestRegistry: startupManifestRegistry } : {}),
+              });
           if (fastPath) {
             // The startup fast path avoids importing the full secrets runtime
             // until refresh/preflight needs dynamic provider or auth-store work.

--- a/src/gateway/server.config-patch.test.ts
+++ b/src/gateway/server.config-patch.test.ts
@@ -5,7 +5,6 @@ import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveDefaultAgentDir } from "../agents/agent-scope.js";
-import { AUTH_PROFILE_FILENAME } from "../agents/auth-profiles/path-constants.js";
 import { loadSessionEntry } from "../config/sessions/session-accessor.js";
 import {
   activateSecretsRuntimeSnapshot,
@@ -152,7 +151,7 @@ async function expectSchemaLookupInvalid(pathValue: unknown) {
 
 async function writeUnresolvedAuthProfileTokenRef(missingEnvVar: string) {
   deleteTestEnvValue(missingEnvVar);
-  const authStorePath = path.join(resolveDefaultAgentDir({}), AUTH_PROFILE_FILENAME);
+  const authStorePath = path.join(resolveDefaultAgentDir({}), "auth-profiles.json");
   await fs.mkdir(path.dirname(authStorePath), { recursive: true });
   await fs.writeFile(
     authStorePath,

--- a/src/secrets/apply.test.ts
+++ b/src/secrets/apply.test.ts
@@ -343,7 +343,7 @@ describe("secrets apply", () => {
       string,
       unknown
     >;
-    expect(nextAuthJson.openai).toBeUndefined();
+    expect(nextAuthJson.openai).toBeDefined();
 
     const nextEnv = await fs.readFile(fixture.envPath, "utf8");
     expect(nextEnv).not.toContain("sk-openai-plaintext");

--- a/src/secrets/apply.ts
+++ b/src/secrets/apply.ts
@@ -46,10 +46,8 @@ import { assertExpectedResolvedSecretValue } from "./secret-value.js";
 import { isNonEmptyString, isRecord, writeTextFileAtomic } from "./shared.js";
 import {
   listAuthProfileStoreAgentDirs,
-  listLegacyAuthJsonPaths,
   listSecretsDotEnvPaths,
   parseEnvAssignmentValue,
-  readJsonObjectIfExists,
 } from "./storage-scan.js";
 
 type FileSnapshot = {
@@ -77,7 +75,6 @@ type ProjectedState = {
   configWriteOptions: ConfigWriteOptions;
   authStoreByPath: Map<string, Record<string, unknown>>;
   authStoreAgentDirByPath: Map<string, string>;
-  authJsonByPath: Map<string, Record<string, unknown>>;
   envRawByPath: Map<string, string>;
   changedFiles: Set<string>;
   warnings: string[];
@@ -334,12 +331,6 @@ async function projectPlanState(params: {
     enabled: options.scrubAuthProfilesForProviderTargets,
   });
 
-  const authJsonByPath = scrubLegacyAuthJsonStores({
-    stateDir,
-    changedFiles,
-    enabled: options.scrubLegacyAuthJson,
-  });
-
   const envRawByPath = scrubEnvFiles({
     configPath,
     stateDir,
@@ -366,7 +357,6 @@ async function projectPlanState(params: {
     configWriteOptions: writeOptions,
     authStoreByPath,
     authStoreAgentDirByPath: targetMutations.authStoreAgentDirByPath,
-    authJsonByPath,
     envRawByPath,
     changedFiles,
     warnings,
@@ -701,40 +691,6 @@ function applyAuthProfileTargetMutation(params: {
   return changed;
 }
 
-function scrubLegacyAuthJsonStores(params: {
-  stateDir: string;
-  changedFiles: Set<string>;
-  enabled: boolean;
-}): Map<string, Record<string, unknown>> {
-  const authJsonByPath = new Map<string, Record<string, unknown>>();
-  if (!params.enabled) {
-    return authJsonByPath;
-  }
-  for (const authJsonPath of listLegacyAuthJsonPaths(params.stateDir)) {
-    const parsedResult = readJsonObjectIfExists(authJsonPath);
-    const parsed = parsedResult.value;
-    if (!parsed) {
-      continue;
-    }
-    let mutated = false;
-    const nextParsed = structuredClone(parsed);
-    for (const [providerId, value] of Object.entries(nextParsed)) {
-      if (!isRecord(value)) {
-        continue;
-      }
-      if (value.type === "api_key" && isNonEmptyString(value.key)) {
-        delete nextParsed[providerId];
-        mutated = true;
-      }
-    }
-    if (mutated) {
-      authJsonByPath.set(authJsonPath, nextParsed);
-      params.changedFiles.add(authJsonPath);
-    }
-  }
-  return authJsonByPath;
-}
-
 function scrubEnvFiles(params: {
   configPath: string;
   stateDir: string;
@@ -861,14 +817,6 @@ function restoreFileSnapshot(pathname: string, snapshot: FileSnapshot): void {
   writeTextFileAtomic(pathname, snapshot.content, snapshot.mode || 0o600);
 }
 
-function toJsonWrite(pathname: string, value: Record<string, unknown>): ApplyWrite {
-  return {
-    path: pathname,
-    content: `${JSON.stringify(value, null, 2)}\n`,
-    mode: 0o600,
-  };
-}
-
 /** Applies or dry-runs a validated secrets plan across config, auth stores, and scrub targets. */
 /** Applies a normalized secrets plan, or reports file/auth-store changes in dry-run mode. */
 export async function runSecretsApply(params: {
@@ -941,10 +889,6 @@ export async function runSecretsApply(params: {
 
   capture(projected.configPath);
   const writes: ApplyWrite[] = [];
-  for (const [pathname, value] of projected.authJsonByPath.entries()) {
-    capture(pathname);
-    writes.push(toJsonWrite(pathname, value));
-  }
   for (const [pathname, raw] of projected.envRawByPath.entries()) {
     capture(pathname);
     writes.push({

--- a/src/secrets/audit.test.ts
+++ b/src/secrets/audit.test.ts
@@ -279,7 +279,7 @@ describe("secrets audit", () => {
     expectFindingCode(report, "PLAINTEXT_FOUND");
   });
 
-  it("does not mutate legacy auth.json during audit", async () => {
+  it("does not inspect or mutate legacy auth.json during audit", async () => {
     await writeJsonFile(fixture.authJsonPath, {
       openai: {
         type: "api_key",
@@ -289,17 +289,28 @@ describe("secrets audit", () => {
 
     const report = await runSecretsAudit({ env: fixture.env });
     expectFindingCode(report, "LEGACY_RESIDUE");
+    expect(report.filesScanned).not.toContain(fixture.authJsonPath);
     const authJsonStat = await fs.stat(fixture.authJsonPath);
     expect(authJsonStat.isFile()).toBe(true);
     await expectPathMissing(fixture.authStorePath);
   });
 
-  it("reports malformed sidecar JSON as findings instead of crashing", async () => {
+  it("ignores malformed legacy auth JSON instead of reading it", async () => {
     await fs.writeFile(fixture.authJsonPath, "{invalid-json", "utf8");
 
     const report = await runSecretsAudit({ env: fixture.env });
+    expectFindingCode(report, "LEGACY_RESIDUE");
     expectFindingFile(report, fixture.authJsonPath);
-    expectFindingCode(report, "REF_UNRESOLVED");
+  });
+
+  it("reports Doctor-created auth archives without reading their contents", async () => {
+    const archivePath = `${fixture.authJsonPath}.migrated-2026-07-25T12-00-00.000Z-fake`;
+    await fs.writeFile(archivePath, "opaque fake credential bytes", "utf8");
+
+    const report = await runSecretsAudit({ env: fixture.env });
+    expectFindingCode(report, "LEGACY_RESIDUE");
+    expectFindingFile(report, archivePath);
+    expect(report.filesScanned).not.toContain(archivePath);
   });
 
   it("skips exec ref resolution during audit unless explicitly allowed", async () => {

--- a/src/secrets/audit.test.ts
+++ b/src/secrets/audit.test.ts
@@ -304,13 +304,20 @@ describe("secrets audit", () => {
   });
 
   it("reports Doctor-created auth archives without reading their contents", async () => {
-    const archivePath = `${fixture.authJsonPath}.migrated-2026-07-25T12-00-00.000Z-fake`;
-    await fs.writeFile(archivePath, "opaque fake credential bytes", "utf8");
+    const archivePaths = [
+      `${fixture.authJsonPath}.migrated-2026-07-25T12-00-00.000Z-fake`,
+      `${fixture.authJsonPath}.sqlite-import.1753430400000.bak`,
+    ];
+    for (const archivePath of archivePaths) {
+      await fs.writeFile(archivePath, "opaque fake credential bytes", "utf8");
+    }
 
     const report = await runSecretsAudit({ env: fixture.env });
     expectFindingCode(report, "LEGACY_RESIDUE");
-    expectFindingFile(report, archivePath);
-    expect(report.filesScanned).not.toContain(archivePath);
+    for (const archivePath of archivePaths) {
+      expectFindingFile(report, archivePath);
+      expect(report.filesScanned).not.toContain(archivePath);
+    }
   });
 
   it("skips exec ref resolution during audit unless explicitly allowed", async () => {

--- a/src/secrets/audit.ts
+++ b/src/secrets/audit.ts
@@ -2,6 +2,10 @@
 import fs from "node:fs";
 import os from "node:os";
 import {
+  listLegacyAuthProfileArchives,
+  listLegacyAuthProfileSources,
+} from "../agents/auth-profiles/legacy-source-diagnostic.js";
+import {
   readPersistedAuthProfileStoreRaw,
   resolveAuthProfileDatabasePath,
 } from "../agents/auth-profiles/sqlite.js";
@@ -36,7 +40,6 @@ import { isNonEmptyString, isRecord } from "./shared.js";
 import {
   listAgentModelsJsonPaths,
   listAuthProfileStoreAgentDirs,
-  listLegacyAuthJsonPaths,
   listSecretsDotEnvPaths,
   parseEnvAssignmentValue,
   readJsonObjectIfExists,
@@ -305,42 +308,6 @@ function collectAuthStoreSecrets(params: {
   }
 }
 
-function collectAuthJsonResidue(params: { stateDir: string; collector: AuditCollector }): void {
-  for (const authJsonPath of listLegacyAuthJsonPaths(params.stateDir)) {
-    params.collector.filesScanned.add(authJsonPath);
-    const parsedResult = readJsonObjectIfExists(authJsonPath);
-    if (parsedResult.error) {
-      addFinding(params.collector, {
-        code: "REF_UNRESOLVED",
-        severity: "error",
-        file: authJsonPath,
-        jsonPath: "<root>",
-        message: `Invalid JSON in legacy auth.json: ${parsedResult.error}`,
-      });
-      continue;
-    }
-    const parsed = parsedResult.value;
-    if (!parsed) {
-      continue;
-    }
-    for (const [providerId, value] of Object.entries(parsed)) {
-      if (!isRecord(value)) {
-        continue;
-      }
-      if (value.type === "api_key" && isNonEmptyString(value.key)) {
-        addFinding(params.collector, {
-          code: "LEGACY_RESIDUE",
-          severity: "warn",
-          file: authJsonPath,
-          jsonPath: providerId,
-          message: "Legacy auth.json contains static api_key credentials.",
-          provider: providerId,
-        });
-      }
-    }
-  }
-}
-
 function collectModelsJsonSecrets(params: {
   modelsJsonPath: string;
   collector: AuditCollector;
@@ -428,6 +395,44 @@ function collectModelsJsonSecrets(params: {
         provider: providerId,
       });
     }
+  }
+}
+
+function collectLegacyAuthSourceFindings(params: {
+  config: OpenClawConfig;
+  stateDir: string;
+  env: NodeJS.ProcessEnv;
+  collector: AuditCollector;
+}): void {
+  const seen = new Set<string>();
+  const agentDirs = listAuthProfileStoreAgentDirs(params.config, params.stateDir);
+  for (const agentDir of agentDirs) {
+    for (const source of listLegacyAuthProfileSources({ agentDir, env: params.env })) {
+      if (seen.has(source.path)) {
+        continue;
+      }
+      seen.add(source.path);
+      addFinding(params.collector, {
+        code: "LEGACY_RESIDUE",
+        severity: source.kind === "auth-state" ? "info" : "warn",
+        file: source.path,
+        jsonPath: "<root>",
+        message: `Retired auth source ${source.kind} is present; run openclaw doctor --fix to migrate and archive it.`,
+      });
+    }
+  }
+  for (const archive of listLegacyAuthProfileArchives({ agentDirs, env: params.env })) {
+    if (seen.has(archive.path)) {
+      continue;
+    }
+    seen.add(archive.path);
+    addFinding(params.collector, {
+      code: "LEGACY_RESIDUE",
+      severity: "warn",
+      file: archive.path,
+      jsonPath: "<root>",
+      message: `Archived auth source ${archive.kind} may contain plaintext credentials; retain it only as long as recovery requires.`,
+    });
   }
 }
 
@@ -687,11 +692,7 @@ export async function runSecretsAudit(
   for (const envPath of envPaths) {
     collectEnvPlaintext({ envPath, collector });
   }
-  collectAuthJsonResidue({
-    stateDir,
-    collector,
-  });
-
+  collectLegacyAuthSourceFindings({ config, stateDir, env, collector });
   const summary = summarizeFindings(collector.findings);
   const status: SecretsAuditStatus =
     summary.unresolvedRefCount > 0

--- a/src/secrets/configure-plan.test.ts
+++ b/src/secrets/configure-plan.test.ts
@@ -213,7 +213,7 @@ describe("secrets configure plan helpers", () => {
     expect(plan.options).toEqual({
       scrubEnv: true,
       scrubAuthProfilesForProviderTargets: true,
-      scrubLegacyAuthJson: true,
+      scrubLegacyAuthJson: false,
     });
   });
 });

--- a/src/secrets/configure-plan.ts
+++ b/src/secrets/configure-plan.ts
@@ -266,7 +266,7 @@ export function buildSecretsConfigurePlan(params: {
     options: {
       scrubEnv: true,
       scrubAuthProfilesForProviderTargets: true,
-      scrubLegacyAuthJson: true,
+      scrubLegacyAuthJson: false,
     },
   };
 }

--- a/src/secrets/plan.ts
+++ b/src/secrets/plan.ts
@@ -186,6 +186,8 @@ export function normalizeSecretsPlanOptions(
   return {
     scrubEnv: options?.scrubEnv ?? true,
     scrubAuthProfilesForProviderTargets: options?.scrubAuthProfilesForProviderTargets ?? true,
-    scrubLegacyAuthJson: options?.scrubLegacyAuthJson ?? true,
+    // Deprecated plan input retained for protocol compatibility. Doctor owns
+    // legacy auth.json migration; secrets apply never reads or rewrites it.
+    scrubLegacyAuthJson: false,
   };
 }

--- a/src/secrets/runtime-auth-profile-owner.ts
+++ b/src/secrets/runtime-auth-profile-owner.ts
@@ -1,10 +1,10 @@
 /** Stable SecretRef owner identity for one agent-scoped auth profile. */
-import { resolveAuthStorePath } from "../agents/auth-profiles/paths.js";
+import { resolveAuthProfileDatabasePath } from "../agents/auth-profiles/sqlite.js";
 
 /** Tuple encoding distinguishes agents and avoids path/profile separator collisions. */
 export function resolveAuthProfileSecretOwnerId(params: {
   agentDir?: string;
   profileId: string;
 }): string {
-  return JSON.stringify([resolveAuthStorePath(params.agentDir), params.profileId]);
+  return JSON.stringify([resolveAuthProfileDatabasePath(params.agentDir), params.profileId]);
 }

--- a/src/secrets/runtime-fast-path.ts
+++ b/src/secrets/runtime-fast-path.ts
@@ -7,15 +7,10 @@ import {
   resolveAgentDir,
   resolveDefaultAgentDir,
 } from "../agents/agent-scope-config.js";
-import {
-  AUTH_PROFILE_FILENAME,
-  AUTH_STATE_FILENAME,
-  LEGACY_AUTH_FILENAME,
-} from "../agents/auth-profiles/path-constants.js";
 import { getRuntimeAuthProfileStoreCredentialsRevision } from "../agents/auth-profiles/runtime-snapshots.js";
 import { resolveAuthProfileDatabasePath } from "../agents/auth-profiles/sqlite.js";
 import type { AuthProfileStore } from "../agents/auth-profiles/types.js";
-import { resolveOAuthPath, resolveStateDir } from "../config/paths.js";
+import { resolveStateDir } from "../config/paths.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
 import type { PluginOrigin } from "../plugins/plugin-origin.types.js";
@@ -99,16 +94,11 @@ function resolveCandidateAgentDirs(params: {
 }
 
 function hasCandidateAuthProfileStoreSource(agentDir: string): boolean {
-  return (
-    existsSync(resolveAuthProfileDatabasePath(agentDir)) ||
-    existsSync(path.join(agentDir, AUTH_PROFILE_FILENAME)) ||
-    existsSync(path.join(agentDir, AUTH_STATE_FILENAME)) ||
-    existsSync(path.join(agentDir, LEGACY_AUTH_FILENAME))
-  );
+  return existsSync(resolveAuthProfileDatabasePath(agentDir));
 }
 
 /**
- * Returns whether auth profile files or OAuth state exist for candidate agent dirs.
+ * Returns whether canonical auth-profile databases exist for candidate agent dirs.
  */
 function hasCandidateAuthProfileStoreSources(params: {
   config: OpenClawConfig;
@@ -126,8 +116,7 @@ function hasCandidateAuthProfileStoreSources(params: {
   );
   return (
     candidateDirs.some((agentDir) => hasCandidateAuthProfileStoreSource(agentDir)) ||
-    hasCandidateAuthProfileStoreSource(mainAgentDir) ||
-    existsSync(resolveOAuthPath(params.env as NodeJS.ProcessEnv))
+    hasCandidateAuthProfileStoreSource(mainAgentDir)
   );
 }
 

--- a/src/secrets/runtime.auth-migration-isolation.test.ts
+++ b/src/secrets/runtime.auth-migration-isolation.test.ts
@@ -1,0 +1,83 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { writePersistedAuthProfileStoreRaw } from "../agents/auth-profiles/sqlite.js";
+import { resolveApiKeyForProvider } from "../agents/model-auth.js";
+import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
+import {
+  activateSecretsRuntimeSnapshot,
+  clearSecretsRuntimeSnapshot,
+  prepareSecretsRuntimeSnapshot,
+} from "./runtime.js";
+
+describe("auth profile migration isolation", () => {
+  const roots: string[] = [];
+
+  afterEach(async () => {
+    clearSecretsRuntimeSnapshot();
+    closeOpenClawAgentDatabasesForTest();
+    vi.unstubAllEnvs();
+    for (const root of roots.splice(0)) {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("isolates one legacy owner and blocks env fallback without affecting a healthy agent", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-auth-migration-isolation-"));
+    roots.push(root);
+    const legacyAgentDir = path.join(root, "agents", "legacy", "agent");
+    const healthyAgentDir = path.join(root, "agents", "healthy", "agent");
+    await fs.mkdir(legacyAgentDir, { recursive: true });
+    await fs.mkdir(healthyAgentDir, { recursive: true });
+    await fs.writeFile(
+      path.join(legacyAgentDir, "auth.json"),
+      `${JSON.stringify({ openai: { type: "api_key", key: "fake-legacy-key" } })}\n`,
+    );
+    writePersistedAuthProfileStoreRaw(
+      {
+        version: 1,
+        profiles: {
+          "openai:default": {
+            type: "api_key",
+            provider: "openai",
+            key: "fake-healthy-key",
+          },
+        },
+      },
+      healthyAgentDir,
+    );
+    vi.stubEnv("OPENAI_API_KEY", "fake-env-fallback-key");
+
+    const snapshot = await prepareSecretsRuntimeSnapshot({
+      config: {},
+      agentDirs: [legacyAgentDir, healthyAgentDir],
+      includeConfigRefs: false,
+      allowUnavailableSecretOwners: true,
+      loadablePluginOrigins: new Map(),
+    });
+    expect(snapshot.degradedOwners).toEqual([
+      expect.objectContaining({
+        ownerKind: "route",
+        reason: "auth profile migration required",
+        paths: ["auth-profile-legacy:legacy-auth"],
+      }),
+    ]);
+    activateSecretsRuntimeSnapshot(snapshot);
+
+    await expect(
+      resolveApiKeyForProvider({ provider: "openai", agentDir: legacyAgentDir }),
+    ).rejects.toMatchObject({
+      code: "AUTH_PROFILE_MIGRATION_REQUIRED",
+      action: "openclaw doctor --fix",
+      sourceKinds: ["legacy-auth"],
+    });
+    await expect(
+      resolveApiKeyForProvider({
+        provider: "openai",
+        agentDir: healthyAgentDir,
+        store: snapshot.authStores.find((entry) => entry.agentDir === healthyAgentDir)?.store,
+      }),
+    ).resolves.toMatchObject({ apiKey: "fake-healthy-key" });
+  });
+});

--- a/src/secrets/runtime.fast-path.test.ts
+++ b/src/secrets/runtime.fast-path.test.ts
@@ -4,9 +4,9 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AuthProfileStore } from "../agents/auth-profiles.js";
+import { resolveLegacyOAuthPath } from "../agents/auth-profiles/legacy-source-diagnostic.js";
 import { saveAuthProfileStore } from "../agents/auth-profiles/store.js";
 import { clearConfigCache, clearRuntimeConfigSnapshot } from "../config/config.js";
-import { resolveOAuthPath } from "../config/paths.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
 import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
@@ -224,31 +224,7 @@ describe("secrets runtime fast path", () => {
     expect(resolveRuntimeWebToolsMock).toHaveBeenCalledTimes(1);
   });
 
-  it.each([
-    {
-      name: "oauth credentials file",
-      setup: (env: NodeJS.ProcessEnv, _mainAgentDir: string, _agentDir: string) => {
-        const credentialsPath = resolveOAuthPath(env);
-        mkdirSync(path.dirname(credentialsPath), { recursive: true });
-        writeFileSync(
-          credentialsPath,
-          `${JSON.stringify({
-            openai: {
-              access: "access-token",
-              refresh: "refresh-token",
-              expires: Date.now() + 60_000,
-            },
-          })}\n`,
-        );
-      },
-    },
-    {
-      name: "inherited main auth store",
-      setup: (_env: NodeJS.ProcessEnv, mainAgentDir: string, _agentDir: string) => {
-        writeAuthProfileStore(mainAgentDir);
-      },
-    },
-  ])("skips the startup-only fast path when $name exists", async ({ setup }) => {
+  it("skips the startup-only fast path when the inherited main auth store exists", async () => {
     const { prepareSecretsRuntimeFastPathSnapshot } = await import("./runtime-fast-path.js");
     const root = mkdtempSync(path.join(tmpdir(), "openclaw-runtime-fast-path-"));
     const env: NodeJS.ProcessEnv = {
@@ -258,7 +234,7 @@ describe("secrets runtime fast path", () => {
     const mainAgentDir = path.join(root, "agents", "main", "agent");
     const agentDir = path.join(root, "custom-agent");
     mkdirSync(agentDir, { recursive: true });
-    setup(env, mainAgentDir, agentDir);
+    writeAuthProfileStore(mainAgentDir);
 
     try {
       const snapshot = prepareSecretsRuntimeFastPathSnapshot({
@@ -271,6 +247,30 @@ describe("secrets runtime fast path", () => {
       });
 
       expect(snapshot).toBeNull();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("detects retired OAuth before entering the secrets fast path", async () => {
+    const { assertAuthProfileMigrationReady, hasLegacyAuthProfileSourcesForStartup } =
+      await import("../agents/auth-profiles/legacy-source-diagnostic.js");
+    const root = mkdtempSync(path.join(tmpdir(), "openclaw-runtime-legacy-preflight-"));
+    const env: NodeJS.ProcessEnv = { HOME: root, OPENCLAW_STATE_DIR: root };
+    const credentialsPath = resolveLegacyOAuthPath(env);
+    mkdirSync(path.dirname(credentialsPath), { recursive: true });
+    writeFileSync(credentialsPath, '{"openai":{"access":"fake"}}\n');
+
+    try {
+      expect(
+        hasLegacyAuthProfileSourcesForStartup({
+          agentDirs: [path.join(root, "custom-agent")],
+          env,
+        }),
+      ).toBe(true);
+      expect(() =>
+        assertAuthProfileMigrationReady(path.join(root, "agents", "main", "agent")),
+      ).toThrow("requires legacy credential migration");
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/src/secrets/runtime.ts
+++ b/src/secrets/runtime.ts
@@ -7,6 +7,11 @@ import {
   loadAuthProfileStoreForSecretsRuntime,
   loadAuthProfileStoreWithoutExternalProfiles,
 } from "../agents/auth-profiles.js";
+import {
+  AuthProfileMigrationRequiredError,
+  clearAuthProfileMigrationDiagnostics,
+  markAuthProfileMigrationRequired,
+} from "../agents/auth-profiles/legacy-source-diagnostic.js";
 import { getRuntimeAuthProfileStoreCredentialsRevision } from "../agents/auth-profiles/runtime-snapshots.js";
 import type { AuthProfileStore } from "../agents/auth-profiles/types.js";
 import {
@@ -23,6 +28,7 @@ import type { PluginOrigin } from "../plugins/plugin-origin.types.js";
 import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
 import { isRecord, resolveUserPath } from "../utils.js";
 import { resolveAuthProfileSecretOwnerId } from "./runtime-auth-profile-owner.js";
+import type { DegradedSecretOwner } from "./runtime-degraded-state.js";
 import {
   canUseSecretsRuntimeFastPath,
   collectCandidateAgentDirs,
@@ -58,6 +64,7 @@ export type { SecretResolverWarning } from "./runtime-shared.js";
 export type { PreparedSecretsRuntimeSnapshot } from "./runtime-state.js";
 
 registerSecretsRuntimeStateClearHook(clearRuntimeAuthProfileStoreSnapshots);
+registerSecretsRuntimeStateClearHook(clearAuthProfileMigrationDiagnostics);
 registerSecretsRuntimeStateClearHook(clearProviderAuthRuntimeSnapshotActivation);
 
 const loadRuntimeManifestHelpers = createLazyRuntimeModule(
@@ -135,6 +142,39 @@ function shouldLoadPluginMetadataForSecrets(config: OpenClawConfig): boolean {
   );
 }
 
+function loadAuthStoresWithMigrationIsolation(params: {
+  agentDirs: readonly string[];
+  loadAuthStore: (agentDir?: string) => AuthProfileStore;
+  allowUnavailable: boolean;
+}): {
+  authStores: Array<{ agentDir: string; store: AuthProfileStore }>;
+  degradedOwners: DegradedSecretOwner[];
+} {
+  const authStores: Array<{ agentDir: string; store: AuthProfileStore }> = [];
+  const degradedOwners: DegradedSecretOwner[] = [];
+  for (const agentDir of params.agentDirs) {
+    try {
+      authStores.push({ agentDir, store: structuredClone(params.loadAuthStore(agentDir)) });
+    } catch (error) {
+      if (!(error instanceof AuthProfileMigrationRequiredError) || !params.allowUnavailable) {
+        throw error;
+      }
+      markAuthProfileMigrationRequired(agentDir, error);
+      authStores.push({ agentDir, store: { version: 1, profiles: {} } });
+      degradedOwners.push({
+        ownerKind: "route",
+        ownerId: error.ownerId,
+        state: "unavailable",
+        degradationState: "cold",
+        paths: error.sourceKinds.map((kind) => `auth-profile-legacy:${kind}`),
+        refKeys: [],
+        reason: "auth profile migration required",
+      });
+    }
+  }
+  return { authStores, degradedOwners };
+}
+
 /** Prepares a secrets runtime snapshot and records refresh context for later activation. */
 export async function prepareSecretsRuntimeSnapshot(params: {
   config: OpenClawConfig;
@@ -165,13 +205,15 @@ export async function prepareSecretsRuntimeSnapshot(params: {
   const candidateDirs = params.agentDirs?.length
     ? uniqueStrings(params.agentDirs.map((entry) => resolveUserPath(entry, runtimeEnv)))
     : collectCandidateAgentDirs(resolvedConfig, runtimeEnv);
+  let migrationDegradedOwners: DegradedSecretOwner[] = [];
   if (includeAuthStoreRefs) {
-    for (const agentDir of candidateDirs) {
-      authStores.push({
-        agentDir,
-        store: structuredClone(fastPathLoadAuthStore(agentDir)),
-      });
-    }
+    const loaded = loadAuthStoresWithMigrationIsolation({
+      agentDirs: candidateDirs,
+      loadAuthStore: fastPathLoadAuthStore,
+      allowUnavailable: params.allowUnavailableSecretOwners === true,
+    });
+    authStores = loaded.authStores;
+    migrationDegradedOwners = loaded.degradedOwners;
   }
   if (
     canUseSecretsRuntimeFastPath({
@@ -187,7 +229,7 @@ export async function prepareSecretsRuntimeSnapshot(params: {
       authStores,
       authStoreCredentialsRevision,
       warnings: [],
-      degradedOwners: [],
+      degradedOwners: migrationDegradedOwners,
       secretOwners: [],
       webTools: createEmptyRuntimeWebToolsMetadata(),
     };
@@ -241,10 +283,13 @@ export async function prepareSecretsRuntimeSnapshot(params: {
   if (includeAuthStoreRefs) {
     const loadAuthStore = params.loadAuthStore ?? loadAuthProfileStoreForSecretsRuntime;
     if (!params.loadAuthStore) {
-      authStores = candidateDirs.map((agentDir) => ({
-        agentDir,
-        store: structuredClone(loadAuthStore(agentDir)),
-      }));
+      const loaded = loadAuthStoresWithMigrationIsolation({
+        agentDirs: candidateDirs,
+        loadAuthStore,
+        allowUnavailable: params.allowUnavailableSecretOwners === true,
+      });
+      authStores = loaded.authStores;
+      migrationDegradedOwners = loaded.degradedOwners;
     }
     for (const entry of authStores) {
       collectAuthStoreAssignments({
@@ -292,7 +337,11 @@ export async function prepareSecretsRuntimeSnapshot(params: {
     authStores,
     authStoreCredentialsRevision,
     warnings: context.warnings,
-    degradedOwners: [...assignmentResolution.degradedOwners, ...webTools.degradedOwners],
+    degradedOwners: [
+      ...migrationDegradedOwners,
+      ...assignmentResolution.degradedOwners,
+      ...webTools.degradedOwners,
+    ],
     secretOwners: [...assignmentSecretOwners, ...webTools.secretOwners],
     webTools: webTools.metadata,
   };

--- a/src/secrets/storage-scan.ts
+++ b/src/secrets/storage-scan.ts
@@ -19,25 +19,6 @@ export function listAuthProfileStoreAgentDirs(config: OpenClawConfig, stateDir: 
   return listAuthProfileStoreAgentDirsFromAuthStorePaths(config, stateDir);
 }
 
-/** Lists legacy per-agent auth.json stores that can contain static credentials. */
-export function listLegacyAuthJsonPaths(stateDir: string): string[] {
-  const out: string[] = [];
-  const agentsRoot = path.join(resolveUserPath(stateDir), "agents");
-  if (!fs.existsSync(agentsRoot)) {
-    return out;
-  }
-  for (const entry of fs.readdirSync(agentsRoot, { withFileTypes: true })) {
-    if (!entry.isDirectory()) {
-      continue;
-    }
-    const candidate = path.join(agentsRoot, entry.name, "agent", "auth.json");
-    if (fs.existsSync(candidate)) {
-      out.push(candidate);
-    }
-  }
-  return out;
-}
-
 /** Lists global dotenv files that can supply secrets for the selected config and state roots. */
 export function listSecretsDotEnvPaths(params: { configPath: string; stateDir: string }): string[] {
   const candidates = [


### PR DESCRIPTION
## What Problem This Solves

Resolves an upgrade-safety problem where steady-state auth runtime still read legacy `auth-profiles.json`, `auth-state.json`, `auth.json`, and shared `credentials/oauth.json` files even though auth profiles now have a canonical per-agent SQLite owner. Removing those fallbacks without a migration would lock out users upgrading from shipped releases through `v2026.7.2-beta.5`.

## Why This Change Was Made

Doctor now owns a locked, idempotent, receipt-backed migration for all four legacy sources, verifies SQLite targets before timestamped archival, resumes interrupted archive finalization, and never deletes credential bytes during import. Runtime, secrets fast paths, source probes, ownership keys, and session auth storage now use SQLite only; detected legacy credentials fail closed per owner with the redacted `AUTH_PROFILE_MIGRATION_REQUIRED` diagnostic.

The Plugin SDK transition adds `AuthStorage.forAgent(agentDir)` first. `AuthStorage.create(path)` remains a named SQLite-backed deprecation with `AUTH_STORAGE_CREATE_DEPRECATED`; the exported `FileAuthStorageBackend` remains as a SQLite-backed compatibility adapter with `FILE_AUTH_STORAGE_BACKEND_DEPRECATED`. Both are eligible for removal after 2026-10-01 and a clean published-plugin reader sweep. Existing deprecated-path files fail closed without being read; absent paths only derive the SQLite owner and are never created or written by the adapters.

No SQLite table/column alteration or schema-version bump is introduced, and the unused `auth_profile_stores` table is not revived.

## Maintainer Decision

The orchestrator-approved Plugin SDK exception is explicit: the modern API is `AuthStorage.forAgent(agentDir)`; the two shipped path-taking symbols remain named, SQLite-backed deprecations through the documented window. An existing deprecated path fails closed without reading its credential contents, while an absent path is used only to derive the SQLite owner and is never created or written by the adapter. Nonstandard file-backed plugin storage must migrate to the agent-owned API during the window; implicit JSON fallback is not retained.

## User Impact

On upgrade, `openclaw doctor --fix` migrates legacy auth files once, verifies the imported credentials and routing state, records crash-recovery receipts, and preserves the original bytes in timestamped archives. After migration, runtime auth is SQLite-only; an unmigrated or unreadable owner fails closed with a redacted instruction to run Doctor instead of silently switching to environment/config credentials.

Plugin developers should migrate from `AuthStorage.create(path)` and `FileAuthStorageBackend` to `AuthStorage.forAgent(agentDir)` during the announced compatibility window. This is release-note context for the auth-profile cutover and SDK deprecation; `CHANGELOG.md` is intentionally unchanged.

## Evidence

- AI-assisted implementation; maintainer-requested and design-approved. I understand the migration, runtime isolation, crash recovery, and SDK compatibility paths.
- Exact pushed SHA `1645a677bf2e5d7ef1193d4555ef0663ebd36f76`: `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs <21 focused files>` passed nine project shards and 511 tests, covering Doctor/receipts, SQLite store/source probes, secrets audit/apply/fast-path/isolation, session AuthStorage, gateway/config, stale Doctor repairs, directive handling, and QA Lab.
- Exact pushed SHA: `node scripts/check-changed.mjs` on Blacksmith Testbox passed formatting, SDK API/deprecation contracts, database-first and schema-version guards, four typecheck lanes, core/extensions/scripts lint, import cycles, and changed guards in 19m19s.
- Exact pushed SHA packaged upgrade survivor: `openclaw@2026.7.1` to candidate `2026.7.2`, scenario `auth-profile-v2026-7-2-beta-5`; Doctor, survival assertions, gateway startup, healthz, readyz, and status passed. Testbox run: https://github.com/openclaw/openclaw/actions/runs/30198626195
- Final branch autoreview against `origin/main`: `autoreview clean: no accepted/actionable findings reported`.
- `git diff --check`: clean.
- Upgrade fixture contains fake-only credential values; no real profile contents or secret values are present.
