### PR TITLE
fix(buzz): require compatible beta host

### DIFF
--- a/extensions/buzz/README.md
+++ b/extensions/buzz/README.md
@@ -184,4 +184,4 @@ Full setup, configuration, access controls, and troubleshooting:
 
 - Plugin id: `buzz`
 - Package: `@openclaw/buzz`
-- Minimum OpenClaw host: `2026.7.2`
+- Minimum OpenClaw host: `2026.7.2-beta.3`

--- a/extensions/buzz/npm-shrinkwrap.json
+++ b/extensions/buzz/npm-shrinkwrap.json
@@ -12,7 +12,7 @@
         "zod": "4.4.3"
       },
       "peerDependencies": {
-        "openclaw": ">=2026.7.2"
+        "openclaw": ">=2026.7.2-beta.3"
       },
       "peerDependenciesMeta": {
         "openclaw": {

--- a/extensions/buzz/package.json
+++ b/extensions/buzz/package.json
@@ -16,7 +16,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.7.2"
+    "openclaw": ">=2026.7.2-beta.3"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -51,10 +51,10 @@
       "clawhubSpec": "clawhub:@openclaw/buzz",
       "npmSpec": "@openclaw/buzz",
       "defaultChoice": "npm",
-      "minHostVersion": ">=2026.7.2"
+      "minHostVersion": ">=2026.7.2-beta.3"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.7.2-beta.3"
     },
     "build": {
       "openclawVersion": "2026.7.2"


### PR DESCRIPTION
## What Problem This Solves

The Buzz plugin uses Plugin SDK exports that are not all present until OpenClaw `2026.7.2-beta.3`, but its package metadata currently declares `>=2026.7.2`. OpenClaw intentionally treats a stable-base plugin API floor as compatible across that beta train, so that declaration can admit beta 1 or beta 2 even though Buzz cannot load there.

## Why This Change Was Made

Set the Buzz npm peer dependency, installer minimum, Plugin API range, shrinkwrap metadata, and package README to the first compatible host: `2026.7.2-beta.3`.

The authoritative external-plugin install/load gate is `openclaw.compat.pluginApi`. Explicit prerelease floors preserve prerelease ordering, so this range rejects beta 1 and beta 2 while accepting beta 3, later betas, stable `2026.7.2`, and later releases.

## User Impact

OpenClaw beta 1 and beta 2 are rejected cleanly instead of installing an unloadable plugin. Beta 3 and newer betas remain supported, and stable `2026.7.2` plus later releases continue to satisfy the range.

## Evidence

- Tag audit: beta 1 lacks `resolveChannelInboundRouteEnvelope` and `createChannelReplayGuard`; beta 2 lacks `resolveChannelInboundRouteEnvelope`; beta 3 through beta 5 contain all required exports.
- Exact-head focused compatibility proof at `8b650eb55336cc5732900acf2193dbbd03a05eea`:
  ```text
  node scripts/run-vitest.mjs src/infra/clawhub.test.ts src/plugins/install.test.ts src/plugins/install.npm-spec.test.ts \
    -t 'preserves prerelease ordering|checks package plugin API before current-host extension shape validation|resolves incompatible prerelease tags to a compatible prerelease version'

  Test Files  3 passed (3)
  Tests       3 passed | 253 skipped (256)
  ```
- Direct semver matrix for `>=2026.7.2-beta.3`:
  ```text
  2026.7.2-beta.1  false
  2026.7.2-beta.2  false
  2026.7.2-beta.3  true
  2026.7.2-beta.5  true
  2026.7.2         true
  2026.7.3         true
  ```
- `oxfmt --check` on the three changed files: pass
- `git diff --check`: pass
- Fresh autoreview: clean, no accepted or actionable findings
