### PR TITLE
fix(e2e): use the newest Windows smoke snapshot

### DIFF
--- a/scripts/e2e/parallels/snapshots.ts
+++ b/scripts/e2e/parallels/snapshots.ts
@@ -38,9 +38,13 @@ export function resolveSnapshot(vmName: string, hint: string): SnapshotInfo {
       `prlctl snapshot-list ${vmName} --json returned no snapshots; create/restore a snapshot or set ${SKIP_SNAPSHOT_RESTORE_ENV}=1 for an already-started guest`,
     );
   }
-  const payload = JSON.parse(output) as Record<string, { name?: string; state?: string }>;
+  const payload = JSON.parse(output) as Record<
+    string,
+    { date?: string; name?: string; state?: string }
+  >;
   let best: SnapshotInfo | null = null;
   let bestScore = -1;
+  let bestDate = "";
   const aliases = (name: string): string[] => {
     const values = [name];
     for (const pattern of [/^(.*)-poweroff$/, /^(.*)-poweroff-\d{4}-\d{2}-\d{2}$/]) {
@@ -78,8 +82,12 @@ export function resolveSnapshot(vmName: string, hint: string): SnapshotInfo {
     if ((meta.state ?? "").toLowerCase() === "poweroff") {
       score += 0.5;
     }
-    if (score > bestScore) {
+    const date = (meta.date ?? "").trim();
+    // Parallels lists snapshots oldest-first. Prefer the newest reusable baseline when fuzzy
+    // names tie, while preserving the original order when date metadata is unavailable.
+    if (score > bestScore || (score === bestScore && date > bestDate)) {
       bestScore = score;
+      bestDate = date;
       best = { id, name, state: (meta.state ?? "").trim() };
     }
   }

--- a/scripts/e2e/parallels/snapshots.ts
+++ b/scripts/e2e/parallels/snapshots.ts
@@ -85,7 +85,7 @@ export function resolveSnapshot(vmName: string, hint: string): SnapshotInfo {
     const date = (meta.date ?? "").trim();
     // Parallels lists snapshots oldest-first. Prefer the newest reusable baseline when fuzzy
     // names tie, while preserving the original order when date metadata is unavailable.
-    if (score > bestScore || (score === bestScore && date > bestDate)) {
+    if (score > bestScore || (score === bestScore && bestDate && date && date > bestDate)) {
       bestScore = score;
       bestDate = date;
       best = { id, name, state: (meta.state ?? "").trim() };

--- a/scripts/e2e/parallels/windows-smoke.ts
+++ b/scripts/e2e/parallels/windows-smoke.ts
@@ -111,7 +111,7 @@ const defaultOptions = (): WindowsOptions => ({
   npmRegistry: undefined,
   provider: "openai",
   skipLatestRefCheck: false,
-  snapshotHint: "pre-openclaw-native-e2e-2026-03-12",
+  snapshotHint: "pre-openclaw-native-e2e-",
   targetPackageSpec: "",
   upgradeFromPackedMain: false,
   vmName: "Windows 11",
@@ -127,7 +127,7 @@ function usage(): string {
 Options:
   --vm <name>                Parallels VM name. Default: "Windows 11"
   --snapshot-hint <name>     Snapshot name substring/fuzzy match.
-                             Default: "pre-openclaw-native-e2e-2026-03-12"
+                             Default: newest "pre-openclaw-native-e2e-*" snapshot
   --mode <fresh|upgrade|both>
   --provider <openai|anthropic|minimax>
   --model <provider/model>    Override the model used for the agent-turn smoke.

--- a/test/scripts/parallels-smoke-model.test.ts
+++ b/test/scripts/parallels-smoke-model.test.ts
@@ -371,6 +371,7 @@ fetch_host_metadata "https://example.test/metadata"`,
     expect(parseMacosSmokeArgs(["--host-port", "65535"]).hostPort).toBe(65535);
     expect(parseLinuxSmokeArgs(["--host-port", "65535"]).hostPort).toBe(65535);
     expect(parseWindowsSmokeArgs(["--host-port", "65535"]).hostPort).toBe(65535);
+    expect(parseWindowsSmokeArgs([]).snapshotHint).toBe("pre-openclaw-native-e2e-");
     for (const parseArgs of [parseMacosSmokeArgs, parseLinuxSmokeArgs, parseWindowsSmokeArgs]) {
       expect(parseArgs(["--npm-registry", "http://192.0.2.2:48123"]).npmRegistry).toBe(
         "http://192.0.2.2:48123",
@@ -764,6 +765,8 @@ if [[ "$1" == "snapshot-list" ]]; then
 {
   "{older}": {"name": "fresh", "state": "running"},
   "{wanted}": {"name": "fresh-poweroff-2026-04-01", "state": "poweroff"},
+  "{old-e2e}": {"name": "pre-openclaw-native-e2e-2026-03-12", "state": "poweroff", "date": "2026-03-12 22:32:24"},
+  "{new-e2e}": {"name": "pre-openclaw-native-e2e-2026-07-26", "state": "poweroff", "date": "2026-07-26 11:52:02"},
   "{other}": {"name": "unrelated", "state": "poweroff"}
 }
 JSON
@@ -780,6 +783,8 @@ if (isPrlctl) {
     console.log(JSON.stringify({
       "{older}": { name: "fresh", state: "running" },
       "{wanted}": { name: "fresh-poweroff-2026-04-01", state: "poweroff" },
+      "{old-e2e}": { name: "pre-openclaw-native-e2e-2026-03-12", state: "poweroff", date: "2026-03-12 22:32:24" },
+      "{new-e2e}": { name: "pre-openclaw-native-e2e-2026-07-26", state: "poweroff", date: "2026-07-26 11:52:02" },
       "{other}": { name: "unrelated", state: "poweroff" },
     }));
     process.exit(0);
@@ -792,11 +797,17 @@ if (isPrlctl) {
     try {
       const output = withEnv(fakePrlctlEnv(tempDir), () => {
         const snapshot = resolveSnapshot("vm", "fresh");
-        return `${shellQuote("it's ok")}\n${[snapshot.id, snapshot.state, snapshot.name].join("\t")}`;
+        const latestE2e = resolveSnapshot("vm", "pre-openclaw-native-e2e-");
+        return [
+          shellQuote("it's ok"),
+          [snapshot.id, snapshot.state, snapshot.name].join("\t"),
+          [latestE2e.id, latestE2e.state, latestE2e.name].join("\t"),
+        ].join("\n");
       });
 
       expect(output.split("\n")[0]).toBe("'it'\"'\"'s ok'");
       expect(output).toContain("{wanted}\tpoweroff\tfresh-poweroff-2026-04-01");
+      expect(output).toContain("{new-e2e}\tpoweroff\tpre-openclaw-native-e2e-2026-07-26");
     } finally {
       rmSync(tempDir, { force: true, recursive: true });
     }

--- a/test/scripts/parallels-smoke-model.test.ts
+++ b/test/scripts/parallels-smoke-model.test.ts
@@ -767,6 +767,8 @@ if [[ "$1" == "snapshot-list" ]]; then
   "{wanted}": {"name": "fresh-poweroff-2026-04-01", "state": "poweroff"},
   "{old-e2e}": {"name": "pre-openclaw-native-e2e-2026-03-12", "state": "poweroff", "date": "2026-03-12 22:32:24"},
   "{new-e2e}": {"name": "pre-openclaw-native-e2e-2026-07-26", "state": "poweroff", "date": "2026-07-26 11:52:02"},
+  "{undated-first}": {"name": "undated-family-1", "state": "poweroff"},
+  "{dated-later}": {"name": "undated-family-2", "state": "poweroff", "date": "2026-07-26 11:52:02"},
   "{other}": {"name": "unrelated", "state": "poweroff"}
 }
 JSON
@@ -785,6 +787,8 @@ if (isPrlctl) {
       "{wanted}": { name: "fresh-poweroff-2026-04-01", state: "poweroff" },
       "{old-e2e}": { name: "pre-openclaw-native-e2e-2026-03-12", state: "poweroff", date: "2026-03-12 22:32:24" },
       "{new-e2e}": { name: "pre-openclaw-native-e2e-2026-07-26", state: "poweroff", date: "2026-07-26 11:52:02" },
+      "{undated-first}": { name: "undated-family-1", state: "poweroff" },
+      "{dated-later}": { name: "undated-family-2", state: "poweroff", date: "2026-07-26 11:52:02" },
       "{other}": { name: "unrelated", state: "poweroff" },
     }));
     process.exit(0);
@@ -798,16 +802,19 @@ if (isPrlctl) {
       const output = withEnv(fakePrlctlEnv(tempDir), () => {
         const snapshot = resolveSnapshot("vm", "fresh");
         const latestE2e = resolveSnapshot("vm", "pre-openclaw-native-e2e-");
+        const missingDate = resolveSnapshot("vm", "undated-family-");
         return [
           shellQuote("it's ok"),
           [snapshot.id, snapshot.state, snapshot.name].join("\t"),
           [latestE2e.id, latestE2e.state, latestE2e.name].join("\t"),
+          [missingDate.id, missingDate.state, missingDate.name].join("\t"),
         ].join("\n");
       });
 
       expect(output.split("\n")[0]).toBe("'it'\"'\"'s ok'");
       expect(output).toContain("{wanted}\tpoweroff\tfresh-poweroff-2026-04-01");
       expect(output).toContain("{new-e2e}\tpoweroff\tpre-openclaw-native-e2e-2026-07-26");
+      expect(output).toContain("{undated-first}\tpoweroff\tundated-family-1");
     } finally {
       rmSync(tempDir, { force: true, recursive: true });
     }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Windows Parallels smoke tests always restored the March 2026 E2E snapshot, even after the baseline preparer created a newer verified snapshot. The stale baseline is below the current Node 24.15+ runtime floor and blocks release-candidate validation.

## Why This Change Was Made

Use the stable `pre-openclaw-native-e2e-` snapshot family as the Windows default and make the shared fuzzy resolver prefer the newest Parallels date when equally relevant snapshots tie. Exact snapshot hints still win by score, power-off snapshots keep their existing preference, and snapshots without dates retain their original ordering.

## User Impact

Release and E2E operators automatically use the newest verified reusable Windows baseline instead of silently falling back to a stale dated snapshot. There is no OpenClaw product behavior change.

## Evidence

- Release-candidate reproduction: with both March and July E2E snapshots present, the Windows lane resolved `pre-openclaw-native-e2e-2026-03-12-poweroff` and began the stale baseline.
- Current inventory includes the newer verified power-off snapshot `pre-openclaw-native-e2e-2026-07-26` with Git 2.55, Node 24.18, npm 11.16, and WSL 2.
- `node scripts/run-vitest.mjs test/scripts/parallels-smoke-model.test.ts` — 87 tests passed, including equal-score newest-date selection and the Windows default hint.
- The resolver regression also covers mixed metadata: an equally scored later dated snapshot does not replace the first match when either candidate lacks a date.
- `pnpm format ...` and `git diff --check` passed.
- Final autoreview after the mixed-metadata fix: clean, no accepted/actionable findings.
