### PR TITLE
fix(models): shape unreleased Claude ids with the newest known contract

### DIFF
--- a/extensions/anthropic/forward-compat-generation.test.ts
+++ b/extensions/anthropic/forward-compat-generation.test.ts
@@ -1,0 +1,55 @@
+// Anthropic tests cover forward-compat resolution for unreleased Claude ids.
+import { supportsClaudeAdaptiveThinking } from "openclaw/plugin-sdk/provider-model-shared";
+import { describe, expect, it } from "vitest";
+import { buildAnthropicProvider } from "./register.runtime.js";
+
+function resolveModel(modelId: string, provider = "anthropic") {
+  return buildAnthropicProvider().resolveDynamicModel?.({
+    provider,
+    modelId,
+    config: {},
+    // Released point releases resolve by cloning a catalog template; an empty
+    // registry keeps this test on the generation path under test.
+    modelRegistry: { find: () => undefined },
+  } as unknown as Parameters<
+    NonNullable<ReturnType<typeof buildAnthropicProvider>["resolveDynamicModel"]>
+  >[0]);
+}
+
+describe("unreleased Claude generations", () => {
+  it.each(["claude-opus-6", "claude-sonnet-6", "claude-opus-5-1"])(
+    "resolves %s onto the newest known contract",
+    (modelId) => {
+      const model = resolveModel(modelId);
+      expect(model).toBeDefined();
+      // Without a canonical stamp the shared contracts fall through to pre-4.6
+      // shaping (budget_tokens + caller sampling), which current models reject.
+      expect(supportsClaudeAdaptiveThinking({ id: modelId, params: model?.params })).toBe(true);
+    },
+  );
+
+  it("keeps the family when it recognizes one", () => {
+    expect(resolveModel("claude-sonnet-6")?.params?.canonicalModelId).toBe("claude-sonnet-5");
+    expect(resolveModel("claude-opus-6")?.params?.canonicalModelId).toBe("claude-opus-5");
+  });
+
+  it("does not stamp a canonical id onto released models", () => {
+    // Released ids already carry their own contract; re-pointing them would
+    // silently change shaping for models that work today.
+    expect(resolveModel("claude-opus-5")?.params?.canonicalModelId).toBeUndefined();
+    expect(resolveModel("claude-opus-4-8")?.params?.canonicalModelId).toBeUndefined();
+  });
+
+  it("leaves pre-4.6 and snapshot-dated ids alone", () => {
+    // claude-opus-4-20250514 is 4.0; a naive parse reads 4.20 and would treat it
+    // as newer than every released generation.
+    expect(resolveModel("claude-opus-4-20250514")?.params?.canonicalModelId).toBeUndefined();
+    expect(supportsClaudeAdaptiveThinking({ id: "claude-haiku-4-5-20251001" })).toBe(false);
+  });
+
+  it("does not claim non-Claude ids", () => {
+    // Third-party models reach the Anthropic-compatible transport too.
+    expect(resolveModel("mimo-v2-flash")).toBeUndefined();
+    expect(resolveModel("kimi-k2.6")).toBeUndefined();
+  });
+});

--- a/extensions/anthropic/register.runtime.ts
+++ b/extensions/anthropic/register.runtime.ts
@@ -390,13 +390,66 @@ function resolveAnthropic46ForwardCompatModel(params: {
   });
 }
 
+/** Newest Claude generation whose request contract this plugin encodes. */
+const ANTHROPIC_NEWEST_KNOWN_GENERATION = { major: 5, minor: 0 } as const;
+
+/**
+ * Read the generation from either Claude id order: `claude-<family>-<major>[-<minor>]`
+ * (4.6 onward) and `claude-<major>[-<minor>]-<family>` (through 3.7). The minor
+ * capture is bounded to two digits so a trailing snapshot date such as
+ * `claude-opus-4-20250514` does not parse as a minor version.
+ */
+function resolveAnthropicModelGeneration(
+  modelId: string,
+): { major: number; minor: number } | undefined {
+  const match =
+    /claude-[a-z]+-(\d{1,2})(?:-(\d{1,2}))?(?![0-9])/.exec(modelId) ??
+    /claude-(\d{1,2})(?:-(\d{1,2}))?(?![0-9])/.exec(modelId);
+  if (!match) {
+    return undefined;
+  }
+  return { major: Number(match[1]), minor: match[2] === undefined ? 0 : Number(match[2]) };
+}
+
+/**
+ * Claude ids from a generation newer than anything this plugin encodes. Request
+ * shaping is selected by version predicates in `@openclaw/llm-core`, so such an
+ * id would otherwise fall through to pre-4.6 shaping — manual `budget_tokens`
+ * plus caller sampling params — which current models reject outright.
+ */
+function isAnthropicUnreleasedGenerationModel(modelId: string): boolean {
+  if (matchesAnthropicModernModel(modelId)) {
+    return false;
+  }
+  const generation = resolveAnthropicModelGeneration(modelId);
+  if (!generation) {
+    return false;
+  }
+  return (
+    generation.major > ANTHROPIC_NEWEST_KNOWN_GENERATION.major ||
+    (generation.major === ANTHROPIC_NEWEST_KNOWN_GENERATION.major &&
+      generation.minor > ANTHROPIC_NEWEST_KNOWN_GENERATION.minor)
+  );
+}
+
+/**
+ * Route an unreleased id onto the newest contract we encode, matching family
+ * when we recognize it. Stamping `canonicalModelId` is the same seam Bedrock and
+ * Mantle use to map a provider-native id onto a canonical Claude contract, so
+ * shaping follows without teaching the shared contracts about unknown ids.
+ */
+function resolveAnthropicUnreleasedCanonicalModelId(modelId: string): string {
+  return /(?:^|-)claude-sonnet-/.test(modelId) ? "claude-sonnet-5" : "claude-opus-5";
+}
+
 function buildAnthropicForwardCompatModel(
   ctx: ProviderResolveDynamicModelContext,
 ): ProviderRuntimeModel | undefined {
   const trimmedModelId = ctx.modelId.trim();
   const lower = normalizeLowercaseStringOrEmpty(trimmedModelId);
   const normalizedProvider = normalizeLowercaseStringOrEmpty(ctx.provider);
-  if (trimmedModelId !== lower || !matchesAnthropicModernModel(lower)) {
+  const unreleasedGeneration = isAnthropicUnreleasedGenerationModel(lower);
+  if (trimmedModelId !== lower || !(matchesAnthropicModernModel(lower) || unreleasedGeneration)) {
     return undefined;
   }
   if (isAnthropicMandatoryClaude5Model(lower) && normalizedProvider !== PROVIDER_ID) {
@@ -423,6 +476,9 @@ function buildAnthropicForwardCompatModel(
     maxTokens: isAnthropic128kOutputModel(trimmedModelId)
       ? ANTHROPIC_MODERN_MAX_OUTPUT_TOKENS
       : 64_000,
+    ...(unreleasedGeneration
+      ? { params: { canonicalModelId: resolveAnthropicUnreleasedCanonicalModelId(lower) } }
+      : {}),
     ...(supportsClaudeNativeXhighEffort({ id: trimmedModelId })
       ? {
           thinkingLevelMap: {


### PR DESCRIPTION
## What Problem This Solves

Claude request shaping is selected by version predicates in `packages/llm-core/src/model-contracts/anthropic.ts`, which are allowlists of released ids. An id from a generation newer than anything we encode matches none of them, so it falls through to pre-4.6 shaping: `thinking: {type: "enabled", budget_tokens: N}` plus caller `temperature`/`top_p`/`top_k`. Both are `400`s on every current Claude model. A user does not get "unsupported" — they get a model that fails every request.

This is the remaining half of #113411. Stage 1 (#113757, #113784, #113906) made live discovery work; the contract gate added there hides an unknown model whose advertised capabilities disagree with our shaping, which is the right *safe* behavior but only covers what discovery publishes. Two paths bypass it entirely:

- a model hand-configured in `openclaw.json`
- a model delivered by the hosted catalog overlay (#113660), which supplies metadata but not shaping

Verified directly: `supportsClaudeAdaptiveThinking({ id: "claude-opus-6" })` returns `false` today.

## Why This Change Was Made

The fix stays inside the Anthropic plugin and reuses two mechanisms that already exist, rather than adding a seam.

`buildAnthropicForwardCompatModel` is already the plugin's forward-compat path for ids the catalog does not list, and is already provider-gated to `anthropic` / `claude-cli`. Its gate is widened to also accept a Claude id whose parsed generation is newer than the newest we encode.

Such a model is then stamped with `params.canonicalModelId`, which `resolveClaudeModelIdentity` reads *before* the model's own id. This is the same seam `extensions/amazon-bedrock/discovery.ts` and `extensions/amazon-bedrock-mantle/discovery.ts` already use to map a provider-native id onto a canonical Claude contract. Family is preserved where recognized (`claude-sonnet-6` → `claude-sonnet-5`, otherwise → `claude-opus-5`).

**No shared contract changes.** That is the point of doing it here. An earlier attempt added a forward-compat default inside `llm-core` and broke two existing tests asserting that `claude-future` on `provider: "github-copilot"` keeps legacy shaping — correctly, because Claude reaches us through third-party routes that may not support adaptive thinking even when Anthropic's own API does. The discriminator is the provider, which `llm-core` does not receive and should not. Keeping the decision in the owning plugin resolves that cleanly: third-party routes are untouched.

Generation parsing bounds the minor version to two digits so a trailing snapshot date does not parse as a minor — `claude-opus-4-20250514` is 4.0, not 4.20.

## User Impact

A Claude generation released after an OpenClaw build now works when selected, instead of failing every request. Nothing changes for released models, for pre-4.6 models, or for Claude served through third-party providers.

Cost is deliberately not guessed: an unreleased id keeps the zero-cost default already used on this path, and real pricing arrives from the hosted catalog or discovery.

## Evidence

**The gap, before and after** — `params` come from the plugin's resolved model:

| Ref | `supportsClaudeAdaptiveThinking` |
|---|---|
| `{ id: "claude-opus-6" }` | `false` — pre-4.6 shaping, every request 400s |
| `{ id: "claude-opus-6", params: { canonicalModelId: "claude-opus-5" } }` | `true` |

**Tests** — `extensions/anthropic/forward-compat-generation.test.ts`, seven cases: unreleased ids resolve onto the newest contract; family is preserved; released ids are *not* re-pointed; pre-4.6 and snapshot-dated ids are left alone; non-Claude ids are not claimed. Verified as a real regression guard by removing the stamp — three cases fail, and `resolves claude-opus-6 onto the newest known contract` fails exactly as the bug describes.

- `node scripts/run-vitest.mjs packages/ai packages/llm-core` — **775 passed**, including the two `github-copilot` tests that the rejected `llm-core` approach broke
- `node scripts/run-vitest.mjs extensions/anthropic extensions/amazon-bedrock extensions/anthropic-vertex extensions/amazon-bedrock-mantle extensions/github-copilot` — **704 passed** across every Claude-serving surface
- `pnpm check:test-types` clean; `oxfmt` + `run-oxlint.mjs extensions/anthropic` clean; `git diff --check` clean
- `$autoreview` (Codex `gpt-5.6-sol`, high): clean, no accepted/actionable findings — "patch is correct (0.98)"

Non-test diff is +57/−1, entirely within `extensions/anthropic`.

Closes the stage-2 shaping item on #113411. Extending discovery to Claude CLI, Vertex, Bedrock and Mantle remains open there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
