### PR TITLE
refactor(state): isolate verifier test cleanup

### DIFF
--- a/src/state/openclaw-database-verify.test.ts
+++ b/src/state/openclaw-database-verify.test.ts
@@ -1,8 +1,8 @@
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
-import { afterAll, afterEach, describe, expect, it } from "vitest";
-import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { requireNodeSqlite } from "../infra/node-sqlite.js";
 import { readStableSqliteFileGeneration } from "../infra/sqlite-file-generation.js";
 import { readSqliteNumberPragma } from "../infra/sqlite-pragma.test-support.js";
@@ -33,14 +33,13 @@ import {
   repairOpenClawStateDatabaseSchema,
 } from "./openclaw-state-db.js";
 
-const tempDirs: string[] = [];
-
-afterEach(() => {
-  closeOpenClawAgentDatabasesForTest();
-  closeOpenClawStateDatabaseForTest();
+const tempDirs = useAutoCleanupTempDirTracker((cleanup) => {
+  afterEach(() => {
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+    cleanup();
+  });
 });
-
-afterAll(() => cleanupTempDirs(tempDirs));
 
 function createUnsafeIndexDrift(databasePath: string): void {
   const { DatabaseSync } = requireNodeSqlite();
@@ -118,7 +117,7 @@ describe("OpenClaw database integrity verifier", () => {
   it.skipIf(process.platform === "win32")(
     "preserves live WAL ownership while snapshotting an open database",
     async () => {
-      const stateDir = makeTempDir(tempDirs, "openclaw-database-verify-live-locks-");
+      const stateDir = tempDirs.make("openclaw-database-verify-live-locks-");
       const env = { OPENCLAW_STATE_DIR: stateDir };
       const agent = openOpenClawAgentDatabase({ agentId: "worker-1", env });
       agent.db
@@ -175,7 +174,7 @@ describe("OpenClaw database integrity verifier", () => {
   );
 
   it("detects corruption off-thread, quarantines it, and latches later opens", async () => {
-    const stateDir = makeTempDir(tempDirs, "openclaw-database-verify-");
+    const stateDir = tempDirs.make("openclaw-database-verify-");
     const env = { OPENCLAW_STATE_DIR: stateDir };
     const agentPath = openOpenClawAgentDatabase({ agentId: "worker-1", env }).path;
     createUnsafeIndexDrift(agentPath);
@@ -225,7 +224,7 @@ describe("OpenClaw database integrity verifier", () => {
   });
 
   it("does not quarantine a healthy database that replaced the verified file", async () => {
-    const stateDir = makeTempDir(tempDirs, "openclaw-database-verify-replacement-");
+    const stateDir = tempDirs.make("openclaw-database-verify-replacement-");
     const env = { OPENCLAW_STATE_DIR: stateDir };
     const agentPath = openOpenClawAgentDatabase({ agentId: "worker-1", env }).path;
     closeOpenClawAgentDatabasesForTest();
@@ -258,7 +257,7 @@ describe("OpenClaw database integrity verifier", () => {
   it.skipIf(process.platform === "win32")(
     "does not quarantine a healthy replacement while the corrupt agent inode is cached",
     async () => {
-      const stateDir = makeTempDir(tempDirs, "openclaw-database-verify-live-agent-replace-");
+      const stateDir = tempDirs.make("openclaw-database-verify-live-agent-replace-");
       const env = { OPENCLAW_STATE_DIR: stateDir };
       const agent = openOpenClawAgentDatabase({ agentId: "worker-1", env });
       const healthyReplacementPath = `${agent.path}.healthy`;
@@ -283,7 +282,7 @@ describe("OpenClaw database integrity verifier", () => {
   it.skipIf(process.platform === "win32")(
     "does not quarantine a healthy replacement while the corrupt state inode is cached",
     async () => {
-      const stateDir = makeTempDir(tempDirs, "openclaw-database-verify-live-state-replace-");
+      const stateDir = tempDirs.make("openclaw-database-verify-live-state-replace-");
       const env = { OPENCLAW_STATE_DIR: stateDir };
       const state = openOpenClawStateDatabase({ env });
       const healthyReplacementPath = `${state.path}.healthy`;
@@ -306,7 +305,7 @@ describe("OpenClaw database integrity verifier", () => {
   );
 
   it("reconfirms and quarantines a corrupt closed database", async () => {
-    const stateDir = makeTempDir(tempDirs, "openclaw-database-verify-closed-");
+    const stateDir = tempDirs.make("openclaw-database-verify-closed-");
     const env = { OPENCLAW_STATE_DIR: stateDir };
     const agentPath = openOpenClawAgentDatabase({ agentId: "worker-1", env }).path;
     closeOpenClawAgentDatabasesForTest();
@@ -328,7 +327,7 @@ describe("OpenClaw database integrity verifier", () => {
   });
 
   it("does not quarantine a repaired database after same-inode mutation", async () => {
-    const stateDir = makeTempDir(tempDirs, "openclaw-database-verify-repair-race-");
+    const stateDir = tempDirs.make("openclaw-database-verify-repair-race-");
     const env = { OPENCLAW_STATE_DIR: stateDir };
     const agentPath = openOpenClawAgentDatabase({ agentId: "worker-1", env }).path;
     closeOpenClawAgentDatabasesForTest();
@@ -351,7 +350,7 @@ describe("OpenClaw database integrity verifier", () => {
   });
 
   it("rejects stale terminal results after draining healthy owners", () => {
-    const stateDir = makeTempDir(tempDirs, "openclaw-database-verify-live-stale-");
+    const stateDir = tempDirs.make("openclaw-database-verify-live-stale-");
     const env = { OPENCLAW_STATE_DIR: stateDir };
     const state = openOpenClawStateDatabase({ env });
     const agent = openOpenClawAgentDatabase({ agentId: "worker-1", env });
@@ -380,7 +379,7 @@ describe("OpenClaw database integrity verifier", () => {
   });
 
   it("revalidates agent schema ownership after confirmation drains a pathname", () => {
-    const stateDir = makeTempDir(tempDirs, "openclaw-database-verify-agent-revalidate-");
+    const stateDir = tempDirs.make("openclaw-database-verify-agent-revalidate-");
     const env = { OPENCLAW_STATE_DIR: stateDir };
     const agent = openOpenClawAgentDatabase({ agentId: "worker-1", env });
     const replacementPath = `${agent.path}.replacement`;
@@ -409,7 +408,7 @@ describe("OpenClaw database integrity verifier", () => {
   });
 
   it("expires a generation-bound process latch after the database changes", () => {
-    const stateDir = makeTempDir(tempDirs, "openclaw-database-verify-latch-generation-");
+    const stateDir = tempDirs.make("openclaw-database-verify-latch-generation-");
     const env = { OPENCLAW_STATE_DIR: stateDir };
     const agentPath = openOpenClawAgentDatabase({ agentId: "worker-1", env }).path;
     closeOpenClawAgentDatabasesForTest();
@@ -430,7 +429,7 @@ describe("OpenClaw database integrity verifier", () => {
   });
 
   it("reports an uncleared quarantine row instead of claiming repair success", () => {
-    const stateDir = makeTempDir(tempDirs, "openclaw-database-verify-clear-failure-");
+    const stateDir = tempDirs.make("openclaw-database-verify-clear-failure-");
     const env = { OPENCLAW_STATE_DIR: stateDir };
     const agentPath = openOpenClawAgentDatabase({ agentId: "worker-1", env }).path;
     openOpenClawStateDatabase({ env });
@@ -471,7 +470,7 @@ describe("OpenClaw database integrity verifier", () => {
   });
 
   it("keeps healthy opens on the missing-store fast path", () => {
-    const stateDir = makeTempDir(tempDirs, "openclaw-database-verify-clean-");
+    const stateDir = tempDirs.make("openclaw-database-verify-clean-");
     const env = { OPENCLAW_STATE_DIR: stateDir };
 
     openOpenClawStateDatabase({ env });
@@ -481,7 +480,7 @@ describe("OpenClaw database integrity verifier", () => {
   });
 
   it("records and clears dedicated quarantine rows with rollback journaling", () => {
-    const stateDir = makeTempDir(tempDirs, "openclaw-database-verify-store-");
+    const stateDir = tempDirs.make("openclaw-database-verify-store-");
     const env = { OPENCLAW_STATE_DIR: stateDir };
     const databasePath = path.join(stateDir, "agent.sqlite");
     const storePath = quarantineStorePath(stateDir);
@@ -520,7 +519,7 @@ describe("OpenClaw database integrity verifier", () => {
   });
 
   it("expires a persisted quarantine when the verified database generation changes", () => {
-    const stateDir = makeTempDir(tempDirs, "openclaw-database-verify-store-generation-");
+    const stateDir = tempDirs.make("openclaw-database-verify-store-generation-");
     const env = { OPENCLAW_STATE_DIR: stateDir };
     const databasePath = path.join(stateDir, "agent.sqlite");
     const { DatabaseSync } = requireNodeSqlite();
@@ -555,7 +554,7 @@ describe("OpenClaw database integrity verifier", () => {
   });
 
   it("reads schema-v1 quarantine rows and migrates them on the next write", () => {
-    const stateDir = makeTempDir(tempDirs, "openclaw-database-verify-store-v1-");
+    const stateDir = tempDirs.make("openclaw-database-verify-store-v1-");
     const env = { OPENCLAW_STATE_DIR: stateDir };
     const databasePath = path.join(stateDir, "agent.sqlite");
     const storePath = quarantineStorePath(stateDir);
@@ -610,7 +609,7 @@ describe("OpenClaw database integrity verifier", () => {
   });
 
   it("recovers an interrupted empty quarantine-store initialization", () => {
-    const stateDir = makeTempDir(tempDirs, "openclaw-database-verify-empty-store-");
+    const stateDir = tempDirs.make("openclaw-database-verify-empty-store-");
     const env = { OPENCLAW_STATE_DIR: stateDir };
     const databasePath = path.join(stateDir, "agent.sqlite");
     const storePath = quarantineStorePath(stateDir);
@@ -632,7 +631,7 @@ describe("OpenClaw database integrity verifier", () => {
   it.skipIf(process.platform === "win32")(
     "recovers a hot rollback journal before reading quarantine",
     () => {
-      const stateDir = makeTempDir(tempDirs, "openclaw-database-verify-hot-journal-");
+      const stateDir = tempDirs.make("openclaw-database-verify-hot-journal-");
       const env = { OPENCLAW_STATE_DIR: stateDir };
       const databasePath = path.join(stateDir, "agent.sqlite");
       const storePath = quarantineStorePath(stateDir);
@@ -671,7 +670,7 @@ describe("OpenClaw database integrity verifier", () => {
   );
 
   it("does not latch transient verifier errors", () => {
-    const stateDir = makeTempDir(tempDirs, "openclaw-database-verify-transient-");
+    const stateDir = tempDirs.make("openclaw-database-verify-transient-");
     const env = { OPENCLAW_STATE_DIR: stateDir };
     const agentPath = openOpenClawAgentDatabase({ agentId: "worker-1", env }).path;
     closeOpenClawAgentDatabasesForTest();
@@ -690,7 +689,7 @@ describe("OpenClaw database integrity verifier", () => {
   });
 
   it("persists state failure quarantine across restart until doctor repair", () => {
-    const stateDir = makeTempDir(tempDirs, "openclaw-database-verify-state-failure-");
+    const stateDir = tempDirs.make("openclaw-database-verify-state-failure-");
     const env = { OPENCLAW_STATE_DIR: stateDir };
     const statePath = openOpenClawStateDatabase({ env }).path;
     closeOpenClawStateDatabaseForTest();

--- a/src/state/openclaw-database-verify.test.ts
+++ b/src/state/openclaw-database-verify.test.ts
@@ -35,9 +35,15 @@ import {
 
 const tempDirs = useAutoCleanupTempDirTracker((cleanup) => {
   afterEach(() => {
-    closeOpenClawAgentDatabasesForTest();
-    closeOpenClawStateDatabaseForTest();
-    cleanup();
+    try {
+      closeOpenClawAgentDatabasesForTest();
+    } finally {
+      try {
+        closeOpenClawStateDatabaseForTest();
+      } finally {
+        cleanup();
+      }
+    }
   });
 });
 


### PR DESCRIPTION
Related: #114016

AI-assisted: yes. This is the explicit maintainer-requested follow-up cleanup from the #114016 landing pass.

## What Problem This Solves

The database verifier test suite kept every temporary state directory alive until the entire file finished. New tests therefore triggered the repository's temp-directory migration warning, and failed tests could retain more cross-test filesystem state than necessary.

## Why This Change Was Made

The suite now uses the repository's auto-cleanup tracker and closes process-held SQLite handles before removing each test's temporary directories. Nested `finally` blocks guarantee that both database owners and the tracker get their teardown attempt even when an earlier close throws. This keeps cleanup aligned with individual test ownership without changing verifier behavior or assertions.

## User Impact

No user-visible behavior changes. Maintainers get tighter test isolation, prompt temporary-file cleanup, and a clean changed-gate report.

## Evidence

- Blacksmith Testbox `tbx_01kygh9fzyer74vhm4chjsj6bd`, Actions run https://github.com/openclaw/openclaw/actions/runs/30228685699
  - `pnpm test src/state/openclaw-database-verify.test.ts`: 19/19 passed.
  - `pnpm check:changed`: complete `coreTests` plan passed, including format, test types, lint, and zero temp-directory migration warnings.
- Post-review Testbox `tbx_01kygj9d7apbdvf03dxag327cf`, Actions run https://github.com/openclaw/openclaw/actions/runs/30229413805: focused verifier suite 19/19 passed.
- Final branch autoreview: clean, no accepted/actionable findings; post-review delta confidence 0.99.
- `git diff --check`: passed.
