### PR TITLE
fix(release): stop npm lock fork packaging loops

### DIFF
--- a/scripts/generate-npm-package-lock.mjs
+++ b/scripts/generate-npm-package-lock.mjs
@@ -22,7 +22,6 @@ import { resolveNpmRunner } from "./npm-runner.mjs";
 
 const ROOT_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const EXACT_VERSION_PATTERN = /^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/u;
-const STABLE_VERSION_PATTERN = /^(\d+)\.(\d+)\.(\d+)$/u;
 const NPM_LOCK_COMMAND_TIMEOUT_MS = 10 * 60 * 1000;
 const NPM_LOCK_COMMAND_MAX_BUFFER_BYTES = 64 * 1024 * 1024;
 const NPM_LOCK_DEFAULT_JOBS = 4;
@@ -169,43 +168,15 @@ function collectPnpmLockPackageVersions(lockfile) {
   return versionsByName;
 }
 
-function stableVersionParts(version) {
-  const match = version.match(STABLE_VERSION_PATTERN);
-  return match
-    ? {
-        major: Number(match[1]),
-        minor: Number(match[2]),
-        patch: Number(match[3]),
-      }
-    : null;
-}
-
 function pnpmLockOverrideVersionForVersions(versions) {
   const sortedVersions = [...versions].toSorted((left, right) => left.localeCompare(right));
   if (sortedVersions.length === 1) {
     return exactVersionFromOverrideSpec(sortedVersions[0]) === null ? null : sortedVersions[0];
   }
-
-  const parsedVersions = sortedVersions.map((version) => ({
-    version,
-    parts: stableVersionParts(version),
-  }));
-  if (parsedVersions.some(({ parts }) => parts === null)) {
-    return null;
-  }
-
-  const [{ parts: firstParts }] = parsedVersions;
-  if (
-    parsedVersions.some(
-      ({ parts }) => parts.major !== firstParts.major || parts.minor !== firstParts.minor,
-    )
-  ) {
-    return null;
-  }
-
-  // npm patch ranges can float past the pnpm lock. Pin to the newest locked patch
-  // when the lock only contains one major/minor line, but keep true version forks free.
-  return parsedVersions.toSorted((left, right) => right.parts.patch - left.parts.patch)[0].version;
+  // Multiple locked versions can come from exact dependency specs even when
+  // they share a major/minor line. Keep those forks scoped to their parents;
+  // a global override would silently erase the pnpm graph's distinction.
+  return null;
 }
 
 function readPnpmLockVersionOverrides() {

--- a/test/scripts/generate-npm-package-lock.test.ts
+++ b/test/scripts/generate-npm-package-lock.test.ts
@@ -140,8 +140,9 @@ describe("generate-npm-package-lock", () => {
     expect(exactVersionFromOverrideSpec("^8.4.0")).toBeNull();
   });
 
-  it("pins same-line pnpm lock versions to the newest locked patch", () => {
-    expect(pnpmLockOverrideVersionForVersions(new Set(["3.972.38", "3.972.39"]))).toBe("3.972.39");
+  it("keeps every multi-version pnpm lock fork scoped to its parent", () => {
+    expect(pnpmLockOverrideVersionForVersions(new Set(["3.972.38"]))).toBe("3.972.38");
+    expect(pnpmLockOverrideVersionForVersions(new Set(["3.972.38", "3.972.39"]))).toBeNull();
     expect(pnpmLockOverrideVersionForVersions(new Set(["3.972.39", "3.973.0"]))).toBeNull();
     expect(pnpmLockOverrideVersionForVersions(new Set(["3.972.39", "4.0.0"]))).toBeNull();
   });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where release maintainers packaging official plugins on Node 24/npm 11 could see `npm ci` run indefinitely when the pnpm lock contained two patch versions of the same dependency from exact parent specs. The Slack package hit this with `@types/retry@0.12.0` and `@types/retry@0.12.5`, blocking the 2026.7.2 beta release.

## Why This Change Was Made

The transient npm-lock generator now preserves every multi-version pnpm fork with its existing parent-scoped overrides. It still globally pins true singleton versions, but no longer collapses same-major/minor forks to the newest patch and thereby rewrites exact dependency edges.

## User Impact

Official plugin packages can be built reproducibly on the supported Node 24/npm 11 release path without an Arborist replacement loop. This does not change plugin runtime behavior.

AI-assisted: yes.

## Evidence

- Before: the exact Slack pack exceeded five minutes while the npm debug log repeated `@types/retry@0.12.5 REPLACE` between `@slack/web-api@8.0.0` and `p-retry@4.6.2` more than 49,000 times.
- After: `OPENCLAW_PLUGIN_NPM_PACK_OUTPUT_DIR=<temp> bash scripts/plugin-npm-publish.sh --pack extensions/slack` completed on Node 24.18.0/npm 11.16.0 in 29.747 seconds and produced the 5,367-entry bundled tarball. Testbox `tbx_01kyfahm6kkey945a4s71f8b1y`; run https://github.com/openclaw/openclaw/actions/runs/30204556735.
- `node scripts/run-vitest.mjs test/scripts/generate-npm-package-lock.test.ts test/plugin-npm-package-manifest.test.ts` — 34 tests passed.
- Remote `pnpm check:changed` — passed, including all 78 transient npm package-lock validations, test-root typecheck, formatting, and lint; 2m50s.
- Autoreview — clean, no accepted or actionable findings.

## Maintainer Decision

The release owner accepts preserving every multi-version pnpm fork as the permanent npm-lock policy. The existing scoped override builder retains the exact parent edges (`@slack/web-api@8.0.0` and `p-retry@4.6.2` keep `@types/retry@0.12.0`, while `@types/proper-lockfile@4.1.4` keeps `0.12.5`); all 78 generated package locks and the exact Slack pack passed with that contract.
