### PR TITLE
fix(ui): preserve concurrent background task progress

### DIFF
--- a/ui/src/lib/tasks/data.test.ts
+++ b/ui/src/lib/tasks/data.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   applyTaskEvent,
   mergeTaskLists,
+  newestTaskSnapshot,
   normalizeTasksCancelResult,
   partitionTasks,
   sortTasks,
@@ -40,7 +41,7 @@ describe("tasks page data", () => {
     expect(result.recent[0]?.id).toBe("terminal-54");
   });
 
-  it("merges task lists by id with later lists winning", () => {
+  it("merges task lists by id while preserving newer running snapshots", () => {
     const recentPage = [
       task({ id: "new-terminal", status: "completed", updatedAt: 900 }),
       task({ id: "shared", status: "running", updatedAt: 800 }),
@@ -52,6 +53,199 @@ describe("tasks page data", () => {
     const merged = mergeTaskLists(recentPage, activePage);
     expect(merged.map((entry) => entry.id)).toEqual(["new-terminal", "shared", "old-running"]);
     expect(merged.find((entry) => entry.id === "shared")?.updatedAt).toBe(850);
+  });
+
+  it("keeps ten completed same-title tasks distinct when the active page is stale", () => {
+    const recentPage = Array.from({ length: 10 }, (_, index) =>
+      task({
+        id: `task-${index}`,
+        status: "completed",
+        title: "Concurrent background task",
+        updatedAt: 2_000 + index,
+      }),
+    );
+    const staleActivePage = recentPage.map((completed) =>
+      task({
+        id: completed.id,
+        status: "running",
+        title: completed.title,
+        updatedAt: 1_000,
+      }),
+    );
+
+    const merged = mergeTaskLists(recentPage, staleActivePage);
+
+    expect(merged).toHaveLength(10);
+    expect(new Set(merged.map((entry) => entry.id)).size).toBe(10);
+    expect(merged.every((entry) => entry.status === "completed")).toBe(true);
+    expect(partitionTasks(merged).active).toEqual([]);
+  });
+
+  it.each(["completed", "failed", "cancelled", "timed_out"] as const)(
+    "preserves an equally recent %s snapshot regardless of page order",
+    (status) => {
+      const terminal = task({ id: "shared", status, updatedAt: 200 });
+      const running = task({ id: "shared", status: "running", updatedAt: 200 });
+
+      expect(mergeTaskLists([terminal], [running])).toEqual([terminal]);
+      expect(mergeTaskLists([running], [terminal])).toEqual([terminal]);
+    },
+  );
+
+  it("advances equally recent queued snapshots to running regardless of page order", () => {
+    const queued = task({ id: "shared", status: "queued", updatedAt: 200 });
+    const running = task({ id: "shared", status: "running", updatedAt: 200 });
+
+    expect(mergeTaskLists([queued], [running])).toEqual([running]);
+    expect(mergeTaskLists([running], [queued])).toEqual([running]);
+  });
+
+  it("keeps the incoming running progress when both pages share a timestamp", () => {
+    const previous = task({
+      id: "shared",
+      status: "running",
+      updatedAt: 200,
+      toolUseCount: 1,
+      lastToolName: "read",
+    });
+    const progress = task({
+      id: "shared",
+      status: "running",
+      updatedAt: 200,
+      toolUseCount: 2,
+      lastToolName: "write",
+    });
+
+    expect(mergeTaskLists([previous], [progress])).toEqual([progress]);
+  });
+
+  it("keeps the later page's equally current tool progress at the same tool count", () => {
+    const previous = task({
+      id: "shared",
+      status: "running",
+      updatedAt: 200,
+      toolUseCount: 2,
+      lastToolName: "write",
+      progressSummary: "Preparing the concurrent task report",
+    });
+    const progress = task({
+      id: "shared",
+      status: "running",
+      updatedAt: 200,
+      toolUseCount: 2,
+      lastToolName: "write",
+      progressSummary: "Finishing the concurrent task report",
+    });
+
+    expect(mergeTaskLists([previous], [progress])).toEqual([progress]);
+  });
+
+  it("does not roll back running tool progress from an equally recent stale page", () => {
+    const progress = task({
+      id: "shared",
+      status: "running",
+      updatedAt: 200,
+      toolUseCount: 2,
+      lastToolName: "write",
+    });
+    const stale = task({
+      id: "shared",
+      status: "running",
+      updatedAt: 200,
+      toolUseCount: 1,
+      lastToolName: "read",
+    });
+
+    expect(mergeTaskLists([progress], [stale])).toEqual([progress]);
+    expect(mergeTaskLists([stale], [progress])).toEqual([progress]);
+  });
+
+  it("preserves an equally current opened task detail", () => {
+    const running = task({ id: "shared", status: "running", updatedAt: 200 });
+    const detail = task({
+      id: "shared",
+      status: "running",
+      updatedAt: 200,
+      prompt: "Inspect the concurrent task owner",
+    });
+
+    expect(newestTaskSnapshot(running, detail)).toEqual(detail);
+  });
+
+  it("retains current tool progress while adopting an opened task prompt", () => {
+    const running = task({
+      id: "shared",
+      status: "running",
+      updatedAt: 200,
+      toolUseCount: 2,
+      lastToolName: "write",
+      progressSummary: "Writing the concurrent task report",
+    });
+    const detail = task({
+      id: "shared",
+      status: "running",
+      updatedAt: 200,
+      toolUseCount: 1,
+      lastToolName: "read",
+      progressSummary: "Reading the concurrent task report",
+      prompt: "Inspect the concurrent task owner",
+    });
+
+    expect(newestTaskSnapshot(running, detail)).toEqual({
+      ...running,
+      prompt: detail.prompt,
+    });
+  });
+
+  it("does not let an equally current opened detail roll back tool progress", () => {
+    const running = task({
+      id: "shared",
+      status: "running",
+      updatedAt: 200,
+      toolUseCount: 2,
+      lastToolName: "write",
+      progressSummary: "Finishing the concurrent task report",
+    });
+    const detail = task({
+      id: "shared",
+      status: "running",
+      updatedAt: 200,
+      toolUseCount: 2,
+      lastToolName: "write",
+      progressSummary: "Preparing the concurrent task report",
+      prompt: "Inspect the concurrent task owner",
+    });
+
+    expect(newestTaskSnapshot(running, detail)).toEqual({
+      ...running,
+      prompt: detail.prompt,
+    });
+  });
+
+  it("keeps current terminal output when an equally current detail is stale", () => {
+    const completed = task({
+      id: "shared",
+      status: "completed",
+      updatedAt: 200,
+      terminalSummary: "Audit complete",
+    });
+    const detail = task({
+      id: "shared",
+      status: "completed",
+      updatedAt: 200,
+      terminalSummary: "Stale running progress",
+      prompt: "Inspect the concurrent task owner",
+    });
+
+    expect(newestTaskSnapshot(completed, detail)).toEqual(completed);
+  });
+
+  it("accepts a genuinely newer running snapshot from the active page", () => {
+    const oldRunning = task({ id: "shared", status: "running", updatedAt: 100 });
+    const newRunning = task({ id: "shared", status: "running", updatedAt: 200 });
+
+    expect(mergeTaskLists([oldRunning], [newRunning])).toEqual([newRunning]);
+    expect(mergeTaskLists([newRunning], [oldRunning])).toEqual([newRunning]);
   });
 
   it("normalizes cancel results including refusals with reasons", () => {
@@ -92,6 +286,135 @@ describe("tasks page data", () => {
     expect(applyTaskEvent(initial, { action: "upserted", task: { id: "broken" } })).toEqual({
       tasks: initial,
       refetch: true,
+    });
+  });
+
+  it.each([100, 200])(
+    "does not resurrect a completed task from a running event timestamped %i",
+    (updatedAt) => {
+      const completed = task({ id: "task-1", status: "completed", updatedAt: 200 });
+      const staleRunning = task({ id: "task-1", status: "running", updatedAt });
+
+      expect(applyTaskEvent([completed], { action: "upserted", task: staleRunning })).toEqual({
+        tasks: [completed],
+        refetch: false,
+      });
+    },
+  );
+
+  it.each(["completed", "failed", "cancelled", "timed_out"] as const)(
+    "does not replace an equally recent %s event with running work",
+    (status) => {
+      const terminal = task({ id: "task-1", status, updatedAt: 200 });
+      const running = task({ id: "task-1", status: "running", updatedAt: 200 });
+
+      expect(applyTaskEvent([terminal], { action: "upserted", task: running })).toEqual({
+        tasks: [terminal],
+        refetch: false,
+      });
+      expect(applyTaskEvent([running], { action: "upserted", task: terminal })).toEqual({
+        tasks: [terminal],
+        refetch: false,
+      });
+    },
+  );
+
+  it.each(["completed", "failed", "cancelled", "timed_out"] as const)(
+    "accepts an authoritative equally recent %s terminal event correction",
+    (status) => {
+      const current = task({
+        id: "task-1",
+        status,
+        updatedAt: 200,
+        terminalSummary: "Previous terminal details",
+      });
+      const correction = task({
+        id: "task-1",
+        status,
+        updatedAt: 200,
+        terminalSummary: "Authoritative terminal details",
+      });
+
+      expect(applyTaskEvent([current], { action: "upserted", task: correction })).toEqual({
+        tasks: [correction],
+        refetch: false,
+      });
+    },
+  );
+
+  it("advances a queued task when its running event shares the timestamp", () => {
+    const queued = task({ id: "task-1", status: "queued", updatedAt: 200 });
+    const running = task({ id: "task-1", status: "running", updatedAt: 200 });
+
+    expect(applyTaskEvent([queued], { action: "upserted", task: running })).toEqual({
+      tasks: [running],
+      refetch: false,
+    });
+  });
+
+  it("applies incoming running tool progress at the same timestamp", () => {
+    const previous = task({
+      id: "task-1",
+      status: "running",
+      updatedAt: 200,
+      toolUseCount: 1,
+      lastToolName: "read",
+    });
+    const progress = task({
+      id: "task-1",
+      status: "running",
+      updatedAt: 200,
+      toolUseCount: 2,
+      lastToolName: "write",
+    });
+
+    expect(applyTaskEvent([previous], { action: "upserted", task: progress })).toEqual({
+      tasks: [progress],
+      refetch: false,
+    });
+  });
+
+  it("does not regress running tool progress from an equally recent stale event", () => {
+    const progress = task({
+      id: "task-1",
+      status: "running",
+      updatedAt: 200,
+      toolUseCount: 2,
+      lastToolName: "write",
+    });
+    const stale = task({
+      id: "task-1",
+      status: "running",
+      updatedAt: 200,
+      toolUseCount: 1,
+      lastToolName: "read",
+    });
+
+    expect(applyTaskEvent([progress], { action: "upserted", task: stale })).toEqual({
+      tasks: [progress],
+      refetch: false,
+    });
+  });
+
+  it("deletes only the requested task after applying task progress", () => {
+    const completed = task({ id: "completed", status: "completed", updatedAt: 200 });
+    const running = task({ id: "running", status: "running", updatedAt: 200 });
+
+    expect(
+      applyTaskEvent([completed, running], { action: "deleted", taskId: "completed" }),
+    ).toEqual({
+      tasks: [running],
+      refetch: false,
+    });
+  });
+
+  it("applies a genuinely newer running task event", () => {
+    const oldRunning = task({ id: "task-1", status: "running", updatedAt: 100 });
+    const newRunning = task({ id: "task-1", status: "running", updatedAt: 200 });
+
+    expect(applyTaskEvent([oldRunning], { action: "upserted", task: newRunning })).toEqual({
+      tasks: [newRunning],
+      refetch: false,
     });
   });
 });

--- a/ui/src/lib/tasks/data.ts
+++ b/ui/src/lib/tasks/data.ts
@@ -202,6 +202,60 @@ export function taskTimestampMs(value: TaskTimestamp | undefined): number {
   return 0;
 }
 
+type TaskSnapshotProvenance = "snapshot" | "event" | "detail";
+
+function preserveTaskPrompt(
+  selected: TaskSummary,
+  current: TaskSummary,
+  lookup: TaskSummary,
+): TaskSummary {
+  const prompt = lookup.prompt ?? current.prompt;
+  return prompt && selected.prompt !== prompt ? { ...selected, prompt } : selected;
+}
+
+export function newestTaskSnapshot(
+  current: TaskSummary,
+  lookup: TaskSummary | undefined,
+  provenance: TaskSnapshotProvenance = "detail",
+): TaskSummary {
+  if (!lookup) {
+    return current;
+  }
+  const currentAt = taskTimestampMs(current.updatedAt ?? current.endedAt ?? current.createdAt);
+  const lookupAt = taskTimestampMs(lookup.updatedAt ?? lookup.endedAt ?? lookup.createdAt);
+  if (lookupAt > currentAt) {
+    return preserveTaskPrompt(lookup, current, lookup);
+  }
+  if (lookupAt < currentAt) {
+    return current;
+  }
+  // Millisecond clocks collide under load. Ordered pages and events advance
+  // active work; only events correct terminal output, and details stay stale-safe.
+  const currentActive = isActiveTask(current);
+  const lookupActive = isActiveTask(lookup);
+  if (currentActive !== lookupActive) {
+    return preserveTaskPrompt(currentActive ? lookup : current, current, lookup);
+  }
+  if (!currentActive) {
+    return provenance === "event" ? preserveTaskPrompt(lookup, current, lookup) : current;
+  }
+  if (current.status === "running" && lookup.status === "queued") {
+    return preserveTaskPrompt(current, current, lookup);
+  }
+  if (current.status === "queued" && lookup.status === "running") {
+    return preserveTaskPrompt(lookup, current, lookup);
+  }
+  const currentToolCount = current.toolUseCount ?? 0;
+  const lookupToolCount = lookup.toolUseCount ?? 0;
+  if (currentToolCount > lookupToolCount) {
+    return preserveTaskPrompt(current, current, lookup);
+  }
+  if (lookupToolCount > currentToolCount || provenance !== "detail") {
+    return preserveTaskPrompt(lookup, current, lookup);
+  }
+  return preserveTaskPrompt(current, current, lookup);
+}
+
 export function sortTasks(tasks: readonly TaskSummary[]): TaskSummary[] {
   return tasks.toSorted((left, right) => {
     const timeDelta = taskTimestampMs(right.updatedAt) - taskTimestampMs(left.updatedAt);
@@ -247,7 +301,8 @@ export function mergeTaskLists(...lists: readonly (readonly TaskSummary[])[]): T
   const byId = new Map<string, TaskSummary>();
   for (const list of lists) {
     for (const task of list) {
-      byId.set(task.id, task);
+      const current = byId.get(task.id);
+      byId.set(task.id, current ? newestTaskSnapshot(current, task, "snapshot") : task);
     }
   }
   return sortTasks([...byId.values()]);
@@ -308,8 +363,10 @@ export function applyTaskEvent(
       refetch: false,
     };
   }
+  const current = tasks.find((task) => task.id === event.task.id);
+  const next = current ? newestTaskSnapshot(current, event.task, "event") : event.task;
   return {
-    tasks: sortTasks([event.task, ...tasks.filter((task) => task.id !== event.task.id)]),
+    tasks: sortTasks([next, ...tasks.filter((task) => task.id !== event.task.id)]),
     refetch: false,
   };
 }

--- a/ui/src/pages/chat/components/chat-background-tasks-concurrency.test.ts
+++ b/ui/src/pages/chat/components/chat-background-tasks-concurrency.test.ts
@@ -1,0 +1,242 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { GatewayBrowserClient } from "../../../api/gateway.ts";
+import type { TaskSummary } from "../../../lib/tasks/data.ts";
+import {
+  createBackgroundTasksProps,
+  handleBackgroundTasksEvent,
+  type BackgroundTasksHost,
+} from "./chat-background-tasks.ts";
+
+const openSession = { onOpenSession: () => {} };
+
+function flushAsync() {
+  return new Promise<void>((resolve) => {
+    setTimeout(resolve, 0);
+  });
+}
+
+function makeTask(overrides: Partial<TaskSummary> & { id: string }): TaskSummary {
+  return {
+    taskId: overrides.id,
+    status: "running",
+    runtime: "subagent",
+    agentId: "main",
+    title: "Investigate concurrent sessions",
+    createdAt: 1_000,
+    updatedAt: 2_000,
+    startedAt: 1_500,
+    ...overrides,
+  };
+}
+
+async function refreshingHost(tasks: TaskSummary[], initial = false) {
+  let resolveActive!: (value: { tasks: TaskSummary[] }) => void;
+  let resolveRecent!: (value: { tasks: TaskSummary[] }) => void;
+  let rejectActive!: (error: Error) => void;
+  const active = new Promise<{ tasks: TaskSummary[] }>((resolve, reject) => {
+    resolveActive = resolve;
+    rejectActive = reject;
+  });
+  const recent = new Promise<{ tasks: TaskSummary[] }>((resolve) => {
+    resolveRecent = resolve;
+  });
+  let deferRefresh = initial;
+  let deferredListCalls = 0;
+  let fallbackTasks = tasks;
+  const request = vi.fn((method: string, params?: unknown) => {
+    if (method === "tasks.cancel") {
+      const taskId = (params as { taskId?: string })?.taskId;
+      const cancelled = makeTask({
+        id: taskId ?? "task-missing",
+        status: "cancelled",
+        updatedAt: 4_000,
+      });
+      return Promise.resolve({ found: true, cancelled: true, task: cancelled });
+    }
+    if (method !== "tasks.list" || !deferRefresh) {
+      return Promise.resolve({ tasks: fallbackTasks });
+    }
+    if (++deferredListCalls > 2) {
+      return Promise.resolve({ tasks: fallbackTasks });
+    }
+    return (params as { status?: readonly string[] })?.status ? active : recent;
+  });
+  const host: BackgroundTasksHost = {
+    sessionKey: "agent:main:current",
+    client: { request } as unknown as GatewayBrowserClient,
+    connected: true,
+    connectionEpoch: 1,
+    hello: null,
+    requestUpdate: vi.fn(),
+  };
+  createBackgroundTasksProps(host, openSession);
+  if (!initial) {
+    await flushAsync();
+    deferRefresh = true;
+    createBackgroundTasksProps(host, openSession).onRefresh();
+  }
+  return {
+    host,
+    request,
+    resolveActive,
+    resolveRecent,
+    rejectActive,
+    setFallbackTasks(next: TaskSummary[]) {
+      fallbackTasks = next;
+    },
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("background tasks concurrent snapshots", () => {
+  it.each([
+    {
+      name: "a terminal event",
+      stale: [makeTask({ id: "task-initial" })],
+      event: {
+        action: "upserted" as const,
+        task: makeTask({ id: "task-initial", status: "completed", updatedAt: 3_000 }),
+      },
+      expected: [["task-initial", "completed"]],
+    },
+    {
+      name: "a task deletion",
+      stale: [makeTask({ id: "task-deleted" }), makeTask({ id: "task-retained" })],
+      event: { action: "deleted" as const, taskId: "task-deleted" },
+      expected: [["task-retained", "running"]],
+    },
+    {
+      name: "a task creation",
+      stale: [makeTask({ id: "task-existing" })],
+      event: {
+        action: "upserted" as const,
+        task: makeTask({ id: "task-created", updatedAt: 3_000 }),
+      },
+      expected: [
+        ["task-created", "running"],
+        ["task-existing", "running"],
+      ],
+    },
+  ])("replays $name during the initial load without a stale second load", async (test) => {
+    const refresh = await refreshingHost(test.stale, true);
+    expect(refresh.request).toHaveBeenCalledTimes(2);
+    expect(createBackgroundTasksProps(refresh.host, openSession).tasks).toBeNull();
+
+    handleBackgroundTasksEvent(refresh.host, test.event);
+    handleBackgroundTasksEvent(refresh.host, {
+      action: "upserted",
+      task: makeTask({ id: "task-other-agent", agentId: "writer", updatedAt: 4_000 }),
+    });
+    refresh.resolveActive({ tasks: test.stale });
+    refresh.resolveRecent({ tasks: test.stale });
+    await flushAsync();
+    await flushAsync();
+
+    expect(refresh.request).toHaveBeenCalledTimes(2);
+    expect(
+      createBackgroundTasksProps(refresh.host, openSession).tasks?.map((task) => [
+        task.id,
+        task.status,
+      ]),
+    ).toEqual(test.expected);
+  });
+
+  it("retains a real terminal event when the initial task snapshot fails", async () => {
+    const stale = [makeTask({ id: "task-snapshot-failed" })];
+    const refresh = await refreshingHost(stale, true);
+
+    handleBackgroundTasksEvent(refresh.host, {
+      action: "upserted",
+      task: makeTask({
+        id: "task-snapshot-failed",
+        status: "completed",
+        updatedAt: 3_000,
+        terminalSummary: "Completed despite snapshot failure",
+      }),
+    });
+    refresh.rejectActive(new Error("Initial task snapshot unavailable"));
+    refresh.resolveRecent({ tasks: stale });
+    await flushAsync();
+
+    const props = createBackgroundTasksProps(refresh.host, openSession);
+    expect(props.error).toBe("Initial task snapshot unavailable");
+    expect(props.tasks?.map((task) => [task.id, task.status])).toEqual([
+      ["task-snapshot-failed", "completed"],
+    ]);
+    expect(refresh.request).toHaveBeenCalledTimes(2);
+  });
+
+  it("preserves all ten unopened task completions after both stale pages resolve", async () => {
+    const tasks = Array.from({ length: 10 }, (_, index) => makeTask({ id: `task-${index}` }));
+    const refresh = await refreshingHost(tasks);
+
+    for (const [index, task] of tasks.entries()) {
+      handleBackgroundTasksEvent(refresh.host, {
+        action: "upserted",
+        task: {
+          ...task,
+          status: "completed",
+          updatedAt: 3_000 + index,
+          terminalSummary: `Completed task ${index + 1}`,
+        },
+      });
+    }
+    refresh.resolveActive({ tasks });
+    refresh.resolveRecent({ tasks });
+    await flushAsync();
+
+    const props = createBackgroundTasksProps(refresh.host, openSession);
+    expect(props.tasks).toHaveLength(10);
+    expect(new Set(props.tasks?.map((task) => task.id)).size).toBe(10);
+    expect(props.tasks?.every((task) => task.status === "completed")).toBe(true);
+    expect(props.tasks?.every((task) => task.terminalSummary?.startsWith("Completed task"))).toBe(
+      true,
+    );
+    expect(props.taskDetails.size).toBe(0);
+  });
+
+  it("preserves successful cancellation while stale snapshot pages are in flight", async () => {
+    const tasks = [makeTask({ id: "task-cancelled" })];
+    const refresh = await refreshingHost(tasks);
+
+    createBackgroundTasksProps(refresh.host, openSession).onCancel("task-cancelled");
+    await flushAsync();
+    expect(createBackgroundTasksProps(refresh.host, openSession).tasks?.[0]?.status).toBe(
+      "cancelled",
+    );
+
+    refresh.resolveActive({ tasks });
+    refresh.resolveRecent({ tasks });
+    await flushAsync();
+
+    expect(createBackgroundTasksProps(refresh.host, openSession).tasks?.[0]?.status).toBe(
+      "cancelled",
+    );
+  });
+
+  it("discards an in-flight snapshot after a same-client connection-epoch change", async () => {
+    const stale = [makeTask({ id: "task-old-account" })];
+    const replacement = [makeTask({ id: "task-new-account", updatedAt: 4_000 })];
+    const refresh = await refreshingHost(stale, true);
+    refresh.setFallbackTasks(replacement);
+    refresh.host.connectionEpoch = 2;
+
+    createBackgroundTasksProps(refresh.host, openSession);
+    await flushAsync();
+    expect(
+      createBackgroundTasksProps(refresh.host, openSession).tasks?.map((task) => task.id),
+    ).toEqual(["task-new-account"]);
+
+    refresh.resolveActive({ tasks: stale });
+    refresh.resolveRecent({ tasks: stale });
+    await flushAsync();
+
+    expect(
+      createBackgroundTasksProps(refresh.host, openSession).tasks?.map((task) => task.id),
+    ).toEqual(["task-new-account"]);
+    expect(refresh.request).toHaveBeenCalledTimes(4);
+  });
+});

--- a/ui/src/pages/chat/components/chat-background-tasks-shared.ts
+++ b/ui/src/pages/chat/components/chat-background-tasks-shared.ts
@@ -1,10 +1,7 @@
 import { t } from "../../../i18n/index.ts";
-import {
-  isActiveTask,
-  taskStatusLabel,
-  taskTimestampMs,
-  type TaskSummary,
-} from "../../../lib/tasks/data.ts";
+import { isActiveTask, taskStatusLabel, type TaskSummary } from "../../../lib/tasks/data.ts";
+
+export { newestTaskSnapshot } from "../../../lib/tasks/data.ts";
 
 // Status tone drives the meta line's colored word and the running pulse dot;
 // pill chips read too heavy at rail width, so tone is typographic only.
@@ -27,22 +24,4 @@ export function backgroundTaskStatusLabel(task: TaskSummary): string {
   return task.status === "completed"
     ? t("tasksPage.status.completed")
     : t("tasksPage.status.failed");
-}
-
-export function newestTaskSnapshot(
-  current: TaskSummary,
-  lookup: TaskSummary | undefined,
-): TaskSummary {
-  if (!lookup) {
-    return current;
-  }
-  const currentAt = taskTimestampMs(current.updatedAt ?? current.endedAt ?? current.createdAt);
-  const lookupAt = taskTimestampMs(lookup.updatedAt ?? lookup.endedAt ?? lookup.createdAt);
-  if (
-    lookupAt > currentAt ||
-    (lookupAt === currentAt && isActiveTask(current) && !isActiveTask(lookup))
-  ) {
-    return lookup;
-  }
-  return current;
 }

--- a/ui/src/pages/chat/components/chat-background-tasks.test.ts
+++ b/ui/src/pages/chat/components/chat-background-tasks.test.ts
@@ -92,6 +92,33 @@ describe("background tasks rail state", () => {
     expect(props.tasks?.map((task) => task.id)).toEqual(["task-1"]);
   });
 
+  it("uses the active page's equally current running progress", async () => {
+    const recent = makeTask({
+      id: "task-1",
+      toolUseCount: 2,
+      lastToolName: "write",
+      progressSummary: "Preparing the concurrent task report",
+    });
+    const active = makeTask({
+      id: "task-1",
+      toolUseCount: 2,
+      lastToolName: "write",
+      progressSummary: "Finishing the concurrent task report",
+    });
+    const { host } = createHost({
+      request: (method, params) => {
+        expect(method).toBe("tasks.list");
+        const status = (params as { status?: string[] }).status;
+        return Promise.resolve({ tasks: [status ? active : recent] });
+      },
+    });
+
+    createBackgroundTasksProps(host, openSession);
+    await flushAsync();
+
+    expect(createBackgroundTasksProps(host, openSession).tasks).toEqual([active]);
+  });
+
   it("loads the snapshot when a task event arrives before any load", async () => {
     const { host, request } = createHost({
       connected: false,
@@ -352,6 +379,81 @@ describe("background tasks rail events", () => {
     handleBackgroundTasksEvent(host, { action: "deleted", taskId: "task-1" });
     props = createBackgroundTasksProps(host, openSession);
     expect(props.tasks?.map((task) => task.id)).toEqual(["task-2"]);
+  });
+
+  it("applies an equally current authoritative terminal event correction", async () => {
+    const completed = makeTask({
+      id: "task-1",
+      status: "completed",
+      updatedAt: 2_000,
+      terminalSummary: "Previous terminal details",
+    });
+    const correction = makeTask({
+      id: "task-1",
+      status: "completed",
+      updatedAt: 2_000,
+      terminalSummary: "Authoritative terminal details",
+    });
+    const { host } = await loadedHost([completed]);
+
+    handleBackgroundTasksEvent(host, { action: "upserted", task: correction });
+
+    expect(createBackgroundTasksProps(host, openSession).tasks).toEqual([correction]);
+  });
+
+  it("does not roll back running tool activity from an equally current event", async () => {
+    const progress = makeTask({
+      id: "task-1",
+      updatedAt: 2_000,
+      toolUseCount: 2,
+      lastToolName: "write",
+    });
+    const stale = makeTask({
+      id: "task-1",
+      updatedAt: 2_000,
+      toolUseCount: 1,
+      lastToolName: "read",
+    });
+    const { host } = await loadedHost([progress]);
+
+    handleBackgroundTasksEvent(host, { action: "upserted", task: stale });
+
+    expect(createBackgroundTasksProps(host, openSession).tasks).toEqual([progress]);
+  });
+
+  it("preserves an opened prompt when a terminal event corrects its output", async () => {
+    const completed = makeTask({
+      id: "task-1",
+      status: "completed",
+      updatedAt: 2_000,
+      terminalSummary: "Previous terminal details",
+    });
+    const prompt = "Inspect the concurrent task owner";
+    const correction = makeTask({
+      id: "task-1",
+      status: "completed",
+      updatedAt: 2_000,
+      terminalSummary: "Authoritative terminal details",
+    });
+    const { host } = createHost({
+      request: (method) =>
+        method === "tasks.get"
+          ? Promise.resolve({ task: { ...completed, prompt } })
+          : Promise.resolve({ tasks: [completed] }),
+    });
+    createBackgroundTasksProps(host, openSession);
+    await flushAsync();
+    createBackgroundTasksProps(host, openSession).onSelectTask(completed);
+    await flushAsync();
+
+    handleBackgroundTasksEvent(host, { action: "upserted", task: correction });
+
+    const props = createBackgroundTasksProps(host, openSession);
+    expect(props.tasks?.[0]?.terminalSummary).toBe("Authoritative terminal details");
+    expect(props.taskDetails.get("task-1")).toMatchObject({
+      prompt,
+      terminalSummary: "Authoritative terminal details",
+    });
   });
 
   it("ignores upserts for other agents", async () => {

--- a/ui/src/pages/chat/components/chat-background-tasks.test.ts
+++ b/ui/src/pages/chat/components/chat-background-tasks.test.ts
@@ -92,20 +92,20 @@ describe("background tasks rail state", () => {
     expect(props.tasks?.map((task) => task.id)).toEqual(["task-1"]);
   });
 
-  it("uses the active page's equally current running progress", async () => {
+  it("keeps the later recent page's equally current running progress", async () => {
     const recent = makeTask({
-      id: "task-1",
-      toolUseCount: 2,
-      lastToolName: "write",
-      progressSummary: "Preparing the concurrent task report",
-    });
-    const active = makeTask({
       id: "task-1",
       toolUseCount: 2,
       lastToolName: "write",
       progressSummary: "Finishing the concurrent task report",
     });
-    const { host } = createHost({
+    const active = makeTask({
+      id: "task-1",
+      toolUseCount: 2,
+      lastToolName: "write",
+      progressSummary: "Preparing the concurrent task report",
+    });
+    const { host, request } = createHost({
       request: (method, params) => {
         expect(method).toBe("tasks.list");
         const status = (params as { status?: string[] }).status;
@@ -116,7 +116,9 @@ describe("background tasks rail state", () => {
     createBackgroundTasksProps(host, openSession);
     await flushAsync();
 
-    expect(createBackgroundTasksProps(host, openSession).tasks).toEqual([active]);
+    expect(request.mock.calls[0]?.[1]).toMatchObject({ status: ["queued", "running"] });
+    expect(request.mock.calls[1]?.[1]).not.toHaveProperty("status");
+    expect(createBackgroundTasksProps(host, openSession).tasks).toEqual([recent]);
   });
 
   it("loads the snapshot when a task event arrives before any load", async () => {

--- a/ui/src/pages/chat/components/chat-background-tasks.ts
+++ b/ui/src/pages/chat/components/chat-background-tasks.ts
@@ -220,7 +220,7 @@ export function handleBackgroundTasksEvent(host: BackgroundTasksHost, payload: u
   }
   const current = state.tasks.find((task) => task.id === event.task.id);
   const detail = state.taskDetails.get(event.task.id);
-  let newest = current ? newestTaskSnapshot(current, event.task) : event.task;
+  let newest = current ? newestTaskSnapshot(current, event.task, "event") : event.task;
   newest = newestTaskSnapshot(newest, detail);
   state.tasks = sortTasks([newest, ...state.tasks.filter((task) => task.id !== event.task.id)]);
   if (detail) {

--- a/ui/src/pages/chat/components/chat-background-tasks.ts
+++ b/ui/src/pages/chat/components/chat-background-tasks.ts
@@ -8,6 +8,7 @@ import { t } from "../../../i18n/index.ts";
 import type { SessionScopeHost } from "../../../lib/sessions/index.ts";
 import { parseAgentSessionKey } from "../../../lib/sessions/session-key.ts";
 import {
+  applyTaskEvent,
   isActiveTask,
   mergeTaskLists,
   normalizeTaskEventPayload,
@@ -27,16 +28,29 @@ import { paneSessionAgentId } from "./chat-session-workspace.ts";
 export { STATUS_TONES } from "./chat-background-tasks-shared.ts";
 export type { BackgroundTasksProps } from "./chat-background-tasks.types.ts";
 
+type BackgroundTaskLoadEvent = NonNullable<ReturnType<typeof normalizeTaskEventPayload>>;
+
+type BackgroundTaskEventBuffer = {
+  requestId: number;
+  client: GatewayBrowserClient;
+  connectionEpoch: number | undefined;
+  agentId: string;
+  events: BackgroundTaskLoadEvent[];
+};
+
 type BackgroundTasksState = {
   agentId: string;
   cancellingTaskIds: Set<string>;
   collapsed: boolean;
+  connectionClient: GatewayBrowserClient | null;
+  connectionEpoch: number | undefined;
   error: string | null;
   finishedCollapsed: boolean;
   // Loads are keyed to the client so a reconnect (or gateway switch) refreshes
   // the snapshot instead of trusting the previous connection's task list.
   loadedClient: GatewayBrowserClient | null;
   loading: boolean;
+  pendingTaskEvents: BackgroundTaskEventBuffer | null;
   pendingReload: boolean;
   requestId: number;
   // wa-tooltip anchors by document id, so the status row's id must stay unique
@@ -53,6 +67,7 @@ export type BackgroundTasksHost = {
   sessionKey: string;
   client: GatewayBrowserClient | null;
   connected: boolean;
+  connectionEpoch?: number;
   hello: GatewayHelloOk | null;
   assistantAgentId?: string | null;
   agentsList?: SessionScopeHost["agentsList"];
@@ -71,7 +86,11 @@ let nextStatusRowId = 0;
 function getBackgroundTasksState(host: BackgroundTasksHost): BackgroundTasksState {
   const agentId = paneSessionAgentId(host);
   const current = host.backgroundTasksState;
-  if (current?.agentId === agentId) {
+  if (
+    current?.agentId === agentId &&
+    current.connectionClient === host.client &&
+    current.connectionEpoch === host.connectionEpoch
+  ) {
     return current;
   }
   nextStatusRowId += 1;
@@ -81,12 +100,17 @@ function getBackgroundTasksState(host: BackgroundTasksHost): BackgroundTasksStat
     // The pane is an agent-level view; keep the open/collapsed choice across
     // agent switches and only reload the task list for the new scope.
     collapsed: current?.collapsed ?? true,
+    // The pane increments this epoch even when a reconnect reuses its client.
+    // Old snapshots and private task details must never enter the new scope.
+    connectionClient: host.client,
+    connectionEpoch: host.connectionEpoch,
     error: null,
     // Finished history starts collapsed so active work owns the rail; the
     // section header still shows the count for discoverability.
     finishedCollapsed: current?.finishedCollapsed ?? true,
     loadedClient: null,
     loading: false,
+    pendingTaskEvents: null,
     pendingReload: false,
     requestId: 0,
     statusRowId: `chat-tasks-status-${nextStatusRowId}`,
@@ -116,6 +140,16 @@ function loadBackgroundTasks(
     return;
   }
   const requestId = ++state.requestId;
+  // Keep live registry events tied to this exact client, scope, and snapshot
+  // so a late page cannot resurrect or overwrite an unopened concurrent task.
+  const eventBuffer: BackgroundTaskEventBuffer = {
+    requestId,
+    client,
+    connectionEpoch: state.connectionEpoch,
+    agentId: state.agentId,
+    events: [],
+  };
+  state.pendingTaskEvents = eventBuffer;
   state.loading = true;
   state.error = null;
   state.pendingReload = false;
@@ -139,7 +173,10 @@ function loadBackgroundTasks(
       if (current !== state || current.requestId !== requestId) {
         return;
       }
-      const merged = mergeTaskLists(recent, active);
+      let merged = mergeTaskLists(recent, active);
+      for (const event of eventBuffer.events) {
+        merged = applyTaskEvent(merged, event).tasks;
+      }
       current.tasks = sortTasks(
         merged.map((task) => newestTaskSnapshot(task, current.taskDetails.get(task.id))),
       );
@@ -147,6 +184,14 @@ function loadBackgroundTasks(
     } catch (error) {
       const current = getBackgroundTasksState(host);
       if (current === state && current.requestId === requestId) {
+        if (current.tasks === null && eventBuffer.events.length > 0) {
+          // Real registry events remain authoritative when an initial page
+          // fails; discarding them would hide active work and completions.
+          current.tasks = eventBuffer.events.reduce(
+            (tasks, event) => applyTaskEvent(tasks, event).tasks,
+            [] as TaskSummary[],
+          );
+        }
         current.error =
           error instanceof Error && error.message.trim()
             ? error.message.trim()
@@ -155,6 +200,9 @@ function loadBackgroundTasks(
     } finally {
       const current = getBackgroundTasksState(host);
       if (current === state && current.requestId === requestId) {
+        if (current.pendingTaskEvents === eventBuffer) {
+          current.pendingTaskEvents = null;
+        }
         current.loading = false;
         const reload = current.pendingReload;
         current.pendingReload = false;
@@ -180,21 +228,53 @@ function taskMatchesAgentScope(task: TaskSummary, agentId: string): boolean {
   );
 }
 
+function bufferBackgroundTaskEvent(
+  host: BackgroundTasksHost,
+  state: BackgroundTasksState,
+  event: BackgroundTaskLoadEvent,
+): boolean {
+  const buffer = state.pendingTaskEvents;
+  if (
+    event.action === "restored" ||
+    !buffer ||
+    !state.loading ||
+    buffer.requestId !== state.requestId ||
+    buffer.client !== host.client ||
+    buffer.connectionEpoch !== host.connectionEpoch ||
+    buffer.agentId !== state.agentId ||
+    (event.action === "upserted" && !taskMatchesAgentScope(event.task, state.agentId))
+  ) {
+    return false;
+  }
+  buffer.events.push(event);
+  return true;
+}
+
 /** Apply a gateway `task` event to the pane's snapshot. Events for other
  * agents are ignored; a registry restore forces a refetch. */
 export function handleBackgroundTasksEvent(host: BackgroundTasksHost, payload: unknown) {
   const state = host.backgroundTasksState;
-  if (!state) {
+  if (
+    !state ||
+    state.connectionClient !== host.client ||
+    state.connectionEpoch !== host.connectionEpoch
+  ) {
     return;
   }
   const event = normalizeTaskEventPayload(payload);
   if (!event) {
     return;
   }
+  if (event.action === "upserted" && !taskMatchesAgentScope(event.task, state.agentId)) {
+    return;
+  }
+  const bufferedEvent = bufferBackgroundTaskEvent(host, state, event);
   if (state.tasks === null) {
-    // Activity arrived before the snapshot finished loading: fold it into a
-    // (re)load so collapsed panes still detect the new task in their badge.
-    loadBackgroundTasks(host, state, true);
+    // The exact in-flight snapshot already replays its buffered events; a
+    // redundant stale reload would immediately undo that initial-load replay.
+    if (!bufferedEvent) {
+      loadBackgroundTasks(host, state, true);
+    }
     return;
   }
   if (event.action === "restored") {
@@ -213,9 +293,6 @@ export function handleBackgroundTasksEvent(host: BackgroundTasksHost, payload: u
     state.taskDetailErrors.delete(event.taskId);
     state.taskDetailLoadingIds.delete(event.taskId);
     host.requestUpdate?.();
-    return;
-  }
-  if (!taskMatchesAgentScope(event.task, state.agentId)) {
     return;
   }
   const current = state.tasks.find((task) => task.id === event.task.id);
@@ -365,6 +442,12 @@ async function cancelBackgroundTask(
     const result = normalizeTasksCancelResult(payload);
     if (result?.task && state.tasks !== null) {
       const cancelled = result.task;
+      const event = normalizeTaskEventPayload({ action: "upserted", task: cancelled });
+      if (event) {
+        // A slow client may miss the best-effort task event; the successful
+        // cancel response must still survive its own in-flight list snapshot.
+        bufferBackgroundTaskEvent(host, state, event);
+      }
       state.tasks = sortTasks([
         cancelled,
         ...state.tasks.filter((task) => task.id !== cancelled.id),

--- a/ui/src/pages/chat/components/chat-background-tasks.ts
+++ b/ui/src/pages/chat/components/chat-background-tasks.ts
@@ -189,9 +189,9 @@ function loadBackgroundTasks(
         if (current.tasks === null && eventBuffer.events.length > 0) {
           // Real registry events remain authoritative when an initial page
           // fails; discarding them would hide active work and completions.
-          current.tasks = eventBuffer.events.reduce(
+          current.tasks = eventBuffer.events.reduce<TaskSummary[]>(
             (tasks, event) => applyTaskEvent(tasks, event).tasks,
-            [] as TaskSummary[],
+            [],
           );
         }
         current.error =

--- a/ui/src/pages/chat/components/chat-background-tasks.ts
+++ b/ui/src/pages/chat/components/chat-background-tasks.ts
@@ -173,7 +173,9 @@ function loadBackgroundTasks(
       if (current !== state || current.requestId !== requestId) {
         return;
       }
-      let merged = mergeTaskLists(recent, active);
+      // The active query is issued first. Apply the later recent snapshot last
+      // so same-millisecond running progress cannot regress when events drop.
+      let merged = mergeTaskLists(active, recent);
       for (const event of eventBuffer.events) {
         merged = applyTaskEvent(merged, event).tasks;
       }

--- a/ui/src/pages/tasks/tasks-page.test.ts
+++ b/ui/src/pages/tasks/tasks-page.test.ts
@@ -1,13 +1,16 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import type { GatewayBrowserClient, GatewayEventFrame } from "../../api/gateway.ts";
 import type { ApplicationContext, ApplicationGatewaySnapshot } from "../../app/context.ts";
+import type { TaskStatus, TaskSummary } from "../../lib/tasks/data.ts";
 import "./tasks-page.ts";
 
 type TasksPageTestElement = HTMLElement & {
   context: ApplicationContext;
+  tasks: TaskSummary[];
   error: string | null;
   cancellingTaskIds: Set<string>;
   cancelTask: (taskId: string) => Promise<void>;
+  refreshTasks: () => Promise<void>;
 };
 
 function deferred<T>() {
@@ -31,6 +34,7 @@ function createGateway(client: GatewayBrowserClient) {
     lastErrorCode: null,
   };
   let snapshotListener: ((snapshot: ApplicationGatewaySnapshot) => void) | undefined;
+  const eventListeners = new Set<(event: GatewayEventFrame) => void>();
   const gateway = {
     snapshot,
     subscribe(listener: (snapshot: ApplicationGatewaySnapshot) => void) {
@@ -41,14 +45,76 @@ function createGateway(client: GatewayBrowserClient) {
         }
       };
     },
-    subscribeEvents: () => () => undefined,
+    subscribeEvents(listener: (event: GatewayEventFrame) => void) {
+      eventListeners.add(listener);
+      return () => eventListeners.delete(listener);
+    },
   } as unknown as ApplicationContext["gateway"];
   return {
     emitConnected(connected: boolean) {
       snapshot.phase = connected ? "connected" : "stopped";
       snapshotListener?.(snapshot);
     },
+    emitTask(payload: unknown) {
+      const event: GatewayEventFrame = { event: "task", payload, type: "event" };
+      for (const listener of eventListeners) {
+        listener(event);
+      }
+    },
     gateway,
+  };
+}
+
+function createTask(
+  id: string,
+  status: TaskStatus = "running",
+  overrides: Partial<TaskSummary> = {},
+): TaskSummary {
+  return { id, taskId: id, status, agentId: "main", updatedAt: 100, ...overrides };
+}
+
+async function createDeferredTaskRefresh(initialTasks: TaskSummary[]) {
+  const active = deferred<{ tasks: TaskSummary[] }>();
+  const recent = deferred<{ tasks: TaskSummary[] }>();
+  let deferRefresh = false;
+  let currentTasks = initialTasks;
+  const request = vi.fn(
+    (method: string, params?: { status?: readonly string[]; taskId?: string }) => {
+      if (method === "tasks.cancel") {
+        return Promise.resolve({
+          found: true,
+          cancelled: true,
+          task: createTask(params?.taskId ?? "task-missing", "cancelled", { updatedAt: 300 }),
+        });
+      }
+      if (method !== "tasks.list" || !deferRefresh) {
+        return Promise.resolve({ tasks: currentTasks });
+      }
+      return params?.status ? active.promise : recent.promise;
+    },
+  );
+  const source = createGateway({ request } as unknown as GatewayBrowserClient);
+  const page = document.createElement("openclaw-tasks-page") as TasksPageTestElement;
+  page.context = createContext(source.gateway);
+  document.body.append(page);
+  await vi.waitFor(() => expect(page.tasks).toHaveLength(initialTasks.length));
+
+  return {
+    active,
+    page,
+    recent,
+    request,
+    source,
+    startRefresh() {
+      deferRefresh = true;
+      return page.refreshTasks();
+    },
+    reconnectWithTasks(tasks: TaskSummary[]) {
+      deferRefresh = false;
+      currentTasks = tasks;
+      source.emitConnected(false);
+      source.emitConnected(true);
+    },
   };
 }
 
@@ -79,6 +145,125 @@ function createContext(
 afterEach(() => {
   document.body.replaceChildren();
   vi.restoreAllMocks();
+});
+
+describe("TasksPage concurrent refresh events", () => {
+  it("preserves all ten same-title task completions while stale snapshot pages resolve", async () => {
+    const initialTasks = Array.from({ length: 10 }, (_, index) =>
+      createTask(`task-${index}`, "running", { title: "Investigate concurrent sessions" }),
+    );
+    const refresh = await createDeferredTaskRefresh(initialTasks);
+    const pending = refresh.startRefresh();
+
+    for (const [index, task] of initialTasks.entries()) {
+      refresh.source.emitTask({
+        action: "upserted",
+        task: { ...task, status: "completed", updatedAt: 200 + index },
+      });
+    }
+    expect(refresh.page.tasks).toHaveLength(10);
+    expect(refresh.page.tasks.every((task) => task.status === "completed")).toBe(true);
+
+    refresh.active.resolve({ tasks: initialTasks });
+    refresh.recent.resolve({ tasks: initialTasks });
+    await pending;
+
+    expect(refresh.page.tasks).toHaveLength(10);
+    expect(new Set(refresh.page.tasks.map((task) => task.id)).size).toBe(10);
+    expect(refresh.page.tasks.every((task) => task.status === "completed")).toBe(true);
+  });
+
+  it("does not resurrect a task deleted while its snapshot is in flight", async () => {
+    const initialTasks = [createTask("task-deleted"), createTask("task-retained")];
+    const refresh = await createDeferredTaskRefresh(initialTasks);
+    const pending = refresh.startRefresh();
+
+    refresh.source.emitTask({ action: "deleted", taskId: "task-deleted" });
+    expect(refresh.page.tasks.map((task) => task.id)).toEqual(["task-retained"]);
+
+    refresh.active.resolve({ tasks: initialTasks });
+    refresh.recent.resolve({ tasks: initialTasks });
+    await pending;
+
+    expect(refresh.page.tasks.map((task) => task.id)).toEqual(["task-retained"]);
+  });
+
+  it("retains a task created after its snapshot requests started", async () => {
+    const initialTasks = [createTask("task-existing")];
+    const refresh = await createDeferredTaskRefresh(initialTasks);
+    const pending = refresh.startRefresh();
+
+    refresh.source.emitTask({
+      action: "upserted",
+      task: createTask("task-created", "running", { updatedAt: 200 }),
+    });
+    expect(refresh.page.tasks.map((task) => task.id)).toEqual(["task-created", "task-existing"]);
+
+    refresh.active.resolve({ tasks: initialTasks });
+    refresh.recent.resolve({ tasks: initialTasks });
+    await pending;
+
+    expect(refresh.page.tasks.map((task) => task.id)).toEqual(["task-created", "task-existing"]);
+  });
+
+  it("does not replay another agent's task into the selected scope", async () => {
+    const initialTasks = [createTask("task-main")];
+    const refresh = await createDeferredTaskRefresh(initialTasks);
+    const pending = refresh.startRefresh();
+
+    refresh.source.emitTask({
+      action: "upserted",
+      task: createTask("task-writer", "running", { agentId: "writer", updatedAt: 200 }),
+    });
+    expect(refresh.page.tasks.map((task) => task.id)).toEqual(["task-main"]);
+
+    refresh.active.resolve({ tasks: initialTasks });
+    refresh.recent.resolve({ tasks: initialTasks });
+    await pending;
+
+    expect(refresh.page.tasks.map((task) => task.id)).toEqual(["task-main"]);
+  });
+
+  it("preserves successful cancellation while stale snapshot pages are in flight", async () => {
+    const initialTasks = [createTask("task-cancelled")];
+    const refresh = await createDeferredTaskRefresh(initialTasks);
+    const pending = refresh.startRefresh();
+
+    await refresh.page.cancelTask("task-cancelled");
+    expect(refresh.page.tasks.map((task) => [task.id, task.status])).toEqual([
+      ["task-cancelled", "cancelled"],
+    ]);
+
+    refresh.active.resolve({ tasks: initialTasks });
+    refresh.recent.resolve({ tasks: initialTasks });
+    await pending;
+
+    expect(refresh.page.tasks.map((task) => [task.id, task.status])).toEqual([
+      ["task-cancelled", "cancelled"],
+    ]);
+  });
+
+  it("does not replay events from a refresh invalidated by a reconnect", async () => {
+    const initialTasks = [createTask("task-before-reconnect")];
+    const replacementTasks = [createTask("task-after-reconnect")];
+    const refresh = await createDeferredTaskRefresh(initialTasks);
+    const pending = refresh.startRefresh();
+
+    refresh.source.emitTask({
+      action: "upserted",
+      task: createTask("task-stale-event", "completed", { updatedAt: 200 }),
+    });
+    refresh.reconnectWithTasks(replacementTasks);
+    await vi.waitFor(() =>
+      expect(refresh.page.tasks.map((task) => task.id)).toEqual(["task-after-reconnect"]),
+    );
+
+    refresh.active.resolve({ tasks: initialTasks });
+    refresh.recent.resolve({ tasks: initialTasks });
+    await pending;
+
+    expect(refresh.page.tasks.map((task) => task.id)).toEqual(["task-after-reconnect"]);
+  });
 });
 
 describe("TasksPage cancellation lifecycle", () => {

--- a/ui/src/pages/tasks/tasks-page.test.ts
+++ b/ui/src/pages/tasks/tasks-page.test.ts
@@ -148,6 +148,28 @@ afterEach(() => {
 });
 
 describe("TasksPage concurrent refresh events", () => {
+  it("keeps the later recent page's equally current running progress", async () => {
+    const initial = createTask("task-progress", "running", {
+      toolUseCount: 2,
+      progressSummary: "Preparing the concurrent task report",
+    });
+    const recent = createTask("task-progress", "running", {
+      toolUseCount: 2,
+      progressSummary: "Finishing the concurrent task report",
+    });
+    const refresh = await createDeferredTaskRefresh([initial]);
+    const pending = refresh.startRefresh();
+
+    const refreshCalls = refresh.request.mock.calls.slice(-2);
+    expect(refreshCalls[0]?.[1]).toMatchObject({ status: ["queued", "running"] });
+    expect(refreshCalls[1]?.[1]).not.toHaveProperty("status");
+    refresh.active.resolve({ tasks: [initial] });
+    refresh.recent.resolve({ tasks: [recent] });
+    await pending;
+
+    expect(refresh.page.tasks).toEqual([recent]);
+  });
+
   it("preserves all ten same-title task completions while stale snapshot pages resolve", async () => {
     const initialTasks = Array.from({ length: 10 }, (_, index) =>
       createTask(`task-${index}`, "running", { title: "Investigate concurrent sessions" }),

--- a/ui/src/pages/tasks/tasks-page.ts
+++ b/ui/src/pages/tasks/tasks-page.ts
@@ -262,7 +262,9 @@ class TasksPage extends OpenClawLightDomElement {
         throw new Error(t("tasksPage.invalidResponse"));
       }
       if (this.isLoadScopeCurrent(gateway, client, generation)) {
-        let tasks = mergeTaskLists(recent, active);
+        // The active query is issued first; a same-millisecond recent page
+        // must win running-progress ties when a pushed event is dropped.
+        let tasks = mergeTaskLists(active, recent);
         for (const event of taskRefreshEvents.events) {
           tasks = applyTaskEvent(tasks, event).tasks;
         }

--- a/ui/src/pages/tasks/tasks-page.ts
+++ b/ui/src/pages/tasks/tasks-page.ts
@@ -16,6 +16,7 @@ import { parseAgentSessionKey } from "../../lib/sessions/session-key.ts";
 import {
   applyTaskEvent,
   mergeTaskLists,
+  normalizeTaskEventPayload,
   normalizeTasksCancelResult,
   normalizeTasksListResult,
   type TaskSummary,
@@ -43,6 +44,16 @@ function taskMatchesAgentScope(task: TaskSummary, agentId: string | null): boole
   );
 }
 
+type TaskRefreshEvent = NonNullable<ReturnType<typeof normalizeTaskEventPayload>>;
+
+type TaskRefreshEventBuffer = {
+  generation: number;
+  gateway: ApplicationContext["gateway"];
+  client: GatewayBrowserClient;
+  scopeId: string | null;
+  events: TaskRefreshEvent[];
+};
+
 class TasksPage extends OpenClawLightDomElement {
   @consume({ context: applicationContext, subscribe: true })
   private context!: ApplicationContext;
@@ -58,6 +69,7 @@ class TasksPage extends OpenClawLightDomElement {
   private operationEpoch = 0;
   private observedAgentScopeId: string | null | undefined;
   private gatewaySource?: ApplicationContext["gateway"];
+  private taskRefreshEvents: TaskRefreshEventBuffer | null = null;
   private readonly subscriptions = new SubscriptionsController(this)
     .effect(
       () => this.context?.gateway,
@@ -90,9 +102,23 @@ class TasksPage extends OpenClawLightDomElement {
             void this.refreshTasks();
             return;
           }
-          this.tasks = result.tasks.filter((task) =>
-            taskMatchesAgentScope(task, this.context.agentSelection.state.scopeId),
-          );
+          const scopeId = this.context.agentSelection.state.scopeId;
+          const normalizedEvent = normalizeTaskEventPayload(event.payload);
+          const buffer = this.taskRefreshEvents;
+          if (
+            normalizedEvent &&
+            normalizedEvent.action !== "restored" &&
+            buffer &&
+            buffer.generation === this.loadGeneration &&
+            buffer.gateway === gateway &&
+            buffer.client === this.client &&
+            buffer.scopeId === scopeId &&
+            (normalizedEvent.action === "deleted" ||
+              taskMatchesAgentScope(normalizedEvent.task, scopeId))
+          ) {
+            buffer.events.push(normalizedEvent);
+          }
+          this.tasks = result.tasks.filter((task) => taskMatchesAgentScope(task, scopeId));
         });
         if (this.connected) {
           void this.refreshTasks();
@@ -163,6 +189,7 @@ class TasksPage extends OpenClawLightDomElement {
     // cancellation responses from mutating the replacement task snapshot.
     this.loadGeneration += 1;
     this.operationEpoch += 1;
+    this.taskRefreshEvents = null;
     this.loading = false;
     this.cancellingTaskIds = new Set();
   }
@@ -204,10 +231,21 @@ class TasksPage extends OpenClawLightDomElement {
       return;
     }
     const generation = ++this.loadGeneration;
+    const scopeId = this.context.agentSelection.state.scopeId;
+    // Replay only events received during this exact scoped request; otherwise
+    // late snapshot pages can undo concurrent completions, creations, or deletes.
+    const taskRefreshEvents: TaskRefreshEventBuffer = {
+      generation,
+      gateway,
+      client,
+      scopeId,
+      events: [],
+    };
+    this.taskRefreshEvents = taskRefreshEvents;
     this.loading = true;
     this.error = null;
     try {
-      const agentId = this.context.agentSelection.state.scopeId ?? undefined;
+      const agentId = scopeId ?? undefined;
       // Active tasks need their own query: the ledger pages newest-first, so a
       // long-running task can hide behind newer terminal records on page one.
       const [activePayload, recentPayload] = await Promise.all([
@@ -223,8 +261,11 @@ class TasksPage extends OpenClawLightDomElement {
       if (!active || !recent) {
         throw new Error(t("tasksPage.invalidResponse"));
       }
-      const tasks = mergeTaskLists(recent, active);
       if (this.isLoadScopeCurrent(gateway, client, generation)) {
+        let tasks = mergeTaskLists(recent, active);
+        for (const event of taskRefreshEvents.events) {
+          tasks = applyTaskEvent(tasks, event).tasks;
+        }
         this.tasks = tasks;
       }
     } catch (error) {
@@ -232,6 +273,9 @@ class TasksPage extends OpenClawLightDomElement {
         this.error = formatTaskError(error, t("tasksPage.loadFailed"));
       }
     } finally {
+      if (this.taskRefreshEvents === taskRefreshEvents) {
+        this.taskRefreshEvents = null;
+      }
       if (this.isLoadScopeCurrent(gateway, client, generation)) {
         this.loading = false;
       }
@@ -260,6 +304,20 @@ class TasksPage extends OpenClawLightDomElement {
       }
       const result = normalizeTasksCancelResult(payload);
       if (result?.task) {
+        const event = normalizeTaskEventPayload({ action: "upserted", task: result.task });
+        const buffer = this.taskRefreshEvents;
+        if (
+          event &&
+          buffer &&
+          buffer.generation === this.loadGeneration &&
+          buffer.gateway === gateway &&
+          buffer.client === client &&
+          buffer.scopeId === this.context.agentSelection.state.scopeId
+        ) {
+          // Cancellation replies are authoritative even if the best-effort
+          // registry event is dropped while the matching pages are in flight.
+          buffer.events.push(event);
+        }
         this.tasks = applyTaskEvent(this.tasks, { action: "upserted", task: result.task }).tasks;
       }
       // Refusals (already terminal, stale id, no cancellation handle) are


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running several background tasks simultaneously could see completed tasks return to running, lose live progress, or have tasks disappear when the Tasks page and chat background-task rail receive concurrent Gateway events and overlapping list snapshots.

## Why This Change Was Made

Both surfaces now use the same canonical freshness policy and request-scoped Gateway-event replay. Active and recent snapshots are merged in the order the real requests are issued, so equal-millisecond progress advances correctly; terminal corrections, selected details, dropped best-effort cancellation events, agent ownership and same-client reconnection epochs remain properly isolated.

## User Impact

All concurrent tasks remain distinct, their genuine progress is visible, and all completed tasks stay completed on both the Tasks page and chat rail. Slow or out-of-order responses can no longer resurrect deleted, cancelled or completed work or leak a previous agent's results.

## Evidence

- Genuine failing-first owner proof: the previous public implementation fails six creation/deletion/completion regressions across both visible consumers; fresh full-branch independent review additionally exposed two real equal-timestamp progress failures, reproduced on both owners before fixing actual snapshot chronology.
- Final focused proof: all four real task-data, Tasks-page, chat-rail and dedicated concurrency owner suites pass **80/80**; all eight changed files pass formatting, lint and whitespace checks.
- Fresh official independent full-eight-path `gpt-5.6-sol`/high committed-branch review of `31d82484d908c3713f63a0b9b95ae891f457f753`: **zero findings**, confidence **0.94**.
- Actual isolated Gateway + real Chromium Control UI proof: completed dedicated Testbox `tbx_01kyf3kvta6w47zhdwv28gd9eb`, lifecycle [30200571514](https://github.com/openclaw/openclaw/actions/runs/30200571514), workflow dispatched at main `43a695396d9ce08256e1603b66a5dc43ad04d907` with all **8/8** reviewed local source blobs independently verified. Real token-authenticated Gateway, real Chromium, two genuine browser WebSocket connections; **10 distinct task IDs / 10 distinct run IDs**, each surface received **10 real progress and 10 real completion events**, all **8 delayed real responses** arrive after their corresponding live events, **10 completed / 0 running / 0 queued / 0 failed**, `mockGateway=false`, `syntheticGatewayFrames=false`. All seven artifacts independently downloaded; six fresh 1440×1000 PNGs SHA-256 `79fe9e79d59987cf4f4c79aa03e2e0d834faa3ac42f66072e2274abaae82b1ac`, `1504fe93149a0919249da2e0594347edf3920c4b63e7f3e48536d4aa9923bca0`, `c34b66a62a585e6e2eadc2138e75ca07d19746525f10ac71391cdd7e2005efce`, `e6ade1731f3fbb8de1f3dbb4ddb496ca496ff260ea24679cc4d0e9d7a4d8e5a0`, `2e1a8d5c320e83a3c3fddcfeaa6d36368c0a1b9948635762d1b5f5d4578ff0e8`, and `7ec36c83b802ff4741269558f805d873e1abc02596d29225e65aab5d1ce07e86`. Actual lease status `completed` and wrapper exit `0`; a post-completion optional Blacksmith portal-list timeout is not a failing scenario and the lifecycle run is not represented as public-head CI.
- Separately, a real live-provider QA scenario on preserved `cd5a5ecb` ran **10 distinct live `openai/gpt-5.4` sessions simultaneously**, with 10 distinct runs, 10 provider starts, overlap 10, 10 persisted final responses, 10 independently written artifacts and **zero pending/failures** (Blacksmith run [30198063543](https://github.com/openclaw/openclaw/actions/runs/30198063543)). This provider run is explicitly distinct from the real-browser registry proof and is not described as an execution on the newer candidate head.
- Complete exact-source changed gate: dedicated latest-main Testbox `tbx_01kyf402xcxrbmtthnmrs6zf4b`, lifecycle [30200786943](https://github.com/openclaw/openclaw/actions/runs/30200786943), `pnpm check:changed --base origin/main`, exactly eight changed UI paths, conflict/line/dependency/package/i18n guards, core-test and UI TypeScript checks, and actual type-aware lint **0 warnings / 0 errors**; `commandMs: 260274`, `totalMs: 292117`, **`exitCode: 0`**, stopped after success. The workflow's actual GitHub `head_sha` is main `43a695396d9ce08256e1603b66a5dc43ad04d907`; its trusted remote checkout independently synchronizes the exact reviewed 31d82484d908c3713f63a0b9b95ae891f457f753 candidate, rather than representing this lifecycle run as public-head CI.
- Base: clean current `main` `43a695396d9ce08256e1603b66a5dc43ad04d907`. The remote Testbox dispatch runs the workflow on that main SHA and synchronizes/verifies all eight candidate source blobs; it is not misrepresented as a completed public-head GitHub check.
- No Gateway protocol, provider/SSE, plugin policy, authentication, approval policy, persisted SQLite state/schema/migrations, public CLI, or configuration-contract changes.