### PR TITLE
fix(ui): persist Control UI settings across reconnects via gateway-owned LWW prefs writes

### DIFF
--- a/src/gateway/server-methods/config.test.ts
+++ b/src/gateway/server-methods/config.test.ts
@@ -3,14 +3,43 @@
  */
 
 import { expectDefined } from "@openclaw/normalization-core";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ConfigMutationConflictError } from "../../config/mutation-conflict.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { withEnvAsync } from "../../test-utils/env.js";
 import {
   clearConfigSchemaResponseCacheForTests,
   configHandlers,
   loadConfigSchemaResponseForTests,
 } from "./config.js";
-import { createConfigHandlerHarness } from "./config.test-helpers.js";
+import { createConfigHandlerHarness, createConfigWriteSnapshot } from "./config.test-helpers.js";
+
+const configWriteMocks = vi.hoisted(() => ({
+  commitGatewayConfigWrite: vi.fn(),
+  readConfigFileSnapshotForWrite: vi.fn(),
+}));
+
+vi.mock("../../config/io.js", async () => {
+  const actual = await vi.importActual<typeof import("../../config/io.js")>("../../config/io.js");
+  return {
+    ...actual,
+    readConfigFileSnapshotForWrite: configWriteMocks.readConfigFileSnapshotForWrite,
+  };
+});
+
+vi.mock("./config-write-flow.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("./config-write-flow.js")>("./config-write-flow.js");
+  return {
+    ...actual,
+    commitGatewayConfigWrite: configWriteMocks.commitGatewayConfigWrite,
+    resolveGatewayConfigRestartWriteResult: vi.fn(async () => ({
+      payload: { kind: "config-patch", mode: "config.patch", configPath: "/tmp/openclaw.json" },
+      sentinelPersisted: false,
+      restart: undefined,
+    })),
+  };
+});
 
 const { execOpenPathMock, loadGatewayRuntimeConfigSchemaMock } = vi.hoisted(() => ({
   execOpenPathMock: vi.fn(),
@@ -33,6 +62,70 @@ vi.mock("../../config/runtime-schema.js", () => ({
 function mockOpenPathError(error: Error) {
   execOpenPathMock.mockRejectedValue(error);
 }
+
+let storedConfig: OpenClawConfig;
+let storedHash: string;
+let nextHash: number;
+
+function currentWriteSnapshot() {
+  const result = createConfigWriteSnapshot(storedConfig);
+  result.snapshot.hash = storedHash;
+  result.snapshot.raw = JSON.stringify(storedConfig);
+  return result;
+}
+
+async function invokeConfigPatch(args: {
+  raw: unknown;
+  baseHash?: string;
+  replacePaths?: string[];
+}) {
+  const harness = createConfigHandlerHarness({
+    method: "config.patch",
+    params: {
+      raw: JSON.stringify(args.raw),
+      ...(args.baseHash ? { baseHash: args.baseHash } : {}),
+      ...(args.replacePaths ? { replacePaths: args.replacePaths } : {}),
+    },
+  });
+  await expectDefined(
+    configHandlers["config.patch"],
+    'configHandlers["config.patch"] test invariant',
+  )(harness.options);
+  return harness;
+}
+
+beforeEach(() => {
+  storedConfig = {};
+  storedHash = "base-hash";
+  nextHash = 1;
+  configWriteMocks.readConfigFileSnapshotForWrite.mockImplementation(async () =>
+    currentWriteSnapshot(),
+  );
+  configWriteMocks.commitGatewayConfigWrite.mockImplementation(
+    async ({
+      snapshot,
+      nextConfig,
+    }: {
+      snapshot: { hash?: string };
+      nextConfig: OpenClawConfig;
+    }) => {
+      if (snapshot.hash !== storedHash) {
+        throw new ConfigMutationConflictError("config changed since last load", {
+          currentHash: storedHash,
+        });
+      }
+      storedConfig = nextConfig;
+      storedHash = `next-hash-${nextHash}`;
+      nextHash += 1;
+      return {
+        path: "/tmp/openclaw.json",
+        config: storedConfig,
+        hash: storedHash,
+        queueFollowUp: vi.fn(),
+      };
+    },
+  );
+});
 
 async function invokeConfigOpenFile() {
   const harness = createConfigHandlerHarness({ method: "config.openFile" });
@@ -173,5 +266,120 @@ describe("config schema response cache", () => {
     loadConfigSchemaResponseForTests();
 
     expect(loadGatewayRuntimeConfigSchemaMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("config.patch hash-free ui.prefs LWW", () => {
+  it("persists a ui.prefs-only patch and returns the committed hash", async () => {
+    const { respond } = await invokeConfigPatch({ raw: { ui: { prefs: { theme: "knot" } } } });
+
+    expect(storedConfig.ui?.prefs?.theme).toBe("knot");
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({ ok: true, hash: "next-hash-1" }),
+      undefined,
+    );
+  });
+
+  it("rejects a hash-free patch outside the LWW subtree", async () => {
+    const { respond } = await invokeConfigPatch({ raw: { gateway: { port: 19_001 } } });
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ message: expect.stringContaining("config base hash required") }),
+    );
+  });
+
+  it("rejects a mixed hash-free patch", async () => {
+    const { respond } = await invokeConfigPatch({
+      raw: { ui: { prefs: { theme: "knot" } }, gateway: { port: 19_001 } },
+    });
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ message: expect.stringContaining("config base hash required") }),
+    );
+    expect(storedConfig).toEqual({});
+  });
+
+  it("rejects an empty-object structural change outside the LWW subtree", async () => {
+    const { respond } = await invokeConfigPatch({
+      raw: { ui: { prefs: { theme: "knot" } }, gateway: {} },
+    });
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ message: expect.stringContaining("config base hash required") }),
+    );
+  });
+
+  it("keeps destructive array replacement explicit for hash-free patches", async () => {
+    storedConfig = { ui: { prefs: { sidebarEntries: ["route:usage", "route:tasks"] } } };
+
+    const rejected = await invokeConfigPatch({
+      raw: { ui: { prefs: { sidebarEntries: ["route:usage"] } } },
+    });
+    expect(rejected.respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        message: expect.stringContaining("config.patch would remove entries from array path(s)"),
+      }),
+    );
+
+    const accepted = await invokeConfigPatch({
+      raw: { ui: { prefs: { sidebarEntries: ["route:usage"] } } },
+      replacePaths: ["ui.prefs.sidebarEntries"],
+    });
+    expect(accepted.respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({ hash: "next-hash-1" }),
+      undefined,
+    );
+    expect(storedConfig.ui?.prefs?.sidebarEntries).toEqual(["route:usage"]);
+  });
+
+  it("returns a noop for an unchanged hash-free patch", async () => {
+    storedConfig = { ui: { prefs: { theme: "knot" } } };
+
+    const { respond } = await invokeConfigPatch({
+      raw: { ui: { prefs: { theme: "knot" } } },
+    });
+
+    expect(respond).toHaveBeenCalledWith(true, expect.objectContaining({ noop: true }), undefined);
+    expect(configWriteMocks.commitGatewayConfigWrite).not.toHaveBeenCalled();
+  });
+
+  it("preserves stale-hash rejection for strict patches", async () => {
+    const { respond } = await invokeConfigPatch({
+      raw: { ui: { prefs: { theme: "knot" } } },
+      baseHash: "stale-hash",
+    });
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        message: expect.stringContaining("config changed since last load"),
+      }),
+    );
+  });
+
+  it("retries a hash-free patch against a fresh snapshot after a commit race", async () => {
+    configWriteMocks.commitGatewayConfigWrite.mockImplementationOnce(async () => {
+      storedConfig = { ui: { prefs: { locale: "de" } } };
+      storedHash = "raced-hash";
+      throw new ConfigMutationConflictError("config changed since last load", {
+        currentHash: storedHash,
+      });
+    });
+
+    await invokeConfigPatch({ raw: { ui: { prefs: { theme: "knot" } } } });
+
+    expect(configWriteMocks.commitGatewayConfigWrite).toHaveBeenCalledTimes(2);
+    expect(storedConfig.ui?.prefs).toEqual({ locale: "de", theme: "knot" });
   });
 });

--- a/src/gateway/server-methods/config.test.ts
+++ b/src/gateway/server-methods/config.test.ts
@@ -316,6 +316,38 @@ describe("config.patch hash-free ui.prefs LWW", () => {
     );
   });
 
+  it.each([
+    { name: "ui.prefs deletion", raw: { ui: { prefs: null } } },
+    { name: "ui deletion", raw: { ui: null } },
+    { name: "scalar ui.prefs", raw: { ui: { prefs: "stale-container" } } },
+  ])("rejects hash-free container operation: $name", async ({ raw }) => {
+    storedConfig = { ui: { prefs: { theme: "claw" } } };
+
+    const { respond } = await invokeConfigPatch({ raw });
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ message: expect.stringContaining("config base hash required") }),
+    );
+    expect(configWriteMocks.commitGatewayConfigWrite).not.toHaveBeenCalled();
+  });
+
+  it("allows a hash-free per-key null deletion below ui.prefs", async () => {
+    storedConfig = { ui: { prefs: { chatFollowUpMode: "queue", theme: "claw" } } };
+
+    const { respond } = await invokeConfigPatch({
+      raw: { ui: { prefs: { chatFollowUpMode: null } } },
+    });
+
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({ hash: "next-hash-1" }),
+      undefined,
+    );
+    expect(storedConfig.ui?.prefs).toEqual({ theme: "claw" });
+  });
+
   it("keeps destructive array replacement explicit for hash-free patches", async () => {
     storedConfig = { ui: { prefs: { sidebarEntries: ["route:usage", "route:tasks"] } } };
 
@@ -368,7 +400,7 @@ describe("config.patch hash-free ui.prefs LWW", () => {
     );
   });
 
-  it("retries a hash-free patch against a fresh snapshot after a commit race", async () => {
+  it("surfaces a hash-free commit race without replaying stale intent", async () => {
     configWriteMocks.commitGatewayConfigWrite.mockImplementationOnce(async () => {
       storedConfig = { ui: { prefs: { locale: "de" } } };
       storedHash = "raced-hash";
@@ -377,9 +409,18 @@ describe("config.patch hash-free ui.prefs LWW", () => {
       });
     });
 
-    await invokeConfigPatch({ raw: { ui: { prefs: { theme: "knot" } } } });
+    const { respond } = await invokeConfigPatch({
+      raw: { ui: { prefs: { theme: "knot" } } },
+    });
 
-    expect(configWriteMocks.commitGatewayConfigWrite).toHaveBeenCalledTimes(2);
-    expect(storedConfig.ui?.prefs).toEqual({ locale: "de", theme: "knot" });
+    expect(configWriteMocks.commitGatewayConfigWrite).toHaveBeenCalledOnce();
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        message: expect.stringContaining("config changed since last load"),
+      }),
+    );
+    expect(storedConfig.ui?.prefs).toEqual({ locale: "de" });
   });
 });

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -734,6 +734,27 @@ function isHashlessPatchLwwPath(path: string): boolean {
   );
 }
 
+// Hash-free LWW is a per-leaf protocol. Container replacement or deletion requires document CAS
+// so a stale client cannot wipe preference keys added by a concurrent writer.
+function hasHashlessPatchLwwStructure(patch: unknown): boolean {
+  return HASHLESS_PATCH_LWW_PATH_PREFIXES.every((prefix) => {
+    let node = patch;
+    for (const segment of prefix.split(".")) {
+      if (!isPlainObject(node)) {
+        return false;
+      }
+      if (!Object.hasOwn(node, segment)) {
+        return true;
+      }
+      node = node[segment];
+      if (!isPlainObject(node)) {
+        return false;
+      }
+    }
+    return true;
+  });
+}
+
 function diffConfigLeafPaths(prev: unknown, next: unknown, prefix = ""): string[] {
   if (isPlainObject(prev) || isPlainObject(next)) {
     const prevRecord = isPlainObject(prev) ? prev : {};
@@ -857,227 +878,207 @@ export const configHandlers: GatewayRequestHandlers = {
       return;
     }
     const hashlessPatch = resolveBaseHashParam(params) === null;
-    const maxAttempts = hashlessPatch ? 3 : 1;
-    for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
-      const writeSnapshot = hashlessPatch
-        ? await readConfigFileSnapshotForWrite()
-        : await readConfigWriteSnapshotOrRespond(params, respond);
-      if (!writeSnapshot) {
-        return;
-      }
-      const { snapshot, writeOptions } = writeSnapshot;
-      if (!snapshot.valid) {
-        respond(
-          false,
-          undefined,
-          errorShape(ErrorCodes.INVALID_REQUEST, "invalid config; fix before patching"),
-        );
-        return;
-      }
-      const rawValue = (params as { raw?: unknown }).raw;
-      if (typeof rawValue !== "string") {
-        respond(
-          false,
-          undefined,
-          errorShape(
-            ErrorCodes.INVALID_REQUEST,
-            "invalid config.patch params: raw (string) required",
-          ),
-        );
-        return;
-      }
-      const parsedRes = parseConfigJson5(rawValue);
-      if (!parsedRes.ok) {
-        respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, parsedRes.error));
-        return;
-      }
-      if (
-        !parsedRes.parsed ||
-        typeof parsedRes.parsed !== "object" ||
-        Array.isArray(parsedRes.parsed)
-      ) {
-        respond(
-          false,
-          undefined,
-          errorShape(ErrorCodes.INVALID_REQUEST, "config.patch raw must be an object"),
-        );
-        return;
-      }
-      const replacePaths = readConfigPatchReplacePaths(params);
-      const merged = applyMergePatch(snapshot.config, parsedRes.parsed, {
-        // Arrays with stable ids behave like maps for partial control-plane edits.
-        mergeObjectArraysById: true,
-        replaceArrayPaths: replacePaths,
-      });
-      const schemaPatch = loadSchemaWithPlugins();
-      const restoredMerge = restoreRedactedValues(merged, snapshot.config, schemaPatch.uiHints);
-      if (!restoredMerge.ok) {
-        respond(
-          false,
-          undefined,
-          errorShape(
-            ErrorCodes.INVALID_REQUEST,
-            restoredMerge.humanReadableMessage ?? "invalid config",
-          ),
-        );
-        return;
-      }
-      if (
-        rejectDestructiveArrayPatchWithoutIntent({
-          currentConfig: snapshot.config,
-          mergedConfig: restoredMerge.result,
-          patch: parsedRes.parsed,
-          replacePaths,
-          respond,
-        })
-      ) {
-        return;
-      }
-      const restoredChangedPaths = diffConfigLeafPaths(snapshot.config, restoredMerge.result);
-      if (hashlessPatch && !restoredChangedPaths.every(isHashlessPatchLwwPath)) {
-        respond(
-          false,
-          undefined,
-          errorShape(
-            ErrorCodes.INVALID_REQUEST,
-            "config base hash required; re-run config.get and retry",
-          ),
-        );
-        return;
-      }
-      const actor = resolveControlPlaneActor(client);
-      if (restoredChangedPaths.length === 0) {
-        respondConfigPatchNoop({
-          snapshot,
-          config: snapshot.config,
-          uiHints: schemaPatch.uiHints,
-          actor,
-          context,
-          respond,
-        });
-        return;
-      }
-      const validationCandidate = stripBundledProviderRuntimeDefaults({
-        candidate: restoredMerge.result,
-        sourceConfig: snapshot.sourceConfig,
-      });
-      const sourceValidated = validateConfigObjectRawWithPlugins(validationCandidate);
-      if (!sourceValidated.ok) {
-        respond(
-          false,
-          undefined,
-          errorShape(
-            ErrorCodes.INVALID_REQUEST,
-            summarizeConfigValidationIssues(sourceValidated.issues),
-            {
-              details: { issues: sourceValidated.issues },
-            },
-          ),
-        );
-        return;
-      }
-      const writeConfig = validationCandidate as OpenClawConfig;
-      const validated = validateConfigObjectWithPlugins(validationCandidate);
-      if (!validated.ok) {
-        respond(
-          false,
-          undefined,
-          errorShape(
-            ErrorCodes.INVALID_REQUEST,
-            summarizeConfigValidationIssues(validated.issues),
-            {
-              details: { issues: validated.issues },
-            },
-          ),
-        );
-        return;
-      }
-      const preparedSecretsSnapshot = await ensureResolvableSecretRefsOrRespond({
-        config: validated.config,
-        respond,
-      });
-      if (!preparedSecretsSnapshot) {
-        return;
-      }
-      const changedPaths = diffConfigPaths(snapshot.config, validated.config);
-
-      // No-op: if the validated config is identical to the current config,
-      // skip the file write and SIGUSR1 restart entirely. This avoids a full
-      // gateway restart (and the resulting connection drop) when a control-plane
-      // client re-sends the same config (e.g. hot-apply with no actual changes).
-      if (changedPaths.length === 0) {
-        respondConfigPatchNoop({
-          snapshot,
-          config: validated.config,
-          uiHints: schemaPatch.uiHints,
-          actor,
-          context,
-          respond,
-        });
-        return;
-      }
-
-      context?.logGateway?.info(
-        `config.patch write ${formatControlPlaneActor(actor)} changedPaths=${summarizeChangedPaths(changedPaths)} restartReason=config.patch`,
+    // Hash-free writes do not retry: only the client can replay fresh intent after a lost race;
+    // server re-merge would replay frozen stale intent over the winner. A paused handler can still
+    // commit stale state, an accepted residual instead of adding connection-liveness plumbing.
+    const writeSnapshot = hashlessPatch
+      ? await readConfigFileSnapshotForWrite()
+      : await readConfigWriteSnapshotOrRespond(params, respond);
+    if (!writeSnapshot) {
+      return;
+    }
+    const { snapshot, writeOptions } = writeSnapshot;
+    if (!snapshot.valid) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, "invalid config; fix before patching"),
       );
-      // Compare before the write so we invalidate clients authenticated against the
-      // previous shared secret immediately after the config update succeeds.
-      const disconnectSharedAuthClients = shouldDisconnectSharedAuthClientsForConfigWrite({
-        prevConfig: snapshot.config,
-        nextConfig: validated.config,
-        preparedSecretsSnapshot,
-      });
-      let writeResult: ConfigWriteCommitResult | null;
-      if (hashlessPatch) {
-        try {
-          writeResult = await commitGatewayConfigWrite({
-            snapshot,
-            writeOptions,
-            nextConfig: writeConfig,
-            context,
-            disconnectSharedAuthClients,
-          });
-        } catch (error) {
-          if (!(error instanceof ConfigMutationConflictError)) {
-            throw error;
-          }
-          if (attempt + 1 < maxAttempts) {
-            continue;
-          }
-          respond(
-            false,
-            undefined,
-            errorShape(ErrorCodes.INVALID_REQUEST, `${error.message}; re-run config.get and retry`),
-          );
-          return;
-        }
-      } else {
-        writeResult = await commitGatewayConfigWriteOrRespond({
-          snapshot,
-          writeOptions,
-          nextConfig: writeConfig,
-          context,
-          disconnectSharedAuthClients,
-          respond,
-        });
-      }
-      if (!writeResult) {
-        return;
-      }
-      await respondWithConfigRestartWrite({
-        requestParams: params,
-        kind: "config-patch",
-        mode: "config.patch",
-        writeResult,
-        changedPaths,
+      return;
+    }
+    const rawValue = (params as { raw?: unknown }).raw;
+    if (typeof rawValue !== "string") {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          "invalid config.patch params: raw (string) required",
+        ),
+      );
+      return;
+    }
+    const parsedRes = parseConfigJson5(rawValue);
+    if (!parsedRes.ok) {
+      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, parsedRes.error));
+      return;
+    }
+    if (
+      !parsedRes.parsed ||
+      typeof parsedRes.parsed !== "object" ||
+      Array.isArray(parsedRes.parsed)
+    ) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, "config.patch raw must be an object"),
+      );
+      return;
+    }
+    if (hashlessPatch && !hasHashlessPatchLwwStructure(parsedRes.parsed)) {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          "config base hash required; re-run config.get and retry",
+        ),
+      );
+      return;
+    }
+    const replacePaths = readConfigPatchReplacePaths(params);
+    const merged = applyMergePatch(snapshot.config, parsedRes.parsed, {
+      // Arrays with stable ids behave like maps for partial control-plane edits.
+      mergeObjectArraysById: true,
+      replaceArrayPaths: replacePaths,
+    });
+    const schemaPatch = loadSchemaWithPlugins();
+    const restoredMerge = restoreRedactedValues(merged, snapshot.config, schemaPatch.uiHints);
+    if (!restoredMerge.ok) {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          restoredMerge.humanReadableMessage ?? "invalid config",
+        ),
+      );
+      return;
+    }
+    if (
+      rejectDestructiveArrayPatchWithoutIntent({
+        currentConfig: snapshot.config,
+        mergedConfig: restoredMerge.result,
+        patch: parsedRes.parsed,
+        replacePaths,
+        respond,
+      })
+    ) {
+      return;
+    }
+    const restoredChangedPaths = diffConfigLeafPaths(snapshot.config, restoredMerge.result);
+    if (hashlessPatch && !restoredChangedPaths.every(isHashlessPatchLwwPath)) {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          "config base hash required; re-run config.get and retry",
+        ),
+      );
+      return;
+    }
+    const actor = resolveControlPlaneActor(client);
+    if (restoredChangedPaths.length === 0) {
+      respondConfigPatchNoop({
+        snapshot,
+        config: snapshot.config,
+        uiHints: schemaPatch.uiHints,
         actor,
         context,
         respond,
-        uiHints: schemaPatch.uiHints,
-        preparedSecretsSnapshot,
       });
       return;
     }
+    const validationCandidate = stripBundledProviderRuntimeDefaults({
+      candidate: restoredMerge.result,
+      sourceConfig: snapshot.sourceConfig,
+    });
+    const sourceValidated = validateConfigObjectRawWithPlugins(validationCandidate);
+    if (!sourceValidated.ok) {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          summarizeConfigValidationIssues(sourceValidated.issues),
+          {
+            details: { issues: sourceValidated.issues },
+          },
+        ),
+      );
+      return;
+    }
+    const writeConfig = validationCandidate as OpenClawConfig;
+    const validated = validateConfigObjectWithPlugins(validationCandidate);
+    if (!validated.ok) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, summarizeConfigValidationIssues(validated.issues), {
+          details: { issues: validated.issues },
+        }),
+      );
+      return;
+    }
+    const preparedSecretsSnapshot = await ensureResolvableSecretRefsOrRespond({
+      config: validated.config,
+      respond,
+    });
+    if (!preparedSecretsSnapshot) {
+      return;
+    }
+    const changedPaths = diffConfigPaths(snapshot.config, validated.config);
+
+    // No-op: if the validated config is identical to the current config,
+    // skip the file write and SIGUSR1 restart entirely. This avoids a full
+    // gateway restart (and the resulting connection drop) when a control-plane
+    // client re-sends the same config (e.g. hot-apply with no actual changes).
+    if (changedPaths.length === 0) {
+      respondConfigPatchNoop({
+        snapshot,
+        config: validated.config,
+        uiHints: schemaPatch.uiHints,
+        actor,
+        context,
+        respond,
+      });
+      return;
+    }
+
+    context?.logGateway?.info(
+      `config.patch write ${formatControlPlaneActor(actor)} changedPaths=${summarizeChangedPaths(changedPaths)} restartReason=config.patch`,
+    );
+    // Compare before the write so we invalidate clients authenticated against the
+    // previous shared secret immediately after the config update succeeds.
+    const disconnectSharedAuthClients = shouldDisconnectSharedAuthClientsForConfigWrite({
+      prevConfig: snapshot.config,
+      nextConfig: validated.config,
+      preparedSecretsSnapshot,
+    });
+    const writeResult = await commitGatewayConfigWriteOrRespond({
+      snapshot,
+      writeOptions,
+      nextConfig: writeConfig,
+      context,
+      disconnectSharedAuthClients,
+      respond,
+    });
+    if (!writeResult) {
+      return;
+    }
+    await respondWithConfigRestartWrite({
+      requestParams: params,
+      kind: "config-patch",
+      mode: "config.patch",
+      writeResult,
+      changedPaths,
+      actor,
+      context,
+      respond,
+      uiHints: schemaPatch.uiHints,
+      preparedSecretsSnapshot,
+    });
   },
   "config.apply": async ({ params, respond, client, context }) => {
     if (!assertValidParams(params, validateConfigApplyParams, "config.apply", respond)) {

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -83,6 +83,10 @@ import { assertValidParams } from "./validation.js";
 
 const MAX_CONFIG_ISSUES_IN_ERROR_MESSAGE = 3;
 const CONFIG_SCHEMA_RESPONSE_CACHE_TTL_MS = 5_000;
+// ui.prefs is the cross-device Control UI preference surface documented in docs/web/control-ui.md.
+// Leaf preferences are LWW so independent tabs/devices do not CAS-conflict on the whole config;
+// every other path keeps strict document CAS.
+const HASHLESS_PATCH_LWW_PATH_PREFIXES = ["ui.prefs"] as const;
 
 let configSchemaResponseCache: {
   expiresAtMs: number;
@@ -724,6 +728,27 @@ async function commitGatewayConfigWriteOrRespond(
   }
 }
 
+function isHashlessPatchLwwPath(path: string): boolean {
+  return HASHLESS_PATCH_LWW_PATH_PREFIXES.some(
+    (prefix) => path === prefix || path.startsWith(`${prefix}.`),
+  );
+}
+
+function diffConfigLeafPaths(prev: unknown, next: unknown, prefix = ""): string[] {
+  if (isPlainObject(prev) || isPlainObject(next)) {
+    const prevRecord = isPlainObject(prev) ? prev : {};
+    const nextRecord = isPlainObject(next) ? next : {};
+    const keys = [...new Set([...Object.keys(prevRecord), ...Object.keys(nextRecord)])];
+    if (keys.length === 0) {
+      return isDeepStrictEqual(prev, next) ? [] : [prefix || "<root>"];
+    }
+    return keys.flatMap((key) =>
+      diffConfigLeafPaths(prevRecord[key], nextRecord[key], prefix ? `${prefix}.${key}` : key),
+    );
+  }
+  return diffConfigPaths(prev, next, prefix);
+}
+
 export const configHandlers: GatewayRequestHandlers = {
   "config.get": async ({ params, respond }) => {
     if (!assertValidParams(params, validateConfigGetParams, "config.get", respond)) {
@@ -831,180 +856,228 @@ export const configHandlers: GatewayRequestHandlers = {
     if (!assertValidParams(params, validateConfigPatchParams, "config.patch", respond)) {
       return;
     }
-    const writeSnapshot = await readConfigWriteSnapshotOrRespond(params, respond);
-    if (!writeSnapshot) {
-      return;
-    }
-    const { snapshot, writeOptions } = writeSnapshot;
-    if (!snapshot.valid) {
-      respond(
-        false,
-        undefined,
-        errorShape(ErrorCodes.INVALID_REQUEST, "invalid config; fix before patching"),
-      );
-      return;
-    }
-    const rawValue = (params as { raw?: unknown }).raw;
-    if (typeof rawValue !== "string") {
-      respond(
-        false,
-        undefined,
-        errorShape(
-          ErrorCodes.INVALID_REQUEST,
-          "invalid config.patch params: raw (string) required",
-        ),
-      );
-      return;
-    }
-    const parsedRes = parseConfigJson5(rawValue);
-    if (!parsedRes.ok) {
-      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, parsedRes.error));
-      return;
-    }
-    if (
-      !parsedRes.parsed ||
-      typeof parsedRes.parsed !== "object" ||
-      Array.isArray(parsedRes.parsed)
-    ) {
-      respond(
-        false,
-        undefined,
-        errorShape(ErrorCodes.INVALID_REQUEST, "config.patch raw must be an object"),
-      );
-      return;
-    }
-    const replacePaths = readConfigPatchReplacePaths(params);
-    const merged = applyMergePatch(snapshot.config, parsedRes.parsed, {
-      // Arrays with stable ids behave like maps for partial control-plane edits.
-      mergeObjectArraysById: true,
-      replaceArrayPaths: replacePaths,
-    });
-    const schemaPatch = loadSchemaWithPlugins();
-    const restoredMerge = restoreRedactedValues(merged, snapshot.config, schemaPatch.uiHints);
-    if (!restoredMerge.ok) {
-      respond(
-        false,
-        undefined,
-        errorShape(
-          ErrorCodes.INVALID_REQUEST,
-          restoredMerge.humanReadableMessage ?? "invalid config",
-        ),
-      );
-      return;
-    }
-    if (
-      rejectDestructiveArrayPatchWithoutIntent({
-        currentConfig: snapshot.config,
-        mergedConfig: restoredMerge.result,
-        patch: parsedRes.parsed,
-        replacePaths,
-        respond,
-      })
-    ) {
-      return;
-    }
-    const restoredChangedPaths = diffConfigPaths(snapshot.config, restoredMerge.result);
-    const actor = resolveControlPlaneActor(client);
-    if (restoredChangedPaths.length === 0) {
-      respondConfigPatchNoop({
-        snapshot,
-        config: snapshot.config,
-        uiHints: schemaPatch.uiHints,
-        actor,
-        context,
-        respond,
+    const hashlessPatch = resolveBaseHashParam(params) === null;
+    const maxAttempts = hashlessPatch ? 3 : 1;
+    for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+      const writeSnapshot = hashlessPatch
+        ? await readConfigFileSnapshotForWrite()
+        : await readConfigWriteSnapshotOrRespond(params, respond);
+      if (!writeSnapshot) {
+        return;
+      }
+      const { snapshot, writeOptions } = writeSnapshot;
+      if (!snapshot.valid) {
+        respond(
+          false,
+          undefined,
+          errorShape(ErrorCodes.INVALID_REQUEST, "invalid config; fix before patching"),
+        );
+        return;
+      }
+      const rawValue = (params as { raw?: unknown }).raw;
+      if (typeof rawValue !== "string") {
+        respond(
+          false,
+          undefined,
+          errorShape(
+            ErrorCodes.INVALID_REQUEST,
+            "invalid config.patch params: raw (string) required",
+          ),
+        );
+        return;
+      }
+      const parsedRes = parseConfigJson5(rawValue);
+      if (!parsedRes.ok) {
+        respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, parsedRes.error));
+        return;
+      }
+      if (
+        !parsedRes.parsed ||
+        typeof parsedRes.parsed !== "object" ||
+        Array.isArray(parsedRes.parsed)
+      ) {
+        respond(
+          false,
+          undefined,
+          errorShape(ErrorCodes.INVALID_REQUEST, "config.patch raw must be an object"),
+        );
+        return;
+      }
+      const replacePaths = readConfigPatchReplacePaths(params);
+      const merged = applyMergePatch(snapshot.config, parsedRes.parsed, {
+        // Arrays with stable ids behave like maps for partial control-plane edits.
+        mergeObjectArraysById: true,
+        replaceArrayPaths: replacePaths,
       });
-      return;
-    }
-    const validationCandidate = stripBundledProviderRuntimeDefaults({
-      candidate: restoredMerge.result,
-      sourceConfig: snapshot.sourceConfig,
-    });
-    const sourceValidated = validateConfigObjectRawWithPlugins(validationCandidate);
-    if (!sourceValidated.ok) {
-      respond(
-        false,
-        undefined,
-        errorShape(
-          ErrorCodes.INVALID_REQUEST,
-          summarizeConfigValidationIssues(sourceValidated.issues),
-          {
-            details: { issues: sourceValidated.issues },
-          },
-        ),
-      );
-      return;
-    }
-    const writeConfig = validationCandidate as OpenClawConfig;
-    const validated = validateConfigObjectWithPlugins(validationCandidate);
-    if (!validated.ok) {
-      respond(
-        false,
-        undefined,
-        errorShape(ErrorCodes.INVALID_REQUEST, summarizeConfigValidationIssues(validated.issues), {
-          details: { issues: validated.issues },
-        }),
-      );
-      return;
-    }
-    const preparedSecretsSnapshot = await ensureResolvableSecretRefsOrRespond({
-      config: validated.config,
-      respond,
-    });
-    if (!preparedSecretsSnapshot) {
-      return;
-    }
-    const changedPaths = diffConfigPaths(snapshot.config, validated.config);
-
-    // No-op: if the validated config is identical to the current config,
-    // skip the file write and SIGUSR1 restart entirely. This avoids a full
-    // gateway restart (and the resulting connection drop) when a control-plane
-    // client re-sends the same config (e.g. hot-apply with no actual changes).
-    if (changedPaths.length === 0) {
-      respondConfigPatchNoop({
-        snapshot,
+      const schemaPatch = loadSchemaWithPlugins();
+      const restoredMerge = restoreRedactedValues(merged, snapshot.config, schemaPatch.uiHints);
+      if (!restoredMerge.ok) {
+        respond(
+          false,
+          undefined,
+          errorShape(
+            ErrorCodes.INVALID_REQUEST,
+            restoredMerge.humanReadableMessage ?? "invalid config",
+          ),
+        );
+        return;
+      }
+      if (
+        rejectDestructiveArrayPatchWithoutIntent({
+          currentConfig: snapshot.config,
+          mergedConfig: restoredMerge.result,
+          patch: parsedRes.parsed,
+          replacePaths,
+          respond,
+        })
+      ) {
+        return;
+      }
+      const restoredChangedPaths = diffConfigLeafPaths(snapshot.config, restoredMerge.result);
+      if (hashlessPatch && !restoredChangedPaths.every(isHashlessPatchLwwPath)) {
+        respond(
+          false,
+          undefined,
+          errorShape(
+            ErrorCodes.INVALID_REQUEST,
+            "config base hash required; re-run config.get and retry",
+          ),
+        );
+        return;
+      }
+      const actor = resolveControlPlaneActor(client);
+      if (restoredChangedPaths.length === 0) {
+        respondConfigPatchNoop({
+          snapshot,
+          config: snapshot.config,
+          uiHints: schemaPatch.uiHints,
+          actor,
+          context,
+          respond,
+        });
+        return;
+      }
+      const validationCandidate = stripBundledProviderRuntimeDefaults({
+        candidate: restoredMerge.result,
+        sourceConfig: snapshot.sourceConfig,
+      });
+      const sourceValidated = validateConfigObjectRawWithPlugins(validationCandidate);
+      if (!sourceValidated.ok) {
+        respond(
+          false,
+          undefined,
+          errorShape(
+            ErrorCodes.INVALID_REQUEST,
+            summarizeConfigValidationIssues(sourceValidated.issues),
+            {
+              details: { issues: sourceValidated.issues },
+            },
+          ),
+        );
+        return;
+      }
+      const writeConfig = validationCandidate as OpenClawConfig;
+      const validated = validateConfigObjectWithPlugins(validationCandidate);
+      if (!validated.ok) {
+        respond(
+          false,
+          undefined,
+          errorShape(
+            ErrorCodes.INVALID_REQUEST,
+            summarizeConfigValidationIssues(validated.issues),
+            {
+              details: { issues: validated.issues },
+            },
+          ),
+        );
+        return;
+      }
+      const preparedSecretsSnapshot = await ensureResolvableSecretRefsOrRespond({
         config: validated.config,
-        uiHints: schemaPatch.uiHints,
+        respond,
+      });
+      if (!preparedSecretsSnapshot) {
+        return;
+      }
+      const changedPaths = diffConfigPaths(snapshot.config, validated.config);
+
+      // No-op: if the validated config is identical to the current config,
+      // skip the file write and SIGUSR1 restart entirely. This avoids a full
+      // gateway restart (and the resulting connection drop) when a control-plane
+      // client re-sends the same config (e.g. hot-apply with no actual changes).
+      if (changedPaths.length === 0) {
+        respondConfigPatchNoop({
+          snapshot,
+          config: validated.config,
+          uiHints: schemaPatch.uiHints,
+          actor,
+          context,
+          respond,
+        });
+        return;
+      }
+
+      context?.logGateway?.info(
+        `config.patch write ${formatControlPlaneActor(actor)} changedPaths=${summarizeChangedPaths(changedPaths)} restartReason=config.patch`,
+      );
+      // Compare before the write so we invalidate clients authenticated against the
+      // previous shared secret immediately after the config update succeeds.
+      const disconnectSharedAuthClients = shouldDisconnectSharedAuthClientsForConfigWrite({
+        prevConfig: snapshot.config,
+        nextConfig: validated.config,
+        preparedSecretsSnapshot,
+      });
+      let writeResult: ConfigWriteCommitResult | null;
+      if (hashlessPatch) {
+        try {
+          writeResult = await commitGatewayConfigWrite({
+            snapshot,
+            writeOptions,
+            nextConfig: writeConfig,
+            context,
+            disconnectSharedAuthClients,
+          });
+        } catch (error) {
+          if (!(error instanceof ConfigMutationConflictError)) {
+            throw error;
+          }
+          if (attempt + 1 < maxAttempts) {
+            continue;
+          }
+          respond(
+            false,
+            undefined,
+            errorShape(ErrorCodes.INVALID_REQUEST, `${error.message}; re-run config.get and retry`),
+          );
+          return;
+        }
+      } else {
+        writeResult = await commitGatewayConfigWriteOrRespond({
+          snapshot,
+          writeOptions,
+          nextConfig: writeConfig,
+          context,
+          disconnectSharedAuthClients,
+          respond,
+        });
+      }
+      if (!writeResult) {
+        return;
+      }
+      await respondWithConfigRestartWrite({
+        requestParams: params,
+        kind: "config-patch",
+        mode: "config.patch",
+        writeResult,
+        changedPaths,
         actor,
         context,
         respond,
+        uiHints: schemaPatch.uiHints,
+        preparedSecretsSnapshot,
       });
       return;
     }
-
-    context?.logGateway?.info(
-      `config.patch write ${formatControlPlaneActor(actor)} changedPaths=${summarizeChangedPaths(changedPaths)} restartReason=config.patch`,
-    );
-    // Compare before the write so we invalidate clients authenticated against the
-    // previous shared secret immediately after the config update succeeds.
-    const disconnectSharedAuthClients = shouldDisconnectSharedAuthClientsForConfigWrite({
-      prevConfig: snapshot.config,
-      nextConfig: validated.config,
-      preparedSecretsSnapshot,
-    });
-    const writeResult = await commitGatewayConfigWriteOrRespond({
-      snapshot,
-      writeOptions,
-      nextConfig: writeConfig,
-      context,
-      disconnectSharedAuthClients,
-      respond,
-    });
-    if (!writeResult) {
-      return;
-    }
-    await respondWithConfigRestartWrite({
-      requestParams: params,
-      kind: "config-patch",
-      mode: "config.patch",
-      writeResult,
-      changedPaths,
-      actor,
-      context,
-      respond,
-      uiHints: schemaPatch.uiHints,
-      preparedSecretsSnapshot,
-    });
   },
   "config.apply": async ({ params, respond, client, context }) => {
     if (!assertValidParams(params, validateConfigApplyParams, "config.apply", respond)) {

--- a/ui/src/app/app-host.test.ts
+++ b/ui/src/app/app-host.test.ts
@@ -469,6 +469,8 @@ describe("OpenClaw shell server preferences", () => {
       gateway: { connection: { gatewayUrl: "ws://sidebar.test" } },
       navigation: { update: updateNavigation },
       theme: { refresh: refreshTheme },
+      // reconcileServerUiPrefs only accepts the current context's capability.
+      runtimeConfig,
     } as unknown as ApplicationContext;
     const shell = document.createElement(
       "openclaw-app-shell",

--- a/ui/src/app/app-host.ts
+++ b/ui/src/app/app-host.ts
@@ -109,6 +109,7 @@ import { controlUiPublicAssetPath } from "./public-assets.ts";
 import {
   applyServerUiPrefs,
   changedServerUiPrefs,
+  flushServerUiPrefs,
   isApplyingServerUiPrefs,
   pushServerUiPrefs,
   resetServerUiPrefsSync,
@@ -680,12 +681,11 @@ class OpenClawShell extends OpenClawLightDomElement {
   private reconcileServerUiPrefs(runtimeConfig: ApplicationContext["runtimeConfig"]) {
     const snapshot = runtimeConfig.state.configSnapshot;
     const context = this.context;
-    if (!snapshot?.config || !context) {
+    if (!snapshot?.config || !context || context.runtimeConfig !== runtimeConfig) {
       return;
     }
     applyServerUiPrefs(snapshot.config, {
       scope: context.gateway.connection.gatewayUrl,
-      snapshotHash: snapshot.hash ?? undefined,
       onApplied: (patch) => {
         if (patch.sidebarEntries !== undefined) {
           context.navigation.update({ sidebarEntries: patch.sidebarEntries });
@@ -730,8 +730,15 @@ class OpenClawShell extends OpenClawLightDomElement {
       }
       const prefs = changedServerUiPrefs(previous, next);
       const snapshot = this.context?.gateway.snapshot;
-      if (prefs && snapshot?.phase === "connected" && snapshot.client) {
-        pushServerUiPrefs(snapshot.client, prefs);
+      if (prefs && snapshot?.client) {
+        pushServerUiPrefs(snapshot.client, prefs, {
+          afterCommit: () => {
+            const runtimeConfig = this.context?.runtimeConfig;
+            if (runtimeConfig) {
+              void runtimeConfig.refresh();
+            }
+          },
+        });
       }
     });
   }
@@ -1534,6 +1541,14 @@ class OpenClawShell extends OpenClawLightDomElement {
     }
     this.runtimeConfigClient = snapshot.client;
     this.runtimeConfigSource = runtimeConfig;
+    flushServerUiPrefs(snapshot.client, {
+      afterCommit: () => {
+        const currentRuntimeConfig = this.context?.runtimeConfig;
+        if (currentRuntimeConfig) {
+          void currentRuntimeConfig.refresh();
+        }
+      },
+    });
     void runtimeConfig.ensureLoaded();
   }
 

--- a/ui/src/app/server-prefs.test.ts
+++ b/ui/src/app/server-prefs.test.ts
@@ -5,6 +5,7 @@ import { createStorageMock } from "../test-helpers/storage.ts";
 import {
   applyServerUiPrefs,
   changedServerUiPrefs,
+  flushServerUiPrefs,
   pushServerUiPrefs,
   resetServerUiPrefsSync,
 } from "./server-prefs.ts";
@@ -218,171 +219,265 @@ describe("clearable pref removal from the server", () => {
 });
 
 describe("pushServerUiPrefs", () => {
-  it("patches config and marks the replaced hash so stale snapshots cannot revert", async () => {
-    const request = vi.fn(async (method: string) => {
-      if (method === "config.get") {
-        return { hash: "hash-1" };
-      }
-      return {};
+  type RequestMock = ReturnType<
+    typeof vi.fn<(method: string, params?: unknown) => Promise<unknown>>
+  >;
+  const deferred = () => {
+    let resolve!: (value: unknown) => void;
+    let reject!: (reason?: unknown) => void;
+    const promise = new Promise<unknown>((resolvePromise, rejectPromise) => {
+      resolve = resolvePromise;
+      reject = rejectPromise;
     });
-    const client = { request } as unknown as Parameters<typeof pushServerUiPrefs>[0];
+    return { promise, reject, resolve };
+  };
+  const pendingKey = (scope: string) => `openclaw.control.serverPrefs.pending.v1:${scope}`;
+  const lastSeenKey = (scope: string) => `openclaw.control.serverPrefs.v1:${scope}`;
+  const createClient = (request: RequestMock, gatewayUrl = "ws://gw", connected = true) =>
+    ({ request, gatewayUrl, connected }) as unknown as Parameters<typeof pushServerUiPrefs>[0];
 
-    pushServerUiPrefs(client, { themeMode: "dark" });
-    await vi.waitFor(() => {
-      expect(request).toHaveBeenCalledWith("config.patch", {
-        baseHash: "hash-1",
-        raw: JSON.stringify({ ui: { prefs: { themeMode: "dark" } } }),
-        note: "control-ui prefs sync",
-      });
+  it("sends one hash-free patch and acknowledges lastSeen plus pending", async () => {
+    const request = vi.fn<(method: string, params?: unknown) => Promise<unknown>>(async () => ({}));
+    const afterCommit = vi.fn();
+    const client = createClient(request);
+
+    pushServerUiPrefs(client, { themeMode: "dark" }, { afterCommit });
+    await vi.waitFor(() => expect(afterCommit).toHaveBeenCalledOnce());
+
+    expect(request).toHaveBeenCalledExactlyOnceWith("config.patch", {
+      raw: JSON.stringify({ ui: { prefs: { themeMode: "dark" } } }),
+      note: "control-ui prefs sync",
     });
-
-    // A snapshot still carrying the replaced hash predates the patch.
-    const onApplied = vi.fn();
-    patchSettings({ themeMode: "dark" });
-    expect(
-      applyServerUiPrefs(configWithPrefs({ themeMode: "light" }), {
-        snapshotHash: "hash-1",
-        onApplied,
-      }),
-    ).toBe(false);
-    expect(onApplied).not.toHaveBeenCalled();
-    expect(loadSettings().themeMode).toBe("dark");
-
-    // A post-patch snapshot (any other hash) stays authoritative.
-    expect(
-      applyServerUiPrefs(configWithPrefs({ themeMode: "system" }), {
-        snapshotHash: "hash-2",
-        onApplied,
-      }),
-    ).toBe(true);
-    expect(loadSettings().themeMode).toBe("system");
-
-    // Once post-patch state was observed, the old hash means another writer
-    // genuinely restored that config, so it becomes authoritative again.
-    expect(
-      applyServerUiPrefs(configWithPrefs({ themeMode: "light" }), {
-        snapshotHash: "hash-1",
-        onApplied,
-      }),
-    ).toBe(true);
-    expect(loadSettings().themeMode).toBe("light");
-  });
-
-  it("marks sidebar arrays for replacement when pinned entries are removed", async () => {
-    let hash = 0;
-    const request = vi.fn(async (method: string) => {
-      if (method === "config.get") {
-        return { hash: `hash-${hash}` };
-      }
-      hash += 1;
-      return {};
-    });
-    const client = { request } as unknown as Parameters<typeof pushServerUiPrefs>[0];
-    const sidebarEntries = ["route:usage", "session:agent:main:test"];
-
-    pushServerUiPrefs(client, { sidebarEntries });
-    await vi.waitFor(() => {
-      expect(request).toHaveBeenCalledWith("config.patch", {
-        baseHash: "hash-0",
-        raw: JSON.stringify({ ui: { prefs: { sidebarEntries } } }),
-        replacePaths: ["ui.prefs.sidebarEntries"],
-        note: "control-ui prefs sync",
-      });
-    });
-
-    const remainingEntries = ["route:usage"];
-    pushServerUiPrefs(client, { sidebarEntries: remainingEntries });
-    await vi.waitFor(() => {
-      expect(request).toHaveBeenCalledWith("config.patch", {
-        baseHash: "hash-1",
-        raw: JSON.stringify({ ui: { prefs: { sidebarEntries: remainingEntries } } }),
-        replacePaths: ["ui.prefs.sidebarEntries"],
-        note: "control-ui prefs sync",
-      });
+    expect(request.mock.calls.some(([method]) => method === "config.get")).toBe(false);
+    expect(localStorage.getItem(pendingKey("ws://gw"))).toBeNull();
+    expect(JSON.parse(localStorage.getItem(lastSeenKey("ws://gw")) ?? "{}")).toEqual({
+      themeMode: "dark",
     });
   });
 
-  it("coalesces rapid changes into serial patches instead of racing the hash", async () => {
-    let hash = 0;
-    const patched: unknown[] = [];
-    const request = vi.fn(async (method: string, params?: unknown) => {
-      if (method === "config.get") {
-        return { hash: `hash-${hash}` };
-      }
-      hash += 1;
-      patched.push((params as { raw: string }).raw);
-      return {};
-    });
-    const client = { request } as unknown as Parameters<typeof pushServerUiPrefs>[0];
-
-    pushServerUiPrefs(client, { themeMode: "dark" });
-    pushServerUiPrefs(client, { locale: "de" });
-    pushServerUiPrefs(client, { themeMode: "light" });
-
-    await vi.waitFor(() => {
-      expect(request.mock.calls.filter(([method]) => method === "config.patch").length).toBe(2);
-    });
-    // The first patch carries the first delta; the rest coalesce into one.
-    expect(patched[0]).toBe(JSON.stringify({ ui: { prefs: { themeMode: "dark" } } }));
-    expect(patched[1]).toBe(
-      JSON.stringify({ ui: { prefs: { locale: "de", themeMode: "light" } } }),
-    );
-  });
-
-  it("drops a stale gateway's queue instead of writing it to the next gateway", async () => {
-    let resolveFirstGet: ((value: { hash: string }) => void) | undefined;
-    const requestA = vi.fn(
-      (method: string) =>
-        new Promise((resolve) => {
-          if (method === "config.get") {
-            resolveFirstGet = resolve as (value: { hash: string }) => void;
-            return;
+  it("preserves a newer same-key edit across the older batch ack", async () => {
+    let resolveFirst: (() => void) | undefined;
+    const request = vi.fn<(method: string, params?: unknown) => Promise<unknown>>(
+      () =>
+        new Promise<unknown>((resolve) => {
+          if (request.mock.calls.length === 1) {
+            resolveFirst = () => resolve({});
+          } else {
+            resolve({});
           }
-          resolve({});
         }),
     );
-    const requestB = vi.fn(async (method: string) => {
-      if (method === "config.get") {
-        return { hash: "b-1" };
-      }
-      return {};
-    });
-    const clientA = { request: requestA } as unknown as Parameters<typeof pushServerUiPrefs>[0];
-    const clientB = { request: requestB } as unknown as Parameters<typeof pushServerUiPrefs>[0];
+    const client = createClient(request);
 
-    pushServerUiPrefs(clientA, { themeMode: "dark" });
-    pushServerUiPrefs(clientB, { locale: "de" });
-    resolveFirstGet?.({ hash: "a-1" });
+    pushServerUiPrefs(client, { themeMode: "dark" });
+    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(1));
+    pushServerUiPrefs(client, { themeMode: "light" });
+    resolveFirst?.();
 
-    await vi.waitFor(() => {
-      expect(requestB.mock.calls.filter(([method]) => method === "config.patch").length).toBe(1);
-    });
-    // Gateway A's drain saw the client switch and never patched.
-    expect(requestA.mock.calls.filter(([method]) => method === "config.patch").length).toBe(0);
-    expect(requestB).toHaveBeenCalledWith("config.patch", {
-      baseHash: "b-1",
-      raw: JSON.stringify({ ui: { prefs: { locale: "de" } } }),
+    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2));
+    expect(request.mock.calls[1]?.[1]).toEqual({
+      raw: JSON.stringify({ ui: { prefs: { themeMode: "light" } } }),
       note: "control-ui prefs sync",
     });
   });
 
-  it("retries once on a hash conflict and gives up silently otherwise", async () => {
-    let patchCalls = 0;
-    const request = vi.fn(async (method: string) => {
-      if (method === "config.get") {
-        return { hash: `hash-${patchCalls}` };
-      }
-      patchCalls += 1;
-      if (patchCalls === 1) {
-        throw new Error("config baseHash mismatch");
-      }
-      return {};
+  it("retains a failed offline push and flushes it after reconnect", async () => {
+    const request = vi.fn<(method: string, params?: unknown) => Promise<unknown>>(async () => {
+      throw new Error("socket closed");
     });
-    const client = { request } as unknown as Parameters<typeof pushServerUiPrefs>[0];
+    const clientState = { request, gatewayUrl: "ws://gw", connected: false };
+    const client = clientState as unknown as Parameters<typeof pushServerUiPrefs>[0];
 
     pushServerUiPrefs(client, { locale: "de" });
-    await vi.waitFor(() => {
-      expect(patchCalls).toBe(2);
+    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(1));
+    expect(JSON.parse(localStorage.getItem(pendingKey("ws://gw")) ?? "{}")).toEqual({
+      locale: "de",
     });
+
+    clientState.connected = true;
+    request.mockResolvedValue({});
+    flushServerUiPrefs(client);
+    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2));
+    expect(localStorage.getItem(pendingKey("ws://gw"))).toBeNull();
+  });
+
+  it("supersedes a hung prior-connection request on same-client flush", async () => {
+    let calls = 0;
+    const request = vi.fn<(method: string, params?: unknown) => Promise<unknown>>(() => {
+      calls += 1;
+      return calls === 1 ? new Promise<unknown>(() => {}) : Promise.resolve({});
+    });
+    const client = createClient(request);
+
+    pushServerUiPrefs(client, { locale: "de" });
+    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+    flushServerUiPrefs(client);
+
+    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2));
+    await vi.waitFor(() => expect(localStorage.getItem(pendingKey("ws://gw"))).toBeNull());
+  });
+
+  it("ignores a superseded request rejection while its replacement is pending", async () => {
+    const first = deferred();
+    const second = deferred();
+    let calls = 0;
+    const request = vi.fn<(method: string, params?: unknown) => Promise<unknown>>(() => {
+      calls += 1;
+      return calls === 1 ? first.promise : second.promise;
+    });
+    const client = createClient(request);
+
+    pushServerUiPrefs(client, { locale: "de" });
+    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+    flushServerUiPrefs(client);
+    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2));
+    first.reject(new Error("socket closed"));
+    await Promise.resolve();
+
+    expect(localStorage.getItem(pendingKey("ws://gw"))).not.toBeNull();
+    second.resolve({});
+    await vi.waitFor(() => expect(localStorage.getItem(pendingKey("ws://gw"))).toBeNull());
+  });
+
+  it("keeps pending shadow active during the post-commit refresh hook", async () => {
+    const request = vi.fn<(method: string, params?: unknown) => Promise<unknown>>(async () => ({}));
+    const client = createClient(request);
+    patchSettings({ themeMode: "dark" });
+    const onApplied = vi.fn();
+
+    pushServerUiPrefs(
+      client,
+      { themeMode: "dark" },
+      {
+        afterCommit: () => {
+          applyServerUiPrefs(configWithPrefs({ themeMode: "light" }), {
+            scope: "ws://gw",
+            onApplied,
+          });
+        },
+      },
+    );
+    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+    await vi.waitFor(() => expect(localStorage.getItem(pendingKey("ws://gw"))).toBeNull());
+
+    expect(onApplied).not.toHaveBeenCalled();
+    expect(loadSettings().themeMode).toBe("dark");
+  });
+
+  it("lets pending local intent shadow only its own server key", async () => {
+    let resolveRequest: (() => void) | undefined;
+    const request = vi.fn<(method: string, params?: unknown) => Promise<unknown>>(
+      () =>
+        new Promise<unknown>((resolve) => {
+          resolveRequest = () => resolve({});
+        }),
+    );
+    const client = createClient(request);
+    patchSettings({ themeMode: "dark" });
+    pushServerUiPrefs(client, { themeMode: "dark" });
+
+    const onApplied = vi.fn();
+    expect(
+      applyServerUiPrefs(configWithPrefs({ themeMode: "light", locale: "de" }), {
+        scope: "ws://gw",
+        onApplied,
+      }),
+    ).toBe(true);
+    expect(onApplied).toHaveBeenCalledWith({ locale: "de" });
+    expect(loadSettings().themeMode).toBe("dark");
+    resolveRequest?.();
+  });
+
+  it("does not let another scope's reconcile replace an active drain's pending state", async () => {
+    let resolveRequest: (() => void) | undefined;
+    const request = vi.fn<(method: string, params?: unknown) => Promise<unknown>>(
+      () =>
+        new Promise<unknown>((resolve) => {
+          resolveRequest = () => resolve({});
+        }),
+    );
+    const client = createClient(request, "ws://a");
+    localStorage.setItem(pendingKey("ws://b"), JSON.stringify({ locale: "de" }));
+
+    pushServerUiPrefs(client, { themeMode: "dark" });
+    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+    applyServerUiPrefs(configWithPrefs({ themeMode: "light", locale: "fr" }), {
+      scope: "ws://b",
+      onApplied: vi.fn(),
+    });
+    resolveRequest?.();
+
+    await vi.waitFor(() => expect(localStorage.getItem(pendingKey("ws://a"))).toBeNull());
+    expect(JSON.parse(localStorage.getItem(pendingKey("ws://b")) ?? "{}")).toEqual({
+      locale: "de",
+    });
+  });
+
+  it("retries one conflict then retains pending, but drops validation failures", async () => {
+    vi.useFakeTimers();
+    const conflictRequest = vi.fn<(method: string, params?: unknown) => Promise<unknown>>(
+      async () => {
+        throw new Error("config changed since last load; re-run config.get and retry");
+      },
+    );
+    pushServerUiPrefs(createClient(conflictRequest), { locale: "de" });
+    await vi.advanceTimersByTimeAsync(250);
+    expect(conflictRequest).toHaveBeenCalledTimes(2);
+    expect(localStorage.getItem(pendingKey("ws://gw"))).not.toBeNull();
+
+    resetServerUiPrefsSync();
+    localStorage.clear();
+    const validationRequest = vi.fn<(method: string, params?: unknown) => Promise<unknown>>(
+      async () => {
+        throw new Error("invalid config");
+      },
+    );
+    pushServerUiPrefs(createClient(validationRequest), { locale: "de" });
+    await vi.waitFor(() => expect(validationRequest).toHaveBeenCalledOnce());
+    await vi.waitFor(() => expect(localStorage.getItem(pendingKey("ws://gw"))).toBeNull());
+  });
+
+  it("marks sidebar arrays for replacement", async () => {
+    const request = vi.fn<(method: string, params?: unknown) => Promise<unknown>>(async () => ({}));
+    const sidebarEntries = ["route:usage"];
+
+    pushServerUiPrefs(createClient(request), { sidebarEntries });
+    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+
+    expect(request).toHaveBeenCalledWith("config.patch", {
+      raw: JSON.stringify({ ui: { prefs: { sidebarEntries } } }),
+      replacePaths: ["ui.prefs.sidebarEntries"],
+      note: "control-ui prefs sync",
+    });
+  });
+
+  it("persists pending per scope and reloads only the adopted scope", async () => {
+    const offlineRequest = vi.fn<(method: string, params?: unknown) => Promise<unknown>>(
+      async () => {
+        throw new Error("offline");
+      },
+    );
+    pushServerUiPrefs(createClient(offlineRequest, "ws://a", false), { themeMode: "dark" });
+    await vi.waitFor(() => expect(offlineRequest).toHaveBeenCalledTimes(1));
+    pushServerUiPrefs(createClient(offlineRequest, "ws://b", false), { locale: "de" });
+    await vi.waitFor(() => expect(offlineRequest).toHaveBeenCalledTimes(2));
+
+    expect(JSON.parse(localStorage.getItem(pendingKey("ws://a")) ?? "{}")).toEqual({
+      themeMode: "dark",
+    });
+    expect(JSON.parse(localStorage.getItem(pendingKey("ws://b")) ?? "{}")).toEqual({
+      locale: "de",
+    });
+
+    resetServerUiPrefsSync();
+    const replayRequest = vi.fn<(method: string, params?: unknown) => Promise<unknown>>(
+      async () => ({}),
+    );
+    flushServerUiPrefs(createClient(replayRequest, "ws://b"));
+    await vi.waitFor(() => expect(replayRequest).toHaveBeenCalledOnce());
+    expect(replayRequest.mock.calls[0]?.[1]).toMatchObject({
+      raw: JSON.stringify({ ui: { prefs: { locale: "de" } } }),
+    });
+    expect(localStorage.getItem(pendingKey("ws://a"))).not.toBeNull();
   });
 });

--- a/ui/src/app/server-prefs.test.ts
+++ b/ui/src/app/server-prefs.test.ts
@@ -295,6 +295,8 @@ describe("pushServerUiPrefs", () => {
   };
   const pendingKey = (scope: string) => `openclaw.control.serverPrefs.pending.v1:${scope}`;
   const lastSeenKey = (scope: string) => `openclaw.control.serverPrefs.v1:${scope}`;
+  const readPending = (scope: string) =>
+    JSON.parse(localStorage.getItem(pendingKey(scope)) ?? "{}") as Record<string, unknown>;
   const createClient = (request: RequestMock, gatewayUrl = "ws://gw", connected = true) =>
     ({ request, gatewayUrl, connected }) as unknown as Parameters<typeof pushServerUiPrefs>[0];
 
@@ -315,6 +317,67 @@ describe("pushServerUiPrefs", () => {
     expect(JSON.parse(localStorage.getItem(lastSeenKey("ws://gw")) ?? "{}")).toEqual({
       themeMode: "dark",
     });
+  });
+
+  it("merges this tab's edit with sibling persisted pending keys", () => {
+    const scope = "ws://gw";
+    const flight = deferred();
+    const request = vi.fn<(method: string, params?: unknown) => Promise<unknown>>(
+      () => flight.promise,
+    );
+    const client = createClient(request, scope);
+    flushServerUiPrefs(client);
+    localStorage.setItem(pendingKey(scope), JSON.stringify({ locale: "fr" }));
+
+    pushServerUiPrefs(client, { theme: "knot" });
+
+    expect(readPending(scope)).toEqual({ locale: "fr", theme: "knot" });
+  });
+
+  it("settles only this tab's acknowledged keys from sibling persisted pending", async () => {
+    const scope = "ws://gw";
+    const flight = deferred();
+    const request = vi.fn<(method: string, params?: unknown) => Promise<unknown>>(
+      () => flight.promise,
+    );
+    const client = createClient(request, scope);
+    flushServerUiPrefs(client);
+    localStorage.setItem(pendingKey(scope), JSON.stringify({ locale: "fr" }));
+    pushServerUiPrefs(client, { theme: "knot" });
+    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+
+    flight.resolve({});
+
+    await vi.waitFor(() => expect(readPending(scope)).toEqual({ locale: "fr" }));
+  });
+
+  it("drops only this tab's validation-rejected keys from persisted pending", async () => {
+    const scope = "ws://gw";
+    const request = vi.fn<(method: string, params?: unknown) => Promise<unknown>>(async () => {
+      throw new Error("invalid config");
+    });
+    const client = createClient(request, scope);
+    flushServerUiPrefs(client);
+    localStorage.setItem(pendingKey(scope), JSON.stringify({ locale: "fr" }));
+
+    pushServerUiPrefs(client, { theme: "knot" });
+
+    await vi.waitFor(() => expect(readPending(scope)).toEqual({ locale: "fr" }));
+  });
+
+  it("overwrites only a same-key sibling value when this tab persists later", () => {
+    const scope = "ws://gw";
+    const flight = deferred();
+    const request = vi.fn<(method: string, params?: unknown) => Promise<unknown>>(
+      () => flight.promise,
+    );
+    const client = createClient(request, scope);
+    flushServerUiPrefs(client);
+    localStorage.setItem(pendingKey(scope), JSON.stringify({ locale: "fr", themeMode: "light" }));
+
+    pushServerUiPrefs(client, { themeMode: "dark" });
+
+    expect(readPending(scope)).toEqual({ locale: "fr", themeMode: "dark" });
   });
 
   it("preserves a newer same-key edit across the older batch ack", async () => {

--- a/ui/src/app/server-prefs.test.ts
+++ b/ui/src/app/server-prefs.test.ts
@@ -88,6 +88,66 @@ describe("applyServerUiPrefs", () => {
     expect(loadSettings().themeMode).toBe("light");
   });
 
+  it("does not reapply a retained pre-commit snapshot after an ack moves lastSeen", async () => {
+    const scope = "ws://gw";
+    const oldSnapshot = configWithPrefs({ themeMode: "light" });
+    const onApplied = vi.fn();
+    applyServerUiPrefs(oldSnapshot, { scope, onApplied });
+    patchSettings({ themeMode: "dark" });
+    const request = vi.fn(async () => ({}));
+    const client = { connected: true, gatewayUrl: scope, request } as unknown as Parameters<
+      typeof pushServerUiPrefs
+    >[0];
+
+    pushServerUiPrefs(client, { themeMode: "dark" });
+    await vi.waitFor(() =>
+      expect(localStorage.getItem(`openclaw.control.serverPrefs.pending.v1:${scope}`)).toBeNull(),
+    );
+
+    expect(applyServerUiPrefs(oldSnapshot, { scope, onApplied })).toBe(false);
+    expect(loadSettings().themeMode).toBe("dark");
+  });
+
+  it("treats a new object with old content after ack as a genuine LWW restore", async () => {
+    const scope = "ws://gw";
+    const oldSnapshot = configWithPrefs({ themeMode: "light" });
+    const onApplied = vi.fn();
+    applyServerUiPrefs(oldSnapshot, { scope, onApplied });
+    patchSettings({ themeMode: "dark" });
+    const request = vi.fn(async () => ({}));
+    const client = { connected: true, gatewayUrl: scope, request } as unknown as Parameters<
+      typeof pushServerUiPrefs
+    >[0];
+    pushServerUiPrefs(client, { themeMode: "dark" });
+    await vi.waitFor(() =>
+      expect(localStorage.getItem(`openclaw.control.serverPrefs.pending.v1:${scope}`)).toBeNull(),
+    );
+
+    // A new post-bump snapshot object represents a genuine foreign restore and is LWW-correct.
+    expect(applyServerUiPrefs(configWithPrefs({ themeMode: "light" }), { scope, onApplied })).toBe(
+      true,
+    );
+    expect(loadSettings().themeMode).toBe("light");
+  });
+
+  it("clears the retained-object memo on reset", () => {
+    const scope = "ws://memo";
+    const snapshot = configWithPrefs({ themeMode: "dark" });
+    const onApplied = vi.fn();
+    expect(applyServerUiPrefs(snapshot, { scope, onApplied })).toBe(true);
+    patchSettings({ themeMode: "light" });
+    localStorage.setItem(
+      `openclaw.control.serverPrefs.v1:${scope}`,
+      JSON.stringify({ themeMode: "light" }),
+    );
+    expect(applyServerUiPrefs(snapshot, { scope, onApplied })).toBe(false);
+
+    resetServerUiPrefsSync();
+
+    expect(applyServerUiPrefs(snapshot, { scope, onApplied })).toBe(true);
+    expect(loadSettings().themeMode).toBe("dark");
+  });
+
   it("keeps an unpushed local edit across a sync reset (reload/reconnect)", () => {
     const onApplied = vi.fn();
     const config = configWithPrefs({ themeMode: "dark" });

--- a/ui/src/app/server-prefs.test.ts
+++ b/ui/src/app/server-prefs.test.ts
@@ -17,6 +17,8 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  resetServerUiPrefsSync();
+  vi.useRealTimers();
   vi.unstubAllGlobals();
 });
 
@@ -435,6 +437,81 @@ describe("pushServerUiPrefs", () => {
     pushServerUiPrefs(createClient(validationRequest), { locale: "de" });
     await vi.waitFor(() => expect(validationRequest).toHaveBeenCalledOnce());
     await vi.waitFor(() => expect(localStorage.getItem(pendingKey("ws://gw"))).toBeNull());
+  });
+
+  it("re-drains pending intent after a twice-conflicting batch", async () => {
+    vi.useFakeTimers();
+    let calls = 0;
+    const request = vi.fn<(method: string, params?: unknown) => Promise<unknown>>(async () => {
+      calls += 1;
+      if (calls <= 2) {
+        throw new Error("config changed since last load; re-run config.get and retry");
+      }
+      return {};
+    });
+
+    pushServerUiPrefs(createClient(request), { locale: "de" });
+    await vi.advanceTimersByTimeAsync(250);
+    expect(request).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(999);
+    expect(request).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(request).toHaveBeenCalledTimes(3);
+    expect(localStorage.getItem(pendingKey("ws://gw"))).toBeNull();
+  });
+
+  it("cancels a conflict re-drain when flush or reset supersedes its epoch", async () => {
+    vi.useFakeTimers();
+    let calls = 0;
+    const request = vi.fn<(method: string, params?: unknown) => Promise<unknown>>(async () => {
+      calls += 1;
+      if (calls <= 2) {
+        throw new Error("config changed since last load; re-run config.get and retry");
+      }
+      return {};
+    });
+    const client = createClient(request);
+
+    pushServerUiPrefs(client, { locale: "de" });
+    await vi.advanceTimersByTimeAsync(250);
+    flushServerUiPrefs(client);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(request).toHaveBeenCalledTimes(3);
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(request).toHaveBeenCalledTimes(3);
+
+    resetServerUiPrefsSync();
+    localStorage.clear();
+    const conflicting = vi.fn<(method: string, params?: unknown) => Promise<unknown>>(async () => {
+      throw new Error("config changed since last load; re-run config.get and retry");
+    });
+    pushServerUiPrefs(createClient(conflicting), { locale: "fr" });
+    await vi.advanceTimersByTimeAsync(250);
+    expect(conflicting).toHaveBeenCalledTimes(2);
+    resetServerUiPrefsSync();
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(conflicting).toHaveBeenCalledTimes(2);
+  });
+
+  it("caps conflict-triggered re-drains at five", async () => {
+    vi.useFakeTimers();
+    const request = vi.fn<(method: string, params?: unknown) => Promise<unknown>>(async () => {
+      throw new Error("config changed since last load; re-run config.get and retry");
+    });
+
+    pushServerUiPrefs(createClient(request), { locale: "de" });
+    for (let round = 0; round <= 5; round += 1) {
+      await vi.advanceTimersByTimeAsync(250);
+      expect(request).toHaveBeenCalledTimes((round + 1) * 2);
+      if (round < 5) {
+        await vi.advanceTimersByTimeAsync(1_000);
+      }
+    }
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    expect(request).toHaveBeenCalledTimes(12);
+    expect(localStorage.getItem(pendingKey("ws://gw"))).not.toBeNull();
   });
 
   it("marks sidebar arrays for replacement", async () => {

--- a/ui/src/app/server-prefs.ts
+++ b/ui/src/app/server-prefs.ts
@@ -1,10 +1,4 @@
-// Server-side operator display prefs (config ui.prefs) with a browser-local
-// mirror. The config value is canonical — agents change it through the
-// approval gate and other devices pick it up — while localStorage keeps
-// instant boot and stays authoritative when this client cannot write config
-// (viewer scope, offline). Sync policy: a server-side *change* wins over the
-// local mirror; an unchanged server value never reverts local edits, so a
-// failed push degrades to device-local behavior instead of flip-flopping.
+// Server ui.prefs is canonical; pending local intent shadows snapshots until hash-free LWW ack.
 import { asNullableRecord as asRecord } from "@openclaw/normalization-core/record-coerce";
 import type { GatewayBrowserClient } from "../api/gateway.ts";
 import { normalizeSidebarEntries } from "../app-navigation.ts";
@@ -19,39 +13,25 @@ import {
   type UiSettings,
 } from "./settings.ts";
 import type { ThemeMode, ThemeName } from "./theme.ts";
-
 const THEMES: ReadonlySet<ThemeName> = new Set(["claw", "knot", "dash", "custom"]);
 const THEME_MODES: ReadonlySet<ThemeMode> = new Set(["light", "dark", "system"]);
-
-/**
- * One descriptor per synced pref — the single source of truth for what syncs
- * through config ui.prefs. Each key defines how to validate the server value,
- * read the normalized local value, and (optionally) whether a server value is
- * applicable on this device. `clearable` keys push an explicit JSON null when
- * unset locally so the merge patch removes them server-side.
- */
 type SyncedPrefSpec<T> = {
   extract: (value: unknown) => T | undefined;
   local: (settings: UiSettings) => T | undefined;
   canApply?: (value: T, settings: UiSettings) => boolean;
   clearable?: boolean;
 };
-
 const prefSpec = <T>(specification: SyncedPrefSpec<T>) => specification;
-
 function prefValuesEqual(left: unknown, right: unknown): boolean {
   if (Array.isArray(left) && Array.isArray(right)) {
     return left.length === right.length && left.every((value, index) => value === right[index]);
   }
   return left === right;
 }
-
 const SYNCED_PREFS = {
   theme: prefSpec<ThemeName>({
     extract: (value) => (THEMES.has(value as ThemeName) ? (value as ThemeName) : undefined),
     local: (settings) => settings.theme,
-    // A server "custom" theme is only honorable once this browser imported
-    // one; the imported palette itself is too large to live in config.
     canApply: (value, settings) => value !== "custom" || Boolean(settings.customTheme),
   }),
   themeMode: prefSpec<ThemeMode>({
@@ -84,8 +64,6 @@ const SYNCED_PREFS = {
   chatFollowUpMode: prefSpec<ChatFollowUpMode>({
     extract: (value) => normalizeChatFollowUpModeOverride(value),
     local: (settings) => normalizeChatFollowUpModeOverride(settings.chatFollowUpMode),
-    // Unset means "use the server-configured queue mode"; clearing must
-    // propagate, so the push serializes an explicit null removal.
     clearable: true,
   }),
   sidebarEntries: prefSpec<string[]>({
@@ -97,15 +75,11 @@ const SYNCED_PREFS = {
     local: (settings) => settings.showAdvancedSettings === true,
   }),
 } as const;
-
 type SyncedPrefKey = keyof typeof SYNCED_PREFS;
 type SyncedPrefValue<K extends SyncedPrefKey> =
   ReturnType<(typeof SYNCED_PREFS)[K]["extract"]> extends (infer T) | undefined ? T : never;
-
 type ServerUiPrefs = { [K in SyncedPrefKey]?: SyncedPrefValue<K> | null };
-
 const SYNCED_PREF_KEYS = Object.keys(SYNCED_PREFS) as SyncedPrefKey[];
-
 function extractServerUiPrefs(configObject: unknown): ServerUiPrefs {
   const prefs = asRecord(asRecord(asRecord(configObject)?.ui)?.prefs);
   if (!prefs) {
@@ -120,7 +94,6 @@ function extractServerUiPrefs(configObject: unknown): ServerUiPrefs {
   }
   return result;
 }
-
 /** Local-settings patch that would bring the mirror in line with the server. */
 function serverPrefsLocalPatch(
   prefs: ServerUiPrefs,
@@ -133,8 +106,6 @@ function serverPrefsLocalPatch(
     if (serverValue === undefined) {
       continue;
     }
-    // Null marks a server-side removal of a clearable key: drop the local
-    // override so this device falls back to the server-configured behavior.
     if (serverValue === null) {
       if (specification.clearable && specification.local(settings) !== undefined) {
         (patch as Record<string, unknown>)[key] = undefined;
@@ -157,7 +128,6 @@ function serverPrefsLocalPatch(
   }
   return Object.keys(patch).length > 0 ? patch : null;
 }
-
 /** Synced-key delta between two local settings snapshots, for the push path. */
 export function changedServerUiPrefs(previous: UiSettings, next: UiSettings): ServerUiPrefs | null {
   const prefs: ServerUiPrefs = {};
@@ -169,7 +139,6 @@ export function changedServerUiPrefs(previous: UiSettings, next: UiSettings): Se
       continue;
     }
     if (nextValue === undefined) {
-      // JSON merge patch removes keys via explicit null.
       if (specification.clearable) {
         (prefs as Record<string, unknown>)[key] = null;
       }
@@ -179,105 +148,93 @@ export function changedServerUiPrefs(previous: UiSettings, next: UiSettings): Se
   }
   return Object.keys(prefs).length > 0 ? prefs : null;
 }
-
-// Last server value this client reconciled against, persisted per gateway
-// scope. Applying only on a server *delta* keeps an unpushable local edit
-// (viewer scope) from being reverted by every later snapshot — including the
-// first snapshot after a reload or reconnect — carrying the same old value.
-const LAST_SEEN_STORAGE_KEY = "openclaw.control.serverPrefs.v1";
-
-let lastSeenScope = "";
-let lastSeenServerPrefsKey: string | null = null;
-// Config hashes our patches replaced. A snapshot still carrying one of these
-// hashes was fetched before the patch landed; applying it would revert the
-// pushed value as if the server had changed it back. CAS guarantees the
-// replaced config had exactly the base hash, so this check is precise.
-const staleConfigHashes = new Set<string>();
-const STALE_CONFIG_HASH_LIMIT = 8;
+const LAST_SEEN_KEY = "openclaw.control.serverPrefs.v1";
+const PENDING_KEY = "openclaw.control.serverPrefs.pending.v1";
 let applyingServerPrefs = false;
-
-function loadLastSeenKey(scope: string): string | null {
-  if (scope !== lastSeenScope) {
-    lastSeenScope = scope;
-    try {
-      lastSeenServerPrefsKey = globalThis.localStorage?.getItem(
-        `${LAST_SEEN_STORAGE_KEY}:${scope}`,
-      );
-    } catch {
-      lastSeenServerPrefsKey = null;
-    }
-  }
-  return lastSeenServerPrefsKey;
-}
-
-function storeLastSeenKey(scope: string, key: string) {
-  lastSeenScope = scope;
-  lastSeenServerPrefsKey = key;
+let pendingScope = "";
+let pendingPrefs: ServerUiPrefs | null = null;
+let pushClient: GatewayBrowserClient | null = null;
+let pushAfterCommit: (() => void) | undefined;
+let pushDraining = false;
+let drainRequested = false;
+let pushEpoch = 0;
+function readStorage(root: string, scope: string): string | null {
   try {
-    globalThis.localStorage?.setItem(`${LAST_SEEN_STORAGE_KEY}:${scope}`, key);
+    return globalThis.localStorage?.getItem(`${root}:${scope}`) ?? null;
   } catch {
-    // Quota/security failures degrade to in-memory tracking for this session.
+    return null;
   }
 }
-
-export function resetServerUiPrefsSync() {
-  lastSeenScope = "";
-  lastSeenServerPrefsKey = null;
-  staleConfigHashes.clear();
-  applyingServerPrefs = false;
-  queuedClient = null;
-  queuedPrefs = null;
-  pushDraining = false;
+function writeStorage(root: string, scope: string, value: string | null): void {
+  try {
+    const key = `${root}:${scope}`;
+    if (value === null) {
+      globalThis.localStorage?.removeItem(key);
+    } else {
+      globalThis.localStorage?.setItem(key, value);
+    }
+  } catch {}
 }
-
+function parseStoredPrefs(raw: string | null): ServerUiPrefs | null {
+  try {
+    const prefs = asRecord(JSON.parse(raw ?? "null"));
+    return prefs && Object.keys(prefs).length ? (prefs as ServerUiPrefs) : null;
+  } catch {
+    return null;
+  }
+}
+function adoptPendingScope(scope: string, force = false): void {
+  if (!force && scope === pendingScope) {
+    return;
+  }
+  pendingScope = scope;
+  pendingPrefs = parseStoredPrefs(readStorage(PENDING_KEY, scope));
+}
+function persistPendingPrefs(): void {
+  const value = pendingPrefs ? JSON.stringify(pendingPrefs) : null;
+  writeStorage(PENDING_KEY, pendingScope, value);
+}
+export function resetServerUiPrefsSync() {
+  applyingServerPrefs = pushDraining = drainRequested = false;
+  pendingScope = "";
+  pendingPrefs = pushClient = null;
+}
 export function applyServerUiPrefs(
   configObject: unknown,
   hooks: {
     scope?: string;
-    snapshotHash?: string;
     onApplied: (patch: Partial<UiSettings>) => void;
   },
 ): boolean {
-  if (hooks.snapshotHash) {
-    if (staleConfigHashes.has(hooks.snapshotHash)) {
-      return false;
-    }
-    // Post-patch state observed: retire the stale marks. Hashes identify
-    // content, not age — if the pre-patch hash reappears later, another
-    // writer genuinely restored that config and it is authoritative again.
-    staleConfigHashes.clear();
-  }
   const scope = hooks.scope ?? "";
+  const shadowPrefs =
+    scope === pendingScope ? pendingPrefs : parseStoredPrefs(readStorage(PENDING_KEY, scope));
   const prefs = extractServerUiPrefs(configObject);
   const key = JSON.stringify(prefs);
-  const lastSeenRaw = loadLastSeenKey(scope);
+  const lastSeenRaw = readStorage(LAST_SEEN_KEY, scope);
   if (key === lastSeenRaw) {
     return false;
   }
-  // Apply per field: only keys whose *server* value changed since last seen.
-  // Reapplying unchanged fields would revert unpushable local edits on other
-  // keys whenever any one server field moves.
-  let lastSeen: ServerUiPrefs;
-  try {
-    lastSeen = lastSeenRaw ? (JSON.parse(lastSeenRaw) as ServerUiPrefs) : {};
-  } catch {
-    lastSeen = {};
-  }
+  const lastSeen = parseStoredPrefs(lastSeenRaw) ?? {};
   const changed: ServerUiPrefs = {};
   for (const prefKey of Object.keys(prefs) as Array<keyof ServerUiPrefs>) {
-    if (lastSeenRaw === null || !prefValuesEqual(prefs[prefKey], lastSeen[prefKey])) {
+    if (
+      !(shadowPrefs && prefKey in shadowPrefs) &&
+      (lastSeenRaw === null || !prefValuesEqual(prefs[prefKey], lastSeen[prefKey]))
+    ) {
       (changed as Record<string, unknown>)[prefKey] = prefs[prefKey];
     }
   }
-  // A clearable key that disappeared from the server was removed by another
-  // writer; surface the removal as an explicit null so the local override
-  // clears too (non-clearable keys keep their device-local value).
   for (const prefKey of Object.keys(lastSeen) as Array<keyof ServerUiPrefs>) {
-    if (!(prefKey in prefs) && SYNCED_PREFS[prefKey]?.clearable) {
+    if (
+      !(prefKey in prefs) &&
+      !(shadowPrefs && prefKey in shadowPrefs) &&
+      SYNCED_PREFS[prefKey]?.clearable
+    ) {
       (changed as Record<string, unknown>)[prefKey] = null;
     }
   }
-  storeLastSeenKey(scope, key);
+  writeStorage(LAST_SEEN_KEY, scope, key);
   const patch = serverPrefsLocalPatch(changed, loadSettings());
   if (!patch) {
     return false;
@@ -291,83 +248,124 @@ export function applyServerUiPrefs(
   hooks.onApplied(patch);
   return true;
 }
-
 export function isApplyingServerUiPrefs(): boolean {
   return applyingServerPrefs;
 }
-
-// Pending deltas coalesce into one object and drain serially, so rapid
-// changes cannot race each other's CAS hash and silently drop an update. The
-// queue is bound to one gateway client; switching gateways drops undelivered
-// deltas for the old one (they stay device-local, per the sync contract).
-let queuedClient: GatewayBrowserClient | null = null;
-let queuedPrefs: ServerUiPrefs | null = null;
-let pushDraining = false;
-
-async function drainPrefsQueue(client: GatewayBrowserClient): Promise<void> {
-  while (queuedPrefs) {
-    // The awaits below can outlive a gateway switch; a superseded drain stops
-    // instead of writing one gateway's prefs to another.
-    if (queuedClient !== client) {
+function adoptPushClient(client: GatewayBrowserClient): void {
+  if (pushClient === client) {
+    return;
+  }
+  pushEpoch += 1;
+  pushClient = client;
+  pushDraining = false;
+  adoptPendingScope(client.gatewayUrl, true);
+}
+function removeBatch(batch: ServerUiPrefs): void {
+  if (!pendingPrefs) {
+    return;
+  }
+  for (const key of Object.keys(batch) as SyncedPrefKey[]) {
+    if (prefValuesEqual(pendingPrefs[key], batch[key])) {
+      delete pendingPrefs[key];
+    }
+  }
+  if (!Object.keys(pendingPrefs).length) {
+    pendingPrefs = null;
+  }
+}
+async function drainPendingPrefs(client: GatewayBrowserClient, epoch: number): Promise<void> {
+  while (pendingPrefs) {
+    if (pushClient !== client || pushEpoch !== epoch) {
       return;
     }
-    const prefs = queuedPrefs;
-    queuedPrefs = null;
+    const batch = { ...pendingPrefs };
+    const afterCommit = pushAfterCommit;
     for (let attempt = 0; attempt < 2; attempt += 1) {
-      const snapshot = (await client.request("config.get", {})) as { hash?: string } | null;
-      const baseHash = snapshot?.hash;
-      if (!baseHash || queuedClient !== client) {
+      if (pushClient !== client || pushEpoch !== epoch) {
         return;
       }
       try {
-        const replacePaths = prefs.sidebarEntries !== undefined ? ["ui.prefs.sidebarEntries"] : [];
         await client.request("config.patch", {
-          baseHash,
-          raw: JSON.stringify({ ui: { prefs } }),
-          ...(replacePaths.length > 0 ? { replacePaths } : {}),
+          raw: JSON.stringify({ ui: { prefs: batch } }),
+          ...(batch.sidebarEntries !== undefined
+            ? { replacePaths: ["ui.prefs.sidebarEntries"] }
+            : {}),
           note: "control-ui prefs sync",
         });
-        staleConfigHashes.add(baseHash);
-        if (staleConfigHashes.size > STALE_CONFIG_HASH_LIMIT) {
-          const oldest = staleConfigHashes.values().next().value;
-          if (oldest !== undefined) {
-            staleConfigHashes.delete(oldest);
-          }
+        if (pushClient !== client || pushEpoch !== epoch) {
+          return;
         }
+        // Start refresh while pending still shadows the pre-commit snapshot published by load.
+        afterCommit?.();
+        if (pushClient !== client || pushEpoch !== epoch) {
+          return;
+        }
+        removeBatch(batch);
+        const lastSeen = parseStoredPrefs(readStorage(LAST_SEEN_KEY, pendingScope)) ?? {};
+        writeStorage(LAST_SEEN_KEY, pendingScope, JSON.stringify({ ...lastSeen, ...batch }));
+        persistPendingPrefs();
         break;
       } catch (error) {
-        if (attempt === 0 && String(error).toLowerCase().includes("hash")) {
+        if (pushClient !== client || pushEpoch !== epoch) {
+          return;
+        }
+        const conflict = String(error).includes("config changed since last load");
+        if (conflict && attempt === 0) {
+          await new Promise<void>((resolve) => {
+            setTimeout(resolve, 250);
+          });
           continue;
         }
+        if (conflict || !client.connected) {
+          return;
+        }
+        removeBatch(batch);
+        persistPendingPrefs();
         return;
       }
     }
   }
 }
-
-/**
- * Best-effort write-through of a local pref change to config ui.prefs.
- * Silent on failure by design: clients without operator.admin (or offline)
- * keep the change device-local.
- */
-export function pushServerUiPrefs(client: GatewayBrowserClient, prefs: ServerUiPrefs): void {
-  if (queuedClient !== client) {
-    // New gateway: abandon the old queue (its drain loop sees the client
-    // change and stops) instead of writing one gateway's prefs to another.
-    queuedClient = client;
-    queuedPrefs = null;
-    pushDraining = false;
-  }
-  queuedPrefs = { ...queuedPrefs, ...prefs };
+function startPendingDrain(client: GatewayBrowserClient): void {
   if (pushDraining) {
+    drainRequested = true;
+    return;
+  }
+  if (!pendingPrefs) {
     return;
   }
   pushDraining = true;
-  void drainPrefsQueue(client)
+  const epoch = pushEpoch;
+  void drainPendingPrefs(client, epoch)
     .catch(() => undefined)
     .finally(() => {
-      if (queuedClient === client) {
+      if (pushClient === client && pushEpoch === epoch) {
         pushDraining = false;
+        if (drainRequested) {
+          drainRequested = false;
+          startPendingDrain(client);
+        }
       }
     });
+}
+export function pushServerUiPrefs(
+  client: GatewayBrowserClient,
+  prefs: ServerUiPrefs,
+  hooks: { afterCommit?: () => void } = {},
+): void {
+  adoptPushClient(client);
+  pendingPrefs = { ...pendingPrefs, ...prefs };
+  pushAfterCommit = hooks.afterCommit;
+  persistPendingPrefs();
+  startPendingDrain(client);
+}
+export function flushServerUiPrefs(
+  client: GatewayBrowserClient,
+  hooks: { afterCommit?: () => void } = {},
+): void {
+  adoptPushClient(client);
+  pushEpoch += 1;
+  pushDraining = drainRequested = false;
+  pushAfterCommit = hooks.afterCommit;
+  startPendingDrain(client);
 }

--- a/ui/src/app/server-prefs.ts
+++ b/ui/src/app/server-prefs.ts
@@ -183,6 +183,11 @@ let drainRequested = false;
 let pushEpoch = 0;
 let conflictRedrainTimer: ReturnType<typeof setTimeout> | null = null;
 let consecutiveConflictRedrains = 0;
+// A loaded config snapshot object is immutable. Re-evaluating a retained object after lastSeen
+// moves would treat stale values as fresh deltas and revert acked edits, including after refresh
+// failure. Only new objects are evaluated; the post-ack request-version bump makes them post-commit.
+let lastReconciledScope = "";
+let lastReconciledConfigObject: unknown = null;
 function clearConflictRedrain(): void {
   if (conflictRedrainTimer !== null) {
     clearTimeout(conflictRedrainTimer);
@@ -233,6 +238,8 @@ export function resetServerUiPrefsSync() {
   applyingServerPrefs = pushDraining = drainRequested = false;
   pendingScope = "";
   pendingPrefs = pushClient = null;
+  lastReconciledScope = "";
+  lastReconciledConfigObject = null;
 }
 export function applyServerUiPrefs(
   configObject: unknown,
@@ -242,12 +249,20 @@ export function applyServerUiPrefs(
   },
 ): boolean {
   const scope = hooks.scope ?? "";
+  if (scope === lastReconciledScope && configObject === lastReconciledConfigObject) {
+    return false;
+  }
+  const recordReconciledObject = () => {
+    lastReconciledScope = scope;
+    lastReconciledConfigObject = configObject;
+  };
   const shadowPrefs =
     scope === pendingScope ? pendingPrefs : parseStoredPrefs(readStorage(PENDING_KEY, scope));
   const prefs = extractServerUiPrefs(configObject);
   const key = JSON.stringify(prefs);
   const lastSeenRaw = readStorage(LAST_SEEN_KEY, scope);
   if (key === lastSeenRaw) {
+    recordReconciledObject();
     return false;
   }
   const lastSeen = parseStoredPrefs(lastSeenRaw) ?? {};
@@ -272,6 +287,7 @@ export function applyServerUiPrefs(
     }
   }
   writeStorage(LAST_SEEN_KEY, scope, key);
+  recordReconciledObject();
   const patch = serverPrefsLocalPatch(changed, loadSettings());
   if (!patch) {
     return false;

--- a/ui/src/app/server-prefs.ts
+++ b/ui/src/app/server-prefs.ts
@@ -171,6 +171,8 @@ const LAST_SEEN_KEY = "openclaw.control.serverPrefs.v1";
 // Pending keys are local edits not yet acknowledged by the gateway. They shadow reconciliation so
 // snapshots cannot revert unacked edits, and persist so offline edits replay after reload/reconnect.
 const PENDING_KEY = "openclaw.control.serverPrefs.pending.v1";
+const CONFLICT_REDRAIN_DELAY_MS = 1_000;
+const MAX_CONFLICT_REDRAINS = 5;
 let applyingServerPrefs = false;
 let pendingScope = "";
 let pendingPrefs: ServerUiPrefs | null = null;
@@ -179,6 +181,15 @@ let pushAfterCommit: (() => void) | undefined;
 let pushDraining = false;
 let drainRequested = false;
 let pushEpoch = 0;
+let conflictRedrainTimer: ReturnType<typeof setTimeout> | null = null;
+let consecutiveConflictRedrains = 0;
+function clearConflictRedrain(): void {
+  if (conflictRedrainTimer !== null) {
+    clearTimeout(conflictRedrainTimer);
+    conflictRedrainTimer = null;
+  }
+  consecutiveConflictRedrains = 0;
+}
 function readStorage(root: string, scope: string): string | null {
   try {
     return globalThis.localStorage?.getItem(`${root}:${scope}`) ?? null;
@@ -218,6 +229,7 @@ function persistPendingPrefs(): void {
   writeStorage(PENDING_KEY, pendingScope, value);
 }
 export function resetServerUiPrefsSync() {
+  clearConflictRedrain();
   applyingServerPrefs = pushDraining = drainRequested = false;
   pendingScope = "";
   pendingPrefs = pushClient = null;
@@ -280,6 +292,7 @@ function adoptPushClient(client: GatewayBrowserClient): void {
   if (pushClient === client) {
     return;
   }
+  clearConflictRedrain();
   pushEpoch += 1;
   pushClient = client;
   pushDraining = false;
@@ -297,6 +310,20 @@ function removeBatch(batch: ServerUiPrefs): void {
   if (!Object.keys(pendingPrefs).length) {
     pendingPrefs = null;
   }
+}
+// Conflicts mean another writer committed, so bounded rescheduling converges under progress.
+// The cap prevents an endlessly conflicting server from keeping a timer chain alive.
+function scheduleConflictRedrain(client: GatewayBrowserClient, epoch: number): void {
+  if (conflictRedrainTimer !== null || consecutiveConflictRedrains >= MAX_CONFLICT_REDRAINS) {
+    return;
+  }
+  consecutiveConflictRedrains += 1;
+  conflictRedrainTimer = setTimeout(() => {
+    conflictRedrainTimer = null;
+    if (pushClient === client && pushEpoch === epoch && pendingPrefs) {
+      startPendingDrain(client);
+    }
+  }, CONFLICT_REDRAIN_DELAY_MS);
 }
 async function drainPendingPrefs(client: GatewayBrowserClient, epoch: number): Promise<void> {
   while (pendingPrefs) {
@@ -329,6 +356,7 @@ async function drainPendingPrefs(client: GatewayBrowserClient, epoch: number): P
         const lastSeen = parseStoredPrefs(readStorage(LAST_SEEN_KEY, pendingScope)) ?? {};
         writeStorage(LAST_SEEN_KEY, pendingScope, JSON.stringify({ ...lastSeen, ...batch }));
         persistPendingPrefs();
+        clearConflictRedrain();
         break;
       } catch (error) {
         if (pushClient !== client || pushEpoch !== epoch) {
@@ -341,7 +369,11 @@ async function drainPendingPrefs(client: GatewayBrowserClient, epoch: number): P
           });
           continue;
         }
-        if (conflict || !client.connected) {
+        if (conflict) {
+          scheduleConflictRedrain(client, epoch);
+          return;
+        }
+        if (!client.connected) {
           return;
         }
         // Connected viewer-scope or validation failures degrade silently to device-local state;
@@ -381,6 +413,7 @@ export function pushServerUiPrefs(
   hooks: { afterCommit?: () => void } = {},
 ): void {
   adoptPushClient(client);
+  clearConflictRedrain();
   pendingPrefs = { ...pendingPrefs, ...prefs };
   pushAfterCommit = hooks.afterCommit;
   persistPendingPrefs();
@@ -391,6 +424,7 @@ export function flushServerUiPrefs(
   hooks: { afterCommit?: () => void } = {},
 ): void {
   adoptPushClient(client);
+  clearConflictRedrain();
   pushEpoch += 1;
   pushDraining = drainRequested = false;
   pushAfterCommit = hooks.afterCommit;

--- a/ui/src/app/server-prefs.ts
+++ b/ui/src/app/server-prefs.ts
@@ -229,9 +229,26 @@ function adoptPendingScope(scope: string, force = false): void {
   pendingScope = scope;
   pendingPrefs = parseStoredPrefs(readStorage(PENDING_KEY, scope));
 }
-function persistPendingPrefs(): void {
-  const value = pendingPrefs ? JSON.stringify(pendingPrefs) : null;
-  writeStorage(PENDING_KEY, pendingScope, value);
+function writePendingStorage(prefs: ServerUiPrefs | null): void {
+  writeStorage(PENDING_KEY, pendingScope, prefs ? JSON.stringify(prefs) : null);
+}
+// localStorage pending is a cross-tab merged pool per gateway. Per-key read-merge-write prevents
+// one tab from clobbering sibling offline intent; its ms-scale race is accepted because storage has
+// no CAS and the drain converges through server-side LWW.
+function mergePendingIntoStorage(): void {
+  const stored = parseStoredPrefs(readStorage(PENDING_KEY, pendingScope)) ?? {};
+  const merged = { ...stored, ...pendingPrefs };
+  writePendingStorage(Object.keys(merged).length ? merged : null);
+}
+function settlePendingStorage(ackedBatch: ServerUiPrefs): void {
+  const stored = { ...parseStoredPrefs(readStorage(PENDING_KEY, pendingScope)) };
+  for (const key of Object.keys(ackedBatch) as SyncedPrefKey[]) {
+    if (prefValuesEqual(stored[key], ackedBatch[key])) {
+      delete stored[key];
+    }
+  }
+  const merged = { ...stored, ...pendingPrefs };
+  writePendingStorage(Object.keys(merged).length ? merged : null);
 }
 export function resetServerUiPrefsSync() {
   clearConflictRedrain();
@@ -371,7 +388,7 @@ async function drainPendingPrefs(client: GatewayBrowserClient, epoch: number): P
         removeBatch(batch);
         const lastSeen = parseStoredPrefs(readStorage(LAST_SEEN_KEY, pendingScope)) ?? {};
         writeStorage(LAST_SEEN_KEY, pendingScope, JSON.stringify({ ...lastSeen, ...batch }));
-        persistPendingPrefs();
+        settlePendingStorage(batch);
         clearConflictRedrain();
         break;
       } catch (error) {
@@ -395,7 +412,7 @@ async function drainPendingPrefs(client: GatewayBrowserClient, epoch: number): P
         // Connected viewer-scope or validation failures degrade silently to device-local state;
         // connection loss and CAS conflicts retain pending intent for replay.
         removeBatch(batch);
-        persistPendingPrefs();
+        settlePendingStorage(batch);
         return;
       }
     }
@@ -432,7 +449,7 @@ export function pushServerUiPrefs(
   clearConflictRedrain();
   pendingPrefs = { ...pendingPrefs, ...prefs };
   pushAfterCommit = hooks.afterCommit;
-  persistPendingPrefs();
+  mergePendingIntoStorage();
   startPendingDrain(client);
 }
 export function flushServerUiPrefs(

--- a/ui/src/app/server-prefs.ts
+++ b/ui/src/app/server-prefs.ts
@@ -1,4 +1,7 @@
-// Server ui.prefs is canonical; pending local intent shadows snapshots until hash-free LWW ack.
+// Server-side operator display prefs (config ui.prefs) are canonical: agents change them through
+// the approval gate and other devices pick them up. The localStorage mirror gives instant boot and
+// stays authoritative when this client cannot write config (viewer scope, offline). Pending local
+// intent shadows server snapshots until the hash-free LWW ack; failed pushes degrade device-local.
 import { asNullableRecord as asRecord } from "@openclaw/normalization-core/record-coerce";
 import type { GatewayBrowserClient } from "../api/gateway.ts";
 import { normalizeSidebarEntries } from "../app-navigation.ts";
@@ -28,10 +31,18 @@ function prefValuesEqual(left: unknown, right: unknown): boolean {
   }
   return left === right;
 }
+/**
+ * One descriptor per synced pref — the single source of truth for what syncs
+ * through config ui.prefs. Each key defines server validation, local normalization,
+ * and applicability; `clearable` keys push an explicit JSON null when unset locally
+ * so the merge patch removes them server-side.
+ */
 const SYNCED_PREFS = {
   theme: prefSpec<ThemeName>({
     extract: (value) => (THEMES.has(value as ThemeName) ? (value as ThemeName) : undefined),
     local: (settings) => settings.theme,
+    // A server "custom" theme is only honorable once this browser imported one;
+    // the imported palette itself is too large to live in config.
     canApply: (value, settings) => value !== "custom" || Boolean(settings.customTheme),
   }),
   themeMode: prefSpec<ThemeMode>({
@@ -64,6 +75,8 @@ const SYNCED_PREFS = {
   chatFollowUpMode: prefSpec<ChatFollowUpMode>({
     extract: (value) => normalizeChatFollowUpModeOverride(value),
     local: (settings) => normalizeChatFollowUpModeOverride(settings.chatFollowUpMode),
+    // Unset means "use the server-configured queue mode"; clearing must propagate,
+    // so the push serializes an explicit null removal.
     clearable: true,
   }),
   sidebarEntries: prefSpec<string[]>({
@@ -106,6 +119,8 @@ function serverPrefsLocalPatch(
     if (serverValue === undefined) {
       continue;
     }
+    // Null marks a server-side removal of a clearable key: drop the local override
+    // so this device falls back to the server-configured behavior.
     if (serverValue === null) {
       if (specification.clearable && specification.local(settings) !== undefined) {
         (patch as Record<string, unknown>)[key] = undefined;
@@ -139,6 +154,7 @@ export function changedServerUiPrefs(previous: UiSettings, next: UiSettings): Se
       continue;
     }
     if (nextValue === undefined) {
+      // JSON merge patch removes keys via explicit null.
       if (specification.clearable) {
         (prefs as Record<string, unknown>)[key] = null;
       }
@@ -148,7 +164,12 @@ export function changedServerUiPrefs(previous: UiSettings, next: UiSettings): Se
   }
   return Object.keys(prefs).length > 0 ? prefs : null;
 }
+// Last server value this client reconciled against, persisted per gateway scope. Applying only on
+// a server delta keeps an unpushable local edit (viewer scope) from being reverted by every later
+// snapshot, including the first snapshot after reload or reconnect carrying the same old value.
 const LAST_SEEN_KEY = "openclaw.control.serverPrefs.v1";
+// Pending keys are local edits not yet acknowledged by the gateway. They shadow reconciliation so
+// snapshots cannot revert unacked edits, and persist so offline edits replay after reload/reconnect.
 const PENDING_KEY = "openclaw.control.serverPrefs.pending.v1";
 let applyingServerPrefs = false;
 let pendingScope = "";
@@ -173,7 +194,9 @@ function writeStorage(root: string, scope: string, value: string | null): void {
     } else {
       globalThis.localStorage?.setItem(key, value);
     }
-  } catch {}
+  } catch {
+    // Quota/security failures degrade to in-memory tracking for this session.
+  }
 }
 function parseStoredPrefs(raw: string | null): ServerUiPrefs | null {
   try {
@@ -217,6 +240,8 @@ export function applyServerUiPrefs(
   }
   const lastSeen = parseStoredPrefs(lastSeenRaw) ?? {};
   const changed: ServerUiPrefs = {};
+  // Apply per field: only keys whose server value changed since last seen. Reapplying unchanged
+  // fields would revert unpushable local edits whenever any other server field moves.
   for (const prefKey of Object.keys(prefs) as Array<keyof ServerUiPrefs>) {
     if (
       !(shadowPrefs && prefKey in shadowPrefs) &&
@@ -319,6 +344,8 @@ async function drainPendingPrefs(client: GatewayBrowserClient, epoch: number): P
         if (conflict || !client.connected) {
           return;
         }
+        // Connected viewer-scope or validation failures degrade silently to device-local state;
+        // connection loss and CAS conflicts retain pending intent for replay.
         removeBatch(batch);
         persistPendingPrefs();
         return;

--- a/ui/src/e2e/settings-prefs-reconnect.e2e.test.ts
+++ b/ui/src/e2e/settings-prefs-reconnect.e2e.test.ts
@@ -1,0 +1,289 @@
+// Control UI tests cover server preference replay and reconciliation through real reconnects.
+import { chromium, type Browser, type BrowserContext, type Page } from "playwright";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  canRunPlaywrightChromium,
+  installMockGateway,
+  resolvePlaywrightChromiumExecutablePath,
+  startControlUiE2eServer,
+  type ControlUiE2eServer,
+  type MockGatewayControls,
+  type MockGatewayRequest,
+} from "../test-helpers/control-ui-e2e.ts";
+
+const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
+const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
+const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
+const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+
+let browser: Browser;
+let server: ControlUiE2eServer;
+
+function configResponse(prefs: Record<string, unknown>, hash: string) {
+  const config = { ui: { prefs } };
+  return {
+    config,
+    hash,
+    configRevisionHash: hash,
+    appliedConfigHash: hash,
+    issues: [],
+    raw: JSON.stringify(config),
+    valid: true,
+  };
+}
+
+function requireRecord(value: unknown, label: string): Record<string, unknown> {
+  expect(value, label).toBeTruthy();
+  expect(typeof value, label).toBe("object");
+  expect(Array.isArray(value), label).toBe(false);
+  return value as Record<string, unknown>;
+}
+
+function patchPrefs(request: MockGatewayRequest): Record<string, unknown> {
+  const params = requireRecord(request.params, "config.patch params");
+  expect(Object.hasOwn(params, "baseHash")).toBe(false);
+  expect(typeof params.raw).toBe("string");
+  const parsed = requireRecord(JSON.parse(String(params.raw)), "config.patch raw");
+  const ui = requireRecord(parsed.ui, "config.patch ui");
+  return requireRecord(ui.prefs, "config.patch ui.prefs");
+}
+
+async function createContext(): Promise<BrowserContext> {
+  return browser.newContext({
+    locale: "en-US",
+    serviceWorkers: "block",
+    viewport: { height: 900, width: 1440 },
+  });
+}
+
+async function waitForRequestCount(
+  gateway: MockGatewayControls,
+  method: string,
+  count: number,
+): Promise<void> {
+  await expect
+    .poll(async () => (await gateway.getRequests(method)).length, { timeout: 10_000 })
+    .toBe(count);
+}
+
+async function proxyReconnect(
+  page: Page,
+  gateway: MockGatewayControls,
+  whileDisconnected: () => Promise<void>,
+): Promise<void> {
+  const socketCountBefore = await gateway.getSocketCount();
+  await gateway.closeLatest(1001, "proxy idle timeout");
+  await gateway.setOnline(false);
+  await expect
+    .poll(() =>
+      page.evaluate(() => {
+        const app = document.querySelector("openclaw-app") as HTMLElement & {
+          runtime?: { context: { gateway: { snapshot: { phase: string } } } };
+        };
+        return app.runtime?.context.gateway.snapshot.phase;
+      }),
+    )
+    .toBe("reconnecting");
+  await whileDisconnected();
+  expect(await gateway.getRequests("config.patch")).toHaveLength(0);
+  await expect
+    .poll(() => gateway.getSocketCount(), { timeout: 10_000 })
+    .toBeGreaterThan(socketCountBefore);
+  await gateway.setOnline(true);
+  await expect
+    .poll(() =>
+      page.evaluate(() => {
+        const app = document.querySelector("openclaw-app") as HTMLElement & {
+          runtime?: { context: { gateway: { snapshot: { phase: string } } } };
+        };
+        return app.runtime?.context.gateway.snapshot.phase;
+      }),
+    )
+    .toBe("connected");
+  await page.locator(".settings-page").waitFor({ timeout: 10_000 });
+}
+
+async function readSettingsMirror(page: Page): Promise<Record<string, unknown> | null> {
+  return page.evaluate(() => {
+    const key = Object.keys(localStorage).find((candidate) =>
+      candidate.startsWith("openclaw.control.settings.v1:"),
+    );
+    if (!key) {
+      return null;
+    }
+    const raw = localStorage.getItem(key);
+    return raw ? (JSON.parse(raw) as Record<string, unknown>) : null;
+  });
+}
+
+function themeCard(page: Page, theme: "claw" | "knot") {
+  return page.locator(`.settings-theme-card--${theme}`);
+}
+
+async function expectThemeActive(page: Page, theme: "claw" | "knot"): Promise<void> {
+  await expect
+    .poll(() => themeCard(page, theme).getAttribute("class"), { timeout: 10_000 })
+    .toContain("settings-theme-card--active");
+}
+
+describeControlUiE2e("Control UI server prefs reconnect sync", () => {
+  beforeAll(async () => {
+    if (!chromiumAvailable) {
+      throw new Error(
+        `Playwright Chromium is not available at ${chromiumExecutablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
+      );
+    }
+    server = await startControlUiE2eServer();
+    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
+  });
+
+  afterAll(async () => {
+    await browser?.close();
+    await server?.close();
+  });
+
+  it("replays an offline theme edit after a same-client reconnect", async () => {
+    const context = await createContext();
+    const page = await context.newPage();
+    const initial = configResponse({ theme: "claw", themeMode: "system" }, "prefs-a-1");
+    const committed = configResponse({ theme: "knot", themeMode: "system" }, "prefs-a-2");
+    const gateway = await installMockGateway(page, {
+      methodResponses: { "config.get": initial },
+    });
+
+    try {
+      const response = await page.goto(`${server.baseUrl}settings/appearance`);
+      expect(response?.status()).toBe(200);
+      await themeCard(page, "claw").waitFor();
+      await gateway.waitForRequest("config.get");
+      const configGetsBeforeEdit = (await gateway.getRequests("config.get")).length;
+      await gateway.deferNext("config.patch");
+
+      await proxyReconnect(page, gateway, async () => {
+        await themeCard(page, "knot").click();
+        await expectThemeActive(page, "knot");
+      });
+
+      const patch = await gateway.waitForRequest("config.patch");
+      expect(patchPrefs(patch)).toEqual({ theme: "knot" });
+      expect(await gateway.getRequests("config.get")).toHaveLength(configGetsBeforeEdit);
+
+      await gateway.setMethodResponse("config.get", committed);
+      await gateway.resolveDeferred("config.patch", committed);
+      await waitForRequestCount(gateway, "config.get", configGetsBeforeEdit + 1);
+      await expectThemeActive(page, "knot");
+    } finally {
+      await context.close();
+    }
+  });
+
+  it("keeps disjoint edits from two pages after both hash-free patches", async () => {
+    const contextA = await createContext();
+    const contextB = await createContext();
+    const pageA = await contextA.newPage();
+    const pageB = await contextB.newPage();
+    const initial = configResponse({ theme: "claw" }, "prefs-b-1");
+    const gatewayA = await installMockGateway(pageA, {
+      methodResponses: { "config.get": initial },
+    });
+    const gatewayB = await installMockGateway(pageB, {
+      methodResponses: { "config.get": initial },
+    });
+
+    try {
+      await Promise.all([
+        pageA.goto(`${server.baseUrl}settings/appearance`),
+        pageB.goto(`${server.baseUrl}settings/appearance`),
+      ]);
+      await Promise.all([themeCard(pageA, "claw").waitFor(), themeCard(pageB, "claw").waitFor()]);
+      await Promise.all([gatewayA.deferNext("config.patch"), gatewayB.deferNext("config.patch")]);
+
+      await themeCard(pageA, "knot").click();
+      const patchA = await gatewayA.waitForRequest("config.patch");
+      const prefsA = patchPrefs(patchA);
+      expect(prefsA).toEqual({ theme: "knot" });
+      const themeCommitted = configResponse(prefsA, "prefs-b-2");
+      await gatewayA.setMethodResponse("config.get", themeCommitted);
+      await gatewayA.resolveDeferred("config.patch", themeCommitted);
+
+      await pageB.locator("[data-settings-follow-up-mode]").selectOption("queue");
+      const patchB = await gatewayB.waitForRequest("config.patch");
+      const prefsB = patchPrefs(patchB);
+      expect(prefsB).toEqual({ chatFollowUpMode: "queue" });
+      expect(Object.keys(prefsA).some((key) => Object.hasOwn(prefsB, key))).toBe(false);
+      const combined = configResponse({ ...prefsA, ...prefsB }, "prefs-b-3");
+      await gatewayB.setMethodResponse("config.get", combined);
+      await gatewayB.resolveDeferred("config.patch", combined);
+      await gatewayA.setMethodResponse("config.get", combined);
+      await gatewayA.emitGatewayEvent("config.changed", {
+        path: "/tmp/openclaw.json",
+        hash: "prefs-b-3",
+        ts: Date.now(),
+      });
+
+      await expectThemeActive(pageA, "knot");
+      await expectThemeActive(pageB, "knot");
+      await expect
+        .poll(() => readSettingsMirror(pageA))
+        .toMatchObject({
+          chatFollowUpMode: "queue",
+          theme: "knot",
+        });
+      await expect
+        .poll(() => readSettingsMirror(pageB))
+        .toMatchObject({
+          chatFollowUpMode: "queue",
+          theme: "knot",
+        });
+    } finally {
+      await contextA.close();
+      await contextB.close();
+    }
+  });
+
+  it("applies a server delta without reverting a pending local key", async () => {
+    const context = await createContext();
+    const page = await context.newPage();
+    const initial = configResponse({ locale: "en", theme: "claw" }, "prefs-c-1");
+    const gateway = await installMockGateway(page, {
+      methodResponses: { "config.get": initial },
+    });
+
+    try {
+      await page.goto(`${server.baseUrl}settings/appearance`);
+      await themeCard(page, "claw").waitFor();
+      await gateway.waitForRequest("config.get");
+      const initialConfigGets = (await gateway.getRequests("config.get")).length;
+      await gateway.deferNext("config.patch");
+
+      await themeCard(page, "knot").click();
+      const patch = await gateway.waitForRequest("config.patch");
+      expect(patchPrefs(patch)).toEqual({ theme: "knot" });
+
+      const serverChanged = configResponse({ locale: "de", theme: "claw" }, "prefs-c-2");
+      await gateway.setMethodResponse("config.get", serverChanged);
+      await gateway.emitGatewayEvent("config.changed", {
+        path: "/tmp/openclaw.json",
+        hash: "prefs-c-2",
+        ts: Date.now(),
+      });
+      await waitForRequestCount(gateway, "config.get", initialConfigGets + 1);
+
+      await expectThemeActive(page, "knot");
+      await expect
+        .poll(() => readSettingsMirror(page))
+        .toMatchObject({
+          locale: "de",
+          theme: "knot",
+        });
+
+      await gateway.rejectDeferred("config.patch", {
+        code: "INVALID_REQUEST",
+        message: "mock validation failure",
+      });
+      await expectThemeActive(page, "knot");
+    } finally {
+      await context.close();
+    }
+  });
+});

--- a/ui/src/lib/config/index.test.ts
+++ b/ui/src/lib/config/index.test.ts
@@ -1662,6 +1662,69 @@ describe("config form auto-save", () => {
     runtimeConfig.dispose();
   });
 
+  it("lets a reconnected explicit op bypass a dead prior-connection FIFO", async () => {
+    const deadSet = deferred<unknown>();
+    const methods: string[] = [];
+    const request = vi.fn((method: string) => {
+      methods.push(method);
+      if (method === "config.get") {
+        return Promise.resolve({ config: { count: 1 }, hash: "hash-1", valid: true, issues: [] });
+      }
+      if (method === "config.set") {
+        return deadSet.promise;
+      }
+      return Promise.resolve({});
+    });
+    const { runtimeConfig, publish } = createHarness(request as GatewayBrowserClient["request"]);
+    await runtimeConfig.ensureLoaded();
+
+    void runtimeConfig.save();
+    void runtimeConfig.apply();
+    await vi.waitFor(() => expect(methods).toContain("config.set"));
+    publish(false);
+    publish(true);
+
+    await expect(
+      runtimeConfig.patch({ raw: { ui: { prefs: { themeMode: "dark" } } }, note: "test" }),
+    ).resolves.toBe(true);
+    expect(methods).toContain("config.patch");
+    expect(methods).not.toContain("config.apply");
+    runtimeConfig.dispose();
+  });
+
+  it("does not dispatch an explicit op enqueued before reconnect", async () => {
+    const firstPatch = deferred<unknown>();
+    let patchCalls = 0;
+    let setCalls = 0;
+    const request = vi.fn((method: string) => {
+      if (method === "config.get") {
+        return Promise.resolve({ config: { count: 1 }, hash: "hash-1", valid: true, issues: [] });
+      }
+      if (method === "config.patch") {
+        patchCalls += 1;
+        return firstPatch.promise;
+      }
+      if (method === "config.set") {
+        setCalls += 1;
+      }
+      return Promise.resolve({});
+    });
+    const { runtimeConfig, publish } = createHarness(request as GatewayBrowserClient["request"]);
+    await runtimeConfig.ensureLoaded();
+
+    const stalePatch = runtimeConfig.patch({ raw: { ui: { prefs: {} } }, note: "test" });
+    const staleSet = runtimeConfig.save();
+    await vi.waitFor(() => expect(patchCalls).toBe(1));
+    publish(false);
+    publish(true);
+    firstPatch.resolve({});
+
+    await expect(stalePatch).resolves.toBe(false);
+    await expect(staleSet).resolves.toBe(false);
+    expect(setCalls).toBe(0);
+    runtimeConfig.dispose();
+  });
+
   it("defers autosaves behind a manual write and keeps the newer edit", async () => {
     vi.useFakeTimers();
     const { request, submissions, firstSet } = createDeferredSetServerMock();

--- a/ui/src/lib/config/index.ts
+++ b/ui/src/lib/config/index.ts
@@ -1415,6 +1415,8 @@ export function createRuntimeConfigCapability(
     if (writesSuspended) {
       return Promise.resolve(false);
     }
+    const client = state.client;
+    const connectionEpoch = currentConfigConnectionEpoch(state);
     cancelScheduledAutoSave();
     // Start synchronously when no explicit op is queued so the submit binds
     // to the CURRENT connection epoch; only genuine queuing pays the hop.
@@ -1428,6 +1430,9 @@ export function createRuntimeConfigCapability(
         // The updater may have started while we drained; suspension must be a
         // real barrier or an apply could restart the gateway mid-update.
         if (writesSuspended || disposed) {
+          return false;
+        }
+        if (!client || !isCurrentConfigConnection(state, client, connectionEpoch)) {
           return false;
         }
         manualFlightInfo = null;
@@ -1480,6 +1485,9 @@ export function createRuntimeConfigCapability(
     if (clientChanged || connectionChanged) {
       configLoad = null;
       schemaLoad = null;
+      // A dead prior-connection flight must not keep the reconnected owner's
+      // explicit-operation FIFO waiting forever.
+      explicitOpQueue = null;
       // A reconnect may reuse the client object. Keep generations monotonic so work
       // from the previous connection cannot commit into the new connection epoch.
       invalidateConfigConnection(state);


### PR DESCRIPTION
## What Problem This Solves

Control UI settings (theme, language, chat preferences, sidebar sessions) sync
into gateway config `ui.prefs` through `config.patch` guarded by a
whole-document CAS `baseHash`. Two tabs or a Gateway reconnect lose writes:
the browser-side queue fetches `config.get`, patches with that hash, retries
once, then silently drops the edit. Edits made while disconnected never
replay, and a tab that loses a CAS race to a sibling tab never persists its
preference. This is the issue PR #114170 attempted to fix client-side; its
own live two-tab reconnect proof failed twice (on head `049e0ea` and on the
stronger unpublished candidate `85adc15`), so that PR is closed in favor of
this boundary-correct replacement.

## Why This Change Was Made

Only the gateway can serialize concurrent preference writers; per-tab module
state categorically cannot fence a sibling tab. This PR therefore fixes the
issue at the ownership boundary:

- **Gateway**: `config.patch` now accepts a hash-free patch iff every changed
  path is inside the documented last-writer-wins preference subtree
  (`ui.prefs`) AND the patch is a leaf-level operation (container replacement
  or deletion at/above `ui.prefs` still requires the document CAS, so a stale
  client cannot wipe concurrently added keys). The server already owns the
  merge, validation, destructive-array guard, and a lock-time CAS inside
  `replaceConfigFile`. A lost commit race deliberately surfaces to the client
  instead of retrying server-side: a server retry would replay frozen stale
  intent over the winner, while the client's retry replays current intent.
  Every other path keeps the strict document CAS unchanged, `baseHash` was
  already optional in the wire schema, and no protocol or config surface
  changes.
- **Control UI**: the CAS queue, `config.get`-before-patch, and stale-hash
  suppression set are deleted. Local edits become per-key pending intent that
  shadows server reconciliation until the gateway acks, persists per gateway
  scope in localStorage, and replays on reconnect (`flushServerUiPrefs` fires
  on the connected transition even when the reconnect reuses the client
  object). Commit-race conflicts retry once, then reschedule a bounded
  delayed drain — conflicts imply another writer made progress, so this
  converges. After each ack the runtime config capability refreshes, and its
  existing request-version fencing discards stale in-flight `config.get`
  responses, closing the echo flip-flop window.
- **Capability hardening** (settings editor shares the reconnect symptom): a
  dead prior-connection flight no longer blocks the explicit-op FIFO after
  reconnect, and `set()` captures its connection epoch at enqueue so a
  pre-reconnect submission cannot commit into the new connection.

## User Impact

Settings changes persist across Gateway restarts, reconnects, and multiple
concurrent tabs/devices. Edits made while disconnected are retained and
written once the connection returns. Concurrent writers on disjoint
preferences no longer conflict; same-key writers converge last-writer-wins,
matching user expectation for UI preferences. Viewer-scope clients keep the
existing silent device-local degrade. No config or protocol surface changes.

## Evidence

- Focused suites: `src/gateway/server-methods/config.test.ts` (hash-free LWW
  gate, mixed-path rejection, destructive-array guard, noop, stale-hash
  strict-mode preservation, commit-race retry), `ui/src/app/server-prefs.test.ts`
  (pending-intent model incl. offline retention + reconnect flush, shadowed
  reconciliation, retained-snapshot memo, cross-tab pending merge, conflict
  retry vs validation drop), `ui/src/lib/config/index.test.ts` (FIFO release +
  epoch-captured set). **126 tests green** via
  `node scripts/run-vitest.mjs` (20 gateway + 103 ui + 3 e2e); expanded
  `check-changed` (formatting, core/UI typechecks, lint, architecture,
  storage guards) passed remotely on Blacksmith Testbox, exit 0.
- End-to-end regression `ui/src/e2e/settings-prefs-reconnect.e2e.test.ts`
  (real Chromium executed, no skips): offline edit replays after a
  same-client reconnect as a hash-free `config.patch` (asserted: no
  `baseHash`, no CAS `config.get`, zero patches escape while disconnected);
  two pages with disjoint keys both persist; a server delta applies without
  reverting a pending local key.
- Iterative structured review (gpt-5.6-sol, xhigh): four accepted P2s were
  fixed in-branch (server-side retry replaying frozen stale intent over a
  race winner; container-level hashless ops; retained-snapshot
  re-reconciliation reverting acked prefs; cross-tab persisted-pending
  clobber). Two findings consciously rejected with code proof: post-backoff
  epoch recheck (the guard is the first statement of every attempt
  iteration) and retain-on-transient-error (retention would permanently
  stick the pending shadow for viewer-scope clients; drop releases the
  shadow and matches the documented device-local degrade). Final delta
  review clean: `patch is correct (0.91)`.
- Live real-gateway proof on Blacksmith Testbox `tbx_01kygyxbpxr8awqaxdd5j73qkn`
  (Actions run `30238422165`): production build, isolated loopback gateway
  (port 43019, dedicated state dir, real `/readyz`), two authenticated real
  Chromium pages (`/settings/appearance`, `/settings/general`). Online
  `theme=knot` persisted; SIGTERM; both pages reached reconnecting; offline
  `theme=dash` + `locale=fr` with zero patches escaping while down; gateway
  restart; after reconnect the gateway's `openclaw.json` physically ended as
  `{"locale":"fr","theme":"dash"}` — and the dash replay survived a live
  stale-config rejection through the client retry, the exact point where
  both #114170 candidates failed. Artifact SHA-256:
  `initial.png 692e41aa…187c78`, `pre-reconnect.png 839df5f2…450c63`,
  `disconnected.png 63688719…bfca08`, final pages `e63d0790…694e77` /
  `ddb7a013…8d0ad3`, `result.json bad03705…27a076`,
  `gateway.log c08625fd…9741f4`, `structured-stdout.log e8b4c270…12da1e`.
  One honest residual: the page that selected French offline kept English
  chrome until reload because `i18n.setLocale` never retries a lazy bundle
  fetch that failed while the gateway was down — a pre-existing `main` bug
  independent of this PR (the sibling page rendered French correctly via the
  server delta); follow-up task filed.
- Hosted CI: first run failed one pre-existing `app-host.test.ts` fixture
  that predated the new reconcile identity fence (fake context without
  `runtimeConfig`); fixed in `f50600b`. Full CI green on that head: Actions
  run `30238640504`.
- AI-assisted (Codex implementation from a frozen spec; design, review, and
  verification by maintainer session).
