### PR TITLE
refactor(ai): preserve abort reasons so restart recovery reads a code

### DIFF
--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -18,6 +18,7 @@ import {
   type AnthropicInlineImageBudget,
 } from "../internal/anthropic-inline-images.js";
 import { calculateCost, clampThinkingLevel } from "../model-utils.js";
+import { transportAbortError } from "../transports/transport-stream-shared.js";
 import type {
   AnthropicMessagesCompat,
   Api,
@@ -804,7 +805,7 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
       }
 
       if (requestOptions?.signal?.aborted) {
-        throw new Error("Request was aborted");
+        throw transportAbortError(requestOptions.signal);
       }
 
       if (output.stopReason === "aborted" || output.stopReason === "error") {

--- a/packages/ai/src/providers/google-shared.ts
+++ b/packages/ai/src/providers/google-shared.ts
@@ -14,6 +14,7 @@ import {
   ThinkingLevel,
 } from "@google/genai";
 import { calculateCost, clampThinkingLevel } from "../model-utils.js";
+import { transportAbortError } from "../transports/transport-stream-shared.js";
 import type {
   Api,
   AssistantMessage,
@@ -907,7 +908,7 @@ export async function consumeGoogleGenerateContentStream<T extends GoogleApiType
   endCurrentBlock();
 
   if (params.signal?.aborted) {
-    throw new Error("Request was aborted");
+    throw transportAbortError(params.signal);
   }
 
   if (params.output.stopReason === "aborted" || params.output.stopReason === "error") {

--- a/packages/ai/src/providers/mistral.ts
+++ b/packages/ai/src/providers/mistral.ts
@@ -12,6 +12,7 @@ import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { getEnvApiKey } from "../env-api-keys.js";
 import { getAiTransportHost } from "../host.js";
 import { calculateCost, clampThinkingLevel } from "../model-utils.js";
+import { transportAbortError } from "../transports/transport-stream-shared.js";
 import type {
   AssistantMessage,
   Context,
@@ -180,7 +181,7 @@ export const streamMistral: StreamFunction<"mistral-conversations", MistralOptio
       await consumeChatStream(model, output, stream, mistralStream);
 
       if (options?.signal?.aborted) {
-        throw new Error("Request was aborted");
+        throw transportAbortError(options.signal);
       }
 
       if (output.stopReason === "aborted" || output.stopReason === "error") {

--- a/packages/ai/src/providers/openai-chatgpt-responses.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.ts
@@ -36,6 +36,7 @@ import { getAiTransportHost, resolveAiTransportHeaderSentinels } from "../host.j
 import { parseRetryAfterHttpDateMs } from "../internal/retry-after.js";
 import { sleepWithAbort } from "../internal/retry-sleep.js";
 import { registerSessionResourceCleanup } from "../session-resources.js";
+import { transportAbortError } from "../transports/transport-stream-shared.js";
 import type {
   Api,
   AssistantMessage,
@@ -341,7 +342,7 @@ export const streamOpenAICodexResponses: StreamFunction<
             );
 
             if (activeSignal?.aborted) {
-              throw new Error("Request was aborted");
+              throw transportAbortError(activeSignal);
             }
             stream.push({
               type: "done",
@@ -398,7 +399,7 @@ export const streamOpenAICodexResponses: StreamFunction<
 
       for (let attempt = 0; attempt <= maxRetries; attempt++) {
         if (activeSignal?.aborted) {
-          throw new Error("Request was aborted");
+          throw transportAbortError(activeSignal);
         }
 
         let attemptResponse: Response;
@@ -480,7 +481,7 @@ export const streamOpenAICodexResponses: StreamFunction<
       await processStream(response, output, stream, model, options, firstEventAbort.abort);
 
       if (activeSignal?.aborted) {
-        throw new Error("Request was aborted");
+        throw transportAbortError(activeSignal);
       }
 
       stream.push({
@@ -1349,7 +1350,7 @@ async function* parseWebSocket(
   try {
     while (true) {
       if (signal?.aborted) {
-        throw new Error("Request was aborted");
+        throw transportAbortError(signal);
       }
       const next = queue.shift();
       if (next !== undefined) {
@@ -1482,7 +1483,7 @@ async function processWebSocketStream(
     useCachedContext && entry ? buildCachedWebSocketRequestBody(entry, fullBody) : fullBody;
   try {
     if (options?.signal?.aborted) {
-      throw new Error("Request was aborted");
+      throw transportAbortError(options.signal);
     }
     socket.send(JSON.stringify({ type: "response.create", ...requestBody }));
     await processResponsesStream(

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -19,6 +19,7 @@ import {
   clampThinkingLevel,
 } from "../model-utils.js";
 import { resolveOpenAIReasoningEffortMap } from "../transports/openai-reasoning-compat.js";
+import { transportAbortError } from "../transports/transport-stream-shared.js";
 import type {
   AssistantMessage,
   CacheRetention,
@@ -569,7 +570,7 @@ export const streamOpenAICompletions: StreamFunction<
         finishBlock(block);
       }
       if (options?.signal?.aborted) {
-        throw new Error("Request was aborted");
+        throw transportAbortError(options.signal);
       }
 
       if (output.stopReason === "aborted") {

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -14,6 +14,7 @@ import type {
   ResponseStreamEvent,
 } from "openai/resources/responses/responses.js";
 import { calculateCost, clampThinkingLevel } from "../model-utils.js";
+import { transportAbortError } from "../transports/transport-stream-shared.js";
 import type {
   Api,
   AssistantMessage,
@@ -661,7 +662,7 @@ export async function runResponsesStreamLifecycle<TApi extends Api>(params: {
     await processResponsesStream(openaiStream, output, stream, model, processStreamOptions);
 
     if (options?.signal?.aborted) {
-      throw new Error("Request was aborted");
+      throw transportAbortError(options.signal);
     }
 
     if (output.stopReason === "aborted" || output.stopReason === "error") {

--- a/packages/ai/src/transports/anthropic-transport-stream.ts
+++ b/packages/ai/src/transports/anthropic-transport-stream.ts
@@ -92,6 +92,7 @@ import {
   mergeTransportHeaders,
   sanitizeNonEmptyTransportPayloadText,
   sanitizeTransportPayloadText,
+  transportAbortError,
 } from "./transport-stream-shared.js";
 import {
   createAbortError as createNamedAbortError,
@@ -1896,7 +1897,7 @@ export function createAnthropicMessagesTransportStreamFn(): StreamFn {
           throw new Error("Anthropic stream ended before message_stop");
         }
         if (transportOptions.signal?.aborted) {
-          throw new Error("Request was aborted");
+          throw transportAbortError(transportOptions.signal);
         }
         if (output.stopReason === "aborted" || output.stopReason === "error") {
           throw new Error(output.errorMessage ?? "An unknown error occurred");

--- a/packages/ai/src/transports/openai-responses-client.ts
+++ b/packages/ai/src/transports/openai-responses-client.ts
@@ -45,7 +45,11 @@ import {
 } from "./openai-transport-params.js";
 import { log, type MutableAssistantOutput } from "./openai-transport-shared.js";
 import { sanitizeResponsesImagePayload } from "./responses-image-payload-sanitizer.js";
-import { assignTransportErrorDetails, mergeTransportMetadata } from "./transport-stream-shared.js";
+import {
+  assignTransportErrorDetails,
+  mergeTransportMetadata,
+  transportAbortError,
+} from "./transport-stream-shared.js";
 
 function resolveProviderTransportTurnState(
   model: Model,
@@ -194,7 +198,7 @@ export function createOpenAIResponsesTransportStreamFn(): StreamFn {
           sessionId: options?.sessionId,
         });
         if (options?.signal?.aborted) {
-          throw new Error("Request was aborted");
+          throw transportAbortError(options.signal);
         }
         if (output.stopReason === "aborted" || output.stopReason === "error") {
           throw new Error("An unknown error occurred");
@@ -312,7 +316,7 @@ export function createAzureOpenAIResponsesTransportStreamFn(): StreamFn {
           sessionId: options?.sessionId,
         });
         if (options?.signal?.aborted) {
-          throw new Error("Request was aborted");
+          throw transportAbortError(options.signal);
         }
         if (output.stopReason === "aborted" || output.stopReason === "error") {
           throw new Error("An unknown error occurred");

--- a/packages/ai/src/transports/openai-transport-shared.ts
+++ b/packages/ai/src/transports/openai-transport-shared.ts
@@ -6,6 +6,7 @@ import {
   type OpenAICompletionsToolChoice,
   type OpenAIReasoningEffort,
 } from "../internal/openai.js";
+import { transportAbortError } from "./transport-stream-shared.js";
 
 const MODEL_STREAM_COOPERATIVE_YIELD_INTERVAL_MS = 12;
 const MODEL_STREAM_COOPERATIVE_YIELD_MAX_EVENTS = 64;
@@ -94,7 +95,7 @@ type ModelStreamCooperativeScheduler = {
 
 export function throwIfModelStreamAborted(signal?: AbortSignal): void {
   if (signal?.aborted) {
-    throw new Error("Request was aborted");
+    throw transportAbortError(signal);
   }
 }
 

--- a/packages/ai/src/transports/transport-stream-shared.ts
+++ b/packages/ai/src/transports/transport-stream-shared.ts
@@ -119,6 +119,17 @@ export function createWritableTransportEventStream() {
   };
 }
 
+/**
+ * Abort error to surface for an aborted `signal`.
+ *
+ * Prefers the caller's abort reason so its `code` survives into `errorCode` on
+ * the persisted assistant message. Synthesizing a fresh Error drops that code
+ * and forces consumers to recognize aborts by matching error text instead.
+ */
+export function transportAbortError(signal?: AbortSignal): Error {
+  return signal?.reason instanceof Error ? signal.reason : new Error("Request was aborted");
+}
+
 export function finalizeTransportStream(params: {
   stream: WritableTransportStream;
   output: TransportOutputShape;
@@ -126,7 +137,7 @@ export function finalizeTransportStream(params: {
 }): void {
   const { stream, output, signal } = params;
   if (signal?.aborted) {
-    throw new Error("Request was aborted");
+    throw transportAbortError(signal);
   }
   if (output.stopReason === "aborted" || output.stopReason === "error") {
     throw new Error(output.errorMessage ?? "An unknown error occurred");

--- a/packages/ai/src/transports/transport-stream-shared.ts
+++ b/packages/ai/src/transports/transport-stream-shared.ts
@@ -122,12 +122,18 @@ export function createWritableTransportEventStream() {
 /**
  * Abort error to surface for an aborted `signal`.
  *
- * Prefers the caller's abort reason so its `code` survives into `errorCode` on
- * the persisted assistant message. Synthesizing a fresh Error drops that code
- * and forces consumers to recognize aborts by matching error text instead.
+ * Rethrows the caller's abort reason only when it carries a `code`, so that code
+ * survives into `errorCode` on the persisted assistant message and consumers can
+ * recognize an abort's origin without matching error text. A default
+ * `abort()` reason is an uncoded DOMException that carries nothing the synthetic
+ * error does not, so it keeps the "Request was aborted" text every transport
+ * already emits rather than churning it.
  */
 export function transportAbortError(signal?: AbortSignal): Error {
-  return signal?.reason instanceof Error ? signal.reason : new Error("Request was aborted");
+  const reason: unknown = signal?.reason;
+  return reason instanceof Error && typeof (reason as { code?: unknown }).code === "string"
+    ? reason
+    : new Error("Request was aborted");
 }
 
 export function finalizeTransportStream(params: {

--- a/src/agents/main-session-restart-recovery-resume-policy.ts
+++ b/src/agents/main-session-restart-recovery-resume-policy.ts
@@ -6,6 +6,10 @@ import {
   isMeaningfulTranscriptMessage,
   readTerminalSourceReplyDeliveryMirror,
 } from "./embedded-agent-runner/message-visibility.js";
+import {
+  AGENT_RUN_RESTART_ABORT_ERROR,
+  AGENT_RUN_RESTART_ABORT_ERROR_CODE,
+} from "./run-termination.js";
 import { isAgentToolReplaySafe } from "./tool-replay-safety.js";
 
 function readDeliveredTerminalSourceReplyToolCallId(
@@ -229,15 +233,16 @@ export function hasReplaySafeCodeModeCheckpointInCurrentTurn(
   return false;
 }
 
-// Generic fetch/undici abort strings plus the gateway's own restart abort
-// reason (run-termination.ts); which one lands depends on whether the provider
-// stream throws or surfaces the abort as an error event. Only "error" tails
-// need this allowlist, so a genuine provider failure is never replayed as
-// lifecycle noise.
-const RESTART_ABORT_ERROR_MESSAGES = new Set([
+// Upgrade-window compat: tails persisted before transports preserved the abort
+// reason carry no `errorCode`, and the old process can write one while shutting
+// down for the very upgrade that starts the new one. Read those by their abort
+// text so that run still resumes. Coded tails never consult this set, so a
+// coded non-restart abort stays excluded. Remove once no pre-`errorCode`
+// transcript can reach restart recovery.
+const LEGACY_RESTART_ABORT_ERROR_MESSAGES = new Set([
   "Request was aborted",
   "This operation was aborted",
-  "agent run aborted for restart",
+  AGENT_RUN_RESTART_ABORT_ERROR,
 ]);
 
 function isRestartAbortAssistantMessage(message: unknown): boolean {
@@ -246,20 +251,27 @@ function isRestartAbortAssistantMessage(message: unknown): boolean {
   }
   const stopReason = normalizeOptionalString((message as { stopReason?: unknown }).stopReason);
   // Every row that reaches restart recovery was mid-run when the process went
-  // down, so an "aborted" tail is that interruption whatever string the
+  // down, so an "aborted" tail is that interruption whatever detail the
   // transport persisted with it ("Worker inference aborted.", a provider cancel
-  // message, or nothing). Matching on the abort strings alone made ordinary
-  // restarts fall through to the unresumable notice.
+  // message, or nothing).
   if (stopReason === "aborted") {
     return true;
   }
   if (stopReason !== "error") {
     return false;
   }
+  // An "error" tail only means the restart when the transport carried the
+  // gateway's own abort code through (transports copy the reason's `code` into
+  // `errorCode`). A provider failure or a first-stream-event timeout carries a
+  // different code and stays unresumable.
+  const errorCode = normalizeOptionalString((message as { errorCode?: unknown }).errorCode);
+  if (errorCode !== undefined) {
+    return errorCode === AGENT_RUN_RESTART_ABORT_ERROR_CODE;
+  }
   const errorMessage = normalizeOptionalString(
     (message as { errorMessage?: unknown }).errorMessage,
   );
-  return errorMessage !== undefined && RESTART_ABORT_ERROR_MESSAGES.has(errorMessage);
+  return errorMessage !== undefined && LEGACY_RESTART_ABORT_ERROR_MESSAGES.has(errorMessage);
 }
 
 export function isRestartAbortTailArtifact(message: unknown): boolean {

--- a/src/agents/main-session-restart-recovery.test.ts
+++ b/src/agents/main-session-restart-recovery.test.ts
@@ -60,6 +60,7 @@ import {
   scheduleRestartAbortedMainSessionRecoveryAfterOwnerRelease,
   scheduleRestartAbortedMainSessionRecovery as scheduleRestartAbortedMainSessionRecoveryBase,
 } from "./main-session-restart-recovery.js";
+import { AGENT_RUN_RESTART_ABORT_ERROR_CODE } from "./run-termination.js";
 import type { SessionLockInspection } from "./session-write-lock.js";
 import {
   createAssistantToolCallMessage,
@@ -3897,6 +3898,16 @@ describe("main-session-restart-recovery", () => {
         stopReason: "error",
       },
     ],
+    [
+      "an errored tail carrying a non-restart abort code",
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "" }],
+        stopReason: "error",
+        errorMessage: "This operation was aborted",
+        errorCode: "OPENCLAW_FIRST_EVENT_TIMEOUT",
+      },
+    ],
   ])("does not resume %s at the transcript tail", async (_label, assistantMessage) => {
     const sessionsDir = await makeSessionsDir();
     await writeStore(sessionsDir, mainSessionStore());
@@ -3908,6 +3919,27 @@ describe("main-session-restart-recovery", () => {
     await expectRecovery({ recovered: 0, failed: 1, skipped: 0 });
     expect(callGateway).not.toHaveBeenCalled();
   });
+
+  it.each([
+    ["Request was aborted"],
+    ["This operation was aborted"],
+    ["agent run aborted for restart"],
+  ])(
+    "resumes a pre-upgrade errored tail persisted as %s without an abort code",
+    async (errorMessage) => {
+      // The process that wrote this tail predates errorCode propagation, and it
+      // can be the very process replaced by the upgrade running recovery now.
+      const sessionsDir = await makeSessionsDir();
+      await writeStore(sessionsDir, mainSessionStore());
+      await writeTranscript(sessionsDir, "main-session", [
+        { role: "user", content: "do the thing" },
+        { role: "assistant", content: [], stopReason: "error", errorMessage },
+      ]);
+
+      await expectRecovery({ recovered: 1, failed: 0, skipped: 0 });
+      expect(callGateway).toHaveBeenCalledTimes(1);
+    },
+  );
 
   it.each([
     [
@@ -4536,6 +4568,7 @@ describe("main-session-restart-recovery", () => {
           content,
           stopReason: "error",
           errorMessage: "Request was aborted",
+          errorCode: AGENT_RUN_RESTART_ABORT_ERROR_CODE,
         },
       ]);
 

--- a/src/agents/restart-abort-code-propagation.test.ts
+++ b/src/agents/restart-abort-code-propagation.test.ts
@@ -1,0 +1,79 @@
+import { failTransportStream, finalizeTransportStream } from "@openclaw/ai/transports";
+import { describe, expect, it, vi } from "vitest";
+import { resolveMainSessionResumePolicy } from "./main-session-restart-recovery-resume-policy.js";
+import {
+  createAssistantOutput,
+  makeCompletionsModel,
+} from "./openai-transport-stream.test-harness.js";
+import { createAgentRunRestartAbortError } from "./run-termination.js";
+
+/**
+ * End-to-end proof of the restart-abort code path, with no hand-written
+ * transcript fixture in the middle: the abort error, the transport's terminal
+ * message assembly, and the recovery classifier are all production code.
+ *
+ * Fixture-based tests can only show that recovery reacts to a message shape.
+ * This shows the shape a real abort actually produces.
+ */
+function runTerminalTransportTurn(signal: AbortSignal): Record<string, unknown> {
+  const model = makeCompletionsModel({
+    id: "restart-abort-probe",
+    name: "Restart Abort Probe",
+    provider: "local",
+    baseUrl: "http://127.0.0.1:18099/v1",
+    reasoning: false,
+    contextWindow: 128000,
+    maxTokens: 4096,
+  });
+  const output = createAssistantOutput(model);
+  // Mirrors the try/catch every transport wraps its stream in
+  // (openai-completions-transport.ts): finalize throws for an aborted signal
+  // and the catch turns that error into the persisted terminal message.
+  try {
+    finalizeTransportStream({
+      stream: { push: vi.fn(), end: vi.fn() },
+      output,
+      signal,
+    });
+  } catch (error) {
+    failTransportStream({ stream: { push: vi.fn(), end: vi.fn() }, output, signal, error });
+  }
+  return output as unknown as Record<string, unknown>;
+}
+
+describe("restart abort code propagation", () => {
+  it("carries the gateway restart code from abort to a resumable recovery verdict", () => {
+    const controller = new AbortController();
+    controller.abort(createAgentRunRestartAbortError());
+
+    const message = runTerminalTransportTurn(controller.signal);
+    expect(message.errorCode).toBe("OPENCLAW_RESTART_ABORT");
+
+    // The transcript tail is the transport's own output, not a fixture.
+    const policy = resolveMainSessionResumePolicy([
+      { role: "user", content: "do the thing" },
+      message,
+    ]);
+    expect(policy).toMatchObject({ action: "resume" });
+  });
+
+  it("keeps a non-restart coded abort unresumable through the same path", () => {
+    const controller = new AbortController();
+    const timeout = Object.assign(new Error("First stream event timed out"), {
+      name: "TimeoutError",
+      code: "OPENCLAW_FIRST_EVENT_TIMEOUT",
+    });
+    controller.abort(timeout);
+
+    const message = runTerminalTransportTurn(controller.signal);
+    expect(message.errorCode).toBe("OPENCLAW_FIRST_EVENT_TIMEOUT");
+
+    // stopReason is "aborted" here because the signal itself aborted, which
+    // stays resumable by design: the run was still interrupted mid-flight.
+    // The code only has to discriminate once a tail lands as "error".
+    const erroredTail = { ...message, stopReason: "error" };
+    expect(
+      resolveMainSessionResumePolicy([{ role: "user", content: "do the thing" }, erroredTail]),
+    ).toMatchObject({ action: "fail" });
+  });
+});

--- a/src/agents/run-termination.ts
+++ b/src/agents/run-termination.ts
@@ -12,8 +12,15 @@ const AGENT_RUN_ABORTED_STOP_REASON = "aborted" as const;
 /** Error text used for aborted agent runs. */
 export const AGENT_RUN_ABORTED_ERROR = "agent run aborted" as const;
 export const AGENT_RUN_RESTART_ABORT_STOP_REASON = "restart" as const;
+/** Error text used for agent runs aborted by a gateway restart. */
+export const AGENT_RUN_RESTART_ABORT_ERROR = "agent run aborted for restart" as const;
 
-const AGENT_RUN_RESTART_ABORT_ERROR_CODE = "OPENCLAW_RESTART_ABORT";
+/**
+ * Transports copy this code onto the persisted assistant message via
+ * `errorCode`, so restart recovery can recognize its own abort without matching
+ * free-form provider error text.
+ */
+export const AGENT_RUN_RESTART_ABORT_ERROR_CODE = "OPENCLAW_RESTART_ABORT";
 const AGENT_RUN_DIRECT_ABORT_ERROR_CODE = "OPENCLAW_DIRECT_ABORT";
 
 export function createAgentRunDirectAbortError(): Error {
@@ -30,7 +37,7 @@ export function isAgentRunDirectAbortReason(value: unknown): boolean {
 }
 
 export function createAgentRunRestartAbortError(): Error {
-  const error = new Error("agent run aborted for restart") as Error & { code: string };
+  const error = new Error(AGENT_RUN_RESTART_ABORT_ERROR) as Error & { code: string };
   error.name = "AbortError";
   error.code = AGENT_RUN_RESTART_ABORT_ERROR_CODE;
   return error;

--- a/src/agents/transport-stream-shared.test.ts
+++ b/src/agents/transport-stream-shared.test.ts
@@ -110,9 +110,20 @@ describe("transport stream shared helpers", () => {
     expect(output.errorCode).toBe("OPENCLAW_RESTART_ABORT");
   });
 
-  it("falls back to a synthetic abort error for a non-Error abort reason", () => {
+  it.each([
+    ["a non-Error abort reason", () => "stringy reason"],
+    // Node's default abort reason. It is an Error, but an uncoded one, so it
+    // carries nothing the synthetic error does not.
+    ["a default uncoded abort reason", () => undefined],
+    ["an uncoded Error abort reason", () => new Error("some upstream failure")],
+  ])("falls back to the synthetic abort error for %s", (_label, makeReason) => {
     const controller = new AbortController();
-    controller.abort("stringy reason");
+    const reason = makeReason();
+    if (reason === undefined) {
+      controller.abort();
+    } else {
+      controller.abort(reason);
+    }
 
     expect(() =>
       finalizeTransportStream({

--- a/src/agents/transport-stream-shared.test.ts
+++ b/src/agents/transport-stream-shared.test.ts
@@ -79,6 +79,50 @@ describe("transport stream shared helpers", () => {
     expect(end).toHaveBeenCalledTimes(1);
   });
 
+  it("rethrows the abort reason so its code reaches the persisted message", () => {
+    // The reason carries the caller's coded AbortError; synthesizing a fresh
+    // Error here would strip `code` and force consumers back onto error text.
+    const controller = new AbortController();
+    const reason = Object.assign(new Error("agent run aborted for restart"), {
+      name: "AbortError",
+      code: "OPENCLAW_RESTART_ABORT",
+    });
+    controller.abort(reason);
+    const output: { stopReason: string; errorMessage?: string; errorCode?: string } = {
+      stopReason: "stop",
+    };
+
+    expect(() =>
+      finalizeTransportStream({
+        stream: { push: vi.fn(), end: vi.fn() },
+        output,
+        signal: controller.signal,
+      }),
+    ).toThrow(reason);
+
+    failTransportStream({
+      stream: { push: vi.fn(), end: vi.fn() },
+      output,
+      signal: controller.signal,
+      error: reason,
+    });
+    expect(output.stopReason).toBe("aborted");
+    expect(output.errorCode).toBe("OPENCLAW_RESTART_ABORT");
+  });
+
+  it("falls back to a synthetic abort error for a non-Error abort reason", () => {
+    const controller = new AbortController();
+    controller.abort("stringy reason");
+
+    expect(() =>
+      finalizeTransportStream({
+        stream: { push: vi.fn(), end: vi.fn() },
+        output: { stopReason: "stop" },
+        signal: controller.signal,
+      }),
+    ).toThrow("Request was aborted");
+  });
+
   it("marks transport stream failures and runs cleanup", () => {
     // Failure finalization mutates the output message before emitting it so
     // downstream transcript consumers see the same error state as the stream.


### PR DESCRIPTION
## What Problem This Solves

Restart recovery had to recognize its own abort by matching provider error text.
`isRestartAbortAssistantMessage` kept an allowlist of three strings, because the
structured signal it wanted was being destroyed one layer up: every transport
handled an aborted signal with

```ts
if (signal?.aborted) {
  throw new Error("Request was aborted");
}
```

That synthesizes a fresh `Error` and discards `signal.reason` — which is the
coded `AbortError` from `createAgentRunRestartAbortError()` carrying
`code: "OPENCLAW_RESTART_ABORT"`. `assignTransportErrorDetails` already copies an
error's `code` into `errorCode` on the persisted assistant message, and
`AssistantMessage.errorCode` already exists. The plumbing was all there; the
reason was just thrown away before it could reach it.

The string list was also a false positive risk in both directions. It could not
recognize a restart whose message differed, and it *did* match
`"This operation was aborted"` from a first-stream-event timeout — a provider
stall, not a gateway restart.

## Why This Change Was Made

Follow-up to #114121, which stopped ordinary restarts from showing the "please
resend" notice. That fix removed the allowlist's influence over `aborted` tails
but left it deciding `error` tails, so the same design smell remained one branch
down. This replaces it with the code.

`transportAbortError(signal)` is added to `transport-stream-shared.ts` and used at
the 14 sites that previously minted a bare abort error. It rethrows
`signal.reason` **only when that reason carries a `code`**, and otherwise keeps
the existing synthetic `"Request was aborted"`.

That narrowing is deliberate and was found by CI rather than by inspection. A
first cut preferred any `Error` reason, which changed the message for the common
`controller.abort()` case: Node's default reason is an uncoded `DOMException`
reading `"This operation was aborted"`. `openai-transport-stream.streaming.test.ts`
caught it. An uncoded reason carries nothing the synthetic error does not, so
preferring it only churned text that transports and tests already rely on. Coded
reasons are the entire point, so the helper now takes exactly those.

This is deliberately not a one-sided fix. Anthropic duplicates the abort check
inline and calls `finalizeTransportStream` without a signal, so changing only the
shared helper would have left the most-used transport unfixed. All core
`packages/ai` transports and providers now route through the one helper.

`AGENT_RUN_RESTART_ABORT_ERROR_CODE` and `AGENT_RUN_RESTART_ABORT_ERROR` are now
exported from `run-termination.ts`. The message literal previously existed as an
unshared duplicate in the thrower and the allowlist, free to drift.

Downstream abort classifiers were checked rather than assumed: `isAbortError`,
`proxy.ts:187`, and `openai-chatgpt-responses.ts:211`/`:436` all test
`name === "AbortError"` first, which the propagated reason sets. The re-wrap at
`:437` passes `{ cause: error }`, and `extractTransportErrorDetails` walks the
cause chain, so the code still survives that path.

## User Impact

A turn interrupted by a gateway restart resumes in more cases and, more
importantly, for the right reason: recovery now asks "did the gateway abort
this?" instead of "does this error text look like an abort?". A first-event
timeout is no longer misread as a restart.

One compatibility case is deliberately preserved. A tail persisted by a build
that predates this change carries no `errorCode`, and the process that writes it
can be the very one being replaced by the upgrade. Those uncoded tails still fall
back to the abort strings; coded tails never consult that set, so a coded
non-restart abort stays excluded. The set is marked for removal once no
pre-`errorCode` transcript can reach recovery.

Non-test LOC grows by 42. That is the named helper plus its contract comment, the
upgrade-window compat block, and imports at 6 files. It buys one decision path
where there were 14 copies of an inline throw, and a structured check where there
was text matching.

## Evidence

Local, all green:

- `node scripts/run-vitest.mjs src/agents/main-session-restart-recovery.test.ts src/agents/transport-stream-shared.test.ts` — 156 passed
- `node scripts/run-vitest.mjs packages/ai` — 764 passed across 46 files
- `node scripts/run-vitest.mjs src/agents/model-fallback.test.ts src/agents/agent-command.compaction-rotation.test.ts src/auto-reply/reply/agent-runner-cli-dispatch.test.ts src/cron/isolated-agent/run.session-lifecycle.test.ts` — abort-adjacent suites, green
- `node scripts/run-vitest.mjs extensions/qa-lab/src/suite-runtime-agent-session.test.ts extensions/llama-cpp/src/inference-provider.test.ts` — the other abort-string consumers, green
- `node --import tsx scripts/check-import-cycles.ts` — 0 runtime value cycles, confirming the new provider to transports edge is one-way
- `node scripts/check-changed.mjs` — exit 0, delegated to Blacksmith Testbox
- `autoreview --mode uncommitted` (Codex `gpt-5.6-sol`, xhigh) — clean, 0.94

Added coverage:

- the abort reason's `code` reaching `errorCode` on the persisted message, and
  non-`Error`, default-uncoded, and uncoded-`Error` reasons all falling back to
  the synthetic error
- an `error` tail carrying a non-restart code staying unresumable
- pre-upgrade uncoded `error` tails still resuming, one case per legacy string

Runtime proof of the chain, no fixture in the middle (`src/agents/restart-abort-code-propagation.test.ts`,
full output in the PR comment): a real `AbortController` aborted with the real
reason, through the exact try/catch every transport wraps its stream in, straight
into `resolveMainSessionResumePolicy`.

```
### gateway restart abort
persisted: {"stopReason":"aborted","errorMessage":"agent run aborted for restart","errorCode":"OPENCLAW_RESTART_ABORT"}
verdict (same tail as 'error'): {"action":"resume","forceRestartSafeTools":false}

### first-stream-event timeout
persisted: {"stopReason":"aborted","errorMessage":"First stream event timed out","errorCode":"OPENCLAW_FIRST_EVENT_TIMEOUT"}
verdict (same tail as 'error'): {"action":"fail","reason":"transcript tail is not resumable"}
```

That is the discrimination the change exists for: the code reaches the persisted
message, and a timeout no longer reads as a restart.

Known gap, carried over from #114121: no live gateway-restart trace. The existing
restart QA scenarios drive the Code Mode `wait` branch, which neither PR touches.
A worker-environment restart scenario remains the right follow-up.

Extensions (`extensions/google`, `ollama`, `amazon-bedrock`) still mint bare abort
errors in their own transports; `llama-cpp` already does the right thing with
`signal?.reason ?? ...`. Those are separately-owned packages and are left as
follow-up rather than widening this PR.
