### PR TITLE
fix(google): reject malformed base64 audio in Gemini TTS responses

### DIFF
--- a/extensions/google/speech-provider.test.ts
+++ b/extensions/google/speech-provider.test.ts
@@ -31,7 +31,7 @@ beforeAll(async () => {
 
 installProviderHttpMockCleanup();
 
-function googleTtsResponse(pcm = Buffer.from([1, 0, 2, 0])) {
+function googleTtsResponse(audio: Buffer | string = Buffer.from([1, 0, 2, 0])) {
   return {
     ok: true,
     json: async () => ({
@@ -42,7 +42,7 @@ function googleTtsResponse(pcm = Buffer.from([1, 0, 2, 0])) {
               {
                 inlineData: {
                   mimeType: "audio/L16;codec=pcm;rate=24000",
-                  data: pcm.toString("base64"),
+                  data: typeof audio === "string" ? audio : audio.toString("base64"),
                 },
               },
             ],
@@ -351,27 +351,9 @@ describe("Google speech provider", () => {
     expect(result.audioBuffer.subarray(44)).toEqual(pcm);
   });
 
-  it("rejects malformed base64 audio payloads instead of decoding corrupted PCM", async () => {
+  it("rejects Gemini audio with non-canonical base64 pad bits", async () => {
     const malformedResponse = {
-      response: {
-        ok: true,
-        json: async () => ({
-          candidates: [
-            {
-              content: {
-                parts: [
-                  {
-                    inlineData: {
-                      mimeType: "audio/L16;codec=pcm;rate=24000",
-                      data: "%%%not-base64!!",
-                    },
-                  },
-                ],
-              },
-            },
-          ],
-        }),
-      },
+      response: googleTtsResponse("ZE=="),
       release: vi.fn(async () => {}),
     };
     const requestSequence = vi.fn().mockResolvedValue(malformedResponse);
@@ -380,7 +362,7 @@ describe("Google speech provider", () => {
 
     await expect(
       provider.synthesize({
-        text: "Hello from OpenClaw.",
+        text: "Reject malformed audio.",
         cfg: {},
         providerConfig: {
           apiKey: "google-test-key",
@@ -389,7 +371,6 @@ describe("Google speech provider", () => {
         timeoutMs: 5_000,
       }),
     ).rejects.toThrow("Google TTS response returned malformed base64 audio data");
-    // Payload decode failures reuse the existing retry-once framework.
     expect(requestSequence).toHaveBeenCalledTimes(2);
   });
 

--- a/extensions/google/speech-provider.test.ts
+++ b/extensions/google/speech-provider.test.ts
@@ -7,9 +7,13 @@ import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest
 
 const transcodeAudioBufferToOpusMock = vi.hoisted(() => vi.fn());
 
-vi.mock("openclaw/plugin-sdk/media-runtime", () => ({
-  transcodeAudioBufferToOpus: transcodeAudioBufferToOpusMock,
-}));
+vi.mock("openclaw/plugin-sdk/media-runtime", async () => {
+  const { canonicalizeBase64 } = await import("@openclaw/media-core/base64");
+  return {
+    canonicalizeBase64,
+    transcodeAudioBufferToOpus: transcodeAudioBufferToOpusMock,
+  };
+});
 
 const {
   assertOkOrThrowProviderErrorMock,
@@ -345,6 +349,48 @@ describe("Google speech provider", () => {
 
     expect(requestSequence).toHaveBeenCalledTimes(2);
     expect(result.audioBuffer.subarray(44)).toEqual(pcm);
+  });
+
+  it("rejects malformed base64 audio payloads instead of decoding corrupted PCM", async () => {
+    const malformedResponse = {
+      response: {
+        ok: true,
+        json: async () => ({
+          candidates: [
+            {
+              content: {
+                parts: [
+                  {
+                    inlineData: {
+                      mimeType: "audio/L16;codec=pcm;rate=24000",
+                      data: "%%%not-base64!!",
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        }),
+      },
+      release: vi.fn(async () => {}),
+    };
+    const requestSequence = vi.fn().mockResolvedValue(malformedResponse);
+    postJsonRequestMock.mockImplementation(requestSequence);
+    const provider = buildGoogleSpeechProvider();
+
+    await expect(
+      provider.synthesize({
+        text: "Hello from OpenClaw.",
+        cfg: {},
+        providerConfig: {
+          apiKey: "google-test-key",
+        },
+        target: "audio-file",
+        timeoutMs: 5_000,
+      }),
+    ).rejects.toThrow("Google TTS response returned malformed base64 audio data");
+    // Payload decode failures reuse the existing retry-once framework.
+    expect(requestSequence).toHaveBeenCalledTimes(2);
   });
 
   it("retries once when Gemini TTS fetch aborts", async () => {

--- a/extensions/google/speech-provider.ts
+++ b/extensions/google/speech-provider.ts
@@ -1,5 +1,5 @@
 // Google provider module implements model/runtime integration.
-import { transcodeAudioBufferToOpus } from "openclaw/plugin-sdk/media-runtime";
+import { canonicalizeBase64, transcodeAudioBufferToOpus } from "openclaw/plugin-sdk/media-runtime";
 import {
   assertOkOrThrowProviderError,
   postJsonRequest,
@@ -297,7 +297,11 @@ function extractGoogleSpeechPcm(payload: GoogleGenerateSpeechResponse): Buffer {
       if (!data) {
         continue;
       }
-      return Buffer.from(data, "base64");
+      const canonicalAudio = canonicalizeBase64(data);
+      if (!canonicalAudio) {
+        throw new Error("Google TTS response returned malformed base64 audio data");
+      }
+      return Buffer.from(canonicalAudio, "base64");
     }
   }
   throw new Error("Google TTS response missing audio data");

--- a/extensions/minimax/music-generation-provider.test.ts
+++ b/extensions/minimax/music-generation-provider.test.ts
@@ -158,6 +158,35 @@ describe("minimax music generation provider", () => {
     expect(result.metadata).not.toHaveProperty("requestedDurationSeconds");
   });
 
+  it.each([
+    {
+      name: "streamed",
+      contentType: "text/event-stream",
+      body: `data: ${JSON.stringify({ data: { status: 1, audio: "ZE==" }, base_resp: { status_code: 0 } })}\n\n`,
+    },
+    {
+      name: "inline",
+      contentType: "application/json",
+      body: JSON.stringify({ data: { audio: "ZE==" }, base_resp: { status_code: 0 } }),
+    },
+  ])("rejects $name audio outside MiniMax's documented hex format", async (fixture) => {
+    postJsonRequestMock.mockResolvedValue({
+      response: new Response(fixture.body, {
+        headers: { "content-type": fixture.contentType },
+      }),
+      release: vi.fn(async () => {}),
+    });
+
+    await expect(
+      buildMinimaxMusicGenerationProvider().generateMusic({
+        provider: "minimax",
+        model: "",
+        prompt: "short track",
+        cfg: {},
+      }),
+    ).rejects.toThrow("MiniMax music generation returned malformed hex audio");
+  });
+
   it("reports streaming music task failures", async () => {
     postJsonRequestMock.mockResolvedValue({
       response: new Response(

--- a/extensions/minimax/music-generation-provider.ts
+++ b/extensions/minimax/music-generation-provider.ts
@@ -96,18 +96,15 @@ function resolveMinimaxGuardedRequestOptions(
   };
 }
 
-function decodePossibleBinaryWithLimit(data: string, maxBytes: number): Buffer {
+function decodeHexAudioWithLimit(data: string, maxBytes: number): Buffer {
   const trimmed = data.trim();
-  if (/^[0-9a-f]+$/iu.test(trimmed) && trimmed.length % 2 === 0) {
-    if (trimmed.length / 2 > maxBytes) {
-      throw createGeneratedMusicTooLargeError(maxBytes);
-    }
-    return Buffer.from(trimmed, "hex");
+  if (!/^[0-9a-f]+$/iu.test(trimmed) || trimmed.length % 2 !== 0) {
+    throw new Error("MiniMax music generation returned malformed hex audio");
   }
-  if (Buffer.byteLength(trimmed, "base64") > maxBytes) {
+  if (trimmed.length / 2 > maxBytes) {
     throw createGeneratedMusicTooLargeError(maxBytes);
   }
-  return Buffer.from(trimmed, "base64");
+  return Buffer.from(trimmed, "hex");
 }
 
 function decodePossibleText(data: string): string {
@@ -261,7 +258,7 @@ async function readStreamingTrack(
       if (String(frame.data?.status ?? "") === "2" && chunks.length > 0) {
         continue;
       }
-      const chunk = decodePossibleBinaryWithLimit(audio, maxBytes - decodedBytes);
+      const chunk = decodeHexAudioWithLimit(audio, maxBytes - decodedBytes);
       const nextDecodedBytes = decodedBytes + chunk.byteLength;
       if (nextDecodedBytes > maxBytes) {
         throw createGeneratedMusicTooLargeError(maxBytes);
@@ -434,7 +431,7 @@ function buildMinimaxMusicProvider(providerId: string): MusicGenerationProvider 
             })
           : inlineAudio
             ? (() => {
-                const buffer = decodePossibleBinaryWithLimit(inlineAudio, maxGeneratedMusicBytes);
+                const buffer = decodeHexAudioWithLimit(inlineAudio, maxGeneratedMusicBytes);
                 return {
                   buffer,
                   mimeType: "audio/mpeg",

--- a/extensions/openrouter/music-generation-provider.test.ts
+++ b/extensions/openrouter/music-generation-provider.test.ts
@@ -241,6 +241,22 @@ describe("openrouter music generation provider", () => {
     expect(releaseLock).toHaveBeenCalledTimes(1);
   });
 
+  it("rejects streamed audio with non-canonical base64 pad bits", async () => {
+    postJsonRequestMock.mockResolvedValue({
+      response: sseResponse(sseResponseLines({ audio: "ZE==", done: true })),
+      release: vi.fn(async () => {}),
+    });
+
+    await expect(
+      buildOpenRouterMusicGenerationProvider().generateMusic({
+        provider: "openrouter",
+        model: "",
+        prompt: "short track",
+        cfg: {},
+      }),
+    ).rejects.toThrow("OpenRouter music generation returned malformed base64 audio data");
+  });
+
   it("decodes independently padded OpenRouter audio chunks", async () => {
     postJsonRequestMock.mockResolvedValue({
       response: sseResponse([

--- a/extensions/openrouter/music-generation-provider.ts
+++ b/extensions/openrouter/music-generation-provider.ts
@@ -1,6 +1,7 @@
 // Openrouter provider module implements model/runtime integration.
 import { toImageDataUrl } from "openclaw/plugin-sdk/image-generation";
 import { resolveGeneratedMediaMaxBytes } from "openclaw/plugin-sdk/media-generation-runtime";
+import { canonicalizeBase64, estimateBase64DecodedBytes } from "openclaw/plugin-sdk/media-runtime";
 import type {
   MusicGenerationProvider,
   MusicGenerationRequest,
@@ -140,11 +141,19 @@ function appendDecodedOpenRouterMusicAudio(
   if (!base64) {
     return;
   }
-  const decodedBytes = Buffer.byteLength(base64, "base64");
-  if (decodedBytes > result.maxBytes - result.audioBytes) {
+  const remainingBytes = result.maxBytes - result.audioBytes;
+  if (estimateBase64DecodedBytes(base64) > remainingBytes) {
     throw createOpenRouterMusicTooLargeError("audio", result.maxBytes);
   }
-  const buffer = Buffer.from(base64, "base64");
+  const canonicalAudio = canonicalizeBase64(base64);
+  if (!canonicalAudio) {
+    throw new Error("OpenRouter music generation returned malformed base64 audio data");
+  }
+  const decodedBytes = Buffer.byteLength(canonicalAudio, "base64");
+  if (decodedBytes > remainingBytes) {
+    throw createOpenRouterMusicTooLargeError("audio", result.maxBytes);
+  }
+  const buffer = Buffer.from(canonicalAudio, "base64");
   const nextBytes = result.audioBytes + buffer.byteLength;
   if (nextBytes > result.maxBytes) {
     throw createOpenRouterMusicTooLargeError("audio", result.maxBytes);

--- a/extensions/xai/realtime-voice-bridge.ts
+++ b/extensions/xai/realtime-voice-bridge.ts
@@ -23,7 +23,7 @@ import {
   toXaiRealtimeWsUrl,
   type XaiRealtimeEvent,
 } from "./realtime-voice-config.js";
-import { XaiRealtimeVoiceEvents } from "./realtime-voice-events.js";
+import { XaiRealtimeMalformedAudioError, XaiRealtimeVoiceEvents } from "./realtime-voice-events.js";
 import { xaiUserAgentHeaderFor } from "./src/xai-user-agent.js";
 
 export class XaiRealtimeVoiceBridge extends XaiRealtimeVoiceEvents implements RealtimeVoiceBridge {
@@ -263,15 +263,15 @@ export class XaiRealtimeVoiceBridge extends XaiRealtimeVoiceEvents implements Re
             rejectStartup(new Error(readXaiRealtimeErrorDetail(event.error)));
             return;
           }
-          const eventFailure = this.handleEvent(event);
-          if (eventFailure) {
-            failConnection(eventFailure);
-            return;
-          }
+          this.handleEvent(event);
           if (event.type === "session.updated") {
             settleResolve();
           }
         } catch (error) {
+          if (error instanceof XaiRealtimeMalformedAudioError) {
+            failConnection(error);
+            return;
+          }
           console.error("[xai] realtime event parse failed:", error);
         }
       });

--- a/extensions/xai/realtime-voice-bridge.ts
+++ b/extensions/xai/realtime-voice-bridge.ts
@@ -33,6 +33,7 @@ export class XaiRealtimeVoiceBridge extends XaiRealtimeVoiceEvents implements Re
   private connected = false;
   private sessionConfigured = false;
   private intentionallyClosed = false;
+  private terminalError: Error | null = null;
   private reconnectAttempts = 0;
   private pendingAudio: Buffer[] = [];
   private pendingToolResults: Array<{
@@ -47,6 +48,9 @@ export class XaiRealtimeVoiceBridge extends XaiRealtimeVoiceEvents implements Re
   private reconnectAbortController = new AbortController();
 
   async connect(): Promise<void> {
+    if (this.terminalError) {
+      throw this.terminalError;
+    }
     this.intentionallyClosed = false;
     if (this.reconnectAbortController.signal.aborted) {
       this.reconnectAbortController = new AbortController();
@@ -146,6 +150,8 @@ export class XaiRealtimeVoiceBridge extends XaiRealtimeVoiceEvents implements Re
     await new Promise<void>((resolve, reject) => {
       let settled = false;
       let startupFailureClosing = false;
+      let terminalFailure: Error | undefined;
+      let terminalCloseNotified = false;
       const settleResolve = () => {
         if (!settled) {
           settled = true;
@@ -159,6 +165,14 @@ export class XaiRealtimeVoiceBridge extends XaiRealtimeVoiceEvents implements Re
           clearTimeout(connectTimeout);
           reject(error);
         }
+      };
+      const notifyTerminalClose = (error: Error) => {
+        settleReject(error);
+        if (terminalCloseNotified) {
+          return;
+        }
+        terminalCloseNotified = true;
+        this.config.onClose?.("error");
       };
       const connectTimeout = setTimeout(() => {
         if (!this.sessionConfigured && !this.intentionallyClosed) {
@@ -187,6 +201,28 @@ export class XaiRealtimeVoiceBridge extends XaiRealtimeVoiceEvents implements Re
         settleReject(error);
         if (ws.readyState !== WebSocket.CLOSED) {
           ws.close(1000, "startup failed");
+        }
+      };
+      const failConnection = (error: Error) => {
+        if (terminalFailure) {
+          return;
+        }
+        terminalFailure = error;
+        this.terminalError = error;
+        this.intentionallyClosed = true;
+        this.reconnectAbortController.abort();
+        this.connected = false;
+        this.sessionConfigured = false;
+        this.pendingToolResultAcks.clear();
+        try {
+          this.config.onError?.(error);
+        } finally {
+          if (ws.readyState !== WebSocket.CLOSED) {
+            ws.close(1002, "Malformed audio payload");
+          } else {
+            this.ws = null;
+            notifyTerminalClose(error);
+          }
         }
       };
 
@@ -227,7 +263,11 @@ export class XaiRealtimeVoiceBridge extends XaiRealtimeVoiceEvents implements Re
             rejectStartup(new Error(readXaiRealtimeErrorDetail(event.error)));
             return;
           }
-          this.handleEvent(event);
+          const eventFailure = this.handleEvent(event);
+          if (eventFailure) {
+            failConnection(eventFailure);
+            return;
+          }
           if (event.type === "session.updated") {
             settleResolve();
           }
@@ -268,6 +308,15 @@ export class XaiRealtimeVoiceBridge extends XaiRealtimeVoiceEvents implements Re
                 : undefined,
           },
         });
+        if (terminalFailure) {
+          if (this.ws === ws) {
+            this.ws = null;
+          }
+          this.connected = false;
+          this.sessionConfigured = false;
+          notifyTerminalClose(terminalFailure);
+          return;
+        }
         if (startupFailureClosing) {
           if (this.ws === ws) {
             this.connected = false;
@@ -343,6 +392,9 @@ export class XaiRealtimeVoiceBridge extends XaiRealtimeVoiceEvents implements Re
         detail: `reason=${reason} attempt=${attempt}`,
       });
     } catch (error) {
+      if (this.terminalError) {
+        return;
+      }
       this.config.onError?.(error instanceof Error ? error : new Error(String(error)));
       await this.attemptReconnect(reason);
     }

--- a/extensions/xai/realtime-voice-events.ts
+++ b/extensions/xai/realtime-voice-events.ts
@@ -8,6 +8,8 @@ import {
 } from "./realtime-voice-config.js";
 import { XaiRealtimeVoiceProtocol } from "./realtime-voice-protocol.js";
 
+export class XaiRealtimeMalformedAudioError extends Error {}
+
 export abstract class XaiRealtimeVoiceEvents extends XaiRealtimeVoiceProtocol {
   private assistantTranscriptBuffer = "";
   private assistantTranscriptFinalized = false;
@@ -15,7 +17,7 @@ export abstract class XaiRealtimeVoiceEvents extends XaiRealtimeVoiceProtocol {
 
   protected abstract onSessionUpdated(): void;
 
-  protected handleEvent(event: XaiRealtimeEvent): Error | undefined {
+  protected handleEvent(event: XaiRealtimeEvent): void {
     this.config.onEvent?.({
       direction: "server",
       type: event.type,
@@ -73,7 +75,9 @@ export abstract class XaiRealtimeVoiceEvents extends XaiRealtimeVoiceProtocol {
         }
         const canonicalAudio = canonicalizeBase64(audioDelta);
         if (!canonicalAudio) {
-          return new Error("xAI realtime voice stream returned malformed base64 audio data");
+          throw new XaiRealtimeMalformedAudioError(
+            "xAI realtime voice stream returned malformed base64 audio data",
+          );
         }
         this.config.onAudio(Buffer.from(canonicalAudio, "base64"));
         if (event.item_id && event.item_id !== this.lastAssistantItemId) {

--- a/extensions/xai/realtime-voice-events.ts
+++ b/extensions/xai/realtime-voice-events.ts
@@ -1,3 +1,4 @@
+import { canonicalizeBase64 } from "openclaw/plugin-sdk/media-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   XAI_REALTIME_ACTIVE_RESPONSE_ERROR_PREFIX,
@@ -14,7 +15,7 @@ export abstract class XaiRealtimeVoiceEvents extends XaiRealtimeVoiceProtocol {
 
   protected abstract onSessionUpdated(): void;
 
-  protected handleEvent(event: XaiRealtimeEvent): void {
+  protected handleEvent(event: XaiRealtimeEvent): Error | undefined {
     this.config.onEvent?.({
       direction: "server",
       type: event.type,
@@ -70,7 +71,11 @@ export abstract class XaiRealtimeVoiceEvents extends XaiRealtimeVoiceProtocol {
         if (!audioDelta) {
           return;
         }
-        this.config.onAudio(Buffer.from(audioDelta, "base64"));
+        const canonicalAudio = canonicalizeBase64(audioDelta);
+        if (!canonicalAudio) {
+          return new Error("xAI realtime voice stream returned malformed base64 audio data");
+        }
+        this.config.onAudio(Buffer.from(canonicalAudio, "base64"));
         if (event.item_id && event.item_id !== this.lastAssistantItemId) {
           this.lastAssistantItemId = event.item_id;
           this.responseStartTimestamp = this.latestMediaTimestamp;

--- a/extensions/xai/realtime-voice-provider.test.ts
+++ b/extensions/xai/realtime-voice-provider.test.ts
@@ -601,6 +601,81 @@ describe("buildXaiRealtimeVoiceProvider", () => {
     },
   );
 
+  it("terminates realtime voice on non-canonical base64 audio", async () => {
+    vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret
+    const onAudio = vi.fn();
+    const onClose = vi.fn();
+    const onError = vi.fn();
+    let retry: Promise<void> | undefined;
+    const handleError = (error: Error) => {
+      onError(error);
+      retry = bridge.connect();
+    };
+    const bridge = buildXaiRealtimeVoiceProvider().createBridge({
+      providerConfig: { apiKey: "xai-test" }, // pragma: allowlist secret
+      onAudio,
+      onClose,
+      onError: handleError,
+      onClearAudio: vi.fn(),
+    });
+
+    const { connecting, socket } = await openRealtimeBridge(bridge);
+    await connecting;
+    socket.emit(
+      "message",
+      Buffer.from(JSON.stringify({ type: "response.output_audio.delta", delta: "ZE==" })),
+    );
+
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "xAI realtime voice stream returned malformed base64 audio data",
+      }),
+    );
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onAudio).not.toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalledWith("error");
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(socket.closed).toBe(true);
+    if (!retry) {
+      throw new Error("expected synchronous retry from onError");
+    }
+    await expect(retry).rejects.toThrow(
+      "xAI realtime voice stream returned malformed base64 audio data",
+    );
+    expect(FakeWebSocket.instances).toHaveLength(1);
+  });
+
+  it("rejects startup when malformed audio arrives before session.updated", async () => {
+    vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret
+    const onClose = vi.fn();
+    const onError = vi.fn();
+    const bridge = buildXaiRealtimeVoiceProvider().createBridge({
+      providerConfig: { apiKey: "xai-test" }, // pragma: allowlist secret
+      onAudio: vi.fn(),
+      onClose,
+      onError,
+      onClearAudio: vi.fn(),
+    });
+
+    const connection = bridge.connect();
+    await waitForRealtimeState(() => expect(FakeWebSocket.instances.length).toBe(1));
+    const socket = requireSocket();
+    socket.readyState = FakeWebSocket.OPEN;
+    socket.emit("open");
+    socket.emit(
+      "message",
+      Buffer.from(JSON.stringify({ type: "response.output_audio.delta", delta: "ZE==" })),
+    );
+
+    await expect(connection).rejects.toThrow(
+      "xAI realtime voice stream returned malformed base64 audio data",
+    );
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledWith("error");
+    expect(socket.closed).toBe(true);
+  });
+
   it("deduplicates repeated function-call arguments done events", async () => {
     vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret
     const provider = buildXaiRealtimeVoiceProvider();


### PR DESCRIPTION
## Summary

Google (Gemini) TTS now rejects malformed base64 `inlineData` payloads instead of silently decoding them into corrupted PCM samples that get wrapped into the output WAV.

## What Problem This Solves

Node's `Buffer.from(value, "base64")` is lenient: it drops characters outside the base64 alphabet without throwing. When the Gemini TTS API returns a damaged or non-base64 `inlineData.data` payload (proxy truncation, gateway error page, provider-side bug), the current code decodes it into garbage PCM samples and wraps them into a RIFF/WAV buffer that looks structurally valid. The user receives a playable-looking but corrupted audio file with no error surfaced.

**Code evidence**: in `extensions/google/speech-provider.ts`, `extractGoogleSpeechPcm` only checks that `inlineData.data` is non-empty before calling `Buffer.from(data, "base64")`. No alphabet/padding validation happens anywhere on the decode path.

## Root Cause

- Introduced by commit `bf59917cd16` ("fix: add Google Gemini TTS provider (#67515)", 2026-04-15), which added the decode path without payload validation.
- Violated invariant: base64 payloads received over the network must be validated before decoding; `Buffer.from(x, "base64")` never throws, so an unchecked call conflates "decodable" with "valid". The repo already encodes this invariant as `canonicalizeBase64` (used by `extensions/xai/tts.ts`, `extensions/minimax/image-generation-provider.ts`, and others).
- Trigger condition: any syntactically invalid base64 in a `candidates[].content.parts[].inlineData.data` field.

## Why This Fix

- Validate with the shared `canonicalizeBase64` helper and throw `Google TTS response returned malformed base64 audio data` when it rejects the payload — the exact pattern used by the sibling `xai/tts.ts` and `minimax/image-generation-provider.ts`.
- The throw flows through the provider's existing payload-decode error path (`synthesizeGoogleTtsPcmOnce`), which already treats decode failures as retryable-once — so a transient truncation still gets one retry, and a persistently malformed response fails with a clear error. No new error-handling machinery was needed.
- Alternatives considered: skipping the malformed part and continuing the scan (rejected: a present-but-corrupt audio part is not "missing audio"; silently salvaging later parts hides provider corruption); a local regex check (rejected: duplicates the shared, chunk-size-aware helper and risks divergent semantics).

## User Impact

- Before: a malformed `inlineData.data` payload becomes garbage PCM samples inside a valid-looking WAV file (or a corrupted Opus transcode for voice notes).
- After: the synthesis retries once (existing framework) and then fails fast with "Google TTS response returned malformed base64 audio data"; no corrupted audio is produced.

## Evidence

- TDD red: the new regression test failed on unmodified code — the synthesis resolved with a decoded buffer instead of rejecting.
- Real runtime before (unmodified `upstream/main` code): driving the real `buildGoogleSpeechProvider().synthesize` through the production fetch path — guarded fetch in trusted env-proxy mode issuing `CONNECT generativelanguage.googleapis.com:443` to a local forward proxy, which tunnels to a local proof HTTPS server answering the real `POST /v1beta/models/gemini-3.1-flash-tts-preview:generateContent` with `inlineData.data="%%%not-base64!!"` — returned a 51-byte WAV whose PCM samples are garbage (`"��~m�\u001e�"`). No test mocks involved.
- Real runtime after (fixed code): the identical runtime setup made the provider retry once (2 requests, existing framework) and then throw `Google TTS response returned malformed base64 audio data`.
- Focused green: `node scripts/test-projects.mjs extensions/google/speech-provider.test.ts` — 19 tests passed.
- `oxfmt --check` on the changed files passed; `git diff --check` clean.

## Real Behavior Proof

The proof drives the real provider runtime (no test mocks): a local forward proxy carries the provider's guarded fetch (env-proxy mode, as in proxy-required deployments), tunneling the pinned production hostname to a local proof HTTPS server that answers the real generateContent call with the malformed payload. The server presents a proof-only throwaway certificate; no real Google endpoint or credential is touched.

### Before (on main)

```bash
$ node --import tsx proof.mjs
proxy CONNECT: generativelanguage.googleapis.com:443 -> loopback proof server
api received: POST /v1beta/models/gemini-3.1-flash-tts-preview:generateContent
synthesize returned 51 WAV bytes; pcm sample: "��~m�\u001e�"
FAIL: malformed base64 payload was silently decoded into WAV samples
```

### After (with fix)

```bash
$ node --import tsx proof.mjs
proxy CONNECT: generativelanguage.googleapis.com:443 -> loopback proof server
api received: POST /v1beta/models/gemini-3.1-flash-tts-preview:generateContent
api received: POST /v1beta/models/gemini-3.1-flash-tts-preview:generateContent   # retry once
synthesize threw: Google TTS response returned malformed base64 audio data | api requests: 2
PASS: malformed base64 payload rejected (retried once, then failed)
```

## Tests and Validation

- New regression test `rejects malformed base64 audio payloads instead of decoding corrupted PCM` in `extensions/google/speech-provider.test.ts`; the file's `media-runtime` module stub now imports the real `canonicalizeBase64` from `@openclaw/media-core/base64` (the full `importOriginal` spread is avoided because it pulls an incompatible transitive export into this test project).
- `node scripts/test-projects.mjs extensions/google/speech-provider.test.ts` — 1 file, 19 tests passed.
- `oxfmt --check extensions/google/speech-provider.ts extensions/google/speech-provider.test.ts` passed.
- Manual verification: real-runtime before/after runs above (provider runtime + guarded fetch + env-proxy tunnel + HTTPS proof server).
