### PR TITLE
fix(ui): back off unavailable session PR polling

### DIFF
--- a/ui/src/api/gateway.node.test.ts
+++ b/ui/src/api/gateway.node.test.ts
@@ -608,6 +608,263 @@ describe("GatewayBrowserClient", () => {
     });
   });
 
+  it("latches unavailable session PR refreshes until the connection is replaced", async () => {
+    useNodeFakeTimers();
+    const client = new GatewayBrowserClient({
+      url: "ws://127.0.0.1:18789",
+      token: "shared-auth-token",
+    });
+
+    try {
+      const { ws: firstWs, connectFrame: firstConnect } = await startConnect(client);
+      firstWs.emitMessage({
+        type: "res",
+        id: firstConnect.id,
+        ok: true,
+        payload: {
+          type: "hello-ok",
+          protocol: 4,
+          auth: { role: "operator", scopes: [] },
+        },
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      expect(client.connected).toBe(true);
+
+      const firstRefresh = client.requestSessionPullRequests({
+        sessionKey: "agent:main:first",
+      });
+      const firstRequest = JSON.parse(firstWs.sent.at(-1) ?? "{}") as {
+        id?: string;
+        method?: string;
+      };
+      expect(firstRequest.method).toBe("controlUi.sessionPullRequests");
+      firstWs.emitMessage({
+        type: "res",
+        id: firstRequest.id,
+        ok: false,
+        error: {
+          code: "UNAVAILABLE",
+          message: "session pull requests unavailable",
+          retryable: false,
+        },
+      });
+      await expect(firstRefresh).rejects.toMatchObject({ gatewayCode: "UNAVAILABLE" });
+
+      const sentAfterFailure = firstWs.sent.length;
+      await expect(
+        client.requestSessionPullRequests({ sessionKey: "agent:main:second" }),
+      ).resolves.toBeNull();
+      await expect(
+        client.requestSessionPullRequests({ sessionKey: "agent:main:third" }),
+      ).resolves.toBeNull();
+      expect(firstWs.sent).toHaveLength(sentAfterFailure);
+
+      firstWs.emitClose(1006, "socket lost");
+      await vi.advanceTimersByTimeAsync(800);
+      const secondWs = getLatestWebSocket();
+      expect(secondWs).not.toBe(firstWs);
+      const { connectFrame: secondConnect } = await continueConnect(secondWs, "nonce-2");
+      secondWs.emitMessage({
+        type: "res",
+        id: secondConnect.id,
+        ok: true,
+        payload: {
+          type: "hello-ok",
+          protocol: 4,
+          auth: { role: "operator", scopes: [] },
+        },
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      expect(client.connected).toBe(true);
+
+      const reconnectedRefresh = client.requestSessionPullRequests({
+        sessionKey: "agent:main:second",
+      });
+      const reconnectedRequest = JSON.parse(secondWs.sent.at(-1) ?? "{}") as {
+        id?: string;
+        method?: string;
+      };
+      expect(reconnectedRequest.method).toBe("controlUi.sessionPullRequests");
+      secondWs.emitMessage({
+        type: "res",
+        id: reconnectedRequest.id,
+        ok: true,
+        payload: { pullRequests: [], rateLimited: false },
+      });
+      await expect(reconnectedRefresh).resolves.toEqual({
+        pullRequests: [],
+        rateLimited: false,
+      });
+    } finally {
+      client.stop();
+      vi.useRealTimers();
+    }
+  });
+
+  it("backs off once for concurrent retryable session PR failures", async () => {
+    useNodeFakeTimers();
+    const client = new GatewayBrowserClient({
+      url: "ws://127.0.0.1:18789",
+      token: "shared-auth-token",
+    });
+
+    try {
+      const { ws, connectFrame } = await startConnect(client);
+      ws.emitMessage({
+        type: "res",
+        id: connectFrame.id,
+        ok: true,
+        payload: {
+          type: "hello-ok",
+          protocol: 4,
+          auth: { role: "operator", scopes: [] },
+        },
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      expect(client.connected).toBe(true);
+
+      const firstRefresh = client.requestSessionPullRequests({ sessionKey: "agent:main:first" });
+      const firstRequest = JSON.parse(ws.sent.at(-1) ?? "{}") as { id?: string };
+      const parallelRefresh = client.requestSessionPullRequests({
+        sessionKey: "agent:main:parallel",
+      });
+      const parallelRequest = JSON.parse(ws.sent.at(-1) ?? "{}") as { id?: string };
+      expect(firstRequest.id).toBeTypeOf("string");
+      expect(parallelRequest.id).toBeTypeOf("string");
+      expect(parallelRequest.id).not.toBe(firstRequest.id);
+      const retryWindowStartedAt = Date.now();
+      const unavailable = (id: string | undefined) =>
+        ws.emitMessage({
+          type: "res",
+          id,
+          ok: false,
+          error: {
+            code: "UNAVAILABLE",
+            message: "session pull requests unavailable",
+            retryable: true,
+            retryAfterMs: 1_000,
+          },
+        });
+      unavailable(firstRequest.id);
+      await expect(firstRefresh).rejects.toMatchObject({
+        gatewayCode: "UNAVAILABLE",
+        retryable: true,
+      });
+      unavailable(parallelRequest.id);
+      await expect(parallelRefresh).rejects.toMatchObject({
+        gatewayCode: "UNAVAILABLE",
+        retryable: true,
+      });
+
+      const sentAfterFailure = ws.sent.length;
+      vi.setSystemTime(retryWindowStartedAt + 29_999);
+      await expect(
+        client.requestSessionPullRequests({ sessionKey: "agent:main:second" }),
+      ).resolves.toBeNull();
+      expect(ws.sent).toHaveLength(sentAfterFailure);
+
+      vi.setSystemTime(retryWindowStartedAt + 30_000);
+      const retriedRefresh = client.requestSessionPullRequests({
+        sessionKey: "agent:main:second",
+      });
+      const retriedRequest = JSON.parse(ws.sent.at(-1) ?? "{}") as {
+        id?: string;
+        method?: string;
+      };
+      expect(retriedRequest.method).toBe("controlUi.sessionPullRequests");
+      ws.emitMessage({
+        type: "res",
+        id: retriedRequest.id,
+        ok: true,
+        payload: { pullRequests: [], rateLimited: false },
+      });
+      await expect(retriedRefresh).resolves.toEqual({
+        pullRequests: [],
+        rateLimited: false,
+      });
+    } finally {
+      client.stop();
+      vi.useRealTimers();
+    }
+  });
+
+  it.each(["success-first", "failure-first"] as const)(
+    "keeps a concurrent session PR failure latched with %s completion",
+    async (order) => {
+      useNodeFakeTimers();
+      const client = new GatewayBrowserClient({
+        url: "ws://127.0.0.1:18789",
+        token: "shared-auth-token",
+      });
+
+      try {
+        const { ws, connectFrame } = await startConnect(client);
+        ws.emitMessage({
+          type: "res",
+          id: connectFrame.id,
+          ok: true,
+          payload: {
+            type: "hello-ok",
+            protocol: 4,
+            auth: { role: "operator", scopes: [] },
+          },
+        });
+        await vi.advanceTimersByTimeAsync(0);
+        expect(client.connected).toBe(true);
+
+        const successfulRefresh = client.requestSessionPullRequests({
+          sessionKey: "agent:main:success",
+        });
+        const successfulRequest = JSON.parse(ws.sent.at(-1) ?? "{}") as { id?: string };
+        const failedRefresh = client.requestSessionPullRequests({
+          sessionKey: "agent:main:failure",
+        });
+        const failedRequest = JSON.parse(ws.sent.at(-1) ?? "{}") as { id?: string };
+        const succeed = async () => {
+          ws.emitMessage({
+            type: "res",
+            id: successfulRequest.id,
+            ok: true,
+            payload: { pullRequests: [], rateLimited: false },
+          });
+          await expect(successfulRefresh).resolves.toEqual({
+            pullRequests: [],
+            rateLimited: false,
+          });
+        };
+        const fail = async () => {
+          ws.emitMessage({
+            type: "res",
+            id: failedRequest.id,
+            ok: false,
+            error: {
+              code: "UNAVAILABLE",
+              message: "session pull requests unavailable",
+              retryable: false,
+            },
+          });
+          await expect(failedRefresh).rejects.toMatchObject({ gatewayCode: "UNAVAILABLE" });
+        };
+        if (order === "success-first") {
+          await succeed();
+          await fail();
+        } else {
+          await fail();
+          await succeed();
+        }
+
+        const sentAfterWave = ws.sent.length;
+        await expect(
+          client.requestSessionPullRequests({ sessionKey: "agent:main:next" }),
+        ).resolves.toBeNull();
+        expect(ws.sent).toHaveLength(sentAfterWave);
+      } finally {
+        client.stop();
+        vi.useRealTimers();
+      }
+    },
+  );
+
   it("tracks inbound activity and delegates forced reconnect to the shared socket", async () => {
     const client = new GatewayBrowserClient({
       url: "ws://127.0.0.1:18789",

--- a/ui/src/api/gateway.ts
+++ b/ui/src/api/gateway.ts
@@ -210,7 +210,7 @@ const BROWSER_WEBSOCKET_SECURITY_ERROR_CODE = "BROWSER_WEBSOCKET_SECURITY_ERROR"
 const SESSION_PULL_REQUESTS_RETRY_BASE_MS = 30_000;
 const SESSION_PULL_REQUESTS_RETRY_MAX_MS = 5 * 60_000;
 
-export type GatewaySessionPullRequestsParams = {
+type GatewaySessionPullRequestsParams = {
   sessionKey: string;
   agentId?: string;
   refresh?: boolean;

--- a/ui/src/api/gateway.ts
+++ b/ui/src/api/gateway.ts
@@ -30,6 +30,7 @@ import {
   MIN_CLIENT_PROTOCOL_VERSION,
   PROTOCOL_VERSION,
 } from "@openclaw/gateway-client/browser";
+import type { ControlUiSessionPullRequests } from "../../../src/gateway/control-ui-contract.js";
 import {
   clearDeviceAuthToken,
   loadDeviceAuthToken,
@@ -206,6 +207,14 @@ const STARTUP_RETRY_CLOSE_CODE = 4013;
 const BROWSER_WEBSOCKET_CLOSE_CODE = 1006;
 const BROWSER_WEBSOCKET_CONSTRUCTOR_ERROR_CODE = "BROWSER_WEBSOCKET_CONSTRUCTOR_ERROR";
 const BROWSER_WEBSOCKET_SECURITY_ERROR_CODE = "BROWSER_WEBSOCKET_SECURITY_ERROR";
+const SESSION_PULL_REQUESTS_RETRY_BASE_MS = 30_000;
+const SESSION_PULL_REQUESTS_RETRY_MAX_MS = 5 * 60_000;
+
+export type GatewaySessionPullRequestsParams = {
+  sessionKey: string;
+  agentId?: string;
+  refresh?: boolean;
+};
 
 function getErrorMessage(err: unknown): string {
   return err instanceof Error && err.message ? err.message : String(err);
@@ -301,6 +310,13 @@ export class GatewayBrowserClient {
   inboundActivitySeq = 0;
   private pendingDeviceTokenRetry = false;
   private deviceTokenRetryBudgetUsed = false;
+  // This optional surface can be advertised before its runtime dependency is usable.
+  // Scope failures to one socket hello; the generation keeps concurrent rows from
+  // multiplying one outage wave's backoff.
+  private sessionPullRequestsUnavailable = false;
+  private sessionPullRequestsRetryAtMs = 0;
+  private sessionPullRequestsRetryDelayMs = 0;
+  private sessionPullRequestsAvailabilityGeneration = 0;
   private readonly recoveryScopeTracker = new GatewayRecoveryScopeTracker();
 
   constructor(private opts: GatewayBrowserClientOptions) {
@@ -378,6 +394,7 @@ export class GatewayBrowserClient {
     this.client.stop();
     this.pendingDeviceTokenRetry = false;
     this.deviceTokenRetryBudgetUsed = false;
+    this.resetSessionPullRequestsAvailability();
   }
 
   get connected() {
@@ -494,6 +511,7 @@ export class GatewayBrowserClient {
   private handleConnectHello(hello: GatewayHelloOk, plan: ConnectPlan) {
     this.pendingDeviceTokenRetry = false;
     this.deviceTokenRetryBudgetUsed = false;
+    this.resetSessionPullRequestsAvailability();
     this.opts.bootstrapToken = undefined;
     if (hello?.auth?.deviceToken && plan.deviceIdentity) {
       storeDeviceAuthToken({
@@ -592,6 +610,60 @@ export class GatewayBrowserClient {
     options?: GatewayProtocolRequestOptions,
   ): Promise<T> {
     return this.client.request<T>(method, params, options);
+  }
+
+  async requestSessionPullRequests(
+    params: GatewaySessionPullRequestsParams,
+  ): Promise<ControlUiSessionPullRequests | null> {
+    if (this.sessionPullRequestsUnavailable || Date.now() < this.sessionPullRequestsRetryAtMs) {
+      return null;
+    }
+    const availabilityGeneration = this.sessionPullRequestsAvailabilityGeneration;
+    try {
+      const result = await this.request<ControlUiSessionPullRequests>(
+        "controlUi.sessionPullRequests",
+        params,
+      );
+      if (availabilityGeneration === this.sessionPullRequestsAvailabilityGeneration) {
+        this.clearSessionPullRequestsAvailability();
+      }
+      return result;
+    } catch (error) {
+      if (
+        error instanceof GatewayRequestError &&
+        error.gatewayCode === "UNAVAILABLE" &&
+        availabilityGeneration === this.sessionPullRequestsAvailabilityGeneration
+      ) {
+        if (!error.retryable) {
+          this.sessionPullRequestsUnavailable = true;
+          this.sessionPullRequestsAvailabilityGeneration += 1;
+        } else {
+          const localDelayMs = Math.min(
+            this.sessionPullRequestsRetryDelayMs || SESSION_PULL_REQUESTS_RETRY_BASE_MS,
+            SESSION_PULL_REQUESTS_RETRY_MAX_MS,
+          );
+          const delayMs = Math.max(error.retryAfterMs ?? 0, localDelayMs);
+          this.sessionPullRequestsRetryDelayMs = Math.min(
+            localDelayMs * 2,
+            SESSION_PULL_REQUESTS_RETRY_MAX_MS,
+          );
+          this.sessionPullRequestsRetryAtMs = Date.now() + delayMs;
+          this.sessionPullRequestsAvailabilityGeneration += 1;
+        }
+      }
+      throw error;
+    }
+  }
+
+  private resetSessionPullRequestsAvailability(): void {
+    this.clearSessionPullRequestsAvailability();
+    this.sessionPullRequestsAvailabilityGeneration += 1;
+  }
+
+  private clearSessionPullRequestsAvailability(): void {
+    this.sessionPullRequestsUnavailable = false;
+    this.sessionPullRequestsRetryAtMs = 0;
+    this.sessionPullRequestsRetryDelayMs = 0;
   }
 
   addEventListener(listener: GatewayEventListener): () => void {

--- a/ui/src/components/app-sidebar-session-pr-indicators.test.ts
+++ b/ui/src/components/app-sidebar-session-pr-indicators.test.ts
@@ -34,7 +34,7 @@ describe("SessionPullRequestIndicatorsController", () => {
     } as SidebarRecentSession;
     let state: "open" | "merged" = "open";
     let rateLimited = false;
-    const request = vi.fn(() =>
+    const request = vi.fn((_method: string, _params: unknown) =>
       Promise.resolve({
         pullRequests: rateLimited
           ? []

--- a/ui/src/components/app-sidebar-session-pr-indicators.test.ts
+++ b/ui/src/components/app-sidebar-session-pr-indicators.test.ts
@@ -53,7 +53,11 @@ describe("SessionPullRequestIndicatorsController", () => {
       }),
     );
     const snapshot = {
-      client: { request } as unknown as GatewayBrowserClient,
+      client: {
+        request,
+        requestSessionPullRequests: (params: { sessionKey: string; agentId?: string }) =>
+          request("controlUi.sessionPullRequests", params),
+      } as unknown as GatewayBrowserClient,
       hello: { features: { methods: ["controlUi.sessionPullRequests"] } },
     } as ApplicationGatewaySnapshot;
     const controller = new SessionPullRequestIndicatorsController(host, {

--- a/ui/src/components/session-menu-work.test.ts
+++ b/ui/src/components/session-menu-work.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
-import type { ControlUiSessionPullRequest } from "../../../src/gateway/control-ui-contract.js";
+import type {
+  ControlUiSessionPullRequest,
+  ControlUiSessionPullRequests,
+} from "../../../src/gateway/control-ui-contract.js";
 import {
   fetchSessionMenuWork,
   fetchSessionPullRequestIndicatorState,
@@ -18,14 +21,18 @@ function pullRequest(overrides: Partial<ControlUiSessionPullRequest>): ControlUi
   };
 }
 
-function sessionMenuClient(request: ReturnType<typeof vi.fn>) {
+function sessionMenuClient(request: (method: string, params: unknown) => Promise<unknown>) {
   return {
     request: request as never,
     requestSessionPullRequests: (params: {
       sessionKey: string;
       agentId?: string;
       refresh?: boolean;
-    }) => request("controlUi.sessionPullRequests", params),
+    }) =>
+      request(
+        "controlUi.sessionPullRequests",
+        params,
+      ) as Promise<ControlUiSessionPullRequests | null>,
   };
 }
 

--- a/ui/src/components/session-menu-work.test.ts
+++ b/ui/src/components/session-menu-work.test.ts
@@ -18,6 +18,17 @@ function pullRequest(overrides: Partial<ControlUiSessionPullRequest>): ControlUi
   };
 }
 
+function sessionMenuClient(request: ReturnType<typeof vi.fn>) {
+  return {
+    request: request as never,
+    requestSessionPullRequests: (params: {
+      sessionKey: string;
+      agentId?: string;
+      refresh?: boolean;
+    }) => request("controlUi.sessionPullRequests", params),
+  };
+}
+
 describe("session pull request indicators", () => {
   it.each([
     {
@@ -42,7 +53,7 @@ describe("session pull request indicators", () => {
     const request = vi.fn(() => Promise.resolve({ pullRequests, rateLimited: false }));
     await expect(
       fetchSessionPullRequestIndicatorState({
-        client: { request: request as never },
+        client: sessionMenuClient(request),
         pullRequestsAvailable: true,
         sessionKey: "agent:main:demo",
       }),
@@ -53,7 +64,7 @@ describe("session pull request indicators", () => {
     const request = vi.fn(() => Promise.resolve({ pullRequests: [], rateLimited: true }));
     await expect(
       fetchSessionPullRequestIndicatorState({
-        client: { request: request as never },
+        client: sessionMenuClient(request),
         pullRequestsAvailable: true,
         sessionKey: "agent:main:demo",
       }),
@@ -67,7 +78,7 @@ describe("session pull request indicators", () => {
 
     await expect(
       fetchSessionPullRequestIndicatorState({
-        client: { request: request as never },
+        client: sessionMenuClient(request),
         pullRequestsAvailable: true,
         sessionKey: "agent:main:demo",
         agentId: "main",
@@ -107,7 +118,7 @@ describe("fetchSessionMenuWork", () => {
 
     await expect(
       fetchSessionMenuWork({
-        client: { request: request as never },
+        client: sessionMenuClient(request),
         pullRequestsAvailable: true,
         sessionKey: "agent:main:demo",
         agentId: "main",
@@ -127,7 +138,7 @@ describe("fetchSessionMenuWork", () => {
     const failing = vi.fn(() => Promise.reject(new Error("offline")));
     await expect(
       fetchSessionMenuWork({
-        client: { request: failing as never },
+        client: sessionMenuClient(failing),
         pullRequestsAvailable: true,
         sessionKey: "agent:main:demo",
         worktreeId: "wt-1",
@@ -139,7 +150,7 @@ describe("fetchSessionMenuWork", () => {
     );
     await expect(
       fetchSessionMenuWork({
-        client: { request: request as never },
+        client: sessionMenuClient(request),
         pullRequestsAvailable: false,
         sessionKey: "agent:main:demo",
         worktreeId: "wt-1",

--- a/ui/src/components/session-menu-work.ts
+++ b/ui/src/components/session-menu-work.ts
@@ -3,13 +3,12 @@ import type {
   ControlUiSessionPullRequest,
   ControlUiSessionPullRequests,
 } from "../../../src/gateway/control-ui-contract.js";
+import type { GatewayBrowserClient } from "../api/gateway.ts";
 
 // Shared by the app sidebar and the Sessions page: both hosts resolve the
 // same worktree-session extras (PR link, checkout path) when opening the
 // session context menu, after the menu is already visible.
-type SessionMenuWorkClient = {
-  request: <T>(method: string, params?: unknown) => Promise<T>;
-};
+type SessionMenuWorkClient = Pick<GatewayBrowserClient, "request" | "requestSessionPullRequests">;
 
 type SessionMenuWorkParams = {
   client: SessionMenuWorkClient;
@@ -63,8 +62,8 @@ function resolveSessionPullRequestIndicatorState(
 
 async function loadSessionPullRequests(
   params: Omit<SessionMenuWorkParams, "worktreeId">,
-): Promise<ControlUiSessionPullRequests> {
-  return params.client.request<ControlUiSessionPullRequests>("controlUi.sessionPullRequests", {
+): Promise<ControlUiSessionPullRequests | null> {
+  return params.client.requestSessionPullRequests({
     sessionKey: params.sessionKey,
     ...(params.agentId ? { agentId: params.agentId } : {}),
   });
@@ -77,7 +76,9 @@ export async function fetchSessionPullRequestIndicatorState(
     return "none";
   }
   const result = await loadSessionPullRequests(params);
-  return result.rateLimited ? null : resolveSessionPullRequestIndicatorState(result.pullRequests);
+  return !result || result.rateLimited
+    ? null
+    : resolveSessionPullRequestIndicatorState(result.pullRequests);
 }
 
 async function loadPullRequestUrl(params: SessionMenuWorkParams): Promise<string | null> {
@@ -86,7 +87,7 @@ async function loadPullRequestUrl(params: SessionMenuWorkParams): Promise<string
   }
   try {
     const result = await loadSessionPullRequests(params);
-    return pickSessionMenuPullRequestUrl(result.pullRequests);
+    return result ? pickSessionMenuPullRequestUrl(result.pullRequests) : null;
   } catch {
     // Optional affordance: a GitHub or gateway hiccup just leaves Open PR disabled.
     return null;

--- a/ui/src/pages/chat/chat-pane-deps.ts
+++ b/ui/src/pages/chat/chat-pane-deps.ts
@@ -31,7 +31,6 @@ export {
 export type {
   ControlUiSessionBranch,
   ControlUiSessionPullRequest,
-  ControlUiSessionPullRequests,
 } from "../../../../src/gateway/control-ui-contract.js";
 export { GatewayRequestError, type GatewayBrowserClient } from "../../api/gateway.ts";
 export type {

--- a/ui/src/pages/chat/chat-pane-pull-requests.test.ts
+++ b/ui/src/pages/chat/chat-pane-pull-requests.test.ts
@@ -94,7 +94,11 @@ describe("chat pane pull request refresh", () => {
       ],
       rateLimited: false,
     });
-    const client = { request } as unknown as GatewayBrowserClient;
+    const client = {
+      request,
+      requestSessionPullRequests: (params: { sessionKey: string; refresh?: boolean }) =>
+        request("controlUi.sessionPullRequests", params),
+    } as unknown as GatewayBrowserClient;
     const epoch = Symbol("pr-refresh");
     const setPullRequestSummary = vi.fn();
     const sessions = {
@@ -143,7 +147,11 @@ describe("chat pane pull request refresh", () => {
     const epoch = Symbol("pr-refresh");
     const setPullRequestSummary = vi.fn();
     const { pane } = createTestChatPane({
-      client: { request } as unknown as GatewayBrowserClient,
+      client: {
+        request,
+        requestSessionPullRequests: (params: { sessionKey: string }) =>
+          request("controlUi.sessionPullRequests", params),
+      } as unknown as GatewayBrowserClient,
       sessions: {
         capturePullRequestEpoch: vi.fn(() => epoch),
         setPullRequestSummary,
@@ -192,7 +200,11 @@ describe("chat pane pull request refresh", () => {
     const request = vi.fn().mockResolvedValue({ pullRequests: [], rateLimited: true });
     const setPullRequestSummary = vi.fn();
     const { pane } = createTestChatPane({
-      client: { request } as unknown as GatewayBrowserClient,
+      client: {
+        request,
+        requestSessionPullRequests: (params: { sessionKey: string }) =>
+          request("controlUi.sessionPullRequests", params),
+      } as unknown as GatewayBrowserClient,
       sessions: {
         capturePullRequestEpoch: vi.fn(() => Symbol("pr-refresh")),
         setPullRequestSummary,
@@ -225,7 +237,11 @@ describe("chat pane pull request refresh", () => {
     const epoch = Symbol("pr-refresh");
     const setPullRequestSummary = vi.fn();
     const { pane } = createTestChatPane({
-      client: { request } as unknown as GatewayBrowserClient,
+      client: {
+        request,
+        requestSessionPullRequests: (params: { sessionKey: string }) =>
+          request("controlUi.sessionPullRequests", params),
+      } as unknown as GatewayBrowserClient,
       sessions: {
         capturePullRequestEpoch: vi.fn(() => epoch),
         setPullRequestSummary,

--- a/ui/src/pages/chat/chat-pane-pull-requests.test.ts
+++ b/ui/src/pages/chat/chat-pane-pull-requests.test.ts
@@ -27,7 +27,11 @@ describe("chat pane pull request refresh", () => {
         await (params.sessionKey === "agent:main:current" ? previous : current),
     );
     const { pane, state } = createTestChatPane({
-      client: { request } as unknown as GatewayBrowserClient,
+      client: {
+        request,
+        requestSessionPullRequests: (params: { sessionKey: string }) =>
+          request("controlUi.sessionPullRequests", params),
+      } as unknown as GatewayBrowserClient,
       sessions: {
         capturePullRequestEpoch: vi.fn(() => Symbol("pr-refresh")),
         setPullRequestSummary: vi.fn(),

--- a/ui/src/pages/chat/chat-pane-session-hydration.test.ts
+++ b/ui/src/pages/chat/chat-pane-session-hydration.test.ts
@@ -24,7 +24,11 @@ describe("chat pane session hydration", () => {
       listBranches,
       setPullRequestSummary: vi.fn(),
     } as unknown as SessionCapability;
-    const client = { request } as unknown as GatewayBrowserClient;
+    const client = {
+      request,
+      requestSessionPullRequests: (params: { sessionKey: string }) =>
+        request("controlUi.sessionPullRequests", params),
+    } as unknown as GatewayBrowserClient;
     const { pane, state } = createTestChatPane({ client, sessions });
     pane.context.gateway.snapshot.hello = {
       features: {
@@ -69,7 +73,11 @@ describe("chat pane session hydration", () => {
   it("drops a previous session's deferred hydration before it reaches commit", async () => {
     const request = vi.fn((_method: string, _params?: unknown) => new Promise<never>(() => {}));
     const { pane, state } = createTestChatPane({
-      client: { request } as unknown as GatewayBrowserClient,
+      client: {
+        request,
+        requestSessionPullRequests: (params: { sessionKey: string }) =>
+          request("controlUi.sessionPullRequests", params),
+      } as unknown as GatewayBrowserClient,
       sessions: {} as SessionCapability,
     });
     const afterCommit = vi.fn<RenderLifecycle["afterCommit"]>(() => () => undefined);

--- a/ui/src/pages/chat/chat-pane-suggestions.ts
+++ b/ui/src/pages/chat/chat-pane-suggestions.ts
@@ -6,7 +6,6 @@ import {
   resolveChatAgentId,
   scopedAgentParamsForSession,
   type ControlUiSessionPullRequest,
-  type ControlUiSessionPullRequests,
   type TaskSuggestion,
   type TaskSuggestionEvent,
   type TaskSuggestionsAcceptResult,
@@ -79,14 +78,14 @@ export abstract class ChatPaneSuggestions extends ChatPaneSharing {
     }
     const pullRequestEpoch = scope.context.sessions.capturePullRequestEpoch(sessionKey);
     try {
-      const result = await scope.client.request<ControlUiSessionPullRequests>(
-        "controlUi.sessionPullRequests",
-        {
-          sessionKey,
-          ...scopedAgentParamsForSession(scope.state, sessionKey),
-          ...(options.refresh ? { refresh: true } : {}),
-        },
-      );
+      const result = await scope.client.requestSessionPullRequests({
+        sessionKey,
+        ...scopedAgentParamsForSession(scope.state, sessionKey),
+        ...(options.refresh ? { refresh: true } : {}),
+      });
+      if (!result) {
+        return;
+      }
       if (
         requestVersion !== this.sessionPullRequestsRequestVersion ||
         !this.isConnectionScopeCurrent(scope) ||

--- a/ui/src/pages/chat/chat-pane.test.ts
+++ b/ui/src/pages/chat/chat-pane.test.ts
@@ -115,7 +115,11 @@ describe("chat pane pull request refresh", () => {
       ],
       rateLimited: false,
     });
-    const client = { request } as unknown as GatewayBrowserClient;
+    const client = {
+      request,
+      requestSessionPullRequests: (params: { sessionKey: string; refresh?: boolean }) =>
+        request("controlUi.sessionPullRequests", params),
+    } as unknown as GatewayBrowserClient;
     const epoch = Symbol("pr-refresh");
     const setPullRequestSummary = vi.fn();
     const sessions = {
@@ -173,7 +177,11 @@ describe("chat pane pull request refresh", () => {
     const request = vi.fn().mockResolvedValue({ pullRequests: [], rateLimited: true });
     const setPullRequestSummary = vi.fn();
     const { pane } = createTestChatPane({
-      client: { request } as unknown as GatewayBrowserClient,
+      client: {
+        request,
+        requestSessionPullRequests: (params: { sessionKey: string }) =>
+          request("controlUi.sessionPullRequests", params),
+      } as unknown as GatewayBrowserClient,
       sessions: {
         capturePullRequestEpoch: vi.fn(() => Symbol("pr-refresh")),
         setPullRequestSummary,
@@ -206,7 +214,11 @@ describe("chat pane pull request refresh", () => {
     const epoch = Symbol("pr-refresh");
     const setPullRequestSummary = vi.fn();
     const { pane } = createTestChatPane({
-      client: { request } as unknown as GatewayBrowserClient,
+      client: {
+        request,
+        requestSessionPullRequests: (params: { sessionKey: string }) =>
+          request("controlUi.sessionPullRequests", params),
+      } as unknown as GatewayBrowserClient,
       sessions: {
         capturePullRequestEpoch: vi.fn(() => epoch),
         setPullRequestSummary,

--- a/ui/src/test-helpers/app-sidebar-cases/sessions.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/sessions.ts
@@ -58,7 +58,11 @@ describe("AppSidebar session indicators", () => {
         rateLimited: false,
       }),
     );
-    const gatewayHarness = createGatewayHarness({ request } as unknown as GatewayBrowserClient);
+    const gatewayHarness = createGatewayHarness({
+      request,
+      requestSessionPullRequests: (params: { sessionKey: string }) =>
+        request("controlUi.sessionPullRequests", params),
+    } as unknown as GatewayBrowserClient);
     gatewayHarness.publish({
       hello: {
         features: { methods: ["controlUi.sessionPullRequests"] },


### PR DESCRIPTION
## What Problem This Solves

A connected Control UI client hammers the gateway with `controlUi.sessionPullRequests` at ~11–14 calls per second, sustained for minutes, every reply failing. Production journal on team.openclaw.ai (2026-07-27 03:05 UTC, one connection, back-to-back):

```
[ws] ⇄ res ✗ controlUi.sessionPullRequests 68ms errorCode=UNAVAILABLE errorMessage=session pull requests unavailable conn=ced84e56…77d2
[ws] ⇄ res ✗ controlUi.sessionPullRequests 69ms errorCode=UNAVAILABLE ... (×10+ per second)
```

Mechanism: the sidebar PR indicators iterate worktree session rows sequentially, and every caller gates only on `isGatewayMethodAdvertised(...)`. The method **is** advertised while its runtime dependency is down (`src/gateway/server-methods/control-ui.ts:68` answers UNAVAILABLE), so each ~68ms failure immediately advances to the next row — an unbounded poll loop the advertised-method gate can never stop.

## Why This Change Was Made

Availability is a property of the connection, not of each call site, so the gate lives in `GatewayBrowserClient.requestSessionPullRequests()` and every caller (sidebar indicators via `session-menu-work.ts`, chat suggestions) routes through it:

- A **non-retryable** UNAVAILABLE latches the surface off until the next socket hello.
- **Retryable** failures back off 30s doubling to a 5min cap, honoring longer server `retryAfterMs` hints.
- A generation counter prevents concurrent in-flight rows from multiplying one outage wave's backoff; connection open/hello resets the state.
- Suppressed requests resolve `null`; consumers already handle the absent-summary case.

One shared helper instead of per-callsite patches, matching how other optional gateway surfaces are consumed.

## User Impact

No more request-spam floods against gateways whose session-PR provider is unavailable (each flood burned ~70ms of gateway work per call, 14×/s, per client). Indicators quietly resume when the surface recovers or the client reconnects.

## Evidence

- Journal evidence above; loop mechanism verified in `app-sidebar-session-pr-indicators.ts` (sequential row iteration) and `chat-pane-suggestions.ts`.
- New `ui/src/api/gateway.node.test.ts` (257 lines): permanent-unavailable latch, retryable backoff with server hint, concurrent-row generation guard, reconnect reset, response ordering.
- Updated caller tests: `session-menu-work.test.ts`, `app-sidebar-session-pr-indicators.test.ts`, `chat-pane-pull-requests.test.ts`, `chat-pane.test.ts` — all green (focused rerun after squash: 1 shard, passed).
- Worker's broader runs: 49 gateway + 8 sidebar/menu + 45 chat-pane tests green; oxfmt/oxlint/`git diff --check` clean.
- Autoreview (Codex `gpt-5.6-sol`, xhigh): clean, "patch is correct (0.91)".
