### PR TITLE
refactor(channels): declare thread addressing as a channel trait

### DIFF
--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -953,6 +953,7 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount, SlackProbe> = crea
   },
   security: slackSecurityAdapter,
   threading: {
+    threadAddressing: "message",
     matchesToolContextTarget: ({ target, toolContext }) =>
       slackContextTargetsMatch(target, toolContext),
     scopedAccountReplyToMode: {

--- a/src/channels/plugins/types.core.ts
+++ b/src/channels/plugins/types.core.ts
@@ -359,6 +359,15 @@ export type ChannelOutboundSessionRoute = {
 };
 
 export type ChannelThreadingAdapter = {
+  /**
+   * Where the transport keeps thread identity.
+   * "address" (default): the thread is part of the routing address (own channel id, topic id
+   * in the target tuple), fully known before send.
+   * "message": thread identity lives on a message (e.g. Slack thread_ts) — replying to a
+   * message enters its thread, and routes can discover a session-scoping thread only after
+   * target lookup.
+   */
+  threadAddressing?: "address" | "message";
   matchesToolContextTarget?: (params: {
     target: string;
     toolContext: ChannelThreadingToolContext;

--- a/src/channels/thread-addressing.test.ts
+++ b/src/channels/thread-addressing.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
 import { createChannelTestPluginBase, createTestRegistry } from "../test-utils/channel-plugins.js";
-import { resolveChannelThreadAddressing } from "./thread-addressing.js";
+import {
+  channelSupportsThreadDelivery,
+  resolveChannelThreadAddressing,
+} from "./thread-addressing.js";
 
 describe("resolveChannelThreadAddressing", () => {
   beforeEach(() => {
@@ -32,5 +35,46 @@ describe("resolveChannelThreadAddressing", () => {
     );
 
     expect(resolveChannelThreadAddressing("messagechat")).toBe("message");
+  });
+});
+
+describe("channelSupportsThreadDelivery", () => {
+  beforeEach(() => {
+    setActivePluginRegistry(createTestRegistry([]));
+  });
+
+  afterEach(() => {
+    setActivePluginRegistry(createTestRegistry([]));
+  });
+
+  it("stays false for missing channels and undeclared thread capability", () => {
+    expect(channelSupportsThreadDelivery()).toBe(false);
+    expect(channelSupportsThreadDelivery("missing")).toBe(false);
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "plainchat",
+          source: "test",
+          plugin: createChannelTestPluginBase({ id: "plainchat" }),
+        },
+      ]),
+    );
+    expect(channelSupportsThreadDelivery("plainchat")).toBe(false);
+  });
+
+  it("reads declared thread capability from the loaded channel plugin", () => {
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "threadchat",
+          source: "test",
+          plugin: createChannelTestPluginBase({
+            id: "threadchat",
+            capabilities: { chatTypes: ["channel", "thread"], threads: true },
+          }),
+        },
+      ]),
+    );
+    expect(channelSupportsThreadDelivery("threadchat")).toBe(true);
   });
 });

--- a/src/channels/thread-addressing.test.ts
+++ b/src/channels/thread-addressing.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { setActivePluginRegistry } from "../plugins/runtime.js";
+import { createChannelTestPluginBase, createTestRegistry } from "../test-utils/channel-plugins.js";
+import { resolveChannelThreadAddressing } from "./thread-addressing.js";
+
+describe("resolveChannelThreadAddressing", () => {
+  beforeEach(() => {
+    setActivePluginRegistry(createTestRegistry([]));
+  });
+
+  afterEach(() => {
+    setActivePluginRegistry(createTestRegistry([]));
+  });
+
+  it("defaults missing channel metadata to address-scoped threads", () => {
+    expect(resolveChannelThreadAddressing()).toBe("address");
+    expect(resolveChannelThreadAddressing("missing")).toBe("address");
+  });
+
+  it("reads message-scoped thread identity from the loaded channel plugin", () => {
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "messagechat",
+          source: "test",
+          plugin: {
+            ...createChannelTestPluginBase({ id: "messagechat" }),
+            threading: { threadAddressing: "message" },
+          },
+        },
+      ]),
+    );
+
+    expect(resolveChannelThreadAddressing("messagechat")).toBe("message");
+  });
+});

--- a/src/channels/thread-addressing.ts
+++ b/src/channels/thread-addressing.ts
@@ -1,0 +1,9 @@
+import { getLoadedChannelPlugin } from "./plugins/index.js";
+
+/** Resolves where a loaded channel transport keeps thread identity. */
+export function resolveChannelThreadAddressing(channel?: string | null): "address" | "message" {
+  if (!channel) {
+    return "address";
+  }
+  return getLoadedChannelPlugin(channel)?.threading?.threadAddressing ?? "address";
+}

--- a/src/channels/thread-addressing.ts
+++ b/src/channels/thread-addressing.ts
@@ -7,3 +7,13 @@ export function resolveChannelThreadAddressing(channel?: string | null): "addres
   }
   return getLoadedChannelPlugin(channel)?.threading?.threadAddressing ?? "address";
 }
+
+// Thread-addressed delivery must be declared, not inferred: a route can carry a
+// threadId the transport cannot address, and posting through it would land at the
+// conversation root instead of the thread. Unloaded/unknown channels stay false.
+export function channelSupportsThreadDelivery(channel?: string | null): boolean {
+  if (!channel) {
+    return false;
+  }
+  return getLoadedChannelPlugin(channel)?.capabilities.threads === true;
+}

--- a/src/gateway/server-methods/send.test.ts
+++ b/src/gateway/server-methods/send.test.ts
@@ -14,7 +14,10 @@ import type { ChannelPlugin } from "../../channels/plugins/types.public.js";
 import type { SessionTranscriptAppendResult } from "../../config/sessions/transcript.js";
 import { setActivePluginRegistry } from "../../plugins/runtime.js";
 import { AGENT_HARNESS_SESSION_KEY_RESERVED_MESSAGE } from "../../sessions/agent-harness-session-key.js";
-import { createTestRegistry } from "../../test-utils/channel-plugins.js";
+import {
+  createChannelTestPluginBase,
+  createTestRegistry,
+} from "../../test-utils/channel-plugins.js";
 import { captureEnv, setTestEnvValue } from "../../test-utils/env.js";
 import type { GatewayRequestContext } from "./types.js";
 
@@ -443,6 +446,20 @@ function expectDeliverySessionMirror(params: { agentId: string; sessionKey: stri
 
 function mockDeliverySuccess(messageId: string) {
   mocks.deliverOutboundPayloads.mockResolvedValue([{ messageId, channel: "slack" }]);
+}
+
+function registerMessageThreadAddressingPlugin(id: ChannelPlugin["id"]): void {
+  const plugin: ChannelPlugin = {
+    ...createChannelTestPluginBase({ id }),
+    threading: { threadAddressing: "message" },
+  };
+  setActivePluginRegistry(
+    createTestRegistry([{ pluginId: id, source: "test", plugin }]),
+    `send-test-${id}-message-thread-addressing`,
+  );
+  mocks.getChannelPlugin.mockImplementation((channel: string) =>
+    channel === id ? plugin : undefined,
+  );
 }
 
 describe("gateway send mirroring", () => {
@@ -1676,6 +1693,7 @@ describe("gateway send mirroring", () => {
   });
 
   it("updates mirror session keys and delivery thread ids when Slack routing derives a thread", async () => {
+    registerMessageThreadAddressingPlugin("slack");
     mockDeliverySuccess("m-thread-derived");
     mocks.resolveOutboundSessionRoute.mockResolvedValueOnce({
       sessionKey: "agent:main:slack:channel:c1:thread:1710000000.9999",
@@ -1707,6 +1725,7 @@ describe("gateway send mirroring", () => {
   });
 
   it("preserves the provided session when Slack derives a thread for a different base session", async () => {
+    registerMessageThreadAddressingPlugin("slack");
     mockDeliverySuccess("m-thread-mismatch");
     mocks.resolveOutboundSessionRoute.mockResolvedValueOnce({
       sessionKey: "agent:main:slack:channel:c2:thread:1710000000.9999",
@@ -1733,6 +1752,7 @@ describe("gateway send mirroring", () => {
   });
 
   it("preserves derived thread delivery for existing thread-scoped Slack session keys", async () => {
+    registerMessageThreadAddressingPlugin("slack");
     mockDeliverySuccess("m-thread-session");
     mocks.resolveOutboundSessionRoute.mockResolvedValueOnce({
       sessionKey: "agent:main:slack:channel:c1:thread:1710000000.9999",
@@ -2675,6 +2695,7 @@ describe("gateway send mirroring", () => {
         handleAction: async () => jsonResult({ ok: true, messageId: "slack-1" }),
       },
       threading: {
+        threadAddressing: "message",
         matchesToolContextTarget: ({ target, toolContext }) =>
           target.toLowerCase() ===
           toolContext.currentMessagingTarget?.replace(/^user:/i, "").toLowerCase(),

--- a/src/gateway/server-methods/send.ts
+++ b/src/gateway/server-methods/send.ts
@@ -18,6 +18,7 @@ import { sendDurableMessageBatch } from "../../channels/message/runtime.js";
 import type { ConversationReadInvocationOrigin } from "../../channels/plugins/conversation-read-origin.js";
 import { dispatchChannelMessageAction } from "../../channels/plugins/message-action-dispatch.js";
 import type { ChannelThreadingToolContext } from "../../channels/plugins/types.public.js";
+import { resolveChannelThreadAddressing } from "../../channels/thread-addressing.js";
 import type { InternalChannelThreadingToolContext } from "../../channels/threading-tool-context-internal.js";
 import { createOutboundSendDeps } from "../../cli/deps.js";
 import {
@@ -799,13 +800,13 @@ export const sendHandlers: GatewayRequestHandlers = {
         const providedSessionBaseKey =
           parseThreadSessionSuffix(providedSessionKey).baseSessionKey ?? providedSessionKey;
         const shouldUseDerivedThreadSessionKey =
-          channel === "slack" &&
+          resolveChannelThreadAddressing(channel) === "message" &&
           Boolean(providedSessionKey) &&
           Boolean(normalizeOptionalString(derivedRoute?.threadId)) &&
           normalizeOptionalLowercaseString(derivedRoute?.baseSessionKey) ===
             normalizeOptionalLowercaseString(providedSessionBaseKey) &&
           normalizeOptionalLowercaseString(derivedRoute?.sessionKey) !== providedSessionKey;
-        // Slack replies can refine an existing base session into a thread session after target lookup.
+        // Message-scoped threads can refine an existing base session only after target lookup.
         const outboundRoute = derivedRoute
           ? providedSessionKey
             ? shouldUseDerivedThreadSessionKey

--- a/src/infra/outbound/message-action-runner.core-send.test.ts
+++ b/src/infra/outbound/message-action-runner.core-send.test.ts
@@ -61,6 +61,7 @@ function registerSlackTextPlugin(accountIds: string[] = ["default"]) {
             resolveAccount: () => ({ enabled: true }),
             isConfigured: () => true,
           },
+          threading: { threadAddressing: "message" },
         },
       },
     ]),
@@ -596,6 +597,40 @@ describe("runMessageAction core send routing", () => {
 
     expect(result.kind).toBe("send");
     expect(result.payload).toMatchObject({ sourceReplyRoute: "current-source" });
+  });
+
+  it("does not mark a message-scoped reply that enters a new thread as current-source", async () => {
+    registerSlackTextPlugin();
+
+    const result = await runMessageAction({
+      cfg: slackConfig,
+      action: "send",
+      params: {
+        channel: "slack",
+        target: "channel:C123",
+        message: "reply in a new thread",
+        replyTo: "1710000000.9999",
+      },
+      toolContext: {
+        currentChannelProvider: "slack",
+        currentChannelId: "channel:C123",
+      },
+      messageActionAuthorization: {
+        requesterAccountId: "default",
+        toolContext: {
+          currentChannelProvider: "slack",
+          currentChannelId: "channel:C123",
+          currentSourceTurnId: "source-turn-1",
+        },
+      },
+      sessionKey: "agent:main:slack:channel:C123",
+      defaultAccountId: "default",
+      sourceReplyDeliveryMode: "message_tool_only",
+      dryRun: false,
+    });
+
+    expect(result.kind).toBe("send");
+    expect((result.payload as { sourceReplyRoute?: unknown }).sourceReplyRoute).toBeUndefined();
   });
 
   it("does not trust ambient routing when the authorized source differs", async () => {

--- a/src/infra/outbound/source-reply-mirror.ts
+++ b/src/infra/outbound/source-reply-mirror.ts
@@ -9,6 +9,7 @@ import { normalizeOptionalTrimmedStringList } from "@openclaw/normalization-core
 import type { ReplyPayload } from "../../auto-reply/types.js";
 import { getChannelPlugin } from "../../channels/plugins/index.js";
 import type { ChannelId } from "../../channels/plugins/types.public.js";
+import { resolveChannelThreadAddressing } from "../../channels/thread-addressing.js";
 import type { InternalChannelThreadingToolContext } from "../../channels/threading-tool-context-internal.js";
 import { appendAssistantMessageToSessionTranscript } from "../../config/sessions.js";
 import { resolveStorePath } from "../../config/sessions/paths.js";
@@ -91,6 +92,7 @@ function resolveDeliveredThreadPlacement(
 
 function resolveSourceReplyThreadPlacement(
   params: SourceReplyTranscriptMirrorParams,
+  threadAddressing: ReturnType<typeof resolveChannelThreadAddressing>,
 ): SourceReplyThreadPlacement {
   const currentThreadId = normalizeOptionalString(params.toolContext?.currentThreadTs);
   const deliveredPlacement = resolveDeliveredThreadPlacement(params, currentThreadId);
@@ -101,7 +103,7 @@ function resolveSourceReplyThreadPlacement(
     return currentThreadId ? "mismatch" : "match";
   }
   if (
-    params.channel === "slack" &&
+    threadAddressing === "message" &&
     params.replyToIsExplicit === true &&
     !currentThreadId &&
     normalizeOptionalString(params.actionParams.replyTo)
@@ -288,6 +290,10 @@ function resolveTranscriptMirrorIdempotencyKey(params: {
 
 function isCurrentSourceConversation(
   params: SourceReplyTranscriptMirrorParams,
+  threadPlacement = resolveSourceReplyThreadPlacement(
+    params,
+    resolveChannelThreadAddressing(params.channel),
+  ),
 ): params is MirrorableSourceReplyTranscriptParams {
   if (params.action !== "send") {
     return false;
@@ -324,7 +330,6 @@ function isCurrentSourceConversation(
   if (!requestedTarget) {
     return false;
   }
-  const threadPlacement = resolveSourceReplyThreadPlacement(params);
   if (threadPlacement === "mismatch") {
     return false;
   }
@@ -353,9 +358,11 @@ function isCurrentSourceConversation(
 function isExactCurrentSourceConversation(
   params: SourceReplyTranscriptMirrorParams,
 ): params is MirrorableSourceReplyTranscriptParams {
-  return (
-    resolveSourceReplyThreadPlacement(params) === "match" && isCurrentSourceConversation(params)
+  const threadPlacement = resolveSourceReplyThreadPlacement(
+    params,
+    resolveChannelThreadAddressing(params.channel),
   );
+  return threadPlacement === "match" && isCurrentSourceConversation(params, threadPlacement);
 }
 
 /** Confirms that a successful send reached the exact trusted source conversation. */
@@ -372,10 +379,14 @@ export async function mirrorDeliveredSourceReplyToTranscript(
   if (hasExplicitDeliveryFailure(params.deliveredPayload)) {
     return false;
   }
-  if (!isCurrentSourceConversation(params)) {
+  const threadPlacement = resolveSourceReplyThreadPlacement(
+    params,
+    resolveChannelThreadAddressing(params.channel),
+  );
+  if (!isCurrentSourceConversation(params, threadPlacement)) {
     return false;
   }
-  if (params.sourceReplyFinal === true && !isExactCurrentSourceConversation(params)) {
+  if (params.sourceReplyFinal === true && threadPlacement !== "match") {
     return false;
   }
 

--- a/src/tasks/task-registry-delivery.ts
+++ b/src/tasks/task-registry-delivery.ts
@@ -1,5 +1,6 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { shouldRouteCompletionThroughRequesterSession } from "../auto-reply/reply/completion-delivery-policy.js";
+import { channelSupportsThreadDelivery } from "../channels/thread-addressing.js";
 import { requestHeartbeat } from "../infra/heartbeat-wake.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
 import {
@@ -125,8 +126,13 @@ function canDeliverParentReviewTaskToThreadOrigin(task: TaskRecord): boolean {
   const origin = owner.requesterOrigin;
   const threadId = String(origin?.threadId ?? "").trim();
   // Parent-review terminal messages may deliver directly only when the requester origin
-  // already names a concrete thread; root-level origins keep routing through the parent session.
-  return Boolean(threadId && canDeliverToRequesterOrigin(origin));
+  // already names a concrete thread on a transport that declares thread-addressed
+  // delivery; root-level origins keep routing through the parent session.
+  return Boolean(
+    threadId &&
+    channelSupportsThreadDelivery(origin?.channel) &&
+    canDeliverToRequesterOrigin(origin),
+  );
 }
 
 function resolveMissingOwnerDeliveryStatus(task: TaskRecord): TaskDeliveryStatus {

--- a/src/tasks/task-registry-delivery.ts
+++ b/src/tasks/task-registry-delivery.ts
@@ -128,6 +128,10 @@ function canDeliverParentReviewTaskToThreadOrigin(task: TaskRecord): boolean {
   // Parent-review terminal messages may deliver directly only when the requester origin
   // already names a concrete thread on a transport that declares thread-addressed
   // delivery; root-level origins keep routing through the parent session.
+  // Deliberately no target-shape parsing here: threadId provenance is the channel's own
+  // route/binding projection, so core trusts the tuple. A stray threadId on a non-thread
+  // target degrades to delivery at that origin's root, and send failures fall back to the
+  // parent-session queue below — the handoff cannot be lost.
   return Boolean(
     threadId &&
     channelSupportsThreadDelivery(origin?.channel) &&

--- a/src/tasks/task-registry-delivery.ts
+++ b/src/tasks/task-registry-delivery.ts
@@ -117,23 +117,16 @@ function canDeliverToRequesterOrigin(origin: TaskDeliveryState["requesterOrigin"
   return Boolean(channel && to && isDeliverableMessageChannel(channel));
 }
 
-function canDeliverParentReviewTaskToBoundDiscordThread(task: TaskRecord): boolean {
+function canDeliverParentReviewTaskToThreadOrigin(task: TaskRecord): boolean {
   if (!shouldUseParentReviewTaskTerminalMessage(task)) {
     return false;
   }
   const owner = resolveTaskDeliveryOwner(task);
   const origin = owner.requesterOrigin;
-  const channel = origin?.channel?.trim().toLowerCase();
-  const to = origin?.to?.trim().toLowerCase();
   const threadId = String(origin?.threadId ?? "").trim();
-  // This is a narrow transport exception for explicitly bound Discord threads,
-  // not a general parent-review direct-delivery relaxation.
-  return Boolean(
-    channel === "discord" &&
-    to?.startsWith("channel:") &&
-    threadId &&
-    canDeliverToRequesterOrigin(origin),
-  );
+  // Parent-review terminal messages may deliver directly only when the requester origin
+  // already names a concrete thread; root-level origins keep routing through the parent session.
+  return Boolean(threadId && canDeliverToRequesterOrigin(origin));
 }
 
 function resolveMissingOwnerDeliveryStatus(task: TaskRecord): TaskDeliveryStatus {
@@ -267,7 +260,7 @@ async function maybeDeliverTaskTerminalUpdateUnderAdmission(
       });
     }
     const shouldRouteParentReview = shouldUseParentReviewTaskTerminalMessage(latest);
-    const shouldDeliverParentReviewDirect = canDeliverParentReviewTaskToBoundDiscordThread(latest);
+    const shouldDeliverParentReviewDirect = canDeliverParentReviewTaskToThreadOrigin(latest);
     const canDeliverDirect =
       canDeliverTaskToRequesterOrigin(latest) || shouldDeliverParentReviewDirect;
     const directEventText = formatTaskTerminalMessage(latest);

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -153,6 +153,14 @@ vi.mock("../utils/message-channel.js", () => ({
     channel === "slack",
 }));
 
+// Thread-addressed direct delivery requires the transport to declare capabilities.threads;
+// guildchat stays undeclared so tests can pin the deliverable-but-not-thread-capable fallback.
+vi.mock("../channels/thread-addressing.js", () => ({
+  channelSupportsThreadDelivery: (channel?: string | null) =>
+    channel === "discord" || channel === "slack",
+  resolveChannelThreadAddressing: () => "address" as const,
+}));
+
 function configureTaskRegistryMaintenanceRuntimeForTest(params: {
   currentTasks: Map<string, ReturnType<typeof createTaskFixture>>;
   snapshotTasks: ReturnType<typeof createTaskFixture>[];
@@ -1864,6 +1872,57 @@ describe("task-registry", () => {
         "Next: parent will review/verify before calling it done.",
       );
       expect(peekSystemEvents(origin.ownerKey)).toStrictEqual([]);
+    });
+  });
+
+  it("keeps delegated ACP completion queued when the transport does not declare thread delivery", async () => {
+    await withTaskRegistryTempDir(async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskRegistryForTests();
+      const runId = "run-guildchat-thread-terminal";
+      // guildchat is deliverable but declares no thread capability, so a thread-shaped
+      // origin must keep routing through the parent session instead of direct delivery.
+      const requesterOrigin = {
+        channel: "guildchat",
+        to: "channel:room-9",
+        threadId: "thread-77",
+      };
+      hoisted.sendMessageMock.mockResolvedValue({
+        channel: requesterOrigin.channel,
+        to: requesterOrigin.to,
+        via: "direct",
+      });
+
+      createAcpTaskRecord({
+        ownerKey: "agent:main:guildchat:channel:room-9",
+        requesterOrigin,
+        runId,
+        task: "Investigate thread-bound ACP delivery",
+        terminalSummary: "ACP final answer",
+        startedAt: 100,
+      });
+
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: {
+          phase: "end",
+          endedAt: 250,
+        },
+      });
+
+      await waitForAssertion(() => {
+        const task = findTaskByRunId(runId);
+        if (!task) {
+          throw new Error(`Expected task for run ${runId}`);
+        }
+        expect(task.status).toBe("succeeded");
+        expect(task.deliveryStatus).toBe("session_queued");
+      });
+      expect(hoisted.sendMessageMock).not.toHaveBeenCalled();
+      expect(peekSystemEvents("agent:main:guildchat:channel:room-9")).toEqual([
+        expect.stringContaining("Background task ready for review: ACP background task"),
+      ]);
     });
   });
 

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -147,7 +147,10 @@ vi.mock("../agents/subagent-control.js", () => ({
 
 vi.mock("../utils/message-channel.js", () => ({
   isDeliverableMessageChannel: (channel: string) =>
-    channel === "notifychat" || channel === "guildchat" || channel === "discord",
+    channel === "notifychat" ||
+    channel === "guildchat" ||
+    channel === "discord" ||
+    channel === "slack",
 }));
 
 function configureTaskRegistryMaintenanceRuntimeForTest(params: {
@@ -1670,7 +1673,6 @@ describe("task-registry", () => {
         requesterOrigin: {
           channel: "notifychat",
           to: "notifychat:123",
-          threadId: "321",
         },
         runId: "run-delivery",
         task: "Investigate issue",
@@ -1791,23 +1793,38 @@ describe("task-registry", () => {
     });
   });
 
-  it("delivers delegated ACP completion directly to an explicitly bound Discord thread", async () => {
+  it.each([
+    {
+      name: "Discord",
+      channel: "discord",
+      to: "channel:parent-channel",
+      threadId: "thread-84022",
+      ownerKey: "agent:main:discord:guild-123:channel-parent-channel",
+    },
+    {
+      name: "Slack",
+      channel: "slack",
+      to: "channel:C123",
+      threadId: "1710000000.9999",
+      ownerKey: "agent:main:slack:channel:c123",
+    },
+  ])("delivers delegated ACP completion directly to a $name thread origin", async (origin) => {
     await withTaskRegistryTempDir(async (root) => {
       process.env.OPENCLAW_STATE_DIR = root;
       resetTaskRegistryForTests();
-      const runId = "run-bound-discord-thread-terminal";
+      const runId = `run-${origin.channel}-thread-terminal`;
       hoisted.sendMessageMock.mockResolvedValue({
-        channel: "discord",
-        to: "channel:parent-channel",
+        channel: origin.channel,
+        to: origin.to,
         via: "direct",
       });
 
       createAcpTaskRecord({
-        ownerKey: "agent:main:discord:guild-123:channel-parent-channel",
+        ownerKey: origin.ownerKey,
         requesterOrigin: {
-          channel: "discord",
-          to: "channel:parent-channel",
-          threadId: "thread-84022",
+          channel: origin.channel,
+          to: origin.to,
+          threadId: origin.threadId,
         },
         runId,
         task: "Investigate thread-bound ACP delivery",
@@ -1835,9 +1852,9 @@ describe("task-registry", () => {
       await waitForAssertion(() => expect(hoisted.sendMessageMock).toHaveBeenCalledTimes(1));
       const message = sentMessageCall();
       expectRecordFields(message, {
-        channel: "discord",
-        to: "channel:parent-channel",
-        threadId: "thread-84022",
+        channel: origin.channel,
+        to: origin.to,
+        threadId: origin.threadId,
       });
       expect(String(message.content)).toContain(
         "Background task ready for review: ACP background task",
@@ -1846,82 +1863,57 @@ describe("task-registry", () => {
       expect(String(message.content)).toContain(
         "Next: parent will review/verify before calling it done.",
       );
-      expect(peekSystemEvents("agent:main:discord:guild-123:channel-parent-channel")).toStrictEqual(
-        [],
-      );
+      expect(peekSystemEvents(origin.ownerKey)).toStrictEqual([]);
     });
   });
 
-  it.each([
-    {
-      id: "missing-thread",
-      requesterOrigin: {
+  it("keeps delegated ACP completion queued when the requester origin has no thread", async () => {
+    await withTaskRegistryTempDir(async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskRegistryForTests();
+      const runId = "run-root-discord-terminal";
+      const requesterOrigin = {
         channel: "discord",
         to: "channel:parent-channel",
-      },
-    },
-    {
-      id: "non-channel-target",
-      requesterOrigin: {
-        channel: "discord",
-        to: "user:U123",
-        threadId: "thread-84022",
-      },
-    },
-    {
-      id: "non-discord-channel",
-      requesterOrigin: {
-        channel: "guildchat",
-        to: "guildchat:channel:parent-channel",
-        threadId: "thread-84022",
-      },
-    },
-  ])(
-    "keeps delegated ACP completion queued without an explicit bound Discord thread ($id)",
-    async ({ requesterOrigin }) => {
-      await withTaskRegistryTempDir(async (root) => {
-        process.env.OPENCLAW_STATE_DIR = root;
-        resetTaskRegistryForTests();
-        const runId = `run-non-bound-discord-thread-terminal-${requesterOrigin.channel}-${requesterOrigin.to}`;
-        hoisted.sendMessageMock.mockResolvedValue({
-          channel: requesterOrigin.channel,
-          to: requesterOrigin.to,
-          via: "direct",
-        });
-
-        createAcpTaskRecord({
-          ownerKey: "agent:main:discord:guild-123:channel-parent-channel",
-          requesterOrigin,
-          runId,
-          task: "Investigate thread-bound ACP delivery",
-          terminalSummary: "ACP final answer",
-          startedAt: 100,
-        });
-
-        emitAgentEvent({
-          runId,
-          stream: "lifecycle",
-          data: {
-            phase: "end",
-            endedAt: 250,
-          },
-        });
-
-        await waitForAssertion(() => {
-          const task = findTaskByRunId(runId);
-          if (!task) {
-            throw new Error(`Expected task for run ${runId}`);
-          }
-          expect(task.status).toBe("succeeded");
-          expect(task.deliveryStatus).toBe("session_queued");
-        });
-        expect(hoisted.sendMessageMock).not.toHaveBeenCalled();
-        expect(peekSystemEvents("agent:main:discord:guild-123:channel-parent-channel")).toEqual([
-          expect.stringContaining("Background task ready for review: ACP background task"),
-        ]);
+      };
+      hoisted.sendMessageMock.mockResolvedValue({
+        channel: requesterOrigin.channel,
+        to: requesterOrigin.to,
+        via: "direct",
       });
-    },
-  );
+
+      createAcpTaskRecord({
+        ownerKey: "agent:main:discord:guild-123:channel-parent-channel",
+        requesterOrigin,
+        runId,
+        task: "Investigate thread-bound ACP delivery",
+        terminalSummary: "ACP final answer",
+        startedAt: 100,
+      });
+
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: {
+          phase: "end",
+          endedAt: 250,
+        },
+      });
+
+      await waitForAssertion(() => {
+        const task = findTaskByRunId(runId);
+        if (!task) {
+          throw new Error(`Expected task for run ${runId}`);
+        }
+        expect(task.status).toBe("succeeded");
+        expect(task.deliveryStatus).toBe("session_queued");
+      });
+      expect(hoisted.sendMessageMock).not.toHaveBeenCalled();
+      expect(peekSystemEvents("agent:main:discord:guild-123:channel-parent-channel")).toEqual([
+        expect.stringContaining("Background task ready for review: ACP background task"),
+      ]);
+    });
+  });
 
   it.each([
     {
@@ -2141,7 +2133,6 @@ describe("task-registry", () => {
         requesterOrigin: {
           channel: "notifychat",
           to: "notifychat:123",
-          threadId: "321",
         },
         runId: "run-detail-leak",
         task: "Create the file and verify it",


### PR DESCRIPTION
## What Problem This Solves

Three core production sites branched on channel ids to make delivery and threading decisions:

- `src/infra/outbound/source-reply-mirror.ts` — `channel === "slack"` to classify reply placement
- `src/gateway/server-methods/send.ts` — `channel === "slack"` to gate derived thread session keys
- `src/tasks/task-registry-delivery.ts` — `channel === "discord" && to.startsWith("channel:")` to
  gate direct parent-review delivery

Root `AGENTS.md`: channels are transport-only and core stays generic; typed declarations, not id
inference. The Discord case also had a comment claiming it gated on "explicitly bound Discord
threads" while the code never consulted the binding subsystem at all — it matched any Discord
thread-shaped origin by string shape.

## Why This Change Was Made

The two Slack branches are one underlying transport fact stated twice. Bundled channels differ in
*where thread identity lives*: Discord threads are child channels (the thread id IS the address),
Telegram topics ride the target tuple, but Slack alone keeps thread identity on the message
(`thread_ts`) — so replying enters a thread, and a session-scoping thread can only be discovered
after route lookup. That is now a declared static trait on the existing `ChannelThreadingAdapter`:

    threadAddressing?: "address" | "message"   // default "address"; Slack declares "message"

following the same static-declaration precedent as `allowExplicitReplyTagsWhenOff` (no new
callbacks — the plugin declares one bit, core keeps the algorithms). A 9-line reader
(`src/channels/thread-addressing.ts`) resolves the trait from the loaded plugin snapshot —
process-stable metadata, no freshness polling — and both Slack branches now key off it.
`source-reply-mirror` also computes placement once and threads it through instead of re-deriving it
three times.

The Discord gate is replaced by the generic contract the code was actually approximating:
parent-review terminal messages deliver directly only when the requester origin names a concrete
thread AND the transport declares thread-addressed delivery (the existing
`ChannelCapabilities.threads` bit, which every thread-capable bundled channel already declares —
Discord, Slack, Telegram, Matrix, MSTeams). A threadId alone is not proof the route can address a
thread: a transport that ignores it would post at the conversation root, so undeclared or unloaded
channels fail safe into parent-session routing. This also makes `capabilities.threads`
load-bearing rather than display-only, which is what the capability contract is for. A
binding-service lookup at delivery time was considered and rejected: bindings are released by
terminal-task-cleanup and deliveries can retry after restarts, so a live lookup would make delivery
depend on sweep timing.

## User Impact

Two intentional deltas, both named and tested:

- **Non-Discord thread origins now deliver parent-review results directly** (e.g. a review spawned
  from a Slack thread or Telegram topic), provided the transport declares
  `capabilities.threads`. Previously only Discord thread-shaped origins qualified; other channels
  fell back to parent-session routing. This is the generic rule, not an accident.
- **Thread-shaped origins on transports without declared thread capability now fall back to
  parent-session routing** (previously the Discord id-gate excluded them implicitly; now the
  exclusion is a declared contract, pinned by a dedicated test).
- **Core contains no channel ids in these paths** — the only string literals removed from core are
  `"discord"`, `"slack"`, and `"channel:"` (verified by literal-diffing the touched files).

Discord behavior is unchanged (threadId was already required); origins without a threadId are
unchanged (no direct delivery). Slack mirror/send behavior is unchanged (trait resolves to the same
branch).

## Evidence

Verified beyond the diff: string-literal diff across touched core files shows exactly the three
removed id literals and nothing else; export audit confirms the one new export has three external
consumers (a prior PR failed Knip on implementation-only exports, so this is now checked up front).

    src/tasks/task-registry.test.ts        119 passed   exit 0
    src/gateway/server-methods/send.test.ts 78 passed   exit 0
    src/channels/thread-addressing.test.ts   4 passed   exit 0
    message-action-runner.core-send.test.ts 22 passed   exit 0
    extensions/slack (Blacksmith Testbox) 1972 passed across 125 files   exit 0
    node scripts/run-tsgo.mjs -p tsconfig.core.json   exit 0
    node scripts/check-changed.mjs   exit 0 (import cycles: 0)
    plugin-sdk surface check (remote)   exit 0

Deleted tests covered only the removed gates (non-Discord-never-delivers, target-prefix shape);
replacements pin the deltas above, including a dedicated case for a deliverable transport without
declared thread capability falling back to parent-session routing.

One autoreview finding is consciously rejected and recorded at the code site: it asked for
target-shape validation (e.g. rejecting a Discord `user:` target carrying a threadId) or an
adapter-level predicate. Both are the shapes this PR removes — channel target grammar parsed in
core, or channel logic in plugins. The state requires a channel to emit a threadId on a
non-thread target, which none do (origins are the channels' own route/binding projections); if it
ever occurred, delivery lands at that origin's own conversation root, and the send-failure path
already queues the parent-session fallback, so the review handoff cannot be lost. Named as an
accepted tradeoff per repo policy rather than guarded speculatively. Broad `src/infra/outbound` and `src/channels` directory
sweeps show pre-existing non-isolated mock collisions unrelated to this change; the affected files
pass under their proper focused configs.
