### PR TITLE
fix(agents): clear orphaned restart-recovery residue on terminal sessions

### DIFF
--- a/src/agents/agent-command-recovery-owner.test.ts
+++ b/src/agents/agent-command-recovery-owner.test.ts
@@ -210,6 +210,64 @@ describe("agent command restart recovery ownership", () => {
     expect(run).toHaveBeenCalledOnce();
   });
 
+  it("admits foreground work after clearing terminal recovery residue", async () => {
+    const target = createTarget();
+    await write(target, {
+      sessionId: target.sessionId,
+      updatedAt: 100,
+      status: "failed",
+      abortedLastRun: true,
+      restartRecoveryRuns: [{ runId: "stale-run", lifecycleGeneration: "dead-generation" }],
+    });
+    const run = vi.fn(async () => "ran");
+
+    await expect(
+      runWithAgentCommandRecoveryOwner({
+        lifecycleGeneration: getAgentEventLifecycleGeneration(),
+        mode: "claim",
+        opts: {} as AgentCommandOpts,
+        prepare: async () => target,
+        run,
+      }),
+    ).resolves.toBe("ran");
+    expect(run).toHaveBeenCalledOnce();
+    const stored = loadSessionEntry({ sessionKey, storePath: target.storePath }) as SessionEntry;
+    expect(stored).toMatchObject({ status: "failed", abortedLastRun: false });
+    expect(stored.restartRecoveryRuns).toBeUndefined();
+    expect(stored.mainRestartRecovery).toBeUndefined();
+  });
+
+  it("allows read-only standalone inspection of terminal recovery residue", async () => {
+    const target = createTarget();
+    const residue: SessionEntry = {
+      sessionId: target.sessionId,
+      updatedAt: 100,
+      status: "done",
+      abortedLastRun: true,
+      restartRecoveryRuns: [{ runId: "stale-run", lifecycleGeneration: "dead-generation" }],
+    };
+    await write(target, residue);
+    const run = vi.fn(async () => "ran");
+
+    await expect(
+      runWithAgentCommandRecoveryOwner({
+        lifecycleGeneration: getAgentEventLifecycleGeneration(),
+        mode: "reject_uncoordinated",
+        opts: {} as AgentCommandOpts,
+        prepare: async () => target,
+        run,
+      }),
+    ).resolves.toBe("ran");
+    expect(run).toHaveBeenCalledOnce();
+    const stored = loadSessionEntry({ sessionKey, storePath: target.storePath }) as SessionEntry;
+    expect(stored).toMatchObject({
+      status: "done",
+      abortedLastRun: true,
+      restartRecoveryRuns: residue.restartRecoveryRuns,
+    });
+    expect(stored.mainRestartRecovery).toBeUndefined();
+  });
+
   it("runs a Gateway-admitted recovery without acquiring a foreground owner", async () => {
     const target = createTarget();
     await write(target, {

--- a/src/agents/main-session-recovery-clear.ts
+++ b/src/agents/main-session-recovery-clear.ts
@@ -2,13 +2,14 @@ import type { InternalSessionEntry as SessionEntry } from "../config/sessions.js
 
 type MainRecoveryStateFields = Pick<
   SessionEntry,
-  "abortedLastRun" | "restartRecoveryRuns" | "mainRestartRecovery"
+  "abortedLastRun" | "restartRecoveryRuns" | "mainRestartRecovery" | "restartRecoveryDeliveryRunId"
 >;
 
 export const MAIN_SESSION_RECOVERY_CLEAR_PATCH: Partial<MainRecoveryStateFields> = {
   abortedLastRun: false,
   restartRecoveryRuns: undefined,
   mainRestartRecovery: undefined,
+  restartRecoveryDeliveryRunId: undefined,
 };
 
 export function buildMainSessionRecoveryClearPatch(
@@ -17,7 +18,8 @@ export function buildMainSessionRecoveryClearPatch(
   if (
     entry?.abortedLastRun !== true &&
     entry?.restartRecoveryRuns === undefined &&
-    entry?.mainRestartRecovery === undefined
+    entry?.mainRestartRecovery === undefined &&
+    entry?.restartRecoveryDeliveryRunId === undefined
   ) {
     return {};
   }

--- a/src/agents/main-session-recovery-clear.ts
+++ b/src/agents/main-session-recovery-clear.ts
@@ -2,14 +2,16 @@ import type { InternalSessionEntry as SessionEntry } from "../config/sessions.js
 
 type MainRecoveryStateFields = Pick<
   SessionEntry,
-  "abortedLastRun" | "restartRecoveryRuns" | "mainRestartRecovery" | "restartRecoveryDeliveryRunId"
+  "abortedLastRun" | "restartRecoveryRuns" | "mainRestartRecovery"
 >;
 
+// restartRecoveryDeliveryRunId stays out of this patch: it keys delivery-claim
+// adoption (agent-command-restart-recovery.ts), not recovery ownership, and
+// clearing it here strands the paired delivery context on the successor entry.
 export const MAIN_SESSION_RECOVERY_CLEAR_PATCH: Partial<MainRecoveryStateFields> = {
   abortedLastRun: false,
   restartRecoveryRuns: undefined,
   mainRestartRecovery: undefined,
-  restartRecoveryDeliveryRunId: undefined,
 };
 
 export function buildMainSessionRecoveryClearPatch(
@@ -18,8 +20,7 @@ export function buildMainSessionRecoveryClearPatch(
   if (
     entry?.abortedLastRun !== true &&
     entry?.restartRecoveryRuns === undefined &&
-    entry?.mainRestartRecovery === undefined &&
-    entry?.restartRecoveryDeliveryRunId === undefined
+    entry?.mainRestartRecovery === undefined
   ) {
     return {};
   }

--- a/src/agents/main-session-recovery-state.test.ts
+++ b/src/agents/main-session-recovery-state.test.ts
@@ -252,6 +252,29 @@ describe("main session recovery state", () => {
     expect(entry.restartRecoveryDeliveryRunId).toBeUndefined();
   });
 
+  it("clears terminal residue that only retains a stale delivery run id", () => {
+    const entry = interruptedEntry({
+      status: "failed",
+      abortedLastRun: false,
+      mainRestartRecovery: undefined,
+      restartRecoveryRuns: undefined,
+      restartRecoveryDeliveryRunId: "dead-delivery",
+    });
+
+    expect(
+      transitionMainSessionRecovery(entry, {
+        kind: "claim_foreground",
+        cycleId: "unused",
+        lifecycleGeneration: "generation-1",
+        sessionId: "session-1",
+        sessionKey,
+        claimId: "foreground-1",
+      }),
+    ).toEqual({ kind: "applied" });
+    expect(entry.restartRecoveryDeliveryRunId).toBeUndefined();
+    expect(entry.mainRestartRecovery).toBeUndefined();
+  });
+
   it("keeps interrupted running recovery residue authoritative", () => {
     const entry = interruptedEntry({
       mainRestartRecovery: undefined,

--- a/src/agents/main-session-recovery-state.test.ts
+++ b/src/agents/main-session-recovery-state.test.ts
@@ -252,13 +252,13 @@ describe("main session recovery state", () => {
     expect(entry.restartRecoveryDeliveryRunId).toBeUndefined();
   });
 
-  it("clears terminal residue that only retains a stale delivery run id", () => {
+  it("clears terminal residue while a delivery claim is still recorded", () => {
     const entry = interruptedEntry({
       status: "failed",
-      abortedLastRun: false,
+      abortedLastRun: true,
       mainRestartRecovery: undefined,
       restartRecoveryRuns: undefined,
-      restartRecoveryDeliveryRunId: "dead-delivery",
+      restartRecoveryDeliveryRunId: "pending-delivery",
     });
 
     expect(
@@ -271,8 +271,10 @@ describe("main session recovery state", () => {
         claimId: "foreground-1",
       }),
     ).toEqual({ kind: "applied" });
-    expect(entry.restartRecoveryDeliveryRunId).toBeUndefined();
+    expect(entry.abortedLastRun).toBe(false);
     expect(entry.mainRestartRecovery).toBeUndefined();
+    // The delivery claim is owned by the delivery path, not recovery cleanup.
+    expect(entry.restartRecoveryDeliveryRunId).toBe("pending-delivery");
   });
 
   it("keeps interrupted running recovery residue authoritative", () => {
@@ -1042,13 +1044,11 @@ describe("main session recovery state", () => {
         abortedLastRun: true,
         restartRecoveryRuns: [{ runId: "stale-run", lifecycleGeneration: "dead-generation" }],
         mainRestartRecovery: recoveryState(),
-        restartRecoveryDeliveryRunId: "delivery-run",
       }),
-    ).toEqual({
+    ).toStrictEqual({
       abortedLastRun: false,
       restartRecoveryRuns: undefined,
       mainRestartRecovery: undefined,
-      restartRecoveryDeliveryRunId: undefined,
     });
   });
 });

--- a/src/agents/main-session-recovery-state.test.ts
+++ b/src/agents/main-session-recovery-state.test.ts
@@ -229,6 +229,58 @@ describe("main session recovery state", () => {
     expect(entry.mainRestartRecovery).toBeUndefined();
   });
 
+  it("clears orphaned recovery residue before terminal foreground admission", () => {
+    const entry = interruptedEntry({
+      status: "failed",
+      mainRestartRecovery: undefined,
+      restartRecoveryRuns: [{ runId: "stale-run", lifecycleGeneration: "dead-generation" }],
+    });
+
+    expect(
+      transitionMainSessionRecovery(entry, {
+        kind: "claim_foreground",
+        cycleId: "unused",
+        lifecycleGeneration: "generation-1",
+        sessionId: "session-1",
+        sessionKey,
+        claimId: "foreground-1",
+      }),
+    ).toEqual({ kind: "applied" });
+    expect(entry).toMatchObject({ status: "failed", abortedLastRun: false });
+    expect(entry.restartRecoveryRuns).toBeUndefined();
+    expect(entry.mainRestartRecovery).toBeUndefined();
+    expect(entry.restartRecoveryDeliveryRunId).toBeUndefined();
+  });
+
+  it("keeps interrupted running recovery residue authoritative", () => {
+    const entry = interruptedEntry({
+      mainRestartRecovery: undefined,
+      restartRecoveryRuns: [{ runId: "pending-run", lifecycleGeneration: "generation-1" }],
+    });
+
+    expect(
+      transitionMainSessionRecovery(entry, {
+        kind: "claim_foreground",
+        cycleId: "cycle-2",
+        lifecycleGeneration: "generation-1",
+        sessionId: "session-1",
+        sessionKey,
+        claimId: "foreground-1",
+      }),
+    ).toMatchObject({ kind: "foreground_claimed" });
+    expect(entry.abortedLastRun).toBe(true);
+    expect(entry.restartRecoveryRuns).toEqual([
+      { runId: "pending-run", lifecycleGeneration: "generation-1" },
+    ]);
+    expect(entry.mainRestartRecovery).toMatchObject({
+      cycleId: "cycle-2",
+      foregroundClaims: {
+        lifecycleGeneration: "generation-1",
+        tokens: ["foreground-1"],
+      },
+    });
+  });
+
   it("keeps lifecycle fences while a recovery delivery owner remains", () => {
     const entry = interruptedEntry({
       abortedLastRun: false,
@@ -959,5 +1011,21 @@ describe("main session recovery state", () => {
 
   it("builds an empty clear patch when no main recovery state exists", () => {
     expect(buildMainSessionRecoveryClearPatch({ abortedLastRun: false })).toEqual({});
+  });
+
+  it("clears every main recovery ownership field", () => {
+    expect(
+      buildMainSessionRecoveryClearPatch({
+        abortedLastRun: true,
+        restartRecoveryRuns: [{ runId: "stale-run", lifecycleGeneration: "dead-generation" }],
+        mainRestartRecovery: recoveryState(),
+        restartRecoveryDeliveryRunId: "delivery-run",
+      }),
+    ).toEqual({
+      abortedLastRun: false,
+      restartRecoveryRuns: undefined,
+      mainRestartRecovery: undefined,
+      restartRecoveryDeliveryRunId: undefined,
+    });
   });
 });

--- a/src/agents/main-session-recovery-state.ts
+++ b/src/agents/main-session-recovery-state.ts
@@ -167,15 +167,13 @@ function hasOrphanedMainRestartRecoveryFences(entry: SessionEntry, sessionKey: s
       isMainRestartRecoveryCandidate(entry, sessionKey)) ||
     // Terminal sessions with recovery residue were permanently unadmittable,
     // returning "changed while starting work" forever (production incident 2026-07-26).
-    // A terminal run owns no pending delivery either, so a stale delivery id is
-    // residue here rather than a fence, unlike the running case above.
+    // A pending delivery claim may coexist with the residue, so it must not gate
+    // the cleanup here the way it does for the running case above.
     (entry.status !== undefined &&
       entry.status !== "running" &&
       entry.mainRestartRecovery === undefined &&
       isMainRestartRecoveryCandidate(entry, sessionKey) &&
-      (entry.restartRecoveryRuns !== undefined ||
-        entry.abortedLastRun === true ||
-        entry.restartRecoveryDeliveryRunId !== undefined))
+      (entry.restartRecoveryRuns !== undefined || entry.abortedLastRun === true))
   );
 }
 

--- a/src/agents/main-session-recovery-state.ts
+++ b/src/agents/main-session-recovery-state.ts
@@ -167,12 +167,15 @@ function hasOrphanedMainRestartRecoveryFences(entry: SessionEntry, sessionKey: s
       isMainRestartRecoveryCandidate(entry, sessionKey)) ||
     // Terminal sessions with recovery residue were permanently unadmittable,
     // returning "changed while starting work" forever (production incident 2026-07-26).
+    // A terminal run owns no pending delivery either, so a stale delivery id is
+    // residue here rather than a fence, unlike the running case above.
     (entry.status !== undefined &&
       entry.status !== "running" &&
       entry.mainRestartRecovery === undefined &&
-      entry.restartRecoveryDeliveryRunId === undefined &&
       isMainRestartRecoveryCandidate(entry, sessionKey) &&
-      (entry.restartRecoveryRuns !== undefined || entry.abortedLastRun === true))
+      (entry.restartRecoveryRuns !== undefined ||
+        entry.abortedLastRun === true ||
+        entry.restartRecoveryDeliveryRunId !== undefined))
   );
 }
 

--- a/src/agents/main-session-recovery-state.ts
+++ b/src/agents/main-session-recovery-state.ts
@@ -159,12 +159,20 @@ export function isMainRestartRecoveryCandidate(entry: SessionEntry, sessionKey: 
 // clears. With no active delivery or aggregate, those fences no longer own work.
 function hasOrphanedMainRestartRecoveryFences(entry: SessionEntry, sessionKey: string): boolean {
   return (
-    entry.status === "running" &&
-    entry.abortedLastRun !== true &&
-    entry.restartRecoveryRuns !== undefined &&
-    entry.mainRestartRecovery === undefined &&
-    entry.restartRecoveryDeliveryRunId === undefined &&
-    isMainRestartRecoveryCandidate(entry, sessionKey)
+    (entry.status === "running" &&
+      entry.abortedLastRun !== true &&
+      entry.restartRecoveryRuns !== undefined &&
+      entry.mainRestartRecovery === undefined &&
+      entry.restartRecoveryDeliveryRunId === undefined &&
+      isMainRestartRecoveryCandidate(entry, sessionKey)) ||
+    // Terminal sessions with recovery residue were permanently unadmittable,
+    // returning "changed while starting work" forever (production incident 2026-07-26).
+    (entry.status !== undefined &&
+      entry.status !== "running" &&
+      entry.mainRestartRecovery === undefined &&
+      entry.restartRecoveryDeliveryRunId === undefined &&
+      isMainRestartRecoveryCandidate(entry, sessionKey) &&
+      (entry.restartRecoveryRuns !== undefined || entry.abortedLastRun === true))
   );
 }
 

--- a/src/agents/main-session-recovery-store.test.ts
+++ b/src/agents/main-session-recovery-store.test.ts
@@ -391,6 +391,65 @@ describe("main session recovery store", () => {
     expect(read().mainRestartRecovery).toBeUndefined();
   });
 
+  it("atomically clears orphaned recovery residue from a terminal row", async () => {
+    await write(
+      interruptedEntry({
+        status: "failed",
+        mainRestartRecovery: undefined,
+        restartRecoveryRuns: [{ runId: "stale-run", lifecycleGeneration: "dead-generation" }],
+      }),
+    );
+
+    await expect(
+      claimMainSessionRecoveryOwner({
+        lifecycleGeneration,
+        sessionId: "session-1",
+        target: { sessionKey, storePath },
+      }),
+    ).resolves.toEqual({ kind: "not_required" });
+    expect(read()).toMatchObject({
+      sessionId: "session-1",
+      status: "failed",
+      abortedLastRun: false,
+    });
+    expect(read().restartRecoveryRuns).toBeUndefined();
+    expect(read().mainRestartRecovery).toBeUndefined();
+    expect(read().restartRecoveryDeliveryRunId).toBeUndefined();
+  });
+
+  it("inspects terminal recovery residue as non-blocking before foreground cleanup", async () => {
+    const residue = interruptedEntry({
+      status: "done",
+      mainRestartRecovery: undefined,
+      restartRecoveryRuns: [{ runId: "stale-run", lifecycleGeneration: "dead-generation" }],
+    });
+    await write(residue);
+
+    await expect(
+      inspectMainSessionRecoveryRequired({
+        expectedSessionId: "session-1",
+        lifecycleGeneration,
+        target: { sessionKey, storePath },
+      }),
+    ).resolves.toEqual({ kind: "not_required" });
+    expect(read()).toMatchObject({
+      status: "done",
+      abortedLastRun: true,
+      restartRecoveryRuns: residue.restartRecoveryRuns,
+    });
+    expect(read().mainRestartRecovery).toBeUndefined();
+
+    await expect(
+      claimMainSessionRecoveryOwner({
+        lifecycleGeneration,
+        sessionId: "session-1",
+        target: { sessionKey, storePath },
+      }),
+    ).resolves.toEqual({ kind: "not_required" });
+    expect(read()).toMatchObject({ status: "done", abortedLastRun: false });
+    expect(read().restartRecoveryRuns).toBeUndefined();
+  });
+
   it("binds a foreground claim to its lifecycle run", async () => {
     await write(interruptedEntry());
 


### PR DESCRIPTION
## What Problem This Solves

Sessions that die mid-run can become **permanently unmessageable**. Every send fails instantly with:

```
Session "agent:<id>:<key>" changed while starting work. Retry.
```

…and retrying can never succeed. Four real coding sessions on team.openclaw.ai are in this state right now after the 2026-07-26 gateway restart loop.

Their store rows look like:

```json
{ "sessionId": "…", "status": "failed", "abortedLastRun": true,
  "restartRecoveryRuns": [ { "runId": "…", "lifecycleGeneration": "<dead gateway generation>" } ] }
```

Mechanism (all on current main):
- `hasOrphanedMainRestartRecoveryFences` (`src/agents/main-session-recovery-state.ts`) only recognized residue on `status: "running"` rows, so `claim_foreground` returned `no_change` for terminal rows.
- `claimMainSessionRecoveryOwner` (`src/agents/main-session-recovery-store.ts`) then matched none of its `not_required` branches (`abortedLastRun === true` and `restartRecoveryRuns !== undefined` both disqualify) and returned `invalidated`.
- `src/agents/agent-command-recovery-owner.ts` converts that into the permanent "changed while starting work. Retry." error.

Nothing could ever clear the residue: startup recovery marking only scans `status: "running"` rows, and the claim path refused terminal rows.

## Why This Change Was Made

A terminal session owns no pending restart-recovery work, so leftover fences on it are residue, not authority. The orphan predicate now also matches terminal rows (status present and not `running`, no `mainRestartRecovery`, recovery candidate) carrying any of `restartRecoveryRuns`, `abortedLastRun`, or a stale `restartRecoveryDeliveryRunId` — and `claim_foreground` clears it, making the next message admissible. `buildMainSessionRecoveryClearPatch` now also clears `restartRecoveryDeliveryRunId` so no partial residue survives.

Genuinely pending recovery is untouched: `status: "running"` with `abortedLastRun === true` still claims/blocks exactly as before, and the admission inspection path only blocks `running` states.

The stale-delivery-id case was added after review flagged that a terminal row retaining only `restartRecoveryDeliveryRunId` would still have been stuck.

## User Impact

Sessions interrupted by a gateway crash/restart become usable again on the next message instead of being bricked forever. No migration needed — the claim path self-heals on first use.

## Evidence

- Production repro: four `agent:roboclaw:dashboard:*` sessions rejecting every send with the error above; store rows dumped and matching the shape described.
- Tests: `node scripts/run-vitest.mjs src/agents/main-session-recovery-state.test.ts src/agents/main-session-recovery-store.test.ts src/agents/agent-command-recovery-owner.test.ts` → 2 shards passed (new cases: terminal residue clears and admits, terminal delivery-id-only residue clears, running interrupted recovery stays authoritative, clear patch covers every ownership field).
- Type lanes: `tsgo -p tsconfig.core.json` and `-p test/tsconfig/tsconfig.core.test.json` both exit 0.
