### PR TITLE
fix: session history rejects older child sessions

### DIFF
--- a/src/agents/tools/sessions-access.test.ts
+++ b/src/agents/tools/sessions-access.test.ts
@@ -551,6 +551,7 @@ describe("resolveDirectSessionVisibility", () => {
         return {
           session: {
             key: "agent:main:dashboard:old-child",
+            sessionId: "old-child-session",
             parentSessionKey: "agent:main:main",
             status: "done",
             endedAt: 1,
@@ -569,7 +570,10 @@ describe("resolveDirectSessionVisibility", () => {
       callGateway: callGateway as never,
     });
 
-    expect(access).toEqual({ allowed: true });
+    expect(access).toEqual({
+      allowed: true,
+      expectedSessionId: "old-child-session",
+    });
     expect(callGateway).toHaveBeenCalledTimes(1);
     expect(callGateway).toHaveBeenCalledWith({
       method: "sessions.describe",

--- a/src/agents/tools/sessions-access.test.ts
+++ b/src/agents/tools/sessions-access.test.ts
@@ -17,7 +17,10 @@ import {
   registerSessionStateWatch,
 } from "../../sessions/session-state-events.js";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
-import { resolveSandboxedSessionToolContext } from "./sessions-access.js";
+import {
+  resolveDirectSessionVisibility,
+  resolveSandboxedSessionToolContext,
+} from "./sessions-access.js";
 import { testing as sessionsResolutionTesting } from "./sessions-resolution.test-support.js";
 
 describe("resolveSessionToolsVisibility", () => {
@@ -538,5 +541,93 @@ describe("createSessionVisibilityGuard", () => {
       error:
         "Session history visibility is restricted to the current session (tools.sessions.visibility=self).",
     });
+  });
+});
+
+describe("resolveDirectSessionVisibility", () => {
+  it("uses durable parent lineage after spawned listings drop an old child", async () => {
+    const callGateway = vi.fn(async (request: { method?: string }) => {
+      if (request.method === "sessions.describe") {
+        return {
+          session: {
+            key: "agent:main:dashboard:old-child",
+            parentSessionKey: "agent:main:main",
+            status: "done",
+            endedAt: 1,
+          },
+        };
+      }
+      throw new Error(`unexpected method: ${request.method}`);
+    });
+
+    const access = await resolveDirectSessionVisibility({
+      action: "history",
+      requesterSessionKey: "agent:main:main",
+      targetSessionKey: "agent:main:dashboard:old-child",
+      visibility: "tree",
+      a2aPolicy: createAgentToAgentPolicy({} as OpenClawConfig),
+      callGateway: callGateway as never,
+    });
+
+    expect(access).toEqual({ allowed: true });
+    expect(callGateway).toHaveBeenCalledTimes(1);
+    expect(callGateway).toHaveBeenCalledWith({
+      method: "sessions.describe",
+      params: { key: "agent:main:dashboard:old-child" },
+    });
+  });
+
+  it("does not grant unrelated same-agent sessions from an exact row", async () => {
+    const access = await resolveDirectSessionVisibility({
+      action: "history",
+      requesterSessionKey: "agent:main:main",
+      targetSessionKey: "agent:main:dashboard:unrelated",
+      visibility: "tree",
+      a2aPolicy: createAgentToAgentPolicy({} as OpenClawConfig),
+      callGateway: vi.fn(async () => ({
+        session: {
+          key: "agent:main:dashboard:unrelated",
+          parentSessionKey: "agent:main:someone-else",
+        },
+      })) as never,
+    });
+
+    expect(access).toEqual({
+      allowed: false,
+      status: "forbidden",
+      error:
+        "Session history visibility is restricted to the current session tree (tools.sessions.visibility=tree).",
+    });
+  });
+
+  it("falls back to the existing fail-closed lookup when describe is unavailable", async () => {
+    const callGateway = vi.fn(async (request: { method?: string }) => {
+      if (request.method === "sessions.describe") {
+        throw new Error("method unavailable");
+      }
+      if (request.method === "sessions.list") {
+        return { sessions: [] };
+      }
+      throw new Error(`unexpected method: ${request.method}`);
+    });
+    sessionsResolutionTesting.setDepsForTest({ callGateway: callGateway as never });
+    try {
+      const access = await resolveDirectSessionVisibility({
+        action: "history",
+        requesterSessionKey: "agent:main:main",
+        targetSessionKey: "agent:main:dashboard:old-child",
+        visibility: "tree",
+        a2aPolicy: createAgentToAgentPolicy({} as OpenClawConfig),
+        callGateway: callGateway as never,
+      });
+
+      expect(access.allowed).toBe(false);
+      expect(callGateway.mock.calls.map(([request]) => request.method)).toEqual([
+        "sessions.describe",
+        "sessions.list",
+      ]);
+    } finally {
+      sessionsResolutionTesting.setDepsForTest();
+    }
   });
 });

--- a/src/agents/tools/sessions-access.test.ts
+++ b/src/agents/tools/sessions-access.test.ts
@@ -600,7 +600,7 @@ describe("resolveDirectSessionVisibility", () => {
       allowed: false,
       status: "forbidden",
       error:
-        "Session history visibility is restricted to the current session tree (tools.sessions.visibility=tree).",
+        "Session history visibility is restricted to the current session tree and any watched same-agent group sessions (tools.sessions.visibility=tree).",
     });
   });
 

--- a/src/agents/tools/sessions-access.ts
+++ b/src/agents/tools/sessions-access.ts
@@ -28,8 +28,9 @@ export {
 } from "../../plugin-sdk/session-visibility.js";
 
 type GatewayCaller = typeof callGateway;
+type DescribedSessionVisibilityRow = SessionVisibilityRow & { sessionId?: string };
 
-function readSessionVisibilityRow(value: unknown): SessionVisibilityRow | undefined {
+function readSessionVisibilityRow(value: unknown): DescribedSessionVisibilityRow | undefined {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     return undefined;
   }
@@ -40,6 +41,7 @@ function readSessionVisibilityRow(value: unknown): SessionVisibilityRow | undefi
   }
   return {
     key,
+    sessionId: normalizeOptionalString(row.sessionId),
     agentId: normalizeOptionalString(row.agentId),
     ownerSessionKey: normalizeOptionalString(row.ownerSessionKey),
     spawnedBy: normalizeOptionalString(row.spawnedBy),
@@ -93,7 +95,10 @@ export async function resolveDirectSessionVisibility(params: {
       });
       const row = readSessionVisibilityRow(result?.session);
       if (row?.key === params.targetSessionKey) {
-        return rowChecker.check(row);
+        const access = rowChecker.check(row);
+        return access.allowed && row.sessionId
+          ? { allowed: true, expectedSessionId: row.sessionId }
+          : access;
       }
     } catch {
       // Preserve compatibility with older or temporarily unavailable gateways.

--- a/src/agents/tools/sessions-access.ts
+++ b/src/agents/tools/sessions-access.ts
@@ -5,7 +5,18 @@
  */
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { resolveSandboxSessionToolsVisibility } from "../../plugin-sdk/session-visibility.js";
+import type { callGateway } from "../../gateway/call.js";
+import {
+  createSessionVisibilityChecker,
+  createSessionVisibilityGuard,
+  createSessionVisibilityRowChecker,
+  resolveSandboxSessionToolsVisibility,
+  type AgentToAgentPolicy,
+  type SessionAccessAction,
+  type SessionAccessResult,
+  type SessionToolsVisibility,
+  type SessionVisibilityRow,
+} from "../../plugin-sdk/session-visibility.js";
 import { isSubagentSessionKey } from "../../routing/session-key.js";
 import { resolveInternalSessionKey, resolveMainSessionAlias } from "./sessions-resolution.js";
 
@@ -15,6 +26,90 @@ export {
   createSessionVisibilityRowChecker,
   resolveEffectiveSessionToolsVisibility,
 } from "../../plugin-sdk/session-visibility.js";
+
+type GatewayCaller = typeof callGateway;
+
+function readSessionVisibilityRow(value: unknown): SessionVisibilityRow | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  const row = value as Record<string, unknown>;
+  const key = normalizeOptionalString(row.key);
+  if (!key) {
+    return undefined;
+  }
+  return {
+    key,
+    agentId: normalizeOptionalString(row.agentId),
+    ownerSessionKey: normalizeOptionalString(row.ownerSessionKey),
+    spawnedBy: normalizeOptionalString(row.spawnedBy),
+    parentSessionKey: normalizeOptionalString(row.parentSessionKey),
+  };
+}
+
+/**
+ * Authorize one exact session target from its durable Gateway row.
+ * Older gateways or unavailable rows fall back to the existing fail-closed lookup.
+ */
+export async function resolveDirectSessionVisibility(params: {
+  action: Exclude<SessionAccessAction, "list">;
+  defaultAgentId?: string;
+  requesterAgentId?: string;
+  requesterSessionKey: string;
+  targetSessionKey: string;
+  visibility: SessionToolsVisibility;
+  a2aPolicy: AgentToAgentPolicy;
+  callGateway: GatewayCaller;
+}): Promise<SessionAccessResult> {
+  const scoped = createSessionVisibilityChecker.resolveScopedAccess({
+    action: params.action,
+    requesterSessionKey: params.requesterSessionKey,
+    targetSessionKey: params.targetSessionKey,
+  });
+  if (scoped) {
+    return { allowed: true, expectedSessionId: scoped.expectedSessionId };
+  }
+
+  const rowChecker = createSessionVisibilityRowChecker({
+    action: params.action,
+    defaultAgentId: params.defaultAgentId,
+    requesterAgentId: params.requesterAgentId,
+    requesterSessionKey: params.requesterSessionKey,
+    visibility: params.visibility,
+    a2aPolicy: params.a2aPolicy,
+  });
+  if (
+    params.targetSessionKey === params.requesterSessionKey ||
+    params.targetSessionKey === "current"
+  ) {
+    return rowChecker.check({ key: params.targetSessionKey });
+  }
+
+  if (params.visibility === "tree" || params.visibility === "all") {
+    try {
+      const result = await params.callGateway<{ session?: unknown }>({
+        method: "sessions.describe",
+        params: { key: params.targetSessionKey },
+      });
+      const row = readSessionVisibilityRow(result?.session);
+      if (row?.key === params.targetSessionKey) {
+        return rowChecker.check(row);
+      }
+    } catch {
+      // Preserve compatibility with older or temporarily unavailable gateways.
+    }
+  }
+
+  const fallback = await createSessionVisibilityGuard({
+    action: params.action,
+    defaultAgentId: params.defaultAgentId,
+    requesterAgentId: params.requesterAgentId,
+    requesterSessionKey: params.requesterSessionKey,
+    visibility: params.visibility,
+    a2aPolicy: params.a2aPolicy,
+  });
+  return fallback.check(params.targetSessionKey);
+}
 
 /** Resolves the requester context used to filter sandboxed session-tool access. */
 export function resolveSandboxedSessionToolContext(params: {

--- a/src/agents/tools/sessions-helpers.ts
+++ b/src/agents/tools/sessions-helpers.ts
@@ -7,6 +7,7 @@ export {
   createAgentToAgentPolicy,
   createSessionVisibilityGuard,
   createSessionVisibilityRowChecker,
+  resolveDirectSessionVisibility,
   resolveEffectiveSessionToolsVisibility,
   resolveSandboxedSessionToolContext,
 } from "./sessions-access.js";

--- a/src/agents/tools/sessions-history-tool.test.ts
+++ b/src/agents/tools/sessions-history-tool.test.ts
@@ -482,6 +482,51 @@ describe("sessions_history redaction", () => {
     }
   });
 
+  it("reads an old child from durable lineage after spawned listings drop it", async () => {
+    const requesterSessionKey = "agent:main:main";
+    const targetSessionKey = "agent:main:dashboard:old-child";
+    const requests: CallGatewayRequest[] = [];
+    const tool = createSessionsHistoryTool({
+      agentSessionKey: requesterSessionKey,
+      config: {
+        tools: { sessions: { visibility: "tree" } },
+      } as OpenClawConfig,
+      callGateway: async <T = Record<string, unknown>>(request: CallGatewayRequest): Promise<T> => {
+        requests.push(request);
+        if (request.method === "sessions.describe") {
+          return {
+            session: {
+              key: targetSessionKey,
+              parentSessionKey: requesterSessionKey,
+              status: "done",
+              endedAt: 1,
+            },
+          } as T;
+        }
+        if (request.method === "chat.history") {
+          return {
+            messages: [{ role: "assistant", content: "durable child history" }],
+          } as T;
+        }
+        throw new Error(`unexpected method: ${request.method}`);
+      },
+    });
+
+    const result = await tool.execute("old-child-history", {
+      sessionKey: targetSessionKey,
+      limit: 1,
+    });
+
+    expect(result.details).toMatchObject({
+      sessionKey: targetSessionKey,
+      messages: [{ role: "assistant", content: "durable child history" }],
+    });
+    expect(requests.map((request) => request.method)).toEqual([
+      "sessions.describe",
+      "chat.history",
+    ]);
+  });
+
   it("rejects a scoped grant when the target incarnation changes before the read", async () => {
     const requesterSessionKey = "agent:main:clickclack:discussion-race";
     const targetSessionKey = "agent:main:main";

--- a/src/agents/tools/sessions-history-tool.test.ts
+++ b/src/agents/tools/sessions-history-tool.test.ts
@@ -485,10 +485,15 @@ describe("sessions_history redaction", () => {
   it("reads an old child from durable lineage after spawned listings drop it", async () => {
     const requesterSessionKey = "agent:main:main";
     const targetSessionKey = "agent:main:dashboard:old-child";
+    const expectedSessionId = "old-child-session";
+    const storePath = await writeSessionStore("old-child.json", {
+      [targetSessionKey]: { sessionId: expectedSessionId, updatedAt: 1 },
+    });
     const requests: CallGatewayRequest[] = [];
     const tool = createSessionsHistoryTool({
       agentSessionKey: requesterSessionKey,
       config: {
+        session: { store: storePath },
         tools: { sessions: { visibility: "tree" } },
       } as OpenClawConfig,
       callGateway: async <T = Record<string, unknown>>(request: CallGatewayRequest): Promise<T> => {
@@ -497,6 +502,7 @@ describe("sessions_history redaction", () => {
           return {
             session: {
               key: targetSessionKey,
+              sessionId: expectedSessionId,
               parentSessionKey: requesterSessionKey,
               status: "done",
               endedAt: 1,
@@ -525,6 +531,45 @@ describe("sessions_history redaction", () => {
       "sessions.describe",
       "chat.history",
     ]);
+  });
+
+  it("rejects a durable-lineage grant when the target incarnation changes", async () => {
+    const requesterSessionKey = "agent:main:main";
+    const targetSessionKey = "agent:main:dashboard:old-child-race";
+    const expectedSessionId = "old-child-session";
+    const storePath = await writeSessionStore("old-child-race.json", {
+      [targetSessionKey]: { sessionId: expectedSessionId, updatedAt: 1 },
+    });
+    const requests: CallGatewayRequest[] = [];
+    const tool = createSessionsHistoryTool({
+      agentSessionKey: requesterSessionKey,
+      config: {
+        session: { store: storePath },
+        tools: { sessions: { visibility: "tree" } },
+      } as OpenClawConfig,
+      callGateway: async <T = Record<string, unknown>>(request: CallGatewayRequest): Promise<T> => {
+        requests.push(request);
+        if (request.method === "sessions.describe") {
+          replaceSessionEntrySync(
+            { storePath, sessionKey: targetSessionKey },
+            { sessionId: "replacement-session", updatedAt: 2 },
+          );
+          return {
+            session: {
+              key: targetSessionKey,
+              sessionId: expectedSessionId,
+              parentSessionKey: requesterSessionKey,
+            },
+          } as T;
+        }
+        throw new Error(`unexpected method: ${request.method}`);
+      },
+    });
+
+    await expect(
+      tool.execute("old-child-history-race", { sessionKey: targetSessionKey }),
+    ).rejects.toThrow(`Session "${targetSessionKey}" changed after access was granted.`);
+    expect(requests.map((request) => request.method)).toEqual(["sessions.describe"]);
   });
 
   it("rejects a scoped grant when the target incarnation changes before the read", async () => {

--- a/src/agents/tools/sessions-history-tool.ts
+++ b/src/agents/tools/sessions-history-tool.ts
@@ -30,8 +30,8 @@ import {
 } from "./common.js";
 import { runWithScopedSessionAccess } from "./scoped-session-access.js";
 import {
-  createSessionVisibilityGuard,
   createAgentToAgentPolicy,
+  resolveDirectSessionVisibility,
   resolveEffectiveSessionToolsVisibility,
   resolveSessionReference,
   resolveSandboxedSessionToolContext,
@@ -431,14 +431,15 @@ export function createSessionsHistoryTool(opts?: {
         cfg,
         sandboxed: opts?.sandboxed === true,
       });
-      const visibilityGuard = await createSessionVisibilityGuard({
+      const access = await resolveDirectSessionVisibility({
         action: "history",
         defaultAgentId: resolveDefaultAgentId(cfg),
         requesterSessionKey: effectiveRequesterKey,
+        targetSessionKey: resolvedKey,
         visibility,
         a2aPolicy,
+        callGateway: gatewayCall,
       });
-      const access = visibilityGuard.check(resolvedKey);
       if (!access.allowed) {
         return jsonResult({
           status: access.status,


### PR DESCRIPTION
AI-assisted: yes. I reviewed the change and understand the session-visibility and incarnation-fencing behavior.

Closes #114180

## What Problem This Solves

Under the default `tree` visibility, `sessions_list` can return an older durable child session while `sessions_history` rejects the same key after the display-recency window expires. Direct history authorization currently depends on a recency-filtered spawned-session listing instead of the target row's stored lineage.

## Why This Change Was Made

Read-only direct history access now obtains the exact target row through `sessions.describe` and applies the existing canonical row-visibility checker. A successful durable-lineage grant carries the row's `sessionId`, and `runWithScopedSessionAccess` revalidates that incarnation before `chat.history`.

If the exact row is unavailable or the Gateway lacks the method, the code falls back to the existing fail-closed direct guard. The scope intentionally remains limited to `sessions_history`; direct send and status behavior is unchanged and remains an explicit maintainer policy decision.

## User Impact

A parent can read an older child's durable history without widening visibility to every same-agent session. Unrelated sessions remain forbidden, and a session replaced between authorization and transcript read is rejected.

## Evidence

- Current-main behavior: an aged child omitted by the recency-filtered spawned listing receives 0 history reads even when its durable `parentSessionKey` matches the requester.
- Candidate behavior: aged-child history access changes 0 -> 1 through `sessions.describe -> chat.history`.
- Negative controls: unrelated same-agent `chat.history` dispatches remain 0; replacement-incarnation dispatches remain 0; unavailable `sessions.describe` falls back to the existing deny path.
- Focused validation: 55/55 tests pass across `sessions-access` and `sessions-history-tool` in 3.92s with one worker.
- Format/lint: changed-file `oxfmt`, changed-file `oxlint`, and `git diff --check` pass.
- Independent review: `codex review --base origin/main` completed with no actionable findings and confirmed canonical row-checker ownership, fail-closed fallback, and `sessionId` fencing.
- Source identity: branch head `3686e66076f2010cbd02c7003653cefa38dd0057`, merge base `e4b6bde45a0769865219fa0b086618c66decdc13`.
- Runtime behavior proof: on the production-equivalent code diff before this rebase, a redacted loopback Gateway run changed aged-child history access from 0 to 1 while unrelated and replacement-incarnation `chat.history` dispatches remained 0.
- Maintainer decision requested: confirm that durable parent lineage should authorize read-only history after recency expiry while send/status remain unchanged.

Signed-off-by: Ho Lim <subhoya@gmail.com>
