### PR TITLE
feat(runtime): run OpenClaw under Bun runtimes that provide node:sqlite

### DIFF
--- a/docs/install/bun.md
+++ b/docs/install/bun.md
@@ -7,24 +7,20 @@ title: "Bun"
 ---
 
 <Warning>
-Bun cannot run the OpenClaw CLI or Gateway because it does not provide the required `node:sqlite` API. Install a supported Node version for all OpenClaw runtime commands.
+Bun releases up to 1.3.x cannot run the OpenClaw CLI or Gateway because they do not provide the required `node:sqlite` API. OpenClaw feature-probes the runtime: Bun builds that ship `node:sqlite` (1.4.0 canary and later) can run the CLI and Gateway experimentally, while older Bun versions are rejected at startup. Node remains the supported and recommended runtime for all OpenClaw runtime commands.
 </Warning>
 
-Bun remains usable as an optional dependency installer and package-script runner. The default package manager remains `pnpm`, which is fully supported and used by docs tooling. Bun cannot use `pnpm-lock.yaml` and ignores it.
+Bun remains usable as an optional package-script runner. The default package manager remains `pnpm`, which is fully supported and used by docs tooling. Bun cannot use `pnpm-lock.yaml` and ignores it, and current Bun versions fail to resolve this repo's `pnpm-workspace.yaml` layout during `bun install`, so dependency installs should use `pnpm install`.
 
 ## Install
 
 <Steps>
   <Step title="Install dependencies">
     ```sh
-    bun install
+    pnpm install
     ```
 
-    `bun.lock` / `bun.lockb` are gitignored, so there is no repo churn. To skip lockfile writes entirely:
-
-    ```sh
-    bun install --no-save
-    ```
+    Current Bun versions (including 1.4 canary) cannot resolve this repo's pnpm workspace layout, so `bun install` fails during workspace resolution. Use `pnpm install`.
 
   </Step>
   <Step title="Build and test">
@@ -33,7 +29,7 @@ Bun remains usable as an optional dependency installer and package-script runner
     bun run vitest run
     ```
 
-    Commands that launch OpenClaw itself must still run through Node.
+    Commands that launch OpenClaw itself should still run through Node; Bun runtimes that provide `node:sqlite` (1.4.0 canary and later) can run them experimentally.
 
   </Step>
 </Steps>

--- a/openclaw.mjs
+++ b/openclaw.mjs
@@ -49,8 +49,19 @@ const isSupportedNodeVersion = (version) => {
 
 const ensureSupportedRuntimeVersion = () => {
   if (process.versions.bun) {
+    // Bun >=1.4 (Rust rewrite) ships node:sqlite; feature-probe instead of
+    // rejecting Bun outright so capable Bun builds can run OpenClaw.
+    let hasNodeSqlite = false;
+    try {
+      hasNodeSqlite = Boolean(process.getBuiltinModule?.("node:sqlite"));
+    } catch {
+      hasNodeSqlite = false;
+    }
+    if (hasNodeSqlite) {
+      return;
+    }
     process.stderr.write(
-      "openclaw: the Bun runtime is unsupported because OpenClaw requires node:sqlite.\n" +
+      "openclaw: this Bun runtime is unsupported because it does not provide node:sqlite.\n" +
         `Use Node.js ${SUPPORTED_NODE_RANGE}; Bun remains supported for installs and package scripts.\n`,
     );
     process.exit(1);

--- a/src/infra/runtime-guard.test.ts
+++ b/src/infra/runtime-guard.test.ts
@@ -79,6 +79,7 @@ describe("runtime-guard", () => {
       version: "20.0.0",
       execPath: "/usr/bin/node",
       pathEnv: "/usr/bin",
+      hasNodeSqlite: false,
     };
     expect(() => assertSupportedRuntime(runtime, details)).toThrow("exit");
     expect(runtime.error).toHaveBeenCalledOnce();
@@ -105,12 +106,31 @@ describe("runtime-guard", () => {
       version: "22.22.3",
       execPath: "/usr/bin/node",
       pathEnv: "/usr/bin",
+      hasNodeSqlite: true,
     };
     expect(assertSupportedRuntime(runtime, details)).toBeUndefined();
     expect(runtime.exit).not.toHaveBeenCalled();
   });
 
-  it("rejects Bun because it does not provide node:sqlite", () => {
+  it("accepts Bun when the runtime provides node:sqlite", () => {
+    const runtime = {
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: vi.fn(),
+    };
+    const details = {
+      kind: "bun" as const,
+      version: "1.4.0",
+      execPath: "/usr/bin/bun",
+      pathEnv: "/usr/bin",
+      hasNodeSqlite: true,
+    };
+    expect(assertSupportedRuntime(runtime, details)).toBeUndefined();
+    expect(runtime.exit).not.toHaveBeenCalled();
+    expect(runtime.error).not.toHaveBeenCalled();
+  });
+
+  it("rejects Bun when it does not provide node:sqlite", () => {
     const runtime = {
       log: vi.fn(),
       error: vi.fn(),
@@ -123,6 +143,7 @@ describe("runtime-guard", () => {
       version: "1.3.14",
       execPath: "/usr/bin/bun",
       pathEnv: "/usr/bin",
+      hasNodeSqlite: false,
     };
 
     expect(() => assertSupportedRuntime(runtime, details)).toThrow("exit");
@@ -150,6 +171,7 @@ describe("runtime-guard", () => {
       version: null,
       execPath: null,
       pathEnv: "(not set)",
+      hasNodeSqlite: false,
     };
 
     expect(() => assertSupportedRuntime(runtime, details)).toThrow("exit");

--- a/src/infra/runtime-guard.ts
+++ b/src/infra/runtime-guard.ts
@@ -33,6 +33,7 @@ type RuntimeDetails = {
   version: string | null;
   execPath: string | null;
   pathEnv: string;
+  hasNodeSqlite: boolean;
 };
 
 const SEMVER_RE = /(\d+)\.(\d+)\.(\d+)/;
@@ -79,13 +80,27 @@ function detectRuntime(): RuntimeDetails {
     version,
     execPath: process.execPath ?? null,
     pathEnv: process.env.PATH ?? "(not set)",
+    hasNodeSqlite: currentRuntimeProvidesNodeSqlite(),
   };
+}
+
+// Bun >=1.4 (Rust rewrite) ships node:sqlite; older Buns do not. Feature-probe
+// instead of version-gating so the guard tracks the actual runtime capability.
+function currentRuntimeProvidesNodeSqlite(): boolean {
+  try {
+    return Boolean(process.getBuiltinModule?.("node:sqlite"));
+  } catch {
+    return false;
+  }
 }
 
 /** Returns whether a detected runtime meets OpenClaw's minimum runtime contract. */
 function runtimeSatisfies(details: RuntimeDetails): boolean {
   if (details.kind === "node") {
     return isSupportedNodeVersion(details.version);
+  }
+  if (details.kind === "bun") {
+    return details.hasNodeSqlite;
   }
   return false;
 }

--- a/src/process/exec-spawn.ts
+++ b/src/process/exec-spawn.ts
@@ -69,12 +69,12 @@ export function spawnCommandWithInvocation<
   invocation: ReturnType<typeof resolveSafeChildProcessInvocation>;
 } {
   const { baseEnv, env, windowsVerbatimArguments, ...execaOptions } = options;
-  // Bun workaround: execa forwards its whole options object to child_process.spawn.
-  // Node ignores the extra `encoding` key there, but Bun's spawn feeds it into its
-  // stream constructor and throws ERR_UNKNOWN_ENCODING for execa's "buffer".
-  // Dropping it under Bun means buffered results arrive as utf8 strings instead of
-  // Buffers; callers already normalize via Buffer.from. Binary-exact output paths
-  // are unverified under Bun. Remove once Bun ignores non-spawn options.
+  // Bun workaround (oven-sh/bun#36049): execa forwards its whole options object to
+  // child_process.spawn. Node ignores the extra `encoding` key there, but Bun's
+  // spawn feeds it into its stream constructor and throws ERR_UNKNOWN_ENCODING for
+  // execa's "buffer". Dropping it under Bun means buffered results arrive as utf8
+  // strings instead of Buffers; callers already normalize via Buffer.from. Binary-
+  // exact output paths are unverified under Bun. Remove once the Bun issue is fixed.
   if (process.versions.bun && execaOptions.encoding === "buffer") {
     delete execaOptions.encoding;
   }

--- a/src/process/exec-spawn.ts
+++ b/src/process/exec-spawn.ts
@@ -69,6 +69,15 @@ export function spawnCommandWithInvocation<
   invocation: ReturnType<typeof resolveSafeChildProcessInvocation>;
 } {
   const { baseEnv, env, windowsVerbatimArguments, ...execaOptions } = options;
+  // Bun workaround: execa forwards its whole options object to child_process.spawn.
+  // Node ignores the extra `encoding` key there, but Bun's spawn feeds it into its
+  // stream constructor and throws ERR_UNKNOWN_ENCODING for execa's "buffer".
+  // Dropping it under Bun means buffered results arrive as utf8 strings instead of
+  // Buffers; callers already normalize via Buffer.from. Binary-exact output paths
+  // are unverified under Bun. Remove once Bun ignores non-spawn options.
+  if (process.versions.bun && execaOptions.encoding === "buffer") {
+    delete execaOptions.encoding;
+  }
   const commandEnv = resolveCommandEnv({ argv, baseEnv, env });
   const invocation = resolveSafeChildProcessInvocation({
     argv,

--- a/src/process/exec-spawn.ts
+++ b/src/process/exec-spawn.ts
@@ -72,12 +72,11 @@ export function spawnCommandWithInvocation<
   // Bun workaround (oven-sh/bun#36049): execa forwards its whole options object to
   // child_process.spawn. Node ignores the extra `encoding` key there, but Bun's
   // spawn feeds it into its stream constructor and throws ERR_UNKNOWN_ENCODING for
-  // execa's "buffer". Dropping it under Bun means buffered results arrive as utf8
+  // execa's "buffer". Clearing it under Bun means buffered results arrive as utf8
   // strings instead of Buffers; callers already normalize via Buffer.from. Binary-
   // exact output paths are unverified under Bun. Remove once the Bun issue is fixed.
-  if (process.versions.bun && execaOptions.encoding === "buffer") {
-    delete execaOptions.encoding;
-  }
+  const dropBufferEncodingForBun =
+    Boolean(process.versions.bun) && execaOptions.encoding === "buffer";
   const commandEnv = resolveCommandEnv({ argv, baseEnv, env });
   const invocation = resolveSafeChildProcessInvocation({
     argv,
@@ -87,6 +86,7 @@ export function spawnCommandWithInvocation<
   });
   const child = execa(invocation.command, invocation.args, {
     ...execaOptions,
+    ...(dropBufferEncodingForBun ? { encoding: undefined } : {}),
     env: commandEnv,
     extendEnv: false,
     shell: false,

--- a/test/openclaw-launcher.e2e.test.ts
+++ b/test/openclaw-launcher.e2e.test.ts
@@ -228,7 +228,7 @@ describe("openclaw launcher", () => {
     }
   });
 
-  it("rejects Bun even when its Node compatibility version is new enough", async () => {
+  it("rejects Bun without node:sqlite even when its Node compatibility version is new enough", async () => {
     const fixtureRoot = await makeLauncherFixture(fixtureRoots);
     await fs.writeFile(
       path.join(fixtureRoot, "dist", "entry.js"),
@@ -241,6 +241,11 @@ describe("openclaw launcher", () => {
       [
         "Object.defineProperty(process.versions, 'bun', { value: '1.3.14' });",
         "Object.defineProperty(process.versions, 'node', { value: '24.3.0' });",
+        // Old Bun has no node:sqlite; the launcher feature-probes instead of
+        // trusting the runtime label, so the mock must hide Node's builtin.
+        "const realGetBuiltinModule = process.getBuiltinModule.bind(process);",
+        "process.getBuiltinModule = (id) =>",
+        "  id === 'node:sqlite' || id === 'sqlite' ? undefined : realGetBuiltinModule(id);",
       ].join("\n"),
       "utf8",
     );
@@ -258,8 +263,38 @@ describe("openclaw launcher", () => {
     expect(result.status).toBe(1);
     expect(result.stdout).toBe("");
     expect(result.stderr).toContain(
-      "the Bun runtime is unsupported because OpenClaw requires node:sqlite",
+      "this Bun runtime is unsupported because it does not provide node:sqlite",
     );
+  });
+
+  it("runs the CLI under Bun when the runtime provides node:sqlite", async () => {
+    const fixtureRoot = await makeLauncherFixture(fixtureRoots);
+    await fs.writeFile(
+      path.join(fixtureRoot, "dist", "entry.js"),
+      'process.stdout.write("bun-runtime-entry\\n");\n',
+      "utf8",
+    );
+    const mockRuntime = path.join(fixtureRoot, "mock-bun-sqlite-runtime.mjs");
+    await fs.writeFile(
+      mockRuntime,
+      // Simulates Bun >=1.4 (Rust rewrite): bun-branded runtime with node:sqlite
+      // available; Node's own getBuiltinModule answers the launcher probe.
+      "Object.defineProperty(process.versions, 'bun', { value: '1.4.0' });",
+      "utf8",
+    );
+
+    const result = spawnSync(
+      process.execPath,
+      ["--import", pathToFileURL(mockRuntime).href, path.join(fixtureRoot, "openclaw.mjs")],
+      {
+        cwd: fixtureRoot,
+        env: launcherEnv(),
+        encoding: "utf8",
+      },
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("bun-runtime-entry");
   });
 
   it("surfaces transitive entry import failures instead of masking them as missing dist", async () => {
@@ -418,30 +453,41 @@ describe("openclaw launcher", () => {
   });
 
   it.runIf(process.env.OPENCLAW_TEST_BUN_LAUNCHER === "1" && hasBunRuntime())(
-    "rejects the real Bun runtime before loading the CLI",
+    "gates the real Bun runtime on node:sqlite availability",
     async () => {
       const fixtureRoot = await makeLauncherFixture(fixtureRoots);
       await fs.writeFile(
         path.join(fixtureRoot, "dist", "entry.js"),
-        "process.stdout.write('unexpected bun entry\\n');\n",
+        "process.stdout.write('bun entry ran\\n');\n",
         "utf8",
       );
 
-      const result = spawnSync(
-        process.env.BUN_BIN ?? "bun",
-        [path.join(fixtureRoot, "openclaw.mjs")],
-        {
-          cwd: fixtureRoot,
-          env: launcherEnv(),
-          encoding: "utf8",
-        },
+      const bunBin = process.env.BUN_BIN ?? "bun";
+      // Bun >=1.4 (Rust rewrite) ships node:sqlite and may run the CLI; older
+      // Buns must be rejected before the entry loads.
+      const probe = spawnSync(
+        bunBin,
+        ["-e", "process.exit(process.getBuiltinModule?.('node:sqlite') ? 0 : 1)"],
+        { encoding: "utf8" },
       );
+      const bunHasNodeSqlite = probe.status === 0;
 
-      expect(result.status).toBe(1);
-      expect(result.stdout).toBe("");
-      expect(result.stderr).toContain(
-        "the Bun runtime is unsupported because OpenClaw requires node:sqlite",
-      );
+      const result = spawnSync(bunBin, [path.join(fixtureRoot, "openclaw.mjs")], {
+        cwd: fixtureRoot,
+        env: launcherEnv(),
+        encoding: "utf8",
+      });
+
+      if (bunHasNodeSqlite) {
+        expect(result.status).toBe(0);
+        expect(result.stdout).toContain("bun entry ran");
+      } else {
+        expect(result.status).toBe(1);
+        expect(result.stdout).toBe("");
+        expect(result.stderr).toContain(
+          "this Bun runtime is unsupported because it does not provide node:sqlite",
+        );
+      }
     },
   );
 


### PR DESCRIPTION
## What Problem This Solves

OpenClaw hard-rejects the Bun runtime at startup with "cannot run under Bun because the runtime does not provide node:sqlite". That reason is now stale: Bun's Rust rewrite (1.4.0 canary, current `oven-sh/bun` main) ships a working `node:sqlite` (`DatabaseSync` roundtrip verified). With the blanket rejection in place, capable Bun builds cannot run the CLI or Gateway at all.

A second, independent blocker: OpenClaw's canonical exec boundary passes execa's documented `encoding: "buffer"` option through to `child_process.spawn`. Node ignores unknown spawn options; Bun consumes `encoding` when building spawn stdio streams and throws `ERR_UNKNOWN_ENCODING`, killing nearly every child process (e.g. `openclaw doctor` dies immediately). Reported upstream with a minimal repro and root cause in Bun source: oven-sh/bun#36049 (reproduces on stable 1.3.14 too, so it is a longstanding Node-compat divergence, not a rewrite regression).

## Why This Change Was Made

- `src/infra/runtime-guard.ts` and `openclaw.mjs` now feature-probe `process.getBuiltinModule?.("node:sqlite")` instead of rejecting the Bun brand outright. Old Buns (<=1.3.x) are still rejected with an accurate message; runtimes that actually provide `node:sqlite` proceed. Probing the capability rather than version-gating keeps the guard truthful as Bun evolves.
- `src/process/exec-spawn.ts` drops the `encoding: "buffer"` execa option under Bun only, at the single canonical spawn boundary, with a comment citing oven-sh/bun#36049 and the removal condition. Buffered exec results arrive as utf8 strings under Bun; callers already normalize via `Buffer.from`.
- `docs/install/bun.md` updated: the runtime warning now describes the feature probe, and the install step points at `pnpm install` because current Bun versions (stable and canary) fail to resolve this repo's `pnpm-workspace.yaml` layout during `bun install`.

## User Impact

Node users: no behavior change (probe returns true on all supported Node versions; guard logic for Node is untouched). Bun 1.3.x users: unchanged rejection, reworded message. Bun 1.4+ (canary) users: the CLI and Gateway now start and work experimentally. Node remains the supported runtime.

## Evidence

Verified locally against Bun `1.4.0-canary.1+43d60f69c` (standalone binary from the oven-sh/bun canary release) and stable Bun 1.3.14, isolated `OPENCLAW_STATE_DIR`:

- `bun openclaw.mjs --version`, `status`, and a full `doctor` run complete under canary after these changes; before the spawn workaround `doctor` crashed with `ERR_UNKNOWN_ENCODING`.
- Gateway boots from dist under canary (`gateway run --port 19777 --allow-unconfigured`), serves HTTP 200, accepts WebSocket connects (device-identity auth gate responds correctly), clean SIGTERM shutdown, no encoding errors in logs.
- `node scripts/run-vitest.mjs run src/infra/runtime-guard.test.ts` — 18/18 (includes new accept/reject cases for `hasNodeSqlite`).
- `node scripts/run-vitest.mjs run src/process/exec` — 60 passed, 1 skipped.
- `node scripts/run-vitest.mjs run test/openclaw-launcher.e2e.test.ts` — 43/43 under plain Node; plus `OPENCLAW_TEST_BUN_LAUNCHER` opt-in runs against both real binaries: canary accepted and runs the entry, stable 1.3.14 rejected with the new message (43/43 each).
- Codex autoreview (`--mode uncommitted`, gpt-5.6-sol): clean, 0 findings.

## Live runtime evidence (ClawSweeper "add real behavior proof")

Redacted terminal transcript, macOS arm64, run against this PR head:

```console
$ bun --revision
1.4.0-canary.1+43d60f69c
$ bun -e "console.log(typeof process.getBuiltinModule, Boolean(process.getBuiltinModule?.(\"node:sqlite\")))"
function true
$ /opt/homebrew/bin/bun --version   # stable
1.3.14
$ /opt/homebrew/bin/bun -e <same probe>
function false
$ bun openclaw.mjs --version
OpenClaw 2026.7.2 (8923bbc)
$ /opt/homebrew/bin/bun openclaw.mjs --version   # stable -> rejected
openclaw: this Bun runtime is unsupported because it does not provide node:sqlite.
$ bun openclaw.mjs doctor | tail -1   # spawns children through the execa boundary

Doctor complete.
```

## ClawSweeper Rank-up moves

- **Add real behavior proof** — applied: transcript above shows the exact Bun versions, the probe result on both runtimes, the launcher accept/reject paths, and a full `doctor` run (child processes through the execa boundary).
- **"Use a Bun-supported probe" / "launcher consistency" (P1 x2)** — skipped as factually incorrect for the target runtime: `process.getBuiltinModule` is implemented by both Bun 1.3.14 (stable) and 1.4.0 canary, verified live above (`typeof process.getBuiltinModule` is `function` on both; the canary returns the `node:sqlite` module, stable returns `undefined` for it, which is exactly the admission split this PR wants). Both guards already share one contract: the same one-line probe, additionally exercised end-to-end against both real binaries by the opt-in launcher e2e (`OPENCLAW_TEST_BUN_LAUNCHER=1`).
- **Binary-output compatibility (P1)** — accepted tradeoff, not hidden: under Bun only, buffered exec output arrives utf8-decoded; the code comment at the single boundary documents this and cites oven-sh/bun#36049 with the removal condition. Node behavior is byte-identical to before. Bun remains an experimental runtime (docs say Node is the supported runtime), so binary-exact exec paths under Bun are explicitly out of the supported surface until the upstream fix lands.
- **Maintainer direction (P2)** — this change was requested and landed by the repo owner; experimental Bun support gated on a live capability probe is that direction.
- **Stored data model note** — false positive: `test/openclaw-launcher.e2e.test.ts` writes throwaway launcher fixtures inside the test temp dir; no persisted product schema changes.
