### PR TITLE
fix(agents): clear recovery residue on sessions without a recorded status

### DIFF
--- a/src/agents/main-session-recovery-state.test.ts
+++ b/src/agents/main-session-recovery-state.test.ts
@@ -229,6 +229,34 @@ describe("main session recovery state", () => {
     expect(entry.mainRestartRecovery).toBeUndefined();
   });
 
+  it("clears orphaned recovery residue when the row never recorded a status", () => {
+    // Production shape (2026-07-26): fences from two dead gateway generations on
+    // a row whose status was never persisted, so it matched no cleanup branch.
+    const entry = interruptedEntry({
+      status: undefined,
+      abortedLastRun: false,
+      mainRestartRecovery: undefined,
+      restartRecoveryRuns: [
+        { runId: "stale-run-1", lifecycleGeneration: "dead-generation-1" },
+        { runId: "stale-run-2", lifecycleGeneration: "dead-generation-2" },
+      ],
+    });
+
+    expect(
+      transitionMainSessionRecovery(entry, {
+        kind: "claim_foreground",
+        cycleId: "unused",
+        lifecycleGeneration: "generation-1",
+        sessionId: "session-1",
+        sessionKey,
+        claimId: "foreground-1",
+      }),
+    ).toEqual({ kind: "applied" });
+    expect(entry.restartRecoveryRuns).toBeUndefined();
+    expect(entry.mainRestartRecovery).toBeUndefined();
+    expect(entry.abortedLastRun).toBe(false);
+  });
+
   it("clears orphaned recovery residue before terminal foreground admission", () => {
     const entry = interruptedEntry({
       status: "failed",

--- a/src/agents/main-session-recovery-state.ts
+++ b/src/agents/main-session-recovery-state.ts
@@ -165,12 +165,13 @@ function hasOrphanedMainRestartRecoveryFences(entry: SessionEntry, sessionKey: s
       entry.mainRestartRecovery === undefined &&
       entry.restartRecoveryDeliveryRunId === undefined &&
       isMainRestartRecoveryCandidate(entry, sessionKey)) ||
-    // Terminal sessions with recovery residue were permanently unadmittable,
-    // returning "changed while starting work" forever (production incident 2026-07-26).
-    // A pending delivery claim may coexist with the residue, so it must not gate
-    // the cleanup here the way it does for the running case above.
-    (entry.status !== undefined &&
-      entry.status !== "running" &&
+    // Sessions that are not running were permanently unadmittable while holding
+    // recovery residue, returning "changed while starting work" forever
+    // (production incident 2026-07-26). A row whose status is absent never
+    // reached an active run either, so it carries residue the same way a
+    // terminal row does. A pending delivery claim may coexist with the residue,
+    // so it must not gate the cleanup the way it does for the running case above.
+    (entry.status !== "running" &&
       entry.mainRestartRecovery === undefined &&
       isMainRestartRecoveryCandidate(entry, sessionKey) &&
       (entry.restartRecoveryRuns !== undefined || entry.abortedLastRun === true))


### PR DESCRIPTION
## What Problem This Solves

Follow-up to #114071, driven by production verification rather than theory.

After #114071 deployed to team.openclaw.ai, **one** of the four permanently-unmessageable sessions recovered — it replied with its real context. The other three still failed every send with:

```
Session "agent:roboclaw:dashboard:<id>" changed while starting work. Retry.
```

Dumping their store rows showed a second residue shape: **no `status` field at all**, plus `restartRecoveryRuns` fences from *two* different dead gateway generations, with `abortedLastRun` false or absent.

```json
{ "abortedLastRun": false,
  "restartRecoveryRuns": [
    { "runId": "…", "lifecycleGeneration": "992dafec-…" },
    { "runId": "…", "lifecycleGeneration": "e3434644-…" } ] }
```

Neither orphan branch matched: the running branch requires `status === "running"`, and the terminal branch added in #114071 required a *present* status (`status !== undefined && status !== "running"`). So `claim_foreground` returned `no_change`, the claim returned `invalidated`, and the session stayed bricked.

## Why This Change Was Made

A row whose status was never persisted never reached an active run, so it holds residue exactly the way a terminal row does. The terminal branch now keys on `status !== "running"`, which covers both terminal and absent status. Genuine pending recovery (`status === "running"` with `abortedLastRun === true`) is still untouched, and the running-orphan branch is unchanged.

## User Impact

The remaining sessions stuck in this state become usable again on their next message, with no operator action or migration.

## Evidence

- Production: session `011e881f` recovered after #114071 (replied with its prior context); `87b9498c`, `4f385725`, `27392869` still failed, and their rows match the shape above.
- Tests: `node scripts/run-vitest.mjs src/agents/main-session-recovery-state.test.ts src/agents/main-session-recovery-store.test.ts src/agents/agent-command-recovery-owner.test.ts src/agents/agent-command.compaction-rotation.test.ts src/agents/main-session-restart-recovery.test.ts` → 2 shards passed, including a new regression test using the exact production shape (absent status, two dead-generation fences).
- Both tsgo lanes exit 0.
