### PR TITLE
perf(ui): parallelize session-switch hydration

### DIFF
--- a/ui/src/e2e/chat-flow.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.e2e.test.ts
@@ -2169,7 +2169,7 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
       await page.goto(`${server.baseUrl}chat`);
       await gateway.waitForRequest("chat.startup");
       expect(await gateway.getRequests("agents.list")).toHaveLength(0);
-      expect(await gateway.getRequests("chat.metadata")).toHaveLength(0);
+      expect(await gateway.getRequests("chat.metadata")).toHaveLength(1);
       expect(await gateway.getRequests("commands.list")).toHaveLength(0);
       expect(await gateway.getRequests("models.list")).toHaveLength(0);
 

--- a/ui/src/pages/chat/chat-history.ts
+++ b/ui/src/pages/chat/chat-history.ts
@@ -677,6 +677,7 @@ type InFlightChatHistoryRequest = {
 };
 
 type LoadChatHistoryOptions = {
+  deferBranches?: boolean;
   startup?: boolean;
 };
 
@@ -993,8 +994,9 @@ export async function loadChatHistory(
     return inFlight.promise;
   }
   if (
-    state.chatBranchesSessionKey !== sessionKey ||
-    state.chatBranchesConnectionEpoch !== connectionEpoch
+    opts.deferBranches !== true &&
+    (state.chatBranchesSessionKey !== sessionKey ||
+      state.chatBranchesConnectionEpoch !== connectionEpoch)
   ) {
     void loadChatBranches(state);
   }

--- a/ui/src/pages/chat/chat-pane-base.ts
+++ b/ui/src/pages/chat/chat-pane-base.ts
@@ -131,6 +131,7 @@ export abstract class ChatPaneBase extends OpenClawLightDomElement {
   protected sessionRailLoad: Promise<void> | null = null;
   protected sessionRailOpenRequest = 0;
   protected sessionRailOpenSessionKey = "";
+  protected deferredSessionHydrationRequestVersion = 0;
   protected sessionCompanionHydrationKey = "";
   protected readonly sessionCompanionThreads = new ChatSessionCompanionThreads(() => {
     this.requestUpdate();

--- a/ui/src/pages/chat/chat-pane-context.ts
+++ b/ui/src/pages/chat/chat-pane-context.ts
@@ -205,13 +205,10 @@ export abstract class ChatPaneContext extends ChatPaneLifecycle {
     if (state.connected && state.pendingAbort) {
       void replayPendingChatAbort(state).finally(() => state.requestUpdate?.());
     }
-    if (sourceChanged && snapshot.phase === "connected" && state.sessionKey) {
-      // Reconnects clear the probed states above; re-probe the active session
-      // so source-owned affordances reappear without a manual session switch.
-      void this.probeSessionDiscussion(state.sessionKey);
-      if (!clientChanged) {
-        void this.refreshSessionPullRequests();
-      }
+    if (sourceChanged && snapshot.phase === "connected" && state.sessionKey && !clientChanged) {
+      // A logical reconnect can retain the browser client and skip full startup.
+      // The existing transcript is already authoritative, so rehydrate after its next commit.
+      this.deferSessionHydrationUntilTranscript(state.sessionKey, Promise.resolve());
     }
     state.terminalAvailable =
       this.context.config.current.terminalEnabled &&
@@ -318,14 +315,19 @@ export abstract class ChatPaneContext extends ChatPaneLifecycle {
       }
       void syncSelectedSessionMessageSubscription(state, { force: true });
       void retryReconnectableQueuedChatSends(state);
-      void refreshPageChat(state, { startup: true, awaitHistory: true }).finally(() => {
+      const historyRefresh = refreshPageChat(state, {
+        startup: true,
+        awaitHistory: true,
+        deferBranches: true,
+      });
+      this.deferSessionHydrationUntilTranscript(startupSessionKey, historyRefresh);
+      void historyRefresh.finally(() => {
         void finishStartup();
       });
       void refreshChatModelAuthStatus(state).finally(() => state.requestUpdate?.());
       void state.loadAssistantIdentity();
       void this.refreshTaskSuggestions();
       void this.refreshSessionSuggestions();
-      void this.refreshSessionPullRequests();
     }
     this.reconcileWaitingApprovalSnapshot();
     state.requestUpdate?.();

--- a/ui/src/pages/chat/chat-pane-deps.ts
+++ b/ui/src/pages/chat/chat-pane-deps.ts
@@ -161,6 +161,7 @@ export type { ChatHistoryPagination } from "./chat-history-pagination.ts";
 export {
   applyChatAgentsList,
   clearChatHistory,
+  loadChatBranches,
   loadChatHistory,
   loadOlderChatHistoryPage,
   rewindChatHistory,

--- a/ui/src/pages/chat/chat-pane-lifecycle.test.ts
+++ b/ui/src/pages/chat/chat-pane-lifecycle.test.ts
@@ -701,6 +701,24 @@ describe("chat pane presentation teardown", () => {
 });
 
 describe("chat pane connection lifecycle", () => {
+  it("rehydrates secondary session state after a same-client logical reconnect", () => {
+    const client = {
+      request: vi.fn(() => new Promise<never>(() => {})),
+    } as unknown as GatewayBrowserClient;
+    const { pane, state } = createTestChatPane({ client, sessions: {} as SessionCapability });
+    const deferHydration = vi.spyOn(pane, "deferSessionHydrationUntilTranscript");
+    state.connected = false;
+    pane.connectedClient = client;
+
+    pane.applyGatewaySnapshot({
+      ...pane.context.gateway.snapshot,
+      client,
+      phase: "connected",
+    });
+
+    expect(deferHydration).toHaveBeenCalledWith(state.sessionKey, expect.any(Promise));
+  });
+
   it("replays a pending exact-run stop when the gateway reconnects", async () => {
     const request = vi.fn((method: string) =>
       method === "chat.abort" ? Promise.resolve({ aborted: true }) : new Promise<never>(() => {}),

--- a/ui/src/pages/chat/chat-pane-lifecycle.ts
+++ b/ui/src/pages/chat/chat-pane-lifecycle.ts
@@ -347,11 +347,9 @@ export abstract class ChatPaneLifecycle extends ChatPaneReset {
         ? this.sessionKey
         : resolveSessionKey(this.sessionKey, this.context.gateway.snapshot.hello);
       if (nextSessionKey) {
+        // Availability belongs to one activation. The replacement probe starts
+        // after its transcript commit in deferSessionHydrationUntilTranscript.
         this.sessionDiscussionStates.delete(nextSessionKey);
-        // Resolve availability before the action renders: the methods are
-        // advertised even without a provider, so an unprobed session would
-        // otherwise show a dead Discussion button on provider-less installs.
-        void this.probeSessionDiscussion(nextSessionKey);
       }
       if (nextSessionKey && nextSessionKey !== this.state.sessionKey) {
         this.switchPaneSession(nextSessionKey);
@@ -402,9 +400,6 @@ export abstract class ChatPaneLifecycle extends ChatPaneReset {
       session: selectedSessionRow,
       digest: null,
     });
-    if (this.state?.sessionKey) {
-      this.hydrateSessionCompanion(this.state.sessionKey);
-    }
     if (this.state?.observerDigest || selectedSessionRow?.observerDigest || observerRunId) {
       this.ensureSessionRail();
     }
@@ -417,6 +412,7 @@ export abstract class ChatPaneLifecycle extends ChatPaneReset {
     this.paneResizeObserver?.disconnect();
     this.paneResizeObserver = null;
     this.connectionGeneration += 1;
+    this.deferredSessionHydrationRequestVersion += 1;
     this.sessionDiscussionPanels.clear();
     this.sessionCompanionHydrationKey = "";
     this.taskSuggestionsRequestVersion += 1;

--- a/ui/src/pages/chat/chat-pane-pull-requests.test.ts
+++ b/ui/src/pages/chat/chat-pane-pull-requests.test.ts
@@ -10,6 +10,66 @@ afterEach(() => {
 });
 
 describe("chat pane pull request refresh", () => {
+  it("does not let a previous session response clobber the current PR state", async () => {
+    let resolvePrevious!: (value: {
+      pullRequests: Array<{ number: number; title: string; url: string; state: "open" }>;
+      rateLimited: boolean;
+    }) => void;
+    let resolveCurrent!: typeof resolvePrevious;
+    const previous = new Promise<Parameters<typeof resolvePrevious>[0]>((resolve) => {
+      resolvePrevious = resolve;
+    });
+    const current = new Promise<Parameters<typeof resolveCurrent>[0]>((resolve) => {
+      resolveCurrent = resolve;
+    });
+    const request = vi.fn(
+      async (_method: string, params: { sessionKey: string }) =>
+        await (params.sessionKey === "agent:main:current" ? previous : current),
+    );
+    const { pane, state } = createTestChatPane({
+      client: { request } as unknown as GatewayBrowserClient,
+      sessions: {
+        capturePullRequestEpoch: vi.fn(() => Symbol("pr-refresh")),
+        setPullRequestSummary: vi.fn(),
+      } as unknown as SessionCapability,
+    });
+    pane.context.gateway.snapshot.hello = {
+      features: { methods: ["controlUi.sessionPullRequests"] },
+    } as never;
+
+    const previousRefresh = pane.refreshSessionPullRequests();
+    state.sessionKey = "agent:main:current-2";
+    const currentRefresh = pane.refreshSessionPullRequests();
+    resolveCurrent({
+      pullRequests: [
+        {
+          number: 2,
+          title: "Current session PR",
+          url: "https://github.com/openclaw/openclaw/pull/2",
+          state: "open",
+        },
+      ],
+      rateLimited: false,
+    });
+    await currentRefresh;
+    resolvePrevious({
+      pullRequests: [
+        {
+          number: 1,
+          title: "Previous session PR",
+          url: "https://github.com/openclaw/openclaw/pull/1",
+          state: "open",
+        },
+      ],
+      rateLimited: false,
+    });
+    await previousRefresh;
+
+    expect(pane.sessionPullRequests).toEqual([
+      expect.objectContaining({ number: 2, title: "Current session PR" }),
+    ]);
+  });
+
   it("forwards an explicit refresh and publishes live PR state", async () => {
     const request = vi.fn().mockResolvedValue({
       pullRequests: [

--- a/ui/src/pages/chat/chat-pane-session-hydration.test.ts
+++ b/ui/src/pages/chat/chat-pane-session-hydration.test.ts
@@ -1,0 +1,94 @@
+/* @vitest-environment jsdom */
+
+import { describe, expect, it, vi } from "vitest";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import type { SessionCapability } from "../../lib/sessions/index.ts";
+import { createTestChatPane } from "./chat-pane.test-support.ts";
+import type { AfterCommitEffect, RenderLifecycle } from "./render-lifecycle.ts";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
+}
+
+describe("chat pane session hydration", () => {
+  it("starts secondary RPCs together only after the transcript commit", async () => {
+    const secondaryResponse = new Promise<never>(() => {});
+    const request = vi.fn(() => secondaryResponse);
+    const listBranches = vi.fn(() => secondaryResponse);
+    const sessions = {
+      capturePullRequestEpoch: vi.fn(() => Symbol("pull-requests")),
+      listBranches,
+      setPullRequestSummary: vi.fn(),
+    } as unknown as SessionCapability;
+    const client = { request } as unknown as GatewayBrowserClient;
+    const { pane, state } = createTestChatPane({ client, sessions });
+    pane.context.gateway.snapshot.hello = {
+      features: {
+        methods: ["controlUi.sessionPullRequests", "session.discussion.info"],
+      },
+    } as never;
+    const commitEffects: AfterCommitEffect[] = [];
+    const afterCommit = vi.fn((effect: AfterCommitEffect) => {
+      commitEffects.push(effect);
+      return () => undefined;
+    });
+    state.renderLifecycle = {
+      invalidate: vi.fn(),
+      afterCommit,
+    } satisfies RenderLifecycle;
+    const transcript = deferred<void>();
+
+    pane.deferSessionHydrationUntilTranscript(state.sessionKey, transcript.promise);
+
+    expect(request).not.toHaveBeenCalled();
+    expect(listBranches).not.toHaveBeenCalled();
+    transcript.resolve();
+    await transcript.promise;
+    await Promise.resolve();
+
+    expect(afterCommit).toHaveBeenCalledOnce();
+    expect(request).not.toHaveBeenCalled();
+    expect(listBranches).not.toHaveBeenCalled();
+
+    const complete = vi.fn();
+    commitEffects[0]?.(complete);
+
+    expect(listBranches).toHaveBeenCalledOnce();
+    expect(request.mock.calls.map(([method]) => method)).toEqual([
+      "session.discussion.info",
+      "sessions.companion.state",
+      "controlUi.sessionPullRequests",
+    ]);
+    expect(complete).toHaveBeenCalledOnce();
+  });
+
+  it("drops a previous session's deferred hydration before it reaches commit", async () => {
+    const request = vi.fn(() => new Promise<never>(() => {}));
+    const { pane, state } = createTestChatPane({
+      client: { request } as unknown as GatewayBrowserClient,
+      sessions: {} as SessionCapability,
+    });
+    const afterCommit = vi.fn<RenderLifecycle["afterCommit"]>(() => () => undefined);
+    state.renderLifecycle = { invalidate: vi.fn(), afterCommit };
+    const previousTranscript = deferred<void>();
+    const currentTranscript = deferred<void>();
+
+    pane.deferSessionHydrationUntilTranscript(state.sessionKey, previousTranscript.promise);
+    state.sessionKey = "agent:main:current-2";
+    pane.deferSessionHydrationUntilTranscript(state.sessionKey, currentTranscript.promise);
+
+    previousTranscript.resolve();
+    await previousTranscript.promise;
+    await Promise.resolve();
+    expect(afterCommit).not.toHaveBeenCalled();
+
+    currentTranscript.resolve();
+    await currentTranscript.promise;
+    await Promise.resolve();
+    expect(afterCommit).toHaveBeenCalledOnce();
+  });
+});

--- a/ui/src/pages/chat/chat-pane-session-hydration.test.ts
+++ b/ui/src/pages/chat/chat-pane-session-hydration.test.ts
@@ -17,7 +17,7 @@ function deferred<T>() {
 describe("chat pane session hydration", () => {
   it("starts secondary RPCs together only after the transcript commit", async () => {
     const secondaryResponse = new Promise<never>(() => {});
-    const request = vi.fn(() => secondaryResponse);
+    const request = vi.fn((_method: string, _params?: unknown) => secondaryResponse);
     const listBranches = vi.fn(() => secondaryResponse);
     const sessions = {
       capturePullRequestEpoch: vi.fn(() => Symbol("pull-requests")),
@@ -67,7 +67,7 @@ describe("chat pane session hydration", () => {
   });
 
   it("drops a previous session's deferred hydration before it reaches commit", async () => {
-    const request = vi.fn(() => new Promise<never>(() => {}));
+    const request = vi.fn((_method: string, _params?: unknown) => new Promise<never>(() => {}));
     const { pane, state } = createTestChatPane({
       client: { request } as unknown as GatewayBrowserClient,
       sessions: {} as SessionCapability,

--- a/ui/src/pages/chat/chat-pane-session.ts
+++ b/ui/src/pages/chat/chat-pane-session.ts
@@ -7,6 +7,7 @@ import {
   flushChatQueueAfterIdleSessionReconciliation,
   flushChatQueueForEvent,
   loadChatComposerSnapshot,
+  loadChatBranches,
   loadChatHistory,
   lookupCatalogSession,
   parseAgentSessionKey,
@@ -40,6 +41,43 @@ import {
 import { ChatPaneSuggestions } from "./chat-pane-suggestions.ts";
 
 export abstract class ChatPaneSession extends ChatPaneSuggestions {
+  protected deferSessionHydrationUntilTranscript(
+    sessionKey: string,
+    transcriptLoad: Promise<unknown>,
+  ): void {
+    const state = this.state;
+    if (!state) {
+      return;
+    }
+    const requestVersion = ++this.deferredSessionHydrationRequestVersion;
+    const connectionGeneration = this.connectionGeneration;
+    const client = state.client;
+    const isCurrent = () =>
+      this.deferredSessionHydrationRequestVersion === requestVersion &&
+      this.connectionGeneration === connectionGeneration &&
+      this.state === state &&
+      state.connected &&
+      state.client === client &&
+      state.sessionKey === sessionKey;
+    const scheduleAfterTranscript = () => {
+      if (!isCurrent()) {
+        return;
+      }
+      // These affordances do not shape the transcript. Start them together only
+      // after the authoritative history has committed so they cannot delay chat paint.
+      state.renderLifecycle.afterCommit((complete) => {
+        if (isCurrent()) {
+          void loadChatBranches(state);
+          void this.probeSessionDiscussion(sessionKey);
+          this.hydrateSessionCompanion(sessionKey);
+          void this.refreshSessionPullRequests();
+        }
+        complete();
+      });
+    };
+    void transcriptLoad.then(scheduleAfterTranscript, scheduleAfterTranscript);
+  }
+
   protected markSessionRead(row: GatewaySessionRow | undefined) {
     const state = this.state;
     if (!state?.connected || !row) {
@@ -205,7 +243,7 @@ export abstract class ChatPaneSession extends ChatPaneSuggestions {
     void refreshChatMetadata(state).finally(() => state.requestUpdate?.());
     const subscriptionSync = syncSelectedSessionMessageSubscription(state);
     const composerStorageError = state.chatError === CHAT_COMPOSER_DRAFT_STORAGE_ERROR;
-    const historyLoad = loadChatHistory(state);
+    const historyLoad = loadChatHistory(state, { deferBranches: true });
     if (composerStorageError) {
       // History loading clears the shared error slot synchronously. Restore the
       // pane-local storage warning unless the retry above made the draft durable.
@@ -215,7 +253,7 @@ export abstract class ChatPaneSession extends ChatPaneSuggestions {
     state.requestUpdate();
     void this.refreshTaskSuggestions();
     void this.refreshSessionSuggestions();
-    void this.refreshSessionPullRequests();
+    this.deferSessionHydrationUntilTranscript(nextSessionKey, historyLoad);
     const scheduleHistoryScroll = () => {
       if (state.sessionKey !== nextSessionKey) {
         return;

--- a/ui/src/pages/chat/chat-pane.test-support.ts
+++ b/ui/src/pages/chat/chat-pane.test-support.ts
@@ -63,6 +63,10 @@ export type TestChatPane = HTMLElement & {
   onPaneSessionChange?: (paneId: string, sessionKey: string) => void;
   sessionKey: string;
   switchPaneSession: (nextSessionKey: string) => void;
+  deferSessionHydrationUntilTranscript: (
+    sessionKey: string,
+    transcriptLoad: Promise<unknown>,
+  ) => void;
   paneTitle: string;
   catalogSession: SessionCatalogSession | null;
   catalogItemMessage: (item: SessionCatalogTranscriptItem) => Record<string, unknown> | null;

--- a/ui/src/pages/chat/chat-send.test.ts
+++ b/ui/src/pages/chat/chat-send.test.ts
@@ -369,6 +369,7 @@ function makeHost(overrides?: MakeHostOverrides): TestChatHost | TestChatHostWit
     sessionsError: null,
     sessionsArchivedFilter: "active" as const,
     chatModelsLoading: false,
+    chatMetadataRequestVersion: 0,
     chatModelCatalog: [],
     refreshSessionsAfterChat: new Map(),
     toolStreamById: new Map(),
@@ -530,6 +531,88 @@ describe("refreshChat", () => {
     expect(host.request).toHaveBeenCalledWith("chat.history", { sessionKey: "main", limit: 100 });
     expect(host.request).not.toHaveBeenCalledWith("sessions.list", expect.anything());
     expect(requestUpdate).not.toHaveBeenCalled();
+  });
+
+  it("starts startup metadata without waiting for the transcript response", async () => {
+    const startup = createDeferred<unknown>();
+    const metadata = createDeferred<unknown>();
+    const host = makeHost({
+      hello: {
+        features: { methods: ["chat.metadata", "chat.startup"] },
+      } as TestChatHost["hello"],
+      requestHandlers: {
+        "chat.metadata": () => metadata.promise,
+        "chat.startup": () => startup.promise,
+      },
+    });
+
+    const refresh = refreshPageChat(asChatPageHost(host), {
+      awaitHistory: true,
+      deferBranches: true,
+      startup: true,
+    });
+
+    expect(host.request.mock.calls.map(([method]) => method)).toEqual([
+      "chat.startup",
+      "chat.metadata",
+    ]);
+    expect(await raceWithMacrotask(refresh)).toBe("pending");
+
+    metadata.resolve({ commands: [], models: [] });
+    startup.resolve({ messages: [] });
+    await expect(refresh).resolves.toBeUndefined();
+  });
+
+  it("preserves startup metadata when parallel metadata needs fallbacks", async () => {
+    const startup = createDeferred<unknown>();
+    const metadata = createDeferred<unknown>();
+    const host = makeHost({
+      hello: {
+        features: { methods: ["chat.metadata", "chat.startup"] },
+      } as TestChatHost["hello"],
+      requestHandlers: {
+        "chat.metadata": () => metadata.promise,
+        "chat.startup": () => startup.promise,
+      },
+    });
+    const refresh = refreshPageChat(asChatPageHost(host), {
+      awaitHistory: true,
+      deferBranches: true,
+      startup: true,
+    });
+
+    metadata.resolve({});
+    await Promise.resolve();
+    expect(host.request).not.toHaveBeenCalledWith("models.list", expect.anything());
+    expect(host.request).not.toHaveBeenCalledWith("commands.list", expect.anything());
+
+    startup.resolve({
+      messages: [],
+      metadata: {
+        commands: [],
+        models: [
+          {
+            available: true,
+            id: "startup-model",
+            name: "Startup Model",
+            provider: "openai",
+          },
+        ],
+      },
+    });
+    await expect(refresh).resolves.toBeUndefined();
+    await vi.waitFor(() =>
+      expect(host.chatModelCatalog).toEqual([
+        {
+          available: true,
+          id: "startup-model",
+          name: "Startup Model",
+          provider: "openai",
+        },
+      ]),
+    );
+    expect(host.request).not.toHaveBeenCalledWith("models.list", expect.anything());
+    expect(host.request).not.toHaveBeenCalledWith("commands.list", expect.anything());
   });
 
   it.each([

--- a/ui/src/pages/chat/chat-state-refresh.ts
+++ b/ui/src/pages/chat/chat-state-refresh.ts
@@ -26,6 +26,7 @@ type ChatMetadataApplyResult = {
 };
 
 type ChatRefreshOptions = {
+  deferBranches?: boolean;
   scheduleScroll?: boolean;
   awaitHistory?: boolean;
   startup?: boolean;
@@ -42,6 +43,18 @@ type ChatMetadataRequest = {
   client: GatewayBrowserClient;
   agentId: string | null | undefined;
   version: number;
+};
+
+type ChatMetadataRefreshOptions = {
+  fallbackMetadata?: Promise<ChatMetadataApplyResult>;
+  onApplied?: (result: ChatMetadataApplyResult) => void;
+  preserveModelCatalogOnFallback?: boolean;
+  requestVersion?: number;
+};
+
+const EMPTY_CHAT_METADATA_APPLY_RESULT: ChatMetadataApplyResult = {
+  commands: false,
+  models: false,
 };
 
 function scheduleChatMetadataRefresh(callback: () => void) {
@@ -66,16 +79,20 @@ function applyChatMetadataResult(
   client: GatewayBrowserClient,
   agentId: string | null | undefined,
   result: ChatMetadataResult,
+  fields: { commands?: boolean; models?: boolean } = {},
 ): ChatMetadataApplyResult {
-  const models = applyModelCatalogResult(result.models);
+  const models = fields.models === false ? undefined : applyModelCatalogResult(result.models);
   if (models) {
     host.chatModelCatalog = models;
   }
-  const commandsApplied = applyRemoteSlashCommandsResult({
-    client,
-    agentId,
-    result,
-  });
+  const commandsApplied =
+    fields.commands === false
+      ? false
+      : applyRemoteSlashCommandsResult({
+          client,
+          agentId,
+          result,
+        });
   return { commands: commandsApplied, models: Boolean(models) };
 }
 
@@ -110,34 +127,56 @@ function canUseCompatibilityModelCatalog(
   return agentId === resolveUiDefaultAgentId(host);
 }
 
+async function refreshMissingChatMetadata(
+  request: ChatMetadataRequest,
+  applied: ChatMetadataApplyResult,
+  opts?: ChatMetadataRefreshOptions,
+): Promise<void> {
+  const startupApplied = opts?.fallbackMetadata
+    ? await opts.fallbackMetadata.catch(() => EMPTY_CHAT_METADATA_APPLY_RESULT)
+    : EMPTY_CHAT_METADATA_APPLY_RESULT;
+  if (!ownsChatMetadataRequest(request)) {
+    return;
+  }
+  const commandsRefresh =
+    applied.commands || startupApplied.commands
+      ? Promise.resolve()
+      : refreshCompatibilityCommands(request);
+  const preserveModels = opts?.preserveModelCatalogOnFallback || startupApplied.models;
+  const modelsRefresh =
+    applied.models || preserveModels
+      ? Promise.resolve()
+      : canUseCompatibilityModelCatalog(request.host, request.agentId)
+        ? refreshCompatibilityModelCatalog(request)
+        : Promise.resolve().then(() => {
+            if (ownsChatMetadataRequest(request)) {
+              request.host.chatModelCatalog = [];
+            }
+          });
+  await Promise.allSettled([commandsRefresh, modelsRefresh]);
+}
+
 export async function refreshChatMetadata(
   host: ChatPageHost,
-  opts?: { preserveModelCatalogOnFallback?: boolean },
-) {
-  const requestVersion = ++host.chatMetadataRequestVersion;
+  opts?: ChatMetadataRefreshOptions,
+): Promise<ChatMetadataApplyResult> {
+  const requestVersion = opts?.requestVersion ?? ++host.chatMetadataRequestVersion;
   if (!host.client || !host.connected) {
     host.chatModelsLoading = false;
     host.chatModelCatalog = [];
-    return;
+    return EMPTY_CHAT_METADATA_APPLY_RESULT;
+  }
+  if (host.chatMetadataRequestVersion !== requestVersion) {
+    return EMPTY_CHAT_METADATA_APPLY_RESULT;
   }
   const client = host.client;
   const agentId = resolveChatAgentId(host);
   const request = { host, client, agentId, version: requestVersion };
-  const shouldRefreshCompatibilityModels =
-    !opts?.preserveModelCatalogOnFallback && canUseCompatibilityModelCatalog(host, agentId);
-  const shouldClearUnresolvedModels =
-    !opts?.preserveModelCatalogOnFallback && !shouldRefreshCompatibilityModels;
   host.chatModelsLoading = true;
   try {
     if (isGatewayMethodAdvertised(host as unknown as ChatState, "chat.metadata") === false) {
-      if (shouldClearUnresolvedModels) {
-        host.chatModelCatalog = [];
-      }
-      await Promise.allSettled([
-        ...(shouldRefreshCompatibilityModels ? [refreshCompatibilityModelCatalog(request)] : []),
-        refreshCompatibilityCommands(request),
-      ]);
-      return;
+      await refreshMissingChatMetadata(request, EMPTY_CHAT_METADATA_APPLY_RESULT, opts);
+      return EMPTY_CHAT_METADATA_APPLY_RESULT;
     }
 
     const result = await client.request<ChatMetadataResult>(
@@ -145,30 +184,19 @@ export async function refreshChatMetadata(
       agentId ? { agentId } : {},
     );
     if (!ownsChatMetadataRequest(request)) {
-      return;
+      return EMPTY_CHAT_METADATA_APPLY_RESULT;
     }
     const metadataApplied = applyChatMetadataResult(host, client, agentId, result);
-    if (!metadataApplied.models && shouldClearUnresolvedModels) {
-      host.chatModelCatalog = [];
-    }
+    opts?.onApplied?.(metadataApplied);
     if (!metadataApplied.models || !metadataApplied.commands) {
-      await Promise.allSettled([
-        ...(!metadataApplied.models && shouldRefreshCompatibilityModels
-          ? [refreshCompatibilityModelCatalog(request)]
-          : []),
-        ...(metadataApplied.commands ? [] : [refreshCompatibilityCommands(request)]),
-      ]);
+      await refreshMissingChatMetadata(request, metadataApplied, opts);
     }
+    return metadataApplied;
   } catch {
     if (ownsChatMetadataRequest(request)) {
-      if (shouldClearUnresolvedModels) {
-        host.chatModelCatalog = [];
-      }
-      await Promise.allSettled([
-        ...(shouldRefreshCompatibilityModels ? [refreshCompatibilityModelCatalog(request)] : []),
-        refreshCompatibilityCommands(request),
-      ]);
+      await refreshMissingChatMetadata(request, EMPTY_CHAT_METADATA_APPLY_RESULT, opts);
     }
+    return EMPTY_CHAT_METADATA_APPLY_RESULT;
   } finally {
     if (ownsChatMetadataRequest(request)) {
       host.chatModelsLoading = false;
@@ -209,6 +237,7 @@ async function refreshChat(
   const requestUpdate = () => host.requestUpdate?.();
   const previousSessionsResult = host.sessionsResult;
   const historyLoad = loadChatHistory(host as unknown as ChatState, {
+    deferBranches: opts?.deferBranches === true,
     startup: opts?.startup === true,
   });
   const historyRefresh = historyLoad.finally(() => {
@@ -297,6 +326,7 @@ export function refreshPageChat(host: ChatPageHost, opts?: ChatRefreshOptions) {
         resolveStartupMetadata = resolve;
       })
     : Promise.resolve({ commands: false, models: false });
+  let parallelMetadataApplied = EMPTY_CHAT_METADATA_APPLY_RESULT;
 
   const refresh = refreshChat(host, {
     ...opts,
@@ -309,7 +339,10 @@ export function refreshPageChat(host: ChatPageHost, opts?: ChatRefreshOptions) {
         resolveChatAgentId(host) === agentId;
       const applied =
         metadata && ownsMetadata
-          ? applyChatMetadataResult(host, client, agentId, metadata)
+          ? applyChatMetadataResult(host, client, agentId, metadata, {
+              commands: !parallelMetadataApplied.commands,
+              models: !parallelMetadataApplied.models,
+            })
           : { commands: false, models: false };
       resolveStartupMetadata(applied);
     },
@@ -321,6 +354,23 @@ export function refreshPageChat(host: ChatPageHost, opts?: ChatRefreshOptions) {
     host.connected &&
     (startupMetadataRequestVersion === null ||
       host.chatMetadataRequestVersion === startupMetadataRequestVersion);
+  const parallelMetadataRefresh =
+    startupMetadataRequestVersion !== null &&
+    isGatewayMethodAdvertised(host as unknown as ChatState, "chat.metadata") !== false
+      ? refreshChatMetadata(host, {
+          fallbackMetadata: startupMetadataApplied,
+          requestVersion: startupMetadataRequestVersion,
+          onApplied: (applied) => {
+            parallelMetadataApplied = {
+              commands: parallelMetadataApplied.commands || applied.commands,
+              models: parallelMetadataApplied.models || applied.models,
+            };
+          },
+        })
+      : null;
+  if (parallelMetadataRefresh) {
+    void parallelMetadataRefresh.finally(() => host.requestUpdate?.());
+  }
   scheduleChatMetadataRefresh(() => {
     if (!ownsScheduledMetadataRefresh()) {
       return;
@@ -335,9 +385,13 @@ export function refreshPageChat(host: ChatPageHost, opts?: ChatRefreshOptions) {
         }
         await Promise.allSettled([
           refreshChatAvatar(host),
-          refreshChatMetadata(host, {
-            preserveModelCatalogOnFallback: opts?.startup === true && metadataApplied.models,
-          }),
+          ...(parallelMetadataRefresh
+            ? []
+            : [
+                refreshChatMetadata(host, {
+                  preserveModelCatalogOnFallback: opts?.startup === true && metadataApplied.models,
+                }),
+              ]),
         ]);
       })
       .finally(() => host.requestUpdate?.());


### PR DESCRIPTION
## What Problem This Solves

Switching sessions in the Control UI triggers a burst of RPCs whose server-side costs stack when serialized. Production averages on team.openclaw.ai: `chat.startup` 436ms, `sessions.branches.list` 341ms, `session.discussion.info` 312ms, `sessions.messages.subscribe` 292ms, `sessions.companion.state` 212ms, `chat.metadata` 137ms. With the previous await structure, secondary hydration gated on earlier calls, so perceived switch latency trended toward the sum (~1.7s) rather than the max (~450ms).

## Why This Change Was Made

Hydration is now split into a critical path and a deferred set:

- `chat.metadata` starts concurrently with `chat.startup` instead of after it, with coordination so startup-provided metadata and the parallel fetch cannot fight (including the compatible model/command fallback path in `chat-state-refresh.ts`).
- Discussion info, branch listing, companion state, and PR suggestions defer until after the transcript commits, so first render is gated only by the transcript-critical calls.
- Fast-switch safety keeps every existing per-surface version guard (history, branch, metadata, discussion, companion, PR); deferred work re-checks session and connection identity before applying, so a stale response can never clobber the newly selected session.

No server, protocol, or config changes.

## User Impact

Session switching renders the chat pane on the critical path only — roughly the slowest single call instead of the whole chain. Deferred panels hydrate immediately after, without blocking input.

## Evidence

- New regressions: reversed PR responses, stale deferred hydration, parallel startup metadata coordination, fallback ordering, same-client reconnects; hydration await-graph test proves `chat.metadata` starts while `chat.startup` is held open.
- Suites: chat metadata/state 281 passed; pane lifecycle 18; pane integration/discussion/PR 73; chat history 14; mocked-browser E2E on Testbox 1 passed (UI usable while `chat.startup` held open).
- Focused re-run post-handoff: hydration/lifecycle/PR/send suites green (1 shard). Type-aware oxlint clean; no new exports (knip-safe); no CHANGELOG edit.
- Autoreview (Codex `gpt-5.6-sol`, xhigh): three fallback/reconnect findings accepted and fixed during the work; final pass clean, "patch is correct (0.9)".
