### PR TITLE
fix(sidebar): resolve unscrollable markdown preview panel when conten…

### DIFF
--- a/ui/src/styles/chat/sidebar.css
+++ b/ui/src/styles/chat/sidebar.css
@@ -1310,6 +1310,7 @@ openclaw-chat-sidebar-region,
   display: flex;
   flex-direction: column;
   height: 100%;
+  min-height: 0;
   background: var(--panel);
 }
 


### PR DESCRIPTION
Closes #114143

## What Problem This Solves

Fixes an issue where users viewing long markdown content (such as large code blocks or documents) in the Markdown Preview panel on the right side of the chat interface would be unable to scroll down to read the rest of the content because the scrollbar was missing or non-functional. This affected both the Control UI webchat (Chrome on Windows/macOS) and the macOS native client.

## Why This Change Was Made

Added `min-height: 0;` to the `.sidebar-panel` class in `ui/src/styles/chat/sidebar.css`. This overrides the default `min-height: auto` of the flex item inside its nested flex container (`openclaw-chat-detail-panel`), allowing `.sidebar-panel` to properly shrink to the available viewport height instead of stretching to match the full height of the rendered markdown. This bounds the `.sidebar-content` child, enabling its vertical scrollbar to trigger and scroll correctly when content overflows.

## User Impact

Users on all clients (Control UI webchat and macOS native client) can now scroll vertically in the Markdown Preview panel to read all content below the fold.

## Evidence

Verified that `.sidebar-panel` constraint styling is resolved. Adding `min-height: 0;` allows the element to shrink as a flex item, ensuring `.sidebar-content` receives a bounded height and correctly generates scroll overflow containers.
