### PR TITLE
Fix auth_profile_store not resyncing when apiKey is updated in openclaw.json

### DIFF
--- a/src/commands/doctor/repair-sequencing.ts
+++ b/src/commands/doctor/repair-sequencing.ts
@@ -26,6 +26,7 @@ import {
   collectChannelDoctorRepairMutations,
 } from "./shared/channel-doctor.js";
 import { maybeRepairCodexRoutes } from "./shared/codex-route-warnings.js";
+import { repairConfigAuthProfileApiKeyDrifts } from "./shared/config-auth-profile-api-key-drift.js";
 import {
   applyDoctorConfigMutation,
   type DoctorConfigMutationState,
@@ -245,6 +246,16 @@ export async function runDoctorRepairSequence(params: {
   if (staleOAuthShadowRepair.warnings.length > 0) {
     warningNotes.push(sanitizeLines(staleOAuthShadowRepair.warnings));
   }
+  const configAuthProfileApiKeyDriftRepair = await repairConfigAuthProfileApiKeyDrifts({
+    cfg: state.candidate,
+    env,
+  });
+  if (configAuthProfileApiKeyDriftRepair.changes.length > 0) {
+    changeNotes.push(sanitizeLines(configAuthProfileApiKeyDriftRepair.changes));
+  }
+  if (configAuthProfileApiKeyDriftRepair.warnings.length > 0) {
+    warningNotes.push(sanitizeLines(configAuthProfileApiKeyDriftRepair.warnings));
+  }
   const authProfileSqliteMigration = await maybeMigrateAuthProfileJsonStoresToSqlite({
     cfg: state.candidate,
     prompter: { confirmAutoFix: async () => true },
@@ -275,6 +286,7 @@ export async function runDoctorRepairSequence(params: {
     legacyOAuthSidecarRepair.changes.length > 0 ||
     openAIAuthProviderRepair.changes.length > 0 ||
     staleOAuthShadowRepair.changes.length > 0 ||
+    configAuthProfileApiKeyDriftRepair.changes.length > 0 ||
     authProfileSqliteMigration.changes.length > 0;
 
   const activeToolSchemaWarnings = collectActiveToolSchemaProjectionWarnings({

--- a/src/commands/doctor/shared/config-auth-profile-api-key-drift.test.ts
+++ b/src/commands/doctor/shared/config-auth-profile-api-key-drift.test.ts
@@ -1,0 +1,199 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { writePersistedAuthProfileStoreRaw } from "../../../agents/auth-profiles/sqlite.js";
+import type { AuthProfileStore } from "../../../agents/auth-profiles/types.js";
+import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import { closeOpenClawAgentDatabasesForTest } from "../../../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../../../state/openclaw-state-db.js";
+import {
+  collectConfigAuthProfileApiKeyDriftWarnings,
+  repairConfigAuthProfileApiKeyDrifts,
+  scanConfigAuthProfileApiKeyDrifts,
+} from "./config-auth-profile-api-key-drift.js";
+
+function litellmStore(key: string): AuthProfileStore {
+  return {
+    version: 1,
+    profiles: {
+      "litellm:default": {
+        type: "api_key",
+        provider: "litellm",
+        key,
+      },
+    },
+  };
+}
+
+async function withStateDir(
+  run: (stateDir: string, env: NodeJS.ProcessEnv) => Promise<void>,
+): Promise<void> {
+  const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-auth-key-drift-"));
+  const env = { OPENCLAW_STATE_DIR: stateDir };
+  try {
+    await run(stateDir, env);
+  } finally {
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+    await fs.rm(stateDir, { recursive: true, force: true });
+  }
+}
+
+describe("scanConfigAuthProfileApiKeyDrifts", () => {
+  afterEach(() => {
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+  });
+
+  it("detects a provider apiKey edit that never reached the stored auth profile", async () => {
+    await withStateDir(async (stateDir, env) => {
+      writePersistedAuthProfileStoreRaw(
+        litellmStore("old-key"),
+        path.join(stateDir, "agents", "main", "agent"),
+      );
+      const cfg = {
+        models: { providers: { litellm: { apiKey: "new-key" } } },
+      } as unknown as OpenClawConfig;
+
+      const hits = scanConfigAuthProfileApiKeyDrifts({ cfg, env });
+
+      expect(hits).toEqual([
+        expect.objectContaining({
+          provider: "litellm",
+          profileId: "litellm:default",
+          configApiKey: "new-key",
+        }),
+      ]);
+      expect(
+        collectConfigAuthProfileApiKeyDriftWarnings({
+          hits,
+          doctorFixCommand: "openclaw doctor --fix",
+        }).join("\n"),
+      ).toContain('Run "openclaw doctor --fix"');
+    });
+  });
+
+  it("finds no drift when the config apiKey already matches the stored profile", async () => {
+    await withStateDir(async (stateDir, env) => {
+      writePersistedAuthProfileStoreRaw(
+        litellmStore("same-key"),
+        path.join(stateDir, "agents", "main", "agent"),
+      );
+      const cfg = {
+        models: { providers: { litellm: { apiKey: "same-key" } } },
+      } as unknown as OpenClawConfig;
+
+      expect(scanConfigAuthProfileApiKeyDrifts({ cfg, env })).toEqual([]);
+    });
+  });
+
+  it("does not flag drift when the provider entry already prefers explicit config apiKey auth", async () => {
+    await withStateDir(async (stateDir, env) => {
+      writePersistedAuthProfileStoreRaw(
+        litellmStore("old-key"),
+        path.join(stateDir, "agents", "main", "agent"),
+      );
+      const cfg = {
+        models: { providers: { litellm: { apiKey: "new-key", auth: "api-key" } } },
+      } as unknown as OpenClawConfig;
+
+      expect(scanConfigAuthProfileApiKeyDrifts({ cfg, env })).toEqual([]);
+    });
+  });
+
+  it("ignores a SecretRef-backed provider apiKey", async () => {
+    await withStateDir(async (stateDir, env) => {
+      writePersistedAuthProfileStoreRaw(
+        litellmStore("old-key"),
+        path.join(stateDir, "agents", "main", "agent"),
+      );
+      const cfg = {
+        models: {
+          providers: { litellm: { apiKey: { secretRef: "env:LITELLM_API_KEY" } } },
+        },
+      } as unknown as OpenClawConfig;
+
+      expect(scanConfigAuthProfileApiKeyDrifts({ cfg, env })).toEqual([]);
+    });
+  });
+
+  it("ignores providers without any stored api_key profile", async () => {
+    await withStateDir(async (stateDir, env) => {
+      writePersistedAuthProfileStoreRaw(
+        { version: 1, profiles: {} },
+        path.join(stateDir, "agents", "main", "agent"),
+      );
+      const cfg = {
+        models: { providers: { litellm: { apiKey: "new-key" } } },
+      } as unknown as OpenClawConfig;
+
+      expect(scanConfigAuthProfileApiKeyDrifts({ cfg, env })).toEqual([]);
+    });
+  });
+
+  it("checks every configured agent's own auth store", async () => {
+    await withStateDir(async (stateDir, env) => {
+      writePersistedAuthProfileStoreRaw(
+        litellmStore("primary-old-key"),
+        path.join(stateDir, "agents", "primary", "agent"),
+      );
+      writePersistedAuthProfileStoreRaw(
+        litellmStore("secondary-old-key"),
+        path.join(stateDir, "agents", "secondary", "agent"),
+      );
+      const cfg = {
+        agents: { list: [{ id: "primary", default: true }, { id: "secondary" }] },
+        models: { providers: { litellm: { apiKey: "new-key" } } },
+      } as unknown as OpenClawConfig;
+
+      const hits = scanConfigAuthProfileApiKeyDrifts({ cfg, env });
+
+      expect(hits.map((hit) => hit.profileId)).toEqual(["litellm:default", "litellm:default"]);
+      expect(hits.every((hit) => hit.configApiKey === "new-key")).toBe(true);
+      expect(hits).toHaveLength(2);
+    });
+  });
+});
+
+describe("repairConfigAuthProfileApiKeyDrifts", () => {
+  afterEach(() => {
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+  });
+
+  it("updates the stored profile so the runtime uses the newly configured apiKey", async () => {
+    await withStateDir(async (stateDir, env) => {
+      const agentDir = path.join(stateDir, "agents", "main", "agent");
+      writePersistedAuthProfileStoreRaw(litellmStore("old-key"), agentDir);
+      const cfg = {
+        models: { providers: { litellm: { apiKey: "new-key" } } },
+      } as unknown as OpenClawConfig;
+
+      const result = await repairConfigAuthProfileApiKeyDrifts({ cfg, env });
+
+      expect(result.warnings).toEqual([]);
+      expect(result.changes).toEqual([
+        expect.stringContaining('Updated auth profile "litellm:default"'),
+      ]);
+      expect(scanConfigAuthProfileApiKeyDrifts({ cfg, env })).toEqual([]);
+    });
+  });
+
+  it("is a no-op when there is nothing to repair", async () => {
+    await withStateDir(async (stateDir, env) => {
+      writePersistedAuthProfileStoreRaw(
+        litellmStore("same-key"),
+        path.join(stateDir, "agents", "main", "agent"),
+      );
+      const cfg = {
+        models: { providers: { litellm: { apiKey: "same-key" } } },
+      } as unknown as OpenClawConfig;
+
+      expect(await repairConfigAuthProfileApiKeyDrifts({ cfg, env })).toEqual({
+        changes: [],
+        warnings: [],
+      });
+    });
+  });
+});

--- a/src/commands/doctor/shared/config-auth-profile-api-key-drift.ts
+++ b/src/commands/doctor/shared/config-auth-profile-api-key-drift.ts
@@ -1,0 +1,160 @@
+// Doctor repair for provider apiKey edits in openclaw.json that never reach
+// the SQLite auth profile the runtime actually resolves for that provider,
+// so the edit has no effect until the profile is separately updated
+// (openclaw/openclaw#113599).
+import {
+  listAgentEntries,
+  resolveAgentDir,
+  resolveDefaultAgentDir,
+} from "../../../agents/agent-scope-config.js";
+import {
+  resolveAuthProfileOrder,
+  resolveAuthStorePathForDisplay,
+} from "../../../agents/auth-profiles.js";
+import { loadPersistedAuthProfileStore } from "../../../agents/auth-profiles/persisted.js";
+import { updateAuthProfileStoreWithLock } from "../../../agents/auth-profiles/store.js";
+import type { AuthProfileStore } from "../../../agents/auth-profiles/types.js";
+import { isNonSecretApiKeyMarker } from "../../../agents/model-auth-markers.js";
+import {
+  resolveProviderConfig,
+  shouldPreferExplicitConfigApiKeyAuth,
+} from "../../../agents/model-auth-provider-config.js";
+import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import { coerceSecretRef } from "../../../config/types.secrets.js";
+import { isRecord, shortenHomePath } from "../../../utils.js";
+import { normalizeOptionalSecretInput } from "../../../utils/normalize-secret-input.js";
+
+type ConfigAuthProfileApiKeyDrift = {
+  agentDir: string;
+  provider: string;
+  profileId: string;
+  configApiKey: string;
+};
+
+function resolveConfiguredProviderIds(cfg: OpenClawConfig): string[] {
+  const models = isRecord(cfg.models) ? cfg.models : {};
+  const providers = isRecord(models.providers) ? models.providers : {};
+  return Object.keys(providers);
+}
+
+function collectCandidateAgentDirs(cfg: OpenClawConfig, env: NodeJS.ProcessEnv): string[] {
+  const dirs = new Set<string>([resolveDefaultAgentDir(cfg, env)]);
+  for (const entry of listAgentEntries(cfg)) {
+    const id = entry.id?.trim();
+    if (id) {
+      dirs.add(resolveAgentDir(cfg, id, env));
+    }
+  }
+  return [...dirs];
+}
+
+/** Literal apiKey configured for a provider entry, or null when unset/SecretRef/marker. */
+function resolveConfiguredLiteralApiKey(cfg: OpenClawConfig, provider: string): string | null {
+  const providerConfig = resolveProviderConfig(cfg, provider);
+  if (!providerConfig || coerceSecretRef(providerConfig.apiKey)) {
+    return null;
+  }
+  const literal = normalizeOptionalSecretInput(providerConfig.apiKey);
+  if (!literal || isNonSecretApiKeyMarker(literal)) {
+    return null;
+  }
+  return literal;
+}
+
+/** Finds the api_key auth profile the runtime would resolve for this provider today. */
+function resolveActiveApiKeyProfile(params: {
+  cfg: OpenClawConfig;
+  store: AuthProfileStore;
+  provider: string;
+}): { profileId: string; key: string } | null {
+  const candidates = resolveAuthProfileOrder({
+    cfg: params.cfg,
+    store: params.store,
+    provider: params.provider,
+  });
+  for (const profileId of candidates) {
+    const credential = params.store.profiles[profileId];
+    if (credential?.type === "api_key" && credential.key) {
+      return { profileId, key: credential.key };
+    }
+  }
+  return null;
+}
+
+/** Detect providers whose configured apiKey no longer matches the auth profile the runtime uses. */
+export function scanConfigAuthProfileApiKeyDrifts(params: {
+  cfg: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+}): ConfigAuthProfileApiKeyDrift[] {
+  const env = params.env ?? process.env;
+  const providers = resolveConfiguredProviderIds(params.cfg).filter(
+    (provider) => !shouldPreferExplicitConfigApiKeyAuth(params.cfg, provider),
+  );
+  if (providers.length === 0) {
+    return [];
+  }
+  const hits: ConfigAuthProfileApiKeyDrift[] = [];
+  for (const agentDir of collectCandidateAgentDirs(params.cfg, env)) {
+    const store = loadPersistedAuthProfileStore(agentDir);
+    if (!store) {
+      continue;
+    }
+    for (const provider of providers) {
+      const configApiKey = resolveConfiguredLiteralApiKey(params.cfg, provider);
+      if (!configApiKey) {
+        continue;
+      }
+      const active = resolveActiveApiKeyProfile({ cfg: params.cfg, store, provider });
+      if (active && active.key !== configApiKey) {
+        hits.push({ agentDir, provider, profileId: active.profileId, configApiKey });
+      }
+    }
+  }
+  return hits;
+}
+
+/** Format warnings for provider apiKey edits shadowed by a stored auth profile. */
+export function collectConfigAuthProfileApiKeyDriftWarnings(params: {
+  hits: ConfigAuthProfileApiKeyDrift[];
+  doctorFixCommand: string;
+}): string[] {
+  return params.hits.map(
+    (hit) =>
+      `- Provider "${hit.provider}" has a new apiKey in openclaw.json, but auth profile "${hit.profileId}" in ${shortenHomePath(resolveAuthStorePathForDisplay(hit.agentDir))} still holds the previous key and is what the runtime sends. Run "${params.doctorFixCommand}" to update the stored profile to match, or set auth: "api-key" on this provider entry to always prefer config.`,
+  );
+}
+
+/** Update stored auth profiles so each provider's runtime credential matches its configured apiKey. */
+export async function repairConfigAuthProfileApiKeyDrifts(params: {
+  cfg: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+}): Promise<{ changes: string[]; warnings: string[] }> {
+  const hits = scanConfigAuthProfileApiKeyDrifts(params);
+  const changes: string[] = [];
+  const warnings: string[] = [];
+  for (const hit of hits) {
+    let updated = false;
+    const result = await updateAuthProfileStoreWithLock({
+      agentDir: hit.agentDir,
+      updater: (store) => {
+        const credential = store.profiles[hit.profileId];
+        if (credential?.type !== "api_key" || credential.key === hit.configApiKey) {
+          return false;
+        }
+        store.profiles[hit.profileId] = { ...credential, key: hit.configApiKey };
+        updated = true;
+        return true;
+      },
+    });
+    if (result && updated) {
+      changes.push(
+        `Updated auth profile "${hit.profileId}" for provider "${hit.provider}" in ${shortenHomePath(resolveAuthStorePathForDisplay(hit.agentDir))} to match the apiKey configured in openclaw.json.`,
+      );
+    } else if (!result) {
+      warnings.push(
+        `Failed to sync auth profile "${hit.profileId}" for provider "${hit.provider}" from openclaw.json; the auth store lock may be busy. Retry "openclaw doctor --fix".`,
+      );
+    }
+  }
+  return { changes, warnings };
+}

--- a/src/commands/doctor/shared/preview-warnings.ts
+++ b/src/commands/doctor/shared/preview-warnings.ts
@@ -912,6 +912,21 @@ export async function collectDoctorPreviewNotes(params: {
     );
   }
 
+  const { collectConfigAuthProfileApiKeyDriftWarnings, scanConfigAuthProfileApiKeyDrifts } =
+    await import("./config-auth-profile-api-key-drift.js");
+  const configAuthProfileApiKeyDrifts = scanConfigAuthProfileApiKeyDrifts({
+    cfg: params.cfg,
+    env,
+  });
+  if (configAuthProfileApiKeyDrifts.length > 0) {
+    warnings.push(
+      collectConfigAuthProfileApiKeyDriftWarnings({
+        hits: configAuthProfileApiKeyDrifts,
+        doctorFixCommand: params.doctorFixCommand,
+      }).join("\n"),
+    );
+  }
+
   const { collectStaleConfiguredAuthOrderWarnings } = await import("./stale-auth-order.js");
   warnings.push(
     ...collectStaleConfiguredAuthOrderWarnings({

--- a/src/gateway/server-startup-bootstrap.ts
+++ b/src/gateway/server-startup-bootstrap.ts
@@ -1,6 +1,11 @@
 import { getActiveBackgroundExecSessionCount } from "../agents/bash-process-registry.js";
 import { getActiveEmbeddedRunCount } from "../agents/embedded-agent-runner/run-state.js";
 import { getTotalPendingReplies } from "../auto-reply/reply/dispatcher-registry.js";
+import { formatCliCommand } from "../cli/command-format.js";
+import {
+  collectConfigAuthProfileApiKeyDriftWarnings,
+  scanConfigAuthProfileApiKeyDrifts,
+} from "../commands/doctor/shared/config-auth-profile-api-key-drift.js";
 import { isRestartEnabled } from "../config/commands.flags.js";
 import {
   collectConfigRuntimeEnvOwnership,
@@ -518,6 +523,28 @@ export async function prepareGatewayServerBootstrap(input: {
       ["deferredChannelPluginCount", metrics.deferredChannelPluginCount],
     ]);
   }
+
+  // Config apiKey edits never reach the bound SQLite auth profile the resolver
+  // prefers, so a plain restart would otherwise keep sending the old key with no
+  // signal. Runs after the plugin metadata snapshot so provider-alias resolution
+  // reuses it instead of forcing an eager discovery load, and stays warn-only:
+  // repair belongs to `openclaw doctor --fix`. A diagnostic must never block boot.
+  await startupTrace.measure("auth.config-profile-drift", () => {
+    try {
+      const configAuthProfileApiKeyDrifts = scanConfigAuthProfileApiKeyDrifts({
+        cfg: cfgAtStart,
+        env: process.env,
+      });
+      for (const warning of collectConfigAuthProfileApiKeyDriftWarnings({
+        hits: configAuthProfileApiKeyDrifts,
+        doctorFixCommand: formatCliCommand("openclaw doctor --fix"),
+      })) {
+        log.warn(warning);
+      }
+    } catch (error) {
+      log.debug(`config auth profile apiKey drift scan skipped: ${String(error)}`);
+    }
+  });
 
   return {
     opts,

--- a/src/gateway/server-startup.config-auth-profile-api-key-drift.test.ts
+++ b/src/gateway/server-startup.config-auth-profile-api-key-drift.test.ts
@@ -1,0 +1,66 @@
+import path from "node:path";
+import { describe, expect, test, vi } from "vitest";
+import { writePersistedAuthProfileStoreRaw } from "../agents/auth-profiles/sqlite.js";
+import { writeConfigFile } from "../config/config.js";
+import { resetLogger, setLoggerOverride } from "../logging.js";
+import { loggingState } from "../logging/state.js";
+import { installGatewayTestHooks, withGatewayServer } from "./test-helpers.js";
+
+installGatewayTestHooks({ scope: "suite" });
+
+describe("gateway startup config auth profile apiKey drift warning", () => {
+  test("warns on plain restart when a provider apiKey edit never reached the SQLite auth profile", async () => {
+    const stateDir = process.env.OPENCLAW_STATE_DIR;
+    if (!stateDir) {
+      throw new Error("expected OPENCLAW_STATE_DIR to be set by installGatewayTestHooks");
+    }
+    writePersistedAuthProfileStoreRaw(
+      {
+        version: 1,
+        profiles: {
+          "litellm:default": {
+            type: "api_key",
+            provider: "litellm",
+            key: "old-key",
+          },
+        },
+      },
+      path.join(stateDir, "agents", "main", "agent"),
+    );
+    await writeConfigFile({
+      models: {
+        providers: {
+          litellm: {
+            apiKey: "new-key",
+            baseUrl: "https://litellm.example.com",
+            models: [],
+          },
+        },
+      },
+    });
+
+    const warnings: string[] = [];
+    loggingState.rawConsole = {
+      log: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn((message: string) => warnings.push(message)),
+      error: vi.fn(),
+    };
+    setLoggerOverride({ level: "silent", consoleLevel: "warn" });
+
+    try {
+      await withGatewayServer(async () => {});
+    } finally {
+      loggingState.rawConsole = null;
+      resetLogger();
+    }
+
+    expect(
+      warnings.some(
+        (message) =>
+          message.includes('Provider "litellm" has a new apiKey in openclaw.json') &&
+          message.includes('auth profile "litellm:default"'),
+      ),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Provider API keys live in two places: `openclaw.json` (config) and the
per-agent SQLite `auth_profile_store` table. They're synced only once,
during interactive `openclaw onboard` / `openclaw models auth login`
(`src/plugins/provider-auth-choice.ts` → `upsertAuthProfileWithLockOrThrow`).

If a user later hand-edits `apiKey` in `openclaw.json` and restarts, the
runtime keeps sending the stale key from SQLite. At request time,
`resolveApiKeyForProvider` (`src/agents/model-auth-provider.ts:255-427`)
resolves a matching stored auth profile from `auth_profile_store` *before*
falling back to the literal `apiKey` in config. The only escape hatch is an
explicit `auth: "api-key"` override
(`shouldPreferExplicitConfigApiKeyAuth`,
`src/agents/model-auth-provider-config.ts:208-218`), which most users never
set. Worse, nothing warns the user that their config edit is being ignored
(openclaw/openclaw#113599).

## Why This Change Was Made

The issue is labeled `clawsweeper:needs-product-decision` — whether config
or SQLite should be authoritative at request time is a maintainer product
call, not something to decide unilaterally in a contributor PR. **This PR
intentionally does not change `model-auth-provider.ts`'s resolution order
or auto-repair credentials on every request/boot.** It only adds detection
+ visibility, plus an explicit opt-in repair gated behind
`openclaw doctor --fix`, following this repo's existing pattern for exactly
this class of problem (`AGENTS.md`: *"If a config change invalidates
existing files, add a matching `openclaw doctor --fix` migration"*) — the
same idiom already used by `repairStaleOAuthProfileShadows` and
`maybeMigrateAuthProfileJsonStoresToSqlite`.

**Update after first review round:** ClawSweeper correctly flagged that the
first version only ran inside `openclaw doctor`, so the exact reported
repro (edit `openclaw.json`, restart the gateway, nothing happens) never
reached the new warning. That's now fixed — see "Real behavior path" below
— without changing runtime credential-resolution precedence or
auto-mutating credentials on every boot.

## User Impact

- `openclaw doctor` (preview mode, no `--fix` needed) warns when a
  provider's configured `apiKey` no longer matches the credential in the
  SQLite auth profile the runtime actually uses.
- **Plain gateway restart now also warns.** `server-startup-bootstrap.ts`
  runs the same detection once at boot (not on the request hot path) and
  logs a warning when a provider's configured `apiKey` doesn't match its
  bound SQLite profile — this is the exact reported repro path (edit config
  → restart), and it no longer fails silently. It is deliberately placed
  *after* `setCurrentPluginMetadataSnapshot` so provider-alias resolution
  reuses the existing snapshot instead of forcing an eager
  `loadPluginMetadataSnapshot` disk load during startup (per
  `src/gateway/CLAUDE.md`), runs inside a `startupTrace.measure`
  (`auth.config-profile-drift`) so its cost stays visible, and is wrapped so
  a warn-only diagnostic can never block gateway boot.
- `openclaw doctor --fix` updates the stored profile's key to match config,
  so the edit takes effect without a manual SQL update. This repair is
  opt-in (explicit `--fix` invocation), never automatic on boot or request.
- Providers with an explicit `auth: "api-key"` override are skipped (config
  already wins there; no behavior change for them).
- **Explicitly out of scope, left to maintainers:** whether config should
  ever automatically override an existing SQLite profile without an
  explicit `--fix` invocation, and what the long-term precedence contract
  should be. This PR's repair only runs when a user explicitly asks for it.

## Evidence

New file `src/commands/doctor/shared/config-auth-profile-api-key-drift.ts`
(+ 8 unit tests) wired into:
- `src/commands/doctor/shared/preview-warnings.ts` (warn-only preview)
- `src/commands/doctor/repair-sequencing.ts` (`--fix` repair)
- `src/gateway/server-startup-bootstrap.ts` (boot-time warning — covers the
  plain-restart path)

**Real behavior path** — new gateway integration test
(`src/gateway/server-startup.config-auth-profile-api-key-drift.test.ts`)
boots an actual gateway server against a real SQLite auth profile store and
a real `openclaw.json`, reproducing the exact issue repro end to end:

1. Seed SQLite `auth_profile_store`: `litellm:default` -> key `"old-key"`
   (simulates onboarding having already run)
2. Write `openclaw.json`: `models.providers.litellm.apiKey = "new-key"`
   (simulates the user's config edit)
3. Boot the gateway (`withGatewayServer`) — a plain restart, no
   `openclaw doctor` invocation
4. Assert a warning is logged: `Provider "litellm" has a new apiKey in
   openclaw.json, but auth profile "litellm:default" ... still holds the
   previous key and is what the runtime sends. Run "openclaw doctor --fix"
   to update the stored profile to match, or set auth: "api-key" on this
   provider entry to always prefer config.`

```
node scripts/run-vitest.mjs src/gateway/server-startup.config-auth-profile-api-key-drift.test.ts -- --reporter=verbose

 ✓ |gateway-server| .../server-startup.config-auth-profile-api-key-drift.test.ts
   > gateway startup config auth profile apiKey drift warning
   > warns on plain restart when a provider apiKey edit never reached the SQLite auth profile   2660ms

 Test Files  1 passed (1)
      Tests  1 passed (1)
```

This does not yet include an actual outbound HTTP call proving key
`"new-key"` reaches litellm after `doctor --fix` — that would need a live
litellm endpoint. The closest available proof without one:
`config-auth-profile-api-key-drift.test.ts` asserts
`repairConfigAuthProfileApiKeyDrifts` updates the stored profile and that
`scanConfigAuthProfileApiKeyDrifts` reports no further drift afterward.

Full local validation (Testbox unavailable in this environment; ran locally
per repo fallback policy):
```
node scripts/run-vitest.mjs src/commands/doctor/shared/config-auth-profile-api-key-drift.test.ts
node scripts/run-vitest.mjs src/commands/doctor/repair-sequencing.test.ts src/commands/doctor/shared/preview-warnings.test.ts
node scripts/run-vitest.mjs src/gateway/server-startup.config-auth-profile-api-key-drift.test.ts
# 72 passed total, no regressions

pnpm tsgo:core            # clean
pnpm tsgo:core:test       # clean
pnpm check:architecture   # import cycles 0, madge 0, deprecated-api, kysely,
                          # database-first legacy stores — all pass
pnpm check:max-lines-ratchet   # OK
node scripts/run-additional-boundary-checks.mjs   # 22/22 [ok], exit 0
node scripts/run-oxlint.mjs <changed files>       # clean
```

The boundary lane matters here specifically because this PR adds a
`src/gateway/**` → `src/commands/doctor/shared/**` import; all 22 boundary
checks plus `check:architecture` pass with it.

## Open question for maintainers

Per ClawSweeper's review: when a configured provider API key and its bound
SQLite auth profile disagree, should config be authoritative at runtime, or
should SQLite remain authoritative until the user explicitly runs
`doctor --fix`? This PR takes the latter position (SQLite stays
authoritative at request time; config only wins via explicit `--fix` or an
explicit `auth: "api-key"` override) because changing runtime precedence is
exactly the product decision the linked issue flags as unresolved. Happy to
adjust the implementation once that's decided.

Fixes openclaw/openclaw#113599
