### PR TITLE
fix(memory-lancedb): make initial table creation race-safe

### DIFF
--- a/extensions/memory-lancedb/lancedb-store.test.ts
+++ b/extensions/memory-lancedb/lancedb-store.test.ts
@@ -71,4 +71,23 @@ describe("MemoryDB agent isolation", () => {
     );
     db.close();
   });
+
+  test("initializes one shared table across concurrent connections", async () => {
+    const databases = Array.from({ length: 2 }, () => new MemoryDB(getDbPath(), 2));
+    try {
+      await expect(Promise.all(databases.map((db) => db.count("main")))).resolves.toEqual(
+        Array.from({ length: databases.length }).fill(0),
+      );
+
+      const first = databases[0];
+      if (!first) {
+        throw new Error("expected a concurrent memory database");
+      }
+      await expect(first.count("main")).resolves.toBe(0);
+    } finally {
+      for (const db of databases) {
+        db.close();
+      }
+    }
+  });
 });

--- a/extensions/memory-lancedb/lancedb-store.ts
+++ b/extensions/memory-lancedb/lancedb-store.ts
@@ -10,7 +10,6 @@ import {
   quoteLanceSqlString,
 } from "./lancedb-schema.js";
 
-const SCHEMA_SENTINEL_ID = "__schema__";
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 export type MemoryEntry = {
@@ -102,26 +101,35 @@ export class MemoryDB {
     const db = await lancedb.connect(this.dbPath, connectionOptions);
     let table: LanceDB.Table | null = null;
     try {
-      const tables = await db.tableNames();
-
-      if (tables.includes(MEMORY_TABLE_NAME)) {
+      try {
         table = await db.openTable(MEMORY_TABLE_NAME);
-        if (!hasAgentScopeColumn(await table.schema())) {
-          throw legacyMemorySchemaError();
+      } catch (openError) {
+        // Confirm absence only after open fails, then let LanceDB resolve a
+        // concurrent creator atomically instead of racing tableNames() and create.
+        if ((await db.tableNames()).includes(MEMORY_TABLE_NAME)) {
+          throw openError;
         }
-      } else {
-        table = await db.createTable(MEMORY_TABLE_NAME, [
-          {
-            id: SCHEMA_SENTINEL_ID,
-            text: "",
-            vector: Array.from({ length: this.vectorDim }).fill(0),
-            importance: 0,
-            category: "other",
-            createdAt: 0,
-            agentId: SCHEMA_SENTINEL_ID,
-          },
-        ]);
-        await table.delete(`id = ${quoteLanceSqlString(SCHEMA_SENTINEL_ID)}`);
+        const schema = lancedb.makeArrowTable(
+          [
+            {
+              id: "",
+              text: "",
+              vector: Array.from({ length: this.vectorDim }).fill(0),
+              importance: 0,
+              category: "other",
+              createdAt: 0,
+              agentId: "",
+            },
+          ],
+          { vectorColumns: { vector: { type: "float32" } } },
+        ).schema;
+        table = await db.createEmptyTable(MEMORY_TABLE_NAME, schema, {
+          mode: "create",
+          existOk: true,
+        });
+      }
+      if (!hasAgentScopeColumn(await table.schema())) {
+        throw legacyMemorySchemaError();
       }
 
       this.db = db;

--- a/extensions/memory-lancedb/lancedb-store.ts
+++ b/extensions/memory-lancedb/lancedb-store.ts
@@ -109,20 +109,17 @@ export class MemoryDB {
         if ((await db.tableNames()).includes(MEMORY_TABLE_NAME)) {
           throw openError;
         }
-        const schema = lancedb.makeArrowTable(
-          [
-            {
-              id: "",
-              text: "",
-              vector: Array.from({ length: this.vectorDim }).fill(0),
-              importance: 0,
-              category: "other",
-              createdAt: 0,
-              agentId: "",
-            },
-          ],
-          { vectorColumns: { vector: { type: "float32" } } },
-        ).schema;
+        const schema = lancedb.makeArrowTable([
+          {
+            id: "",
+            text: "",
+            vector: Array.from({ length: this.vectorDim }).fill(0),
+            importance: 0,
+            category: "other",
+            createdAt: 0,
+            agentId: "",
+          },
+        ]).schema;
         table = await db.createEmptyTable(MEMORY_TABLE_NAME, schema, {
           mode: "create",
           existOk: true,


### PR DESCRIPTION
Closes #105680

## What Problem This Solves

Fixes an issue where concurrent Gateway or worker startup could race while creating the initial LanceDB memory table, causing initialization failures.

## Why This Change Was Made

Initialization now opens an existing table first and, only after confirming absence, uses LanceDB's atomic `exist_ok` empty-table creation mode. The resulting schema is still validated for the agent-scope column, preserving the existing doctor migration error for legacy tables without adding a process lock or dependency.

## User Impact

Multiple processes can initialize the same new LanceDB memory store concurrently without racing through a check-then-create sequence.

## Evidence

- AI-assisted change; manually reviewed across initialization, legacy-schema detection, cleanup, and installed `@lancedb/lancedb` 0.30.0 source/types.
- Direct dependency proof: `createEmptyTable(..., { mode: "create", existOk: true })` maps to LanceDB's native `exist_ok`; the default `vector` column is inferred as `FixedSizeList<Float32>`. The removed string `"float32"` was invalid against `VectorColumnOptions.type: Float`.
- `node scripts/run-vitest.mjs extensions/memory-lancedb/lancedb-store.test.ts` — 3/3 passed on exact head `fe91541dd9`.
- `node scripts/check-extension-package-tsc-boundary.mjs --mode=compile` — all 125 plugin packages compiled, including `memory-lancedb`; the former TS2322 is gone.
- Targeted `oxfmt`, `oxlint`, and `git diff --check` passed.

## Real behavior proof

Behavior or issue addressed:

Two OS processes must be able to initialize the same absent native LanceDB table concurrently, while an existing legacy unscoped table must still fail closed with the doctor migration instruction.

Real environment tested:

Windows x64, Node 24.18.0, native `@lancedb/lancedb` 0.30.0, exact head `fe91541dd9`. Two independent Node child processes opened the same fresh database path simultaneously.

Exact steps or command run after this patch:

`node --import tsx .proof-lancedb-init.ts`

The parent spawned two `node --import tsx` workers, each constructed `MemoryDB(sharedPath, 2)` and called `count("main")`; it then opened the native table directly, inspected Arrow schema fields, and separately exercised a pre-agent-scope legacy table.

Evidence after fix:

```text
worker pid=30176 count=0
worker pid=27848 count=0
tableNames=["memories"]
vectorType=FixedSizeList[2]<Float32>
agentIdType=Utf8
legacyError=memory-lancedb: the existing memory table predates per-agent isolation.
            Run "openclaw doctor --fix" to assign legacy rows to the default agent,
            then restart OpenClaw.
```

Observed result after fix:

Both processes succeeded against one table, the inferred vector type is the required Float32 fixed-size list, the `agentId` scope column exists, and the legacy migration contract remains exact.

What was not tested:

This run used the local native LanceDB filesystem backend, not an object-store `storageOptions` backend. The atomic-create option and schema path are shared; remote backend behavior was not claimed.
