### PR TITLE
fix(plugins): keep policy, manifests, and CLI mutations consistent

### DIFF
--- a/src/cli/plugins-cli.policy.test.ts
+++ b/src/cli/plugins-cli.policy.test.ts
@@ -1,5 +1,5 @@
 // Plugins CLI policy tests cover plugin command policy checks and warnings.
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import {
   buildPluginRegistrySnapshotReport,
@@ -11,6 +11,13 @@ import {
   runPluginsCommand,
   writeConfigFile,
 } from "./plugins-cli-test-helpers.js";
+
+vi.mock("../plugins/plugin-lifecycle-lease.js", () => ({
+  withPluginLifecycleLease: async (
+    _options: unknown,
+    task: () => Promise<unknown>,
+  ): Promise<unknown> => await task(),
+}));
 
 const ORIGINAL_OPENCLAW_NIX_MODE = process.env.OPENCLAW_NIX_MODE;
 
@@ -91,6 +98,27 @@ describe("plugins cli policy mutations", () => {
       policyPluginIds: ["alpha"],
       reason: "policy-changed",
     });
+  });
+
+  it("does not persist or refresh when plugin enablement is blocked", async () => {
+    const sourceConfig = {
+      plugins: {
+        deny: ["alpha"],
+      },
+    } as OpenClawConfig;
+    loadConfig.mockReturnValue(sourceConfig);
+    enablePluginInConfig.mockReturnValue({
+      config: sourceConfig,
+      enabled: false,
+      pluginId: "alpha",
+      reason: "blocked by denylist",
+    });
+    mockPluginRegistry(["alpha"]);
+
+    await runPluginsCommand(["plugins", "enable", "alpha"]);
+
+    expect(writeConfigFile).not.toHaveBeenCalled();
+    expect(refreshPluginRegistry).not.toHaveBeenCalled();
   });
 
   it("refuses plugin enablement in Nix mode before config mutation", async () => {

--- a/src/cli/plugins-cli.runtime.ts
+++ b/src/cli/plugins-cli.runtime.ts
@@ -203,9 +203,6 @@ async function runPluginsEnableCommandUnlocked(idInput: string): Promise<void> {
   const { enableExplicitlySelectedPluginInConfig } = await import("../plugins/enable.js");
   const { normalizePluginId } = await loadPluginsConfigState();
   const { buildPluginRegistrySnapshotReport } = await loadPluginsStatus();
-  const { applySlotSelectionForPlugin } = await loadPluginSlotSelection();
-  const { logSlotWarnings } = await loadPluginsCommandHelpers();
-  const { refreshPluginRegistryAfterConfigMutation } = await loadPluginsRegistryRefresh();
   const snapshot = await readConfigFileSnapshot();
   const cfg = (snapshot.sourceConfig ?? snapshot.config) as OpenClawConfig;
   const report = buildPluginRegistrySnapshotReport({ config: cfg });
@@ -216,6 +213,17 @@ async function runPluginsEnableCommandUnlocked(idInput: string): Promise<void> {
   const enableResult = enableExplicitlySelectedPluginInConfig(cfg, id, {
     updateChannelConfig: false,
   });
+  if (!enableResult.enabled) {
+    defaultRuntime.log(
+      theme.warn(
+        `Plugin "${id}" could not be enabled (${enableResult.reason ?? "unknown reason"}).`,
+      ),
+    );
+    return;
+  }
+  const { applySlotSelectionForPlugin } = await loadPluginSlotSelection();
+  const { logSlotWarnings } = await loadPluginsCommandHelpers();
+  const { refreshPluginRegistryAfterConfigMutation } = await loadPluginsRegistryRefresh();
   let next: OpenClawConfig = enableResult.config;
   const slotResult = applySlotSelectionForPlugin(next, id);
   next = slotResult.config;
@@ -233,13 +241,7 @@ async function runPluginsEnableCommandUnlocked(idInput: string): Promise<void> {
     },
   });
   logSlotWarnings(slotResult.warnings);
-  if (enableResult.enabled) {
-    defaultRuntime.log(`Enabled plugin "${id}". Restart the gateway to apply.`);
-    return;
-  }
-  defaultRuntime.log(
-    theme.warn(`Plugin "${id}" could not be enabled (${enableResult.reason ?? "unknown reason"}).`),
-  );
+  defaultRuntime.log(`Enabled plugin "${id}". Restart the gateway to apply.`);
 }
 
 /** Disable a plugin in config and refresh the registry snapshot for the changed policy. */

--- a/src/cli/plugins-config.test.ts
+++ b/src/cli/plugins-config.test.ts
@@ -31,6 +31,29 @@ describe("setPluginEnabledInConfig", () => {
     });
   });
 
+  it("canonicalizes compatibility ids without losing existing config", () => {
+    const config = {
+      plugins: {
+        allow: ["GOOGLE-GEMINI-CLI"],
+        entries: {
+          "GOOGLE-GEMINI-CLI": {
+            enabled: false,
+            config: { region: "us" },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const next = setPluginEnabledInConfig(config, "google", true);
+
+    expect(next.plugins?.allow).toEqual(["google"]);
+    expect(next.plugins?.entries?.google).toEqual({
+      enabled: true,
+      config: { region: "us" },
+    });
+    expect(next.plugins?.entries?.["GOOGLE-GEMINI-CLI"]).toBeUndefined();
+  });
+
   it("keeps built-in channel and plugin entry flags in sync", () => {
     const config = {
       channels: {

--- a/src/plugins/enable.test.ts
+++ b/src/plugins/enable.test.ts
@@ -78,10 +78,37 @@ describe("enablePluginInConfig", () => {
       },
     },
     {
+      name: "enables a canonical plugin allowed through a compatibility id",
+      cfg: {
+        plugins: {
+          allow: ["GOOGLE-GEMINI-CLI"],
+        },
+      } as OpenClawConfig,
+      pluginId: "google",
+      expectedEnabled: true,
+      assert: (result: ReturnType<typeof enablePluginInConfig>) => {
+        expect(result.config.plugins?.entries?.google?.enabled).toBe(true);
+        expectEnabledAllowlist(result, ["google"]);
+      },
+    },
+    {
       name: "refuses enable when plugin is denylisted",
       cfg: {
         plugins: {
           deny: ["google"],
+        },
+      } as OpenClawConfig,
+      pluginId: "google",
+      expectedEnabled: false,
+      assert: (result: ReturnType<typeof enablePluginInConfig>) => {
+        expect(result.reason).toBe("blocked by denylist");
+      },
+    },
+    {
+      name: "refuses a canonical plugin denied through a compatibility id",
+      cfg: {
+        plugins: {
+          deny: ["GOOGLE-GEMINI-CLI"],
         },
       } as OpenClawConfig,
       pluginId: "google",

--- a/src/plugins/enable.ts
+++ b/src/plugins/enable.ts
@@ -2,6 +2,7 @@
 import { normalizeChatChannelId } from "../channels/ids.js";
 import { ensurePluginAllowlisted } from "../config/plugins-allowlist.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { normalizePluginId, normalizePluginsConfig } from "./config-state.js";
 import { setPluginEnabledInConfig } from "./toggle-config.js";
 
 type PluginEnableOptions = {
@@ -23,20 +24,15 @@ export function enablePluginInConfig(
   options: PluginEnableOptions = {},
 ): PluginEnableResult {
   const builtInChannelId = normalizeChatChannelId(pluginId);
-  const resolvedId = builtInChannelId ?? pluginId;
-  if (cfg.plugins?.enabled === false) {
+  const resolvedId = normalizePluginId(builtInChannelId ?? pluginId);
+  const plugins = normalizePluginsConfig(cfg.plugins);
+  if (!plugins.enabled) {
     return { config: cfg, enabled: false, pluginId: resolvedId, reason: "plugins disabled" };
   }
-  if (cfg.plugins?.deny?.includes(pluginId) || cfg.plugins?.deny?.includes(resolvedId)) {
+  if (plugins.deny.includes(resolvedId)) {
     return { config: cfg, enabled: false, pluginId: resolvedId, reason: "blocked by denylist" };
   }
-  const allow = cfg.plugins?.allow;
-  if (
-    Array.isArray(allow) &&
-    allow.length > 0 &&
-    !allow.includes(pluginId) &&
-    !allow.includes(resolvedId)
-  ) {
+  if (plugins.allow.length > 0 && !plugins.allow.includes(resolvedId)) {
     return { config: cfg, enabled: false, pluginId: resolvedId, reason: "blocked by allowlist" };
   }
   return {

--- a/src/plugins/manifest.json5-tolerance.test.ts
+++ b/src/plugins/manifest.json5-tolerance.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import JSON5 from "json5";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { resolveMemorySlotDecision } from "./config-state.js";
 import { loadPluginManifest } from "./manifest.js";
 import { cleanupTrackedTempDirs, makeTrackedTempDir } from "./test-helpers/fs-fixtures.js";
 
@@ -119,6 +120,54 @@ describe("loadPluginManifest JSON5 tolerance", () => {
     expect(result.ok).toBe(true);
     if (result.ok) {
       expect(result.manifest.id).toBe("unquoted-keys");
+    }
+  });
+
+  it("filters and deduplicates plugin kinds", () => {
+    const dir = makeTempDir();
+    fs.writeFileSync(
+      path.join(dir, "openclaw.plugin.json"),
+      JSON.stringify({
+        id: "kind-normalization",
+        kind: ["memory", "memory", "unknown", 42, "context-engine"],
+        configSchema: { type: "object" },
+      }),
+      "utf-8",
+    );
+
+    const result = loadPluginManifest(dir, false);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.manifest.kind).toEqual(["memory", "context-engine"]);
+    }
+  });
+
+  it("collapses duplicate memory kinds so slot policy cannot be bypassed", () => {
+    const dir = makeTempDir();
+    fs.writeFileSync(
+      path.join(dir, "openclaw.plugin.json"),
+      JSON.stringify({
+        id: "duplicate-memory",
+        kind: ["memory", "memory"],
+        configSchema: { type: "object" },
+      }),
+      "utf-8",
+    );
+
+    const result = loadPluginManifest(dir, false);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.manifest.kind).toBe("memory");
+      expect(
+        resolveMemorySlotDecision({
+          id: result.manifest.id,
+          kind: result.manifest.kind,
+          slot: "memory-core",
+          selectedId: "memory-core",
+        }),
+      ).toEqual({ enabled: false, reason: 'memory slot set to "memory-core"' });
     }
   });
 

--- a/src/plugins/manifest.ts
+++ b/src/plugins/manifest.ts
@@ -29,6 +29,7 @@ const PLUGIN_MANIFEST_FILENAMES = [PLUGIN_MANIFEST_FILENAME] as const;
 const MAX_PLUGIN_MANIFEST_BYTES = 256 * 1024;
 const MAX_PLUGIN_MANIFEST_LOAD_CACHE_ENTRIES = 512;
 const CORE_RESERVED_PLUGIN_IDS = new Set(["node-mcp"]);
+const VALID_PLUGIN_KINDS = new Set<PluginKind>(["memory", "context-engine"]);
 
 export function isCoreReservedPluginId(id: string): boolean {
   return CORE_RESERVED_PLUGIN_IDS.has(normalizePluginPolicyId(id));
@@ -109,13 +110,15 @@ function setCachedPluginManifestLoadResult(
 }
 
 function parsePluginKind(raw: unknown): PluginKind | PluginKind[] | undefined {
-  if (typeof raw === "string") {
-    return raw as PluginKind;
+  const values = typeof raw === "string" ? [raw] : Array.isArray(raw) ? raw : [];
+  const kinds: PluginKind[] = [];
+  for (const value of values) {
+    const kind = typeof value === "string" ? (value as PluginKind) : undefined;
+    if (kind && VALID_PLUGIN_KINDS.has(kind) && !kinds.includes(kind)) {
+      kinds.push(kind);
+    }
   }
-  if (Array.isArray(raw) && raw.length > 0 && raw.every((k) => typeof k === "string")) {
-    return raw.length === 1 ? (raw[0] as PluginKind) : (raw as PluginKind[]);
-  }
-  return undefined;
+  return kinds.length === 0 ? undefined : kinds.length === 1 ? kinds[0] : kinds;
 }
 
 export function loadPluginManifest(

--- a/src/plugins/toggle-config.ts
+++ b/src/plugins/toggle-config.ts
@@ -1,6 +1,7 @@
 // Toggles plugin enablement config for channels and agents.
 import { normalizeChatChannelId } from "../channels/ids.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { normalizePluginId, normalizePluginTargetConfig } from "./config-state.js";
 
 /** Returns config with a plugin enabled/disabled and optional built-in channel state synced. */
 export function setPluginEnabledInConfig(
@@ -10,16 +11,23 @@ export function setPluginEnabledInConfig(
   options: { updateChannelConfig?: boolean } = {},
 ): OpenClawConfig {
   const builtInChannelId = normalizeChatChannelId(pluginId);
-  const resolvedId = builtInChannelId ?? pluginId;
+  const resolvedId = normalizePluginId(builtInChannelId ?? pluginId);
+  const normalizedConfig = normalizePluginTargetConfig(config, resolvedId);
+  const existingEntry: NonNullable<NonNullable<OpenClawConfig["plugins"]>["entries"]>[string] = {};
+  for (const [entryId, entry] of Object.entries(config.plugins?.entries ?? {})) {
+    if (normalizePluginId(entryId) === resolvedId) {
+      Object.assign(existingEntry, entry);
+    }
+  }
 
   const next: OpenClawConfig = {
-    ...config,
+    ...normalizedConfig,
     plugins: {
-      ...config.plugins,
+      ...normalizedConfig.plugins,
       entries: {
-        ...config.plugins?.entries,
+        ...normalizedConfig.plugins?.entries,
         [resolvedId]: {
-          ...(config.plugins?.entries?.[resolvedId] as object | undefined),
+          ...existingEntry,
           enabled,
         },
       },
@@ -30,7 +38,7 @@ export function setPluginEnabledInConfig(
     return next;
   }
 
-  const channels = config.channels as Record<string, unknown> | undefined;
+  const channels = normalizedConfig.channels as Record<string, unknown> | undefined;
   const existing = channels?.[builtInChannelId];
   const existingRecord =
     existing && typeof existing === "object" && !Array.isArray(existing)
@@ -40,7 +48,7 @@ export function setPluginEnabledInConfig(
   return {
     ...next,
     channels: {
-      ...config.channels,
+      ...normalizedConfig.channels,
       [builtInChannelId]: {
         ...existingRecord,
         enabled,


### PR DESCRIPTION
Closes #114320
Closes #114321
Closes #114322

## What Problem This Solves

Fixes three plugin control-plane failures where compatibility IDs could disagree with allow/deny policy, malformed or duplicate manifest kinds could evade slot semantics, and a policy-blocked CLI enable could still mutate persisted slot/config state.

## Why This Change Was Made

The change makes the mutation path use the same canonical plugin identity and normalized policy as runtime loading, validates manifest kinds as a deduplicated closed set, and stops a blocked CLI command before any persistence or slot side effect.

## User Impact

Plugin allow/deny decisions are consistent across aliases and casing, exclusive slots cannot be bypassed by duplicate kinds, and blocked enable commands leave configuration unchanged.

## Evidence

- Canonical enable/config group: 18/18 passed.
- Manifest kind group: 14/14 passed.
- CLI policy group: 11/11 passed.
- Wider config/slot, manifest/registry, and install/management/provider groups: 296/296 passed.
- Production and focused-test typechecks, targeted `oxfmt`, targeted `oxlint`, import-cycle, `git diff --check`, public Plugin SDK surface, protected-path, and secret scans passed.
- Fresh independent autoreview: no actionable findings, correctness 0.98.
- AI-assisted implementation and review; no public Plugin SDK, generated protocol, dependency, or lockfile boundary changed.
