### PR TITLE
fix(memory-core): memory_search timeouts and cooldown replays are reported as embedding provider errors

### DIFF
--- a/extensions/memory-core/src/tools.citations.test.ts
+++ b/extensions/memory-core/src/tools.citations.test.ts
@@ -34,6 +34,9 @@ import {
   createMemoryGetToolOrThrow,
   createMemorySearchToolOrThrow,
   expectUnavailableMemorySearchDetails,
+  MEMORY_SEARCH_TIMEOUT_ACTION,
+  MEMORY_SEARCH_TIMEOUT_WARNING,
+  memorySearchFailureDebug,
 } from "./tools.test-helpers.js";
 
 const { createTempWorkspace } = createMemoryCoreTestHarness();
@@ -177,6 +180,7 @@ describe("memory tools", () => {
       error: "openai embeddings failed: 429 insufficient_quota",
       warning: "Memory search is unavailable because the embedding provider quota is exhausted.",
       action: "Top up or switch embedding provider, then retry memory_search.",
+      debug: memorySearchFailureDebug({ phase: "memory" }),
     });
   });
 
@@ -644,8 +648,9 @@ describe("memory tools", () => {
       const stalledAllResult = await stalledAllResultPromise;
       expectUnavailableMemorySearchDetails(stalledAllResult.details, {
         error: "memory_search timed out after 15s",
-        warning: "Memory search is unavailable due to an embedding/provider error.",
-        action: "Check embedding provider configuration and retry memory_search.",
+        warning: MEMORY_SEARCH_TIMEOUT_WARNING,
+        action: MEMORY_SEARCH_TIMEOUT_ACTION,
+        debug: memorySearchFailureDebug({ timedOut: true, phase: "supplement" }),
       });
 
       const memoryResult = await tool.execute("call_memory_after_stalled_wiki", {
@@ -692,8 +697,9 @@ describe("memory tools", () => {
       const stalledAllResult = await stalledAllResultPromise;
       expectUnavailableMemorySearchDetails(stalledAllResult.details, {
         error: "memory_search timed out after 15s",
-        warning: "Memory search is unavailable due to an embedding/provider error.",
-        action: "Check embedding provider configuration and retry memory_search.",
+        warning: MEMORY_SEARCH_TIMEOUT_WARNING,
+        action: MEMORY_SEARCH_TIMEOUT_ACTION,
+        debug: memorySearchFailureDebug({ timedOut: true, phase: "memory" }),
       });
 
       const wikiOnlyResult = await tool.execute("call_all_after_stalled_memory", {

--- a/extensions/memory-core/src/tools.shared.ts
+++ b/extensions/memory-core/src/tools.shared.ts
@@ -123,6 +123,18 @@ export function buildMemorySearchUnavailableResult(
   overrides?: {
     warning?: string;
     action?: string;
+    /**
+     * Measurements only the caller knows. Omitted when the payload is built
+     * outside a tool run, where no timing is knowable.
+     */
+    diagnostics?: {
+      /** Wall-clock ms this tool call spent before giving up. */
+      elapsedMs: number;
+      /** Tool stage the failure was attributed to, when one was active. */
+      phase?: "memory" | "supplement";
+      /** Time left on the cooldown window when this payload replays it. */
+      cooldownRemainingMs?: number;
+    };
   },
 ) {
   const reason = (error ?? "memory search unavailable").trim() || "memory search unavailable";
@@ -131,20 +143,29 @@ export function buildMemorySearchUnavailableResult(
   const isMissingNodeSqlite = /missing node:sqlite|no such built-?in module: node:sqlite/.test(
     normalizedReason,
   );
+  // The search deadline also fires on local index maintenance, so a timeout is
+  // not evidence that the embedding provider misbehaved.
+  const isTimeout = normalizedReason.includes("timed out");
   const warning =
     overrides?.warning ??
     (isQuotaError
       ? "Memory search is unavailable because the embedding provider quota is exhausted."
       : isMissingNodeSqlite
         ? "Memory search is unavailable because this OpenClaw Node runtime does not provide SQLite support."
-        : "Memory search is unavailable due to an embedding/provider error.");
+        : isTimeout
+          ? "Memory search is unavailable because it timed out before completing; this can be local index maintenance rather than an embedding provider fault."
+          : "Memory search is unavailable due to an embedding/provider error.");
   const action =
     overrides?.action ??
     (isQuotaError
       ? "Top up or switch embedding provider, then retry memory_search."
       : isMissingNodeSqlite
         ? "Run OpenClaw with a Node runtime that includes node:sqlite, then retry memory_search."
-        : "Check embedding provider configuration and retry memory_search.");
+        : isTimeout
+          ? "Check memory index status (openclaw memory status --index) before retrying memory_search."
+          : "Check embedding provider configuration and retry memory_search.");
+  const diagnostics = overrides?.diagnostics;
+  const cooldownRemainingMs = diagnostics?.cooldownRemainingMs;
   return {
     results: [],
     disabled: true,
@@ -152,10 +173,20 @@ export function buildMemorySearchUnavailableResult(
     error: reason,
     warning,
     action,
+    // A cooldown replay never reaches the index or the provider; without this
+    // marker it is indistinguishable from a fresh attempt.
+    ...(cooldownRemainingMs === undefined ? {} : { cached: true, cooldownRemainingMs }),
     debug: {
       warning,
       action,
       error: reason,
+      ...(diagnostics
+        ? {
+            elapsedMs: diagnostics.elapsedMs,
+            timedOut: isTimeout,
+            ...(diagnostics.phase ? { phase: diagnostics.phase } : {}),
+          }
+        : {}),
     },
   };
 }

--- a/extensions/memory-core/src/tools.test-helpers.ts
+++ b/extensions/memory-core/src/tools.test-helpers.ts
@@ -52,12 +52,36 @@ export function createAutoCitationsMemorySearchTool(agentSessionKey: string) {
   });
 }
 
+export const MEMORY_SEARCH_TIMEOUT_WARNING =
+  "Memory search is unavailable because it timed out before completing; this can be local index maintenance rather than an embedding provider fault.";
+export const MEMORY_SEARCH_TIMEOUT_ACTION =
+  "Check memory index status (openclaw memory status --index) before retrying memory_search.";
+
+/**
+ * Diagnostics the memory_search tool attaches when it fails inside a run.
+ * Payloads built outside a run carry none of these.
+ */
+export function memorySearchFailureDebug(params?: {
+  timedOut?: boolean;
+  phase?: "memory" | "supplement";
+}): Record<string, unknown> {
+  return {
+    elapsedMs: expect.any(Number),
+    timedOut: params?.timedOut ?? false,
+    ...(params?.phase ? { phase: params.phase } : {}),
+  };
+}
+
 export function expectUnavailableMemorySearchDetails(
   details: unknown,
   params: {
     error: string;
     warning: string;
     action: string;
+    /** Failure diagnostics merged into `debug`; see `memorySearchFailureDebug`. */
+    debug?: Record<string, unknown>;
+    cached?: boolean;
+    cooldownRemainingMs?: number;
   },
 ) {
   expect(details).toEqual({
@@ -67,10 +91,15 @@ export function expectUnavailableMemorySearchDetails(
     error: params.error,
     warning: params.warning,
     action: params.action,
+    ...(params.cached === undefined ? {} : { cached: params.cached }),
+    ...(params.cooldownRemainingMs === undefined
+      ? {}
+      : { cooldownRemainingMs: params.cooldownRemainingMs }),
     debug: {
       warning: params.warning,
       action: params.action,
       error: params.error,
+      ...params.debug,
     },
   });
 }

--- a/extensions/memory-core/src/tools.test.ts
+++ b/extensions/memory-core/src/tools.test.ts
@@ -33,6 +33,9 @@ import {
   asOpenClawConfig,
   createMemorySearchToolOrThrow,
   expectUnavailableMemorySearchDetails,
+  MEMORY_SEARCH_TIMEOUT_ACTION,
+  MEMORY_SEARCH_TIMEOUT_WARNING,
+  memorySearchFailureDebug,
 } from "./tools.test-helpers.js";
 
 const sessionStore = vi.hoisted(() => ({
@@ -65,11 +68,16 @@ function createQmdTimeoutSearchTool(options?: { oneShotCliRun?: boolean }) {
   });
 }
 
-function expectMemorySearchTimeout(details: unknown, seconds: number): void {
+function expectMemorySearchTimeout(
+  details: unknown,
+  seconds: number,
+  phase: "memory" | "supplement" = "memory",
+): void {
   expectUnavailableMemorySearchDetails(details, {
     error: `memory_search timed out after ${seconds}s`,
-    warning: "Memory search is unavailable due to an embedding/provider error.",
-    action: "Check embedding provider configuration and retry memory_search.",
+    warning: MEMORY_SEARCH_TIMEOUT_WARNING,
+    action: MEMORY_SEARCH_TIMEOUT_ACTION,
+    debug: memorySearchFailureDebug({ timedOut: true, phase }),
   });
 }
 
@@ -294,6 +302,7 @@ describe("memory_search unavailable payloads", () => {
       error: "openai embeddings failed: 429 insufficient_quota",
       warning: "Memory search is unavailable because the embedding provider quota is exhausted.",
       action: "Top up or switch embedding provider, then retry memory_search.",
+      debug: memorySearchFailureDebug({ phase: "memory" }),
     });
   });
 
@@ -312,6 +321,7 @@ describe("memory_search unavailable payloads", () => {
         "Memory search is unavailable because this OpenClaw Node runtime does not provide SQLite support.",
       action:
         "Run OpenClaw with a Node runtime that includes node:sqlite, then retry memory_search.",
+      debug: memorySearchFailureDebug({ phase: "memory" }),
     });
   });
 
@@ -339,6 +349,7 @@ describe("memory_search unavailable payloads", () => {
       error: "embedding provider timeout",
       warning: "Memory search is unavailable due to an embedding/provider error.",
       action: "Check embedding provider configuration and retry memory_search.",
+      debug: memorySearchFailureDebug({ phase: "memory" }),
     });
   });
 
@@ -388,18 +399,18 @@ describe("memory_search unavailable payloads", () => {
       await vi.advanceTimersByTimeAsync(15_000);
 
       const result = await resultPromise;
-      expectUnavailableMemorySearchDetails(result.details, {
-        error: "memory_search timed out after 15s",
-        warning: "Memory search is unavailable due to an embedding/provider error.",
-        action: "Check embedding provider configuration and retry memory_search.",
-      });
+      expectMemorySearchTimeout(result.details, 15);
       // The deadline must abort the orphaned search, not just race past it.
       expect(searchSignal?.aborted).toBe(true);
       const cooldownResult = await tool.execute("search-cooldown", { query: "hello again" });
       expectUnavailableMemorySearchDetails(cooldownResult.details, {
         error: "memory_search timed out after 15s",
-        warning: "Memory search is unavailable due to an embedding/provider error.",
-        action: "Check embedding provider configuration and retry memory_search.",
+        warning: MEMORY_SEARCH_TIMEOUT_WARNING,
+        action:
+          "Memory search is in a 60s cooldown after a recent failure; do not retry memory_search until it expires.",
+        cached: true,
+        cooldownRemainingMs: 60_000,
+        debug: memorySearchFailureDebug({ timedOut: true }),
       });
       expect(searchCalls).toBe(1);
     } finally {
@@ -426,11 +437,78 @@ describe("memory_search unavailable payloads", () => {
       await vi.advanceTimersByTimeAsync(15_000);
 
       const result = await resultPromise;
-      expectUnavailableMemorySearchDetails(result.details, {
+      expectMemorySearchTimeout(result.details, 15);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("blames the deadline instead of the embedding provider for timeouts", () => {
+    // The 15s deadline also fires on local index maintenance, so pointing the
+    // model at the embedding provider sends every timeout to the wrong owner.
+    const result = buildMemorySearchUnavailableResult("memory_search timed out after 15s");
+
+    expect(result.warning).toBe(MEMORY_SEARCH_TIMEOUT_WARNING);
+    expect(result.action).toBe(MEMORY_SEARCH_TIMEOUT_ACTION);
+  });
+
+  it("keeps elapsed timing and the failing phase on a timed-out payload", async () => {
+    vi.useFakeTimers();
+    try {
+      setMemorySearchImpl(async () => await new Promise(() => {}));
+      const tool = createMemorySearchToolOrThrow();
+
+      const resultPromise = tool.execute("timeout-diagnostics", { query: "hello" });
+      await vi.advanceTimersByTimeAsync(15_000);
+
+      const details = (await resultPromise).details as { debug?: Record<string, unknown> };
+      // Echoing warning/action/error back into `debug` reports nothing the
+      // payload does not already say; a maintainer reading it cannot tell a 15s
+      // stall from an instant provider rejection without the elapsed time.
+      expect(details.debug).toEqual({
+        warning: MEMORY_SEARCH_TIMEOUT_WARNING,
+        action: MEMORY_SEARCH_TIMEOUT_ACTION,
         error: "memory_search timed out after 15s",
-        warning: "Memory search is unavailable due to an embedding/provider error.",
-        action: "Check embedding provider configuration and retry memory_search.",
+        elapsedMs: 15_000,
+        timedOut: true,
+        phase: "memory",
       });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("marks a cooldown replay as cached instead of a fresh failure", async () => {
+    vi.useFakeTimers();
+    try {
+      let searchCalls = 0;
+      setMemorySearchImpl(async () => {
+        searchCalls += 1;
+        return await new Promise(() => {});
+      });
+      const tool = createMemorySearchToolOrThrow();
+
+      const armed = tool.execute("cooldown-arm", { query: "hello" });
+      await vi.advanceTimersByTimeAsync(15_000);
+      await armed;
+      await vi.advanceTimersByTimeAsync(10_000);
+      const replay = await tool.execute("cooldown-replay", { query: "hello again" });
+
+      const details = replay.details as {
+        action?: string;
+        cached?: boolean;
+        cooldownRemainingMs?: number;
+        debug?: Record<string, unknown>;
+      };
+      // The replay never touches the index or the provider, so a payload that is
+      // byte-identical to the fresh failure misreports a second live attempt...
+      expect(searchCalls).toBe(1);
+      expect(details.cached).toBe(true);
+      expect(details.cooldownRemainingMs).toBe(50_000);
+      expect(details.debug?.elapsedMs).toBe(0);
+      // ...and its action must not send the model back into the open breaker.
+      expect(details.action).toMatch(/do not retry/i);
+      expect(details.action).toMatch(/cooldown/i);
     } finally {
       vi.useRealTimers();
     }
@@ -634,8 +712,9 @@ describe("memory_search unavailable payloads", () => {
       const result = await resultPromise;
       expectUnavailableMemorySearchDetails(result.details, {
         error: "qmd query timed out after 45s",
-        warning: "Memory search is unavailable due to an embedding/provider error.",
-        action: "Check embedding provider configuration and retry memory_search.",
+        warning: MEMORY_SEARCH_TIMEOUT_WARNING,
+        action: MEMORY_SEARCH_TIMEOUT_ACTION,
+        debug: memorySearchFailureDebug({ timedOut: true, phase: "memory" }),
       });
     } finally {
       vi.useRealTimers();
@@ -663,7 +742,7 @@ describe("memory_search unavailable payloads", () => {
 
       expect(settled).toBe(true);
       const result = await resultPromise;
-      expectMemorySearchTimeout(result.details, 15);
+      expectMemorySearchTimeout(result.details, 15, "supplement");
       expect(getMemorySearchManagerMockCalls()).toBe(0);
     } finally {
       vi.useRealTimers();

--- a/extensions/memory-core/src/tools.ts
+++ b/extensions/memory-core/src/tools.ts
@@ -118,7 +118,7 @@ function resolveMemorySearchToolCooldownKey(options: {
   return options.agentId ?? options.agentSessionKey ?? "default";
 }
 
-function readMemorySearchToolCooldown(key: string): { error: string } | undefined {
+function readMemorySearchToolCooldown(key: string): { until: number; error: string } | undefined {
   const entry = memorySearchToolCooldowns.get(key);
   if (!entry) {
     return undefined;
@@ -127,7 +127,7 @@ function readMemorySearchToolCooldown(key: string): { error: string } | undefine
     memorySearchToolCooldowns.delete(key);
     return undefined;
   }
-  return { error: entry.error };
+  return { until: entry.until, error: entry.error };
 }
 
 function recordMemorySearchToolCooldown(key: string, error: string): void {
@@ -520,12 +520,21 @@ export function createMemorySearchTool(options: {
             parentSignal: callerSignal,
             run: task,
           });
+        const toolStartedAt = Date.now();
         const runMemorySearchTool = async () => {
-          const toolStartedAt = Date.now();
           const shouldQuerySupplements = requestedCorpus === "wiki" || requestedCorpus === "all";
           const shouldQueryMemory = requestedCorpus !== "wiki" && !cooldown;
           if (cooldown && !shouldQuerySupplements) {
-            return jsonResult(buildMemorySearchUnavailableResult(cooldown.error));
+            const cooldownRemainingMs = Math.max(0, cooldown.until - Date.now());
+            return jsonResult(
+              buildMemorySearchUnavailableResult(cooldown.error, {
+                action: `Memory search is in a ${Math.ceil(cooldownRemainingMs / 1000)}s cooldown after a recent failure; do not retry memory_search until it expires.`,
+                diagnostics: {
+                  elapsedMs: Math.max(0, Date.now() - toolStartedAt),
+                  cooldownRemainingMs,
+                },
+              }),
+            );
           }
           const memoryManagerPurpose = options.oneShotCliRun ? "cli" : undefined;
           const memoryManagersToClose = new Set<ActiveMemoryManagerContext["manager"]>();
@@ -852,7 +861,14 @@ export function createMemorySearchTool(options: {
           if (shouldRecordCooldown) {
             recordMemorySearchToolCooldown(cooldownKey, message);
           }
-          return jsonResult(buildMemorySearchUnavailableResult(message));
+          return jsonResult(
+            buildMemorySearchUnavailableResult(message, {
+              diagnostics: {
+                elapsedMs: Math.max(0, Date.now() - toolStartedAt),
+                ...(unavailablePhase ? { phase: unavailablePhase } : {}),
+              },
+            }),
+          );
         }
       },
   });


### PR DESCRIPTION
Related: #112196

> **Author note:** Written by an AI assistant in an agent session, reviewed and submitted with the operator's approval.

## What Problem This Solves

Resolves a problem where operators debugging a failed `memory_search` are sent after the wrong component,
and then cannot tell how bad the failure actually is.

Three separate misreports, all in the payload the caller sees:

1. **A timeout is reported as an embedding-provider fault.** The classifier matches quota and missing
   `node:sqlite`, and otherwise falls through to *"Memory search is unavailable due to an embedding/provider
   error"* with the action *"Check embedding provider configuration"*. The deadline error
   (`memory_search timed out after 15s`) matches neither pattern — so a stall caused by local index
   maintenance points at the provider. #112196 is exactly this: operators verified `/embeddings` was healthy
   while the real cause was index work.
2. **The failure payload carries no timing.** `debug` was `{ warning, action, error }` — a verbatim copy of
   the three fields directly above it. The success path collects `managerMs`/`searchMs`/`toolMs`; none of it
   survives the failure path, which is precisely when it is needed.
3. **A 60s cooldown replay is indistinguishable from a fresh failure.** During the window the tool returns
   the stored error without touching the index or the provider, in a byte-identical payload — while its own
   action tells the caller to retry, i.e. straight back into the open breaker.

## Why This Change Was Made

Adds a timeout branch to the classifier that names the deadline and points at index status; threads the
elapsed time, a `timedOut` flag and the already-computed `unavailablePhase` into the failure `debug`; and
returns the stored `until` from the cooldown reader so a replay can be marked `cached` with its remaining
window and an action that says to wait rather than retry.

Diagnostics only — control flow, the deadline value, and when the cooldown is armed are all unchanged.
The new `overrides.diagnostics` argument is optional, so callers that cannot measure anything are
unaffected.

Two deliberate boundaries: the manager-setup-error and paused-index-identity early returns still emit the
3-key `debug` (only the catch path has `unavailablePhase`), and this PR does not touch the 15s deadline
itself (#91947).

One visible side effect worth calling out: the classifier matches `"timed out"`, so a QMD subprocess
deadline (`qmd query timed out after 45s`) now also gets the timeout wording instead of the provider
wording. That reads correct to me, but it is a wording change beyond the 15s string. `"embedding provider
timeout"` still classifies as a provider fault, and the existing test covering that still passes.

## User Impact

When memory recall fails, operators and agents now see which component actually failed, how long the call
took before giving up, and whether the response is a live attempt or a cached cooldown replay — instead of
a uniform "embedding/provider error" with no timing. Retry guidance during a cooldown now says to wait out
the window rather than to retry immediately.

No configuration changes, no behavioural change to search itself.

## Evidence

Three tests added to `extensions/memory-core/src/tools.test.ts`:

- `blames the deadline instead of the embedding provider for timeouts`
- `keeps elapsed timing and the failing phase on a timed-out payload`
- `marks a cooldown replay as cached instead of a fresh failure`

Written test-first. With the tests added and no implementation, the file gave
`Tests 4 failed | 43 passed (47)` — the three new ones failing on wrong warning text, missing `debug`
diagnostics, and `cached` being `undefined`, with the 43 pre-existing results unchanged.

Same command on both revisions, Node 24.18.0
(`pnpm exec vitest run extensions/memory-core/src/tools.test.ts`):

| revision | result |
|---|---|
| `4bb8df6` (unmodified base) | `Tests 1 failed \| 43 passed (44)` |
| this branch | `Tests 1 failed \| 46 passed (47)` |

`tools.citations.test.ts` shares the assertion helper and was also updated, so it was run on both
revisions too: `1 failed | 27 passed (28)` on each — identical.

The single failure on each revision is pre-existing and environmental: whichever test in a file first
constructs and executes a memory tool pays a ~130s warm-up on this machine and trips the 120s vitest limit
(`rejects fractional maxResults before searching`, and `appends source information when citations are
enabled`). Neither is touched by this change.

Also clean: `oxlint` on `extensions/memory-core`, `oxfmt --check` on all five changed files, and `run-tsgo`
on `extensions/memory-core/tsconfig.json` plus `test/tsconfig/tsconfig.extensions.test.json`.

**Caveat, stated plainly:** I could not obtain a green full-extension run on this platform. Residual
failures in `pnpm test:extension memory-core` are Windows filesystem limits in unrelated fixtures
(`mkdir '...Notes #1: blue'` — `:` is illegal in Windows filenames; `symlink ... EPERM` needs elevation).
Please lean on the targeted before/after comparison above and on CI.

Note on diff size: `expectUnavailableMemorySearchDetails` asserts the whole payload with a strict
`toEqual`, so every existing unavailable-payload assertion had to declare its diagnostics. That accounts
for most of the test-file churn; no assertion was weakened.

`CHANGELOG.md` intentionally untouched, per CONTRIBUTING.
