### PR TITLE
refactor(volcengine): reuse model compat patcher

### DIFF
--- a/extensions/volcengine/api.ts
+++ b/extensions/volcengine/api.ts
@@ -1,4 +1,5 @@
 // Volcengine API module exposes the plugin public contract.
+import { applyModelCompatPatch } from "openclaw/plugin-sdk/provider-model-shared";
 import type { ModelCompatConfig } from "openclaw/plugin-sdk/provider-model-shared";
 import { uniqueStrings } from "openclaw/plugin-sdk/string-coerce-runtime";
 
@@ -11,41 +12,25 @@ export const VOLCENGINE_UNSUPPORTED_TOOL_SCHEMA_KEYWORDS = [
   "maxContains",
 ] as const;
 
-function mergeUnsupportedToolSchemaKeywords(existing: readonly string[] | undefined): string[] {
-  return uniqueStrings([...(existing ?? []), ...VOLCENGINE_UNSUPPORTED_TOOL_SCHEMA_KEYWORDS]);
-}
-
-export function resolveVolcengineToolSchemaCompatPatch(
-  compat?: ModelCompatConfig,
-): ModelCompatConfig {
-  return {
-    unsupportedToolSchemaKeywords: mergeUnsupportedToolSchemaKeywords(
-      compat?.unsupportedToolSchemaKeywords,
-    ),
-  };
+function mergeUnsupportedToolSchemaKeywords(existing: string[] | undefined): string[] {
+  const merged = uniqueStrings([
+    ...(existing ?? []),
+    ...VOLCENGINE_UNSUPPORTED_TOOL_SCHEMA_KEYWORDS,
+  ]);
+  return existing?.length === merged.length &&
+    existing.every((value, index) => value === merged[index])
+    ? existing
+    : merged;
 }
 
 export function applyVolcengineToolSchemaCompat<T extends { compat?: ModelCompatConfig }>(
   model: T,
 ): T {
-  const unsupportedToolSchemaKeywords = mergeUnsupportedToolSchemaKeywords(
-    model.compat?.unsupportedToolSchemaKeywords,
-  );
-  if (
-    model.compat?.unsupportedToolSchemaKeywords?.length === unsupportedToolSchemaKeywords.length &&
-    unsupportedToolSchemaKeywords.every(
-      (keyword, index) => model.compat?.unsupportedToolSchemaKeywords?.[index] === keyword,
-    )
-  ) {
-    return model;
-  }
-  return {
-    ...model,
-    compat: {
-      ...model.compat,
-      unsupportedToolSchemaKeywords,
-    },
-  };
+  return applyModelCompatPatch(model, {
+    unsupportedToolSchemaKeywords: mergeUnsupportedToolSchemaKeywords(
+      model.compat?.unsupportedToolSchemaKeywords,
+    ),
+  });
 }
 
 export { buildDoubaoCodingProvider, buildDoubaoProvider } from "./provider-catalog.js";

--- a/extensions/volcengine/index.test.ts
+++ b/extensions/volcengine/index.test.ts
@@ -3,10 +3,7 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { registerSingleProviderPlugin } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { describe, expect, it } from "vitest";
-import {
-  VOLCENGINE_UNSUPPORTED_TOOL_SCHEMA_KEYWORDS,
-  resolveVolcengineToolSchemaCompatPatch,
-} from "./api.js";
+import { VOLCENGINE_UNSUPPORTED_TOOL_SCHEMA_KEYWORDS } from "./api.js";
 import plugin from "./index.js";
 import { DOUBAO_CODING_MODEL_CATALOG, DOUBAO_MODEL_CATALOG } from "./models.js";
 
@@ -75,9 +72,6 @@ describe("volcengine plugin", () => {
     const provider = await registerSingleProviderPlugin(plugin);
 
     expect(provider.hookAliases).toContain("volcengine-plan");
-    expect(resolveVolcengineToolSchemaCompatPatch()).toEqual({
-      unsupportedToolSchemaKeywords: [...VOLCENGINE_UNSUPPORTED_TOOL_SCHEMA_KEYWORDS],
-    });
 
     const normalized = provider.normalizeResolvedModel?.({
       provider: "volcengine-plan",
@@ -97,5 +91,8 @@ describe("volcengine plugin", () => {
       "not",
       ...VOLCENGINE_UNSUPPORTED_TOOL_SCHEMA_KEYWORDS,
     ]);
+
+    const normalizedAgain = provider.normalizeResolvedModel?.({ model: normalized } as never);
+    expect(normalizedAgain).toBe(normalized);
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Volcengine maintained a provider-local model compatibility patcher that duplicated the shared model compat helper’s object merge behavior and also exposed a resolver with no production caller.

## Why This Change Was Made

This maintainer-requested refactor keeps Volcengine’s ordered keyword merge local, reuses the existing `applyModelCompatPatch` SDK helper for the compat update, and removes the dead resolver. The keyword merge reuses an already-canonical array so repeated normalization preserves object identity under the shared helper’s reference-equality contract.

AI-assisted: implemented and reviewed with Codex.

## User Impact

No intended user-visible behavior change. Volcengine models retain the same unsupported tool-schema keywords, ordering, deduplication, unrelated compat fields, and no-op identity behavior.

Release-note context: internal behavior-preserving provider refactor; no standalone release note needed.

## Evidence

- `node scripts/run-vitest.mjs extensions/volcengine/index.test.ts` — 4 tests passed after the final rebase.
- The provider test now verifies repeated normalization returns the same model object.
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/volcengine/api.ts extensions/volcengine/index.test.ts` — passed.
- `oxfmt --check` and `git diff --check origin/main...HEAD` — passed.
- Codex autoreview initially found the array-reference idempotence regression; the merge now reuses the existing array when content is unchanged. Three post-fix reviews, including the final branch review, completed clean with no accepted/actionable findings.
- Production diff: 15 additions, 30 deletions (net -15 LOC).
