### PR TITLE
perf(gateway): cache session-PR local git facts

### DIFF
--- a/src/gateway/control-ui-session-prs-local-git.ts
+++ b/src/gateway/control-ui-session-prs-local-git.ts
@@ -1,0 +1,95 @@
+import { runGit } from "../agents/worktrees/git.js";
+import {
+  gitOutput,
+  resolveBranchLanding,
+  type MergedPullHead,
+} from "./control-ui-session-prs-landing.js";
+import { parseGitHubRemoteUrl } from "./github-remote.js";
+
+const LOCAL_GIT_CACHE_MS = 10_000;
+const LOCAL_GIT_CACHE_LIMIT = 100;
+
+/** GitHub repo + branch resolved from a session's git checkout. */
+export type SessionPullRequestGitContext = {
+  owner: string;
+  repo: string;
+  branch: string;
+  /** Checkout root for local diff stats; absent for stubbed test contexts. */
+  root?: string;
+  /** Remote default branch when origin/HEAD is resolvable. */
+  defaultBranch?: string;
+};
+
+export type SessionPullRequestLocalGitDeps = {
+  gitOutput?: typeof gitOutput;
+  runGit?: typeof runGit;
+  resolveBranchLanding?: typeof resolveBranchLanding;
+};
+
+type SessionPullRequestBranchFacts = {
+  creatable: boolean;
+  stats: { additions: number; deletions: number; changedFiles: number } | null;
+};
+
+type LocalGitCacheEntry<T> = { expiresAt: number; promise: Promise<T> };
+
+function createLocalGitCache<T>() {
+  const entries = new Map<string, LocalGitCacheEntry<T>>();
+  return (key: string, load: () => Promise<T>): Promise<T> => {
+    const cached = entries.get(key);
+    if (cached && cached.expiresAt > Date.now()) {
+      entries.delete(key);
+      entries.set(key, cached);
+      return cached.promise;
+    }
+    const entry = { expiresAt: Date.now() + LOCAL_GIT_CACHE_MS, promise: load() };
+    entries.delete(key);
+    entries.set(key, entry);
+    while (entries.size > LOCAL_GIT_CACHE_LIMIT) {
+      const oldestKey = entries.keys().next().value;
+      if (oldestKey === undefined) {
+        break;
+      }
+      entries.delete(oldestKey);
+    }
+    return entry.promise;
+  };
+}
+
+// Process-local and bounded: ten seconds keeps sidebar checkout/tree facts
+// responsive; removing this freshness window respawns Git for every row.
+const cachedGitContext = createLocalGitCache<SessionPullRequestGitContext | null>();
+const cachedBranchFacts = createLocalGitCache<SessionPullRequestBranchFacts | undefined>();
+
+export function resolveCachedGitContext(
+  root: string,
+  deps: SessionPullRequestLocalGitDeps,
+): Promise<SessionPullRequestGitContext | null> {
+  return cachedGitContext(root, async () => {
+    const output = deps.gitOutput ?? gitOutput;
+    const branch = await output(root, ["rev-parse", "--abbrev-ref", "HEAD"]);
+    if (!branch || branch === "HEAD") {
+      return null;
+    }
+    const remoteUrl = await output(root, ["remote", "get-url", "origin"]);
+    const remote = remoteUrl ? parseGitHubRemoteUrl(remoteUrl) : null;
+    if (!remote) {
+      return null;
+    }
+    const defaultRef = await output(root, ["symbolic-ref", "--short", "refs/remotes/origin/HEAD"]);
+    const defaultBranch = defaultRef?.replace(/^origin\//, "");
+    if (defaultBranch === branch) {
+      return null;
+    }
+    return { ...remote, branch, root, ...(defaultBranch ? { defaultBranch } : {}) };
+  });
+}
+
+export function resolveCachedSessionBranchFacts(
+  context: SessionPullRequestGitContext & { root: string },
+  mergedHeads: readonly MergedPullHead[],
+  load: () => Promise<SessionPullRequestBranchFacts | undefined>,
+): Promise<SessionPullRequestBranchFacts | undefined> {
+  const landingKey = JSON.stringify([context.defaultBranch ?? null, mergedHeads]);
+  return cachedBranchFacts(`${context.root}\0${context.branch}\0${landingKey}`, load);
+}

--- a/src/gateway/control-ui-session-prs.test.ts
+++ b/src/gateway/control-ui-session-prs.test.ts
@@ -331,6 +331,114 @@ describe("loadControlUiSessionPullRequests", () => {
     expect(fetchImpl.mock.calls).toHaveLength(0);
   });
 
+  it("caches git context through repeated GitHub failures, then expires it", async () => {
+    const fetchImpl = routedFetch([
+      {
+        match: "/pulls?head=",
+        response: () => githubJson({ message: "unavailable" }, 503),
+      },
+    ]);
+    const gitOutputImpl = vi.fn(async (_root: string, args: string[]) => {
+      if (args[0] === "rev-parse") {
+        return "feature";
+      }
+      if (args[0] === "remote") {
+        return "git@github.com:openclaw/openclaw.git";
+      }
+      return "origin/main";
+    });
+    const load = (root = "/repo/context-cache") =>
+      loadControlUiSessionPullRequests(
+        { sessionKey: "agent:main:main" },
+        {
+          fetchImpl,
+          resolveGitRoot: async () => root,
+          gitOutput: gitOutputImpl,
+        },
+      );
+
+    await expect(load()).rejects.toBeInstanceOf(Error);
+    await expect(load()).rejects.toBeInstanceOf(Error);
+    expect(gitOutputImpl).toHaveBeenCalledTimes(3);
+    expect(fetchImpl.mock.calls).toHaveLength(1);
+
+    await expect(load("/repo/other-context")).rejects.toBeInstanceOf(Error);
+    expect(gitOutputImpl).toHaveBeenCalledTimes(6);
+
+    vi.advanceTimersByTime(10_001);
+    await expect(load()).rejects.toBeInstanceOf(Error);
+    expect(gitOutputImpl).toHaveBeenCalledTimes(9);
+    // The longer GitHub failure cache remains independent of local Git expiry.
+    expect(fetchImpl.mock.calls).toHaveLength(1);
+  });
+
+  it("caches branch facts by root while refresh only bypasses the GitHub cache", async () => {
+    let pulls: Record<string, unknown>[] = [];
+    const fetchImpl = routedFetch([
+      { match: "/pulls?head=", response: () => githubJson(pulls) },
+      { match: "/repos/openclaw/openclaw", response: () => githubJson({ fork: false }) },
+    ]);
+    const resolveBranchLanding = vi.fn(async () => ({
+      pushedSha: "a".repeat(40),
+      statsBase: "base",
+      hasLandedPullRequest: false,
+      provenNewPushedWork: false,
+    }));
+    const gitOutputImpl = vi.fn(async (_root: string, args: string[]) =>
+      args[0] === "rev-list" ? "1" : null,
+    );
+    const runGitImpl = vi.fn(async (root: string) => ({
+      stdout:
+        root === "/repo/b" ? " 1 file changed, 2 insertions(+)" : " 1 file changed, 1 insertion(+)",
+      stderr: "",
+      code: 0,
+    }));
+    const load = (sessionKey: string, refresh = false) =>
+      loadControlUiSessionPullRequests(
+        { sessionKey, ...(refresh ? { refresh: true } : {}) },
+        {
+          fetchImpl,
+          resolveGitContext: async () => ({
+            ...context,
+            branch: "cache/test",
+            root: sessionKey.endsWith(":b") ? "/repo/b" : "/repo/a",
+            defaultBranch: "main",
+          }),
+          gitOutput: gitOutputImpl,
+          runGit: runGitImpl,
+          resolveBranchLanding,
+        },
+      );
+
+    expect((await load("agent:main:a")).branch?.additions).toBe(1);
+    expect((await load("agent:main:a", true)).branch?.additions).toBe(1);
+    expect(resolveBranchLanding).toHaveBeenCalledTimes(1);
+    expect(runGitImpl).toHaveBeenCalledTimes(1);
+    expect(gitOutputImpl).toHaveBeenCalledTimes(2);
+    expect(
+      fetchImpl.mock.calls.filter((call) =>
+        requestUrl(call[0] as RequestInfo | URL).includes("/pulls?head="),
+      ),
+    ).toHaveLength(2);
+
+    pulls = [pullListItem({ merged_at: "2026-07-09T10:00:00Z" })];
+    expect((await load("agent:main:a", true)).branch?.additions).toBe(1);
+    expect(resolveBranchLanding).toHaveBeenCalledTimes(2);
+    expect(runGitImpl).toHaveBeenCalledTimes(2);
+    expect(gitOutputImpl).toHaveBeenCalledTimes(4);
+
+    vi.advanceTimersByTime(10_001);
+    expect((await load("agent:main:a")).branch?.additions).toBe(1);
+    expect(resolveBranchLanding).toHaveBeenCalledTimes(3);
+    expect(runGitImpl).toHaveBeenCalledTimes(3);
+    expect(gitOutputImpl).toHaveBeenCalledTimes(6);
+
+    expect((await load("agent:main:b")).branch?.additions).toBe(2);
+    expect(resolveBranchLanding).toHaveBeenCalledTimes(4);
+    expect(runGitImpl).toHaveBeenCalledTimes(4);
+    expect(gitOutputImpl).toHaveBeenCalledTimes(8);
+  });
+
   it("refreshes a cached empty result after the assistant creates a PR", async () => {
     let pulls: Record<string, unknown>[] = [];
     const fetchImpl = routedFetch([

--- a/src/gateway/control-ui-session-prs.ts
+++ b/src/gateway/control-ui-session-prs.ts
@@ -25,7 +25,12 @@ import {
   resolveBranchLanding,
   type MergedPullHead,
 } from "./control-ui-session-prs-landing.js";
-import { parseGitHubRemoteUrl } from "./github-remote.js";
+import {
+  resolveCachedGitContext,
+  resolveCachedSessionBranchFacts,
+  type SessionPullRequestGitContext,
+  type SessionPullRequestLocalGitDeps,
+} from "./control-ui-session-prs-local-git.js";
 import { loadSessionEntryReadOnly } from "./session-utils.js";
 
 const SUCCESS_CACHE_MS = 60_000;
@@ -40,17 +45,6 @@ export type ControlUiSessionPullRequestsParams = {
   sessionKey: string;
   agentId?: string;
   refresh?: boolean;
-};
-
-/** GitHub repo + branch resolved from a session's git checkout. */
-type SessionPullRequestGitContext = {
-  owner: string;
-  repo: string;
-  branch: string;
-  /** Checkout root for local diff stats; absent for stubbed test contexts. */
-  root?: string;
-  /** Remote default branch when origin/HEAD is resolvable. */
-  defaultBranch?: string;
 };
 
 type PullListItem = {
@@ -87,6 +81,14 @@ type CacheEntry = {
 
 const branchCache = new Map<string, CacheEntry>();
 
+type LoadSessionPullRequestDeps = SessionPullRequestLocalGitDeps & {
+  fetchImpl?: typeof fetch;
+  resolveGitRoot?: (params: ControlUiSessionPullRequestsParams) => Promise<string | null>;
+  resolveGitContext?: (
+    params: ControlUiSessionPullRequestsParams,
+  ) => Promise<SessionPullRequestGitContext | null>;
+};
+
 export function parseControlUiSessionPullRequestsParams(
   value: unknown,
 ): ControlUiSessionPullRequestsParams | null {
@@ -105,16 +107,10 @@ export function parseControlUiSessionPullRequestsParams(
   };
 }
 
-/**
- * Resolves the GitHub repo + branch a session works on. Returns null for
- * unknown sessions, non-git roots, detached HEADs, non-GitHub remotes, and
- * the remote default branch (no PR can have the default branch as head from
- * the same checkout, and skipping it protects the anonymous GitHub quota for
- * plain sessions).
- */
-async function resolveSessionPullRequestGitContext(
+/** Resolves the checkout root without spawning Git. */
+function resolveSessionPullRequestGitRoot(
   params: ControlUiSessionPullRequestsParams,
-): Promise<SessionPullRequestGitContext | null> {
+): string | null {
   const { cfg, entry, storePath, canonicalKey } = loadSessionEntryReadOnly(params.sessionKey, {
     agentId: params.agentId,
   });
@@ -137,21 +133,24 @@ async function resolveSessionPullRequestGitContext(
   if (!root) {
     return null;
   }
-  const branch = await gitOutput(root, ["rev-parse", "--abbrev-ref", "HEAD"]);
-  if (!branch || branch === "HEAD") {
+  return root;
+}
+
+/**
+ * Resolves the GitHub repo + branch, caching detached/default/non-GitHub
+ * outcomes too so repeated sidebar requests do not respawn the same probes.
+ */
+async function resolveSessionPullRequestGitContext(
+  params: ControlUiSessionPullRequestsParams,
+  deps: LoadSessionPullRequestDeps,
+): Promise<SessionPullRequestGitContext | null> {
+  const root = deps.resolveGitRoot
+    ? await deps.resolveGitRoot(params)
+    : resolveSessionPullRequestGitRoot(params);
+  if (!root) {
     return null;
   }
-  const remoteUrl = await gitOutput(root, ["remote", "get-url", "origin"]);
-  const remote = remoteUrl ? parseGitHubRemoteUrl(remoteUrl) : null;
-  if (!remote) {
-    return null;
-  }
-  const defaultRef = await gitOutput(root, ["symbolic-ref", "--short", "refs/remotes/origin/HEAD"]);
-  const defaultBranch = defaultRef?.replace(/^origin\//, "");
-  if (defaultBranch === branch) {
-    return null;
-  }
-  return { ...remote, branch, root, ...(defaultBranch ? { defaultBranch } : {}) };
+  return resolveCachedGitContext(root, deps);
 }
 
 // git push's own "create a pull request" hint URL; GitHub resolves the base
@@ -175,10 +174,10 @@ const MAX_UNTRACKED_STAT_BYTES = 512 * 1024;
 
 /**
  * Line count for one untracked file, computed in-process: this runs on the
- * chat view's 60s poll, so it must not spawn one git subprocess per path.
- * lstat gates on regular files so FIFOs/sockets can never block the RPC and
- * symlinks never resolve outside the checkout; only a line count is exposed,
- * so sessions-diff's hardlink content guard is unnecessary here.
+ * chat view's poll, so it must not spawn one git subprocess per path. lstat
+ * gates on regular files so FIFOs/sockets can never block the RPC and symlinks
+ * never resolve outside the checkout; only a line count is exposed, so
+ * sessions-diff's hardlink content guard is unnecessary here.
  */
 async function untrackedFileAdditions(root: string, filePath: string): Promise<number> {
   try {
@@ -206,8 +205,11 @@ async function untrackedFileAdditions(root: string, filePath: string): Promise<n
   }
 }
 
-async function untrackedStats(root: string): Promise<{ additions: number; files: number }> {
-  const listing = await gitOutput(root, ["ls-files", "--others", "--exclude-standard", "-z"]);
+async function untrackedStats(
+  root: string,
+  output: typeof gitOutput,
+): Promise<{ additions: number; files: number }> {
+  const listing = await output(root, ["ls-files", "--others", "--exclude-standard", "-z"]);
   const paths = (listing ?? "").split("\0").filter(Boolean);
   let additions = 0;
   for (const filePath of paths.slice(0, MAX_UNTRACKED_STAT_FILES)) {
@@ -220,17 +222,17 @@ async function untrackedStats(root: string): Promise<{ additions: number; files:
  * Working-tree diff counts vs an explicit base, untracked files included:
  * the size the PR would have if the current work were committed and pushed;
  * changedFiles decides row visibility for unpushed branches. Unlike bare
- * `git diff`, diffing against an explicit base counts unmerged (conflict)
- * paths, so conflict-only trees still show.
+ * `git diff`, this also counts unmerged (conflict) paths.
  */
 async function diffStatsAgainst(
   root: string,
   base: string,
+  deps: LoadSessionPullRequestDeps,
 ): Promise<{ additions: number; deletions: number; changedFiles: number } | null> {
   try {
-    // --no-ext-diff/--no-textconv: checkout-configurable diff drivers must
-    // never execute in the Gateway process (same guard as sessions-diff).
-    const result = await runGit(root, [
+    // Checkout-configurable diff drivers must never execute in the Gateway
+    // process (same guard as sessions-diff).
+    const result = await (deps.runGit ?? runGit)(root, [
       "diff",
       "--shortstat",
       "--no-ext-diff",
@@ -242,7 +244,7 @@ async function diffStatsAgainst(
     }
     // Empty output means an empty diff, not a failure.
     const summary = result.stdout.trim();
-    const untracked = await untrackedStats(root);
+    const untracked = await untrackedStats(root, deps.gitOutput ?? gitOutput);
     return {
       additions: Number(SHORTSTAT_INSERTIONS.exec(summary)?.[1] ?? 0) + untracked.additions,
       deletions: Number(SHORTSTAT_DELETIONS.exec(summary)?.[1] ?? 0),
@@ -255,22 +257,20 @@ async function diffStatsAgainst(
 
 /**
  * GitHub's pull/new page only has something to offer once the pushed branch
- * carries commits the default branch lacks; unpushed or fully-merged remote
- * branches get "nothing to compare" (or a 404), so createUrl is withheld and
- * the row only reports local changed files. Rename-only commits still count —
+ * carries commits the default branch lacks. Rename-only commits still count:
  * this gate keys on commits, not line counts.
  */
 async function branchHasCreatablePullRequest(
   root: string,
   context: SessionPullRequestGitContext,
   pushedSha: string | null,
+  output: typeof gitOutput,
 ): Promise<boolean> {
-  // Fail closed without a resolvable default branch: a session sitting on the
-  // actual default in a clone lacking origin/HEAD must not get a Create PR row.
+  // Fail closed when origin/HEAD is missing or the branch is not pushed.
   if (!context.defaultBranch || !pushedSha) {
     return false;
   }
-  const ahead = await gitOutput(root, [
+  const ahead = await output(root, [
     "rev-list",
     "--count",
     `refs/remotes/origin/${context.defaultBranch}..refs/remotes/origin/${context.branch}`,
@@ -282,6 +282,7 @@ async function branchHasCreatablePullRequest(
 async function resolveSessionBranch(
   context: SessionPullRequestGitContext,
   mergedHeads: readonly MergedPullHead[],
+  deps: LoadSessionPullRequestDeps,
 ): Promise<ControlUiSessionBranch | undefined> {
   const root = context.root;
   if (!root) {
@@ -293,25 +294,39 @@ async function resolveSessionBranch(
       createUrl: branchCreateUrl(context),
     };
   }
-  const landing = await resolveBranchLanding(root, {
-    branch: context.branch,
-    defaultBranch: context.defaultBranch,
+  const facts = await resolveCachedSessionBranchFacts(
+    { ...context, root },
     mergedHeads,
-  });
-  const creatable =
-    (!landing.hasLandedPullRequest || landing.provenNewPushedWork) &&
-    (await branchHasCreatablePullRequest(root, context, landing.pushedSha));
-  const stats = landing.statsBase ? await diffStatsAgainst(root, landing.statsBase) : null;
-  // No createUrl until GitHub can compare, but local changes still get a row.
-  if (!creatable && !(stats && stats.changedFiles > 0)) {
+    async () => {
+      const landing = await (deps.resolveBranchLanding ?? resolveBranchLanding)(root, {
+        branch: context.branch,
+        defaultBranch: context.defaultBranch,
+        mergedHeads,
+      });
+      const creatable =
+        (!landing.hasLandedPullRequest || landing.provenNewPushedWork) &&
+        (await branchHasCreatablePullRequest(
+          root,
+          context,
+          landing.pushedSha,
+          deps.gitOutput ?? gitOutput,
+        ));
+      const stats = landing.statsBase
+        ? await diffStatsAgainst(root, landing.statsBase, deps)
+        : null;
+      // No createUrl until GitHub can compare, but local changes still get a row.
+      return !creatable && !(stats && stats.changedFiles > 0) ? undefined : { creatable, stats };
+    },
+  );
+  if (!facts) {
     return undefined;
   }
   return {
     owner: context.owner,
     repo: context.repo,
     branch: context.branch,
-    ...(creatable ? { createUrl: branchCreateUrl(context) } : {}),
-    ...(stats ? { additions: stats.additions, deletions: stats.deletions } : {}),
+    ...(facts.creatable ? { createUrl: branchCreateUrl(context) } : {}),
+    ...(facts.stats ? { additions: facts.stats.additions, deletions: facts.stats.deletions } : {}),
   };
 }
 
@@ -593,33 +608,24 @@ async function refreshBranchPullRequests(
   }
 }
 
-type LoadSessionPullRequestDeps = {
-  fetchImpl?: typeof fetch;
-  resolveGitContext?: (
-    params: ControlUiSessionPullRequestsParams,
-  ) => Promise<SessionPullRequestGitContext | null>;
-};
-
 export async function loadControlUiSessionPullRequests(
   params: ControlUiSessionPullRequestsParams,
   deps: LoadSessionPullRequestDeps = {},
 ): Promise<ControlUiSessionPullRequests> {
-  const resolveGitContext = deps.resolveGitContext ?? resolveSessionPullRequestGitContext;
-  const context = await resolveGitContext(params);
+  const context = deps.resolveGitContext
+    ? await deps.resolveGitContext(params)
+    : await resolveSessionPullRequestGitContext(params, deps);
   if (!context) {
     return { pullRequests: [], rateLimited: false };
   }
-  // Branch metadata is local git only, so it stays fresh per request (the
-  // working-tree diff moves while the agent works) and keeps the pre-PR row
-  // alive when GitHub is rate limited; only the GitHub fetch is cached.
-  // Sequenced after the snapshot because branch resolution needs the merged
-  // head SHAs; the snapshot is usually a cache hit, so this costs little.
+  // Local Git uses a separate short TTL; refresh only forces the GitHub layer.
+  // Branch resolution follows the snapshot because merged head SHAs affect it.
   const { mergedHeads, ...snapshot } = await cachedBranchPullRequests(
     context,
     deps,
     params.refresh === true,
   );
-  const branch = await resolveSessionBranch(context, mergedHeads);
+  const branch = await resolveSessionBranch(context, mergedHeads, deps);
   return branch ? { ...snapshot, branch } : snapshot;
 }
 


### PR DESCRIPTION
## What Problem This Solves

`controlUi.sessionPullRequests` forks git subprocesses on every call. Production CPU profile on team.openclaw.ai (Node `--cpu-prof`, 289s window under Control UI load): **9.1s of process self-time in `child_process` spawn**, all attributed to `runGit <- gitOutput <- resolveSessionPullRequestGitContext <- loadControlUiSessionPullRequests`. The method served 3,625 calls in 4h (avg 129ms, max 5.8s). A cold call runs ~9 subprocesses (`rev-parse --abbrev-ref HEAD`, `remote get-url origin`, `symbolic-ref origin/HEAD`, untracked listing, ahead-count, branch landing checks) — including calls that then fail as UNAVAILABLE in ~68ms because only the GitHub layer had a cache.

## Why This Change Was Made

The file's own freshness contract ("branch metadata stays fresh while the agent works") is about seconds, not per-sidebar-row subprocess storms. Local git facts now sit in two bounded, process-local caches (10s TTL, 100-entry LRU, mirroring the existing `branchCache` shape):

- git context keyed by checkout root (branch, owner/repo from remote, default branch)
- branch facts keyed by (root, branch, default branch, merged-head snapshot) so a merge invalidates immediately

`refresh: true` still forces only the GitHub layer, exactly as before. Cold call: ~9 subprocesses; warm call within TTL: **0**. Repeated UNAVAILABLE calls: first 3 spawns, then 0 within the window — composing with the client-side unavailable latch in #114266.

## User Impact

Sidebar PR indicators and chat PR suggestions stop forking git per row; gateway CPU and call latency drop on session-heavy installs (this was the top spawn source in the production profile).

## Evidence

- Profile + journal evidence above.
- New `control-ui-session-prs.test.ts`: cache reuse within TTL (counting git stubs), expiry after TTL, per-root isolation, GitHub-refresh independence, merged-head invalidation — 19/19 green; branch regressions 19/19.
- Extracted `control-ui-session-prs-local-git.ts` keeps the main file under the 700-line cap; oxlint rc=0; `git diff --check` clean.
- Autoreview (Codex `gpt-5.6-sol`, xhigh): clean, "patch is correct (0.87)".
