### PR TITLE
fix(release): use trusted harness pnpm pin

### DIFF
--- a/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
+++ b/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
@@ -1990,11 +1990,10 @@ jobs:
 
       - name: Setup artifact package validation environment
         if: steps.plan.outputs.needs_package == '1' && inputs.package_artifact_id != ''
-        uses: ./.release-harness/.github/actions/setup-node-env
+        uses: ./.release-harness/.github/actions/setup-pnpm-store-cache
         with:
           node-version: ${{ env.NODE_VERSION }}
-          install-bun: "false"
-          install-deps: "false"
+          package-manager-file: .release-harness/package.json
           use-actions-cache: "false"
 
       - name: Install trusted package validation dependencies

--- a/test/scripts/release-no-push-workflow.test.ts
+++ b/test/scripts/release-no-push-workflow.test.ts
@@ -668,8 +668,9 @@ describe("release validation no-push transport", () => {
     const validatePackage = step(dockerProducer, "Validate OpenClaw Docker E2E package");
     expect(step(dockerProducer, "Setup artifact package validation environment")).toMatchObject({
       if: "steps.plan.outputs.needs_package == '1' && inputs.package_artifact_id != ''",
+      uses: "./.release-harness/.github/actions/setup-pnpm-store-cache",
       with: {
-        "install-deps": "false",
+        "package-manager-file": ".release-harness/package.json",
         "use-actions-cache": "false",
       },
     });


### PR DESCRIPTION
## Summary

When package validation uses a nested trusted release harness, initialize pnpm from that harness’s `package.json` rather than from the frozen candidate root. This prevents a legitimate historical candidate pnpm pin from conflicting with the trusted harness install.

## Reproduction

Full Release Validation `30187866615`, attempt 3, Plugin Prerelease Docker preparation: Corepack activated the candidate’s pnpm 11.2.2, then `pnpm --dir .release-harness install` correctly rejected it because the trusted harness requires 11.15.1.

## Evidence

- Exact source probe confirms the trusted harness pin is selected.
- Workflow regression assertion updated.
- `git diff --check` and autoreview clean.

Harness-only; release candidate unchanged.