### PR TITLE
build(ui): let control-ui baseline updates take CI-measured bytes

### DIFF
--- a/scripts/check-control-ui-performance.mjs
+++ b/scripts/check-control-ui-performance.mjs
@@ -14,7 +14,9 @@ const DEFAULT_STARTUP_BUDGET_BASELINE_PATH = path.resolve(
 );
 
 // This absorbs measured local-to-Linux gzip variance, but landed changes can
-// still consume the tolerance. The fixed JS ceiling bounds cumulative creep.
+// still consume the tolerance. Local zlib emits smaller streams than CI's Linux
+// builder, so baseline updates must use CI bytes via --startup-js-bytes. The
+// fixed JS ceiling bounds cumulative creep.
 export const CONTROL_UI_STARTUP_JS_GZIP_TOLERANCE_BYTES = 1024;
 
 // Small, explicit headroom over the optimized baseline. Budget changes should
@@ -179,7 +181,7 @@ function formatAssetSummary(summary) {
 
 function formatViolation(violation) {
   if (violation.baseline !== undefined && violation.tolerance !== undefined) {
-    return `${violation.metric}: ${violation.actual} B exceeds baseline ${violation.baseline} B + tolerance ${violation.tolerance} B (limit ${violation.limit} B); intentionally raise the baseline with node scripts/check-control-ui-performance.mjs --update-baseline --reason "<reason>"`;
+    return `${violation.metric}: ${violation.actual} B exceeds baseline ${violation.baseline} B + tolerance ${violation.tolerance} B (limit ${violation.limit} B); intentionally raise the baseline with node scripts/check-control-ui-performance.mjs --update-baseline --startup-js-bytes ${violation.actual} --reason "<reason>"`;
   }
   const actual =
     violation.unit === "bytes"
@@ -293,6 +295,15 @@ function writeControlUiStartupBudgetBaseline(baselinePath, startupJsGzipBytes, r
   return baseline;
 }
 
+function validateExplicitStartupJsBytes(startupJsBytes, currentBaseline) {
+  const delta = Math.abs(startupJsBytes - currentBaseline.startupJsGzipBytes);
+  if (delta > STARTUP_JS_BASELINE_RATCHET_BYTES) {
+    throw new Error(
+      `startup JS gzip baseline update: ${startupJsBytes} B differs from current baseline ${currentBaseline.startupJsGzipBytes} B by ${delta} B, exceeding the ${STARTUP_JS_BASELINE_RATCHET_BYTES} B ratchet`,
+    );
+  }
+}
+
 export function runControlUiPerformanceCheck(
   distDir,
   budgets = CONTROL_UI_PERFORMANCE_BUDGETS,
@@ -316,6 +327,7 @@ function main(argv = process.argv.slice(2)) {
   let json = false;
   let updateBaseline = false;
   let reason;
+  let startupJsBytes;
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
     if (arg === "--json") {
@@ -328,6 +340,16 @@ function main(argv = process.argv.slice(2)) {
         throw new Error("--reason requires a non-empty value");
       }
       index += 1;
+    } else if (arg === "--startup-js-bytes") {
+      const value = argv[index + 1];
+      if (!value || !/^[1-9]\d*$/u.test(value)) {
+        throw new Error("--startup-js-bytes requires a positive integer");
+      }
+      startupJsBytes = Number(value);
+      if (!Number.isSafeInteger(startupJsBytes)) {
+        throw new Error("--startup-js-bytes requires a positive integer");
+      }
+      index += 1;
     } else {
       throw new Error(`Unknown option: ${arg}`);
     }
@@ -335,15 +357,25 @@ function main(argv = process.argv.slice(2)) {
   if (reason !== undefined && !updateBaseline) {
     throw new Error("--reason requires --update-baseline");
   }
+  if (startupJsBytes !== undefined && !updateBaseline) {
+    throw new Error("--startup-js-bytes requires --update-baseline");
+  }
   if (json && updateBaseline) {
     throw new Error("--json cannot be combined with --update-baseline");
   }
   const distDir = path.resolve(SCRIPT_DIR, "../dist/control-ui");
   if (updateBaseline) {
-    const metrics = collectControlUiPerformanceMetrics(distDir);
+    if (startupJsBytes !== undefined) {
+      const currentBaseline = readControlUiStartupBudgetBaseline(
+        DEFAULT_STARTUP_BUDGET_BASELINE_PATH,
+      );
+      validateExplicitStartupJsBytes(startupJsBytes, currentBaseline);
+    }
+    const nextStartupJsBytes =
+      startupJsBytes ?? collectControlUiPerformanceMetrics(distDir).startup.js.gzipBytes;
     const baseline = writeControlUiStartupBudgetBaseline(
       DEFAULT_STARTUP_BUDGET_BASELINE_PATH,
-      metrics.startup.js.gzipBytes,
+      nextStartupJsBytes,
       reason ?? "manual baseline update",
     );
     process.stdout.write(

--- a/test/scripts/control-ui-performance.test.ts
+++ b/test/scripts/control-ui-performance.test.ts
@@ -215,7 +215,7 @@ describe("Control UI performance budgets", () => {
       ),
     ).toContain("startup JS gzip vs baseline");
     expect(formatControlUiPerformanceReport(metrics, looseBudgets, baseline)).toContain(
-      '11025 B exceeds baseline 10000 B + tolerance 1024 B (limit 11024 B); intentionally raise the baseline with node scripts/check-control-ui-performance.mjs --update-baseline --reason "<reason>"',
+      '11025 B exceeds baseline 10000 B + tolerance 1024 B (limit 11024 B); intentionally raise the baseline with node scripts/check-control-ui-performance.mjs --update-baseline --startup-js-bytes 11025 --reason "<reason>"',
     );
   });
 
@@ -258,7 +258,7 @@ describe("Control UI performance budgets", () => {
     );
   });
 
-  it("updates the baseline from exact current dist metrics without rebuilding", () => {
+  it("updates the baseline from local or explicit CI metrics", () => {
     const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-control-ui-budget-cli-"));
     tempDirs.push(rootDir);
     const scriptsDir = path.join(rootDir, "scripts");
@@ -312,6 +312,41 @@ describe("Control UI performance budgets", () => {
         fs.readFileSync(path.join(configDir, "control-ui-startup-budget-baseline.json"), "utf8"),
       ),
     ).toMatchObject({ startupJsGzipBytes: 65, reason: "fixture update" });
+
+    fs.rmSync(distDir, { recursive: true });
+    const explicitBytesResult = spawnSync(
+      process.execPath,
+      [
+        fs.realpathSync(scriptPath),
+        "--update-baseline",
+        "--startup-js-bytes",
+        "321",
+        "--reason",
+        "CI measurement",
+      ],
+      { cwd: rootDir, encoding: "utf8" },
+    );
+    expect(explicitBytesResult.status, explicitBytesResult.stderr).toBe(0);
+    expect(
+      JSON.parse(
+        fs.readFileSync(path.join(configDir, "control-ui-startup-budget-baseline.json"), "utf8"),
+      ),
+    ).toMatchObject({ startupJsGzipBytes: 321, reason: "CI measurement" });
+
+    const beyondRatchetResult = spawnSync(
+      process.execPath,
+      [fs.realpathSync(scriptPath), "--update-baseline", "--startup-js-bytes", "4418"],
+      { cwd: rootDir, encoding: "utf8" },
+    );
+    expect(beyondRatchetResult.status).toBe(1);
+    expect(beyondRatchetResult.stderr).toContain(
+      "4418 B differs from current baseline 321 B by 4097 B, exceeding the 4096 B ratchet",
+    );
+    expect(
+      JSON.parse(
+        fs.readFileSync(path.join(configDir, "control-ui-startup-budget-baseline.json"), "utf8"),
+      ),
+    ).toMatchObject({ startupJsGzipBytes: 321, reason: "CI measurement" });
   });
 
   it("fails when a compressed sidecar is missing", () => {


### PR DESCRIPTION
## What Problem This Solves

The Control UI startup-JS budget reads gzip byte sizes from precompressed `.gz` sidecars produced
during the build, so the measured value depends on the builder's zlib. A local macOS build of
identical source measures ~600 B lower than CI's Linux Node 24 build. The 1024 B tolerance exists
to absorb that variance — but `--update-baseline` recorded the *locally* measured value, so a
maintainer updating the baseline from their machine left CI sitting at or over the ceiling.

Observed consequence: the stale baseline surfaced as QA Smoke failures on an unrelated PR
(#113979, zero `ui/` files, 321300–321330 B vs a 321286 B ceiling), was nearly "fixed" by a second
locally-measured update that would have regressed the ceiling (#113992, closed), and was actually
fixed by a CI-measured value (#113981). Nothing prevented the next recurrence.

## Why This Change Was Made

Baseline updates can now be CI-sourced end to end:

- `--update-baseline` accepts `--startup-js-bytes <n>` to write an explicit value instead of the
  locally measured one. The value is validated as a positive safe integer and must stay within the
  existing 4096 B `STARTUP_JS_BASELINE_RATCHET_BYTES` of the current baseline, so the flag cannot
  be used to leap the ratchet. With an explicit value, no local dist build is needed at all.
- The CI violation message now emits a copy-pasteable command carrying its own measured bytes:
  `--update-baseline --startup-js-bytes <actual> --reason "<reason>"`. A maintainer fixes a stale
  baseline by pasting the line CI printed, not by measuring on a machine that measures differently.
- The local-vs-CI zlib trap is documented at the tolerance constant, where the next person will
  look.

No metric change, no tolerance change, no ratchet change, no baseline JSON shape change, and the
baseline value itself is untouched in this PR.

## User Impact

None at runtime; this is build-guard tooling. For maintainers, the failure message is now the fix.

## Evidence

    node scripts/run-vitest.mjs test/scripts/control-ui-performance.test.ts   11 passed, exit 0
    node scripts/check-changed.mjs                                            exit 0
    script declaration gate (check:script-declarations lane)                  covered, exit 0

New tests: explicit value within ratchet writes it; value beyond ratchet fails with the ratchet
error; `--startup-js-bytes` without `--update-baseline` fails; the violation message includes the
measured bytes.
