### PR TITLE
docs: clarify Control UI pairing in private browsing (issue #113000)

### DIFF
--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -88,6 +88,7 @@ Once approved, the device is remembered and won't require re-approval unless you
 - Tailscale Serve can skip the pairing round trip for Control UI operator sessions when `gateway.auth.allowTailscale: true`, Tailscale identity verifies, and the browser presents its device identity. Device-less browsers and node-role connections still follow the normal device checks.
 - Direct Tailnet binds and LAN browser connects still require explicit approval. Browser profiles without device identity cannot use loopback auto-approval.
 - Each browser profile generates a unique device ID, so switching browsers or clearing browser data requires re-pairing.
+- Private windows and browser profiles that discard site data on exit, including Firefox Never remember history, also discard the stored device identity and per-device token. They will appear as a new browser after each restart; use a persistent browser profile to stay paired, and remove stale entries with `openclaw devices remove <deviceId>` when the paired-device list grows.
 
 </Note>
 


### PR DESCRIPTION
﻿Closes #113000

## What Problem This Solves
Fixes an issue where users browsing the Control UI in Firefox private modes or other profiles that clear site data on exit would lose their browser identity after every restart and accumulate new trusted device entries.

## Why This Change Was Made
The Control UI docs now call out that persistent device pairing depends on a browser profile that keeps site data. The note points users to a persistent profile for stable pairing and to `openclaw devices remove <deviceId>` when they need to clean up stale paired entries.

## User Impact
Users can tell why Firefox Never remember history behaves like a fresh browser on every launch, and they have a direct CLI path for removing old entries instead of guessing at the cause.

## Evidence
- `pnpm docs:list`
- `node scripts/check-docs-mdx.mjs docs/web/control-ui.md`
- `git diff --check`
- `trufflehog filesystem docs/web/control-ui.md --json --no-update --only-verified` -> no verified or unverified secrets
- autoreview attempted, but the bundled TruffleHog Git scan fails on this Windows checkout with a file-URI parsing bug before model review starts
