### PR TITLE
fix(openrouter): reject malformed base64 audio in music generation

### DIFF
--- a/extensions/openrouter/music-generation-provider.test.ts
+++ b/extensions/openrouter/music-generation-provider.test.ts
@@ -211,6 +211,29 @@ describe("openrouter music generation provider", () => {
     expect(release).toHaveBeenCalledOnce();
   });
 
+  it("rejects malformed base64 audio in streamed OpenRouter deltas", async () => {
+    const release = vi.fn(async () => {});
+    postJsonRequestMock.mockResolvedValue({
+      response: sseResponse([
+        `data: ${JSON.stringify({ choices: [{ delta: { audio: { data: "%%%not-base64!!" } } }] })}\n`,
+        "data: [DONE]\n",
+      ]),
+      release,
+    });
+
+    await expect(
+      buildOpenRouterMusicGenerationProvider().generateMusic({
+        provider: "openrouter",
+        model: "",
+        prompt: "bright soundtrack",
+        cfg: {},
+        instrumental: true,
+        format: "wav",
+      }),
+    ).rejects.toThrow("OpenRouter music generation returned malformed base64 audio data");
+    expect(release).toHaveBeenCalledOnce();
+  });
+
   it("preserves completed OpenRouter audio when reader cleanup fails", async () => {
     const cancel = vi.fn(async () => {
       throw new Error("cancel failed");

--- a/extensions/openrouter/music-generation-provider.ts
+++ b/extensions/openrouter/music-generation-provider.ts
@@ -1,6 +1,7 @@
 // Openrouter provider module implements model/runtime integration.
 import { toImageDataUrl } from "openclaw/plugin-sdk/image-generation";
 import { resolveGeneratedMediaMaxBytes } from "openclaw/plugin-sdk/media-generation-runtime";
+import { canonicalizeBase64 } from "openclaw/plugin-sdk/media-runtime";
 import type {
   MusicGenerationProvider,
   MusicGenerationRequest,
@@ -140,11 +141,15 @@ function appendDecodedOpenRouterMusicAudio(
   if (!base64) {
     return;
   }
-  const decodedBytes = Buffer.byteLength(base64, "base64");
+  const canonicalAudio = canonicalizeBase64(base64);
+  if (!canonicalAudio) {
+    throw new Error("OpenRouter music generation returned malformed base64 audio data");
+  }
+  const decodedBytes = Buffer.byteLength(canonicalAudio, "base64");
   if (decodedBytes > result.maxBytes - result.audioBytes) {
     throw createOpenRouterMusicTooLargeError("audio", result.maxBytes);
   }
-  const buffer = Buffer.from(base64, "base64");
+  const buffer = Buffer.from(canonicalAudio, "base64");
   const nextBytes = result.audioBytes + buffer.byteLength;
   if (nextBytes > result.maxBytes) {
     throw createOpenRouterMusicTooLargeError("audio", result.maxBytes);


### PR DESCRIPTION
## Summary

OpenRouter music generation now rejects malformed base64 audio deltas instead of silently decoding them into corrupted track bytes on the SSE inbound path.

## What Problem This Solves

Node's `Buffer.from(value, "base64")` is lenient: it drops characters outside the base64 alphabet without throwing. OpenRouter streams `delta.audio.data` as slices of one base64 stream; the accumulator decodes each complete-quartet slice straight into the track buffers without validating the alphabet/padding. A damaged or non-base64 slice (proxy truncation, gateway error page, provider-side bug) becomes garbage bytes inside the returned music track, with no error surfaced — and the same unvalidated input feeds the media-cap size estimate.

**Code evidence**: in `extensions/openrouter/music-generation-provider.ts`, `appendDecodedOpenRouterMusicAudio` estimates `Buffer.byteLength(base64, "base64")` and decodes `Buffer.from(base64, "base64")` with no validation; `appendOpenRouterMusicAudio` feeds it every inbound SSE audio slice.

## Root Cause

- Introduced by commit `ce6cb3b2502` ("fix(openrouter): bound music SSE buffering (#101488)", 2026-07-10), which added the streaming accumulator without payload validation.
- Violated invariant: base64 payloads received over the network must be validated before decoding; `Buffer.from(x, "base64")` never throws, so an unchecked call conflates "decodable" with "valid". The repo already encodes this invariant as `canonicalizeBase64` (used by `extensions/xai/tts.ts`, `extensions/minimax/image-generation-provider.ts`, and others).
- Trigger condition: any syntactically invalid base64 in a `delta.audio.data` slice (or in the final flushed remainder).

## Why This Fix

- Validate with the shared `canonicalizeBase64` helper in `appendDecodedOpenRouterMusicAudio` and throw `OpenRouter music generation returned malformed base64 audio data` — the exact pattern used by the sibling fixes above.
- The helper is stream-safe for this path: complete-quartet slices pass through unchanged, a 2–3 character unpadded final remainder is re-padded exactly like the lenient decoder, and only genuinely invalid payloads (bad alphabet/padding/length) are rejected. Arbitrary provider chunk boundaries keep working.
- The size-cap checks now run on the canonical payload, so dirty data can no longer evade `maxBytes`.
- Alternatives considered: skipping malformed slices (rejected: silently produces gapped audio and hides provider corruption); validating only at stream end (rejected: corrupted bytes would already be buffered into the track).

## User Impact

- Before: a malformed audio delta becomes garbage bytes inside the returned music track.
- After: the generation fails fast with "OpenRouter music generation returned malformed base64 audio data"; no corrupted track is produced.

## Evidence

- TDD red: the new regression test failed on unmodified code — the generation resolved instead of rejecting.
- Real runtime before (unmodified `upstream/main` code): driving the real `buildOpenRouterMusicGenerationProvider().generateMusic` against a real local SSE server streaming `delta.audio.data="%%%not-base64!!"` returned a 6-byte garbage track (`"��~m�\u001e"`). The request traveled the production fetch path end to end: the guarded fetch auto-upgraded to trusted env-proxy mode, issued `CONNECT` to a local forward proxy, and reached the SSE server — no test mocks involved.
- Real runtime after (fixed code): the identical runtime setup made `generateMusic` throw `OpenRouter music generation returned malformed base64 audio data`.
- Focused green: `node scripts/test-projects.mjs extensions/openrouter` — 13 test files, 134 tests passed.
- `oxfmt --check` on the changed files passed; `git diff --check` clean.

## Real Behavior Proof

The proof drives the real provider runtime (no test mocks): a local SSE API server streams the malformed delta, and a local HTTP forward proxy carries the provider's guarded fetch to it (env-proxy mode, exercised exactly as in proxy-required deployments). Hostname shown as `openrouter-proof.test`; the proxy tunnels it to the loopback server.

### Before (on main)

```bash
$ node --import tsx proof.mjs
fake api on 127.0.0.1:<port>, forward proxy on 127.0.0.1:<port>
proxy CONNECT: openrouter-proof.test:<port> -> 127.0.0.1
api server received: POST /chat/completions
generateMusic returned track: 6 bytes as utf8: "��~m�\u001e"
FAIL: malformed base64 delta was silently decoded into the track buffer
```

### After (with fix)

```bash
$ node --import tsx proof.mjs
fake api on 127.0.0.1:<port>, forward proxy on 127.0.0.1:<port>
proxy CONNECT: openrouter-proof.test:<port> -> 127.0.0.1
api server received: POST /chat/completions
generateMusic threw: OpenRouter music generation returned malformed base64 audio data
PASS: malformed base64 delta rejected instead of decoded
```

## Tests and Validation

- New regression test `rejects malformed base64 audio in streamed OpenRouter deltas` in `extensions/openrouter/music-generation-provider.test.ts`: streams one malformed `delta.audio.data` slice over the existing SSE harness and asserts the generation rejects with the malformed-data error (and releases the response).
- `node scripts/test-projects.mjs extensions/openrouter` — 13 files, 134 tests passed.
- `oxfmt --check extensions/openrouter/music-generation-provider.ts extensions/openrouter/music-generation-provider.test.ts` passed.
- Manual verification: real-runtime before/after runs above (provider runtime + guarded fetch + env-proxy tunnel + SSE server).
