### PR TITLE
fix(telegram): recover startup identity for replayed updates

### DIFF
--- a/extensions/matrix/src/matrix/monitor/handler.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.test.ts
@@ -619,180 +619,126 @@ describe("matrix monitor handler pairing account scope", () => {
     expect(enqueueSystemEvent).not.toHaveBeenCalled();
   });
 
-  it("drops room messages from configured Matrix bot accounts when allowBots is off", async () => {
-    const { handler, recordInboundSession } = createMatrixHandlerTestHarness({
-      isDirectMessage: false,
-      configuredBotUserIds: new Set(["@ops:example.org"]),
-      roomsConfig: {
-        "!room:example.org": { requireMention: false },
-      },
-      getMemberDisplayName: async () => "ops-bot",
-    });
-
-    await handler(
-      "!room:example.org",
-      createMatrixTextMessageEvent({
-        eventId: "$bot-off",
-        sender: "@ops:example.org",
-        body: "hello from bot",
-      }),
-    );
-
-    expect(recordInboundSession).not.toHaveBeenCalled();
-  });
-
-  it("accepts room messages from configured Matrix bot accounts when allowBots is true", async () => {
-    const { handler, recordInboundSession, runPrepared } = createMatrixHandlerTestHarness({
-      isDirectMessage: false,
+  type MatrixBotPolicyCase = {
+    name: string;
+    eventId: string;
+    accepted: boolean;
+    accountAllowBots?: boolean | "mentions";
+    sender?: string;
+    directMessage?: boolean;
+    mention?: boolean;
+    roomDeniesBots?: boolean;
+    verifyBotLoopProtection?: boolean;
+  };
+  const matrixBotPolicyCases: MatrixBotPolicyCase[] = [
+    {
+      name: "drops room messages from configured Matrix bot accounts when allowBots is off",
+      eventId: "$bot-off",
+      accepted: false,
+    },
+    {
+      name: "accepts room messages from configured Matrix bot accounts when allowBots is true",
+      eventId: "$bot-on",
+      accepted: true,
       accountAllowBots: true,
-      accountConfig: { botLoopProtection: { windowSeconds: 120, cooldownSeconds: 240 } },
-      configuredBotUserIds: new Set(["@ops:example.org"]),
-      roomsConfig: {
-        "!room:example.org": {
-          requireMention: false,
-          botLoopProtection: { maxEventsPerWindow: 3 },
-        },
-      },
-      getMemberDisplayName: async () => "ops-bot",
-    });
-
-    await handler(
-      "!room:example.org",
-      createMatrixTextMessageEvent({
-        eventId: "$bot-on",
-        sender: "@ops:example.org",
-        body: "hello from bot",
-        originServerTs: 123_456,
-      }),
-    );
-
-    expect(recordInboundSession).toHaveBeenCalled();
-    expect(runPrepared.mock.calls[0]?.[0].ctxPayload.GroupRequireMention).toBe(false);
-    expect(runPrepared.mock.calls[0]?.[0].botLoopProtection).toEqual({
-      scopeId: "ops",
-      conversationId: "!room:example.org",
-      senderId: "@ops:example.org",
-      receiverId: "@bot:example.org",
-      config: { maxEventsPerWindow: 3, windowSeconds: 120, cooldownSeconds: 240 },
-      defaultsConfig: undefined,
-      defaultEnabled: true,
-      nowMs: 123_456,
-    });
-  });
-
-  it("does not treat unconfigured Matrix users as bots when allowBots is off", async () => {
-    const { handler, resolveAgentRoute, recordInboundSession } = createMatrixHandlerTestHarness({
-      isDirectMessage: false,
-      configuredBotUserIds: new Set(["@ops:example.org"]),
-      roomsConfig: {
-        "!room:example.org": { requireMention: false },
-      },
-      getMemberDisplayName: async () => "human",
-    });
-
-    await handler(
-      "!room:example.org",
-      createMatrixTextMessageEvent({
-        eventId: "$non-bot",
-        sender: "@alice:example.org",
-        body: "hello from human",
-      }),
-    );
-
-    expect(resolveAgentRoute).toHaveBeenCalled();
-    expect(recordInboundSession).toHaveBeenCalled();
-  });
-
-  it('drops configured Matrix bot room messages without a mention when allowBots="mentions"', async () => {
-    const { handler, recordInboundSession } = createMatrixHandlerTestHarness({
-      isDirectMessage: false,
+      verifyBotLoopProtection: true,
+    },
+    {
+      name: "does not treat unconfigured Matrix users as bots when allowBots is off",
+      eventId: "$non-bot",
+      accepted: true,
+      sender: "@alice:example.org",
+    },
+    {
+      name: 'drops configured Matrix bot room messages without a mention when allowBots="mentions"',
+      eventId: "$bot-mentions-off",
+      accepted: false,
       accountAllowBots: "mentions",
-      configuredBotUserIds: new Set(["@ops:example.org"]),
-      roomsConfig: {
-        "!room:example.org": { requireMention: false },
-      },
-      mentionRegexes: [/@bot/i],
-      getMemberDisplayName: async () => "ops-bot",
-    });
-
-    await handler(
-      "!room:example.org",
-      createMatrixTextMessageEvent({
-        eventId: "$bot-mentions-off",
-        sender: "@ops:example.org",
-        body: "hello from bot",
-      }),
-    );
-
-    expect(recordInboundSession).not.toHaveBeenCalled();
-  });
-
-  it('accepts configured Matrix bot room messages with a mention when allowBots="mentions"', async () => {
-    const { handler, recordInboundSession } = createMatrixHandlerTestHarness({
-      isDirectMessage: false,
+    },
+    {
+      name: 'accepts configured Matrix bot room messages with a mention when allowBots="mentions"',
+      eventId: "$bot-mentions-on",
+      accepted: true,
       accountAllowBots: "mentions",
-      configuredBotUserIds: new Set(["@ops:example.org"]),
-      roomsConfig: {
-        "!room:example.org": { requireMention: false },
-      },
-      mentionRegexes: [/@bot/i],
-      getMemberDisplayName: async () => "ops-bot",
-    });
-
-    await handler(
-      "!room:example.org",
-      createMatrixTextMessageEvent({
-        eventId: "$bot-mentions-on",
-        sender: "@ops:example.org",
-        body: "hello @bot",
-        mentions: { user_ids: ["@bot:example.org"] },
-      }),
-    );
-
-    expect(recordInboundSession).toHaveBeenCalled();
-  });
-
-  it('accepts configured Matrix bot DMs without a mention when allowBots="mentions"', async () => {
-    const { handler, recordInboundSession } = createMatrixHandlerTestHarness({
-      isDirectMessage: true,
+      mention: true,
+    },
+    {
+      name: 'accepts configured Matrix bot DMs without a mention when allowBots="mentions"',
+      eventId: "$bot-dm-mentions",
+      accepted: true,
       accountAllowBots: "mentions",
-      configuredBotUserIds: new Set(["@ops:example.org"]),
-      getMemberDisplayName: async () => "ops-bot",
-    });
-
-    await handler(
-      "!dm:example.org",
-      createMatrixTextMessageEvent({
-        eventId: "$bot-dm-mentions",
-        sender: "@ops:example.org",
-        body: "hello from dm bot",
-      }),
-    );
-
-    expect(recordInboundSession).toHaveBeenCalled();
-  });
-
-  it("lets room-level allowBots override a permissive account default", async () => {
-    const { handler, recordInboundSession } = createMatrixHandlerTestHarness({
-      isDirectMessage: false,
+      directMessage: true,
+    },
+    {
+      name: "lets room-level allowBots override a permissive account default",
+      eventId: "$bot-room-override",
+      accepted: false,
       accountAllowBots: true,
-      configuredBotUserIds: new Set(["@ops:example.org"]),
-      roomsConfig: {
-        "!room:example.org": { requireMention: false, allowBots: false },
-      },
-      getMemberDisplayName: async () => "ops-bot",
-    });
+      roomDeniesBots: true,
+    },
+  ];
+
+  it.each(matrixBotPolicyCases)("$name", async (testCase) => {
+    const { handler, recordInboundSession, resolveAgentRoute, runPrepared } =
+      createMatrixHandlerTestHarness({
+        isDirectMessage: testCase.directMessage ?? false,
+        ...(testCase.accountAllowBots !== undefined && {
+          accountAllowBots: testCase.accountAllowBots,
+        }),
+        ...(testCase.verifyBotLoopProtection && {
+          accountConfig: { botLoopProtection: { windowSeconds: 120, cooldownSeconds: 240 } },
+        }),
+        configuredBotUserIds: new Set(["@ops:example.org"]),
+        ...(!testCase.directMessage && {
+          roomsConfig: {
+            "!room:example.org": {
+              requireMention: false,
+              ...(testCase.roomDeniesBots && { allowBots: false }),
+              ...(testCase.verifyBotLoopProtection && {
+                botLoopProtection: { maxEventsPerWindow: 3 },
+              }),
+            },
+          },
+        }),
+        ...(testCase.accountAllowBots === "mentions" &&
+          !testCase.directMessage && { mentionRegexes: [/@bot/i] }),
+        getMemberDisplayName: async () => (testCase.sender ? "human" : "ops-bot"),
+      });
 
     await handler(
-      "!room:example.org",
+      testCase.directMessage ? "!dm:example.org" : "!room:example.org",
       createMatrixTextMessageEvent({
-        eventId: "$bot-room-override",
-        sender: "@ops:example.org",
-        body: "hello from bot",
+        eventId: testCase.eventId,
+        sender: testCase.sender ?? "@ops:example.org",
+        body: testCase.sender
+          ? "hello from human"
+          : testCase.mention
+            ? "hello @bot"
+            : testCase.directMessage
+              ? "hello from dm bot"
+              : "hello from bot",
+        ...(testCase.mention && { mentions: { user_ids: ["@bot:example.org"] } }),
+        ...(testCase.verifyBotLoopProtection && { originServerTs: 123_456 }),
       }),
     );
 
-    expect(recordInboundSession).not.toHaveBeenCalled();
+    expect(recordInboundSession).toHaveBeenCalledTimes(testCase.accepted ? 1 : 0);
+    if (testCase.sender) {
+      expect(resolveAgentRoute).toHaveBeenCalled();
+    }
+    if (testCase.verifyBotLoopProtection) {
+      expect(runPrepared.mock.calls[0]?.[0].ctxPayload.GroupRequireMention).toBe(false);
+      expect(runPrepared.mock.calls[0]?.[0].botLoopProtection).toEqual({
+        scopeId: "ops",
+        conversationId: "!room:example.org",
+        senderId: "@ops:example.org",
+        receiverId: "@bot:example.org",
+        config: { maxEventsPerWindow: 3, windowSeconds: 120, cooldownSeconds: 240 },
+        defaultsConfig: undefined,
+        defaultEnabled: true,
+        nowMs: 123_456,
+      });
+    }
   });
 
   it("blocks room control commands from DM-only paired senders", async () => {
@@ -2128,186 +2074,113 @@ describe("matrix monitor handler live allowlist reload", () => {
       ([params]) => JSON.stringify((params.entries ?? []).map(String)) === JSON.stringify(entries),
     ).length;
 
-  it("accepts a DM sender added to live dm.allowFrom", async () => {
+  const liveDmAllowlistCases: Array<{
+    name: string;
+    event: string;
+    initialAllowFrom: string[];
+    updatedAllowFrom: string[];
+    expectedBefore: number;
+    expectedAfter: number;
+    accountScoped?: boolean;
+    startupDisplayName?: boolean;
+  }> = [
+    {
+      name: "accepts a DM sender added to live dm.allowFrom",
+      event: "add",
+      initialAllowFrom: [],
+      updatedAllowFrom: ["@alice:example.org"],
+      expectedBefore: 0,
+      expectedAfter: 1,
+    },
+    {
+      name: "blocks a DM sender removed from live dm.allowFrom",
+      event: "remove",
+      initialAllowFrom: ["@alice:example.org"],
+      updatedAllowFrom: [],
+      expectedBefore: 1,
+      expectedAfter: 1,
+    },
+    {
+      name: "blocks a DM sender after live wildcard removal",
+      event: "wildcard",
+      initialAllowFrom: ["*"],
+      updatedAllowFrom: [],
+      expectedBefore: 1,
+      expectedAfter: 1,
+    },
+    {
+      name: "uses account-scoped live dm.allowFrom overrides",
+      event: "account",
+      initialAllowFrom: ["@alice:example.org"],
+      updatedAllowFrom: [],
+      expectedBefore: 1,
+      expectedAfter: 1,
+      accountScoped: true,
+    },
+    {
+      name: "keeps startup-resolved display names only while the raw input remains configured",
+      event: "name",
+      initialAllowFrom: ["Alice"],
+      updatedAllowFrom: [],
+      expectedBefore: 1,
+      expectedAfter: 1,
+      startupDisplayName: true,
+    },
+  ];
+
+  it.each(liveDmAllowlistCases)("$name", async (testCase) => {
     const dispatchInboundMessage = createDispatchInboundMessage();
     const cfg = {
       channels: {
         matrix: {
-          dm: { allowFrom: [] as string[] },
-        },
-      },
-    };
-    const { handler } = createMatrixHandlerTestHarness({
-      cfg,
-      dmPolicy: "allowlist",
-      isDirectMessage: true,
-      allowFrom: [],
-      allowFromResolvedEntries: [],
-      dispatchInboundMessage,
-    });
-
-    await sendLiveAllowlistMessage(handler, {
-      eventId: "$dm-add-before",
-      sender: "@alice:example.org",
-      body: "hello",
-    });
-    expect(dispatchInboundMessage).not.toHaveBeenCalled();
-
-    cfg.channels.matrix.dm.allowFrom = ["@alice:example.org"];
-    await sendLiveAllowlistMessage(handler, {
-      eventId: "$dm-add-after",
-      sender: "@alice:example.org",
-      body: "hello again",
-    });
-
-    expect(dispatchInboundMessage).toHaveBeenCalledTimes(1);
-  });
-
-  it("blocks a DM sender removed from live dm.allowFrom", async () => {
-    const dispatchInboundMessage = createDispatchInboundMessage();
-    const cfg = {
-      channels: {
-        matrix: {
-          dm: { allowFrom: ["@alice:example.org"] },
-        },
-      },
-    };
-    const { handler } = createMatrixHandlerTestHarness({
-      cfg,
-      dmPolicy: "allowlist",
-      isDirectMessage: true,
-      allowFrom: ["@alice:example.org"],
-      allowFromResolvedEntries: [{ input: "@alice:example.org", id: "@alice:example.org" }],
-      dispatchInboundMessage,
-    });
-
-    await sendLiveAllowlistMessage(handler, {
-      eventId: "$dm-remove-before",
-      sender: "@alice:example.org",
-      body: "hello",
-    });
-    expect(dispatchInboundMessage).toHaveBeenCalledTimes(1);
-
-    cfg.channels.matrix.dm.allowFrom = [];
-    await sendLiveAllowlistMessage(handler, {
-      eventId: "$dm-remove-after",
-      sender: "@alice:example.org",
-      body: "hello again",
-    });
-
-    expect(dispatchInboundMessage).toHaveBeenCalledTimes(1);
-  });
-
-  it("blocks a DM sender after live wildcard removal", async () => {
-    const dispatchInboundMessage = createDispatchInboundMessage();
-    const cfg = {
-      channels: {
-        matrix: {
-          dm: { allowFrom: ["*"] },
-        },
-      },
-    };
-    const { handler } = createMatrixHandlerTestHarness({
-      cfg,
-      dmPolicy: "allowlist",
-      isDirectMessage: true,
-      allowFrom: ["*"],
-      allowFromResolvedEntries: [],
-      dispatchInboundMessage,
-    });
-
-    await sendLiveAllowlistMessage(handler, {
-      eventId: "$dm-wildcard-before",
-      sender: "@alice:example.org",
-      body: "hello",
-    });
-    expect(dispatchInboundMessage).toHaveBeenCalledTimes(1);
-
-    cfg.channels.matrix.dm.allowFrom = [];
-    await sendLiveAllowlistMessage(handler, {
-      eventId: "$dm-wildcard-after",
-      sender: "@alice:example.org",
-      body: "hello again",
-    });
-
-    expect(dispatchInboundMessage).toHaveBeenCalledTimes(1);
-  });
-
-  it("uses account-scoped live dm.allowFrom overrides", async () => {
-    const dispatchInboundMessage = createDispatchInboundMessage();
-    const cfg = {
-      channels: {
-        matrix: {
-          dm: { allowFrom: ["@base:example.org"] },
-          accounts: {
-            ops: {
-              dm: { allowFrom: ["@alice:example.org"] },
-            },
+          ...(testCase.startupDisplayName && { dangerouslyAllowNameMatching: true }),
+          dm: {
+            allowFrom: testCase.accountScoped
+              ? ["@base:example.org"]
+              : [...testCase.initialAllowFrom],
           },
+          ...(testCase.accountScoped && {
+            accounts: { ops: { dm: { allowFrom: [...testCase.initialAllowFrom] } } },
+          }),
         },
       },
     };
+    const startupAllowFrom = testCase.startupDisplayName
+      ? ["@alice:example.org"]
+      : testCase.initialAllowFrom;
     const { handler } = createMatrixHandlerTestHarness({
       cfg,
-      accountId: "ops",
+      ...(testCase.accountScoped && { accountId: "ops" }),
       dmPolicy: "allowlist",
       isDirectMessage: true,
-      allowFrom: ["@alice:example.org"],
-      allowFromResolvedEntries: [{ input: "@alice:example.org", id: "@alice:example.org" }],
+      allowFrom: startupAllowFrom,
+      allowFromResolvedEntries: testCase.initialAllowFrom
+        .filter((entry) => entry !== "*")
+        .map((input) => ({ input, id: "@alice:example.org" })),
       dispatchInboundMessage,
     });
 
     await sendLiveAllowlistMessage(handler, {
-      eventId: "$dm-account-before",
+      eventId: `$dm-${testCase.event}-before`,
       sender: "@alice:example.org",
       body: "hello",
     });
-    expect(dispatchInboundMessage).toHaveBeenCalledTimes(1);
+    expect(dispatchInboundMessage).toHaveBeenCalledTimes(testCase.expectedBefore);
 
-    cfg.channels.matrix.accounts.ops.dm.allowFrom = [];
+    const liveDm = testCase.accountScoped
+      ? cfg.channels.matrix.accounts?.ops.dm
+      : cfg.channels.matrix.dm;
+    if (!liveDm) {
+      throw new Error("expected account-scoped Matrix DM configuration");
+    }
+    liveDm.allowFrom = testCase.updatedAllowFrom;
     await sendLiveAllowlistMessage(handler, {
-      eventId: "$dm-account-after",
+      eventId: `$dm-${testCase.event}-after`,
       sender: "@alice:example.org",
       body: "hello again",
     });
 
-    expect(dispatchInboundMessage).toHaveBeenCalledTimes(1);
-  });
-
-  it("keeps startup-resolved display names only while the raw input remains configured", async () => {
-    const dispatchInboundMessage = createDispatchInboundMessage();
-    const cfg = {
-      channels: {
-        matrix: {
-          dangerouslyAllowNameMatching: true,
-          dm: { allowFrom: ["Alice"] },
-        },
-      },
-    };
-    const { handler } = createMatrixHandlerTestHarness({
-      cfg,
-      dmPolicy: "allowlist",
-      isDirectMessage: true,
-      allowFrom: ["@alice:example.org"],
-      allowFromResolvedEntries: [{ input: "Alice", id: "@alice:example.org" }],
-      dispatchInboundMessage,
-    });
-
-    await sendLiveAllowlistMessage(handler, {
-      eventId: "$dm-name-before",
-      sender: "@alice:example.org",
-      body: "hello",
-    });
-    expect(dispatchInboundMessage).toHaveBeenCalledTimes(1);
-
-    cfg.channels.matrix.dm.allowFrom = [];
-    await sendLiveAllowlistMessage(handler, {
-      eventId: "$dm-name-after",
-      sender: "@alice:example.org",
-      body: "hello again",
-    });
-
-    expect(dispatchInboundMessage).toHaveBeenCalledTimes(1);
+    expect(dispatchInboundMessage).toHaveBeenCalledTimes(testCase.expectedAfter);
   });
 
   it("accepts a DM sender added as a live-resolved display name", async () => {
@@ -2359,7 +2232,20 @@ describe("matrix monitor handler live allowlist reload", () => {
     expect(dispatchInboundMessage).toHaveBeenCalledTimes(1);
   });
 
-  it("refreshes cached live display-name allowlists when name matching is disabled", async () => {
+  it.each([
+    {
+      name: "refreshes cached live display-name allowlists when name matching is disabled",
+      event: "disable",
+      initiallyEnabled: true,
+      expectedBefore: 1,
+    },
+    {
+      name: "refreshes cached live display-name allowlists when name matching is enabled",
+      event: "enable",
+      initiallyEnabled: false,
+      expectedBefore: 0,
+    },
+  ])("$name", async ({ event, initiallyEnabled, expectedBefore }) => {
     const dispatchInboundMessage = createDispatchInboundMessage();
     const resolveLiveUserAllowlist = vi.fn(async (params: LiveNameMatchingResolveParams) =>
       isLiveNameMatchingEnabled(params.cfg) ? ["@alice:example.org"] : [],
@@ -2367,7 +2253,7 @@ describe("matrix monitor handler live allowlist reload", () => {
     const cfg = {
       channels: {
         matrix: {
-          dangerouslyAllowNameMatching: true,
+          dangerouslyAllowNameMatching: initiallyEnabled,
           dm: { allowFrom: ["Alice"] },
         },
       },
@@ -2383,58 +2269,15 @@ describe("matrix monitor handler live allowlist reload", () => {
     });
 
     await sendLiveAllowlistMessage(handler, {
-      eventId: "$dm-live-name-disable-before",
+      eventId: `$dm-live-name-${event}-before`,
       sender: "@alice:example.org",
       body: "hello",
     });
-    expect(dispatchInboundMessage).toHaveBeenCalledTimes(1);
+    expect(dispatchInboundMessage).toHaveBeenCalledTimes(expectedBefore);
 
-    cfg.channels.matrix.dangerouslyAllowNameMatching = false;
+    cfg.channels.matrix.dangerouslyAllowNameMatching = !initiallyEnabled;
     await sendLiveAllowlistMessage(handler, {
-      eventId: "$dm-live-name-disable-after",
-      sender: "@alice:example.org",
-      body: "hello again",
-    });
-
-    expect(countLiveAllowlistCallsForEntries(resolveLiveUserAllowlist.mock.calls, ["Alice"])).toBe(
-      2,
-    );
-    expect(dispatchInboundMessage).toHaveBeenCalledTimes(1);
-  });
-
-  it("refreshes cached live display-name allowlists when name matching is enabled", async () => {
-    const dispatchInboundMessage = createDispatchInboundMessage();
-    const resolveLiveUserAllowlist = vi.fn(async (params: LiveNameMatchingResolveParams) =>
-      isLiveNameMatchingEnabled(params.cfg) ? ["@alice:example.org"] : [],
-    );
-    const cfg = {
-      channels: {
-        matrix: {
-          dangerouslyAllowNameMatching: false,
-          dm: { allowFrom: ["Alice"] },
-        },
-      },
-    };
-    const { handler } = createMatrixHandlerTestHarness({
-      cfg,
-      dmPolicy: "allowlist",
-      isDirectMessage: true,
-      allowFrom: [],
-      allowFromResolvedEntries: [],
-      dispatchInboundMessage,
-      resolveLiveUserAllowlist,
-    });
-
-    await sendLiveAllowlistMessage(handler, {
-      eventId: "$dm-live-name-enable-before",
-      sender: "@alice:example.org",
-      body: "hello",
-    });
-    expect(dispatchInboundMessage).not.toHaveBeenCalled();
-
-    cfg.channels.matrix.dangerouslyAllowNameMatching = true;
-    await sendLiveAllowlistMessage(handler, {
-      eventId: "$dm-live-name-enable-after",
+      eventId: `$dm-live-name-${event}-after`,
       sender: "@alice:example.org",
       body: "hello again",
     });

--- a/extensions/telegram/src/bot-handlers.message-events.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.message-events.runtime.ts
@@ -22,7 +22,7 @@ import type { TelegramContext, TelegramGetChat } from "./bot/types.js";
 import type { TelegramMessageDispatchReplayClaim } from "./message-dispatch-dedupe.js";
 
 export function registerTelegramMessageHandlers(
-  { bot, runtime, shouldSkipUpdate }: RegisterTelegramHandlerParams,
+  { bot, opts, runtime, shouldSkipUpdate }: RegisterTelegramHandlerParams,
   messageRuntime: TelegramHandlerMessageRuntime,
   authorizationRuntime: TelegramHandlerAuthorizationRuntime,
   inboundRuntime: TelegramHandlerInboundRuntime,
@@ -40,6 +40,10 @@ export function registerTelegramMessageHandlers(
   const { authorizeInboundMessage } = authorizationRuntime;
   const { processInboundMessage } = inboundRuntime;
   const getChat: TelegramGetChat = bot.api.getChat.bind(bot.api);
+  // Replayed updates may omit grammY's per-update identity. Keep all message,
+  // edit, and channel-post paths on the bot's authenticated startup identity.
+  const resolveBotUserId = (ctx: TelegramContext) =>
+    ctx.me?.id ?? opts.botInfo?.id ?? bot.botInfo.id;
   type InboundTelegramEvent = {
     ctxForDedupe: TelegramUpdateKeyContext;
     ctx: TelegramContext;
@@ -247,15 +251,16 @@ export function registerTelegramMessageHandlers(
       getChat,
     });
     const normalizedMsg = withResolvedTelegramForumFlag(msg, isForum);
+    const botUserId = resolveBotUserId(ctx);
     // Bot-authored message updates can be echoed back by Telegram. Skip them here
     // and rely on the dedicated channel_post handler for channel-originated posts.
-    if (normalizedMsg.from?.id != null && normalizedMsg.from.id === ctx.me?.id) {
+    if (normalizedMsg.from?.id != null && normalizedMsg.from.id === botUserId) {
       return;
     }
     await handleInboundMessageLike({
       ctxForDedupe: ctx,
       ctx: buildSyntheticContext(ctx, normalizedMsg),
-      botUserId: ctx.me.id,
+      botUserId,
       msg: normalizedMsg,
       chatId: normalizedMsg.chat.id,
       isGroup,
@@ -279,7 +284,7 @@ export function registerTelegramMessageHandlers(
       ctxForDedupe: ctx,
       msg,
       requireConfiguredGroup: false,
-      botUserId: ctx.me.id,
+      botUserId: resolveBotUserId(ctx),
     });
   });
 
@@ -298,7 +303,7 @@ export function registerTelegramMessageHandlers(
     await handleInboundMessageLike({
       ctxForDedupe: ctx,
       ctx: buildSyntheticContext(ctx, syntheticMsg),
-      botUserId: ctx.me.id,
+      botUserId: resolveBotUserId(ctx),
       msg: syntheticMsg,
       chatId,
       isGroup: true,
@@ -326,7 +331,7 @@ export function registerTelegramMessageHandlers(
       ctxForDedupe: ctx,
       msg: normalizeChannelPostMessage(post),
       requireConfiguredGroup: true,
-      botUserId: ctx.me.id,
+      botUserId: resolveBotUserId(ctx),
     });
   });
 }

--- a/extensions/telegram/src/bot-handlers.message-events.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.message-events.runtime.ts
@@ -42,7 +42,7 @@ export function registerTelegramMessageHandlers(
   const getChat: TelegramGetChat = bot.api.getChat.bind(bot.api);
   // Replayed updates may omit grammY's per-update identity. Keep all message,
   // edit, and channel-post paths on the bot's authenticated startup identity.
-  const resolveBotUserId = (ctx: TelegramContext) =>
+  const resolveBotUserId = (ctx: { me?: { id: number } }) =>
     ctx.me?.id ?? opts.botInfo?.id ?? bot.botInfo.id;
   type InboundTelegramEvent = {
     ctxForDedupe: TelegramUpdateKeyContext;

--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -638,6 +638,23 @@ describe("createTelegramBot", () => {
       });
   });
 
+  function createTelegramApprovalBot(
+    approvers: string[] = ["9"],
+    overrides: Record<string, unknown> = {},
+  ) {
+    loadConfig.mockReturnValue({
+      channels: {
+        telegram: {
+          dmPolicy: "open",
+          allowFrom: ["*"],
+          ...overrides,
+          execApprovals: { enabled: true, approvers, target: "dm" },
+        },
+      },
+    });
+    createTelegramBot({ token: "tok" });
+  }
+
   it("starts with retired includeGroupHistoryContext still present in raw config", async () => {
     loadConfig.mockReturnValue({
       messages: { groupChat: { unmentionedInbound: "room_event" } },
@@ -1230,20 +1247,7 @@ describe("createTelegramBot", () => {
     editMessageTextSpy.mockClear();
     resolveExecApprovalSpy.mockClear();
 
-    loadConfig.mockReturnValue({
-      channels: {
-        telegram: {
-          dmPolicy: "open",
-          allowFrom: ["*"],
-          execApprovals: {
-            enabled: true,
-            approvers: ["9"],
-            target: "dm",
-          },
-        },
-      },
-    });
-    createTelegramBot({ token: "tok" });
+    createTelegramApprovalBot();
     const callbackHandler = getTelegramCallbackHandlerForTests();
 
     await callbackHandler(
@@ -1302,22 +1306,7 @@ describe("createTelegramBot", () => {
     editMessageReplyMarkupSpy.mockClear();
     editMessageTextSpy.mockClear();
 
-    loadConfig.mockReturnValue({
-      channels: {
-        telegram: {
-          botToken: "tok",
-          dmPolicy: "open",
-          allowFrom: ["*"],
-          capabilities: ["vision"],
-          execApprovals: {
-            enabled: true,
-            approvers: ["9"],
-            target: "dm",
-          },
-        },
-      },
-    });
-    createTelegramBot({ token: "tok" });
+    createTelegramApprovalBot(["9"], { botToken: "tok", capabilities: ["vision"] });
     const callbackHandler = getTelegramCallbackHandlerForTests();
 
     await callbackHandler(
@@ -1358,20 +1347,7 @@ describe("createTelegramBot", () => {
       },
     });
 
-    loadConfig.mockReturnValue({
-      channels: {
-        telegram: {
-          dmPolicy: "open",
-          allowFrom: ["*"],
-          execApprovals: {
-            enabled: true,
-            approvers: ["9"],
-            target: "dm",
-          },
-        },
-      },
-    });
-    createTelegramBot({ token: "tok" });
+    createTelegramApprovalBot();
     const callbackHandler = getTelegramCallbackHandlerForTests();
     const callbackData = buildTelegramApprovalCallbackData({
       type: "approval",
@@ -1441,20 +1417,7 @@ describe("createTelegramBot", () => {
       },
     });
 
-    loadConfig.mockReturnValue({
-      channels: {
-        telegram: {
-          dmPolicy: "open",
-          allowFrom: ["*"],
-          execApprovals: {
-            enabled: true,
-            approvers: ["9"],
-            target: "dm",
-          },
-        },
-      },
-    });
-    createTelegramBot({ token: "tok" });
+    createTelegramApprovalBot();
     const callbackData = buildTelegramApprovalCallbackData({
       type: "approval",
       approvalId: "fallback-receipt-id",
@@ -1513,20 +1476,7 @@ describe("createTelegramBot", () => {
       handler: pluginHandler as never,
     });
 
-    loadConfig.mockReturnValue({
-      channels: {
-        telegram: {
-          dmPolicy: "open",
-          allowFrom: ["*"],
-          execApprovals: {
-            enabled: true,
-            approvers: ["9"],
-            target: "dm",
-          },
-        },
-      },
-    });
-    createTelegramBot({ token: "tok" });
+    createTelegramApprovalBot();
 
     await getTelegramCallbackHandlerForTests()({
       callbackQuery: {
@@ -1586,20 +1536,7 @@ describe("createTelegramBot", () => {
       },
     });
 
-    loadConfig.mockReturnValue({
-      channels: {
-        telegram: {
-          dmPolicy: "open",
-          allowFrom: ["*"],
-          execApprovals: {
-            enabled: true,
-            approvers: ["9"],
-            target: "dm",
-          },
-        },
-      },
-    });
-    createTelegramBot({ token: "tok" });
+    createTelegramApprovalBot();
 
     await getTelegramCallbackHandlerForTests()({
       callbackQuery: {
@@ -1649,20 +1586,7 @@ describe("createTelegramBot", () => {
       .mockRejectedValueOnce(alreadyResolved)
       .mockRejectedValueOnce(new Error("unknown or expired approval id"));
 
-    loadConfig.mockReturnValue({
-      channels: {
-        telegram: {
-          dmPolicy: "open",
-          allowFrom: ["*"],
-          execApprovals: {
-            enabled: true,
-            approvers: ["9"],
-            target: "dm",
-          },
-        },
-      },
-    });
-    createTelegramBot({ token: "tok" });
+    createTelegramApprovalBot();
 
     await getTelegramCallbackHandlerForTests()({
       callbackQuery: {
@@ -1705,20 +1629,7 @@ describe("createTelegramBot", () => {
       .mockRejectedValueOnce(alreadyResolved)
       .mockRejectedValueOnce(new Error("gateway unavailable"));
 
-    loadConfig.mockReturnValue({
-      channels: {
-        telegram: {
-          dmPolicy: "open",
-          allowFrom: ["*"],
-          execApprovals: {
-            enabled: true,
-            approvers: ["9"],
-            target: "dm",
-          },
-        },
-      },
-    });
-    createTelegramBot({ token: "tok" });
+    createTelegramApprovalBot();
 
     await expect(
       getTelegramCallbackHandlerForTests()({
@@ -1751,20 +1662,7 @@ describe("createTelegramBot", () => {
     resolveExecApprovalSpy.mockClear();
     resolveExecApprovalSpy.mockRejectedValueOnce(new Error("unknown or expired approval id"));
 
-    loadConfig.mockReturnValue({
-      channels: {
-        telegram: {
-          dmPolicy: "open",
-          allowFrom: ["*"],
-          execApprovals: {
-            enabled: true,
-            approvers: ["9"],
-            target: "dm",
-          },
-        },
-      },
-    });
-    createTelegramBot({ token: "tok" });
+    createTelegramApprovalBot();
     const callbackHandler = getTelegramCallbackHandlerForTests();
 
     await callbackHandler(
@@ -1809,20 +1707,7 @@ describe("createTelegramBot", () => {
     editMessageReplyMarkupSpy.mockClear();
     resolveExecApprovalSpy.mockClear();
 
-    loadConfig.mockReturnValue({
-      channels: {
-        telegram: {
-          dmPolicy: "open",
-          allowFrom: ["*"],
-          execApprovals: {
-            enabled: true,
-            approvers: ["9"],
-            target: "dm",
-          },
-        },
-      },
-    });
-    createTelegramBot({ token: "tok" });
+    createTelegramApprovalBot();
     const callbackHandler = getTelegramCallbackHandlerForTests();
 
     await callbackHandler(
@@ -1844,20 +1729,7 @@ describe("createTelegramBot", () => {
     editMessageTextSpy.mockClear();
     resolveExecApprovalSpy.mockClear();
 
-    loadConfig.mockReturnValue({
-      channels: {
-        telegram: {
-          dmPolicy: "open",
-          allowFrom: ["*"],
-          execApprovals: {
-            enabled: true,
-            approvers: ["999"],
-            target: "dm",
-          },
-        },
-      },
-    });
-    createTelegramBot({ token: "tok" });
+    createTelegramApprovalBot(["999"]);
     const callbackHandler = getTelegramCallbackHandlerForTests();
 
     await callbackHandler(
@@ -1881,20 +1753,7 @@ describe("createTelegramBot", () => {
     resolveExecApprovalSpy.mockClear();
     resolveExecApprovalSpy.mockRejectedValueOnce(new Error("gateway secret detail"));
 
-    loadConfig.mockReturnValue({
-      channels: {
-        telegram: {
-          dmPolicy: "open",
-          allowFrom: ["*"],
-          execApprovals: {
-            enabled: true,
-            approvers: ["9"],
-            target: "dm",
-          },
-        },
-      },
-    });
-    createTelegramBot({ token: "tok" });
+    createTelegramApprovalBot();
     const callbackHandler = getTelegramCallbackHandlerForTests();
 
     await expect(
@@ -2025,20 +1884,7 @@ describe("createTelegramBot", () => {
       .mockRejectedValueOnce(new Error("unknown or expired approval id"))
       .mockRejectedValueOnce(new Error("unknown or expired approval id"));
 
-    loadConfig.mockReturnValue({
-      channels: {
-        telegram: {
-          dmPolicy: "open",
-          allowFrom: ["*"],
-          execApprovals: {
-            enabled: true,
-            approvers: ["9"],
-            target: "dm",
-          },
-        },
-      },
-    });
-    createTelegramBot({ token: "tok" });
+    createTelegramApprovalBot();
     const callbackHandler = getTelegramCallbackHandlerForTests();
 
     await callbackHandler(
@@ -6272,223 +6118,108 @@ describe("createTelegramBot", () => {
     expect(enqueueSystemEventSpy).toHaveBeenCalledTimes(expectedEnqueueCalls);
   });
 
-  it("skips reaction when reactionNotifications is off", async () => {
-    onSpy.mockClear();
-    enqueueSystemEventSpy.mockClear();
-    wasSentByBot.mockReturnValue(true);
-
-    loadConfig.mockReturnValue({
-      channels: {
-        telegram: { dmPolicy: "open", reactionNotifications: "off" },
-      },
-    });
-
-    createTelegramBot({ token: "tok" });
-    const handler = getOnHandler("message_reaction") as (
-      ctx: Record<string, unknown>,
-    ) => Promise<void>;
-
-    await handler({
-      update: { update_id: 501 },
-      messageReaction: {
-        chat: { id: 1234, type: "private" },
-        message_id: 42,
-        user: { id: 9, first_name: "Ada" },
-        date: 1736380800,
-        old_reaction: [],
-        new_reaction: [{ type: "emoji", emoji: THUMBS_UP_EMOJI }],
-      },
-    });
-
-    expect(enqueueSystemEventSpy).not.toHaveBeenCalled();
-  });
-
-  it("defaults reactionNotifications to own", async () => {
-    onSpy.mockClear();
-    enqueueSystemEventSpy.mockClear();
-    wasSentByBot.mockReturnValue(true);
-
-    loadConfig.mockReturnValue({
-      channels: {
-        telegram: { dmPolicy: "open", allowFrom: ["*"] },
-      },
-    });
-
-    createTelegramBot({ token: "tok" });
-    const handler = getOnHandler("message_reaction") as (
-      ctx: Record<string, unknown>,
-    ) => Promise<void>;
-
-    await handler({
-      update: { update_id: 502 },
-      messageReaction: {
-        chat: { id: 1234, type: "private" },
-        message_id: 43,
-        user: { id: 9, first_name: "Ada" },
-        date: 1736380800,
-        old_reaction: [],
-        new_reaction: [{ type: "emoji", emoji: THUMBS_UP_EMOJI }],
-      },
-    });
-
-    expect(enqueueSystemEventSpy).toHaveBeenCalledTimes(1);
-  });
-
-  it("allows reaction in all mode regardless of message sender", async () => {
-    onSpy.mockClear();
-    enqueueSystemEventSpy.mockClear();
-    wasSentByBot.mockReturnValue(false);
-
-    loadConfig.mockReturnValue({
-      channels: {
-        telegram: { dmPolicy: "open", allowFrom: ["*"], reactionNotifications: "all" },
-      },
-    });
-
-    createTelegramBot({ token: "tok" });
-    const handler = getOnHandler("message_reaction") as (
-      ctx: Record<string, unknown>,
-    ) => Promise<void>;
-
-    await handler({
-      update: { update_id: 503 },
-      messageReaction: {
-        chat: { id: 1234, type: "private" },
+  it.each([
+    {
+      name: "skips reaction when reactionNotifications is off",
+      updateId: 501,
+      channelConfig: { dmPolicy: "open", reactionNotifications: "off" },
+      sentByBot: true,
+      expectedEnqueueCalls: 0,
+    },
+    {
+      name: "defaults reactionNotifications to own",
+      updateId: 502,
+      channelConfig: { dmPolicy: "open", allowFrom: ["*"] },
+      sentByBot: true,
+      reaction: { message_id: 43 },
+      expectedEnqueueCalls: 1,
+    },
+    {
+      name: "allows reaction in all mode regardless of message sender",
+      updateId: 503,
+      channelConfig: { dmPolicy: "open", allowFrom: ["*"], reactionNotifications: "all" },
+      sentByBot: false,
+      reaction: {
         message_id: 99,
-        user: { id: 9, first_name: "Ada" },
-        date: 1736380800,
-        old_reaction: [],
         new_reaction: [{ type: "emoji", emoji: PARTY_EMOJI }],
       },
-    });
-
-    expect(enqueueSystemEventSpy).toHaveBeenCalledTimes(1);
-    expect(firstSystemEventArg(0)).toBe(`Telegram reaction added: ${PARTY_EMOJI} by Ada on msg 99`);
-    expect(firstSystemEventArg(1)).toBeTypeOf("object");
-  });
-
-  it("skips reaction in own mode when message is not sent by bot", async () => {
-    onSpy.mockClear();
-    enqueueSystemEventSpy.mockClear();
-    wasSentByBot.mockReturnValue(false);
-
-    loadConfig.mockReturnValue({
-      channels: {
-        telegram: { dmPolicy: "open", allowFrom: ["*"], reactionNotifications: "own" },
-      },
-    });
-
-    createTelegramBot({ token: "tok" });
-    const handler = getOnHandler("message_reaction") as (
-      ctx: Record<string, unknown>,
-    ) => Promise<void>;
-
-    await handler({
-      update: { update_id: 503 },
-      messageReaction: {
-        chat: { id: 1234, type: "private" },
+      expectedEnqueueCalls: 1,
+      expectedMessage: `Telegram reaction added: ${PARTY_EMOJI} by Ada on msg 99`,
+    },
+    {
+      name: "skips reaction in own mode when message is not sent by bot",
+      updateId: 503,
+      channelConfig: { dmPolicy: "open", allowFrom: ["*"], reactionNotifications: "own" },
+      sentByBot: false,
+      reaction: {
         message_id: 99,
-        user: { id: 9, first_name: "Ada" },
-        date: 1736380800,
-        old_reaction: [],
         new_reaction: [{ type: "emoji", emoji: PARTY_EMOJI }],
       },
-    });
-
-    expect(enqueueSystemEventSpy).not.toHaveBeenCalled();
-  });
-
-  it("allows reaction in own mode when message is sent by bot", async () => {
-    onSpy.mockClear();
-    enqueueSystemEventSpy.mockClear();
-    wasSentByBot.mockReturnValue(true);
-
-    loadConfig.mockReturnValue({
-      channels: {
-        telegram: { dmPolicy: "open", allowFrom: ["*"], reactionNotifications: "own" },
-      },
-    });
-
-    createTelegramBot({ token: "tok" });
-    const handler = getOnHandler("message_reaction") as (
-      ctx: Record<string, unknown>,
-    ) => Promise<void>;
-
-    await handler({
-      update: { update_id: 503 },
-      messageReaction: {
-        chat: { id: 1234, type: "private" },
+      expectedEnqueueCalls: 0,
+    },
+    {
+      name: "allows reaction in own mode when message is sent by bot",
+      updateId: 503,
+      channelConfig: { dmPolicy: "open", allowFrom: ["*"], reactionNotifications: "own" },
+      sentByBot: true,
+      reaction: {
         message_id: 99,
-        user: { id: 9, first_name: "Ada" },
-        date: 1736380800,
-        old_reaction: [],
         new_reaction: [{ type: "emoji", emoji: PARTY_EMOJI }],
       },
-    });
-
-    expect(enqueueSystemEventSpy).toHaveBeenCalledTimes(1);
-  });
-
-  it("skips reaction from bot users", async () => {
-    onSpy.mockClear();
-    enqueueSystemEventSpy.mockClear();
-    wasSentByBot.mockReturnValue(true);
-
-    loadConfig.mockReturnValue({
-      channels: {
-        telegram: { dmPolicy: "open", allowFrom: ["*"], reactionNotifications: "all" },
-      },
-    });
-
-    createTelegramBot({ token: "tok" });
-    const handler = getOnHandler("message_reaction") as (
-      ctx: Record<string, unknown>,
-    ) => Promise<void>;
-
-    await handler({
-      update: { update_id: 503 },
-      messageReaction: {
-        chat: { id: 1234, type: "private" },
+      expectedEnqueueCalls: 1,
+    },
+    {
+      name: "skips reaction from bot users",
+      updateId: 503,
+      channelConfig: { dmPolicy: "open", allowFrom: ["*"], reactionNotifications: "all" },
+      sentByBot: true,
+      reaction: {
         message_id: 99,
         user: { id: 9, first_name: "Bot", is_bot: true },
-        date: 1736380800,
-        old_reaction: [],
         new_reaction: [{ type: "emoji", emoji: PARTY_EMOJI }],
       },
-    });
-
-    expect(enqueueSystemEventSpy).not.toHaveBeenCalled();
-  });
-
-  it("skips reaction removal (only processes added reactions)", async () => {
-    onSpy.mockClear();
-    enqueueSystemEventSpy.mockClear();
-
-    loadConfig.mockReturnValue({
-      channels: {
-        telegram: { dmPolicy: "open", allowFrom: ["*"], reactionNotifications: "all" },
-      },
-    });
-
-    createTelegramBot({ token: "tok" });
-    const handler = getOnHandler("message_reaction") as (
-      ctx: Record<string, unknown>,
-    ) => Promise<void>;
-
-    await handler({
-      update: { update_id: 504 },
-      messageReaction: {
-        chat: { id: 1234, type: "private" },
-        message_id: 42,
-        user: { id: 9, first_name: "Ada" },
-        date: 1736380800,
+      expectedEnqueueCalls: 0,
+    },
+    {
+      name: "skips reaction removal (only processes added reactions)",
+      updateId: 504,
+      channelConfig: { dmPolicy: "open", allowFrom: ["*"], reactionNotifications: "all" },
+      sentByBot: true,
+      reaction: {
         old_reaction: [{ type: "emoji", emoji: THUMBS_UP_EMOJI }],
         new_reaction: [],
       },
-    });
+      expectedEnqueueCalls: 0,
+    },
+    {
+      name: "blocks reaction in own mode when cache is warm and message not sent by bot",
+      updateId: 601,
+      channelConfig: { dmPolicy: "open", reactionNotifications: "own" },
+      sentByBot: false,
+      reaction: { message_id: 99 },
+      expectedEnqueueCalls: 0,
+    },
+  ])(
+    "$name",
+    async ({ updateId, channelConfig, sentByBot, reaction, expectedEnqueueCalls, ...expected }) => {
+      onSpy.mockClear();
+      enqueueSystemEventSpy.mockClear();
+      wasSentByBot.mockReturnValue(sentByBot);
+      loadConfig.mockReturnValue({ channels: { telegram: channelConfig } });
+      createTelegramBot({ token: "tok" });
 
-    expect(enqueueSystemEventSpy).not.toHaveBeenCalled();
-  });
+      const handler = getOnHandler("message_reaction") as (
+        ctx: Record<string, unknown>,
+      ) => Promise<void>;
+      await handler(createTelegramReactionContext({ updateId, reaction }));
+
+      expect(enqueueSystemEventSpy).toHaveBeenCalledTimes(expectedEnqueueCalls);
+      if ("expectedMessage" in expected && expected.expectedMessage) {
+        expect(firstSystemEventArg(0)).toBe(expected.expectedMessage);
+        expect(firstSystemEventArg(1)).toBeTypeOf("object");
+      }
+    },
+  );
 
   it("enqueues one event per added emoji reaction", async () => {
     onSpy.mockClear();
@@ -6528,147 +6259,68 @@ describe("createTelegramBot", () => {
     ]);
   });
 
-  it("routes forum group reactions to the general topic (thread id not available on reactions)", async () => {
-    onSpy.mockClear();
-    enqueueSystemEventSpy.mockClear();
-
-    loadConfig.mockReturnValue({
-      channels: {
-        telegram: { dmPolicy: "open", reactionNotifications: "all" },
-      },
-    });
-
-    createTelegramBot({ token: "tok" });
-    const handler = getOnHandler("message_reaction") as (
-      ctx: Record<string, unknown>,
-    ) => Promise<void>;
-
-    // MessageReactionUpdated does not include message_thread_id in the Bot API,
-    // so forum reactions always route to the general topic (1).
-    await handler({
-      update: { update_id: 505 },
-      messageReaction: {
+  // The Bot API omits thread metadata on reaction updates, so forum reactions
+  // must use the General topic while regular groups remain unthreaded.
+  it.each([
+    {
+      name: "routes forum group reactions to the general topic (thread id not available on reactions)",
+      updateId: 505,
+      reaction: {
         chat: { id: 5678, type: "supergroup", is_forum: true },
         message_id: 100,
         user: { id: 10, first_name: "Bob", username: "bob_user" },
-        date: 1736380800,
-        old_reaction: [],
         new_reaction: [{ type: "emoji", emoji: FIRE_EMOJI }],
       },
-    });
-
-    expect(enqueueSystemEventSpy).toHaveBeenCalledTimes(1);
-    expect(firstSystemEventArg(0)).toBe(
-      `Telegram reaction added: ${FIRE_EMOJI} by Bob (@bob_user) on msg 100`,
-    );
-    expect(String(systemEventOptions().sessionKey)).toContain("telegram:group:5678:topic:1");
-    expect(String(systemEventOptions().contextKey)).toContain("telegram:reaction:add:5678:100:10");
-  });
-
-  it("uses correct session key for forum group reactions in general topic", async () => {
-    onSpy.mockClear();
-    enqueueSystemEventSpy.mockClear();
-
-    loadConfig.mockReturnValue({
-      channels: {
-        telegram: { dmPolicy: "open", reactionNotifications: "all" },
-      },
-    });
-
-    createTelegramBot({ token: "tok" });
-    const handler = getOnHandler("message_reaction") as (
-      ctx: Record<string, unknown>,
-    ) => Promise<void>;
-
-    await handler({
-      update: { update_id: 506 },
-      messageReaction: {
+      message: `Telegram reaction added: ${FIRE_EMOJI} by Bob (@bob_user) on msg 100`,
+      session: "telegram:group:5678:topic:1",
+      context: "telegram:reaction:add:5678:100:10",
+    },
+    {
+      name: "uses correct session key for forum group reactions in general topic",
+      updateId: 506,
+      reaction: {
         chat: { id: 5678, type: "supergroup", is_forum: true },
         message_id: 101,
-        // No message_thread_id - should default to general topic (1)
         user: { id: 10, first_name: "Bob" },
-        date: 1736380800,
-        old_reaction: [],
         new_reaction: [{ type: "emoji", emoji: EYES_EMOJI }],
       },
-    });
-
-    expect(enqueueSystemEventSpy).toHaveBeenCalledTimes(1);
-    expect(firstSystemEventArg(0)).toBe(`Telegram reaction added: ${EYES_EMOJI} by Bob on msg 101`);
-    expect(String(systemEventOptions().sessionKey)).toContain("telegram:group:5678:topic:1");
-    expect(String(systemEventOptions().contextKey)).toContain("telegram:reaction:add:5678:101:10");
-  });
-
-  it("uses correct session key for regular group reactions without topic", async () => {
-    onSpy.mockClear();
-    enqueueSystemEventSpy.mockClear();
-
-    loadConfig.mockReturnValue({
-      channels: {
-        telegram: { dmPolicy: "open", reactionNotifications: "all" },
-      },
-    });
-
-    createTelegramBot({ token: "tok" });
-    const handler = getOnHandler("message_reaction") as (
-      ctx: Record<string, unknown>,
-    ) => Promise<void>;
-
-    await handler({
-      update: { update_id: 507 },
-      messageReaction: {
+      message: `Telegram reaction added: ${EYES_EMOJI} by Bob on msg 101`,
+      session: "telegram:group:5678:topic:1",
+      context: "telegram:reaction:add:5678:101:10",
+    },
+    {
+      name: "uses correct session key for regular group reactions without topic",
+      updateId: 507,
+      reaction: {
         chat: { id: 9999, type: "group" },
         message_id: 200,
         user: { id: 11, first_name: "Charlie" },
-        date: 1736380800,
-        old_reaction: [],
         new_reaction: [{ type: "emoji", emoji: HEART_EMOJI }],
       },
-    });
-
-    expect(enqueueSystemEventSpy).toHaveBeenCalledTimes(1);
-    expect(firstSystemEventArg(0)).toBe(
-      `Telegram reaction added: ${HEART_EMOJI} by Charlie on msg 200`,
-    );
-    expect(String(systemEventOptions().sessionKey)).toContain("telegram:group:9999");
-    expect(String(systemEventOptions().contextKey)).toContain("telegram:reaction:add:9999:200:11");
-    // Verify session key does NOT contain :topic:
-    const eventOptions = firstSystemEventArg(1) as {
-      sessionKey?: string;
-    };
-    const sessionKey = eventOptions.sessionKey ?? "";
-    expect(sessionKey).not.toContain(":topic:");
-  });
-
-  it("blocks reaction in own mode when cache is warm and message not sent by bot", async () => {
+      message: `Telegram reaction added: ${HEART_EMOJI} by Charlie on msg 200`,
+      session: "telegram:group:9999",
+      context: "telegram:reaction:add:9999:200:11",
+    },
+  ])("$name", async ({ updateId, reaction, message, session, context }) => {
     onSpy.mockClear();
     enqueueSystemEventSpy.mockClear();
-    wasSentByBot.mockReturnValue(false);
-
     loadConfig.mockReturnValue({
-      channels: {
-        telegram: { dmPolicy: "open", reactionNotifications: "own" },
-      },
+      channels: { telegram: { dmPolicy: "open", reactionNotifications: "all" } },
     });
-
     createTelegramBot({ token: "tok" });
     const handler = getOnHandler("message_reaction") as (
       ctx: Record<string, unknown>,
     ) => Promise<void>;
 
-    await handler({
-      update: { update_id: 601 },
-      messageReaction: {
-        chat: { id: 1234, type: "private" },
-        message_id: 99,
-        user: { id: 9, first_name: "Ada" },
-        date: 1736380800,
-        old_reaction: [],
-        new_reaction: [{ type: "emoji", emoji: THUMBS_UP_EMOJI }],
-      },
-    });
+    await handler(createTelegramReactionContext({ updateId, reaction }));
 
-    expect(enqueueSystemEventSpy).not.toHaveBeenCalled();
+    expect(enqueueSystemEventSpy).toHaveBeenCalledTimes(1);
+    expect(firstSystemEventArg(0)).toBe(message);
+    expect(String(systemEventOptions().sessionKey)).toContain(session);
+    expect(String(systemEventOptions().contextKey)).toContain(context);
+    if (!reaction.chat.is_forum) {
+      expect(String(systemEventOptions().sessionKey)).not.toContain(":topic:");
+    }
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */


### PR DESCRIPTION
## What Problem This Solves

Telegram message replays can carry authenticated startup bot metadata without grammY's per-update `ctx.me`. The four message, edit, channel-post, and edited-channel-post ingestion paths dereferenced `ctx.me.id` directly, crashing instead of processing the update. The existing frozen-main regression already reproduces that crash. Matrix and Telegram transport tests also repeated large identity, approval, reaction, mention-policy, and live-allowlist fixtures, making these regressions unnecessarily expensive to review.

## Why This Change Was Made

Resolve bot identity once from the authenticated per-update identity, configured startup bot information, or grammY's documented initialized bot identity. Use that same canonical identity for self-echo protection and all four sibling Telegram ingress paths. Consolidate existing Matrix bot-policy and live-allowlist cases and Telegram approval, reaction, and topic cases into named data-driven scenarios while preserving every original case and security assertion. The grammY `Bot.botInfo` getter and `BotConfig.botInfo` types were checked directly against the installed dependency before implementing the fallback.

## User Impact

Telegram replays no longer crash solely because per-update identity metadata is missing. Bot self-message rejection, approval authorization, room and DM bot policies, account-scoped live allowlists, mention protection, forum topic routing, and reaction filtering remain protected. Developers maintain the same scenarios in approximately 500 fewer net lines. AI-assisted, maintainer-requested consolidation.

## Evidence

- **Known frozen-main proof gap:** the full Telegram owner file also contains an unrelated, unchanged native-command case, `keeps unconfigured dm topic commands on the flat dm session`, that independently hangs on clean frozen `main` and on the after tree. A focused clean-main reproduction reaches the repository's no-output watchdog. This PR does not skip, delete, change, or claim to have passed that case or the full Telegram file. Telegram proof is the explicit same-name approval, approver, reaction, and forum-routing partitions below, plus the separately demonstrated startup-identity red/green regression.
- Frozen clean `main` at `16d2b7e46784c75eb5d57329269e9fd47222d2ef`: the existing `startup bot metadata` regression fails with `TypeError: Cannot read properties of undefined (reading 'id')` at `bot-handlers.message-events.runtime.ts:258`; the identical unmodified case passes after the fix.
- The exact frozen-main deterministic Telegram partition passes all 29 selected approval, approver, reaction, and forum-routing cases; the same named partition passes after consolidation. Its V8-covered statement count increases from 64 to 65 because the canonical identity resolver adds production code; branch hits remain 23. The separate red/green startup-identity case exercises the added authenticated fallback.
- Matrix production-owner coverage, before and after: all 121 named cases pass; statements `106/132`, branches `85/120`, functions `16/25`, and lines `106/131` are identical, with explicit nonzero V8 owner includes and the same exclusions.
- Full remote `pnpm check:changed`: exit 0, including production-extension type-checking, extension-test type-checking, changed-file lint with zero warnings and zero errors, formatting, plugin boundaries, dependency guards, and runtime import-cycle checks.
- Fresh immutable-head branch-scoped autoreview: exit 0, no accepted/actionable findings, TruffleHog clean.
- All four Telegram message and channel ingress paths share the same authenticated identity fallback, and self-echo detection uses that exact identity.
- The grammY dependency's installed `out/bot.js` getter and `out/bot.d.ts` `BotConfig.botInfo` / `Bot.botInfo` contracts were inspected directly.
- Targeted source formatting and `git diff --check` pass. No test, assertion, threshold, snapshot, production-owner file, or coverage exclusion is removed.
