### PR TITLE
fix(gateway): bound session observer digest attempts and stop unpersistable loops

### DIFF
--- a/src/gateway/session-observer-model.ts
+++ b/src/gateway/session-observer-model.ts
@@ -345,13 +345,16 @@ export async function synthesizeSessionObserverTerminalDigest(params: {
         return false;
       }
       try {
-        return await params.persistDigest({
+        // null means the store entry is gone (unpersistable session) — treat as
+        // a terminal false rather than a retryable failure.
+        const persisted = await params.persistDigest({
           sessionKey,
           sessionId,
           agentId,
           digest: candidate,
           stillCurrent: params.stillCurrent,
         });
+        return persisted === true;
       } catch (error) {
         lastError = error;
       }

--- a/src/gateway/session-observer-model.ts
+++ b/src/gateway/session-observer-model.ts
@@ -203,7 +203,7 @@ export type SessionObserverDeps = {
     /** Evaluated inside the entry updater so run rollover cannot commit a
      * digest from a replaced run between acceptance and the async write. */
     stillCurrent?: () => boolean;
-  }) => Promise<boolean>;
+  }) => Promise<boolean | null>;
   now?: () => number;
   setTimeoutFn?: typeof setTimeout;
   clearTimeoutFn?: typeof clearTimeout;
@@ -267,11 +267,13 @@ export async function defaultPersistDigest(params: {
   agentId: string;
   digest: SessionObserverDigest;
   stillCurrent?: () => boolean;
-}): Promise<boolean> {
+}): Promise<boolean | null> {
+  let missingEntry = false;
   const result = await patchSessionEntry(
     { sessionKey: params.sessionKey, agentId: params.agentId },
     (entry, context) => {
       if (!context.existingEntry) {
+        missingEntry = true;
         return null;
       }
       if (params.stillCurrent?.() === false) {
@@ -287,7 +289,10 @@ export async function defaultPersistDigest(params: {
     },
     { preserveActivity: true },
   );
-  return result != null;
+  if (result) {
+    return true;
+  }
+  return missingEntry ? null : false;
 }
 
 export function isTerminalLifecycleEvent(event: AgentEventPayload): boolean {

--- a/src/gateway/session-observer-persistence.test.ts
+++ b/src/gateway/session-observer-persistence.test.ts
@@ -38,6 +38,7 @@ describe("session observer digest persistence", () => {
       now: () => now,
       persistDigest,
       stillCurrent: () => () => true,
+      onMissingEntry: vi.fn(),
       onError: vi.fn(),
     });
     const session = state();

--- a/src/gateway/session-observer-persistence.ts
+++ b/src/gateway/session-observer-persistence.ts
@@ -9,6 +9,7 @@ export function createSessionObserverDigestPersister(params: {
   now: () => number;
   persistDigest: PersistDigest;
   stillCurrent: (runId: string, sessionKey: string) => () => boolean;
+  onMissingEntry: (state: SessionObserverState) => void;
   onError: (state: SessionObserverState, error: unknown) => void;
 }) {
   const preamblePersistedAt = new WeakMap<SessionObserverState, number>();
@@ -36,6 +37,10 @@ export function createSessionObserverDigestPersister(params: {
           digest,
           stillCurrent: params.stillCurrent(state.runId, state.sessionKey),
         });
+        if (accepted === null) {
+          params.onMissingEntry(state);
+          return;
+        }
         if (accepted) {
           if (kind === "preamble") {
             preamblePersistedAt.set(state, params.now());

--- a/src/gateway/session-observer.digest-budget.test.ts
+++ b/src/gateway/session-observer.digest-budget.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createHarness,
+  event,
+  flushObserver,
+  modelMessage,
+  resetSessionObserverEventSequence,
+  startAndAddToolNotes,
+} from "./session-observer.test-utils.js";
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  resetSessionObserverEventSequence();
+});
+
+describe("session observer digest budget", () => {
+  it("accepts a model digest after the preamble generation advances", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    let resolveModel: ((value: ReturnType<typeof modelMessage>) => void) | undefined;
+    const completeModel = vi.fn(
+      () =>
+        new Promise<ReturnType<typeof modelMessage>>((resolve) => {
+          resolveModel = resolve;
+        }),
+    );
+    const harness = createHarness({ completeModel });
+    startAndAddToolNotes(harness.observer);
+    await vi.advanceTimersByTimeAsync(11_500);
+    harness.observer.handleEvent(
+      event({
+        stream: "item",
+        data: { kind: "preamble", phase: "update", progressText: "Checking files" },
+      }),
+    );
+    await vi.advanceTimersByTimeAsync(500);
+    expect(completeModel).toHaveBeenCalledOnce();
+
+    await vi.advanceTimersByTimeAsync(100);
+    harness.observer.handleEvent(
+      event({
+        stream: "item",
+        data: { kind: "preamble", phase: "update", progressText: "Running focused tests" },
+      }),
+    );
+    resolveModel?.(modelMessage({ headline: "Stale model summary", health: "on-track" }));
+    await flushObserver();
+    expect(harness.broadcastToConnIds.mock.calls.at(-1)?.[1]).toMatchObject({
+      headline: "Stale model summary",
+    });
+    await vi.advanceTimersByTimeAsync(1_900);
+    expect(harness.broadcastToConnIds.mock.calls.at(-1)?.[1]).toMatchObject({
+      headline: "Stale model summary",
+    });
+    harness.observer.dispose();
+  });
+
+  it("stops live model attempts at the budget when requests are superseded", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    let utilityModelRef = "openai/gpt-a";
+    const completeModel = vi.fn(
+      () =>
+        new Promise<never>(() => {
+          // Each request is superseded through the model slot before it completes.
+        }),
+    );
+    const harness = createHarness({
+      completeModel,
+      resolveUtilityModelRef: vi.fn(() => utilityModelRef),
+    });
+    startAndAddToolNotes(harness.observer);
+    await vi.advanceTimersByTimeAsync(12_000);
+    expect(completeModel).toHaveBeenCalledOnce();
+
+    for (let attempt = 1; attempt <= 39; attempt += 1) {
+      utilityModelRef = "openai/gpt-b";
+      harness.observer.handleEvent(
+        event({ stream: "tool", data: { phase: "start", name: "read", args: { attempt } } }),
+      );
+      utilityModelRef = "openai/gpt-a";
+      harness.observer.handleEvent(
+        event({ stream: "tool", data: { phase: "start", name: "read", args: { attempt } } }),
+      );
+      await flushObserver();
+      if (attempt === 39) {
+        break;
+      }
+      for (let note = 0; note < 4; note += 1) {
+        harness.observer.handleEvent(
+          event({
+            stream: "tool",
+            data: { phase: "start", name: "read", args: { attempt, note } },
+          }),
+        );
+      }
+      await vi.advanceTimersByTimeAsync(12_000);
+      expect(completeModel).toHaveBeenCalledTimes(attempt + 1);
+    }
+
+    startAndAddToolNotes(harness.observer, { count: 4 });
+    await vi.advanceTimersByTimeAsync(24_000);
+    expect(completeModel).toHaveBeenCalledTimes(39);
+    harness.observer.dispose();
+  });
+
+  it("disables model work when digest persistence reports a missing entry", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const persistDigest = vi.fn(async () => null);
+    const harness = createHarness({ persistDigest });
+    startAndAddToolNotes(harness.observer);
+
+    await vi.advanceTimersByTimeAsync(12_000);
+    await flushObserver();
+    expect(harness.completeModel).toHaveBeenCalledOnce();
+    expect(persistDigest).toHaveBeenCalledOnce();
+    expect(vi.getTimerCount()).toBe(0);
+
+    startAndAddToolNotes(harness.observer, { count: 4 });
+    await vi.advanceTimersByTimeAsync(24_000);
+    expect(harness.completeModel).toHaveBeenCalledOnce();
+    harness.observer.dispose();
+  });
+});

--- a/src/gateway/session-observer.test.ts
+++ b/src/gateway/session-observer.test.ts
@@ -243,47 +243,6 @@ describe("session observer", () => {
     harness.observer.dispose();
   });
 
-  it("accepts a model digest after the preamble generation advances", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(0);
-    let resolveModel: ((value: ReturnType<typeof modelMessage>) => void) | undefined;
-    const completeModel = vi.fn(
-      () =>
-        new Promise<ReturnType<typeof modelMessage>>((resolve) => {
-          resolveModel = resolve;
-        }),
-    );
-    const harness = createHarness({ completeModel });
-    startAndAddToolNotes(harness.observer);
-    await vi.advanceTimersByTimeAsync(11_500);
-    harness.observer.handleEvent(
-      event({
-        stream: "item",
-        data: { kind: "preamble", phase: "update", progressText: "Checking files" },
-      }),
-    );
-    await vi.advanceTimersByTimeAsync(500);
-    expect(completeModel).toHaveBeenCalledOnce();
-
-    await vi.advanceTimersByTimeAsync(100);
-    harness.observer.handleEvent(
-      event({
-        stream: "item",
-        data: { kind: "preamble", phase: "update", progressText: "Running focused tests" },
-      }),
-    );
-    resolveModel?.(modelMessage({ headline: "Stale model summary", health: "on-track" }));
-    await flushObserver();
-    expect(harness.broadcastToConnIds.mock.calls.at(-1)?.[1]).toMatchObject({
-      headline: "Stale model summary",
-    });
-    await vi.advanceTimersByTimeAsync(1_900);
-    expect(harness.broadcastToConnIds.mock.calls.at(-1)?.[1]).toMatchObject({
-      headline: "Stale model summary",
-    });
-    harness.observer.dispose();
-  });
-
   it("aborts a live assessment when the run becomes terminal", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(0);
@@ -543,74 +502,6 @@ describe("session observer", () => {
       | SessionObserverDigest
       | undefined;
     expect(finalDigest?.health).toBe("done");
-    harness.observer.dispose();
-  });
-
-  it("stops live model attempts at the budget when requests are superseded", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(0);
-    let utilityModelRef = "openai/gpt-a";
-    const completeModel = vi.fn(
-      () =>
-        new Promise<never>(() => {
-          // Each request is superseded through the model slot before it completes.
-        }),
-    );
-    const harness = createHarness({
-      completeModel,
-      resolveUtilityModelRef: vi.fn(() => utilityModelRef),
-    });
-    startAndAddToolNotes(harness.observer);
-    await vi.advanceTimersByTimeAsync(12_000);
-    expect(completeModel).toHaveBeenCalledOnce();
-
-    for (let attempt = 1; attempt <= 39; attempt += 1) {
-      utilityModelRef = "openai/gpt-b";
-      harness.observer.handleEvent(
-        event({ stream: "tool", data: { phase: "start", name: "read", args: { attempt } } }),
-      );
-      utilityModelRef = "openai/gpt-a";
-      harness.observer.handleEvent(
-        event({ stream: "tool", data: { phase: "start", name: "read", args: { attempt } } }),
-      );
-      await flushObserver();
-      if (attempt === 39) {
-        break;
-      }
-      for (let note = 0; note < 4; note += 1) {
-        harness.observer.handleEvent(
-          event({
-            stream: "tool",
-            data: { phase: "start", name: "read", args: { attempt, note } },
-          }),
-        );
-      }
-      await vi.advanceTimersByTimeAsync(12_000);
-      expect(completeModel).toHaveBeenCalledTimes(attempt + 1);
-    }
-
-    startAndAddToolNotes(harness.observer, { count: 4 });
-    await vi.advanceTimersByTimeAsync(24_000);
-    expect(completeModel).toHaveBeenCalledTimes(39);
-    harness.observer.dispose();
-  });
-
-  it("disables model work when digest persistence reports a missing entry", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(0);
-    const persistDigest = vi.fn(async () => null);
-    const harness = createHarness({ persistDigest });
-    startAndAddToolNotes(harness.observer);
-
-    await vi.advanceTimersByTimeAsync(12_000);
-    await flushObserver();
-    expect(harness.completeModel).toHaveBeenCalledOnce();
-    expect(persistDigest).toHaveBeenCalledOnce();
-    expect(vi.getTimerCount()).toBe(0);
-
-    startAndAddToolNotes(harness.observer, { count: 4 });
-    await vi.advanceTimersByTimeAsync(24_000);
-    expect(harness.completeModel).toHaveBeenCalledOnce();
     harness.observer.dispose();
   });
 

--- a/src/gateway/session-observer.test.ts
+++ b/src/gateway/session-observer.test.ts
@@ -243,7 +243,7 @@ describe("session observer", () => {
     harness.observer.dispose();
   });
 
-  it("does not let an older model result overwrite a newer preamble", async () => {
+  it("accepts a model digest after the preamble generation advances", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(0);
     let resolveModel: ((value: ReturnType<typeof modelMessage>) => void) | undefined;
@@ -274,14 +274,12 @@ describe("session observer", () => {
     );
     resolveModel?.(modelMessage({ headline: "Stale model summary", health: "on-track" }));
     await flushObserver();
-    expect(
-      harness.broadcastToConnIds.mock.calls.some(
-        (call) => (call[1] as SessionObserverDigest).headline === "Stale model summary",
-      ),
-    ).toBe(false);
+    expect(harness.broadcastToConnIds.mock.calls.at(-1)?.[1]).toMatchObject({
+      headline: "Stale model summary",
+    });
     await vi.advanceTimersByTimeAsync(1_900);
     expect(harness.broadcastToConnIds.mock.calls.at(-1)?.[1]).toMatchObject({
-      headline: "Running focused tests",
+      headline: "Stale model summary",
     });
     harness.observer.dispose();
   });
@@ -545,6 +543,74 @@ describe("session observer", () => {
       | SessionObserverDigest
       | undefined;
     expect(finalDigest?.health).toBe("done");
+    harness.observer.dispose();
+  });
+
+  it("stops live model attempts at the budget when requests are superseded", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    let utilityModelRef = "openai/gpt-a";
+    const completeModel = vi.fn(
+      () =>
+        new Promise<never>(() => {
+          // Each request is superseded through the model slot before it completes.
+        }),
+    );
+    const harness = createHarness({
+      completeModel,
+      resolveUtilityModelRef: vi.fn(() => utilityModelRef),
+    });
+    startAndAddToolNotes(harness.observer);
+    await vi.advanceTimersByTimeAsync(12_000);
+    expect(completeModel).toHaveBeenCalledOnce();
+
+    for (let attempt = 1; attempt <= 39; attempt += 1) {
+      utilityModelRef = "openai/gpt-b";
+      harness.observer.handleEvent(
+        event({ stream: "tool", data: { phase: "start", name: "read", args: { attempt } } }),
+      );
+      utilityModelRef = "openai/gpt-a";
+      harness.observer.handleEvent(
+        event({ stream: "tool", data: { phase: "start", name: "read", args: { attempt } } }),
+      );
+      await flushObserver();
+      if (attempt === 39) {
+        break;
+      }
+      for (let note = 0; note < 4; note += 1) {
+        harness.observer.handleEvent(
+          event({
+            stream: "tool",
+            data: { phase: "start", name: "read", args: { attempt, note } },
+          }),
+        );
+      }
+      await vi.advanceTimersByTimeAsync(12_000);
+      expect(completeModel).toHaveBeenCalledTimes(attempt + 1);
+    }
+
+    startAndAddToolNotes(harness.observer, { count: 4 });
+    await vi.advanceTimersByTimeAsync(24_000);
+    expect(completeModel).toHaveBeenCalledTimes(39);
+    harness.observer.dispose();
+  });
+
+  it("disables model work when digest persistence reports a missing entry", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const persistDigest = vi.fn(async () => null);
+    const harness = createHarness({ persistDigest });
+    startAndAddToolNotes(harness.observer);
+
+    await vi.advanceTimersByTimeAsync(12_000);
+    await flushObserver();
+    expect(harness.completeModel).toHaveBeenCalledOnce();
+    expect(persistDigest).toHaveBeenCalledOnce();
+    expect(vi.getTimerCount()).toBe(0);
+
+    startAndAddToolNotes(harness.observer, { count: 4 });
+    await vi.advanceTimersByTimeAsync(24_000);
+    expect(harness.completeModel).toHaveBeenCalledOnce();
     harness.observer.dispose();
   });
 

--- a/src/gateway/session-observer.ts
+++ b/src/gateway/session-observer.ts
@@ -666,6 +666,8 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
       state.terminalHealth = terminalHealthFor(event);
       disabledRuns.delete(event.runId);
       const endedAt = readFiniteNumber(event.data.endedAt) ?? now();
+      // previousDigest is set on every ACCEPTED digest of this run; digestCount now
+      // counts attempts (budget), so it no longer implies any digest was published.
       const hasRunDigest = state.previousDigest?.runId === state.runId;
       if (!hasRunDigest && endedAt - state.startedAt < FINAL_DIGEST_MIN_RUN_MS) {
         dormantRuns.delete(state.runId);

--- a/src/gateway/session-observer.ts
+++ b/src/gateway/session-observer.ts
@@ -104,6 +104,10 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
     now,
     persistDigest,
     stillCurrent: runStillCurrent,
+    onMissingEntry: (state) => {
+      // An unpersistable session must not re-bill the utility model every cycle.
+      disableModelForRun(state);
+    },
     onError: (state, error) => {
       observerLog.warn("session observer digest persistence failed", {
         sessionKey: state.sessionKey,
@@ -343,8 +347,13 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
     state.inFlight = true;
     state.lastRunAt = now();
     const lastSelectedSequence = selectedNotes.at(-1)?.sequence ?? state.lastDigestNoteSequence;
-    const requestedPreambleGeneration = preamblePublisher.generation(state);
+    const retireSelectedNotes = () => {
+      // Run rollover replaces the state object, and inFlight serializes its slots;
+      // stale work can only retire this run's own notes, monotonically.
+      state.lastDigestNoteSequence = Math.max(state.lastDigestNoteSequence, lastSelectedSequence);
+    };
     const requestGeneration = modelSlots.beginRequest(state);
+    state.digestCount += 1;
     void (async () => {
       try {
         const modelDigest = await requestModelDigest(
@@ -354,9 +363,9 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
         const stale =
           !modelStateIsCurrent(state) ||
           !modelSlots.requestIsCurrent(state, requestGeneration) ||
-          (!final && state.terminalHealth !== undefined) ||
-          preamblePublisher.generation(state) !== requestedPreambleGeneration;
+          (!final && state.terminalHealth !== undefined);
         if (stale) {
+          retireSelectedNotes();
           if (final && states.get(state.sessionKey) === state) {
             void synthesizeTerminalDigest({ state });
             dormantRuns.delete(state.runId);
@@ -375,8 +384,7 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
         preamblePublisher.clear(state);
         state.consecutiveFailures = 0;
         state.revision += 1;
-        state.digestCount += 1;
-        state.lastDigestNoteSequence = lastSelectedSequence;
+        retireSelectedNotes();
         const digest: SessionObserverDigest = {
           sessionKey: state.sessionKey,
           runId: state.runId,
@@ -410,6 +418,7 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
           !modelSlots.requestIsCurrent(state, requestGeneration) ||
           (!final && state.terminalHealth !== undefined);
         if (stale) {
+          retireSelectedNotes();
           if (final && states.get(state.sessionKey) === state) {
             void synthesizeTerminalDigest({ state });
             dormantRuns.delete(state.runId);
@@ -657,7 +666,7 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
       state.terminalHealth = terminalHealthFor(event);
       disabledRuns.delete(event.runId);
       const endedAt = readFiniteNumber(event.data.endedAt) ?? now();
-      const hasRunDigest = state.digestCount > 0 || state.previousDigest?.runId === state.runId;
+      const hasRunDigest = state.previousDigest?.runId === state.runId;
       if (!hasRunDigest && endedAt - state.startedAt < FINAL_DIGEST_MIN_RUN_MS) {
         dormantRuns.delete(state.runId);
         dropState(state);


### PR DESCRIPTION
## What Problem This Solves

The Control-UI session observer could enter an unbounded model-call loop. On team.openclaw.ai (2026-07-26) the gateway POSTed `gpt-5.6-luna` every 2–5 seconds, indefinitely, across restarts, while producing zero digests — pegging the event loop (p99 delays 3–7.5 s) and burning real OpenAI spend.

Mechanism: Codex-backed sessions stream preambles constantly; every preamble bumped the generation that `runDigest` used for its staleness check, so nearly every completed digest was discarded. Discarded attempts consumed no budget (`MAX_DIGESTS_PER_RUN` counted accepts only), advanced no note cursor (the same notes stayed "pending"), and counted as no failure (`MAX_CONSECUTIVE_FAILURES` never tripped) — while `finally` always rescheduled. Separately, sessions whose store entry no longer exists (e.g. their agent was removed from `agents.entries`) could never persist a digest, only warned, and re-billed the model forever.

## Why This Change Was Made

- A completed digest is no longer discarded just because a newer preamble arrived; the digest publishes and the next one supersedes it. The remaining staleness clauses (superseded state/slot, terminal-during-flight) stand.
- `digestCount` now counts **attempts**, incremented before the model call, so the per-run budget is a real ceiling on model calls.
- Notes selected for an attempt are retired monotonically on every exit path (accept, stale, failure), so the same notes can never be re-billed.
- When persistence reports a missing store entry, the run's observer model is disabled (`disableModelForRun`) instead of warning and looping.
- The terminal short-run skip now keys on `previousDigest.runId` (set on every accepted digest) since `digestCount` no longer implies published output.

## User Impact

Gateways with active Codex sessions and an open Control UI tab stop generating a continuous background model-call stream. Observer digests still publish — more often than before, in fact, since completed digests are no longer thrown away.

## Evidence

- Production journal (team.openclaw.ai): `[model-fetch] … model=gpt-5.6-luna` every 2–5 s for hours; 0 calls in 10 minutes after disabling the observer; load average 13.8 → 0.4.
- Focused tests: `node scripts/run-vitest.mjs src/gateway/session-observer` → 69 passed (new cases: digest accepted despite preamble bump, attempts consume budget, missing-entry persist disables the run).
