### PR TITLE
fix(linux): restore the macOS build of the Tauri companion

### DIFF
--- a/.github/workflows/linux-app-release.yml
+++ b/.github/workflows/linux-app-release.yml
@@ -163,7 +163,10 @@ jobs:
     name: Build unsigned macOS test bundles
     if: ${{ inputs['desktop-test-bundles'] }}
     needs: validate_release
-    runs-on: macos-14
+    # macos-15, not macos-14: tauri-plugin-notifications' Swift sources use
+    # typed throws (`throws(FFIResult)`), which needs Swift 6. The macos-14
+    # image still ships Swift 5.x, so this job could not build the plugin.
+    runs-on: macos-15
     timeout-minutes: 45
     steps:
       - name: Checkout selected tag

--- a/.github/workflows/linux-app.yml
+++ b/.github/workflows/linux-app.yml
@@ -89,3 +89,39 @@ jobs:
           path: |
             apps/linux/src-tauri/target/release/bundle/deb/*.deb
             apps/linux/src-tauri/target/release/bundle/appimage/*.AppImage
+
+  check-macos:
+    name: Check macOS companion
+    # This app also ships macOS desktop-test bundles, but the only job that
+    # compiles them (linux-app-release.yml build_macos) runs behind a manual
+    # dispatch input. Without a per-PR check, a macOS-gated Tauri API can break
+    # the macOS target for weeks unnoticed - `WebviewWindowBuilder::transparent`
+    # did exactly that. Match that job's runner so this proves the same target.
+    runs-on: macos-14
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 1
+          fetch-tags: false
+          persist-credentials: false
+          submodules: false
+
+      - name: Install Rust
+        run: rustup toolchain install stable --profile minimal
+
+      - name: Cache Cargo
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            apps/linux/src-tauri/target
+          key: macos-app-${{ runner.os }}-${{ hashFiles('apps/linux/src-tauri/Cargo.lock') }}
+          restore-keys: |
+            macos-app-${{ runner.os }}-
+
+      - name: Check macOS companion
+        working-directory: apps/linux/src-tauri
+        run: cargo +stable check --locked --all-targets

--- a/.github/workflows/linux-app.yml
+++ b/.github/workflows/linux-app.yml
@@ -96,8 +96,12 @@ jobs:
     # compiles them (linux-app-release.yml build_macos) runs behind a manual
     # dispatch input. Without a per-PR check, a macOS-gated Tauri API can break
     # the macOS target for weeks unnoticed - `WebviewWindowBuilder::transparent`
-    # did exactly that. Match that job's runner so this proves the same target.
-    runs-on: macos-14
+    # did exactly that.
+    #
+    # macos-15, not macos-14: tauri-plugin-notifications' Swift sources use
+    # typed throws (`throws(FFIResult)`), which needs Swift 6. The macos-14
+    # image still ships Swift 5.x and fails to parse them.
+    runs-on: macos-15
     timeout-minutes: 30
     steps:
       - name: Checkout

--- a/apps/linux/src-tauri/Cargo.toml
+++ b/apps/linux/src-tauri/Cargo.toml
@@ -24,7 +24,16 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"
 sha2 = "0.11.0"
 subtle = "2.6.1"
-tauri = { version = "2.11.5", features = ["image-png", "tray-icon", "unstable"] }
+# macos-private-api backs Quick Chat's transparent window. Tauri gates
+# `WebviewWindowBuilder::transparent` behind it on macOS, and the feature must
+# stay in sync with `app.macOSPrivateApi` in tauri.conf.json or tauri-build
+# fails. It is inert on Linux and Windows.
+tauri = { version = "2.11.5", features = [
+  "image-png",
+  "macos-private-api",
+  "tray-icon",
+  "unstable",
+] }
 tauri-plugin-autostart = "2.5.1"
 tauri-plugin-deep-link = "2.4.9"
 tauri-plugin-global-shortcut = "2.3.2"

--- a/apps/linux/src-tauri/tauri.conf.json
+++ b/apps/linux/src-tauri/tauri.conf.json
@@ -20,6 +20,7 @@
     }
   },
   "app": {
+    "macOSPrivateApi": true,
     "withGlobalTauri": true,
     "windows": [
       {


### PR DESCRIPTION
## Problem

`apps/linux/src-tauri` has not compiled for macOS since 2026-07-17:

```
error[E0599]: no method named `transparent` found for struct `WebviewWindowBuilder` in the current scope
   --> src/quickchat.rs:470:6
```

Tauri v2 gates `WebviewWindowBuilder::transparent` behind `#[cfg(any(not(target_os = "macos"), feature = "macos-private-api"))]`. Quick Chat calls it unconditionally, so the macOS target broke the moment the floating composer landed in 277f009cc902ae (#109947).

It went unnoticed for nine days because nothing compiles the macOS target per PR. `linux-app.yml` builds deb/appimage on Linux only, and the one job that does build macOS — `build_macos` in `linux-app-release.yml` — sits behind the manual `desktop-test-bundles` dispatch input.

## Fix

Enable the `macos-private-api` cargo feature on the `tauri` dependency, plus the `app.macOSPrivateApi` config flag. Tauri requires the two to agree; with only the feature set, `tauri-build` fails the allowlist check:

```
The `tauri` dependency features on the `Cargo.toml` file does not match the allowlist defined under `tauri.conf.json`.
```

The feature is inert on Linux and Windows, and `Cargo.lock` is unchanged — it pulls in no new dependencies.

Dropping `.transparent(true)` on macOS would have compiled too, but it would ship something visibly wrong. `quickchat.css` sets `html` and `body` to `background: transparent` and paints the composer as a 16px-radius card at `rgb(28 28 30 / 94%)` with a `0 10px 36px` drop shadow. Without an transparent window, macOS would draw an opaque rectangle around that rounded card and clip its shadow. Keeping the intended floating look is the reason the private API is worth it here.

**Tradeoff, confirmed with the maintainer:** Tauri documents that apps using the private API cannot ship through the Mac App Store. That costs this app nothing — it bundles and executes `install-cli.sh`, manages a local Gateway system service, and does mDNS discovery, none of which survive App Store sandboxing, and it already distributes through GitHub releases and a self-update channel.

## Regression guard

Adds a `check-macos` job to `linux-app.yml` running `cargo check --locked --all-targets` on macOS, so the target that ships as a desktop-test bundle is compiled on every PR touching `apps/linux/**`.

### The guard immediately found a second, unrelated break

On its first run the job failed — not on this change, but in `tauri-plugin-notifications`:

```
Swift build failed for target: arm64-apple-macosx13.0
NotificationPlugin.swift:133:63: error: consecutive statements on a line
  func showNotification(notification: Notification) async throws(FFIResult) -> UNNotificationRequest {
```

Those sources use **typed throws** (`throws(FFIResult)`), a Swift 6 feature. The `macos-14` runner image still ships Swift 5.x and cannot parse them. It builds locally only because current macOS dev machines have Swift 6 (verified: Swift 6.4 here).

The important consequence: `build_macos` in `linux-app-release.yml` compiles the same crate on the same `macos-14` image, so **it could not have produced a macOS bundle either** — invisible because that job only runs behind the manual `desktop-test-bundles` dispatch input. Both jobs move to `macos-15`.

## Proof

Local, on macOS 27.0 (Apple silicon), after touching `src/quickchat.rs` to force a real recompile rather than a cache hit:

```
cargo check --locked --all-targets   # exit 0, 0 errors  (the exact CI command)
cargo build                          # exit 0, 0 errors
```

The same tree without these two settings still reproduces the `E0599` above, so the new job would have caught the original break.

The `macos-15` runner change is proven for `check-macos` by this PR's own CI. For `build_macos` it is unproven by design — that job is part of the release workflow and dispatching it is not something to do casually — but it compiles the same crate on the same image, so the same Swift 6 requirement applies.

### Proof gap

Compilation and configuration are verified; Quick Chat's transparency was **not** visually confirmed at runtime on macOS. Doing so needs a bundle built under a throwaway identifier (a stale companion instance holds the single-instance lock) plus synthetic global-shortcut input. The transparency behavior itself is Tauri's documented contract for these two settings.
