### PR TITLE
fix: delegated subagents honor per-call timeouts

### DIFF
--- a/docs/tools/acp-agents-setup.md
+++ b/docs/tools/acp-agents-setup.md
@@ -264,9 +264,10 @@ openclaw config set plugins.entries.acpx.config.timeoutSeconds 180
 ```
 
 Runtime turns use OpenClaw agent/run timeouts, including `/acp timeout`.
-`sessions_spawn` does not accept per-call timeout overrides; the operator path
-is `agents.defaults.subagents.runTimeoutSeconds`. Restart the gateway after
-changing `timeoutSeconds`.
+`sessions_spawn.timeoutSeconds` overrides
+`agents.defaults.subagents.runTimeoutSeconds` for one spawned run. When the
+task declares `HANDOFF_TIMEOUT_SECONDS`, the per-call value is required and
+must match it.
 
 ### Health probe agent configuration
 

--- a/docs/tools/acp-agents-setup.md
+++ b/docs/tools/acp-agents-setup.md
@@ -265,9 +265,7 @@ openclaw config set plugins.entries.acpx.config.timeoutSeconds 180
 
 Runtime turns use OpenClaw agent/run timeouts, including `/acp timeout`.
 `sessions_spawn.timeoutSeconds` overrides
-`agents.defaults.subagents.runTimeoutSeconds` for one spawned run. When the
-task declares `HANDOFF_TIMEOUT_SECONDS`, the per-call value is required and
-must match it.
+`agents.defaults.subagents.runTimeoutSeconds` for one spawned run.
 
 ### Health probe agent configuration
 

--- a/docs/tools/acp-agents.md
+++ b/docs/tools/acp-agents.md
@@ -540,6 +540,12 @@ Two ways to start an ACP session:
 <ParamField path="label" type="string">
   Operator-facing label used in session/banner text.
 </ParamField>
+<ParamField path="timeoutSeconds" type="number">
+  Child run timeout in seconds for this spawn. Overrides
+  `agents.defaults.subagents.runTimeoutSeconds`. If the task declares
+  `HANDOFF_TIMEOUT_SECONDS`, this value is required and must match it. Range:
+  `0` to `2147000` seconds.
+</ParamField>
 <ParamField path="resumeSessionId" type="string">
   Resume an existing ACP session instead of creating a new one. The agent
   replays its conversation history via `session/load`. Requires
@@ -557,9 +563,7 @@ Two ways to start an ACP session:
 </ParamField>
 
 ACP `sessions_spawn` runs use `agents.defaults.subagents.runTimeoutSeconds`
-for their default child turn limit. The tool does not accept per-call
-timeout overrides (`runTimeoutSeconds`/`timeoutSeconds` are rejected with a
-config-the-default error).
+for their default child turn limit when `timeoutSeconds` is omitted.
 
 <ParamField path="model" type="string">
   Explicit model override for the ACP child session. Codex ACP spawns

--- a/docs/tools/acp-agents.md
+++ b/docs/tools/acp-agents.md
@@ -542,9 +542,8 @@ Two ways to start an ACP session:
 </ParamField>
 <ParamField path="timeoutSeconds" type="number">
   Child run timeout in seconds for this spawn. Overrides
-  `agents.defaults.subagents.runTimeoutSeconds`. If the task declares
-  `HANDOFF_TIMEOUT_SECONDS`, this value is required and must match it. Range:
-  `0` to `2147000` seconds.
+  `agents.defaults.subagents.runTimeoutSeconds`. Range: `0` to `2147000`
+  seconds.
 </ParamField>
 <ParamField path="resumeSessionId" type="string">
   Resume an existing ACP session instead of creating a new one. The agent

--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -147,7 +147,7 @@ session to confirm the effective tool list.
 
 - **Model:** native sub-agents inherit the caller unless you set `agents.defaults.subagents.model` (or per-agent `agents.entries.*.subagents.model`). ACP runtime spawns use the same configured subagent model when present; otherwise the ACP harness keeps its own default. An explicit `sessions_spawn.model` still wins.
 - **Thinking:** native sub-agents inherit the caller unless you set `agents.defaults.subagents.thinking` (or per-agent `agents.entries.*.subagents.thinking`). ACP runtime spawns also apply `agents.defaults.models["provider/model"].params.thinking` for the selected model. An explicit `sessions_spawn.thinking` still wins.
-- **Run timeout:** OpenClaw uses `agents.defaults.subagents.runTimeoutSeconds` when set; otherwise it falls back to `0` (no timeout). `sessions_spawn` does not accept per-call timeout overrides.
+- **Run timeout:** `sessions_spawn.timeoutSeconds` sets the child run limit for that call and overrides `agents.defaults.subagents.runTimeoutSeconds`. When omitted, OpenClaw uses the configured default, or `0` (no timeout) when no default is set. If the task declares `HANDOFF_TIMEOUT_SECONDS`, `timeoutSeconds` is required and must match it so the stated delegation budget cannot differ from the enforced limit. Per-call timeouts are unavailable with `visible: true`.
 - **Process lifetime:** a detached OpenClaw sub-agent has its own run lifecycle. A background task created inside an external CLI backend is different: it shares the parent CLI subprocess and stops if that parent reaches `agents.defaults.timeoutSeconds`.
 - **Task delivery:** native sub-agents receive the delegated task in their first visible `[Subagent Task]` message. The sub-agent system prompt carries runtime rules and routing context, not a hidden duplicate of the task.
 
@@ -215,6 +215,12 @@ Per-agent override: `agents.entries.*.subagents.delegationMode`.
 <ParamField path="thinking" type="string">
   Override thinking level for the sub-agent run. Not available with `visible: true`.
 </ParamField>
+<ParamField path="timeoutSeconds" type="number">
+  Set the child run timeout for this spawn. Overrides
+  `agents.defaults.subagents.runTimeoutSeconds`. If `task` declares
+  `HANDOFF_TIMEOUT_SECONDS`, this value is required and must match it. Not
+  available with `visible: true`. Range: `0` to `2147000` seconds.
+</ParamField>
 <ParamField path="thread" type="boolean" default="false">
   When `true`, requests channel thread binding for this sub-agent session.
 </ParamField>
@@ -252,7 +258,7 @@ their latest assistant turn back to the requester; external delivery stays with
 the parent/requester agent.
 </Warning>
 
-With `visible: true`, `model`, `cwd`, and a same-agent `context: "fork"` are supported. A sandboxed target restricts `cwd` to that agent's workspace. Thread binding, `mode`, thinking overrides, `lightContext`, `attachments`, and `attachAs` are unavailable on this path because visible sessions are persistent dashboard sessions created through `sessions.create`. Visible spawning is rejected when the requester was itself spawned with an inherited tool allowlist or denylist; that restriction is fixed at spawn time and has no config override. Session listing and addressing obey `tools.sessions.visibility`; the default `tree` scope covers the current session and its own spawn subtree. See [Managed worktrees](/concepts/managed-worktrees) for checkout naming, setup, cleanup, and restore behavior.
+With `visible: true`, `model`, `cwd`, and a same-agent `context: "fork"` are supported. A sandboxed target restricts `cwd` to that agent's workspace. Thread binding, `mode`, thinking and timeout overrides, `lightContext`, `attachments`, and `attachAs` are unavailable on this path because visible sessions are persistent dashboard sessions created through `sessions.create`. Visible spawning is rejected when the requester was itself spawned with an inherited tool allowlist or denylist; that restriction is fixed at spawn time and has no config override. Session listing and addressing obey `tools.sessions.visibility`; the default `tree` scope covers the current session and its own spawn subtree. See [Managed worktrees](/concepts/managed-worktrees) for checkout naming, setup, cleanup, and restore behavior.
 
 ### Task names and targeting
 

--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -147,7 +147,7 @@ session to confirm the effective tool list.
 
 - **Model:** native sub-agents inherit the caller unless you set `agents.defaults.subagents.model` (or per-agent `agents.entries.*.subagents.model`). ACP runtime spawns use the same configured subagent model when present; otherwise the ACP harness keeps its own default. An explicit `sessions_spawn.model` still wins.
 - **Thinking:** native sub-agents inherit the caller unless you set `agents.defaults.subagents.thinking` (or per-agent `agents.entries.*.subagents.thinking`). ACP runtime spawns also apply `agents.defaults.models["provider/model"].params.thinking` for the selected model. An explicit `sessions_spawn.thinking` still wins.
-- **Run timeout:** `sessions_spawn.timeoutSeconds` sets the child run limit for that call and overrides `agents.defaults.subagents.runTimeoutSeconds`. When omitted, OpenClaw uses the configured default, or `0` (no timeout) when no default is set. If the task declares `HANDOFF_TIMEOUT_SECONDS`, `timeoutSeconds` is required and must match it so the stated delegation budget cannot differ from the enforced limit. Per-call timeouts are unavailable with `visible: true`.
+- **Run timeout:** `sessions_spawn.timeoutSeconds` sets the child run limit for that call and overrides `agents.defaults.subagents.runTimeoutSeconds`. When omitted, OpenClaw uses the configured default, or `0` (no timeout) when no default is set. Per-call timeouts are unavailable with `visible: true`.
 - **Process lifetime:** a detached OpenClaw sub-agent has its own run lifecycle. A background task created inside an external CLI backend is different: it shares the parent CLI subprocess and stops if that parent reaches `agents.defaults.timeoutSeconds`.
 - **Task delivery:** native sub-agents receive the delegated task in their first visible `[Subagent Task]` message. The sub-agent system prompt carries runtime rules and routing context, not a hidden duplicate of the task.
 
@@ -217,9 +217,8 @@ Per-agent override: `agents.entries.*.subagents.delegationMode`.
 </ParamField>
 <ParamField path="timeoutSeconds" type="number">
   Set the child run timeout for this spawn. Overrides
-  `agents.defaults.subagents.runTimeoutSeconds`. If `task` declares
-  `HANDOFF_TIMEOUT_SECONDS`, this value is required and must match it. Not
-  available with `visible: true`. Range: `0` to `2147000` seconds.
+  `agents.defaults.subagents.runTimeoutSeconds`. Not available with
+  `visible: true`. Range: `0` to `2147000` seconds.
 </ParamField>
 <ParamField path="thread" type="boolean" default="false">
   When `true`, requests channel thread binding for this sub-agent session.

--- a/src/agents/openclaw-tools.subagents.sessions-spawn.lifecycle.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn.lifecycle.test.ts
@@ -318,6 +318,57 @@ describe("openclaw-tools: subagents (sessions_spawn lifecycle)", () => {
     expect(childAgentCall?.timeoutMs).toBe(125_000);
   });
 
+  it("honors a per-call timeout above the global default on the native spawn path", async () => {
+    const perCallTimeoutSeconds = 14_400;
+    const ctx = setupSessionsSpawnGatewayMock({
+      includeChatHistory: true,
+      agentWaitResult: { status: "ok", startedAt: 1000, endedAt: 2000 },
+    });
+    setSessionsSpawnConfigOverride({
+      session: { mainKey: "main", scope: "per-sender" },
+      messages: { queue: {} },
+      agents: {
+        defaults: {
+          subagents: {
+            runTimeoutSeconds: 1_800,
+          },
+        },
+      },
+    });
+    const tool = await getSessionsSpawnTool({
+      agentSessionKey: "main",
+      agentChannel: "whatsapp",
+    });
+
+    const result = await tool.execute("call-per-run-timeout", {
+      task: `long build\nHANDOFF_TIMEOUT_SECONDS: ${perCallTimeoutSeconds}`,
+      timeoutSeconds: perCallTimeoutSeconds,
+    });
+
+    expectAcceptedRunDetails(result.details);
+    const child = ctx.getChild();
+    const childAgentCall = ctx.calls.find((call) => {
+      const params = call.params as { lane?: string } | undefined;
+      return call.method === "agent" && params?.lane === "subagent";
+    });
+    expect(childAgentCall?.params).toMatchObject({
+      timeout: perCallTimeoutSeconds,
+      lane: "subagent",
+    });
+    if (!child.sessionKey) {
+      throw new Error("missing child sessionKey");
+    }
+    expect(getLatestSubagentRunByChildSessionKey(child.sessionKey)?.runTimeoutSeconds).toBe(
+      perCallTimeoutSeconds,
+    );
+    await waitForSessionsSpawnEvent("per-call timeout reaches native wait path", () =>
+      ctx.waitCalls.some((call) => call.runId === child.runId),
+    );
+    expect(ctx.waitCalls.find((call) => call.runId === child.runId)?.timeoutMs).toBe(
+      perCallTimeoutSeconds * 1_000,
+    );
+  });
+
   it("sessions_spawn retires bundle MCP runtime when run-mode cleanup completes", async () => {
     let resumeAnnounceFlow: ((value: boolean) => void) | undefined;
     let announceFlowStarted: (() => void) | undefined;

--- a/src/agents/openclaw-tools.subagents.sessions-spawn.lifecycle.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn.lifecycle.test.ts
@@ -341,7 +341,7 @@ describe("openclaw-tools: subagents (sessions_spawn lifecycle)", () => {
     });
 
     const result = await tool.execute("call-per-run-timeout", {
-      task: `long build\nHANDOFF_TIMEOUT_SECONDS: ${perCallTimeoutSeconds}`,
+      task: "long build",
       timeoutSeconds: perCallTimeoutSeconds,
     });
 

--- a/src/agents/tools/sessions-spawn-tool.test.ts
+++ b/src/agents/tools/sessions-spawn-tool.test.ts
@@ -272,7 +272,7 @@ describe("sessions_spawn tool", () => {
       maximum: MAX_TIMER_TIMEOUT_SECONDS,
     });
     expect(schema.properties?.timeoutSeconds?.description).toContain("overrides");
-    expect(schema.properties?.timeoutSeconds?.description).toContain("HANDOFF_TIMEOUT_SECONDS");
+    expect(schema.properties?.timeoutSeconds?.description).not.toContain("task");
   });
 
   it("hides and rejects swarm parameters while tools.swarm is disabled", async () => {
@@ -1267,51 +1267,40 @@ describe("sessions_spawn tool", () => {
     },
   );
 
-  it("requires an explicit per-call timeout for a declared handoff contract", async () => {
-    const tool = createSessionsSpawnTool({
-      agentSessionKey: "agent:main:main",
-    });
-
-    await expect(
-      tool.execute("call-missing-handoff-timeout", {
-        task: "do thing\nHANDOFF_TIMEOUT_SECONDS: 7200",
-      }),
-    ).rejects.toThrow(
-      "sessions_spawn requires timeoutSeconds when the task declares HANDOFF_TIMEOUT_SECONDS.",
-    );
-
-    expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
-  });
-
-  it("rejects a per-call timeout that differs from the handoff contract", async () => {
-    const tool = createSessionsSpawnTool({
-      agentSessionKey: "agent:main:main",
-    });
-
-    await expect(
-      tool.execute("call-mismatched-handoff-timeout", {
-        task: "do thing\nHANDOFF_TIMEOUT_SECONDS: 7200",
-        timeoutSeconds: 3600,
-      }),
-    ).rejects.toThrow(
-      "sessions_spawn timeoutSeconds (3600) must match HANDOFF_TIMEOUT_SECONDS (7200).",
-    );
-
-    expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
-  });
-
-  it("forwards a matching declared timeout to native subagent spawn", async () => {
-    const tool = createSessionsSpawnTool({
-      agentSessionKey: "agent:main:main",
-    });
-
-    await tool.execute("call-matching-handoff-timeout", {
+  it.each([
+    {
+      name: "missing structured timeout",
       task: "do thing\nHANDOFF_TIMEOUT_SECONDS: 7200",
+      timeoutSeconds: undefined,
+    },
+    {
+      name: "mismatched structured timeout",
+      task: "do thing\nHANDOFF_TIMEOUT_SECONDS: 7200",
+      timeoutSeconds: 3600,
+    },
+    {
+      name: "malformed task text",
+      task: "do thing\nHANDOFF_TIMEOUT_SECONDS: tomorrow",
       timeoutSeconds: 7200,
+    },
+    {
+      name: "conflicting task text",
+      task: "HANDOFF_TIMEOUT_SECONDS: 3600\nHANDOFF_TIMEOUT_SECONDS: 7200",
+      timeoutSeconds: 5400,
+    },
+  ])("treats timeout-like task text as inert: $name", async ({ task, timeoutSeconds }) => {
+    const tool = createSessionsSpawnTool({
+      agentSessionKey: "agent:main:main",
+    });
+
+    await tool.execute("call-inert-task-timeout", {
+      task,
+      ...(timeoutSeconds === undefined ? {} : { timeoutSeconds }),
     });
 
     const spawnArgs = mockCallArg(hoisted.spawnSubagentDirectMock, 0, 0, "spawnSubagentDirect");
-    expect(spawnArgs.runTimeoutSeconds).toBe(7200);
+    expect(spawnArgs.task).toBe(task);
+    expect(spawnArgs.runTimeoutSeconds).toBe(timeoutSeconds);
   });
 
   it("normalizes the snake-case per-call timeout alias", async () => {

--- a/src/agents/tools/sessions-spawn-tool.test.ts
+++ b/src/agents/tools/sessions-spawn-tool.test.ts
@@ -1,6 +1,7 @@
 // sessions_spawn tool tests cover model-visible schema gating, ACP/subagent
 // dispatch, and result details for spawned child sessions.
 import path from "node:path";
+import { MAX_TIMER_TIMEOUT_SECONDS } from "@openclaw/normalization-core/number-coercion";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { upsertSessionEntry } from "../../config/sessions/session-accessor.js";
 import { withTempDir } from "../../test-helpers/temp-dir.js";
@@ -250,17 +251,28 @@ describe("sessions_spawn tool", () => {
     expect(schema.properties?.runtime?.enum).toEqual(["subagent", "acp"]);
   });
 
-  it("does not expose timeout override fields to the model", () => {
+  it("exposes the canonical timeout override to the model", () => {
     const tool = createSessionsSpawnTool();
     const schema = tool.parameters as {
       properties?: {
         runTimeoutSeconds?: unknown;
-        timeoutSeconds?: unknown;
+        timeoutSeconds?: {
+          type?: string;
+          minimum?: number;
+          maximum?: number;
+          description?: string;
+        };
       };
     };
 
     expect(schema.properties?.runTimeoutSeconds).toBeUndefined();
-    expect(schema.properties?.timeoutSeconds).toBeUndefined();
+    expect(schema.properties?.timeoutSeconds).toMatchObject({
+      type: "integer",
+      minimum: 0,
+      maximum: MAX_TIMER_TIMEOUT_SECONDS,
+    });
+    expect(schema.properties?.timeoutSeconds?.description).toContain("overrides");
+    expect(schema.properties?.timeoutSeconds?.description).toContain("HANDOFF_TIMEOUT_SECONDS");
   });
 
   it("hides and rejects swarm parameters while tools.swarm is disabled", async () => {
@@ -1065,6 +1077,7 @@ describe("sessions_spawn tool", () => {
       agentId: "main",
       model: "anthropic/claude-sonnet-4-6",
       thinking: "medium",
+      timeoutSeconds: 14_400,
       cwd: "/workspace/requester",
       thread: true,
       mode: "session",
@@ -1083,7 +1096,7 @@ describe("sessions_spawn tool", () => {
     expect(spawnArgs.model).toBe("anthropic/claude-sonnet-4-6");
     expect(spawnArgs.thinking).toBe("medium");
     expect(spawnArgs.cwd).toBe("/workspace/requester");
-    expect(spawnArgs).not.toHaveProperty("runTimeoutSeconds");
+    expect(spawnArgs.runTimeoutSeconds).toBe(14_400);
     expect(spawnArgs.thread).toBe(true);
     expect(spawnArgs.mode).toBe("session");
     expect(spawnArgs.cleanup).toBe("keep");
@@ -1234,23 +1247,99 @@ describe("sessions_spawn tool", () => {
     expect(result.details).not.toHaveProperty("role");
   });
 
-  it.each([
-    "runTimeoutSeconds",
-    "timeoutSeconds",
-    "run_timeout_seconds",
-    "timeout_seconds",
-  ] as const)("rejects stale timeout override argument %s", async (timeoutParam) => {
+  it.each(["runTimeoutSeconds", "run_timeout_seconds"] as const)(
+    "rejects stale timeout override argument %s",
+    async (timeoutParam) => {
+      const tool = createSessionsSpawnTool({
+        agentSessionKey: "agent:main:main",
+      });
+
+      await expect(
+        tool.execute("call-stale-timeout-override", {
+          task: "do thing",
+          [timeoutParam]: 2,
+        }),
+      ).rejects.toThrow(
+        `sessions_spawn does not support "${timeoutParam}". Use "timeoutSeconds" for a per-call run timeout.`,
+      );
+
+      expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it("requires an explicit per-call timeout for a declared handoff contract", async () => {
     const tool = createSessionsSpawnTool({
       agentSessionKey: "agent:main:main",
     });
 
     await expect(
-      tool.execute("call-stale-timeout-override", {
-        task: "do thing",
-        [timeoutParam]: 2,
+      tool.execute("call-missing-handoff-timeout", {
+        task: "do thing\nHANDOFF_TIMEOUT_SECONDS: 7200",
       }),
     ).rejects.toThrow(
-      `sessions_spawn does not support per-call "${timeoutParam}". Configure agents.defaults.subagents.runTimeoutSeconds instead.`,
+      "sessions_spawn requires timeoutSeconds when the task declares HANDOFF_TIMEOUT_SECONDS.",
+    );
+
+    expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a per-call timeout that differs from the handoff contract", async () => {
+    const tool = createSessionsSpawnTool({
+      agentSessionKey: "agent:main:main",
+    });
+
+    await expect(
+      tool.execute("call-mismatched-handoff-timeout", {
+        task: "do thing\nHANDOFF_TIMEOUT_SECONDS: 7200",
+        timeoutSeconds: 3600,
+      }),
+    ).rejects.toThrow(
+      "sessions_spawn timeoutSeconds (3600) must match HANDOFF_TIMEOUT_SECONDS (7200).",
+    );
+
+    expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
+  });
+
+  it("forwards a matching declared timeout to native subagent spawn", async () => {
+    const tool = createSessionsSpawnTool({
+      agentSessionKey: "agent:main:main",
+    });
+
+    await tool.execute("call-matching-handoff-timeout", {
+      task: "do thing\nHANDOFF_TIMEOUT_SECONDS: 7200",
+      timeoutSeconds: 7200,
+    });
+
+    const spawnArgs = mockCallArg(hoisted.spawnSubagentDirectMock, 0, 0, "spawnSubagentDirect");
+    expect(spawnArgs.runTimeoutSeconds).toBe(7200);
+  });
+
+  it("normalizes the snake-case per-call timeout alias", async () => {
+    const tool = createSessionsSpawnTool({
+      agentSessionKey: "agent:main:main",
+    });
+
+    await tool.execute("call-snake-case-timeout", {
+      task: "do thing",
+      timeout_seconds: 7200,
+    });
+
+    const spawnArgs = mockCallArg(hoisted.spawnSubagentDirectMock, 0, 0, "spawnSubagentDirect");
+    expect(spawnArgs.runTimeoutSeconds).toBe(7200);
+  });
+
+  it("rejects a per-call timeout above the timer-safe maximum", async () => {
+    const tool = createSessionsSpawnTool({
+      agentSessionKey: "agent:main:main",
+    });
+
+    await expect(
+      tool.execute("call-oversized-timeout", {
+        task: "do thing",
+        timeoutSeconds: MAX_TIMER_TIMEOUT_SECONDS + 1,
+      }),
+    ).rejects.toThrow(
+      `timeoutSeconds must be an integer between 0 and ${MAX_TIMER_TIMEOUT_SECONDS}.`,
     );
 
     expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
@@ -1323,6 +1412,7 @@ describe("sessions_spawn tool", () => {
       task: "investigate the failing CI run",
       agentId: "codex",
       cwd: "/workspace",
+      timeoutSeconds: 14_400,
       thread: true,
       mode: "session",
       streamTo: "parent",
@@ -1337,7 +1427,7 @@ describe("sessions_spawn tool", () => {
     expect(spawnArgs.task).toBe("investigate the failing CI run");
     expect(spawnArgs.agentId).toBe("codex");
     expect(spawnArgs.cwd).toBe("/workspace");
-    expect(spawnArgs).not.toHaveProperty("runTimeoutSeconds");
+    expect(spawnArgs.runTimeoutSeconds).toBe(14_400);
     expect(spawnArgs.thread).toBe(true);
     expect(spawnArgs.mode).toBe("session");
     expect(spawnArgs.cleanup).toBe("keep");

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -3,6 +3,7 @@
  *
  * Starts subagent or ACP-backed sessions with inherited tool policy and delivery context.
  */
+import { MAX_TIMER_TIMEOUT_SECONDS } from "@openclaw/normalization-core/number-coercion";
 import { Type } from "typebox";
 import { isAcpRuntimeSpawnAvailable } from "../../acp/runtime/availability.js";
 import {
@@ -44,6 +45,7 @@ import type { AnyAgentTool } from "./common.js";
 import {
   jsonResult,
   normalizeToolModelOverride,
+  readNonNegativeIntegerParam,
   readStringParam,
   ToolInputError,
 } from "./common.js";
@@ -67,10 +69,8 @@ const UNSUPPORTED_SESSIONS_SPAWN_PARAM_KEYS = [
   "replyTo",
   "reply_to",
 ] as const;
-const UNSUPPORTED_SESSIONS_SPAWN_TIMEOUT_PARAM_KEYS = [
-  "runTimeoutSeconds",
-  "timeoutSeconds",
-] as const;
+const UNSUPPORTED_SESSIONS_SPAWN_TIMEOUT_PARAM_KEYS = ["runTimeoutSeconds"] as const;
+const HANDOFF_TIMEOUT_CONTRACT_PATTERN = /^\s*HANDOFF_TIMEOUT_SECONDS\s*:\s*([^\r\n]*)\s*$/gim;
 
 type AcpSpawnModule = typeof import("../acp-spawn.js");
 
@@ -99,6 +99,54 @@ type SessionsSpawnThreadAvailability = {
 
 function hasAnyThreadAvailability(availability: SessionsSpawnThreadAvailability): boolean {
   return availability.subagent || availability.acp;
+}
+
+function resolveSessionsSpawnRunTimeoutSeconds(
+  params: Record<string, unknown>,
+  task: string,
+): number | undefined {
+  const runTimeoutSeconds = readNonNegativeIntegerParam(params, "timeoutSeconds", {
+    max: MAX_TIMER_TIMEOUT_SECONDS,
+    message: `timeoutSeconds must be an integer between 0 and ${MAX_TIMER_TIMEOUT_SECONDS}.`,
+  });
+  const declaredValues = Array.from(
+    task.matchAll(HANDOFF_TIMEOUT_CONTRACT_PATTERN),
+    (match) => match[1]?.trim() ?? "",
+  );
+  if (declaredValues.length === 0) {
+    return runTimeoutSeconds;
+  }
+  const declaredTimeouts = declaredValues.map((value) => {
+    if (!/^(?:0|[1-9]\d*)$/.test(value)) {
+      throw new ToolInputError(
+        "HANDOFF_TIMEOUT_SECONDS must declare a non-negative integer number of seconds.",
+      );
+    }
+    const timeout = Number(value);
+    if (!Number.isSafeInteger(timeout) || timeout > MAX_TIMER_TIMEOUT_SECONDS) {
+      throw new ToolInputError(
+        `HANDOFF_TIMEOUT_SECONDS must declare an integer between 0 and ${MAX_TIMER_TIMEOUT_SECONDS}.`,
+      );
+    }
+    return timeout;
+  });
+  const declaredTimeoutSeconds = declaredTimeouts[0];
+  if (declaredTimeouts.some((value) => value !== declaredTimeoutSeconds)) {
+    throw new ToolInputError(
+      "Conflicting HANDOFF_TIMEOUT_SECONDS values were declared in the spawn task.",
+    );
+  }
+  if (runTimeoutSeconds === undefined) {
+    throw new ToolInputError(
+      "sessions_spawn requires timeoutSeconds when the task declares HANDOFF_TIMEOUT_SECONDS.",
+    );
+  }
+  if (runTimeoutSeconds !== declaredTimeoutSeconds) {
+    throw new ToolInputError(
+      `sessions_spawn timeoutSeconds (${runTimeoutSeconds}) must match HANDOFF_TIMEOUT_SECONDS (${declaredTimeoutSeconds}).`,
+    );
+  }
+  return runTimeoutSeconds;
 }
 
 function resolveSessionsSpawnThreadAvailability(opts?: {
@@ -153,6 +201,14 @@ function createSessionsSpawnToolSchema(params: {
     model: Type.Optional(Type.String()),
     thinking: Type.Optional(
       Type.String({ description: "Thinking override; unavailable with visible=true." }),
+    ),
+    timeoutSeconds: Type.Optional(
+      Type.Integer({
+        minimum: 0,
+        maximum: MAX_TIMER_TIMEOUT_SECONDS,
+        description:
+          "Run timeout in seconds; overrides agents.defaults.subagents.runTimeoutSeconds. Must match HANDOFF_TIMEOUT_SECONDS when declared in task.",
+      }),
     ),
     cwd: Type.Optional(Type.String()),
     ...(params.threadAvailable
@@ -331,10 +387,11 @@ export function createSessionsSpawnTool(
         const providedTimeoutParam =
           resolveSnakeCaseParamKey(params, unsupportedTimeoutParam) ?? unsupportedTimeoutParam;
         throw new ToolInputError(
-          `sessions_spawn does not support per-call "${providedTimeoutParam}". Configure agents.defaults.subagents.runTimeoutSeconds instead.`,
+          `sessions_spawn does not support "${providedTimeoutParam}". Use "timeoutSeconds" for a per-call run timeout.`,
         );
       }
       const task = readStringParam(params, "task", { required: true });
+      const runTimeoutSeconds = resolveSessionsSpawnRunTimeoutSeconds(params, task);
       const taskNameResult = normalizeSubagentTaskName(params.taskName);
       if (taskNameResult.error) {
         return jsonResult({
@@ -371,6 +428,7 @@ export function createSessionsSpawnTool(
         runtime,
         requestedAgentId,
         sandbox,
+        runTimeoutSeconds,
         options: opts,
       });
       if (visibleResult) {
@@ -445,6 +503,7 @@ export function createSessionsSpawnTool(
             resumeSessionId,
             model: modelOverride,
             thinking: thinkingOverrideRaw,
+            runTimeoutSeconds,
             cwd,
             mode: mode === "run" || mode === "session" ? mode : undefined,
             thread,
@@ -485,6 +544,7 @@ export function createSessionsSpawnTool(
           agentId: requestedAgentId,
           model: modelOverride,
           thinking: thinkingOverrideRaw,
+          runTimeoutSeconds,
           collect: hasCollectParam ? collect : undefined,
           outputSchema:
             params.outputSchema && typeof params.outputSchema === "object"

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -70,7 +70,6 @@ const UNSUPPORTED_SESSIONS_SPAWN_PARAM_KEYS = [
   "reply_to",
 ] as const;
 const UNSUPPORTED_SESSIONS_SPAWN_TIMEOUT_PARAM_KEYS = ["runTimeoutSeconds"] as const;
-const HANDOFF_TIMEOUT_CONTRACT_PATTERN = /^\s*HANDOFF_TIMEOUT_SECONDS\s*:\s*([^\r\n]*)\s*$/gim;
 
 type AcpSpawnModule = typeof import("../acp-spawn.js");
 
@@ -99,54 +98,6 @@ type SessionsSpawnThreadAvailability = {
 
 function hasAnyThreadAvailability(availability: SessionsSpawnThreadAvailability): boolean {
   return availability.subagent || availability.acp;
-}
-
-function resolveSessionsSpawnRunTimeoutSeconds(
-  params: Record<string, unknown>,
-  task: string,
-): number | undefined {
-  const runTimeoutSeconds = readNonNegativeIntegerParam(params, "timeoutSeconds", {
-    max: MAX_TIMER_TIMEOUT_SECONDS,
-    message: `timeoutSeconds must be an integer between 0 and ${MAX_TIMER_TIMEOUT_SECONDS}.`,
-  });
-  const declaredValues = Array.from(
-    task.matchAll(HANDOFF_TIMEOUT_CONTRACT_PATTERN),
-    (match) => match[1]?.trim() ?? "",
-  );
-  if (declaredValues.length === 0) {
-    return runTimeoutSeconds;
-  }
-  const declaredTimeouts = declaredValues.map((value) => {
-    if (!/^(?:0|[1-9]\d*)$/.test(value)) {
-      throw new ToolInputError(
-        "HANDOFF_TIMEOUT_SECONDS must declare a non-negative integer number of seconds.",
-      );
-    }
-    const timeout = Number(value);
-    if (!Number.isSafeInteger(timeout) || timeout > MAX_TIMER_TIMEOUT_SECONDS) {
-      throw new ToolInputError(
-        `HANDOFF_TIMEOUT_SECONDS must declare an integer between 0 and ${MAX_TIMER_TIMEOUT_SECONDS}.`,
-      );
-    }
-    return timeout;
-  });
-  const declaredTimeoutSeconds = declaredTimeouts[0];
-  if (declaredTimeouts.some((value) => value !== declaredTimeoutSeconds)) {
-    throw new ToolInputError(
-      "Conflicting HANDOFF_TIMEOUT_SECONDS values were declared in the spawn task.",
-    );
-  }
-  if (runTimeoutSeconds === undefined) {
-    throw new ToolInputError(
-      "sessions_spawn requires timeoutSeconds when the task declares HANDOFF_TIMEOUT_SECONDS.",
-    );
-  }
-  if (runTimeoutSeconds !== declaredTimeoutSeconds) {
-    throw new ToolInputError(
-      `sessions_spawn timeoutSeconds (${runTimeoutSeconds}) must match HANDOFF_TIMEOUT_SECONDS (${declaredTimeoutSeconds}).`,
-    );
-  }
-  return runTimeoutSeconds;
 }
 
 function resolveSessionsSpawnThreadAvailability(opts?: {
@@ -207,7 +158,7 @@ function createSessionsSpawnToolSchema(params: {
         minimum: 0,
         maximum: MAX_TIMER_TIMEOUT_SECONDS,
         description:
-          "Run timeout in seconds; overrides agents.defaults.subagents.runTimeoutSeconds. Must match HANDOFF_TIMEOUT_SECONDS when declared in task.",
+          "Run timeout in seconds; overrides agents.defaults.subagents.runTimeoutSeconds.",
       }),
     ),
     cwd: Type.Optional(Type.String()),
@@ -391,7 +342,10 @@ export function createSessionsSpawnTool(
         );
       }
       const task = readStringParam(params, "task", { required: true });
-      const runTimeoutSeconds = resolveSessionsSpawnRunTimeoutSeconds(params, task);
+      const runTimeoutSeconds = readNonNegativeIntegerParam(params, "timeoutSeconds", {
+        max: MAX_TIMER_TIMEOUT_SECONDS,
+        message: `timeoutSeconds must be an integer between 0 and ${MAX_TIMER_TIMEOUT_SECONDS}.`,
+      });
       const taskNameResult = normalizeSubagentTaskName(params.taskName);
       if (taskNameResult.error) {
         return jsonResult({

--- a/src/agents/tools/sessions-spawn-visible.ts
+++ b/src/agents/tools/sessions-spawn-visible.ts
@@ -93,6 +93,7 @@ export async function maybeSpawnVisibleSession(params: {
   runtime: "subagent" | "acp";
   requestedAgentId?: string;
   sandbox: "inherit" | "require";
+  runTimeoutSeconds?: number;
   options?: VisibleSessionsSpawnOptions;
 }): Promise<Record<string, unknown> | undefined> {
   const worktree = params.raw.worktree === true;
@@ -138,6 +139,11 @@ export async function maybeSpawnVisibleSession(params: {
       "lightContext",
       params.raw.lightContext === true ? true : undefined,
       "bootstrap staging is not wired to the sessions.create path",
+    ],
+    [
+      "timeoutSeconds",
+      params.runTimeoutSeconds,
+      "initial dashboard run timeout is not wired to the sessions.create path",
     ],
     [
       "attachments",

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
@@ -230,6 +230,12 @@
           "description": "Bind new chat thread when supported; true defaults mode=\"session\"; unavailable with visible=true.",
           "type": "boolean"
         },
+        "timeoutSeconds": {
+          "description": "Run timeout in seconds; overrides agents.defaults.subagents.runTimeoutSeconds. Must match HANDOFF_TIMEOUT_SECONDS when declared in task.",
+          "maximum": 2147000,
+          "minimum": 0,
+          "type": "integer"
+        },
         "visible": {
           "description": "Persistent UI session; subagent only; omit mode/thread/thinking/lightContext/attachments/attachAs; unavailable with inherited tool allow/denylist.",
           "type": "boolean"

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
@@ -231,7 +231,7 @@
           "type": "boolean"
         },
         "timeoutSeconds": {
-          "description": "Run timeout in seconds; overrides agents.defaults.subagents.runTimeoutSeconds. Must match HANDOFF_TIMEOUT_SECONDS when declared in task.",
+          "description": "Run timeout in seconds; overrides agents.defaults.subagents.runTimeoutSeconds.",
           "maximum": 2147000,
           "minimum": 0,
           "type": "integer"

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
@@ -226,6 +226,12 @@
           "description": "Thinking override; unavailable with visible=true.",
           "type": "string"
         },
+        "timeoutSeconds": {
+          "description": "Run timeout in seconds; overrides agents.defaults.subagents.runTimeoutSeconds. Must match HANDOFF_TIMEOUT_SECONDS when declared in task.",
+          "maximum": 2147000,
+          "minimum": 0,
+          "type": "integer"
+        },
         "visible": {
           "description": "Persistent UI session; subagent only; omit mode/thread/thinking/lightContext/attachments/attachAs; unavailable with inherited tool allow/denylist.",
           "type": "boolean"

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
@@ -227,7 +227,7 @@
           "type": "string"
         },
         "timeoutSeconds": {
-          "description": "Run timeout in seconds; overrides agents.defaults.subagents.runTimeoutSeconds. Must match HANDOFF_TIMEOUT_SECONDS when declared in task.",
+          "description": "Run timeout in seconds; overrides agents.defaults.subagents.runTimeoutSeconds.",
           "maximum": 2147000,
           "minimum": 0,
           "type": "integer"

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
@@ -226,6 +226,12 @@
           "description": "Thinking override; unavailable with visible=true.",
           "type": "string"
         },
+        "timeoutSeconds": {
+          "description": "Run timeout in seconds; overrides agents.defaults.subagents.runTimeoutSeconds. Must match HANDOFF_TIMEOUT_SECONDS when declared in task.",
+          "maximum": 2147000,
+          "minimum": 0,
+          "type": "integer"
+        },
         "visible": {
           "description": "Persistent UI session; subagent only; omit mode/thread/thinking/lightContext/attachments/attachAs; unavailable with inherited tool allow/denylist.",
           "type": "boolean"

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
@@ -227,7 +227,7 @@
           "type": "string"
         },
         "timeoutSeconds": {
-          "description": "Run timeout in seconds; overrides agents.defaults.subagents.runTimeoutSeconds. Must match HANDOFF_TIMEOUT_SECONDS when declared in task.",
+          "description": "Run timeout in seconds; overrides agents.defaults.subagents.runTimeoutSeconds.",
           "maximum": 2147000,
           "minimum": 0,
           "type": "integer"

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
@@ -221,8 +221,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 59298,
-    "roughTokens": 14825
+    "chars": 59584,
+    "roughTokens": 14896
   },
   "openClawDeveloperInstructions": {
     "chars": 3715,
@@ -233,8 +233,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 7041
   },
   "totalWithDynamicToolsJson": {
-    "chars": 87462,
-    "roughTokens": 21866
+    "chars": 87748,
+    "roughTokens": 21937
   },
   "userInputText": {
     "chars": 1364,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
@@ -221,8 +221,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 59584,
-    "roughTokens": 14896
+    "chars": 59526,
+    "roughTokens": 14882
   },
   "openClawDeveloperInstructions": {
     "chars": 3715,
@@ -233,8 +233,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 7041
   },
   "totalWithDynamicToolsJson": {
-    "chars": 87748,
-    "roughTokens": 21937
+    "chars": 87690,
+    "roughTokens": 21923
   },
   "userInputText": {
     "chars": 1364,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -221,8 +221,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 58990,
-    "roughTokens": 14748
+    "chars": 59276,
+    "roughTokens": 14819
   },
   "openClawDeveloperInstructions": {
     "chars": 2606,
@@ -233,8 +233,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6671
   },
   "totalWithDynamicToolsJson": {
-    "chars": 85674,
-    "roughTokens": 21419
+    "chars": 85960,
+    "roughTokens": 21490
   },
   "userInputText": {
     "chars": 993,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -221,8 +221,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 59276,
-    "roughTokens": 14819
+    "chars": 59218,
+    "roughTokens": 14805
   },
   "openClawDeveloperInstructions": {
     "chars": 2606,
@@ -233,8 +233,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6671
   },
   "totalWithDynamicToolsJson": {
-    "chars": 85960,
-    "roughTokens": 21490
+    "chars": 85902,
+    "roughTokens": 21476
   },
   "userInputText": {
     "chars": 993,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
@@ -222,8 +222,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 60552,
-    "roughTokens": 15138
+    "chars": 60838,
+    "roughTokens": 15210
   },
   "openClawDeveloperInstructions": {
     "chars": 2625,
@@ -234,8 +234,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6783
   },
   "totalWithDynamicToolsJson": {
-    "chars": 87684,
-    "roughTokens": 21921
+    "chars": 87970,
+    "roughTokens": 21993
   },
   "userInputText": {
     "chars": 1348,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
@@ -222,8 +222,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 60838,
-    "roughTokens": 15210
+    "chars": 60780,
+    "roughTokens": 15195
   },
   "openClawDeveloperInstructions": {
     "chars": 2625,
@@ -234,8 +234,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6783
   },
   "totalWithDynamicToolsJson": {
-    "chars": 87970,
-    "roughTokens": 21993
+    "chars": 87912,
+    "roughTokens": 21978
   },
   "userInputText": {
     "chars": 1348,


### PR DESCRIPTION
Closes #114187

## What Problem This Solves

Delegated native and ACP workers could be terminated at the global subagent timeout because `sessions_spawn` did not expose the existing per-run timeout path. Coordinators could intend a longer budget, but the runtime still enforced the global default.

A real incident exposed the gap: a delegated coding build estimated at 90–180 minutes was killed at the 30-minute global cap mid-implementation even though the delegation intended a four-hour budget.

## Why This Approach

This adds a bounded structured `timeoutSeconds` parameter to the public spawn tool and maps it into the existing native and ACP runtime timeout field.

- An explicit `timeoutSeconds` value overrides `agents.defaults.subagents.runTimeoutSeconds` for that spawn.
- Omitting `timeoutSeconds` preserves the configured-default behavior.
- Free-form `task` text is inert. It is never scanned for `HANDOFF_TIMEOUT_SECONDS`, so existing task payloads remain compatible and there is only one structured timeout authority.
- Visible-session spawning rejects an explicit timeout until that separate creation path can enforce it.
- The global 1,800-second default is unchanged.

## Concrete Use Cases

- Long coding builds: repository setup, implementation, validation, and review can legitimately take 90–180 minutes. A coordinator can grant one worker a four-hour budget without raising the ceiling for every spawn.
- Long mechanical runs: cloning a large repository, installing dependencies, running type-aware lint, or executing integration tests can exceed 30 minutes even when the task is healthy and bounded.
- Multi-agent orchestration: orchestrators can budget different timeouts per delegated task and rely on the runtime enforcing the structured value rather than silently substituting a global cap.
- Conservative defaults: ordinary spawns with no override still inherit the global 1,800-second safety limit.

## Compatibility

Compatibility tests pass task bodies containing missing, malformed, conflicting, and mismatched `HANDOFF_TIMEOUT_SECONDS` text. All remain ordinary task content. Only the structured `timeoutSeconds` field affects the runtime.

Codex compatibility was also inspected against `openai/codex@18f50c9e628af083a52d9240de09fc2db24d79ce`: dynamic tool arguments remain opaque JSON (`DynamicToolCallRequest.arguments`), while Codex validates the supplied tool schema and forwards it into the thread. It does not parse the task string as a timeout contract.

## Evidence

### Real Native Runtime Proof

Run on 2026-07-26 from exact PR head `f7f50634e46d6e0434ccf128f07f79951f70ad2b` with an isolated temporary OpenClaw state directory, a loopback-only real Gateway, and a provider-backed native child. The operator Gateway and user configuration were not used or changed.

Configuration and call:

```text
agents.defaults.subagents.runTimeoutSeconds = 1800
sessions_spawn({
  runtime: "subagent",
  task: "Reply exactly <redacted-token> and nothing else.",
  context: "isolated",
  timeoutSeconds: 14400
})
```

Redacted observed output:

```text
[t5886-timeout-proof] {
  "runtime": "native-subagent",
  "configuredDefaultSeconds": 1800,
  "structuredTimeoutSeconds": 14400,
  "gatewayObservedTimeoutSeconds": 14400,
  "registryTimeoutSeconds": 14400,
  "childAccepted": true,
  "toolStatus": "accepted"
}

Test Files  1 passed (1)
Tests       1 passed | 3 skipped (4)
```

This proof exercised the real native spawn path: the real Gateway accepted the child, the actual in-process `agent` dispatch received `timeout: 14400`, and the persistent native subagent registry recorded `runTimeoutSeconds: 14400` despite the 1,800-second global default. The isolated Gateway was then torn down.

The deterministic native lifecycle regression additionally proves the same 14,400-second value reaches all three enforcement points: Gateway request, run registry, and completion wait (`14,400,000ms`).

### Validation

- Focused native/tool suite: 96/96 tests passed.
- Prompt snapshots: current (7 files).
- Real isolated native Gateway proof: passed, transcript above.
- Exact head: `f7f50634e46d6e0434ccf128f07f79951f70ad2b`.
- No global timeout or Gateway configuration changed.

## Maintainer Decision

Implementation and runtime proof are ready. Maintainers still own the product decision to accept the public structured per-call `timeoutSeconds` override and the merge itself.
