### PR TITLE
refactor(agents): clarify provider request param classifier

### DIFF
--- a/src/agents/harness/support.ts
+++ b/src/agents/harness/support.ts
@@ -12,7 +12,7 @@ import type {
 } from "../../plugin-sdk/provider-model-types.js";
 import { resolveProviderModelRoutes } from "../../plugins/provider-model-routes.js";
 import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
-import { hasModelExtraParams } from "../model-extra-params.js";
+import { hasAuthoredProviderRequestParams } from "../model-extra-params.js";
 import { canonicalizeProviderModelId } from "../provider-model-route.js";
 import type { AgentRuntimeAuthPlan } from "../runtime-plan/types.js";
 import { resolveAgentHarnessAutoSelectionHint } from "./auto-selection.js";
@@ -96,7 +96,7 @@ export function buildAgentHarnessSupportContext(params: {
   const agentId =
     params.agentId ??
     (params.sessionKey ? resolveAgentIdFromSessionKey(params.sessionKey) : undefined);
-  const hasConfiguredParams = hasModelExtraParams({
+  const hasConfiguredProviderRequestParams = hasAuthoredProviderRequestParams({
     config: params.config,
     provider: params.provider,
     modelId: params.modelId,
@@ -122,11 +122,11 @@ export function buildAgentHarnessSupportContext(params: {
   const requestTransportOverrides: ProviderRouteOverridePresence =
     params.modelProvider?.requestTransportOverrides === "present" ||
     configuredModelProvider?.requestTransportOverrides === "present" ||
-    hasConfiguredParams
+    hasConfiguredProviderRequestParams
       ? "present"
       : "none";
   const modelProviderFacts =
-    params.modelProvider || configuredModelProvider || hasConfiguredParams
+    params.modelProvider || configuredModelProvider || hasConfiguredProviderRequestParams
       ? {
           api: params.modelProvider?.api ?? configuredModelProvider?.api,
           baseUrl: params.modelProvider?.baseUrl ?? configuredModelProvider?.baseUrl,

--- a/src/agents/model-extra-params.ts
+++ b/src/agents/model-extra-params.ts
@@ -68,7 +68,7 @@ export function resolveModelExtraParamSources(params: {
 }
 
 /** Returns whether embedded OpenClaw would apply authored provider request parameters. */
-export function hasModelExtraParams(
+export function hasAuthoredProviderRequestParams(
   params: Parameters<typeof resolveModelExtraParamSources>[0],
 ): boolean {
   const sources = resolveModelExtraParamSources(params);

--- a/src/agents/openai-routing.ts
+++ b/src/agents/openai-routing.ts
@@ -12,7 +12,7 @@ import {
   normalizeOptionalAgentRuntimeId,
   resolveAgentScopedRuntimeOverride,
 } from "./agent-runtime-id.js";
-import { hasModelExtraParams } from "./model-extra-params.js";
+import { hasAuthoredProviderRequestParams } from "./model-extra-params.js";
 import { resolveModelRuntimePolicy } from "./model-runtime-policy.js";
 import { resolveOpenAIModelRoutes } from "./openai-model-routes.js";
 import { canonicalizeProviderModelId } from "./provider-model-route.js";
@@ -53,14 +53,16 @@ export function resolveOpenAIImplicitAgentRuntime(params: {
   const agentId =
     params.agentId ??
     (params.sessionKey ? resolveAgentIdFromSessionKey(params.sessionKey) : undefined);
-  const hasConfiguredParams = hasModelExtraParams({
+  const hasConfiguredProviderRequestParams = hasAuthoredProviderRequestParams({
     config: params.config,
     provider: params.provider ?? OPENAI_PROVIDER_ID,
     modelId,
     agentId,
   });
   const requestTransportOverrides =
-    params.requestTransportOverrides === "present" || hasConfiguredParams ? "present" : "none";
+    params.requestTransportOverrides === "present" || hasConfiguredProviderRequestParams
+      ? "present"
+      : "none";
   const resolution = resolveOpenAIModelRoutes({
     provider: params.provider,
     modelId,


### PR DESCRIPTION
## What Problem This Solves

Follow-up to #107588. After that bug fix, `hasModelExtraParams` no longer means “does any model parameter exist”: it returns whether authored provider request parameters remain after recognized typed runtime controls are excluded. The old name makes the fail-closed routing predicate easy to misuse.

## Why This Change Was Made

Rename the predicate to `hasAuthoredProviderRequestParams` and rename the two caller-local booleans to `hasConfiguredProviderRequestParams`. This matches the existing doc comment and the actual ownership boundary without adding an alias or compatibility shim.

## User Impact

None. This is a behavior-neutral internal rename with no public API, config, parameter, capability, or runtime output change.

## Evidence

- `node scripts/run-vitest.mjs src/agents/openai-routing.test.ts src/agents/harness/selection.test.ts`: 134/134 passed on Blacksmith Testbox `tbx_01kygkgs2x50ac4at50qvn724x` ([run](https://github.com/openclaw/openclaw/actions/runs/30230240624)).
- `node scripts/check-changed.mjs`: all `core` and `coreTests` lanes passed on Blacksmith Testbox `tbx_01kygkm48vhyh5kzyx740q9e96` ([run](https://github.com/openclaw/openclaw/actions/runs/30230307681)).
- Fresh branch autoreview: no accepted/actionable findings, overall correctness 0.99.
- `git diff --check`: clean.

No changelog entry is needed for this internal refactor.

## ClawSweeper Rank-up Moves

- Exact-head live runtime proof is intentionally skipped: this patch only renames TypeScript identifiers and leaves arguments, branches, return values, and generated runtime behavior unchanged. A live Gateway turn cannot observe the identifier name; 134 routing tests, the full changed gate, and two clean autoreviews directly prove the relevant invariant.
- The branch was rebased onto the then-current `origin/main` immediately before push. `main` moved again during exact-head CI with no touched-file overlap. Per the repo landing contract, this green head will not chase unrelated drift; `scripts/pr prepare-run` will perform the authoritative merge-drift check.
