### PR TITLE
fix(openai): retry transient Codex device polling failures

### DIFF
--- a/extensions/openai/openai-chatgpt-device-code.test.ts
+++ b/extensions/openai/openai-chatgpt-device-code.test.ts
@@ -18,6 +18,33 @@ function createJsonResponse(body: unknown, init?: { status?: number }) {
   });
 }
 
+function createDeviceCodeResponse(interval = "0") {
+  return createJsonResponse({
+    device_auth_id: "device-auth-123",
+    user_code: "CODE-12345",
+    interval,
+  });
+}
+
+function createAuthorizationResponse() {
+  return createJsonResponse({
+    authorization_code: "authorization-code-123",
+    code_verifier: "code-verifier-123",
+  });
+}
+
+function createCredentialsResponse(accessToken: string) {
+  return createJsonResponse({
+    access_token: accessToken,
+    refresh_token: "refresh-token-123",
+    expires_in: 600,
+  });
+}
+
+function resolveRequestUrl(input: RequestInfo | URL): string {
+  return typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+}
+
 function cancelTrackedResponse(
   text: string,
   init: ResponseInit,
@@ -295,46 +322,132 @@ describe("loginOpenAICodexDeviceCode", () => {
     });
     let pollAttempts = 0;
     const fetchMock = vi.fn<typeof fetch>(async (input, init) => {
-      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      const url = resolveRequestUrl(input);
       if (url.endsWith("/api/accounts/deviceauth/usercode")) {
-        return createJsonResponse({
-          device_auth_id: "device-auth-123",
-          user_code: "CODE-12345",
-          interval: "0",
-        });
+        return createDeviceCodeResponse();
       }
       if (url.endsWith("/api/accounts/deviceauth/token")) {
         pollAttempts += 1;
         if (pollAttempts === 1) {
           return await waitForFetchAbort(init);
         }
-        return createJsonResponse({
-          authorization_code: "authorization-code-123",
-          code_verifier: "code-verifier-123",
-        });
+        return createAuthorizationResponse();
       }
       if (url.endsWith("/oauth/token")) {
-        return createJsonResponse({
-          access_token: accessToken,
-          refresh_token: "refresh-token-123",
-          expires_in: 600,
-        });
+        return createCredentialsResponse(accessToken);
       }
       throw new Error(`unexpected OpenAI device-code URL: ${url}`);
     });
 
-    const login = loginOpenAICodexDeviceCode({
-      fetchFn: fetchMock,
-      onVerification: async () => {},
-    });
-    await vi.advanceTimersByTimeAsync(0);
-    expect(pollAttempts).toBe(1);
+    try {
+      const login = loginOpenAICodexDeviceCode({
+        fetchFn: fetchMock,
+        onVerification: async () => {},
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      expect(pollAttempts).toBe(1);
+      await vi.advanceTimersToNextTimerAsync();
+      expect(pollAttempts).toBe(1);
 
-    const resolved = expect(login).resolves.toMatchObject({ refresh: "refresh-token-123" });
-    await vi.advanceTimersByTimeAsync(30_000);
-    await resolved;
-    expect(pollAttempts).toBe(2);
-    expect(fetchMock).toHaveBeenCalledTimes(4);
+      const resolved = expect(login).resolves.toMatchObject({ refresh: "refresh-token-123" });
+      await vi.advanceTimersToNextTimerAsync();
+      await resolved;
+      expect(pollAttempts).toBe(2);
+      expect(fetchMock).toHaveBeenCalledTimes(4);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("retries a transient authorization poll network failure after the poll delay", async () => {
+    vi.useFakeTimers();
+    try {
+      const accessToken = createJwt({
+        exp: Math.floor(Date.now() / 1000) + 600,
+      });
+      let pollAttempts = 0;
+      const fetchMock = vi.fn<typeof fetch>(async (input) => {
+        const url = resolveRequestUrl(input);
+        if (url.endsWith("/api/accounts/deviceauth/usercode")) {
+          return createDeviceCodeResponse("2");
+        }
+        if (url.endsWith("/api/accounts/deviceauth/token")) {
+          pollAttempts += 1;
+          if (pollAttempts === 1) {
+            throw new TypeError("fetch failed", {
+              cause: Object.assign(new Error("getaddrinfo ENOTFOUND auth.openai.com"), {
+                code: "ENOTFOUND",
+              }),
+            });
+          }
+          return createAuthorizationResponse();
+        }
+        if (url.endsWith("/oauth/token")) {
+          return createCredentialsResponse(accessToken);
+        }
+        throw new Error(`unexpected OpenAI device-code URL: ${url}`);
+      });
+
+      const login = loginOpenAICodexDeviceCode({
+        fetchFn: fetchMock,
+        onVerification: async () => {},
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      expect(pollAttempts).toBe(1);
+
+      const resolved = expect(login).resolves.toMatchObject({ refresh: "refresh-token-123" });
+      await vi.advanceTimersToNextTimerAsync();
+      await resolved;
+      expect(pollAttempts).toBe(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("retries transient authorization poll HTTP status responses", async () => {
+    vi.useFakeTimers();
+    try {
+      const accessToken = createJwt({
+        exp: Math.floor(Date.now() / 1000) + 600,
+      });
+      const fetchMock = vi
+        .fn<typeof fetch>()
+        .mockResolvedValueOnce(createDeviceCodeResponse("1"))
+        .mockResolvedValueOnce(new Response("slow down", { status: 429 }))
+        .mockResolvedValueOnce(new Response("bad gateway", { status: 502 }))
+        .mockResolvedValueOnce(createAuthorizationResponse())
+        .mockResolvedValueOnce(createCredentialsResponse(accessToken));
+
+      const login = loginOpenAICodexDeviceCode({
+        fetchFn: fetchMock,
+        onVerification: async () => {},
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      await vi.advanceTimersToNextTimerAsync();
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+
+      const resolved = expect(login).resolves.toMatchObject({ refresh: "refresh-token-123" });
+      await vi.advanceTimersToNextTimerAsync();
+      await resolved;
+      expect(fetchMock).toHaveBeenCalledTimes(5);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("still surfaces local authorization poll errors that are not transport failures", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(createDeviceCodeResponse())
+      .mockRejectedValueOnce(new TypeError("undefined is not a function"));
+
+    await expect(
+      loginOpenAICodexDeviceCode({
+        fetchFn: fetchMock,
+        onVerification: async () => {},
+      }),
+    ).rejects.toThrow("undefined is not a function");
   });
 
   it("aborts device-code polling without another request", async () => {

--- a/extensions/openai/openai-chatgpt-device-code.test.ts
+++ b/extensions/openai/openai-chatgpt-device-code.test.ts
@@ -18,33 +18,6 @@ function createJsonResponse(body: unknown, init?: { status?: number }) {
   });
 }
 
-function createDeviceCodeResponse(interval = "0") {
-  return createJsonResponse({
-    device_auth_id: "device-auth-123",
-    user_code: "CODE-12345",
-    interval,
-  });
-}
-
-function createAuthorizationResponse() {
-  return createJsonResponse({
-    authorization_code: "authorization-code-123",
-    code_verifier: "code-verifier-123",
-  });
-}
-
-function createCredentialsResponse(accessToken: string) {
-  return createJsonResponse({
-    access_token: accessToken,
-    refresh_token: "refresh-token-123",
-    expires_in: 600,
-  });
-}
-
-function resolveRequestUrl(input: RequestInfo | URL): string {
-  return typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
-}
-
 function cancelTrackedResponse(
   text: string,
   init: ResponseInit,
@@ -322,41 +295,46 @@ describe("loginOpenAICodexDeviceCode", () => {
     });
     let pollAttempts = 0;
     const fetchMock = vi.fn<typeof fetch>(async (input, init) => {
-      const url = resolveRequestUrl(input);
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
       if (url.endsWith("/api/accounts/deviceauth/usercode")) {
-        return createDeviceCodeResponse();
+        return createJsonResponse({
+          device_auth_id: "device-auth-123",
+          user_code: "CODE-12345",
+          interval: "0",
+        });
       }
       if (url.endsWith("/api/accounts/deviceauth/token")) {
         pollAttempts += 1;
         if (pollAttempts === 1) {
           return await waitForFetchAbort(init);
         }
-        return createAuthorizationResponse();
+        return createJsonResponse({
+          authorization_code: "authorization-code-123",
+          code_verifier: "code-verifier-123",
+        });
       }
       if (url.endsWith("/oauth/token")) {
-        return createCredentialsResponse(accessToken);
+        return createJsonResponse({
+          access_token: accessToken,
+          refresh_token: "refresh-token-123",
+          expires_in: 600,
+        });
       }
       throw new Error(`unexpected OpenAI device-code URL: ${url}`);
     });
 
-    try {
-      const login = loginOpenAICodexDeviceCode({
-        fetchFn: fetchMock,
-        onVerification: async () => {},
-      });
-      await vi.advanceTimersByTimeAsync(0);
-      expect(pollAttempts).toBe(1);
-      await vi.advanceTimersToNextTimerAsync();
-      expect(pollAttempts).toBe(1);
+    const login = loginOpenAICodexDeviceCode({
+      fetchFn: fetchMock,
+      onVerification: async () => {},
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(pollAttempts).toBe(1);
 
-      const resolved = expect(login).resolves.toMatchObject({ refresh: "refresh-token-123" });
-      await vi.advanceTimersToNextTimerAsync();
-      await resolved;
-      expect(pollAttempts).toBe(2);
-      expect(fetchMock).toHaveBeenCalledTimes(4);
-    } finally {
-      vi.useRealTimers();
-    }
+    const resolved = expect(login).resolves.toMatchObject({ refresh: "refresh-token-123" });
+    await vi.advanceTimersByTimeAsync(30_000);
+    await resolved;
+    expect(pollAttempts).toBe(2);
+    expect(fetchMock).toHaveBeenCalledTimes(4);
   });
 
   it("retries a transient authorization poll network failure after the poll delay", async () => {
@@ -365,58 +343,35 @@ describe("loginOpenAICodexDeviceCode", () => {
       const accessToken = createJwt({
         exp: Math.floor(Date.now() / 1000) + 600,
       });
-      let pollAttempts = 0;
-      const fetchMock = vi.fn<typeof fetch>(async (input) => {
-        const url = resolveRequestUrl(input);
-        if (url.endsWith("/api/accounts/deviceauth/usercode")) {
-          return createDeviceCodeResponse("2");
-        }
-        if (url.endsWith("/api/accounts/deviceauth/token")) {
-          pollAttempts += 1;
-          if (pollAttempts === 1) {
-            throw new TypeError("fetch failed", {
-              cause: Object.assign(new Error("getaddrinfo ENOTFOUND auth.openai.com"), {
-                code: "ENOTFOUND",
-              }),
-            });
-          }
-          return createAuthorizationResponse();
-        }
-        if (url.endsWith("/oauth/token")) {
-          return createCredentialsResponse(accessToken);
-        }
-        throw new Error(`unexpected OpenAI device-code URL: ${url}`);
-      });
-
-      const login = loginOpenAICodexDeviceCode({
-        fetchFn: fetchMock,
-        onVerification: async () => {},
-      });
-      await vi.advanceTimersByTimeAsync(0);
-      expect(pollAttempts).toBe(1);
-
-      const resolved = expect(login).resolves.toMatchObject({ refresh: "refresh-token-123" });
-      await vi.advanceTimersToNextTimerAsync();
-      await resolved;
-      expect(pollAttempts).toBe(2);
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  it("retries transient authorization poll HTTP status responses", async () => {
-    vi.useFakeTimers();
-    try {
-      const accessToken = createJwt({
-        exp: Math.floor(Date.now() / 1000) + 600,
-      });
       const fetchMock = vi
         .fn<typeof fetch>()
-        .mockResolvedValueOnce(createDeviceCodeResponse("1"))
-        .mockResolvedValueOnce(new Response("slow down", { status: 429 }))
-        .mockResolvedValueOnce(new Response("bad gateway", { status: 502 }))
-        .mockResolvedValueOnce(createAuthorizationResponse())
-        .mockResolvedValueOnce(createCredentialsResponse(accessToken));
+        .mockResolvedValueOnce(
+          createJsonResponse({
+            device_auth_id: "device-auth-123",
+            user_code: "CODE-12345",
+            interval: "2",
+          }),
+        )
+        .mockRejectedValueOnce(
+          new TypeError("fetch failed", {
+            cause: Object.assign(new Error("getaddrinfo ENOTFOUND auth.openai.com"), {
+              code: "ENOTFOUND",
+            }),
+          }),
+        )
+        .mockResolvedValueOnce(
+          createJsonResponse({
+            authorization_code: "authorization-code-123",
+            code_verifier: "code-verifier-123",
+          }),
+        )
+        .mockResolvedValueOnce(
+          createJsonResponse({
+            access_token: accessToken,
+            refresh_token: "refresh-token-123",
+            expires_in: 600,
+          }),
+        );
 
       const login = loginOpenAICodexDeviceCode({
         fetchFn: fetchMock,
@@ -424,13 +379,13 @@ describe("loginOpenAICodexDeviceCode", () => {
       });
       await vi.advanceTimersByTimeAsync(0);
       expect(fetchMock).toHaveBeenCalledTimes(2);
-      await vi.advanceTimersToNextTimerAsync();
-      expect(fetchMock).toHaveBeenCalledTimes(3);
 
       const resolved = expect(login).resolves.toMatchObject({ refresh: "refresh-token-123" });
-      await vi.advanceTimersToNextTimerAsync();
+      await vi.advanceTimersByTimeAsync(1_999);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      await vi.advanceTimersByTimeAsync(1);
       await resolved;
-      expect(fetchMock).toHaveBeenCalledTimes(5);
+      expect(fetchMock).toHaveBeenCalledTimes(4);
     } finally {
       vi.useRealTimers();
     }
@@ -439,7 +394,13 @@ describe("loginOpenAICodexDeviceCode", () => {
   it("still surfaces local authorization poll errors that are not transport failures", async () => {
     const fetchMock = vi
       .fn<typeof fetch>()
-      .mockResolvedValueOnce(createDeviceCodeResponse())
+      .mockResolvedValueOnce(
+        createJsonResponse({
+          device_auth_id: "device-auth-123",
+          user_code: "CODE-12345",
+          interval: "0",
+        }),
+      )
       .mockRejectedValueOnce(new TypeError("undefined is not a function"));
 
     await expect(

--- a/extensions/openai/openai-chatgpt-device-code.ts
+++ b/extensions/openai/openai-chatgpt-device-code.ts
@@ -21,6 +21,10 @@ const OPENAI_CODEX_DEVICE_CODE_MIN_INTERVAL_MS = 1_000;
 const OPENAI_CODEX_DEVICE_CALLBACK_URL = `${OPENAI_AUTH_BASE_URL}/deviceauth/callback`;
 const OPENAI_CODEX_DEVICE_ERROR_BODY_LIMIT_BYTES = 8 * 1024;
 const OPENAI_CODEX_DEVICE_JSON_BODY_LIMIT_BYTES = 256 * 1024;
+const RETRYABLE_DEVICE_CODE_TRANSPORT_ERROR_CODE_RE =
+  /^(?:EAI_AGAIN|ECONNABORTED|ECONNREFUSED|ECONNRESET|EHOSTDOWN|EHOSTUNREACH|ENETRESET|ENETUNREACH|ENOTFOUND|EPIPE|ETIMEDOUT|UND_ERR_CONNECT_TIMEOUT|UND_ERR_SOCKET)$/u;
+const RETRYABLE_DEVICE_CODE_TRANSPORT_ERROR_RE =
+  /\b(?:fetch failed|network error|network request failed|socket hang up|connection (?:aborted|reset|refused|error)|network is unreachable|host is unreachable)\b/i;
 
 function resolveOpenAICodexDeviceCodeHeaders(contentType: string): Record<string, string> {
   const version = process.env.OPENCLAW_VERSION?.trim();
@@ -119,6 +123,44 @@ function resolveDeviceCodePollRequestTimeoutMs(deadlineMs: number): number {
 
 function isDeviceCodeOperationTimeoutError(error: unknown): boolean {
   return error instanceof Error && (error.name === "TimeoutError" || error.name === "AbortError");
+}
+
+function readErrorCode(error: unknown): string | undefined {
+  if (!error || typeof error !== "object" || !("code" in error)) {
+    return undefined;
+  }
+  const code = (error as { code?: unknown }).code;
+  return typeof code === "string" ? code.toUpperCase() : undefined;
+}
+
+function isRetryableDeviceCodePollTransportError(
+  error: unknown,
+  visited = new Set<unknown>(),
+): boolean {
+  if (!error || visited.has(error)) {
+    return false;
+  }
+  visited.add(error);
+
+  const code = readErrorCode(error);
+  if (code && RETRYABLE_DEVICE_CODE_TRANSPORT_ERROR_CODE_RE.test(code)) {
+    return true;
+  }
+
+  if (error instanceof Error) {
+    if (RETRYABLE_DEVICE_CODE_TRANSPORT_ERROR_RE.test(error.message)) {
+      return true;
+    }
+    if (isRetryableDeviceCodePollTransportError(error.cause, visited)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function isRetryableDeviceCodePollStatus(status: number): boolean {
+  return status === 408 || status === 429 || (status >= 500 && status < 600);
 }
 
 function rethrowIfDeviceCodeCallerAborted(signal: AbortSignal | undefined, error: unknown): void {
@@ -299,8 +341,14 @@ async function pollOpenAICodexDeviceCode(params: {
       });
     } catch (error) {
       rethrowIfDeviceCodeCallerAborted(params.signal, error);
-      // A stalled poll is transient; keep the overall 15-minute authorization deadline.
-      if (isDeviceCodeOperationTimeoutError(error)) {
+      if (
+        isDeviceCodeOperationTimeoutError(error) ||
+        isRetryableDeviceCodePollTransportError(error)
+      ) {
+        await waitForDeviceCodePoll(
+          resolveNextDeviceCodePollDelayMs(params.intervalMs, deadline),
+          params.signal,
+        );
         continue;
       }
       throw error;
@@ -320,6 +368,14 @@ async function pollOpenAICodexDeviceCode(params: {
     }
 
     if (result.status === 403 || result.status === 404) {
+      await waitForDeviceCodePoll(
+        resolveNextDeviceCodePollDelayMs(params.intervalMs, deadline),
+        params.signal,
+      );
+      continue;
+    }
+
+    if (isRetryableDeviceCodePollStatus(result.status)) {
       await waitForDeviceCodePoll(
         resolveNextDeviceCodePollDelayMs(params.intervalMs, deadline),
         params.signal,

--- a/extensions/openai/openai-chatgpt-device-code.ts
+++ b/extensions/openai/openai-chatgpt-device-code.ts
@@ -1,3 +1,4 @@
+import { collectErrorGraphCandidates, extractErrorCode } from "openclaw/plugin-sdk/error-runtime";
 // Openai plugin module implements openai chatgpt device code behavior.
 import {
   shouldUseEnvHttpProxyForUrl,
@@ -8,6 +9,7 @@ import {
   resolveExpiresAtMsFromDurationSeconds,
 } from "openclaw/plugin-sdk/number-runtime";
 import { readResponseTextLimited } from "openclaw/plugin-sdk/provider-http";
+import { classifyTransientNetworkErrorCode } from "openclaw/plugin-sdk/retry-runtime";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import { resolveCodexAccessTokenExpiry } from "./openai-chatgpt-auth-identity.js";
 import { trimNonEmptyString } from "./openai-chatgpt-shared.js";
@@ -21,10 +23,6 @@ const OPENAI_CODEX_DEVICE_CODE_MIN_INTERVAL_MS = 1_000;
 const OPENAI_CODEX_DEVICE_CALLBACK_URL = `${OPENAI_AUTH_BASE_URL}/deviceauth/callback`;
 const OPENAI_CODEX_DEVICE_ERROR_BODY_LIMIT_BYTES = 8 * 1024;
 const OPENAI_CODEX_DEVICE_JSON_BODY_LIMIT_BYTES = 256 * 1024;
-const RETRYABLE_DEVICE_CODE_TRANSPORT_ERROR_CODE_RE =
-  /^(?:EAI_AGAIN|ECONNABORTED|ECONNREFUSED|ECONNRESET|EHOSTDOWN|EHOSTUNREACH|ENETRESET|ENETUNREACH|ENOTFOUND|EPIPE|ETIMEDOUT|UND_ERR_CONNECT_TIMEOUT|UND_ERR_SOCKET)$/u;
-const RETRYABLE_DEVICE_CODE_TRANSPORT_ERROR_RE =
-  /\b(?:fetch failed|network error|network request failed|socket hang up|connection (?:aborted|reset|refused|error)|network is unreachable|host is unreachable)\b/i;
 
 function resolveOpenAICodexDeviceCodeHeaders(contentType: string): Record<string, string> {
   const version = process.env.OPENCLAW_VERSION?.trim();
@@ -123,44 +121,6 @@ function resolveDeviceCodePollRequestTimeoutMs(deadlineMs: number): number {
 
 function isDeviceCodeOperationTimeoutError(error: unknown): boolean {
   return error instanceof Error && (error.name === "TimeoutError" || error.name === "AbortError");
-}
-
-function readErrorCode(error: unknown): string | undefined {
-  if (!error || typeof error !== "object" || !("code" in error)) {
-    return undefined;
-  }
-  const code = (error as { code?: unknown }).code;
-  return typeof code === "string" ? code.toUpperCase() : undefined;
-}
-
-function isRetryableDeviceCodePollTransportError(
-  error: unknown,
-  visited = new Set<unknown>(),
-): boolean {
-  if (!error || visited.has(error)) {
-    return false;
-  }
-  visited.add(error);
-
-  const code = readErrorCode(error);
-  if (code && RETRYABLE_DEVICE_CODE_TRANSPORT_ERROR_CODE_RE.test(code)) {
-    return true;
-  }
-
-  if (error instanceof Error) {
-    if (RETRYABLE_DEVICE_CODE_TRANSPORT_ERROR_RE.test(error.message)) {
-      return true;
-    }
-    if (isRetryableDeviceCodePollTransportError(error.cause, visited)) {
-      return true;
-    }
-  }
-
-  return false;
-}
-
-function isRetryableDeviceCodePollStatus(status: number): boolean {
-  return status === 408 || status === 429 || (status >= 500 && status < 600);
 }
 
 function rethrowIfDeviceCodeCallerAborted(signal: AbortSignal | undefined, error: unknown): void {
@@ -341,17 +301,22 @@ async function pollOpenAICodexDeviceCode(params: {
       });
     } catch (error) {
       rethrowIfDeviceCodeCallerAborted(params.signal, error);
-      if (
-        isDeviceCodeOperationTimeoutError(error) ||
-        isRetryableDeviceCodePollTransportError(error)
-      ) {
-        await waitForDeviceCodePoll(
-          resolveNextDeviceCodePollDelayMs(params.intervalMs, deadline),
-          params.signal,
-        );
+      if (isDeviceCodeOperationTimeoutError(error)) {
         continue;
       }
-      throw error;
+      const retryableTransportError = collectErrorGraphCandidates(error, (candidate) => [
+        candidate.cause,
+      ]).some(
+        (candidate) => classifyTransientNetworkErrorCode(extractErrorCode(candidate)) !== undefined,
+      );
+      if (!retryableTransportError) {
+        throw error;
+      }
+      await waitForDeviceCodePoll(
+        resolveNextDeviceCodePollDelayMs(params.intervalMs, deadline),
+        params.signal,
+      );
+      continue;
     }
 
     if (result.ok) {
@@ -368,14 +333,6 @@ async function pollOpenAICodexDeviceCode(params: {
     }
 
     if (result.status === 403 || result.status === 404) {
-      await waitForDeviceCodePoll(
-        resolveNextDeviceCodePollDelayMs(params.intervalMs, deadline),
-        params.signal,
-      );
-      continue;
-    }
-
-    if (isRetryableDeviceCodePollStatus(result.status)) {
       await waitForDeviceCodePoll(
         resolveNextDeviceCodePollDelayMs(params.intervalMs, deadline),
         params.signal,


### PR DESCRIPTION
Closes #114086

## What Problem This Solves

Fixes an issue where a transient DNS, connection, or socket failure during OpenAI Codex device-code polling would abort the active authorization session and force the user to start over.

## Why This Change Was Made

The polling owner now retries only structured transient transport failures recognized by the existing plugin SDK classifier, waiting for the provider's polling interval and staying within the existing 15-minute deadline. Caller cancellation, SSRF-policy failures, malformed success responses, and non-pending HTTP statuses remain terminal. This matches upstream Codex's HTTP contract, where only `403` and `404` are pending responses.

The maintainer rewrite deliberately removes the contributor branch's catch-all message matching and its proposed `408`/`429`/`5xx` retry expansion. Those policies were not present on `main` and are not part of upstream Codex's device-poll contract.

## User Impact

A brief classified network interruption no longer destroys an otherwise valid OpenAI device-code login session. Invalid authorization responses and explicit cancellation still fail promptly.

## Evidence

- Current-main source probe at `00175666189e` rejected a nested `ENOTFOUND` after exactly one poll.
- `node scripts/run-vitest.mjs extensions/openai/openai-chatgpt-device-code.test.ts` — 17/17 passed.
- The regression test proves no retry before the two-second provider interval, then successful completion in the same session.
- Existing focused coverage proves caller cancellation and terminal HTTP `401` remain immediate failures.
- `git diff --check` — passed.
- Exact-head CI for `c46a5202b91c50de90787f1afe98ad9adca8d049` — green: https://github.com/openclaw/openclaw/actions/runs/30246892586
- Independent adversarial refuter: `NO-ACTIONABLE-OBJECTION`.
- Codex autoreview: no accepted/actionable findings.

A live OpenAI login cannot deterministically inject a transport failure into the polling request without an interception harness, so this does not claim live provider fault-injection proof. The maintainer accepts that bounded proof gap based on the exact runtime-boundary probe, focused regression coverage, and direct upstream contract inspection.

## Credit

Original approaches and test work by @lanyoung and @LeonidasLux; both are retained as co-authors in the maintainer rewrite.

## AI-Assisted

- [x] AI-assisted changes were reviewed and rewritten by a maintainer-side Codex worker.
- [x] The final behavior, upstream contract, focused tests, and exact-head CI were independently checked.
