### PR TITLE
fix(e2e): make Windows prerequisite setup deterministic

### DIFF
--- a/scripts/e2e/parallels-windows-prepare.sh
+++ b/scripts/e2e/parallels-windows-prepare.sh
@@ -509,8 +509,8 @@ winget_download() {
   version="${manifest_fact%%|*}"
   WINGET_EXPECTED_HASH="${manifest_fact#*|}"
   local download_dir="${GUEST_PROFILE//\//\\}\\Downloads\\OpenClawPrereqs"
-  guest_user_ps "Remove-Item -LiteralPath '${GUEST_PROFILE_PS}/Downloads/OpenClawPrereqs' -Recurse -Force -ErrorAction SilentlyContinue"
-  guest_user_cmd "if not exist \"${download_dir}\" mkdir \"${download_dir}\" & winget.exe download --id ${package_id} -e --version \"${version}\" --scope machine --download-directory \"${download_dir}\" --accept-source-agreements --accept-package-agreements --disable-interactivity"
+  guest_user_ps "if (Test-Path -LiteralPath '${GUEST_PROFILE_PS}/Downloads/OpenClawPrereqs') { Remove-Item -LiteralPath '${GUEST_PROFILE_PS}/Downloads/OpenClawPrereqs' -Recurse -Force }"
+  guest_user_cmd "if not exist \"${download_dir}\" mkdir \"${download_dir}\" & winget.exe download --source winget --id ${package_id} -e --version \"${version}\" --scope machine --download-directory \"${download_dir}\" --accept-source-agreements --accept-package-agreements --disable-interactivity"
 }
 
 downloaded_installer() {

--- a/test/scripts/parallels-smoke-model.test.ts
+++ b/test/scripts/parallels-smoke-model.test.ts
@@ -281,6 +281,10 @@ describe("Parallels smoke model selection", () => {
     expect(controller).toContain('prlctl stop "$VM_NAME" --acpi');
     expect(controller).toContain("HypervisorPresent");
     expect(controller).toContain("git --version && node --version && npm --version");
+    expect(controller).toContain(
+      "if (Test-Path -LiteralPath '${GUEST_PROFILE_PS}/Downloads/OpenClawPrereqs')",
+    );
+    expect(controller).toContain("winget.exe download --source winget");
     expect(controller).toContain("OPENCLAW_PARALLELS_WINDOWS_LIBRARY_ONLY");
     expect(controller).not.toContain("openclaw-windows-node");
   });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the reusable Windows Parallels baseline preparation exited before installing Git when the temporary download directory did not exist. If it reached WinGet, WinGet also queried the Microsoft Store source and could fail on that unrelated source before downloading the pinned community package.

## Why This Change Was Made

Guard cleanup with `Test-Path` so a missing transient directory is a successful no-op, and constrain the already version-and-hash-pinned download to the `winget` community source. The signed installer, manifest hash, Authenticode publisher, and protected SYSTEM staging checks remain unchanged.

## User Impact

Release operators can prepare a clean Windows 11 Parallels baseline without an absent-directory exit or Microsoft Store source failure. There is no OpenClaw product behavior change.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/parallels-smoke-model.test.ts` — 87 tests passed.
- Autoreview: clean, no accepted/actionable findings.
- Live Windows 11 ARM64 Parallels preparation from this PR head:
  - installed Git 2.55.0.windows.3
  - installed Node 24.18.0 and npm 11.16.0
  - verified WSL 2.7.11 with default version 2
  - verified no OpenClaw product state and no pending Windows reboot
  - created power-off snapshot `pre-openclaw-native-e2e-2026-07-26`
