### PR TITLE
docs: explain why steering waits for the current tool-call batch

### DIFF
--- a/docs/concepts/queue-steering.md
+++ b/docs/concepts/queue-steering.md
@@ -2,6 +2,7 @@
 summary: "How active-run steering queues messages at runtime boundaries"
 read_when:
   - Explaining how steer behaves while an agent is using tools
+  - Explaining why steering does not cancel an in-flight tool-call batch
   - Changing active-run queue behavior or runtime steering integration
   - Comparing steering with followup, collect, and interrupt queue modes
 title: "Steering queue"
@@ -26,6 +27,16 @@ This keeps tool results paired with the assistant message that requested them, t
 The native Codex app-server harness exposes `turn/steer` instead of OpenClaw runtime's internal steering queue. OpenClaw batches queued prompts for the configured quiet window, then sends a single `turn/steer` request with all collected user input in arrival order.
 
 Codex review and manual compaction turns reject same-turn steering. When a runtime cannot accept steering in `steer` mode, OpenClaw waits for the active run to finish before starting the prompt.
+
+## Why steering waits for the current batch
+
+Steering applies corrections at the next model step instead of cancelling tool calls the assistant already requested. This is a deliberate design decision, not a missing feature:
+
+- A tool-call batch is one unit of work. When the model requests several tool calls in one assistant message, they usually depend on each other, for example edits across multiple files. Cancelling the not-yet-started calls leaves that work half applied, and the next model step typically has to redo the whole batch to get back to a consistent state.
+- Every tool call keeps a real result. Dropping requested calls means fabricating aborted results for them, and models routinely misread synthetic failures as real ones, then retry or route around tools that never actually failed.
+- The context stays append-only. Steered messages are appended at the tail, so nothing already sent to the model is rewritten and provider prompt caches stay valid.
+
+The wait is bounded by the current tool-call batch, not by the run: a steered correction is visible to the model at its next reasoning step. Stopping the current work is a different intent than redirecting it; use `/queue interrupt` (or `/stop`) when the newest message should abort the active run instead of steering it.
 
 ## Modes
 

--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -2929,6 +2929,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
 - Route: /concepts/queue-steering
 - Headings:
   - H2: Runtime boundary
+  - H2: Why steering waits for the current batch
   - H2: Modes
   - H2: Burst example
   - H2: Scope


### PR DESCRIPTION
## What Problem This Solves

The steering docs describe *that* steer waits for the current tool-call batch but not *why*. Users coming from other agent tools keep filing requests for mid-batch interruption (most recently tracked in #10960), and the docs give reviewers and triage nothing durable to point at when explaining that this is a deliberate design decision rather than a missing feature.

## Why This Change Was Made

Adds a "Why steering waits for the current batch" section to `docs/concepts/queue-steering.md` stating the rationale in generic terms: tool-call batches are treated as one unit of work (cancelling mid-batch leaves half-applied state the model must redo), every tool call keeps a real result (models misread fabricated aborted results and retry or route around healthy tools), and steering stays append-only so provider prompt caches remain valid. It also names the supported alternative for the "stop now" intent (`/queue interrupt`, `/stop`). Adds a matching `read_when` entry so the page is discoverable for this question.

## User Impact

Docs-only. Users and triage now have a canonical explanation of steer-vs-interrupt intent and the batch-boundary contract; no runtime behavior changes.

## Evidence

- Docs-only diff: `docs/concepts/queue-steering.md` (+11 lines, one new section plus one `read_when` bullet).
- `git diff --check` clean; Mintlify link/heading rules followed (no em dashes or apostrophes in the new heading, root-relative links unchanged).
- Rationale matches shipped behavior documented in the same page ("Runtime boundary") and `docs/concepts/queue.md` (`steer` does not abort in-flight tools; `interrupt` aborts the active run).
