### PR TITLE
fix(linux): execute tray gateway operations in click order

### DIFF
--- a/apps/linux/src-tauri/src/gateway_operation_queue.rs
+++ b/apps/linux/src-tauri/src/gateway_operation_queue.rs
@@ -1,0 +1,135 @@
+use crate::gateway::{GatewayAction, GatewaySnapshot};
+use crate::installer::InstallChannel;
+use crate::operation_executor::OperationExecutor;
+use tokio::sync::oneshot;
+
+pub(crate) enum GatewayOperation {
+    Connect,
+    ConnectExplicitLocal,
+    Install(InstallChannel),
+    Action(GatewayAction),
+}
+
+struct QueuedGatewayOperation {
+    operation: GatewayOperation,
+    reply: Option<oneshot::Sender<Result<GatewaySnapshot, String>>>,
+}
+
+pub(crate) struct GatewayOperationQueue {
+    executor: OperationExecutor<QueuedGatewayOperation>,
+}
+
+impl GatewayOperationQueue {
+    pub(crate) fn new<F, E>(sink: F, show_error: E) -> Self
+    where
+        F: Fn(GatewayOperation) -> Result<GatewaySnapshot, String> + Send + Sync + 'static,
+        E: Fn(&str) + Send + Sync + 'static,
+    {
+        Self {
+            executor: OperationExecutor::new(
+                "openclaw-gateway-operations",
+                move |request: QueuedGatewayOperation| {
+                    let result = sink(request.operation);
+                    if let Some(reply) = request.reply {
+                        let _ = reply.send(result);
+                    } else if let Err(error) = result {
+                        show_error(&error);
+                    }
+                },
+            ),
+        }
+    }
+
+    pub(crate) fn submit_connect(&self) {
+        self.submit_detached(GatewayOperation::ConnectExplicitLocal);
+    }
+
+    pub(crate) fn submit_action(&self, action: GatewayAction) {
+        self.submit_detached(GatewayOperation::Action(action));
+    }
+
+    pub(crate) async fn execute(
+        &self,
+        operation: GatewayOperation,
+    ) -> Result<GatewaySnapshot, String> {
+        let (reply, receiver) = oneshot::channel();
+        self.executor
+            .submit(QueuedGatewayOperation {
+                operation,
+                reply: Some(reply),
+            })
+            .map_err(|_| "Gateway operation queue is unavailable.".to_string())?;
+        receiver
+            .await
+            .map_err(|_| "Gateway operation worker stopped unexpectedly.".to_string())?
+    }
+
+    fn submit_detached(&self, operation: GatewayOperation) {
+        let _ = self.executor.submit(QueuedGatewayOperation {
+            operation,
+            reply: None,
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{GatewayOperation, GatewayOperationQueue};
+    use crate::gateway::GatewayAction;
+    use std::sync::{mpsc, Arc, Barrier};
+    use std::thread;
+    use std::time::Duration;
+
+    #[derive(Debug, Eq, PartialEq)]
+    enum ObservedOperation {
+        Stop,
+        Connect,
+    }
+
+    #[test]
+    fn orders_non_tray_connect_after_gateway_action() {
+        let contention = Arc::new(Barrier::new(2));
+        let worker_contention = Arc::clone(&contention);
+        let (observed_sender, observed_receiver) = mpsc::channel();
+        let queue = Arc::new(GatewayOperationQueue::new(
+            move |operation| {
+                let observed = match operation {
+                    GatewayOperation::Action(GatewayAction::Stop) => {
+                        worker_contention.wait();
+                        thread::sleep(Duration::from_millis(100));
+                        ObservedOperation::Stop
+                    }
+                    GatewayOperation::ConnectExplicitLocal => ObservedOperation::Connect,
+                    _ => panic!("unexpected operation"),
+                };
+                observed_sender.send(observed).expect("record operation");
+                Err("test operation".to_string())
+            },
+            |_| {},
+        ));
+
+        let connect_queue = Arc::clone(&queue);
+        let connect_submitter = thread::spawn(move || {
+            contention.wait();
+            connect_queue.submit_connect();
+        });
+        let action_queue = Arc::clone(&queue);
+        let action_submitter = thread::spawn(move || {
+            action_queue.submit_action(GatewayAction::Stop);
+        });
+
+        action_submitter.join().expect("action submitter");
+        connect_submitter.join().expect("connect submitter");
+        let observed = (0..2)
+            .map(|_| {
+                observed_receiver
+                    .recv_timeout(Duration::from_secs(1))
+                    .expect("operation should execute")
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            observed,
+            [ObservedOperation::Stop, ObservedOperation::Connect]
+        );
+    }
+}

--- a/apps/linux/src-tauri/src/main.rs
+++ b/apps/linux/src-tauri/src/main.rs
@@ -4,9 +4,11 @@ mod cli;
 mod discovery;
 mod gateway;
 mod gateway_device_identity;
+mod gateway_operation_queue;
 mod gateway_ws;
 mod installer;
 mod notify;
+mod operation_executor;
 mod pending_approvals;
 mod quickchat;
 mod quickchat_widgets;
@@ -15,6 +17,7 @@ mod updater;
 
 use cli::{CliError, OpenClawCli};
 use gateway::{GatewayAction, GatewaySnapshot};
+use gateway_operation_queue::{GatewayOperation, GatewayOperationQueue};
 use installer::InstallChannel;
 use serde::Serialize;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -62,8 +65,7 @@ fn handle_deep_links(app: &AppHandle, urls: Vec<Url>) {
     for url in urls {
         match deep_link_route(&url) {
             DeepLinkRoute::Dashboard => {
-                let desktop = app.state::<DesktopState>();
-                tray::open_dashboard(app, desktop.inner());
+                tray::open_dashboard(app);
             }
             DeepLinkRoute::FocusOnly => tray::show_window(app),
         }
@@ -655,37 +657,25 @@ fn build_info(app: AppHandle) -> BuildInfo {
 
 #[tauri::command]
 async fn bootstrap(
-    app: AppHandle,
-    state: State<'_, DesktopState>,
+    operations: State<'_, GatewayOperationQueue>,
 ) -> Result<GatewaySnapshot, String> {
-    let state = state.inner().clone();
-    tauri::async_runtime::spawn_blocking(move || state.connect(&app))
-        .await
-        .map_err(|error| format!("Gateway task failed: {error}"))?
+    operations.execute(GatewayOperation::Connect).await
 }
 
 #[tauri::command]
 async fn install_cli(
-    app: AppHandle,
-    state: State<'_, DesktopState>,
+    operations: State<'_, GatewayOperationQueue>,
     channel: InstallChannel,
 ) -> Result<GatewaySnapshot, String> {
-    let state = state.inner().clone();
-    tauri::async_runtime::spawn_blocking(move || state.install_cli(&app, channel))
-        .await
-        .map_err(|error| format!("Installer task failed: {error}"))?
+    operations.execute(GatewayOperation::Install(channel)).await
 }
 
 #[tauri::command]
 async fn gateway_action(
-    app: AppHandle,
-    state: State<'_, DesktopState>,
+    operations: State<'_, GatewayOperationQueue>,
     action: GatewayAction,
 ) -> Result<GatewaySnapshot, String> {
-    let state = state.inner().clone();
-    tauri::async_runtime::spawn_blocking(move || state.gateway_action(&app, action))
-        .await
-        .map_err(|error| format!("Gateway task failed: {error}"))?
+    operations.execute(GatewayOperation::Action(action)).await
 }
 
 fn main() {
@@ -742,6 +732,26 @@ fn main() {
         let state = DesktopState::new(window.url()?);
         app.manage(state.clone());
         app.manage(gateway_ws::GatewayClient::new());
+        let operation_app = app.handle().clone();
+        let operation_state = state.clone();
+        let error_app = app.handle().clone();
+        let error_state = state.clone();
+        // Every caller of the operation mutex enters this queue so UI source cannot reorder work.
+        app.manage(GatewayOperationQueue::new(
+            move |operation| match operation {
+                GatewayOperation::Connect => operation_state.connect(&operation_app),
+                GatewayOperation::ConnectExplicitLocal => {
+                    operation_state.connect_explicit_local(&operation_app)
+                }
+                GatewayOperation::Install(channel) => {
+                    operation_state.install_cli(&operation_app, channel)
+                }
+                GatewayOperation::Action(action) => {
+                    operation_state.gateway_action(&operation_app, action)
+                }
+            },
+            move |error| error_state.show_error(&error_app, error),
+        ));
         let deep_link_app = app.handle().clone();
         app.deep_link().on_open_url(move |event| {
             handle_deep_links(&deep_link_app, event.urls());

--- a/apps/linux/src-tauri/src/operation_executor.rs
+++ b/apps/linux/src-tauri/src/operation_executor.rs
@@ -1,0 +1,111 @@
+use std::sync::mpsc;
+use std::thread;
+
+pub(crate) struct OperationExecutor<T> {
+    sender: mpsc::Sender<T>,
+}
+
+impl<T> Clone for OperationExecutor<T> {
+    fn clone(&self) -> Self {
+        Self {
+            sender: self.sender.clone(),
+        }
+    }
+}
+
+impl<T: Send + 'static> OperationExecutor<T> {
+    pub(crate) fn new<F>(name: &str, sink: F) -> Self
+    where
+        F: Fn(T) + Send + Sync + 'static,
+    {
+        let (sender, receiver) = mpsc::channel();
+        thread::Builder::new()
+            .name(name.to_string())
+            .spawn(move || {
+                for operation in receiver {
+                    sink(operation);
+                }
+            })
+            .expect("operation executor worker should start");
+        Self { sender }
+    }
+
+    pub(crate) fn submit(&self, operation: T) -> Result<(), mpsc::SendError<T>> {
+        self.sender.send(operation)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::OperationExecutor;
+    use std::sync::{mpsc, Arc, Barrier};
+    use std::thread;
+    use std::time::Duration;
+
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    enum TestOperation {
+        Stop,
+        Restart,
+    }
+
+    #[test]
+    fn executes_contending_submissions_in_submission_order() {
+        let contention = Arc::new(Barrier::new(2));
+        let worker_contention = Arc::clone(&contention);
+        let (observed_sender, observed_receiver) = mpsc::channel();
+        let executor = OperationExecutor::new("ordered-operation-test", move |operation| {
+            if operation == TestOperation::Stop {
+                worker_contention.wait();
+                thread::sleep(Duration::from_millis(100));
+            }
+            observed_sender.send(operation).expect("record operation");
+        });
+
+        let restart_executor = executor.clone();
+        let restart_submitter = thread::spawn(move || {
+            contention.wait();
+            restart_executor
+                .submit(TestOperation::Restart)
+                .expect("submit restart");
+        });
+        let stop_executor = executor.clone();
+        let stop_submitter = thread::spawn(move || {
+            stop_executor
+                .submit(TestOperation::Stop)
+                .expect("submit stop");
+        });
+
+        stop_submitter.join().expect("stop submitter");
+        restart_submitter.join().expect("restart submitter");
+        let observed = (0..2)
+            .map(|_| {
+                observed_receiver
+                    .recv_timeout(Duration::from_secs(1))
+                    .expect("operation should execute")
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(observed, [TestOperation::Stop, TestOperation::Restart]);
+    }
+
+    #[test]
+    fn executes_every_rapid_submission_in_order() {
+        let (observed_sender, observed_receiver) = mpsc::channel();
+        let executor = OperationExecutor::new("rapid-operation-test", move |operation| {
+            observed_sender.send(operation).expect("record operation");
+        });
+        let expected = (0..256).collect::<Vec<_>>();
+
+        for operation in expected.iter().copied() {
+            executor.submit(operation).expect("submit operation");
+        }
+
+        let observed = (0..expected.len())
+            .map(|_| {
+                observed_receiver
+                    .recv_timeout(Duration::from_secs(1))
+                    .expect("operation should execute")
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(observed, expected);
+    }
+}

--- a/apps/linux/src-tauri/src/quickchat.rs
+++ b/apps/linux/src-tauri/src/quickchat.rs
@@ -811,13 +811,9 @@ pub async fn quickchat_ready(
 }
 
 #[tauri::command]
-pub fn quickchat_show_dashboard(
-    webview: Webview,
-    app: AppHandle,
-    desktop: State<'_, DesktopState>,
-) -> Result<(), String> {
+pub fn quickchat_show_dashboard(webview: Webview, app: AppHandle) -> Result<(), String> {
     require_quickchat_webview(&webview)?;
-    tray::open_dashboard(&app, desktop.inner());
+    tray::open_dashboard(&app);
     Ok(())
 }
 

--- a/apps/linux/src-tauri/src/tray.rs
+++ b/apps/linux/src-tauri/src/tray.rs
@@ -1,4 +1,5 @@
 use crate::gateway::{GatewayAction, GatewaySnapshot};
+use crate::gateway_operation_queue::GatewayOperationQueue;
 use crate::quickchat;
 use crate::DesktopState;
 use std::fs;
@@ -341,9 +342,9 @@ pub fn show_window(app: &AppHandle) {
     }
 }
 
-pub fn open_dashboard(app: &AppHandle, state: &DesktopState) {
+pub fn open_dashboard(app: &AppHandle) {
     show_window(app);
-    spawn_connect(app.clone(), state.clone());
+    app.state::<GatewayOperationQueue>().submit_connect();
 }
 
 fn handle_menu(
@@ -360,7 +361,7 @@ fn handle_menu(
             app.exit(0);
         }
         QUICKCHAT_ID => quickchat::toggle_quickchat(app),
-        OPEN_ID => open_dashboard(app, state),
+        OPEN_ID => open_dashboard(app),
         CHECK_UPDATES_ID => {
             show_window(app);
             crate::updater::spawn_check(app.clone());
@@ -376,9 +377,18 @@ fn handle_menu(
                 toggle_global_shortcut(app, global_shortcut);
             }
         }
-        START_ID => spawn_action(app.clone(), state.clone(), GatewayAction::Start),
-        STOP_ID => spawn_action(app.clone(), state.clone(), GatewayAction::Stop),
-        RESTART_ID => spawn_action(app.clone(), state.clone(), GatewayAction::Restart),
+        START_ID => {
+            app.state::<GatewayOperationQueue>()
+                .submit_action(GatewayAction::Start);
+        }
+        STOP_ID => {
+            app.state::<GatewayOperationQueue>()
+                .submit_action(GatewayAction::Stop);
+        }
+        RESTART_ID => {
+            app.state::<GatewayOperationQueue>()
+                .submit_action(GatewayAction::Restart);
+        }
         _ => {}
     }
 }
@@ -511,22 +521,6 @@ fn toggle_autostart(app: &AppHandle, item: &CheckMenuItem<tauri::Wry>) {
             let _ = item.set_checked(enabled);
         }
     }
-}
-
-fn spawn_connect(app: AppHandle, state: DesktopState) {
-    std::thread::spawn(move || {
-        if let Err(error) = state.connect_explicit_local(&app) {
-            state.show_error(&app, &error);
-        }
-    });
-}
-
-fn spawn_action(app: AppHandle, state: DesktopState, action: GatewayAction) {
-    std::thread::spawn(move || {
-        if let Err(error) = state.gateway_action(&app, action) {
-            state.show_error(&app, &error);
-        }
-    });
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Problem

Tray Gateway operations could execute in the wrong order.

Every Start/Stop/Restart menu click called `spawn_action`, which did `std::thread::spawn(...)`. The operation itself is serialized by a mutex in `main.rs`, but a mutex grants no FIFO ordering — whichever thread wins the race runs first.

With the Gateway running, both Stop and Restart are enabled. Click Stop, then Restart. If the Restart thread takes the mutex first, Restart runs, then Stop runs, and the Gateway ends up **stopped** even though the user's last click was Restart. The menu stays live while an operation runs and gateway service commands are slow, so overlapping clicks are realistic rather than theoretical. Repeated "Open Dashboard" clicks likewise piled up threads all blocking on the same mutex.

## Fix

A single long-lived worker (`operation_executor.rs`) drains an `mpsc` channel, so execution order is submission order by construction. `gateway_operation_queue.rs` wraps it with the two shapes this app needs: fire-and-forget submissions that report failures through `show_error` exactly as before, and request/reply submissions over a `oneshot` for the commands that must return a snapshot to their caller.

Every operation that contends on that mutex now goes through the one queue — tray actions, `open_dashboard`, Quick Chat, deep-link/second-launch, bootstrap, the installer, and renderer-issued gateway actions. `spawn_connect` is deleted so the bypass cannot be reintroduced.

That breadth is deliberate. An earlier revision queued only the tray menu clicks, which left `open_dashboard` still spawning a raw thread from `main.rs` and `quickchat.rs`; a connect from a second app launch could still overtake a queued Stop and reproduce the identical defect through a different entry point. Ordering is only meaningful if every contender shares the queue.

Menu callbacks stay non-blocking, error reporting is unchanged, menu enablement is untouched, and requests are never coalesced — every submission executes, in order.

## Proof

```
cargo test --locked --all-targets     # 80 passed; 0 failed
cargo fmt --check                     # clean
```

**Mutation-checked.** Restoring thread-per-operation makes the contention tests fail with exactly the defect:

```
left: [Restart, Stop]      left: [Connect, Stop]
right: [Stop, Restart]     right: [Stop, Connect]
```

The tests force real contention with a barrier and cover both the tray-only case and a mixed case where a non-tray connect is queued behind a tray Stop.

### Proof gap

The queue and its ordering are unit-tested directly. What is not covered, because it needs a running desktop app: live Tauri menu callbacks, `AppHandle` teardown, and shutdown interaction. The worker thread ends when its senders drop and does not block process exit.

The one remaining `thread::spawn` in `main.rs` is the connection watchdog. It only observes — `try_lock`, read status, update the tray — and never issues Start/Stop/Restart, so it does not participate in ordering.
