### PR TITLE
refactor(cli): consolidate coverage-preserving regression tests

### DIFF
--- a/src/cli/devices-cli.test.ts
+++ b/src/cli/devices-cli.test.ts
@@ -127,6 +127,47 @@ function mockLocalPairingFallback(message?: string) {
   summarizeDeviceTokens.mockReturnValue(undefined);
 }
 
+function mockReplacementPairing(
+  params: {
+    original?: Record<string, unknown> | null;
+    replacement?: Record<string, unknown>;
+    paired?: Record<string, unknown>[];
+  } = {},
+) {
+  const pending = (requestId: "req-old" | "req-new", overrides: Record<string, unknown> = {}) => ({
+    requestId,
+    deviceId: "device-1",
+    publicKey: "pk",
+    ...(Object.hasOwn(overrides, "roles") ? {} : { role: "operator" }),
+    scopes: requestId === "req-old" ? ["operator.read"] : ["operator.read", "operator.pairing"],
+    clientId: "openclaw-macos",
+    clientMode: "cli",
+    isRepair: true,
+    ts: requestId === "req-old" ? 1 : 2,
+    ...overrides,
+  });
+  const replacement = pending("req-new", params.replacement);
+  const paired = params.paired ?? [];
+  rejectGatewayForLocalFallback("scope upgrade pending approval (requestId: req-new)");
+  rejectGatewayForLocalFallback("scope upgrade pending approval (requestId: req-new)");
+  listDevicePairing
+    .mockResolvedValueOnce({
+      pending:
+        params.original === null
+          ? [replacement]
+          : [pending("req-old", params.original), replacement],
+      paired,
+    })
+    .mockResolvedValueOnce({ pending: [replacement], paired });
+}
+
+function mockApprovedReplacement() {
+  approveDevicePairing.mockResolvedValueOnce({
+    requestId: "req-new",
+    device: { deviceId: "device-1", publicKey: "pk", approvedAtMs: 1, createdAtMs: 1 },
+  });
+}
+
 function requireRecord(value: unknown, label: string): Record<string, unknown> {
   if (typeof value !== "object" || value === null) {
     throw new Error(`${label} was not an object`);
@@ -770,60 +811,8 @@ describe("devices cli local fallback", () => {
   });
 
   it("approves a same-device compatible replacement request during local fallback", async () => {
-    rejectGatewayForLocalFallback("scope upgrade pending approval (requestId: req-new)");
-    rejectGatewayForLocalFallback("scope upgrade pending approval (requestId: req-new)");
-    listDevicePairing.mockResolvedValueOnce({
-      pending: [
-        {
-          requestId: "req-old",
-          deviceId: "device-1",
-          publicKey: "pk",
-          role: "operator",
-          scopes: ["operator.read"],
-          clientId: "openclaw-macos",
-          clientMode: "cli",
-          isRepair: true,
-          ts: 1,
-        },
-        {
-          requestId: "req-new",
-          deviceId: "device-1",
-          publicKey: "pk",
-          role: "operator",
-          scopes: ["operator.read", "operator.pairing"],
-          clientId: "openclaw-macos",
-          clientMode: "cli",
-          isRepair: true,
-          ts: 2,
-        },
-      ],
-      paired: [],
-    });
-    listDevicePairing.mockResolvedValueOnce({
-      pending: [
-        {
-          requestId: "req-new",
-          deviceId: "device-1",
-          publicKey: "pk",
-          role: "operator",
-          scopes: ["operator.read", "operator.pairing"],
-          clientId: "openclaw-macos",
-          clientMode: "cli",
-          isRepair: true,
-          ts: 2,
-        },
-      ],
-      paired: [],
-    });
-    approveDevicePairing.mockResolvedValueOnce({
-      requestId: "req-new",
-      device: {
-        deviceId: "device-1",
-        publicKey: "pk",
-        approvedAtMs: 1,
-        createdAtMs: 1,
-      },
-    });
+    mockReplacementPairing();
+    mockApprovedReplacement();
     summarizeDeviceTokens.mockReturnValue(undefined);
 
     await runDevicesApprove(["req-old"]);
@@ -840,61 +829,8 @@ describe("devices cli local fallback", () => {
   });
 
   it("emits resolved metadata in JSON mode when local fallback approves a replacement request", async () => {
-    rejectGatewayForLocalFallback("scope upgrade pending approval (requestId: req-new)");
-    rejectGatewayForLocalFallback("scope upgrade pending approval (requestId: req-new)");
-    listDevicePairing
-      .mockResolvedValueOnce({
-        pending: [
-          {
-            requestId: "req-old",
-            deviceId: "device-1",
-            publicKey: "pk",
-            role: "operator",
-            scopes: ["operator.read"],
-            clientId: "openclaw-macos",
-            clientMode: "cli",
-            isRepair: true,
-            ts: 1,
-          },
-          {
-            requestId: "req-new",
-            deviceId: "device-1",
-            publicKey: "pk",
-            role: "operator",
-            scopes: ["operator.read", "operator.pairing"],
-            clientId: "openclaw-macos",
-            clientMode: "cli",
-            isRepair: true,
-            ts: 2,
-          },
-        ],
-        paired: [],
-      })
-      .mockResolvedValueOnce({
-        pending: [
-          {
-            requestId: "req-new",
-            deviceId: "device-1",
-            publicKey: "pk",
-            role: "operator",
-            scopes: ["operator.read", "operator.pairing"],
-            clientId: "openclaw-macos",
-            clientMode: "cli",
-            isRepair: true,
-            ts: 2,
-          },
-        ],
-        paired: [],
-      });
-    approveDevicePairing.mockResolvedValueOnce({
-      requestId: "req-new",
-      device: {
-        deviceId: "device-1",
-        publicKey: "pk",
-        approvedAtMs: 1,
-        createdAtMs: 1,
-      },
-    });
+    mockReplacementPairing();
+    mockApprovedReplacement();
 
     await runDevicesApprove(["req-old", "--json"]);
 
@@ -919,77 +855,19 @@ describe("devices cli local fallback", () => {
   });
 
   it("approves a replacement request when the original repair inherited scopes from the paired token", async () => {
-    rejectGatewayForLocalFallback("scope upgrade pending approval (requestId: req-new)");
-    rejectGatewayForLocalFallback("scope upgrade pending approval (requestId: req-new)");
-    listDevicePairing
-      .mockResolvedValueOnce({
-        pending: [
-          {
-            requestId: "req-old",
-            deviceId: "device-1",
-            publicKey: "pk",
-            role: "operator",
-            scopes: [],
-            clientId: "openclaw-macos",
-            clientMode: "cli",
-            isRepair: true,
-            ts: 1,
-          },
-          {
-            requestId: "req-new",
-            deviceId: "device-1",
-            publicKey: "pk",
-            role: "operator",
-            scopes: ["operator.read", "operator.pairing"],
-            clientId: "openclaw-macos",
-            clientMode: "cli",
-            isRepair: true,
-            ts: 2,
-          },
-        ],
-        paired: [
-          {
-            deviceId: "device-1",
-            publicKey: "pk",
-            roles: ["operator"],
-            scopes: ["operator.read"],
-            tokens: [{ role: "operator", scopes: ["operator.read"] }],
-          },
-        ],
-      })
-      .mockResolvedValueOnce({
-        pending: [
-          {
-            requestId: "req-new",
-            deviceId: "device-1",
-            publicKey: "pk",
-            role: "operator",
-            scopes: ["operator.read", "operator.pairing"],
-            clientId: "openclaw-macos",
-            clientMode: "cli",
-            isRepair: true,
-            ts: 2,
-          },
-        ],
-        paired: [
-          {
-            deviceId: "device-1",
-            publicKey: "pk",
-            roles: ["operator"],
-            scopes: ["operator.read"],
-            tokens: [{ role: "operator", scopes: ["operator.read"] }],
-          },
-        ],
-      });
-    approveDevicePairing.mockResolvedValueOnce({
-      requestId: "req-new",
-      device: {
-        deviceId: "device-1",
-        publicKey: "pk",
-        approvedAtMs: 1,
-        createdAtMs: 1,
-      },
+    mockReplacementPairing({
+      original: { scopes: [] },
+      paired: [
+        {
+          deviceId: "device-1",
+          publicKey: "pk",
+          roles: ["operator"],
+          scopes: ["operator.read"],
+          tokens: [{ role: "operator", scopes: ["operator.read"] }],
+        },
+      ],
     });
+    mockApprovedReplacement();
 
     await runDevicesApprove(["req-old"]);
 
@@ -1001,366 +879,36 @@ describe("devices cli local fallback", () => {
     );
   });
 
-  it("fails closed when the original request snapshot is missing", async () => {
-    rejectGatewayForLocalFallback("scope upgrade pending approval (requestId: req-new)");
-    rejectGatewayForLocalFallback("scope upgrade pending approval (requestId: req-new)");
-    listDevicePairing
-      .mockResolvedValueOnce({
-        pending: [
-          {
-            requestId: "req-new",
-            deviceId: "device-1",
-            publicKey: "pk",
-            role: "operator",
-            scopes: ["operator.read", "operator.pairing"],
-            clientId: "openclaw-macos",
-            clientMode: "cli",
-            isRepair: true,
-            ts: 2,
-          },
-        ],
-        paired: [],
-      })
-      .mockResolvedValueOnce({
-        pending: [
-          {
-            requestId: "req-new",
-            deviceId: "device-1",
-            publicKey: "pk",
-            role: "operator",
-            scopes: ["operator.read", "operator.pairing"],
-            clientId: "openclaw-macos",
-            clientMode: "cli",
-            isRepair: true,
-            ts: 2,
-          },
-        ],
-        paired: [],
-      });
-
-    await expect(runDevicesApprove(["req-old"])).rejects.toThrow(
-      "local fallback pairing state does not contain the gateway request",
-    );
-    expect(approveDevicePairing).not.toHaveBeenCalled();
-  });
-
-  it("fails closed when the replacement request is not a compatible scope superset", async () => {
-    rejectGatewayForLocalFallback("scope upgrade pending approval (requestId: req-new)");
-    rejectGatewayForLocalFallback("scope upgrade pending approval (requestId: req-new)");
-    listDevicePairing
-      .mockResolvedValueOnce({
-        pending: [
-          {
-            requestId: "req-old",
-            deviceId: "device-1",
-            publicKey: "pk",
-            role: "operator",
-            scopes: ["operator.read", "operator.write"],
-            clientId: "openclaw-macos",
-            clientMode: "cli",
-            isRepair: true,
-            ts: 1,
-          },
-          {
-            requestId: "req-new",
-            deviceId: "device-1",
-            publicKey: "pk",
-            role: "operator",
-            scopes: ["operator.pairing"],
-            clientId: "openclaw-macos",
-            clientMode: "cli",
-            isRepair: true,
-            ts: 2,
-          },
-        ],
-        paired: [],
-      })
-      .mockResolvedValueOnce({
-        pending: [
-          {
-            requestId: "req-new",
-            deviceId: "device-1",
-            publicKey: "pk",
-            role: "operator",
-            scopes: ["operator.pairing"],
-            clientId: "openclaw-macos",
-            clientMode: "cli",
-            isRepair: true,
-            ts: 2,
-          },
-        ],
-        paired: [],
-      });
-
-    await expect(runDevicesApprove(["req-old"])).rejects.toThrow(
-      "local fallback pairing state does not contain the gateway request",
-    );
-    expect(approveDevicePairing).not.toHaveBeenCalled();
-  });
-
-  it("fails closed when the replacement request adds unrelated broader scopes", async () => {
-    rejectGatewayForLocalFallback("scope upgrade pending approval (requestId: req-new)");
-    rejectGatewayForLocalFallback("scope upgrade pending approval (requestId: req-new)");
-    listDevicePairing
-      .mockResolvedValueOnce({
-        pending: [
-          {
-            requestId: "req-old",
-            deviceId: "device-1",
-            publicKey: "pk",
-            role: "operator",
-            scopes: ["operator.read"],
-            clientId: "openclaw-macos",
-            clientMode: "cli",
-            isRepair: true,
-            ts: 1,
-          },
-          {
-            requestId: "req-new",
-            deviceId: "device-1",
-            publicKey: "pk",
-            role: "operator",
-            scopes: ["operator.read", "operator.write"],
-            clientId: "openclaw-macos",
-            clientMode: "cli",
-            isRepair: true,
-            ts: 2,
-          },
-        ],
-        paired: [],
-      })
-      .mockResolvedValueOnce({
-        pending: [
-          {
-            requestId: "req-new",
-            deviceId: "device-1",
-            publicKey: "pk",
-            role: "operator",
-            scopes: ["operator.read", "operator.write"],
-            clientId: "openclaw-macos",
-            clientMode: "cli",
-            isRepair: true,
-            ts: 2,
-          },
-        ],
-        paired: [],
-      });
-
-    await expect(runDevicesApprove(["req-old"])).rejects.toThrow(
-      "local fallback pairing state does not contain the gateway request",
-    );
-    expect(approveDevicePairing).not.toHaveBeenCalled();
-  });
-
-  it("fails closed when the replacement request belongs to a different device", async () => {
-    rejectGatewayForLocalFallback("scope upgrade pending approval (requestId: req-new)");
-    rejectGatewayForLocalFallback("scope upgrade pending approval (requestId: req-new)");
-    listDevicePairing
-      .mockResolvedValueOnce({
-        pending: [
-          {
-            requestId: "req-old",
-            deviceId: "device-1",
-            publicKey: "pk",
-            role: "operator",
-            scopes: ["operator.read"],
-            clientId: "openclaw-macos",
-            clientMode: "cli",
-            isRepair: true,
-            ts: 1,
-          },
-          {
-            requestId: "req-new",
-            deviceId: "device-2",
-            publicKey: "pk",
-            role: "operator",
-            scopes: ["operator.read", "operator.pairing"],
-            clientId: "openclaw-macos",
-            clientMode: "cli",
-            isRepair: true,
-            ts: 2,
-          },
-        ],
-        paired: [],
-      })
-      .mockResolvedValueOnce({
-        pending: [
-          {
-            requestId: "req-new",
-            deviceId: "device-2",
-            publicKey: "pk",
-            role: "operator",
-            scopes: ["operator.read", "operator.pairing"],
-            clientId: "openclaw-macos",
-            clientMode: "cli",
-            isRepair: true,
-            ts: 2,
-          },
-        ],
-        paired: [],
-      });
-
-    await expect(runDevicesApprove(["req-old"])).rejects.toThrow(
-      "local fallback pairing state does not contain the gateway request",
-    );
-    expect(approveDevicePairing).not.toHaveBeenCalled();
-  });
-
-  it("fails closed when the replacement request has a different public key", async () => {
-    rejectGatewayForLocalFallback("scope upgrade pending approval (requestId: req-new)");
-    rejectGatewayForLocalFallback("scope upgrade pending approval (requestId: req-new)");
-    listDevicePairing
-      .mockResolvedValueOnce({
-        pending: [
-          {
-            requestId: "req-old",
-            deviceId: "device-1",
-            publicKey: "pk-old",
-            role: "operator",
-            scopes: ["operator.read"],
-            clientId: "openclaw-macos",
-            clientMode: "cli",
-            isRepair: true,
-            ts: 1,
-          },
-          {
-            requestId: "req-new",
-            deviceId: "device-1",
-            publicKey: "pk-new",
-            role: "operator",
-            scopes: ["operator.read", "operator.pairing"],
-            clientId: "openclaw-macos",
-            clientMode: "cli",
-            isRepair: true,
-            ts: 2,
-          },
-        ],
-        paired: [],
-      })
-      .mockResolvedValueOnce({
-        pending: [
-          {
-            requestId: "req-new",
-            deviceId: "device-1",
-            publicKey: "pk-new",
-            role: "operator",
-            scopes: ["operator.read", "operator.pairing"],
-            clientId: "openclaw-macos",
-            clientMode: "cli",
-            isRepair: true,
-            ts: 2,
-          },
-        ],
-        paired: [],
-      });
-
-    await expect(runDevicesApprove(["req-old"])).rejects.toThrow(
-      "local fallback pairing state does not contain the gateway request",
-    );
-    expect(approveDevicePairing).not.toHaveBeenCalled();
-  });
-
-  it("fails closed when the replacement request changes the requested role set", async () => {
-    rejectGatewayForLocalFallback("scope upgrade pending approval (requestId: req-new)");
-    rejectGatewayForLocalFallback("scope upgrade pending approval (requestId: req-new)");
-    listDevicePairing
-      .mockResolvedValueOnce({
-        pending: [
-          {
-            requestId: "req-old",
-            deviceId: "device-1",
-            publicKey: "pk",
-            role: "operator",
-            scopes: ["operator.read"],
-            clientId: "openclaw-macos",
-            clientMode: "cli",
-            isRepair: true,
-            ts: 1,
-          },
-          {
-            requestId: "req-new",
-            deviceId: "device-1",
-            publicKey: "pk",
-            roles: ["operator", "different-role"],
-            scopes: ["operator.read", "operator.pairing"],
-            clientId: "openclaw-macos",
-            clientMode: "cli",
-            isRepair: true,
-            ts: 2,
-          },
-        ],
-        paired: [],
-      })
-      .mockResolvedValueOnce({
-        pending: [
-          {
-            requestId: "req-new",
-            deviceId: "device-1",
-            publicKey: "pk",
-            roles: ["operator", "different-role"],
-            scopes: ["operator.read", "operator.pairing"],
-            clientId: "openclaw-macos",
-            clientMode: "cli",
-            isRepair: true,
-            ts: 2,
-          },
-        ],
-        paired: [],
-      });
-
-    await expect(runDevicesApprove(["req-old"])).rejects.toThrow(
-      "local fallback pairing state does not contain the gateway request",
-    );
-    expect(approveDevicePairing).not.toHaveBeenCalled();
-  });
-
-  it("fails closed when the replacement request conflicts with client metadata", async () => {
-    rejectGatewayForLocalFallback("scope upgrade pending approval (requestId: req-new)");
-    rejectGatewayForLocalFallback("scope upgrade pending approval (requestId: req-new)");
-    listDevicePairing
-      .mockResolvedValueOnce({
-        pending: [
-          {
-            requestId: "req-old",
-            deviceId: "device-1",
-            publicKey: "pk",
-            role: "operator",
-            scopes: ["operator.read"],
-            clientId: "openclaw-macos",
-            clientMode: "cli",
-            isRepair: true,
-            ts: 1,
-          },
-          {
-            requestId: "req-new",
-            deviceId: "device-1",
-            publicKey: "pk",
-            role: "operator",
-            scopes: ["operator.read", "operator.pairing"],
-            clientId: "openclaw-ios",
-            clientMode: "agent",
-            isRepair: true,
-            ts: 2,
-          },
-        ],
-        paired: [],
-      })
-      .mockResolvedValueOnce({
-        pending: [
-          {
-            requestId: "req-new",
-            deviceId: "device-1",
-            publicKey: "pk",
-            role: "operator",
-            scopes: ["operator.read", "operator.pairing"],
-            clientId: "openclaw-ios",
-            clientMode: "agent",
-            isRepair: true,
-            ts: 2,
-          },
-        ],
-        paired: [],
-      });
+  it.each([
+    { name: "the original request snapshot is missing", original: null },
+    {
+      name: "the replacement request is not a compatible scope superset",
+      original: { scopes: ["operator.read", "operator.write"] },
+      replacement: { scopes: ["operator.pairing"] },
+    },
+    {
+      name: "the replacement request adds unrelated broader scopes",
+      replacement: { scopes: ["operator.read", "operator.write"] },
+    },
+    {
+      name: "the replacement request belongs to a different device",
+      replacement: { deviceId: "device-2" },
+    },
+    {
+      name: "the replacement request has a different public key",
+      original: { publicKey: "pk-old" },
+      replacement: { publicKey: "pk-new" },
+    },
+    {
+      name: "the replacement request changes the requested role set",
+      replacement: { roles: ["operator", "different-role"] },
+    },
+    {
+      name: "the replacement request conflicts with client metadata",
+      replacement: { clientId: "openclaw-ios", clientMode: "agent" },
+    },
+  ])("fails closed when $name", async ({ original, replacement }) => {
+    mockReplacementPairing({ original, replacement });
 
     await expect(runDevicesApprove(["req-old"])).rejects.toThrow(
       "local fallback pairing state does not contain the gateway request",

--- a/src/cli/plugins-cli.install.test.ts
+++ b/src/cli/plugins-cli.install.test.ts
@@ -316,20 +316,6 @@ function primeHookPackNpmFallback() {
   return { cfg, installedCfg };
 }
 
-function primeBlockedNpmPluginInstall(params: {
-  spec: string;
-  pluginId: string;
-  code?: "security_scan_blocked" | "security_scan_failed";
-}) {
-  loadConfig.mockReturnValue({} as OpenClawConfig);
-  mockClawHubPackageNotFound(params.spec);
-  installPluginFromNpmSpec.mockResolvedValue({
-    ok: false,
-    error: `Plugin "${params.pluginId}" installation blocked: dangerous code patterns detected: finding details`,
-    code: params.code ?? "security_scan_blocked",
-  });
-}
-
 function primeHookPackPathFallback(params: {
   tmpRoot: string;
   pluginInstallError: string;
@@ -1593,9 +1579,7 @@ describe("plugins cli install", () => {
   );
 
   it("does not show the non-ClawHub warning for explicit ClawHub installs", async () => {
-    const cfg = createEmptyPluginConfig();
-    const enabledCfg = createEnabledPluginConfig("demo");
-    loadConfig.mockReturnValue(cfg);
+    primeSuccessfulPluginPersistence("demo");
     parseClawHubPluginSpec.mockReturnValue({ name: "demo" });
     installPluginFromClawHub.mockResolvedValue(
       createClawHubInstallResult({
@@ -1605,12 +1589,6 @@ describe("plugins cli install", () => {
         channel: "official",
       }),
     );
-    enablePluginInConfig.mockReturnValue({ config: enabledCfg });
-    applyExclusiveSlotSelection.mockReturnValue({
-      config: enabledCfg,
-      warnings: [],
-    });
-
     await runPluginsCommand(["plugins", "install", "clawhub:demo"]);
 
     expect(runtimeLogsContain("outside ClawHub review")).toBe(false);
@@ -1991,16 +1969,9 @@ describe("plugins cli install", () => {
   });
 
   it("resolves exact official external plugin ids through their npm package", async () => {
-    const cfg = createEmptyPluginConfig();
-    const enabledCfg = createEnabledPluginConfig("brave");
-    loadConfig.mockReturnValue(cfg);
+    const { enabledCfg } = primeSuccessfulPluginPersistence("brave");
     findBundledPluginSourceMock.mockReturnValue(undefined);
     installPluginFromNpmSpec.mockResolvedValue(createNpmPluginInstallResult("brave"));
-    enablePluginInConfig.mockReturnValue({ config: enabledCfg });
-    applyExclusiveSlotSelection.mockReturnValue({
-      config: enabledCfg,
-      warnings: [],
-    });
 
     await runPluginsCommand(["plugins", "install", "brave"]);
 
@@ -2021,18 +1992,11 @@ describe("plugins cli install", () => {
   });
 
   it("passes third-party external catalog integrity with catalog install trust", async () => {
-    const cfg = createEmptyPluginConfig();
-    const enabledCfg = createEnabledPluginConfig("wecom-openclaw-plugin");
-    loadConfig.mockReturnValue(cfg);
+    primeSuccessfulPluginPersistence("wecom-openclaw-plugin");
     findBundledPluginSourceMock.mockReturnValue(undefined);
     installPluginFromNpmSpec.mockResolvedValue(
       createNpmPluginInstallResult("wecom-openclaw-plugin"),
     );
-    enablePluginInConfig.mockReturnValue({ config: enabledCfg });
-    applyExclusiveSlotSelection.mockReturnValue({
-      config: enabledCfg,
-      warnings: [],
-    });
 
     await runPluginsCommand(["plugins", "install", "wecom"]);
 
@@ -2047,16 +2011,9 @@ describe("plugins cli install", () => {
   it.each(OFFICIAL_EXTERNAL_NPM_INSTALLS_WITHOUT_INTEGRITY)(
     "keeps official external npm installs trusted without integrity for $pluginId",
     async ({ pluginId, npmSpec }) => {
-      const cfg = createEmptyPluginConfig();
-      const enabledCfg = createEnabledPluginConfig(pluginId);
-      loadConfig.mockReturnValue(cfg);
+      primeSuccessfulPluginPersistence(pluginId);
       findBundledPluginSourceMock.mockReturnValue(undefined);
       installPluginFromNpmSpec.mockResolvedValue(createNpmPluginInstallResult(pluginId));
-      enablePluginInConfig.mockReturnValue({ config: enabledCfg });
-      applyExclusiveSlotSelection.mockReturnValue({
-        config: enabledCfg,
-        warnings: [],
-      });
 
       await runPluginsCommand(["plugins", "install", pluginId]);
 
@@ -2095,15 +2052,8 @@ describe("plugins cli install", () => {
   });
 
   it("installs ordinary bare plugin specs through npm without ClawHub lookup", async () => {
-    const cfg = createEmptyPluginConfig();
-    const enabledCfg = createEnabledPluginConfig("demo");
-    loadConfig.mockReturnValue(cfg);
+    const { enabledCfg } = primeSuccessfulPluginPersistence("demo");
     installPluginFromNpmSpec.mockResolvedValue(createNpmPluginInstallResult("demo"));
-    enablePluginInConfig.mockReturnValue({ config: enabledCfg });
-    applyExclusiveSlotSelection.mockReturnValue({
-      config: enabledCfg,
-      warnings: [],
-    });
 
     await runAcknowledgedPluginsInstallCommand(["plugins", "install", "demo"]);
 
@@ -2120,9 +2070,7 @@ describe("plugins cli install", () => {
   });
 
   it("stores npm resolution metadata without changing the active plugin install selector", async () => {
-    const cfg = createEmptyPluginConfig();
-    const enabledCfg = createEnabledPluginConfig("demo");
-    loadConfig.mockReturnValue(cfg);
+    primeSuccessfulPluginPersistence("demo");
     installPluginFromNpmSpec.mockResolvedValue({
       ok: true,
       pluginId: "demo",
@@ -2135,12 +2083,6 @@ describe("plugins cli install", () => {
         integrity: "sha512-demo",
       },
     });
-    enablePluginInConfig.mockReturnValue({ config: enabledCfg });
-    applyExclusiveSlotSelection.mockReturnValue({
-      config: enabledCfg,
-      warnings: [],
-    });
-
     await runAcknowledgedPluginsInstallCommand(["plugins", "install", "demo"]);
 
     const record = persistedInstallRecord("demo");
@@ -2150,15 +2092,8 @@ describe("plugins cli install", () => {
   });
 
   it("passes bare npm selectors through npm without ClawHub lookup", async () => {
-    const cfg = createEmptyPluginConfig();
-    const enabledCfg = createEnabledPluginConfig("demo");
-    loadConfig.mockReturnValue(cfg);
+    primeSuccessfulPluginPersistence("demo");
     installPluginFromNpmSpec.mockResolvedValue(createNpmPluginInstallResult("demo"));
-    enablePluginInConfig.mockReturnValue({ config: enabledCfg });
-    applyExclusiveSlotSelection.mockReturnValue({
-      config: enabledCfg,
-      warnings: [],
-    });
 
     await runAcknowledgedPluginsInstallCommand(["plugins", "install", "demo@beta"]);
 
@@ -2167,17 +2102,8 @@ describe("plugins cli install", () => {
   });
 
   it("installs directly from npm when npm: prefix is used", async () => {
-    const cfg = createEmptyPluginConfig();
-    const enabledCfg = createEnabledPluginConfig("demo");
-
-    loadConfig.mockReturnValue(cfg);
+    const { enabledCfg } = primeSuccessfulPluginPersistence("demo");
     installPluginFromNpmSpec.mockResolvedValue(createNpmPluginInstallResult("demo"));
-    enablePluginInConfig.mockReturnValue({ config: enabledCfg });
-    recordPluginInstall.mockReturnValue(enabledCfg);
-    applyExclusiveSlotSelection.mockReturnValue({
-      config: enabledCfg,
-      warnings: [],
-    });
 
     await runAcknowledgedPluginsInstallCommand(["plugins", "install", "npm:demo"]);
 
@@ -2193,18 +2119,9 @@ describe("plugins cli install", () => {
   });
 
   it("installs npm-pack archives through npm install semantics", async () => {
-    const cfg = createEmptyPluginConfig();
-    const enabledCfg = createEnabledPluginConfig("demo");
+    const { enabledCfg } = primeSuccessfulPluginPersistence("demo");
     const archivePath = "/tmp/openclaw-demo-1.2.3.tgz";
-
-    loadConfig.mockReturnValue(cfg);
     installPluginFromNpmPackArchive.mockResolvedValue(createNpmPackPluginInstallResult("demo"));
-    enablePluginInConfig.mockReturnValue({ config: enabledCfg });
-    recordPluginInstall.mockReturnValue(enabledCfg);
-    applyExclusiveSlotSelection.mockReturnValue({
-      config: enabledCfg,
-      warnings: [],
-    });
 
     await runAcknowledgedPluginsInstallCommand(["plugins", "install", `npm-pack:${archivePath}`]);
 
@@ -2227,17 +2144,8 @@ describe("plugins cli install", () => {
   });
 
   it("keeps npm-prefixed official plugin ids on explicit npm semantics", async () => {
-    const cfg = createEmptyPluginConfig();
-    const enabledCfg = createEnabledPluginConfig("brave");
-
-    loadConfig.mockReturnValue(cfg);
+    primeSuccessfulPluginPersistence("brave");
     installPluginFromNpmSpec.mockResolvedValue(createNpmPluginInstallResult("brave"));
-    enablePluginInConfig.mockReturnValue({ config: enabledCfg });
-    recordPluginInstall.mockReturnValue(enabledCfg);
-    applyExclusiveSlotSelection.mockReturnValue({
-      config: enabledCfg,
-      warnings: [],
-    });
 
     await runAcknowledgedPluginsInstallCommand(["plugins", "install", "npm:brave"]);
 
@@ -2250,17 +2158,8 @@ describe("plugins cli install", () => {
   });
 
   it("marks explicit official npm package installs as trusted", async () => {
-    const cfg = createEmptyPluginConfig();
-    const enabledCfg = createEnabledPluginConfig("discord");
-
-    loadConfig.mockReturnValue(cfg);
+    primeSuccessfulPluginPersistence("discord");
     installPluginFromNpmSpec.mockResolvedValue(createNpmPluginInstallResult("discord"));
-    enablePluginInConfig.mockReturnValue({ config: enabledCfg });
-    recordPluginInstall.mockReturnValue(enabledCfg);
-    applyExclusiveSlotSelection.mockReturnValue({
-      config: enabledCfg,
-      warnings: [],
-    });
 
     await runPluginsCommand(["plugins", "install", "npm:@openclaw/discord"]);
 
@@ -2272,18 +2171,9 @@ describe("plugins cli install", () => {
   });
 
   it("marks scoped official npm package installs as trusted", async () => {
-    const cfg = createEmptyPluginConfig();
-    const enabledCfg = createEnabledPluginConfig("discord");
-
-    loadConfig.mockReturnValue(cfg);
+    primeSuccessfulPluginPersistence("discord");
     findBundledPluginSourceMock.mockReturnValue(undefined);
     installPluginFromNpmSpec.mockResolvedValue(createNpmPluginInstallResult("discord"));
-    enablePluginInConfig.mockReturnValue({ config: enabledCfg });
-    recordPluginInstall.mockReturnValue(enabledCfg);
-    applyExclusiveSlotSelection.mockReturnValue({
-      config: enabledCfg,
-      warnings: [],
-    });
 
     await runPluginsCommand(["plugins", "install", "@openclaw/discord"]);
 
@@ -2294,11 +2184,8 @@ describe("plugins cli install", () => {
   });
 
   it("uses bundled OpenClaw package specs instead of pinning stale managed npm overrides", async () => {
-    const cfg = createEmptyPluginConfig();
-    const enabledCfg = createEnabledPluginConfig("discord");
+    primeSuccessfulPluginPersistence("discord");
     const bundledPath = "/app/dist/extensions/discord";
-
-    loadConfig.mockReturnValue(cfg);
     findBundledPluginSourceMock.mockImplementation((params: unknown) => {
       const { lookup } = params as {
         lookup: { kind: "pluginId" | "npmSpec"; value: string };
@@ -2312,13 +2199,6 @@ describe("plugins cli install", () => {
           }
         : undefined;
     });
-    enablePluginInConfig.mockReturnValue({ config: enabledCfg });
-    recordPluginInstall.mockReturnValue(enabledCfg);
-    applyExclusiveSlotSelection.mockReturnValue({
-      config: enabledCfg,
-      warnings: [],
-    });
-
     await runPluginsCommand([
       "plugins",
       "install",
@@ -2344,20 +2224,11 @@ describe("plugins cli install", () => {
   });
 
   it("marks catalog npm package installs with alternate selectors as trusted", async () => {
-    const cfg = createEmptyPluginConfig();
-    const enabledCfg = createEnabledPluginConfig("wecom-openclaw-plugin");
-
-    loadConfig.mockReturnValue(cfg);
+    primeSuccessfulPluginPersistence("wecom-openclaw-plugin");
     findBundledPluginSourceMock.mockReturnValue(undefined);
     installPluginFromNpmSpec.mockResolvedValue(
       createNpmPluginInstallResult("wecom-openclaw-plugin"),
     );
-    enablePluginInConfig.mockReturnValue({ config: enabledCfg });
-    recordPluginInstall.mockReturnValue(enabledCfg);
-    applyExclusiveSlotSelection.mockReturnValue({
-      config: enabledCfg,
-      warnings: [],
-    });
 
     await runPluginsCommand(["plugins", "install", "@wecom/wecom-openclaw-plugin@latest"]);
 
@@ -2373,17 +2244,8 @@ describe("plugins cli install", () => {
 
   it("passes the active profile extensions dir to npm installs", async () => {
     const extensionsDir = useProfileExtensionsDir();
-    const cfg = createEmptyPluginConfig();
-    const enabledCfg = createEnabledPluginConfig("demo");
-
-    loadConfig.mockReturnValue(cfg);
+    primeSuccessfulPluginPersistence("demo");
     installPluginFromNpmSpec.mockResolvedValue(createNpmPluginInstallResult("demo"));
-    enablePluginInConfig.mockReturnValue({ config: enabledCfg });
-    recordPluginInstall.mockReturnValue(enabledCfg);
-    applyExclusiveSlotSelection.mockReturnValue({
-      config: enabledCfg,
-      warnings: [],
-    });
 
     await runAcknowledgedPluginsInstallCommand(["plugins", "install", "npm:demo"]);
 
@@ -2392,13 +2254,8 @@ describe("plugins cli install", () => {
   });
 
   it("passes npm: prefix installs through npm options without ClawHub lookup", async () => {
-    const cfg = createEmptyPluginConfig();
-    const enabledCfg = createEnabledPluginConfig("demo");
-
-    loadConfig.mockReturnValue(cfg);
+    primeSuccessfulPluginPersistence("demo");
     installPluginFromNpmSpec.mockResolvedValue(createNpmPluginInstallResult("demo"));
-    enablePluginInConfig.mockReturnValue({ config: enabledCfg });
-    recordPluginInstall.mockReturnValue(enabledCfg);
 
     await runAcknowledgedPluginsInstallCommand([
       "plugins",
@@ -2527,17 +2384,8 @@ describe("plugins cli install", () => {
   });
 
   it("installs directly from git when git: prefix is used", async () => {
-    const cfg = createEmptyPluginConfig();
-    const enabledCfg = createEnabledPluginConfig("demo");
-
-    loadConfig.mockReturnValue(cfg);
+    const { enabledCfg } = primeSuccessfulPluginPersistence("demo");
     installPluginFromGitSpec.mockResolvedValue(createGitPluginInstallResult("demo"));
-    enablePluginInConfig.mockReturnValue({ config: enabledCfg });
-    recordPluginInstall.mockReturnValue(enabledCfg);
-    applyExclusiveSlotSelection.mockReturnValue({
-      config: enabledCfg,
-      warnings: [],
-    });
 
     await runAcknowledgedPluginsInstallCommand([
       "plugins",
@@ -2723,10 +2571,7 @@ describe("plugins cli install", () => {
   it("passes the active profile extensions dir to local path installs", async () => {
     const extensionsDir = useProfileExtensionsDir();
     const localPluginDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-local-plugin-"));
-    const cfg = createEmptyPluginConfig();
-    const enabledCfg = createEnabledPluginConfig("demo");
-
-    loadConfig.mockReturnValue(cfg);
+    primeSuccessfulPluginPersistence("demo");
     installPluginFromPath.mockResolvedValue({
       ok: true,
       pluginId: "demo",
@@ -2734,13 +2579,6 @@ describe("plugins cli install", () => {
       version: "1.2.3",
       extensions: ["./dist/index.js"],
     });
-    enablePluginInConfig.mockReturnValue({ config: enabledCfg });
-    recordPluginInstall.mockReturnValue(enabledCfg);
-    applyExclusiveSlotSelection.mockReturnValue({
-      config: enabledCfg,
-      warnings: [],
-    });
-
     try {
       await runAcknowledgedPluginsInstallCommand(["plugins", "install", localPluginDir]);
     } finally {
@@ -2871,178 +2709,101 @@ describe("plugins cli install", () => {
     ).toBe(true);
   });
 
-  it("does not fall back to hook pack for local path when a no-flag security scan fails", async () => {
+  it.each([
+    {
+      name: "a no-flag security scan fails",
+      code: "security_scan_failed",
+      error: "plugin security scan failed",
+      flags: [],
+    },
+    {
+      name: "dangerous force unsafe install is set",
+      code: "security_scan_blocked",
+      error: "plugin blocked by security scan",
+      flags: ["--dangerously-force-unsafe-install"],
+    },
+    {
+      name: "security scan fails under dangerous force unsafe install",
+      code: "security_scan_failed",
+      error: "plugin security scan failed",
+      flags: ["--dangerously-force-unsafe-install"],
+    },
+  ] as const)("does not fall back to hook pack for local path when $name", async (testCase) => {
     const localPluginDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-local-plugin-"));
-    const pluginInstallError = "plugin security scan failed";
-
     loadConfig.mockReturnValue({} as OpenClawConfig);
     installPluginFromPath.mockResolvedValue({
       ok: false,
-      error: pluginInstallError,
-      code: "security_scan_failed",
+      error: testCase.error,
+      code: testCase.code,
     });
 
     try {
       await expect(
-        runAcknowledgedPluginsInstallCommand(["plugins", "install", localPluginDir]),
+        runAcknowledgedPluginsInstallCommand([
+          "plugins",
+          "install",
+          localPluginDir,
+          ...testCase.flags,
+        ]),
       ).rejects.toThrow("__exit__:1");
     } finally {
       fs.rmSync(localPluginDir, { recursive: true, force: true });
     }
 
     expect(installHooksFromPath).not.toHaveBeenCalled();
-    expect(runtimeErrors.at(-1)).toContain(pluginInstallError);
+    expect(runtimeErrors.at(-1)).toContain(testCase.error);
     expect(runtimeErrors.at(-1)).not.toContain("Also not a valid hook pack");
   });
 
-  it("does not fall back to hook pack for local path when dangerous force unsafe install is set", async () => {
-    const localPluginDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-local-plugin-"));
-    const cfg = {} as OpenClawConfig;
-    const pluginInstallError = "plugin blocked by security scan";
-
-    loadConfig.mockReturnValue(cfg);
-    installPluginFromPath.mockResolvedValue({
-      ok: false,
-      error: pluginInstallError,
+  it.each([
+    {
+      name: "dangerous force unsafe install is set",
       code: "security_scan_blocked",
-    });
-
-    try {
-      await expect(
-        runAcknowledgedPluginsInstallCommand([
-          "plugins",
-          "install",
-          localPluginDir,
-          "--dangerously-force-unsafe-install",
-        ]),
-      ).rejects.toThrow("__exit__:1");
-    } finally {
-      fs.rmSync(localPluginDir, { recursive: true, force: true });
-    }
-
-    expect(installHooksFromPath).not.toHaveBeenCalled();
-    expect(runtimeErrors.at(-1)).toContain(pluginInstallError);
-  });
-
-  it("does not fall back to hook pack for local path when security scan fails under dangerous force unsafe install", async () => {
-    const localPluginDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-local-plugin-"));
-    const cfg = {} as OpenClawConfig;
-    const pluginInstallError = "plugin security scan failed";
-
-    loadConfig.mockReturnValue(cfg);
-    installPluginFromPath.mockResolvedValue({
-      ok: false,
-      error: pluginInstallError,
-      code: "security_scan_failed",
-    });
-
-    try {
-      await expect(
-        runAcknowledgedPluginsInstallCommand([
-          "plugins",
-          "install",
-          localPluginDir,
-          "--dangerously-force-unsafe-install",
-        ]),
-      ).rejects.toThrow("__exit__:1");
-    } finally {
-      fs.rmSync(localPluginDir, { recursive: true, force: true });
-    }
-
-    expect(installHooksFromPath).not.toHaveBeenCalled();
-    expect(runtimeErrors.at(-1)).toContain(pluginInstallError);
-  });
-
-  it("does not fall back to hook pack for npm installs when dangerous force unsafe install is set", async () => {
-    const cfg = {} as OpenClawConfig;
-    const pluginInstallError = "plugin blocked by security scan";
-
-    loadConfig.mockReturnValue(cfg);
-    installPluginFromClawHub.mockResolvedValue({
-      ok: false,
-      error: "ClawHub /api/v1/packages/demo failed (404): Package not found",
-      code: "package_not_found",
-    });
-    installPluginFromNpmSpec.mockResolvedValue({
-      ok: false,
-      error: pluginInstallError,
+      error: "plugin blocked by security scan",
+      spec: "demo",
+      flags: ["--dangerously-force-unsafe-install"],
+    },
+    {
+      name: "a no-flag security scan blocks",
       code: "security_scan_blocked",
-    });
-
-    await expect(
-      runAcknowledgedPluginsInstallCommand([
-        "plugins",
-        "install",
-        "demo",
-        "--dangerously-force-unsafe-install",
-      ]),
-    ).rejects.toThrow("__exit__:1");
-
-    expect(installHooksFromNpmSpec).not.toHaveBeenCalled();
-    expect(runtimeErrors.at(-1)).toContain(pluginInstallError);
-  });
-
-  it("does not fall back to hook pack for npm installs when a no-flag security scan blocks", async () => {
-    primeBlockedNpmPluginInstall({
+      error:
+        'Plugin "unsafe-plugin" installation blocked: dangerous code patterns detected: finding details',
       spec: "@acme/unsafe-plugin",
-      pluginId: "unsafe-plugin",
-    });
-
-    await expect(
-      runAcknowledgedPluginsInstallCommand(["plugins", "install", "@acme/unsafe-plugin"]),
-    ).rejects.toThrow("__exit__:1");
-
-    expect(installHooksFromNpmSpec).not.toHaveBeenCalled();
-    expect(runtimeErrors.at(-1)).toContain('Plugin "unsafe-plugin" installation blocked');
-    expect(runtimeErrors.at(-1)).not.toContain("Also not a valid hook pack");
-  });
-
-  it("does not fall back to hook pack for npm installs when security scan fails under dangerous force unsafe install", async () => {
-    const cfg = {} as OpenClawConfig;
-    const pluginInstallError = "plugin security scan failed";
-
-    loadConfig.mockReturnValue(cfg);
-    installPluginFromClawHub.mockResolvedValue({
-      ok: false,
-      error: "ClawHub /api/v1/packages/demo failed (404): Package not found",
-      code: "package_not_found",
-    });
+      flags: [],
+    },
+    {
+      name: "security scan fails under dangerous force unsafe install",
+      code: "security_scan_failed",
+      error: "plugin security scan failed",
+      spec: "demo",
+      flags: ["--dangerously-force-unsafe-install"],
+    },
+  ] as const)("does not fall back to hook pack for npm installs when $name", async (testCase) => {
+    loadConfig.mockReturnValue({} as OpenClawConfig);
+    mockClawHubPackageNotFound(testCase.spec);
     installPluginFromNpmSpec.mockResolvedValue({
       ok: false,
-      error: pluginInstallError,
-      code: "security_scan_failed",
+      error: testCase.error,
+      code: testCase.code,
     });
 
     await expect(
       runAcknowledgedPluginsInstallCommand([
         "plugins",
         "install",
-        "demo",
-        "--dangerously-force-unsafe-install",
+        testCase.spec,
+        ...testCase.flags,
       ]),
     ).rejects.toThrow("__exit__:1");
 
     expect(installHooksFromNpmSpec).not.toHaveBeenCalled();
-    expect(runtimeErrors.at(-1)).toContain(pluginInstallError);
+    expect(runtimeErrors.at(-1)).toContain(testCase.error);
+    expect(runtimeErrors.at(-1)).not.toContain("Also not a valid hook pack");
   });
 
   it("still falls back to local hook pack when dangerous force unsafe install is set for non-security errors", async () => {
     const localHookDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-local-hook-pack-"));
-    const cfg = {} as OpenClawConfig;
-    const installedCfg = {
-      hooks: {
-        internal: {
-          installs: {
-            "demo-hooks": {
-              source: "path",
-              sourcePath: localHookDir,
-            },
-          },
-        },
-      },
-    } as OpenClawConfig;
-
-    loadConfig.mockReturnValue(cfg);
+    loadConfig.mockReturnValue({} as OpenClawConfig);
     installPluginFromPath.mockResolvedValue({
       ok: false,
       error: "package.json missing openclaw.plugin.json",
@@ -3055,7 +2816,7 @@ describe("plugins cli install", () => {
       targetDir: "/tmp/hooks/demo-hooks",
       version: "1.2.3",
     });
-    recordHookInstall.mockReturnValue(installedCfg);
+    recordHookInstall.mockReturnValue(createPathHookPackInstalledConfig(localHookDir));
 
     try {
       await runAcknowledgedPluginsInstallCommand([
@@ -3073,45 +2834,7 @@ describe("plugins cli install", () => {
   });
 
   it("still falls back to npm hook pack when dangerous force unsafe install is set for non-security errors", async () => {
-    const cfg = {} as OpenClawConfig;
-    const installedCfg = {
-      hooks: {
-        internal: {
-          installs: {
-            "demo-hooks": {
-              source: "npm",
-              spec: "@acme/demo-hooks@1.2.3",
-            },
-          },
-        },
-      },
-    } as OpenClawConfig;
-
-    loadConfig.mockReturnValue(cfg);
-    installPluginFromClawHub.mockResolvedValue({
-      ok: false,
-      error: "ClawHub /api/v1/packages/@acme/demo-hooks failed (404): Package not found",
-      code: "package_not_found",
-    });
-    installPluginFromNpmSpec.mockResolvedValue({
-      ok: false,
-      error: "package.json missing openclaw.plugin.json",
-      code: "missing_openclaw_extensions",
-    });
-    installHooksFromNpmSpec.mockResolvedValue({
-      ok: true,
-      hookPackId: "demo-hooks",
-      hooks: ["command-audit"],
-      targetDir: "/tmp/hooks/demo-hooks",
-      version: "1.2.3",
-      npmResolution: {
-        name: "@acme/demo-hooks",
-        version: "1.2.3",
-        resolvedSpec: "@acme/demo-hooks@1.2.3",
-        integrity: "sha256-demo",
-      },
-    });
-    recordHookInstall.mockReturnValue(installedCfg);
+    primeHookPackNpmFallback();
 
     await runAcknowledgedPluginsInstallCommand([
       "plugins",

--- a/src/cli/run-main.exit.test.ts
+++ b/src/cli/run-main.exit.test.ts
@@ -2660,74 +2660,42 @@ describe("runCli exit behavior", () => {
     }
   });
 
-  it("starts onboarding for bare root invocations before config exists", async () => {
-    readConfigFileSnapshotMock.mockResolvedValueOnce({
-      exists: false,
-      valid: true,
-      sourceConfig: {},
-    });
-
-    await withInteractiveTty(async () => {
-      await runCli(["node", "openclaw"]);
-    });
-
-    expect(readConfigFileSnapshotMock).toHaveBeenCalledTimes(1);
-    expect(setupWizardCommandMock).toHaveBeenCalledWith({});
-    expect(tryRouteCliMock).not.toHaveBeenCalled();
-    expect(buildProgramMock).not.toHaveBeenCalled();
-  });
-
-  it("starts onboarding for bare root invocations when config is empty", async () => {
-    readConfigFileSnapshotMock.mockResolvedValueOnce({
-      exists: true,
-      valid: true,
-      sourceConfig: {},
-    });
-
-    await withInteractiveTty(async () => {
-      await runCli(["node", "openclaw"]);
-    });
-
-    expect(readConfigFileSnapshotMock).toHaveBeenCalledTimes(1);
-    expect(setupWizardCommandMock).toHaveBeenCalledWith({});
-    expect(tryRouteCliMock).not.toHaveBeenCalled();
-    expect(buildProgramMock).not.toHaveBeenCalled();
-  });
-
-  it("starts onboarding for bare root invocations when config only has metadata", async () => {
-    readConfigFileSnapshotMock.mockResolvedValueOnce({
-      exists: true,
-      valid: true,
-      sourceConfig: {
-        $schema: "https://openclaw.ai/config.json",
-        meta: { updatedBy: "fixture" },
+  it.each([
+    {
+      name: "starts onboarding for bare root invocations before config exists",
+      snapshot: { exists: false, valid: true, sourceConfig: {} },
+    },
+    {
+      name: "starts onboarding for bare root invocations when config is empty",
+      snapshot: { exists: true, valid: true, sourceConfig: {} },
+    },
+    {
+      name: "starts onboarding for bare root invocations when config only has metadata",
+      snapshot: {
+        exists: true,
+        valid: true,
+        sourceConfig: {
+          $schema: "https://openclaw.ai/config.json",
+          meta: { updatedBy: "fixture" },
+        },
       },
-    });
-
-    await withInteractiveTty(async () => {
-      await runCli(["node", "openclaw"]);
-    });
-
-    expect(readConfigFileSnapshotMock).toHaveBeenCalledTimes(1);
-    expect(setupWizardCommandMock).toHaveBeenCalledWith({});
-    expect(tryRouteCliMock).not.toHaveBeenCalled();
-    expect(buildProgramMock).not.toHaveBeenCalled();
-  });
-
-  it("resumes onboarding when an interrupted first run only persisted risk acknowledgement", async () => {
-    readConfigFileSnapshotMock.mockResolvedValueOnce({
-      exists: true,
-      valid: true,
-      sourceConfig: {
-        meta: { updatedBy: "fixture" },
-        wizard: { securityAcknowledgedAt: "2026-07-13T00:00:00.000Z" },
+    },
+    {
+      name: "resumes onboarding when an interrupted first run only persisted risk acknowledgement",
+      snapshot: {
+        exists: true,
+        valid: true,
+        sourceConfig: {
+          meta: { updatedBy: "fixture" },
+          wizard: { securityAcknowledgedAt: "2026-07-13T00:00:00.000Z" },
+        },
       },
-    });
+    },
+  ])("$name", async ({ snapshot }) => {
+    readConfigFileSnapshotMock.mockResolvedValueOnce(snapshot);
+    await withInteractiveTty(async () => runCli(["node", "openclaw"]));
 
-    await withInteractiveTty(async () => {
-      await runCli(["node", "openclaw"]);
-    });
-
+    expect(readConfigFileSnapshotMock).toHaveBeenCalledOnce();
     expect(setupWizardCommandMock).toHaveBeenCalledWith({});
     expect(tryRouteCliMock).not.toHaveBeenCalled();
     expect(buildProgramMock).not.toHaveBeenCalled();

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -2129,15 +2129,9 @@ describe("update-cli", () => {
   });
 
   it("post-core resume mode persists the requested update channel with the updated process", async () => {
-    vi.mocked(readConfigFileSnapshot).mockResolvedValue({
-      ...baseSnapshot,
-      parsed: { update: { channel: "stable" } },
-      resolved: { update: { channel: "stable" } } as OpenClawConfig,
-      sourceConfig: { update: { channel: "stable" } } as OpenClawConfig,
-      runtimeConfig: { update: { channel: "stable" } } as OpenClawConfig,
-      config: { update: { channel: "stable" } } as OpenClawConfig,
-      hash: "stable-hash",
-    });
+    vi.mocked(readConfigFileSnapshot).mockResolvedValue(
+      configSnapshot({ update: { channel: "stable" } }, { hash: "stable-hash" }),
+    );
 
     await runPostCoreCommand(
       { restart: false },
@@ -2166,37 +2160,14 @@ describe("update-cli", () => {
   });
 
   it("post-core resume mode retries update channel persistence after config hash drift", async () => {
-    vi.mocked(readConfigFileSnapshot).mockResolvedValueOnce({
-      ...baseSnapshot,
-      parsed: { update: { channel: "stable" } },
-      resolved: { update: { channel: "stable" } } as OpenClawConfig,
-      sourceConfig: { update: { channel: "stable" } } as OpenClawConfig,
-      runtimeConfig: { update: { channel: "stable" } } as OpenClawConfig,
-      config: { update: { channel: "stable" } } as OpenClawConfig,
-      hash: "stable-hash",
-    });
+    vi.mocked(readConfigFileSnapshot).mockResolvedValueOnce(
+      configSnapshot({ update: { channel: "stable" } }, { hash: "stable-hash" }),
+    );
     const newerSnapshot = {
-      ...baseSnapshot,
-      parsed: {
+      ...configSnapshot({
         meta: { lastTouchedVersion: "2026.4.30" },
         update: { channel: "stable" },
-      },
-      resolved: {
-        meta: { lastTouchedVersion: "2026.4.30" },
-        update: { channel: "stable" },
-      } as OpenClawConfig,
-      sourceConfig: {
-        meta: { lastTouchedVersion: "2026.4.30" },
-        update: { channel: "stable" },
-      } as OpenClawConfig,
-      runtimeConfig: {
-        meta: { lastTouchedVersion: "2026.4.30" },
-        update: { channel: "stable" },
-      } as OpenClawConfig,
-      config: {
-        meta: { lastTouchedVersion: "2026.4.30" },
-        update: { channel: "stable" },
-      } as OpenClawConfig,
+      }),
       hash: "newer-hash",
     };
     vi.mocked(mutateConfigFileWithRetry).mockImplementationOnce(async (params) => {
@@ -2567,14 +2538,7 @@ describe("update-cli", () => {
         },
       },
     } as OpenClawConfig;
-    vi.mocked(readConfigFileSnapshot).mockResolvedValue({
-      ...baseSnapshot,
-      parsed: config,
-      resolved: config,
-      sourceConfig: config,
-      config,
-      runtimeConfig: config,
-    });
+    vi.mocked(readConfigFileSnapshot).mockResolvedValue(configSnapshot(config));
     loadInstalledPluginIndexInstallRecords.mockResolvedValueOnce({
       demo: {
         source: "npm",
@@ -3322,14 +3286,7 @@ describe("update-cli", () => {
     mockPackageInstallStatus(tempDir);
     readPackageVersion.mockResolvedValue("2026.6.33");
     const config = { update: { channel: "extended-stable" } } as OpenClawConfig;
-    vi.mocked(readConfigFileSnapshot).mockResolvedValue({
-      ...baseSnapshot,
-      parsed: config,
-      sourceConfig: config,
-      resolved: config,
-      runtimeConfig: config,
-      config,
-    });
+    vi.mocked(readConfigFileSnapshot).mockResolvedValue(configSnapshot(config));
 
     await updateCommand({ yes: true, restart: false });
 
@@ -3366,14 +3323,7 @@ describe("update-cli", () => {
     const tempDir = createCaseDir("openclaw-update");
     mockPackageInstallStatus(tempDir);
     const config = { update: { channel: "extended-stable" } } as OpenClawConfig;
-    vi.mocked(readConfigFileSnapshot).mockResolvedValue({
-      ...baseSnapshot,
-      parsed: config,
-      sourceConfig: config,
-      resolved: config,
-      runtimeConfig: config,
-      config,
-    });
+    vi.mocked(readConfigFileSnapshot).mockResolvedValue(configSnapshot(config));
     vi.mocked(resolveExtendedStablePackage).mockResolvedValueOnce({
       status: "failed",
       reason: "selector_query_failed",
@@ -3397,14 +3347,7 @@ describe("update-cli", () => {
     mockPackageInstallStatus(tempDir);
     if (!explicit) {
       const config = { update: { channel: "extended-stable" } } as OpenClawConfig;
-      vi.mocked(readConfigFileSnapshot).mockResolvedValue({
-        ...baseSnapshot,
-        parsed: config,
-        sourceConfig: config,
-        resolved: config,
-        runtimeConfig: config,
-        config,
-      });
+      vi.mocked(readConfigFileSnapshot).mockResolvedValue(configSnapshot(config));
     }
 
     await updateCommand({


### PR DESCRIPTION
## What Problem This Solves

The core CLI regression suite repeatedly constructed the same device-pairing requests, plugin-install fixtures, onboarding configurations, and update snapshots. That duplication made security-sensitive device approval behavior unnecessarily difficult to audit and slowed routine test maintenance.

## Why This Change Was Made

This maintainer-requested, AI-assisted test consolidation reuses existing plugin-install and update snapshot helpers, introduces one exact-shape device repair fixture, and preserves each pairing authorization failure, ClawHub install-safety outcome, first-run onboarding case, and update configuration case as a separately executed named test. It changes no production code, CLI options, configuration, snapshots, coverage thresholds, or public behavior.

## User Impact

No user-visible behavior changes. Contributors and maintainers get a smaller, clearer CLI regression suite while retaining fail-closed device approval, safe plugin installation, interactive onboarding, and update coverage.

## Evidence

- Frozen comparison base: `16d2b7e46784c75eb5d57329269e9fd47222d2ef`.
- Test-only reduction: 4 files, **+207/-1025; 818 fewer lines**.
- Matched Linux V8 coverage across the exact four CLI production modules, with inherited CLI coverage exclusions explicitly replaced:
  - Tests: **598 passed before; 598 passed after**.
  - Lines: **564/714 (78.99%) before and after**.
  - Branches: **347/461 (75.27%) before and after**.
  - Statements: **583/737 (79.10%) before and after**.
  - Functions: **98/143 (68.53%) before and after**.
- Remote proof: Blacksmith Testbox `tbx_01kygzethvefnzgmzveefv775v`.
- Exact focused command:

```text
node scripts/run-vitest.mjs run --config test/vitest/vitest.cli.config.ts src/cli/devices-cli.test.ts src/cli/update-cli.test.ts src/cli/run-main.exit.test.ts src/cli/plugins-cli.install.test.ts --coverage --coverage.provider=v8 --coverage.include=src/cli/devices-cli.ts --coverage.include=src/cli/update-cli.ts --coverage.include=src/cli/run-main.ts --coverage.include=src/cli/plugins-cli.ts --coverage.exclude=**/*.test.ts --coverage.exclude=**/node_modules/** --coverage.reporter=text-summary --coverage.reporter=json-summary
```

- Structured independent review: `.agents/skills/autoreview/scripts/autoreview --mode uncommitted`; clean, no actionable findings.
- Remote changed gate: `corepack pnpm check:changed`.
