### PR TITLE
fix(gateway): stop rechecking plugin routes after lazy load

### DIFF
--- a/src/gateway/server-runtime-state.test.ts
+++ b/src/gateway/server-runtime-state.test.ts
@@ -1,6 +1,7 @@
 /**
  * Gateway runtime state construction tests.
  */
+import { connect } from "node:net";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createEmptyPluginRegistry } from "../plugins/registry.js";
 import {
@@ -45,6 +46,37 @@ function createRegistryWithRoute(path: string) {
     source: "test",
   });
   return registry;
+}
+
+async function requestPluginUpgrade(port: number, path: string): Promise<string> {
+  return await new Promise<string>((resolve, reject) => {
+    const socket = connect({ host: "127.0.0.1", port });
+    let response = "";
+    let settled = false;
+    const finish = () => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      resolve(response);
+    };
+    socket.setEncoding("utf8");
+    socket.on("connect", () => {
+      socket.write(
+        `GET ${path} HTTP/1.1\r\nHost: 127.0.0.1:${port}\r\nConnection: Upgrade\r\nUpgrade: demo\r\n\r\n`,
+      );
+    });
+    socket.on("data", (chunk) => {
+      response += String(chunk);
+    });
+    socket.on("end", finish);
+    socket.on("close", finish);
+    socket.on("error", reject);
+    socket.setTimeout(2_000, () => {
+      socket.destroy();
+      reject(new Error(`plugin upgrade timed out for ${path}`));
+    });
+  });
 }
 
 describe("createGatewayRuntimeState", () => {
@@ -132,6 +164,85 @@ describe("createGatewayRuntimeState", () => {
       });
 
       expect(firstRequestReads).toBe(routeReads + 1);
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+
+  it("keeps a loaded plugin upgrade handler on the repinned route registry", async () => {
+    const startupRegistry = createEmptyPluginRegistry();
+    let runtimeRegistry = startupRegistry;
+    let startupUpgradeCalls = 0;
+    startupRegistry.httpRoutes.push({
+      path: "/demo",
+      auth: "plugin",
+      match: "exact",
+      handler: () => false,
+      handleUpgrade: (_req, socket) => {
+        startupUpgradeCalls++;
+        socket.end(
+          "HTTP/1.1 101 Switching Protocols\r\nConnection: Upgrade\r\nUpgrade: demo\r\n\r\n",
+        );
+        return true;
+      },
+      pluginId: "startup",
+      source: "test",
+    });
+    const runtimeState = await createGatewayRuntimeStateForTest(startupRegistry, {
+      getPluginRouteRegistry: () => runtimeRegistry,
+    });
+    const server = runtimeState.httpServers[0];
+    if (!server) {
+      throw new Error("expected gateway HTTP server");
+    }
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("expected TCP gateway address");
+    }
+    try {
+      await expect(requestPluginUpgrade(address.port, "/demo")).resolves.toContain(
+        "101 Switching Protocols",
+      );
+      expect(startupUpgradeCalls).toBe(1);
+
+      const replacementRegistry = createEmptyPluginRegistry();
+      let replacementUpgradeCalls = 0;
+      replacementRegistry.httpRoutes.push({
+        path: "/demo",
+        auth: "plugin",
+        match: "exact",
+        handler: () => false,
+        handleUpgrade: (_req, socket) => {
+          replacementUpgradeCalls++;
+          socket.end(
+            "HTTP/1.1 101 Switching Protocols\r\nConnection: Upgrade\r\nUpgrade: demo\r\n\r\n",
+          );
+          return true;
+        },
+        pluginId: "replacement",
+        source: "test",
+      });
+      const emptyRegistry = createEmptyPluginRegistry();
+      runtimeRegistry = emptyRegistry;
+      pinActivePluginHttpRouteRegistry(emptyRegistry);
+      await expect(requestPluginUpgrade(address.port, "/demo")).resolves.not.toContain(
+        "101 Switching Protocols",
+      );
+      expect(startupUpgradeCalls).toBe(1);
+
+      runtimeRegistry = replacementRegistry;
+      pinActivePluginHttpRouteRegistry(replacementRegistry);
+
+      await expect(requestPluginUpgrade(address.port, "/demo")).resolves.toContain(
+        "101 Switching Protocols",
+      );
+      expect(startupUpgradeCalls).toBe(1);
+      expect(replacementUpgradeCalls).toBe(1);
     } finally {
       await new Promise<void>((resolve, reject) => {
         server.close((error) => (error ? reject(error) : resolve()));

--- a/src/gateway/server-runtime-state.test.ts
+++ b/src/gateway/server-runtime-state.test.ts
@@ -84,6 +84,61 @@ describe("createGatewayRuntimeState", () => {
     expect(getActivePluginChannelRegistry()).toBe(startupRegistry);
   });
 
+  it("delegates directly after lazily loading the plugin HTTP handler", async () => {
+    const registry = createEmptyPluginRegistry();
+    const routes = registry.httpRoutes;
+    routes.push({
+      path: "/demo",
+      auth: "plugin",
+      match: "exact",
+      handler: (_req, res) => {
+        res.statusCode = 204;
+        res.end();
+        return true;
+      },
+      pluginId: "demo",
+      source: "test",
+    });
+    let routeReads = 0;
+    Object.defineProperty(registry, "httpRoutes", {
+      configurable: true,
+      get: () => {
+        routeReads++;
+        return routes;
+      },
+    });
+    const runtimeState = await createGatewayRuntimeStateForTest(registry);
+    const server = runtimeState.httpServers[0];
+    if (!server) {
+      throw new Error("expected gateway HTTP server");
+    }
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("expected TCP gateway address");
+    }
+    try {
+      routeReads = 0;
+      await expect(fetch(`http://127.0.0.1:${address.port}/demo`)).resolves.toMatchObject({
+        status: 204,
+      });
+      const firstRequestReads = routeReads;
+
+      routeReads = 0;
+      await expect(fetch(`http://127.0.0.1:${address.port}/demo`)).resolves.toMatchObject({
+        status: 204,
+      });
+
+      expect(firstRequestReads).toBe(routeReads + 1);
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+
   it("fails startup when the required IPv4 loopback alias cannot bind", async () => {
     const warn = vi.fn();
     mocks.resolveGatewayListenHosts.mockResolvedValue(["100.64.0.1", "127.0.0.1"]);

--- a/src/gateway/server-runtime-state.ts
+++ b/src/gateway/server-runtime-state.ts
@@ -222,21 +222,22 @@ export async function createGatewayRuntimeState(params: {
       pathContext,
       dispatchContext,
     ) => {
+      if (loadedPluginRequestHandler) {
+        return await loadedPluginRequestHandler(req, res, pathContext, dispatchContext);
+      }
       const registry = resolvePluginRouteRegistry();
       if ((registry.httpRoutes ?? []).length === 0) {
         return false;
       }
-      if (!loadedPluginRequestHandler) {
-        // Route registries can be re-pinned after bootstrap; keep the handler lazy and route
-        // lookup dynamic so plugin HTTP routes follow the active registry snapshot.
-        const { createGatewayPluginRequestHandler } = await loadGatewayPluginsHttpModule();
-        loadedPluginRequestHandler = createGatewayPluginRequestHandler({
-          registry: params.pluginRegistry,
-          getRouteRegistry: resolvePluginRouteRegistry,
-          log: params.logPlugins,
-          getGatewayRequestContext: params.getGatewayRequestContext,
-        });
-      }
+      // Route registries can be re-pinned after bootstrap; the loaded handler owns dynamic
+      // lookup, while this wrapper only avoids importing it for route-free gateways.
+      const { createGatewayPluginRequestHandler } = await loadGatewayPluginsHttpModule();
+      loadedPluginRequestHandler = createGatewayPluginRequestHandler({
+        registry: params.pluginRegistry,
+        getRouteRegistry: resolvePluginRouteRegistry,
+        log: params.logPlugins,
+        getGatewayRequestContext: params.getGatewayRequestContext,
+      });
       return await loadedPluginRequestHandler(req, res, pathContext, dispatchContext);
     };
     const handlePluginUpgrade: GatewayPluginUpgradeHandler = async (
@@ -246,21 +247,22 @@ export async function createGatewayRuntimeState(params: {
       pathContext,
       dispatchContext,
     ) => {
+      if (loadedPluginUpgradeHandler) {
+        return await loadedPluginUpgradeHandler(req, socket, head, pathContext, dispatchContext);
+      }
       const registry = resolvePluginRouteRegistry();
       if ((registry.httpRoutes ?? []).length === 0) {
         return false;
       }
-      if (!loadedPluginUpgradeHandler) {
-        // WebSocket upgrades share the same dynamic route registry as HTTP requests; this keeps
-        // reloads from serving stale plugin upgrade handlers.
-        const { createGatewayPluginUpgradeHandler } = await loadGatewayPluginsHttpModule();
-        loadedPluginUpgradeHandler = createGatewayPluginUpgradeHandler({
-          registry: params.pluginRegistry,
-          getRouteRegistry: resolvePluginRouteRegistry,
-          log: params.logPlugins,
-          getGatewayRequestContext: params.getGatewayRequestContext,
-        });
-      }
+      // WebSocket upgrades share the loaded handler's dynamic route registry, so reloads still
+      // follow the active snapshot without a duplicate wrapper lookup on every upgrade.
+      const { createGatewayPluginUpgradeHandler } = await loadGatewayPluginsHttpModule();
+      loadedPluginUpgradeHandler = createGatewayPluginUpgradeHandler({
+        registry: params.pluginRegistry,
+        getRouteRegistry: resolvePluginRouteRegistry,
+        log: params.logPlugins,
+        getGatewayRequestContext: params.getGatewayRequestContext,
+      });
       return await loadedPluginUpgradeHandler(req, socket, head, pathContext, dispatchContext);
     };
     const shouldEnforcePluginGatewayAuth = (pathContext: PluginRoutePathContext): boolean => {


### PR DESCRIPTION
Closes #106649

## What Problem This Solves

Fixes an issue where plugin HTTP and WebSocket traffic repeatedly re-read the plugin route registry in the Gateway's lazy-loading wrapper even after the real handlers had already loaded.

## Why This Change Was Made

After the first route-bearing request loads a handler, the wrapper now delegates directly to it. The loaded handler still owns dynamic registry lookup, so registry re-pinning and reload behavior remain current while the duplicate wrapper lookup leaves the request hot path.

## User Impact

Plugin API requests and WebSocket upgrades avoid an unnecessary registry traversal after initialization, with no configuration or plugin API changes.

## Evidence

- AI-assisted change; manually reviewed across the lazy wrapper, loaded HTTP/upgrade handlers, registry re-pinning contract, and Gateway lifecycle.
- The regression now covers both changed transports. It sends real TCP Upgrade requests through the Gateway HTTP server and proves an already-loaded upgrade handler observes route removal and replacement.
- `node scripts/run-vitest.mjs src/gateway/server-runtime-state.test.ts` — 9/9 passed on exact head `3c1a5280b3`.
- Targeted `oxfmt`, `oxlint`, and `git diff --check` passed.

## Real behavior proof

Behavior or issue addressed:

The lazy HTTP and WebSocket wrappers must stop doing their own registry lookup after load without pinning the loaded handlers to a stale registry.

Real environment tested:

Windows x64, Node 24.18.0, exact head `3c1a5280b3`. A no-Vitest runner imported production `createGatewayRuntimeState`, started its real loopback HTTP server, used `fetch` for HTTP, and used `node:net` for valid WebSocket Upgrade requests.

Exact steps or command run after this patch:

`OPENCLAW_CONFIG_PATH=<isolated missing config> OPENCLAW_STATE_DIR=<isolated temp state> node --import tsx .proof-plugin-routing.ts`

The runner requested `/proof`, replaced the runtime registry with an empty registry, requested again, then pinned a replacement registry and repeated both HTTP and Upgrade requests. Its route body is equivalent to the committed TCP regression, but it used the production listener rather than mocked listen hooks.

Evidence after fix:

```text
first HTTP:       204, X-Proof-Owner=startup
first Upgrade:    101 Switching Protocols, X-Proof-Owner=startup
route removed:    503 Service Unavailable
replacement HTTP: 204, X-Proof-Owner=replacement
replacement WS:   101 Switching Protocols, X-Proof-Owner=replacement
upgrade calls:    ["startup", "replacement"]
```

Observed result after fix:

Both loaded handlers followed the runtime registry. Removal did not call the stale startup handler, and re-addition called only the replacement handler.

What was not tested:

No third-party plugin service or browser client was used; the proof targets the Gateway route/transport boundary directly. Gateway-authenticated routes are covered by existing adjacent suites, not this isolated plugin-auth route.
