### PR TITLE
refactor(reply): share turn accounting and recovery

### DIFF
--- a/src/auto-reply/reply/agent-runner-result-accounting.ts
+++ b/src/auto-reply/reply/agent-runner-result-accounting.ts
@@ -14,7 +14,28 @@ import { drainPendingToolTasks } from "./pending-tool-task-drain.js";
 import { buildReplyUsageState, recordReplyUsageState } from "./reply-usage-state.js";
 import { persistRunSessionUsage } from "./session-run-accounting.js";
 
-export async function accountReplyAgentRun(context: FinalizeReplyAgentRunInput) {
+type AgentTurnAccountingContext = Pick<
+  FinalizeReplyAgentRunInput,
+  | "activeSessionEntry"
+  | "activeSessionStore"
+  | "agentCfgContextTokens"
+  | "blockReplyPipeline"
+  | "cfg"
+  | "defaultModel"
+  | "followupRun"
+  | "isHeartbeat"
+  | "pendingToolTasks"
+  | "preflightCompactionApplied"
+  | "resolvedVerboseLevel"
+  | "runOutcome"
+  | "runStartedAt"
+  | "sessionCtx"
+  | "sessionKey"
+  | "shouldInjectGroupIntro"
+  | "storePath"
+>;
+
+export async function accountAgentTurn(context: AgentTurnAccountingContext) {
   const {
     activeSessionStore,
     agentCfgContextTokens,

--- a/src/auto-reply/reply/agent-runner-result-complete.ts
+++ b/src/auto-reply/reply/agent-runner-result-complete.ts
@@ -18,7 +18,7 @@ import {
   resolveSourceReplyPolicy,
 } from "./agent-runner-core.js";
 import { normalizeAssistantFinalDeliveryText } from "./agent-runner-core.js";
-import type { accountReplyAgentRun } from "./agent-runner-result-accounting.js";
+import type { accountAgentTurn } from "./agent-runner-result-accounting.js";
 import type { FinalizeReplyAgentRunInput } from "./agent-runner-result.types.js";
 import {
   accumulateSessionUsageFromTranscript,
@@ -36,17 +36,14 @@ import {
 import { appendUsageLine } from "./agent-runner-usage-line.js";
 import { buildPendingFinalDeliveryText } from "./pending-final-delivery.js";
 import { readPostCompactionContext } from "./post-compaction-context.js";
-import {
-  shouldWarnAboutPrivateMessageToolFinal,
-  warnPrivateMessageToolFinal,
-} from "./private-message-tool-final.js";
+import { warnPrivateMessageToolFinal } from "./private-message-tool-final.js";
 import { enqueueFollowupRun, refreshQueuedFollowupSession } from "./queue.js";
 import { incrementRunCompactionCount } from "./session-run-accounting.js";
 import {
   buildStrandedReplyDeliveryFailurePayload,
-  buildStrandedReplyRetryFollowupRun,
+  resolveStrandedReplyRecovery,
 } from "./stranded-reply-recovery.js";
-type ReplyAgentAccounting = Awaited<ReturnType<typeof accountReplyAgentRun>>;
+type ReplyAgentAccounting = Awaited<ReturnType<typeof accountAgentTurn>>;
 type PreparedReplyAgentPayloads = {
   kind: "continue";
   activeSessionEntry: SessionEntry | undefined;
@@ -315,26 +312,18 @@ export async function completeReplyAgentRun(input: {
         ? runResult.meta.finalAssistantVisibleText
         : (rawAssistantText ?? ""),
     );
-    const isRoomEvent = sessionCtx.InboundEventKind === "room_event";
     // Heartbeats already deliver fallback finals via sendDurableMessageBatch;
     // recovering here would duplicate that message.
-    const isStrandedReply =
-      !isHeartbeat &&
-      !isRoomEvent &&
-      shouldWarnAboutPrivateMessageToolFinal({
-        sourceReplyDeliveryMode: sourceReplyPolicy.sourceReplyDeliveryMode,
-        sendPolicyDenied: sourceReplyPolicy.sendPolicyDenied,
-        successfulSourceReplyDelivery: completedSourceReplyDelivery,
-        finalText: assistantFinalText,
-      });
-    const retryMissingSourceDelivery =
-      isStrandedReplyRetryRun &&
-      !isHeartbeat &&
-      !isRoomEvent &&
-      sourceReplyPolicy.sourceReplyDeliveryMode === "message_tool_only" &&
-      !sourceReplyPolicy.sendPolicyDenied &&
-      !completedSourceReplyDelivery;
-    if (isStrandedReply) {
+    const recovery = resolveStrandedReplyRecovery({
+      base: followupRun,
+      finalText: assistantFinalText,
+      sourceReplyDeliveryMode: sourceReplyPolicy.sourceReplyDeliveryMode,
+      sendPolicyDenied: sourceReplyPolicy.sendPolicyDenied,
+      successfulSourceReplyDelivery: completedSourceReplyDelivery,
+      isHeartbeat,
+      isRoomEvent: sessionCtx.InboundEventKind === "room_event",
+    });
+    if (recovery.kind === "retry" || (recovery.kind === "diagnostic" && recovery.warn)) {
       warnPrivateMessageToolFinal({
         sessionKey,
         channel:
@@ -345,25 +334,20 @@ export async function completeReplyAgentRun(input: {
         finalTextLength: assistantFinalText.trim().length,
       });
     }
-    if (isStrandedReply || retryMissingSourceDelivery) {
-      if (isStrandedReplyRetryRun) {
+    if (recovery.kind === "diagnostic") {
+      finalPayloads = [...finalPayloads, recovery.payload];
+    } else if (recovery.kind === "retry") {
+      const retryEnqueued = enqueueFollowupRun(
+        queueKey,
+        recovery.run,
+        resolvedQueue,
+        "none",
+        runFollowupTurn,
+        false,
+        { position: "front" },
+      );
+      if (!retryEnqueued) {
         finalPayloads = [...finalPayloads, buildStrandedReplyDeliveryFailurePayload()];
-      } else {
-        const retryEnqueued = enqueueFollowupRun(
-          queueKey,
-          buildStrandedReplyRetryFollowupRun(followupRun, {
-            finalText: assistantFinalText,
-            sourceReplyDeliveryMode: sourceReplyPolicy.sourceReplyDeliveryMode,
-          }),
-          resolvedQueue,
-          "none",
-          runFollowupTurn,
-          false,
-          { position: "front" },
-        );
-        if (!retryEnqueued) {
-          finalPayloads = [...finalPayloads, buildStrandedReplyDeliveryFailurePayload()];
-        }
       }
     }
     const pendingText = sourceReplyPolicy.suppressDelivery ? "" : finalDeliveryText;

--- a/src/auto-reply/reply/agent-runner-result-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-result-payloads.ts
@@ -35,15 +35,15 @@ import {
   hasSessionRelatedCronJobs,
   hasUnbackedReminderCommitment,
 } from "./agent-runner-reminder-guard.js";
-import type { accountReplyAgentRun } from "./agent-runner-result-accounting.js";
+import type { accountAgentTurn } from "./agent-runner-result-accounting.js";
 import type { FinalizeReplyAgentRunInput } from "./agent-runner-result.types.js";
 import { resolveResponseUsageLine } from "./agent-runner-usage-line.js";
 import { attachMcpAppChannelAction } from "./mcp-app-channel-action.js";
 import { normalizeReplyPayload } from "./normalize-reply.js";
 import { resolveOriginMessageTo } from "./origin-routing.js";
 import { createReplyToModeFilterForChannel } from "./reply-threading.js";
-import { buildStrandedReplyDeliveryFailurePayload } from "./stranded-reply-recovery.js";
-type ReplyAgentAccounting = Awaited<ReturnType<typeof accountReplyAgentRun>>;
+import { resolveStrandedReplyRecovery } from "./stranded-reply-recovery.js";
+type ReplyAgentAccounting = Awaited<ReturnType<typeof accountAgentTurn>>;
 
 export async function prepareReplyAgentPayloads(state: {
   context: FinalizeReplyAgentRunInput;
@@ -162,13 +162,16 @@ export async function prepareReplyAgentPayloads(state: {
       runtimePolicySessionKey,
       opts,
     });
-    if (
-      sourceReplyPolicy.sourceReplyDeliveryMode !== "message_tool_only" ||
-      sourceReplyPolicy.sendPolicyDenied
-    ) {
-      return undefined;
-    }
-    return buildStrandedReplyDeliveryFailurePayload();
+    const recovery = resolveStrandedReplyRecovery({
+      base: followupRun,
+      finalText: "",
+      sourceReplyDeliveryMode: sourceReplyPolicy.sourceReplyDeliveryMode,
+      sendPolicyDenied: sourceReplyPolicy.sendPolicyDenied,
+      successfulSourceReplyDelivery: completedSourceReplyDelivery,
+      isHeartbeat,
+      isRoomEvent: false,
+    });
+    return recovery.kind === "diagnostic" ? recovery.payload : undefined;
   };
   if (opts?.sourceReplyDeliveryMode === "message_tool_only" && completedSourceReplyDelivery) {
     await opts.onObservedReplyDelivery?.();

--- a/src/auto-reply/reply/agent-runner-result-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-result-payloads.ts
@@ -162,6 +162,8 @@ export async function prepareReplyAgentPayloads(state: {
       runtimePolicySessionKey,
       opts,
     });
+    // The guard above limits this to a one-shot recovery turn. A second miss
+    // always gets a diagnostic, even when the retry produced no final text.
     const recovery = resolveStrandedReplyRecovery({
       base: followupRun,
       finalText: "",

--- a/src/auto-reply/reply/agent-runner-result.ts
+++ b/src/auto-reply/reply/agent-runner-result.ts
@@ -1,5 +1,5 @@
 import type { ReplyPayload } from "../types.js";
-import { accountReplyAgentRun } from "./agent-runner-result-accounting.js";
+import { accountAgentTurn } from "./agent-runner-result-accounting.js";
 import { completeReplyAgentRun } from "./agent-runner-result-complete.js";
 import { prepareReplyAgentPayloads } from "./agent-runner-result-payloads.js";
 import type { FinalizeReplyAgentRunInput } from "./agent-runner-result.types.js";
@@ -7,7 +7,7 @@ import type { FinalizeReplyAgentRunInput } from "./agent-runner-result.types.js"
 export async function finalizeReplyAgentRun(
   context: FinalizeReplyAgentRunInput,
 ): Promise<ReplyPayload | ReplyPayload[] | undefined> {
-  const accounting = await accountReplyAgentRun(context);
+  const accounting = await accountAgentTurn(context);
   const prepared = await prepareReplyAgentPayloads({ context, accounting });
   if (prepared.kind === "return") {
     return prepared.value;

--- a/src/auto-reply/reply/stranded-reply-recovery.test.ts
+++ b/src/auto-reply/reply/stranded-reply-recovery.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 import { completeFollowupRunLifecycle, markFollowupRunEnqueued } from "./queue/types.js";
-import { buildStrandedReplyRetryFollowupRun } from "./stranded-reply-recovery.js";
+import {
+  buildStrandedReplyRetryFollowupRun,
+  resolveStrandedReplyRecovery,
+} from "./stranded-reply-recovery.js";
 import { createMockFollowupRun } from "./test-helpers.js";
 
 const STRANDED_REPLY_RETRY_MARKER = "stranded-reply-retry";
@@ -47,5 +50,68 @@ describe("buildStrandedReplyRetryFollowupRun lifecycle ownership", () => {
     expect(onComplete).toHaveBeenCalledTimes(1);
     completeFollowupRunLifecycle(parent);
     expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("resolveStrandedReplyRecovery", () => {
+  const substantiveFinal =
+    "This reply is substantive enough to look user-facing. It contains a second sentence so the private-final policy treats it as stranded output.";
+
+  it("creates one priority retry for a substantive private final", () => {
+    const base = createMockFollowupRun({ prompt: "question" });
+
+    const recovery = resolveStrandedReplyRecovery({
+      base,
+      finalText: substantiveFinal,
+      sourceReplyDeliveryMode: "message_tool_only",
+      sendPolicyDenied: false,
+      successfulSourceReplyDelivery: false,
+      isHeartbeat: false,
+      isRoomEvent: false,
+    });
+
+    expect(recovery.kind).toBe("retry");
+    if (recovery.kind === "retry") {
+      expect(recovery.run.strandedReplyRetry).toBe(true);
+      expect(recovery.run.disableCollectBatching).toBe(true);
+    }
+  });
+
+  it("returns a diagnostic rather than a second retry", () => {
+    const base = createMockFollowupRun({ prompt: "question", strandedReplyRetry: true });
+
+    const recovery = resolveStrandedReplyRecovery({
+      base,
+      finalText: "",
+      sourceReplyDeliveryMode: "message_tool_only",
+      sendPolicyDenied: false,
+      successfulSourceReplyDelivery: false,
+      isHeartbeat: false,
+      isRoomEvent: false,
+    });
+
+    expect(recovery).toMatchObject({ kind: "diagnostic", warn: false });
+  });
+
+  it.each([
+    { label: "room events", isRoomEvent: true },
+    { label: "heartbeats", isHeartbeat: true },
+    { label: "send-policy denial", sendPolicyDenied: true },
+    { label: "completed delivery", successfulSourceReplyDelivery: true },
+  ])("does not recover $label", (override) => {
+    const base = createMockFollowupRun({ prompt: "question" });
+
+    const recovery = resolveStrandedReplyRecovery({
+      base,
+      finalText: substantiveFinal,
+      sourceReplyDeliveryMode: "message_tool_only",
+      sendPolicyDenied: false,
+      successfulSourceReplyDelivery: false,
+      isHeartbeat: false,
+      isRoomEvent: false,
+      ...override,
+    });
+
+    expect(recovery).toEqual({ kind: "none" });
   });
 });

--- a/src/auto-reply/reply/stranded-reply-recovery.ts
+++ b/src/auto-reply/reply/stranded-reply-recovery.ts
@@ -1,6 +1,7 @@
 import type { SourceReplyDeliveryMode } from "../get-reply-options.types.js";
 import { markReplyPayloadForSourceSuppressionDelivery } from "../reply-payload.js";
 import type { ReplyPayload } from "../types.js";
+import { shouldWarnAboutPrivateMessageToolFinal } from "./private-message-tool-final.js";
 import type { FollowupRun } from "./queue/types.js";
 
 const STRANDED_REPLY_RETRY_MARKER = "stranded-reply-retry";
@@ -13,6 +14,55 @@ export function buildStrandedReplyDeliveryFailurePayload(): ReplyPayload {
     isError: true,
     isStatusNotice: true,
   });
+}
+
+export type StrandedReplyRecovery =
+  | { kind: "none" }
+  | { kind: "retry"; run: FollowupRun }
+  | { kind: "diagnostic"; payload: ReplyPayload; warn: boolean };
+
+/** Resolve the one allowed recovery action for a final that missed source delivery. */
+export function resolveStrandedReplyRecovery(params: {
+  base: FollowupRun;
+  finalText: string;
+  sourceReplyDeliveryMode: SourceReplyDeliveryMode | undefined;
+  sendPolicyDenied: boolean;
+  successfulSourceReplyDelivery: boolean;
+  isHeartbeat: boolean;
+  isRoomEvent: boolean;
+}): StrandedReplyRecovery {
+  if (
+    params.isHeartbeat ||
+    params.isRoomEvent ||
+    params.sourceReplyDeliveryMode !== "message_tool_only" ||
+    params.sendPolicyDenied ||
+    params.successfulSourceReplyDelivery
+  ) {
+    return { kind: "none" };
+  }
+  const shouldWarn = shouldWarnAboutPrivateMessageToolFinal({
+    sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
+    sendPolicyDenied: params.sendPolicyDenied,
+    successfulSourceReplyDelivery: params.successfulSourceReplyDelivery,
+    finalText: params.finalText,
+  });
+  if (params.base.strandedReplyRetry === true) {
+    return {
+      kind: "diagnostic",
+      payload: buildStrandedReplyDeliveryFailurePayload(),
+      warn: shouldWarn,
+    };
+  }
+  if (!shouldWarn) {
+    return { kind: "none" };
+  }
+  return {
+    kind: "retry",
+    run: buildStrandedReplyRetryFollowupRun(params.base, {
+      finalText: params.finalText,
+      sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
+    }),
+  };
 }
 
 function buildStrandedReplyRetryPrompt(finalText: string): string {

--- a/src/auto-reply/reply/stranded-reply-recovery.ts
+++ b/src/auto-reply/reply/stranded-reply-recovery.ts
@@ -16,7 +16,7 @@ export function buildStrandedReplyDeliveryFailurePayload(): ReplyPayload {
   });
 }
 
-export type StrandedReplyRecovery =
+type StrandedReplyRecovery =
   | { kind: "none" }
   | { kind: "retry"; run: FollowupRun }
   | { kind: "diagnostic"; payload: ReplyPayload; warn: boolean };


### PR DESCRIPTION
## What Problem This Solves

The foreground reply finalizer owned stranded-reply recovery decisions and agent-run accounting through foreground-specific entry points, which prevented queued follow-up turns from reusing those policies without copying them.

## Why This Change Was Made

This behavior-neutral first step introduces one closed stranded-reply recovery decision and one delivery-independent `accountAgentTurn` entry. The foreground path adopts both before the queued follow-up runner changes, preserving retry, diagnostic, warning, session, usage, and delivery behavior.

## User Impact

No user-visible behavior changes. This prepares the canonical accounting and recovery boundaries needed to converge queued follow-up turns onto the foreground execution pipeline.

## Evidence

- `node scripts/run-vitest.mjs src/auto-reply/reply/stranded-reply-recovery.test.ts` — 7 tests passed.
- `node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts` — 74 tests passed.
- `git diff --check origin/main...HEAD` — clean.
- `$HOME/.claude/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — clean; no accepted/actionable findings.
- Exact-head CI: [run 30230341889](https://github.com/openclaw/openclaw/actions/runs/30230341889), attempt 2 — green at `aa7e32748052c2c2d7e507cdfb63cf9e45797fc5`. Attempt 1 had one unrelated packed tooling-shard failure; the same SHA passed unchanged on the failed-job rerun.

AI-assisted implementation; the maintainer-directed design and behavior invariants were reviewed against the affected foreground finalization path.

## ClawSweeper Rank-up Moves

- Real private-reply runtime proof is deferred to the Phase 2 queued-convergence PR, whose acceptance matrix exercises the actual queued execution and delivery path. This staging PR does not change the foreground execution or transport contract; foreground equivalence is covered by the focused 74-test runner suite, the dedicated recovery tests, and exact-head CI. The maintainer-approved split intentionally lands this behavior-neutral owner extraction first.
- The branch was rebased twice over concurrent `main` movement before the final exact-head run. Later base drift is left to the repository's strict test-merge gate rather than invalidating a green exact-head run again; the PR remains conflict-free.
