### PR TITLE
test(ui): assert the Home run ring in chat run lifecycle e2e

### DIFF
--- a/ui/src/e2e/chat-run-lifecycle.e2e.test.ts
+++ b/ui/src/e2e/chat-run-lifecycle.e2e.test.ts
@@ -16,6 +16,9 @@ const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.
 const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
 const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
 const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+// Home mirrors the sidebar leading-slot contract: an active run rings the Home
+// glyph instead of adding a trailing spinner (see app-sidebar-render.ts).
+const HOME_RUN_RING_SELECTOR = ".session-glyph--running .session-glyph__ring";
 
 // Browser contexts preserve test isolation; keep one process warm for this file.
 let browser: Browser;
@@ -155,6 +158,7 @@ describeControlUiE2e("Control UI chat run lifecycle", () => {
 
     await currentPage.getByRole("button", { name: "Stop generating" }).waitFor();
     const mainSession = currentPage.locator(".nav-item--home");
+    const mainSessionRunRing = mainSession.locator(HOME_RUN_RING_SELECTOR);
     await mainSession.waitFor({ state: "visible" });
     const sessionListsBeforeActive = (await gateway.getRequests("sessions.list")).length;
     await gateway.deferNext("sessions.list");
@@ -173,11 +177,11 @@ describeControlUiE2e("Control UI chat run lifecycle", () => {
     await expect
       .poll(async () => (await gateway.getRequests("sessions.list")).length)
       .toBeGreaterThan(sessionListsBeforeActive);
-    await mainSession.locator(".session-run-spinner").waitFor();
+    await mainSessionRunRing.waitFor();
 
     await gateway.emitChatFinal({ runId, text: "Run complete." });
     await currentPage.locator(".chat-bubble").getByText("Run complete.", { exact: true }).waitFor();
-    await expect.poll(() => mainSession.locator(".session-run-spinner").count()).toBe(0);
+    await expect.poll(() => mainSessionRunRing.count()).toBe(0);
     const staleActiveLabel = "Main stale active snapshot";
     await gateway.resolveDeferred("sessions.list", {
       count: 1,
@@ -202,7 +206,7 @@ describeControlUiE2e("Control UI chat run lifecycle", () => {
     });
     await currentPage.locator(".chat-pane__session-title", { hasText: staleActiveLabel }).waitFor();
     expect(await currentPage.getByRole("button", { name: "Stop generating" }).count()).toBe(0);
-    await expect.poll(() => mainSession.locator(".session-run-spinner").count()).toBe(0);
+    await expect.poll(() => mainSessionRunRing.count()).toBe(0);
 
     const sessionListsBeforeStaleActive = (await gateway.getRequests("sessions.list")).length;
     await gateway.deferNext("sessions.list");
@@ -220,12 +224,12 @@ describeControlUiE2e("Control UI chat run lifecycle", () => {
       .poll(async () => (await gateway.getRequests("sessions.list")).length)
       .toBeGreaterThan(sessionListsBeforeStaleActive);
     expect(await currentPage.getByRole("button", { name: "Stop generating" }).count()).toBe(0);
-    await expect.poll(() => mainSession.locator(".session-run-spinner").count()).toBe(0);
+    await expect.poll(() => mainSessionRunRing.count()).toBe(0);
     await gateway.resolveDeferred("sessions.list");
 
     await currentPage.clock.fastForward(CHAT_RUN_STATUS_TOAST_DURATION_MS + 250);
     expect(await currentPage.getByRole("button", { name: "Stop generating" }).count()).toBe(0);
-    expect(await mainSession.locator(".session-run-spinner").count()).toBe(0);
+    expect(await mainSessionRunRing.count()).toBe(0);
 
     // Event timestamps must follow the page's virtual clock so freshness checks
     // see the same elapsed suppression window that the UI just observed.
@@ -243,7 +247,7 @@ describeControlUiE2e("Control UI chat run lifecycle", () => {
       .poll(async () => (await gateway.getRequests("sessions.list")).length)
       .toBeGreaterThan(sessionListsBeforeOtherSession);
     expect(await currentPage.getByRole("button", { name: "Stop generating" }).count()).toBe(0);
-    await expect.poll(() => mainSession.locator(".session-run-spinner").count()).toBe(0);
+    await expect.poll(() => mainSessionRunRing.count()).toBe(0);
     await gateway.resolveDeferred("sessions.list");
 
     // Re-publish after the former 10-second suppression window. The completed
@@ -266,7 +270,7 @@ describeControlUiE2e("Control UI chat run lifecycle", () => {
       .poll(async () => (await gateway.getRequests("sessions.list")).length)
       .toBeGreaterThan(sessionListsBeforeLateStaleActive);
     expect(await currentPage.getByRole("button", { name: "Stop generating" }).count()).toBe(0);
-    await expect.poll(() => mainSession.locator(".session-run-spinner").count()).toBe(0);
+    await expect.poll(() => mainSessionRunRing.count()).toBe(0);
     await gateway.resolveDeferred("sessions.list");
   });
 
@@ -298,6 +302,7 @@ describeControlUiE2e("Control UI chat run lifecycle", () => {
 
     await currentPage.getByRole("button", { name: "Stop generating" }).waitFor();
     const mainSession = currentPage.locator(".nav-item--home");
+    const mainSessionRunRing = mainSession.locator(HOME_RUN_RING_SELECTOR);
     await mainSession.waitFor({ state: "visible" });
     const sessionListsBeforeActive = (await gateway.getRequests("sessions.list")).length;
     await gateway.deferNext("sessions.list");
@@ -314,7 +319,7 @@ describeControlUiE2e("Control UI chat run lifecycle", () => {
     await expect
       .poll(async () => (await gateway.getRequests("sessions.list")).length)
       .toBeGreaterThan(sessionListsBeforeActive);
-    await mainSession.locator(".session-run-spinner").waitFor();
+    await mainSessionRunRing.waitFor();
 
     const finalText = "The gateway will restart; I will resume verification afterward.";
     await gateway.emitGatewayEvent("chat", {
@@ -332,7 +337,7 @@ describeControlUiE2e("Control UI chat run lifecycle", () => {
 
     await currentPage.locator(".chat-thread-inner").getByText(finalText, { exact: true }).waitFor();
     expect(await currentPage.getByRole("button", { name: "Stop generating" }).count()).toBe(0);
-    await expect.poll(() => mainSession.locator(".session-run-spinner").count()).toBe(0);
+    await expect.poll(() => mainSessionRunRing.count()).toBe(0);
     await expect
       .poll(() => currentPage.locator(".agent-chat__run-status-announcement").textContent())
       .toBe("");


### PR DESCRIPTION
## What Problem This Solves

Two Control UI E2E scenarios in `ui/src/e2e/chat-run-lifecycle.e2e.test.ts` fail
deterministically on current `main`, each burning a 30-second Playwright timeout:

- `clears shared session activity when chat final arrives first`
- `does not announce Done when a yielded parent is waiting for continuation`

Both hang on `.nav-item--home .session-run-spinner`, a selector that no longer
exists in the DOM. #113645 moved Home's run state out of the row's trailing badge
slot into the shared leading glyph, so an active run now renders
`.session-glyph--running > .session-glyph__ring` around the Home icon and emits no
trailing spinner at all (`ui/src/components/app-sidebar-render.ts:127-160`,
`ui/src/components/session-glyph.ts:19-31`).

The sidebar unit cases were updated in that PR
(`ui/src/test-helpers/app-sidebar-cases/basics.ts:560` already asserts
`.nav-item--home .session-glyph--running .session-glyph__ring`), but this E2E file
was missed. CI stayed green because the changed-file router never ran it: a change
under `ui/src/components/` resolves to `lanes=coreTests, ui`, and
`isControlUiE2eTarget` (`scripts/test-projects.test-support.mjs:3544`) only selects
the `uiE2e` lane when `ui/src/e2e/**` or `control-ui-e2e.ts` itself changes.

## Why This Change Was Made

The tests now wait on the real run signal instead of the retired one. A single
`HOME_RUN_RING_SELECTOR` constant replaces all nine spinner references across both
scenarios via a per-test `mainSessionRunRing` locator.

This is not just a timeout fix. The seven `count()).toBe(0)` assertions were
passing vacuously against a selector that matched nothing, so the "activity clears
when the chat final lands first" and "no Done announcement while a yielded parent
waits" invariants were not actually being verified. The leading `waitFor` now proves
the ring appears while the deferred `sessions.list` is still outstanding, which is
what makes the subsequent zero-count assertions meaningful again.

No production code changes; Home's run indicator behavior is unchanged and remains
as #113645 shipped it.

## User Impact

None directly. Two Control UI run-lifecycle regressions are covered again rather
than silently skipped, and the E2E file no longer costs 60s of timeout on every
local run.

## Evidence

Focused lane, before (clean `origin/main` at 5347285d6bc, macOS):

```
❯ ui/src/e2e/chat-run-lifecycle.e2e.test.ts (4 tests | 2 failed) 65550ms
  × clears shared session activity when chat final arrives first 31001ms
  × does not announce Done when a yielded parent is waiting for continuation 31063ms

TimeoutError: locator.waitFor: Timeout 30000ms exceeded.
Call log:
  - waiting for locator('.nav-item--home').locator('.session-run-spinner') to be visible
```

After, same command (`node scripts/run-vitest.mjs ui/src/e2e/chat-run-lifecycle.e2e.test.ts`):

```
Test Files  1 passed (1)
     Tests  4 passed (4)
  Duration  6.62s
```

Other `.session-run-spinner` users are unaffected and were left alone:
`ui/src/e2e/session-management.e2e.test.ts:439` targets a `.sidebar-recent-session`
row, which still renders the spinner through `renderSessionState`, and
`ui/src/pages/chat/chat-view.test.ts:957` targets the history-pagination sentinel.
