### PR TITLE
fix(worktrees): reclaim git worktree locks left by dead processes

### DIFF
--- a/src/agents/worktrees/git-lock.test.ts
+++ b/src/agents/worktrees/git-lock.test.ts
@@ -1,0 +1,117 @@
+import { execFile, spawn } from "node:child_process";
+import { once } from "node:events";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { promisify } from "node:util";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { lockState, lockWorktreeForProcess } from "./git-lock.js";
+import { listGitWorktrees } from "./git.js";
+import type { ManagedWorktreeRecord } from "./types.js";
+
+const execFileAsync = promisify(execFile);
+
+async function git(cwd: string, ...args: string[]): Promise<void> {
+  await execFileAsync("git", ["-C", cwd, ...args]);
+}
+
+/** A pid that has exited, so isPidDefinitelyDead reports ESRCH for it. */
+async function exitedPid(): Promise<number> {
+  const child = spawn(process.execPath, ["-e", ""], { stdio: "ignore" });
+  const pid = child.pid;
+  await once(child, "close");
+  if (pid === undefined) {
+    throw new Error("failed to spawn probe process");
+  }
+  return pid;
+}
+
+async function lockedReason(repoRoot: string, worktreePath: string): Promise<string | undefined> {
+  const entries = await listGitWorktrees(repoRoot);
+  return entries.find((entry) => path.resolve(entry.path) === path.resolve(worktreePath))
+    ?.lockedReason;
+}
+
+describe("lockWorktreeForProcess", () => {
+  const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+  async function setupWorktree(): Promise<ManagedWorktreeRecord> {
+    const root = await fs.realpath(tempDirs.make("openclaw-git-lock-"));
+    const repo = path.join(root, "repo");
+    await fs.mkdir(repo, { recursive: true });
+    await git(repo, "init", "-b", "main");
+    await git(repo, "config", "user.name", "OpenClaw Test");
+    await git(repo, "config", "user.email", "openclaw-test@example.invalid");
+    await fs.writeFile(path.join(repo, "README.md"), "base\n");
+    await git(repo, "add", "README.md");
+    await git(repo, "commit", "-m", "initial");
+    const worktreePath = path.join(root, "wt-lock");
+    await git(repo, "worktree", "add", "-b", "wt-lock", worktreePath, "HEAD");
+    return {
+      id: "wt-lock",
+      name: "wt-lock",
+      repoFingerprint: "fingerprint",
+      repoRoot: repo,
+      path: worktreePath,
+      branch: "wt-lock",
+      baseRef: "main",
+      ownerKind: "session",
+      createdAt: 0,
+      lastActiveAt: 0,
+    };
+  }
+
+  it("reclaims a lock left behind by a dead OpenClaw process", async () => {
+    const record = await setupWorktree();
+    const stalePid = await exitedPid();
+    await git(
+      record.repoRoot,
+      "worktree",
+      "lock",
+      "--reason",
+      `openclaw pid=${stalePid}`,
+      record.path,
+    );
+    expect(await lockState(record)).toEqual({ kind: "dead", pid: stalePid });
+
+    await expect(lockWorktreeForProcess(record)).resolves.toBeUndefined();
+
+    expect(await lockedReason(record.repoRoot, record.path)).toBe(`openclaw pid=${process.pid}`);
+  });
+
+  it("keeps a lock held by a live OpenClaw process", async () => {
+    const record = await setupWorktree();
+    // The parent process is alive and is not this process, so the lock must stand.
+    const livePid = process.ppid;
+    await git(
+      record.repoRoot,
+      "worktree",
+      "lock",
+      "--reason",
+      `openclaw pid=${livePid}`,
+      record.path,
+    );
+
+    await expect(lockWorktreeForProcess(record)).rejects.toThrow(/git worktree lock/);
+
+    expect(await lockedReason(record.repoRoot, record.path)).toBe(`openclaw pid=${livePid}`);
+  });
+
+  it("keeps a foreign lock that OpenClaw does not own", async () => {
+    const record = await setupWorktree();
+    await git(record.repoRoot, "worktree", "lock", "--reason", "held by hand", record.path);
+
+    await expect(lockWorktreeForProcess(record)).rejects.toThrow(/git worktree lock/);
+
+    expect(await lockedReason(record.repoRoot, record.path)).toBe("held by hand");
+  });
+
+  it("is idempotent for a lock this process already holds", async () => {
+    const record = await setupWorktree();
+    await lockWorktreeForProcess(record);
+
+    await expect(lockWorktreeForProcess(record)).resolves.toBeUndefined();
+
+    expect(await lockedReason(record.repoRoot, record.path)).toBe(`openclaw pid=${process.pid}`);
+  });
+});

--- a/src/agents/worktrees/git-lock.ts
+++ b/src/agents/worktrees/git-lock.ts
@@ -28,19 +28,44 @@ export async function lockState(record: ManagedWorktreeRecord): Promise<LockStat
   return isPidDefinitelyDead(pid) ? { kind: "dead", pid } : { kind: "live", pid };
 }
 
-export async function lockWorktreeForProcess(record: ManagedWorktreeRecord): Promise<void> {
-  const result = await runGit(record.repoRoot, [
+function heldByThisProcess(state: LockState): boolean {
+  return state.kind === "live" && state.pid === process.pid;
+}
+
+async function runLock(record: ManagedWorktreeRecord) {
+  return await runGit(record.repoRoot, [
     "worktree",
     "lock",
     "--reason",
     `openclaw pid=${process.pid}`,
     record.path,
   ]);
-  if (result.code !== 0) {
-    const state = await lockState(record);
-    if (state.kind !== "live" || state.pid !== process.pid) {
-      throw commandError("git worktree lock", result);
-    }
+}
+
+export async function lockWorktreeForProcess(record: ManagedWorktreeRecord): Promise<void> {
+  const result = await runLock(record);
+  if (result.code === 0) {
+    return;
+  }
+  const state = await lockState(record);
+  if (heldByThisProcess(state)) {
+    return;
+  }
+  // A lock naming a dead OpenClaw pid is restart residue: the owner died (crash or
+  // update restart) without unlocking, so git refuses every later lock forever and
+  // the run would otherwise proceed unprotected. remove()/release() already treat a
+  // dead owner as reclaimable, so reclaim it here instead of failing the acquire.
+  // Accepted tradeoff: the observe-then-unlock window is the same one those two
+  // callers already take, so two processes reclaiming the identical stale lock at
+  // once can both believe they won. Closing it needs a reclaim guard shared by all
+  // three call sites (openclaw#114129); today's behavior loses the lock every time.
+  if (state.kind !== "dead") {
+    throw commandError("git worktree lock", result);
+  }
+  await unlockWorktree(record);
+  const retry = await runLock(record);
+  if (retry.code !== 0 && !heldByThisProcess(await lockState(record))) {
+    throw commandError("git worktree lock", retry);
   }
 }
 

--- a/src/agents/worktrees/git-lock.ts
+++ b/src/agents/worktrees/git-lock.ts
@@ -57,8 +57,10 @@ export async function lockWorktreeForProcess(record: ManagedWorktreeRecord): Pro
   // dead owner as reclaimable, so reclaim it here instead of failing the acquire.
   // Accepted tradeoff: the observe-then-unlock window is the same one those two
   // callers already take, so two processes reclaiming the identical stale lock at
-  // once can both believe they won. Closing it needs a reclaim guard shared by all
-  // three call sites (openclaw#114129); today's behavior loses the lock every time.
+  // once can both believe they won. Closing it needs one reclaim guard shared by all
+  // four paths -- this acquire plus service.ts release(), remove(), and
+  // isProtectedFromAutoRemoval() (openclaw#114129); today's behavior instead loses
+  // the lock every time.
   if (state.kind !== "dead") {
     throw commandError("git worktree lock", result);
   }


### PR DESCRIPTION
## What Problem This Solves

On team.openclaw.ai, agent worktrees stop being lock-protected after any gateway restart. The journal shows it directly, 12 times in 24 hours:

```
Jul 26 15:16:20 openclaw-team node[2005252]: fatal: '/home/openclaw/.openclaw/worktrees/1e598874939a02aa/wt-fc8dbb29' is already locked, reason: openclaw pid=1829694
```

Every one of those pids is a dead process from an earlier gateway generation. Six worktrees on that host are currently pinned by three dead pids (`1662213`, `1323185`, `1829694`); `git worktree list` reports them as `locked` with no live owner.

`lockState()` already models this exact case as `{ kind: "dead" }`, and both `release()` and `remove()` in `service.ts` reclaim a dead owner. Only `lockWorktreeForProcess()` threw instead. Worse, the throw is swallowed: `retainGitLock()` in `run-lease.ts:91` catches it, logs `worktree git lock unavailable`, and lets the run proceed with `gitLocked = false`. So a single stale lock permanently disables the protection it exists to provide, for that worktree, forever.

## Why This Change Was Made

Reclaim a dead-owner lock on acquire, matching the invariant the sibling call sites already apply. `isPidDefinitelyDead()` only reports true for ESRCH/zombie owners, so a cross-user (EPERM) or live owner is still never reclaimed.

An atomic rename of git's `locked` file was tried and reverted: it is a compare-and-swap on file *existence*, not on the observed *content*, so a delayed reclaimer can still rename away a replacement lock. It added moving parts without closing the window.

**Known tradeoff, recorded in the code and in #114129:** the observe-then-unlock window is the same one `release()` (`service.ts:714`/`:722`), `remove()` (`:741`/`:750`), and `:1004`/`:1009` already take, so two processes reclaiming the identical stale lock at once can both believe they won. Closing it properly needs a reclaim guard shared by all four call sites, not a fourth local inference layer — that is #114129. This PR does not widen the window; it replaces a failure that loses the lock 100% of the time with one that loses it only under concurrent reclaim.

## User Impact

Agent worktrees regain mutual exclusion after a gateway crash or update restart instead of silently running unprotected. The recurring `fatal: ... is already locked` noise stops.

## Evidence

New `src/agents/worktrees/git-lock.test.ts` builds a real repo and linked worktree and covers four behaviors: reclaims a lock owned by a genuinely exited pid, keeps a lock held by a live OpenClaw pid, keeps a foreign non-OpenClaw lock, and stays idempotent for a lock this process already holds.

Regression proof — the reclaim test fails against unpatched `main` with the exact production error:

```
Caused by: Error: git worktree lock failed:
fatal: '/private/var/folders/.../wt-lock' is already locked, reason: openclaw pid=15148
 ❯ lockWorktreeForProcess src/agents/worktrees/git-lock.ts:42:13
```

Local runs: `git-lock.test.ts` 4 passed; `run-lease.test.ts` 15 passed; `src/agents/worktrees/service*` 58 passed / 1 skipped. `oxfmt`, changed-file `oxlint` (rc=0), and `git diff --check` clean. Autoreview (Codex `gpt-5.6-sol`, xhigh) run three times across the iterations; its remaining P1 is the concurrent-reclaim window addressed above and tracked in #114129.
