### PR TITLE
fix(config): preserve authorized agent deletions

### DIFF
--- a/src/config/io.runtime.ts
+++ b/src/config/io.runtime.ts
@@ -291,6 +291,7 @@ export async function writeConfigFile(
     explicitSetValueSource: options.explicitSetPaths
       ? (options.explicitSetValueSource ?? cfg)
       : undefined,
+    allowedAgentRosterRemovals: options.allowedAgentRosterRemovals,
     allowIncludeAncestorExplicitSetPaths: options.allowIncludeAncestorExplicitSetPaths,
     afterWrite: options.afterWrite,
     allowDestructiveWrite: options.allowDestructiveWrite,

--- a/src/config/io.write-config.test.ts
+++ b/src/config/io.write-config.test.ts
@@ -1608,6 +1608,54 @@ describe("config io write", () => {
     });
   });
 
+  it("forwards explicitly authorized agent roster removals", async () => {
+    await withSuiteHome(async (home) => {
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      await fs.writeFile(
+        configPath,
+        `${JSON.stringify(
+          {
+            agents: {
+              entries: {
+                main: { default: true, workspace: "/srv/shared" },
+                ops: { workspace: "/srv/shared" },
+              },
+            },
+          },
+          null,
+          2,
+        )}\n`,
+        "utf-8",
+      );
+
+      await withEnvAsync(
+        {
+          OPENCLAW_CONFIG_PATH: configPath,
+          OPENCLAW_TEST_FAST: "1",
+        },
+        async () => {
+          await writeConfigFile(
+            {
+              agents: {
+                entries: { main: { default: true, workspace: "/srv/shared" } },
+              },
+            },
+            {
+              allowedAgentRosterRemovals: ["ops"],
+              skipRuntimeSnapshotRefresh: true,
+            },
+          );
+        },
+      );
+
+      const persisted = JSON.parse(await fs.readFile(configPath, "utf-8")) as OpenClawConfig;
+      expect(persisted.agents?.entries).toEqual({
+        main: { default: true, workspace: "/srv/shared" },
+      });
+    });
+  });
+
   it("assigns distinct snapshot hashes to missing and empty root config", async () => {
     await withSuiteHome(async (home) => {
       const configPath = path.join(home, ".openclaw", "openclaw.json");


### PR DESCRIPTION
Related: #114054

## What Problem This Solves

Fixes an issue where `openclaw agents delete <id>` could fail with `Config write would drop agent roster entries without an explicit deletion` even though the delete command explicitly authorized that agent removal.

## Why This Change Was Made

The public config writer now forwards the existing `allowedAgentRosterRemovals` option to the underlying IO owner. The roster-loss guard remains unchanged and still rejects every deletion not named by the caller.

## User Impact

Explicit agent deletion works again while silent or unrelated roster loss remains blocked.

AI-assisted implementation and review.

## Evidence

- `mise x node@24.18.0 -- node scripts/run-vitest.mjs src/config/io.write-config.test.ts` — 79 tests passed
- Blacksmith Testbox `tbx_01kyf5e4f3b0enge89fw8e2ndt`, Actions run `30201600648`: `pnpm test:docker:agents-delete-shared-workspace` — passed
- Same Testbox: `pnpm check:changed` — core production/test typechecks, lint, formatting, architecture, schema, and guards passed
- `git diff --check` — passed
- Codex autoreview — clean, no accepted/actionable findings
