### PR TITLE
fix(auth): complete profile migration when main already owns an OAuth credential

### DIFF
--- a/src/agents/auth-profiles/store.ts
+++ b/src/agents/auth-profiles/store.ts
@@ -236,7 +236,13 @@ function resolvePersistedLoadOptions(
   };
 }
 
-function isInheritedMainOAuthCredential(params: {
+/**
+ * A non-main agent store deliberately does not persist an OAuth credential the
+ * main store already owns at the same or newer expiry. Callers that verify a
+ * write must treat such a profile as intentionally deduped rather than lost,
+ * otherwise the credential looks like it vanished during the write.
+ */
+export function isInheritedMainOAuthCredential(params: {
   agentDir?: string;
   profileId: string;
   credential: AuthProfileStore["profiles"][string];

--- a/src/commands/doctor-auth-flat-profiles.ts
+++ b/src/commands/doctor-auth-flat-profiles.ts
@@ -30,6 +30,7 @@ import {
 import { coerceAuthProfileState } from "../agents/auth-profiles/state.js";
 import {
   clearRuntimeAuthProfileStoreSnapshots,
+  isInheritedMainOAuthCredential,
   saveAuthProfileStore,
 } from "../agents/auth-profiles/store.js";
 import type {
@@ -1310,12 +1311,35 @@ export async function maybeMigrateAuthProfileJsonStoresToSqlite(params: {
               database,
             );
             const loaded = loadMigratedStore(candidate.agentDir, { database });
+            // A non-main store drops an OAuth credential the main store already
+            // owns at the same or newer expiry. That dedup is intentional, so
+            // verifying it as missing would abort a migration that lost nothing
+            // and leave the legacy JSON in place, which blocks gateway startup.
+            const dedupedToMainProfileIds = new Set(
+              [...importedProfileIds].filter((profileId) => {
+                const credential = next.profiles[profileId];
+                return (
+                  credential !== undefined &&
+                  !loaded?.profiles[profileId] &&
+                  isInheritedMainOAuthCredential({
+                    agentDir: candidate.agentDir,
+                    profileId,
+                    credential,
+                  })
+                );
+              }),
+            );
+            const verifiableProfileIds = new Set(
+              [...importedProfileIds].filter(
+                (profileId) => !dedupedToMainProfileIds.has(profileId),
+              ),
+            );
             const verificationFailure = formatMissingAuthProfileSqliteVerification({
               expected: next,
-              importedProfileIds,
+              importedProfileIds: verifiableProfileIds,
               loaded,
             });
-            const mismatchedCredential = [...importedProfileIds].some((profileId) => {
+            const mismatchedCredential = [...verifiableProfileIds].some((profileId) => {
               if (existingProfileIds.has(profileId)) {
                 return false;
               }

--- a/src/commands/doctor-auth-migration-inherited-oauth.test.ts
+++ b/src/commands/doctor-auth-migration-inherited-oauth.test.ts
@@ -1,0 +1,114 @@
+// Doctor auth tests cover migrating a non-main agent whose legacy JSON holds an
+// OAuth credential the main store already owns at a newer expiry.
+import fs from "node:fs";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { loadPersistedAuthProfileStore } from "../agents/auth-profiles/persisted.js";
+import {
+  clearRuntimeAuthProfileStoreSnapshots,
+  saveAuthProfileStore,
+} from "../agents/auth-profiles/store.js";
+import type { AuthProfileStore } from "../agents/auth-profiles/types.js";
+import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../test-utils/openclaw-test-state.js";
+import { maybeMigrateAuthProfileJsonStoresToSqlite } from "./doctor-auth-flat-profiles.js";
+import type { DoctorPrompter } from "./doctor-prompter.js";
+
+const states: OpenClawTestState[] = [];
+
+function makePrompter(): DoctorPrompter {
+  return {
+    confirm: vi.fn(async () => true),
+    confirmAutoFix: vi.fn(async () => true),
+    confirmAggressiveAutoFix: vi.fn(async () => true),
+    confirmRuntimeRepair: vi.fn(async () => true),
+    select: vi.fn(async (_params, fallback) => fallback),
+    shouldRepair: true,
+    shouldForce: false,
+    repairMode: { shouldRepair: true, shouldForce: false },
+  } as unknown as DoctorPrompter;
+}
+
+async function makeTestState(): Promise<OpenClawTestState> {
+  const state = await createOpenClawTestState();
+  states.push(state);
+  return state;
+}
+
+afterEach(async () => {
+  clearRuntimeAuthProfileStoreSnapshots();
+  closeOpenClawAgentDatabasesForTest();
+  closeOpenClawStateDatabaseForTest();
+  while (states.length > 0) {
+    await states.pop()?.cleanup();
+  }
+});
+
+describe("auth profile migration with an inherited main OAuth credential", () => {
+  it("completes and removes the legacy JSON instead of failing verification", async () => {
+    const state = await makeTestState();
+
+    // Main is already migrated and owns a live copy of the same profile id.
+    // This is the real shape: doctor migrates main successfully, then fails on
+    // the remaining agent, so main's SQLite store is already populated.
+    saveAuthProfileStore(
+      {
+        version: 1,
+        profiles: {
+          "openai:shared@example.test": {
+            type: "oauth",
+            provider: "openai",
+            access: "fake-main-access",
+            refresh: "fake-main-refresh",
+            expires: Date.parse("2027-01-01T00:00:00.000Z"),
+          },
+        },
+      } as AuthProfileStore,
+      state.agentDir(),
+      { syncExternalCli: false },
+    );
+
+    // A non-main agent holds an older copy of that same profile. The save path
+    // drops it as inherited from main, which previously read as data loss and
+    // aborted the migration, leaving this file on disk.
+    const secondaryAgentDir = state.agentDir("gadget");
+    const secondaryAuthPath = await state.writeText(
+      "agents/gadget/agent/auth-profiles.json",
+      `${JSON.stringify(
+        {
+          version: 1,
+          profiles: {
+            "openai:shared@example.test": {
+              type: "oauth",
+              provider: "openai",
+              access: "fake-stale-access",
+              refresh: "fake-stale-refresh",
+              expires: Date.parse("2026-06-20T00:00:00.000Z"),
+            },
+          },
+        },
+        null,
+        2,
+      )}\n`,
+    );
+
+    const result = await maybeMigrateAuthProfileJsonStoresToSqlite({
+      cfg: { agents: { list: [{ id: "gadget", agentDir: secondaryAgentDir }] } },
+      prompter: makePrompter(),
+      env: state.env,
+      now: () => Date.parse("2026-07-26T12:00:00.000Z"),
+    });
+
+    expect(result.warnings).toStrictEqual([]);
+    // The runtime refuses to start while a legacy credential file remains, so
+    // leaving this behind is what turned a failed verification into a boot loop.
+    expect(fs.existsSync(secondaryAuthPath)).toBe(false);
+    // Nothing is lost: main still owns the newer credential.
+    expect(
+      loadPersistedAuthProfileStore(state.agentDir())?.profiles["openai:shared@example.test"],
+    ).toMatchObject({ type: "oauth", access: "fake-main-access" });
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Upgrading an existing multi-agent install past the SQLite-only auth profile cutover (#114033) can leave the gateway unable to start, with remediation advice that points at the command which just failed.

Observed on a real gateway. `openclaw doctor --fix` migrated the `main` agent, then stopped on another agent:

```
Left auth profile JSON in place for .../agents/<agent>/agent/auth-profiles.json
because SQLite verification failed (imported profile(s): openai:<account>).
```

The gateway then refused to boot:

```
AuthProfileMigrationRequiredError: Auth profile store .../openclaw-agent.sqlite
requires legacy credential migration; run openclaw doctor --fix.
```

Re-running `doctor --fix` reproduced the same failure. That is a deadlock: `loadAuthProfileStoreForAgent` fails closed on the mere *presence* of a legacy credential file, doctor refuses to remove a file it could not import, and the printed remediation is the command that cannot succeed. Recovery required renaming the file by hand.

### Root cause

`shouldKeepProfileInLocalStore` (`src/agents/auth-profiles/store.ts`) deliberately does not persist an OAuth credential into a non-main agent store when the main store already owns the same profile id at an equal or newer expiry — `isInheritedMainOAuthCredential`. That dedup is correct and predates this change.

The migration then verified its own write by reloading the store and comparing **every** imported profile id. The deduped credential is legitimately absent from the reload, so verification read it as data loss, threw `AuthProfileMigrationVerificationError`, and aborted a migration that had in fact lost nothing.

The trigger is cross-agent duplication, not expiry on its own: expiry only decides which copy wins. Any non-main agent holding a copy of a profile `main` also owns will hit this.

## Why This Change Was Made

Verification now excludes profiles the local store intentionally deduped to main, using the same `isInheritedMainOAuthCredential` predicate that dropped them, so the two cannot drift. Everything else still verifies exactly as before — a genuinely missing or altered credential still aborts the migration.

The alternative — making `filterExternalAuthProfiles: false` also override the inherited-main drop — was rejected. That flag is about external CLI profiles, and widening it would push duplicate credential copies into every agent store, defeating the dedup this behavior exists to provide.

## User Impact

An existing multi-agent install upgrades cleanly instead of dropping into a boot loop that only a manual file rename escapes. No credential is created, moved, or removed that was not already being deduped; main keeps owning the newer copy, exactly as before.

## Evidence

**Regression test** — `src/commands/doctor-auth-migration-inherited-oauth.test.ts` reconstructs the observed shape: `main` already migrated and holding the profile at a later expiry, a second agent still holding an older copy in legacy JSON. It asserts the migration completes, the legacy file is removed, and main's credential is intact.

Verified as a real guard by reverting the fix — the test fails with the exact production message:

```
Left auth profile JSON in place for $OPENCLAW_HOME/.openclaw/agents/gadget/agent/auth-profiles.json
because SQLite verification failed (imported profile(s): openai:shared@example.test).
```

An earlier version of this fixture migrated both agents in one pass and passed either way, because `main`'s SQLite is still empty when the second agent saves. Seeding `main` as already-migrated is what reproduces it — worth knowing for anyone extending these tests.

- `node scripts/run-vitest.mjs src/commands/doctor-auth src/agents/auth-profiles` — **436 passed** across 35 files
- `pnpm check:test-types` clean; `oxfmt` + `run-oxlint.mjs` clean; `git diff --check` clean
- `$autoreview` (Codex `gpt-5.6-sol`, high): clean, no accepted/actionable findings — "patch is correct (0.98)"

Non-test diff is +33/−3.

Related but distinct: #100067 reports the 2026.6.x auth-store migration *silently* stranding JSON profiles. This is a hard startup failure with a different cause, so it is not filed as a duplicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
