### PR TITLE
feat(cli): add agents set-default command

### DIFF
--- a/docs/cli/agents.md
+++ b/docs/cli/agents.md
@@ -1,5 +1,5 @@
 ---
-summary: "CLI reference for `openclaw agents` (list/add/delete/bindings/bind/unbind/set identity)"
+summary: "CLI reference for `openclaw agents` (list/add/delete/bindings/bind/unbind/set default/set identity)"
 read_when:
   - You want multiple isolated agents (workspaces + routing + auth)
 title: "Agents"
@@ -26,6 +26,7 @@ openclaw agents add ops --workspace ~/.openclaw/workspace-ops --bind telegram:op
 openclaw agents bindings
 openclaw agents bind --agent work --bind telegram:ops
 openclaw agents unbind --agent work --bind telegram:ops
+openclaw agents set-default work
 openclaw agents set-identity --workspace ~/.openclaw/workspace --from-identity
 openclaw agents set-identity --agent main --avatar avatars/openclaw.png
 openclaw agents delete work
@@ -58,6 +59,12 @@ Options: `--agent <id>` (defaults to the current default agent), `--bind <channe
 
 Options: `--agent <id>` (defaults to the current default agent), `--bind <channel[:accountId]>` (repeatable), `--all`, `--json`. Accepts either `--all` or one or more `--bind` values, not both.
 
+### `agents set-default <id>`
+
+Reassigns the default agent in one config update. If the selected agent is already the default, the command succeeds without rewriting the config.
+
+Options: `--json`.
+
 ### `agents set-identity`
 
 Options: `--agent <id>`, `--workspace <dir>`, `--identity-file <path>`, `--from-identity`, `--name <name>`, `--theme <theme>`, `--emoji <emoji>`, `--avatar <value>`, `--json`. See [Set identity](#set-identity) below.
@@ -67,6 +74,7 @@ Options: `--agent <id>`, `--workspace <dir>`, `--identity-file <path>`, `--from-
 Options: `--force`, `--json`.
 
 - `main` cannot be deleted.
+- The default agent cannot be deleted. Reassign it first with `openclaw agents set-default <id>`.
 - Without `--force`, interactive confirmation is required (fails in a non-TTY session; re-run with `--force`).
 - Workspace, agent state, and session transcript directories move to Trash, not hard-deleted. If Trash is unavailable, agent config deletion still succeeds and reports paths requiring manual cleanup.
 - When the Gateway is reachable, deletion routes through the Gateway so config and session-store cleanup share the same writer as runtime traffic. If the Gateway is unreachable, the CLI falls back to the offline local path.

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -225,6 +225,7 @@ openclaw [--dev] [--profile <name>] <command>
     bindings
     bind
     unbind
+    set-default
     set-identity
   attach
   acp

--- a/docs/gateway/config-agents.md
+++ b/docs/gateway/config-agents.md
@@ -1029,7 +1029,7 @@ for provider examples and precedence.
 ```
 
 - `id`: stable agent id (required).
-- `default`: when multiple are set, first wins (warning logged). If none set, first list entry is default.
+- `default`: exactly one configured agent must set this to `true`. Reassign the marker atomically with `openclaw agents set-default <id>`; the command is a no-op when that agent is already the default.
 - `model`: string form sets a strict per-agent primary with no model fallback; object form `{ primary }` is also strict unless you add `fallbacks`. Use `{ primary, fallbacks: [...] }` to opt that agent into fallback, or `{ primary, fallbacks: [] }` to make strict behavior explicit. Cron jobs that only override `primary` still inherit default fallbacks unless you set `fallbacks: []`.
 - `utilityModel`: optional per-agent override for short internal tasks such as generated session and thread titles. Falls back to `agents.defaults.utilityModel`, then the effective session provider's declared small-model default. Dashboard titles retry once with the effective regular session model. An empty string skips the alternate utility route for this agent without disabling dashboard title generation.
 - `params`: per-agent stream params merged over the selected model entry in `agents.defaults.models`. Use this for agent-specific overrides like `cacheRetention`, `temperature`, or `maxTokens` without duplicating the whole model catalog.

--- a/src/cli/command-catalog.ts
+++ b/src/cli/command-catalog.ts
@@ -131,6 +131,11 @@ export const cliCommandCatalog: readonly CliCommandCatalogEntry[] = [
     policy: { loadPlugins: "never" },
   },
   {
+    commandPath: ["agents", "set-default"],
+    exact: true,
+    policy: { loadPlugins: "never" },
+  },
+  {
     commandPath: ["agents", "set-identity"],
     exact: true,
     policy: { loadPlugins: "never" },

--- a/src/cli/command-path-policy.test.ts
+++ b/src/cli/command-path-policy.test.ts
@@ -184,6 +184,7 @@ describe("command-path-policy", () => {
       ["agents", "bind"],
       ["agents", "bindings"],
       ["agents", "unbind"],
+      ["agents", "set-default"],
       ["agents", "set-identity"],
       ["agents", "delete"],
     ]) {

--- a/src/cli/command-startup-policy.test.ts
+++ b/src/cli/command-startup-policy.test.ts
@@ -160,6 +160,11 @@ describe("command-startup-policy", () => {
     ).toBe(false);
     expect(
       resolvePolicy({
+        commandPath: ["agents", "set-default"],
+      }).loadPlugins,
+    ).toBe(false);
+    expect(
+      resolvePolicy({
         commandPath: ["agents", "set-identity"],
       }).loadPlugins,
     ).toBe(false);

--- a/src/cli/help-cold-imports.test.ts
+++ b/src/cli/help-cold-imports.test.ts
@@ -185,6 +185,11 @@ vi.mock("../commands/agents.commands.list.js", () => {
   return { agentsListCommand: vi.fn(async () => {}) };
 });
 
+vi.mock("../commands/agents.commands.set-default.js", () => {
+  loaded.mark("agents-set-default-command");
+  return { agentsSetDefaultCommand: vi.fn(async () => {}) };
+});
+
 vi.mock("@clack/prompts", () => {
   loaded.mark("clack-prompts");
   return {
@@ -335,6 +340,7 @@ describe("subcommand help cold imports", () => {
     expect(loaded.modules).not.toContain("agents-delete-command");
     expect(loaded.modules).not.toContain("agents-identity-command");
     expect(loaded.modules).not.toContain("agents-list-command");
+    expect(loaded.modules).not.toContain("agents-set-default-command");
     expect(loaded.modules).not.toContain("default-runtime");
   });
 

--- a/src/cli/program/register.agent.test.ts
+++ b/src/cli/program/register.agent.test.ts
@@ -12,6 +12,7 @@ const mocks = vi.hoisted(() => ({
   agentsBindCommandMock: vi.fn(),
   agentsDeleteCommandMock: vi.fn(),
   agentsListCommandMock: vi.fn(),
+  agentsSetDefaultCommandMock: vi.fn(),
   agentsSetIdentityCommandMock: vi.fn(),
   agentsUnbindCommandMock: vi.fn(),
   setVerboseMock: vi.fn(),
@@ -29,6 +30,7 @@ const agentsBindingsCommandMock = mocks.agentsBindingsCommandMock;
 const agentsBindCommandMock = mocks.agentsBindCommandMock;
 const agentsDeleteCommandMock = mocks.agentsDeleteCommandMock;
 const agentsListCommandMock = mocks.agentsListCommandMock;
+const agentsSetDefaultCommandMock = mocks.agentsSetDefaultCommandMock;
 const agentsSetIdentityCommandMock = mocks.agentsSetIdentityCommandMock;
 const agentsUnbindCommandMock = mocks.agentsUnbindCommandMock;
 const setVerboseMock = mocks.setVerboseMock;
@@ -64,6 +66,10 @@ vi.mock("../../commands/agents.commands.list.js", () => ({
   agentsListCommand: mocks.agentsListCommandMock,
 }));
 
+vi.mock("../../commands/agents.commands.set-default.js", () => ({
+  agentsSetDefaultCommand: mocks.agentsSetDefaultCommandMock,
+}));
+
 vi.mock("../../global-state.js", () => ({
   setVerbose: mocks.setVerboseMock,
 }));
@@ -90,6 +96,7 @@ describe("agent command registration", () => {
     agentsBindCommandMock.mockResolvedValue(undefined);
     agentsDeleteCommandMock.mockResolvedValue(undefined);
     agentsListCommandMock.mockResolvedValue(undefined);
+    agentsSetDefaultCommandMock.mockResolvedValue(undefined);
     agentsSetIdentityCommandMock.mockResolvedValue(undefined);
     agentsUnbindCommandMock.mockResolvedValue(undefined);
   });
@@ -323,6 +330,17 @@ describe("agent command registration", () => {
     expect((options as { force?: boolean }).force).toBe(true);
     expect((options as { json?: boolean }).json).toBe(true);
     expect(callRuntime).toBe(runtime);
+  });
+
+  it("forwards agents set-default options", async () => {
+    await runCli(["agents", "set-default", "worker-a", "--json"]);
+    expect(agentsSetDefaultCommandMock).toHaveBeenCalledWith(
+      {
+        id: "worker-a",
+        json: true,
+      },
+      runtime,
+    );
   });
 
   it("forwards set-identity options", async () => {

--- a/src/cli/program/register.agent.ts
+++ b/src/cli/program/register.agent.ts
@@ -12,6 +12,7 @@ type AgentsBindModule = typeof import("../../commands/agents.commands.bind.js");
 type AgentsDeleteModule = typeof import("../../commands/agents.commands.delete.js");
 type AgentsIdentityModule = typeof import("../../commands/agents.commands.identity.js");
 type AgentsListModule = typeof import("../../commands/agents.commands.list.js");
+type AgentsSetDefaultModule = typeof import("../../commands/agents.commands.set-default.js");
 type CliUtilsModule = typeof import("../cli-utils.js");
 type RuntimeModule = typeof import("../../runtime.js");
 
@@ -47,6 +48,12 @@ async function loadAgentsSetIdentityCommand(): Promise<
 
 async function loadAgentsListCommand(): Promise<AgentsListModule["agentsListCommand"]> {
   return (await import("../../commands/agents.commands.list.js")).agentsListCommand;
+}
+
+async function loadAgentsSetDefaultCommand(): Promise<
+  AgentsSetDefaultModule["agentsSetDefaultCommand"]
+> {
+  return (await import("../../commands/agents.commands.set-default.js")).agentsSetDefaultCommand;
 }
 
 async function loadAgentsActionRuntime(): Promise<{
@@ -191,6 +198,23 @@ export function registerAgentsCommands(program: Command): void {
           },
           runtime,
           { hasFlags },
+        );
+      });
+    });
+
+  agents
+    .command("set-default <id>")
+    .description("Set the default agent")
+    .option("--json", "Output JSON summary", false)
+    .action(async (id, opts): Promise<void> => {
+      await runAgentsCommandAction(async (runtime) => {
+        const agentsSetDefaultCommand = await loadAgentsSetDefaultCommand();
+        await agentsSetDefaultCommand(
+          {
+            id: String(id),
+            json: Boolean(opts.json),
+          },
+          runtime,
         );
       });
     });

--- a/src/commands/agents.commands.delete.ts
+++ b/src/commands/agents.commands.delete.ts
@@ -112,7 +112,7 @@ export async function agentsDeleteCommand(
   }
   if (agentId === resolveDefaultAgentId(cfg)) {
     runtime.error(
-      `Agent "${agentId}" is the default and cannot be deleted. Reassign default first.`,
+      `Agent "${agentId}" is the default and cannot be deleted. Reassign it with ${formatCliCommand(`openclaw agents set-default <id>`)} first.`,
     );
     runtime.exit(1);
     return;

--- a/src/commands/agents.commands.set-default.ts
+++ b/src/commands/agents.commands.set-default.ts
@@ -1,0 +1,83 @@
+// Implements default-agent reassignment for configured agent rosters.
+import { resolveDefaultAgentId } from "../agents/agent-scope.js";
+import { formatCliCommand } from "../cli/command-format.js";
+import { replaceConfigFile } from "../config/config.js";
+import { logConfigUpdated } from "../config/logging.js";
+import { normalizeAgentId } from "../routing/session-key.js";
+import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
+import { defaultRuntime } from "../runtime.js";
+import { requireValidConfigFileSnapshot } from "./agents.command-shared.js";
+import { findAgentEntryIndex, listAgentEntries } from "./agents.config.js";
+
+type AgentsSetDefaultOptions = {
+  id: string;
+  json?: boolean;
+};
+
+/** Reassign the default marker in one validated config write. */
+export async function agentsSetDefaultCommand(
+  opts: AgentsSetDefaultOptions,
+  runtime: RuntimeEnv = defaultRuntime,
+) {
+  const configSnapshot = await requireValidConfigFileSnapshot(runtime);
+  if (!configSnapshot) {
+    return;
+  }
+  const cfg = configSnapshot.sourceConfig ?? configSnapshot.config;
+  const baseHash = configSnapshot.hash;
+
+  const input = opts.id?.trim();
+  if (!input) {
+    runtime.error(
+      `Agent id is required. Run ${formatCliCommand("openclaw agents list")} to choose one.`,
+    );
+    runtime.exit(1);
+    return;
+  }
+
+  const agentId = normalizeAgentId(input);
+  const entries = listAgentEntries(cfg);
+  if (findAgentEntryIndex(entries, agentId) < 0) {
+    runtime.error(
+      `Agent "${agentId}" not found. Run ${formatCliCommand("openclaw agents list")} to see configured agents.`,
+    );
+    runtime.exit(1);
+    return;
+  }
+
+  if (agentId === resolveDefaultAgentId(cfg)) {
+    if (opts.json) {
+      writeRuntimeJson(runtime, { agentId, changed: false });
+    } else {
+      runtime.log(`Agent "${agentId}" is already the default.`);
+    }
+    return;
+  }
+
+  const nextEntries = Object.fromEntries(
+    entries.map((entry) => {
+      const { default: _default, id, ...config } = entry;
+      return [id, normalizeAgentId(id) === agentId ? { ...config, default: true } : config];
+    }),
+  );
+  const { list: _legacyList, ...agentsConfig } = cfg.agents ?? {};
+  const nextConfig = {
+    ...cfg,
+    agents: {
+      ...agentsConfig,
+      entries: nextEntries,
+    },
+  };
+
+  await replaceConfigFile({
+    nextConfig,
+    ...(baseHash !== undefined ? { baseHash } : {}),
+  });
+
+  if (opts.json) {
+    writeRuntimeJson(runtime, { agentId, changed: true });
+    return;
+  }
+  logConfigUpdated(runtime);
+  runtime.log(`Default agent: ${agentId}`);
+}

--- a/src/commands/agents.delete.test.ts
+++ b/src/commands/agents.delete.test.ts
@@ -407,7 +407,7 @@ describe("agents delete command", () => {
       await agentsDeleteCommand({ id: "ops", force: true, json: true }, runtime);
 
       expect(runtime.error).toHaveBeenCalledWith(
-        'Agent "ops" is the default and cannot be deleted. Reassign default first.',
+        'Agent "ops" is the default and cannot be deleted. Reassign it with openclaw agents set-default <id> first.',
       );
       expect(runtime.exit).toHaveBeenCalledWith(1);
       expectSessionStore(storePath, {

--- a/src/commands/agents.set-default.test.ts
+++ b/src/commands/agents.set-default.test.ts
@@ -58,7 +58,11 @@ describe("agents set-default command", () => {
     await agentsSetDefaultCommand({ id: "work", json: true }, runtime);
 
     expect(configMocks.replaceConfigFile).toHaveBeenCalledOnce();
-    const [{ nextConfig, baseHash }] = configMocks.replaceConfigFile.mock.calls[0] ?? [];
+    const writeCall = configMocks.replaceConfigFile.mock.calls[0];
+    if (!writeCall) {
+      throw new Error("expected config write");
+    }
+    const [{ nextConfig, baseHash }] = writeCall;
     expect(baseHash).toBe("base-hash");
     expect(nextConfig.agents.entries).toEqual({
       main: { name: "Main" },

--- a/src/commands/agents.set-default.test.ts
+++ b/src/commands/agents.set-default.test.ts
@@ -1,11 +1,17 @@
 // Agents set-default tests cover atomic config reassignment and no-op/error paths.
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { AgentsSchema } from "../config/zod-schema.agents.js";
 import { baseConfigSnapshot, createTestRuntime } from "./test-runtime-config-helpers.js";
 
+type ReplaceConfigParams = {
+  nextConfig: OpenClawConfig;
+  baseHash?: string;
+};
+
 const configMocks = vi.hoisted(() => ({
   readConfigFileSnapshot: vi.fn(),
-  replaceConfigFile: vi.fn(async () => {}),
+  replaceConfigFile: vi.fn(async (_params: ReplaceConfigParams) => {}),
 }));
 
 vi.mock("../config/config.js", async () => ({

--- a/src/commands/agents.set-default.test.ts
+++ b/src/commands/agents.set-default.test.ts
@@ -1,0 +1,99 @@
+// Agents set-default tests cover atomic config reassignment and no-op/error paths.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AgentsSchema } from "../config/zod-schema.agents.js";
+import { baseConfigSnapshot, createTestRuntime } from "./test-runtime-config-helpers.js";
+
+const configMocks = vi.hoisted(() => ({
+  readConfigFileSnapshot: vi.fn(),
+  replaceConfigFile: vi.fn(async () => {}),
+}));
+
+vi.mock("../config/config.js", async () => ({
+  ...(await vi.importActual<typeof import("../config/config.js")>("../config/config.js")),
+  readConfigFileSnapshot: configMocks.readConfigFileSnapshot,
+  replaceConfigFile: configMocks.replaceConfigFile,
+}));
+
+import { agentsSetDefaultCommand } from "./agents.commands.set-default.js";
+
+const runtime = createTestRuntime();
+
+function readJsonLog(): Record<string, unknown> {
+  const message = runtime.log.mock.calls.at(-1)?.[0];
+  if (typeof message !== "string") {
+    throw new Error("expected JSON log output");
+  }
+  return JSON.parse(message) as Record<string, unknown>;
+}
+
+describe("agents set-default command", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("reassigns the default marker in one validated config write", async () => {
+    const config = {
+      agents: {
+        defaults: { workspace: "/workspace" },
+        entries: {
+          main: { default: true, name: "Main" },
+          work: { name: "Work" },
+          ops: { name: "Ops" },
+        },
+      },
+    };
+    configMocks.readConfigFileSnapshot.mockResolvedValue({
+      ...baseConfigSnapshot,
+      hash: "base-hash",
+      config,
+      sourceConfig: config,
+    });
+
+    await agentsSetDefaultCommand({ id: "work", json: true }, runtime);
+
+    expect(configMocks.replaceConfigFile).toHaveBeenCalledOnce();
+    const [{ nextConfig, baseHash }] = configMocks.replaceConfigFile.mock.calls[0] ?? [];
+    expect(baseHash).toBe("base-hash");
+    expect(nextConfig.agents.entries).toEqual({
+      main: { name: "Main" },
+      work: { name: "Work", default: true },
+      ops: { name: "Ops" },
+    });
+    expect(AgentsSchema.safeParse(nextConfig.agents).success).toBe(true);
+    expect(readJsonLog()).toEqual({ agentId: "work", changed: true });
+  });
+
+  it("errors without writing when the agent does not exist", async () => {
+    const config = { agents: { entries: { main: { default: true } } } };
+    configMocks.readConfigFileSnapshot.mockResolvedValue({
+      ...baseConfigSnapshot,
+      config,
+      sourceConfig: config,
+    });
+
+    await agentsSetDefaultCommand({ id: "missing" }, runtime);
+
+    expect(runtime.error).toHaveBeenCalledWith(
+      'Agent "missing" not found. Run openclaw agents list to see configured agents.',
+    );
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+    expect(configMocks.replaceConfigFile).not.toHaveBeenCalled();
+  });
+
+  it("succeeds without writing when the agent is already default", async () => {
+    const config = {
+      agents: { entries: { main: { default: true }, work: { name: "Work" } } },
+    };
+    configMocks.readConfigFileSnapshot.mockResolvedValue({
+      ...baseConfigSnapshot,
+      config,
+      sourceConfig: config,
+    });
+
+    await agentsSetDefaultCommand({ id: "main", json: true }, runtime);
+
+    expect(configMocks.replaceConfigFile).not.toHaveBeenCalled();
+    expect(runtime.exit).not.toHaveBeenCalled();
+    expect(readJsonLog()).toEqual({ agentId: "main", changed: false });
+  });
+});

--- a/src/commands/agents.set-default.test.ts
+++ b/src/commands/agents.set-default.test.ts
@@ -63,13 +63,17 @@ describe("agents set-default command", () => {
       throw new Error("expected config write");
     }
     const [{ nextConfig, baseHash }] = writeCall;
+    const nextAgents = nextConfig.agents;
+    if (!nextAgents) {
+      throw new Error("expected agents config");
+    }
     expect(baseHash).toBe("base-hash");
-    expect(nextConfig.agents.entries).toEqual({
+    expect(nextAgents.entries).toEqual({
       main: { name: "Main" },
       work: { name: "Work", default: true },
       ops: { name: "Ops" },
     });
-    expect(AgentsSchema.safeParse(nextConfig.agents).success).toBe(true);
+    expect(AgentsSchema.safeParse(nextAgents).success).toBe(true);
     expect(readJsonLog()).toEqual({ agentId: "work", changed: true });
   });
 


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where users could not reassign the default agent even though `openclaw agents delete` told them to reassign it before deleting the current default. The only available workaround required a raw two-path config update.

## Why This Change Was Made

Adds `openclaw agents set-default <id>` with text and JSON output. The command loads one validated config snapshot, clears the old marker and sets the target marker in memory, then performs one conflict-checked config replacement so the exactly-one-default invariant is never broken between writes. Missing agents fail cleanly, and selecting the current default succeeds without rewriting config.

The agents command catalog, startup-policy coverage, delete guidance, CLI reference, and agent configuration reference now include the new command.

## User Impact

Operators can now run `openclaw agents set-default work` before deleting the previous default. Automation can use `--json`, which reports `{ "agentId": "work", "changed": true }` for a reassignment and `changed: false` for an already-default no-op.

## Evidence

- Source-blind CLI validation against an isolated state directory: reassignment persisted `work` as the sole default; a fresh `agents list --json` observed it; repeating the command returned `changed: false` without changing the config hash or mtime; an unknown id exited 1 without changing the file.
- Focused Testbox proof: 71 tests passed across command behavior, deletion guidance, registration/help, and startup policy: https://github.com/openclaw/openclaw/actions/runs/30189142994
- Exact-head `pnpm check:changed` and `pnpm build` passed on Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/30188308852
- Docs checks passed: `pnpm docs:list`, MDX validation across 751 files, 6,181 internal links with zero broken links, and docs formatting.
- Final Codex autoreview against `origin/main`: no accepted or actionable findings.
