### PR TITLE
fix(models): make refreshed catalogs usable from the CLI

### DIFF
--- a/src/commands/models/list.list-command.forward-compat.test.ts
+++ b/src/commands/models/list.list-command.forward-compat.test.ts
@@ -898,6 +898,48 @@ describe("modelsListCommand forward-compat", () => {
   });
 
   describe("--all catalog supplementation", () => {
+    it("includes refreshed manifest models for runtime-backed provider lists", async () => {
+      mocks.resolveConfiguredEntries.mockReturnValueOnce({ entries: [] });
+      mocks.hasProviderRuntimeCatalogForFilter.mockResolvedValueOnce(true);
+      mocks.loadProviderCatalogModelsForList.mockResolvedValueOnce([
+        {
+          provider: "anthropic",
+          id: "claude-live",
+          name: "Claude Live",
+          api: "anthropic-messages",
+          baseUrl: "https://api.anthropic.com",
+          input: ["text"],
+          contextWindow: 200_000,
+          maxTokens: 4096,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        },
+      ]);
+      mocks.loadSupplementalManifestCatalogRowsForList.mockReturnValueOnce([
+        {
+          provider: "anthropic",
+          id: "claude-refreshed",
+          ref: "anthropic/claude-refreshed",
+          mergeKey: "anthropic::claude-refreshed",
+          name: "Claude Refreshed",
+          source: "runtime-refresh",
+          input: ["text"],
+          reasoning: false,
+          status: "available",
+          baseUrl: "https://api.anthropic.com",
+          contextWindow: 200_000,
+        },
+      ]);
+      const runtime = createRuntime();
+
+      await modelsListCommand({ all: true, provider: "anthropic", json: true }, runtime as never);
+
+      expect(mocks.loadModelRegistry).not.toHaveBeenCalled();
+      expectRowKeys(lastPrintedRows<{ key: string }>(), [
+        "anthropic/claude-live",
+        "anthropic/claude-refreshed",
+      ]);
+    });
+
     it("keeps provider-catalog Codex availability indeterminate without model auth", async () => {
       mocks.resolveConfiguredEntries.mockReturnValueOnce({ entries: [] });
       mocks.hasProviderStaticCatalogForFilter.mockResolvedValueOnce(true);

--- a/src/commands/models/list.row-sources.ts
+++ b/src/commands/models/list.row-sources.ts
@@ -61,6 +61,16 @@ export async function appendAllModelRowSources(
         seenKeys,
         staticOnly: params.sourcePlan.kind === "provider-runtime-static",
       });
+      if (params.sourcePlan.manifestCatalogRows.length > 0) {
+        // Runtime discovery keeps precedence; refreshed manifest rows fill only
+        // model refs the provider runtime has not materialized yet.
+        catalogRows += await appendManifestCatalogRows({
+          rows: params.rows,
+          context: { ...params.context, skipRuntimeModelSuppression: true },
+          seenKeys,
+          manifestRows: params.sourcePlan.manifestCatalogRows,
+        });
+      }
     }
     if (params.entries && params.entries.length > 0) {
       const missingEntries = params.entries.filter((entry) => !seenKeys.has(entry.key));

--- a/src/commands/models/list.source-plan.test.ts
+++ b/src/commands/models/list.source-plan.test.ts
@@ -56,7 +56,7 @@ describe("planAllModelListSources", () => {
     expect(mocks.hasProviderStaticCatalogForFilter).not.toHaveBeenCalled();
   });
 
-  it("uses runtime catalog plans before supplemental manifest rows for live providers", async () => {
+  it("retains refreshed manifest supplements for runtime-backed providers", async () => {
     const { planAllModelListSources } = await import("./list.source-plan.js");
     mocks.hasProviderRuntimeCatalogForFilter.mockResolvedValueOnce(true);
     mocks.loadSupplementalManifestCatalogRowsForList.mockReturnValueOnce([catalogRow]);
@@ -71,11 +71,16 @@ describe("planAllModelListSources", () => {
     expect(plan.kind).toBe("provider-runtime-scoped");
     expect(plan.requiresInitialRegistry).toBe(false);
     expect(plan.fallbackToRegistryWhenEmpty).toBe(true);
+    expect(plan.manifestCatalogRows).toEqual([catalogRow]);
     expect(mocks.loadStaticManifestCatalogRowsForList).toHaveBeenCalledWith({
       cfg: {},
       providerFilter: "openai",
     });
-    expect(mocks.loadSupplementalManifestCatalogRowsForList).not.toHaveBeenCalled();
+    expect(mocks.loadSupplementalManifestCatalogRowsForList).toHaveBeenCalledWith({
+      cfg: {},
+      providerFilter: "openai",
+      metadataSnapshot: undefined,
+    });
     expect(mocks.hasProviderStaticCatalogForFilter).not.toHaveBeenCalled();
   });
 

--- a/src/commands/models/list.source-plan.ts
+++ b/src/commands/models/list.source-plan.ts
@@ -138,6 +138,11 @@ export async function planAllModelListSources(params: {
   if (hasProviderRuntimeCatalog) {
     return createSourcePlan({
       kind: "provider-runtime-scoped",
+      manifestCatalogRows: loadSupplementalManifestCatalogRowsForList({
+        cfg: params.cfg,
+        providerFilter: params.providerFilter,
+        metadataSnapshot: params.metadataSnapshot,
+      }),
       fallbackToRegistryWhenEmpty: true,
     });
   }

--- a/src/commands/models/refresh.test.ts
+++ b/src/commands/models/refresh.test.ts
@@ -9,7 +9,13 @@ vi.mock("../../model-catalog/remote-refresh.js", () => ({
 import { modelsRefreshCommand } from "./refresh.js";
 
 function runtime() {
-  return { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+  return {
+    log: vi.fn(),
+    error: vi.fn(),
+    exit: vi.fn(),
+    writeStdout: vi.fn(),
+    writeJson: vi.fn(),
+  };
 }
 
 beforeEach(() => mocks.refresh.mockReset());
@@ -59,8 +65,23 @@ describe("models refresh", () => {
     const jsonRuntime = runtime();
     mocks.refresh.mockResolvedValueOnce({ status: "disabled", providers: 0, models: 0 });
     await modelsRefreshCommand({ json: true }, jsonRuntime);
-    expect(jsonRuntime.log).toHaveBeenCalledWith(
-      JSON.stringify({ status: "disabled", providers: 0, models: 0 }),
+    expect(jsonRuntime.writeJson).toHaveBeenCalledWith(
+      { status: "disabled", providers: 0, models: 0 },
+      0,
     );
+    expect(jsonRuntime.log).not.toHaveBeenCalled();
+  });
+
+  it("writes refresh errors to structured stdout before exiting in JSON mode", async () => {
+    const jsonRuntime = runtime();
+    const result = { status: "error", providers: 0, models: 0, error: "boom" };
+    mocks.refresh.mockResolvedValueOnce(result);
+
+    await modelsRefreshCommand({ json: true }, jsonRuntime);
+
+    expect(jsonRuntime.writeJson).toHaveBeenCalledWith(result, 0);
+    expect(jsonRuntime.exit).toHaveBeenCalledWith(1);
+    expect(jsonRuntime.log).not.toHaveBeenCalled();
+    expect(jsonRuntime.error).not.toHaveBeenCalled();
   });
 });

--- a/src/commands/models/refresh.ts
+++ b/src/commands/models/refresh.ts
@@ -1,6 +1,6 @@
 import { getRuntimeConfig } from "../../config/config.js";
 import { refreshRemoteModelCatalog } from "../../model-catalog/remote-refresh.js";
-import type { RuntimeEnv } from "../../runtime.js";
+import { type RuntimeEnv, writeRuntimeJson } from "../../runtime.js";
 
 export async function modelsRefreshCommand(
   options: { json?: boolean },
@@ -8,7 +8,7 @@ export async function modelsRefreshCommand(
 ): Promise<void> {
   const result = await refreshRemoteModelCatalog({ config: getRuntimeConfig(), force: true });
   if (options.json) {
-    runtime.log(JSON.stringify(result));
+    writeRuntimeJson(runtime, result, 0);
     if (result.status === "error") {
       runtime.exit(1);
     }


### PR DESCRIPTION
## What Problem This Solves

Fixes two independently reproduced problems in the dynamic model catalog added by #113660:

- `openclaw models refresh --json` wrote its machine-readable result to stderr, leaving stdout empty and breaking pipes, scripts, and `jq`.
- `openclaw models list --all --provider anthropic` omitted newly refreshed plugin-owned models even though the restarted Gateway correctly exposed the same models through `models.list`. The same provider-scoped planning affected other runtime-backed refreshable providers.

## Why This Change Was Made

Route refresh output through the existing structured runtime JSON writer. Carry canonical supplemental manifest catalog rows through runtime-backed, provider-scoped model planning, append only previously unseen model references, and retain live runtime discovery precedence. The change does not introduce configuration, fallback paths, transport overrides, dependency changes, SQLite schema changes, or provider ownership changes.

AI-assisted: Codex. The root causes, ownership boundaries, regression coverage, and packaged Gateway behavior were independently reviewed and verified.

## User Impact

`openclaw models refresh --json | jq .` now reads valid structured JSON from stdout. Refresh errors continue to exit nonzero. Fresh plugin-owned models are now consistently visible in both provider-filtered CLI model lists and restarted Gateway model RPC responses.

## Evidence

- Before fix, the packaged CLI exited successfully with `stdoutBytes=0` and the entire JSON refresh result on stderr.
- Before fix, a real isolated built Gateway loaded a synthetic refreshed Anthropic model from the shared SQLite catalog and exposed it over `models.list`, while `models list --all --provider anthropic` omitted it.
- After fix, a production-built, loopback-only Gateway passed all 13 real integration checks with a local mirror, 39 providers, and 218 models: published manifest; baseline absence; Gateway readiness; unchanged live snapshot; forced refresh and parseable JSON stdout; SQLite bundle and ETag; restarted Gateway RPC; provider-filtered CLI; conditional HTTP 304; disabled refresh with zero requests; disabled CLI; and disabled restarted Gateway.
- All 203 focused tests passed across catalog validation, publisher, remote refresh, SQLite store, overlay, manifest planner, provider-scoped CLI, Gateway RPC, model discovery, and startup scheduling.
- Full `pnpm build` passed, including all 142 public plugin SDK subpaths and the production control UI.
- Full `pnpm check:changed` passed: format, core and core-test typechecks, zero-error lint, provider and plugin ownership boundaries, dependency pins, schema and database guards, and runtime import cycles.
- `git diff --check` passed.
- Independent `.agents/skills/autoreview/scripts/autoreview --mode uncommitted` passed with no accepted or actionable findings; secret scanning was clean.
- Proof ran on isolated Linux Node 24.18 Testbox `tbx_01kygp8qfxh6w2hssqtf05qgxc`.
- The live hosted catalog and publisher were verified independently; the successful catalog publish run is https://github.com/openclaw/catalog/actions/runs/30228779376.
