### PR TITLE
fix(agents): keep login-shell commands on human approval

### DIFF
--- a/src/agents/bash-tools.exec-host-gateway.test.ts
+++ b/src/agents/bash-tools.exec-host-gateway.test.ts
@@ -849,6 +849,36 @@ describe("processGatewayAllowlist", () => {
     expect(JSON.stringify(captured.events)).not.toContain("allowed");
   });
 
+  it("keeps login-shell commands off auto-review", async () => {
+    const payload = "rm -rf /tmp/openclaw-auto-review-target && echo done";
+    const command = `bash -lc "${payload}"`;
+    const { authorizationPlan } = await configurePlanBackedCommand({ command });
+    expect(authorizationPlan).toMatchObject({
+      ok: true,
+      groups: [
+        {
+          candidates: [
+            {
+              sourceSegment: { argv: ["bash", "-lc", payload] },
+              transport: { kind: "direct" },
+              trustMode: "executable",
+            },
+          ],
+        },
+      ],
+    });
+
+    const result = await runGatewayAllowlist({
+      command,
+      ask: "on-miss",
+      autoReview: true,
+    });
+
+    expect(defaultExecAutoReviewerMock).not.toHaveBeenCalled();
+    expect(createAndRegisterDefaultExecApprovalRequestMock).toHaveBeenCalledTimes(1);
+    expect(result.pendingResult?.details.status).toBe("approval-pending");
+  });
+
   it("does not execute after cancellation wins during auto-review", async () => {
     const command = "echo ok";
     await configurePlanBackedCommand({ command });

--- a/src/agents/bash-tools.exec-host-gateway.test.ts
+++ b/src/agents/bash-tools.exec-host-gateway.test.ts
@@ -849,35 +849,38 @@ describe("processGatewayAllowlist", () => {
     expect(JSON.stringify(captured.events)).not.toContain("allowed");
   });
 
-  it("keeps login-shell commands off auto-review", async () => {
-    const payload = "rm -rf /tmp/openclaw-auto-review-target && echo done";
-    const command = `bash -lc "${payload}"`;
-    const { authorizationPlan } = await configurePlanBackedCommand({ command });
-    expect(authorizationPlan).toMatchObject({
-      ok: true,
-      groups: [
-        {
-          candidates: [
-            {
-              sourceSegment: { argv: ["bash", "-lc", payload] },
-              transport: { kind: "direct" },
-              trustMode: "executable",
-            },
-          ],
-        },
-      ],
-    });
+  it.each(["bash", "sh", "/bin/sh"])(
+    "keeps %s login-shell commands off auto-review",
+    async (shell) => {
+      const payload = "rm -rf /tmp/openclaw-auto-review-target && echo done";
+      const command = `${shell} -lc "${payload}"`;
+      const { authorizationPlan } = await configurePlanBackedCommand({ command });
+      expect(authorizationPlan).toMatchObject({
+        ok: true,
+        groups: [
+          {
+            candidates: [
+              {
+                sourceSegment: { argv: [shell, "-lc", payload] },
+                transport: { kind: "direct" },
+                trustMode: "executable",
+              },
+            ],
+          },
+        ],
+      });
 
-    const result = await runGatewayAllowlist({
-      command,
-      ask: "on-miss",
-      autoReview: true,
-    });
+      const result = await runGatewayAllowlist({
+        command,
+        ask: "on-miss",
+        autoReview: true,
+      });
 
-    expect(defaultExecAutoReviewerMock).not.toHaveBeenCalled();
-    expect(createAndRegisterDefaultExecApprovalRequestMock).toHaveBeenCalledTimes(1);
-    expect(result.pendingResult?.details.status).toBe("approval-pending");
-  });
+      expect(defaultExecAutoReviewerMock).not.toHaveBeenCalled();
+      expect(createAndRegisterDefaultExecApprovalRequestMock).toHaveBeenCalledTimes(1);
+      expect(result.pendingResult?.details.status).toBe("approval-pending");
+    },
+  );
 
   it("does not execute after cancellation wins during auto-review", async () => {
     const command = "echo ok";

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -40,6 +40,7 @@ import {
   type ExecAutoReviewInput,
 } from "../infra/exec-auto-review.js";
 import type { SafeBinProfile } from "../infra/exec-safe-bin-policy.js";
+import { isBlockedShellWrapperCommand } from "../infra/exec-wrapper-resolution.js";
 import {
   GatewayDrainingError,
   runWithGatewayIndependentRootWorkAdmission,
@@ -762,11 +763,15 @@ export async function processGatewayAllowlist(
       };
     }
     const [autoReviewSegment] = allowlistEval.segments;
+    // Login and interactive shell startup may execute code outside the inline payload.
+    // Keep opaque wrappers on the explicit human-approval path.
     const autoReviewArgv =
       allowlistEval.segments.length === 1 &&
+      autoReviewSegment !== undefined &&
+      !isBlockedShellWrapperCommand(autoReviewSegment.argv, autoReviewSegment.raw) &&
       (autoReviewSegment?.raw === undefined ||
         autoReviewSegment.raw.trim() === params.command.trim())
-        ? autoReviewSegment?.argv
+        ? autoReviewSegment.argv
         : undefined;
     const autoReviewHasBoundCommand = analysisOk && autoReviewArgv !== undefined;
     // A model approval is valid only for the executable resolved during review;

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -768,7 +768,7 @@ export async function processGatewayAllowlist(
     const autoReviewArgv =
       allowlistEval.segments.length === 1 &&
       autoReviewSegment !== undefined &&
-      !isBlockedShellWrapperCommand(autoReviewSegment.argv, autoReviewSegment.raw) &&
+      !isBlockedShellWrapperCommand(autoReviewSegment.argv) &&
       (autoReviewSegment?.raw === undefined ||
         autoReviewSegment.raw.trim() === params.command.trim())
         ? autoReviewSegment.argv

--- a/src/agents/bash-tools.exec-host-node-phases.ts
+++ b/src/agents/bash-tools.exec-host-node-phases.ts
@@ -650,7 +650,7 @@ export async function analyzeNodeApprovalRequirement(params: {
   const autoReviewArgv =
     autoReviewBindingEval.segments.length === 1 &&
     autoReviewSegment !== undefined &&
-    !isBlockedShellWrapperCommand(autoReviewSegment.argv, autoReviewSegment.raw) &&
+    !isBlockedShellWrapperCommand(autoReviewSegment.argv) &&
     (autoReviewSegment.raw === undefined ||
       autoReviewSegment.raw.trim() === autoReviewBindingCommand.trim())
       ? autoReviewSegment.argv

--- a/src/agents/bash-tools.exec-host-node-phases.ts
+++ b/src/agents/bash-tools.exec-host-node-phases.ts
@@ -26,6 +26,7 @@ import {
   resolveAllowAlwaysPatternCoverage,
   type AllowAlwaysPattern,
 } from "../infra/exec-approvals.js";
+import { isBlockedShellWrapperCommand } from "../infra/exec-wrapper-resolution.js";
 import { buildNodeShellCommand } from "../infra/node-shell.js";
 import {
   parsePreparedSystemRunPayload,
@@ -643,6 +644,17 @@ export async function analyzeNodeApprovalRequirement(params: {
       // Fall back to requiring approval if node approvals cannot be fetched.
     }
   }
+  const [autoReviewSegment] = autoReviewBindingEval.segments;
+  // Login and interactive shell startup may execute code outside the inline payload.
+  // Keep opaque wrappers on the explicit human-approval path.
+  const autoReviewArgv =
+    autoReviewBindingEval.segments.length === 1 &&
+    autoReviewSegment !== undefined &&
+    !isBlockedShellWrapperCommand(autoReviewSegment.argv, autoReviewSegment.raw) &&
+    (autoReviewSegment.raw === undefined ||
+      autoReviewSegment.raw.trim() === autoReviewBindingCommand.trim())
+      ? autoReviewSegment.argv
+      : undefined;
   return {
     analysisOk,
     allowlistSatisfied,
@@ -663,11 +675,6 @@ export async function analyzeNodeApprovalRequirement(params: {
       runtimePayload: inlineEvalHit !== null,
       preparedCoverage: params.prepared.allowAlwaysCoverage,
     }),
-    autoReviewArgv:
-      autoReviewBindingEval.segments.length === 1 &&
-      (autoReviewBindingEval.segments.at(0)?.raw === undefined ||
-        autoReviewBindingEval.segments.at(0)?.raw.trim() === autoReviewBindingCommand.trim())
-        ? autoReviewBindingEval.segments.at(0)?.argv
-        : undefined,
+    autoReviewArgv,
   };
 }

--- a/src/agents/bash-tools.exec-host-node.test.ts
+++ b/src/agents/bash-tools.exec-host-node.test.ts
@@ -1690,7 +1690,7 @@ describe("executeNodeHostCommand", () => {
     expectSystemRunInvoke({ invokeTimeoutMs: 35_000, runTimeoutMs: 30_000 });
   });
 
-  it("keeps non-transport login shells approval-gated", async () => {
+  it("keeps non-transport login shells off auto-review", async () => {
     const loginPlan = {
       argv: ["bash", "-lc", "./scripts/check_mail.sh --limit 5"],
       cwd: "/tmp/work",
@@ -1745,9 +1745,9 @@ describe("executeNodeHostCommand", () => {
         params?.allowlistSatisfied !== true && params?.durableApprovalSatisfied !== true,
     );
     const autoReviewer = vi.fn<ExecAutoReviewer>(async () => ({
-      decision: "ask",
-      risk: "medium",
-      rationale: "login shell needs human approval",
+      decision: "allow-once",
+      risk: "low",
+      rationale: "would allow the opaque login shell",
     }));
     resolveExecHostApprovalContextMock.mockReturnValue({
       approvals: { allowlist: [], file: { version: 1, agents: {} } },
@@ -1772,12 +1772,7 @@ describe("executeNodeHostCommand", () => {
     });
 
     expect(result.details?.status).toBe("approval-pending");
-    expect(autoReviewer).toHaveBeenCalledWith(
-      expect.objectContaining({
-        command: `bash -lc "./scripts/check_mail.sh --limit 5"`,
-        argv: ["bash", "-lc", "./scripts/check_mail.sh --limit 5"],
-      }),
-    );
+    expect(autoReviewer).not.toHaveBeenCalled();
     expect(createAndRegisterDefaultExecApprovalRequestMock).toHaveBeenCalled();
   });
 

--- a/src/agents/bash-tools.exec-host-node.test.ts
+++ b/src/agents/bash-tools.exec-host-node.test.ts
@@ -1690,91 +1690,97 @@ describe("executeNodeHostCommand", () => {
     expectSystemRunInvoke({ invokeTimeoutMs: 35_000, runTimeoutMs: 30_000 });
   });
 
-  it("keeps non-transport login shells off auto-review", async () => {
-    const loginPlan = {
-      argv: ["bash", "-lc", "./scripts/check_mail.sh --limit 5"],
-      cwd: "/tmp/work",
-      commandText: `bash -lc "./scripts/check_mail.sh --limit 5"`,
-      commandPreview: "./scripts/check_mail.sh --limit 5",
-      agentId: "prepared-agent",
-      sessionKey: "prepared-session",
-    };
-    parsePreparedSystemRunPayloadMock.mockReturnValue({
-      plan: loginPlan,
-      execPolicy: { security: "full", ask: "off" },
-    });
-    const nodeAllowlist = [{ pattern: "./scripts/check_mail.sh" }];
-    resolveExecApprovalsFromFileMock.mockReturnValue({
-      allowlist: nodeAllowlist,
-      file: { version: 1, agents: {} },
-      agent: {
-        security: "full",
-        ask: "off",
-        askFallback: "deny",
-        autoAllowSkills: false,
-      },
-    });
-    evaluateShellAllowlistMock.mockImplementation(
-      (params?: { command?: string; allowlist?: unknown[] }) => {
+  it.each(["bash", "sh", "/bin/sh"])(
+    "keeps non-transport %s login shells off auto-review",
+    async (shell) => {
+      const payload = "./scripts/check_mail.sh --limit 5";
+      const loginCommand = `${shell} -lc "${payload}"`;
+      const loginPlan = {
+        argv: ["/bin/sh", "-lc", loginCommand],
+        cwd: "/tmp/work",
+        commandText: `/bin/sh -lc "${loginCommand.replaceAll('"', '\\"')}"`,
+        commandPreview: loginCommand,
+        agentId: "prepared-agent",
+        sessionKey: "prepared-session",
+      };
+      parsePreparedSystemRunPayloadMock.mockReturnValue({
+        plan: loginPlan,
+        execPolicy: { security: "full", ask: "off" },
+      });
+      resolveExecApprovalsFromFileMock.mockReturnValue({
+        allowlist: [],
+        file: { version: 1, agents: {} },
+        agent: {
+          security: "full",
+          ask: "off",
+          askFallback: "deny",
+          autoAllowSkills: false,
+        },
+      });
+      evaluateShellAllowlistMock.mockImplementation((params?: { command?: string }) => {
         const command = params?.command ?? "";
-        const hasNodeAllowlist = Array.isArray(params?.allowlist) && params.allowlist.length > 0;
-        const semanticMatch = command === "./scripts/check_mail.sh --limit 5";
         return {
-          allowlistMatches: semanticMatch && hasNodeAllowlist ? [{}] : [],
+          allowlistMatches: [],
           analysisOk: true,
-          allowlistSatisfied: semanticMatch && hasNodeAllowlist,
+          allowlistSatisfied: false,
           segments: [
-            command.startsWith("bash")
+            command === loginPlan.commandText
               ? {
                   resolution: null,
-                  argv: ["bash", "-lc", "./scripts/check_mail.sh --limit 5"],
-                  raw: `bash -lc "./scripts/check_mail.sh --limit 5"`,
+                  argv: ["/bin/sh", "-lc", loginCommand],
+                  raw: loginPlan.commandText,
                 }
-              : {
-                  resolution: null,
-                  argv: ["./scripts/check_mail.sh", "--limit", "5"],
-                  raw: "./scripts/check_mail.sh --limit 5",
-                },
+              : command === loginCommand
+                ? {
+                    resolution: null,
+                    argv: [shell, "-lc", payload],
+                    raw: loginCommand,
+                  }
+                : {
+                    resolution: null,
+                    argv: ["./scripts/check_mail.sh", "--limit", "5"],
+                    raw: payload,
+                  },
           ],
-          segmentAllowlistEntries: semanticMatch && hasNodeAllowlist ? [{}] : [],
+          segmentAllowlistEntries: [],
         };
-      },
-    );
-    requiresExecApprovalMock.mockImplementation(
-      (params?: { allowlistSatisfied?: boolean; durableApprovalSatisfied?: boolean }) =>
-        params?.allowlistSatisfied !== true && params?.durableApprovalSatisfied !== true,
-    );
-    const autoReviewer = vi.fn<ExecAutoReviewer>(async () => ({
-      decision: "allow-once",
-      risk: "low",
-      rationale: "would allow the opaque login shell",
-    }));
-    resolveExecHostApprovalContextMock.mockReturnValue({
-      approvals: { allowlist: [], file: { version: 1, agents: {} } },
-      hostSecurity: "allowlist",
-      hostAsk: "on-miss",
-      askFallback: "deny",
-    });
+      });
+      requiresExecApprovalMock.mockImplementation(
+        (params?: { allowlistSatisfied?: boolean; durableApprovalSatisfied?: boolean }) =>
+          params?.allowlistSatisfied !== true && params?.durableApprovalSatisfied !== true,
+      );
+      const autoReviewer = vi.fn<ExecAutoReviewer>(async () => ({
+        decision: "allow-once",
+        risk: "low",
+        rationale: "would allow the opaque login shell",
+      }));
+      resolveExecHostApprovalContextMock.mockReturnValue({
+        approvals: { allowlist: [], file: { version: 1, agents: {} } },
+        hostSecurity: "allowlist",
+        hostAsk: "on-miss",
+        askFallback: "deny",
+      });
 
-    const result = await executeNodeHostCommand({
-      command: "./scripts/check_mail.sh --limit 5",
-      workdir: "/tmp/work",
-      env: {},
-      security: "allowlist",
-      ask: "on-miss",
-      autoReview: true,
-      autoReviewer,
-      defaultTimeoutSec: 30,
-      approvalRunningNoticeMs: 0,
-      warnings: [],
-      agentId: "requested-agent",
-      sessionKey: "requested-session",
-    });
+      const result = await executeNodeHostCommand({
+        command: loginCommand,
+        workdir: "/tmp/work",
+        env: {},
+        security: "allowlist",
+        ask: "on-miss",
+        autoReview: true,
+        autoReviewer,
+        defaultTimeoutSec: 30,
+        approvalRunningNoticeMs: 0,
+        warnings: [],
+        agentId: "requested-agent",
+        sessionKey: "requested-session",
+      });
 
-    expect(result.details?.status).toBe("approval-pending");
-    expect(autoReviewer).not.toHaveBeenCalled();
-    expect(createAndRegisterDefaultExecApprovalRequestMock).toHaveBeenCalled();
-  });
+      expect(result.details?.status).toBe("approval-pending");
+      expect(autoReviewer).not.toHaveBeenCalled();
+      expect(createAndRegisterDefaultExecApprovalRequestMock).toHaveBeenCalled();
+    },
+  );
 
   it("requires human approval when prepared shell payload has multiple commands", async () => {
     const chainPlan = {

--- a/src/plugin-sdk/agent-harness-exec-review-runtime.ts
+++ b/src/plugin-sdk/agent-harness-exec-review-runtime.ts
@@ -37,10 +37,12 @@ export async function buildExecAutoReviewInputForShellCommand(params: {
     { commandRequiresSecurityAuditSuppressionApproval, evaluateShellAllowlistWithAuthorization },
     { detectUnsafeExecControlShellCommand },
     { detectPolicyInlineEval },
+    { isBlockedShellWrapperCommand },
   ] = await Promise.all([
     import("../infra/exec-approvals.js"),
     import("../infra/exec-control-command-guard.js"),
     import("../infra/command-analysis/policy.js"),
+    import("../infra/exec-wrapper-resolution.js"),
   ]);
   const command = params.command.trim();
   const host: ExecAutoReviewHost = params.host;
@@ -61,6 +63,11 @@ export async function buildExecAutoReviewInputForShellCommand(params: {
     segment !== undefined &&
     segment.raw.trim() === command;
   if (!boundSingleCommand) {
+    return undefined;
+  }
+  // Login and interactive shell startup may execute code outside the inline payload.
+  // Keep opaque wrappers on the explicit human-approval path.
+  if (isBlockedShellWrapperCommand(segment.argv, segment.raw)) {
     return undefined;
   }
   if (

--- a/src/plugin-sdk/agent-harness-exec-review-runtime.ts
+++ b/src/plugin-sdk/agent-harness-exec-review-runtime.ts
@@ -67,7 +67,7 @@ export async function buildExecAutoReviewInputForShellCommand(params: {
   }
   // Login and interactive shell startup may execute code outside the inline payload.
   // Keep opaque wrappers on the explicit human-approval path.
-  if (isBlockedShellWrapperCommand(segment.argv, segment.raw)) {
+  if (isBlockedShellWrapperCommand(segment.argv)) {
     return undefined;
   }
   if (


### PR DESCRIPTION
Closes #113282

## What Problem This Solves

Fixes an issue where users running exec with `tools.exec.mode: "auto"` could have startup-capable shell wrappers such as `bash -lc "..."` and `sh -lc "..."` approved by the model reviewer, even though shell startup files may execute code outside the reviewed inline payload.

## Why This Change Was Made

Auto-review now reuses the existing blocked-shell-wrapper classification without the legacy raw-command binding exception. Login or interactive shell wrappers therefore stay on the explicit human-approval path across gateway execution, node-host execution, and the public agent-harness helper. Ordinary single-command auto-review behavior remains unchanged.

Regression coverage exercises `bash`, `sh`, and `/bin/sh`. The node-host cases model the real outer `/bin/sh -lc` transport carrying an inner user-requested login shell.

## User Impact

Login and interactive shell commands can no longer bypass human approval through an optimistic model-review decision. Normal bindable commands remain eligible for automatic review.

This change was developed with Codex assistance. I reviewed the implementation, tests, and affected execution paths and understand the change.

## Evidence

- Regression-first proof: before the initial runtime change, the two new tests failed because the gateway invoked the reviewer and the node-host command completed without human approval; 146 existing tests passed.
- Review follow-up: removed the legacy raw-command override at all three auto-review entry points and expanded gateway/node coverage to `bash`, `sh`, and `/bin/sh`.
- Focused Node 24 local-container proof: 303 tests passed (`151` wrapper-resolution, `65` node-host, and `87` gateway).
- Direct public SDK probe: all three login-shell variants returned no auto-review request.
- `check:changed` against current `main` passed core and extension typechecks, lint, formatting, SDK/API contracts, import-cycle checks, and repository architecture/security guards.
- One pre-PR autoreview round was clean with no accepted or actionable findings.
- The prior-head CI failure was unrelated: `src/secrets/runtime.auth-migration-isolation.test.ts` timed out after 120 seconds while 709 tests in that shard passed.
- Non-visual behavior change; screenshots are not applicable.

<!-- agent-transcript:start -->
## Agent Transcript

<details>
<summary>Redacted Codex session transcript</summary>

````text
source: [LOCAL_SESSION]
redaction: local paths, account details, and raw tool output omitted

[user]
113282 is good, but lets double check if there's no PRs covering it before working on it

[assistant]
I’ll use `issue-bounty-hunt` to do an independent all-state recheck and verify the timeline, PR searches, recent commits, and current `main`. This is read-only.

No same-root PR or commit was found. Adjacent work touched the execution path but did not cover the default `auto + on-miss` login-shell wrapper gap.

[user]
still no same-root pr as of now?

[assistant]
I’ll refresh the live timeline, all-state PR/commit searches, and current `main` using the same strict no-overlap standard.

Still no same-root PR. Newly opened wrapper-hardening PRs were deep-checked and found adjacent rather than overlapping.

[user]
good lets fix it in a new worktree then

[assistant]
I’ll create an isolated `codex/` worktree from current `main`, reproduce the login-shell approval gap with focused tests, and keep the change scoped to #113282.

Red proof produced exactly two new failures with 146 existing tests passing. Both gateway and node-host paths handed the outer `bash -lc` argv to the reviewer; a low-risk decision bypassed human approval.

The shared fail-closed guard was applied at the gateway, node-host, and public agent-harness auto-review entry points. Focused and sibling tests, the changed-file gate, the Codex bridge checks, and the single allowed autoreview round were clean.

[user]
draft the PR then

[assistant]
The verified five-file patch was committed, pushed to the fork, and opened as draft PR #114175 with maintainer edits enabled.

[user]
address whatever action is needed from me

[assistant]
I treated that as approval to add this sanitized transcript and handle current author actions.

The live audit found a real ClawSweeper finding: passing raw command text into the shell-wrapper guard re-enabled a legacy canonical `sh -lc` binding exception. The three call sites were corrected, and gateway/node regressions were expanded to `bash`, `sh`, and `/bin/sh`.

The first expanded node test modeled `sh` as the trusted outer node transport and was corrected to model the real shape: an outer `/bin/sh -lc` transport carrying an inner user-requested login shell.

Final focused proof passed 303 tests and the public SDK probe. After rebasing onto current `main`, the full changed-surface gate passed all typecheck, lint, SDK/API, architecture, and security checks. The branch was force-updated safely and the PR was restored to draft state.
````

</details>
<!-- agent-transcript:end -->
