### PR TITLE
fix: prevent auth migration isolation CI timeouts

### DIFF
--- a/src/secrets/runtime.auth-migration-isolation.test.ts
+++ b/src/secrets/runtime.auth-migration-isolation.test.ts
@@ -76,6 +76,8 @@ describe("auth profile migration isolation", () => {
       resolveApiKeyForProvider({
         provider: "openai",
         agentDir: healthyAgentDir,
+        profileId: "openai:default",
+        lockedProfile: true,
         store: snapshot.authStores.find((entry) => entry.agentDir === healthyAgentDir)?.store,
       }),
     ).resolves.toMatchObject({ apiKey: "fake-healthy-key" });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the auth migration-isolation regression test could time out in the full secrets shard because its healthy-agent assertion entered broad automatic provider/profile discovery.

## Why This Change Was Made

The fixture already creates and selects `openai:default`. Resolve that exact locked profile for the healthy-agent assertion so the test exercises migration isolation, not unrelated provider discovery.

## User Impact

No product behavior changes. Maintainer CI gets a deterministic, bounded regression test.

## Evidence

- Before on current `main`, focused Blacksmith Testbox proof: test body 68.2-70.1 seconds; three full-shard runs exceeded the 120-second timeout.
- After on current `main`, Blacksmith Testbox `tbx_01kygh9b69xsanhazmfwqgxphe`: 1 test passed; test body 154 ms.
- Blacksmith Testbox `tbx_01kyghed7mphcceb8xdv9367hw`: `node scripts/check-changed.mjs` passed (format, boundaries, dependency guards, core-test typecheck, lint).
- AutoReview: no actionable findings.
