### PR TITLE
refactor(providers): share admin usage aggregation

### DIFF
--- a/extensions/anthropic/usage.test.ts
+++ b/extensions/anthropic/usage.test.ts
@@ -89,10 +89,20 @@ describe("Anthropic provider usage", () => {
       fetchFn: fetchFn as typeof fetch,
     });
 
-    expect(result).toMatchObject({
+    expect(result).toEqual({
       provider: "anthropic",
+      displayName: "Anthropic",
+      windows: [],
       plan: "Admin API",
-      billing: [{ type: "spend", amount: 12.34, unit: "USD", period: "30d" }],
+      billing: [
+        {
+          type: "spend",
+          label: "30-day API spend",
+          amount: 12.34,
+          unit: "USD",
+          period: "30d",
+        },
+      ],
       costHistory: {
         unit: "USD",
         periodDays: 30,
@@ -107,9 +117,19 @@ describe("Anthropic provider usage", () => {
             totalTokens: 1_700,
           },
         ],
-        models: [{ name: "claude-opus-4-8", totalTokens: 1_700 }],
+        models: [
+          {
+            name: "claude-opus-4-8",
+            inputTokens: 1_000,
+            cacheReadTokens: 300,
+            cacheWriteTokens: 150,
+            outputTokens: 250,
+            totalTokens: 1_700,
+          },
+        ],
         categories: [{ name: "Claude API", amount: 12.34 }],
       },
+      summary: "1,700 tokens",
     });
     for (const [input, init] of fetchFn.mock.calls) {
       const url = requestUrl(input);

--- a/extensions/anthropic/usage.ts
+++ b/extensions/anthropic/usage.ts
@@ -7,12 +7,21 @@ import {
   readClaudeCliCredentialsCached,
   validateAnthropicSetupToken,
 } from "openclaw/plugin-sdk/provider-auth";
-import { readProviderJsonObjectResponse } from "openclaw/plugin-sdk/provider-http";
 import {
+  addProviderUsageModel,
+  asProviderUsageObject,
   buildUsageHttpErrorSnapshot,
+  buildProviderUsageHistorySnapshot,
+  cleanProviderUsageCredential,
+  createProviderUsageDailyAccumulator,
+  decodeProviderUsageAdminToken,
+  encodeProviderUsageAdminToken,
+  fetchProviderUsagePages,
   fetchClaudeUsage,
-  type ProviderUsageCostDaily,
-  type ProviderUsageModelBreakdown,
+  parseProviderUsageNonNegativeInteger,
+  parseProviderUsageNumber,
+  resolveProviderUsageDailyPeriod,
+  resolveProviderUsageDisplayName,
   type ProviderUsageSnapshot,
 } from "openclaw/plugin-sdk/provider-usage";
 import { CLAUDE_CLI_BACKEND_ID } from "./cli-constants.js";
@@ -23,33 +32,9 @@ const ANTHROPIC_MESSAGES_USAGE_URL =
 const ANTHROPIC_ADMIN_TOKEN_PREFIX = "openclaw:anthropic-admin:v1:";
 const ANTHROPIC_USAGE_RESPONSE_MAX_BYTES = 4 * 1024 * 1024;
 const ANTHROPIC_USAGE_HISTORY_DAYS = 30;
-const MAX_PAGES = 100;
-
-type AnthropicUsagePage = {
-  data: unknown[];
-  hasMore: boolean;
-  nextPage?: string;
-};
-
-type DailyAccumulator = ProviderUsageCostDaily & {
-  categories: Map<string, number>;
-  models: Map<string, ProviderUsageModelBreakdown>;
-};
-
-function cleanCredential(raw: string | undefined): string | undefined {
-  const trimmed = raw?.replaceAll(/[\r\n]/g, "").trim();
-  if (!trimmed) {
-    return undefined;
-  }
-  const quoted =
-    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
-    (trimmed.startsWith("'") && trimmed.endsWith("'"));
-  const cleaned = quoted ? trimmed.slice(1, -1).trim() : trimmed;
-  return cleaned || undefined;
-}
 
 function normalizeAdminKey(raw: string | undefined): string | undefined {
-  const cleaned = cleanCredential(raw);
+  const cleaned = cleanProviderUsageCredential(raw);
   if (!cleaned) {
     return undefined;
   }
@@ -60,98 +45,16 @@ function normalizeAdminKey(raw: string | undefined): string | undefined {
 }
 
 function encodeAdminToken(token: string): string {
-  return `${ANTHROPIC_ADMIN_TOKEN_PREFIX}${JSON.stringify({ token })}`;
+  return encodeProviderUsageAdminToken(ANTHROPIC_ADMIN_TOKEN_PREFIX, token);
 }
 
 function decodeAdminToken(raw: string): string | undefined {
-  if (!raw.startsWith(ANTHROPIC_ADMIN_TOKEN_PREFIX)) {
-    return undefined;
-  }
-  try {
-    const value = JSON.parse(raw.slice(ANTHROPIC_ADMIN_TOKEN_PREFIX.length)) as unknown;
-    const token = objectRecord(value)?.token;
-    return typeof token === "string" && token.trim() ? token.trim() : undefined;
-  } catch {
-    return undefined;
-  }
-}
-
-function objectRecord(value: unknown): Record<string, unknown> | undefined {
-  return value !== null && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : undefined;
-}
-
-function finiteNumber(value: unknown): number | undefined {
-  const parsed =
-    typeof value === "number"
-      ? value
-      : typeof value === "string" && value.trim()
-        ? Number(value)
-        : Number.NaN;
-  return Number.isFinite(parsed) ? parsed : undefined;
-}
-
-function nonNegativeInteger(value: unknown): number {
-  const parsed = finiteNumber(value);
-  return parsed === undefined ? 0 : Math.max(0, Math.trunc(parsed));
-}
-
-function displayName(value: unknown, fallback: string): string {
-  return typeof value === "string" && value.trim() ? value.trim() : fallback;
+  return decodeProviderUsageAdminToken(ANTHROPIC_ADMIN_TOKEN_PREFIX, raw);
 }
 
 function utcDay(value: string): string | undefined {
   const date = new Date(value);
   return Number.isFinite(date.getTime()) ? date.toISOString().slice(0, 10) : undefined;
-}
-
-function emptyDaily(date: string): DailyAccumulator {
-  return {
-    date,
-    amount: 0,
-    inputTokens: 0,
-    cacheReadTokens: 0,
-    cacheWriteTokens: 0,
-    outputTokens: 0,
-    totalTokens: 0,
-    categories: new Map(),
-    models: new Map(),
-  };
-}
-
-function resolveDailyRange(now: number, periodDays: number) {
-  const current = new Date(now);
-  const todayStart = Date.UTC(
-    current.getUTCFullYear(),
-    current.getUTCMonth(),
-    current.getUTCDate(),
-  );
-  return {
-    startingAt: new Date(todayStart - (periodDays - 1) * 86_400_000).toISOString(),
-    endingAt: new Date(todayStart + 86_400_000).toISOString(),
-  };
-}
-
-async function readPage(response: Response, timeoutMs: number): Promise<AnthropicUsagePage> {
-  const payload = await readProviderJsonObjectResponse(response, "Anthropic usage", {
-    maxBytes: ANTHROPIC_USAGE_RESPONSE_MAX_BYTES,
-    chunkTimeoutMs: timeoutMs,
-    onIdleTimeout: ({ chunkTimeoutMs }) =>
-      new Error(`Anthropic usage response stalled for ${chunkTimeoutMs}ms`),
-  });
-  if (!Array.isArray(payload.data)) {
-    throw new Error("Anthropic usage response is not an object with data");
-  }
-  const nextPage =
-    typeof payload.next_page === "string" && payload.next_page.trim()
-      ? payload.next_page.trim()
-      : undefined;
-  return {
-    data: payload.data,
-    hasMore: payload.has_more === true,
-    ...(nextPage ? { nextPage } : {}),
-  };
 }
 
 async function fetchPages(params: {
@@ -164,78 +67,31 @@ async function fetchPages(params: {
   timeoutMs: number;
   fetchFn: typeof fetch;
 }): Promise<{ ok: true; data: unknown[] } | { ok: false; status?: number }> {
-  const data: unknown[] = [];
-  const seenPages = new Set<string>();
-  let page: string | undefined;
-
-  for (let pageCount = 1; pageCount <= MAX_PAGES; pageCount += 1) {
-    const url = new URL(params.baseUrl);
-    url.searchParams.set("starting_at", params.startingAt);
-    url.searchParams.set("ending_at", params.endingAt);
-    url.searchParams.set("bucket_width", "1d");
-    url.searchParams.set("limit", String(params.periodDays));
-    url.searchParams.set("group_by[]", params.groupBy);
-    if (page) {
-      url.searchParams.set("page", page);
-    }
-
-    let response: Response;
-    try {
-      response = await params.fetchFn(url, {
+  return await fetchProviderUsagePages({
+    responseLabel: "Anthropic usage",
+    responseMaxBytes: ANTHROPIC_USAGE_RESPONSE_MAX_BYTES,
+    timeoutMs: params.timeoutMs,
+    fetchFn: params.fetchFn,
+    buildRequest: (page) => {
+      const url = new URL(params.baseUrl);
+      url.searchParams.set("starting_at", params.startingAt);
+      url.searchParams.set("ending_at", params.endingAt);
+      url.searchParams.set("bucket_width", "1d");
+      url.searchParams.set("limit", String(params.periodDays));
+      url.searchParams.set("group_by[]", params.groupBy);
+      if (page) {
+        url.searchParams.set("page", page);
+      }
+      return {
+        url,
         headers: {
           Accept: "application/json",
           "anthropic-version": "2023-06-01",
           "x-api-key": params.apiKey,
         },
-        signal: AbortSignal.timeout(params.timeoutMs),
-      });
-    } catch {
-      return { ok: false };
-    }
-    if (!response.ok) {
-      await response.body?.cancel().catch(() => undefined);
-      return { ok: false, status: response.status };
-    }
-
-    let parsed: AnthropicUsagePage;
-    try {
-      parsed = await readPage(response, params.timeoutMs);
-    } catch {
-      return { ok: false };
-    }
-    data.push(...parsed.data);
-    if (!parsed.hasMore) {
-      return { ok: true, data };
-    }
-    if (!parsed.nextPage || seenPages.has(parsed.nextPage)) {
-      return { ok: false };
-    }
-    seenPages.add(parsed.nextPage);
-    page = parsed.nextPage;
-  }
-
-  return { ok: false };
-}
-
-function addModelUsage(
-  accumulator: DailyAccumulator,
-  name: string,
-  usage: Omit<ProviderUsageModelBreakdown, "name">,
-) {
-  const current = accumulator.models.get(name) ?? {
-    name,
-    inputTokens: 0,
-    cacheReadTokens: 0,
-    cacheWriteTokens: 0,
-    outputTokens: 0,
-    totalTokens: 0,
-  };
-  current.inputTokens += usage.inputTokens;
-  current.cacheReadTokens += usage.cacheReadTokens;
-  current.cacheWriteTokens += usage.cacheWriteTokens;
-  current.outputTokens += usage.outputTokens;
-  current.totalTokens += usage.totalTokens;
-  accumulator.models.set(name, current);
+      };
+    },
+  });
 }
 
 function aggregateHistory(params: {
@@ -243,19 +99,19 @@ function aggregateHistory(params: {
   messages: unknown[];
   periodDays: number;
 }): ProviderUsageSnapshot {
-  const daily = new Map<string, DailyAccumulator>();
+  const daily = new Map<string, ReturnType<typeof createProviderUsageDailyAccumulator>>();
   const getDaily = (startingAt: string) => {
     const date = utcDay(startingAt);
     if (!date) {
       return undefined;
     }
-    const current = daily.get(date) ?? emptyDaily(date);
+    const current = daily.get(date) ?? createProviderUsageDailyAccumulator(date);
     daily.set(date, current);
     return current;
   };
 
   for (const rawBucket of params.costs) {
-    const bucket = objectRecord(rawBucket);
+    const bucket = asProviderUsageObject(rawBucket);
     const startingAt = typeof bucket?.starting_at === "string" ? bucket.starting_at : undefined;
     if (!startingAt || !Array.isArray(bucket?.results)) {
       continue;
@@ -265,16 +121,19 @@ function aggregateHistory(params: {
       continue;
     }
     for (const rawResult of bucket.results) {
-      const result = objectRecord(rawResult);
-      const amount = (finiteNumber(result?.amount) ?? 0) / 100;
-      const category = displayName(result?.description ?? result?.cost_type, "Claude API");
+      const result = asProviderUsageObject(rawResult);
+      const amount = (parseProviderUsageNumber(result?.amount) ?? 0) / 100;
+      const category = resolveProviderUsageDisplayName(
+        result?.description ?? result?.cost_type,
+        "Claude API",
+      );
       accumulator.amount += amount;
       accumulator.categories.set(category, (accumulator.categories.get(category) ?? 0) + amount);
     }
   }
 
   for (const rawBucket of params.messages) {
-    const bucket = objectRecord(rawBucket);
+    const bucket = asProviderUsageObject(rawBucket);
     const startingAt = typeof bucket?.starting_at === "string" ? bucket.starting_at : undefined;
     if (!startingAt || !Array.isArray(bucket?.results)) {
       continue;
@@ -284,90 +143,46 @@ function aggregateHistory(params: {
       continue;
     }
     for (const rawResult of bucket.results) {
-      const result = objectRecord(rawResult);
+      const result = asProviderUsageObject(rawResult);
       if (!result) {
         continue;
       }
-      const cacheCreation = objectRecord(result.cache_creation);
-      const inputTokens = nonNegativeInteger(result.uncached_input_tokens);
+      const cacheCreation = asProviderUsageObject(result.cache_creation);
+      const inputTokens = parseProviderUsageNonNegativeInteger(result.uncached_input_tokens);
       const cacheWriteTokens =
-        nonNegativeInteger(cacheCreation?.ephemeral_1h_input_tokens) +
-        nonNegativeInteger(cacheCreation?.ephemeral_5m_input_tokens);
-      const cacheReadTokens = nonNegativeInteger(result.cache_read_input_tokens);
-      const outputTokens = nonNegativeInteger(result.output_tokens);
+        parseProviderUsageNonNegativeInteger(cacheCreation?.ephemeral_1h_input_tokens) +
+        parseProviderUsageNonNegativeInteger(cacheCreation?.ephemeral_5m_input_tokens);
+      const cacheReadTokens = parseProviderUsageNonNegativeInteger(result.cache_read_input_tokens);
+      const outputTokens = parseProviderUsageNonNegativeInteger(result.output_tokens);
       const totalTokens = inputTokens + cacheWriteTokens + cacheReadTokens + outputTokens;
       accumulator.inputTokens += inputTokens;
       accumulator.cacheWriteTokens += cacheWriteTokens;
       accumulator.cacheReadTokens += cacheReadTokens;
       accumulator.outputTokens += outputTokens;
       accumulator.totalTokens += totalTokens;
-      addModelUsage(accumulator, displayName(result.model, "Claude API"), {
-        inputTokens,
-        cacheReadTokens,
-        cacheWriteTokens,
-        outputTokens,
-        totalTokens,
-      });
+      addProviderUsageModel(
+        accumulator,
+        resolveProviderUsageDisplayName(result.model, "Claude API"),
+        {
+          inputTokens,
+          cacheReadTokens,
+          cacheWriteTokens,
+          outputTokens,
+          totalTokens,
+        },
+      );
     }
   }
 
-  const categories = new Map<string, number>();
-  const models = new Map<string, ProviderUsageModelBreakdown>();
-  const historyDaily = [...daily.values()]
-    .toSorted((a, b) => a.date.localeCompare(b.date))
-    .map((entry) => {
-      for (const [name, amount] of entry.categories) {
-        categories.set(name, (categories.get(name) ?? 0) + amount);
-      }
-      for (const model of entry.models.values()) {
-        const current = models.get(model.name) ?? {
-          name: model.name,
-          inputTokens: 0,
-          cacheReadTokens: 0,
-          cacheWriteTokens: 0,
-          outputTokens: 0,
-          totalTokens: 0,
-        };
-        current.inputTokens += model.inputTokens;
-        current.cacheReadTokens += model.cacheReadTokens;
-        current.cacheWriteTokens += model.cacheWriteTokens;
-        current.outputTokens += model.outputTokens;
-        current.totalTokens += model.totalTokens;
-        models.set(model.name, current);
-      }
-      const { categories: _categories, models: _models, ...day } = entry;
-      return day;
-    });
-  const amount = historyDaily.reduce((total, day) => total + day.amount, 0);
-  const totalTokens = historyDaily.reduce((total, day) => total + day.totalTokens, 0);
-
-  return {
+  return buildProviderUsageHistorySnapshot({
     provider: "anthropic",
     displayName: "Anthropic",
-    windows: [],
     plan: "Admin API",
-    billing: [
-      {
-        type: "spend",
-        label: `${params.periodDays}-day API spend`,
-        amount,
-        unit: "USD",
-        period: `${params.periodDays}d`,
-      },
-    ],
-    costHistory: {
-      unit: "USD",
-      periodDays: params.periodDays,
-      daily: historyDaily,
-      models: [...models.values()].toSorted(
-        (a, b) => b.totalTokens - a.totalTokens || a.name.localeCompare(b.name),
-      ),
-      categories: [...categories.entries()]
-        .map(([name, categoryAmount]) => ({ name, amount: categoryAmount }))
-        .toSorted((a, b) => b.amount - a.amount || a.name.localeCompare(b.name)),
-    },
-    summary: `${totalTokens.toLocaleString("en-US")} tokens`,
-  };
+    periodDays: params.periodDays,
+    unit: "USD",
+    daily: daily.values(),
+    formatSummary: ({ totalTokens }) => `${totalTokens.toLocaleString("en-US")} tokens`,
+  });
 }
 
 async function fetchAnthropicAdminUsage(params: {
@@ -377,15 +192,16 @@ async function fetchAnthropicAdminUsage(params: {
   now?: number;
   periodDays?: number;
 }): Promise<ProviderUsageSnapshot> {
-  const periodDays = Math.max(
-    1,
-    Math.min(31, Math.trunc(params.periodDays ?? ANTHROPIC_USAGE_HISTORY_DAYS)),
-  );
-  const range = resolveDailyRange(params.now ?? Date.now(), periodDays);
+  const period = resolveProviderUsageDailyPeriod({
+    now: params.now ?? Date.now(),
+    periodDays: params.periodDays,
+    defaultPeriodDays: ANTHROPIC_USAGE_HISTORY_DAYS,
+  });
   const common = {
     apiKey: params.apiKey,
-    ...range,
-    periodDays,
+    startingAt: new Date(period.startMs).toISOString(),
+    endingAt: new Date(period.endMs).toISOString(),
+    periodDays: period.periodDays,
     timeoutMs: params.timeoutMs,
     fetchFn: params.fetchFn,
   };
@@ -412,15 +228,19 @@ async function fetchAnthropicAdminUsage(params: {
           error: "Usage unavailable",
         };
   }
-  return aggregateHistory({ costs: costs.data, messages: messages.data, periodDays });
+  return aggregateHistory({
+    costs: costs.data,
+    messages: messages.data,
+    periodDays: period.periodDays,
+  });
 }
 
 export async function resolveAnthropicUsageAuth(
   ctx: ProviderResolveUsageAuthContext,
 ): Promise<ProviderResolvedUsageAuth> {
   const explicitAdminKey =
-    cleanCredential(ctx.env.ANTHROPIC_ADMIN_KEY) ??
-    cleanCredential(ctx.env.ANTHROPIC_ADMIN_API_KEY);
+    cleanProviderUsageCredential(ctx.env.ANTHROPIC_ADMIN_KEY) ??
+    cleanProviderUsageCredential(ctx.env.ANTHROPIC_ADMIN_API_KEY);
   if (explicitAdminKey) {
     return { token: encodeAdminToken(explicitAdminKey) };
   }

--- a/extensions/openai/usage.test.ts
+++ b/extensions/openai/usage.test.ts
@@ -78,10 +78,20 @@ describe("OpenAI provider usage", () => {
       fetchFn: fetchFn as typeof fetch,
     });
 
-    expect(result).toMatchObject({
+    expect(result).toEqual({
       provider: "openai",
+      displayName: "OpenAI",
+      windows: [],
       plan: "Admin API · proj_test",
-      billing: [{ type: "spend", amount: 12.34, unit: "USD", period: "30d" }],
+      billing: [
+        {
+          type: "spend",
+          label: "30-day API spend",
+          amount: 12.34,
+          unit: "USD",
+          period: "30d",
+        },
+      ],
       costHistory: {
         unit: "USD",
         periodDays: 30,
@@ -93,6 +103,7 @@ describe("OpenAI provider usage", () => {
             requests: 8,
             inputTokens: 600,
             cacheReadTokens: 400,
+            cacheWriteTokens: 0,
             outputTokens: 250,
             totalTokens: 1_250,
           },
@@ -103,11 +114,14 @@ describe("OpenAI provider usage", () => {
             requests: 8,
             inputTokens: 600,
             cacheReadTokens: 400,
+            cacheWriteTokens: 0,
+            outputTokens: 250,
             totalTokens: 1_250,
           },
         ],
         categories: [{ name: "Responses", amount: 12.34 }],
       },
+      summary: "8 requests · 1,250 tokens",
     });
     expect(fetchFn).toHaveBeenCalledTimes(2);
     for (const [input, init] of fetchFn.mock.calls) {

--- a/extensions/openai/usage.ts
+++ b/extensions/openai/usage.ts
@@ -3,12 +3,21 @@ import type {
   ProviderResolveUsageAuthContext,
   ProviderResolvedUsageAuth,
 } from "openclaw/plugin-sdk/plugin-entry";
-import { readProviderJsonObjectResponse } from "openclaw/plugin-sdk/provider-http";
 import {
+  addProviderUsageModel,
+  asProviderUsageObject,
+  buildProviderUsageHistorySnapshot,
   buildUsageHttpErrorSnapshot,
+  cleanProviderUsageCredential,
+  createProviderUsageDailyAccumulator,
+  decodeProviderUsageAdminToken,
+  encodeProviderUsageAdminToken,
+  fetchProviderUsagePages,
   fetchCodexUsage,
-  type ProviderUsageCostDaily,
-  type ProviderUsageModelBreakdown,
+  parseProviderUsageNonNegativeInteger,
+  parseProviderUsageNumber,
+  resolveProviderUsageDailyPeriod,
+  resolveProviderUsageDisplayName,
   type ProviderUsageSnapshot,
 } from "openclaw/plugin-sdk/provider-usage";
 import { resolveCodexAuthIdentity } from "./openai-chatgpt-auth-identity.js";
@@ -18,124 +27,17 @@ const OPENAI_COMPLETIONS_USAGE_URL = "https://api.openai.com/v1/organization/usa
 const OPENAI_ADMIN_TOKEN_PREFIX = "openclaw:openai-admin:v1:";
 const OPENAI_USAGE_RESPONSE_MAX_BYTES = 4 * 1024 * 1024;
 const OPENAI_USAGE_HISTORY_DAYS = 30;
-const MAX_PAGES = 100;
-
-type OpenAIUsagePage = {
-  data: unknown[];
-  hasMore: boolean;
-  nextPage?: string;
-};
-
-type DailyAccumulator = ProviderUsageCostDaily & {
-  categories: Map<string, number>;
-  models: Map<string, ProviderUsageModelBreakdown>;
-};
-
-function cleanCredential(raw: string | undefined): string | undefined {
-  const trimmed = raw?.replaceAll(/[\r\n]/g, "").trim();
-  if (!trimmed) {
-    return undefined;
-  }
-  const quoted =
-    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
-    (trimmed.startsWith("'") && trimmed.endsWith("'"));
-  const cleaned = quoted ? trimmed.slice(1, -1).trim() : trimmed;
-  return cleaned || undefined;
-}
 
 function encodeAdminToken(token: string): string {
-  return `${OPENAI_ADMIN_TOKEN_PREFIX}${JSON.stringify({ token })}`;
+  return encodeProviderUsageAdminToken(OPENAI_ADMIN_TOKEN_PREFIX, token);
 }
 
 function decodeAdminToken(raw: string): string | undefined {
-  if (!raw.startsWith(OPENAI_ADMIN_TOKEN_PREFIX)) {
-    return undefined;
-  }
-  try {
-    const value = JSON.parse(raw.slice(OPENAI_ADMIN_TOKEN_PREFIX.length)) as unknown;
-    const token = objectRecord(value)?.token;
-    return typeof token === "string" && token.trim() ? token.trim() : undefined;
-  } catch {
-    return undefined;
-  }
-}
-
-function objectRecord(value: unknown): Record<string, unknown> | undefined {
-  return value !== null && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : undefined;
-}
-
-function finiteNumber(value: unknown): number | undefined {
-  const parsed =
-    typeof value === "number"
-      ? value
-      : typeof value === "string" && value.trim()
-        ? Number(value)
-        : Number.NaN;
-  return Number.isFinite(parsed) ? parsed : undefined;
-}
-
-function nonNegativeInteger(value: unknown): number {
-  const parsed = finiteNumber(value);
-  return parsed === undefined ? 0 : Math.max(0, Math.trunc(parsed));
-}
-
-function displayName(value: unknown, fallback: string): string {
-  return typeof value === "string" && value.trim() ? value.trim() : fallback;
+  return decodeProviderUsageAdminToken(OPENAI_ADMIN_TOKEN_PREFIX, raw);
 }
 
 function utcDay(epochSeconds: number): string {
   return new Date(epochSeconds * 1000).toISOString().slice(0, 10);
-}
-
-function emptyDaily(date: string): DailyAccumulator {
-  return {
-    date,
-    amount: 0,
-    requests: 0,
-    inputTokens: 0,
-    cacheReadTokens: 0,
-    cacheWriteTokens: 0,
-    outputTokens: 0,
-    totalTokens: 0,
-    categories: new Map(),
-    models: new Map(),
-  };
-}
-
-function resolveDailyRange(now: number, periodDays: number) {
-  const current = new Date(now);
-  const todayStart = Date.UTC(
-    current.getUTCFullYear(),
-    current.getUTCMonth(),
-    current.getUTCDate(),
-  );
-  return {
-    startTime: Math.floor((todayStart - (periodDays - 1) * 86_400_000) / 1000),
-    endTime: Math.floor((todayStart + 86_400_000) / 1000),
-  };
-}
-
-async function readPage(response: Response, timeoutMs: number): Promise<OpenAIUsagePage> {
-  const payload = await readProviderJsonObjectResponse(response, "OpenAI usage", {
-    maxBytes: OPENAI_USAGE_RESPONSE_MAX_BYTES,
-    chunkTimeoutMs: timeoutMs,
-    onIdleTimeout: ({ chunkTimeoutMs }) =>
-      new Error(`OpenAI usage response stalled for ${chunkTimeoutMs}ms`),
-  });
-  if (!Array.isArray(payload.data)) {
-    throw new Error("OpenAI usage response is not an object with data");
-  }
-  const nextPage =
-    typeof payload.next_page === "string" && payload.next_page.trim()
-      ? payload.next_page.trim()
-      : undefined;
-  return {
-    data: payload.data,
-    hasMore: payload.has_more === true,
-    ...(nextPage ? { nextPage } : {}),
-  };
 }
 
 async function fetchPages(params: {
@@ -149,82 +51,33 @@ async function fetchPages(params: {
   timeoutMs: number;
   fetchFn: typeof fetch;
 }): Promise<{ ok: true; data: unknown[] } | { ok: false; status?: number }> {
-  const data: unknown[] = [];
-  const seenPages = new Set<string>();
-  let page: string | undefined;
-
-  for (let pageCount = 1; pageCount <= MAX_PAGES; pageCount += 1) {
-    const url = new URL(params.baseUrl);
-    url.searchParams.set("start_time", String(params.startTime));
-    url.searchParams.set("end_time", String(params.endTime));
-    url.searchParams.set("bucket_width", "1d");
-    url.searchParams.set("limit", String(params.periodDays));
-    url.searchParams.set("group_by", params.groupBy);
-    if (params.projectId) {
-      url.searchParams.set("project_ids", params.projectId);
-    }
-    if (page) {
-      url.searchParams.set("page", page);
-    }
-
-    let response: Response;
-    try {
-      response = await params.fetchFn(url, {
+  return await fetchProviderUsagePages({
+    responseLabel: "OpenAI usage",
+    responseMaxBytes: OPENAI_USAGE_RESPONSE_MAX_BYTES,
+    timeoutMs: params.timeoutMs,
+    fetchFn: params.fetchFn,
+    buildRequest: (page) => {
+      const url = new URL(params.baseUrl);
+      url.searchParams.set("start_time", String(params.startTime));
+      url.searchParams.set("end_time", String(params.endTime));
+      url.searchParams.set("bucket_width", "1d");
+      url.searchParams.set("limit", String(params.periodDays));
+      url.searchParams.set("group_by", params.groupBy);
+      if (params.projectId) {
+        url.searchParams.set("project_ids", params.projectId);
+      }
+      if (page) {
+        url.searchParams.set("page", page);
+      }
+      return {
+        url,
         headers: {
           Accept: "application/json",
           Authorization: `Bearer ${params.apiKey}`,
         },
-        signal: AbortSignal.timeout(params.timeoutMs),
-      });
-    } catch {
-      return { ok: false };
-    }
-    if (!response.ok) {
-      await response.body?.cancel().catch(() => undefined);
-      return { ok: false, status: response.status };
-    }
-
-    let parsed: OpenAIUsagePage;
-    try {
-      parsed = await readPage(response, params.timeoutMs);
-    } catch {
-      return { ok: false };
-    }
-    data.push(...parsed.data);
-    if (!parsed.hasMore) {
-      return { ok: true, data };
-    }
-    if (!parsed.nextPage || seenPages.has(parsed.nextPage)) {
-      return { ok: false };
-    }
-    seenPages.add(parsed.nextPage);
-    page = parsed.nextPage;
-  }
-
-  return { ok: false };
-}
-
-function addModelUsage(
-  accumulator: DailyAccumulator,
-  name: string,
-  usage: Omit<ProviderUsageModelBreakdown, "name">,
-) {
-  const current = accumulator.models.get(name) ?? {
-    name,
-    requests: 0,
-    inputTokens: 0,
-    cacheReadTokens: 0,
-    cacheWriteTokens: 0,
-    outputTokens: 0,
-    totalTokens: 0,
-  };
-  current.requests = (current.requests ?? 0) + (usage.requests ?? 0);
-  current.inputTokens += usage.inputTokens;
-  current.cacheReadTokens += usage.cacheReadTokens;
-  current.cacheWriteTokens += usage.cacheWriteTokens;
-  current.outputTokens += usage.outputTokens;
-  current.totalTokens += usage.totalTokens;
-  accumulator.models.set(name, current);
+      };
+    },
+  });
 }
 
 function aggregateHistory(params: {
@@ -233,126 +86,82 @@ function aggregateHistory(params: {
   periodDays: number;
   projectId?: string;
 }): ProviderUsageSnapshot {
-  const daily = new Map<number, DailyAccumulator>();
+  const daily = new Map<number, ReturnType<typeof createProviderUsageDailyAccumulator>>();
   const getDaily = (startTime: number) => {
-    const current = daily.get(startTime) ?? emptyDaily(utcDay(startTime));
+    const current =
+      daily.get(startTime) ?? createProviderUsageDailyAccumulator(utcDay(startTime), true);
     daily.set(startTime, current);
     return current;
   };
 
   for (const rawBucket of params.costs) {
-    const bucket = objectRecord(rawBucket);
-    const startTime = finiteNumber(bucket?.start_time);
+    const bucket = asProviderUsageObject(rawBucket);
+    const startTime = parseProviderUsageNumber(bucket?.start_time);
     if (startTime === undefined || !Array.isArray(bucket?.results)) {
       continue;
     }
     const accumulator = getDaily(startTime);
     for (const rawResult of bucket.results) {
-      const result = objectRecord(rawResult);
-      const amount = finiteNumber(objectRecord(result?.amount)?.value) ?? 0;
-      const category = displayName(result?.line_item, "API");
+      const result = asProviderUsageObject(rawResult);
+      const amount = parseProviderUsageNumber(asProviderUsageObject(result?.amount)?.value) ?? 0;
+      const category = resolveProviderUsageDisplayName(result?.line_item, "API");
       accumulator.amount += amount;
       accumulator.categories.set(category, (accumulator.categories.get(category) ?? 0) + amount);
     }
   }
 
   for (const rawBucket of params.completions) {
-    const bucket = objectRecord(rawBucket);
-    const startTime = finiteNumber(bucket?.start_time);
+    const bucket = asProviderUsageObject(rawBucket);
+    const startTime = parseProviderUsageNumber(bucket?.start_time);
     if (startTime === undefined || !Array.isArray(bucket?.results)) {
       continue;
     }
     const accumulator = getDaily(startTime);
     for (const rawResult of bucket.results) {
-      const result = objectRecord(rawResult);
+      const result = asProviderUsageObject(rawResult);
       if (!result) {
         continue;
       }
-      const requests = nonNegativeInteger(result.num_model_requests);
-      const textInputTokens = nonNegativeInteger(result.input_tokens);
-      const audioInputTokens = nonNegativeInteger(result.input_audio_tokens);
-      const cacheReadTokens = nonNegativeInteger(result.input_cached_tokens);
+      const requests = parseProviderUsageNonNegativeInteger(result.num_model_requests);
+      const textInputTokens = parseProviderUsageNonNegativeInteger(result.input_tokens);
+      const audioInputTokens = parseProviderUsageNonNegativeInteger(result.input_audio_tokens);
+      const cacheReadTokens = parseProviderUsageNonNegativeInteger(result.input_cached_tokens);
       const inputTokens = Math.max(0, textInputTokens - cacheReadTokens) + audioInputTokens;
       const outputTokens =
-        nonNegativeInteger(result.output_tokens) + nonNegativeInteger(result.output_audio_tokens);
+        parseProviderUsageNonNegativeInteger(result.output_tokens) +
+        parseProviderUsageNonNegativeInteger(result.output_audio_tokens);
       const totalTokens = textInputTokens + audioInputTokens + outputTokens;
       accumulator.requests = (accumulator.requests ?? 0) + requests;
       accumulator.inputTokens += inputTokens;
       accumulator.cacheReadTokens += cacheReadTokens;
       accumulator.outputTokens += outputTokens;
       accumulator.totalTokens += totalTokens;
-      addModelUsage(accumulator, displayName(result.model, "Responses and Chat Completions"), {
-        requests,
-        inputTokens,
-        cacheReadTokens,
-        cacheWriteTokens: 0,
-        outputTokens,
-        totalTokens,
-      });
+      addProviderUsageModel(
+        accumulator,
+        resolveProviderUsageDisplayName(result.model, "Responses and Chat Completions"),
+        {
+          requests,
+          inputTokens,
+          cacheReadTokens,
+          cacheWriteTokens: 0,
+          outputTokens,
+          totalTokens,
+        },
+      );
     }
   }
 
-  const categories = new Map<string, number>();
-  const models = new Map<string, ProviderUsageModelBreakdown>();
-  const historyDaily = [...daily.entries()]
-    .toSorted(([a], [b]) => a - b)
-    .map(([, entry]) => {
-      for (const [name, amount] of entry.categories) {
-        categories.set(name, (categories.get(name) ?? 0) + amount);
-      }
-      for (const model of entry.models.values()) {
-        const current = models.get(model.name) ?? {
-          name: model.name,
-          requests: 0,
-          inputTokens: 0,
-          cacheReadTokens: 0,
-          cacheWriteTokens: 0,
-          outputTokens: 0,
-          totalTokens: 0,
-        };
-        current.requests = (current.requests ?? 0) + (model.requests ?? 0);
-        current.inputTokens += model.inputTokens;
-        current.cacheReadTokens += model.cacheReadTokens;
-        current.cacheWriteTokens += model.cacheWriteTokens;
-        current.outputTokens += model.outputTokens;
-        current.totalTokens += model.totalTokens;
-        models.set(model.name, current);
-      }
-      const { categories: _categories, models: _models, ...day } = entry;
-      return day;
-    });
-  const amount = historyDaily.reduce((total, day) => total + day.amount, 0);
-  const requests = historyDaily.reduce((total, day) => total + (day.requests ?? 0), 0);
-  const totalTokens = historyDaily.reduce((total, day) => total + day.totalTokens, 0);
-
-  return {
+  return buildProviderUsageHistorySnapshot({
     provider: "openai",
     displayName: "OpenAI",
-    windows: [],
     plan: params.projectId ? `Admin API · ${params.projectId}` : "Admin API",
-    billing: [
-      {
-        type: "spend",
-        label: `${params.periodDays}-day API spend`,
-        amount,
-        unit: "USD",
-        period: `${params.periodDays}d`,
-      },
-    ],
-    costHistory: {
-      unit: "USD",
-      periodDays: params.periodDays,
-      ...(params.projectId ? { scope: `Project ${params.projectId}` } : {}),
-      daily: historyDaily,
-      models: [...models.values()].toSorted(
-        (a, b) => b.totalTokens - a.totalTokens || a.name.localeCompare(b.name),
-      ),
-      categories: [...categories.entries()]
-        .map(([name, categoryAmount]) => ({ name, amount: categoryAmount }))
-        .toSorted((a, b) => b.amount - a.amount || a.name.localeCompare(b.name)),
-    },
-    summary: `${requests.toLocaleString("en-US")} requests · ${totalTokens.toLocaleString("en-US")} tokens`,
-  };
+    periodDays: params.periodDays,
+    unit: "USD",
+    ...(params.projectId ? { scope: `Project ${params.projectId}` } : {}),
+    daily: [...daily.entries()].toSorted(([a], [b]) => a - b).map(([, entry]) => entry),
+    formatSummary: ({ requests, totalTokens }) =>
+      `${requests.toLocaleString("en-US")} requests · ${totalTokens.toLocaleString("en-US")} tokens`,
+  });
 }
 
 async function fetchOpenAIAdminUsage(params: {
@@ -363,17 +172,17 @@ async function fetchOpenAIAdminUsage(params: {
   now?: number;
   periodDays?: number;
 }): Promise<ProviderUsageSnapshot> {
-  const periodDays = Math.max(
-    1,
-    Math.min(31, Math.trunc(params.periodDays ?? OPENAI_USAGE_HISTORY_DAYS)),
-  );
-  const range = resolveDailyRange(params.now ?? Date.now(), periodDays);
+  const period = resolveProviderUsageDailyPeriod({
+    now: params.now ?? Date.now(),
+    periodDays: params.periodDays,
+    defaultPeriodDays: OPENAI_USAGE_HISTORY_DAYS,
+  });
   const common = {
     apiKey: params.apiKey,
     projectId: params.projectId,
-    startTime: range.startTime,
-    endTime: range.endTime,
-    periodDays,
+    startTime: Math.floor(period.startMs / 1000),
+    endTime: Math.floor(period.endMs / 1000),
+    periodDays: period.periodDays,
     timeoutMs: params.timeoutMs,
     fetchFn: params.fetchFn,
   };
@@ -407,7 +216,7 @@ async function fetchOpenAIAdminUsage(params: {
   return aggregateHistory({
     costs: costs.data,
     completions: completions.data,
-    periodDays,
+    periodDays: period.periodDays,
     projectId: params.projectId,
   });
 }
@@ -415,7 +224,7 @@ async function fetchOpenAIAdminUsage(params: {
 export async function resolveOpenAIUsageAuth(
   ctx: ProviderResolveUsageAuthContext,
 ): Promise<ProviderResolvedUsageAuth> {
-  const explicitAdminKey = cleanCredential(ctx.env.OPENAI_ADMIN_KEY);
+  const explicitAdminKey = cleanProviderUsageCredential(ctx.env.OPENAI_ADMIN_KEY);
   if (explicitAdminKey) {
     return { token: encodeAdminToken(explicitAdminKey) };
   }
@@ -446,7 +255,7 @@ export async function fetchOpenAIUsage(
   }
   return await fetchOpenAIAdminUsage({
     apiKey: adminKey,
-    projectId: cleanCredential(ctx.env.OPENAI_PROJECT_ID),
+    projectId: cleanProviderUsageCredential(ctx.env.OPENAI_PROJECT_ID),
     timeoutMs: ctx.timeoutMs,
     fetchFn: ctx.fetchFn,
   });

--- a/src/infra/provider-usage.admin.ts
+++ b/src/infra/provider-usage.admin.ts
@@ -1,0 +1,263 @@
+import { readProviderJsonObjectResponse } from "../agents/provider-http-errors.js";
+import type {
+  ProviderUsageCostDaily,
+  ProviderUsageModelBreakdown,
+  ProviderUsageSnapshot,
+  UsageProviderId,
+} from "./provider-usage.types.js";
+
+const DAY_MS = 86_400_000;
+const MAX_USAGE_PAGES = 100;
+
+type ProviderUsagePageRequest = {
+  url: URL;
+  headers: HeadersInit;
+};
+
+type ProviderUsageDailyAccumulator = ProviderUsageCostDaily & {
+  categories: Map<string, number>;
+  models: Map<string, ProviderUsageModelBreakdown>;
+};
+
+export function cleanProviderUsageCredential(raw: string | undefined): string | undefined {
+  const trimmed = raw?.replaceAll(/[\r\n]/g, "").trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  const quoted =
+    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"));
+  const cleaned = quoted ? trimmed.slice(1, -1).trim() : trimmed;
+  return cleaned || undefined;
+}
+
+export function encodeProviderUsageAdminToken(prefix: string, token: string): string {
+  return `${prefix}${JSON.stringify({ token })}`;
+}
+
+export function decodeProviderUsageAdminToken(prefix: string, raw: string): string | undefined {
+  if (!raw.startsWith(prefix)) {
+    return undefined;
+  }
+  try {
+    const token = asProviderUsageObject(JSON.parse(raw.slice(prefix.length)) as unknown)?.token;
+    return typeof token === "string" && token.trim() ? token.trim() : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function asProviderUsageObject(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+export function parseProviderUsageNumber(value: unknown): number | undefined {
+  const parsed =
+    typeof value === "number"
+      ? value
+      : typeof value === "string" && value.trim()
+        ? Number(value)
+        : Number.NaN;
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+export function parseProviderUsageNonNegativeInteger(value: unknown): number {
+  const parsed = parseProviderUsageNumber(value);
+  return parsed === undefined ? 0 : Math.max(0, Math.trunc(parsed));
+}
+
+export function resolveProviderUsageDisplayName(value: unknown, fallback: string): string {
+  return typeof value === "string" && value.trim() ? value.trim() : fallback;
+}
+
+export function resolveProviderUsageDailyPeriod(params: {
+  now: number;
+  periodDays?: number;
+  defaultPeriodDays: number;
+}): { periodDays: number; startMs: number; endMs: number } {
+  const periodDays = Math.max(
+    1,
+    Math.min(31, Math.trunc(params.periodDays ?? params.defaultPeriodDays)),
+  );
+  const current = new Date(params.now);
+  const todayStart = Date.UTC(
+    current.getUTCFullYear(),
+    current.getUTCMonth(),
+    current.getUTCDate(),
+  );
+  return {
+    periodDays,
+    startMs: todayStart - (periodDays - 1) * DAY_MS,
+    endMs: todayStart + DAY_MS,
+  };
+}
+
+export async function fetchProviderUsagePages(params: {
+  responseLabel: string;
+  responseMaxBytes: number;
+  timeoutMs: number;
+  fetchFn: typeof fetch;
+  buildRequest: (page: string | undefined) => ProviderUsagePageRequest;
+}): Promise<{ ok: true; data: unknown[] } | { ok: false; status?: number }> {
+  const data: unknown[] = [];
+  const seenPages = new Set<string>();
+  let page: string | undefined;
+
+  for (let pageCount = 1; pageCount <= MAX_USAGE_PAGES; pageCount += 1) {
+    const request = params.buildRequest(page);
+    let response: Response;
+    try {
+      response = await params.fetchFn(request.url, {
+        headers: request.headers,
+        signal: AbortSignal.timeout(params.timeoutMs),
+      });
+    } catch {
+      return { ok: false };
+    }
+    if (!response.ok) {
+      await response.body?.cancel().catch(() => undefined);
+      return { ok: false, status: response.status };
+    }
+
+    let payload: Record<string, unknown>;
+    try {
+      payload = await readProviderJsonObjectResponse(response, params.responseLabel, {
+        maxBytes: params.responseMaxBytes,
+        chunkTimeoutMs: params.timeoutMs,
+        onIdleTimeout: ({ chunkTimeoutMs }) =>
+          new Error(`${params.responseLabel} response stalled for ${chunkTimeoutMs}ms`),
+      });
+    } catch {
+      return { ok: false };
+    }
+    if (!Array.isArray(payload.data)) {
+      return { ok: false };
+    }
+    data.push(...payload.data);
+    if (payload.has_more !== true) {
+      return { ok: true, data };
+    }
+    const nextPage =
+      typeof payload.next_page === "string" && payload.next_page.trim()
+        ? payload.next_page.trim()
+        : undefined;
+    if (!nextPage || seenPages.has(nextPage)) {
+      return { ok: false };
+    }
+    seenPages.add(nextPage);
+    page = nextPage;
+  }
+
+  return { ok: false };
+}
+
+export function createProviderUsageDailyAccumulator(
+  date: string,
+  includeRequests = false,
+): ProviderUsageDailyAccumulator {
+  return {
+    date,
+    amount: 0,
+    ...(includeRequests ? { requests: 0 } : {}),
+    inputTokens: 0,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 0,
+    outputTokens: 0,
+    totalTokens: 0,
+    categories: new Map(),
+    models: new Map(),
+  };
+}
+
+function mergeModelUsage(
+  models: Map<string, ProviderUsageModelBreakdown>,
+  name: string,
+  usage: Omit<ProviderUsageModelBreakdown, "name">,
+): void {
+  const current = models.get(name) ?? {
+    name,
+    ...(usage.requests === undefined ? {} : { requests: 0 }),
+    inputTokens: 0,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 0,
+    outputTokens: 0,
+    totalTokens: 0,
+  };
+  if (usage.requests !== undefined) {
+    current.requests = (current.requests ?? 0) + usage.requests;
+  }
+  current.inputTokens += usage.inputTokens;
+  current.cacheReadTokens += usage.cacheReadTokens;
+  current.cacheWriteTokens += usage.cacheWriteTokens;
+  current.outputTokens += usage.outputTokens;
+  current.totalTokens += usage.totalTokens;
+  models.set(name, current);
+}
+
+export function addProviderUsageModel(
+  accumulator: ProviderUsageDailyAccumulator,
+  name: string,
+  usage: Omit<ProviderUsageModelBreakdown, "name">,
+): void {
+  mergeModelUsage(accumulator.models, name, usage);
+}
+
+export function buildProviderUsageHistorySnapshot(params: {
+  provider: UsageProviderId;
+  displayName: string;
+  plan: string;
+  periodDays: number;
+  unit: string;
+  scope?: string;
+  daily: Iterable<ProviderUsageDailyAccumulator>;
+  formatSummary: (totals: { requests: number; totalTokens: number }) => string;
+}): ProviderUsageSnapshot {
+  const categories = new Map<string, number>();
+  const models = new Map<string, ProviderUsageModelBreakdown>();
+  const daily = [...params.daily]
+    .toSorted((a, b) => a.date.localeCompare(b.date))
+    .map((entry) => {
+      for (const [name, amount] of entry.categories) {
+        categories.set(name, (categories.get(name) ?? 0) + amount);
+      }
+      for (const model of entry.models.values()) {
+        mergeModelUsage(models, model.name, model);
+      }
+      const { categories: _categories, models: _models, ...day } = entry;
+      return day;
+    });
+  const amount = daily.reduce((total, day) => total + day.amount, 0);
+  const requests = daily.reduce((total, day) => total + (day.requests ?? 0), 0);
+  const totalTokens = daily.reduce((total, day) => total + day.totalTokens, 0);
+
+  return {
+    provider: params.provider,
+    displayName: params.displayName,
+    windows: [],
+    plan: params.plan,
+    billing: [
+      {
+        type: "spend",
+        label: `${params.periodDays}-day API spend`,
+        amount,
+        unit: params.unit,
+        period: `${params.periodDays}d`,
+      },
+    ],
+    costHistory: {
+      unit: params.unit,
+      periodDays: params.periodDays,
+      ...(params.scope ? { scope: params.scope } : {}),
+      daily,
+      models: [...models.values()].toSorted(
+        (a, b) => b.totalTokens - a.totalTokens || a.name.localeCompare(b.name),
+      ),
+      categories: [...categories.entries()]
+        .map(([name, categoryAmount]) => ({ name, amount: categoryAmount }))
+        .toSorted((a, b) => b.amount - a.amount || a.name.localeCompare(b.name)),
+    },
+    summary: params.formatSummary({ requests, totalTokens }),
+  };
+}

--- a/src/plugin-sdk/provider-usage.ts
+++ b/src/plugin-sdk/provider-usage.ts
@@ -21,6 +21,20 @@ export {
 } from "../infra/provider-usage.fetch.js";
 export { clampPercent, PROVIDER_LABELS } from "../infra/provider-usage.shared.js";
 export {
+  addProviderUsageModel,
+  asProviderUsageObject,
+  buildProviderUsageHistorySnapshot,
+  cleanProviderUsageCredential,
+  createProviderUsageDailyAccumulator,
+  decodeProviderUsageAdminToken,
+  encodeProviderUsageAdminToken,
+  fetchProviderUsagePages,
+  parseProviderUsageNonNegativeInteger,
+  parseProviderUsageNumber,
+  resolveProviderUsageDailyPeriod,
+  resolveProviderUsageDisplayName,
+} from "../infra/provider-usage.admin.js";
+export {
   buildUsageErrorSnapshot,
   buildUsageHttpErrorSnapshot,
   fetchJson,


### PR DESCRIPTION
## What Problem This Solves

Anthropic and OpenAI admin usage reporting maintained separate copies of the same credential cleanup, UTC daily-window calculation, bounded pagination, coercion, model/category aggregation, sorting, and snapshot assembly. That duplication made equivalent provider behavior harder to keep aligned.

## Why This Change Was Made

This maintainer-requested refactor moves the shared generic machinery behind the existing local-only `openclaw/plugin-sdk/provider-usage` seam. Provider-specific endpoints, query parameters, headers, wire-row parsing, credential precedence, and error wording remain owned by each plugin.

AI-assisted: implemented and reviewed with Codex.

## User Impact

No intended user-visible behavior change. Anthropic and OpenAI usage history retain their exact provider-specific output while future pagination and aggregation fixes now have one owner.

Release-note context: internal behavior-preserving provider refactor; no standalone release note needed.

## Evidence

- `node scripts/run-vitest.mjs extensions/anthropic/usage.test.ts extensions/openai/usage.test.ts` — 15 tests passed across both provider shards after rebasing onto current `origin/main`.
- Both provider fixtures now assert exact snapshot equality, including billing labels, token/cache/request totals, model/category ordering, scopes, and summaries.
- `node --max-old-space-size=8192 --import tsx scripts/generate-plugin-sdk-api-baseline.ts --check` — passed.
- `node scripts/sync-plugin-sdk-exports.mjs --check` — passed.
- `node --max-old-space-size=8192 scripts/plugin-sdk-surface-report.mjs --check` — passed; the seam remains local-only.
- `oxfmt --check ...` and `git diff --check origin/main...HEAD` — passed.
- Codex autoreview — clean, no accepted/actionable findings; overall correct at 0.96. The mandated global wrapper crashed in its pre-review JavaScript secret lexer, so the same Codex/Sol branch review was completed with the checked-in OpenClaw helper.
- Production diff: 446 additions, 540 deletions (net -94 LOC).

## Maintainer Decision

Accept the exact-fixture, SDK-contract, and exact-head CI proof without a live organization-admin API run. A live run would require secret-bearing Anthropic and OpenAI organization credentials, while this change leaves provider URLs, query names, headers, credential precedence, and vendor row parsing untouched; every moved branch is covered by exact output fixtures. The new exports intentionally remain on the existing bundled/local-only `provider-usage` SDK subpath, confirmed by `plugin-sdk-surface-report --check`.
