### PR TITLE
fix: stop fanout QA from racing child transcripts

### DIFF
--- a/extensions/qa-lab/src/scenario-catalog-channels.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog-channels.test.ts
@@ -59,19 +59,26 @@ describe("qa scenario catalog channel contracts", () => {
     expect(subagentFanout.execution.suiteIsolation).toBe("isolated");
   });
 
-  it("settles subagent completions before reading the SQLite session store", () => {
+  it("uses durable subagent completion evidence before accepting fanout", () => {
     const scenario = requireFlowScenario(readQaScenarioById("subagent-fanout-synthesis"));
     const flow = JSON.stringify(scenario.execution.flow);
-    const completionWaits = [...flow.matchAll(/expectedChildCompletionMarkers/gu)].map(
-      (match) => match.index,
-    );
+    const completionWait = flow.indexOf('"items":{"expr":"config.expectedChildCompletionMarkers"}');
     const storeReads = [...flow.matchAll(/readRawQaSessionStore/gu)].map((match) => match.index);
 
     expect(flow).toContain("readSessionTranscriptSummary(env, sessionKey)");
     expect(flow).not.toContain("waitForAgentHistoryReply");
-    expect(completionWaits).toHaveLength(2);
+    expect(
+      flow.split("String(candidate.text ?? '').trim() === childCompletionMarker").length - 1,
+    ).toBe(1);
+    expect(flow).toContain(
+      "timeoutSawAlpha && timeoutSawBeta && timeoutAlphaOk && timeoutBetaOk && timeoutSpawnRequests.length >= 2",
+    );
+    expect(flow).toContain("Boolean(env.mock) ? config.expectedChildCompletionMarkers[0] : 'ok'");
+    expect(flow).toContain('saveAs":"timeoutEvidence');
+    expect(flow).toContain("Promise.all([readSessionTranscriptSummary");
+    expect(completionWait).toBeGreaterThan(-1);
     expect(storeReads).toHaveLength(2);
-    expect(completionWaits.every((wait, index) => wait < (storeReads[index] ?? -1))).toBe(true);
+    expect(completionWait).toBeLessThan(storeReads[0] ?? -1);
   });
 
   it("adds a dreaming shadow trial report scenario", () => {

--- a/qa/scenarios/agents/subagent-fanout-synthesis.yaml
+++ b/qa/scenarios/agents/subagent-fanout-synthesis.yaml
@@ -179,43 +179,47 @@ flow:
                           - if:
                               expr: "/timed out after/i.test(formatErrorMessage(attemptError))"
                               then:
-                                - if:
-                                    expr: "Boolean(env.mock) && env.gateway.runtimeEnv.OPENCLAW_QA_FORCE_RUNTIME !== 'codex'"
-                                    then:
-                                      - forEach:
-                                          items:
-                                            expr: "config.expectedChildCompletionMarkers"
-                                          item: childCompletionMarker
-                                          actions:
-                                            - call: waitForOutboundMessage
-                                              args:
-                                                - ref: state
-                                                - lambda:
-                                                    params: [candidate]
-                                                    expr: "String(candidate.text ?? '').trim() === childCompletionMarker"
-                                                - 30000
-                                - call: readRawQaSessionStore
-                                  saveAs: timeoutStore
+                                - set: timeoutAlphaExpected
+                                  value:
+                                    expr: "Boolean(env.mock) ? config.expectedChildCompletionMarkers[0] : 'ok'"
+                                - set: timeoutBetaExpected
+                                  value:
+                                    expr: "Boolean(env.mock) ? config.expectedChildCompletionMarkers[1] : 'ok'"
+                                - call: waitForCondition
+                                  saveAs: timeoutEvidence
                                   args:
-                                    - ref: env
+                                    - lambda:
+                                        async: true
+                                        expr: "(async () => { const store = await readRawQaSessionStore(env); const childEntries = Object.entries(store).map(([key, entry]) => ({ ...entry, key })).filter((entry) => entry.spawnedBy === sessionKey); const alphaEntry = childEntries.find((entry) => entry.label === alphaLabel); const betaEntry = childEntries.find((entry) => entry.label === betaLabel); if (!alphaEntry || !betaEntry) return undefined; const [alphaTranscript, betaTranscript] = await Promise.all([readSessionTranscriptSummary(env, alphaEntry.key), readSessionTranscriptSummary(env, betaEntry.key)]); const alphaOk = normalizeLowercaseStringOrEmpty(alphaTranscript.finalText) === normalizeLowercaseStringOrEmpty(timeoutAlphaExpected); const betaOk = normalizeLowercaseStringOrEmpty(betaTranscript.finalText) === normalizeLowercaseStringOrEmpty(timeoutBetaExpected); return alphaOk && betaOk ? { store, childEntries, alphaTranscript, betaTranscript } : undefined; })().catch(() => undefined)"
+                                    - expr: "30000"
+                                    - expr: "env.providerMode === 'mock-openai' ? 100 : 250"
+                                - set: timeoutStore
+                                  value:
+                                    expr: "timeoutEvidence.store"
                                 - set: timeoutChildEntries
                                   value:
-                                    expr: "Object.entries(timeoutStore).map(([key, entry]) => ({ ...entry, key })).filter((entry) => entry.spawnedBy === sessionKey)"
+                                    expr: "timeoutEvidence.childEntries"
                                 - set: timeoutChildRows
                                   value:
                                     expr: "timeoutChildEntries"
-                                - set: timeoutAlphaSessionKey
-                                  value:
-                                    expr: "timeoutChildEntries.find((entry) => entry.label === alphaLabel)?.key ?? ''"
-                                - set: timeoutBetaSessionKey
-                                  value:
-                                    expr: "timeoutChildEntries.find((entry) => entry.label === betaLabel)?.key ?? ''"
                                 - set: timeoutSawAlpha
                                   value:
                                     expr: "timeoutChildRows.some((entry) => entry.label === alphaLabel)"
                                 - set: timeoutSawBeta
                                   value:
                                     expr: "timeoutChildRows.some((entry) => entry.label === betaLabel)"
+                                - set: timeoutAlphaTranscript
+                                  value:
+                                    expr: "timeoutEvidence.alphaTranscript"
+                                - set: timeoutBetaTranscript
+                                  value:
+                                    expr: "timeoutEvidence.betaTranscript"
+                                - set: timeoutAlphaOk
+                                  value:
+                                    expr: "normalizeLowercaseStringOrEmpty(timeoutAlphaTranscript?.finalText) === normalizeLowercaseStringOrEmpty(timeoutAlphaExpected)"
+                                - set: timeoutBetaOk
+                                  value:
+                                    expr: "normalizeLowercaseStringOrEmpty(timeoutBetaTranscript?.finalText) === normalizeLowercaseStringOrEmpty(timeoutBetaExpected)"
                                 - if:
                                     expr: "Boolean(env.mock)"
                                     then:
@@ -223,25 +227,13 @@ flow:
                                         value:
                                           expr: "[...(await fetchJson(`${env.mock.baseUrl}/debug/requests`))].filter((request) => request.plannedToolName === 'sessions_spawn' && /subagent fanout synthesis check/i.test(String(request.allInputText ?? '')))"
                                       - if:
-                                          expr: "timeoutSawAlpha && timeoutSawBeta && timeoutSpawnRequests.length >= 2"
+                                          expr: "timeoutSawAlpha && timeoutSawBeta && timeoutAlphaOk && timeoutBetaOk && timeoutSpawnRequests.length >= 2"
                                           then:
                                             - set: details
                                               value: "subagent-1: ok\nsubagent-2: ok"
                                             - set: lastError
                                               value: __done__
                                     else:
-                                      - set: timeoutAlphaTranscript
-                                        value:
-                                          expr: "timeoutAlphaSessionKey ? await readSessionTranscriptSummary(env, timeoutAlphaSessionKey) : null"
-                                      - set: timeoutBetaTranscript
-                                        value:
-                                          expr: "timeoutBetaSessionKey ? await readSessionTranscriptSummary(env, timeoutBetaSessionKey) : null"
-                                      - set: timeoutAlphaOk
-                                        value:
-                                          expr: "normalizeLowercaseStringOrEmpty(timeoutAlphaTranscript?.finalText) === 'ok'"
-                                      - set: timeoutBetaOk
-                                        value:
-                                          expr: "normalizeLowercaseStringOrEmpty(timeoutBetaTranscript?.finalText) === 'ok'"
                                       - if:
                                           expr: "timeoutSawAlpha && timeoutSawBeta && timeoutAlphaOk && timeoutBetaOk"
                                           then:


### PR DESCRIPTION
## What Problem This Solves

Resolves a release-validation failure where `subagent-fanout-synthesis` timed out after both child tasks had completed because its timeout fallback waited for transient outbound markers instead of durable child transcript state.

## Why This Change Was Made

The timeout path now polls the session store and both child transcripts under a bounded deadline. It accepts the fallback only after both expected child labels exist, both durable final replies match their provider-mode markers, and mock execution records at least two distinct `sessions_spawn` calls.

## User Impact

No product behavior changes. Release QA no longer turns transport/projection timing into a false subagent-fanout failure.

## Evidence

- Release Checks baseline [30195275337](https://github.com/openclaw/openclaw/actions/runs/30195275337) reproduced the 30-second timeout after the first 8 parity scenarios passed.
- Exact baseline-shaped source run passed with `anthropic/claude-opus-4-8` and `anthropic/claude-sonnet-4-6` model refs under `mock-openai`.
- `node scripts/run-vitest.mjs` across the four QA catalog/CLI files — 154 passed.
- Formatting and `git diff --check` passed.
- Autoreview caught and drove the bounded transcript-polling improvement; the final run was clean with no accepted/actionable findings.
- Exact-head [CI](https://github.com/openclaw/openclaw/actions/runs/30196119654) passed, including all four QA Smoke profiles.

ClawSweeper rank-up ordering: the suggested main refresh is skipped because the branch is conflict-free, current-main drift does not overlap either touched QA file, and the repo-native landing policy treats behind-main drift as advisory unless the merge gate requires synchronization.

<details>
<summary>Redacted QA output</summary>

```text
Subagent fanout synthesis: pass
subagent-1: ok
subagent-2: ok
```

</details>

AI-assisted: yes. The patch was reviewed and verified against the exact baseline model shape.
