### PR TITLE
fix(codex): preserve continuity across races and paginated history

### DIFF
--- a/extensions/codex/src/app-server/attempt-steering.test.ts
+++ b/extensions/codex/src/app-server/attempt-steering.test.ts
@@ -225,6 +225,30 @@ describe("Codex app-server steering queue", () => {
     expect(request).not.toHaveBeenCalled();
   });
 
+  it("steers when a claimed pending input was resolved before the answer", async () => {
+    const request = vi.fn(async () => ({ turnId: "turn-1" }));
+    const answerPendingUserInput = vi.fn(() => false);
+    const queue = createQueue(request, {
+      claimPendingUserInput: () => ({
+        answer: answerPendingUserInput,
+        cancel: vi.fn(() => false),
+      }),
+    });
+
+    const queued = queue.queue("do not drop this", { debounceMs: 0 });
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(answerPendingUserInput).toHaveBeenCalledWith("do not drop this");
+    expect(request).toHaveBeenCalledWith("turn/steer", {
+      threadId: "thread-1",
+      expectedTurnId: "turn-1",
+      input: [{ type: "text", text: "do not drop this", text_elements: [] }],
+      clientUserMessageId: "openclaw:turn-1:steer:1",
+    });
+    expect(queue.confirmConsumed("openclaw:turn-1:steer:1")).toBe(true);
+    await queued;
+  });
+
   it("steers a complete image reply before releasing pending input", async () => {
     const request = vi.fn(async () => ({ turnId: "turn-1" }));
     const answerPendingUserInput = vi.fn(() => true);

--- a/extensions/codex/src/app-server/attempt-steering.ts
+++ b/extensions/codex/src/app-server/attempt-steering.ts
@@ -189,15 +189,24 @@ export function createCodexSteeringQueue(params: {
       const pendingUserInput = params.claimPendingUserInput();
       if (pendingUserInput) {
         if (!options?.images?.length) {
-          pendingUserInput.answer(text);
+          // Codex may resolve or clear the request after it was claimed but
+          // before this answer wins. Preserve the user message by steering it
+          // into the still-active turn when that compare-and-resolve fails.
+          if (pendingUserInput.answer(text)) {
+            return;
+          }
+        }
+        if (options?.images?.length) {
+          // request_user_input cannot carry images. Submit the complete message
+          // before releasing the prompt so no partial text answer can win the race.
+          void flushBatch().catch(() => undefined);
+          const { item, delivery } = createPendingMessage(text, options.images);
+          await Promise.all([
+            enqueueSend([item]).finally(() => pendingUserInput.cancel()),
+            delivery,
+          ]);
           return;
         }
-        // request_user_input cannot carry images. Submit the complete message
-        // before releasing the prompt so no partial text answer can win the race.
-        void flushBatch().catch(() => undefined);
-        const { item, delivery } = createPendingMessage(text, options.images);
-        await Promise.all([enqueueSend([item]).finally(() => pendingUserInput.cancel()), delivery]);
-        return;
       }
       if (closedError) {
         throw closedError;

--- a/extensions/codex/src/app-server/client.test.ts
+++ b/extensions/codex/src/app-server/client.test.ts
@@ -623,6 +623,53 @@ describe("CodexAppServerClient", () => {
     });
   });
 
+  it("aborts an in-flight server request when its transport closes", async () => {
+    const harness = createClientHarness();
+    clients.push(harness.client);
+    let requestSignal: AbortSignal | undefined;
+    harness.client.addRequestHandler((_request, signal) => {
+      requestSignal = signal;
+      return new Promise<never>(() => {});
+    });
+
+    harness.send({ id: "srv-close", method: "item/tool/call", params: { tool: "message" } });
+    await vi.waitFor(() => expect(requestSignal).toBeDefined());
+
+    harness.client.close();
+
+    expect(requestSignal?.aborted).toBe(true);
+  });
+
+  it("runs every close handler even when an earlier handler throws", () => {
+    const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
+    const harness = createClientHarness();
+    clients.push(harness.client);
+    const laterHandler = vi.fn();
+    harness.client.addCloseHandler(() => {
+      throw new Error("broken close observer");
+    });
+    harness.client.addCloseHandler(laterHandler);
+
+    expect(() => harness.client.close()).not.toThrow();
+
+    expect(laterHandler).toHaveBeenCalledWith(harness.client);
+    expect(warn).toHaveBeenCalledWith("codex app-server close handler failed", {
+      error: expect.any(Error),
+    });
+  });
+
+  it("notifies a close handler registered after the transport already closed", () => {
+    const harness = createClientHarness();
+    clients.push(harness.client);
+    harness.client.close();
+    const lateHandler = vi.fn();
+
+    const remove = harness.client.addCloseHandler(lateHandler);
+
+    expect(lateHandler).toHaveBeenCalledWith(harness.client);
+    expect(remove()).toBeUndefined();
+  });
+
   it("fails closed for unhandled native app-server approvals", async () => {
     const harness = createClientHarness();
     clients.push(harness.client);

--- a/extensions/codex/src/app-server/client.ts
+++ b/extensions/codex/src/app-server/client.ts
@@ -237,6 +237,7 @@ export class CodexAppServerClient {
   private readonly requestHandlers = new Set<CodexServerRequestHandler>();
   private readonly notificationHandlers = new Set<CodexServerNotificationHandler>();
   private readonly closeHandlers = new Set<(client: CodexAppServerClient) => void>();
+  private readonly serverRequestControllers = new Set<AbortController>();
   private nextId = 1;
   private initialized = false;
   private closed = false;
@@ -692,6 +693,10 @@ export class CodexAppServerClient {
 
   /** Registers a close handler and returns its disposer. */
   addCloseHandler(handler: (client: CodexAppServerClient) => void): () => void {
+    if (this.closed) {
+      this.notifyCloseHandler(handler);
+      return () => undefined;
+    }
     this.closeHandlers.add(handler);
     return () => this.closeHandlers.delete(handler);
   }
@@ -879,32 +884,37 @@ export class CodexAppServerClient {
     request: Required<Pick<RpcRequest, "id" | "method">> & { params?: JsonValue },
   ): Promise<JsonValue | undefined> {
     const controller = new AbortController();
-    const timeoutResponse = timeoutServerRequestResponse(request);
-    if (!timeoutResponse) {
-      return await this.runServerRequestHandlersWithoutTimeout(request, controller.signal);
-    }
-
-    let timeout: ReturnType<typeof setTimeout> | undefined;
+    this.serverRequestControllers.add(controller);
     try {
-      return await Promise.race([
-        this.runServerRequestHandlersWithoutTimeout(request, controller.signal),
-        new Promise<JsonValue>((resolve) => {
-          timeout = setTimeout(() => {
-            embeddedAgentLog.warn("codex app-server server request timed out", {
-              id: request.id,
-              method: request.method,
-              timeoutMs: CODEX_DYNAMIC_TOOL_SERVER_REQUEST_TIMEOUT_MS,
-            });
-            controller.abort(new Error("codex app-server server request timed out"));
-            resolve(timeoutResponse);
-          }, CODEX_DYNAMIC_TOOL_SERVER_REQUEST_TIMEOUT_MS);
-          timeout.unref?.();
-        }),
-      ]);
-    } finally {
-      if (timeout) {
-        clearTimeout(timeout);
+      const timeoutResponse = timeoutServerRequestResponse(request);
+      if (!timeoutResponse) {
+        return await this.runServerRequestHandlersWithoutTimeout(request, controller.signal);
       }
+
+      let timeout: ReturnType<typeof setTimeout> | undefined;
+      try {
+        return await Promise.race([
+          this.runServerRequestHandlersWithoutTimeout(request, controller.signal),
+          new Promise<JsonValue>((resolve) => {
+            timeout = setTimeout(() => {
+              embeddedAgentLog.warn("codex app-server server request timed out", {
+                id: request.id,
+                method: request.method,
+                timeoutMs: CODEX_DYNAMIC_TOOL_SERVER_REQUEST_TIMEOUT_MS,
+              });
+              controller.abort(new Error("codex app-server server request timed out"));
+              resolve(timeoutResponse);
+            }, CODEX_DYNAMIC_TOOL_SERVER_REQUEST_TIMEOUT_MS);
+            timeout.unref?.();
+          }),
+        ]);
+      } finally {
+        if (timeout) {
+          clearTimeout(timeout);
+        }
+      }
+    } finally {
+      this.serverRequestControllers.delete(controller);
     }
   }
 
@@ -944,6 +954,10 @@ export class CodexAppServerClient {
     }
     this.closed = true;
     this.closeError = error;
+    for (const controller of this.serverRequestControllers) {
+      controller.abort(error);
+    }
+    this.serverRequestControllers.clear();
     this.lines.close();
     this.rejectPendingRequests(error);
     return true;
@@ -956,7 +970,15 @@ export class CodexAppServerClient {
     }
     this.pending.clear();
     for (const handler of this.closeHandlers) {
+      this.notifyCloseHandler(handler);
+    }
+  }
+
+  private notifyCloseHandler(handler: (client: CodexAppServerClient) => void): void {
+    try {
       handler(this);
+    } catch (error) {
+      embeddedAgentLog.warn("codex app-server close handler failed", { error });
     }
   }
 }

--- a/extensions/codex/src/app-server/thread-history.ts
+++ b/extensions/codex/src/app-server/thread-history.ts
@@ -1,0 +1,71 @@
+import type {
+  CodexThread,
+  CodexThreadTurnsListParams,
+  CodexThreadTurnsListResponse,
+  CodexTurn,
+} from "./protocol.js";
+
+const TURN_PAGE_LIMIT = 100;
+const PAGINATED_INCLUDE_TURNS_ERROR =
+  "paginated threads do not support thread/read(includeTurns=true)";
+
+export type CodexThreadHistoryReader = {
+  readThread(threadId: string, includeTurns?: boolean): Promise<CodexThread>;
+  listTurnPage(params: CodexThreadTurnsListParams): Promise<CodexThreadTurnsListResponse>;
+};
+
+/** Read full turn items in stable oldest-first order, guarding malformed pagination. */
+export async function listCodexThreadTurns(
+  reader: Pick<CodexThreadHistoryReader, "listTurnPage">,
+  threadId: string,
+): Promise<CodexTurn[]> {
+  const turns: CodexTurn[] = [];
+  const seenCursors = new Set<string>();
+  let cursor: string | undefined;
+  for (;;) {
+    const page = await reader.listTurnPage({
+      threadId,
+      limit: TURN_PAGE_LIMIT,
+      sortDirection: "asc",
+      itemsView: "full",
+      ...(cursor ? { cursor } : {}),
+    });
+    turns.push(...page.data);
+    const nextCursor = page.nextCursor?.trim() || undefined;
+    if (!nextCursor) {
+      return turns;
+    }
+    if (seenCursors.has(nextCursor)) {
+      throw new Error("Codex returned a repeated thread/turns/list cursor");
+    }
+    seenCursors.add(nextCursor);
+    cursor = nextCursor;
+  }
+}
+
+/** Read complete legacy or paginated history without using the unsupported
+ * thread/read(includeTurns=true) form for paginated threads. */
+export async function readCodexThreadWithTurns(
+  reader: CodexThreadHistoryReader,
+  threadId: string,
+): Promise<CodexThread> {
+  try {
+    return await reader.readThread(threadId, true);
+  } catch (error) {
+    if (!(error instanceof Error) || error.message !== PAGINATED_INCLUDE_TURNS_ERROR) {
+      throw error;
+    }
+  }
+
+  const metadata = await reader.readThread(threadId, false);
+  if (metadata.id !== threadId) {
+    throw new Error("Codex app-server returned a different thread than requested");
+  }
+  if (metadata.historyMode !== "paginated") {
+    throw new Error("Codex rejected a full history read for a non-paginated thread");
+  }
+  return {
+    ...metadata,
+    turns: await listCodexThreadTurns(reader, threadId),
+  };
+}

--- a/extensions/codex/src/app-server/thread-lifecycle.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.test.ts
@@ -1958,6 +1958,105 @@ describe("Codex app-server supervised branch lifecycle", () => {
     });
   });
 
+  it("materializes a paginated source through full turn pages", async () => {
+    const sourceThreadId = "thread-source-paginated";
+    const probeThreadId = "thread-probe-paginated";
+    const finalThreadId = "thread-final-paginated";
+    const lastTurnId = "turn-terminal";
+    const workspaceDir = path.join(tempDir, "workspace-paginated");
+    const attempt = createThreadLifecycleParams(path.join(tempDir, "session.jsonl"), workspaceDir);
+    await seedPendingSupervisionBinding({
+      attempt,
+      cwd: workspaceDir,
+      pending: { sourceThreadId, lastTurnId },
+    });
+    const terminalTurn = {
+      id: lastTurnId,
+      status: "completed",
+      items: [
+        {
+          id: "user-1",
+          type: "userMessage",
+          content: [{ type: "text", text: "Paginated question" }],
+        },
+        { id: "assistant-1", type: "agentMessage", text: "Paginated answer" },
+      ],
+    };
+    const request = vi.fn(async (method: string, requestParams: unknown) => {
+      if (method === "thread/read") {
+        const read = requestParams as { threadId: string; includeTurns?: boolean };
+        if (read.includeTurns) {
+          throw new Error("paginated threads do not support thread/read(includeTurns=true)");
+        }
+        return {
+          thread: {
+            ...sourceThread({ threadId: sourceThreadId }),
+            historyMode: "paginated",
+            turns: undefined,
+          },
+        };
+      }
+      if (method === "thread/turns/list") {
+        return { data: [terminalTurn] };
+      }
+      if (method === "thread/fork") {
+        return nativeThreadResult(probeThreadId, "native-effective", "native-provider");
+      }
+      if (method === "thread/start") {
+        return nativeThreadResult(finalThreadId, "native-effective", "native-provider");
+      }
+      if (method === "thread/inject_items" || method === "thread/archive") {
+        return {};
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    await expect(
+      startOrResumeThread({
+        client: { request } as never,
+        params: attempt,
+        cwd: workspaceDir,
+        dynamicTools: [],
+        appServer: createThreadLifecycleAppServerOptions(),
+      }),
+    ).resolves.toMatchObject({
+      threadId: finalThreadId,
+      lifecycle: { action: "forked" },
+      conversationSourceTransferComplete: true,
+    });
+
+    expect(request.mock.calls.map(([method]) => method)).toEqual([
+      "thread/read",
+      "thread/read",
+      "thread/turns/list",
+      "thread/fork",
+      "thread/start",
+      "thread/inject_items",
+      "thread/archive",
+    ]);
+    expect(request.mock.calls[2]?.[1]).toEqual({
+      threadId: sourceThreadId,
+      limit: 100,
+      sortDirection: "asc",
+      itemsView: "full",
+    });
+    expect(request.mock.calls[5]?.[1]).toEqual({
+      threadId: finalThreadId,
+      items: [
+        {
+          type: "message",
+          role: "user",
+          content: [{ type: "input_text", text: "Paginated question" }],
+        },
+        {
+          type: "message",
+          role: "assistant",
+          content: [{ type: "output_text", text: "Paginated answer" }],
+        },
+      ],
+    });
+  });
+
   it("rejects materialization after the supervised source connection changes", async () => {
     const workspaceDir = path.join(tempDir, "workspace");
     const attempt = createThreadLifecycleParams(path.join(tempDir, "session.jsonl"), workspaceDir);

--- a/extensions/codex/src/app-server/thread-supervision.ts
+++ b/extensions/codex/src/app-server/thread-supervision.ts
@@ -30,6 +30,7 @@ import type {
   CodexAppServerPendingSupervisionBranch,
   CodexAppServerThreadBinding,
 } from "./session-binding.js";
+import { readCodexThreadWithTurns } from "./thread-history.js";
 import {
   CodexThreadBindingConflictAfterCleanupError,
   CodexThreadBindingConflictError,
@@ -90,15 +91,26 @@ export async function materializePendingSupervisionBranch(
   pending = await recoverPendingSupervisionArtifacts(params, pending);
   params.throwIfAborted();
 
-  const sourceResponse = await params.lifecycleTiming.measure("supervision-source-read", () =>
-    params.client.request(
-      "thread/read",
-      { threadId: pending.sourceThreadId, includeTurns: true },
-      { signal: params.signal },
+  const sourceThread = await params.lifecycleTiming.measure("supervision-source-read", () =>
+    readCodexThreadWithTurns(
+      {
+        readThread: async (threadId, includeTurns = false) =>
+          (
+            await params.client.request(
+              "thread/read",
+              { threadId, includeTurns },
+              { signal: params.signal },
+            )
+          ).thread,
+        listTurnPage: async (requestParams) =>
+          await params.client.request("thread/turns/list", requestParams, {
+            signal: params.signal,
+          }),
+      },
+      pending.sourceThreadId,
     ),
   );
   params.throwIfAborted();
-  const sourceThread = sourceResponse.thread;
   if (sourceThread.id !== pending.sourceThreadId) {
     throw new Error(
       `Codex supervision source read returned ${sourceThread.id} for ${pending.sourceThreadId}`,

--- a/extensions/codex/src/app-server/upstream-fork-boundary.test.ts
+++ b/extensions/codex/src/app-server/upstream-fork-boundary.test.ts
@@ -185,8 +185,18 @@ describe("resolveCodexUpstreamForkBoundaryFromTurns", () => {
 });
 
 describe("resolveCodexUpstreamForkBoundary", () => {
-  it("rejects paginated-history threads before reading turns", async () => {
+  it("maps paginated-history threads through full turn pages", async () => {
     const readThread = vi.fn(async () => ({ id: "thread-1", historyMode: "paginated" }));
+    const listTurnPage = vi.fn(async () => ({ data: [turn("turn-1", [user("one")])] }));
+    transcriptMocks.readVisibleEntries.mockResolvedValue([
+      {
+        entryId: "entry-1",
+        parentId: null,
+        seq: 0,
+        role: "user",
+        message: { role: "user", content: "one", timestamp: 0 },
+      },
+    ] satisfies SessionTranscriptMessageEntry[]);
     const result = await resolveCodexUpstreamForkBoundary({
       agentId: "main",
       sessionId: "session-1",
@@ -194,12 +204,26 @@ describe("resolveCodexUpstreamForkBoundary", () => {
       storePath: "/tmp/does-not-matter",
       entryId: "entry-1",
       threadId: "thread-1",
-      control: { readThread } as unknown as Parameters<
+      control: { readThread, listTurnPage } as unknown as Parameters<
         typeof resolveCodexUpstreamForkBoundary
       >[0]["control"],
     });
 
-    expect(result).toMatchObject({ ok: false, code: "upstream-unavailable" });
-    expect(readThread).toHaveBeenCalledWith("thread-1", false);
+    expect(result).toEqual({
+      ok: true,
+      boundary: {
+        beforeTurnId: "turn-1",
+        targetTurnId: "turn-1",
+        retainedMarker: { turnId: null, userMessageCount: 0 },
+      },
+      editorText: "one",
+    });
+    expect(readThread).not.toHaveBeenCalled();
+    expect(listTurnPage).toHaveBeenCalledWith({
+      threadId: "thread-1",
+      limit: 100,
+      sortDirection: "asc",
+      itemsView: "full",
+    });
   });
 });

--- a/extensions/codex/src/app-server/upstream-fork-boundary.ts
+++ b/extensions/codex/src/app-server/upstream-fork-boundary.ts
@@ -1,6 +1,7 @@
 import { readVisibleSessionTranscriptMessageEntries } from "openclaw/plugin-sdk/session-transcript-runtime";
 import type { CodexSessionCatalogControl } from "../session-catalog-types.js";
 import type { CodexThreadItem, CodexTurn } from "./protocol.js";
+import { listCodexThreadTurns } from "./thread-history.js";
 
 type CodexUpstreamForkBoundaryFailureCode =
   | "steer-message"
@@ -20,8 +21,6 @@ type CodexUpstreamForkBoundary = {
 type CodexUpstreamForkBoundaryResult =
   | { ok: true; boundary: CodexUpstreamForkBoundary; editorText?: string }
   | { ok: false; code: CodexUpstreamForkBoundaryFailureCode; message: string };
-
-const TURN_PAGE_LIMIT = 100;
 
 type UserInput = {
   type?: unknown;
@@ -219,28 +218,7 @@ export async function listCodexUpstreamTurns(
   control: CodexSessionCatalogControl,
   threadId: string,
 ): Promise<CodexTurn[]> {
-  const turns: CodexTurn[] = [];
-  const seenCursors = new Set<string>();
-  let cursor: string | undefined;
-  for (;;) {
-    const page = await control.listTurnPage({
-      threadId,
-      limit: TURN_PAGE_LIMIT,
-      sortDirection: "asc",
-      itemsView: "full",
-      ...(cursor ? { cursor } : {}),
-    });
-    turns.push(...page.data);
-    const nextCursor = page.nextCursor?.trim() || undefined;
-    if (!nextCursor) {
-      return turns;
-    }
-    if (seenCursors.has(nextCursor)) {
-      throw new Error("Codex returned a repeated thread/turns/list cursor");
-    }
-    seenCursors.add(nextCursor);
-    cursor = nextCursor;
-  }
+  return await listCodexThreadTurns(control, threadId);
 }
 
 export async function resolveCodexUpstreamForkBoundary(params: {
@@ -253,15 +231,6 @@ export async function resolveCodexUpstreamForkBoundary(params: {
   control: CodexSessionCatalogControl;
 }): Promise<CodexUpstreamForkBoundaryResult> {
   try {
-    // Paginated-history threads reject itemsView "full" turn reads (thread/items/list
-    // is required); fork support for them is future work — fail closed with intent.
-    const thread = await params.control.readThread(params.threadId, false);
-    if (thread.historyMode === "paginated") {
-      return failure(
-        "upstream-unavailable",
-        "This Codex thread uses paginated history, which cannot be forked from OpenClaw yet.",
-      );
-    }
     const entries = await readVisibleSessionTranscriptMessageEntries({
       agentId: params.agentId,
       sessionId: params.sessionId,

--- a/extensions/codex/src/session-catalog.test.ts
+++ b/extensions/codex/src/session-catalog.test.ts
@@ -1584,6 +1584,63 @@ describe("Codex supervision catalog", () => {
 });
 
 describe("Codex supervision actions", () => {
+  it("continues a paginated thread through full turn pages", async () => {
+    const turns = [
+      { id: "turn-1", status: "completed", items: [] },
+      { id: "turn-2", status: "completed", items: [] },
+    ] as NonNullable<CodexThread["turns"]>;
+    const readThread = vi.fn(async (threadId: string, includeTurns: boolean) => {
+      if (includeTurns) {
+        throw new Error("paginated threads do not support thread/read(includeTurns=true)");
+      }
+      return idleThread({ id: threadId, historyMode: "paginated" });
+    });
+    const listTurnPage = vi.fn(async (params: { cursor?: string | null }) =>
+      params.cursor ? { data: [turns[1]!] } : { data: [turns[0]!], nextCursor: "turns-page-2" },
+    );
+    const control = createEligibleControl({ readThread, listTurnPage });
+    const { runtime } = createRuntime();
+    const { api } = createGatewayApi(runtime);
+    const bindingStore = createCodexTestBindingStore();
+
+    await expect(
+      continueLocalCodexSession({
+        api,
+        bindingStore,
+        config,
+        control,
+        threadId: "thread-1",
+      }),
+    ).resolves.toMatchObject({ disposition: "forked" });
+
+    expect(readThread).toHaveBeenCalledTimes(2);
+    expect(readThread).toHaveBeenNthCalledWith(1, "thread-1", true);
+    expect(readThread).toHaveBeenNthCalledWith(2, "thread-1", false);
+    expect(listTurnPage).toHaveBeenNthCalledWith(1, {
+      threadId: "thread-1",
+      limit: 100,
+      sortDirection: "asc",
+      itemsView: "full",
+    });
+    expect(listTurnPage).toHaveBeenNthCalledWith(2, {
+      threadId: "thread-1",
+      limit: 100,
+      sortDirection: "asc",
+      itemsView: "full",
+      cursor: "turns-page-2",
+    });
+    expect(transcriptMirrorMocks.importCodexThreadHistoryToTranscript).toHaveBeenCalledWith(
+      expect.objectContaining({
+        thread: expect.objectContaining({
+          id: "thread-1",
+          historyMode: "paginated",
+          turns,
+        }),
+        throughTurnId: "turn-2",
+      }),
+    );
+  });
+
   it("creates one pending locked branch and reuses its source mapping", async () => {
     const sourceThread = idleThread({
       modelProvider: "openai",

--- a/extensions/codex/src/session-catalog.ts
+++ b/extensions/codex/src/session-catalog.ts
@@ -40,6 +40,7 @@ import {
   releaseLeasedSharedCodexAppServerClient,
 } from "./app-server/shared-client.js";
 import { assertCodexArchiveDescendantsUnowned } from "./app-server/thread-archive-guard.js";
+import { readCodexThreadWithTurns } from "./app-server/thread-history.js";
 import { codexControlRequest } from "./command-rpc.js";
 import { resolveCodexCatalogCreateSession } from "./session-catalog-create.js";
 import {
@@ -1003,7 +1004,7 @@ async function continueLocalCodexSessionInner(params: {
   });
   if (existing) {
     const boundThreadId = requireBoundThread(existing);
-    const boundThread = await params.control.readThread(boundThreadId, true);
+    const boundThread = await readCodexThreadWithTurns(params.control, boundThreadId);
     if (boundThread.id !== boundThreadId) {
       throw new Error("Codex app-server returned a different thread than requested");
     }
@@ -1040,7 +1041,7 @@ async function continueLocalCodexSessionInner(params: {
     return { sessionKey: existing.key, disposition: "existing" };
   }
 
-  const sourceThread = await params.control.readThread(params.threadId, true);
+  const sourceThread = await readCodexThreadWithTurns(params.control, params.threadId);
   if (sourceThread.id !== params.threadId) {
     throw new Error("Codex app-server returned a different thread than requested");
   }
@@ -1062,7 +1063,7 @@ async function continueLocalCodexSessionInner(params: {
   const baselineThread =
     boundThreadId === sourceThread.id
       ? sourceThread
-      : await params.control.readThread(boundThreadId, true);
+      : await readCodexThreadWithTurns(params.control, boundThreadId);
   if (baselineThread.id !== boundThreadId) {
     throw new Error("Codex app-server returned a different thread than requested");
   }


### PR DESCRIPTION
Closes #114302
Closes #114304
Closes #114305
Closes #114306
Closes #114308

## What Problem This Solves

Fixes five Codex continuity failures where users could lose a message during a request-input race, fail to continue or fork paginated threads, leave request handlers running after disconnect, or miss client-close cleanup when observers throw or subscribe late.

## Why This Change Was Made

The change honors the compare-and-resolve result before steering, adds one validated full-history reader for paginated and inline Codex threads, and makes the client close transition abort active inbound handlers while delivering terminal state to every observer exactly once. The implementation follows the currently checked-out official Codex app-server contracts and remains internal to the Codex extension.

## User Impact

Messages survive request-input resolution races, paginated threads can be continued/materialized/message-forked, and disconnect cleanup is deterministic across active, throwing, and late observers.

## Evidence

- Steering, fork boundary, catalog, and lifecycle group: 227/227 passed.
- Client, shared-client, and turn-router group: 112/112 passed.
- User-input bridge: 6/6 passed.
- Upstream session fork: 6/6 passed.
- Production extensions typecheck, targeted `oxfmt`, targeted `oxlint`, `git diff --check`, public Plugin SDK surface, protected-path, and secret scans passed.
- Fresh independent autoreview: no actionable findings, correctness 0.98.
- Official Codex source was inspected at `18f50c9e628af083a52d9240de09fc2db24d79ce` for paginated-history and request-resolution semantics.
- AI-assisted implementation and review; no public Plugin SDK or generated protocol boundary changed.
