### PR TITLE
fix(clickclack): resetting any session stops discussions working for every session

### DIFF
--- a/extensions/clickclack/src/discussions/register.test.ts
+++ b/extensions/clickclack/src/discussions/register.test.ts
@@ -1,0 +1,102 @@
+import type {
+  OpenClawPluginApi,
+  PluginRuntimeLifecycleRegistration,
+} from "openclaw/plugin-sdk/core";
+// ClickClack discussion tests cover runtime lifecycle cleanup scoping.
+import { createSessionVisibilityChecker } from "openclaw/plugin-sdk/session-visibility";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { serviceCleanup } = vi.hoisted(() => ({ serviceCleanup: vi.fn() }));
+
+// The service opens a binding store against a live runtime; the lifecycle scope
+// under test does not depend on it.
+vi.mock("./service.js", () => ({
+  ClickClackDiscussionService: class {
+    provider = { id: "clickclack" };
+    cleanup = serviceCleanup;
+  },
+}));
+
+vi.mock("./tool-policy.js", () => ({
+  enforceClickClackDiscussionToolTarget: vi.fn(),
+  isClickClackDiscussionSessionTarget: vi.fn(() => ({ binding: { sessionId: "discussion-1" } })),
+}));
+
+import { registerClickClackDiscussions } from "./register.js";
+
+// Derive from the registration contract so the test tracks the host's reason union.
+type LifecycleCleanup = NonNullable<PluginRuntimeLifecycleRegistration["cleanup"]>;
+
+// The scoped access provider registry is module state shared by every test in
+// this file, so each registration must be released before the next case.
+const registeredCleanups: LifecycleCleanup[] = [];
+
+function registerAndCaptureCleanup(): LifecycleCleanup {
+  let cleanup: LifecycleCleanup | undefined;
+  const api = {
+    registrationMode: "runtime",
+    runtime: {},
+    registerTool: vi.fn(),
+    on: vi.fn(),
+    lifecycle: {
+      registerRuntimeLifecycle: (registration: PluginRuntimeLifecycleRegistration) => {
+        cleanup = registration.cleanup;
+      },
+    },
+  } as unknown as OpenClawPluginApi;
+  registerClickClackDiscussions(api);
+  if (!cleanup) {
+    throw new Error("registerClickClackDiscussions did not register a runtime lifecycle cleanup");
+  }
+  registeredCleanups.push(cleanup);
+  return cleanup;
+}
+
+function resolveDiscussionAccess() {
+  return createSessionVisibilityChecker.resolveScopedAccess({
+    action: "history",
+    requesterSessionKey: "agent:main:clickclack:discussion",
+    targetSessionKey: "agent:main:main",
+  });
+}
+
+describe("ClickClack discussions runtime lifecycle", () => {
+  beforeEach(() => {
+    serviceCleanup.mockClear();
+  });
+
+  afterEach(async () => {
+    for (const cleanup of registeredCleanups.splice(0)) {
+      await cleanup({ reason: "disable" });
+    }
+    expect(resolveDiscussionAccess()).toBeUndefined();
+  });
+
+  // Session reset/delete runs every plugin's runtime cleanup, so a session-scoped
+  // reason must leave the process-stable access provider registered.
+  it.each(["reset", "delete"] as const)(
+    "keeps the scoped access provider on a %s reason",
+    async (reason) => {
+      const cleanup = registerAndCaptureCleanup();
+      expect(resolveDiscussionAccess()).toEqual({ expectedSessionId: "discussion-1" });
+
+      await cleanup({ reason });
+
+      expect(resolveDiscussionAccess()).toEqual({ expectedSessionId: "discussion-1" });
+      expect(serviceCleanup).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(["disable", "restart"] as const)(
+    "releases the scoped access provider on a %s reason",
+    async (reason) => {
+      const cleanup = registerAndCaptureCleanup();
+      expect(resolveDiscussionAccess()).toEqual({ expectedSessionId: "discussion-1" });
+
+      await cleanup({ reason });
+
+      expect(resolveDiscussionAccess()).toBeUndefined();
+      expect(serviceCleanup).toHaveBeenCalledTimes(1);
+    },
+  );
+});

--- a/extensions/clickclack/src/discussions/register.ts
+++ b/extensions/clickclack/src/discussions/register.ts
@@ -37,7 +37,13 @@ export function registerClickClackDiscussions(api: OpenClawPluginApi): void {
   api.lifecycle.registerRuntimeLifecycle({
     id: "clickclack-discussions",
     description: "Stops the lifecycle reconciler for managed ClickClack discussions.",
-    cleanup: () => {
+    cleanup: ({ reason }) => {
+      // Session reset/delete runs every plugin's runtime cleanup, so scoping this
+      // to plugin-wide reasons keeps one session's reset from unregistering the
+      // process-stable access provider for every other discussion session.
+      if (reason === "reset" || reason === "delete") {
+        return;
+      }
       unregisterSessionAccess();
       service.cleanup();
     },


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where resetting or deleting **any** session stops ClickClack
discussions from working for **every** discussion session, until the gateway is
restarted.

`extensions/clickclack/src/discussions/register.ts` registers a runtime lifecycle
whose cleanup unconditionally tears down its scoped session-access provider and
stops the reconciliation timer:

```ts
api.lifecycle.registerRuntimeLifecycle({
  id: "clickclack-discussions",
  cleanup: () => {
    unregisterSessionAccess();
    service.cleanup();
  },
});
```

That cleanup is not scoped to the plugin. Both cleanup paths in
`src/gateway/session-reset-service.ts` call
`runPluginHostCleanup({ reason: "reset" | "delete", sessionKey, ... })` without a
`pluginId` — line 781 in the pre-mutation path, which maps
`session-reset`/`session-delete` onto `reset`/`delete`, and line 1159 in the reset
path — and `shouldCleanPlugin` in
`src/plugins/host-hook-cleanup.ts` treats a missing filter as "every plugin":

```ts
function shouldCleanPlugin(pluginId: string, filterPluginId?: string): boolean {
  return !filterPluginId || pluginId === filterPluginId;
}
```

So one session's reset runs every plugin's runtime cleanup. The registration is
process-stable, as the site says itself:

> Registration is process-stable; provider methods read live config so a channel
> hot reload can enable discussions without restarting the gateway.

A session reset does not re-register it, so discussion side sessions can no longer
reach their attached main sessions under the default `tree` visibility and
existing bindings stop synchronizing in the background. Recovery needs something
that rebuilds the registry — a gateway restart, or a plugin reload: registry
replacement runs this same cleanup with `restart`
(`src/plugins/host-hook-cleanup.ts`), and re-registration restores the provider
through `registerFull` (`extensions/clickclack/index.ts`).

## Why This Change Was Made

The cleanup now reads `reason` and returns early for the session-scoped ones,
tearing down only on plugin-wide reasons:

```ts
cleanup: ({ reason }) => {
  if (reason === "reset" || reason === "delete") {
    return;
  }
  unregisterSessionAccess();
  service.cleanup();
},
```

`PluginHostCleanupReason` (`src/plugins/host-hooks.ts`) is
`"disable" | "reset" | "delete" | "restart"`, and the host passes it to every
runtime lifecycle cleanup precisely so a registration can tell a session reset
apart from the plugin going away. The other `registerRuntimeLifecycle` consumer in
the repo already does this — `extensions/codex/index.ts` guards its realtime
browser session lease with the same check and the same rationale:

```ts
cleanup: async ({ reason }) => {
  // Session cleanup must not release the process runtime. Registry
  // restart and plugin disable release this registration's lease.
  if (reason === "reset" || reason === "delete") {
    return;
  }
  await realtimeBrowserSession.cleanup();
},
```

Non-goal: the host's fan-out is left alone. Passing a `pluginId` or narrowing
`shouldCleanPlugin` would change cleanup behavior for every plugin, and the
`reason` argument exists so registrations can make this decision themselves.

## User Impact

Operators using ClickClack discussions keep them working after resetting or
deleting an unrelated session. Previously a single `session reset` anywhere
silently disabled discussion access for the whole process, and nothing in the
session lifecycle brought it back — recovery meant a gateway restart or a plugin
reload.

## Evidence

Behavior addressed: a session-scoped plugin host cleanup releases ClickClack's
process-stable scoped session-access provider, so discussions stop working for
every session until the gateway restarts.

Real environment tested: Linux, Node v24.18.0, base `upstream/main`
`01f8bd9d12` (rebased), PR head
`bfbc7d924ce552b37f2a01088addbf355c2f3bae`. This is a code-path trace plus a focused
regression and a gateway smoke capture, not an end-to-end reproduction of the
user-visible failure: no live, pre-existing discussion binding was observed
resolving scoped access after a reset. Three captures:

1. A harness that drives the shipped `runPluginHostCleanup` with exactly the
   arguments `session-reset-service.ts` passes for a session reset, to show the
   host reaches a plugin unrelated to the session. The registrations it passes are
   synthetic sentinels, so this establishes the fan-out contract, not that a live
   ClickClack registry was involved. `HOME` and `OPENCLAW_STATE_DIR` are
   redirected into a fresh `mkdtemp` root before the imports so no live operator
   state is opened. Not committed; reproduced in full below.
2. Focused tests that exercise the real `createSessionVisibilityChecker` provider
   registry — the observable is whether the provider is still registered, read
   through the exported `resolveScopedAccess`, not a spy.

Exact steps or command run after this patch:

```
./node_modules/.bin/tsx .local-proof/live-teardown-harness.mts
./node_modules/.bin/vitest run extensions/clickclack/src/discussions/register.test.ts
```

Before evidence — the guard reverted to base, tests at PR head:

```
 ❯ |extensions| ../../extensions/clickclack/src/discussions/register.test.ts (4 tests | 2 failed)
     × keeps the scoped access provider on a reset reason 47ms
     × keeps the scoped access provider on a delete reason 2ms

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 2 ⎯⎯⎯⎯⎯⎯⎯

AssertionError: expected undefined to deeply equal { expectedSessionId: 'discussion-1' }

 Test Files  1 failed (1)
      Tests  2 failed | 2 passed (4)
```

`expected undefined` is the provider already being gone: after a `reset` cleanup
the real registry no longer resolves scoped access for the discussion session.

Evidence after fix:

```
 Test Files  1 passed (1)
      Tests  4 passed (4)
```

The `disable` and `restart` cases pass in both runs, so plugin-wide teardown is
unchanged; only the session-scoped reasons stop releasing the provider.

Host fan-out (independent of this patch — it holds either way):

```
git HEAD          : bfbc7d924ce552b37f2a01088addbf355c2f3bae
clickclack guard  : present (patched)
state dir         : /tmp/clickclack-teardown-proof-AU5bI1/home/.openclaw

runPluginHostCleanup(reason="reset", pluginId=<none>)
  cleanupCount             : 2
  runtime cleanups invoked : 2
    - clickclack: reason=reset sessionKey=agent:main:unrelated-session
    - some-other-plugin: reason=reset sessionKey=agent:main:unrelated-session

RESULT: a session-scoped reset reaches every plugin's runtime cleanup with reason="reset"
```

Unfiltered fan-out invokes every registered runtime cleanup with the supplied
`reason` and `sessionKey`, which is why the decision has to live in the
registration. These registrations are sentinels with no ownership model of their
own. Repeated 3 times with the same result.

Observed result after fix: the same session-scoped cleanup that previously left
the registry unable to resolve discussion access now leaves it intact, while
`disable` / `restart` still release it.

Live gateway (real `sessions.reset` RPC against a gateway running this patch):

```
git HEAD         : bfbc7d924ce552b37f2a01088addbf355c2f3bae
cleanup guard    : present (patched)
gateway          : ws://127.0.0.1:18799 (proof profile, isolated state)
sessions.list    : (no sessions yet)

sessions.reset   : key=agent:main:proof-unrelated-session
  response       : {"ok":true,"key":"agent:main:proof-unrelated-session","entry":{"sessionId":"1403d17e-57d8-411e-b2be-7eb8fb610627","sessionFile":"sqlite:main:1403d17e-57d8-411e-b2be-7eb8fb610627:/home/masato/dev/openclaw/runtime/state-proof/agents/main/sess

--- gateway log (excerpt, ANSI stripped) ---
2026-07-25T20:23:53.879+09:00 [gateway] http server listening (10 plugins: acpx, anthropic, browser, canvas, device-pair, file-transfer, memory-core, ollama, phone-control, talk-voice; 1.3s)
2026-07-25T20:26:59.862+09:00 [gateway] http server listening (10 plugins: acpx, anthropic, browser, canvas, device-pair, file-transfer, memory-core, ollama, phone-control, talk-voice; 1.2s)
2026-07-27T00:42:49.425+09:00 [gateway] http server listening (17 plugins: acpx, anthropic, browser, canvas, clickclack, device-pair, file-transfer, google-meet, linux-canvas, linux-node, memory-core, ollama, opencode, phone-control, talk-voice, teams-meetings, zoom-meetings; 1.4s)
2026-07-27T00:44:11.144+09:00 [ws] ⇄ res ✓ tools.catalog 450ms conn=39d8b330…1980 id=64078b1f…0117
2026-07-27T00:46:19.836+09:00 [ws] ⇄ res ✓ tools.catalog 182ms conn=ca6d9838…8c2f id=a590bae2…dc87
2026-07-27T00:49:46.735+09:00 [ws] ⇄ res ✓ sessions.reset 300ms conn=8f07b7a3…f09f id=baada323…0d69
```

(The `response` line is truncated by the capture script, not by redaction.)

The gateway is the channel-free proof profile on an isolated state directory and a
non-default port; the operator's live state was never opened. This is a smoke
capture: it shows a gateway with the patched ClickClack plugin loaded (`clickclack`
appears among the 17 loaded plugins) accepting a real `sessions.reset`. It does
**not** by itself show ClickClack's lifecycle hook running or scoped access staying
registered — that link comes from the source path
(`src/gateway/session-reset-service.ts:781` and `:1159` call the unfiltered cleanup,
`src/plugins/host-hook-cleanup.ts` fans it out to every runtime lifecycle) plus the
fan-out capture above.

### Why the scoped-access observation is not in this proof

ClawSweeper asked for a live capture showing an existing discussion still resolving
scoped access after an unrelated reset. That specific observation is not reachable
from outside the gateway, for three reasons found while attempting it:

1. Scoped access is consulted only by agent tools — `createSessionVisibilityGuard`
   has no gateway-RPC consumer (`src/agents/tools/sessions-history-tool.ts`,
   `sessions-search-tool.ts`, `sessions-tool.ts`). The `tools.invoke` RPC can drive
   those tools without a model, so this hop alone is not the blocker.
2. The observation is only meaningful with a discussion binding present.
   `isClickClackDiscussionSessionTarget` reads the binding store, the revoked-channel
   store, the session incarnation and the config account — no remote call — so a
   ClickClack server is not needed for the check itself.
3. Creating one through the product flow needs a reachable ClickClack server.
   `session.discussion.open` is a supported gateway RPC (`operator.write`) that calls
   the registered provider's `open()`, which is ClickClack's normal binding-creation
   path — but that call resolves a configured discussion account and talks to the
   server. The proof profile here deliberately points at an unreachable loopback
   port so the capture makes no outbound connections, so no binding could be created.
   Hand-writing a binding row into an isolated state database is technically possible
   — bindings are ordinary persisted plugin state that
   `ClickClackDiscussionBindingStore` indexes in its constructor — but that is
   fabricated state rather than a discussion the product created.

So the missing prerequisite is a reachable ClickClack server, not a missing seam.
Rather than stand up a fake ClickClack API and present it as a real setup, the
evidence here covers the reset path in a real gateway and the scoped-access behavior
in the real visibility registry, and the gap is stated plainly.

What was not tested: no live, pre-existing ClickClack discussion was observed
resolving scoped access after a reset — that is the gap described above. The
reconciliation timer's own behavior after `service.cleanup()` is not asserted beyond
the call being skipped, and the plugin-reload recovery path is traced in source
rather than executed.

Proof limitations: the focused tests stub two of the plugin's own local modules —
`./service.js` (its constructor opens a binding store against a live runtime) and
`./tool-policy.js`. The visibility registry, the lifecycle registration, and the
reason plumbing are real. The fan-out harness does exercise the real unfiltered
cleanup path and its plugin filter; what it does not exercise is the gateway handler
or a real ClickClack registration.

Test placement: `register.test.ts` is a new colocated file, matching the repo's
colocated `*.test.ts` convention and the existing
`extensions/acpx/register.runtime.test.ts` precedent for register-level tests.

<details>
<summary>Harness used for the fan-out capture (not in the diff)</summary>

Save as `.local-proof/live-teardown-harness.mts` (it imports `../src/...`, so it
must sit one directory below the repo root) and run
`./node_modules/.bin/tsx .local-proof/live-teardown-harness.mts` from the root.

```ts
import fs from "node:fs";
import os from "node:os";
import path from "node:path";

const root = fs.mkdtempSync(path.join(os.tmpdir(), "clickclack-teardown-proof-"));
fs.mkdirSync(path.join(root, "home", ".openclaw", "state"), { recursive: true });
process.env.HOME = path.join(root, "home");
process.env.OPENCLAW_STATE_DIR = path.join(root, "home", ".openclaw");

const { execFileSync } = await import("node:child_process");
const { runPluginHostCleanup } = await import("../src/plugins/host-hook-cleanup.js");

const registerSource = fs.readFileSync("extensions/clickclack/src/discussions/register.ts", "utf-8");
console.log(`git HEAD          : ${execFileSync("git", ["rev-parse", "HEAD"], { encoding: "utf8" }).trim()}`);
console.log(
  `clickclack guard  : ${
    registerSource.includes('reason === "reset" || reason === "delete"')
      ? "present (patched)"
      : "absent (unpatched)"
  }`,
);
console.log(`state dir         : ${process.env.OPENCLAW_STATE_DIR}`);

type Seen = { plugin: string; reason: string; sessionKey?: string };
const seen: Seen[] = [];
const lifecycle = (pluginId: string, id: string) => ({
  pluginId,
  lifecycle: {
    id,
    cleanup: (ctx: { reason: string; sessionKey?: string }) => {
      seen.push({ plugin: pluginId, reason: ctx.reason, sessionKey: ctx.sessionKey });
    },
  },
});

const registrations = [
  lifecycle("clickclack", "clickclack-discussions"),
  lifecycle("some-other-plugin", "other-runtime"),
];

const result = await runPluginHostCleanup({
  cfg: {} as never,
  registry: {
    sessionExtensions: [],
    runtimeLifecycles: registrations,
    agentEventSubscriptions: [],
    sessionSchedulerJobs: [],
    plugins: [],
  } as never,
  reason: "reset",
  sessionKey: "agent:main:unrelated-session",
  shouldCleanup: () => true,
});

console.log(`  cleanupCount             : ${result.cleanupCount}`);
console.log(`  runtime cleanups invoked : ${seen.length}`);
for (const entry of seen) {
  console.log(`    - ${entry.plugin}: reason=${entry.reason} sessionKey=${entry.sessionKey}`);
}
fs.rmSync(root, { recursive: true, force: true });
```

</details>
