### PR TITLE
fix(xai): reject malformed base64 audio in realtime voice deltas

### DIFF
--- a/extensions/xai/realtime-voice-events.ts
+++ b/extensions/xai/realtime-voice-events.ts
@@ -1,3 +1,4 @@
+import { canonicalizeBase64 } from "openclaw/plugin-sdk/media-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   XAI_REALTIME_ACTIVE_RESPONSE_ERROR_PREFIX,
@@ -70,7 +71,14 @@ export abstract class XaiRealtimeVoiceEvents extends XaiRealtimeVoiceProtocol {
         if (!audioDelta) {
           return;
         }
-        this.config.onAudio(Buffer.from(audioDelta, "base64"));
+        const canonicalAudio = canonicalizeBase64(audioDelta);
+        if (!canonicalAudio) {
+          this.config.onError?.(
+            new Error("xAI realtime voice stream returned malformed base64 audio data"),
+          );
+          return;
+        }
+        this.config.onAudio(Buffer.from(canonicalAudio, "base64"));
         if (event.item_id && event.item_id !== this.lastAssistantItemId) {
           this.lastAssistantItemId = event.item_id;
           this.responseStartTimestamp = this.latestMediaTimestamp;

--- a/extensions/xai/realtime-voice-provider.test.ts
+++ b/extensions/xai/realtime-voice-provider.test.ts
@@ -595,6 +595,44 @@ describe("buildXaiRealtimeVoiceProvider", () => {
     ]);
   });
 
+  it("reports malformed base64 audio deltas through onError without emitting audio", async () => {
+    vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret
+    const provider = buildXaiRealtimeVoiceProvider();
+    const onAudio = vi.fn();
+    const onError = vi.fn();
+    const bridge = provider.createBridge({
+      providerConfig: { apiKey: "xai-test" }, // pragma: allowlist secret
+      onAudio,
+      onError,
+      onClearAudio: vi.fn(),
+    });
+
+    void bridge.connect();
+    await waitForRealtimeState(() => expect(FakeWebSocket.instances.length).toBe(1));
+    const socket = requireSocket();
+    socket.readyState = FakeWebSocket.OPEN;
+    socket.emit("open");
+    socket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+    socket.emit(
+      "message",
+      Buffer.from(
+        JSON.stringify({
+          type: "response.output_audio.delta",
+          item_id: "item_1",
+          delta: "%%%not-base64!!",
+        }),
+      ),
+    );
+    bridge.close();
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError.mock.calls[0]?.[0]).toBeInstanceOf(Error);
+    expect((onError.mock.calls[0]?.[0] as Error).message).toBe(
+      "xAI realtime voice stream returned malformed base64 audio data",
+    );
+    expect(onAudio).not.toHaveBeenCalled();
+  });
+
   it("truncates queued playback on server-VAD barge-in without cancelling xAI", async () => {
     vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret
     const provider = buildXaiRealtimeVoiceProvider();


### PR DESCRIPTION
## Summary

The xAI realtime voice bridge now rejects malformed base64 `response.output_audio.delta` events instead of decoding them into corrupted bytes pushed to playback.

## What Problem This Solves

Node's `Buffer.from(value, "base64")` is lenient: it drops characters outside the base64 alphabet without throwing. When the realtime server sends a damaged or non-base64 audio delta (proxy truncation, protocol drift, provider-side bug), the bridge currently decodes it into garbage bytes and pushes them straight into `onAudio` — the user hears corrupted playback with no error surfaced.

**Code evidence**: in `extensions/xai/realtime-voice-events.ts`, the `response.output_audio.delta` handler only checks that `event.delta ?? event.data` is truthy before calling `this.config.onAudio(Buffer.from(audioDelta, "base64"))`. The sibling `extensions/xai/tts.ts` already validates the same payload class with `canonicalizeBase64` (the `audio.delta` stream handler) — this path was missed.

## Root Cause

- Introduced by commit `6c5084f1adb` ("feat(xai): add realtime voice provider (#106267)", 2026-07-13), which added the bridge event handlers without payload validation.
- Violated invariant: base64 payloads received over the network must be validated before decoding; `Buffer.from(x, "base64")` never throws, so an unchecked call conflates "decodable" with "valid". The same extension's `tts.ts` encodes exactly this invariant for its streaming audio.
- Trigger condition: any syntactically invalid base64 in `response.output_audio.delta.delta` (or legacy `data`).

## Why This Fix

- Validate with the shared `canonicalizeBase64` helper; on rejection report `new Error("xAI realtime voice stream returned malformed base64 audio data")` through the bridge's existing `onError` callback and emit no audio — the direct counterpart of the `xai/tts.ts` `audio.delta` handler, which fails the stream on the same payload class.
- Dropping the single corrupt delta (instead of killing the session) matches realtime playback semantics: one bad frame must not terminate a live voice conversation, but it must never reach the speaker silently. `onError` gives the host visibility either way.
- Alternatives considered: pushing the decode failure into playback silence without `onError` (rejected: hides provider corruption); closing the bridge (rejected: disproportionate for a single-frame corruption, and inconsistent with how other bridge errors are surfaced).

## User Impact

- Before: a malformed audio delta becomes garbage bytes played back as corrupted audio.
- After: the delta is rejected, `onError` fires with a clear message, and playback continues with the next valid frame.

## Evidence

- TDD red: the new regression test failed on unmodified code — `onAudio` was called with the corrupted buffer instead of `onError` being reported.
- Real behavior before (unmodified code): against a real local WebSocket server that completes the bridge handshake and pushes `delta="%%%not-base64!!"`, `onAudio` received 1 garbage buffer (`"��~m�\u001e�"`).
- Real behavior after (fixed code): the same setup produced 0 `onAudio` calls and 1 `onError` (`xAI realtime voice stream returned malformed base64 audio data`).
- Focused green: `node scripts/test-projects.mjs extensions/xai/realtime-voice-provider.test.ts` — 37 tests passed.
- `oxfmt --check` on the changed files passed; `git diff --check` clean.

## Real Behavior Proof

The proof creates the real provider bridge over a real local WebSocket server (reachable through the documented `XAI_BASE_URL`/`baseUrl` override) and pushes the malformed delta after the handshake.

### Before (on main)

```bash
$ node --import tsx proof.mjs
fake xAI realtime WS server listening on 127.0.0.1:<port>
onAudio calls: 1 [ '"��~m�\\u001e�"' ]
onError calls: 0 []
FAIL: malformed base64 delta was decoded and pushed to playback
```

### After (with fix)

```bash
$ node --import tsx proof.mjs
fake xAI realtime WS server listening on 127.0.0.1:<port>
onAudio calls: 0 []
onError calls: 1 [ 'xAI realtime voice stream returned malformed base64 audio data' ]
PASS: malformed base64 delta reported through onError, no audio emitted
```

## Tests and Validation

- New regression test `reports malformed base64 audio deltas through onError without emitting audio` in `extensions/xai/realtime-voice-provider.test.ts`: drives the bridge through the existing fake-socket harness with a malformed delta and asserts `onError` fires once with the malformed-data message and `onAudio` is never called.
- `node scripts/test-projects.mjs extensions/xai/realtime-voice-provider.test.ts` — 1 file, 37 tests passed.
- `oxfmt --check extensions/xai/realtime-voice-events.ts extensions/xai/realtime-voice-provider.test.ts` passed.
- Manual verification: real-WebSocket before/after runs above.
