### PR TITLE
fix(agents): retry live model switches outside fallback chain

### DIFF
--- a/docs/concepts/model-failover.md
+++ b/docs/concepts/model-failover.md
@@ -287,7 +287,7 @@ OpenClaw builds the candidate list from the currently requested `provider/model`
     - overloaded/provider-busy errors
     - timeout-shaped failover errors
     - billing disables
-    - `LiveSessionModelSwitchError`, which is normalized into a failover path so a stale persisted model does not create an outer retry loop
+    - `LiveSessionModelSwitchError` for a stale current or earlier candidate; later configured targets redirect directly, while targets outside the chain return to the bounded session-model retry owner
     - other unrecognized errors when there are still remaining candidates
 
   </Tab>
@@ -330,6 +330,7 @@ Live model switching follows these rules:
 - `/status` shows the selected model and, when fallback state differs, the active fallback model and reason.
 - Live-session reconciliation prefers persisted session overrides over stale runtime model fields.
 - If a live-switch error points at a later candidate in the active fallback chain, OpenClaw jumps directly to that selected model instead of walking unrelated candidates first.
+- If a live switch selects a model outside the active fallback chain, OpenClaw returns the original switch to the agent, reply, or isolated-cron retry owner so the selected model can complete the same turn.
 
 The active run carries its chosen candidate directly. Live reconciliation changes that candidate only for an explicit pending user switch, so no temporary fallback override or rollback is needed.
 

--- a/src/agents/model-fallback-attempt.ts
+++ b/src/agents/model-fallback-attempt.ts
@@ -555,18 +555,19 @@ export function appendFailedCandidateAttempt(params: {
   });
 }
 
-export function findLiveSessionModelSwitchRedirectIndex(params: {
+export function resolveLiveSessionModelSwitchRedirectIndex(params: {
   error: LiveSessionModelSwitchError;
   candidates: ModelCandidate[];
   currentIndex: number;
 }): number | null {
   const targetKey = modelKey(params.error.provider, params.error.model);
-  for (const [offset, candidate] of params.candidates.slice(params.currentIndex + 1).entries()) {
-    if (modelKey(candidate.provider, candidate.model) === targetKey) {
-      return params.currentIndex + 1 + offset;
-    }
+  const targetIndex = params.candidates.findIndex(
+    (candidate) => modelKey(candidate.provider, candidate.model) === targetKey,
+  );
+  if (targetIndex === -1) {
+    throw params.error;
   }
-  return null;
+  return targetIndex > params.currentIndex ? targetIndex : null;
 }
 
 export function hasDifferentLiveSessionRuntimeSelection(params: {

--- a/src/agents/model-fallback-attempt.ts
+++ b/src/agents/model-fallback-attempt.ts
@@ -567,18 +567,19 @@ export function appendFailedCandidateAttempt(params: {
   });
 }
 
-export function findLiveSessionModelSwitchRedirectIndex(params: {
+export function resolveLiveSessionModelSwitchRedirectIndex(params: {
   error: LiveSessionModelSwitchError;
   candidates: ModelCandidate[];
   currentIndex: number;
 }): number | null {
   const targetKey = modelKey(params.error.provider, params.error.model);
-  for (const [offset, candidate] of params.candidates.slice(params.currentIndex + 1).entries()) {
-    if (modelKey(candidate.provider, candidate.model) === targetKey) {
-      return params.currentIndex + 1 + offset;
-    }
+  const targetIndex = params.candidates.findIndex(
+    (candidate) => modelKey(candidate.provider, candidate.model) === targetKey,
+  );
+  if (targetIndex === -1) {
+    throw params.error;
   }
-  return null;
+  return targetIndex > params.currentIndex ? targetIndex : null;
 }
 
 export function hasDifferentLiveSessionRuntimeSelection(params: {

--- a/src/agents/model-fallback-runner.ts
+++ b/src/agents/model-fallback-runner.ts
@@ -665,6 +665,16 @@ async function runWithModelFallbackInternal<T>(
         continue;
       }
 
+      const pointsAtCurrentOrEarlierCandidate = candidates
+        .slice(0, i + 1)
+        .some((fallbackCandidate) => sameModelCandidate(fallbackCandidate, err));
+      if (!pointsAtCurrentOrEarlierCandidate) {
+        // The user selected a model outside this fallback chain. Return the
+        // control signal to the bounded outer owner so it can rebuild runtime,
+        // auth, and fallback state around that exact selection.
+        throw err;
+      }
+
       const switchMsg = err.message;
       const switchNormalized = new FailoverError(switchMsg, {
         reason: "unknown",

--- a/src/agents/model-fallback-runner.ts
+++ b/src/agents/model-fallback-runner.ts
@@ -37,7 +37,6 @@ import {
 import { LiveSessionModelSwitchError } from "./live-model-switch-error.js";
 import {
   appendFailedCandidateAttempt,
-  findLiveSessionModelSwitchRedirectIndex,
   hasDifferentLiveSessionRuntimeSelection,
   isTranscriptNotContinuableError,
   type ModelFallbackAuthRuntime,
@@ -51,6 +50,7 @@ import {
   type ModelFallbackStepHandler,
   recordFailedCandidateAttempt,
   resolveFallbackSoonestCooldownExpiry,
+  resolveLiveSessionModelSwitchRedirectIndex,
   resolveModelFallbackCandidateAgentRuntime,
   resolveModelFallbackCandidateHarnessAuthPrecheck,
   resolveNextFallbackCandidateIndex,
@@ -655,7 +655,7 @@ async function runWithModelFallbackInternal<T>(
       ) {
         throw err;
       }
-      const liveSwitchTargetIndex = findLiveSessionModelSwitchRedirectIndex({
+      const liveSwitchTargetIndex = resolveLiveSessionModelSwitchRedirectIndex({
         error: err,
         candidates,
         currentIndex: i,
@@ -663,16 +663,6 @@ async function runWithModelFallbackInternal<T>(
       if (liveSwitchTargetIndex !== null) {
         i = liveSwitchTargetIndex - 1;
         continue;
-      }
-
-      const pointsAtCurrentOrEarlierCandidate = candidates
-        .slice(0, i + 1)
-        .some((fallbackCandidate) => sameModelCandidate(fallbackCandidate, err));
-      if (!pointsAtCurrentOrEarlierCandidate) {
-        // The user selected a model outside this fallback chain. Return the
-        // control signal to the bounded outer owner so it can rebuild runtime,
-        // auth, and fallback state around that exact selection.
-        throw err;
       }
 
       const switchMsg = err.message;

--- a/src/agents/model-fallback-runner.ts
+++ b/src/agents/model-fallback-runner.ts
@@ -612,6 +612,16 @@ async function runWithModelFallbackInternal<T>(
         continue;
       }
 
+      const pointsAtCurrentOrEarlierCandidate = candidates
+        .slice(0, i + 1)
+        .some((fallbackCandidate) => sameModelCandidate(fallbackCandidate, err));
+      if (!pointsAtCurrentOrEarlierCandidate) {
+        // The user selected a model outside this fallback chain. Return the
+        // control signal to the bounded outer owner so it can rebuild runtime,
+        // auth, and fallback state around that exact selection.
+        throw err;
+      }
+
       const switchMsg = err.message;
       const switchNormalized = new FailoverError(switchMsg, {
         reason: "unknown",

--- a/src/agents/model-fallback-runner.ts
+++ b/src/agents/model-fallback-runner.ts
@@ -37,7 +37,6 @@ import {
 import { LiveSessionModelSwitchError } from "./live-model-switch-error.js";
 import {
   appendFailedCandidateAttempt,
-  findLiveSessionModelSwitchRedirectIndex,
   hasDifferentLiveSessionRuntimeSelection,
   isTranscriptNotContinuableError,
   type ModelFallbackAuthRuntime,
@@ -51,6 +50,7 @@ import {
   type ModelFallbackStepHandler,
   recordFailedCandidateAttempt,
   resolveFallbackSoonestCooldownExpiry,
+  resolveLiveSessionModelSwitchRedirectIndex,
   resolveModelFallbackCandidateAgentRuntime,
   resolveModelFallbackCandidateHarnessAuthPrecheck,
   resolveNextFallbackCandidateIndex,
@@ -602,7 +602,7 @@ async function runWithModelFallbackInternal<T>(
       ) {
         throw err;
       }
-      const liveSwitchTargetIndex = findLiveSessionModelSwitchRedirectIndex({
+      const liveSwitchTargetIndex = resolveLiveSessionModelSwitchRedirectIndex({
         error: err,
         candidates,
         currentIndex: i,
@@ -610,16 +610,6 @@ async function runWithModelFallbackInternal<T>(
       if (liveSwitchTargetIndex !== null) {
         i = liveSwitchTargetIndex - 1;
         continue;
-      }
-
-      const pointsAtCurrentOrEarlierCandidate = candidates
-        .slice(0, i + 1)
-        .some((fallbackCandidate) => sameModelCandidate(fallbackCandidate, err));
-      if (!pointsAtCurrentOrEarlierCandidate) {
-        // The user selected a model outside this fallback chain. Return the
-        // control signal to the bounded outer owner so it can rebuild runtime,
-        // auth, and fallback state around that exact selection.
-        throw err;
       }
 
       const switchMsg = err.message;

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -2942,7 +2942,7 @@ describe("runWithModelFallback", () => {
         defaults: {
           model: {
             primary: "openai/gpt-4.1-mini",
-            fallbacks: ["anthropic/claude-haiku-3-5", "openrouter/deepseek-chat"],
+            fallbacks: ["anthropic/claude-haiku-3-5", "deepseek/deepseek-chat"],
           },
         },
       },
@@ -2970,8 +2970,8 @@ describe("runWithModelFallback", () => {
       run,
     });
     expect(result.result).toBe("ok");
-    expect(result.provider).toBe("openrouter");
-    expect(result.model).toBe("openrouter/deepseek-chat");
+    expect(result.provider).toBe("deepseek");
+    expect(result.model).toBe("deepseek-chat");
     expect(run).toHaveBeenCalledTimes(3);
   });
 

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -2917,13 +2917,51 @@ describe("runWithModelFallback", () => {
     expect(run).toHaveBeenCalledTimes(1);
   });
 
-  it("continues fallback chain past LiveSessionModelSwitchError to next candidate (#58496 family)", async () => {
-    const cfg = makeCfg();
+  it("returns an unconfigured live switch target to the retry owner (#101676)", async () => {
     const switchError = new LiveSessionModelSwitchError({
       provider: "anthropic",
       model: "claude-sonnet-4-6",
     });
-    const run = vi.fn().mockRejectedValueOnce(switchError).mockResolvedValueOnce("ok");
+    const run = vi.fn().mockRejectedValue(switchError);
+
+    await expect(
+      runWithModelFallback({
+        cfg: makeCfg(),
+        provider: "openai",
+        model: "gpt-4.1-mini",
+        fallbacksOverride: [],
+        run,
+      }),
+    ).rejects.toBe(switchError);
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it("continues fallback past a stale switch to an earlier candidate (#58496 family)", async () => {
+    const cfg = makeCfg({
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai/gpt-4.1-mini",
+            fallbacks: ["anthropic/claude-haiku-3-5", "openrouter/deepseek-chat"],
+          },
+        },
+      },
+    });
+    const switchError = new LiveSessionModelSwitchError({
+      provider: "openai",
+      model: "gpt-4.1-mini",
+    });
+    const run = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new FailoverError("rate limited", {
+          reason: "rate_limit",
+          provider: "openai",
+          model: "gpt-4.1-mini",
+        }),
+      )
+      .mockRejectedValueOnce(switchError)
+      .mockResolvedValueOnce("ok");
 
     const result = await runWithModelFallback({
       cfg,
@@ -2932,7 +2970,9 @@ describe("runWithModelFallback", () => {
       run,
     });
     expect(result.result).toBe("ok");
-    expect(run).toHaveBeenCalledTimes(2);
+    expect(result.provider).toBe("openrouter");
+    expect(result.model).toBe("openrouter/deepseek-chat");
+    expect(run).toHaveBeenCalledTimes(3);
   });
 
   it("jumps directly to a later live-session model switch candidate (#57471)", async () => {

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -2758,13 +2758,51 @@ describe("runWithModelFallback", () => {
     expect(run).toHaveBeenCalledTimes(1);
   });
 
-  it("continues fallback chain past LiveSessionModelSwitchError to next candidate (#58496 family)", async () => {
-    const cfg = makeCfg();
+  it("returns an unconfigured live switch target to the retry owner (#101676)", async () => {
     const switchError = new LiveSessionModelSwitchError({
       provider: "anthropic",
       model: "claude-sonnet-4-6",
     });
-    const run = vi.fn().mockRejectedValueOnce(switchError).mockResolvedValueOnce("ok");
+    const run = vi.fn().mockRejectedValue(switchError);
+
+    await expect(
+      runWithModelFallback({
+        cfg: makeCfg(),
+        provider: "openai",
+        model: "gpt-4.1-mini",
+        fallbacksOverride: [],
+        run,
+      }),
+    ).rejects.toBe(switchError);
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it("continues fallback past a stale switch to an earlier candidate (#58496 family)", async () => {
+    const cfg = makeCfg({
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai/gpt-4.1-mini",
+            fallbacks: ["anthropic/claude-haiku-3-5", "openrouter/deepseek-chat"],
+          },
+        },
+      },
+    });
+    const switchError = new LiveSessionModelSwitchError({
+      provider: "openai",
+      model: "gpt-4.1-mini",
+    });
+    const run = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new FailoverError("rate limited", {
+          reason: "rate_limit",
+          provider: "openai",
+          model: "gpt-4.1-mini",
+        }),
+      )
+      .mockRejectedValueOnce(switchError)
+      .mockResolvedValueOnce("ok");
 
     const result = await runWithModelFallback({
       cfg,
@@ -2773,7 +2811,9 @@ describe("runWithModelFallback", () => {
       run,
     });
     expect(result.result).toBe("ok");
-    expect(run).toHaveBeenCalledTimes(2);
+    expect(result.provider).toBe("openrouter");
+    expect(result.model).toBe("openrouter/deepseek-chat");
+    expect(run).toHaveBeenCalledTimes(3);
   });
 
   it("jumps directly to a later live-session model switch candidate (#57471)", async () => {

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -2783,7 +2783,7 @@ describe("runWithModelFallback", () => {
         defaults: {
           model: {
             primary: "openai/gpt-4.1-mini",
-            fallbacks: ["anthropic/claude-haiku-3-5", "openrouter/deepseek-chat"],
+            fallbacks: ["anthropic/claude-haiku-3-5", "deepseek/deepseek-chat"],
           },
         },
       },
@@ -2811,8 +2811,8 @@ describe("runWithModelFallback", () => {
       run,
     });
     expect(result.result).toBe("ok");
-    expect(result.provider).toBe("openrouter");
-    expect(result.model).toBe("openrouter/deepseek-chat");
+    expect(result.provider).toBe("deepseek");
+    expect(result.model).toBe("deepseek-chat");
     expect(run).toHaveBeenCalledTimes(3);
   });
 


### PR DESCRIPTION
AI-assisted: yes. I reviewed the change and understand the fallback and live-switch retry behavior.

Closes #101676

## What Problem This Solves

A model switch during an active turn currently terminates that turn when the selected model is allowed but is not already in the configured fallback chain. The fallback runner converts the live-switch control signal into a fallback failure before the existing bounded retry owner can handle it.

## Why This Change Was Made

The fallback owner now classifies the requested target across the complete candidate chain. A later configured target still redirects in-chain, a current or earlier target retains the stale-switch loop guard, and a target outside the chain returns the original control signal to the existing bounded agent or cron retry owner.

This keeps candidate-chain decisions in the fallback runner while leaving model validation, session-state refresh, and retry limits with their existing outer owners.

## User Impact

An in-flight switch to an allowed model outside the fallback chain can continue the same turn on the selected model instead of ending with a fallback error. Existing fallback ordering and stale-switch protections remain unchanged.

## Evidence

- Current-main baseline: the focused #101676 regression loses both out-of-chain control signals because they become `FailoverError` (0/2 exact propagations).
- Rebased candidate: both agent-runtime lanes preserve the exact `LiveSessionModelSwitchError` (2/2).
- Focused owner-boundary validation: 296/296 tests pass across fallback classification, agent-command retry, live selection state, and isolated cron retry paths with one worker.
- Correctness gate: later configured targets remain in-chain; current or earlier stale targets remain non-restartable; runtime-only switches and bounded outer retries pass.
- Format/lint: changed-file `oxfmt`, changed-file `oxlint`, and `git diff --check` pass.
- Independent review: `codex review --base origin/main` completed with no actionable findings.
- Source identity: branch head `d54d8ce7f10c25de73eea55216fe63f821b51163`, merge base `e4b6bde45a0769865219fa0b086618c66decdc13`.
- Runtime behavior proof: on the production-equivalent code diff before the test-only fixture clarification, a local Gateway turn with zero configured fallbacks switched from model A to out-of-chain model B. Provider requests were exactly `model-a`, then `model-b`; the same turn completed on B with `fallbackUsed=false`, no external credentials, and zero external cost.

### Inspectable redacted runtime transcript

```text
configuredFallbackCount=0
providerRequestModels=[model-a,model-b]
winnerModel=model-b
fallbackUsed=false
sameTurnCompleted=true
completionMarker=SWITCHED_MODEL_B_OK
externalCredentialsUsed=false
```

Signed-off-by: Ho Lim <subhoya@gmail.com>
