### PR TITLE
test(tui): show terminal output when a PTY fixture RPC wait times out

### DIFF
--- a/src/tui/tui-pty-harness.e2e.test.ts
+++ b/src/tui/tui-pty-harness.e2e.test.ts
@@ -37,6 +37,7 @@ async function waitForFixtureLogEntry(
   logPath: string,
   predicate: (entry: FixtureLogEntry) => boolean,
   timeoutMs = OUTPUT_TIMEOUT_MS,
+  readPtyOutput?: () => string,
 ) {
   const start = Date.now();
   while (Date.now() - start < timeoutMs) {
@@ -48,7 +49,12 @@ async function waitForFixtureLogEntry(
     await sleep(25);
   }
   const entries = await readFixtureLog(logPath);
-  throw new Error(`timed out waiting for fixture log entry\n${JSON.stringify(entries, null, 2)}`);
+  // A swallowed command leaves no RPC behind, so the RPC log alone cannot say
+  // whether the TUI rejected the input; the terminal output carries that reason.
+  const ptyOutput = readPtyOutput?.() ?? "";
+  throw new Error(
+    `timed out waiting for fixture log entry\n${JSON.stringify(entries, null, 2)}\n${ptyOutput}`,
+  );
 }
 
 function objectFieldEquals(entry: FixtureLogEntry, field: string, value: unknown) {
@@ -526,7 +532,7 @@ async function startTuiFixture(opts: { env?: NodeJS.ProcessEnv } = {}) {
     run,
     logPath,
     waitForLogEntry: async (predicate: (entry: FixtureLogEntry) => boolean, timeoutMs?: number) =>
-      await waitForFixtureLogEntry(logPath, predicate, timeoutMs),
+      await waitForFixtureLogEntry(logPath, predicate, timeoutMs, run.output),
     cleanup: async () => {
       await run.dispose();
       await rm(tempDir, { recursive: true, force: true });


### PR DESCRIPTION
Related: #113994

## What Problem This Solves

When the TUI PTY harness times out waiting for a fixture RPC, the failure message
lists only the fixture RPC log. If the TUI rejected the typed command instead of
issuing the RPC, that rejection is a line of terminal output, not an RPC, so the
dump proves nothing and the failure has to be re-derived by hand from CI logs.

That is exactly what happened with #113994: the `/reset` case failed with
`timed out waiting for fixture log entry` and an RPC list ending at
`sendChat "after new"`. The real cause was visible only in the terminal —
`abort the current run before /reset` — and the dump did not carry it.

## Why This Change Was Made

`waitForFixtureLogEntry` now also takes the PTY output reader and appends the
captured terminal output to the timeout error, matching what
`PtyRun.waitForOutput` already does on its own timeouts. The next occurrence of
this failure mode is self-diagnosing instead of needing a manual replay.

The underlying `/reset` flake in #113994 is already fixed on `main`: #113872
added `waitForOutput("PTY_RESPONSE: after new")` to the preceding `/new` case,
so the next case no longer types `/reset` while that run is still in flight and
the rollover guard added in #113841 no longer rejects it. All failing runs cited
in the issue predate that commit. This PR only closes the diagnostics gap the
issue also asked for.

## User Impact

None. Test-harness diagnostics only; no runtime or product behavior changes.

## Evidence

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts --configLoader runner src/tui/tui-pty-harness.e2e.test.ts` — 29 passed.
- 25 consecutive runs of that shard under deliberate CPU pressure (12 busy loops) — all green, no flake.
- `node scripts/check-changed.mjs -- src/tui/tui-pty-harness.e2e.test.ts` — typecheck + lint clean (delegated to Blacksmith Testbox).
- Codex autoreview `--mode uncommitted` — clean, no accepted findings.
