### PR TITLE
fix(gateway): scope agent delete trash allowedRoots to target parent dir

### DIFF
--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -415,6 +415,30 @@ function isMissingCleanupPathError(error: unknown): boolean {
   );
 }
 
+async function resolveAgentPathAllowedRoots(
+  cleanupPath: AgentDeleteCleanupPath,
+): Promise<string[]> {
+  // movePathToTrash defaults allowedRoots to [os.homedir(), os.tmpdir()], which
+  // rejects trash targets that live outside those roots (e.g. a custom stateDir,
+  // container-mounted agent/workspace dirs). Scope allowedRoots to the resolved
+  // parent directory of the target instead, matching the CLI's moveToTrash
+  // helper, so agent deletion succeeds regardless of where state is stored.
+  const allowedRoots = [cleanupPath.parentPath];
+  try {
+    const stat = await fs.lstat(cleanupPath.trashPath);
+    if (stat.isSymbolicLink()) {
+      try {
+        allowedRoots.push(path.dirname(await fs.realpath(cleanupPath.trashPath)));
+      } catch {
+        // Broken symlinks are handled lexically by fs-safe.
+      }
+    }
+  } catch {
+    // Existence was already checked by the caller; ignore races here.
+  }
+  return [...new Set(allowedRoots)];
+}
+
 async function removeAgentPath(
   cleanupPath: AgentDeleteCleanupPath,
 ): Promise<AgentDeletePathOutcome> {
@@ -433,7 +457,8 @@ async function removeAgentPath(
   try {
     // fs-safe pins traversal and identity for validation; Trash has no fd-relative move API, so
     // replacement after this check and before its rename is the accepted residual race bound.
-    await movePathToTrash(trashPath);
+    const allowedRoots = await resolveAgentPathAllowedRoots(cleanupPath);
+    await movePathToTrash(trashPath, { allowedRoots });
     return { removed: { path: pathname, method: "trash" } };
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code !== "ENOENT") {


### PR DESCRIPTION
## Bug

Agent deletion (`agents.delete` gateway method, used by all UI apps and the CLI's gateway-first path) silently fails to remove the agent's files whenever the agent's workspace/agentDir/sessionsDir live outside `os.homedir()` or `os.tmpdir()` — e.g. a custom `stateDir`, container-mounted paths, or any non-default storage layout.

## Root cause

In `src/gateway/server-methods/agents.ts`, `removeAgentPath()` calls:

```ts
await movePathToTrash(trashPath);
```

`@openclaw/fs-safe`'s `movePathToTrash` defaults `allowedRoots` to `[os.homedir(), os.tmpdir()]` when the option is omitted, and throws `"Refusing to trash path outside allowed roots"` for anything else. That error lands the path in the response's `failed[]` array — after the agent's config entry has already been removed — so the agent looks "deleted" from the roster but its files (and, transitively, the whole operation from the user's point of view) appear broken/incomplete.

The CLI-only path (`src/commands/onboard-helpers.ts` → `moveToTrash`) already handles this correctly: it computes `allowedRoots` from the resolved parent directory of the target (plus the resolved symlink target's parent, when applicable) before calling `movePathToTrash`. The gateway handler — which is what the UI/apps actually call — never got the same treatment.

## Fix

Added a `resolveAgentPathAllowedRoots()` helper in `agents.ts`, mirroring the CLI's approach, and pass its result as `allowedRoots` when calling `movePathToTrash` in `removeAgentPath()`. This makes agent-file cleanup succeed regardless of where the agent's directories live on disk, instead of only working when they happen to sit under the OS home/tmp roots.

## Testing

Traced through `@openclaw/fs-safe`'s `movePathToTrash`/`assertAllowedTrashTarget` implementation to confirm the default-roots behavior, and compared against the CLI's `moveToTrash` for the correct fix pattern. Sandbox here didn't have write access to run the existing gateway test suite (read-only mount), so please run `vitest run src/gateway/server-methods/agents.ts` (and the broader agents delete suite) in CI.
