### PR TITLE
chore: ignore .env variants while keeping .env.example templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 node_modules
 **/node_modules/
 .env
+.env.*
+!*.env.example
 docker-compose.override.yml
 docker-compose.extra.yml
 docker-compose.sandbox.yml


### PR DESCRIPTION
## What Problem This Solves

`.gitignore` ignores bare `.env` and nothing else, so every other conventional environment-file variant is fully visible to `git add`.

A real `.env.secrets` in a working tree shows up as an untracked file in `git status` and is one `git add -A` away from being committed. The same applies to `.env.local`, `.env.production`, and any other `.env.<suffix>` a contributor or tool creates. Nothing in the repo prevents that today — the only thing keeping such a file out of a commit is that nobody happened to run a broad `git add`.

## Why This Change Was Made

Adds `.env.*` to cover the variants, plus `!*.env.example` so the tracked template files stay visible.

The negation is the substantive part. A bare `.env.*` rule also matches `.env.example`, `apps/ios/fastlane/.env.example`, and `apps/android/fastlane/.env.example`. The currently tracked copies would survive, since `.gitignore` does not affect already-tracked files — but the failure is latent: a newly added, restored, or renamed template would be silently unaddable, and a contributor would have no obvious signal why. `!*.env.example` keeps all three templates includable at any depth while every secret-bearing variant stays ignored.

This is split out of the `AGENTS.md` documentation work it was originally bundled with (#108488, #108496), so the security-sensitive-file authorization gate applies to this one-file change on its own instead of blocking unrelated docs.

## User Impact

Contributors and operators get protection against accidentally committing local environment secrets, and the `.env.example` templates keep working exactly as before. No runtime or product behavior changes.

## Evidence

Secret-bearing variants are ignored:

```
$ git check-ignore --no-index -v .env .env.local .env.production .env.secrets
.gitignore:3:.env      .env
.gitignore:4:.env.*    .env.local
.gitignore:4:.env.*    .env.production
.gitignore:4:.env.*    .env.secrets
```

All three tracked templates remain includable:

```
$ git check-ignore --no-index -q .env.example                       ; echo $?
1
$ git check-ignore --no-index -q apps/ios/fastlane/.env.example      ; echo $?
1
$ git check-ignore --no-index -q apps/android/fastlane/.env.example  ; echo $?
1
```

Exit status 1 means not ignored. Without `!*.env.example` these three return 0, which is the regression this rule prevents.

No tracked file changes status:

```
$ git ls-files | grep -c "\.env\.example"
3
```

Observed end to end: a local `.env.secrets` present in the working tree appeared as `?? .env.secrets` in `git status` before this change and does not appear at all after it, while `git status` still reports nothing unexpected about the templates.

Single-file change, 2 insertions. `git diff --check` clean.

Note for maintainers: this PR trips the security-sensitive-file guard by design, since `.gitignore` is the file being fixed. It needs `/allow-security-sensitive-change` on the current head from a repository admin or `@openclaw/openclaw-secops`.
