### PR TITLE
fix(release): select supported macOS candidate snapshots

### DIFF
--- a/scripts/e2e/parallels/npm-update-smoke.ts
+++ b/scripts/e2e/parallels/npm-update-smoke.ts
@@ -61,6 +61,7 @@ interface NpmUpdateOptions {
   registryPackageTarballs: string[];
   freshTargetSpec?: string;
   hostIp?: string;
+  macosSnapshotHint?: string;
   macosVm?: string;
   packageSpec: string;
   targetTarball?: string;
@@ -390,6 +391,8 @@ Options:
   --platform <list>           Comma-separated platforms to run: all, macos, windows, linux.
                              Default: all
   --macos-vm <name>           Explicit Parallels macOS VM name.
+  --macos-snapshot-hint <hint>
+                             Snapshot name substring/fuzzy match passed to macOS fresh lanes.
   --provider <openai|anthropic|minimax>
   --model <provider/model>    Override the model used for agent-turn smoke checks.
   --host-ip <ip>             Override Parallels host IP.
@@ -409,6 +412,7 @@ export function parseArgs(argv: string[]): NpmUpdateOptions {
     registryPackageTarballs: [],
     freshTargetSpec: undefined,
     json: false,
+    macosSnapshotHint: undefined,
     macosVm: undefined,
     modelId: undefined,
     packageSpec: "",
@@ -463,6 +467,10 @@ export function parseArgs(argv: string[]): NpmUpdateOptions {
         break;
       case "--macos-vm":
         options.macosVm = ensureValue(args, i, arg);
+        i++;
+        break;
+      case "--macos-snapshot-hint":
+        options.macosSnapshotHint = ensureValue(args, i, arg);
         i++;
         break;
       case "--provider":
@@ -691,7 +699,7 @@ export class NpmUpdateSmoke {
   private async runFreshBaselines(): Promise<void> {
     const jobs: Job[] = [];
     if (this.options.platforms.has("macos")) {
-      jobs.push(this.spawnFresh("macOS", "macos", ["--vm", this.macosVm]));
+      jobs.push(this.spawnFresh("macOS", "macos", this.macosFreshArgs()));
     }
     if (this.options.platforms.has("windows")) {
       jobs.push(this.spawnFresh("Windows", "windows", []));
@@ -713,7 +721,7 @@ export class NpmUpdateSmoke {
         this.spawnFresh(
           "macOS",
           "macos",
-          ["--vm", this.macosVm],
+          this.macosFreshArgs(),
           {},
           this.freshTargetSpec,
           "fresh-target",
@@ -740,6 +748,16 @@ export class NpmUpdateSmoke {
       );
     }
     await this.finishFreshJobs("fresh-target", "fresh target", jobs, this.freshTargetStatus);
+  }
+
+  private macosFreshArgs(): string[] {
+    return [
+      "--vm",
+      this.macosVm,
+      ...(this.options.macosSnapshotHint
+        ? ["--snapshot-hint", this.options.macosSnapshotHint]
+        : []),
+    ];
   }
 
   private async finishFreshJobs(

--- a/scripts/release-candidate-checklist.d.mts
+++ b/scripts/release-candidate-checklist.d.mts
@@ -256,12 +256,14 @@ export function candidateParallelsArgs(
   dependencyTarballPaths?: unknown[],
   toolingRoot?: string,
   registryPackageTarballPaths?: unknown[],
+  macosSnapshotHint?: string,
 ): unknown[];
 export function candidateParallelsShellCommand(
   tarballPath: unknown,
   timeoutBin: unknown,
   dependencyTarballPaths?: unknown[],
   registryPackageTarballPaths?: unknown[],
+  macosSnapshotHint?: string,
 ): string;
 declare function gitIsAncestor(ancestor: unknown, target: unknown): boolean;
 declare function loadCandidateShippedBaseline(ref: unknown): {

--- a/scripts/release-candidate-checklist.mjs
+++ b/scripts/release-candidate-checklist.mjs
@@ -1361,6 +1361,7 @@ export function candidateParallelsArgs(
   dependencyTarballPaths = [],
   toolingRoot = TOOLING_ROOT,
   registryPackageTarballPaths = [],
+  macosSnapshotHint = "",
 ) {
   return [
     "exec",
@@ -1373,6 +1374,7 @@ export function candidateParallelsArgs(
       "--registry-package-tarball",
       registryPackage,
     ]),
+    ...(macosSnapshotHint ? ["--macos-snapshot-hint", macosSnapshotHint] : []),
     "--json",
   ];
 }
@@ -1382,6 +1384,7 @@ export function candidateParallelsShellCommand(
   timeoutBin,
   dependencyTarballPaths = [],
   registryPackageTarballPaths = [],
+  macosSnapshotHint = "",
 ) {
   // Login shells can replace the candidate's supported Node with ambient host Node.
   // Keep the invoking Node first so pnpm and npm use the validated runtime.
@@ -1399,6 +1402,7 @@ export function candidateParallelsShellCommand(
       dependencyTarballPaths,
       TOOLING_ROOT,
       registryPackageTarballPaths,
+      macosSnapshotHint,
     ).map(shellQuote),
   ].join(" ");
 }
@@ -1425,6 +1429,7 @@ async function runParallelsIfNeeded(
     timeoutBin,
     dependencyTarballPaths,
     registryPackageTarballPaths,
+    process.env.OPENCLAW_PARALLELS_MACOS_SNAPSHOT_HINT?.trim() ?? "",
   );
   run("bash", ["-lc", command], {
     env: {

--- a/test/scripts/parallels-npm-update-smoke.test.ts
+++ b/test/scripts/parallels-npm-update-smoke.test.ts
@@ -137,6 +137,15 @@ describe("parallels npm update smoke", () => {
     ).toThrow("--registry-package-tarball requires --target-tarball");
   });
 
+  it("passes an explicit macOS snapshot hint through fresh lanes", () => {
+    expect(
+      parseArgs(["--platform", "macos", "--macos-snapshot-hint", "macOS 26.5 Node 24"]),
+    ).toMatchObject({
+      macosSnapshotHint: "macOS 26.5 Node 24",
+      platforms: new Set(["macos"]),
+    });
+  });
+
   it("stops the host artifact server when the wrapper fails mid-run", async () => {
     let stopCalls = 0;
     const server: HostServer = {

--- a/test/scripts/release-candidate-checklist.test.ts
+++ b/test/scripts/release-candidate-checklist.test.ts
@@ -543,6 +543,7 @@ describe("release candidate checklist", () => {
         [".artifacts/preflight/openclaw-ai.tgz"],
         "/trusted",
         [".artifacts/preflight/openclaw-codex.tgz"],
+        "macOS 26.5 Node 24",
       ),
     ).toEqual([
       "exec",
@@ -554,6 +555,8 @@ describe("release candidate checklist", () => {
       ".artifacts/preflight/openclaw-ai.tgz",
       "--registry-package-tarball",
       ".artifacts/preflight/openclaw-codex.tgz",
+      "--macos-snapshot-hint",
+      "macOS 26.5 Node 24",
       "--json",
     ]);
   });


### PR DESCRIPTION
## What Problem This Solves

Fixes a release-candidate blocker where the aggregate Parallels npm-update harness always selected its default macOS snapshot even when another pristine snapshot carried the supported Node runtime. The default snapshot exposed Node 25.2.1, so the baseline package correctly refused to start; the prepared Node 24 snapshot could not be selected through the aggregate or candidate helper.

## Why This Change Was Made

The aggregate now accepts `--macos-snapshot-hint` and forwards it to every macOS fresh and fresh-target lane. The release-candidate helper passes the optional `OPENCLAW_PARALLELS_MACOS_SNAPSHOT_HINT` operator value through shell-safe argument construction, leaving the default behavior unchanged when no override is supplied.

## User Impact

Release operators can run the complete fresh/install/update candidate matrix against an existing supported macOS baseline without renaming snapshots, provisioning another VM, or skipping Parallels proof. Product runtime behavior and release bytes are unchanged.

AI-assisted: yes.

## Evidence

- Before: the beta.5 candidate matrix restored `macOS 26.5 LATEST`, installed the baseline package, then failed because that snapshot exposes unsupported Node 25.2.1.
- Inventory proof: the release host already had a pristine Node 24 power-on snapshot; no new VM or snapshot was created.
- After from PR head `763b4722d43`: the aggregate resolved the requested Node 24 snapshot and completed the exact prepared beta.5 macOS matrix. Fresh baseline passed in 218,196 ms, same-guest `openclaw update` passed in 186,724 ms with installed version `2026.7.2-beta.5`, and fresh beta.5 install passed in 205,749 ms. The candidate package recorded build commit `3114ea0`; total matrix time was 632,881 ms.
- `node scripts/run-vitest.mjs test/scripts/parallels-npm-update-smoke.test.ts test/scripts/release-candidate-checklist.test.ts` — 92 tests passed.
- Remote `pnpm check:changed` — passed, including script/test-root typechecks, declaration contracts, formatting, lint, and boundary guards; Testbox run https://github.com/openclaw/openclaw/actions/runs/30212508150.
- Autoreview — clean, no accepted or actionable findings.

## Maintainer Decision

The release owner accepts the optional snapshot selector after the successful PR-head matrix above. The no-hint path remains unchanged; the override is used only when the operator explicitly selects an existing verified snapshot. Current `main` is one unrelated channel-setup commit ahead and changes none of the Parallels, candidate-helper, or test files; the repo-native merge check will verify the clean merge result without rewriting this proven head.
