### PR TITLE
fix(minimax): reject malformed base64 audio in music generation

### DIFF
--- a/extensions/minimax/music-generation-provider.test.ts
+++ b/extensions/minimax/music-generation-provider.test.ts
@@ -158,6 +158,55 @@ describe("minimax music generation provider", () => {
     expect(result.metadata).not.toHaveProperty("requestedDurationSeconds");
   });
 
+  it("rejects malformed base64 audio in streamed music chunks", async () => {
+    postJsonRequestMock.mockResolvedValue({
+      response: new Response(
+        `data: ${JSON.stringify({ data: { status: 1, audio: "%%%not-base64!!" }, base_resp: { status_code: 0 } })}\n\n`,
+        {
+          headers: { "content-type": "text/event-stream" },
+        },
+      ),
+      release: vi.fn(async () => {}),
+    });
+
+    const provider = buildMinimaxMusicGenerationProvider();
+    await expect(
+      provider.generateMusic({
+        provider: "minimax",
+        model: "",
+        prompt: "upbeat dance-pop",
+        cfg: {},
+      }),
+    ).rejects.toThrow("MiniMax music generation returned malformed audio base64");
+  });
+
+  it("rejects malformed base64 audio in inline music payloads", async () => {
+    postJsonRequestMock.mockResolvedValue({
+      response: new Response(
+        JSON.stringify({
+          data: {
+            audio: "%%%not-base64!!",
+          },
+          base_resp: { status_code: 0 },
+        }),
+        {
+          headers: { "content-type": "application/json" },
+        },
+      ),
+      release: vi.fn(async () => {}),
+    });
+
+    const provider = buildMinimaxMusicGenerationProvider();
+    await expect(
+      provider.generateMusic({
+        provider: "minimax",
+        model: "music-2.6",
+        prompt: "short track",
+        cfg: {},
+      }),
+    ).rejects.toThrow("MiniMax music generation returned malformed audio base64");
+  });
+
   it("reports streaming music task failures", async () => {
     postJsonRequestMock.mockResolvedValue({
       response: new Response(

--- a/extensions/minimax/music-generation-provider.ts
+++ b/extensions/minimax/music-generation-provider.ts
@@ -1,6 +1,7 @@
 // Minimax provider module implements model/runtime integration.
 import { resolveGeneratedMediaMaxBytes } from "openclaw/plugin-sdk/media-generation-runtime";
 import { extensionForMime } from "openclaw/plugin-sdk/media-mime";
+import { canonicalizeBase64 } from "openclaw/plugin-sdk/media-runtime";
 import type {
   GeneratedMusicAsset,
   MusicGenerationProvider,
@@ -104,10 +105,14 @@ function decodePossibleBinaryWithLimit(data: string, maxBytes: number): Buffer {
     }
     return Buffer.from(trimmed, "hex");
   }
-  if (Buffer.byteLength(trimmed, "base64") > maxBytes) {
+  const canonicalBase64 = canonicalizeBase64(trimmed);
+  if (!canonicalBase64) {
+    throw new Error("MiniMax music generation returned malformed audio base64");
+  }
+  if (Buffer.byteLength(canonicalBase64, "base64") > maxBytes) {
     throw createGeneratedMusicTooLargeError(maxBytes);
   }
-  return Buffer.from(trimmed, "base64");
+  return Buffer.from(canonicalBase64, "base64");
 }
 
 function decodePossibleText(data: string): string {


### PR DESCRIPTION
## Summary

MiniMax music generation now rejects malformed base64 audio payloads instead of silently decoding them into corrupted track bytes, on both the streaming (SSE) and inline response decode paths.

## What Problem This Solves

Node's `Buffer.from(value, "base64")` is lenient: it drops characters outside the base64 alphabet without throwing. `decodePossibleBinaryWithLimit` falls back to the base64 branch whenever `data.audio` is not hex-encoded and not a URL — and it neither validates the alphabet/padding nor gets a trustworthy size estimate: `Buffer.byteLength(dirty, "base64")` is computed on the same unvalidated input, so dirty data both evades the media cap check and decodes into garbage bytes that are concatenated into the track and written to disk as an mp3.

**Code evidence**: in `extensions/minimax/music-generation-provider.ts`, `decodePossibleBinaryWithLimit` estimates and decodes the base64 branch without any validation. The helper feeds both decode paths: streamed SSE chunks (`readStreamingTrack`) and inline `data.audio` responses.

## Root Cause

- Introduced by commit `036298fbaec` ("fix(music): bound generated track downloads", 2026-05-29), which added the hex/base64 sniffing helper without payload validation.
- Violated invariant: base64 payloads received over the network must be validated before decoding; `Buffer.from(x, "base64")` never throws, so an unchecked call conflates "decodable" with "valid". The same extension already encodes this invariant in `image-generation-provider.ts` (`canonicalizeBase64` + "MiniMax image generation returned malformed image base64").
- Trigger condition: any syntactically invalid base64 in `data.audio` (streamed chunk or inline payload).

## Why This Fix

- Validate with the shared `canonicalizeBase64` helper and throw `MiniMax music generation returned malformed audio base64` — the direct counterpart of the image provider's established pattern in the same extension, including the test template (`rejects malformed base64 image payloads`).
- The size-cap check now runs on the canonical payload, so dirty data can no longer evade `maxBytes`.
- The single helper fix covers both decode paths (streaming + inline).
- Alternatives considered: skipping malformed streamed chunks (rejected: silently produces gapped audio and hides provider corruption); a local regex check (rejected: duplicates the shared, chunk-size-aware helper and risks divergent semantics).

## User Impact

- Before: a malformed base64 audio chunk becomes garbage bytes inside the generated mp3 (and can also slip past the configured media cap).
- After: the generation fails fast with "MiniMax music generation returned malformed audio base64"; no corrupted track is produced.

## Evidence

- TDD red: both new regression tests failed on unmodified code (streaming + inline paths).
- Real behavior before (unmodified code): against a local fake MiniMax SSE server streaming `audio="%%%not-base64!!"`, `generateMusic` returned a 7-byte garbage track buffer (`"��~m�\u001e�"`).
- Real behavior after (fixed code): the same server/payload made `generateMusic` throw `MiniMax music generation returned malformed audio base64`.
- Focused green: `node scripts/test-projects.mjs extensions/minimax` — 11 test files, 156 tests passed.
- `oxfmt --check` on the changed files passed; `git diff --check` clean.

## Real Behavior Proof

The proof runs the real `buildMinimaxMusicGenerationProvider().generateMusic` against a real local SSE server (reachable through the provider's documented `baseUrl` override plus the private-network opt-in) streaming the malformed chunk.

### Before (on main)

```bash
$ node --import tsx proof.mjs
fake MiniMax SSE server listening on http://127.0.0.1:<port>
generateMusic returned track: 7 bytes as utf8: "��~m�\u001e�"
FAIL: malformed base64 chunk was silently decoded into the track buffer
```

### After (with fix)

```bash
$ node --import tsx proof.mjs
fake MiniMax SSE server listening on http://127.0.0.1:<port>
generateMusic threw: MiniMax music generation returned malformed audio base64
PASS: malformed base64 chunk rejected instead of decoded
```

## Tests and Validation

- New regression tests `rejects malformed base64 audio in streamed music chunks` and `rejects malformed base64 audio in inline music payloads` in `extensions/minimax/music-generation-provider.test.ts` — one per decode path, modeled on the same extension's `rejects malformed base64 image payloads` test.
- `node scripts/test-projects.mjs extensions/minimax` — 11 files, 156 tests passed.
- `oxfmt --check extensions/minimax/music-generation-provider.ts extensions/minimax/music-generation-provider.test.ts` passed.
- Manual verification: fake-server before/after runs above.
