### PR TITLE
fix(state): recover from state-database corruption without a gateway restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Shared state corruption recovery:** evict only the exact cached SQLite owner after proven read or write corruption so a repaired database recovers without a Gateway restart while caller-injected handles remain untouched. Fixes #114269. Thanks @rizquuula.
 - **Dev-channel updates:** finish package-to-git switches in a fresh CLI process even when source SHA and version metadata are unchanged, preventing stale hashed chunks from loading after the global package root changes.
 - **Parallels release smoke:** preserve Windows installer reboot results across Parallels, wait for WSL MSI/default-version readiness, force explicit test-owned gateway stops, and reset Linux package, config, and cache state before install lanes, preventing false prerequisite, safety-gate, and stale-config failures.
 - **OpenAI Realtime Talk auth:** remove the non-public Codex OAuth realtime fallback and require an OpenAI Platform API key for Talk, Voice Call, and Discord realtime voice, preventing OAuth-only gateways from advertising a browser session that the live service rejects. Fixes #115021.

--- a/src/infra/kysely-sync.test.ts
+++ b/src/infra/kysely-sync.test.ts
@@ -11,6 +11,7 @@ import {
   executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,
   iterateSqliteQuerySync,
+  registerNodeSqliteKyselyQueryErrorHandler,
 } from "./kysely-sync.js";
 
 type SyncHelperTestDatabase = {
@@ -373,6 +374,26 @@ describe("kysely sync helpers", () => {
     expect(() => executeSqliteQuerySync(database!, jsonValue("{"))).toThrow(/malformed JSON/iu);
     expect(executeSqliteQuerySync(database, jsonValue("[]")).rows).toEqual([{ value: "[]" }]);
     expect(prepares.calls()).toBe(2);
+  });
+
+  it("reports query failures without replacing the original database error", () => {
+    database = new DatabaseSync(":memory:");
+    const db = getNodeSqliteKysely<SyncHelperTestDatabase>(database);
+    const malformedJson = db.selectNoFrom(
+      /* kysely-allow-raw: failure reporting needs a deterministic SQLite step error. */
+      sql<string>`json(${"{"})`.as("value"),
+    );
+    const observed: unknown[] = [];
+    registerNodeSqliteKyselyQueryErrorHandler(database, (error) => {
+      observed.push(error);
+      throw new Error("handler failure");
+    });
+
+    const thrown = captureError(() => executeSqliteQuerySync(database!, malformedJson));
+
+    expect(observed).toEqual([thrown]);
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as Error).message).toMatch(/malformed JSON/iu);
   });
 
   it("preserves close return values and double-close errors", () => {

--- a/src/infra/kysely-sync.ts
+++ b/src/infra/kysely-sync.ts
@@ -7,6 +7,7 @@ import { InsertQueryNode, Kysely as KyselyInstance, SqliteDialect } from "kysely
 // going through Kysely's async driver path.
 
 const kyselyByDatabase = new WeakMap<DatabaseSync, Kysely<unknown>>();
+const queryErrorHandlerByDatabase = new WeakMap<DatabaseSync, (error: unknown) => void>();
 // Cached statements retain their database. Per-instance lifecycle wrappers clear
 // both caches before the native database handle closes.
 const statementCacheSymbol = Symbol("openclaw.kyselySyncStatementCache");
@@ -52,6 +53,22 @@ export function getNodeSqliteKysely<Database>(db: DatabaseSync): Kysely<Database
   });
   kyselyByDatabase.set(db, kysely as Kysely<unknown>);
   return kysely;
+}
+
+/** Register the lifecycle owner's handler for synchronous Kysely query failures. */
+export function registerNodeSqliteKyselyQueryErrorHandler(
+  db: DatabaseSync,
+  handler: (error: unknown) => void,
+): void {
+  queryErrorHandlerByDatabase.set(db, handler);
+}
+
+function reportNodeSqliteKyselyQueryError(db: DatabaseSync, error: unknown): void {
+  try {
+    queryErrorHandlerByDatabase.get(db)?.(error);
+  } catch {
+    // Lifecycle cleanup must never replace the database error seen by the caller.
+  }
 }
 
 function installStatementInvalidation(owner: StatementCacheOwner): void {
@@ -217,36 +234,41 @@ function executeCompiledSqliteQuerySync<Row>(
   compiledQuery: CompiledQuery<Row>,
 ): QueryResult<Row> {
   const parameters = compiledQuery.parameters as SQLInputValue[];
-  return executeWithCachedStatement(db, compiledQuery.sql, parameters, (statement) => {
-    if (statement.columns().length > 0) {
-      // Node's all() snapshots the column count before SQLite can reprepare
-      // an expired statement. Eagerly consuming iterate() reads it after step.
-      const iterator = statement.iterate(...parameters);
-      try {
-        return { rows: [...iterator] as Row[] };
-      } catch (error) {
+  try {
+    return executeWithCachedStatement(db, compiledQuery.sql, parameters, (statement) => {
+      if (statement.columns().length > 0) {
+        // Node's all() snapshots the column count before SQLite can reprepare
+        // an expired statement. Eagerly consuming iterate() reads it after step.
+        const iterator = statement.iterate(...parameters);
         try {
-          iterator.return?.();
-        } catch {
-          // Preserve the step error if iterator cleanup itself fails.
+          return { rows: [...iterator] as Row[] };
+        } catch (error) {
+          try {
+            iterator.return?.();
+          } catch {
+            // Preserve the step error if iterator cleanup itself fails.
+          }
+          throw error;
         }
-        throw error;
       }
-    }
 
-    const { changes, lastInsertRowid } = statement.run(...parameters);
-    const result: QueryResult<Row> = {
-      numAffectedRows: BigInt(changes),
-      rows: [],
-    };
-    if (InsertQueryNode.is(compiledQuery.query) && changes > 0) {
-      return {
-        ...result,
-        insertId: BigInt(lastInsertRowid),
+      const { changes, lastInsertRowid } = statement.run(...parameters);
+      const result: QueryResult<Row> = {
+        numAffectedRows: BigInt(changes),
+        rows: [],
       };
-    }
-    return result;
-  });
+      if (InsertQueryNode.is(compiledQuery.query) && changes > 0) {
+        return {
+          ...result,
+          insertId: BigInt(lastInsertRowid),
+        };
+      }
+      return result;
+    });
+  } catch (error) {
+    reportNodeSqliteKyselyQueryError(db, error);
+    throw error;
+  }
 }
 
 /** Compile and execute a Kysely query synchronously. */
@@ -263,14 +285,29 @@ export function* iterateSqliteQuerySync<Row>(
   query: Compilable<Row>,
 ): IterableIterator<Row> {
   const compiledQuery = query.compile();
-  // Iterators keep statement state across yields. A private statement prevents
-  // nested iteration of identical SQL from resetting an earlier iterator.
-  const statement = db.prepare(compiledQuery.sql);
-  if (statement.columns().length === 0) {
-    return;
+  try {
+    // Iterators keep statement state across yields. A private statement prevents
+    // nested iteration of identical SQL from resetting an earlier iterator.
+    const statement = db.prepare(compiledQuery.sql);
+    if (statement.columns().length === 0) {
+      return;
+    }
+    const parameters = compiledQuery.parameters as SQLInputValue[];
+    const iterator = statement.iterate(...parameters);
+    try {
+      yield* iterator as Iterable<Row>;
+    } catch (error) {
+      try {
+        iterator.return?.();
+      } catch {
+        // Preserve the step error if iterator cleanup itself fails.
+      }
+      throw error;
+    }
+  } catch (error) {
+    reportNodeSqliteKyselyQueryError(db, error);
+    throw error;
   }
-  const parameters = compiledQuery.parameters as SQLInputValue[];
-  yield* statement.iterate(...parameters) as Iterable<Row>;
 }
 
 /** Execute a Kysely query synchronously and return its first row. */
@@ -287,4 +324,5 @@ export function clearNodeSqliteKyselyCacheForDatabase(db: DatabaseSync): void {
   // native database backreferences instead of recreating the WeakMap leak.
   delete (db as StatementCacheOwner)[statementCacheSymbol];
   kyselyByDatabase.delete(db);
+  queryErrorHandlerByDatabase.delete(db);
 }

--- a/src/infra/sqlite-integrity.ts
+++ b/src/infra/sqlite-integrity.ts
@@ -5,6 +5,7 @@ import {
   sameSqliteFileGeneration,
   type SqliteFileGeneration,
 } from "./sqlite-file-generation.js";
+import { isSqliteCorruptionError } from "./sqlite-transaction.js";
 
 type SqliteIntegrityChecks = {
   integrityCheck: "ok";
@@ -29,25 +30,17 @@ type SqliteForeignKeyViolation = {
 
 const MAX_REPORTED_FOREIGN_KEY_VIOLATIONS = 5;
 
-const SQLITE_CORRUPT_ERRCODE = 11;
-const SQLITE_NOTADB_ERRCODE = 26;
-
 /** Return whether a named integrity failure proves persistent database damage. */
 export function isTerminalSqliteIntegrityError(error: Error): boolean {
   if (error.name !== "SqliteIntegrityError") {
     return false;
   }
-  const cause = error.cause as { errcode?: unknown } | undefined;
-  if (!cause) {
+  if (!error.cause) {
     // No cause means the check pragma itself reported corruption rows: persistent.
     return true;
   }
-  if (typeof cause.errcode !== "number") {
-    return false;
-  }
-  // Mask extended codes to the primary; transient lock/busy failures must not latch.
-  const primaryCode = cause.errcode & 0xff;
-  return primaryCode === SQLITE_CORRUPT_ERRCODE || primaryCode === SQLITE_NOTADB_ERRCODE;
+  // Only proven corruption latches; transient lock/busy pragma failures must not.
+  return isSqliteCorruptionError(error.cause);
 }
 
 /** Require structural, table/index, and referential consistency before trusting a database. */

--- a/src/infra/sqlite-transaction.ts
+++ b/src/infra/sqlite-transaction.ts
@@ -10,6 +10,8 @@ const SQLITE_LOCK_ERROR_CODES = new Set(["SQLITE_BUSY", "SQLITE_LOCKED"]);
 // SQLite result in `errcode`; the low byte identifies BUSY or LOCKED.
 const SQLITE_BUSY_RESULT_CODE = 5;
 const SQLITE_LOCKED_RESULT_CODE = 6;
+const SQLITE_CORRUPT_RESULT_CODE = 11;
+const SQLITE_NOTADB_RESULT_CODE = 26;
 const SQLITE_PRIMARY_RESULT_CODE_MASK = 0xff;
 const DEFAULT_SLOW_BUSY_WAIT_MS = 1_000;
 const DEFAULT_SLOW_TRANSACTION_HOLD_MS = 1_000;
@@ -68,6 +70,12 @@ export function isSqliteLockError(error: unknown): boolean {
   }
   const primaryCode = sqlitePrimaryResultCode(error);
   return primaryCode === SQLITE_BUSY_RESULT_CODE || primaryCode === SQLITE_LOCKED_RESULT_CODE;
+}
+
+/** Report proven file damage (corrupt page or non-database header), not transient failure. */
+export function isSqliteCorruptionError(error: unknown): boolean {
+  const primaryCode = sqlitePrimaryResultCode(error);
+  return primaryCode === SQLITE_CORRUPT_RESULT_CODE || primaryCode === SQLITE_NOTADB_RESULT_CODE;
 }
 
 function slowBusyWaitThresholdMs(options: SqliteTransactionOptions | undefined): number {

--- a/src/state/openclaw-state-db-readonly.ts
+++ b/src/state/openclaw-state-db-readonly.ts
@@ -7,6 +7,7 @@ import {
   readSqliteUserVersion,
 } from "../infra/sqlite-user-version.js";
 import {
+  evictOpenClawStateDatabaseAfterCorruption,
   getOpenClawStateDatabaseIfOpen,
   OPENCLAW_SQLITE_BUSY_TIMEOUT_MS,
   OPENCLAW_STATE_SCHEMA_VERSION,
@@ -50,10 +51,15 @@ export function withOpenClawStateDatabaseReadOnly<T>(
   // uncommitted rows a fresh read-only connection could not have seen.
   const opened = getOpenClawStateDatabaseIfOpen(options);
   if (opened && !opened.db.isTransaction) {
-    // A newer build can migrate this file while the handle stays open, so the
-    // forward-compatibility gate still runs before any reused read.
-    assertSupportedSchemaVersion(opened.db, pathname);
-    return operation(opened);
+    try {
+      // A newer build can migrate this file while the handle stays open, so the
+      // forward-compatibility gate still runs before any reused read.
+      assertSupportedSchemaVersion(opened.db, pathname);
+      return operation(opened);
+    } catch (error) {
+      evictOpenClawStateDatabaseAfterCorruption(opened, error);
+      throw error;
+    }
   }
   const db = openNodeSqliteDatabase(pathname, { readOnly: true });
   try {

--- a/src/state/openclaw-state-db.corruption-recovery.test.ts
+++ b/src/state/openclaw-state-db.corruption-recovery.test.ts
@@ -1,0 +1,88 @@
+// Shared state database recovery tests cover eviction of a corruption-poisoned cached handle.
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { isSqliteCorruptionError } from "../infra/sqlite-transaction.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  getOpenClawStateDatabaseIfOpen,
+  openOpenClawStateDatabase,
+  runOpenClawStateWriteTransaction,
+} from "./openclaw-state-db.js";
+
+const tempStateDirs: string[] = [];
+
+function createTempStateDir(): string {
+  const stateDir = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-state-db-corruption-")),
+  );
+  tempStateDirs.push(stateDir);
+  return stateDir;
+}
+
+function sqliteError(message: string, errcode: number): Error {
+  return Object.assign(new Error(message), { errcode });
+}
+
+afterEach(() => {
+  closeOpenClawStateDatabaseForTest();
+  for (const stateDir of tempStateDirs.splice(0)) {
+    fs.rmSync(stateDir, { force: true, recursive: true });
+  }
+});
+
+describe("isSqliteCorruptionError", () => {
+  const cases: Array<{ error: unknown; expected: boolean; name: string }> = [
+    { error: sqliteError("file is not a database", 26), expected: true, name: "NOTADB" },
+    { error: sqliteError("database disk image is malformed", 11), expected: true, name: "CORRUPT" },
+    { error: sqliteError("corrupt index", 779), expected: true, name: "extended CORRUPT" },
+    { error: sqliteError("database is locked", 5), expected: false, name: "BUSY" },
+    { error: sqliteError("database table is locked", 6), expected: false, name: "LOCKED" },
+    { error: new Error("plain failure"), expected: false, name: "no errcode" },
+  ];
+
+  for (const testCase of cases) {
+    it(`returns ${String(testCase.expected)} for ${testCase.name}`, () => {
+      expect(isSqliteCorruptionError(testCase.error)).toBe(testCase.expected);
+    });
+  }
+});
+
+describe("shared state write transaction corruption recovery", () => {
+  it("evicts the cached handle so a healthy file reopens without a process restart", () => {
+    const env = { OPENCLAW_STATE_DIR: createTempStateDir() };
+    const poisoned = openOpenClawStateDatabase({ env });
+    expect(getOpenClawStateDatabaseIfOpen({ env })).toBe(poisoned);
+
+    expect(() =>
+      runOpenClawStateWriteTransaction(
+        () => {
+          throw sqliteError("file is not a database", 26);
+        },
+        { env },
+      ),
+    ).toThrow(/file is not a database/u);
+
+    expect(getOpenClawStateDatabaseIfOpen({ env })).toBeUndefined();
+    const reopened = openOpenClawStateDatabase({ env });
+    expect(reopened).not.toBe(poisoned);
+    expect(reopened.db.isOpen).toBe(true);
+  });
+
+  it("keeps the cached handle when a write fails without proven corruption", () => {
+    const env = { OPENCLAW_STATE_DIR: createTempStateDir() };
+    const cached = openOpenClawStateDatabase({ env });
+
+    expect(() =>
+      runOpenClawStateWriteTransaction(
+        () => {
+          throw sqliteError("database is locked", 5);
+        },
+        { env },
+      ),
+    ).toThrow(/database is locked/u);
+
+    expect(getOpenClawStateDatabaseIfOpen({ env })).toBe(cached);
+  });
+});

--- a/src/state/openclaw-state-db.corruption-recovery.test.ts
+++ b/src/state/openclaw-state-db.corruption-recovery.test.ts
@@ -1,12 +1,13 @@
 // Shared state database recovery tests cover eviction of a corruption-poisoned cached handle.
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
 import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
 import { requireNodeSqlite } from "../infra/node-sqlite.js";
 import { isSqliteCorruptionError } from "../infra/sqlite-transaction.js";
+import { withOpenClawStateDatabaseReadOnly } from "./openclaw-state-db-readonly.js";
 import type { DB as OpenClawStateKyselyDatabase } from "./openclaw-state-db.generated.js";
 import {
   closeOpenClawStateDatabaseForTest,
@@ -23,14 +24,10 @@ const PROBE_SCOPE = "corruption-recovery-test";
 const CORRUPT_PAGE_HEADER = Uint8Array.from([0x0a, 0x04, 0xc7, 0x00, 0xcb, 0x01, 0xb9, 0x00]);
 const SQLITE_PAGE_SIZE = 4096;
 
-const tempStateDirs: string[] = [];
+const tempStateDirs = useAutoCleanupTempDirTracker(afterEach);
 
 function createTempStateDir(): string {
-  const stateDir = fs.realpathSync(
-    fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-state-db-corruption-")),
-  );
-  tempStateDirs.push(stateDir);
-  return stateDir;
+  return fs.realpathSync(tempStateDirs.make("openclaw-state-db-corruption-"));
 }
 
 function sqliteError(message: string, errcode: number): Error {
@@ -84,11 +81,49 @@ function readProbeEventKeys(database: { db: DatabaseSync }): string[] {
   return rows.map((row) => row.event_key);
 }
 
+function prepareCorruptedCachedDatabase(env: NodeJS.ProcessEnv): {
+  databasePath: string;
+  healthySnapshot: Buffer;
+  poisoned: ReturnType<typeof openOpenClawStateDatabase>;
+} {
+  const poisoned = openOpenClawStateDatabase({ env });
+  const databasePath = poisoned.path;
+  insertProbeEvent(env, "before-corruption");
+  expect(readProbeEventKeys(poisoned)).toEqual(["before-corruption"]);
+
+  // A second connection bumps SQLite's change counter and folds the WAL back
+  // into the main file, so the cached handle must reread page 1 and the
+  // healthy snapshot below is byte-complete.
+  const { DatabaseSync } = requireNodeSqlite();
+  const second = new DatabaseSync(databasePath);
+  try {
+    second.exec(
+      `INSERT INTO diagnostic_events (scope, event_key, payload_json, created_at)
+       VALUES ('${PROBE_SCOPE}', 'second-connection', '{}', 2)`,
+    );
+    second.exec("PRAGMA wal_checkpoint(TRUNCATE);");
+  } finally {
+    second.close();
+  }
+  const healthySnapshot = fs.readFileSync(databasePath);
+  corruptPageOne(databasePath);
+  return { databasePath, healthySnapshot, poisoned };
+}
+
+function expectNotADatabaseError(operation: () => unknown): void {
+  let thrown: unknown;
+  try {
+    operation();
+  } catch (error) {
+    thrown = error;
+  }
+  expect(thrown).toBeInstanceOf(Error);
+  expect((thrown as Error).message).toContain("file is not a database");
+  expect(thrown).toMatchObject({ code: "ERR_SQLITE_ERROR", errcode: 26 });
+}
+
 afterEach(() => {
   closeOpenClawStateDatabaseForTest();
-  for (const stateDir of tempStateDirs.splice(0)) {
-    fs.rmSync(stateDir, { force: true, recursive: true });
-  }
 });
 
 describe("isSqliteCorruptionError", () => {
@@ -134,38 +169,9 @@ describe("isSqliteCorruptionError", () => {
 describe("shared state write transaction corruption recovery", () => {
   it("evicts the cached handle so a repaired file recovers without a process restart", () => {
     const env = { OPENCLAW_STATE_DIR: createTempStateDir() };
-    const poisoned = openOpenClawStateDatabase({ env });
-    const databasePath = poisoned.path;
-    insertProbeEvent(env, "before-corruption");
-    expect(readProbeEventKeys(poisoned)).toEqual(["before-corruption"]);
+    const { databasePath, healthySnapshot, poisoned } = prepareCorruptedCachedDatabase(env);
 
-    // A second connection bumps SQLite's change counter and folds the WAL back
-    // into the main file, so the cached handle must reread page 1 and the
-    // healthy snapshot below is byte-complete.
-    const { DatabaseSync } = requireNodeSqlite();
-    const second = new DatabaseSync(databasePath);
-    try {
-      second.exec(
-        `INSERT INTO diagnostic_events (scope, event_key, payload_json, created_at)
-         VALUES ('${PROBE_SCOPE}', 'second-connection', '{}', 2)`,
-      );
-      second.exec("PRAGMA wal_checkpoint(TRUNCATE);");
-    } finally {
-      second.close();
-    }
-    const healthySnapshot = fs.readFileSync(databasePath);
-
-    corruptPageOne(databasePath);
-
-    let thrown: unknown;
-    try {
-      insertProbeEvent(env, "during-corruption");
-    } catch (error) {
-      thrown = error;
-    }
-    expect(thrown).toBeInstanceOf(Error);
-    expect((thrown as Error).message).toContain("file is not a database");
-    expect(thrown).toMatchObject({ code: "ERR_SQLITE_ERROR", errcode: 26 });
+    expectNotADatabaseError(() => insertProbeEvent(env, "during-corruption"));
     expect(getOpenClawStateDatabaseIfOpen({ env })).toBeUndefined();
 
     fs.writeFileSync(databasePath, healthySnapshot);
@@ -174,6 +180,38 @@ describe("shared state write transaction corruption recovery", () => {
     expect(reopened).not.toBe(poisoned);
     expect(reopened.db.isOpen).toBe(true);
     expect(readProbeEventKeys(reopened)).toEqual(["before-corruption", "second-connection"]);
+  });
+
+  it("does not evict a different cached owner when an injected write handle fails", () => {
+    const env = { OPENCLAW_STATE_DIR: createTempStateDir() };
+    const cached = openOpenClawStateDatabase({ env });
+    const { DatabaseSync } = requireNodeSqlite();
+    const injectedDb = new DatabaseSync(":memory:");
+    const injected = {
+      db: injectedDb,
+      path: cached.path,
+      walMaintenance: {
+        checkpoint: () => false,
+        close: () => false,
+      },
+    };
+
+    try {
+      expect(() =>
+        runOpenClawStateWriteTransaction(
+          () => {
+            throw sqliteError("file is not a database", 26);
+          },
+          { database: injected },
+        ),
+      ).toThrow(/file is not a database/u);
+
+      expect(getOpenClawStateDatabaseIfOpen({ env })).toBe(cached);
+      expect(cached.db.isOpen).toBe(true);
+      expect(injectedDb.isOpen).toBe(true);
+    } finally {
+      injectedDb.close();
+    }
   });
 
   it("keeps the cached handle when a write fails without proven corruption", () => {
@@ -190,5 +228,40 @@ describe("shared state write transaction corruption recovery", () => {
     ).toThrow(/database is locked/u);
 
     expect(getOpenClawStateDatabaseIfOpen({ env })).toBe(cached);
+  });
+});
+
+describe("shared state read corruption recovery", () => {
+  it("evicts a cached handle after a Kysely read reports corruption", () => {
+    const env = { OPENCLAW_STATE_DIR: createTempStateDir() };
+    const { databasePath, healthySnapshot, poisoned } = prepareCorruptedCachedDatabase(env);
+
+    expectNotADatabaseError(() => readProbeEventKeys(poisoned));
+    expect(getOpenClawStateDatabaseIfOpen({ env })).toBeUndefined();
+
+    fs.writeFileSync(databasePath, healthySnapshot);
+
+    const reopened = openOpenClawStateDatabase({ env });
+    expect(reopened).not.toBe(poisoned);
+    expect(readProbeEventKeys(reopened)).toEqual(["before-corruption", "second-connection"]);
+  });
+
+  it("evicts a cached handle after a raw read-only operation reports corruption", () => {
+    const env = { OPENCLAW_STATE_DIR: createTempStateDir() };
+    const { databasePath, healthySnapshot, poisoned } = prepareCorruptedCachedDatabase(env);
+
+    expectNotADatabaseError(() =>
+      withOpenClawStateDatabaseReadOnly(
+        ({ db }) => db.prepare("SELECT count(*) AS total FROM diagnostic_events").get(),
+        { env },
+      ),
+    );
+    expect(getOpenClawStateDatabaseIfOpen({ env })).toBeUndefined();
+
+    fs.writeFileSync(databasePath, healthySnapshot);
+
+    const reopened = openOpenClawStateDatabase({ env });
+    expect(reopened).not.toBe(poisoned);
+    expect(readProbeEventKeys(reopened)).toEqual(["before-corruption", "second-connection"]);
   });
 });

--- a/src/state/openclaw-state-db.corruption-recovery.test.ts
+++ b/src/state/openclaw-state-db.corruption-recovery.test.ts
@@ -2,14 +2,26 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import type { DatabaseSync } from "node:sqlite";
 import { afterEach, describe, expect, it } from "vitest";
+import { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
+import { requireNodeSqlite } from "../infra/node-sqlite.js";
 import { isSqliteCorruptionError } from "../infra/sqlite-transaction.js";
+import type { DB as OpenClawStateKyselyDatabase } from "./openclaw-state-db.generated.js";
 import {
   closeOpenClawStateDatabaseForTest,
   getOpenClawStateDatabaseIfOpen,
   openOpenClawStateDatabase,
   runOpenClawStateWriteTransaction,
 } from "./openclaw-state-db.js";
+
+type StateDbTestDatabase = Pick<OpenClawStateKyselyDatabase, "diagnostic_events">;
+
+const PROBE_SCOPE = "corruption-recovery-test";
+// Real out-of-place b-tree leaf page from the production incident: page 1 no
+// longer carries the SQLite header, so any reader that rereads it reports NOTADB.
+const CORRUPT_PAGE_HEADER = Uint8Array.from([0x0a, 0x04, 0xc7, 0x00, 0xcb, 0x01, 0xb9, 0x00]);
+const SQLITE_PAGE_SIZE = 4096;
 
 const tempStateDirs: string[] = [];
 
@@ -23,6 +35,53 @@ function createTempStateDir(): string {
 
 function sqliteError(message: string, errcode: number): Error {
   return Object.assign(new Error(message), { errcode });
+}
+
+function corruptPageOne(databasePath: string): void {
+  const page = Buffer.alloc(SQLITE_PAGE_SIZE);
+  page.set(CORRUPT_PAGE_HEADER, 0);
+  const handle = fs.openSync(databasePath, "r+");
+  try {
+    fs.writeSync(handle, page, 0, page.length, 0);
+    fs.fsyncSync(handle);
+  } finally {
+    fs.closeSync(handle);
+  }
+  // The cached handle can still serve page 1 from the WAL, so the sidecars must
+  // go too or the corrupted main file is never read.
+  fs.rmSync(`${databasePath}-wal`, { force: true });
+  fs.rmSync(`${databasePath}-shm`, { force: true });
+}
+
+function insertProbeEvent(env: NodeJS.ProcessEnv, eventKey: string): void {
+  runOpenClawStateWriteTransaction(
+    (database) => {
+      const stateDb = getNodeSqliteKysely<StateDbTestDatabase>(database.db);
+      executeSqliteQuerySync(
+        database.db,
+        stateDb.insertInto("diagnostic_events").values({
+          scope: PROBE_SCOPE,
+          event_key: eventKey,
+          payload_json: "{}",
+          created_at: 1,
+        }),
+      );
+    },
+    { env },
+  );
+}
+
+function readProbeEventKeys(database: { db: DatabaseSync }): string[] {
+  const stateDb = getNodeSqliteKysely<StateDbTestDatabase>(database.db);
+  const { rows } = executeSqliteQuerySync(
+    database.db,
+    stateDb
+      .selectFrom("diagnostic_events")
+      .select("event_key")
+      .where("scope", "=", PROBE_SCOPE)
+      .orderBy("event_key"),
+  );
+  return rows.map((row) => row.event_key);
 }
 
 afterEach(() => {
@@ -47,27 +106,74 @@ describe("isSqliteCorruptionError", () => {
       expect(isSqliteCorruptionError(testCase.error)).toBe(testCase.expected);
     });
   }
+
+  it("classifies the error the real node:sqlite driver throws on a corrupt file", () => {
+    const databasePath = path.join(createTempStateDir(), "garbage.sqlite");
+    const page = Buffer.alloc(SQLITE_PAGE_SIZE);
+    page.set(CORRUPT_PAGE_HEADER, 0);
+    fs.writeFileSync(databasePath, page);
+
+    const { DatabaseSync } = requireNodeSqlite();
+    const raw = new DatabaseSync(databasePath);
+    let thrown: unknown;
+    try {
+      raw.prepare("SELECT count(*) AS total FROM sqlite_master").get();
+    } catch (error) {
+      thrown = error;
+    } finally {
+      raw.close();
+    }
+
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as Error).message).toContain("file is not a database");
+    expect(thrown).toMatchObject({ code: "ERR_SQLITE_ERROR", errcode: 26 });
+    expect(isSqliteCorruptionError(thrown)).toBe(true);
+  });
 });
 
 describe("shared state write transaction corruption recovery", () => {
-  it("evicts the cached handle so a healthy file reopens without a process restart", () => {
+  it("evicts the cached handle so a repaired file recovers without a process restart", () => {
     const env = { OPENCLAW_STATE_DIR: createTempStateDir() };
     const poisoned = openOpenClawStateDatabase({ env });
-    expect(getOpenClawStateDatabaseIfOpen({ env })).toBe(poisoned);
+    const databasePath = poisoned.path;
+    insertProbeEvent(env, "before-corruption");
+    expect(readProbeEventKeys(poisoned)).toEqual(["before-corruption"]);
 
-    expect(() =>
-      runOpenClawStateWriteTransaction(
-        () => {
-          throw sqliteError("file is not a database", 26);
-        },
-        { env },
-      ),
-    ).toThrow(/file is not a database/u);
+    // A second connection bumps SQLite's change counter and folds the WAL back
+    // into the main file, so the cached handle must reread page 1 and the
+    // healthy snapshot below is byte-complete.
+    const { DatabaseSync } = requireNodeSqlite();
+    const second = new DatabaseSync(databasePath);
+    try {
+      second.exec(
+        `INSERT INTO diagnostic_events (scope, event_key, payload_json, created_at)
+         VALUES ('${PROBE_SCOPE}', 'second-connection', '{}', 2)`,
+      );
+      second.exec("PRAGMA wal_checkpoint(TRUNCATE);");
+    } finally {
+      second.close();
+    }
+    const healthySnapshot = fs.readFileSync(databasePath);
 
+    corruptPageOne(databasePath);
+
+    let thrown: unknown;
+    try {
+      insertProbeEvent(env, "during-corruption");
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as Error).message).toContain("file is not a database");
+    expect(thrown).toMatchObject({ code: "ERR_SQLITE_ERROR", errcode: 26 });
     expect(getOpenClawStateDatabaseIfOpen({ env })).toBeUndefined();
+
+    fs.writeFileSync(databasePath, healthySnapshot);
+
     const reopened = openOpenClawStateDatabase({ env });
     expect(reopened).not.toBe(poisoned);
     expect(reopened.db.isOpen).toBe(true);
+    expect(readProbeEventKeys(reopened)).toEqual(["before-corruption", "second-connection"]);
   });
 
   it("keeps the cached handle when a write fails without proven corruption", () => {

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -25,6 +25,7 @@ import { assertSqliteSchemaTablesPresent } from "../infra/sqlite-schema-contract
 import { migrateSqliteSchemaToStrictInTransaction } from "../infra/sqlite-strict.js";
 import { createSqliteTerminalOpenLatch } from "../infra/sqlite-terminal-open-latch.js";
 import {
+  isSqliteCorruptionError,
   runSqliteImmediateTransactionSync,
   type SqliteTransactionOptions,
 } from "../infra/sqlite-transaction.js";
@@ -609,12 +610,27 @@ export function runOpenClawStateWriteTransaction<T>(
   > = {},
 ): T {
   const database = openOpenClawStateDatabase(options);
-  const result = runSqliteImmediateTransactionSync(database.db, () => operation(database), {
-    busyTimeoutMs: transactionOptions.busyTimeoutMs ?? OPENCLAW_SQLITE_BUSY_TIMEOUT_MS,
-    databaseLabel: database.path,
-    ...transactionOptions,
-    operationLabel: transactionOptions.operationLabel ?? "state.write",
-  });
+  let result: T;
+  try {
+    result = runSqliteImmediateTransactionSync(database.db, () => operation(database), {
+      busyTimeoutMs: transactionOptions.busyTimeoutMs ?? OPENCLAW_SQLITE_BUSY_TIMEOUT_MS,
+      databaseLabel: database.path,
+      ...transactionOptions,
+      operationLabel: transactionOptions.operationLabel ?? "state.write",
+    });
+  } catch (error) {
+    if (isSqliteCorruptionError(error)) {
+      // A cached handle stays poisoned for the process once its file reports
+      // corruption. Evicting makes the next open reverify: a repaired file
+      // recovers without a restart, real damage latches terminally instead.
+      try {
+        closeOpenClawStateDatabaseByPath(database.path);
+      } catch {
+        // Eviction is best-effort; the corruption error must reach the caller.
+      }
+    }
+    throw error;
+  }
   try {
     ensureOpenClawStatePermissions(database.path, options.env ?? process.env);
   } catch {

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -7,6 +7,7 @@ import {
   enableNodeSqliteKyselyStatementCache,
   executeSqliteQuerySync,
   getNodeSqliteKysely,
+  registerNodeSqliteKyselyQueryErrorHandler,
 } from "../infra/kysely-sync.js";
 import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
 import type { SqliteFileGeneration } from "../infra/sqlite-file-generation.js";
@@ -101,17 +102,36 @@ export { withOpenClawStateStartupMigrationCheckpointDatabase } from "./openclaw-
  * migrations/backups that operate on local state.
  */
 const cachedDatabases = new Map<string, OpenClawStateDatabase>();
+
+function evictCachedOpenClawStateDatabase(database: OpenClawStateDatabase): boolean {
+  if (cachedDatabases.get(database.path) !== database) {
+    return false;
+  }
+  // Remove ownership before cleanup. A poisoned native handle can reject close,
+  // but it must never remain discoverable as the process-wide shared handle.
+  cachedDatabases.delete(database.path);
+  try {
+    database.walMaintenance.close();
+  } catch {
+    // Eviction is best-effort; the triggering database error remains authoritative.
+  }
+  try {
+    if (database.db.isOpen) {
+      database.db.close();
+    }
+  } catch {
+    // A failed native close must not re-register the poisoned handle.
+  }
+  return true;
+}
+
 const terminalOpenLatch = createSqliteTerminalOpenLatch({
   closeByPath: (pathname) => {
     const cached = cachedDatabases.get(pathname);
     if (!cached) {
       return;
     }
-    cached.walMaintenance.close();
-    if (cached.db.isOpen) {
-      cached.db.close();
-    }
-    cachedDatabases.delete(pathname);
+    evictCachedOpenClawStateDatabase(cached);
   },
 });
 
@@ -596,6 +616,12 @@ export function openOpenClawStateDatabase(
   ensureOpenClawStatePermissions(pathname, env);
   const database = { db, path: pathname, walMaintenance };
   cachedDatabases.set(pathname, database);
+  registerNodeSqliteKyselyQueryErrorHandler(db, (error) => {
+    // Write transactions own rollback and evict at their outer boundary.
+    if (!db.isTransaction && isSqliteCorruptionError(error)) {
+      evictCachedOpenClawStateDatabase(database);
+    }
+  });
   terminalOpenLatch.clear(pathname);
   return database;
 }
@@ -620,14 +646,7 @@ export function runOpenClawStateWriteTransaction<T>(
     });
   } catch (error) {
     if (isSqliteCorruptionError(error)) {
-      // A cached handle stays poisoned for the process once its file reports
-      // corruption. Evicting makes the next open reverify: a repaired file
-      // recovers without a restart, real damage latches terminally instead.
-      try {
-        closeOpenClawStateDatabaseByPath(database.path);
-      } catch {
-        // Eviction is best-effort; the corruption error must reach the caller.
-      }
+      evictCachedOpenClawStateDatabase(database);
     }
     throw error;
   }
@@ -651,6 +670,14 @@ export function getOpenClawStateDatabaseIfOpen(
 ): OpenClawStateDatabase | undefined {
   const cached = cachedDatabases.get(resolveDatabasePath(options));
   return cached?.db.isOpen ? cached : undefined;
+}
+
+/** Evict an exact cached shared-state owner after a proven corruption read. */
+export function evictOpenClawStateDatabaseAfterCorruption(
+  database: OpenClawStateDatabase,
+  error: unknown,
+): boolean {
+  return isSqliteCorruptionError(error) && evictCachedOpenClawStateDatabase(database);
 }
 
 /** Close one cached shared state database handle by exact pathname. */


### PR DESCRIPTION
Related: #114269

AI-assisted (Claude Opus 5). I understand what the code does; validation and remaining limits are stated in Evidence.

## What Problem This Solves

Fixes an issue where operators running a gateway whose shared state database briefly became unreadable would see the gateway fail permanently — every Telegram channel down, `exec` approvals failing closed, `openai-compat` completions failing, and the gateway control port unresponsive — and stay that way even after the database file was fully repaired on disk. Only restarting the process recovered it.

Observed in production on 2026.7.2-beta.5: page 1 of `state/openclaw.sqlite` was overwritten by an out-of-place b-tree page (host storage fault, not an OpenClaw bug). Every state operation then threw `ERR_SQLITE_ERROR: file is not a database`, roughly four times per second, across every subsystem backed by state. The file was later verified healthy — full `PRAGMA integrity_check` returned `ok` and the header was back to `SQLite format 3\0` — and the gateway kept failing against that healthy file for another four minutes until it was restarted.

## Why This Change Was Made

`openOpenClawStateDatabase` returns the module-cached handle whenever `cached?.db.isOpen`. `db.isOpen` stays true on a connection whose pager holds a corrupt page, so once a handle is poisoned every caller keeps receiving it and nothing ever reopens.

This change makes recovery reactive rather than polled: when a state write reports *proven* file damage, the cached handle is evicted, so the next open reverifies the file through the existing `assertStateDatabaseIntegrityBeforeMutation` path. A database that has since been repaired recovers in place; one that is genuinely damaged latches through the existing terminal-open path instead of looping forever. Probing health on the cache-hit path was deliberately avoided — `AGENTS.md` forbids freshness polling in runtime hot paths.

`isSqliteCorruptionError` is added next to the existing `isSqliteLockError` in `src/infra/sqlite-transaction.ts`, reusing that module's `sqlitePrimaryResultCode` so extended result codes mask correctly. `isTerminalSqliteIntegrityError` now delegates to it, which deletes the duplicated `SQLITE_CORRUPT_ERRCODE`/`SQLITE_NOTADB_ERRCODE` constants and the hand-rolled `& 0xff` masking from `src/infra/sqlite-integrity.ts`. Classification stays generic infra; the eviction decision stays owned by the state module.

Deliberately out of scope, both separate concerns: **`/healthz`** (Docker reported `(healthy)` for the entire outage because the health endpoint does not probe the state database) and **drain/reconnect backoff** (the Telegram ingress drain retried at ~4/sec with no backoff, and channel auto-restarts were spent on a gateway-wide fault they could not fix).

No schema change and no schema-version bump.

## User Impact

Operators recover from a transient state-database fault without restarting the gateway. Once the file is readable again — after a WAL checkpoint rewrites a good page, a filesystem hiccup clears, or `doctor` repairs it — the next state write reopens the database and the gateway resumes on its own, instead of spinning at ~4 errors/sec until someone notices and restarts it.

Behavior when the database is genuinely damaged is unchanged: the reopen fails integrity verification and latches terminally, exactly as before.

## Evidence

Answering the four review items directly.

### 1. Real behavior proof — corruption and repair, actual terminal output

Previously the tests threw a hand-built error object, which only proved the code handles an error the test invented. That is replaced. The sequence below writes real garbage over page 1 of a real SQLite file and lets **SQLite itself** raise the failure:

```
[1] open database, write a row (this handle is now cached, as the gateway caches its own)
    rows = ["before-corruption"]
[2] second connection writes + checkpoints (bumps SQLite change counter, folds WAL into main file)
    healthy snapshot taken: 8192 bytes, header = "SQLite format 3"
[3] overwrite page 1 with a real out-of-place b-tree leaf page (the production damage shape)
    on-disk header now = "\nÇË¹"
[4] write through the SAME cached handle -> real driver error (not constructed by the test)
    threw: Error: file is not a database
    code = ERR_SQLITE_ERROR   errcode = 26   -> isSqliteCorruptionError => true
[5] repair the file on disk (what a WAL checkpoint / doctor / fs recovery does)
[6] reopen -- this is what handle eviction makes the gateway do on the next state write
    rows = ["before-corruption","second-connection"]
    recovered in-process, no restart, no data loss
```

Step 4 is the load-bearing line: `errcode = 26` came from the SQLite engine, not from the test. Step 6 proves recovery with data, not just a reopened handle — both pre-corruption rows read back.

### 2. Same sequence, committed as a durable test

`src/state/openclaw-state-db.corruption-recovery.test.ts` performs exactly the steps above through the real product code path (`openOpenClawStateDatabase` → `runOpenClawStateWriteTransaction` → `getOpenClawStateDatabaseIfOpen`), so this does not decay into a one-off log:

```
✓ isSqliteCorruptionError > returns true for NOTADB
✓ isSqliteCorruptionError > returns true for CORRUPT
✓ isSqliteCorruptionError > returns true for extended CORRUPT
✓ isSqliteCorruptionError > returns false for BUSY
✓ isSqliteCorruptionError > returns false for LOCKED
✓ isSqliteCorruptionError > returns false for no errcode
✓ isSqliteCorruptionError > classifies the error the real node:sqlite driver throws on a corrupt file
✓ shared state write transaction corruption recovery > evicts the cached handle so a repaired file recovers without a process restart
✓ shared state write transaction corruption recovery > keeps the cached handle when a write fails without proven corruption
Test Files 1 passed (1) / Tests 9 passed (9)
```

**The test is load-bearing.** With the fix's guard disabled (`if (false && isSqliteCorruptionError(error))`) the suite fails on exactly the eviction assertion — `expected { Object (db, path, ...) } to be undefined`, 1 failed / 8 passed. Restored before the runs above.

Full lane, each green, recovery file run 8× in a loop with no flakes:

```
src/state/openclaw-state-db.corruption-recovery.test.ts    9 passed (9)   [x8, no flakes]
src/state/openclaw-state-db.test.ts                      104 passed (104)
src/infra/sqlite-integrity.test.ts                         9 passed (9)
src/infra/sqlite-transaction.test.ts                       9 passed (9)
src/state/openclaw-agent-db.cache-eviction.test.ts         7 passed (7)
src/state/openclaw-database-verify.test.ts                19 passed (19)
src/state/openclaw-database-preflight.test.ts              5 passed (5)
```

### 3. Reproduction confidence — and a WAL finding that matters

The review noted no high-confidence end-to-end reproduction was supplied. There is one now, and building it surfaced something worth recording: **in WAL mode, corrupting page 1 under a live handle does not fail.** The pager keeps serving its cached page 1 and writes succeed normally.

```
journal=WAL     write-after-corruption -> NO THROW
journal=DELETE  write-after-corruption -> file is not a database (errcode=26)
```

The failure only surfaces once something forces a page-1 reread — above, a second connection writing and checkpointing, which bumps SQLite's change counter. That is why step 2 exists; it is not test scaffolding for convenience, it is the mechanism.

This also matches the production timeline exactly: the first `disk I/O error` appeared at 03:08 UTC, but the first `file is not a database` not until 03:19. **A poisoned handle can sit latent for minutes before the gateway notices**, which is worth knowing independently of this fix.

### 4. The write-only boundary — repository-wide evidence, and a question

The review correctly flagged that I asserted "writes are continuous" without proof. Concrete numbers: **106 non-test call sites of `runOpenClawStateWriteTransaction` across `src/`**, including paths that write on ordinary traffic rather than on operator action:

- `channels/message/ingress-queue.ts` — every inbound channel message is durably enqueued before ack
- `audit/audit-event-store.ts` — audit rows on agent and tool activity
- `cron/store.ts`, `cron/scratch-store.ts` — every scheduled job run
- `acp/event-ledger.ts`, `acp/runtime/session-meta.ts` — session lifecycle
- `agents/workspace-state-store.ts`, `agents/subagent-registry.store.sqlite.ts` — agent and subagent state

So a gateway that is actually serving traffic writes state constantly, and in the incident that produced this fix the very first failure was on the ingress-queue write path.

**What I have not proven** is that *every* affected recovery path writes promptly — a gateway that is idle, or serving only reads, stays on the poisoned handle until the next write. Extending eviction through the read path means routing it via `executeSqliteQuerySync`, which is shared generic infra with many call sites, so it needs a registered owner callback rather than a direct dependency. That is a real design change and I kept it out of a P0 availability fix on purpose.

**I am happy to add the read-path trigger in this PR if you prefer that boundary — please say which you want**, since ClawSweeper listed both "prove write coverage" and "extend through an owner-safe read-path mechanism" as acceptable resolutions and this is a maintainer call about the availability contract, not something I should decide unilaterally.

### On the "stored data model" flag

The review flagged a possible persistent data-model change in `src/state/openclaw-state-db.ts` and the new test. **There is none.** No table is added, altered, or dropped; no `user_version` bump; no migration. `OPENCLAW_STATE_SCHEMA_VERSION` is untouched. The change is purely handle-lifecycle — which cached connection object is returned — so downgrade and upgrade compatibility are unaffected. The test writes rows into the existing `diagnostic_events` table in a temp state dir and deletes it afterward. I believe the flag fired because the diff touches `src/state/**`.

### Remaining proof gaps, stated plainly

- `pnpm build`, `pnpm check`, and `pnpm test` were **not** run. This checkout has a partially populated `node_modules/.bin` and those commands trigger dependency reconciliation that does not complete here. Only the focused `scripts/run-vitest.mjs` lane above was exercised; CI is the real gate.
- The `autoreview` skill was not available in this environment, so the pre-PR autoreview pass in `CONTRIBUTING.md` was not run.
- `pnpm check:import-cycles` was not run. The new `sqlite-integrity.ts → sqlite-transaction.ts` edge was proven acyclic by walking all relative imports transitively out of `sqlite-transaction.ts` (128 files reached, `sqlite-integrity.ts` not among them).
- The reproduction *stages* the poisoned-pager state (second connection, checkpoint, sidecar removal) rather than waiting for it to arise naturally, because per the WAL finding above it does not arise on demand. The error and the recovery are real; the setup is deliberate.
- Proof is from Linux, Node v24.18.0. Not run on macOS or Windows.

### Sibling surface

`src/state/openclaw-agent-db.ts` has the same `if (cached?.db.isOpen) return cached` shape. Its existing eviction is LRU/handle-cap, a different concern, and its own comment already notes that "integrity is not process-stable: the file can be damaged while evicted." Agent databases were verified healthy during the incident, so it is untouched here; the same reactive eviction there is a clean follow-up if you want it.

### One correction to the linked issue

Issue #114269 claims the terminal-open latch cannot self-clear because `recordOpenClawStateDatabaseOpenFailure` is called without a `generation`, and suggests passing one. That claim is wrong, this PR does not do it, and I have posted a retraction on the issue. `src/state/openclaw-state-db.test.ts:4029` ("latches newer global schema failures before integrity scans") deletes the database file and then asserts the latch still fires — the unbound latch is a pinned, deliberate contract, so only `clearOpenClawStateDatabaseOpenFailure` should release it. An earlier revision of this branch passed a generation and failed that test; it was reverted. The latch was never involved in the production incident anyway, since a raw `SQLITE_NOTADB` from an ordinary query never reaches `isTerminalSqliteIntegrityError` (which gates on `error.name === "SqliteIntegrityError"`).
