### PR TITLE
refactor(gateway): consolidate chat send and abort regression tests

### DIFF
--- a/src/gateway/server-methods/chat.abort-persistence.test.ts
+++ b/src/gateway/server-methods/chat.abort-persistence.test.ts
@@ -493,16 +493,27 @@ describe("chat abort transcript persistence", () => {
     });
   });
 
-  it("plain stop aborts runs tracked under the canonical session key", async () => {
-    const { sessionId } = await createTranscriptFixture("openclaw-chat-stop-canonical-");
+  it.each([
+    [
+      "plain stop aborts runs tracked under the canonical session key",
+      "canonical",
+      "main",
+      "alias-main",
+    ],
+    [
+      "plain stop aborts raw-alias runs for the same backing session",
+      "raw-alias",
+      "alias-main",
+      "main",
+    ],
+  ])("%s", async (_name, caseId, activeSessionKey, requestedSessionKey) => {
+    const { sessionId } = await createTranscriptFixture(`openclaw-chat-stop-${caseId}-`);
     const respond = vi.fn();
-    const active = createActiveRun("main", { sessionId });
+    const runId = `run-stop-${caseId}`;
+    const active = createActiveRun(activeSessionKey, { sessionId });
     const context = createChatAbortContext({
-      chatAbortControllers: new Map([["run-stop-canonical", active]]),
-      removeChatRun: vi.fn().mockReturnValue({
-        sessionKey: "main",
-        clientRunId: "run-stop-canonical",
-      }),
+      chatAbortControllers: new Map([[runId, active]]),
+      removeChatRun: vi.fn().mockReturnValue({ sessionKey: activeSessionKey, clientRunId: runId }),
     });
 
     await expectDefined(
@@ -510,9 +521,9 @@ describe("chat abort transcript persistence", () => {
       'chatHandlers["chat.send"] test invariant',
     )({
       params: {
-        sessionKey: "alias-main",
+        sessionKey: requestedSessionKey,
         message: "stop",
-        idempotencyKey: "idem-stop-canonical",
+        idempotencyKey: `idem-stop-${caseId}`,
       },
       respond,
       context: context as never,
@@ -523,75 +534,40 @@ describe("chat abort transcript persistence", () => {
 
     const [ok, payload] = requireLastRespondCall(respond);
     expect(ok).toBe(true);
-    expectAbortPayload(payload, { runIds: ["run-stop-canonical"] });
+    expectAbortPayload(payload, { runIds: [runId] });
     expect(active.controller.signal.aborted).toBe(true);
-    expect(context.chatAbortControllers.has("run-stop-canonical")).toBe(false);
+    expect(context.chatAbortControllers.has(runId)).toBe(false);
   });
 
-  it("plain stop aborts raw-alias runs for the same backing session", async () => {
-    const { sessionId } = await createTranscriptFixture("openclaw-chat-stop-raw-alias-");
-    const respond = vi.fn();
-    const active = createActiveRun("alias-main", { sessionId });
-    const context = createChatAbortContext({
-      chatAbortControllers: new Map([["run-stop-raw-alias", active]]),
-      removeChatRun: vi.fn().mockReturnValue({
-        sessionKey: "alias-main",
-        clientRunId: "run-stop-raw-alias",
-      }),
-    });
-
-    await expectDefined(
-      chatHandlers["chat.send"],
-      'chatHandlers["chat.send"] test invariant',
-    )({
-      params: {
-        sessionKey: "main",
-        message: "stop",
-        idempotencyKey: "idem-stop-raw-alias",
-      },
-      respond,
-      context: context as never,
-      req: {} as never,
-      client: null,
-      isWebchatConnect: () => false,
-    });
-
-    const [ok, payload] = requireLastRespondCall(respond);
-    expect(ok).toBe(true);
-    expectAbortPayload(payload, { runIds: ["run-stop-raw-alias"] });
-    expect(active.controller.signal.aborted).toBe(true);
-    expect(context.chatAbortControllers.has("run-stop-raw-alias")).toBe(false);
-  });
-
-  it("scopes global stop commands to the selected agent", async () => {
-    const { sessionId } = await createTranscriptFixture("openclaw-chat-stop-global-agent-");
+  it.each([
+    ["scopes global stop commands to the selected agent", "work", "agent"],
+    ["scopes bare global stop commands to the default agent", "main", "default"],
+  ])("%s", async (_name, selectedAgentId, fixtureId) => {
+    const { sessionId } = await createTranscriptFixture(`openclaw-chat-stop-global-${fixtureId}-`);
     sessionEntryState.canonicalKey = "global";
-    sessionEntryState.cfg = {
-      agents: {
-        list: [{ id: "main", default: true }, { id: "work" }],
-      },
-    };
+    sessionEntryState.cfg = { agents: { list: [{ id: "main", default: true }, { id: "work" }] } };
     const respond = vi.fn();
     const mainActive = createActiveRun("global", {
-      sessionId: "sess-main-global",
+      sessionId: selectedAgentId === "main" ? sessionId : "sess-main-global",
       agentId: "main",
     });
     const workActive = createActiveRun("global", {
-      sessionId,
+      sessionId: selectedAgentId === "work" ? sessionId : "sess-work-global",
       agentId: "work",
     });
+    const runId = `run-${selectedAgentId}-global`;
     const context = createChatAbortContext({
       chatAbortControllers: new Map([
         ["run-main-global", mainActive],
         ["run-work-global", workActive],
       ]),
       chatRunState: createAbortTestRunState([
-        ["run-work-global", { buffer: "partial work response" }],
+        [runId, { buffer: `partial ${selectedAgentId} response` }],
       ]),
       removeChatRun: vi.fn().mockReturnValue({
         sessionKey: "global",
-        agentId: "work",
-        clientRunId: "run-work-global",
+        agentId: selectedAgentId,
+        clientRunId: runId,
       }),
     });
 
@@ -601,9 +577,9 @@ describe("chat abort transcript persistence", () => {
     )({
       params: {
         sessionKey: "global",
-        agentId: "work",
+        ...(selectedAgentId === "work" ? { agentId: selectedAgentId } : {}),
         message: "stop",
-        idempotencyKey: "idem-stop-work-global",
+        idempotencyKey: `idem-stop-${selectedAgentId === "work" ? "work" : "default"}-global`,
       },
       respond,
       context: context as never,
@@ -614,71 +590,27 @@ describe("chat abort transcript persistence", () => {
 
     const [ok, payload] = requireLastRespondCall(respond);
     expect(ok).toBe(true);
-    expectAbortPayload(payload, { runIds: ["run-work-global"] });
-    expect(mainActive.controller.signal.aborted).toBe(false);
-    expect(workActive.controller.signal.aborted).toBe(true);
-    expect(sessionEntryState.loadCalls).toContainEqual({
-      sessionKey: "global",
-      opts: { agentId: "work" },
-    });
+    expectAbortPayload(payload, { runIds: [runId] });
+    expect(mainActive.controller.signal.aborted).toBe(selectedAgentId === "main");
+    expect(workActive.controller.signal.aborted).toBe(selectedAgentId === "work");
+    if (selectedAgentId === "work") {
+      expect(sessionEntryState.loadCalls).toContainEqual({
+        sessionKey: "global",
+        opts: { agentId: "work" },
+      });
+    }
   });
 
-  it("scopes bare global stop commands to the default agent", async () => {
-    const { sessionId } = await createTranscriptFixture("openclaw-chat-stop-global-default-");
-    sessionEntryState.canonicalKey = "global";
-    sessionEntryState.cfg = {
-      agents: {
-        list: [{ id: "main", default: true }, { id: "work" }],
-      },
-    };
-    const respond = vi.fn();
-    const mainActive = createActiveRun("global", {
-      sessionId,
-      agentId: "main",
-    });
-    const workActive = createActiveRun("global", {
-      sessionId: "sess-work-global",
-      agentId: "work",
-    });
-    const context = createChatAbortContext({
-      chatAbortControllers: new Map([
-        ["run-main-global", mainActive],
-        ["run-work-global", workActive],
-      ]),
-      chatRunState: createAbortTestRunState([
-        ["run-main-global", { buffer: "partial main response" }],
-      ]),
-      removeChatRun: vi.fn().mockReturnValue({
-        sessionKey: "global",
-        agentId: "main",
-        clientRunId: "run-main-global",
-      }),
-    });
-
-    await expectDefined(
-      chatHandlers["chat.send"],
-      'chatHandlers["chat.send"] test invariant',
-    )({
-      params: {
-        sessionKey: "global",
-        message: "stop",
-        idempotencyKey: "idem-stop-default-global",
-      },
-      respond,
-      context: context as never,
-      req: {} as never,
-      client: null,
-      isWebchatConnect: () => false,
-    });
-
-    const [ok, payload] = requireLastRespondCall(respond);
-    expect(ok).toBe(true);
-    expectAbortPayload(payload, { runIds: ["run-main-global"] });
-    expect(mainActive.controller.signal.aborted).toBe(true);
-    expect(workActive.controller.signal.aborted).toBe(false);
-  });
-
-  it("scopes global chat.abort requests to the selected agent", async () => {
+  it.each([
+    ["scopes global chat.abort requests to the selected agent", "global", "work", false],
+    ["scopes bare global chat.abort requests to the default agent", "global", undefined, true],
+    [
+      "infers selected global chat.abort scope from agent-prefixed aliases",
+      "agent:work:main",
+      undefined,
+      true,
+    ],
+  ])("%s", async (_name, sessionKey, agentId, needsGlobalConfig) => {
     const respond = vi.fn();
     const mainActive = createActiveRun("global", {
       sessionId: "sess-main-global",
@@ -693,6 +625,14 @@ describe("chat abort transcript persistence", () => {
         ["run-main-global", mainActive],
         ["run-work-global", workActive],
       ]),
+      ...(needsGlobalConfig
+        ? {
+            getRuntimeConfig: () => ({
+              agents: { list: [{ id: "main", default: true }, { id: "work" }] },
+              session: { scope: "global" },
+            }),
+          }
+        : {}),
     });
     const agentEvents: Array<{ runId: string; sessionKey?: string; agentId?: string }> = [];
     const unsubscribe = onAgentEvent((event) => {
@@ -708,10 +648,7 @@ describe("chat abort transcript persistence", () => {
         chatHandlers["chat.abort"],
         'chatHandlers["chat.abort"] test invariant',
       )({
-        params: {
-          sessionKey: "global",
-          agentId: "work",
-        },
+        params: { sessionKey, ...(agentId ? { agentId } : {}) },
         respond,
         context: context as never,
         req: {} as never,
@@ -722,100 +659,19 @@ describe("chat abort transcript persistence", () => {
       unsubscribe();
     }
 
+    const expectedAgentId = agentId ?? (sessionKey.startsWith("agent:work:") ? "work" : "main");
     const [ok, payload] = requireLastRespondCall(respond);
     expect(ok).toBe(true);
-    expectAbortPayload(payload, { runIds: ["run-work-global"] });
-    expect(mainActive.controller.signal.aborted).toBe(false);
-    expect(workActive.controller.signal.aborted).toBe(true);
-    expect(agentEvents).toContainEqual({
-      runId: "run-work-global",
-      sessionKey: "global",
-      agentId: "work",
-    });
-  });
-
-  it("scopes bare global chat.abort requests to the default agent", async () => {
-    const respond = vi.fn();
-    const mainActive = createActiveRun("global", {
-      sessionId: "sess-main-global",
-      agentId: "main",
-    });
-    const workActive = createActiveRun("global", {
-      sessionId: "sess-work-global",
-      agentId: "work",
-    });
-    const context = createChatAbortContext({
-      chatAbortControllers: new Map([
-        ["run-main-global", mainActive],
-        ["run-work-global", workActive],
-      ]),
-      getRuntimeConfig: () => ({
-        agents: { list: [{ id: "main", default: true }, { id: "work" }] },
-        session: { scope: "global" },
-      }),
-    });
-
-    await expectDefined(
-      chatHandlers["chat.abort"],
-      'chatHandlers["chat.abort"] test invariant',
-    )({
-      params: {
+    expectAbortPayload(payload, { runIds: [`run-${expectedAgentId}-global`] });
+    expect(mainActive.controller.signal.aborted).toBe(expectedAgentId === "main");
+    expect(workActive.controller.signal.aborted).toBe(expectedAgentId === "work");
+    if (!needsGlobalConfig) {
+      expect(agentEvents).toContainEqual({
+        runId: "run-work-global",
         sessionKey: "global",
-      },
-      respond,
-      context: context as never,
-      req: {} as never,
-      client: null,
-      isWebchatConnect: () => false,
-    });
-
-    const [ok, payload] = requireLastRespondCall(respond);
-    expect(ok).toBe(true);
-    expectAbortPayload(payload, { runIds: ["run-main-global"] });
-    expect(mainActive.controller.signal.aborted).toBe(true);
-    expect(workActive.controller.signal.aborted).toBe(false);
-  });
-
-  it("infers selected global chat.abort scope from agent-prefixed aliases", async () => {
-    const respond = vi.fn();
-    const mainActive = createActiveRun("global", {
-      sessionId: "sess-main-global",
-      agentId: "main",
-    });
-    const workActive = createActiveRun("global", {
-      sessionId: "sess-work-global",
-      agentId: "work",
-    });
-    const context = createChatAbortContext({
-      chatAbortControllers: new Map([
-        ["run-main-global", mainActive],
-        ["run-work-global", workActive],
-      ]),
-      getRuntimeConfig: () => ({
-        agents: { list: [{ id: "main", default: true }, { id: "work" }] },
-        session: { scope: "global" },
-      }),
-    });
-
-    await expectDefined(
-      chatHandlers["chat.abort"],
-      'chatHandlers["chat.abort"] test invariant',
-    )({
-      params: {
-        sessionKey: "agent:work:main",
-      },
-      respond,
-      context: context as never,
-      req: {} as never,
-      client: null,
-      isWebchatConnect: () => false,
-    });
-
-    const [ok, payload] = requireLastRespondCall(respond);
-    expect(ok).toBe(true);
-    expectAbortPayload(payload, { runIds: ["run-work-global"] });
-    expect(mainActive.controller.signal.aborted).toBe(false);
-    expect(workActive.controller.signal.aborted).toBe(true);
+        agentId: "work",
+      });
+    }
   });
 
   it("rejects selected global chat.abort when agentId conflicts with the key agent", async () => {
@@ -934,7 +790,10 @@ describe("chat abort transcript persistence", () => {
     );
   });
 
-  it("does not abort hidden pending internal agent runs by visible session key", async () => {
+  it.each([
+    ["does not abort hidden pending internal agent runs by visible session key", false],
+    ["aborts hidden pending internal agent runs by explicit owner run id", true],
+  ])("%s", async (_name, explicitRunId) => {
     const respond = vi.fn();
     const context = createChatAbortContext();
     context.dedupe.set("agent:run-hidden", {
@@ -955,9 +814,7 @@ describe("chat abort transcript persistence", () => {
         'chatHandlers["chat.abort"] test invariant',
       ),
       context,
-      request: {
-        sessionKey: "main",
-      },
+      request: { sessionKey: "main", ...(explicitRunId ? { runId: "run-hidden" } : {}) },
       client: { connId: "conn-hidden" },
       respond,
     });
@@ -965,56 +822,14 @@ describe("chat abort transcript persistence", () => {
     const [ok, payload] = requireLastRespondCall(respond);
     expect(ok).toBe(true);
     const actual = expectRecord(payload, "abort payload");
-    expect(actual.aborted).toBe(false);
-    expect(actual.runIds).toEqual([]);
+    expect(actual.aborted).toBe(explicitRunId);
+    expect(actual.runIds).toEqual(explicitRunId ? ["run-hidden"] : []);
     expect(context.dedupe.get("agent:run-hidden")).toEqual(
       expect.objectContaining({
         payload: expect.objectContaining({
-          status: "accepted",
+          status: explicitRunId ? "timeout" : "accepted",
           controlUiVisible: false,
-        }),
-      }),
-    );
-  });
-
-  it("aborts hidden pending internal agent runs by explicit owner run id", async () => {
-    const respond = vi.fn();
-    const context = createChatAbortContext();
-    context.dedupe.set("agent:run-hidden", {
-      ts: Date.now(),
-      ok: true,
-      payload: {
-        runId: "run-hidden",
-        sessionKey: "main",
-        status: "accepted",
-        controlUiVisible: false,
-        ownerConnId: "conn-hidden",
-      },
-    });
-
-    await invokeChatAbortHandler({
-      handler: expectDefined(
-        chatHandlers["chat.abort"],
-        'chatHandlers["chat.abort"] test invariant',
-      ),
-      context,
-      request: {
-        sessionKey: "main",
-        runId: "run-hidden",
-      },
-      client: { connId: "conn-hidden" },
-      respond,
-    });
-
-    const [ok, payload] = requireLastRespondCall(respond);
-    expect(ok).toBe(true);
-    expectAbortPayload(payload, { runIds: ["run-hidden"] });
-    expect(context.dedupe.get("agent:run-hidden")).toEqual(
-      expect.objectContaining({
-        payload: expect.objectContaining({
-          status: "timeout",
-          controlUiVisible: false,
-          stopReason: "rpc",
+          ...(explicitRunId ? { stopReason: "rpc" } : {}),
         }),
       }),
     );
@@ -1163,7 +978,10 @@ describe("chat abort transcript persistence", () => {
     expect(active.controller.signal.aborted).toBe(true);
   });
 
-  it("does not abort pending default global agent runs for another selected agent", async () => {
+  it.each([
+    ["does not abort pending default global agent runs for another selected agent", "work", false],
+    ["aborts pending default global agent runs for the default selected agent", "main", true],
+  ])("%s", async (_name, agentId, shouldAbort) => {
     const respond = vi.fn();
     const context = createChatAbortContext();
     context.dedupe.set("agent:run-main-global", {
@@ -1183,11 +1001,7 @@ describe("chat abort transcript persistence", () => {
         'chatHandlers["chat.abort"] test invariant',
       ),
       context,
-      request: {
-        sessionKey: "global",
-        agentId: "work",
-        runId: "run-main-global",
-      },
+      request: { sessionKey: "global", agentId, runId: "run-main-global" },
       client: { connId: "conn-main" },
       respond,
     });
@@ -1195,50 +1009,14 @@ describe("chat abort transcript persistence", () => {
     const [ok, payload] = requireLastRespondCall(respond);
     expect(ok).toBe(true);
     const actual = expectRecord(payload, "abort payload");
-    expect(actual.aborted).toBe(false);
-    expect(actual.runIds).toEqual([]);
+    expect(actual.aborted).toBe(shouldAbort);
+    expect(actual.runIds).toEqual(shouldAbort ? ["run-main-global"] : []);
     expect(context.dedupe.get("agent:run-main-global")).toEqual(
       expect.objectContaining({
-        payload: expect.objectContaining({ status: "accepted" }),
-      }),
-    );
-  });
-
-  it("aborts pending default global agent runs for the default selected agent", async () => {
-    const respond = vi.fn();
-    const context = createChatAbortContext();
-    context.dedupe.set("agent:run-main-global", {
-      ts: Date.now(),
-      ok: true,
-      payload: {
-        runId: "run-main-global",
-        sessionKey: "global",
-        status: "accepted",
-        ownerConnId: "conn-main",
-      },
-    });
-
-    await invokeChatAbortHandler({
-      handler: expectDefined(
-        chatHandlers["chat.abort"],
-        'chatHandlers["chat.abort"] test invariant',
-      ),
-      context,
-      request: {
-        sessionKey: "global",
-        agentId: "main",
-        runId: "run-main-global",
-      },
-      client: { connId: "conn-main" },
-      respond,
-    });
-
-    const [ok, payload] = requireLastRespondCall(respond);
-    expect(ok).toBe(true);
-    expectAbortPayload(payload, { runIds: ["run-main-global"] });
-    expect(context.dedupe.get("agent:run-main-global")).toEqual(
-      expect.objectContaining({
-        payload: expect.objectContaining({ status: "timeout", stopReason: "rpc" }),
+        payload: expect.objectContaining({
+          status: shouldAbort ? "timeout" : "accepted",
+          ...(shouldAbort ? { stopReason: "rpc" } : {}),
+        }),
       }),
     );
   });

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -843,7 +843,41 @@ function createChatContext(): Pick<
 }
 
 type ChatContext = ReturnType<typeof createChatContext>;
+
+function createChatRequestFixture() {
+  return { context: createChatContext(), respond: vi.fn() };
+}
+
 type NonStreamingChatSendWaitFor = "broadcast" | "dedupe" | "none";
+type ChatDeliveryRoutingCase = readonly [
+  name: string,
+  id: string,
+  delivery: { channel: string; to: string; accountId: string; threadId?: string | number },
+  sessionKey: string,
+  options?: {
+    deliver?: boolean;
+    clientMode?: string;
+    mainSessionKey?: string;
+    origin?: { provider: string; accountId: string; threadId?: string };
+    omitClientDetails?: boolean;
+    external?: boolean;
+  },
+];
+type SlashCommandMediaCase = {
+  name: string;
+  id: string;
+  files: string[];
+  replies: (paths: [string, string]) => typeof mockState.dispatchedReplies;
+  verify: (content: Array<Record<string, any>>, paths: [string, string]) => void;
+};
+
+function createSlashCommandMediaReply(
+  kind: "block" | "final",
+  mediaUrls: string[],
+  payload: (typeof mockState.dispatchedReplies)[number]["payload"] = {},
+): (typeof mockState.dispatchedReplies)[number] {
+  return { kind, payload: { mediaUrls, trustedLocalMedia: true, ...payload } };
+}
 
 async function runNonStreamingChatSend(params: {
   context: ChatContext;
@@ -977,8 +1011,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       parentId: null,
     });
     const before = loadTranscriptEventsSync(transcriptScope());
-    const context = createChatContext();
-    const respond = vi.fn();
+    const { context, respond } = createChatRequestFixture();
 
     await runNonStreamingChatSend({
       context,
@@ -1000,8 +1033,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
 
   it("allows an expected empty leaf when the transcript is still empty", async () => {
     await createGatewayUserTurnSqliteFixture("openclaw-chat-send-matching-empty-leaf-");
-    const context = createChatContext();
-    const respond = vi.fn();
+    const { context, respond } = createChatRequestFixture();
 
     await runNonStreamingChatSend({
       context,
@@ -1030,8 +1062,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       now: 1,
       parentId: null,
     });
-    const context = createChatContext();
-    const respond = vi.fn();
+    const { context, respond } = createChatRequestFixture();
 
     await runNonStreamingChatSend({
       context,
@@ -1063,8 +1094,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         reason: "command-metadata",
       },
     ];
-    const context = createChatContext();
-    const respond = vi.fn();
+    const { context, respond } = createChatRequestFixture();
 
     await runNonStreamingChatSend({
       context,
@@ -1103,8 +1133,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       },
     ];
     mockState.dispatchErrorAfterDelivery = new Error("delivery failed after metadata");
-    const context = createChatContext();
-    const respond = vi.fn();
+    const { context, respond } = createChatRequestFixture();
 
     await runNonStreamingChatSend({
       context,
@@ -1128,8 +1157,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   it("persists non-agent delivery mirrors with the chat send idempotency key", async () => {
     await createTranscriptFixture("openclaw-chat-send-final-idem-");
     mockState.finalText = "mirror text";
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     await runNonStreamingChatSend({
       context,
@@ -1152,8 +1180,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   it("persists non-agent delivery mirrors to SQLite without creating active JSONL", async () => {
     await withSqliteTranscriptFixtureState("openclaw-chat-send-final-sqlite-", async () => {
       mockState.finalText = "sqlite mirror text";
-      const respond = vi.fn();
-      const context = createChatContext();
+      const { context, respond } = createChatRequestFixture();
 
       await runNonStreamingChatSend({
         context,
@@ -1183,8 +1210,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         },
       },
     );
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     await runNonStreamingChatSend({
       context,
@@ -1219,8 +1245,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         },
       },
     );
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     await runNonStreamingChatSend({
       context,
@@ -1251,8 +1276,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         },
       },
     );
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     await runNonStreamingChatSend({
       context,
@@ -1286,8 +1310,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       },
       { kind: "final", payload: { text: "derived reply without owner" } },
     ];
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     await runNonStreamingChatSend({
       context,
@@ -1318,8 +1341,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         },
       },
     );
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     await runNonStreamingChatSend({
       context,
@@ -1345,8 +1367,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     mockState.finalText = "ok";
     mockState.triggerAgentRunStart = true;
     mockState.agentRunId = "run-current";
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
     context.chatAbortControllers.set("run-same-session", {
       controller: new AbortController(),
       sessionId: "sess-prev",
@@ -1388,8 +1409,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     mockState.finalText = "ok";
     mockState.triggerAgentRunStart = true;
     mockState.agentRunId = "run-current-global";
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
     context.chatAbortControllers.set("run-default-global", {
       controller: new AbortController(),
       sessionId: "sess-default-global",
@@ -1434,8 +1454,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     mockState.finalText = "ok";
     mockState.triggerAgentRunStart = true;
     mockState.agentRunId = "run-current-work-global";
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
     context.chatAbortControllers.set("run-default-global", {
       controller: new AbortController(),
       sessionId: "sess-default-global",
@@ -1477,8 +1496,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       session: { scope: "global" },
     };
     mockState.sessionEntry = { canonicalKey: "global" };
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     await runNonStreamingChatSend({
       context,
@@ -1501,8 +1519,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       session: { scope: "global" },
     };
     mockState.sessionEntry = { canonicalKey: "global" };
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     await runNonStreamingChatSend({
       context,
@@ -1531,8 +1548,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       agents: { list: [{ id: "main", default: true }] },
       session: { scope: "per-sender" },
     };
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     await runNonStreamingChatSend({
       context,
@@ -1579,8 +1595,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     mockState.dispatchWait = new Promise((resolve) => {
       releaseDispatch = resolve;
     });
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     const pending = runNonStreamingChatSend({
       context,
@@ -1607,8 +1622,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       session: { scope: "global" },
     };
     mockState.sessionEntry = { canonicalKey: "global" };
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
     mockState.loadSessionEntryCalls = [];
 
     await expectDefined(
@@ -1661,8 +1675,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     mockState.finalText = "ok";
     mockState.triggerAgentRunStart = true;
     mockState.agentRunId = "run-no-cap";
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     await runNonStreamingChatSend({
       context,
@@ -1702,8 +1715,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         },
       },
     ];
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     await runNonStreamingChatSend({
       context,
@@ -1769,8 +1781,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
           ),
         },
       ];
-      const respond = vi.fn();
-      const context = createChatContext();
+      const { context, respond } = createChatRequestFixture();
 
       await runNonStreamingChatSend({
         context,
@@ -1822,8 +1833,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         },
       },
     ];
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     await runNonStreamingChatSend({
       context,
@@ -1884,8 +1894,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         },
       },
     ];
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     await runNonStreamingChatSend({
       context,
@@ -1931,8 +1940,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         },
       },
     ];
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     await runNonStreamingChatSend({
       context,
@@ -1986,8 +1994,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         payload: sourceReply,
       },
     ];
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     const broadcast = await runNonStreamingChatSend({
       context,
@@ -2031,8 +2038,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         },
       },
     ];
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     const broadcast = await runNonStreamingChatSend({
       context,
@@ -2092,8 +2098,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
             payload: sourceReply,
           },
         ];
-        const respond = vi.fn();
-        const context = createChatContext();
+        const { context, respond } = createChatRequestFixture();
 
         vi.useFakeTimers({ toFake: ["Date"] });
         vi.setSystemTime(rewrittenAt);
@@ -2170,8 +2175,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
             ),
           },
         ];
-        const respond = vi.fn();
-        const context = createChatContext();
+        const { context, respond } = createChatRequestFixture();
 
         await runNonStreamingChatSend({
           context,
@@ -2220,8 +2224,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
             ),
           },
         ];
-        const respond = vi.fn();
-        const context = createChatContext();
+        const { context, respond } = createChatRequestFixture();
 
         const broadcast = await runNonStreamingChatSend({
           context,
@@ -2303,8 +2306,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
             ),
           },
         ];
-        const respond = vi.fn();
-        const context = createChatContext();
+        const { context, respond } = createChatRequestFixture();
 
         const broadcast = await runNonStreamingChatSend({
           context,
@@ -2386,8 +2388,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
             ),
           },
         ];
-        const respond = vi.fn();
-        const context = createChatContext();
+        const { context, respond } = createChatRequestFixture();
 
         const broadcast = await runNonStreamingChatSend({
           context,
@@ -2463,8 +2464,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
             ),
           },
         ];
-        const respond = vi.fn();
-        const context = createChatContext();
+        const { context, respond } = createChatRequestFixture();
 
         const broadcast = await runNonStreamingChatSend({
           context,
@@ -2521,8 +2521,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
             ),
           },
         ];
-        const respond = vi.fn();
-        const context = createChatContext();
+        const { context, respond } = createChatRequestFixture();
 
         const broadcast = await runNonStreamingChatSend({
           context,
@@ -2571,8 +2570,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
             ),
           },
         ];
-        const respond = vi.fn();
-        const context = createChatContext();
+        const { context, respond } = createChatRequestFixture();
 
         const broadcast = await runNonStreamingChatSend({
           context,
@@ -2639,8 +2637,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
             ),
           },
         ];
-        const respond = vi.fn();
-        const context = createChatContext();
+        const { context, respond } = createChatRequestFixture();
 
         const broadcast = await runNonStreamingChatSend({
           context,
@@ -2701,8 +2698,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
             ),
           },
         ];
-        const respond = vi.fn();
-        const context = createChatContext();
+        const { context, respond } = createChatRequestFixture();
 
         const broadcast = await runNonStreamingChatSend({
           context,
@@ -2757,8 +2753,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         },
       },
     ];
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     const broadcast = await runNonStreamingChatSend({
       context,
@@ -2856,8 +2851,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         },
       },
     ];
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     const broadcast = await runNonStreamingChatSend({
       context,
@@ -2892,8 +2886,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         },
       },
     ];
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     const broadcast = await runNonStreamingChatSend({
       context,
@@ -2946,8 +2939,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       trustedLocalMedia: true,
       audioAsVoice: true,
     };
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     const payload = await runNonStreamingChatSend({
       context,
@@ -2991,8 +2983,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         },
       },
     ];
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     const payload = await runNonStreamingChatSend({
       context,
@@ -3049,8 +3040,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         },
       },
     ];
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     const payload = await runNonStreamingChatSend({
       context,
@@ -3096,8 +3086,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         },
       },
     ];
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     const payload = await runNonStreamingChatSend({
       context,
@@ -3140,8 +3129,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         payload: { text: "Approve once to create the bundle." },
       },
     ];
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     const payload = await runNonStreamingChatSend({
       context,
@@ -3172,8 +3160,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         },
       },
     ];
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     const payload = await runNonStreamingChatSend({
       context,
@@ -3208,8 +3195,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         payload: { text: "[[reply_to_current]]" },
       },
     ];
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     const payload = await runNonStreamingChatSend({
       context,
@@ -3231,605 +3217,275 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     );
   });
 
-  it("keeps media from duplicate slash-command finals without duplicating block text", async () => {
-    const transcriptDir = await createTranscriptFixture(
-      "openclaw-chat-send-command-block-media-dupe-",
-    );
-    const audioPath = path.join(transcriptDir, "tts.mp3");
-    fs.writeFileSync(audioPath, Buffer.from([0xff, 0xfb, 0x90, 0x00]));
-    mockState.config = {
-      agents: {
-        defaults: {
-          workspace: transcriptDir,
-        },
-      },
-    };
-    mockState.dispatchedReplies = [
-      {
-        kind: "block",
-        payload: {
+  it.each([
+    {
+      name: "keeps media from duplicate slash-command finals without duplicating block text",
+      id: "media-dupe",
+      files: ["tts.mp3"],
+      replies: ([audio]) => [
+        createSlashCommandMediaReply("block", [audio], {
           text: "Trajectory exports can include prompts.",
-          mediaUrl: audioPath,
-          mediaUrls: [audioPath],
-          trustedLocalMedia: true,
-        },
-      },
-      {
-        kind: "final",
-        payload: {
+          mediaUrl: audio,
+        }),
+        createSlashCommandMediaReply("final", [audio], {
           text: "[[audio_as_voice]]",
-          mediaUrl: audioPath,
-          mediaUrls: [audioPath],
-          trustedLocalMedia: true,
-        },
+          mediaUrl: audio,
+        }),
+      ],
+      verify: (content) => {
+        const text = content
+          .map((block) => (typeof block.text === "string" ? block.text : ""))
+          .filter(Boolean)
+          .join("\n");
+        expect(text.match(/Trajectory exports/gu)).toHaveLength(1);
+        expect(content[1]).toEqual({
+          type: "attachment",
+          attachment: expect.objectContaining({
+            isVoiceNote: true,
+            kind: "audio",
+            label: "tts.mp3",
+          }),
+        });
       },
-    ];
-    const respond = vi.fn();
-    const context = createChatContext();
-
-    const payload = await runNonStreamingChatSend({
-      context,
-      respond,
-      idempotencyKey: "idem-command-block-media-dupe",
-      message: "/export-trajectory bundle",
-    });
-
-    const text = getMessageContent(payload)
-      .map((block) => (typeof block.text === "string" ? block.text : ""))
-      .filter(Boolean)
-      .join("\n");
-    expect(text.match(/Trajectory exports/gu)).toHaveLength(1);
-    expect(getMessageContent(payload)[1]).toEqual({
-      type: "attachment",
-      attachment: expect.objectContaining({
-        isVoiceNote: true,
-        kind: "audio",
-        label: "tts.mp3",
-      }),
-    });
-  });
-
-  it("deduplicates slash-command media when file URLs and paths reference the same attachment", async () => {
-    const transcriptDir = await createTranscriptFixture(
-      "openclaw-chat-send-command-block-media-file-url-",
-    );
-    const audioPath = path.join(transcriptDir, "voice.mp3");
-    fs.writeFileSync(audioPath, Buffer.from([0xff, 0xfb, 0x90, 0x00]));
-    mockState.config = {
-      agents: {
-        defaults: {
-          workspace: transcriptDir,
-        },
-      },
-    };
-    mockState.dispatchedReplies = [
-      {
-        kind: "block",
-        payload: {
+    },
+    {
+      name: "deduplicates slash-command media when file URLs and paths reference the same attachment",
+      id: "media-file-url",
+      files: ["voice.mp3"],
+      replies: ([audio]) => [
+        createSlashCommandMediaReply("block", [audio], {
           text: "Trajectory exports can include prompts.",
-          mediaUrls: [audioPath],
-          trustedLocalMedia: true,
-        },
-      },
-      {
-        kind: "final",
-        payload: {
-          mediaUrls: [pathToFileURL(audioPath).href],
-          trustedLocalMedia: true,
+        }),
+        createSlashCommandMediaReply("final", [pathToFileURL(audio).href], {
           audioAsVoice: true,
-        },
+        }),
+      ],
+      verify: (content) => {
+        expect(content).toHaveLength(2);
+        expect(content[1]).toEqual({
+          type: "attachment",
+          attachment: expect.objectContaining({
+            isVoiceNote: true,
+            kind: "audio",
+            label: "voice.mp3",
+          }),
+        });
       },
-    ];
-    const respond = vi.fn();
-    const context = createChatContext();
-
-    const payload = await runNonStreamingChatSend({
-      context,
-      respond,
-      idempotencyKey: "idem-command-block-media-file-url",
-      message: "/export-trajectory bundle",
-    });
-
-    const content = getMessageContent(payload);
-    expect(content).toHaveLength(2);
-    expect(content[1]).toEqual({
-      type: "attachment",
-      attachment: expect.objectContaining({
-        isVoiceNote: true,
-        kind: "audio",
-        label: "voice.mp3",
-      }),
-    });
-  });
-
-  it("does not downgrade a voice-note block when a duplicate final has normalized false flags", async () => {
-    const transcriptDir = await createTranscriptFixture(
-      "openclaw-chat-send-command-block-voice-sticky-",
-    );
-    const audioPath = path.join(transcriptDir, "voice.mp3");
-    fs.writeFileSync(audioPath, Buffer.from([0xff, 0xfb, 0x90, 0x00]));
-    mockState.config = {
-      agents: {
-        defaults: {
-          workspace: transcriptDir,
-        },
-      },
-    };
-    mockState.dispatchedReplies = [
-      {
-        kind: "block",
-        payload: {
+    },
+    {
+      name: "does not downgrade a voice-note block when a duplicate final has normalized false flags",
+      id: "voice-sticky",
+      files: ["voice.mp3"],
+      replies: ([audio]) => [
+        createSlashCommandMediaReply("block", [audio], {
           text: "Trajectory exports can include prompts.",
-          mediaUrls: [audioPath],
-          trustedLocalMedia: true,
           audioAsVoice: true,
-        },
+        }),
+        createSlashCommandMediaReply("final", [audio], { audioAsVoice: false }),
+      ],
+      verify: (content) => {
+        const attachments = content.filter((block) => block.type === "attachment");
+        expect(attachments).toHaveLength(1);
+        expect(attachments[0]?.attachment).toEqual(
+          expect.objectContaining({ isVoiceNote: true, label: "voice.mp3" }),
+        );
       },
-      {
-        kind: "final",
-        payload: {
-          mediaUrls: [audioPath],
-          trustedLocalMedia: true,
-          audioAsVoice: false,
-        },
-      },
-    ];
-    const respond = vi.fn();
-    const context = createChatContext();
-
-    const payload = await runNonStreamingChatSend({
-      context,
-      respond,
-      idempotencyKey: "idem-command-block-voice-sticky",
-      message: "/export-trajectory bundle",
-    });
-
-    const attachments = getMessageContent(payload).filter((block) => block.type === "attachment");
-    expect(attachments).toHaveLength(1);
-    expect(attachments[0]?.attachment).toEqual(
-      expect.objectContaining({
-        isVoiceNote: true,
-        label: "voice.mp3",
-      }),
-    );
-  });
-
-  it("keeps final text when only the slash-command media is duplicated", async () => {
-    const transcriptDir = await createTranscriptFixture(
-      "openclaw-chat-send-command-block-media-different-final-text-",
-    );
-    const audioPath = path.join(transcriptDir, "voice.mp3");
-    fs.writeFileSync(audioPath, Buffer.from([0xff, 0xfb, 0x90, 0x00]));
-    mockState.config = {
-      agents: {
-        defaults: {
-          workspace: transcriptDir,
-        },
-      },
-    };
-    mockState.dispatchedReplies = [
-      {
-        kind: "block",
-        payload: {
-          text: "preview",
-          mediaUrls: [audioPath],
-          trustedLocalMedia: true,
-        },
-      },
-      {
-        kind: "final",
-        payload: {
+    },
+    {
+      name: "keeps final text when only the slash-command media is duplicated",
+      id: "media-different-final-text",
+      files: ["voice.mp3"],
+      replies: ([audio]) => [
+        createSlashCommandMediaReply("block", [audio], { text: "preview" }),
+        createSlashCommandMediaReply("final", [audio], {
           text: "done",
-          mediaUrls: [audioPath],
-          trustedLocalMedia: true,
           replyToCurrent: true,
-        },
-      },
-    ];
-    const respond = vi.fn();
-    const context = createChatContext();
-
-    const payload = await runNonStreamingChatSend({
-      context,
-      respond,
-      idempotencyKey: "idem-command-block-media-different-final-text",
-      message: "/export-trajectory bundle",
-    });
-
-    const content = getMessageContent(payload);
-    const text = content
-      .map((block) => (typeof block.text === "string" ? block.text : ""))
-      .filter(Boolean)
-      .join("\n");
-    expect(text).toContain("preview");
-    expect(text).toContain("done");
-    expect(content.filter((block) => block.type === "attachment")).toHaveLength(1);
-    const transcriptUpdate = mockState.emittedTranscriptUpdates.find(
-      (update) =>
-        typeof update.message === "object" &&
-        update.message !== null &&
-        (update.message as { role?: unknown }).role === "assistant",
-    );
-    expect(JSON.stringify(transcriptUpdate?.message)).toContain("[[reply_to_current]]");
-    expect(JSON.stringify(transcriptUpdate?.message)).toContain("done");
-  });
-
-  it("keeps same-caption slash-command finals when media differs", async () => {
-    const transcriptDir = await createTranscriptFixture(
-      "openclaw-chat-send-command-block-same-caption-different-media-",
-    );
-    const blockAudioPath = path.join(transcriptDir, "block.mp3");
-    const finalAudioPath = path.join(transcriptDir, "final.mp3");
-    fs.writeFileSync(blockAudioPath, Buffer.from([0xff, 0xfb, 0x90, 0x00]));
-    fs.writeFileSync(finalAudioPath, Buffer.from([0xff, 0xfb, 0x90, 0x01]));
-    mockState.config = {
-      agents: {
-        defaults: {
-          workspace: transcriptDir,
-        },
-      },
-    };
-    mockState.dispatchedReplies = [
-      {
-        kind: "block",
-        payload: {
-          text: "shared caption",
-          mediaUrls: [blockAudioPath],
-          trustedLocalMedia: true,
-        },
-      },
-      {
-        kind: "final",
-        payload: {
-          text: "shared caption",
-          mediaUrls: [finalAudioPath],
-          trustedLocalMedia: true,
-          audioAsVoice: true,
-        },
-      },
-    ];
-    const respond = vi.fn();
-    const context = createChatContext();
-
-    const payload = await runNonStreamingChatSend({
-      context,
-      respond,
-      idempotencyKey: "idem-command-block-same-caption-different-media",
-      message: "/export-trajectory bundle",
-    });
-
-    const attachments = getMessageContent(payload).filter((block) => block.type === "attachment");
-    expect(attachments).toHaveLength(2);
-    expect(attachments[0]?.attachment).toEqual(
-      expect.objectContaining({
-        label: "block.mp3",
-      }),
-    );
-    expect(
-      (attachments[0]?.attachment as { isVoiceNote?: unknown } | undefined)?.isVoiceNote,
-    ).not.toBe(true);
-    expect(attachments[1]?.attachment).toEqual(
-      expect.objectContaining({
-        isVoiceNote: true,
-        label: "final.mp3",
-      }),
-    );
-  });
-
-  it("deduplicates slash-command final echoes against the same text and media block", async () => {
-    const transcriptDir = await createTranscriptFixture(
-      "openclaw-chat-send-command-block-same-caption-same-media-",
-    );
-    const firstAudioPath = path.join(transcriptDir, "first.mp3");
-    const secondAudioPath = path.join(transcriptDir, "second.mp3");
-    fs.writeFileSync(firstAudioPath, Buffer.from([0xff, 0xfb, 0x90, 0x00]));
-    fs.writeFileSync(secondAudioPath, Buffer.from([0xff, 0xfb, 0x90, 0x01]));
-    mockState.config = {
-      agents: {
-        defaults: {
-          workspace: transcriptDir,
-        },
-      },
-    };
-    mockState.dispatchedReplies = [
-      {
-        kind: "block",
-        payload: {
-          text: "shared caption",
-          mediaUrls: [firstAudioPath],
-          trustedLocalMedia: true,
-        },
-      },
-      {
-        kind: "block",
-        payload: {
-          text: "shared caption",
-          mediaUrls: [secondAudioPath],
-          trustedLocalMedia: true,
-        },
-      },
-      {
-        kind: "final",
-        payload: {
-          text: "shared caption",
-          mediaUrls: [secondAudioPath],
-          trustedLocalMedia: true,
-          audioAsVoice: true,
-        },
-      },
-    ];
-    const respond = vi.fn();
-    const context = createChatContext();
-
-    const payload = await runNonStreamingChatSend({
-      context,
-      respond,
-      idempotencyKey: "idem-command-block-same-caption-same-media",
-      message: "/export-trajectory bundle",
-    });
-
-    const content = getMessageContent(payload);
-    const text = content
-      .map((block) => (typeof block.text === "string" ? block.text : ""))
-      .filter(Boolean)
-      .join("\n");
-    expect(text.match(/shared caption/gu)).toHaveLength(2);
-    const attachments = content.filter((block) => block.type === "attachment");
-    expect(attachments).toHaveLength(2);
-    expect(attachments[0]?.attachment).toEqual(
-      expect.objectContaining({
-        label: "first.mp3",
-      }),
-    );
-    expect(attachments[1]?.attachment).toEqual(
-      expect.objectContaining({
-        isVoiceNote: true,
-        label: "second.mp3",
-      }),
-    );
-  });
-
-  it("uses canonical mediaUrls when deduplicating slash-command block media", async () => {
-    const transcriptDir = await createTranscriptFixture(
-      "openclaw-chat-send-command-block-media-canonical-",
-    );
-    const blockAudioPath = path.join(transcriptDir, "block.mp3");
-    const finalAudioPath = path.join(transcriptDir, "final.mp3");
-    fs.writeFileSync(blockAudioPath, Buffer.from([0xff, 0xfb, 0x90, 0x00]));
-    fs.writeFileSync(finalAudioPath, Buffer.from([0xff, 0xfb, 0x90, 0x01]));
-    mockState.config = {
-      agents: {
-        defaults: {
-          workspace: transcriptDir,
-        },
-      },
-    };
-    mockState.dispatchedReplies = [
-      {
-        kind: "block",
-        payload: {
-          text: "Trajectory exports can include prompts.",
-          mediaUrl: finalAudioPath,
-          mediaUrls: [blockAudioPath],
-          trustedLocalMedia: true,
-          audioAsVoice: true,
-        },
-      },
-      {
-        kind: "final",
-        payload: {
-          mediaUrls: [finalAudioPath],
-          trustedLocalMedia: true,
-          audioAsVoice: true,
-        },
-      },
-    ];
-    const respond = vi.fn();
-    const context = createChatContext();
-
-    const payload = await runNonStreamingChatSend({
-      context,
-      respond,
-      idempotencyKey: "idem-command-block-media-canonical",
-      message: "/export-trajectory bundle",
-    });
-
-    const content = getMessageContent(payload);
-    expect(content[0]).toMatchObject({
-      type: "text",
-      text: expect.stringContaining("Trajectory exports can include prompts."),
-    });
-    expect(content.slice(1)).toEqual([
-      {
-        type: "attachment",
-        attachment: expect.objectContaining({
-          kind: "audio",
-          label: "block.mp3",
         }),
+      ],
+      verify: (content) => {
+        const text = content
+          .map((block) => (typeof block.text === "string" ? block.text : ""))
+          .filter(Boolean)
+          .join("\n");
+        expect(text).toContain("preview");
+        expect(text).toContain("done");
+        expect(content.filter((block) => block.type === "attachment")).toHaveLength(1);
+        const transcriptUpdate = mockState.emittedTranscriptUpdates.find(
+          (update) =>
+            typeof update.message === "object" &&
+            update.message !== null &&
+            (update.message as { role?: unknown }).role === "assistant",
+        );
+        expect(JSON.stringify(transcriptUpdate?.message)).toContain("[[reply_to_current]]");
+        expect(JSON.stringify(transcriptUpdate?.message)).toContain("done");
       },
-      {
-        type: "attachment",
-        attachment: expect.objectContaining({
-          kind: "audio",
-          label: "final.mp3",
+    },
+    {
+      name: "keeps same-caption slash-command finals when media differs",
+      id: "same-caption-different-media",
+      files: ["block.mp3", "final.mp3"],
+      replies: ([first, second]) => [
+        createSlashCommandMediaReply("block", [first], { text: "shared caption" }),
+        createSlashCommandMediaReply("final", [second], {
+          text: "shared caption",
+          audioAsVoice: true,
         }),
+      ],
+      verify: (content) => {
+        const attachments = content.filter((block) => block.type === "attachment");
+        expect(attachments).toHaveLength(2);
+        expect(attachments[0]?.attachment).toEqual(expect.objectContaining({ label: "block.mp3" }));
+        expect(
+          (attachments[0]?.attachment as { isVoiceNote?: unknown } | undefined)?.isVoiceNote,
+        ).not.toBe(true);
+        expect(attachments[1]?.attachment).toEqual(
+          expect.objectContaining({ isVoiceNote: true, label: "final.mp3" }),
+        );
       },
-    ]);
-  });
-
-  it("does not spread duplicate final media flags across multi-media command blocks", async () => {
-    const transcriptDir = await createTranscriptFixture(
-      "openclaw-chat-send-command-block-media-partial-",
-    );
-    const firstAudioPath = path.join(transcriptDir, "first.mp3");
-    const secondAudioPath = path.join(transcriptDir, "second.mp3");
-    fs.writeFileSync(firstAudioPath, Buffer.from([0xff, 0xfb, 0x90, 0x00]));
-    fs.writeFileSync(secondAudioPath, Buffer.from([0xff, 0xfb, 0x90, 0x01]));
-    mockState.config = {
-      agents: {
-        defaults: {
-          workspace: transcriptDir,
-        },
-      },
-    };
-    mockState.dispatchedReplies = [
-      {
-        kind: "block",
-        payload: {
-          text: "Trajectory exports can include prompts.",
-          mediaUrls: [firstAudioPath, secondAudioPath],
-          trustedLocalMedia: true,
-        },
-      },
-      {
-        kind: "final",
-        payload: {
-          mediaUrls: [firstAudioPath],
-          trustedLocalMedia: true,
+    },
+    {
+      name: "deduplicates slash-command final echoes against the same text and media block",
+      id: "same-caption-same-media",
+      files: ["first.mp3", "second.mp3"],
+      replies: ([first, second]) => [
+        createSlashCommandMediaReply("block", [first], { text: "shared caption" }),
+        createSlashCommandMediaReply("block", [second], { text: "shared caption" }),
+        createSlashCommandMediaReply("final", [second], {
+          text: "shared caption",
           audioAsVoice: true,
-        },
+        }),
+      ],
+      verify: (content) => {
+        const text = content
+          .map((block) => (typeof block.text === "string" ? block.text : ""))
+          .filter(Boolean)
+          .join("\n");
+        expect(text.match(/shared caption/gu)).toHaveLength(2);
+        const attachments = content.filter((block) => block.type === "attachment");
+        expect(attachments).toHaveLength(2);
+        expect(attachments[0]?.attachment).toEqual(expect.objectContaining({ label: "first.mp3" }));
+        expect(attachments[1]?.attachment).toEqual(
+          expect.objectContaining({ isVoiceNote: true, label: "second.mp3" }),
+        );
       },
-    ];
-    const respond = vi.fn();
-    const context = createChatContext();
+    },
+    {
+      name: "uses canonical mediaUrls when deduplicating slash-command block media",
+      id: "media-canonical",
+      files: ["block.mp3", "final.mp3"],
+      replies: ([first, second]) => [
+        createSlashCommandMediaReply("block", [first], {
+          text: "Trajectory exports can include prompts.",
+          mediaUrl: second,
+          audioAsVoice: true,
+        }),
+        createSlashCommandMediaReply("final", [second], { audioAsVoice: true }),
+      ],
+      verify: (content) => {
+        expect(content[0]).toMatchObject({
+          type: "text",
+          text: expect.stringContaining("Trajectory exports can include prompts."),
+        });
+        expect(content.slice(1)).toEqual([
+          {
+            type: "attachment",
+            attachment: expect.objectContaining({ kind: "audio", label: "block.mp3" }),
+          },
+          {
+            type: "attachment",
+            attachment: expect.objectContaining({ kind: "audio", label: "final.mp3" }),
+          },
+        ]);
+      },
+    },
+    {
+      name: "does not spread duplicate final media flags across multi-media command blocks",
+      id: "media-partial",
+      files: ["first.mp3", "second.mp3"],
+      replies: ([first, second]) => [
+        createSlashCommandMediaReply("block", [first, second], {
+          text: "Trajectory exports can include prompts.",
+        }),
+        createSlashCommandMediaReply("final", [first], { audioAsVoice: true }),
+      ],
+      verify: (content) => {
+        const attachments = content.filter((block) => block.type === "attachment");
+        expect(attachments).toHaveLength(3);
+        expect(attachments[0]?.attachment).toEqual(expect.objectContaining({ label: "first.mp3" }));
+        expect(attachments[0]?.attachment?.isVoiceNote).not.toBe(true);
+        expect(attachments[1]?.attachment).toEqual(
+          expect.objectContaining({ label: "second.mp3" }),
+        );
+        expect(attachments[1]?.attachment?.isVoiceNote).not.toBe(true);
+        expect(attachments[2]?.attachment).toEqual(
+          expect.objectContaining({ isVoiceNote: true, label: "first.mp3" }),
+        );
+      },
+    },
+    {
+      name: "keeps sensitive overlapping slash-command media out of transcripts",
+      id: "media-sensitive-overlap",
+      files: ["secret.mp3", "public.mp3"],
+      replies: ([secret, publicAudio]) => [
+        createSlashCommandMediaReply("block", [secret, publicAudio], { text: "preview" }),
+        createSlashCommandMediaReply("final", [secret], { sensitiveMedia: true }),
+      ],
+      verify: (_content, [secret]) => {
+        const transcriptUpdate = mockState.emittedTranscriptUpdates.find(
+          (update) =>
+            typeof update.message === "object" &&
+            update.message !== null &&
+            (update.message as { role?: unknown }).role === "assistant",
+        );
+        expect(JSON.stringify(transcriptUpdate?.message)).not.toContain(secret);
+      },
+    },
+    {
+      name: "keeps reordered slash-command final media instead of treating it as duplicate",
+      id: "media-reordered",
+      files: ["first.mp3", "second.mp3"],
+      replies: ([first, second]) => [
+        createSlashCommandMediaReply("block", [first, second], {
+          text: "Trajectory exports can include prompts.",
+        }),
+        createSlashCommandMediaReply("final", [second, first], { audioAsVoice: true }),
+      ],
+      verify: (content) => {
+        const attachments = content.filter((block) => block.type === "attachment");
+        expect(attachments.map((block) => block.attachment?.label)).toEqual([
+          "first.mp3",
+          "second.mp3",
+          "second.mp3",
+          "first.mp3",
+        ]);
+        expect(
+          attachments.slice(0, 2).every((block) => block.attachment?.isVoiceNote !== true),
+        ).toBe(true);
+        expect(attachments.slice(2).every((block) => block.attachment?.isVoiceNote === true)).toBe(
+          true,
+        );
+      },
+    },
+  ] satisfies SlashCommandMediaCase[])("$name", async ({ id, files, replies, verify }) => {
+    const transcriptDir = await createTranscriptFixture(`openclaw-chat-send-command-block-${id}-`);
+    const audioPaths = files.map((file, index) => {
+      const audioPath = path.join(transcriptDir, file);
+      fs.writeFileSync(audioPath, Buffer.from([0xff, 0xfb, 0x90, index]));
+      return audioPath;
+    });
+    const firstAudioPath = expectDefined(audioPaths[0], "slash-command media fixture");
+    const fixturePaths: [string, string] = [firstAudioPath, audioPaths[1] ?? firstAudioPath];
+    mockState.config = { agents: { defaults: { workspace: transcriptDir } } };
+    mockState.dispatchedReplies = replies(fixturePaths);
 
     const payload = await runNonStreamingChatSend({
-      context,
-      respond,
-      idempotencyKey: "idem-command-block-media-partial",
+      context: createChatContext(),
+      respond: vi.fn(),
+      idempotencyKey: `idem-command-block-${id}`,
       message: "/export-trajectory bundle",
     });
 
-    const attachments = getMessageContent(payload).filter((block) => block.type === "attachment");
-    expect(attachments).toHaveLength(3);
-    expect(attachments[0]?.attachment).toEqual(
-      expect.objectContaining({
-        label: "first.mp3",
-      }),
-    );
-    expect(attachments[0]?.attachment?.isVoiceNote).not.toBe(true);
-    expect(attachments[1]?.attachment).toEqual(
-      expect.objectContaining({
-        label: "second.mp3",
-      }),
-    );
-    expect(attachments[1]?.attachment?.isVoiceNote).not.toBe(true);
-    expect(attachments[2]?.attachment).toEqual(
-      expect.objectContaining({
-        isVoiceNote: true,
-        label: "first.mp3",
-      }),
-    );
-  });
-
-  it("keeps sensitive overlapping slash-command media out of transcripts", async () => {
-    const transcriptDir = await createTranscriptFixture(
-      "openclaw-chat-send-command-block-media-sensitive-overlap-",
-    );
-    const secretAudioPath = path.join(transcriptDir, "secret.mp3");
-    const publicAudioPath = path.join(transcriptDir, "public.mp3");
-    fs.writeFileSync(secretAudioPath, Buffer.from([0xff, 0xfb, 0x90, 0x00]));
-    fs.writeFileSync(publicAudioPath, Buffer.from([0xff, 0xfb, 0x90, 0x01]));
-    mockState.config = {
-      agents: {
-        defaults: {
-          workspace: transcriptDir,
-        },
-      },
-    };
-    mockState.dispatchedReplies = [
-      {
-        kind: "block",
-        payload: {
-          text: "preview",
-          mediaUrls: [secretAudioPath, publicAudioPath],
-          trustedLocalMedia: true,
-        },
-      },
-      {
-        kind: "final",
-        payload: {
-          mediaUrls: [secretAudioPath],
-          sensitiveMedia: true,
-          trustedLocalMedia: true,
-        },
-      },
-    ];
-    const respond = vi.fn();
-    const context = createChatContext();
-
-    await runNonStreamingChatSend({
-      context,
-      respond,
-      idempotencyKey: "idem-command-block-media-sensitive-overlap",
-      message: "/export-trajectory bundle",
-    });
-
-    const transcriptUpdate = mockState.emittedTranscriptUpdates.find(
-      (update) =>
-        typeof update.message === "object" &&
-        update.message !== null &&
-        (update.message as { role?: unknown }).role === "assistant",
-    );
-    expect(JSON.stringify(transcriptUpdate?.message)).not.toContain(secretAudioPath);
-  });
-
-  it("keeps reordered slash-command final media instead of treating it as duplicate", async () => {
-    const transcriptDir = await createTranscriptFixture(
-      "openclaw-chat-send-command-block-media-reordered-",
-    );
-    const firstAudioPath = path.join(transcriptDir, "first.mp3");
-    const secondAudioPath = path.join(transcriptDir, "second.mp3");
-    fs.writeFileSync(firstAudioPath, Buffer.from([0xff, 0xfb, 0x90, 0x00]));
-    fs.writeFileSync(secondAudioPath, Buffer.from([0xff, 0xfb, 0x90, 0x01]));
-    mockState.config = {
-      agents: {
-        defaults: {
-          workspace: transcriptDir,
-        },
-      },
-    };
-    mockState.dispatchedReplies = [
-      {
-        kind: "block",
-        payload: {
-          text: "Trajectory exports can include prompts.",
-          mediaUrls: [firstAudioPath, secondAudioPath],
-          trustedLocalMedia: true,
-        },
-      },
-      {
-        kind: "final",
-        payload: {
-          mediaUrls: [secondAudioPath, firstAudioPath],
-          trustedLocalMedia: true,
-          audioAsVoice: true,
-        },
-      },
-    ];
-    const respond = vi.fn();
-    const context = createChatContext();
-
-    const payload = await runNonStreamingChatSend({
-      context,
-      respond,
-      idempotencyKey: "idem-command-block-media-reordered",
-      message: "/export-trajectory bundle",
-    });
-
-    const attachments = getMessageContent(payload).filter((block) => block.type === "attachment");
-    expect(attachments.map((block) => block.attachment?.label)).toEqual([
-      "first.mp3",
-      "second.mp3",
-      "second.mp3",
-      "first.mp3",
-    ]);
-    expect(attachments.slice(0, 2).every((block) => block.attachment?.isVoiceNote !== true)).toBe(
-      true,
-    );
-    expect(attachments.slice(2).every((block) => block.attachment?.isVoiceNote === true)).toBe(
-      true,
-    );
+    verify(getMessageContent(payload), fixturePaths);
   });
 
   it("renders image reply payloads as assistant image content instead of MEDIA text", async () => {
@@ -3838,8 +3494,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       text: "Scan this QR code with the OpenClaw iOS app:",
       mediaUrl: "data:image/png;base64,cG5n",
     };
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     const payload = await runNonStreamingChatSend({
       context,
@@ -3869,8 +3524,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         payload: { text: "final answer" },
       },
     ];
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     const payload = await runNonStreamingChatSend({
       context,
@@ -3884,8 +3538,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
 
   it("chat.inject keeps message defined when directive tag is the only content", async () => {
     await createTranscriptFixture("openclaw-chat-inject-directive-only-");
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     await expectDefined(
       chatHandlers["chat.inject"],
@@ -3914,8 +3567,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   it("chat.inject rejects archived sessions without appending", async () => {
     await createTranscriptFixture("openclaw-chat-inject-archived-");
     mockState.sessionEntry = { archivedAt: Date.now() };
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     await expectDefined(
       chatHandlers["chat.inject"],
@@ -3950,8 +3602,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       },
     });
     await mutationStarted.promise;
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     try {
       const inject = expectDefined(
@@ -3984,8 +3635,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
 
   it("chat.inject persists to SQLite without creating active JSONL", async () => {
     await withSqliteTranscriptFixtureState("openclaw-chat-inject-sqlite-", async () => {
-      const respond = vi.fn();
-      const context = createChatContext();
+      const { context, respond } = createChatRequestFixture();
 
       await expectDefined(
         chatHandlers["chat.inject"],
@@ -4012,8 +3662,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   it("chat.send non-streaming final keeps message defined for directive-only assistant text", async () => {
     await createTranscriptFixture("openclaw-chat-send-directive-only-");
     mockState.finalText = "[[reply_to_current]]";
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     const payload = await runNonStreamingChatSend({
       context,
@@ -4032,8 +3681,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   it("preserves inline reply directives in transcript text while stripping them from display", async () => {
     await createTranscriptFixture("openclaw-chat-send-inline-reply-transcript-");
     mockState.finalText = "see[[reply_to_current]]now  with  spacing";
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     const payload = await runNonStreamingChatSend({
       context,
@@ -4054,8 +3702,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
 
   it("rejects oversized chat.send session keys before dispatch", async () => {
     await createTranscriptFixture("openclaw-chat-send-session-key-too-long-");
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     await expectDefined(
       chatHandlers["chat.send"],
@@ -4083,8 +3730,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   it("rejects chat.send creation in an agent harness-owned namespace", async () => {
     await createTranscriptFixture("openclaw-chat-send-harness-reserved-");
     mockState.sessionMissing = true;
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     await expectDefined(
       chatHandlers["chat.send"],
@@ -4114,8 +3760,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
 
   it("chat.inject strips external untrusted wrapper metadata from final payload text", async () => {
     await createTranscriptFixture("openclaw-chat-inject-untrusted-meta-");
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     await expectDefined(
       chatHandlers["chat.inject"],
@@ -4143,8 +3788,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     mockState.sessionEntry = {
       canonicalKey: "agent:main:canon",
     };
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     await expectDefined(
       chatHandlers["chat.inject"],
@@ -4180,8 +3824,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       updatedAt,
       status: "done",
     });
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
     vi.useFakeTimers({ toFake: ["Date"] });
     vi.setSystemTime(appendedAt);
     try {
@@ -4218,8 +3861,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       session: { scope: "global" },
     };
     mockState.sessionEntry = { canonicalKey: "global" };
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     await expectDefined(
       chatHandlers["chat.inject"],
@@ -4257,8 +3899,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   it("chat.send non-streaming final strips external untrusted wrapper metadata from final payload text", async () => {
     await createTranscriptFixture("openclaw-chat-send-untrusted-meta-");
     mockState.finalText = `hello\n\n${UNTRUSTED_CONTEXT_SUFFIX}`;
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     const payload = await runNonStreamingChatSend({
       context,
@@ -4274,8 +3915,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       canonicalKey: "agent:main:canon",
     };
     mockState.finalText = "hello";
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     const payload = await runNonStreamingChatSend({
       context,
@@ -4294,8 +3934,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   it("chat.send broadcasts final replies for telegram-shaped session keys", async () => {
     await createTranscriptFixture("openclaw-chat-send-telegram-final-");
     mockState.finalText = "telegram ok";
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
     const sessionKey = "agent:main:telegram:direct:123456";
 
     const payload = await runNonStreamingChatSend({
@@ -4319,45 +3958,10 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     expect(nodeSend?.[2].state).toBe("final");
   });
 
-  it("chat.send keeps explicit delivery routes for channel-scoped sessions", async () => {
-    await createTranscriptFixture("openclaw-chat-send-origin-routing-");
-    mockState.finalText = "ok";
-    mockState.sessionEntry = {
-      delivery: normalizeSessionDeliveryState({
-        context: {
-          channel: "telegram",
-          to: "telegram:6812765697",
-          accountId: "default",
-          threadId: 42,
-        },
-      }),
-    };
-    const respond = vi.fn();
-    const context = createChatContext();
-
-    await runNonStreamingChatSend({
-      context,
-      respond,
-      idempotencyKey: "idem-origin-routing",
-      sessionKey: "agent:main:telegram:direct:6812765697",
-      deliver: true,
-      expectBroadcast: false,
-    });
-
-    expectDispatchContextFields({
-      OriginatingChannel: "telegram",
-      OriginatingTo: "telegram:6812765697",
-      ExplicitDeliverRoute: true,
-      AccountId: "default",
-      MessageThreadId: 42,
-    });
-  });
-
   it("chat.send marks user slash commands as text command sources", async () => {
     await createTranscriptFixture("openclaw-chat-send-text-command-source-");
     mockState.finalText = "ok";
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     await runNonStreamingChatSend({
       context,
@@ -4376,8 +3980,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   it("chat.send keeps thinking metadata out of command text for normal messages", async () => {
     await createTranscriptFixture("openclaw-chat-send-thinking-normal-message-");
     mockState.finalText = "ok";
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     await runNonStreamingChatSend({
       context,
@@ -4407,527 +4010,191 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     expect(mockState.lastDispatchThinkingLevelOverride).toBe("low");
   });
 
-  it("chat.send keeps explicit delivery routes for Feishu channel-scoped sessions", async () => {
-    await createTranscriptFixture("openclaw-chat-send-feishu-origin-routing-");
-    mockState.finalText = "ok";
-    mockState.sessionEntry = {
-      delivery: normalizeSessionDeliveryState({
-        context: { channel: "feishu", to: "ou_feishu_direct_123", accountId: "default" },
-      }),
-    };
-    const respond = vi.fn();
-    const context = createChatContext();
-
-    await runNonStreamingChatSend({
-      context,
-      respond,
-      idempotencyKey: "idem-feishu-origin-routing",
-      sessionKey: "agent:main:feishu:direct:ou_feishu_direct_123",
-      deliver: true,
-      expectBroadcast: false,
-    });
-
-    expectDispatchContextFields({
-      OriginatingChannel: "feishu",
-      OriginatingTo: "ou_feishu_direct_123",
-      ExplicitDeliverRoute: true,
-      AccountId: "default",
-    });
-  });
-
-  it("chat.send keeps explicit delivery routes for per-account channel-peer sessions", async () => {
-    await createTranscriptFixture("openclaw-chat-send-per-account-channel-peer-routing-");
-    mockState.finalText = "ok";
-    mockState.sessionEntry = {
-      delivery: normalizeSessionDeliveryState({
-        context: {
-          channel: "telegram",
-          to: "telegram:6812765697",
-          accountId: "account-a",
-        },
-      }),
-    };
-    const respond = vi.fn();
-    const context = createChatContext();
-
-    await runNonStreamingChatSend({
-      context,
-      respond,
-      idempotencyKey: "idem-per-account-channel-peer-routing",
-      sessionKey: "agent:main:telegram:account-a:direct:6812765697",
-      deliver: true,
-      expectBroadcast: false,
-    });
-
-    expectDispatchContextFields({
-      OriginatingChannel: "telegram",
-      OriginatingTo: "telegram:6812765697",
-      ExplicitDeliverRoute: true,
-      AccountId: "account-a",
-    });
-  });
-
-  it("chat.send keeps explicit delivery routes for legacy channel-peer sessions", async () => {
-    await createTranscriptFixture("openclaw-chat-send-legacy-channel-peer-routing-");
-    mockState.finalText = "ok";
-    mockState.sessionEntry = {
-      delivery: normalizeSessionDeliveryState({
-        context: {
-          channel: "telegram",
-          to: "telegram:6812765697",
-          accountId: "default",
-        },
-      }),
-    };
-    const respond = vi.fn();
-    const context = createChatContext();
-
-    await runNonStreamingChatSend({
-      context,
-      respond,
-      idempotencyKey: "idem-legacy-channel-peer-routing",
-      sessionKey: "agent:main:telegram:6812765697",
-      deliver: true,
-      expectBroadcast: false,
-    });
-
-    expectDispatchContextFields({
-      OriginatingChannel: "telegram",
-      OriginatingTo: "telegram:6812765697",
-      ExplicitDeliverRoute: true,
-      AccountId: "default",
-    });
-  });
-
-  it("chat.send keeps explicit delivery routes for legacy thread sessions", async () => {
-    await createTranscriptFixture("openclaw-chat-send-legacy-thread-channel-peer-routing-");
-    mockState.finalText = "ok";
-    mockState.sessionEntry = {
-      delivery: normalizeSessionDeliveryState({
-        context: {
-          channel: "telegram",
-          to: "telegram:6812765697",
-          accountId: "default",
-          threadId: "42",
-        },
-      }),
-    };
-    const respond = vi.fn();
-    const context = createChatContext();
-
-    await runNonStreamingChatSend({
-      context,
-      respond,
-      idempotencyKey: "idem-legacy-thread-channel-peer-routing",
-      sessionKey: "agent:main:telegram:6812765697:thread:42",
-      deliver: true,
-      expectBroadcast: false,
-    });
-
-    expectDispatchContextFields({
-      OriginatingChannel: "telegram",
-      OriginatingTo: "telegram:6812765697",
-      ExplicitDeliverRoute: true,
-      AccountId: "default",
-      MessageThreadId: "42",
-    });
-  });
-
-  it("chat.send does not inherit external delivery context for shared main sessions", async () => {
-    await createTranscriptFixture("openclaw-chat-send-main-no-cross-route-");
-    mockState.finalText = "ok";
-    mockState.sessionEntry = {
-      delivery: normalizeSessionDeliveryState({
-        context: { channel: "discord", to: "discord:1234567890", accountId: "default" },
-      }),
-    };
-    const respond = vi.fn();
-    const context = createChatContext();
-
-    await runNonStreamingChatSend({
-      context,
-      respond,
-      idempotencyKey: "idem-main-no-cross-route",
-      sessionKey: "main",
-      expectBroadcast: false,
-    });
-
-    expectDispatchContextFields({
-      OriginatingChannel: "webchat",
-      OriginatingTo: undefined,
-      ExplicitDeliverRoute: false,
-      AccountId: undefined,
-    });
-  });
-
-  it("chat.send does not inherit external delivery context for UI clients on main sessions", async () => {
-    await createTranscriptFixture("openclaw-chat-send-main-ui-routes-");
-    mockState.finalText = "ok";
-    mockState.sessionEntry = {
-      delivery: normalizeSessionDeliveryState({
-        context: {
-          channel: "whatsapp",
-          to: "whatsapp:+8613800138000",
-          accountId: "default",
-        },
-      }),
-    };
-    const respond = vi.fn();
-    const context = createChatContext();
-
-    await runNonStreamingChatSend({
-      context,
-      respond,
-      idempotencyKey: "idem-main-ui-routes",
-      client: {
-        connect: {
-          client: {
-            mode: GATEWAY_CLIENT_MODES.UI,
-            id: "openclaw-tui",
-          },
-        },
-      } as unknown,
-      sessionKey: "agent:main:main",
-      expectBroadcast: false,
-    });
-
-    expectDispatchContextFields({
-      OriginatingChannel: "webchat",
-      OriginatingTo: undefined,
-      AccountId: undefined,
-    });
-  });
-
-  it("chat.send does not inherit external delivery context for UI clients on main sessions when deliver is enabled", async () => {
-    await createTranscriptFixture("openclaw-chat-send-main-ui-deliver-no-route-");
-    mockState.finalText = "ok";
-    mockState.sessionEntry = {
-      delivery: normalizeSessionDeliveryState({
-        context: { channel: "telegram", to: "telegram:200482621", accountId: "default" },
-      }),
-    };
-    const respond = vi.fn();
-    const context = createChatContext();
-
-    await runNonStreamingChatSend({
-      context,
-      respond,
-      idempotencyKey: "idem-main-ui-deliver-no-route",
-      client: {
-        connect: {
-          client: {
-            mode: GATEWAY_CLIENT_MODES.UI,
-            id: "openclaw-tui",
-          },
-        },
-      } as unknown,
-      sessionKey: "agent:main:main",
-      deliver: true,
-      expectBroadcast: false,
-    });
-
-    expectDispatchContextFields({
-      OriginatingChannel: "webchat",
-      OriginatingTo: undefined,
-      ExplicitDeliverRoute: false,
-      AccountId: undefined,
-    });
-  });
-
-  it("chat.send inherits external delivery context for CLI clients on configured main sessions", async () => {
-    await createTranscriptFixture("openclaw-chat-send-config-main-cli-routes-");
-    mockState.mainSessionKey = "work";
-    mockState.finalText = "ok";
-    mockState.sessionEntry = {
-      delivery: normalizeSessionDeliveryState({
-        context: {
-          channel: "whatsapp",
-          to: "whatsapp:+8613800138000",
-          accountId: "default",
-        },
-      }),
-    };
-    const respond = vi.fn();
-    const context = createChatContext();
-
-    await runNonStreamingChatSend({
-      context,
-      respond,
-      idempotencyKey: "idem-config-main-cli-routes",
-      client: {
-        connect: {
-          client: {
-            mode: GATEWAY_CLIENT_MODES.CLI,
-            id: "cli",
-          },
-        },
-      } as unknown,
-      sessionKey: "agent:main:work",
-      deliver: true,
-      expectBroadcast: false,
-    });
-
-    expectDispatchContextFields({
-      OriginatingChannel: "whatsapp",
-      OriginatingTo: "whatsapp:+8613800138000",
-      AccountId: "default",
-    });
-  });
-
-  it("chat.send inherits canonical origin-backed routing for configured main CLI sessions", async () => {
-    await createTranscriptFixture("openclaw-chat-send-config-main-origin-provider-routes-");
-    mockState.mainSessionKey = "work";
-    mockState.finalText = "ok";
-    mockState.sessionEntry = {
-      delivery: normalizeSessionDeliveryState({
-        context: {
-          channel: "whatsapp",
-          to: "whatsapp:+8613800138000",
-          accountId: "default",
-        },
+  it.each([
+    [
+      "keeps explicit delivery routes for channel-scoped sessions",
+      "origin-routing",
+      { channel: "telegram", to: "telegram:6812765697", accountId: "default", threadId: 42 },
+      "agent:main:telegram:direct:6812765697",
+      { deliver: true, external: true },
+    ],
+    [
+      "keeps explicit delivery routes for Feishu channel-scoped sessions",
+      "feishu-origin-routing",
+      { channel: "feishu", to: "ou_feishu_direct_123", accountId: "default" },
+      "agent:main:feishu:direct:ou_feishu_direct_123",
+      { deliver: true, external: true },
+    ],
+    [
+      "keeps explicit delivery routes for per-account channel-peer sessions",
+      "per-account-channel-peer-routing",
+      { channel: "telegram", to: "telegram:6812765697", accountId: "account-a" },
+      "agent:main:telegram:account-a:direct:6812765697",
+      { deliver: true, external: true },
+    ],
+    [
+      "keeps explicit delivery routes for legacy channel-peer sessions",
+      "legacy-channel-peer-routing",
+      { channel: "telegram", to: "telegram:6812765697", accountId: "default" },
+      "agent:main:telegram:6812765697",
+      { deliver: true, external: true },
+    ],
+    [
+      "keeps explicit delivery routes for legacy thread sessions",
+      "legacy-thread-channel-peer-routing",
+      { channel: "telegram", to: "telegram:6812765697", accountId: "default", threadId: "42" },
+      "agent:main:telegram:6812765697:thread:42",
+      { deliver: true, external: true },
+    ],
+    [
+      "does not inherit external delivery context for shared main sessions",
+      "main-no-cross-route",
+      { channel: "discord", to: "discord:1234567890", accountId: "default" },
+      "main",
+    ],
+    [
+      "does not inherit external delivery context for UI clients on main sessions",
+      "main-ui-routes",
+      { channel: "whatsapp", to: "whatsapp:+8613800138000", accountId: "default" },
+      "agent:main:main",
+      { clientMode: GATEWAY_CLIENT_MODES.UI },
+    ],
+    [
+      "does not inherit external delivery context for UI clients on main sessions when deliver is enabled",
+      "main-ui-deliver-no-route",
+      { channel: "telegram", to: "telegram:200482621", accountId: "default" },
+      "agent:main:main",
+      { clientMode: GATEWAY_CLIENT_MODES.UI, deliver: true },
+    ],
+    [
+      "inherits external delivery context for CLI clients on configured main sessions",
+      "config-main-cli-routes",
+      { channel: "whatsapp", to: "whatsapp:+8613800138000", accountId: "default" },
+      "agent:main:work",
+      {
+        clientMode: GATEWAY_CLIENT_MODES.CLI,
+        mainSessionKey: "work",
+        deliver: true,
+        external: true,
+      },
+    ],
+    [
+      "inherits canonical origin-backed routing for configured main CLI sessions",
+      "config-main-origin-provider-routes",
+      { channel: "whatsapp", to: "whatsapp:+8613800138000", accountId: "default" },
+      "agent:main:work",
+      {
+        clientMode: GATEWAY_CLIENT_MODES.CLI,
+        mainSessionKey: "work",
         origin: { provider: "whatsapp", accountId: "default" },
-      }),
-    };
-    const respond = vi.fn();
-    const context = createChatContext();
-
-    await runNonStreamingChatSend({
-      context,
-      respond,
-      idempotencyKey: "idem-config-main-origin-provider-routes",
-      client: {
-        connect: {
-          client: {
-            mode: GATEWAY_CLIENT_MODES.CLI,
-            id: "cli",
-          },
-        },
-      } as unknown,
-      sessionKey: "agent:main:work",
-      deliver: true,
-      expectBroadcast: false,
-    });
-
-    expectDispatchContextFields({
-      OriginatingChannel: "whatsapp",
-      OriginatingTo: "whatsapp:+8613800138000",
-      AccountId: "default",
-    });
-  });
-
-  it("chat.send inherits canonical origin-backed thread routing for configured main CLI sessions", async () => {
-    await createTranscriptFixture("openclaw-chat-send-config-main-origin-thread-routes-");
-    mockState.mainSessionKey = "work";
-    mockState.finalText = "ok";
-    mockState.sessionEntry = {
-      delivery: normalizeSessionDeliveryState({
-        context: {
-          channel: "telegram",
-          to: "telegram:6812765697",
-          accountId: "default",
-          threadId: "42",
-        },
+        deliver: true,
+        external: true,
+      },
+    ],
+    [
+      "inherits canonical origin-backed thread routing for configured main CLI sessions",
+      "config-main-origin-thread-routes",
+      { channel: "telegram", to: "telegram:6812765697", accountId: "default", threadId: "42" },
+      "agent:main:work",
+      {
+        clientMode: GATEWAY_CLIENT_MODES.CLI,
+        mainSessionKey: "work",
         origin: { provider: "telegram", accountId: "default", threadId: "42" },
-      }),
-    };
-    const respond = vi.fn();
-    const context = createChatContext();
+        deliver: true,
+        external: true,
+      },
+    ],
+    [
+      "keeps configured main delivery inheritance when connect metadata omits client details",
+      "config-main-connect-no-client",
+      { channel: "whatsapp", to: "whatsapp:+8613800138000", accountId: "default" },
+      "agent:main:work",
+      { mainSessionKey: "work", omitClientDetails: true, deliver: true, external: true },
+    ],
+    // Two custom tokens exercise legacy-shape detection; a single token does not.
+    [
+      "does not inherit external delivery context for non-channel custom sessions",
+      "custom-no-cross-route",
+      { channel: "discord", to: "discord:1234567890", accountId: "default" },
+      "agent:main:work:ticket-123",
+    ],
+    [
+      "keeps replies on the internal surface when deliver is not enabled",
+      "no-deliver-internal-surface",
+      { channel: "discord", to: "user:1234567890", accountId: "default" },
+      "agent:main:discord:direct:1234567890",
+      { deliver: false },
+    ],
+    [
+      "does not inherit external routes for webchat clients on channel-scoped sessions",
+      "webchat-channel-scoped-no-inherit",
+      { channel: "imessage", to: "+8619800001234", accountId: "default" },
+      "agent:main:imessage:direct:+8619800001234",
+      { clientMode: GATEWAY_CLIENT_MODES.WEBCHAT, deliver: true },
+    ],
+    [
+      "still inherits external routes for UI clients on channel-scoped sessions",
+      "ui-channel-scoped-inherit",
+      { channel: "imessage", to: "+8619800001234", accountId: "default" },
+      "agent:main:imessage:direct:+8619800001234",
+      { clientMode: GATEWAY_CLIENT_MODES.UI, deliver: true, external: true },
+    ],
+  ] satisfies ChatDeliveryRoutingCase[])(
+    "chat.send %s",
+    async (...[_name, id, delivery, sessionKey, options = {}]: ChatDeliveryRoutingCase) => {
+      await createTranscriptFixture(`openclaw-chat-send-${id}-`);
+      mockState.finalText = "ok";
+      mockState.mainSessionKey = options.mainSessionKey ?? "main";
+      mockState.sessionEntry = {
+        delivery: normalizeSessionDeliveryState({
+          context: delivery,
+          ...(options.origin ? { origin: options.origin } : {}),
+        }),
+      };
+      const client = options.clientMode
+        ? {
+            connect: {
+              client: {
+                mode: options.clientMode,
+                id:
+                  options.clientMode === GATEWAY_CLIENT_MODES.CLI
+                    ? "cli"
+                    : options.clientMode === GATEWAY_CLIENT_MODES.WEBCHAT
+                      ? "openclaw-webchat"
+                      : "openclaw-tui",
+              },
+            },
+          }
+        : options.omitClientDetails
+          ? { connect: {} }
+          : undefined;
 
-    await runNonStreamingChatSend({
-      context,
-      respond,
-      idempotencyKey: "idem-config-main-origin-thread-routes",
-      client: {
-        connect: {
-          client: {
-            mode: GATEWAY_CLIENT_MODES.CLI,
-            id: "cli",
-          },
-        },
-      } as unknown,
-      sessionKey: "agent:main:work",
-      deliver: true,
-      expectBroadcast: false,
-    });
+      await runNonStreamingChatSend({
+        context: createChatContext(),
+        respond: vi.fn(),
+        idempotencyKey: `idem-${id}`,
+        sessionKey,
+        ...(client ? { client } : {}),
+        ...(typeof options.deliver === "boolean" ? { deliver: options.deliver } : {}),
+        expectBroadcast: false,
+      });
 
-    expectDispatchContextFields({
-      OriginatingChannel: "telegram",
-      OriginatingTo: "telegram:6812765697",
-      ExplicitDeliverRoute: true,
-      AccountId: "default",
-      MessageThreadId: "42",
-    });
-  });
-
-  it("chat.send keeps configured main delivery inheritance when connect metadata omits client details", async () => {
-    await createTranscriptFixture("openclaw-chat-send-config-main-connect-no-client-");
-    mockState.mainSessionKey = "work";
-    mockState.finalText = "ok";
-    mockState.sessionEntry = {
-      delivery: normalizeSessionDeliveryState({
-        context: {
-          channel: "whatsapp",
-          to: "whatsapp:+8613800138000",
-          accountId: "default",
-        },
-      }),
-    };
-    const respond = vi.fn();
-    const context = createChatContext();
-
-    await runNonStreamingChatSend({
-      context,
-      respond,
-      idempotencyKey: "idem-config-main-connect-no-client",
-      client: {
-        connect: {},
-      } as unknown,
-      sessionKey: "agent:main:work",
-      deliver: true,
-      expectBroadcast: false,
-    });
-
-    expectDispatchContextFields({
-      OriginatingChannel: "whatsapp",
-      OriginatingTo: "whatsapp:+8613800138000",
-      AccountId: "default",
-    });
-  });
-
-  it("chat.send does not inherit external delivery context for non-channel custom sessions", async () => {
-    await createTranscriptFixture("openclaw-chat-send-custom-no-cross-route-");
-    mockState.finalText = "ok";
-    mockState.sessionEntry = {
-      delivery: normalizeSessionDeliveryState({
-        context: { channel: "discord", to: "discord:1234567890", accountId: "default" },
-      }),
-    };
-    const respond = vi.fn();
-    const context = createChatContext();
-
-    await runNonStreamingChatSend({
-      context,
-      respond,
-      idempotencyKey: "idem-custom-no-cross-route",
-      // Keep a second custom scope token so legacy-shape detection is exercised.
-      // "agent:main:work" only yields one rest token and does not hit that path.
-      sessionKey: "agent:main:work:ticket-123",
-      expectBroadcast: false,
-    });
-
-    expectDispatchContextFields({
-      OriginatingChannel: "webchat",
-      OriginatingTo: undefined,
-      AccountId: undefined,
-    });
-  });
-
-  it("chat.send keeps replies on the internal surface when deliver is not enabled", async () => {
-    await createTranscriptFixture("openclaw-chat-send-no-deliver-internal-surface-");
-    mockState.finalText = "ok";
-    mockState.sessionEntry = {
-      delivery: normalizeSessionDeliveryState({
-        context: { channel: "discord", to: "user:1234567890", accountId: "default" },
-      }),
-    };
-    const respond = vi.fn();
-    const context = createChatContext();
-
-    await runNonStreamingChatSend({
-      context,
-      respond,
-      idempotencyKey: "idem-no-deliver-internal-surface",
-      sessionKey: "agent:main:discord:direct:1234567890",
-      deliver: false,
-      expectBroadcast: false,
-    });
-
-    expectDispatchContextFields({
-      OriginatingChannel: "webchat",
-      OriginatingTo: undefined,
-      AccountId: undefined,
-    });
-  });
-
-  it("chat.send does not inherit external routes for webchat clients on channel-scoped sessions", async () => {
-    await createTranscriptFixture("openclaw-chat-send-webchat-channel-scoped-no-inherit-");
-    mockState.finalText = "ok";
-    mockState.sessionEntry = {
-      delivery: normalizeSessionDeliveryState({
-        context: { channel: "imessage", to: "+8619800001234", accountId: "default" },
-      }),
-    };
-    const respond = vi.fn();
-    const context = createChatContext();
-
-    // Webchat client accessing an iMessage channel-scoped session should NOT
-    // inherit the external delivery route. Fixes #38957.
-    await runNonStreamingChatSend({
-      context,
-      respond,
-      idempotencyKey: "idem-webchat-channel-scoped-no-inherit",
-      client: {
-        connect: {
-          client: {
-            mode: GATEWAY_CLIENT_MODES.WEBCHAT,
-            id: "openclaw-webchat",
-          },
-        },
-      } as unknown,
-      sessionKey: "agent:main:imessage:direct:+8619800001234",
-      deliver: true,
-      expectBroadcast: false,
-    });
-
-    expectDispatchContextFields({
-      OriginatingChannel: "webchat",
-      OriginatingTo: undefined,
-      ExplicitDeliverRoute: false,
-      AccountId: undefined,
-    });
-  });
-
-  it("chat.send still inherits external routes for UI clients on channel-scoped sessions", async () => {
-    await createTranscriptFixture("openclaw-chat-send-ui-channel-scoped-inherit-");
-    mockState.finalText = "ok";
-    mockState.sessionEntry = {
-      delivery: normalizeSessionDeliveryState({
-        context: { channel: "imessage", to: "+8619800001234", accountId: "default" },
-      }),
-    };
-    const respond = vi.fn();
-    const context = createChatContext();
-
-    await runNonStreamingChatSend({
-      context,
-      respond,
-      idempotencyKey: "idem-ui-channel-scoped-inherit",
-      client: {
-        connect: {
-          client: {
-            mode: GATEWAY_CLIENT_MODES.UI,
-            id: "openclaw-tui",
-          },
-        },
-      } as unknown,
-      sessionKey: "agent:main:imessage:direct:+8619800001234",
-      deliver: true,
-      expectBroadcast: false,
-    });
-
-    expectDispatchContextFields({
-      OriginatingChannel: "imessage",
-      OriginatingTo: "+8619800001234",
-      ExplicitDeliverRoute: true,
-      AccountId: "default",
-    });
-  });
+      expectDispatchContextFields({
+        OriginatingChannel: options.external ? delivery.channel : "webchat",
+        OriginatingTo: options.external ? delivery.to : undefined,
+        ExplicitDeliverRoute: Boolean(options.external && options.deliver),
+        AccountId: options.external ? delivery.accountId : undefined,
+        ...(options.external && delivery.threadId !== undefined
+          ? { MessageThreadId: delivery.threadId }
+          : {}),
+      });
+    },
+  );
 
   it("chat.send accepts admin-scoped synthetic originating routes without external delivery", async () => {
     await createTranscriptFixture("openclaw-chat-send-synthetic-origin-admin-");
     mockState.finalText = "ok";
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     await runNonStreamingChatSend({
       context,
@@ -4956,8 +4223,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   it("rejects synthetic originating routes when the caller lacks admin scope", async () => {
     await createTranscriptFixture("openclaw-chat-send-synthetic-origin-reject-");
     mockState.finalText = "ok";
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     await runNonStreamingChatSend({
       context,
@@ -4981,8 +4247,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   it("rejects reserved system provenance fields for non-ACP clients", async () => {
     await createTranscriptFixture("openclaw-chat-send-system-provenance-reject-");
     mockState.finalText = "ok";
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     await runNonStreamingChatSend({
       context,
@@ -5005,8 +4270,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   it("rejects forged ACP metadata when the caller lacks admin scope", async () => {
     await createTranscriptFixture("openclaw-chat-send-system-provenance-spoof-reject-");
     mockState.finalText = "ok";
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     await runNonStreamingChatSend({
       context,
@@ -5040,8 +4304,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   it("allows admin-scoped clients to inject system provenance without ACP metadata", async () => {
     await createTranscriptFixture("openclaw-chat-send-system-provenance-admin-");
     mockState.finalText = "ok";
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     await runNonStreamingChatSend({
       context,
@@ -5080,8 +4343,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   it("forwards gateway caller scopes into the dispatch context", async () => {
     await createTranscriptFixture("openclaw-chat-send-gateway-client-scopes-");
     mockState.finalText = "ok";
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     await runNonStreamingChatSend({
       context,
@@ -5102,8 +4364,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   it("forwards gateway client capabilities into the dispatch context", async () => {
     await createTranscriptFixture("openclaw-chat-send-gateway-client-caps-");
     mockState.finalText = "ok";
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     await runNonStreamingChatSend({
       context,
@@ -5122,8 +4383,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   it("normalizes missing gateway caller scopes to an empty array before dispatch", async () => {
     await createTranscriptFixture("openclaw-chat-send-missing-gateway-client-scopes-");
     mockState.finalText = "ok";
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     await runNonStreamingChatSend({
       context,
@@ -5142,8 +4402,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   it("injects ACP system provenance into the agent-visible body", async () => {
     await createTranscriptFixture("openclaw-chat-send-system-provenance-acp-");
     mockState.finalText = "ok";
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
     const provenance = {
       kind: "external_user" as const,
       originSessionId: "acp-session-1",
@@ -5192,8 +4451,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     await createTranscriptFixture("openclaw-chat-send-user-transcript-agent-run-");
     mockState.finalText = "ok";
     mockState.triggerAgentRunStart = true;
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     await runNonStreamingChatSend({
       context,
@@ -5230,8 +4488,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
           (update.message as { role?: unknown }).role === "user",
       ).length;
     };
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     await runNonStreamingChatSend({
       context,
@@ -5266,8 +4523,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         ),
       },
     ];
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     await runNonStreamingChatSend({
       context,
@@ -5291,8 +4547,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     mockState.triggerAgentRunStart = true;
     mockState.hasBeforeAgentRunHooks = true;
     mockState.dispatchErrorAfterAgentRunStart = new Error("model unavailable");
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     await runNonStreamingChatSend({
       context,
@@ -5320,8 +4575,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       { path: "/tmp/chat-send-image-a.png", contentType: "image/png" },
       { path: "/tmp/chat-send-image-b.jpg", contentType: "image/jpeg" },
     ];
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     await runNonStreamingChatSend({
       context,
@@ -5392,8 +4646,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     mockState.savedMediaResults = [
       { path: "/tmp/chat-send-brief.pdf", contentType: "application/pdf" },
     ];
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     await runNonStreamingChatSend({
       context,
@@ -5462,8 +4715,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       { path: "/tmp/offloaded-big.png", contentType: "image/png" },
       { path: "/tmp/chat-send-inline.png", contentType: "image/png" },
     ];
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
     const bigPng = Buffer.alloc(2_100_000);
     bigPng.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a], 0);
 
@@ -5513,8 +4765,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     mockState.savedMediaResults = [
       { path: "/tmp/should-not-be-used.png", contentType: "image/png" },
     ];
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     await runNonStreamingChatSend({
       context,
@@ -5565,8 +4816,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     mockState.saveMediaWait = new Promise<void>((resolve) => {
       releaseSave = resolve;
     });
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     await runNonStreamingChatSend({
       context,
@@ -5602,8 +4852,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   it("preserves media-only final replies in the final broadcast message", async () => {
     await createTranscriptFixture("openclaw-chat-send-media-only-final-");
     mockState.finalPayload = { mediaUrl: "data:image/png;base64,cG5n" };
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     const payload = await runNonStreamingChatSend({
       context,
@@ -5623,8 +4872,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       text: "NO_REPLY",
       mediaUrl: "data:image/png;base64,cG5n",
     };
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     const payload = await runNonStreamingChatSend({
       context,
@@ -5644,8 +4892,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       replyToCurrent: true,
       mediaUrl: "data:image/png;base64,cG5n",
     };
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     const payload = await runNonStreamingChatSend({
       context,
@@ -5684,8 +4931,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       mediaUrl: "data:image/png;base64,cG5n",
       sensitiveMedia: true,
     };
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     const payload = await runNonStreamingChatSend({
       context,
@@ -5723,8 +4969,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       text: "hello",
       replyToId: "abc]]\n[[audio_as_voice]]",
     };
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     const payload = await runNonStreamingChatSend({
       context,
@@ -5749,8 +4994,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       text: "hello[[reply_to:inline-id]]",
       replyToId: "]]\n[[",
     };
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     const payload = await runNonStreamingChatSend({
       context,
@@ -5783,8 +5027,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         input: ["text"],
       },
     ];
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     await runNonStreamingChatSend({
       context,
@@ -5844,8 +5087,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         input: ["text", "image"],
       },
     ];
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     await runNonStreamingChatSend({
       context,
@@ -5895,8 +5137,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     bindingMocks.resolveByConversation.mockReturnValue({
       targetSessionKey: "agent:claude:acp:spawned",
     });
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     await runNonStreamingChatSend({
       context,
@@ -5960,8 +5201,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         input: ["text"],
       },
     ];
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     await runNonStreamingChatSend({
       context,
@@ -6023,8 +5263,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     mockState.savedMediaResults = [
       { path: "/home/user/.openclaw/media/inbound/report.pdf", contentType: "application/pdf" },
     ];
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
     const pdf = Buffer.from("%PDF-1.4\n%µ¶\n1 0 obj\n<<>>\nendobj\n").toString("base64");
 
     await runNonStreamingChatSend({
@@ -6082,8 +5321,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     mockState.savedMediaResults = [
       { path: "/home/user/.openclaw/media/inbound/fake.zip", contentType: "application/zip" },
     ];
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
     const zip = Buffer.from("PK\u0003\u0004zip-archive-bytes").toString("base64");
 
     await runNonStreamingChatSend({
@@ -6144,8 +5382,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     ];
     mockState.sandboxWorkspace = { workspaceDir: "/sandbox/workspace" };
     mockState.stagedRelativePaths = ["media/inbound/report.pdf"];
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
     const pdf = Buffer.from("%PDF-1.4\n%µ¶\n1 0 obj\n<<>>\nendobj\n").toString("base64");
 
     await runNonStreamingChatSend({
@@ -6203,8 +5440,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     ];
     mockState.sandboxWorkspace = { workspaceDir: "/sandbox/workspace" };
     mockState.stagedRelativePaths = ["media/inbound/report.pdf"];
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
     const pdf = Buffer.from("%PDF-1.4\n").toString("base64");
 
     await runNonStreamingChatSend({
@@ -6282,8 +5518,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     stageError.stack =
       "Error: ENOSPC: no space left on device\n    at stageSandboxMedia (stage-sandbox-media.ts:1:1)";
     mockState.stageSandboxMediaError = stageError;
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
     const binPayload = Buffer.from("OPENCLAW-BINARY\n").toString("base64");
 
     await runNonStreamingChatSend({
@@ -6332,8 +5567,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
 
   it("logs chat.send attachment parse failures with stack details", async () => {
     await createTranscriptFixture("openclaw-chat-send-attachment-parse-stack-");
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     await runNonStreamingChatSend({
       context,
@@ -6410,8 +5644,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     mockState.sandboxWorkspace = { workspaceDir: "/sandbox/workspace" };
     mockState.stagedRelativePaths = ["media/inbound/report.bin", "media/inbound/data.bin"];
     mockState.unstagedSources = ["/home/user/.openclaw/media/inbound/data.bin"];
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
     const binPayload = Buffer.from("OPENCLAW-BINARY\n").toString("base64");
 
     await runNonStreamingChatSend({
@@ -6475,8 +5708,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       { path: "/home/user/.openclaw/media/inbound/huge.pdf", contentType: "application/pdf" },
     ];
     mockState.sandboxWorkspace = { workspaceDir: "/sandbox/workspace" };
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
     // 6MB PDF — above STAGED_MEDIA_MAX_BYTES (5MB) but below the 20MB parse cap.
     const oversized = Buffer.alloc(6 * 1024 * 1024);
     oversized.set(Buffer.from("%PDF-1.4\n"), 0);
@@ -6538,8 +5770,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     mockState.stageSandboxMediaError = Object.assign(new Error("ENOSPC: no space left on device"), {
       code: "ENOSPC",
     });
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
     // Small PDF (below the 5MB staging cap) so it takes the staging path, not the
     // oversized pass-through path.
     const pdf = Buffer.from("%PDF-1.4\n%µ¶\nendobj\n").toString("base64");
@@ -6594,8 +5825,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     mockState.sandboxWorkspace = { workspaceDir: "/sandbox/workspace" };
     // No stagedRelativePaths → staged map is empty and the fact keeps the
     // absolute path, mirroring stageSandboxMedia silently skipping the file.
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
     const pdf = Buffer.from("%PDF-1.4\n%µ¶\nendobj\n").toString("base64");
 
     await runNonStreamingChatSend({
@@ -6649,8 +5879,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     mockState.sandboxWorkspace = { workspaceDir: "/sandbox/workspace" };
     mockState.stagedRelativePaths = ["media/inbound/report.pdf", "media/inbound/data.bin"];
     mockState.unstagedSources = ["/home/user/.openclaw/media/inbound/data.bin"];
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
     const pdf = Buffer.from("%PDF-1.4\n").toString("base64");
     const bin = Buffer.from("OPENCLAW-BINARY\n").toString("base64");
 
@@ -6718,8 +5947,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       },
     ];
     mockState.sandboxWorkspace = { workspaceDir: "/sandbox/workspace" };
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
     // 6MB buffer — above STAGED_MEDIA_MAX_BYTES (5MB) but below the 20MB parse cap.
     const oversized = Buffer.alloc(6 * 1024 * 1024);
     oversized.set(Buffer.from("OPENCLAW-BINARY\n"), 0);
@@ -6775,8 +6003,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       },
     ];
     mockState.savedMediaResults = [{ path: "/tmp/offloaded-big.png", contentType: "image/png" }];
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
     const bigPng = Buffer.alloc(2_100_000);
     bigPng.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a], 0);
 
@@ -6820,8 +6047,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       },
     ];
     mockState.saveMediaError = new Error("disk full");
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
     const bigPng = Buffer.alloc(2_100_000);
     bigPng.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a], 0);
 
@@ -6858,8 +6084,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     mockState.saveMediaWait = new Promise<void>((resolve) => {
       releaseSave = resolve;
     });
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     await runNonStreamingChatSend({
       context,
@@ -6899,8 +6124,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   it("does not parse or offload attachments for stop commands", async () => {
     await createTranscriptFixture("openclaw-chat-send-stop-command-attachments-");
     mockState.savedMediaResults = [{ path: "/tmp/should-not-exist.png", contentType: "image/png" }];
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
     context.chatAbortControllers.set("run-same-session", {
       controller: new AbortController(),
       sessionId: "sess-prev",
@@ -6939,8 +6163,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   it("emits a user transcript update when chat.send completes without an agent run", async () => {
     await createGatewayUserTurnSqliteFixture("openclaw-chat-send-user-transcript-no-run-");
     mockState.finalText = "ok";
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     await runNonStreamingChatSend({
       context,
@@ -6963,8 +6186,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   it("emits a user transcript update when chat.send fails before an agent run starts", async () => {
     await createGatewayUserTurnSqliteFixture("openclaw-chat-send-user-transcript-error-no-run-");
     mockState.dispatchError = new Error("upstream unavailable");
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     await runNonStreamingChatSend({
       context,
@@ -6992,8 +6214,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       "openclaw-chat-send-user-transcript-slash-error-no-run-",
     );
     mockState.dispatchError = new Error("slash command continued into unavailable runtime");
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     await runNonStreamingChatSend({
       context,
@@ -7055,8 +6276,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     );
     mockState.hasBeforeAgentRunHooks = true;
     mockState.dispatchError = new Error("resolver unavailable");
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     await runNonStreamingChatSend({
       context,
@@ -7082,8 +6302,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     );
     mockState.triggerAgentRunStart = true;
     mockState.dispatchErrorAfterAgentRunStart = new Error("cli backend unavailable");
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     await runNonStreamingChatSend({
       context,
@@ -7114,8 +6333,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     mockState.triggerAgentRunStart = true;
     mockState.dispatchErrorAfterAgentRunStart = new Error("cli backend unavailable");
     mockState.beforeMessageWriteContent = "[redacted by hook]";
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     await runNonStreamingChatSend({
       context,
@@ -7144,8 +6362,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     mockState.triggerAgentRunStart = true;
     mockState.dispatchErrorAfterAgentRunStart = new Error("cli backend unavailable");
     mockState.beforeMessageWriteBlock = true;
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     await runNonStreamingChatSend({
       context,
@@ -7171,8 +6388,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     );
     mockState.triggerAgentRunStart = true;
     mockState.finalPayload = { text: "agent failed before prompt append", isError: true };
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     await runNonStreamingChatSend({
       context,
@@ -7203,8 +6419,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       setTimeout(() => reject(new Error("runtime prompt mirror failed")), 0);
     });
     mockState.finalPayload = { text: "agent still answered" };
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     await runNonStreamingChatSend({
       context,
@@ -7236,8 +6451,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     mockState.triggerAgentRunStart = true;
     mockState.hasBeforeAgentRunHooks = true;
     mockState.finalPayload = { text: "agent failed before prompt append", isError: true };
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     await runNonStreamingChatSend({
       context,
@@ -7261,8 +6475,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
 describe("chat.send operator UI client sender context", () => {
   it("does not inject sender identity fields for Control UI clients", async () => {
     await createGatewayUserTurnSqliteFixture("openclaw-chat-send-control-ui-sender-");
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     await runNonStreamingChatSend({
       context,
@@ -7291,8 +6504,7 @@ describe("chat.send operator UI client sender context", () => {
   });
 
   it("enables task suggestions for TUI clients", async () => {
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     await runNonStreamingChatSend({
       context,
@@ -7318,8 +6530,7 @@ describe("chat.send operator UI client sender context", () => {
   });
 
   it("withholds task suggestions from operator UI clients that cannot accept them", async () => {
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     await runNonStreamingChatSend({
       context,
@@ -7345,8 +6556,7 @@ describe("chat.send operator UI client sender context", () => {
   });
 
   it("withholds task suggestions from non-operator gateway clients", async () => {
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     await runNonStreamingChatSend({
       context,
@@ -7372,8 +6582,7 @@ describe("chat.send operator UI client sender context", () => {
   });
 
   it("withholds task suggestions from operator UI clients without action support", async () => {
-    const respond = vi.fn();
-    const context = createChatContext();
+    const { context, respond } = createChatRequestFixture();
 
     await runNonStreamingChatSend({
       context,


### PR DESCRIPTION
## What Problem This Solves\n\nMaintainer-requested test consolidation: Gateway chat send, media routing, delivery authorization, and abort regression suites repeat the same request fixtures and scenario scaffolding thousands of times, making the tests harder to audit and maintain.\n\n## Why This Change Was Made\n\nExtract one typed chat-request fixture, consolidate equivalent channel-delivery and local-media matrices, and table-drive canonical, global, hidden, and owner-scoped chat abort cases while preserving distinct, descriptive scenario names and existing security assertions. This changes tests only; no Gateway protocol, production behavior, dependencies, snapshots, or baseline files are changed.\n\n## User Impact\n\nNo product behavior changes. Gateway developers retain the same 216 chat regression scenarios and identical statement, branch, function, and line coverage with 1,013 fewer net lines and a faster focused test run.\n\n## Evidence\n\n- Exact frozen diff: 2 test files; +1,065/-2,078; 1,013 net lines removed.\n- Pinned baseline: 16d2b7e46784c75eb5d57329269e9fd47222d2ef.\n- Blacksmith Testbox: tbx_01kygzcjh37h6dpzzgf350t94w.\n- Before and after: 216/216 Gateway chat and abort tests pass.\n- Before and after V8: statements 1,757/2,503; branches 1,703/2,619; functions 310/389; lines 1,733/2,476.\n- Matched focused run: 15.88 s before; 14.98 s after.\n- Passed remote core-test typecheck and complete scoped changed gate, including all guards, format, plugin boundaries, and lint (0 warnings; 0 errors).\n- Fresh structured Codex autoreview: clean, no accepted or actionable findings.\n- AI-assisted, maintainer-requested implementation; no private session transcript included.