### PR TITLE
fix(gateway): prevent missing assets on nested dashboard routes

### DIFF
--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -1090,6 +1090,56 @@ describe("handleControlUiHttpRequest", () => {
     });
   });
 
+  it.each([
+    {
+      name: "root-mounted nested routes",
+      requestPath: "/settings/approvals",
+      basePath: undefined,
+      expectedPrefix: "",
+    },
+    {
+      name: "base-mounted nested routes",
+      requestPath: "/openclaw/settings/approvals",
+      basePath: "/openclaw",
+      expectedPrefix: "/openclaw",
+    },
+  ])(
+    "anchors Vite-relative public asset hrefs for $name",
+    async ({ requestPath, basePath, expectedPrefix }) => {
+      const assets = [
+        "favicon.svg",
+        "favicon-32.png",
+        "apple-touch-icon.png",
+        "manifest.webmanifest",
+      ];
+      const html = `<html><head>${assets
+        .map((asset) => `<link href="./${asset}" />`)
+        .join("")}</head><body></body></html>\n`;
+
+      await withControlUiRoot({
+        indexHtml: html,
+        fn: async (tmp) => {
+          const { res, end } = makeMockHttpResponse();
+          const handled = await handleControlUiHttpRequest(
+            { url: requestPath, method: "GET" } as IncomingMessage,
+            res,
+            {
+              ...(basePath ? { basePath } : {}),
+              root: { kind: "resolved", path: tmp },
+            },
+          );
+
+          expect(handled).toBe(true);
+          const body = String(end.mock.calls[0]?.[0] ?? "");
+          for (const asset of assets) {
+            expect(body).toContain(`href="${expectedPrefix}/${asset}"`);
+            expect(body).not.toContain(`href="./${asset}"`);
+          }
+        },
+      });
+    },
+  );
+
   it("serves bootstrap config JSON", async () => {
     await withControlUiRoot({
       fn: async (tmp) => {

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -125,17 +125,18 @@ const CONTROL_UI_ROOT_PUBLIC_ASSETS = new Set([
   "sw.js",
 ]);
 
-/** Rewrites root-absolute Control UI public asset hrefs for configured base paths. */
+/** Anchors bundled public assets before deep-linked documents begin preloading. */
 function rewriteControlUiIndexHtmlPublicAssetHrefs(html: string, basePath: string): string {
   const normalized = normalizeControlUiBasePath(basePath);
-  if (!normalized) {
-    return html;
-  }
   let next = html;
   for (const asset of CONTROL_UI_ROOT_PUBLIC_ASSETS) {
-    const rootHref = `href="/${asset}"`;
-    const baseHref = `href="${normalized}/${asset}"`;
-    next = next.split(rootHref).join(baseHref);
+    const assetHref = `href="${normalized}/${asset}"`;
+    // Vite's portable ./ base emits relative hrefs, which the browser starts
+    // resolving against a nested route before the UI can correct them.
+    next = next.replaceAll(`href="./${asset}"`, assetHref);
+    if (normalized) {
+      next = next.replaceAll(`href="/${asset}"`, assetHref);
+    }
   }
   return next;
 }


### PR DESCRIPTION
Related: #94157

## What Problem This Solves

Fixes an issue where users opening a nested Control UI page, such as Settings or Approvals, would request favicons, touch icons, and the web app manifest relative to that page instead of the Control UI root. This caused genuine missing asset responses on both root-mounted and base-mounted dashboards.

## Why This Change Was Made

Normalize Vite-relative bundled public-asset hrefs in the existing Gateway Control UI HTML owner before the browser starts preloading. Preserve the existing configured-base handling for root-absolute hrefs, the constrained six-asset allowlist, routing, authentication, CSP, and static-file containment.

## User Impact

Directly opening or refreshing a nested dashboard page now loads the existing favicon, touch icon, and web app manifest from the correct root or configured base path.

## Evidence

- Latest main base: `8eafae4af749fe275f14ecf6d393975369ae6f4d`; candidate: `ae50a95e1e1fcbc0b5c6f8881d7b5d689e696914`; both author and committer are Peter Steinberger.
- Real failing-before: the two new root-mounted and base-mounted Gateway HTTP regressions fail against byte-identical current production; 107 unrelated cases are correctly skipped; authoritative trusted Testbox exit is `1`.
- Real passing-after on the rebased final candidate: all six Gateway HTTP, auto-root, routing, CSP, root-containment, and authentication modules pass: **205/205**, trusted Testbox command `pnpm test src/gateway/control-ui.http.test.ts src/gateway/control-ui-routing.test.ts src/gateway/control-ui-csp.test.ts src/gateway/control-ui.auto-root.http.test.ts src/gateway/server.control-ui-root.test.ts src/gateway/server.auth.control-ui.test.ts`, `exitCode=0`.
- Complete latest-head `pnpm check:changed` passes, including core and core-test tsgo, format, lint, dependency, SDK/owner, native-state, database-first, import-cycle, and pairing guards; authoritative remote `commandMs=267977`, `exitCode=0`.
- Fresh official `gpt-5.6-sol` high-reasoning branch autoreview against `origin/main`: no findings, patch correct, **0.95 confidence**, exit `0`.
- Testbox provenance: synthetic remote Git HEAD `151605110d1e2036efb99367465f617b8c1be4a3`; independently verified actual executed production blob `1696d0820b7b320d2a7063c91db2e254d9328739` and test blob `7a67d4eaf664cb62e2c95e244d65e82811d9872e`; the synthetic remote HEAD is not misrepresented as the public candidate.
- Preserved real built-Gateway browser proof is historical `908e181f3fc0c61a363cf90a6b090b1a20ef9864`, not this candidate: 30 before and 30 after Chromium/Firefox screenshots; **24 Firefox-owned nested-route public-asset 404s become zero**, while the 18 unrelated responses remain accurately reported. Current-head proof is the real Gateway owner regression, not a claim of newly captured screenshots.

AI-assisted; all final production and regression content exactly preserves the original Peter-authored two-file fix.

### Fresh exact-head real browser and Gateway proof

After the ClawSweeper request for direct current-head behavior evidence, I built the exact candidate Control UI on a freshly isolated trusted Testbox, verified all **610** finalized compressed sidecars and dashboard performance guards, resolved the actual system Chromium executable, and started two real Gateway processes with individually allocated loopback ports and temporary isolated state. This does not use the user Gateway or any mocked Gateway.

Actual Chromium output from exact candidate production blob `1696d0820b7b320d2a7063c91db2e254d9328739`:

```text
mount=/           route=/settings/general    document=200 health=pass assets=[/favicon.svg:200,/favicon-32.png:200,/apple-touch-icon.png:200,/manifest.webmanifest:200] ownedBrowser404s=0
mount=/           route=/settings/approvals  document=200 health=pass assets=[/favicon.svg:200,/favicon-32.png:200,/apple-touch-icon.png:200,/manifest.webmanifest:200] ownedBrowser404s=0
mount=/openclaw   route=/settings/general    document=200 health=pass assets=[/openclaw/favicon.svg:200,/openclaw/favicon-32.png:200,/openclaw/apple-touch-icon.png:200,/openclaw/manifest.webmanifest:200] ownedBrowser404s=0
mount=/openclaw   route=/settings/approvals  document=200 health=pass assets=[/openclaw/favicon.svg:200,/openclaw/favicon-32.png:200,/openclaw/apple-touch-icon.png:200,/openclaw/manifest.webmanifest:200] ownedBrowser404s=0
```

The real browser independently verifies the actual document head has all four correctly anchored hrefs with no `./` href, no visible `GatewayRequestError` or `UNKNOWN_AGENT`, and persists **four actual 1440×1000 screenshots** as `chromium-root-general.png`, `chromium-root-approvals.png`, `chromium-base-general.png`, and `chromium-base-approvals.png` under the remote Testbox `.artifacts/control-ui-e2e/autoqa-deep-route-public-assets-ae50/`. Screenshot files are remote artifacts, not falsely represented as downloaded. The command genuinely completes on `tbx_01kyeky924qeyb3vx2g423077s`, `commandMs=36711`, `exitCode=0`; both temporary Gateway processes and state directories are cleaned up.

Exact candidate CI run `30191910001` and its required `openclaw/ci-gate` genuinely complete **SUCCESS**. Upstream has advanced in unrelated session-observer files; both Gateway asset owner blobs remain byte-identical, and the native reviewed merge is conflict-free. The prior `908e181f` Firefox screenshots remain correctly labeled historical rather than substituted for this new real current-head proof.