### PR TITLE
fix(browser): accept 127/8 loopback Gateway URLs

### DIFF
--- a/extensions/browser/chrome-extension/modules/copilot-background-shared.js
+++ b/extensions/browser/chrome-extension/modules/copilot-background-shared.js
@@ -1,3 +1,5 @@
+import { isLoopbackUrlHost } from "./relay-core.js";
+
 const PANEL_PATH = "sidepanel.html";
 
 function parsePanelBindingUrl(chromeApi, raw) {
@@ -90,8 +92,7 @@ export function sessionKeyFromEvent(event) {
 
 function isLoopbackUrl(raw) {
   try {
-    const host = new URL(raw).hostname.toLowerCase();
-    return host === "localhost" || host === "127.0.0.1" || host === "[::1]";
+    return isLoopbackUrlHost(new URL(raw).hostname);
   } catch {
     return false;
   }

--- a/extensions/browser/chrome-extension/modules/panel-core.js
+++ b/extensions/browser/chrome-extension/modules/panel-core.js
@@ -1,5 +1,6 @@
 // Chrome-free browser-copilot helpers. Kept small so the session/binding and
 // rendering invariants run in the normal extension Vitest lane.
+import { isLoopbackUrlHost } from "./relay-core.js";
 
 /** Mint an isolated child thread without exposing the tab id in Gateway state. */
 export function deriveTabSessionKey(mainSessionKey, sessionId) {
@@ -45,8 +46,7 @@ export function normalizeGatewayUrl(raw) {
   if (parsed.username || parsed.password || parsed.search || parsed.hash) {
     return null;
   }
-  const host = parsed.hostname.toLowerCase();
-  const loopback = host === "localhost" || host === "127.0.0.1" || host === "[::1]";
+  const loopback = isLoopbackUrlHost(parsed.hostname);
   if (parsed.protocol !== "wss:" && !(parsed.protocol === "ws:" && loopback)) {
     return null;
   }

--- a/extensions/browser/chrome-extension/modules/panel-core.test.ts
+++ b/extensions/browser/chrome-extension/modules/panel-core.test.ts
@@ -34,6 +34,7 @@ describe("browser copilot panel contracts", () => {
     expect(gatewayUrlFromPairing("ws://127.0.0.1:18792/extension", "ws://127.0.0.1:18789")).toBe(
       "ws://127.0.0.1:18789/",
     );
+    expect(normalizeGatewayUrl("ws://127.0.0.2:18789")).toBe("ws://127.0.0.2:18789/");
     expect(normalizeGatewayUrl("ws://gateway.example")).toBeNull();
     const credentialed = new URL("wss://gateway.example");
     credentialed.username = "fixture-user";

--- a/extensions/browser/chrome-extension/modules/relay-core.d.ts
+++ b/extensions/browser/chrome-extension/modules/relay-core.d.ts
@@ -2,6 +2,7 @@
 // it can load unbundled in Chrome). Kept in sync with relay-core.js.
 
 export const OPENCLAW_TAB_GROUP_TITLE: string;
+export function isLoopbackUrlHost(host: unknown): boolean;
 export function parsePairingString(raw: unknown): {
   relayUrl: string;
   token: string;

--- a/extensions/browser/chrome-extension/modules/relay-core.js
+++ b/extensions/browser/chrome-extension/modules/relay-core.js
@@ -7,6 +7,24 @@ export const OPENCLAW_TAB_GROUP_TITLE = "OpenClaw";
 const EXTENSION_RELAY_PROTOCOL = "openclaw-extension-relay";
 const EXTENSION_RELAY_TOKEN_PROTOCOL_PREFIX = "openclaw-extension-token.";
 
+/** Match the loopback host forms accepted by the pairing CLI. */
+export function isLoopbackUrlHost(host) {
+  let normalized = String(host ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/\.+$/, "");
+  if (normalized.startsWith("[") && normalized.endsWith("]")) {
+    normalized = normalized.slice(1, -1);
+  }
+  return (
+    normalized === "localhost" ||
+    normalized === "::1" ||
+    normalized.startsWith("127.") ||
+    normalized.startsWith("::ffff:127.") ||
+    /^::ffff:7f[0-9a-f]{2}:/u.test(normalized)
+  );
+}
+
 const CHROME_GROUP_COLORS = {
   grey: [128, 128, 128],
   blue: [66, 133, 244],


### PR DESCRIPTION
Closes #114293

## What Problem This Solves

Fixes an issue where Chrome extension users could complete a valid local pairing but have the side panel reject the Gateway when it used a loopback address other than `127.0.0.1` within `127.0.0.0/8`.

## Why This Change Was Made

The extension now has one Chrome-safe loopback-host helper shared by pairing-adjacent panel and copilot topology checks. This aligns the extension with the existing CLI contract without changing public SDK or protocol surfaces.

## User Impact

Valid local Gateways on the full IPv4 loopback range, plus the already-supported IPv6 and mapped-loopback forms, behave consistently throughout the Chrome extension.

## Evidence

- Regression: `normalizeGatewayUrl("ws://127.0.0.2:18789")` returns the normalized URL.
- Browser changed-surface suite: 142 tests passed.
- Adjacent browser pairing CLI contract: 2 tests passed.
- `oxfmt`, targeted `oxlint`, `git diff --check`, public Plugin SDK guard, protected-path guard, and secret scan passed.
- Fresh independent autoreview of the source patch reported no actionable findings, correctness 0.97.
- AI-assisted implementation and review; all reported tests and repository-boundary checks were executed against the pinned checkout.
