### PR TITLE
fix(agents): route Codex budget compaction natively

### DIFF
--- a/extensions/codex/src/app-server/compact.test.ts
+++ b/extensions/codex/src/app-server/compact.test.ts
@@ -381,7 +381,7 @@ describe("maybeCompactCodexAppServerSession", () => {
     });
   });
 
-  it("starts native app-server compaction for post-context-engine budget requests", async () => {
+  it("resumes the bound thread before post-context-engine budget compaction", async () => {
     const fake = createFakeCodexClient();
     setCodexAppServerClientFactoryForTest(async () => fake.client);
     const sessionFile = await writeTestBinding({
@@ -417,6 +417,11 @@ describe("maybeCompactCodexAppServerSession", () => {
       { threadId: "thread-1" },
       { timeoutMs: 60_000 },
     );
+    expect(fake.request.mock.calls.map(([method]) => method)).toEqual([
+      "thread/resume",
+      "thread/compact/start",
+      "thread/unsubscribe",
+    ]);
     expect(result.ok).toBe(true);
     expect(result.compacted).toBe(true);
     expect(result.reason).toBeUndefined();
@@ -489,6 +494,61 @@ describe("maybeCompactCodexAppServerSession", () => {
       trigger: "budget",
       expectedThreadId: "thread-1",
       currentThreadId: "thread-1",
+    });
+    expect(await readCodexAppServerBinding(sessionFile)).toMatchObject({
+      threadId: "thread-1",
+      contextEngine: {
+        projection: {
+          epoch: "epoch-1",
+          fingerprint: "fingerprint-1",
+        },
+      },
+    });
+  });
+
+  it("preserves projection when the post-run thread cannot be resumed", async () => {
+    const fake = createFakeCodexClient();
+    fake.request.mockRejectedValueOnce(
+      new CodexAppServerRpcError(
+        { code: -32_600, message: "thread not found: thread-1" },
+        "thread/resume",
+      ),
+    );
+    setCodexAppServerClientFactoryForTest(async () => fake.client);
+    const sessionFile = await writeTestBinding({
+      contextEngine: {
+        schemaVersion: 1,
+        engineId: "lossless-claw",
+        policyFingerprint: "policy-1",
+        projection: {
+          schemaVersion: 1,
+          mode: "thread_bootstrap",
+          epoch: "epoch-1",
+          fingerprint: "fingerprint-1",
+        },
+      },
+    });
+
+    const result = requireCompactResult(
+      await maybeCompactCodexAppServerSession(
+        {
+          sessionId: "session-1",
+          sessionKey: "agent:main:session-1",
+          sessionFile,
+          workspaceDir: tempDir,
+          trigger: "budget",
+          currentTokenCount: 456,
+        },
+        { allowNonManualNativeRequest: true },
+      ),
+    );
+
+    expect(fake.request.mock.calls.map(([method]) => method)).toEqual(["thread/resume"]);
+    expect(result).toMatchObject({
+      ok: false,
+      compacted: false,
+      reason: "thread not found: thread-1",
+      failure: { reason: "stale_thread_binding" },
     });
     expect(await readCodexAppServerBinding(sessionFile)).toMatchObject({
       threadId: "thread-1",
@@ -588,7 +648,13 @@ describe("maybeCompactCodexAppServerSession", () => {
     let externalWriteStarted = false;
     let externalWriteFinished = false;
     const fake = createFakeCodexClient();
-    fake.request.mockImplementation(async () => {
+    fake.request.mockImplementation(async (method, params) => {
+      if (method === "thread/resume") {
+        return codexThreadResumeResult((params as { threadId: string }).threadId);
+      }
+      if (method === "thread/unsubscribe") {
+        return {};
+      }
       const response = await expectExternalMutationBlockedDuringNativeRequest({
         releaseExternalMutation: releaseExternalWrite,
         isExternalMutationStarted: () => externalWriteStarted,
@@ -672,7 +738,13 @@ describe("maybeCompactCodexAppServerSession", () => {
     let externalClearStarted = false;
     let externalClearFinished = false;
     const fake = createFakeCodexClient();
-    fake.request.mockImplementation(async () => {
+    fake.request.mockImplementation(async (method, params) => {
+      if (method === "thread/resume") {
+        return codexThreadResumeResult((params as { threadId: string }).threadId);
+      }
+      if (method === "thread/unsubscribe") {
+        return {};
+      }
       const response = await expectExternalMutationBlockedDuringNativeRequest({
         releaseExternalMutation: releaseExternalClear,
         isExternalMutationStarted: () => externalClearStarted,
@@ -1479,8 +1551,9 @@ describe("maybeCompactCodexAppServerSession", () => {
   });
 
   it("detaches a guarded remote start after releasing the binding lock", async () => {
-    const fake = createFakeCodexClient();
-    fake.request.mockRejectedValueOnce(new Error("thread/compact/start timed out"));
+    const fake = createFakeCodexClient({
+      compactStartError: new Error("thread/compact/start timed out"),
+    });
     fake.closeAndWait.mockResolvedValueOnce(false);
     const sessionFile = await writeTestBinding();
 
@@ -1896,9 +1969,45 @@ describe("maybeCompactCodexAppServerSession", () => {
   });
 });
 
+function codexThreadResumeResult(threadId: string) {
+  return {
+    thread: {
+      id: threadId,
+      sessionId: "session-1",
+      forkedFromId: null,
+      preview: "",
+      ephemeral: false,
+      modelProvider: "openai",
+      createdAt: 1,
+      updatedAt: 1,
+      status: { type: "idle" },
+      path: null,
+      cwd: tempDir,
+      cliVersion: "0.139.0",
+      source: "unknown",
+      agentNickname: null,
+      agentRole: null,
+      gitInfo: null,
+      name: null,
+      turns: [],
+    },
+    model: "gpt-5.5-codex",
+    modelProvider: "openai",
+    serviceTier: null,
+    cwd: tempDir,
+    instructionSources: [],
+    approvalPolicy: "never",
+    approvalsReviewer: "user",
+    sandbox: { type: "dangerFullAccess" },
+    permissionProfile: null,
+    reasoningEffort: null,
+  };
+}
+
 function createFakeCodexClient(
   options: {
     autoCompleteCompaction?: boolean;
+    compactStartError?: Error;
     interruptError?: Error;
     rejectInterrupt?: boolean;
   } = {},
@@ -1951,11 +2060,17 @@ function createFakeCodexClient(
   };
   const request = vi.fn<CodexAppServerClient["request"]>(
     async (method: string, params?: unknown) => {
+      if (method === "thread/resume") {
+        return codexThreadResumeResult((params as { threadId: string }).threadId);
+      }
       if (method === "turn/interrupt" && options.interruptError) {
         throw options.interruptError;
       }
       if (method === "turn/interrupt" && options.rejectInterrupt) {
         throw new Error("interrupt unavailable");
+      }
+      if (method === "thread/compact/start" && options.compactStartError) {
+        throw options.compactStartError;
       }
       if (method === "thread/compact/start" && options.autoCompleteCompaction !== false) {
         const threadId = (params as { threadId?: unknown }).threadId;

--- a/extensions/codex/src/app-server/compact.ts
+++ b/extensions/codex/src/app-server/compact.ts
@@ -8,6 +8,11 @@ import {
   type EmbeddedAgentCompactResult,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { resolveAgentDir, resolveDefaultAgentId } from "openclaw/plugin-sdk/agent-runtime";
+import {
+  closeCodexStartupClientBestEffort,
+  CODEX_APP_SERVER_UNSUBSCRIBE_TIMEOUT_MS,
+  unsubscribeCodexThreadBestEffort,
+} from "./attempt-client-cleanup.js";
 import { readCodexNotificationItem } from "./attempt-notifications.js";
 import { resolveCodexBindingAppServerConnection } from "./binding-connection.js";
 import { CodexAppServerRpcError, type CodexAppServerClient } from "./client.js";
@@ -29,6 +34,7 @@ import {
   releaseLeasedSharedCodexAppServerClient,
   type CodexAppServerClientFactory,
 } from "./shared-client.js";
+import { resumeCodexAppServerThread } from "./thread-resume.js";
 
 const warnedIgnoredCompactionOverrides = new Set<string>();
 const codexNativeCompactionQueues = new Map<string, Promise<void>>();
@@ -581,6 +587,7 @@ async function compactCodexNativeThread(
           agentDir: params.agentDir,
           config: params.config,
         });
+        let subscribedForPostRunCompaction = false;
         const completionWatch = watchCodexNativeCompactionCompletion({
           client,
           threadId: binding.threadId,
@@ -682,6 +689,36 @@ async function compactCodexNativeThread(
                   };
                 }
                 binding = currentBinding;
+                try {
+                  // One-shot runs retire their app-server before post-run budget
+                  // checks, so restore the persisted thread on this leased client.
+                  await resumeCodexAppServerThread({
+                    client,
+                    abandonClient: () => closeCodexStartupClientBestEffort(client),
+                    request: {
+                      threadId: binding.threadId,
+                      excludeTurns: true,
+                      initialTurnsPage: {
+                        limit: 1,
+                        sortDirection: "desc",
+                        itemsView: "notLoaded",
+                      },
+                    },
+                    timeoutMs: Math.min(
+                      appServer.requestTimeoutMs,
+                      CODEX_APP_SERVER_BINDING_GUARDED_REQUEST_TIMEOUT_MS,
+                    ),
+                    ...(params.abortSignal ? { signal: params.abortSignal } : {}),
+                  });
+                  subscribedForPostRunCompaction = true;
+                } catch (error) {
+                  return {
+                    started: true as const,
+                    accepted: false as const,
+                    requestStarted: false as const,
+                    error,
+                  };
+                }
                 await clearContextEngineProjectionBeforeNativeCompaction({
                   sessionId: params.sessionId,
                   bindingStore: options.bindingStore,
@@ -695,7 +732,11 @@ async function compactCodexNativeThread(
                       CODEX_APP_SERVER_BINDING_GUARDED_REQUEST_TIMEOUT_MS,
                     ),
                   );
-                  return { started: true as const, accepted: true as const };
+                  return {
+                    started: true as const,
+                    accepted: true as const,
+                    requestStarted: true as const,
+                  };
                 } catch (error) {
                   await options.bindingStore.mutate(bindingIdentity, {
                     kind: "set",
@@ -703,7 +744,12 @@ async function compactCodexNativeThread(
                   });
                   // Retire outside the binding lock: remote detach acquires this
                   // same lock and would otherwise deadlock the failure path.
-                  return { started: true as const, accepted: false as const, error };
+                  return {
+                    started: true as const,
+                    accepted: false as const,
+                    requestStarted: true as const,
+                    error,
+                  };
                 }
               },
             );
@@ -711,7 +757,9 @@ async function compactCodexNativeThread(
               return guardedResult.result;
             }
             if (!guardedResult.accepted) {
-              await settleNativeCompactionRequestError(guardedResult.error);
+              if (guardedResult.requestStarted) {
+                await settleNativeCompactionRequestError(guardedResult.error);
+              }
               throw guardedResult.error;
             }
           } else {
@@ -756,6 +804,25 @@ async function compactCodexNativeThread(
           };
         } finally {
           completionWatch.cancel();
+          if (subscribedForPostRunCompaction) {
+            const unsubscribed = await unsubscribeCodexThreadBestEffort(client, {
+              threadId: binding.threadId,
+              timeoutMs: CODEX_APP_SERVER_UNSUBSCRIBE_TIMEOUT_MS,
+            });
+            if (!unsubscribed) {
+              try {
+                await closeCodexStartupClientBestEffort(client);
+              } catch (error) {
+                embeddedAgentLog.warn(
+                  "failed to retire codex app-server after compaction unsubscribe failure",
+                  {
+                    threadId: binding.threadId,
+                    reason: formatCompactionError(error),
+                  },
+                );
+              }
+            }
+          }
           if (shouldReleaseDefaultLease) {
             releaseLeasedSharedCodexAppServerClient(client);
           }

--- a/src/agents/command/cli-compaction.test.ts
+++ b/src/agents/command/cli-compaction.test.ts
@@ -804,7 +804,7 @@ describe("runCliTurnCompactionLifecycle", () => {
     expect(recordCliCompactionInStore).not.toHaveBeenCalled();
   });
 
-  it("falls back to context-engine compaction when Codex owns automatic compaction", async () => {
+  it("uses Codex native automatic compaction before context-engine fallback", async () => {
     const sessionKey = "agent:main:codex-native-auto-compaction";
     const sessionId = "session-codex-native-auto-compaction";
     const sessionFile = path.join(tmpDir, "session-codex-native-auto-compaction.jsonl");
@@ -825,16 +825,21 @@ describe("runCliTurnCompactionLifecycle", () => {
 
     const compactCalls: Array<Parameters<ContextEngine["compact"]>[0]> = [];
     const maintenance = vi.fn(async () => ({ changed: false, bytesFreed: 0, rewrittenEntries: 0 }));
-    const compactAgentHarnessSession = vi.fn(async (_params: Record<string, unknown>) => ({
-      ok: true,
-      compacted: false,
-      reason: "codex app-server owns automatic compaction",
-      result: {
-        summary: "",
-        firstKeptEntryId: "",
-        tokensBefore: 950,
+    const compactAgentHarnessSession = vi.fn(
+      async (_params: Record<string, unknown>, options?: { nativeCompactionRequest?: string }) => {
+        expect(options).toEqual({ nativeCompactionRequest: "after_context_engine" });
+        return {
+          ok: true,
+          compacted: true,
+          result: {
+            summary: "",
+            firstKeptEntryId: "",
+            tokensBefore: 950,
+            tokensAfter: 100,
+          },
+        };
       },
-    }));
+    );
     const recordCliCompactionInStore = vi.fn(async () => ({
       ...sessionEntry,
       compactionCount: 1,
@@ -877,11 +882,8 @@ describe("runCliTurnCompactionLifecycle", () => {
     });
 
     expect(compactAgentHarnessSession).toHaveBeenCalledTimes(1);
-    expect(compactCalls).toHaveLength(1);
-    expect(compactCalls[0]?.sessionId).toBe(sessionId);
-    expect(compactCalls[0]?.sessionKey).toBe(sessionKey);
-    expect(compactCalls[0]?.currentTokenCount).toBe(950);
-    expect(maintenance).toHaveBeenCalledTimes(1);
+    expect(compactCalls).toHaveLength(0);
+    expect(maintenance).not.toHaveBeenCalled();
     expect(recordCliCompactionInStore).toHaveBeenCalledWith(
       expect.objectContaining({
         provider: "codex",
@@ -908,9 +910,9 @@ describe("runCliTurnCompactionLifecycle", () => {
     });
 
     expect(compactAgentHarnessSession).toHaveBeenCalledTimes(2);
-    expect(compactCalls).toHaveLength(1);
-    expect(maintenance).toHaveBeenCalledTimes(1);
-    expect(recordCliCompactionInStore).toHaveBeenCalledTimes(1);
+    expect(compactCalls).toHaveLength(0);
+    expect(maintenance).not.toHaveBeenCalled();
+    expect(recordCliCompactionInStore).toHaveBeenCalledTimes(2);
     const lockedNativeCall = compactAgentHarnessSession.mock.calls[1]?.[0];
     expect(lockedNativeCall).toMatchObject({
       agentHarnessId: "codex",
@@ -922,7 +924,7 @@ describe("runCliTurnCompactionLifecycle", () => {
         model: "gpt-5.5",
       }),
     });
-    expect(lockedResult).toBe(lockedEntry);
+    expect(lockedResult?.compactionCount).toBe(1);
   });
 
   it("does not fall back when native harness compaction returns no result", async () => {

--- a/src/agents/command/cli-compaction.test.ts
+++ b/src/agents/command/cli-compaction.test.ts
@@ -827,6 +827,7 @@ describe("runCliTurnCompactionLifecycle", () => {
     const maintenance = vi.fn(async () => ({ changed: false, bytesFreed: 0, rewrittenEntries: 0 }));
     const compactAgentHarnessSession = vi.fn(
       async (_params: Record<string, unknown>, options?: { nativeCompactionRequest?: string }) => {
+        expect(_params).not.toHaveProperty("abortSignal");
         expect(options).toEqual({ nativeCompactionRequest: "after_context_engine" });
         return {
           ok: true,
@@ -868,7 +869,7 @@ describe("runCliTurnCompactionLifecycle", () => {
     });
 
     const result = await runCliTurnCompactionLifecycle({
-      cfg: {} as OpenClawConfig,
+      cfg: { agents: { defaults: { compaction: { timeoutSeconds: 1 } } } } as OpenClawConfig,
       sessionId,
       sessionKey,
       sessionEntry,
@@ -896,7 +897,7 @@ describe("runCliTurnCompactionLifecycle", () => {
     const lockedEntry: SessionEntry = { ...sessionEntry, modelSelectionLocked: true };
     sessionStore[sessionKey] = lockedEntry;
     const lockedResult = await runCliTurnCompactionLifecycle({
-      cfg: {} as OpenClawConfig,
+      cfg: { agents: { defaults: { compaction: { timeoutSeconds: 1 } } } } as OpenClawConfig,
       sessionId,
       sessionKey,
       sessionEntry: lockedEntry,

--- a/src/agents/command/cli-compaction.ts
+++ b/src/agents/command/cli-compaction.ts
@@ -473,6 +473,15 @@ async function compactNativeHarnessCliTranscript(params: {
     const nativeHarnessId = params.sessionEntry.agentHarnessId?.trim();
     const modelSelectionLocked = params.sessionEntry.modelSelectionLocked === true;
     const authProfileId = params.sessionEntry.authProfileOverride?.trim() || undefined;
+    const compactHarnessSession = (
+      request: Parameters<typeof cliCompactionDeps.maybeCompactAgentHarnessSession>[0],
+    ) =>
+      cliCompactionDeps.maybeCompactAgentHarnessSession(
+        request,
+        normalizeOptionalAgentRuntimeId(nativeHarnessId) === "codex"
+          ? { nativeCompactionRequest: "after_context_engine" }
+          : undefined,
+      );
     await cliCompactionDeps.ensureSelectedAgentHarnessPlugin({
       provider: params.provider,
       modelId: params.model,
@@ -484,7 +493,7 @@ async function compactNativeHarnessCliTranscript(params: {
     });
     result = await compactWithSafetyTimeout(
       (abortSignal) =>
-        cliCompactionDeps.maybeCompactAgentHarnessSession({
+        compactHarnessSession({
           sessionId: params.sessionId,
           sessionKey: params.sessionKey,
           sessionFile: params.sessionFile,

--- a/src/agents/command/cli-compaction.ts
+++ b/src/agents/command/cli-compaction.ts
@@ -473,14 +473,13 @@ async function compactNativeHarnessCliTranscript(params: {
     const nativeHarnessId = params.sessionEntry.agentHarnessId?.trim();
     const modelSelectionLocked = params.sessionEntry.modelSelectionLocked === true;
     const authProfileId = params.sessionEntry.authProfileOverride?.trim() || undefined;
+    const usesCodexNativeCompaction = normalizeOptionalAgentRuntimeId(nativeHarnessId) === "codex";
     const compactHarnessSession = (
       request: Parameters<typeof cliCompactionDeps.maybeCompactAgentHarnessSession>[0],
     ) =>
       cliCompactionDeps.maybeCompactAgentHarnessSession(
         request,
-        normalizeOptionalAgentRuntimeId(nativeHarnessId) === "codex"
-          ? { nativeCompactionRequest: "after_context_engine" }
-          : undefined,
+        usesCodexNativeCompaction ? { nativeCompactionRequest: "after_context_engine" } : undefined,
       );
     await cliCompactionDeps.ensureSelectedAgentHarnessPlugin({
       provider: params.provider,
@@ -491,62 +490,67 @@ async function compactNativeHarnessCliTranscript(params: {
       ...(sessionAgentId ? { agentId: sessionAgentId } : {}),
       ...(nativeHarnessId ? { agentHarnessRuntimeOverride: nativeHarnessId } : {}),
     });
-    result = await compactWithSafetyTimeout(
-      (abortSignal) =>
-        compactHarnessSession({
-          sessionId: params.sessionId,
-          sessionKey: params.sessionKey,
-          sessionFile: params.sessionFile,
-          workspaceDir: params.workspaceDir,
-          cwd: params.cwd,
-          agentDir: params.agentDir,
-          config: params.cfg,
-          skillsSnapshot: params.skillsSnapshot,
-          provider: params.provider,
-          model: params.model,
-          authProfileId,
-          contextTokenBudget: params.contextTokenBudget,
-          currentTokenCount: params.currentTokenCount,
-          trigger: "budget",
-          force: true,
-          messageChannel: params.messageChannel,
-          agentAccountId: params.agentAccountId,
-          senderIsOwner: params.senderIsOwner,
-          thinkLevel: params.thinkLevel,
-          extraSystemPrompt: params.extraSystemPrompt,
-          modelSelectionLocked,
-          allowGatewaySubagentBinding: true,
-          ...(params.contextEngine
-            ? {
-                contextEngine: params.contextEngine,
-                contextEngineRuntimeContext: buildCliCompactionRuntimeContext({
-                  sessionKey: params.sessionKey,
-                  messageChannel: params.messageChannel,
-                  agentAccountId: params.agentAccountId,
-                  authProfileId,
-                  workspaceDir: params.workspaceDir,
-                  cwd: params.cwd,
-                  agentDir: params.agentDir,
-                  cfg: params.cfg,
-                  skillsSnapshot: params.skillsSnapshot,
-                  senderIsOwner: params.senderIsOwner,
-                  provider: params.provider,
-                  model: params.model,
-                  harnessRuntime: nativeHarnessId,
-                  modelSelectionLocked,
-                  thinkLevel: params.thinkLevel,
-                  extraSystemPrompt: params.extraSystemPrompt,
-                  currentTokenCount: params.currentTokenCount,
-                  contextTokenBudget: params.contextTokenBudget,
-                  trigger: "cli_native_budget",
-                }),
-              }
-            : {}),
-          ...(nativeHarnessId ? { agentHarnessId: nativeHarnessId } : {}),
-          ...(abortSignal ? { abortSignal } : {}),
-        }),
-      resolveCompactionTimeoutMs(params.cfg),
-    );
+    const runHarnessCompaction = (abortSignal?: AbortSignal) =>
+      compactHarnessSession({
+        sessionId: params.sessionId,
+        sessionKey: params.sessionKey,
+        sessionFile: params.sessionFile,
+        workspaceDir: params.workspaceDir,
+        cwd: params.cwd,
+        agentDir: params.agentDir,
+        config: params.cfg,
+        skillsSnapshot: params.skillsSnapshot,
+        provider: params.provider,
+        model: params.model,
+        authProfileId,
+        contextTokenBudget: params.contextTokenBudget,
+        currentTokenCount: params.currentTokenCount,
+        trigger: "budget",
+        force: true,
+        messageChannel: params.messageChannel,
+        agentAccountId: params.agentAccountId,
+        senderIsOwner: params.senderIsOwner,
+        thinkLevel: params.thinkLevel,
+        extraSystemPrompt: params.extraSystemPrompt,
+        modelSelectionLocked,
+        allowGatewaySubagentBinding: true,
+        ...(params.contextEngine
+          ? {
+              contextEngine: params.contextEngine,
+              contextEngineRuntimeContext: buildCliCompactionRuntimeContext({
+                sessionKey: params.sessionKey,
+                messageChannel: params.messageChannel,
+                agentAccountId: params.agentAccountId,
+                authProfileId,
+                workspaceDir: params.workspaceDir,
+                cwd: params.cwd,
+                agentDir: params.agentDir,
+                cfg: params.cfg,
+                skillsSnapshot: params.skillsSnapshot,
+                senderIsOwner: params.senderIsOwner,
+                provider: params.provider,
+                model: params.model,
+                harnessRuntime: nativeHarnessId,
+                modelSelectionLocked,
+                thinkLevel: params.thinkLevel,
+                extraSystemPrompt: params.extraSystemPrompt,
+                currentTokenCount: params.currentTokenCount,
+                contextTokenBudget: params.contextTokenBudget,
+                trigger: "cli_native_budget",
+              }),
+            }
+          : {}),
+        ...(nativeHarnessId ? { agentHarnessId: nativeHarnessId } : {}),
+        ...(abortSignal ? { abortSignal } : {}),
+      });
+    // Codex owns the terminal-event watchdog for this asynchronous request.
+    // Keep transcript ownership until the native bridge has fully settled.
+    result = usesCodexNativeCompaction
+      ? await runHarnessCompaction()
+      : await compactWithSafetyTimeout(
+          (abortSignal) => runHarnessCompaction(abortSignal),
+          resolveCompactionTimeoutMs(params.cfg),
+        );
   } catch (error) {
     log.warn(
       `CLI native harness compaction failed for ${params.provider}/${params.model}: ${error instanceof Error ? error.message : String(error)}`,


### PR DESCRIPTION
Closes #114155

## What Problem This Solves

Budget-triggered compaction for Codex OAuth sessions called the ordinary native harness hook. Codex correctly reported that its app-server owns automatic compaction, but the CLI lifecycle then fell back to API-key-backed context-engine compaction. OAuth-only sessions could therefore fail with `No API key found for provider "openai"` after a successful turn.

## Why This Change Was Made

Codex already exposes a private native compaction request that permits non-manual `thread/compact/start` on the authenticated app-server connection. The CLI budget path now selects that existing request only when the pinned harness is Codex. Post-run compaction resumes the persisted thread on the newly leased app-server client before starting compaction, then unsubscribes after terminal completion.

This restores the native OAuth compaction contract established by #95831 without adding configuration or changing public APIs. Codex retains its terminal-event watchdog and transcript ownership until native compaction settles; other harnesses retain the existing outer timeout and fallback behavior.

## User Impact

Codex OAuth-only sessions can perform budget maintenance without requiring a separate OpenAI API key or turning a completed response into a failed run. The lifecycle removes the direct context-engine fallback for Codex-owned automatic compaction.

## Evidence

Current-head real behavior proof used GitHub CI's `dist-runtime-build` artifact for merge commit `11f1bf65369dee35bde860f2932e1f271bf6a8a9`, whose parents are current `main` (`c66ca2fbb2b038f4796abfa76bd52dcc3b675b02`) and branch head `850c9fa7b09216222b444f1d4aa104118e124e35`.

A real loopback Gateway ran one Codex session with a deliberately small 4,000-token context budget and a dense prompt. `OPENAI_API_KEY` and `OPENAI_BASE_URL` were both unset; runtime logs confirmed external CLI OAuth bootstrap.

Redacted observed result:

```text
artifact merge head: 11f1bf65369d
branch head:         850c9fa7b092
OpenAI API key:      absent
OpenAI base URL:     absent
agent status:        ok
completion marker:   matched
elapsed:             15s
one-shot cleanup:    observed before post-run compaction
native compact start:    1
native compact complete: 1
thread-not-found errors: 0
context-engine fallback: 0
native fallback warnings: 0
```

The completed answer remained successful while the persisted Codex thread was resumed and compacted natively after one-shot app-server cleanup.

## Validation

- `node_modules/.bin/vitest run src/agents/command/cli-compaction.test.ts extensions/codex/src/app-server/compact.test.ts --maxWorkers=2` -> 3 loaded files, 85 tests passed.
- Focused measurement -> 3/3 contracts passed; native compaction success `0 -> 1`, context-engine compaction and maintenance calls `1 -> 0`.
- Changed-file `oxfmt`, `oxlint`, and `git diff --check` -> passed.
- `codex review --base upstream/main` -> no actionable findings; independently confirmed `thread/resume -> thread/compact/start -> thread/unsubscribe` against the Codex protocol.
- GitHub CI broad checks remain authoritative for repository-wide validation.

AI-assisted: yes. I traced the CLI budget lifecycle, reproduced the OAuth-only product path, found the one-shot app-server lifecycle gap, added focused lifecycle and stale-binding tests, and reviewed the final diff.

Signed-off-by: Ho Lim <subhoya@gmail.com>
