### PR TITLE
perf(sessions): stop per-row full-store scans in ACP meta reads

### DIFF
--- a/src/acp/runtime/session-meta-store.ts
+++ b/src/acp/runtime/session-meta-store.ts
@@ -1,0 +1,131 @@
+/** Store binding for ACP session metadata: resolves which session-store row owns a key. */
+import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import { resolveDefaultAgentId } from "../../agents/agent-scope-config.js";
+import { getRuntimeConfig } from "../../config/config.js";
+import { resolveStorePath } from "../../config/sessions/paths.js";
+import {
+  listSessionEntriesReadOnly,
+  loadExactSessionEntryReadOnly,
+  type SessionEntrySummary,
+} from "../../config/sessions/session-accessor.js";
+import type { SessionEntry } from "../../config/sessions/types.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { parseAgentSessionKey } from "../../routing/session-key.js";
+
+/**
+ * Resolve one session's store key and entry with targeted single-row probes.
+ * Gateway sessions.list calls this per row; listing the whole store here made
+ * that path O(rows²) in JSON parsing (12.7s of a 78.5s production profile).
+ * The full scan survives only as the fallback for legacy case-variant keys
+ * that neither the exact nor the lowercased probe can hit.
+ */
+export function resolveStoreEntryForSessionKey(params: {
+  agentId?: string;
+  storePath: string;
+  sessionKey: string;
+  clone?: boolean;
+}): { storeSessionKey: string; entry?: SessionEntry } {
+  const scope = {
+    ...(params.agentId ? { agentId: params.agentId } : {}),
+    storePath: params.storePath,
+    ...(params.clone === false ? { clone: false } : {}),
+  };
+  const normalized = params.sessionKey.trim();
+  if (!normalized) {
+    return { storeSessionKey: "" };
+  }
+  const exact = loadExactSessionEntryReadOnly({ ...scope, sessionKey: normalized });
+  if (exact) {
+    return { storeSessionKey: normalized, entry: exact.entry };
+  }
+  const lower = normalizeLowercaseStringOrEmpty(normalized);
+  if (lower !== normalized) {
+    const lowered = loadExactSessionEntryReadOnly({ ...scope, sessionKey: lower });
+    if (lowered) {
+      return { storeSessionKey: lower, entry: lowered.entry };
+    }
+  }
+  const entries = listSessionEntriesReadOnly(scope);
+  const storeSessionKey = resolveStoreSessionKey(entries, normalized);
+  return {
+    storeSessionKey,
+    entry: entries.find((candidate) => candidate.sessionKey === storeSessionKey)?.entry,
+  };
+}
+
+function resolveStoreSessionKey(
+  entries: readonly SessionEntrySummary[],
+  sessionKey: string,
+): string {
+  const normalized = sessionKey.trim();
+  if (!normalized) {
+    return "";
+  }
+  if (entries.some((entry) => entry.sessionKey === normalized)) {
+    return normalized;
+  }
+  const lower = normalizeLowercaseStringOrEmpty(normalized);
+  if (entries.some((entry) => entry.sessionKey === lower)) {
+    return lower;
+  }
+  for (const entry of entries) {
+    if (normalizeLowercaseStringOrEmpty(entry.sessionKey) === lower) {
+      return entry.sessionKey;
+    }
+  }
+  return lower;
+}
+
+/** Resolves the session store path that owns an ACP session key. */
+export function resolveSessionStorePathForAcp(params: {
+  sessionKey: string;
+  cfg?: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+}): { cfg: OpenClawConfig; agentId?: string; storePath: string } {
+  const cfg = params.cfg ?? getRuntimeConfig();
+  const parsed = parseAgentSessionKey(params.sessionKey);
+  const agentId = parsed?.agentId ?? resolveDefaultAgentId(cfg);
+  return {
+    cfg,
+    agentId,
+    storePath: resolveStorePath(cfg.session?.store, { agentId, env: params.env }),
+  };
+}
+
+/** Reads one session's store binding, falling back to a lowercased key on store errors. */
+export function readSessionEntryFromStore(params: {
+  sessionKey: string;
+  cfg?: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+  clone?: boolean;
+}): {
+  cfg: OpenClawConfig;
+  agentId?: string;
+  storePath: string;
+  storeSessionKey: string;
+  entry?: SessionEntry;
+  storeReadFailed?: boolean;
+} {
+  const { cfg, agentId, storePath } = resolveSessionStorePathForAcp({
+    sessionKey: params.sessionKey,
+    cfg: params.cfg,
+    env: params.env,
+  });
+  try {
+    const { storeSessionKey, entry } = resolveStoreEntryForSessionKey({
+      ...(agentId ? { agentId } : {}),
+      storePath,
+      sessionKey: params.sessionKey,
+      ...(params.clone === false ? { clone: false } : {}),
+    });
+    return { cfg, agentId, storePath, storeSessionKey, entry };
+  } catch {
+    return {
+      cfg,
+      agentId,
+      storePath,
+      storeSessionKey: normalizeLowercaseStringOrEmpty(params.sessionKey),
+      storeReadFailed: true,
+    };
+  }
+}

--- a/src/acp/runtime/session-meta-store.ts
+++ b/src/acp/runtime/session-meta-store.ts
@@ -4,9 +4,8 @@ import { resolveDefaultAgentId } from "../../agents/agent-scope-config.js";
 import { getRuntimeConfig } from "../../config/config.js";
 import { resolveStorePath } from "../../config/sessions/paths.js";
 import {
-  listSessionEntriesReadOnly,
+  listSessionEntryKeysReadOnly,
   loadExactSessionEntryReadOnly,
-  type SessionEntrySummary,
 } from "../../config/sessions/session-accessor.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -45,35 +44,18 @@ export function resolveStoreEntryForSessionKey(params: {
       return { storeSessionKey: lower, entry: lowered.entry };
     }
   }
-  const entries = listSessionEntriesReadOnly(scope);
-  const storeSessionKey = resolveStoreSessionKey(entries, normalized);
+  // Both direct probes missed, so only a legacy case-variant key can match.
+  // Scan persisted keys without parsing any entry_json, then probe the winner.
+  const variant = listSessionEntryKeysReadOnly(scope).find(
+    (candidate) => normalizeLowercaseStringOrEmpty(candidate) === lower,
+  );
+  if (variant === undefined) {
+    return { storeSessionKey: lower };
+  }
   return {
-    storeSessionKey,
-    entry: entries.find((candidate) => candidate.sessionKey === storeSessionKey)?.entry,
+    storeSessionKey: variant,
+    entry: loadExactSessionEntryReadOnly({ ...scope, sessionKey: variant })?.entry,
   };
-}
-
-function resolveStoreSessionKey(
-  entries: readonly SessionEntrySummary[],
-  sessionKey: string,
-): string {
-  const normalized = sessionKey.trim();
-  if (!normalized) {
-    return "";
-  }
-  if (entries.some((entry) => entry.sessionKey === normalized)) {
-    return normalized;
-  }
-  const lower = normalizeLowercaseStringOrEmpty(normalized);
-  if (entries.some((entry) => entry.sessionKey === lower)) {
-    return lower;
-  }
-  for (const entry of entries) {
-    if (normalizeLowercaseStringOrEmpty(entry.sessionKey) === lower) {
-      return entry.sessionKey;
-    }
-  }
-  return lower;
 }
 
 /** Resolves the session store path that owns an ACP session key. */

--- a/src/acp/runtime/session-meta.ts
+++ b/src/acp/runtime/session-meta.ts
@@ -4,15 +4,8 @@ import { safeParseJson } from "@openclaw/normalization-core";
 import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import type { Insertable, Selectable } from "kysely";
-import { resolveDefaultAgentId } from "../../agents/agent-scope-config.js";
 import { getRuntimeConfig } from "../../config/config.js";
-import { resolveStorePath } from "../../config/sessions/paths.js";
-import {
-  listSessionEntriesReadOnly,
-  loadExactSessionEntryReadOnly,
-  patchSessionEntryWithKey,
-  type SessionEntrySummary,
-} from "../../config/sessions/session-accessor.js";
+import { patchSessionEntryWithKey } from "../../config/sessions/session-accessor.js";
 import {
   mergeSessionEntry,
   type AcpSessionRuntimeOptions,
@@ -26,15 +19,21 @@ import {
   executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,
 } from "../../infra/kysely-sync.js";
-import { parseAgentSessionKey } from "../../routing/session-key.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../../state/openclaw-state-db.generated.js";
 import {
   openOpenClawStateDatabase,
   type OpenClawStateDatabaseOptions,
   runOpenClawStateWriteTransaction,
 } from "../../state/openclaw-state-db.js";
+import {
+  readSessionEntryFromStore,
+  resolveSessionStorePathForAcp,
+  resolveStoreEntryForSessionKey,
+} from "./session-meta-store.js";
 
 /** ACP metadata joined with its legacy session-store row and config context. */
+export { resolveSessionStorePathForAcp } from "./session-meta-store.js";
+
 export type AcpSessionStoreEntry = {
   cfg: OpenClawConfig;
   agentId?: string;
@@ -52,86 +51,6 @@ type AcpSessionMetaDatabase = Pick<OpenClawStateKyselyDatabase, "acp_sessions">;
 type AcpSessionRow = Selectable<AcpSessionsTable>;
 type AcpSessionEntryBinding = Pick<SessionEntry, "lifecycleRevision"> &
   Partial<Pick<SessionEntry, "sessionId" | "sessionStartedAt">>;
-
-/**
- * Resolve one session's store key and entry with targeted single-row probes.
- * Gateway sessions.list calls this per row; listing the whole store here made
- * that path O(rows²) in JSON parsing (12.7s of a 78.5s production profile).
- * The full scan survives only as the fallback for legacy case-variant keys
- * that neither the exact nor the lowercased probe can hit.
- */
-function resolveStoreEntryForSessionKey(params: {
-  agentId?: string;
-  storePath: string;
-  sessionKey: string;
-  clone?: boolean;
-}): { storeSessionKey: string; entry?: SessionEntry } {
-  const scope = {
-    ...(params.agentId ? { agentId: params.agentId } : {}),
-    storePath: params.storePath,
-    ...(params.clone === false ? { clone: false } : {}),
-  };
-  const normalized = params.sessionKey.trim();
-  if (!normalized) {
-    return { storeSessionKey: "" };
-  }
-  const exact = loadExactSessionEntryReadOnly({ ...scope, sessionKey: normalized });
-  if (exact) {
-    return { storeSessionKey: normalized, entry: exact.entry };
-  }
-  const lower = normalizeLowercaseStringOrEmpty(normalized);
-  if (lower !== normalized) {
-    const lowered = loadExactSessionEntryReadOnly({ ...scope, sessionKey: lower });
-    if (lowered) {
-      return { storeSessionKey: lower, entry: lowered.entry };
-    }
-  }
-  const entries = listSessionEntriesReadOnly(scope);
-  const storeSessionKey = resolveStoreSessionKey(entries, normalized);
-  return {
-    storeSessionKey,
-    entry: entries.find((candidate) => candidate.sessionKey === storeSessionKey)?.entry,
-  };
-}
-
-function resolveStoreSessionKey(
-  entries: readonly SessionEntrySummary[],
-  sessionKey: string,
-): string {
-  const normalized = sessionKey.trim();
-  if (!normalized) {
-    return "";
-  }
-  if (entries.some((entry) => entry.sessionKey === normalized)) {
-    return normalized;
-  }
-  const lower = normalizeLowercaseStringOrEmpty(normalized);
-  if (entries.some((entry) => entry.sessionKey === lower)) {
-    return lower;
-  }
-  for (const entry of entries) {
-    if (normalizeLowercaseStringOrEmpty(entry.sessionKey) === lower) {
-      return entry.sessionKey;
-    }
-  }
-  return lower;
-}
-
-/** Resolves the session store path that owns an ACP session key. */
-export function resolveSessionStorePathForAcp(params: {
-  sessionKey: string;
-  cfg?: OpenClawConfig;
-  env?: NodeJS.ProcessEnv;
-}): { cfg: OpenClawConfig; agentId?: string; storePath: string } {
-  const cfg = params.cfg ?? getRuntimeConfig();
-  const parsed = parseAgentSessionKey(params.sessionKey);
-  const agentId = parsed?.agentId ?? resolveDefaultAgentId(cfg);
-  return {
-    cfg,
-    agentId,
-    storePath: resolveStorePath(cfg.session?.store, { agentId, env: params.env }),
-  };
-}
 
 function getAcpSessionKysely(db: DatabaseSync) {
   return getNodeSqliteKysely<AcpSessionMetaDatabase>(db);
@@ -450,43 +369,6 @@ function upsertAcpSessionMetaRow(db: DatabaseSync, row: Insertable<AcpSessionsTa
         }),
       ),
   );
-}
-
-function readSessionEntryFromStore(params: {
-  sessionKey: string;
-  cfg?: OpenClawConfig;
-  env?: NodeJS.ProcessEnv;
-  clone?: boolean;
-}): {
-  cfg: OpenClawConfig;
-  agentId?: string;
-  storePath: string;
-  storeSessionKey: string;
-  entry?: SessionEntry;
-  storeReadFailed?: boolean;
-} {
-  const { cfg, agentId, storePath } = resolveSessionStorePathForAcp({
-    sessionKey: params.sessionKey,
-    cfg: params.cfg,
-    env: params.env,
-  });
-  try {
-    const { storeSessionKey, entry } = resolveStoreEntryForSessionKey({
-      ...(agentId ? { agentId } : {}),
-      storePath,
-      sessionKey: params.sessionKey,
-      ...(params.clone === false ? { clone: false } : {}),
-    });
-    return { cfg, agentId, storePath, storeSessionKey, entry };
-  } catch {
-    return {
-      cfg,
-      agentId,
-      storePath,
-      storeSessionKey: normalizeLowercaseStringOrEmpty(params.sessionKey),
-      storeReadFailed: true,
-    };
-  }
 }
 
 export function readAcpSessionEntry(params: {

--- a/src/acp/runtime/session-meta.ts
+++ b/src/acp/runtime/session-meta.ts
@@ -9,6 +9,7 @@ import { getRuntimeConfig } from "../../config/config.js";
 import { resolveStorePath } from "../../config/sessions/paths.js";
 import {
   listSessionEntriesReadOnly,
+  loadExactSessionEntryReadOnly,
   patchSessionEntryWithKey,
   type SessionEntrySummary,
 } from "../../config/sessions/session-accessor.js";
@@ -51,6 +52,47 @@ type AcpSessionMetaDatabase = Pick<OpenClawStateKyselyDatabase, "acp_sessions">;
 type AcpSessionRow = Selectable<AcpSessionsTable>;
 type AcpSessionEntryBinding = Pick<SessionEntry, "lifecycleRevision"> &
   Partial<Pick<SessionEntry, "sessionId" | "sessionStartedAt">>;
+
+/**
+ * Resolve one session's store key and entry with targeted single-row probes.
+ * Gateway sessions.list calls this per row; listing the whole store here made
+ * that path O(rows²) in JSON parsing (12.7s of a 78.5s production profile).
+ * The full scan survives only as the fallback for legacy case-variant keys
+ * that neither the exact nor the lowercased probe can hit.
+ */
+function resolveStoreEntryForSessionKey(params: {
+  agentId?: string;
+  storePath: string;
+  sessionKey: string;
+  clone?: boolean;
+}): { storeSessionKey: string; entry?: SessionEntry } {
+  const scope = {
+    ...(params.agentId ? { agentId: params.agentId } : {}),
+    storePath: params.storePath,
+    ...(params.clone === false ? { clone: false } : {}),
+  };
+  const normalized = params.sessionKey.trim();
+  if (!normalized) {
+    return { storeSessionKey: "" };
+  }
+  const exact = loadExactSessionEntryReadOnly({ ...scope, sessionKey: normalized });
+  if (exact) {
+    return { storeSessionKey: normalized, entry: exact.entry };
+  }
+  const lower = normalizeLowercaseStringOrEmpty(normalized);
+  if (lower !== normalized) {
+    const lowered = loadExactSessionEntryReadOnly({ ...scope, sessionKey: lower });
+    if (lowered) {
+      return { storeSessionKey: lower, entry: lowered.entry };
+    }
+  }
+  const entries = listSessionEntriesReadOnly(scope);
+  const storeSessionKey = resolveStoreSessionKey(entries, normalized);
+  return {
+    storeSessionKey,
+    entry: entries.find((candidate) => candidate.sessionKey === storeSessionKey)?.entry,
+  };
+}
 
 function resolveStoreSessionKey(
   entries: readonly SessionEntrySummary[],
@@ -429,13 +471,12 @@ function readSessionEntryFromStore(params: {
     env: params.env,
   });
   try {
-    const entries = listSessionEntriesReadOnly({
+    const { storeSessionKey, entry } = resolveStoreEntryForSessionKey({
       ...(agentId ? { agentId } : {}),
       storePath,
+      sessionKey: params.sessionKey,
       ...(params.clone === false ? { clone: false } : {}),
     });
-    const storeSessionKey = resolveStoreSessionKey(entries, params.sessionKey);
-    const entry = entries.find((candidate) => candidate.sessionKey === storeSessionKey)?.entry;
     return { cfg, agentId, storePath, storeSessionKey, entry };
   } catch {
     return {
@@ -503,20 +544,18 @@ export async function listAcpSessionEntries(params: {
       cfg,
       env: params.env,
     });
-    let sessionEntries: SessionEntrySummary[];
+    let storeSessionKey: string;
+    let entry: SessionEntry | undefined;
     try {
-      sessionEntries = listSessionEntriesReadOnly({
+      ({ storeSessionKey, entry } = resolveStoreEntryForSessionKey({
         ...(agentId ? { agentId } : {}),
         storePath,
+        sessionKey,
         ...(params.clone === false ? { clone: false } : {}),
-      });
+      }));
     } catch {
       continue;
     }
-    const storeSessionKey = resolveStoreSessionKey(sessionEntries, sessionKey);
-    const entry = sessionEntries.find(
-      (candidate) => candidate.sessionKey === storeSessionKey,
-    )?.entry;
     const readableRow = resolveReadableAcpSessionRow({
       row,
       entry,

--- a/src/config/sessions/session-accessor.entry.ts
+++ b/src/config/sessions/session-accessor.entry.ts
@@ -12,6 +12,7 @@ import { clearPluginOwnedSessionState } from "./plugin-host-cleanup.js";
 import {
   listSqliteSessionEntries,
   listSqliteSessionEntriesReadOnly,
+  listSqliteSessionEntryKeysReadOnly,
   loadExactSqliteSessionEntry,
   loadExactSqliteSessionEntryReadOnly,
   loadSqliteSessionEntry,
@@ -354,6 +355,11 @@ export function listSessionEntriesReadOnly(
   scope: SessionEntryListScope = {},
 ): SessionEntrySummary[] {
   return listSqliteSessionEntriesReadOnly(scope);
+}
+
+/** Lists persisted session keys only; the fallback probe for case-variant keys. */
+export function listSessionEntryKeysReadOnly(scope: SessionEntryListScope = {}): string[] {
+  return listSqliteSessionEntryKeysReadOnly(scope);
 }
 
 /**

--- a/src/config/sessions/session-accessor.entry.ts
+++ b/src/config/sessions/session-accessor.entry.ts
@@ -13,6 +13,7 @@ import {
   listSqliteSessionEntries,
   listSqliteSessionEntriesReadOnly,
   loadExactSqliteSessionEntry,
+  loadExactSqliteSessionEntryReadOnly,
   loadSqliteSessionEntry,
   loadSqliteSessionEntryReadOnly,
   patchSqliteSessionEntry,
@@ -328,6 +329,13 @@ export function loadSessionEntryReadOnly(scope: SessionAccessScope): SessionEntr
  */
 export function loadExactSessionEntry(scope: SessionAccessScope): ExactSessionEntry | undefined {
   return loadExactSqliteSessionEntry(scope);
+}
+
+/** Exact persisted-key probe on the read-only handle; see loadExactSessionEntry. */
+export function loadExactSessionEntryReadOnly(
+  scope: SessionAccessScope,
+): ExactSessionEntry | undefined {
+  return loadExactSqliteSessionEntryReadOnly(scope);
 }
 
 /** Lists entries from the resolved store, preserving the persisted key for each row. */

--- a/src/config/sessions/session-accessor.sqlite-entry.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry.ts
@@ -110,6 +110,21 @@ export function loadExactSqliteSessionEntry(
   return row ? { sessionKey, entry: row.entry } : undefined;
 }
 
+/** Lists persisted session keys only, skipping entry_json parsing entirely. */
+export function listSqliteSessionEntryKeysReadOnly(
+  scope: Partial<Omit<SessionAccessScope, "sessionKey">> = {},
+): string[] {
+  const resolved = resolveSqliteScope({ ...scope, sessionKey: "" });
+  const result = withOpenClawAgentDatabaseReadOnly((database) => {
+    const db = getSessionKysely(database.db);
+    return executeSqliteQuerySync(
+      database.db,
+      db.selectFrom("session_nodes").select(["session_key"]).orderBy("session_key", "asc"),
+    ).rows.map((row) => row.session_key);
+  }, toDatabaseOptions(resolved));
+  return result.found ? result.value : [];
+}
+
 /** Exact persisted-key probe on the read-only handle, for per-row hot paths. */
 export function loadExactSqliteSessionEntryReadOnly(
   scope: SessionAccessScope,

--- a/src/config/sessions/session-accessor.sqlite-entry.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry.ts
@@ -110,6 +110,22 @@ export function loadExactSqliteSessionEntry(
   return row ? { sessionKey, entry: row.entry } : undefined;
 }
 
+/** Exact persisted-key probe on the read-only handle, for per-row hot paths. */
+export function loadExactSqliteSessionEntryReadOnly(
+  scope: SessionAccessScope,
+): ExactSessionEntry | undefined {
+  const sessionKey = scope.sessionKey.trim();
+  if (!sessionKey) {
+    return undefined;
+  }
+  const resolved = resolveSqliteScope(scope);
+  const result = withOpenClawAgentDatabaseReadOnly(
+    (database) => readExactSessionEntryRow(database, sessionKey)?.entry,
+    toDatabaseOptions(resolved),
+  );
+  return result.found && result.value ? { sessionKey, entry: result.value } : undefined;
+}
+
 /** Resolves the persisted session key for a SQLite transcript session id. */
 export function resolveSqliteSessionKeyBySessionId(
   scope: Pick<SessionTranscriptReadScope, "agentId" | "env" | "sessionId" | "storePath">,

--- a/src/config/sessions/session-accessor.sqlite.ts
+++ b/src/config/sessions/session-accessor.sqlite.ts
@@ -2,6 +2,7 @@
 export {
   listSqliteSessionEntries,
   listSqliteSessionEntriesReadOnly,
+  listSqliteSessionEntryKeysReadOnly,
   listSqliteSessionEntriesByStatus,
   listSqliteSessionTranscriptInstances,
   loadExactSqliteSessionEntry,

--- a/src/config/sessions/session-accessor.sqlite.ts
+++ b/src/config/sessions/session-accessor.sqlite.ts
@@ -5,6 +5,7 @@ export {
   listSqliteSessionEntriesByStatus,
   listSqliteSessionTranscriptInstances,
   loadExactSqliteSessionEntry,
+  loadExactSqliteSessionEntryReadOnly,
   loadSqliteSessionEntry,
   loadSqliteSessionEntryReadOnly,
   patchSqliteSessionEntry,

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -123,6 +123,7 @@ export {
   clearPluginOwnedSessionState,
   listSessionEntries,
   listSessionEntriesReadOnly,
+  listSessionEntryKeysReadOnly,
   loadExactSessionEntry,
   loadExactSessionEntryReadOnly,
   loadSessionEntry,

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -124,6 +124,7 @@ export {
   listSessionEntries,
   listSessionEntriesReadOnly,
   loadExactSessionEntry,
+  loadExactSessionEntryReadOnly,
   loadSessionEntry,
   loadSessionEntryReadOnly,
   openSessionEntryReadView,


### PR DESCRIPTION
## What Problem This Solves

Gateway `sessions.list` is O(rows²) in JSON parsing. Every per-session ACP meta read (`buildGatewaySessionRow` → `resolveGatewaySessionThinkingProjectionInternal` → `readAcpSessionMeta` → `readSessionEntryFromStore`) listed and JSON-parsed the **entire** session store just to find one row. With 180 sessions on team.openclaw.ai, a CPU profile (`--cpu-prof`, 10ms sampling, 78.5s window under normal agent load) attributes:

- 12.69s to `parseSqliteSessionEntryJson` + `executeCompiledSqliteQuerySync` under exactly this chain
- ≈19% of the whole window, ≈29% of non-idle time, spent re-parsing the same session rows

`listAcpSessionEntries` had the same shape per ACP row.

## Why This Change Was Made

`readSessionEntryFromStore` only needs one row and its persisted key. Resolve it with targeted read-only single-row probes — exact key, then lowercased key — matching the first two steps of the old `resolveStoreSessionKey` exactly. Only when both probes miss can a legacy case-variant key match, and that fallback now lists **persisted keys only** (no `entry_json` parsing) and probes the single winner. The common path parses 1 row instead of N; the miss path parses ≤1 row instead of N.

Two narrow accessors were added next to their existing siblings: `loadExactSessionEntryReadOnly` (the read-only twin of `loadExactSessionEntry`, keeping hot reads off the writable lifecycle handle) and `listSessionEntryKeysReadOnly`. The store-binding helpers moved to `session-meta-store.ts` because the change pushed `session-meta.ts` over the 700-line cap; the public entrypoint is re-exported unchanged.

## User Impact

Faster session list and lower steady-state CPU on gateways with many sessions; the effect scales quadratically with session count. This is also the dominant cost that made the session observer unaffordable to re-enable on team.openclaw.ai.

## Evidence

- Production CPU profile evidence above (collected on team.openclaw.ai, Node `--cpu-prof` via systemd drop-in).
- `src/acp/runtime/session-meta` 12 passed — including `keeps SQLite ACP metadata visible when legacy store keys are canonicalized`, which exercises the case-variant fallback, and lifecycle-revision binding tests that prove `storeSessionKey`/`entry` semantics are unchanged.
- `src/config/sessions/session-accessor` 175 passed; `src/gateway/session-utils` suites passed; `src/acp/runtime` 43 passed.
- Changed-file oxlint rc=0, oxfmt clean, `git diff --check` clean.
- Autoreview (Codex `gpt-5.6-sol`, xhigh): first pass flagged that the fallback still parsed the full store per miss — fixed with the keys-only listing; second pass clean, "patch is correct (0.88)".
- Note: local full-project `tsgo` shows one pre-existing unrelated error (`@openclaw/session-url-contract` unresolved — stale worktree `node_modules` for a package newly added on `main`); present on clean `origin/main` checkout too, CI is authoritative.
