### PR TITLE
feat(cron): default agent turns to the current conversation, add /loop, tighten cron tool surface

### DIFF
--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -110,9 +110,13 @@ When a stream job also has `trigger.script`, the gate runs once per closed batch
 
 Recurring jobs can set `pacing.min` and/or `pacing.max` to duration strings such as `15m` or `4h`; at least one bound is required. Use `--pacing-min` and `--pacing-max` with `cron add|edit` (`--clear-pacing` removes both bounds).
 
-During an isolated run, a paced job can call the `cron` tool with `action: "next_check"` and `in: "30m"`. The proposal applies only to that currently running job and is measured from successful run completion. OpenClaw silently clamps it to the configured bounds.
+During an agent-turn run, a paced job can call the `cron` tool with `action: "next_check"` and `in: "30m"`. The proposal applies only to that currently running job and is measured from successful run completion. OpenClaw silently clamps it to the configured bounds.
 
 Pacing without a proposal leaves the normal schedule unchanged. Failed, timed-out, and skipped runs discard the proposal, so existing retry and error-backoff behavior takes precedence. Manually forcing a recurring job is out-of-band and preserves its pending natural or paced slot. For condition-triggered jobs, the built-in minimum interval remains a lower bound even when a proposal requests an earlier check.
+
+### `/loop` chat shortcut
+
+In chat, the owner-only `/loop [interval] <prompt>` command creates a recurring agent-turn job bound to that conversation. Give an interval such as `5m` for fixed cadence, or omit it to let the loop self-pace between 1 minute and 1 hour with `next_check`. Use `/loop status` to list conversation-bound loops and `/loop stop [name]` to remove them.
 
 ### Day-of-month and day-of-week use OR logic
 
@@ -283,6 +287,8 @@ Throws, timeouts, exhausted tool budgets, invalid results, and `nextCheck` witho
 | Isolated        | `isolated`          | Dedicated `cron:<jobId>` | Reports, background chores      |
 | Current session | `current`           | Bound at creation time   | Context-aware recurring work    |
 | Custom session  | `session:custom-id` | Persistent named session | Workflows that build on history |
+
+Agent-turn jobs default to the creating conversation when the create request carries session context. Callers without a session key, including CLI and API callers that do not supply one, fall back to `isolated`. System events and heartbeats still default to `main`; command and script payloads still default to `isolated`.
 
 <AccordionGroup>
   <Accordion title="Main session vs isolated vs custom">

--- a/docs/cli/cron.md
+++ b/docs/cli/cron.md
@@ -56,6 +56,8 @@ openclaw cron create "*/15 * * * *" \
 
 `--session` accepts `main`, `isolated`, `current`, or `session:<id>`.
 
+Agent-turn jobs default to the creating conversation when session context is available. Without a session key, including ordinary CLI calls and API calls that omit one, the target falls back to `isolated`.
+
 <AccordionGroup>
   <Accordion title="Session keys">
     - `main` binds to the agent's main session.

--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -69,6 +69,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H3: Heartbeat task migration
   - H3: Stream sources
   - H3: Dynamic cadence (pacing)
+  - H3: /loop chat shortcut
   - H3: Day-of-month and day-of-week use OR logic
   - H2: Event triggers (condition watchers)
   - H2: Payloads
@@ -10477,6 +10478,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H3: Bundled plugin commands
   - H3: Skill commands
   - H2: /tools: what the agent can use now
+  - H2: /loop: recurring conversation work
   - H2: /model: model selection
   - H2: /config: on-disk config writes
   - H2: /mcp: MCP server config

--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -248,6 +248,9 @@ plugins.
     | --- | --- |
     | `/skill <name> [input]` | Run a skill by name |
     | `/learn [request]` | Draft one reviewable skill from the current conversation or named sources through [Skill Workshop](/tools/skill-workshop) |
+    | `/loop [interval] <prompt>` | Owner-only. Repeat a prompt in this conversation; omit the interval for self-paced checks |
+    | `/loop status` | Owner-only. List loops bound to this conversation |
+    | `/loop stop [name]` | Owner-only. Stop matching loops bound to this conversation |
     | `/allowlist [list\|add\|remove] ...` | Manage allowlist entries. Text-only |
     | `/approve <id> <decision>` | Resolve exec or plugin approval prompts |
     | `/btw <question>` | Ask a side question without changing session context. Alias: `/side`. See [BTW](/tools/btw) |
@@ -353,6 +356,10 @@ conversation** — not a static config catalog.
 Results are session-scoped. Changing agent, channel, thread, sender
 authorization, or model can change the output. For profile and override editing,
 use the Control UI Tools panel or config surfaces.
+
+## `/loop`: recurring conversation work
+
+`/loop` is owner-only because it uses the cron control-plane tool. `/loop 5m check deploy status` asks the agent to create a fixed-cadence cron job in the current conversation. Without an interval, `/loop watch for new issues` creates a self-paced loop that checks more often while active and backs off toward 1 hour while quiet. `/loop status` lists the conversation's loop jobs; `/loop stop [name]` removes them.
 
 ## `/model`: model selection
 

--- a/src/agents/tools/cron-tool.flat-params.test.ts
+++ b/src/agents/tools/cron-tool.flat-params.test.ts
@@ -73,7 +73,7 @@ describe("cron tool flat-params", () => {
     ).toBeUndefined();
   });
 
-  it("preserves explicit top-level sessionKey during flat-params recovery", async () => {
+  it("binds recovered agentTurn jobs to the creating conversation by default", async () => {
     const tool = createCronTool(
       { agentSessionKey: "agent:main:discord:channel:ops" },
       { callGatewayTool: callGatewayToolMock },
@@ -85,9 +85,13 @@ describe("cron tool flat-params", () => {
       message: "do stuff",
     });
 
-    const [method, _gatewayOpts, params] = firstGatewayToolCall<{ sessionKey?: string }>();
+    const [method, _gatewayOpts, params] = firstGatewayToolCall<{
+      sessionKey?: string;
+      sessionTarget?: string;
+    }>();
     expect(method).toBe("cron.add");
-    expect(params.sessionKey).toBe("agent:main:telegram:group:-100123:topic:99");
+    expect(params.sessionTarget).toBe("current");
+    expect(params.sessionKey).toBe("agent:main:discord:channel:ops");
   });
 
   it("recovers flat cron schedule shorthand for add", async () => {

--- a/src/agents/tools/cron-tool.schema.test.ts
+++ b/src/agents/tools/cron-tool.schema.test.ts
@@ -128,6 +128,29 @@ describe("createCronToolSchema", () => {
         "tz",
       ].toSorted(),
     );
+    expect(propertyAt(schemaRecord, "job.schedule.kind")?.enum).toContain("stream");
+  });
+
+  it("documents wake, context, and session-target fields", () => {
+    expect(propertyAt(schemaRecord, "text")?.description).toBe(
+      'systemEvent text for action="wake"',
+    );
+    expect(propertyAt(schemaRecord, "mode")?.description).toBe(
+      'Wake mode for action="wake" (default next-heartbeat)',
+    );
+    for (const path of ["job.sessionTarget", "patch.sessionTarget"]) {
+      expect(propertyAt(schemaRecord, path)?.description).toBe(
+        "main | isolated | current (agentTurn default) | session:<id>",
+      );
+    }
+    for (const path of ["job.payload", "patch.payload"]) {
+      expect(propertyAt(schemaRecord, `${path}.lightContext`)?.description).toBe(
+        "Lightweight bootstrap context (skip full workspace context)",
+      );
+      expect(propertyAt(schemaRecord, `${path}.allowUnsafeExternalContent`)?.description).toBe(
+        "Allow untrusted external content in prompt",
+      );
+    }
   });
 
   it("marks staggerMs as cron-only in both job and patch schedule schemas", () => {

--- a/src/agents/tools/cron-tool.test.ts
+++ b/src/agents/tools/cron-tool.test.ts
@@ -88,10 +88,10 @@ describe("cron tool", () => {
   it("tells models to keep cron expressions in local wall-clock time for tz", () => {
     const tool = createTestCronTool();
 
-    expect(tool.description).toContain("requested local wall time");
+    expect(tool.description).toContain("expr is wall time in tz");
     expect(tool.description).toContain("never pre-convert to UTC");
-    expect(tool.description).toContain("Missing tz = Gateway host local");
-    expect(tool.description).toContain("timezone-less = UTC");
+    expect(tool.description).toContain("no tz=gateway host local");
+    expect(tool.description).toContain("no tz=UTC");
     expect(tool.description).toContain('expr:"0 18 * * *"');
     expect(tool.description).toContain('tz:"Asia/Shanghai"');
   });
@@ -690,29 +690,27 @@ describe("cron tool", () => {
 
   it("documents deferred follow-up guidance in the tool description", () => {
     const tool = createTestCronTool();
-    expect(tool.description).toContain("reminders, later checks/follow-ups, recurring work");
-    expect(tool.description).toContain("Never exec sleep/process-poll as timer.");
+    expect(tool.description).toContain("reminders, delayed self-wakeups, loops, recurring work");
+    expect(tool.description).toContain("Never exec sleep/poll as timer.");
   });
 
   it("documents the event-trigger authoring contract", () => {
     const tool = createTestCronTool();
 
-    expect(tool.description).toContain("Requires cron.triggers.enabled");
-    expect(tool.description).toContain("quiet check has no model");
-    expect(tool.description).toContain("trigger.state");
-    expect(tool.description).toContain("fire:false saves state only; no payload/history");
-    expect(tool.description).toContain("fired state saves only after payload success");
-    expect(tool.description).toContain("every actionable state, including failures/timeouts");
-    expect(tool.description).toContain("success-only watchers go silent when broken");
     expect(tool.description).toContain(
-      "Dedupe by comparing trigger.state and returning new state, never memory",
+      "needs cron.triggers.enabled — if off, say so; never model-poll instead",
     );
-    expect(tool.description).toContain("scripts read-only; actions belong in payload");
-    expect(tool.description).toContain("message must be self-contained");
-    expect(tool.description).toContain("the fired run's entire context");
-    expect(tool.description).toContain('Silent watcher: top-level delivery.mode="none"');
-    expect(tool.description).toContain("missing route may fail");
-    expect(tool.description).toContain("once:true disables after first successful fire");
+    expect(tool.description).toContain("Quiet headless check, no model");
+    expect(tool.description).toContain("trigger.state");
+    expect(tool.description).toContain("fire:false saves state only");
+    expect(tool.description).toContain("fire:true runs payload");
+    expect(tool.description).toContain("Fire on failures/timeouts too");
+    expect(tool.description).toContain("success-only watchers look healthy when broken");
+    expect(tool.description).toContain("dedupe via state, never memory");
+    expect(tool.description).toContain("Script stays read-only; actions belong in payload");
+    expect(tool.description).toContain("message is that run's entire context — self-contained");
+    expect(tool.description).toContain('Silent watcher=>mode:"none"');
+    expect(tool.description).toContain("once:true disables after first fire");
     expect(tool.description).toContain('await tools.call("exec"');
   });
 
@@ -721,7 +719,7 @@ describe("cron tool", () => {
     const parameters = tool.parameters as SchemaLike;
     const runMode = parameters.properties?.runMode;
 
-    expect(tool.description).toContain('run jobId (due only; runMode="force" now)');
+    expect(tool.description).toContain('run jobId (runMode "force"=now)');
     expect(runMode?.description).toContain('omitted defaults to "due"');
     expect(runMode?.description).toContain('use "force" to trigger now');
   });
@@ -1550,6 +1548,22 @@ describe("cron tool", () => {
       agentSessionKey: callerSessionKey,
     });
     expect(sessionKey).toBe(callerSessionKey);
+  });
+
+  it("defaults scoped agentTurn adds to the creating conversation", async () => {
+    const callerSessionKey = "agent:main:discord:channel:ops";
+    const tool = createTestCronTool({ agentSessionKey: callerSessionKey });
+
+    await tool.execute("call-current-default", {
+      action: "add",
+      job: buildReminderAgentTurnJob(),
+    });
+
+    expect(expectSingleGatewayCallMethod("cron.add")).toMatchObject({
+      sessionTarget: "current",
+      sessionKey: callerSessionKey,
+      delivery: { mode: "announce" },
+    });
   });
 
   it("forwards authenticated source account separately from delivery account", async () => {

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -75,7 +75,7 @@ const CRON_ACTIONS = [
   "wake",
 ] as const;
 
-const CRON_SCHEDULE_KINDS = ["at", "every", "cron"] as const;
+const CRON_SCHEDULE_KINDS = ["at", "every", "cron", "stream"] as const;
 const CRON_WAKE_MODES = ["now", "next-heartbeat"] as const;
 const CRON_PAYLOAD_KINDS = ["systemEvent", "agentTurn", "script"] as const;
 const CRON_DELIVERY_MODES = ["none", "announce", "webhook"] as const;
@@ -133,8 +133,14 @@ function cronPayloadObjectSchema(params: {
       thinking: Type.Optional(Type.String({ description: "Thinking override" })),
       timeoutSeconds: optionalFiniteNumberSchema({ minimum: 0 }),
       toolBudget: optionalPositiveIntegerSchema({ description: "Maximum script tool calls" }),
-      lightContext: Type.Optional(Type.Boolean()),
-      allowUnsafeExternalContent: Type.Optional(Type.Boolean()),
+      lightContext: Type.Optional(
+        Type.Boolean({
+          description: "Lightweight bootstrap context (skip full workspace context)",
+        }),
+      ),
+      allowUnsafeExternalContent: Type.Optional(
+        Type.Boolean({ description: "Allow untrusted external content in prompt" }),
+      ),
       fallbacks: params.fallbacks,
       toolsAllow: params.toolsAllow,
     },
@@ -339,7 +345,7 @@ function createCronJobObjectSchema(): TSchema {
         trigger: createCronTriggerSchema({ nullableClears: false }),
         sessionTarget: Type.Optional(
           Type.String({
-            description: "main | isolated | current | session:<id>",
+            description: "main | isolated | current (agentTurn default) | session:<id>",
           }),
         ),
         wakeMode: optionalStringEnum(CRON_WAKE_MODES, { description: "Wake timing" }),
@@ -370,7 +376,11 @@ function createCronPatchObjectSchema(): TSchema {
         schedule: createCronScheduleSchema(),
         pacing: createCronPacingSchema({ nullableClears: true }),
         trigger: createCronTriggerSchema({ nullableClears: true }),
-        sessionTarget: Type.Optional(Type.String({ description: "Session target" })),
+        sessionTarget: Type.Optional(
+          Type.String({
+            description: "main | isolated | current (agentTurn default) | session:<id>",
+          }),
+        ),
         wakeMode: optionalStringEnum(CRON_WAKE_MODES),
         payload: Type.Optional(
           cronPayloadObjectSchema({
@@ -408,8 +418,10 @@ function createCronToolSchema(): TSchema {
           description: 'Relative duration for action="next_check" (for example, "15m")',
         }),
       ),
-      text: Type.Optional(Type.String()),
-      mode: optionalStringEnum(CRON_WAKE_MODES),
+      text: Type.Optional(Type.String({ description: 'systemEvent text for action="wake"' })),
+      mode: optionalStringEnum(CRON_WAKE_MODES, {
+        description: 'Wake mode for action="wake" (default next-heartbeat)',
+      }),
       runMode: optionalStringEnum(CRON_RUN_MODES, {
         description:
           'Run mode for action="run": omitted defaults to "due"; use "force" to trigger now.',
@@ -740,44 +752,33 @@ export function createCronTool(opts?: CronToolOptions, deps?: CronToolDeps): Any
     label: "Cron",
     name: "cron",
     displaySummary: CRON_TOOL_DISPLAY_SUMMARY,
-    description: `Gateway schedules/wakes: reminders, later checks/follow-ups, recurring work. Never exec sleep/process-poll as timer. Main job => heartbeat system event; isolated => background task in \`openclaw tasks\`.
+    description: `Gateway scheduler: reminders, delayed self-wakeups, loops, recurring work, event watchers. Never exec sleep/poll as timer.
 
-ACTIONS:
-- status scheduler; list compact summaries (includeDisabled, session agentId auto-filter; get for full); get jobId
-- add job; update jobId+patch; remove jobId
-- run jobId (due only; runMode="force" now); runs jobId history; next_check in (current paced job only)
-- wake text (+ optional mode). Default caller lane; top-level sessionKey/agentId selects another caller-owned lane.
+ACTIONS: status | list [includeDisabled] | get jobId | add job | update jobId patch | remove jobId | run jobId (runMode "force"=now) | runs jobId = history | next_check in:"30m" (own paced run only) | wake text mode?:"now"|"next-heartbeat"(default) nudges a caller-owned lane (sessionKey/agentId to pick another).
 
-ADD JOB:
-{ "name":"...", "schedule":{...}, "pacing":{ "min":"15m", "max":"4h" }, "trigger":{ "script":"...", "once":false }, "payload":{...}, "delivery":{...}, "sessionTarget":"main|isolated|current|session:<id>", "enabled":true }
-Required: schedule,payload. enabled default true. trigger only every/cron.
-
-TARGET/PAYLOAD:
-- main => systemEvent {kind:"systemEvent",text:"..."} or script; systemEvent defaults main.
-- isolated/current/session:<id> => agentTurn {kind:"agentTurn",message:"...",model?,thinking?,timeoutSeconds?}; agentTurn defaults isolated. timeoutSeconds=0 means none.
-- script {kind:"script",script:"...",timeoutSeconds?,toolBudget?} supports main or isolated only and requires cron.triggers.enabled.
-- current binds caller session at creation. session:<id> is persistent. Prefer isolated unless user explicitly wants current binding.
+ADD: {name?,schedule,payload,sessionTarget?,pacing?,trigger?,delivery?,enabled?}. Required: schedule+payload.
 
 SCHEDULE:
-- at: {kind:"at",at:"ISO-8601"}; timezone-less = UTC.
-- every: {kind:"every",everyMs:<ms>,anchorMs?}.
-- cron: {kind:"cron",expr:"...",tz?:"IANA"}. Expr is requested local wall time; never pre-convert to UTC. Missing tz = Gateway host local, not UTC. Shanghai 18:00: {kind:"cron",expr:"0 18 * * *",tz:"Asia/Shanghai"}.
+- {kind:"at",at:"ISO-8601"} one-shot; no tz=UTC; auto-deletes after run.
+- {kind:"every",everyMs}.
+- {kind:"cron",expr,tz?:"IANA"}: expr is wall time in tz; never pre-convert to UTC; no tz=gateway host local. 18:00 Shanghai => {expr:"0 18 * * *",tz:"Asia/Shanghai"}.
+- {kind:"stream",command:[argv],mode?:"line"|"match",match?}: fires on supervised process output; needs cron.triggers.enabled.
 
-TRIGGER SCRIPT:
-- Requires cron.triggers.enabled; if off, explain and never model-poll fallback.
-- Headless owner allowlist; quiet check has no model. Prior trigger.state is frozen JSON. Return/json({fire:boolean,message?:string,state?:JSONValue}); create new state, never mutate prior.
-- fire:false saves state only; no payload/history. fire:true runs payload and appends message; fired state saves only after payload success.
-- Fire on every actionable state, including failures/timeouts; success-only watchers go silent when broken, which looks healthy. Dedupe by comparing trigger.state and returning new state, never memory.
-- Keep scripts read-only; actions belong in payload. message must be self-contained: it is the fired run's entire context.
-- Silent watcher: top-level delivery.mode="none". Omitted delivery on isolated agentTurn announces and missing route may fail.
-- once:true disables after first successful fire. Per check: 30s, 5 tool calls, 16KB state.
-- Hidden Code Mode tools: await tools.call("exec", {command:"..."}); unknown id => search/describe.
+TARGET+PAYLOAD:
+- "current" (agentTurn default) = this conversation: run carries this chat's context, result lands here. Self-wakeup/"continue later"/loop = at|every + agentTurn + current.
+- "isolated" = fresh detached session (shows in \`openclaw tasks\`); standalone background work.
+- "main" = heartbeat lane; payload {kind:"systemEvent",text} (systemEvent default target).
+- "session:<key>" = named session.
+- agentTurn {kind:"agentTurn",message,model?,thinking?,timeoutSeconds?}; timeoutSeconds 0=none.
+- script {kind:"script",script,timeoutSeconds?,toolBudget?}: main|isolated only; needs cron.triggers.enabled.
 
-DELIVERY top-level: {mode:"none|announce|webhook",channel?,to?,threadId?,bestEffort?}
-- Isolated agentTurn omitted delivery => announce. announce only isolated/current/session; channel/to optional; threadId chat topic. Specific chat: set channel/to; no messaging tool inside run.
-- webhook posts finished-run event to URL in to.
+PACED LOOP: recurring job + pacing{min?,max?} durations ("15m","4h"; at least one). Inside its run, job calls next_check in:"<dur>" to set the next delay (clamped to bounds, measured from run end; failed runs keep normal backoff). Adaptive polling: tighten when active, back off when quiet.
 
-Restricted isolated runs may only self status/list, current get/runs/remove, and next_check for their own paced job. wake mode: next-heartbeat default | now. jobId canonical; id compat. contextMessages 0-10 adds prior messages.`,
+TRIGGER (condition watcher on every/cron): {script,once?}; needs cron.triggers.enabled — if off, say so; never model-poll instead. Quiet headless check, no model; 30s/5 tool calls/16KB state. Read frozen trigger.state, return json({fire,message?,state?}) with NEW state; dedupe via state, never memory. fire:false saves state only. fire:true runs payload; message is that run's entire context — self-contained. Fire on failures/timeouts too; success-only watchers look healthy when broken. Script stays read-only; actions belong in payload. once:true disables after first fire. Code Mode: await tools.call("exec",{command:"..."}).
+
+DELIVERY {mode:"none"|"announce"|"webhook",channel?,to?,threadId?,bestEffort?}: where detached run output goes. Omitted=announce (current=>this chat; isolated=>last route; set channel/to for a specific chat — no messaging tool inside the run). Silent watcher=>mode:"none". webhook posts finished-run event to URL in \`to\`.
+
+Job wakeMode (main jobs): "now"(default)|"next-heartbeat". Restricted cron-run sessions: self status/list/get/runs/remove + own next_check only. failureAlert {...}|false disables. jobId canonical (id=compat). contextMessages 0-10 embeds recent chat lines into reminder text.`,
     parameters: createCronToolSchema(),
     execute: async (_toolCallId, args) => {
       const params = args as Record<string, unknown>;

--- a/src/auto-reply/commands-registry.shared.ts
+++ b/src/auto-reply/commands-registry.shared.ts
@@ -251,6 +251,23 @@ export function buildBuiltinChatCommands(
       ],
     }),
     defineChatCommand({
+      key: "loop",
+      nativeName: "loop",
+      description: "Loop a prompt: /loop [interval] <prompt> | /loop status | /loop stop [name]",
+      textAlias: "/loop",
+      category: "tools",
+      tier: "standard",
+      args: [
+        {
+          name: "spec",
+          description: "[interval] prompt, or status/stop",
+          type: "string",
+          required: false,
+          captureRemaining: true,
+        },
+      ],
+    }),
+    defineChatCommand({
       key: "status",
       nativeName: "status",
       description: "Show current status.",

--- a/src/auto-reply/commands-registry.test.ts
+++ b/src/auto-reply/commands-registry.test.ts
@@ -306,6 +306,17 @@ describe("commands registry", () => {
     );
   });
 
+  it("registers /loop as a standard tools command with an optional spec", () => {
+    const loop = requireChatCommand("loop");
+    expect(loop.nativeName).toBe("loop");
+    expect(loop.textAliases).toEqual(["/loop"]);
+    expect(loop.category).toBe("tools");
+    expect(loop.tier).toBe("standard");
+    expect(loop.acceptsArgs).toBe(true);
+    expect(requireCommandArg(loop, "spec").required).not.toBe(true);
+    expect(resolveTextCommand("/loop 5m check ci")?.args).toBe("5m check ci");
+  });
+
   it("preserves multiline payloads for direct skill slash aliases only when unregistered", () => {
     expect(normalizeCommandBody("/demo_skill first line\nsecond line")).toBe(
       "/demo_skill first line\nsecond line",
@@ -525,6 +536,7 @@ describe("commands registry", () => {
     expect(detection.exact.has("/commands")).toBe(true);
     expect(detection.exact.has("/skill")).toBe(true);
     expect(detection.exact.has("/learn")).toBe(true);
+    expect(detection.exact.has("/loop")).toBe(true);
     expect(detection.exact.has("/compact")).toBe(true);
     expect(detection.exact.has("/whoami")).toBe(true);
     expect(detection.exact.has("/id")).toBe(true);

--- a/src/auto-reply/reply/commands-handlers.order.ts
+++ b/src/auto-reply/reply/commands-handlers.order.ts
@@ -22,6 +22,7 @@ export const commandHandlerOrder = [
   "status",
   "goal",
   "learn",
+  "loop",
   "name",
   "diagnostics",
   "tasks",

--- a/src/auto-reply/reply/commands-handlers.runtime.ts
+++ b/src/auto-reply/reply/commands-handlers.runtime.ts
@@ -22,6 +22,7 @@ import {
 } from "./commands-info.js";
 import { handleLearnCommand } from "./commands-learn.js";
 import { handleLoginCommand } from "./commands-login.js";
+import { handleLoopCommand } from "./commands-loop.js";
 import { handleMcpCommand } from "./commands-mcp.js";
 import { handleModelsCommand } from "./commands-models.js";
 import { handleNameCommand } from "./commands-name.js";
@@ -66,6 +67,7 @@ const commandHandlersById = {
   goal: handleGoalCommand,
   help: handleHelpCommand,
   learn: handleLearnCommand,
+  loop: handleLoopCommand,
   login: handleLoginCommand,
   mcp: handleMcpCommand,
   models: handleModelsCommand,

--- a/src/auto-reply/reply/commands-loop.test.ts
+++ b/src/auto-reply/reply/commands-loop.test.ts
@@ -1,0 +1,132 @@
+// Tests /loop recognition, work-order rewriting, authorization, and interval guards.
+import { describe, expect, it } from "vitest";
+import { INTERNAL_MESSAGE_CHANNEL } from "../../utils/message-channel.js";
+import { handleLoopCommand } from "./commands-loop.js";
+import type { HandleCommandsParams } from "./commands-types.js";
+
+function buildLoopParams(commandBodyNormalized: string): HandleCommandsParams {
+  return {
+    cfg: {},
+    ctx: {
+      Provider: INTERNAL_MESSAGE_CHANNEL,
+      Surface: INTERNAL_MESSAGE_CHANNEL,
+      CommandSource: "text",
+      Body: commandBodyNormalized,
+      RawBody: commandBodyNormalized,
+      CommandBody: commandBodyNormalized,
+      BodyForCommands: commandBodyNormalized,
+      BodyForAgent: commandBodyNormalized,
+      BodyStripped: commandBodyNormalized,
+    },
+    command: {
+      commandBodyNormalized,
+      isAuthorizedSender: true,
+      senderIsOwner: true,
+      senderId: "tester",
+      channel: INTERNAL_MESSAGE_CHANNEL,
+      channelId: INTERNAL_MESSAGE_CHANNEL,
+      surface: INTERNAL_MESSAGE_CHANNEL,
+      ownerList: [],
+      rawBodyNormalized: commandBodyNormalized,
+    },
+    directives: {},
+    elevated: { enabled: true, allowed: true, failures: [] },
+    sessionKey: "agent:main:webchat:test",
+    workspaceDir: "/tmp",
+    provider: "openai",
+    model: "gpt-5.6",
+    contextTokens: 0,
+    defaultGroupActivation: () => "mention",
+    resolvedVerboseLevel: "off",
+    resolvedReasoningLevel: "off",
+    resolveDefaultThinkingLevel: async () => undefined,
+    isGroup: false,
+  } as unknown as HandleCommandsParams;
+}
+
+function rewrittenBody(params: HandleCommandsParams): string {
+  return (params.ctx as { BodyForAgent?: string }).BodyForAgent ?? "";
+}
+
+describe("loop command", () => {
+  it("ignores non-loop text", async () => {
+    expect(await handleLoopCommand(buildLoopParams("check ci"), true)).toBeNull();
+  });
+
+  it("returns usage for bare /loop without continuing", async () => {
+    const result = await handleLoopCommand(buildLoopParams("/loop"), true);
+
+    expect(result?.shouldContinue).toBe(false);
+    expect(result?.reply?.text).toBe(
+      "Usage: /loop [interval] <prompt> — repeat a prompt in this chat (e.g. /loop 5m check deploy status). Without interval the loop self-paces between 1m and 1h. /loop status lists loops; /loop stop [name] stops.",
+    );
+  });
+
+  it("rewrites a fixed interval loop as a current-session cron job", async () => {
+    const params = buildLoopParams("/loop 5m check ci");
+
+    expect(await handleLoopCommand(params, true)).toEqual({ shouldContinue: true });
+    expect(rewrittenBody(params)).toContain('schedule:{kind:"every",everyMs:300000}');
+    expect(rewrittenBody(params)).toContain('sessionTarget:"current"');
+  });
+
+  it("preserves parseDurationMs unitless millisecond intervals", async () => {
+    const params = buildLoopParams("/loop 30000 check ci");
+
+    expect(await handleLoopCommand(params, true)).toEqual({ shouldContinue: true });
+    expect(rewrittenBody(params)).toContain('schedule:{kind:"every",everyMs:30000}');
+  });
+
+  it("rewrites an interval-free loop with pacing and next_check guidance", async () => {
+    const params = buildLoopParams("/loop watch for new github issues");
+
+    expect(await handleLoopCommand(params, true)).toEqual({ shouldContinue: true });
+    expect(rewrittenBody(params)).toContain('pacing:{min:"1m",max:"1h"}');
+    expect(rewrittenBody(params)).toContain('action:\\"next_check\\"');
+    expect(rewrittenBody(params)).toContain('in:\\"<duration>\\"');
+  });
+
+  it("rewrites /loop status as a conversation-scoped list work order", async () => {
+    const params = buildLoopParams("/loop status");
+
+    expect(await handleLoopCommand(params, true)).toEqual({ shouldContinue: true });
+    expect(rewrittenBody(params)).toContain('action:"list"');
+    expect(rewrittenBody(params)).toContain('names starting with "loop:"');
+    expect(rewrittenBody(params)).toContain("bound to this conversation");
+    expect(rewrittenBody(params)).toContain('action:"get"');
+    expect(rewrittenBody(params)).toContain('sessionKey exactly "agent:main:webchat:test"');
+  });
+
+  it("rewrites /loop stop as a scoped cron removal work order", async () => {
+    const params = buildLoopParams("/loop stop");
+
+    expect(await handleLoopCommand(params, true)).toEqual({ shouldContinue: true });
+    expect(rewrittenBody(params)).toContain('starting "loop:"');
+    expect(rewrittenBody(params)).toContain('action:"remove"');
+    expect(rewrittenBody(params)).toContain('action:"get"');
+    expect(rewrittenBody(params)).toContain('sessionKey exactly "agent:main:webchat:test"');
+  });
+
+  it("rejects unauthorized senders", async () => {
+    const params = buildLoopParams("/loop 5m check ci");
+    params.command.isAuthorizedSender = false;
+
+    expect(await handleLoopCommand(params, true)).toEqual({ shouldContinue: false });
+    expect(rewrittenBody(params)).toBe("/loop 5m check ci");
+  });
+
+  it("rejects authorized non-owner senders before starting an agent turn", async () => {
+    const params = buildLoopParams("/loop 5m check ci");
+    params.command.senderIsOwner = false;
+
+    expect(await handleLoopCommand(params, true)).toEqual({ shouldContinue: false });
+    expect(rewrittenBody(params)).toBe("/loop 5m check ci");
+  });
+
+  it("rejects intervals below 30 seconds", async () => {
+    const result = await handleLoopCommand(buildLoopParams("/loop 5s x"), true);
+
+    expect(result?.shouldContinue).toBe(false);
+    expect(result?.reply?.text).toContain("Minimum interval 30s");
+  });
+});

--- a/src/auto-reply/reply/commands-loop.test.ts
+++ b/src/auto-reply/reply/commands-loop.test.ts
@@ -1,4 +1,5 @@
 // Tests /loop recognition, work-order rewriting, authorization, and interval guards.
+import { createHash } from "node:crypto";
 import { describe, expect, it } from "vitest";
 import { INTERNAL_MESSAGE_CHANNEL } from "../../utils/message-channel.js";
 import { handleLoopCommand } from "./commands-loop.js";
@@ -48,6 +49,9 @@ function rewrittenBody(params: HandleCommandsParams): string {
   return (params.ctx as { BodyForAgent?: string }).BodyForAgent ?? "";
 }
 
+// Mirrors the handler's conversation tag for the fixture sessionKey.
+const LOOP_PREFIX = `loop[${createHash("sha256").update("agent:main:webchat:test").digest("hex").slice(0, 6)}]`;
+
 describe("loop command", () => {
   it("ignores non-loop text", async () => {
     expect(await handleLoopCommand(buildLoopParams("check ci"), true)).toBeNull();
@@ -68,6 +72,8 @@ describe("loop command", () => {
     expect(await handleLoopCommand(params, true)).toEqual({ shouldContinue: true });
     expect(rewrittenBody(params)).toContain('schedule:{kind:"every",everyMs:300000}');
     expect(rewrittenBody(params)).toContain('sessionTarget:"current"');
+    expect(rewrittenBody(params)).toContain(`"${LOOP_PREFIX} check ci"`);
+    expect(rewrittenBody(params)).toContain("do not use the message tool");
   });
 
   it("preserves parseDurationMs unitless millisecond intervals", async () => {
@@ -91,20 +97,18 @@ describe("loop command", () => {
 
     expect(await handleLoopCommand(params, true)).toEqual({ shouldContinue: true });
     expect(rewrittenBody(params)).toContain('action:"list"');
-    expect(rewrittenBody(params)).toContain('names starting with "loop:"');
-    expect(rewrittenBody(params)).toContain("bound to this conversation");
-    expect(rewrittenBody(params)).toContain('action:"get"');
-    expect(rewrittenBody(params)).toContain('sessionKey exactly "agent:main:webchat:test"');
+    expect(rewrittenBody(params)).toContain(`name starts with "${LOOP_PREFIX}"`);
   });
 
   it("rewrites /loop stop as a scoped cron removal work order", async () => {
     const params = buildLoopParams("/loop stop");
 
     expect(await handleLoopCommand(params, true)).toEqual({ shouldContinue: true });
-    expect(rewrittenBody(params)).toContain('starting "loop:"');
+    expect(rewrittenBody(params)).toContain(`name starts with "${LOOP_PREFIX}"`);
     expect(rewrittenBody(params)).toContain('action:"remove"');
-    expect(rewrittenBody(params)).toContain('action:"get"');
-    expect(rewrittenBody(params)).toContain('sessionKey exactly "agent:main:webchat:test"');
+    expect(rewrittenBody(params)).toContain(
+      `Never remove a job whose name does not start with "${LOOP_PREFIX}"`,
+    );
   });
 
   it("rejects unauthorized senders", async () => {

--- a/src/auto-reply/reply/commands-loop.test.ts
+++ b/src/auto-reply/reply/commands-loop.test.ts
@@ -50,7 +50,7 @@ function rewrittenBody(params: HandleCommandsParams): string {
 }
 
 // Mirrors the handler's conversation tag for the fixture sessionKey.
-const LOOP_PREFIX = `loop[${createHash("sha256").update("agent:main:webchat:test").digest("hex").slice(0, 6)}]`;
+const LOOP_PREFIX = `loop[${createHash("sha256").update("agent:main:webchat:test").digest("hex").slice(0, 12)}]`;
 
 describe("loop command", () => {
   it("ignores non-loop text", async () => {

--- a/src/auto-reply/reply/commands-loop.test.ts
+++ b/src/auto-reply/reply/commands-loop.test.ts
@@ -96,7 +96,7 @@ describe("loop command", () => {
     const params = buildLoopParams("/loop status");
 
     expect(await handleLoopCommand(params, true)).toEqual({ shouldContinue: true });
-    expect(rewrittenBody(params)).toContain('action:"list"');
+    expect(rewrittenBody(params)).toContain('action:"list", includeDisabled:true');
     expect(rewrittenBody(params)).toContain(`name starts with "${LOOP_PREFIX}"`);
   });
 
@@ -104,6 +104,7 @@ describe("loop command", () => {
     const params = buildLoopParams("/loop stop");
 
     expect(await handleLoopCommand(params, true)).toEqual({ shouldContinue: true });
+    expect(rewrittenBody(params)).toContain('action:"list", includeDisabled:true');
     expect(rewrittenBody(params)).toContain(`name starts with "${LOOP_PREFIX}"`);
     expect(rewrittenBody(params)).toContain('action:"remove"');
     expect(rewrittenBody(params)).toContain(

--- a/src/auto-reply/reply/commands-loop.ts
+++ b/src/auto-reply/reply/commands-loop.ts
@@ -1,0 +1,155 @@
+// Handles /loop by rewriting chat sugar into a cron-tool work order.
+import { parseDurationMs } from "../../cli/parse-duration.js";
+import { truncateUtf16Safe } from "../../utils.js";
+import { rejectNonOwnerCommand, rejectUnauthorizedCommand } from "./command-gates.js";
+import type {
+  CommandHandler,
+  CommandHandlerResult,
+  HandleCommandsParams,
+} from "./commands-types.js";
+
+const LOOP_COMMAND_PREFIX = "/loop";
+const LOOP_MIN_INTERVAL_MS = 30_000;
+const LOOP_DEFAULT_INTERVAL_MS = 15 * 60_000;
+const LOOP_NAME_MAX_LENGTH = 40;
+const LOOP_USAGE =
+  "Usage: /loop [interval] <prompt> — repeat a prompt in this chat (e.g. /loop 5m check deploy status). Without interval the loop self-paces between 1m and 1h. /loop status lists loops; /loop stop [name] stops.";
+
+function directReply(text: string): CommandHandlerResult {
+  return { shouldContinue: false, reply: { text } };
+}
+
+function applyLoopWorkOrderToContext(ctx: HandleCommandsParams["ctx"], instruction: string): void {
+  const mutableCtx = ctx as HandleCommandsParams["ctx"] & {
+    Body?: string;
+    RawBody?: string;
+    CommandBody?: string;
+    BodyForCommands?: string;
+    BodyForAgent?: string;
+    BodyStripped?: string;
+    commandText?: string;
+    agentText?: string;
+    rawText?: string;
+  };
+  mutableCtx.commandText = instruction;
+  mutableCtx.agentText = instruction;
+  mutableCtx.rawText = instruction;
+  mutableCtx.Body = instruction;
+  mutableCtx.RawBody = instruction;
+  mutableCtx.CommandBody = instruction;
+  mutableCtx.BodyForCommands = instruction;
+  mutableCtx.BodyForAgent = instruction;
+  mutableCtx.BodyStripped = instruction;
+}
+
+function applyLoopWorkOrder(params: HandleCommandsParams, instruction: string): void {
+  applyLoopWorkOrderToContext(params.ctx, instruction);
+  if (params.rootCtx && params.rootCtx !== params.ctx) {
+    applyLoopWorkOrderToContext(params.rootCtx, instruction);
+  }
+  params.command.rawBodyNormalized = instruction;
+  params.command.commandBodyNormalized = instruction;
+}
+
+function loopNameForPrompt(prompt: string): { jobName: string; shortName: string } {
+  const shortName = truncateUtf16Safe(prompt.trim(), LOOP_NAME_MAX_LENGTH).trimEnd();
+  return { jobName: `loop: ${shortName}`, shortName };
+}
+
+function buildLoopPayloadMessage(params: {
+  prompt: string;
+  shortName: string;
+  selfPaced: boolean;
+}): string {
+  const lines = [
+    `[loop ${params.shortName}] ${params.prompt}`,
+    "Do the task and reply concisely. If nothing changed since the last run, reply briefly.",
+  ];
+  if (params.selfPaced) {
+    lines.push(
+      'After finishing, call the cron tool action:"next_check" with in:"<duration>" — pick the next check interval yourself based on how active the task is; back off toward 1h when quiet.',
+    );
+  }
+  return lines.join("\n");
+}
+
+function buildFixedLoopWorkOrder(prompt: string, everyMs: number): string {
+  const { jobName, shortName } = loopNameForPrompt(prompt);
+  const message = buildLoopPayloadMessage({ prompt, shortName, selfPaced: false });
+  return `Create a recurring loop with the cron tool, then confirm in one short line (name + cadence + '/loop stop' hint). action:"add", job:{name:${JSON.stringify(jobName)},schedule:{kind:"every",everyMs:${everyMs}},sessionTarget:"current",payload:{kind:"agentTurn",message:${JSON.stringify(message)}}}.`;
+}
+
+function buildSelfPacedLoopWorkOrder(prompt: string): string {
+  const { jobName, shortName } = loopNameForPrompt(prompt);
+  const message = buildLoopPayloadMessage({ prompt, shortName, selfPaced: true });
+  return `Create a recurring loop with the cron tool, then confirm in one short line (name + cadence + '/loop stop' hint). action:"add", job:{name:${JSON.stringify(jobName)},schedule:{kind:"every",everyMs:${LOOP_DEFAULT_INTERVAL_MS}},pacing:{min:"1m",max:"1h"},sessionTarget:"current",payload:{kind:"agentTurn",message:${JSON.stringify(message)}}}.`;
+}
+
+function buildLoopStatusWorkOrder(sessionKey: string): string {
+  return `Use the cron tool (action:"list") and report the loop jobs bound to this conversation (names starting with "loop:"): name, schedule/pacing, last run, next run. If none, say so. The list is agent-wide, so call action:"get" for each "loop:" candidate and include it only when its full definition has sessionTarget:"current" and sessionKey exactly ${JSON.stringify(sessionKey)}.`;
+}
+
+function buildLoopStopWorkOrder(name: string, sessionKey: string): string {
+  const matchInstruction = name ? ` Match ${JSON.stringify(name)} against the job name.` : "";
+  return `List cron jobs, find jobs named starting "loop:" bound to this conversation.${matchInstruction} Remove them with action:"remove" and confirm the removed names. If none matched, say so and list active loop names. The list is agent-wide: immediately before each removal, call action:"get" and remove only a job whose full definition has sessionTarget:"current" and sessionKey exactly ${JSON.stringify(sessionKey)}.`;
+}
+
+/** Command handler for conversation-bound recurring loops. */
+export const handleLoopCommand: CommandHandler = async (params, allowTextCommands) => {
+  if (!allowTextCommands) {
+    return null;
+  }
+  const trimmed = params.command.commandBodyNormalized.trim();
+  const commandEnd = trimmed.search(/\s/u);
+  const commandToken = commandEnd === -1 ? trimmed : trimmed.slice(0, commandEnd);
+  if (commandToken.toLowerCase() !== LOOP_COMMAND_PREFIX) {
+    return null;
+  }
+  const unauthorized = rejectUnauthorizedCommand(params, LOOP_COMMAND_PREFIX);
+  if (unauthorized) {
+    return unauthorized;
+  }
+  const nonOwner = rejectNonOwnerCommand(params, LOOP_COMMAND_PREFIX);
+  if (nonOwner) {
+    return nonOwner;
+  }
+
+  const spec = commandEnd === -1 ? "" : trimmed.slice(commandEnd).trim();
+  if (!spec || spec.toLowerCase() === "help") {
+    return directReply(LOOP_USAGE);
+  }
+  if (spec.toLowerCase() === "status") {
+    applyLoopWorkOrder(params, buildLoopStatusWorkOrder(params.sessionKey));
+    return { shouldContinue: true };
+  }
+
+  const [firstToken = ""] = spec.split(/\s+/u);
+  if (firstToken.toLowerCase() === "stop") {
+    const name = spec.slice(firstToken.length).trim();
+    applyLoopWorkOrder(params, buildLoopStopWorkOrder(name, params.sessionKey));
+    return { shouldContinue: true };
+  }
+
+  let everyMs: number | undefined;
+  // Preserve parseDurationMs semantics: bare numbers are milliseconds.
+  // The 30s floor rejects hot-loop values instead of reinterpreting them as prompt text.
+  try {
+    everyMs = parseDurationMs(firstToken);
+  } catch {
+    everyMs = undefined;
+  }
+  if (everyMs !== undefined) {
+    if (everyMs < LOOP_MIN_INTERVAL_MS) {
+      return directReply(`${LOOP_USAGE} Minimum interval 30s.`);
+    }
+    const prompt = spec.slice(firstToken.length).trim();
+    if (!prompt) {
+      return directReply(LOOP_USAGE);
+    }
+    applyLoopWorkOrder(params, buildFixedLoopWorkOrder(prompt, everyMs));
+    return { shouldContinue: true };
+  }
+
+  applyLoopWorkOrder(params, buildSelfPacedLoopWorkOrder(spec));
+  return { shouldContinue: true };
+};

--- a/src/auto-reply/reply/commands-loop.ts
+++ b/src/auto-reply/reply/commands-loop.ts
@@ -1,4 +1,5 @@
 // Handles /loop by rewriting chat sugar into a cron-tool work order.
+import { createHash } from "node:crypto";
 import { parseDurationMs } from "../../cli/parse-duration.js";
 import { truncateUtf16Safe } from "../../utils.js";
 import { rejectNonOwnerCommand, rejectUnauthorizedCommand } from "./command-gates.js";
@@ -51,10 +52,23 @@ function applyLoopWorkOrder(params: HandleCommandsParams, instruction: string): 
   params.command.commandBodyNormalized = instruction;
 }
 
-function loopNameForPrompt(prompt: string): { jobName: string; shortName: string } {
-  const shortName = truncateUtf16Safe(prompt.trim(), LOOP_NAME_MAX_LENGTH).trimEnd();
-  return { jobName: `loop: ${shortName}`, shortName };
+function loopShortName(prompt: string): string {
+  return truncateUtf16Safe(prompt.trim(), LOOP_NAME_MAX_LENGTH).trimEnd();
 }
+
+// Conversation tag baked into the job name at create time. Status/stop match by
+// this same tag, so loop discovery never depends on how the cron side resolves
+// session keys (which can differ from the command pipeline's sessionKey).
+function loopConversationTag(sessionKey: string): string {
+  return createHash("sha256").update(sessionKey).digest("hex").slice(0, 6);
+}
+
+function loopNamePrefix(sessionKey: string): string {
+  return `loop[${loopConversationTag(sessionKey)}]`;
+}
+
+const LOOP_FINAL_REPLY_ONLY =
+  "Reply with your normal final message only; do not use the message tool.";
 
 function buildLoopPayloadMessage(params: {
   prompt: string;
@@ -67,31 +81,37 @@ function buildLoopPayloadMessage(params: {
   ];
   if (params.selfPaced) {
     lines.push(
-      'After finishing, call the cron tool action:"next_check" with in:"<duration>" — pick the next check interval yourself based on how active the task is; back off toward 1h when quiet.',
+      'Before replying, ALWAYS call the cron tool action:"next_check" with in:"<duration>" — pick the next check interval from how active the task is; back off toward 1h when quiet.',
     );
   }
   return lines.join("\n");
 }
 
-function buildFixedLoopWorkOrder(prompt: string, everyMs: number): string {
-  const { jobName, shortName } = loopNameForPrompt(prompt);
+function buildFixedLoopWorkOrder(prompt: string, everyMs: number, sessionKey: string): string {
+  const shortName = loopShortName(prompt);
+  const jobName = `${loopNamePrefix(sessionKey)} ${shortName}`;
   const message = buildLoopPayloadMessage({ prompt, shortName, selfPaced: false });
-  return `Create a recurring loop with the cron tool, then confirm in one short line (name + cadence + '/loop stop' hint). action:"add", job:{name:${JSON.stringify(jobName)},schedule:{kind:"every",everyMs:${everyMs}},sessionTarget:"current",payload:{kind:"agentTurn",message:${JSON.stringify(message)}}}.`;
+  return `Create a recurring loop with the cron tool, then confirm in one short line (name + cadence + '/loop stop' hint). ${LOOP_FINAL_REPLY_ONLY} action:"add", job:{name:${JSON.stringify(jobName)},schedule:{kind:"every",everyMs:${everyMs}},sessionTarget:"current",payload:{kind:"agentTurn",message:${JSON.stringify(message)}}}.`;
 }
 
-function buildSelfPacedLoopWorkOrder(prompt: string): string {
-  const { jobName, shortName } = loopNameForPrompt(prompt);
+function buildSelfPacedLoopWorkOrder(prompt: string, sessionKey: string): string {
+  const shortName = loopShortName(prompt);
+  const jobName = `${loopNamePrefix(sessionKey)} ${shortName}`;
   const message = buildLoopPayloadMessage({ prompt, shortName, selfPaced: true });
-  return `Create a recurring loop with the cron tool, then confirm in one short line (name + cadence + '/loop stop' hint). action:"add", job:{name:${JSON.stringify(jobName)},schedule:{kind:"every",everyMs:${LOOP_DEFAULT_INTERVAL_MS}},pacing:{min:"1m",max:"1h"},sessionTarget:"current",payload:{kind:"agentTurn",message:${JSON.stringify(message)}}}.`;
+  return `Create a recurring loop with the cron tool, then confirm in one short line (name + cadence + '/loop stop' hint). ${LOOP_FINAL_REPLY_ONLY} action:"add", job:{name:${JSON.stringify(jobName)},schedule:{kind:"every",everyMs:${LOOP_DEFAULT_INTERVAL_MS}},pacing:{min:"1m",max:"1h"},sessionTarget:"current",payload:{kind:"agentTurn",message:${JSON.stringify(message)}}}.`;
 }
 
 function buildLoopStatusWorkOrder(sessionKey: string): string {
-  return `Use the cron tool (action:"list") and report the loop jobs bound to this conversation (names starting with "loop:"): name, schedule/pacing, last run, next run. If none, say so. The list is agent-wide, so call action:"get" for each "loop:" candidate and include it only when its full definition has sessionTarget:"current" and sessionKey exactly ${JSON.stringify(sessionKey)}.`;
+  const prefix = loopNamePrefix(sessionKey);
+  return `Use the cron tool (action:"list") and report this conversation's loop jobs — exactly those whose name starts with ${JSON.stringify(prefix)}: name, schedule/pacing, last run, next run. If none, say so. ${LOOP_FINAL_REPLY_ONLY}`;
 }
 
 function buildLoopStopWorkOrder(name: string, sessionKey: string): string {
-  const matchInstruction = name ? ` Match ${JSON.stringify(name)} against the job name.` : "";
-  return `List cron jobs, find jobs named starting "loop:" bound to this conversation.${matchInstruction} Remove them with action:"remove" and confirm the removed names. If none matched, say so and list active loop names. The list is agent-wide: immediately before each removal, call action:"get" and remove only a job whose full definition has sessionTarget:"current" and sessionKey exactly ${JSON.stringify(sessionKey)}.`;
+  const prefix = loopNamePrefix(sessionKey);
+  const matchInstruction = name
+    ? ` Among those, match ${JSON.stringify(name)} against the job name.`
+    : "";
+  return `List cron jobs and find this conversation's loops — exactly those whose name starts with ${JSON.stringify(prefix)}.${matchInstruction} Remove the matching jobs with action:"remove" and confirm the removed names. If none matched, say so and list this conversation's active loop names. Never remove a job whose name does not start with ${JSON.stringify(prefix)}. ${LOOP_FINAL_REPLY_ONLY}`;
 }
 
 /** Command handler for conversation-bound recurring loops. */
@@ -146,10 +166,10 @@ export const handleLoopCommand: CommandHandler = async (params, allowTextCommand
     if (!prompt) {
       return directReply(LOOP_USAGE);
     }
-    applyLoopWorkOrder(params, buildFixedLoopWorkOrder(prompt, everyMs));
+    applyLoopWorkOrder(params, buildFixedLoopWorkOrder(prompt, everyMs, params.sessionKey));
     return { shouldContinue: true };
   }
 
-  applyLoopWorkOrder(params, buildSelfPacedLoopWorkOrder(spec));
+  applyLoopWorkOrder(params, buildSelfPacedLoopWorkOrder(spec, params.sessionKey));
   return { shouldContinue: true };
 };

--- a/src/auto-reply/reply/commands-loop.ts
+++ b/src/auto-reply/reply/commands-loop.ts
@@ -106,7 +106,7 @@ function buildSelfPacedLoopWorkOrder(prompt: string, sessionKey: string): string
 
 function buildLoopStatusWorkOrder(sessionKey: string): string {
   const prefix = loopNamePrefix(sessionKey);
-  return `Use the cron tool (action:"list") and report this conversation's loop jobs — exactly those whose name starts with ${JSON.stringify(prefix)}: name, schedule/pacing, last run, next run. If none, say so. ${LOOP_FINAL_REPLY_ONLY}`;
+  return `Use the cron tool (action:"list", includeDisabled:true) and report this conversation's loop jobs — exactly those whose name starts with ${JSON.stringify(prefix)}: name, schedule/pacing, enabled, last run, next run. If none, say so. ${LOOP_FINAL_REPLY_ONLY}`;
 }
 
 function buildLoopStopWorkOrder(name: string, sessionKey: string): string {
@@ -114,7 +114,7 @@ function buildLoopStopWorkOrder(name: string, sessionKey: string): string {
   const matchInstruction = name
     ? ` Among those, match ${JSON.stringify(name)} against the job name.`
     : "";
-  return `List cron jobs and find this conversation's loops — exactly those whose name starts with ${JSON.stringify(prefix)}.${matchInstruction} Remove the matching jobs with action:"remove" and confirm the removed names. If none matched, say so and list this conversation's active loop names. Never remove a job whose name does not start with ${JSON.stringify(prefix)}. ${LOOP_FINAL_REPLY_ONLY}`;
+  return `List cron jobs (action:"list", includeDisabled:true) and find this conversation's loops — exactly those whose name starts with ${JSON.stringify(prefix)}.${matchInstruction} Remove the matching jobs with action:"remove" and confirm the removed names. If none matched, say so and list this conversation's active loop names. Never remove a job whose name does not start with ${JSON.stringify(prefix)}. ${LOOP_FINAL_REPLY_ONLY}`;
 }
 
 /** Command handler for conversation-bound recurring loops. */

--- a/src/auto-reply/reply/commands-loop.ts
+++ b/src/auto-reply/reply/commands-loop.ts
@@ -58,9 +58,12 @@ function loopShortName(prompt: string): string {
 
 // Conversation tag baked into the job name at create time. Status/stop match by
 // this same tag, so loop discovery never depends on how the cron side resolves
-// session keys (which can differ from the command pipeline's sessionKey).
+// session keys (which can differ from the command pipeline's sessionKey and
+// made stored-binding checks misfire in live testing). 48 bits keeps accidental
+// cross-conversation prefix collisions negligible; all matched jobs are still
+// the owner's own agent jobs.
 function loopConversationTag(sessionKey: string): string {
-  return createHash("sha256").update(sessionKey).digest("hex").slice(0, 6);
+  return createHash("sha256").update(sessionKey).digest("hex").slice(0, 12);
 }
 
 function loopNamePrefix(sessionKey: string): string {

--- a/src/cron/normalize.session-target-default.test.ts
+++ b/src/cron/normalize.session-target-default.test.ts
@@ -1,0 +1,33 @@
+// Create-time sessionTarget defaulting: agentTurn binds to the creating conversation.
+import { describe, expect, it } from "vitest";
+import { normalizeCronJobCreate } from "./normalize.js";
+
+describe("normalizeCronJobCreate sessionTarget defaults", () => {
+  it("defaults agentTurn jobs with session context to current announce jobs", () => {
+    const normalized = normalizeCronJobCreate(
+      {
+        name: "agent turn current default",
+        schedule: { kind: "every", everyMs: 60_000 },
+        payload: { kind: "agentTurn", message: "hello" },
+      },
+      { sessionContext: { sessionKey: "agent:main:discord:channel:ops" } },
+    );
+    expect(normalized).toMatchObject({
+      sessionTarget: "current",
+      sessionKey: "agent:main:discord:channel:ops",
+      delivery: { mode: "announce" },
+    });
+  });
+
+  it("downgrades the agentTurn current default to isolated without session context", () => {
+    const normalized = normalizeCronJobCreate({
+      name: "agent turn isolated fallback",
+      schedule: { kind: "every", everyMs: 60_000 },
+      payload: { kind: "agentTurn", message: "hello" },
+    });
+    expect(normalized).toMatchObject({
+      sessionTarget: "isolated",
+      delivery: { mode: "announce" },
+    });
+  });
+});

--- a/src/cron/normalize.test.ts
+++ b/src/cron/normalize.test.ts
@@ -433,13 +433,32 @@ describe("normalizeCronJobCreate", () => {
     expect(delivery.mode).toBe("announce");
   });
 
-  it("defaults omitted agentTurn targets to isolated announce jobs", () => {
+  it("defaults agentTurn jobs with session context to current announce jobs", () => {
+    const normalized = normalizeCronJobCreate(
+      {
+        name: "agent turn current default",
+        schedule: { kind: "every", everyMs: 60_000 },
+        payload: { kind: "agentTurn", message: "hello" },
+      },
+      { sessionContext: { sessionKey: "agent:main:discord:channel:ops" } },
+    );
+    expect(normalized).toMatchObject({
+      sessionTarget: "current",
+      sessionKey: "agent:main:discord:channel:ops",
+      delivery: { mode: "announce" },
+    });
+  });
+
+  it("downgrades the agentTurn current default to isolated without session context", () => {
     const normalized = normalizeCronJobCreate({
-      name: "agent turn default",
+      name: "agent turn isolated fallback",
       schedule: { kind: "every", everyMs: 60_000 },
       payload: { kind: "agentTurn", message: "hello" },
     });
-    expect(normalized).toMatchObject({ sessionTarget: "isolated", delivery: { mode: "announce" } });
+    expect(normalized).toMatchObject({
+      sessionTarget: "isolated",
+      delivery: { mode: "announce" },
+    });
   });
 
   it("defaults command payloads to isolated announce jobs", () => {

--- a/src/cron/normalize.test.ts
+++ b/src/cron/normalize.test.ts
@@ -433,34 +433,6 @@ describe("normalizeCronJobCreate", () => {
     expect(delivery.mode).toBe("announce");
   });
 
-  it("defaults agentTurn jobs with session context to current announce jobs", () => {
-    const normalized = normalizeCronJobCreate(
-      {
-        name: "agent turn current default",
-        schedule: { kind: "every", everyMs: 60_000 },
-        payload: { kind: "agentTurn", message: "hello" },
-      },
-      { sessionContext: { sessionKey: "agent:main:discord:channel:ops" } },
-    );
-    expect(normalized).toMatchObject({
-      sessionTarget: "current",
-      sessionKey: "agent:main:discord:channel:ops",
-      delivery: { mode: "announce" },
-    });
-  });
-
-  it("downgrades the agentTurn current default to isolated without session context", () => {
-    const normalized = normalizeCronJobCreate({
-      name: "agent turn isolated fallback",
-      schedule: { kind: "every", everyMs: 60_000 },
-      payload: { kind: "agentTurn", message: "hello" },
-    });
-    expect(normalized).toMatchObject({
-      sessionTarget: "isolated",
-      delivery: { mode: "announce" },
-    });
-  });
-
   it("defaults command payloads to isolated announce jobs", () => {
     const normalized = normalizeCronJobCreate({
       name: "command default",

--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -501,11 +501,14 @@ export function normalizeCronJobInput(
     }
     if (!next.sessionTarget && isRecord(next.payload)) {
       const kind = typeof next.payload.kind === "string" ? next.payload.kind : "";
-      // Keep create-time defaults explicit: system events join main, while agent
-      // turns isolate by default to avoid unbounded token accumulation.
+      // Agent turns bind to the creating conversation by default: the run carries
+      // that chat's context and announces its result there. Callers without session
+      // context are downgraded to isolated by resolveCronCurrentSessionTarget.
       if (kind === "systemEvent" || kind === "heartbeat") {
         next.sessionTarget = "main";
-      } else if (kind === "agentTurn" || kind === "command" || kind === "script") {
+      } else if (kind === "agentTurn") {
+        next.sessionTarget = "current";
+      } else if (kind === "command" || kind === "script") {
         next.sessionTarget = "isolated";
       }
     }
@@ -555,8 +558,8 @@ export function normalizeCronJobInput(
     const payload = isRecord(next.payload) ? next.payload : null;
     const payloadKind = payload && typeof payload.kind === "string" ? payload.kind : "";
     const sessionTarget = typeof next.sessionTarget === "string" ? next.sessionTarget : "";
-    // Omitted output targets were canonicalized to "isolated" above. Resolved
-    // "current" and custom session ids share those announce semantics.
+    // Agent turns resolve to current with context and isolated without it.
+    // Current and custom session ids share isolated announce semantics.
     const hasDelivery = "delivery" in next && next.delivery !== undefined;
     if (!hasDelivery && shouldDefaultCronDeliveryToAnnounce({ payloadKind, sessionTarget })) {
       next.delivery = { mode: "announce" };

--- a/src/gateway/server.cron.test.ts
+++ b/src/gateway/server.cron.test.ts
@@ -453,6 +453,42 @@ describe("gateway server cron", () => {
     closeTrackedBrowserTabsForSessionsMock.mockClear();
   });
 
+  test("defaults cron.add agentTurn targets from available session context", async () => {
+    const { prevSkipCron } = await setupCronTestRun({
+      tempPrefix: "openclaw-gw-cron-agent-turn-default-",
+      cronEnabled: false,
+    });
+    const cronState = await createDirectCronState();
+
+    try {
+      const withContext = await directCronReq(cronState, "cron.add", {
+        name: "conversation loop",
+        schedule: { kind: "every", everyMs: 60_000 },
+        sessionKey: "agent:main:webchat:loop",
+        payload: { kind: "agentTurn", message: "check status" },
+      });
+      expect(withContext.ok).toBe(true);
+      expect(withContext.payload).toMatchObject({
+        sessionTarget: "current",
+        sessionKey: "agent:main:webchat:loop",
+        delivery: { mode: "announce" },
+      });
+
+      const withoutContext = await directCronReq(cronState, "cron.add", {
+        name: "detached loop",
+        schedule: { kind: "every", everyMs: 60_000 },
+        payload: { kind: "agentTurn", message: "check status" },
+      });
+      expect(withoutContext.ok).toBe(true);
+      expect(withoutContext.payload).toMatchObject({
+        sessionTarget: "isolated",
+        delivery: { mode: "announce" },
+      });
+    } finally {
+      await cleanupCronTestRun({ cronState, prevSkipCron });
+    }
+  });
+
   test("handles cron CRUD, normalization, and patch semantics", { timeout: 45_000 }, async () => {
     const { prevSkipCron } = await setupCronTestRun({
       tempPrefix: "openclaw-gw-cron-",

--- a/src/plugins/command-registration.ts
+++ b/src/plugins/command-registration.ts
@@ -52,6 +52,7 @@ function getReservedCommands(): Set<string> {
     "activation",
     "skill",
     "learn",
+    "loop",
     "subagents",
     "kill",
     "steer",

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
@@ -434,7 +434,7 @@
       },
       {
         "deferLoading": true,
-        "description": "Gateway schedules/wakes: reminders, later checks/follow-ups, recurring work. Never exec sleep/process-poll as timer. Main job => heartbeat system event; isolated => background task in `openclaw tasks`.\n\nACTIONS:\n- status scheduler; list compact summaries (includeDisabled, session agentId auto-filter; get for full); get jobId\n- add job; update jobId+patch; remove jobId\n- run jobId (due only; runMode=\"force\" now); runs jobId history; next_check in (current paced job only)\n- wake text (+ optional mode). Default caller lane; top-level sessionKey/agentId selects another caller-owned lane.\n\nADD JOB:\n{ \"name\":\"...\", \"schedule\":{...}, \"pacing\":{ \"min\":\"15m\", \"max\":\"4h\" }, \"trigger\":{ \"script\":\"...\", \"once\":false }, \"payload\":{...}, \"delivery\":{...}, \"sessionTarget\":\"main|isolated|current|session:<id>\", \"enabled\":true }\nRequired: schedule,payload. enabled default true. trigger only every/cron.\n\nTARGET/PAYLOAD:\n- main => systemEvent {kind:\"systemEvent\",text:\"...\"} or script; systemEvent defaults main.\n- isolated/current/session:<id> => agentTurn {kind:\"agentTurn\",message:\"...\",model?,thinking?,timeoutSeconds?}; agentTurn defaults isolated. timeoutSeconds=0 means none.\n- script {kind:\"script\",script:\"...\",timeoutSeconds?,toolBudget?} supports main or isolated only and requires cron.triggers.enabled.\n- current binds caller session at creation. session:<id> is persistent. Prefer isolated unless user explicitly wants current binding.\n\nSCHEDULE:\n- at: {kind:\"at\",at:\"ISO-8601\"}; timezone-less = UTC.\n- every: {kind:\"every\",everyMs:<ms>,anchorMs?}.\n- cron: {kind:\"cron\",expr:\"...\",tz?:\"IANA\"}. Expr is requested local wall time; never pre-convert to UTC. Missing tz = Gateway host local, not UTC. Shanghai 18:00: {kind:\"cron\",expr:\"0 18 * * *\",tz:\"Asia/Shanghai\"}.\n\nTRIGGER SCRIPT:\n- Requires cron.triggers.enabled; if off, explain and never model-poll fallback.\n- Headless owner allowlist; quiet check has no model. Prior trigger.state is frozen JSON. Return/json({fire:boolean,message?:string,state?:JSONValue}); create new state, never mutate prior.\n- fire:false saves state only; no payload/history. fire:true runs payload and appends message; fired state saves only after payload success.\n- Fire on every actionable state, including failures/timeouts; success-only watchers go silent when broken, which looks healthy. Dedupe by comparing trigger.state and returning new state, never memory.\n- Keep scripts read-only; actions belong in payload. message must be self-contained: it is the fired run's entire context.\n- Silent watcher: top-level delivery.mode=\"none\". Omitted delivery on isolated agentTurn announces and missing route may fail.\n- once:true disables after first successful fire. Per check: 30s, 5 tool calls, 16KB state.\n- Hidden Code Mode tools: await tools.call(\"exec\", {command:\"...\"}); unknown id => search/describe.\n\nDELIVERY top-level: {mode:\"none|announce|webhook\",channel?,to?,threadId?,bestEffort?}\n- Isolated agentTurn omitted delivery => announce. announce only isolated/current/session; channel/to optional; threadId chat topic. Specific chat: set channel/to; no messaging tool inside run.\n- webhook posts finished-run event to URL in to.\n\nRestricted isolated runs may only self status/list, current get/runs/remove, and next_check for their own paced job. wake mode: next-heartbeat default | now. jobId canonical; id compat. contextMessages 0-10 adds prior messages.",
+        "description": "Gateway scheduler: reminders, delayed self-wakeups, loops, recurring work, event watchers. Never exec sleep/poll as timer.\n\nACTIONS: status | list [includeDisabled] | get jobId | add job | update jobId patch | remove jobId | run jobId (runMode \"force\"=now) | runs jobId = history | next_check in:\"30m\" (own paced run only) | wake text mode?:\"now\"|\"next-heartbeat\"(default) nudges a caller-owned lane (sessionKey/agentId to pick another).\n\nADD: {name?,schedule,payload,sessionTarget?,pacing?,trigger?,delivery?,enabled?}. Required: schedule+payload.\n\nSCHEDULE:\n- {kind:\"at\",at:\"ISO-8601\"} one-shot; no tz=UTC; auto-deletes after run.\n- {kind:\"every\",everyMs}.\n- {kind:\"cron\",expr,tz?:\"IANA\"}: expr is wall time in tz; never pre-convert to UTC; no tz=gateway host local. 18:00 Shanghai => {expr:\"0 18 * * *\",tz:\"Asia/Shanghai\"}.\n- {kind:\"stream\",command:[argv],mode?:\"line\"|\"match\",match?}: fires on supervised process output; needs cron.triggers.enabled.\n\nTARGET+PAYLOAD:\n- \"current\" (agentTurn default) = this conversation: run carries this chat's context, result lands here. Self-wakeup/\"continue later\"/loop = at|every + agentTurn + current.\n- \"isolated\" = fresh detached session (shows in `openclaw tasks`); standalone background work.\n- \"main\" = heartbeat lane; payload {kind:\"systemEvent\",text} (systemEvent default target).\n- \"session:<key>\" = named session.\n- agentTurn {kind:\"agentTurn\",message,model?,thinking?,timeoutSeconds?}; timeoutSeconds 0=none.\n- script {kind:\"script\",script,timeoutSeconds?,toolBudget?}: main|isolated only; needs cron.triggers.enabled.\n\nPACED LOOP: recurring job + pacing{min?,max?} durations (\"15m\",\"4h\"; at least one). Inside its run, job calls next_check in:\"<dur>\" to set the next delay (clamped to bounds, measured from run end; failed runs keep normal backoff). Adaptive polling: tighten when active, back off when quiet.\n\nTRIGGER (condition watcher on every/cron): {script,once?}; needs cron.triggers.enabled — if off, say so; never model-poll instead. Quiet headless check, no model; 30s/5 tool calls/16KB state. Read frozen trigger.state, return json({fire,message?,state?}) with NEW state; dedupe via state, never memory. fire:false saves state only. fire:true runs payload; message is that run's entire context — self-contained. Fire on failures/timeouts too; success-only watchers look healthy when broken. Script stays read-only; actions belong in payload. once:true disables after first fire. Code Mode: await tools.call(\"exec\",{command:\"...\"}).\n\nDELIVERY {mode:\"none\"|\"announce\"|\"webhook\",channel?,to?,threadId?,bestEffort?}: where detached run output goes. Omitted=announce (current=>this chat; isolated=>last route; set channel/to for a specific chat — no messaging tool inside the run). Silent watcher=>mode:\"none\". webhook posts finished-run event to URL in `to`.\n\nJob wakeMode (main jobs): \"now\"(default)|\"next-heartbeat\". Restricted cron-run sessions: self status/list/get/runs/remove + own next_check only. failureAlert {...}|false disables. jobId canonical (id=compat). contextMessages 0-10 embeds recent chat lines into reminder text.",
         "inputSchema": {
           "additionalProperties": true,
           "properties": {
@@ -652,6 +652,7 @@
                   "additionalProperties": true,
                   "properties": {
                     "allowUnsafeExternalContent": {
+                      "description": "Allow untrusted external content in prompt",
                       "type": "boolean"
                     },
                     "fallbacks": {
@@ -667,6 +668,7 @@
                       "type": "string"
                     },
                     "lightContext": {
+                      "description": "Lightweight bootstrap context (skip full workspace context)",
                       "type": "boolean"
                     },
                     "message": {
@@ -748,7 +750,7 @@
                     },
                     "kind": {
                       "description": "Schedule kind",
-                      "enum": ["at", "every", "cron"],
+                      "enum": ["at", "every", "cron", "stream"],
                       "type": "string"
                     },
                     "match": {
@@ -787,7 +789,7 @@
                   "description": "Explicit session key, or null to clear it"
                 },
                 "sessionTarget": {
-                  "description": "main | isolated | current | session:<id>",
+                  "description": "main | isolated | current (agentTurn default) | session:<id>",
                   "type": "string"
                 },
                 "trigger": {
@@ -817,6 +819,7 @@
               "type": "string"
             },
             "mode": {
+              "description": "Wake mode for action=\"wake\" (default next-heartbeat)",
               "enum": ["now", "next-heartbeat"],
               "type": "string"
             },
@@ -1044,6 +1047,7 @@
                   "additionalProperties": true,
                   "properties": {
                     "allowUnsafeExternalContent": {
+                      "description": "Allow untrusted external content in prompt",
                       "type": "boolean"
                     },
                     "fallbacks": {
@@ -1066,6 +1070,7 @@
                       "type": "string"
                     },
                     "lightContext": {
+                      "description": "Lightweight bootstrap context (skip full workspace context)",
                       "type": "boolean"
                     },
                     "message": {
@@ -1161,7 +1166,7 @@
                     },
                     "kind": {
                       "description": "Schedule kind",
-                      "enum": ["at", "every", "cron"],
+                      "enum": ["at", "every", "cron", "stream"],
                       "type": "string"
                     },
                     "match": {
@@ -1200,7 +1205,7 @@
                   "description": "Explicit session key, or null to clear it"
                 },
                 "sessionTarget": {
-                  "description": "Session target",
+                  "description": "main | isolated | current (agentTurn default) | session:<id>",
                   "type": "string"
                 },
                 "trigger": {
@@ -1242,6 +1247,7 @@
               "type": "string"
             },
             "text": {
+              "description": "systemEvent text for action=\"wake\"",
               "type": "string"
             },
             "timeoutMs": {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
@@ -430,7 +430,7 @@
       },
       {
         "deferLoading": true,
-        "description": "Gateway schedules/wakes: reminders, later checks/follow-ups, recurring work. Never exec sleep/process-poll as timer. Main job => heartbeat system event; isolated => background task in `openclaw tasks`.\n\nACTIONS:\n- status scheduler; list compact summaries (includeDisabled, session agentId auto-filter; get for full); get jobId\n- add job; update jobId+patch; remove jobId\n- run jobId (due only; runMode=\"force\" now); runs jobId history; next_check in (current paced job only)\n- wake text (+ optional mode). Default caller lane; top-level sessionKey/agentId selects another caller-owned lane.\n\nADD JOB:\n{ \"name\":\"...\", \"schedule\":{...}, \"pacing\":{ \"min\":\"15m\", \"max\":\"4h\" }, \"trigger\":{ \"script\":\"...\", \"once\":false }, \"payload\":{...}, \"delivery\":{...}, \"sessionTarget\":\"main|isolated|current|session:<id>\", \"enabled\":true }\nRequired: schedule,payload. enabled default true. trigger only every/cron.\n\nTARGET/PAYLOAD:\n- main => systemEvent {kind:\"systemEvent\",text:\"...\"} or script; systemEvent defaults main.\n- isolated/current/session:<id> => agentTurn {kind:\"agentTurn\",message:\"...\",model?,thinking?,timeoutSeconds?}; agentTurn defaults isolated. timeoutSeconds=0 means none.\n- script {kind:\"script\",script:\"...\",timeoutSeconds?,toolBudget?} supports main or isolated only and requires cron.triggers.enabled.\n- current binds caller session at creation. session:<id> is persistent. Prefer isolated unless user explicitly wants current binding.\n\nSCHEDULE:\n- at: {kind:\"at\",at:\"ISO-8601\"}; timezone-less = UTC.\n- every: {kind:\"every\",everyMs:<ms>,anchorMs?}.\n- cron: {kind:\"cron\",expr:\"...\",tz?:\"IANA\"}. Expr is requested local wall time; never pre-convert to UTC. Missing tz = Gateway host local, not UTC. Shanghai 18:00: {kind:\"cron\",expr:\"0 18 * * *\",tz:\"Asia/Shanghai\"}.\n\nTRIGGER SCRIPT:\n- Requires cron.triggers.enabled; if off, explain and never model-poll fallback.\n- Headless owner allowlist; quiet check has no model. Prior trigger.state is frozen JSON. Return/json({fire:boolean,message?:string,state?:JSONValue}); create new state, never mutate prior.\n- fire:false saves state only; no payload/history. fire:true runs payload and appends message; fired state saves only after payload success.\n- Fire on every actionable state, including failures/timeouts; success-only watchers go silent when broken, which looks healthy. Dedupe by comparing trigger.state and returning new state, never memory.\n- Keep scripts read-only; actions belong in payload. message must be self-contained: it is the fired run's entire context.\n- Silent watcher: top-level delivery.mode=\"none\". Omitted delivery on isolated agentTurn announces and missing route may fail.\n- once:true disables after first successful fire. Per check: 30s, 5 tool calls, 16KB state.\n- Hidden Code Mode tools: await tools.call(\"exec\", {command:\"...\"}); unknown id => search/describe.\n\nDELIVERY top-level: {mode:\"none|announce|webhook\",channel?,to?,threadId?,bestEffort?}\n- Isolated agentTurn omitted delivery => announce. announce only isolated/current/session; channel/to optional; threadId chat topic. Specific chat: set channel/to; no messaging tool inside run.\n- webhook posts finished-run event to URL in to.\n\nRestricted isolated runs may only self status/list, current get/runs/remove, and next_check for their own paced job. wake mode: next-heartbeat default | now. jobId canonical; id compat. contextMessages 0-10 adds prior messages.",
+        "description": "Gateway scheduler: reminders, delayed self-wakeups, loops, recurring work, event watchers. Never exec sleep/poll as timer.\n\nACTIONS: status | list [includeDisabled] | get jobId | add job | update jobId patch | remove jobId | run jobId (runMode \"force\"=now) | runs jobId = history | next_check in:\"30m\" (own paced run only) | wake text mode?:\"now\"|\"next-heartbeat\"(default) nudges a caller-owned lane (sessionKey/agentId to pick another).\n\nADD: {name?,schedule,payload,sessionTarget?,pacing?,trigger?,delivery?,enabled?}. Required: schedule+payload.\n\nSCHEDULE:\n- {kind:\"at\",at:\"ISO-8601\"} one-shot; no tz=UTC; auto-deletes after run.\n- {kind:\"every\",everyMs}.\n- {kind:\"cron\",expr,tz?:\"IANA\"}: expr is wall time in tz; never pre-convert to UTC; no tz=gateway host local. 18:00 Shanghai => {expr:\"0 18 * * *\",tz:\"Asia/Shanghai\"}.\n- {kind:\"stream\",command:[argv],mode?:\"line\"|\"match\",match?}: fires on supervised process output; needs cron.triggers.enabled.\n\nTARGET+PAYLOAD:\n- \"current\" (agentTurn default) = this conversation: run carries this chat's context, result lands here. Self-wakeup/\"continue later\"/loop = at|every + agentTurn + current.\n- \"isolated\" = fresh detached session (shows in `openclaw tasks`); standalone background work.\n- \"main\" = heartbeat lane; payload {kind:\"systemEvent\",text} (systemEvent default target).\n- \"session:<key>\" = named session.\n- agentTurn {kind:\"agentTurn\",message,model?,thinking?,timeoutSeconds?}; timeoutSeconds 0=none.\n- script {kind:\"script\",script,timeoutSeconds?,toolBudget?}: main|isolated only; needs cron.triggers.enabled.\n\nPACED LOOP: recurring job + pacing{min?,max?} durations (\"15m\",\"4h\"; at least one). Inside its run, job calls next_check in:\"<dur>\" to set the next delay (clamped to bounds, measured from run end; failed runs keep normal backoff). Adaptive polling: tighten when active, back off when quiet.\n\nTRIGGER (condition watcher on every/cron): {script,once?}; needs cron.triggers.enabled — if off, say so; never model-poll instead. Quiet headless check, no model; 30s/5 tool calls/16KB state. Read frozen trigger.state, return json({fire,message?,state?}) with NEW state; dedupe via state, never memory. fire:false saves state only. fire:true runs payload; message is that run's entire context — self-contained. Fire on failures/timeouts too; success-only watchers look healthy when broken. Script stays read-only; actions belong in payload. once:true disables after first fire. Code Mode: await tools.call(\"exec\",{command:\"...\"}).\n\nDELIVERY {mode:\"none\"|\"announce\"|\"webhook\",channel?,to?,threadId?,bestEffort?}: where detached run output goes. Omitted=announce (current=>this chat; isolated=>last route; set channel/to for a specific chat — no messaging tool inside the run). Silent watcher=>mode:\"none\". webhook posts finished-run event to URL in `to`.\n\nJob wakeMode (main jobs): \"now\"(default)|\"next-heartbeat\". Restricted cron-run sessions: self status/list/get/runs/remove + own next_check only. failureAlert {...}|false disables. jobId canonical (id=compat). contextMessages 0-10 embeds recent chat lines into reminder text.",
         "inputSchema": {
           "additionalProperties": true,
           "properties": {
@@ -648,6 +648,7 @@
                   "additionalProperties": true,
                   "properties": {
                     "allowUnsafeExternalContent": {
+                      "description": "Allow untrusted external content in prompt",
                       "type": "boolean"
                     },
                     "fallbacks": {
@@ -663,6 +664,7 @@
                       "type": "string"
                     },
                     "lightContext": {
+                      "description": "Lightweight bootstrap context (skip full workspace context)",
                       "type": "boolean"
                     },
                     "message": {
@@ -744,7 +746,7 @@
                     },
                     "kind": {
                       "description": "Schedule kind",
-                      "enum": ["at", "every", "cron"],
+                      "enum": ["at", "every", "cron", "stream"],
                       "type": "string"
                     },
                     "match": {
@@ -783,7 +785,7 @@
                   "description": "Explicit session key, or null to clear it"
                 },
                 "sessionTarget": {
-                  "description": "main | isolated | current | session:<id>",
+                  "description": "main | isolated | current (agentTurn default) | session:<id>",
                   "type": "string"
                 },
                 "trigger": {
@@ -813,6 +815,7 @@
               "type": "string"
             },
             "mode": {
+              "description": "Wake mode for action=\"wake\" (default next-heartbeat)",
               "enum": ["now", "next-heartbeat"],
               "type": "string"
             },
@@ -1040,6 +1043,7 @@
                   "additionalProperties": true,
                   "properties": {
                     "allowUnsafeExternalContent": {
+                      "description": "Allow untrusted external content in prompt",
                       "type": "boolean"
                     },
                     "fallbacks": {
@@ -1062,6 +1066,7 @@
                       "type": "string"
                     },
                     "lightContext": {
+                      "description": "Lightweight bootstrap context (skip full workspace context)",
                       "type": "boolean"
                     },
                     "message": {
@@ -1157,7 +1162,7 @@
                     },
                     "kind": {
                       "description": "Schedule kind",
-                      "enum": ["at", "every", "cron"],
+                      "enum": ["at", "every", "cron", "stream"],
                       "type": "string"
                     },
                     "match": {
@@ -1196,7 +1201,7 @@
                   "description": "Explicit session key, or null to clear it"
                 },
                 "sessionTarget": {
-                  "description": "Session target",
+                  "description": "main | isolated | current (agentTurn default) | session:<id>",
                   "type": "string"
                 },
                 "trigger": {
@@ -1238,6 +1243,7 @@
               "type": "string"
             },
             "text": {
+              "description": "systemEvent text for action=\"wake\"",
               "type": "string"
             },
             "timeoutMs": {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
@@ -430,7 +430,7 @@
       },
       {
         "deferLoading": true,
-        "description": "Gateway schedules/wakes: reminders, later checks/follow-ups, recurring work. Never exec sleep/process-poll as timer. Main job => heartbeat system event; isolated => background task in `openclaw tasks`.\n\nACTIONS:\n- status scheduler; list compact summaries (includeDisabled, session agentId auto-filter; get for full); get jobId\n- add job; update jobId+patch; remove jobId\n- run jobId (due only; runMode=\"force\" now); runs jobId history; next_check in (current paced job only)\n- wake text (+ optional mode). Default caller lane; top-level sessionKey/agentId selects another caller-owned lane.\n\nADD JOB:\n{ \"name\":\"...\", \"schedule\":{...}, \"pacing\":{ \"min\":\"15m\", \"max\":\"4h\" }, \"trigger\":{ \"script\":\"...\", \"once\":false }, \"payload\":{...}, \"delivery\":{...}, \"sessionTarget\":\"main|isolated|current|session:<id>\", \"enabled\":true }\nRequired: schedule,payload. enabled default true. trigger only every/cron.\n\nTARGET/PAYLOAD:\n- main => systemEvent {kind:\"systemEvent\",text:\"...\"} or script; systemEvent defaults main.\n- isolated/current/session:<id> => agentTurn {kind:\"agentTurn\",message:\"...\",model?,thinking?,timeoutSeconds?}; agentTurn defaults isolated. timeoutSeconds=0 means none.\n- script {kind:\"script\",script:\"...\",timeoutSeconds?,toolBudget?} supports main or isolated only and requires cron.triggers.enabled.\n- current binds caller session at creation. session:<id> is persistent. Prefer isolated unless user explicitly wants current binding.\n\nSCHEDULE:\n- at: {kind:\"at\",at:\"ISO-8601\"}; timezone-less = UTC.\n- every: {kind:\"every\",everyMs:<ms>,anchorMs?}.\n- cron: {kind:\"cron\",expr:\"...\",tz?:\"IANA\"}. Expr is requested local wall time; never pre-convert to UTC. Missing tz = Gateway host local, not UTC. Shanghai 18:00: {kind:\"cron\",expr:\"0 18 * * *\",tz:\"Asia/Shanghai\"}.\n\nTRIGGER SCRIPT:\n- Requires cron.triggers.enabled; if off, explain and never model-poll fallback.\n- Headless owner allowlist; quiet check has no model. Prior trigger.state is frozen JSON. Return/json({fire:boolean,message?:string,state?:JSONValue}); create new state, never mutate prior.\n- fire:false saves state only; no payload/history. fire:true runs payload and appends message; fired state saves only after payload success.\n- Fire on every actionable state, including failures/timeouts; success-only watchers go silent when broken, which looks healthy. Dedupe by comparing trigger.state and returning new state, never memory.\n- Keep scripts read-only; actions belong in payload. message must be self-contained: it is the fired run's entire context.\n- Silent watcher: top-level delivery.mode=\"none\". Omitted delivery on isolated agentTurn announces and missing route may fail.\n- once:true disables after first successful fire. Per check: 30s, 5 tool calls, 16KB state.\n- Hidden Code Mode tools: await tools.call(\"exec\", {command:\"...\"}); unknown id => search/describe.\n\nDELIVERY top-level: {mode:\"none|announce|webhook\",channel?,to?,threadId?,bestEffort?}\n- Isolated agentTurn omitted delivery => announce. announce only isolated/current/session; channel/to optional; threadId chat topic. Specific chat: set channel/to; no messaging tool inside run.\n- webhook posts finished-run event to URL in to.\n\nRestricted isolated runs may only self status/list, current get/runs/remove, and next_check for their own paced job. wake mode: next-heartbeat default | now. jobId canonical; id compat. contextMessages 0-10 adds prior messages.",
+        "description": "Gateway scheduler: reminders, delayed self-wakeups, loops, recurring work, event watchers. Never exec sleep/poll as timer.\n\nACTIONS: status | list [includeDisabled] | get jobId | add job | update jobId patch | remove jobId | run jobId (runMode \"force\"=now) | runs jobId = history | next_check in:\"30m\" (own paced run only) | wake text mode?:\"now\"|\"next-heartbeat\"(default) nudges a caller-owned lane (sessionKey/agentId to pick another).\n\nADD: {name?,schedule,payload,sessionTarget?,pacing?,trigger?,delivery?,enabled?}. Required: schedule+payload.\n\nSCHEDULE:\n- {kind:\"at\",at:\"ISO-8601\"} one-shot; no tz=UTC; auto-deletes after run.\n- {kind:\"every\",everyMs}.\n- {kind:\"cron\",expr,tz?:\"IANA\"}: expr is wall time in tz; never pre-convert to UTC; no tz=gateway host local. 18:00 Shanghai => {expr:\"0 18 * * *\",tz:\"Asia/Shanghai\"}.\n- {kind:\"stream\",command:[argv],mode?:\"line\"|\"match\",match?}: fires on supervised process output; needs cron.triggers.enabled.\n\nTARGET+PAYLOAD:\n- \"current\" (agentTurn default) = this conversation: run carries this chat's context, result lands here. Self-wakeup/\"continue later\"/loop = at|every + agentTurn + current.\n- \"isolated\" = fresh detached session (shows in `openclaw tasks`); standalone background work.\n- \"main\" = heartbeat lane; payload {kind:\"systemEvent\",text} (systemEvent default target).\n- \"session:<key>\" = named session.\n- agentTurn {kind:\"agentTurn\",message,model?,thinking?,timeoutSeconds?}; timeoutSeconds 0=none.\n- script {kind:\"script\",script,timeoutSeconds?,toolBudget?}: main|isolated only; needs cron.triggers.enabled.\n\nPACED LOOP: recurring job + pacing{min?,max?} durations (\"15m\",\"4h\"; at least one). Inside its run, job calls next_check in:\"<dur>\" to set the next delay (clamped to bounds, measured from run end; failed runs keep normal backoff). Adaptive polling: tighten when active, back off when quiet.\n\nTRIGGER (condition watcher on every/cron): {script,once?}; needs cron.triggers.enabled — if off, say so; never model-poll instead. Quiet headless check, no model; 30s/5 tool calls/16KB state. Read frozen trigger.state, return json({fire,message?,state?}) with NEW state; dedupe via state, never memory. fire:false saves state only. fire:true runs payload; message is that run's entire context — self-contained. Fire on failures/timeouts too; success-only watchers look healthy when broken. Script stays read-only; actions belong in payload. once:true disables after first fire. Code Mode: await tools.call(\"exec\",{command:\"...\"}).\n\nDELIVERY {mode:\"none\"|\"announce\"|\"webhook\",channel?,to?,threadId?,bestEffort?}: where detached run output goes. Omitted=announce (current=>this chat; isolated=>last route; set channel/to for a specific chat — no messaging tool inside the run). Silent watcher=>mode:\"none\". webhook posts finished-run event to URL in `to`.\n\nJob wakeMode (main jobs): \"now\"(default)|\"next-heartbeat\". Restricted cron-run sessions: self status/list/get/runs/remove + own next_check only. failureAlert {...}|false disables. jobId canonical (id=compat). contextMessages 0-10 embeds recent chat lines into reminder text.",
         "inputSchema": {
           "additionalProperties": true,
           "properties": {
@@ -648,6 +648,7 @@
                   "additionalProperties": true,
                   "properties": {
                     "allowUnsafeExternalContent": {
+                      "description": "Allow untrusted external content in prompt",
                       "type": "boolean"
                     },
                     "fallbacks": {
@@ -663,6 +664,7 @@
                       "type": "string"
                     },
                     "lightContext": {
+                      "description": "Lightweight bootstrap context (skip full workspace context)",
                       "type": "boolean"
                     },
                     "message": {
@@ -744,7 +746,7 @@
                     },
                     "kind": {
                       "description": "Schedule kind",
-                      "enum": ["at", "every", "cron"],
+                      "enum": ["at", "every", "cron", "stream"],
                       "type": "string"
                     },
                     "match": {
@@ -783,7 +785,7 @@
                   "description": "Explicit session key, or null to clear it"
                 },
                 "sessionTarget": {
-                  "description": "main | isolated | current | session:<id>",
+                  "description": "main | isolated | current (agentTurn default) | session:<id>",
                   "type": "string"
                 },
                 "trigger": {
@@ -813,6 +815,7 @@
               "type": "string"
             },
             "mode": {
+              "description": "Wake mode for action=\"wake\" (default next-heartbeat)",
               "enum": ["now", "next-heartbeat"],
               "type": "string"
             },
@@ -1040,6 +1043,7 @@
                   "additionalProperties": true,
                   "properties": {
                     "allowUnsafeExternalContent": {
+                      "description": "Allow untrusted external content in prompt",
                       "type": "boolean"
                     },
                     "fallbacks": {
@@ -1062,6 +1066,7 @@
                       "type": "string"
                     },
                     "lightContext": {
+                      "description": "Lightweight bootstrap context (skip full workspace context)",
                       "type": "boolean"
                     },
                     "message": {
@@ -1157,7 +1162,7 @@
                     },
                     "kind": {
                       "description": "Schedule kind",
-                      "enum": ["at", "every", "cron"],
+                      "enum": ["at", "every", "cron", "stream"],
                       "type": "string"
                     },
                     "match": {
@@ -1196,7 +1201,7 @@
                   "description": "Explicit session key, or null to clear it"
                 },
                 "sessionTarget": {
-                  "description": "Session target",
+                  "description": "main | isolated | current (agentTurn default) | session:<id>",
                   "type": "string"
                 },
                 "trigger": {
@@ -1238,6 +1243,7 @@
               "type": "string"
             },
             "text": {
+              "description": "systemEvent text for action=\"wake\"",
               "type": "string"
             },
             "timeoutMs": {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
@@ -221,8 +221,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 59298,
-    "roughTokens": 14825
+    "chars": 59624,
+    "roughTokens": 14906
   },
   "openClawDeveloperInstructions": {
     "chars": 3715,
@@ -233,8 +233,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 7041
   },
   "totalWithDynamicToolsJson": {
-    "chars": 87462,
-    "roughTokens": 21866
+    "chars": 87788,
+    "roughTokens": 21947
   },
   "userInputText": {
     "chars": 1364,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -221,8 +221,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 58990,
-    "roughTokens": 14748
+    "chars": 59316,
+    "roughTokens": 14829
   },
   "openClawDeveloperInstructions": {
     "chars": 2606,
@@ -233,8 +233,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6671
   },
   "totalWithDynamicToolsJson": {
-    "chars": 85674,
-    "roughTokens": 21419
+    "chars": 86000,
+    "roughTokens": 21500
   },
   "userInputText": {
     "chars": 993,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
@@ -222,8 +222,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 60552,
-    "roughTokens": 15138
+    "chars": 60878,
+    "roughTokens": 15220
   },
   "openClawDeveloperInstructions": {
     "chars": 2625,
@@ -234,8 +234,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6783
   },
   "totalWithDynamicToolsJson": {
-    "chars": 87684,
-    "roughTokens": 21921
+    "chars": 88010,
+    "roughTokens": 22003
   },
   "userInputText": {
     "chars": 1348,


### PR DESCRIPTION
## What Problem This Solves

The cron tool was hard to use for the most common agent scheduling patterns:

- `agentTurn` jobs defaulted to `sessionTarget: "isolated"`, so "remind me in 20 minutes" / "continue this later" jobs ran detached from the conversation that created them and the tool description actively steered models away from `current` ("Prefer isolated unless user explicitly wants current binding"). The self-wakeup pattern users expect from a scheduler was effectively undocumented and non-default.
- The model-facing schedule-kind enum omitted `stream` even though the schema already advertises the stream-only fields (`command`, `cwd`, `mode`, `match`, `batchMs`, `maxBatchBytes`) and the whole pipeline supports it; strict providers reject a kind the enum forbids.
- Several model-facing fields (`lightContext`, `allowUnsafeExternalContent`, wake `text`/`mode`) had no descriptions, and pacing/`next_check` — the adaptive-polling feature — was essentially invisible in the tool description.
- There was no chat-level shorthand for recurring conversation-bound work.

## Why This Change Was Made

- `normalizeCronJobCreate` now defaults `agentTurn` payloads to `sessionTarget: "current"`; `resolveCronCurrentSessionTarget` already downgrades to `isolated` when no session context exists, so CLI/API/claws callers without a session key keep the old behavior. `command`/`script` payloads still default to `isolated`, `systemEvent`/`heartbeat` to `main`.
- The cron tool description was rewritten in compact telegraph style: it now documents the self-wakeup pattern (`at` + `agentTurn` + `current`), the paced-loop pattern (`pacing` + `next_check`), `stream` schedules, and delivery semantics, while keeping all trigger-script operational rules. `stream` was added to the schedule-kind enum (`on-exit` stays deliberately blocked for agents by `assertNoCronShellExecution`).
- New owner-only `/loop` chat command (mirrors the `/learn` rewrite pattern): `/loop 5m <prompt>` creates a fixed-cadence conversation-bound cron job; `/loop <prompt>` creates a self-paced loop (`every` 15m + `pacing {1m..1h}` + `next_check` guidance); `/loop status` / `/loop stop [name]` manage them. The handler parses the interval deterministically (30s floor) and stamps each job name with a 48-bit conversation tag (`loop[<hash>]`) so status/stop scope by name prefix instead of session-key equality — live testing showed the command pipeline's session key and the cron-side binding key can legitimately differ.

## User Impact

- Agent-created "remind me / check later / continue this" jobs now land back in the conversation that created them by default (result announces into the same chat) instead of a detached session.
- Compatibility note (config/default surface, intentional): gateway `cron.add` calls that pass a `sessionKey` alongside an `agentTurn` payload without an explicit `sessionTarget` now bind to that session (`current`) instead of `isolated`. Callers without session context are unchanged. One default changed, no config keys added or removed.
- New `/loop` command on all chat surfaces (owner-only; native registration on Discord/Telegram).
- Models get an accurate schedule enum (`stream`) and documented pacing/self-wakeup patterns; prompt snapshots regenerated for the new description.

## Evidence

- Focused suites green: `src/cron/normalize.test.ts` (62), `src/agents/tools/cron-tool.test.ts` (166), `cron-tool.flat-params.test.ts` (20), `cron-tool.schema.test.ts` (23), `src/auto-reply/reply/commands-loop.test.ts` (10), `commands-registry.test.ts` (39), `src/docs/slash-commands-doc.test.ts`, gateway cron suites (80), prompt snapshot check.
- Live E2E on an isolated dev gateway (`OPENCLAW_STATE_DIR` sandbox, qa-channel transport, live `openai/gpt-5.6-luna`):
  - "compute 17*23 but tell me in 2 minutes" → model created `{kind:"at"}` `agentTurn` job with **no explicit sessionTarget**; default bound it `current` to the QA DM session with announce delivery; answer "391" arrived in the same DM ~2 min later; job auto-deleted.
  - `/loop 1m <prompt>` → tagged job (`loop[<tag>] …`, everyMs 60000, current), multiple on-cadence runs delivered into the chat, `/loop status` reported name/cadence/last/next, `/loop stop` removed exactly the tagged job.
  - Self-paced `/loop <prompt>` → job with `pacing {min:"1m",max:"1h"}`; forced run executed and delivered.
  - Live testing surfaced and fixed two real issues pre-merge: session-key mismatch in status/stop scoping (now name-tag based) and message-tool double-send in loop confirmations (work orders now request final-reply-only).
- `$autoreview` (Codex, gpt-5.6-sol): 3 rounds; accepted + fixed 48-bit tag widening and `includeDisabled` listing; rejected native-gating finding (refuted by `shouldHandleTextCommands` returning true for `commandSource === "native"`); final run clean.
- Known follow-up (pre-existing, filed separately): replies to body-rewritten command turns (`/learn`-pattern) can double-deliver on qa-channel; unrelated to this diff's surfaces.

## Live Proof (redacted terminal excerpts)

Isolated dev gateway (`OPENCLAW_STATE_DIR` sandbox, port 19850, qa-channel synthetic bus on 43123, live `openai/gpt-5.6-luna`, sender `tester` in `commands.ownerAllowFrom`). All excerpts are verbatim tool output from the QA bus state endpoint and gateway RPC; the environment is synthetic (no real users/credentials in transcripts).

**1. Self-wakeup with the new `current` default** — model created the job with NO explicit `sessionTarget`; the default bound it to the creating conversation:

```
$ cron.list (after: "compute 17*23 but tell me in ~2 minutes, not now")
{"name":"delayed multiplication answer","schedule":{"kind":"at","at":"2026-07-27T04:13:00.000Z"},
 "sessionTarget":"current","sessionKey":"agent:main:qa-channel:default:direct:tester",
 "payloadKind":"agentTurn","delivery":{"mode":"announce","channel":"qa-channel","to":"dm:tester","bestEffort":true},
 "deleteAfterRun":true}

QA DM transcript (bus /v1/state), ~2 minutes later:
[outbound] Confirmed—I'll send it here in about two minutes. ...
[outbound] 17 × 23 = 391
```

**2. `/loop 1m` fixed-cadence lifecycle** — tagged job, on-cadence runs, status, stop:

```
$ cron.list (after: "/loop 1m share one surprising fact about a different chemical element each time")
{"name":"loop[6d9217] share one surprising fact about a differ","schedule":{"kind":"every","everyMs":60000},
 "sessionTarget":"current","sessionKey":"agent:main:qa-channel:default:direct:tester"}

QA DM (successive minutes):
[outbound] Fun fact: **97** is the largest two-digit prime number—...
[outbound] Fun fact: **101** is the smallest three-digit prime—...
[outbound] Technetium is the first element discovered to have no stable isotopes—...
[outbound] Gallium melts at about 30°C, so a solid gallium spoon can melt in your hand.

$ cron.runs <loop-job-id> (excerpt)
{"status":"ok","delivered":true,"summary":"Gallium is a metal that melts in your hand..."}
{"status":"ok","delivered":true,"summary":"**Rhenium (Re)** is so rare that it was the last naturally occurring stable element..."}

[inbound] /loop status
[outbound] - **loop[6d9217] share one surprising fact about a differ** — every 60 seconds; last run **00:32:50 EDT**; next run **00:33:50 EDT**.

[inbound] /loop stop
[outbound] Removed loop: **loop[6d9217] share one surprising fact about a differ**.
$ cron.list => loops: 0
```

**3. Self-paced `/loop` (pacing + forced run)**:

```
$ cron.list (after: "/loop keep an eye on this chat and share a one-line haiku ...")
{"id":"5fd36be0-...","pacing":{"min":"1m","max":"1h"},"everyMs":900000,"name":"loop[6d9217] keep an eye on this chat an"}

$ cron.run {"id":"5fd36be0-...","mode":"force"}   => {"ok":true,"enqueued":true,...}
$ cron.runs (top entry)
{"status":"ok","summary":"Quiet chat, moonlight / Small loop watches passing words / Night folds into dawn","delivered":true}
```

## Merge-risk notes (maintainer decisions)

- **Gateway callers passing `sessionKey` without `sessionTarget` now bind `current`**: intentional product decision (operator-requested default change). The caller explicitly named a session; binding the job to it matches intent. No stored config/data is invalidated (runtime create-time default only), so no doctor migration is needed. Callers wanting detached runs keep `sessionTarget:"isolated"` explicitly. Covered by `src/gateway/server.cron.test.ts` (with/without session context).
- **`/loop` authorization/scoping/cleanup**: owner-only (`rejectUnauthorizedCommand` + `rejectNonOwnerCommand`); status/stop scope strictly by the 48-bit conversation name tag baked in at create time and instruct never to remove non-matching jobs; stop verified live to remove exactly the tagged job (fixed and paced variants); `includeDisabled:true` so disabled loops stay visible/removable.
- **`stream` schedule exposure**: creation remains gated server-side by `cron.triggers.enabled` (`src/cron/service/jobs.ts` validation + `executeScriptCronJob`/stream trigger paths); `assertNoCronShellExecution` still blocks `on-exit` and `command` payloads for agents — the enum change only aligns the model-facing schema with fields it already advertised (`command`, `mode`, `match`, `batchMs`, `maxBatchBytes`) and with `cron-tool-canonicalize`, which already recovered `stream` inputs.
