### PR TITLE
fix(memory): avoid rebuilding the index after empty searches

### DIFF
--- a/extensions/memory-core/src/tools.test.ts
+++ b/extensions/memory-core/src/tools.test.ts
@@ -520,23 +520,11 @@ describe("memory_search unavailable payloads", () => {
     expect(getMemoryCloseMockCalls()).toBe(1);
   });
 
-  it("forces a sync and retries once when the first search has zero hits", async () => {
+  it("returns a zero-hit search without tool-owned sync or retry", async () => {
     let searchCalls = 0;
     setMemorySearchImpl(async () => {
       searchCalls += 1;
-      if (searchCalls === 1) {
-        return [];
-      }
-      return [
-        {
-          path: "MEMORY.md",
-          startLine: 1,
-          endLine: 1,
-          score: 0.9,
-          snippet: "Thread-hidden codename: ORBIT-22.",
-          source: "memory" as const,
-        },
-      ];
+      return [];
     });
 
     const tool = createMemorySearchToolOrThrow({
@@ -547,13 +535,12 @@ describe("memory_search unavailable payloads", () => {
     });
     const result = await tool.execute("zero-hit-retry", { query: "hidden thread codename" });
 
-    expect((result.details as { results?: Array<{ path: string }> }).results?.[0]?.path).toBe(
-      "MEMORY.md",
-    );
-    expect(searchCalls).toBe(2);
+    expect((result.details as { results?: unknown[] }).results).toEqual([]);
+    expect(searchCalls).toBe(1);
+    expect(getMemorySyncMockCalls()).toBe(0);
   });
 
-  it("qualifies empty results when the index remains dirty after retry", async () => {
+  it("qualifies empty results when the manager reports a dirty index", async () => {
     setMemoryStatusDirty(true);
     setMemorySearchImpl(async () => []);
     const tool = createMemorySearchToolOrThrow({
@@ -571,7 +558,7 @@ describe("memory_search unavailable payloads", () => {
       warning: "Memory index is dirty. Search results may be incomplete.",
       action: "Run: openclaw memory status --index --agent main",
     });
-    expect(getMemorySyncMockCalls()).toBe(1);
+    expect(getMemorySyncMockCalls()).toBe(0);
   });
 
   it("surfaces embedding bootstrap degradation when keyword search has no hits", async () => {

--- a/extensions/memory-core/src/tools.ts
+++ b/extensions/memory-core/src/tools.ts
@@ -631,25 +631,6 @@ export function createMemorySearchTool(options: {
                 if (pausedIndexIdentityReason) {
                   return;
                 }
-                // Retry once after an empty result so the builtin index can finish bootstrap.
-                if (
-                  rawResults.length === 0 &&
-                  !runtimeDebug.some((entry) => entry.embeddingBootstrap) &&
-                  activeMemory.manager.sync
-                ) {
-                  await runWithDefaultDeadline(async () => {
-                    // Sync may join shared/background manager maintenance and has
-                    // no request-cancellation contract. Bound only this tool's wait.
-                    await activeMemory.manager.sync?.({ reason: "search", force: true });
-                  });
-                  rawResults = await searchActiveMemory();
-                  pausedIndexIdentityReason = resolvePausedMemoryIndexIdentityReason(
-                    activeMemory.manager.status(),
-                  );
-                  if (pausedIndexIdentityReason) {
-                    return;
-                  }
-                }
                 rawResults = await runWithDefaultDeadline(
                   async () =>
                     await filterMemorySearchHitsBySessionVisibility({


### PR DESCRIPTION
## Summary

- remove the `memory_search` tool's zero-hit forced sync and retry
- leave empty-index bootstrap, dirty-index on-search sync, and watcher freshness with `MemoryIndexManager`
- keep the broader dirty-index contract in #112196 out of this repair

## Root cause and owner

After a legitimate builtin-backend miss, the tool called `sync({ reason: "search", force: true })` and searched again. A forced sync without target files selects a full shadow reindex, so an ordinary miss could rebuild every memory and session file, exceed the tool timeout, and arm the cooldown.

The manager already owns this lifecycle: it force-bootstraps an empty index before querying, performs an unforced dirty sync when `sync.onSearch` is enabled, and uses the watcher for later file visibility. The canonical fix is therefore deletion of the duplicate tool-owned sync/retry path.

## Scope and delta

- production: `+0/-19`
- tests: `+7/-20`
- changed files: `extensions/memory-core/src/tools.ts`, `extensions/memory-core/src/tools.test.ts`
- no config, storage, schema, provider, plugin API, dependency, or changelog changes

## Red/green proof

- red control with the new expectations against the old production path: 2 failures (`2` searches instead of `1`; `1` tool sync instead of `0`)
- fixed focused tests: 42/42 passed across the tool and manager async-search suites
- redacted real SQLite corpus, 500 files:
  - first legitimate miss: 4 ms
  - immediate repeated miss: 1 ms
  - clean unforced sync: 0 ms
  - forced full-reindex control: 439 ms
  - new-file visibility through watcher/on-search: 40 ms
  - normal-path full reindexes: 0
  - forced-control full reindexes: 1
- hosted changed-check/Testbox: passed, run 31444838494
- P1 autoreview: no actionable findings
- exact-patch local Claw review: 1 feature, 0 findings (`20260811T004208-d325be`)

## Alternatives and provenance

Keeping an unforced tool retry would still duplicate manager ownership and add a second search. Expanding the dirty-index contract belongs in #112196 and is intentionally excluded.

The retry originated in #95757 / `2725742cad4` and became builtin-only after QMD removal in #120936 / `8b0735e89f2`. This rewrite preserves contributor credit for @RowanZhong while rebuilding the fix on current `main`.

Punchcard-Session: cobalt-orchard-willow-ps
Punchcard-Attestation: att_01KZQ4JSAKVD3FYEN05DB1K6RG
