### PR TITLE
fix: reduce reply delay when model policy is configured

### DIFF
--- a/src/agents/model-selection.plugin-runtime.test.ts
+++ b/src/agents/model-selection.plugin-runtime.test.ts
@@ -19,6 +19,7 @@ const emptyPluginMetadataSnapshot = vi.hoisted(() => ({
   ],
 }));
 const getCurrentPluginMetadataSnapshotMock = vi.hoisted(() => vi.fn());
+const loadPreparedModelCatalogSnapshotMock = vi.hoisted(() => vi.fn());
 
 vi.mock("./provider-model-normalization.runtime.js", () => ({
   normalizeProviderModelIdWithRuntime: (params: unknown) =>
@@ -27,6 +28,12 @@ vi.mock("./provider-model-normalization.runtime.js", () => ({
 
 vi.mock("../plugins/current-plugin-metadata-snapshot.js", () => ({
   getCurrentPluginMetadataSnapshot: getCurrentPluginMetadataSnapshotMock,
+}));
+
+vi.mock("./model-catalog.runtime.js", () => ({
+  loadManifestModelCatalog: () => [],
+  loadPreparedModelCatalog: async () => [],
+  loadPreparedModelCatalogSnapshot: loadPreparedModelCatalogSnapshotMock,
 }));
 
 let createModelSelectionStateForTest: typeof import("../auto-reply/reply/model-selection.js").createModelSelectionState;
@@ -41,6 +48,8 @@ describe("model-selection plugin runtime normalization", () => {
     normalizeProviderModelIdWithPluginMock.mockReset();
     getCurrentPluginMetadataSnapshotMock.mockReset();
     getCurrentPluginMetadataSnapshotMock.mockReturnValue(emptyPluginMetadataSnapshot);
+    loadPreparedModelCatalogSnapshotMock.mockReset();
+    loadPreparedModelCatalogSnapshotMock.mockResolvedValue({ entries: [], authoritative: true });
   });
 
   it("delegates provider-owned model id normalization to plugin runtime hooks", async () => {
@@ -264,6 +273,63 @@ describe("model-selection plugin runtime normalization", () => {
       config: cfg,
       allowWorkspaceScopedSnapshot: true,
     });
+  });
+
+  it("keeps concurrent model-policy runs isolated while sharing metadata", async () => {
+    normalizeProviderModelIdWithPluginMock.mockReturnValue(undefined);
+    let signalFirstCatalogLoad: (() => void) | undefined;
+    let releaseFirstCatalogLoad: (() => void) | undefined;
+    const firstCatalogLoadStarted = new Promise<void>((resolve) => {
+      signalFirstCatalogLoad = resolve;
+    });
+    const firstCatalogLoadRelease = new Promise<void>((resolve) => {
+      releaseFirstCatalogLoad = resolve;
+    });
+    loadPreparedModelCatalogSnapshotMock
+      .mockImplementationOnce(async () => {
+        signalFirstCatalogLoad?.();
+        await firstCatalogLoadRelease;
+        return { entries: [], authoritative: true };
+      })
+      .mockResolvedValue({ entries: [], authoritative: true });
+    const createConfig = (model: string) => ({
+      agents: {
+        defaults: {
+          modelPolicy: { allow: [`custom-provider/${model}`] },
+          models: { [`custom-provider/${model}`]: {} },
+        },
+      },
+    });
+    const firstConfig = createConfig("first");
+    const secondConfig = createConfig("second");
+
+    const select = (cfg: ReturnType<typeof createConfig>, model: string) =>
+      createModelSelectionStateForTest({
+        cfg,
+        agentCfg: cfg.agents.defaults,
+        defaultProvider: "custom-provider",
+        defaultModel: model,
+        provider: "custom-provider",
+        model,
+        hasModelDirective: true,
+      });
+
+    const firstPromise = select(firstConfig, "first");
+    await firstCatalogLoadStarted;
+    const secondPromise = select(secondConfig, "second");
+    await vi.waitFor(() => expect(loadPreparedModelCatalogSnapshotMock).toHaveBeenCalledTimes(2));
+    releaseFirstCatalogLoad?.();
+    const [first, second] = await Promise.all([firstPromise, secondPromise]);
+
+    expect([...first.allowedModelKeys]).toContain("custom-provider/first");
+    expect([...first.allowedModelKeys]).not.toContain("custom-provider/second");
+    expect([...second.allowedModelKeys]).toContain("custom-provider/second");
+    expect([...second.allowedModelKeys]).not.toContain("custom-provider/first");
+    expect(getCurrentPluginMetadataSnapshotMock).toHaveBeenCalledTimes(2);
+    expect(getCurrentPluginMetadataSnapshotMock.mock.calls).toEqual([
+      [{ config: firstConfig, allowWorkspaceScopedSnapshot: true }],
+      [{ config: secondConfig, allowWorkspaceScopedSnapshot: true }],
+    ]);
   });
 
   it("preserves runtime discovery fallback across configured, stored, and fallback refs", async () => {

--- a/src/agents/model-selection.plugin-runtime.test.ts
+++ b/src/agents/model-selection.plugin-runtime.test.ts
@@ -18,6 +18,7 @@ const emptyPluginMetadataSnapshot = vi.hoisted(() => ({
     },
   ],
 }));
+const getCurrentPluginMetadataSnapshotMock = vi.hoisted(() => vi.fn());
 
 vi.mock("./provider-model-normalization.runtime.js", () => ({
   normalizeProviderModelIdWithRuntime: (params: unknown) =>
@@ -25,7 +26,7 @@ vi.mock("./provider-model-normalization.runtime.js", () => ({
 }));
 
 vi.mock("../plugins/current-plugin-metadata-snapshot.js", () => ({
-  getCurrentPluginMetadataSnapshot: () => emptyPluginMetadataSnapshot,
+  getCurrentPluginMetadataSnapshot: getCurrentPluginMetadataSnapshotMock,
 }));
 
 let createModelSelectionStateForTest: typeof import("../auto-reply/reply/model-selection.js").createModelSelectionState;
@@ -38,6 +39,8 @@ describe("model-selection plugin runtime normalization", () => {
 
   beforeEach(() => {
     normalizeProviderModelIdWithPluginMock.mockReset();
+    getCurrentPluginMetadataSnapshotMock.mockReset();
+    getCurrentPluginMetadataSnapshotMock.mockReturnValue(emptyPluginMetadataSnapshot);
   });
 
   it("delegates provider-owned model id normalization to plugin runtime hooks", async () => {
@@ -229,6 +232,109 @@ describe("model-selection plugin runtime normalization", () => {
     expect(state.provider).toBe("custom-provider");
     expect(state.model).toBe("custom-modern-model");
     expect(state.resetModelOverride).toBe(false);
+  });
+
+  it("reuses one lifecycle metadata snapshot across auto-reply model normalization", async () => {
+    normalizeProviderModelIdWithPluginMock.mockReturnValue(undefined);
+    const configuredRefs = Object.fromEntries(
+      Array.from({ length: 20 }, (_, index) => [`custom-provider/model-${index}`, {}]),
+    );
+    const cfg = {
+      agents: {
+        defaults: {
+          modelPolicy: { allow: Object.keys(configuredRefs) },
+          models: configuredRefs,
+        },
+      },
+    };
+
+    const state = await createModelSelectionStateForTest({
+      cfg,
+      agentCfg: cfg.agents.defaults,
+      defaultProvider: "custom-provider",
+      defaultModel: "model-0",
+      provider: "custom-provider",
+      model: "model-0",
+      hasModelDirective: false,
+    });
+
+    expect(state.allowedModelCatalog).toHaveLength(20);
+    expect(getCurrentPluginMetadataSnapshotMock).toHaveBeenCalledTimes(1);
+    expect(getCurrentPluginMetadataSnapshotMock).toHaveBeenCalledWith({
+      config: cfg,
+      allowWorkspaceScopedSnapshot: true,
+    });
+  });
+
+  it("preserves runtime discovery fallback across configured, stored, and fallback refs", async () => {
+    getCurrentPluginMetadataSnapshotMock.mockReturnValue(undefined);
+    const aliases = new Map([
+      ["configured-legacy", "configured-modern"],
+      ["stored-legacy", "stored-modern"],
+      ["fallback-legacy", "fallback-modern"],
+    ]);
+    normalizeProviderModelIdWithPluginMock.mockImplementation(({ context, plugins }) => {
+      if (plugins) {
+        expect(plugins.length).toBeGreaterThan(0);
+      }
+      const modelId = (context as { modelId?: string }).modelId ?? "";
+      return aliases.get(modelId);
+    });
+    const cfg = {
+      agents: {
+        defaults: {
+          model: {
+            primary: "custom-provider/configured-legacy",
+            fallbacks: ["custom-provider/fallback-legacy"],
+          },
+          modelPolicy: {
+            allow: ["custom-provider/configured-legacy", "custom-provider/stored-legacy"],
+          },
+          models: {
+            "custom-provider/configured-legacy": {},
+            "custom-provider/stored-legacy": {},
+          },
+        },
+      },
+    };
+    const sessionKey = "agent:main:discord:channel:c1";
+    const sessionEntry = {
+      sessionId: sessionKey,
+      updatedAt: 1,
+      providerOverride: "custom-provider",
+      modelOverride: "stored-legacy",
+    };
+
+    const state = await createModelSelectionStateForTest({
+      cfg,
+      agentCfg: cfg.agents.defaults,
+      sessionEntry,
+      sessionStore: { [sessionKey]: sessionEntry },
+      sessionKey,
+      defaultProvider: "custom-provider",
+      defaultModel: "configured-legacy",
+      provider: "custom-provider",
+      model: "configured-legacy",
+      hasModelDirective: false,
+    });
+
+    expect(state.provider).toBe("custom-provider");
+    expect(state.model).toBe("stored-modern");
+    expect([...state.allowedModelKeys]).toEqual(
+      expect.arrayContaining([
+        "custom-provider/configured-modern",
+        "custom-provider/stored-modern",
+      ]),
+    );
+    expect(getCurrentPluginMetadataSnapshotMock).toHaveBeenCalledWith({
+      config: cfg,
+      allowWorkspaceScopedSnapshot: true,
+    });
+    expect(
+      normalizeProviderModelIdWithPluginMock.mock.calls.map(
+        ([call]) => (call as { context?: { modelId?: string } }).context?.modelId,
+      ),
+    ).toEqual(expect.arrayContaining(["configured-legacy", "stored-legacy", "fallback-legacy"]));
   });
 
   it("forwards manifestPlugins to the runtime normalization call so it can skip the slot-or-load disk walk", async () => {

--- a/src/auto-reply/reply/model-runtime-normalization.ts
+++ b/src/auto-reply/reply/model-runtime-normalization.ts
@@ -1,0 +1,26 @@
+/** Prepared plugin metadata handoff for runtime model normalization. */
+import { normalizeModelRef } from "../../agents/model-selection.js";
+import { RUNTIME_MODEL_VISIBILITY_NORMALIZATION } from "../../agents/model-visibility-policy.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { getCurrentPluginMetadataSnapshot } from "../../plugins/current-plugin-metadata-snapshot.js";
+
+export type RuntimeModelNormalization = NonNullable<Parameters<typeof normalizeModelRef>[2]>;
+
+/** Carries the Gateway-owned metadata snapshot through one model-selection run. */
+export function resolveRuntimeNormalization(cfg: OpenClawConfig): RuntimeModelNormalization {
+  return {
+    ...RUNTIME_MODEL_VISIBILITY_NORMALIZATION,
+    manifestPlugins: getCurrentPluginMetadataSnapshot({
+      config: cfg,
+      allowWorkspaceScopedSnapshot: true,
+    })?.plugins,
+  };
+}
+
+export function normalizeRuntimeRef(
+  provider: string,
+  model: string,
+  normalization: RuntimeModelNormalization = RUNTIME_MODEL_VISIBILITY_NORMALIZATION,
+) {
+  return normalizeModelRef(provider, model, normalization);
+}

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -16,7 +16,6 @@ import {
   buildConfiguredModelCatalog,
   legacyModelKey,
   modelKey,
-  normalizeModelRef,
   normalizeProviderId,
   normalizeStoredOverrideModel,
   resolvePersistedOverrideModelRef,
@@ -24,7 +23,6 @@ import {
   resolveThinkingDefault,
 } from "../../agents/model-selection.js";
 import {
-  RUNTIME_MODEL_VISIBILITY_NORMALIZATION,
   createModelVisibilityPolicy,
   type ModelVisibilityPolicy,
 } from "../../agents/model-visibility-policy.js";
@@ -48,6 +46,7 @@ export {
   resolveModelDirectiveSelection,
   type ModelDirectiveSelection,
 } from "./model-selection-directive.js";
+import { normalizeRuntimeRef, resolveRuntimeNormalization } from "./model-runtime-normalization.js";
 import {
   isStaleHeartbeatAutoFallbackOverride,
   normalizeStoredRuntimeModelRef,
@@ -123,9 +122,6 @@ const modelCatalogRuntimeLoader = createLazyImportLoader(
 const sessionPersistenceRuntimeLoader = createLazyImportLoader(
   () => import("./session-entry-persistence.js"),
 );
-function normalizeRuntimeModelRef(provider: string, model: string) {
-  return normalizeModelRef(provider, model, RUNTIME_MODEL_VISIBILITY_NORMALIZATION);
-}
 
 function loadPreparedModelCatalogRuntime() {
   return modelCatalogRuntimeLoader.load();
@@ -197,6 +193,8 @@ export async function createModelSelectionState(params: {
     agentId: catalogAgentId,
     agentDir: resolveAgentDir(cfg, catalogAgentId),
   };
+  const runtimeModelNormalization = resolveRuntimeNormalization(cfg);
+  const { manifestPlugins } = runtimeModelNormalization;
 
   let provider = params.provider;
   let model = params.model;
@@ -211,7 +209,7 @@ export async function createModelSelectionState(params: {
     defaultProvider,
     defaultModel,
     agentId: params.agentId,
-    ...RUNTIME_MODEL_VISIBILITY_NORMALIZATION,
+    ...runtimeModelNormalization,
   });
   const hasAllowlist = !visibilityPolicy.allowAny;
   const hasConfiguredModels =
@@ -221,7 +219,7 @@ export async function createModelSelectionState(params: {
     provider: defaultProvider,
     model: defaultModel,
   });
-  const configuredModelCatalog = buildConfiguredModelCatalog({ cfg });
+  const configuredModelCatalog = buildConfiguredModelCatalog({ cfg, manifestPlugins });
   const needsModelCatalog =
     params.hasModelDirective ||
     (hasAllowlist && visibilityPolicy.hasProviderWildcards && !defaultModelVisibleByWildcard);
@@ -270,15 +268,26 @@ export async function createModelSelectionState(params: {
     normalizeProviderId(directStoredModelOverride.provider ?? "") === OPENAI_CODEX_PROVIDER_ID &&
     normalizeProviderId(primaryProvider) === OPENAI_PROVIDER_ID &&
     primaryHarnessPolicy.runtime === "codex" &&
-    normalizeRuntimeModelRef(OPENAI_PROVIDER_ID, directStoredModelOverride.model).model ===
-      normalizeRuntimeModelRef(OPENAI_PROVIDER_ID, primaryModel).model;
-  const normalizedCurrentSelection = normalizeRuntimeModelRef(provider, model);
+    normalizeRuntimeRef(
+      OPENAI_PROVIDER_ID,
+      directStoredModelOverride.model,
+      runtimeModelNormalization,
+    ).model ===
+      normalizeRuntimeRef(OPENAI_PROVIDER_ID, primaryModel, runtimeModelNormalization).model;
+  const normalizedCurrentSelection = normalizeRuntimeRef(
+    provider,
+    model,
+    runtimeModelNormalization,
+  );
   const normalizedDirectOverride = directStoredModelOverride
-    ? normalizeRuntimeModelRef(directStoredModelOverride.provider, directStoredModelOverride.model)
+    ? normalizeRuntimeRef(
+        directStoredModelOverride.provider,
+        directStoredModelOverride.model,
+        runtimeModelNormalization,
+      )
     : null;
-  // Only treat the legacy auto pin as stale when the current selection differs from the stored
-  // override. The current==stored case is the turn that deliberately re-applies the pin (e.g. an
-  // explicit run override); clearing there would fight that intent, so the guard must stay.
+  // A current selection equal to the stored legacy pin deliberately reapplies it; clearing then
+  // would fight an explicit override, so only treat differing selections as stale.
   const staleLegacyAutoFallbackWithoutOrigin =
     directStoredModelOverride?.source === "session" &&
     hasLegacyAutoFallbackWithoutOrigin(sessionEntry) &&
@@ -307,7 +316,7 @@ export async function createModelSelectionState(params: {
       defaultProvider,
       defaultModel,
       agentId: params.agentId,
-      ...RUNTIME_MODEL_VISIBILITY_NORMALIZATION,
+      ...runtimeModelNormalization,
     });
     allowedModelCatalog = visibilityPolicy.allowedCatalog;
     allowedModelKeys = visibilityPolicy.allowedKeys;
@@ -322,7 +331,7 @@ export async function createModelSelectionState(params: {
       defaultProvider,
       defaultModel,
       agentId: params.agentId,
-      ...RUNTIME_MODEL_VISIBILITY_NORMALIZATION,
+      ...runtimeModelNormalization,
     });
     allowedModelCatalog = visibilityPolicy.allowedCatalog;
     allowedModelKeys = visibilityPolicy.allowedKeys;
@@ -346,15 +355,12 @@ export async function createModelSelectionState(params: {
       directStoredOverride.model,
       cfg,
       sessionEntry,
+      runtimeModelNormalization,
     );
     const key = modelKey(normalizedOverride.provider, normalizedOverride.model);
     const overrideAllowed = visibilityPolicy.allowsKey(key);
-    // A degraded catalog (discovery failed, static/empty fallback) makes the
-    // allow-list unreliable, so `!allowsKey` cannot prove a pin is really
-    // disallowed. Never destroy the pin for that: the turn already falls back to
-    // the primary via the allowsKey gate below, and the override is re-evaluated
-    // once discovery recovers. Stale is a config fact (override model absent from
-    // config), catalog-independent, so it still resets.
+    // A degraded catalog cannot prove a pin is disallowed. Preserve it while the turn falls back
+    // to primary, then re-evaluate after discovery recovers; config-proven stale pins still reset.
     const overrideTemporarilyUnavailable =
       !staleDirectStoredOverride && !overrideAllowed && !catalogAuthoritative;
     if (overrideTemporarilyUnavailable) {
@@ -437,6 +443,7 @@ export async function createModelSelectionState(params: {
       storedOverride.model,
       cfg,
       sessionEntry,
+      runtimeModelNormalization,
     );
     const key = modelKey(normalizedStoredOverride.provider, normalizedStoredOverride.model);
     if (visibilityPolicy.allowsKey(key)) {
@@ -519,7 +526,7 @@ export async function createModelSelectionState(params: {
       defaultProvider,
       defaultModel,
       agentId: params.agentId,
-      ...RUNTIME_MODEL_VISIBILITY_NORMALIZATION,
+      ...runtimeModelNormalization,
     }).allowedCatalog;
   const loadManifestCatalog = async () => {
     if (manifestModelCatalog) {

--- a/src/auto-reply/reply/stored-model-override.ts
+++ b/src/auto-reply/reply/stored-model-override.ts
@@ -12,6 +12,7 @@ import { RUNTIME_MODEL_VISIBILITY_NORMALIZATION } from "../../agents/model-visib
 import { resolveSessionParentSessionKey } from "../../channels/plugins/session-conversation.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type { RuntimeModelNormalization } from "./model-runtime-normalization.js";
 
 /** Model override loaded from the current session or its parent session. */
 export type StoredModelOverride = {
@@ -26,8 +27,9 @@ export function normalizeStoredRuntimeModelRef(
   model: string,
   cfg?: OpenClawConfig,
   sessionEntry?: SessionEntry,
+  normalization: RuntimeModelNormalization = RUNTIME_MODEL_VISIBILITY_NORMALIZATION,
 ) {
-  const normalized = normalizeModelRef(provider, model, RUNTIME_MODEL_VISIBILITY_NORMALIZATION);
+  const normalized = normalizeModelRef(provider, model, normalization);
   const hasCliSessionBinding =
     sessionEntry?.cliSessionBindings?.[normalized.provider] !== undefined;
   const canonicalProvider =


### PR DESCRIPTION
Related: #81143

AI-assisted change.

## Summary

### High Level TLDR

Reply turns with configured model policy could spend seconds repeatedly rediscovering plugin manifests before the model request. This change resolves the Gateway's current plugin metadata snapshot once per model-selection run and carries it through every policy, catalog, and model-normalization step.

## What Problem This Solves

Fixes an issue where users sending a message through an existing agent session could experience several seconds of pre-request delay when configured model allowlists or overrides caused the reply path to normalize multiple model references.

The delay happened before provider inference. A runtime trace attributed 3.2–4.5 seconds to directive/model-selection preparation on affected turns.

## Root Cause

Current `main` already provides a process-lifecycle plugin metadata snapshot, introduced by #82814 and reused in more model paths by #83033. The auto-reply model-selection entry point did not carry that snapshot into its complete decision surface.

As a result, visibility-policy construction, configured catalog construction, and repeated current/stored model-reference normalization could independently fall through to plugin manifest discovery. With a synthetic 20-model configuration and 151 discovered plugins, a production-source benchmark on `354c6db7310602f6132a3ce84bd3f303422dcbde` showed:

```text
{"elapsedMs":[2046,2,2],"manifestPlugins":151,"metadataLoadMs":119}
```

The first call paid about two seconds even though loading the authoritative metadata snapshot itself took 119 ms. Warm calls were fast because process caches were then populated.

The existing dependency/lifecycle contract is that Gateway plugin metadata is process-stable and should be reused from the current snapshot. The regression was an incomplete handoff at the auto-reply caller boundary, not a need for another cache.

## Why This Change Was Made

The reply path now resolves one workspace-compatible current metadata snapshot and passes its plugins through all model policy, configured catalog, direct/stored override, and fallback catalog normalization work for that run. If no current snapshot exists, existing discovery fallback behavior remains unchanged.

## User Impact

Affected reply turns spend substantially less time in local model-selection preparation before sending the request to the configured provider. Model selection, policy enforcement, and fallback behavior remain unchanged.

## Real behavior proof

Environment: clean checkout of current `main`, production source modules, 20 synthetic configured model references, and the real discovered plugin metadata set. No private configuration, credentials, chat identifiers, or messages were used in the benchmark.

Exact command used for both revisions:

```text
node --import tsx .tmp-model-selection-benchmark.mts
```

Before, on `354c6db7310602f6132a3ce84bd3f303422dcbde`:

```text
{"elapsedMs":[2046,2,2],"manifestPlugins":151,"metadataLoadMs":119}
```

After this patch:

```text
{"elapsedMs":[653,2,1],"manifestPlugins":151,"metadataLoadMs":134}
```

Observed result: cold model-selection preparation fell from 2046 ms to 653 ms, about a 68% reduction, while warm calls remained 1–2 ms. The remaining cold cost is provider-runtime/plugin activation and is intentionally outside this fix.

The temporary benchmark was not committed; the regression test checks the durable invariant that one snapshot lookup serves the complete model-selection run.

## Evidence

Focused behavior tests:

```text
node scripts/run-vitest.mjs src/agents/model-selection.plugin-runtime.test.ts src/auto-reply/reply/stored-model-override.test.ts src/auto-reply/reply/model-selection.test.ts
Test Files  3 passed (3)
Tests       78 passed (78)
```

Changed-surface gate:

```text
OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 pnpm check:changed
exit 0
```

Packaged build:

```text
pnpm build
exit 0
```

Fresh exact-head autoreview:

```text
autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.91)
```

## Verification

- Rebased cleanly onto `c66ca2fbb2b038f4796abfa76bd52dcc3b675b02`; the production patch is unchanged.
- Exact-head GitHub Actions shard `checks-node-compact-small-14` passed the model-selection regression suite; `check-test-types` also passed.
- All other exact-head CI jobs passed except the unrelated `src/secrets/runtime.auth-migration-isolation.test.ts` 120-second timeout; the fork account cannot rerun that admin-gated job.
- `git diff --check origin/main...HEAD` passed.
- Full changed-surface checks and the packaged build passed before the clean rebase; the intervening upstream commit only changed release lock handling.
- Regression coverage verifies one workspace-scoped snapshot lookup with 20 configured refs and preserves runtime discovery fallback across configured, stored, and automatic-fallback refs when no compatible snapshot is available.

## What was not tested

- No live Gateway update, deployment, restart, or Telegram end-to-end was performed, per operator constraint.
- The exact fork head was not executed locally or on a credentialed Testbox; repository policy routes it to GitHub CI.
- The separate SQLite whole-session-store materialization issue is not changed here; it is tracked in #112240 with an active proposed fix in #113959.
- The remaining cold Codex plugin activation cost is not changed here; that broader issue is tracked in #85122.

