### PR TITLE
fix(agents): resume interrupted turns without a recognized abort string

### DIFF
--- a/docs/gateway/restart-recovery.md
+++ b/docs/gateway/restart-recovery.md
@@ -117,10 +117,16 @@ message-tool-only turn without reconstructable channel authority is failed
 closed and receives the one-time resend notice.
 
 Before resuming, the gateway checks that the transcript tail is safe to
-continue from. If it is not (for example, the turn ended on a stale pending
-approval), the session is not blindly re-run; the agent instead posts a short
-notice asking the user to resend the last request. For WebChat, that notice is
-written directly to the session history so it remains visible after reconnect.
+continue from. An aborted turn is the interruption itself, so it resumes on a
+best-effort basis whatever abort detail the provider or worker recorded with it:
+partial streamed text stays in the transcript and the continuation picks up from
+the message beneath it, while a tool call left dangling is dropped from the next
+provider payload and restricted to restart-safe tools unless it is audited
+replay-safe. If the tail is genuinely unsafe (for example a provider failure, or
+a turn that ended on a stale pending approval), the session is not blindly
+re-run; the agent instead posts a short notice asking the user to resend the
+last request. For WebChat, that notice is written directly to the session
+history so it remains visible after reconnect.
 
 OpenClaw can also reconstruct interrupted read-only [Code Mode](/tools/code-mode)
 work. Code Mode marks these runs as restart-safe and rejects side-effecting

--- a/src/agents/main-session-restart-recovery-resume-policy.ts
+++ b/src/agents/main-session-restart-recovery-resume-policy.ts
@@ -231,7 +231,9 @@ export function hasReplaySafeCodeModeCheckpointInCurrentTurn(
 
 // Generic fetch/undici abort strings plus the gateway's own restart abort
 // reason (run-termination.ts); which one lands depends on whether the provider
-// stream throws or surfaces the abort as an error event.
+// stream throws or surfaces the abort as an error event. Only "error" tails
+// need this allowlist, so a genuine provider failure is never replayed as
+// lifecycle noise.
 const RESTART_ABORT_ERROR_MESSAGES = new Set([
   "Request was aborted",
   "This operation was aborted",
@@ -243,7 +245,15 @@ function isRestartAbortAssistantMessage(message: unknown): boolean {
     return false;
   }
   const stopReason = normalizeOptionalString((message as { stopReason?: unknown }).stopReason);
-  if (stopReason !== "error" && stopReason !== "aborted") {
+  // Every row that reaches restart recovery was mid-run when the process went
+  // down, so an "aborted" tail is that interruption whatever string the
+  // transport persisted with it ("Worker inference aborted.", a provider cancel
+  // message, or nothing). Matching on the abort strings alone made ordinary
+  // restarts fall through to the unresumable notice.
+  if (stopReason === "aborted") {
+    return true;
+  }
+  if (stopReason !== "error") {
     return false;
   }
   const errorMessage = normalizeOptionalString(

--- a/src/agents/main-session-restart-recovery.test.ts
+++ b/src/agents/main-session-restart-recovery.test.ts
@@ -331,6 +331,17 @@ function codeModeWaitCallMessage() {
   };
 }
 
+// A provider failure is the remaining unresumable transcript tail: restart
+// aborts now resume, so notice-delivery tests need a shape that still fails.
+function unresumableAssistantMessage(text = "provider failed") {
+  return {
+    role: "assistant",
+    content: [{ type: "text", text }],
+    stopReason: "error",
+    errorMessage: "Provider finish_reason: content_filter",
+  };
+}
+
 function cleanedLockForPath(lockPath: string): SessionLockInspection {
   // Simulates lock cleanup after process restart: stale lock removed, owning
   // PID dead, and the transcript path available for recovery.
@@ -3886,22 +3897,6 @@ describe("main-session-restart-recovery", () => {
         stopReason: "error",
       },
     ],
-    [
-      "aborted tool call",
-      {
-        role: "assistant",
-        content: [{ type: "toolCall", id: "call-1", name: "write", arguments: {} }],
-        stopReason: "aborted",
-      },
-    ],
-    [
-      "aborted assistant output with text",
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "partial answer" }],
-        stopReason: "aborted",
-      },
-    ],
   ])("does not resume %s at the transcript tail", async (_label, assistantMessage) => {
     const sessionsDir = await makeSessionsDir();
     await writeStore(sessionsDir, mainSessionStore());
@@ -3913,6 +3908,56 @@ describe("main-session-restart-recovery", () => {
     await expectRecovery({ recovered: 0, failed: 1, skipped: 0 });
     expect(callGateway).not.toHaveBeenCalled();
   });
+
+  it.each([
+    [
+      "no abort string",
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "partial answer" }],
+        stopReason: "aborted",
+      },
+      false,
+    ],
+    [
+      "a worker abort string",
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "" }],
+        stopReason: "aborted",
+        errorMessage: "Worker inference aborted.",
+      },
+      false,
+    ],
+    [
+      "a dangling side-effecting call",
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call-1", name: "write", arguments: {} }],
+        stopReason: "aborted",
+        errorMessage: "Worker inference aborted.",
+      },
+      true,
+    ],
+  ])(
+    "resumes an aborted tail persisted with %s",
+    async (_label, assistantMessage, forceRestartSafeTools) => {
+      const sessionsDir = await makeSessionsDir();
+      await writeStore(sessionsDir, mainSessionStore());
+      await writeTranscript(sessionsDir, "main-session", [
+        { role: "user", content: "do the thing" },
+        assistantMessage,
+      ]);
+
+      await expectRecovery({ recovered: 1, failed: 0, skipped: 0 });
+      expect(callGateway).toHaveBeenCalledTimes(1);
+      if (forceRestartSafeTools) {
+        expect(gatewayParams()).toMatchObject({ forceRestartSafeTools: true });
+      } else {
+        expect(gatewayParams()).not.toMatchObject({ forceRestartSafeTools: true });
+      }
+    },
+  );
 
   it("keeps an unresumable Control UI notice in history despite a stale external route", async () => {
     const sessionsDir = await makeSessionsDir();
@@ -3926,11 +3971,7 @@ describe("main-session-restart-recovery", () => {
     });
     await writeTranscript(sessionsDir, "main-session", [
       { role: "user", content: "do the thing" },
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "partial answer" }],
-        stopReason: "aborted",
-      },
+      unresumableAssistantMessage(),
     ]);
 
     await expectRecovery({ recovered: 0, failed: 1, skipped: 0 });
@@ -3985,11 +4026,7 @@ describe("main-session-restart-recovery", () => {
     );
     await writeTranscript(sessionsDir, "main-session", [
       { role: "user", content: "do another thing" },
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "another partial answer" }],
-        stopReason: "aborted",
-      },
+      unresumableAssistantMessage("another provider failure"),
     ]);
 
     await expectRecovery({ recovered: 0, failed: 1, skipped: 0 });
@@ -4030,11 +4067,7 @@ describe("main-session-restart-recovery", () => {
     });
     await writeTranscript(sessionsDir, "main-session", [
       { role: "user", content: "do the thing" },
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "partial answer" }],
-        stopReason: "aborted",
-      },
+      unresumableAssistantMessage(),
     ]);
     transcriptMocks.appendAssistantMessageToSessionTranscript.mockResolvedValueOnce({
       ok: false,
@@ -4091,11 +4124,7 @@ describe("main-session-restart-recovery", () => {
     });
     await writeTranscript(sessionsDir, "interrupted-session", [
       { role: "user", content: "do the thing" },
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "partial answer" }],
-        stopReason: "aborted",
-      },
+      unresumableAssistantMessage(),
     ]);
     let entryAtExternalSend: SessionEntry | undefined;
     vi.mocked(callGateway).mockImplementationOnce(async () => {


### PR DESCRIPTION
## What Problem This Solves

An ordinary gateway restart could leave a main session showing the terminal
notice instead of resuming:

> I was interrupted by a gateway restart and couldn't safely resume the previous
> turn. Please send that last request again and I'll pick it up cleanly.

Restart recovery classifies the transcript tail before resuming. An interrupted
turn is persisted as an assistant message with `stopReason: "aborted"`, but
`isRestartAbortAssistantMessage` in
`src/agents/main-session-restart-recovery-resume-policy.ts` additionally required
`errorMessage` to be one of three exact strings:

- `Request was aborted`
- `This operation was aborted`
- `agent run aborted for restart`

Production writes several other abort details on that same tail. The worker
inference adapter persists `Worker inference aborted.` and
`Worker inference aborted before start.`
(`src/worker/inference-stream.runtime.ts:246`, `:262`), and
`terminalErrorMessage` copies whatever cancel message the transport reported
(`src/worker/inference-stream.runtime.ts:195`). A tail carrying any of those fell
through every resume branch to `transcript tail is not resumable`, so the user
was asked to re-send a request the gateway could have continued on its own.

## Why This Change Was Made

Every row that reaches `recoverStore` was mid-run when the process went down:
`mark_interrupted` is dispatched only from the restart/startup-orphan paths in
`src/agents/main-session-restart-recovery-marking.ts`, and the entry must still be
`running` with `abortedLastRun === true`. In that context `stopReason: "aborted"`
*is* the interruption, so matching on the abort string was a leaky proxy for a
fact the stop reason already carries.

`isRestartAbortAssistantMessage` now treats any `aborted` tail as the restart
abort and keeps the allowlist for `stopReason: "error"`, where the error may be a
genuine provider failure rather than lifecycle noise.

The safety machinery downstream is unchanged and does the real work:

- A dangling tool call in the aborted tail still goes through
  `classifyDanglingToolCalls`, so anything outside the audited replay-safe
  allowlist resumes with `forceRestartSafeTools`; the continuation can inspect
  and report, never silently re-execute an ambiguous side effect.
- Partial streamed text stays in the transcript and the message beneath it
  decides resume safety.
- Code Mode control calls keep their stricter replay-safe checkpoint gating.
- Unknown `before_agent_reply` outcomes, unknown terminal delivery outcomes,
  stale approval-pending tails, missing message-tool authority, and empty
  transcripts all still fail closed with the notice.

## User Impact

A gateway restart during a turn now resumes best-effort in the common case
instead of asking the user to send the request again. Side-effect safety is
unchanged: ambiguous tool calls resume restricted to restart-safe tools, and
genuinely unsafe tails still get the notice.

`docs/gateway/restart-recovery.md` describes the aborted-tail behavior and
narrows the "unsafe tail" example to a provider failure or stale approval.

## Evidence

- `node scripts/run-vitest.mjs src/agents/main-session-restart-recovery.test.ts`
  — 137 passed. Adds a table covering aborted tails persisted with no abort
  string, with a worker abort string, and with a dangling side-effecting call
  (asserting `forceRestartSafeTools`); removes the two aborted rows from the
  "does not resume" table that encoded the old behavior.
- `node scripts/run-vitest.mjs src/agents/main-session-recovery-state.test.ts src/agents/main-session-recovery-store.test.ts src/agents/agent-command-restart-recovery.test.ts src/agents/agent-command-recovery-owner.test.ts`
  — 97 passed.
- `node scripts/run-vitest.mjs src/gateway/server.chat.gateway-server-chat-b.test.ts`
  — 89 passed.
- `node scripts/check-changed.mjs` — exit 0 (delegated to Blacksmith Testbox
  `tbx_01kyfec215qvz6tvh7ce6hbyqw`, 5m12s).
- Autoreview (Codex `gpt-5.6-sol`, xhigh): clean, no accepted/actionable
  findings.

Three notice-delivery tests used an aborted tail purely as a convenient
"unresumable" fixture; they now use a shared `unresumableAssistantMessage()`
provider-failure shape so they keep proving notice mechanics rather than resume
classification.
