### PR TITLE
docs(cli): cross-link agent exec from automation and policy pages

### DIFF
--- a/docs/automation/standing-orders.md
+++ b/docs/automation/standing-orders.md
@@ -19,6 +19,8 @@ Standing orders grant your agent **permanent operating authority** for defined p
 
 Standing orders are defined in your [agent workspace](/concepts/agent-workspace) files. The recommended approach is to include them directly in `AGENTS.md` (which is auto-injected every session) so the agent always has them in context. For larger configurations, you can also place them in a dedicated file like `standing-orders.md` and reference it from `AGENTS.md`.
 
+For a strict, ephemeral CI or scripting entry point, use [`openclaw agent exec`](/cli/agent#agent-exec). It skips workspace bootstrap files, so each one-shot run is self-contained rather than governed by standing orders.
+
 Each program specifies:
 
 1. **Scope** - what the agent is authorized to do

--- a/docs/automation/tasks.md
+++ b/docs/automation/tasks.md
@@ -16,6 +16,8 @@ Background tasks track work that runs **outside your main conversation session**
 
 Tasks do **not** replace sessions, cron jobs, or heartbeats - they are the **activity ledger** that records what detached work happened, when, and whether it succeeded.
 
+For a strict, ephemeral one-shot agent run in CI or a script, use [`openclaw agent exec`](/cli/agent#agent-exec) instead of managed background work.
+
 <Note>
 Not every agent run creates a task. Heartbeat turns and normal interactive chat do not. All cron executions, ACP spawns, subagent spawns, gateway-dispatched CLI agent commands, and agent-started background `exec` commands do.
 </Note>

--- a/docs/cli/policy.md
+++ b/docs/cli/policy.md
@@ -26,6 +26,10 @@ not be enabled" or "governed tools must declare risk and owner metadata." If
 you only need local behavior with no attestation or drift detection, plain
 config is enough.
 
+Separately, [`openclaw agent exec`](/cli/agent#agent-exec) applies an isolated
+implicit policy config for each run: the agent sandbox is off, Gateway-host
+execution is fully allowed, and filesystem tools are restricted to `--cwd`.
+
 ## Quick start
 
 ```bash

--- a/docs/cli/sandbox.md
+++ b/docs/cli/sandbox.md
@@ -7,6 +7,8 @@ status: active
 
 Manage sandbox runtimes for isolated agent execution: Docker containers, SSH targets, or OpenShell backends.
 
+[`openclaw agent exec`](/cli/agent#agent-exec) does not use these configured runtimes. Its isolated implicit policy config turns the agent sandbox off, allows full Gateway-host execution, and restricts filesystem tools to `--cwd`.
+
 ## Commands
 
 ### `openclaw sandbox list`

--- a/docs/tools/agent-send.md
+++ b/docs/tools/agent-send.md
@@ -11,6 +11,9 @@ inbound chat message. Use it for scripted workflows, testing, and
 programmatic delivery. Full flag and behavior reference:
 [Agent CLI reference](/cli/agent).
 
+For strict, ephemeral CI or coding automation that should own setup, cleanup,
+output projection, and process status, use [`openclaw agent exec`](/cli/agent#agent-exec).
+
 ## Quick start
 
 <Steps>


### PR DESCRIPTION
## What Problem This Solves

Users arriving through automation, scripting, policy, or sandbox documentation cannot discover the strict headless `openclaw agent exec` entry point because only its CLI reference currently mentions it.

## Why This Change Was Made

Adds concise cross-links from the two relevant automation pages and the policy and sandbox references, plus one broader scripting entry point on the Agent send page. The links point to the canonical `agent exec` reference instead of duplicating its behavior, and no navigation change is needed because the Agent CLI page is already listed.

AI-assisted: yes. The final wording and behavior claims were checked against the canonical Agent CLI reference and reviewed with the repository autoreview workflow.

## User Impact

Users can now find the strict, ephemeral CI runner from the docs paths where they choose automation modes or reason about policy and sandbox behavior. The policy pages also make the runner's isolated implicit policy explicit: sandbox off, full Gateway-host execution, and filesystem tools restricted to `--cwd`.

## Evidence

- `pnpm check:docs`
- `pnpm docs:check-links:anchors`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output` — clean, no accepted/actionable findings
- `pnpm docs:map:gen` — regenerated with no diff because routes and headings are unchanged
