### PR TITLE
refactor(meetings): centralize talk-back readiness

### DIFF
--- a/extensions/google-meet/src/plugin-helpers.ts
+++ b/extensions/google-meet/src/plugin-helpers.ts
@@ -7,6 +7,7 @@ import {
   type GatewayRequestHandlerOptions,
 } from "openclaw/plugin-sdk/gateway-runtime";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
+import { MeetingPlatformAdapter } from "openclaw/plugin-sdk/meeting-runtime";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
@@ -47,10 +48,6 @@ export function normalizeMode(value: unknown): GoogleMeetMode | undefined {
     return "agent";
   }
   return value === "agent" || value === "bidi" || value === "transcribe" ? value : undefined;
-}
-
-function isGoogleMeetTalkBackMode(mode: GoogleMeetMode): boolean {
-  return mode === "agent" || mode === "bidi";
 }
 
 export function resolveMeetingInput(config: GoogleMeetConfig, value: unknown): string {
@@ -133,7 +130,7 @@ function isGoogleMeetAgentToolActionUnsupportedOnHost(params: {
     action === "test_speech"
       ? "agent"
       : (normalizeMode(params.raw.mode) ?? params.config.defaultMode);
-  return transport === "chrome" && isGoogleMeetTalkBackMode(mode);
+  return transport === "chrome" && MeetingPlatformAdapter.isTalkBackMode(mode);
 }
 
 export function assertGoogleMeetAgentToolActionSupported(params: {

--- a/extensions/google-meet/src/runtime-probes.ts
+++ b/extensions/google-meet/src/runtime-probes.ts
@@ -53,7 +53,7 @@ const probes = MeetingPlatformAdapter.createRuntimeProbes<
       (session.transport === "chrome" || session.transport === "chrome-node") &&
       session.chrome?.launched,
     ),
-  talkBackMode: (mode) => mode === "agent" || mode === "bidi",
+  talkBackMode: MeetingPlatformAdapter.isTalkBackMode,
   normalizeUrl: normalizeMeetUrl,
   resolveRequestMode: (mode) => (mode === "realtime" ? "agent" : mode),
   defaultTransport: (config) => config.defaultTransport,

--- a/extensions/google-meet/src/runtime.ts
+++ b/extensions/google-meet/src/runtime.ts
@@ -4,6 +4,7 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import {
   createMeetingSession,
+  MeetingPlatformAdapter,
   MeetingSessionRuntime,
   type MeetingSessionLeaveResult,
   type MeetingSessionRuntimeHandles,
@@ -41,10 +42,7 @@ import {
   recoverCurrentMeetTab,
   recoverCurrentMeetTabOnNode,
 } from "./transports/chrome.js";
-import {
-  GOOGLE_MEET_PLATFORM_ADAPTER,
-  isGoogleMeetTalkBackMode,
-} from "./transports/google-meet-platform-adapter.js";
+import { GOOGLE_MEET_PLATFORM_ADAPTER } from "./transports/google-meet-platform-adapter.js";
 import type {
   GoogleMeetBrowserTab,
   GoogleMeetChromeHealth,
@@ -156,7 +154,7 @@ export class GoogleMeetRuntime {
       resolveSpeechInstructions: (request) =>
         request.message ?? params.config.realtime.introMessage,
       isBrowserTransport,
-      isTalkBackMode: isGoogleMeetTalkBackMode,
+      isTalkBackMode: (mode) => MeetingPlatformAdapter.isTalkBackMode(mode),
       isTranscribeMode: (mode) => mode === "transcribe",
       sameMeetingUrl: (left, right) => adapter.urls.isSameMeeting(left, right),
       normalizeMeetingUrlForReuse: (url) => adapter.urls.normalizeForReuse(url),
@@ -370,7 +368,7 @@ export class GoogleMeetRuntime {
           ? session.transport === "chrome-node"
             ? "Chrome node transport joins as the signed-in Google profile on the selected node and routes realtime audio through the node bridge."
             : "Chrome transport joins as the signed-in Google profile and routes realtime audio through the configured bridge."
-          : isGoogleMeetTalkBackMode(session.mode)
+          : MeetingPlatformAdapter.isTalkBackMode(session.mode)
             ? "Chrome transport joins as the signed-in Google profile and expects BlackHole 2ch audio routing."
             : "Chrome transport joins as the signed-in Google profile without starting the realtime audio bridge.",
       );
@@ -413,7 +411,7 @@ export class GoogleMeetRuntime {
           sessionKey: delegatedAgentId
             ? `agent:${delegatedAgentId}:google-meet:${session.id}`
             : `voice:google-meet:${session.id}`,
-          message: isGoogleMeetTalkBackMode(session.mode)
+          message: MeetingPlatformAdapter.isTalkBackMode(session.mode)
             ? (request.message ??
               this.params.config.voiceCall.introMessage ??
               this.params.config.realtime.introMessage)
@@ -471,7 +469,7 @@ export class GoogleMeetRuntime {
     session: GoogleMeetSession,
   ): Promise<MeetingSessionRuntimeHandles<GoogleMeetChromeHealth> | undefined> {
     if (
-      !isGoogleMeetTalkBackMode(session.mode) ||
+      !MeetingPlatformAdapter.isTalkBackMode(session.mode) ||
       !isBrowserTransport(session.transport) ||
       session.state !== "active" ||
       !session.chrome ||

--- a/extensions/google-meet/src/setup.ts
+++ b/extensions/google-meet/src/setup.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import {
   addMeetingSetupCheck,
   createMeetingSetupStatus,
+  MeetingPlatformAdapter,
   type MeetingSetupCheck,
   type MeetingSetupStatus,
 } from "openclaw/plugin-sdk/meeting-runtime";
@@ -113,7 +114,7 @@ export function getGoogleMeetSetupStatus(
   const mode = options?.mode ?? config.defaultMode;
   const transport = options?.transport ?? config.defaultTransport;
   const needsChromeRealtimeAudio =
-    (mode === "agent" || mode === "bidi") &&
+    MeetingPlatformAdapter.isTalkBackMode(mode) &&
     (transport === "chrome" || transport === "chrome-node");
   const pluginEntries = asRecord(asRecord(fullConfig.plugins).entries);
   const pluginAllow = asRecord(fullConfig.plugins).allow;

--- a/extensions/google-meet/src/transports/chrome.ts
+++ b/extensions/google-meet/src/transports/chrome.ts
@@ -9,6 +9,7 @@ import {
   readMeetingTranscriptWithBrowser,
   recoverMeetingBrowserTab,
   resolveLocalMeetingBrowserRequest,
+  MeetingPlatformAdapter,
   startMeetingAgentRealtimeEngine,
   startMeetingRealtimeEngine,
   type MeetingRealtimeAudioEngineHandle,
@@ -27,10 +28,7 @@ import {
   resolveChromeNode,
   type BrowserTab,
 } from "./chrome-browser-proxy.js";
-import {
-  GOOGLE_MEET_PLATFORM_ADAPTER,
-  isGoogleMeetTalkBackMode,
-} from "./google-meet-platform-adapter.js";
+import { GOOGLE_MEET_PLATFORM_ADAPTER } from "./google-meet-platform-adapter.js";
 import { GOOGLE_MEET_NODE_COMMAND } from "./google-meet-platform-constants.js";
 import type {
   GoogleMeetBrowserTab,
@@ -104,7 +102,7 @@ export async function launchChromeMeet(params: {
   tab?: GoogleMeetBrowserTab;
 }> {
   const checkRealtimeAudioPrerequisites = async () => {
-    if (!isGoogleMeetTalkBackMode(params.mode)) {
+    if (!MeetingPlatformAdapter.isTalkBackMode(params.mode)) {
       return;
     }
     await assertBlackHole2chAvailable({
@@ -130,7 +128,7 @@ export async function launchChromeMeet(params: {
     | ({ type: "command-pair" } & ChromeRealtimeAudioBridgeHandle)
     | undefined
   > => {
-    if (!isGoogleMeetTalkBackMode(params.mode)) {
+    if (!MeetingPlatformAdapter.isTalkBackMode(params.mode)) {
       return undefined;
     }
     if (params.config.chrome.audioBridgeCommand) {
@@ -224,7 +222,7 @@ export async function launchChromeMeet(params: {
     },
   });
   const shouldStartRealtimeBridge =
-    isGoogleMeetTalkBackMode(params.mode) &&
+    MeetingPlatformAdapter.isTalkBackMode(params.mode) &&
     result.browser?.inCall === true &&
     result.browser.micMuted === false &&
     result.browser.manualActionRequired !== true;
@@ -524,7 +522,7 @@ export async function launchChromeMeetOnNode(params: {
   // Browser-managed joins require explicit unmuted health before node audio starts.
   if (
     params.config.chrome.launch &&
-    isGoogleMeetTalkBackMode(params.mode) &&
+    MeetingPlatformAdapter.isTalkBackMode(params.mode) &&
     (browserControl.browser?.inCall !== true ||
       browserControl.browser.micMuted !== false ||
       browserControl.browser.manualActionRequired === true)

--- a/extensions/google-meet/src/transports/google-meet-platform-adapter.ts
+++ b/extensions/google-meet/src/transports/google-meet-platform-adapter.ts
@@ -42,10 +42,6 @@ type GoogleMeetDialInPlan = {
   dtmfSequence?: string;
 };
 
-export function isGoogleMeetTalkBackMode(mode: GoogleMeetMode): boolean {
-  return mode === "agent" || mode === "bidi";
-}
-
 function parsePermissionGrantNotes(result: unknown): string[] {
   const record = result && typeof result === "object" ? (result as Record<string, unknown>) : {};
   const unsupportedPermissions = Array.isArray(record.unsupportedPermissions)
@@ -133,10 +129,10 @@ export const GOOGLE_MEET_PLATFORM_ADAPTER = MeetingPlatformAdapter.create<
     },
   },
   browser: {
-    allowsMicrophone: isGoogleMeetTalkBackMode,
+    allowsMicrophone: MeetingPlatformAdapter.isTalkBackMode,
     buildStatusJoinScript: (params) =>
       meetStatusScript({
-        allowMicrophone: isGoogleMeetTalkBackMode(params.mode),
+        allowMicrophone: MeetingPlatformAdapter.isTalkBackMode(params.mode),
         autoJoin: params.autoJoin,
         captionSessionId: params.meetingSessionId || undefined,
         captureCaptions: params.captureCaptions,

--- a/extensions/teams-meetings/src/runtime-probes.ts
+++ b/extensions/teams-meetings/src/runtime-probes.ts
@@ -48,7 +48,7 @@ const probes = MeetingPlatformAdapter.createRuntimeProbes<
   invalidRequest: (message) => new Error(message),
   resolveTimeoutMs: resolveProbeTimeoutMs,
   shouldWaitForListening: (session) => Boolean(session.chrome?.launched),
-  talkBackMode: (mode) => mode === "agent" || mode === "bidi",
+  talkBackMode: MeetingPlatformAdapter.isTalkBackMode,
 });
 
 export const testTeamsMeetingListening: (

--- a/extensions/teams-meetings/src/runtime-setup.ts
+++ b/extensions/teams-meetings/src/runtime-setup.ts
@@ -3,6 +3,7 @@ import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import {
   addMeetingSetupCheck,
   createMeetingSetupStatus,
+  MeetingPlatformAdapter,
   resolveMeetingBrowserNodeInfo,
   type MeetingSetupStatus,
 } from "openclaw/plugin-sdk/meeting-runtime";
@@ -39,7 +40,7 @@ export async function getTeamsMeetingsSetupStatus(params: {
   const mode = params.options?.mode ?? params.config.defaultMode;
   const transport =
     params.options?.transport ?? (params.config.chromeNode.node ? "chrome-node" : "chrome");
-  const talkBack = mode === "agent" || mode === "bidi";
+  const talkBack = MeetingPlatformAdapter.isTalkBackMode(mode);
   let status = createMeetingSetupStatus([
     {
       id: "chrome-profile",

--- a/extensions/teams-meetings/src/runtime.ts
+++ b/extensions/teams-meetings/src/runtime.ts
@@ -3,6 +3,7 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import {
   createMeetingSession,
+  MeetingPlatformAdapter,
   MeetingSessionRuntime,
   type MeetingSessionRuntimeHandles,
   type MeetingSessionRuntimeJoinContext,
@@ -27,11 +28,7 @@ import {
   readTeamsMeetingTranscript,
   recoverCurrentTeamsMeetingTab,
 } from "./transports/chrome.js";
-import {
-  TEAMS_MEETINGS_PLATFORM_ADAPTER,
-  isTeamsMeetingsRealtimeRouteReady,
-  isTeamsMeetingsTalkBackMode,
-} from "./transports/teams-meetings-platform-adapter.js";
+import { TEAMS_MEETINGS_PLATFORM_ADAPTER } from "./transports/teams-meetings-platform-adapter.js";
 import type {
   TeamsMeetingsBrowserTab,
   TeamsMeetingsChromeHealth,
@@ -157,7 +154,7 @@ export class TeamsMeetingsRuntime {
       resolveSpeechInstructions: (request) =>
         request.message ?? params.config.realtime.introMessage,
       isBrowserTransport: () => true,
-      isTalkBackMode: isTeamsMeetingsTalkBackMode,
+      isTalkBackMode: (mode) => MeetingPlatformAdapter.isTalkBackMode(mode),
       isTranscribeMode: (mode) => mode === "transcribe",
       sameMeetingUrl: (left, right) =>
         TEAMS_MEETINGS_PLATFORM_ADAPTER.urls.isSameMeeting(left, right),
@@ -378,11 +375,11 @@ export class TeamsMeetingsRuntime {
     session: TeamsMeetingsSession,
   ): Promise<MeetingSessionRuntimeHandles<TeamsMeetingsChromeHealth> | undefined> {
     if (
-      !isTeamsMeetingsTalkBackMode(session.mode) ||
+      !MeetingPlatformAdapter.isTalkBackMode(session.mode) ||
       session.state !== "active" ||
       !session.chrome ||
       session.chrome.audioBridge ||
-      !isTeamsMeetingsRealtimeRouteReady(session.mode, session.chrome.health)
+      !MeetingPlatformAdapter.isRealtimeRouteReady(session.mode, session.chrome.health)
     ) {
       return undefined;
     }

--- a/extensions/teams-meetings/src/transports/chrome.ts
+++ b/extensions/teams-meetings/src/transports/chrome.ts
@@ -11,11 +11,7 @@ import {
   TEAMS_MEETINGS_SYSTEM_PROFILER_COMMAND,
   outputMentionsBlackHole2ch,
 } from "./chrome-audio-device.js";
-import {
-  TEAMS_MEETINGS_PLATFORM_ADAPTER,
-  isTeamsMeetingsRealtimeRouteReady,
-  isTeamsMeetingsTalkBackMode,
-} from "./teams-meetings-platform-adapter.js";
+import { TEAMS_MEETINGS_PLATFORM_ADAPTER } from "./teams-meetings-platform-adapter.js";
 import {
   TEAMS_MEETINGS_BROWSER_NODE_ADAPTER,
   TEAMS_MEETINGS_NODE_COMMAND,
@@ -29,8 +25,8 @@ const chromeTransport = MeetingPlatformAdapter.createChromeTransport<
   TeamsMeetingsTranscriptSnapshot
 >({
   browserNodeAdapter: TEAMS_MEETINGS_BROWSER_NODE_ADAPTER,
-  isRealtimeRouteReady: isTeamsMeetingsRealtimeRouteReady,
-  isTalkBackMode: isTeamsMeetingsTalkBackMode,
+  isRealtimeRouteReady: MeetingPlatformAdapter.isRealtimeRouteReady,
+  isTalkBackMode: MeetingPlatformAdapter.isTalkBackMode,
   meetingLabel: "Microsoft Teams meeting",
   nodeCommandName: TEAMS_MEETINGS_NODE_COMMAND,
   outputMentionsAudioDevice: outputMentionsBlackHole2ch,

--- a/extensions/teams-meetings/src/transports/teams-meetings-platform-adapter.test.ts
+++ b/extensions/teams-meetings/src/transports/teams-meetings-platform-adapter.test.ts
@@ -1,8 +1,6 @@
+import { MeetingPlatformAdapter } from "openclaw/plugin-sdk/meeting-runtime";
 import { describe, expect, it, vi } from "vitest";
-import {
-  TEAMS_MEETINGS_PLATFORM_ADAPTER,
-  isTeamsMeetingsRealtimeRouteReady,
-} from "./teams-meetings-platform-adapter.js";
+import { TEAMS_MEETINGS_PLATFORM_ADAPTER } from "./teams-meetings-platform-adapter.js";
 import {
   CONSUMER_URL,
   MEETING_STATE_KEY,
@@ -746,7 +744,7 @@ describe("Microsoft Teams meeting platform adapter", () => {
 
   it("requires positive input and output route evidence before realtime", () => {
     expect(
-      isTeamsMeetingsRealtimeRouteReady("agent", {
+      MeetingPlatformAdapter.isRealtimeRouteReady("agent", {
         audioInputRouted: true,
         audioOutputRouted: true,
         inCall: true,
@@ -758,10 +756,10 @@ describe("Microsoft Teams meeting platform adapter", () => {
       { audioInputRouted: true, inCall: true, micMuted: false },
       { audioInputRouted: true, audioOutputRouted: true, inCall: true },
     ]) {
-      expect(isTeamsMeetingsRealtimeRouteReady("agent", health)).toBe(false);
+      expect(MeetingPlatformAdapter.isRealtimeRouteReady("agent", health)).toBe(false);
     }
     expect(
-      isTeamsMeetingsRealtimeRouteReady("transcribe", {
+      MeetingPlatformAdapter.isRealtimeRouteReady("transcribe", {
         audioInputRouted: true,
         audioOutputRouted: true,
         inCall: true,

--- a/extensions/teams-meetings/src/transports/teams-meetings-platform-adapter.ts
+++ b/extensions/teams-meetings/src/transports/teams-meetings-platform-adapter.ts
@@ -29,24 +29,6 @@ function teamsMeetingOrigin(meetingUrl: string): string | undefined {
   }
 }
 
-export function isTeamsMeetingsTalkBackMode(mode: TeamsMeetingsMode): boolean {
-  return mode === "agent" || mode === "bidi";
-}
-
-export function isTeamsMeetingsRealtimeRouteReady(
-  mode: TeamsMeetingsMode,
-  health: TeamsMeetingsChromeHealth | undefined,
-): boolean {
-  return (
-    isTeamsMeetingsTalkBackMode(mode) &&
-    health?.inCall === true &&
-    health.micMuted === false &&
-    health.audioInputRouted === true &&
-    health.audioOutputRouted === true &&
-    health.manualActionRequired !== true
-  );
-}
-
 function classifyManualActionReason(reason: string): MeetingManualActionCategory {
   switch (reason) {
     case "teams-login-required":
@@ -110,10 +92,10 @@ export const TEAMS_MEETINGS_PLATFORM_ADAPTER = MeetingPlatformAdapter.create<
     localeAction: () => undefined,
   },
   browser: {
-    allowsMicrophone: isTeamsMeetingsTalkBackMode,
+    allowsMicrophone: MeetingPlatformAdapter.isTalkBackMode,
     buildStatusJoinScript: (params) =>
       teamsMeetingStatusScript({
-        allowMicrophone: isTeamsMeetingsTalkBackMode(params.mode),
+        allowMicrophone: MeetingPlatformAdapter.isTalkBackMode(params.mode),
         allowSessionAdoption: params.allowSessionAdoption,
         autoJoin: params.autoJoin,
         captureCaptions: params.captureCaptions,

--- a/extensions/zoom-meetings/src/runtime-probes.ts
+++ b/extensions/zoom-meetings/src/runtime-probes.ts
@@ -40,7 +40,7 @@ const probes = MeetingPlatformAdapter.createRuntimeProbes<
   invalidRequest: zoomMeetingsInvalidRequest,
   resolveTimeoutMs: resolveZoomMeetingsProbeTimeoutMs,
   shouldWaitForListening: (session) => Boolean(session.chrome?.browserTab?.targetId),
-  talkBackMode: (mode) => mode === "agent" || mode === "bidi",
+  talkBackMode: MeetingPlatformAdapter.isTalkBackMode,
 });
 
 export const testZoomMeetingListening: (

--- a/extensions/zoom-meetings/src/runtime-setup.ts
+++ b/extensions/zoom-meetings/src/runtime-setup.ts
@@ -3,6 +3,7 @@ import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import {
   addMeetingSetupCheck,
   createMeetingSetupStatus,
+  MeetingPlatformAdapter,
   resolveMeetingBrowserNodeInfo,
   type MeetingSetupStatus,
 } from "openclaw/plugin-sdk/meeting-runtime";
@@ -39,7 +40,7 @@ export async function getZoomMeetingsSetupStatus(params: {
   const mode = params.options?.mode ?? params.config.defaultMode;
   const transport =
     params.options?.transport ?? (params.config.chromeNode.node ? "chrome-node" : "chrome");
-  const talkBack = mode === "agent" || mode === "bidi";
+  const talkBack = MeetingPlatformAdapter.isTalkBackMode(mode);
   const guestJoinReady = Boolean(
     params.config.chrome.guestName &&
     params.config.chrome.autoJoin &&

--- a/extensions/zoom-meetings/src/runtime.ts
+++ b/extensions/zoom-meetings/src/runtime.ts
@@ -3,6 +3,7 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import {
   createMeetingSession,
+  MeetingPlatformAdapter,
   MeetingSessionRuntime,
   type MeetingSessionRuntimeHandles,
   type MeetingSessionRuntimeJoinContext,
@@ -34,11 +35,7 @@ import type {
   ZoomMeetingsJoinResult,
   ZoomMeetingsSession,
 } from "./transports/types.js";
-import {
-  ZOOM_MEETINGS_PLATFORM_ADAPTER,
-  isZoomMeetingsRealtimeRouteReady,
-  isZoomMeetingsTalkBackMode,
-} from "./transports/zoom-meetings-platform-adapter.js";
+import { ZOOM_MEETINGS_PLATFORM_ADAPTER } from "./transports/zoom-meetings-platform-adapter.js";
 import { hasSameZoomMeetingJoinCredential } from "./transports/zoom-meetings-urls.js";
 
 type ManualActionReason = NonNullable<ZoomMeetingsChromeHealth["manualActionReason"]>;
@@ -164,7 +161,7 @@ export class ZoomMeetingsRuntime {
       resolveSpeechInstructions: (request) =>
         request.message ?? params.config.realtime.introMessage,
       isBrowserTransport: () => true,
-      isTalkBackMode: isZoomMeetingsTalkBackMode,
+      isTalkBackMode: (mode) => MeetingPlatformAdapter.isTalkBackMode(mode),
       isTranscribeMode: (mode) => mode === "transcribe",
       sameMeetingUrl: (left, right) =>
         ZOOM_MEETINGS_PLATFORM_ADAPTER.urls.isSameMeeting(left, right),
@@ -439,11 +436,11 @@ export class ZoomMeetingsRuntime {
   ): Promise<MeetingSessionRuntimeHandles<ZoomMeetingsChromeHealth> | undefined> {
     const bridgeClosed = session.chrome?.health?.bridgeClosed === true;
     if (
-      !isZoomMeetingsTalkBackMode(session.mode) ||
+      !MeetingPlatformAdapter.isTalkBackMode(session.mode) ||
       session.state !== "active" ||
       !session.chrome ||
       (session.chrome.audioBridge && !bridgeClosed) ||
-      !isZoomMeetingsRealtimeRouteReady(session.mode, session.chrome.health)
+      !MeetingPlatformAdapter.isRealtimeRouteReady(session.mode, session.chrome.health)
     ) {
       return undefined;
     }

--- a/extensions/zoom-meetings/src/transports/chrome.ts
+++ b/extensions/zoom-meetings/src/transports/chrome.ts
@@ -12,11 +12,7 @@ import {
   outputMentionsBlackHole2ch,
 } from "./chrome-audio-device.js";
 import type { ZoomMeetingsChromeHealth, ZoomMeetingsTranscriptSnapshot } from "./types.js";
-import {
-  ZOOM_MEETINGS_PLATFORM_ADAPTER,
-  isZoomMeetingsRealtimeRouteReady,
-  isZoomMeetingsTalkBackMode,
-} from "./zoom-meetings-platform-adapter.js";
+import { ZOOM_MEETINGS_PLATFORM_ADAPTER } from "./zoom-meetings-platform-adapter.js";
 import {
   ZOOM_MEETINGS_BROWSER_NODE_ADAPTER,
   ZOOM_MEETINGS_NODE_COMMAND,
@@ -29,8 +25,8 @@ const chromeTransport = MeetingPlatformAdapter.createChromeTransport<
   ZoomMeetingsTranscriptSnapshot
 >({
   browserNodeAdapter: ZOOM_MEETINGS_BROWSER_NODE_ADAPTER,
-  isRealtimeRouteReady: isZoomMeetingsRealtimeRouteReady,
-  isTalkBackMode: isZoomMeetingsTalkBackMode,
+  isRealtimeRouteReady: MeetingPlatformAdapter.isRealtimeRouteReady,
+  isTalkBackMode: MeetingPlatformAdapter.isTalkBackMode,
   meetingLabel: "Zoom meeting",
   nodeCommandName: ZOOM_MEETINGS_NODE_COMMAND,
   outputMentionsAudioDevice: outputMentionsBlackHole2ch,

--- a/extensions/zoom-meetings/src/transports/zoom-meetings-platform-adapter.test.ts
+++ b/extensions/zoom-meetings/src/transports/zoom-meetings-platform-adapter.test.ts
@@ -1,10 +1,8 @@
 import { runInNewContext } from "node:vm";
+import { MeetingPlatformAdapter } from "openclaw/plugin-sdk/meeting-runtime";
 import { describe, expect, it, vi } from "vitest";
 import { zoomMeetingLeaveScript, zoomMeetingStatusScript } from "./zoom-meetings-page-scripts.js";
-import {
-  ZOOM_MEETINGS_PLATFORM_ADAPTER,
-  isZoomMeetingsRealtimeRouteReady,
-} from "./zoom-meetings-platform-adapter.js";
+import { ZOOM_MEETINGS_PLATFORM_ADAPTER } from "./zoom-meetings-platform-adapter.js";
 
 const URL = "https://acme.zoom.us/j/12345678901?pwd=abc";
 
@@ -239,7 +237,7 @@ describe("Zoom meeting platform adapter", () => {
 
   it("requires verified bidirectional audio before realtime startup", () => {
     expect(
-      isZoomMeetingsRealtimeRouteReady("agent", {
+      MeetingPlatformAdapter.isRealtimeRouteReady("agent", {
         inCall: true,
         micMuted: false,
         audioInputRouted: true,
@@ -247,7 +245,7 @@ describe("Zoom meeting platform adapter", () => {
       }),
     ).toBe(true);
     expect(
-      isZoomMeetingsRealtimeRouteReady("agent", {
+      MeetingPlatformAdapter.isRealtimeRouteReady("agent", {
         inCall: true,
         micMuted: true,
         audioInputRouted: true,

--- a/extensions/zoom-meetings/src/transports/zoom-meetings-platform-adapter.ts
+++ b/extensions/zoom-meetings/src/transports/zoom-meetings-platform-adapter.ts
@@ -22,24 +22,6 @@ function zoomMeetingOrigin(meetingUrl: string): string | undefined {
   return normalizeZoomMeetingUrlForReuse(meetingUrl) ? "https://app.zoom.us" : undefined;
 }
 
-export function isZoomMeetingsTalkBackMode(mode: ZoomMeetingsMode): boolean {
-  return mode === "agent" || mode === "bidi";
-}
-
-export function isZoomMeetingsRealtimeRouteReady(
-  mode: ZoomMeetingsMode,
-  health: ZoomMeetingsChromeHealth | undefined,
-): boolean {
-  return (
-    isZoomMeetingsTalkBackMode(mode) &&
-    health?.inCall === true &&
-    health.micMuted === false &&
-    health.audioInputRouted === true &&
-    health.audioOutputRouted === true &&
-    health.manualActionRequired !== true
-  );
-}
-
 function classifyManualActionReason(reason: string): MeetingManualActionCategory {
   switch (reason) {
     case "zoom-login-required":
@@ -105,10 +87,10 @@ export const ZOOM_MEETINGS_PLATFORM_ADAPTER = MeetingPlatformAdapter.create<
     localeAction: () => undefined,
   },
   browser: {
-    allowsMicrophone: isZoomMeetingsTalkBackMode,
+    allowsMicrophone: MeetingPlatformAdapter.isTalkBackMode,
     buildStatusJoinScript: (params) =>
       zoomMeetingStatusScript({
-        allowMicrophone: isZoomMeetingsTalkBackMode(params.mode),
+        allowMicrophone: MeetingPlatformAdapter.isTalkBackMode(params.mode),
         allowSessionAdoption: params.allowSessionAdoption,
         autoJoin: params.autoJoin,
         captureCaptions: params.captureCaptions,

--- a/src/meeting-bot/platform-adapter.ts
+++ b/src/meeting-bot/platform-adapter.ts
@@ -361,6 +361,29 @@ function createMeetingPlatformAdapter<
   };
 }
 
+function isMeetingTalkBackMode(mode: string): boolean {
+  return mode === "agent" || mode === "bidi";
+}
+
+function isMeetingRealtimeRouteReady(
+  mode: string,
+  health:
+    | (MeetingBrowserHealth & {
+        audioInputRouted?: boolean;
+        audioOutputRouted?: boolean;
+      })
+    | undefined,
+): boolean {
+  return (
+    isMeetingTalkBackMode(mode) &&
+    health?.inCall === true &&
+    health.micMuted === false &&
+    health.audioInputRouted === true &&
+    health.audioOutputRouted === true &&
+    health.manualActionRequired !== true
+  );
+}
+
 export const MeetingPlatformAdapter = {
   create: createMeetingPlatformAdapter,
   createChromeTransport: createMeetingChromeTransport,
@@ -369,4 +392,6 @@ export const MeetingPlatformAdapter = {
   createPluginEntry: createMeetingPluginEntryOptions,
   createStatusCallSource: createMeetingStatusCallSource,
   createStatusPreludeSource: createMeetingStatusPreludeSource,
+  isRealtimeRouteReady: isMeetingRealtimeRouteReady,
+  isTalkBackMode: isMeetingTalkBackMode,
 };

--- a/src/meeting-bot/runtime-probes.test.ts
+++ b/src/meeting-bot/runtime-probes.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { MeetingPlatformAdapter } from "./platform-adapter.js";
 import { createMeetingRuntimeProbes } from "./runtime-probes.js";
 import type { MeetingBrowserHealth } from "./session-types.js";
 
@@ -66,7 +67,7 @@ describe.each(cases)("$name meeting runtime probe parity", (testCase) => {
       },
       resolveTimeoutMs: () => 5,
       shouldWaitForListening: testCase.shouldWaitForListening,
-      talkBackMode: (mode) => mode === "agent" || mode === "bidi",
+      talkBackMode: MeetingPlatformAdapter.isTalkBackMode,
     });
 
   it("preserves the platform invalid-request contract", async () => {


### PR DESCRIPTION
## What Problem This Solves

The Google Meet, Microsoft Teams, and Zoom meeting plugins independently decided which modes can talk back, while Teams and Zoom also duplicated the same realtime-route readiness predicate. That let one shared meeting invariant drift across setup, probes, transport startup, and runtime recovery.

## Why This Change Was Made

This maintainer-requested refactor moves both decisions into the shared `MeetingPlatformAdapter` owner and makes every current meeting-plugin caller consume that canonical policy. The predicates retain their existing conditions; this removes plugin-local copies without changing behavior.

AI-assisted implementation; reviewed against the full affected call graph and all three sibling plugins. Release-note context: no user-visible behavior change.

Maintainer proof decision: live meeting proof is explicitly waived for this behavior-neutral internal refactor. The predicates are moved without changing their conditions, focused tests exercise all three plugins, and exact-head CI covers the integrated tree; a real meeting run would not isolate the ownership-only change.

## User Impact

No user-visible behavior changes. Meeting talk-back eligibility and Teams/Zoom route readiness now have one implementation, reducing the chance that setup, probes, and runtime startup disagree in a future change.

## Evidence

- `node scripts/run-vitest.mjs src/meeting-bot extensions/google-meet extensions/teams-meetings extensions/zoom-meetings` — 61 files and 648 tests passed.
- Hosted targeted `run-oxlint.mjs` plus core and extension `run-tsgo.mjs` lanes — passed on Blacksmith Testbox `tbx_01kygkk1ckxddz7tyrtkxzds0y`.
- `git diff --check` — passed.
- `autoreview --mode uncommitted` and `autoreview --mode branch --base origin/main` — clean, no accepted/actionable findings.
- Production diff: +70/-103, net -33 lines.
