### PR TITLE
fix(openai): transient network errors no longer abort the 15-minute device-code auth flow

### DIFF
--- a/extensions/openai/openai-chatgpt-device-code.ts
+++ b/extensions/openai/openai-chatgpt-device-code.ts
@@ -299,11 +299,11 @@ async function pollOpenAICodexDeviceCode(params: {
       });
     } catch (error) {
       rethrowIfDeviceCodeCallerAborted(params.signal, error);
-      // A stalled poll is transient; keep the overall 15-minute authorization deadline.
-      if (isDeviceCodeOperationTimeoutError(error)) {
-        continue;
-      }
-      throw error;
+      // Any transient network error (DNS resolution failure, socket hangup,
+      // timeout, SSRF guard interrupt, etc.) should not abort the 15-minute
+      // authorization flow. The deadline above bounds retry and prevents
+      // infinite loops.
+      continue;
     }
 
     if (result.ok) {


### PR DESCRIPTION
Closes #114086

AI-assisted PR (Claude Fable 5).

## What Problem This Solves

Fixes an issue where users authorizing via OpenAI Codex device code would see the entire 15-minute OAuth flow aborted if a transient network error (DNS resolution failure, socket hangup, SSRF guard interrupt, etc.) occurred during polling. The flow only retried on `TimeoutError` and `AbortError`, treating all other transient errors as fatal.

## Why This Change Was Made

The polling loop already has a 15-minute deadline that bounds retry and guarantees termination. There is no need to distinguish error types—any transient network error during this bounded window should be retried.

Changed the catch block to unconditionally `continue` instead of checking `isDeviceCodeOperationTimeoutError`. The `rethrowIfDeviceCodeCallerAborted` guard remains in place to respect user-initiated cancellation.

## User Impact

Users no longer need to restart the entire Codex device authorization flow when a brief network hiccup occurs during the polling phase. The flow transparently retries until the user completes authorization or the 15-minute deadline elapses.

## Evidence

- 15/15 unit tests pass for `openai-chatgpt-device-code.test.ts`
- `extension-provider-openai` suite: 484/487 passed — 3 failures are pre-existing (Node/SQLite version incompatibility and a 1ms timing edge case in video-generation-provider tests)
- Fix is a 5-line simplification (removed conditional + throw, added unconditional continue)

## AI-Assisted

- [x] AI-assisted (Claude Fable 5 via Claude Code CLI)
- [x] Confirmed understanding of the code change
- [x] Ran existing tests