### PR TITLE
fix(cron): stop retrying permanent billing errors returned as HTTP 429

### DIFF
--- a/src/cron/retry-hint.test.ts
+++ b/src/cron/retry-hint.test.ts
@@ -20,6 +20,15 @@ describe("resolveCronExecutionRetryHint", () => {
     ).toEqual({ retryable: true, category: "rate_limit" });
   });
 
+  it("does not let transient error text override a permanent provider classification", () => {
+    expect(
+      resolveCronExecutionRetryHint({
+        error: "HTTP 429: all available credits have been exhausted",
+        classifiedReason: "billing",
+      }),
+    ).toEqual({ retryable: false });
+  });
+
   it("treats common network error codes as network when retryOn only includes network", () => {
     for (const code of [
       "EAI_AGAIN",

--- a/src/cron/retry-hint.ts
+++ b/src/cron/retry-hint.ts
@@ -1,3 +1,5 @@
+import type { FailoverReason } from "../agents/embedded-agent-helpers/types.js";
+
 /** Classifies cron run failures for retry policy decisions. */
 export type CronRetryOn = "rate_limit" | "overloaded" | "network" | "timeout" | "server_error";
 
@@ -10,7 +12,7 @@ type CronRetryHint = {
 type CronRetryHintInput = {
   error: string | undefined;
   retryOn?: CronRetryOn[];
-  classifiedReason?: string | null;
+  classifiedReason?: FailoverReason | null;
   executionStarted?: boolean;
 };
 
@@ -56,9 +58,12 @@ export function resolveCronExecutionRetryHint(input: CronRetryHintInput): CronRe
   }
   const keys = retryOn?.length ? retryOn : (Object.keys(TRANSIENT_PATTERNS) as CronRetryOn[]);
   const classified = classifiedReason ?? undefined;
-  if (classified && keys.includes(classified as CronRetryOn)) {
-    // Structured provider classifications win over brittle message regexes when allowed.
-    return { retryable: true, category: classified as CronRetryOn };
+  if (classified) {
+    // Structured provider classifications are authoritative. Falling through
+    // would let incidental transient text override a permanent reason.
+    return keys.includes(classified as CronRetryOn)
+      ? { retryable: true, category: classified as CronRetryOn }
+      : { retryable: false };
   }
   for (const key of keys) {
     if (TRANSIENT_PATTERNS[key]?.test(error)) {

--- a/src/cron/service/timer-trigger.test.ts
+++ b/src/cron/service/timer-trigger.test.ts
@@ -1,0 +1,34 @@
+// Retry-decision tests preserve provider classifications before cron message matching.
+import { describe, expect, it } from "vitest";
+import { resolveTransientCronRetryDecision } from "./timer-trigger.js";
+
+describe("resolveTransientCronRetryDecision", () => {
+  it("keeps permanent-looking and transient provider classifications distinct", () => {
+    const error = "HTTP 429: all available credits have been exhausted";
+
+    expect(
+      resolveTransientCronRetryDecision({
+        error,
+        errorClassification: { kind: "reason", reason: "billing" },
+        consecutiveErrors: 1,
+      }),
+    ).toEqual({
+      retryable: false,
+      consecutiveErrors: 1,
+      reason: "permanent error",
+    });
+
+    expect(
+      resolveTransientCronRetryDecision({
+        error,
+        errorClassification: { kind: "reason", reason: "rate_limit" },
+        consecutiveErrors: 1,
+      }),
+    ).toMatchObject({
+      retryable: true,
+      consecutiveErrors: 1,
+      retryCategory: "rate_limit",
+      reason: "transient retry",
+    });
+  });
+});

--- a/src/cron/service/timer-trigger.ts
+++ b/src/cron/service/timer-trigger.ts
@@ -60,7 +60,7 @@ export function resolveTransientCronRetryDecision(params: {
   cronConfig?: CronConfig;
   error: string | undefined;
   errorClassification?: CronRunErrorClassification;
-  lastErrorReason?: string;
+  lastErrorReason?: CronJob["state"]["lastErrorReason"];
   executionStarted?: boolean;
   consecutiveErrors: number | undefined;
 }): TransientCronRetryDecision {


### PR DESCRIPTION
## What Problem This Solves

Scheduled jobs treated an exhausted balance or spending limit as transient whenever the provider's permanent billing diagnostic also contained HTTP 429. That caused needless model attempts and kept unrecoverable cron work in the retry path.

## Why This Change Was Made

The provider already classifies the response before cron receives it. Cron now treats every current structured classification as authoritative: allowed transient reasons retain backoff, while all other classified reasons terminate without falling through to message regexes. This fixes the complete invariant rather than special-casing xAI or one billing string, and leaves the existing raw-text fallback for unclassified failures.

The previous PR diff was discarded because it predated later rate-limit hardening and rewrote an unrelated 40-job admission test. The new boundary test targets the retry owner directly. The latest ClawSweeper review had no `Rank-up moves:` section or patch finding; this maintainer repair accepts its stated availability boundary that provider-classified billing is terminal.

One adjacent bounded behavior remains intentionally separate: the lower-level agent-session retry classifier can make up to three raw-message retries before provider classification reaches cron. It does not own cron rescheduling and cannot consume this structured result today; unifying that inner classifier is follow-up work rather than a second behavior change in this PR.

## User Impact

Permanent provider billing failures stop after the failed scheduled run instead of being rescheduled as rate limits. Genuine provider-classified rate limits keep their existing backoff and retry behavior.

## Evidence

- Current-main failure is `src/cron/retry-hint.ts:63`: a non-transient structured reason fell through to `RATE_LIMIT_PATTERN` and became retryable from incidental 429 text.
- Fail-first command: `node scripts/run-vitest.mjs src/cron/retry-hint.test.ts src/cron/service/timer-trigger.test.ts` -> 2 failed, 11 passed. Both failures showed billing classified as `rate_limit` with a 30-second retry.
- Fixed command: `node scripts/run-vitest.mjs src/cron/retry-hint.test.ts src/cron/service/timer-trigger.test.ts` -> 2 files passed, 13 tests passed.
- `git diff --check` passed.
- Isolated Codex autoreview completed in one round with no accepted/actionable findings and 0.99 confidence.
- Production delta: +10/-5. Test delta: +43/-0.
- Exact-head CI run `31328754637` is green on attempt 2, including `check-dependencies`, typechecks, lint, guards, build artifacts, SQLite boundaries, and the aggregate `openclaw/ci-gate`. Attempt 1 had one unrelated ordering flake in `workspace-sync-tunnel.test.ts`; the unchanged failed-job rerun passed.
