### PR TITLE
fix(plugins): report empty npm install failures

### DIFF
--- a/src/plugins/install-managed-npm-state.ts
+++ b/src/plugins/install-managed-npm-state.ts
@@ -14,7 +14,7 @@ import {
 import { parseRegistryNpmSpec, validateRegistryNpmSpec } from "../infra/npm-registry-spec.js";
 import { isNotFoundPathError } from "../infra/path-guards.js";
 import { createSafeNpmInstallEnv } from "../infra/safe-package-install.js";
-import { runCommandWithTimeout } from "../process/exec.js";
+import { runCommandWithTimeout, type SpawnResult } from "../process/exec.js";
 import {
   resolvePluginNpmGenerationProjectDir,
   resolvePluginNpmGenerationProjectDirPrefix,
@@ -435,8 +435,18 @@ export async function cleanupManagedNpmPluginInstallRollbackSnapshot(params: {
   }
 }
 
-export function formatNpmCommandFailureOutput(result: { stdout: string; stderr: string }): string {
-  return result.stderr.trim() || result.stdout.trim();
+export function formatNpmCommandFailureOutput(result: SpawnResult): string {
+  const detail = result.stderr.trim() || result.stdout.trim();
+  if (detail) {
+    return detail;
+  }
+  if (result.code !== null) {
+    return `exit code ${result.code} (no output from npm)`;
+  }
+  if (result.signal) {
+    return `signal ${result.signal} (no output from npm)`;
+  }
+  return `termination ${result.termination} (no output from npm)`;
 }
 
 export function isManagedNpmProjectCorruptionInstallFailure(result: {

--- a/src/plugins/install-managed-npm.ts
+++ b/src/plugins/install-managed-npm.ts
@@ -358,7 +358,7 @@ export async function installPluginFromManagedNpmRoot(
       if (install.code !== 0) {
         return await rollbackFailedManagedNpmInstall({
           ok: false,
-          error: `npm install failed after syncing managed peer dependencies: ${install.stderr.trim() || install.stdout.trim()}`,
+          error: `npm install failed after syncing managed peer dependencies: ${formatNpmCommandFailureOutput(install)}`,
         });
       }
     }

--- a/src/plugins/install.npm-spec.test.ts
+++ b/src/plugins/install.npm-spec.test.ts
@@ -1880,6 +1880,45 @@ describe("installPluginFromNpmSpec", () => {
     expect(managedInstallAttempts).toBe(2);
   });
 
+  it("reports the npm exit code when a managed install fails without output", async () => {
+    const stateDir = suiteTempRootTracker.makeTempDir();
+    const npmRoot = path.join(stateDir, "npm");
+    const packageName = "empty-output-plugin";
+    const npmProjectRoot = resolvePluginNpmProjectDir({ npmDir: npmRoot, packageName });
+
+    mockNpmViewAndInstall({
+      spec: `${packageName}@1.0.0`,
+      packageName,
+      version: "1.0.0",
+      pluginId: packageName,
+      npmRoot,
+      expectedDependencySpec: "1.0.0",
+    });
+    const delegate = runCommandWithTimeoutMock.getMockImplementation();
+    if (!delegate) {
+      throw new Error("expected npm mock implementation");
+    }
+    runCommandWithTimeoutMock.mockImplementation(
+      async (argv: string[], options?: { cwd?: string }) => {
+        if (isManagedNpmInstallCommand(argv) && options?.cwd === npmProjectRoot) {
+          return failedSpawn("");
+        }
+        return await delegate(argv, options);
+      },
+    );
+
+    const result = await installPluginFromNpmSpec({
+      spec: `${packageName}@1.0.0`,
+      npmDir: npmRoot,
+      logger: { info: () => {}, warn: () => {} },
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("npm install failed: exit code 1 (no output from npm)");
+    }
+  });
+
   it("keeps corrupt managed npm project artifacts quarantined when the rebuild retry fails", async () => {
     const stateDir = suiteTempRootTracker.makeTempDir();
     const npmRoot = path.join(stateDir, "npm");


### PR DESCRIPTION
Fixes #113975

## What Problem This Solves

Fixes an issue where users whose managed plugin installation failed without npm output saw an empty `npm install failed:` diagnostic instead of useful failure information.

## Why This Change Was Made

The managed npm installer now reports its exit code, signal, or termination reason when npm produces no stdout or stderr. Existing npm output remains unchanged when it is available, and the CLI continues to exit nonzero on installation failure.

The peer-dependency reconciliation retry now uses that same formatter, so a later silent npm failure cannot reintroduce an empty diagnostic.

## User Impact

Users can distinguish a silent npm failure from a successful installation and have actionable information for retrying or reporting the failure.

## Evidence

- Rebased onto current `origin/main`; head: `2a5649e44c`.
- Controlled local managed-installer integration: an isolated, PATH-prepended `npm` executable exited 1 without stdout/stderr. The actual `installPluginFromManagedNpmRoot` path returned `npm install failed: exit code 1 (no output from npm)` and the harness exited 1. This proves the managed installer’s subprocess boundary; it is not represented as a public-registry npm run.
- `node scripts/run-vitest.mjs src/plugins/install.npm-spec.test.ts` — 63 passed.
- `node scripts/run-vitest.mjs src/cli/plugins-cli.install.test.ts -t "reports npm install failures without trying ClawHub when npm: prefix is used"` — 1 passed; verifies the CLI failure path exits 1.
- `git diff --check` — passed.
