### PR TITLE
fix(ui): preserve settings across concurrent Gateway writes

### DIFF
--- a/ui/src/app/app-host.ts
+++ b/ui/src/app/app-host.ts
@@ -54,6 +54,7 @@ import { i18n, isSupportedLocale, t } from "../i18n/index.ts";
 import { normalizeAgentLabel } from "../lib/agents/display.ts";
 import type { BoardFace } from "../lib/board/settings.ts";
 import { copyToClipboard } from "../lib/clipboard.ts";
+import { hasCurrentConfigSnapshot } from "../lib/config/index.ts";
 import { isGatewayMethodAdvertised } from "../lib/gateway-methods.ts";
 import { createIdleImport } from "../lib/idle-import.ts";
 import { isWorkboardEnabledInConfigSnapshot } from "../lib/plugin-activation.ts";
@@ -523,6 +524,7 @@ class OpenClawShell extends OpenClawLightDomElement {
   private sessionKeyClient: GatewayBrowserClient | null = null;
   private runtimeConfigClient: GatewayBrowserClient | null = null;
   private runtimeConfigSource: ApplicationContext["runtimeConfig"] | null = null;
+  private runtimeConfigConnectionEpoch: number | null = null;
   private sidebarWorkboardSnapshot = EMPTY_SIDEBAR_WORKBOARD_SNAPSHOT;
   private sidebarWorkboardRuntime: SidebarWorkboardRuntime | null = null;
   private sidebarWorkboardHost: ApplicationContext["workboard"] | null = null;
@@ -655,18 +657,21 @@ class OpenClawShell extends OpenClawLightDomElement {
       )
       .watch(
         () => this.context?.runtimeConfig,
-        (runtimeConfig, notify) =>
-          runtimeConfig.subscribe(() => {
-            this.reconcileServerUiPrefs(runtimeConfig);
-            this.syncSidebarWorkboard();
-            notify();
-          }),
+        (runtimeConfig, notify) => runtimeConfig.subscribe(notify),
         (runtimeConfig) => {
-          const snapshot = this.context?.gateway.snapshot;
+          const context = this.context;
+          if (context?.runtimeConfig !== runtimeConfig) {
+            return;
+          }
+          const snapshot = context.gateway.snapshot;
           if (snapshot) {
             this.ensureRuntimeConfig(snapshot, runtimeConfig);
           }
-          this.reconcileServerUiPrefs(runtimeConfig);
+          this.reconcileServerUiPrefs(
+            runtimeConfig,
+            runtimeConfig.state.configSnapshot,
+            runtimeConfig.connectionEpoch,
+          );
           this.syncSidebarWorkboard();
         },
       );
@@ -677,15 +682,26 @@ class OpenClawShell extends OpenClawLightDomElement {
    * apply server-side deltas to the browser mirror whenever a config snapshot
    * lands (connect, settings pages, reloads).
    */
-  private reconcileServerUiPrefs(runtimeConfig: ApplicationContext["runtimeConfig"]) {
-    const snapshot = runtimeConfig.state.configSnapshot;
+  private reconcileServerUiPrefs(
+    runtimeConfig: ApplicationContext["runtimeConfig"],
+    snapshot = runtimeConfig.state.configSnapshot,
+    connectionEpoch = runtimeConfig.connectionEpoch,
+  ) {
     const context = this.context;
-    if (!snapshot?.config || !context) {
+    if (
+      !snapshot?.config ||
+      !context ||
+      (context.runtimeConfig &&
+        (context.runtimeConfig !== runtimeConfig || !hasCurrentConfigSnapshot(runtimeConfig))) ||
+      runtimeConfig.connectionEpoch !== connectionEpoch ||
+      runtimeConfig.state.configSnapshot !== snapshot
+    ) {
       return;
     }
     applyServerUiPrefs(snapshot.config, {
       scope: context.gateway.connection.gatewayUrl,
       snapshotHash: snapshot.hash ?? undefined,
+      runtimeConfig,
       onApplied: (patch) => {
         if (patch.sidebarEntries !== undefined) {
           context.navigation.update({ sidebarEntries: patch.sidebarEntries });
@@ -730,8 +746,8 @@ class OpenClawShell extends OpenClawLightDomElement {
       }
       const prefs = changedServerUiPrefs(previous, next);
       const snapshot = this.context?.gateway.snapshot;
-      if (prefs && snapshot?.phase === "connected" && snapshot.client) {
-        pushServerUiPrefs(snapshot.client, prefs);
+      if (prefs && snapshot?.phase === "connected" && snapshot.client && this.context) {
+        pushServerUiPrefs(this.context.runtimeConfig, prefs);
       }
     });
   }
@@ -784,6 +800,7 @@ class OpenClawShell extends OpenClawLightDomElement {
     this.sessionKeyClient = null;
     this.runtimeConfigClient = null;
     this.runtimeConfigSource = null;
+    this.runtimeConfigConnectionEpoch = null;
     this.disposeSidebarWorkboard();
     if (this.agentRosterRefreshTimer !== null) {
       globalThis.clearTimeout(this.agentRosterRefreshTimer);
@@ -1524,16 +1541,19 @@ class OpenClawShell extends OpenClawLightDomElement {
     // load eagerly instead of waiting for a page that happens to fetch it.
     if (snapshot.phase !== "connected" || !snapshot.client || !runtimeConfig) {
       this.runtimeConfigClient = null;
+      this.runtimeConfigConnectionEpoch = null;
       return;
     }
     if (
       this.runtimeConfigClient === snapshot.client &&
-      this.runtimeConfigSource === runtimeConfig
+      this.runtimeConfigSource === runtimeConfig &&
+      this.runtimeConfigConnectionEpoch === runtimeConfig.connectionEpoch
     ) {
       return;
     }
     this.runtimeConfigClient = snapshot.client;
     this.runtimeConfigSource = runtimeConfig;
+    this.runtimeConfigConnectionEpoch = runtimeConfig.connectionEpoch;
     void runtimeConfig.ensureLoaded();
   }
 

--- a/ui/src/app/server-prefs.test.ts
+++ b/ui/src/app/server-prefs.test.ts
@@ -1,6 +1,12 @@
 /* @vitest-environment jsdom */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { GatewayBrowserClient } from "../api/gateway.ts";
+import "./app-host.ts";
+import {
+  createRuntimeConfigCapability,
+  type RuntimeConfigCapability,
+} from "../lib/config/index.ts";
 import { createStorageMock } from "../test-helpers/storage.ts";
 import {
   applyServerUiPrefs,
@@ -21,6 +27,79 @@ afterEach(() => {
 
 function configWithPrefs(prefs: Record<string, unknown>) {
   return { ui: { prefs } };
+}
+
+function createPrefsGateway(request: GatewayBrowserClient["request"]) {
+  const client = { request } as GatewayBrowserClient;
+  let snapshot: {
+    client: GatewayBrowserClient;
+    phase: "connected" | "reconnecting";
+    sessionKey: string;
+  } = { client, phase: "connected", sessionKey: "main" };
+  const listeners = new Set<(next: typeof snapshot) => void>();
+  const runtimeConfig = createRuntimeConfigCapability({
+    get snapshot() {
+      return snapshot;
+    },
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+  });
+  return {
+    runtimeConfig,
+    publish(connected: boolean) {
+      snapshot = {
+        client,
+        phase: connected ? "connected" : "reconnecting",
+        sessionKey: "main",
+      };
+      for (const listener of listeners) {
+        listener(snapshot);
+      }
+    },
+  };
+}
+
+function createPrefsRuntime(request: GatewayBrowserClient["request"]) {
+  return createPrefsGateway(request).runtimeConfig;
+}
+
+function observePrefsSnapshots(
+  runtimeConfig: RuntimeConfigCapability,
+  scope: string,
+  onApplied: Parameters<typeof applyServerUiPrefs>[1]["onApplied"],
+  observedHashes?: string[],
+) {
+  return runtimeConfig.subscribe((state) => {
+    const snapshot = state.configSnapshot;
+    if (!snapshot) {
+      return;
+    }
+    if (snapshot.hash) {
+      observedHashes?.push(snapshot.hash);
+    }
+    applyServerUiPrefs(snapshot.sourceConfig ?? snapshot.config, {
+      scope,
+      snapshotHash: snapshot.hash ?? undefined,
+      runtimeConfig,
+      onApplied,
+    });
+  });
+}
+
+function settlePrefsQueue(): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, 0);
+  });
+}
+
+function createPrefsSignal() {
+  let release!: () => void;
+  const promise = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  return { promise, release };
 }
 
 describe("server pref extraction", () => {
@@ -66,6 +145,8 @@ describe("server pref extraction", () => {
     expect(applyServerUiPrefs({}, { onApplied })).toBe(false);
     resetServerUiPrefsSync();
     expect(applyServerUiPrefs(null, { onApplied })).toBe(false);
+    expect(applyServerUiPrefs(configWithPrefs({ theme: "custom" }), { onApplied })).toBe(false);
+    expect(loadSettings().theme).toBe("claw");
     expect(onApplied).not.toHaveBeenCalled();
   });
 });
@@ -137,20 +218,25 @@ describe("applyServerUiPrefs", () => {
     expect(loadSettings().themeMode).toBe("light");
     expect(onApplied).toHaveBeenLastCalledWith({ themeMode: "light" });
   });
-
-  it("ignores a server custom theme until this browser imported one", () => {
-    const onApplied = vi.fn();
-    expect(applyServerUiPrefs(configWithPrefs({ theme: "custom" }), { onApplied })).toBe(false);
-    expect(loadSettings().theme).toBe("claw");
-  });
 });
 
 describe("changedServerUiPrefs", () => {
-  it("returns only the synced keys that changed", () => {
+  it("returns only changed shareable preferences", () => {
     const previous = loadSettings();
     const next = { ...previous, themeMode: "dark" as const, navCollapsed: !previous.navCollapsed };
     expect(changedServerUiPrefs(previous, next)).toEqual({ themeMode: "dark" });
     expect(changedServerUiPrefs(previous, { ...previous })).toBeNull();
+    expect(
+      changedServerUiPrefs(previous, {
+        ...previous,
+        textScale: 125,
+        sidebarLiveActivity: false,
+        chatMessageMaxWidth: "82%",
+      }),
+    ).toBeNull();
+    expect(changedServerUiPrefs(previous, { ...previous, showAdvancedSettings: true })).toEqual({
+      showAdvancedSettings: true,
+    });
   });
 
   it("syncs canonical sidebar entries without treating equal arrays as changes", () => {
@@ -165,26 +251,6 @@ describe("changedServerUiPrefs", () => {
         { ...previous, sidebarEntries: [...sidebarEntries] },
       ),
     ).toBeNull();
-  });
-
-  it("does not sync browser-local presentation preferences", () => {
-    const previous = loadSettings();
-    expect(
-      changedServerUiPrefs(previous, {
-        ...previous,
-        textScale: 125,
-        sidebarLiveActivity: false,
-        chatMessageMaxWidth: "82%",
-      }),
-    ).toBeNull();
-  });
-
-  it("syncs the advanced settings visibility preference", () => {
-    const previous = loadSettings();
-    expect(previous.showAdvancedSettings).toBe(false);
-    expect(changedServerUiPrefs(previous, { ...previous, showAdvancedSettings: true })).toEqual({
-      showAdvancedSettings: true,
-    });
   });
 
   it("syncs chat behavior prefs and pushes clearable resets as null", () => {
@@ -218,171 +284,785 @@ describe("clearable pref removal from the server", () => {
 });
 
 describe("pushServerUiPrefs", () => {
-  it("patches config and marks the replaced hash so stale snapshots cannot revert", async () => {
-    const request = vi.fn(async (method: string) => {
-      if (method === "config.get") {
-        return { hash: "hash-1" };
-      }
-      return {};
-    });
-    const client = { request } as unknown as Parameters<typeof pushServerUiPrefs>[0];
-
-    pushServerUiPrefs(client, { themeMode: "dark" });
-    await vi.waitFor(() => {
-      expect(request).toHaveBeenCalledWith("config.patch", {
-        baseHash: "hash-1",
-        raw: JSON.stringify({ ui: { prefs: { themeMode: "dark" } } }),
-        note: "control-ui prefs sync",
+  it.each(
+    (["replaced", "committed"] as const).flatMap((marker) =>
+      (["new gateway runtime", "same-client reconnect"] as const).flatMap((transition) =>
+        (
+          [
+            "snapshot before push",
+            "push before first snapshot",
+            "snapshot before owner adoption",
+          ] as const
+        ).map((arrival) => ({
+          marker,
+          transition,
+          arrival,
+        })),
+      ),
+    ),
+  )(
+    "never carries a $marker hash across $transition with $arrival",
+    async ({ marker, transition, arrival }) => {
+      const sharedHash = "shared-independent-gateway-hash";
+      let owner: "previous" | "current" = "previous";
+      let previousGets = 0;
+      let currentGets = 0;
+      let currentHash = sharedHash;
+      let currentPrefs: Record<string, unknown> = {
+        sidebarEntries: ["session:agent:current:private"],
+        locale: "fr",
+        themeMode: "light",
+      };
+      const submissions: Array<{ owner: string; raw: string }> = [];
+      const previousSnapshot = createPrefsSignal();
+      const currentSnapshot = createPrefsSignal();
+      const request = vi.fn(async (method: string, params?: unknown) => {
+        const requestOwner = owner;
+        if (method === "config.get") {
+          if (requestOwner === "previous") {
+            if (++previousGets === 2) {
+              await previousSnapshot.promise;
+            }
+            const prefs = { sidebarEntries: ["session:agent:previous:private"], locale: "de" };
+            const config = configWithPrefs(prefs);
+            return {
+              hash: marker === "replaced" ? sharedHash : "previous-base",
+              config,
+              sourceConfig: structuredClone(config),
+            };
+          }
+          if (++currentGets === 1) {
+            await currentSnapshot.promise;
+          }
+          const config = configWithPrefs(currentPrefs);
+          return { hash: currentHash, config, sourceConfig: structuredClone(config) };
+        }
+        if (method !== "config.patch") {
+          return {};
+        }
+        const { raw } = params as { raw: string };
+        submissions.push({ owner: requestOwner, raw });
+        if (requestOwner === "previous") {
+          return { hash: marker === "committed" ? sharedHash : "previous-committed" };
+        }
+        currentPrefs = {
+          ...currentPrefs,
+          ...(JSON.parse(raw) as { ui: { prefs: Record<string, unknown> } }).ui.prefs,
+        };
+        currentHash = "current-committed";
+        return { hash: currentHash };
       });
-    });
+      const previous = createPrefsGateway(request as GatewayBrowserClient["request"]);
+      const scope = "ws://same-gateway-url.test";
+      const onApplied = vi.fn();
+      let unsubscribe = () => {};
+      let current = previous;
+      try {
+        await previous.runtimeConfig.ensureLoaded();
+        const previousConfigSnapshot = previous.runtimeConfig.state.configSnapshot;
+        const previousConnectionEpoch = previous.runtimeConfig.connectionEpoch;
+        applyServerUiPrefs(
+          configWithPrefs({ sidebarEntries: ["session:agent:previous:private"] }),
+          {
+            scope,
+            snapshotHash: marker === "replaced" ? sharedHash : "previous-base",
+            runtimeConfig: previous.runtimeConfig,
+            onApplied,
+          },
+        );
+        onApplied.mockClear();
+        pushServerUiPrefs(previous.runtimeConfig, { themeMode: "dark" });
+        pushServerUiPrefs(previous.runtimeConfig, {
+          sidebarEntries: ["session:agent:previous:private"],
+        });
+        await vi.waitFor(() => expect(previousGets).toBe(2));
 
-    // A snapshot still carrying the replaced hash predates the patch.
-    const onApplied = vi.fn();
-    patchSettings({ themeMode: "dark" });
-    expect(
+        if (transition === "same-client reconnect") {
+          previous.publish(false);
+        }
+        owner = "current";
+        if (transition === "new gateway runtime") {
+          current = createPrefsGateway(request as GatewayBrowserClient["request"]);
+        }
+        if (arrival !== "snapshot before owner adoption") {
+          unsubscribe = observePrefsSnapshots(current.runtimeConfig, scope, onApplied);
+        }
+        if (transition === "same-client reconnect") {
+          current.publish(true);
+        }
+        if (arrival === "push before first snapshot") {
+          pushServerUiPrefs(current.runtimeConfig, { themeMode: "system" });
+        } else {
+          void current.runtimeConfig.ensureLoaded();
+        }
+        if (arrival === "snapshot before owner adoption") {
+          currentSnapshot.release();
+          await current.runtimeConfig.ensureLoaded();
+          const authoritativeSnapshot = current.runtimeConfig.state.configSnapshot;
+          if (!authoritativeSnapshot) {
+            throw new Error("Current Gateway snapshot was not loaded");
+          }
+          applyServerUiPrefs(authoritativeSnapshot.sourceConfig ?? authoritativeSnapshot.config, {
+            scope,
+            snapshotHash: authoritativeSnapshot.hash ?? undefined,
+            runtimeConfig: current.runtimeConfig,
+            onApplied,
+          });
+          unsubscribe = observePrefsSnapshots(current.runtimeConfig, scope, onApplied);
+          pushServerUiPrefs(current.runtimeConfig, { themeMode: "system" });
+        }
+        const navigation = { update: vi.fn() };
+        const shell = document.createElement("openclaw-app-shell") as unknown as {
+          runtime: unknown;
+          reconcileServerUiPrefs: (
+            runtimeConfig: RuntimeConfigCapability,
+            snapshot?: unknown,
+            connectionEpoch?: number,
+          ) => void;
+        };
+        shell.runtime = {
+          context: {
+            runtimeConfig: current.runtimeConfig,
+            gateway: { connection: { gatewayUrl: scope } },
+            navigation,
+            theme: { refresh: vi.fn() },
+          },
+        };
+        pushServerUiPrefs(current.runtimeConfig, { locale: "fr" });
+        for (let callback = 0; callback < 10; callback += 1) {
+          shell.reconcileServerUiPrefs(
+            previous.runtimeConfig,
+            previousConfigSnapshot,
+            previousConnectionEpoch,
+          );
+        }
+        currentSnapshot.release();
+
+        await vi.waitFor(() =>
+          expect(onApplied).toHaveBeenCalledWith({
+            sidebarEntries: ["session:agent:current:private"],
+            locale: "fr",
+            themeMode: "light",
+          }),
+        );
+        expect(loadSettings().sidebarEntries).toEqual(["session:agent:current:private"]);
+        expect(loadSettings().locale).toBe("fr");
+        expect(
+          submissions
+            .filter((submission) => submission.owner === "current")
+            .some((submission) => submission.raw.includes("session:agent:previous:private")),
+        ).toBe(false);
+        expect(navigation.update).not.toHaveBeenCalledWith({
+          sidebarEntries: ["session:agent:previous:private"],
+        });
+        await vi.waitFor(() =>
+          expect(
+            submissions
+              .filter((submission) => submission.owner === "current")
+              .map((submission) => submission.raw),
+          ).toEqual(
+            expect.arrayContaining([
+              expect.stringContaining('"fr"'),
+              ...(arrival === "snapshot before owner adoption"
+                ? [expect.stringContaining('"system"')]
+                : []),
+            ]),
+          ),
+        );
+      } finally {
+        previousSnapshot.release();
+        currentSnapshot.release();
+        unsubscribe();
+        if (current !== previous) {
+          current.runtimeConfig.dispose();
+        }
+        previous.runtimeConfig.dispose();
+      }
+    },
+  );
+
+  it.each([
+    { acknowledgement: "hashed", omitAckHash: false },
+    { acknowledgement: "hashless", omitAckHash: true },
+  ])(
+    "accepts a genuinely restored predecessor hash after observing its own $acknowledgement commit",
+    async ({ acknowledgement, omitAckHash }) => {
+      let revision = 1;
+      let serverThemeMode = "light";
+      const { promise: committedSnapshot, release: releaseCommittedSnapshot } = createPrefsSignal();
+      const request = vi.fn(async (method: string, params?: unknown) => {
+        if (method === "config.get") {
+          if (revision === 2) {
+            await committedSnapshot;
+          }
+          const config = configWithPrefs({ themeMode: serverThemeMode });
+          return { hash: `hash-${revision}`, config, sourceConfig: structuredClone(config) };
+        }
+        if (method !== "config.patch") {
+          return {};
+        }
+        const submission = params as { baseHash: string; raw: string };
+        if (submission.baseHash !== `hash-${revision}`) {
+          throw new Error("config changed since last load; re-run config.get and retry");
+        }
+        serverThemeMode = (JSON.parse(submission.raw) as { ui: { prefs: { themeMode: string } } })
+          .ui.prefs.themeMode;
+        revision += 1;
+        return omitAckHash ? {} : { hash: `hash-${revision}` };
+      });
+      const runtimeConfig = createPrefsRuntime(request as GatewayBrowserClient["request"]);
+      await runtimeConfig.ensureLoaded();
+      const onApplied = vi.fn();
+      const scope = `ws://restored-${acknowledgement}-predecessor.test`;
       applyServerUiPrefs(configWithPrefs({ themeMode: "light" }), {
+        scope,
         snapshotHash: "hash-1",
         onApplied,
-      }),
-    ).toBe(false);
-    expect(onApplied).not.toHaveBeenCalled();
-    expect(loadSettings().themeMode).toBe("dark");
+      });
+      onApplied.mockClear();
+      const unsubscribe = observePrefsSnapshots(runtimeConfig, scope, onApplied);
 
-    // A post-patch snapshot (any other hash) stays authoritative.
-    expect(
-      applyServerUiPrefs(configWithPrefs({ themeMode: "system" }), {
-        snapshotHash: "hash-2",
-        onApplied,
-      }),
-    ).toBe(true);
-    expect(loadSettings().themeMode).toBe("system");
+      patchSettings({ themeMode: "dark" });
+      pushServerUiPrefs(runtimeConfig, { themeMode: "dark" });
+      await vi.waitFor(() =>
+        expect(request.mock.calls.filter(([method]) => method === "config.get")).toHaveLength(2),
+      );
+      expect(
+        applyServerUiPrefs(configWithPrefs({ themeMode: "light" }), {
+          scope,
+          snapshotHash: "hash-1",
+          onApplied,
+        }),
+      ).toBe(false);
+      releaseCommittedSnapshot();
+      await vi.waitFor(() => expect(runtimeConfig.state.configSnapshot?.hash).toBe("hash-2"));
 
-    // Once post-patch state was observed, the old hash means another writer
-    // genuinely restored that config, so it becomes authoritative again.
-    expect(
-      applyServerUiPrefs(configWithPrefs({ themeMode: "light" }), {
+      expect(loadSettings().themeMode).toBe("dark");
+      expect(onApplied).not.toHaveBeenCalledWith({ themeMode: "dark" });
+      expect(
+        applyServerUiPrefs(configWithPrefs({ themeMode: "light" }), {
+          scope,
+          snapshotHash: "hash-1",
+          onApplied,
+        }),
+      ).toBe(true);
+      expect(loadSettings().themeMode).toBe("light");
+      expect(onApplied).toHaveBeenCalledWith({ themeMode: "light" });
+
+      unsubscribe();
+      runtimeConfig.dispose();
+    },
+  );
+
+  it.each(
+    (
+      [
+        { acknowledgement: "hashed", omitAckHash: false },
+        { acknowledgement: "hashless", omitAckHash: true },
+      ] as const
+    ).flatMap((acknowledgement) =>
+      [
+        {
+          preference: "theme mode",
+          initialPrefs: { themeMode: "light" },
+          committedPrefs: { themeMode: "dark" as const },
+          restoredPrefs: { themeMode: "light" },
+          expectedPatch: { themeMode: "light" },
+        },
+        {
+          preference: "clearable removal",
+          initialPrefs: {},
+          committedPrefs: { chatFollowUpMode: "queue" as const },
+          restoredPrefs: {},
+          expectedPatch: { chatFollowUpMode: undefined },
+        },
+      ].flatMap((preference) =>
+        (
+          [
+            { restoration: "a distinct hash", restoreOriginalHash: false },
+            { restoration: "the original hash", restoreOriginalHash: true },
+          ] as const
+        ).map((restoration) => Object.assign({}, acknowledgement, preference, restoration)),
+      ),
+    ),
+  )(
+    "applies a foreign $preference restoration to $restoration before its $acknowledgement commit is observed",
+    async ({
+      acknowledgement,
+      omitAckHash,
+      initialPrefs,
+      committedPrefs,
+      restoredPrefs,
+      expectedPatch,
+      restoreOriginalHash,
+    }) => {
+      let revision = 1;
+      let getCalls = 0;
+      let persistedPrefs: Record<string, unknown> = { ...initialPrefs };
+      const request = vi.fn(async (method: string, params?: unknown) => {
+        if (method === "config.get") {
+          getCalls += 1;
+          if (getCalls === 2) {
+            revision = restoreOriginalHash ? 1 : 3;
+            persistedPrefs = { ...restoredPrefs };
+          }
+          const config = {
+            ...configWithPrefs(persistedPrefs),
+            foreignRevision: revision,
+          };
+          return { hash: `hash-${revision}`, config, sourceConfig: structuredClone(config) };
+        }
+        if (method !== "config.patch") {
+          return {};
+        }
+        const submission = params as { baseHash: string; raw: string };
+        if (submission.baseHash !== `hash-${revision}`) {
+          throw new Error("config changed since last load; re-run config.get and retry");
+        }
+        persistedPrefs = {
+          ...persistedPrefs,
+          ...(JSON.parse(submission.raw) as { ui: { prefs: Record<string, unknown> } }).ui.prefs,
+        };
+        revision = 2;
+        return omitAckHash ? {} : { hash: "hash-2" };
+      });
+      const runtimeConfig = createPrefsRuntime(request as GatewayBrowserClient["request"]);
+      await runtimeConfig.ensureLoaded();
+      const onApplied = vi.fn();
+      const scope = `ws://foreign-${acknowledgement}-${Object.keys(committedPrefs)[0]}.test`;
+      applyServerUiPrefs(configWithPrefs(initialPrefs), {
+        scope,
         snapshotHash: "hash-1",
         onApplied,
-      }),
-    ).toBe(true);
-    expect(loadSettings().themeMode).toBe("light");
-  });
+      });
+      onApplied.mockClear();
+      const unsubscribe = observePrefsSnapshots(runtimeConfig, scope, onApplied);
+
+      patchSettings(committedPrefs);
+      pushServerUiPrefs(runtimeConfig, committedPrefs);
+      await vi.waitFor(() => expect(getCalls).toBe(2));
+      expect(runtimeConfig.state.configSnapshot?.hash).toBe(
+        restoreOriginalHash ? "hash-1" : "hash-3",
+      );
+      await vi.waitFor(() => expect(onApplied).toHaveBeenCalledWith(expectedPatch));
+      expect(loadSettings()).toMatchObject(expectedPatch);
+
+      unsubscribe();
+      runtimeConfig.dispose();
+    },
+  );
 
   it("marks sidebar arrays for replacement when pinned entries are removed", async () => {
     let hash = 0;
-    const request = vi.fn(async (method: string) => {
+    let storedEntries: string[] = [];
+    const request = vi.fn(async (method: string, params?: unknown) => {
       if (method === "config.get") {
-        return { hash: `hash-${hash}` };
+        const config = configWithPrefs({ sidebarEntries: storedEntries });
+        return { hash: `hash-${hash}`, config, sourceConfig: config };
       }
+      const patch = JSON.parse((params as { raw: string }).raw) as {
+        ui: { prefs: { sidebarEntries: string[] } };
+      };
+      storedEntries = patch.ui.prefs.sidebarEntries;
       hash += 1;
-      return {};
+      return { hash: `hash-${hash}` };
     });
-    const client = { request } as unknown as Parameters<typeof pushServerUiPrefs>[0];
+    const runtimeConfig = createPrefsRuntime(request as GatewayBrowserClient["request"]);
+    await runtimeConfig.ensureLoaded();
     const sidebarEntries = ["route:usage", "session:agent:main:test"];
 
-    pushServerUiPrefs(client, { sidebarEntries });
+    pushServerUiPrefs(runtimeConfig, { sidebarEntries });
     await vi.waitFor(() => {
       expect(request).toHaveBeenCalledWith("config.patch", {
         baseHash: "hash-0",
         raw: JSON.stringify({ ui: { prefs: { sidebarEntries } } }),
         replacePaths: ["ui.prefs.sidebarEntries"],
+        sessionKey: "main",
         note: "control-ui prefs sync",
       });
+      expect(runtimeConfig.state.configSnapshot?.hash).toBe("hash-1");
     });
 
     const remainingEntries = ["route:usage"];
-    pushServerUiPrefs(client, { sidebarEntries: remainingEntries });
+    pushServerUiPrefs(runtimeConfig, { sidebarEntries: remainingEntries });
     await vi.waitFor(() => {
       expect(request).toHaveBeenCalledWith("config.patch", {
         baseHash: "hash-1",
         raw: JSON.stringify({ ui: { prefs: { sidebarEntries: remainingEntries } } }),
         replacePaths: ["ui.prefs.sidebarEntries"],
+        sessionKey: "main",
         note: "control-ui prefs sync",
       });
     });
+    runtimeConfig.dispose();
   });
 
-  it("coalesces rapid changes into serial patches instead of racing the hash", async () => {
-    let hash = 0;
-    const patched: unknown[] = [];
+  it("keeps a newer local preference when its queued follow-up write fails", async () => {
+    let revision = 1;
+    let serverThemeMode = "light";
+    let patchCalls = 0;
+    const { promise: firstPatch, release: releaseFirstPatch } = createPrefsSignal();
     const request = vi.fn(async (method: string, params?: unknown) => {
       if (method === "config.get") {
-        return { hash: `hash-${hash}` };
+        const config = configWithPrefs({ themeMode: serverThemeMode });
+        return { hash: `hash-${revision}`, config, sourceConfig: config };
       }
-      hash += 1;
-      patched.push((params as { raw: string }).raw);
-      return {};
+      if (method !== "config.patch") {
+        return {};
+      }
+      patchCalls += 1;
+      if (patchCalls > 1) {
+        throw new Error("queued preference temporarily unavailable");
+      }
+      await firstPatch;
+      const parsed = JSON.parse((params as { raw: string }).raw) as {
+        ui: { prefs: { themeMode: string } };
+      };
+      serverThemeMode = parsed.ui.prefs.themeMode;
+      revision += 1;
+      return { hash: `hash-${revision}` };
     });
-    const client = { request } as unknown as Parameters<typeof pushServerUiPrefs>[0];
+    const runtimeConfig = createPrefsRuntime(request as GatewayBrowserClient["request"]);
+    await runtimeConfig.ensureLoaded();
+    const onApplied = vi.fn();
+    const scope = "ws://queued-preference.test";
+    applyServerUiPrefs(configWithPrefs({ themeMode: serverThemeMode }), {
+      scope,
+      snapshotHash: `hash-${revision}`,
+      onApplied,
+    });
+    const unsubscribe = observePrefsSnapshots(runtimeConfig, scope, onApplied);
 
-    pushServerUiPrefs(client, { themeMode: "dark" });
-    pushServerUiPrefs(client, { locale: "de" });
-    pushServerUiPrefs(client, { themeMode: "light" });
+    patchSettings({ themeMode: "dark" });
+    pushServerUiPrefs(runtimeConfig, { themeMode: "dark" });
+    await vi.waitFor(() => expect(patchCalls).toBe(1));
+    patchSettings({ themeMode: "light" });
+    pushServerUiPrefs(runtimeConfig, { themeMode: "light" });
+    releaseFirstPatch();
+    await vi.waitFor(() => expect(patchCalls).toBe(2));
 
+    expect(serverThemeMode).toBe("dark");
+    expect(loadSettings().themeMode).toBe("light");
+    expect(onApplied).not.toHaveBeenCalledWith({ themeMode: "dark" });
+    unsubscribe();
+    runtimeConfig.dispose();
+  });
+
+  it("retains acknowledged preference protection after its authoritative reload fails", async () => {
+    let revision = 1;
+    let serverThemeMode = "light";
+    let getCalls = 0;
+    let patchCalls = 0;
+    const observedHashes: string[] = [];
+    const { promise: recoveryPatch, release: releaseRecoveryPatch } = createPrefsSignal();
+    const request = vi.fn(async (method: string, params?: unknown) => {
+      if (method === "config.get") {
+        getCalls += 1;
+        if (getCalls === 2) {
+          throw new Error("authoritative preference snapshot temporarily unavailable");
+        }
+        const config = configWithPrefs({ themeMode: serverThemeMode });
+        return { hash: `hash-${revision}`, config, sourceConfig: structuredClone(config) };
+      }
+      if (method !== "config.patch") {
+        return {};
+      }
+      patchCalls += 1;
+      const submission = params as { baseHash: string; raw: string };
+      if (submission.baseHash !== `hash-${revision}`) {
+        throw new Error("config changed since last load; re-run config.get and retry");
+      }
+      if (patchCalls === 2) {
+        await recoveryPatch;
+      }
+      serverThemeMode = (JSON.parse(submission.raw) as { ui: { prefs: { themeMode: string } } }).ui
+        .prefs.themeMode;
+      revision += 1;
+      return { hash: `hash-${revision}` };
+    });
+    const runtimeConfig = createPrefsRuntime(request as GatewayBrowserClient["request"]);
+    await runtimeConfig.ensureLoaded();
+    const onApplied = vi.fn();
+    const scope = "ws://failed-acknowledged-preference-reload.test";
+    applyServerUiPrefs(configWithPrefs({ themeMode: serverThemeMode }), {
+      scope,
+      snapshotHash: "hash-1",
+      onApplied,
+    });
+    onApplied.mockClear();
+    const unsubscribe = observePrefsSnapshots(runtimeConfig, scope, onApplied, observedHashes);
+
+    patchSettings({ themeMode: "dark" });
+    pushServerUiPrefs(runtimeConfig, { themeMode: "dark" });
+    await vi.waitFor(() => expect(getCalls).toBe(2));
+    await settlePrefsQueue();
+
+    patchSettings({ themeMode: "light" });
+    pushServerUiPrefs(runtimeConfig, { themeMode: "light" });
+    await vi.waitFor(() => expect(patchCalls).toBe(2));
+    await runtimeConfig.refresh();
+    const themeAfterRecovery = loadSettings().themeMode;
+    releaseRecoveryPatch();
+    await vi.waitFor(() => expect(runtimeConfig.state.configSnapshot?.hash).toBe("hash-3"));
+
+    expect(observedHashes).toContain("hash-2");
+    expect(serverThemeMode).toBe("light");
+    expect(themeAfterRecovery).toBe("light");
+    expect(loadSettings().themeMode).toBe("light");
+    expect(onApplied).not.toHaveBeenCalledWith({ themeMode: "dark" });
+    unsubscribe();
+    runtimeConfig.dispose();
+  });
+
+  it.each([
+    { acknowledgement: "hashed", omitAckHash: false },
+    { acknowledgement: "hashless", omitAckHash: true },
+  ])(
+    "releases a queued preference after a committed $acknowledgement reload fails",
+    async ({ acknowledgement, omitAckHash }) => {
+      let revision = 1;
+      let serverThemeMode = "light";
+      let getCalls = 0;
+      let patchCalls = 0;
+      const submittedBaseHashes: string[] = [];
+      const { promise: firstPatch, release: releaseFirstPatch } = createPrefsSignal();
+      const request = vi.fn(async (method: string, params?: unknown) => {
+        if (method === "config.get") {
+          getCalls += 1;
+          if (getCalls === 2) {
+            throw new Error("authoritative preference snapshot temporarily unavailable");
+          }
+          const config = {
+            ...configWithPrefs({ themeMode: serverThemeMode }),
+            agents: { list: [{ id: "main", default: true }, { id: "worker" }] },
+            env: { vars: { OPENCLAW_SYNTHETIC_TEST_ONLY: "synthetic-source-value" } },
+          };
+          return { hash: `hash-${revision}`, config, sourceConfig: structuredClone(config) };
+        }
+        if (method !== "config.patch") {
+          return {};
+        }
+        patchCalls += 1;
+        const submission = params as { baseHash: string; raw: string };
+        submittedBaseHashes.push(submission.baseHash);
+        if (submission.baseHash !== `hash-${revision}`) {
+          throw new Error("config changed since last load; re-run config.get and retry");
+        }
+        if (patchCalls === 1) {
+          await firstPatch;
+        }
+        serverThemeMode = (JSON.parse(submission.raw) as { ui: { prefs: { themeMode: string } } })
+          .ui.prefs.themeMode;
+        revision += 1;
+        return patchCalls === 1 && omitAckHash
+          ? { config: { agents: "__OPENCLAW_REDACTED__" } }
+          : { hash: `hash-${revision}`, config: { agents: "__OPENCLAW_REDACTED__" } };
+      });
+      const runtimeConfig = createPrefsRuntime(request as GatewayBrowserClient["request"]);
+      await runtimeConfig.ensureLoaded();
+      const onApplied = vi.fn();
+      const scope = `ws://${acknowledgement}-acknowledged-preference.test`;
+      applyServerUiPrefs(configWithPrefs({ themeMode: serverThemeMode }), {
+        scope,
+        snapshotHash: "hash-1",
+        onApplied,
+      });
+      onApplied.mockClear();
+      const unsubscribe = observePrefsSnapshots(runtimeConfig, scope, onApplied);
+
+      patchSettings({ themeMode: "dark" });
+      pushServerUiPrefs(runtimeConfig, { themeMode: "dark" });
+      await vi.waitFor(() => expect(patchCalls).toBe(1));
+      patchSettings({ themeMode: "light" });
+      pushServerUiPrefs(runtimeConfig, { themeMode: "light" });
+      releaseFirstPatch();
+
+      await vi.waitFor(() => expect(patchCalls).toBe(2));
+      await vi.waitFor(() => expect(runtimeConfig.state.configSnapshot?.hash).toBe("hash-3"));
+      expect(submittedBaseHashes).toEqual(["hash-1", "hash-2"]);
+      expect(getCalls).toBe(4);
+      expect(serverThemeMode).toBe("light");
+      expect(loadSettings().themeMode).toBe("light");
+      expect(onApplied).not.toHaveBeenCalledWith({ themeMode: "dark" });
+      expect(runtimeConfig.state.configSnapshot?.sourceConfig).toEqual({
+        ...configWithPrefs({ themeMode: "light" }),
+        agents: { list: [{ id: "main", default: true }, { id: "worker" }] },
+        env: { vars: { OPENCLAW_SYNTHETIC_TEST_ONLY: "synthetic-source-value" } },
+      });
+      unsubscribe();
+      runtimeConfig.dispose();
+    },
+  );
+
+  it("protects intent queued after the acknowledgement and before its snapshot publishes", async () => {
+    let revision = 1;
+    let themeMode = "light";
+    let getCalls = 0;
+    let patchCalls = 0;
+    const { promise: committedSnapshot, release: releaseCommittedSnapshot } = createPrefsSignal();
+    const request = vi.fn(async (method: string, params?: unknown) => {
+      if (method === "config.get") {
+        getCalls += 1;
+        if (getCalls === 2) {
+          await committedSnapshot;
+        }
+        const config = configWithPrefs({ themeMode });
+        return { hash: `hash-${revision}`, config, sourceConfig: config };
+      }
+      if (method !== "config.patch") {
+        return {};
+      }
+      patchCalls += 1;
+      if (patchCalls > 1) {
+        throw new Error("queued preference temporarily unavailable");
+      }
+      const patch = JSON.parse((params as { raw: string }).raw) as {
+        ui: { prefs: { themeMode: string } };
+      };
+      themeMode = patch.ui.prefs.themeMode;
+      revision += 1;
+      return { hash: `hash-${revision}` };
+    });
+    const runtimeConfig = createPrefsRuntime(request as GatewayBrowserClient["request"]);
+    await runtimeConfig.ensureLoaded();
+    const onApplied = vi.fn();
+    const scope = "ws://ack-before-reload.test";
+    applyServerUiPrefs(configWithPrefs({ themeMode }), {
+      scope,
+      snapshotHash: "hash-1",
+      onApplied,
+    });
+    onApplied.mockClear();
+    const unsubscribe = observePrefsSnapshots(runtimeConfig, scope, onApplied);
+
+    patchSettings({ themeMode: "dark" });
+    pushServerUiPrefs(runtimeConfig, { themeMode: "dark" });
     await vi.waitFor(() => {
-      expect(request.mock.calls.filter(([method]) => method === "config.patch").length).toBe(2);
+      expect(patchCalls).toBe(1);
+      expect(getCalls).toBe(2);
     });
+
+    patchSettings({ themeMode: "light" });
+    pushServerUiPrefs(runtimeConfig, { themeMode: "light" });
+    releaseCommittedSnapshot();
+    await vi.waitFor(() => expect(patchCalls).toBe(2));
+
+    expect(themeMode).toBe("dark");
+    expect(loadSettings().themeMode).toBe("light");
+    expect(onApplied).not.toHaveBeenCalledWith({ themeMode: "dark" });
+    unsubscribe();
+    runtimeConfig.dispose();
+  });
+
+  it("waits for the connected runtime's initial authoritative config snapshot", async () => {
+    const { promise: initialSnapshot, release: releaseInitialSnapshot } = createPrefsSignal();
+    let revision = 1;
+    let themeMode = "light";
+    let getCalls = 0;
+    let patchCalls = 0;
+    const request = vi.fn(async (method: string, params?: unknown) => {
+      if (method === "config.get") {
+        getCalls += 1;
+        if (getCalls === 1) {
+          await initialSnapshot;
+        }
+        const config = configWithPrefs({ themeMode });
+        return { hash: `hash-${revision}`, config, sourceConfig: config };
+      }
+      if (method !== "config.patch") {
+        return {};
+      }
+      patchCalls += 1;
+      const submission = params as { raw: string; baseHash: string };
+      if (submission.baseHash !== `hash-${revision}`) {
+        throw new Error("config changed since last load; re-run config.get and retry");
+      }
+      themeMode = (JSON.parse(submission.raw) as { ui: { prefs: { themeMode: string } } }).ui.prefs
+        .themeMode;
+      revision += 1;
+      return { hash: `hash-${revision}` };
+    });
+    const runtimeConfig = createPrefsRuntime(request as GatewayBrowserClient["request"]);
+    const initialLoad = runtimeConfig.ensureLoaded();
+    await vi.waitFor(() => expect(getCalls).toBe(1));
+    expect(runtimeConfig.state.configSnapshot).toBeNull();
+
+    pushServerUiPrefs(runtimeConfig, { themeMode: "dark" });
+    expect(patchCalls).toBe(0);
+    releaseInitialSnapshot();
+    await initialLoad;
+    await vi.waitFor(() => expect(patchCalls).toBe(1));
+
+    expect(themeMode).toBe("dark");
+    expect(runtimeConfig.state.configSnapshot?.hash).toBe("hash-2");
+    runtimeConfig.dispose();
+  });
+
+  it("coalesces serial preference patches across a foreign CAS conflict", async () => {
+    let hash = 1;
+    const patched: unknown[] = [];
+    const baseHashes: string[] = [];
+    let storedPrefs: Record<string, unknown> = { themeMode: "light", locale: "en" };
+    let agents = [{ id: "main" }, { id: "worker" }];
+    const env = { vars: { OPENCLAW_SYNTHETIC_TEST_ONLY: "synthetic-source-value" } };
+    const request = vi.fn(async (method: string, params?: unknown) => {
+      if (method === "config.get") {
+        const config = { ...configWithPrefs(storedPrefs), agents: { list: agents }, env };
+        return { hash: `hash-${hash}`, config, sourceConfig: structuredClone(config) };
+      }
+      if (method !== "config.patch") {
+        return {};
+      }
+      const submission = params as { raw: string; baseHash: string };
+      baseHashes.push(submission.baseHash);
+      if (baseHashes.length === 1) {
+        storedPrefs = { ...storedPrefs, locale: "fr" };
+        agents = [...agents, { id: "foreign" }];
+        hash += 1;
+      }
+      if (submission.baseHash !== `hash-${hash}`) {
+        throw new Error("config changed since last load; re-run config.get and retry");
+      }
+      const parsed = JSON.parse(submission.raw) as {
+        ui: { prefs: Record<string, unknown> };
+      };
+      storedPrefs = { ...storedPrefs, ...parsed.ui.prefs };
+      hash += 1;
+      patched.push(submission.raw);
+      return { hash: `hash-${hash}` };
+    });
+    const runtimeConfig = createPrefsRuntime(request as GatewayBrowserClient["request"]);
+    await runtimeConfig.ensureLoaded();
+    const onApplied = vi.fn();
+    const scope = "ws://coalesced-foreign-preference-owner.test";
+    applyServerUiPrefs(configWithPrefs(storedPrefs), {
+      scope,
+      snapshotHash: "hash-1",
+      onApplied,
+    });
+    const unsubscribe = observePrefsSnapshots(runtimeConfig, scope, onApplied);
+
+    patchSettings({ themeMode: "dark" });
+    pushServerUiPrefs(runtimeConfig, { themeMode: "dark" });
+    patchSettings({ locale: "de", themeMode: "light" });
+    pushServerUiPrefs(runtimeConfig, { locale: "de" });
+    pushServerUiPrefs(runtimeConfig, { themeMode: "light" });
+
+    await vi.waitFor(() => expect(patched).toHaveLength(2));
     // The first patch carries the first delta; the rest coalesce into one.
     expect(patched[0]).toBe(JSON.stringify({ ui: { prefs: { themeMode: "dark" } } }));
     expect(patched[1]).toBe(
       JSON.stringify({ ui: { prefs: { locale: "de", themeMode: "light" } } }),
     );
-  });
-
-  it("drops a stale gateway's queue instead of writing it to the next gateway", async () => {
-    let resolveFirstGet: ((value: { hash: string }) => void) | undefined;
-    const requestA = vi.fn(
-      (method: string) =>
-        new Promise((resolve) => {
-          if (method === "config.get") {
-            resolveFirstGet = resolve as (value: { hash: string }) => void;
-            return;
-          }
-          resolve({});
-        }),
-    );
-    const requestB = vi.fn(async (method: string) => {
-      if (method === "config.get") {
-        return { hash: "b-1" };
-      }
-      return {};
+    expect(baseHashes).toEqual(["hash-1", "hash-2", "hash-3"]);
+    expect(loadSettings()).toMatchObject({ themeMode: "light", locale: "de" });
+    expect(runtimeConfig.state.configSnapshot?.sourceConfig).toEqual({
+      ...configWithPrefs(storedPrefs),
+      agents: { list: agents },
+      env,
     });
-    const clientA = { request: requestA } as unknown as Parameters<typeof pushServerUiPrefs>[0];
-    const clientB = { request: requestB } as unknown as Parameters<typeof pushServerUiPrefs>[0];
-
-    pushServerUiPrefs(clientA, { themeMode: "dark" });
-    pushServerUiPrefs(clientB, { locale: "de" });
-    resolveFirstGet?.({ hash: "a-1" });
-
-    await vi.waitFor(() => {
-      expect(requestB.mock.calls.filter(([method]) => method === "config.patch").length).toBe(1);
-    });
-    // Gateway A's drain saw the client switch and never patched.
-    expect(requestA.mock.calls.filter(([method]) => method === "config.patch").length).toBe(0);
-    expect(requestB).toHaveBeenCalledWith("config.patch", {
-      baseHash: "b-1",
-      raw: JSON.stringify({ ui: { prefs: { locale: "de" } } }),
-      note: "control-ui prefs sync",
-    });
-  });
-
-  it("retries once on a hash conflict and gives up silently otherwise", async () => {
-    let patchCalls = 0;
-    const request = vi.fn(async (method: string) => {
-      if (method === "config.get") {
-        return { hash: `hash-${patchCalls}` };
-      }
-      patchCalls += 1;
-      if (patchCalls === 1) {
-        throw new Error("config baseHash mismatch");
-      }
-      return {};
-    });
-    const client = { request } as unknown as Parameters<typeof pushServerUiPrefs>[0];
-
-    pushServerUiPrefs(client, { locale: "de" });
-    await vi.waitFor(() => {
-      expect(patchCalls).toBe(2);
-    });
+    expect(agents).toContainEqual({ id: "foreign" });
+    unsubscribe();
+    runtimeConfig.dispose();
   });
 });

--- a/ui/src/app/server-prefs.ts
+++ b/ui/src/app/server-prefs.ts
@@ -6,9 +6,9 @@
 // local mirror; an unchanged server value never reverts local edits, so a
 // failed push degrades to device-local behavior instead of flip-flopping.
 import { asNullableRecord as asRecord } from "@openclaw/normalization-core/record-coerce";
-import type { GatewayBrowserClient } from "../api/gateway.ts";
 import { normalizeSidebarEntries } from "../app-navigation.ts";
 import { isSupportedLocale } from "../i18n/index.ts";
+import { hasCurrentConfigSnapshot, type RuntimeConfigCapability } from "../lib/config/index.ts";
 import {
   loadSettings,
   normalizeChatFollowUpModeOverride,
@@ -188,11 +188,10 @@ const LAST_SEEN_STORAGE_KEY = "openclaw.control.serverPrefs.v1";
 
 let lastSeenScope = "";
 let lastSeenServerPrefsKey: string | null = null;
-// Config hashes our patches replaced. A snapshot still carrying one of these
-// hashes was fetched before the patch landed; applying it would revert the
-// pushed value as if the server had changed it back. CAS guarantees the
-// replaced config had exactly the base hash, so this check is precise.
-const staleConfigHashes = new Set<string>();
+// Only revisions proven to be either the exact replaced CAS base or the
+// gateway-acknowledged, superseded local commit may be suppressed. External
+// snapshots must continue to reconcile normally.
+const staleConfigHashes = new Map<string, "replaced" | "committed">();
 const STALE_CONFIG_HASH_LIMIT = 8;
 let applyingServerPrefs = false;
 
@@ -225,9 +224,13 @@ export function resetServerUiPrefsSync() {
   lastSeenServerPrefsKey = null;
   staleConfigHashes.clear();
   applyingServerPrefs = false;
-  queuedClient = null;
+  queuedRuntimeConfig = null;
+  queuedConnectionEpoch = null;
   queuedPrefs = null;
+  queuedPrefsRequireCurrentSnapshot = false;
+  activePrefsCommit = null;
   pushDraining = false;
+  prefsSyncGeneration += 1;
 }
 
 export function applyServerUiPrefs(
@@ -235,20 +238,102 @@ export function applyServerUiPrefs(
   hooks: {
     scope?: string;
     snapshotHash?: string;
+    runtimeConfig?: RuntimeConfigCapability;
     onApplied: (patch: Partial<UiSettings>) => void;
   },
 ): boolean {
+  if (hooks.runtimeConfig) {
+    const runtimeConfig = hooks.runtimeConfig;
+    adoptPrefsOwner(runtimeConfig);
+    const runtimeSnapshot = runtimeConfig.state.configSnapshot;
+    if (
+      queuedPrefsRequireCurrentSnapshot &&
+      runtimeSnapshot?.hash &&
+      hooks.snapshotHash === runtimeSnapshot.hash &&
+      hasCurrentConfigSnapshot(runtimeConfig) &&
+      isCurrentPrefsOwner(runtimeConfig, prefsSyncGeneration, runtimeConfig.connectionEpoch) &&
+      (configObject === runtimeSnapshot.config || configObject === runtimeSnapshot.sourceConfig)
+    ) {
+      queuedPrefsRequireCurrentSnapshot = false;
+    }
+  }
+  const scope = hooks.scope ?? "";
+  const prefs = extractServerUiPrefs(configObject);
   if (hooks.snapshotHash) {
-    if (staleConfigHashes.has(hooks.snapshotHash)) {
+    const runtimeConfig = hooks.runtimeConfig;
+    const runtimeSnapshot = runtimeConfig?.state.configSnapshot;
+    const pendingCommit = activePrefsCommit;
+    const isAuthoritativeCommitSnapshot = Boolean(
+      pendingCommit &&
+      runtimeConfig &&
+      runtimeSnapshot &&
+      runtimeConfig === pendingCommit.runtimeConfig &&
+      isCurrentPrefsOwner(runtimeConfig, pendingCommit.generation, pendingCommit.connectionEpoch) &&
+      runtimeSnapshot !== pendingCommit.snapshot &&
+      !runtimeConfig.state.configLoading &&
+      hooks.snapshotHash === runtimeSnapshot.hash &&
+      (configObject === runtimeSnapshot.config || configObject === runtimeSnapshot.sourceConfig),
+    );
+    const staleKind = staleConfigHashes.get(hooks.snapshotHash);
+    if (staleKind === "replaced" && !isAuthoritativeCommitSnapshot) {
       return false;
+    }
+    if (staleKind === "committed") {
+      const commit = activePrefsCommit;
+      if (
+        !commit ||
+        (isCurrentPrefsOwner(commit.runtimeConfig, commit.generation, commit.connectionEpoch) &&
+          commit.hash === hooks.snapshotHash &&
+          Object.keys(commit.prefs).every((key) => {
+            const prefKey = key as SyncedPrefKey;
+            const committedValue = commit.prefs[prefKey];
+            return committedValue === null
+              ? !(prefKey in prefs)
+              : prefValuesEqual(prefs[prefKey], committedValue);
+          }))
+      ) {
+        // Observe our real committed server values without applying them over
+        // newer device-local intent. Later foreign revisions must delta from
+        // this acknowledged snapshot, not replay its superseded preferences.
+        storeLastSeenKey(scope, JSON.stringify(prefs));
+        if (commit?.hash === hooks.snapshotHash) {
+          activePrefsCommit = null;
+          // Content hashes can recur when another writer restores the old
+          // bytes. The observed commit is the only safe point to retire its
+          // replaced predecessor before that genuine restoration arrives.
+          staleConfigHashes.clear();
+        } else {
+          staleConfigHashes.delete(hooks.snapshotHash);
+        }
+        return false;
+      }
+    }
+    const commit = activePrefsCommit;
+    if (
+      commit &&
+      isCurrentPrefsOwner(commit.runtimeConfig, commit.generation, commit.connectionEpoch) &&
+      (hooks.snapshotHash !== commit.baseHash || isAuthoritativeCommitSnapshot)
+    ) {
+      // A newer snapshot can arrive before the physically acknowledged
+      // commit. Seed every owned field from that real commit first so a
+      // foreign restoration or removal remains a genuine server delta.
+      const baseline = parseLastSeenPrefs(loadLastSeenKey(scope));
+      for (const prefKey of Object.keys(commit.prefs) as SyncedPrefKey[]) {
+        const committedValue = commit.prefs[prefKey];
+        if (committedValue === null) {
+          delete baseline[prefKey];
+        } else {
+          (baseline as Record<string, unknown>)[prefKey] = committedValue;
+        }
+      }
+      storeLastSeenKey(scope, JSON.stringify(baseline));
+      activePrefsCommit = null;
     }
     // Post-patch state observed: retire the stale marks. Hashes identify
     // content, not age — if the pre-patch hash reappears later, another
     // writer genuinely restored that config and it is authoritative again.
     staleConfigHashes.clear();
   }
-  const scope = hooks.scope ?? "";
-  const prefs = extractServerUiPrefs(configObject);
   const key = JSON.stringify(prefs);
   const lastSeenRaw = loadLastSeenKey(scope);
   if (key === lastSeenRaw) {
@@ -257,12 +342,7 @@ export function applyServerUiPrefs(
   // Apply per field: only keys whose *server* value changed since last seen.
   // Reapplying unchanged fields would revert unpushable local edits on other
   // keys whenever any one server field moves.
-  let lastSeen: ServerUiPrefs;
-  try {
-    lastSeen = lastSeenRaw ? (JSON.parse(lastSeenRaw) as ServerUiPrefs) : {};
-  } catch {
-    lastSeen = {};
-  }
+  const lastSeen = parseLastSeenPrefs(lastSeenRaw);
   const changed: ServerUiPrefs = {};
   for (const prefKey of Object.keys(prefs) as Array<keyof ServerUiPrefs>) {
     if (lastSeenRaw === null || !prefValuesEqual(prefs[prefKey], lastSeen[prefKey])) {
@@ -296,51 +376,134 @@ export function isApplyingServerUiPrefs(): boolean {
   return applyingServerPrefs;
 }
 
-// Pending deltas coalesce into one object and drain serially, so rapid
-// changes cannot race each other's CAS hash and silently drop an update. The
-// queue is bound to one gateway client; switching gateways drops undelivered
-// deltas for the old one (they stay device-local, per the sync contract).
-let queuedClient: GatewayBrowserClient | null = null;
-let queuedPrefs: ServerUiPrefs | null = null;
-let pushDraining = false;
+function parseLastSeenPrefs(value: string | null): ServerUiPrefs {
+  try {
+    return value ? (JSON.parse(value) as ServerUiPrefs) : {};
+  } catch {
+    return {};
+  }
+}
 
-async function drainPrefsQueue(client: GatewayBrowserClient): Promise<void> {
+// Coalesce UI intent only; the runtime capability exclusively owns physical
+// writes, CAS refresh, updater suspension, and connection-epoch fencing.
+let queuedRuntimeConfig: RuntimeConfigCapability | null = null;
+let queuedConnectionEpoch: number | null = null;
+let queuedPrefs: ServerUiPrefs | null = null;
+let queuedPrefsRequireCurrentSnapshot = false;
+let activePrefsCommit: {
+  runtimeConfig: RuntimeConfigCapability;
+  generation: number;
+  connectionEpoch: number;
+  snapshot: RuntimeConfigCapability["state"]["configSnapshot"];
+  baseHash: string;
+  hash: string | null;
+  prefs: ServerUiPrefs;
+} | null = null;
+let pushDraining = false;
+let prefsSyncGeneration = 0;
+
+function rememberStaleConfigHash(hash: string, kind: "replaced" | "committed") {
+  if (kind === "committed" || !staleConfigHashes.has(hash)) {
+    staleConfigHashes.set(hash, kind);
+  }
+  if (staleConfigHashes.size > STALE_CONFIG_HASH_LIMIT) {
+    const oldest = staleConfigHashes.keys().next().value;
+    if (oldest !== undefined) {
+      staleConfigHashes.delete(oldest);
+    }
+  }
+}
+
+function adoptPrefsOwner(runtimeConfig: RuntimeConfigCapability) {
+  const connectionEpoch = runtimeConfig.connectionEpoch;
+  if (queuedRuntimeConfig === runtimeConfig && queuedConnectionEpoch === connectionEpoch) {
+    return;
+  }
+  const previousConnectionSnapshot = queuedRuntimeConfig === runtimeConfig;
+  // Snapshot hashes identify bytes, not a gateway or physical connection.
+  // Retire the old owner's marks before the first new snapshot can collide.
+  staleConfigHashes.clear();
+  queuedRuntimeConfig = runtimeConfig;
+  queuedConnectionEpoch = connectionEpoch;
+  queuedPrefs = null;
+  queuedPrefsRequireCurrentSnapshot = previousConnectionSnapshot;
+  activePrefsCommit = null;
+  pushDraining = false;
+  prefsSyncGeneration += 1;
+}
+
+function isCurrentPrefsOwner(
+  runtimeConfig: RuntimeConfigCapability,
+  generation: number,
+  connectionEpoch: number,
+): boolean {
+  return (
+    queuedRuntimeConfig === runtimeConfig &&
+    queuedConnectionEpoch === connectionEpoch &&
+    prefsSyncGeneration === generation &&
+    runtimeConfig.connectionEpoch === connectionEpoch
+  );
+}
+
+async function drainPrefsQueue(
+  runtimeConfig: RuntimeConfigCapability,
+  generation: number,
+  connectionEpoch: number,
+): Promise<void> {
   while (queuedPrefs) {
-    // The awaits below can outlive a gateway switch; a superseded drain stops
-    // instead of writing one gateway's prefs to another.
-    if (queuedClient !== client) {
+    if (!isCurrentPrefsOwner(runtimeConfig, generation, connectionEpoch)) {
       return;
+    }
+    if (queuedPrefsRequireCurrentSnapshot || !runtimeConfig.state.configSnapshot?.hash) {
+      const previousSnapshot = runtimeConfig.state.configSnapshot;
+      const requireCurrentSnapshot = queuedPrefsRequireCurrentSnapshot;
+      // Reconnects retain their old snapshot. The config owner must first
+      // publish a snapshot from this physical epoch before it supplies a CAS base.
+      await runtimeConfig.ensureLoaded();
+      if (
+        !isCurrentPrefsOwner(runtimeConfig, generation, connectionEpoch) ||
+        !runtimeConfig.state.configSnapshot?.hash ||
+        (requireCurrentSnapshot && runtimeConfig.state.configSnapshot === previousSnapshot)
+      ) {
+        return;
+      }
+      queuedPrefsRequireCurrentSnapshot = false;
     }
     const prefs = queuedPrefs;
     queuedPrefs = null;
-    for (let attempt = 0; attempt < 2; attempt += 1) {
-      const snapshot = (await client.request("config.get", {})) as { hash?: string } | null;
-      const baseHash = snapshot?.hash;
-      if (!baseHash || queuedClient !== client) {
-        return;
-      }
-      try {
-        const replacePaths = prefs.sidebarEntries !== undefined ? ["ui.prefs.sidebarEntries"] : [];
-        await client.request("config.patch", {
+    let physicallyCommitted = false;
+    const didCommit = await runtimeConfig.patch({
+      raw: { ui: { prefs } },
+      ...(prefs.sidebarEntries !== undefined ? { replacePaths: ["ui.prefs.sidebarEntries"] } : {}),
+      note: "control-ui prefs sync",
+      onCommitted: ({ hash, baseHash }) => {
+        if (!isCurrentPrefsOwner(runtimeConfig, generation, connectionEpoch)) {
+          return;
+        }
+        physicallyCommitted = true;
+        rememberStaleConfigHash(baseHash, "replaced");
+        // The ack precedes authoritative config.get publication. Keep its
+        // physical hash and preference baseline until an owned snapshot is
+        // observed, even when the first authoritative reload fails.
+        activePrefsCommit = {
+          runtimeConfig,
+          generation,
+          connectionEpoch,
+          snapshot: runtimeConfig.state.configSnapshot,
           baseHash,
-          raw: JSON.stringify({ ui: { prefs } }),
-          ...(replacePaths.length > 0 ? { replacePaths } : {}),
-          note: "control-ui prefs sync",
-        });
-        staleConfigHashes.add(baseHash);
-        if (staleConfigHashes.size > STALE_CONFIG_HASH_LIMIT) {
-          const oldest = staleConfigHashes.values().next().value;
-          if (oldest !== undefined) {
-            staleConfigHashes.delete(oldest);
-          }
+          hash,
+          prefs,
+        };
+        if (hash) {
+          rememberStaleConfigHash(hash, "committed");
         }
-        break;
-      } catch (error) {
-        if (attempt === 0 && String(error).toLowerCase().includes("hash")) {
-          continue;
-        }
-        return;
-      }
+      },
+    });
+    if (!isCurrentPrefsOwner(runtimeConfig, generation, connectionEpoch)) {
+      return;
+    }
+    if (!didCommit && !physicallyCommitted) {
+      return;
     }
   }
 }
@@ -350,23 +513,30 @@ async function drainPrefsQueue(client: GatewayBrowserClient): Promise<void> {
  * Silent on failure by design: clients without operator.admin (or offline)
  * keep the change device-local.
  */
-export function pushServerUiPrefs(client: GatewayBrowserClient, prefs: ServerUiPrefs): void {
-  if (queuedClient !== client) {
-    // New gateway: abandon the old queue (its drain loop sees the client
-    // change and stops) instead of writing one gateway's prefs to another.
-    queuedClient = client;
-    queuedPrefs = null;
-    pushDraining = false;
+export function pushServerUiPrefs(
+  runtimeConfig: RuntimeConfigCapability,
+  prefs: ServerUiPrefs,
+): void {
+  adoptPrefsOwner(runtimeConfig);
+  const connectionEpoch = runtimeConfig.connectionEpoch;
+  if (
+    activePrefsCommit?.runtimeConfig === runtimeConfig &&
+    activePrefsCommit.generation === prefsSyncGeneration &&
+    activePrefsCommit.connectionEpoch === connectionEpoch &&
+    activePrefsCommit.hash
+  ) {
+    rememberStaleConfigHash(activePrefsCommit.hash, "committed");
   }
   queuedPrefs = { ...queuedPrefs, ...prefs };
   if (pushDraining) {
     return;
   }
   pushDraining = true;
-  void drainPrefsQueue(client)
+  const generation = prefsSyncGeneration;
+  void drainPrefsQueue(runtimeConfig, generation, connectionEpoch)
     .catch(() => undefined)
     .finally(() => {
-      if (queuedClient === client) {
+      if (isCurrentPrefsOwner(runtimeConfig, generation, connectionEpoch)) {
         pushDraining = false;
       }
     });

--- a/ui/src/lib/config/index.test.ts
+++ b/ui/src/lib/config/index.test.ts
@@ -4,7 +4,9 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { ConfigSchemaResponse, ConfigSnapshot } from "../../api/types.ts";
 import type { ApplicationGatewayPhase } from "../../app/gateway.ts";
+import { setSelfLearningEnabled } from "../../pages/skill-workshop/self-learning.ts";
 import { createRuntimeConfigCapability, findAgentConfigEntryIndex } from "./index.ts";
+import { buildAddMcpServerPatch, patchMcpServers } from "./mcp-servers.ts";
 
 const CONFIG_FORM_AUTO_SAVE_DEBOUNCE_MS = 800;
 
@@ -128,6 +130,34 @@ function createDeferredSetServerMock(options: { legacyAck?: boolean } = {}) {
 }
 
 describe("createRuntimeConfigCapability", () => {
+  it("reloads the authoritative snapshot when the same gateway client reconnects", async () => {
+    let snapshotCount = 0;
+    const request = vi.fn(async (method: string) => {
+      if (method !== "config.get") {
+        return {};
+      }
+      snapshotCount += 1;
+      return { config: { revision: snapshotCount }, hash: `hash-${snapshotCount}` };
+    });
+    const client = { request } as unknown as GatewayBrowserClient;
+    const { gateway, publish } = createGatewayHarness(client);
+    const runtimeConfig = createRuntimeConfigCapability(gateway);
+
+    expect(runtimeConfig.connectionEpoch).toBe(0);
+    await runtimeConfig.ensureLoaded();
+    expect(runtimeConfig.state.configSnapshot?.hash).toBe("hash-1");
+    publish(false);
+    expect(runtimeConfig.connectionEpoch).toBe(1);
+    publish(true);
+    expect(runtimeConfig.connectionEpoch).toBe(2);
+    expect(runtimeConfig.state.configSnapshot?.hash).toBe("hash-1");
+    await runtimeConfig.ensureLoaded();
+    expect(runtimeConfig.state.configSnapshot?.hash).toBe("hash-2");
+    expect(snapshotCount).toBe(2);
+
+    runtimeConfig.dispose();
+  });
+
   it("preserves a dirty draft and its original base hash across refreshes", async () => {
     let getCount = 0;
     const request = vi.fn(async (method: string) => {
@@ -1509,6 +1539,736 @@ describe("config form auto-save", () => {
     runtimeConfig.dispose();
   });
 
+  it("serializes ten overlapping preference patches against authoritative config hashes", async () => {
+    vi.useFakeTimers();
+    let revision = 1;
+    let persistedConfig = {
+      agents: {
+        list: [
+          { id: "main", default: true },
+          { id: "worker", workspace: "/srv/worker" },
+        ],
+      },
+      ui: { prefs: { themeMode: "light" } },
+      env: { vars: { OPENCLAW_SYNTHETIC_TEST_ONLY: "synthetic-source-value" } },
+    };
+    const attemptedBaseHashes: string[] = [];
+    const request = vi.fn(async (method: string, params?: unknown) => {
+      if (method === "config.get") {
+        const config = structuredClone(persistedConfig);
+        return {
+          config,
+          sourceConfig: structuredClone(config),
+          raw: JSON.stringify(config),
+          hash: `hash-${revision}`,
+          configRevisionHash: `hash-${revision}`,
+          appliedConfigHash: "hash-1",
+          valid: true,
+          issues: [],
+        };
+      }
+      if (method !== "config.patch") {
+        return {};
+      }
+      const submission = params as { baseHash: string; raw: string };
+      attemptedBaseHashes.push(submission.baseHash);
+      if (submission.baseHash !== `hash-${revision}`) {
+        throw new Error("config changed since last load; re-run config.get and retry");
+      }
+      const patch = JSON.parse(submission.raw) as {
+        ui?: { prefs?: { themeMode?: string } };
+      };
+      const themeMode = patch.ui?.prefs?.themeMode;
+      if (themeMode !== "dark" && themeMode !== "light") {
+        throw new Error("missing supported test preference patch");
+      }
+      persistedConfig = {
+        ...persistedConfig,
+        ui: {
+          ...persistedConfig.ui,
+          prefs: { ...persistedConfig.ui.prefs, themeMode },
+        },
+      };
+      revision += 1;
+      return {
+        hash: `hash-${revision}`,
+        config: {
+          ...structuredClone(persistedConfig),
+          env: { vars: { OPENCLAW_SYNTHETIC_TEST_ONLY: "__OPENCLAW_REDACTED__" } },
+        },
+      };
+    });
+    const { runtimeConfig } = createHarness(request as GatewayBrowserClient["request"]);
+    await runtimeConfig.ensureLoaded();
+
+    const writes = Array.from({ length: 10 }, (_, index) =>
+      runtimeConfig.patch({
+        raw: { ui: { prefs: { themeMode: index % 2 === 0 ? "dark" : "light" } } },
+        note: "control-ui prefs sync",
+      }),
+    );
+    await expect(Promise.all(writes)).resolves.toEqual(Array.from({ length: 10 }, () => true));
+    expect(attemptedBaseHashes).toEqual(
+      Array.from({ length: 10 }, (_, index) => `hash-${index + 1}`),
+    );
+    expect(persistedConfig.agents.list).toEqual([
+      { id: "main", default: true },
+      { id: "worker", workspace: "/srv/worker" },
+    ]);
+    expect(persistedConfig.ui.prefs.themeMode).toBe("light");
+    expect(persistedConfig.env.vars.OPENCLAW_SYNTHETIC_TEST_ONLY).toBe("synthetic-source-value");
+    expect(runtimeConfig.state.configSnapshot?.sourceConfig).toEqual(persistedConfig);
+    runtimeConfig.dispose();
+  });
+
+  it("rebases a conflicted patch once without overwriting a foreign config owner", async () => {
+    let revision = 1;
+    let persistedConfig = {
+      agents: { list: [{ id: "main", default: true }, { id: "worker" }] },
+      ui: { prefs: { themeMode: "light", locale: "en" } },
+      env: { vars: { OPENCLAW_SYNTHETIC_TEST_ONLY: "synthetic-source-value" } },
+    };
+    const baseHashes: string[] = [];
+    const commits: Array<{ hash: string | null; baseHash: string }> = [];
+    const request = vi.fn(async (method: string, params?: unknown) => {
+      if (method === "config.get") {
+        const config = structuredClone(persistedConfig);
+        return {
+          config,
+          sourceConfig: structuredClone(config),
+          raw: JSON.stringify(config),
+          hash: `hash-${revision}`,
+          valid: true,
+          issues: [],
+        };
+      }
+      if (method !== "config.patch") {
+        return {};
+      }
+      const submission = params as { baseHash: string; raw: string };
+      baseHashes.push(submission.baseHash);
+      if (baseHashes.length === 1) {
+        persistedConfig = {
+          ...persistedConfig,
+          agents: { list: [...persistedConfig.agents.list, { id: "foreign" }] },
+          ui: { prefs: { ...persistedConfig.ui.prefs, locale: "fr" } },
+        };
+        revision += 1;
+      }
+      if (submission.baseHash !== `hash-${revision}`) {
+        throw new Error("config changed since last load; re-run config.get and retry");
+      }
+      const fragment = JSON.parse(submission.raw) as { ui: { prefs: { themeMode: string } } };
+      persistedConfig = {
+        ...persistedConfig,
+        ui: { prefs: { ...persistedConfig.ui.prefs, ...fragment.ui.prefs } },
+      };
+      revision += 1;
+      return { hash: `hash-${revision}`, config: { env: "__OPENCLAW_REDACTED__" } };
+    });
+    const { runtimeConfig } = createHarness(request as GatewayBrowserClient["request"]);
+    await runtimeConfig.ensureLoaded();
+
+    await expect(
+      runtimeConfig.patch({
+        raw: { ui: { prefs: { themeMode: "dark" } } },
+        note: "recover a foreign configuration CAS conflict",
+        onCommitted: (commit) => commits.push(commit),
+      }),
+    ).resolves.toBe(true);
+
+    expect(baseHashes).toEqual(["hash-1", "hash-2"]);
+    expect(commits).toEqual([{ hash: "hash-3", baseHash: "hash-2" }]);
+    expect(persistedConfig.ui.prefs).toEqual({ themeMode: "dark", locale: "fr" });
+    expect(persistedConfig.agents.list).toContainEqual({ id: "foreign" });
+    expect(runtimeConfig.state.configSnapshot?.sourceConfig).toEqual(persistedConfig);
+    expect(persistedConfig.env.vars.OPENCLAW_SYNTHETIC_TEST_ONLY).toBe("synthetic-source-value");
+    runtimeConfig.dispose();
+  });
+
+  it("rebuilds an MCP snapshot mutation against the foreign owner after a CAS conflict", async () => {
+    let revision = 1;
+    let persistedConfig = {
+      agents: { list: [{ id: "main", default: true }, { id: "worker" }] },
+      mcp: { servers: {} as Record<string, { url: string }> },
+      env: { vars: { OPENCLAW_SYNTHETIC_TEST_ONLY: "synthetic-source-value" } },
+    };
+    const baseHashes: string[] = [];
+    const observedServerNames: string[][] = [];
+    const request = vi.fn(async (method: string, params?: unknown) => {
+      if (method === "config.get") {
+        const config = structuredClone(persistedConfig);
+        return {
+          config,
+          sourceConfig: structuredClone(config),
+          raw: JSON.stringify(config),
+          hash: `hash-${revision}`,
+          valid: true,
+          issues: [],
+        };
+      }
+      if (method !== "config.patch") {
+        return {};
+      }
+      const submission = params as { baseHash: string };
+      baseHashes.push(submission.baseHash);
+      persistedConfig = {
+        ...persistedConfig,
+        mcp: { servers: { alpha: { url: "https://foreign-owner.example/alpha" } } },
+      };
+      revision += 1;
+      throw new Error("config changed since last load; re-run config.get and retry");
+    });
+    const { runtimeConfig } = createHarness(request as GatewayBrowserClient["request"]);
+    await runtimeConfig.ensureLoaded();
+
+    const result = await patchMcpServers(runtimeConfig, {
+      buildPatch: (servers) => {
+        observedServerNames.push(Object.keys(servers));
+        return buildAddMcpServerPatch(servers, "alpha", {
+          url: "https://local-owner.example/alpha",
+        });
+      },
+      note: "preserve the concurrently installed MCP owner",
+    });
+
+    expect(result).toMatchObject({ ok: false });
+    if (!result.ok) {
+      expect(result.error).toContain("alpha");
+    }
+    expect(observedServerNames).toEqual([[], ["alpha"]]);
+    expect(baseHashes).toEqual(["hash-1"]);
+    expect(runtimeConfig.state.configSnapshot?.sourceConfig).toEqual(persistedConfig);
+    expect(persistedConfig.mcp.servers.alpha?.url).toBe("https://foreign-owner.example/alpha");
+    expect(persistedConfig.env.vars.OPENCLAW_SYNTHETIC_TEST_ONLY).toBe("synthetic-source-value");
+    runtimeConfig.dispose();
+  });
+
+  it.each([
+    {
+      failure: "repeated CAS conflict",
+      error: "config changed since last load; re-run config.get and retry",
+      attempts: 2,
+    },
+    { failure: "permission failure", error: "config.patch forbidden", attempts: 1 },
+  ])("bounds $failure retries to actual physical CAS attempts", async ({ error, attempts }) => {
+    let revision = 1;
+    const baseHashes: string[] = [];
+    const request = vi.fn(async (method: string, params?: unknown) => {
+      if (method === "config.get") {
+        const config = { agents: { list: [{ id: "main", default: true }] } };
+        return {
+          config,
+          sourceConfig: structuredClone(config),
+          raw: JSON.stringify(config),
+          hash: `hash-${revision}`,
+          valid: true,
+          issues: [],
+        };
+      }
+      if (method === "config.patch") {
+        baseHashes.push((params as { baseHash: string }).baseHash);
+        revision += 1;
+        throw new Error(error);
+      }
+      return {};
+    });
+    const onCommitted = vi.fn();
+    const { runtimeConfig } = createHarness(request as GatewayBrowserClient["request"]);
+    await runtimeConfig.ensureLoaded();
+
+    await expect(
+      runtimeConfig.patch({ raw: { count: 1 }, note: "bounded conflict recovery", onCommitted }),
+    ).resolves.toBe(false);
+
+    expect(baseHashes).toEqual(Array.from({ length: attempts }, (_, index) => `hash-${index + 1}`));
+    expect(runtimeConfig.state.lastError).toMatch(
+      attempts === 2 ? /configuration changed again/i : /config\.patch forbidden/i,
+    );
+    expect(onCommitted).not.toHaveBeenCalled();
+    runtimeConfig.dispose();
+  });
+
+  it("never stacks a self-learning fallback onto the canonical one-conflict retry", async () => {
+    let revision = 1;
+    const baseHashes: string[] = [];
+    const request = vi.fn(async (method: string, params?: unknown) => {
+      if (method === "config.get") {
+        const config = {
+          agents: { list: [{ id: "main", default: true }] },
+          skills: { workshop: { autonomous: { enabled: false } } },
+        };
+        return {
+          config,
+          sourceConfig: structuredClone(config),
+          raw: JSON.stringify(config),
+          hash: `hash-${revision}`,
+          valid: true,
+          issues: [],
+        };
+      }
+      if (method === "config.patch") {
+        baseHashes.push((params as { baseHash: string }).baseHash);
+        revision += 1;
+        throw new Error("config changed since last load; re-run config.get and retry");
+      }
+      return {};
+    });
+    const { runtimeConfig } = createHarness(request as GatewayBrowserClient["request"]);
+    await runtimeConfig.ensureLoaded();
+
+    await expect(setSelfLearningEnabled(runtimeConfig, true)).resolves.toMatch(
+      /configuration changed again/i,
+    );
+
+    expect(baseHashes).toEqual(["hash-1", "hash-2"]);
+    runtimeConfig.dispose();
+  });
+
+  it("never retries a conflicted patch after its authoritative refresh fails", async () => {
+    let getCalls = 0;
+    let patchCalls = 0;
+    const request = vi.fn(async (method: string) => {
+      if (method === "config.get") {
+        getCalls += 1;
+        if (getCalls > 1) {
+          throw new Error("authoritative config unavailable");
+        }
+        return {
+          config: { count: 1 },
+          sourceConfig: { count: 1 },
+          raw: '{"count":1}',
+          hash: "hash-1",
+          valid: true,
+          issues: [],
+        };
+      }
+      if (method === "config.patch") {
+        patchCalls += 1;
+        throw new Error("config changed since last load; re-run config.get and retry");
+      }
+      return {};
+    });
+    const { runtimeConfig } = createHarness(request as GatewayBrowserClient["request"]);
+    await runtimeConfig.ensureLoaded();
+
+    await expect(
+      runtimeConfig.patch({ raw: { count: 2 }, note: "fail-closed refresh" }),
+    ).resolves.toBe(false);
+
+    expect(patchCalls).toBe(1);
+    expect(getCalls).toBe(2);
+    expect(runtimeConfig.state.lastError).toContain("authoritative config unavailable");
+    runtimeConfig.dispose();
+  });
+
+  it("never replays a CAS conflict into a reconnected gateway epoch", async () => {
+    let getCalls = 0;
+    let patchCalls = 0;
+    const recoverySnapshot = deferred<Record<string, unknown>>();
+    const request = vi.fn(async (method: string) => {
+      if (method === "config.get") {
+        getCalls += 1;
+        if (getCalls === 2) {
+          return recoverySnapshot.promise;
+        }
+        return {
+          config: { count: 1 },
+          sourceConfig: { count: 1 },
+          raw: '{"count":1}',
+          hash: `hash-${getCalls}`,
+          valid: true,
+          issues: [],
+        };
+      }
+      if (method === "config.patch") {
+        patchCalls += 1;
+        throw new Error("config changed since last load; re-run config.get and retry");
+      }
+      return {};
+    });
+    const { runtimeConfig, publish } = createHarness(request as GatewayBrowserClient["request"]);
+    await runtimeConfig.ensureLoaded();
+    const patch = runtimeConfig.patch({
+      raw: { count: 2 },
+      note: "reject stale gateway ownership",
+    });
+    await vi.waitFor(() => expect(getCalls).toBe(2));
+    publish(false);
+    publish(true);
+    recoverySnapshot.resolve({
+      config: { count: 9 },
+      sourceConfig: { count: 9 },
+      raw: '{"count":9}',
+      hash: "hash-2",
+      valid: true,
+      issues: [],
+    });
+
+    await expect(patch).resolves.toBe(false);
+    expect(patchCalls).toBe(1);
+    runtimeConfig.dispose();
+  });
+
+  it("never retries a CAS conflict when updates are suspended during its refresh", async () => {
+    let getCalls = 0;
+    let patchCalls = 0;
+    const recoverySnapshot = deferred<Record<string, unknown>>();
+    const request = vi.fn(async (method: string) => {
+      if (method === "config.get") {
+        getCalls += 1;
+        if (getCalls === 2) {
+          return recoverySnapshot.promise;
+        }
+        return {
+          config: { count: 1 },
+          sourceConfig: { count: 1 },
+          raw: '{"count":1}',
+          hash: "hash-1",
+          valid: true,
+          issues: [],
+        };
+      }
+      if (method === "config.patch") {
+        patchCalls += 1;
+        throw new Error("config changed since last load; re-run config.get and retry");
+      }
+      return {};
+    });
+    const { runtimeConfig } = createHarness(request as GatewayBrowserClient["request"]);
+    await runtimeConfig.ensureLoaded();
+    const patch = runtimeConfig.patch({ raw: { count: 2 }, note: "honor update suspension" });
+    await vi.waitFor(() => expect(getCalls).toBe(2));
+    runtimeConfig.setWritesSuspended(true);
+    recoverySnapshot.resolve({
+      config: { count: 9 },
+      sourceConfig: { count: 9 },
+      raw: '{"count":9}',
+      hash: "hash-2",
+      valid: true,
+      issues: [],
+    });
+
+    await expect(patch).resolves.toBe(false);
+    expect(patchCalls).toBe(1);
+    runtimeConfig.dispose();
+  });
+
+  it("reports a physically committed config patch when its acknowledgement omits the hash", async () => {
+    let revision = 1;
+    let count = 1;
+    const committed: Array<{ hash: string | null; baseHash: string }> = [];
+    const request = vi.fn(async (method: string, params?: unknown) => {
+      if (method === "config.get") {
+        const config = {
+          count,
+          agents: { list: [{ id: "main", default: true }, { id: "worker" }] },
+        };
+        return {
+          config,
+          sourceConfig: structuredClone(config),
+          raw: JSON.stringify(config),
+          hash: `hash-${revision}`,
+          valid: true,
+          issues: [],
+        };
+      }
+      if (method !== "config.patch") {
+        return {};
+      }
+      const submission = params as { raw: string; baseHash: string };
+      if (submission.baseHash !== `hash-${revision}`) {
+        throw new Error("config changed since last load; re-run config.get and retry");
+      }
+      count = (JSON.parse(submission.raw) as { count: number }).count;
+      revision += 1;
+      return { config: { agents: "__OPENCLAW_REDACTED__" } };
+    });
+    const { runtimeConfig } = createHarness(request as GatewayBrowserClient["request"]);
+    await runtimeConfig.ensureLoaded();
+
+    await expect(
+      runtimeConfig.patch({
+        raw: { count: 2 },
+        note: "physically committed hashless patch",
+        onCommitted: (commit) => committed.push(commit),
+      }),
+    ).resolves.toBe(true);
+
+    expect(committed).toEqual([{ hash: null, baseHash: "hash-1" }]);
+    expect(runtimeConfig.state.configSnapshot?.sourceConfig).toEqual({
+      count: 2,
+      agents: { list: [{ id: "main", default: true }, { id: "worker" }] },
+    });
+    runtimeConfig.dispose();
+  });
+
+  it("does not report a no-op config patch as a physical commit", async () => {
+    let getCalls = 0;
+    const onCommitted = vi.fn();
+    const request = vi.fn(async (method: string) => {
+      if (method === "config.get") {
+        getCalls += 1;
+        return { config: { count: 1 }, hash: "hash-1", valid: true, issues: [] };
+      }
+      return { noop: true, config: { count: 1 } };
+    });
+    const { runtimeConfig } = createHarness(request as GatewayBrowserClient["request"]);
+    await runtimeConfig.ensureLoaded();
+
+    await expect(
+      runtimeConfig.patch({ raw: { count: 1 }, note: "unchanged patch", onCommitted }),
+    ).resolves.toBe(true);
+
+    expect(onCommitted).not.toHaveBeenCalled();
+    expect(getCalls).toBe(1);
+    expect(runtimeConfig.state.configNeedsApply).toBe(false);
+    expect(runtimeConfig.state.configSnapshot?.hash).toBe("hash-1");
+    runtimeConfig.dispose();
+  });
+
+  it("reports the physical CAS base after an earlier queued config write", async () => {
+    let revision = 1;
+    let count = 1;
+    const firstPatch = deferred<void>();
+    const submittedBaseHashes: string[] = [];
+    const committed: Array<{ hash: string | null; baseHash: string }> = [];
+    const request = vi.fn(async (method: string, params?: unknown) => {
+      if (method === "config.get") {
+        const config = { count };
+        return {
+          config,
+          sourceConfig: structuredClone(config),
+          raw: JSON.stringify(config),
+          hash: `hash-${revision}`,
+          valid: true,
+          issues: [],
+        };
+      }
+      if (method !== "config.patch") {
+        return {};
+      }
+      const submission = params as { baseHash: string; raw: string };
+      submittedBaseHashes.push(submission.baseHash);
+      if (submission.baseHash !== `hash-${revision}`) {
+        throw new Error("config changed since last load; re-run config.get and retry");
+      }
+      if (submittedBaseHashes.length === 1) {
+        await firstPatch.promise;
+      }
+      count = (JSON.parse(submission.raw) as { count: number }).count;
+      revision += 1;
+      return { hash: `hash-${revision}` };
+    });
+    const { runtimeConfig } = createHarness(request as GatewayBrowserClient["request"]);
+    await runtimeConfig.ensureLoaded();
+
+    const firstWrite = runtimeConfig.patch({ raw: { count: 2 }, note: "first queued write" });
+    const secondWrite = runtimeConfig.patch({
+      raw: { count: 3 },
+      note: "second queued write",
+      onCommitted: (commit) => committed.push(commit),
+    });
+    expect(submittedBaseHashes).toEqual(["hash-1"]);
+    firstPatch.resolve();
+    await expect(Promise.all([firstWrite, secondWrite])).resolves.toEqual([true, true]);
+    expect(submittedBaseHashes).toEqual(["hash-1", "hash-2"]);
+    expect(committed).toEqual([{ hash: "hash-3", baseHash: "hash-2" }]);
+    runtimeConfig.dispose();
+  });
+
+  it("refreshes a committed revision before releasing later queued CAS writes", async () => {
+    let revision = 1;
+    let count = 1;
+    let getCalls = 0;
+    const submittedBaseHashes: string[] = [];
+    const request = vi.fn(async (method: string, params?: unknown) => {
+      if (method === "config.get") {
+        getCalls += 1;
+        if (getCalls === 2) {
+          throw new Error("authoritative snapshot temporarily unavailable");
+        }
+        const config = {
+          count,
+          agents: { list: [{ id: "main", default: true }, { id: "worker" }] },
+        };
+        return {
+          config,
+          sourceConfig: structuredClone(config),
+          raw: JSON.stringify(config),
+          hash: `hash-${revision}`,
+          valid: true,
+          issues: [],
+        };
+      }
+      if (method !== "config.patch") {
+        return {};
+      }
+      const submission = params as { baseHash: string; raw: string };
+      submittedBaseHashes.push(submission.baseHash);
+      if (submission.baseHash !== `hash-${revision}`) {
+        throw new Error("config changed since last load; re-run config.get and retry");
+      }
+      count = (JSON.parse(submission.raw) as { count: number }).count;
+      revision += 1;
+      return { hash: `hash-${revision}`, config: { count, agents: "__OPENCLAW_REDACTED__" } };
+    });
+    const { runtimeConfig } = createHarness(request as GatewayBrowserClient["request"]);
+    await runtimeConfig.ensureLoaded();
+
+    const firstWrite = runtimeConfig.patch({ raw: { count: 2 }, note: "first physical write" });
+    const secondWrite = runtimeConfig.patch({ raw: { count: 3 }, note: "second physical write" });
+
+    await expect(Promise.all([firstWrite, secondWrite])).resolves.toEqual([true, true]);
+    expect(submittedBaseHashes).toEqual(["hash-1", "hash-2"]);
+    expect(getCalls).toBe(4);
+    expect(runtimeConfig.state.configSnapshot?.sourceConfig).toEqual({
+      count: 3,
+      agents: { list: [{ id: "main", default: true }, { id: "worker" }] },
+    });
+    runtimeConfig.dispose();
+  });
+
+  it("builds a queued MCP mutation only after refreshing its committed predecessor", async () => {
+    let revision = 1;
+    let getCalls = 0;
+    const firstPatch = deferred<void>();
+    const submittedBaseHashes: string[] = [];
+    const observedServerNames: string[][] = [];
+    let persistedConfig = {
+      agents: { list: [{ id: "main", default: true }, { id: "worker" }] },
+      mcp: { servers: {} as Record<string, { url: string }> },
+      env: { vars: { OPENCLAW_SYNTHETIC_TEST_ONLY: "synthetic-source-value" } },
+    };
+    const request = vi.fn(async (method: string, params?: unknown) => {
+      if (method === "config.get") {
+        getCalls += 1;
+        if (getCalls === 2) {
+          throw new Error("authoritative MCP snapshot temporarily unavailable");
+        }
+        const config = structuredClone(persistedConfig);
+        return {
+          config,
+          sourceConfig: structuredClone(config),
+          raw: JSON.stringify(config),
+          hash: `hash-${revision}`,
+          valid: true,
+          issues: [],
+        };
+      }
+      if (method !== "config.patch") {
+        return {};
+      }
+      const submission = params as { baseHash: string; raw: string };
+      submittedBaseHashes.push(submission.baseHash);
+      if (submission.baseHash !== `hash-${revision}`) {
+        throw new Error("config changed since last load; re-run config.get and retry");
+      }
+      if (submittedBaseHashes.length === 1) {
+        await firstPatch.promise;
+      }
+      const fragment = JSON.parse(submission.raw) as {
+        mcp: { servers: Record<string, { url: string }> };
+      };
+      persistedConfig = {
+        ...persistedConfig,
+        mcp: {
+          servers: { ...persistedConfig.mcp.servers, ...fragment.mcp.servers },
+        },
+      };
+      revision += 1;
+      return {
+        hash: `hash-${revision}`,
+        config: { mcp: "__OPENCLAW_REDACTED__" },
+      };
+    });
+    const { runtimeConfig } = createHarness(request as GatewayBrowserClient["request"]);
+    await runtimeConfig.ensureLoaded();
+
+    const firstWrite = runtimeConfig.patch({
+      raw: { mcp: { servers: { alpha: { url: "https://owner.example/alpha" } } } },
+      note: "install the authoritative MCP owner",
+    });
+    expect(submittedBaseHashes).toEqual(["hash-1"]);
+    const duplicateAdd = patchMcpServers(runtimeConfig, {
+      buildPatch: (servers) => {
+        observedServerNames.push(Object.keys(servers));
+        return buildAddMcpServerPatch(servers, "alpha", {
+          url: "https://other-owner.example/alpha",
+        });
+      },
+      note: "reject an already installed MCP owner",
+    });
+    await Promise.resolve();
+    firstPatch.resolve();
+
+    const [firstResult, duplicateResult] = await Promise.all([firstWrite, duplicateAdd]);
+    expect(firstResult).toBe(true);
+    expect(duplicateResult).toMatchObject({ ok: false });
+    if (!duplicateResult.ok) {
+      expect(duplicateResult.error).toContain("alpha");
+    }
+    expect(observedServerNames).toEqual([["alpha"]]);
+    expect(submittedBaseHashes).toEqual(["hash-1"]);
+    expect(runtimeConfig.state.configSnapshot?.sourceConfig).toEqual(persistedConfig);
+    expect(persistedConfig.mcp.servers.alpha?.url).toBe("https://owner.example/alpha");
+    expect(persistedConfig.agents.list).toEqual([{ id: "main", default: true }, { id: "worker" }]);
+    expect(persistedConfig.env.vars.OPENCLAW_SYNTHETIC_TEST_ONLY).toBe("synthetic-source-value");
+    runtimeConfig.dispose();
+  });
+
+  it("reports a committed self-learning toggle as successful when its first reload fails", async () => {
+    let revision = 1;
+    let getCalls = 0;
+    let patchCalls = 0;
+    let persistedConfig = {
+      agents: { list: [{ id: "main", default: true }, { id: "worker" }] },
+      skills: { workshop: { autonomous: { enabled: false } } },
+    };
+    const request = vi.fn(async (method: string, params?: unknown) => {
+      if (method === "config.get") {
+        getCalls += 1;
+        if (getCalls === 2) {
+          throw new Error("authoritative self-learning snapshot temporarily unavailable");
+        }
+        const config = structuredClone(persistedConfig);
+        return {
+          config,
+          sourceConfig: structuredClone(config),
+          raw: JSON.stringify(config),
+          hash: `hash-${revision}`,
+          valid: true,
+          issues: [],
+        };
+      }
+      if (method !== "config.patch") {
+        return {};
+      }
+      patchCalls += 1;
+      const submission = params as { raw: string; baseHash: string };
+      if (submission.baseHash !== `hash-${revision}`) {
+        throw new Error("config changed since last load; re-run config.get and retry");
+      }
+      const fragment = JSON.parse(submission.raw) as {
+        skills: { workshop: { autonomous: { enabled: boolean } } };
+      };
+      persistedConfig = { ...persistedConfig, skills: fragment.skills };
+      revision += 1;
+      return { hash: `hash-${revision}`, config: { agents: "__OPENCLAW_REDACTED__" } };
+    });
+    const { runtimeConfig } = createHarness(request as GatewayBrowserClient["request"]);
+    await runtimeConfig.ensureLoaded();
+
+    await expect(setSelfLearningEnabled(runtimeConfig, true)).resolves.toBeNull();
+
+    expect(patchCalls).toBe(1);
+    expect(getCalls).toBe(3);
+    expect(runtimeConfig.state.configSnapshot?.sourceConfig).toEqual(persistedConfig);
+    expect(persistedConfig.agents.list).toEqual([{ id: "main", default: true }, { id: "worker" }]);
+    expect(persistedConfig.skills.workshop.autonomous.enabled).toBe(true);
+    runtimeConfig.dispose();
+  });
+
   it("refreshes applied revision truth after config.patch", async () => {
     vi.useFakeTimers();
     let getCount = 0;
@@ -1534,7 +2294,8 @@ describe("config form auto-save", () => {
     await expect(runtimeConfig.patch({ raw: { count: 2 }, note: "test patch" })).resolves.toBe(
       true,
     );
-    expect(runtimeConfig.state.configNeedsApply).toBe(true);
+    expect(runtimeConfig.state.configNeedsApply).toBe(false);
+    expect(runtimeConfig.state.configSnapshot?.configRevisionHash).toBe("revision-2");
 
     await vi.advanceTimersByTimeAsync(250);
     expect(runtimeConfig.state.configNeedsApply).toBe(false);

--- a/ui/src/lib/config/index.ts
+++ b/ui/src/lib/config/index.ts
@@ -74,6 +74,8 @@ type ConfigState = {
 const autoAllowlistedPluginIdsByState = new WeakMap<ConfigState, Set<string>>();
 const requestVersionsByState = new WeakMap<ConfigState, { config: number; schema: number }>();
 const connectionEpochsByState = new WeakMap<object, number>();
+const loadedConfigConnectionEpochsByState = new WeakMap<ConfigState, number>();
+const committedConfigRefreshRequiredByState = new WeakSet<ConfigState>();
 
 type RuntimeConfigGatewaySnapshot = {
   client: GatewayBrowserClient | null;
@@ -88,6 +90,8 @@ type RuntimeConfigGateway = {
 
 export type RuntimeConfigCapability = {
   readonly state: ConfigState;
+  /** Monotonic physical Gateway owner, including same-client reconnects. */
+  readonly connectionEpoch: number;
   ensureLoaded: () => Promise<void>;
   ensureSchemaLoaded: () => Promise<void>;
   refresh: (options?: LoadConfigOptions) => Promise<void>;
@@ -114,6 +118,17 @@ export type RuntimeConfigCapability = {
   dispose: () => void;
 };
 
+/** A retained snapshot is authoritative only in the epoch that loaded it. */
+export function hasCurrentConfigSnapshot(runtimeConfig: RuntimeConfigCapability): boolean {
+  const state = runtimeConfig.state;
+  return (
+    state.connected &&
+    !state.configLoading &&
+    state.configSnapshot !== null &&
+    loadedConfigConnectionEpochsByState.get(state) === runtimeConfig.connectionEpoch
+  );
+}
+
 type LoadConfigOptions = {
   discardPendingChanges?: boolean;
 };
@@ -123,6 +138,8 @@ type ConfigPatchOptions = {
   note: string;
   /** Array paths the caller intentionally shrinks; required by the gateway's destructive-array guard. */
   replacePaths?: string[];
+  /** Observe each real write; a persisted Gateway hash is additive, not required. */
+  onCommitted?: (commit: { hash: string | null; baseHash: string }) => void;
 };
 
 type ConfigPatchBuildResult = { options: ConfigPatchOptions } | { error: string };
@@ -135,18 +152,6 @@ type ConfigGatewayClient = {
 type ConfigConnectionState = {
   client: ConfigGatewayClient | null;
   connected: boolean;
-};
-
-type ConfigGatewayState = Pick<
-  ConfigState,
-  | "connected"
-  | "applySessionKey"
-  | "configNeedsApply"
-  | "configSnapshot"
-  | "lastError"
-  | "chatError"
-> & {
-  client: ConfigGatewayClient | null;
 };
 
 function createInitialConfigState(snapshot?: Partial<RuntimeConfigGatewaySnapshot>): ConfigState {
@@ -243,6 +248,7 @@ async function loadConfig(
       return false;
     }
     applyConfigSnapshot(state, res, options);
+    committedConfigRefreshRequiredByState.delete(state);
     return true;
   } catch (err) {
     if (isCurrentRequest(state, "config", version, client, connectionEpoch)) {
@@ -331,6 +337,7 @@ function applyConfigSnapshot(
   }
   const draftBaseHash = state.configDraftBaseHash ?? state.configSnapshot?.hash ?? null;
   state.configSnapshot = snapshot;
+  loadedConfigConnectionEpochsByState.set(state, currentConfigConnectionEpoch(state));
   const editableConfig = resolveEditableSnapshotConfig(snapshot);
   const rawAvailable =
     typeof snapshot.raw === "string" || Boolean(editableConfig) || Boolean(state.configForm);
@@ -565,6 +572,7 @@ function adoptConfigSetAck(state: ConfigState, submittedRaw: string, ackHash: st
     issues: [],
     ...(parsed ? { config: parsed, sourceConfig: parsed } : {}),
   };
+  loadedConfigConnectionEpochsByState.set(state, currentConfigConnectionEpoch(state));
   state.configValid = true;
   state.configIssues = [];
   setConfigRawOriginal(state, submittedRaw);
@@ -841,10 +849,7 @@ async function applyConfig(state: ConfigState): Promise<boolean> {
   });
 }
 
-async function patchConfig(
-  state: ConfigGatewayState,
-  options: ConfigPatchOptions,
-): Promise<boolean> {
+async function patchConfig(state: ConfigState, options: ConfigPatchOptions): Promise<boolean> {
   const client = state.client;
   if (!client || !state.connected) {
     return false;
@@ -858,7 +863,7 @@ async function patchConfig(
   state.lastError = null;
   state.chatError = null;
   try {
-    const ack = await client.request<{ noop?: boolean }>("config.patch", {
+    const ack = await client.request<{ hash?: string; noop?: boolean }>("config.patch", {
       baseHash,
       raw: typeof options.raw === "string" ? options.raw : JSON.stringify(options.raw),
       sessionKey: state.applySessionKey,
@@ -868,10 +873,16 @@ async function patchConfig(
     if (!isCurrentConfigConnection(state, client, connectionEpoch)) {
       return false;
     }
-    if (ack.noop !== true) {
-      state.configNeedsApply = true;
+    if (ack.noop === true) {
+      return true;
     }
-    return true;
+    state.configNeedsApply = true;
+    committedConfigRefreshRequiredByState.add(state);
+    options.onCommitted?.({ hash: readAckHash(ack), baseHash });
+    // The physical write already succeeded. Reload full source opportunistically;
+    // on failure the retained barrier refreshes before the next FIFO builder.
+    await loadConfig(state);
+    return isCurrentConfigConnection(state, client, connectionEpoch);
   } catch (err) {
     if (isCurrentConfigConnection(state, client, connectionEpoch)) {
       state.lastError = String(err);
@@ -1415,11 +1426,21 @@ export function createRuntimeConfigCapability(
     if (writesSuspended) {
       return Promise.resolve(false);
     }
+    const queuedClient = state.client;
+    const queuedConnectionEpoch = currentConfigConnectionEpoch(state);
+    if (!queuedClient || !isCurrentConfigConnection(state, queuedClient, queuedConnectionEpoch)) {
+      return Promise.resolve(false);
+    }
     cancelScheduledAutoSave();
     // Start synchronously when no explicit op is queued so the submit binds
     // to the CURRENT connection epoch; only genuine queuing pays the hop.
     const start = () =>
       run(async () => {
+        // Capture the owner at enqueue, not dispatch: one capability and even
+        // one client object can survive a reconnect to another gateway epoch.
+        if (!isCurrentConfigConnection(state, queuedClient, queuedConnectionEpoch)) {
+          return false;
+        }
         // Drain before the explicit op — otherwise an apply could race a
         // pending config.set on the same base hash into a CAS failure.
         if (autoSaveInFlight ?? manualSubmitInFlight) {
@@ -1427,7 +1448,11 @@ export function createRuntimeConfigCapability(
         }
         // The updater may have started while we drained; suspension must be a
         // real barrier or an apply could restart the gateway mid-update.
-        if (writesSuspended || disposed) {
+        if (
+          writesSuspended ||
+          disposed ||
+          !isCurrentConfigConnection(state, queuedClient, queuedConnectionEpoch)
+        ) {
           return false;
         }
         manualFlightInfo = null;
@@ -1463,7 +1488,10 @@ export function createRuntimeConfigCapability(
     return queued;
   };
   const ensureLoaded = async () => {
-    if (!state.configSnapshot) {
+    if (
+      !state.configSnapshot ||
+      loadedConfigConnectionEpochsByState.get(state) !== currentConfigConnectionEpoch(state)
+    ) {
       await loadOnce("config", () => loadConfig(state));
     }
     reconcileAppliedRefresh();
@@ -1480,6 +1508,9 @@ export function createRuntimeConfigCapability(
     if (clientChanged || connectionChanged) {
       configLoad = null;
       schemaLoad = null;
+      // Explicit writes belong to their physical connection. A dead prior
+      // flight must not keep the reconnected owner's FIFO waiting forever.
+      explicitOpQueue = null;
       // A reconnect may reuse the client object. Keep generations monotonic so work
       // from the previous connection cannot commit into the new connection epoch.
       invalidateConfigConnection(state);
@@ -1598,12 +1629,68 @@ export function createRuntimeConfigCapability(
       // A drained autosave can start its own refresh while this patch waits.
       cancelAppliedRefresh();
       try {
-        const resolved = resolveOptions();
-        if ("error" in resolved) {
-          state.lastError = resolved.error;
+        if (committedConfigRefreshRequiredByState.has(state)) {
+          const client = state.client;
+          const connectionEpoch = currentConfigConnectionEpoch(state);
+          // Snapshot builders make existence/ownership decisions. Recover
+          // complete authoritative config before building their CAS payload.
+          if (
+            !client ||
+            !(await loadConfig(state)) ||
+            !isCurrentConfigConnection(state, client, connectionEpoch)
+          ) {
+            return false;
+          }
+        }
+        const client = state.client;
+        const connectionEpoch = currentConfigConnectionEpoch(state);
+        if (
+          !client ||
+          writesSuspended ||
+          disposed ||
+          !isCurrentConfigConnection(state, client, connectionEpoch)
+        ) {
           return false;
         }
-        return await patchConfig(state, resolved.options);
+
+        for (let attempt = 0; attempt < 2; attempt += 1) {
+          const resolved = resolveOptions();
+          if ("error" in resolved) {
+            state.lastError = resolved.error;
+            return false;
+          }
+
+          const patched = await patchConfig(state, resolved.options);
+          if (patched) {
+            return true;
+          }
+          if (
+            writesSuspended ||
+            disposed ||
+            !isCurrentConfigConnection(state, client, connectionEpoch) ||
+            !isConfigBaseHashConflictError(state.lastError)
+          ) {
+            return false;
+          }
+          if (attempt > 0) {
+            // Mark exhausted recovery distinctly so older scalar-owner
+            // fallbacks cannot start a second independent retry chain.
+            state.lastError = "Configuration changed again during recovery; refresh and retry.";
+            return false;
+          }
+
+          // A foreign write invalidates both the CAS hash and any snapshot
+          // builder. Rebuild once from the full current owner's source.
+          if (
+            !(await loadConfig(state)) ||
+            writesSuspended ||
+            disposed ||
+            !isCurrentConfigConnection(state, client, connectionEpoch)
+          ) {
+            return false;
+          }
+        }
+        return false;
       } finally {
         reconcileAppliedRefresh();
       }
@@ -1615,6 +1702,9 @@ export function createRuntimeConfigCapability(
   return {
     get state() {
       return state;
+    },
+    get connectionEpoch() {
+      return currentConfigConnectionEpoch(state);
     },
     ensureLoaded,
     ensureSchemaLoaded,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users changing Control UI Settings, sidebar sessions,
locale, or chat preferences could lose updates, inherit the previous account's
private sidebar, or permanently stop saving after a same-client Gateway
reconnect, an already-loaded snapshot, or a concurrent configuration write.

## Why This Change Was Made

Make the existing runtime configuration capability the sole physical Settings
writer. Carry the authoritative snapshot's actual physical connection epoch
through the owner, and fence subscriptions, sidebar projections, queued
writes, and stale callbacks by that same runtime, source object, content
hash, and epoch.

An already-loaded authoritative reconnect snapshot now permits the first
real preference writes immediately; a retained old-connection snapshot
still cannot bypass the refresh barrier. A permanently stalled previous
write queue is retired with its connection. A genuine foreign-owner CAS
conflict rebuilds from complete current configuration and retries once.

This change does not modify provider/SSE contracts, authentication, approval
policy, public Gateway protocol, SQLite state/schema, plugin/catalog trust,
or public CLI compatibility.

## User Impact

Settings changes complete and physically persist when users reconnect or run
multiple sessions. The current account retains its own sidebar and locale;
delayed callbacks or dead writes from an old connection cannot corrupt or
block it. Concurrent Skills and MCP configuration owners retain their data.

## Evidence

- Exact clean `main` base:
  `c66ca2fbb2b038f4796abfa76bd52dcc3b675b02`.
- Exact Peter-authored commit:
  `049e0ea2ad566aabc43763da3ec6f08d1f1b2d18`.
- Initial current-main fail-first proof, with production byte-pristine:
  **42 failed / 104 passed**, exit 1.
- A genuine first official reviewer identified a further snapshot-first
  reconnect P1. With all three production files still identical to the
  rejected commit, the new targeted regression produced **2 failed cases**
  and **zero physical writes**, exit 1. The root cause is fixed rather than
  waived; the preserved rejected-review artifact is
  `06e5087639bf9b22879612b52fed06f364d3eaac5162c008127b5ed7a503f7d2`.
- Corrected final owner suites: **149/149 passed**. Root independently ran
  all **13** affected UI suites, including both newly merged Skills view and
  runtime-capability suites: **303/303 passed**, exit 0.
- Twelve marker, runtime, and arrival-order combinations each exercise ten
  stale callbacks and prove **both** new-owner `system` and `fr` physical
  `config.patch` writes. Foreign CAS, repeated content hashes, hashless
  acknowledgements, no-op, failed authoritative reload, updater suspension,
  Skills/MCP writer ownership, and sidebar privacy remain covered.
- Fresh final `gpt-5.6-sol` high official structured review:
  `019fa00e-4873-7f02-8717-3ff08afc2f56`; **PASS**, zero findings,
  `patch is correct`, confidence **0.91**, artifact SHA-256
  `07242d002706c4a8968e4dc0845f1663a906036be1b65e847923b12324be40c4`.
- Full exact-source remote changed gate passed on sole Testbox
  `tbx_01kyg0xne76f61m7t3we1s98jb`, Actions run `30218488698`:
  **PASS**, original wrapper exit 0, `commandMs=274654`,
  `totalMs=306335`, native `exitCode=0`, and zero warnings or errors.
  Both strict type-checks, formatting, package, architecture, SDK,
  translation, and 245-rule lint guards passed. The temporary full checkout
  correctly overlays the exact five committed source blobs onto synthetic
  current base `c66`; the six synchronized transport items are not claimed
  as six changed product files or a remote checkout of the local commit.
- No Browser screenshot or current-head live-provider pass is claimed.
  Historical ten-session results are accurately historical; the new
  one-Gateway, ten-GPT-5.4, medium-sized-task scenario will set
  `retryCount: 0` and run after the verified merge.
- AI-assisted; the before/after reproduction, official-review finding,
  corrected source, current Skills consumers, and exact commit were each
  independently verified.
