### PR TITLE
fix(models): make dynamic catalog selection follow one canonical plan

### DIFF
--- a/src/commands/models/list.list-command.ts
+++ b/src/commands/models/list.list-command.ts
@@ -139,7 +139,7 @@ export async function modelsListCommand(
         metadataSnapshot,
       })
     : undefined;
-  const shouldLoadRegistry = sourcePlan?.requiresInitialRegistry ?? false;
+  const shouldLoadRegistry = sourcePlan?.kind === "registry";
   const loadRegistryState = async (optsLocal?: {
     normalizeModels?: boolean;
     loadAvailability?: boolean;
@@ -202,7 +202,11 @@ export async function modelsListCommand(
     if (!sourcePlan || !sourcePlanModule) {
       throw new Error("models list source plan was not initialized");
     }
-    let rowContext = buildRowContext(sourcePlan.skipRuntimeModelSuppression);
+    let rowContext = buildRowContext(
+      sourcePlan.kind === "manifest" ||
+        sourcePlan.kind === "provider-index" ||
+        sourcePlan.kind === "provider-runtime-static",
+    );
     const initialAppend = await appendAllModelRowSources({
       rows,
       entries,

--- a/src/commands/models/list.manifest-catalog.ts
+++ b/src/commands/models/list.manifest-catalog.ts
@@ -2,7 +2,10 @@
 import { normalizeModelCatalogProviderId } from "@openclaw/model-catalog-core/model-catalog-refs";
 import type { NormalizedModelCatalogRow } from "@openclaw/model-catalog-core/model-catalog-types";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { planEffectiveModelCatalogRows } from "../../model-catalog/index.js";
+import {
+  planEffectiveModelCatalogRows,
+  type ManifestModelCatalogRowSelection,
+} from "../../model-catalog/index.js";
 import { loadManifestMetadataSnapshot } from "../../plugins/manifest-contract-eligibility.js";
 import type { PluginManifestRegistry } from "../../plugins/manifest-registry.js";
 import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
@@ -13,14 +16,10 @@ import {
   type PluginRegistrySnapshot,
 } from "../../plugins/plugin-registry.js";
 
-type ManifestCatalogRowsForListMode = "static-authoritative" | "supplemental";
-
 function loadManifestCatalogRowsForPluginIds(params: {
   cfg: OpenClawConfig;
-  env?: NodeJS.ProcessEnv;
-  index: PluginRegistrySnapshot;
   registry: PluginManifestRegistry;
-  mode: ManifestCatalogRowsForListMode;
+  mode: ManifestModelCatalogRowSelection;
   pluginIds?: readonly string[];
   providerFilter?: string;
 }): readonly NormalizedModelCatalogRow[] {
@@ -34,35 +33,12 @@ function loadManifestCatalogRowsForPluginIds(params: {
         plugins: params.registry.plugins.filter((plugin) => pluginIdSet.has(plugin.id)),
       }
     : params.registry;
-  const plan = planEffectiveModelCatalogRows({
+  return planEffectiveModelCatalogRows({
     registry,
     config: params.cfg,
     ...(params.providerFilter ? { providerFilter: params.providerFilter } : {}),
-  });
-  const eligibleProviders = new Set(
-    plan.entries
-      .filter((entry) =>
-        params.mode === "static-authoritative"
-          ? entry.discovery === "static"
-          : entry.discovery !== "runtime",
-      )
-      .map((entry) => entry.provider),
-  );
-  const runtimeRefreshProviders = new Set(
-    params.mode === "supplemental"
-      ? plan.entries.filter((entry) => entry.discovery === "runtime").map((entry) => entry.provider)
-      : [],
-  );
-  if (eligibleProviders.size === 0 && runtimeRefreshProviders.size === 0) {
-    return [];
-  }
-  // Runtime-owned providers still discover authoritative models live; only
-  // validated remote-refresh rows may supplement that provider catalog.
-  return plan.rows.filter(
-    (row) =>
-      eligibleProviders.has(row.provider) ||
-      (runtimeRefreshProviders.has(row.provider) && row.source === "runtime-refresh"),
-  );
+    selection: params.mode,
+  }).rows;
 }
 
 function resolveConventionModelCatalogPluginIds(params: {
@@ -104,13 +80,13 @@ function loadManifestCatalogRowsForList(params: {
   cfg: OpenClawConfig;
   providerFilter?: string;
   env?: NodeJS.ProcessEnv;
-  mode?: ManifestCatalogRowsForListMode;
+  mode?: ManifestModelCatalogRowSelection;
   metadataSnapshot?: PluginMetadataSnapshot;
 }): readonly NormalizedModelCatalogRow[] {
   const providerFilter = params.providerFilter
     ? normalizeModelCatalogProviderId(params.providerFilter)
     : undefined;
-  const mode = params.mode ?? "static-authoritative";
+  const mode = params.mode ?? "static";
   const snapshot =
     params.metadataSnapshot ??
     loadManifestMetadataSnapshot({
@@ -121,16 +97,12 @@ function loadManifestCatalogRowsForList(params: {
   if (!providerFilter) {
     return loadManifestCatalogRowsForPluginIds({
       cfg: params.cfg,
-      env: params.env,
-      index,
       registry: snapshot.manifestRegistry,
       mode,
     });
   }
   const conventionRows = loadManifestCatalogRowsForPluginIds({
     cfg: params.cfg,
-    env: params.env,
-    index,
     registry: snapshot.manifestRegistry,
     mode,
     pluginIds: resolveConventionModelCatalogPluginIds({
@@ -145,8 +117,6 @@ function loadManifestCatalogRowsForList(params: {
   }
   return loadManifestCatalogRowsForPluginIds({
     cfg: params.cfg,
-    env: params.env,
-    index,
     registry: snapshot.manifestRegistry,
     mode,
     pluginIds: resolveDeclaredModelCatalogPluginIds({
@@ -167,7 +137,7 @@ export function loadStaticManifestCatalogRowsForList(params: {
 }): readonly NormalizedModelCatalogRow[] {
   return loadManifestCatalogRowsForList({
     ...params,
-    mode: "static-authoritative",
+    mode: "static",
   });
 }
 

--- a/src/commands/models/list.row-sources.ts
+++ b/src/commands/models/list.row-sources.ts
@@ -94,7 +94,8 @@ export async function appendAllModelRowSources(
     if (
       catalogRows === 0 &&
       params.rows.length === 0 &&
-      params.sourcePlan.fallbackToRegistryWhenEmpty
+      (params.sourcePlan.kind === "provider-runtime-static" ||
+        params.sourcePlan.kind === "provider-runtime-scoped")
     ) {
       // Provider-scoped static sources can be empty when a plugin exposes only
       // runtime discovery; tell the caller to load the registry and retry.

--- a/src/commands/models/list.source-plan.test.ts
+++ b/src/commands/models/list.source-plan.test.ts
@@ -43,8 +43,6 @@ describe("planAllModelListSources", () => {
     });
 
     expect(plan.kind).toBe("manifest");
-    expect(plan.requiresInitialRegistry).toBe(false);
-    expect(plan.skipRuntimeModelSuppression).toBe(true);
     expect(plan.manifestCatalogRows).toEqual([catalogRow]);
     expect(mocks.loadStaticManifestCatalogRowsForList).toHaveBeenCalledWith({
       cfg: {},
@@ -69,8 +67,6 @@ describe("planAllModelListSources", () => {
     });
 
     expect(plan.kind).toBe("provider-runtime-scoped");
-    expect(plan.requiresInitialRegistry).toBe(false);
-    expect(plan.fallbackToRegistryWhenEmpty).toBe(true);
     expect(plan.manifestCatalogRows).toEqual([catalogRow]);
     expect(mocks.loadStaticManifestCatalogRowsForList).toHaveBeenCalledWith({
       cfg: {},
@@ -97,8 +93,6 @@ describe("planAllModelListSources", () => {
     });
 
     expect(plan.kind).toBe("provider-index");
-    expect(plan.requiresInitialRegistry).toBe(false);
-    expect(plan.skipRuntimeModelSuppression).toBe(true);
     expect(plan.providerIndexCatalogRows).toEqual([providerIndexRow]);
     expect(mocks.hasProviderStaticCatalogForFilter).not.toHaveBeenCalled();
   });
@@ -115,8 +109,6 @@ describe("planAllModelListSources", () => {
     });
 
     expect(plan.kind).toBe("registry");
-    expect(plan.requiresInitialRegistry).toBe(true);
-    expect(plan.skipRuntimeModelSuppression).toBe(false);
     expect(plan.manifestCatalogRows).toEqual([catalogRow]);
     expect(mocks.loadStaticManifestCatalogRowsForList).toHaveBeenCalledWith({
       cfg: {},
@@ -139,9 +131,6 @@ describe("planAllModelListSources", () => {
       dependencies: mocks,
     });
     expect(plan.kind).toBe("provider-runtime-scoped");
-    expect(plan.requiresInitialRegistry).toBe(false);
-    expect(plan.skipRuntimeModelSuppression).toBe(false);
-    expect(plan.fallbackToRegistryWhenEmpty).toBe(true);
   });
 
   it("keeps broad all-model lists on the registry path with cheap catalog supplements", async () => {
@@ -157,8 +146,6 @@ describe("planAllModelListSources", () => {
     });
 
     expect(plan.kind).toBe("registry");
-    expect(plan.requiresInitialRegistry).toBe(true);
-    expect(plan.skipRuntimeModelSuppression).toBe(false);
     expect(plan.manifestCatalogRows).toEqual([catalogRow]);
     expect(plan.providerIndexCatalogRows).toEqual([providerIndexRow]);
     expect(mocks.loadSupplementalManifestCatalogRowsForList).toHaveBeenCalledWith({
@@ -179,9 +166,6 @@ describe("planAllModelListSources", () => {
       dependencies: mocks,
     });
     expect(plan.kind).toBe("provider-runtime-static");
-    expect(plan.requiresInitialRegistry).toBe(false);
-    expect(plan.skipRuntimeModelSuppression).toBe(true);
-    expect(plan.fallbackToRegistryWhenEmpty).toBe(true);
   });
 
   it("uses runtime-scoped plans for providers with live and static catalog hooks", async () => {
@@ -196,9 +180,6 @@ describe("planAllModelListSources", () => {
       dependencies: mocks,
     });
     expect(plan.kind).toBe("provider-runtime-scoped");
-    expect(plan.requiresInitialRegistry).toBe(false);
-    expect(plan.skipRuntimeModelSuppression).toBe(false);
-    expect(plan.fallbackToRegistryWhenEmpty).toBe(true);
     expect(mocks.hasProviderStaticCatalogForFilter).not.toHaveBeenCalled();
   });
 });

--- a/src/commands/models/list.source-plan.ts
+++ b/src/commands/models/list.source-plan.ts
@@ -17,9 +17,6 @@ export type ModelListSourcePlan = {
   kind: ModelListSourcePlanKind;
   manifestCatalogRows: readonly NormalizedModelCatalogRow[];
   providerIndexCatalogRows: readonly NormalizedModelCatalogRow[];
-  requiresInitialRegistry: boolean;
-  skipRuntimeModelSuppression: boolean;
-  fallbackToRegistryWhenEmpty: boolean;
 };
 
 type ProviderIndexCatalogModule = typeof import("./list.provider-index-catalog.js");
@@ -44,26 +41,17 @@ function createSourcePlan(params: {
   kind: ModelListSourcePlanKind;
   manifestCatalogRows?: readonly NormalizedModelCatalogRow[];
   providerIndexCatalogRows?: readonly NormalizedModelCatalogRow[];
-  requiresInitialRegistry?: boolean;
-  skipRuntimeModelSuppression?: boolean;
-  fallbackToRegistryWhenEmpty?: boolean;
 }): ModelListSourcePlan {
   return {
     kind: params.kind,
     manifestCatalogRows: params.manifestCatalogRows ?? [],
     providerIndexCatalogRows: params.providerIndexCatalogRows ?? [],
-    requiresInitialRegistry: params.requiresInitialRegistry ?? false,
-    skipRuntimeModelSuppression: params.skipRuntimeModelSuppression ?? false,
-    fallbackToRegistryWhenEmpty: params.fallbackToRegistryWhenEmpty ?? false,
   };
 }
 
 /** Creates the baseline plan that loads the runtime model registry. */
 export function createRegistryModelListSourcePlan(): ModelListSourcePlan {
-  return createSourcePlan({
-    kind: "registry",
-    requiresInitialRegistry: true,
-  });
+  return createSourcePlan({ kind: "registry" });
 }
 
 /** Plans source precedence for all/provider-filtered model-list output. */
@@ -103,7 +91,6 @@ export async function planAllModelListSources(params: {
       providerIndexCatalogRows: loadProviderIndexCatalogRowsForList({
         cfg: params.cfg,
       }),
-      requiresInitialRegistry: true,
     });
   }
 
@@ -124,7 +111,6 @@ export async function planAllModelListSources(params: {
     return createSourcePlan({
       kind: "manifest",
       manifestCatalogRows: staticManifestCatalogRows,
-      skipRuntimeModelSuppression: true,
     });
   }
 
@@ -143,7 +129,6 @@ export async function planAllModelListSources(params: {
         providerFilter: params.providerFilter,
         metadataSnapshot: params.metadataSnapshot,
       }),
-      fallbackToRegistryWhenEmpty: true,
     });
   }
 
@@ -159,7 +144,6 @@ export async function planAllModelListSources(params: {
     return createSourcePlan({
       kind: "registry",
       manifestCatalogRows,
-      requiresInitialRegistry: true,
     });
   }
 
@@ -175,7 +159,6 @@ export async function planAllModelListSources(params: {
     return createSourcePlan({
       kind: "provider-index",
       providerIndexCatalogRows,
-      skipRuntimeModelSuppression: true,
     });
   }
 
@@ -187,15 +170,8 @@ export async function planAllModelListSources(params: {
     metadataSnapshot: params.metadataSnapshot,
   });
   if (hasProviderStaticCatalog) {
-    return createSourcePlan({
-      kind: "provider-runtime-static",
-      skipRuntimeModelSuppression: true,
-      fallbackToRegistryWhenEmpty: true,
-    });
+    return createSourcePlan({ kind: "provider-runtime-static" });
   }
 
-  return createSourcePlan({
-    kind: "provider-runtime-scoped",
-    fallbackToRegistryWhenEmpty: true,
-  });
+  return createSourcePlan({ kind: "provider-runtime-scoped" });
 }

--- a/src/model-catalog/index.ts
+++ b/src/model-catalog/index.ts
@@ -5,13 +5,17 @@ export { planManifestModelCatalogSuppressions } from "./manifest-planner.js";
 export { planProviderIndexModelCatalogRows } from "./provider-index-planner.js";
 import type { ModelCatalogProvider } from "@openclaw/model-catalog-core/model-catalog-types";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { planManifestModelCatalogRows } from "./manifest-planner.js";
+import {
+  planManifestModelCatalogRows,
+  type ManifestModelCatalogRowSelection,
+} from "./manifest-planner.js";
 import { getRemoteModelCatalogOverlay } from "./remote-overlay.js";
 
 export function planEffectiveModelCatalogRows(params: {
   registry: Parameters<typeof planManifestModelCatalogRows>[0]["registry"];
   config: OpenClawConfig;
   providerFilter?: string;
+  selection?: ManifestModelCatalogRowSelection;
 }) {
   const remoteOverlay: Readonly<Record<string, ModelCatalogProvider>> | undefined =
     getRemoteModelCatalogOverlay(params.config);
@@ -19,7 +23,11 @@ export function planEffectiveModelCatalogRows(params: {
     registry: params.registry,
     ...(params.providerFilter ? { providerFilter: params.providerFilter } : {}),
     ...(remoteOverlay ? { remoteOverlay } : {}),
+    ...(params.selection ? { selection: params.selection } : {}),
   });
 }
-export type { ManifestModelCatalogSuppressionEntry } from "./manifest-planner.js";
+export type {
+  ManifestModelCatalogRowSelection,
+  ManifestModelCatalogSuppressionEntry,
+} from "./manifest-planner.js";
 export type { OpenClawProviderIndexProvider } from "./provider-index/index.js";

--- a/src/model-catalog/manifest-planner.test.ts
+++ b/src/model-catalog/manifest-planner.test.ts
@@ -77,6 +77,81 @@ describe("manifest model catalog planner", () => {
       { provider: "anthropic-alias", id: "old", name: "Remote alias", source: "runtime-refresh" },
     ]);
   });
+
+  it("selects static and supplemental rows at their owning catalog boundary", () => {
+    const providers = [
+      ["static-provider", "static"],
+      ["refreshable-provider", "refreshable"],
+      ["runtime-provider", "runtime"],
+    ] as const;
+    const registry = {
+      plugins: providers.map(([provider, discovery]) => ({
+        id: provider,
+        providers: [provider],
+        modelCatalog: {
+          providers: { [provider]: { models: [{ id: "known" }] } },
+          discovery: { [provider]: discovery },
+        },
+      })),
+    };
+    const remoteOverlay = Object.fromEntries(
+      providers.map(([provider]) => [provider, { models: [{ id: "refreshed" }] }]),
+    );
+    const refsFor = (selection?: Parameters<typeof planManifestModelCatalogRows>[0]["selection"]) =>
+      planManifestModelCatalogRows({
+        registry,
+        remoteOverlay,
+        ...(selection ? { selection } : {}),
+      }).rows.map((row) => row.ref);
+
+    expect(refsFor()).toEqual([
+      "refreshable-provider/known",
+      "refreshable-provider/refreshed",
+      "runtime-provider/known",
+      "runtime-provider/refreshed",
+      "static-provider/known",
+      "static-provider/refreshed",
+    ]);
+    expect(refsFor("static")).toEqual(["static-provider/known", "static-provider/refreshed"]);
+    expect(refsFor("supplemental")).toEqual([
+      "refreshable-provider/known",
+      "refreshable-provider/refreshed",
+      "runtime-provider/refreshed",
+      "static-provider/known",
+      "static-provider/refreshed",
+    ]);
+  });
+
+  it("keeps conflicting model rows excluded from every catalog selection", () => {
+    const registry = {
+      plugins: [
+        {
+          id: "first-owner",
+          modelCatalog: {
+            providers: { shared: { models: [{ id: "conflicted" }] } },
+            discovery: { shared: "static" as const },
+          },
+        },
+        {
+          id: "second-owner",
+          modelCatalog: {
+            providers: { shared: { models: [{ id: "conflicted" }] } },
+            discovery: { shared: "runtime" as const },
+          },
+        },
+      ],
+    };
+
+    for (const selection of [undefined, "static", "supplemental"] as const) {
+      const plan = planManifestModelCatalogRows({
+        registry,
+        ...(selection ? { selection } : {}),
+      });
+      expect(plan.rows, selection).toEqual([]);
+      expect(plan.conflicts, selection).toHaveLength(1);
+    }
+  });
+
   it("builds manifest rows from plugin-owned catalog providers", () => {
     const plan = planManifestModelCatalogRows({
       registry: {

--- a/src/model-catalog/manifest-planner.ts
+++ b/src/model-catalog/manifest-planner.ts
@@ -52,6 +52,8 @@ type ManifestModelCatalogPlan = {
   conflicts: readonly ManifestModelCatalogConflict[];
 };
 
+export type ManifestModelCatalogRowSelection = "static" | "supplemental";
+
 export type ManifestModelCatalogSuppressionEntry = {
   pluginId: string;
   provider: string;
@@ -82,6 +84,7 @@ export function planManifestModelCatalogRows(params: {
   registry: ManifestModelCatalogRegistry;
   providerFilter?: string;
   remoteOverlay?: Readonly<Record<string, ModelCatalogProvider>>;
+  selection?: ManifestModelCatalogRowSelection;
 }): ManifestModelCatalogPlan {
   const providerFilter = params.providerFilter
     ? normalizeModelCatalogProviderId(params.providerFilter)
@@ -99,7 +102,14 @@ export function planManifestModelCatalogRows(params: {
   }
 
   const rowCandidates: NormalizedModelCatalogRow[] = [];
-  const seenRows = new Map<string, { pluginId: string; row: NormalizedModelCatalogRow }>();
+  const seenRows = new Map<
+    string,
+    {
+      pluginId: string;
+      row: NormalizedModelCatalogRow;
+      discovery: ModelCatalogDiscovery | undefined;
+    }
+  >();
   const conflicts = new Map<string, ManifestModelCatalogConflict>();
   for (const entry of entries) {
     for (const row of entry.rows) {
@@ -119,13 +129,30 @@ export function planManifestModelCatalogRows(params: {
         }
         continue;
       }
-      seenRows.set(row.mergeKey, { pluginId: entry.pluginId, row });
+      seenRows.set(row.mergeKey, {
+        pluginId: entry.pluginId,
+        row,
+        discovery: entry.discovery,
+      });
       rowCandidates.push(row);
     }
   }
 
   const conflictedMergeKeys = new Set(conflicts.keys());
-  const rows = rowCandidates.filter((row) => !conflictedMergeKeys.has(row.mergeKey));
+  const rows = rowCandidates.filter((row) => {
+    if (conflictedMergeKeys.has(row.mergeKey)) {
+      return false;
+    }
+    const discovery = seenRows.get(row.mergeKey)?.discovery;
+    if (params.selection === "static") {
+      return discovery === "static";
+    }
+    return (
+      params.selection !== "supplemental" ||
+      discovery !== "runtime" ||
+      row.source === "runtime-refresh"
+    );
+  });
 
   return {
     entries,


### PR DESCRIPTION
Related: #113660, #114244, #114265.

## What Problem This Solves

Fixes the recurring class of dynamic-model catalog regressions where the Gateway, provider-filtered CLI, picker, and runtime discovery can disagree about which static, refreshed, or live provider models are eligible. The previous fixes restored the missing outputs but left discovery rules split between the manifest planner and CLI, plus three independently maintained source-plan booleans that could express contradictory states.

## Why This Change Was Made

Make the existing manifest catalog planner the sole owner of static and supplemental row eligibility. Preserve conflict rejection before projecting either view, and derive CLI registry loading, suppression, and empty-catalog fallback directly from the discriminated source kind. The change removes 14 production lines, all three duplicated source-plan state flags, and the CLI's separate provider-eligibility sets; it does not introduce a new config option, storage schema, runtime compatibility path, provider special case, or public SDK surface.

AI-assisted: Codex. OpenAI live discovery remains authoritative and the runtime manifest is unchanged. Checked upstream Codex revision `95637f7056835fea66bdd0044414af480fc0fd74`: `codex-rs/app-server/src/models.rs:13`, `codex-rs/app-server/src/request_processors/catalog_processor.rs:255`, `codex-rs/app-server/tests/suite/v2/model_list.rs:153`, and `codex-rs/app-server/src/models_refresh_worker.rs:30`.

## User Impact

Refreshed OpenAI, Anthropic, and other provider models follow the same ownership, source, precedence, and suppression rules in Gateway, CLI, onboarding, and agent model selection. Existing live/account-aware discovery and provider trust remain unchanged, with fewer opportunities for one consumer to silently drop valid models.

## Evidence

- Existing Linux development-Gateway scenario passed all 29 checks on the actual rebuilt product: 39 providers, 219 models, six simultaneous SQLite refresh writers, six simultaneous Gateway readers, twelve concurrent post-restart Gateway/CLI reads, OpenAI and Anthropic provider filtering, exact duplicate precedence, trusted transport-field stripping, repeated restarts, HTTP 500, malformed/oversized/duplicate/future-version/future-timestamp catalogs, older/same-generation rollback rejection, HTTP 304, and parallel disabled refresh with zero requests.
- 610 passing catalog, CLI, Gateway, publisher, update, agent, runtime discovery, suppression, OpenAI, and Anthropic tests across 11 routed shards.
- 158 additional passing sibling tests: model picker, onboarding, full CLI E2E, embedded-agent static catalog, and OpenAI Gateway route resolution.
- New canonical planner regressions directly cover static, refreshable, and runtime provider selection plus conflicting provider ownership across all selection modes.
- Three consecutive focused planner, source-plan, manifest, CLI, and deduplication passes: 207 additional clean regression executions.
- Production `pnpm build`, all 142 public SDK export checks, full `pnpm check:changed`, and `git diff --check`.
- Fresh independent `.agents/skills/autoreview/scripts/autoreview --mode uncommitted`: clean; TruffleHog clean.
- Linux Node 24.18.0; `blacksmith-testbox` lease `tbx_01kygw85gedvg7cyxhq4b36ft0`.
