### PR TITLE
fix(browser): cancel passive status transport probes

### DIFF
--- a/extensions/browser/src/browser/routes/basic.existing-session.test.ts
+++ b/extensions/browser/src/browser/routes/basic.existing-session.test.ts
@@ -609,7 +609,7 @@ describe("basic browser routes", () => {
 
     expect(response.statusCode).toBe(200);
     expect(isTransportAvailable).toHaveBeenCalledTimes(1);
-    expect(isTransportAvailable).toHaveBeenCalledWith(5_000);
+    expect(isTransportAvailable).toHaveBeenCalledWith(5_000, expect.any(AbortSignal));
     const [timeoutMs, reachabilityOptions] = readFirstReachabilityCall(isReachable);
     expect(timeoutMs).toBeGreaterThan(0);
     expect(timeoutMs).toBeLessThanOrEqual(7_000);

--- a/extensions/browser/src/browser/routes/basic.ts
+++ b/extensions/browser/src/browser/routes/basic.ts
@@ -150,6 +150,7 @@ async function buildBrowserStatus(
         const statusStartedAtMs = Date.now();
         const transportReady = await profileCtx.isTransportAvailable(
           STATUS_CHROME_MCP_TRANSPORT_TIMEOUT_MS,
+          signal,
         );
         if (!transportReady) {
           return [false, false, false] as const;
@@ -165,8 +166,8 @@ async function buildBrowserStatus(
       })()
     : await (async () => {
         const [http, ready] = await Promise.all([
-          profileCtx.isHttpReachable(STATUS_CDP_HTTP_TIMEOUT_MS),
-          profileCtx.isTransportAvailable(STATUS_CDP_TRANSPORT_TIMEOUT_MS),
+          profileCtx.isHttpReachable(STATUS_CDP_HTTP_TIMEOUT_MS, signal),
+          profileCtx.isTransportAvailable(STATUS_CDP_TRANSPORT_TIMEOUT_MS, signal),
         ]);
         // For managed CDP profiles, the transport check already includes a WS
         // handshake against the page, so pageReady mirrors cdpReady.


### PR DESCRIPTION
Closes #114295

## What Problem This Solves

Fixes an issue where cancelling a passive browser-status request could leave its transport probe running until the probe timeout.

## Why This Change Was Made

The route-owned `AbortSignal` is now passed through the Chrome-MCP and regular CDP transport/HTTP probes, matching the cancellation already used by the later page-readiness check.

## User Impact

Cancelled status requests terminate promptly and consistently instead of lingering for the transport-probe budget.

## Evidence

- Regression asserts the exact `isTransportAvailable(5_000, signal)` call.
- Browser changed-surface suite: 142 tests passed.
- `oxfmt`, targeted `oxlint`, `git diff --check`, public Plugin SDK guard, protected-path guard, and secret scan passed.
- Fresh independent autoreview of the source patch reported no actionable findings, correctness 0.97.
- AI-assisted implementation and review; all reported tests and repository-boundary checks were executed against the pinned checkout.
