### PR TITLE
test(ai): freeze Responses stream processor parity

### DIFF
--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -14,6 +14,7 @@ import type {
   ResponseStreamEvent,
 } from "openai/resources/responses/responses.js";
 import { calculateCost, clampThinkingLevel } from "../model-utils.js";
+import type { OpenAIResponsesStreamEvent } from "../transports/openai-responses-stream-internal.js";
 import { transportAbortError } from "../transports/transport-stream-shared.js";
 import type {
   Api,
@@ -50,7 +51,6 @@ import {
   AZURE_RESPONSES_TEXT_CONTENT_PART_TYPE,
   OPENAI_RESPONSES_OUTPUT_TEXT_CONTENT_PART_TYPE,
   type AzureResponsesTextContentPart,
-  type AzureResponsesTextDeltaEvent,
   isAzureResponsesTextDeltaEvent,
   isResponsesTextContentPartType,
   resolveResponsesMessageSnapshotCollapse,
@@ -114,29 +114,8 @@ type ResponsesTextContentPart =
   | ResponseOutputMessage["content"][number]
   | AzureResponsesTextContentPart;
 type ResponsesStreamOutputMessage = Omit<ResponseOutputMessage, "content"> & {
-  content: ResponsesTextContentPart[];
+  content: ResponsesTextContentPart[] | null;
 };
-type ResponsesContentPartAddedEvent = Extract<
-  ResponseStreamEvent,
-  { type: "response.content_part.added" }
->;
-type ResponsesOutputItemDoneEvent = Extract<
-  ResponseStreamEvent,
-  { type: "response.output_item.done" }
->;
-type AzureResponsesContentPartAddedEvent = Omit<ResponsesContentPartAddedEvent, "part"> & {
-  part: AzureResponsesTextContentPart;
-};
-type AzureResponsesOutputItemDoneEvent = Omit<ResponsesOutputItemDoneEvent, "item"> & {
-  item: ResponsesStreamOutputMessage;
-};
-
-type OpenAIResponsesStreamEvent =
-  | ResponseStreamEvent
-  | AzureResponsesContentPartAddedEvent
-  | AzureResponsesOutputItemDoneEvent
-  | AzureResponsesTextDeltaEvent;
-
 function normalizeResponsesReasoningReplayItem(params: {
   item: ReplayableResponseReasoningItem;
   replayResponsesItemIds: boolean;

--- a/packages/ai/src/transports/openai-responses-stream-internal.ts
+++ b/packages/ai/src/transports/openai-responses-stream-internal.ts
@@ -1,7 +1,11 @@
 import { randomUUID } from "node:crypto";
 import type { Model } from "@openclaw/llm-core";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
-import type { ResponseCreateParamsStreaming } from "openai/resources/responses/responses.js";
+import type {
+  ResponseCreateParamsStreaming,
+  ResponseOutputMessage,
+  ResponseStreamEvent,
+} from "openai/resources/responses/responses.js";
 import {
   createResponsesToolCallTracker,
   isResponsesTextContentPartType,
@@ -31,6 +35,66 @@ import {
   throwIfModelStreamAborted,
   type MutableAssistantOutput,
 } from "./openai-transport-shared.js";
+
+type ResponsesConsumedEventType =
+  | "error"
+  | "response.completed"
+  | "response.content_part.added"
+  | "response.created"
+  | "response.failed"
+  | "response.function_call_arguments.delta"
+  | "response.function_call_arguments.done"
+  | "response.incomplete"
+  | "response.output_item.added"
+  | "response.output_item.done"
+  | "response.output_text.delta"
+  | "response.reasoning_summary_part.added"
+  | "response.reasoning_summary_part.done"
+  | "response.reasoning_summary_text.delta"
+  | "response.reasoning_text.delta"
+  | "response.refusal.delta";
+
+type OpenAIResponsesConsumedEvent = Extract<
+  ResponseStreamEvent,
+  { type: ResponsesConsumedEventType }
+>;
+type OpenAIResponsesIgnoredSdkEvent = Exclude<ResponseStreamEvent, OpenAIResponsesConsumedEvent>;
+type ResponsesTextContentPart =
+  | ResponseOutputMessage["content"][number]
+  | {
+      type: "text";
+      text: string;
+    };
+type ResponsesStreamOutputMessage = Omit<ResponseOutputMessage, "content"> & {
+  content: ResponsesTextContentPart[] | null;
+};
+type ResponsesContentPartAddedEvent = Extract<
+  ResponseStreamEvent,
+  { type: "response.content_part.added" }
+>;
+type ResponsesOutputItemDoneEvent = Extract<
+  ResponseStreamEvent,
+  { type: "response.output_item.done" }
+>;
+
+/** Private structural event contract shared by Responses stream callers. */
+export type OpenAIResponsesStreamEvent =
+  | OpenAIResponsesConsumedEvent
+  | OpenAIResponsesIgnoredSdkEvent
+  | (Omit<ResponsesContentPartAddedEvent, "part"> & {
+      part: Extract<ResponsesTextContentPart, { type: "text" }>;
+    })
+  | (Omit<ResponsesOutputItemDoneEvent, "item"> & {
+      item: ResponsesStreamOutputMessage;
+    })
+  | {
+      type: "response.text.delta";
+      delta: string;
+      output_index?: number;
+      item_id?: string;
+      content_index?: number;
+      sequence_number?: number;
+    };
 
 export async function processResponsesStream(
   openaiStream: AsyncIterable<unknown>,
@@ -235,7 +299,7 @@ export async function processResponsesStream(
   const cooperativeScheduler = createModelStreamCooperativeScheduler(options?.signal);
   for await (const rawEvent of guardedStream) {
     throwIfModelStreamAborted(options?.signal);
-    const event = rawEvent as Record<string, unknown>;
+    const event = rawEvent as unknown as Record<string, unknown>;
     const type = stringifyUnknown(event.type);
     eventCount += 1;
     eventTypes.set(type, (eventTypes.get(type) ?? 0) + 1);

--- a/packages/ai/src/transports/openai-responses-stream-parity.test.ts
+++ b/packages/ai/src/transports/openai-responses-stream-parity.test.ts
@@ -1,0 +1,769 @@
+import type { AssistantMessage, AssistantMessageEvent, Model } from "@openclaw/llm-core";
+import { describe, expect, it } from "vitest";
+import { processResponsesStream as processProviderStream } from "../providers/openai-responses-shared.js";
+import { AssistantMessageEventStream } from "../utils/event-stream.js";
+import {
+  processResponsesStream as processTransportStream,
+  type OpenAIResponsesStreamEvent,
+} from "./openai-responses-stream-internal.js";
+
+type ProcessorName = "provider" | "transport";
+
+type ProjectedEvent = {
+  type: string;
+  contentIndex?: number;
+  delta?: string;
+  content?: string;
+};
+
+type ProjectedBlock =
+  | { type: "thinking"; thinking: string; encrypted: boolean }
+  | { type: "text"; text: string }
+  | {
+      type: "toolCall";
+      id: string;
+      name: string;
+      arguments: unknown;
+      partialJson: boolean;
+    };
+
+type ProcessResult = {
+  events: ProjectedEvent[];
+  content: ProjectedBlock[];
+  responseId: string | null;
+  stopReason: string;
+  error: string | null;
+};
+
+type ParityFixture = {
+  name: string;
+  events: Record<string, unknown>[];
+  canonical: ProcessResult;
+  knownDivergence?: Partial<Record<ProcessorName, string>>;
+};
+
+const model = {
+  id: "gpt-5.6-luna",
+  name: "GPT-5.6 Luna",
+  api: "openai-responses",
+  provider: "openai",
+  baseUrl: "https://api.openai.com/v1",
+  reasoning: true,
+  input: ["text"],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 200_000,
+  maxTokens: 8192,
+} satisfies Model<"openai-responses">;
+
+function createOutput(): AssistantMessage {
+  return {
+    role: "assistant",
+    content: [],
+    api: model.api,
+    provider: model.provider,
+    model: model.id,
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: "stop",
+    timestamp: 0,
+  };
+}
+
+async function* eventStream(
+  events: readonly Record<string, unknown>[],
+): AsyncGenerator<OpenAIResponsesStreamEvent> {
+  for (const event of events) {
+    yield event as OpenAIResponsesStreamEvent;
+  }
+}
+
+function projectEvent(event: AssistantMessageEvent): ProjectedEvent | undefined {
+  if (
+    event.type !== "thinking_start" &&
+    event.type !== "thinking_delta" &&
+    event.type !== "thinking_end" &&
+    event.type !== "text_start" &&
+    event.type !== "text_delta" &&
+    event.type !== "text_end" &&
+    event.type !== "toolcall_start" &&
+    event.type !== "toolcall_delta" &&
+    event.type !== "toolcall_end"
+  ) {
+    return undefined;
+  }
+  return {
+    type: event.type,
+    contentIndex: event.contentIndex,
+    ...(event.type === "thinking_delta" ||
+    event.type === "text_delta" ||
+    event.type === "toolcall_delta"
+      ? { delta: event.delta }
+      : {}),
+    ...(event.type === "thinking_end" || event.type === "text_end"
+      ? { content: event.content }
+      : {}),
+  };
+}
+
+function projectBlock(block: AssistantMessage["content"][number]): ProjectedBlock {
+  if (block.type === "thinking") {
+    let encrypted = false;
+    if (block.thinkingSignature) {
+      try {
+        const item = JSON.parse(block.thinkingSignature) as { encrypted_content?: unknown };
+        encrypted = typeof item.encrypted_content === "string" && item.encrypted_content.length > 0;
+      } catch {
+        encrypted = false;
+      }
+    }
+    return { type: "thinking", thinking: block.thinking, encrypted };
+  }
+  if (block.type === "text") {
+    return { type: "text", text: block.text };
+  }
+  const toolCall = block as typeof block & { partialJson?: string };
+  return {
+    type: "toolCall",
+    id: toolCall.id.replace(/^call_[a-f0-9]{24}/, "call_<generated>"),
+    name: toolCall.name,
+    arguments: toolCall.arguments,
+    partialJson: "partialJson" in toolCall,
+  };
+}
+
+async function runFixture(
+  processor: ProcessorName,
+  events: readonly Record<string, unknown>[],
+): Promise<ProcessResult> {
+  const output = createOutput();
+  const captured: AssistantMessageEvent[] = [];
+  let error: string | null = null;
+  try {
+    if (processor === "provider") {
+      const stream = new AssistantMessageEventStream();
+      const push = stream.push.bind(stream);
+      stream.push = (event) => {
+        captured.push(event);
+        push(event);
+      };
+      await processProviderStream(eventStream(events), output, stream, model);
+    } else {
+      await processTransportStream(
+        eventStream(events),
+        output as Parameters<typeof processTransportStream>[1],
+        { push: (event) => captured.push(event as AssistantMessageEvent) },
+        model,
+      );
+    }
+  } catch (cause) {
+    error = cause instanceof Error ? cause.message : String(cause);
+  }
+  return {
+    events: captured.map(projectEvent).filter((event) => event !== undefined),
+    content: output.content.map(projectBlock),
+    responseId: output.responseId ?? null,
+    stopReason: output.stopReason,
+    error,
+  };
+}
+
+const completed = (id: string, output: unknown[] = []) => ({
+  type: "response.completed",
+  sequence_number: 99,
+  response: { id, status: "completed", output },
+});
+
+const fixtures: ParityFixture[] = [
+  {
+    name: "indexed interleaved reasoning items",
+    events: [
+      {
+        type: "response.output_item.added",
+        output_index: 0,
+        item: { id: "rs_0", type: "reasoning", summary: [], content: [] },
+      },
+      {
+        type: "response.output_item.added",
+        output_index: 1,
+        item: { id: "rs_1", type: "reasoning", summary: [], content: [] },
+      },
+      { type: "response.reasoning_text.delta", output_index: 0, item_id: "rs_0", delta: "A" },
+      { type: "response.reasoning_text.delta", output_index: 1, item_id: "rs_1", delta: "B" },
+      {
+        type: "response.output_item.done",
+        output_index: 1,
+        item: { id: "rs_1", type: "reasoning", summary: [], content: [] },
+      },
+      {
+        type: "response.output_item.done",
+        output_index: 0,
+        item: { id: "rs_0", type: "reasoning", summary: [], content: [] },
+      },
+      completed("resp_interleaved"),
+    ],
+    canonical: {
+      events: [
+        { type: "thinking_start", contentIndex: 0 },
+        { type: "thinking_start", contentIndex: 1 },
+        { type: "thinking_delta", contentIndex: 0, delta: "A" },
+        { type: "thinking_delta", contentIndex: 1, delta: "B" },
+        { type: "thinking_end", contentIndex: 1, content: "B" },
+        { type: "thinking_end", contentIndex: 0, content: "A" },
+      ],
+      content: [
+        { type: "thinking", thinking: "A", encrypted: false },
+        { type: "thinking", thinking: "B", encrypted: false },
+      ],
+      responseId: "resp_interleaved",
+      stopReason: "stop",
+      error: null,
+    },
+    knownDivergence: {
+      transport: "the transport processor has only one current non-tool item",
+    },
+  },
+  {
+    name: "raw reasoning delta with empty summary",
+    events: [
+      {
+        type: "response.output_item.added",
+        output_index: 0,
+        item: { id: "rs_raw", type: "reasoning", summary: [], content: [] },
+      },
+      {
+        type: "response.reasoning_text.delta",
+        output_index: 0,
+        item_id: "rs_raw",
+        delta: "raw thought",
+      },
+      {
+        type: "response.output_item.done",
+        output_index: 0,
+        item: { id: "rs_raw", type: "reasoning", summary: [], content: [] },
+      },
+      completed("resp_raw"),
+    ],
+    canonical: {
+      events: [
+        { type: "thinking_start", contentIndex: 0 },
+        { type: "thinking_delta", contentIndex: 0, delta: "raw thought" },
+        { type: "thinking_end", contentIndex: 0, content: "raw thought" },
+      ],
+      content: [{ type: "thinking", thinking: "raw thought", encrypted: false }],
+      responseId: "resp_raw",
+      stopReason: "stop",
+      error: null,
+    },
+    knownDivergence: {
+      transport: "the transport processor ignores response.reasoning_text.delta",
+    },
+  },
+  {
+    name: "stream close without terminal response",
+    events: [
+      {
+        type: "response.output_item.done",
+        output_index: 0,
+        item: {
+          id: "msg_early",
+          type: "message",
+          role: "assistant",
+          status: "completed",
+          content: [{ type: "output_text", text: "early", annotations: [] }],
+        },
+      },
+    ],
+    canonical: {
+      events: [
+        { type: "text_start", contentIndex: 0 },
+        { type: "text_end", contentIndex: 0, content: "early" },
+      ],
+      content: [{ type: "text", text: "early" }],
+      responseId: null,
+      stopReason: "stop",
+      error: "OpenAI Responses stream ended before a terminal response event",
+    },
+    knownDivergence: { transport: "the transport processor silently accepts early close" },
+  },
+  {
+    name: "terminal encrypted reasoning backfill",
+    events: [
+      {
+        type: "response.output_item.added",
+        output_index: 0,
+        item: { id: "rs_backfill", type: "reasoning", summary: [], content: [] },
+      },
+      {
+        type: "response.output_item.done",
+        output_index: 0,
+        item: {
+          id: "rs_backfill",
+          type: "reasoning",
+          summary: [{ type: "summary_text", text: "thought" }],
+          content: [],
+        },
+      },
+      completed("resp_backfill", [
+        {
+          id: "rs_backfill",
+          type: "reasoning",
+          summary: [{ type: "summary_text", text: "thought" }],
+          content: [],
+          encrypted_content: "encrypted",
+        },
+      ]),
+    ],
+    canonical: {
+      events: [
+        { type: "thinking_start", contentIndex: 0 },
+        { type: "thinking_end", contentIndex: 0, content: "thought" },
+      ],
+      content: [{ type: "thinking", thinking: "thought", encrypted: true }],
+      responseId: "resp_backfill",
+      stopReason: "stop",
+      error: null,
+    },
+    knownDivergence: {
+      transport: "the transport processor does not backfill terminal encrypted reasoning",
+    },
+  },
+  {
+    name: "null completed message content preserves streamed text",
+    events: [
+      {
+        type: "response.output_item.added",
+        output_index: 0,
+        item: {
+          id: "msg_null",
+          type: "message",
+          role: "assistant",
+          status: "in_progress",
+          content: [],
+        },
+      },
+      {
+        type: "response.content_part.added",
+        output_index: 0,
+        item_id: "msg_null",
+        content_index: 0,
+        part: { type: "output_text", text: "", annotations: [] },
+      },
+      {
+        type: "response.output_text.delta",
+        output_index: 0,
+        item_id: "msg_null",
+        content_index: 0,
+        delta: "kept",
+      },
+      {
+        type: "response.output_item.done",
+        output_index: 0,
+        item: {
+          id: "msg_null",
+          type: "message",
+          role: "assistant",
+          status: "completed",
+          content: null,
+        },
+      },
+      completed("resp_null"),
+    ],
+    canonical: {
+      events: [
+        { type: "text_start", contentIndex: 0 },
+        { type: "text_delta", contentIndex: 0, delta: "kept" },
+        { type: "text_end", contentIndex: 0, content: "kept" },
+      ],
+      content: [{ type: "text", text: "kept" }],
+      responseId: "resp_null",
+      stopReason: "stop",
+      error: null,
+    },
+    knownDivergence: { transport: "the transport processor maps null content to empty text" },
+  },
+  {
+    name: "finalized tool call drops streaming scratch",
+    events: [
+      {
+        type: "response.output_item.added",
+        output_index: 0,
+        item: {
+          id: "fc_scratch",
+          call_id: "call_scratch",
+          type: "function_call",
+          name: "lookup",
+          arguments: "",
+          status: "in_progress",
+        },
+      },
+      {
+        type: "response.function_call_arguments.delta",
+        output_index: 0,
+        item_id: "fc_scratch",
+        delta: '{"q":"x"}',
+      },
+      {
+        type: "response.output_item.done",
+        output_index: 0,
+        item: {
+          id: "fc_scratch",
+          call_id: "call_scratch",
+          type: "function_call",
+          name: "lookup",
+          arguments: '{"q":"x"}',
+          status: "completed",
+        },
+      },
+      completed("resp_scratch"),
+    ],
+    canonical: {
+      events: [
+        { type: "toolcall_start", contentIndex: 0 },
+        { type: "toolcall_delta", contentIndex: 0, delta: '{"q":"x"}' },
+        { type: "toolcall_end", contentIndex: 0 },
+      ],
+      content: [
+        {
+          type: "toolCall",
+          id: "call_scratch|fc_scratch",
+          name: "lookup",
+          arguments: { q: "x" },
+          partialJson: false,
+        },
+      ],
+      responseId: "resp_scratch",
+      stopReason: "toolUse",
+      error: null,
+    },
+    knownDivergence: { transport: "the transport processor retains partialJson" },
+  },
+  {
+    name: "reused indexed output slot fails closed",
+    events: [
+      {
+        type: "response.output_item.added",
+        output_index: 0,
+        item: { id: "rs_first", type: "reasoning", summary: [], content: [] },
+      },
+      {
+        type: "response.output_item.added",
+        output_index: 0,
+        item: { id: "rs_second", type: "reasoning", summary: [], content: [] },
+      },
+      completed("resp_reused"),
+    ],
+    canonical: {
+      events: [{ type: "thinking_start", contentIndex: 0 }],
+      content: [
+        { type: "thinking", thinking: "", encrypted: false },
+        { type: "thinking", thinking: "", encrypted: false },
+      ],
+      responseId: null,
+      stopReason: "stop",
+      error: "Responses stream reused active output index 0",
+    },
+    knownDivergence: { transport: "the transport processor does not track non-tool indices" },
+  },
+  {
+    name: "normal output text lifecycle",
+    events: [
+      {
+        type: "response.output_item.added",
+        output_index: 0,
+        item: {
+          id: "msg_text",
+          type: "message",
+          role: "assistant",
+          status: "in_progress",
+          content: [],
+        },
+      },
+      {
+        type: "response.content_part.added",
+        output_index: 0,
+        item_id: "msg_text",
+        content_index: 0,
+        part: { type: "output_text", text: "", annotations: [] },
+      },
+      {
+        type: "response.output_text.delta",
+        output_index: 0,
+        item_id: "msg_text",
+        content_index: 0,
+        delta: "hello",
+      },
+      {
+        type: "response.output_item.done",
+        output_index: 0,
+        item: {
+          id: "msg_text",
+          type: "message",
+          role: "assistant",
+          status: "completed",
+          content: [{ type: "output_text", text: "hello", annotations: [] }],
+        },
+      },
+      completed("resp_text"),
+    ],
+    canonical: {
+      events: [
+        { type: "text_start", contentIndex: 0 },
+        { type: "text_delta", contentIndex: 0, delta: "hello" },
+        { type: "text_end", contentIndex: 0, content: "hello" },
+      ],
+      content: [{ type: "text", text: "hello" }],
+      responseId: "resp_text",
+      stopReason: "stop",
+      error: null,
+    },
+  },
+  {
+    name: "terminal-only completed message recovery",
+    events: [
+      completed("resp_terminal_text", [
+        {
+          id: "msg_terminal",
+          type: "message",
+          role: "assistant",
+          status: "completed",
+          content: [{ type: "output_text", text: "recovered", annotations: [] }],
+        },
+      ]),
+    ],
+    canonical: {
+      events: [
+        { type: "text_start", contentIndex: 0 },
+        { type: "text_end", contentIndex: 0, content: "recovered" },
+      ],
+      content: [{ type: "text", text: "recovered" }],
+      responseId: "resp_terminal_text",
+      stopReason: "stop",
+      error: null,
+    },
+    knownDivergence: { provider: "the provider processor lacks public terminal recovery" },
+  },
+  {
+    name: "output text delta without content part",
+    events: [
+      {
+        type: "response.output_item.added",
+        output_index: 0,
+        item: {
+          id: "msg_no_part",
+          type: "message",
+          role: "assistant",
+          status: "in_progress",
+          content: [],
+        },
+      },
+      {
+        type: "response.output_text.delta",
+        output_index: 0,
+        item_id: "msg_no_part",
+        content_index: 0,
+        delta: "compatible",
+      },
+      {
+        type: "response.output_item.done",
+        output_index: 0,
+        item: {
+          id: "msg_no_part",
+          type: "message",
+          role: "assistant",
+          status: "completed",
+          content: [{ type: "output_text", text: "compatible", annotations: [] }],
+        },
+      },
+      completed("resp_no_part"),
+    ],
+    canonical: {
+      events: [
+        { type: "text_start", contentIndex: 0 },
+        { type: "text_delta", contentIndex: 0, delta: "compatible" },
+        { type: "text_end", contentIndex: 0, content: "compatible" },
+      ],
+      content: [{ type: "text", text: "compatible" }],
+      responseId: "resp_no_part",
+      stopReason: "stop",
+      error: null,
+    },
+    knownDivergence: { provider: "the provider processor requires a content-part item" },
+  },
+  {
+    name: "detailed response failure is terminal",
+    events: [
+      {
+        type: "response.failed",
+        sequence_number: 1,
+        response: {
+          id: "resp_failed",
+          status: "failed",
+          error: { code: "invalid_prompt", message: "rejected" },
+        },
+      },
+    ],
+    canonical: {
+      events: [],
+      content: [],
+      responseId: "resp_failed",
+      stopReason: "stop",
+      error: "invalid_prompt: rejected",
+    },
+    knownDivergence: { provider: "the provider processor mutates output and returns" },
+  },
+];
+
+const legacyDivergentResults: Record<string, Partial<Record<ProcessorName, ProcessResult>>> = {
+  "indexed interleaved reasoning items": {
+    transport: {
+      events: [
+        { type: "thinking_start", contentIndex: 0 },
+        { type: "thinking_start", contentIndex: 1 },
+        { type: "thinking_end", contentIndex: 1, content: "" },
+      ],
+      content: [
+        { type: "thinking", thinking: "", encrypted: false },
+        { type: "thinking", thinking: "", encrypted: false },
+      ],
+      responseId: "resp_interleaved",
+      stopReason: "stop",
+      error: null,
+    },
+  },
+  "raw reasoning delta with empty summary": {
+    transport: {
+      events: [
+        { type: "thinking_start", contentIndex: 0 },
+        { type: "thinking_end", contentIndex: 0, content: "" },
+      ],
+      content: [{ type: "thinking", thinking: "", encrypted: false }],
+      responseId: "resp_raw",
+      stopReason: "stop",
+      error: null,
+    },
+  },
+  "stream close without terminal response": {
+    transport: {
+      events: [],
+      content: [],
+      responseId: null,
+      stopReason: "stop",
+      error: null,
+    },
+  },
+  "terminal encrypted reasoning backfill": {
+    transport: {
+      events: [
+        { type: "thinking_start", contentIndex: 0 },
+        { type: "thinking_end", contentIndex: 0, content: "thought" },
+      ],
+      content: [{ type: "thinking", thinking: "thought", encrypted: false }],
+      responseId: "resp_backfill",
+      stopReason: "stop",
+      error: null,
+    },
+  },
+  "null completed message content preserves streamed text": {
+    transport: {
+      events: [
+        { type: "text_start", contentIndex: 0 },
+        { type: "text_delta", contentIndex: 0, delta: "kept" },
+        { type: "text_end", contentIndex: 0, content: "" },
+      ],
+      content: [{ type: "text", text: "" }],
+      responseId: "resp_null",
+      stopReason: "stop",
+      error: null,
+    },
+  },
+  "finalized tool call drops streaming scratch": {
+    transport: {
+      events: [
+        { type: "toolcall_start", contentIndex: 0 },
+        { type: "toolcall_delta", contentIndex: 0, delta: '{"q":"x"}' },
+        { type: "toolcall_end", contentIndex: 0 },
+      ],
+      content: [
+        {
+          type: "toolCall",
+          id: "call_scratch|fc_scratch",
+          name: "lookup",
+          arguments: { q: "x" },
+          partialJson: true,
+        },
+      ],
+      responseId: "resp_scratch",
+      stopReason: "toolUse",
+      error: null,
+    },
+  },
+  "reused indexed output slot fails closed": {
+    transport: {
+      events: [
+        { type: "thinking_start", contentIndex: 0 },
+        { type: "thinking_start", contentIndex: 1 },
+      ],
+      content: [
+        { type: "thinking", thinking: "", encrypted: false },
+        { type: "thinking", thinking: "", encrypted: false },
+      ],
+      responseId: "resp_reused",
+      stopReason: "stop",
+      error: null,
+    },
+  },
+  "terminal-only completed message recovery": {
+    provider: {
+      events: [],
+      content: [],
+      responseId: "resp_terminal_text",
+      stopReason: "stop",
+      error: null,
+    },
+  },
+  "output text delta without content part": {
+    provider: {
+      events: [
+        { type: "text_start", contentIndex: 0 },
+        { type: "text_end", contentIndex: 0, content: "compatible" },
+      ],
+      content: [{ type: "text", text: "compatible" }],
+      responseId: "resp_no_part",
+      stopReason: "stop",
+      error: null,
+    },
+  },
+  "detailed response failure is terminal": {
+    provider: {
+      events: [],
+      content: [],
+      responseId: "resp_failed",
+      stopReason: "error",
+      error: null,
+    },
+  },
+};
+
+describe("Responses stream processor parity fixtures", () => {
+  it.each(fixtures)("$name", async (fixture) => {
+    for (const processor of ["provider", "transport"] as const) {
+      const result = await runFixture(processor, fixture.events);
+      const divergence = fixture.knownDivergence?.[processor];
+      if (divergence) {
+        const expected = legacyDivergentResults[fixture.name]?.[processor];
+        if (!expected) {
+          throw new Error(`Missing pinned ${processor} divergence for ${fixture.name}`);
+        }
+        expect(result, `${processor}: ${divergence}`).toEqual(expected);
+      } else {
+        expect(result, processor).toEqual(fixture.canonical);
+      }
+    }
+  });
+});

--- a/packages/ai/src/transports/openai-responses-stream-parity.test.ts
+++ b/packages/ai/src/transports/openai-responses-stream-parity.test.ts
@@ -156,7 +156,7 @@ async function runFixture(
     } else {
       await processTransportStream(
         eventStream(events),
-        output as Parameters<typeof processTransportStream>[1],
+        output as unknown as Parameters<typeof processTransportStream>[1],
         { push: (event) => captured.push(event as AssistantMessageEvent) },
         model,
       );


### PR DESCRIPTION
## What Problem This Solves

The two private OpenAI Responses stream processors currently disagree on indexed output routing, reasoning coverage, terminal validation and recovery, and streaming scratch cleanup. Consolidating them without first freezing those differences would make it easy to lose a supported provider behavior or silently preserve a known bug.

## Why This Change Was Made

This behavior-neutral first step defines one private structural event contract and a table-driven fixture matrix that runs through both existing processors. Canonical expectations and every known legacy divergence are pinned explicitly so the follow-up consolidation can delete one processor and prove each drift is resolved.

The event type remains private to the package internals and is not exported from any `@openclaw/ai` entrypoint. Runtime state transitions are unchanged in this PR.

AI-assisted: implemented and reviewed with Codex under maintainer direction.

## User Impact

No user-visible behavior changes. This adds regression coverage and a private type boundary for the canonical processor migration.

## Evidence

- `node scripts/run-vitest.mjs packages/ai/src/transports/openai-responses-stream-parity.test.ts` — 11 passed
- `node scripts/run-vitest.mjs packages/ai/src/providers/openai-responses-shared.test.ts` — 71 passed
- `node scripts/run-vitest.mjs src/agents/openai-transport-stream.base.test.ts src/agents/openai-transport-stream.streaming.test.ts src/agents/openai-transport-stream.incomplete-output.test.ts` — 93 passed
- `/Users/steipete/.claude/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — clean, no accepted/actionable findings
- `git diff --check origin/main...HEAD` — clean

The fixture names directly pin the seven approved drift repairs: indexed interleaving, raw reasoning deltas, missing terminal responses, terminal encrypted-reasoning backfill, null message snapshots, tool scratch cleanup, and reused indexed slots.

### ClawSweeper rank-up moves

The owning maintainer approved these seven classifications in the implementation batch before this PR was opened. Separate external runtime proof is intentionally deferred: this PR does not change runtime behavior, and its purpose is to execute both current processor implementations against the same structural events and record their existing differences. The follow-up canonical-processor PR carries the real behavior change and its hosted caller/build proof. For this behavior-neutral baseline, exact-head CI run 30231119987 is green, including build artifacts, production types, test types, lint, package boundaries, and all selected Node shards.
