### PR TITLE
feat(mac): gateway menu-bar surfaces and Gateways main menu

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -31594,8 +31594,56 @@
       "id": "native.apple.b42d8e457b71b478"
     },
     {
+      "kind": "ui-localized-call",
+      "line": 40,
+      "path": "apps/macos/Sources/OpenClaw/DashboardGatewayMenuModel.swift",
+      "source": "OpenClaw Not Configured",
+      "surface": "apple",
+      "id": "native.apple.905508b749e99f2a"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 42,
+      "path": "apps/macos/Sources/OpenClaw/DashboardGatewayMenuModel.swift",
+      "source": "Remote OpenClaw Active",
+      "surface": "apple",
+      "id": "native.apple.293bf9a6e721036d"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 44,
+      "path": "apps/macos/Sources/OpenClaw/DashboardGatewayMenuModel.swift",
+      "source": "OpenClaw Active",
+      "surface": "apple",
+      "id": "native.apple.a7b0d4e6bf5796c0"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 49,
+      "path": "apps/macos/Sources/OpenClaw/DashboardGatewayMenuModel.swift",
+      "source": "OpenClaw Not Configured — \\(primaryName)",
+      "surface": "apple",
+      "id": "native.apple.b36a54d8fef80333"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 51,
+      "path": "apps/macos/Sources/OpenClaw/DashboardGatewayMenuModel.swift",
+      "source": "Remote OpenClaw Active — \\(primaryName)",
+      "surface": "apple",
+      "id": "native.apple.adee4bfd71731d2d"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 53,
+      "path": "apps/macos/Sources/OpenClaw/DashboardGatewayMenuModel.swift",
+      "source": "OpenClaw Active — \\(primaryName)",
+      "surface": "apple",
+      "id": "native.apple.2be6d3dd1a0d2699"
+    },
+    {
       "kind": "ui-named-argument",
-      "line": 205,
+      "line": 222,
       "path": "apps/macos/Sources/OpenClaw/DashboardManager.swift",
       "source": "Dashboard reconnecting",
       "surface": "apple",
@@ -31603,7 +31651,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 206,
+      "line": 223,
       "path": "apps/macos/Sources/OpenClaw/DashboardManager.swift",
       "source": "The selected Gateway changed.",
       "surface": "apple",
@@ -31611,7 +31659,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 207,
+      "line": 224,
       "path": "apps/macos/Sources/OpenClaw/DashboardManager.swift",
       "source": "Waiting for a fresh authenticated connection.",
       "surface": "apple",
@@ -31619,7 +31667,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 345,
+      "line": 362,
       "path": "apps/macos/Sources/OpenClaw/DashboardManager.swift",
       "source": "Dashboard unavailable",
       "surface": "apple",
@@ -31627,7 +31675,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 347,
+      "line": 364,
       "path": "apps/macos/Sources/OpenClaw/DashboardManager.swift",
       "source": "Check Settings → Connection or use Debug → Reset Remote Tunnel, then try again.",
       "surface": "apple",
@@ -31635,7 +31683,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 546,
+      "line": 566,
       "path": "apps/macos/Sources/OpenClaw/DashboardManager.swift",
       "source": "Could Not Switch Gateway",
       "surface": "apple",
@@ -31643,27 +31691,27 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 573,
+      "line": 594,
       "path": "apps/macos/Sources/OpenClaw/DashboardManager.swift",
       "source": "Could Not Open Gateway Window",
       "surface": "apple",
       "id": "native.apple.213d824f2205d071"
     },
     {
-      "kind": "ui-named-argument",
-      "line": 593,
-      "path": "apps/macos/Sources/OpenClaw/DashboardManager.swift",
-      "source": "Could Not Set Primary Gateway",
-      "surface": "apple",
-      "id": "native.apple.f821306f90ed7692"
-    },
-    {
       "kind": "conditional-branch",
-      "line": 703,
+      "line": 698,
       "path": "apps/macos/Sources/OpenClaw/DashboardManager.swift",
       "source": "\\(base)-\\(UUID().uuidString)",
       "surface": "apple",
       "id": "native.apple.11ffe8832b728acd"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 938,
+      "path": "apps/macos/Sources/OpenClaw/DashboardManager.swift",
+      "source": "Could Not Set Primary Gateway",
+      "surface": "apple",
+      "id": "native.apple.f821306f90ed7692"
     },
     {
       "kind": "conditional-branch",
@@ -33787,7 +33835,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 126,
+      "line": 127,
       "path": "apps/macos/Sources/OpenClaw/MenuBar.swift",
       "source": "Back",
       "surface": "apple",
@@ -33795,7 +33843,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 131,
+      "line": 132,
       "path": "apps/macos/Sources/OpenClaw/MenuBar.swift",
       "source": "Forward",
       "surface": "apple",
@@ -33803,7 +33851,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 138,
+      "line": 139,
       "path": "apps/macos/Sources/OpenClaw/MenuBar.swift",
       "source": "Command Palette…",
       "surface": "apple",
@@ -33811,7 +33859,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 156,
+      "line": 157,
       "path": "apps/macos/Sources/OpenClaw/MenuBar.swift",
       "source": "OpenClaw - Voice Wake live meter active",
       "surface": "apple",
@@ -33819,7 +33867,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 157,
+      "line": 158,
       "path": "apps/macos/Sources/OpenClaw/MenuBar.swift",
       "source": "OpenClaw",
       "surface": "apple",
@@ -33827,7 +33875,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 454,
+      "line": 455,
       "path": "apps/macos/Sources/OpenClaw/MenuBar.swift",
       "source": "Close Canvas",
       "surface": "apple",
@@ -33835,7 +33883,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 454,
+      "line": 455,
       "path": "apps/macos/Sources/OpenClaw/MenuBar.swift",
       "source": "Open Canvas",
       "surface": "apple",
@@ -33843,7 +33891,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 53,
+      "line": 54,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Pairing approval pending (\\(self.pairingPrompter.pendingCount))",
       "surface": "apple",
@@ -33851,7 +33899,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 57,
+      "line": 58,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": " · \\(repairCount) repair",
       "surface": "apple",
@@ -33859,7 +33907,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 59,
+      "line": 60,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Device pairing pending (\\(self.devicePairingPrompter.pendingCount))\\(repairSuffix)",
       "surface": "apple",
@@ -33867,7 +33915,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 68,
+      "line": 69,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Send Heartbeats",
       "surface": "apple",
@@ -33875,7 +33923,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 80,
+      "line": 81,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Browser Control",
       "surface": "apple",
@@ -33883,7 +33931,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 83,
+      "line": 84,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Allow Camera",
       "surface": "apple",
@@ -33891,7 +33939,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 92,
+      "line": 93,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Exec Approvals",
       "surface": "apple",
@@ -33899,7 +33947,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 95,
+      "line": 96,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Loading Exec Approvals…",
       "surface": "apple",
@@ -33907,7 +33955,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 101,
+      "line": 102,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Retry Exec Approvals",
       "surface": "apple",
@@ -33915,7 +33963,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 115,
+      "line": 116,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Allow Canvas",
       "surface": "apple",
@@ -33923,7 +33971,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 123,
+      "line": 124,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Voice Wake",
       "surface": "apple",
@@ -33931,7 +33979,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 134,
+      "line": 135,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Open Dashboard",
       "surface": "apple",
@@ -33939,7 +33987,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 139,
+      "line": 140,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Open Chat",
       "surface": "apple",
@@ -33947,7 +33995,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 145,
+      "line": 146,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Quick Chat",
       "surface": "apple",
@@ -33955,7 +34003,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 154,
+      "line": 155,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Close Canvas",
       "surface": "apple",
@@ -33963,7 +34011,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 154,
+      "line": 155,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Open Canvas",
       "surface": "apple",
@@ -33971,7 +34019,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 161,
+      "line": 162,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Stop Talk Mode",
       "surface": "apple",
@@ -33979,7 +34027,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 161,
+      "line": 162,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Talk Mode",
       "surface": "apple",
@@ -33987,7 +34035,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 166,
+      "line": 167,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Settings…",
       "surface": "apple",
@@ -33995,7 +34043,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 169,
+      "line": 170,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "About OpenClaw",
       "surface": "apple",
@@ -34003,7 +34051,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 171,
+      "line": 172,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Update ready, restart now?",
       "surface": "apple",
@@ -34011,39 +34059,15 @@
     },
     {
       "kind": "ui-call",
-      "line": 173,
+      "line": 174,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Quit",
       "surface": "apple",
       "id": "native.apple.f20b8f0da1520f4b"
     },
     {
-      "kind": "conditional-branch",
-      "line": 206,
-      "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
-      "source": "OpenClaw Not Configured",
-      "surface": "apple",
-      "id": "native.apple.5021ed413c045620"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 208,
-      "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
-      "source": "Remote OpenClaw Active",
-      "surface": "apple",
-      "id": "native.apple.4d10ab5feb4add3f"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 210,
-      "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
-      "source": "OpenClaw Active",
-      "surface": "apple",
-      "id": "native.apple.b49dea5c1fdb3dd3"
-    },
-    {
       "kind": "ui-call",
-      "line": 246,
+      "line": 242,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Debug",
       "surface": "apple",
@@ -34051,7 +34075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 250,
+      "line": 246,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Open Config Folder",
       "surface": "apple",
@@ -34059,7 +34083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 255,
+      "line": 251,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Run Health Check Now",
       "surface": "apple",
@@ -34067,7 +34091,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 260,
+      "line": 256,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Send Test Heartbeat",
       "surface": "apple",
@@ -34075,7 +34099,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 266,
+      "line": 262,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Show Pairing Panel (Demo)",
       "surface": "apple",
@@ -34083,7 +34107,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 273,
+      "line": 269,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Remote Tunnel",
       "surface": "apple",
@@ -34091,7 +34115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 276,
+      "line": 272,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Reset Remote Tunnel",
       "surface": "apple",
@@ -34099,7 +34123,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 284,
+      "line": 280,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Verbose Logging (Main): On",
       "surface": "apple",
@@ -34107,7 +34131,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 285,
+      "line": 281,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Verbose Logging (Main): Off",
       "surface": "apple",
@@ -34115,7 +34139,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 289,
+      "line": 285,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Verbosity",
       "surface": "apple",
@@ -34123,7 +34147,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 297,
+      "line": 293,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "File Logging: On",
       "surface": "apple",
@@ -34131,7 +34155,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 298,
+      "line": 294,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "File Logging: Off",
       "surface": "apple",
@@ -34139,7 +34163,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 302,
+      "line": 298,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "App Logging",
       "surface": "apple",
@@ -34147,7 +34171,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 307,
+      "line": 303,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Open Session Store",
       "surface": "apple",
@@ -34155,7 +34179,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 313,
+      "line": 309,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Open Agent Events…",
       "surface": "apple",
@@ -34163,7 +34187,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 318,
+      "line": 314,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Open Log",
       "surface": "apple",
@@ -34171,7 +34195,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 323,
+      "line": 319,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Send Debug Voice Text",
       "surface": "apple",
@@ -34179,7 +34203,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 328,
+      "line": 324,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Send Test Notification",
       "surface": "apple",
@@ -34187,7 +34211,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 335,
+      "line": 331,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Restart Gateway",
       "surface": "apple",
@@ -34195,7 +34219,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 341,
+      "line": 337,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Restart Onboarding",
       "surface": "apple",
@@ -34203,7 +34227,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 346,
+      "line": 342,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Restart App",
       "surface": "apple",
@@ -34211,7 +34235,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 389,
+      "line": 385,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Main",
       "surface": "apple",
@@ -34219,7 +34243,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 389,
+      "line": 385,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Other",
       "surface": "apple",
@@ -34227,7 +34251,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 463,
+      "line": 459,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Show pairing requests",
       "surface": "apple",
@@ -34235,7 +34259,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 488,
+      "line": 484,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Refreshing microphones…",
       "surface": "apple",
@@ -34243,7 +34267,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 495,
+      "line": 491,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Microphone",
       "surface": "apple",
@@ -34251,11 +34275,51 @@
     },
     {
       "kind": "ui-call",
-      "line": 520,
+      "line": 516,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Disconnected (using System default)",
       "surface": "apple",
       "id": "native.apple.3e248379359c7593"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 21,
+      "path": "apps/macos/Sources/OpenClaw/MenuGatewaysInjector.swift",
+      "source": "Gateways",
+      "surface": "apple",
+      "id": "native.apple.ceb653c5fa582beb"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 41,
+      "path": "apps/macos/Sources/OpenClaw/MenuGatewaysInjector.swift",
+      "source": "Set \\(gateway.name) as Primary…",
+      "surface": "apple",
+      "id": "native.apple.cce28f94dfe25e14"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 66,
+      "path": "apps/macos/Sources/OpenClaw/MenuGatewaysInjector.swift",
+      "source": "\\(name), healthy",
+      "surface": "apple",
+      "id": "native.apple.86861746f8e1c38c"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 68,
+      "path": "apps/macos/Sources/OpenClaw/MenuGatewaysInjector.swift",
+      "source": "\\(name), health error",
+      "surface": "apple",
+      "id": "native.apple.184a5dddee2c5794"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 70,
+      "path": "apps/macos/Sources/OpenClaw/MenuGatewaysInjector.swift",
+      "source": "\\(name), health unknown",
+      "surface": "apple",
+      "id": "native.apple.d34b1a73300c51f2"
     },
     {
       "kind": "ui-named-argument",
@@ -34267,7 +34331,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 244,
+      "line": 245,
       "path": "apps/macos/Sources/OpenClaw/MenuSessionsInjector.swift",
       "source": "Loading devices...",
       "surface": "apple",
@@ -34275,7 +34339,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 244,
+      "line": 245,
       "path": "apps/macos/Sources/OpenClaw/MenuSessionsInjector.swift",
       "source": "No devices yet",
       "surface": "apple",
@@ -34283,7 +34347,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1002,
+      "line": 1003,
       "path": "apps/macos/Sources/OpenClaw/MenuSessionsInjector.swift",
       "source": "No",
       "surface": "apple",
@@ -34291,7 +34355,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1002,
+      "line": 1003,
       "path": "apps/macos/Sources/OpenClaw/MenuSessionsInjector.swift",
       "source": "Yes",
       "surface": "apple",
@@ -34299,7 +34363,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1058,
+      "line": 1059,
       "path": "apps/macos/Sources/OpenClaw/MenuSessionsInjector.swift",
       "source": "Update thinking failed",
       "surface": "apple",
@@ -34307,7 +34371,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1076,
+      "line": 1077,
       "path": "apps/macos/Sources/OpenClaw/MenuSessionsInjector.swift",
       "source": "Update verbose failed",
       "surface": "apple",
@@ -34315,7 +34379,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1096,
+      "line": 1097,
       "path": "apps/macos/Sources/OpenClaw/MenuSessionsInjector.swift",
       "source": "Reset session?",
       "surface": "apple",
@@ -34323,7 +34387,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1097,
+      "line": 1098,
       "path": "apps/macos/Sources/OpenClaw/MenuSessionsInjector.swift",
       "source": "Starts a new session id for “\\(key)”.",
       "surface": "apple",
@@ -34331,7 +34395,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1105,
+      "line": 1106,
       "path": "apps/macos/Sources/OpenClaw/MenuSessionsInjector.swift",
       "source": "Reset failed",
       "surface": "apple",
@@ -34339,7 +34403,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1115,
+      "line": 1116,
       "path": "apps/macos/Sources/OpenClaw/MenuSessionsInjector.swift",
       "source": "Compact session log?",
       "surface": "apple",
@@ -34347,7 +34411,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1116,
+      "line": 1117,
       "path": "apps/macos/Sources/OpenClaw/MenuSessionsInjector.swift",
       "source": "Keeps the last 400 lines; archives the old file.",
       "surface": "apple",
@@ -34355,7 +34419,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1124,
+      "line": 1125,
       "path": "apps/macos/Sources/OpenClaw/MenuSessionsInjector.swift",
       "source": "Compact failed",
       "surface": "apple",
@@ -34363,7 +34427,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1134,
+      "line": 1135,
       "path": "apps/macos/Sources/OpenClaw/MenuSessionsInjector.swift",
       "source": "Delete session?",
       "surface": "apple",
@@ -34371,7 +34435,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1135,
+      "line": 1136,
       "path": "apps/macos/Sources/OpenClaw/MenuSessionsInjector.swift",
       "source": "Deletes the “\\(key)” entry and archives its transcript.",
       "surface": "apple",
@@ -34379,7 +34443,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1143,
+      "line": 1144,
       "path": "apps/macos/Sources/OpenClaw/MenuSessionsInjector.swift",
       "source": "Delete failed",
       "surface": "apple",

--- a/apps/macos/Sources/OpenClaw/DashboardGatewayCommands.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardGatewayCommands.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+@MainActor
+struct DashboardGatewayCommands: Commands {
+    @Bindable private var dashboardManager: DashboardManager
+
+    init(dashboardManager: DashboardManager) {
+        self._dashboardManager = Bindable(wrappedValue: dashboardManager)
+    }
+
+    var body: some Commands {
+        let items = DashboardGatewayMenuModel.items(from: self.dashboardManager.gatewayEntries)
+        if !items.isEmpty {
+            CommandMenu("Gateways") {
+                ForEach(items) { item in
+                    if let shortcutNumber = item.shortcutNumber {
+                        Toggle(item.name, isOn: self.selectionBinding(for: item.target))
+                            .keyboardShortcut(
+                                KeyEquivalent(Character(String(shortcutNumber))),
+                                modifiers: .command)
+                    } else {
+                        Toggle(item.name, isOn: self.selectionBinding(for: item.target))
+                    }
+                }
+            }
+        }
+    }
+
+    private func selectionBinding(for target: DashboardGatewayTarget) -> Binding<Bool> {
+        Binding(
+            get: { self.dashboardManager.frontmostDashboardTarget == target },
+            set: { _ in self.dashboardManager.switchFrontmostDashboard(to: target) })
+    }
+}

--- a/apps/macos/Sources/OpenClaw/DashboardGatewayMenuModel.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardGatewayMenuModel.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+struct DashboardGatewayMenuItem: Equatable, Identifiable, Sendable {
+    let target: DashboardGatewayTarget
+    let name: String
+    let health: DashboardGatewayHealth
+    let isPrimary: Bool
+    let canPromote: Bool
+    let shortcutNumber: Int?
+
+    var id: String {
+        self.target.bridgeID
+    }
+}
+
+enum DashboardGatewayMenuModel {
+    static func items(from entries: [DashboardGatewayEntry]) -> [DashboardGatewayMenuItem] {
+        guard entries.count >= 2 else { return [] }
+        return entries.enumerated().compactMap { index, entry in
+            guard let target = DashboardGatewayTarget(bridgeID: entry.id) else { return nil }
+            return DashboardGatewayMenuItem(
+                target: target,
+                name: entry.name,
+                health: entry.health,
+                isPrimary: entry.isPrimary,
+                canPromote: entry.canPromote,
+                shortcutNumber: index < 9 ? index + 1 : nil)
+        }
+    }
+
+    static func connectionLabel(
+        mode: AppState.ConnectionMode,
+        entries: [DashboardGatewayEntry]) -> String
+    {
+        guard entries.count >= 2,
+              let primaryName = entries.first(where: \.isPrimary)?.name.nonEmpty
+        else {
+            return switch mode {
+            case .unconfigured:
+                String(localized: "OpenClaw Not Configured")
+            case .remote:
+                String(localized: "Remote OpenClaw Active")
+            case .local:
+                String(localized: "OpenClaw Active")
+            }
+        }
+        return switch mode {
+        case .unconfigured:
+            String(localized: "OpenClaw Not Configured — \(primaryName)")
+        case .remote:
+            String(localized: "Remote OpenClaw Active — \(primaryName)")
+        case .local:
+            String(localized: "OpenClaw Active — \(primaryName)")
+        }
+    }
+}

--- a/apps/macos/Sources/OpenClaw/DashboardManager.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardManager.swift
@@ -1,11 +1,13 @@
 import AppKit
 import Foundation
+import Observation
 import OpenClawKit
 import OSLog
 
 private let dashboardManagerLogger = Logger(subsystem: "ai.openclaw", category: "DashboardManager")
 
 @MainActor
+@Observable
 final class DashboardManager {
     static let shared = DashboardManager()
 
@@ -22,21 +24,22 @@ final class DashboardManager {
         let displayName: String
     }
 
-    private var controller: DashboardWindowController?
-    private var mainTarget = DashboardGatewayTarget.primary
-    private var auxiliaryWindows: [UUID: AuxiliaryWindowInstance] = [:]
-    private var auxiliaryWindowOrder: [UUID] = []
-    private var endpointTask: Task<Void, Never>?
-    private var pendingOpenCommands: [DashboardNativeCommand] = []
-    private var openForCommandTask: Task<Void, Never>?
-    private var updater: UpdaterProviding?
-    private var displayedRouteRevision: UInt64?
-    private var switchGenerations: [ObjectIdentifier: UInt64] = [:]
-    private let authTokenProvider: @Sendable (GatewayConnection.Config) async -> String?
-    private let routeProbe: @Sendable () async -> Void
-    private let mainWindowAutosaveName: String
-    private var gatewayEntries: [DashboardGatewayEntry] = []
-    private var gatewayRefreshObservers: [NSObjectProtocol] = []
+    @ObservationIgnored private var controller: DashboardWindowController?
+    @ObservationIgnored private var mainTarget = DashboardGatewayTarget.primary
+    @ObservationIgnored private var auxiliaryWindows: [UUID: AuxiliaryWindowInstance] = [:]
+    @ObservationIgnored private var auxiliaryWindowOrder: [UUID] = []
+    @ObservationIgnored private var endpointTask: Task<Void, Never>?
+    @ObservationIgnored private var pendingOpenCommands: [DashboardNativeCommand] = []
+    @ObservationIgnored private var openForCommandTask: Task<Void, Never>?
+    @ObservationIgnored private var updater: UpdaterProviding?
+    @ObservationIgnored private var displayedRouteRevision: UInt64?
+    @ObservationIgnored private var switchGenerations: [ObjectIdentifier: UInt64] = [:]
+    @ObservationIgnored private let authTokenProvider: @Sendable (GatewayConnection.Config) async -> String?
+    @ObservationIgnored private let routeProbe: @Sendable () async -> Void
+    @ObservationIgnored private let mainWindowAutosaveName: String
+    private(set) var gatewayEntries: [DashboardGatewayEntry] = []
+    private(set) var frontmostDashboardTarget: DashboardGatewayTarget?
+    @ObservationIgnored private var gatewayRefreshObservers: [NSObjectProtocol] = []
     #if DEBUG
     private var testPrimaryEndpointProvider:
         (@Sendable (AppState.ConnectionMode) async throws -> GatewayConnection.EndpointSnapshot)?
@@ -78,11 +81,25 @@ final class DashboardManager {
                     Task { @MainActor [weak self] in await self?.refreshGatewaySnapshots() }
                 }
             }
+            let windowNames: [Notification.Name] = [
+                NSWindow.didBecomeKeyNotification,
+                NSWindow.willCloseNotification,
+            ]
+            self.gatewayRefreshObservers += windowNames.map { name in
+                NotificationCenter.default.addObserver(
+                    forName: name,
+                    object: nil,
+                    queue: .main)
+                { [weak self] _ in
+                    Task { @MainActor [weak self] in self?.updateFrontmostDashboardTarget() }
+                }
+            }
         }
     }
 
     func configure(updater: UpdaterProviding) {
         self.updater = updater
+        Task { await self.refreshGatewaySnapshots() }
     }
 
     /// The card's native update path only makes sense when the app owns the
@@ -356,6 +373,7 @@ final class DashboardManager {
         for controller in controllers {
             controller.closeDashboard()
         }
+        self.frontmostDashboardTarget = nil
     }
 
     func handleOnboardingCompletion() {
@@ -379,7 +397,8 @@ final class DashboardManager {
         case let .openWindow(target):
             Task { await self.openWindow(for: target) }
         case let .setPrimary(target):
-            self.confirmSetPrimary(target, from: source)
+            guard self.target(for: source) == target else { return }
+            self.presentSetPrimaryConfirmation(target, source: source)
         case .openSettings:
             AppNavigationActions.openSettings(tab: .gateways)
         }
@@ -540,6 +559,7 @@ final class DashboardManager {
             }
             self.finishSwitch(generation, for: source)
             await self.refreshGatewaySnapshots()
+            self.updateFrontmostDashboardTarget()
         } catch {
             guard self.switchIsCurrent(generation, for: source) else { return }
             self.finishSwitch(generation, for: source)
@@ -569,35 +589,9 @@ final class DashboardManager {
             }
             controller.show(url: configuration.url, auth: configuration.auth)
             await self.refreshGatewaySnapshots()
+            self.updateFrontmostDashboardTarget()
         } catch {
             Self.showGatewayError(error, message: "Could Not Open Gateway Window")
-        }
-    }
-
-    private func confirmSetPrimary(_ target: DashboardGatewayTarget, from source: DashboardWindowController) {
-        guard case let .profile(profileID) = target,
-              self.target(for: source) == target,
-              let entry = self.gatewayEntries.first(where: { $0.id == target.bridgeID }),
-              entry.canPromote
-        else {
-            return
-        }
-        let alert = DashboardWindowController.makeSetPrimaryAlert(gatewayName: entry.name)
-        let apply: (NSApplication.ModalResponse) -> Void = { [weak self, weak source] response in
-            guard response == .alertFirstButtonReturn, let self, let source else { return }
-            Task { @MainActor in
-                do {
-                    try await DashboardPrimaryGatewayAdapter(state: AppStateStore.shared).apply(profileID: profileID)
-                    await self.switchTarget(.primary, in: source)
-                } catch {
-                    Self.showGatewayError(error, message: "Could Not Set Primary Gateway")
-                }
-            }
-        }
-        if let window = source.window {
-            alert.beginSheetModal(for: window, completionHandler: apply)
-        } else {
-            apply(alert.runModal())
         }
     }
 
@@ -679,6 +673,7 @@ final class DashboardManager {
             self.switchGenerations[ObjectIdentifier(controller)] = nil
             self.auxiliaryWindows.removeValue(forKey: windowID)
             self.auxiliaryWindowOrder.removeAll { $0 == windowID }
+            self.updateFrontmostDashboardTarget()
         }
     }
 
@@ -833,6 +828,125 @@ final class DashboardManager {
     }
 }
 
+extension DashboardManager {
+    func openOrFocusDashboard(for target: DashboardGatewayTarget) {
+        Task { await self.performOpenOrFocusDashboard(for: target) }
+    }
+
+    func switchFrontmostDashboard(to target: DashboardGatewayTarget) {
+        Task { await self.performSwitchFrontmostDashboard(to: target) }
+    }
+
+    func confirmSetPrimary(_ target: DashboardGatewayTarget) {
+        self.presentSetPrimaryConfirmation(target, source: nil)
+    }
+
+    private func dashboardControllers() -> [(target: DashboardGatewayTarget, controller: DashboardWindowController)] {
+        var result: [(DashboardGatewayTarget, DashboardWindowController)] = []
+        if let controller, controller.isWindowOpen {
+            result.append((self.mainTarget, controller))
+        }
+        result += self.auxiliaryWindowOrder.compactMap { windowID in
+            guard let instance = self.auxiliaryWindows[windowID], instance.controller.isWindowOpen else { return nil }
+            return (instance.target, instance.controller)
+        }
+        return result
+    }
+
+    private func frontmostDashboard()
+        -> (target: DashboardGatewayTarget, controller: DashboardWindowController)?
+    {
+        let controllers = self.dashboardControllers()
+        if let key = controllers.first(where: { $0.controller.window?.isKeyWindow == true }) {
+            return key
+        }
+        for window in NSApp.orderedWindows {
+            if let match = controllers.first(where: { $0.controller.window === window }) {
+                return match
+            }
+        }
+        return controllers.last
+    }
+
+    private func updateFrontmostDashboardTarget() {
+        self.frontmostDashboardTarget = self.frontmostDashboard()?.target
+    }
+
+    private func dashboardController(for target: DashboardGatewayTarget) -> DashboardWindowController? {
+        if let frontmost = self.frontmostDashboard(), frontmost.target == target {
+            return frontmost.controller
+        }
+        if self.mainTarget == target, let controller, controller.isWindowOpen {
+            return controller
+        }
+        return self.auxiliaryWindowOrder.reversed().lazy
+            .compactMap { self.auxiliaryWindows[$0] }
+            .first { $0.target == target && $0.controller.isWindowOpen }?
+            .controller
+    }
+
+    private func performOpenOrFocusDashboard(for target: DashboardGatewayTarget) async {
+        if let controller = self.dashboardController(for: target) {
+            NSApp.activate(ignoringOtherApps: true)
+            controller.show()
+            self.updateFrontmostDashboardTarget()
+            return
+        }
+        if self.mainTarget == target || (target == .primary && self.controller == nil) {
+            do {
+                try await self.show()
+            } catch {
+                self.showFailure(error)
+            }
+        } else {
+            await self.openWindow(for: target)
+        }
+        self.updateFrontmostDashboardTarget()
+    }
+
+    private func performSwitchFrontmostDashboard(to target: DashboardGatewayTarget) async {
+        guard let frontmost = self.frontmostDashboard() else {
+            await self.performOpenOrFocusDashboard(for: target)
+            return
+        }
+        await self.switchTarget(target, in: frontmost.controller, present: true)
+        self.updateFrontmostDashboardTarget()
+    }
+
+    private func presentSetPrimaryConfirmation(
+        _ target: DashboardGatewayTarget,
+        source: DashboardWindowController?)
+    {
+        guard case let .profile(profileID) = target,
+              let entry = self.gatewayEntries.first(where: { $0.id == target.bridgeID }),
+              entry.canPromote
+        else {
+            return
+        }
+        let alert = DashboardWindowController.makeSetPrimaryAlert(gatewayName: entry.name)
+        let apply: (NSApplication.ModalResponse) -> Void = { [weak self, weak source] response in
+            guard response == .alertFirstButtonReturn, let self else { return }
+            Task { @MainActor in
+                do {
+                    try await DashboardPrimaryGatewayAdapter(state: AppStateStore.shared).apply(profileID: profileID)
+                    if let source, self.target(for: source) != nil {
+                        await self.switchTarget(.primary, in: source)
+                    } else {
+                        await self.refreshGatewaySnapshots()
+                    }
+                } catch {
+                    Self.showGatewayError(error, message: "Could Not Set Primary Gateway")
+                }
+            }
+        }
+        if let window = source?.window {
+            alert.beginSheetModal(for: window, completionHandler: apply)
+        } else {
+            apply(alert.runModal())
+        }
+    }
+}
+
 #if DEBUG
 extension DashboardManager {
     /// Test instances skip `observeEndpointChanges()` so the shared endpoint
@@ -876,6 +990,10 @@ extension DashboardManager {
 
     func _testSwitchTarget(_ target: DashboardGatewayTarget, in source: DashboardWindowController) async {
         await self.switchTarget(target, in: source)
+    }
+
+    func _testSwitchFrontmostDashboard(to target: DashboardGatewayTarget) async {
+        await self.performSwitchFrontmostDashboard(to: target)
     }
 
     func _testWindowTLSParams(for target: DashboardGatewayTarget) async throws -> GatewayTLSParams? {

--- a/apps/macos/Sources/OpenClaw/MenuBar.swift
+++ b/apps/macos/Sources/OpenClaw/MenuBar.swift
@@ -121,6 +121,7 @@ struct OpenClawApp: App {
                 }
                 .keyboardShortcut(",", modifiers: .command)
             }
+            DashboardGatewayCommands(dashboardManager: DashboardManager.shared)
             SidebarCommands()
             CommandMenu("Navigate") {
                 Button("Back") {

--- a/apps/macos/Sources/OpenClaw/MenuContentView.swift
+++ b/apps/macos/Sources/OpenClaw/MenuContentView.swift
@@ -14,6 +14,7 @@ struct MenuContent: View {
     private let healthStore = HealthStore.shared
     private let heartbeatStore = HeartbeatStore.shared
     private let controlChannel = ControlChannel.shared
+    private let dashboardManager = DashboardManager.shared
     private let activityStore = WorkActivityStore.shared
     private let nodesStore = NodesStore.shared
     @Bindable private var pairingPrompter = NodePairingApprovalPrompter.shared
@@ -201,14 +202,9 @@ struct MenuContent: View {
     }
 
     private var connectionLabel: String {
-        switch self.state.connectionMode {
-        case .unconfigured:
-            "OpenClaw Not Configured"
-        case .remote:
-            "Remote OpenClaw Active"
-        case .local:
-            "OpenClaw Active"
-        }
+        DashboardGatewayMenuModel.connectionLabel(
+            mode: self.state.connectionMode,
+            entries: self.dashboardManager.gatewayEntries)
     }
 
     private func loadBrowserControlEnabled() async {

--- a/apps/macos/Sources/OpenClaw/MenuGatewaysInjector.swift
+++ b/apps/macos/Sources/OpenClaw/MenuGatewaysInjector.swift
@@ -1,0 +1,95 @@
+import AppKit
+
+@MainActor
+final class MenuGatewaysInjector: NSObject {
+    static let shared = MenuGatewaysInjector()
+
+    private let tag = 9_415_559
+
+    func inject(into menu: NSMenu) {
+        for item in menu.items where item.tag == self.tag {
+            menu.removeItem(item)
+        }
+
+        let items = DashboardGatewayMenuModel.items(from: DashboardManager.shared.gatewayEntries)
+        guard !items.isEmpty,
+              var cursor = menu.items.lastIndex(where: \.isSeparatorItem)
+        else {
+            return
+        }
+
+        let header = NSMenuItem.sectionHeader(title: String(localized: "Gateways"))
+        header.tag = self.tag
+        menu.insertItem(header, at: cursor)
+        cursor += 1
+
+        for gateway in items {
+            let item = NSMenuItem(
+                title: gateway.name,
+                action: #selector(self.openGateway(_:)),
+                keyEquivalent: "")
+            item.tag = self.tag
+            item.target = self
+            item.representedObject = gateway.id
+            item.image = Self.healthImage(for: gateway.health, name: gateway.name)
+            item.state = gateway.isPrimary ? .on : .off
+            menu.insertItem(item, at: cursor)
+            cursor += 1
+
+            if gateway.canPromote {
+                let alternate = NSMenuItem(
+                    title: String(localized: "Set \(gateway.name) as Primary…"),
+                    action: #selector(self.setPrimary(_:)),
+                    keyEquivalent: "")
+                alternate.tag = self.tag
+                alternate.target = self
+                alternate.representedObject = gateway.id
+                alternate.isAlternate = true
+                alternate.keyEquivalentModifierMask = [.option]
+                menu.insertItem(alternate, at: cursor)
+                cursor += 1
+            }
+        }
+    }
+
+    private static func healthImage(for health: DashboardGatewayHealth, name: String) -> NSImage? {
+        let (symbolName, color): (String, NSColor) = switch health {
+        case .ok:
+            ("circle.fill", .systemGreen)
+        case .error:
+            ("exclamationmark.circle.fill", .systemRed)
+        case .unknown:
+            ("circle", .tertiaryLabelColor)
+        }
+        let accessibilityDescription = switch health {
+        case .ok:
+            String(localized: "\(name), healthy")
+        case .error:
+            String(localized: "\(name), health error")
+        case .unknown:
+            String(localized: "\(name), health unknown")
+        }
+        let image = NSImage(systemSymbolName: symbolName, accessibilityDescription: accessibilityDescription)
+        return image?.withSymbolConfiguration(.init(paletteColors: [color]))
+    }
+
+    @objc
+    private func openGateway(_ sender: NSMenuItem) {
+        guard let id = sender.representedObject as? String,
+              let target = DashboardGatewayTarget(bridgeID: id)
+        else {
+            return
+        }
+        DashboardManager.shared.openOrFocusDashboard(for: target)
+    }
+
+    @objc
+    private func setPrimary(_ sender: NSMenuItem) {
+        guard let id = sender.representedObject as? String,
+              let target = DashboardGatewayTarget(bridgeID: id)
+        else {
+            return
+        }
+        DashboardManager.shared.confirmSetPrimary(target)
+    }
+}

--- a/apps/macos/Sources/OpenClaw/MenuSessionsInjector.swift
+++ b/apps/macos/Sources/OpenClaw/MenuSessionsInjector.swift
@@ -63,6 +63,7 @@ final class MenuSessionsInjector: NSObject, NSMenuDelegate {
 
         self.inject(into: menu)
         self.injectNodes(into: menu)
+        MenuGatewaysInjector.shared.inject(into: menu)
 
         // Refresh in the background for the next open. Rebuilding custom menu
         // rows while AppKit is tracking the menu causes visible flicker.

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardGatewayMenuTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardGatewayMenuTests.swift
@@ -1,0 +1,82 @@
+import Testing
+@testable import OpenClaw
+
+@MainActor
+struct DashboardGatewayMenuTests {
+    @Test func `connection label names primary only for multiple gateways`() {
+        let primary = Self.entry(id: "primary", name: "Mac Studio", isPrimary: true, health: .ok)
+        let profile = Self.entry(id: "profile:travel", name: "Travel", canPromote: true)
+        let cases: [(AppState.ConnectionMode, [DashboardGatewayEntry], String)] = [
+            (.unconfigured, [primary], "OpenClaw Not Configured"),
+            (.unconfigured, [primary, profile], "OpenClaw Not Configured — Mac Studio"),
+            (.local, [primary], "OpenClaw Active"),
+            (.local, [primary, profile], "OpenClaw Active — Mac Studio"),
+            (.remote, [primary], "Remote OpenClaw Active"),
+            (.remote, [primary, profile], "Remote OpenClaw Active — Mac Studio"),
+        ]
+
+        for (mode, entries, expected) in cases {
+            #expect(DashboardGatewayMenuModel.connectionLabel(mode: mode, entries: entries) == expected)
+        }
+    }
+
+    @Test func `menu model is gated and preserves catalog facts`() {
+        let primary = Self.entry(id: "primary", name: "Mac Studio", isPrimary: true, health: .ok)
+        let profile = Self.entry(
+            id: "profile:travel",
+            name: "Travel",
+            canPromote: true,
+            health: .unknown)
+        let cases: [([DashboardGatewayEntry], [DashboardGatewayMenuItem])] = [
+            ([primary], []),
+            ([primary, profile], [
+                DashboardGatewayMenuItem(
+                    target: .primary,
+                    name: "Mac Studio",
+                    health: .ok,
+                    isPrimary: true,
+                    canPromote: false,
+                    shortcutNumber: 1),
+                DashboardGatewayMenuItem(
+                    target: .profile("travel"),
+                    name: "Travel",
+                    health: .unknown,
+                    isPrimary: false,
+                    canPromote: true,
+                    shortcutNumber: 2),
+            ]),
+        ]
+
+        for (entries, expected) in cases {
+            #expect(DashboardGatewayMenuModel.items(from: entries) == expected)
+        }
+    }
+
+    @Test func `gateway shortcuts stop after command nine`() {
+        let entries = [
+            Self.entry(id: "primary", name: "Primary", isPrimary: true, health: .ok),
+        ] + (1...10).map { index in
+            Self.entry(id: "profile:\(index)", name: "Gateway \(index)", canPromote: true)
+        }
+
+        let shortcuts = DashboardGatewayMenuModel.items(from: entries).map(\.shortcutNumber)
+
+        #expect(shortcuts == [1, 2, 3, 4, 5, 6, 7, 8, 9, nil, nil])
+    }
+
+    private static func entry(
+        id: String,
+        name: String,
+        isPrimary: Bool = false,
+        canPromote: Bool = false,
+        health: DashboardGatewayHealth = .unknown) -> DashboardGatewayEntry
+    {
+        DashboardGatewayEntry(
+            id: id,
+            name: name,
+            kind: isPrimary ? "local" : "remote",
+            isPrimary: isPrimary,
+            canPromote: canPromote,
+            health: health)
+    }
+}

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardGatewaysTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardGatewaysTests.swift
@@ -257,6 +257,60 @@ struct DashboardManagerGatewayTargetTests {
         #expect(manager._testMainTarget() == .profile("second"))
         #expect(manager._testController()?.currentURL.port == 60003)
     }
+
+    @Test func `main menu switch replaces the frontmost dashboard in place`() async throws {
+        let sourceURL = try #require(URL(string: "http://127.0.0.1:60001/#token=current"))
+        let controller = DashboardWindowController(
+            url: sourceURL,
+            auth: DashboardWindowAuth(
+                gatewayUrl: "ws://127.0.0.1:60001/",
+                token: "current",
+                password: nil),
+            windowAutosaveName: "OpenClawDashboardWindow-Test-\(UUID().uuidString)")
+        let frame = NSRect(x: 190, y: 190, width: 940, height: 700)
+        controller.window?.setFrame(frame, display: false)
+        controller.show()
+        let entries = DashboardGatewayTestEntries.withProfiles(["studio"])
+        let manager = DashboardManager._testMake(
+            profileEndpointProvider: { profileID in
+                let url = try #require(URL(string: "ws://127.0.0.1:60002"))
+                return GatewayConnection.EndpointSnapshot(
+                    config: (url: url, token: profileID, password: nil),
+                    routeAuthority: nil)
+            },
+            gatewayEntriesProvider: { entries })
+        manager._testSetController(controller)
+        defer { manager.close() }
+
+        await manager._testSwitchFrontmostDashboard(to: .profile("studio"))
+
+        #expect(manager._testMainTarget() == .profile("studio"))
+        #expect(manager.frontmostDashboardTarget == .profile("studio"))
+        #expect(manager._testController() !== controller)
+        #expect(manager._testController()?.currentURL.port == 60002)
+        #expect(manager._testController()?.window?.frame == frame)
+    }
+
+    @Test func `main menu switch opens requested gateway when no dashboard exists`() async {
+        let entries = DashboardGatewayTestEntries.withProfiles(["studio"])
+        let manager = DashboardManager._testMake(
+            profileEndpointProvider: { profileID in
+                let url = try #require(URL(string: "ws://127.0.0.1:60002"))
+                return GatewayConnection.EndpointSnapshot(
+                    config: (url: url, token: profileID, password: nil),
+                    routeAuthority: nil)
+            },
+            gatewayEntriesProvider: { entries })
+        defer { manager.close() }
+
+        await manager._testSwitchFrontmostDashboard(to: .profile("studio"))
+
+        let windows = manager._testAuxiliaryWindows()
+        #expect(windows.count == 1)
+        #expect(windows.first?.target == .profile("studio"))
+        #expect(windows.first?.controller.isWindowOpen == true)
+        #expect(manager.frontmostDashboardTarget == .profile("studio"))
+    }
 }
 
 private enum DashboardGatewayTestEntries {

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardGatewaysTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardGatewaysTests.swift
@@ -203,6 +203,8 @@ struct DashboardManagerGatewayTargetTests {
         let frame = NSRect(x: 180, y: 180, width: 960, height: 720)
         controller.window?.setFrame(frame, display: false)
         controller.show()
+        // CI display bounds clamp window frames during show, so preserve the post-clamp source frame.
+        let sourceFrame = try #require(controller.window).frame
         let entries = DashboardGatewayTestEntries.withProfiles(["studio"])
         let manager = DashboardManager._testMake(gatewayEntriesProvider: { entries })
         manager.configure(updater: DashboardGatewayTestUpdater())
@@ -214,12 +216,13 @@ struct DashboardManagerGatewayTargetTests {
 
         #expect(manager._testController() === controller)
         #expect(manager._testMainTarget() == .profile("studio"))
-        #expect(controller.window?.frame == frame)
+        #expect(controller.window?.frame == sourceFrame)
         let auxiliaryWindows = manager._testAuxiliaryWindows()
         #expect(auxiliaryWindows.count == 1)
         let auxiliary = try #require(auxiliaryWindows.first)
         #expect(auxiliary.target == .primary)
         #expect(auxiliary.controller !== controller)
+        #expect(auxiliary.controller.window !== controller.window)
         #expect(auxiliary.controller.window?.frameAutosaveName != controller.window?.frameAutosaveName)
         #expect(!auxiliary.controller._testUpdateBridgeAvailable)
     }
@@ -270,6 +273,8 @@ struct DashboardManagerGatewayTargetTests {
         let frame = NSRect(x: 190, y: 190, width: 940, height: 700)
         controller.window?.setFrame(frame, display: false)
         controller.show()
+        // CI display bounds clamp window frames during show, so compare replacement against the actual source frame.
+        let sourceFrame = try #require(controller.window).frame
         let entries = DashboardGatewayTestEntries.withProfiles(["studio"])
         let manager = DashboardManager._testMake(
             profileEndpointProvider: { profileID in
@@ -288,7 +293,7 @@ struct DashboardManagerGatewayTargetTests {
         #expect(manager.frontmostDashboardTarget == .profile("studio"))
         #expect(manager._testController() !== controller)
         #expect(manager._testController()?.currentURL.port == 60002)
-        #expect(manager._testController()?.window?.frame == frame)
+        #expect(manager._testController()?.window?.frame == sourceFrame)
     }
 
     @Test func `main menu switch opens requested gateway when no dashboard exists`() async {

--- a/docs/platforms/mac/menu-bar.md
+++ b/docs/platforms/mac/menu-bar.md
@@ -12,7 +12,10 @@ title: "Menu bar"
 - A root "Context" item opens a submenu with recent sessions instead of expanding them in the root menu.
 - A "Nodes" block in the root menu lists paired **devices** only (from `node.list`), not client/presence entries.
 - A root "Usage" section appears below Context when provider usage snapshots are available, followed by cost details when available.
+- When two or more Gateways are available, the first status row includes the primary Gateway name and a root "Gateways" section lists every Gateway with its health and primary marker. Select a row to open or focus that Gateway's dashboard; hold Option to reveal "Set as Primary…" for eligible saved Gateways.
 - **Quick Chat** opens the floating main-session composer; its current global shortcut appears beside the item.
+
+Single-Gateway setups keep the existing menu unchanged. With two or more Gateways, the app's main **Gateways** menu also assigns Command-1 through Command-9 in catalog order. Its checkmark follows the frontmost dashboard window, and selecting an item switches that window in place or opens the selected Gateway when no dashboard window exists.
 
 ## State model
 
@@ -60,6 +63,7 @@ title: "Menu bar"
 
 ## Status row text (menu)
 
+- With two or more Gateways, the connection label appends the primary Gateway's catalog display name, such as `OpenClaw Active — Mac Studio`.
 - While work is active: `<Session role> · <activity label>` (`"\(roleLabel) · \(activity.label)"` in `MenuContentView`), where role label is `Main` or `Other`.
 - When idle: falls back to the health summary.
 


### PR DESCRIPTION
## What Problem This Solves

The menu bar gave no indication of which gateway the Mac app belongs to, and with multiple gateways configured there was no menu-level way to reach or switch them — the dashboard's gateway picker (#113965) was the only surface.

## Why This Change Was Made

Completes the multi-gateway program's menu surfaces, all gated on **2+ configured gateways** (single-gateway installs are unchanged):

- The status-item menu's connection row names the primary gateway ("OpenClaw Active — Mac Studio").
- A **Gateways** section in the status-item menu lists every gateway (health dot on primary, checkmark marker); clicking opens/focuses that gateway's dashboard; ⌥ reveals "Set as Primary…" alternates for promotable entries, routed through the existing confirmation + `DashboardPrimaryGatewayAdapter` path (AppKit rows via the `MenuSessionsInjector` idiom).
- A native **Gateways** main menu (⌘1–⌘9) switches the frontmost dashboard window in place via the existing `DashboardManager` switch machinery; opens a dashboard when none exists.
- `DashboardManager` becomes `@Observable`, publishing exactly two properties (`gatewayEntries`, `frontmostDashboardTarget`); all other state is `@ObservationIgnored`. Frontmost tracking rides `NSWindow` key/close notifications. No new catalog loaders or polling.

## User Impact

Multi-gateway users can see which gateway their Mac belongs to at a glance and reach or switch any gateway from the menu bar. Single-gateway users see no change.

Note: menu surfaces exist only inside the running Mac app; screenshot capture would require driving the operator's live app state, so visual capture is deferred to the queued Parallels VM smoke pass (same follow-up as #113965). Behavior is proven by the test suites below.

Maintainer directive: ClawSweeper review iteration is waived for this PR by the repository owner; landing on green CI + clean structured review.

## Evidence

- `swift test --package-path apps/macos --filter DashboardGatewayMenuTests --filter DashboardGatewaysTests` — 21 tests across 5 suites: connection-label formatting (1 vs 2+ entries), menu-model building (table-driven, ⌘1–9 capped), frontmost-switch routing, promotion confirmation gating.
- Native i18n inventory regenerated (`entries=5316`); Periphery clean; SwiftFormat/SwiftLint clean; docs map check passed.
- Codex autoreview (gpt-5.6-sol, xhigh): clean, "patch is correct (0.86)".
- Docs: `docs/platforms/mac/menu-bar.md` updated.
