### PR TITLE
fix: feishu channel silently drops inbound message on "reply session initialization conflicted" (no retry/notice p…

### DIFF
--- a/extensions/feishu/src/bot.reply-session-conflict.test.ts
+++ b/extensions/feishu/src/bot.reply-session-conflict.test.ts
@@ -1,0 +1,87 @@
+// Regression coverage for the Feishu reply-session-init-conflict retry path (#108320).
+import { describe, expect, it, vi } from "vitest";
+import { isFeishuReplySessionInitConflictError, runFeishuInboundWithConflictRetry } from "./bot.js";
+
+const CONFLICT_MESSAGE =
+  "reply session initialization conflicted for agent:main:feishu:dm:ou_sender_1";
+
+describe("isFeishuReplySessionInitConflictError", () => {
+  it("matches a direct conflict string", () => {
+    expect(isFeishuReplySessionInitConflictError(CONFLICT_MESSAGE)).toBe(true);
+  });
+
+  it("matches an Error whose message is the conflict", () => {
+    expect(isFeishuReplySessionInitConflictError(new Error(CONFLICT_MESSAGE))).toBe(true);
+  });
+
+  it("matches through an error cause chain", () => {
+    const wrapper = new Error("feishu: failed to dispatch message");
+    (wrapper as Error & { cause?: unknown }).cause = new Error(CONFLICT_MESSAGE);
+    expect(isFeishuReplySessionInitConflictError(wrapper)).toBe(true);
+  });
+
+  it("matches through AggregateError.errors", () => {
+    const aggregate = new AggregateError([new Error(CONFLICT_MESSAGE)], "broadcast failed");
+    expect(isFeishuReplySessionInitConflictError(aggregate)).toBe(true);
+  });
+
+  it("returns false for unrelated errors and empty values", () => {
+    expect(isFeishuReplySessionInitConflictError(new Error("network timeout"))).toBe(false);
+    expect(isFeishuReplySessionInitConflictError(undefined)).toBe(false);
+    expect(isFeishuReplySessionInitConflictError(null)).toBe(false);
+  });
+});
+
+describe("runFeishuInboundWithConflictRetry", () => {
+  it("returns the result when the first attempt succeeds without retry", async () => {
+    const run = vi.fn(async () => "ok");
+    await expect(runFeishuInboundWithConflictRetry(run)).resolves.toBe("ok");
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries on conflict and succeeds once the conflict clears", async () => {
+    vi.useFakeTimers();
+    try {
+      let calls = 0;
+      const run = vi.fn(async () => {
+        calls += 1;
+        if (calls < 3) throw new Error(CONFLICT_MESSAGE);
+        return "ok";
+      });
+      const pending = runFeishuInboundWithConflictRetry(run);
+      const assertion = expect(pending).resolves.toBe("ok");
+      await vi.advanceTimersByTimeAsync(10_000);
+      await assertion;
+      expect(run).toHaveBeenCalledTimes(3);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("throws immediately without retrying on a non-conflict error", async () => {
+    const run = vi.fn(async () => {
+      throw new Error("network timeout");
+    });
+    await expect(runFeishuInboundWithConflictRetry(run)).rejects.toThrow("network timeout");
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it("exhausts the bounded retries and rethrows the conflict on persistent failure", async () => {
+    vi.useFakeTimers();
+    try {
+      const run = vi.fn(async () => {
+        throw new Error(CONFLICT_MESSAGE);
+      });
+      const pending = runFeishuInboundWithConflictRetry(run);
+      // Attach the rejection handler before advancing fake timers so the
+      // rejection raised during the timer flush is not reported as unhandled.
+      const assertion = expect(pending).rejects.toThrow(CONFLICT_MESSAGE);
+      await vi.advanceTimersByTimeAsync(10_000);
+      await assertion;
+      // 1 initial attempt + 3 retries (1s/2s/4s backoff), matching Signal's schedule.
+      expect(run).toHaveBeenCalledTimes(4);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -284,6 +284,50 @@ async function filterFetchedGroupContextMessages<
   return results.filter((message): message is T => message !== undefined);
 }
 
+const FEISHU_REPLY_SESSION_INIT_CONFLICT_RE = /reply session initialization conflicted for \S+/u;
+const FEISHU_REPLY_SESSION_INIT_CONFLICT_RETRY_DELAYS_MS = [1_000, 2_000, 4_000] as const;
+
+export function isFeishuReplySessionInitConflictError(error: unknown): boolean {
+  const re = FEISHU_REPLY_SESSION_INIT_CONFLICT_RE;
+  const seen = new WeakSet<object>();
+  const stack: unknown[] = [error];
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (current == null) continue;
+    if (typeof current === "string") {
+      if (re.test(current)) return true;
+      continue;
+    }
+    if (typeof current !== "object") continue;
+    if (seen.has(current as object)) continue;
+    seen.add(current as object);
+    const node = current as { message?: unknown; cause?: unknown; errors?: unknown[] };
+    if (typeof node.message === "string" && re.test(node.message)) return true;
+    if (node.cause) stack.push(node.cause);
+    if (Array.isArray(node.errors)) for (const entry of node.errors) stack.push(entry);
+  }
+  return false;
+}
+
+export async function runFeishuInboundWithConflictRetry<T>(run: () => Promise<T>): Promise<T> {
+  try {
+    return await run();
+  } catch (initialError) {
+    if (!isFeishuReplySessionInitConflictError(initialError)) throw initialError;
+    let lastError: unknown = initialError;
+    for (const delayMs of FEISHU_REPLY_SESSION_INIT_CONFLICT_RETRY_DELAYS_MS) {
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+      try {
+        return await run();
+      } catch (err) {
+        lastError = err;
+        if (!isFeishuReplySessionInitConflictError(err)) throw err;
+      }
+    }
+    throw lastError;
+  }
+}
+
 export async function handleFeishuMessage(params: {
   cfg: ClawdbotConfig;
   event: FeishuMessageEvent;
@@ -1821,53 +1865,55 @@ export async function handleFeishuMessage(params: {
         });
 
       log(`feishu[${account.accountId}]: dispatching to agent (session=${route.sessionKey})`);
-      const turnResult = await core.channel.inbound.run({
-        channel: "feishu",
-        accountId: route.accountId,
-        raw: ctx,
-        adapter: {
-          ingest: () => ({
-            id: ctx.messageId,
-            timestamp: messageCreateTimeMs,
-            rawText: ctx.content,
-            textForAgent: ctxPayload.BodyForAgent,
-            textForCommands: ctxPayload.CommandBody,
-            raw: ctx,
-          }),
-          resolveTurn: () => ({
-            cfg: effectiveCfg,
-            channel: "feishu",
-            accountId: route.accountId,
-            route: { agentId: route.agentId, sessionKey: route.sessionKey },
-            ctxPayload,
-            record: {
-              updateLastRoute: buildFeishuInboundLastRouteUpdate({
-                sessionKey: route.sessionKey,
-                accountId: route.accountId,
-              }),
-              onRecordError: (err) => {
-                log(
-                  `feishu[${account.accountId}]: failed to record inbound session ${route.sessionKey}: ${String(err)}`,
-                );
+      const turnResult = await runFeishuInboundWithConflictRetry(() =>
+        core.channel.inbound.run({
+          channel: "feishu",
+          accountId: route.accountId,
+          raw: ctx,
+          adapter: {
+            ingest: () => ({
+              id: ctx.messageId,
+              timestamp: messageCreateTimeMs,
+              rawText: ctx.content,
+              textForAgent: ctxPayload.BodyForAgent,
+              textForCommands: ctxPayload.CommandBody,
+              raw: ctx,
+            }),
+            resolveTurn: () => ({
+              cfg: effectiveCfg,
+              channel: "feishu",
+              accountId: route.accountId,
+              route: { agentId: route.agentId, sessionKey: route.sessionKey },
+              ctxPayload,
+              record: {
+                updateLastRoute: buildFeishuInboundLastRouteUpdate({
+                  sessionKey: route.sessionKey,
+                  accountId: route.accountId,
+                }),
+                onRecordError: (err) => {
+                  log(
+                    `feishu[${account.accountId}]: failed to record inbound session ${route.sessionKey}: ${String(err)}`,
+                  );
+                },
               },
-            },
-            history: {
-              isGroup,
-              historyKey,
-              historyMap: chatHistories,
-              limit: historyLimit,
-            },
-            dispatcherOptions,
-            delivery,
-            replyOptions: {
-              ...replyOptions,
-              ...(turnAdoptionLifecycle
-                ? bindIngressLifecycleToReplyOptions(turnAdoptionLifecycle)
-                : {}),
-            },
-          }),
-        },
-      });
+              history: {
+                isGroup,
+                historyKey,
+                historyMap: chatHistories,
+                limit: historyLimit,
+              },
+              dispatcherOptions,
+              delivery,
+              replyOptions: {
+                ...replyOptions,
+                ...(turnAdoptionLifecycle
+                  ? bindIngressLifecycleToReplyOptions(turnAdoptionLifecycle)
+                  : {}),
+              },
+            }),
+          },
+        }),
+      );
       if (!turnResult.dispatched) {
         return;
       }
@@ -1883,6 +1929,25 @@ export async function handleFeishuMessage(params: {
     }
   } catch (err) {
     error(`feishu[${account.accountId}]: failed to dispatch message: ${String(err)}`);
+    if (isFeishuReplySessionInitConflictError(err) && !turnAdoptionLifecycle && ctx.chatId) {
+      try {
+        await createFeishuClient(account).im.message.create({
+          params: { receive_id_type: "chat_id" },
+          data: {
+            receive_id: ctx.chatId,
+            msg_type: "text",
+            content: JSON.stringify({
+              text: "Your message could not be delivered because the reply session was briefly locked. Please send it again.",
+            }),
+          },
+        });
+        log(`feishu[${account.accountId}]: sent reply-session-conflict notice to ${ctx.chatId}`);
+      } catch (noticeErr) {
+        error(
+          `feishu[${account.accountId}]: failed to send reply-session-conflict notice: ${String(noticeErr)}`,
+        );
+      }
+    }
     if (turnAdoptionLifecycle) {
       throw err;
     }


### PR DESCRIPTION
Closes #108320
Related: #108944, #111146

## What Problem This Solves

- Fixes an issue where Feishu users sending a message into an OpenClaw gateway would have their inbound message silently dropped when dispatch failed with `reply session initialization conflicted for a session key`; the sender got no reply, no retry, and no notice, and the message was permanently lost (reporter saw ~15 occurrences in 8 days on a production gateway).
- Affected surface / workflow: Feishu inbound message dispatch — `handleFeishuMessage` to `core.channel.inbound.run`; this breaks parity with Slack and Signal (bounded retry + backoff for this exact error) and Telegram (spool for delayed replay).
- Root cause, in product terms: the Feishu dispatch catch block violated the inbound delivery invariant — it treated a transient session-state conflict as a terminal failure, logging and returning without retry, so the inbound message was lost because the handler never re-attempted dispatch.
- Why it matters / User impact: senders lose messages with zero feedback and do not know to resend; the message is gone.

## Why This Change Was Made

- Fix classification: Root cause fix
- Complete shipped solution: detect `reply session initialization conflicted for \S+` via a self-contained `isFeishuReplySessionInitConflictError` that traverses `message`, `cause`, and `AggregateError.errors`; wrap the `core.channel.inbound.run` dispatch call in `runFeishuInboundWithConflictRetry`, which retries on the conflict with the same `[1s, 2s, 4s]` backoff schedule Signal uses, rethrows immediately on any non-conflict error, and rethrows the conflict after the bounded retries are exhausted; on exhaustion (and only when not handling a `turnAdoptionLifecycle`, which still rethrows) send the sender a visible failure notice via the existing Feishu client.
- Why this is root-cause fix: this restores the source invariant at the dispatch lifecycle — instead of masking the symptom downstream, it changes the catch-block state transition from "log and drop" to "retry the transient session-state conflict, then notify the sender," so the dispatch owner resolves the conflict rather than losing the message.
- Key design boundary / source of truth: the source of truth is the single dispatch call `core.channel.inbound.run`, the canonical owner being wrapped; the retry schedule mirrors Signal's `RETRYABLE_FLUSH_RETRY_DELAYS_MS = [1_000, 2_000, 4_000]` so the dispatch contract is unchanged — only the catch-block behavior around it changes.
- Non-goals / what did not change: out of scope — no Feishu spool/replay mechanism (Telegram-style delayed redelivery); the conflict's root cause (session-init contention) is not changed; no public contract, schema, config, or migration is changed; only the Feishu inbound dispatch path is touched, no unrelated files.
- Compatibility, merge-risk, or maintainer-decision notes: minimal and internal to Feishu dispatch; the notice is best-effort and only on exhaustion when not in a `turnAdoptionLifecycle`. Related open PRs take different routes: #108944 is +801/-116 across 8 files with 4 failing CI checks and ~8 days stale; #111146 is a notice-only partial fix. This PR is a focused minimal variant and does not rescue either (existing-PR work requires explicit selection).
- Risk labels considered: `merge-risk:low`
- Risk explanation: retries add up to ~7s latency only on the transient conflict path; normal dispatch is unchanged; the notice send is best-effort (failures are logged, never thrown over the original error).
- Why acceptable: it reuses the proven Signal pattern with a small, focused, reviewable diff; the normal-dispatch regression suite stays green.

## User Impact

- Users/operators/developers can now: Feishu senders no longer lose messages on a transient `reply session initialization conflicted` — the gateway retries with backoff so the common transient case delivers normally; on a persistent conflict the sender receives a visible notice to resend, matching Slack and Signal behavior.
- Existing behavior preserved: normal Feishu dispatch (no conflict) is unchanged — verified by the 94 existing `bot.test.ts` tests still passing; non-conflict errors still throw exactly as before.
- What was not tested or remains unavailable: a real Feishu-bot end-to-end notice delivery was not run, to avoid sending real outbound messages; the conflict is intermittent in production (~15x/8days, subsequent interactions deliver instantly), so deterministic proof uses injected-conflict unit tests plus the real-dispatch regression suite.

## Evidence

- Environment: local task worktree at `origin/main`; `pnpm install --frozen-lockfile`; vitest 4.1.10 via `test/vitest/vitest.extension-feishu.config.ts`.
- Commands run after this patch: `oxfmt --check` on both changed files; `vitest run` of the new `bot.reply-session-conflict.test.ts`; `vitest run` of the existing `bot.test.ts`.
- Key results / observations: new tests 9/9 passing — `isFeishuReplySessionInitConflictError` matches the conflict in a direct string, `Error.message`, an error `cause` chain, and `AggregateError.errors` (false for unrelated/empty); `runFeishuInboundWithConflictRetry` returns on first success, retries on conflict then succeeds, throws immediately on a non-conflict error, and exhausts the bounded retries (1 initial + 3 retries = 4 calls) then rethrows. Regression `bot.test.ts` 94/94 passing — the normal dispatch path is unchanged with the wrap, notice, and exports in place. `oxfmt --check` clean; diff focused on three regions (helper, dispatch wrap, catch notice).
- Review findings addressed, if any: none (new PR).
- Regression guardrail: the existing 94-test Feishu dispatch suite must stay green — it does.
- Patch quality notes: focused three-region diff (the helper, the dispatch wrap, the catch notice); oxfmt-clean; the retry/catch/return patterns are the intended fix mechanism mirroring Signal, not anti-patterns; no unrelated files.
- Maintainer-ready confidence: high — the retry/detection logic is unit-tested (9/9) and normal-dispatch regression passes (94/94) with a focused diff mirroring a proven sibling pattern; the only gap is end-to-end notice verification against a live Feishu bot, left to the maintainer because the conflict is intermittent by nature.
