### PR TITLE
fix(gateway): run channel health checks after startup grace

### DIFF
--- a/src/gateway/channel-health-monitor.test.ts
+++ b/src/gateway/channel-health-monitor.test.ts
@@ -76,8 +76,7 @@ async function startAndRunCheck(
 ) {
   const monitor = startDefaultMonitor(manager, overrides);
   const startupGraceMs = overrides.timing?.monitorStartupGraceMs ?? 0;
-  const checkIntervalMs = overrides.checkIntervalMs ?? DEFAULT_CHECK_INTERVAL_MS;
-  await vi.advanceTimersByTimeAsync(startupGraceMs + checkIntervalMs + 1);
+  await vi.advanceTimersByTimeAsync(startupGraceMs + 1);
   return monitor;
 }
 
@@ -192,13 +191,15 @@ describe("channel-health-monitor", () => {
     expect(removeEventListener).toHaveBeenCalledWith("abort", addEventListener.mock.calls[0]?.[1]);
   });
 
-  it("normalizes oversized check intervals before arming timers", () => {
-    const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
+  it("normalizes oversized check intervals before rearming timers", async () => {
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
     const monitor = startDefaultMonitor(createMockChannelManager(), {
       checkIntervalMs: Number.MAX_SAFE_INTEGER,
     });
 
-    expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
     monitor.stop();
   });
 
@@ -212,9 +213,13 @@ describe("channel-health-monitor", () => {
 
   it("runs health check after grace period", async () => {
     const manager = createMockChannelManager();
-    const monitor = await startAndRunCheck(manager, {
+    const monitor = startDefaultMonitor(manager, {
+      checkIntervalMs: 60_000,
       timing: { monitorStartupGraceMs: 1_000 },
     });
+
+    await vi.advanceTimersByTimeAsync(1_001);
+
     expect(manager.getRuntimeSnapshot).toHaveBeenCalled();
     monitor.stop();
   });
@@ -230,7 +235,9 @@ describe("channel-health-monitor", () => {
     });
     const monitor = startDefaultMonitor(manager);
 
-    await vi.advanceTimersByTimeAsync(DEFAULT_CHECK_INTERVAL_MS + 1);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(manager.getRuntimeSnapshot).toHaveBeenCalledTimes(1);
+
     await vi.advanceTimersByTimeAsync(DEFAULT_CHECK_INTERVAL_MS + 1);
 
     expect(manager.getRuntimeSnapshot).toHaveBeenCalledTimes(2);

--- a/src/gateway/channel-health-monitor.ts
+++ b/src/gateway/channel-health-monitor.ts
@@ -81,7 +81,7 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
   let stopped = false;
   let abandonInFlightRestart = false;
   let activeCheck: Promise<void> | null = null;
-  let timer: ReturnType<typeof setInterval> | null = null;
+  let timer: ReturnType<typeof setTimeout> | null = null;
   const suppressedAccounts = new Set<string>();
 
   const rKey = (channelId: string, accountId: string) => `${channelId}:${accountId}`;
@@ -229,11 +229,25 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
     return check;
   }
 
+  function scheduleCheck(delayMs: number) {
+    timer = setTimeout(() => {
+      timer = null;
+      void runCheck().finally(() => {
+        if (!stopped) {
+          scheduleCheck(checkIntervalMs);
+        }
+      });
+    }, delayMs);
+    if (typeof timer === "object" && "unref" in timer) {
+      timer.unref();
+    }
+  }
+
   function retire(abandonRestart: boolean) {
     stopped = true;
     abandonInFlightRestart ||= abandonRestart;
     if (timer) {
-      clearInterval(timer);
+      clearTimeout(timer);
       timer = null;
     }
     if (!activeCheck) {
@@ -276,10 +290,9 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
     abandonInFlightRestart = true;
   } else {
     abortSignal?.addEventListener("abort", shutdown, { once: true });
-    timer = setInterval(() => void runCheck(), checkIntervalMs);
-    if (typeof timer === "object" && "unref" in timer) {
-      timer.unref();
-    }
+    // One lifecycle-owned timer runs first when startup grace expires, then rearms only after
+    // each check settles so slow provider recovery cannot overlap the next evaluation.
+    scheduleCheck(resolveTimerTimeoutMs(timing.monitorStartupGraceMs, 0, 0));
     log.info?.(
       `started (interval: ${Math.round(checkIntervalMs / 1000)}s, startup-grace: ${Math.round(timing.monitorStartupGraceMs / 1000)}s, channel-connect-grace: ${Math.round(timing.channelConnectGraceMs / 1000)}s)`,
     );


### PR DESCRIPTION
Closes #105668

## What Problem This Solves

Fixes an issue where channel recovery did not run until the full five-minute health-check interval elapsed after Gateway startup, leaving a blind spot after startup grace expired.

## Why This Change Was Made

The monitor now schedules its first evaluation when startup grace expires, then rearms one lifecycle-owned timeout only after each check settles. This preserves abort and shutdown cleanup while preventing slow recovery work from overlapping a later interval.

## User Impact

Stale or failed channel runtimes become eligible for automated recovery as soon as startup grace ends instead of waiting up to five minutes.

## Evidence

- AI-assisted change; manually reviewed across startup, abort, stop, in-flight restart, timer normalization, and repeated-check paths.
- Focused regressions prove the first check runs after startup grace, later checks retain the configured interval, oversized delays are normalized, and stopped monitors do not rearm.
- `node scripts/run-vitest.mjs src/gateway/channel-health-monitor.test.ts` — 45/45 passed on exact head `893e5a6cfd`.
- Targeted formatting/lint and `git diff --check` passed on the submitted head.

## Real behavior proof

Behavior or issue addressed:

The first production monitor evaluation must run when startup grace expires, not one full interval later, and shutdown must prevent the timer from rearming.

Real environment tested:

Windows x64, Node 24.18.0, exact head `893e5a6cfd`. A standalone live Node process imported production `startChannelHealthMonitor` and used real timers—no Vitest, fake clocks, or timer mocks.

Exact steps or command run after this patch:

`node --import tsx .proof-health-monitor.ts`

The runner configured a 500 ms startup grace and 1,000 ms steady interval, sampled before grace, sampled after grace, called `shutdown()` plus `waitForIdle()`, and then waited longer than one full steady interval.

Evidence after fix:

```text
beforeGraceChecks=0
afterGraceChecks=1
checkTimesMs=[512]
checksAfterShutdownWait=1
```

Observed result after fix:

The first real timer evaluation occurred 12 ms after the 500 ms grace target, with no pre-grace evaluation. Waiting 1.1 seconds after shutdown produced no second evaluation.

What was not tested:

No external channel provider was restarted in this proof; provider-specific stop/start behavior is unchanged. The proof exercises the production monitor scheduler and lifecycle boundary with a minimal channel-manager implementation.
