### PR TITLE
fix(release): retain workflow ref after failed validation

### DIFF
--- a/scripts/full-release-validation-at-sha.d.mts
+++ b/scripts/full-release-validation-at-sha.d.mts
@@ -18,6 +18,11 @@ export function releaseProfileForTarget(
   readPackageJson?: (sha: string) => string,
 ): "beta" | "stable";
 export function releaseEvidenceVerificationArgs(parentRunId: unknown): string[];
+export function shouldDeleteTemporaryWorkflowRef(params: {
+  keepBranch: boolean;
+  dryRun: boolean;
+  parentConclusion: string;
+}): boolean;
 export function releaseEvidenceVerifierPath(worktreeRoot: unknown): string;
 export function resolveRemoteTargetRefSha(
   targetRef: string,

--- a/scripts/full-release-validation-at-sha.mjs
+++ b/scripts/full-release-validation-at-sha.mjs
@@ -319,6 +319,10 @@ export function releaseEvidenceVerificationArgs(parentRunId) {
   return ["--validate-run", String(parentRunId), "--trusted-workflow-ref", "main", "--json"];
 }
 
+export function shouldDeleteTemporaryWorkflowRef(params) {
+  return !params.keepBranch && (params.dryRun || params.parentConclusion === "success");
+}
+
 export function releaseEvidenceVerifierPath(worktreeRoot) {
   const candidates = [
     join(worktreeRoot, "scripts", "release-ci-summary.mjs"),
@@ -388,6 +392,7 @@ function main() {
   });
 
   let parentRunId;
+  let parentConclusion = "";
   try {
     const dispatchArgs = ["workflow", "run", WORKFLOW, "--ref", branch];
     for (const [key, value] of Object.entries(dispatchInputs)) {
@@ -416,16 +421,32 @@ function main() {
     }
 
     console.log(`Parent run: https://github.com/openclaw/openclaw/actions/runs/${parentRunId}`);
-    waitForWorkflowRun(parentRunId, workflowSha);
+    const completedRun = waitForWorkflowRun(parentRunId, workflowSha);
+    parentConclusion = String(completedRun.conclusion ?? "");
+    if (parentConclusion !== "success") {
+      throw new Error(
+        `Full Release Validation concluded ${parentConclusion.toLowerCase() || "without a conclusion"}: https://github.com/openclaw/openclaw/actions/runs/${parentRunId}`,
+      );
+    }
     verifyReleaseEvidence(parentRunId, workflowSha);
   } finally {
-    if (!args.keepBranch) {
+    if (
+      shouldDeleteTemporaryWorkflowRef({
+        keepBranch: args.keepBranch,
+        dryRun: args.dryRun,
+        parentConclusion,
+      })
+    ) {
       run("git", ["push", "origin", `:${remoteBranchRef}`], {
         dryRun: args.dryRun,
         stdio: "inherit",
       });
     } else {
-      console.log(`Kept ${remoteBranchRef}`);
+      console.warn(
+        args.keepBranch
+          ? `Kept ${remoteBranchRef}`
+          : `Kept ${remoteBranchRef}: parent concluded ${parentConclusion || "without a conclusion"}. Keep it through any GitHub reruns; delete it after a successful parent attempt.`,
+      );
     }
   }
 }

--- a/test/scripts/full-release-validation-at-sha.test.ts
+++ b/test/scripts/full-release-validation-at-sha.test.ts
@@ -8,6 +8,7 @@ import {
   releaseEvidenceVerificationArgs,
   releaseEvidenceVerifierPath,
   resolveRemoteTargetRefSha,
+  shouldDeleteTemporaryWorkflowRef,
 } from "../../scripts/full-release-validation-at-sha.mjs";
 
 describe("full-release-validation-at-sha", () => {
@@ -153,6 +154,30 @@ describe("full-release-validation-at-sha", () => {
     expect(source).toContain("workflowRun.head_sha !== workflowSha");
     expect(source).not.toContain('"graphql"');
     expect(source).not.toContain('["run", "watch"');
+  });
+
+  it("retains a failed parent workflow ref for GitHub reruns", () => {
+    expect(
+      shouldDeleteTemporaryWorkflowRef({
+        dryRun: false,
+        keepBranch: false,
+        parentConclusion: "failure",
+      }),
+    ).toBe(false);
+    expect(
+      shouldDeleteTemporaryWorkflowRef({
+        dryRun: false,
+        keepBranch: false,
+        parentConclusion: "success",
+      }),
+    ).toBe(true);
+    expect(
+      shouldDeleteTemporaryWorkflowRef({
+        dryRun: true,
+        keepBranch: false,
+        parentConclusion: "",
+      }),
+    ).toBe(true);
   });
 
   it("supports current and legacy verifier locations in trusted workflow checkouts", () => {


### PR DESCRIPTION
## Summary

Keep a SHA-pinned `release-ci/*` workflow ref when Full Release Validation ends unsuccessfully, so GitHub Actions failed-job reruns can dispatch child workflows from the same immutable source. Delete it only after a successful parent attempt.

## Evidence

- Reproduced: Full Release Validation run 30187866615 attempt 2 failed before candidate CI because its deleted workflow ref returned GitHub API 422.
- Focused lifecycle predicate probe passed.
- Autoreview passed with no actionable findings.

## Release impact

Harness-only fix; candidate `1d1f9a2a16e845bc44552ad502f84f37015ffa45` remains unchanged.