### PR TITLE
fix(google-meet): scope untargeted recover_current_tab to owned tabs

### DIFF
--- a/extensions/google-meet/src/runtime-recover-ownership.ts
+++ b/extensions/google-meet/src/runtime-recover-ownership.ts
@@ -6,7 +6,7 @@ import { isBrowserTransport } from "./runtime-session.js";
 import { GOOGLE_MEET_PLATFORM_ADAPTER } from "./transports/google-meet-platform-adapter.js";
 import type { GoogleMeetSession } from "./transports/types.js";
 
-export interface RecoverOwnership {
+interface RecoverOwnership {
   trackedMeetingUrl?: string;
   trackedTargetId?: string;
 }

--- a/extensions/google-meet/src/runtime-recover-ownership.ts
+++ b/extensions/google-meet/src/runtime-recover-ownership.ts
@@ -1,0 +1,66 @@
+// Resolves which tab an untargeted recover_current_tab call may reattach to,
+// so recovery never arms mic/captions on an unrelated Meet tab in a shared
+// Chrome profile (see #113990).
+import type { GoogleMeetTransport } from "./config.js";
+import { isBrowserTransport } from "./runtime-session.js";
+import { GOOGLE_MEET_PLATFORM_ADAPTER } from "./transports/google-meet-platform-adapter.js";
+import type { GoogleMeetSession } from "./transports/types.js";
+
+export interface RecoverOwnership {
+  trackedMeetingUrl?: string;
+  trackedTargetId?: string;
+}
+
+/** Prefer active session tab for this transport; else createViaBrowser tab. */
+export function resolveRecoverOwnership(params: {
+  url?: string;
+  transport: GoogleMeetTransport;
+  sessions: readonly GoogleMeetSession[];
+  createdBrowserTabs: ReadonlyMap<string, string>;
+}): RecoverOwnership {
+  const sessions = params.sessions.filter(
+    (session) =>
+      isBrowserTransport(session.transport) &&
+      session.transport === params.transport &&
+      Boolean(session.chrome?.browserTab?.targetId),
+  );
+  const urlMatched = params.url
+    ? sessions.find((session) =>
+        GOOGLE_MEET_PLATFORM_ADAPTER.urls.isSameMeeting(session.url, params.url),
+      )
+    : undefined;
+  const ownedSession =
+    urlMatched ??
+    (!params.url
+      ? [...sessions].toSorted((a, b) => b.updatedAt.localeCompare(a.updatedAt))[0]
+      : undefined);
+  if (ownedSession?.chrome?.browserTab?.targetId) {
+    return {
+      trackedMeetingUrl: ownedSession.url,
+      trackedTargetId: ownedSession.chrome.browserTab.targetId,
+    };
+  }
+  for (const [key, meetingUri] of params.createdBrowserTabs) {
+    const sep = key.indexOf(":");
+    const nodeId = sep >= 0 ? key.slice(0, sep) : "";
+    const targetId = sep >= 0 ? key.slice(sep + 1) : key;
+    if (!targetId) {
+      continue;
+    }
+    // createViaBrowser keys as `${nodeId}:${targetId}` (local often empty nodeId).
+    if (params.transport === "chrome-node" && !nodeId) {
+      continue;
+    }
+    if (params.transport === "chrome" && nodeId && nodeId !== "local") {
+      continue;
+    }
+    if (params.url && !GOOGLE_MEET_PLATFORM_ADAPTER.urls.isSameMeeting(meetingUri, params.url)) {
+      continue;
+    }
+    return { trackedMeetingUrl: meetingUri, trackedTargetId: targetId };
+  }
+  if (params.url) {
+    return { trackedMeetingUrl: params.url };
+  }
+  return {};
+}

--- a/extensions/google-meet/src/runtime.ts
+++ b/extensions/google-meet/src/runtime.ts
@@ -23,6 +23,7 @@ import {
   testGoogleMeetSpeech,
   type GoogleMeetRuntimeProbeContext,
 } from "./runtime-probes.js";
+import { resolveRecoverOwnership } from "./runtime-recover-ownership.js";
 import {
   isBrowserTransport,
   noteSession,
@@ -252,19 +253,27 @@ export class GoogleMeetRuntime {
     const url = request.url
       ? GOOGLE_MEET_PLATFORM_ADAPTER.urls.validateAndNormalize(request.url)
       : undefined;
+    // Untargeted recovery must only reattach to a tab this runtime owns.
+    // Without trackedTargetId, findRecoverableTab falls through to any Meet
+    // identity in the shared Chrome profile and arms mic/captions on it.
+    const ownership = resolveRecoverOwnership({
+      url,
+      transport,
+      sessions: this.list(),
+      createdBrowserTabs: this.#createdBrowserTabs,
+    });
+
+    if (!url && !ownership.trackedTargetId) {
+      const message = "No owned Meet tab available for untargeted recovery.";
+      return transport === "chrome-node"
+        ? { transport: "chrome-node" as const, nodeId: "", found: false, message }
+        : { transport: "chrome" as const, found: false, message };
+    }
+    const { runtime, config, fullConfig } = this.params;
+    const recoverParams = { runtime, config, fullConfig, url, ...ownership };
     return transport === "chrome-node"
-      ? await recoverCurrentMeetTabOnNode({
-          runtime: this.params.runtime,
-          config: this.params.config,
-          fullConfig: this.params.fullConfig,
-          url,
-        })
-      : await recoverCurrentMeetTab({
-          runtime: this.params.runtime,
-          config: this.params.config,
-          fullConfig: this.params.fullConfig,
-          url,
-        });
+      ? await recoverCurrentMeetTabOnNode(recoverParams)
+      : await recoverCurrentMeetTab(recoverParams);
   }
 
   async join(request: GoogleMeetJoinRequest): Promise<GoogleMeetJoinResult> {

--- a/src/meeting-bot/browser-controller.test.ts
+++ b/src/meeting-bot/browser-controller.test.ts
@@ -107,6 +107,76 @@ describe("meeting browser join readiness", () => {
 });
 
 describe("meeting browser recovery", () => {
+  it("refuses untargeted recovery when no tracked target owns a tab", async () => {
+    const calls: string[] = [];
+    const result = await recoverMeetingBrowserTab({
+      adapter: {
+        browserLabel: "Test meeting",
+        urls: {
+          accountHint: () => undefined,
+          buildJoinUrl: (session) => session.url,
+          isPreferredJoinUrl: () => true,
+          isRecoverableTab: () => true,
+          isSameMeeting: () => true,
+          localeAction: () => undefined,
+          normalizeForReuse: () => "test-meeting",
+          validateAndNormalize: (input) => String(input),
+        },
+        browser: {
+          allowsMicrophone: () => true,
+          browserControlUnavailable: () => ({
+            category: "browser-control-unavailable",
+            reason: "browser-unavailable",
+            message: "Browser unavailable.",
+          }),
+          buildLeaveScript: () => "",
+          buildStatusJoinScript: () => "() => '{}'",
+          captions: {
+            buildTranscriptScript: () => "",
+            enabled: () => true,
+            parseTranscript: () => ({ droppedLines: 0, lines: [] }),
+          },
+          classifyManualAction: () => undefined,
+          parseLeaveResult: () => ({ departed: false }),
+          parseStatus: () => ({ status: "browser-control", inCall: true }),
+          permissions: () => undefined,
+          permissionNotes: () => [],
+        },
+      },
+      callBrowser: async (request) => {
+        calls.push(`${request.method} ${request.path}`);
+        if (request.path === "/tabs") {
+          return {
+            tabs: [
+              {
+                targetId: "unrelated-meet-tab",
+                url: "https://meet.google.com/hum-anpr-ivt",
+              },
+            ],
+          };
+        }
+        throw new Error(`unexpected browser call: ${request.method} ${request.path}`);
+      },
+      config: {
+        launch: true,
+        reuseExistingTab: true,
+        autoJoin: true,
+        guestName: "OpenClaw QA",
+        joinTimeoutMs: 2_000,
+        waitForInCallMs: 2_000,
+      },
+      locationLabel: "in local Chrome",
+      mode: "bidi",
+      requestedMeetingUrl: undefined,
+      trackedMeetingUrl: undefined,
+      trackedTargetId: undefined,
+    });
+
+    expect(result.found).toBe(false);
+    expect(result.message).toContain("No existing Test meeting tab found");
+    expect(calls).toEqual(["GET /tabs"]);
+  });
+
   it("retries status inspection when auto-join navigation destroys the page context", async () => {
     const adoptionAttempts: boolean[] = [];
     let evaluationAttempts = 0;

--- a/src/meeting-bot/browser-controller.test.ts
+++ b/src/meeting-bot/browser-controller.test.ts
@@ -177,6 +177,80 @@ describe("meeting browser recovery", () => {
     expect(calls).toEqual(["GET /tabs"]);
   });
 
+  it("refuses untargeted recovery when the tracked target is stale and only an unrelated tab remains", async () => {
+    const calls: string[] = [];
+    const result = await recoverMeetingBrowserTab({
+      adapter: {
+        browserLabel: "Test meeting",
+        urls: {
+          accountHint: () => undefined,
+          buildJoinUrl: (session) => session.url,
+          isPreferredJoinUrl: () => true,
+          isRecoverableTab: () => true,
+          isSameMeeting: () => true,
+          localeAction: () => undefined,
+          normalizeForReuse: () => "test-meeting",
+          validateAndNormalize: (input) => String(input),
+        },
+        browser: {
+          allowsMicrophone: () => true,
+          browserControlUnavailable: () => ({
+            category: "browser-control-unavailable",
+            reason: "browser-unavailable",
+            message: "Browser unavailable.",
+          }),
+          buildLeaveScript: () => "",
+          buildStatusJoinScript: () => "() => '{}'",
+          captions: {
+            buildTranscriptScript: () => "",
+            enabled: () => true,
+            parseTranscript: () => ({ droppedLines: 0, lines: [] }),
+          },
+          classifyManualAction: () => undefined,
+          parseLeaveResult: () => ({ departed: false }),
+          parseStatus: () => ({ status: "browser-control", inCall: true }),
+          permissions: () => undefined,
+          permissionNotes: () => [],
+        },
+      },
+      callBrowser: async (request) => {
+        calls.push(`${request.method} ${request.path}`);
+        if (request.path === "/tabs") {
+          // The tracked target ("owned-meet-tab") is gone — only an unrelated
+          // meeting tab remains open in the shared profile.
+          return {
+            tabs: [
+              {
+                targetId: "unrelated-meet-tab",
+                url: "https://meet.google.com/hum-anpr-ivt",
+              },
+            ],
+          };
+        }
+        throw new Error(`unexpected browser call: ${request.method} ${request.path}`);
+      },
+      config: {
+        launch: true,
+        reuseExistingTab: true,
+        autoJoin: true,
+        guestName: "OpenClaw QA",
+        joinTimeoutMs: 2_000,
+        waitForInCallMs: 2_000,
+      },
+      locationLabel: "in local Chrome",
+      mode: "bidi",
+      requestedMeetingUrl: undefined,
+      trackedMeetingUrl: undefined,
+      trackedTargetId: "owned-meet-tab",
+    });
+
+    expect(result.found).toBe(false);
+    expect(result.message).toContain("No existing Test meeting tab found");
+    // Only tabs are listed — no focus, permission grant, or script dispatch on
+    // the unrelated tab.
+    expect(calls).toEqual(["GET /tabs"]);
+  });
+
   it("retries status inspection when auto-join navigation destroys the page context", async () => {
     const adoptionAttempts: boolean[] = [];
     let evaluationAttempts = 0;

--- a/src/meeting-bot/browser-controller.ts
+++ b/src/meeting-bot/browser-controller.ts
@@ -563,13 +563,19 @@ export async function recoverMeetingBrowserTab<
     (!trackedUrlHasMeetingIdentity || trackedUrlMatches)
       ? trackedCandidate
       : undefined;
+  // Untargeted recovery without a tracked target must not attach to a random
+  // meeting tab in a shared browser profile (mic + captions would arm on it).
+  const allowUntargetedEnumeration =
+    Boolean(params.requestedMeetingUrl) || Boolean(params.trackedTargetId);
   const tab =
     trackedTab ??
-    findRecoverableTab({
-      adapter: params.adapter,
-      tabs,
-      requestedMeetingUrl: params.requestedMeetingUrl,
-    });
+    (allowUntargetedEnumeration
+      ? findRecoverableTab({
+          adapter: params.adapter,
+          tabs,
+          requestedMeetingUrl: params.requestedMeetingUrl,
+        })
+      : undefined);
   const targetId = tab?.targetId;
   if (!tab || !targetId) {
     return {

--- a/src/meeting-bot/browser-controller.ts
+++ b/src/meeting-bot/browser-controller.ts
@@ -563,10 +563,13 @@ export async function recoverMeetingBrowserTab<
     (!trackedUrlHasMeetingIdentity || trackedUrlMatches)
       ? trackedCandidate
       : undefined;
-  // Untargeted recovery without a tracked target must not attach to a random
-  // meeting tab in a shared browser profile (mic + captions would arm on it).
-  const allowUntargetedEnumeration =
-    Boolean(params.requestedMeetingUrl) || Boolean(params.trackedTargetId);
+  // Untargeted recovery must not attach to a random meeting tab in a shared
+  // browser profile (mic + captions would arm on it). A tracked target is a
+  // constraint, not blanket authorization: when it resolves it is used above
+  // via `trackedTab`. A stale/absent tracked target (or one that now points at
+  // a different meeting) must NOT fall through to generic enumeration — only a
+  // requested meeting URL can license discovery of an untracked tab.
+  const allowUntargetedEnumeration = Boolean(params.requestedMeetingUrl);
   const tab =
     trackedTab ??
     (allowUntargetedEnumeration


### PR DESCRIPTION
## Summary
`recover_current_tab` without a URL no longer attaches to a random Meet tab in the shared Chrome profile. Google Meet runtime now prefers a session/createViaBrowser-owned target, and meeting-bot recovery refuses untargeted enumeration without a tracked target.

Fixes #113990

## What Problem This Solves
Without ownership wiring, untargeted `recover_current_tab` enumerated any Google Meet tab in the shared Chrome profile and could focus an unrelated user meeting — granting mic/camera and arming the join script on a tab the bot never owned. A present-but-stale `trackedTargetId` also fell through to generic enumeration. This scopes recovery to owned/tracked tabs only.

## Evidence
`node scripts/run-vitest.mjs src/meeting-bot/browser-controller.test.ts` — 7 tests pass, including the new stale-target regression (recovery returns `found: false` with no focus, permission grant, or script dispatch when the tracked target is gone or points at a different meeting).
