### PR TITLE
refactor(ui): consolidate chat lifecycle regression tests

### DIFF
--- a/ui/src/pages/chat/chat-gateway.test.ts
+++ b/ui/src/pages/chat/chat-gateway.test.ts
@@ -56,6 +56,20 @@ function expectTextChatMessage(message: unknown, role: string, text: string): vo
   expect(record.content).toEqual([{ type: "text", text }]);
 }
 
+function createTextChatMessage(
+  role: "assistant" | "user",
+  text: string,
+  metadata?: Record<string, unknown>,
+  timestamp?: number,
+) {
+  return {
+    role,
+    content: [{ type: "text" as const, text }],
+    ...(metadata ? { __openclaw: metadata } : {}),
+    ...(timestamp === undefined ? {} : { timestamp }),
+  };
+}
+
 function createActiveStreamingState() {
   return createState({
     sessionKey: "main",
@@ -445,127 +459,62 @@ describe("handleChatGatewayEvent", () => {
     expect(state.chatRunId).toBe("run-1");
   });
 
-  it("appends gateway deltaText when the cumulative snapshot matches the current prefix", () => {
-    const state = createState({
-      sessionKey: "main",
-      chatRunId: "run-1",
-      chatStream: "Live",
-    });
-    const payload: ChatEventPayload = {
-      runId: "run-1",
-      sessionKey: "main",
-      state: "delta",
-      deltaText: " reply",
-      message: {
-        role: "assistant",
-        content: [{ type: "text", text: "Live reply" }],
-      },
-    };
-
-    expect(handleChatGatewayEvent(state, payload)).toBe("delta");
-    expect(state.chatStream).toBe("Live reply");
-  });
-
-  it("uses the cumulative snapshot when the first observed delta joins mid-stream", () => {
-    const state = createState({
-      sessionKey: "main",
-      chatRunId: "run-1",
-      chatStream: null,
-    });
-    const payload: ChatEventPayload = {
-      runId: "run-1",
-      sessionKey: "main",
-      state: "delta",
-      deltaText: " reply",
-      message: {
-        role: "assistant",
-        content: [{ type: "text", text: "Live reply" }],
-      },
-    };
-
-    expect(handleChatGatewayEvent(state, payload)).toBe("delta");
-    expect(state.chatStream).toBe("Live reply");
-  });
-
-  it("appends gateway deltaText when no full message snapshot is present", () => {
-    const state = createState({
-      sessionKey: "main",
-      chatRunId: "run-1",
-      chatStream: "Live",
-    });
-    const payload: ChatEventPayload = {
-      runId: "run-1",
-      sessionKey: "main",
-      state: "delta",
-      deltaText: " reply",
-    };
-
-    expect(handleChatGatewayEvent(state, payload)).toBe("delta");
-    expect(state.chatStream).toBe("Live reply");
-  });
-
-  it("uses the cumulative snapshot when a missed delta would make append stale", () => {
-    const state = createState({
-      sessionKey: "main",
-      chatRunId: "run-1",
-      chatStream: "Hello",
-    });
-    const payload: ChatEventPayload = {
-      runId: "run-1",
-      sessionKey: "main",
-      state: "delta",
-      deltaText: "!",
-      message: {
-        role: "assistant",
-        content: [{ type: "text", text: "Hello world!" }],
-      },
-    };
-
-    expect(handleChatGatewayEvent(state, payload)).toBe("delta");
-    expect(state.chatStream).toBe("Hello world!");
-  });
-
-  it("uses the cumulative snapshot when a same-length missed replacement changes the prefix", () => {
-    const state = createState({
-      sessionKey: "main",
-      chatRunId: "run-1",
-      chatStream: "AB",
-    });
-    const payload: ChatEventPayload = {
-      runId: "run-1",
-      sessionKey: "main",
-      state: "delta",
-      deltaText: "E",
-      message: {
-        role: "assistant",
-        content: [{ type: "text", text: "CDE" }],
-      },
-    };
-
-    expect(handleChatGatewayEvent(state, payload)).toBe("delta");
-    expect(state.chatStream).toBe("CDE");
-  });
-
-  it("replaces the stream when gateway deltaText marks a replacement", () => {
-    const state = createState({
-      sessionKey: "main",
-      chatRunId: "run-1",
-      chatStream: "Alpha beta",
-    });
-    const payload: ChatEventPayload = {
-      runId: "run-1",
-      sessionKey: "main",
-      state: "delta",
-      deltaText: "Alpha",
+  it.each([
+    {
+      name: "appends gateway deltaText when the cumulative snapshot matches the current prefix",
+      previous: "Live",
+      delta: " reply",
+      snapshot: "Live reply",
+      expected: "Live reply",
+    },
+    {
+      name: "uses the cumulative snapshot when the first observed delta joins mid-stream",
+      previous: null,
+      delta: " reply",
+      snapshot: "Live reply",
+      expected: "Live reply",
+    },
+    {
+      name: "appends gateway deltaText when no full message snapshot is present",
+      previous: "Live",
+      delta: " reply",
+      expected: "Live reply",
+    },
+    {
+      name: "uses the cumulative snapshot when a missed delta would make append stale",
+      previous: "Hello",
+      delta: "!",
+      snapshot: "Hello world!",
+      expected: "Hello world!",
+    },
+    {
+      name: "uses the cumulative snapshot when a same-length missed replacement changes the prefix",
+      previous: "AB",
+      delta: "E",
+      snapshot: "CDE",
+      expected: "CDE",
+    },
+    {
+      name: "replaces the stream when gateway deltaText marks a replacement",
+      previous: "Alpha beta",
+      delta: "Alpha",
+      snapshot: "ignored snapshot",
       replace: true,
-      message: {
-        role: "assistant",
-        content: [{ type: "text", text: "ignored snapshot" }],
-      },
+      expected: "Alpha",
+    },
+  ])("$name", ({ previous, delta, snapshot, replace, expected }) => {
+    const state = createState({ sessionKey: "main", chatRunId: "run-1", chatStream: previous });
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "delta",
+      deltaText: delta,
+      ...(snapshot === undefined ? {} : { message: createTextChatMessage("assistant", snapshot) }),
+      ...(replace ? { replace: true } : {}),
     };
 
     expect(handleChatGatewayEvent(state, payload)).toBe("delta");
-    expect(state.chatStream).toBe("Alpha");
+    expect(state.chatStream).toBe(expected);
   });
 
   it("adopts the run id for selected-session live deltas observed from another channel", () => {
@@ -1484,506 +1433,304 @@ describe("handleChatGatewayEvent", () => {
     expect(state.chatStreamSegments).toEqual([]);
   });
 
-  it("processes aborted from own run and keeps partial assistant message", () => {
-    const existingMessage = {
-      role: "user",
-      content: [{ type: "text", text: "Hi" }],
-      timestamp: 1,
-    };
-    const partialMessage = {
-      role: "assistant",
-      content: [{ type: "text", text: "Partial reply" }],
-      timestamp: 2,
-    };
+  it.each([
+    {
+      name: "processes aborted from own run and keeps partial assistant message",
+      stream: "Partial reply",
+      message: createTextChatMessage("assistant", "Partial reply", undefined, 2),
+      expectedText: "Partial reply",
+      preservePayload: true,
+      trackAssignments: true,
+    },
+    {
+      name: "falls back to streamed partial when aborted payload message is invalid",
+      stream: "Partial reply",
+      message: "not-an-assistant-message",
+      expectedText: "Partial reply",
+    },
+    {
+      name: "falls back to streamed partial when aborted payload has non-assistant role",
+      stream: "Partial reply",
+      message: createTextChatMessage("user", "unexpected"),
+      expectedText: "Partial reply",
+    },
+    {
+      name: "processes aborted from own run without message and empty stream",
+      stream: "",
+    },
+  ])("$name", ({ stream, message, expectedText, preservePayload, trackAssignments }) => {
+    const existing = createTextChatMessage("user", "Hi", undefined, 1);
     const state = createState({
       sessionKey: "main",
       chatRunId: "run-1",
-      chatStream: "Partial reply",
+      chatStream: stream,
       chatStreamStartedAt: 100,
-      chatMessages: [existingMessage],
-    });
-    const payload: ChatEventPayload = {
-      runId: "run-1",
-      sessionKey: "main",
-      state: "aborted",
-      message: partialMessage,
-    };
-    const assignments = trackChatMessagesAssignments(state);
-
-    expect(handleChatGatewayEvent(state, payload)).toBe("aborted");
-    expect(assignments.at(-1)).toMatchObject({
-      chatRunId: "run-1",
-      chatStream: "Partial reply",
-    });
-    expect(state.chatRunId).toBe(null);
-    expect(state.chatStream).toBe(null);
-    expect(state.chatStreamStartedAt).toBe(null);
-    expect(state.chatMessages).toEqual([existingMessage, partialMessage]);
-  });
-
-  it("falls back to streamed partial when aborted payload message is invalid", () => {
-    const existingMessage = {
-      role: "user",
-      content: [{ type: "text", text: "Hi" }],
-      timestamp: 1,
-    };
-    const state = createState({
-      sessionKey: "main",
-      chatRunId: "run-1",
-      chatStream: "Partial reply",
-      chatStreamStartedAt: 100,
-      chatMessages: [existingMessage],
+      chatMessages: [existing],
     });
     const payload = {
       runId: "run-1",
       sessionKey: "main",
       state: "aborted",
-      message: "not-an-assistant-message",
+      ...(message === undefined ? {} : { message }),
     } as unknown as ChatEventPayload;
+    const assignments = trackAssignments ? trackChatMessagesAssignments(state) : undefined;
 
     expect(handleChatGatewayEvent(state, payload)).toBe("aborted");
-    expect(state.chatRunId).toBe(null);
-    expect(state.chatStream).toBe(null);
-    expect(state.chatStreamStartedAt).toBe(null);
-    expect(state.chatMessages).toHaveLength(2);
-    expect(state.chatMessages[0]).toEqual(existingMessage);
-    expectTextChatMessage(state.chatMessages[1], "assistant", "Partial reply");
+    expect(state.chatRunId).toBeNull();
+    expect(state.chatStream).toBeNull();
+    expect(state.chatStreamStartedAt).toBeNull();
+    expect(state.chatMessages[0]).toEqual(existing);
+    expect(state.chatMessages).toHaveLength(expectedText ? 2 : 1);
+    if (expectedText) {
+      expectTextChatMessage(state.chatMessages[1], "assistant", expectedText);
+    }
+    if (preservePayload) {
+      expect(state.chatMessages[1]).toEqual(message);
+    }
+    if (assignments) {
+      expect(assignments.at(-1)).toMatchObject({
+        chatRunId: "run-1",
+        chatStream: stream,
+      });
+    }
   });
+  type TerminalErrorFixture = {
+    stream?: string | null;
+    previous?: ReturnType<typeof createTextChatMessage>[];
+    segments?: Array<{ text: string; ts: number; toolCallId?: string }>;
+    message?: Record<string, unknown>;
+    error: string;
+    expected: Array<readonly ["assistant" | "user", string]>;
+    verify?: (state: ChatState) => void;
+  };
 
-  it("falls back to streamed partial when aborted payload has non-assistant role", () => {
-    const existingMessage = {
-      role: "user",
-      content: [{ type: "text", text: "Hi" }],
-      timestamp: 1,
-    };
-    const state = createState({
-      sessionKey: "main",
-      chatRunId: "run-1",
-      chatStream: "Partial reply",
-      chatStreamStartedAt: 100,
-      chatMessages: [existingMessage],
-    });
-    const payload: ChatEventPayload = {
-      runId: "run-1",
-      sessionKey: "main",
-      state: "aborted",
-      message: {
-        role: "user",
-        content: [{ type: "text", text: "unexpected" }],
+  it.each([
+    {
+      name: "keeps error events outside the assistant transcript",
+      create(): TerminalErrorFixture {
+        const error = 'No API key found for provider "openai".';
+        return {
+          previous: [createTextChatMessage("user", "Ping", undefined, 1)],
+          message: createTextChatMessage("assistant", `Error: ${error}`, undefined, 10),
+          error,
+          expected: [["user", "Ping"]],
+        };
       },
-    };
-
-    expect(handleChatGatewayEvent(state, payload)).toBe("aborted");
-    expect(state.chatMessages).toHaveLength(2);
-    expectTextChatMessage(state.chatMessages[1], "assistant", "Partial reply");
-  });
-
-  it("processes aborted from own run without message and empty stream", () => {
-    const existingMessage = {
-      role: "user",
-      content: [{ type: "text", text: "Hi" }],
-      timestamp: 1,
-    };
-    const state = createState({
-      sessionKey: "main",
-      chatRunId: "run-1",
-      chatStream: "",
-      chatStreamStartedAt: 100,
-      chatMessages: [existingMessage],
-    });
-    const payload: ChatEventPayload = {
-      runId: "run-1",
-      sessionKey: "main",
-      state: "aborted",
-    };
-
-    expect(handleChatGatewayEvent(state, payload)).toBe("aborted");
-    expect(state.chatRunId).toBe(null);
-    expect(state.chatStream).toBe(null);
-    expect(state.chatStreamStartedAt).toBe(null);
-    expect(state.chatMessages).toEqual([existingMessage]);
-  });
-
-  it("keeps error events outside the assistant transcript", () => {
-    const existingMessage = {
-      role: "user",
-      content: [{ type: "text", text: "Ping" }],
-      timestamp: 1,
-    };
-    const state = createState({
-      sessionKey: "main",
-      chatRunId: "run-1",
-      chatMessages: [existingMessage],
-    });
-    const payload: ChatEventPayload = {
-      runId: "run-1",
-      sessionKey: "main",
-      state: "error",
-      errorMessage: 'No API key found for provider "openai".',
-      message: {
-        role: "assistant",
-        content: [{ type: "text", text: 'Error: No API key found for provider "openai".' }],
-        timestamp: 10,
+    },
+    {
+      name: "keeps streamed assistant text visible when an error ends the run",
+      create(): TerminalErrorFixture {
+        return {
+          previous: [createTextChatMessage("user", "Ping", undefined, 1)],
+          stream: "Partial answer before gateway error.",
+          error: "gateway disconnected",
+          expected: [
+            ["user", "Ping"],
+            ["assistant", "Partial answer before gateway error."],
+          ],
+        };
       },
-    };
-
-    expect(handleChatGatewayEvent(state, payload)).toBe("error");
-    expect(state.chatRunId).toBe(null);
-    expect(state.chatMessages).toEqual([existingMessage]);
-    expect(state.chatRunError).toEqual({
-      summary: 'Error: No API key found for provider "openai".',
-    });
-  });
-
-  it("keeps streamed assistant text visible when an error ends the run", () => {
-    const existingMessage = {
-      role: "user",
-      content: [{ type: "text", text: "Ping" }],
-      timestamp: 1,
-    };
+    },
+    {
+      name: "keeps streamed text without appending the error payload message",
+      create(): TerminalErrorFixture {
+        return {
+          stream: "Partial answer before gateway error.",
+          message: {
+            ...createTextChatMessage("assistant", "Error: gateway disconnected", undefined, 101),
+            metadata: { source: "gateway" },
+          },
+          error: "gateway disconnected",
+          expected: [["assistant", "Partial answer before gateway error."]],
+        };
+      },
+    },
+    {
+      name: "uses the gateway error when the payload message repeats the streamed text",
+      create(): TerminalErrorFixture {
+        const text = "Partial answer before gateway error.";
+        return {
+          stream: text,
+          message: createTextChatMessage("assistant", text, undefined, 101),
+          error: "gateway disconnected",
+          expected: [["assistant", text]],
+        };
+      },
+    },
+    {
+      name: "preserves terminal assistant content that extends the streamed text",
+      create(): TerminalErrorFixture {
+        const text = "Partial answer before gateway error. Final detail.";
+        return {
+          stream: "Partial answer before gateway error.",
+          message: createTextChatMessage("assistant", text, undefined, 101),
+          error: "gateway disconnected",
+          expected: [["assistant", text]],
+        };
+      },
+    },
+    {
+      name: "preserves streamed text before a differing terminal assistant message",
+      create(): TerminalErrorFixture {
+        const terminal = createTextChatMessage(
+          "assistant",
+          "Configure provider auth, then try again.",
+          undefined,
+          101,
+        );
+        return {
+          stream: "Partial answer before gateway error.",
+          message: terminal,
+          error: "gateway disconnected",
+          expected: [
+            ["assistant", "Partial answer before gateway error."],
+            ["assistant", "Configure provider auth, then try again."],
+          ],
+          verify: (state) => expect(state.chatMessages[1]).toEqual(terminal),
+        };
+      },
+    },
+    {
+      name: "preserves terminal extensions after a tool splits the stream",
+      create(): TerminalErrorFixture {
+        const text = "First thought. After tool. Final detail.";
+        return {
+          stream: "After tool.",
+          segments: [{ text: "First thought.", ts: 90, toolCallId: "call-1" }],
+          message: createTextChatMessage("assistant", text, undefined, 101),
+          error: "gateway disconnected",
+          expected: [["assistant", text]],
+        };
+      },
+    },
+    {
+      name: "preserves a split stream when the terminal message only overlaps its prefix",
+      create(): TerminalErrorFixture {
+        const terminal = createTextChatMessage(
+          "assistant",
+          "First thought. Configure provider auth.",
+          undefined,
+          101,
+        );
+        return {
+          stream: "After tool.",
+          segments: [{ text: "First thought.", ts: 90, toolCallId: "call-1" }],
+          message: terminal,
+          error: "gateway disconnected",
+          expected: [
+            ["assistant", "First thought."],
+            ["assistant", "After tool."],
+            ["assistant", "First thought. Configure provider auth."],
+          ],
+          verify: (state) => expect(state.chatMessages[2]).toEqual(terminal),
+        };
+      },
+    },
+    {
+      name: "preserves terminal extensions when split stream punctuation is adjacent",
+      create(): TerminalErrorFixture {
+        return {
+          stream: ", world",
+          segments: [{ text: "Hello", ts: 90, toolCallId: "call-1" }],
+          message: createTextChatMessage("assistant", "Hello, world!", undefined, 101),
+          error: "gateway disconnected",
+          expected: [["assistant", "Hello, world!"]],
+        };
+      },
+    },
+    {
+      name: "keeps stream segments visible when an error ends after a tool event",
+      create(): TerminalErrorFixture {
+        return {
+          previous: [createTextChatMessage("user", "Ping", undefined, 1)],
+          stream: null,
+          segments: [{ text: "Visible text before tool.", ts: 100 }],
+          error: "gateway disconnected",
+          expected: [
+            ["user", "Ping"],
+            ["assistant", "Visible text before tool."],
+          ],
+        };
+      },
+    },
+    {
+      name: "does not let a substring-matching error projection replace streamed text",
+      create(): TerminalErrorFixture {
+        return {
+          stream: "OK",
+          message: createTextChatMessage(
+            "assistant",
+            "Error: provider said NOT OK yet",
+            undefined,
+            101,
+          ),
+          error: "provider said NOT OK yet",
+          expected: [["assistant", "OK"]],
+        };
+      },
+    },
+    {
+      name: "keeps the post-tool stream tail without appending the error projection",
+      create(): TerminalErrorFixture {
+        return {
+          stream: "First thought. After tool.",
+          segments: [{ text: "First thought.", ts: 90 }],
+          message: createTextChatMessage(
+            "assistant",
+            "Error: gateway disconnected",
+            undefined,
+            101,
+          ),
+          error: "gateway disconnected",
+          expected: [
+            ["assistant", "First thought."],
+            ["assistant", "After tool."],
+          ],
+        };
+      },
+    },
+    {
+      name: "does not append legacy assistant-shaped error projections",
+      create(): TerminalErrorFixture {
+        return {
+          message: createTextChatMessage("assistant", "Error: raw gateway error", undefined, 10),
+          error: "raw gateway error",
+          expected: [],
+          verify: (state) => expect(state.lastError).toBeNull(),
+        };
+      },
+    },
+  ])("$name", (fixture) => {
+    const { stream, previous, segments, message, error, expected, verify } = fixture.create();
     const state = createState({
       sessionKey: "main",
       chatRunId: "run-1",
-      chatMessages: [existingMessage],
-      chatStream: "Partial answer before gateway error.",
-      chatStreamStartedAt: 100,
-    });
+      ...(previous ? { chatMessages: previous } : {}),
+      ...(stream === undefined
+        ? {}
+        : { chatStream: stream, chatStreamStartedAt: stream ? 100 : null }),
+    }) as ChatState & { chatStreamSegments?: TerminalErrorFixture["segments"] };
+    if (segments) {
+      state.chatStreamSegments = segments;
+    }
     const payload: ChatEventPayload = {
       runId: "run-1",
       sessionKey: "main",
       state: "error",
-      errorMessage: "gateway disconnected",
+      errorMessage: error,
+      ...(message ? { message } : {}),
     };
 
     expect(handleChatGatewayEvent(state, payload)).toBe("error");
-    expect(state.chatRunId).toBe(null);
-    expect(state.chatStream).toBe(null);
-    expect(state.chatStreamStartedAt).toBe(null);
-    expect(state.chatMessages).toHaveLength(2);
-    expect(state.chatMessages[0]).toEqual(existingMessage);
-    expectTextChatMessage(
-      state.chatMessages[1],
-      "assistant",
-      "Partial answer before gateway error.",
-    );
-    expect(state.chatRunError).toEqual({ summary: "Error: gateway disconnected" });
+    expect(state.chatRunId).toBeNull();
+    expect(state.chatStream).toBeNull();
+    expect(state.chatMessages).toHaveLength(expected.length);
+    for (const [index, [role, text]] of expected.entries()) {
+      expectTextChatMessage(state.chatMessages[index], role, text);
+    }
+    expect(state.chatRunError).toEqual({ summary: `Error: ${error}` });
+    verify?.(state);
   });
-
-  it("keeps streamed text without appending the error payload message", () => {
-    const message = {
-      role: "assistant",
-      content: [{ type: "text", text: "Error: gateway disconnected" }],
-      timestamp: 101,
-      metadata: { source: "gateway" },
-    };
-    const state = createState({
-      sessionKey: "main",
-      chatRunId: "run-1",
-      chatStream: "Partial answer before gateway error.",
-      chatStreamStartedAt: 100,
-    });
-    const payload: ChatEventPayload = {
-      runId: "run-1",
-      sessionKey: "main",
-      state: "error",
-      errorMessage: "gateway disconnected",
-      message,
-    };
-
-    expect(handleChatGatewayEvent(state, payload)).toBe("error");
-    expect(state.chatMessages).toHaveLength(1);
-    expectTextChatMessage(
-      state.chatMessages[0],
-      "assistant",
-      "Partial answer before gateway error.",
-    );
-  });
-
-  it("uses the gateway error when the payload message repeats the streamed text", () => {
-    const partialText = "Partial answer before gateway error.";
-    const state = createState({
-      sessionKey: "main",
-      chatRunId: "run-1",
-      chatStream: partialText,
-      chatStreamStartedAt: 100,
-    });
-
-    expect(
-      handleChatGatewayEvent(state, {
-        runId: "run-1",
-        sessionKey: "main",
-        state: "error",
-        errorMessage: "gateway disconnected",
-        message: {
-          role: "assistant",
-          content: [{ type: "text", text: partialText }],
-          timestamp: 101,
-        },
-      }),
-    ).toBe("error");
-    expect(state.chatMessages).toHaveLength(1);
-    expectTextChatMessage(state.chatMessages[0], "assistant", partialText);
-    expect(state.chatRunError).toEqual({ summary: "Error: gateway disconnected" });
-  });
-
-  it("preserves terminal assistant content that extends the streamed text", () => {
-    const message = {
-      role: "assistant",
-      content: [{ type: "text", text: "Partial answer before gateway error. Final detail." }],
-      timestamp: 101,
-    };
-    const state = createState({
-      sessionKey: "main",
-      chatRunId: "run-1",
-      chatStream: "Partial answer before gateway error.",
-      chatStreamStartedAt: 100,
-    });
-    const payload: ChatEventPayload = {
-      runId: "run-1",
-      sessionKey: "main",
-      state: "error",
-      errorMessage: "gateway disconnected",
-      message,
-    };
-
-    expect(handleChatGatewayEvent(state, payload)).toBe("error");
-    expect(state.chatMessages).toHaveLength(1);
-    expectTextChatMessage(
-      state.chatMessages[0],
-      "assistant",
-      "Partial answer before gateway error. Final detail.",
-    );
-    expect(state.chatRunError).toEqual({ summary: "Error: gateway disconnected" });
-  });
-
-  it("preserves streamed text before a differing terminal assistant message", () => {
-    const terminalMessage = {
-      role: "assistant",
-      content: [{ type: "text", text: "Configure provider auth, then try again." }],
-      timestamp: 101,
-    };
-    const state = createState({
-      sessionKey: "main",
-      chatRunId: "run-1",
-      chatStream: "Partial answer before gateway error.",
-      chatStreamStartedAt: 100,
-    });
-
-    expect(
-      handleChatGatewayEvent(state, {
-        runId: "run-1",
-        sessionKey: "main",
-        state: "error",
-        errorMessage: "gateway disconnected",
-        message: terminalMessage,
-      }),
-    ).toBe("error");
-    expect(state.chatMessages).toHaveLength(2);
-    expectTextChatMessage(
-      state.chatMessages[0],
-      "assistant",
-      "Partial answer before gateway error.",
-    );
-    expect(state.chatMessages[1]).toEqual(terminalMessage);
-  });
-
-  it("preserves terminal extensions after a tool splits the stream", () => {
-    const message = {
-      role: "assistant",
-      content: [{ type: "text", text: "First thought. After tool. Final detail." }],
-      timestamp: 101,
-    };
-    const state = createState({
-      sessionKey: "main",
-      chatRunId: "run-1",
-      chatStream: "After tool.",
-      chatStreamStartedAt: 100,
-    }) as ChatState & {
-      chatStreamSegments: Array<{ text: string; ts: number; toolCallId: string }>;
-    };
-    state.chatStreamSegments = [{ text: "First thought.", ts: 90, toolCallId: "call-1" }];
-
-    expect(
-      handleChatGatewayEvent(state, {
-        runId: "run-1",
-        sessionKey: "main",
-        state: "error",
-        errorMessage: "gateway disconnected",
-        message,
-      }),
-    ).toBe("error");
-    expect(state.chatMessages).toHaveLength(1);
-    expectTextChatMessage(
-      state.chatMessages[0],
-      "assistant",
-      "First thought. After tool. Final detail.",
-    );
-    expect(state.chatRunError).toEqual({ summary: "Error: gateway disconnected" });
-  });
-
-  it("preserves a split stream when the terminal message only overlaps its prefix", () => {
-    const terminalMessage = {
-      role: "assistant",
-      content: [{ type: "text", text: "First thought. Configure provider auth." }],
-      timestamp: 101,
-    };
-    const state = createState({
-      sessionKey: "main",
-      chatRunId: "run-1",
-      chatStream: "After tool.",
-      chatStreamStartedAt: 100,
-    }) as ChatState & {
-      chatStreamSegments: Array<{ text: string; ts: number; toolCallId: string }>;
-    };
-    state.chatStreamSegments = [{ text: "First thought.", ts: 90, toolCallId: "call-1" }];
-
-    expect(
-      handleChatGatewayEvent(state, {
-        runId: "run-1",
-        sessionKey: "main",
-        state: "error",
-        errorMessage: "gateway disconnected",
-        message: terminalMessage,
-      }),
-    ).toBe("error");
-    expect(state.chatMessages).toHaveLength(3);
-    expectTextChatMessage(state.chatMessages[0], "assistant", "First thought.");
-    expectTextChatMessage(state.chatMessages[1], "assistant", "After tool.");
-    expect(state.chatMessages[2]).toEqual(terminalMessage);
-  });
-
-  it("preserves terminal extensions when split stream punctuation is adjacent", () => {
-    const state = createState({
-      sessionKey: "main",
-      chatRunId: "run-1",
-      chatStream: ", world",
-      chatStreamStartedAt: 100,
-    }) as ChatState & {
-      chatStreamSegments: Array<{ text: string; ts: number; toolCallId: string }>;
-    };
-    state.chatStreamSegments = [{ text: "Hello", ts: 90, toolCallId: "call-1" }];
-
-    expect(
-      handleChatGatewayEvent(state, {
-        runId: "run-1",
-        sessionKey: "main",
-        state: "error",
-        errorMessage: "gateway disconnected",
-        message: {
-          role: "assistant",
-          content: [{ type: "text", text: "Hello, world!" }],
-          timestamp: 101,
-        },
-      }),
-    ).toBe("error");
-    expect(state.chatMessages).toHaveLength(1);
-    expectTextChatMessage(state.chatMessages[0], "assistant", "Hello, world!");
-    expect(state.chatRunError).toEqual({ summary: "Error: gateway disconnected" });
-  });
-
-  it("keeps stream segments visible when an error ends after a tool event", () => {
-    const existingMessage = {
-      role: "user",
-      content: [{ type: "text", text: "Ping" }],
-      timestamp: 1,
-    };
-    const state = createState({
-      sessionKey: "main",
-      chatRunId: "run-1",
-      chatMessages: [existingMessage],
-      chatStream: null,
-      chatStreamStartedAt: null,
-    }) as ChatState & { chatStreamSegments: Array<{ text: string; ts: number }> };
-    state.chatStreamSegments = [{ text: "Visible text before tool.", ts: 100 }];
-    const payload: ChatEventPayload = {
-      runId: "run-1",
-      sessionKey: "main",
-      state: "error",
-      errorMessage: "gateway disconnected",
-    };
-
-    expect(handleChatGatewayEvent(state, payload)).toBe("error");
-    expect(state.chatMessages).toHaveLength(2);
-    expect(state.chatMessages[0]).toEqual(existingMessage);
-    expectTextChatMessage(state.chatMessages[1], "assistant", "Visible text before tool.");
-  });
-
-  it("does not let a substring-matching error projection replace streamed text", () => {
-    const message = {
-      role: "assistant",
-      content: [{ type: "text", text: "Error: provider said NOT OK yet" }],
-      timestamp: 101,
-    };
-    const state = createState({
-      sessionKey: "main",
-      chatRunId: "run-1",
-      chatStream: "OK",
-      chatStreamStartedAt: 100,
-    });
-    const payload: ChatEventPayload = {
-      runId: "run-1",
-      sessionKey: "main",
-      state: "error",
-      errorMessage: "provider said NOT OK yet",
-      message,
-    };
-
-    expect(handleChatGatewayEvent(state, payload)).toBe("error");
-    expect(state.chatMessages).toHaveLength(1);
-    expectTextChatMessage(state.chatMessages[0], "assistant", "OK");
-  });
-
-  it("keeps the post-tool stream tail without appending the error projection", () => {
-    const message = {
-      role: "assistant",
-      content: [{ type: "text", text: "Error: gateway disconnected" }],
-      timestamp: 101,
-    };
-    const state = createState({
-      sessionKey: "main",
-      chatRunId: "run-1",
-      chatStream: "First thought. After tool.",
-      chatStreamStartedAt: 100,
-    }) as ChatState & { chatStreamSegments: Array<{ text: string; ts: number }> };
-    state.chatStreamSegments = [{ text: "First thought.", ts: 90 }];
-    const payload: ChatEventPayload = {
-      runId: "run-1",
-      sessionKey: "main",
-      state: "error",
-      errorMessage: "gateway disconnected",
-      message,
-    };
-
-    expect(handleChatGatewayEvent(state, payload)).toBe("error");
-    expect(state.chatMessages).toHaveLength(2);
-    expectTextChatMessage(state.chatMessages[0], "assistant", "First thought.");
-    expectTextChatMessage(state.chatMessages[1], "assistant", "After tool.");
-  });
-
-  it("does not append legacy assistant-shaped error projections", () => {
-    const state = createState({
-      sessionKey: "main",
-      chatRunId: "run-1",
-    });
-    const message = {
-      role: "assistant",
-      content: [{ type: "text", text: "Error: raw gateway error" }],
-      timestamp: 10,
-    };
-    const payload: ChatEventPayload = {
-      runId: "run-1",
-      sessionKey: "main",
-      state: "error",
-      errorMessage: "raw gateway error",
-      message,
-    };
-
-    expect(handleChatGatewayEvent(state, payload)).toBe("error");
-    expect(state.chatMessages).toEqual([]);
-    expect(state.lastError).toBeNull();
-    expect(state.chatRunError).toEqual({ summary: "Error: raw gateway error" });
-  });
-
   it.each([
     "Error: the configuration uses an unsupported field.",
     "⚠️ This operation may require additional review.",
@@ -2736,1036 +2483,627 @@ describe("loadChatHistory retry handling", () => {
     ]);
   });
 
-  it("keeps local optimistic tail messages when history reload returns a stale snapshot", async () => {
-    const persistedUser = {
-      role: "user",
-      content: [{ type: "text", text: "first" }],
-      __openclaw: { seq: 1 },
-    };
-    const optimisticUser = {
-      role: "user",
-      content: [{ type: "text", text: "latest ask" }],
-      timestamp: 10,
-    };
-    const optimisticAssistant = {
-      role: "assistant",
-      content: [{ type: "text", text: "latest answer" }],
-      timestamp: 11,
-    };
+  type HistoryReconciliationFixture = {
+    history: unknown[];
+    visible: unknown[];
+    expected: unknown[];
+    state?: Partial<ChatState>;
+    response?: Record<string, unknown>;
+    verify?: (state: ChatState) => void;
+  };
+
+  it.each([
+    {
+      name: "keeps local optimistic tail messages when history reload returns a stale snapshot",
+      create(): HistoryReconciliationFixture {
+        const persisted = createTextChatMessage("user", "first", { seq: 1 });
+        const user = createTextChatMessage("user", "latest ask", undefined, 10);
+        const assistant = createTextChatMessage("assistant", "latest answer", undefined, 11);
+        return {
+          history: [persisted],
+          visible: [persisted, user, assistant],
+          expected: [persisted, user, assistant],
+          response: { thinkingLevel: "low" },
+          verify: (state) => expect(state.chatStream).toBeNull(),
+        };
+      },
+    },
+    {
+      name: "keeps a newly sent repeated user message when history reload is still stale",
+      create(): HistoryReconciliationFixture {
+        const first = createTextChatMessage(
+          "user",
+          "continue",
+          { id: "first-user-message", idempotencyKey: "first-run:user", seq: 1 },
+          10,
+        );
+        const pending = createTextChatMessage(
+          "user",
+          "continue",
+          { idempotencyKey: "second-run:user" },
+          20,
+        );
+        return { history: [first], visible: [first, pending], expected: [first, pending] };
+      },
+    },
+    {
+      name: "preserves a distinct pending turn after an earlier repeated-history anchor",
+      create(): HistoryReconciliationFixture {
+        const first = createTextChatMessage("user", "continue", { seq: 1 });
+        const second = createTextChatMessage("user", "continue", { seq: 2 });
+        const pending = createTextChatMessage("user", "a distinct pending turn", {
+          idempotencyKey: "third-run:user",
+        });
+        return {
+          history: [first, second],
+          visible: [first, pending],
+          expected: [first, second, pending],
+        };
+      },
+    },
+    {
+      name: "does not revive an unmatched pending turn beyond unrelated history",
+      create(): HistoryReconciliationFixture {
+        const shared = createTextChatMessage("user", "shared earlier turn", {
+          id: "shared-user",
+          seq: 1,
+        });
+        const later = createTextChatMessage("user", "different authoritative turn", {
+          id: "later-user",
+          seq: 2,
+        });
+        const pending = createTextChatMessage("user", "unmatched pending turn", {
+          idempotencyKey: "pending-run:user",
+        });
+        return { history: [shared, later], visible: [shared, pending], expected: [shared, later] };
+      },
+    },
+    {
+      name: "does not adopt an imported message through a colliding native transcript id",
+      create(): HistoryReconciliationFixture {
+        const native = createTextChatMessage("user", "native transcript", {
+          id: "source-local-id",
+        });
+        const imported = createTextChatMessage("user", "imported transcript", {
+          id: "source-local-id",
+          externalId: "source-local-id",
+          importedFrom: "claude-cli",
+          cliSessionId: "imported-session",
+        });
+        const pending = createTextChatMessage("user", "unmatched pending turn", {
+          idempotencyKey: "pending-run:user",
+        });
+        return {
+          history: [native, imported],
+          visible: [native, pending],
+          expected: [native, imported],
+        };
+      },
+    },
+    {
+      name: "does not guess an imported source identity when its session is missing",
+      create(): HistoryReconciliationFixture {
+        const imported = () =>
+          createTextChatMessage("user", "repeated imported turn", {
+            id: "source-local-id",
+            externalId: "source-local-id",
+            importedFrom: "claude-cli",
+          });
+        const first = imported();
+        const second = imported();
+        const previous = imported();
+        const pending = createTextChatMessage("user", "unmatched pending turn", {
+          idempotencyKey: "pending-run:user",
+        });
+        return {
+          history: [first, second],
+          visible: [previous, pending],
+          expected: [first, second],
+        };
+      },
+    },
+    {
+      name: "does not anchor a missing canonical id to another same-sequence projection",
+      create(): HistoryReconciliationFixture {
+        const unrelated = createTextChatMessage("user", "different sequence projection", {
+          seq: 7,
+        });
+        const previous = createTextChatMessage("user", "original sequence projection", {
+          id: "missing-canonical-id",
+          seq: 7,
+        });
+        const pending = createTextChatMessage("user", "unmatched pending turn", {
+          idempotencyKey: "pending-run:user",
+        });
+        return { history: [unrelated], visible: [previous, pending], expected: [unrelated] };
+      },
+    },
+    {
+      name: "does not adopt import provenance lacking an external id as a native row",
+      create(): HistoryReconciliationFixture {
+        const native = createTextChatMessage("user", "native transcript", {
+          id: "source-local-id",
+        });
+        const imported = createTextChatMessage("user", "imported transcript", {
+          id: "source-local-id",
+          importedFrom: "claude-cli",
+          cliSessionId: "imported-session",
+        });
+        const pending = createTextChatMessage("user", "unmatched pending turn", {
+          idempotencyKey: "pending-run:user",
+        });
+        return {
+          history: [native, imported],
+          visible: [native, pending],
+          expected: [native, imported],
+        };
+      },
+    },
+    {
+      name: "does not use matching display text to adopt an incomplete imported source",
+      create(): HistoryReconciliationFixture {
+        const previous = createTextChatMessage("user", "repeated imported turn", {
+          externalId: "first-import",
+          importedFrom: "claude-cli",
+        });
+        const other = createTextChatMessage("user", "repeated imported turn", {
+          externalId: "different-import",
+          importedFrom: "claude-cli",
+        });
+        const pending = createTextChatMessage("user", "unmatched pending turn", {
+          idempotencyKey: "pending-run:user",
+        });
+        return { history: [other], visible: [previous, pending], expected: [other] };
+      },
+    },
+    {
+      name: "does not drop a canonical id for a same-text sequence projection",
+      create(): HistoryReconciliationFixture {
+        const unrelated = createTextChatMessage("user", "repeated projection", { seq: 7 });
+        const previous = createTextChatMessage("user", "repeated projection", {
+          id: "missing-canonical-id",
+          seq: 7,
+        });
+        const pending = createTextChatMessage("user", "unmatched pending turn", {
+          idempotencyKey: "pending-run:user",
+        });
+        return { history: [unrelated], visible: [previous, pending], expected: [unrelated] };
+      },
+    },
+    {
+      name: "does not revive an identity-free tail after a distinct repeated history turn",
+      create(): HistoryReconciliationFixture {
+        const first = createTextChatMessage("user", "continue", { id: "first-user", seq: 1 });
+        const second = createTextChatMessage("user", "continue", { id: "second-user", seq: 2 });
+        const pending = createTextChatMessage("user", "identity-free pending turn");
+        return { history: [first, second], visible: [first, pending], expected: [first, second] };
+      },
+    },
+    {
+      name: "does not reconcile native legacy history with an imported display match",
+      create(): HistoryReconciliationFixture {
+        const native = createTextChatMessage("user", "same visible turn", {
+          senderId: "native-user",
+        });
+        const imported = createTextChatMessage("user", "same visible turn", {
+          externalId: "external-user",
+          importedFrom: "claude-cli",
+          cliSessionId: "external-session",
+        });
+        const pending = createTextChatMessage("user", "unmatched pending turn", {
+          idempotencyKey: "pending-run:user",
+        });
+        return { history: [imported], visible: [native, pending], expected: [imported] };
+      },
+    },
+    {
+      name: "does not replay an optimistic send already persisted before the history anchor",
+      create(): HistoryReconciliationFixture {
+        const user = createTextChatMessage("user", "already persisted prompt", {
+          id: "persisted-user",
+          seq: 1,
+          idempotencyKey: "persisted-run:user",
+        });
+        const assistant = createTextChatMessage("assistant", "already persisted answer", {
+          id: "persisted-assistant",
+          seq: 2,
+        });
+        const pending = createTextChatMessage("user", "already persisted prompt", {
+          idempotencyKey: "persisted-run:user",
+        });
+        return {
+          history: [user, assistant],
+          visible: [user, assistant, pending],
+          expected: [user, assistant],
+        };
+      },
+    },
+    {
+      name: "does not cross unrelated signature-free history markers",
+      create(): HistoryReconciliationFixture {
+        const first = {
+          content: [{ type: "status", value: "first marker" }],
+          __openclaw: { id: "first-marker", seq: 1 },
+        };
+        const later = {
+          content: [{ type: "status", value: "different marker" }],
+          __openclaw: { id: "later-marker", seq: 2 },
+        };
+        const pending = createTextChatMessage("user", "unmatched pending turn", {
+          idempotencyKey: "pending-run:user",
+        });
+        return { history: [first, later], visible: [first, pending], expected: [first, later] };
+      },
+    },
+    {
+      name: "does not duplicate repeated history without an echoed send identity",
+      create(): HistoryReconciliationFixture {
+        const first = createTextChatMessage("user", "continue", { id: "first-user", seq: 1 });
+        const repeated = createTextChatMessage("user", "continue", {
+          id: "persisted-repeated-user",
+          seq: 2,
+        });
+        const pending = createTextChatMessage("user", "continue", {
+          idempotencyKey: "repeated-run:user",
+        });
+        return {
+          history: [first, repeated],
+          visible: [first, pending],
+          expected: [first, repeated],
+        };
+      },
+    },
+    {
+      name: "does not revive an assistant after its user was persisted before the anchor",
+      create(): HistoryReconciliationFixture {
+        const user = createTextChatMessage("user", "already persisted prompt", {
+          id: "persisted-user",
+          seq: 1,
+          idempotencyKey: "persisted-run:user",
+        });
+        const assistant = createTextChatMessage("assistant", "already persisted answer", {
+          id: "persisted-assistant",
+          seq: 2,
+        });
+        const pendingUser = createTextChatMessage("user", "already persisted prompt", {
+          idempotencyKey: "persisted-run:user",
+        });
+        const pendingAssistant = createTextChatMessage("assistant", "stale streamed assistant");
+        return {
+          history: [user, assistant],
+          visible: [user, assistant, pendingUser, pendingAssistant],
+          expected: [user, assistant],
+        };
+      },
+    },
+    {
+      name: "preserves a distinct repeated send when the earlier anchor has different text",
+      create(): HistoryReconciliationFixture {
+        const setup = createTextChatMessage("user", "setup", {
+          id: "setup-user",
+          seq: 1,
+          idempotencyKey: "setup-run:user",
+        });
+        const second = createTextChatMessage("user", "continue", {
+          id: "second-user",
+          seq: 2,
+          idempotencyKey: "second-run:user",
+        });
+        const third = createTextChatMessage("user", "continue", {
+          idempotencyKey: "third-run:user",
+        });
+        return {
+          history: [setup, second],
+          visible: [setup, third],
+          expected: [setup, second, third],
+        };
+      },
+    },
+    {
+      name: "keeps a new repeated prompt after a different same-text turn reaches history",
+      create(): HistoryReconciliationFixture {
+        const first = createTextChatMessage("user", "continue", {
+          id: "first-user",
+          idempotencyKey: "first-run:user",
+          seq: 1,
+        });
+        const second = createTextChatMessage("user", "continue", {
+          id: "second-user",
+          idempotencyKey: "second-run:user",
+          seq: 2,
+        });
+        const pending = createTextChatMessage("user", "continue", {
+          idempotencyKey: "third-run:user",
+        });
+        const stream = {
+          chatRunId: "third-run",
+          chatStream: "Still working on the third turn.",
+          chatStreamStartedAt: 100,
+        };
+        return {
+          history: [first, second],
+          visible: [first, pending],
+          expected: [first, second, pending],
+          state: stream,
+          verify: (state) => expect(state).toMatchObject(stream),
+        };
+      },
+    },
+    {
+      name: "reconciles repeated imported messages using the complete external source identity",
+      create(): HistoryReconciliationFixture {
+        const imported = (cliSessionId: string) =>
+          createTextChatMessage("user", "continue", {
+            id: "shared-external-id",
+            externalId: "shared-external-id",
+            importedFrom: "claude-cli",
+            cliSessionId,
+          });
+        const first = imported("first-session");
+        const second = imported("second-session");
+        const pending = createTextChatMessage("user", "continue");
+        return { history: [first, second], visible: [first, pending], expected: [first, second] };
+      },
+    },
+    {
+      name: "does not invent an anchor for ambiguous identity-free repeated history",
+      create(): HistoryReconciliationFixture {
+        const legacy = () => createTextChatMessage("user", "continue", { senderId: "alice" });
+        const first = legacy();
+        const second = legacy();
+        const previous = legacy();
+        const pending = createTextChatMessage("user", "unproven pending turn", {
+          idempotencyKey: "pending-run:user",
+        });
+        return {
+          history: [first, second],
+          visible: [previous, pending],
+          expected: [first, second],
+        };
+      },
+    },
+    {
+      name: "does not attach a current optimistic turn to an unrelated older snapshot",
+      create(): HistoryReconciliationFixture {
+        const older = createTextChatMessage("user", "older snapshot", { id: "older-user", seq: 1 });
+        const current = createTextChatMessage("user", "current snapshot", {
+          id: "current-user",
+          seq: 2,
+        });
+        const pending = createTextChatMessage("user", "pending on the current snapshot", {
+          idempotencyKey: "pending-run:user",
+        });
+        return { history: [older], visible: [current, pending], expected: [older] };
+      },
+    },
+    {
+      name: "never restores a hidden optimistic assistant during history reconciliation",
+      create(): HistoryReconciliationFixture {
+        const user = createTextChatMessage("user", "visible prompt", {
+          id: "visible-user",
+          seq: 1,
+        });
+        const hidden = createTextChatMessage("assistant", "NO_REPLY");
+        return { history: [user], visible: [user, hidden], expected: [user] };
+      },
+    },
+    {
+      name: "keeps active streamed assistant text when history reload returns a stale snapshot",
+      create(): HistoryReconciliationFixture {
+        const persisted = createTextChatMessage("user", "first", { seq: 1 });
+        const pending = createTextChatMessage("user", "latest ask", undefined, 10);
+        const stream = {
+          chatRunId: "run-1",
+          chatStream: "First visible stream text.",
+          chatStreamStartedAt: 100,
+        };
+        return {
+          history: [persisted],
+          visible: [persisted, pending],
+          expected: [persisted, pending],
+          state: stream,
+          response: { thinkingLevel: "low" },
+          verify: (state) => expect(state).toMatchObject(stream),
+        };
+      },
+    },
+  ])("$name", async (fixture) => {
+    const { history, visible, expected, state: overrides, response, verify } = fixture.create();
+    const request = vi.fn().mockResolvedValue({ messages: history, ...response });
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+      chatMessages: visible,
+      ...overrides,
+    });
+
+    await loadChatHistory(state);
+
+    expect(request).toHaveBeenCalledWith("chat.history", { sessionKey: "main", limit: 100 });
+    expect(state.chatMessages).toEqual(expected);
+    verify?.(state);
+  });
+  type HistoryToolSegment = { text: string; ts: number; toolCallId?: string };
+  type RecoveredToolFixture = {
+    tools: Record<string, unknown>[];
+    persistedCount: number;
+    segments: HistoryToolSegment[];
+    stream: string;
+    expectedRows: Array<number | { text: string; timestamp: number }>;
+    expectedStream: string;
+    remainingTools?: number[];
+    remainingSegments?: HistoryToolSegment[];
+  };
+
+  const historyTool = (id: string, text: string, timestamp: number, seq: number) => ({
+    role: "toolResult",
+    toolCallId: id,
+    toolName: "shell",
+    content: [{ type: "text", text }],
+    timestamp,
+    __openclaw: { seq },
+  });
+
+  it.each([
+    {
+      name: "clears live tool cards when history catches up before assistant text",
+      create(): RecoveredToolFixture {
+        return {
+          tools: [historyTool("call_1", "tool output", 2, 2)],
+          persistedCount: 1,
+          segments: [{ text: "before tool", ts: 1 }],
+          stream: "Still answering.",
+          expectedRows: [{ text: "before tool", timestamp: 1 }, 0],
+          expectedStream: "Still answering.",
+        };
+      },
+    },
+    {
+      name: "inserts multiple recovered stream segments before their matching persisted tools",
+      create(): RecoveredToolFixture {
+        return {
+          tools: [
+            historyTool("call_1", "first output", 2, 2),
+            historyTool("call_2", "second output", 4, 3),
+          ],
+          persistedCount: 2,
+          segments: [
+            { text: "before first tool", ts: 1 },
+            { text: "before first tool\nbefore second tool", ts: 3 },
+          ],
+          stream: "Still answering.",
+          expectedRows: [
+            { text: "before first tool", timestamp: 1 },
+            0,
+            { text: "before second tool", timestamp: 3 },
+            1,
+          ],
+          expectedStream: "Still answering.",
+        };
+      },
+    },
+    {
+      name: "prunes only the live tool cards that history has caught up with",
+      create(): RecoveredToolFixture {
+        return {
+          tools: [
+            historyTool("call_1", "first output", 2, 2),
+            {
+              role: "assistant",
+              toolCallId: "call_2",
+              runId: "run-1",
+              content: [
+                { type: "toolcall", name: "shell", arguments: {} },
+                { type: "toolresult", name: "shell", text: "second output" },
+              ],
+              timestamp: 4,
+            },
+          ],
+          persistedCount: 1,
+          segments: [
+            { text: "before first tool", ts: 1, toolCallId: "call_1" },
+            { text: "before first tool\nbefore second tool", ts: 3, toolCallId: "call_2" },
+          ],
+          stream: "before first tool\nbefore second tool\nStill answering.",
+          expectedRows: [{ text: "before first tool", timestamp: 1 }, 0],
+          expectedStream: "Still answering.",
+          remainingTools: [1],
+          remainingSegments: [{ text: "before second tool", ts: 3, toolCallId: "call_2" }],
+        };
+      },
+    },
+    {
+      name: "uses segment tool ids when a tool starts before any stream text",
+      create(): RecoveredToolFixture {
+        return {
+          tools: [
+            historyTool("call_1", "first output", 2, 2),
+            historyTool("call_2", "second output", 4, 3),
+          ],
+          persistedCount: 2,
+          segments: [{ text: "before second tool", ts: 3, toolCallId: "call_2" }],
+          stream: "Still answering.",
+          expectedRows: [0, { text: "before second tool", timestamp: 3 }, 1],
+          expectedStream: "Still answering.",
+        };
+      },
+    },
+    {
+      name: "trims accumulated current stream after materializing caught-up tool segments",
+      create(): RecoveredToolFixture {
+        return {
+          tools: [historyTool("call_1", "tool output", 2, 2)],
+          persistedCount: 1,
+          segments: [{ text: "before tool", ts: 1, toolCallId: "call_1" }],
+          stream: "before tool\nafter tool",
+          expectedRows: [{ text: "before tool", timestamp: 1 }, 0],
+          expectedStream: "after tool",
+        };
+      },
+    },
+  ])("$name", async (fixture) => {
+    const {
+      tools,
+      persistedCount,
+      segments,
+      stream,
+      expectedRows,
+      expectedStream,
+      remainingTools = [],
+      remainingSegments = [],
+    } = fixture.create();
+    const persistedUser = createTextChatMessage("user", "latest ask", { seq: 1 });
     const request = vi.fn().mockResolvedValue({
-      messages: [persistedUser],
+      messages: [persistedUser, ...tools.slice(0, persistedCount)],
       thinkingLevel: "low",
     });
     const state = createState({
       connected: true,
       client: { request } as unknown as ChatState["client"],
-      chatMessages: [persistedUser, optimisticUser, optimisticAssistant],
-    });
-
-    await loadChatHistory(state);
-
-    expect(state.chatMessages).toEqual([persistedUser, optimisticUser, optimisticAssistant]);
-    expect(state.chatStream).toBeNull();
-  });
-
-  it("keeps a newly sent repeated user message when history reload is still stale", async () => {
-    const persistedUser = {
-      role: "user",
-      content: [{ type: "text", text: "continue" }],
-      timestamp: 10,
-      __openclaw: {
-        id: "first-user-message",
-        idempotencyKey: "first-run:user",
-        seq: 1,
-      },
-    };
-    const optimisticUser = {
-      role: "user",
-      content: [{ type: "text", text: "continue" }],
-      timestamp: 20,
-      __openclaw: { idempotencyKey: "second-run:user" },
-    };
-    const request = vi.fn().mockResolvedValue({
-      messages: [persistedUser],
-    });
-    const state = createState({
-      connected: true,
-      client: { request } as unknown as ChatState["client"],
-      chatMessages: [persistedUser, optimisticUser],
-    });
-
-    await loadChatHistory(state);
-
-    expect(state.chatMessages).toEqual([persistedUser, optimisticUser]);
-  });
-
-  it("preserves a distinct pending turn after an earlier repeated-history anchor", async () => {
-    const firstRepeatedUser = {
-      role: "user",
-      content: [{ type: "text", text: "continue" }],
-      __openclaw: { seq: 1 },
-    };
-    const secondRepeatedUser = {
-      role: "user",
-      content: [{ type: "text", text: "continue" }],
-      __openclaw: { seq: 2 },
-    };
-    const optimisticUser = {
-      role: "user",
-      content: [{ type: "text", text: "a distinct pending turn" }],
-      __openclaw: { idempotencyKey: "third-run:user" },
-    };
-    const request = vi.fn().mockResolvedValue({
-      messages: [firstRepeatedUser, secondRepeatedUser],
-    });
-    const state = createState({
-      connected: true,
-      client: { request } as unknown as ChatState["client"],
-      chatMessages: [firstRepeatedUser, optimisticUser],
-    });
-
-    await loadChatHistory(state);
-
-    expect(state.chatMessages).toEqual([firstRepeatedUser, secondRepeatedUser, optimisticUser]);
-  });
-
-  it("does not revive an unmatched pending turn beyond unrelated history", async () => {
-    const sharedUser = {
-      role: "user",
-      content: [{ type: "text", text: "shared earlier turn" }],
-      __openclaw: { id: "shared-user", seq: 1 },
-    };
-    const laterUser = {
-      role: "user",
-      content: [{ type: "text", text: "different authoritative turn" }],
-      __openclaw: { id: "later-user", seq: 2 },
-    };
-    const optimisticUser = {
-      role: "user",
-      content: [{ type: "text", text: "unmatched pending turn" }],
-      __openclaw: { idempotencyKey: "pending-run:user" },
-    };
-    const request = vi.fn().mockResolvedValue({ messages: [sharedUser, laterUser] });
-    const state = createState({
-      connected: true,
-      client: { request } as unknown as ChatState["client"],
-      chatMessages: [sharedUser, optimisticUser],
-    });
-
-    await loadChatHistory(state);
-
-    expect(state.chatMessages).toEqual([sharedUser, laterUser]);
-  });
-
-  it("does not adopt an imported message through a colliding native transcript id", async () => {
-    const nativeUser = {
-      role: "user",
-      content: [{ type: "text", text: "native transcript" }],
-      __openclaw: { id: "source-local-id" },
-    };
-    const importedUser = {
-      role: "user",
-      content: [{ type: "text", text: "imported transcript" }],
-      __openclaw: {
-        id: "source-local-id",
-        externalId: "source-local-id",
-        importedFrom: "claude-cli",
-        cliSessionId: "imported-session",
-      },
-    };
-    const optimisticUser = {
-      role: "user",
-      content: [{ type: "text", text: "unmatched pending turn" }],
-      __openclaw: { idempotencyKey: "pending-run:user" },
-    };
-    const request = vi.fn().mockResolvedValue({ messages: [nativeUser, importedUser] });
-    const state = createState({
-      connected: true,
-      client: { request } as unknown as ChatState["client"],
-      chatMessages: [nativeUser, optimisticUser],
-    });
-
-    await loadChatHistory(state);
-
-    expect(state.chatMessages).toEqual([nativeUser, importedUser]);
-  });
-
-  it("does not guess an imported source identity when its session is missing", async () => {
-    const firstImportedUser = {
-      role: "user",
-      content: [{ type: "text", text: "repeated imported turn" }],
-      __openclaw: {
-        id: "source-local-id",
-        externalId: "source-local-id",
-        importedFrom: "claude-cli",
-      },
-    };
-    const secondImportedUser = {
-      role: "user",
-      content: [{ type: "text", text: "repeated imported turn" }],
-      __openclaw: {
-        id: "source-local-id",
-        externalId: "source-local-id",
-        importedFrom: "claude-cli",
-      },
-    };
-    const previousImportedUser = {
-      role: "user",
-      content: [{ type: "text", text: "repeated imported turn" }],
-      __openclaw: {
-        id: "source-local-id",
-        externalId: "source-local-id",
-        importedFrom: "claude-cli",
-      },
-    };
-    const optimisticUser = {
-      role: "user",
-      content: [{ type: "text", text: "unmatched pending turn" }],
-      __openclaw: { idempotencyKey: "pending-run:user" },
-    };
-    const request = vi.fn().mockResolvedValue({
-      messages: [firstImportedUser, secondImportedUser],
-    });
-    const state = createState({
-      connected: true,
-      client: { request } as unknown as ChatState["client"],
-      chatMessages: [previousImportedUser, optimisticUser],
-    });
-
-    await loadChatHistory(state);
-
-    expect(state.chatMessages).toEqual([firstImportedUser, secondImportedUser]);
-  });
-
-  it("does not anchor a missing canonical id to another same-sequence projection", async () => {
-    const unrelatedProjection = {
-      role: "user",
-      content: [{ type: "text", text: "different sequence projection" }],
-      __openclaw: { seq: 7 },
-    };
-    const previousProjection = {
-      role: "user",
-      content: [{ type: "text", text: "original sequence projection" }],
-      __openclaw: { id: "missing-canonical-id", seq: 7 },
-    };
-    const optimisticUser = {
-      role: "user",
-      content: [{ type: "text", text: "unmatched pending turn" }],
-      __openclaw: { idempotencyKey: "pending-run:user" },
-    };
-    const request = vi.fn().mockResolvedValue({ messages: [unrelatedProjection] });
-    const state = createState({
-      connected: true,
-      client: { request } as unknown as ChatState["client"],
-      chatMessages: [previousProjection, optimisticUser],
-    });
-
-    await loadChatHistory(state);
-
-    expect(state.chatMessages).toEqual([unrelatedProjection]);
-  });
-
-  it("does not adopt import provenance lacking an external id as a native row", async () => {
-    const nativeUser = {
-      role: "user",
-      content: [{ type: "text", text: "native transcript" }],
-      __openclaw: { id: "source-local-id" },
-    };
-    const importedUser = {
-      role: "user",
-      content: [{ type: "text", text: "imported transcript" }],
-      __openclaw: {
-        id: "source-local-id",
-        importedFrom: "claude-cli",
-        cliSessionId: "imported-session",
-      },
-    };
-    const optimisticUser = {
-      role: "user",
-      content: [{ type: "text", text: "unmatched pending turn" }],
-      __openclaw: { idempotencyKey: "pending-run:user" },
-    };
-    const request = vi.fn().mockResolvedValue({ messages: [nativeUser, importedUser] });
-    const state = createState({
-      connected: true,
-      client: { request } as unknown as ChatState["client"],
-      chatMessages: [nativeUser, optimisticUser],
-    });
-
-    await loadChatHistory(state);
-
-    expect(state.chatMessages).toEqual([nativeUser, importedUser]);
-  });
-
-  it("does not use matching display text to adopt an incomplete imported source", async () => {
-    const previousImportedUser = {
-      role: "user",
-      content: [{ type: "text", text: "repeated imported turn" }],
-      __openclaw: { externalId: "first-import", importedFrom: "claude-cli" },
-    };
-    const otherImportedUser = {
-      role: "user",
-      content: [{ type: "text", text: "repeated imported turn" }],
-      __openclaw: { externalId: "different-import", importedFrom: "claude-cli" },
-    };
-    const optimisticUser = {
-      role: "user",
-      content: [{ type: "text", text: "unmatched pending turn" }],
-      __openclaw: { idempotencyKey: "pending-run:user" },
-    };
-    const request = vi.fn().mockResolvedValue({ messages: [otherImportedUser] });
-    const state = createState({
-      connected: true,
-      client: { request } as unknown as ChatState["client"],
-      chatMessages: [previousImportedUser, optimisticUser],
-    });
-
-    await loadChatHistory(state);
-
-    expect(state.chatMessages).toEqual([otherImportedUser]);
-  });
-
-  it("does not drop a canonical id for a same-text sequence projection", async () => {
-    const unrelatedProjection = {
-      role: "user",
-      content: [{ type: "text", text: "repeated projection" }],
-      __openclaw: { seq: 7 },
-    };
-    const previousProjection = {
-      role: "user",
-      content: [{ type: "text", text: "repeated projection" }],
-      __openclaw: { id: "missing-canonical-id", seq: 7 },
-    };
-    const optimisticUser = {
-      role: "user",
-      content: [{ type: "text", text: "unmatched pending turn" }],
-      __openclaw: { idempotencyKey: "pending-run:user" },
-    };
-    const request = vi.fn().mockResolvedValue({ messages: [unrelatedProjection] });
-    const state = createState({
-      connected: true,
-      client: { request } as unknown as ChatState["client"],
-      chatMessages: [previousProjection, optimisticUser],
-    });
-
-    await loadChatHistory(state);
-
-    expect(state.chatMessages).toEqual([unrelatedProjection]);
-  });
-
-  it("does not revive an identity-free tail after a distinct repeated history turn", async () => {
-    const firstUser = {
-      role: "user",
-      content: [{ type: "text", text: "continue" }],
-      __openclaw: { id: "first-user", seq: 1 },
-    };
-    const secondUser = {
-      role: "user",
-      content: [{ type: "text", text: "continue" }],
-      __openclaw: { id: "second-user", seq: 2 },
-    };
-    const identityFreeTail = {
-      role: "user",
-      content: [{ type: "text", text: "identity-free pending turn" }],
-    };
-    const request = vi.fn().mockResolvedValue({ messages: [firstUser, secondUser] });
-    const state = createState({
-      connected: true,
-      client: { request } as unknown as ChatState["client"],
-      chatMessages: [firstUser, identityFreeTail],
-    });
-
-    await loadChatHistory(state);
-
-    expect(state.chatMessages).toEqual([firstUser, secondUser]);
-  });
-
-  it("does not reconcile native legacy history with an imported display match", async () => {
-    const previousNativeUser = {
-      role: "user",
-      content: [{ type: "text", text: "same visible turn" }],
-      __openclaw: { senderId: "native-user" },
-    };
-    const importedUser = {
-      role: "user",
-      content: [{ type: "text", text: "same visible turn" }],
-      __openclaw: {
-        externalId: "external-user",
-        importedFrom: "claude-cli",
-        cliSessionId: "external-session",
-      },
-    };
-    const optimisticUser = {
-      role: "user",
-      content: [{ type: "text", text: "unmatched pending turn" }],
-      __openclaw: { idempotencyKey: "pending-run:user" },
-    };
-    const request = vi.fn().mockResolvedValue({ messages: [importedUser] });
-    const state = createState({
-      connected: true,
-      client: { request } as unknown as ChatState["client"],
-      chatMessages: [previousNativeUser, optimisticUser],
-    });
-
-    await loadChatHistory(state);
-
-    expect(state.chatMessages).toEqual([importedUser]);
-  });
-
-  it("does not replay an optimistic send already persisted before the history anchor", async () => {
-    const persistedUser = {
-      role: "user",
-      content: [{ type: "text", text: "already persisted prompt" }],
-      __openclaw: { id: "persisted-user", seq: 1, idempotencyKey: "persisted-run:user" },
-    };
-    const persistedAssistant = {
-      role: "assistant",
-      content: [{ type: "text", text: "already persisted answer" }],
-      __openclaw: { id: "persisted-assistant", seq: 2 },
-    };
-    const staleOptimisticUser = {
-      role: "user",
-      content: [{ type: "text", text: "already persisted prompt" }],
-      __openclaw: { idempotencyKey: "persisted-run:user" },
-    };
-    const request = vi.fn().mockResolvedValue({
-      messages: [persistedUser, persistedAssistant],
-    });
-    const state = createState({
-      connected: true,
-      client: { request } as unknown as ChatState["client"],
-      chatMessages: [persistedUser, persistedAssistant, staleOptimisticUser],
-    });
-
-    await loadChatHistory(state);
-
-    expect(state.chatMessages).toEqual([persistedUser, persistedAssistant]);
-  });
-
-  it("does not cross unrelated signature-free history markers", async () => {
-    const firstMarker = {
-      content: [{ type: "status", value: "first marker" }],
-      __openclaw: { id: "first-marker", seq: 1 },
-    };
-    const laterMarker = {
-      content: [{ type: "status", value: "different marker" }],
-      __openclaw: { id: "later-marker", seq: 2 },
-    };
-    const optimisticUser = {
-      role: "user",
-      content: [{ type: "text", text: "unmatched pending turn" }],
-      __openclaw: { idempotencyKey: "pending-run:user" },
-    };
-    const request = vi.fn().mockResolvedValue({ messages: [firstMarker, laterMarker] });
-    const state = createState({
-      connected: true,
-      client: { request } as unknown as ChatState["client"],
-      chatMessages: [firstMarker, optimisticUser],
-    });
-
-    await loadChatHistory(state);
-
-    expect(state.chatMessages).toEqual([firstMarker, laterMarker]);
-  });
-
-  it("does not duplicate repeated history without an echoed send identity", async () => {
-    const firstUser = {
-      role: "user",
-      content: [{ type: "text", text: "continue" }],
-      __openclaw: { id: "first-user", seq: 1 },
-    };
-    const persistedRepeatedUser = {
-      role: "user",
-      content: [{ type: "text", text: "continue" }],
-      __openclaw: { id: "persisted-repeated-user", seq: 2 },
-    };
-    const optimisticRepeatedUser = {
-      role: "user",
-      content: [{ type: "text", text: "continue" }],
-      __openclaw: { idempotencyKey: "repeated-run:user" },
-    };
-    const request = vi.fn().mockResolvedValue({
-      messages: [firstUser, persistedRepeatedUser],
-    });
-    const state = createState({
-      connected: true,
-      client: { request } as unknown as ChatState["client"],
-      chatMessages: [firstUser, optimisticRepeatedUser],
-    });
-
-    await loadChatHistory(state);
-
-    expect(state.chatMessages).toEqual([firstUser, persistedRepeatedUser]);
-  });
-
-  it("does not revive an assistant after its user was persisted before the anchor", async () => {
-    const persistedUser = {
-      role: "user",
-      content: [{ type: "text", text: "already persisted prompt" }],
-      __openclaw: { id: "persisted-user", seq: 1, idempotencyKey: "persisted-run:user" },
-    };
-    const persistedAssistant = {
-      role: "assistant",
-      content: [{ type: "text", text: "already persisted answer" }],
-      __openclaw: { id: "persisted-assistant", seq: 2 },
-    };
-    const staleOptimisticUser = {
-      role: "user",
-      content: [{ type: "text", text: "already persisted prompt" }],
-      __openclaw: { idempotencyKey: "persisted-run:user" },
-    };
-    const staleOptimisticAssistant = {
-      role: "assistant",
-      content: [{ type: "text", text: "stale streamed assistant" }],
-    };
-    const request = vi.fn().mockResolvedValue({
-      messages: [persistedUser, persistedAssistant],
-    });
-    const state = createState({
-      connected: true,
-      client: { request } as unknown as ChatState["client"],
-      chatMessages: [
-        persistedUser,
-        persistedAssistant,
-        staleOptimisticUser,
-        staleOptimisticAssistant,
-      ],
-    });
-
-    await loadChatHistory(state);
-
-    expect(state.chatMessages).toEqual([persistedUser, persistedAssistant]);
-  });
-
-  it("preserves a distinct repeated send when the earlier anchor has different text", async () => {
-    const setupUser = {
-      role: "user",
-      content: [{ type: "text", text: "setup" }],
-      __openclaw: { id: "setup-user", seq: 1, idempotencyKey: "setup-run:user" },
-    };
-    const secondUser = {
-      role: "user",
-      content: [{ type: "text", text: "continue" }],
-      __openclaw: { id: "second-user", seq: 2, idempotencyKey: "second-run:user" },
-    };
-    const thirdUser = {
-      role: "user",
-      content: [{ type: "text", text: "continue" }],
-      __openclaw: { idempotencyKey: "third-run:user" },
-    };
-    const request = vi.fn().mockResolvedValue({ messages: [setupUser, secondUser] });
-    const state = createState({
-      connected: true,
-      client: { request } as unknown as ChatState["client"],
-      chatMessages: [setupUser, thirdUser],
-    });
-
-    await loadChatHistory(state);
-
-    expect(state.chatMessages).toEqual([setupUser, secondUser, thirdUser]);
-  });
-
-  it("keeps a new repeated prompt after a different same-text turn reaches history", async () => {
-    const firstUser = {
-      role: "user",
-      content: [{ type: "text", text: "continue" }],
-      __openclaw: { id: "first-user", idempotencyKey: "first-run:user", seq: 1 },
-    };
-    const secondUser = {
-      role: "user",
-      content: [{ type: "text", text: "continue" }],
-      __openclaw: { id: "second-user", idempotencyKey: "second-run:user", seq: 2 },
-    };
-    const optimisticThirdUser = {
-      role: "user",
-      content: [{ type: "text", text: "continue" }],
-      __openclaw: { idempotencyKey: "third-run:user" },
-    };
-    const request = vi.fn().mockResolvedValue({ messages: [firstUser, secondUser] });
-    const state = createState({
-      connected: true,
-      client: { request } as unknown as ChatState["client"],
-      chatMessages: [firstUser, optimisticThirdUser],
-      chatRunId: "third-run",
-      chatStream: "Still working on the third turn.",
-      chatStreamStartedAt: 100,
-    });
-
-    await loadChatHistory(state);
-
-    expect(state.chatMessages).toEqual([firstUser, secondUser, optimisticThirdUser]);
-    expect(state.chatRunId).toBe("third-run");
-    expect(state.chatStream).toBe("Still working on the third turn.");
-    expect(state.chatStreamStartedAt).toBe(100);
-  });
-
-  it("reconciles repeated imported messages using the complete external source identity", async () => {
-    const firstImportedUser = {
-      role: "user",
-      content: [{ type: "text", text: "continue" }],
-      __openclaw: {
-        id: "shared-external-id",
-        externalId: "shared-external-id",
-        importedFrom: "claude-cli",
-        cliSessionId: "first-session",
-      },
-    };
-    const secondImportedUser = {
-      role: "user",
-      content: [{ type: "text", text: "continue" }],
-      __openclaw: {
-        id: "shared-external-id",
-        externalId: "shared-external-id",
-        importedFrom: "claude-cli",
-        cliSessionId: "second-session",
-      },
-    };
-    const optimisticSecondUser = {
-      role: "user",
-      content: [{ type: "text", text: "continue" }],
-    };
-    const request = vi.fn().mockResolvedValue({
-      messages: [firstImportedUser, secondImportedUser],
-    });
-    const state = createState({
-      connected: true,
-      client: { request } as unknown as ChatState["client"],
-      chatMessages: [firstImportedUser, optimisticSecondUser],
-    });
-
-    await loadChatHistory(state);
-
-    expect(state.chatMessages).toEqual([firstImportedUser, secondImportedUser]);
-  });
-
-  it("does not invent an anchor for ambiguous identity-free repeated history", async () => {
-    const firstLegacyUser = {
-      role: "user",
-      content: [{ type: "text", text: "continue" }],
-      __openclaw: { senderId: "alice" },
-    };
-    const secondLegacyUser = {
-      role: "user",
-      content: [{ type: "text", text: "continue" }],
-      __openclaw: { senderId: "alice" },
-    };
-    const previousLegacyUser = {
-      role: "user",
-      content: [{ type: "text", text: "continue" }],
-      __openclaw: { senderId: "alice" },
-    };
-    const optimisticUser = {
-      role: "user",
-      content: [{ type: "text", text: "unproven pending turn" }],
-      __openclaw: { idempotencyKey: "pending-run:user" },
-    };
-    const request = vi.fn().mockResolvedValue({
-      messages: [firstLegacyUser, secondLegacyUser],
-    });
-    const state = createState({
-      connected: true,
-      client: { request } as unknown as ChatState["client"],
-      chatMessages: [previousLegacyUser, optimisticUser],
-    });
-
-    await loadChatHistory(state);
-
-    expect(state.chatMessages).toEqual([firstLegacyUser, secondLegacyUser]);
-  });
-
-  it("does not attach a current optimistic turn to an unrelated older snapshot", async () => {
-    const olderHistoryUser = {
-      role: "user",
-      content: [{ type: "text", text: "older snapshot" }],
-      __openclaw: { id: "older-user", seq: 1 },
-    };
-    const currentHistoryUser = {
-      role: "user",
-      content: [{ type: "text", text: "current snapshot" }],
-      __openclaw: { id: "current-user", seq: 2 },
-    };
-    const optimisticUser = {
-      role: "user",
-      content: [{ type: "text", text: "pending on the current snapshot" }],
-      __openclaw: { idempotencyKey: "pending-run:user" },
-    };
-    const request = vi.fn().mockResolvedValue({ messages: [olderHistoryUser] });
-    const state = createState({
-      connected: true,
-      client: { request } as unknown as ChatState["client"],
-      chatMessages: [currentHistoryUser, optimisticUser],
-    });
-
-    await loadChatHistory(state);
-
-    expect(state.chatMessages).toEqual([olderHistoryUser]);
-  });
-
-  it("never restores a hidden optimistic assistant during history reconciliation", async () => {
-    const persistedUser = {
-      role: "user",
-      content: [{ type: "text", text: "visible prompt" }],
-      __openclaw: { id: "visible-user", seq: 1 },
-    };
-    const hiddenAssistant = {
-      role: "assistant",
-      content: [{ type: "text", text: "NO_REPLY" }],
-    };
-    const request = vi.fn().mockResolvedValue({ messages: [persistedUser] });
-    const state = createState({
-      connected: true,
-      client: { request } as unknown as ChatState["client"],
-      chatMessages: [persistedUser, hiddenAssistant],
-    });
-
-    await loadChatHistory(state);
-
-    expect(state.chatMessages).toEqual([persistedUser]);
-  });
-
-  it("keeps active streamed assistant text when history reload returns a stale snapshot", async () => {
-    const persistedUser = {
-      role: "user",
-      content: [{ type: "text", text: "first" }],
-      __openclaw: { seq: 1 },
-    };
-    const optimisticUser = {
-      role: "user",
-      content: [{ type: "text", text: "latest ask" }],
-      timestamp: 10,
-    };
-    const request = vi.fn().mockResolvedValue({
-      messages: [persistedUser],
-      thinkingLevel: "low",
-    });
-    const state = createState({
-      connected: true,
-      client: { request } as unknown as ChatState["client"],
-      chatMessages: [persistedUser, optimisticUser],
+      chatMessages: [persistedUser],
       chatRunId: "run-1",
-      chatStream: "First visible stream text.",
+      chatStream: stream,
       chatStreamStartedAt: 100,
-    });
+    }) as ChatState & {
+      chatStreamSegments: HistoryToolSegment[];
+      chatToolMessages: Record<string, unknown>[];
+      toolStreamById: Map<string, unknown>;
+      toolStreamOrder: string[];
+      toolStreamSyncTimer: number | null;
+    };
+    state.chatStreamSegments = segments;
+    state.chatToolMessages = tools;
+    state.toolStreamById = new Map(
+      tools.map((tool) => [String(tool.toolCallId), { message: tool }]),
+    );
+    state.toolStreamOrder = tools.map((tool) => String(tool.toolCallId));
+    state.toolStreamSyncTimer = null;
 
     await loadChatHistory(state);
 
-    expect(state.chatMessages).toEqual([persistedUser, optimisticUser]);
+    expect(state.chatMessages).toHaveLength(expectedRows.length + 1);
+    expect(state.chatMessages[0]).toEqual(persistedUser);
+    for (const [index, row] of expectedRows.entries()) {
+      if (typeof row === "number") {
+        expect(state.chatMessages[index + 1]).toEqual(tools[row]);
+      } else {
+        expectTextChatMessage(state.chatMessages[index + 1], "assistant", row.text);
+        expect(requireRecord(state.chatMessages[index + 1]).timestamp).toBe(row.timestamp);
+      }
+    }
     expect(state.chatRunId).toBe("run-1");
-    expect(state.chatStream).toBe("First visible stream text.");
+    expect(state.chatStream).toBe(expectedStream);
     expect(state.chatStreamStartedAt).toBe(100);
+    expect(state.chatToolMessages).toEqual(remainingTools.map((index) => tools[index]));
+    expect(state.chatStreamSegments).toEqual(remainingSegments);
+    expect(state.toolStreamById.size).toBe(remainingTools.length);
+    expect(state.toolStreamOrder).toEqual(
+      remainingTools.map((index) => String(tools[index]?.toolCallId)),
+    );
+    for (const index of remainingTools) {
+      expect(state.toolStreamById.has(String(tools[index]?.toolCallId))).toBe(true);
+    }
   });
-
-  it("clears live tool cards when history catches up before assistant text", async () => {
-    const persistedUser = {
-      role: "user",
-      content: [{ type: "text", text: "latest ask" }],
-      __openclaw: { seq: 1 },
-    };
-    const persistedToolResult = {
-      role: "toolResult",
-      toolCallId: "call_1",
-      toolName: "shell",
-      content: [{ type: "text", text: "tool output" }],
-      timestamp: 2,
-      __openclaw: { seq: 2 },
-    };
-    const request = vi.fn().mockResolvedValue({
-      messages: [persistedUser, persistedToolResult],
-      thinkingLevel: "low",
-    });
-    const state = createState({
-      connected: true,
-      client: { request } as unknown as ChatState["client"],
-      chatMessages: [persistedUser],
-      chatRunId: "run-1",
-      chatStream: "Still answering.",
-      chatStreamStartedAt: 100,
-    }) as ChatState & {
-      chatStreamSegments: Array<{ text: string; ts: number }>;
-      chatToolMessages: Record<string, unknown>[];
-      toolStreamById: Map<string, unknown>;
-      toolStreamOrder: string[];
-      toolStreamSyncTimer: number | null;
-    };
-    state.chatStreamSegments = [{ text: "before tool", ts: 1 }];
-    state.chatToolMessages = [persistedToolResult];
-    state.toolStreamById = new Map([["call_1", { message: persistedToolResult }]]);
-    state.toolStreamOrder = ["call_1"];
-    state.toolStreamSyncTimer = null;
-
-    await loadChatHistory(state);
-
-    expect(state.chatMessages).toHaveLength(3);
-    expect(state.chatMessages[0]).toEqual(persistedUser);
-    expectTextChatMessage(state.chatMessages[1], "assistant", "before tool");
-    expect(requireRecord(state.chatMessages[1]).timestamp).toBe(1);
-    expect(state.chatMessages[2]).toEqual(persistedToolResult);
-    expect(state.chatRunId).toBe("run-1");
-    expect(state.chatStream).toBe("Still answering.");
-    expect(state.chatStreamStartedAt).toBe(100);
-    expect(state.chatToolMessages).toEqual([]);
-    expect(state.chatStreamSegments).toEqual([]);
-    expect(state.toolStreamById.size).toBe(0);
-    expect(state.toolStreamOrder).toEqual([]);
-  });
-
-  it("inserts multiple recovered stream segments before their matching persisted tools", async () => {
-    const persistedUser = {
-      role: "user",
-      content: [{ type: "text", text: "latest ask" }],
-      __openclaw: { seq: 1 },
-    };
-    const firstToolResult = {
-      role: "toolResult",
-      toolCallId: "call_1",
-      toolName: "shell",
-      content: [{ type: "text", text: "first output" }],
-      timestamp: 2,
-      __openclaw: { seq: 2 },
-    };
-    const secondToolResult = {
-      role: "toolResult",
-      toolCallId: "call_2",
-      toolName: "shell",
-      content: [{ type: "text", text: "second output" }],
-      timestamp: 4,
-      __openclaw: { seq: 3 },
-    };
-    const request = vi.fn().mockResolvedValue({
-      messages: [persistedUser, firstToolResult, secondToolResult],
-      thinkingLevel: "low",
-    });
-    const state = createState({
-      connected: true,
-      client: { request } as unknown as ChatState["client"],
-      chatMessages: [persistedUser],
-      chatRunId: "run-1",
-      chatStream: "Still answering.",
-      chatStreamStartedAt: 100,
-    }) as ChatState & {
-      chatStreamSegments: Array<{ text: string; ts: number }>;
-      chatToolMessages: Record<string, unknown>[];
-      toolStreamById: Map<string, unknown>;
-      toolStreamOrder: string[];
-      toolStreamSyncTimer: number | null;
-    };
-    state.chatStreamSegments = [
-      { text: "before first tool", ts: 1 },
-      { text: "before first tool\nbefore second tool", ts: 3 },
-    ];
-    state.chatToolMessages = [firstToolResult, secondToolResult];
-    state.toolStreamById = new Map([
-      ["call_1", { message: firstToolResult }],
-      ["call_2", { message: secondToolResult }],
-    ]);
-    state.toolStreamOrder = ["call_1", "call_2"];
-    state.toolStreamSyncTimer = null;
-
-    await loadChatHistory(state);
-
-    expect(state.chatMessages).toHaveLength(5);
-    expect(state.chatMessages[0]).toEqual(persistedUser);
-    expectTextChatMessage(state.chatMessages[1], "assistant", "before first tool");
-    expect(state.chatMessages[2]).toEqual(firstToolResult);
-    expectTextChatMessage(state.chatMessages[3], "assistant", "before second tool");
-    expect(state.chatMessages[4]).toEqual(secondToolResult);
-    expect(requireRecord(state.chatMessages[1]).timestamp).toBe(1);
-    expect(requireRecord(state.chatMessages[3]).timestamp).toBe(3);
-    expect(state.chatToolMessages).toEqual([]);
-    expect(state.chatStreamSegments).toEqual([]);
-    expect(state.toolStreamById.size).toBe(0);
-    expect(state.toolStreamOrder).toEqual([]);
-  });
-
-  it("prunes only the live tool cards that history has caught up with", async () => {
-    const persistedUser = {
-      role: "user",
-      content: [{ type: "text", text: "latest ask" }],
-      __openclaw: { seq: 1 },
-    };
-    const firstToolResult = {
-      role: "toolResult",
-      toolCallId: "call_1",
-      toolName: "shell",
-      content: [{ type: "text", text: "first output" }],
-      timestamp: 2,
-      __openclaw: { seq: 2 },
-    };
-    const secondLiveToolResult = {
-      role: "assistant",
-      toolCallId: "call_2",
-      runId: "run-1",
-      content: [
-        { type: "toolcall", name: "shell", arguments: {} },
-        { type: "toolresult", name: "shell", text: "second output" },
-      ],
-      timestamp: 4,
-    };
-    const request = vi.fn().mockResolvedValue({
-      messages: [persistedUser, firstToolResult],
-      thinkingLevel: "low",
-    });
-    const state = createState({
-      connected: true,
-      client: { request } as unknown as ChatState["client"],
-      chatMessages: [persistedUser],
-      chatRunId: "run-1",
-      chatStream: "before first tool\nbefore second tool\nStill answering.",
-      chatStreamStartedAt: 100,
-    }) as ChatState & {
-      chatStreamSegments: Array<{ text: string; ts: number; toolCallId?: string }>;
-      chatToolMessages: Record<string, unknown>[];
-      toolStreamById: Map<string, unknown>;
-      toolStreamOrder: string[];
-      toolStreamSyncTimer: number | null;
-    };
-    state.chatStreamSegments = [
-      { text: "before first tool", ts: 1, toolCallId: "call_1" },
-      {
-        text: "before first tool\nbefore second tool",
-        ts: 3,
-        toolCallId: "call_2",
-      },
-    ];
-    state.chatToolMessages = [firstToolResult, secondLiveToolResult];
-    state.toolStreamById = new Map([
-      ["call_1", { message: firstToolResult }],
-      ["call_2", { message: secondLiveToolResult }],
-    ]);
-    state.toolStreamOrder = ["call_1", "call_2"];
-    state.toolStreamSyncTimer = null;
-
-    await loadChatHistory(state);
-
-    expect(state.chatMessages).toHaveLength(3);
-    expect(state.chatMessages[0]).toEqual(persistedUser);
-    expectTextChatMessage(state.chatMessages[1], "assistant", "before first tool");
-    expect(state.chatMessages[2]).toEqual(firstToolResult);
-    expect(state.chatToolMessages).toEqual([secondLiveToolResult]);
-    expect(state.chatStreamSegments).toEqual([
-      { text: "before second tool", ts: 3, toolCallId: "call_2" },
-    ]);
-    expect(state.chatStream).toBe("Still answering.");
-    expect(state.toolStreamById.size).toBe(1);
-    expect(state.toolStreamById.has("call_2")).toBe(true);
-    expect(state.toolStreamOrder).toEqual(["call_2"]);
-  });
-
-  it("uses segment tool ids when a tool starts before any stream text", async () => {
-    const persistedUser = {
-      role: "user",
-      content: [{ type: "text", text: "latest ask" }],
-      __openclaw: { seq: 1 },
-    };
-    const firstToolResult = {
-      role: "toolResult",
-      toolCallId: "call_1",
-      toolName: "shell",
-      content: [{ type: "text", text: "first output" }],
-      timestamp: 2,
-      __openclaw: { seq: 2 },
-    };
-    const secondToolResult = {
-      role: "toolResult",
-      toolCallId: "call_2",
-      toolName: "shell",
-      content: [{ type: "text", text: "second output" }],
-      timestamp: 4,
-      __openclaw: { seq: 3 },
-    };
-    const request = vi.fn().mockResolvedValue({
-      messages: [persistedUser, firstToolResult, secondToolResult],
-      thinkingLevel: "low",
-    });
-    const state = createState({
-      connected: true,
-      client: { request } as unknown as ChatState["client"],
-      chatMessages: [persistedUser],
-      chatRunId: "run-1",
-      chatStream: "Still answering.",
-      chatStreamStartedAt: 100,
-    }) as ChatState & {
-      chatStreamSegments: Array<{ text: string; ts: number; toolCallId?: string }>;
-      chatToolMessages: Record<string, unknown>[];
-      toolStreamById: Map<string, unknown>;
-      toolStreamOrder: string[];
-      toolStreamSyncTimer: number | null;
-    };
-    state.chatStreamSegments = [{ text: "before second tool", ts: 3, toolCallId: "call_2" }];
-    state.chatToolMessages = [firstToolResult, secondToolResult];
-    state.toolStreamById = new Map([
-      ["call_1", { message: firstToolResult }],
-      ["call_2", { message: secondToolResult }],
-    ]);
-    state.toolStreamOrder = ["call_1", "call_2"];
-    state.toolStreamSyncTimer = null;
-
-    await loadChatHistory(state);
-
-    expect(state.chatMessages).toHaveLength(4);
-    expect(state.chatMessages[0]).toEqual(persistedUser);
-    expect(state.chatMessages[1]).toEqual(firstToolResult);
-    expectTextChatMessage(state.chatMessages[2], "assistant", "before second tool");
-    expect(state.chatMessages[3]).toEqual(secondToolResult);
-    expect(requireRecord(state.chatMessages[2]).timestamp).toBe(3);
-    expect(state.chatToolMessages).toEqual([]);
-    expect(state.chatStreamSegments).toEqual([]);
-    expect(state.toolStreamById.size).toBe(0);
-    expect(state.toolStreamOrder).toEqual([]);
-  });
-
-  it("trims accumulated current stream after materializing caught-up tool segments", async () => {
-    const persistedUser = {
-      role: "user",
-      content: [{ type: "text", text: "latest ask" }],
-      __openclaw: { seq: 1 },
-    };
-    const persistedToolResult = {
-      role: "toolResult",
-      toolCallId: "call_1",
-      toolName: "shell",
-      content: [{ type: "text", text: "tool output" }],
-      timestamp: 2,
-      __openclaw: { seq: 2 },
-    };
-    const request = vi.fn().mockResolvedValue({
-      messages: [persistedUser, persistedToolResult],
-      thinkingLevel: "low",
-    });
-    const state = createState({
-      connected: true,
-      client: { request } as unknown as ChatState["client"],
-      chatMessages: [persistedUser],
-      chatRunId: "run-1",
-      chatStream: "before tool\nafter tool",
-      chatStreamStartedAt: 100,
-    }) as ChatState & {
-      chatStreamSegments: Array<{ text: string; ts: number; toolCallId?: string }>;
-      chatToolMessages: Record<string, unknown>[];
-      toolStreamById: Map<string, unknown>;
-      toolStreamOrder: string[];
-      toolStreamSyncTimer: number | null;
-    };
-    state.chatStreamSegments = [{ text: "before tool", ts: 1, toolCallId: "call_1" }];
-    state.chatToolMessages = [persistedToolResult];
-    state.toolStreamById = new Map([["call_1", { message: persistedToolResult }]]);
-    state.toolStreamOrder = ["call_1"];
-    state.toolStreamSyncTimer = null;
-
-    await loadChatHistory(state);
-
-    expect(state.chatMessages).toHaveLength(3);
-    expect(state.chatMessages[0]).toEqual(persistedUser);
-    expectTextChatMessage(state.chatMessages[1], "assistant", "before tool");
-    expect(state.chatMessages[2]).toEqual(persistedToolResult);
-    expect(state.chatStream).toBe("after tool");
-    expect(state.chatStreamStartedAt).toBe(100);
-    expect(state.chatToolMessages).toEqual([]);
-    expect(state.chatStreamSegments).toEqual([]);
-    expect(state.toolStreamById.size).toBe(0);
-    expect(state.toolStreamOrder).toEqual([]);
-  });
-
   it("keeps live tool cards when only older history has a persisted tool result", async () => {
     const olderUser = {
       role: "user",

--- a/ui/src/pages/chat/chat-send.test.ts
+++ b/ui/src/pages/chat/chat-send.test.ts
@@ -751,103 +751,34 @@ describe("refreshChatAvatar", () => {
     await loadChatHelpers();
   });
 
-  it("uses a route-relative avatar endpoint before basePath bootstrap finishes", async () => {
-    const createObjectURL = vi.fn(() => "blob:local-avatar");
-    const revokeObjectURL = vi.fn();
-    vi.stubGlobal(
-      "URL",
-      class extends URL {
-        static override createObjectURL = createObjectURL;
-        static override revokeObjectURL = revokeObjectURL;
-      },
-    );
-    const fetchMock = vi.fn((input: string | URL | Request) => {
-      const url = requestUrl(input);
-      if (url === "/avatar/main?meta=1") {
-        return Promise.resolve({
-          ok: true,
-          json: async () => ({ avatarUrl: "/avatar/main" }),
-        });
-      }
-      if (url === "/avatar/main") {
-        return Promise.resolve({
-          ok: true,
-          blob: async () => new Blob(["avatar"]),
-        });
-      }
-      throw new Error(`Unexpected avatar URL: ${url}`);
-    });
-    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
-
-    const host = makeHost({ basePath: "", sessionKey: "agent:main" });
-    await refreshChatAvatar(host);
-
-    expect(fetchUrl(fetchMock as unknown as MockCallSource, 0)).toBe("/avatar/main?meta=1");
-    expect(fetchInit(fetchMock as unknown as MockCallSource, 0).method).toBe("GET");
-    expect(fetchUrl(fetchMock as unknown as MockCallSource, 1)).toBe("/avatar/main");
-    expect(fetchInit(fetchMock as unknown as MockCallSource, 1).method).toBe("GET");
-    expect(fetchInit(fetchMock as unknown as MockCallSource, 1)).not.toHaveProperty("headers");
-    expect(createObjectURL).toHaveBeenCalledTimes(1);
-    expect(revokeObjectURL).not.toHaveBeenCalled();
-    expect(host.chatAvatarUrl).toBe("blob:local-avatar");
-  });
-
-  it("prefers the paired device token for avatar metadata and local avatar URLs", async () => {
-    const createObjectURL = vi.fn(() => "blob:device-avatar");
-    const revokeObjectURL = vi.fn();
-    vi.stubGlobal(
-      "URL",
-      class extends URL {
-        static override createObjectURL = createObjectURL;
-        static override revokeObjectURL = revokeObjectURL;
-      },
-    );
-    const fetchMock = vi.fn((input: string | URL | Request) => {
-      const url = requestUrl(input);
-      if (url === "/openclaw/avatar/main?meta=1") {
-        return Promise.resolve({
-          ok: true,
-          json: async () => ({ avatarUrl: "/avatar/main" }),
-        });
-      }
-      if (url === "/avatar/main") {
-        return Promise.resolve({
-          ok: true,
-          blob: async () => new Blob(["avatar"]),
-        });
-      }
-      throw new Error(`Unexpected avatar URL: ${url}`);
-    });
-    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
-
-    const host = makeHost({
+  it.each([
+    {
+      name: "uses a route-relative avatar endpoint before basePath bootstrap finishes",
+      basePath: "",
+      objectUrl: "blob:local-avatar",
+      expectedToken: undefined,
+      overrides: {},
+    },
+    {
+      name: "prefers the paired device token for avatar metadata and local avatar URLs",
       basePath: "/openclaw/",
-      sessionKey: "agent:main",
-      settings: { token: "session-token" },
-      password: "shared-password",
-      hello: { auth: { deviceToken: "device-token" } } as ChatHost["hello"],
-    });
-    await refreshChatAvatar(host);
-
-    expect(fetchUrl(fetchMock as unknown as MockCallSource, 0)).toBe(
-      "/openclaw/avatar/main?meta=1",
-    );
-    expect(fetchInit(fetchMock as unknown as MockCallSource, 0).method).toBe("GET");
-    expect(fetchInit(fetchMock as unknown as MockCallSource, 0).headers).toEqual({
-      Authorization: "Bearer device-token",
-    });
-    expect(fetchUrl(fetchMock as unknown as MockCallSource, 1)).toBe("/avatar/main");
-    expect(fetchInit(fetchMock as unknown as MockCallSource, 1).method).toBe("GET");
-    expect(fetchInit(fetchMock as unknown as MockCallSource, 1).headers).toEqual({
-      Authorization: "Bearer device-token",
-    });
-    expect(createObjectURL).toHaveBeenCalledTimes(1);
-    expect(revokeObjectURL).not.toHaveBeenCalled();
-    expect(host.chatAvatarUrl).toBe("blob:device-avatar");
-  });
-
-  it("fetches local avatars through Authorization headers instead of tokenized URLs", async () => {
-    const createObjectURL = vi.fn(() => "blob:session-avatar");
+      objectUrl: "blob:device-avatar",
+      expectedToken: "device-token",
+      overrides: {
+        settings: { token: "session-token" },
+        password: "shared-password",
+        hello: { auth: { deviceToken: "device-token" } } as ChatHost["hello"],
+      },
+    },
+    {
+      name: "fetches local avatars through Authorization headers instead of tokenized URLs",
+      basePath: "/openclaw/",
+      objectUrl: "blob:session-avatar",
+      expectedToken: "session-token",
+      overrides: { settings: { token: "session-token" } },
+    },
+  ])("$name", async ({ basePath, objectUrl, expectedToken, overrides }) => {
+    const createObjectURL = vi.fn(() => objectUrl);
     const revokeObjectURL = vi.fn();
     vi.stubGlobal(
       "URL",
@@ -856,48 +787,36 @@ describe("refreshChatAvatar", () => {
         static override revokeObjectURL = revokeObjectURL;
       },
     );
+    const metadataUrl = `${basePath.replace(/\/$/, "")}/avatar/main?meta=1`;
     const fetchMock = vi.fn((input: string | URL | Request) => {
       const url = requestUrl(input);
-      if (url === "/openclaw/avatar/main?meta=1") {
-        return Promise.resolve({
-          ok: true,
-          json: async () => ({ avatarUrl: "/avatar/main" }),
-        });
+      if (url === metadataUrl) {
+        return Promise.resolve({ ok: true, json: async () => ({ avatarUrl: "/avatar/main" }) });
       }
       if (url === "/avatar/main") {
-        return Promise.resolve({
-          ok: true,
-          blob: async () => new Blob(["avatar"]),
-        });
+        return Promise.resolve({ ok: true, blob: async () => new Blob(["avatar"]) });
       }
       throw new Error(`Unexpected avatar URL: ${url}`);
     });
     vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+    const host = makeHost({ basePath, sessionKey: "agent:main", ...overrides });
 
-    const host = makeHost({
-      basePath: "/openclaw/",
-      sessionKey: "agent:main",
-      settings: { token: "session-token" },
-    });
     await refreshChatAvatar(host);
 
-    expect(fetchUrl(fetchMock as unknown as MockCallSource, 0)).toBe(
-      "/openclaw/avatar/main?meta=1",
-    );
-    expect(fetchInit(fetchMock as unknown as MockCallSource, 0).method).toBe("GET");
-    expect(fetchInit(fetchMock as unknown as MockCallSource, 0).headers).toEqual({
-      Authorization: "Bearer session-token",
-    });
-    expect(fetchUrl(fetchMock as unknown as MockCallSource, 1)).toBe("/avatar/main");
-    expect(fetchInit(fetchMock as unknown as MockCallSource, 1).method).toBe("GET");
-    expect(fetchInit(fetchMock as unknown as MockCallSource, 1).headers).toEqual({
-      Authorization: "Bearer session-token",
-    });
+    for (const [index, url] of [metadataUrl, "/avatar/main"].entries()) {
+      expect(fetchUrl(fetchMock as unknown as MockCallSource, index)).toBe(url);
+      const init = fetchInit(fetchMock as unknown as MockCallSource, index);
+      expect(init.method).toBe("GET");
+      if (expectedToken) {
+        expect(init.headers).toEqual({ Authorization: `Bearer ${expectedToken}` });
+      } else {
+        expect(init).not.toHaveProperty("headers");
+      }
+    }
     expect(createObjectURL).toHaveBeenCalledTimes(1);
     expect(revokeObjectURL).not.toHaveBeenCalled();
-    expect(host.chatAvatarUrl).toBe("blob:session-avatar");
+    expect(host.chatAvatarUrl).toBe(objectUrl);
   });
-
   it("keeps mounted dashboard avatar endpoints under the normalized base path", async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: false,
@@ -954,7 +873,29 @@ describe("refreshChatAvatar", () => {
     expect(host.chatAvatarReason).toBe("missing");
   });
 
-  it("ignores stale avatar responses after switching sessions", async () => {
+  it.each([
+    {
+      name: "ignores stale avatar responses after switching sessions",
+      firstAgent: "main",
+      overrides: { sessionKey: "agent:main:main" },
+      switchAgent(host: TestChatHost) {
+        host.sessionKey = "agent:ops:main";
+      },
+    },
+    {
+      name: "ignores stale global avatar responses after switching selected agents",
+      firstAgent: "work",
+      overrides: {
+        sessionKey: "global",
+        assistantAgentId: "work",
+        agentsList: { defaultId: "main" },
+      },
+      switchAgent(host: TestChatHost) {
+        host.assistantAgentId = "ops";
+      },
+    },
+  ])("$name", async (fixture) => {
+    const { firstAgent, overrides } = fixture;
     const createObjectURL = vi.fn(() => "blob:ops-avatar");
     const revokeObjectURL = vi.fn();
     vi.stubGlobal(
@@ -964,114 +905,41 @@ describe("refreshChatAvatar", () => {
         static override revokeObjectURL = revokeObjectURL;
       },
     );
-    const mainRequest = createDeferred<{ avatarUrl?: string }>();
+    const firstRequest = createDeferred<{ avatarUrl?: string }>();
     const opsRequest = createDeferred<{ avatarUrl?: string }>();
+    const firstMetadataUrl = `/avatar/${firstAgent}?meta=1`;
     const fetchMock = vi.fn((input: string | URL | Request) => {
       const url = requestUrl(input);
-      if (url === "/avatar/main?meta=1") {
-        return Promise.resolve({
-          ok: true,
-          json: async () => mainRequest.promise,
-        });
+      if (url === firstMetadataUrl) {
+        return Promise.resolve({ ok: true, json: async () => firstRequest.promise });
       }
       if (url === "/avatar/ops?meta=1") {
-        return Promise.resolve({
-          ok: true,
-          json: async () => opsRequest.promise,
-        });
+        return Promise.resolve({ ok: true, json: async () => opsRequest.promise });
       }
       if (url === "/avatar/ops") {
-        return Promise.resolve({
-          ok: true,
-          blob: async () => new Blob(["avatar"]),
-        });
+        return Promise.resolve({ ok: true, blob: async () => new Blob(["avatar"]) });
       }
       throw new Error(`Unexpected avatar URL: ${url}`);
     });
     vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
-
-    const host = makeHost({ basePath: "", sessionKey: "agent:main:main" });
+    const host = makeHost({ basePath: "", ...overrides });
 
     const firstRefresh = refreshChatAvatar(host);
-    host.sessionKey = "agent:ops:main";
+    fixture.switchAgent(host);
     const secondRefresh = refreshChatAvatar(host);
-
-    mainRequest.resolve({ avatarUrl: "/avatar/main" });
+    firstRequest.resolve({ avatarUrl: `/avatar/${firstAgent}` });
     await firstRefresh;
     expect(host.chatAvatarUrl).toBeNull();
-
     opsRequest.resolve({ avatarUrl: "/avatar/ops" });
     await secondRefresh;
 
     expect(createObjectURL).toHaveBeenCalledTimes(1);
+    expect(revokeObjectURL).not.toHaveBeenCalled();
     expect(host.chatAvatarUrl).toBe("blob:ops-avatar");
-    expect(fetchUrl(fetchMock as unknown as MockCallSource, 0)).toBe("/avatar/main?meta=1");
-    expect(fetchInit(fetchMock as unknown as MockCallSource, 0).method).toBe("GET");
-    expect(fetchUrl(fetchMock as unknown as MockCallSource, 1)).toBe("/avatar/ops?meta=1");
-    expect(fetchInit(fetchMock as unknown as MockCallSource, 1).method).toBe("GET");
-    expect(fetchUrl(fetchMock as unknown as MockCallSource, 2)).toBe("/avatar/ops");
-    expect(fetchInit(fetchMock as unknown as MockCallSource, 2).method).toBe("GET");
-  });
-
-  it("ignores stale global avatar responses after switching selected agents", async () => {
-    const createObjectURL = vi.fn(() => "blob:ops-avatar");
-    const revokeObjectURL = vi.fn();
-    vi.stubGlobal(
-      "URL",
-      class extends URL {
-        static override createObjectURL = createObjectURL;
-        static override revokeObjectURL = revokeObjectURL;
-      },
-    );
-    const workRequest = createDeferred<{ avatarUrl?: string }>();
-    const opsRequest = createDeferred<{ avatarUrl?: string }>();
-    const fetchMock = vi.fn((input: string | URL | Request) => {
-      const url = requestUrl(input);
-      if (url === "/avatar/work?meta=1") {
-        return Promise.resolve({
-          ok: true,
-          json: async () => workRequest.promise,
-        });
-      }
-      if (url === "/avatar/ops?meta=1") {
-        return Promise.resolve({
-          ok: true,
-          json: async () => opsRequest.promise,
-        });
-      }
-      if (url === "/avatar/ops") {
-        return Promise.resolve({
-          ok: true,
-          blob: async () => new Blob(["avatar"]),
-        });
-      }
-      throw new Error(`Unexpected avatar URL: ${url}`);
-    });
-    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
-
-    const host = makeHost({
-      basePath: "",
-      sessionKey: "global",
-      assistantAgentId: "work",
-      agentsList: { defaultId: "main" },
-    });
-
-    const firstRefresh = refreshChatAvatar(host);
-    host.assistantAgentId = "ops";
-    const secondRefresh = refreshChatAvatar(host);
-
-    workRequest.resolve({ avatarUrl: "/avatar/work" });
-    await firstRefresh;
-    expect(host.chatAvatarUrl).toBeNull();
-
-    opsRequest.resolve({ avatarUrl: "/avatar/ops" });
-    await secondRefresh;
-
-    expect(createObjectURL).toHaveBeenCalledTimes(1);
-    expect(host.chatAvatarUrl).toBe("blob:ops-avatar");
-    expect(fetchUrl(fetchMock as unknown as MockCallSource, 0)).toBe("/avatar/work?meta=1");
-    expect(fetchUrl(fetchMock as unknown as MockCallSource, 1)).toBe("/avatar/ops?meta=1");
-    expect(fetchUrl(fetchMock as unknown as MockCallSource, 2)).toBe("/avatar/ops");
+    for (const [index, url] of [firstMetadataUrl, "/avatar/ops?meta=1", "/avatar/ops"].entries()) {
+      expect(fetchUrl(fetchMock as unknown as MockCallSource, index)).toBe(url);
+      expect(fetchInit(fetchMock as unknown as MockCallSource, index).method).toBe("GET");
+    }
   });
 });
 

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -1060,68 +1060,56 @@ describe("grouped chat rendering", () => {
     expect(tooltip?.content).toBe("Rewind is unavailable while the agent is working");
   });
 
-  it("places the delete confirm below the trigger near the top viewport edge", () => {
-    stubDeleteConfirmGeometry({
+  it.each([
+    {
+      name: "places the delete confirm below the trigger near the top viewport edge",
       trigger: { left: 20, top: 4, width: 24, height: 24 },
       popover: { width: 200, height: 96 },
       viewport: { width: 320, height: 240 },
-    });
-    const fixture = renderDeleteConfirmFixture();
-
-    openDeleteConfirm(fixture.deleteButton);
-
-    const popover = expectElement(fixture.container, ".chat-delete-confirm", HTMLElement);
-    expect(popover.dataset.placement).toBe("below");
-    expect(popover.style.top).toBe("34px");
-    expect(popover.style.left).toBe("20px");
-  });
-
-  it("places the delete confirm above the trigger near the bottom viewport edge", () => {
-    stubDeleteConfirmGeometry({
+      placement: "below",
+      top: "34px",
+      left: "20px",
+    },
+    {
+      name: "places the delete confirm above the trigger near the bottom viewport edge",
       trigger: { left: 20, top: 190, width: 24, height: 24 },
       popover: { width: 200, height: 80 },
       viewport: { width: 320, height: 240 },
-    });
-    const fixture = renderDeleteConfirmFixture();
-
-    openDeleteConfirm(fixture.deleteButton);
-
-    const popover = expectElement(fixture.container, ".chat-delete-confirm", HTMLElement);
-    expect(popover.dataset.placement).toBe("above");
-    expect(popover.style.top).toBe("104px");
-    expect(popover.style.left).toBe("20px");
-  });
-
-  it("clamps the delete confirm horizontally inside narrow viewports", () => {
-    stubDeleteConfirmGeometry({
+      placement: "above",
+      top: "104px",
+      left: "20px",
+    },
+    {
+      name: "clamps the delete confirm horizontally inside narrow viewports",
       trigger: { left: 260, top: 120, width: 24, height: 24 },
       popover: { width: 200, height: 80 },
       viewport: { width: 320, height: 240 },
-    });
-    const fixture = renderDeleteConfirmFixture();
-
-    openDeleteConfirm(fixture.deleteButton);
-
-    const popover = expectElement(fixture.container, ".chat-delete-confirm", HTMLElement);
-    expect(popover.style.left).toBe("112px");
-  });
-
-  it("clamps the delete confirm inside shifted visual viewports", () => {
-    stubDeleteConfirmGeometry({
+      left: "112px",
+    },
+    {
+      name: "clamps the delete confirm inside shifted visual viewports",
       trigger: { left: 620, top: 540, width: 24, height: 24 },
       popover: { width: 200, height: 80 },
       viewport: { left: 320, top: 300, width: 320, height: 240 },
-    });
+      placement: "above",
+      top: "452px",
+      left: "432px",
+    },
+  ])("$name", ({ trigger, popover, viewport, placement, top, left }) => {
+    stubDeleteConfirmGeometry({ trigger, popover, viewport });
     const fixture = renderDeleteConfirmFixture();
 
     openDeleteConfirm(fixture.deleteButton);
 
-    const popover = expectElement(fixture.container, ".chat-delete-confirm", HTMLElement);
-    expect(popover.dataset.placement).toBe("above");
-    expect(popover.style.left).toBe("432px");
-    expect(popover.style.top).toBe("452px");
+    const element = expectElement(fixture.container, ".chat-delete-confirm", HTMLElement);
+    if (placement) {
+      expect(element.dataset.placement).toBe(placement);
+    }
+    if (top) {
+      expect(element.style.top).toBe(top);
+    }
+    expect(element.style.left).toBe(left);
   });
-
   it("exposes dialog semantics and keeps keyboard focus inside the confirmation", () => {
     const fixture = renderDeleteConfirmFixture();
 


### PR DESCRIPTION
## What Problem This Solves

The Control UI chat regressions repeated the same Gateway, avatar, abort, tool-replay, and confirmation setup across hundreds of lines, making critical send, stream, and reconnect scenarios harder to understand and maintain.

## Why This Change Was Made

Replace duplicated chat fixtures with descriptive, isolated, table-driven behavior matrices. Preserve every existing named regression and every production scenario, including malformed aborts, cross-session avatar authorization, exact tool ordering and timestamps, stream recovery, and confirmation positioning. This is a maintainer-requested, AI-assisted test consolidation; no production code, snapshots, coverage configuration, or expected-failure inventories are changed.

## User Impact

No product behavior change. Chat regressions remain independently visible while the test suite loses 806 net formatted lines and preserves every covered production statement, branch, function, and line.

## Evidence

- Blacksmith Testbox `tbx_01kygzecvarf3fn7f8nzjnpx62`; Node 24; existing `test/vitest/vitest.ui.config.ts` UI lane.
- All four focused chat suites: **719/719 passing both before and after** (send 232, gateway 156, chat view 201, chat-message rendering 130).
- Identical V8 production source set, include `ui/src/pages/chat/**/*.ts`, same denominator before and after:
  - Statements: **6,404/18,630 → 6,404/18,630**.
  - Branches: **5,955/17,451 → 5,955/17,451**.
  - Functions: **1,248/3,404 → 1,248/3,404**.
  - Lines: **6,269/18,160 → 6,269/18,160**.
- `git diff --check` and targeted `oxfmt` pass.
- Fresh structured `autoreview` and the remote UI changed gate: **pass**.
- Exact-head hosted CI: [complete CI run 30239614483](https://github.com/openclaw/openclaw/actions/runs/30239614483); [required openclaw/ci-gate](https://github.com/openclaw/openclaw/actions/runs/30239614483/job/89894688297), [complete Control UI test lane](https://github.com/openclaw/openclaw/actions/runs/30239614483/job/89894019668), test types, and all four QA smoke profiles: **success**.

## Exact named-regression traceability

Compared directly against baseline `16d2b7e46784c75eb5d57329269e9fd47222d2ef` and the frozen PR head `f76d10f44e2b81e2250e0710daea9543f349ec0a`: all **60** removed standalone named regressions are preserved one-for-one as independently named `it.each` rows with the **identical original test name**. No removed standalone scenario was unmatched. The complete four-suite execution remains **719/719**, and all four production V8 counts remain exactly unchanged as recorded above.

<details>
<summary><code>ui/src/pages/chat/chat-gateway.test.ts</code>: 51 exact original-name-to-row mappings</summary>

- `appends gateway deltaText when the cumulative snapshot matches the current prefix` → [identically named table row](https://github.com/openclaw/openclaw/blob/f76d10f44e2b81e2250e0710daea9543f349ec0a/ui/src/pages/chat/chat-gateway.test.ts#L464)
- `uses the cumulative snapshot when the first observed delta joins mid-stream` → [identically named table row](https://github.com/openclaw/openclaw/blob/f76d10f44e2b81e2250e0710daea9543f349ec0a/ui/src/pages/chat/chat-gateway.test.ts#L471)
- `appends gateway deltaText when no full message snapshot is present` → [identically named table row](https://github.com/openclaw/openclaw/blob/f76d10f44e2b81e2250e0710daea9543f349ec0a/ui/src/pages/chat/chat-gateway.test.ts#L478)
- `uses the cumulative snapshot when a missed delta would make append stale` → [identically named table row](https://github.com/openclaw/openclaw/blob/f76d10f44e2b81e2250e0710daea9543f349ec0a/ui/src/pages/chat/chat-gateway.test.ts#L484)
- `uses the cumulative snapshot when a same-length missed replacement changes the prefix` → [identically named table row](https://github.com/openclaw/openclaw/blob/f76d10f44e2b81e2250e0710daea9543f349ec0a/ui/src/pages/chat/chat-gateway.test.ts#L491)
- `replaces the stream when gateway deltaText marks a replacement` → [identically named table row](https://github.com/openclaw/openclaw/blob/f76d10f44e2b81e2250e0710daea9543f349ec0a/ui/src/pages/chat/chat-gateway.test.ts#L498)
- `processes aborted from own run and keeps partial assistant message` → [identically named table row](https://github.com/openclaw/openclaw/blob/f76d10f44e2b81e2250e0710daea9543f349ec0a/ui/src/pages/chat/chat-gateway.test.ts#L1438)
- `falls back to streamed partial when aborted payload message is invalid` → [identically named table row](https://github.com/openclaw/openclaw/blob/f76d10f44e2b81e2250e0710daea9543f349ec0a/ui/src/pages/chat/chat-gateway.test.ts#L1446)
- `falls back to streamed partial when aborted payload has non-assistant role` → [identically named table row](https://github.com/openclaw/openclaw/blob/f76d10f44e2b81e2250e0710daea9543f349ec0a/ui/src/pages/chat/chat-gateway.test.ts#L1452)
- `processes aborted from own run without message and empty stream` → [identically named table row](https://github.com/openclaw/openclaw/blob/f76d10f44e2b81e2250e0710daea9543f349ec0a/ui/src/pages/chat/chat-gateway.test.ts#L1458)
- `keeps error events outside the assistant transcript` → [identically named table row](https://github.com/openclaw/openclaw/blob/f76d10f44e2b81e2250e0710daea9543f349ec0a/ui/src/pages/chat/chat-gateway.test.ts#L1509)
- `keeps streamed assistant text visible when an error ends the run` → [identically named table row](https://github.com/openclaw/openclaw/blob/f76d10f44e2b81e2250e0710daea9543f349ec0a/ui/src/pages/chat/chat-gateway.test.ts#L1521)
- `keeps streamed text without appending the error payload message` → [identically named table row](https://github.com/openclaw/openclaw/blob/f76d10f44e2b81e2250e0710daea9543f349ec0a/ui/src/pages/chat/chat-gateway.test.ts#L1535)
- `uses the gateway error when the payload message repeats the streamed text` → [identically named table row](https://github.com/openclaw/openclaw/blob/f76d10f44e2b81e2250e0710daea9543f349ec0a/ui/src/pages/chat/chat-gateway.test.ts#L1549)
- `preserves terminal assistant content that extends the streamed text` → [identically named table row](https://github.com/openclaw/openclaw/blob/f76d10f44e2b81e2250e0710daea9543f349ec0a/ui/src/pages/chat/chat-gateway.test.ts#L1561)
- `preserves streamed text before a differing terminal assistant message` → [identically named table row](https://github.com/openclaw/openclaw/blob/f76d10f44e2b81e2250e0710daea9543f349ec0a/ui/src/pages/chat/chat-gateway.test.ts#L1573)
- `preserves terminal extensions after a tool splits the stream` → [identically named table row](https://github.com/openclaw/openclaw/blob/f76d10f44e2b81e2250e0710daea9543f349ec0a/ui/src/pages/chat/chat-gateway.test.ts#L1594)
- `preserves a split stream when the terminal message only overlaps its prefix` → [identically named table row](https://github.com/openclaw/openclaw/blob/f76d10f44e2b81e2250e0710daea9543f349ec0a/ui/src/pages/chat/chat-gateway.test.ts#L1607)
- `preserves terminal extensions when split stream punctuation is adjacent` → [identically named table row](https://github.com/openclaw/openclaw/blob/f76d10f44e2b81e2250e0710daea9543f349ec0a/ui/src/pages/chat/chat-gateway.test.ts#L1630)
- `keeps stream segments visible when an error ends after a tool event` → [identically named table row](https://github.com/openclaw/openclaw/blob/f76d10f44e2b81e2250e0710daea9543f349ec0a/ui/src/pages/chat/chat-gateway.test.ts#L1642)
- `does not let a substring-matching error projection replace streamed text` → [identically named table row](https://github.com/openclaw/openclaw/blob/f76d10f44e2b81e2250e0710daea9543f349ec0a/ui/src/pages/chat/chat-gateway.test.ts#L1657)
- `keeps the post-tool stream tail without appending the error projection` → [identically named table row](https://github.com/openclaw/openclaw/blob/f76d10f44e2b81e2250e0710daea9543f349ec0a/ui/src/pages/chat/chat-gateway.test.ts#L1673)
- `does not append legacy assistant-shaped error projections` → [identically named table row](https://github.com/openclaw/openclaw/blob/f76d10f44e2b81e2250e0710daea9543f349ec0a/ui/src/pages/chat/chat-gateway.test.ts#L1693)
- `keeps local optimistic tail messages when history reload returns a stale snapshot` → [identically named table row](https://github.com/openclaw/openclaw/blob/f76d10f44e2b81e2250e0710daea9543f349ec0a/ui/src/pages/chat/chat-gateway.test.ts#L2497)
- `keeps a newly sent repeated user message when history reload is still stale` → [identically named table row](https://github.com/openclaw/openclaw/blob/f76d10f44e2b81e2250e0710daea9543f349ec0a/ui/src/pages/chat/chat-gateway.test.ts#L2512)
- `preserves a distinct pending turn after an earlier repeated-history anchor` → [identically named table row](https://github.com/openclaw/openclaw/blob/f76d10f44e2b81e2250e0710daea9543f349ec0a/ui/src/pages/chat/chat-gateway.test.ts#L2530)
- `does not revive an unmatched pending turn beyond unrelated history` → [identically named table row](https://github.com/openclaw/openclaw/blob/f76d10f44e2b81e2250e0710daea9543f349ec0a/ui/src/pages/chat/chat-gateway.test.ts#L2545)
- `does not adopt an imported message through a colliding native transcript id` → [identically named table row](https://github.com/openclaw/openclaw/blob/f76d10f44e2b81e2250e0710daea9543f349ec0a/ui/src/pages/chat/chat-gateway.test.ts#L2562)
- `does not guess an imported source identity when its session is missing` → [identically named table row](https://github.com/openclaw/openclaw/blob/f76d10f44e2b81e2250e0710daea9543f349ec0a/ui/src/pages/chat/chat-gateway.test.ts#L2584)
- `does not anchor a missing canonical id to another same-sequence projection` → [identically named table row](https://github.com/openclaw/openclaw/blob/f76d10f44e2b81e2250e0710daea9543f349ec0a/ui/src/pages/chat/chat-gateway.test.ts#L2606)
- `does not adopt import provenance lacking an external id as a native row` → [identically named table row](https://github.com/openclaw/openclaw/blob/f76d10f44e2b81e2250e0710daea9543f349ec0a/ui/src/pages/chat/chat-gateway.test.ts#L2622)
- `does not use matching display text to adopt an incomplete imported source` → [identically named table row](https://github.com/openclaw/openclaw/blob/f76d10f44e2b81e2250e0710daea9543f349ec0a/ui/src/pages/chat/chat-gateway.test.ts#L2643)
- `does not drop a canonical id for a same-text sequence projection` → [identically named table row](https://github.com/openclaw/openclaw/blob/f76d10f44e2b81e2250e0710daea9543f349ec0a/ui/src/pages/chat/chat-gateway.test.ts#L2660)
- `does not revive an identity-free tail after a distinct repeated history turn` → [identically named table row](https://github.com/openclaw/openclaw/blob/f76d10f44e2b81e2250e0710daea9543f349ec0a/ui/src/pages/chat/chat-gateway.test.ts#L2674)
- `does not reconcile native legacy history with an imported display match` → [identically named table row](https://github.com/openclaw/openclaw/blob/f76d10f44e2b81e2250e0710daea9543f349ec0a/ui/src/pages/chat/chat-gateway.test.ts#L2683)
- `does not replay an optimistic send already persisted before the history anchor` → [identically named table row](https://github.com/openclaw/openclaw/blob/f76d10f44e2b81e2250e0710daea9543f349ec0a/ui/src/pages/chat/chat-gateway.test.ts#L2700)
- `does not cross unrelated signature-free history markers` → [identically named table row](https://github.com/openclaw/openclaw/blob/f76d10f44e2b81e2250e0710daea9543f349ec0a/ui/src/pages/chat/chat-gateway.test.ts#L2722)
- `does not duplicate repeated history without an echoed send identity` → [identically named table row](https://github.com/openclaw/openclaw/blob/f76d10f44e2b81e2250e0710daea9543f349ec0a/ui/src/pages/chat/chat-gateway.test.ts#L2739)
- `does not revive an assistant after its user was persisted before the anchor` → [identically named table row](https://github.com/openclaw/openclaw/blob/f76d10f44e2b81e2250e0710daea9543f349ec0a/ui/src/pages/chat/chat-gateway.test.ts#L2757)
- `preserves a distinct repeated send when the earlier anchor has different text` → [identically named table row](https://github.com/openclaw/openclaw/blob/f76d10f44e2b81e2250e0710daea9543f349ec0a/ui/src/pages/chat/chat-gateway.test.ts#L2780)
- `keeps a new repeated prompt after a different same-text turn reaches history` → [identically named table row](https://github.com/openclaw/openclaw/blob/f76d10f44e2b81e2250e0710daea9543f349ec0a/ui/src/pages/chat/chat-gateway.test.ts#L2803)
- `reconciles repeated imported messages using the complete external source identity` → [identically named table row](https://github.com/openclaw/openclaw/blob/f76d10f44e2b81e2250e0710daea9543f349ec0a/ui/src/pages/chat/chat-gateway.test.ts#L2833)
- `does not invent an anchor for ambiguous identity-free repeated history` → [identically named table row](https://github.com/openclaw/openclaw/blob/f76d10f44e2b81e2250e0710daea9543f349ec0a/ui/src/pages/chat/chat-gateway.test.ts#L2849)
- `does not attach a current optimistic turn to an unrelated older snapshot` → [identically named table row](https://github.com/openclaw/openclaw/blob/f76d10f44e2b81e2250e0710daea9543f349ec0a/ui/src/pages/chat/chat-gateway.test.ts#L2866)
- `never restores a hidden optimistic assistant during history reconciliation` → [identically named table row](https://github.com/openclaw/openclaw/blob/f76d10f44e2b81e2250e0710daea9543f349ec0a/ui/src/pages/chat/chat-gateway.test.ts#L2880)
- `keeps active streamed assistant text when history reload returns a stale snapshot` → [identically named table row](https://github.com/openclaw/openclaw/blob/f76d10f44e2b81e2250e0710daea9543f349ec0a/ui/src/pages/chat/chat-gateway.test.ts#L2891)
- `clears live tool cards when history catches up before assistant text` → [identically named table row](https://github.com/openclaw/openclaw/blob/f76d10f44e2b81e2250e0710daea9543f349ec0a/ui/src/pages/chat/chat-gateway.test.ts#L2949)
- `inserts multiple recovered stream segments before their matching persisted tools` → [identically named table row](https://github.com/openclaw/openclaw/blob/f76d10f44e2b81e2250e0710daea9543f349ec0a/ui/src/pages/chat/chat-gateway.test.ts#L2962)
- `prunes only the live tool cards that history has caught up with` → [identically named table row](https://github.com/openclaw/openclaw/blob/f76d10f44e2b81e2250e0710daea9543f349ec0a/ui/src/pages/chat/chat-gateway.test.ts#L2986)
- `uses segment tool ids when a tool starts before any stream text` → [identically named table row](https://github.com/openclaw/openclaw/blob/f76d10f44e2b81e2250e0710daea9543f349ec0a/ui/src/pages/chat/chat-gateway.test.ts#L3016)
- `trims accumulated current stream after materializing caught-up tool segments` → [identically named table row](https://github.com/openclaw/openclaw/blob/f76d10f44e2b81e2250e0710daea9543f349ec0a/ui/src/pages/chat/chat-gateway.test.ts#L3032)

</details>

<details>
<summary><code>ui/src/pages/chat/chat-send.test.ts</code>: 5 exact original-name-to-row mappings</summary>

- `uses a route-relative avatar endpoint before basePath bootstrap finishes` → [identically named table row](https://github.com/openclaw/openclaw/blob/f76d10f44e2b81e2250e0710daea9543f349ec0a/ui/src/pages/chat/chat-send.test.ts#L756)
- `prefers the paired device token for avatar metadata and local avatar URLs` → [identically named table row](https://github.com/openclaw/openclaw/blob/f76d10f44e2b81e2250e0710daea9543f349ec0a/ui/src/pages/chat/chat-send.test.ts#L763)
- `fetches local avatars through Authorization headers instead of tokenized URLs` → [identically named table row](https://github.com/openclaw/openclaw/blob/f76d10f44e2b81e2250e0710daea9543f349ec0a/ui/src/pages/chat/chat-send.test.ts#L774)
- `ignores stale avatar responses after switching sessions` → [identically named table row](https://github.com/openclaw/openclaw/blob/f76d10f44e2b81e2250e0710daea9543f349ec0a/ui/src/pages/chat/chat-send.test.ts#L878)
- `ignores stale global avatar responses after switching selected agents` → [identically named table row](https://github.com/openclaw/openclaw/blob/f76d10f44e2b81e2250e0710daea9543f349ec0a/ui/src/pages/chat/chat-send.test.ts#L886)

</details>

<details>
<summary><code>ui/src/pages/chat/components/chat-message.test.ts</code>: 4 exact original-name-to-row mappings</summary>

- `places the delete confirm below the trigger near the top viewport edge` → [identically named table row](https://github.com/openclaw/openclaw/blob/f76d10f44e2b81e2250e0710daea9543f349ec0a/ui/src/pages/chat/components/chat-message.test.ts#L1065)
- `places the delete confirm above the trigger near the bottom viewport edge` → [identically named table row](https://github.com/openclaw/openclaw/blob/f76d10f44e2b81e2250e0710daea9543f349ec0a/ui/src/pages/chat/components/chat-message.test.ts#L1074)
- `clamps the delete confirm horizontally inside narrow viewports` → [identically named table row](https://github.com/openclaw/openclaw/blob/f76d10f44e2b81e2250e0710daea9543f349ec0a/ui/src/pages/chat/components/chat-message.test.ts#L1083)
- `clamps the delete confirm inside shifted visual viewports` → [identically named table row](https://github.com/openclaw/openclaw/blob/f76d10f44e2b81e2250e0710daea9543f349ec0a/ui/src/pages/chat/components/chat-message.test.ts#L1090)

</details>

## Real-behavior proof and maintainer policy

This is exclusively a three-file test-only refactor. **No live UI recording, live user session, or executed live-product demonstration is claimed.** The successful [Real behavior proof policy job](https://github.com/openclaw/openclaw/actions/runs/30240049765/job/89895187237) explicitly records the existing maintainer exception: `PR author @steipete is an active member of the openclaw/maintainer team; skipping PR context check.` That job proves the repository-authorized maintainer policy exemption; it is not represented as live UI proof. Product-regression evidence is the exact-head successful complete Control UI lane, all four QA smoke profiles, the 719 named focused cases, the one-for-one mapping above, and unchanged statement, branch, function, and line coverage.

