### PR TITLE
fix(ui): make the detail panel sidebar scroll when content overflows

### DIFF
--- a/ui/src/pages/chat/components/chat-sidebar.ts
+++ b/ui/src/pages/chat/components/chat-sidebar.ts
@@ -1281,7 +1281,7 @@ class ChatDetailPanel extends OpenClawLightDomElement {
       ? Math.min(this.fileSearchMatchIndex, matches.length - 1)
       : 0;
     return html`
-      <div @click=${this.handlePanelClick}>
+      <div class="sidebar-detail-panel__frame" @click=${this.handlePanelClick}>
         ${renderMarkdownSidebar({
           content: this.visibleContent,
           error: this.error,

--- a/ui/src/styles/chat/sidebar.css
+++ b/ui/src/styles/chat/sidebar.css
@@ -1306,10 +1306,25 @@ openclaw-chat-sidebar-region,
 }
 
 /* Sidebar Panel */
+/*
+ * Frame wrapping the detail panel inside openclaw-chat-detail-panel.
+ * The host is bounded (flex: 1 1 0; min-height: 0; overflow: hidden), so this
+ * wrapper must be a flex column that fills it — otherwise it grows to content
+ * height and the bounded host clips it, leaving .sidebar-content unscrollable.
+ */
+.sidebar-detail-panel__frame {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 0;
+  min-width: 0;
+  min-height: 0;
+}
+
 .sidebar-panel {
   display: flex;
   flex-direction: column;
   height: 100%;
+  min-height: 0;
   background: var(--panel);
 }
 


### PR DESCRIPTION
## Problem
The markdown/file **detail panel** (`openclaw-chat-detail-panel`) never scrolls when its content is taller than the viewport — the content is clipped at the panel's bottom edge with no way to reach the rest. Reproduce by opening a long file/markdown preview in the sidebar (e.g. a workspace `.md` file) and trying to scroll.

## Root cause
The host element is correctly bounded:
```css
.sidebar-column__panel > :is(..., openclaw-chat-detail-panel, ...) {
  flex: 1 1 0; min-height: 0; overflow: hidden;
}
```
But `ChatDetailPanel.render()` wraps its body in an **unclassed** `<div>`:
```ts
<div @click=${this.handlePanelClick}>
  ${renderMarkdownSidebar(...)}   // <div class="sidebar-panel">…
</div>
```
That wrapper's default `flex: 0 1 auto` / `min-height: auto` let it grow to full content height, overflowing the bounded host — which then clips it. As a result `.sidebar-content` (`overflow: auto`) never receives a constrained height, so it can't scroll.

Verified in the live DOM: the wrapper is the only element in the chain that overflows (clientHeight 1578 vs scrollHeight 1759) while carrying no scroll.

## Fix
- Add a class `sidebar-detail-panel__frame` to the wrapper and style it as a flex column that fills the bounded host (`flex: 1 1 0; min-height: 0`).
- Add `min-height: 0` to `.sidebar-panel` so the height constraint cascades to `.sidebar-content`.

No behavior change beyond enabling scroll; the sticky `.sidebar-header` still sticks. Matches the existing `min-height: 0` idiom used throughout the sidebar layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
