### PR TITLE
fix(config): refuse roster writes that silently drop agent entries

### DIFF
--- a/src/commands/agents.commands.delete.ts
+++ b/src/commands/agents.commands.delete.ts
@@ -176,7 +176,10 @@ export async function agentsDeleteCommand(
   await replaceConfigFile({
     nextConfig: result.config,
     ...(baseHash !== undefined ? { baseHash } : {}),
-    writeOptions: opts.json ? { skipOutputLogs: true } : undefined,
+    writeOptions: {
+      allowedAgentRosterRemovals: [agentId],
+      ...(opts.json ? { skipOutputLogs: true } : {}),
+    },
   });
   if (!opts.json) {
     logConfigUpdated(runtime);

--- a/src/config/io.types.ts
+++ b/src/config/io.types.ts
@@ -45,6 +45,8 @@ export type ConfigWriteOptions = {
   explicitSetPaths?: readonly (readonly string[])[];
   /** Source-shaped values paired with explicitSetPaths. */
   explicitSetValueSource?: OpenClawConfig;
+  /** Agent ids that this write intentionally removes from the canonical roster. */
+  allowedAgentRosterRemovals?: readonly string[];
   /** Permit explicit local overrides below an ancestor $include without flattening it. */
   allowIncludeAncestorExplicitSetPaths?: boolean;
   /** Fresh snapshot fast path for an immediate write. */

--- a/src/config/io.write-prepare.test.ts
+++ b/src/config/io.write-prepare.test.ts
@@ -89,6 +89,88 @@ describe("config io write prepare", () => {
     });
   });
 
+  it("preserves roster siblings for an explicit agent leaf write", () => {
+    const current = {
+      agents: {
+        entries: {
+          main: { default: true },
+          worker: { workspace: "/srv/worker" },
+        },
+      },
+    } satisfies OpenClawConfig;
+    const nextConfig = {
+      agents: {
+        entries: {
+          main: { default: true },
+          worker: { workspace: "/srv/worker", default: false },
+        },
+      },
+    } satisfies OpenClawConfig;
+
+    const persisted = resolvePersistCandidateForWrite({
+      runtimeConfig: current,
+      sourceConfig: current,
+      rootAuthoredConfig: current,
+      nextConfig,
+      explicitSetPaths: [["agents", "entries", "worker", "default"]],
+      explicitSetValueSource: {
+        agents: { entries: { worker: { default: false } } },
+      },
+    }) as OpenClawConfig;
+
+    expect(persisted.agents?.entries).toEqual({
+      main: { default: true },
+      worker: { workspace: "/srv/worker", default: false },
+    });
+  });
+
+  it("rejects a canonical roster rewrite that silently drops an entry", () => {
+    const current = {
+      agents: {
+        entries: {
+          main: { default: true },
+          worker: { workspace: "/srv/worker" },
+        },
+      },
+    } satisfies OpenClawConfig;
+
+    expect(() =>
+      resolvePersistCandidateForWrite({
+        runtimeConfig: current,
+        sourceConfig: current,
+        rootAuthoredConfig: current,
+        nextConfig: {
+          agents: { entries: { worker: { workspace: "/srv/worker" } } },
+        },
+      }),
+    ).toThrow("Config write would drop agent roster entries without an explicit deletion: main.");
+  });
+
+  it("allows an explicitly authorized agent deletion from the canonical roster", () => {
+    const current = {
+      agents: {
+        entries: {
+          main: { default: true },
+          worker: { workspace: "/srv/worker" },
+        },
+      },
+    } satisfies OpenClawConfig;
+
+    const persisted = resolvePersistCandidateForWrite({
+      runtimeConfig: current,
+      sourceConfig: current,
+      rootAuthoredConfig: current,
+      nextConfig: {
+        agents: { entries: { worker: { workspace: "/srv/worker" } } },
+      },
+      allowedAgentRosterRemovals: ["main"],
+    }) as OpenClawConfig;
+
+    expect(persisted.agents?.entries).toEqual({
+      worker: { workspace: "/srv/worker" },
+    });
+  });
+
   it("replaces a complete legacy list atomically when the roster changes", () => {
     const entries = {
       main: { default: true },
@@ -574,6 +656,7 @@ describe("config io write prepare", () => {
       explicitSetValueSource: {
         agents: { list: [{ id: "primary", ...runtimeEntry }] },
       },
+      allowedAgentRosterRemovals: ["main"],
     }) as OpenClawConfig;
 
     expect(persisted.agents?.entries?.primary?.sandbox?.ssh?.identityData).toEqual(identityRef);
@@ -620,6 +703,7 @@ describe("config io write prepare", () => {
         agents: { list: [{ id: "primary", default: true }] },
       },
       unsetPaths: [["agents", "list", "0", "workspace"]],
+      allowedAgentRosterRemovals: ["main"],
     }) as OpenClawConfig;
 
     expect(persisted.agents?.entries).toEqual({ primary: { default: true } });
@@ -719,6 +803,7 @@ describe("config io write prepare", () => {
         },
       },
       unsetPaths: [["agents", "list", "0"]],
+      allowedAgentRosterRemovals: ["0"],
     }) as OpenClawConfig;
 
     expect(persisted.agents?.entries).toEqual({ main: { default: true } });
@@ -1067,6 +1152,7 @@ describe("config io write prepare", () => {
           },
         },
         unsetPaths: [["agents", "list", "1"]],
+        allowedAgentRosterRemovals: ["worker"],
       }) as OpenClawConfig,
       [["agents", "list", "1"]],
     );
@@ -1098,6 +1184,7 @@ describe("config io write prepare", () => {
         },
         nextConfig: { agents: { entries: { main: { default: true } } } },
         unsetPaths: [["agents", "list"]],
+        allowedAgentRosterRemovals: ["main"],
       }) as OpenClawConfig,
       [["agents", "list"]],
     );

--- a/src/config/io.write-prepare.ts
+++ b/src/config/io.write-prepare.ts
@@ -1007,6 +1007,34 @@ function shouldPersistCanonicalAgentRoster(params: {
   );
 }
 
+function assertCanonicalAgentRosterRetainsEntries(params: {
+  currentConfig: unknown;
+  canonicalConfig: unknown;
+  allowedRemovals?: readonly string[];
+}): void {
+  const allowedRemovals = new Set(
+    (params.allowedRemovals ?? []).map((agentId) => normalizeAgentId(agentId)),
+  );
+  const canonicalIds = new Set(
+    listAgentEntries(params.canonicalConfig as OpenClawConfig).map((entry) =>
+      normalizeAgentId(entry.id),
+    ),
+  );
+  const droppedIds = listAgentEntries(params.currentConfig as OpenClawConfig)
+    .filter((entry) => {
+      const agentId = normalizeAgentId(entry.id);
+      return !canonicalIds.has(agentId) && !allowedRemovals.has(agentId);
+    })
+    .map((entry) => entry.id)
+    .toSorted();
+  if (droppedIds.length === 0) {
+    return;
+  }
+  throw new Error(
+    `Config write would drop agent roster entries without an explicit deletion: ${droppedIds.join(", ")}.`,
+  );
+}
+
 type ProjectedRosterValue = { present: false } | { present: true; value: unknown };
 
 function containsAuthoredRosterReference(value: unknown): boolean {
@@ -1591,6 +1619,7 @@ export function resolvePersistCandidateForWrite(params: {
   unsetPaths?: readonly string[][];
   explicitSetPaths?: readonly (readonly string[])[];
   explicitSetValueSource?: unknown;
+  allowedAgentRosterRemovals?: readonly string[];
   allowIncludeAncestorExplicitSetPaths?: boolean;
   modelIdNormalizationPolicies?: ReadonlyMap<string, ManifestModelIdNormalizationProvider>;
 }): unknown {
@@ -1676,6 +1705,15 @@ export function resolvePersistCandidateForWrite(params: {
         persistedCandidate: persisted,
       })
     : persisted;
+  if (persistCanonicalRoster) {
+    // A roster rewrite must never drop entries the mutation did not explicitly delete.
+    // A 2026-07-25 production incident lost agents.entries.main twice through silent rewrites.
+    assertCanonicalAgentRosterRetainsEntries({
+      currentConfig: params.sourceConfig,
+      canonicalConfig: withPreservedIncludes,
+      allowedRemovals: params.allowedAgentRosterRemovals,
+    });
+  }
   const withSchema = preserveRootSchemaUri({
     rootAuthoredConfig,
     nextConfig: params.nextConfig,

--- a/src/config/io.write.ts
+++ b/src/config/io.write.ts
@@ -140,6 +140,7 @@ export async function writeConfigFileFromContext(
       unsetPaths,
       explicitSetPaths: options.explicitSetPaths,
       explicitSetValueSource: options.explicitSetValueSource,
+      allowedAgentRosterRemovals: options.allowedAgentRosterRemovals,
       allowIncludeAncestorExplicitSetPaths: options.allowIncludeAncestorExplicitSetPaths,
       modelIdNormalizationPolicies: resolveModelIdNormalizationPolicies(
         snapshotRead.pluginMetadataSnapshot,

--- a/src/gateway/server-methods/agents-config-mutations.ts
+++ b/src/gateway/server-methods/agents-config-mutations.ts
@@ -67,6 +67,7 @@ export async function deleteAgentConfigEntry(params: {
 }> {
   const committed = await mutateConfigFileWithRetry<AgentDeleteMutationResult | undefined>({
     afterWrite: { mode: "auto" },
+    writeOptions: { allowedAgentRosterRemovals: [params.agentId] },
     mutate: (draft) => {
       params.validateConfig?.(draft);
       const configured = isConfiguredAgent(draft, params.agentId);

--- a/src/gateway/server-methods/agents-mutate.test.ts
+++ b/src/gateway/server-methods/agents-mutate.test.ts
@@ -112,6 +112,7 @@ vi.mock("../../config/config.js", async () => {
       snapshot: { sourceConfig: mocks.loadConfigReturn },
     }),
     mutateConfigFileWithRetry: async (params: {
+      writeOptions?: unknown;
       mutate: (draft: Record<string, unknown>, context: unknown) => unknown;
     }) => {
       const draft = structuredClone(mocks.loadConfigReturn);
@@ -120,7 +121,7 @@ vi.mock("../../config/config.js", async () => {
         previousHash: "test-hash",
         attempt: 0,
       });
-      await mocks.writeConfigFile(draft);
+      await mocks.writeConfigFile(draft, params.writeOptions);
       return {
         path: "/tmp/openclaw/config.json",
         previousHash: "test-hash",
@@ -2746,6 +2747,9 @@ describe("agents.delete", () => {
       ]),
     );
     expect(mocks.writeConfigFile).toHaveBeenCalled();
+    expect(mocks.writeConfigFile).toHaveBeenCalledWith(expect.anything(), {
+      allowedAgentRosterRemovals: ["test-agent"],
+    });
     expect(mocks.movePathToTrash).toHaveBeenCalled();
   });
 

--- a/src/gateway/server-methods/agents-mutate.test.ts
+++ b/src/gateway/server-methods/agents-mutate.test.ts
@@ -17,7 +17,7 @@ const mocks = vi.hoisted(() => ({
   findAgentEntryIndex: vi.fn((_list?: unknown, _agentId?: string) => -1),
   applyAgentConfig: vi.fn((_cfg: unknown, _opts: unknown) => ({})),
   pruneAgentConfig: vi.fn(() => ({ config: {}, removedBindings: 0 })),
-  writeConfigFile: vi.fn(async (_nextConfig?: unknown) => {}),
+  writeConfigFile: vi.fn(async (_nextConfig?: unknown, _writeOptions?: unknown) => {}),
   omitConfigMutationResult: false,
   ensureAgentWorkspace: vi.fn(
     async (params?: { dir?: string }): Promise<{ dir: string; identityPathCreated: boolean }> => ({

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -18,6 +18,7 @@ import {
   validateConfigSchemaParams,
   validateConfigSetParams,
 } from "../../../packages/gateway-protocol/src/index.js";
+import { readAgentRosterProperty } from "../../agents/agent-scope-config.js";
 import {
   createConfigIO,
   parseConfigJson5,
@@ -41,6 +42,7 @@ import {
 import { isBuiltInModelProviderOverlayId } from "../../config/zod-schema.core.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { isPlainObject } from "../../infra/plain-object.js";
+import { normalizeAgentId } from "../../routing/session-key.js";
 import {
   isRetryableSecretDegradationReason,
   redactSecretDegradationReason,
@@ -478,6 +480,45 @@ function parseValidateConfigFromRawOrRespond(
   };
 }
 
+function listExplicitAgentRosterIds(config: OpenClawConfig): string[] {
+  const roster = readAgentRosterProperty(config);
+  if (roster?.kind === "entries" && isRecord(roster.value)) {
+    return Object.keys(roster.value);
+  }
+  if (roster?.kind !== "list" || !Array.isArray(roster.value)) {
+    return [];
+  }
+  return roster.value.flatMap((entry) =>
+    isRecord(entry) && typeof entry.id === "string" ? [entry.id] : [],
+  );
+}
+
+function rejectDroppedAgentRosterEntries(params: {
+  currentConfig: OpenClawConfig;
+  submittedConfig: OpenClawConfig;
+  respond: RespondFn;
+}): boolean {
+  const submittedIds = new Set(
+    listExplicitAgentRosterIds(params.submittedConfig).map((agentId) => normalizeAgentId(agentId)),
+  );
+  const droppedIds = listExplicitAgentRosterIds(params.currentConfig)
+    .filter((agentId) => !submittedIds.has(normalizeAgentId(agentId)))
+    .toSorted();
+  if (droppedIds.length === 0) {
+    return false;
+  }
+  params.respond(
+    false,
+    undefined,
+    errorShape(
+      ErrorCodes.INVALID_REQUEST,
+      `config.set would remove existing agent entries: ${droppedIds.join(", ")}. ` +
+        "Use the agents.delete RPC or `openclaw agents delete <id>` for intentional deletion.",
+    ),
+  );
+  return true;
+}
+
 function summarizeConfigValidationIssues(issues: ReadonlyArray<ConfigValidationIssue>): string {
   const trimmed = issues.slice(0, MAX_CONFIG_ISSUES_IN_ERROR_MESSAGE);
   const lines = normalizeStringEntries(
@@ -738,6 +779,15 @@ export const configHandlers: GatewayRequestHandlers = {
     const { snapshot, writeOptions } = writeSnapshot;
     const parsed = parseValidateConfigFromRawOrRespond(params, "config.set", snapshot, respond);
     if (!parsed) {
+      return;
+    }
+    if (
+      rejectDroppedAgentRosterEntries({
+        currentConfig: snapshot.config,
+        submittedConfig: parsed.config,
+        respond,
+      })
+    ) {
       return;
     }
     const preparedSecretsSnapshot = await ensureResolvableSecretRefsOrRespond({

--- a/src/gateway/server.config-patch.test.ts
+++ b/src/gateway/server.config-patch.test.ts
@@ -320,6 +320,89 @@ describe("gateway config methods", () => {
     requireConfigObject(res.payload?.config, "updated config");
   });
 
+  it("rejects config.set when a stale snapshot drops an agent entry without changing disk", async () => {
+    const { resetConfigRuntimeState } = await import("../config/config.js");
+    const original = await getCurrentConfigObject();
+    const rosterConfig = structuredClone(original.config);
+    const agents = requireConfigObject(rosterConfig.agents ?? {}, "agents config");
+    rosterConfig.agents = {
+      ...agents,
+      entries: {
+        main: { default: true },
+        worker: { workspace: "/srv/worker" },
+      },
+    };
+    delete (rosterConfig.agents as Record<string, unknown>).list;
+
+    try {
+      await writeJsonFile(original.path, rosterConfig);
+      resetConfigRuntimeState();
+      const current = await getCurrentConfigObject();
+      const staleConfig = structuredClone(current.config);
+      const staleAgents = requireConfigObject(staleConfig.agents, "stale agents config");
+      const staleEntries = requireConfigObject(staleAgents.entries, "stale agent entries");
+      delete staleEntries.worker;
+      const before = await fs.readFile(original.path, "utf-8");
+
+      const res = await sendConfigSet(configRawPayload(staleConfig, current.hash));
+
+      expect(res.ok).toBe(false);
+      expect(res.error?.code).toBe("INVALID_REQUEST");
+      expect(res.error?.message ?? "").toContain("worker");
+      expect(res.error?.message ?? "").toContain("agents.delete RPC");
+      expect(res.error?.message ?? "").toContain("openclaw agents delete");
+      await expect(fs.readFile(original.path, "utf-8")).resolves.toBe(before);
+    } finally {
+      await restoreConfigFileForTest(original);
+      resetConfigRuntimeState();
+    }
+  });
+
+  it("accepts config.set when the submitted roster keeps every agent entry", async () => {
+    const { resetConfigRuntimeState } = await import("../config/config.js");
+    const original = await getCurrentConfigObject();
+    const rosterConfig = structuredClone(original.config);
+    const agents = requireConfigObject(rosterConfig.agents ?? {}, "agents config");
+    rosterConfig.agents = {
+      ...agents,
+      entries: {
+        main: { default: true },
+        Worker: { workspace: "/srv/worker" },
+      },
+    };
+    delete (rosterConfig.agents as Record<string, unknown>).list;
+
+    try {
+      await writeJsonFile(original.path, rosterConfig);
+      resetConfigRuntimeState();
+      const current = await getCurrentConfigObject();
+      const submittedConfig = structuredClone(current.config);
+      const submittedAgents = requireConfigObject(
+        submittedConfig.agents,
+        "submitted agents config",
+      );
+      const submittedEntries = requireConfigObject(
+        submittedAgents.entries,
+        "submitted agent entries",
+      );
+      const worker = submittedEntries.Worker ?? submittedEntries.worker;
+      delete submittedEntries.Worker;
+      submittedEntries.worker = worker;
+
+      const res = await sendConfigSet(configRawPayload(submittedConfig, current.hash));
+
+      expect(res.error).toBeUndefined();
+      expect(res.ok).toBe(true);
+      const persisted = JSON.parse(await fs.readFile(original.path, "utf-8")) as {
+        agents?: { entries?: Record<string, unknown> };
+      };
+      expect(Object.keys(persisted.agents?.entries ?? {}).toSorted()).toEqual(["main", "worker"]);
+    } finally {
+      await restoreConfigFileForTest(original);
+      resetConfigRuntimeState();
+    }
+  });
+
   it("returns the persisted config from config.set responses", async () => {
     const current = await getCurrentConfigObject();
     const nextConfig = structuredClone(current.config);


### PR DESCRIPTION
## What Problem This Solves

`agents.entries` can be silently erased. On a production gateway (team.openclaw.ai), `agents.entries.main` disappeared twice on 2026-07-25, orphaning 120+ sessions whose agent id no longer resolved (`unknown agent id "main"` across `sessions.catalog.list` / `chat.metadata` / `commands.list`).

Two unguarded write paths allow this:

1. The `config.set` RPC accepts a **whole config object** from the client and commits it. A client that round-trips a stale snapshot missing an agent entry deletes that entry permanently — the CLI's `assertNonDestructiveReplacement` protection never runs on this path.
2. The write layer re-derives the entire roster on any roster-adjacent write (`persistCanonicalRoster` deletes `agents.entries`/`agents.list` and re-injects them from the in-memory config). Any upstream caller handing it a roster-incomplete config silently loses entries.

## Why This Change Was Made

- `config.set` now compares roster ids and rejects submissions that drop existing entries, pointing at the supported deletion flow (`agents.delete` RPC / `openclaw agents delete`).
- The canonical-roster persist path asserts every entry in the persisted base survives unless the mutation explicitly allowed its removal; the explicit-removal signal is threaded from the real deletion callers (`deleteAgentConfigEntry` / prune) via `allowedAgentRosterRemovals` — never inferred.
- Key-set comparison only; intentional deletions keep working.

## User Impact

Losing an agent entry now requires the deletion flow. Stale Control UI snapshots, partial config round-trips, or upstream normalization bugs can no longer orphan an agent's sessions.

## Evidence

- Production config-audit journal (`state/openclaw.sqlite`, scope `config-audit`) documents the two erasure events on 2026-07-25.
- Focused tests: `node scripts/run-vitest.mjs src/config/io.write-prepare.test.ts src/gateway/server.config-patch.test.ts src/gateway/server-methods/agents-mutate.test.ts` → 227 passed (new: RPC rejects dropped entries, write-layer assert fires on roster-incomplete configs, explicit deletion still works, leaf writes preserve siblings).
