### PR TITLE
fix: validate releases that predate npm lock gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2199,7 +2199,14 @@ jobs:
               pnpm check:import-cycles
               ;;
             npm-lock)
-              pnpm deps:npm-lock:check
+              if has_package_script "deps:npm-lock:check"; then
+                pnpm deps:npm-lock:check
+              elif [[ "$HISTORICAL_TARGET" != "true" ]]; then
+                echo "Current CI targets must provide the deps:npm-lock:check package script." >&2
+                exit 1
+              else
+                echo "[skip] historical target predates the transient npm lock contract"
+              fi
               ;;
             bundled-channel-config-metadata)
               pnpm check:bundled-channel-config-metadata

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -4162,6 +4162,13 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
     );
     expect(checkShard.run).toContain("pnpm tsgo:scripts");
     expect(checkShard.run).toContain('elif [[ "$HISTORICAL_TARGET" != "true" ]]');
+    expect(checkShard.run).toContain('has_package_script "deps:npm-lock:check"');
+    expect(checkShard.run).toContain(
+      "Current CI targets must provide the deps:npm-lock:check package script.",
+    );
+    expect(checkShard.run).toContain(
+      "[skip] historical target predates the transient npm lock contract",
+    );
     expect(checkShard.run).toContain('has_package_script "deadcode:dependencies"');
     expect(checkShard.run).toContain('has_package_script "deadcode:unused-files"');
     expect(checkShard.run).toContain('has_package_script "deadcode:exports"');


### PR DESCRIPTION
## What Problem This Solves

Resolves a release-validation failure where current trusted CI unconditionally invoked `deps:npm-lock:check` against a frozen release candidate that predates that package script.

## Why This Change Was Made

The npm-lock check now follows the existing frozen-target compatibility pattern used by neighboring CI contracts: run the script when present, fail current targets when it is unexpectedly absent, and skip only an explicitly authorized historical target.

The release candidate remains unchanged. This repairs only the trusted current-main harness that validates it.

## User Impact

No product behavior changes. Maintainers can validate older frozen release candidates without weakening the npm-lock contract for current branches.

## Evidence

- Full Release Validation child [30193989255](https://github.com/openclaw/openclaw/actions/runs/30193989255) failed only because `deps:npm-lock:check` was absent on the authorized historical target.
- `node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts` — 88 passed, 1 skipped.
- `actionlint`, zizmor 1.28.0, formatting, composite-action interpolation, conflict-marker, and `git diff --check` checks passed.
- Autoreview: clean, no accepted/actionable findings.
- Exact-head PR CI proves the current-target path still runs `deps:npm-lock:check` and stays green.

ClawSweeper rank-up ordering: successful frozen-target release proof requires this trusted workflow revision to exist on `main`; the unchanged `release/2026.7.2` candidate will be rerun immediately after merge and the replacement Full Release Validation run will be recorded in the release ledger.

AI-assisted: yes. The change was reviewed and is scoped to the exact release blocker.
