### PR TITLE
fix(ui): show workspace avatar in sidebar

### DIFF
--- a/ui/src/components/app-sidebar-agent-menu.ts
+++ b/ui/src/components/app-sidebar-agent-menu.ts
@@ -2,6 +2,7 @@
 // component inside the TS LOC ratchet.
 import { html, nothing } from "lit";
 import { ref } from "lit/directives/ref.js";
+import type { AgentIdentityResult } from "../api/types.ts";
 import { titleForRoute, type NavigationRouteId } from "../app-navigation.ts";
 import type { ApplicationNavigationOptions } from "../app/context.ts";
 import type { ThemeMode } from "../app/theme.ts";
@@ -57,6 +58,7 @@ type SidebarAgentMenuParams = {
   activeId: string;
   activeName: string;
   agents: readonly AgentMenuAgent[];
+  identities: ReadonlyMap<string, AgentIdentityResult>;
   filter: string;
   pinnedAgentIds: readonly string[];
   connected: boolean;
@@ -99,6 +101,7 @@ function sidebarAgentMenuRows(params: {
   activeId: string;
   filter: string;
   pinnedAgentIds: readonly string[];
+  identities: ReadonlyMap<string, AgentIdentityResult>;
 }) {
   const { agents, activeId } = params;
   const availableIds = new Set(agents.map((agent) => normalizeAgentId(agent.id)));
@@ -121,7 +124,9 @@ function sidebarAgentMenuRows(params: {
       const agentId = normalizeAgentId(entry.id);
       return (
         agentId.toLowerCase().includes(query) ||
-        normalizeAgentLabel(entry).toLowerCase().includes(query)
+        (params.identities.get(agentId)?.name?.trim() || normalizeAgentLabel(entry))
+          .toLowerCase()
+          .includes(query)
       );
     });
     return { rows, showFilter: true };
@@ -147,7 +152,8 @@ function sidebarAgentMenuRows(params: {
 
 function renderAgentRow(agent: AgentMenuAgent, params: SidebarAgentMenuParams) {
   const agentId = normalizeAgentId(agent.id);
-  const label = normalizeAgentLabel(agent);
+  const identity = params.identities.get(agentId) ?? null;
+  const label = identity?.name?.trim() || normalizeAgentLabel(agent);
   const active = agentId === params.activeId;
   const unread = active ? 0 : params.agentUnreadCount(agentId);
   const approvals = params.agentApprovalCount(agentId);
@@ -165,7 +171,7 @@ function renderAgentRow(agent: AgentMenuAgent, params: SidebarAgentMenuParams) {
       aria-checked=${String(active)}
       ${ref((element) => syncDropdownItemRadio(element, active))}
     >
-      <span slot="icon">${renderAgentSelectAvatar(option)}</span>
+      <span slot="icon">${renderAgentSelectAvatar(option, identity)}</span>
       ${renderAgentSelectCopy(option)}
       ${approvals > 0
         ? html`<span

--- a/ui/src/components/app-sidebar-render.ts
+++ b/ui/src/components/app-sidebar-render.ts
@@ -68,15 +68,21 @@ function readSidebarNativeGateway(): SidebarNativeGateway | null {
 }
 
 export function renderAppSidebarBrand(host: AppSidebarRenderHost) {
-  const { activeId: cardAgentId, agent: cardAgent, agents: cardAgents } = host.activeChipAgent();
+  const {
+    activeId: cardAgentId,
+    agent: cardAgent,
+    agents: cardAgents,
+    identity: cardIdentity,
+  } = host.activeChipAgent();
   const menuUnread = cardAgents.some((entry) => {
     const agentId = normalizeAgentId(entry.id);
     return agentId !== cardAgentId && host.agentUnreadCount(agentId) > 0;
   });
-  const cardName = cardAgent ? normalizeAgentLabel(cardAgent) : cardAgentId;
+  const cardName =
+    cardIdentity?.name?.trim() || (cardAgent ? normalizeAgentLabel(cardAgent) : cardAgentId);
   const approvalCount = host.sessionData.approvalBadgeSnapshot().agentCounts.get(cardAgentId) ?? 0;
   const cardAvatarText =
-    (cardAgent ? resolveAgentTextAvatar(cardAgent) : null) ??
+    (cardAgent ? resolveAgentTextAvatar(cardAgent, cardIdentity) : cardIdentity?.emoji) ??
     (cardName || cardAgentId).slice(0, 1).toUpperCase();
   // The sidebar action follows gateway availability; collapsed native chrome
   // keeps its separate offline-tolerant ⌘N mirror.
@@ -84,7 +90,9 @@ export function renderAppSidebarBrand(host: AppSidebarRenderHost) {
     <div class="sidebar-brand">
       <openclaw-sidebar-agent-card
         .agentName=${cardName}
-        .avatarUrl=${cardAgent ? resolveAgentAvatarUrl(cardAgent) : null}
+        .avatarUrl=${cardAgent
+          ? resolveAgentAvatarUrl(cardAgent, cardIdentity)
+          : cardIdentity?.avatar}
         .avatarText=${cardAvatarText}
         .subtitle=${host.agentChipSubtitle(cardAgentId)}
         .menuOpen=${host.sidebarMenus.agentMenuPosition !== null}

--- a/ui/src/components/app-sidebar-session-navigation.ts
+++ b/ui/src/components/app-sidebar-session-navigation.ts
@@ -470,7 +470,14 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
     const roster = this.context?.agents.state.agentsList?.agents ?? [];
     const activeId = this.expandedAgentId();
     const agent = roster.find((entry) => normalizeAgentId(entry.id) === activeId);
-    return { activeId, agent, agents: listSelectableAgents(roster) };
+    const identities = new Map(
+      (this.context?.agentIdentity.entries() ?? []).map(
+        (identity) => [identity.agentId, identity] as const,
+      ),
+    );
+    const agents = listSelectableAgents(roster);
+    const identity = identities.get(activeId) ?? null;
+    return { activeId, agent, agents, identity, identities };
   }
 
   /** Newest visible session for an agent; the chip menu resumes here. */

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -89,12 +89,17 @@ class AppSidebar extends AppSidebarSessionNavigationElement implements SessionLi
       }
     },
   );
+  private readonly agentIdentitySubscriptions = new SubscriptionsController(this).watch(
+    () => this.context?.agentIdentity,
+    (agentIdentity, notify) => agentIdentity.subscribe(notify),
+  );
 
   @state() catalogProjectGrouping = loadStoredSidebarCatalogGrouping();
 
   constructor() {
     super();
     void this.narrationSubscriptions;
+    void this.agentIdentitySubscriptions;
     void new BoardAvailabilityController(
       this,
       () => {
@@ -146,6 +151,14 @@ class AppSidebar extends AppSidebarSessionNavigationElement implements SessionLi
 
   protected override willUpdate(changed: PropertyValues<this>) {
     super.willUpdate(changed);
+    const chip = this.activeChipAgent();
+    // An open switcher tracks roster/reconnect updates; otherwise only hydrate
+    // the active card and avoid background RPCs for every configured agent.
+    const identityIds =
+      this.sidebarMenus.agentMenuPosition === null
+        ? [chip.activeId]
+        : chip.agents.map((agent) => agent.id);
+    this.ensureAgentIdentities(identityIds);
     // A fresh draft must be visible where it will live: genuinely expand a
     // collapsed Threads section (persisted) instead of overriding at render
     // time, so the header toggle keeps matching the visible state.
@@ -155,6 +168,12 @@ class AppSidebar extends AppSidebarSessionNavigationElement implements SessionLi
       this.collapsedSessionSections.has("ungrouped")
     ) {
       this.sessionOrganizer.toggleSection("ungrouped");
+    }
+  }
+
+  ensureAgentIdentities(agentIds: readonly string[]): void {
+    if (this.connected) {
+      void this.context?.agentIdentity.ensure(agentIds);
     }
   }
 

--- a/ui/src/components/sidebar-menus-controller.ts
+++ b/ui/src/components/sidebar-menus-controller.ts
@@ -1,4 +1,5 @@
 import { nothing, type ReactiveController, type ReactiveControllerHost } from "lit";
+import type { AgentIdentityResult } from "../api/types.ts";
 import {
   cancelRoutePreload,
   scheduleRoutePreload,
@@ -102,7 +103,10 @@ export interface SidebarMenusControllerHost
     activeId: string;
     agent: SidebarMenuAgent | undefined;
     agents: readonly SidebarMenuAgent[];
+    identity: AgentIdentityResult | null;
+    identities: ReadonlyMap<string, AgentIdentityResult>;
   };
+  ensureAgentIdentities(agentIds: readonly string[]): void;
   agentUnreadCount(agentId: string): number;
   askAgentCapabilities(agentId: string): void;
   getRouteSessionKey(): string;

--- a/ui/src/components/sidebar-menus-render.ts
+++ b/ui/src/components/sidebar-menus-render.ts
@@ -73,12 +73,13 @@ export function renderSidebarAgentMenuForController(controller: SidebarMenusCont
   const { host } = controller;
   const position = controller.agentMenuPosition;
   const trigger = controller.agentMenuTrigger;
-  const { activeId, agent, agents } = host.activeChipAgent();
+  const { activeId, agent, agents, identity, identities } = host.activeChipAgent();
   return renderSidebarAgentMenu({
     position,
     activeId,
-    activeName: agent ? normalizeAgentLabel(agent) : activeId,
+    activeName: identity?.name?.trim() || (agent ? normalizeAgentLabel(agent) : activeId),
     agents,
+    identities,
     filter: controller.agentMenuFilter,
     pinnedAgentIds: host.pinnedAgentIds,
     connected: host.connected,

--- a/ui/src/e2e/sidebar-customization.e2e.test.ts
+++ b/ui/src/e2e/sidebar-customization.e2e.test.ts
@@ -888,16 +888,30 @@ describeControlUiE2e("Control UI sidebar customization mocked Gateway E2E", () =
     });
     const page = await context.newPage();
     const agentsList = {
-      agents: [
-        { id: "main", identity: { name: "Main" }, name: "Main" },
-        { id: "research", identity: { name: "Research" }, name: "Research" },
-      ],
+      agents: [{ id: "main" }, { id: "research" }],
       defaultId: "main",
       mainKey: "main",
       scope: "agent",
     };
     await installMockGateway(page, {
       methodResponses: {
+        "agent.identity.get": {
+          cases: [
+            {
+              match: { agentId: "main" },
+              response: { agentId: "main", avatar: "", emoji: "🦞", name: "Main" },
+            },
+            {
+              match: { agentId: "research" },
+              response: {
+                agentId: "research",
+                avatar:
+                  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
+                name: "Research",
+              },
+            },
+          ],
+        },
         "agents.list": agentsList,
         "chat.startup": {
           agentsList,
@@ -923,6 +937,9 @@ describeControlUiE2e("Control UI sidebar customization mocked Gateway E2E", () =
           ),
         )
         .toBe(true);
+      await expect
+        .poll(() => researchSwitch.locator("img.agent-select__avatar").getAttribute("src"))
+        .toContain("data:image/png;base64,");
       await expect.poll(() => menu.getByText(/^New thread —/).count()).toBe(0);
       await expect
         .poll(() => mainSwitch.evaluate((element) => element === document.activeElement))
@@ -936,6 +953,58 @@ describeControlUiE2e("Control UI sidebar customization mocked Gateway E2E", () =
       await expect
         .poll(() => new URL(page.url()).pathname)
         .toBe(controlUiSessionPath("agent:research:main"));
+    } finally {
+      await context.close();
+    }
+  });
+
+  it("shows a workspace identity avatar in the sidebar agent card", async () => {
+    const context = await browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1440 },
+    });
+    const page = await context.newPage();
+    const agentsList = {
+      agents: [{ id: "main" }],
+      defaultId: "main",
+      mainKey: "main",
+      scope: "agent",
+    };
+    const avatar =
+      "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=";
+    const gateway = await installMockGateway(page, {
+      methodResponses: {
+        "agent.identity.get": {
+          agentId: "main",
+          avatar,
+          avatarStatus: "data",
+          name: "Workspace Molty",
+        },
+        "agents.list": agentsList,
+        "chat.startup": {
+          agentsList,
+          messages: [],
+          metadata: { models: [] },
+          sessionId: "control-ui-e2e-session",
+          thinkingLevel: null,
+        },
+      },
+    });
+
+    try {
+      await page.goto(`${server.baseUrl}chat`);
+      await gateway.waitForRequest("agent.identity.get");
+      const card = page.locator("openclaw-app-sidebar openclaw-sidebar-agent-card");
+      await expect
+        .poll(() => card.locator(".sidebar-agent-card__name").textContent())
+        .toContain("Workspace Molty");
+      const image = card.locator(".sidebar-agent-card__avatar img");
+      await expect.poll(() => image.getAttribute("src")).toBe(avatar);
+      await expect
+        .poll(() => image.evaluate((element: HTMLImageElement) => element.naturalWidth))
+        .toBe(1);
+      await captureUiProof(page, "workspace-agent-avatar.png");
     } finally {
       await context.close();
     }

--- a/ui/src/test-helpers/app-sidebar-cases/agent-menu.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/agent-menu.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import type { AgentsListResult } from "../../api/types.ts";
+import { createAgentIdentityCapability } from "../../lib/agents/identity.ts";
 import { SESSION_FACE_PREFERENCE_PARAM } from "../../lib/sessions/route-navigation.ts";
 import {
   createGateway,
@@ -12,6 +14,80 @@ import {
 import "../../components/app-sidebar.ts";
 
 describe("AppSidebar agent chip", () => {
+  it("loads the workspace identity used by the Agents editor", async () => {
+    const request = vi.fn().mockResolvedValue({
+      agentId: "main",
+      name: "Workspace Molty",
+      emoji: "🦞",
+      avatar: "data:image/png;base64,d29ya3NwYWNl",
+    });
+    const gatewayHarness = createGatewayHarness({ request } as unknown as GatewayBrowserClient);
+    const agentIdentity = createAgentIdentityCapability(gatewayHarness.gateway);
+    const { sidebar } = await mountSidebar(
+      gatewayHarness.gateway,
+      createSessions("main", ["agent:main:main"]),
+      "panel",
+      {
+        defaultId: "main",
+        mainKey: "main",
+        scope: "agent",
+        agents: [{ id: "main" }],
+      },
+      [],
+      agentIdentity,
+    );
+
+    sidebar.connected = true;
+    await vi.waitFor(() => {
+      expect(sidebar.querySelector(".sidebar-agent-card__name")?.textContent?.trim()).toContain(
+        "Workspace Molty",
+      );
+      expect(sidebar.querySelector<HTMLImageElement>(".sidebar-agent-card__avatar img")?.src).toBe(
+        "data:image/png;base64,d29ya3NwYWNl",
+      );
+    });
+    expect(request).toHaveBeenCalledWith("agent.identity.get", { agentId: "main" });
+  });
+
+  it("hydrates agents added while the switcher remains open", async () => {
+    const request = vi.fn(async (_method: string, params: { agentId: string }) => ({
+      agentId: params.agentId,
+      name: `Workspace ${params.agentId}`,
+    }));
+    const gatewayHarness = createGatewayHarness({ request } as unknown as GatewayBrowserClient);
+    const agentIdentity = createAgentIdentityCapability(gatewayHarness.gateway);
+    const { sidebar, context } = await mountSidebar(
+      gatewayHarness.gateway,
+      createSessions("main", ["agent:main:main"]),
+      "panel",
+      {
+        defaultId: "main",
+        mainKey: "main",
+        scope: "agent",
+        agents: [{ id: "main" }],
+      },
+      [],
+      agentIdentity,
+    );
+    sidebar.connected = true;
+    await vi.waitFor(() =>
+      expect(request).toHaveBeenCalledWith("agent.identity.get", { agentId: "main" }),
+    );
+    sidebar.querySelector<HTMLButtonElement>(".sidebar-agent-card__main")?.click();
+    await sidebar.updateComplete;
+    expect(sidebar.querySelector(".sidebar-agent-menu")).not.toBeNull();
+
+    (context.agents.state as { agentsList: AgentsListResult | null }).agentsList = TWO_AGENTS;
+    sidebar.requestUpdate();
+
+    await vi.waitFor(() => {
+      expect(request).toHaveBeenCalledWith("agent.identity.get", { agentId: "research" });
+      expect(sidebar.querySelector(".sidebar-agent-menu")?.textContent).toContain(
+        "Workspace research",
+      );
+    });
+  });
+
   it("opens the agent-scoped menu with its inline roster", async () => {
     const gatewayHarness = createGatewayHarness({} as GatewayBrowserClient);
     const setSessionKey = vi.fn();

--- a/ui/src/test-helpers/app-sidebar.ts
+++ b/ui/src/test-helpers/app-sidebar.ts
@@ -20,6 +20,7 @@ import type {
 } from "../components/app-sidebar-workboard.ts";
 import type { SessionDataController } from "../components/session-data-controller.ts";
 import type { SessionOrganizerController } from "../components/session-organizer-controller.ts";
+import type { AgentIdentityCapability } from "../lib/agents/identity.ts";
 import type { SessionCapability } from "../lib/sessions/index.ts";
 import { reconcileSessionHistory } from "../lib/sessions/reconcile.ts";
 import { createApplicationContextProvider } from "./application-context.ts";
@@ -307,6 +308,13 @@ export function createContext(
   sessions: SessionCapability,
   agentsList: AgentsListResult | null = null,
   approvalQueue: readonly ExecApprovalRequest[] = [],
+  agentIdentity: AgentIdentityCapability = {
+    get: () => null,
+    entries: () => [],
+    ensure: async () => undefined,
+    invalidate: () => undefined,
+    subscribe: () => () => undefined,
+  },
 ): ApplicationContext<RouteId> {
   const selectedAgentId = sessions.state.agentId ?? "main";
   return {
@@ -322,6 +330,7 @@ export function createContext(
       },
       subscribe: () => () => undefined,
     },
+    agentIdentity,
     agentSelection: {
       state: { selectedId: selectedAgentId, scopeId: selectedAgentId },
       set: () => undefined,
@@ -341,8 +350,9 @@ export async function mountSidebar(
   variant: SidebarLifecycleState["variant"] = "panel",
   agentsList: AgentsListResult | null = null,
   approvalQueue: readonly ExecApprovalRequest[] = [],
+  agentIdentity?: AgentIdentityCapability,
 ) {
-  const context = createContext(gateway, sessions, agentsList, approvalQueue);
+  const context = createContext(gateway, sessions, agentsList, approvalQueue, agentIdentity);
   const provider = createApplicationContextProvider(context);
   const sidebar = document.createElement(
     "openclaw-app-sidebar",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users who configure an agent identity in the workspace would still see the fallback agent name or avatar in the Control UI sidebar and agent switcher, even though the identity appeared correctly in the Agents editor.

## Why This Change Was Made

The sidebar now consumes the existing `agent.identity.get` capability used by the Agents editor, subscribes to identity updates, and lazily hydrates the active agent plus switcher rows. This keeps workspace-backed names and avatars consistent without adding a new API or identity source.

AI-assisted implementation; the final diff was reviewed with the repository autoreview workflow.

## User Impact

Configured workspace agent names and avatars now appear in the top sidebar card and agent switcher. Users no longer get a fallback initial or stale config-only identity on those surfaces.

## Evidence

- Exact head: `baf180df024b6ae0e6297d32f88f314916a66a61`.
- `node scripts/run-vitest.mjs ui/src/components/app-sidebar.test.ts` — **194 tests passed**, including an open-switcher roster-refresh regression.
- Added browser scenario: **1 passed** (`shows a workspace identity avatar in the sidebar agent card`), covering the active card and inactive switcher identity.
- Full sidebar browser file: the other **10 scenarios passed**; one unrelated settings-search scenario timed out twice on a detached/missing existing control during the full-file run.
- `pnpm build` — passed after the initial current-main rebase, including the production Control UI build and performance gates; final-head hosted build is required below.
- `pnpm lint` — passed on the final head after moving identity hydration below the 700-line ratchet.
- `git diff --check origin/main..HEAD` — passed.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --stream-engine-output` — clean; no accepted/actionable findings.

### Real Gateway proof

[Redacted exact-head diagnostic artifact](https://litter.catbox.moe/jbudck.json) from an isolated real OpenClaw Gateway on Node 24.15.0:

- `/readyz` returned **200**.
- Real `agents.list` returned `main` and `research` with `main` as the default.
- Both agents used real temporary workspace `IDENTITY.md` files with workspace-relative `avatars/avatar.png` paths.
- Real `agent.identity.get` returned `avatarStatus: local`, preserved `avatarSource: avatars/avatar.png`, and produced PNG data URLs for both the active and inactive agents.
- The endpoint, temporary paths, and credentials are redacted; no user data or secrets are present.

### Browser proof

The mocked browser proof exercises the exact rendering lifecycle after the real Gateway contract proof above:

![Workspace avatar and name in the sidebar card](https://litter.catbox.moe/b9lwm1.png)

![Inactive agent identity in the sidebar switcher](https://litter.catbox.moe/lpn9os.png)
