### PR TITLE
test(memory): mock admitted search sync

### DIFF
--- a/extensions/memory-core/src/memory/manager.async-search.test.ts
+++ b/extensions/memory-core/src/memory/manager.async-search.test.ts
@@ -55,7 +55,7 @@ describe("memory search async sync", () => {
       assertRequiredProviderAvailable: vi.fn(),
       dirty: true,
       sessionsDirty: false,
-      sync: syncMock,
+      syncAdmitted: syncMock,
       provider: null,
       providerLifecycle: { mode: "fts-only", reason: "test" },
       refreshIndexIdentityDirty: () => ({ status: "valid" }),


### PR DESCRIPTION
Related: #113471

## What Problem This Solves

Fixes a release-blocking test failure where the memory async-search test still mocked the public sync wrapper after search synchronization moved to the admitted lifecycle method.

## Why This Change Was Made

The test double now intercepts the same private admitted sync entry point that production search invokes. Runtime behavior is unchanged; this restores the test's intended assertion that dirty search waits for synchronization before querying.

## User Impact

No runtime behavior change. Plugin prerelease validation can again verify the existing dirty-search synchronization contract.

AI-assisted implementation and review.

## Evidence

- `mise x node@24.18.0 -- node scripts/run-vitest.mjs extensions/memory-core/src/memory/manager.async-search.test.ts` — 7 tests passed
- Blacksmith Testbox `tbx_01kyf2c005pk4pkyhngka6zbnb`, Actions run `30199886532`: extension test typecheck, lint, formatting, and changed-scope guards passed
- `git diff --check` — passed
- Codex autoreview — clean, no accepted/actionable findings
