### PR TITLE
fix(codex): recover in-place session resets

### DIFF
--- a/extensions/codex/harness.test.ts
+++ b/extensions/codex/harness.test.ts
@@ -237,7 +237,7 @@ describe("Codex agent harness supports()", () => {
 });
 
 describe("Codex agent harness reset()", () => {
-  it("retires the physical session generation", async () => {
+  it("clears an in-place session generation without stranding its replacement", async () => {
     const bindingStore = createCodexTestBindingStore();
     const identity = sessionBindingIdentity({
       agentId: "worker",
@@ -261,6 +261,70 @@ describe("Codex agent harness reset()", () => {
     });
 
     await expect(bindingStore.read(identity)).resolves.toBeUndefined();
+    await expect(
+      bindingStore.mutate(identity, {
+        kind: "set",
+        binding: { threadId: "thread-2", cwd: "/repo" },
+      }),
+    ).resolves.toBe(true);
+    await expect(bindingStore.read(identity)).resolves.toMatchObject({ threadId: "thread-2" });
+  });
+
+  it("repairs a retirement fence left by an earlier in-place reset", async () => {
+    const bindingStore = createCodexTestBindingStore();
+    const identity = sessionBindingIdentity({
+      agentId: "worker",
+      sessionId: "session-1",
+      sessionKey: "agent:worker:main",
+    });
+    await bindingStore.mutate(identity, {
+      kind: "set",
+      binding: { threadId: "thread-1", cwd: "/repo" },
+    });
+    await bindingStore.retireSessionGeneration(identity);
+    const harness = createCodexAppServerAgentHarness({ bindingStore });
+
+    await harness.reset?.({
+      agentId: "worker",
+      sessionId: "session-1",
+      sessionKey: "agent:worker:main",
+      reason: "reset",
+    });
+
+    await expect(
+      bindingStore.mutate(identity, {
+        kind: "set",
+        binding: { threadId: "thread-recovered", cwd: "/repo" },
+      }),
+    ).resolves.toBe(true);
+  });
+
+  it("keeps deleted session generations retired", async () => {
+    const bindingStore = createCodexTestBindingStore();
+    const identity = sessionBindingIdentity({
+      agentId: "worker",
+      sessionId: "session-1",
+      sessionKey: "agent:worker:main",
+    });
+    await bindingStore.mutate(identity, {
+      kind: "set",
+      binding: { threadId: "thread-1", cwd: "/repo" },
+    });
+    const harness = createCodexAppServerAgentHarness({ bindingStore });
+
+    await harness.reset?.({
+      agentId: "worker",
+      sessionId: "session-1",
+      sessionKey: "agent:worker:main",
+      reason: "deleted",
+    });
+
+    await expect(
+      bindingStore.mutate(identity, {
+        kind: "set",
+        binding: { threadId: "thread-stale", cwd: "/repo" },
+      }),
+    ).resolves.toBe(false);
   });
 });
 

--- a/extensions/codex/harness.test.ts
+++ b/extensions/codex/harness.test.ts
@@ -1,4 +1,8 @@
 // Codex tests cover harness plugin behavior.
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { upsertSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
 import { describe, expect, it, vi } from "vitest";
 import { createCodexAppServerAgentHarness } from "./harness.js";
 import {
@@ -271,32 +275,48 @@ describe("Codex agent harness reset()", () => {
   });
 
   it("repairs a retirement fence left by an earlier in-place reset", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-codex-harness-reset-"));
+    const storePath = path.join(root, "sessions.json");
     const bindingStore = createCodexTestBindingStore();
+    const sessionKey = "agent:worker:main";
     const identity = sessionBindingIdentity({
       agentId: "worker",
       sessionId: "session-1",
-      sessionKey: "agent:worker:main",
+      sessionKey,
     });
-    await bindingStore.mutate(identity, {
-      kind: "set",
-      binding: { threadId: "thread-1", cwd: "/repo" },
-    });
-    await bindingStore.retireSessionGeneration(identity);
-    const harness = createCodexAppServerAgentHarness({ bindingStore });
-
-    await harness.reset?.({
-      agentId: "worker",
-      sessionId: "session-1",
-      sessionKey: "agent:worker:main",
-      reason: "reset",
-    });
-
-    await expect(
-      bindingStore.mutate(identity, {
+    try {
+      await upsertSessionEntry({
+        agentId: identity.agentId,
+        sessionKey,
+        storePath,
+        entry: { sessionId: identity.sessionId, updatedAt: 1 },
+      });
+      await bindingStore.mutate(identity, {
         kind: "set",
-        binding: { threadId: "thread-recovered", cwd: "/repo" },
-      }),
-    ).resolves.toBe(true);
+        binding: { threadId: "thread-1", cwd: "/repo" },
+      });
+      await bindingStore.retireSessionGeneration(identity);
+      const harness = createCodexAppServerAgentHarness({
+        bindingStore,
+        resolveConfig: () => ({ session: { store: storePath } }),
+      });
+
+      await harness.reset?.({
+        agentId: "worker",
+        sessionId: "session-1",
+        sessionKey,
+        reason: "reset",
+      });
+
+      await expect(
+        bindingStore.mutate(identity, {
+          kind: "set",
+          binding: { threadId: "thread-recovered", cwd: "/repo" },
+        }),
+      ).resolves.toBe(true);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
   });
 
   it("keeps deleted session generations retired", async () => {

--- a/extensions/codex/harness.ts
+++ b/extensions/codex/harness.ts
@@ -218,18 +218,22 @@ export function createCodexAppServerAgentHarness(options: {
           sessionId: params.sessionId,
           sessionKey: params.sessionKey,
         });
-        let retired = await options.bindingStore.retireSessionGeneration(identity);
-        if (retired === "conflict") {
+        const resetGeneration =
+          params.reason === "deleted"
+            ? options.bindingStore.retireSessionGeneration.bind(options.bindingStore)
+            : options.bindingStore.resetSessionGeneration.bind(options.bindingStore);
+        let reset = await resetGeneration(identity);
+        if (reset === "conflict") {
           const reclaimed = await reclaimCurrentCodexSessionGeneration({
             bindingStore: options.bindingStore,
             identity,
             config: options.resolveConfig?.(),
           });
           if (reclaimed) {
-            retired = await options.bindingStore.retireSessionGeneration(identity);
+            reset = await resetGeneration(identity);
           }
         }
-        if (retired === "conflict") {
+        if (reset === "conflict") {
           throw new Error(
             `Codex binding generation changed before session ${params.sessionId} could reset`,
           );

--- a/extensions/codex/index.test.ts
+++ b/extensions/codex/index.test.ts
@@ -526,6 +526,30 @@ describe("codex plugin", () => {
     );
     await expect(bindingStore.read(parent)).resolves.toMatchObject({ threadId: "thread-parent" });
 
+    // In-place reset cleanup is awaited before the replacement starts. Its
+    // delayed session_end event must not retire that same-id replacement.
+    const inPlace = sessionBindingIdentity({
+      agentId: "worker",
+      sessionId: "in-place-1",
+      sessionKey: "agent:worker:in-place",
+    });
+    await bindingStore.mutate(inPlace, {
+      kind: "set",
+      binding: { threadId: "thread-in-place-replacement", cwd: "/repo" },
+    });
+    await sessionEnd(
+      {
+        sessionId: "in-place-1",
+        sessionKey: "agent:worker:in-place",
+        reason: "reset",
+        nextSessionId: "in-place-1",
+      },
+      { agentId: "worker", sessionId: "in-place-1" },
+    );
+    await expect(bindingStore.read(inPlace)).resolves.toMatchObject({
+      threadId: "thread-in-place-replacement",
+    });
+
     // A same-key replacement that still names the successor id (physical rollover)
     // has no distinct nextSessionKey, so it retires as before.
     await sessionEnd(

--- a/extensions/codex/index.ts
+++ b/extensions/codex/index.ts
@@ -348,6 +348,11 @@ export default definePluginEntry({
       if (endedSessionKey && nextSessionKey && nextSessionKey !== endedSessionKey) {
         return;
       }
+      // Reset hooks already clear in-place lifecycle state before the next turn.
+      // A delayed session_end must not retire a replacement that reuses the id.
+      if (event.nextSessionId?.trim() === event.sessionId.trim()) {
+        return;
+      }
       const config = resolveCurrentConfig();
       const { sessionBindingIdentity } = await import("./src/app-server/session-binding.js");
       await bindingStore.retireSessionGeneration(

--- a/extensions/codex/src/app-server/session-binding-store.ts
+++ b/extensions/codex/src/app-server/session-binding-store.ts
@@ -30,6 +30,7 @@ export function createLazyCodexAppServerBindingStore(
       (await store()).prepareSessionGenerationReclaim(identity),
     adoptSessionGeneration: async (identity, previousSessionId) =>
       (await store()).adoptSessionGeneration(identity, previousSessionId),
+    resetSessionGeneration: async (identity) => (await store()).resetSessionGeneration(identity),
     retireSessionGeneration: async (identity) => (await store()).retireSessionGeneration(identity),
     withThreadArchiveFence: async (run) => (await store()).withThreadArchiveFence(run),
     withLease: async (identity, run) => (await store()).withLease(identity, run),

--- a/extensions/codex/src/app-server/session-binding.test.ts
+++ b/extensions/codex/src/app-server/session-binding.test.ts
@@ -960,6 +960,36 @@ describe("Codex app-server binding store", () => {
     await expect(store.read(current)).resolves.toMatchObject({ threadId: "thread-new" });
   });
 
+  it("keeps a retired in-place generation fenced until it is verified", async () => {
+    const { state, values } = createStateStore();
+    const store = createCodexAppServerBindingStore(state);
+    const identity = {
+      kind: "session" as const,
+      agentId: "main",
+      sessionId: "session-1",
+      sessionKey: "agent:main:telegram:chat-1",
+    };
+    await store.mutate(identity, {
+      kind: "set",
+      binding: { threadId: "thread-old", cwd: "/old" },
+    });
+    await store.retireSessionGeneration(identity);
+
+    await expect(store.resetSessionGeneration(identity)).resolves.toBe("conflict");
+    expect(values.get(bindingStoreKey(identity))).toEqual({
+      version: 1,
+      state: "cleared",
+      retired: true,
+      sessionId: identity.sessionId,
+    });
+    await expect(
+      store.mutate(identity, {
+        kind: "set",
+        binding: { threadId: "thread-unverified", cwd: "/new" },
+      }),
+    ).resolves.toBe(false);
+  });
+
   it("verifies and releases a retired fence for the still-current stable session id", async () => {
     const { state, values } = createStateStore();
     const store = createCodexAppServerBindingStore(state);

--- a/extensions/codex/src/app-server/session-binding.test.ts
+++ b/extensions/codex/src/app-server/session-binding.test.ts
@@ -7,6 +7,7 @@ import {
   createPluginStateSyncKeyedStoreForTests,
   resetPluginStateStoreForTests,
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { upsertSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   bindingStoreKey,
@@ -15,6 +16,7 @@ import {
   createStoredCodexAppServerBinding,
   hashCodexAppServerBindingFingerprint,
   readCodexAppServerThreadBinding,
+  reclaimCurrentCodexSessionGeneration,
   type StoredCodexAppServerBinding,
 } from "./session-binding.js";
 
@@ -956,6 +958,90 @@ describe("Codex app-server binding store", () => {
       }),
     ).resolves.toBe(true);
     await expect(store.read(current)).resolves.toMatchObject({ threadId: "thread-new" });
+  });
+
+  it("verifies and releases a retired fence for the still-current stable session id", async () => {
+    const { state, values } = createStateStore();
+    const store = createCodexAppServerBindingStore(state);
+    const identity = {
+      kind: "session" as const,
+      agentId: "main",
+      sessionId: "session-1",
+      sessionKey: "agent:main:telegram:chat-1",
+    };
+    await store.mutate(identity, {
+      kind: "set",
+      binding: { threadId: "thread-old", cwd: "/old" },
+    });
+    await store.retireSessionGeneration(identity);
+
+    const plan = await store.prepareSessionGenerationReclaim(identity);
+    expect(plan).toEqual({
+      kind: "verify",
+      expectedPreviousSessionId: identity.sessionId,
+    });
+    if (plan.kind !== "verify") {
+      throw new Error("expected the current retired generation to require verification");
+    }
+    await expect(
+      store.mutate(identity, {
+        kind: "reclaim-generation",
+        expectedPreviousSessionId: plan.expectedPreviousSessionId,
+      }),
+    ).resolves.toBe(true);
+    expect(values.get(bindingStoreKey(identity))).toEqual({
+      version: 1,
+      state: "cleared",
+      sessionId: identity.sessionId,
+    });
+    await expect(
+      store.mutate(identity, {
+        kind: "set",
+        binding: { threadId: "thread-recovered", cwd: "/new" },
+      }),
+    ).resolves.toBe(true);
+  });
+
+  it("recovers a retired in-place generation through the authoritative session store", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-codex-reset-reclaim-"));
+    const storePath = path.join(root, "sessions.json");
+    const { state } = createStateStore();
+    const store = createCodexAppServerBindingStore(state);
+    const identity = {
+      kind: "session" as const,
+      agentId: "main",
+      sessionId: "session-current",
+      sessionKey: "agent:main:telegram:direct:123",
+    };
+    try {
+      await upsertSessionEntry({
+        agentId: identity.agentId,
+        sessionKey: identity.sessionKey,
+        storePath,
+        entry: { sessionId: identity.sessionId, updatedAt: 1 },
+      });
+      await store.mutate(identity, {
+        kind: "set",
+        binding: { threadId: "thread-before-reset", cwd: "/repo" },
+      });
+      await store.retireSessionGeneration(identity);
+
+      await expect(
+        reclaimCurrentCodexSessionGeneration({
+          bindingStore: store,
+          identity,
+          config: { session: { store: storePath } },
+        }),
+      ).resolves.toBe(true);
+      await expect(
+        store.mutate(identity, {
+          kind: "set",
+          binding: { threadId: "thread-after-reset", cwd: "/repo" },
+        }),
+      ).resolves.toBe(true);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
   });
 
   it("drains an in-flight ownership mutation and rejects late attachment during archive", async () => {

--- a/extensions/codex/src/app-server/session-binding.ts
+++ b/extensions/codex/src/app-server/session-binding.ts
@@ -523,6 +523,9 @@ export type CodexAppServerBindingStore = {
     identity: Extract<CodexAppServerBindingIdentity, { kind: "session" }>,
     expectedPreviousSessionId: string,
   ): Promise<CodexSessionGenerationAdoptionResult>;
+  resetSessionGeneration(
+    identity: Extract<CodexAppServerBindingIdentity, { kind: "session" }>,
+  ): Promise<CodexSessionGenerationRetirementResult>;
   retireSessionGeneration(
     identity: Extract<CodexAppServerBindingIdentity, { kind: "session" }>,
   ): Promise<CodexSessionGenerationRetirementResult>;
@@ -757,11 +760,16 @@ export function createCodexAppServerBindingStore(
         return { kind: "resolved", result: true };
       }
       const currentSessionId = current.sessionId;
-      if (!currentSessionId || currentSessionId === identity.sessionId) {
+      if (!currentSessionId) {
         return {
           kind: "resolved",
           result: current.state !== "cleared" || current.retired !== true,
         };
+      }
+      if (currentSessionId === identity.sessionId) {
+        return current.state === "cleared" && current.retired === true
+          ? { kind: "verify", expectedPreviousSessionId: currentSessionId }
+          : { kind: "resolved", result: true };
       }
       return { kind: "verify", expectedPreviousSessionId: currentSessionId };
     },
@@ -787,6 +795,24 @@ export function createCodexAppServerBindingStore(
                 return { result: true };
               }
               if (ownsGeneration) {
+                if (
+                  current.state === "cleared" &&
+                  current.retired === true &&
+                  current.sessionId === mutation.expectedPreviousSessionId
+                ) {
+                  // Reset boundaries now retain the OpenClaw session id. The
+                  // authoritative session-store check above proves this fence
+                  // belongs to the previous in-place lifecycle, not live work.
+                  return {
+                    result: true,
+                    next: {
+                      version: 1,
+                      state: "cleared",
+                      sessionId: identity.sessionId,
+                      ...ownedLease,
+                    },
+                  };
+                }
                 return {
                   result: current.state !== "cleared" || current.retired !== true,
                 };
@@ -930,6 +956,35 @@ export function createCodexAppServerBindingStore(
             next: { ...current, sessionId: targetSessionId },
           };
         });
+      });
+    },
+
+    async resetSessionGeneration(identity) {
+      return await runBindingMutation(async () => {
+        const key = bindingStoreKey(identity);
+        return await transactKey(
+          key,
+          (current, leaseToken) => {
+            if (!current) {
+              return { result: "absent" as const };
+            }
+            if (!ownsStoredSessionGeneration(identity, current)) {
+              return { result: "conflict" as const };
+            }
+            return {
+              result: "applied" as const,
+              next: {
+                version: 1,
+                state: "cleared",
+                ...storedSessionGeneration(identity, current),
+                ...(current.lease && current.lease.token === leaseToken
+                  ? { lease: current.lease }
+                  : {}),
+              },
+            };
+          },
+          leaseContext.getStore()?.has(key) ? undefined : 1,
+        );
       });
     },
 

--- a/extensions/codex/src/app-server/session-binding.ts
+++ b/extensions/codex/src/app-server/session-binding.ts
@@ -971,6 +971,11 @@ export function createCodexAppServerBindingStore(
             if (!ownsStoredSessionGeneration(identity, current)) {
               return { result: "conflict" as const };
             }
+            // A retired same-id row may be a deletion fence. Only the authoritative
+            // session-store reclaim path can prove it belongs to an in-place reset.
+            if (current.state === "cleared" && current.retired === true) {
+              return { result: "conflict" as const };
+            }
             return {
               result: "applied" as const,
               next: {

--- a/src/auto-reply/reply/agent-runner-session-reset.test.ts
+++ b/src/auto-reply/reply/agent-runner-session-reset.test.ts
@@ -15,6 +15,7 @@ import { setAgentRunnerSessionResetTestDeps } from "./agent-runner-session-reset
 import { createTestFollowupRun, writeTestSessionStore } from "./agent-runner.test-fixtures.js";
 
 const refreshQueuedFollowupSessionMock = vi.fn();
+const resetRegisteredAgentHarnessSessionsMock = vi.fn();
 const errorMock = vi.fn();
 
 async function writeFileTranscript(filePath: string, sessionId: string): Promise<void> {
@@ -55,10 +56,12 @@ describe("resetReplyRunSession", () => {
   beforeEach(async () => {
     rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-reset-run-"));
     refreshQueuedFollowupSessionMock.mockReset();
+    resetRegisteredAgentHarnessSessionsMock.mockReset();
     errorMock.mockReset();
     setAgentRunnerSessionResetTestDeps({
       generateSecureUuid: () => "00000000-0000-0000-0000-000000000123",
       refreshQueuedFollowupSession: refreshQueuedFollowupSessionMock as never,
+      resetRegisteredAgentHarnessSessions: resetRegisteredAgentHarnessSessionsMock,
       error: errorMock,
     });
   });
@@ -178,6 +181,13 @@ describe("resetReplyRunSession", () => {
       previousSessionId: "session",
       nextSessionId: activeSessionEntry?.sessionId,
       nextSessionFile: activeSessionEntry?.sessionFile,
+    });
+    expect(resetRegisteredAgentHarnessSessionsMock).toHaveBeenCalledWith({
+      agentId: followupRun.run.agentId,
+      sessionId: "session",
+      sessionKey: "main",
+      sessionFile: activeSessionEntry?.sessionFile,
+      reason: "reset",
     });
     expect(errorMock).toHaveBeenCalledWith("reset session");
 

--- a/src/auto-reply/reply/agent-runner-session-reset.ts
+++ b/src/auto-reply/reply/agent-runner-session-reset.ts
@@ -1,5 +1,6 @@
 import { clearBootstrapSnapshotOnSessionBoundary } from "../../agents/bootstrap-cache.js";
 import { clearAllCliSessions } from "../../agents/cli-session.js";
+import { resetRegisteredAgentHarnessSessions } from "../../agents/harness/registry.js";
 // Handles session reset requests produced during agent runner execution.
 import { transitionMainSessionRecovery } from "../../agents/main-session-recovery-state.js";
 import type { SessionEntry } from "../../config/sessions.js";
@@ -27,6 +28,7 @@ const deps = {
   generateSecureUuid,
   persistSessionResetLifecycle,
   refreshQueuedFollowupSession,
+  resetRegisteredAgentHarnessSessions,
   error: (message: string) => defaultRuntime.error(message),
 };
 
@@ -35,6 +37,7 @@ function setAgentRunnerSessionResetTestDeps(overrides?: Partial<typeof deps>): v
     generateSecureUuid,
     persistSessionResetLifecycle,
     refreshQueuedFollowupSession,
+    resetRegisteredAgentHarnessSessions,
     error: (message: string) => defaultRuntime.error(message),
     ...overrides,
   });
@@ -141,6 +144,13 @@ export async function resetReplyRunSession(params: {
   clearBootstrapSnapshotOnSessionBoundary({
     boundaryAppended: true,
     sessionKey: params.sessionKey,
+  });
+  await deps.resetRegisteredAgentHarnessSessions({
+    agentId,
+    sessionId: nextSessionId,
+    sessionKey: params.sessionKey,
+    sessionFile: nextSessionFile,
+    reason: "reset",
   });
   params.followupRun.run.sessionId = nextSessionId;
   params.followupRun.run.sessionFile = nextSessionFile;


### PR DESCRIPTION
## What Problem This Solves

Codex-backed chats can become permanently unusable after an in-place session reset, returning:

`This Codex session changed before your message could run. Please send it again.`

The failure is transport-independent and was reproduced across a Telegram direct chat and multiple topic sessions. Current `main` preserves the OpenClaw session ID across resets, while the Codex harness retired that same physical generation. Every later turn then hit the durable superseded-session fence. The regression is also present in `v2026.7.2-beta.4`.

## Why This Change Was Made

- Add a non-retiring generation reset for ordinary reset boundaries; keep durable retirement for deletion.
- Ignore delayed `session_end` cleanup when the successor intentionally reuses the same session ID.
- Reset registered harness state in the internal memory-flush/role-ordering recovery path, which also resets in place.
- Let the existing authoritative session-store reclaim path repair already-retired same-ID rows, so affected chats recover without a manual state migration.

This keeps one host-owned lifecycle invariant across gateway resets, reply-run recovery, and Codex binding admission. The additional production surface is the explicit reset transition plus bounded recovery for a real persisted state; it removes the accidental split between gateway and runner reset paths.

Codex contract check: `thread/start` creates a fresh Codex thread without an OpenClaw generation field, while `thread/resume` addresses an existing Codex thread by `thread_id`. OpenClaw's generation fence is therefore host-owned and can be cleared at an in-place OpenClaw reset without changing the Codex protocol:
- [ThreadStartParams / ThreadResumeParams](https://github.com/openai/codex/blob/87b808bb570f01f4b6fc8485c5459052fac0e320/codex-rs/app-server-protocol/src/protocol/v2/thread.rs#L95-L395)
- [thread start/resume processing](https://github.com/openai/codex/blob/87b808bb570f01f4b6fc8485c5459052fac0e320/codex-rs/app-server/src/request_processors/thread_processor.rs#L802-L1095)

## User Impact

Existing affected chats self-heal on the next message after deploying/restarting onto the fixed runtime. Future `/new`, `/reset`, idle/daily, memory-flush, and role-ordering resets can start a fresh Codex thread without stranding the stable OpenClaw session. Deleted sessions remain fenced against stale work.

## Evidence

- Read-only live diagnosis: the same superseded-generation exception appeared under one direct-chat key and multiple topic keys; the persisted Codex binding rows were retired while the authoritative session store still named the identical session IDs. Identifiers are intentionally omitted.
- `pnpm exec vitest run extensions/codex/harness.test.ts extensions/codex/index.test.ts extensions/codex/src/app-server/session-binding.test.ts src/auto-reply/reply/agent-runner-session-reset.test.ts` — 4 files, 101 tests passed.
- `pnpm exec oxfmt --check <changed files>` — passed.
- `pnpm exec oxlint --type-aware <changed files>` — passed.
- `pnpm tsgo:prod` — passed.
- `pnpm tsgo:core:test` — passed.
- `pnpm tsgo:extensions:test` — passed.
- `git diff --check` — passed.
- `pnpm check:changed` was attempted, but the delegated Blacksmith Testbox bootstrap rejected its `crabbox` binary during the pre-run sanity check; the local targeted/static/type lanes above were run instead.


### Live recovery proof (2026-07-26)

The reporter built head `1a83dac6df70056499e9cc5e343d20a1c4b871ca` and restarted the gateway from that checkout. Local artifact/service timing confirms the rebuilt `dist/index.js` preceded the restarted process:

```text
dist/index.js mtime: 2026-07-26 12:01:03 +05:30
gateway active since: 2026-07-26 12:03:08 +05:30
```

Before the fixed restart, the affected direct chat and topic sessions repeatedly failed with the superseded-generation exception. Identifiers are redacted:

```text
11:09:15 [diagnostic] AgentHarnessSessionSupersededError: Codex session generation is no longer current: [session-id-redacted]
11:09:47 [diagnostic] AgentHarnessSessionSupersededError: Codex session generation is no longer current: [session-id-redacted]
11:11:05 [diagnostic] AgentHarnessSessionSupersededError: Codex session generation is no longer current: [session-id-redacted]
```

The first direct Telegram turn after the fixed restart completed through Codex and delivered its reply:

```text
12:04:02 [telegram] Inbound message telegram:[redacted] -> @[redacted] (direct, 2 chars)
12:04:27 [telegram] outbound send ok chatId=[redacted] messageId=[redacted] operation=sendMessage deliveryKind=text
12:04:27 [agent/embedded] codex app-server turn released after terminal dynamic tool result
```

A sanitized read-only query of the authoritative current direct-chat session and its Codex plugin row after that turn showed the previously stranded stable generation had reclaimed normally:

```text
binding_state  retired  codex_thread_bound
active         false    yes
superseded_errors_since_restart=0
```

Deletion remains deliberately fenced; performing a destructive live deletion solely for proof was avoided. The two review-specific safety tests passed:

```text
keeps deleted session generations retired
recovers a retired in-place generation through the authoritative session store

Test Files  2 passed
Tests       2 passed | 70 skipped
```

This demonstrates the observed persisted-state upgrade path: the same affected chat that failed before deployment successfully reclaimed a fresh Codex binding on its next message after deployment, without manual state editing.