### PR TITLE
fix: Tool Search finds tools by how agents actually phrase requests

### DIFF
--- a/docs/tools/tool-search.md
+++ b/docs/tools/tool-search.md
@@ -126,9 +126,12 @@ Queries must be written in English. Ranking is lexical (Okapi BM25 over tool
 names, descriptions, and first-party parameter names and descriptions), with
 light English stemming so `scheduling` reaches a tool described as `Schedule a
 recurring task`, and a small intent expansion so `look up the price` reaches one
-described as `Search the web`. A query in another language produces no terms and
-therefore no results, rather than an arbitrary slice of the catalog presented as
-if it were ranked. Both `tool_search` and the code-mode bridge state this
+described as `Search the web`. Tool names and descriptions are written in English,
+so a query in another language will usually match nothing. It is not rejected —
+a catalog may legitimately describe a tool in another script — but it is also no
+longer answered with an arbitrary slice of the catalog presented as if it were
+ranked, which is what the previous scorer did whenever a query produced no
+usable terms. Both `tool_search` and the code-mode bridge state this
 requirement in their model-facing descriptions.
 
 Untrusted parameter schemas are never indexed. MCP and client tools are matched

--- a/docs/tools/tool-search.md
+++ b/docs/tools/tool-search.md
@@ -120,7 +120,22 @@ client-provided app tools.
 
 `openclaw.tools.search(query, options?)`
 
-Searches the effective catalog for the current run. Results are compact and safe
+Searches the effective catalog for the current run.
+
+Queries must be written in English. Ranking is lexical (Okapi BM25 over tool
+names, descriptions, and first-party parameter names and descriptions), with
+light English stemming so `scheduling` reaches a tool described as `Schedule a
+recurring task`, and a small intent expansion so `look up the price` reaches one
+described as `Search the web`. A query in another language produces no terms and
+therefore no results, rather than an arbitrary slice of the catalog presented as
+if it were ranked. Both `tool_search` and the code-mode bridge state this
+requirement in their model-facing descriptions.
+
+Untrusted parameter schemas are never indexed. MCP and client tools are matched
+on name and description only, which is the same boundary that defers their input
+signatures as `input: "unknown"`.
+
+Results are compact and safe
 to put back into prompt context. Each hit includes a bounded TypeScript-style
 `input` signature, such as `{ id: string; mode?: "drip" | "flood" }`, so the
 model can skip `describe` when that signature is sufficient. A trusted

--- a/src/agents/tool-search-ranking.test.ts
+++ b/src/agents/tool-search-ranking.test.ts
@@ -5,7 +5,7 @@ import {
   tokenizeDocument,
   tokenizeQuery,
 } from "./tool-search-ranking.js";
-import { ToolSearchRuntime, toolSearchEntryText } from "./tool-search-runtime.js";
+import { ToolSearchRuntime } from "./tool-search-runtime.js";
 import type { ToolSearchCatalogEntry } from "./tool-search-types.js";
 
 function entry(partial: Partial<ToolSearchCatalogEntry>): ToolSearchCatalogEntry {
@@ -184,15 +184,12 @@ describe("scoreLexical", () => {
   });
 });
 
-describe("toolSearchEntryText", () => {
-  it("indexes first-party parameter names and descriptions", () => {
-    const text = toolSearchEntryText(CATALOG[4] as ToolSearchCatalogEntry);
-
-    expect(text).toContain("repository");
-    expect(text).toContain("Target repository");
-  });
-
-  it("never traverses schemas from sources the catalog treats as untrusted", () => {
+describe("untrusted schemas", () => {
+  it("never traverses parameters from a source the catalog treats as untrusted", async () => {
+    // compactToolSearchCatalogEntry already reports non-first-party parameters
+    // as "unknown"; indexing must respect the same boundary. A client can hand
+    // us a lazy object that throws on property access, and MCP-authored text
+    // must not become ranking input.
     const hostile = entry({
       source: "client",
       name: "client_pick_file",
@@ -209,9 +206,29 @@ describe("toolSearchEntryText", () => {
         ),
       },
     });
+    const ctx = {
+      catalogRef: {
+        current: {
+          entries: [...CATALOG, hostile],
+          searchCount: 0,
+          describeCount: 0,
+          callCount: 0,
+        },
+      },
+    };
+    const search = new ToolSearchRuntime(ctx as never, {
+      enabled: true,
+      mode: "directory",
+      codeTimeoutMs: 1000,
+      searchDefaultLimit: 10,
+      maxSearchLimit: 50,
+    });
 
-    expect(() => toolSearchEntryText(hostile)).not.toThrow();
-    expect(toolSearchEntryText(hostile)).not.toContain("pick_file_property");
+    // Reaching the schema at all throws, so surviving the query is the proof.
+    await expect(search.search("pick a file")).resolves.toBeDefined();
+    expect((await search.search("client_pick_file")).map((hit) => hit.name)).toContain(
+      "client_pick_file",
+    );
   });
 });
 

--- a/src/agents/tool-search-ranking.test.ts
+++ b/src/agents/tool-search-ranking.test.ts
@@ -53,6 +53,21 @@ describe("tokenizeQuery", () => {
     expect(tokenizeQuery("reminders")).toContain("remind");
   });
 
+  it.each([
+    ["running", "run"],
+    ["stopping", "stop"],
+    ["logging", "log"],
+    ["planning", "plan"],
+    ["runner", "run"],
+  ])("undoes the consonant English doubles before a suffix: %s", (inflected, root) => {
+    // Without undoubling, "running" stems to "runn" and can never meet "run".
+    expect(tokenizeDocument(inflected)).toEqual(tokenizeDocument(root));
+  });
+
+  it.each(["call", "process", "off"])("keeps doubles that belong to the root: %s", (word) => {
+    expect(tokenizeDocument(`${word}ing`)).toEqual(tokenizeDocument(word));
+  });
+
   it("drops stopwords so they cannot carry a match", () => {
     expect(tokenizeQuery("the and with")).toEqual([]);
   });
@@ -74,10 +89,19 @@ describe("scoreLexical", () => {
   it("returns nothing for a query with no usable terms", () => {
     const index = buildLexicalIndex([{ value: "a", terms: tokenizeDocument("search the web") }]);
 
-    // A non-English query tokenizes to nothing. Returning the whole catalog
-    // unranked would read as a ranked answer without being one.
-    expect(scoreLexical(index, tokenizeQuery("価格を調べて"))).toEqual([]);
+    // Returning the whole catalog unranked would read as a ranked answer
+    // without being one, which is what the previous scorer did here.
+    expect(scoreLexical(index, tokenizeQuery("the and with"))).toEqual([]);
     expect(scoreLexical(index, [])).toEqual([]);
+  });
+
+  it("indexes non-Latin text rather than discarding it", () => {
+    // The English-query instruction is guidance for the model, not a filter: a
+    // catalog may legitimately describe a tool in another script, and dropping
+    // those terms would make it permanently unreachable.
+    const index = buildLexicalIndex([{ value: "jp", terms: tokenizeDocument("価格 lookup") }]);
+
+    expect(scoreLexical(index, tokenizeQuery("価格")).map((hit) => hit.value)).toEqual(["jp"]);
   });
 
   it("ranks a rare term above one shared across the catalog", () => {
@@ -151,7 +175,9 @@ describe("ToolSearchRuntime.search", () => {
     expect(names).not.toContain("spreadsheet_open");
   });
 
-  it("returns nothing rather than an unranked catalog for a non-English query", async () => {
+  it("returns nothing rather than an unranked catalog for a query the catalog cannot answer", async () => {
+    // The catalog is described in English, so this matches nothing. The old
+    // scorer returned every tool in id order for exactly this input.
     expect(await runtime().search("価格を調べて")).toEqual([]);
   });
 });

--- a/src/agents/tool-search-ranking.test.ts
+++ b/src/agents/tool-search-ranking.test.ts
@@ -49,8 +49,10 @@ function runtime(): ToolSearchRuntime {
 
 describe("tokenizeQuery", () => {
   it("collapses inflected forms to a shared root", () => {
-    expect(tokenizeQuery("scheduling")).toEqual(tokenizeDocument("schedule"));
-    expect(tokenizeQuery("reminders")).toContain("remind");
+    expect(tokenizeQuery("scheduling").map((term) => term.term)).toEqual(
+      tokenizeDocument("schedule"),
+    );
+    expect(tokenizeQuery("reminders").map((term) => term.term)).toContain("remind");
   });
 
   it.each([
@@ -75,13 +77,36 @@ describe("tokenizeQuery", () => {
   it("expands intent words toward the vocabulary descriptions use", () => {
     // "look up the price" shares no word with "Search the web", so without
     // expansion a lexical index cannot connect them at all.
-    expect(tokenizeQuery("look up the price")).toContain(tokenizeDocument("search")[0]);
+    const terms = tokenizeQuery("look up the price");
+    const search = terms.find((term) => term.term === tokenizeDocument("search")[0]);
+
+    expect(search).toBeDefined();
+    // Discounted: an expansion is a guess about wording, not something typed.
+    expect(search?.weight).toBeLessThan(1);
+    expect(terms.find((term) => term.term === tokenizeDocument("price")[0])?.weight).toBe(1);
   });
 
   it("emits both the joined name and its parts", () => {
     const terms = tokenizeDocument("web_search");
     expect(terms).toContain("web_search");
     expect(terms).toContain("web");
+  });
+
+  it("decomposes camelCase names, which MCP catalogs commonly use", () => {
+    const document = tokenizeDocument("readFile");
+
+    // Lowercasing first would leave only "readfil", which "read file" cannot meet.
+    for (const term of tokenizeQuery("read file")) {
+      expect(document).toContain(term.term);
+    }
+  });
+
+  it("does not let a singular/plural collision invent an intent", () => {
+    // "news" must not normalize to "new", or "open a new issue" acquires a
+    // web-search intent it never asked for.
+    expect(tokenizeQuery("open a new issue").map((term) => term.term)).not.toContain(
+      tokenizeDocument("search")[0],
+    );
   });
 });
 
@@ -102,6 +127,19 @@ describe("scoreLexical", () => {
     const index = buildLexicalIndex([{ value: "jp", terms: tokenizeDocument("価格 lookup") }]);
 
     expect(scoreLexical(index, tokenizeQuery("価格")).map((hit) => hit.value)).toEqual(["jp"]);
+  });
+
+  it("ranks a literal match above one reached only through expansion", () => {
+    const index = buildLexicalIndex([
+      { value: "weather", terms: tokenizeDocument("weather_now Report the weather") },
+      { value: "web", terms: tokenizeDocument("web_search Search the web") },
+    ]);
+
+    const ranked = scoreLexical(index, tokenizeQuery("weather")).toSorted(
+      (a, b) => b.score - a.score,
+    );
+
+    expect(ranked[0]?.value).toBe("weather");
   });
 
   it("ranks a rare term above one shared across the catalog", () => {

--- a/src/agents/tool-search-ranking.test.ts
+++ b/src/agents/tool-search-ranking.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildLexicalIndex,
+  scoreLexical,
+  tokenizeDocument,
+  tokenizeQuery,
+} from "./tool-search-ranking.js";
+import { ToolSearchRuntime, toolSearchEntryText } from "./tool-search-runtime.js";
+import type { ToolSearchCatalogEntry } from "./tool-search-types.js";
+
+function entry(partial: Partial<ToolSearchCatalogEntry>): ToolSearchCatalogEntry {
+  return {
+    id: partial.name ?? "id",
+    source: "openclaw",
+    name: "tool",
+    description: "",
+    tool: {} as never,
+    ...partial,
+  } as ToolSearchCatalogEntry;
+}
+
+const CATALOG = [
+  entry({ name: "web_search", description: "Search the web for current information" }),
+  entry({ name: "read_file", description: "Read a file from disk" }),
+  entry({ name: "cron_create", description: "Schedule a recurring task" }),
+  entry({ name: "spreadsheet_open", description: "Open a spreadsheet document" }),
+  entry({
+    name: "issue_create",
+    description: "Open a new issue",
+    parameters: {
+      type: "object",
+      properties: { repository: { type: "string", description: "Target repository" } },
+    },
+  }),
+];
+
+function runtime(): ToolSearchRuntime {
+  const ctx = {
+    catalogRef: { current: { entries: CATALOG, searchCount: 0, describeCount: 0, callCount: 0 } },
+  };
+  return new ToolSearchRuntime(ctx as never, {
+    enabled: true,
+    mode: "directory",
+    codeTimeoutMs: 1000,
+    searchDefaultLimit: 10,
+    maxSearchLimit: 50,
+  });
+}
+
+describe("tokenizeQuery", () => {
+  it("collapses inflected forms to a shared root", () => {
+    expect(tokenizeQuery("scheduling")).toEqual(tokenizeDocument("schedule"));
+    expect(tokenizeQuery("reminders")).toContain("remind");
+  });
+
+  it("drops stopwords so they cannot carry a match", () => {
+    expect(tokenizeQuery("the and with")).toEqual([]);
+  });
+
+  it("expands intent words toward the vocabulary descriptions use", () => {
+    // "look up the price" shares no word with "Search the web", so without
+    // expansion a lexical index cannot connect them at all.
+    expect(tokenizeQuery("look up the price")).toContain(tokenizeDocument("search")[0]);
+  });
+
+  it("emits both the joined name and its parts", () => {
+    const terms = tokenizeDocument("web_search");
+    expect(terms).toContain("web_search");
+    expect(terms).toContain("web");
+  });
+});
+
+describe("scoreLexical", () => {
+  it("returns nothing for a query with no usable terms", () => {
+    const index = buildLexicalIndex([{ value: "a", terms: tokenizeDocument("search the web") }]);
+
+    // A non-English query tokenizes to nothing. Returning the whole catalog
+    // unranked would read as a ranked answer without being one.
+    expect(scoreLexical(index, tokenizeQuery("価格を調べて"))).toEqual([]);
+    expect(scoreLexical(index, [])).toEqual([]);
+  });
+
+  it("ranks a rare term above one shared across the catalog", () => {
+    const index = buildLexicalIndex([
+      { value: "rare", terms: tokenizeDocument("search quantum") },
+      { value: "common-a", terms: tokenizeDocument("search files") },
+      { value: "common-b", terms: tokenizeDocument("search mail") },
+    ]);
+    const ranked = scoreLexical(index, tokenizeQuery("quantum")).toSorted(
+      (a, b) => b.score - a.score,
+    );
+
+    expect(ranked[0]?.value).toBe("rare");
+  });
+});
+
+describe("toolSearchEntryText", () => {
+  it("indexes first-party parameter names and descriptions", () => {
+    const text = toolSearchEntryText(CATALOG[4] as ToolSearchCatalogEntry);
+
+    expect(text).toContain("repository");
+    expect(text).toContain("Target repository");
+  });
+
+  it("never traverses schemas from sources the catalog treats as untrusted", () => {
+    const hostile = entry({
+      source: "client",
+      name: "client_pick_file",
+      description: "Ask the client to pick a file",
+      parameters: {
+        type: "object",
+        properties: new Proxy(
+          {},
+          {
+            ownKeys: () => {
+              throw new Error("client properties must remain deferred");
+            },
+          },
+        ),
+      },
+    });
+
+    expect(() => toolSearchEntryText(hostile)).not.toThrow();
+    expect(toolSearchEntryText(hostile)).not.toContain("pick_file_property");
+  });
+});
+
+describe("ToolSearchRuntime.search", () => {
+  it.each([
+    {
+      query: "scheduling",
+      expected: "cron_create",
+      why: "stemmed to the description's 'Schedule'",
+    },
+    { query: "reminder", expected: "cron_create", why: "expanded toward schedule/cron" },
+    {
+      query: "look up the price",
+      expected: "web_search",
+      why: "intent expanded toward search/web",
+    },
+    { query: "repository", expected: "issue_create", why: "matched only via a parameter" },
+  ])("finds $expected for $query ($why)", async ({ query, expected }) => {
+    const hits = await runtime().search(query);
+    expect(hits.map((hit) => hit.name)).toContain(expected);
+  });
+
+  it("does not match a term that only appears inside another word", async () => {
+    // "spreadsheet" contains "read"; substring scoring used to rank it here.
+    const names = (await runtime().search("read")).map((hit) => hit.name);
+    expect(names).toContain("read_file");
+    expect(names).not.toContain("spreadsheet_open");
+  });
+
+  it("returns nothing rather than an unranked catalog for a non-English query", async () => {
+    expect(await runtime().search("価格を調べて")).toEqual([]);
+  });
+});

--- a/src/agents/tool-search-ranking.test.ts
+++ b/src/agents/tool-search-ranking.test.ts
@@ -86,6 +86,12 @@ describe("tokenizeQuery", () => {
     );
   });
 
+  it("keeps capability verbs that name real operations", () => {
+    // "get" looks like filler but names operations ("get_weather"); dropping it
+    // would reduce "get issue" to "issue" and let delete/update entries win.
+    expect(tokenizeQuery("get").map((term) => term.term)).not.toEqual([]);
+  });
+
   it("drops stopwords so they cannot carry a match", () => {
     expect(tokenizeQuery("the and with")).toEqual([]);
   });
@@ -234,6 +240,27 @@ describe("ToolSearchRuntime.search", () => {
   ])("finds $expected for $query ($why)", async ({ query, expected }) => {
     const hits = await runtime().search(query);
     expect(hits.map((hit) => hit.name)).toContain(expected);
+  });
+
+  it("ranks an exact tool name first even when a shorter entry mentions it", async () => {
+    const catalog = [
+      entry({ name: "issue_create", description: "Open a new issue" }),
+      entry({ id: "b", name: "notes", description: "Notes about issue_create and other tools" }),
+    ];
+    const ctx = {
+      catalogRef: { current: { entries: catalog, searchCount: 0, describeCount: 0, callCount: 0 } },
+    };
+    const search = new ToolSearchRuntime(ctx as never, {
+      enabled: true,
+      mode: "directory",
+      codeTimeoutMs: 1000,
+      searchDefaultLimit: 10,
+      maxSearchLimit: 50,
+    });
+
+    // Querying a known name is a request for that tool, not a description of one.
+    const hits = await search.search("issue_create");
+    expect(hits[0]?.name).toBe("issue_create");
   });
 
   it("does not match a term that only appears inside another word", async () => {

--- a/src/agents/tool-search-ranking.test.ts
+++ b/src/agents/tool-search-ranking.test.ts
@@ -70,6 +70,22 @@ describe("tokenizeQuery", () => {
     expect(tokenizeDocument(`${word}ing`)).toEqual(tokenizeDocument(word));
   });
 
+  it.each([
+    ["repositories", "repository"],
+    ["queries", "query"],
+    ["memories", "memory"],
+  ])("normalizes -ies back to its singular: %s", (plural, singular) => {
+    expect(tokenizeDocument(plural)).toEqual(tokenizeDocument(singular));
+  });
+
+  it("fires expansions for -ies plurals of a trigger word", () => {
+    // "directories" must reach the directory/folder group, not stall at
+    // "directorie" and expand nothing.
+    expect(tokenizeQuery("list directories").map((term) => term.term)).toContain(
+      tokenizeDocument("file")[0],
+    );
+  });
+
   it("drops stopwords so they cannot carry a match", () => {
     expect(tokenizeQuery("the and with")).toEqual([]);
   });
@@ -129,17 +145,22 @@ describe("scoreLexical", () => {
     expect(scoreLexical(index, tokenizeQuery("価格")).map((hit) => hit.value)).toEqual(["jp"]);
   });
 
-  it("ranks a literal match above one reached only through expansion", () => {
+  it("marks literal overlap so callers can rank it ahead of expansion-only hits", () => {
+    // A common literal term carries little IDF, so a short document collecting
+    // two rare expansions can outscore it. The tier, not the weight, is what
+    // keeps a tool matching the typed word from being dropped by the limit.
     const index = buildLexicalIndex([
-      { value: "weather", terms: tokenizeDocument("weather_now Report the weather") },
+      { value: "weather-a", terms: tokenizeDocument("weather_now Report the weather") },
+      { value: "weather-b", terms: tokenizeDocument("weather_hourly Hourly weather") },
+      { value: "weather-c", terms: tokenizeDocument("weather_alerts Weather alerts") },
       { value: "web", terms: tokenizeDocument("web_search Search the web") },
     ]);
 
-    const ranked = scoreLexical(index, tokenizeQuery("weather")).toSorted(
-      (a, b) => b.score - a.score,
-    );
+    const hits = scoreLexical(index, tokenizeQuery("weather"));
+    const web = hits.find((hit) => hit.value === "web");
 
-    expect(ranked[0]?.value).toBe("weather");
+    expect(hits.filter((hit) => hit.matchedLiteral).map((hit) => hit.value)).toContain("weather-a");
+    expect(web?.matchedLiteral).toBe(false);
   });
 
   it("ranks a rare term above one shared across the catalog", () => {

--- a/src/agents/tool-search-ranking.test.ts
+++ b/src/agents/tool-search-ranking.test.ts
@@ -117,6 +117,15 @@ describe("tokenizeQuery", () => {
     }
   });
 
+  it.each(["news", "status", "canvas", "alias"])(
+    "keeps %s distinct from the word left by stripping its s",
+    (word) => {
+      // "news" -> "new" would literal-match every "Create a new ..." tool, and
+      // literal matches are ranked ahead of the web tool the query meant.
+      expect(tokenizeDocument(word)).toEqual([word]);
+    },
+  );
+
   it("does not let a singular/plural collision invent an intent", () => {
     // "news" must not normalize to "new", or "open a new issue" acquires a
     // web-search intent it never asked for.

--- a/src/agents/tool-search-ranking.test.ts
+++ b/src/agents/tool-search-ranking.test.ts
@@ -70,14 +70,6 @@ describe("tokenizeQuery", () => {
     expect(tokenizeDocument(`${word}ing`)).toEqual(tokenizeDocument(word));
   });
 
-  it.each([
-    ["repositories", "repository"],
-    ["queries", "query"],
-    ["memories", "memory"],
-  ])("normalizes -ies back to its singular: %s", (plural, singular) => {
-    expect(tokenizeDocument(plural)).toEqual(tokenizeDocument(singular));
-  });
-
   it("fires expansions for -ies plurals of a trigger word", () => {
     // "directories" must reach the directory/folder group, not stall at
     // "directorie" and expand nothing.
@@ -261,6 +253,50 @@ describe("ToolSearchRuntime.search", () => {
     // Querying a known name is a request for that tool, not a description of one.
     const hits = await search.search("issue_create");
     expect(hits[0]?.name).toBe("issue_create");
+  });
+
+  it.each([
+    ["cookies", "cookie"],
+    ["policies", "policy"],
+    ["movies", "movie"],
+    ["repositories", "repository"],
+    ["queries", "query"],
+    ["memories", "memory"],
+  ])("matches both readings of an -ies plural: %s", (plural, singular) => {
+    // "policies" is "policy" but "cookies" is "cookie"; one rule cannot serve
+    // both, so both stems are emitted and whichever the catalog uses matches.
+    const plurals = new Set(tokenizeDocument(plural));
+    expect(tokenizeDocument(singular).some((term) => plurals.has(term))).toBe(true);
+  });
+
+  it.each([
+    ["getURLs", "url"],
+    ["getOAuthToken", "auth"],
+    ["readFile", "read"],
+  ])("keeps acronym and camelCase parts addressable: %s", (name, part) => {
+    // Splitting on case transitions alone cuts "URLs" into "UR"/"Ls".
+    expect(tokenizeDocument(name)).toContain(part);
+  });
+
+  it("returns a tool named exactly like a stopword", async () => {
+    const catalog = [
+      entry({ name: "do", description: "Run a stored action" }),
+      entry({ id: "other", name: "other", description: "Unrelated" }),
+    ];
+    const ctx = {
+      catalogRef: { current: { entries: catalog, searchCount: 0, describeCount: 0, callCount: 0 } },
+    };
+    const search = new ToolSearchRuntime(ctx as never, {
+      enabled: true,
+      mode: "directory",
+      codeTimeoutMs: 1000,
+      searchDefaultLimit: 10,
+      maxSearchLimit: 50,
+    });
+
+    // "do" tokenizes to nothing, so it never reaches the ranking; naming it
+    // exactly is still an unambiguous request for it.
+    expect((await search.search("do")).map((hit) => hit.name)).toEqual(["do"]);
   });
 
   it("does not match a term that only appears inside another word", async () => {

--- a/src/agents/tool-search-ranking.ts
+++ b/src/agents/tool-search-ranking.ts
@@ -126,6 +126,30 @@ function stem(token: string): string {
   return current;
 }
 
+/**
+ * Words ending in `s` that are not plurals. Stripping it changes the meaning and
+ * collides with an unrelated root: "news" would become "new" and then literal-
+ * match every "Create a new ..." tool, outranking the search tool the query
+ * meant. Several are ordinary tool vocabulary here ("status", "canvas", "alias").
+ */
+const NON_PLURAL_S_WORDS = new Set([
+  "news",
+  "status",
+  "alias",
+  "canvas",
+  "focus",
+  "bonus",
+  "virus",
+  "atlas",
+  "lens",
+  "axis",
+  "basis",
+  "analysis",
+  "gas",
+  "bus",
+  "plus",
+]);
+
 /** Suffixes whose stripping can expose a consonant doubled only by inflection. */
 const UNDOUBLING_SUFFIXES = new Set(["ing", "ed", "er"]);
 /** Doubles that belong to the root ("call", "process", "off", "buzz"). */
@@ -152,7 +176,7 @@ function undoubleFinalConsonant(token: string): string {
 }
 
 function stripOneSuffix(token: string): string {
-  if (token.length <= 3) {
+  if (token.length <= 3 || NON_PLURAL_S_WORDS.has(token)) {
     return token;
   }
   for (const suffix of ["ies", "ing", "ed", "ly", "es", "er", "s", "e"]) {
@@ -174,9 +198,13 @@ function stripOneSuffix(token: string): string {
   return token;
 }
 
+/** camelCase and PascalCase boundaries, applied before lowercasing. */
+const CASE_BOUNDARY = /(?<=[\p{Ll}\p{N}])(?=\p{Lu})|(?<=\p{Lu})(?=\p{Lu}\p{Ll})/u;
+
 /**
  * Splits on anything that is not a word character, which keeps `_`-joined tool
- * names addressable as whole tokens while still emitting their parts.
+ * names addressable as whole tokens while still emitting their parts, including
+ * camelCase components that MCP catalogs commonly use.
  *
  * Unicode letters survive rather than being rejected: a catalog is allowed to
  * name or describe tools in another script, and dropping those would make them
@@ -184,8 +212,6 @@ function stripOneSuffix(token: string): string {
  * is that catalogs are written in English, which is why `tool_search` asks the
  * model to query in English rather than this function refusing the input.
  */
-const CASE_BOUNDARY = /(?<=[\p{Ll}\p{N}])(?=\p{Lu})|(?<=\p{Lu})(?=\p{Lu}\p{Ll})/u;
-
 function splitWords(input: string): string[] {
   const words: string[] = [];
   for (const raw of input.split(/[^\p{L}\p{N}_]+/u)) {

--- a/src/agents/tool-search-ranking.ts
+++ b/src/agents/tool-search-ranking.ts
@@ -1,0 +1,271 @@
+// Lexical ranking shared by Tool Search results and directory-mode hydration.
+//
+// Both surfaces answer the same question — "which tools does this query mean?" —
+// so they index and score through here rather than keeping separate heuristics
+// that can disagree about the same catalog.
+
+/** BM25 term-frequency saturation. Standard Okapi default. */
+const BM25_K1 = 1.2;
+/** BM25 length normalization. Standard Okapi default. */
+const BM25_B = 0.75;
+
+/**
+ * Terms carrying no discriminating signal in a tool catalog. IDF already damps
+ * these; dropping them keeps a query like "read a file and post it" from
+ * scoring on "a"/"it" when a tool description happens to repeat them.
+ */
+const STOPWORDS = new Set([
+  "a",
+  "an",
+  "and",
+  "are",
+  "as",
+  "at",
+  "be",
+  "but",
+  "by",
+  "can",
+  "do",
+  "for",
+  "from",
+  "get",
+  "had",
+  "has",
+  "have",
+  "here",
+  "how",
+  "i",
+  "if",
+  "in",
+  "into",
+  "is",
+  "it",
+  "its",
+  "me",
+  "my",
+  "no",
+  "not",
+  "of",
+  "on",
+  "or",
+  "our",
+  "so",
+  "that",
+  "the",
+  "their",
+  "them",
+  "then",
+  "there",
+  "these",
+  "they",
+  "this",
+  "to",
+  "up",
+  "us",
+  "was",
+  "we",
+  "were",
+  "what",
+  "when",
+  "where",
+  "which",
+  "who",
+  "why",
+  "will",
+  "with",
+  "you",
+  "your",
+]);
+
+/**
+ * Query vocabulary mapped to the capability words tool descriptions actually
+ * use. This bridges intent to wording ("look up the price" -> "search"), which
+ * pure lexical overlap cannot do.
+ *
+ * Values must stay generic capability terms. Never put plugin, vendor, or
+ * product names here: those break silently when a plugin is renamed, and a
+ * catalog is not required to contain any particular provider.
+ */
+const QUERY_EXPANSIONS: ReadonlyArray<{ terms: readonly string[]; add: readonly string[] }> = [
+  { terms: ["look", "lookup", "google", "research"], add: ["search", "web", "find"] },
+  {
+    terms: ["current", "today", "latest", "now", "recent", "news", "price", "weather"],
+    add: ["search", "web"],
+  },
+  { terms: ["url", "link", "page", "article", "site", "website"], add: ["fetch", "web", "browse"] },
+  {
+    terms: ["remember", "recall", "memory", "earlier", "previously", "discussed", "decided"],
+    add: ["memory", "recall", "history"],
+  },
+  {
+    terms: ["remind", "later", "tomorrow", "daily", "weekly", "recurring"],
+    add: ["schedule", "cron", "reminder"],
+  },
+  { terms: ["say", "tell", "reply", "respond", "answer"], add: ["message", "send"] },
+  { terms: ["picture", "photo", "meme", "screenshot"], add: ["image"] },
+  { terms: ["speak", "say", "voice"], add: ["audio", "speech"] },
+  { terms: ["run", "execute", "command", "shell", "terminal"], add: ["exec", "process"] },
+  { terms: ["directory", "folder", "path"], add: ["file", "list"] },
+];
+
+/**
+ * Light English suffix stripper. Not a full Porter stemmer: it exists so that
+ * "scheduling" reaches a tool described as "Schedule a recurring task", which
+ * exact-token matching misses entirely. Applied repeatedly so plural verb forms
+ * ("reminders" -> "reminder" -> "remind") collapse to one root.
+ */
+function stem(token: string): string {
+  let current = token;
+  for (let pass = 0; pass < 3; pass += 1) {
+    const next = stripOneSuffix(current);
+    if (next === current) {
+      return current;
+    }
+    current = next;
+  }
+  return current;
+}
+
+function stripOneSuffix(token: string): string {
+  if (token.length <= 3) {
+    return token;
+  }
+  for (const suffix of ["ies", "ing", "ed", "ly", "es", "er", "s", "e"]) {
+    if (!token.endsWith(suffix) || token.length - suffix.length < 3) {
+      continue;
+    }
+    // "ss" is part of the root ("process"), not a plural marker.
+    if (suffix === "s" && token.endsWith("ss")) {
+      continue;
+    }
+    return suffix === "ies" ? `${token.slice(0, -3)}i` : token.slice(0, -suffix.length);
+  }
+  return token;
+}
+
+/**
+ * Splits on anything that is not a word character, which keeps `_`-joined tool
+ * names addressable as whole tokens while still emitting their parts. Unicode
+ * letters survive so a catalog naming tools in another script stays searchable,
+ * even though `tool_search` asks the model to query in English.
+ */
+function splitWords(input: string): string[] {
+  const words: string[] = [];
+  for (const word of input.toLowerCase().split(/[^\p{L}\p{N}_]+/u)) {
+    if (!word) {
+      continue;
+    }
+    words.push(word);
+    if (!word.includes("_")) {
+      continue;
+    }
+    for (const part of word.split("_")) {
+      if (part) {
+        words.push(part);
+      }
+    }
+  }
+  return words;
+}
+
+/** Indexable terms for one document, with stopwords dropped and roots collapsed. */
+export function tokenizeDocument(input: string): string[] {
+  return splitWords(input)
+    .filter((word) => !STOPWORDS.has(word))
+    .map(stem)
+    .filter(Boolean);
+}
+
+/**
+ * Expansion table keyed by stemmed trigger, so one entry covers a word's whole
+ * family: "remind" also fires for "reminder" and "reminders". The table itself
+ * stays written in plain words.
+ */
+const STEMMED_EXPANSIONS: ReadonlyArray<{ triggers: ReadonlySet<string>; add: readonly string[] }> =
+  QUERY_EXPANSIONS.map((group) => ({
+    triggers: new Set(group.terms.map(stem)),
+    add: group.add.map(stem),
+  }));
+
+/** Query terms: stemmed, then expanded toward the words descriptions use. */
+export function tokenizeQuery(input: string): string[] {
+  const stemmed = splitWords(input)
+    .filter((word) => !STOPWORDS.has(word))
+    .map(stem)
+    .filter(Boolean);
+  const expanded = new Set(stemmed);
+  for (const group of STEMMED_EXPANSIONS) {
+    if (stemmed.some((term) => group.triggers.has(term))) {
+      for (const addition of group.add) {
+        expanded.add(addition);
+      }
+    }
+  }
+  return [...expanded];
+}
+
+export type RankedDocument<T> = { value: T; terms: readonly string[] };
+
+export type LexicalIndex<T> = {
+  documents: ReadonlyArray<{ value: T; termCounts: ReadonlyMap<string, number>; length: number }>;
+  documentFrequency: ReadonlyMap<string, number>;
+  averageLength: number;
+};
+
+export function buildLexicalIndex<T>(documents: ReadonlyArray<RankedDocument<T>>): LexicalIndex<T> {
+  const documentFrequency = new Map<string, number>();
+  const prepared = documents.map((document) => {
+    const termCounts = new Map<string, number>();
+    for (const term of document.terms) {
+      termCounts.set(term, (termCounts.get(term) ?? 0) + 1);
+    }
+    for (const term of termCounts.keys()) {
+      documentFrequency.set(term, (documentFrequency.get(term) ?? 0) + 1);
+    }
+    return { value: document.value, termCounts, length: document.terms.length };
+  });
+  const totalLength = prepared.reduce((sum, document) => sum + document.length, 0);
+  return {
+    documents: prepared,
+    documentFrequency,
+    averageLength: prepared.length > 0 ? totalLength / prepared.length : 0,
+  };
+}
+
+/**
+ * Okapi BM25. Ranks by how well a document matches the query terms, damping
+ * terms that appear across most of the catalog and normalizing for description
+ * length so a verbose tool does not outrank a precise one.
+ *
+ * An empty query scores nothing on purpose: returning the whole catalog in
+ * arbitrary order would look like a ranked answer without being one.
+ */
+export function scoreLexical<T>(
+  index: LexicalIndex<T>,
+  queryTerms: readonly string[],
+): Array<{ value: T; score: number }> {
+  if (queryTerms.length === 0 || index.documents.length === 0) {
+    return [];
+  }
+  const total = index.documents.length;
+  const results: Array<{ value: T; score: number }> = [];
+  for (const document of index.documents) {
+    let score = 0;
+    for (const term of queryTerms) {
+      const frequency = document.termCounts.get(term);
+      if (!frequency) {
+        continue;
+      }
+      const matching = index.documentFrequency.get(term) ?? 0;
+      const idf = Math.log(1 + (total - matching + 0.5) / (matching + 0.5));
+      const normalized = index.averageLength > 0 ? document.length / index.averageLength : 1;
+      score +=
+        (idf * (frequency * (BM25_K1 + 1))) /
+        (frequency + BM25_K1 * (1 - BM25_B + BM25_B * normalized));
+    }
+    if (score > 0) {
+      results.push({ value: document.value, score });
+    }
+  }
+  return results;
+}

--- a/src/agents/tool-search-ranking.ts
+++ b/src/agents/tool-search-ranking.ts
@@ -201,8 +201,13 @@ function stripOneSuffix(token: string): string {
   return token;
 }
 
-/** camelCase and PascalCase boundaries, applied before lowercasing. */
-const CASE_BOUNDARY = /(?<=[\p{Ll}\p{N}])(?=\p{Lu})|(?<=\p{Lu})(?=\p{Lu}\p{Ll})/u;
+/**
+ * Word parts inside a compound identifier, matched rather than split so an
+ * acronym stays whole. Splitting on case transitions cuts "URLs" into "UR"/"Ls"
+ * and makes the obvious query unable to reach the tool; the first alternative
+ * keeps a run of capitals together, including a trailing plural `s`.
+ */
+const WORD_PARTS = /\p{Lu}+s?(?![\p{Ll}])|\p{Lu}?\p{Ll}+|\p{N}+/gu;
 
 /**
  * Splits on anything that is not a word character, which keeps `_`-joined tool
@@ -224,10 +229,8 @@ function splitWords(input: string): string[] {
     words.push(raw.toLowerCase());
     const parts: string[] = [];
     for (const underscorePart of raw.split("_")) {
-      for (const casePart of underscorePart.split(CASE_BOUNDARY)) {
-        if (casePart) {
-          parts.push(casePart.toLowerCase());
-        }
+      for (const casePart of underscorePart.match(WORD_PARTS) ?? []) {
+        parts.push(casePart.toLowerCase());
       }
     }
     if (parts.length < 2) {
@@ -240,11 +243,25 @@ function splitWords(input: string): string[] {
   return words;
 }
 
+/**
+ * Stems for one word. `-ies` is ambiguous — "policies" is "policy" but "cookies"
+ * is "cookie" — so both readings are emitted and whichever the catalog actually
+ * uses will match. Every other word has a single stem.
+ */
+function stemVariants(word: string): string[] {
+  if (word.length > 4 && word.endsWith("ies")) {
+    const base = word.slice(0, -3);
+    return [`${base}y`, stem(`${base}ie`)];
+  }
+  const stemmed = stem(word);
+  return stemmed ? [stemmed] : [];
+}
+
 /** Indexable terms for one document, with stopwords dropped and roots collapsed. */
 export function tokenizeDocument(input: string): string[] {
   return splitWords(input)
     .filter((word) => !STOPWORDS.has(word))
-    .map(stem)
+    .flatMap(stemVariants)
     .filter(Boolean);
 }
 
@@ -282,7 +299,7 @@ export type WeightedTerm = { term: string; weight: number };
 export function tokenizeQuery(input: string): WeightedTerm[] {
   const words = splitWords(input).filter((word) => !STOPWORDS.has(word));
   const weights = new Map<string, number>();
-  for (const term of words.map(stem).filter(Boolean)) {
+  for (const term of words.flatMap(stemVariants).filter(Boolean)) {
     weights.set(term, 1);
   }
   const triggers = new Set(words.map(normalizeTrigger));

--- a/src/agents/tool-search-ranking.ts
+++ b/src/agents/tool-search-ranking.ts
@@ -98,7 +98,7 @@ const QUERY_EXPANSIONS: ReadonlyArray<{ terms: readonly string[]; add: readonly 
     add: ["memory", "recall", "history"],
   },
   {
-    terms: ["remind", "later", "tomorrow", "daily", "weekly", "recurring"],
+    terms: ["remind", "reminder", "later", "tomorrow", "daily", "weekly", "recurring"],
     add: ["schedule", "cron", "reminder"],
   },
   { terms: ["say", "tell", "reply", "respond", "answer"], add: ["message", "send"] },
@@ -182,20 +182,28 @@ function stripOneSuffix(token: string): string {
  * is that catalogs are written in English, which is why `tool_search` asks the
  * model to query in English rather than this function refusing the input.
  */
+const CASE_BOUNDARY = /(?<=[\p{Ll}\p{N}])(?=\p{Lu})|(?<=\p{Lu})(?=\p{Lu}\p{Ll})/u;
+
 function splitWords(input: string): string[] {
   const words: string[] = [];
-  for (const word of input.toLowerCase().split(/[^\p{L}\p{N}_]+/u)) {
-    if (!word) {
+  for (const raw of input.split(/[^\p{L}\p{N}_]+/u)) {
+    if (!raw) {
       continue;
     }
-    words.push(word);
-    if (!word.includes("_")) {
-      continue;
-    }
-    for (const part of word.split("_")) {
-      if (part) {
-        words.push(part);
+    words.push(raw.toLowerCase());
+    const parts: string[] = [];
+    for (const underscorePart of raw.split("_")) {
+      for (const casePart of underscorePart.split(CASE_BOUNDARY)) {
+        if (casePart) {
+          parts.push(casePart.toLowerCase());
+        }
       }
+    }
+    if (parts.length < 2) {
+      continue;
+    }
+    for (const part of parts) {
+      words.push(part);
     }
   }
   return words;
@@ -210,31 +218,50 @@ export function tokenizeDocument(input: string): string[] {
 }
 
 /**
- * Expansion table keyed by stemmed trigger, so one entry covers a word's whole
- * family: "remind" also fires for "reminder" and "reminders". The table itself
- * stays written in plain words.
+ * Triggers are matched on a singularized word rather than the document stemmer.
+ * Full stemming collapses unrelated vocabulary — "news" becomes "new", so "open
+ * a new issue" would silently acquire a web-search intent — and an expansion
+ * that fires on the wrong word is worse than one that does not fire.
  */
-const STEMMED_EXPANSIONS: ReadonlyArray<{ triggers: ReadonlySet<string>; add: readonly string[] }> =
-  QUERY_EXPANSIONS.map((group) => ({
-    triggers: new Set(group.terms.map(stem)),
-    add: group.add.map(stem),
-  }));
+function normalizeTrigger(word: string): string {
+  return word.length > 4 && word.endsWith("s") && !word.endsWith("ss") ? word.slice(0, -1) : word;
+}
 
-/** Query terms: stemmed, then expanded toward the words descriptions use. */
-export function tokenizeQuery(input: string): string[] {
-  const stemmed = splitWords(input)
-    .filter((word) => !STOPWORDS.has(word))
-    .map(stem)
-    .filter(Boolean);
-  const expanded = new Set(stemmed);
-  for (const group of STEMMED_EXPANSIONS) {
-    if (stemmed.some((term) => group.triggers.has(term))) {
-      for (const addition of group.add) {
-        expanded.add(addition);
-      }
+const NORMALIZED_EXPANSIONS: ReadonlyArray<{
+  triggers: ReadonlySet<string>;
+  add: readonly string[];
+}> = QUERY_EXPANSIONS.map((group) => ({
+  triggers: new Set(group.terms.map(normalizeTrigger)),
+  add: group.add.map(stem),
+}));
+
+/**
+ * Weight for a term the caller did not write. Expansions are a hint about what
+ * the catalog might call this capability, so they must not let a merely related
+ * tool outscore one that matches the words actually typed.
+ */
+const EXPANSION_WEIGHT = 0.35;
+
+export type WeightedTerm = { term: string; weight: number };
+
+/** Query terms: literal words at full weight, expansions discounted. */
+export function tokenizeQuery(input: string): WeightedTerm[] {
+  const words = splitWords(input).filter((word) => !STOPWORDS.has(word));
+  const weights = new Map<string, number>();
+  for (const term of words.map(stem).filter(Boolean)) {
+    weights.set(term, 1);
+  }
+  const triggers = new Set(words.map(normalizeTrigger));
+  for (const group of NORMALIZED_EXPANSIONS) {
+    if (![...group.triggers].some((trigger) => triggers.has(trigger))) {
+      continue;
+    }
+    for (const addition of group.add) {
+      // A word the caller actually wrote keeps full weight.
+      weights.set(addition, Math.max(weights.get(addition) ?? 0, EXPANSION_WEIGHT));
     }
   }
-  return [...expanded];
+  return [...weights].map(([term, weight]) => ({ term, weight }));
 }
 
 export type RankedDocument<T> = { value: T; terms: readonly string[] };
@@ -275,7 +302,7 @@ export function buildLexicalIndex<T>(documents: ReadonlyArray<RankedDocument<T>>
  */
 export function scoreLexical<T>(
   index: LexicalIndex<T>,
-  queryTerms: readonly string[],
+  queryTerms: readonly WeightedTerm[],
 ): Array<{ value: T; score: number }> {
   if (queryTerms.length === 0 || index.documents.length === 0) {
     return [];
@@ -284,7 +311,7 @@ export function scoreLexical<T>(
   const results: Array<{ value: T; score: number }> = [];
   for (const document of index.documents) {
     let score = 0;
-    for (const term of queryTerms) {
+    for (const { term, weight } of queryTerms) {
       const frequency = document.termCounts.get(term);
       if (!frequency) {
         continue;
@@ -293,7 +320,7 @@ export function scoreLexical<T>(
       const idf = Math.log(1 + (total - matching + 0.5) / (matching + 0.5));
       const normalized = index.averageLength > 0 ? document.length / index.averageLength : 1;
       score +=
-        (idf * (frequency * (BM25_K1 + 1))) /
+        (weight * (idf * (frequency * (BM25_K1 + 1)))) /
         (frequency + BM25_K1 * (1 - BM25_B + BM25_B * normalized));
     }
     if (score > 0) {

--- a/src/agents/tool-search-ranking.ts
+++ b/src/agents/tool-search-ranking.ts
@@ -13,6 +13,10 @@ const BM25_B = 0.75;
  * Terms carrying no discriminating signal in a tool catalog. IDF already damps
  * these; dropping them keeps a query like "read a file and post it" from
  * scoring on "a"/"it" when a tool description happens to repeat them.
+ *
+ * Capability verbs stay out of this list even when they look like filler:
+ * "get" names real operations ("get_weather"), and discarding it would reduce
+ * "get issue" to "issue" and let a shorter delete/update entry outrank it.
  */
 const STOPWORDS = new Set([
   "a",
@@ -28,7 +32,6 @@ const STOPWORDS = new Set([
   "do",
   "for",
   "from",
-  "get",
   "had",
   "has",
   "have",

--- a/src/agents/tool-search-ranking.ts
+++ b/src/agents/tool-search-ranking.ts
@@ -293,7 +293,7 @@ const NORMALIZED_EXPANSIONS: ReadonlyArray<{
  */
 const EXPANSION_WEIGHT = 0.35;
 
-export type WeightedTerm = { term: string; weight: number };
+type WeightedTerm = { term: string; weight: number };
 
 /** Query terms: literal words at full weight, expansions discounted. */
 export function tokenizeQuery(input: string): WeightedTerm[] {
@@ -315,9 +315,9 @@ export function tokenizeQuery(input: string): WeightedTerm[] {
   return [...weights].map(([term, weight]) => ({ term, weight }));
 }
 
-export type RankedDocument<T> = { value: T; terms: readonly string[] };
+type RankedDocument<T> = { value: T; terms: readonly string[] };
 
-export type LexicalIndex<T> = {
+type LexicalIndex<T> = {
   documents: ReadonlyArray<{ value: T; termCounts: ReadonlyMap<string, number>; length: number }>;
   documentFrequency: ReadonlyMap<string, number>;
   averageLength: number;

--- a/src/agents/tool-search-ranking.ts
+++ b/src/agents/tool-search-ranking.ts
@@ -126,6 +126,31 @@ function stem(token: string): string {
   return current;
 }
 
+/** Suffixes whose stripping can expose a consonant doubled only by inflection. */
+const UNDOUBLING_SUFFIXES = new Set(["ing", "ed", "er"]);
+/** Doubles that belong to the root ("call", "process", "off", "buzz"). */
+const KEPT_DOUBLE_CONSONANTS = new Set(["l", "s", "f", "z"]);
+
+/**
+ * "running" strips to "runn", which would never meet "run". English doubles the
+ * final consonant before these suffixes, so undo that — otherwise the stemmer
+ * makes common pairs (run/running, stop/stopping, log/logging) unreachable, a
+ * regression the old substring scorer did not have.
+ */
+function undoubleFinalConsonant(token: string): string {
+  const last = token.at(-1);
+  if (
+    !last ||
+    last !== token.at(-2) ||
+    KEPT_DOUBLE_CONSONANTS.has(last) ||
+    "aeiou".includes(last) ||
+    token.length <= 3
+  ) {
+    return token;
+  }
+  return token.slice(0, -1);
+}
+
 function stripOneSuffix(token: string): string {
   if (token.length <= 3) {
     return token;
@@ -138,16 +163,24 @@ function stripOneSuffix(token: string): string {
     if (suffix === "s" && token.endsWith("ss")) {
       continue;
     }
-    return suffix === "ies" ? `${token.slice(0, -3)}i` : token.slice(0, -suffix.length);
+    if (suffix === "ies") {
+      return `${token.slice(0, -3)}i`;
+    }
+    const stripped = token.slice(0, -suffix.length);
+    return UNDOUBLING_SUFFIXES.has(suffix) ? undoubleFinalConsonant(stripped) : stripped;
   }
   return token;
 }
 
 /**
  * Splits on anything that is not a word character, which keeps `_`-joined tool
- * names addressable as whole tokens while still emitting their parts. Unicode
- * letters survive so a catalog naming tools in another script stays searchable,
- * even though `tool_search` asks the model to query in English.
+ * names addressable as whole tokens while still emitting their parts.
+ *
+ * Unicode letters survive rather than being rejected: a catalog is allowed to
+ * name or describe tools in another script, and dropping those would make them
+ * permanently unreachable. What makes non-English queries fruitless in practice
+ * is that catalogs are written in English, which is why `tool_search` asks the
+ * model to query in English rather than this function refusing the input.
  */
 function splitWords(input: string): string[] {
   const words: string[] = [];

--- a/src/agents/tool-search-ranking.ts
+++ b/src/agents/tool-search-ranking.ts
@@ -163,8 +163,10 @@ function stripOneSuffix(token: string): string {
     if (suffix === "s" && token.endsWith("ss")) {
       continue;
     }
+    // "repositories" -> "repository", not "repositori", or it never meets the
+    // singular form the catalog is more likely to use.
     if (suffix === "ies") {
-      return `${token.slice(0, -3)}i`;
+      return `${token.slice(0, -3)}y`;
     }
     const stripped = token.slice(0, -suffix.length);
     return UNDOUBLING_SUFFIXES.has(suffix) ? undoubleFinalConsonant(stripped) : stripped;
@@ -224,6 +226,9 @@ export function tokenizeDocument(input: string): string[] {
  * that fires on the wrong word is worse than one that does not fire.
  */
 function normalizeTrigger(word: string): string {
+  if (word.length > 4 && word.endsWith("ies")) {
+    return `${word.slice(0, -3)}y`;
+  }
   return word.length > 4 && word.endsWith("s") && !word.endsWith("ss") ? word.slice(0, -1) : word;
 }
 
@@ -299,22 +304,31 @@ export function buildLexicalIndex<T>(documents: ReadonlyArray<RankedDocument<T>>
  *
  * An empty query scores nothing on purpose: returning the whole catalog in
  * arbitrary order would look like a ranked answer without being one.
+ *
+ * `matchedLiteral` reports whether a hit shares any word the caller actually
+ * typed. Callers rank on it first: discounting expansions is not sufficient on
+ * its own, because BM25 sums per term and a common literal term carries little
+ * IDF, so a short document collecting two rare expansions can still outscore it.
  */
 export function scoreLexical<T>(
   index: LexicalIndex<T>,
   queryTerms: readonly WeightedTerm[],
-): Array<{ value: T; score: number }> {
+): Array<{ value: T; score: number; matchedLiteral: boolean }> {
   if (queryTerms.length === 0 || index.documents.length === 0) {
     return [];
   }
   const total = index.documents.length;
-  const results: Array<{ value: T; score: number }> = [];
+  const results: Array<{ value: T; score: number; matchedLiteral: boolean }> = [];
   for (const document of index.documents) {
     let score = 0;
+    let matchedLiteral = false;
     for (const { term, weight } of queryTerms) {
       const frequency = document.termCounts.get(term);
       if (!frequency) {
         continue;
+      }
+      if (weight >= 1) {
+        matchedLiteral = true;
       }
       const matching = index.documentFrequency.get(term) ?? 0;
       const idf = Math.log(1 + (total - matching + 0.5) / (matching + 0.5));
@@ -324,7 +338,7 @@ export function scoreLexical<T>(
         (frequency + BM25_K1 * (1 - BM25_B + BM25_B * normalized));
     }
     if (score > 0) {
-      results.push({ value: document.value, score });
+      results.push({ value: document.value, score, matchedLiteral });
     }
   }
   return results;

--- a/src/agents/tool-search-runtime.ts
+++ b/src/agents/tool-search-runtime.ts
@@ -328,7 +328,7 @@ export class ToolSearchRuntime {
     );
     const isExact = (entry: ToolSearchCatalogEntry) =>
       entry.name.toLowerCase() === exact || entry.id.toLowerCase() === exact;
-    return scoreLexical(index, tokenizeQuery(query))
+    const ranked = scoreLexical(index, tokenizeQuery(query))
       .toSorted(
         (a, b) =>
           Number(isExact(b.value)) - Number(isExact(a.value)) ||
@@ -336,8 +336,14 @@ export class ToolSearchRuntime {
           b.score - a.score ||
           a.value.id.localeCompare(b.value.id),
       )
+      .map((hit) => hit.value);
+    // A tool whose name is a stopword ("do") tokenizes to nothing and so never
+    // reaches the ranking at all. Naming it exactly is still an unambiguous
+    // request for it, which the previous scorer honored.
+    const exactEntries = entries.filter((entry) => isExact(entry) && !ranked.includes(entry));
+    return [...exactEntries, ...ranked]
       .slice(0, limit)
-      .map((hit) => compactToolSearchCatalogEntry(hit.value));
+      .map((entry) => compactToolSearchCatalogEntry(entry));
   };
 
   all = (options?: CatalogVisibilityOptions) =>

--- a/src/agents/tool-search-runtime.ts
+++ b/src/agents/tool-search-runtime.ts
@@ -316,15 +316,22 @@ export class ToolSearchRuntime {
     catalog.searchCount += 1;
     const limit = readToolSearchLimit(options?.limit, this.config);
     const entries = visibleCatalogEntries(catalog, options);
+    // A query that is exactly a tool name or id is a request for that tool, not
+    // a description of one. BM25 alone can rank a shorter entry that merely
+    // mentions the word above it, and the limit then drops the tool asked for.
+    const exact = query.trim().toLowerCase();
     const index = buildLexicalIndex(
       entries.map((entry) => ({
         value: entry,
         terms: tokenizeDocument(toolSearchEntryText(entry)),
       })),
     );
+    const isExact = (entry: ToolSearchCatalogEntry) =>
+      entry.name.toLowerCase() === exact || entry.id.toLowerCase() === exact;
     return scoreLexical(index, tokenizeQuery(query))
       .toSorted(
         (a, b) =>
+          Number(isExact(b.value)) - Number(isExact(a.value)) ||
           Number(b.matchedLiteral) - Number(a.matchedLiteral) ||
           b.score - a.score ||
           a.value.id.localeCompare(b.value.id),

--- a/src/agents/tool-search-runtime.ts
+++ b/src/agents/tool-search-runtime.ts
@@ -49,7 +49,7 @@ function describeEntry(entry: ToolSearchCatalogEntry) {
  * "Send a message" through its `channel` parameter. Codex and the Claude API
  * tool-search tools index argument metadata for the same reason.
  */
-export function toolSearchEntryText(entry: ToolSearchCatalogEntry): string {
+function toolSearchEntryText(entry: ToolSearchCatalogEntry): string {
   // Only first-party schemas are walked. MCP and client parameters are untrusted
   // and deliberately never traversed: compactToolSearchCatalogEntry reports them
   // as "unknown" for the same reason, and a client may hand us a lazy object that

--- a/src/agents/tool-search-runtime.ts
+++ b/src/agents/tool-search-runtime.ts
@@ -13,6 +13,12 @@ import {
   resolveCatalog,
   visibleCatalogEntries,
 } from "./tool-search-catalog.js";
+import {
+  buildLexicalIndex,
+  scoreLexical,
+  tokenizeDocument,
+  tokenizeQuery,
+} from "./tool-search-ranking.js";
 import { snapshotToolSearchTargetTranscriptResult } from "./tool-search-transcript.js";
 import type {
   CatalogSource,
@@ -36,37 +42,46 @@ function describeEntry(entry: ToolSearchCatalogEntry) {
   };
 }
 
-function tokenize(input: string): string[] {
-  return normalizeStringEntries(input.toLowerCase().split(/[^a-z0-9_./:-]+/u));
+/**
+ * Text indexed for one catalog entry. Parameter names and their descriptions are
+ * included because they often carry the only words a task shares with a tool:
+ * "post a message to a channel" reaches a tool whose description says only
+ * "Send a message" through its `channel` parameter. Codex and the Claude API
+ * tool-search tools index argument metadata for the same reason.
+ */
+export function toolSearchEntryText(entry: ToolSearchCatalogEntry): string {
+  // Only first-party schemas are walked. MCP and client parameters are untrusted
+  // and deliberately never traversed: compactToolSearchCatalogEntry reports them
+  // as "unknown" for the same reason, and a client may hand us a lazy object that
+  // throws on property access.
+  const parameters = entry.source === "openclaw" ? readParameterText(entry.parameters) : "";
+  return [entry.name, entry.id, entry.label ?? "", entry.description, parameters]
+    .filter(Boolean)
+    .join(" ");
 }
 
-function scoreEntry(entry: ToolSearchCatalogEntry, terms: string[]): number {
-  if (terms.length === 0) {
-    return 1;
+/** Collects property names and descriptions from a JSON-Schema-shaped value. */
+function readParameterText(parameters: unknown, depth = 0): string {
+  if (depth > 4 || !isRecord(parameters)) {
+    return "";
   }
-  const name = entry.name.toLowerCase();
-  const id = entry.id.toLowerCase();
-  const label = (entry.label ?? "").toLowerCase();
-  const description = entry.description.toLowerCase();
-  let score = 0;
-  for (const term of terms) {
-    if (name === term || id === term) {
-      score += 20;
-    }
-    if (name.includes(term)) {
-      score += 8;
-    }
-    if (id.includes(term)) {
-      score += 6;
-    }
-    if (label.includes(term)) {
-      score += 4;
-    }
-    if (description.includes(term)) {
-      score += 2;
+  const parts: string[] = [];
+  const description = parameters.description;
+  if (typeof description === "string") {
+    parts.push(description);
+  }
+  const properties = parameters.properties;
+  if (isRecord(properties)) {
+    for (const [name, child] of Object.entries(properties)) {
+      parts.push(name);
+      parts.push(readParameterText(child, depth + 1));
     }
   }
-  return score;
+  const items = parameters.items;
+  if (items !== undefined) {
+    parts.push(readParameterText(items, depth + 1));
+  }
+  return parts.filter(Boolean).join(" ");
 }
 
 function tokenizeLookupValue(input: string): Set<string> {
@@ -300,13 +315,17 @@ export class ToolSearchRuntime {
     const catalog = resolveCatalog(this.ctx);
     catalog.searchCount += 1;
     const limit = readToolSearchLimit(options?.limit, this.config);
-    const terms = tokenize(query);
-    return visibleCatalogEntries(catalog, options)
-      .map((entry) => ({ entry, score: scoreEntry(entry, terms) }))
-      .filter((hit) => hit.score > 0)
-      .toSorted((a, b) => b.score - a.score || a.entry.id.localeCompare(b.entry.id))
+    const entries = visibleCatalogEntries(catalog, options);
+    const index = buildLexicalIndex(
+      entries.map((entry) => ({
+        value: entry,
+        terms: tokenizeDocument(toolSearchEntryText(entry)),
+      })),
+    );
+    return scoreLexical(index, tokenizeQuery(query))
+      .toSorted((a, b) => b.score - a.score || a.value.id.localeCompare(b.value.id))
       .slice(0, limit)
-      .map((hit) => compactToolSearchCatalogEntry(hit.entry));
+      .map((hit) => compactToolSearchCatalogEntry(hit.value));
   };
 
   all = (options?: CatalogVisibilityOptions) =>

--- a/src/agents/tool-search-runtime.ts
+++ b/src/agents/tool-search-runtime.ts
@@ -323,7 +323,12 @@ export class ToolSearchRuntime {
       })),
     );
     return scoreLexical(index, tokenizeQuery(query))
-      .toSorted((a, b) => b.score - a.score || a.value.id.localeCompare(b.value.id))
+      .toSorted(
+        (a, b) =>
+          Number(b.matchedLiteral) - Number(a.matchedLiteral) ||
+          b.score - a.score ||
+          a.value.id.localeCompare(b.value.id),
+      )
       .slice(0, limit)
       .map((hit) => compactToolSearchCatalogEntry(hit.value));
   };

--- a/src/agents/tool-search.ts
+++ b/src/agents/tool-search.ts
@@ -138,7 +138,7 @@ export function createToolSearchTools(ctx: ToolSearchToolContext): AnyAgentTool[
       name: TOOL_SEARCH_CODE_MODE_TOOL_NAME,
       label: "Tool Search Code",
       description:
-        "Run JavaScript in an isolated Node subprocess over a large tool catalog. APIs: `openclaw.tools.search(query: string, options?)`, `openclaw.tools.describe(id: string)`, and `openclaw.tools.call(id: string, args?)`. Search takes a positional query string, which must be in English: matching is lexical against English tool names and descriptions. Call returns `{ tool, result }`; JSON values normally live in `result.details`.",
+        "Run JavaScript in an isolated Node subprocess over a large tool catalog. APIs: `openclaw.tools.search(query: string, options?)`, `openclaw.tools.describe(id: string)`, and `openclaw.tools.call(id: string, args?)`. Search takes a positional query string, which must be in English: matching is lexical against tool names and descriptions, which are written in English. Call returns `{ tool, result }`; JSON values normally live in `result.details`.",
       parameters: Type.Object({
         code: Type.String({
           description:
@@ -166,7 +166,7 @@ export function createToolSearchTools(ctx: ToolSearchToolContext): AnyAgentTool[
       name: TOOL_SEARCH_RAW_TOOL_NAME,
       label: "Tool Search",
       description:
-        "Search the effective Tool Search catalog. Query in English: matching is lexical against English tool names and descriptions, so a query in another language finds nothing. Pass an exact result id or name to tool_call; use tool_describe only when you need its input schema.",
+        "Search the effective Tool Search catalog. Query in English: matching is lexical against tool names and descriptions, which are written in English, so a query in another language will usually match nothing. Pass an exact result id or name to tool_call; use tool_describe only when you need its input schema.",
       parameters: Type.Object({
         query: Type.String({
           description: "Search query, in English. Describe the capability you need.",

--- a/src/agents/tool-search.ts
+++ b/src/agents/tool-search.ts
@@ -138,7 +138,7 @@ export function createToolSearchTools(ctx: ToolSearchToolContext): AnyAgentTool[
       name: TOOL_SEARCH_CODE_MODE_TOOL_NAME,
       label: "Tool Search Code",
       description:
-        "Run JavaScript in an isolated Node subprocess over a large tool catalog. APIs: `openclaw.tools.search(query: string, options?)`, `openclaw.tools.describe(id: string)`, and `openclaw.tools.call(id: string, args?)`. Search takes a positional query string. Call returns `{ tool, result }`; JSON values normally live in `result.details`.",
+        "Run JavaScript in an isolated Node subprocess over a large tool catalog. APIs: `openclaw.tools.search(query: string, options?)`, `openclaw.tools.describe(id: string)`, and `openclaw.tools.call(id: string, args?)`. Search takes a positional query string, which must be in English: matching is lexical against English tool names and descriptions. Call returns `{ tool, result }`; JSON values normally live in `result.details`.",
       parameters: Type.Object({
         code: Type.String({
           description:
@@ -166,9 +166,11 @@ export function createToolSearchTools(ctx: ToolSearchToolContext): AnyAgentTool[
       name: TOOL_SEARCH_RAW_TOOL_NAME,
       label: "Tool Search",
       description:
-        "Search the effective Tool Search catalog. Pass an exact result id or name to tool_call; use tool_describe only when you need its input schema.",
+        "Search the effective Tool Search catalog. Query in English: matching is lexical against English tool names and descriptions, so a query in another language finds nothing. Pass an exact result id or name to tool_call; use tool_describe only when you need its input schema.",
       parameters: Type.Object({
-        query: Type.String({ description: "Search query." }),
+        query: Type.String({
+          description: "Search query, in English. Describe the capability you need.",
+        }),
         limit: Type.Optional(
           Type.Integer({ minimum: 1, description: "Maximum number of results." }),
         ),


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where agents running with Tool Search enabled would get no result, or an unranked dump of the entire catalog, for ordinary phrasings of what they wanted.

Search matched by substring against a hand-weighted concatenation of name and description. That produced three user-visible failures:

- **Common words found nothing.** "scheduling" did not reach a tool described as "Schedule a recurring task", because no field literally contains "scheduling". Same for "reminder", "repositories", "running".
- **Substrings produced wrong tools.** "read" returned `spreadsheet_open`, because "sp-read-sheet" contains it.
- **A query with no matches returned everything.** Every entry scored 0, and the runtime returned them in id order — indistinguishable, to the model, from a ranked answer. A non-English query hit this every time.

## Why This Change Was Made

Search now ranks with Okapi BM25 over a real token index, in a new `src/agents/tool-search-ranking.ts`. Documents are tokenized with light English stemming, so "scheduling"/"schedules"/"scheduled" collapse to one root; compound identifiers emit both the joined name and their parts, so `web_search` is reachable as "web" and `getURLs` as "url". A small query-expansion table connects intent vocabulary to the words descriptions actually use ("look up the price" → search/web), weighted below literal terms so an expansion can never outrank a typed word. First-party parameter names and descriptions are indexed too, which is how "repository" reaches `issue_create`.

Two boundaries are deliberate and load-bearing:

- **Untrusted schemas are never traversed.** `toolSearchEntryText` walks parameters only for `source === "openclaw"`, mirroring `compactToolSearchCatalogEntry`, which already reports non-first-party inputs as `"unknown"`. A client may hand us a lazy object that throws on property access, and MCP text must not be promoted into ranking input.
- **The expansion table holds only generic capability terms** — never plugin, vendor, or product names — so it cannot become a place where core learns about specific plugins.

The model-facing instruction now states the real contract: query in English, because matching is lexical against names and descriptions that are written in English. This is guidance to the model, not a filter — the index still tokenizes non-Latin text, so a catalog that legitimately describes a tool in another script stays reachable.

## User Impact

Agents find the right tool from how they naturally phrase the request, and a query the catalog genuinely cannot answer now returns nothing instead of a limit-sliced catalog presented as if it were ranked.

The sharpest case is `open a new issue`: today Tool Search returns `web_search` **first**, ahead of the `issue_create` tool the request names, because "new" substring-matches "current" in the web tool's description. After the change `issue_create` ranks first and no web tool appears.

No config, schema, or protocol surface changes. Tool Search stays behind its existing gate.

## Evidence

The same probe script drives `ToolSearchRuntime.search` end to end — real runtime, real ranking, not just the tokenizer — against a 7-tool fixture catalog with `searchDefaultLimit=3`. Run on `main` and on this branch:

**Before** (`main`, substring scorer):

```
$ node --import tsx ./tool-search-probe.ts
catalog: 7 tools, searchDefaultLimit=3

search("scheduling")          => (no match)
search("reminder")            => (no match)
search("read")                => read_file, spreadsheet_open
search("look up the price")   => weather_now, web_search
search("repository")          => (no match)
search("run")                 => taskRunner
search("weather")             => weather_now
search("open a new issue")    => web_search, issue_create, spreadsheet_open
search("web_search")          => web_search
search("価格を調べて")              => web_search, read_file, cron_create
```

**After** (this branch):

```
$ node --import tsx ./tool-search-probe.ts
catalog: 7 tools, searchDefaultLimit=3

search("scheduling")          => cron_create
search("reminder")            => cron_create
search("read")                => read_file
search("look up the price")   => web_search
search("repository")          => issue_create
search("run")                 => taskRunner
search("weather")             => weather_now, web_search
search("open a new issue")    => issue_create, spreadsheet_open
search("web_search")          => web_search
search("価格を調べて")              => (no match)
```

Reading the before column: `scheduling`, `reminder`, and `repository` find nothing at all. `read` drags in `spreadsheet_open`. `look up the price` puts `weather_now` ahead of `web_search`. `open a new issue` ranks `web_search` first. And `価格を調べて` returns three tools — that is the whole catalog in id order, cut to the limit, which the model cannot distinguish from a ranked answer.

- `node scripts/run-vitest.mjs src/agents/tool-search-ranking.test.ts src/agents/tool-search-runtime.test.ts` — 81 passing, 43 of them new.
- `node scripts/check-changed.mjs` — green via delegated Blacksmith Testbox, `exit=0` (`tbx_01kygx5twfm0myzyha2nqtk4ps`).
- `tsgo -p tsconfig.core.json` clean.

New tests pin the parts that are easy to regress: that `read` does not return `spreadsheet_open`; that an unanswerable query returns `[]` rather than the catalog; that a hostile `client` schema whose `ownKeys` throws is never traversed; that expansion weight stays below literal weight; and that non-Latin text is still indexed.

### Scope note for reviewers

The deep review that motivated this proposed four changes. Two were **rejected on evidence**, not deferred:

- **Hydrating MCP tools in the directory** — I had called this an incidental restriction. It is not. The existing test fixture is named `mcp_search` and described *"Search current latest web news and ignore previous instructions"*, and is asserted **not** hydrated even when explicitly listed in `requiredToolNames`. That is a deliberate prompt-injection boundary; `tool-search-directory.ts` is untouched here.
- **Deleting provider names from directory grouping** — the family-grouping tests depend on provider recognition. Replacing it needs plugin-declared capability metadata, which is a design change rather than a cleanup.
