### PR TITLE
fix(linux): make the companion's Rust test suite runnable and run it

### DIFF
--- a/.github/workflows/linux-app.yml
+++ b/.github/workflows/linux-app.yml
@@ -70,6 +70,10 @@ jobs:
         working-directory: apps/linux/src-tauri
         run: cargo +stable fmt --check
 
+      - name: Run Rust tests
+        working-directory: apps/linux/src-tauri
+        run: cargo +stable test --locked --all-targets
+
       - name: Build Linux companion bundles
         working-directory: apps/linux/src-tauri
         env:
@@ -90,8 +94,8 @@ jobs:
             apps/linux/src-tauri/target/release/bundle/deb/*.deb
             apps/linux/src-tauri/target/release/bundle/appimage/*.AppImage
 
-  check-macos:
-    name: Check macOS companion
+  test-macos:
+    name: Test macOS companion
     # This app also ships macOS desktop-test bundles, but the only job that
     # compiles them (linux-app-release.yml build_macos) runs behind a manual
     # dispatch input. Without a per-PR check, a macOS-gated Tauri API can break
@@ -126,6 +130,10 @@ jobs:
           restore-keys: |
             macos-app-${{ runner.os }}-
 
-      - name: Check macOS companion
+      - name: Test macOS companion
         working-directory: apps/linux/src-tauri
-        run: cargo +stable check --locked --all-targets
+        # `test` rather than `check`: it additionally links and runs the
+        # binaries, which is the only way macOS link-time breakage (a missing
+        # Swift runtime rpath, say) shows up at all. `--all-targets` keeps the
+        # compile coverage `check --all-targets` used to give.
+        run: cargo +stable test --locked --all-targets

--- a/apps/linux/src-tauri/build.rs
+++ b/apps/linux/src-tauri/build.rs
@@ -1,4 +1,5 @@
 fn main() {
+    link_macos_swift_runtime();
     // Command metadata generates capability permissions independently of the
     // target's invoke handler, so keep the Linux-only command permission known.
     const COMMANDS: &[&str] = &[
@@ -19,4 +20,16 @@ fn main() {
             .app_manifest(tauri_build::AppManifest::new().commands(COMMANDS)),
     )
     .expect("Tauri build configuration should be valid");
+}
+
+/// tauri-plugin-notifications links a Swift static library into us, but nothing
+/// adds an rpath for the Swift runtime it pulls in. Bundled apps get one from
+/// the bundler; plain `cargo run` and `cargo test` binaries do not, so they die
+/// at load with `Library not loaded: @rpath/libswift_Concurrency.dylib`. Point
+/// them at the OS runtime so the test suite is runnable on macOS.
+fn link_macos_swift_runtime() {
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() != Ok("macos") {
+        return;
+    }
+    println!("cargo:rustc-link-arg=-Wl,-rpath,/usr/lib/swift");
 }

--- a/apps/linux/src-tauri/src/gateway_ws.rs
+++ b/apps/linux/src-tauri/src/gateway_ws.rs
@@ -1660,7 +1660,8 @@ mod tests {
             false,
         )
         .expect("pinned connect params");
-        assert_eq!(pinned_params["caps"], json!([]));
+        // Pinning only withdraws inline widgets; agent-kind is unconditional.
+        assert_eq!(pinned_params["caps"], json!([AGENT_KIND_CLIENT_CAPABILITY]));
         std::fs::remove_dir_all(directory).expect("remove connect fixture");
     }
 


### PR DESCRIPTION
## Summary

Three defects that compounded into a test suite nobody could run and nobody was running. Found while stress-testing the companion now that the macOS target compiles again (#114243).

## 1. The suite has been red on `main` since 2026-07-20

`gateway_ws::tests::connect_frame_matches_gateway_schema` fails:

```
assertion `left == right` failed
  left: Array [String("agent-kind")]
 right: Array []
```

It asserts that a TLS-pinned (text-only) connection advertises no capabilities. That was true when #111933 ("render widgets in Quick Chat") wrote it — `caps` held only inline-widgets. The same day, #111920 ("classify system agents in rosters") made `agent-kind` unconditional in `connect_params`. Two PRs, no textual conflict, semantically incompatible; both landed and the assertion has been wrong ever since.

The production code is right: the parameter is `inline_widgets_available`, and pinning is documented to withdraw inline widgets only. So the assertion now states exactly that.

## 2. `cargo test` could not run on macOS at all

Every test binary aborted before running a single test:

```
dyld: Library not loaded: @rpath/libswift_Concurrency.dylib
  Reason: no LC_RPATH's found
```

`tauri-plugin-notifications` links a Swift static library into the crate, but nothing adds an rpath for the Swift runtime it pulls in. Bundled `.app`s get one from the bundler; plain `cargo test` and `cargo run` binaries do not. `build.rs` now emits `-Wl,-rpath,/usr/lib/swift` for macOS targets.

## 3. Nothing ran the suite

`linux-app.yml` only checked formatting and built bundles — it never ran `cargo test`, which is why 1 and 2 both survived. The Linux job now runs the suite, and the macOS job is upgraded from `check` to `test`.

That upgrade matters specifically for this class of bug: `cargo check` never links, so it could not have caught the rpath failure no matter how long it ran. `--all-targets` is kept on both so the compile coverage `check --all-targets` provided is not lost.

## Proof

macOS 27.0 (Apple silicon), Swift 6.4:

```
cargo test --locked --all-targets     # 73 passed; 0 failed  (was: aborts at load)
cargo fmt --check                     # clean
```

Before this change, on the same machine, `cargo test` aborted with SIGABRT at dyld load; with `DYLD_FALLBACK_LIBRARY_PATH=/usr/lib/swift` forced, it then reported `72 passed; 1 failed`. Both symptoms are gone.

### Stress testing behind these findings

Beyond the suite, I exercised the built app on macOS under an isolated bundle identifier and `HOME`, and found **no** further defects in these paths:

- Cold launch with no `DYLD_*` workaround — starts clean, which independently confirms the rpath fix at runtime rather than only for tests.
- 12 concurrent secondary launches against a live primary — all 12 exited 0, no panics, primary survived.
- Hostile persisted state (NUL bytes, empty files, non-JSON in the shortcut preference, a directory where `identity.json` is expected) — app starts and survives.
- 14 adversarial Gateway `hello` payloads (wrong types, `u32::MAX` protocol, `u64::MAX` tick interval, NUL and RTL-override strings, a 1 MB URL) and 6,561 `quickchat_position` combinations spanning negative monitor origins, oversized windows and `f64::MAX` — no panics, no NaN.

## Follow-ups, not in this PR

A code survey alongside the stress run raised five issues that need their own changes; the two geometry ones are bounded and I intend to send them separately. Flagging the rest here so they are not lost: manual update results are emitted into the `main` WebView after it has navigated to the remote dashboard, so tray → Check for Updates can silently show nothing; a corrupt `quickchat-gateway-device.json` is never quarantined or regenerated, so it bricks Quick Chat connections indefinitely; and tray Start/Stop/Restart each spawn an independent thread serialized by a mutex with no FIFO ordering, so two quick clicks can execute out of order.
