### PR TITLE
fix(control-ui): center the lazy panel loading state

### DIFF
--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -1431,6 +1431,19 @@ openclaw-session-owner-chip {
   color: var(--ok);
 }
 
+/* Lazy route/panel pending — a centered panel state like .lazy-view-error.
+   Without an explicit box it inherits the host content axis; `.content--chat`
+   makes the outlet a row flex box, which collapsed this card to a full-height
+   text-width strip sitting under the fixed .shell-chrome-controls buttons. */
+.lazy-view-state {
+  margin: auto;
+  display: grid;
+  justify-items: center;
+  text-align: center;
+  width: min(440px, 100%);
+  padding: 48px 24px;
+}
+
 /* Lazy route load failure — a centered panel state, not a stretched callout. */
 .lazy-view-error {
   margin: auto;


### PR DESCRIPTION
## What Problem This Solves

On chat-like routes, the panel the control UI shows while a route is still pending rendered as a 134px-wide strip running the full height of the viewport, with the sidebar-collapse and search buttons printed on top of its title.

![Control UI chat route stuck in the pending panel state, rendered as a narrow full-height strip with the chrome buttons overlapping the title](https://github.com/user-attachments/assets/06f2aa82-c328-4f1f-a246-6670595cc18b)

**What this shows:** PR base behavior. The pending panel is 134px wide and 860px tall, starts at `y=0`, and the fixed `.shell-chrome-controls` buttons cover the word "Loading" in its title.

**State:** `/chat?session=main` in the repo's control-UI mock harness (`pnpm dev:ui:mock`), dark theme, 1280x860 viewport, `ui/src/styles/components.css` at PR base `cd5a5ec`. The chat route's `import("./chat-page.ts")` is held open so the outlet stays in `renderPending()`. Viewport crop — the empty area to the right is part of the defect.

The cause is that `.lazy-view-state` had no CSS rule of its own, so the card inherited whichever layout axis its host content area used. `ui/src/styles/layout.css:3594` makes the outlet on chat-like routes (`chat`, `custodian`, `new-session`) a flex container with no `flex-direction`, so it defaults to `row`. Real page roots set their own `flex: 1` and are unaffected; the bare fallback card collapsed to its text width and stretched to full height. Starting at `y=0` also put it underneath `.shell-chrome-controls` (`layout.css:74`, `position: fixed; top: 10px`).

## Why This Change Was Made

`.lazy-view-error` — the failure state rendered by the same outlet — already solves this, and its comment states the intent: *"a centered panel state, not a stretched callout."* The pending state never got the matching rule.

Giving `.lazy-view-state` an explicit centered box makes it container-agnostic. Auto margins additionally opt the card out of flex stretch on both axes, so it renders the same whether the host is a row flex box, a column flex box, or a plain block.

Deliberately not changed: the missing `flex-direction` on `.content--chat > openclaw-router-outlet`. Styling the fallback is axis-independent and carries no risk to the real chat layout, whereas forcing that outlet to `column` would change how the chat page lays out its own children.

## User Impact

The pending panel now renders as a centered 440px card, clear of the chrome buttons.

![Control UI chat route in the pending panel state, now a centered 440px card clear of the chrome buttons](https://github.com/user-attachments/assets/cd33b1c2-b523-44df-8939-46c2c24a19a0)

**What this shows:** Same route, same held-open import, same viewport — only `components.css` differs. The card is 440x147 centered in the content area, and the chrome buttons no longer touch it.

**State:** Identical to the capture above except `ui/src/styles/components.css` is at this branch's HEAD.

Three states share this class and all three change: the route-pending panel, the workboard panel shown while plugin enablement is still unknown (`ui/src/pages/workboard/view.ts:1996`), and the plugin-tab unavailable/insecure panels (`ui/src/pages/plugin/plugin-page.ts:570`).

## Evidence

Measured with Playwright against the real `base.css` + `layout.css` + `components.css`, rendering `<section class="card lazy-view-state">` in each of the three host contexts it can land in, at 1280x860:

| host context | before | after |
| --- | --- | --- |
| `.content--chat` (row flex outlet) | x=278 y=0 w=134 h=860 | x=549 y=357 w=440 h=147 |
| `.content` (block) | x=278 y=16 w=982 h=87 | x=549 y=16 w=440 h=147 |
| `.content--workboard` (column flex outlet) | x=278 y=16 w=982 h=87 | x=549 y=357 w=440 h=147 |

Rect-intersection against the `.shell-chrome-controls` button group goes from overlapping to clear in all three contexts:

```text
before | chat       | chrome buttons overlap card: true
before | default    | chrome buttons overlap card: true
before | workboard  | chrome buttons overlap card: true
after  | chat       | chrome buttons overlap card: false
after  | default    | chrome buttons overlap card: false
after  | workboard  | chrome buttons overlap card: false
```

To reproduce: run `pnpm dev:ui:mock`, open `/chat?session=main`, and block the request for `chat-page.ts` (DevTools request blocking, or `page.route("**/chat-page.ts*", () => {})` in Playwright). The pending panel stays on screen.

Checks:

- `pnpm format:check ui/src/styles/components.css` — clean.
- `pnpm lint:ui:styles` — exit 0. This is the stylelint lane that covers `ui/src` stylesheets.
- `pnpm test ui/src` — 399 files passed, 4 failed.

The 4 failures (`ui/src/pages/usage/view.test.ts`, `ui/src/pages/usage/view-overview.test.ts`, `ui/src/pages/chat/chat-composer.test.ts`, `ui/src/components/board/board-view.test.ts`) are pre-existing on `main` and unrelated: re-running those four files with this diff stashed reproduces them on the clean base tree (`3 failed | 1 passed`; `board-view.test.ts` is flaky between runs). No test asserts on `.lazy-view-state` or `.lazy-view-error`.
