### PR TITLE
fix(models): show refreshed OpenAI models in provider-filtered lists

### DIFF
--- a/src/commands/models/list.list-command.forward-compat.test.ts
+++ b/src/commands/models/list.list-command.forward-compat.test.ts
@@ -940,6 +940,60 @@ describe("modelsListCommand forward-compat", () => {
       ]);
     });
 
+    it("keeps OpenAI runtime rows authoritative while adding refreshed models once", async () => {
+      mocks.resolveConfiguredEntries.mockReturnValueOnce({ entries: [] });
+      mocks.hasProviderRuntimeCatalogForFilter.mockResolvedValueOnce(true);
+      mocks.loadProviderCatalogModelsForList.mockResolvedValueOnce([
+        {
+          provider: "openai",
+          id: "gpt-live",
+          name: "Live GPT",
+          api: "openai-responses",
+          baseUrl: "https://api.openai.com/v1",
+          input: ["text"],
+          contextWindow: 200_000,
+          maxTokens: 4096,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        },
+      ]);
+      mocks.loadSupplementalManifestCatalogRowsForList.mockReturnValueOnce([
+        {
+          provider: "openai",
+          id: "gpt-live",
+          ref: "openai/gpt-live",
+          mergeKey: "openai::gpt-live",
+          name: "Refreshed Duplicate GPT",
+          source: "runtime-refresh",
+          input: ["text"],
+          reasoning: false,
+          status: "available",
+          baseUrl: "https://api.openai.com/v1",
+          contextWindow: 200_000,
+        },
+        {
+          provider: "openai",
+          id: "gpt-refreshed",
+          ref: "openai/gpt-refreshed",
+          mergeKey: "openai::gpt-refreshed",
+          name: "Refreshed GPT",
+          source: "runtime-refresh",
+          input: ["text"],
+          reasoning: false,
+          status: "available",
+          baseUrl: "https://api.openai.com/v1",
+          contextWindow: 200_000,
+        },
+      ]);
+      const runtime = createRuntime();
+
+      await modelsListCommand({ all: true, provider: "openai", json: true }, runtime as never);
+
+      expect(mocks.loadModelRegistry).not.toHaveBeenCalled();
+      const rows = lastPrintedRows<{ key: string; name: string }>();
+      expectRowKeys(rows, ["openai/gpt-live", "openai/gpt-refreshed"]);
+      expect(requireRow(rows, "openai/gpt-live").name).toBe("Live GPT");
+    });
+
     it("keeps provider-catalog Codex availability indeterminate without model auth", async () => {
       mocks.resolveConfiguredEntries.mockReturnValueOnce({ entries: [] });
       mocks.hasProviderStaticCatalogForFilter.mockResolvedValueOnce(true);

--- a/src/commands/models/list.manifest-catalog.test.ts
+++ b/src/commands/models/list.manifest-catalog.test.ts
@@ -6,6 +6,7 @@ const mocks = vi.hoisted(() => ({
   resolvePluginContributionOwners: vi.fn(),
   getPluginRecord: vi.fn(),
   isPluginEnabled: vi.fn(),
+  getRemoteModelCatalogOverlay: vi.fn(),
 }));
 
 vi.mock("../../plugins/plugin-registry.js", () => ({
@@ -17,6 +18,10 @@ vi.mock("../../plugins/plugin-registry.js", () => ({
 vi.mock("../../plugins/plugin-metadata-snapshot.js", () => ({
   loadPluginMetadataSnapshot: mocks.loadPluginMetadataSnapshot,
   resolvePluginMetadataSnapshot: mocks.loadPluginMetadataSnapshot,
+}));
+
+vi.mock("../../model-catalog/remote-overlay.js", () => ({
+  getRemoteModelCatalogOverlay: mocks.getRemoteModelCatalogOverlay,
 }));
 
 const moonshotPlugin = {
@@ -49,9 +54,25 @@ const openrouterPlugin = {
   },
 };
 
+const openaiRuntimePlugin = {
+  id: "openai",
+  providers: ["openai"],
+  modelCatalog: {
+    providers: {
+      openai: {
+        models: [{ id: "gpt-known", name: "Known GPT" }],
+      },
+    },
+    discovery: {
+      openai: "runtime",
+    },
+  },
+};
+
 describe("loadStaticManifestCatalogRowsForList", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.getRemoteModelCatalogOverlay.mockReturnValue(undefined);
   });
 
   it("loads only static manifest catalog rows without a provider filter", async () => {
@@ -97,6 +118,45 @@ describe("loadStaticManifestCatalogRowsForList", () => {
         cfg: {},
       }).map((row) => row.ref),
     ).toEqual(["moonshot/kimi-k2.6", "openrouter/auto"]);
+  });
+
+  it("supplements runtime-owned providers with refreshed rows only", async () => {
+    const { loadStaticManifestCatalogRowsForList, loadSupplementalManifestCatalogRowsForList } =
+      await import("./list.manifest-catalog.js");
+    const manifestRegistry = {
+      plugins: [openaiRuntimePlugin],
+      diagnostics: [],
+    };
+    const metadataSnapshot = {
+      index: { plugins: [], diagnostics: [] },
+      manifestRegistry,
+      plugins: manifestRegistry.plugins,
+    };
+    mocks.getRemoteModelCatalogOverlay.mockReturnValue({
+      openai: {
+        models: [{ id: "gpt-refreshed", name: "Refreshed GPT" }],
+      },
+    });
+    mocks.getPluginRecord.mockReturnValue({ pluginId: "openai" });
+    mocks.isPluginEnabled.mockReturnValue(true);
+
+    const params = {
+      cfg: {},
+      providerFilter: "openai",
+      metadataSnapshot: metadataSnapshot as unknown as Parameters<
+        typeof loadSupplementalManifestCatalogRowsForList
+      >[0]["metadataSnapshot"],
+    };
+
+    expect(loadStaticManifestCatalogRowsForList(params)).toEqual([]);
+    expect(loadSupplementalManifestCatalogRowsForList(params)).toMatchObject([
+      {
+        provider: "openai",
+        id: "gpt-refreshed",
+        ref: "openai/gpt-refreshed",
+        source: "runtime-refresh",
+      },
+    ]);
   });
 
   it("uses an injected metadata snapshot instead of loading metadata again", async () => {

--- a/src/commands/models/list.manifest-catalog.ts
+++ b/src/commands/models/list.manifest-catalog.ts
@@ -48,10 +48,21 @@ function loadManifestCatalogRowsForPluginIds(params: {
       )
       .map((entry) => entry.provider),
   );
-  if (eligibleProviders.size === 0) {
+  const runtimeRefreshProviders = new Set(
+    params.mode === "supplemental"
+      ? plan.entries.filter((entry) => entry.discovery === "runtime").map((entry) => entry.provider)
+      : [],
+  );
+  if (eligibleProviders.size === 0 && runtimeRefreshProviders.size === 0) {
     return [];
   }
-  return plan.rows.filter((row) => eligibleProviders.has(row.provider));
+  // Runtime-owned providers still discover authoritative models live; only
+  // validated remote-refresh rows may supplement that provider catalog.
+  return plan.rows.filter(
+    (row) =>
+      eligibleProviders.has(row.provider) ||
+      (runtimeRefreshProviders.has(row.provider) && row.source === "runtime-refresh"),
+  );
 }
 
 function resolveConventionModelCatalogPluginIds(params: {


### PR DESCRIPTION
Related: #114244, #113660.

## What Problem This Solves

Fixes an issue where users refreshing the hosted dynamic model catalog would still not see newly published OpenAI models in `openclaw models list --all --provider openai`, even though refresh succeeded and the model was safely persisted. The same workflow already exposed refreshed Anthropic models, which made the OpenAI runtime-provider regression easy to miss.

## Why This Change Was Made

Preserve authoritative, account-aware runtime model discovery and the existing OpenAI manifest. Supplement runtime-owned provider output only with validated `runtime-refresh` rows from the existing hosted catalog; ordinary static manifest rows remain excluded, and live-discovered rows retain priority when deduplicating.

AI-assisted: Codex. The runtime-discovery contract was checked directly against upstream Codex revision `95637f7056835fea66bdd0044414af480fc0fd74`, including `codex-rs/app-server/src/models.rs:13`, `codex-rs/app-server/src/request_processors/catalog_processor.rs:255`, `codex-rs/app-server/tests/suite/v2/model_list.rs:153`, and `codex-rs/app-server/src/models_refresh_worker.rs:30`.

## User Impact

Refreshed OpenAI and other runtime-owned provider models appear in provider-filtered lists after Gateway restart, alongside normal runtime-discovered models. Provider authorization, suppression, trusted transport, duplicate precedence, stable running-Gateway snapshots, and disabled-refresh behavior remain unchanged.

## Evidence

- Reproduced on current `main` using a real, production-built Gateway and isolated local hosted mirror: refreshed OpenAI was persisted but filtered output failed with `OpenAI provider list omitted the refreshed model`.
- Proved the defect failing-first: the new runtime-provider unit regression returned `[]` before the production change.
- Production-built Gateway stress: 29 checks passed against a 39-provider, 219-model mirror, including six concurrent refresh writers, six concurrent live Gateway readers, twelve concurrent post-restart Gateway/CLI reads, OpenAI and Anthropic provider filtering, single-row model deduplication, malicious transport-field stripping, repeated restarts, failed and malformed mirrors, oversized and duplicate catalogs, future-version/timestamp rejection, rollback refusal, HTTP 304, and concurrent disabled refresh with zero mirror requests.
- 608 passing tests across 11 scoped shards covering the model catalog, Gateway, publisher, updater, OpenAI/Anthropic plugins, runtime-provider discovery, suppression, and CLI composition.
- Five complete consecutive passes of the four direct regression files: 230 passing regression executions.
- Production `pnpm build`, final `pnpm check:changed`, and `git diff --check`.
- Fresh independent `.agents/skills/autoreview/scripts/autoreview --mode uncommitted`: clean; secret scan clean.
- All heavy validation ran on Linux Node 24.18.0 using the maintained Blacksmith development Testbox.
