### PR TITLE
fix(config): model policy refs padded around the provider/model separator fail config validation

### DIFF
--- a/src/agents/model-visibility-policy.test.ts
+++ b/src/agents/model-visibility-policy.test.ts
@@ -217,7 +217,7 @@ describe("explicit model visibility policy", () => {
     const policy = createPolicy({
       agents: {
         defaults: {
-          modelPolicy: { allow: ["clawrouter/anthropic /*", " openai / gpt-5.5 "] },
+          modelPolicy: { allow: [" clawrouter / anthropic / * ", " openai / gpt-5.5 "] },
         },
       },
     });

--- a/src/agents/model-visibility-policy.test.ts
+++ b/src/agents/model-visibility-policy.test.ts
@@ -213,6 +213,27 @@ describe("explicit model visibility policy", () => {
     ]);
   });
 
+  it("keeps nested prefix wildcards scoped when segments carry boundary whitespace", () => {
+    const policy = createPolicy({
+      agents: {
+        defaults: {
+          modelPolicy: { allow: ["clawrouter/anthropic /*", " openai / gpt-5.5 "] },
+        },
+      },
+    });
+
+    // The padded nested wildcard must keep its namespace rather than widening to
+    // every clawrouter model.
+    expect(policy.allowsKey("clawrouter/anthropic/claude-haiku-4-5")).toBe(true);
+    expect(policy.allowsKey("clawrouter/google/gemini-3.5-flash")).toBe(false);
+    expect(policy.allowsKey("openai/gpt-5.5")).toBe(true);
+    expect(policy.allowsKey("openai/gpt-5.6-sol")).toBe(false);
+    expect(policy.allowedCatalog.map((entry) => `${entry.provider}/${entry.id}`)).toEqual([
+      "clawrouter/anthropic/claude-haiku-4-5",
+      "openai/gpt-5.5",
+    ]);
+  });
+
   it("keeps top-level provider wildcard behavior for nested model ids", () => {
     const policy = createPolicy({
       agents: {

--- a/src/config/config.model-ref-validation.test.ts
+++ b/src/config/config.model-ref-validation.test.ts
@@ -174,4 +174,72 @@ describe("config model reference validation", () => {
       expect(res.config.models?.providers?.myproxy?.models?.[0]?.id).toBe("vendor/modern-model");
     }
   });
+  it("accepts model policy refs whose segments carry boundary whitespace", () => {
+    const res = validateConfigObjectWithPlugins(
+      {
+        agents: {
+          defaults: {
+            modelPolicy: { allow: [" openai / gpt-5.5 ", "openai/ns /*"] },
+          },
+        },
+      },
+      { pluginValidation: "skip" },
+    );
+
+    expect(res.ok).toBe(true);
+  });
+
+  it("rejects nested exact refs whose model remainder keeps internal whitespace", () => {
+    // The runtime trims only the provider and the whole model remainder, so this ref
+    // would resolve to model id "anthropic /claude-haiku-4-5".
+    const res = validateConfigObjectWithPlugins(
+      {
+        agents: {
+          defaults: {
+            modelPolicy: { allow: ["clawrouter/anthropic /claude-haiku-4-5"] },
+          },
+        },
+      },
+      { pluginValidation: "skip" },
+    );
+
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.issues[0]?.path).toBe("agents.defaults.modelPolicy.allow.0");
+    }
+  });
+
+  it("accepts nested exact refs padded only at the remainder boundary", () => {
+    const res = validateConfigObjectWithPlugins(
+      {
+        agents: {
+          defaults: {
+            modelPolicy: { allow: ["clawrouter/ anthropic/claude-haiku-4-5"] },
+          },
+        },
+      },
+      { pluginValidation: "skip" },
+    );
+
+    expect(res.ok).toBe(true);
+  });
+
+  it("still rejects model policy refs with whitespace inside a segment", () => {
+    const res = validateConfigObjectWithPlugins(
+      {
+        agents: {
+          defaults: {
+            modelPolicy: { allow: ["openai/gpt 5.5"] },
+          },
+        },
+      },
+      { pluginValidation: "skip" },
+    );
+
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.issues[0]?.path).toBe("agents.defaults.modelPolicy.allow.0");
+      expect(res.issues[0]?.message).toContain("invalid model policy ref");
+    }
+  });
 });

--- a/src/config/config.model-ref-validation.test.ts
+++ b/src/config/config.model-ref-validation.test.ts
@@ -174,72 +174,61 @@ describe("config model reference validation", () => {
       expect(res.config.models?.providers?.myproxy?.models?.[0]?.id).toBe("vendor/modern-model");
     }
   });
-  it("accepts model policy refs whose segments carry boundary whitespace", () => {
-    const res = validateConfigObjectWithPlugins(
+  it.each([
+    [
+      "default policy",
       {
         agents: {
           defaults: {
-            modelPolicy: { allow: [" openai / gpt-5.5 ", "openai/ns /*"] },
+            modelPolicy: {
+              allow: [
+                " openai / gpt-5.5 ",
+                "clawrouter/ anthropic/claude-haiku-4-5",
+                "openai/ns /*",
+              ],
+            },
           },
         },
       },
-      { pluginValidation: "skip" },
-    );
+    ],
+    [
+      "per-agent policy",
+      {
+        agents: {
+          list: [
+            {
+              id: "worker",
+              modelPolicy: { allow: [" openai / gpt-5.5 ", "openai/ns /*"] },
+            },
+          ],
+        },
+      },
+    ],
+  ])("accepts separator padding in the %s", (_label, config) => {
+    const res = validateConfigObjectWithPlugins(config, { pluginValidation: "skip" });
 
     expect(res.ok).toBe(true);
   });
 
-  it("rejects nested exact refs whose model remainder keeps internal whitespace", () => {
-    // The runtime trims only the provider and the whole model remainder, so this ref
-    // would resolve to model id "anthropic /claude-haiku-4-5".
-    const res = validateConfigObjectWithPlugins(
-      {
-        agents: {
-          defaults: {
-            modelPolicy: { allow: ["clawrouter/anthropic /claude-haiku-4-5"] },
+  it.each(["clawrouter/anthropic /claude-haiku-4-5", "openai/gpt 5.5", "openai//gpt-5.5"])(
+    "still rejects malformed model policy ref %j",
+    (ref) => {
+      const res = validateConfigObjectWithPlugins(
+        {
+          agents: {
+            defaults: {
+              modelPolicy: { allow: [ref] },
+            },
           },
         },
-      },
-      { pluginValidation: "skip" },
-    );
+        { pluginValidation: "skip" },
+      );
 
-    expect(res.ok).toBe(false);
-    if (!res.ok) {
-      expect(res.issues[0]?.path).toBe("agents.defaults.modelPolicy.allow.0");
-    }
-  });
-
-  it("accepts nested exact refs padded only at the remainder boundary", () => {
-    const res = validateConfigObjectWithPlugins(
-      {
-        agents: {
-          defaults: {
-            modelPolicy: { allow: ["clawrouter/ anthropic/claude-haiku-4-5"] },
-          },
-        },
-      },
-      { pluginValidation: "skip" },
-    );
-
-    expect(res.ok).toBe(true);
-  });
-
-  it("still rejects model policy refs with whitespace inside a segment", () => {
-    const res = validateConfigObjectWithPlugins(
-      {
-        agents: {
-          defaults: {
-            modelPolicy: { allow: ["openai/gpt 5.5"] },
-          },
-        },
-      },
-      { pluginValidation: "skip" },
-    );
-
-    expect(res.ok).toBe(false);
-    if (!res.ok) {
-      expect(res.issues[0]?.path).toBe("agents.defaults.modelPolicy.allow.0");
-      expect(res.issues[0]?.message).toContain("invalid model policy ref");
-    }
-  });
+      expect(res.ok).toBe(false);
+      if (!res.ok) {
+        expect(res.issues[0]?.path).toBe("agents.defaults.modelPolicy.allow.0");
+        expect(res.issues[0]?.message).toContain("invalid model policy ref");
+      }
+    },
+  );
 });

--- a/src/config/config.model-ref-validation.test.ts
+++ b/src/config/config.model-ref-validation.test.ts
@@ -184,7 +184,8 @@ describe("config model reference validation", () => {
               allow: [
                 " openai / gpt-5.5 ",
                 "clawrouter/ anthropic/claude-haiku-4-5",
-                "openai/ns /*",
+                " openai / * ",
+                " clawrouter / anthropic / * ",
               ],
             },
           },
@@ -198,7 +199,9 @@ describe("config model reference validation", () => {
           list: [
             {
               id: "worker",
-              modelPolicy: { allow: [" openai / gpt-5.5 ", "openai/ns /*"] },
+              modelPolicy: {
+                allow: [" openai / gpt-5.5 ", " openai / * ", " openai / ns / * "],
+              },
             },
           ],
         },

--- a/src/config/model-policy-ref.ts
+++ b/src/config/model-policy-ref.ts
@@ -14,6 +14,21 @@ function hasControlCharacter(value: string): boolean {
   return false;
 }
 
+/**
+ * Trim each segment of a wildcard prefix. The wildcard key is matched on segment
+ * boundaries, so padding around a namespace is normalization; without this a
+ * padded prefix would keep the padding in its canonical key and never match.
+ */
+function splitWildcardPrefixSegments(trimmed: string): string[] {
+  return trimmed.split("/").map((segment) => segment.trim());
+}
+
+function isValidRefValue(value: string): boolean {
+  return (
+    value.length > 0 && !value.includes("*") && !/\s/u.test(value) && !hasControlCharacter(value)
+  );
+}
+
 function hasValidSegments(
   segments: readonly string[],
   bounds: { min: number; max?: number },
@@ -21,13 +36,7 @@ function hasValidSegments(
   return (
     segments.length >= bounds.min &&
     (bounds.max === undefined || segments.length <= bounds.max) &&
-    segments.every(
-      (segment) =>
-        segment.length > 0 &&
-        !segment.includes("*") &&
-        !/\s/u.test(segment) &&
-        !hasControlCharacter(segment),
-    )
+    segments.every(isValidRefValue)
   );
 }
 
@@ -42,7 +51,7 @@ export function parseModelPolicyWildcardRef(raw: string): ModelPolicyWildcardRef
   if (!trimmed.endsWith("/*")) {
     return null;
   }
-  const segments = trimmed.split("/");
+  const segments = splitWildcardPrefixSegments(trimmed);
   if (
     segments.at(-1) !== "*" ||
     !hasValidSegments(segments.slice(0, -1), {
@@ -63,9 +72,18 @@ export function parseModelPolicyWildcardRef(raw: string): ModelPolicyWildcardRef
 
 /** True for a syntactically valid exact provider/model policy reference. */
 export function isValidExactModelPolicyRef(raw: string): boolean {
-  const trimmed = raw.trim();
-  const parsed = parseModelCatalogRef(trimmed);
-  return Boolean(parsed && hasValidSegments(trimmed.split("/"), { min: 2 }));
+  const parsed = parseModelCatalogRef(raw.trim());
+  if (!parsed) {
+    return false;
+  }
+  // Validate the values the runtime actually resolves: it trims the provider and the
+  // whole model remainder, not each nested segment. Trimming per segment here would
+  // accept refs that resolve to a model id with embedded whitespace.
+  return (
+    isValidRefValue(parsed.provider) &&
+    isValidRefValue(parsed.modelId) &&
+    !parsed.modelId.split("/").includes("")
+  );
 }
 
 /** True for a supported bare selector whose target is resolved from config. */

--- a/src/config/model-policy-ref.ts
+++ b/src/config/model-policy-ref.ts
@@ -39,9 +39,6 @@ type ModelPolicyWildcardRef = {
 /** Parse and canonicalize a segment-boundary model-policy prefix wildcard. */
 export function parseModelPolicyWildcardRef(raw: string): ModelPolicyWildcardRef | null {
   const trimmed = raw.trim();
-  if (!trimmed.endsWith("/*")) {
-    return null;
-  }
   // Wildcard keys match on segment boundaries, so normalize boundary padding
   // before building the canonical key used by policy matching.
   const segments = trimmed.split("/").map((segment) => segment.trim());

--- a/src/config/model-policy-ref.ts
+++ b/src/config/model-policy-ref.ts
@@ -14,21 +14,6 @@ function hasControlCharacter(value: string): boolean {
   return false;
 }
 
-/**
- * Trim each segment of a wildcard prefix. The wildcard key is matched on segment
- * boundaries, so padding around a namespace is normalization; without this a
- * padded prefix would keep the padding in its canonical key and never match.
- */
-function splitWildcardPrefixSegments(trimmed: string): string[] {
-  return trimmed.split("/").map((segment) => segment.trim());
-}
-
-function isValidRefValue(value: string): boolean {
-  return (
-    value.length > 0 && !value.includes("*") && !/\s/u.test(value) && !hasControlCharacter(value)
-  );
-}
-
 function hasValidSegments(
   segments: readonly string[],
   bounds: { min: number; max?: number },
@@ -36,7 +21,13 @@ function hasValidSegments(
   return (
     segments.length >= bounds.min &&
     (bounds.max === undefined || segments.length <= bounds.max) &&
-    segments.every(isValidRefValue)
+    segments.every(
+      (segment) =>
+        segment.length > 0 &&
+        !segment.includes("*") &&
+        !/\s/u.test(segment) &&
+        !hasControlCharacter(segment),
+    )
   );
 }
 
@@ -51,7 +42,9 @@ export function parseModelPolicyWildcardRef(raw: string): ModelPolicyWildcardRef
   if (!trimmed.endsWith("/*")) {
     return null;
   }
-  const segments = splitWildcardPrefixSegments(trimmed);
+  // Wildcard keys match on segment boundaries, so normalize boundary padding
+  // before building the canonical key used by policy matching.
+  const segments = trimmed.split("/").map((segment) => segment.trim());
   if (
     segments.at(-1) !== "*" ||
     !hasValidSegments(segments.slice(0, -1), {
@@ -72,17 +65,12 @@ export function parseModelPolicyWildcardRef(raw: string): ModelPolicyWildcardRef
 
 /** True for a syntactically valid exact provider/model policy reference. */
 export function isValidExactModelPolicyRef(raw: string): boolean {
-  const parsed = parseModelCatalogRef(raw.trim());
-  if (!parsed) {
-    return false;
-  }
-  // Validate the values the runtime actually resolves: it trims the provider and the
-  // whole model remainder, not each nested segment. Trimming per segment here would
-  // accept refs that resolve to a model id with embedded whitespace.
-  return (
-    isValidRefValue(parsed.provider) &&
-    isValidRefValue(parsed.modelId) &&
-    !parsed.modelId.split("/").includes("")
+  const parsed = parseModelCatalogRef(raw);
+  return Boolean(
+    parsed &&
+    hasValidSegments([parsed.provider, ...parsed.modelId.split("/")], {
+      min: 2,
+    }),
   );
 }
 


### PR DESCRIPTION
## What Problem This Solves

`agents.defaults.modelPolicy.allow` rejected exact refs padded around the provider/model separator, such as `" openai / gpt-5.5 "`, even though the shared model-catalog parser and runtime normalize that boundary. The invalid-policy result rejects the whole config at load time.

The same bug class affected prefix wildcards: separator padding such as `" openai / * "` or `" clawrouter / anthropic / * "` was rejected before the wildcard key could be canonicalized.

## Why This Change Was Made

The fix stays in the shared model-policy reference parser used by both default and per-agent policies:

- Exact refs validate the provider and model-id segments returned by `parseModelCatalogRef`, so only the provider/remainder boundary normalization already owned by the dependency is accepted.
- Wildcard refs split and trim segment boundaries before requiring a terminal `*` and applying the existing segment validation. Canonical nested prefixes remain namespace-scoped.

This is acceptance-only normalization. The config shape remains `string[]`, so exported types, Zod shape, help, labels, generated baselines, and docs do not change; no doctor migration is needed.

## User Impact

Hand-written model allowlists with harmless separator padding now load and resolve to the same canonical exact or prefix policy as their unpadded form. Internal identifier whitespace, control characters, empty segments, malformed stars, and nonterminal wildcards remain rejected.

## Evidence

- Exact then-current-main reproduction at `a04ba3a4683cad2a7d2fbc186add956575e3a27d`: padded exact ref rejected at `agents.defaults.modelPolicy.allow.0` in Testbox run https://github.com/openclaw/openclaw/actions/runs/30306810430.
- Focused exact-head proof: 45/45 tests passed across config validation, runtime model visibility, and `model-catalog-core` parser contracts.
- Hosted `pnpm check:changed` passed on Blacksmith Testbox `tbx_01kyjr6n39memj3z6yfhpefh25`, run https://github.com/openclaw/openclaw/actions/runs/30307659001.
- Tests cover default, `agents.list`, and `agents.entries` policy paths; both-sided top-level and nested wildcard padding; malformed exact/wildcard inputs; and nested runtime scope.
- Independent adversarial refuter: `NO-ACTIONABLE-OBJECTION`.
- Final exact-head Codex autoreview: no accepted/actionable findings.
