### PR TITLE
fix: report unavailable system Node versions accurately

### DIFF
--- a/src/daemon/runtime-paths.test.ts
+++ b/src/daemon/runtime-paths.test.ts
@@ -491,7 +491,26 @@ describe("resolveSystemNodeInfo", () => {
     expect(execFile).not.toHaveBeenCalled();
   });
 
-  it("renders a warning when system node is too old", () => {
+  it("reports an unavailable system Node version while preserving the selected runtime", () => {
+    const selectedNode = "/Users/me/.fnm/node-22/bin/node";
+    const warning = renderSystemNodeWarning(
+      {
+        path: darwinNode,
+        sqliteVersion: null,
+        version: null,
+        nodeSharedSqlite: false,
+        supported: false,
+      },
+      selectedNode,
+    );
+
+    expect(warning).toBe(
+      `System Node at ${darwinNode} is available, but its version could not be determined. Using ${selectedNode} for the daemon. Install Node 24.15+ (recommended) or Node 22.22.3+ from nodejs.org or Homebrew.`,
+    );
+  });
+
+  it("reports a known unsupported system Node version", () => {
+    const selectedNode = "/Users/me/.fnm/node-22/bin/node";
     const warning = renderSystemNodeWarning(
       {
         path: darwinNode,
@@ -500,11 +519,27 @@ describe("resolveSystemNodeInfo", () => {
         nodeSharedSqlite: false,
         supported: false,
       },
+      selectedNode,
+    );
+
+    expect(warning).toBe(
+      `System Node 18.19.0 at ${darwinNode} is outside the supported range. Using ${selectedNode} for the daemon. Install Node 24.15+ (recommended) or Node 22.22.3+ from nodejs.org or Homebrew.`,
+    );
+  });
+
+  it("does not warn for a supported system Node version", () => {
+    const warning = renderSystemNodeWarning(
+      {
+        path: darwinNode,
+        sqliteVersion: "3.51.3",
+        version: "24.15.0",
+        nodeSharedSqlite: false,
+        supported: true,
+      },
       "/Users/me/.fnm/node-22/bin/node",
     );
 
-    expect(warning).toContain("outside the supported range");
-    expect(warning).toContain(darwinNode);
+    expect(warning).toBeNull();
   });
 
   it("renders a WAL safety warning for supported Node with unsafe SQLite", () => {

--- a/src/daemon/runtime-paths.ts
+++ b/src/daemon/runtime-paths.ts
@@ -232,7 +232,7 @@ export async function resolveSystemNodeInfo(params: {
   return firstAvailable;
 }
 
-/** Renders a warning when the system Node exists but is outside the supported range. */
+/** Renders a warning when the system Node exists but is unsuitable for the daemon. */
 export function renderSystemNodeWarning(
   systemNode: SystemNodeInfo | null,
   selectedNodePath?: string,
@@ -240,8 +240,11 @@ export function renderSystemNodeWarning(
   if (!systemNode || systemNode.supported) {
     return null;
   }
-  const versionLabel = systemNode.version ?? "unknown";
   const selectedLabel = selectedNodePath ? ` Using ${selectedNodePath} for the daemon.` : "";
+  if (systemNode.version === null) {
+    return `System Node at ${systemNode.path} is available, but its version could not be determined.${selectedLabel} Install Node 24.15+ (recommended) or Node 22.22.3+ from nodejs.org or Homebrew.`;
+  }
+  const versionLabel = systemNode.version;
   if (isSupportedNodeVersion(systemNode.version)) {
     const sqliteLabel = systemNode.sqliteVersion ?? "unknown";
     if (systemNode.nodeSharedSqlite) {


### PR DESCRIPTION
<!-- AI-assisted change prepared with Codex. -->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users running `openclaw doctor` would see an unavailable system Node version described as though it were a known unsupported version.

## Why This Change Was Made

Doctor now reports that the version could not be determined when the system Node probe returns no version. Known unsupported versions keep their existing range warning, supported versions remain silent, and the message identifying the active fallback daemon runtime is preserved.

## User Impact

Operators can distinguish a failed or unavailable Node version probe from an installed Node version that is outside OpenClaw's supported ranges, without losing the path of the runtime the daemon will actually use.

## Evidence

- `pnpm test src/daemon/runtime-paths.test.ts`: 33 tests passed on Blacksmith Testbox ([run](https://github.com/openclaw/openclaw/actions/runs/30237944290)).
- `node scripts/check-changed.mjs`: formatting, core production/test typechecks, lint, and boundary guards passed on Blacksmith Testbox ([run](https://github.com/openclaw/openclaw/actions/runs/30238024901)).
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted`: clean, with no accepted/actionable findings.
