### PR TITLE
fix(scripts): make the mock Control UI exec approval opt-in via --fixture=approval

### DIFF
--- a/scripts/control-ui-mock-dev.ts
+++ b/scripts/control-ui-mock-dev.ts
@@ -24,7 +24,7 @@ import { buildSkillWorkshopMocks } from "./control-ui-mock-skill-workshop.js";
 
 type CliOptions = {
   allowedHosts: string[];
-  fixture?: "board" | "swarm";
+  fixture?: "approval" | "board" | "swarm";
   host: string;
   port: number;
 };
@@ -140,11 +140,11 @@ function parseArgs(args: string[]): CliOptions {
   return options;
 }
 
-function parseFixture(value: string | undefined): "board" | "swarm" | undefined {
+function parseFixture(value: string | undefined): CliOptions["fixture"] {
   if (!value) {
     return undefined;
   }
-  if (value !== "board" && value !== "swarm") {
+  if (value !== "approval" && value !== "board" && value !== "swarm") {
     throw new Error(`Unknown Control UI mock fixture: ${value}`);
   }
   return value;
@@ -1415,10 +1415,12 @@ async function createChatPickerScenario(
           },
         ],
       },
+      // Pending exec approvals reopen as a blocking modal on every page load
+      // (connect-time exec.approval.list recovery), so the demo approval is
+      // opt-in via --fixture=approval instead of polluting the default mock.
       "exec.approval.list":
-        fixture === "swarm"
-          ? []
-          : [
+        fixture === "approval"
+          ? [
               {
                 id: "mock-production-export-approval",
                 request: {
@@ -1428,7 +1430,8 @@ async function createChatPickerScenario(
                 createdAtMs: baseTime - 75_000,
                 expiresAtMs: ATTENTION_FIXTURE_EXPIRES_AT,
               },
-            ],
+            ]
+          : [],
       "plugin.approval.list": [],
       "openclaw.approval.list": [],
       "sessions.patch": { ok: true },


### PR DESCRIPTION
## What Problem This Solves

Every `pnpm dev:ui:mock` startup (the Control UI mock dev server, default port 5187) greets the developer with a blocking "Exec approval needed" modal for the seeded `openclaw export --target production` fixture, on every page and after every reload. The fixture expires in 2099, so the dialog also renders an absurd `expires in 38096493:38` countdown. Deny/refresh cannot get rid of it because the mock's `exec.approval.list` response is static and the app re-recovers pending approvals on every connect (`ui/src/app/exec-approval.ts` connect-time `exec.approval.list` recovery) — that modal-on-recovery behavior is intentional product behavior, so the fix belongs in the mock fixture.

## Why This Change Was Made

The pending approval was seeded in #111035 to exercise the sidebar attention states; the always-on blocking modal is collateral. This PR makes the demo approval opt-in via a new `--fixture=approval` value on the existing fixture switch in `scripts/control-ui-mock-dev.ts`. The default mock (and `board`/`swarm` fixtures) no longer seed a pending exec approval; the sidebar attention zone stays exercised by the still-seeded pending question fixture (`question.list`). A comment at the fixture records why it is gated.

## User Impact

Developer-only (mock dev harness; the script is not part of the packaged build). Default `pnpm dev:ui:mock` starts clean; `pnpm dev:ui:mock --fixture=approval` shows the exec approval dialog for anyone iterating on that UI. No product, config, or test surface changes — the approval e2e suites build their own gateway harness and do not consume this fixture.

## Evidence

- `node scripts/check-changed.mjs -- scripts/control-ui-mock-dev.ts` green (0 lint/type findings; delegated run exit 0).
- Visual proof, both directions: default server on 5187 renders `/settings/labs` with no modal; `--fixture=approval` on a second port shows the same "Exec approval needed" dialog as before (command, session key, Allow once / Always allow / Deny).
- `rg mock-production-export-approval` confirms no test or helper depends on the default seed.
