### PR TITLE
fix(memory): keep implicit embeddings recall available

### DIFF
--- a/docs/reference/api-usage-costs.md
+++ b/docs/reference/api-usage-costs.md
@@ -71,7 +71,7 @@ See [Image generation](/tools/image-generation) and [Video generation](/tools/vi
 
 ### Memory embeddings and semantic search
 
-Semantic memory search uses embedding APIs when `memory.search.provider` names a remote adapter (for example `openai`, `gemini`, `voyage`, `mistral`, `deepinfra`, `github-copilot`, `amazon-bedrock`). `memory.search.provider = "lmstudio"` or `"ollama"` runs against a local/self-hosted server and typically has no hosted billing. `memory.search.provider = "local"` keeps everything on-device with no API usage. An optional `memory.search.fallback` provider can cover local-embedding failures.
+Semantic memory search uses embedding APIs when `memory.search.provider` names a remote adapter (for example `openai`, `gemini`, `voyage`, `mistral`, `deepinfra`, `github-copilot`, `amazon-bedrock`). Implicit OpenAI embeddings use OpenAI API key auth only; Codex OAuth does not satisfy embedding requests, and OpenClaw falls back to lexical FTS recall when the implicit provider is unavailable. `memory.search.provider = "lmstudio"` or `"ollama"` runs against a local/self-hosted server and typically has no hosted billing. `memory.search.provider = "local"` keeps everything on-device with no API usage. An optional `memory.search.fallback` provider can cover local-embedding failures.
 
 See [Memory](/concepts/memory).
 

--- a/docs/reference/memory-config.md
+++ b/docs/reference/memory-config.md
@@ -108,10 +108,11 @@ reply.
 | `model`    | `string`  | provider default | Embedding model name                                                                                                                                                                                                                                                                        |
 | `fallback` | `string`  | `"none"`         | Fallback adapter ID when the primary fails                                                                                                                                                                                                                                                  |
 
-When `provider` is not set, OpenClaw uses OpenAI embeddings. Set `provider`
-explicitly to use Bedrock, DeepInfra, Gemini, GitHub Copilot, Mistral, Ollama,
-Voyage, a local GGUF model, or an OpenAI-compatible `/v1/embeddings` endpoint.
-Legacy configs that still say `provider: "auto"` resolve to `openai`.
+When `provider` is not set, OpenClaw uses OpenAI embeddings when OpenAI API key
+auth is available. Set `provider` explicitly to use Bedrock, DeepInfra, Gemini,
+GitHub Copilot, Mistral, Ollama, Voyage, a local GGUF model, or an
+OpenAI-compatible `/v1/embeddings` endpoint. Legacy configs that still say
+`provider: "auto"` resolve to `openai`.
 
 <Warning>
 Changing the embedding provider, model, provider settings, sources, scope,
@@ -124,7 +125,9 @@ automatically re-embedding everything. Rebuild when you are ready with
 
 When `provider` is unset, legacy `provider: "auto"` is present, or
 `provider: "none"` intentionally selects FTS-only mode, memory recall can still
-use lexical FTS ranking when embeddings are unavailable.
+use lexical FTS ranking when embeddings are unavailable. Implicit OpenAI
+embeddings do not use Codex OAuth; without API key auth, OpenClaw keeps recall
+available as FTS-only.
 
 Explicit non-local providers fail closed. If you set `memory.search.provider` to
 a concrete remote-backed provider such as Bedrock, DeepInfra, Gemini, GitHub

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -1216,7 +1216,7 @@ describe("memory index", () => {
     }
   });
 
-  it("does not search stale provider rows after embeddings become unavailable", async () => {
+  it("uses read-only FTS recall from implicit provider rows after embeddings become unavailable", async () => {
     const oldCfg = createCfg({
       model: "semantic-embed",
       hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
@@ -1230,11 +1230,33 @@ describe("memory index", () => {
     try {
       const results = await nextManager.search("alpha");
 
-      expect(results).toStrictEqual([]);
+      expect(results.map((result) => result.path)).toContain("memory/2026-01-12.md");
       expect(nextManager.status().dirty).toBe(true);
-      expect(nextManager.status().custom?.indexIdentity).toMatchObject({
-        status: "mismatched",
+      expect(nextManager.status().custom?.indexIdentity).toEqual({ status: "valid" });
+      expect(nextManager.status().custom?.providerState).toMatchObject({
+        mode: "fts-only",
       });
+    } finally {
+      await nextManager.close?.();
+    }
+  });
+
+  it("does not search stale explicit provider rows after embeddings become unavailable", async () => {
+    const oldCfg = createCfg({
+      provider: "openai",
+      model: "semantic-embed",
+      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
+    });
+    const oldManager = await getFreshManager(oldCfg);
+    await oldManager.sync({ reason: "test", force: true });
+    await oldManager.close?.();
+
+    forceNoProvider = true;
+    const nextManager = await getFreshManager(oldCfg);
+    try {
+      await expect(nextManager.search("alpha")).rejects.toThrow(
+        /Memory search unavailable: embedding provider "openai" is configured but unavailable\./,
+      );
     } finally {
       await nextManager.close?.();
     }

--- a/extensions/memory-core/src/memory/manager-reindex-state.ts
+++ b/extensions/memory-core/src/memory/manager-reindex-state.ts
@@ -100,6 +100,50 @@ function configuredMetaSourcesDiffer(params: {
   return metaSources.some((source, index) => source !== params.configuredSources[index]);
 }
 
+function resolveMemoryLexicalIndexIdentityState(params: {
+  meta: MemoryIndexMeta | null;
+  configuredSources: MemorySource[];
+  configuredScopeHash: string;
+  chunkTokens: number;
+  chunkOverlap: number;
+  ftsTokenizer: string;
+}): MemoryIndexIdentityState {
+  const { meta } = params;
+  if (!meta) {
+    return { status: "missing", reason: "index metadata is missing" };
+  }
+  if (
+    configuredMetaSourcesDiffer({
+      meta,
+      configuredSources: params.configuredSources,
+    })
+  ) {
+    return {
+      status: "mismatched",
+      reason: "index sources changed",
+    };
+  }
+  if (meta.scopeHash !== params.configuredScopeHash) {
+    return {
+      status: "mismatched",
+      reason: "index scope changed",
+    };
+  }
+  if (meta.chunkTokens !== params.chunkTokens || meta.chunkOverlap !== params.chunkOverlap) {
+    return {
+      status: "mismatched",
+      reason: "index chunking changed",
+    };
+  }
+  if ((meta.ftsTokenizer ?? "unicode61") !== params.ftsTokenizer) {
+    return {
+      status: "mismatched",
+      reason: "index FTS tokenizer changed",
+    };
+  }
+  return { status: "valid" };
+}
+
 export function resolveConfiguredScopeHash(params: {
   workspaceDir: string;
   extraPaths?: string[];
@@ -137,10 +181,22 @@ export function resolveMemoryIndexIdentityState(params: {
   vectorReady: boolean;
   hasIndexedChunks?: boolean;
   ftsTokenizer: string;
+  lexicalOnly?: boolean;
 }): MemoryIndexIdentityState {
   const { meta } = params;
   if (!meta) {
     return { status: "missing", reason: "index metadata is missing" };
+  }
+  const lexicalParams = {
+    meta,
+    configuredSources: params.configuredSources,
+    configuredScopeHash: params.configuredScopeHash,
+    chunkTokens: params.chunkTokens,
+    chunkOverlap: params.chunkOverlap,
+    ftsTokenizer: params.ftsTokenizer,
+  };
+  if (params.lexicalOnly) {
+    return resolveMemoryLexicalIndexIdentityState(lexicalParams);
   }
   const expectedModel = params.provider?.model?.trim() || "fts-only";
   const matchingModelIdentities = [
@@ -169,39 +225,14 @@ export function resolveMemoryIndexIdentityState(params: {
       reason: "index provider settings changed",
     };
   }
-  if (
-    configuredMetaSourcesDiffer({
-      meta,
-      configuredSources: params.configuredSources,
-    })
-  ) {
-    return {
-      status: "mismatched",
-      reason: "index sources changed",
-    };
-  }
-  if (meta.scopeHash !== params.configuredScopeHash) {
-    return {
-      status: "mismatched",
-      reason: "index scope changed",
-    };
-  }
-  if (meta.chunkTokens !== params.chunkTokens || meta.chunkOverlap !== params.chunkOverlap) {
-    return {
-      status: "mismatched",
-      reason: "index chunking changed",
-    };
+  const lexicalState = resolveMemoryLexicalIndexIdentityState(lexicalParams);
+  if (lexicalState.status !== "valid") {
+    return lexicalState;
   }
   if (params.vectorReady && params.hasIndexedChunks !== false && !meta.vectorDims) {
     return {
       status: "mismatched",
       reason: "index vector dimensions are missing",
-    };
-  }
-  if ((meta.ftsTokenizer ?? "unicode61") !== params.ftsTokenizer) {
-    return {
-      status: "mismatched",
-      reason: "index FTS tokenizer changed",
     };
   }
   return { status: "valid" };

--- a/extensions/memory-core/src/memory/manager-sync-base.ts
+++ b/extensions/memory-core/src/memory/manager-sync-base.ts
@@ -366,6 +366,7 @@ export abstract class MemoryManagerSyncBase {
     providerKeyKnown?: boolean;
     vectorReady?: boolean;
     hasIndexedChunks?: boolean;
+    lexicalOnly?: boolean;
   }): MemoryIndexIdentityState {
     const hasProviderOverride = params && "provider" in params;
     const configuredIndexIdentity =
@@ -445,6 +446,7 @@ export abstract class MemoryManagerSyncBase {
           ? Boolean(params.hasIndexedChunks)
           : this.hasIndexedChunks(),
       ftsTokenizer: this.settings.store.fts.tokenizer,
+      lexicalOnly: params?.lexicalOnly,
     });
   }
 
@@ -570,7 +572,7 @@ export abstract class MemoryManagerSyncBase {
     });
   }
 
-  private markConfiguredSourcesForFullReindex(): void {
+  protected markConfiguredSourcesForFullReindex(): void {
     // This flag selects the shadow-reindex path even for a sessions-only index;
     // the rebuild itself still filters work through the configured sources.
     this.memoryFullRetryDirty = true;

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -157,14 +157,24 @@ export abstract class MemoryManagerSyncOps extends MemoryManagerSourceSyncOps {
     this.assertFtsOnlySyncAllowed();
 
     const progress = params?.progress ? this.createSyncProgress(params.progress) : undefined;
-    if (progress) {
+    const syncProvider = this.syncProviderGeneration
+      ? this.syncProviderGeneration.provider
+      : this.provider;
+    const syncProviderKey = this.syncProviderGeneration
+      ? this.syncProviderGeneration.providerKey
+      : this.providerKey;
+    const syncProviderIdentities =
+      this.syncProviderGeneration?.identities ?? this.resolveProviderIndexIdentities();
+    if (syncProvider && progress) {
       progress.report({
         completed: progress.completed,
         total: progress.total,
         label: "Loading vector extension…",
       });
     }
-    const vectorReady = await this.ensureVectorReady();
+    // Providerless FTS-only sync cannot write semantic rows, so vector-store
+    // probing is pure delay and can strand lexical-only recall behind sqlite-vec.
+    const vectorReady = syncProvider ? await this.ensureVectorReady() : false;
     const meta = this.readMeta();
     const targetArchiveFiles = await this.combineTargetArchiveFiles({
       sessions: params?.sessions,
@@ -177,14 +187,6 @@ export abstract class MemoryManagerSyncOps extends MemoryManagerSourceSyncOps {
     if (params?.reason === "cli" && !params.force && !hasTargetArchiveFiles) {
       await this.markSessionStartupCatchupDirtyFiles();
     }
-    const syncProvider = this.syncProviderGeneration
-      ? this.syncProviderGeneration.provider
-      : this.provider;
-    const syncProviderKey = this.syncProviderGeneration
-      ? this.syncProviderGeneration.providerKey
-      : this.providerKey;
-    const syncProviderIdentities =
-      this.syncProviderGeneration?.identities ?? this.resolveProviderIndexIdentities();
     const indexIdentity = resolveMemoryIndexIdentityState({
       meta,
       // Also detects provider→FTS-only transitions so orphaned old-model FTS rows are cleaned up.

--- a/extensions/memory-core/src/memory/manager.fts-only-reindex.test.ts
+++ b/extensions/memory-core/src/memory/manager.fts-only-reindex.test.ts
@@ -11,14 +11,10 @@ import type { MemoryIndexMeta } from "./manager-reindex-state.js";
 import type { MemoryIndexManager } from "./manager.js";
 import "./test-runtime-mocks.js";
 
-const createEmbeddingProviderMock = vi.hoisted(() =>
-  vi.fn(async () => ({
-    requestedProvider: "auto",
-    provider: null,
-    providerUnavailableReason: "No embeddings provider available.",
-  })),
-);
+const createEmbeddingProviderMock = vi.hoisted(() => vi.fn());
 const originalFtsOnlyStateDir = process.env.OPENCLAW_STATE_DIR;
+const OPENAI_API_KEY_MISSING = 'No API key found for provider "openai".';
+const MEMORY_FILE_CONTENT = "Alpha topic\n\nKeep this note.";
 
 function setFtsOnlyStateDir(stateDir: string): void {
   Reflect.set(process.env, "OPENCLAW_STATE_DIR", stateDir);
@@ -30,6 +26,33 @@ function restoreFtsOnlyStateDir(): void {
   } else {
     Reflect.set(process.env, "OPENCLAW_STATE_DIR", originalFtsOnlyStateDir);
   }
+}
+
+function installDefaultEmbeddingProviderMock(): void {
+  createEmbeddingProviderMock.mockImplementation(async () => ({
+    requestedProvider: "auto",
+    provider: null,
+    providerUnavailableReason: "No embeddings provider available.",
+  }));
+}
+
+function createAvailableOpenAiEmbeddingProviderResult() {
+  return {
+    requestedProvider: "openai",
+    provider: {
+      id: "openai",
+      model: "text-embedding-3-small",
+      embedQuery: async () => [1],
+      embedBatch: async (texts: string[]) => texts.map(() => [1]),
+    },
+    runtime: { id: "openai" },
+  };
+}
+
+function installAvailableOpenAiEmbeddingProviderMock(): void {
+  createEmbeddingProviderMock.mockImplementation(async () =>
+    createAvailableOpenAiEmbeddingProviderResult(),
+  );
 }
 
 vi.mock("./embeddings.js", () => ({
@@ -53,10 +76,11 @@ describe("memory manager FTS-only reindex", () => {
   });
 
   beforeEach(async () => {
-    createEmbeddingProviderMock.mockClear();
+    createEmbeddingProviderMock.mockReset();
+    installDefaultEmbeddingProviderMock();
     workspaceDir = path.join(fixtureRoot, `case-${caseId++}`);
     await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });
-    await fs.writeFile(path.join(workspaceDir, "MEMORY.md"), "Alpha topic\n\nKeep this note.");
+    await fs.writeFile(path.join(workspaceDir, "MEMORY.md"), MEMORY_FILE_CONTENT);
     setFtsOnlyStateDir(path.join(workspaceDir, "state"));
     indexPath = resolveOpenClawAgentSqlitePath({ agentId: "main" });
   });
@@ -78,7 +102,12 @@ describe("memory manager FTS-only reindex", () => {
   });
 
   async function createManager(
-    params: { provider?: string; vectorEnabled?: boolean } = {},
+    params: {
+      provider?: string;
+      vectorEnabled?: boolean;
+      onSearch?: boolean;
+      extraPaths?: string[];
+    } = {},
   ): Promise<MemoryIndexManager> {
     const store =
       params.vectorEnabled === undefined
@@ -91,9 +120,10 @@ describe("memory manager FTS-only reindex", () => {
         search: {
           provider: params.provider ?? "auto",
           model: "",
+          extraPaths: params.extraPaths,
           store,
           cache: { enabled: false },
-          sync: { watch: false, onSessionStart: false, onSearch: false },
+          sync: { watch: false, onSessionStart: false, onSearch: params.onSearch ?? false },
         },
       },
       agents: {
@@ -124,16 +154,72 @@ describe("memory manager FTS-only reindex", () => {
   }
 
   function writeExistingMeta(memoryManager: MemoryIndexManager, model: string): void {
-    const metaWriter = memoryManager as unknown as {
+    const metaAccess = memoryManager as unknown as {
+      readMeta(): MemoryIndexMeta | null;
       writeMeta(meta: MemoryIndexMeta): void;
     };
-    metaWriter.writeMeta({
-      model,
+    const existingMeta = metaAccess.readMeta();
+    metaAccess.writeMeta({
+      ...(existingMeta ?? {
+        chunkTokens: 600,
+        chunkOverlap: 120,
+        sources: ["memory"],
+      }),
       provider: "openai",
-      chunkTokens: 600,
-      chunkOverlap: 120,
-      sources: ["memory"],
+      model,
+      providerKey: "semantic-provider-key",
+      vectorDims: 1536,
     });
+  }
+
+  function expireOptionalProviderRetry(memoryManager: MemoryIndexManager): void {
+    (
+      memoryManager as unknown as {
+        optionalProviderInitRetryAfterMs: number;
+      }
+    ).optionalProviderInitRetryAfterMs = Date.now() - 1;
+  }
+
+  function expectMissingOpenAiFtsOnly(memoryManager: MemoryIndexManager): void {
+    expect(memoryManager.status().custom?.providerState).toEqual({
+      mode: "fts-only",
+      reason: OPENAI_API_KEY_MISSING,
+      attemptedProviderId: "openai",
+    });
+  }
+
+  function makeKeywordHit(pathname: string, source: "memory" | "sessions" = "memory") {
+    return {
+      id: `${source}:${pathname}:1`,
+      path: pathname,
+      startLine: 1,
+      endLine: 1,
+      score: 1,
+      snippet: "",
+      source,
+      textScore: 1,
+      pathScore: 0,
+      exactPathSpecificity: 0 as const,
+    };
+  }
+
+  async function createManagerAfterMissingOpenAiFallback(
+    params: { vectorEnabled?: boolean; onSearch?: boolean } = {},
+  ): Promise<MemoryIndexManager> {
+    createEmbeddingProviderMock.mockRejectedValueOnce(new Error(OPENAI_API_KEY_MISSING));
+    const memoryManager = await createManager(params);
+    await memoryManager.sync({ force: true });
+    expectMissingOpenAiFtsOnly(memoryManager);
+    return memoryManager;
+  }
+
+  async function createManagerReadyForOpenAiRecovery(
+    params: { vectorEnabled?: boolean; onSearch?: boolean } = {},
+  ): Promise<MemoryIndexManager> {
+    const memoryManager = await createManagerAfterMissingOpenAiFallback(params);
+    installAvailableOpenAiEmbeddingProviderMock();
+    expireOptionalProviderRetry(memoryManager);
+    return memoryManager;
   }
 
   it("preserves indexed chunks across forced reindex in FTS-only mode", async () => {
@@ -148,6 +234,367 @@ describe("memory manager FTS-only reindex", () => {
     const secondStatus = memoryManager.status();
     expect(secondStatus.chunks).toBeGreaterThan(0);
     expect(countChunksContaining("Alpha topic")).toBeGreaterThan(0);
+  });
+
+  it("does not load the vector store while syncing providerless FTS-only memory", async () => {
+    const memoryManager = await createManager();
+    const progress = vi.fn();
+
+    await memoryManager.sync({ force: true, progress });
+
+    expect(progress).not.toHaveBeenCalledWith(
+      expect.objectContaining({ label: "Loading vector extension…" }),
+    );
+    expect(countChunksContaining("Alpha topic")).toBeGreaterThan(0);
+  });
+
+  it("uses FTS-only recall when implicit OpenAI provider initialization fails", async () => {
+    createEmbeddingProviderMock.mockRejectedValue(new Error(OPENAI_API_KEY_MISSING));
+    const memoryManager = await createManager();
+
+    await memoryManager.sync({ force: true });
+
+    expect(createEmbeddingProviderMock).toHaveBeenCalledOnce();
+    expect(countChunksContaining("Alpha topic")).toBeGreaterThan(0);
+    expect(memoryManager.status().custom?.indexIdentity).toEqual({ status: "valid" });
+    expectMissingOpenAiFtsOnly(memoryManager);
+  });
+
+  it("retries optional provider initialization after FTS-only fallback", async () => {
+    const memoryManager = await createManagerAfterMissingOpenAiFallback();
+    installAvailableOpenAiEmbeddingProviderMock();
+    expireOptionalProviderRetry(memoryManager);
+
+    await expect(memoryManager.probeEmbeddingAvailability()).resolves.toEqual({ ok: true });
+
+    expect(createEmbeddingProviderMock).toHaveBeenCalledTimes(2);
+    expect(memoryManager.status().provider).toBe("openai");
+    expect(memoryManager.status().custom?.providerState).toEqual({
+      mode: "active",
+      providerId: "openai",
+    });
+  });
+
+  it("joins an in-flight optional provider retry for concurrent callers", async () => {
+    const memoryManager = await createManagerAfterMissingOpenAiFallback();
+    let resolveProvider: () => void = () => {};
+    const providerReady = new Promise<
+      ReturnType<typeof createAvailableOpenAiEmbeddingProviderResult>
+    >((resolve) => {
+      resolveProvider = () => resolve(createAvailableOpenAiEmbeddingProviderResult());
+    });
+    createEmbeddingProviderMock.mockImplementation(async () => await providerReady);
+    expireOptionalProviderRetry(memoryManager);
+
+    const firstProbe = memoryManager.probeEmbeddingAvailability();
+    const secondProbe = memoryManager.probeEmbeddingAvailability();
+    await vi.waitFor(() => expect(createEmbeddingProviderMock).toHaveBeenCalledTimes(2));
+    resolveProvider();
+
+    await expect(Promise.all([firstProbe, secondProbe])).resolves.toEqual([
+      { ok: true },
+      { ok: true },
+    ]);
+    expect(memoryManager.status().provider).toBe("openai");
+  });
+
+  it("keeps lexical recall after optional provider recovery", async () => {
+    const memoryManager = await createManagerReadyForOpenAiRecovery();
+
+    const results = await memoryManager.search("Alpha topic", { minScore: 0, maxResults: 3 });
+
+    expect(results.map((result) => result.path)).toContain("MEMORY.md");
+    expect(memoryManager.status()).toMatchObject({
+      provider: "openai",
+      model: "text-embedding-3-small",
+    });
+
+    await memoryManager.sync({ force: true });
+
+    expect(memoryManager.status()).toMatchObject({
+      dirty: false,
+      provider: "openai",
+      model: "text-embedding-3-small",
+    });
+    expect(memoryManager.status().custom?.indexIdentity).toEqual({ status: "valid" });
+  });
+
+  it("does not return deleted memory during optional provider recovery FTS fallback", async () => {
+    const memoryManager = await createManagerReadyForOpenAiRecovery({ vectorEnabled: false });
+    await expect(memoryManager.probeEmbeddingAvailability()).resolves.toEqual({ ok: true });
+    await vi.waitFor(() => expect(Reflect.get(memoryManager, "syncing")).toBeNull());
+    await fs.rm(path.join(workspaceDir, "MEMORY.md"));
+
+    await expect(
+      memoryManager.search("Alpha topic", { minScore: 0, maxResults: 3 }),
+    ).resolves.toEqual([]);
+
+    expect(memoryManager.status()).toMatchObject({
+      provider: "openai",
+      model: "text-embedding-3-small",
+    });
+  });
+
+  it("preserves dirty state when optional provider recovery races with FTS-only sync", async () => {
+    createEmbeddingProviderMock.mockRejectedValueOnce(new Error(OPENAI_API_KEY_MISSING));
+    const memoryManager = await createManager({ vectorEnabled: false });
+    const originalSyncMemoryFiles = Reflect.get(memoryManager, "syncMemoryFiles") as (params: {
+      needsFullReindex: boolean;
+      progress?: unknown;
+    }) => Promise<void>;
+    let releaseInitialSync: () => void = () => {};
+    let releasedInitialSync = false;
+    const initialSyncGate = new Promise<void>((resolve) => {
+      releaseInitialSync = () => {
+        releasedInitialSync = true;
+        resolve();
+      };
+    });
+    let initialSyncStarted: () => void = () => {};
+    const initialSyncStartedPromise = new Promise<void>((resolve) => {
+      initialSyncStarted = resolve;
+    });
+    let heldFirstSync = false;
+    Reflect.set(
+      memoryManager,
+      "syncMemoryFiles",
+      async (params: { needsFullReindex: boolean; progress?: unknown }) => {
+        if (!heldFirstSync) {
+          heldFirstSync = true;
+          initialSyncStarted();
+          await initialSyncGate;
+        }
+        return await originalSyncMemoryFiles.call(memoryManager, params);
+      },
+    );
+
+    const initialSync = memoryManager.sync({ force: true });
+    try {
+      await initialSyncStartedPromise;
+      expect(Reflect.get(memoryManager, "syncProviderGeneration")).toMatchObject({
+        kind: "fts-only",
+        provider: null,
+      });
+      expect(countChunksContaining("Alpha topic")).toBe(0);
+      installAvailableOpenAiEmbeddingProviderMock();
+      expireOptionalProviderRetry(memoryManager);
+
+      await expect(memoryManager.probeEmbeddingAvailability()).resolves.toEqual({ ok: true });
+      releaseInitialSync();
+      await initialSync;
+      await vi.waitFor(() => expect(Reflect.get(memoryManager, "syncing")).toBeNull());
+      await vi.waitFor(() =>
+        expect(Reflect.get(memoryManager, "syncProviderGeneration")).toBeNull(),
+      );
+
+      expect(memoryManager.status()).toMatchObject({
+        dirty: true,
+        provider: "openai",
+        model: "text-embedding-3-small",
+      });
+      expect(memoryManager.status().custom?.indexIdentity).toMatchObject({
+        status: "mismatched",
+      });
+      await expect(
+        memoryManager.search("Alpha topic", { minScore: 0, maxResults: 3 }),
+      ).resolves.toEqual([expect.objectContaining({ path: "MEMORY.md" })]);
+
+      await memoryManager.sync({ force: true });
+
+      expect(memoryManager.status()).toMatchObject({
+        dirty: false,
+        provider: "openai",
+        model: "text-embedding-3-small",
+      });
+      expect(memoryManager.status().custom?.indexIdentity).toEqual({ status: "valid" });
+    } finally {
+      if (!releasedInitialSync) {
+        releaseInitialSync();
+      }
+      await initialSync.catch(() => undefined);
+    }
+  });
+
+  it("clears cached probe failures when optional provider recovery happens during search", async () => {
+    const memoryManager = await createManagerAfterMissingOpenAiFallback({ vectorEnabled: false });
+    await expect(memoryManager.probeEmbeddingAvailability()).resolves.toEqual({
+      ok: false,
+      error: OPENAI_API_KEY_MISSING,
+    });
+    installAvailableOpenAiEmbeddingProviderMock();
+    expireOptionalProviderRetry(memoryManager);
+
+    await expect(
+      memoryManager.search("Alpha topic", { minScore: 0, maxResults: 3 }),
+    ).resolves.toEqual([]);
+
+    await expect(memoryManager.probeEmbeddingAvailability()).resolves.toEqual({ ok: true });
+  });
+
+  it("keeps an already-valid semantic index valid after optional provider recovery", async () => {
+    installAvailableOpenAiEmbeddingProviderMock();
+    const memoryManager = await createManager({ vectorEnabled: false });
+    await memoryManager.sync({ force: true });
+    expect(memoryManager.status().custom?.indexIdentity).toEqual({ status: "valid" });
+    await memoryManager.close();
+    manager = null;
+    await closeAllMemorySearchManagers();
+    createEmbeddingProviderMock.mockRejectedValue(new Error(OPENAI_API_KEY_MISSING));
+    const reloadedManager = await createManager({ vectorEnabled: false });
+    await expect(
+      reloadedManager.search("Alpha topic", { minScore: 0, maxResults: 3 }),
+    ).resolves.toHaveLength(1);
+    installAvailableOpenAiEmbeddingProviderMock();
+    expireOptionalProviderRetry(reloadedManager);
+
+    await expect(reloadedManager.probeEmbeddingAvailability()).resolves.toEqual({ ok: true });
+
+    expect(reloadedManager.status()).toMatchObject({
+      provider: "openai",
+      model: "text-embedding-3-small",
+    });
+    expect(reloadedManager.status().custom?.indexIdentity).toEqual({ status: "valid" });
+    expect(Reflect.get(reloadedManager, "memoryFullRetryDirty")).toBe(false);
+  });
+
+  it("fails closed when an explicit OpenAI provider initialization fails", async () => {
+    createEmbeddingProviderMock.mockImplementation(async () => {
+      throw new Error(OPENAI_API_KEY_MISSING);
+    });
+    const memoryManager = await createManager({ provider: "openai" });
+
+    await expect(memoryManager.sync({ force: true })).rejects.toThrow(OPENAI_API_KEY_MISSING);
+  });
+
+  it("keeps FTS recall for an existing semantic index when implicit OpenAI initialization fails", async () => {
+    const memoryManager = await createManager();
+    await memoryManager.sync({ force: true });
+    writeExistingMeta(memoryManager, "text-embedding-3-small");
+    await memoryManager.close();
+    manager = null;
+    await closeAllMemorySearchManagers();
+    createEmbeddingProviderMock.mockClear();
+    createEmbeddingProviderMock.mockImplementation(async () => {
+      throw new Error(OPENAI_API_KEY_MISSING);
+    });
+    const reloadedManager = await createManager({ onSearch: true });
+
+    const results = await reloadedManager.search("Alpha topic", { minScore: 0, maxResults: 3 });
+
+    expect(results.map((result) => result.path)).toContain("MEMORY.md");
+    expect(createEmbeddingProviderMock).toHaveBeenCalledTimes(1);
+    expect(
+      Reflect.get(reloadedManager, "optionalProviderInitRetryAfterMs") as number,
+    ).toBeGreaterThan(Date.now());
+    await expect(
+      reloadedManager.search("Alpha topic", { minScore: 0, maxResults: 3 }),
+    ).resolves.not.toHaveLength(0);
+    expect(createEmbeddingProviderMock).toHaveBeenCalledTimes(1);
+    expect(reloadedManager.status().custom?.indexIdentity).toEqual({ status: "valid" });
+    expectMissingOpenAiFtsOnly(reloadedManager);
+    await expect(reloadedManager.sync({ force: true })).rejects.toThrow(
+      "Refusing to run sync in fts-only fallback mode to protect existing vector index (current model: text-embedding-3-small).",
+    );
+  });
+
+  it("does not return deleted memory through read-only semantic FTS fallback", async () => {
+    const memoryManager = await createManager();
+    await memoryManager.sync({ force: true });
+    writeExistingMeta(memoryManager, "text-embedding-3-small");
+    await fs.rm(path.join(workspaceDir, "MEMORY.md"));
+    await memoryManager.close();
+    manager = null;
+    await closeAllMemorySearchManagers();
+    createEmbeddingProviderMock.mockClear();
+    createEmbeddingProviderMock.mockImplementation(async () => {
+      throw new Error(OPENAI_API_KEY_MISSING);
+    });
+    const reloadedManager = await createManager({ onSearch: true });
+
+    await expect(
+      reloadedManager.search("Alpha topic", { minScore: 0, maxResults: 3 }),
+    ).resolves.toEqual([]);
+
+    expect(createEmbeddingProviderMock).toHaveBeenCalledTimes(1);
+    expect(reloadedManager.status().custom?.indexIdentity).toEqual({ status: "valid" });
+    expectMissingOpenAiFtsOnly(reloadedManager);
+  });
+
+  it("filters removed external extra-path memory from read-only fallback hits", async () => {
+    const extraDir = path.join(fixtureRoot, `external-${caseId}`);
+    await fs.mkdir(extraDir, { recursive: true });
+    const extraFile = path.join(extraDir, "extra.md");
+    await fs.writeFile(extraFile, "Gamma private note");
+    const memoryManager = await createManager({ extraPaths: [extraDir] });
+    await memoryManager.sync({ force: true });
+    const extraPath = path.relative(workspaceDir, extraFile).replace(/\\/g, "/");
+    expect(countChunksContaining("Gamma private")).toBeGreaterThan(0);
+    await memoryManager.close();
+    manager = null;
+    await closeAllMemorySearchManagers();
+    const reloadedManager = await createManager({ extraPaths: [] });
+    const filterReadOnlyFallbackKeywordResults = Reflect.get(
+      reloadedManager,
+      "filterReadOnlyFallbackKeywordResults",
+    ) as (
+      hits: Array<ReturnType<typeof makeKeywordHit>>,
+    ) => Promise<Array<ReturnType<typeof makeKeywordHit>>>;
+
+    const filtered = await filterReadOnlyFallbackKeywordResults.call(reloadedManager, [
+      makeKeywordHit("MEMORY.md"),
+      makeKeywordHit(extraPath),
+    ]);
+
+    expect(filtered.map((hit) => hit.path)).toEqual(["MEMORY.md"]);
+  });
+
+  it("drops session hits while filtering read-only fallback memory hits", async () => {
+    const memoryManager = await createManager();
+    const filterReadOnlyFallbackKeywordResults = Reflect.get(
+      memoryManager,
+      "filterReadOnlyFallbackKeywordResults",
+    ) as (
+      hits: Array<ReturnType<typeof makeKeywordHit>>,
+    ) => Promise<Array<ReturnType<typeof makeKeywordHit>>>;
+
+    const filtered = await filterReadOnlyFallbackKeywordResults.call(memoryManager, [
+      makeKeywordHit("memory/deleted.md"),
+      makeKeywordHit("sessions/recent.md", "sessions"),
+    ]);
+
+    expect(filtered.map((hit) => `${hit.source}:${hit.path}`)).toEqual([]);
+  });
+
+  it("replenishes read-only fallback candidates after filtering stale hits", async () => {
+    const memoryManager = await createManager();
+    await memoryManager.sync({ force: true });
+    const staleHit = makeKeywordHit("memory/deleted.md");
+    const validHit = makeKeywordHit("MEMORY.md");
+    const searchKeyword = vi.fn(async (term: string) =>
+      term === "Alpha topic" ? [staleHit] : [validHit],
+    );
+    Reflect.set(memoryManager, "searchKeyword", searchKeyword);
+    const searchReadOnlyFallbackKeywordResults = Reflect.get(
+      memoryManager,
+      "searchReadOnlyFallbackKeywordResults",
+    ) as (
+      query: string,
+      candidates: number,
+      options: { boostFallbackRanking?: boolean },
+      sourceFilterList: Array<"memory" | "sessions">,
+    ) => Promise<Array<ReturnType<typeof makeKeywordHit>>>;
+
+    const results = await searchReadOnlyFallbackKeywordResults.call(
+      memoryManager,
+      "Alpha topic",
+      1,
+      { boostFallbackRanking: true },
+      ["memory"],
+    );
+
+    expect(searchKeyword.mock.calls[0]?.[0]).toBe("Alpha topic");
+    expect(searchKeyword.mock.calls.some((call) => call[0] !== "Alpha topic")).toBe(true);
+    expect(results.map((hit) => hit.path)).toEqual(["MEMORY.md"]);
   });
 
   it("syncs explicit provider-none memory without resolving an embedding provider", async () => {
@@ -223,6 +670,14 @@ describe("memory manager FTS-only reindex", () => {
     await expect(memoryManager.sync({ force: true })).rejects.toThrow(
       "Refusing to run sync in fts-only fallback mode to protect existing vector index (current model: mock-embed).",
     );
-    expect(memoryManager.status().provider).toBe("openai");
+    expect(memoryManager.status().provider).toBe("none");
+    expect(memoryManager.status().custom?.providerState).toEqual({
+      mode: "fts-only",
+      reason: "No embeddings provider available.",
+      attemptedProviderId: "auto",
+    });
+    expect(
+      Reflect.get(memoryManager, "optionalProviderInitRetryAfterMs") as number,
+    ).toBeGreaterThan(Date.now());
   });
 });

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -1,4 +1,5 @@
 // Memory Core plugin module implements manager behavior.
+import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
 import type { FSWatcher } from "chokidar";
 import { resolveAgentConfig } from "openclaw/plugin-sdk/agent-runtime";
@@ -16,6 +17,8 @@ import {
 } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
 import { extractKeywords } from "openclaw/plugin-sdk/memory-core-host-engine-qmd";
 import {
+  buildFileEntry,
+  normalizeExtraMemoryPaths,
   readMemoryFile,
   MEMORY_EMBEDDING_CACHE_TABLE,
   MEMORY_INDEX_FTS_TABLE,
@@ -64,7 +67,7 @@ import {
   resolveMemoryProviderState,
   type MemoryProviderLifecycleState,
 } from "./manager-provider-state.js";
-import type { MemoryIndexIdentityState } from "./manager-reindex-state.js";
+import type { MemoryIndexIdentityState, MemoryIndexMeta } from "./manager-reindex-state.js";
 import { resolveMemorySearchPreflight } from "./manager-search-preflight.js";
 import {
   resolveExactPathSpecificity,
@@ -106,8 +109,10 @@ const MEMORY_INDEX_MANAGER_GLOBAL_LIFECYCLE_KEY = Symbol.for(
   "openclaw.memoryIndexManagerGlobalLifecycle.v3",
 );
 const EMBEDDING_PROBE_CACHE_TTL_MS = 30_000;
+const OPTIONAL_PROVIDER_INIT_RETRY_DELAY_MS = 30_000;
 const KEYWORD_FALLBACK_SEARCH_TERM_LIMIT = 6;
 const EXACT_PATH_CANDIDATE_LIMIT = 200;
+const READ_ONLY_FALLBACK_MAX_CANDIDATES = 1000;
 const log = createSubsystemLogger("memory");
 type MemoryIndexManagerPurpose = "default" | "status" | "cli";
 type MemoryEmbeddingProviderRequirement = {
@@ -426,6 +431,8 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
   private closing = false;
   private activeManagerOperations = 0;
   private managerIdleWaiters = new Set<() => void>();
+  private optionalProviderInitRetryAfterMs = 0;
+  private retryingOptionalProviderFromFtsOnly = false;
   protected override fallbackFrom?: EmbeddingProviderId;
   protected override fallbackReason?: string;
   protected providerUnavailableReason?: string;
@@ -702,12 +709,34 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     this.providerLifecycle = providerState.lifecycle;
     this.providerRuntime = providerState.providerRuntime;
     this.providerInitialized = true;
+    this.optionalProviderInitRetryAfterMs =
+      !providerState.provider &&
+      this.providerRequirement.mode === "optional" &&
+      this.settings.provider !== "none"
+        ? Date.now() + OPTIONAL_PROVIDER_INIT_RETRY_DELAY_MS
+        : 0;
+  }
+
+  private shouldRetryOptionalProviderInitialization(): boolean {
+    return (
+      this.providerInitialized &&
+      !this.provider &&
+      this.providerRequirement.mode === "optional" &&
+      this.providerLifecycle.mode === "fts-only" &&
+      this.optionalProviderInitRetryAfterMs > 0 &&
+      Date.now() >= this.optionalProviderInitRetryAfterMs
+    );
   }
 
   private async ensureProviderInitialized(): Promise<void> {
     if (this.providerInitialized) {
       await this.getPendingFallbackProviderInitialization()?.catch(() => undefined);
-      return;
+      if (this.providerInitialized) {
+        if (!this.shouldRetryOptionalProviderInitialization()) {
+          return;
+        }
+        this.resetProviderInitializationForRetry();
+      }
     }
     if (this.settings.provider === "none") {
       this.applyProviderResult({
@@ -726,15 +755,36 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
         if (this.closed) {
           return;
         }
-        const providerResult = await MemoryIndexManager.loadProviderResult({
-          cfg: this.cfg,
-          agentId: this.agentId,
-          settings: this.settings,
-          acquireLocalService: this.acquireLocalService,
-        });
+        let providerResult: EmbeddingProviderResult;
+        try {
+          providerResult = await MemoryIndexManager.loadProviderResult({
+            cfg: this.cfg,
+            agentId: this.agentId,
+            settings: this.settings,
+            acquireLocalService: this.acquireLocalService,
+          });
+        } catch (err) {
+          if (this.providerRequirement.mode !== "optional") {
+            throw err;
+          }
+          const reason = formatErrorMessage(err);
+          providerResult = {
+            provider: null,
+            requestedProvider: this.providerRequirement.provider,
+            providerUnavailableReason: reason,
+          };
+          log.warn(`memory embeddings unavailable; using FTS-only search: ${reason}`);
+        }
+        const recoveredFromOptionalFtsOnly =
+          this.retryingOptionalProviderFromFtsOnly && Boolean(providerResult.provider);
         this.applyProviderResult(providerResult);
+        this.retryingOptionalProviderFromFtsOnly = false;
         this.providerKey = this.computeProviderKey();
         this.batch = this.resolveBatchConfig();
+        if (recoveredFromOptionalFtsOnly) {
+          this.clearCachedEmbeddingAvailability();
+          this.markRecoveredOptionalProviderFtsOnlyIndexDirtyIfNeeded();
+        }
       })();
     }
     try {
@@ -752,11 +802,32 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
   }
 
   protected resetProviderInitializationForRetry(): void {
+    if (
+      this.providerInitialized &&
+      !this.provider &&
+      this.providerRequirement.mode === "optional" &&
+      this.providerLifecycle.mode === "fts-only" &&
+      this.settings.provider !== "none" &&
+      this.optionalProviderInitRetryAfterMs > Date.now()
+    ) {
+      return;
+    }
+    this.retryingOptionalProviderFromFtsOnly =
+      this.providerInitialized &&
+      !this.provider &&
+      this.providerRequirement.mode === "optional" &&
+      this.providerLifecycle.mode === "fts-only" &&
+      this.settings.provider !== "none";
     void this.retireCurrentProvider();
     this.providerInitialized = false;
     this.providerInitPromise = null;
     this.providerUnavailableReason = undefined;
     this.providerLifecycle = createPendingMemoryProviderLifecycle(this.requestedProvider);
+    this.optionalProviderInitRetryAfterMs = 0;
+  }
+
+  private clearCachedEmbeddingAvailability(): void {
+    EMBEDDING_PROBE_CACHE.delete(this.cacheKey);
   }
 
   protected markLocalEmbeddingProviderDegraded(err: unknown): void {
@@ -780,7 +851,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       reason: message,
       code: workerFailure.code,
     });
-    EMBEDDING_PROBE_CACHE.delete(this.cacheKey);
+    this.clearCachedEmbeddingAvailability();
     this.providerKey = this.computeProviderKey();
     this.batch = this.resolveBatchConfig();
     this.vector.semanticAvailable = false;
@@ -893,7 +964,41 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     }
   }
 
+  private shouldUseOptionalProviderFtsReadOnlyIndex(meta: MemoryIndexMeta | null): boolean {
+    return Boolean(
+      meta &&
+      this.providerRequirement.mode === "optional" &&
+      this.providerInitialized &&
+      !this.provider &&
+      this.providerLifecycle.mode === "fts-only" &&
+      this.settings.provider !== "none" &&
+      meta.provider !== "none" &&
+      meta.model.trim() !== "fts-only",
+    );
+  }
+
+  private shouldSearchRecoveredOptionalProviderFtsOnlyIndex(meta: MemoryIndexMeta | null): boolean {
+    // Only FTS-only fallback indexes are readable after optional provider recovery.
+    // Existing semantic indexes stay fail-closed until explicit identity repair.
+    return Boolean(
+      meta &&
+      this.providerRequirement.mode === "optional" &&
+      this.providerInitialized &&
+      this.provider &&
+      this.settings.provider !== "none" &&
+      meta.provider === "none" &&
+      meta.model.trim() === "fts-only",
+    );
+  }
+
+  private markRecoveredOptionalProviderFtsOnlyIndexDirtyIfNeeded(): void {
+    if (this.shouldSearchRecoveredOptionalProviderFtsOnlyIndex(this.readMeta())) {
+      this.markConfiguredSourcesForFullReindex();
+    }
+  }
+
   private refreshIndexIdentityDirty(params?: { providerKeyKnown?: boolean }) {
+    const meta = this.readMeta();
     const provider =
       this.settings.provider === "none"
         ? null
@@ -902,10 +1007,16 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
             ? { id: this.provider.id, model: this.provider.model }
             : null
           : undefined;
-    const state = this.resolveCurrentIndexIdentityState({
+    let state = this.resolveCurrentIndexIdentityState({
+      meta,
       ...(provider !== undefined ? { provider } : {}),
       providerKeyKnown: params?.providerKeyKnown,
     });
+    if (state.status !== "valid" && this.shouldUseOptionalProviderFtsReadOnlyIndex(meta)) {
+      // Sync still guards semantic indexes in assertFtsOnlySyncAllowed(); this
+      // relaxation only prevents read-only FTS recall from looking paused.
+      state = this.resolveCurrentIndexIdentityState({ meta, lexicalOnly: true });
+    }
     this.indexIdentityState = state;
     this.indexIdentityDirty =
       state.status === "mismatched" ||
@@ -1024,12 +1135,6 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
           });
         }
       }
-      const indexIdentity = this.refreshIndexIdentityDirty({
-        providerKeyKnown: this.providerInitialized,
-      });
-      if (indexIdentity.status !== "valid") {
-        return [];
-      }
       const minScore = opts?.minScore ?? this.settings.query.minScore;
       const maxResults = opts?.maxResults ?? this.settings.query.maxResults;
       const searchSources =
@@ -1052,6 +1157,46 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
         200,
         Math.max(1, Math.floor(maxResults * hybrid.candidateMultiplier)),
       );
+      const indexIdentity = this.refreshIndexIdentityDirty({
+        providerKeyKnown: this.providerInitialized,
+      });
+      if (indexIdentity.status !== "valid") {
+        const meta = this.readMeta();
+        const readOnlyRecoveredFtsOnlyIndex =
+          this.shouldSearchRecoveredOptionalProviderFtsOnlyIndex(meta);
+        const lexicalIdentity = readOnlyRecoveredFtsOnlyIndex
+          ? this.resolveCurrentIndexIdentityState({ meta, lexicalOnly: true })
+          : indexIdentity;
+        if (lexicalIdentity.status === "valid" && this.fts.enabled && this.fts.available) {
+          const keywordOptions = { boostFallbackRanking: true };
+          const keywordResults = readOnlyRecoveredFtsOnlyIndex
+            ? await this.searchReadOnlyFallbackKeywordResults(
+                cleaned,
+                candidates,
+                keywordOptions,
+                sourceFilterList,
+              )
+            : await this.searchKeywordWithFallback(
+                cleaned,
+                candidates,
+                keywordOptions,
+                sourceFilterList,
+              ).catch((err: unknown) => {
+                log.warn(`memory search: FTS keyword query failed: ${formatErrorMessage(err)}`);
+                return [];
+              });
+          if (readOnlyRecoveredFtsOnlyIndex) {
+            this.markConfiguredSourcesForFullReindex();
+          }
+          return await this.finalizeKeywordOnlyResults({
+            results: keywordResults,
+            temporalDecay: hybrid.temporalDecay,
+            maxResults,
+            minScore,
+          });
+        }
+        return [];
+      }
 
       // FTS-only mode: no embedding provider available
       if (!this.provider) {
@@ -1061,17 +1206,26 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
           return [];
         }
 
-        const keywordResults = await this.searchKeywordWithFallback(
-          cleaned,
-          candidates,
-          {
-            boostFallbackRanking: true,
-          },
-          sourceFilterList,
-        ).catch((err: unknown) => {
-          log.warn(`memory search: FTS keyword query failed: ${formatErrorMessage(err)}`);
-          return [];
-        });
+        const readOnlyOptionalProviderIndex = this.shouldUseOptionalProviderFtsReadOnlyIndex(
+          this.readMeta(),
+        );
+        const keywordOptions = { boostFallbackRanking: true };
+        const keywordResults = readOnlyOptionalProviderIndex
+          ? await this.searchReadOnlyFallbackKeywordResults(
+              cleaned,
+              candidates,
+              keywordOptions,
+              sourceFilterList,
+            )
+          : await this.searchKeywordWithFallback(
+              cleaned,
+              candidates,
+              keywordOptions,
+              sourceFilterList,
+            ).catch((err: unknown) => {
+              log.warn(`memory search: FTS keyword query failed: ${formatErrorMessage(err)}`);
+              return [];
+            });
 
         return await this.finalizeKeywordOnlyResults({
           results: keywordResults,
@@ -1288,6 +1442,167 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     return this.toMemorySearchResults(
       this.selectScoredResults(ranked, params.maxResults, params.minScore, 0),
     );
+  }
+
+  private isPathInConfiguredMemoryScope(pathname: string): boolean {
+    const normalized = pathname.replace(/\\/g, "/");
+    if (
+      normalized === "MEMORY.md" ||
+      normalized.toLowerCase() === "dreams.md" ||
+      normalized.startsWith("memory/")
+    ) {
+      return true;
+    }
+    const absPath = path.resolve(this.workspaceDir, pathname);
+    return normalizeExtraMemoryPaths(this.workspaceDir, this.settings.extraPaths).some(
+      (extraPath) => {
+        const relative = path.relative(extraPath, absPath);
+        return (
+          relative === "" ||
+          (relative !== "" && !relative.startsWith("..") && !path.isAbsolute(relative))
+        );
+      },
+    );
+  }
+
+  private readMemorySourceHash(pathname: string): string | null {
+    const row = this.db
+      .prepare(`SELECT hash FROM memory_index_sources WHERE path = ? AND source = 'memory'`)
+      .get(pathname) as { hash?: string } | undefined;
+    return row?.hash ?? null;
+  }
+
+  private async isReadOnlyFallbackMemoryHitCurrent(hit: KeywordSearchHit): Promise<boolean> {
+    if (hit.source !== "memory") {
+      // Session rows need session-sync ownership to prove deletion/redaction state.
+      // This providerless read-only fallback serves verified memory files only.
+      return false;
+    }
+    if (!this.isPathInConfiguredMemoryScope(hit.path)) {
+      return false;
+    }
+    const indexedHash = this.readMemorySourceHash(hit.path);
+    if (!indexedHash) {
+      // Read-only fallback can safely use only rows tied to current source hashes.
+      // Source-rowless legacy rows may contain deleted or redacted text.
+      return false;
+    }
+    try {
+      const currentEntry = await buildFileEntry(
+        path.resolve(this.workspaceDir, hit.path),
+        this.workspaceDir,
+        this.settings.multimodal,
+      );
+      return currentEntry?.path === hit.path && currentEntry.hash === indexedHash;
+    } catch (err) {
+      log.debug(
+        `memory search: dropping unverified read-only fallback hit ${hit.path}: ${formatErrorMessage(err)}`,
+      );
+      return false;
+    }
+  }
+
+  private async filterReadOnlyFallbackKeywordResults(
+    results: KeywordSearchHit[],
+  ): Promise<KeywordSearchHit[]> {
+    const currentByPath = new Map<string, Promise<boolean>>();
+    const keep = await Promise.all(
+      results.map((result) => {
+        const key = `${result.source}:${result.path}`;
+        let current = currentByPath.get(key);
+        if (!current) {
+          current = this.isReadOnlyFallbackMemoryHitCurrent(result);
+          currentByPath.set(key, current);
+        }
+        return current;
+      }),
+    );
+    return results.filter((_, index) => keep[index]);
+  }
+
+  private async searchReadOnlyFallbackKeywordResults(
+    query: string,
+    candidates: number,
+    options: { boostFallbackRanking?: boolean } | undefined,
+    sourceFilterList: MemorySource[],
+  ): Promise<KeywordSearchHit[]> {
+    let limit = candidates;
+    while (true) {
+      const fullQueryResults = await this.searchKeyword(
+        query,
+        limit,
+        options,
+        sourceFilterList,
+      ).catch((err: unknown) => {
+        log.warn(`memory search: FTS keyword query failed: ${formatErrorMessage(err)}`);
+        return [];
+      });
+      const filteredFullQueryResults =
+        await this.filterReadOnlyFallbackKeywordResults(fullQueryResults);
+      if (filteredFullQueryResults.length >= candidates) {
+        return this.limitKeywordSearchHits(filteredFullQueryResults, candidates);
+      }
+      if (fullQueryResults.length >= limit && limit < READ_ONLY_FALLBACK_MAX_CANDIDATES) {
+        limit = Math.min(READ_ONLY_FALLBACK_MAX_CANDIDATES, limit * 2);
+        continue;
+      }
+      return await this.searchReadOnlyFallbackKeywordTerms(
+        query,
+        candidates,
+        options,
+        sourceFilterList,
+        filteredFullQueryResults,
+      );
+    }
+  }
+
+  private async searchReadOnlyFallbackKeywordTerms(
+    query: string,
+    candidates: number,
+    options: { boostFallbackRanking?: boolean } | undefined,
+    sourceFilterList: MemorySource[],
+    fullQueryResults: KeywordSearchHit[],
+  ): Promise<KeywordSearchHit[]> {
+    const fallbackTerms = this.resolveKeywordFallbackTerms(query);
+    if (fallbackTerms.length === 0) {
+      return this.limitKeywordSearchHits(fullQueryResults, candidates);
+    }
+    let limit = candidates;
+    while (true) {
+      const resultSets = await Promise.all(
+        fallbackTerms.map((term) =>
+          this.searchKeyword(
+            term,
+            limit,
+            { ...options, exactPathQuery: query },
+            sourceFilterList,
+          ).catch((err: unknown) => {
+            log.warn(
+              `memory search: FTS keyword fallback query failed: ${formatErrorMessage(err)}`,
+            );
+            return [];
+          }),
+        ),
+      );
+      const fallbackResults = this.limitKeywordSearchHits(
+        this.mergeKeywordSearchHits(resultSets, query),
+        limit,
+      );
+      const filteredFallbackResults =
+        await this.filterReadOnlyFallbackKeywordResults(fallbackResults);
+      const merged = this.limitKeywordSearchHits(
+        this.mergeKeywordSearchHits([fullQueryResults, filteredFallbackResults], query),
+        candidates,
+      );
+      if (
+        merged.length >= candidates ||
+        fallbackResults.length < limit ||
+        limit >= READ_ONLY_FALLBACK_MAX_CANDIDATES
+      ) {
+        return merged;
+      }
+      limit = Math.min(READ_ONLY_FALLBACK_MAX_CANDIDATES, limit * 2);
+    }
   }
 
   private hasIndexedContent(): boolean {
@@ -1589,7 +1904,11 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       try {
         await this.runSyncWithReadonlyRecovery(params);
       } finally {
+        const completedProviderlessSync = this.syncProviderGeneration?.kind === "fts-only";
         this.endSyncProviderGeneration();
+        if (completedProviderlessSync) {
+          this.markRecoveredOptionalProviderFtsOnlyIndexDirtyIfNeeded();
+        }
       }
     })().finally(() => {
       this.syncing = null;

--- a/packages/memory-host-sdk/src/host/embeddings-remote-client.test.ts
+++ b/packages/memory-host-sdk/src/host/embeddings-remote-client.test.ts
@@ -1,8 +1,27 @@
 // Memory Host SDK tests cover embeddings remote client behavior.
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveRemoteEmbeddingBearerClient } from "./embeddings-remote-client.js";
 
+const authMocks = vi.hoisted(() => ({
+  resolveApiKeyForProvider: vi.fn(),
+}));
+
+vi.mock("./openclaw-runtime-auth.js", () => ({
+  requireApiKey: (auth: { apiKey?: string }, provider: string) => {
+    const apiKey = auth.apiKey?.trim();
+    if (!apiKey) {
+      throw new Error(`No API key resolved for provider "${provider}".`);
+    }
+    return apiKey;
+  },
+  resolveApiKeyForProvider: authMocks.resolveApiKeyForProvider,
+}));
+
 describe("resolveRemoteEmbeddingBearerClient", () => {
+  beforeEach(() => {
+    authMocks.resolveApiKeyForProvider.mockReset();
+  });
+
   it("uses configured OpenAI provider baseUrl for memory embeddings", async () => {
     const client = await resolveRemoteEmbeddingBearerClient({
       provider: "openai",
@@ -26,6 +45,33 @@ describe("resolveRemoteEmbeddingBearerClient", () => {
     });
 
     expect(client.baseUrl).toBe("https://proxy.example.test/openai/v1");
+  });
+
+  it("resolves native OpenAI embeddings with direct platform auth", async () => {
+    authMocks.resolveApiKeyForProvider.mockResolvedValue({
+      apiKey: "sk-resolved",
+      source: "profile:openai",
+      mode: "api-key",
+    });
+
+    const client = await resolveRemoteEmbeddingBearerClient({
+      provider: "openai",
+      defaultBaseUrl: "https://api.openai.com/v1",
+      options: {
+        agentDir: "/tmp/openclaw-agent",
+        config: { models: {} } as never,
+        model: "text-embedding-3-small",
+      },
+    });
+
+    expect(authMocks.resolveApiKeyForProvider).toHaveBeenCalledWith({
+      provider: "openai",
+      cfg: { models: {} },
+      agentDir: "/tmp/openclaw-agent",
+      modelId: "text-embedding-3-small",
+      modelApi: "openai-responses",
+    });
+    expect(client.headers.Authorization).toBe("Bearer sk-resolved");
   });
 
   it("adds OpenClaw attribution to native OpenAI embedding requests", async () => {

--- a/packages/memory-host-sdk/src/host/embeddings-remote-client.ts
+++ b/packages/memory-host-sdk/src/host/embeddings-remote-client.ts
@@ -10,6 +10,9 @@ import type { SsrFPolicy } from "./ssrf-policy.js";
 
 /** Provider id used for remote embedding auth and config lookup. */
 export type RemoteEmbeddingProviderId = string;
+// Model-auth treats any direct OpenAI platform API as API-key-only; only the
+// Codex/ChatGPT transport may use OAuth. Embeddings are direct platform calls.
+const OPENAI_PLATFORM_EMBEDDINGS_AUTH_API = "openai-responses";
 
 /** Attribution headers for native OpenAI embedding calls. */
 function resolveOpenClawAttributionHeaders(): Record<string, string> {
@@ -53,6 +56,10 @@ export async function resolveRemoteEmbeddingBearerClient(params: {
           provider: params.provider,
           cfg: params.options.config,
           agentDir: params.options.agentDir,
+          modelId: params.options.model,
+          ...(params.provider === "openai"
+            ? { modelApi: OPENAI_PLATFORM_EMBEDDINGS_AUTH_API }
+            : {}),
         }),
         params.provider,
       );


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users relying on the implicit/default memory embedding provider could see memory search report paused or unavailable when OpenAI API-key auth was not available, even though lexical FTS recall could still answer from the local memory-file index. This can happen when the active agent model/auth route is not an OpenAI API-key route, for example after switching the agent harness/model route to Grok or another non-OpenAI route.

Root-cause proof:
- Native OpenAI memory embeddings are direct OpenAI platform `/v1/embeddings` calls, not Codex/ChatGPT transport calls.
- OpenClaw only allows OAuth/token auth for the `openai-chatgpt-responses` transport; direct OpenAI platform APIs require API-key auth (`src/agents/model-auth-openai.ts:8`, `src/agents/model-auth-openai.ts:34`, `src/agents/model-auth-openai.ts:39`).
- Sibling Codex source keeps API-key, ChatGPT, agent-identity, and personal-token auth as distinct modes (`../codex/codex-rs/login/src/auth/manager.rs:207`, `../codex/codex-rs/login/src/auth/manager.rs:245`), builds Codex request-header auth from Codex auth snapshots (`../codex/codex-rs/model-provider/src/auth.rs:106`), and its direct Responses API proxy requires an API key from stdin (`../codex/codex-rs/responses-api-proxy/src/read_api_key.rs:133`).
- Current `main` initialized implicit OpenAI embeddings through the hard provider path, so missing API-key auth could throw before the manager reached usable FTS recall.

Current-main documented contract before this PR:

Shipped-release contract proof:
- Stable tag `v2026.7.1` already documented the same behavior: unset/legacy-auto memory embeddings fall back to keyword-only ranking when no embedding auth is configured (`v2026.7.1:docs/concepts/memory-search.md:90`), `provider: "none"` keeps lexical FTS recall available when embeddings are unavailable (`v2026.7.1:docs/reference/memory-config.md:71`), and explicit non-local providers remain unavailable instead of silently degrading (`v2026.7.1:docs/concepts/memory-search.md:97`, `v2026.7.1:docs/reference/memory-config.md:78`).
- Latest beta tag `v2026.7.2-beta.4` carries the same shipped contract: implicit/auto fallback to keyword-only ranking when no embedding auth is configured (`v2026.7.2-beta.4:docs/concepts/memory-search.md:91`), FTS recall for unavailable embeddings (`v2026.7.2-beta.4:docs/reference/memory-config.md:126`), and explicit non-local provider fail-closed behavior (`v2026.7.2-beta.4:docs/concepts/memory-search.md:98`, `v2026.7.2-beta.4:docs/reference/memory-config.md:133`).
- The released code also already had FTS-only lifecycle/search and semantic-index downgrade protection: stable `v2026.7.1` logs keyword-only search when embeddings are unavailable (`v2026.7.1:extensions/memory-core/src/memory/manager.ts:779`), reports FTS-only search as usable (`v2026.7.1:extensions/memory-core/src/memory/manager.ts:1282`), and refuses providerless sync that would downgrade an existing semantic index (`v2026.7.1:extensions/memory-core/src/memory/manager-sync-ops.ts:2399`). Latest beta `v2026.7.2-beta.4` has the same search and sync-guard behavior (`v2026.7.2-beta.4:extensions/memory-core/src/memory/manager.ts:881`, `v2026.7.2-beta.4:extensions/memory-core/src/memory/manager.ts:1547`, `v2026.7.2-beta.4:extensions/memory-core/src/memory/manager-sync-ops.ts:92`).
- That means this PR is not adding a broad new memory mode. It restores the already-shipped implicit/auto fallback contract for the broken OpenAI-auth-loss path, while keeping the shipped explicit-provider fail-closed boundary and the shipped semantic-index downgrade guard.
- `docs/concepts/memory-search.md:89` already says `provider: "none"` intentionally disables embeddings, and leaving `provider` unset or set to `"auto"` falls back to keyword-only ranking when no embedding auth is configured, without erroring.
- `docs/reference/memory-config.md:125` already says unset, legacy-auto, and `provider: "none"` memory recall can still use lexical FTS ranking when embeddings are unavailable.
- `docs/concepts/memory-builtin.md:23` documents default OpenAI vector search only when `OPENAI_API_KEY` or `models.providers.openai.apiKey` is already configured, and `docs/concepts/memory-builtin.md:39` says that without an embedding provider only keyword search is available.

This PR implements that existing implicit-provider contract. The exact-head runtime proof shows existing local memory-file FTS recall remains available without any OpenAI API request, while explicit remote providers still fail closed.

## Why This Change Was Made

Implicit/auto OpenAI embedding initialization is now optional: if the implicit provider cannot initialize, memory enters FTS-only recall instead of throwing. Explicit non-local providers still fail closed, existing semantic indexes get read-only FTS compatibility only when corpus shape matches, and sync still refuses to downgrade semantic metadata while embeddings are unavailable.

The fallback is intentionally narrow. It serves only verified memory-file rows whose path is still in the configured memory scope and whose indexed source hash still matches the current file. It does not serve session transcript rows from the providerless read-only fallback because session deletion/redaction freshness belongs to session sync/reconciliation. When the optional provider later recovers, existing sync/reindex state marks affected sources dirty and rebuilds the semantic index through the normal owner path.

Native OpenAI embedding auth now asks model auth with direct OpenAI platform API semantics (`modelApi: "openai-responses"`) and the embedding model id, so Codex/ChatGPT OAuth profiles are not used for `/v1/embeddings`.

This is one behavior fix across the required surfaces: auth selection, provider initialization, index identity, sync protection, recovery, tests, and docs. No knobs, migrations, SDK surface, or unrelated refactor were added.

## User Impact

Users keep memory-file recall via lexical FTS when the implicit OpenAI embedding provider is unavailable, without needing to configure a new provider or pay for OpenAI API usage just because their agent model route uses Codex, Grok, or another harness. Users who explicitly configure a remote embedding provider still get fail-closed behavior when that provider is unavailable, and existing semantic indexes are protected from silent downgrade.

No new config surface.

AI-assisted: yes, with local autoreview clean and exact-head runtime/test proof below.

## Evidence

Current PR head: `c2c0178f5f6eb61b55f6392ac0637bddee62c554`.
Runtime: Node `v24.15.0`, SQLite `3.51.3`.

Bug/root-cause evidence:
- Confirmed current-main docs already promised the implicit/auto FTS-only fallback contract before this branch (`docs/concepts/memory-search.md:89`, `docs/reference/memory-config.md:125`, `docs/concepts/memory-builtin.md:23`, `docs/concepts/memory-builtin.md:39`).
- Inspected OpenClaw auth contract: `src/agents/model-auth-openai.ts:8`, `src/agents/model-auth-openai.ts:34`, and `src/agents/model-auth-openai.ts:39` prove direct OpenAI platform APIs require API-key auth while Codex/ChatGPT transport uses OAuth/token.
- Inspected sibling Codex source: `../codex/codex-rs/login/src/auth/manager.rs:207`, `../codex/codex-rs/login/src/auth/manager.rs:245`, `../codex/codex-rs/model-provider/src/auth.rs:106`, and `../codex/codex-rs/responses-api-proxy/src/read_api_key.rs:133`.
- Added regression coverage for implicit OpenAI init failure, explicit provider failure, existing semantic-index FTS read-only fallback, semantic-index sync protection, optional provider retry backoff, concurrent retry callers, provider recovery through search/probe, concurrent search recovery joining, recovery-sync failure returning to FTS-only, stale probe-cache invalidation, valid semantic-index no-rebuild recovery, recovery during in-flight providerless sync, stale/deleted memory-file filtering, removed extra-path filtering, session-hit exclusion in the read-only fallback, provider `none`, and providerless sync skipping vector-store loading.

Exact-head runtime proof on `c2c0178f5f6e`:
- Ran `PATH=/tmp/openclaw-node24/bin:$PATH node /tmp/openclaw-memory-implicit-openai-proof.mjs` from this PR head.
- The smoke used built production modules from `dist/extensions/memory-core/runtime-api.js`, `dist/plugin-sdk/memory-core-host-engine-embeddings.js`, and `dist/extensions/openai/memory-embedding-adapter.js`; this did not use Vitest mocks.
- The smoke used an isolated temp OpenClaw state/workspace and a local loopback OpenAI-compatible `/v1/embeddings` server via `memory.search.remote.baseUrl`. `OPENAI_API_KEY` was cleared; the smoke API key came only from an env SecretRef and all auth output was redacted. `externalOpenAiCalls: 0`.
- Seed phase with the env SecretRef available built an existing semantic index: `provider: "openai"`, `model: "text-embedding-3-small"`, `chunks: 1`, `fts.available: true`, `vector.enabled: true`, `vector.dims: 8`, `indexIdentity: { status: "valid" }`, and embedding requests `0 -> 1`.
- Missing-auth phase deleted the env SecretRef and reopened the same index. Runtime status became `provider: "none"`, `searchMode: "fts-only"`, `providerState.mode: "fts-only"`, `indexIdentity: { status: "valid" }`. Search returned `MEMORY.md`; embedding requests stayed `1 -> 1`, proving no external/provider embedding call was attempted while auth was missing.
- The same missing-auth run logged the semantic-index guard: sync refused to run providerless because it would protect the existing vector index (`current model: text-embedding-3-small`), while read-only FTS recall still succeeded.
- Restored-auth phase put the env SecretRef back, expired the retry backoff in-process to avoid waiting 30s, and searched again. Runtime recovered to `provider: "openai"`, `providerState.mode: "active"`, `dirty: false`, `indexIdentity: { status: "valid" }`, returned `MEMORY.md`, and embedding requests increased `1 -> 2` with `Authorization: Bearer sk-...proof`.

Exact-head local validation on `c2c0178f5f6e` after rebasing onto current `origin/main`:
- `PATH=/tmp/openclaw-node24/bin:$PATH node scripts/run-vitest.mjs extensions/memory-core/src/memory/manager.fts-only-reindex.test.ts extensions/memory-core/src/memory/index.test.ts packages/memory-host-sdk/src/host/embeddings-remote-client.test.ts` - passed, 2 Vitest shards, 126 tests.
- `PATH=/tmp/openclaw-node24/bin:$PATH node scripts/run-vitest.mjs extensions/memory-core/src/memory/manager-reindex-state.test.ts extensions/memory-core/src/memory/manager-sync-ops.archive-delta-bypass.test.ts extensions/memory-core/src/memory/manager-sync-ops.interval.test.ts extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts extensions/memory-core/src/memory/manager-sync-yield.test.ts extensions/memory-core/src/memory/manager.session-reindex.test.ts` - passed, 1 Vitest shard, 46 tests.
- `./node_modules/.bin/oxfmt --check extensions/memory-core/src/memory/manager.ts extensions/memory-core/src/memory/manager.fts-only-reindex.test.ts` - passed.
- `git diff --check` - passed.
- `PATH=/tmp/openclaw-node24/bin:$PATH pnpm docs:list` - passed.
- `PATH=/tmp/openclaw-node24/bin:$PATH pnpm build` - passed.
- `PATH=/tmp/openclaw-node24/bin:/tmp/openclaw-tools/bin:$PATH .agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` - TruffleHog clean; no accepted/actionable findings; overall patch correct (0.88).

Broad validation: GitHub PR CI.
