### PR TITLE
fix(auto-reply): strip sentence-attached trailing NO_REPLY

### DIFF
--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -200,6 +200,25 @@ describe("normalizeReplyPayload", () => {
     expect(reply.text).not.toContain("NO_REPLY");
   });
 
+  it("strips trailing NO_REPLY glued after sentence-final punctuation", () => {
+    const result = normalizeReplyPayload({
+      text: "Done as requested.NO_REPLY",
+    });
+    expect(expectNormalizedReply(result).text).toBe("Done as requested.");
+  });
+
+  it("keeps ordinary NO_REPLY mentions around punctuation", () => {
+    expect(
+      expectNormalizedReply(normalizeReplyPayload({ text: "The token is NO_REPLY." })).text,
+    ).toBe("The token is NO_REPLY.");
+    expect(
+      expectNormalizedReply(normalizeReplyPayload({ text: "NO_REPLY: explanation" })).text,
+    ).toBe("NO_REPLY: explanation");
+    expect(expectNormalizedReply(normalizeReplyPayload({ text: "interject.NO_REPLY" })).text).toBe(
+      "interject.NO_REPLY",
+    );
+  });
+
   it("strips glued leading NO_REPLY text without leaking the token", () => {
     const result = normalizeReplyPayload({
       text: "NO_REPLYThe user is saying hello",

--- a/src/auto-reply/tokens.test.ts
+++ b/src/auto-reply/tokens.test.ts
@@ -219,6 +219,24 @@ describe("stripSilentToken", () => {
     expect(stripSilentToken("interject.NO_REPLY")).toBe("interject.NO_REPLY");
   });
 
+  it("strips trailing token glued after sentence-final punctuation", () => {
+    expect(stripSilentToken("Done as requested.NO_REPLY")).toBe("Done as requested.");
+    expect(stripSilentToken("Done as requested!NO_REPLY")).toBe("Done as requested!");
+    expect(stripSilentToken("Done as requested?NO_REPLY")).toBe("Done as requested?");
+  });
+
+  it("keeps ordinary NO_REPLY mentions around punctuation", () => {
+    expect(stripSilentToken("The token is NO_REPLY.")).toBe("The token is NO_REPLY.");
+    expect(stripSilentToken("NO_REPLY: explanation")).toBe("NO_REPLY: explanation");
+    expect(stripSilentToken("interject.NO_REPLY")).toBe("interject.NO_REPLY");
+  });
+
+  it("keeps long attached trailing token text without qualifying sentence punctuation", () => {
+    const longMultiwordReply = `${Array.from({ length: 5000 }, (_, index) => `word${index}`).join(" ")}NO_REPLY`;
+
+    expect(stripSilentToken(longMultiwordReply)).toBe(longMultiwordReply);
+  });
+
   it("strips only trailing occurrence", () => {
     expect(stripSilentToken("NO_REPLY ok NO_REPLY")).toBe("NO_REPLY ok");
   });

--- a/src/auto-reply/tokens.ts
+++ b/src/auto-reply/tokens.ts
@@ -232,7 +232,21 @@ export function isSilentReplyPayloadText(
  * If the result is empty, the entire message should be treated as silent.
  */
 export function stripSilentToken(text: string, token: string = SILENT_REPLY_TOKEN): string {
-  return text.replace(getSilentTrailingRegex(token), "").trim();
+  const trimmed = text.trim();
+  const delimitedStripped = text.replace(getSilentTrailingRegex(token), "").trim();
+  if (delimitedStripped !== trimmed) {
+    return delimitedStripped;
+  }
+
+  const trimmedEnd = text.trimEnd();
+  if (!trimmedEnd.toLowerCase().endsWith(token.toLowerCase())) {
+    return trimmed;
+  }
+  const prefix = trimmedEnd.slice(0, -token.length);
+  if (!/[.!?]$/.test(prefix) || !/\s/.test(prefix.slice(0, -1))) {
+    return trimmed;
+  }
+  return prefix.trim();
 }
 
 const silentLeadingRegexByToken = new Map<string, RegExp>();


### PR DESCRIPTION
## Summary

- replace the trailing-token regex branch flagged by ClawSweeper with bounded suffix parsing
- strip sentence-attached `NO_REPLY` after `.`, `!`, or `?` while preserving visible text and punctuation
- add deterministic long non-matching input coverage plus helper and delivery-path regressions

Fixes #114100.

## What Problem This Solves

A model reply such as `Done as requested.NO_REPLY` currently reaches `normalizeReplyPayload` with the internal control token still attached because the existing trailing matcher only accepts the start of text, whitespace, or asterisks before `NO_REPLY`. The first PR revision addressed this with a nested greedy regex branch, but ClawSweeper correctly identified excessive-backtracking risk on long non-matching text.

This revision keeps the original delimiter regex bounded. If that matcher makes no change, `stripSilentToken` performs a bounded suffix check and strips the token only when the visible prefix ends in `.`, `!`, or `?` and contains whitespace. It preserves ordinary mentions such as `interject.NO_REPLY`, `The token is NO_REPLY.`, and `NO_REPLY: explanation`.

## Evidence

Independent RED reproduction against live upstream `main` at `af9d583e1d200fa5f853bad7cb1572bcfaaf4f0b` showed both the helper and `normalizeReplyPayload` returning `Done as requested.NO_REPLY` instead of `Done as requested.`. Immediately before publication, upstream advanced to `71eb9a3ec9d9b7b13491c74ce192c3a2ab77830c`; the three affected paths were unchanged, and the audited patch was replayed exactly on that head.

After the corrective patch:

```text
Done as requested.NO_REPLY -> Done as requested.
Done as requested!NO_REPLY -> Done as requested!
Done as requested?NO_REPLY -> Done as requested?
interject.NO_REPLY -> interject.NO_REPLY
The token is NO_REPLY. -> The token is NO_REPLY.
NO_REPLY: explanation -> NO_REPLY: explanation
```

The regression suite also includes a 5,000-word non-matching input and asserts it remains unchanged. The final production diff contains no nested overlapping wildcard regex.

## Validation

- current-main RED: focused helper/delivery tests failed on `Done as requested.NO_REPLY` before the production patch
- `node scripts/run-vitest.mjs src/auto-reply/tokens.test.ts src/auto-reply/reply/reply-utils.test.ts` (141 tests passed)
- `node scripts/run-vitest.mjs src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts` (101 tests passed)
- `node scripts/run-vitest.mjs src/auto-reply/tokens.test.ts -t "keeps long attached trailing token text without qualifying sentence punctuation"`
- `pnpm format:check src/auto-reply/tokens.ts src/auto-reply/tokens.test.ts src/auto-reply/reply/reply-utils.test.ts`
- `pnpm tsgo:core`
- `git diff --check`

Independent read-only audits passed both candidate review and patch review and confirmed the bounded suffix parser fully addresses the ClawSweeper feedback.

## Duplicate Check

Rechecked issue #114100, its timeline, live upstream `main` at `71eb9a3ec9d9b7b13491c74ce192c3a2ab77830c`, open PRs by issue number and behavior, and recent changes to the three affected paths. No active or landed equivalent fix was found; this PR is the only open PR matching #114100. PR #114127 concerns leading/newline tokens, while merged PR #98224 concerns token-only punctuation rather than mixed visible text.

## Browser / Playwright

Not run: this is a shared TypeScript token-normalization and reply-payload cleanup path with deterministic unit and delivery-path coverage; it does not change a browser or visual surface.
