### PR TITLE
docs(agents): add ops telegraph notes for CI dispatch, release logs, and shared checkouts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,10 +208,15 @@ Skills own workflows; root owns hard policy and routing.
 - `rg`: options/globs before `--`; `--` immediately before a leading-dash pattern only.
 - `gh --jq` is not standalone `jq`; pipe JSON to `jq` for variables or `--arg`.
 - Shared checkout: serialize `git fetch`; on ref-lock failure, re-read the ref before retry.
+- Main locked elsewhere: detach at `origin/main`, then create the task branch.
 - Git fetch/pull yielding without completion: inspect/stop only the owned process before retry; never overlap retries.
 - `gh api --paginate '<endpoint>' | jq -s ...`; gh `--slurp` may emit nothing and forbids `--jq`/`--template`.
 - Main-bound workflow dispatch: resolve server `main` SHA immediately before dispatch; retry if identity fails after `main` advances.
+- `release-ci-summary` accepts Full Release Validation parent runs only.
+- Diverged release-branch logs: use `--first-parent` plus a bounded count.
 - `gh run view --json` uses `attempt`, not `attemptNumber`.
+- GH job logs: filter the exact tab-delimited step first; broad patterns also match the job name.
+- Path formatter: `node_modules/.bin/oxfmt`; `pnpm exec` may reconcile workspace deps.
 - Crabbox stop: no `--timing-json`; use `node scripts/crabbox-wrapper.mjs stop --provider <provider> --id <id>`.
 - macOS `find` has no `-printf`; use `-print0` plus `stat`.
 - Actions checkout refs: use full 40-char SHAs; short SHAs resolve as branches/tags.
@@ -243,7 +248,7 @@ Skills own workflows; root owns hard policy and routing.
 - GitHub issue/PR create: read `$agent-transcript`; ask about sanitized transcript logs when available.
 - Contributor PRs: parsed context requires authored `What Problem This Solves` and `Evidence` sections. Do not require field-level proof forms; reviewers inspect code, tests, and CI for correctness.
 - PR artifacts/screenshots: attach to PR/comment/external artifact store. Never push screenshots, videos, proof images, or proof assets to OpenClaw or any product repo branch, including temp artifact branches. Use Crabbox artifact publishing plus the manifest URL. Do not commit `.github/pr-assets`.
-- CI polling: exact SHA, relevant checks only, minimal fields. Skip routine noise (`Auto response`, `Labeler`, docs agents, performance/stale). Logs only after failure/completion or concrete need. Never `gh run watch`; its 3s polling exhausts API quota. Use sparse GraphQL rollups. Filter `gh run list` by workflow/branch/commit; broad JSON lists can exceed relay caps. `gh --jq` has no jq `--arg`; use `--commit` for SHA filtering. Reruns need `gh run view <run> --attempt <n>`; default output may show the prior attempt.
+- CI polling: exact SHA, relevant checks only, minimal fields. Skip routine noise (`Auto response`, `Labeler`, docs agents, performance/stale). Logs only after failure/completion or concrete need. Never `gh run watch`; its 3s polling exhausts API quota. Use sparse GraphQL rollups. Filter `gh run list` by workflow/branch/commit; broad JSON lists can exceed relay caps. `gh --jq` has no jq `--arg`; use `--commit` for SHA filtering. Reruns need `gh run view <run> --attempt <n>`; default output may show the prior attempt. Exact-SHA fallback dispatches require the full 40-character SHA.
 - CI waits: node scripts/watch-pr-ci.mjs <pr> <head-sha> — prechecks mergeable (CONFLICTING = pull_request CI cannot attach) and run attachment before polling; watchers emit every terminal state; no unbounded polls.
 - Trusted-workflow release-branch CI: pass `target_ref` + `release_candidate_ref`; never `release_gate` (requires workflow head == target).
 - Agent PR landing to `main`: use only the repo-native `scripts/pr` wrapper: run `scripts/pr review-init <PR>`, follow its emitted checkout/guard guidance, initialize and complete review artifacts with `scripts/pr review-artifacts-init <PR>`, validate them with `scripts/pr review-validate-artifacts <PR>`, then run `OPENCLAW_TESTBOX=1 scripts/pr prepare-run <PR>` and `scripts/pr merge-run <PR>`. The Testbox flag is mandatory for agents so prepare verifies hosted CI/Testbox on the current head or reuses a patch-identical pre-rebase run green within 24 hours instead of running full gates locally. `prepare-run` fails fast; invoke only after exact-head CI is complete and green. For owner-approved reviewed fork code without hosted Testbox, use `OPENCLAW_PR_GATES_REMOTE=testbox` instead. Do not rebase only because `main` advanced; merge drift is advisory unless strict drift is explicitly enabled, while GitHub still blocks conflicts. Do not idle on `auto-response` or `check-docs`.


### PR DESCRIPTION
## What Problem This Solves

Root `AGENTS.md` was missing several hard-won operational rules that agents keep rediscovering the expensive way: workflow dispatch fallbacks silently resolving short SHAs, `release-ci-summary` being fed non-parent runs, unbounded log reads on diverged release branches, GH job-log greps matching job names instead of steps, `pnpm exec` reconciling workspace deps when only a formatter was needed, and shared-checkout contention when `main` is locked by a sibling worktree.

## Why This Change Was Made

These telegraph-style notes capture operator/agent policy learned during recent release and CI work so future sessions do not repeat the same failures. Root `AGENTS.md` is the designated home for hard rules of this kind.

## User Impact

None at runtime. Docs-only: agent/maintainer guidance in the repo root instruction file. No code, config, tests, or published surfaces change.

## Evidence

- Diff is a single file, `AGENTS.md`: 6 added telegraph lines plus one sentence appended to the existing CI-polling rule ("Exact-SHA fallback dispatches require the full 40-character SHA.").
- `git diff --check` clean; sanity read of the surrounding GitHub/PRs section confirms placement next to the existing `gh`/dispatch/Crabbox rules.
- Docs-only change per repo validation policy (no heavy suite required).
