### PR TITLE
fix(scripts): run changed checks locally when Blacksmith never ran them

### DIFF
--- a/scripts/check-changed.d.mts
+++ b/scripts/check-changed.d.mts
@@ -38,6 +38,7 @@ export function shouldDelegateChangedCheckToCrabbox(
   options?: { cwd?: string; result?: ChangedLaneResult; diffRefsReady?: boolean },
 ): boolean;
 export function buildChangedCheckCrabboxArgs(argv?: string[], options?: { cwd?: string }): string[];
+export function delegationFailedBeforeRunning(output: string): boolean;
 export function shouldRunNpmLockGuard(paths: string[]): boolean;
 export function shouldRunPromptSnapshotCheck(paths: string[]): boolean;
 export function shouldRunPromptSnapshotOwnerTest(paths: string[]): boolean;

--- a/scripts/check-changed.mjs
+++ b/scripts/check-changed.mjs
@@ -354,13 +354,48 @@ export function createNpmLockGuardCommand(paths) {
   };
 }
 
+// Enough of the wrapper tail to hold its run summary; the rest is streamed, not kept.
+const DELEGATION_OUTPUT_TAIL_LIMIT = 64 * 1024;
+
+/**
+ * Whether a failed delegation means the remote never ran our command.
+ *
+ * The wrapper only emits a run summary once the command reached the box, so a
+ * failure carrying `command-exit` is a real check failure. Anything else — a
+ * lease, broker, DNS, or network error — never produced a verdict, which is the
+ * case AGENTS.md says falls back to local execution.
+ *
+ * This has to stay a positive test for `command-exit` rather than a blocklist of
+ * infrastructure errors: guessing wrong toward "infrastructure" only re-runs the
+ * checks locally, while guessing wrong toward "real failure" would block on an
+ * outage. Never widen it to fall back on any non-zero exit — some lanes (prompt
+ * snapshots) are Linux-only truth and would pass locally on macOS.
+ */
+export function delegationFailedBeforeRunning(output) {
+  return !/"errorKind"\s*:\s*"command-exit"/u.test(output);
+}
+
 async function runChangedCheckViaCrabbox(argv = [], env = process.env) {
   console.error("[check:changed] delegating to Blacksmith Testbox via the Node wrapper.");
-  return await runManagedCommand({
+  let tail = "";
+  const exitCode = await runManagedCommand({
     bin: "node",
     args: buildChangedCheckCrabboxArgs(argv),
     env,
+    stdio: ["inherit", "pipe", "pipe"],
+    onReady: (child) => {
+      for (const stream of [child.stdout, child.stderr]) {
+        stream?.on("data", (chunk) => {
+          process.stderr.write(chunk);
+          tail = (tail + chunk).slice(-DELEGATION_OUTPUT_TAIL_LIMIT);
+        });
+      }
+    },
   });
+  return {
+    exitCode,
+    backendUnavailable: exitCode !== 0 && delegationFailedBeforeRunning(tail),
+  };
 }
 
 export function createChangedCheckPlan(result, options = {}) {
@@ -1006,7 +1041,13 @@ if (isDirectRun()) {
       if (!shouldDelegateChangedCheckToCrabbox(argv, process.env)) {
         throw error;
       }
-      process.exitCode = await runChangedCheckViaCrabbox(argv, process.env);
+      // No local fallback here: this path exists because the checkout cannot
+      // resolve the diff refs itself, so there is nothing local to run.
+      const delegated = await runChangedCheckViaCrabbox(argv, process.env);
+      if (delegated.backendUnavailable) {
+        throw error;
+      }
+      process.exitCode = delegated.exitCode;
     }
     if (paths) {
       const result = detectChangedLanesForPaths({
@@ -1028,7 +1069,20 @@ if (isDirectRun()) {
             : undefined,
         })
       ) {
-        process.exitCode = await runChangedCheckViaCrabbox(argv, process.env);
+        const delegated = await runChangedCheckViaCrabbox(argv, process.env);
+        if (delegated.backendUnavailable) {
+          // Say this loudly: the proof below is local, so whoever reads the run
+          // knows which machine produced it and that Linux-only lanes are unproven.
+          console.error(
+            "[check:changed] Blacksmith never ran the checks (no run summary). Falling back to local execution; note this in the proof summary.",
+          );
+        }
+        process.exitCode = delegated.backendUnavailable
+          ? await runChangedCheck(result, {
+              ...args,
+              explicitPaths: args.paths.length > 0,
+            })
+          : delegated.exitCode;
       } else {
         process.exitCode = await runChangedCheck(result, {
           ...args,

--- a/scripts/check-changed.mjs
+++ b/scripts/check-changed.mjs
@@ -358,21 +358,34 @@ export function createNpmLockGuardCommand(paths) {
 const DELEGATION_OUTPUT_TAIL_LIMIT = 64 * 1024;
 
 /**
- * Whether a failed delegation means the remote never ran our command.
+ * Signatures of a failure that happened before the remote command was dispatched:
+ * the broker or its API was unreachable, or no lease was ever obtained.
+ */
+const BACKEND_UNAVAILABLE_SIGNATURES = [
+  /request failed: \w+ "https?:\/\/[^"]*blacksmith[^"]*"/iu,
+  /context deadline exceeded/iu,
+  /(?:no such host|dial tcp|connection refused|network is unreachable)/iu,
+  /failed to (?:acquire|create|warm|start)\b[^\n]*\b(?:lease|testbox)/iu,
+];
+
+/**
+ * Whether a failed delegation provably never ran our command.
  *
- * The wrapper only emits a run summary once the command reached the box, so a
- * failure carrying `command-exit` is a real check failure. Anything else — a
- * lease, broker, DNS, or network error — never produced a verdict, which is the
- * case AGENTS.md says falls back to local execution.
+ * Fails closed on purpose. A missing final summary alone cannot prove the remote
+ * never started — a wrapper that crashes or loses its output transport after
+ * dispatch looks identical — so this requires a positive pre-dispatch signature
+ * and treats everything else as a real failure. Getting this backwards is the
+ * dangerous direction: some lanes (prompt snapshots) are Linux-only truth, so a
+ * local rerun on macOS could turn an unknown or failing gate green.
  *
- * This has to stay a positive test for `command-exit` rather than a blocklist of
- * infrastructure errors: guessing wrong toward "infrastructure" only re-runs the
- * checks locally, while guessing wrong toward "real failure" would block on an
- * outage. Never widen it to fall back on any non-zero exit — some lanes (prompt
- * snapshots) are Linux-only truth and would pass locally on macOS.
+ * `command-exit` vetoes regardless: it only appears once the command reached the
+ * box, so it is proof a verdict exists and must be propagated as-is.
  */
 export function delegationFailedBeforeRunning(output) {
-  return !/"errorKind"\s*:\s*"command-exit"/u.test(output);
+  if (/"errorKind"\s*:\s*"command-exit"/u.test(output)) {
+    return false;
+  }
+  return BACKEND_UNAVAILABLE_SIGNATURES.some((signature) => signature.test(output));
 }
 
 async function runChangedCheckViaCrabbox(argv = [], env = process.env) {
@@ -386,8 +399,14 @@ async function runChangedCheckViaCrabbox(argv = [], env = process.env) {
     onReady: (child) => {
       for (const stream of [child.stdout, child.stderr]) {
         stream?.on("data", (chunk) => {
-          process.stderr.write(chunk);
           tail = (tail + chunk).slice(-DELEGATION_OUTPUT_TAIL_LIMIT);
+          // Inherited stdio used to get OS backpressure for free. Piping means we
+          // have to reapply it, or a verbose delegated run buffers its whole
+          // output in this process when stderr is an async pipe (typical in CI).
+          if (!process.stderr.write(chunk)) {
+            stream.pause();
+            process.stderr.once("drain", () => stream.resume());
+          }
         });
       }
     },

--- a/test/scripts/changed-lanes.test.ts
+++ b/test/scripts/changed-lanes.test.ts
@@ -2109,9 +2109,27 @@ describe("delegationFailedBeforeRunning", () => {
   });
 
   it("does not mistake an infrastructure error kind for a command verdict", () => {
-    const output =
-      '{"provider":"blacksmith-testbox","runStatus":"failed","errorKind":"lease-timeout","exitCode":1}';
+    const output = [
+      "failed to acquire lease for testbox",
+      '{"provider":"blacksmith-testbox","runStatus":"failed","errorKind":"lease-timeout","exitCode":1}',
+    ].join("\n");
 
     expect(delegationFailedBeforeRunning(output)).toBe(true);
+  });
+
+  // A crash after dispatch produces no summary either, so absence of one cannot
+  // be read as "never ran" — that is how an unknown Linux result would go green.
+  it("fails closed when the wrapper dies without saying why", () => {
+    expect(delegationFailedBeforeRunning("node: killed\n")).toBe(false);
+    expect(delegationFailedBeforeRunning("")).toBe(false);
+  });
+
+  it("keeps a command verdict authoritative even alongside network noise", () => {
+    const output = [
+      'request failed: Get "https://backend.blacksmith.sh/api/testbox/list": context deadline exceeded',
+      '{"provider":"blacksmith-testbox","runStatus":"failed","errorKind":"command-exit","exitCode":1}',
+    ].join("\n");
+
+    expect(delegationFailedBeforeRunning(output)).toBe(false);
   });
 });

--- a/test/scripts/changed-lanes.test.ts
+++ b/test/scripts/changed-lanes.test.ts
@@ -38,6 +38,7 @@ import {
   shouldRunSqliteSessionSchemaBaselineCheck,
   shouldRunTestTempCreationReport,
   createNpmLockGuardCommand,
+  delegationFailedBeforeRunning,
 } from "../../scripts/check-changed.mjs";
 import { resolveOxfmtInvocation } from "../../scripts/format-docs.mjs";
 import { isDirectRunPath } from "../../scripts/lib/direct-run.mjs";
@@ -2081,5 +2082,36 @@ describe("scripts/changed-lanes", () => {
       },
       { name: "package patch guard", args: ["deps:patches:check"] },
     ]);
+  });
+});
+
+describe("delegationFailedBeforeRunning", () => {
+  // The wrapper only prints a run summary once the command reached the box, so
+  // the summary is the evidence that a verdict exists at all.
+  it("treats a lease or network failure as never having run", () => {
+    const output = [
+      'request failed: Get "https://backend.blacksmith.sh/api/testbox/list?all=true": context deadline exceeded',
+      "blacksmith testbox run exited 1",
+    ].join("\n");
+
+    expect(delegationFailedBeforeRunning(output)).toBe(true);
+  });
+
+  it("treats a reported command exit as a real check failure", () => {
+    const output = [
+      "  64.95s  failed:1   typecheck core tests",
+      '{"provider":"blacksmith-testbox","runStatus":"failed","errorKind":"command-exit","exitCode":1}',
+    ].join("\n");
+
+    // Falling back locally here would re-run on macOS and could pass a lane
+    // whose truth is Linux, turning a red gate green.
+    expect(delegationFailedBeforeRunning(output)).toBe(false);
+  });
+
+  it("does not mistake an infrastructure error kind for a command verdict", () => {
+    const output =
+      '{"provider":"blacksmith-testbox","runStatus":"failed","errorKind":"lease-timeout","exitCode":1}';
+
+    expect(delegationFailedBeforeRunning(output)).toBe(true);
   });
 });


### PR DESCRIPTION
## What Problem This Solves

`AGENTS.md` already states that trusted-source work falls back to local execution when the remote backend is unavailable, but the tooling never implemented it. A lease, broker, DNS, or network failure surfaced as a plain `exit 1`, so `check:changed` reported the lanes red without ever having evaluated them.

That is worse than slow. During this session a Blacksmith outage (`context deadline exceeded` on `testbox/list`) meant the lint and dead-export gates silently never ran on a branch — the failures only appeared later on hosted CI, after the PR was open. A run that never happened looked exactly like a run that failed.

## Why This Change Was Made

The wrapper's run summary is the discriminator: it only appears once the command actually reached the box.

The classifier is deliberately **fail-closed**. A missing summary alone cannot prove the remote never started — a wrapper that crashes or loses its output transport after dispatch produces no summary either — so this requires a *positive* pre-dispatch signature (broker/API unreachable, DNS, or lease acquisition failure) and treats everything else as a real failure. A summary carrying `command-exit` vetoes regardless, since it is proof a verdict exists.

Getting this backwards is the dangerous direction. Guessing "infrastructure" when it was a real failure only re-runs the checks locally; guessing "real failure" during an outage merely blocks. But widening it to "fall back on any non-zero exit" would be unsafe: prompt snapshots are Linux-only truth (`AGENTS.md`: "CI truth is Linux Node 24"), so a local rerun on macOS could turn an unknown or failing gate green. There is a regression test for exactly that.

The sparse-checkout path keeps no fallback: it exists precisely because the checkout cannot resolve the diff refs, so there is nothing local to run.

Teeing the output also meant reapplying backpressure by hand — inherited stdio got it from the OS, piping does not, so a verbose delegated run would otherwise buffer its entire output in the parent process when stderr is an async pipe.

## User Impact

Maintainers running `pnpm check:changed` during a Blacksmith outage now get their checks run locally with a loud note, instead of an exit 1 that reads as "your code is broken". The note matters: the proof summary has to record which machine produced the result, because Linux-only lanes are unproven locally.

No behavior change when the remote is healthy.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/changed-lanes.test.ts` — 115 passed, including 5 new cases covering the observed outage output, a real `command-exit` verdict, an infrastructure error kind, a wrapper that dies without explanation, and a verdict that must stay authoritative alongside network noise.
- `node scripts/run-tsgo.mjs -p tsconfig.scripts.json` and `-p test/tsconfig/tsconfig.test.root.json` — clean.
- `node scripts/check-script-declarations.mjs` — 242 declaration contracts match (the new export has its `.d.mts` declaration).
- `$autoreview` raised both a P1 (the original classifier was an absence test, which could not distinguish a post-dispatch crash) and a P2 (missing backpressure); both are fixed in the second commit and are why the classifier is shaped the way it is.
