### PR TITLE
refactor(providers): consolidate streaming and model contract tests

### DIFF
--- a/extensions/amazon-bedrock/index.test.ts
+++ b/extensions/amazon-bedrock/index.test.ts
@@ -371,89 +371,55 @@ describe("amazon-bedrock provider plugin", () => {
     expect(restricted?.thinkingLevelMap).toEqual({ xhigh: null, max: null });
   });
 
-  it("mirrors Claude Opus 4.7 thinking levels for Bedrock model refs", async () => {
+  it.each([
+    {
+      name: "mirrors Claude Opus 4.7 thinking levels for Bedrock model refs",
+      modelIds: [
+        "us.anthropic.claude-opus-4-7",
+        "us.anthropic.claude-opus-4.7-v1:0",
+        "eu.anthropic.claude-opus-4-7",
+        "arn:aws:bedrock:us-west-2:123456789012:inference-profile/us.anthropic.claude-opus-4-7",
+      ],
+      defaultLevel: "off",
+    },
+    {
+      name: "defaults Claude Opus 5 Bedrock model refs to high adaptive thinking",
+      modelIds: [
+        "anthropic.claude-opus-5",
+        "us.anthropic.claude-opus-5",
+        "global.anthropic.claude-opus-5",
+      ],
+      defaultLevel: "high",
+    },
+    {
+      name: "leaves Claude Opus 4.8 Bedrock model refs off by default",
+      modelIds: [
+        "us.anthropic.claude-opus-4-8",
+        "us.anthropic.claude-opus-4.8-v1:0",
+        "arn:aws:bedrock:us-west-2:123456789012:inference-profile/us.anthropic.claude-opus-4-8",
+      ],
+      defaultLevel: "off",
+    },
+    {
+      name: "keeps mandatory-adaptive Claude 5 models at high default effort",
+      modelIds: [
+        "anthropic.claude-fable-5",
+        "us.anthropic.claude-fable-5",
+        "global.anthropic.claude-fable-5",
+        "anthropic.claude-mythos-5",
+        "us.anthropic.claude-mythos-5",
+        "global.anthropic.claude-mythos-5",
+      ],
+      defaultLevel: "high",
+    },
+  ])("$name", async ({ modelIds, defaultLevel }) => {
     const provider = await registerSingleProviderPlugin(amazonBedrockPlugin);
-
-    for (const modelId of [
-      "us.anthropic.claude-opus-4-7",
-      "us.anthropic.claude-opus-4.7-v1:0",
-      "eu.anthropic.claude-opus-4-7",
-      "arn:aws:bedrock:us-west-2:123456789012:inference-profile/us.anthropic.claude-opus-4-7",
-    ]) {
+    for (const modelId of modelIds) {
       expectThinkingProfile(
-        provider.resolveThinkingProfile?.({
-          provider: "amazon-bedrock",
-          modelId,
-        } as never),
+        provider.resolveThinkingProfile?.({ provider: "amazon-bedrock", modelId } as never),
         {
           levelIds: ["off", "minimal", "low", "medium", "high", "xhigh", "adaptive", "max"],
-          defaultLevel: "off",
-        },
-      );
-    }
-  });
-
-  it("defaults Claude Opus 5 Bedrock model refs to high adaptive thinking", async () => {
-    const provider = await registerSingleProviderPlugin(amazonBedrockPlugin);
-
-    for (const modelId of [
-      "anthropic.claude-opus-5",
-      "us.anthropic.claude-opus-5",
-      "global.anthropic.claude-opus-5",
-    ]) {
-      expectThinkingProfile(
-        provider.resolveThinkingProfile?.({
-          provider: "amazon-bedrock",
-          modelId,
-        } as never),
-        {
-          levelIds: ["off", "minimal", "low", "medium", "high", "xhigh", "adaptive", "max"],
-          defaultLevel: "high",
-        },
-      );
-    }
-  });
-
-  it("leaves Claude Opus 4.8 Bedrock model refs off by default", async () => {
-    const provider = await registerSingleProviderPlugin(amazonBedrockPlugin);
-
-    for (const modelId of [
-      "us.anthropic.claude-opus-4-8",
-      "us.anthropic.claude-opus-4.8-v1:0",
-      "arn:aws:bedrock:us-west-2:123456789012:inference-profile/us.anthropic.claude-opus-4-8",
-    ]) {
-      expectThinkingProfile(
-        provider.resolveThinkingProfile?.({
-          provider: "amazon-bedrock",
-          modelId,
-        } as never),
-        {
-          levelIds: ["off", "minimal", "low", "medium", "high", "xhigh", "adaptive", "max"],
-          defaultLevel: "off",
-        },
-      );
-    }
-  });
-
-  it("keeps mandatory-adaptive Claude 5 models at high default effort", async () => {
-    const provider = await registerSingleProviderPlugin(amazonBedrockPlugin);
-
-    for (const modelId of [
-      "anthropic.claude-fable-5",
-      "us.anthropic.claude-fable-5",
-      "global.anthropic.claude-fable-5",
-      "anthropic.claude-mythos-5",
-      "us.anthropic.claude-mythos-5",
-      "global.anthropic.claude-mythos-5",
-    ]) {
-      expectThinkingProfile(
-        provider.resolveThinkingProfile?.({
-          provider: "amazon-bedrock",
-          modelId,
-        } as never),
-        {
-          levelIds: ["off", "minimal", "low", "medium", "high", "xhigh", "adaptive", "max"],
-          defaultLevel: "high",
+          defaultLevel,
         },
       );
     }
@@ -559,151 +525,76 @@ describe("amazon-bedrock provider plugin", () => {
     );
   });
 
-  it("omits temperature for Bedrock Opus 4.7 model ids", async () => {
-    const provider = await registerSingleProviderPlugin(amazonBedrockPlugin);
-    const wrapped = provider.wrapStreamFn?.({
-      provider: "amazon-bedrock",
-      modelId: "us.anthropic.claude-opus-4-7",
-      streamFn: spyStreamFn,
-    } as never);
-
-    const result = wrapped?.(
-      {
-        api: "bedrock-converse-stream",
-        provider: "amazon-bedrock",
-        id: "us.anthropic.claude-opus-4-7",
-      } as never,
-      { messages: [] } as never,
-      { temperature: 0.2, maxTokens: 10 },
-    ) as Record<string, unknown> | undefined;
-
-    expectWrappedResultFields(result, { maxTokens: 10 });
-    expect(result).not.toHaveProperty("temperature");
-    expect(result).not.toHaveProperty("cacheRetention", "none");
-  });
-
-  it("omits temperature for Bedrock Opus 4.8 model ids", async () => {
-    const provider = await registerSingleProviderPlugin(amazonBedrockPlugin);
-    const wrapped = provider.wrapStreamFn?.({
-      provider: "amazon-bedrock",
-      modelId: "us.anthropic.claude-opus-4-8",
-      streamFn: spyStreamFn,
-    } as never);
-
-    const result = wrapped?.(
-      {
-        api: "bedrock-converse-stream",
-        provider: "amazon-bedrock",
-        id: "us.anthropic.claude-opus-4-8",
-      } as never,
-      { messages: [] } as never,
-      { temperature: 0.2, maxTokens: 10 },
-    ) as Record<string, unknown> | undefined;
-
-    expectWrappedResultFields(result, { maxTokens: 10 });
-    expect(result).not.toHaveProperty("temperature");
-    expect(result).not.toHaveProperty("cacheRetention", "none");
-  });
-
-  it("omits temperature for Bedrock Fable deployment aliases", async () => {
-    const provider = await registerSingleProviderPlugin(amazonBedrockPlugin);
-    const wrapped = provider.wrapStreamFn?.({
-      provider: "amazon-bedrock",
-      modelId: "production-fable",
-      model: {
-        api: "bedrock-converse-stream",
-        provider: "amazon-bedrock",
-        id: "production-fable",
-        params: { canonicalModelId: "claude-fable-5" },
-      },
-      streamFn: spyStreamFn,
-    } as never);
-
-    const result = wrapped?.(
-      {
-        api: "bedrock-converse-stream",
-        provider: "amazon-bedrock",
-        id: "production-fable",
-        params: { canonicalModelId: "claude-fable-5" },
-      } as never,
-      { messages: [] } as never,
-      { temperature: 0.2, maxTokens: 10 },
-    ) as Record<string, unknown> | undefined;
-
-    expectWrappedResultFields(result, { maxTokens: 10 });
-    expect(result).not.toHaveProperty("temperature");
-    expect(result).not.toHaveProperty("cacheRetention", "none");
-  });
-
-  it("omits temperature for canonical Bedrock Opus aliases", async () => {
+  it.each([
+    {
+      name: "omits temperature for Bedrock Opus 4.7 model ids",
+      id: "us.anthropic.claude-opus-4-7",
+      options: { temperature: 0.2, maxTokens: 10 },
+      expected: { maxTokens: 10 },
+      checkAnthropicCache: true,
+    },
+    {
+      name: "omits temperature for Bedrock Opus 4.8 model ids",
+      id: "us.anthropic.claude-opus-4-8",
+      options: { temperature: 0.2, maxTokens: 10 },
+      expected: { maxTokens: 10 },
+      checkAnthropicCache: true,
+    },
+    {
+      name: "omits temperature for Bedrock Fable deployment aliases",
+      id: "production-fable",
+      canonicalModelId: "claude-fable-5",
+      options: { temperature: 0.2, maxTokens: 10 },
+      expected: { maxTokens: 10 },
+      checkAnthropicCache: true,
+    },
+    {
+      name: "omits temperature for canonical Bedrock Opus aliases",
+      id: "production-claude",
+      canonicalModelId: "claude-opus-4-8",
+      options: { temperature: 0.2, maxTokens: 10 },
+      expected: { maxTokens: 10 },
+      checkAnthropicCache: true,
+    },
+    {
+      name: "omits temperature for dotted Bedrock Opus 4.7 model ids",
+      id: "us.anthropic.claude-opus-4.7-v1:0",
+      options: { temperature: 0.2, maxTokens: 10 },
+      expected: { maxTokens: 10 },
+    },
+    {
+      name: "omits temperature for named Bedrock Opus 4.7 inference profile ARNs",
+      id: "arn:aws:bedrock:us-west-2:123456789012:inference-profile/us.anthropic.claude-opus-4-7",
+      options: { temperature: 0, region: "us-west-2" },
+      expected: { region: "us-west-2" },
+    },
+    {
+      name: "omits temperature for non-US Bedrock Opus 4.7 regional profiles",
+      id: "eu.anthropic.claude-opus-4-7",
+      options: { temperature: 0.4, maxTokens: 12 },
+      expected: { maxTokens: 12 },
+    },
+  ])("$name", async ({ id, canonicalModelId, options, expected, checkAnthropicCache }) => {
     const provider = await registerSingleProviderPlugin(amazonBedrockPlugin);
     const model = {
       api: "bedrock-converse-stream",
       provider: "amazon-bedrock",
-      id: "production-claude",
-      params: { canonicalModelId: "claude-opus-4-8" },
+      id,
+      ...(canonicalModelId ? { params: { canonicalModelId } } : {}),
     };
     const wrapped = provider.wrapStreamFn?.({
       provider: "amazon-bedrock",
-      modelId: model.id,
-      model,
+      modelId: id,
+      ...(canonicalModelId ? { model } : {}),
       streamFn: spyStreamFn,
     } as never);
+    const result = wrapped?.(model as never, { messages: [] } as never, options as never);
 
-    const result = wrapped?.(model as never, { messages: [] } as never, {
-      temperature: 0.2,
-      maxTokens: 10,
-    }) as Record<string, unknown> | undefined;
-
-    expectWrappedResultFields(result, { maxTokens: 10 });
+    expectWrappedResultFields(result, expected);
     expect(result).not.toHaveProperty("temperature");
-    expect(result).not.toHaveProperty("cacheRetention", "none");
-  });
-
-  it("omits temperature for dotted Bedrock Opus 4.7 model ids", async () => {
-    const provider = await registerSingleProviderPlugin(amazonBedrockPlugin);
-    const wrapped = provider.wrapStreamFn?.({
-      provider: "amazon-bedrock",
-      modelId: "us.anthropic.claude-opus-4.7-v1:0",
-      streamFn: spyStreamFn,
-    } as never);
-
-    const result = wrapped?.(
-      {
-        api: "bedrock-converse-stream",
-        provider: "amazon-bedrock",
-        id: "us.anthropic.claude-opus-4.7-v1:0",
-      } as never,
-      { messages: [] } as never,
-      { temperature: 0.2, maxTokens: 10 },
-    ) as Record<string, unknown> | undefined;
-
-    expectWrappedResultFields(result, { maxTokens: 10 });
-    expect(result).not.toHaveProperty("temperature");
-  });
-
-  it("omits temperature for named Bedrock Opus 4.7 inference profile ARNs", async () => {
-    const provider = await registerSingleProviderPlugin(amazonBedrockPlugin);
-    const modelId =
-      "arn:aws:bedrock:us-west-2:123456789012:inference-profile/us.anthropic.claude-opus-4-7";
-    const wrapped = provider.wrapStreamFn?.({
-      provider: "amazon-bedrock",
-      modelId,
-      streamFn: spyStreamFn,
-    } as never);
-
-    const result = wrapped?.(
-      {
-        api: "bedrock-converse-stream",
-        provider: "amazon-bedrock",
-        id: modelId,
-      } as never,
-      { messages: [] } as never,
-      { temperature: 0, region: "us-west-2" } as never,
-    ) as Record<string, unknown> | undefined;
-
-    expectWrappedResultFields(result, { region: "us-west-2" });
-    expect(result).not.toHaveProperty("temperature");
+    if (checkAnthropicCache) {
+      expect(result).not.toHaveProperty("cacheRetention", "none");
+    }
   });
 
   it("uses plugin discovery region when provider URLs do not encode one", async () => {
@@ -736,193 +627,107 @@ describe("amazon-bedrock provider plugin", () => {
     expectWrappedResultFields(result, { region: "eu-central-1" });
   });
 
-  it("omits temperature for non-US Bedrock Opus 4.7 regional profiles", async () => {
-    const provider = await registerSingleProviderPlugin(amazonBedrockPlugin);
-    const wrapped = provider.wrapStreamFn?.({
-      provider: "amazon-bedrock",
-      modelId: "eu.anthropic.claude-opus-4-7",
-      streamFn: spyStreamFn,
-    } as never);
-
-    const result = wrapped?.(
-      {
-        api: "bedrock-converse-stream",
-        provider: "amazon-bedrock",
-        id: "eu.anthropic.claude-opus-4-7",
-      } as never,
-      { messages: [] } as never,
-      { temperature: 0.4, maxTokens: 12 },
-    ) as Record<string, unknown> | undefined;
-
-    expectWrappedResultFields(result, { maxTokens: 12 });
-    expect(result).not.toHaveProperty("temperature");
-  });
-
-  it("preserves Bedrock Opus 4.7 max thinking in the final payload", async () => {
-    const provider = await registerSingleProviderPlugin(amazonBedrockPlugin);
-    const wrapped = provider.wrapStreamFn?.({
-      provider: "amazon-bedrock",
+  it.each([
+    {
+      name: "preserves Bedrock Opus 4.7 max thinking in the final payload",
       modelId: "us.anthropic.claude-opus-4-7",
-      streamFn: spyStreamFn,
       thinkingLevel: "max",
-    } as never);
-
-    const result = wrapped?.(
-      {
-        api: "bedrock-converse-stream",
-        provider: "amazon-bedrock",
-        id: "us.anthropic.claude-opus-4-7",
-      } as never,
-      { messages: [] } as never,
-      { reasoning: "xhigh" } as never,
-    ) as Record<string, unknown> | undefined;
-    const payload = {
-      additionalModelRequestFields: {
-        thinking: { type: "adaptive" },
-        output_config: { effort: "xhigh" },
-      },
-    };
-
-    await (result?.onPayload as ((p: Record<string, unknown>) => unknown) | undefined)?.(payload);
-
-    expect(payload.additionalModelRequestFields.output_config).toEqual({ effort: "max" });
-  });
-
-  it("preserves Bedrock Opus 4.6 max thinking in the final payload", async () => {
-    const provider = await registerSingleProviderPlugin(amazonBedrockPlugin);
-    const wrapped = provider.wrapStreamFn?.({
-      provider: "amazon-bedrock",
+      reasoning: "xhigh",
+      initialEffort: "xhigh",
+      expectedEffort: "max",
+      adaptive: true,
+    },
+    {
+      name: "preserves Bedrock Opus 4.6 max thinking in the final payload",
       modelId: "us.anthropic.claude-opus-4-6-v1",
-      streamFn: spyStreamFn,
       thinkingLevel: "max",
-    } as never);
-
-    const result = wrapped?.(
-      {
-        api: "bedrock-converse-stream",
-        provider: "amazon-bedrock",
-        id: "us.anthropic.claude-opus-4-6-v1",
-      } as never,
-      { messages: [] } as never,
-      { reasoning: "high" } as never,
-    ) as Record<string, unknown> | undefined;
-    const payload = {
-      additionalModelRequestFields: {
-        thinking: { type: "adaptive" },
-        output_config: { effort: "high" },
-      },
-    };
-
-    await (result?.onPayload as ((p: Record<string, unknown>) => unknown) | undefined)?.(payload);
-
-    expect(payload.additionalModelRequestFields.output_config).toEqual({ effort: "max" });
-  });
-
-  it("keeps Bedrock Opus 4.7 xhigh thinking distinct from max", async () => {
-    const provider = await registerSingleProviderPlugin(amazonBedrockPlugin);
-    const wrapped = provider.wrapStreamFn?.({
-      provider: "amazon-bedrock",
+      reasoning: "high",
+      initialEffort: "high",
+      expectedEffort: "max",
+      adaptive: true,
+    },
+    {
+      name: "keeps Bedrock Opus 4.7 xhigh thinking distinct from max",
       modelId: "us.anthropic.claude-opus-4-7",
-      streamFn: spyStreamFn,
       thinkingLevel: "xhigh",
-    } as never);
-
-    const result = wrapped?.(
-      {
-        api: "bedrock-converse-stream",
-        provider: "amazon-bedrock",
-        id: "us.anthropic.claude-opus-4-7",
-      } as never,
-      { messages: [] } as never,
-      { reasoning: "xhigh" } as never,
-    ) as Record<string, unknown> | undefined;
-
-    const payload = {
-      additionalModelRequestFields: {
-        output_config: { effort: "xhigh" },
-      },
-    };
-
-    await (result?.onPayload as ((p: Record<string, unknown>) => unknown) | undefined)?.(payload);
-
-    expect(payload.additionalModelRequestFields.output_config).toEqual({ effort: "xhigh" });
-  });
-
-  it("uses adaptive max thinking for Bedrock Opus 4.8", async () => {
-    const provider = await registerSingleProviderPlugin(amazonBedrockPlugin);
-    const wrapped = provider.wrapStreamFn?.({
-      provider: "amazon-bedrock",
+      reasoning: "xhigh",
+      initialEffort: "xhigh",
+      expectedEffort: "xhigh",
+    },
+    {
+      name: "uses adaptive max thinking for Bedrock Opus 4.8",
       modelId: "us.anthropic.claude-opus-4-8",
-      streamFn: spyStreamFn,
+      modelName: "Claude Opus 4.8",
       thinkingLevel: "max",
-    } as never);
-
-    const result = wrapped?.(
-      {
-        api: "bedrock-converse-stream",
-        provider: "amazon-bedrock",
-        id: "us.anthropic.claude-opus-4-8",
-        name: "Claude Opus 4.8",
-        reasoning: true,
-      } as never,
-      { messages: [] } as never,
-      { reasoning: "max" } as never,
-    ) as Record<string, unknown> | undefined;
-
-    const payload = {
-      inferenceConfig: { temperature: 0.2 },
-      additionalModelRequestFields: {
-        thinking: { type: "adaptive" },
-        output_config: { effort: "xhigh" },
-      },
-    };
-
-    await (result?.onPayload as ((p: Record<string, unknown>) => unknown) | undefined)?.(payload);
-
-    expect(payload.additionalModelRequestFields).toEqual({
-      thinking: { type: "adaptive" },
-      output_config: { effort: "max" },
-    });
-    expect(payload.inferenceConfig).toEqual({});
-  });
-
-  it("does not re-upgrade Mythos Preview max thinking in the final payload", async () => {
-    const provider = await registerSingleProviderPlugin(amazonBedrockPlugin);
-    const wrapped = provider.wrapStreamFn?.({
-      provider: "amazon-bedrock",
+      reasoning: "max",
+      initialEffort: "xhigh",
+      expectedEffort: "max",
+      adaptive: true,
+      omitTemperature: true,
+    },
+    {
+      name: "does not re-upgrade Mythos Preview max thinking in the final payload",
       modelId: "us.anthropic.claude-mythos-preview",
-      streamFn: spyStreamFn,
+      modelName: "Claude Mythos Preview",
       thinkingLevel: "max",
-    } as never);
-
-    const result = wrapped?.(
-      {
-        api: "bedrock-converse-stream",
+      reasoning: "max",
+      initialEffort: "high",
+      expectedEffort: "high",
+      adaptive: true,
+      omitTemperature: true,
+    },
+  ])(
+    "$name",
+    async ({
+      modelId,
+      modelName,
+      thinkingLevel,
+      reasoning,
+      initialEffort,
+      expectedEffort,
+      adaptive,
+      omitTemperature,
+    }) => {
+      const provider = await registerSingleProviderPlugin(amazonBedrockPlugin);
+      const wrapped = provider.wrapStreamFn?.({
         provider: "amazon-bedrock",
-        id: "us.anthropic.claude-mythos-preview",
-        name: "Claude Mythos Preview",
-        reasoning: true,
-      } as never,
-      { messages: [] } as never,
-      { reasoning: "max" } as never,
-    ) as Record<string, unknown> | undefined;
+        modelId,
+        streamFn: spyStreamFn,
+        thinkingLevel,
+      } as never);
+      const result = wrapped?.(
+        {
+          api: "bedrock-converse-stream",
+          provider: "amazon-bedrock",
+          id: modelId,
+          ...(modelName ? { name: modelName, reasoning: true } : {}),
+        } as never,
+        { messages: [] } as never,
+        { reasoning } as never,
+      ) as Record<string, unknown> | undefined;
+      const payload = {
+        ...(omitTemperature ? { inferenceConfig: { temperature: 0.2 } } : {}),
+        additionalModelRequestFields: {
+          ...(adaptive ? { thinking: { type: "adaptive" } } : {}),
+          output_config: { effort: initialEffort },
+        },
+      };
 
-    const payload = {
-      inferenceConfig: { temperature: 0.2 },
-      additionalModelRequestFields: {
-        thinking: { type: "adaptive" },
-        output_config: { effort: "high" },
-      },
-    };
+      await (result?.onPayload as ((value: Record<string, unknown>) => unknown) | undefined)?.(
+        payload,
+      );
 
-    await (result?.onPayload as ((p: Record<string, unknown>) => unknown) | undefined)?.(payload);
-
-    expect(payload.additionalModelRequestFields).toEqual({
-      thinking: { type: "adaptive" },
-      output_config: { effort: "high" },
-    });
-    expect(payload.inferenceConfig).toEqual({});
-  });
+      expect(payload.additionalModelRequestFields.output_config).toEqual({
+        effort: expectedEffort,
+      });
+      if (adaptive) {
+        expect(payload.additionalModelRequestFields.thinking).toEqual({ type: "adaptive" });
+      }
+      if (omitTemperature) {
+        expect(payload.inferenceConfig).toEqual({});
+      }
+    },
+  );
 
   it("classifies nested Bedrock deprecated-temperature validation as format failover", async () => {
     const provider = await registerSingleProviderPlugin(amazonBedrockPlugin);
@@ -1002,86 +807,54 @@ describe("amazon-bedrock provider plugin", () => {
       expectWrappedResultFields(result, { cacheRetention: "none" });
     });
 
-    it("injects all four fields when guardrail config includes optional fields", async () => {
-      const provider = await registerWithConfig({
+    it.each([
+      {
+        name: "injects all four fields when guardrail config includes optional fields",
         guardrail: {
           guardrailIdentifier: "my-guardrail-id",
           guardrailVersion: "1",
           streamProcessingMode: "sync",
           trace: "enabled",
         },
-      });
-      const result = await callWrappedStream(provider, NON_ANTHROPIC_MODEL, MODEL_DESCRIPTOR);
-
-      expect(result.capturedPayload).toEqual({
-        guardrailConfig: {
-          guardrailIdentifier: "my-guardrail-id",
-          guardrailVersion: "1",
-          streamProcessingMode: "sync",
-          trace: "enabled",
-        },
-      });
-    });
-
-    it("injects only required fields when optional fields are omitted", async () => {
-      const provider = await registerWithConfig({
-        guardrail: {
-          guardrailIdentifier: "abc123",
-          guardrailVersion: "DRAFT",
-        },
-      });
-      const result = await callWrappedStream(provider, NON_ANTHROPIC_MODEL, MODEL_DESCRIPTOR);
-
-      expect(result.capturedPayload).toEqual({
-        guardrailConfig: {
-          guardrailIdentifier: "abc123",
-          guardrailVersion: "DRAFT",
-        },
-      });
-    });
-
-    it("injects guardrailConfig for Anthropic models without cacheRetention: none", async () => {
-      const provider = await registerWithConfig({
+        anthropic: false,
+      },
+      {
+        name: "injects only required fields when optional fields are omitted",
+        guardrail: { guardrailIdentifier: "abc123", guardrailVersion: "DRAFT" },
+        anthropic: false,
+      },
+      {
+        name: "injects guardrailConfig for Anthropic models without cacheRetention: none",
         guardrail: {
           guardrailIdentifier: "guardrail-anthropic",
           guardrailVersion: "2",
           streamProcessingMode: "async",
           trace: "disabled",
         },
-      });
-      const result = await callWrappedStream(provider, ANTHROPIC_MODEL, ANTHROPIC_MODEL_DESCRIPTOR);
+        anthropic: true,
+        checkCacheRetention: true,
+      },
+      {
+        name: "injects guardrailConfig for non-Anthropic models with cacheRetention: none",
+        guardrail: { guardrailIdentifier: "guardrail-nova", guardrailVersion: "3" },
+        anthropic: false,
+        checkCacheRetention: true,
+      },
+    ])("$name", async ({ guardrail, anthropic, checkCacheRetention }) => {
+      const provider = await registerWithConfig({ guardrail });
+      const result = await callWrappedStream(
+        provider,
+        anthropic ? ANTHROPIC_MODEL : NON_ANTHROPIC_MODEL,
+        anthropic ? ANTHROPIC_MODEL_DESCRIPTOR : MODEL_DESCRIPTOR,
+      );
 
-      // Anthropic models should get guardrailConfig
-      expect(result.capturedPayload).toEqual({
-        guardrailConfig: {
-          guardrailIdentifier: "guardrail-anthropic",
-          guardrailVersion: "2",
-          streamProcessingMode: "async",
-          trace: "disabled",
-        },
-      });
-      // Anthropic models should NOT get cacheRetention: "none"
-      expect(result).not.toHaveProperty("cacheRetention", "none");
-    });
-
-    it("injects guardrailConfig for non-Anthropic models with cacheRetention: none", async () => {
-      const provider = await registerWithConfig({
-        guardrail: {
-          guardrailIdentifier: "guardrail-nova",
-          guardrailVersion: "3",
-        },
-      });
-      const result = await callWrappedStream(provider, NON_ANTHROPIC_MODEL, MODEL_DESCRIPTOR);
-
-      // Non-Anthropic models should get guardrailConfig
-      expect(result.capturedPayload).toEqual({
-        guardrailConfig: {
-          guardrailIdentifier: "guardrail-nova",
-          guardrailVersion: "3",
-        },
-      });
-      // Non-Anthropic models should also get cacheRetention: "none"
-      expectWrappedResultFields(result, { cacheRetention: "none" });
+      expect(result.capturedPayload).toEqual({ guardrailConfig: guardrail });
+      if (checkCacheRetention && anthropic) {
+        expect(result).not.toHaveProperty("cacheRetention", "none");
+      }
+      if (checkCacheRetention && !anthropic) {
+        expectWrappedResultFields(result, { cacheRetention: "none" });
+      }
     });
 
     it("uses live plugin config to inject guardrailConfig after startup disable", async () => {
@@ -1280,70 +1053,53 @@ describe("amazon-bedrock provider plugin", () => {
       return payload;
     }
 
-    it("injects cache points for application inference profile ARNs", async () => {
+    it.each([
+      {
+        name: "injects cache points for application inference profile ARNs",
+        options: { cacheRetention: "short" },
+        expectedCachePoint: { type: "default" },
+        verifyUserMessage: true,
+      },
+      {
+        name: "uses long TTL when cacheRetention is 'long'",
+        options: { cacheRetention: "long" },
+        expectedCachePoint: { type: "default", ttl: "1h" },
+      },
+      {
+        name: "does not inject cache points when cacheRetention is 'none'",
+        options: { cacheRetention: "none" },
+      },
+      {
+        name: "defaults to 'short' cache retention when not explicitly set",
+        options: {},
+        expectedCachePoint: { type: "default" },
+      },
+    ])("$name", async ({ options, expectedCachePoint, verifyUserMessage }) => {
       const provider = await registerWithConfig(undefined);
       const payload: Record<string, unknown> = {
         system: [{ text: "You are helpful." }],
         messages: [{ role: "user", content: [{ text: "Hello" }] }],
       };
-
       await callWrappedStreamWithPayload(
         provider,
         APP_INFERENCE_PROFILE_ARN,
         APP_INFERENCE_PROFILE_DESCRIPTOR,
-        { cacheRetention: "short" },
+        options,
         payload,
       );
 
-      const system = payload.system as Array<Record<string, unknown>>;
-      expect(system).toHaveLength(2);
-      expect(system[1]).toEqual({ cachePoint: { type: "default" } });
-
-      const messages = payload.messages as Array<{
-        role: string;
-        content: Array<Record<string, unknown>>;
-      }>;
-      const lastUserContent = expectDefined(messages[0], "last user message").content;
-      expect(lastUserContent).toHaveLength(2);
-      expect(lastUserContent[1]).toEqual({ cachePoint: { type: "default" } });
-    });
-
-    it("uses long TTL when cacheRetention is 'long'", async () => {
-      const provider = await registerWithConfig(undefined);
-      const payload: Record<string, unknown> = {
-        system: [{ text: "You are helpful." }],
-        messages: [{ role: "user", content: [{ text: "Hello" }] }],
-      };
-
-      await callWrappedStreamWithPayload(
-        provider,
-        APP_INFERENCE_PROFILE_ARN,
-        APP_INFERENCE_PROFILE_DESCRIPTOR,
-        { cacheRetention: "long" },
-        payload,
-      );
-
-      const system = payload.system as Array<Record<string, unknown>>;
-      expect(system[1]).toEqual({ cachePoint: { type: "default", ttl: "1h" } });
-    });
-
-    it("does not inject cache points when cacheRetention is 'none'", async () => {
-      const provider = await registerWithConfig(undefined);
-      const payload: Record<string, unknown> = {
-        system: [{ text: "You are helpful." }],
-        messages: [{ role: "user", content: [{ text: "Hello" }] }],
-      };
-
-      await callWrappedStreamWithPayload(
-        provider,
-        APP_INFERENCE_PROFILE_ARN,
-        APP_INFERENCE_PROFILE_DESCRIPTOR,
-        { cacheRetention: "none" },
-        payload,
-      );
-
-      const system = payload.system as Array<Record<string, unknown>>;
-      expect(system).toHaveLength(1);
+      const system = requireArray(payload.system, "Bedrock system prompt");
+      expect(system).toHaveLength(expectedCachePoint ? 2 : 1);
+      if (expectedCachePoint) {
+        expect(system[1]).toEqual({ cachePoint: expectedCachePoint });
+      }
+      if (verifyUserMessage) {
+        const messages = requireArray(payload.messages, "Bedrock messages");
+        const user = requireRecord(messages[0], "last user message");
+        const content = requireArray(user.content, "last user content");
+        expect(content).toHaveLength(2);
+        expect(content[1]).toEqual({ cachePoint: { type: "default" } });
+      }
     });
 
     it("does not double-inject cache points if already present", async () => {
@@ -1427,27 +1183,6 @@ describe("amazon-bedrock provider plugin", () => {
 
       const system = payload.system as Array<Record<string, unknown>>;
       expect(system).toHaveLength(1);
-    });
-
-    it("defaults to 'short' cache retention when not explicitly set", async () => {
-      const provider = await registerWithConfig(undefined);
-      const payload: Record<string, unknown> = {
-        system: [{ text: "You are helpful." }],
-        messages: [{ role: "user", content: [{ text: "Hello" }] }],
-      };
-
-      await callWrappedStreamWithPayload(
-        provider,
-        APP_INFERENCE_PROFILE_ARN,
-        APP_INFERENCE_PROFILE_DESCRIPTOR,
-        {},
-        payload,
-      );
-
-      const system = payload.system as Array<Record<string, unknown>>;
-      expect(system).toHaveLength(2);
-      // Default is "short" which means no ttl field
-      expect(system[1]).toEqual({ cachePoint: { type: "default" } });
     });
 
     it("injects cache point only on last USER message", async () => {

--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -91,6 +91,69 @@ function buildGoogleVertexModel(
   };
 }
 
+function buildGeminiUserParams(
+  model: Partial<Model<"google-generative-ai">> = {},
+  options?: Record<string, unknown>,
+) {
+  return buildGoogleGenerativeAiParams(
+    buildGeminiModel(model),
+    { messages: [{ role: "user", content: "hello", timestamp: 0 }] } as never,
+    options as never,
+  );
+}
+
+async function runGeminiStreamResult(params: {
+  model?: Model<"google-generative-ai">;
+  context?: Parameters<ReturnType<typeof createGoogleGenerativeAiTransportStreamFn>>[1];
+  options?: Record<string, unknown>;
+}) {
+  const streamFn = createGoogleGenerativeAiTransportStreamFn();
+  const stream = await Promise.resolve(
+    streamFn(
+      params.model ?? buildGeminiModel(),
+      (params.context ?? {
+        messages: [{ role: "user", content: "hello", timestamp: 0 }],
+      }) as Parameters<typeof streamFn>[1],
+      params.options as Parameters<typeof streamFn>[2],
+    ),
+  );
+  return stream.result();
+}
+
+async function runGoogleVertexStreamResult(params: {
+  model?: Model<"google-vertex">;
+  fetch: typeof guardedFetchMock;
+}) {
+  const streamFn = createGoogleVertexTransportStreamFn();
+  const stream = await Promise.resolve(
+    streamFn(
+      params.model ?? buildGoogleVertexModel(),
+      { messages: [{ role: "user", content: "hello", timestamp: 0 }] } as Parameters<
+        typeof streamFn
+      >[1],
+      { apiKey: "gcp-vertex-credentials", fetch: params.fetch } as Parameters<typeof streamFn>[2],
+    ),
+  );
+  return stream.result();
+}
+
+async function useGoogleAuthorizedUserCredentials(label: string, refreshToken: string) {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), `openclaw-google-vertex-${label}-`));
+  const credentialsPath = path.join(tempDir, "application_default_credentials.json");
+  await writeFile(
+    credentialsPath,
+    JSON.stringify({
+      type: "authorized_user",
+      client_id: "client-id",
+      client_secret: "client-secret",
+      refresh_token: refreshToken,
+    }),
+    "utf8",
+  );
+  vi.stubEnv("GOOGLE_APPLICATION_CREDENTIALS", credentialsPath);
+  return credentialsPath;
+}
+
 function buildSseResponse(events: unknown[]): Response {
   const sse = `${events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("")}data: [DONE]\n\n`;
   return buildRawSseResponse(sse);
@@ -514,125 +577,61 @@ describe("google transport stream", () => {
     );
   });
 
-  it("does not rotate OAuth JSON credentials through configured Gemini API keys", async () => {
+  it.each([
+    {
+      name: "does not rotate OAuth JSON credentials through configured Gemini API keys",
+      options: { apiKey: JSON.stringify({ token: "oauth-token", projectId: "demo" }) },
+      expectedHeaders: {
+        Authorization: "Bearer oauth-token",
+        "Content-Type": "application/json",
+      },
+      omitApiKeyHeader: true,
+    },
+    {
+      name: "does not rotate when request headers override Gemini authentication",
+      options: {
+        apiKey: "explicit-option-key",
+        headers: { "x-goog-api-key": "header-key" },
+      },
+      expectedHeaders: { "x-goog-api-key": "header-key" },
+    },
+    {
+      name: "does not rotate global Gemini API keys into custom Gemini endpoints",
+      model: {
+        provider: "custom-google",
+        baseUrl: "https://proxy.example.com/gemini/v1beta",
+      },
+      options: { apiKey: "explicit-proxy-key" },
+      expectedHeaders: { "x-goog-api-key": "explicit-proxy-key" },
+      expectedUrl:
+        "https://proxy.example.com/gemini/v1beta/models/gemini-2.5-pro:streamGenerateContent?alt=sse",
+    },
+    {
+      name: "does not rotate global Gemini API keys into non-TLS Gemini endpoints",
+      model: { baseUrl: "http://generativelanguage.googleapis.com/v1beta" },
+      options: { apiKey: "explicit-http-key" },
+      expectedHeaders: { "x-goog-api-key": "explicit-http-key" },
+      expectedUrl:
+        "http://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-pro:streamGenerateContent?alt=sse",
+    },
+  ])("$name", async ({ model, options, expectedHeaders, expectedUrl, omitApiKeyHeader }) => {
     vi.stubEnv("OPENCLAW_LIVE_GEMINI_KEY", "");
     vi.stubEnv("GEMINI_API_KEYS", "gemini-env-key");
     guardedFetchMock.mockResolvedValueOnce(buildRateLimitResponse());
 
-    const streamFn = createGoogleGenerativeAiTransportStreamFn();
-    const stream = await Promise.resolve(
-      streamFn(
-        buildGeminiModel(),
-        {
-          messages: [{ role: "user", content: "hello", timestamp: 0 }],
-        } as Parameters<typeof streamFn>[1],
-        {
-          apiKey: JSON.stringify({ token: "oauth-token", projectId: "demo" }),
-        } as Parameters<typeof streamFn>[2],
-      ),
-    );
-    const result = await stream.result();
-
-    expect(result.stopReason).toBe("error");
-    expect(guardedFetchMock).toHaveBeenCalledTimes(1);
-    const init = requireRequestInit(
-      requireMockCall(guardedFetchMock, 0, "guarded fetch"),
-      "guarded fetch",
-    );
-    expectHeaders(init, {
-      Authorization: "Bearer oauth-token",
-      "Content-Type": "application/json",
-    });
-    expect(new Headers(init.headers).has("x-goog-api-key")).toBe(false);
-  });
-
-  it("does not rotate when request headers override Gemini authentication", async () => {
-    vi.stubEnv("OPENCLAW_LIVE_GEMINI_KEY", "");
-    vi.stubEnv("GEMINI_API_KEYS", "gemini-env-key");
-    guardedFetchMock.mockResolvedValueOnce(buildRateLimitResponse());
-
-    const streamFn = createGoogleGenerativeAiTransportStreamFn();
-    const stream = await Promise.resolve(
-      streamFn(
-        buildGeminiModel(),
-        {
-          messages: [{ role: "user", content: "hello", timestamp: 0 }],
-        } as Parameters<typeof streamFn>[1],
-        {
-          apiKey: "explicit-option-key",
-          headers: { "x-goog-api-key": "header-key" },
-        } as Parameters<typeof streamFn>[2],
-      ),
-    );
-    const result = await stream.result();
-
-    expect(result.stopReason).toBe("error");
-    expect(guardedFetchMock).toHaveBeenCalledTimes(1);
-    expectHeaders(
-      requireRequestInit(requireMockCall(guardedFetchMock, 0, "guarded fetch"), "guarded fetch"),
-      { "x-goog-api-key": "header-key" },
-    );
-  });
-
-  it("does not rotate global Gemini API keys into custom Gemini endpoints", async () => {
-    vi.stubEnv("OPENCLAW_LIVE_GEMINI_KEY", "");
-    vi.stubEnv("GEMINI_API_KEYS", "gemini-env-key");
-    guardedFetchMock.mockResolvedValueOnce(buildRateLimitResponse());
-
-    const streamFn = createGoogleGenerativeAiTransportStreamFn();
-    const stream = await Promise.resolve(
-      streamFn(
-        buildGeminiModel({
-          provider: "custom-google",
-          baseUrl: "https://proxy.example.com/gemini/v1beta",
-        }),
-        {
-          messages: [{ role: "user", content: "hello", timestamp: 0 }],
-        } as Parameters<typeof streamFn>[1],
-        { apiKey: "explicit-proxy-key" } as Parameters<typeof streamFn>[2],
-      ),
-    );
-    const result = await stream.result();
+    const result = await runGeminiStreamResult({ model: buildGeminiModel(model), options });
 
     expect(result.stopReason).toBe("error");
     expect(guardedFetchMock).toHaveBeenCalledTimes(1);
     const guardedCall = requireMockCall(guardedFetchMock, 0, "guarded fetch");
-    expect(guardedCall[0]).toBe(
-      "https://proxy.example.com/gemini/v1beta/models/gemini-2.5-pro:streamGenerateContent?alt=sse",
-    );
-    expectHeaders(requireRequestInit(guardedCall, "guarded fetch"), {
-      "x-goog-api-key": "explicit-proxy-key",
-    });
-  });
-
-  it("does not rotate global Gemini API keys into non-TLS Gemini endpoints", async () => {
-    vi.stubEnv("OPENCLAW_LIVE_GEMINI_KEY", "");
-    vi.stubEnv("GEMINI_API_KEYS", "gemini-env-key");
-    guardedFetchMock.mockResolvedValueOnce(buildRateLimitResponse());
-
-    const streamFn = createGoogleGenerativeAiTransportStreamFn();
-    const stream = await Promise.resolve(
-      streamFn(
-        buildGeminiModel({
-          baseUrl: "http://generativelanguage.googleapis.com/v1beta",
-        }),
-        {
-          messages: [{ role: "user", content: "hello", timestamp: 0 }],
-        } as Parameters<typeof streamFn>[1],
-        { apiKey: "explicit-http-key" } as Parameters<typeof streamFn>[2],
-      ),
-    );
-    const result = await stream.result();
-
-    expect(result.stopReason).toBe("error");
-    expect(guardedFetchMock).toHaveBeenCalledTimes(1);
-    const guardedCall = requireMockCall(guardedFetchMock, 0, "guarded fetch");
-    expect(guardedCall[0]).toBe(
-      "http://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-pro:streamGenerateContent?alt=sse",
-    );
-    expectHeaders(requireRequestInit(guardedCall, "guarded fetch"), {
-      "x-goog-api-key": "explicit-http-key",
-    });
+    const init = requireRequestInit(guardedCall, "guarded fetch");
+    expectHeaders(init, Object.fromEntries(Object.entries(expectedHeaders)));
+    if (expectedUrl) {
+      expect(guardedCall[0]).toBe(expectedUrl);
+    }
+    if (omitApiKeyHeader) {
+      expect(new Headers(init.headers).has("x-goog-api-key")).toBe(false);
+    }
   });
 
   it("preserves MAX_TOKENS when the partial response contains a function call", async () => {
@@ -1276,19 +1275,7 @@ describe("google transport stream", () => {
   });
 
   it("refreshes authorized_user ADC before Google Vertex requests", async () => {
-    const tempDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-google-vertex-adc-"));
-    const credentialsPath = path.join(tempDir, "application_default_credentials.json");
-    await writeFile(
-      credentialsPath,
-      JSON.stringify({
-        type: "authorized_user",
-        client_id: "client-id",
-        client_secret: "client-secret",
-        refresh_token: "refresh-token",
-      }),
-      "utf8",
-    );
-    vi.stubEnv("GOOGLE_APPLICATION_CREDENTIALS", credentialsPath);
+    await useGoogleAuthorizedUserCredentials("adc", "refresh-token");
     vi.stubEnv("GOOGLE_CLOUD_PROJECT", "vertex-project");
     vi.stubEnv("GOOGLE_CLOUD_LOCATION", "global");
     const tokenFetchMock = vi.fn().mockResolvedValue(
@@ -1305,22 +1292,7 @@ describe("google transport stream", () => {
       ]),
     );
 
-    const model = buildGoogleVertexModel();
-
-    const streamFn = createGoogleVertexTransportStreamFn();
-    const stream = await Promise.resolve(
-      streamFn(
-        model,
-        {
-          messages: [{ role: "user", content: "hello", timestamp: 0 }],
-        } as Parameters<typeof streamFn>[1],
-        {
-          apiKey: "gcp-vertex-credentials",
-          fetch: tokenFetchMock,
-        } as Parameters<typeof streamFn>[2],
-      ),
-    );
-    const result = await stream.result();
+    const result = await runGoogleVertexStreamResult({ fetch: tokenFetchMock });
 
     const tokenCall = requireMockCall(tokenFetchMock, 0, "token fetch");
     expect(tokenCall[0]).toBe("https://oauth2.googleapis.com/token");
@@ -1344,19 +1316,7 @@ describe("google transport stream", () => {
   });
 
   it("times out an authorized_user ADC token refresh", async () => {
-    const tempDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-google-vertex-adc-timeout-"));
-    const credentialsPath = path.join(tempDir, "application_default_credentials.json");
-    await writeFile(
-      credentialsPath,
-      JSON.stringify({
-        type: "authorized_user",
-        client_id: "client-id",
-        client_secret: "client-secret",
-        refresh_token: "timeout-refresh-token",
-      }),
-      "utf8",
-    );
-    vi.stubEnv("GOOGLE_APPLICATION_CREDENTIALS", credentialsPath);
+    await useGoogleAuthorizedUserCredentials("adc-timeout", "timeout-refresh-token");
     vi.useFakeTimers();
 
     let observedSignal: AbortSignal | undefined;
@@ -1394,19 +1354,7 @@ describe("google transport stream", () => {
   });
 
   it("refreshes authorized_user ADC from a compressed token response", async () => {
-    const tempDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-google-vertex-adc-gzip-"));
-    const credentialsPath = path.join(tempDir, "application_default_credentials.json");
-    await writeFile(
-      credentialsPath,
-      JSON.stringify({
-        type: "authorized_user",
-        client_id: "client-id",
-        client_secret: "client-secret",
-        refresh_token: "gzip-refresh-token",
-      }),
-      "utf8",
-    );
-    vi.stubEnv("GOOGLE_APPLICATION_CREDENTIALS", credentialsPath);
+    await useGoogleAuthorizedUserCredentials("adc-gzip", "gzip-refresh-token");
     vi.stubEnv("GOOGLE_CLOUD_PROJECT", "vertex-project");
     vi.stubEnv("GOOGLE_CLOUD_LOCATION", "global");
     const tokenFetchMock = vi.fn().mockResolvedValue(
@@ -1429,20 +1377,7 @@ describe("google transport stream", () => {
       ]),
     );
 
-    const streamFn = createGoogleVertexTransportStreamFn();
-    const stream = await Promise.resolve(
-      streamFn(
-        buildGoogleVertexModel(),
-        {
-          messages: [{ role: "user", content: "hello", timestamp: 0 }],
-        } as Parameters<typeof streamFn>[1],
-        {
-          apiKey: "gcp-vertex-credentials",
-          fetch: tokenFetchMock,
-        } as Parameters<typeof streamFn>[2],
-      ),
-    );
-    await stream.result();
+    await runGoogleVertexStreamResult({ fetch: tokenFetchMock });
 
     expect(tokenFetchMock).toHaveBeenCalledTimes(1);
     const guardedCall = requireMockCall(guardedFetchMock, 0, "guarded fetch");
@@ -1452,19 +1387,7 @@ describe("google transport stream", () => {
   });
 
   it("rejects oversized authorized_user ADC token responses", async () => {
-    const tempDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-google-vertex-adc-large-"));
-    const credentialsPath = path.join(tempDir, "application_default_credentials.json");
-    await writeFile(
-      credentialsPath,
-      JSON.stringify({
-        type: "authorized_user",
-        client_id: "client-id",
-        client_secret: "client-secret",
-        refresh_token: "large-refresh-token",
-      }),
-      "utf8",
-    );
-    vi.stubEnv("GOOGLE_APPLICATION_CREDENTIALS", credentialsPath);
+    await useGoogleAuthorizedUserCredentials("adc-large", "large-refresh-token");
     const tokenFetchMock = vi
       .fn()
       .mockResolvedValue(new Response("x".repeat(1024 * 1024 + 1), { status: 200 }));
@@ -1475,19 +1398,7 @@ describe("google transport stream", () => {
   });
 
   it("rejects authorized_user ADC gzip responses that expand past the limit", async () => {
-    const tempDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-google-vertex-adc-bomb-"));
-    const credentialsPath = path.join(tempDir, "application_default_credentials.json");
-    await writeFile(
-      credentialsPath,
-      JSON.stringify({
-        type: "authorized_user",
-        client_id: "client-id",
-        client_secret: "client-secret",
-        refresh_token: "bomb-refresh-token",
-      }),
-      "utf8",
-    );
-    vi.stubEnv("GOOGLE_APPLICATION_CREDENTIALS", credentialsPath);
+    await useGoogleAuthorizedUserCredentials("adc-bomb", "bomb-refresh-token");
     const tokenFetchMock = vi.fn().mockResolvedValue(
       new Response(gzipSync("x".repeat(1024 * 1024 + 1)), {
         status: 200,
@@ -1501,19 +1412,7 @@ describe("google transport stream", () => {
   });
 
   it("does not reuse authorized_user ADC tokens with unsafe expiry lifetimes", async () => {
-    const tempDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-google-vertex-unsafe-adc-"));
-    const credentialsPath = path.join(tempDir, "application_default_credentials.json");
-    await writeFile(
-      credentialsPath,
-      JSON.stringify({
-        type: "authorized_user",
-        client_id: "client-id",
-        client_secret: "client-secret",
-        refresh_token: "refresh-token",
-      }),
-      "utf8",
-    );
-    vi.stubEnv("GOOGLE_APPLICATION_CREDENTIALS", credentialsPath);
+    await useGoogleAuthorizedUserCredentials("unsafe-adc", "refresh-token");
     const tokenFetchMock = vi
       .fn()
       .mockResolvedValueOnce(
@@ -1635,94 +1534,67 @@ describe("google transport stream", () => {
     });
   });
 
-  it("replays Gemini tool call thought signatures for same-model history", () => {
-    const model = buildGeminiModel({
-      id: "gemini-3-flash-preview",
-      name: "Gemini 3 Flash Preview",
-    });
-
-    const params = buildGoogleGenerativeAiParams(model, {
+  it.each([
+    {
+      name: "replays Gemini tool call thought signatures for same-model history",
+      modelId: "gemini-3-flash-preview",
+      signature: "Y2FsbF9zaWdfMQ==",
       messages: [
-        {
-          role: "assistant",
-          provider: "google",
-          api: "google-generative-ai",
+        googleToolCallAssistantTurn({
           model: "gemini-3-flash-preview",
-          stopReason: "toolUse",
-          timestamp: 0,
-          content: [
-            {
-              type: "toolCall",
-              id: "call_1",
-              name: "lookup",
-              arguments: { q: "hello" },
-              thoughtSignature: "Y2FsbF9zaWdfMQ==",
-            },
-          ],
-        },
-      ],
-    } as never);
-
-    expect(params.contents[0]).toEqual({
-      role: "model",
-      parts: [
-        {
           thoughtSignature: "Y2FsbF9zaWdfMQ==",
-          functionCall: { name: "lookup", args: { q: "hello" } },
-        },
+        }),
       ],
-    });
-  });
-
-  it("re-attaches replayed Gemini thought signatures when a later tool call is missing one", () => {
-    const model = buildGeminiModel({
-      id: "gemini-3.1-pro-preview",
-      name: "Gemini 3.1 Pro Preview",
-    });
-
-    const params = buildGoogleGenerativeAiParams(model, {
+    },
+    {
+      name: "re-attaches replayed Gemini thought signatures when a later tool call is missing one",
+      modelId: "gemini-3.1-pro-preview",
+      signature: "Y2FsbF9zaWdfcmVwbGF5XzE=",
       messages: [
         googleToolCallAssistantTurn({ thoughtSignature: "Y2FsbF9zaWdfcmVwbGF5XzE=" }),
         toolResultTurn(),
         googleToolCallAssistantTurn({ timestamp: 2 }),
       ],
-    } as never);
-
-    // Find the last model-role content; should carry the replayed signature
-    // even though the second stored toolCall block had none.
-    expect(getLastModelTurn(params.contents)).toMatchObject({
-      role: "model",
-      parts: [
-        {
-          thoughtSignature: "Y2FsbF9zaWdfcmVwbGF5XzE=",
-          functionCall: { name: "lookup", args: { q: "hello" } },
-        },
-      ],
-    });
-  });
-
-  it("treats the Google transport alias as the same route for signature replay", () => {
-    const model = {
-      ...buildGeminiModel({
-        id: "gemini-3.1-pro-preview",
-        name: "Gemini 3.1 Pro Preview",
-      }),
+    },
+    {
+      name: "treats the Google transport alias as the same route for signature replay",
+      modelId: "gemini-3.1-pro-preview",
       api: "openclaw-google-generative-ai-transport",
-    } as Model<"openclaw-google-generative-ai-transport">;
-
-    const params = buildGoogleGenerativeAiParams(model, {
+      signature: "Y2FsbF9zaWdfYWxpYXNfMQ==",
       messages: [
         googleToolCallAssistantTurn({ thoughtSignature: "Y2FsbF9zaWdfYWxpYXNfMQ==" }),
         toolResultTurn(),
         googleToolCallAssistantTurn({ timestamp: 2 }),
       ],
-    } as never);
+    },
+    {
+      name: "preserves opaque same-route Gemini thought signatures during replay",
+      modelId: "gemini-3.1-pro-preview",
+      signature: "b3BhcXVlLnNpZy11cmxfc2FmZX4x",
+      messages: [
+        googleToolCallAssistantTurn({ thoughtSignature: "b3BhcXVlLnNpZy11cmxfc2FmZX4x" }),
+        toolResultTurn(),
+        googleToolCallAssistantTurn({ timestamp: 2 }),
+      ],
+    },
+  ])("$name", ({ modelId, api, signature, messages }) => {
+    const model = {
+      ...buildGeminiModel({
+        id: modelId,
+        name:
+          modelId === "gemini-3-flash-preview"
+            ? "Gemini 3 Flash Preview"
+            : "Gemini 3.1 Pro Preview",
+      }),
+      ...(api ? { api } : {}),
+    } as Parameters<typeof buildGoogleGenerativeAiParams>[0];
+    const params = buildGoogleGenerativeAiParams(model, { messages } as never);
 
-    expect(getLastModelTurn(params.contents)).toMatchObject({
+    expect(getLastModelTurn(params.contents)).toEqual({
       role: "model",
       parts: [
         {
-          thoughtSignature: "Y2FsbF9zaWdfYWxpYXNfMQ==",
+          thoughtSignature: signature,
           functionCall: { name: "lookup", args: { q: "hello" } },
         },
       ],
@@ -1774,31 +1646,6 @@ describe("google transport stream", () => {
         {
           text: "answer",
           thoughtSignature: "dGV4dF9zaWdfYWxpYXNfMQ==",
-        },
-      ],
-    });
-  });
-
-  it("preserves opaque same-route Gemini thought signatures during replay", () => {
-    const model = buildGeminiModel({
-      id: "gemini-3.1-pro-preview",
-      name: "Gemini 3.1 Pro Preview",
-    });
-
-    const params = buildGoogleGenerativeAiParams(model, {
-      messages: [
-        googleToolCallAssistantTurn({ thoughtSignature: "b3BhcXVlLnNpZy11cmxfc2FmZX4x" }),
-        toolResultTurn(),
-        googleToolCallAssistantTurn({ timestamp: 2 }),
-      ],
-    } as never);
-
-    expect(getLastModelTurn(params.contents)).toMatchObject({
-      role: "model",
-      parts: [
-        {
-          thoughtSignature: "b3BhcXVlLnNpZy11cmxfc2FmZX4x",
-          functionCall: { name: "lookup", args: { q: "hello" } },
         },
       ],
     });
@@ -2169,66 +2016,40 @@ describe("google transport stream", () => {
     expect(thinkingConfig).not.toHaveProperty("thinkingBudget");
   });
 
-  it("does not send thinkingConfig when the resolved Google model disables reasoning", () => {
-    const params = buildGoogleGenerativeAiParams(
-      buildGeminiModel({
-        id: "gemma-4-26b-a4b-it",
-        reasoning: false,
-      }),
-      {
-        messages: [{ role: "user", content: "hello", timestamp: 0 }],
-      } as never,
-      {
-        reasoning: "medium",
-      },
-    );
-
-    expect(params.generationConfig ?? {}).not.toHaveProperty("thinkingConfig");
-  });
-
-  it("omits disabled thinkingBudget=0 for Gemini 2.5 Pro direct payloads", () => {
-    const params = buildGoogleGenerativeAiParams(
-      buildGeminiModel(),
-      {
-        messages: [{ role: "user", content: "hello", timestamp: 0 }],
-      } as never,
-      {
-        maxTokens: 128,
-      } as never,
-    );
-
-    const generationConfig = requireGenerationConfig(params);
-    expect(generationConfig.maxOutputTokens).toBe(128);
+  it.each([
+    {
+      name: "does not send thinkingConfig when the resolved Google model disables reasoning",
+      model: { id: "gemma-4-26b-a4b-it", reasoning: false },
+      options: { reasoning: "medium" },
+    },
+    {
+      name: "omits disabled thinkingBudget=0 for Gemini 2.5 Pro direct payloads",
+      model: {},
+      options: { maxTokens: 128 },
+      maxOutputTokens: 128,
+    },
+  ])("$name", ({ model, options, maxOutputTokens }) => {
+    const generationConfig = buildGeminiUserParams(model, options).generationConfig ?? {};
     expect(generationConfig).not.toHaveProperty("thinkingConfig");
+    if (maxOutputTokens !== undefined) {
+      expect(generationConfig).toHaveProperty("maxOutputTokens", maxOutputTokens);
+    }
   });
 
-  it("forwards configured stop sequences to the Gemini generationConfig", () => {
-    const params = buildGoogleGenerativeAiParams(
-      buildGeminiModel(),
-      {
-        messages: [{ role: "user", content: "hello", timestamp: 0 }],
-      } as never,
-      {
-        stop: ["</tool>", "\n\nObservation:"],
-      } as never,
-    );
-
-    const generationConfig = requireGenerationConfig(params);
-    expect(generationConfig.stopSequences).toEqual(["</tool>", "\n\nObservation:"]);
-  });
-
-  it("omits stopSequences when the stop list is empty", () => {
-    const params = buildGoogleGenerativeAiParams(
-      buildGeminiModel(),
-      {
-        messages: [{ role: "user", content: "hello", timestamp: 0 }],
-      } as never,
-      {
-        stop: [],
-      } as never,
-    );
-
-    expect(params.generationConfig ?? {}).not.toHaveProperty("stopSequences");
+  it.each([
+    {
+      name: "forwards configured stop sequences to the Gemini generationConfig",
+      stop: ["</tool>", "\n\nObservation:"],
+      expected: ["</tool>", "\n\nObservation:"],
+    },
+    { name: "omits stopSequences when the stop list is empty", stop: [], expected: undefined },
+  ])("$name", ({ stop, expected }) => {
+    const generationConfig = buildGeminiUserParams({}, { stop }).generationConfig ?? {};
+    if (expected) {
+      expect(generationConfig).toHaveProperty("stopSequences", expected);
+    } else {
+      expect(generationConfig).not.toHaveProperty("stopSequences");
+    }
   });
 
   it("sends stopSequences in the serialized Gemini request body via the guarded fetch transport", async () => {

--- a/extensions/ollama/src/stream-runtime.test.ts
+++ b/extensions/ollama/src/stream-runtime.test.ts
@@ -51,6 +51,10 @@ function requireRecord(value: unknown, label: string): Record<string, unknown> {
   return value as Record<string, unknown>;
 }
 
+function requireOptionalRecord(value: unknown): Record<string, unknown> | undefined {
+  return value === undefined ? undefined : requireRecord(value, "request options");
+}
+
 function requireHeaders(value: unknown): Record<string, string> {
   return requireRecord(value, "request headers") as Record<string, string>;
 }
@@ -106,30 +110,32 @@ describe("buildOllamaChatRequest", () => {
     });
   });
 
-  it("strips the ollama/ prefix from chat model ids", () => {
-    const request = buildOllamaChatRequest({
+  it.each([
+    {
+      name: "strips the ollama/ prefix from chat model ids",
       modelId: "ollama/qwen3:14b-q8_0",
-      messages: [{ role: "user", content: "hello" }],
-    });
-    expect(request.model).toBe("qwen3:14b-q8_0");
-  });
-
-  it("strips the active custom provider prefix from chat model ids", () => {
-    const request = buildOllamaChatRequest({
+      expected: "qwen3:14b-q8_0",
+    },
+    {
+      name: "strips the active custom provider prefix from chat model ids",
       modelId: "ollama-spark/qwen3:32b",
       providerId: "ollama-spark",
-      messages: [{ role: "user", content: "hello" }],
-    });
-    expect(request.model).toBe("qwen3:32b");
-  });
-
-  it("keeps unrelated slash-containing Ollama model ids intact", () => {
-    const request = buildOllamaChatRequest({
+      expected: "qwen3:32b",
+    },
+    {
+      name: "keeps unrelated slash-containing Ollama model ids intact",
       modelId: "library/qwen3:32b",
       providerId: "ollama-spark",
-      messages: [{ role: "user", content: "hello" }],
-    });
-    expect(request.model).toBe("library/qwen3:32b");
+      expected: "library/qwen3:32b",
+    },
+  ])("$name", ({ modelId, providerId, expected }) => {
+    expect(
+      buildOllamaChatRequest({
+        modelId,
+        providerId,
+        messages: [{ role: "user", content: "hello" }],
+      }).model,
+    ).toBe(expected);
   });
 
   it("keeps native Ollama replay tool arguments as objects", () => {
@@ -288,266 +294,89 @@ describe("createConfiguredOllamaCompatStreamWrapper", () => {
     expect(payload.options).toEqual({ num_ctx: 131072 });
   });
 
-  it("forwards think=false on native Ollama chat requests when thinking is off", async () => {
-    await withMockNdjsonFetch(
-      [
-        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"ok"},"done":false}',
-        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":1,"eval_count":1}',
-      ],
-      async (fetchMock) => {
-        const baseStreamFn = createOllamaStreamFn("http://ollama-host:11434");
-        const model = {
-          api: "ollama",
+  it.each([
+    {
+      name: "forwards think=false on native Ollama chat requests when thinking is off",
+      id: "qwen3:32b",
+      contextWindow: 131072,
+      thinkingLevel: "off",
+      expectedThink: false,
+    },
+    {
+      name: "does not overwrite configured native Ollama params.thinking with implicit off",
+      id: "qwen3:32b",
+      contextWindow: 131072,
+      thinkingLevel: "off",
+      params: { thinking: "medium" },
+      expectedThink: "medium",
+    },
+    {
+      name: "does not forward truthy configured native Ollama thinking for non-reasoning models",
+      id: "llama3.2:latest",
+      contextWindow: 8192,
+      reasoning: false,
+      thinkingLevel: "off",
+      params: { thinking: "medium" },
+      expectedThink: undefined,
+    },
+    {
+      name: "does not forward runtime native Ollama thinking for non-reasoning models",
+      id: "llama3.2:latest",
+      contextWindow: 8192,
+      reasoning: false,
+      thinkingLevel: "low",
+      expectedThink: undefined,
+    },
+    {
+      name: "forwards the native think effort on native Ollama chat requests when thinking is enabled",
+      id: "qwen3:32b",
+      contextWindow: 131072,
+      thinkingLevel: "low",
+      expectedThink: "low",
+    },
+    {
+      name: "maps native Ollama max thinking to think=high on the wire",
+      id: "gpt-oss:20b",
+      contextWindow: 131072,
+      thinkingLevel: "max",
+      expectedThink: "high",
+    },
+  ])("$name", async ({ id, contextWindow, reasoning, thinkingLevel, params, expectedThink }) => {
+    await withSuccessfulOllamaFetch(async (fetchMock) => {
+      const model = {
+        api: "ollama",
+        provider: "ollama",
+        id,
+        contextWindow,
+        ...(reasoning === undefined ? {} : { reasoning }),
+        ...(params ? { params } : {}),
+      };
+      const wrapped = expectDefined(
+        createConfiguredOllamaCompatStreamWrapper({
           provider: "ollama",
-          id: "qwen3:32b",
-          contextWindow: 131072,
-        };
-
-        const wrapped = createConfiguredOllamaCompatStreamWrapper({
-          provider: "ollama",
-          modelId: "qwen3:32b",
+          modelId: id,
           model,
-          streamFn: baseStreamFn,
-          thinkingLevel: "off",
-        } as never);
-        if (!wrapped) {
-          throw new Error("Expected wrapped Ollama stream function");
-        }
+          streamFn: createOllamaStreamFn("http://ollama-host:11434"),
+          thinkingLevel,
+        } as never),
+        "wrapped Ollama stream function",
+      );
+      const stream = await Promise.resolve(
+        wrapped(
+          model as never,
+          { messages: [{ role: "user", content: "hello" }] } as never,
+          {} as never,
+        ),
+      );
+      await collectStreamEvents(stream);
 
-        const stream = await Promise.resolve(
-          wrapped(
-            model as never,
-            {
-              messages: [{ role: "user", content: "hello" }],
-            } as never,
-            {} as never,
-          ),
-        );
-
-        await collectStreamEvents(stream);
-
-        const requestInit = getGuardedFetchCall(fetchMock).init ?? {};
-        if (typeof requestInit.body !== "string") {
-          throw new Error("Expected string request body");
-        }
-        const requestBody = JSON.parse(requestInit.body) as {
-          think?: boolean;
-          options?: { think?: boolean; num_ctx?: number };
-        };
-        expect(requestBody.think).toBe(false);
-        expect(requestBody.options?.think).toBeUndefined();
-        expect(requestBody.options?.num_ctx).toBeUndefined();
-      },
-    );
-  });
-
-  it("does not overwrite configured native Ollama params.thinking with implicit off", async () => {
-    await withMockNdjsonFetch(
-      [
-        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"ok"},"done":false}',
-        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":1,"eval_count":1}',
-      ],
-      async (fetchMock) => {
-        const baseStreamFn = createOllamaStreamFn("http://ollama-host:11434");
-        const model = {
-          api: "ollama",
-          provider: "ollama",
-          id: "qwen3:32b",
-          contextWindow: 131072,
-          params: { thinking: "medium" },
-        };
-
-        const wrapped = createConfiguredOllamaCompatStreamWrapper({
-          provider: "ollama",
-          modelId: "qwen3:32b",
-          model,
-          streamFn: baseStreamFn,
-          thinkingLevel: "off",
-        } as never);
-        if (!wrapped) {
-          throw new Error("Expected wrapped Ollama stream function");
-        }
-
-        const stream = await Promise.resolve(
-          wrapped(
-            model as never,
-            {
-              messages: [{ role: "user", content: "hello" }],
-            } as never,
-            {} as never,
-          ),
-        );
-
-        await collectStreamEvents(stream);
-
-        const requestInit = getGuardedFetchCall(fetchMock).init ?? {};
-        if (typeof requestInit.body !== "string") {
-          throw new Error("Expected string request body");
-        }
-        const requestBody = JSON.parse(requestInit.body) as { think?: string };
-        expect(requestBody.think).toBe("medium");
-      },
-    );
-  });
-
-  it("does not forward truthy configured native Ollama thinking for non-reasoning models", async () => {
-    await withMockNdjsonFetch(
-      [
-        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"ok"},"done":false}',
-        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":1,"eval_count":1}',
-      ],
-      async (fetchMock) => {
-        const baseStreamFn = createOllamaStreamFn("http://ollama-host:11434");
-        const model = {
-          api: "ollama",
-          provider: "ollama",
-          id: "llama3.2:latest",
-          contextWindow: 8192,
-          reasoning: false,
-          params: { thinking: "medium" },
-        };
-
-        const wrapped = createConfiguredOllamaCompatStreamWrapper({
-          provider: "ollama",
-          modelId: "llama3.2:latest",
-          model,
-          streamFn: baseStreamFn,
-          thinkingLevel: "off",
-        } as never);
-        if (!wrapped) {
-          throw new Error("Expected wrapped Ollama stream function");
-        }
-
-        const stream = await Promise.resolve(
-          wrapped(
-            model as never,
-            {
-              messages: [{ role: "user", content: "hello" }],
-            } as never,
-            {} as never,
-          ),
-        );
-
-        await collectStreamEvents(stream);
-
-        const requestInit = getGuardedFetchCall(fetchMock).init ?? {};
-        if (typeof requestInit.body !== "string") {
-          throw new Error("Expected string request body");
-        }
-        const requestBody = JSON.parse(requestInit.body) as {
-          think?: string;
-          options?: { think?: string };
-        };
-        expect(requestBody.think).toBeUndefined();
-        expect(requestBody.options?.think).toBeUndefined();
-      },
-    );
-  });
-
-  it("does not forward runtime native Ollama thinking for non-reasoning models", async () => {
-    await withMockNdjsonFetch(
-      [
-        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"ok"},"done":false}',
-        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":1,"eval_count":1}',
-      ],
-      async (fetchMock) => {
-        const baseStreamFn = createOllamaStreamFn("http://ollama-host:11434");
-        const model = {
-          api: "ollama",
-          provider: "ollama",
-          id: "llama3.2:latest",
-          contextWindow: 8192,
-          reasoning: false,
-        };
-
-        const wrapped = createConfiguredOllamaCompatStreamWrapper({
-          provider: "ollama",
-          modelId: "llama3.2:latest",
-          model,
-          streamFn: baseStreamFn,
-          thinkingLevel: "low",
-        } as never);
-        if (!wrapped) {
-          throw new Error("Expected wrapped Ollama stream function");
-        }
-
-        const stream = await Promise.resolve(
-          wrapped(
-            model as never,
-            {
-              messages: [{ role: "user", content: "hello" }],
-            } as never,
-            {} as never,
-          ),
-        );
-
-        await collectStreamEvents(stream);
-
-        const requestInit = getGuardedFetchCall(fetchMock).init ?? {};
-        if (typeof requestInit.body !== "string") {
-          throw new Error("Expected string request body");
-        }
-        const requestBody = JSON.parse(requestInit.body) as {
-          think?: string;
-          options?: { think?: string };
-        };
-        expect(requestBody.think).toBeUndefined();
-        expect(requestBody.options?.think).toBeUndefined();
-      },
-    );
-  });
-
-  it("forwards the native think effort on native Ollama chat requests when thinking is enabled", async () => {
-    await withMockNdjsonFetch(
-      [
-        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"ok"},"done":false}',
-        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":1,"eval_count":1}',
-      ],
-      async (fetchMock) => {
-        const baseStreamFn = createOllamaStreamFn("http://ollama-host:11434");
-        const model = {
-          api: "ollama",
-          provider: "ollama",
-          id: "qwen3:32b",
-          contextWindow: 131072,
-        };
-
-        const wrapped = createConfiguredOllamaCompatStreamWrapper({
-          provider: "ollama",
-          modelId: "qwen3:32b",
-          model,
-          streamFn: baseStreamFn,
-          thinkingLevel: "low",
-        } as never);
-        if (!wrapped) {
-          throw new Error("Expected wrapped Ollama stream function");
-        }
-
-        const stream = await Promise.resolve(
-          wrapped(
-            model as never,
-            {
-              messages: [{ role: "user", content: "hello" }],
-            } as never,
-            {} as never,
-          ),
-        );
-
-        await collectStreamEvents(stream);
-
-        const requestInit = getGuardedFetchCall(fetchMock).init ?? {};
-        if (typeof requestInit.body !== "string") {
-          throw new Error("Expected string request body");
-        }
-        const requestBody = JSON.parse(requestInit.body) as {
-          think?: boolean | string;
-          options?: { think?: boolean | string; num_ctx?: number };
-        };
-        expect(requestBody.think).toBe("low");
-        expect(requestBody.options?.think).toBeUndefined();
-        expect(requestBody.options?.num_ctx).toBeUndefined();
-      },
-    );
+      const requestBody = getGuardedFetchJsonBody(fetchMock);
+      expect(requestBody.think).toBe(expectedThink);
+      expect(requireOptionalRecord(requestBody.options)?.think).toBeUndefined();
+      if (reasoning !== false) {
+        expect(requireOptionalRecord(requestBody.options)?.num_ctx).toBeUndefined();
+      }
+    });
   });
 
   it("passes resolved provider request timeouts to native Ollama chat fetches", async () => {
@@ -588,59 +417,6 @@ describe("createConfiguredOllamaCompatStreamWrapper", () => {
         expect(request.timeoutMs).toBe(123_456);
         expect(request.signal).toBe(signal);
         expect(request.init?.signal).toBeUndefined();
-      },
-    );
-  });
-
-  it("maps native Ollama max thinking to think=high on the wire", async () => {
-    await withMockNdjsonFetch(
-      [
-        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"ok"},"done":false}',
-        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":1,"eval_count":1}',
-      ],
-      async (fetchMock) => {
-        const baseStreamFn = createOllamaStreamFn("http://ollama-host:11434");
-        const model = {
-          api: "ollama",
-          provider: "ollama",
-          id: "gpt-oss:20b",
-          contextWindow: 131072,
-        };
-
-        const wrapped = createConfiguredOllamaCompatStreamWrapper({
-          provider: "ollama",
-          modelId: "gpt-oss:20b",
-          model,
-          streamFn: baseStreamFn,
-          thinkingLevel: "max",
-        } as never);
-        if (!wrapped) {
-          throw new Error("Expected wrapped Ollama stream function");
-        }
-
-        const stream = await Promise.resolve(
-          wrapped(
-            model as never,
-            {
-              messages: [{ role: "user", content: "hello" }],
-            } as never,
-            {} as never,
-          ),
-        );
-
-        await collectStreamEvents(stream);
-
-        const requestInit = getGuardedFetchCall(fetchMock).init ?? {};
-        if (typeof requestInit.body !== "string") {
-          throw new Error("Expected string request body");
-        }
-        const requestBody = JSON.parse(requestInit.body) as {
-          think?: boolean | string;
-          options?: { think?: boolean | string; num_ctx?: number };
-        };
-        expect(requestBody.think).toBe("high");
-        expect(requestBody.options?.think).toBeUndefined();
-        expect(requestBody.options?.num_ctx).toBeUndefined();
       },
     );
   });
@@ -1075,99 +851,52 @@ describe("buildAssistantMessage", () => {
     expect(result.usage.output).toBe(6);
   });
 
-  it("strips inline reasoning prefix from kimi cloud visible text", () => {
-    const response = {
-      model: "kimi-k2.6:cloud",
-      created_at: "2026-01-01T00:00:00Z",
-      message: {
-        role: "assistant" as const,
-        content:
-          "I should think privately and not leak this planning text in the answer. I need to keep deciding what to say next. ️Final answer only.",
-      },
-      done: true,
-    };
-    const result = buildAssistantMessage(response, {
-      api: "ollama",
-      provider: "ollama",
+  it.each([
+    {
+      name: "strips inline reasoning prefix from kimi cloud visible text",
       id: "kimi-k2.6:cloud",
-    });
-    expect(result.content).toEqual([{ type: "text", text: "Final answer only." }]);
-  });
-
-  it("strips inline reasoning for provider-qualified Kimi cloud refs", () => {
-    const response = {
-      model: "kimi-k2.6:cloud",
-      created_at: "2026-01-01T00:00:00Z",
-      message: {
-        role: "assistant" as const,
-        content:
-          "I should think privately and not leak this planning text in the answer. I need to keep deciding what to say next. ️Final answer only.",
-      },
-      done: true,
-    };
-    const result = buildAssistantMessage(response, {
-      api: "ollama",
-      provider: "ollama",
+      answer: "Final answer only.",
+      separator: "️",
+    },
+    {
+      name: "strips inline reasoning for provider-qualified Kimi cloud refs",
       id: "ollama/kimi-k2.6:cloud",
-    });
-    expect(result.content).toEqual([{ type: "text", text: "Final answer only." }]);
-  });
-
-  it("strips inline reasoning when the Kimi boundary is followed by whitespace", () => {
+      answer: "Final answer only.",
+      separator: "️",
+    },
+    {
+      name: "strips inline reasoning when the Kimi boundary is followed by whitespace",
+      id: "kimi-k2.6:cloud",
+      answer: "Final answer only.",
+      separator: "️ ",
+    },
+    {
+      name: "strips inline reasoning before short Kimi cloud answers",
+      id: "kimi-k2.6:cloud",
+      answer: "OK.",
+      separator: "️ ",
+    },
+    {
+      name: "strips inline reasoning when the Kimi boundary has no visible answer",
+      id: "kimi-k2.6:cloud",
+      answer: "",
+      separator: "️ ",
+    },
+  ])("$name", ({ id, answer, separator }) => {
     const response = {
       model: "kimi-k2.6:cloud",
       created_at: "2026-01-01T00:00:00Z",
       message: {
         role: "assistant" as const,
         content:
-          "I should think privately and not leak this planning text in the answer. I need to keep deciding what to say next. ️ Final answer only.",
+          "I should think privately and not leak this planning text in the answer. " +
+          `I need to keep deciding what to say next. ${separator}${answer}`,
       },
       done: true,
     };
-    const result = buildAssistantMessage(response, {
-      api: "ollama",
-      provider: "ollama",
-      id: "kimi-k2.6:cloud",
-    });
-    expect(result.content).toEqual([{ type: "text", text: "Final answer only." }]);
-  });
-
-  it("strips inline reasoning before short Kimi cloud answers", () => {
-    const response = {
-      model: "kimi-k2.6:cloud",
-      created_at: "2026-01-01T00:00:00Z",
-      message: {
-        role: "assistant" as const,
-        content:
-          "I should think privately and not leak this planning text in the answer. I need to keep deciding what to say next. ️ OK.",
-      },
-      done: true,
-    };
-    const result = buildAssistantMessage(response, {
-      api: "ollama",
-      provider: "ollama",
-      id: "kimi-k2.6:cloud",
-    });
-    expect(result.content).toEqual([{ type: "text", text: "OK." }]);
-  });
-
-  it("strips inline reasoning when the Kimi boundary has no visible answer", () => {
-    const response = {
-      model: "kimi-k2.6:cloud",
-      created_at: "2026-01-01T00:00:00Z",
-      message: {
-        role: "assistant" as const,
-        content:
-          "I should think privately and not leak this planning text in the answer. I need to keep deciding what to say next. ️ ",
-      },
-      done: true,
-    };
-    const result = buildAssistantMessage(response, {
-      api: "ollama",
-      provider: "ollama",
-      id: "kimi-k2.6:cloud",
-    });
-    expect(result.content).toEqual([]);
+    expect(
+      buildAssistantMessage(response, { api: "ollama", provider: "ollama", id }).content,
+    ).toEqual(answer ? [{ type: "text", text: answer }] : []);
   });
 
   it("does not strip inline boundary marker on non-kimi models", () => {
@@ -1765,6 +1494,18 @@ async function withMockNdjsonFetch(
   await run(fetchWithSsrFGuardMock);
 }
 
+async function withSuccessfulOllamaFetch(
+  run: (fetchMock: typeof fetchWithSsrFGuardMock) => Promise<void>,
+): Promise<void> {
+  await withMockNdjsonFetch(
+    [
+      '{"model":"m","created_at":"t","message":{"role":"assistant","content":"ok"},"done":false}',
+      '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":1,"eval_count":1}',
+    ],
+    run,
+  );
+}
+
 function createControlledNdjsonFetch(): {
   fetchImpl: () => Promise<{ response: Response; release: () => Promise<void> }>;
   pushLine: (line: string) => void;
@@ -1802,6 +1543,16 @@ function createControlledNdjsonFetch(): {
 
 function getGuardedFetchCall(fetchMock: typeof fetchWithSsrFGuardMock): GuardedFetchCall {
   return (fetchMock.mock.calls.at(0)?.[0] as GuardedFetchCall | undefined) ?? { url: "" };
+}
+
+function getGuardedFetchJsonBody(
+  fetchMock: typeof fetchWithSsrFGuardMock,
+): Record<string, unknown> {
+  const body = getGuardedFetchCall(fetchMock).init?.body;
+  if (typeof body !== "string") {
+    throw new Error("Expected string request body");
+  }
+  return requireRecord(JSON.parse(body), "Ollama request body");
 }
 
 function cancelTrackedResponse(
@@ -1863,6 +1614,25 @@ async function collectStreamEvents<T>(stream: AsyncIterable<T>): Promise<T[]> {
     events.push(event);
   }
   return events;
+}
+
+async function expectSuccessfulOllamaRequest(
+  params: Parameters<typeof createOllamaTestStream>[0],
+  verify: (observation: {
+    body: Record<string, unknown>;
+    fetchMock: typeof fetchWithSsrFGuardMock;
+    request: GuardedFetchCall;
+  }) => void | Promise<void>,
+): Promise<void> {
+  await withSuccessfulOllamaFetch(async (fetchMock) => {
+    const events = await collectStreamEvents(await createOllamaTestStream(params));
+    expect(events.at(-1)?.type).toBe("done");
+    await verify({
+      body: getGuardedFetchJsonBody(fetchMock),
+      fetchMock,
+      request: getGuardedFetchCall(fetchMock),
+    });
+  });
 }
 
 async function nextEventWithin<T>(
@@ -2555,177 +2325,102 @@ describe("createOllamaStreamFn streaming events", () => {
 
 describe("createOllamaStreamFn", () => {
   it("normalizes /v1 baseUrl and maps maxTokens + signal", async () => {
-    await withMockNdjsonFetch(
-      [
-        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"ok"},"done":false}',
-        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":1,"eval_count":1}',
-      ],
-      async (fetchMock) => {
-        const signal = new AbortController().signal;
-        const stream = await createOllamaTestStream({
-          baseUrl: "http://ollama-host:11434/v1/",
-          options: { maxTokens: 123, signal },
-        });
-
-        const events = await collectStreamEvents(stream);
-        expect(events.at(-1)?.type).toBe("done");
-
+    const signal = new AbortController().signal;
+    await expectSuccessfulOllamaRequest(
+      { baseUrl: "http://ollama-host:11434/v1/", options: { maxTokens: 123, signal } },
+      ({ body, fetchMock, request }) => {
         expect(fetchMock).toHaveBeenCalledTimes(1);
-        const request = getGuardedFetchCall(fetchMock);
         expect(request.url).toBe("http://ollama-host:11434/api/chat");
         expect(request.auditContext).toBe("ollama-stream.chat");
         expect(request.signal).toBe(signal);
-        const requestInit = request.init ?? {};
-        expect(requestInit.signal).toBeUndefined();
-        if (typeof requestInit.body !== "string") {
-          throw new Error("Expected string request body");
-        }
-
-        const requestBody = JSON.parse(requestInit.body) as {
-          options?: { num_ctx?: number; num_predict?: number };
-        };
-        if (!requestBody.options) {
-          throw new Error("Expected Ollama request options");
-        }
-        expect(requestBody.options?.num_ctx).toBeUndefined();
-        expect(requestBody.options.num_predict).toBe(123);
+        expect(request.init?.signal).toBeUndefined();
+        const options = requireRecord(body.options, "Ollama request options");
+        expect(options.num_ctx).toBeUndefined();
+        expect(options.num_predict).toBe(123);
       },
     );
   });
 
   it("maps responseFormat JSON Schema to native Ollama format", async () => {
-    await withMockNdjsonFetch(
-      ['{"model":"m","created_at":"t","message":{"role":"assistant","content":"ok"},"done":true}'],
-      async (fetchMock) => {
-        const schema = {
-          type: "object",
-          properties: { reply: { type: "string" } },
-          required: ["reply"],
-          additionalProperties: false,
-        };
-        const stream = await createOllamaTestStream({
-          baseUrl: "http://ollama-host:11434",
-          options: { responseFormat: schema },
-        });
-
-        await collectStreamEvents(stream);
-
-        const requestInit = getGuardedFetchCall(fetchMock).init ?? {};
-        if (typeof requestInit.body !== "string") {
-          throw new Error("Expected string request body");
-        }
-        expect(JSON.parse(requestInit.body)).toMatchObject({ format: schema });
-      },
-    );
-  });
-
-  it("omits native Ollama format when responseFormat is absent", async () => {
-    await withMockNdjsonFetch(
-      ['{"model":"m","created_at":"t","message":{"role":"assistant","content":"ok"},"done":true}'],
-      async (fetchMock) => {
-        const stream = await createOllamaTestStream({
-          baseUrl: "http://ollama-host:11434",
-        });
-
-        await collectStreamEvents(stream);
-
-        const requestInit = getGuardedFetchCall(fetchMock).init ?? {};
-        if (typeof requestInit.body !== "string") {
-          throw new Error("Expected string request body");
-        }
-        expect(JSON.parse(requestInit.body)).not.toHaveProperty("format");
-      },
-    );
-  });
-
-  it("keeps provider-shaped text response formats off the native Ollama wire", async () => {
-    await withMockNdjsonFetch(
-      ['{"model":"m","created_at":"t","message":{"role":"assistant","content":"ok"},"done":true}'],
-      async (fetchMock) => {
-        const stream = await createOllamaTestStream({
-          baseUrl: "http://ollama-host:11434",
-          options: { responseFormat: { type: "text" } },
-        });
-
-        await collectStreamEvents(stream);
-
-        const requestInit = getGuardedFetchCall(fetchMock).init ?? {};
-        if (typeof requestInit.body !== "string") {
-          throw new Error("Expected string request body");
-        }
-        expect(JSON.parse(requestInit.body)).not.toHaveProperty("format");
-      },
+    const schema = {
+      type: "object",
+      properties: { reply: { type: "string" } },
+      required: ["reply"],
+      additionalProperties: false,
+    };
+    await expectSuccessfulOllamaRequest(
+      { baseUrl: "http://ollama-host:11434", options: { responseFormat: schema } },
+      ({ body }) => expect(body).toMatchObject({ format: schema }),
     );
   });
 
   it.each([
     {
-      name: "cloud model through a local daemon",
+      name: "omits native Ollama format when responseFormat is absent",
+      baseUrl: "http://ollama-host:11434",
+    },
+    {
+      name: "keeps provider-shaped text response formats off the native Ollama wire",
+      baseUrl: "http://ollama-host:11434",
+      responseFormat: { type: "text" },
+    },
+    {
+      name: "omits native Ollama format for cloud model through a local daemon",
       baseUrl: "http://ollama-host:11434",
       id: "gemma4:cloud",
-    },
-    { name: "hosted Ollama Cloud", baseUrl: "https://ollama.com/v1", id: "gemma4" },
-  ])("omits native Ollama format for $name", async ({ baseUrl, id }) => {
-    await withMockNdjsonFetch(
-      ['{"model":"m","created_at":"t","message":{"role":"assistant","content":"ok"},"done":true}'],
-      async (fetchMock) => {
-        const stream = await createOllamaTestStream({
-          baseUrl,
-          model: { id },
-          options: {
-            responseFormat: {
-              type: "object",
-              properties: { reply: { type: "string" } },
-              required: ["reply"],
-              additionalProperties: false,
-            },
-          },
-        });
-
-        await collectStreamEvents(stream);
-
-        const requestInit = getGuardedFetchCall(fetchMock).init ?? {};
-        if (typeof requestInit.body !== "string") {
-          throw new Error("Expected string request body");
-        }
-        expect(JSON.parse(requestInit.body)).not.toHaveProperty("format");
+      responseFormat: {
+        type: "object",
+        properties: { reply: { type: "string" } },
+        required: ["reply"],
+        additionalProperties: false,
       },
+    },
+    {
+      name: "omits native Ollama format for hosted Ollama Cloud",
+      baseUrl: "https://ollama.com/v1",
+      id: "gemma4",
+      responseFormat: {
+        type: "object",
+        properties: { reply: { type: "string" } },
+        required: ["reply"],
+        additionalProperties: false,
+      },
+    },
+  ])("$name", async ({ baseUrl, id, responseFormat }) => {
+    await expectSuccessfulOllamaRequest(
+      {
+        baseUrl,
+        ...(id ? { model: { id } } : {}),
+        ...(responseFormat ? { options: { responseFormat } } : {}),
+      },
+      ({ body }) => expect(body).not.toHaveProperty("format"),
     );
   });
 
   it("lets native Ollama tools win over responseFormat", async () => {
-    await withMockNdjsonFetch(
-      ['{"model":"m","created_at":"t","message":{"role":"assistant","content":"ok"},"done":true}'],
-      async (fetchMock) => {
-        const stream = await createOllamaTestStream({
-          baseUrl: "http://ollama-host:11434",
-          context: {
-            messages: [{ role: "user", content: "weather" }],
-            tools: [
-              {
-                name: "weather",
-                description: "Get weather",
-                parameters: { type: "object", properties: {} },
-              },
-            ],
-          },
-          options: {
-            responseFormat: {
-              type: "object",
-              properties: { reply: { type: "string" } },
-              required: ["reply"],
-              additionalProperties: false,
+    await expectSuccessfulOllamaRequest(
+      {
+        baseUrl: "http://ollama-host:11434",
+        context: {
+          messages: [{ role: "user", content: "weather" }],
+          tools: [
+            {
+              name: "weather",
+              description: "Get weather",
+              parameters: { type: "object", properties: {} },
             },
+          ],
+        },
+        options: {
+          responseFormat: {
+            type: "object",
+            properties: { reply: { type: "string" } },
+            required: ["reply"],
+            additionalProperties: false,
           },
-        });
-
-        await collectStreamEvents(stream);
-
-        const requestInit = getGuardedFetchCall(fetchMock).init ?? {};
-        if (typeof requestInit.body !== "string") {
-          throw new Error("Expected string request body");
-        }
-        const body = JSON.parse(requestInit.body);
+        },
+      },
+      ({ body }) => {
         expect(body.tools).toHaveLength(1);
         expect(body).not.toHaveProperty("format");
       },
@@ -2733,417 +2428,154 @@ describe("createOllamaStreamFn", () => {
   });
 
   it("uses configured params.num_ctx for native Ollama chat options", async () => {
-    await withMockNdjsonFetch(
-      [
-        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"ok"},"done":false}',
-        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":1,"eval_count":1}',
-      ],
-      async (fetchMock) => {
-        const stream = await createOllamaTestStream({
-          baseUrl: "http://ollama-host:11434",
-          model: {
-            params: {
-              num_ctx: 32768,
-              temperature: 0.2,
-              top_p: 0.9,
-              thinking: false,
-              streaming: false,
-            },
-            contextWindow: 131072,
-            contextTokens: 16384,
+    await expectSuccessfulOllamaRequest(
+      {
+        baseUrl: "http://ollama-host:11434",
+        model: {
+          params: {
+            num_ctx: 32768,
+            temperature: 0.2,
+            top_p: 0.9,
+            thinking: false,
+            streaming: false,
           },
-          options: { temperature: 0.7, maxTokens: 55 },
+          contextWindow: 131072,
+          contextTokens: 16384,
+        },
+        options: { temperature: 0.7, maxTokens: 55 },
+      },
+      ({ body }) => {
+        const options = requireRecord(body.options, "Ollama request options");
+        expect(options).toMatchObject({
+          num_ctx: 32768,
+          num_predict: 55,
+          temperature: 0.7,
+          top_p: 0.9,
         });
-
-        const events = await collectStreamEvents(stream);
-        expect(events.at(-1)?.type).toBe("done");
-
-        const requestInit = getGuardedFetchCall(fetchMock).init ?? {};
-        if (typeof requestInit.body !== "string") {
-          throw new Error("Expected string request body");
-        }
-        const requestBody = JSON.parse(requestInit.body) as {
-          think?: boolean;
-          options: {
-            num_ctx?: number;
-            num_predict?: number;
-            temperature?: number;
-            top_p?: number;
-            streaming?: boolean;
-          };
-        };
-        expect(requestBody.options.num_ctx).toBe(32768);
-        expect(requestBody.options.num_predict).toBe(55);
-        expect(requestBody.options.temperature).toBe(0.7);
-        expect(requestBody.options.top_p).toBe(0.9);
-        expect(requestBody.options.streaming).toBeUndefined();
-        expect(requestBody.think).toBe(false);
+        expect(options.streaming).toBeUndefined();
+        expect(body.think).toBe(false);
       },
     );
   });
 
-  it("uses effective contextTokens for native Ollama chat options", async () => {
-    await withMockNdjsonFetch(
-      [
-        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"ok"},"done":false}',
-        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":1,"eval_count":1}',
-      ],
-      async (fetchMock) => {
-        const stream = await createOllamaTestStream({
-          baseUrl: "http://ollama-host:11434",
-          model: { contextWindow: 262_144, contextTokens: 32_768 },
-        });
-
-        await collectStreamEvents(stream);
-
-        const requestInit = getGuardedFetchCall(fetchMock).init ?? {};
-        if (typeof requestInit.body !== "string") {
-          throw new Error("Expected string request body");
-        }
-        const requestBody = JSON.parse(requestInit.body) as {
-          options: { num_ctx?: number };
-        };
-        expect(requestBody.options.num_ctx).toBe(32_768);
-      },
+  it.each([
+    {
+      name: "uses effective contextTokens for native Ollama chat options",
+      model: { contextWindow: 262_144, contextTokens: 32_768 },
+      expected: 32_768,
+    },
+    {
+      name: "omits num_ctx when the model has no params.num_ctx and no catalog window",
+      model: { contextWindow: undefined },
+      expected: undefined,
+    },
+    {
+      name: "does not fall back to catalog contextWindow as native Ollama num_ctx",
+      model: { contextWindow: 32_768 },
+      expected: undefined,
+    },
+    {
+      name: "does not fall back to catalog maxTokens as native Ollama num_ctx",
+      model: { contextWindow: undefined, maxTokens: 65_536 },
+      expected: undefined,
+    },
+  ])("$name", async ({ model, expected }) => {
+    await expectSuccessfulOllamaRequest(
+      { baseUrl: "http://ollama-host:11434", model },
+      ({ body }) => expect(requireOptionalRecord(body.options)?.num_ctx).toBe(expected),
     );
   });
 
-  it("sets top_p=1 for native Ollama greedy sampling requests", async () => {
-    await withMockNdjsonFetch(
-      [
-        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"ok"},"done":false}',
-        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":1,"eval_count":1}',
-      ],
-      async (fetchMock) => {
-        const stream = await createOllamaTestStream({
-          baseUrl: "http://ollama-host:11434",
-          model: {
-            params: {
-              num_ctx: 4096,
-              top_p: 0.9,
-              thinking: false,
-            },
-          },
-          options: { temperature: 0 },
-        });
-
-        const events = await collectStreamEvents(stream);
-        expect(events.at(-1)?.type).toBe("done");
-
-        const requestInit = getGuardedFetchCall(fetchMock).init ?? {};
-        if (typeof requestInit.body !== "string") {
-          throw new Error("Expected string request body");
-        }
-        const requestBody = JSON.parse(requestInit.body) as {
-          options: {
-            temperature?: number;
-            top_p?: number;
-          };
-        };
-        expect(requestBody.options.temperature).toBe(0);
-        expect(requestBody.options.top_p).toBe(1);
-      },
-    );
-  });
-
-  it("sets top_p=1 for native Ollama greedy requests without configured top_p", async () => {
-    await withMockNdjsonFetch(
-      [
-        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"ok"},"done":false}',
-        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":1,"eval_count":1}',
-      ],
-      async (fetchMock) => {
-        const stream = await createOllamaTestStream({
-          baseUrl: "http://ollama-host:11434",
-          model: {
-            params: {
-              num_ctx: 4096,
-              thinking: false,
-            },
-          },
-          options: { temperature: 0 },
-        });
-
-        const events = await collectStreamEvents(stream);
-        expect(events.at(-1)?.type).toBe("done");
-
-        const requestInit = getGuardedFetchCall(fetchMock).init ?? {};
-        if (typeof requestInit.body !== "string") {
-          throw new Error("Expected string request body");
-        }
-        const requestBody = JSON.parse(requestInit.body) as {
-          options: {
-            temperature?: number;
-            top_p?: number;
-          };
-        };
-        expect(requestBody.options.temperature).toBe(0);
-        expect(requestBody.options.top_p).toBe(1);
-      },
-    );
-  });
-
-  it("preserves configured top_p for native Ollama non-greedy sampling requests", async () => {
-    await withMockNdjsonFetch(
-      [
-        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"ok"},"done":false}',
-        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":1,"eval_count":1}',
-      ],
-      async (fetchMock) => {
-        const stream = await createOllamaTestStream({
-          baseUrl: "http://ollama-host:11434",
-          model: {
-            params: {
-              top_p: 0.9,
-            },
-          },
-          options: { temperature: 0.2 },
-        });
-
-        const events = await collectStreamEvents(stream);
-        expect(events.at(-1)?.type).toBe("done");
-
-        const requestInit = getGuardedFetchCall(fetchMock).init ?? {};
-        if (typeof requestInit.body !== "string") {
-          throw new Error("Expected string request body");
-        }
-        const requestBody = JSON.parse(requestInit.body) as {
-          options: {
-            temperature?: number;
-            top_p?: number;
-          };
-        };
-        expect(requestBody.options.temperature).toBe(0.2);
-        expect(requestBody.options.top_p).toBe(0.9);
-      },
-    );
-  });
-
-  it("omits num_ctx when the model has no params.num_ctx and no catalog window", async () => {
-    await withMockNdjsonFetch(
-      [
-        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"ok"},"done":false}',
-        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":1,"eval_count":1}',
-      ],
-      async (fetchMock) => {
-        const stream = await createOllamaTestStream({
-          baseUrl: "http://ollama-host:11434",
-          // Override the helper default contextWindow back to undefined so the
-          // request body should leave Ollama's Modelfile to decide num_ctx.
-          model: { contextWindow: undefined },
-        });
-
-        await collectStreamEvents(stream);
-
-        const requestInit = getGuardedFetchCall(fetchMock).init ?? {};
-        if (typeof requestInit.body !== "string") {
-          throw new Error("Expected string request body");
-        }
-        const requestBody = JSON.parse(requestInit.body) as {
-          options?: { num_ctx?: number };
-        };
-        expect(requestBody.options?.num_ctx).toBeUndefined();
-      },
-    );
-  });
-
-  it("does not fall back to catalog contextWindow as native Ollama num_ctx", async () => {
-    await withMockNdjsonFetch(
-      [
-        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"ok"},"done":false}',
-        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":1,"eval_count":1}',
-      ],
-      async (fetchMock) => {
-        const stream = await createOllamaTestStream({
-          baseUrl: "http://ollama-host:11434",
-          model: { contextWindow: 32768 },
-        });
-
-        await collectStreamEvents(stream);
-
-        const requestInit = getGuardedFetchCall(fetchMock).init ?? {};
-        if (typeof requestInit.body !== "string") {
-          throw new Error("Expected string request body");
-        }
-        const requestBody = JSON.parse(requestInit.body) as {
-          options?: { num_ctx?: number };
-        };
-        expect(requestBody.options?.num_ctx).toBeUndefined();
-      },
-    );
-  });
-
-  it("does not fall back to catalog maxTokens as native Ollama num_ctx", async () => {
-    await withMockNdjsonFetch(
-      [
-        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"ok"},"done":false}',
-        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":1,"eval_count":1}',
-      ],
-      async (fetchMock) => {
-        const stream = await createOllamaTestStream({
-          baseUrl: "http://ollama-host:11434",
-          // The helper default contextWindow is overridden back to undefined so
-          // the right side of `model.contextWindow ?? model.maxTokens` is the
-          // load-bearing branch.
-          model: { contextWindow: undefined, maxTokens: 65536 },
-        });
-
-        await collectStreamEvents(stream);
-
-        const requestInit = getGuardedFetchCall(fetchMock).init ?? {};
-        if (typeof requestInit.body !== "string") {
-          throw new Error("Expected string request body");
-        }
-        const requestBody = JSON.parse(requestInit.body) as {
-          options?: { num_ctx?: number };
-        };
-        expect(requestBody.options?.num_ctx).toBeUndefined();
+  it.each([
+    {
+      name: "sets top_p=1 for native Ollama greedy sampling requests",
+      params: { num_ctx: 4096, top_p: 0.9, thinking: false },
+      temperature: 0,
+      expectedTopP: 1,
+    },
+    {
+      name: "sets top_p=1 for native Ollama greedy requests without configured top_p",
+      params: { num_ctx: 4096, thinking: false },
+      temperature: 0,
+      expectedTopP: 1,
+    },
+    {
+      name: "preserves configured top_p for native Ollama non-greedy sampling requests",
+      params: { top_p: 0.9 },
+      temperature: 0.2,
+      expectedTopP: 0.9,
+    },
+  ])("$name", async ({ params, temperature, expectedTopP }) => {
+    await expectSuccessfulOllamaRequest(
+      { baseUrl: "http://ollama-host:11434", model: { params }, options: { temperature } },
+      ({ body }) => {
+        const options = requireRecord(body.options, "Ollama sampling options");
+        expect(options.temperature).toBe(temperature);
+        expect(options.top_p).toBe(expectedTopP);
       },
     );
   });
 
   it("maps configured native Ollama params.thinking=max to the stable top-level think value", async () => {
-    await withMockNdjsonFetch(
-      [
-        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"ok"},"done":false}',
-        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":1,"eval_count":1}',
-      ],
-      async (fetchMock) => {
-        const stream = await createOllamaTestStream({
-          baseUrl: "http://ollama-host:11434",
-          model: { params: { thinking: "max" } },
-        });
-
-        const events = await collectStreamEvents(stream);
-        expect(events.at(-1)?.type).toBe("done");
-
-        const requestInit = getGuardedFetchCall(fetchMock).init ?? {};
-        if (typeof requestInit.body !== "string") {
-          throw new Error("Expected string request body");
-        }
-        const requestBody = JSON.parse(requestInit.body) as {
-          think?: string;
-          options?: { think?: string };
-        };
-        expect(requestBody.think).toBe("high");
-        expect(requestBody.options?.think).toBeUndefined();
+    await expectSuccessfulOllamaRequest(
+      { baseUrl: "http://ollama-host:11434", model: { params: { thinking: "max" } } },
+      ({ body }) => {
+        expect(body.think).toBe("high");
+        expect(requireOptionalRecord(body.options)?.think).toBeUndefined();
       },
     );
   });
 
   it("uses the default loopback policy when baseUrl is empty", async () => {
-    await withMockNdjsonFetch(
-      [
-        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"ok"},"done":false}',
-        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":1,"eval_count":1}',
-      ],
-      async (fetchMock) => {
-        const stream = await createOllamaTestStream({ baseUrl: "" });
-
-        const events = await collectStreamEvents(stream);
-        expect(events.at(-1)?.type).toBe("done");
-
-        const request = getGuardedFetchCall(fetchMock);
-        expect(request.url).toBe("http://127.0.0.1:11434/api/chat");
-        const policy = requireRecord(request.policy, "ssrf policy");
-        expect(policy.hostnameAllowlist).toEqual(["127.0.0.1"]);
-        expect(policy.allowPrivateNetwork).toBe(true);
-      },
-    );
+    await expectSuccessfulOllamaRequest({ baseUrl: "" }, ({ request }) => {
+      expect(request.url).toBe("http://127.0.0.1:11434/api/chat");
+      const policy = requireRecord(request.policy, "ssrf policy");
+      expect(policy.hostnameAllowlist).toEqual(["127.0.0.1"]);
+      expect(policy.allowPrivateNetwork).toBe(true);
+    });
   });
 
   it("merges default headers and allows request headers to override them", async () => {
-    await withMockNdjsonFetch(
-      [
-        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"ok"},"done":false}',
-        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":1,"eval_count":1}',
-      ],
-      async (fetchMock) => {
-        const stream = await createOllamaTestStream({
-          baseUrl: "http://ollama-host:11434",
-          defaultHeaders: {
-            "X-OLLAMA-KEY": "provider-secret",
-            "X-Trace": "default",
-          },
-          options: {
-            headers: {
-              "X-Trace": "request",
-              "X-Request-Only": "1",
-            },
-          },
-        });
-
-        const events = await collectStreamEvents(stream);
-        expect(events.at(-1)?.type).toBe("done");
-
-        const requestInit = getGuardedFetchCall(fetchMock).init ?? {};
-        const headers = requireHeaders(requestInit.headers);
-        expect(headers["Content-Type"]).toBe("application/json");
-        expect(headers["X-OLLAMA-KEY"]).toBe("provider-secret");
-        expect(headers["X-Trace"]).toBe("request");
-        expect(headers["X-Request-Only"]).toBe("1");
+    await expectSuccessfulOllamaRequest(
+      {
+        baseUrl: "http://ollama-host:11434",
+        defaultHeaders: { "X-OLLAMA-KEY": "provider-secret", "X-Trace": "default" },
+        options: { headers: { "X-Trace": "request", "X-Request-Only": "1" } },
       },
+      ({ request }) =>
+        expect(requireHeaders(request.init?.headers)).toMatchObject({
+          "Content-Type": "application/json",
+          "X-OLLAMA-KEY": "provider-secret",
+          "X-Trace": "request",
+          "X-Request-Only": "1",
+        }),
     );
   });
 
   it("preserves an explicit Authorization header when apiKey is a local marker", async () => {
-    await withMockNdjsonFetch(
-      [
-        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"ok"},"done":false}',
-        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":1,"eval_count":1}',
-      ],
-      async (fetchMock) => {
-        const stream = await createOllamaTestStream({
-          baseUrl: "http://ollama-host:11434",
-          defaultHeaders: {
-            Authorization: "Bearer proxy-token",
-          },
-          options: {
-            apiKey: "ollama-local", // pragma: allowlist secret
-            headers: {
-              Authorization: "Bearer proxy-token",
-            },
-          },
-        });
-
-        await collectStreamEvents(stream);
-        const requestInit = getGuardedFetchCall(fetchMock).init ?? {};
-        expect(requireHeaders(requestInit.headers).Authorization).toBe("Bearer proxy-token");
+    await expectSuccessfulOllamaRequest(
+      {
+        baseUrl: "http://ollama-host:11434",
+        defaultHeaders: { Authorization: "Bearer proxy-token" },
+        options: {
+          apiKey: "ollama-local", // pragma: allowlist secret
+          headers: { Authorization: "Bearer proxy-token" },
+        },
       },
+      ({ request }) =>
+        expect(requireHeaders(request.init?.headers).Authorization).toBe("Bearer proxy-token"),
     );
   });
 
   it("allows a real apiKey to override an explicit Authorization header", async () => {
-    await withMockNdjsonFetch(
-      [
-        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"ok"},"done":false}',
-        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":1,"eval_count":1}',
-      ],
-      async (fetchMock) => {
-        const streamFn = createOllamaStreamFn("http://ollama-host:11434", {
-          Authorization: "Bearer proxy-token",
-        });
-        const stream = await Promise.resolve(
-          streamFn(
-            {
-              id: "qwen3:32b",
-              api: "ollama",
-              provider: "custom-ollama",
-              contextWindow: 131072,
-            } as never,
-            {
-              messages: [{ role: "user", content: "hello" }],
-            } as never,
-            {
-              apiKey: "real-token", // pragma: allowlist secret
-            } as never,
-          ),
-        );
-
-        await collectStreamEvents(stream);
-        const requestInit = getGuardedFetchCall(fetchMock).init ?? {};
-        expect(requireHeaders(requestInit.headers).Authorization).toBe("Bearer real-token");
+    await expectSuccessfulOllamaRequest(
+      {
+        baseUrl: "http://ollama-host:11434",
+        defaultHeaders: { Authorization: "Bearer proxy-token" },
+        options: { apiKey: "real-token" }, // pragma: allowlist secret
       },
+      ({ request }) =>
+        expect(requireHeaders(request.init?.headers).Authorization).toBe("Bearer real-token"),
     );
   });
 


### PR DESCRIPTION
## What Problem This Solves\n\nProvider regression tests repeated large request, stream, authentication, model-policy, and guardrail fixtures, making genuine Ollama, Google, and Amazon Bedrock compatibility guarantees harder to understand and slower to maintain.\n\n## Why This Change Was Made\n\nConsolidate repeated provider-local setup into small helpers and individually named case tables. Preserve every original case and assertion surface, with no changes to production code, provider or authentication contracts, dependencies, Vitest configuration, or coverage baselines.\n\n## User Impact\n\nNo runtime or user-visible behavior changes. Maintainers retain independently named failure and compatibility tests while removing a net 1,012 test lines.\n\n## Evidence\n\n- Pinned baseline: 16d2b7e46784c75eb5d57329269e9fd47222d2ef.\n- Exact same four provider test files: 362 passing tests before and after.\n- Production statements: 1933/6918 before and after.\n- Production branches: 1575/6042 before and after.\n- Production functions: 374/1283 before and after.\n- Production lines: 1916/6830 before and after.\n- Final remote focused coverage: 4 files passed, 362 tests passed.\n- Complete remote changed-code gate passed, including all repository guards, formatting, extension-test TypeScript, and changed-file lint (0 warnings, 0 errors); Testbox timing JSON confirmed exitCode 0.\n- Fresh independent autoreview: clean, no accepted or actionable findings.\n- AI-assisted refactor; all changes are restricted to existing provider test files.