### PR TITLE
fix: debug proxy respects response backpressure (issue #105701)

### DIFF
--- a/src/proxy-capture/proxy-server.test.ts
+++ b/src/proxy-capture/proxy-server.test.ts
@@ -275,9 +275,12 @@ describe("startDebugProxyServer", () => {
     const responseBody = `pressure-${"x".repeat(1024)}`;
     const origin = await startLargeBodyOrigin(responseBody);
     const proxy = await startDebugProxyServer({ settings });
-    const originalWrite = ServerResponse.prototype.write as (...args: unknown[]) => boolean;
-    const originalPause = IncomingMessage.prototype.pause;
-    const originalResume = IncomingMessage.prototype.resume;
+    const originalWrite = Object.getOwnPropertyDescriptor(ServerResponse.prototype, "write")
+      ?.value as (...args: unknown[]) => boolean;
+    const originalPause = Object.getOwnPropertyDescriptor(IncomingMessage.prototype, "pause")
+      ?.value as typeof IncomingMessage.prototype.pause;
+    const originalResume = Object.getOwnPropertyDescriptor(IncomingMessage.prototype, "resume")
+      ?.value as typeof IncomingMessage.prototype.resume;
     let forcedBackpressure = false;
     let upstreamPauseCount = 0;
     let upstreamResumeCount = 0;

--- a/src/proxy-capture/proxy-server.test.ts
+++ b/src/proxy-capture/proxy-server.test.ts
@@ -149,12 +149,15 @@ type ProxyResponseResult = {
   statusCode?: number;
 };
 
-function getPrototypeMethod<T>(prototype: object, methodName: string): T {
+function getPrototypeMethod(
+  prototype: object,
+  methodName: string,
+): (...args: unknown[]) => unknown {
   let current: object | null = prototype;
   while (current) {
     const value = Object.getOwnPropertyDescriptor(current, methodName)?.value;
     if (typeof value === "function") {
-      return value as T;
+      return value as (...args: unknown[]) => unknown;
     }
     current = Object.getPrototypeOf(current);
   }
@@ -364,18 +367,18 @@ describe("startDebugProxyServer", () => {
     const settings = await makeSettings();
     const responseChunks = [Buffer.from("pressure-"), Buffer.alloc(1024, "x")];
     const responseBodyBytes = responseChunks.reduce((total, chunk) => total + chunk.byteLength, 0);
-    const originalWrite = getPrototypeMethod<typeof ServerResponse.prototype.write>(
+    const originalWrite = getPrototypeMethod(
       ServerResponse.prototype,
       "write",
-    );
-    const originalPause = getPrototypeMethod<typeof IncomingMessage.prototype.pause>(
+    ) as typeof ServerResponse.prototype.write;
+    const originalPause = getPrototypeMethod(
       IncomingMessage.prototype,
       "pause",
-    );
-    const originalResume = getPrototypeMethod<typeof IncomingMessage.prototype.resume>(
+    ) as typeof IncomingMessage.prototype.pause;
+    const originalResume = getPrototypeMethod(
       IncomingMessage.prototype,
       "resume",
-    );
+    ) as typeof IncomingMessage.prototype.resume;
     let forcedBackpressure = false;
     let upstreamPauseCount = 0;
     let upstreamResumeCount = 0;

--- a/src/proxy-capture/proxy-server.test.ts
+++ b/src/proxy-capture/proxy-server.test.ts
@@ -3,7 +3,8 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import {
   request as httpRequest,
   createServer as createHttpServer,
-  type IncomingMessage,
+  IncomingMessage,
+  ServerResponse,
 } from "node:http";
 import type { AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
@@ -264,6 +265,64 @@ describe("startDebugProxyServer", () => {
         captureTruncated: true,
       });
     } finally {
+      await proxy.stop();
+      await origin.stop();
+    }
+  });
+
+  it("pauses the upstream response while downstream forwarding is backpressured", async () => {
+    const settings = await makeSettings();
+    const responseBody = `pressure-${"x".repeat(1024)}`;
+    const origin = await startLargeBodyOrigin(responseBody);
+    const proxy = await startDebugProxyServer({ settings });
+    const originalWrite = ServerResponse.prototype.write as (...args: unknown[]) => boolean;
+    const originalPause = IncomingMessage.prototype.pause;
+    const originalResume = IncomingMessage.prototype.resume;
+    let forcedBackpressure = false;
+    let upstreamPauseCount = 0;
+    let upstreamResumeCount = 0;
+
+    ServerResponse.prototype.write = function patchedWrite(
+      this: ServerResponse,
+      ...args: unknown[]
+    ): boolean {
+      const wrote = originalWrite.apply(this, args);
+      const requestUrl = (this as ServerResponse & { req?: IncomingMessage }).req?.url ?? "";
+      if (!forcedBackpressure && requestUrl.startsWith("http://") && args[0] instanceof Buffer) {
+        forcedBackpressure = true;
+        setTimeout(() => this.emit("drain"), 10);
+        return false;
+      }
+      return wrote;
+    } as typeof ServerResponse.prototype.write;
+    IncomingMessage.prototype.pause = function patchedPause(
+      this: IncomingMessage,
+    ): IncomingMessage {
+      if (forcedBackpressure && this.statusCode === 200) {
+        upstreamPauseCount++;
+      }
+      return originalPause.call(this);
+    };
+    IncomingMessage.prototype.resume = function patchedResume(
+      this: IncomingMessage,
+    ): IncomingMessage {
+      if (forcedBackpressure && this.statusCode === 200) {
+        upstreamResumeCount++;
+      }
+      return originalResume.call(this);
+    };
+
+    try {
+      const forwarded = await getThroughProxy(proxy.proxyUrl, origin.url);
+
+      expect(forcedBackpressure).toBe(true);
+      expect(forwarded).toMatchObject({ body: responseBody, complete: true, statusCode: 200 });
+      expect(upstreamPauseCount).toBeGreaterThanOrEqual(1);
+      expect(upstreamResumeCount).toBeGreaterThanOrEqual(1);
+    } finally {
+      ServerResponse.prototype.write = originalWrite as typeof ServerResponse.prototype.write;
+      IncomingMessage.prototype.pause = originalPause;
+      IncomingMessage.prototype.resume = originalResume;
       await proxy.stop();
       await origin.stop();
     }

--- a/src/proxy-capture/proxy-server.test.ts
+++ b/src/proxy-capture/proxy-server.test.ts
@@ -403,7 +403,7 @@ describe("startDebugProxyServer", () => {
       this: ServerResponse,
       ...args: unknown[]
     ): boolean {
-      const wrote = originalWrite.apply(this, args);
+      const wrote = Reflect.apply(originalWrite, this, args) as boolean;
       const requestUrl = (this as ServerResponse & { req?: IncomingMessage }).req?.url ?? "";
       if (!forcedBackpressure && requestUrl.startsWith("http://") && args[0] instanceof Buffer) {
         forcedBackpressure = true;

--- a/src/proxy-capture/proxy-server.test.ts
+++ b/src/proxy-capture/proxy-server.test.ts
@@ -6,7 +6,7 @@ import {
   IncomingMessage,
   ServerResponse,
 } from "node:http";
-import type { AddressInfo } from "node:net";
+import net, { type AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -149,6 +149,18 @@ type ProxyResponseResult = {
   statusCode?: number;
 };
 
+function getPrototypeMethod<T>(prototype: object, methodName: string): T {
+  let current: object | null = prototype;
+  while (current) {
+    const value = Object.getOwnPropertyDescriptor(current, methodName)?.value;
+    if (typeof value === "function") {
+      return value as T;
+    }
+    current = Object.getPrototypeOf(current);
+  }
+  throw new Error(`Missing prototype method ${methodName}`);
+}
+
 async function getThroughProxy(proxyUrl: string, targetUrl: string): Promise<ProxyResponseResult> {
   const proxy = new URL(proxyUrl);
   return await new Promise<ProxyResponseResult>((resolve) => {
@@ -229,6 +241,84 @@ async function postThroughProxy(params: {
   });
 }
 
+async function rawSlowGetThroughProxy(params: {
+  pauseBeforeReadMs: number;
+  proxyUrl: string;
+  targetUrl: string;
+}): Promise<{ receivedBytes: number; resumed: boolean; statusLine: string }> {
+  const proxy = new URL(params.proxyUrl);
+  return await new Promise((resolve, reject) => {
+    let bodyBytes = 0;
+    let contentLength: number | undefined;
+    let headerBytes = Buffer.alloc(0);
+    let receivedBytes = 0;
+    let resumed = false;
+    let settled = false;
+    let statusLine = "";
+    const socket = net.connect(Number(proxy.port), proxy.hostname);
+    const timeout = setTimeout(() => {
+      socket.destroy();
+      if (!settled) {
+        settled = true;
+        reject(new Error("slow proxy client timed out"));
+      }
+    }, 15000);
+    const finish = () => {
+      clearTimeout(timeout);
+      if (!settled) {
+        settled = true;
+        resolve({ receivedBytes, resumed, statusLine });
+      }
+    };
+    const maybeFinishCompleteBody = () => {
+      if (contentLength !== undefined && bodyBytes >= contentLength) {
+        socket.destroy();
+        finish();
+      }
+    };
+    socket.on("connect", () => {
+      socket.write(
+        `GET ${params.targetUrl} HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n`,
+      );
+      socket.pause();
+      setTimeout(() => {
+        resumed = true;
+        socket.resume();
+      }, params.pauseBeforeReadMs);
+    });
+    socket.on("data", (chunk) => {
+      receivedBytes += chunk.length;
+      if (contentLength === undefined) {
+        headerBytes = Buffer.concat([headerBytes, Buffer.from(chunk)]);
+        const headerEnd = headerBytes.indexOf("\r\n\r\n");
+        if (headerEnd === -1) {
+          return;
+        }
+        const headerText = headerBytes.subarray(0, headerEnd).toString("latin1");
+        statusLine = headerText.split("\r\n")[0] ?? "";
+        const contentLengthHeader = headerText
+          .split("\r\n")
+          .find((line) => line.toLowerCase().startsWith("content-length:"));
+        const parsedContentLength = Number(contentLengthHeader?.split(":")[1]?.trim());
+        contentLength = Number.isFinite(parsedContentLength) ? parsedContentLength : 0;
+        bodyBytes += headerBytes.byteLength - headerEnd - 4;
+        headerBytes = Buffer.alloc(0);
+      } else {
+        bodyBytes += chunk.length;
+      }
+      maybeFinishCompleteBody();
+    });
+    socket.on("error", (error) => {
+      clearTimeout(timeout);
+      if (!settled) {
+        settled = true;
+        reject(error);
+      }
+    });
+    socket.on("close", finish);
+  });
+}
+
 afterEach(async () => {
   await cleanupTestRoot();
 });
@@ -272,18 +362,42 @@ describe("startDebugProxyServer", () => {
 
   it("pauses the upstream response while downstream forwarding is backpressured", async () => {
     const settings = await makeSettings();
-    const responseBody = `pressure-${"x".repeat(1024)}`;
-    const origin = await startLargeBodyOrigin(responseBody);
-    const proxy = await startDebugProxyServer({ settings });
-    const originalWrite = Object.getOwnPropertyDescriptor(ServerResponse.prototype, "write")
-      ?.value as (...args: unknown[]) => boolean;
-    const originalPause = Object.getOwnPropertyDescriptor(IncomingMessage.prototype, "pause")
-      ?.value as typeof IncomingMessage.prototype.pause;
-    const originalResume = Object.getOwnPropertyDescriptor(IncomingMessage.prototype, "resume")
-      ?.value as typeof IncomingMessage.prototype.resume;
+    const responseChunks = [Buffer.from("pressure-"), Buffer.alloc(1024, "x")];
+    const responseBodyBytes = responseChunks.reduce((total, chunk) => total + chunk.byteLength, 0);
+    const originalWrite = getPrototypeMethod<typeof ServerResponse.prototype.write>(
+      ServerResponse.prototype,
+      "write",
+    );
+    const originalPause = getPrototypeMethod<typeof IncomingMessage.prototype.pause>(
+      IncomingMessage.prototype,
+      "pause",
+    );
+    const originalResume = getPrototypeMethod<typeof IncomingMessage.prototype.resume>(
+      IncomingMessage.prototype,
+      "resume",
+    );
     let forcedBackpressure = false;
     let upstreamPauseCount = 0;
     let upstreamResumeCount = 0;
+    const originServer = createHttpServer((req, res) => {
+      req.resume();
+      res.writeHead(200, {
+        "content-length": String(responseBodyBytes),
+        "content-type": "text/plain; charset=utf-8",
+      });
+      res.write(responseChunks[0]);
+      setTimeout(() => res.end(responseChunks[1]), 30);
+    });
+    await new Promise<void>((resolve, reject) => {
+      originServer.once("error", reject);
+      originServer.listen(0, "127.0.0.1", () => {
+        originServer.off("error", reject);
+        resolve();
+      });
+    });
+    const originAddress = originServer.address() as AddressInfo;
+    const originUrl = `http://127.0.0.1:${originAddress.port}/capture`;
+    const proxy = await startDebugProxyServer({ settings });
 
     ServerResponse.prototype.write = function patchedWrite(
       this: ServerResponse,
@@ -316,18 +430,31 @@ describe("startDebugProxyServer", () => {
     };
 
     try {
-      const forwarded = await getThroughProxy(proxy.proxyUrl, origin.url);
+      const forwarded = await rawSlowGetThroughProxy({
+        pauseBeforeReadMs: 0,
+        proxyUrl: proxy.proxyUrl,
+        targetUrl: originUrl,
+      });
 
+      expect(forwarded).toMatchObject({ resumed: true, statusLine: "HTTP/1.1 200 OK" });
       expect(forcedBackpressure).toBe(true);
-      expect(forwarded).toMatchObject({ body: responseBody, complete: true, statusCode: 200 });
+      expect(forwarded.receivedBytes).toBeGreaterThanOrEqual(responseBodyBytes);
       expect(upstreamPauseCount).toBeGreaterThanOrEqual(1);
       expect(upstreamResumeCount).toBeGreaterThanOrEqual(1);
     } finally {
       ServerResponse.prototype.write = originalWrite as typeof ServerResponse.prototype.write;
       IncomingMessage.prototype.pause = originalPause;
       IncomingMessage.prototype.resume = originalResume;
+      await new Promise<void>((resolve, reject) => {
+        originServer.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve();
+        });
+      });
       await proxy.stop();
-      await origin.stop();
     }
   });
 

--- a/src/proxy-capture/proxy-server.test.ts
+++ b/src/proxy-capture/proxy-server.test.ts
@@ -3,13 +3,12 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import {
   request as httpRequest,
   createServer as createHttpServer,
-  IncomingMessage,
-  ServerResponse,
+  type IncomingMessage,
 } from "node:http";
 import net, { type AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import type { DebugProxySettings } from "./env.js";
 import { startDebugProxyServer } from "./proxy-server.js";
@@ -149,21 +148,6 @@ type ProxyResponseResult = {
   statusCode?: number;
 };
 
-function getPrototypeMethod(
-  prototype: object,
-  methodName: string,
-): (...args: unknown[]) => unknown {
-  let current: object | null = prototype;
-  while (current) {
-    const value = Object.getOwnPropertyDescriptor(current, methodName)?.value;
-    if (typeof value === "function") {
-      return value as (...args: unknown[]) => unknown;
-    }
-    current = Object.getPrototypeOf(current);
-  }
-  throw new Error(`Missing prototype method ${methodName}`);
-}
-
 async function getThroughProxy(proxyUrl: string, targetUrl: string): Promise<ProxyResponseResult> {
   const proxy = new URL(proxyUrl);
   return await new Promise<ProxyResponseResult>((resolve) => {
@@ -244,13 +228,105 @@ async function postThroughProxy(params: {
   });
 }
 
+type StreamingProxyOrigin = {
+  state: {
+    closedResponses: number;
+    drainWaits: number;
+    finishedResponses: number;
+    queuedBytes: number;
+  };
+  stop: () => Promise<void>;
+  url: string;
+};
+
+async function startStreamingProxyOrigin(responseBodyBytes: number): Promise<StreamingProxyOrigin> {
+  const state = {
+    closedResponses: 0,
+    drainWaits: 0,
+    finishedResponses: 0,
+    queuedBytes: 0,
+  };
+  const chunk = Buffer.alloc(64 * 1024, "x");
+  const server = createHttpServer((req, res) => {
+    req.resume();
+    if (req.url === "/healthy") {
+      res.writeHead(200, {
+        "content-length": 2,
+        "content-type": "text/plain; charset=utf-8",
+      });
+      res.end("ok");
+      return;
+    }
+
+    res.writeHead(200, {
+      "content-length": responseBodyBytes,
+      "content-type": "text/plain; charset=utf-8",
+    });
+    res.on("close", () => {
+      state.closedResponses++;
+    });
+    res.on("finish", () => {
+      state.finishedResponses++;
+    });
+
+    const writeNextChunk = () => {
+      while (state.queuedBytes < responseBodyBytes && !res.destroyed) {
+        const chunkBytes = Math.min(chunk.byteLength, responseBodyBytes - state.queuedBytes);
+        state.queuedBytes += chunkBytes;
+        if (!res.write(chunk.subarray(0, chunkBytes))) {
+          state.drainWaits++;
+          res.once("drain", writeNextChunk);
+          return;
+        }
+      }
+      if (state.queuedBytes === responseBodyBytes && !res.destroyed) {
+        res.end();
+      }
+    };
+    writeNextChunk();
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  const address = server.address() as AddressInfo;
+  return {
+    state,
+    stop: async () =>
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve();
+        });
+      }),
+    url: `http://127.0.0.1:${address.port}`,
+  };
+}
+
 async function rawSlowGetThroughProxy(params: {
+  abortAfterBytes?: number;
+  abortWithReset?: boolean;
+  onResume?: () => void;
   pauseBeforeReadMs: number;
   proxyUrl: string;
   targetUrl: string;
-}): Promise<{ receivedBytes: number; resumed: boolean; statusLine: string }> {
+}): Promise<{
+  aborted: boolean;
+  bodyBytes: number;
+  receivedBytes: number;
+  resumed: boolean;
+  statusLine: string;
+}> {
   const proxy = new URL(params.proxyUrl);
   return await new Promise((resolve, reject) => {
+    let aborted = false;
     let bodyBytes = 0;
     let contentLength: number | undefined;
     let headerBytes = Buffer.alloc(0);
@@ -258,6 +334,7 @@ async function rawSlowGetThroughProxy(params: {
     let resumed = false;
     let settled = false;
     let statusLine = "";
+    let resumeTimeout: ReturnType<typeof setTimeout> | undefined;
     const socket = net.connect(Number(proxy.port), proxy.hostname);
     const timeout = setTimeout(() => {
       socket.destroy();
@@ -268,9 +345,10 @@ async function rawSlowGetThroughProxy(params: {
     }, 15000);
     const finish = () => {
       clearTimeout(timeout);
+      clearTimeout(resumeTimeout);
       if (!settled) {
         settled = true;
-        resolve({ receivedBytes, resumed, statusLine });
+        resolve({ aborted, bodyBytes, receivedBytes, resumed, statusLine });
       }
     };
     const maybeFinishCompleteBody = () => {
@@ -284,8 +362,9 @@ async function rawSlowGetThroughProxy(params: {
         `GET ${params.targetUrl} HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n`,
       );
       socket.pause();
-      setTimeout(() => {
+      resumeTimeout = setTimeout(() => {
         resumed = true;
+        params.onResume?.();
         socket.resume();
       }, params.pauseBeforeReadMs);
     });
@@ -309,10 +388,21 @@ async function rawSlowGetThroughProxy(params: {
       } else {
         bodyBytes += chunk.length;
       }
+      if (params.abortAfterBytes !== undefined && bodyBytes >= params.abortAfterBytes) {
+        aborted = true;
+        if (params.abortWithReset) {
+          socket.resetAndDestroy();
+        } else {
+          socket.destroy();
+        }
+        finish();
+        return;
+      }
       maybeFinishCompleteBody();
     });
     socket.on("error", (error) => {
       clearTimeout(timeout);
+      clearTimeout(resumeTimeout);
       if (!settled) {
         settled = true;
         reject(error);
@@ -365,99 +455,143 @@ describe("startDebugProxyServer", () => {
 
   it("pauses the upstream response while downstream forwarding is backpressured", async () => {
     const settings = await makeSettings();
-    const responseChunks = [Buffer.from("pressure-"), Buffer.alloc(1024, "x")];
-    const responseBodyBytes = responseChunks.reduce((total, chunk) => total + chunk.byteLength, 0);
-    const originalWrite = getPrototypeMethod(
-      ServerResponse.prototype,
-      "write",
-    ) as typeof ServerResponse.prototype.write;
-    const originalPause = getPrototypeMethod(
-      IncomingMessage.prototype,
-      "pause",
-    ) as typeof IncomingMessage.prototype.pause;
-    const originalResume = getPrototypeMethod(
-      IncomingMessage.prototype,
-      "resume",
-    ) as typeof IncomingMessage.prototype.resume;
-    let forcedBackpressure = false;
-    let upstreamPauseCount = 0;
-    let upstreamResumeCount = 0;
-    const originServer = createHttpServer((req, res) => {
-      req.resume();
-      res.writeHead(200, {
-        "content-length": String(responseBodyBytes),
-        "content-type": "text/plain; charset=utf-8",
-      });
-      res.write(responseChunks[0]);
-      setTimeout(() => res.end(responseChunks[1]), 30);
-    });
-    await new Promise<void>((resolve, reject) => {
-      originServer.once("error", reject);
-      originServer.listen(0, "127.0.0.1", () => {
-        originServer.off("error", reject);
-        resolve();
-      });
-    });
-    const originAddress = originServer.address() as AddressInfo;
-    const originUrl = `http://127.0.0.1:${originAddress.port}/capture`;
+    const responseBodyBytes = 16 * 1024 * 1024;
+    const origin = await startStreamingProxyOrigin(responseBodyBytes);
     const proxy = await startDebugProxyServer({ settings });
-
-    ServerResponse.prototype.write = function patchedWrite(
-      this: ServerResponse,
-      ...args: unknown[]
-    ): boolean {
-      const wrote = Reflect.apply(originalWrite, this, args) as boolean;
-      const requestUrl = (this as ServerResponse & { req?: IncomingMessage }).req?.url ?? "";
-      if (!forcedBackpressure && requestUrl.startsWith("http://") && args[0] instanceof Buffer) {
-        forcedBackpressure = true;
-        setTimeout(() => this.emit("drain"), 10);
-        return false;
-      }
-      return wrote;
-    } as typeof ServerResponse.prototype.write;
-    IncomingMessage.prototype.pause = function patchedPause(
-      this: IncomingMessage,
-    ): IncomingMessage {
-      if (forcedBackpressure && this.statusCode === 200) {
-        upstreamPauseCount++;
-      }
-      return originalPause.call(this);
-    };
-    IncomingMessage.prototype.resume = function patchedResume(
-      this: IncomingMessage,
-    ): IncomingMessage {
-      if (forcedBackpressure && this.statusCode === 200) {
-        upstreamResumeCount++;
-      }
-      return originalResume.call(this);
-    };
+    let queuedBytesAtResume = 0;
 
     try {
       const forwarded = await rawSlowGetThroughProxy({
-        pauseBeforeReadMs: 0,
+        onResume: () => {
+          queuedBytesAtResume = origin.state.queuedBytes;
+        },
+        pauseBeforeReadMs: 150,
         proxyUrl: proxy.proxyUrl,
-        targetUrl: originUrl,
+        targetUrl: `${origin.url}/capture`,
       });
 
-      expect(forwarded).toMatchObject({ resumed: true, statusLine: "HTTP/1.1 200 OK" });
-      expect(forcedBackpressure).toBe(true);
-      expect(forwarded.receivedBytes).toBeGreaterThanOrEqual(responseBodyBytes);
-      expect(upstreamPauseCount).toBeGreaterThanOrEqual(1);
-      expect(upstreamResumeCount).toBeGreaterThanOrEqual(1);
-    } finally {
-      ServerResponse.prototype.write = originalWrite as typeof ServerResponse.prototype.write;
-      IncomingMessage.prototype.pause = originalPause;
-      IncomingMessage.prototype.resume = originalResume;
-      await new Promise<void>((resolve, reject) => {
-        originServer.close((error) => {
-          if (error) {
-            reject(error);
-            return;
-          }
-          resolve();
-        });
+      expect(forwarded).toMatchObject({
+        aborted: false,
+        bodyBytes: responseBodyBytes,
+        resumed: true,
+        statusLine: "HTTP/1.1 200 OK",
       });
+      expect(queuedBytesAtResume).toBeLessThan(responseBodyBytes);
+      expect(origin.state.drainWaits).toBeGreaterThan(0);
+      expect(origin.state.queuedBytes).toBe(responseBodyBytes);
+      const captureEvents = getDebugProxyCaptureStore()
+        .getSessionEvents(settings.sessionId, 20)
+        .filter((event) => event.path === "/capture");
+      expect(captureEvents.filter((event) => event.kind === "error")).toEqual([]);
+      expect(captureEvents.filter((event) => event.kind === "response")).toEqual([
+        expect.objectContaining({ direction: "inbound", status: 200 }),
+      ]);
+    } finally {
       await proxy.stop();
+      await origin.stop();
+    }
+  });
+
+  it("closes the upstream response when a slow downstream client aborts", async () => {
+    const settings = await makeSettings();
+    const responseBodyBytes = 16 * 1024 * 1024;
+    const origin = await startStreamingProxyOrigin(responseBodyBytes);
+    const proxy = await startDebugProxyServer({ settings });
+
+    try {
+      const aborted = await rawSlowGetThroughProxy({
+        abortAfterBytes: 64 * 1024,
+        pauseBeforeReadMs: 0,
+        proxyUrl: proxy.proxyUrl,
+        targetUrl: `${origin.url}/capture`,
+      });
+
+      expect(aborted).toMatchObject({
+        aborted: true,
+        resumed: true,
+        statusLine: "HTTP/1.1 200 OK",
+      });
+      expect(aborted.bodyBytes).toBeGreaterThanOrEqual(64 * 1024);
+
+      await vi.waitFor(() => {
+        expect(origin.state.closedResponses).toBe(1);
+        expect(origin.state.finishedResponses).toBe(0);
+        const captureEvents = getDebugProxyCaptureStore()
+          .getSessionEvents(settings.sessionId, 20)
+          .filter((event) => event.path === "/capture");
+        const capturedRequest = captureEvents.find((event) => event.kind === "request");
+        expect(capturedRequest).toBeDefined();
+        expect(captureEvents.filter((event) => event.kind === "error")).toEqual([
+          expect.objectContaining({
+            direction: "local",
+            errorText: "Downstream response closed before completion",
+            flowId: capturedRequest?.flowId,
+          }),
+        ]);
+        expect(captureEvents.filter((event) => event.kind === "response")).toEqual([]);
+      });
+
+      const healthy = await getThroughProxy(proxy.proxyUrl, `${origin.url}/healthy`);
+      expect(healthy).toMatchObject({ body: "ok", complete: true, statusCode: 200 });
+      expect(
+        getDebugProxyCaptureStore()
+          .getSessionEvents(settings.sessionId, 20)
+          .filter((event) => event.path === "/healthy" && event.kind === "error"),
+      ).toEqual([]);
+    } finally {
+      await proxy.stop();
+      await origin.stop();
+    }
+  });
+
+  it("records a reset downstream client as exactly one local capture error", async () => {
+    const settings = await makeSettings();
+    const origin = await startStreamingProxyOrigin(16 * 1024 * 1024);
+    const proxy = await startDebugProxyServer({ settings });
+
+    try {
+      const aborted = await rawSlowGetThroughProxy({
+        abortAfterBytes: 64 * 1024,
+        abortWithReset: true,
+        pauseBeforeReadMs: 0,
+        proxyUrl: proxy.proxyUrl,
+        targetUrl: `${origin.url}/capture`,
+      });
+
+      expect(aborted).toMatchObject({
+        aborted: true,
+        resumed: true,
+        statusLine: "HTTP/1.1 200 OK",
+      });
+
+      await vi.waitFor(() => {
+        expect(origin.state.closedResponses).toBe(1);
+        expect(origin.state.finishedResponses).toBe(0);
+        const captureEvents = getDebugProxyCaptureStore()
+          .getSessionEvents(settings.sessionId, 20)
+          .filter((event) => event.path === "/capture");
+        const capturedRequest = captureEvents.find((event) => event.kind === "request");
+        expect(capturedRequest).toBeDefined();
+        expect(captureEvents.filter((event) => event.kind === "error")).toEqual([
+          expect.objectContaining({
+            direction: "local",
+            errorText: expect.any(String),
+            flowId: capturedRequest?.flowId,
+          }),
+        ]);
+        expect(captureEvents.filter((event) => event.kind === "response")).toEqual([]);
+      });
+
+      const healthy = await getThroughProxy(proxy.proxyUrl, `${origin.url}/healthy`);
+      expect(healthy).toMatchObject({ body: "ok", complete: true, statusCode: 200 });
+      expect(
+        getDebugProxyCaptureStore()
+          .getSessionEvents(settings.sessionId, 20)
+          .filter((event) => event.path === "/healthy" && event.kind === "error"),
+      ).toEqual([]);
+    } finally {
+      await proxy.stop();
+      await origin.stop();
     }
   });
 

--- a/src/proxy-capture/proxy-server.ts
+++ b/src/proxy-capture/proxy-server.ts
@@ -247,12 +247,53 @@ export async function startDebugProxyServer(params: {
         },
         (upstreamRes) => {
           const responseCapture = createBodyPreviewCapture();
+          let responseFinished = false;
+          let downstreamFailed = false;
+          let pausedForDownstream = false;
+          const resumeUpstreamResponse = () => {
+            pausedForDownstream = false;
+            if (!res.destroyed && !res.writableEnded && !upstreamRes.destroyed) {
+              upstreamRes.resume();
+            }
+          };
+          const handleDownstreamFailure = (error?: Error) => {
+            if (downstreamFailed || responseFinished) {
+              return;
+            }
+            downstreamFailed = true;
+            res.off("drain", resumeUpstreamResponse);
+            if (error) {
+              recordTargetEvent({
+                direction: "local",
+                kind: "error",
+                errorText: error.message,
+              });
+            }
+            upstream.destroy(error);
+            upstreamRes.destroy(error);
+          };
+          res.on("error", handleDownstreamFailure);
+          res.on("close", () => handleDownstreamFailure());
           upstreamRes.on("data", (chunk) => {
             const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
             appendBodyPreviewCapture(responseCapture, buffer);
-            res.write(buffer);
+            if (res.destroyed || res.writableEnded) {
+              upstreamRes.destroy();
+              return;
+            }
+            try {
+              if (!res.write(buffer) && !pausedForDownstream) {
+                pausedForDownstream = true;
+                upstreamRes.pause();
+                res.once("drain", resumeUpstreamResponse);
+              }
+            } catch (error) {
+              handleDownstreamFailure(error instanceof Error ? error : new Error(String(error)));
+            }
           });
           upstreamRes.on("end", () => {
+            responseFinished = true;
+            res.off("drain", resumeUpstreamResponse);
             recordTargetEvent({
               direction: "inbound",
               kind: "response",
@@ -260,9 +301,13 @@ export async function startDebugProxyServer(params: {
               headersJson: JSON.stringify(upstreamRes.headers),
               ...finishBodyPreviewCapture(responseCapture),
             });
-            res.end();
+            if (!res.destroyed && !res.writableEnded) {
+              res.end();
+            }
           });
           upstreamRes.on("error", (error) => {
+            responseFinished = true;
+            res.off("drain", resumeUpstreamResponse);
             recordTargetEvent({
               direction: "inbound",
               kind: "error",

--- a/src/proxy-capture/proxy-server.ts
+++ b/src/proxy-capture/proxy-server.ts
@@ -247,6 +247,8 @@ export async function startDebugProxyServer(params: {
         },
         (upstreamRes) => {
           const responseCapture = createBodyPreviewCapture();
+          let upstreamFinished = false;
+          let upstreamFailed = false;
           let responseFinished = false;
           let downstreamFailed = false;
           let pausedForDownstream = false;
@@ -257,28 +259,40 @@ export async function startDebugProxyServer(params: {
             }
           };
           const handleDownstreamFailure = (error?: Error) => {
-            if (downstreamFailed || responseFinished) {
+            if (downstreamFailed || responseFinished || upstreamFailed) {
               return;
             }
             downstreamFailed = true;
             res.off("drain", resumeUpstreamResponse);
-            if (error) {
-              recordTargetEvent({
-                direction: "local",
-                kind: "error",
-                errorText: error.message,
-              });
-            }
-            upstream.destroy(error);
-            upstreamRes.destroy(error);
+            recordTargetEvent({
+              direction: "local",
+              kind: "error",
+              errorText: error?.message ?? "Downstream response closed before completion",
+            });
+            upstream.destroy();
+            upstreamRes.destroy();
           };
+          res.on("finish", () => {
+            if (!upstreamFinished || downstreamFailed || upstreamFailed) {
+              return;
+            }
+            responseFinished = true;
+            res.off("drain", resumeUpstreamResponse);
+            recordTargetEvent({
+              direction: "inbound",
+              kind: "response",
+              status: upstreamRes.statusCode ?? undefined,
+              headersJson: JSON.stringify(upstreamRes.headers),
+              ...finishBodyPreviewCapture(responseCapture),
+            });
+          });
           res.on("error", handleDownstreamFailure);
           res.on("close", () => handleDownstreamFailure());
           upstreamRes.on("data", (chunk) => {
             const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
             appendBodyPreviewCapture(responseCapture, buffer);
             if (res.destroyed || res.writableEnded) {
-              upstreamRes.destroy();
+              handleDownstreamFailure();
               return;
             }
             try {
@@ -292,21 +306,19 @@ export async function startDebugProxyServer(params: {
             }
           });
           upstreamRes.on("end", () => {
-            responseFinished = true;
+            upstreamFinished = true;
             res.off("drain", resumeUpstreamResponse);
-            recordTargetEvent({
-              direction: "inbound",
-              kind: "response",
-              status: upstreamRes.statusCode ?? undefined,
-              headersJson: JSON.stringify(upstreamRes.headers),
-              ...finishBodyPreviewCapture(responseCapture),
-            });
             if (!res.destroyed && !res.writableEnded) {
               res.end();
+            } else if (!res.writableFinished) {
+              handleDownstreamFailure();
             }
           });
           upstreamRes.on("error", (error) => {
-            responseFinished = true;
+            if (downstreamFailed || responseFinished || upstreamFailed) {
+              return;
+            }
+            upstreamFailed = true;
             res.off("drain", resumeUpstreamResponse);
             recordTargetEvent({
               direction: "inbound",


### PR DESCRIPTION
Closes #105701

## What Problem This Solves

Fixes an issue where users running the debug proxy could have upstream response data forwarded without honoring downstream response backpressure, allowing slow clients to keep pulling upstream data into memory instead of pausing until the downstream socket drains.

## Why This Change Was Made

The HTTP forwarding path now treats the upstream response and downstream `ServerResponse` as one lifecycle: it pauses upstream reads when `res.write()` returns false, resumes after `drain`, and tears down upstream forwarding if the downstream response closes or errors. CONNECT tunneling and capture preview behavior are unchanged.

## User Impact

Debug proxy forwarding now follows Node writable-stream backpressure semantics and is more resilient when clients read slowly or disconnect mid-response.

## Evidence

- Exact published head: `977570fa8ea4d054bbd94668ef0d87e69e5049eb`.
- Original contributor: @qingminglong; the reviewed fix and follow-up preserve contributor ancestry.
- Real raw TCP loopback proves a slow client forwards the entire 16 MiB response with real upstream backpressure and completes successfully; no Node prototype or global stream patching.
- Real graceful disconnect and TCP reset each terminate upstream promptly, record exactly one local SQLite capture error, never record a false successful response, and allow a subsequent healthy request.
- Capture success is recorded only after the actual downstream `finish`; existing UTF-8 previews, HTTP 502 handling, managed-proxy policy, and CLI remain covered.
- Focused owner and sibling regression proof: 4 files, 38 tests passed.
- Independent `gpt-5.6-sol` extra-high-effort full-branch autoreview: clean, confidence 0.93.
- Node writable-stream contract independently checked against `node_modules/@types/node/stream.d.ts`: a false `write()` return must pause upstream until `drain`.

AI-assisted: yes. I understand what the code does and kept the change scoped to the debug proxy forwarding lifecycle and its focused regression test.