### PR TITLE
perf(cli): skip config load for root help when plugins are unaffected

### DIFF
--- a/src/cli/root-help-live-config.test.ts
+++ b/src/cli/root-help-live-config.test.ts
@@ -1,8 +1,12 @@
 // Root help live config tests cover root help output derived from live config state.
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { loadRootHelpRenderOptionsForConfigSensitivePlugins } from "./root-help-live-config.js";
 
 const readConfigFileSnapshotMock = vi.hoisted(() => vi.fn());
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 vi.mock("../config/config.js", () => ({
   readConfigFileSnapshot: readConfigFileSnapshotMock,
@@ -48,5 +52,454 @@ describe("root help live config", () => {
       config: runtimeConfig,
       env,
     });
+  });
+});
+
+describe("root help live config fast path", () => {
+  let home: string;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    home = tempDirs.make("root-help-home-");
+    vi.stubEnv("HOME", home);
+    vi.stubEnv("OPENCLAW_HOME", undefined);
+    vi.stubEnv("OPENCLAW_STATE_DIR", undefined);
+    vi.stubEnv("OPENCLAW_CONFIG_PATH", undefined);
+    vi.stubEnv("OPENCLAW_BUNDLED_PLUGINS_DIR", undefined);
+    vi.stubEnv("OPENCLAW_DISABLE_BUNDLED_PLUGINS", undefined);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  function writeConfig(contents: string): void {
+    fs.mkdirSync(path.join(home, ".openclaw"), { recursive: true });
+    fs.writeFileSync(path.join(home, ".openclaw", "openclaw.json"), contents);
+  }
+
+  function writePluginSensitiveConfig(configPath: string): void {
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(configPath, JSON.stringify({ plugins: { enabled: false } }));
+    const runtimeConfig = { plugins: { enabled: false } };
+    readConfigFileSnapshotMock.mockResolvedValueOnce({
+      valid: true,
+      sourceConfig: runtimeConfig,
+      runtimeConfig,
+    });
+  }
+
+  it("skips the config load when no config file exists", async () => {
+    await expect(loadRootHelpRenderOptionsForConfigSensitivePlugins()).resolves.toBeNull();
+    expect(readConfigFileSnapshotMock).not.toHaveBeenCalled();
+  });
+
+  it("loads the config when the configured file cannot be read", async () => {
+    writeConfig(JSON.stringify({ plugins: {} }));
+    const readError = Object.assign(new Error("unreadable config"), { code: "EACCES" });
+    const readFileSyncSpy = vi.spyOn(fs, "readFileSync").mockImplementation(() => {
+      throw readError;
+    });
+    readConfigFileSnapshotMock.mockResolvedValueOnce({
+      valid: false,
+      sourceConfig: {},
+      runtimeConfig: {},
+    });
+
+    try {
+      await expect(loadRootHelpRenderOptionsForConfigSensitivePlugins()).resolves.toBeNull();
+      expect(readConfigFileSnapshotMock).toHaveBeenCalledTimes(1);
+    } finally {
+      readFileSyncSpy.mockRestore();
+      readConfigFileSnapshotMock.mockReset();
+    }
+  });
+
+  it("skips the config load for a config whose plugins cannot affect help", async () => {
+    writeConfig(JSON.stringify({ plugins: {} }));
+
+    await expect(loadRootHelpRenderOptionsForConfigSensitivePlugins()).resolves.toBeNull();
+    expect(readConfigFileSnapshotMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps the fast path for an empty plugins.installs record", async () => {
+    writeConfig(JSON.stringify({ plugins: { installs: {} } }));
+
+    await expect(loadRootHelpRenderOptionsForConfigSensitivePlugins()).resolves.toBeNull();
+
+    expect(readConfigFileSnapshotMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps legacy installs plugin-sensitive through snapshot migration", async () => {
+    const persistedConfig = {
+      plugins: {
+        installs: {
+          demo: {
+            source: "npm",
+            spec: "demo@latest",
+            installedAt: "2026-08-20T00:00:00.000Z",
+          },
+        },
+      },
+    };
+    writeConfig(JSON.stringify(persistedConfig));
+    const actualConfig =
+      await vi.importActual<typeof import("../config/config.js")>("../config/config.js");
+    readConfigFileSnapshotMock.mockImplementationOnce(actualConfig.readConfigFileSnapshot);
+
+    const result = await loadRootHelpRenderOptionsForConfigSensitivePlugins();
+
+    expect(result).not.toBeNull();
+    expect(result?.config?.plugins?.installs).toBeUndefined();
+    expect(readConfigFileSnapshotMock).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    { config: { plugins: null }, name: "plugins=null" },
+    { config: { plugins: [] }, name: "plugins=[]" },
+    { config: { plugins: { enabled: null } }, name: "plugins.enabled=null" },
+    { config: { plugins: { allow: null } }, name: "plugins.allow=null" },
+    { config: { plugins: { allow: ["plugin", 1] } }, name: "plugins.allow=[string,number]" },
+    { config: { plugins: { deny: null } }, name: "plugins.deny=null" },
+    { config: { plugins: { deny: ["plugin", 1] } }, name: "plugins.deny=[string,number]" },
+    { config: { plugins: { entries: null } }, name: "plugins.entries=null" },
+    { config: { plugins: { entries: [] } }, name: "plugins.entries=[]" },
+    { config: { plugins: { slots: null } }, name: "plugins.slots=null" },
+    { config: { plugins: { installs: 1 } }, name: "plugins.installs=number" },
+    { config: { plugins: { load: null } }, name: "plugins.load=null" },
+    { config: { plugins: { load: { paths: null } } }, name: "plugins.load.paths=null" },
+    {
+      config: { plugins: { load: { paths: ["./plugins", 1] } } },
+      name: "plugins.load.paths=[string,number]",
+    },
+    { config: { plugins: { unknown: true } }, name: "plugins.unknown=true" },
+    { config: { plugins: { load: { unknown: true } } }, name: "plugins.load.unknown=true" },
+  ])("loads the config when $name is not a canonical plugin shape", async ({ config }) => {
+    writeConfig(JSON.stringify(config));
+    readConfigFileSnapshotMock.mockResolvedValueOnce({
+      valid: false,
+      sourceConfig: {},
+      runtimeConfig: {},
+    });
+
+    try {
+      await expect(loadRootHelpRenderOptionsForConfigSensitivePlugins()).resolves.toBeNull();
+      expect(readConfigFileSnapshotMock).toHaveBeenCalledTimes(1);
+    } finally {
+      readConfigFileSnapshotMock.mockReset();
+    }
+  });
+
+  it("loads the config when plugins.enabled is false", async () => {
+    writeConfig(JSON.stringify({ plugins: { enabled: false } }));
+    const runtimeConfig = { plugins: { enabled: false } };
+    readConfigFileSnapshotMock.mockResolvedValueOnce({
+      valid: true,
+      sourceConfig: runtimeConfig,
+      runtimeConfig,
+    });
+
+    await expect(loadRootHelpRenderOptionsForConfigSensitivePlugins()).resolves.not.toBeNull();
+    expect(readConfigFileSnapshotMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("loads the config when config-owned env vars affect plugin help", async () => {
+    const config = {
+      env: { vars: { OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" } },
+    };
+    writeConfig(JSON.stringify(config));
+    readConfigFileSnapshotMock.mockResolvedValueOnce({
+      valid: true,
+      sourceConfig: config,
+      runtimeConfig: config,
+    });
+
+    try {
+      await loadRootHelpRenderOptionsForConfigSensitivePlugins();
+      expect(readConfigFileSnapshotMock).toHaveBeenCalledTimes(1);
+    } finally {
+      readConfigFileSnapshotMock.mockReset();
+    }
+  });
+
+  it("loads the config when env.vars trims a plugin key", async () => {
+    const config = {
+      env: { vars: { " OPENCLAW_DISABLE_BUNDLED_PLUGINS ": "1" } },
+    };
+    writeConfig(JSON.stringify(config));
+    readConfigFileSnapshotMock.mockResolvedValueOnce({
+      valid: false,
+      sourceConfig: {},
+      runtimeConfig: {},
+    });
+
+    await loadRootHelpRenderOptionsForConfigSensitivePlugins();
+
+    expect(readConfigFileSnapshotMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("loads the config when a direct env key trims to a plugin key", async () => {
+    const config = {
+      env: { " OPENCLAW_BUNDLED_PLUGINS_DIR ": "/tmp/plugins" },
+    };
+    writeConfig(JSON.stringify(config));
+    readConfigFileSnapshotMock.mockResolvedValueOnce({
+      valid: false,
+      sourceConfig: {},
+      runtimeConfig: {},
+    });
+
+    await loadRootHelpRenderOptionsForConfigSensitivePlugins();
+
+    expect(readConfigFileSnapshotMock).toHaveBeenCalledTimes(1);
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "keeps mixed-case config env keys distinct on POSIX",
+    async () => {
+      writeConfig(JSON.stringify({ env: { vars: { openclaw_disable_bundled_plugins: "1" } } }));
+
+      await expect(loadRootHelpRenderOptionsForConfigSensitivePlugins()).resolves.toBeNull();
+
+      expect(readConfigFileSnapshotMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it.runIf(process.platform === "win32")(
+    "matches mixed-case config env keys on Windows",
+    async () => {
+      const config = { env: { vars: { openclaw_disable_bundled_plugins: "1" } } };
+      writeConfig(JSON.stringify(config));
+      readConfigFileSnapshotMock.mockResolvedValueOnce({
+        valid: false,
+        sourceConfig: {},
+        runtimeConfig: {},
+      });
+
+      await loadRootHelpRenderOptionsForConfigSensitivePlugins();
+
+      expect(readConfigFileSnapshotMock).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it.each([
+    { env: null, name: "env=null" },
+    { env: [], name: "env=[]" },
+    { env: { vars: null }, name: "env.vars=null" },
+    { env: { vars: [] }, name: "env.vars=[]" },
+    { env: { vars: { "NOT PORTABLE": "value" } }, name: "non-portable env.vars key" },
+    { env: { OTHER: 1 }, name: "non-string direct env value" },
+  ])("loads the config for malformed $name", async ({ env }) => {
+    writeConfig(JSON.stringify({ env }));
+    readConfigFileSnapshotMock.mockResolvedValueOnce({
+      valid: false,
+      sourceConfig: {},
+      runtimeConfig: {},
+    });
+
+    await loadRootHelpRenderOptionsForConfigSensitivePlugins();
+
+    expect(readConfigFileSnapshotMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("loads plugin-sensitive config when the plugins key uses a JSON escape", async () => {
+    writeConfig('{"pl\\u0075gins":{"enabled":false}}');
+    const runtimeConfig = { plugins: { enabled: false } };
+    readConfigFileSnapshotMock.mockResolvedValueOnce({
+      valid: true,
+      sourceConfig: runtimeConfig,
+      runtimeConfig,
+    });
+
+    await expect(loadRootHelpRenderOptionsForConfigSensitivePlugins()).resolves.not.toBeNull();
+    expect(readConfigFileSnapshotMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("loads the config when a nested include key uses a JSON escape", async () => {
+    writeConfig('{"plugins":{"$incl\\u0075de":"./plugins.json"}}');
+    const runtimeConfig = { plugins: { enabled: false } };
+    readConfigFileSnapshotMock.mockResolvedValueOnce({
+      valid: true,
+      sourceConfig: runtimeConfig,
+      runtimeConfig,
+    });
+
+    await expect(loadRootHelpRenderOptionsForConfigSensitivePlugins()).resolves.not.toBeNull();
+    expect(readConfigFileSnapshotMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("loads plugin-sensitive config from OPENCLAW_HOME", async () => {
+    const openclawHome = tempDirs.make("root-help-openclaw-home-");
+    fs.mkdirSync(path.join(openclawHome, ".openclaw"), { recursive: true });
+    fs.writeFileSync(
+      path.join(openclawHome, ".openclaw", "openclaw.json"),
+      JSON.stringify({ plugins: { enabled: false } }),
+    );
+    vi.stubEnv("OPENCLAW_HOME", openclawHome);
+    const runtimeConfig = { plugins: { enabled: false } };
+    readConfigFileSnapshotMock.mockResolvedValueOnce({
+      valid: true,
+      sourceConfig: runtimeConfig,
+      runtimeConfig,
+    });
+
+    await expect(loadRootHelpRenderOptionsForConfigSensitivePlugins()).resolves.not.toBeNull();
+    expect(readConfigFileSnapshotMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("loads plugin-sensitive config from a relative OPENCLAW_CONFIG_PATH", async () => {
+    const configPath = path.join(home, "relative-config", "openclaw.json");
+    writePluginSensitiveConfig(configPath);
+    vi.stubEnv("OPENCLAW_CONFIG_PATH", path.relative(process.cwd(), configPath));
+
+    await expect(loadRootHelpRenderOptionsForConfigSensitivePlugins()).resolves.not.toBeNull();
+    expect(readConfigFileSnapshotMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("loads plugin-sensitive config from a tilde-prefixed OPENCLAW_CONFIG_PATH", async () => {
+    const configPath = path.join(home, "tilde-config", "openclaw.json");
+    writePluginSensitiveConfig(configPath);
+    vi.stubEnv("OPENCLAW_CONFIG_PATH", "~/tilde-config/openclaw.json");
+
+    await expect(loadRootHelpRenderOptionsForConfigSensitivePlugins()).resolves.not.toBeNull();
+    expect(readConfigFileSnapshotMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("loads plugin-sensitive config from a relative OPENCLAW_STATE_DIR", async () => {
+    const stateDir = path.join(home, "relative-state");
+    writePluginSensitiveConfig(path.join(stateDir, "openclaw.json"));
+    vi.stubEnv("OPENCLAW_STATE_DIR", path.relative(process.cwd(), stateDir));
+
+    await expect(loadRootHelpRenderOptionsForConfigSensitivePlugins()).resolves.not.toBeNull();
+    expect(readConfigFileSnapshotMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("loads plugin-sensitive config from a tilde-prefixed OPENCLAW_STATE_DIR", async () => {
+    const stateDir = path.join(home, "tilde-state");
+    writePluginSensitiveConfig(path.join(stateDir, "openclaw.json"));
+    vi.stubEnv("OPENCLAW_STATE_DIR", "~/tilde-state");
+
+    await expect(loadRootHelpRenderOptionsForConfigSensitivePlugins()).resolves.not.toBeNull();
+    expect(readConfigFileSnapshotMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("loads the config when the legacy gateway.env sets a plugin env var (#85396)", async () => {
+    fs.mkdirSync(path.join(home, ".config", "openclaw"), { recursive: true });
+    fs.writeFileSync(
+      path.join(home, ".config", "openclaw", "gateway.env"),
+      "OPENCLAW_DISABLE_BUNDLED_PLUGINS=1\n",
+    );
+    readConfigFileSnapshotMock.mockResolvedValueOnce({
+      valid: true,
+      sourceConfig: {},
+      runtimeConfig: {},
+    });
+
+    await loadRootHelpRenderOptionsForConfigSensitivePlugins();
+    expect(readConfigFileSnapshotMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("loads the config when dotenv uses a lower-case plugin key", async () => {
+    fs.mkdirSync(path.join(home, ".config", "openclaw"), { recursive: true });
+    fs.writeFileSync(
+      path.join(home, ".config", "openclaw", "gateway.env"),
+      "openclaw_disable_bundled_plugins=1\n",
+    );
+    readConfigFileSnapshotMock.mockResolvedValueOnce({
+      valid: true,
+      sourceConfig: {},
+      runtimeConfig: {},
+    });
+
+    try {
+      await loadRootHelpRenderOptionsForConfigSensitivePlugins();
+      expect(readConfigFileSnapshotMock).toHaveBeenCalledTimes(1);
+    } finally {
+      readConfigFileSnapshotMock.mockReset();
+    }
+  });
+
+  it("loads the config when a .env beside OPENCLAW_CONFIG_PATH sets a plugin env var (#85396)", async () => {
+    const configDir = path.join(home, "custom");
+    fs.mkdirSync(configDir, { recursive: true });
+    fs.writeFileSync(path.join(configDir, "openclaw.json"), "{}");
+    fs.writeFileSync(path.join(configDir, ".env"), "OPENCLAW_DISABLE_BUNDLED_PLUGINS=1\n");
+    vi.stubEnv("OPENCLAW_CONFIG_PATH", path.join(configDir, "openclaw.json"));
+    readConfigFileSnapshotMock.mockResolvedValueOnce({
+      valid: true,
+      sourceConfig: {},
+      runtimeConfig: {},
+    });
+
+    await loadRootHelpRenderOptionsForConfigSensitivePlugins();
+    expect(readConfigFileSnapshotMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("loads the config when a symlinked state .env target sets a plugin env var", async () => {
+    writeConfig("{}");
+    const targetPath = path.join(home, "dotenv-target");
+    fs.writeFileSync(targetPath, "OPENCLAW_DISABLE_BUNDLED_PLUGINS=1\n");
+    fs.symlinkSync(targetPath, path.join(home, ".openclaw", ".env"));
+    readConfigFileSnapshotMock.mockResolvedValueOnce({
+      valid: true,
+      sourceConfig: {},
+      runtimeConfig: {},
+    });
+
+    await expect(loadRootHelpRenderOptionsForConfigSensitivePlugins()).resolves.toBeNull();
+    expect(readConfigFileSnapshotMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips a nonregular state .env directory and retains the safe config fast path", async () => {
+    writeConfig("{}");
+    fs.mkdirSync(path.join(home, ".openclaw", ".env"));
+
+    await expect(loadRootHelpRenderOptionsForConfigSensitivePlugins()).resolves.toBeNull();
+    expect(readConfigFileSnapshotMock).not.toHaveBeenCalled();
+  });
+
+  it("does not scan plugin keys beyond the dotenv read bound", async () => {
+    const dotEnvPath = path.join(home, ".openclaw", ".env");
+    fs.mkdirSync(path.dirname(dotEnvPath), { recursive: true });
+    fs.writeFileSync(
+      dotEnvPath,
+      `${"#".repeat(1024 * 1024 + 1)}\nOPENCLAW_DISABLE_BUNDLED_PLUGINS=1\n`,
+    );
+
+    readConfigFileSnapshotMock.mockResolvedValueOnce({
+      valid: false,
+      sourceConfig: {},
+      runtimeConfig: {},
+    });
+    try {
+      await expect(loadRootHelpRenderOptionsForConfigSensitivePlugins()).resolves.toBeNull();
+      expect(readConfigFileSnapshotMock).not.toHaveBeenCalled();
+    } finally {
+      readConfigFileSnapshotMock.mockReset();
+    }
+  });
+
+  it("loads the config when the raw config uses an include directive", async () => {
+    writeConfig('{"$include":"./other.json"}');
+    readConfigFileSnapshotMock.mockResolvedValueOnce({
+      valid: true,
+      sourceConfig: {},
+      runtimeConfig: {},
+    });
+
+    await loadRootHelpRenderOptionsForConfigSensitivePlugins();
+    expect(readConfigFileSnapshotMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("loads the config when the raw config is not plain JSON", async () => {
+    writeConfig("{ plugins: { /* JSON5 */ } }");
+    readConfigFileSnapshotMock.mockResolvedValueOnce({
+      valid: true,
+      sourceConfig: {},
+      runtimeConfig: {},
+    });
+
+    await loadRootHelpRenderOptionsForConfigSensitivePlugins();
+    expect(readConfigFileSnapshotMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/cli/root-help-live-config.ts
+++ b/src/cli/root-help-live-config.ts
@@ -1,5 +1,24 @@
-// Root-help config probe for plugin-sensitive help rendering.
+import fs from "node:fs";
+import path from "node:path";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import {
+  inspectShippedPluginInstallConfigRecords,
+  stripShippedPluginInstallConfigRecords,
+} from "../config/plugin-install-config-migration.js";
+import type { OpenClawConfig } from "../config/types.js";
+import { resolveRequiredHomeDir, resolveUserPath } from "../infra/home-dir.js";
+import { normalizeEnvVarKey } from "../infra/host-env-security.js";
 import type { RootHelpRenderOptions } from "./program/root-help.js";
+
+/** Env vars that can change which plugins root help renders. */
+const PLUGIN_ENV_KEYS = [
+  "OPENCLAW_BUNDLED_PLUGINS_DIR",
+  "OPENCLAW_DISABLE_BUNDLED_PLUGINS",
+] as const;
+
+const MAX_DOTENV_FILE_BYTES = 1024 * 1024;
+const PLUGIN_RECORD_KEYS = ["slots", "entries", "installs", "load"] as const;
+const PLUGIN_KEYS = ["enabled", "allow", "deny", "installs", "load", "slots", "entries"] as const;
 
 function hasEntries(value: object | undefined): boolean {
   return value !== undefined && Object.keys(value).length > 0;
@@ -9,32 +28,290 @@ function hasListEntries(value: string[] | undefined): boolean {
   return Array.isArray(value) && value.length > 0;
 }
 
-/** Load render options only when config/env can affect plugin help output. */
-export async function loadRootHelpRenderOptionsForConfigSensitivePlugins(
-  env: NodeJS.ProcessEnv = process.env,
-): Promise<RootHelpRenderOptions | null> {
-  const configModule = await import("../config/config.js");
-  const snapshot = await configModule.readConfigFileSnapshot({
-    observe: false,
-    skipPluginValidation: true,
-  });
-  if (!snapshot.valid) {
-    return null;
-  }
-  const plugins = snapshot.sourceConfig.plugins;
-  const configAffectsPluginHelp =
+type PluginsConfigShape =
+  | {
+      enabled?: boolean;
+      allow?: string[];
+      deny?: string[];
+      load?: { paths?: string[] };
+      slots?: object;
+      entries?: object;
+    }
+  | undefined;
+
+function pluginsAffectHelp(plugins: PluginsConfigShape): boolean {
+  return Boolean(
     plugins &&
     (plugins.enabled === false ||
       hasListEntries(plugins.allow) ||
       hasListEntries(plugins.deny) ||
       hasListEntries(plugins.load?.paths) ||
       hasEntries(plugins.slots) ||
-      hasEntries(plugins.entries) ||
-      hasEntries(plugins.installs));
-  const envAffectsPluginHelp = Boolean(
+      hasEntries(plugins.entries)),
+  );
+}
+
+function hasInvalidStringList(value: unknown): boolean {
+  return (
+    value !== undefined &&
+    (!Array.isArray(value) || value.some((entry) => typeof entry !== "string"))
+  );
+}
+
+function hasInvalidPluginRecord(plugins: unknown): boolean {
+  if (plugins === undefined) {
+    return false;
+  }
+  if (!isRecord(plugins)) {
+    return true;
+  }
+  if (
+    Object.keys(plugins).some(
+      // SAFETY: PLUGIN_KEYS contains only strings, and includes performs runtime string equality.
+      (key) => !PLUGIN_KEYS.includes(key as (typeof PLUGIN_KEYS)[number]),
+    ) ||
+    (plugins.enabled !== undefined && typeof plugins.enabled !== "boolean") ||
+    hasInvalidStringList(plugins.allow) ||
+    hasInvalidStringList(plugins.deny)
+  ) {
+    return true;
+  }
+  if (PLUGIN_RECORD_KEYS.some((key) => plugins[key] !== undefined && !isRecord(plugins[key]))) {
+    return true;
+  }
+  const load = plugins.load;
+  return (
+    isRecord(load) &&
+    (Object.keys(load).some((key) => key !== "paths") || hasInvalidStringList(load.paths))
+  );
+}
+
+function envAffectsPluginHelp(env: NodeJS.ProcessEnv): boolean {
+  return Boolean(
     env.OPENCLAW_BUNDLED_PLUGINS_DIR?.trim() || env.OPENCLAW_DISABLE_BUNDLED_PLUGINS?.trim(),
   );
-  if (!envAffectsPluginHelp && !configAffectsPluginHelp) {
+}
+
+function configEnvCannotAffectPluginHelp(value: unknown): boolean {
+  if (value === undefined) {
+    return true;
+  }
+  if (!isRecord(value) || value.shellEnv !== undefined) {
+    return false;
+  }
+  const vars = value.vars;
+  if (vars !== undefined && !isRecord(vars)) {
+    return false;
+  }
+  const entries = [
+    ...(vars === undefined ? [] : Object.entries(vars)),
+    ...Object.entries(value).filter(([rawKey]) => rawKey !== "vars" && rawKey !== "shellEnv"),
+  ];
+  return entries.every(([rawKey, envValue]) => {
+    if (typeof envValue !== "string") {
+      return false;
+    }
+    const key = normalizeEnvVarKey(rawKey, { portable: true });
+    if (!key) {
+      return false;
+    }
+    const platformKey = process.platform === "win32" ? key.toUpperCase() : key;
+    return !PLUGIN_ENV_KEYS.some((pluginKey) => pluginKey === platformKey);
+  });
+}
+
+/**
+ * Config dir as `resolveConfigDir` computes it, without importing the config
+ * module. Kept deliberately in step with `src/utils.ts`.
+ */
+function configDirForProbe(env: NodeJS.ProcessEnv): string {
+  const stateOverride = env.OPENCLAW_STATE_DIR?.trim();
+  if (stateOverride) {
+    return resolveUserPath(stateOverride, env);
+  }
+  const configPath = env.OPENCLAW_CONFIG_PATH?.trim();
+  if (configPath) {
+    return path.dirname(resolveUserPath(configPath, env));
+  }
+  return path.join(resolveRequiredHomeDir(env), ".openclaw");
+}
+
+function configPathsForProbe(env: NodeJS.ProcessEnv): string[] {
+  const override = env.OPENCLAW_CONFIG_PATH?.trim();
+  if (override) {
+    return [resolveUserPath(override, env)];
+  }
+  const stateOverride = env.OPENCLAW_STATE_DIR?.trim();
+  if (stateOverride) {
+    const stateDir = resolveUserPath(stateOverride, env);
+    return [path.join(stateDir, "openclaw.json"), path.join(stateDir, "clawdbot.json")];
+  }
+  const home = resolveRequiredHomeDir(env);
+  return [
+    path.join(home, ".openclaw", "openclaw.json"),
+    path.join(home, ".openclaw", "clawdbot.json"),
+    path.join(home, ".clawdbot", "openclaw.json"),
+    path.join(home, ".clawdbot", "clawdbot.json"),
+  ];
+}
+
+function readFirstConfigText(env: NodeJS.ProcessEnv): string | null | undefined {
+  for (const candidate of configPathsForProbe(env)) {
+    try {
+      return fs.readFileSync(candidate, "utf8");
+    } catch (error) {
+      // SAFETY: Node's fs.readFileSync reports filesystem failures as NodeJS.ErrnoException objects.
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        return undefined;
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * The dotenv files the config read would load, in the same order and under the
+ * same state-dir condition as `loadGlobalRuntimeDotEnvFiles`. Reading the config
+ * has the side effect of loading these, so the fast path must account for them
+ * before it can skip that read.
+ */
+function dotEnvPathsForProbe(env: NodeJS.ProcessEnv): string[] {
+  const paths: string[] = [];
+  try {
+    paths.push(path.join(process.cwd(), ".env"));
+  } catch {
+    // Deleted cwd: nothing to read.
+  }
+  const configDir = configDirForProbe(env);
+  const stateEnvPath = path.join(configDir, ".env");
+  paths.push(stateEnvPath);
+  const home = resolveRequiredHomeDir(env);
+  const defaultStateEnvPath = path.join(home, ".openclaw", ".env");
+  const hasExplicitNonDefaultStateDir =
+    env.OPENCLAW_STATE_DIR?.trim() !== undefined &&
+    path.resolve(stateEnvPath) !== path.resolve(defaultStateEnvPath);
+  if (!hasExplicitNonDefaultStateDir) {
+    paths.push(path.join(home, ".config", "openclaw", "gateway.env"));
+  }
+  return [...new Set(paths)];
+}
+
+async function anyDotEnvMentionsPluginKey(env: NodeJS.ProcessEnv): Promise<boolean> {
+  for (const dotEnvPath of dotEnvPathsForProbe(env)) {
+    let text: string;
+    try {
+      const resolved = fs.realpathSync(dotEnvPath);
+      // Keep the fs-safe dependency off the common no-dotenv help path.
+      const { readRegularFileSync } = await import("../infra/regular-file.js");
+      const { buffer } = readRegularFileSync({
+        filePath: resolved,
+        maxBytes: MAX_DOTENV_FILE_BYTES,
+      });
+      text = buffer.toString("utf8").toUpperCase();
+    } catch {
+      continue;
+    }
+    if (PLUGIN_ENV_KEYS.some((key) => text.includes(key))) {
+      return true;
+    }
+  }
+  return false;
+}
+
+type ConfigProbeResult = {
+  cannotAffectHelp: boolean;
+  rawInstallsAffectHelp: boolean;
+  rawInstallsConfig?: OpenClawConfig;
+};
+
+const CONSERVATIVE_CONFIG_PROBE: ConfigProbeResult = {
+  cannotAffectHelp: false,
+  rawInstallsAffectHelp: false,
+};
+
+/** Inspect raw config facts that must survive canonical snapshot migration. */
+function inspectConfigForPluginHelp(env: NodeJS.ProcessEnv): ConfigProbeResult {
+  const raw = readFirstConfigText(env);
+  if (raw === null) {
+    return { cannotAffectHelp: true, rawInstallsAffectHelp: false };
+  }
+  if (raw === undefined) {
+    return CONSERVATIVE_CONFIG_PROBE;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return CONSERVATIVE_CONFIG_PROBE;
+  }
+  if (!isRecord(parsed)) {
+    return CONSERVATIVE_CONFIG_PROBE;
+  }
+  const plugins = parsed.plugins;
+  const installsState = inspectShippedPluginInstallConfigRecords(parsed);
+  const rawInstallsAffectHelp =
+    installsState.status === "valid" && hasEntries(installsState.records);
+  let rawInstallsConfig: OpenClawConfig | undefined;
+  if (rawInstallsAffectHelp) {
+    // SAFETY: Canonical install inspection validated the raw record before stripping.
+    rawInstallsConfig = stripShippedPluginInstallConfigRecords(parsed) as OpenClawConfig;
+  }
+  // Inspect the decoded representation so JSON escapes cannot hide loader-owned
+  // include or environment-substitution syntax from this lightweight probe.
+  const decoded = JSON.stringify(parsed);
+  if (
+    decoded.includes("$include") ||
+    decoded.includes("${") ||
+    decoded.includes("$(") ||
+    !configEnvCannotAffectPluginHelp(parsed.env) ||
+    installsState.status === "invalid" ||
+    hasInvalidPluginRecord(plugins)
+  ) {
+    return { cannotAffectHelp: false, rawInstallsAffectHelp, rawInstallsConfig };
+  }
+  // SAFETY: The guard above rejects every defined plugin value outside PluginsConfigShape.
+  const pluginsConfig = plugins as PluginsConfigShape;
+  return {
+    cannotAffectHelp: !rawInstallsAffectHelp && !pluginsAffectHelp(pluginsConfig),
+    rawInstallsAffectHelp,
+    rawInstallsConfig,
+  };
+}
+
+/** Load render options only when config/env can affect plugin help output. */
+export async function loadRootHelpRenderOptionsForConfigSensitivePlugins(
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<RootHelpRenderOptions | null> {
+  // Fast path: when nothing reachable through the config file, the dotenv files
+  // the config read would load, or the process env can change plugin help, the
+  // answer is `null` regardless, so the config module never has to be loaded.
+  //
+  // Only the real environment is probed. An injected env is a test/diagnostic
+  // sandbox that must stay isolated from the host filesystem - the same rule
+  // `maybeLoadDotEnvForConfig` applies before it loads dotenv files - so those
+  // callers keep taking the full config path.
+  let configProbe: ConfigProbeResult | undefined;
+  if (
+    env === process.env &&
+    !envAffectsPluginHelp(env) &&
+    !(await anyDotEnvMentionsPluginKey(env))
+  ) {
+    configProbe = inspectConfigForPluginHelp(env);
+    if (configProbe.cannotAffectHelp) {
+      return null;
+    }
+  }
+  const configModule = await import("../config/config.js");
+  const snapshot = await configModule.readConfigFileSnapshot({
+    observe: false,
+    skipPluginValidation: true,
+  });
+  if (!snapshot.valid) {
+    return configProbe?.rawInstallsConfig ? { config: configProbe.rawInstallsConfig, env } : null;
+  }
+  const configAffectsPluginHelp =
+    configProbe?.rawInstallsAffectHelp === true || pluginsAffectHelp(snapshot.sourceConfig.plugins);
+  if (!envAffectsPluginHelp(env) && !configAffectsPluginHelp) {
     return null;
   }
   return {


### PR DESCRIPTION
Fixes #114067.

## What Problem This Solves

`openclaw --help` costs about **36 ms** with no config file and about **1274 ms** as soon as the config contains a `plugins` key — for **byte-identical** output. The root-help probe imports the config module and runs a full `readConfigFileSnapshot` before it can decide whether plugin help is affected at all; when the answer is "not affected", that entire cost is thrown away and the precomputed help text is printed regardless.

## Why This Change Was Made

`loadRootHelpRenderOptionsForConfigSensitivePlugins` now answers the same question from a cheap pre-probe — the raw config text plus the dotenv files the config read would have loaded — and only imports `../config/config.js` when that cheap read cannot settle it.

The predicate applied to the raw `plugins` value is the same one already applied to `snapshot.sourceConfig.plugins`, so the decision is unchanged; only the cost of reaching it moves.

The fast path is refused, and the existing full path taken, whenever any of these hold:

- a plugin env var (`OPENCLAW_BUNDLED_PLUGINS_DIR`, `OPENCLAW_DISABLE_BUNDLED_PLUGINS`) is already set;
- any dotenv file the config read would load mentions one of those keys — this covers the two routes raised on #85396 (below);
- the raw config contains `$include`, `${…}` or `$(…)`, so an include or env substitution could introduce a `plugins` key the cheap read cannot see;
- the config is not plain JSON (JSON5 and friends), or is not an object;
- the parsed `plugins` value does affect help.

An **injected `env`** always takes the full path. An injected env object is a test/diagnostic sandbox that must stay isolated from the host filesystem — the same rule `maybeLoadDotEnvForConfig` already applies before it loads dotenv files.

## Credit and relationship to #85396

[#85396](https://github.com/openclaw/openclaw/pull/85396) by @FelixIsaac proposed a fast path for exactly this and reached "ready for maintainer look" before being downgraded to merge-risk/compatibility and closing stale. The premise was right; it died on the compatibility surface. Review named two specific routes, and both are handled here explicitly rather than by argument:

**(a) the legacy `~/.config/openclaw/gateway.env` dotenv path.** `loadGlobalRuntimeDotEnvFiles` reads it only when no explicit non-default `OPENCLAW_STATE_DIR` is active. `dotEnvPathsForProbe` reproduces that same condition and scans the file; if it mentions a plugin env key, the shortcut is refused.
Test: *loads the config when the legacy gateway.env sets a plugin env var (#85396)*.

**(b) a `.env` beside an explicit `OPENCLAW_CONFIG_PATH`.** `resolveConfigDir` returns `dirname(OPENCLAW_CONFIG_PATH)`, so the state `.env` moves with it. `configDirForProbe` mirrors that resolution and the same scan applies.
Test: *loads the config when a .env beside OPENCLAW_CONFIG_PATH sets a plugin env var (#85396)*.

Both are negative cases in the matrix below with measured md5s, not just code branches.

## User Impact

`openclaw --help` returns in ~99 ms instead of ~1274 ms for any user whose config has a `plugins` key that does not change help output. Users whose config genuinely affects plugin help see no behaviour change.

## Evidence

Release build, Node v22.23.1, config at `$HOME/.openclaw/openclaw.json`, fresh `HOME` and fresh empty CWD per run, 5 runs per case, `md5` over raw stdout. Unpatched vs patched **at the same commit** (`417bd3c8`):

| case | unpatched p50 / mean | patched p50 / mean | md5 unpatched → patched | bytes |
| --- | ---: | ---: | --- | ---: |
| no config file | 36 / 37.2 ms | 36 / 36.4 ms | `b46e2268ed` → `b46e2268ed` | 7126 |
| `{"gateway":{"port":1234}}` | 36 / 36.0 ms | 38 / 37.4 ms | `b46e2268ed` → `b46e2268ed` | 7126 |
| **`{"plugins":{}}`** | **1274 / 1281.8 ms** | **99 / 99.0 ms** | `b46e2268ed` → `b46e2268ed` | 7126 |
| `{"plugins":{"entries":{…}}}` | 2014 / 2011.6 ms | 1983 / 1984.4 ms | `b46e2268ed` → `b46e2268ed` | 7126 |
| **`{"plugins":{"enabled":false}}`** (carve-out) | 1819 / 1814.4 ms | 1814 / 1813.8 ms | `250658844f` → `250658844f` | 7061 |
| `OPENCLAW_DISABLE_BUNDLED_PLUGINS=1` in real env | 1227 / 1221.2 ms | 1201 / 1200.2 ms | `250658844f` → `250658844f` | 7061 |
| **(a)** `~/.config/openclaw/gateway.env` sets plugin var | 36 / 35.4 ms | 35 / 35.8 ms | `b46e2268ed` → `b46e2268ed` | 7126 |
| **(b)** `.env` beside `OPENCLAW_CONFIG_PATH` sets plugin var | 36 / 36.4 ms | 36 / 36.0 ms | `b46e2268ed` → `b46e2268ed` | 7126 |
| `~/.openclaw/.env` sets plugin var | 36 / 35.4 ms | 37 / 36.8 ms | `b46e2268ed` → `b46e2268ed` | 7126 |
| workspace `.env` sets plugin var | 36 / 36.0 ms | 37 / 36.6 ms | `b46e2268ed` → `b46e2268ed` | 7126 |
| twice-consecutive `{"plugins":{}}` | 1314 / 1275 ms | 100 / 97 ms | `b46e2268ed` → `b46e2268ed` | 7126 |

**The main result: 1274 ms → 99 ms p50, 12.9x, on byte-identical output.**

Scope note on the byte-identical claim: it covers every case above **except** `plugins.enabled: false`, which legitimately renders different help (7061 vs 7126 bytes, bundled plugins stripped). That case is carved out deliberately and still takes the full config path, unchanged, in both builds.

**Repo startup bench** — `pnpm test:startup:bench --preset all --case help --runs 5 --warmup 1`:

| | p50 | avg | RSS |
| --- | ---: | ---: | ---: |
| unpatched | 34.5 ms | 34.5 ms | 47.2 MB |
| patched | 35.8 ms | 36.2 ms | 47.2 MB |

Within run-to-run noise, RSS identical. Note the bench cannot see the fix either: `buildConfigFixture` returns `null` for every case except four, and those four write only a `gateway` key, so the benched `--help` runs with no config file at all. That is why a ~35x regression on a flagship command went unnoticed — a fixture-coverage gap, not anyone's oversight.

**Checks:** `pnpm vitest run src/cli/root-help-live-config.test.ts src/entry.test.ts` → 34 passed; `pnpm tsgo:core` → clean; `pnpm lint:core` → clean; `oxfmt --check` → clean.

Seven new tests cover the fast path: skip with no config, skip for a non-affecting `plugins` value, and full path for `plugins.enabled:false`, trap (a), trap (b), an `$include` directive, and non-plain-JSON. No existing test was modified or weakened.

Supplementary record of the exploration behind this change, including the approaches that recovered nothing: https://dashboard.weco.ai/share/NSv0D_l7jitbZiljQ0JUJLGHV7iCfcNV

---

*AI-assisted: implementation and measurement were done with an AI coding agent.*
