### PR TITLE
fix(ui): recover from unknown selected agents and surface session-catalog failures

### DIFF
--- a/ui/src/app/agent-selection.test.ts
+++ b/ui/src/app/agent-selection.test.ts
@@ -97,4 +97,22 @@ describe("agent selection", () => {
 
     expect(selection.state).toEqual({ selectedId: "ops", scopeId: "ops" });
   });
+
+  it("self-heals an unknown cold-load selection to the roster default", () => {
+    const gateway = createGateway("Main");
+    const roster = createRoster();
+    const selection = createAgentSelectionCapability(gateway.gateway, roster.roster);
+
+    roster.publish({
+      defaultId: "Roboclaw",
+      mainKey: "main",
+      scope: "per-sender",
+      agents: [{ id: "roboclaw", kind: "agent" }],
+    });
+
+    expect(selection.state).toEqual({ selectedId: "roboclaw", scopeId: "roboclaw" });
+
+    selection.set("main");
+    expect(selection.state).toEqual({ selectedId: "roboclaw", scopeId: "roboclaw" });
+  });
 });

--- a/ui/src/app/agent-selection.ts
+++ b/ui/src/app/agent-selection.ts
@@ -32,6 +32,19 @@ export function createAgentSelectionCapability(
   gateway: AgentSelectionGateway,
   roster: AgentSelectionRoster,
 ): AgentSelectionCapability {
+  const reconcileSelectedId = (value: string | null): string | null => {
+    const selectedId = value?.trim() ? normalizeAgentId(value) : null;
+    const agentsList = roster.state.agentsList;
+    if (
+      !selectedId ||
+      !agentsList ||
+      agentsList.agents.length === 0 ||
+      agentsList.agents.some((agent) => normalizeAgentId(agent.id) === selectedId)
+    ) {
+      return selectedId;
+    }
+    return normalizeAgentId(agentsList.defaultId);
+  };
   const resolveScopeId = (value: string | null): string | null => {
     const scopeId = value?.trim() ? normalizeAgentId(value) : null;
     // System agents remain valid concrete chat targets, but never become shared page filters.
@@ -51,7 +64,11 @@ export function createAgentSelectionCapability(
   const listeners = new Set<(next: AgentSelectionState) => void>();
 
   const publish = (next: AgentSelectionState) => {
-    const reconciled = { ...next, scopeId: resolveScopeId(next.scopeId) };
+    const selectedId = reconcileSelectedId(next.selectedId);
+    // Selection and page scope move together when a configured agent vanishes.
+    // Otherwise route-derived agent ids keep sending agent-scoped RPCs to a dead target.
+    const scopeId = selectedId === next.selectedId ? next.scopeId : selectedId;
+    const reconciled = { selectedId, scopeId: resolveScopeId(scopeId) };
     if (state.selectedId === reconciled.selectedId && state.scopeId === reconciled.scopeId) {
       return;
     }

--- a/ui/src/app/app-host.ts
+++ b/ui/src/app/app-host.ts
@@ -921,12 +921,11 @@ class OpenClawShell extends OpenClawLightDomElement {
     if (rosterDiff.changedIds.length > 0) {
       void context.agentIdentity.ensure(rosterDiff.changedIds);
     }
-    const previousIds = new Set(previous?.agents.map((agent) => agent.id) ?? []);
     const nextIds = new Set(next.agents.map((agent) => agent.id));
     if (
       activeAgentId &&
       context.agentSelection.state.selectedId === activeAgentId &&
-      previousIds.has(activeAgentId) &&
+      next.agents.length > 0 &&
       !nextIds.has(activeAgentId)
     ) {
       context.agentSelection.set(next.defaultId);

--- a/ui/src/components/app-sidebar-session-catalog-live.ts
+++ b/ui/src/components/app-sidebar-session-catalog-live.ts
@@ -58,7 +58,7 @@ async function requestSessionCatalogList(params: {
       progressive: true,
     };
   } catch (error) {
-    if (!(error instanceof GatewayRequestError) || error.gatewayCode !== "INVALID_REQUEST") {
+    if (!isLegacyProgressIdRejection(error)) {
       throw error;
     }
     // Older Gateways advertise the list method but reject the additive field.
@@ -68,6 +68,21 @@ async function requestSessionCatalogList(params: {
       progressive: false,
     };
   }
+}
+
+function isLegacyProgressIdRejection(error: unknown): boolean {
+  if (!(error instanceof GatewayRequestError) || error.gatewayCode !== "INVALID_REQUEST") {
+    return false;
+  }
+  const message = error.message.toLowerCase();
+  return (
+    message.includes("progressid") &&
+    (message.includes("unexpected property") ||
+      message.includes("additional property") ||
+      message.includes("additional properties") ||
+      message.includes("unknown property") ||
+      message.includes("unrecognized property"))
+  );
 }
 
 function isSessionsCatalogHostEvent(value: unknown): value is SessionsCatalogHostEvent {
@@ -116,6 +131,7 @@ export class SessionCatalogLiveState {
   private readonly hostProgressSequences = new Map<string, number>();
   private readonly hostIdsByCatalog = new Map<string, ReadonlySet<string>>();
   private readonly requestChangedHostKeys = new Set<string>();
+  private readonly warnedRequestErrors = new Set<string>();
   private requestOwner: symbol | null = null;
 
   cancelTimer() {
@@ -227,6 +243,17 @@ export class SessionCatalogLiveState {
 
   ownsRequest(owner: symbol) {
     return this.requestOwner === owner;
+  }
+
+  warnRequestError(error: unknown) {
+    const code = error instanceof GatewayRequestError ? error.gatewayCode : "UNAVAILABLE";
+    const message = error instanceof Error ? error.message : String(error);
+    const signature = `${code}\u0000${message}`;
+    if (this.warnedRequestErrors.has(signature)) {
+      return;
+    }
+    this.warnedRequestErrors.add(signature);
+    console.warn("Session catalog refresh failed", error);
   }
 
   markFinal(params: {
@@ -430,6 +457,7 @@ export async function refreshSessionCatalogsLive(params: {
   pageDepths: ReadonlyMap<string, number>;
   connected: () => boolean;
   applyFinal: (catalogs: SessionCatalog[], revisedCatalogIds: ReadonlySet<string>) => void;
+  applyError: (error: unknown) => void;
   refresh: () => void;
 }) {
   const { live, client, generation, revision } = params;
@@ -469,8 +497,12 @@ export async function refreshSessionCatalogsLive(params: {
     ]);
     params.applyFinal(catalogs, revisedCatalogIds);
     live.markFinal({ catalogs, hadCatalogs, previousSnapshot, progressSequence });
-  } catch {
+  } catch (error) {
     // A transient poll failure must not collapse already visible or expanded pages.
+    if (revisionIsCurrent()) {
+      live.warnRequestError(error);
+      params.applyError(error);
+    }
   } finally {
     live.endRefetch(refetchOwner);
     const ownsRequest = live.ownsRequest(requestOwner);

--- a/ui/src/components/app-sidebar-session-list-render.ts
+++ b/ui/src/components/app-sidebar-session-list-render.ts
@@ -22,6 +22,7 @@ import {
   type SidebarRecentSession,
 } from "./app-sidebar-session-types.ts";
 import { icons } from "./icons.ts";
+import { renderPanelRefreshStatus, type PanelRefreshStatus } from "./panel-refresh-status.ts";
 
 type RenderableSessionSection = SidebarSessionSection<SidebarRecentSession> & {
   totalRowCount: number;
@@ -32,6 +33,7 @@ type RenderableSessionSection = SidebarSessionSection<SidebarRecentSession> & {
 
 type SessionCatalogRenderSnapshot = {
   catalogs: readonly SessionCatalog[];
+  refreshStatus: PanelRefreshStatus;
   basePath: string;
   routeSessionKey: string;
   newSessionAgentId: string;
@@ -313,40 +315,48 @@ function renderSessionCatalogs(params: {
   snapshot: SessionCatalogRenderSnapshot;
 }) {
   const { host, snapshot } = params;
-  return renderSessionCatalogGroups({
-    catalogs: snapshot.catalogs,
-    connected: host.connected,
-    basePath: snapshot.basePath,
-    routeSessionKey: snapshot.routeSessionKey,
-    newSessionAgentId: snapshot.newSessionAgentId,
-    collapsedSections: host.collapsedSessionSections,
-    loadingMoreCatalogIds: snapshot.loadingMoreCatalogIds,
-    projectGrouping: snapshot.projectGrouping,
-    liveRows: snapshot.liveRows,
-    creatorId: snapshot.creatorId,
-    renderLiveRow: (row, display) =>
-      renderRecentSession({
-        host,
-        session: snapshot.sidebarRowsByKey.get(row.key)!,
-        display,
-      }),
-    onToggleSection: (sectionId) => host.toggleSection(sectionId),
-    // aria-expanded must land on the one header whose menu is open, so the
-    // catalog id rides on the trigger's data attribute instead of a global flag.
-    viewMenuOpenCatalogId: host.sidebarMenus.catalogViewMenuPosition
-      ? (host.sidebarMenus.catalogViewMenuTrigger?.getAttribute("data-session-catalog-view-menu") ??
-        null)
-      : null,
-    creatorFilterActive: host.sessionCreatorFilterActive,
-    onOpenViewMenu: (trigger) => host.sidebarMenus.toggleCatalogViewMenu(trigger),
-    onLoadMore: (catalogId) => void host.sessionData.loadMoreSessionCatalog(catalogId),
-    onOpenNewSession: host.onOpenNewSession,
-    onNavigate: host.onNavigate,
-    catalogOpenTarget: snapshot.catalogOpenTarget,
-    terminalAvailable: snapshot.terminalAvailable,
-    onOpenTerminal: openCatalogSessionInTerminal,
-    onOpenMenu: (request, x, y, trigger) => host.openCatalogMenu(request, x, y, trigger),
-  });
+  return html`
+    ${renderPanelRefreshStatus({
+      status: snapshot.refreshStatus,
+      onRetry: () => void host.sessionData.refreshSessionCatalogs(),
+      className: "sidebar-session-error sidebar-session-catalog-error",
+    })}
+    ${renderSessionCatalogGroups({
+      catalogs: snapshot.catalogs,
+      connected: host.connected,
+      basePath: snapshot.basePath,
+      routeSessionKey: snapshot.routeSessionKey,
+      newSessionAgentId: snapshot.newSessionAgentId,
+      collapsedSections: host.collapsedSessionSections,
+      loadingMoreCatalogIds: snapshot.loadingMoreCatalogIds,
+      projectGrouping: snapshot.projectGrouping,
+      liveRows: snapshot.liveRows,
+      creatorId: snapshot.creatorId,
+      renderLiveRow: (row, display) =>
+        renderRecentSession({
+          host,
+          session: snapshot.sidebarRowsByKey.get(row.key)!,
+          display,
+        }),
+      onToggleSection: (sectionId) => host.toggleSection(sectionId),
+      // aria-expanded must land on the one header whose menu is open, so the
+      // catalog id rides on the trigger's data attribute instead of a global flag.
+      viewMenuOpenCatalogId: host.sidebarMenus.catalogViewMenuPosition
+        ? (host.sidebarMenus.catalogViewMenuTrigger?.getAttribute(
+            "data-session-catalog-view-menu",
+          ) ?? null)
+        : null,
+      creatorFilterActive: host.sessionCreatorFilterActive,
+      onOpenViewMenu: (trigger) => host.sidebarMenus.toggleCatalogViewMenu(trigger),
+      onLoadMore: (catalogId) => void host.sessionData.loadMoreSessionCatalog(catalogId),
+      onOpenNewSession: host.onOpenNewSession,
+      onNavigate: host.onNavigate,
+      catalogOpenTarget: snapshot.catalogOpenTarget,
+      terminalAvailable: snapshot.terminalAvailable,
+      onOpenTerminal: openCatalogSessionInTerminal,
+      onOpenMenu: (request, x, y, trigger) => host.openCatalogMenu(request, x, y, trigger),
+    })}
+  `;
 }
 
 function renderSessionListBody(params: {
@@ -443,7 +453,8 @@ export function renderSessionList(params: {
               ? nothing
               : html`${renderSessionCatalogs({ host, snapshot: params.catalogs })}`,
           codingTrailingPresent:
-            host.sessionsStatusFilter !== "archived" && params.catalogs.catalogs.length > 0,
+            host.sessionsStatusFilter !== "archived" &&
+            (params.catalogs.catalogs.length > 0 || params.catalogs.refreshStatus.error !== null),
         })}
         ${host.sessionsStatusFilter === "archived" && params.empty
           ? html`<span class="sidebar-session-empty-hint"

--- a/ui/src/components/app-sidebar-session-row-render.ts
+++ b/ui/src/components/app-sidebar-session-row-render.ts
@@ -48,6 +48,8 @@ export interface SessionListHost {
     | "loadMoreSessionCatalog"
     | "presenceInstanceId"
     | "presencePayload"
+    | "refreshSessionCatalogs"
+    | "sessionCatalogRefreshStatus"
     | "sessionMutationError"
   >;
   readonly fullyShownChildSessionKeys: ReadonlySet<string>;

--- a/ui/src/components/app-sidebar.test.ts
+++ b/ui/src/components/app-sidebar.test.ts
@@ -8,6 +8,7 @@ import "../test-helpers/app-sidebar-cases/catalog-compat.ts";
 import "../test-helpers/app-sidebar-cases/catalog-live-events.ts";
 import "../test-helpers/app-sidebar-cases/catalog-project-activity.ts";
 import "../test-helpers/app-sidebar-cases/catalog-live.ts";
+import "../test-helpers/app-sidebar-cases/catalog-live-errors.ts";
 import "../test-helpers/app-sidebar-cases/catalog-live-state.ts";
 import "../test-helpers/app-sidebar-cases/catalog-pages.ts";
 import "../test-helpers/app-sidebar-cases/child-sessions-cap.ts";

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -327,6 +327,7 @@ class AppSidebar extends AppSidebarSessionNavigationElement implements SessionLi
         normalizeAgentId(this.draftSessionAgentId) === expandedAgentId,
       catalogs: {
         catalogs: this.sessionData.sessionCatalogs,
+        refreshStatus: this.sessionData.sessionCatalogRefreshStatus,
         basePath: this.basePath,
         routeSessionKey: this.activeRouteId === "chat" ? this.getRouteSessionKey() : "",
         newSessionAgentId: expandedAgentId,

--- a/ui/src/components/session-data-controller-catalog.ts
+++ b/ui/src/components/session-data-controller-catalog.ts
@@ -17,6 +17,12 @@ import {
 } from "./app-sidebar-session-catalog-state.ts";
 import { sessionCatalogHostKey } from "./app-sidebar-session-types.ts";
 import type { SidebarSessionStatusFilter } from "./app-sidebar-session-types.ts";
+import {
+  completePanelRefresh,
+  createPanelRefreshStatus,
+  failPanelRefresh,
+  type PanelRefreshStatus,
+} from "./panel-refresh-status.ts";
 
 export interface SessionDataControllerHost extends ReactiveControllerHost {
   readonly isConnected: boolean;
@@ -35,6 +41,7 @@ export interface SessionCatalogDataOwner {
   readonly isSessionDataHostConnected: boolean;
   readonly sessionDataHostConnected: boolean;
   sessionCatalogs: SessionCatalog[];
+  sessionCatalogRefreshStatus: PanelRefreshStatus;
   loadingMoreSessionCatalogIds: ReadonlySet<string>;
   readonly sessionCatalogLive: SessionCatalogLiveState;
   sessionCatalogAgentId: string | null;
@@ -68,6 +75,7 @@ export function synchronizeSessionCatalogAgent(
   owner.sessionCatalogGeneration += 1;
   owner.sessionCatalogRevision += 1;
   owner.sessionCatalogLive.clear();
+  owner.sessionCatalogRefreshStatus = createPanelRefreshStatus();
   owner.loadingMoreSessionCatalogIds = new Set();
   if (owner.sessionCatalogs.some((catalog) => catalog.capabilities.createSession)) {
     owner.sessionCatalogs = owner.sessionCatalogs.map((catalog) => {
@@ -141,6 +149,7 @@ export async function refreshSessionCatalogs(owner: SessionCatalogDataOwner): Pr
     connected: () => owner.isSessionDataHostConnected,
     applyFinal: (catalogs, revisedCatalogIds) => {
       owner.sessionCatalogs = catalogs;
+      owner.sessionCatalogRefreshStatus = completePanelRefresh();
       owner.requestSessionDataUpdate();
       for (const catalogId of revisedCatalogIds) {
         owner.sessionCatalogRevisions.set(
@@ -149,6 +158,13 @@ export async function refreshSessionCatalogs(owner: SessionCatalogDataOwner): Pr
         );
       }
       owner.sessionCatalogRevision += 1;
+    },
+    applyError: (error) => {
+      owner.sessionCatalogRefreshStatus = failPanelRefresh(
+        owner.sessionCatalogRefreshStatus,
+        sessionCatalogRequestError(error).message,
+      );
+      owner.requestSessionDataUpdate();
     },
     refresh: () => void owner.refreshSessionCatalogs(),
   });

--- a/ui/src/components/session-data-controller.ts
+++ b/ui/src/components/session-data-controller.ts
@@ -32,6 +32,7 @@ import {
   type SidebarSessionStatusFilter,
   type SidebarSessionsScrollState,
 } from "./app-sidebar-session-types.ts";
+import { createPanelRefreshStatus, type PanelRefreshStatus } from "./panel-refresh-status.ts";
 import {
   applySessionCatalogHostEvent as applySessionCatalogHostEventToData,
   loadMoreSessionCatalog as loadMoreSessionCatalogData,
@@ -46,6 +47,7 @@ import {
 /** Gateway-backed session-list and external-catalog data ownership. */
 export class SessionDataController implements ReactiveController, SessionCatalogDataOwner {
   sessionCatalogs: SessionCatalog[] = [];
+  sessionCatalogRefreshStatus: PanelRefreshStatus = createPanelRefreshStatus();
   loadingMoreSessionCatalogIds: ReadonlySet<string> = new Set();
   visibleSessionLimits = new Map<string, number>();
   sessionsResult: SessionsListResult | null = null;
@@ -251,6 +253,7 @@ export class SessionDataController implements ReactiveController, SessionCatalog
     this.sessionCatalogRevision += 1;
     this.sessionCatalogLive.resetConnection();
     this.sessionCatalogs = [];
+    this.sessionCatalogRefreshStatus = createPanelRefreshStatus();
     this.loadingMoreSessionCatalogIds = new Set();
     this.sessionCatalogPageDepths.clear();
     this.sessionCatalogRevisions.clear();

--- a/ui/src/test-helpers/app-sidebar-cases/catalog-live-errors.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/catalog-live-errors.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+import { GatewayRequestError, type GatewayBrowserClient } from "../../api/gateway.ts";
+import type { ApplicationGatewaySnapshot } from "../../app/context.ts";
+import { createGatewayHarness, createSessions, mountSidebar } from "../app-sidebar.ts";
+import "../../components/app-sidebar.ts";
+
+describe("AppSidebar session catalog request errors", () => {
+  it("does not retry unrelated INVALID_REQUEST failures and renders a local retry", async () => {
+    vi.useFakeTimers();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    try {
+      const request = vi.fn().mockRejectedValue(
+        new GatewayRequestError({
+          code: "INVALID_REQUEST",
+          message: 'unknown agent id "main"',
+        }),
+      );
+      const gateway = createGatewayHarness({ request } as unknown as GatewayBrowserClient);
+      gateway.publish({
+        hello: {
+          features: { methods: ["sessions.catalog.list"] },
+        } as ApplicationGatewaySnapshot["hello"],
+      });
+      const { sidebar } = await mountSidebar(
+        gateway.gateway,
+        createSessions("main", ["agent:main:main"]),
+      );
+      sidebar.connected = true;
+      await sidebar.updateComplete;
+      await vi.advanceTimersByTimeAsync(0);
+      await sidebar.updateComplete;
+
+      expect(request).toHaveBeenCalledTimes(1);
+      const error = sidebar.querySelector<HTMLElement>(".sidebar-session-catalog-error");
+      expect(error?.textContent).toContain('unknown agent id "main"');
+
+      error?.querySelector<HTMLButtonElement>("button")?.click();
+      await vi.advanceTimersByTimeAsync(0);
+      await sidebar.updateComplete;
+
+      expect(request).toHaveBeenCalledTimes(2);
+      expect(warn).toHaveBeenCalledTimes(1);
+    } finally {
+      warn.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+});

--- a/ui/src/test-helpers/app-sidebar-cases/catalog-live.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/catalog-live.ts
@@ -65,47 +65,6 @@ describe("AppSidebar session catalog pagination", () => {
     }
   });
 
-  it("does not retry unrelated INVALID_REQUEST failures and renders a local retry", async () => {
-    vi.useFakeTimers();
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
-    try {
-      const request = vi.fn().mockRejectedValue(
-        new GatewayRequestError({
-          code: "INVALID_REQUEST",
-          message: 'unknown agent id "main"',
-        }),
-      );
-      const gateway = createGatewayHarness({ request } as unknown as GatewayBrowserClient);
-      gateway.publish({
-        hello: {
-          features: { methods: ["sessions.catalog.list"] },
-        } as ApplicationGatewaySnapshot["hello"],
-      });
-      const { sidebar } = await mountSidebar(
-        gateway.gateway,
-        createSessions("main", ["agent:main:main"]),
-      );
-      sidebar.connected = true;
-      await sidebar.updateComplete;
-      await vi.advanceTimersByTimeAsync(0);
-      await sidebar.updateComplete;
-
-      expect(request).toHaveBeenCalledTimes(1);
-      const error = sidebar.querySelector<HTMLElement>(".sidebar-session-catalog-error");
-      expect(error?.textContent).toContain('unknown agent id "main"');
-
-      error?.querySelector<HTMLButtonElement>("button")?.click();
-      await vi.advanceTimersByTimeAsync(0);
-      await sidebar.updateComplete;
-
-      expect(request).toHaveBeenCalledTimes(2);
-      expect(warn).toHaveBeenCalledTimes(1);
-    } finally {
-      warn.mockRestore();
-      vi.useRealTimers();
-    }
-  });
-
   it("ignores a legacy fallback that settles after the Gateway client changes", async () => {
     vi.useFakeTimers();
     try {

--- a/ui/src/test-helpers/app-sidebar-cases/catalog-live.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/catalog-live.ts
@@ -24,7 +24,11 @@ describe("AppSidebar session catalog pagination", () => {
       const request = vi
         .fn()
         .mockRejectedValueOnce(
-          new GatewayRequestError({ code: "INVALID_REQUEST", message: "invalid params" }),
+          new GatewayRequestError({
+            code: "INVALID_REQUEST",
+            message:
+              "invalid sessions.catalog.list params: at root: unexpected property 'progressId'",
+          }),
         )
         .mockResolvedValue(catalogPage([]));
       const gateway = createGatewayHarness({ request } as unknown as GatewayBrowserClient);
@@ -61,6 +65,47 @@ describe("AppSidebar session catalog pagination", () => {
     }
   });
 
+  it("does not retry unrelated INVALID_REQUEST failures and renders a local retry", async () => {
+    vi.useFakeTimers();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    try {
+      const request = vi.fn().mockRejectedValue(
+        new GatewayRequestError({
+          code: "INVALID_REQUEST",
+          message: 'unknown agent id "main"',
+        }),
+      );
+      const gateway = createGatewayHarness({ request } as unknown as GatewayBrowserClient);
+      gateway.publish({
+        hello: {
+          features: { methods: ["sessions.catalog.list"] },
+        } as ApplicationGatewaySnapshot["hello"],
+      });
+      const { sidebar } = await mountSidebar(
+        gateway.gateway,
+        createSessions("main", ["agent:main:main"]),
+      );
+      sidebar.connected = true;
+      await sidebar.updateComplete;
+      await vi.advanceTimersByTimeAsync(0);
+      await sidebar.updateComplete;
+
+      expect(request).toHaveBeenCalledTimes(1);
+      const error = sidebar.querySelector<HTMLElement>(".sidebar-session-catalog-error");
+      expect(error?.textContent).toContain('unknown agent id "main"');
+
+      error?.querySelector<HTMLButtonElement>("button")?.click();
+      await vi.advanceTimersByTimeAsync(0);
+      await sidebar.updateComplete;
+
+      expect(request).toHaveBeenCalledTimes(2);
+      expect(warn).toHaveBeenCalledTimes(1);
+    } finally {
+      warn.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
   it("ignores a legacy fallback that settles after the Gateway client changes", async () => {
     vi.useFakeTimers();
     try {
@@ -68,7 +113,11 @@ describe("AppSidebar session catalog pagination", () => {
       const legacyRequest = vi
         .fn()
         .mockRejectedValueOnce(
-          new GatewayRequestError({ code: "INVALID_REQUEST", message: "invalid params" }),
+          new GatewayRequestError({
+            code: "INVALID_REQUEST",
+            message:
+              "invalid sessions.catalog.list params: at root: unexpected property 'progressId'",
+          }),
         )
         .mockReturnValueOnce(legacyFallback.promise);
       const legacyGateway = createGatewayHarness({


### PR DESCRIPTION
## What Problem This Solves

On a gateway whose configured agent roster changed while tabs were open (production case: `agents.entries.main` was removed, leaving only `roboclaw`), the Control UI keeps issuing agent-scoped RPCs with the stale agent id and hides every resulting failure:

- `sessions.catalog.list` fails with `unknown agent id "main"`, but the progressive-list helper misclassifies **any** `INVALID_REQUEST` as the legacy "old gateway rejects `progressId`" case ([app-sidebar-session-catalog-live.ts](ui/src/components/app-sidebar-session-catalog-live.ts)), retries without `progressId` (doubling every failing poll), then swallows the error in a bare `catch`. The sidebar catalog silently stays empty — users read it as "my coding sessions are gone".
- The selection self-heal in `app-host.ts` only fired when the tab *observed* the roster transition (`previousIds.has(activeAgentId)`); a cold page load after the change never recovered, so `chat.metadata` / `commands.list` kept erroring on every refresh.

Observed live on team.openclaw.ai on 2026-07-26 (journal: repeated `res ✗ sessions.catalog.list … unknown agent id "main"` with zero UI feedback).

## Why This Change Was Made

- `reconcileSelectedId` in [agent-selection.ts](ui/src/app/agent-selection.ts) now resets a selected agent id that is absent from the roster to the roster default, moving the page scope with it, so agent-scoped RPCs never target a dead agent.
- The cold-load guard in [app-host.ts](ui/src/app/app-host.ts) no longer requires having watched the agent disappear; any non-empty roster that lacks the active agent triggers the reset.
- `isLegacyProgressIdRejection` narrows the catalog retry to genuine legacy-gateway `progressId` rejections; other errors surface through the existing `panel-refresh-status` pattern (inline error + retry affordance) instead of a bare catch, with one deduped `console.warn` per distinct error.

## User Impact

Users whose gateway lost/renamed an agent see their session list again (scoped to the current default agent) instead of a silently empty sidebar, and genuine catalog failures now render an error with a retry button instead of nothing.

## Evidence

- Focused tests: `node scripts/run-vitest.mjs ui/src/components/app-sidebar.test.ts ui/src/app/agent-selection` → 2 files, 181 tests passed (includes new cases: cold-load self-heal, progressId-retry narrowing, catalog error state).
- Production forensics in the PR discussion: session-catalog polls failing with `unknown agent id "main"` every ~2 s per tab with no user-visible error.
