### PR TITLE
fix(openai): preserve Responses controls and terminal state

### DIFF
--- a/packages/ai/src/providers/openai-response-format.ts
+++ b/packages/ai/src/providers/openai-response-format.ts
@@ -1,4 +1,5 @@
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import type { ResponseFormatTextConfig } from "openai/resources/responses/responses.js";
 
 const JSON_SCHEMA_RESPONSE_FORMAT_NAME = "openclaw_response";
 const OLLAMA_CLOUD_ORIGIN = "https://ollama.com";
@@ -65,5 +66,29 @@ export function resolveOpenAICompletionsResponseFormat(
       name: JSON_SCHEMA_RESPONSE_FORMAT_NAME,
       schema: responseFormat,
     },
+  };
+}
+
+/** Maps shared or provider-shaped structured-output options to the Responses API text format. */
+export function resolveOpenAIResponsesTextFormat(
+  responseFormat: Record<string, unknown>,
+): ResponseFormatTextConfig {
+  if (responseFormat.type === "json_schema") {
+    if (isRecord(responseFormat.json_schema)) {
+      return {
+        ...responseFormat.json_schema,
+        type: "json_schema",
+      } as ResponseFormatTextConfig;
+    }
+    // Responses-native json_schema format already carries name/schema at this level.
+    return responseFormat as unknown as ResponseFormatTextConfig;
+  }
+  if (responseFormat.type === "json_object" || responseFormat.type === "text") {
+    return responseFormat as unknown as ResponseFormatTextConfig;
+  }
+  return {
+    type: "json_schema",
+    name: JSON_SCHEMA_RESPONSE_FORMAT_NAME,
+    schema: responseFormat,
   };
 }

--- a/packages/ai/src/providers/openai-responses-shared.test.ts
+++ b/packages/ai/src/providers/openai-responses-shared.test.ts
@@ -1410,6 +1410,12 @@ describe("processResponsesStream", () => {
             id: "resp_failed",
             status: "failed",
             error: { code: "server_error", message: "provider failed" },
+            usage: {
+              input_tokens: 21,
+              output_tokens: 4,
+              total_tokens: 25,
+              input_tokens_details: { cached_tokens: 6, cache_write_tokens: 2 },
+            },
           },
         },
       ]),
@@ -1422,6 +1428,13 @@ describe("processResponsesStream", () => {
       responseId: "resp_failed",
       stopReason: "error",
       errorMessage: "server_error: provider failed",
+      usage: {
+        input: 13,
+        output: 4,
+        cacheRead: 6,
+        cacheWrite: 2,
+        totalTokens: 25,
+      },
     });
   });
 

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -951,17 +951,12 @@ export async function processResponsesStream<TApi extends Api>(
       });
     }
   };
-  const finalizeResponse = (
+  const finalizeUsage = (
     response: Extract<
       ResponseStreamEvent,
-      { type: "response.completed" | "response.incomplete" }
+      { type: "response.completed" | "response.incomplete" | "response.failed" }
     >["response"],
   ): void => {
-    terminalResponseEvent = "finalized";
-    backfillReasoningSignatures(response.output ?? []);
-    if (response.id) {
-      output.responseId = response.id;
-    }
     const mappedUsage = mapResponsesTerminalUsage(response.usage);
     if (mappedUsage) {
       output.usage = {
@@ -976,8 +971,23 @@ export async function processResponsesStream<TApi extends Api>(
         : (response.service_tier ?? options.serviceTier);
       options.applyServiceTierPricing(output.usage, serviceTier);
     }
+  };
+  const finalizeResponse = (
+    response: Extract<
+      ResponseStreamEvent,
+      { type: "response.completed" | "response.incomplete" }
+    >["response"],
+    terminalEventType: "response.completed" | "response.incomplete",
+  ): void => {
+    terminalResponseEvent = "finalized";
+    backfillReasoningSignatures(response.output ?? []);
+    if (response.id) {
+      output.responseId = response.id;
+    }
+    finalizeUsage(response);
     const terminal = resolveResponsesTerminalStopReason({
       status: response.status,
+      terminalEventType,
       incompleteReason: response.incomplete_details?.reason,
       hasToolCall: output.content.some((block) => block.type === "toolCall"),
     });
@@ -1370,7 +1380,7 @@ export async function processResponsesStream<TApi extends Api>(
       if (streamingToolCalls.hasActive()) {
         throw new Error("Responses stream completed with unresolved tool calls");
       }
-      finalizeResponse(event.response);
+      finalizeResponse(event.response, event.type);
     } else if (event.type === "error") {
       throw new Error(
         event.message ? `Error Code ${event.code}: ${event.message}` : "Unknown error",
@@ -1379,6 +1389,7 @@ export async function processResponsesStream<TApi extends Api>(
       const error = event.response?.error;
       const details = event.response?.incomplete_details;
       output.responseId = event.response.id;
+      finalizeUsage(event.response);
       output.stopReason = "error";
       output.errorMessage = error
         ? `${error.code || "unknown"}: ${error.message || "no message"}`

--- a/packages/ai/src/providers/openai-responses-terminal-usage.test.ts
+++ b/packages/ai/src/providers/openai-responses-terminal-usage.test.ts
@@ -90,4 +90,14 @@ describe("resolveResponsesTerminalStopReason", () => {
       },
     );
   });
+
+  it("uses the terminal event type when a compatible response omits status", () => {
+    expect(
+      resolveResponsesTerminalStopReason({
+        status: undefined,
+        terminalEventType: "response.incomplete",
+        hasToolCall: false,
+      }),
+    ).toEqual({ stopReason: "length" });
+  });
 });

--- a/packages/ai/src/providers/openai-responses-terminal-usage.ts
+++ b/packages/ai/src/providers/openai-responses-terminal-usage.ts
@@ -91,13 +91,23 @@ function mapResponsesTerminalStopReason(
  */
 export function resolveResponsesTerminalStopReason(params: {
   status: OpenAI.Responses.ResponseStatus | undefined;
+  terminalEventType?: "response.completed" | "response.incomplete" | "response.failed";
   incompleteReason?: string;
   hasToolCall: boolean;
 }): { stopReason: StopReason; errorMessage?: string } {
-  if (params.status === "incomplete" && params.incompleteReason === "content_filter") {
+  const status =
+    params.status ??
+    (params.terminalEventType === "response.completed"
+      ? "completed"
+      : params.terminalEventType === "response.incomplete"
+        ? "incomplete"
+        : params.terminalEventType === "response.failed"
+          ? "failed"
+          : undefined);
+  if (status === "incomplete" && params.incompleteReason === "content_filter") {
     return { stopReason: "error", errorMessage: "Provider incomplete_reason: content_filter" };
   }
-  const stopReason = mapResponsesTerminalStopReason(params.status);
+  const stopReason = mapResponsesTerminalStopReason(status);
   if (stopReason === "stop" && params.hasToolCall) {
     return { stopReason: "toolUse" };
   }

--- a/packages/ai/src/providers/openai-responses.test.ts
+++ b/packages/ai/src/providers/openai-responses.test.ts
@@ -24,7 +24,7 @@ vi.mock("openai", () => ({
   },
 }));
 
-import { streamOpenAIResponses } from "./openai-responses.js";
+import { streamOpenAIResponses, streamSimpleOpenAIResponses } from "./openai-responses.js";
 
 const context = {
   messages: [{ role: "user", content: "hello", timestamp: 0 }],
@@ -101,5 +101,30 @@ describe("OpenAI Responses provider", () => {
     expect(result.stopReason).toBe("error");
     expect(openAiMockState.params[0]).toMatchObject({ max_output_tokens: 16, store: false });
     expect(openAiMockState.requestOptions[0]).toMatchObject({ maxRetries: 0 });
+  });
+
+  it("projects structured-output schemas for direct and simple Responses streams", async () => {
+    const responseFormat = {
+      type: "object",
+      properties: { reply: { type: "string" } },
+      required: ["reply"],
+      additionalProperties: false,
+    };
+
+    await streamOpenAIResponses(model(), context, {
+      apiKey: "sentinel-key",
+      responseFormat,
+    }).result();
+    await streamSimpleOpenAIResponses(model(), context, {
+      apiKey: "sentinel-key",
+      responseFormat,
+    }).result();
+
+    const expectedText = {
+      format: { type: "json_schema", name: "openclaw_response", schema: responseFormat },
+    };
+    expect(openAiMockState.params).toHaveLength(2);
+    expect(openAiMockState.params[0]).toMatchObject({ text: expectedText });
+    expect(openAiMockState.params[1]).toMatchObject({ text: expectedText });
   });
 });

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -19,6 +19,7 @@ import { isCloudflareProvider, resolveCloudflareBaseUrl } from "./cloudflare.js"
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copilot-headers.js";
 import { clampOpenAIPromptCacheKey } from "./openai-prompt-cache.js";
 import { supportsOpenAITemperature } from "./openai-reasoning-effort.js";
+import { resolveOpenAIResponsesTextFormat } from "./openai-response-format.js";
 import {
   applyCommonResponsesParams,
   convertResponsesMessages,
@@ -205,6 +206,10 @@ function buildParams(
     prompt_cache_retention: getPromptCacheRetention(compat, cacheRetention),
     store: false,
   };
+
+  if (options?.responseFormat !== undefined) {
+    params.text = { format: resolveOpenAIResponsesTextFormat(options.responseFormat) };
+  }
 
   if (options?.maxTokens) {
     params.max_output_tokens = options?.maxTokens;

--- a/packages/ai/src/providers/simple-options.test.ts
+++ b/packages/ai/src/providers/simple-options.test.ts
@@ -35,4 +35,14 @@ describe("simple stream max-token clamp", () => {
     expect(clampMaxTokensToModel(makeModel(), undefined)).toBeUndefined();
     expect(buildBaseOptions(makeModel()).maxTokens).toBeUndefined();
   });
+
+  it("preserves structured-output schemas for provider-specific projection", () => {
+    const responseFormat = {
+      type: "object",
+      properties: { reply: { type: "string" } },
+      required: ["reply"],
+    };
+
+    expect(buildBaseOptions(makeModel(), { responseFormat }).responseFormat).toBe(responseFormat);
+  });
 });

--- a/packages/ai/src/providers/simple-options.ts
+++ b/packages/ai/src/providers/simple-options.ts
@@ -22,6 +22,7 @@ export function buildBaseOptions(
   return {
     temperature: options?.temperature,
     maxTokens: options?.maxTokens,
+    responseFormat: options?.responseFormat,
     stop: options?.stop,
     signal: options?.signal,
     apiKey: apiKey || options?.apiKey,

--- a/packages/ai/src/transports/openai-completions-transport.ts
+++ b/packages/ai/src/transports/openai-completions-transport.ts
@@ -333,7 +333,10 @@ export function createOpenAICompletionsTransportStreamFn(): StreamFn {
         firstEventAbort = createFirstStreamEventAbortController(options?.signal);
         const responseStream = (await client.chat.completions.create(
           params as never,
-          buildOpenAISdkRequestOptions(model, firstEventAbort.signal),
+          buildOpenAISdkRequestOptions(model, firstEventAbort.signal, {
+            timeoutMs: options?.timeoutMs,
+            maxRetries: options?.maxRetries,
+          }),
         )) as unknown as AsyncIterable<ChatCompletionChunk>;
         stream.push({ type: "start", partial: output as never });
         await processOpenAICompletionsStream(responseStream, output, model, stream, {

--- a/packages/ai/src/transports/openai-responses-client.ts
+++ b/packages/ai/src/transports/openai-responses-client.ts
@@ -164,6 +164,8 @@ export function createOpenAIResponsesTransportStreamFn(): StreamFn {
         firstEventAbort = createFirstStreamEventAbortController(options?.signal);
         const requestOptions = buildOpenAISdkRequestOptions(model, firstEventAbort.signal, {
           stream: true,
+          timeoutMs: options?.timeoutMs,
+          maxRetries: options?.maxRetries,
         });
         emitModelTransportDebug(
           log,
@@ -285,7 +287,10 @@ export function createAzureOpenAIResponsesTransportStreamFn(): StreamFn {
         }
         const requestStartedAt = Date.now();
         firstEventAbort = createFirstStreamEventAbortController(options?.signal);
-        const requestOptions = buildOpenAISdkRequestOptions(model, firstEventAbort.signal);
+        const requestOptions = buildOpenAISdkRequestOptions(model, firstEventAbort.signal, {
+          timeoutMs: options?.timeoutMs,
+          maxRetries: options?.maxRetries,
+        });
         emitModelTransportDebug(
           log,
           `[responses] start provider=${model.provider} api=${model.api} model=${model.id} ` +

--- a/packages/ai/src/transports/openai-responses-params-internal.ts
+++ b/packages/ai/src/transports/openai-responses-params-internal.ts
@@ -1,10 +1,6 @@
 import type { Context, Model } from "@openclaw/llm-core";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
-import type {
-  FunctionTool,
-  ResponseFormatTextConfig,
-  ResponseInput,
-} from "openai/resources/responses/responses.js";
+import type { FunctionTool, ResponseInput } from "openai/resources/responses/responses.js";
 import {
   normalizeOpenAIReasoningEffort,
   normalizeOpenAIStrictToolParameters,
@@ -15,6 +11,7 @@ import {
   type OpenAIToolProjection,
 } from "../internal/openai.js";
 import { stripSystemPromptCacheBoundary } from "../internal/shared.js";
+import { resolveOpenAIResponsesTextFormat } from "../providers/openai-response-format.js";
 import { resolveOpenAIStrictToolSetting } from "./host-policy.js";
 import {
   OPENAI_CODEX_RESPONSES_DEFAULT_INSTRUCTIONS,
@@ -204,23 +201,6 @@ function ensureOpenAICodexResponsesInput(messages: ResponseInput, context: Conte
       { type: "input_text", text: OPENAI_CODEX_RESPONSES_EMPTY_INPUT_TEXT },
     ]),
   );
-}
-
-function resolveOpenAIResponsesTextFormat(
-  responseFormat: Record<string, unknown>,
-): ResponseFormatTextConfig {
-  if (
-    responseFormat.type === "json_schema" &&
-    responseFormat.json_schema &&
-    typeof responseFormat.json_schema === "object" &&
-    !Array.isArray(responseFormat.json_schema)
-  ) {
-    return {
-      ...(responseFormat.json_schema as Record<string, unknown>),
-      type: "json_schema",
-    } as unknown as ResponseFormatTextConfig;
-  }
-  return responseFormat as unknown as ResponseFormatTextConfig;
 }
 
 export function buildOpenAIResponsesParams(

--- a/packages/ai/src/transports/openai-responses-stream-internal.ts
+++ b/packages/ai/src/transports/openai-responses-stream-internal.ts
@@ -551,6 +551,7 @@ export async function processResponsesStream(
       }
       recordResponsesTerminalOutcome({
         response,
+        terminalEventType: type,
         output,
         model,
         serviceTier: options?.serviceTier,
@@ -566,6 +567,15 @@ export async function processResponsesStream(
         `Error Code ${stringifyUnknown(event.code, "unknown")}: ${stringifyUnknown(event.message, "Unknown error")}`,
       );
     } else if (type === "response.failed") {
+      const response = event.response as Record<string, unknown> | undefined;
+      recordResponsesTerminalOutcome({
+        response,
+        terminalEventType: "response.failed",
+        output,
+        model,
+        serviceTier: options?.serviceTier,
+        applyServiceTierPricing: options?.applyServiceTierPricing,
+      });
       const failure = normalizeResponsesFailedEvent(event, model);
       if (failure.responseId) {
         output.responseId = failure.responseId;

--- a/packages/ai/src/transports/openai-responses-terminal-outcome.ts
+++ b/packages/ai/src/transports/openai-responses-terminal-outcome.ts
@@ -29,6 +29,7 @@ function readIncompleteReason(response: Record<string, unknown> | undefined): st
 /** Record usage, cost and stop reason from a terminal Responses event onto the output. */
 export function recordResponsesTerminalOutcome(params: {
   response: Record<string, unknown> | undefined;
+  terminalEventType?: "response.completed" | "response.incomplete" | "response.failed";
   output: MutableAssistantOutput;
   model: Model;
   serviceTier?: ResponseCreateParamsStreaming["service_tier"];
@@ -58,6 +59,7 @@ export function recordResponsesTerminalOutcome(params: {
   }
   const terminal = resolveResponsesTerminalStopReason({
     status: response?.status as OpenAI.Responses.ResponseStatus | undefined,
+    terminalEventType: params.terminalEventType,
     incompleteReason: readIncompleteReason(response),
     hasToolCall: output.content.some((block) => block.type === "toolCall"),
   });

--- a/packages/ai/src/transports/openai-transport-params.ts
+++ b/packages/ai/src/transports/openai-transport-params.ts
@@ -237,20 +237,28 @@ export function buildOpenAISdkClientOptions(model: Model): { timeout?: number } 
 export function buildOpenAISdkRequestOptions(
   model: Model,
   signal?: AbortSignal,
-  options?: { stream?: boolean },
-): { signal?: AbortSignal; timeout?: number; headers?: Record<string, string> } | undefined {
-  const timeout = resolveOpenAISdkTimeoutMs(model);
+  options?: { stream?: boolean; timeoutMs?: number; maxRetries?: number },
+):
+  | {
+      signal?: AbortSignal;
+      timeout?: number;
+      maxRetries?: number;
+      headers?: Record<string, string>;
+    }
+  | undefined {
+  const timeout = resolveModelRequestTimeoutMs(model, options?.timeoutMs);
   const headers =
     options?.stream === true && usesNativeOpenAICodexResponsesBackend(model)
       ? { Accept: "text/event-stream" }
       : undefined;
-  if (timeout === undefined && !signal && !headers) {
+  if (timeout === undefined && options?.maxRetries === undefined && !signal && !headers) {
     return undefined;
   }
   return {
     ...(headers ? { headers } : {}),
     ...(signal ? { signal } : {}),
     ...(timeout !== undefined ? { timeout } : {}),
+    ...(options?.maxRetries !== undefined ? { maxRetries: options.maxRetries } : {}),
   };
 }
 

--- a/src/agents/openai-transport-stream.base.test.ts
+++ b/src/agents/openai-transport-stream.base.test.ts
@@ -189,6 +189,13 @@ describe("openai transport stream", () => {
               id: "resp_failed_runtime",
               status: "failed",
               model: "gpt-5.4-pro",
+              usage: {
+                input_tokens: 18,
+                output_tokens: 3,
+                total_tokens: 21,
+                input_tokens_details: { cached_tokens: 4, cache_write_tokens: 2 },
+                output_tokens_details: { reasoning_tokens: 1 },
+              },
             },
           },
         ]),
@@ -199,6 +206,14 @@ describe("openai transport stream", () => {
     ).rejects.toThrow("Unknown error (no error details in response)");
 
     expect(output.responseId).toBe("resp_failed_runtime");
+    expect(output.usage).toMatchObject({
+      input: 12,
+      output: 3,
+      cacheRead: 4,
+      cacheWrite: 2,
+      reasoningTokens: 1,
+      totalTokens: 21,
+    });
   });
 
   it("treats empty Responses error objects as detail-less failures", async () => {

--- a/src/agents/openai-transport-stream.deepseek-and-shaping.test.ts
+++ b/src/agents/openai-transport-stream.deepseek-and-shaping.test.ts
@@ -1358,6 +1358,21 @@ describe("openai transport stream", () => {
     }
 
     {
+      const schema = {
+        type: "object",
+        properties: { reply: { type: "string" } },
+        required: ["reply"],
+        additionalProperties: false,
+      };
+      const params = buildOpenAIResponsesParams(model, context, {
+        responseFormat: schema,
+      }) as Record<string, unknown>;
+      expect(params.text).toEqual({
+        format: { type: "json_schema", name: "openclaw_response", schema },
+      });
+    }
+
+    {
       const params = buildOpenAIResponsesParams(model, context, {}) as Record<string, unknown>;
       expect(params).not.toHaveProperty("text");
     }

--- a/src/agents/openai-transport-stream.incomplete-output.test.ts
+++ b/src/agents/openai-transport-stream.incomplete-output.test.ts
@@ -10,6 +10,38 @@ import { testing } from "./openai-transport-stream.test-support.js";
 // streams that emitted nothing. These cover the two sides of that guard: an incomplete turn
 // whose text arrived only on the terminal event, and one whose text already streamed.
 describe("incomplete Responses terminal output", () => {
+  it("uses the incomplete event type when a compatible endpoint omits response status", async () => {
+    const model = createAzureResponsesModel();
+    const output = createResponsesAssistantOutput(model);
+
+    await testing.processResponsesStream(
+      streamChunks([
+        {
+          type: "response.incomplete",
+          response: {
+            id: "resp-status-omitted",
+            incomplete_details: { reason: "max_output_tokens" },
+            output: [
+              {
+                type: "message",
+                id: "msg-status-omitted",
+                role: "assistant",
+                content: [{ type: "text", text: "TERMINAL_PARTIAL" }],
+              },
+            ],
+            usage: { input_tokens: 9, output_tokens: 2, total_tokens: 11 },
+          },
+        },
+      ]),
+      output,
+      { push: vi.fn() },
+      model,
+    );
+
+    expect(output.stopReason).toBe("length");
+    expect(output.content).toMatchObject([{ type: "text", text: "TERMINAL_PARTIAL" }]);
+  });
+
   it("does not replay terminal text that already streamed", async () => {
     const model = createAzureResponsesModel();
     const output = createResponsesAssistantOutput(model);

--- a/src/agents/openai-transport-stream.streaming.test.ts
+++ b/src/agents/openai-transport-stream.streaming.test.ts
@@ -81,6 +81,31 @@ describe("openai transport stream", () => {
     ).toBeUndefined();
   });
 
+  it("lets per-turn timeout and retry controls override model SDK defaults", () => {
+    const signal = new AbortController().signal;
+    const model = {
+      id: "gpt-5.6-luna",
+      name: "GPT-5.6 Luna",
+      api: "openai-responses",
+      provider: "openai",
+      baseUrl: "https://api.openai.com/v1",
+      reasoning: true,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 200_000,
+      maxTokens: 8192,
+      requestTimeoutMs: 900_000,
+    } satisfies Model<"openai-responses"> & { requestTimeoutMs: number };
+
+    expect(
+      testing.buildOpenAISdkRequestOptions(model, signal, {
+        timeoutMs: 1_234,
+        maxRetries: 0,
+        stream: true,
+      }),
+    ).toEqual({ signal, timeout: 1_234, maxRetries: 0 });
+  });
+
   it("streams OpenAI-compatible loopback requests with the configured SDK timeout", async () => {
     let captured: { path?: string; timeout?: string; model?: string; roles?: string[] } = {};
     const server = createServer((req, res) => {


### PR DESCRIPTION
Closes #114200
Closes #114201
Closes #114202
Closes #114203

## What Problem This Solves

Fixes four related OpenAI transport problems where structured-output constraints could be lost or malformed, failed Responses calls lost terminal usage, status-less incomplete events were treated as complete and lost partial text, and per-turn timeout/retry controls never reached the SDK.

## Why This Change Was Made

The OpenAI provider and transport paths now share one canonical Responses text-format projection, one consistent terminal classification/usage flow, and one SDK request-options builder that accepts the existing per-turn controls. Explicit terminal status still wins when present; the event type is used only as the compatibility fallback. Incomplete tool calls remain excluded from execution.

These fixes belong to the same request/terminal projection boundary and were validated across both the package provider and OpenClaw transport implementations. The change does not alter the plugin SDK, public provider interface, gateway protocol, dependencies, generated artifacts, or configuration schema.

## User Impact

Users can rely on schema-constrained OpenAI Responses output, accurate usage/cost accounting even when a response fails, preserved partial text and `length` semantics from compatible incomplete events, and the timeout/retry policy selected for each turn.

## Evidence

- Changed OpenAI transport matrix: 4 files, 139/139 tests passed.
- Package Responses matrix: 5 files, 98/98 tests passed.
- Wider adjacent Responses/replay/tools matrix: 371/371 tests passed.
- Every reported root cause has a deterministic fail-before/pass-after regression.
- Formatter and oxlint/declaration checks passed on all 19 changed files.
- `git diff --check`: passed.
- Public Plugin SDK surface check: 142 entrypoints; zero forbidden exported subpaths.
- Protected Plugin SDK/protocol diff: zero files.
- Changed-file high-confidence secret scan: zero findings.
- Fresh independent Codex autoreview: no actionable findings; patch-correct confidence 0.93.

AI-assisted development disclosure: this change was developed and reviewed with Codex. The evidence above was collected against the pinned upstream base `c66ca2fbb2b0` and the published head `2f6917d249`.
