### PR TITLE
fix(ui): keep first prompt visible after gateway reconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Control UI initial prompts:** keep accepted first messages visible across Gateway transport reconnects by binding the process-local handoff to the logical browser client instead of the per-handshake hello snapshot.
 - **Gateway exec deny fallback:** fail closed immediately when shell-expanded arguments prevent an allowlisted command from producing an enforceable execution plan and effective policy is `ask=off` with `askFallback=deny`, instead of registering an approval that can only time out. Fixes #113191. Thanks @shakkernerd.
 - **Cron local-provider preflight:** report the guarded-fetch deadline as a bounded preflight timeout, preserve concrete nested non-timeout errors, and carry the failure reason into fallback warnings. Thanks @shakkernerd.
 - **ClickClack split-origin setup codes:** consume versioned exact claim endpoints without appending a second claim path, validate the returned canonical API base, preserve private API transport overrides, and keep legacy setup URLs working. Fixes #111919. Thanks @shakkernerd.

--- a/ui/src/app/context.ts
+++ b/ui/src/app/context.ts
@@ -69,6 +69,7 @@ export type ApplicationInitialUserMessage = {
 
 type InitialUserMessageHandoff = {
   message: ApplicationInitialUserMessage;
+  /** Logical Gateway client; per-transport hello objects rotate on reconnect. */
   owner: object;
   sessionKey: string;
 };

--- a/ui/src/e2e/new-session-page.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.e2e.test.ts
@@ -24,6 +24,12 @@ const uiProofArtifactDir = path.join(
   "control-ui-e2e",
   "cloud-worker-session",
 );
+const reconnectProofArtifactDir = path.join(
+  process.cwd(),
+  ".artifacts",
+  "control-ui-e2e",
+  "initial-prompt-reconnect",
+);
 
 const WORKSPACE = "/home/peter/openclaw";
 const PICKED = "/home/peter/openclaw/packages";
@@ -201,6 +207,76 @@ describeControlUiE2e("Control UI new-session page mocked Gateway E2E", () => {
         throw new Error("expected visible prompt and tool rows");
       }
       expect(userRow.y).toBeLessThan(toolRow.y);
+    } finally {
+      await context.close();
+    }
+  });
+
+  it("keeps the initial prompt visible across a Gateway reconnect", async () => {
+    const context = await browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const sessionKey = "agent:main:reconnected-initial-prompt";
+    const message = "keep this first prompt through reconnect";
+    const gateway = await installMockGateway(page, {
+      methodResponses: {
+        "sessions.create": { key: sessionKey, runStarted: true },
+        "chat.history": {
+          messages: [],
+          sessionId: "reconnected-initial-prompt",
+          sessionInfo: { hasActiveRun: true, key: sessionKey, status: "running" },
+        },
+      },
+    });
+    try {
+      await page.goto(`${server.baseUrl}new`);
+      await page.locator(".new-session-page__message").fill(message);
+      await page.getByRole("button", { name: "Start thread" }).click();
+      await page.waitForURL((url) => url.searchParams.get("session") === sessionKey, {
+        timeout: 30_000,
+      });
+      await gateway.waitForRequest("chat.history");
+      await expect.poll(() => page.locator(".chat-group.user").textContent()).toContain(message);
+
+      const socketsBeforeReconnect = await gateway.getSocketCount();
+      await gateway.setOnline(false);
+      await expect
+        .poll(() => gateway.getSocketCount(), { timeout: 10_000 })
+        .toBeGreaterThan(socketsBeforeReconnect);
+      await gateway.setOnline(true);
+      await expect
+        .poll(() =>
+          page.evaluate(() => {
+            const app = document.querySelector("openclaw-app") as HTMLElement & {
+              runtime?: { context: { gateway: { snapshot: { phase: string } } } };
+            };
+            return app.runtime?.context.gateway.snapshot.phase;
+          }),
+        )
+        .toBe("connected");
+      await page.evaluate((selectedSessionKey) => {
+        const pane = document.querySelector("openclaw-chat-pane") as unknown as HTMLElement & {
+          state: { chatMessages: unknown[]; chatMessagesBySession: Map<string, unknown> };
+          switchPaneSession: (sessionKey: string) => void;
+        };
+        pane.state.chatMessages = [];
+        pane.state.chatMessagesBySession.clear();
+        pane.switchPaneSession("agent:main:temporary-session");
+        pane.switchPaneSession(selectedSessionKey);
+      }, sessionKey);
+      if (captureUiProofEnabled) {
+        await mkdir(reconnectProofArtifactDir, { recursive: true });
+        await page.screenshot({
+          path: path.join(reconnectProofArtifactDir, "reconnected-session.png"),
+          fullPage: true,
+        });
+      }
+
+      await expect.poll(() => page.locator(".chat-group.user").textContent()).toContain(message);
+      await expect.poll(() => page.locator(".chat-group.user").count()).toBe(1);
     } finally {
       await context.close();
     }

--- a/ui/src/pages/chat/initial-turn-handoff.test.ts
+++ b/ui/src/pages/chat/initial-turn-handoff.test.ts
@@ -9,7 +9,7 @@ import {
 describe("initial user message handoff", () => {
   it("reprojects an accepted first prompt across state replacement until history owns it", () => {
     const sessionKey = "agent:main:new-session";
-    const hello = {};
+    const client = {};
     const handoff = createInitialUserMessageHandoff();
     prepareInitialUserMessageHandoff(
       handoff,
@@ -18,14 +18,14 @@ describe("initial user message handoff", () => {
         text: "show this while the run is active",
         createdAt: 123,
       },
-      hello,
+      client,
     );
 
-    const otherSession = { chatMessages: [] as unknown[], hello };
+    const otherSession = { chatMessages: [] as unknown[], client };
     expect(admitInitialUserMessageHandoff(handoff, otherSession, "agent:main:other")).toBe(false);
     expect(otherSession.chatMessages).toEqual([]);
 
-    const createdSession = { chatMessages: [] as unknown[], hello };
+    const createdSession = { chatMessages: [] as unknown[], client };
     expect(admitInitialUserMessageHandoff(handoff, createdSession, sessionKey)).toBe(true);
     expect(createdSession.chatMessages).toEqual([
       {
@@ -44,9 +44,9 @@ describe("initial user message handoff", () => {
         text: "keep the other active prompt too",
         createdAt: 124,
       },
-      hello,
+      client,
     );
-    const secondActiveSession = { chatMessages: [] as unknown[], hello };
+    const secondActiveSession = { chatMessages: [] as unknown[], client };
     expect(admitInitialUserMessageHandoff(handoff, secondActiveSession, secondSessionKey)).toBe(
       true,
     );
@@ -55,7 +55,7 @@ describe("initial user message handoff", () => {
       role: "assistant",
       content: [{ type: "text", text: "already working" }],
     };
-    const remountedSession = { chatMessages: [assistantOutput] as unknown[], hello };
+    const remountedSession = { chatMessages: [assistantOutput] as unknown[], client };
     expect(admitInitialUserMessageHandoff(handoff, remountedSession, sessionKey)).toBe(true);
     expect(remountedSession.chatMessages).toEqual([
       ...createdSession.chatMessages,
@@ -71,13 +71,13 @@ describe("initial user message handoff", () => {
     expect(
       reconcileInitialUserMessageHandoff(handoff, remountedSession, sessionKey, [persisted], true),
     ).toBe(false);
-    const activeRunReset = { chatMessages: [] as unknown[], hello };
+    const activeRunReset = { chatMessages: [] as unknown[], client };
     expect(admitInitialUserMessageHandoff(handoff, activeRunReset, sessionKey)).toBe(true);
     activeRunReset.chatMessages = [persisted];
     expect(
       reconcileInitialUserMessageHandoff(handoff, activeRunReset, sessionKey, [persisted], false),
     ).toBe(false);
-    expect(admitInitialUserMessageHandoff(handoff, { chatMessages: [], hello }, sessionKey)).toBe(
+    expect(admitInitialUserMessageHandoff(handoff, { chatMessages: [], client }, sessionKey)).toBe(
       false,
     );
   });
@@ -85,7 +85,7 @@ describe("initial user message handoff", () => {
   it("does not duplicate a first prompt that history already loaded", () => {
     const sessionKey = "agent:main:main";
     const routeSessionKey = "main";
-    const hello = {};
+    const client = {};
     const handoff = createInitialUserMessageHandoff();
     prepareInitialUserMessageHandoff(
       handoff,
@@ -94,14 +94,14 @@ describe("initial user message handoff", () => {
         text: "history won the race",
         createdAt: 123,
       },
-      hello,
+      client,
     );
     const persisted = {
       role: "user",
       content: [{ type: "text", text: "history won the race" }],
       __openclaw: { seq: 1 },
     };
-    const createdSession = { chatMessages: [persisted] as unknown[], hello };
+    const createdSession = { chatMessages: [persisted] as unknown[], client };
 
     expect(
       reconcileInitialUserMessageHandoff(
@@ -114,13 +114,13 @@ describe("initial user message handoff", () => {
     ).toBe(false);
     expect(createdSession.chatMessages).toEqual([persisted]);
     expect(
-      admitInitialUserMessageHandoff(handoff, { chatMessages: [], hello }, routeSessionKey),
+      admitInitialUserMessageHandoff(handoff, { chatMessages: [], client }, routeSessionKey),
     ).toBe(false);
   });
 
   it("reconciles an image prompt by accepted message sequence", () => {
     const sessionKey = "agent:main:image-session";
-    const hello = {};
+    const client = {};
     const handoff = createInitialUserMessageHandoff();
     prepareInitialUserMessageHandoff(
       handoff,
@@ -138,10 +138,10 @@ describe("initial user message handoff", () => {
         ],
         createdAt: 123,
       },
-      hello,
+      client,
       { messageId: "initial-image-send", messageSeq: 1 },
     );
-    const projectedSession = { chatMessages: [] as unknown[], hello };
+    const projectedSession = { chatMessages: [] as unknown[], client };
     expect(admitInitialUserMessageHandoff(handoff, projectedSession, sessionKey)).toBe(true);
     expect(projectedSession.chatMessages).toEqual([
       {
@@ -168,7 +168,7 @@ describe("initial user message handoff", () => {
         media: [{ path: "/media/image-1", contentType: "image/png" }],
       },
     };
-    const createdSession = { chatMessages: [persisted] as unknown[], hello };
+    const createdSession = { chatMessages: [persisted] as unknown[], client };
     const projectedMessage = projectedSession.chatMessages[0];
 
     expect(
@@ -189,18 +189,33 @@ describe("initial user message handoff", () => {
     ]);
   });
 
-  it("does not expose a pending prompt after reconnecting", () => {
+  it("keeps a pending prompt across reconnects from the same browser client", () => {
     const sessionKey = "agent:main:new-session";
-    const originalConnection = {};
+    const client = {};
     const handoff = createInitialUserMessageHandoff();
     prepareInitialUserMessageHandoff(
       handoff,
       sessionKey,
       { text: "private prompt", createdAt: 123 },
-      originalConnection,
+      client,
     );
 
-    const replacementGatewaySession = { chatMessages: [] as unknown[], hello: {} };
+    const reconnectedSession = { chatMessages: [] as unknown[], client };
+    expect(admitInitialUserMessageHandoff(handoff, reconnectedSession, sessionKey)).toBe(true);
+    expect(reconnectedSession.chatMessages).toHaveLength(1);
+  });
+
+  it("does not expose a pending prompt to a replacement gateway client", () => {
+    const sessionKey = "agent:main:new-session";
+    const handoff = createInitialUserMessageHandoff();
+    prepareInitialUserMessageHandoff(
+      handoff,
+      sessionKey,
+      { text: "private prompt", createdAt: 123 },
+      {},
+    );
+
+    const replacementGatewaySession = { chatMessages: [] as unknown[], client: {} };
     expect(admitInitialUserMessageHandoff(handoff, replacementGatewaySession, sessionKey)).toBe(
       false,
     );

--- a/ui/src/pages/chat/initial-turn-handoff.ts
+++ b/ui/src/pages/chat/initial-turn-handoff.ts
@@ -186,10 +186,10 @@ export function admitInitialTurnHandoff(
 
 export function admitInitialUserMessageHandoff(
   handoff: ApplicationInitialUserMessageHandoff,
-  host: { chatMessages: unknown[]; hello?: object | null },
+  host: { chatMessages: unknown[]; client?: object | null },
   sessionKey: string,
 ): boolean {
-  const message = handoff.read(sessionKey, host.hello ?? null);
+  const message = handoff.read(sessionKey, host.client ?? null);
   if (!message) {
     return false;
   }
@@ -206,12 +206,12 @@ export function admitInitialUserMessageHandoff(
 /** Keeps the accepted prompt projected until authoritative history owns it. */
 export function reconcileInitialUserMessageHandoff(
   handoff: ApplicationInitialUserMessageHandoff,
-  host: { chatMessages: unknown[]; hello?: object | null },
+  host: { chatMessages: unknown[]; client?: object | null },
   sessionKey: string,
   authoritativeMessages: unknown[],
   runActive: boolean,
 ): boolean {
-  const message = handoff.read(sessionKey, host.hello ?? null);
+  const message = handoff.read(sessionKey, host.client ?? null);
   if (!message) {
     return false;
   }

--- a/ui/src/pages/new-session/new-session-page.ts
+++ b/ui/src/pages/new-session/new-session-page.ts
@@ -779,8 +779,7 @@ class NewSessionPage extends OpenClawLightDomElement {
       ? this.pendingCloud.gatewayUrl
       : context.gateway.connection.gatewayUrl;
     const submissionClient = context.gateway.snapshot.client;
-    const submissionConnection = context.gateway.snapshot.hello;
-    if (!submissionClient || !submissionConnection) {
+    if (!submissionClient || !context.gateway.snapshot.hello) {
       return;
     }
     const submissionRecoveryScope = pendingCloud
@@ -969,7 +968,7 @@ class NewSessionPage extends OpenClawLightDomElement {
             attachments,
             createdAt: submittedAt,
           },
-          submissionConnection,
+          submissionClient,
           { messageId: cloudStart.messageId, messageSeq: cloudStart.messageSeq },
         );
         this.attachmentDraft.clearAfterSubmit(true);
@@ -996,7 +995,7 @@ class NewSessionPage extends OpenClawLightDomElement {
               attachments,
               createdAt: submittedAt,
             },
-            submissionConnection,
+            submissionClient,
             {
               messageId: result.initialRun.messageId,
               messageSeq: result.initialRun.messageSeq,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a newly created Control UI task could lose its first visible user message when the Gateway transport reconnected before authoritative history adopted that prompt and the chat pane rebuilt its state.

## Why This Change Was Made

The process-local initial-message handoff now belongs to the logical Gateway browser client, which survives a transport reconnect, instead of the per-handshake `hello` snapshot, which is replaced on every reconnect. A replacement Gateway client still cannot consume the prior client's pending prompt.

## User Impact

The first prompt in a newly created task remains visible exactly once after a Gateway restart or reconnect while the task is still running.

## Evidence

- Failing-before focused regression: 3/5 initial-message handoff cases failed when consumption remained bound to the handshake snapshot, including the same-client reconnect case.
- Focused unit proof: 5/5 passing in `ui/src/pages/chat/initial-turn-handoff.test.ts`.
- Browser proof: the focused Chromium new-session scenario passed after creating a task, reconnecting the same Gateway client, clearing cached pane state, switching away and back, and confirming the exact first prompt remained once while `chat.history` stayed empty.
- Changed-surface gate: formatting, conflict and max-lines guards, changelog attribution, dependency and package-patch guards, Control UI i18n verification, core/UI typechecks, and changed-file lint all passed on Blacksmith Testbox `tbx_01kyedr49peyvww315ekav0j4a`.
- Source-blind behavior contract: 3/3 clauses passed; the prompt survived reconnect and state rebuild as the exact submitted fixture text, not a static placeholder or history row.
- Fresh Codex autoreview against the rebased branch: clean, no accepted/actionable findings, 0.91 confidence.

Provenance: clear regression from #111953 (`21bfc75648d1`, July 20, 2026), which introduced the connection-scoped initial-message handoff and keyed it to `hello`; code and PR author/merger were Jason (Json) (`@fuller-stack-dev`).

AI-assisted; I reviewed the ownership boundary and understand the change.
