### PR TITLE
fix: avoid recursive search tool summaries (issue #113401)

### DIFF
--- a/src/agents/tool-display-exec.ts
+++ b/src/agents/tool-display-exec.ts
@@ -118,6 +118,9 @@ function summarizeKnownExec(words: string[]): string {
     const pattern = optionValue(words, ["-e", "--regexp"]) ?? positional[0];
     const target = positional.length > 1 ? positional.at(-1) : undefined;
     if (pattern) {
+      if (isUnsafeSearchSummaryPattern(pattern)) {
+        return target ? `search text in ${target}` : "search text";
+      }
       return target ? `search "${pattern}" in ${target}` : `search "${pattern}"`;
     }
     return "search text";
@@ -288,6 +291,17 @@ function summarizeKnownExec(words: string[]): string {
     return `run ${bin}`;
   }
   return /^[A-Za-z0-9._/-]+$/.test(arg) ? `run ${bin} ${arg}` : `run ${bin}`;
+}
+
+function isUnsafeSearchSummaryPattern(pattern: string): boolean {
+  const trimmed = pattern.trim();
+  return (
+    trimmed.length > 120 ||
+    /[\r\n`]/u.test(trimmed) ||
+    /^Bash failed:/iu.test(trimmed) ||
+    /^search(?:\s|$)/iu.test(trimmed) ||
+    /\|\s*search(?:\s|$)/iu.test(trimmed)
+  );
 }
 
 function summarizePipeline(stage: string): string {

--- a/src/agents/tool-display-exec.ts
+++ b/src/agents/tool-display-exec.ts
@@ -299,8 +299,8 @@ function isUnsafeSearchSummaryPattern(pattern: string): boolean {
     trimmed.length > 120 ||
     /[\r\n`]/u.test(trimmed) ||
     /^Bash failed:/iu.test(trimmed) ||
-    /^search(?:\s|$)/iu.test(trimmed) ||
-    /\|\s*search(?:\s|$)/iu.test(trimmed)
+    /^search\s+["'][^"'\r\n]+["'](?:\s+in\s+\S.*)?$/iu.test(trimmed) ||
+    /\|\s*search\s+["'][^"'\r\n]+["'](?:\s+in\s+\S.*)?(?:\||$)/iu.test(trimmed)
   );
 }
 

--- a/src/agents/tool-display.test.ts
+++ b/src/agents/tool-display.test.ts
@@ -213,27 +213,41 @@ describe("tool display details", () => {
   });
 
   it("keeps normal search patterns concise", () => {
-    const detail = formatToolDetail(
-      resolveToolDisplay({
-        name: "exec",
-        args: { command: 'rg "foo|bar" src/agents' },
-        detailMode: "explain",
-      }),
-    );
+    const cases = [
+      ['rg "foo|bar" src/agents', 'search "foo|bar" in src/agents'],
+      ["rg search src/agents", 'search "search" in src/agents'],
+    ];
 
-    expect(detail).toBe('search "foo|bar" in src/agents');
+    for (const [command, expected] of cases) {
+      const detail = formatToolDetail(
+        resolveToolDisplay({
+          name: "exec",
+          args: { command },
+          detailMode: "explain",
+        }),
+      );
+
+      expect(detail).toBe(expected);
+    }
   });
 
   it("uses a neutral label for recursive search summary patterns", () => {
-    const detail = formatToolDetail(
-      resolveToolDisplay({
-        name: "exec",
-        args: { command: 'rg "Bash failed: search \\"foo\\" in src|search \\"bar\\"" src' },
-        detailMode: "explain",
-      }),
-    );
+    const cases = [
+      'rg "search \\"foo\\" in src/agents" src',
+      'rg "Bash failed: search \\"foo\\" in src|search \\"bar\\"" src',
+    ];
 
-    expect(detail).toBe("search text in src");
+    for (const command of cases) {
+      const detail = formatToolDetail(
+        resolveToolDisplay({
+          name: "exec",
+          args: { command },
+          detailMode: "explain",
+        }),
+      );
+
+      expect(detail).toBe("search text in src");
+    }
   });
 
   it("summarizes bash commands with the same command explainer", () => {

--- a/src/agents/tool-display.test.ts
+++ b/src/agents/tool-display.test.ts
@@ -212,6 +212,30 @@ describe("tool display details", () => {
     expect(detail).toContain("(agent)");
   });
 
+  it("keeps normal search patterns concise", () => {
+    const detail = formatToolDetail(
+      resolveToolDisplay({
+        name: "exec",
+        args: { command: 'rg "foo|bar" src/agents' },
+        detailMode: "explain",
+      }),
+    );
+
+    expect(detail).toBe('search "foo|bar" in src/agents');
+  });
+
+  it("uses a neutral label for recursive search summary patterns", () => {
+    const detail = formatToolDetail(
+      resolveToolDisplay({
+        name: "exec",
+        args: { command: 'rg "Bash failed: search \\"foo\\" in src|search \\"bar\\"" src' },
+        detailMode: "explain",
+      }),
+    );
+
+    expect(detail).toBe("search text in src");
+  });
+
   it("summarizes bash commands with the same command explainer", () => {
     const detail = formatToolDetail(
       resolveToolDisplay({


### PR DESCRIPTION
Closes #113401

## What Problem This Solves

Fixes an issue where users inspecting exec tool output could see recursive or malformed search summaries such as nested `search "..." in ...` text when an extracted `rg`/`grep` pattern already resembled prior display output.

## Why This Change Was Made

The exec display formatter now keeps normal concise search summaries, but falls back to a neutral `search text` label only when a search pattern looks like already-rendered output, multiline text, or other unsafe presentation content. This stays in the display boundary and does not change shell execution.

## User Impact

Tool timelines and transcript cards stay readable when search commands fail or include recursive display text, while ordinary `rg` and `grep` summaries continue to show the searched pattern and target.

AI-assisted: yes.
Maintainer edits: enabled.

## Evidence

- Formatter runtime proof on head `e3aa13cba9dbbe51d48819c3cbacec5dab354e19`: `rg search src/agents` rendered `🛠️ search "search" in src/agents`, while `rg "search \"foo\" in src/agents" src` rendered `🛠️ search text in src`.
- `node scripts/run-vitest.mjs src/agents/tool-display.test.ts` passed: 1 file, 56 tests.
- `git diff --check -- src/agents/tool-display-exec.ts src/agents/tool-display.test.ts` passed.
- `node_modules\.bin\oxfmt.CMD --check src/agents/tool-display-exec.ts src/agents/tool-display.test.ts` passed.
- `trufflehog filesystem src/agents/tool-display-exec.ts src/agents/tool-display.test.ts --no-update --no-color --results=verified,unknown --fail --fail-on-scan-errors` passed: 0 verified and 0 unverified secrets.