### PR TITLE
fix(openshell): bound generated sandbox names

### DIFF
--- a/extensions/openshell/src/backend.exec-workdir.test.ts
+++ b/extensions/openshell/src/backend.exec-workdir.test.ts
@@ -147,9 +147,9 @@ describe("openshell backend exec workdir validation", () => {
       cwd: workspaceDir,
     });
     expect(backend.runtimeId).toMatch(/^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/);
-    expect(backend.runtimeId).toContain("somalley-alice");
+    expect(backend.runtimeId).toMatch(/^os-age-[a-f0-9]{12}$/);
     expect(backend.runtimeId).not.toContain("_");
-    expect(backend.runtimeId.length).toBeLessThanOrEqual(63);
+    expect(backend.runtimeId.length).toBeLessThanOrEqual(19);
     expect(execSpec.env.OPENAI_API_KEY).toBeUndefined();
     expect(execSpec.env.ANTHROPIC_API_KEY).toBeUndefined();
     expect(execSpec.env.LANG).toBe("en_US.UTF-8");

--- a/extensions/openshell/src/backend.name.test.ts
+++ b/extensions/openshell/src/backend.name.test.ts
@@ -1,0 +1,51 @@
+// Openshell tests cover deterministic sandbox naming.
+import { describe, expect, it } from "vitest";
+import { buildOpenShellSandboxName } from "./backend.js";
+
+const DNS_1123_LABEL_RE = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/;
+
+describe("OpenShell sandbox names", () => {
+  const scopeKeys = [
+    "agent:main",
+    "agent:an-agent-with-a-long-scope-key-that-needs-compaction",
+    "session:primary",
+    "shared:team:engineering",
+    "agent:hello__world..!",
+    "agent:\u{1F99E}:\u00DCnicode",
+    "",
+  ];
+
+  it.each(scopeKeys)("keeps %j within the OpenShell DNS label limit", (scopeKey) => {
+    const name = buildOpenShellSandboxName(scopeKey);
+
+    expect(name.length).toBeLessThanOrEqual(19);
+    expect(name).toMatch(DNS_1123_LABEL_RE);
+    expect(name).not.toContain("--");
+  });
+
+  it("is deterministic across repeated calls", () => {
+    const scopeKey = "agent:main:thread:123";
+
+    expect(buildOpenShellSandboxName(scopeKey)).toBe(buildOpenShellSandboxName(scopeKey));
+  });
+
+  it("keeps representative session, agent, and shared keys distinct", () => {
+    const names = new Set(
+      ["session:primary", "agent:main", "shared:team"].map(buildOpenShellSandboxName),
+    );
+
+    expect(names.size).toBe(3);
+  });
+
+  it("uses the hash suffix to distinguish values with the same slug", () => {
+    const first = buildOpenShellSandboxName("agent:foo_bar");
+    const second = buildOpenShellSandboxName("agent:foo.bar");
+
+    expect(first.slice(0, 7)).toBe(second.slice(0, 7));
+    expect(first).not.toBe(second);
+  });
+
+  it("uses the session fallback for empty input", () => {
+    expect(buildOpenShellSandboxName("   ")).toBe(buildOpenShellSandboxName("session"));
+  });
+});

--- a/extensions/openshell/src/backend.ts
+++ b/extensions/openshell/src/backend.ts
@@ -1,4 +1,5 @@
 // Openshell plugin module implements backend behavior.
+import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import type {
@@ -891,17 +892,16 @@ function resolveOpenShellPluginConfigFromConfig(
   return resolveOpenShellPluginConfig(pluginConfig);
 }
 
-function buildOpenShellSandboxName(scopeKey: string): string {
+export function buildOpenShellSandboxName(scopeKey: string): string {
   const trimmed = scopeKey.trim() || "session";
-  const safe = normalizeLowercaseStringOrEmpty(trimmed)
+  const slug = normalizeLowercaseStringOrEmpty(trimmed)
     .replace(/[^a-z0-9-]+/g, "-")
+    .replace(/-+/g, "-")
     .replace(/^-+|-+$/g, "")
-    .slice(0, 32);
-  const hash = Array.from(trimmed).reduce(
-    (acc, char) => ((acc * 33) ^ char.charCodeAt(0)) >>> 0,
-    5381,
-  );
-  return `openclaw-${safe || "session"}-${hash.toString(16).slice(0, 8)}`;
+    .slice(0, 3)
+    .replace(/-+$/g, "");
+  const hash = createHash("sha256").update(trimmed).digest("hex").slice(0, 12);
+  return `os-${slug || "x"}-${hash}`;
 }
 
 function resolveRemoteMaterializedSkillsWorkspaceDir(remoteWorkspaceDir: string): string {

--- a/extensions/openshell/src/openshell-core.test.ts
+++ b/extensions/openshell/src/openshell-core.test.ts
@@ -353,7 +353,66 @@ describe("openshell backend manager", () => {
     });
   });
 
-  it("removes runtimes via openshell sandbox delete", async () => {
+  it("reuses a found generated sandbox without creating a duplicate", async () => {
+    const workspaceDir = await makeTempDir("openclaw-openshell-workspace-");
+    const factory = createOpenShellSandboxBackendFactory({
+      pluginConfig: resolveOpenShellPluginConfig({ command: "openshell", mode: "remote" }),
+    });
+    const backend = await factory({
+      sessionKey: "agent:main:turn",
+      scopeKey: "agent:main",
+      workspaceDir,
+      agentWorkspaceDir: workspaceDir,
+      cfg: createOpenShellBackendSandboxConfig(),
+    });
+
+    cliMocks.runOpenShellCli.mockResolvedValue({ code: 0, stdout: "", stderr: "" });
+    await backend.runShellCommand?.({ script: "true" });
+    await backend.runShellCommand?.({ script: "true" });
+
+    const lifecycleCalls = cliMocks.runOpenShellCli.mock.calls
+      .map(([params]) => params)
+      .filter(
+        (params) => params.args[0] === "sandbox" && ["get", "create"].includes(params.args[1]),
+      );
+    expect(lifecycleCalls).toEqual([
+      expect.objectContaining({ args: ["sandbox", "get", backend.runtimeId] }),
+    ]);
+  });
+
+  it("creates one generated sandbox after a failed lookup", async () => {
+    const workspaceDir = await makeTempDir("openclaw-openshell-workspace-");
+    const factory = createOpenShellSandboxBackendFactory({
+      pluginConfig: resolveOpenShellPluginConfig({ command: "openshell", mode: "remote" }),
+    });
+    const backend = await factory({
+      sessionKey: "agent:main:turn",
+      scopeKey: "agent:main",
+      workspaceDir,
+      agentWorkspaceDir: workspaceDir,
+      cfg: createOpenShellBackendSandboxConfig(),
+    });
+
+    cliMocks.runOpenShellCli
+      .mockResolvedValueOnce({ code: 1, stdout: "", stderr: "not found" })
+      .mockResolvedValueOnce({ code: 0, stdout: "", stderr: "" });
+    await backend.runShellCommand?.({ script: "true" });
+    await backend.runShellCommand?.({ script: "true" });
+
+    const lifecycleCalls = cliMocks.runOpenShellCli.mock.calls
+      .map(([params]) => params)
+      .filter(
+        (params) => params.args[0] === "sandbox" && ["get", "create"].includes(params.args[1]),
+      );
+    expect(lifecycleCalls).toEqual([
+      expect.objectContaining({ args: ["sandbox", "get", backend.runtimeId] }),
+      expect.objectContaining({
+        args: expect.arrayContaining(["sandbox", "create", "--name", backend.runtimeId]),
+      }),
+    ]);
+  });
+
+  it("removes runtimes using their stored sandbox name", async () => {
     cliMocks.runOpenShellCli.mockResolvedValue({
       code: 0,
       stdout: "",
@@ -369,9 +428,9 @@ describe("openshell backend manager", () => {
 
     await manager.removeRuntime({
       entry: {
-        containerName: "openclaw-session-5678",
+        containerName: "openclaw-session-5678-legacy-runtime-name",
         backendId: "openshell",
-        runtimeLabel: "openclaw-session-5678",
+        runtimeLabel: "openclaw-session-5678-legacy-runtime-name",
         sessionKey: "agent:main",
         createdAtMs: 1,
         lastUsedAtMs: 1,
@@ -387,10 +446,10 @@ describe("openshell backend manager", () => {
     });
     expect(cliMocks.runOpenShellCli).toHaveBeenCalledWith({
       context: {
-        sandboxName: "openclaw-session-5678",
+        sandboxName: "openclaw-session-5678-legacy-runtime-name",
         config: expectedConfig,
       },
-      args: ["sandbox", "delete", "openclaw-session-5678"],
+      args: ["sandbox", "delete", "openclaw-session-5678-legacy-runtime-name"],
     });
   });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users creating OpenShell-backed sandboxes can receive a rejected sandbox creation when a scope-derived name exceeds OpenShell's 19-character DNS-label limit.

## Why This Change Was Made

Generated names are now deterministic, DNS-safe, and bounded as `os-${slug3}-${sha256(normalizedScopeKey).slice(0, 12)}`. The three-character normalized slug preserves a human hint while the 48-bit SHA-256 suffix preserves practical uniqueness. This change intentionally adds no legacy lookup, adoption, migration, or compatibility behavior; legacy old-format sandbox reuse is unverified.

## User Impact

OpenShell sandbox creation uses a compact valid name for session, agent, and shared scopes, avoiding name-length rejection while retaining stable reuse for the same scope key.

## Evidence

- The production implementation derives from frozen candidate `172801d0aa75f14b481711950a3b1caf0673bd3d`; the only follow-up is the `Set.size` test assertion correction.
- `git diff --check origin/main...HEAD` passed.
- Focused backend-name test passed (11 tests), and `pnpm test:extension openshell` passed (69 tests).
- Repository autoreview completed clean with checksum-verified TruffleHog secret scanning.

AI-assisted: Yes — prepared with Codex.

Author confirmation: I understand the implementation: it generates compact deterministic names only for new OpenShell runtime IDs and continues to use each stored runtime name for describe/delete operations.



<!-- openshell-bounded-name-live-proof:start -->

## Real OpenShell behavior proof

Tested against a real OpenShell 0.0.91 gateway using the same
`extensions/openshell/src/backend.ts` implementation present in this PR.

### Source correspondence

- Runtime-tested candidate: `172801d0aa75f14b481711950a3b1caf0673bd3d`
- Public PR head: `ec54e092c23b1ef90324680e6e75b879eb8c363f`
- Candidate backend SHA-256: `c6233cd2ccb7303fd6eed11502168368e1af135ba642895d5b2c63f68b2f1c96`
- Public backend SHA-256: `c6233cd2ccb7303fd6eed11502168368e1af135ba642895d5b2c63f68b2f1c96`
- Backend implementation: **identical**
- Validation-record SHA-256: `e9e62ac6ad4be2f3077139bbf738b2c93b6ffe14e62f400728457a3a61235c91`

The only candidate-to-public difference among the four PR files is a test-only
correction from `expect(names).toHaveLength(3)` to
`expect(names.size).toBe(3)`.

### Real lifecycle result

- OpenShell version: `0.0.91`
- Fresh long scope generated: `os-ses-9ce14eaad894`
- Generated-name length: `19`
- Exactly one sandbox was created.
- Same-process reuse returned the existing sandbox.
- A persistence marker was written and read through the backend.
- A fresh backend process reused the same runtime name.
- The marker remained present after the fresh-process restart.
- Sandbox identity remained:
  `<redacted-stable-sandbox-id>`
- No duplicate sandbox was created.
- Cleanup removed only the canary sandbox.
- Repeated cleanup returned without error.
- Final inventory matched the baseline except for the gateway-managed
  resource-version counter.
- The pre-existing sandbox was not accessed, modified, or deleted.

### Compatibility boundary

This proves bounded-name creation, deterministic reuse, fresh-process reuse,
marker persistence, stable sandbox identity, and cleanup.

It does not claim migration or adoption of sandbox identities created using
the previous naming algorithm. Maintainer direction is requested on whether
that historical identity transition is required for this narrow provider-limit
fix or should be treated as an explicit compatibility break.

### Upstream OpenShell compatibility context

The upstream OpenShell workspace change that introduced the 19-character
sandbox-name limit also documented pre-existing resource re-creation as an
intentional pre-GA compatibility break:

- NVIDIA/OpenShell#2243
- https://github.com/NVIDIA/OpenShell/pull/2243

This PR does not claim automatic adoption or migration of names generated by
the previous OpenClaw algorithm. Maintainer direction is requested on whether
that historical identity transition must be implemented here or whether the
upstream pre-GA compatibility break is acceptable for this narrowly scoped
provider-limit correction.

<!-- openshell-bounded-name-live-proof:end -->
