### PR TITLE
fix: finish ClawHub plugin uninstall and cutover

### DIFF
--- a/src/cli/plugins-uninstall-selection.test.ts
+++ b/src/cli/plugins-uninstall-selection.test.ts
@@ -5,6 +5,11 @@ import { resolvePluginUninstallId } from "./plugins-uninstall-selection.js";
 
 describe("resolvePluginUninstallId", () => {
   it("accepts the recorded ClawHub spec as an uninstall target", () => {
+    const plugin = {
+      id: "linkmind-context",
+      name: "linkmind-context",
+      channelIds: ["linkmind-channel"],
+    };
     const result = resolvePluginUninstallId({
       rawId: "clawhub:linkmind-context",
       config: {
@@ -21,13 +26,19 @@ describe("resolvePluginUninstallId", () => {
           },
         },
       } as OpenClawConfig,
-      plugins: [{ id: "linkmind-context", name: "linkmind-context" }],
+      plugins: [plugin],
     });
 
     expect(result.pluginId).toBe("linkmind-context");
+    expect(result.plugin).toBe(plugin);
   });
 
   it("accepts a versionless ClawHub spec when the install was pinned", () => {
+    const plugin = {
+      id: "linkmind-context",
+      name: "linkmind-context",
+      channelIds: ["linkmind-channel"],
+    };
     const result = resolvePluginUninstallId({
       rawId: "clawhub:linkmind-context",
       config: {
@@ -43,9 +54,10 @@ describe("resolvePluginUninstallId", () => {
           },
         },
       } as OpenClawConfig,
-      plugins: [{ id: "linkmind-context", name: "linkmind-context" }],
+      plugins: [plugin],
     });
 
     expect(result.pluginId).toBe("linkmind-context");
+    expect(result.plugin).toBe(plugin);
   });
 });

--- a/src/cli/plugins-uninstall-selection.ts
+++ b/src/cli/plugins-uninstall-selection.ts
@@ -12,6 +12,10 @@ export function resolvePluginUninstallId<
   plugins: TPlugin[];
 }): { pluginId: string; plugin?: TPlugin } {
   const rawId = params.rawId.trim();
+  const resolveInstalledPlugin = (pluginId: string) => {
+    const plugin = params.plugins.find((entry) => entry.id === pluginId);
+    return plugin ? { pluginId, plugin } : { pluginId };
+  };
   const plugin = params.plugins.find((entry) => entry.id === rawId || entry.name === rawId);
   if (plugin) {
     return { pluginId: plugin.id, plugin };
@@ -24,7 +28,7 @@ export function resolvePluginUninstallId<
       install.resolvedName === rawId ||
       install.marketplacePlugin === rawId
     ) {
-      return { pluginId };
+      return resolveInstalledPlugin(pluginId);
     }
   }
 
@@ -36,7 +40,7 @@ export function resolvePluginUninstallId<
         parseClawHubPluginSpec(install.spec ?? "")?.name ??
         parseClawHubPluginSpec(install.resolvedSpec ?? "")?.name;
       if (installedClawHubName === requestedClawHub.name) {
-        return { pluginId };
+        return resolveInstalledPlugin(pluginId);
       }
     }
   }

--- a/src/state/claw-package-adoption.test.ts
+++ b/src/state/claw-package-adoption.test.ts
@@ -10,7 +10,10 @@ import {
 } from "../claws/provenance.js";
 import type { ClawAddPlan } from "../claws/types.js";
 import { markClawPackageIndependentlyOwned } from "./claw-package-adoption.js";
-import { acquireClawPackageLifecycleLease } from "./claw-package-lifecycle-lease.js";
+import {
+  acquireClawPackageLifecycleLease,
+  withClawPackageLifecycleLease,
+} from "./claw-package-lifecycle-lease.js";
 import { closeOpenClawStateDatabaseForTest } from "./openclaw-state-db.js";
 
 afterEach(() => closeOpenClawStateDatabaseForTest());
@@ -235,6 +238,34 @@ describe("Claw package independent adoption", () => {
       ),
     ).toThrow("being changed by another OpenClaw lifecycle");
     directLease?.release();
+  });
+
+  it("releases a package lease when process exit bypasses async cleanup", async () => {
+    const env = { OPENCLAW_STATE_DIR: tempDirs.make("claw-exit-lease-") };
+    const artifact = { kind: "plugin", source: "clawhub", ref: "@acme/audit" } as const;
+    const existingExitListeners = new Set(process.listeners("exit"));
+
+    await expect(
+      withClawPackageLifecycleLease(
+        artifact,
+        async () => {
+          const exitCleanup = process
+            .listeners("exit")
+            .find((listener) => !existingExitListeners.has(listener));
+          expect(exitCleanup).toBeTypeOf("function");
+          exitCleanup?.(1);
+          throw new Error("simulated process exit");
+        },
+        { env, required: true },
+      ),
+    ).rejects.toThrow("simulated process exit");
+
+    expect(
+      process.listeners("exit").filter((listener) => !existingExitListeners.has(listener)),
+    ).toEqual([]);
+    const nextLease = acquireClawPackageLifecycleLease(artifact, { env, required: true });
+    expect(nextLease).not.toBeNull();
+    nextLease?.release();
   });
 
   it("fails open only for optional direct leases when lifecycle state is unavailable", () => {

--- a/src/state/claw-package-lifecycle-lease.ts
+++ b/src/state/claw-package-lifecycle-lease.ts
@@ -205,11 +205,22 @@ export async function withClawPackageLifecycleLease<T>(
     return await operation();
   }
   const maintained = maintainClawPackageLifecycleLease(lease);
+  // CLI failures call process.exit(), which skips async finally blocks. Release
+  // synchronously on exit so the next package command is not blocked until TTL.
+  const releaseOnExit = () => {
+    try {
+      maintained.release();
+    } catch {
+      // Expiry recovers a lease whose exit cleanup loses a database race.
+    }
+  };
+  process.once("exit", releaseOnExit);
   try {
     const result = await operation();
     maintained.assertCurrent();
     return result;
   } finally {
+    process.removeListener("exit", releaseOnExit);
     try {
       maintained.release();
     } catch {


### PR DESCRIPTION
Related: #102228

## What Problem This Solves

Fixes an issue where users uninstalling a ClawHub plugin by its recorded package spec could leave plugin-owned channel configuration behind. It also fixes an expected failed ClawHub install leaving a package lifecycle lease active for five minutes, which blocked an immediate retry or npm-to-ClawHub cutover.

## Why This Change Was Made

The uninstall resolver now preserves the discovered plugin record when the target matches install metadata, so the uninstall owner receives the channel IDs it needs. The package lifecycle wrapper also releases its lease from a synchronous process-exit handler, matching the existing shared state-lease contract when CLI errors call `process.exit()` before asynchronous cleanup can run.

## User Impact

ClawHub plugin uninstalls remove their owned channel configuration, and a failed install no longer blocks the next package operation until the lease TTL expires.

AI-assisted implementation and review.

## Evidence

- `node scripts/run-vitest.mjs src/cli/plugins-uninstall-selection.test.ts src/state/claw-package-adoption.test.ts` — 10 tests passed
- Blacksmith Testbox `tbx_01kyeyyr6qnh0gtjga4zd5gjjq`, Actions run `30198046824`: `pnpm test:docker:kitchen-sink-plugin` — all 7 packaged install/uninstall/cutover scenarios passed
- Same Testbox: `pnpm check:changed` — core production/test typechecks, lint, formatting, architecture, schema, and guard lanes passed
- `git diff --check` — passed
- Codex autoreview — clean, no accepted/actionable findings
