### PR TITLE
fix(onepassword): op:// secret refs fail under Bun with a masked readonly-property error

### DIFF
--- a/extensions/onepassword/onepassword-secret-ref-resolver.js
+++ b/extensions/onepassword/onepassword-secret-ref-resolver.js
@@ -183,9 +183,11 @@ function opEnvironment(token) {
 }
 
 async function runOpRead(opCommand, token, secretReference) {
+  // Keep execa's default utf8 encoding: secrets are decoded as utf8 anyway, and
+  // Bun's spawn rejects execa's "buffer" encoding option (oven-sh/bun#36049),
+  // surfacing as a masked "Attempted to assign to readonly property." TypeError.
   const subprocess = execa(opCommand, ["read", "--cache=false", "--no-newline", secretReference], {
     cleanup: true,
-    encoding: "buffer",
     env: opEnvironment(token),
     extendEnv: false,
     killDescendants: true,
@@ -223,10 +225,12 @@ async function runOpRead(opCommand, token, secretReference) {
   if (result.exitCode !== 0) {
     throw new Error(`op read failed with exit code ${String(result.exitCode)}.`);
   }
-  if (!(result.stdout instanceof Uint8Array)) {
+  // A missing stdout string means the subprocess never produced output streams
+  // (spawn-level failure with reject:false), not an empty secret.
+  if (typeof result.stdout !== "string") {
     throw new Error("op read could not be started.");
   }
-  return Buffer.from(result.stdout).toString("utf8");
+  return result.stdout;
 }
 
 async function runWithConcurrency(values, limit, task) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where running the OpenClaw gateway under Bun (1.3.x and 1.4.0-canary) made every 1Password `op://` secret reference fail with the opaque error `Attempted to assign to readonly property.` instead of resolving the secret. The same masked TypeError is what previously surfaced on the `openclaw status` Gateway service line before the core spawn workaround landed in #114256.

## Why This Change Was Made

Bun's `child_process.spawn` consumes execa's `encoding: "buffer"` option and feeds it into its stream constructor, throwing `ERR_UNKNOWN_ENCODING` at spawn time (oven-sh/bun#36049). execa then routes that spawn failure through `handleEarlyError` -> `createDummyStreams`, which does `Object.assign(new ChildProcess(), { stdin, stdout, stderr, stdio })` (`execa/lib/return/early-error.js:54`). Bun's `ChildProcess` exposes `stdin`/`stdout`/`stderr` as getter-only prototype accessors (Node uses writable instance properties), so the assign throws `TypeError: Attempted to assign to readonly property.` in strict mode, replacing the real error.

The onepassword secret-ref resolver was the last remaining direct `execa(..., { encoding: "buffer" })` call site (core spawns already clear the option under Bun via `src/process/exec-spawn.ts`). The resolver decodes the result as utf8 anyway, so the clean fix is to drop the Bun-hostile option and consume execa's default utf8 string output. The byte-based output limit still counts raw stream chunks, and the spawn-failure sentinel becomes a `typeof result.stdout !== "string"` check.

## User Impact

Gateway operators running under a Bun runtime with `node:sqlite` (supported since #114256) can now use 1Password `op://` secret references. Node behavior is unchanged (same utf8 decoding, `--no-newline`/`stripFinalNewline` semantics preserved).

## Evidence

- Before (Bun 1.4.0-canary, resolver invoked with a fake `op`): exit 1, `{"errors":{"op://vault/item/field":{"message":"Attempted to assign to readonly property."}}}`
- After (same setup): exit 0, `{"values":{"op://vault/item/field":"not-a-real-value"},"errors":{}}`
- Node regression suite: `node scripts/run-vitest.mjs extensions/onepassword/src/secret-ref-resolver.test.ts` -> 20 passed, 1 skipped.
- Launcher Bun e2e with real Bun 1.4.0-canary: `OPENCLAW_TEST_BUN_LAUNCHER=1 BUN_BIN=<bun-canary> node scripts/run-vitest.mjs test/openclaw-launcher.e2e.test.ts` -> 43 passed.
- Codex autoreview (gpt-5.6-sol, xhigh): clean, no accepted/actionable findings.
