### PR TITLE
refactor(ui): consolidate workboard regression fixtures

### DIFF
--- a/ui/src/lib/workboard/index.test.ts
+++ b/ui/src/lib/workboard/index.test.ts
@@ -68,7 +68,10 @@ function syncLifecycle(
   return syncWorkboardLifecycle({ host, client, sessions, ...options });
 }
 
-function refreshBoard(client: WorkboardTestClient, source: "live" | "manual") {
+function refreshBoard(
+  client: Parameters<typeof refreshWorkboard>[0]["client"],
+  source: "live" | "manual",
+) {
   return refreshWorkboard({ host, client, source });
 }
 

--- a/ui/src/lib/workboard/index.test.ts
+++ b/ui/src/lib/workboard/index.test.ts
@@ -53,6 +53,13 @@ const sampleTask = createWorkboardTask();
 let host: object;
 let state: ReturnType<typeof getWorkboardState>;
 
+function loadBoard(
+  client: WorkboardTestClient,
+  options: Omit<Parameters<typeof loadWorkboard>[0], "host" | "client" | "force"> = {},
+) {
+  return loadWorkboard({ host, client, force: true, ...options });
+}
+
 function syncLifecycle(
   client: WorkboardTestClient,
   sessions: GatewaySessionRow[] = [],
@@ -189,7 +196,7 @@ describe("workboard controller", () => {
         },
       });
 
-      await loadWorkboard({ host, client: client as never, force: true });
+      await loadBoard(client);
 
       expect(getWorkboardState(host).boards).toEqual([
         {
@@ -225,10 +232,10 @@ describe("workboard controller", () => {
         return {};
       });
 
-      const staleLoad = loadWorkboard({ host, client: client as never, force: true });
+      const staleLoad = loadBoard(client);
       await Promise.resolve();
       stopWorkboardLifecycleRefresh(host);
-      await loadWorkboard({ host, client: client as never, force: true });
+      await loadBoard(client);
 
       staleList.resolve({
         cards: [{ ...sampleCard, title: "Stale generation" }],
@@ -258,11 +265,7 @@ describe("workboard controller", () => {
         return {};
       });
 
-      const syncing = syncWorkboardLifecycle({
-        host,
-        client: client as never,
-        sessions: [sampleSession],
-      });
+      const syncing = syncLifecycle(client, [sampleSession]);
       await waitForFast(() => {
         expect(client.request).toHaveBeenCalledWith(
           "workboard.cards.update",
@@ -293,7 +296,7 @@ describe("workboard controller", () => {
       "workboard.cards.list": { cards: [sampleCard], statuses: ["todo", "done"] },
     });
 
-    await loadWorkboard({ host, client: client as never, force: true });
+    await loadBoard(client);
 
     expect(client.request).toHaveBeenCalledWith("workboard.cards.list", {});
     expect(getWorkboardState(host).cards).toEqual([sampleCard]);
@@ -305,12 +308,7 @@ describe("workboard controller", () => {
       "workboard.cards.list": { cards: [sampleCard], statuses: ["todo", "done"] },
     });
 
-    await loadWorkboard({
-      host,
-      client: client as never,
-      force: true,
-      refreshDiagnostics: true,
-    });
+    await loadBoard(client, { refreshDiagnostics: true });
 
     expect(client.request).toHaveBeenNthCalledWith(1, "workboard.cards.diagnostics.refresh", {});
     expect(client.request).toHaveBeenNthCalledWith(2, "workboard.cards.list", {});
@@ -324,12 +322,7 @@ describe("workboard controller", () => {
       return { cards: [sampleCard], statuses: ["todo", "done"] };
     });
 
-    await loadWorkboard({
-      host,
-      client: client as never,
-      force: true,
-      refreshDiagnostics: true,
-    });
+    await loadBoard(client, { refreshDiagnostics: true });
 
     expect(client.request).toHaveBeenNthCalledWith(1, "workboard.cards.diagnostics.refresh", {});
     expect(client.request).toHaveBeenNthCalledWith(2, "workboard.cards.list", {});
@@ -349,7 +342,7 @@ describe("workboard controller", () => {
       "tasks.list": { tasks: [sampleTask] },
     });
 
-    await loadWorkboard({ host, client: client as never, force: true });
+    await loadBoard(client);
 
     expect(client.request).toHaveBeenCalledWith("tasks.list", { limit: 500 });
     expect(state.cards[0]).toMatchObject({ id: "card-1", taskId: "task-1" });
@@ -377,7 +370,7 @@ describe("workboard controller", () => {
       return {};
     });
 
-    await loadWorkboard({ host, client: client as never, force: true });
+    await loadBoard(client);
 
     expect(state.cards[0]).toMatchObject({ id: sampleCard.id, taskId: sampleTask.taskId });
     expect(state.tasksByCardId.get(sampleCard.id)).toEqual(sampleTask);
@@ -409,7 +402,7 @@ describe("workboard controller", () => {
       return {};
     });
 
-    await loadWorkboard({ host, client: client as never, force: true });
+    await loadBoard(client);
 
     expect(client.request).toHaveBeenCalledWith("tasks.get", { taskId: sampleTask.taskId });
     expect(state.cards[0]).toMatchObject({ taskId: sampleTask.taskId });
@@ -429,7 +422,7 @@ describe("workboard controller", () => {
       "tasks.get": { task: sampleTask },
     });
 
-    await loadWorkboard({ host, client: client as never, force: true });
+    await loadBoard(client);
 
     expect(client.request).toHaveBeenCalledWith("tasks.get", { taskId: sampleTask.taskId });
     expect(state.cards[0]).toMatchObject({ taskId: sampleTask.taskId });
@@ -458,13 +451,13 @@ describe("workboard controller", () => {
       return {};
     });
 
-    await loadWorkboard({ host, client: client as never, force: true });
+    await loadBoard(client);
 
     expect(state.lifecycleTaskRefreshFailed).toBe(true);
     expect(state.lastRefreshError).toBe("task confirmation unavailable");
     vi.clearAllMocks();
 
-    await syncWorkboardLifecycle({ host, client: client as never, sessions: [] });
+    await syncLifecycle(client);
 
     expect(client.request).not.toHaveBeenCalled();
   });
@@ -491,7 +484,7 @@ describe("workboard controller", () => {
       return {};
     });
 
-    await loadWorkboard({ host, client: client as never, force: true });
+    await loadBoard(client);
 
     expect(state.cards[0]).toMatchObject({ taskId: sampleTask.taskId });
     expect(state.tasksByCardId.get(linked.id)).toEqual(sampleTask);
@@ -537,20 +530,20 @@ describe("workboard controller", () => {
       return {};
     });
 
-    await loadWorkboard({ host, client: client as never, force: true, taskRefresh: "linked" });
+    await loadBoard(client, { taskRefresh: "linked" });
     const retryAt = state.lifecycleTaskRefreshRetryAt;
     expect(state.lifecycleTaskRefreshFailed).toBe(true);
     expect(state.lifecycleTasksPrepared).toBe(false);
     expect(state.lastRefreshError).toBe("task-31 unavailable");
 
-    await loadWorkboard({ host, client: client as never, force: true, taskRefresh: "linked" });
+    await loadBoard(client, { taskRefresh: "linked" });
     expect(failedTaskRequests).toBe(1);
     expect(state.lifecycleTaskRefreshFailed).toBe(true);
     expect(state.lifecycleTaskRefreshRetryAt).toBe(retryAt);
     expect(state.lifecycleTasksPrepared).toBe(false);
     expect(state.lastRefreshError).toBe("task-31 unavailable");
 
-    await loadWorkboard({ host, client: client as never, force: true, taskRefresh: "all" });
+    await loadBoard(client, { taskRefresh: "all" });
     expect(state.lifecycleTaskRefreshFailed).toBe(false);
     expect(state.lifecycleTasksPrepared).toBe(true);
     expect(state.lastRefreshError).toBeNull();
@@ -568,7 +561,7 @@ describe("workboard controller", () => {
       "workboard.cards.list": { cards, statuses: ["todo", "running", "done"] },
     });
 
-    await loadWorkboard({ host, client: client as never, force: true, taskRefresh: "linked" });
+    await loadBoard(client, { taskRefresh: "linked" });
 
     expect(state.lifecycleTaskRefreshFailed).toBe(false);
     expect(state.lifecycleTaskRefreshRetryAt).toBeNull();
@@ -590,12 +583,12 @@ describe("workboard controller", () => {
       "tasks.get": { task: sampleTask },
     });
 
-    await loadWorkboard({ host, client: client as never, force: true });
+    await loadBoard(client);
 
     expect(state.lifecycleTasksPrepared).toBe(true);
     vi.clearAllMocks();
 
-    await syncWorkboardLifecycle({ host, client: client as never, sessions: [] });
+    await syncLifecycle(client);
 
     expect(client.request).not.toHaveBeenCalled();
     expect(state.tasksByCardId.get(sampleCard.id)).toEqual(sampleTask);
@@ -619,7 +612,7 @@ describe("workboard controller", () => {
       "tasks.list": { tasks: [sampleTask, unrelated] },
     });
 
-    await loadWorkboard({ host, client: client as never, force: true });
+    await loadBoard(client);
 
     expect(state.cards[0]).toMatchObject({ taskId: sampleTask.taskId });
     expect(state.tasksByCardId.get(sampleCard.id)).toEqual(sampleTask);
@@ -630,11 +623,7 @@ describe("workboard controller", () => {
       "workboard.cards.list": { cards: [sampleCard], statuses: ["todo", "done"] },
       "tasks.list": { tasks: [] },
     });
-    await refreshWorkboard({
-      host,
-      client: client as never,
-      source: "live",
-    });
+    await refreshBoard(client, "live");
 
     expect(client.request).toHaveBeenCalledWith("workboard.cards.list", {});
     expect(state.lastRefreshSource).toBe("live");
@@ -650,11 +639,7 @@ describe("workboard controller", () => {
       "tasks.list": { tasks: [] },
     });
 
-    await refreshWorkboard({
-      host,
-      client: client as never,
-      source: "live",
-    });
+    await refreshBoard(client, "live");
 
     expect(state.error).toBe("move denied");
     expect(state.lastRefreshError).toBeNull();
@@ -676,7 +661,7 @@ describe("workboard controller", () => {
       return {};
     });
 
-    await loadWorkboard({ host, client: client as never, force: true });
+    await loadBoard(client);
 
     expect(state.loaded).toBe(false);
     expect(state.error).toBe("cards unavailable");
@@ -685,11 +670,7 @@ describe("workboard controller", () => {
     expect(state.loadAttempted).toBe(false);
 
     cardsAvailable = true;
-    await refreshWorkboard({
-      host,
-      client: client as never,
-      source: "live",
-    });
+    await refreshBoard(client, "live");
 
     expect(state.loaded).toBe(true);
     expect(state.cards).toEqual([sampleCard]);
@@ -713,16 +694,12 @@ describe("workboard controller", () => {
       return {};
     });
 
-    await loadWorkboard({ host, client: client as never, force: true });
+    await loadBoard(client);
 
     state.error = "move denied";
     cardsAvailable = true;
 
-    await refreshWorkboard({
-      host,
-      client: client as never,
-      source: "live",
-    });
+    await refreshBoard(client, "live");
 
     expect(state.loaded).toBe(true);
     expect(state.cards).toEqual([sampleCard]);
@@ -736,11 +713,7 @@ describe("workboard controller", () => {
       throw new Error("refresh unavailable");
     });
 
-    await refreshWorkboard({
-      host,
-      client: client as never,
-      source: "live",
-    });
+    await refreshBoard(client, "live");
 
     expect(state.error).toBe("move denied");
     expect(state.lastRefreshError).toBe("refresh unavailable");
@@ -763,17 +736,13 @@ describe("workboard controller", () => {
   });
 
   it("clears stale refresh errors after a later direct load succeeds", async () => {
-    await refreshWorkboard({
-      host,
-      client: null,
-      source: "manual",
-    });
+    await refreshBoard(null, "manual");
 
     const client = createClient({
       "workboard.cards.list": { cards: [sampleCard], statuses: ["todo", "done"] },
       "tasks.list": { tasks: [] },
     });
-    await loadWorkboard({ host, client: client as never, force: true });
+    await loadBoard(client);
 
     expect(state.loaded).toBe(true);
     expect(state.error).toBeNull();
@@ -792,11 +761,7 @@ describe("workboard controller", () => {
       return {};
     });
 
-    await refreshWorkboard({
-      host,
-      client: client as never,
-      source: "manual",
-    });
+    await refreshBoard(client, "manual");
 
     expect(state.cards).toMatchObject([{ title: "Refreshed card" }]);
     expect(state.error).toBeNull();
@@ -826,24 +791,19 @@ describe("workboard controller", () => {
       return {};
     });
 
-    await loadWorkboard({
-      host,
-      client: client as never,
-      force: true,
-      requestUpdate,
-    });
+    await loadBoard(client, { requestUpdate });
     vi.clearAllMocks();
 
-    await syncWorkboardLifecycle({ host, client: client as never, sessions: [], requestUpdate });
-    await syncWorkboardLifecycle({ host, client: client as never, sessions: [], requestUpdate });
+    await syncLifecycle(client, [], { requestUpdate });
+    await syncLifecycle(client, [], { requestUpdate });
 
     expect(client.request).not.toHaveBeenCalled();
     expect(requestUpdate).not.toHaveBeenCalled();
 
     tasksAvailable = true;
-    await loadWorkboard({ host, client: client as never, force: true });
+    await loadBoard(client);
     vi.clearAllMocks();
-    await syncWorkboardLifecycle({ host, client: client as never, sessions: [] });
+    await syncLifecycle(client);
 
     expect(client.request).not.toHaveBeenCalledWith("tasks.list", { limit: 500 });
     expect(getWorkboardState(host).tasksByCardId.get(sampleCard.id)).toEqual(sampleTask);
@@ -866,11 +826,7 @@ describe("workboard controller", () => {
       return {};
     });
 
-    await refreshWorkboard({
-      host,
-      client: client as never,
-      source: "live",
-    });
+    await refreshBoard(client, "live");
 
     expect(state.tasksByCardId.get(sampleCard.id)).toEqual(sampleTask);
     expect(state.lifecycleTasksPrepared).toBe(false);
@@ -898,11 +854,7 @@ describe("workboard controller", () => {
       return {};
     });
 
-    await refreshWorkboard({
-      host,
-      client: client as never,
-      source: "live",
-    });
+    await refreshBoard(client, "live");
 
     expect(client.request).toHaveBeenCalledWith("tasks.get", { taskId: sampleTask.taskId });
     expect(state.cards[0]).toMatchObject({ taskId: sampleTask.taskId });
@@ -911,11 +863,7 @@ describe("workboard controller", () => {
     expect(state.lastRefreshError).toBeNull();
 
     vi.clearAllMocks();
-    await refreshWorkboard({
-      host,
-      client: client as never,
-      source: "live",
-    });
+    await refreshBoard(client, "live");
 
     expect(client.request).not.toHaveBeenCalledWith("tasks.get", { taskId: sampleTask.taskId });
   });
@@ -926,11 +874,7 @@ describe("workboard controller", () => {
       "workboard.cards.list": { cards: [sampleCard], statuses: ["todo", "done"] },
     });
 
-    await refreshWorkboard({
-      host,
-      client: client as never,
-      source: "live",
-    });
+    await refreshBoard(client, "live");
 
     expect(state.cards[0]).not.toHaveProperty("taskId");
     expect(state.tasksByCardId.has(sampleCard.id)).toBe(false);
@@ -974,11 +918,7 @@ describe("workboard controller", () => {
     state.tasksByCardId.set(sampleCard.id, sampleTask);
     state.tasksByCardId.set(olderCard.id, olderTask);
 
-    await refreshWorkboard({
-      host,
-      client: client as never,
-      source: "live",
-    });
+    await refreshBoard(client, "live");
 
     expect(client.request).toHaveBeenCalledWith("workboard.cards.list", {});
     expect(client.request).not.toHaveBeenCalledWith(
@@ -1018,7 +958,7 @@ describe("workboard controller", () => {
       return {};
     });
 
-    await refreshWorkboard({ host, client: client as never, source: "live" });
+    await refreshBoard(client, "live");
 
     expect(client.request).toHaveBeenCalledWith("tasks.get", { taskId: "task-2" });
     expect(client.request).not.toHaveBeenCalledWith("tasks.get", { taskId: "task-1" });
@@ -1046,12 +986,12 @@ describe("workboard controller", () => {
       return {};
     });
 
-    await refreshWorkboard({ host, client: client as never, source: "live" });
+    await refreshBoard(client, "live");
     const firstBatch = client.request.mock.calls
       .filter(([method]) => method === "tasks.get")
       .map(([, params]) => (params as { taskId: string }).taskId);
     vi.clearAllMocks();
-    await refreshWorkboard({ host, client: client as never, source: "live" });
+    await refreshBoard(client, "live");
     const secondBatch = client.request.mock.calls
       .filter(([method]) => method === "tasks.get")
       .map(([, params]) => (params as { taskId: string }).taskId);
@@ -1087,11 +1027,11 @@ describe("workboard controller", () => {
       return {};
     });
 
-    await refreshWorkboard({ host, client: client as never, source: "live" });
+    await refreshBoard(client, "live");
 
     expect(getWorkboardState(host).lifecycleTasksPrepared).toBe(false);
     vi.clearAllMocks();
-    await syncWorkboardLifecycle({ host, client: client as never, sessions: [] });
+    await syncLifecycle(client);
 
     expect(client.request).toHaveBeenCalledWith("tasks.list", { limit: 500 });
     expect(client.request).not.toHaveBeenCalledWith("workboard.cards.update", expect.anything());
@@ -1127,7 +1067,7 @@ describe("workboard controller", () => {
       return {};
     });
 
-    await refreshWorkboard({ host, client: client as never, source: "live" });
+    await refreshBoard(client, "live");
     const firstDiscoveryCalls = client.request.mock.calls.filter(
       ([method]) => method === "tasks.list",
     );
@@ -1139,7 +1079,7 @@ describe("workboard controller", () => {
     expect(getWorkboardState(host).lifecycleTasksPrepared).toBe(false);
 
     vi.clearAllMocks();
-    await refreshWorkboard({ host, client: client as never, source: "live" });
+    await refreshBoard(client, "live");
     const secondDiscoveryCalls = client.request.mock.calls.filter(
       ([method]) => method === "tasks.list",
     );
@@ -1166,7 +1106,7 @@ describe("workboard controller", () => {
       return {};
     });
 
-    await refreshWorkboard({ host, client: client as never, source: "live" });
+    await refreshBoard(client, "live");
 
     expect(client.request).toHaveBeenCalledWith("tasks.list", { limit: 500 });
     expect(getWorkboardState(host).cards[0]).toMatchObject({ taskId: sampleTask.taskId });
@@ -1209,7 +1149,7 @@ describe("workboard controller", () => {
       return {};
     });
 
-    await refreshWorkboard({ host, client: client as never, source: "live" });
+    await refreshBoard(client, "live");
 
     expect(client.request).not.toHaveBeenCalledWith("tasks.get", { taskId: missingTaskId });
     expect(client.request).toHaveBeenCalledWith("tasks.list", { limit: 500 });
@@ -1218,7 +1158,7 @@ describe("workboard controller", () => {
     expect(state.missingTaskIds).toEqual(new Set([missingTaskId]));
 
     vi.clearAllMocks();
-    await refreshWorkboard({ host, client: client as never, source: "live" });
+    await refreshBoard(client, "live");
 
     expect(client.request).toHaveBeenCalledWith("tasks.get", { taskId: replacementTaskId });
     expect(client.request).not.toHaveBeenCalledWith("tasks.get", { taskId: missingTaskId });
@@ -1247,11 +1187,11 @@ describe("workboard controller", () => {
       return {};
     });
 
-    await refreshWorkboard({ host, client: client as never, source: "live" });
+    await refreshBoard(client, "live");
     expect(getWorkboardState(host).cards[0]).not.toHaveProperty("taskId");
 
     vi.clearAllMocks();
-    await refreshWorkboard({ host, client: client as never, source: "live" });
+    await refreshBoard(client, "live");
 
     expect(client.request).toHaveBeenCalledWith("tasks.list", {
       limit: 500,
@@ -1279,9 +1219,9 @@ describe("workboard controller", () => {
       return {};
     });
 
-    await refreshWorkboard({ host, client: client as never, source: "live" });
-    await refreshWorkboard({ host, client: client as never, source: "live" });
-    await refreshWorkboard({ host, client: client as never, source: "live" });
+    await refreshBoard(client, "live");
+    await refreshBoard(client, "live");
+    await refreshBoard(client, "live");
 
     const discoveryCalls = client.request.mock.calls.filter(([method]) => method === "tasks.list");
     expect(discoveryCalls.map(([, params]) => params)).toEqual([
@@ -1486,7 +1426,7 @@ describe("workboard controller", () => {
         "tasks.list": { tasks: [] },
       });
 
-      await refreshWorkboard({ host, client: client as never, source: "manual" });
+      await refreshBoard(client, "manual");
 
       expect(client.request).not.toHaveBeenCalled();
       if (mutation === "dispatch") {
@@ -1538,9 +1478,7 @@ describe("workboard controller", () => {
         "workboard.cards.list": { cards: [sampleCard], statuses: ["todo", "done"] },
       });
 
-      await expect(loadWorkboard({ host, client: client as never, force: true })).resolves.toBe(
-        false,
-      );
+      await expect(loadBoard(client)).resolves.toBe(false);
 
       expect(client.request).not.toHaveBeenCalled();
     },
@@ -1711,7 +1649,7 @@ describe("workboard controller", () => {
     state.editingCardId = sampleCard.id;
     state.draftTitle = "Saved title";
 
-    const refresh = loadWorkboard({ host, client: client as never, force: true });
+    const refresh = loadBoard(client);
     await Promise.resolve();
     const save = saveWorkboardCardDraft({ host, client: client as never });
     await waitForFast(() => {
@@ -1753,20 +1691,9 @@ describe("workboard controller", () => {
       return {};
     });
 
-    const poll = loadWorkboard({
-      host,
-      client: client as never,
-      force: true,
-      taskRefresh: "linked",
-    });
+    const poll = loadBoard(client, { taskRefresh: "linked" });
     await Promise.resolve();
-    const forced = loadWorkboard({
-      host,
-      client: client as never,
-      force: true,
-      refreshDiagnostics: true,
-      taskRefresh: "all",
-    });
+    const forced = loadBoard(client, { refreshDiagnostics: true, taskRefresh: "all" });
     pollList.resolve({ cards: [sampleCard], statuses: ["todo", "done"] });
     await Promise.all([poll, forced]);
 
@@ -1800,26 +1727,10 @@ describe("workboard controller", () => {
       return {};
     });
 
-    const initial = loadWorkboard({
-      host,
-      client: client as never,
-      force: true,
-      taskRefresh: "linked",
-    });
+    const initial = loadBoard(client, { taskRefresh: "linked" });
     await Promise.resolve();
-    const weaker = loadWorkboard({
-      host,
-      client: client as never,
-      force: true,
-      taskRefresh: "linked",
-    });
-    const stronger = loadWorkboard({
-      host,
-      client: client as never,
-      force: true,
-      refreshDiagnostics: true,
-      taskRefresh: "all",
-    });
+    const weaker = loadBoard(client, { taskRefresh: "linked" });
+    const stronger = loadBoard(client, { refreshDiagnostics: true, taskRefresh: "all" });
     initialList.resolve({ cards: [sampleCard], statuses: ["todo", "done"] });
     await Promise.all([initial, weaker, stronger]);
 
@@ -1840,20 +1751,9 @@ describe("workboard controller", () => {
       return {};
     });
 
-    const poll = loadWorkboard({
-      host,
-      client: client as never,
-      force: true,
-      taskRefresh: "linked",
-    });
+    const poll = loadBoard(client, { taskRefresh: "linked" });
     await Promise.resolve();
-    const forced = loadWorkboard({
-      host,
-      client: client as never,
-      force: true,
-      refreshDiagnostics: true,
-      taskRefresh: "all",
-    });
+    const forced = loadBoard(client, { refreshDiagnostics: true, taskRefresh: "all" });
     stopWorkboardLifecycleRefresh(host);
     pollList.resolve({ cards: [sampleCard], statuses: ["todo", "done"] });
     await Promise.all([poll, forced]);
@@ -2024,20 +1924,9 @@ describe("workboard controller", () => {
       return {};
     });
 
-    const initial = loadWorkboard({
-      host,
-      client: client as never,
-      force: true,
-      taskRefresh: "linked",
-    });
+    const initial = loadBoard(client, { taskRefresh: "linked" });
     await Promise.resolve();
-    const forced = loadWorkboard({
-      host,
-      client: client as never,
-      force: true,
-      refreshDiagnostics: true,
-      taskRefresh: "all",
-    });
+    const forced = loadBoard(client, { refreshDiagnostics: true, taskRefresh: "all" });
     stopWorkboardLifecycleRefresh(host);
     const reopened = loadWorkboard({ host, client: client as never });
 
@@ -2094,20 +1983,9 @@ describe("workboard controller", () => {
       return {};
     });
 
-    const poll = loadWorkboard({
-      host,
-      client: client as never,
-      force: true,
-      taskRefresh: "linked",
-    });
+    const poll = loadBoard(client, { taskRefresh: "linked" });
     await Promise.resolve();
-    const forced = loadWorkboard({
-      host,
-      client: client as never,
-      force: true,
-      refreshDiagnostics: true,
-      taskRefresh: "all",
-    });
+    const forced = loadBoard(client, { refreshDiagnostics: true, taskRefresh: "all" });
     getWorkboardState(host).busyCardIds.add(sampleCard.id);
     pollList.resolve({ cards: [sampleCard], statuses: ["todo", "done"] });
     await Promise.all([poll, forced]);
@@ -2183,7 +2061,7 @@ describe("workboard controller", () => {
       return {};
     });
 
-    await loadWorkboard({ host, client: client as never, force: true });
+    await loadBoard(client);
 
     expect(client.request).toHaveBeenCalledWith("tasks.list", { limit: 500 });
     expect(client.request).toHaveBeenCalledWith("tasks.list", {
@@ -2493,7 +2371,7 @@ describe("workboard controller", () => {
       },
     });
 
-    await loadWorkboard({ host, client: client as never, force: true });
+    await loadBoard(client);
 
     expect(getWorkboardState(host).cards[0]).toMatchObject({ taskId: "task-1" });
   });
@@ -2517,7 +2395,7 @@ describe("workboard controller", () => {
       },
     });
 
-    await loadWorkboard({ host, client: client as never, force: true });
+    await loadBoard(client);
 
     expect(state.cards[0]).not.toHaveProperty("taskId");
     expect(state.tasksByCardId.has("card-1")).toBe(false);
@@ -2594,7 +2472,7 @@ describe("workboard controller", () => {
       },
     });
 
-    await loadWorkboard({ host, client: client as never, force: true });
+    await loadBoard(client);
 
     expect(getWorkboardState(host).cards[0]?.metadata).toMatchObject({
       automation: {
@@ -2798,11 +2676,7 @@ describe("workboard controller", () => {
         "workboard.cards.update": { card: { ...sampleCard, status: "running" } },
       });
 
-      await syncWorkboardLifecycle({
-        host,
-        client: client as never,
-        sessions: [{ ...sampleSession, status: "running", hasActiveRun: true }],
-      });
+      await syncLifecycle(client, [{ ...sampleSession, status: "running", hasActiveRun: true }]);
 
       expect(client.request).not.toHaveBeenCalled();
     },
@@ -2822,7 +2696,7 @@ describe("workboard controller", () => {
       return {};
     });
 
-    const loading = loadWorkboard({ host, client: client as never, force: true });
+    const loading = loadBoard(client);
     await Promise.resolve();
     await syncLifecycle(client, [{ ...sampleSession, status: "running", hasActiveRun: true }]);
 
@@ -3139,7 +3013,7 @@ describe("workboard controller", () => {
       return {};
     });
 
-    const loading = loadWorkboard({ host, client: client as never, force: true });
+    const loading = loadBoard(client);
     const captured = captureSession(client, sampleSession);
 
     await Promise.resolve();
@@ -3470,7 +3344,7 @@ describe("workboard controller", () => {
       }
       return { card: running };
     });
-    await loadWorkboard({ host, client: client as never, force: true });
+    await loadBoard(client);
     client.request.mockClear();
 
     const sessionKey = await startWorkboardCard({
@@ -3620,7 +3494,7 @@ describe("workboard controller", () => {
     const client = createClient({
       "workboard.cards.list": { cards: [scheduled], statuses: ["scheduled", "running", "done"] },
     });
-    await loadWorkboard({ host, client: client as never, force: true });
+    await loadBoard(client);
     client.request.mockClear();
 
     const sessionKey = await startWorkboardCard({
@@ -3745,7 +3619,7 @@ describe("workboard controller", () => {
       }
       return {};
     });
-    await loadWorkboard({ host, client: dueClient as never, force: true });
+    await loadBoard(dueClient);
     dueClient.request.mockClear();
 
     const dueSessionKey = await startWorkboardCard({
@@ -4675,7 +4549,7 @@ describe("workboard controller", () => {
       return {};
     });
 
-    const sync = syncWorkboardLifecycle({ host, client: client as never, sessions: [] });
+    const sync = syncLifecycle(client);
     await waitForFast(() => {
       expect(client.request).toHaveBeenCalledWith("tasks.list", { limit: 500 });
     });
@@ -4743,11 +4617,11 @@ describe("workboard controller", () => {
       return {};
     });
 
-    const first = syncWorkboardLifecycle({ host, client: client as never, sessions: [] });
+    const first = syncLifecycle(client);
     await waitForFast(() => {
       expect(client.request).toHaveBeenCalledWith("tasks.list", { limit: 500 });
     });
-    const second = syncWorkboardLifecycle({ host, client: client as never, sessions: [] });
+    const second = syncLifecycle(client);
     await Promise.resolve();
 
     expect(client.request.mock.calls.filter(([method]) => method === "tasks.list")).toHaveLength(1);
@@ -4784,12 +4658,7 @@ describe("workboard controller", () => {
     });
     const requestUpdate = vi.fn();
 
-    const first = syncWorkboardLifecycle({
-      host,
-      client: client as never,
-      sessions: [],
-      requestUpdate,
-    });
+    const first = syncLifecycle(client, [], { requestUpdate });
     await waitForFast(() => {
       expect(client.request).toHaveBeenCalledWith("tasks.list", { limit: 500 });
     });
@@ -4802,24 +4671,14 @@ describe("workboard controller", () => {
     });
     vi.clearAllMocks();
 
-    const second = syncWorkboardLifecycle({
-      host,
-      client: client as never,
-      sessions: [],
-      requestUpdate,
-    });
+    const second = syncLifecycle(client, [], { requestUpdate });
     firstTaskList.resolve({ tasks: [sampleTask] });
     await Promise.all([first, second]);
 
     expect(requestUpdate).toHaveBeenCalledOnce();
     vi.clearAllMocks();
 
-    await syncWorkboardLifecycle({
-      host,
-      client: client as never,
-      sessions: [],
-      requestUpdate,
-    });
+    await syncLifecycle(client, [], { requestUpdate });
 
     expect(client.request).toHaveBeenNthCalledWith(1, "tasks.list", { limit: 500 });
     expect(client.request).toHaveBeenNthCalledWith(2, "workboard.cards.update", {
@@ -4843,7 +4702,7 @@ describe("workboard controller", () => {
       "tasks.list": { tasks: [] },
     });
 
-    await syncWorkboardLifecycle({ host, client: client as never, sessions: [] });
+    await syncLifecycle(client);
 
     expect(client.request).toHaveBeenCalledWith("tasks.list", { limit: 500 });
     expect(client.request).not.toHaveBeenCalledWith("workboard.cards.update", expect.anything());
@@ -4916,7 +4775,7 @@ describe("workboard controller", () => {
       "tasks.get": { task: sampleTask },
     });
 
-    await syncWorkboardLifecycle({ host, client: client as never, sessions: [] });
+    await syncLifecycle(client);
 
     expect(client.request).toHaveBeenNthCalledWith(1, "tasks.list", { limit: 500 });
     expect(client.request).toHaveBeenNthCalledWith(2, "tasks.get", {
@@ -4943,7 +4802,7 @@ describe("workboard controller", () => {
     });
     const requestUpdate = vi.fn();
 
-    await syncWorkboardLifecycle({ host, client: client as never, sessions: [], requestUpdate });
+    await syncLifecycle(client, [], { requestUpdate });
 
     expect(state.tasksByCardId.get(linked.id)).toEqual(confirmedTask);
     expect(state.lifecycleTasksPrepared).toBe(true);
@@ -4974,7 +4833,7 @@ describe("workboard controller", () => {
     });
     const requestUpdate = vi.fn();
 
-    await syncWorkboardLifecycle({ host, client: client as never, sessions: [], requestUpdate });
+    await syncLifecycle(client, [], { requestUpdate });
 
     expect(client.request.mock.calls.filter(([method]) => method === "tasks.get")).toHaveLength(32);
     expect(client.request).not.toHaveBeenCalledWith("workboard.cards.update", expect.anything());
@@ -4984,7 +4843,7 @@ describe("workboard controller", () => {
     await vi.advanceTimersByTimeAsync(100);
     expect(requestUpdate).toHaveBeenCalledOnce();
     vi.clearAllMocks();
-    await syncWorkboardLifecycle({ host, client: client as never, sessions: [], requestUpdate });
+    await syncLifecycle(client, [], { requestUpdate });
 
     expect(client.request.mock.calls.filter(([method]) => method === "tasks.get")).toHaveLength(32);
     expect(client.request).not.toHaveBeenCalledWith("workboard.cards.update", expect.anything());
@@ -4992,7 +4851,7 @@ describe("workboard controller", () => {
 
     vi.clearAllMocks();
     await vi.advanceTimersByTimeAsync(100);
-    await syncWorkboardLifecycle({ host, client: client as never, sessions: [], requestUpdate });
+    await syncLifecycle(client, [], { requestUpdate });
 
     expect(client.request.mock.calls.filter(([method]) => method === "tasks.get")).toHaveLength(1);
     expect(client.request).not.toHaveBeenCalledWith("workboard.cards.update", expect.anything());
@@ -5021,14 +4880,14 @@ describe("workboard controller", () => {
     });
     const requestUpdate = vi.fn();
 
-    await syncWorkboardLifecycle({ host, client: client as never, sessions: [], requestUpdate });
+    await syncLifecycle(client, [], { requestUpdate });
 
     expect(client.request.mock.calls.filter(([method]) => method === "tasks.get")).toHaveLength(32);
     expect(state.lifecycleTaskRefreshContinueAt).not.toBeNull();
 
     vi.clearAllMocks();
     await vi.advanceTimersByTimeAsync(5001);
-    await syncWorkboardLifecycle({ host, client: client as never, sessions: [], requestUpdate });
+    await syncLifecycle(client, [], { requestUpdate });
 
     expect(client.request).not.toHaveBeenCalled();
     expect(client.request).not.toHaveBeenCalledWith("workboard.cards.update", expect.anything());
@@ -5065,7 +4924,7 @@ describe("workboard controller", () => {
       return {};
     });
 
-    await syncWorkboardLifecycle({ host, client: client as never, sessions: [] });
+    await syncLifecycle(client);
 
     expect(client.request.mock.calls.filter(([method]) => method === "tasks.get")).toHaveLength(32);
     expect(client.request).not.toHaveBeenCalledWith("workboard.cards.update", expect.anything());
@@ -5108,7 +4967,7 @@ describe("workboard controller", () => {
       return { task: replacementTask };
     });
 
-    await syncWorkboardLifecycle({ host, client: client as never, sessions: [] });
+    await syncLifecycle(client);
 
     expect(client.request).toHaveBeenCalledWith("tasks.list", { limit: 500 });
     if (failure !== "tasks unavailable") {
@@ -5140,7 +4999,7 @@ describe("workboard controller", () => {
       return {};
     });
 
-    await syncWorkboardLifecycle({ host, client: client as never, sessions: [] });
+    await syncLifecycle(client);
 
     expect(client.request).not.toHaveBeenCalledWith("workboard.cards.update", expect.anything());
     expect(state.lifecycleTaskRefreshFailed).toBe(true);
@@ -5169,7 +5028,7 @@ describe("workboard controller", () => {
     });
     const requestUpdate = vi.fn();
 
-    await syncWorkboardLifecycle({ host, client: client as never, sessions: [], requestUpdate });
+    await syncLifecycle(client, [], { requestUpdate });
 
     expect(state.missingTaskIds).toEqual(new Set([sampleTask.taskId]));
     expect(client.request).not.toHaveBeenCalledWith("workboard.cards.update", expect.anything());
@@ -5183,8 +5042,8 @@ describe("workboard controller", () => {
       "tasks.list": { tasks: [sampleTask] },
     });
 
-    await syncWorkboardLifecycle({ host, client: client as never, sessions: [] });
-    await syncWorkboardLifecycle({ host, client: client as never, sessions: [] });
+    await syncLifecycle(client);
+    await syncLifecycle(client);
 
     expect(client.request).not.toHaveBeenCalled();
     expect(state.lifecycleTasksPrepared).toBe(true);
@@ -5200,13 +5059,13 @@ describe("workboard controller", () => {
     });
     const requestUpdate = vi.fn();
 
-    await syncWorkboardLifecycle({ host, client: client as never, sessions: [], requestUpdate });
+    await syncLifecycle(client, [], { requestUpdate });
     expect(client.request).not.toHaveBeenCalled();
 
     await vi.advanceTimersByTimeAsync(5000);
     expect(requestUpdate).toHaveBeenCalledOnce();
     vi.clearAllMocks();
-    await syncWorkboardLifecycle({ host, client: client as never, sessions: [], requestUpdate });
+    await syncLifecycle(client, [], { requestUpdate });
 
     expect(client.request).toHaveBeenNthCalledWith(1, "tasks.list", { limit: 500 });
     expect(client.request).toHaveBeenNthCalledWith(2, "workboard.cards.update", expect.anything());
@@ -5227,14 +5086,14 @@ describe("workboard controller", () => {
       return {};
     });
 
-    await syncWorkboardLifecycle({ host, client: client as never, sessions: [], requestUpdate });
+    await syncLifecycle(client, [], { requestUpdate });
     expect(client.request).toHaveBeenCalledOnce();
     expect(requestUpdate).toHaveBeenCalledOnce();
     expect(state.lifecycleTaskRefreshError).toBe("tasks unavailable");
     state.lastRefreshError = "tasks unavailable";
     vi.clearAllMocks();
 
-    await syncWorkboardLifecycle({ host, client: client as never, sessions: [], requestUpdate });
+    await syncLifecycle(client, [], { requestUpdate });
 
     expect(client.request).not.toHaveBeenCalled();
     expect(requestUpdate).not.toHaveBeenCalled();
@@ -5245,7 +5104,7 @@ describe("workboard controller", () => {
     vi.clearAllMocks();
     state.error = "unrelated write error";
     state.lastRefreshError = "newer cards refresh failure";
-    await syncWorkboardLifecycle({ host, client: client as never, sessions: [], requestUpdate });
+    await syncLifecycle(client, [], { requestUpdate });
 
     expect(client.request).toHaveBeenCalledWith("tasks.list", { limit: 500 });
     expect(state.lifecycleTaskRefreshFailed).toBe(false);
@@ -5481,12 +5340,7 @@ describe("workboard controller", () => {
       throw new Error("write denied");
     });
 
-    await syncWorkboardLifecycle({
-      host,
-      client: client as never,
-      sessions: [sampleSession],
-      canWrite: false,
-    });
+    await syncLifecycle(client, [sampleSession], { canWrite: false });
 
     expect(client.request).not.toHaveBeenCalled();
     expect(state.error).toBeNull();
@@ -5506,12 +5360,7 @@ describe("workboard controller", () => {
     state.lastRefreshError = "tasks unavailable";
     const client = createClient({ "tasks.list": { tasks: [sampleTask] } });
 
-    await syncWorkboardLifecycle({
-      host,
-      client: client as never,
-      sessions: [],
-      canWrite: false,
-    });
+    await syncLifecycle(client, [], { canWrite: false });
 
     expect(client.request).toHaveBeenCalledOnce();
     expect(client.request).toHaveBeenCalledWith("tasks.list", { limit: 500 });

--- a/ui/src/pages/workboard/view.test.ts
+++ b/ui/src/pages/workboard/view.test.ts
@@ -3,10 +3,34 @@ import { nothing, render } from "lit";
 import { describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import { getWorkboardState, stopWorkboardLifecycleRefresh } from "../../lib/workboard/index.ts";
+import { createWorkboardCard } from "../../lib/workboard/test/index-helpers.ts";
 import { getRenderedModalDialog } from "../../test-helpers/modal-dialog.ts";
 import { renderWorkboard } from "./view.ts";
 
 type WorkboardRenderProps = Parameters<typeof renderWorkboard>[0];
+
+function createLoadedWorkboardState() {
+  const host = {};
+  const state = getWorkboardState(host);
+  state.loaded = true;
+  return { host, state };
+}
+
+function createWorkboardRenderProps(
+  host: WorkboardRenderProps["host"],
+  overrides: Partial<WorkboardRenderProps> = {},
+): WorkboardRenderProps {
+  return {
+    host,
+    client: null,
+    connected: true,
+    pluginEnabled: true,
+    agentsList: null,
+    sessions: [],
+    onOpenSession: () => undefined,
+    ...overrides,
+  };
+}
 
 function nextFrame() {
   return new Promise<void>((resolve) => {
@@ -66,32 +90,17 @@ function selectWorkboardAgent(select: Element | null | undefined, value: string)
 
 describe("renderWorkboard", () => {
   it("shows a card dashboard only for linked cards while the plugin is active", () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    state.loaded = true;
+    const { host, state } = createLoadedWorkboardState();
     state.detailCardId = "card-1";
     state.cards = [
-      {
-        id: "card-1",
+      createWorkboardCard({
         title: "Dashboard-aware card",
         status: "running",
-        priority: "normal",
-        labels: [],
         position: 1,
-        createdAt: 1,
-        updatedAt: 1,
-      },
+      }),
     ];
     const container = document.createElement("div");
-    const props: WorkboardRenderProps = {
-      host,
-      client: null,
-      connected: true,
-      pluginEnabled: true,
-      agentsList: null,
-      sessions: [],
-      onOpenSession: () => undefined,
-    };
+    const props = createWorkboardRenderProps(host);
 
     renderInto(container, props);
     expect(container.querySelector("openclaw-workboard-card-dashboard")).toBeNull();
@@ -111,17 +120,12 @@ describe("renderWorkboard", () => {
     state.loaded = true;
     state.detailCardId = "card-1";
     state.cards = [
-      {
-        id: "card-1",
+      createWorkboardCard({
         title: "Disposable dashboard card",
         status: "running",
-        priority: "normal",
-        labels: [],
         position: 1,
-        createdAt: 1,
-        updatedAt: 1,
         sessionKey,
-      },
+      }),
     ];
     const removeListener = vi.fn();
     const request = vi.fn(async () => ({
@@ -132,18 +136,12 @@ describe("renderWorkboard", () => {
     }));
     const container = document.createElement("div");
     document.body.append(container);
-    const props: WorkboardRenderProps = {
-      host,
+    const props = createWorkboardRenderProps(host, {
       client: {
         request,
         addEventListener: vi.fn(() => removeListener),
       } as unknown as GatewayBrowserClient,
-      connected: true,
-      pluginEnabled: true,
-      agentsList: null,
-      sessions: [],
-      onOpenSession: () => undefined,
-    };
+    });
 
     renderInto(container, props);
     await vi.waitFor(() => expect(request).toHaveBeenCalledWith("board.get", { sessionKey }));
@@ -157,43 +155,20 @@ describe("renderWorkboard", () => {
   });
 
   it("keeps manual recovery refresh visible while data is loading", () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    state.loaded = true;
+    const { host, state } = createLoadedWorkboardState();
     state.loading = true;
     const container = document.createElement("div");
 
-    render(
-      renderWorkboard({
-        host,
-        client: null,
-        connected: true,
-        pluginEnabled: true,
-        agentsList: null,
-        sessions: [],
-        onOpenSession: () => undefined,
-      }),
-      container,
-    );
+    render(renderWorkboard(createWorkboardRenderProps(host)), container);
 
     expect(buttonByText(container, "Refreshing")?.disabled).toBe(true);
   });
 
   it("renders lifecycle refresh errors without replacing generic errors", () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    state.loaded = true;
+    const { host, state } = createLoadedWorkboardState();
     state.lifecycleTaskRefreshError = "Task refresh unavailable";
     const container = document.createElement("div");
-    const props: WorkboardRenderProps = {
-      host,
-      client: null,
-      connected: true,
-      pluginEnabled: true,
-      agentsList: null,
-      sessions: [],
-      onOpenSession: () => undefined,
-    };
+    const props = createWorkboardRenderProps(host);
 
     renderInto(container, props);
     expect(container.querySelector(".callout.danger")?.textContent).toBe(
@@ -206,20 +181,10 @@ describe("renderWorkboard", () => {
   });
 
   it("keeps dispatch available during refresh and disables it during writes", () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    state.loaded = true;
+    const { host, state } = createLoadedWorkboardState();
     state.loading = true;
     const container = document.createElement("div");
-    const props: WorkboardRenderProps = {
-      host,
-      client: null,
-      connected: true,
-      pluginEnabled: true,
-      agentsList: null,
-      sessions: [],
-      onOpenSession: () => undefined,
-    };
+    const props = createWorkboardRenderProps(host);
 
     render(renderWorkboard(props), container);
 
@@ -256,30 +221,18 @@ describe("renderWorkboard", () => {
     state.dispatching = true;
     state.detailCardId = "card-1";
     state.cards = [
-      {
-        id: "card-1",
+      createWorkboardCard({
         title: "Dispatch-safe card",
-        status: "todo",
-        priority: "normal",
-        labels: [],
-        position: 1000,
-        createdAt: 1,
-        updatedAt: 1,
         sessionKey,
-      },
+      }),
     ];
     const container = document.createElement("div");
-    const props: WorkboardRenderProps = {
-      host,
+    const props = createWorkboardRenderProps(host, {
       client: { request } as unknown as GatewayBrowserClient,
-      connected: true,
-      pluginEnabled: true,
-      agentsList: null,
       sessions: [
         { key: sessionKey, kind: "direct", status: "running", hasActiveRun: true, updatedAt: 2 },
       ],
-      onOpenSession: () => undefined,
-    };
+    });
 
     render(renderWorkboard(props), container);
 
@@ -315,9 +268,7 @@ describe("renderWorkboard", () => {
   });
 
   it("renders stable card action slots and top updated timestamps", () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    state.loaded = true;
+    const { host, state } = createLoadedWorkboardState();
     state.cards = [
       {
         id: "ready",
@@ -345,23 +296,19 @@ describe("renderWorkboard", () => {
     const container = document.createElement("div");
 
     render(
-      renderWorkboard({
-        host,
-        client: null,
-        connected: true,
-        pluginEnabled: true,
-        agentsList: null,
-        sessions: [
-          {
-            key: "agent:main:dashboard:1",
-            kind: "direct",
-            updatedAt: Date.now(),
-            status: "running",
-            hasActiveRun: true,
-          },
-        ],
-        onOpenSession: () => undefined,
-      }),
+      renderWorkboard(
+        createWorkboardRenderProps(host, {
+          sessions: [
+            {
+              key: "agent:main:dashboard:1",
+              kind: "direct",
+              updatedAt: Date.now(),
+              status: "running",
+              hasActiveRun: true,
+            },
+          ],
+        }),
+      ),
       container,
     );
 
@@ -397,9 +344,7 @@ describe("renderWorkboard", () => {
   });
 
   it("renders date and time in detail drawer timestamps", () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    state.loaded = true;
+    const { host, state } = createLoadedWorkboardState();
     state.detailCardId = "card-1";
     state.cards = [
       {
@@ -421,18 +366,7 @@ describe("renderWorkboard", () => {
     ];
     const container = document.createElement("div");
 
-    render(
-      renderWorkboard({
-        host,
-        client: null,
-        connected: true,
-        pluginEnabled: true,
-        agentsList: null,
-        sessions: [],
-        onOpenSession: () => undefined,
-      }),
-      container,
-    );
+    render(renderWorkboard(createWorkboardRenderProps(host)), container);
 
     const detailText = container.querySelector(".workboard-detail")?.textContent ?? "";
     expect(detailText).toContain("Updated");
@@ -440,26 +374,13 @@ describe("renderWorkboard", () => {
   });
 
   it("keeps the last updated timestamp stable next to density controls while refreshing", () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    state.loaded = true;
+    const { host, state } = createLoadedWorkboardState();
     state.loading = true;
     state.lastRefreshAt = new Date("2026-06-03T18:47:00Z").getTime();
     state.lastRefreshStartedAt = Date.now();
     const container = document.createElement("div");
 
-    render(
-      renderWorkboard({
-        host,
-        client: null,
-        connected: true,
-        pluginEnabled: true,
-        agentsList: null,
-        sessions: [],
-        onOpenSession: () => undefined,
-      }),
-      container,
-    );
+    render(renderWorkboard(createWorkboardRenderProps(host)), container);
 
     const layoutControls = container.querySelector(".workboard-layout-controls");
     expect(layoutControls?.querySelector(".workboard-layout-toggle")).toBeTruthy();
@@ -471,9 +392,7 @@ describe("renderWorkboard", () => {
 
   it("renders board columns and preloaded cards", () => {
     const now = Date.now();
-    const host = {};
-    const state = getWorkboardState(host);
-    state.loaded = true;
+    const { host, state } = createLoadedWorkboardState();
     state.cards = [
       {
         id: "card-1",
@@ -492,24 +411,20 @@ describe("renderWorkboard", () => {
     const container = document.createElement("div");
 
     render(
-      renderWorkboard({
-        host,
-        client: null,
-        connected: true,
-        pluginEnabled: true,
-        agentsList: null,
-        sessions: [
-          {
-            key: "agent:main:dashboard:1",
-            kind: "direct",
-            displayName: "Dashboard session",
-            updatedAt: now,
-            hasActiveRun: true,
-            status: "running",
-          },
-        ],
-        onOpenSession: () => undefined,
-      }),
+      renderWorkboard(
+        createWorkboardRenderProps(host, {
+          sessions: [
+            {
+              key: "agent:main:dashboard:1",
+              kind: "direct",
+              displayName: "Dashboard session",
+              updatedAt: now,
+              hasActiveRun: true,
+              status: "running",
+            },
+          ],
+        }),
+      ),
       container,
     );
 
@@ -523,33 +438,17 @@ describe("renderWorkboard", () => {
   });
 
   it("distinguishes the dragged card from its available drop columns", () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    state.loaded = true;
+    const { host, state } = createLoadedWorkboardState();
     state.cards = [
-      {
-        id: "card-1",
+      createWorkboardCard({
         title: "Drag feedback",
-        status: "todo",
-        priority: "normal",
-        labels: [],
-        position: 1000,
-        createdAt: 1,
-        updatedAt: 1,
-      },
+      }),
     ];
     state.draggedCardId = "card-1";
     const container = document.createElement("div");
-    const props: WorkboardRenderProps = {
-      host,
-      client: null,
-      connected: true,
+    const props = createWorkboardRenderProps(host, {
       canWrite: true,
-      pluginEnabled: true,
-      agentsList: null,
-      sessions: [],
-      onOpenSession: () => undefined,
-    };
+    });
 
     renderInto(container, props);
 
@@ -566,20 +465,11 @@ describe("renderWorkboard", () => {
   });
 
   it("hides cached card mutation controls until a lifecycle teardown reload succeeds", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    state.loaded = true;
+    const { host, state } = createLoadedWorkboardState();
     state.cards = [
-      {
-        id: "card-1",
+      createWorkboardCard({
         title: "Stale cached card",
-        status: "todo",
-        priority: "normal",
-        labels: [],
-        position: 1000,
-        createdAt: 1,
-        updatedAt: 1,
-      },
+      }),
     ];
     stopWorkboardLifecycleRefresh(host);
     const props = {
@@ -608,20 +498,11 @@ describe("renderWorkboard", () => {
   });
 
   it("keeps a stale edit draft disabled until it is cancelled", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    state.loaded = true;
+    const { host, state } = createLoadedWorkboardState();
     state.cards = [
-      {
-        id: "card-1",
+      createWorkboardCard({
         title: "Canonical title",
-        status: "todo",
-        priority: "normal",
-        labels: [],
-        position: 1000,
-        createdAt: 1,
-        updatedAt: 1,
-      },
+      }),
     ];
     state.draftOpen = true;
     state.editingCardId = "card-1";
@@ -657,19 +538,11 @@ describe("renderWorkboard", () => {
   });
 
   it("renders health counts and dense card metadata", () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    state.loaded = true;
+    const { host, state } = createLoadedWorkboardState();
     state.cards = [
-      {
-        id: "card-1",
+      createWorkboardCard({
         title: "Blocked worker",
         status: "blocked",
-        priority: "normal",
-        labels: [],
-        position: 1000,
-        createdAt: 1,
-        updatedAt: 1,
         metadata: {
           attempts: [{ id: "attempt-1", status: "failed", startedAt: 1 }],
           claim: {
@@ -702,22 +575,11 @@ describe("renderWorkboard", () => {
           ],
           notifications: [{ id: "note-1", kind: "failed", createdAt: 1, message: "Needs proof." }],
         },
-      },
+      }),
     ];
     const container = document.createElement("div");
 
-    render(
-      renderWorkboard({
-        host,
-        client: null,
-        connected: true,
-        pluginEnabled: true,
-        agentsList: null,
-        sessions: [],
-        onOpenSession: () => undefined,
-      }),
-      container,
-    );
+    render(renderWorkboard(createWorkboardRenderProps(host)), container);
 
     expect(container.querySelector(".workboard-health")?.textContent).toContain("1blocked");
     expect(container.textContent).toContain("1 attempts");
@@ -728,19 +590,11 @@ describe("renderWorkboard", () => {
   });
 
   it("keeps bounded diagnostic badges UTF-16 safe", () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    state.loaded = true;
+    const { host, state } = createLoadedWorkboardState();
     state.cards = [
-      {
+      createWorkboardCard({
         id: "card-boundary",
         title: "Boundary badge",
-        status: "todo",
-        priority: "normal",
-        labels: [],
-        position: 1000,
-        createdAt: 1,
-        updatedAt: 1,
         metadata: {
           diagnostics: [
             {
@@ -755,22 +609,11 @@ describe("renderWorkboard", () => {
             },
           ],
         },
-      },
+      }),
     ];
     const container = document.createElement("div");
 
-    render(
-      renderWorkboard({
-        host,
-        client: null,
-        connected: true,
-        pluginEnabled: true,
-        agentsList: null,
-        sessions: [],
-        onOpenSession: () => undefined,
-      }),
-      container,
-    );
+    render(renderWorkboard(createWorkboardRenderProps(host)), container);
 
     expect(container.querySelector(".workboard-card__badge--warning")?.textContent?.trim()).toBe(
       `${"x".repeat(62)}…`,
@@ -780,19 +623,11 @@ describe("renderWorkboard", () => {
   it("renders sub-minute heartbeat ages with the duration count interpolation", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-06-13T12:00:00Z"));
-    const host = {};
-    const state = getWorkboardState(host);
-    state.loaded = true;
+    const { host, state } = createLoadedWorkboardState();
     state.cards = [
-      {
-        id: "card-1",
+      createWorkboardCard({
         title: "Active worker",
         status: "running",
-        priority: "normal",
-        labels: [],
-        position: 1000,
-        createdAt: 1,
-        updatedAt: 1,
         metadata: {
           claim: {
             ownerId: "agent-1",
@@ -801,7 +636,7 @@ describe("renderWorkboard", () => {
             lastHeartbeatAt: Date.now() - 42_000,
           },
         },
-      },
+      }),
     ];
     const container = document.createElement("div");
 
@@ -823,20 +658,12 @@ describe("renderWorkboard", () => {
   });
 
   it("highlights cards matching a clicked health badge", () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    state.loaded = true;
+    const { host, state } = createLoadedWorkboardState();
     state.cards = [
-      {
-        id: "card-1",
+      createWorkboardCard({
         title: "Blocked worker",
         status: "blocked",
-        priority: "normal",
-        labels: [],
-        position: 1000,
-        createdAt: 1,
-        updatedAt: 1,
-      },
+      }),
       {
         id: "card-2",
         title: "Running worker",
@@ -849,19 +676,7 @@ describe("renderWorkboard", () => {
       },
     ];
     const container = document.createElement("div");
-    const renderBoard = () =>
-      render(
-        renderWorkboard({
-          host,
-          client: null,
-          connected: true,
-          pluginEnabled: true,
-          agentsList: null,
-          sessions: [],
-          onOpenSession: () => undefined,
-        }),
-        container,
-      );
+    const renderBoard = () => render(renderWorkboard(createWorkboardRenderProps(host)), container);
 
     renderBoard();
 
@@ -897,46 +712,23 @@ describe("renderWorkboard", () => {
   });
 
   it("filters cards with the view preset selector", () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    state.loaded = true;
+    const { host, state } = createLoadedWorkboardState();
     state.viewPreset = "ready";
     state.cards = [
-      {
+      createWorkboardCard({
         id: "ready",
         title: "Ready card",
         status: "ready",
-        priority: "normal",
-        labels: [],
-        position: 1000,
-        createdAt: 1,
-        updatedAt: 1,
-      },
-      {
+      }),
+      createWorkboardCard({
         id: "blocked",
         title: "Blocked card",
         status: "blocked",
-        priority: "normal",
-        labels: [],
-        position: 1000,
-        createdAt: 1,
-        updatedAt: 1,
-      },
+      }),
     ];
     const container = document.createElement("div");
 
-    render(
-      renderWorkboard({
-        host,
-        client: null,
-        connected: true,
-        pluginEnabled: true,
-        agentsList: null,
-        sessions: [],
-        onOpenSession: () => undefined,
-      }),
-      container,
-    );
+    render(renderWorkboard(createWorkboardRenderProps(host)), container);
 
     expect(container.textContent).toContain("Ready card");
     expect(container.textContent).not.toContain("Blocked card");
@@ -954,36 +746,18 @@ describe("renderWorkboard", () => {
   });
 
   it("shows an empty state and disables zero-result view presets", () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    state.loaded = true;
+    const { host, state } = createLoadedWorkboardState();
     state.viewPreset = "running";
     state.cards = [
-      {
+      createWorkboardCard({
         id: "card-ready",
         title: "Ready card",
         status: "ready",
-        priority: "normal",
-        labels: [],
-        position: 1000,
-        createdAt: 1,
-        updatedAt: 1,
-      },
+      }),
     ];
     const container = document.createElement("div");
 
-    render(
-      renderWorkboard({
-        host,
-        client: null,
-        connected: true,
-        pluginEnabled: true,
-        agentsList: null,
-        sessions: [],
-        onOpenSession: () => undefined,
-      }),
-      container,
-    );
+    render(renderWorkboard(createWorkboardRenderProps(host)), container);
 
     expect(container.querySelector(".workboard-column")).toBeNull();
     expect(container.querySelector(".workboard-board")).toBeNull();
@@ -999,37 +773,19 @@ describe("renderWorkboard", () => {
   });
 
   it("shows the empty state when non-view filters match no cards", () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    state.loaded = true;
+    const { host, state } = createLoadedWorkboardState();
     state.viewPreset = "all";
     state.priorityFilter = "urgent";
     state.cards = [
-      {
+      createWorkboardCard({
         id: "card-ready",
         title: "Ready card",
         status: "ready",
-        priority: "normal",
-        labels: [],
-        position: 1000,
-        createdAt: 1,
-        updatedAt: 1,
-      },
+      }),
     ];
     const container = document.createElement("div");
 
-    render(
-      renderWorkboard({
-        host,
-        client: null,
-        connected: true,
-        pluginEnabled: true,
-        agentsList: null,
-        sessions: [],
-        onOpenSession: () => undefined,
-      }),
-      container,
-    );
+    render(renderWorkboard(createWorkboardRenderProps(host)), container);
 
     expect(container.querySelector(".workboard-column")).toBeNull();
     expect(container.querySelector(".workboard-empty-state")?.textContent).toContain(
@@ -1038,26 +794,20 @@ describe("renderWorkboard", () => {
   });
 
   it("uses the same Web Awesome select control for Workboard toolbar filters", () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    state.loaded = true;
+    const { host } = createLoadedWorkboardState();
     const container = document.createElement("div");
 
     render(
-      renderWorkboard({
-        host,
-        client: null,
-        connected: true,
-        pluginEnabled: true,
-        agentsList: {
-          defaultId: "main",
-          mainKey: "agent:main:main",
-          scope: "test",
-          agents: [{ id: "main", name: "Main" }],
-        },
-        sessions: [],
-        onOpenSession: () => undefined,
-      }),
+      renderWorkboard(
+        createWorkboardRenderProps(host, {
+          agentsList: {
+            defaultId: "main",
+            mainKey: "agent:main:main",
+            scope: "test",
+            agents: [{ id: "main", name: "Main" }],
+          },
+        }),
+      ),
       container,
     );
 
@@ -1081,22 +831,15 @@ describe("renderWorkboard", () => {
   });
 
   it("filters cards to the global agent scope and hides the secondary agent filter", () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    state.loaded = true;
+    const { host, state } = createLoadedWorkboardState();
     state.viewPreset = "all";
     state.cards = [
-      {
+      createWorkboardCard({
         id: "writer-card",
         title: "Writer card",
         status: "ready",
-        priority: "normal",
-        labels: [],
-        position: 1000,
-        createdAt: 1,
-        updatedAt: 1,
         agentId: "writer",
-      },
+      }),
       {
         id: "ops-card",
         title: "Ops card",
@@ -1112,22 +855,18 @@ describe("renderWorkboard", () => {
     const container = document.createElement("div");
 
     render(
-      renderWorkboard({
-        host,
-        client: null,
-        connected: true,
-        pluginEnabled: true,
-        agentsList: {
-          defaultId: "main",
-          mainKey: "agent:main:main",
-          scope: "test",
-          agents: [{ id: "main" }, { id: "writer" }, { id: "ops" }],
-        },
-        sessions: [],
-        scopeAgentId: "writer",
-        showAgentFilter: false,
-        onOpenSession: () => undefined,
-      }),
+      renderWorkboard(
+        createWorkboardRenderProps(host, {
+          agentsList: {
+            defaultId: "main",
+            mainKey: "agent:main:main",
+            scope: "test",
+            agents: [{ id: "main" }, { id: "writer" }, { id: "ops" }],
+          },
+          scopeAgentId: "writer",
+          showAgentFilter: false,
+        }),
+      ),
       container,
     );
 
@@ -1137,23 +876,10 @@ describe("renderWorkboard", () => {
   });
 
   it("uses labelled controls for Workboard filters", () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    state.loaded = true;
+    const { host } = createLoadedWorkboardState();
     const container = document.createElement("div");
 
-    render(
-      renderWorkboard({
-        host,
-        client: null,
-        connected: true,
-        pluginEnabled: true,
-        agentsList: null,
-        sessions: [],
-        onOpenSession: () => undefined,
-      }),
-      container,
-    );
+    render(renderWorkboard(createWorkboardRenderProps(host)), container);
 
     const selects = [
       ...container.querySelectorAll<HTMLElement & { value: string }>(
@@ -1175,20 +901,11 @@ describe("renderWorkboard", () => {
   });
 
   it("can hide empty columns while keeping populated columns visible", () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    state.loaded = true;
+    const { host, state } = createLoadedWorkboardState();
     state.cards = [
-      {
-        id: "card-1",
+      createWorkboardCard({
         title: "Keep visible",
-        status: "todo",
-        priority: "normal",
-        labels: [],
-        position: 1000,
-        createdAt: 1,
-        updatedAt: 1,
-      },
+      }),
     ];
     const container = document.createElement("div");
     const props = {
@@ -1224,9 +941,7 @@ describe("renderWorkboard", () => {
   });
 
   it("does not render Invalid Date for Date-invalid card timestamps", () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    state.loaded = true;
+    const { host, state } = createLoadedWorkboardState();
     state.cards = [
       {
         id: "card-1",
@@ -1242,18 +957,7 @@ describe("renderWorkboard", () => {
     ];
     const container = document.createElement("div");
 
-    render(
-      renderWorkboard({
-        host,
-        client: null,
-        connected: true,
-        pluginEnabled: true,
-        agentsList: null,
-        sessions: [],
-        onOpenSession: () => undefined,
-      }),
-      container,
-    );
+    render(renderWorkboard(createWorkboardRenderProps(host)), container);
 
     expect(container.textContent).toContain("Bad timestamp card");
     expect(container.textContent).not.toContain("Invalid Date");
@@ -1265,63 +969,51 @@ describe("renderWorkboard", () => {
     const onOpenSession = vi.fn();
     state.loaded = true;
     state.cards = [
-      {
-        id: "card-1",
+      createWorkboardCard({
         title: "Inspect a running task",
         status: "running",
-        priority: "normal",
-        labels: [],
-        position: 1000,
-        createdAt: 1,
-        updatedAt: 1,
         sessionKey: "agent:main:dashboard:1",
-      },
+      }),
     ];
     const container = document.createElement("div");
 
     render(
-      renderWorkboard({
-        host,
-        client: null,
-        connected: true,
-        pluginEnabled: true,
-        agentsList: null,
-        sessions: [
-          {
-            key: "agent:main:dashboard:1",
-            kind: "direct",
-            displayName: "Dashboard session",
-            updatedAt: 2,
-            hasActiveRun: true,
-            status: "running",
-          },
-        ],
-        onOpenSession,
-      }),
+      renderWorkboard(
+        createWorkboardRenderProps(host, {
+          sessions: [
+            {
+              key: "agent:main:dashboard:1",
+              kind: "direct",
+              displayName: "Dashboard session",
+              updatedAt: 2,
+              hasActiveRun: true,
+              status: "running",
+            },
+          ],
+          onOpenSession,
+        }),
+      ),
       container,
     );
 
     const card = container.querySelector<HTMLElement>(".workboard-card");
     card?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     render(
-      renderWorkboard({
-        host,
-        client: null,
-        connected: true,
-        pluginEnabled: true,
-        agentsList: null,
-        sessions: [
-          {
-            key: "agent:main:dashboard:1",
-            kind: "direct",
-            displayName: "Dashboard session",
-            updatedAt: 2,
-            hasActiveRun: true,
-            status: "running",
-          },
-        ],
-        onOpenSession,
-      }),
+      renderWorkboard(
+        createWorkboardRenderProps(host, {
+          sessions: [
+            {
+              key: "agent:main:dashboard:1",
+              kind: "direct",
+              displayName: "Dashboard session",
+              updatedAt: 2,
+              hasActiveRun: true,
+              status: "running",
+            },
+          ],
+          onOpenSession,
+        }),
+      ),
       container,
     );
     expect(container.querySelector(".workboard-detail")?.textContent).toContain(
@@ -1343,40 +1035,32 @@ describe("renderWorkboard", () => {
     state.loaded = true;
     state.detailCardId = "card-1";
     state.cards = [
-      {
-        id: "card-1",
+      createWorkboardCard({
         title: "Detail parity",
         status: "running",
-        priority: "normal",
-        labels: [],
-        position: 1000,
-        createdAt: 1,
-        updatedAt: 1,
         sessionKey,
-      },
+      }),
     ];
     const container = document.createElement("div");
     const onOpenSession = vi.fn();
 
     render(
-      renderWorkboard({
-        host,
-        client: { request: vi.fn() } as unknown as GatewayBrowserClient,
-        connected: true,
-        pluginEnabled: true,
-        agentsList: null,
-        sessions: [
-          {
-            key: sessionKey,
-            kind: "direct",
-            displayName: "Detail parity session",
-            updatedAt: 2,
-            hasActiveRun: true,
-            status: "running",
-          },
-        ],
-        onOpenSession,
-      }),
+      renderWorkboard(
+        createWorkboardRenderProps(host, {
+          client: { request: vi.fn() } as unknown as GatewayBrowserClient,
+          sessions: [
+            {
+              key: sessionKey,
+              kind: "direct",
+              displayName: "Detail parity session",
+              updatedAt: 2,
+              hasActiveRun: true,
+              status: "running",
+            },
+          ],
+          onOpenSession,
+        }),
+      ),
       container,
     );
 
@@ -1400,22 +1084,13 @@ describe("renderWorkboard", () => {
   });
 
   it("keeps focus inside the card modal and restores focus on Escape", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    state.loaded = true;
+    const { host, state } = createLoadedWorkboardState();
     state.cards = [];
     const container = document.createElement("div");
     document.body.append(container);
-    const props: WorkboardRenderProps = {
-      host,
-      client: null,
-      connected: true,
-      pluginEnabled: true,
-      agentsList: null,
-      sessions: [],
-      onOpenSession: () => undefined,
+    const props = createWorkboardRenderProps(host, {
       onRequestUpdate: () => renderInto(container, props),
-    };
+    });
 
     try {
       renderInto(container, props);
@@ -1451,21 +1126,12 @@ describe("renderWorkboard", () => {
   });
 
   it("lets Escape close the card modal from a closed Web Awesome select", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    state.loaded = true;
+    const { host } = createLoadedWorkboardState();
     const container = document.createElement("div");
     document.body.append(container);
-    const props: WorkboardRenderProps = {
-      host,
-      client: null,
-      connected: true,
-      pluginEnabled: true,
-      agentsList: null,
-      sessions: [],
-      onOpenSession: () => undefined,
+    const props = createWorkboardRenderProps(host, {
       onRequestUpdate: () => renderInto(container, props),
-    };
+    });
 
     try {
       renderInto(container, props);
@@ -1489,33 +1155,17 @@ describe("renderWorkboard", () => {
   });
 
   it("treats the detail drawer as a labelled keyboard-modal dialog", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    state.loaded = true;
+    const { host, state } = createLoadedWorkboardState();
     state.cards = [
-      {
-        id: "card-1",
+      createWorkboardCard({
         title: "Inspect drawer focus",
-        status: "todo",
-        priority: "normal",
-        labels: [],
-        position: 1000,
-        createdAt: 1,
-        updatedAt: 1,
-      },
+      }),
     ];
     const container = document.createElement("div");
     document.body.append(container);
-    const props: WorkboardRenderProps = {
-      host,
-      client: null,
-      connected: true,
-      pluginEnabled: true,
-      agentsList: null,
-      sessions: [],
-      onOpenSession: () => undefined,
+    const props = createWorkboardRenderProps(host, {
       onRequestUpdate: () => renderInto(container, props),
-    };
+    });
 
     try {
       renderInto(container, props);
@@ -1548,22 +1198,13 @@ describe("renderWorkboard", () => {
   });
 
   it("does not restore focus to a disconnected modal opener", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    state.loaded = true;
+    const { host, state } = createLoadedWorkboardState();
     state.cards = [];
     const container = document.createElement("div");
     document.body.append(container);
-    const props: WorkboardRenderProps = {
-      host,
-      client: null,
-      connected: true,
-      pluginEnabled: true,
-      agentsList: null,
-      sessions: [],
-      onOpenSession: () => undefined,
+    const props = createWorkboardRenderProps(host, {
       onRequestUpdate: () => renderInto(container, props),
-    };
+    });
 
     try {
       renderInto(container, props);
@@ -1590,33 +1231,17 @@ describe("renderWorkboard", () => {
   });
 
   it("restores focus when the detail drawer is removed by state", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    state.loaded = true;
+    const { host, state } = createLoadedWorkboardState();
     state.cards = [
-      {
-        id: "card-1",
+      createWorkboardCard({
         title: "Remove drawer externally",
-        status: "todo",
-        priority: "normal",
-        labels: [],
-        position: 1000,
-        createdAt: 1,
-        updatedAt: 1,
-      },
+      }),
     ];
     const container = document.createElement("div");
     document.body.append(container);
-    const props: WorkboardRenderProps = {
-      host,
-      client: null,
-      connected: true,
-      pluginEnabled: true,
-      agentsList: null,
-      sessions: [],
-      onOpenSession: () => undefined,
+    const props = createWorkboardRenderProps(host, {
       onRequestUpdate: () => renderInto(container, props),
-    };
+    });
 
     try {
       renderInto(container, props);
@@ -1640,35 +1265,15 @@ describe("renderWorkboard", () => {
   });
 
   it("keeps cards compact and puts model-specific execution actions in details", () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    state.loaded = true;
+    const { host, state } = createLoadedWorkboardState();
     state.cards = [
-      {
-        id: "card-1",
+      createWorkboardCard({
         title: "Start this later",
-        status: "todo",
-        priority: "normal",
-        labels: [],
-        position: 1000,
-        createdAt: 1,
-        updatedAt: 1,
-      },
+      }),
     ];
     const container = document.createElement("div");
 
-    render(
-      renderWorkboard({
-        host,
-        client: null,
-        connected: true,
-        pluginEnabled: true,
-        agentsList: null,
-        sessions: [],
-        onOpenSession: () => undefined,
-      }),
-      container,
-    );
+    render(renderWorkboard(createWorkboardRenderProps(host)), container);
 
     const startButtons = [
       ...container.querySelectorAll<HTMLButtonElement>(".workboard-card__start"),
@@ -1682,18 +1287,7 @@ describe("renderWorkboard", () => {
     container
       .querySelector<HTMLButtonElement>('button[aria-label="View details"]')
       ?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-    render(
-      renderWorkboard({
-        host,
-        client: null,
-        connected: true,
-        pluginEnabled: true,
-        agentsList: null,
-        sessions: [],
-        onOpenSession: () => undefined,
-      }),
-      container,
-    );
+    render(renderWorkboard(createWorkboardRenderProps(host)), container);
 
     const detailStartButtons = [
       ...container.querySelectorAll<HTMLButtonElement>(".workboard-detail .workboard-card__start"),
@@ -1708,20 +1302,12 @@ describe("renderWorkboard", () => {
   });
 
   it("shows unfinished parent dependencies without blocking stale local starts", () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    state.loaded = true;
+    const { host, state } = createLoadedWorkboardState();
     state.cards = [
-      {
+      createWorkboardCard({
         id: "parent-1",
         title: "Finish art pass",
-        status: "todo",
-        priority: "normal",
-        labels: [],
-        position: 1000,
-        createdAt: 1,
-        updatedAt: 1,
-      },
+      }),
       {
         id: "child-1",
         title: "Ship game shell",
@@ -1784,34 +1370,20 @@ describe("renderWorkboard", () => {
   });
 
   it("hides autonomous model override actions for non-admin operators", () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    state.loaded = true;
+    const { host, state } = createLoadedWorkboardState();
     state.cards = [
-      {
-        id: "card-1",
+      createWorkboardCard({
         title: "Start with default model",
-        status: "todo",
-        priority: "normal",
-        labels: [],
-        position: 1000,
-        createdAt: 1,
-        updatedAt: 1,
-      },
+      }),
     ];
     const container = document.createElement("div");
 
     render(
-      renderWorkboard({
-        host,
-        client: null,
-        connected: true,
-        canModelOverride: false,
-        pluginEnabled: true,
-        agentsList: null,
-        sessions: [],
-        onOpenSession: () => undefined,
-      }),
+      renderWorkboard(
+        createWorkboardRenderProps(host, {
+          canModelOverride: false,
+        }),
+      ),
       container,
     );
 
@@ -1827,16 +1399,11 @@ describe("renderWorkboard", () => {
       .querySelector<HTMLButtonElement>('button[aria-label="View details"]')
       ?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     render(
-      renderWorkboard({
-        host,
-        client: null,
-        connected: true,
-        canModelOverride: false,
-        pluginEnabled: true,
-        agentsList: null,
-        sessions: [],
-        onOpenSession: () => undefined,
-      }),
+      renderWorkboard(
+        createWorkboardRenderProps(host, {
+          canModelOverride: false,
+        }),
+      ),
       container,
     );
     const detailStartButtons = [
@@ -1850,23 +1417,15 @@ describe("renderWorkboard", () => {
   });
 
   it("renders linked Gateway task status on cards", () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    state.loaded = true;
+    const { host, state } = createLoadedWorkboardState();
     state.cards = [
-      {
-        id: "card-1",
+      createWorkboardCard({
         title: "Review task result",
         status: "running",
-        priority: "normal",
-        labels: [],
-        position: 1000,
-        createdAt: 1,
-        updatedAt: 1,
         sessionKey: "agent:main:subagent:workboard-default-card-1",
         runId: "run-1",
         taskId: "task-1",
-      },
+      }),
     ];
     state.tasksByCardId.set("card-1", {
       id: "task-1",
@@ -1879,18 +1438,7 @@ describe("renderWorkboard", () => {
     });
     const container = document.createElement("div");
 
-    render(
-      renderWorkboard({
-        host,
-        client: null,
-        connected: true,
-        pluginEnabled: true,
-        agentsList: null,
-        sessions: [],
-        onOpenSession: () => undefined,
-      }),
-      container,
-    );
+    render(renderWorkboard(createWorkboardRenderProps(host)), container);
 
     expect(container.textContent).toContain("task linked");
     expect(container.textContent).toContain("Task complete");
@@ -1898,23 +1446,15 @@ describe("renderWorkboard", () => {
   });
 
   it("uses terminal session lifecycle when cached task status is stale", () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    state.loaded = true;
+    const { host, state } = createLoadedWorkboardState();
     state.cards = [
-      {
-        id: "card-1",
+      createWorkboardCard({
         title: "Finished despite stale task",
         status: "running",
-        priority: "normal",
-        labels: [],
-        position: 1000,
-        createdAt: 1,
-        updatedAt: 1,
         sessionKey: "agent:main:subagent:workboard-default-card-1",
         runId: "run-1",
         taskId: "task-1",
-      },
+      }),
     ];
     state.tasksByCardId.set("card-1", {
       id: "task-1",
@@ -1965,21 +1505,13 @@ describe("renderWorkboard", () => {
   });
 
   it("shows stop controls without start controls for active task-only cards", () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    state.loaded = true;
+    const { host, state } = createLoadedWorkboardState();
     state.cards = [
-      {
-        id: "card-1",
+      createWorkboardCard({
         title: "Task only run",
         status: "running",
-        priority: "normal",
-        labels: [],
-        position: 1000,
-        createdAt: 1,
-        updatedAt: 1,
         taskId: "task-1",
-      },
+      }),
     ];
     state.tasksByCardId.set("card-1", {
       id: "task-1",
@@ -2019,72 +1551,34 @@ describe("renderWorkboard", () => {
   });
 
   it("keeps unresolved task-linked cards from exposing duplicate starts", () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    state.loaded = true;
+    const { host, state } = createLoadedWorkboardState();
     state.cards = [
-      {
-        id: "card-1",
+      createWorkboardCard({
         title: "Historical task link",
         status: "running",
-        priority: "normal",
-        labels: [],
-        position: 1000,
-        createdAt: 1,
-        updatedAt: 1,
         taskId: "task-older-than-poll-page",
-      },
+      }),
     ];
     const container = document.createElement("div");
 
-    render(
-      renderWorkboard({
-        host,
-        client: null,
-        connected: true,
-        pluginEnabled: true,
-        agentsList: null,
-        sessions: [],
-        onOpenSession: () => undefined,
-      }),
-      container,
-    );
+    render(renderWorkboard(createWorkboardRenderProps(host)), container);
 
     expect(container.querySelector('button[aria-label="Stop thread"]')).not.toBeNull();
     expect(container.querySelectorAll<HTMLButtonElement>(".workboard-card__start")).toHaveLength(0);
   });
 
   it("does not expose live controls for terminal cards with unresolved task links", () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    state.loaded = true;
+    const { host, state } = createLoadedWorkboardState();
     state.cards = [
-      {
-        id: "card-1",
+      createWorkboardCard({
         title: "Completed historical task",
         status: "done",
-        priority: "normal",
-        labels: [],
-        position: 1000,
-        createdAt: 1,
-        updatedAt: 1,
         taskId: "task-older-than-poll-page",
-      },
+      }),
     ];
     const container = document.createElement("div");
 
-    render(
-      renderWorkboard({
-        host,
-        client: null,
-        connected: true,
-        pluginEnabled: true,
-        agentsList: null,
-        sessions: [],
-        onOpenSession: () => undefined,
-      }),
-      container,
-    );
+    render(renderWorkboard(createWorkboardRenderProps(host)), container);
 
     expect(container.querySelector(".workboard-live")).toBeNull();
     expect(container.querySelector('button[aria-label="Stop thread"]')).toBeNull();
@@ -2092,108 +1586,56 @@ describe("renderWorkboard", () => {
   });
 
   it("keeps newly started unresolved runs from exposing duplicate starts", () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    state.loaded = true;
+    const { host, state } = createLoadedWorkboardState();
     state.cards = [
-      {
-        id: "card-1",
+      createWorkboardCard({
         title: "Newly started run",
         status: "running",
-        priority: "normal",
-        labels: [],
-        position: 1000,
-        createdAt: 1,
-        updatedAt: 1,
         sessionKey: "agent:main:subagent:workboard-default-card-1",
         runId: "run-1",
-      },
+      }),
     ];
     const container = document.createElement("div");
 
-    render(
-      renderWorkboard({
-        host,
-        client: null,
-        connected: true,
-        pluginEnabled: true,
-        agentsList: null,
-        sessions: [],
-        onOpenSession: () => undefined,
-      }),
-      container,
-    );
+    render(renderWorkboard(createWorkboardRenderProps(host)), container);
 
     expect(container.querySelector('button[aria-label="Stop thread"]')).not.toBeNull();
     expect(container.querySelectorAll<HTMLButtonElement>(".workboard-card__start")).toHaveLength(0);
   });
 
   it("allows starts for authoritatively missing historical task links", () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    state.loaded = true;
+    const { host, state } = createLoadedWorkboardState();
     state.cards = [
-      {
-        id: "card-1",
+      createWorkboardCard({
         title: "Historical task link",
         status: "running",
-        priority: "normal",
-        labels: [],
-        position: 1000,
-        createdAt: 1,
-        updatedAt: 1,
         taskId: "task-pruned-from-ledger",
-      },
+      }),
     ];
     state.missingTaskIds = new Set(["task-pruned-from-ledger"]);
     const container = document.createElement("div");
 
-    render(
-      renderWorkboard({
-        host,
-        client: null,
-        connected: true,
-        pluginEnabled: true,
-        agentsList: null,
-        sessions: [],
-        onOpenSession: () => undefined,
-      }),
-      container,
-    );
+    render(renderWorkboard(createWorkboardRenderProps(host)), container);
 
     expect(container.querySelector('button[aria-label="Stop thread"]')).toBeNull();
     expect(container.querySelectorAll<HTMLButtonElement>(".workboard-card__start")).toHaveLength(1);
   });
 
   it("hides write controls for read-only operators", () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    state.loaded = true;
+    const { host, state } = createLoadedWorkboardState();
     state.cards = [
-      {
-        id: "card-1",
+      createWorkboardCard({
         title: "Inspect only",
-        status: "todo",
-        priority: "normal",
-        labels: [],
-        position: 1000,
-        createdAt: 1,
-        updatedAt: 1,
-      },
+      }),
     ];
     const container = document.createElement("div");
 
     render(
-      renderWorkboard({
-        host,
-        client: null,
-        connected: true,
-        canWrite: false,
-        pluginEnabled: true,
-        agentsList: null,
-        sessions: [],
-        onOpenSession: () => undefined,
-      }),
+      renderWorkboard(
+        createWorkboardRenderProps(host, {
+          canWrite: false,
+        }),
+      ),
       container,
     );
 
@@ -2209,20 +1651,11 @@ describe("renderWorkboard", () => {
   });
 
   it("moves a card from the compact status control", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    state.loaded = true;
+    const { host, state } = createLoadedWorkboardState();
     state.cards = [
-      {
-        id: "card-1",
+      createWorkboardCard({
         title: "Keyboard move",
-        status: "todo",
-        priority: "normal",
-        labels: [],
-        position: 1000,
-        createdAt: 1,
-        updatedAt: 1,
-      },
+      }),
     ];
     const request = vi.fn(async () => ({
       card: { ...state.cards[0], status: "blocked", position: 1000, updatedAt: 2 },
@@ -2265,20 +1698,11 @@ describe("renderWorkboard", () => {
   });
 
   it("moves a focused status control with keyboard arrows", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    state.loaded = true;
+    const { host, state } = createLoadedWorkboardState();
     state.cards = [
-      {
-        id: "card-1",
+      createWorkboardCard({
         title: "Keyboard arrow move",
-        status: "todo",
-        priority: "normal",
-        labels: [],
-        position: 1000,
-        createdAt: 1,
-        updatedAt: 1,
-      },
+      }),
     ];
     const request = vi.fn(async () => ({
       card: { ...state.cards[0], status: "scheduled", position: 1000, updatedAt: 2 },
@@ -2313,21 +1737,12 @@ describe("renderWorkboard", () => {
   });
 
   it("does not queue status-control moves while a card is busy", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    state.loaded = true;
+    const { host, state } = createLoadedWorkboardState();
     state.busyCardIds.add("card-1");
     state.cards = [
-      {
-        id: "card-1",
+      createWorkboardCard({
         title: "Busy move",
-        status: "todo",
-        priority: "normal",
-        labels: [],
-        position: 1000,
-        createdAt: 1,
-        updatedAt: 1,
-      },
+      }),
     ];
     const request = vi.fn();
     const props = {
@@ -2359,36 +1774,17 @@ describe("renderWorkboard", () => {
   });
 
   it("offers start controls when a linked session no longer exists", () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    state.loaded = true;
+    const { host, state } = createLoadedWorkboardState();
     state.cards = [
-      {
-        id: "card-1",
+      createWorkboardCard({
         title: "Restart this",
         status: "blocked",
-        priority: "normal",
-        labels: [],
-        position: 1000,
-        createdAt: 1,
-        updatedAt: 1,
         sessionKey: "agent:main:missing:1",
-      },
+      }),
     ];
     const container = document.createElement("div");
 
-    render(
-      renderWorkboard({
-        host,
-        client: null,
-        connected: true,
-        pluginEnabled: true,
-        agentsList: null,
-        sessions: [],
-        onOpenSession: () => undefined,
-      }),
-      container,
-    );
+    render(renderWorkboard(createWorkboardRenderProps(host)), container);
 
     expect(container.textContent).toContain("Thread missing");
     expect(container.querySelectorAll<HTMLButtonElement>(".workboard-card__start")).toHaveLength(1);
@@ -2399,34 +1795,12 @@ describe("renderWorkboard", () => {
     getWorkboardState(host).loaded = true;
     const container = document.createElement("div");
 
-    render(
-      renderWorkboard({
-        host,
-        client: null,
-        connected: true,
-        pluginEnabled: true,
-        agentsList: null,
-        sessions: [],
-        onOpenSession: () => undefined,
-      }),
-      container,
-    );
+    render(renderWorkboard(createWorkboardRenderProps(host)), container);
 
     container
       .querySelector<HTMLButtonElement>(".workboard-toolbar__actions .btn.primary")
       ?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-    render(
-      renderWorkboard({
-        host,
-        client: null,
-        connected: true,
-        pluginEnabled: true,
-        agentsList: null,
-        sessions: [],
-        onOpenSession: () => undefined,
-      }),
-      container,
-    );
+    render(renderWorkboard(createWorkboardRenderProps(host)), container);
 
     expect(container.querySelector("openclaw-modal-dialog")?.textContent).toContain("New card");
     expect(container.querySelector('[aria-label="Card templates"]')?.textContent).toContain(
@@ -2436,9 +1810,7 @@ describe("renderWorkboard", () => {
   });
 
   it("applies card templates in the create modal", () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    state.loaded = true;
+    const { host, state } = createLoadedWorkboardState();
     state.draftOpen = true;
     const container = document.createElement("div");
     const props = {
@@ -2468,9 +1840,7 @@ describe("renderWorkboard", () => {
   });
 
   it("renders card event history", () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    state.loaded = true;
+    const { host, state } = createLoadedWorkboardState();
     state.cards = [
       {
         id: "card-1",
@@ -2520,19 +1890,10 @@ describe("renderWorkboard", () => {
   });
 
   it("renders card metadata badges and hides archived cards", () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    state.loaded = true;
+    const { host, state } = createLoadedWorkboardState();
     state.cards = [
-      {
-        id: "card-1",
+      createWorkboardCard({
         title: "Metadata rich",
-        status: "todo",
-        priority: "normal",
-        labels: [],
-        position: 1000,
-        createdAt: 1,
-        updatedAt: 1,
         metadata: {
           templateId: "plugin",
           attempts: [{ id: "run-1", status: "blocked", startedAt: 1, endedAt: 2 }],
@@ -2561,7 +1922,7 @@ describe("renderWorkboard", () => {
           })),
           stale: { detectedAt: 6, reason: "No recent activity." },
         },
-      },
+      }),
       {
         id: "card-2",
         title: "Archived task",
@@ -2576,18 +1937,7 @@ describe("renderWorkboard", () => {
     ];
     const container = document.createElement("div");
 
-    render(
-      renderWorkboard({
-        host,
-        client: null,
-        connected: true,
-        pluginEnabled: true,
-        agentsList: null,
-        sessions: [],
-        onOpenSession: () => undefined,
-      }),
-      container,
-    );
+    render(renderWorkboard(createWorkboardRenderProps(host)), container);
 
     expect(container.textContent).toContain("Plugin");
     expect(container.textContent).toContain("1 failed");
@@ -2599,36 +1949,14 @@ describe("renderWorkboard", () => {
     container
       .querySelector<HTMLButtonElement>(".workboard-archive-toggle")
       ?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-    render(
-      renderWorkboard({
-        host,
-        client: null,
-        connected: true,
-        pluginEnabled: true,
-        agentsList: null,
-        sessions: [],
-        onOpenSession: () => undefined,
-      }),
-      container,
-    );
+    render(renderWorkboard(createWorkboardRenderProps(host)), container);
     expect(container.textContent).toContain("Archived task");
     expect(container.querySelector<HTMLButtonElement>(".workboard-archive-toggle")).not.toBeNull();
 
     container
       .querySelector<HTMLButtonElement>('button[aria-label="View details"]')
       ?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-    render(
-      renderWorkboard({
-        host,
-        client: null,
-        connected: true,
-        pluginEnabled: true,
-        agentsList: null,
-        sessions: [],
-        onOpenSession: () => undefined,
-      }),
-      container,
-    );
+    render(renderWorkboard(createWorkboardRenderProps(host)), container);
     expect(container.querySelector(".workboard-detail")?.textContent).toContain("1 attempts");
     expect(container.querySelector(".workboard-detail")?.textContent).toContain("1 links");
     expect(container.querySelector(".workboard-detail")?.textContent).not.toContain("pnpm test 1");
@@ -2676,16 +2004,10 @@ describe("renderWorkboard", () => {
       },
     ];
     state.cards = [
-      {
+      createWorkboardCard({
         id: "card-default",
         title: "Default work",
-        status: "todo",
-        priority: "normal",
-        labels: [],
-        position: 1000,
-        createdAt: 1,
-        updatedAt: 1,
-      },
+      }),
       {
         id: "card-ops",
         title: "Ops work",
@@ -2699,16 +2021,9 @@ describe("renderWorkboard", () => {
       },
     ];
     const container = document.createElement("div");
-    const props: WorkboardRenderProps = {
-      host,
-      client: null,
-      connected: true,
-      pluginEnabled: true,
-      agentsList: null,
-      sessions: [],
-      onOpenSession: () => undefined,
+    const props = createWorkboardRenderProps(host, {
       onBoardFilterChange,
-    };
+    });
 
     renderInto(container, props);
     const boardFilter = container.querySelector(".workboard-select--toolbar-board");
@@ -2725,9 +2040,7 @@ describe("renderWorkboard", () => {
   });
 
   it("shows the board switcher at two boards with icon, color, and fallback glyphs", () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    state.loaded = true;
+    const { host, state } = createLoadedWorkboardState();
     state.boards = [
       { id: "default", total: 0, active: 0, archived: 0, byStatus: {} },
       {
@@ -2765,22 +2078,14 @@ describe("renderWorkboard", () => {
   });
 
   it("keeps a deleted routed board filtered instead of exposing every board", () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    state.loaded = true;
+    const { host, state } = createLoadedWorkboardState();
     state.boardFilter = "deleted";
     state.boards = [{ id: "default", total: 1, active: 1, archived: 0, byStatus: { todo: 1 } }];
     state.cards = [
-      {
+      createWorkboardCard({
         id: "default-card",
         title: "Default board work",
-        status: "todo",
-        priority: "normal",
-        labels: [],
-        position: 1000,
-        createdAt: 1,
-        updatedAt: 1,
-      },
+      }),
     ];
     const container = document.createElement("div");
 
@@ -2799,9 +2104,7 @@ describe("renderWorkboard", () => {
   });
 
   it("filters cards by linked agent", () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    state.loaded = true;
+    const { host, state } = createLoadedWorkboardState();
     state.cards = [
       {
         id: "card-1",
@@ -2840,23 +2143,19 @@ describe("renderWorkboard", () => {
     const container = document.createElement("div");
 
     render(
-      renderWorkboard({
-        host,
-        client: null,
-        connected: true,
-        pluginEnabled: true,
-        agentsList: {
-          defaultId: "main",
-          mainKey: "agent:main:main",
-          scope: "test",
-          agents: [
-            { id: "main", name: "Main" },
-            { id: "ops", name: "Ops" },
-          ],
-        },
-        sessions: [],
-        onOpenSession: () => undefined,
-      }),
+      renderWorkboard(
+        createWorkboardRenderProps(host, {
+          agentsList: {
+            defaultId: "main",
+            mainKey: "agent:main:main",
+            scope: "test",
+            agents: [
+              { id: "main", name: "Main" },
+              { id: "ops", name: "Ops" },
+            ],
+          },
+        }),
+      ),
       container,
     );
 
@@ -2873,23 +2172,19 @@ describe("renderWorkboard", () => {
 
     selectWorkboardAgent(agentFilter, "ops");
     render(
-      renderWorkboard({
-        host,
-        client: null,
-        connected: true,
-        pluginEnabled: true,
-        agentsList: {
-          defaultId: "main",
-          mainKey: "agent:main:main",
-          scope: "test",
-          agents: [
-            { id: "main", name: "Main" },
-            { id: "ops", name: "Ops" },
-          ],
-        },
-        sessions: [],
-        onOpenSession: () => undefined,
-      }),
+      renderWorkboard(
+        createWorkboardRenderProps(host, {
+          agentsList: {
+            defaultId: "main",
+            mainKey: "agent:main:main",
+            scope: "test",
+            agents: [
+              { id: "main", name: "Main" },
+              { id: "ops", name: "Ops" },
+            ],
+          },
+        }),
+      ),
       container,
     );
 
@@ -2905,23 +2200,19 @@ describe("renderWorkboard", () => {
       "workboard-dispatcher",
     );
     render(
-      renderWorkboard({
-        host,
-        client: null,
-        connected: true,
-        pluginEnabled: true,
-        agentsList: {
-          defaultId: "main",
-          mainKey: "agent:main:main",
-          scope: "test",
-          agents: [
-            { id: "main", name: "Main" },
-            { id: "ops", name: "Ops" },
-          ],
-        },
-        sessions: [],
-        onOpenSession: () => undefined,
-      }),
+      renderWorkboard(
+        createWorkboardRenderProps(host, {
+          agentsList: {
+            defaultId: "main",
+            mainKey: "agent:main:main",
+            scope: "test",
+            agents: [
+              { id: "main", name: "Main" },
+              { id: "ops", name: "Ops" },
+            ],
+          },
+        }),
+      ),
       container,
     );
 
@@ -2934,9 +2225,7 @@ describe("renderWorkboard", () => {
   });
 
   it("limits assignment choices to configured agents and preserves an unknown current assignee", () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    state.loaded = true;
+    const { host, state } = createLoadedWorkboardState();
     state.draftOpen = true;
     state.draftTitle = "Assign me";
     state.draftAgentId = "workboard-dispatcher";
@@ -2956,24 +2245,20 @@ describe("renderWorkboard", () => {
     const container = document.createElement("div");
 
     render(
-      renderWorkboard({
-        host,
-        client: null,
-        connected: true,
-        pluginEnabled: true,
-        agentsList: {
-          defaultId: "main",
-          mainKey: "agent:main:main",
-          scope: "test",
-          agents: [
-            { id: "main", name: "Main" },
-            { id: "main", name: "Main duplicate" },
-            { id: "ops", name: "Ops" },
-          ],
-        },
-        sessions: [],
-        onOpenSession: () => undefined,
-      }),
+      renderWorkboard(
+        createWorkboardRenderProps(host, {
+          agentsList: {
+            defaultId: "main",
+            mainKey: "agent:main:main",
+            scope: "test",
+            agents: [
+              { id: "main", name: "Main" },
+              { id: "main", name: "Main duplicate" },
+              { id: "ops", name: "Ops" },
+            ],
+          },
+        }),
+      ),
       container,
     );
 
@@ -2990,25 +2275,12 @@ describe("renderWorkboard", () => {
   });
 
   it("renders the card modal with a single scrollable body and stable footer actions", () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    state.loaded = true;
+    const { host, state } = createLoadedWorkboardState();
     state.draftOpen = true;
     state.draftTitle = "New task";
     const container = document.createElement("div");
 
-    render(
-      renderWorkboard({
-        host,
-        client: null,
-        connected: true,
-        pluginEnabled: true,
-        agentsList: null,
-        sessions: [],
-        onOpenSession: () => undefined,
-      }),
-      container,
-    );
+    render(renderWorkboard(createWorkboardRenderProps(host)), container);
 
     const draft = container.querySelector(".workboard-draft");
     const body = draft?.querySelector(".workboard-draft__body");
@@ -3021,25 +2293,12 @@ describe("renderWorkboard", () => {
   });
 
   it("delegates modal select positioning and dismissal to Web Awesome", () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    state.loaded = true;
+    const { host, state } = createLoadedWorkboardState();
     state.draftOpen = true;
     state.draftTitle = "New task";
     const container = document.createElement("div");
 
-    render(
-      renderWorkboard({
-        host,
-        client: null,
-        connected: true,
-        pluginEnabled: true,
-        agentsList: null,
-        sessions: [],
-        onOpenSession: () => undefined,
-      }),
-      container,
-    );
+    render(renderWorkboard(createWorkboardRenderProps(host)), container);
 
     const selects = container.querySelectorAll(".workboard-draft wa-select");
     expect(selects.length).toBeGreaterThan(0);
@@ -3047,9 +2306,7 @@ describe("renderWorkboard", () => {
   });
 
   it("preflights model-specific starts for ACP runtime agents", () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    state.loaded = true;
+    const { host, state } = createLoadedWorkboardState();
     state.detailCardId = "card-1";
     state.cards = [
       {
@@ -3067,20 +2324,16 @@ describe("renderWorkboard", () => {
     const container = document.createElement("div");
 
     render(
-      renderWorkboard({
-        host,
-        client: null,
-        connected: true,
-        pluginEnabled: true,
-        agentsList: {
-          defaultId: "main",
-          mainKey: "agent:main:main",
-          scope: "test",
-          agents: [{ id: "main", name: "Main", agentRuntime: { id: "codex", source: "agent" } }],
-        },
-        sessions: [],
-        onOpenSession: () => undefined,
-      }),
+      renderWorkboard(
+        createWorkboardRenderProps(host, {
+          agentsList: {
+            defaultId: "main",
+            mainKey: "agent:main:main",
+            scope: "test",
+            agents: [{ id: "main", name: "Main", agentRuntime: { id: "codex", source: "agent" } }],
+          },
+        }),
+      ),
       container,
     );
 
@@ -3095,37 +2348,17 @@ describe("renderWorkboard", () => {
   });
 
   it("does not render details for archived selected cards", () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    state.loaded = true;
+    const { host, state } = createLoadedWorkboardState();
     state.detailCardId = "card-1";
     state.cards = [
-      {
-        id: "card-1",
+      createWorkboardCard({
         title: "Archived selected task",
-        status: "todo",
-        priority: "normal",
-        labels: [],
-        position: 1000,
-        createdAt: 1,
-        updatedAt: 1,
         metadata: { archivedAt: 2 },
-      },
+      }),
     ];
     const container = document.createElement("div");
 
-    render(
-      renderWorkboard({
-        host,
-        client: null,
-        connected: true,
-        pluginEnabled: true,
-        agentsList: null,
-        sessions: [],
-        onOpenSession: () => undefined,
-      }),
-      container,
-    );
+    render(renderWorkboard(createWorkboardRenderProps(host)), container);
 
     expect(container.querySelector(".workboard-detail")).toBeNull();
     expect(container.querySelectorAll<HTMLButtonElement>(".workboard-card__start")).toHaveLength(0);
@@ -3134,19 +2367,11 @@ describe("renderWorkboard", () => {
   it("shows stale lifecycle on executed linked cards", () => {
     const nowSpy = vi.spyOn(Date, "now").mockReturnValue(60 * 60 * 1000);
     try {
-      const host = {};
-      const state = getWorkboardState(host);
-      state.loaded = true;
+      const { host, state } = createLoadedWorkboardState();
       state.cards = [
-        {
-          id: "card-1",
+        createWorkboardCard({
           title: "Watch stale run",
           status: "running",
-          priority: "normal",
-          labels: [],
-          position: 1000,
-          createdAt: 1,
-          updatedAt: 1,
           execution: {
             id: "exec-1",
             kind: "agent-session",
@@ -3158,29 +2383,25 @@ describe("renderWorkboard", () => {
             startedAt: 1,
             updatedAt: 1,
           },
-        },
+        }),
       ];
       const container = document.createElement("div");
 
       render(
-        renderWorkboard({
-          host,
-          client: null,
-          connected: true,
-          pluginEnabled: true,
-          agentsList: null,
-          sessions: [
-            {
-              key: "agent:main:dashboard:1",
-              kind: "direct",
-              displayName: "Dashboard session",
-              updatedAt: 1,
-              hasActiveRun: false,
-              status: "running",
-            },
-          ],
-          onOpenSession: () => undefined,
-        }),
+        renderWorkboard(
+          createWorkboardRenderProps(host, {
+            sessions: [
+              {
+                key: "agent:main:dashboard:1",
+                kind: "direct",
+                displayName: "Dashboard session",
+                updatedAt: 1,
+                hasActiveRun: false,
+                status: "running",
+              },
+            ],
+          }),
+        ),
         container,
       );
 
@@ -3195,42 +2416,30 @@ describe("renderWorkboard", () => {
   });
 
   it("keeps live controls for legacy running session rows", () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    state.loaded = true;
+    const { host, state } = createLoadedWorkboardState();
     state.cards = [
-      {
-        id: "card-1",
+      createWorkboardCard({
         title: "Stop legacy run",
         status: "running",
-        priority: "normal",
-        labels: [],
-        position: 1000,
-        createdAt: 1,
-        updatedAt: 1,
         sessionKey: "agent:main:dashboard:1",
-      },
+      }),
     ];
     const container = document.createElement("div");
 
     render(
-      renderWorkboard({
-        host,
-        client: null,
-        connected: true,
-        pluginEnabled: true,
-        agentsList: null,
-        sessions: [
-          {
-            key: "agent:main:dashboard:1",
-            kind: "direct",
-            displayName: "Dashboard session",
-            updatedAt: 1,
-            status: "running",
-          },
-        ],
-        onOpenSession: () => undefined,
-      }),
+      renderWorkboard(
+        createWorkboardRenderProps(host, {
+          sessions: [
+            {
+              key: "agent:main:dashboard:1",
+              kind: "direct",
+              displayName: "Dashboard session",
+              updatedAt: 1,
+              status: "running",
+            },
+          ],
+        }),
+      ),
       container,
     );
 
@@ -3239,9 +2448,7 @@ describe("renderWorkboard", () => {
   });
 
   it("opens an edit modal and submits card updates", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    state.loaded = true;
+    const { host, state } = createLoadedWorkboardState();
     state.cards = [
       {
         id: "card-1",
@@ -3362,40 +2569,20 @@ describe("renderWorkboard", () => {
   });
 
   it("locks edit-modal actions while a comment request is in flight", () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    state.loaded = true;
+    const { host, state } = createLoadedWorkboardState();
     state.draftOpen = true;
     state.editingCardId = "card-1";
     state.draftTitle = "Rename me";
     state.draftCommentBody = "Ship after CI";
     state.busyCardIds.add("card-1");
     state.cards = [
-      {
-        id: "card-1",
+      createWorkboardCard({
         title: "Rename me",
-        status: "todo",
-        priority: "normal",
-        labels: [],
-        position: 1000,
-        createdAt: 1,
-        updatedAt: 1,
-      },
+      }),
     ];
     const container = document.createElement("div");
 
-    render(
-      renderWorkboard({
-        host,
-        client: null,
-        connected: true,
-        pluginEnabled: true,
-        agentsList: null,
-        sessions: [],
-        onOpenSession: () => undefined,
-      }),
-      container,
-    );
+    render(renderWorkboard(createWorkboardRenderProps(host)), container);
 
     const buttons = [...container.querySelectorAll<HTMLButtonElement>("button")];
     expect(buttons.find((button) => button.textContent?.includes("Create"))?.disabled).toBe(true);
@@ -3403,20 +2590,12 @@ describe("renderWorkboard", () => {
   });
 
   it("adds operator notes from the details drawer", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    state.loaded = true;
+    const { host, state } = createLoadedWorkboardState();
     state.cards = [
-      {
-        id: "card-1",
+      createWorkboardCard({
         title: "Investigate proof gap",
         status: "review",
-        priority: "normal",
-        labels: [],
-        position: 1000,
-        createdAt: 1,
-        updatedAt: 1,
-      },
+      }),
     ];
     const request = vi.fn(async () => ({
       card: {
@@ -3463,20 +2642,12 @@ describe("renderWorkboard", () => {
   });
 
   it("archives cards from the card action", async () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    state.loaded = true;
+    const { host, state } = createLoadedWorkboardState();
     state.cards = [
-      {
-        id: "card-1",
+      createWorkboardCard({
         title: "Archive me",
         status: "done",
-        priority: "normal",
-        labels: [],
-        position: 1000,
-        createdAt: 1,
-        updatedAt: 1,
-      },
+      }),
     ];
     const request = vi.fn(async () => ({
       card: { ...state.cards[0], metadata: { archivedAt: 2 } },
@@ -3484,16 +2655,12 @@ describe("renderWorkboard", () => {
     const container = document.createElement("div");
 
     render(
-      renderWorkboard({
-        host,
-        client: { request } as unknown as GatewayBrowserClient,
-        connected: true,
-        pluginEnabled: true,
-        agentsList: null,
-        sessions: [],
-        onOpenSession: () => undefined,
-        onRequestUpdate: () => undefined,
-      }),
+      renderWorkboard(
+        createWorkboardRenderProps(host, {
+          client: { request } as unknown as GatewayBrowserClient,
+          onRequestUpdate: () => undefined,
+        }),
+      ),
       container,
     );
     container
@@ -3510,29 +2677,23 @@ describe("renderWorkboard", () => {
   });
 
   it("offers existing sessions when creating a card", () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    state.loaded = true;
+    const { host, state } = createLoadedWorkboardState();
     state.draftOpen = true;
     const container = document.createElement("div");
 
     render(
-      renderWorkboard({
-        host,
-        client: null,
-        connected: true,
-        pluginEnabled: true,
-        agentsList: null,
-        sessions: [
-          {
-            key: "agent:main:dashboard:1",
-            kind: "direct",
-            displayName: "Existing session",
-            updatedAt: 2,
-          },
-        ],
-        onOpenSession: () => undefined,
-      }),
+      renderWorkboard(
+        createWorkboardRenderProps(host, {
+          sessions: [
+            {
+              key: "agent:main:dashboard:1",
+              kind: "direct",
+              displayName: "Existing session",
+              updatedAt: 2,
+            },
+          ],
+        }),
+      ),
       container,
     );
 
@@ -3541,25 +2702,12 @@ describe("renderWorkboard", () => {
   });
 
   it("shows a missing current session key instead of a false empty selection", () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    state.loaded = true;
+    const { host, state } = createLoadedWorkboardState();
     state.draftOpen = true;
     state.draftSessionKey = "agent:main:archived-session";
     const container = document.createElement("div");
 
-    render(
-      renderWorkboard({
-        host,
-        client: null,
-        connected: true,
-        pluginEnabled: true,
-        agentsList: null,
-        sessions: [],
-        onOpenSession: () => undefined,
-      }),
-      container,
-    );
+    render(renderWorkboard(createWorkboardRenderProps(host)), container);
 
     const sessionSelect = [
       ...(container
@@ -3573,35 +2721,29 @@ describe("renderWorkboard", () => {
   });
 
   it("does not offer synthetic heartbeat sessions when creating a card", () => {
-    const host = {};
-    const state = getWorkboardState(host);
-    state.loaded = true;
+    const { host, state } = createLoadedWorkboardState();
     state.draftOpen = true;
     const container = document.createElement("div");
 
     render(
-      renderWorkboard({
-        host,
-        client: null,
-        connected: true,
-        pluginEnabled: true,
-        agentsList: null,
-        sessions: [
-          {
-            key: "agent:main:heartbeat",
-            kind: "direct",
-            displayName: "heartbeat",
-            updatedAt: 2,
-          },
-          {
-            key: "agent:main:dashboard:1",
-            kind: "direct",
-            displayName: "Dashboard session",
-            updatedAt: 3,
-          },
-        ],
-        onOpenSession: () => undefined,
-      }),
+      renderWorkboard(
+        createWorkboardRenderProps(host, {
+          sessions: [
+            {
+              key: "agent:main:heartbeat",
+              kind: "direct",
+              displayName: "heartbeat",
+              updatedAt: 2,
+            },
+            {
+              key: "agent:main:dashboard:1",
+              kind: "direct",
+              displayName: "Dashboard session",
+              updatedAt: 3,
+            },
+          ],
+        }),
+      ),
       container,
     );
 


### PR DESCRIPTION
## What Problem This Solves

The Workboard UI and controller regression suites repeatedly construct the same gateway client, host, render properties, and canonical card fields. That repetition makes real lifecycle, accessibility, keyboard, modal, and refresh regressions harder to identify without adding coverage.

## Why This Change Was Made

- Consolidate loaded Workboard state and typed rendering props behind test-local fixtures.
- Reuse the existing typed controller lifecycle and refresh helpers, adding a matching load helper for 107 equivalent controller calls.
- Use the existing shared canonical Workboard card factory and omit only defaults verified against its implementation.
- Preserve every existing scenario and assertion; change no production code, coverage configuration, snapshots, dependencies, or package scripts.

## User Impact

No production behavior changes. The Workboard regression suite is 1,006 lines smaller, easier to maintain, and retains all lifecycle, task, filtering, modal, accessibility, and keyboard behavior checks.

## Evidence

- Exact nine-suite before/after: **279/279 tests pass**.
- Statements: **2215/2488**, unchanged.
- Branches: **2256/2750**, unchanged.
- Functions: **461/531**, unchanged.
- Lines: **2176/2442**, unchanged.
- `ui/src/lib/workboard/index.test.ts`: +118/-266.
- `ui/src/pages/workboard/view.test.ts`: +475/-1333.
- Total immutable-head change: **+593/-1599, net -1006**, across two test files.
- Repository type-aware targeted lint and `git diff --check`: pass.
- Full path-scoped `pnpm check:changed`: verified on Blacksmith Testbox.
- Fresh mandatory uncommitted autoreview: no accepted or actionable findings.

AI-assisted implementation; scenarios, fixture ownership, source defaults, exact V8 coverage, and changed-file checks were verified against the actual repository and remote test environment.
