### PR TITLE
refactor(retry): consolidate abort-safe ClawHub and memory retries

### DIFF
--- a/extensions/memory-core/src/memory/manager-embedding-ops.retry.test.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-ops.retry.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { EmbeddingProvider } from "./embeddings.js";
+import { MemoryManagerEmbeddingOps } from "./manager-embedding-ops.js";
+
+type EmbeddingQueryRetryHarness = {
+  provider: EmbeddingProvider;
+  embedQueryWithRetry: (text: string, signal?: AbortSignal) => Promise<number[]>;
+  markLocalEmbeddingProviderDegraded: (error: unknown) => void;
+  resolveEmbeddingTimeout: () => number;
+  withProviderUse: <T>(provider: EmbeddingProvider, run: () => Promise<T>) => Promise<T>;
+};
+
+function createEmbeddingQueryRetryHarness(
+  embedQuery: EmbeddingProvider["embedQuery"],
+): EmbeddingQueryRetryHarness {
+  const provider: EmbeddingProvider = {
+    id: "test-provider",
+    model: "test-embedding-model",
+    embedQuery,
+    embedBatch: async () => [],
+  };
+
+  // Exercise the real query and retry methods without opening an unrelated
+  // memory index or acquiring an external embedding provider.
+  return Object.assign(Object.create(MemoryManagerEmbeddingOps.prototype), {
+    provider,
+    resolveEmbeddingTimeout: () => 60_000,
+    markLocalEmbeddingProviderDegraded: vi.fn(),
+    withProviderUse: async <T>(_provider: EmbeddingProvider, run: () => Promise<T>) => await run(),
+  }) as EmbeddingQueryRetryHarness;
+}
+
+describe("memory embedding query retry cancellation", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("cancels provider backoff immediately without sending a second request", async () => {
+    vi.useFakeTimers();
+    const controller = new AbortController();
+    const abortReason = new Error("memory search was cancelled");
+    const embedQuery = vi
+      .fn<EmbeddingProvider["embedQuery"]>()
+      .mockRejectedValue(new Error("TypeError: fetch failed"));
+    const manager = createEmbeddingQueryRetryHarness(embedQuery);
+
+    const pending = manager.embedQueryWithRetry("search terms", controller.signal);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(embedQuery).toHaveBeenCalledOnce();
+    expect(vi.getTimerCount()).toBe(1);
+
+    controller.abort(abortReason);
+
+    await expect(pending).rejects.toMatchObject({
+      code: "MEMORY_EMBEDDING_OPERATION_FAILED",
+      operation: "query",
+      cause: { message: "aborted", cause: abortReason },
+    });
+    expect(embedQuery).toHaveBeenCalledOnce();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("never starts a provider request for an already-cancelled search", async () => {
+    const abortReason = new Error("memory search was cancelled");
+    const embedQuery = vi.fn<EmbeddingProvider["embedQuery"]>();
+    const manager = createEmbeddingQueryRetryHarness(embedQuery);
+
+    await expect(
+      manager.embedQueryWithRetry("search terms", AbortSignal.abort(abortReason)),
+    ).rejects.toMatchObject({
+      code: "MEMORY_EMBEDDING_OPERATION_FAILED",
+      operation: "query",
+      cause: abortReason,
+    });
+    expect(embedQuery).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/memory-core/src/memory/manager-embedding-ops.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-ops.ts
@@ -24,6 +24,7 @@ import {
   type MemorySource,
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import { MAX_TIMER_TIMEOUT_MS, resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
+import { sleepWithAbort } from "openclaw/plugin-sdk/runtime-env";
 import { runSqliteImmediateTransactionSync } from "openclaw/plugin-sdk/sqlite-runtime";
 import type { EmbeddingProvider } from "./embeddings.js";
 import {
@@ -632,16 +633,18 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
     }
   }
 
-  private async waitForEmbeddingRetry(delayMs: number, action: string): Promise<void> {
+  private async waitForEmbeddingRetry(
+    delayMs: number,
+    action: string,
+    signal?: AbortSignal,
+  ): Promise<void> {
     const waitMs = resolveMemoryEmbeddingRetryDelay(
       delayMs,
       Math.random(),
       EMBEDDING_RETRY_MAX_DELAY_MS,
     );
     log.warn(`memory embeddings retryable error; ${action} in ${waitMs}ms`);
-    await new Promise((resolve) => {
-      setTimeout(resolve, waitMs);
-    });
+    await sleepWithAbort(waitMs, signal);
   }
 
   private resolveEmbeddingTimeout(
@@ -688,7 +691,7 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
             signal,
             isRetryable: isRetryableMemoryEmbeddingError,
             waitForRetry: async (delayMs) => {
-              await this.waitForEmbeddingRetry(delayMs, "retrying query");
+              await this.waitForEmbeddingRetry(delayMs, "retrying query", signal);
             },
             maxAttempts: EMBEDDING_RETRY_MAX_ATTEMPTS,
             baseDelayMs: EMBEDDING_RETRY_BASE_DELAY_MS,

--- a/extensions/memory-core/src/memory/manager-embedding-policy.test.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-policy.test.ts
@@ -1,4 +1,5 @@
 // Memory Core tests cover manager embedding policy plugin behavior.
+import { sleepWithAbort } from "openclaw/plugin-sdk/runtime-env";
 import { describe, expect, it, vi } from "vitest";
 import {
   buildMemoryEmbeddingBatches,
@@ -94,6 +95,66 @@ describe("memory embedding policy", () => {
     ).rejects.toThrow("memory embeddings query timed out after 60s");
 
     expect(run).toHaveBeenCalledTimes(1);
+    expect(waitForRetry).not.toHaveBeenCalled();
+  });
+
+  it("aborts an in-progress retry delay without starting another provider request", async () => {
+    vi.useFakeTimers();
+    try {
+      const controller = new AbortController();
+      const abortReason = new Error("memory search was cancelled");
+      const run = vi.fn(async () => {
+        throw new Error("memory embeddings query timed out after 60s");
+      });
+      const waitForRetry = vi.fn(async (delayMs: number) => {
+        await sleepWithAbort(delayMs, controller.signal);
+      });
+
+      const pending = runMemoryEmbeddingRetryLoop({
+        run,
+        isRetryable: isRetryableMemoryEmbeddingError,
+        waitForRetry,
+        maxAttempts: 3,
+        baseDelayMs: 500,
+        signal: controller.signal,
+      });
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(run).toHaveBeenCalledOnce();
+      expect(waitForRetry).toHaveBeenCalledWith(500);
+      expect(vi.getTimerCount()).toBe(1);
+
+      controller.abort(abortReason);
+
+      await expect(pending).rejects.toMatchObject({
+        message: "aborted",
+        cause: abortReason,
+      });
+      expect(run).toHaveBeenCalledOnce();
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("preserves permanent provider error identity without retrying", async () => {
+    const permanentError = new Error("embedding validation failed");
+    const run = vi.fn(async () => {
+      throw permanentError;
+    });
+    const waitForRetry = vi.fn(async () => {});
+
+    await expect(
+      runMemoryEmbeddingRetryLoop({
+        run,
+        isRetryable: isRetryableMemoryEmbeddingError,
+        waitForRetry,
+        maxAttempts: 3,
+        baseDelayMs: 500,
+      }),
+    ).rejects.toBe(permanentError);
+
+    expect(run).toHaveBeenCalledOnce();
     expect(waitForRetry).not.toHaveBeenCalled();
   });
 

--- a/extensions/memory-core/src/memory/manager-embedding-policy.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-policy.ts
@@ -1,5 +1,6 @@
 // Memory Core plugin module implements manager embedding policy behavior.
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { retryAsync } from "openclaw/plugin-sdk/retry-runtime";
 
 type MemoryEmbeddingTextPart = {
   type: "text";
@@ -122,26 +123,15 @@ export async function runMemoryEmbeddingRetryLoop<T>(params: {
   /** Caller-owned cancellation; an aborted caller stops the retry loop. */
   signal?: AbortSignal;
 }): Promise<T> {
-  const attempts = Math.max(1, params.maxAttempts);
-  for (const attempt of Array.from({ length: attempts }, (_, index) => index + 1)) {
-    const delayMs = params.baseDelayMs * 2 ** (attempt - 1);
-    try {
-      return await params.run();
-    } catch (err) {
-      // Abort must win over retryable-looking failures: abort reasons often
-      // carry "timed out" messages that match the retryable transport
-      // patterns and would otherwise keep retrying for an absent caller.
-      if (params.signal?.aborted) {
-        throw err;
-      }
-      const message = formatErrorMessage(err);
-      if (!params.isRetryable(message) || attempt >= params.maxAttempts) {
-        throw err;
-      }
-      await params.waitForRetry(delayMs);
-    }
-  }
-  throw new Error("retry loop exhausted");
+  return await retryAsync(params.run, {
+    attempts: params.maxAttempts,
+    minDelayMs: params.baseDelayMs,
+    maxDelayMs: Number.MAX_SAFE_INTEGER,
+    // Caller cancellation wins even when its timeout resembles a retryable
+    // provider error; otherwise abandoned searches start another request.
+    shouldRetry: (err) => !params.signal?.aborted && params.isRetryable(formatErrorMessage(err)),
+    sleep: params.waitForRetry,
+  });
 }
 
 export async function runMemoryEmbeddingBatchRetryWithSplit<TInput, TOutput>(params: {

--- a/extensions/memory-core/src/memory/qmd-manager-sync.retry.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager-sync.retry.test.ts
@@ -1,0 +1,116 @@
+import type { PluginStateLeaseContext } from "openclaw/plugin-sdk/plugin-state-runtime";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { QmdMemoryManager } from "./qmd-manager.js";
+
+type QmdRetryHarness = {
+  runQmdUpdateOnce: (reason: string, lease: PluginStateLeaseContext) => Promise<void>;
+  runQmdUpdateWithRetry: (reason: string, lease: PluginStateLeaseContext) => Promise<void>;
+};
+
+function createQmdRetryHarness(
+  runQmdUpdateOnce: QmdRetryHarness["runQmdUpdateOnce"],
+): QmdRetryHarness {
+  // The real inherited retry path needs only its update operation and lease;
+  // creating a full manager would start an unrelated external qmd process.
+  const manager = Object.create(QmdMemoryManager.prototype) as QmdRetryHarness;
+  manager.runQmdUpdateOnce = runQmdUpdateOnce;
+  return manager;
+}
+
+function createQmdRetryLease(signal: AbortSignal): PluginStateLeaseContext {
+  return { signal, assertOwned: vi.fn() };
+}
+
+describe("QMD update retry policy", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("retries boot-time SQLite lock failures on the canonical exponential schedule", async () => {
+    vi.useFakeTimers();
+    const runQmdUpdateOnce = vi
+      .fn<QmdRetryHarness["runQmdUpdateOnce"]>()
+      .mockRejectedValueOnce(new Error("SQLITE_BUSY: database is locked"))
+      .mockRejectedValueOnce(new Error("SQLITE_BUSY: database is locked"))
+      .mockResolvedValueOnce(undefined);
+    const controller = new AbortController();
+    const lease = createQmdRetryLease(controller.signal);
+    const manager = createQmdRetryHarness(runQmdUpdateOnce);
+
+    const pending = manager.runQmdUpdateWithRetry("boot", lease);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(runQmdUpdateOnce).toHaveBeenCalledOnce();
+
+    await vi.advanceTimersByTimeAsync(499);
+    expect(runQmdUpdateOnce).toHaveBeenCalledOnce();
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(runQmdUpdateOnce).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(999);
+    expect(runQmdUpdateOnce).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await expect(pending).resolves.toBeUndefined();
+    expect(runQmdUpdateOnce).toHaveBeenCalledTimes(3);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("preserves the lease abort reason and clears a pending retry timer", async () => {
+    vi.useFakeTimers();
+    const runQmdUpdateOnce = vi
+      .fn<QmdRetryHarness["runQmdUpdateOnce"]>()
+      .mockRejectedValue(new Error("SQLITE_BUSY: database is locked"));
+    const controller = new AbortController();
+    const leaseLost = new Error("qmd write lease was lost");
+    const manager = createQmdRetryHarness(runQmdUpdateOnce);
+
+    const pending = manager.runQmdUpdateWithRetry(
+      "boot:startup",
+      createQmdRetryLease(controller.signal),
+    );
+    await vi.advanceTimersByTimeAsync(0);
+    expect(vi.getTimerCount()).toBe(1);
+
+    controller.abort(leaseLost);
+
+    await expect(pending).rejects.toBe(leaseLost);
+    expect(runQmdUpdateOnce).toHaveBeenCalledOnce();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("preserves lease cancellation when it races with a retryable update failure", async () => {
+    const controller = new AbortController();
+    const leaseLost = new Error("qmd write lease was lost");
+    const runQmdUpdateOnce = vi.fn<QmdRetryHarness["runQmdUpdateOnce"]>(async () => {
+      controller.abort(leaseLost);
+      throw new Error("SQLITE_BUSY: database is locked");
+    });
+    const manager = createQmdRetryHarness(runQmdUpdateOnce);
+
+    await expect(
+      manager.runQmdUpdateWithRetry("boot", createQmdRetryLease(controller.signal)),
+    ).rejects.toBe(leaseLost);
+
+    expect(runQmdUpdateOnce).toHaveBeenCalledOnce();
+  });
+
+  it("does not replay failed manual updates or permanent boot failures", async () => {
+    const scenarios = [
+      { reason: "manual", error: new Error("SQLITE_BUSY: database is locked") },
+      { reason: "boot", error: new Error("qmd collection is invalid") },
+    ];
+
+    for (const { reason, error } of scenarios) {
+      const runQmdUpdateOnce = vi
+        .fn<QmdRetryHarness["runQmdUpdateOnce"]>()
+        .mockRejectedValue(error);
+      const manager = createQmdRetryHarness(runQmdUpdateOnce);
+
+      await expect(
+        manager.runQmdUpdateWithRetry(reason, createQmdRetryLease(new AbortController().signal)),
+      ).rejects.toBe(error);
+      expect(runQmdUpdateOnce).toHaveBeenCalledOnce();
+    }
+  });
+});

--- a/extensions/memory-core/src/memory/qmd-manager-sync.ts
+++ b/extensions/memory-core/src/memory/qmd-manager-sync.ts
@@ -5,6 +5,8 @@ import {
   PluginStateLeaseError,
   type PluginStateLeaseContext,
 } from "openclaw/plugin-sdk/plugin-state-runtime";
+import { retryAsync } from "openclaw/plugin-sdk/retry-runtime";
+import { sleepWithAbort } from "openclaw/plugin-sdk/runtime-env";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { asQmdAbortError, isSqliteBusyError } from "./qmd-command-errors.js";
 import { QmdManagerBase, qmdManagerLog } from "./qmd-manager-base.js";
@@ -155,22 +157,37 @@ export abstract class QmdManagerSync extends QmdManagerBase {
   ): Promise<void> {
     const { signal } = lease;
     const isBootRun = reason === "boot" || reason.startsWith("boot:");
-    const maxAttempts = isBootRun ? 3 : 1;
-    for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
-      try {
-        await this.runQmdUpdateOnce(reason, lease);
-        return;
-      } catch (err) {
-        if (attempt >= maxAttempts || !this.isRetryableUpdateError(err)) {
-          throw err;
+    await retryAsync(() => this.runQmdUpdateOnce(reason, lease), {
+      attempts: isBootRun ? 3 : 1,
+      minDelayMs: 500,
+      maxDelayMs: 1_000,
+      shouldRetry: (err) => {
+        if (!this.isRetryableUpdateError(err)) {
+          return false;
         }
-        const delayMs = 500 * 2 ** (attempt - 1);
+        // A lease can be revoked while its update fails. Preserve the owning
+        // lease's abort reason instead of leaking the stale update failure.
+        this.throwIfAborted(signal);
+        return true;
+      },
+      onRetry: ({ attempt, maxAttempts, err }) => {
         qmdManagerLog.warn(
           `qmd update retry ${attempt}/${maxAttempts - 1} after failure (${reason}): ${String(err)}`,
         );
-        await this.waitForRetryDelay(delayMs, signal);
-      }
-    }
+      },
+      sleep: async (delayMs) => {
+        try {
+          await sleepWithAbort(delayMs, signal);
+        } catch (err) {
+          // Lease owners need their original abort reason, not the retry
+          // scheduler's generic abort wrapper.
+          if (signal.aborted) {
+            throw asQmdAbortError(signal);
+          }
+          throw err;
+        }
+      },
+    });
   }
 
   protected async runQmdUpdateOnce(reason: string, lease: PluginStateLeaseContext): Promise<void> {
@@ -211,21 +228,6 @@ export abstract class QmdManagerSync extends QmdManagerBase {
     if (signal.aborted) {
       throw asQmdAbortError(signal);
     }
-  }
-
-  protected async waitForRetryDelay(delayMs: number, signal: AbortSignal): Promise<void> {
-    this.throwIfAborted(signal);
-    await new Promise<void>((resolve, reject) => {
-      const onAbort = () => {
-        clearTimeout(timeout);
-        reject(asQmdAbortError(signal));
-      };
-      const timeout = setTimeout(() => {
-        signal.removeEventListener("abort", onAbort);
-        resolve();
-      }, delayMs);
-      signal.addEventListener("abort", onAbort, { once: true });
-    });
   }
 
   protected shouldRunEmbed(force?: boolean): boolean {

--- a/src/infra/clawhub-retry.test.ts
+++ b/src/infra/clawhub-retry.test.ts
@@ -74,6 +74,69 @@ describe("retryClawHubRead", () => {
     },
   );
 
+  it("honors a valid HTTP-date Retry-After through the shared parser", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2027-03-02T23:59:30.000Z"));
+    try {
+      const delays: number[] = [];
+      let attempts = 0;
+
+      const result = await retryClawHubRead(
+        async () => {
+          attempts += 1;
+          return {
+            response: new Response(attempts === 1 ? "limited" : "ok", {
+              status: attempts === 1 ? 503 : 200,
+              headers:
+                attempts === 1 ? { "Retry-After": "Tue, 02 Mar 2027 23:59:35 GMT" } : undefined,
+            }),
+          };
+        },
+        {
+          disposeRetry: async ({ response }) => {
+            await response.body?.cancel();
+          },
+          sleep: async (ms) => {
+            delays.push(ms);
+          },
+        },
+      );
+
+      expect(await result.response.text()).toBe("ok");
+      expect(delays).toEqual([5_000]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("uses the bounded schedule when Retry-After exceeds the ClawHub cap", async () => {
+    const delays: number[] = [];
+    let attempts = 0;
+
+    const result = await retryClawHubRead(
+      async () => {
+        attempts += 1;
+        return {
+          response: new Response(attempts === 1 ? "limited" : "ok", {
+            status: attempts === 1 ? 503 : 200,
+            headers: attempts === 1 ? { "Retry-After": "61" } : undefined,
+          }),
+        };
+      },
+      {
+        disposeRetry: async ({ response }) => {
+          await response.body?.cancel();
+        },
+        sleep: async (ms) => {
+          delays.push(ms);
+        },
+      },
+    );
+
+    expect(await result.response.text()).toBe("ok");
+    expect(delays).toEqual([1_000]);
+  });
+
   it("ignores Retry-After HTTP dates that Date.parse would normalize", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2027-03-02T23:59:30.000Z"));

--- a/src/infra/clawhub-retry.ts
+++ b/src/infra/clawhub-retry.ts
@@ -1,5 +1,5 @@
 // Defines the bounded retry contract shared by ClawHub runtime and release reads.
-import { parseRetryAfterHttpDateMs } from "../../packages/ai/src/internal/retry-after.js";
+import { parseRetryAfterHeaderSeconds } from "./retry-after.js";
 import { retryAsync } from "./retry.js";
 
 const CLAWHUB_RETRY_DELAYS_MS = [1_000, 3_000, 10_000] as const;
@@ -32,27 +32,12 @@ function isRetryableClawHubStatus(status: number, retryRateLimit: boolean): bool
 }
 
 function parseRetryAfterMs(headers: Headers): number | undefined {
-  const retryAfter = headers.get("retry-after")?.trim();
-  if (!retryAfter) {
+  const retryAfterSeconds = parseRetryAfterHeaderSeconds(headers.get("retry-after"));
+  if (retryAfterSeconds === undefined) {
     return undefined;
   }
-  if (/^\d+$/.test(retryAfter)) {
-    const seconds = Number(retryAfter);
-    const delayMs = Math.round(seconds * 1_000);
-    return delayMs <= CLAWHUB_MAX_RETRY_AFTER_MS ? delayMs : undefined;
-  }
-  const retryAt = parseRetryAfterHttpDateMs(retryAfter);
-  if (retryAt === undefined) {
-    return undefined;
-  }
-  const delayMs = Math.max(0, retryAt - Date.now());
+  const delayMs = retryAfterSeconds * 1_000;
   return delayMs <= CLAWHUB_MAX_RETRY_AFTER_MS ? delayMs : undefined;
-}
-
-async function defaultSleep(ms: number): Promise<void> {
-  await new Promise<void>((resolve) => {
-    setTimeout(resolve, ms);
-  });
 }
 
 /**
@@ -86,7 +71,7 @@ export async function retryClawHubRead<T extends ClawHubResponseHandle>(
             await options.disposeRetry(err.result);
           }
         },
-        sleep: options.sleep ?? defaultSleep,
+        sleep: options.sleep,
       },
     );
   } catch (error) {

--- a/src/infra/retry-after.ts
+++ b/src/infra/retry-after.ts
@@ -1,5 +1,9 @@
-import { parseRetryAfterHttpDateMs } from "@openclaw/ai/internal/retry-after";
-import { asFiniteNumberInRange, parseStrictNonNegativeInteger } from "../shared/number-coercion.js";
+// Release harnesses execute source before workspace package dist files exist.
+import { parseRetryAfterHttpDateMs } from "../../packages/ai/src/internal/retry-after.js";
+import {
+  asFiniteNumberInRange,
+  parseStrictNonNegativeInteger,
+} from "../../packages/normalization-core/src/number-coercion.js";
 
 const RETRY_AFTER_HEADER_DELAY_RE = /^\d+$/;
 const MAX_SAFE_RETRY_AFTER_SECONDS = Number.MAX_SAFE_INTEGER / 1000;


### PR DESCRIPTION
## What Problem This Solves

ClawHub and Memory Core maintained independent HTTP retry parsing, retry scheduling, and timer cleanup. That duplication could leave a cancelled memory search waiting through provider backoff, obscure the original cause of a revoked QMD write lease, or let rate-limit handling diverge from OpenClaw's canonical retry contract.

## Why This Change Was Made

Use the existing core Retry-After parser, retry runner, and abortable sleep instead of maintaining parallel implementations. Preserve ClawHub's strict HTTP-date validation, 60-second rate-limit cap, response disposal, final HTTP response ownership, and refusal to replay non-idempotent requests. Preserve QMD's boot-only exponential retries, exact lease cancellation reason, and memory embedding retry classification, batch splitting, terminal error identity, and cancellation.

## User Impact

Cancelled memory searches and revoked QMD leases now stop retry timers immediately without sending extra requests. ClawHub keeps its existing bounded, safe read-retry behavior. This removes production code without adding configuration, compatibility layers, provider routes, or public SDK surfaces.

## Evidence

- Historical release compatibility: `pnpm test test/scripts/release-wrapper-scripts.test.ts` — **4/4 passed**, including trusted current-source planning and verification against an old release target before workspace package distribution artifacts exist. The shared Retry-After parser imports both canonical date and normalization implementations directly from their source modules.
- Follow-up Blacksmith Testbox `tbx_01kygzrsbp3e4r7dr51g19y5tr`; [historical release and cross-channel proof](https://github.com/openclaw/openclaw/actions/runs/30239064978).
- Expanded 15-target regression: **442 passed**, 2 existing skipped, including the historical release harness, strict AI HTTP-date parsing, canonical retry, ClawHub, live-loopback Discord API and retry scheduling, Microsoft Teams throttling, and all focused QMD and memory cancellation tests.
- Same pushed-commit production proof: `pnpm format:check src/infra/retry-after.ts`, all three Knip gates (`pnpm deadcode:dependencies`, `pnpm deadcode:unused-files`, and `pnpm deadcode:exports`), and the complete `pnpm build` **passed**. Knip reported zero unused files or exports; the build verified all 142 public plugin SDK subpaths, CLI bootstrap, and production Control UI.
- Fresh `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output` of the historical-release source compatibility correction: clean, no actionable findings.
- Blacksmith Testbox `tbx_01kygy1gchgbb9m61cbdr96bh8`; [remote proof](https://github.com/openclaw/openclaw/actions/runs/30237779820).
- `pnpm test packages/retry/src/index.test.ts src/infra/retry.test.ts src/infra/retry-policy.test.ts src/infra/clawhub-retry.test.ts src/infra/clawhub.test.ts extensions/memory-core/src/memory/manager-embedding-policy.test.ts extensions/memory-core/src/memory/manager-embedding-ops.retry.test.ts extensions/memory-core/src/memory/qmd-manager-sync.retry.test.ts extensions/memory-core/src/memory/qmd-manager.test.ts`: **345 passed**, 2 existing skipped.
- Trusted Testbox terminal: canonical retry **10 passed**; core retry, HTTP-date parsing, bounded ClawHub reads, response disposal, and write safety **152 passed / 2 existing skipped**; complete QMD and memory cancellation regression tests **183 passed**. The exact abort-race test verifies the original QMD lease error; direct memory query cancellation verifies **one request and zero pending timers**.
- Direct production-runtime smoke, using `node --import tsx` to invoke the real strict parser, ClawHub reader, retry runner, and abortable sleep on Testbox:

  ```json
  {"strictDateSeconds":5,"fractionalDelayRejected":true,"clawhub":{"attempts":2,"delaysMs":[5000],"disposedResponses":1,"result":"ok"},"canonicalBackoff":{"attempts":3,"delaysMs":[500,1000],"result":"ok"},"abort":{"message":"aborted","originalReason":"qmd write lease was lost","signalAborted":true}}
  ```
- Focused regressions prove strict and bounded HTTP-date handling, disposal of retry responses, no replay of writes or permanent provider failures, exact QMD retry timing, cancellation during embedding backoff, no orphaned timers, and preservation of the original lease abort reason even when cancellation races with a failed update.
- Changed-scope `pnpm check:changed -- <all eight changed files>`: all **four** core, core-test, plugin, and plugin-test typechecks, plus formatting, SDK contracts, and architecture guards passed. The remaining full-repository serial lint fan-out is delegated to hosted PR CI.
- `pnpm deadcode:dependencies`, `pnpm deadcode:unused-files`, and `pnpm deadcode:exports`.
- `pnpm build`.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output`: clean after addressing the QMD cancellation-race finding.
- AI-assisted; reviewed against existing production callers, the canonical retry implementation, strict HTTP-date parser, lease ownership, plugin boundaries, and adjacent regression tests.
