### PR TITLE
fix(gateway): prevent duplicate socket client ownership

### DIFF
--- a/src/gateway/server/ws-connection.startup.test.ts
+++ b/src/gateway/server/ws-connection.startup.test.ts
@@ -22,6 +22,66 @@ import {
 } from "./ws-connection.test-helpers.js";
 
 describe("attachGatewayWsConnectionHandler startup readiness", () => {
+  it("admits only one of two connect frames that race during lazy handler loading", async () => {
+    const sent: unknown[] = [];
+    const clients = new Set<unknown>();
+    const socket = createGatewayWsTestSocket({
+      onSend: (data) => {
+        sent.push(JSON.parse(data));
+      },
+    });
+
+    attachGatewayWsForTest({
+      attach: attachGatewayWsConnectionHandler,
+      clients,
+      socket,
+      options: {
+        resolvedAuth: { mode: "token", allowTailscale: false, token: "test-token" },
+        buildRequestContext: () => createGatewayWsTestRequestContext() as never,
+      },
+    });
+    const connectFrame = (id: string) =>
+      JSON.stringify({
+        type: "req",
+        id,
+        method: "connect",
+        params: {
+          minProtocol: PROTOCOL_VERSION,
+          maxProtocol: PROTOCOL_VERSION,
+          client: {
+            id: "gateway-client",
+            version: "dev",
+            platform: "test",
+            mode: GATEWAY_CLIENT_MODES.BACKEND,
+          },
+          role: "operator",
+          scopes: [],
+          caps: [],
+          auth: { token: "test-token" },
+        },
+      });
+
+    socket.emit("message", connectFrame("connect-1"));
+    socket.emit("message", connectFrame("connect-2"));
+    await vi.dynamicImportSettled();
+
+    await vi.waitFor(() => {
+      expect(clients.size).toBe(1);
+      expect(
+        sent.filter(
+          (frame) =>
+            typeof frame === "object" &&
+            frame !== null &&
+            (frame as { type?: unknown; ok?: unknown }).type === "res" &&
+            (frame as { ok?: unknown }).ok === true,
+        ),
+      ).toHaveLength(1);
+    });
+
+    socket.emit("close", 1000, Buffer.from("done"));
+    expect(clients.size).toBe(0);
+  });
+
   it.each([GATEWAY_STARTUP_CLOSE_CODE, 1006])(
     "keeps startup-unavailable close code %i at debug level",
     async (observedCloseCode) => {

--- a/src/gateway/server/ws-connection.test.ts
+++ b/src/gateway/server/ws-connection.test.ts
@@ -230,6 +230,38 @@ describe("attachGatewayWsConnectionHandler", () => {
     expect(clients.size).toBe(0);
   });
 
+  it("allows only one authenticated client registration per socket", async () => {
+    vi.useFakeTimers();
+    const clients = new Set();
+    const socket = createGatewayWsTestSocket({ ping: true });
+    const { passed } = await connectTestWs({ clients, socket });
+    const handlerParams = passed as {
+      setClient: (client: unknown) => boolean;
+    };
+    const firstClient = {
+      socket,
+      connect: { client: { id: "openclaw-control-ui", mode: "webchat" } },
+      connId: "first-client",
+      usesSharedGatewayAuth: false,
+    };
+    const racedClient = {
+      ...firstClient,
+      connId: "raced-client",
+    };
+
+    expect(handlerParams.setClient(firstClient)).toBe(true);
+    expect(handlerParams.setClient(racedClient)).toBe(false);
+    expect(clients).toEqual(new Set([firstClient]));
+
+    vi.advanceTimersByTime(25_000);
+    expect(socket.ping).toHaveBeenCalledOnce();
+
+    socket.emit("close", 1000, Buffer.from("done"));
+    expect(clients.size).toBe(0);
+    vi.advanceTimersByTime(25_000);
+    expect(socket.ping).toHaveBeenCalledOnce();
+  });
+
   it("continues protocol pings after pong and stops when the connection closes", async () => {
     vi.useFakeTimers();
     const socket = Object.assign(createGatewayWsTestSocket({ ping: true }), {

--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -596,7 +596,9 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
     });
 
     const setClient = (next: GatewayWsClient) => {
-      if (closed) {
+      // Concurrent connect frames can finish authentication out of order. Keep
+      // one socket owner so a raced finalizer cannot leak a client or ping loop.
+      if (closed || client) {
         return false;
       }
       if (next.worker) {


### PR DESCRIPTION
Closes #114195

## What Problem This Solves

Fixes an issue where a gateway WebSocket receiving two valid `connect` frames during lazy handler loading could retain an orphaned client and heartbeat after the socket closed.

## Why This Change Was Made

The per-socket registration boundary now enforces one client owner. A raced finalizer is rejected through the existing caller cleanup path, preserving the first client and its single heartbeat lifecycle without changing protocol shapes or authentication behavior.

## User Impact

Gateway connections no longer accumulate stale client state or heartbeat intervals when duplicate connect frames race during startup.

## Evidence

- Fail-before direct ownership test: second registration returned `true`; 1 failed / 17 passed.
- Fail-before lazy replay test: `clients.size` was 2; 1 failed / 2 passed.
- Pass-after independent focused run: 63 tests passed across the gateway WebSocket test projects.
- `oxfmt`, `oxlint`, `git diff --check`, and the 142-entrypoint public Plugin SDK guard passed.
- Independent Codex `autoreview`: no accepted/actionable P0/P1 findings; overall patch correct (0.94).
- Changed-file secret scan: 3 files scanned, 0 findings.
- Plugin SDK/protocol boundary diff: empty.

## AI Assistance

AI-assisted with Codex. I reviewed the implementation and tests, understand the single-owner lifecycle invariant, and independently reran the focused validation before publication.
