### PR TITLE
fix(telegram): preserve ingress timeout diagnostics

### DIFF
--- a/extensions/codex/src/app-server/run-attempt-active-turn.ts
+++ b/extensions/codex/src/app-server/run-attempt-active-turn.ts
@@ -2,6 +2,7 @@ import {
   cancelPendingAgentQuestionForSession,
   claimPendingAgentQuestionAnswer,
   embeddedAgentLog,
+  resolveAgentRunAbortLifecycleFields,
   setActiveEmbeddedRun,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import {
@@ -218,6 +219,11 @@ export async function activateCodexAttemptTurn(
     upstreamUserText: turnState.codexTurnPromptText,
   });
   const abortListener = () => {
+    if (
+      resolveAgentRunAbortLifecycleFields(runAbortController.signal).stopReason === "timeout"
+    ) {
+      state.timedOut = true;
+    }
     if (state.timedOut) {
       void (async () => {
         // Supervised sessions stay native; clearing scope would silently move the next attempt.

--- a/extensions/codex/src/app-server/run-attempt-cleanup.ts
+++ b/extensions/codex/src/app-server/run-attempt-cleanup.ts
@@ -1,6 +1,7 @@
 import {
   clearActiveEmbeddedRun,
   embeddedAgentLog,
+  resolveAgentRunAbortLifecycleFields,
   runAgentCleanupStep,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { isIncognitoSessionKey } from "../incognito-session.js";
@@ -14,6 +15,7 @@ import type { CodexAttemptLifecycleController } from "./run-attempt-lifecycle-co
 import type { CodexAttemptResources } from "./run-attempt-resources.js";
 import type { prepareCodexAttemptTurnRequest } from "./run-attempt-turn-request.js";
 import type { CodexAttemptTurnState } from "./run-attempt-turn-state.js";
+import { normalizeCodexTrajectoryAbortReason } from "./trajectory.js";
 
 export async function cleanupCodexAttempt(
   resources: CodexAttemptResources,
@@ -41,6 +43,9 @@ export async function cleanupCodexAttempt(
   } = lifecycle;
   const { codexModelCallDiagnostics } = requestRuntime;
   const { activeTurnId, abortListener, handle, freezeRunTerminalOutcome } = activeTurn;
+  const effectiveTimedOut =
+    state.timedOut ||
+    resolveAgentRunAbortLifecycleFields(runAbortController.signal).stopReason === "timeout";
   if (params.isFinalFallbackAttempt !== false) {
     await maybeEmitFastModeAutoResetBestEffort();
   }
@@ -52,19 +57,20 @@ export async function cleanupCodexAttempt(
     error: "codex app-server run completed without lifecycle terminal event",
     ...buildLifecycleTerminalMeta({
       aborted: runAbortController.signal.aborted && !state.clientClosedAbort,
-      timedOut: state.timedOut,
+      timedOut: effectiveTimedOut,
     }),
   });
   if (trajectoryRecorder && !resourceState.trajectoryEndRecorded) {
     trajectoryRecorder.recordEvent("session.ended", {
       status:
-        state.timedOut || (runAbortController.signal.aborted && !state.clientClosedAbort)
+        effectiveTimedOut || (runAbortController.signal.aborted && !state.clientClosedAbort)
           ? "interrupted"
           : "cleanup",
       threadId: resourceState.thread.threadId,
       turnId: activeTurnId,
-      timedOut: state.timedOut,
+      timedOut: effectiveTimedOut,
       aborted: runAbortController.signal.aborted && !state.clientClosedAbort,
+      abortReason: normalizeCodexTrajectoryAbortReason(runAbortController.signal.reason),
     });
   }
   await runAgentCleanupStep({
@@ -74,7 +80,7 @@ export async function cleanupCodexAttempt(
     log: embeddedAgentLog,
     cleanup: async () => trajectoryRecorder?.flush(),
   });
-  if (!state.timedOut && !runAbortController.signal.aborted) {
+  if (!effectiveTimedOut && !runAbortController.signal.aborted) {
     await steeringQueueRef.current?.flushPending();
   }
   const retainLiveIncognitoThread =
@@ -87,7 +93,7 @@ export async function cleanupCodexAttempt(
         })
       : true;
   // Successful incognito turns retain the live subscription for cross-turn continuity.
-  if (!state.timedOut && !retainLiveIncognitoThread) {
+  if (!effectiveTimedOut && !retainLiveIncognitoThread) {
     // Clear first: if a newer owner won the binding, its live subscription must remain intact.
     if (bindingReleased) {
       await unsubscribeCodexThreadBestEffort(resourceState.client, {

--- a/extensions/codex/src/app-server/run-attempt-finalize.ts
+++ b/extensions/codex/src/app-server/run-attempt-finalize.ts
@@ -4,6 +4,7 @@ import {
   embeddedAgentLog,
   finalizeHarnessContextEngineTurn,
   formatErrorMessage,
+  resolveAgentRunAbortLifecycleFields,
   resolveContextEngineOwnerPluginId,
   runAgentHarnessLlmOutputHook,
   runHarnessContextEngineMaintenance,
@@ -37,7 +38,11 @@ import type { prepareCodexAttemptTurnRequest } from "./run-attempt-turn-request.
 import type { CodexAttemptTurnState } from "./run-attempt-turn-state.js";
 import { captureCodexSettledTurnFinalizationContext } from "./settled-turn-context.js";
 import { settleCodexSourceReplyFinality } from "./source-reply-finality.js";
-import { normalizeCodexTrajectoryError, recordCodexTrajectoryCompletion } from "./trajectory.js";
+import {
+  normalizeCodexTrajectoryAbortReason,
+  normalizeCodexTrajectoryError,
+  recordCodexTrajectoryCompletion,
+} from "./trajectory.js";
 import { codexTranscriptMirrorRuntime } from "./transcript-mirror.js";
 import {
   createCodexUsageLimitPromptError,
@@ -147,7 +152,10 @@ export async function finalizeCodexAttempt(
     yieldDetected: toolState.yieldDetected,
   });
   const projectedTerminal = attemptTerminal.project(result.terminal);
-  const effectiveTimedOut = state.timedOut && !recoveredTurnWatchTimeout;
+  const effectiveTimedOut =
+    (state.timedOut ||
+      resolveAgentRunAbortLifecycleFields(runAbortController.signal).stopReason === "timeout") &&
+    !recoveredTurnWatchTimeout;
   const effectiveTurnCompletionIdleTimedOut =
     state.turnCompletionIdleTimedOut && !recoveredTurnWatchTimeout;
   const isFinalAborted = () =>
@@ -475,15 +483,18 @@ export async function finalizeCodexAttempt(
     yieldDetected: toolState.yieldDetected,
   });
   trajectoryRecorder?.recordEvent("session.ended", {
-    status: finalPromptError
-      ? "error"
-      : finalAborted || effectiveTimedOut
-        ? "interrupted"
-        : "success",
+    status: effectiveTimedOut
+      ? "interrupted"
+      : finalPromptError
+        ? "error"
+        : finalAborted
+          ? "interrupted"
+          : "success",
     threadId: resourceState.thread.threadId,
     turnId: activeTurnId,
     timedOut: effectiveTimedOut,
     yieldDetected: toolState.yieldDetected,
+    abortReason: normalizeCodexTrajectoryAbortReason(runAbortController.signal.reason),
     promptError: normalizeCodexTrajectoryError(finalPromptError),
   });
   markTrajectoryEndRecorded();

--- a/extensions/codex/src/app-server/run-attempt-turn-start.ts
+++ b/extensions/codex/src/app-server/run-attempt-turn-start.ts
@@ -1,6 +1,7 @@
 import {
   embeddedAgentLog,
   formatErrorMessage,
+  resolveAgentRunAbortLifecycleFields,
   runAgentCleanupStep,
   runAgentHarnessLlmInputHook,
   runAgentHarnessLlmOutputHook,
@@ -28,6 +29,7 @@ import {
 } from "./run-attempt-state.js";
 import type { prepareCodexAttemptTurnRequest } from "./run-attempt-turn-request.js";
 import type { CodexAttemptTurnState } from "./run-attempt-turn-state.js";
+import { normalizeCodexTrajectoryAbortReason } from "./trajectory.js";
 import { buildCodexUserPromptMessage } from "./transcript-mirror.js";
 import {
   createCodexUsageLimitPromptError,
@@ -180,11 +182,15 @@ export async function startCodexAttemptTurn(
         stream: "codex_app_server.lifecycle",
         data: { phase: "turn_start_failed", error: message },
       });
+      const effectiveTimedOut =
+        state.timedOut ||
+        resolveAgentRunAbortLifecycleFields(runAbortController.signal).stopReason === "timeout";
       trajectoryRecorder?.recordEvent("session.ended", {
-        status: "error",
+        status: effectiveTimedOut ? "interrupted" : "error",
         threadId: resourceState.thread.threadId,
-        timedOut: state.timedOut,
+        timedOut: effectiveTimedOut,
         aborted: runAbortController.signal.aborted,
+        abortReason: normalizeCodexTrajectoryAbortReason(runAbortController.signal.reason),
         promptError: message,
       });
       markTrajectoryEndRecorded();

--- a/extensions/codex/src/app-server/run-attempt.turn-watches.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.turn-watches.test.ts
@@ -3676,29 +3676,52 @@ describe("runCodexAppServerAttempt turn watches", () => {
     const abortController = new AbortController();
     const onRunAgentEvent = vi.fn();
     const params = createTestParams();
+    const trajectoryEvents: Array<{ type: string; data?: Record<string, unknown> }> = [];
+    vi.stubEnv("OPENCLAW_TRAJECTORY", "1");
     params.abortSignal = abortController.signal;
     params.onAgentEvent = onRunAgentEvent;
+    Object.assign(params, {
+      trajectorySessionFile: `sqlite:main:${params.sessionId}:${path.join(tempDir, "openclaw-agent.sqlite")}`,
+      trajectoryRecorder: {
+        recordEvent: (type: string, data?: Record<string, unknown>) => {
+          trajectoryEvents.push({ type, data });
+        },
+        flush: async () => undefined,
+      },
+    });
     const run = runCodexAppServerAttempt(params, { turnTerminalIdleTimeoutMs: 60_000 });
 
     await harness.waitForMethod("turn/start");
-    const timeoutError = new Error("cron watchdog timeout");
-    timeoutError.name = "TimeoutError";
+    const timeoutError = Object.assign(new Error("Telegram ingress handler timed out"), {
+      name: "TimeoutError",
+      code: "telegram_spool_handler_timeout",
+    });
     abortController.abort(timeoutError);
     await harness.notify(turnCompleted({ id: "turn-1", status: "interrupted" }));
 
     const result = await run;
     expect(readAttemptTerminal(result).aborted).toBe(true);
-    expect(readAttemptTerminal(result).promptError).toBeNull();
+    expect(readAttemptTerminal(result).timedOut).toBe(true);
+    expect(readAttemptTerminal(result).promptError).toBe("codex app-server attempt timed out");
     expect(
       onRunAgentEvent.mock.calls
         .map(([event]) => event)
-        .find((event) => event.stream === "lifecycle" && event.data.phase === "end")?.data,
+        .find(
+          (event) =>
+            event.stream === "lifecycle" &&
+            (event.data.phase === "end" || event.data.phase === "error"),
+        )?.data,
     ).toMatchObject({
       aborted: true,
       status: "timed_out",
       stopReason: "timeout",
       timeoutPhase: "provider",
       providerStarted: true,
+    });
+    expect(trajectoryEvents.find((event) => event.type === "session.ended")?.data).toMatchObject({
+      status: "interrupted",
+      timedOut: true,
+      abortReason: "telegram_spool_handler_timeout",
     });
   });
 

--- a/extensions/codex/src/app-server/trajectory.test.ts
+++ b/extensions/codex/src/app-server/trajectory.test.ts
@@ -12,6 +12,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   type CodexHostTrajectoryRecorder,
   createCodexTrajectoryRecorder,
+  normalizeCodexTrajectoryAbortReason,
   recordCodexTrajectoryCompletion,
   recordCodexTrajectoryContext,
 } from "./trajectory.js";
@@ -115,6 +116,15 @@ function createSqliteHostTrajectoryRecorder(params: {
 }
 
 describe("Codex trajectory recorder", () => {
+  it("prefers a stable abort code over an Error name or message", () => {
+    const error = Object.assign(new Error("Telegram ingress handler timed out"), {
+      name: "TimeoutError",
+      code: "telegram_spool_handler_timeout",
+    });
+
+    expect(normalizeCodexTrajectoryAbortReason(error)).toBe("telegram_spool_handler_timeout");
+  });
+
   it("rejects file-backed trajectory targets without creating sidecars", () => {
     const tmpDir = makeTempDir();
     const warn = vi.fn();

--- a/extensions/codex/src/app-server/trajectory.ts
+++ b/extensions/codex/src/app-server/trajectory.ts
@@ -319,3 +319,18 @@ export function normalizeCodexTrajectoryError(value: unknown): string | null {
     return "Unknown error";
   }
 }
+
+/** Converts an AbortSignal reason into a stable trajectory classification. */
+export function normalizeCodexTrajectoryAbortReason(value: unknown): string | null {
+  if (!value) {
+    return null;
+  }
+  if (value instanceof Error) {
+    const code = "code" in value && typeof value.code === "string" ? value.code.trim() : "";
+    return code || value.name || value.message || "Error";
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+  return normalizeCodexTrajectoryError(value);
+}

--- a/extensions/telegram/src/telegram-ingress-drain.ts
+++ b/extensions/telegram/src/telegram-ingress-drain.ts
@@ -206,6 +206,7 @@ export function createTelegramIngressMonitor(params: CreateTelegramIngressMonito
       failedMaxEntries: TELEGRAM_SPOOLED_UPDATE_FAILED_MAX_ENTRIES,
     },
     drain: {
+      adoptionStallAbortReason: "telegram_spool_handler_timeout",
       adoptionStallTimeoutMs: params.adoptionStallTimeoutMs ?? DEFAULT_INGRESS_ADOPTION_STALL_MS,
       orderBy: "id",
       scanLimit: TELEGRAM_SPOOLED_DRAIN_SCAN_LIMIT,

--- a/src/agents/command/cli-compaction.test.ts
+++ b/src/agents/command/cli-compaction.test.ts
@@ -804,7 +804,7 @@ describe("runCliTurnCompactionLifecycle", () => {
     expect(recordCliCompactionInStore).not.toHaveBeenCalled();
   });
 
-  it("falls back to context-engine compaction when Codex owns automatic compaction", async () => {
+  it("does not invoke context-engine compaction when Codex owns automatic compaction", async () => {
     const sessionKey = "agent:main:codex-native-auto-compaction";
     const sessionId = "session-codex-native-auto-compaction";
     const sessionFile = path.join(tmpDir, "session-codex-native-auto-compaction.jsonl");
@@ -819,6 +819,7 @@ describe("runCliTurnCompactionLifecycle", () => {
       totalTokens: 950,
       totalTokensFresh: true,
       agentHarnessId: "codex",
+      authProfileOverride: "openai:oauth-test",
     };
     const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
     await persistSessionEntry({ sessionKey, storePath, entry: sessionEntry });
@@ -877,19 +878,10 @@ describe("runCliTurnCompactionLifecycle", () => {
     });
 
     expect(compactAgentHarnessSession).toHaveBeenCalledTimes(1);
-    expect(compactCalls).toHaveLength(1);
-    expect(compactCalls[0]?.sessionId).toBe(sessionId);
-    expect(compactCalls[0]?.sessionKey).toBe(sessionKey);
-    expect(compactCalls[0]?.currentTokenCount).toBe(950);
-    expect(maintenance).toHaveBeenCalledTimes(1);
-    expect(recordCliCompactionInStore).toHaveBeenCalledWith(
-      expect.objectContaining({
-        provider: "codex",
-        sessionKey,
-        tokensAfter: 100,
-      }),
-    );
-    expect(result?.compactionCount).toBe(1);
+    expect(compactCalls).toHaveLength(0);
+    expect(maintenance).not.toHaveBeenCalled();
+    expect(recordCliCompactionInStore).not.toHaveBeenCalled();
+    expect(result).toBe(sessionEntry);
 
     const lockedEntry: SessionEntry = { ...sessionEntry, modelSelectionLocked: true };
     sessionStore[sessionKey] = lockedEntry;
@@ -908,9 +900,9 @@ describe("runCliTurnCompactionLifecycle", () => {
     });
 
     expect(compactAgentHarnessSession).toHaveBeenCalledTimes(2);
-    expect(compactCalls).toHaveLength(1);
-    expect(maintenance).toHaveBeenCalledTimes(1);
-    expect(recordCliCompactionInStore).toHaveBeenCalledTimes(1);
+    expect(compactCalls).toHaveLength(0);
+    expect(maintenance).not.toHaveBeenCalled();
+    expect(recordCliCompactionInStore).not.toHaveBeenCalled();
     const lockedNativeCall = compactAgentHarnessSession.mock.calls[1]?.[0];
     expect(lockedNativeCall).toMatchObject({
       agentHarnessId: "codex",

--- a/src/agents/command/cli-compaction.ts
+++ b/src/agents/command/cli-compaction.ts
@@ -557,14 +557,10 @@ async function compactNativeHarnessCliTranscript(params: {
       return { compacted: false };
     }
     if (isIntentionalNativeAutoCompactionSkip(result)) {
-      if (params.sessionEntry.modelSelectionLocked === true) {
-        return { compacted: false };
-      }
-      return {
-        compacted: false,
-        fallbackToContextEngine: true,
-        failureReason: CODEX_APP_SERVER_OWNS_AUTO_COMPACTION_REASON,
-      };
+      log.info(
+        `CLI native harness compaction deferred to ${params.provider}/${params.model}: ${reason}`,
+      );
+      return { compacted: false };
     }
     const recoverableBindingFailure = isRecoverableNativeHarnessBindingFailure(result);
     const fallbackToContextEngine =

--- a/src/channels/message/ingress-drain.test.ts
+++ b/src/channels/message/ingress-drain.test.ts
@@ -327,11 +327,20 @@ describe("channel ingress drain", () => {
       });
       await queue.enqueue("evt-stall", { text: "x" }, { laneKey: "l1" });
 
+      let timeoutReason: unknown;
       const drain = createChannelIngressDrain<Payload>({
         queue,
         now: () => clock,
         adoptionStallTimeoutMs: 5_000,
-        dispatchClaimedEvent: async () => {
+        adoptionStallAbortReason: "telegram_spool_handler_timeout",
+        dispatchClaimedEvent: async (_event, lifecycle) => {
+          lifecycle.abortSignal.addEventListener(
+            "abort",
+            () => {
+              timeoutReason = lifecycle.abortSignal.reason;
+            },
+            { once: true },
+          );
           // Never adopt, never return — stall until watchdog.
           await new Promise(() => {});
         },
@@ -348,6 +357,10 @@ describe("channel ingress drain", () => {
       if (reenqueue.kind === "failed") {
         expect(reenqueue.record.reason).toBe("handler-timeout");
       }
+      expect(timeoutReason).toMatchObject({
+        name: "TimeoutError",
+        code: "telegram_spool_handler_timeout",
+      });
       drain.dispose();
     });
   });
@@ -419,8 +432,8 @@ describe("channel ingress drain", () => {
       await vi.waitFor(async () => {
         expect(await queue.listClaims()).toEqual([]);
       });
-      clock += 60_000;
-      await vi.advanceTimersByTimeAsync(60_000);
+      clock += 26 * 60_000;
+      await vi.advanceTimersByTimeAsync(26 * 60_000);
       // Still only completed — not failed by watchdog.
       const status = await queue.enqueue("evt-long", { text: "x" });
       expect(status.kind).toBe("completed");

--- a/src/channels/message/ingress-drain.ts
+++ b/src/channels/message/ingress-drain.ts
@@ -54,6 +54,17 @@ export function isIngressAdoptionLostError(error: unknown): error is IngressAdop
   return error instanceof IngressAdoptionLostError;
 }
 
+/** Typed abort reason for a claim that never reached durable adoption. */
+export class IngressHandlerTimeoutError extends Error {
+  readonly code: string;
+
+  constructor(message: string, code = "channel_ingress_handler_timeout") {
+    super(message);
+    this.name = "TimeoutError";
+    this.code = code;
+  }
+}
+
 /** Full pre-adoption → adoption ownership lifecycle for one claimed event. */
 type ChannelIngressDispatchLifecycle = {
   /** Pre-adoption only. After adopt the drain treats this signal as inert. */
@@ -112,6 +123,8 @@ export type CreateChannelIngressDrainOptions<
   deriveLaneKey?: (record: ChannelIngressQueueRecord<TPayload, TMetadata>) => string | undefined;
   ownerId?: string;
   adoptionStallTimeoutMs?: number;
+  /** Stable machine-readable abort reason for pre-adoption watchdog expiry. */
+  adoptionStallAbortReason?: string;
   claimLeaseMs?: number;
   retryPolicy?: IngressRetryPolicyConfig;
   now?: () => number;
@@ -473,7 +486,9 @@ export function createChannelIngressDrain<
       clearStallTimer(state);
       log(message);
       try {
-        state.abortController.abort(new Error(message));
+        state.abortController.abort(
+          new IngressHandlerTimeoutError(message, options.adoptionStallAbortReason),
+        );
       } catch {
         // AbortController.abort is not fallible in practice.
       }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a stalled Telegram durable-ingress handler could interrupt a healthy run with only an opaque `interrupted` outcome, leaving recovery unable to distinguish a timeout from another abort. OAuth-backed native Codex recovery could also fall back to legacy compaction after Codex had already claimed automatic compaction.

## Why This Change Was Made

The Telegram drain now supplies a stable timeout code, and the Codex app-server path carries that typed timeout through its lifecycle and trajectory terminal state. The native-compaction owner remains Codex instead of falling back to the legacy context engine.

## User Impact

Long Telegram turns remain outside the pre-adoption watchdog after durable adoption, while genuinely stalled ingress work is reported as a timed-out run with a machine-readable reason that automatic recovery can act on.

## Evidence

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.channels.config.ts src/channels/message/ingress-drain.test.ts` — 25 passing
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-codex-app-server-attempt-extra.config.ts extensions/codex/src/app-server/run-attempt.turn-watches.test.ts` — 94 passing
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.agents.config.ts src/agents/command/cli-compaction.test.ts` — 21 passing
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-codex.config.ts extensions/codex/src/app-server/trajectory.test.ts` — 9 passing
- Extension SDK boundary checks and durable recovery fixtures passed.

AI-assisted; reviewed against the Codex app-server protocol and its automatic-compaction implementation.