### PR TITLE
fix(memory): scale heap pressure thresholds to V8 limit

### DIFF
--- a/src/daemon/gateway-heap.test.ts
+++ b/src/daemon/gateway-heap.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   formatGatewayHeapLimitReport,
   inspectGatewayHeapLimit,
+  isExplicitGatewayHeapLimit,
   resolveGatewayHeapNodeOptions,
 } from "./gateway-heap.js";
 
@@ -112,5 +113,44 @@ describe("Gateway service NODE_OPTIONS", () => {
     expect(formatGatewayHeapLimitReport(report)).toBe(
       "6144 MiB (service setting; adaptive default 4096 MiB from 50% of 8192 MiB constrained memory, target range 2048-8192 MiB, native headroom cap 6144 MiB)",
     );
+  });
+
+  it("distinguishes managed adaptive defaults from operator heap overrides", () => {
+    const memory = {
+      constrainedMemoryBytes: 16_384 * MIB,
+      physicalMemoryBytes: 32_768 * MIB,
+    };
+    expect(
+      isExplicitGatewayHeapLimit({
+        nodeOptions: "--max-old-space-size=8192",
+        execArgv: [],
+        serviceMarker: "openclaw",
+        memory,
+      }),
+    ).toBe(false);
+    expect(
+      isExplicitGatewayHeapLimit({
+        nodeOptions: "--max-old-space-size=6144",
+        execArgv: [],
+        serviceMarker: "openclaw",
+        memory,
+      }),
+    ).toBe(true);
+    expect(
+      isExplicitGatewayHeapLimit({
+        nodeOptions: "--max-old-space-size=8192",
+        execArgv: [],
+        serviceMarker: "",
+        memory,
+      }),
+    ).toBe(true);
+    expect(
+      isExplicitGatewayHeapLimit({
+        nodeOptions: "--max-old-space-size=8192",
+        execArgv: ["--max-old-space-size", "7168"],
+        serviceMarker: "openclaw",
+        memory,
+      }),
+    ).toBe(true);
   });
 });

--- a/src/daemon/gateway-heap.ts
+++ b/src/daemon/gateway-heap.ts
@@ -1,5 +1,6 @@
 /** Adaptive Node heap policy for the managed Gateway service. */
 import os from "node:os";
+import { GATEWAY_SERVICE_MARKER } from "./constants.js";
 
 const MEBIBYTE_BYTES = 1024 * 1024;
 const GATEWAY_HEAP_FLOOR_MIB = 2048;
@@ -146,6 +147,31 @@ export function inspectGatewayHeapLimit(
     ...resolveGatewayHeapLimit(memory),
     appliedMiB: parseMaxOldSpaceSizeMiB(nodeOptions),
   };
+}
+
+export function isExplicitGatewayHeapLimit(params?: {
+  nodeOptions?: string;
+  execArgv?: readonly string[];
+  serviceMarker?: string;
+  memory?: GatewayHeapMemoryInputs;
+}): boolean {
+  const execArgv = params?.execArgv ?? process.execArgv;
+  if (parseMaxOldSpaceSizeMiB(execArgv.join(" ")) !== null) {
+    return true;
+  }
+  const report = inspectGatewayHeapLimit(
+    params?.nodeOptions ?? process.env.NODE_OPTIONS,
+    params?.memory,
+  );
+  if (report.appliedMiB === null) {
+    return false;
+  }
+  // Managed services always materialize their resource-derived default as
+  // NODE_OPTIONS. Only a different applied value represents an operator override.
+  return (
+    (params?.serviceMarker ?? process.env.OPENCLAW_SERVICE_MARKER)?.trim() !==
+      GATEWAY_SERVICE_MARKER || report.appliedMiB !== report.maxOldSpaceSizeMiB
+  );
 }
 
 export function formatGatewayHeapLimitReport(report: GatewayHeapLimitReport): string {

--- a/src/logging/diagnostic-memory.test.ts
+++ b/src/logging/diagnostic-memory.test.ts
@@ -23,6 +23,7 @@ import { resetLogger, setLoggerOverride } from "./logger.js";
 
 const mocks = vi.hoisted(() => ({
   heapSizeLimitBytes: undefined as number | undefined,
+  explicitGatewayHeapLimit: false,
 }));
 
 vi.mock("node:v8", async (importOriginal) => {
@@ -35,6 +36,14 @@ vi.mock("node:v8", async (importOriginal) => {
         ? {}
         : { heap_size_limit: mocks.heapSizeLimitBytes }),
     }),
+  };
+});
+
+vi.mock("../daemon/gateway-heap.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../daemon/gateway-heap.js")>();
+  return {
+    ...actual,
+    isExplicitGatewayHeapLimit: () => mocks.explicitGatewayHeapLimit,
   };
 });
 
@@ -63,6 +72,7 @@ describe("diagnostic memory", () => {
     resetDiagnosticStabilityRecorderForTest();
     resetLogger();
     mocks.heapSizeLimitBytes = undefined;
+    mocks.explicitGatewayHeapLimit = false;
   });
 
   afterEach(() => {
@@ -179,6 +189,28 @@ describe("diagnostic memory", () => {
     );
   });
 
+  it("preserves fixed defaults for a resource-derived enlarged heap", () => {
+    mocks.heapSizeLimitBytes = 8 * 1024 * 1024 * 1024;
+    const events: DiagnosticEventPayload[] = [];
+    const stop = onDiagnosticEvent((event) => events.push(event));
+
+    emitDiagnosticMemorySample({
+      now: 1000,
+      memoryUsage: memoryUsage({
+        heapTotal: 3 * 1024 * 1024 * 1024,
+        heapUsed: 3 * 1024 * 1024 * 1024,
+      }),
+    });
+    stop();
+
+    expect(events.at(-1)).toMatchObject({
+      type: "diagnostic.memory.pressure",
+      level: "critical",
+      reason: "heap_threshold",
+      thresholdBytes: 2 * 1024 * 1024 * 1024,
+    });
+  });
+
   it.each([
     {
       name: "default-sized",
@@ -205,6 +237,7 @@ describe("diagnostic memory", () => {
     "resolves heap pressure thresholds for $name V8 heaps",
     ({ heapSizeLimitBytes, heapUsedBytes, level, thresholdBytes }) => {
       mocks.heapSizeLimitBytes = heapSizeLimitBytes;
+      mocks.explicitGatewayHeapLimit = true;
       const events: DiagnosticEventPayload[] = [];
       const stop = onDiagnosticEvent((event) => events.push(event));
 

--- a/src/logging/diagnostic-memory.test.ts
+++ b/src/logging/diagnostic-memory.test.ts
@@ -21,6 +21,23 @@ import {
 } from "./diagnostic-stability.js";
 import { resetLogger, setLoggerOverride } from "./logger.js";
 
+const mocks = vi.hoisted(() => ({
+  heapSizeLimitBytes: undefined as number | undefined,
+}));
+
+vi.mock("node:v8", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:v8")>();
+  return {
+    ...actual,
+    getHeapStatistics: () => ({
+      ...actual.getHeapStatistics(),
+      ...(mocks.heapSizeLimitBytes === undefined
+        ? {}
+        : { heap_size_limit: mocks.heapSizeLimitBytes }),
+    }),
+  };
+});
+
 function flushDiagnosticEvents() {
   return vi.runAllTimersAsync();
 }
@@ -45,6 +62,7 @@ describe("diagnostic memory", () => {
     resetDiagnosticStabilityBundleForTest();
     resetDiagnosticStabilityRecorderForTest();
     resetLogger();
+    mocks.heapSizeLimitBytes = undefined;
   });
 
   afterEach(() => {
@@ -136,6 +154,50 @@ describe("diagnostic memory", () => {
       },
     ]);
   });
+
+  it.each([
+    {
+      name: "constrained",
+      heapSizeLimitBytes: 512 * 1024 * 1024,
+      heapUsedBytes: 300 * 1024 * 1024,
+      level: "warning",
+      thresholdBytes: 256 * 1024 * 1024,
+    },
+    {
+      name: "default-sized",
+      heapSizeLimitBytes: 4 * 1024 * 1024 * 1024,
+      heapUsedBytes: 1536 * 1024 * 1024,
+      level: "warning",
+      thresholdBytes: 1024 * 1024 * 1024,
+    },
+    {
+      name: "enlarged",
+      heapSizeLimitBytes: 8 * 1024 * 1024 * 1024,
+      heapUsedBytes: 2 * 1024 * 1024 * 1024,
+      level: "warning",
+      thresholdBytes: 2 * 1024 * 1024 * 1024,
+    },
+  ])(
+    "scales default heap thresholds for $name V8 heaps",
+    ({ heapSizeLimitBytes, heapUsedBytes, level, thresholdBytes }) => {
+      mocks.heapSizeLimitBytes = heapSizeLimitBytes;
+      const events: DiagnosticEventPayload[] = [];
+      const stop = onDiagnosticEvent((event) => events.push(event));
+
+      emitDiagnosticMemorySample({
+        now: 1000,
+        memoryUsage: memoryUsage({ heapTotal: heapUsedBytes, heapUsed: heapUsedBytes }),
+      });
+      stop();
+
+      expect(events.at(-1)).toMatchObject({
+        type: "diagnostic.memory.pressure",
+        level,
+        reason: "heap_threshold",
+        thresholdBytes,
+      });
+    },
+  );
 
   it("can check pressure without recording an idle memory sample", () => {
     const events: DiagnosticEventPayload[] = [];

--- a/src/logging/diagnostic-memory.test.ts
+++ b/src/logging/diagnostic-memory.test.ts
@@ -155,14 +155,31 @@ describe("diagnostic memory", () => {
     ]);
   });
 
+  it("preserves the established defaults for constrained heaps", () => {
+    mocks.heapSizeLimitBytes = 512 * 1024 * 1024;
+    const events: DiagnosticEventPayload[] = [];
+    const stop = onDiagnosticEvent((event) => events.push(event));
+
+    emitDiagnosticMemorySample({
+      now: 1000,
+      memoryUsage: memoryUsage({
+        heapTotal: 300 * 1024 * 1024,
+        heapUsed: 300 * 1024 * 1024,
+      }),
+    });
+    stop();
+
+    expect(events).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "diagnostic.memory.pressure",
+          reason: "heap_threshold",
+        }),
+      ]),
+    );
+  });
+
   it.each([
-    {
-      name: "constrained",
-      heapSizeLimitBytes: 512 * 1024 * 1024,
-      heapUsedBytes: 300 * 1024 * 1024,
-      level: "warning",
-      thresholdBytes: 256 * 1024 * 1024,
-    },
     {
       name: "default-sized",
       heapSizeLimitBytes: 4 * 1024 * 1024 * 1024,
@@ -177,8 +194,15 @@ describe("diagnostic memory", () => {
       level: "warning",
       thresholdBytes: 2 * 1024 * 1024 * 1024,
     },
+    {
+      name: "enlarged critical",
+      heapSizeLimitBytes: 8 * 1024 * 1024 * 1024,
+      heapUsedBytes: 5 * 1024 * 1024 * 1024,
+      level: "critical",
+      thresholdBytes: 4 * 1024 * 1024 * 1024,
+    },
   ])(
-    "scales default heap thresholds for $name V8 heaps",
+    "resolves heap pressure thresholds for $name V8 heaps",
     ({ heapSizeLimitBytes, heapUsedBytes, level, thresholdBytes }) => {
       mocks.heapSizeLimitBytes = heapSizeLimitBytes;
       const events: DiagnosticEventPayload[] = [];

--- a/src/logging/diagnostic-memory.ts
+++ b/src/logging/diagnostic-memory.ts
@@ -1,4 +1,5 @@
 // Diagnostic memory helpers capture process memory facts for support diagnostics.
+import { getHeapStatistics } from "node:v8";
 import {
   emitInternalDiagnosticEvent as emitDiagnosticEvent,
   type DiagnosticMemoryPressureEvent,
@@ -61,11 +62,22 @@ function normalizeMemoryUsage(memory: NodeJS.MemoryUsage): DiagnosticMemoryUsage
 function resolveThresholds(
   thresholds?: DiagnosticMemoryThresholds,
 ): Required<DiagnosticMemoryThresholds> {
+  const heapSizeLimitBytes = getHeapStatistics().heap_size_limit;
+  // Keep the established 1/2 GiB defaults near a 4 GiB heap, but bound them to
+  // 25-50% and 50-75% of V8's real limit so constrained and enlarged heaps scale safely.
+  const heapUsedWarningBytes = Math.max(
+    Math.min(DEFAULT_HEAP_WARNING_BYTES, Math.floor(heapSizeLimitBytes * 0.5)),
+    Math.floor(heapSizeLimitBytes * 0.25),
+  );
+  const heapUsedCriticalBytes = Math.max(
+    Math.min(DEFAULT_HEAP_CRITICAL_BYTES, Math.floor(heapSizeLimitBytes * 0.75)),
+    Math.floor(heapSizeLimitBytes * 0.5),
+  );
   return {
     rssWarningBytes: thresholds?.rssWarningBytes ?? DEFAULT_RSS_WARNING_BYTES,
     rssCriticalBytes: thresholds?.rssCriticalBytes ?? DEFAULT_RSS_CRITICAL_BYTES,
-    heapUsedWarningBytes: thresholds?.heapUsedWarningBytes ?? DEFAULT_HEAP_WARNING_BYTES,
-    heapUsedCriticalBytes: thresholds?.heapUsedCriticalBytes ?? DEFAULT_HEAP_CRITICAL_BYTES,
+    heapUsedWarningBytes: thresholds?.heapUsedWarningBytes ?? heapUsedWarningBytes,
+    heapUsedCriticalBytes: thresholds?.heapUsedCriticalBytes ?? heapUsedCriticalBytes,
     rssGrowthWarningBytes: thresholds?.rssGrowthWarningBytes ?? DEFAULT_RSS_GROWTH_WARNING_BYTES,
     rssGrowthCriticalBytes: thresholds?.rssGrowthCriticalBytes ?? DEFAULT_RSS_GROWTH_CRITICAL_BYTES,
     growthWindowMs: thresholds?.growthWindowMs ?? DEFAULT_GROWTH_WINDOW_MS,

--- a/src/logging/diagnostic-memory.ts
+++ b/src/logging/diagnostic-memory.ts
@@ -63,14 +63,14 @@ function resolveThresholds(
   thresholds?: DiagnosticMemoryThresholds,
 ): Required<DiagnosticMemoryThresholds> {
   const heapSizeLimitBytes = getHeapStatistics().heap_size_limit;
-  // Keep the established 1/2 GiB defaults near a 4 GiB heap, but bound them to
-  // 25-50% and 50-75% of V8's real limit so constrained and enlarged heaps scale safely.
+  // The established 1/2 GiB defaults remain floors. Only enlarged V8 heaps scale
+  // upward, avoiding restart policy changes for existing constrained/default heaps.
   const heapUsedWarningBytes = Math.max(
-    Math.min(DEFAULT_HEAP_WARNING_BYTES, Math.floor(heapSizeLimitBytes * 0.5)),
+    DEFAULT_HEAP_WARNING_BYTES,
     Math.floor(heapSizeLimitBytes * 0.25),
   );
   const heapUsedCriticalBytes = Math.max(
-    Math.min(DEFAULT_HEAP_CRITICAL_BYTES, Math.floor(heapSizeLimitBytes * 0.75)),
+    DEFAULT_HEAP_CRITICAL_BYTES,
     Math.floor(heapSizeLimitBytes * 0.5),
   );
   return {

--- a/src/logging/diagnostic-memory.ts
+++ b/src/logging/diagnostic-memory.ts
@@ -1,5 +1,6 @@
 // Diagnostic memory helpers capture process memory facts for support diagnostics.
 import { getHeapStatistics } from "node:v8";
+import { isExplicitGatewayHeapLimit } from "../daemon/gateway-heap.js";
 import {
   emitInternalDiagnosticEvent as emitDiagnosticEvent,
   type DiagnosticMemoryPressureEvent,
@@ -63,16 +64,15 @@ function resolveThresholds(
   thresholds?: DiagnosticMemoryThresholds,
 ): Required<DiagnosticMemoryThresholds> {
   const heapSizeLimitBytes = getHeapStatistics().heap_size_limit;
-  // The established 1/2 GiB defaults remain floors. Only enlarged V8 heaps scale
-  // upward, avoiding restart policy changes for existing constrained/default heaps.
-  const heapUsedWarningBytes = Math.max(
-    DEFAULT_HEAP_WARNING_BYTES,
-    Math.floor(heapSizeLimitBytes * 0.25),
-  );
-  const heapUsedCriticalBytes = Math.max(
-    DEFAULT_HEAP_CRITICAL_BYTES,
-    Math.floor(heapSizeLimitBytes * 0.5),
-  );
+  // Managed services materialize resource-derived defaults as NODE_OPTIONS.
+  // Scale only for a distinct operator override or direct Node CLI heap flag.
+  const useAdaptiveHeapThresholds = isExplicitGatewayHeapLimit();
+  const heapUsedWarningBytes = useAdaptiveHeapThresholds
+    ? Math.max(DEFAULT_HEAP_WARNING_BYTES, Math.floor(heapSizeLimitBytes * 0.25))
+    : DEFAULT_HEAP_WARNING_BYTES;
+  const heapUsedCriticalBytes = useAdaptiveHeapThresholds
+    ? Math.max(DEFAULT_HEAP_CRITICAL_BYTES, Math.floor(heapSizeLimitBytes * 0.5))
+    : DEFAULT_HEAP_CRITICAL_BYTES;
   return {
     rssWarningBytes: thresholds?.rssWarningBytes ?? DEFAULT_RSS_WARNING_BYTES,
     rssCriticalBytes: thresholds?.rssCriticalBytes ?? DEFAULT_RSS_CRITICAL_BYTES,


### PR DESCRIPTION
Closes #104631

## What Problem This Solves

Fixes an issue where a Gateway with an operator-configured large V8 heap could report critical heap pressure and restart at the legacy fixed 2 GiB threshold despite having substantial heap headroom.

## Why This Change Was Made

The established 1 GiB warning and 2 GiB critical defaults remain unchanged for automatic/resource-derived heap sizing. Only a distinct managed-service override or direct Node CLI `--max-old-space-size` flag enables thresholds that scale upward to 25% and 50% of the actual `heap_size_limit`. Existing explicit diagnostic threshold overrides and all RSS/growth thresholds remain unchanged.

## User Impact

Operator-enlarged heaps no longer treat 2 GiB as an unconditional critical limit. Existing deployments that rely on the managed service's resource-derived heap sizing retain their current restart-driving thresholds.

## Evidence

- AI-assisted change; manually reviewed across managed service heap derivation, Node option parsing, diagnostic sampling, explicit overrides, event severity, stability-bundle behavior, and restart-driving pressure output.
- The prior P1 policy finding is resolved: `isExplicitGatewayHeapLimit` distinguishes the managed adaptive `NODE_OPTIONS` value from an operator value by comparing it with the canonical resource-derived limit. A direct Node CLI heap flag remains explicitly operator-controlled.
- The branch was rebased onto current `origin/main` `b34c19632f`.
- `node scripts/run-vitest.mjs src/logging/diagnostic-memory.test.ts` — 16/16 passed.
- `node scripts/run-vitest.mjs src/daemon/gateway-heap.test.ts` — 12/12 passed.
- Targeted `oxfmt`, `oxlint`, and `git diff --check` passed on exact head `71c22a8ec6`.

## Real behavior proof

Behavior or issue addressed:

At the same approximately 8 GiB V8 limit and 2.25 GiB used, a managed resource-derived limit must preserve the historical critical event, while a direct operator CLI limit must emit the new proportional warning.

Real environment tested:

Windows x64, Node 24.18.0, exact rebased head `71c22a8ec6`. Both runs used production `isExplicitGatewayHeapLimit`, `emitDiagnosticMemorySample`, `getHeapStatistics`, and the diagnostic event bus.

Exact steps or command run after this patch:

```text
NODE_OPTIONS=--max-old-space-size=8110 OPENCLAW_SERVICE_MARKER=openclaw \
  node --import tsx .proof-heap-boundary.ts

OPENCLAW_SERVICE_MARKER=openclaw \
  node --max-old-space-size=8192 --import tsx .proof-heap-boundary.ts
```

The first value is the canonical resource-derived default reported on this host (`8110 MiB`, 50% of 16,221 MiB physical memory). Both runners injected a 2.25 GiB diagnostic sample at the sampler boundary, avoiding an unsafe multi-gigabyte physical allocation.

Evidence after fix:

```text
managed resource-derived:
  explicitGatewayHeapLimit=false
  heapSizeLimitBytes=8705277952
  level=critical
  thresholdBytes=2147483648 (2 GiB)

direct operator CLI:
  explicitGatewayHeapLimit=true
  heapSizeLimitBytes=8791261184
  level=warning
  thresholdBytes=2197815296 (~2.05 GiB)
```

Observed result after fix:

The compatibility boundary is explicit and observable: resource-derived service sizing preserves the old 2 GiB critical signal, while the direct 8 GiB operator override classifies the same usage as warning against 25% of the real heap.

What was not tested:

Neither process physically allocated 2.25 GiB. The proof validates the production classification boundary with real V8 limits and process option sources; physical OOM and OS pressure behavior are outside this change.
