### PR TITLE
improve(slack): streamline transport regression coverage

### DIFF
--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -1,5 +1,5 @@
 // Slack tests cover dispatch.preview fallback plugin behavior.
-import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
+import type { GetReplyOptions, ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const FINAL_REPLY_TEXT = "final answer";
@@ -44,77 +44,7 @@ let mockedBlockStreamingEnabled: boolean | undefined = false;
 let mockedSlackStreamingMode: "off" | "partial" | "block" | "progress" = "partial";
 let mockedSlackDraftMode: "replace" | "status_final" | "append" = "append";
 let mockedPinnedMainDmOwner: string | undefined;
-let capturedReplyOptions:
-  | {
-      disableBlockStreaming?: boolean;
-      sourceReplyDeliveryMode?: "automatic" | "message_tool_only";
-      suppressTyping?: boolean;
-      suppressDefaultToolProgressMessages?: boolean;
-      commentaryProgressEnabled?: boolean;
-      progressPreambleEnabled?: boolean;
-      commentaryPayloadsEnabled?: boolean;
-      onVerboseProgressVisibility?: (isActive: () => boolean) => void;
-      allowProgressCallbacksWhenSourceDeliverySuppressed?: boolean;
-      allowToolLifecycleWhenProgressHidden?: boolean;
-      turnAdoptionLifecycle?: object;
-      onAssistantMessageStart?: () => Promise<void> | void;
-      onReasoningEnd?: () => Promise<void> | void;
-      onReasoningStream?: (payload?: {
-        text?: string;
-        isReasoningSnapshot?: boolean;
-      }) => Promise<void> | void;
-      onItemEvent?: (payload: {
-        kind?: string;
-        itemId?: string;
-        toolCallId?: string;
-        progressText?: string;
-        summary?: string;
-        title?: string;
-        name?: string;
-        phase?: string;
-        status?: string;
-        meta?: string;
-      }) => Promise<void> | void;
-      onCommandOutput?: (payload: {
-        itemId?: string;
-        toolCallId?: string;
-        phase?: string;
-        title?: string;
-        name?: string;
-        status?: string;
-        exitCode?: number | null;
-      }) => Promise<void> | void;
-      onToolStart?: (payload: {
-        itemId?: string;
-        toolCallId?: string;
-        name: string;
-        phase?: string;
-        args?: Record<string, unknown>;
-        detailMode?: "explain" | "raw";
-      }) => Promise<void> | void;
-      onPatchSummary?: (payload: {
-        itemId?: string;
-        toolCallId?: string;
-        phase?: string;
-        title?: string;
-        name?: string;
-        added?: string[];
-        modified?: string[];
-        deleted?: string[];
-        summary?: string;
-      }) => Promise<void> | void;
-      onPlanUpdate?: (payload: {
-        phase?: string;
-        explanation?: string;
-        steps?: Array<{
-          step: string;
-          status: "pending" | "in_progress" | "completed";
-        }>;
-      }) => Promise<void> | void;
-      onPartialReply?: (payload: { text: string }) => Promise<void> | void;
-      onQueuedFollowupAdmitted?: () => Promise<void> | void;
-    }
-  | undefined;
+let capturedReplyOptions: GetReplyOptions | undefined;
 let capturedStatusReactionOptions: { enabled?: boolean; initialEmoji?: string } | undefined;
 const statusReactionControllerMock = {
   setQueued: vi.fn(async () => {}),
@@ -345,11 +275,11 @@ const noopAsync = async () => {};
 function createDraftStreamStub() {
   return {
     update: vi.fn(),
-    flush: noopAsync,
-    clear: noopAsync,
-    discardPending: noopAsync,
-    seal: noopAsync,
-    stop: noop,
+    flush: vi.fn(noopAsync),
+    clear: vi.fn(noopAsync),
+    discardPending: vi.fn(noopAsync),
+    seal: vi.fn(noopAsync),
+    stop: vi.fn(noop),
     forceNewMessage: vi.fn(),
     messageId: () => "171234.567",
     channelId: () => "C123",
@@ -1397,13 +1327,7 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
   });
 
   it("finalizes fast draft preview text without sending a duplicate normal reply", async () => {
-    const draftStream = {
-      ...createDraftStreamStub(),
-      flush: vi.fn(noopAsync),
-      clear: vi.fn(noopAsync),
-      discardPending: vi.fn(noopAsync),
-      seal: vi.fn(noopAsync),
-    };
+    const draftStream = createDraftStreamStub();
     createSlackDraftStreamMock.mockReturnValueOnce(draftStream);
     finalizeSlackPreviewEditMock.mockResolvedValueOnce(undefined);
     mockedDispatchSequence = [{ kind: "final", payload: { text: "✅" } }];
@@ -1429,13 +1353,7 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
   });
 
   it("finalizes native chart blocks without re-escaping accessible preview text", async () => {
-    const draftStream = {
-      ...createDraftStreamStub(),
-      flush: vi.fn(noopAsync),
-      clear: vi.fn(noopAsync),
-      discardPending: vi.fn(noopAsync),
-      seal: vi.fn(noopAsync),
-    };
+    const draftStream = createDraftStreamStub();
     const accessibleText =
       "Quarterly results\n\nRevenue (bar chart)\n- &lt;@U123&gt;: Q1: 12; Q2: 18";
     mockedSlackReplyBlocks = [
@@ -1503,13 +1421,7 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
   });
 
   it("normalizes only authored preview text when blocks own their fallback", async () => {
-    const draftStream = {
-      ...createDraftStreamStub(),
-      flush: vi.fn(noopAsync),
-      clear: vi.fn(noopAsync),
-      discardPending: vi.fn(noopAsync),
-      seal: vi.fn(noopAsync),
-    };
+    const draftStream = createDraftStreamStub();
     createSlackDraftStreamMock.mockReturnValueOnce(draftStream);
     finalizeSlackPreviewEditMock.mockResolvedValueOnce(undefined);
     mockedDispatchSequence = [
@@ -1544,13 +1456,7 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
   });
 
   it("delivers split table fallbacks normally instead of hiding them in a preview edit", async () => {
-    const draftStream = {
-      ...createDraftStreamStub(),
-      flush: vi.fn(noopAsync),
-      clear: vi.fn(noopAsync),
-      discardPending: vi.fn(noopAsync),
-      seal: vi.fn(noopAsync),
-    };
+    const draftStream = createDraftStreamStub();
     const payload = {
       text: "Accounts",
       presentation: {
@@ -1621,13 +1527,7 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
   });
 
   it("does not clear a finalized Slack draft when a later tool warning is delivered", async () => {
-    const draftStream = {
-      ...createDraftStreamStub(),
-      flush: vi.fn(noopAsync),
-      clear: vi.fn(noopAsync),
-      discardPending: vi.fn(noopAsync),
-      seal: vi.fn(noopAsync),
-    };
+    const draftStream = createDraftStreamStub();
     createSlackDraftStreamMock.mockReturnValueOnce(draftStream);
     finalizeSlackPreviewEditMock.mockResolvedValueOnce(undefined);
     mockedDispatchSequence = [
@@ -1657,13 +1557,7 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
   });
 
   it("does not reuse draft cleanup after a normally delivered final reply", async () => {
-    const draftStream = {
-      ...createDraftStreamStub(),
-      flush: vi.fn(noopAsync),
-      clear: vi.fn(noopAsync),
-      discardPending: vi.fn(noopAsync),
-      seal: vi.fn(noopAsync),
-    };
+    const draftStream = createDraftStreamStub();
     createSlackDraftStreamMock.mockReturnValueOnce(draftStream);
     mockedDispatchSequence = [
       {
@@ -2037,13 +1931,7 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
   });
 
   it("renders rich status-final progress drafts as legacy Slack section blocks and finalizes once", async () => {
-    const draftStream = {
-      ...createDraftStreamStub(),
-      flush: vi.fn(noopAsync),
-      clear: vi.fn(noopAsync),
-      discardPending: vi.fn(noopAsync),
-      seal: vi.fn(noopAsync),
-    };
+    const draftStream = createDraftStreamStub();
     createSlackDraftStreamMock.mockReturnValueOnce(draftStream);
     finalizeSlackPreviewEditMock.mockResolvedValueOnce(undefined);
     mockedSlackStreamingMode = "progress";
@@ -2145,13 +2033,7 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
   });
 
   it("keeps unlabeled rich Slack progress drafts as legacy section blocks", async () => {
-    const draftStream = {
-      ...createDraftStreamStub(),
-      flush: vi.fn(noopAsync),
-      clear: vi.fn(noopAsync),
-      discardPending: vi.fn(noopAsync),
-      seal: vi.fn(noopAsync),
-    };
+    const draftStream = createDraftStreamStub();
     createSlackDraftStreamMock.mockReturnValueOnce(draftStream);
     finalizeSlackPreviewEditMock.mockResolvedValueOnce(undefined);
     mockedSlackStreamingMode = "progress";
@@ -2193,7 +2075,7 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
   });
 
   it("sends a progress final fresh before collapsing its draft to a receipt", async () => {
-    const draftStream = { ...createDraftStreamStub(), clear: vi.fn(noopAsync) };
+    const draftStream = createDraftStreamStub();
     createSlackDraftStreamMock.mockReturnValueOnce(draftStream);
     finalizeSlackPreviewEditMock.mockResolvedValueOnce(undefined);
     mockedReplyThreadTsSequence = [undefined];
@@ -2230,7 +2112,7 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
   });
 
   it("leaves a progress draft untouched when the fresh final send fails", async () => {
-    const draftStream = { ...createDraftStreamStub(), clear: vi.fn(noopAsync) };
+    const draftStream = createDraftStreamStub();
     createSlackDraftStreamMock.mockReturnValueOnce(draftStream);
     deliverRepliesMock.mockRejectedValueOnce(new Error("final send failed"));
     mockedSlackStreamingMode = "progress";
@@ -2252,7 +2134,7 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
   });
 
   it("keeps a progress draft for an error final without creating a receipt", async () => {
-    const draftStream = { ...createDraftStreamStub(), clear: vi.fn(noopAsync) };
+    const draftStream = createDraftStreamStub();
     createSlackDraftStreamMock.mockReturnValueOnce(draftStream);
     mockedSlackStreamingMode = "progress";
     mockedSlackDraftMode = "status_final";
@@ -3418,13 +3300,7 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
   });
 
   it("preserves the last rich Slack progress lines after a draft boundary status update", async () => {
-    const draftStream = {
-      ...createDraftStreamStub(),
-      flush: vi.fn(noopAsync),
-      clear: vi.fn(noopAsync),
-      discardPending: vi.fn(noopAsync),
-      seal: vi.fn(noopAsync),
-    };
+    const draftStream = createDraftStreamStub();
     createSlackDraftStreamMock.mockReturnValueOnce(draftStream);
     finalizeSlackPreviewEditMock.mockResolvedValueOnce(undefined);
     mockedSlackStreamingMode = "progress";
@@ -3574,10 +3450,7 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
   });
 
   it("starts a new draft delivery target when a queued followup is admitted", async () => {
-    const draftStream = {
-      ...createDraftStreamStub(),
-      flush: vi.fn(noopAsync),
-    };
+    const draftStream = createDraftStreamStub();
     createSlackDraftStreamMock.mockReturnValueOnce(draftStream);
     mockedSlackStreamingMode = "partial";
     mockedSlackDraftMode = "replace";
@@ -3893,13 +3766,7 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
   });
 
   it("preserves hidden-title rich Slack progress drafts when the label is hidden", async () => {
-    const draftStream = {
-      ...createDraftStreamStub(),
-      flush: vi.fn(noopAsync),
-      clear: vi.fn(noopAsync),
-      discardPending: vi.fn(noopAsync),
-      seal: vi.fn(noopAsync),
-    };
+    const draftStream = createDraftStreamStub();
     createSlackDraftStreamMock.mockReturnValueOnce(draftStream);
     finalizeSlackPreviewEditMock.mockResolvedValueOnce(undefined);
     mockedSlackStreamingMode = "progress";
@@ -4174,13 +4041,7 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
   });
 
   it("does not flush draft previews for media finals before normal delivery", async () => {
-    const draftStream = {
-      ...createDraftStreamStub(),
-      flush: vi.fn(noopAsync),
-      clear: vi.fn(noopAsync),
-      discardPending: vi.fn(noopAsync),
-      seal: vi.fn(noopAsync),
-    };
+    const draftStream = createDraftStreamStub();
     createSlackDraftStreamMock.mockReturnValueOnce(draftStream);
     finalizeSlackPreviewEditMock.mockResolvedValueOnce(undefined);
     mockedDispatchSequence = [
@@ -4200,13 +4061,7 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
   });
 
   it("keeps the preview and sends media-only for TTS supplement finals", async () => {
-    const draftStream = {
-      ...createDraftStreamStub(),
-      flush: vi.fn(noopAsync),
-      clear: vi.fn(noopAsync),
-      discardPending: vi.fn(noopAsync),
-      seal: vi.fn(noopAsync),
-    };
+    const draftStream = createDraftStreamStub();
     createSlackDraftStreamMock.mockReturnValueOnce(draftStream);
     finalizeSlackPreviewEditMock.mockResolvedValueOnce(undefined);
     mockedReplyThreadTsSequence = [undefined];
@@ -4292,13 +4147,7 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
   });
 
   it("suppresses duplicate TTS supplement finals after preview finalization", async () => {
-    const draftStream = {
-      ...createDraftStreamStub(),
-      flush: vi.fn(noopAsync),
-      clear: vi.fn(noopAsync),
-      discardPending: vi.fn(noopAsync),
-      seal: vi.fn(noopAsync),
-    };
+    const draftStream = createDraftStreamStub();
     createSlackDraftStreamMock.mockReturnValueOnce(draftStream);
     finalizeSlackPreviewEditMock.mockResolvedValueOnce(undefined);
     mockedSlackIsThreadReply = false;
@@ -4340,13 +4189,7 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
   });
 
   it("falls back with visible text when TTS supplement preview finalization fails", async () => {
-    const draftStream = {
-      ...createDraftStreamStub(),
-      flush: vi.fn(noopAsync),
-      clear: vi.fn(noopAsync),
-      discardPending: vi.fn(noopAsync),
-      seal: vi.fn(noopAsync),
-    };
+    const draftStream = createDraftStreamStub();
     createSlackDraftStreamMock.mockReturnValueOnce(draftStream);
     mockedReplyThreadTsSequence = [undefined];
     mockedDispatchSequence = [
@@ -4383,13 +4226,7 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
   });
 
   it("keeps chart semantics singular when TTS preview finalization fails", async () => {
-    const draftStream = {
-      ...createDraftStreamStub(),
-      flush: vi.fn(noopAsync),
-      clear: vi.fn(noopAsync),
-      discardPending: vi.fn(noopAsync),
-      seal: vi.fn(noopAsync),
-    };
+    const draftStream = createDraftStreamStub();
     mockedSlackReplyBlocks = [
       {
         type: "section",
@@ -4552,13 +4389,7 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
   });
 
   it("does not flush draft previews for error finals before normal delivery", async () => {
-    const draftStream = {
-      ...createDraftStreamStub(),
-      flush: vi.fn(noopAsync),
-      clear: vi.fn(noopAsync),
-      discardPending: vi.fn(noopAsync),
-      seal: vi.fn(noopAsync),
-    };
+    const draftStream = createDraftStreamStub();
     createSlackDraftStreamMock.mockReturnValueOnce(draftStream);
     mockedDispatchSequence = [
       {

--- a/extensions/slack/src/monitor/message-handler/prepare.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.test.ts
@@ -1931,190 +1931,117 @@ Second paragraph should still reach the agent after Slack's preview cutoff.`;
     expect(prepared.ctxPayload.RawBody).toContain("bot DM");
   });
 
-  it("drops channel message mentioning another user when ignoreOtherMentions=true", async () => {
-    const slackCtx = createInboundSlackCtx({
-      cfg: {
-        channels: { slack: { enabled: true } },
-      } as OpenClawConfig,
-      defaultRequireMention: false,
-      channelsConfig: { "*": { ignoreOtherMentions: true } },
-    });
-    slackCtx.historyLimit = 5;
+  const otherMentionCases: Array<{
+    name: string;
+    text: string;
+    accepted: boolean;
+    recordHistory?: boolean;
+    threadTs?: string;
+    resolveUserGroup?: boolean;
+    directMessage?: boolean;
+    unresolvedBot?: boolean;
+    mentionPatterns?: string[];
+  }> = [
+    {
+      name: "drops channel message mentioning another user when ignoreOtherMentions=true",
+      text: "<@U456> hey",
+      accepted: false,
+      recordHistory: true,
+    },
+    {
+      name: "drops other-user mentions even in a bot-participated thread",
+      text: "<@U456> hey",
+      accepted: false,
+      threadTs: "10.000",
+    },
+    {
+      name: "drops a user-group mention when the bot is not a member",
+      text: "<!subteam^S123|team> hey",
+      accepted: false,
+      resolveUserGroup: true,
+    },
+    {
+      name: "does not drop channel message mentioning bot alongside another user when ignoreOtherMentions=true",
+      text: "<@B1> <@U456> hey",
+      accepted: true,
+    },
+    {
+      name: "does not drop DM mentioning another user when ignoreOtherMentions=true",
+      text: "<@U456> hey",
+      accepted: true,
+      directMessage: true,
+    },
+    {
+      name: "does not drop channel message with no user mentions when ignoreOtherMentions=true",
+      text: "hello team",
+      accepted: true,
+    },
+    {
+      name: "does not drop when botUserId is unresolved (no native identity)",
+      text: "<@U456> hey",
+      accepted: true,
+      unresolvedBot: true,
+    },
+    {
+      name: "does not drop when botUserId is unresolved even with mention regexes configured",
+      text: "<@U456> hey",
+      accepted: true,
+      unresolvedBot: true,
+      mentionPatterns: ["\\bmy-bot\\b"],
+    },
+  ];
 
-    const prepared = await prepareMessageWith(
-      slackCtx,
-      defaultAccount,
-      createSlackMessage({
-        channel: "C123",
-        channel_type: "channel",
-        text: "<@U456> hey",
-      }),
-    );
-
-    expect(prepared).toBeNull();
-    expect(Array.from(slackCtx.channelHistories.values()).flat()).toMatchObject([
-      { body: "<@U456> hey", sender: "U1" },
-    ]);
-  });
-
-  it("drops other-user mentions even in a bot-participated thread", async () => {
-    const slackCtx = createInboundSlackCtx({
-      cfg: { channels: { slack: { enabled: true } } } as OpenClawConfig,
-      defaultRequireMention: false,
-      channelsConfig: { "*": { ignoreOtherMentions: true } },
-    });
-    recordSlackThreadParticipation("default", "C123", "10.000");
-
-    const prepared = await prepareMessageWith(
-      slackCtx,
-      defaultAccount,
-      createSlackMessage({
-        channel: "C123",
-        channel_type: "channel",
-        text: "<@U456> hey",
-        thread_ts: "10.000",
-      }),
-    );
-
-    expect(prepared).toBeNull();
-  });
-
-  it("drops a user-group mention when the bot is not a member", async () => {
+  it.each(otherMentionCases)("$name", async (testCase) => {
     const usergroupsUsersList = vi.fn().mockResolvedValue({ ok: true, users: ["U456"] });
     const slackCtx = createInboundSlackCtx({
-      cfg: { channels: { slack: { enabled: true } } } as OpenClawConfig,
-      appClient: {
-        usergroups: { users: { list: usergroupsUsersList } },
-      } as unknown as App["client"],
-      defaultRequireMention: false,
-      channelsConfig: { "*": { ignoreOtherMentions: true } },
-    });
-
-    const prepared = await prepareMessageWith(
-      slackCtx,
-      defaultAccount,
-      createSlackMessage({
-        channel: "C123",
-        channel_type: "channel",
-        text: "<!subteam^S123|team> hey",
-      }),
-    );
-
-    expect(prepared).toBeNull();
-    expect(usergroupsUsersList).toHaveBeenCalledWith({ usergroup: "S123", team_id: "T1" });
-  });
-
-  it("does not drop channel message mentioning bot alongside another user when ignoreOtherMentions=true", async () => {
-    const slackCtx = createInboundSlackCtx({
       cfg: {
         channels: { slack: { enabled: true } },
+        ...(testCase.mentionPatterns && {
+          messages: { groupChat: { mentionPatterns: testCase.mentionPatterns } },
+        }),
       } as OpenClawConfig,
+      ...(testCase.resolveUserGroup && {
+        appClient: {
+          usergroups: { users: { list: usergroupsUsersList } },
+        } as unknown as App["client"],
+      }),
       defaultRequireMention: false,
       channelsConfig: { "*": { ignoreOtherMentions: true } },
     });
+    if (testCase.recordHistory) {
+      slackCtx.historyLimit = 5;
+    }
+    if (testCase.unresolvedBot) {
+      slackCtx.botUserId = undefined as unknown as string;
+    }
+    if (testCase.threadTs) {
+      recordSlackThreadParticipation("default", "C123", testCase.threadTs);
+    }
 
     const prepared = await prepareMessageWith(
       slackCtx,
       defaultAccount,
       createSlackMessage({
-        channel: "C123",
-        channel_type: "channel",
-        text: "<@B1> <@U456> hey",
+        channel: testCase.directMessage ? "D123" : "C123",
+        channel_type: testCase.directMessage ? "im" : "channel",
+        text: testCase.text,
+        ...(testCase.threadTs && { thread_ts: testCase.threadTs }),
       }),
     );
 
-    assertPrepared(prepared);
-  });
-
-  it("does not drop DM mentioning another user when ignoreOtherMentions=true", async () => {
-    const slackCtx = createInboundSlackCtx({
-      cfg: {
-        channels: { slack: { enabled: true } },
-      } as OpenClawConfig,
-      defaultRequireMention: false,
-      channelsConfig: { "*": { ignoreOtherMentions: true } },
-    });
-
-    const prepared = await prepareMessageWith(
-      slackCtx,
-      defaultAccount,
-      createSlackMessage({
-        channel: "D123",
-        channel_type: "im",
-        text: "<@U456> hey",
-      }),
-    );
-
-    assertPrepared(prepared);
-  });
-
-  it("does not drop channel message with no user mentions when ignoreOtherMentions=true", async () => {
-    const slackCtx = createInboundSlackCtx({
-      cfg: {
-        channels: { slack: { enabled: true } },
-      } as OpenClawConfig,
-      defaultRequireMention: false,
-      channelsConfig: { "*": { ignoreOtherMentions: true } },
-    });
-
-    const prepared = await prepareMessageWith(
-      slackCtx,
-      defaultAccount,
-      createSlackMessage({
-        channel: "C123",
-        channel_type: "channel",
-        text: "hello team",
-      }),
-    );
-
-    assertPrepared(prepared);
-  });
-
-  it("does not drop when botUserId is unresolved (no native identity)", async () => {
-    const slackCtx = createInboundSlackCtx({
-      cfg: {
-        channels: { slack: { enabled: true } },
-      } as OpenClawConfig,
-      defaultRequireMention: false,
-      channelsConfig: { "*": { ignoreOtherMentions: true } },
-    });
-    slackCtx.botUserId = undefined as unknown as string;
-
-    const prepared = await prepareMessageWith(
-      slackCtx,
-      defaultAccount,
-      createSlackMessage({
-        channel: "C123",
-        channel_type: "channel",
-        text: "<@U456> hey",
-      }),
-    );
-
-    assertPrepared(prepared);
-  });
-
-  it("does not drop when botUserId is unresolved even with mention regexes configured", async () => {
-    const slackCtx = createInboundSlackCtx({
-      cfg: {
-        channels: { slack: { enabled: true } },
-        messages: { groupChat: { mentionPatterns: ["\\bmy-bot\\b"] } },
-      } as OpenClawConfig,
-      defaultRequireMention: false,
-      channelsConfig: { "*": { ignoreOtherMentions: true } },
-    });
-    slackCtx.botUserId = undefined as unknown as string;
-
-    const prepared = await prepareMessageWith(
-      slackCtx,
-      defaultAccount,
-      createSlackMessage({
-        channel: "C123",
-        channel_type: "channel",
-        text: "<@U456> hey",
-      }),
-    );
-
-    assertPrepared(prepared);
+    if (testCase.accepted) {
+      assertPrepared(prepared);
+    } else {
+      expect(prepared).toBeNull();
+    }
+    if (testCase.recordHistory) {
+      expect(Array.from(slackCtx.channelHistories.values()).flat()).toMatchObject([
+        { body: testCase.text, sender: "U1" },
+      ]);
+    }
+    if (testCase.resolveUserGroup) {
+      expect(usergroupsUsersList).toHaveBeenCalledWith({ usergroup: "S123", team_id: "T1" });
+    }
   });
 
   it("drops bot-authored room messages when owner presence lookup fails (#59284)", async () => {


### PR DESCRIPTION
## What Problem This Solves

Slack transport regression tests repeated draft-stream spies and independently reimplemented the public reply callback contract. Mention-policy cases also rebuilt nearly identical fixtures. The resulting duplication obscured which transport, streaming, and sender-authorization behaviors were actually protected.

## Why This Change Was Made

Use the actual public `GetReplyOptions` contract, give the shared draft-stream builder observable asynchronous lifecycle spies, and express all eight distinct other-mention authorization cases as an explicit named scenario matrix. Keep the existing Slack owner, entry points, individual case names, assertions, plugin boundaries, and production code unchanged.

## User Impact

No production behavior changes. Developers retain equivalent Slack delivery, draft finalization, user-group, thread, direct-message, and unresolved-bot regression protection with 242 fewer test lines. AI-assisted, maintainer-requested consolidation.

## Evidence

- Exact frozen-base comparison: all 248 named Slack owner tests pass before and after.
- Statements and lines: 551/619 (89.01%) before and after.
- Branches: 736/851 (86.48%) before and after.
- Functions: 55/66 (83.33%) before and after.
- Coverage includes the real Slack `prepare.ts` and `dispatch.ts` production owners and uses identical explicit V8 include/exclude lists for both measurements; no threshold, exclusion, snapshot, or assertion is weakened.
- `git diff --check` passes. The commit contains only the two Slack owner test files; Telegram and Matrix changes remain outside this pull request.
