### PR TITLE
fix(ui): keep the live token counter current in memoized chat rows

### DIFF
--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -2222,6 +2222,54 @@ describe("chat loading skeleton", () => {
     expect(replyCall?.[1].activeContinuation).toBeUndefined();
   });
 
+  it("keeps the live token counter current when only run usage changes", () => {
+    // Run usage arrives on its own patches, so the transcript items, the
+    // shared render context, and this row's own identity all stay put while
+    // the counter ticks.
+    const readingIndicator = { kind: "reading-indicator", key: "reading:test", startedAt: 1 };
+    const reply = {
+      kind: "group",
+      key: "group:assistant:reply",
+      role: "assistant",
+      messages: [
+        {
+          key: "message:assistant:reply",
+          message: { role: "assistant", content: "Interim answer", timestamp: 1 },
+        },
+      ],
+      timestamp: 1,
+      isStreaming: false,
+    };
+    const renderWithUsage = (container: HTMLElement, runOutputTokens: number) => {
+      render(
+        renderChat(createChatProps({ canAbort: true, runOutputTokens, stream: null })),
+        container,
+      );
+    };
+
+    const streamGroupSpy = vi.fn(renderStreamGroupMock);
+    vi.spyOn(chatMessage, "renderStreamGroup").mockImplementation(streamGroupSpy);
+    vi.mocked(chatThread.buildCachedChatItems).mockReturnValue([readingIndicator] as ReturnType<
+      typeof chatThread.buildCachedChatItems
+    >);
+    const standalone = document.createElement("div");
+    renderWithUsage(standalone, 5_500);
+    renderWithUsage(standalone, 7_200);
+    expect(streamGroupSpy.mock.calls.at(-1)?.[1]?.runOutputTokens).toBe(7_200);
+
+    vi.mocked(chatThread.buildCachedChatItems).mockReturnValue([
+      reply,
+      readingIndicator,
+    ] as ReturnType<typeof chatThread.buildCachedChatItems>);
+    const embedded = document.createElement("div");
+    renderWithUsage(embedded, 5_500);
+    renderMessageGroupMock.mockClear();
+    renderWithUsage(embedded, 7_200);
+    expect(
+      renderMessageGroupMock.mock.calls.at(-1)?.[1].activeContinuation?.options.runOutputTokens,
+    ).toBe(7_200);
+  });
+
   it("releases the embedded recap when a later reply becomes the settled turn", () => {
     const firstReply = {
       kind: "group",

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -1130,19 +1130,16 @@ function trackTranscriptRenderDependencies(
 
 function guardChatRenderItems(
   state: ChatThreadState,
-  // Turn status ownership is decided by sibling rows, not by the owning row's
-  // own content: an unchanged reply that gains or loses the embedded working
-  // row / recap must re-render, or the stale copy stacks with the new owner.
-  statusOwnership: (item: ChatRenderItem) => string,
+  // Live run status is not derivable from a row's own item identity: ownership
+  // is decided by sibling rows, and the usage counter ticks on run patches that
+  // touch nothing else. Rows showing status must re-render on both, or the
+  // memoized copy stacks a second claw row or freezes the token count.
+  liveStatus: (item: ChatRenderItem) => string,
   render: (item: ChatRenderItem) => unknown,
 ) {
   return (item: ChatRenderItem) =>
     guard(
-      [
-        ...chatRenderItemGuardDependencies(item),
-        state.transcriptRenderContext,
-        statusOwnership(item),
-      ],
+      [...chatRenderItemGuardDependencies(item), state.transcriptRenderContext, liveStatus(item)],
       () => render(item),
     );
 }
@@ -1317,19 +1314,28 @@ function renderChatThreadContents(
       turnRecap: turnRecapByGroupKey.get(item.key),
     });
   };
-  const statusOwnershipSignature = (item: ChatRenderItem): string => {
+  // Only the working indicator shows live usage, so rows without one keep
+  // memoizing across usage patches.
+  const workingUsageKey = `usage:${props.runOutputTokens ?? ""}`;
+  const liveStatusSignature = (item: ChatRenderItem): string => {
+    if (item.kind === "stream-run") {
+      return item.parts.some((part) => part.kind === "reading-indicator") ? workingUsageKey : "";
+    }
     if (item.kind !== "group") {
       return "";
     }
     const continuation = activeContinuationByGroupKey.get(item.key);
     const recap = turnRecapByGroupKey.get(item.key);
-    // Part keys stand in for the continuation: its options mirror props that
-    // already invalidate every row through the shared render context.
-    return `${continuation?.parts.map((part) => part.key).join(" ") ?? ""}|${
-      recap ? `${recap.runtimeMs}:${recap.outputTokens ?? ""}` : ""
-    }`;
+    // Part keys stand in for the rest of the continuation: its remaining
+    // options mirror props that already invalidate every row through the
+    // shared render context.
+    const continuationKey = continuation
+      ? `${continuation.parts.map((part) => part.key).join(" ")}${workingUsageKey}`
+      : "";
+    const recapKey = recap ? `${recap.runtimeMs}:${recap.outputTokens ?? ""}` : "";
+    return `${continuationKey}|${recapKey}`;
   };
-  const renderItem = guardChatRenderItems(state, statusOwnershipSignature, (item) => {
+  const renderItem = guardChatRenderItems(state, liveStatusSignature, (item) => {
     if (item.kind === "divider") {
       return renderChatDivider(item, props.onOpenSessionCheckpoints);
     }


### PR DESCRIPTION
## What Problem This Solves

The live output-token counter in the chat working indicator freezes at whatever value it had when its row first rendered. During a long turn the claw keeps animating and the elapsed timer keeps counting, but "5.5k output tokens" never moves — so the one number that tells you the model is actually producing something is the one number that lies.

## Why This Change Was Made

Transcript rows memoize through `guard()` on their own item identity plus a shared render context, and `trackTranscriptRenderDependencies` deliberately excludes `chatItems` so appending a row does not invalidate its neighbours. Run usage arrives on its own patches into `chatRunUsageById` and reaches the thread as `props.runOutputTokens`, which is in neither dependency set. Meanwhile the reading-indicator item is intentionally stable — `resolveWorkingProgress` caches `key`/`startedAt` per run and `sameChatItem` compares only `startedAt` — so the row that renders the counter has no reason to re-render as usage ticks.

Unlike `openclaw-elapsed-time` and `openclaw-working-phrase`, which are self-updating components, `renderLiveOutputTokens` is plain markup evaluated at render time. A memoized row therefore keeps the stale count indefinitely.

Adding `runOutputTokens` to the shared render context would fix it by invalidating every transcript row on every usage patch, which is exactly the churn that context is built to avoid. Instead this extends the per-row signature introduced in #114039 (renamed `statusOwnershipSignature` -> `liveStatusSignature`, since it now covers both reasons a status row goes stale). Only rows that actually render a working indicator carry the usage value: a standalone `stream-run` containing a reading indicator, and an assistant group with an embedded continuation. Every other row keeps memoizing untouched.

## User Impact

The output-token counter now advances while the agent works, in both presentations — the standalone status row and the status embedded in the owning assistant reply.

## Evidence

- `node scripts/run-vitest.mjs ui/src/pages/chat` — 1894 passed, 9 skipped (79 files).
- New regression test `keeps the live token counter current when only run usage changes` renders twice into one container with stable item objects, so `guard()` memoization is genuinely exercised, and covers both the standalone row and the embedded continuation. It fails on the parent commit (`expected 5500 to be 7200`) and passes here; neutralizing just the usage key in the signature reproduces that failure.
- `node scripts/run-tsgo.mjs -p tsconfig.ui.json` — clean.
- `node scripts/run-oxlint.mjs` over the touched files — clean. `git diff --check` — clean.
- Fresh branch-mode autoreview (Codex `gpt-5.6-sol`, xhigh) against current `main`: `autoreview clean: no accepted/actionable findings reported`.

No screenshot: the change is a re-render trigger, not a visual change — the indicator markup is untouched, and its rendering is already covered by `shows live output usage beside elapsed time` in `ui/src/pages/chat/components/chat-message.test.ts`. A static screenshot cannot show a counter failing to advance.

Follow-up from the review of [#114039](https://github.com/openclaw/openclaw/pull/114039), where this was noted as pre-existing and out of scope.

AI-assisted implementation and review.
