### PR TITLE
fix(agents): keep queued replies alive across lane waits and make stuck recovery truthful

### DIFF
--- a/src/agents/embedded-agent-runner/run.codex-app-server-recovery.test.ts
+++ b/src/agents/embedded-agent-runner/run.codex-app-server-recovery.test.ts
@@ -141,7 +141,9 @@ describe("runEmbeddedAgent Codex app-server recovery", () => {
     const replyOperation = {
       freezeAbort,
       markDeferredMaintenanceWaitEnded: vi.fn(),
+      markGlobalLaneWaitEnded: vi.fn(),
       markWaitingForDeferredMaintenance: vi.fn(),
+      markWaitingForGlobalLane: vi.fn(),
     } as unknown as NonNullable<Parameters<typeof runEmbeddedAgent>[0]["replyOperation"]>;
     mockedRunEmbeddedAttempt
       .mockImplementationOnce(async () => {
@@ -212,7 +214,9 @@ describe("runEmbeddedAgent Codex app-server recovery", () => {
     const replyOperation = {
       abortByUser,
       markDeferredMaintenanceWaitEnded: vi.fn(),
+      markGlobalLaneWaitEnded: vi.fn(),
       markWaitingForDeferredMaintenance: vi.fn(),
+      markWaitingForGlobalLane: vi.fn(),
     } as unknown as NonNullable<Parameters<typeof runEmbeddedAgent>[0]["replyOperation"]>;
     mockedRunEmbeddedAttempt.mockImplementationOnce(async (attemptParams) => {
       asAttemptParams(attemptParams).onAttemptAbort?.();
@@ -244,7 +248,9 @@ describe("runEmbeddedAgent Codex app-server recovery", () => {
     const replyOperation = {
       abortByUser,
       markDeferredMaintenanceWaitEnded: vi.fn(),
+      markGlobalLaneWaitEnded: vi.fn(),
       markWaitingForDeferredMaintenance: vi.fn(),
+      markWaitingForGlobalLane: vi.fn(),
     } as unknown as NonNullable<Parameters<typeof runEmbeddedAgent>[0]["replyOperation"]>;
     mockedRunEmbeddedAttempt.mockImplementationOnce(async (attemptParams) => {
       controller.abort(upstreamAbort);

--- a/src/agents/embedded-agent-runner/run/lane-controller.ts
+++ b/src/agents/embedded-agent-runner/run/lane-controller.ts
@@ -32,7 +32,10 @@ export function createEmbeddedRunLaneController<TParams extends LaneParams>(opti
   setParams: (params: TParams) => void;
 }) {
   const initialParams = options.getParams();
-  const sessionQueuePriority = resolveEmbeddedRunSessionQueuePriority(initialParams.trigger);
+  const sessionQueuePriority = resolveEmbeddedRunSessionQueuePriority(
+    initialParams.trigger,
+    initialParams.inputProvenance,
+  );
   const laneTaskTimeoutMs = resolveEmbeddedRunLaneTimeoutMs(initialParams.timeoutMs);
   const laneTaskAbortController = new AbortController();
   const laneTaskReleaseController = new AbortController();
@@ -99,6 +102,9 @@ export function createEmbeddedRunLaneController<TParams extends LaneParams>(opti
     task: () => Promise<EmbeddedAgentRunResult>,
     opts?: CommandQueueEnqueueOptions,
   ) => {
+    // Global-lane admission is healthy waiting, not run execution. Keep reply
+    // staleness and stuck recovery fenced until this queue grants capacity.
+    options.getParams().replyOperation?.markWaitingForGlobalLane();
     const globalOpts: CommandQueueEnqueueOptions = {
       ...opts,
       priority: sessionQueuePriority,
@@ -106,6 +112,7 @@ export function createEmbeddedRunLaneController<TParams extends LaneParams>(opti
     const taskWithCurrentLifecycle = async () => {
       let params = options.getParams();
       params.onLaneWait?.({ waitMs: 0, queuedAhead: 0, waiting: false });
+      params.replyOperation?.markGlobalLaneWaitEnded();
       throwIfAborted();
       let lifecycleGeneration = options.getLifecycleGeneration();
       const currentLifecycleGeneration = getAgentEventLifecycleGeneration();

--- a/src/agents/embedded-agent-runner/run/lane-runtime.test.ts
+++ b/src/agents/embedded-agent-runner/run/lane-runtime.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { enqueueCommandInLane, setCommandLaneConcurrency } from "../../../process/command-queue.js";
+import { resetCommandQueueStateForTest } from "../../../process/command-queue.test-support.js";
+import { MAIN_SESSION_RESTART_RECOVERY_SOURCE_TOOL } from "../../../sessions/input-provenance.js";
+import { resolveEmbeddedRunSessionQueuePriority } from "./lane-runtime.js";
+
+describe("embedded run lane priority", () => {
+  afterEach(() => {
+    resetCommandQueueStateForTest();
+  });
+
+  it("runs a foreground user turn before queued restart recovery", async () => {
+    const lane = "test:restart-recovery-priority";
+    setCommandLaneConcurrency(lane, 1);
+    let releaseBlocker: () => void = () => {};
+    const blockerGate = new Promise<void>((resolve) => {
+      releaseBlocker = resolve;
+    });
+    const blocker = enqueueCommandInLane(lane, async () => {
+      await blockerGate;
+    });
+    const order: string[] = [];
+    const restartRecovery = enqueueCommandInLane(
+      lane,
+      async () => {
+        order.push("restart-recovery");
+      },
+      {
+        priority: resolveEmbeddedRunSessionQueuePriority("user", {
+          kind: "internal_system",
+          sourceTool: MAIN_SESSION_RESTART_RECOVERY_SOURCE_TOOL,
+        }),
+      },
+    );
+    const foreground = enqueueCommandInLane(
+      lane,
+      async () => {
+        order.push("foreground-user");
+      },
+      { priority: resolveEmbeddedRunSessionQueuePriority("user") },
+    );
+
+    releaseBlocker();
+    await Promise.all([blocker, foreground, restartRecovery]);
+
+    expect(order).toEqual(["foreground-user", "restart-recovery"]);
+  });
+});

--- a/src/agents/embedded-agent-runner/run/lane-runtime.ts
+++ b/src/agents/embedded-agent-runner/run/lane-runtime.ts
@@ -3,6 +3,7 @@ import {
   MAX_TIMER_TIMEOUT_MS,
 } from "@openclaw/normalization-core/number-coercion";
 import type { CommandQueueEnqueueOptions } from "../../../process/command-queue.types.js";
+import { isMainSessionRestartRecoveryInputProvenance } from "../../../sessions/input-provenance.js";
 import { DEFAULT_AGENT_TIMEOUT_MS } from "../../timeout.js";
 import type { RunEmbeddedAgentParams } from "./params.js";
 
@@ -34,7 +35,11 @@ export function withEmbeddedRunLaneTimeout(
 
 export function resolveEmbeddedRunSessionQueuePriority(
   trigger: RunEmbeddedAgentParams["trigger"],
+  inputProvenance?: RunEmbeddedAgentParams["inputProvenance"],
 ): CommandQueueEnqueueOptions["priority"] {
+  if (isMainSessionRestartRecoveryInputProvenance(inputProvenance)) {
+    return "background";
+  }
   switch (trigger) {
     case "user":
     case "manual":

--- a/src/auto-reply/reply/agent-runner-direct-runtime-config.test.ts
+++ b/src/auto-reply/reply/agent-runner-direct-runtime-config.test.ts
@@ -131,6 +131,8 @@ function createReplyOperation(): ReplyOperation {
     setPhase: vi.fn(),
     markWaitingForDeferredMaintenance: vi.fn(),
     markDeferredMaintenanceWaitEnded: vi.fn(),
+    markWaitingForGlobalLane: vi.fn(),
+    markGlobalLaneWaitEnded: vi.fn(),
     updateSessionId: vi.fn((nextSessionId: string) => {
       sessionId = nextSessionId;
     }),

--- a/src/auto-reply/reply/agent-runner-embedded-candidate.ts
+++ b/src/auto-reply/reply/agent-runner-embedded-candidate.ts
@@ -39,6 +39,7 @@ import type { AgentTurnTimingTracker } from "./agent-runner-turn-timing.js";
 import { buildEmbeddedRunExecutionParams } from "./agent-runner-utils.js";
 import type { FollowupRun } from "./queue.js";
 import { isReplyOperationRestartAbort } from "./reply-operation-abort.js";
+import { markReplyOperationGlobalLaneWaitProgress } from "./reply-run-registry.js";
 
 type EmbeddedPresentation = Pick<
   ReturnType<typeof createAgentTurnPresentation>,
@@ -248,6 +249,11 @@ export async function runEmbeddedFallbackCandidate(params: {
           }
         },
         onExecutionPhase: params.signalExecutionPhaseForTyping,
+        onLaneWait: ({ waiting }) => {
+          if (waiting) {
+            markReplyOperationGlobalLaneWaitProgress(turn.replyOperation);
+          }
+        },
         blockReplyBreak: turn.resolvedBlockStreamingBreak,
         blockReplyChunking: turn.blockReplyChunking,
         // Subscriber callbacks are detached. Stage channel presentation before typing I/O.

--- a/src/auto-reply/reply/agent-runner-embedded-candidate.ts
+++ b/src/auto-reply/reply/agent-runner-embedded-candidate.ts
@@ -250,8 +250,9 @@ export async function runEmbeddedFallbackCandidate(params: {
         },
         onExecutionPhase: params.signalExecutionPhaseForTyping,
         onLaneWait: ({ waiting }) => {
-          if (waiting) {
-            markReplyOperationGlobalLaneWaitProgress(turn.replyOperation);
+          const replyOperation = turn.replyOperation;
+          if (waiting && replyOperation) {
+            markReplyOperationGlobalLaneWaitProgress(replyOperation);
           }
         },
         blockReplyBreak: turn.resolvedBlockStreamingBreak,

--- a/src/auto-reply/reply/agent-runner-execution-lifecycle.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-lifecycle.test.ts
@@ -3,6 +3,7 @@ import type { SessionMcpRuntime } from "../../agents/agent-bundle-mcp-types.js";
 import { updateMcpAppModelContext } from "../../agents/mcp-app-model-context.js";
 import { createAgentRunRestartAbortError } from "../../agents/run-termination.js";
 import { HEARTBEAT_RUN_SCOPE } from "../../infra/heartbeat-run-scope.js";
+import { getDiagnosticSessionActivitySnapshot } from "../../logging/diagnostic-run-activity.js";
 import { SILENT_REPLY_TOKEN } from "../tokens.js";
 import type { GetReplyOptions } from "../types.js";
 import {
@@ -48,6 +49,36 @@ describe("runAgentTurnWithFallback: run lifecycle and ownership", () => {
     expect(fallbackCall.abortSignal).toBe(replyOperation.abortSignal);
     expect(fallbackCall.sessionId).toBe("session");
     expect(embeddedCall.abortSignal).toBe(replyOperation.abortSignal);
+  });
+
+  it("records diagnostic progress from global-lane wait notifications", async () => {
+    const replyOperation = createReplyOperation({
+      sessionKey: "agent:main:global-lane-progress",
+      sessionId: "global-lane-progress",
+      resetTriggered: false,
+    });
+    replyOperation.markWaitingForGlobalLane();
+    let progressReasonDuringWait: string | undefined;
+    state.runEmbeddedAgentMock.mockImplementationOnce(async (params: EmbeddedAgentParams) => {
+      params.onLaneWait?.({ waitMs: 5_000, queuedAhead: 4, waiting: true });
+      progressReasonDuringWait = getDiagnosticSessionActivitySnapshot({
+        sessionId: replyOperation.sessionId,
+        sessionKey: replyOperation.key,
+      }).lastProgressReason;
+      return { payloads: [{ text: "ok" }], meta: {} };
+    });
+
+    try {
+      const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+      await runAgentTurnWithFallback({
+        ...createMinimalRunAgentTurnParams(),
+        replyOperation,
+      });
+
+      expect(progressReasonDuringWait).toBe("global_lane:waiting");
+    } finally {
+      replyOperation.complete();
+    }
   });
 
   it("revalidates thinking for each main-chat fallback candidate without mutating the run", async () => {

--- a/src/auto-reply/reply/agent-runner-execution.test-support.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test-support.ts
@@ -407,6 +407,7 @@ export function createMockReplyOperation(options?: { abortSignal?: AbortSignal }
       key: "main",
       sessionId: "session",
       abortSignal: options?.abortSignal ?? new AbortController().signal,
+      staleExpiryReason: undefined,
       resetTriggered: false,
       terminalRecovery: false,
       acceptedSteeredInboundAudio: false,

--- a/src/auto-reply/reply/agent-runner-execution.test-support.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test-support.ts
@@ -301,6 +301,7 @@ export type EmbeddedAgentParams = {
     toolCallId?: string;
     itemId?: string;
   }) => void;
+  onLaneWait?: (info: { waitMs: number; queuedAhead: number; waiting?: boolean }) => void;
   onBlockReply?: (payload: { text?: string; mediaUrls?: string[] }) => Promise<void> | void;
   onPartialReply?: (payload: { text?: string; mediaUrls?: string[] }) => Promise<void> | void;
   onAssistantMessageStart?: () => Promise<void> | void;
@@ -418,6 +419,8 @@ export function createMockReplyOperation(options?: { abortSignal?: AbortSignal }
       setPhase: vi.fn(),
       markWaitingForDeferredMaintenance: vi.fn(),
       markDeferredMaintenanceWaitEnded: vi.fn(),
+      markWaitingForGlobalLane: vi.fn(),
+      markGlobalLaneWaitEnded: vi.fn(),
       updateSessionId: updateSessionIdMock,
       updateSessionKey: vi.fn(),
       attachBackend: vi.fn(),

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -83,6 +83,8 @@ function createReplyOperation(): TestReplyOperation {
     markAcceptedSteeredInboundAudio: vi.fn(),
     markWaitingForDeferredMaintenance: vi.fn(),
     markDeferredMaintenanceWaitEnded: vi.fn(),
+    markWaitingForGlobalLane: vi.fn(),
+    markGlobalLaneWaitEnded: vi.fn(),
   };
 }
 

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -55,6 +55,7 @@ function createReplyOperation(): TestReplyOperation {
     key: "test",
     sessionId: "session",
     abortSignal: new AbortController().signal,
+    staleExpiryReason: undefined,
     resetTriggered: false,
     terminalRecovery: false,
     acceptedSteeredInboundAudio: false,

--- a/src/auto-reply/reply/dispatch-from-config.prepare-context.ts
+++ b/src/auto-reply/reply/dispatch-from-config.prepare-context.ts
@@ -73,6 +73,7 @@ export async function prepareDispatchOperationContext(state: PrepareDispatchDeli
     ctx,
     deliverBindingPayload,
     dispatcher,
+    getDispatchReplyOperation,
     hookRunner,
     isInternalWebchatTurn,
     markIdle,
@@ -426,12 +427,20 @@ export async function prepareDispatchOperationContext(state: PrepareDispatchDeli
     });
   };
   const finishReplyOperationAbortedDispatch = (): DispatchFromConfigResult => {
+    const operation = getDispatchReplyOperation();
+    const queuedFinal =
+      operation?.result?.kind === "failed" && operation.result.code === "run_stalled"
+        ? dispatcher.sendFinalReply({
+            text: "⚠️ Your reply was dropped because the gateway was overloaded. Please retry.",
+            isError: true,
+          })
+        : false;
     commitInboundDedupeIfClaimed();
     recordProcessed("completed", { reason: "reply_operation_aborted" });
     markIdle("message_completed");
     completeDispatchReplyOperation();
     return attachSourceReplyDeliveryMode({
-      queuedFinal: false,
+      queuedFinal,
       counts: dispatcher.getQueuedCounts(),
     });
   };

--- a/src/auto-reply/reply/dispatch-from-config.prepare-context.ts
+++ b/src/auto-reply/reply/dispatch-from-config.prepare-context.ts
@@ -428,13 +428,19 @@ export async function prepareDispatchOperationContext(state: PrepareDispatchDeli
   };
   const finishReplyOperationAbortedDispatch = (): DispatchFromConfigResult => {
     const operation = getDispatchReplyOperation();
-    const queuedFinal =
-      operation?.result?.kind === "failed" && operation.result.code === "run_stalled"
-        ? dispatcher.sendFinalReply({
-            text: "⚠️ Your reply was dropped because the gateway was overloaded. Please retry.",
-            isError: true,
-          })
-        : false;
+    // Feedback only for pre-run drops: the user never saw output. Finalization or
+    // terminal-settle stalls already produced/settled output, so a notice is noise.
+    const droppedBeforeOutput =
+      operation?.result?.kind === "failed" &&
+      operation.result.code === "run_stalled" &&
+      (operation.staleExpiryReason === "no_activity" ||
+        operation.staleExpiryReason === "stuck_recovery");
+    const queuedFinal = droppedBeforeOutput
+      ? dispatcher.sendFinalReply({
+          text: "⚠️ Your reply was dropped because the gateway was overloaded. Please retry.",
+          isError: true,
+        })
+      : false;
     commitInboundDedupeIfClaimed();
     recordProcessed("completed", { reason: "reply_operation_aborted" });
     markIdle("message_completed");

--- a/src/auto-reply/reply/dispatch-from-config.stale-recovery.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.stale-recovery.test.ts
@@ -10,10 +10,13 @@ import {
   resetPluginTtsAndThreadMocks,
   runtimePluginMocks,
 } from "./dispatch-from-config.shared.test-harness.js";
+import type { DispatchFromConfigParams } from "./dispatch-from-config.types.js";
 import { buildTestCtx } from "./test-ctx.js";
 
 let dispatchReplyFromConfig: typeof import("./dispatch-from-config.js").dispatchReplyFromConfig;
 let createReplyOperation: typeof import("./reply-run-registry.js").createReplyOperation;
+let expireStaleReplyOperation: typeof import("./reply-run-registry.js").expireStaleReplyOperation;
+let replyRunRegistry: typeof import("./reply-run-registry.js").replyRunRegistry;
 let replyRunTesting: typeof import("./reply-run-registry.test-support.js").testing;
 let resetInboundDedupe: typeof import("./inbound-dedupe.js").resetInboundDedupe;
 
@@ -23,7 +26,9 @@ function setNoAbort() {
   mocks.tryFastAbortFromMessage.mockResolvedValue(noAbortResult);
 }
 
-function createVisibleDispatchParams(replyResolver: () => Promise<ReplyPayload>) {
+function createVisibleDispatchParams(
+  replyResolver: NonNullable<DispatchFromConfigParams["replyResolver"]>,
+) {
   return {
     ctx: buildTestCtx({
       Provider: "telegram",
@@ -44,7 +49,8 @@ function createVisibleDispatchParams(replyResolver: () => Promise<ReplyPayload>)
 describe("dispatchReplyFromConfig stale visible admission recovery", () => {
   beforeAll(async () => {
     ({ dispatchReplyFromConfig } = await import("./dispatch-from-config.js"));
-    ({ createReplyOperation } = await import("./reply-run-registry.js"));
+    ({ createReplyOperation, expireStaleReplyOperation, replyRunRegistry } =
+      await import("./reply-run-registry.js"));
     ({ testing: replyRunTesting } = await import("./reply-run-registry.test-support.js"));
     ({ resetInboundDedupe } = await import("./inbound-dedupe.js"));
   });
@@ -132,5 +138,33 @@ describe("dispatchReplyFromConfig stale visible admission recovery", () => {
     });
     expect(replyResolver).toHaveBeenCalledTimes(1);
     expect(dispatchParams.dispatcher.sendFinalReply).toHaveBeenCalledTimes(1);
+  });
+
+  it("sends overload feedback when stuck recovery expires the active reply", async () => {
+    let resolverStarted: () => void = () => {};
+    const resolverStartedPromise = new Promise<void>((resolve) => {
+      resolverStarted = resolve;
+    });
+    const dispatchParams = createVisibleDispatchParams(async (_ctx, options) => {
+      resolverStarted();
+      await new Promise<void>((resolve) => {
+        options?.abortSignal?.addEventListener("abort", () => resolve(), { once: true });
+      });
+      const error = new Error("reply expired");
+      error.name = "AbortError";
+      throw error;
+    });
+
+    const dispatchPromise = dispatchReplyFromConfig(dispatchParams);
+    await resolverStartedPromise;
+    const operation = replyRunRegistry.get(sessionKey);
+    expect(operation).toBeDefined();
+    expect(expireStaleReplyOperation(operation!, "stuck_recovery")).toBe(true);
+
+    await expect(dispatchPromise).resolves.toMatchObject({ queuedFinal: true });
+    expect(dispatchParams.dispatcher.sendFinalReply).toHaveBeenCalledWith({
+      text: "⚠️ Your reply was dropped because the gateway was overloaded. Please retry.",
+      isError: true,
+    });
   });
 });

--- a/src/auto-reply/reply/reply-run-registry.test.ts
+++ b/src/auto-reply/reply/reply-run-registry.test.ts
@@ -7,6 +7,8 @@ import {
   RUN_STALE_TAKEOVER_MS,
 } from "../../logging/diagnostic-run-activity.js";
 import { diagnosticLogger } from "../../logging/diagnostic-runtime.js";
+import { enqueueCommandInLane, setCommandLaneConcurrency } from "../../process/command-queue.js";
+import { resetCommandQueueStateForTest } from "../../process/command-queue.test-support.js";
 import { MAX_TIMER_TIMEOUT_MS } from "../../shared/number-coercion.js";
 import { beginReplyOperationFinalizationWork } from "./reply-run-finalization-lease.js";
 import {
@@ -14,6 +16,7 @@ import {
   createReplyOperation,
   expireStaleReplyOperation,
   forceClearReplyRunBySessionId,
+  isReplyRunEvidenceStale,
   isReplyRunActiveForSessionId,
   isReplyRunAbortableForCompaction,
   isReplyRunAbortableForSignal,
@@ -23,6 +26,7 @@ import {
   REPLY_RUN_TERMINAL_SETTLE_TIMEOUT_MS,
   ReplyRunAlreadyActiveError,
   replyRunRegistry,
+  markReplyOperationGlobalLaneWaitProgress,
   runAfterReplyOperationClear,
   resolveActiveReplyRunSessionId,
   resolveReplyRunPhaseForSessionId,
@@ -36,6 +40,7 @@ const REPLY_RUN_FINALIZATION_SETTLE_TIMEOUT_MS = 60_000;
 describe("reply run registry", () => {
   afterEach(() => {
     testing.resetReplyRunRegistry();
+    resetCommandQueueStateForTest();
     resetDiagnosticRunActivityForTest();
     vi.restoreAllMocks();
   });
@@ -171,6 +176,51 @@ describe("reply run registry", () => {
       activeWorkKind: undefined,
       lastProgressReason: "deferred_maintenance:wait_ended",
     });
+  });
+
+  it("keeps a reply alive while the saturated global lane waits past the stale threshold", async () => {
+    vi.useFakeTimers();
+    const operation = createReplyOperation({
+      sessionKey: "agent:main:telegram:direct:lane-wait",
+      sessionId: "session-global-lane-wait",
+      resetTriggered: false,
+    });
+    try {
+      const lane = "test:reply-global-wait";
+      setCommandLaneConcurrency(lane, 0);
+      operation.setPhase("running");
+      operation.markWaitingForGlobalLane();
+      let ran = false;
+
+      const queued = enqueueCommandInLane(
+        lane,
+        async () => {
+          operation.markGlobalLaneWaitEnded();
+          ran = true;
+        },
+        { onWait: () => markReplyOperationGlobalLaneWaitProgress(operation) },
+      );
+
+      await vi.advanceTimersByTimeAsync(RUN_STALE_TAKEOVER_MS + 1);
+      expect(operation.phase).toBe("waiting_for_global_lane");
+      expect(isReplyRunEvidenceStale(operation)).toBe(false);
+      expect(ran).toBe(false);
+
+      setCommandLaneConcurrency(lane, 1);
+      await queued;
+
+      expect(ran).toBe(true);
+      expect(operation.phase).toBe("running");
+      expect(
+        getDiagnosticSessionActivitySnapshot({
+          sessionId: operation.sessionId,
+          sessionKey: operation.key,
+        }).lastProgressReason,
+      ).toBe("global_lane:wait_ended");
+    } finally {
+      operation.complete();
+      vi.useRealTimers();
+    }
   });
 
   it("clears deferred-maintenance operations immediately on user abort", () => {

--- a/src/auto-reply/reply/reply-run-registry.ts
+++ b/src/auto-reply/reply/reply-run-registry.ts
@@ -154,7 +154,7 @@ export type ReplyOperation = {
   readonly phase: ReplyOperationPhase;
   readonly result: ReplyOperationResult | null;
   /** Set when a stale-watchdog expiry forced this operation's run_stalled result. */
-  readonly staleExpiryReason: ReplyOperationStaleReason | undefined;
+  readonly staleExpiryReason?: ReplyOperationStaleReason;
   readonly startedAtMs: number;
   readonly lastActivityAtMs: number;
   /** True when this operation has owned the supplied session ID. */

--- a/src/auto-reply/reply/reply-run-registry.ts
+++ b/src/auto-reply/reply/reply-run-registry.ts
@@ -153,6 +153,8 @@ export type ReplyOperation = {
   readonly acceptedSteeredInboundAudio: boolean;
   readonly phase: ReplyOperationPhase;
   readonly result: ReplyOperationResult | null;
+  /** Set when a stale-watchdog expiry forced this operation's run_stalled result. */
+  readonly staleExpiryReason: ReplyOperationStaleReason | undefined;
   readonly startedAtMs: number;
   readonly lastActivityAtMs: number;
   /** True when this operation has owned the supplied session ID. */
@@ -585,6 +587,7 @@ export function createReplyOperation(params: {
   let currentSessionId = sessionId;
   let phase: ReplyOperationPhase = "queued";
   let phaseBeforeGlobalLaneWait: "queued" | "running" | undefined;
+  let staleExpiryReason: ReplyOperationStaleReason | undefined;
   let result: ReplyOperationResult | null = null;
   let stateCleared = false;
   let retainFailureUntilComplete = false;
@@ -707,6 +710,9 @@ export function createReplyOperation(params: {
     },
     get result() {
       return result;
+    },
+    get staleExpiryReason() {
+      return staleExpiryReason;
     },
     get startedAtMs() {
       return startedAtMs;
@@ -962,6 +968,9 @@ export function createReplyOperation(params: {
     if (!result) {
       abortFrozenOperations.add(operation);
       detachUpstreamAbort();
+      // The reason distinguishes pre-run drops (user got nothing; feedback owed)
+      // from post-output stalls (finalization/terminal cleanup; feedback is noise).
+      staleExpiryReason = reason;
       setResult({ kind: "failed", code: "run_stalled" });
       phase = "failed";
     }

--- a/src/auto-reply/reply/reply-run-registry.ts
+++ b/src/auto-reply/reply/reply-run-registry.ts
@@ -108,6 +108,7 @@ export function resolveReplyBackendQueueMessageMismatch(
 export type ReplyOperationPhase =
   | "queued"
   | "waiting_for_deferred_maintenance"
+  | "waiting_for_global_lane"
   | "preflight_compacting"
   | "memory_flushing"
   | "running"
@@ -161,6 +162,7 @@ export type ReplyOperation = {
     next:
       | "queued"
       | "waiting_for_deferred_maintenance"
+      | "waiting_for_global_lane"
       | "preflight_compacting"
       | "memory_flushing"
       | "running",
@@ -169,6 +171,10 @@ export type ReplyOperation = {
   markWaitingForDeferredMaintenance(): void;
   /** Return a maintenance-waiting operation to queued if the run has not started. */
   markDeferredMaintenanceWaitEnded(): void;
+  /** Mark this operation as waiting for process-global run capacity. */
+  markWaitingForGlobalLane(): void;
+  /** Return a global-lane-waiting operation to queued once capacity is granted. */
+  markGlobalLaneWaitEnded(): void;
   /** Mark this operation as an in-flight terminal-session recovery. */
   markTerminalRecovery(): void;
   markAcceptedSteeredInboundAudio(): void;
@@ -348,7 +354,11 @@ function isReplyRunCompacting(operation: ReplyOperation): boolean {
 }
 
 function isReplyOperationPreBackendPhase(phase: ReplyOperationPhase): boolean {
-  return phase === "queued" || phase === "waiting_for_deferred_maintenance";
+  return (
+    phase === "queued" ||
+    phase === "waiting_for_deferred_maintenance" ||
+    phase === "waiting_for_global_lane"
+  );
 }
 
 const attachedBackendByOperation = new WeakMap<ReplyOperation, ReplyBackendHandle>();
@@ -574,6 +584,7 @@ export function createReplyOperation(params: {
   let currentSessionKey = sessionKey;
   let currentSessionId = sessionId;
   let phase: ReplyOperationPhase = "queued";
+  let phaseBeforeGlobalLaneWait: "queued" | "running" | undefined;
   let result: ReplyOperationResult | null = null;
   let stateCleared = false;
   let retainFailureUntilComplete = false;
@@ -737,6 +748,32 @@ export function createReplyOperation(params: {
         sessionKey: currentSessionKey,
         sessionId: currentSessionId,
         reason: "deferred_maintenance:wait_ended",
+      });
+    },
+    markWaitingForGlobalLane() {
+      if (result || (phase !== "queued" && phase !== "running")) {
+        return;
+      }
+      // Queued-on-lane is healthy waiting, not a wedged run. Removing this phase
+      // lets stale recovery silently drop replies while global capacity is busy.
+      phaseBeforeGlobalLaneWait = phase;
+      phase = "waiting_for_global_lane";
+      markReplyRunDiagnosticProgress({
+        sessionKey: currentSessionKey,
+        sessionId: currentSessionId,
+        reason: "global_lane:waiting",
+      });
+    },
+    markGlobalLaneWaitEnded() {
+      if (result || phase !== "waiting_for_global_lane") {
+        return;
+      }
+      phase = phaseBeforeGlobalLaneWait ?? "queued";
+      phaseBeforeGlobalLaneWait = undefined;
+      markReplyRunDiagnosticProgress({
+        sessionKey: currentSessionKey,
+        sessionId: currentSessionId,
+        reason: "global_lane:wait_ended",
       });
     },
     markTerminalRecovery() {
@@ -1064,8 +1101,20 @@ export function isReplyRunEvidenceStale(operation: ReplyOperation): boolean {
   });
   return (
     !operation.result &&
+    operation.phase !== "waiting_for_global_lane" &&
     Date.now() - operation.lastActivityAtMs > resolveRunStaleThresholdMs(activity)
   );
+}
+
+export function markReplyOperationGlobalLaneWaitProgress(operation: ReplyOperation): void {
+  if (operation.result || operation.phase !== "waiting_for_global_lane") {
+    return;
+  }
+  markReplyRunDiagnosticProgress({
+    sessionKey: operation.key,
+    sessionId: operation.sessionId,
+    reason: "global_lane:waiting",
+  });
 }
 
 export function isReplyRunEvidenceStaleBySessionId(sessionId: string): boolean {

--- a/src/logging/diagnostic-session-recovery.ts
+++ b/src/logging/diagnostic-session-recovery.ts
@@ -8,6 +8,7 @@ type DiagnosticSessionRecoverySkipReason =
   | "active_embedded_run"
   | "active_reply_work"
   | "deferred_maintenance_wait"
+  | "global_lane_wait"
   | "active_lane_task"
   | "already_in_flight"
   | "missing_session_ref"

--- a/src/logging/diagnostic-stuck-session-recovery.runtime.test.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.runtime.test.ts
@@ -187,6 +187,27 @@ describe("stuck session recovery", () => {
     expect(outcome.status).toBe("aborted");
     expect(warnLogMessages().some((m) => m.includes("reclaiming stale active run"))).toBe(true);
   });
+
+  it("reclaims an orphaned handle once classification age is stale without an activity record", async () => {
+    mocks.resolveActiveEmbeddedRunHandleSessionId.mockReturnValue("orphaned-session");
+    mocks.getDiagnosticSessionActivitySnapshot.mockReturnValue({});
+    mocks.abortEmbeddedAgentRun.mockReturnValue(true);
+    mocks.waitForEmbeddedAgentRunEnd.mockResolvedValue(true);
+
+    const outcome = await recoverStuckDiagnosticSession({
+      sessionId: "orphaned-session",
+      sessionKey: "agent:main:main",
+      ageMs: 10 * 60_000,
+      queueDepth: 1,
+    });
+
+    expect(mocks.abortEmbeddedAgentRun).toHaveBeenCalledWith("orphaned-session");
+    expect(outcome).toMatchObject({
+      status: "aborted",
+      action: "abort_embedded_run",
+      activeSessionId: "orphaned-session",
+    });
+  });
   it("aborts an active embedded run when active abort recovery is enabled", async () => {
     mocks.resolveActiveEmbeddedRunHandleSessionId.mockReturnValue("session-1");
     mocks.abortEmbeddedAgentRun.mockReturnValue(true);
@@ -472,6 +493,31 @@ describe("stuck session recovery", () => {
     expect(warnLogMessages()).toEqual([
       "stuck session recovery outcome: status=skipped action=keep_lane sessionId=queued-reply-session sessionKey=agent:main:main activeSessionId=queued-reply-session reason=deferred_maintenance_wait",
     ]);
+  });
+
+  it("keeps a reply queued on the global lane instead of reclaiming it", async () => {
+    mocks.resolveActiveEmbeddedRunSessionId.mockReturnValue("queued-reply-session");
+    mocks.resolveActiveEmbeddedRunHandleSessionId.mockReturnValue(undefined);
+    mocks.resolveEmbeddedAgentReplyRunPhase.mockReturnValue("waiting_for_global_lane");
+    mocks.isEmbeddedAgentRunActive.mockReturnValue(true);
+
+    const outcome = await recoverStuckDiagnosticSession({
+      sessionId: "queued-reply-session",
+      sessionKey: "agent:main:main",
+      ageMs: 15 * 60_000,
+      queueDepth: 1,
+      allowActiveAbort: true,
+    });
+
+    expect(outcome).toMatchObject({
+      status: "skipped",
+      action: "keep_lane",
+      reason: "global_lane_wait",
+      activeSessionId: "queued-reply-session",
+    });
+    expect(mocks.abortEmbeddedAgentRun).not.toHaveBeenCalled();
+    expect(mocks.forceClearEmbeddedAgentRun).not.toHaveBeenCalled();
+    expect(mocks.resetCommandLane).not.toHaveBeenCalled();
   });
 
   it("releases the session lane when abort+drain succeeds but queued messages remain (ghost run + queued messages)", async () => {

--- a/src/logging/diagnostic-stuck-session-recovery.runtime.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.runtime.ts
@@ -57,6 +57,7 @@ function resolveStaleActiveLaneTaskReleaseMs(params: StuckSessionRecoveryParams)
 }
 
 function isActiveRunProgressStale(params: {
+  ageMs: number;
   sessionId?: string;
   sessionKey?: string;
   queueDepth?: number;
@@ -70,7 +71,11 @@ function isActiveRunProgressStale(params: {
     sessionKey: params.sessionKey,
   });
   const lastProgressAgeMs = activity.lastProgressAgeMs;
-  return typeof lastProgressAgeMs === "number" && lastProgressAgeMs >= params.staleAbortMs;
+  // A missing activity row is the orphan-handle state: classification age is
+  // the only progress evidence available, so it owns the stale fallback.
+  return typeof lastProgressAgeMs === "number"
+    ? lastProgressAgeMs >= params.staleAbortMs
+    : params.ageMs >= params.staleAbortMs;
 }
 
 function formatRecoveryContext(
@@ -160,11 +165,30 @@ export async function recoverStuckDiagnosticSession(
     let forceCleared = false;
     const staleActiveProgressAbortMs = resolveStaleActiveProgressAbortMs(params);
     const staleActiveLaneTaskReleaseMs = resolveStaleActiveLaneTaskReleaseMs(params);
+    const activeReplyPhase = activeWorkSessionId
+      ? resolveEmbeddedAgentReplyRunPhase(activeWorkSessionId)
+      : undefined;
+
+    if (activeReplyPhase === "waiting_for_global_lane") {
+      // A global-lane queue owner is healthy pending work. Reclaiming it here
+      // reintroduces the silent reply drop that the wait phase prevents.
+      const outcome: StuckSessionRecoveryOutcome = {
+        status: "skipped",
+        action: "keep_lane",
+        reason: "global_lane_wait",
+        sessionId: params.sessionId,
+        sessionKey: params.sessionKey,
+        activeSessionId: activeWorkSessionId,
+      };
+      diag.warn(`stuck session recovery outcome: ${formatRecoveryOutcome(outcome)}`);
+      return outcome;
+    }
 
     if (activeSessionId) {
       const reclaimStaleActiveRun =
         params.allowActiveAbort !== true &&
         isActiveRunProgressStale({
+          ageMs: params.ageMs,
           sessionId: activeSessionId,
           sessionKey: params.sessionKey,
           queueDepth: params.queueDepth,
@@ -206,7 +230,6 @@ export async function recoverStuckDiagnosticSession(
     }
 
     if (!activeSessionId && activeWorkSessionId && isEmbeddedAgentRunActive(activeWorkSessionId)) {
-      const activeReplyPhase = resolveEmbeddedAgentReplyRunPhase(activeWorkSessionId);
       if (activeReplyPhase === "waiting_for_deferred_maintenance") {
         const outcome: StuckSessionRecoveryOutcome = {
           status: "skipped",
@@ -222,6 +245,7 @@ export async function recoverStuckDiagnosticSession(
       const reclaimStaleReplyWork =
         params.allowActiveAbort !== true &&
         isActiveRunProgressStale({
+          ageMs: params.ageMs,
           sessionId: activeWorkSessionId,
           sessionKey: params.sessionKey,
           queueDepth: params.queueDepth,

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -369,7 +369,7 @@ describe("stuck session diagnostics threshold", () => {
     );
   });
 
-  it("keeps queued stale sessions eligible for lane recovery", () => {
+  it("does not count a single in-flight turn as queued work without an active run", () => {
     const events: DiagnosticEventPayload[] = [];
     const recoverStuckSession = vi.fn();
     const unsubscribe = onDiagnosticEvent((event) => {
@@ -396,12 +396,12 @@ describe("stuck session diagnostics threshold", () => {
     expect(stuckEvents).toHaveLength(1);
     expectRecordFields(requireRecord(stuckEvents[0], "stuck event"), {
       classification: "stale_session_state",
-      reason: "queued_work_without_active_run",
-      queueDepth: 1,
+      reason: "stale_session_state",
+      queueDepth: 0,
     });
     expectRecoveryCall(
       recoverStuckSession,
-      { sessionId: "s1", sessionKey: "main", queueDepth: 1 },
+      { sessionId: "s1", sessionKey: "main", queueDepth: 0 },
       ["ageMs", "stateGeneration"],
     );
   });
@@ -1980,9 +1980,9 @@ describe("stuck session diagnostics threshold", () => {
     expect(longRunningEvents).toHaveLength(1);
     expectRecordFields(requireRecord(longRunningEvents[0], "long-running event"), {
       classification: "long_running",
-      reason: "queued_behind_active_work",
+      reason: "active_work",
       activeWorkKind: "embedded_run",
-      queueDepth: 1,
+      queueDepth: 0,
     });
     expect(recoverStuckSession).not.toHaveBeenCalled();
   });
@@ -2031,13 +2031,13 @@ describe("stuck session diagnostics threshold", () => {
       classification: "stalled_agent_run",
       reason: "queued_behind_terminal_active_work",
       activeWorkKind: "embedded_run",
-      queueDepth: 2,
+      queueDepth: 1,
       terminalProgressStale: true,
       lastProgressReason: terminalReason,
     });
     expectRecoveryCall(
       recoverStuckSession,
-      { sessionId: "s1", sessionKey: "main", queueDepth: 2, allowActiveAbort: true },
+      { sessionId: "s1", sessionKey: "main", queueDepth: 1, allowActiveAbort: true },
       ["ageMs", "stateGeneration"],
     );
   });

--- a/src/logging/diagnostic.ts
+++ b/src/logging/diagnostic.ts
@@ -236,6 +236,17 @@ function pushLimitedDiagnosticLabel(labels: string[], label: string, limit = 5):
   }
 }
 
+function resolveDiagnosticQueuedBacklog(state: {
+  activeQueuedTurn?: boolean;
+  queueDepth: number;
+  state: SessionStateValue;
+}): number {
+  return Math.max(
+    0,
+    state.queueDepth - (state.state === "processing" && state.activeQueuedTurn ? 1 : 0),
+  );
+}
+
 function getDiagnosticWorkSnapshot(now = Date.now()): DiagnosticWorkSnapshot {
   let activeCount = 0;
   let waitingCount = 0;
@@ -252,10 +263,7 @@ function getDiagnosticWorkSnapshot(now = Date.now()): DiagnosticWorkSnapshot {
       waitingCount += 1;
       pushLimitedDiagnosticLabel(waitingLabels, formatDiagnosticWorkLabel(state, now));
     }
-    const queuedBacklog = Math.max(
-      0,
-      state.queueDepth - (state.state === "processing" && state.activeQueuedTurn ? 1 : 0),
-    );
+    const queuedBacklog = resolveDiagnosticQueuedBacklog(state);
     if (queuedBacklog > 0) {
       pushLimitedDiagnosticLabel(queuedLabels, formatDiagnosticWorkLabel(state, now));
     }
@@ -1002,9 +1010,10 @@ export function logSessionAttention(
   );
   const stuckSessionAbortMs =
     params.abortThresholdMs ?? resolveStalledEmbeddedRunAbortMs(params.thresholdMs);
+  const queueDepth = resolveDiagnosticQueuedBacklog(state);
   const classification = classifySessionAttention({
     state: state.state as "idle" | "processing" | "waiting" | undefined,
-    queueDepth: state.queueDepth,
+    queueDepth,
     activity,
     staleMs: params.thresholdMs,
     stuckSessionAbortMs,
@@ -1070,11 +1079,11 @@ export function logSessionAttention(
   const message = `${label}: sessionId=${state.sessionId ?? "unknown"} sessionKey=${
     state.sessionKey ?? "unknown"
   } state=${params.state} age=${Math.round(params.ageMs / 1000)}s queueDepth=${
-    state.queueDepth
+    queueDepth
   } reason=${classification.reason} classification=${classification.classification}${
     classification.activeWorkKind ? ` activeWorkKind=${classification.activeWorkKind}` : ""
   }${detailFields ? ` ${detailFields}` : ""} recovery=${recoveryEligible ? "checking" : "none"}`;
-  if (classification.eventType === "session.long_running" && state.queueDepth <= 0) {
+  if (classification.eventType === "session.long_running" && queueDepth <= 0) {
     diag.debug(message);
   } else {
     diag.warn(message);
@@ -1084,7 +1093,7 @@ export function logSessionAttention(
     sessionKey: state.sessionKey,
     state: params.state,
     ageMs: params.ageMs,
-    queueDepth: state.queueDepth,
+    queueDepth,
     reason: classification.reason,
     ...sessionAttentionFields({ classification, activity }),
   };
@@ -1339,7 +1348,7 @@ export function startDiagnosticHeartbeat(
             sessionKey: state.sessionKey,
             sessionFile: state.sessionFile,
             ageMs: attentionAgeMs,
-            queueDepth: state.queueDepth,
+            queueDepth: resolveDiagnosticQueuedBacklog(state),
             expectedState: state.state,
             stateGeneration: state.generation,
             ...(activeAbortEligible


### PR DESCRIPTION
## What Problem This Solves

On busy gateways, a user's "Continue" can silently vanish. Every agent turn holds a slot on the process-global `main` lane for its entire run; with the lane saturated by long Codex runs, a newly-arrived reply for an *idle* session queues — but its activity clock started before the enqueue, so after ~6–10 minutes the reply is killed as a wedged run (`AbortError: Reply operation expired as stale`) with **zero user feedback**. Observed on team.openclaw.ai (2026-07-26): replies queued 19+ minutes (`lane wait exceeded: lane=main waitedMs=1168362 queueAhead=4 activeAhead=4`), then aborted; `session.stuck reason=queued_work_without_active_run` + `session.recovery.requested` fired every 30 s (69× in 25 min) without ever recovering anything; after each restart, recovery resumed the interrupted runs at foreground priority and re-starved fresh replies.

## Why This Change Was Made

- **Lane waits are now a tracked wait phase.** A reply enqueued on the global lane enters `waiting_for_global_lane` (mirroring the existing `waiting_for_deferred_maintenance` fence): reply staleness ignores it, stuck recovery skips it (`skipped/keep_lane reason=global_lane_wait`), and `onLaneWait` ticks stamp diagnostic progress.
- **Restart-recovery resumes run at background priority.** Resumed sessions are recognized by their restart-recovery input provenance and no longer contend with live user replies at foreground priority.
- **Dropped replies now say so.** When a reply operation genuinely expires while the gateway runs (`run_stalled`), the dispatcher sends an error reply instead of silently going idle.
- **The watchdog tells the truth.** `logSessionAttention` uses the same in-flight-adjusted backlog as the work snapshot, so a single processing message no longer classifies as `queued_work_without_active_run` with `queueDepth=1`.
- **Orphaned handles become reclaimable.** When the activity snapshot has no progress row at all (exactly the state the classifier detects), the classification age now owns the stale fallback, closing the `skipped/observe_only` forever-loop.

## User Impact

"Continue" during busy periods starts when capacity frees instead of being silently killed; if a reply is ever genuinely dropped, the user sees an error instead of nothing. Restarted gateways stop starving live users behind resumed background runs.

## Evidence

- Production forensics (journal + stability bundle, team.openclaw.ai 2026-07-26) in the PR discussion: 19-minute lane waits, 69 no-op recovery requests, silent reply drops.
- Focused tests: `node scripts/run-vitest.mjs src/auto-reply/reply/reply-run-registry.test.ts src/logging/diagnostic-stuck-session-recovery.runtime.test.ts src/logging/diagnostic.test.ts src/auto-reply/reply/dispatch-from-config.stale-recovery.test.ts src/auto-reply/reply/agent-runner-execution-lifecycle.test.ts` → 2 shards passed (240 tests in the worker run; re-verified).
- Note: `src/agents/embedded-agent-runner/run.codex-app-server-recovery.test.ts`'s warm-harness `beforeAll` times out on the development Mac identically on clean `origin/main` (17 skipped) — environmental; Linux CI is authoritative for it.
