### PR TITLE
fix(telegram): linkPreview:false is ignored on streamed replies

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch-draft.ts
+++ b/extensions/telegram/src/bot-message-dispatch-draft.ts
@@ -128,6 +128,7 @@ export function createTelegramDraftController(params: {
           replyToMessageId: params.draftReplyToMessageId,
           replyToMode: params.replyToMode,
           richMessages: params.telegramCfg.richMessages,
+          linkPreview: params.telegramCfg.linkPreview,
           minInitialChars: params.streamMode === "progress" ? 0 : DRAFT_MIN_INITIAL_CHARS,
           renderText: renderStreamText,
           onRetainedPage: (page) => {

--- a/extensions/telegram/src/draft-stream.test.ts
+++ b/extensions/telegram/src/draft-stream.test.ts
@@ -313,12 +313,22 @@ describe("createTelegramDraftStream", () => {
 
   it("disables link previews on the streamed send and on every edit", async () => {
     const api = createMockDraftApi();
-    const stream = createDraftStream(api, { linkPreview: false });
+    const stream = createDraftStream(api, {
+      linkPreview: false,
+      thread: { id: 42, scope: "dm" },
+      replyToMessageId: 411,
+      replyToMode: "all",
+    });
 
     stream.update("see https://example.com");
     await stream.flush();
 
     expect(api.sendMessage).toHaveBeenCalledWith(123, "see https://example.com", {
+      message_thread_id: 42,
+      reply_parameters: {
+        message_id: 411,
+        allow_sending_without_reply: true,
+      },
       link_preview_options: { is_disabled: true },
     });
 

--- a/extensions/telegram/src/draft-stream.test.ts
+++ b/extensions/telegram/src/draft-stream.test.ts
@@ -311,6 +311,65 @@ describe("createTelegramDraftStream", () => {
     });
   });
 
+  it("disables link previews on the streamed send and on every edit", async () => {
+    const api = createMockDraftApi();
+    const stream = createDraftStream(api, { linkPreview: false });
+
+    stream.update("see https://example.com");
+    await stream.flush();
+
+    expect(api.sendMessage).toHaveBeenCalledWith(123, "see https://example.com", {
+      link_preview_options: { is_disabled: true },
+    });
+
+    // The edit matters as much as the send: Telegram re-enables the preview on
+    // any edit that omits the field, and finalization skips the edit when the
+    // streamed draft already equals the final text.
+    stream.update("see https://example.com now");
+    await stream.flush();
+
+    expect(api.editMessageText).toHaveBeenCalledWith(123, 17, "see https://example.com now", {
+      link_preview_options: { is_disabled: true },
+    });
+  });
+
+  it("keeps parse_mode alongside disabled link previews on the HTML transport", async () => {
+    const api = createMockDraftApi();
+    const stream = createDraftStream(api, {
+      linkPreview: false,
+      renderText: (text) => ({ text: `<i>${text}</i>`, parseMode: "HTML" }),
+    });
+
+    stream.update("https://example.com");
+    await stream.flush();
+
+    expect(api.sendMessage).toHaveBeenCalledWith(123, "<i>https://example.com</i>", {
+      parse_mode: "HTML",
+      link_preview_options: { is_disabled: true },
+    });
+
+    stream.update("https://example.com/two");
+    await stream.flush();
+
+    expect(api.editMessageText).toHaveBeenCalledWith(123, 17, "<i>https://example.com/two</i>", {
+      parse_mode: "HTML",
+      link_preview_options: { is_disabled: true },
+    });
+  });
+
+  it("omits link_preview_options entirely when linkPreview is not disabled", async () => {
+    const api = createMockDraftApi();
+    const stream = createDraftStream(api);
+
+    stream.update("see https://example.com");
+    await stream.flush();
+    stream.update("see https://example.com now");
+    await stream.flush();
+
+    expect(api.sendMessage).toHaveBeenCalledWith(123, "see https://example.com", {});
+    expect(api.editMessageText).toHaveBeenCalledWith(123, 17, "see https://example.com now");
+  });
+
   it("finalizeToPreview edits the live window message in place without deleting", async () => {
     const api = createMockDraftApi();
     const stream = createDraftStream(api, { thread: { id: 42, scope: "dm" } });

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -235,6 +235,11 @@ export function createTelegramDraftStream(params: {
   replyToMode?: ReplyToMode;
   richMessages?: boolean;
   throttleMs?: number;
+  /**
+   * When false, suppress Telegram link previews on the streamed draft. Rich
+   * messages express this as `skip_entity_detection` at render time instead.
+   */
+  linkPreview?: boolean;
   /** Minimum chars before sending first message (debounce for push notifications) */
   minInitialChars?: number;
   /** Optional preview renderer (e.g. markdown -> HTML + parse mode). */
@@ -252,6 +257,12 @@ export function createTelegramDraftStream(params: {
   const throttleMs = Math.max(250, params.throttleMs ?? DEFAULT_THROTTLE_MS);
   const minInitialChars = params.minInitialChars;
   const chatId = params.chatId;
+  // Telegram re-enables the preview on any edit that omits the field, so the
+  // flag has to ride along with every send AND every edit, not just the first
+  // send. Finalization cannot be relied on to clean it up: it deliberately
+  // skips the edit when the streamed draft already equals the final text.
+  const linkPreviewParams =
+    params.linkPreview === false ? ({ link_preview_options: { is_disabled: true } } as const) : {};
   const threadParams = buildTelegramThreadParams(params.thread);
   const replyToMessageId = normalizeTelegramReplyToMessageId(params.replyToMessageId);
   const initialSendMessageParams =
@@ -312,6 +323,18 @@ export function createTelegramDraftStream(params: {
   // ephemeral preview to delete, NOT a durable content chunk to retain — that
   // distinguishes a reposition from forceNewMessage's continuation-chunk race.
   const repositionedSendGenerations = new Set<number>();
+  // Keep the call arity unchanged when no preview options apply: an explicit
+  // trailing `undefined` is a different call than omitting the argument.
+  const editMessageTextWithPreview = async (
+    messageId: number,
+    text: string,
+    other?: NonNullable<Parameters<Bot["api"]["editMessageText"]>[3]>,
+  ) => {
+    const merged = other ? { ...other, ...linkPreviewParams } : linkPreviewParams;
+    return Object.keys(merged).length > 0
+      ? await params.api.editMessageText(chatId, messageId, text, merged)
+      : await params.api.editMessageText(chatId, messageId, text);
+  };
   const fallbackSnapshot = (plainText: string): TelegramDraftMessageSnapshot => ({
     text: plainText,
     sourceText: escapeTelegramHtml(plainText),
@@ -377,14 +400,20 @@ export function createTelegramDraftStream(params: {
           throw err;
         }
         return {
-          message: await params.api.sendMessage(chatId, fallbackPlan.plainText, sendMessageParams),
+          message: await params.api.sendMessage(chatId, fallbackPlan.plainText, {
+            ...sendMessageParams,
+            ...linkPreviewParams,
+          }),
           snapshot: fallbackSnapshot(fallbackPlan.plainText),
         };
       }
     }
     if (page.sourceTextMode !== "html") {
       return {
-        message: await params.api.sendMessage(chatId, page.text, sendMessageParams),
+        message: await params.api.sendMessage(chatId, page.text, {
+          ...sendMessageParams,
+          ...linkPreviewParams,
+        }),
         snapshot: page,
       };
     }
@@ -393,6 +422,7 @@ export function createTelegramDraftStream(params: {
         message: await params.api.sendMessage(chatId, page.sourceText, {
           parse_mode: "HTML" as const,
           ...sendMessageParams,
+          ...linkPreviewParams,
         }),
         snapshot: page,
       };
@@ -401,7 +431,10 @@ export function createTelegramDraftStream(params: {
         throw err;
       }
       return {
-        message: await params.api.sendMessage(chatId, page.text, sendMessageParams),
+        message: await params.api.sendMessage(chatId, page.text, {
+          ...sendMessageParams,
+          ...linkPreviewParams,
+        }),
         snapshot: fallbackSnapshot(page.text),
       };
     }
@@ -436,23 +469,23 @@ export function createTelegramDraftStream(params: {
           if (!fallbackPlan) {
             throw err;
           }
-          await params.api.editMessageText(chatId, targetMessageId, fallbackPlan.plainText);
+          await editMessageTextWithPreview(targetMessageId, fallbackPlan.plainText);
           acceptedSnapshot = fallbackSnapshot(fallbackPlan.plainText);
         }
       } else if (page.sourceTextMode === "html") {
         try {
-          await params.api.editMessageText(chatId, targetMessageId, page.sourceText, {
+          await editMessageTextWithPreview(targetMessageId, page.sourceText, {
             parse_mode: "HTML" as const,
           });
         } catch (err) {
           if (!isTelegramHtmlParseError(err)) {
             throw err;
           }
-          await params.api.editMessageText(chatId, targetMessageId, page.text);
+          await editMessageTextWithPreview(targetMessageId, page.text);
           acceptedSnapshot = fallbackSnapshot(page.text);
         }
       } else {
-        await params.api.editMessageText(chatId, targetMessageId, page.sourceText);
+        await editMessageTextWithPreview(targetMessageId, page.sourceText);
       }
       if (sendGeneration === generation && streamMessageId === targetMessageId) {
         streamMessageSnapshot = acceptedSnapshot;


### PR DESCRIPTION
Closes #111525

> AI-assisted: written with Claude Code. The source tracing and the before/after test runs below were verified locally by me.

## What Problem This Solves

Fixes an issue where users running Telegram with `channels.telegram.linkPreview: false` would still get link-preview cards on streamed replies. Any answer containing a URL unfurls it, so the setting silently does not hold for the delivery path most users actually see.

Non-streamed sends (the `message` tool, the CLI send path) already honor the flag, which makes the inconsistency hard to diagnose: the same config visibly works on one path and not the other.

## Why This Change Was Made

`createTelegramDraftStream` was never given `linkPreview` at its creation site in `createDraftLane`, and never set `link_preview_options` on either its initial `sendMessage` or any of its `editMessageText` calls.

Finalization does not rescue it. `editStreamMessage` does pass `linkPreview`, but finalization deliberately skips that edit when the streamed draft text already equals the final text — which is the common case, since the draft *is* the final message. So the preview survives.

Two details drove the shape of the fix:

- **Every edit needs the field, not just the send.** Telegram re-enables the preview on any `editMessageText` that omits `link_preview_options`, so setting it once on the first send is not enough.
- **Rich messages are already handled.** The rich path expresses this as `skip_entity_detection` at render time (`bot-message-dispatch-draft.ts:111`), matching how `delivery.send.ts` splits the two transports. This PR deliberately leaves that path alone and only fixes the HTML/plain transports, plus the plain fallbacks the rich path drops to on error.

Edit calls go through a small helper that preserves call arity when no preview options apply — appending an explicit `undefined` would have changed existing three-argument `editMessageText` assertions without changing behavior.

## User Impact

`channels.telegram.linkPreview: false` now suppresses link previews on streamed replies, matching the non-streamed send path and the documented meaning of the setting. Users who set it stop seeing unfurled cards on the streaming path. Behavior is unchanged when `linkPreview` is unset or `true`: no `link_preview_options` field is sent at all.

## Evidence

Three tests added to `extensions/telegram/src/draft-stream.test.ts`: preview disabled on send *and* on the follow-up edit, `parse_mode` preserved alongside it on the HTML transport, and a guard that the field stays absent by default.

**Before** (fix neutralized, tests present) — the two behavior tests fail, and the default-path guard correctly still passes:

```
 × disables link previews on the streamed send and on every edit 16ms
 × keeps parse_mode alongside disabled link previews on the HTML transport 4ms

 Test Files  1 failed (1)
      Tests  2 failed | 85 passed (87)
```

**After** (fix applied):

```
$ node scripts/run-vitest.mjs run extensions/telegram/src/draft-stream.test.ts

 Test Files  1 passed (1)
      Tests  87 passed (87)
```

No regressions in the dispatch paths that build the draft lane:

```
$ node scripts/run-vitest.mjs run \
    extensions/telegram/src/bot-message-dispatch.draft-finalization.test.ts \
    extensions/telegram/src/bot-message-dispatch.draft-rotation.test.ts \
    extensions/telegram/src/bot-message-dispatch.draft-failures-progress.test.ts

 Test Files  3 passed (3)
      Tests  45 passed (45)
```

I do not have a live Telegram bot to record the unfurl itself, so the proof here is the transport-level assertion that `link_preview_options: { is_disabled: true }` now rides on both the send and the edit — which is the exact API contract the issue identifies as missing. The issue reporter states they are carrying a local patch doing the same thing and offered to test a fix.
