### PR TITLE
refactor(cli): consolidate capability and command regression suites

### DIFF
--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -12,6 +12,10 @@ import { CAPABILITY_METADATA, registerCapabilityCli } from "./capability-cli.js"
 const PNG_1X1_BASE64 =
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+yf7kAAAAASUVORK5CYII=";
 
+function runCap(...argv: string[]): Promise<void> {
+  return runRegisteredCli({ register: registerCapabilityCli as (program: Command) => void, argv });
+}
+
 type LocalAudioSelection = Awaited<ReturnType<typeof inspectLocalAudioSelection>>;
 
 const closeEmbeddingProviderMock = vi.hoisted(() => vi.fn(async () => {}));
@@ -586,20 +590,17 @@ describe("capability cli", () => {
   });
 
   async function runModelRunWithModel(model: string, transport: "local" | "gateway") {
-    await runRegisteredCli({
-      register: registerCapabilityCli as (program: Command) => void,
-      argv: [
-        "capability",
-        "model",
-        "run",
-        "--model",
-        model,
-        "--prompt",
-        "hello",
-        ...(transport === "gateway" ? ["--gateway"] : []),
-        "--json",
-      ],
-    });
+    await runCap(
+      "capability",
+      "model",
+      "run",
+      "--model",
+      model,
+      "--prompt",
+      "hello",
+      ...(transport === "gateway" ? ["--gateway"] : []),
+      "--json",
+    );
   }
 
   type GatewayCall = {
@@ -685,6 +686,24 @@ describe("capability cli", () => {
     return calls[0]?.[0];
   }
 
+  function primeGeneratedVideoUrl(url: string): void {
+    mocks.generateVideo.mockResolvedValue({
+      provider: "vydra",
+      model: "veo3",
+      attempts: [],
+      videos: [{ url, mimeType: "video/mp4", fileName: "provider-name.mp4" }],
+    });
+  }
+
+  function primeGeneratedImage(model: string, fileName: string): void {
+    mocks.generateImage.mockResolvedValue({
+      provider: "openai",
+      model,
+      attempts: [],
+      images: [{ buffer: Buffer.from("png-bytes"), mimeType: "image/png", fileName }],
+    });
+  }
+
   function firstAudioTranscriptionCall() {
     const calls = mocks.transcribeAudioFile.mock.calls as unknown as Array<
       [{ cfg?: unknown; filePath?: string; language?: unknown; prompt?: unknown }]
@@ -725,10 +744,7 @@ describe("capability cli", () => {
   }
 
   it("lists canonical capabilities", async () => {
-    await runRegisteredCli({
-      register: registerCapabilityCli as (program: Command) => void,
-      argv: ["capability", "list", "--json"],
-    });
+    await runCap("capability", "list", "--json");
 
     const payload = (firstJsonOutput() as unknown as Array<{ id: string }> | undefined) ?? [];
     const ids = payload.map((entry) => entry.id);
@@ -737,10 +753,7 @@ describe("capability cli", () => {
   });
 
   it("defaults model run to local transport", async () => {
-    await runRegisteredCli({
-      register: registerCapabilityCli as (program: Command) => void,
-      argv: ["capability", "model", "run", "--prompt", "hello", "--json"],
-    });
+    await runCap("capability", "model", "run", "--prompt", "hello", "--json");
 
     expect(mocks.prepareSimpleCompletionModelForAgent).toHaveBeenCalledTimes(1);
     expect(mocks.completeWithPreparedSimpleCompletionModel).toHaveBeenCalledTimes(1);
@@ -750,10 +763,7 @@ describe("capability cli", () => {
   });
 
   it("runs local model probes through the lean completion path", async () => {
-    await runRegisteredCli({
-      register: registerCapabilityCli as (program: Command) => void,
-      argv: ["capability", "model", "run", "--prompt", "hello", "--json"],
-    });
+    await runCap("capability", "model", "run", "--prompt", "hello", "--json");
 
     const preparedParams = firstPreparedModelParams();
     expect(preparedParams?.agentId).toBe("main");
@@ -775,10 +785,7 @@ describe("capability cli", () => {
   });
 
   it("does not enable bundled static catalog fallback without an explicit provider/model override", async () => {
-    await runRegisteredCli({
-      register: registerCapabilityCli as (program: Command) => void,
-      argv: ["capability", "model", "run", "--prompt", "hello", "--json"],
-    });
+    await runCap("capability", "model", "run", "--prompt", "hello", "--json");
 
     const calls = mocks.prepareSimpleCompletionModelForAgent.mock.calls as unknown as Array<
       [Record<string, unknown>]
@@ -794,19 +801,16 @@ describe("capability cli", () => {
     const tempInput = path.join(os.tmpdir(), `openclaw-model-run-image-${Date.now()}.png`);
     await fs.writeFile(tempInput, Buffer.from(PNG_1X1_BASE64, "base64"));
 
-    await runRegisteredCli({
-      register: registerCapabilityCli as (program: Command) => void,
-      argv: [
-        "capability",
-        "model",
-        "run",
-        "--prompt",
-        "describe this",
-        "--file",
-        tempInput,
-        "--json",
-      ],
-    });
+    await runCap(
+      "capability",
+      "model",
+      "run",
+      "--prompt",
+      "describe this",
+      "--file",
+      tempInput,
+      "--json",
+    );
 
     const call = firstCompletionCall();
     expect(call?.context?.messages?.[0]?.role).toBe("user");
@@ -841,19 +845,16 @@ describe("capability cli", () => {
       },
     } as never);
 
-    await runRegisteredCli({
-      register: registerCapabilityCli as (program: Command) => void,
-      argv: [
-        "capability",
-        "model",
-        "run",
-        "--model",
-        "openai/gpt-5.5",
-        "--prompt",
-        "hello",
-        "--json",
-      ],
-    });
+    await runCap(
+      "capability",
+      "model",
+      "run",
+      "--model",
+      "openai/gpt-5.5",
+      "--prompt",
+      "hello",
+      "--json",
+    );
 
     const call = firstCompletionCall();
     expect(call?.context?.systemPrompt).toBe(
@@ -864,10 +865,7 @@ describe("capability cli", () => {
   });
 
   it("passes thinking overrides to local model probes", async () => {
-    await runRegisteredCli({
-      register: registerCapabilityCli as (program: Command) => void,
-      argv: ["capability", "model", "run", "--prompt", "hello", "--thinking", "high", "--json"],
-    });
+    await runCap("capability", "model", "run", "--prompt", "hello", "--thinking", "high", "--json");
 
     expect(firstCompletionCall()?.options?.reasoning).toBe("high");
   });
@@ -876,20 +874,17 @@ describe("capability cli", () => {
     const tempInput = path.join(os.tmpdir(), `openclaw-model-run-gateway-image-${Date.now()}.png`);
     await fs.writeFile(tempInput, Buffer.from(PNG_1X1_BASE64, "base64"));
 
-    await runRegisteredCli({
-      register: registerCapabilityCli as (program: Command) => void,
-      argv: [
-        "capability",
-        "model",
-        "run",
-        "--prompt",
-        "describe this",
-        "--file",
-        tempInput,
-        "--gateway",
-        "--json",
-      ],
-    });
+    await runCap(
+      "capability",
+      "model",
+      "run",
+      "--prompt",
+      "describe this",
+      "--file",
+      tempInput,
+      "--gateway",
+      "--json",
+    );
 
     const gatewayCall = firstGatewayCall();
     expect(gatewayCall?.method).toBe("agent");
@@ -910,19 +905,16 @@ describe("capability cli", () => {
     const tempInput = path.join(os.tmpdir(), `openclaw-model-run-image-${Date.now()}.heic`);
     await fs.writeFile(tempInput, Buffer.from("heic-like"));
 
-    await runRegisteredCli({
-      register: registerCapabilityCli as (program: Command) => void,
-      argv: [
-        "capability",
-        "model",
-        "run",
-        "--prompt",
-        "describe this",
-        "--file",
-        tempInput,
-        "--json",
-      ],
-    });
+    await runCap(
+      "capability",
+      "model",
+      "run",
+      "--prompt",
+      "describe this",
+      "--file",
+      tempInput,
+      "--json",
+    );
 
     expect(mocks.convertHeicToJpeg).toHaveBeenCalledWith(Buffer.from("heic-like"));
     const call = firstCompletionCall();
@@ -946,19 +938,16 @@ describe("capability cli", () => {
     await fs.writeFile(tempInput, Buffer.from("not really audio"));
 
     await expect(
-      runRegisteredCli({
-        register: registerCapabilityCli as (program: Command) => void,
-        argv: [
-          "capability",
-          "model",
-          "run",
-          "--prompt",
-          "transcribe this",
-          "--file",
-          tempInput,
-          "--json",
-        ],
-      }),
+      runCap(
+        "capability",
+        "model",
+        "run",
+        "--prompt",
+        "transcribe this",
+        "--file",
+        tempInput,
+        "--json",
+      ),
     ).rejects.toThrow("exit 1");
 
     expectRuntimeErrorContains("Only image files are supported");
@@ -972,10 +961,7 @@ describe("capability cli", () => {
     } as never);
 
     await expect(
-      runRegisteredCli({
-        register: registerCapabilityCli as (program: Command) => void,
-        argv: ["capability", "model", "run", "--prompt", "hello", "--json"],
-      }),
+      runCap("capability", "model", "run", "--prompt", "hello", "--json"),
     ).rejects.toThrow("exit 1");
 
     expectRuntimeErrorContains('No text output returned for provider "openai" model "gpt-5.4"');
@@ -990,10 +976,7 @@ describe("capability cli", () => {
     } as never);
 
     await expect(
-      runRegisteredCli({
-        register: registerCapabilityCli as (program: Command) => void,
-        argv: ["capability", "model", "run", "--prompt", "hello", "--json"],
-      }),
+      runCap("capability", "model", "run", "--prompt", "hello", "--json"),
     ).rejects.toThrow("exit 1");
 
     expectRuntimeErrorContains('{"detail":"Instructions are required"}');
@@ -1020,19 +1003,16 @@ describe("capability cli", () => {
     } as never);
 
     await expect(
-      runRegisteredCli({
-        register: registerCapabilityCli as (program: Command) => void,
-        argv: [
-          "capability",
-          "model",
-          "run",
-          "--model",
-          "codex/gpt-5.4",
-          "--prompt",
-          "hello",
-          "--json",
-        ],
-      }),
+      runCap(
+        "capability",
+        "model",
+        "run",
+        "--model",
+        "codex/gpt-5.4",
+        "--prompt",
+        "hello",
+        "--json",
+      ),
     ).rejects.toThrow("exit 1");
 
     expectRuntimeErrorContains("Codex app-server agent runtime");
@@ -1044,10 +1024,7 @@ describe("capability cli", () => {
     "rejects empty model run prompts before local dispatch (%j)",
     async (prompt) => {
       await expect(
-        runRegisteredCli({
-          register: registerCapabilityCli as (program: Command) => void,
-          argv: ["capability", "model", "run", "--prompt", prompt, "--json"],
-        }),
+        runCap("capability", "model", "run", "--prompt", prompt, "--json"),
       ).rejects.toThrow("exit 1");
 
       expectRuntimeErrorContains("--prompt cannot be empty or whitespace-only.");
@@ -1059,10 +1036,7 @@ describe("capability cli", () => {
   );
 
   it("runs gateway model probes in fresh raw sessions without chat-agent prompt policy or tools", async () => {
-    await runRegisteredCli({
-      register: registerCapabilityCli as (program: Command) => void,
-      argv: ["capability", "model", "run", "--prompt", "hello", "--gateway", "--json"],
-    });
+    await runCap("capability", "model", "run", "--prompt", "hello", "--gateway", "--json");
 
     const gatewayCall = firstGatewayCall();
     const sessionId = gatewayCall?.params?.sessionId;
@@ -1077,10 +1051,7 @@ describe("capability cli", () => {
     expect(gatewayCall?.params?.modelRun).toBe(true);
     expect(gatewayCall?.params?.promptMode).toBe("none");
 
-    await runRegisteredCli({
-      register: registerCapabilityCli as (program: Command) => void,
-      argv: ["capability", "model", "run", "--prompt", "again", "--gateway", "--json"],
-    });
+    await runCap("capability", "model", "run", "--prompt", "again", "--gateway", "--json");
 
     const gatewayCalls = mocks.callGateway.mock.calls as unknown as Array<[GatewayCall]>;
     const nextGatewayCall = gatewayCalls[1]?.[0];
@@ -1116,10 +1087,7 @@ describe("capability cli", () => {
       },
     } as never);
 
-    await runRegisteredCli({
-      register: registerCapabilityCli as (program: Command) => void,
-      argv: ["capability", "model", "run", "--prompt", "hello", "--gateway", "--json"],
-    });
+    await runCap("capability", "model", "run", "--prompt", "hello", "--gateway", "--json");
 
     const payload = firstJsonOutput();
     const attempts = payload?.attempts as Array<Record<string, unknown>>;
@@ -1132,20 +1100,17 @@ describe("capability cli", () => {
   });
 
   it("requests admin scope for gateway model probes with provider/model overrides", async () => {
-    await runRegisteredCli({
-      register: registerCapabilityCli as (program: Command) => void,
-      argv: [
-        "capability",
-        "model",
-        "run",
-        "--prompt",
-        "hello",
-        "--gateway",
-        "--model",
-        "anthropic/claude-haiku-4-5",
-        "--json",
-      ],
-    });
+    await runCap(
+      "capability",
+      "model",
+      "run",
+      "--prompt",
+      "hello",
+      "--gateway",
+      "--model",
+      "anthropic/claude-haiku-4-5",
+      "--json",
+    );
 
     const gatewayCall = firstGatewayCall();
     expect(gatewayCall?.clientName).toBe("gateway-client");
@@ -1205,20 +1170,17 @@ describe("capability cli", () => {
   });
 
   it("passes thinking overrides to gateway model probes", async () => {
-    await runRegisteredCli({
-      register: registerCapabilityCli as (program: Command) => void,
-      argv: [
-        "capability",
-        "model",
-        "run",
-        "--prompt",
-        "hello",
-        "--gateway",
-        "--thinking",
-        "high",
-        "--json",
-      ],
-    });
+    await runCap(
+      "capability",
+      "model",
+      "run",
+      "--prompt",
+      "hello",
+      "--gateway",
+      "--thinking",
+      "high",
+      "--json",
+    );
 
     const gatewayCall = firstGatewayCall();
     expect(gatewayCall?.method).toBe("agent");
@@ -1229,19 +1191,16 @@ describe("capability cli", () => {
 
   it("rejects invalid model run thinking overrides before dispatch", async () => {
     await expect(
-      runRegisteredCli({
-        register: registerCapabilityCli as (program: Command) => void,
-        argv: [
-          "capability",
-          "model",
-          "run",
-          "--prompt",
-          "hello",
-          "--thinking",
-          "turbo-mode",
-          "--json",
-        ],
-      }),
+      runCap(
+        "capability",
+        "model",
+        "run",
+        "--prompt",
+        "hello",
+        "--thinking",
+        "turbo-mode",
+        "--json",
+      ),
     ).rejects.toThrow("exit 1");
 
     expectRuntimeErrorContains("Invalid thinking level.");
@@ -1253,10 +1212,7 @@ describe("capability cli", () => {
 
   it("rejects empty model run prompts before gateway dispatch", async () => {
     await expect(
-      runRegisteredCli({
-        register: registerCapabilityCli as (program: Command) => void,
-        argv: ["capability", "model", "run", "--prompt", " ", "--gateway", "--json"],
-      }),
+      runCap("capability", "model", "run", "--prompt", " ", "--gateway", "--json"),
     ).rejects.toThrow("exit 1");
 
     expectRuntimeErrorContains("--prompt cannot be empty or whitespace-only.");
@@ -1265,20 +1221,14 @@ describe("capability cli", () => {
   });
 
   it("defaults tts status to gateway transport", async () => {
-    await runRegisteredCli({
-      register: registerCapabilityCli as (program: Command) => void,
-      argv: ["capability", "tts", "status", "--json"],
-    });
+    await runCap("capability", "tts", "status", "--json");
 
     expect(firstGatewayCall()?.method).toBe("tts.status");
     expect(firstJsonOutput()?.transport).toBe("gateway");
   });
 
   it("routes image describe through media understanding, not generation", async () => {
-    await runRegisteredCli({
-      register: registerCapabilityCli as (program: Command) => void,
-      argv: ["capability", "image", "describe", "--file", "photo.jpg", "--json"],
-    });
+    await runCap("capability", "image", "describe", "--file", "photo.jpg", "--json");
 
     const describeCall = imageDescribeCall();
     expect(path.basename(describeCall?.filePath ?? "")).toBe("photo.jpg");
@@ -1291,10 +1241,7 @@ describe("capability cli", () => {
 
   it("keeps encoded image describe HTTP URLs intact", async () => {
     const mediaUrl = "https://cdn.example.com/clip%2Emp4?download=1#preview";
-    await runRegisteredCli({
-      register: registerCapabilityCli as (program: Command) => void,
-      argv: ["capability", "image", "describe", "--file", mediaUrl, "--json"],
-    });
+    await runCap("capability", "image", "describe", "--file", mediaUrl, "--json");
 
     const describeCall = imageDescribeCall();
     expect(describeCall).toMatchObject({ filePath: mediaUrl, mediaUrl });
@@ -1304,21 +1251,18 @@ describe("capability cli", () => {
   });
 
   it("passes image describe prompts through media understanding", async () => {
-    await runRegisteredCli({
-      register: registerCapabilityCli as (program: Command) => void,
-      argv: [
-        "capability",
-        "image",
-        "describe",
-        "--file",
-        "photo.jpg",
-        "--prompt",
-        "Read the menu text",
-        "--timeout-ms",
-        "90000",
-        "--json",
-      ],
-    });
+    await runCap(
+      "capability",
+      "image",
+      "describe",
+      "--file",
+      "photo.jpg",
+      "--prompt",
+      "Read the menu text",
+      "--timeout-ms",
+      "90000",
+      "--json",
+    );
 
     const describeCall = imageDescribeCall();
     expect(path.basename(describeCall?.filePath ?? "")).toBe("photo.jpg");
@@ -1327,17 +1271,14 @@ describe("capability cli", () => {
   });
 
   it("keeps image describe URL files as remote media references", async () => {
-    await runRegisteredCli({
-      register: registerCapabilityCli as (program: Command) => void,
-      argv: [
-        "capability",
-        "image",
-        "describe",
-        "--file",
-        "https://example.com/photo.png",
-        "--json",
-      ],
-    });
+    await runCap(
+      "capability",
+      "image",
+      "describe",
+      "--file",
+      "https://example.com/photo.png",
+      "--json",
+    );
 
     const describeCall = imageDescribeCall();
     expect(describeCall?.filePath).toBe("https://example.com/photo.png");
@@ -1347,23 +1288,20 @@ describe("capability cli", () => {
   });
 
   it("uses the explicit media-understanding provider for image describe model overrides", async () => {
-    await runRegisteredCli({
-      register: registerCapabilityCli as (program: Command) => void,
-      argv: [
-        "capability",
-        "image",
-        "describe",
-        "--file",
-        "photo.jpg",
-        "--model",
-        "ollama/qwen2.5vl:7b",
-        "--prompt",
-        "Count visible buttons",
-        "--timeout-ms",
-        "120000",
-        "--json",
-      ],
-    });
+    await runCap(
+      "capability",
+      "image",
+      "describe",
+      "--file",
+      "photo.jpg",
+      "--model",
+      "ollama/qwen2.5vl:7b",
+      "--prompt",
+      "Count visible buttons",
+      "--timeout-ms",
+      "120000",
+      "--json",
+    );
 
     const prepareCall = firstImagePrepareCall();
     const describeCall = firstImageDescribeWithModelCall();
@@ -1378,19 +1316,16 @@ describe("capability cli", () => {
   });
 
   it("keeps explicit-model image describe URL files as remote media references", async () => {
-    await runRegisteredCli({
-      register: registerCapabilityCli as (program: Command) => void,
-      argv: [
-        "capability",
-        "image",
-        "describe",
-        "--file",
-        "https://example.com/photo.png",
-        "--model",
-        "ollama/qwen2.5vl:7b",
-        "--json",
-      ],
-    });
+    await runCap(
+      "capability",
+      "image",
+      "describe",
+      "--file",
+      "https://example.com/photo.png",
+      "--model",
+      "ollama/qwen2.5vl:7b",
+      "--json",
+    );
 
     const prepareCall = firstImagePrepareCall();
     expect(prepareCall?.filePath).toBe("https://example.com/photo.png");
@@ -1401,19 +1336,16 @@ describe("capability cli", () => {
   });
 
   it("keeps explicit-model image describe HTTP URLs as URLs", async () => {
-    await runRegisteredCli({
-      register: registerCapabilityCli as (program: Command) => void,
-      argv: [
-        "capability",
-        "image",
-        "describe",
-        "--file",
-        "https://httpbin.org/image/png",
-        "--model",
-        "minimax-cn/MiniMax-VL-01",
-        "--json",
-      ],
-    });
+    await runCap(
+      "capability",
+      "image",
+      "describe",
+      "--file",
+      "https://httpbin.org/image/png",
+      "--model",
+      "minimax-cn/MiniMax-VL-01",
+      "--json",
+    );
 
     const prepareCall = firstImagePrepareCall();
     const describeCall = firstImageDescribeWithModelCall();
@@ -1445,19 +1377,16 @@ describe("capability cli", () => {
         model: "google/gemma-4-31b-it",
       });
 
-    await runRegisteredCli({
-      register: registerCapabilityCli as (program: Command) => void,
-      argv: [
-        "capability",
-        "image",
-        "describe",
-        "--file",
-        "photo.jpg",
-        "--model",
-        "openrouter/google/gemma-4-31b-it:free",
-        "--json",
-      ],
-    });
+    await runCap(
+      "capability",
+      "image",
+      "describe",
+      "--file",
+      "photo.jpg",
+      "--model",
+      "openrouter/google/gemma-4-31b-it:free",
+      "--json",
+    );
 
     expect(mocks.prepareImageDescriptionInput).toHaveBeenCalledTimes(1);
     const calls = mocks.describePreparedImageWithModel.mock.calls as unknown as Array<
@@ -1506,19 +1435,16 @@ describe("capability cli", () => {
     mocks.prepareImageDescriptionInput.mockRejectedValueOnce(new Error("image file not found"));
 
     await expect(
-      runRegisteredCli({
-        register: registerCapabilityCli as (program: Command) => void,
-        argv: [
-          "capability",
-          "image",
-          "describe",
-          "--file",
-          "missing.jpg",
-          "--model",
-          "openrouter/google/gemma-4-31b-it:free",
-          "--json",
-        ],
-      }),
+      runCap(
+        "capability",
+        "image",
+        "describe",
+        "--file",
+        "missing.jpg",
+        "--model",
+        "openrouter/google/gemma-4-31b-it:free",
+        "--json",
+      ),
     ).rejects.toThrow("exit 1");
 
     expectRuntimeErrorContains("image file not found");
@@ -1527,23 +1453,20 @@ describe("capability cli", () => {
   });
 
   it("passes describe-many prompts to each image", async () => {
-    await runRegisteredCli({
-      register: registerCapabilityCli as (program: Command) => void,
-      argv: [
-        "capability",
-        "image",
-        "describe-many",
-        "--file",
-        "a.jpg",
-        "--file",
-        "b.jpg",
-        "--prompt",
-        "Extract all visible labels",
-        "--timeout-ms",
-        "45000",
-        "--json",
-      ],
-    });
+    await runCap(
+      "capability",
+      "image",
+      "describe-many",
+      "--file",
+      "a.jpg",
+      "--file",
+      "b.jpg",
+      "--prompt",
+      "Extract all visible labels",
+      "--timeout-ms",
+      "45000",
+      "--json",
+    );
 
     expect(mocks.describeImageFile).toHaveBeenCalledTimes(2);
     const firstDescribe = imageDescribeCall(0);
@@ -1564,54 +1487,37 @@ describe("capability cli", () => {
     } as never);
 
     await expect(
-      runRegisteredCli({
-        register: registerCapabilityCli as (program: Command) => void,
-        argv: ["capability", "image", "describe", "--file", "photo.jpg", "--json"],
-      }),
+      runCap("capability", "image", "describe", "--file", "photo.jpg", "--json"),
     ).rejects.toThrow("exit 1");
     expect(runtimeErrorMessages()).toEqual([
       `Error: No description returned for image: ${path.resolve("photo.jpg")}`,
     ]);
   });
 
-  it("reports missing image understanding configuration for image describe", async () => {
-    mocks.describeImageFile.mockResolvedValueOnce({
-      text: undefined,
-      decision: {
-        capability: "image",
-        outcome: "skipped",
-        attachments: [{ attachmentIndex: 0, attempts: [] }],
-      },
-    } as never);
+  it.each([
+    { command: "describe", checksImageModel: true },
+    { command: "describe-many", checksImageModel: false },
+  ])(
+    "reports missing image understanding configuration for image $command",
+    async ({ command, checksImageModel }) => {
+      mocks.describeImageFile.mockResolvedValueOnce({
+        text: undefined,
+        decision: {
+          capability: "image",
+          outcome: "skipped",
+          attachments: [{ attachmentIndex: 0, attempts: [] }],
+        },
+      } as never);
 
-    await expect(
-      runRegisteredCli({
-        register: registerCapabilityCli as (program: Command) => void,
-        argv: ["capability", "image", "describe", "--file", "photo.jpg", "--json"],
-      }),
-    ).rejects.toThrow("exit 1");
-    expectRuntimeErrorContains("No image understanding provider is configured or ready");
-    expectRuntimeErrorContains("agents.defaults.imageModel.primary");
-  });
-
-  it("reports missing image understanding configuration for image describe-many", async () => {
-    mocks.describeImageFile.mockResolvedValueOnce({
-      text: undefined,
-      decision: {
-        capability: "image",
-        outcome: "skipped",
-        attachments: [{ attachmentIndex: 0, attempts: [] }],
-      },
-    } as never);
-
-    await expect(
-      runRegisteredCli({
-        register: registerCapabilityCli as (program: Command) => void,
-        argv: ["capability", "image", "describe-many", "--file", "photo.jpg", "--json"],
-      }),
-    ).rejects.toThrow("exit 1");
-    expectRuntimeErrorContains("No image understanding provider is configured or ready");
-  });
+      await expect(
+        runCap("capability", "image", command, "--file", "photo.jpg", "--json"),
+      ).rejects.toThrow("exit 1");
+      expectRuntimeErrorContains("No image understanding provider is configured or ready");
+      if (checksImageModel) {
+        expectRuntimeErrorContains("agents.defaults.imageModel.primary");
+      }
+    },
+  );
 
   it("rewrites mismatched explicit image output extensions to the detected file type", async () => {
     const jpegBase64 =
@@ -1633,19 +1539,16 @@ describe("capability cli", () => {
     await fs.rm(tempOutput, { force: true });
     await fs.rm(tempOutput.replace(/\.png$/, ".jpg"), { force: true });
 
-    await runRegisteredCli({
-      register: registerCapabilityCli as (program: Command) => void,
-      argv: [
-        "capability",
-        "image",
-        "generate",
-        "--prompt",
-        "friendly lobster",
-        "--output",
-        tempOutput,
-        "--json",
-      ],
-    });
+    await runCap(
+      "capability",
+      "image",
+      "generate",
+      "--prompt",
+      "friendly lobster",
+      "--output",
+      tempOutput,
+      "--json",
+    );
 
     const outputs = firstJsonOutput()?.outputs as Array<Record<string, unknown>>;
     expect(outputs).toHaveLength(1);
@@ -1654,68 +1557,40 @@ describe("capability cli", () => {
   });
 
   it("passes image generation timeout through to runtime", async () => {
-    mocks.generateImage.mockResolvedValue({
-      provider: "openai",
-      model: "gpt-image-1",
-      attempts: [],
-      images: [
-        {
-          buffer: Buffer.from("png-bytes"),
-          mimeType: "image/png",
-          fileName: "provider-output.png",
-        },
-      ],
-    });
+    primeGeneratedImage("gpt-image-1", "provider-output.png");
 
-    await runRegisteredCli({
-      register: registerCapabilityCli as (program: Command) => void,
-      argv: [
-        "capability",
-        "image",
-        "generate",
-        "--prompt",
-        "friendly lobster",
-        "--timeout-ms",
-        "180000",
-        "--json",
-      ],
-    });
+    await runCap(
+      "capability",
+      "image",
+      "generate",
+      "--prompt",
+      "friendly lobster",
+      "--timeout-ms",
+      "180000",
+      "--json",
+    );
 
     expect(firstImageGenerationCall()?.prompt).toBe("friendly lobster");
     expect(firstImageGenerationCall()?.timeoutMs).toBe(180000);
   });
 
   it("passes image output format and generic background hints through to generation runtime", async () => {
-    mocks.generateImage.mockResolvedValue({
-      provider: "openai",
-      model: "gpt-image-1.5",
-      attempts: [],
-      images: [
-        {
-          buffer: Buffer.from("png-bytes"),
-          mimeType: "image/png",
-          fileName: "transparent.png",
-        },
-      ],
-    });
+    primeGeneratedImage("gpt-image-1.5", "transparent.png");
 
-    await runRegisteredCli({
-      register: registerCapabilityCli as (program: Command) => void,
-      argv: [
-        "capability",
-        "image",
-        "generate",
-        "--prompt",
-        "transparent sticker",
-        "--model",
-        "openai/gpt-image-1.5",
-        "--output-format",
-        "png",
-        "--background",
-        "transparent",
-        "--json",
-      ],
-    });
+    await runCap(
+      "capability",
+      "image",
+      "generate",
+      "--prompt",
+      "transparent sticker",
+      "--model",
+      "openai/gpt-image-1.5",
+      "--output-format",
+      "png",
+      "--background",
+      "transparent",
+      "--json",
+    );
 
     const generationCall = firstImageGenerationCall();
     expect(generationCall?.prompt).toBe("transparent sticker");
@@ -1726,34 +1601,20 @@ describe("capability cli", () => {
   });
 
   it("passes image quality and OpenAI moderation hints through to generation runtime", async () => {
-    mocks.generateImage.mockResolvedValue({
-      provider: "openai",
-      model: "gpt-image-2",
-      attempts: [],
-      images: [
-        {
-          buffer: Buffer.from("png-bytes"),
-          mimeType: "image/png",
-          fileName: "draft.png",
-        },
-      ],
-    });
+    primeGeneratedImage("gpt-image-2", "draft.png");
 
-    await runRegisteredCli({
-      register: registerCapabilityCli as (program: Command) => void,
-      argv: [
-        "capability",
-        "image",
-        "generate",
-        "--prompt",
-        "low-cost draft",
-        "--quality",
-        "low",
-        "--openai-moderation",
-        "low",
-        "--json",
-      ],
-    });
+    await runCap(
+      "capability",
+      "image",
+      "generate",
+      "--prompt",
+      "low-cost draft",
+      "--quality",
+      "low",
+      "--openai-moderation",
+      "low",
+      "--json",
+    );
 
     const generationCall = firstImageGenerationCall();
     expect(generationCall?.prompt).toBe("low-cost draft");
@@ -1766,44 +1627,30 @@ describe("capability cli", () => {
   });
 
   it("passes image output format, quality, and OpenAI hints through to edit runtime", async () => {
-    mocks.generateImage.mockResolvedValue({
-      provider: "openai",
-      model: "gpt-image-1.5",
-      attempts: [],
-      images: [
-        {
-          buffer: Buffer.from("png-bytes"),
-          mimeType: "image/png",
-          fileName: "transparent-edit.png",
-        },
-      ],
-    });
+    primeGeneratedImage("gpt-image-1.5", "transparent-edit.png");
     const inputPath = path.join(os.tmpdir(), `openclaw-image-edit-${Date.now()}.png`);
     await fs.writeFile(inputPath, Buffer.from("png-input"));
 
-    await runRegisteredCli({
-      register: registerCapabilityCli as (program: Command) => void,
-      argv: [
-        "capability",
-        "image",
-        "edit",
-        "--file",
-        inputPath,
-        "--prompt",
-        "make background transparent",
-        "--model",
-        "openai/gpt-image-1.5",
-        "--output-format",
-        "png",
-        "--openai-background",
-        "transparent",
-        "--openai-moderation",
-        "auto",
-        "--quality",
-        "high",
-        "--json",
-      ],
-    });
+    await runCap(
+      "capability",
+      "image",
+      "edit",
+      "--file",
+      inputPath,
+      "--prompt",
+      "make background transparent",
+      "--model",
+      "openai/gpt-image-1.5",
+      "--output-format",
+      "png",
+      "--openai-background",
+      "transparent",
+      "--openai-moderation",
+      "auto",
+      "--quality",
+      "high",
+      "--json",
+    );
 
     const generationCall = firstImageGenerationCall();
     const inputImages = generationCall?.inputImages as Array<Record<string, unknown>>;
@@ -1823,49 +1670,38 @@ describe("capability cli", () => {
   });
 
   it("forwards --count through to the image edit runtime", async () => {
-    mocks.generateImage.mockResolvedValue({
-      provider: "openai",
-      model: "gpt-image-1.5",
-      attempts: [],
-      images: [{ buffer: Buffer.from("png-bytes"), mimeType: "image/png", fileName: "edit.png" }],
-    });
+    primeGeneratedImage("gpt-image-1.5", "edit.png");
     const inputPath = path.join(os.tmpdir(), `openclaw-image-edit-count-${Date.now()}.png`);
     await fs.writeFile(inputPath, Buffer.from("png-input"));
 
-    await runRegisteredCli({
-      register: registerCapabilityCli as (program: Command) => void,
-      argv: [
-        "capability",
-        "image",
-        "edit",
-        "--file",
-        inputPath,
-        "--prompt",
-        "make three variants",
-        "--count",
-        "3",
-        "--json",
-      ],
-    });
+    await runCap(
+      "capability",
+      "image",
+      "edit",
+      "--file",
+      inputPath,
+      "--prompt",
+      "make three variants",
+      "--count",
+      "3",
+      "--json",
+    );
 
     expect(firstImageGenerationCall()?.count).toBe(3);
   });
 
   it("rejects unsupported image output format and background hints", async () => {
     await expect(
-      runRegisteredCli({
-        register: registerCapabilityCli as (program: Command) => void,
-        argv: [
-          "capability",
-          "image",
-          "generate",
-          "--prompt",
-          "transparent sticker",
-          "--output-format",
-          "gif",
-          "--json",
-        ],
-      }),
+      runCap(
+        "capability",
+        "image",
+        "generate",
+        "--prompt",
+        "transparent sticker",
+        "--output-format",
+        "gif",
+        "--json",
+      ),
     ).rejects.toThrow("exit 1");
     expect(mocks.runtime.error).toHaveBeenCalledWith(
       "Error: --output-format must be one of png, jpeg, or webp",
@@ -1873,19 +1709,16 @@ describe("capability cli", () => {
 
     mocks.runtime.error.mockClear();
     await expect(
-      runRegisteredCli({
-        register: registerCapabilityCli as (program: Command) => void,
-        argv: [
-          "capability",
-          "image",
-          "generate",
-          "--prompt",
-          "transparent sticker",
-          "--openai-background",
-          "clear",
-          "--json",
-        ],
-      }),
+      runCap(
+        "capability",
+        "image",
+        "generate",
+        "--prompt",
+        "transparent sticker",
+        "--openai-background",
+        "clear",
+        "--json",
+      ),
     ).rejects.toThrow("exit 1");
     expect(mocks.runtime.error).toHaveBeenCalledWith(
       "Error: --openai-background must be one of transparent, opaque, or auto",
@@ -1893,19 +1726,16 @@ describe("capability cli", () => {
 
     mocks.runtime.error.mockClear();
     await expect(
-      runRegisteredCli({
-        register: registerCapabilityCli as (program: Command) => void,
-        argv: [
-          "capability",
-          "image",
-          "generate",
-          "--prompt",
-          "transparent sticker",
-          "--background",
-          "clear",
-          "--json",
-        ],
-      }),
+      runCap(
+        "capability",
+        "image",
+        "generate",
+        "--prompt",
+        "transparent sticker",
+        "--background",
+        "clear",
+        "--json",
+      ),
     ).rejects.toThrow("exit 1");
     expect(mocks.runtime.error).toHaveBeenCalledWith(
       "Error: --background must be one of transparent, opaque, or auto",
@@ -1913,19 +1743,16 @@ describe("capability cli", () => {
 
     mocks.runtime.error.mockClear();
     await expect(
-      runRegisteredCli({
-        register: registerCapabilityCli as (program: Command) => void,
-        argv: [
-          "capability",
-          "image",
-          "generate",
-          "--prompt",
-          "transparent sticker",
-          "--quality",
-          "expensive",
-          "--json",
-        ],
-      }),
+      runCap(
+        "capability",
+        "image",
+        "generate",
+        "--prompt",
+        "transparent sticker",
+        "--quality",
+        "expensive",
+        "--json",
+      ),
     ).rejects.toThrow("exit 1");
     expect(mocks.runtime.error).toHaveBeenCalledWith(
       "Error: --quality must be one of low, medium, high, or auto",
@@ -1933,19 +1760,16 @@ describe("capability cli", () => {
 
     mocks.runtime.error.mockClear();
     await expect(
-      runRegisteredCli({
-        register: registerCapabilityCli as (program: Command) => void,
-        argv: [
-          "capability",
-          "image",
-          "generate",
-          "--prompt",
-          "transparent sticker",
-          "--openai-moderation",
-          "none",
-          "--json",
-        ],
-      }),
+      runCap(
+        "capability",
+        "image",
+        "generate",
+        "--prompt",
+        "transparent sticker",
+        "--openai-moderation",
+        "none",
+        "--json",
+      ),
     ).rejects.toThrow("exit 1");
     expect(mocks.runtime.error).toHaveBeenCalledWith(
       "Error: --openai-moderation must be one of low or auto",
@@ -1973,29 +1797,26 @@ describe("capability cli", () => {
     await fs.writeFile(tempInput, Buffer.from(pngBase64, "base64"));
     await fs.rm(tempOutput, { force: true });
 
-    await runRegisteredCli({
-      register: registerCapabilityCli as (program: Command) => void,
-      argv: [
-        "capability",
-        "image",
-        "edit",
-        "--file",
-        tempInput,
-        "--prompt",
-        "remove the background object",
-        "--model",
-        "openai/gpt-image-2",
-        "--size",
-        "2160x3840",
-        "--aspect-ratio",
-        "9:16",
-        "--resolution",
-        "4K",
-        "--output",
-        tempOutput,
-        "--json",
-      ],
-    });
+    await runCap(
+      "capability",
+      "image",
+      "edit",
+      "--file",
+      tempInput,
+      "--prompt",
+      "remove the background object",
+      "--model",
+      "openai/gpt-image-2",
+      "--size",
+      "2160x3840",
+      "--aspect-ratio",
+      "9:16",
+      "--resolution",
+      "4K",
+      "--output",
+      tempOutput,
+      "--json",
+    );
 
     const generationCall = firstImageGenerationCall();
     const inputImages = generationCall?.inputImages as Array<Record<string, unknown>>;
@@ -2010,10 +1831,7 @@ describe("capability cli", () => {
   });
 
   it("reports the expanded image.edit flags in capability inspect", async () => {
-    await runRegisteredCli({
-      register: registerCapabilityCli as (program: Command) => void,
-      argv: ["capability", "inspect", "--name", "image.edit", "--json"],
-    });
+    await runCap("capability", "inspect", "--name", "image.edit", "--json");
 
     expect(firstJsonOutput()?.id).toBe("image.edit");
     expect(firstJsonOutput()?.flags).toEqual([
@@ -2036,10 +1854,7 @@ describe("capability cli", () => {
   });
 
   it("reports the expanded image.generate flags in capability inspect", async () => {
-    await runRegisteredCli({
-      register: registerCapabilityCli as (program: Command) => void,
-      argv: ["capability", "inspect", "--name", "image.generate", "--json"],
-    });
+    await runCap("capability", "inspect", "--name", "image.generate", "--json");
 
     expect(firstJsonOutput()?.id).toBe("image.generate");
     expect(firstJsonOutput()?.flags).toEqual([
@@ -2092,18 +1907,7 @@ describe("capability cli", () => {
   });
 
   it("streams url-only generated videos to --output paths", async () => {
-    mocks.generateVideo.mockResolvedValue({
-      provider: "vydra",
-      model: "veo3",
-      attempts: [],
-      videos: [
-        {
-          url: "https://example.com/generated-video.mp4",
-          mimeType: "video/mp4",
-          fileName: "provider-name.mp4",
-        },
-      ],
-    });
+    primeGeneratedVideoUrl("https://example.com/generated-video.mp4");
     const fetchMock = vi.fn(
       async () =>
         new Response(Buffer.from("video-bytes"), {
@@ -2116,19 +1920,16 @@ describe("capability cli", () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-video-generate-"));
     const outputBase = path.join(tempDir, "result");
 
-    await runRegisteredCli({
-      register: registerCapabilityCli as (program: Command) => void,
-      argv: [
-        "capability",
-        "video",
-        "generate",
-        "--prompt",
-        "friendly lobster",
-        "--output",
-        outputBase,
-        "--json",
-      ],
-    });
+    await runCap(
+      "capability",
+      "video",
+      "generate",
+      "--prompt",
+      "friendly lobster",
+      "--output",
+      outputBase,
+      "--json",
+    );
 
     const outputPath = `${outputBase}.mp4`;
     const fetchCalls = fetchMock.mock.calls as unknown as Array<[string, { signal?: unknown }]>;
@@ -2148,18 +1949,7 @@ describe("capability cli", () => {
 
   it("blocks private-network url-only generated video downloads by default", async () => {
     mocks.loadConfig.mockReturnValue({});
-    mocks.generateVideo.mockResolvedValue({
-      provider: "vydra",
-      model: "veo3",
-      attempts: [],
-      videos: [
-        {
-          url: "http://127.0.0.2:40123/private-video.mp4?sig=secret-presigned-token",
-          mimeType: "video/mp4",
-          fileName: "provider-name.mp4",
-        },
-      ],
-    });
+    primeGeneratedVideoUrl("http://127.0.0.2:40123/private-video.mp4?sig=secret-presigned-token");
     const fetchMock = vi.fn(
       async () =>
         new Response(Buffer.from("video-bytes"), {
@@ -2170,10 +1960,7 @@ describe("capability cli", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     await expect(
-      runRegisteredCli({
-        register: registerCapabilityCli as (program: Command) => void,
-        argv: ["capability", "video", "generate", "--prompt", "friendly lobster", "--json"],
-      }),
+      runCap("capability", "video", "generate", "--prompt", "friendly lobster", "--json"),
     ).rejects.toThrow("exit 1");
 
     expect(fetchMock).not.toHaveBeenCalled();
@@ -2192,18 +1979,7 @@ describe("capability cli", () => {
         },
       },
     });
-    mocks.generateVideo.mockResolvedValue({
-      provider: "vydra",
-      model: "veo3",
-      attempts: [],
-      videos: [
-        {
-          url: "http://127.0.0.2:40123/private-video.mp4",
-          mimeType: "video/mp4",
-          fileName: "provider-name.mp4",
-        },
-      ],
-    });
+    primeGeneratedVideoUrl("http://127.0.0.2:40123/private-video.mp4");
     const fetchMock = vi.fn(
       async () =>
         new Response(Buffer.from("video-bytes"), {
@@ -2213,10 +1989,7 @@ describe("capability cli", () => {
     );
     vi.stubGlobal("fetch", fetchMock);
 
-    await runRegisteredCli({
-      register: registerCapabilityCli as (program: Command) => void,
-      argv: ["capability", "video", "generate", "--prompt", "friendly lobster", "--json"],
-    });
+    await runCap("capability", "video", "generate", "--prompt", "friendly lobster", "--json");
 
     const fetchCalls = fetchMock.mock.calls as unknown as Array<[string]>;
     expect(fetchCalls[0]?.[0]).toBe("http://127.0.0.2:40123/private-video.mp4");
@@ -2240,31 +2013,28 @@ describe("capability cli", () => {
       ],
     });
 
-    await runRegisteredCli({
-      register: registerCapabilityCli as (program: Command) => void,
-      argv: [
-        "capability",
-        "video",
-        "generate",
-        "--prompt",
-        "friendly lobster",
-        "--model",
-        "minimax/MiniMax-Hailuo-2.3",
-        "--size",
-        "1280x768",
-        "--aspect-ratio",
-        "16:9",
-        "--resolution",
-        "768p",
-        "--duration",
-        "6",
-        "--audio",
-        "--watermark",
-        "--timeout-ms",
-        "300000",
-        "--json",
-      ],
-    });
+    await runCap(
+      "capability",
+      "video",
+      "generate",
+      "--prompt",
+      "friendly lobster",
+      "--model",
+      "minimax/MiniMax-Hailuo-2.3",
+      "--size",
+      "1280x768",
+      "--aspect-ratio",
+      "16:9",
+      "--resolution",
+      "768p",
+      "--duration",
+      "6",
+      "--audio",
+      "--watermark",
+      "--timeout-ms",
+      "300000",
+      "--json",
+    );
 
     const videoCall = firstVideoGenerationCall();
     expect(videoCall?.prompt).toBe("friendly lobster");
@@ -2287,28 +2057,14 @@ describe("capability cli", () => {
     });
 
     await expect(
-      runRegisteredCli({
-        register: registerCapabilityCli as (program: Command) => void,
-        argv: ["capability", "video", "generate", "--prompt", "friendly lobster", "--json"],
-      }),
+      runCap("capability", "video", "generate", "--prompt", "friendly lobster", "--json"),
     ).rejects.toThrow("exit 1");
     expectRuntimeErrorContains("Video asset at index 0 has neither buffer nor url");
   });
 
   it("fails closed when an url-only generated video exceeds the in-memory byte cap", async () => {
     mocks.loadConfig.mockReturnValue({});
-    mocks.generateVideo.mockResolvedValue({
-      provider: "vydra",
-      model: "veo3",
-      attempts: [],
-      videos: [
-        {
-          url: "https://example.com/oversized-video.mp4?sig=secret-presigned-token",
-          mimeType: "video/mp4",
-          fileName: "provider-name.mp4",
-        },
-      ],
-    });
+    primeGeneratedVideoUrl("https://example.com/oversized-video.mp4?sig=secret-presigned-token");
     // Offer far more than the 16 MiB default video cap in 1 MiB chunks so the
     // bounded reader has to cancel mid-stream instead of buffering it all. The
     // source would yield 64 MiB if fully drained; a correct guard stops early.
@@ -2338,12 +2094,9 @@ describe("capability cli", () => {
     );
     vi.stubGlobal("fetch", fetchMock);
 
+    // No --output: forces the in-memory buffered fallback path.
     await expect(
-      runRegisteredCli({
-        register: registerCapabilityCli as (program: Command) => void,
-        // No --output: forces the in-memory buffered fallback path.
-        argv: ["capability", "video", "generate", "--prompt", "friendly lobster", "--json"],
-      }),
+      runCap("capability", "video", "generate", "--prompt", "friendly lobster", "--json"),
     ).rejects.toThrow("exit 1");
 
     // Real path was driven: the provider URL was actually fetched...
@@ -2368,18 +2121,7 @@ describe("capability cli", () => {
 
   it("redacts provider video URLs when the no-output download fails", async () => {
     mocks.loadConfig.mockReturnValue({});
-    mocks.generateVideo.mockResolvedValue({
-      provider: "vydra",
-      model: "veo3",
-      attempts: [],
-      videos: [
-        {
-          url: "https://example.com/private-video.mp4?sig=secret-presigned-token",
-          mimeType: "video/mp4",
-          fileName: "provider-name.mp4",
-        },
-      ],
-    });
+    primeGeneratedVideoUrl("https://example.com/private-video.mp4?sig=secret-presigned-token");
     const fetchMock = vi.fn(
       async () =>
         new Response("download forbidden", {
@@ -2391,10 +2133,7 @@ describe("capability cli", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     await expect(
-      runRegisteredCli({
-        register: registerCapabilityCli as (program: Command) => void,
-        argv: ["capability", "video", "generate", "--prompt", "friendly lobster", "--json"],
-      }),
+      runCap("capability", "video", "generate", "--prompt", "friendly lobster", "--json"),
     ).rejects.toThrow("exit 1");
 
     expectRuntimeErrorContains("vydra generated video download failed");
@@ -2405,18 +2144,7 @@ describe("capability cli", () => {
 
   it("buffers an url-only generated video that stays under the byte cap", async () => {
     mocks.loadConfig.mockReturnValue({});
-    mocks.generateVideo.mockResolvedValue({
-      provider: "vydra",
-      model: "veo3",
-      attempts: [],
-      videos: [
-        {
-          url: "https://example.com/small-video.mp4",
-          mimeType: "video/mp4",
-          fileName: "provider-name.mp4",
-        },
-      ],
-    });
+    primeGeneratedVideoUrl("https://example.com/small-video.mp4");
     const fetchMock = vi.fn(
       async () =>
         new Response(Buffer.from("small-video-bytes"), {
@@ -2426,11 +2154,8 @@ describe("capability cli", () => {
     );
     vi.stubGlobal("fetch", fetchMock);
 
-    await runRegisteredCli({
-      register: registerCapabilityCli as (program: Command) => void,
-      // No --output: in-memory buffered fallback path, under cap.
-      argv: ["capability", "video", "generate", "--prompt", "friendly lobster", "--json"],
-    });
+    // No --output: in-memory buffered fallback path, under cap.
+    await runCap("capability", "video", "generate", "--prompt", "friendly lobster", "--json");
 
     const fetchCalls = fetchMock.mock.calls as unknown as Array<[string]>;
     expect(fetchCalls[0]?.[0]).toBe("https://example.com/small-video.mp4");
@@ -2446,18 +2171,7 @@ describe("capability cli", () => {
     // Operators can lower the cap via agents.defaults.mediaMaxMb; the bounded
     // read must respect it (here 2 MiB) and cancel even earlier.
     mocks.loadConfig.mockReturnValue({ agents: { defaults: { mediaMaxMb: 2 } } });
-    mocks.generateVideo.mockResolvedValue({
-      provider: "vydra",
-      model: "veo3",
-      attempts: [],
-      videos: [
-        {
-          url: "https://example.com/over-2mb-video.mp4",
-          mimeType: "video/mp4",
-          fileName: "provider-name.mp4",
-        },
-      ],
-    });
+    primeGeneratedVideoUrl("https://example.com/over-2mb-video.mp4");
     const oneMiBChunk = new Uint8Array(1024 * 1024);
     const totalChunks = 16;
     let enqueued = 0;
@@ -2477,10 +2191,7 @@ describe("capability cli", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     await expect(
-      runRegisteredCli({
-        register: registerCapabilityCli as (program: Command) => void,
-        argv: ["capability", "video", "generate", "--prompt", "friendly lobster", "--json"],
-      }),
+      runCap("capability", "video", "generate", "--prompt", "friendly lobster", "--json"),
     ).rejects.toThrow("exit 1");
 
     // Cap resolved from config (2 MiB = 2097152), not the 16 MiB default.
@@ -2492,18 +2203,7 @@ describe("capability cli", () => {
   it("buffers an empty-body url-only generated video without error", async () => {
     // Boundary: a 0-byte body is trivially under the cap and must not error.
     mocks.loadConfig.mockReturnValue({});
-    mocks.generateVideo.mockResolvedValue({
-      provider: "vydra",
-      model: "veo3",
-      attempts: [],
-      videos: [
-        {
-          url: "https://example.com/empty-video.mp4",
-          mimeType: "video/mp4",
-          fileName: "provider-name.mp4",
-        },
-      ],
-    });
+    primeGeneratedVideoUrl("https://example.com/empty-video.mp4");
     const fetchMock = vi.fn(
       async () =>
         new Response(Buffer.alloc(0), {
@@ -2513,10 +2213,7 @@ describe("capability cli", () => {
     );
     vi.stubGlobal("fetch", fetchMock);
 
-    await runRegisteredCli({
-      register: registerCapabilityCli as (program: Command) => void,
-      argv: ["capability", "video", "generate", "--prompt", "friendly lobster", "--json"],
-    });
+    await runCap("capability", "video", "generate", "--prompt", "friendly lobster", "--json");
 
     const output = firstJsonOutput();
     expect(output?.capability).toBe("video.generate");
@@ -2525,10 +2222,7 @@ describe("capability cli", () => {
 
   it("rejects partial image generate count before provider dispatch", async () => {
     await expect(
-      runRegisteredCli({
-        register: registerCapabilityCli as (program: Command) => void,
-        argv: ["capability", "image", "generate", "--prompt", "portrait", "--count", "2x"],
-      }),
+      runCap("capability", "image", "generate", "--prompt", "portrait", "--count", "2x"),
     ).rejects.toThrow("exit 1");
     expectRuntimeErrorContains("--count must be a positive integer");
     expect(mocks.generateImage).not.toHaveBeenCalled();
@@ -2536,10 +2230,7 @@ describe("capability cli", () => {
 
   it("rejects partial image generate timeout before provider dispatch", async () => {
     await expect(
-      runRegisteredCli({
-        register: registerCapabilityCli as (program: Command) => void,
-        argv: ["capability", "image", "generate", "--prompt", "portrait", "--timeout-ms", "1000ms"],
-      }),
+      runCap("capability", "image", "generate", "--prompt", "portrait", "--timeout-ms", "1000ms"),
     ).rejects.toThrow("exit 1");
     expectRuntimeErrorContains("Invalid --timeout. Use a positive millisecond value");
     expect(mocks.generateImage).not.toHaveBeenCalled();
@@ -2577,12 +2268,7 @@ describe("capability cli", () => {
       ["capability", "video", "generate", "--prompt", "clip", "--timeout-ms", "1000ms"],
     ],
   ])("rejects malformed %s timeout before provider dispatch", async (_name, argv) => {
-    await expect(
-      runRegisteredCli({
-        register: registerCapabilityCli as (program: Command) => void,
-        argv,
-      }),
-    ).rejects.toThrow("exit 1");
+    await expect(runCap(...argv)).rejects.toThrow("exit 1");
 
     expectRuntimeErrorContains("Invalid --timeout. Use a positive millisecond value");
     expect(mocks.generateImage).not.toHaveBeenCalled();
@@ -2592,10 +2278,7 @@ describe("capability cli", () => {
   });
 
   it("routes audio transcribe through transcription, not realtime", async () => {
-    await runRegisteredCli({
-      register: registerCapabilityCli as (program: Command) => void,
-      argv: ["capability", "audio", "transcribe", "--file", "memo.m4a", "--json"],
-    });
+    await runCap("capability", "audio", "transcribe", "--file", "memo.m4a", "--json");
 
     expect(path.basename(firstAudioTranscriptionCall()?.filePath ?? "")).toBe("memo.m4a");
     const output = firstJsonOutput();
@@ -2615,10 +2298,7 @@ describe("capability cli", () => {
       diagnostics: [],
     } as never);
 
-    await runRegisteredCli({
-      register: registerCapabilityCli as (program: Command) => void,
-      argv: ["capability", "audio", "transcribe", "--file", "memo.m4a", "--json"],
-    });
+    await runCap("capability", "audio", "transcribe", "--file", "memo.m4a", "--json");
 
     expect(firstCommandConfigResolutionCall()).toEqual(
       expect.objectContaining({
@@ -2641,10 +2321,7 @@ describe("capability cli", () => {
     mocks.transcribeAudioFile.mockResolvedValueOnce({ text: undefined } as never);
 
     await expect(
-      runRegisteredCli({
-        register: registerCapabilityCli as (program: Command) => void,
-        argv: ["capability", "audio", "transcribe", "--file", "memo.m4a", "--json"],
-      }),
+      runCap("capability", "audio", "transcribe", "--file", "memo.m4a", "--json"),
     ).rejects.toThrow("exit 1");
     expect(runtimeErrorMessages()).toEqual([
       `Error: No transcript returned for audio: ${path.resolve("memo.m4a")}`,
@@ -2662,10 +2339,7 @@ describe("capability cli", () => {
     } as never);
 
     await expect(
-      runRegisteredCli({
-        register: registerCapabilityCli as (program: Command) => void,
-        argv: ["capability", "audio", "transcribe", "--file", "memo.m4a", "--json"],
-      }),
+      runCap("capability", "audio", "transcribe", "--file", "memo.m4a", "--json"),
     ).rejects.toThrow("exit 1");
     expectRuntimeErrorContains("No audio transcription provider is configured or ready");
     expectRuntimeErrorContains("tools.media.models");
@@ -2677,30 +2351,24 @@ describe("capability cli", () => {
     );
 
     await expect(
-      runRegisteredCli({
-        register: registerCapabilityCli as (program: Command) => void,
-        argv: ["capability", "audio", "transcribe", "--file", "memo.m4a", "--json"],
-      }),
+      runCap("capability", "audio", "transcribe", "--file", "memo.m4a", "--json"),
     ).rejects.toThrow("exit 1");
     expect(runtimeErrorMessages()).toEqual(["Error: Audio transcription response missing text"]);
   });
 
   it("forwards transcription prompt and language hints", async () => {
-    await runRegisteredCli({
-      register: registerCapabilityCli as (program: Command) => void,
-      argv: [
-        "capability",
-        "audio",
-        "transcribe",
-        "--file",
-        "memo.m4a",
-        "--language",
-        "en",
-        "--prompt",
-        "Focus on names",
-        "--json",
-      ],
-    });
+    await runCap(
+      "capability",
+      "audio",
+      "transcribe",
+      "--file",
+      "memo.m4a",
+      "--language",
+      "en",
+      "--prompt",
+      "Focus on names",
+      "--json",
+    );
 
     const transcribeCall = firstAudioTranscriptionCall();
     expect(path.basename(transcribeCall?.filePath ?? "")).toBe("memo.m4a");
@@ -2709,21 +2377,18 @@ describe("capability cli", () => {
   });
 
   it("uses request-scoped TTS overrides without mutating prefs", async () => {
-    await runRegisteredCli({
-      register: registerCapabilityCli as (program: Command) => void,
-      argv: [
-        "capability",
-        "tts",
-        "convert",
-        "--text",
-        "hello",
-        "--model",
-        "openai/gpt-4o-mini-tts",
-        "--voice",
-        "alloy",
-        "--json",
-      ],
-    });
+    await runCap(
+      "capability",
+      "tts",
+      "convert",
+      "--text",
+      "hello",
+      "--model",
+      "openai/gpt-4o-mini-tts",
+      "--voice",
+      "alloy",
+      "--json",
+    );
 
     const ttsCall = firstTextToSpeechCall();
     const overrides = ttsCall?.overrides as
@@ -2747,19 +2412,16 @@ describe("capability cli", () => {
       mode: "api-key",
     });
 
-    await runRegisteredCli({
-      register: registerCapabilityCli as (program: Command) => void,
-      argv: [
-        "capability",
-        "tts",
-        "convert",
-        "--text",
-        "hello",
-        "--model",
-        "openai/gpt-4o-mini-tts",
-        "--json",
-      ],
-    });
+    await runCap(
+      "capability",
+      "tts",
+      "convert",
+      "--text",
+      "hello",
+      "--model",
+      "openai/gpt-4o-mini-tts",
+      "--json",
+    );
 
     expect(mocks.resolveApiKeyForProvider).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -2787,10 +2449,7 @@ describe("capability cli", () => {
       mode: "api-key",
     });
 
-    await runRegisteredCli({
-      register: registerCapabilityCli as (program: Command) => void,
-      argv: ["capability", "tts", "convert", "--text", "hello", "--json"],
-    });
+    await runCap("capability", "tts", "convert", "--text", "hello", "--json");
 
     expect(mocks.resolveApiKeyForProvider).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -2816,10 +2475,16 @@ describe("capability cli", () => {
       mode: "api-key",
     });
 
-    await runRegisteredCli({
-      register: registerCapabilityCli as (program: Command) => void,
-      argv: ["capability", "tts", "convert", "--text", "hello", "--channel", "discord", "--json"],
-    });
+    await runCap(
+      "capability",
+      "tts",
+      "convert",
+      "--text",
+      "hello",
+      "--channel",
+      "discord",
+      "--json",
+    );
 
     expect(mocks.resolveTtsConfig).toHaveBeenCalledWith(rawConfig, { channelId: "discord" });
     expect(mocks.resolveExplicitTtsOverrides).toHaveBeenCalledWith(
@@ -2850,10 +2515,16 @@ describe("capability cli", () => {
       mode: "api-key",
     });
 
-    await runRegisteredCli({
-      register: registerCapabilityCli as (program: Command) => void,
-      argv: ["capability", "tts", "convert", "--text", "hello", "--channel", "discord", "--json"],
-    });
+    await runCap(
+      "capability",
+      "tts",
+      "convert",
+      "--text",
+      "hello",
+      "--channel",
+      "discord",
+      "--json",
+    );
 
     const cfg = firstTextToSpeechCall()?.cfg as {
       channels?: {
@@ -2890,10 +2561,16 @@ describe("capability cli", () => {
       mode: "api-key",
     });
 
-    await runRegisteredCli({
-      register: registerCapabilityCli as (program: Command) => void,
-      argv: ["capability", "tts", "convert", "--text", "hello", "--channel", "discord", "--json"],
-    });
+    await runCap(
+      "capability",
+      "tts",
+      "convert",
+      "--text",
+      "hello",
+      "--channel",
+      "discord",
+      "--json",
+    );
 
     const cfg = firstTextToSpeechCall()?.cfg as {
       tts?: { providers?: { openai?: { apiKey?: string } } };
@@ -2915,10 +2592,7 @@ describe("capability cli", () => {
       mode: "token",
     });
 
-    await runRegisteredCli({
-      register: registerCapabilityCli as (program: Command) => void,
-      argv: ["capability", "tts", "convert", "--text", "hello", "--json"],
-    });
+    await runCap("capability", "tts", "convert", "--text", "hello", "--json");
 
     const cfg = firstTextToSpeechCall()?.cfg as {
       tts?: { providers?: { openai?: { apiKey?: string } } };
@@ -2935,19 +2609,16 @@ describe("capability cli", () => {
       mode: "api-key",
     });
 
-    await runRegisteredCli({
-      register: registerCapabilityCli as (program: Command) => void,
-      argv: [
-        "capability",
-        "tts",
-        "convert",
-        "--text",
-        "hello",
-        "--model",
-        "openai/gpt-4o-mini-tts",
-        "--json",
-      ],
-    });
+    await runCap(
+      "capability",
+      "tts",
+      "convert",
+      "--text",
+      "hello",
+      "--model",
+      "openai/gpt-4o-mini-tts",
+      "--json",
+    );
 
     const cfg = firstTextToSpeechCall()?.cfg as {
       tts?: { providers?: { openai?: { apiKey?: string }; OpenAI?: { apiKey?: string } } };
@@ -2965,19 +2636,16 @@ describe("capability cli", () => {
       mode: "api-key",
     });
 
-    await runRegisteredCli({
-      register: registerCapabilityCli as (program: Command) => void,
-      argv: [
-        "capability",
-        "tts",
-        "convert",
-        "--text",
-        "hello",
-        "--model",
-        "openai/gpt-4o-mini-tts",
-        "--json",
-      ],
-    });
+    await runCap(
+      "capability",
+      "tts",
+      "convert",
+      "--text",
+      "hello",
+      "--model",
+      "openai/gpt-4o-mini-tts",
+      "--json",
+    );
 
     const cfg = firstTextToSpeechCall()?.cfg as {
       tts?: {
@@ -2990,40 +2658,34 @@ describe("capability cli", () => {
   });
 
   it("disables TTS fallback when explicit provider or voice/model selection is requested", async () => {
-    await runRegisteredCli({
-      register: registerCapabilityCli as (program: Command) => void,
-      argv: [
-        "capability",
-        "tts",
-        "convert",
-        "--text",
-        "hello",
-        "--model",
-        "openai/gpt-4o-mini-tts",
-        "--voice",
-        "alloy",
-        "--json",
-      ],
-    });
+    await runCap(
+      "capability",
+      "tts",
+      "convert",
+      "--text",
+      "hello",
+      "--model",
+      "openai/gpt-4o-mini-tts",
+      "--voice",
+      "alloy",
+      "--json",
+    );
 
     expect(firstTextToSpeechCall()?.disableFallback).toBe(true);
   });
 
   it("does not infer and forward a local provider guess for gateway TTS overrides", async () => {
-    await runRegisteredCli({
-      register: registerCapabilityCli as (program: Command) => void,
-      argv: [
-        "capability",
-        "tts",
-        "convert",
-        "--gateway",
-        "--text",
-        "hello",
-        "--voice",
-        "alloy",
-        "--json",
-      ],
-    });
+    await runCap(
+      "capability",
+      "tts",
+      "convert",
+      "--gateway",
+      "--text",
+      "hello",
+      "--voice",
+      "alloy",
+      "--json",
+    );
 
     expect(firstGatewayCall()?.method).toBe("tts.convert");
     expect(firstGatewayCall()?.params?.provider).toBeUndefined();
@@ -3039,30 +2701,24 @@ describe("capability cli", () => {
     });
 
     await expect(
-      runRegisteredCli({
-        register: registerCapabilityCli as (program: Command) => void,
-        argv: [
-          "capability",
-          "tts",
-          "convert",
-          "--gateway",
-          "--text",
-          "hello",
-          "--output",
-          "hello.mp3",
-          "--json",
-        ],
-      }),
+      runCap(
+        "capability",
+        "tts",
+        "convert",
+        "--gateway",
+        "--text",
+        "hello",
+        "--output",
+        "hello.mp3",
+        "--json",
+      ),
     ).rejects.toThrow("exit 1");
 
     expectRuntimeErrorContains("--output is not supported for remote gateway TTS yet");
   });
 
   it("uses only embedding providers for embedding creation", async () => {
-    await runRegisteredCli({
-      register: registerCapabilityCli as (program: Command) => void,
-      argv: ["capability", "embedding", "create", "--text", "hello", "--json"],
-    });
+    await runCap("capability", "embedding", "create", "--text", "hello", "--json");
 
     expect(firstEmbeddingProviderCall()?.provider).toBe("auto");
     expect(firstEmbeddingProviderCall()?.fallback).toBe("none");
@@ -3087,10 +2743,7 @@ describe("capability cli", () => {
     });
 
     await expect(
-      runRegisteredCli({
-        register: registerCapabilityCli as (program: Command) => void,
-        argv: ["capability", "embedding", "create", "--text", "hello", "--json"],
-      }),
+      runCap("capability", "embedding", "create", "--text", "hello", "--json"),
     ).rejects.toThrow("exit 1");
 
     expect(closeEmbeddingProviderMock).toHaveBeenCalledTimes(2);
@@ -3103,10 +2756,7 @@ describe("capability cli", () => {
       .mockRejectedValueOnce(new Error("close failed"));
 
     await expect(
-      runRegisteredCli({
-        register: registerCapabilityCli as (program: Command) => void,
-        argv: ["capability", "embedding", "create", "--text", "hello", "--json"],
-      }),
+      runCap("capability", "embedding", "create", "--text", "hello", "--json"),
     ).rejects.toThrow("exit 1");
 
     expect(closeEmbeddingProviderMock).toHaveBeenCalledTimes(2);
@@ -3123,10 +2773,7 @@ describe("capability cli", () => {
       diagnostics: [],
     } as never);
 
-    await runRegisteredCli({
-      register: registerCapabilityCli as (program: Command) => void,
-      argv: ["capability", "model", "run", "--prompt", "hello", "--json"],
-    });
+    await runCap("capability", "model", "run", "--prompt", "hello", "--json");
 
     expect(firstCommandConfigResolutionCall()).toEqual(
       expect.objectContaining({
@@ -3148,19 +2795,16 @@ describe("capability cli", () => {
   });
 
   it("derives the embedding provider from a provider/model override", async () => {
-    await runRegisteredCli({
-      register: registerCapabilityCli as (program: Command) => void,
-      argv: [
-        "capability",
-        "embedding",
-        "create",
-        "--text",
-        "hello",
-        "--model",
-        "openai/text-embedding-3-large",
-        "--json",
-      ],
-    });
+    await runCap(
+      "capability",
+      "embedding",
+      "create",
+      "--text",
+      "hello",
+      "--model",
+      "openai/text-embedding-3-large",
+      "--json",
+    );
 
     expect(firstEmbeddingProviderCall()?.provider).toBe("openai");
     expect(firstEmbeddingProviderCall()?.fallback).toBe("none");
@@ -3208,10 +2852,7 @@ describe("capability cli", () => {
       },
     );
 
-    await runRegisteredCli({
-      register: registerCapabilityCli as (program: Command) => void,
-      argv: ["capability", "model", "auth", "logout", "--provider", "openai", "--json"],
-    });
+    await runCap("capability", "model", "auth", "logout", "--provider", "openai", "--json");
 
     if (updatedStore === null) {
       throw new Error("expected updated auth store");
@@ -3237,20 +2878,17 @@ describe("capability cli", () => {
   it("removes model auth profiles from the selected agent store", async () => {
     mocks.listProfilesForProvider.mockReturnValue(["openai:default"] as never);
 
-    await runRegisteredCli({
-      register: registerCapabilityCli as (program: Command) => void,
-      argv: [
-        "capability",
-        "model",
-        "auth",
-        "logout",
-        "--provider",
-        "openai",
-        "--agent",
-        "poe",
-        "--json",
-      ],
-    });
+    await runCap(
+      "capability",
+      "model",
+      "auth",
+      "logout",
+      "--provider",
+      "openai",
+      "--agent",
+      "poe",
+      "--json",
+    );
 
     expect(mocks.loadAuthProfileStoreForRuntime).toHaveBeenCalledWith("/tmp/agent-poe");
     expect(mocks.updateAuthProfileStoreWithLock).toHaveBeenCalledWith(
@@ -3267,83 +2905,52 @@ describe("capability cli", () => {
     mocks.updateAuthProfileStoreWithLock.mockResolvedValueOnce(null as never);
 
     await expect(
-      runRegisteredCli({
-        register: registerCapabilityCli as (program: Command) => void,
-        argv: ["capability", "model", "auth", "logout", "--provider", "openai", "--json"],
-      }),
+      runCap("capability", "model", "auth", "logout", "--provider", "openai", "--json"),
     ).rejects.toThrow("exit 1");
 
     expectRuntimeErrorContains("Failed to remove saved auth profiles for provider openai.");
   });
 
-  it("rejects providerless audio model overrides", async () => {
-    await expect(
-      runRegisteredCli({
-        register: registerCapabilityCli as (program: Command) => void,
-        argv: [
-          "capability",
-          "audio",
-          "transcribe",
-          "--file",
-          "memo.m4a",
-          "--model",
-          "whisper-1",
-          "--json",
-        ],
-      }),
-    ).rejects.toThrow("exit 1");
-
-    expectRuntimeErrorContains("Model overrides must use the form <provider/model>.");
-    expect(mocks.transcribeAudioFile).not.toHaveBeenCalled();
-  });
-
-  it("rejects providerless image describe model overrides", async () => {
-    await expect(
-      runRegisteredCli({
-        register: registerCapabilityCli as (program: Command) => void,
-        argv: [
-          "capability",
-          "image",
-          "describe",
-          "--file",
-          "photo.jpg",
-          "--model",
-          "gpt-4.1-mini",
-          "--json",
-        ],
-      }),
-    ).rejects.toThrow("exit 1");
-
-    expectRuntimeErrorContains("Model overrides must use the form <provider/model>.");
-    expect(mocks.describeImageFile).not.toHaveBeenCalled();
-  });
-
-  it("rejects providerless video describe model overrides", async () => {
-    const mediaRuntime = await import("../media-understanding/runtime.js");
-    vi.mocked(mediaRuntime.describeVideoFile).mockResolvedValue({
-      text: "friendly lobster",
-      provider: "openai",
+  it.each([
+    {
+      name: "rejects providerless audio model overrides",
+      capability: "audio",
+      action: "transcribe",
+      file: "memo.m4a",
+      model: "whisper-1",
+    },
+    {
+      name: "rejects providerless image describe model overrides",
+      capability: "image",
+      action: "describe",
+      file: "photo.jpg",
       model: "gpt-4.1-mini",
-    } as never);
-
+    },
+    {
+      name: "rejects providerless video describe model overrides",
+      capability: "video",
+      action: "describe",
+      file: "clip.mp4",
+      model: "gpt-4.1-mini",
+    },
+  ])("$name", async ({ capability, action, file, model }) => {
+    let dispatchMock: ReturnType<typeof vi.fn>;
+    if (capability === "video") {
+      const mediaRuntime = await import("../media-understanding/runtime.js");
+      dispatchMock = vi.mocked(mediaRuntime.describeVideoFile);
+      dispatchMock.mockResolvedValue({
+        text: "friendly lobster",
+        provider: "openai",
+        model: "gpt-4.1-mini",
+      } as never);
+    } else {
+      dispatchMock = capability === "audio" ? mocks.transcribeAudioFile : mocks.describeImageFile;
+    }
     await expect(
-      runRegisteredCli({
-        register: registerCapabilityCli as (program: Command) => void,
-        argv: [
-          "capability",
-          "video",
-          "describe",
-          "--file",
-          "clip.mp4",
-          "--model",
-          "gpt-4.1-mini",
-          "--json",
-        ],
-      }),
+      runCap("capability", capability, action, "--file", file, "--model", model, "--json"),
     ).rejects.toThrow("exit 1");
-
     expectRuntimeErrorContains("Model overrides must use the form <provider/model>.");
-    expect(vi.mocked(mediaRuntime.describeVideoFile)).not.toHaveBeenCalled();
+    expect(dispatchMock).not.toHaveBeenCalled();
   });
 
   it("lists generic embedding providers when the memory registry is empty", async () => {
@@ -3352,10 +2959,7 @@ describe("capability cli", () => {
       { id: "generic", defaultModel: "generic-embed", transport: "remote" },
     ] as never);
 
-    await runRegisteredCli({
-      register: registerCapabilityCli as (program: Command) => void,
-      argv: ["capability", "embedding", "providers", "--json"],
-    });
+    await runCap("capability", "embedding", "providers", "--json");
 
     expect(firstJsonOutput()).toMatchObject([
       { id: "generic", defaultModel: "generic-embed", transport: "remote" },
@@ -3386,10 +2990,7 @@ describe("capability cli", () => {
       ]),
     );
 
-    await runRegisteredCli({
-      register: registerCapabilityCli as (program: Command) => void,
-      argv: ["capability", "audio", "providers", "--json"],
-    });
+    await runCap("capability", "audio", "providers", "--json");
 
     expect(mocks.runtime.writeJson).toHaveBeenCalledWith([
       {
@@ -3446,10 +3047,7 @@ describe("capability cli", () => {
       selected: candidate,
     });
 
-    await runRegisteredCli({
-      register: registerCapabilityCli as (program: Command) => void,
-      argv: ["capability", "audio", "providers", "--json"],
-    });
+    await runCap("capability", "audio", "providers", "--json");
 
     expect(firstJsonOutput()).toEqual([
       {
@@ -3516,10 +3114,7 @@ describe("capability cli", () => {
       result: { results: [] },
     } as never);
 
-    await runRegisteredCli({
-      register: registerCapabilityCli as (program: Command) => void,
-      argv: ["infer", "web", "search", "--query", "ping", "--json"],
-    });
+    await runCap("infer", "web", "search", "--query", "ping", "--json");
 
     const { getCapabilityWebSearchCommandSecretTargets } =
       await import("./command-secret-targets.js");
@@ -3541,10 +3136,7 @@ describe("capability cli", () => {
     const webSearchRuntime = await import("../web-search/runtime.js");
     vi.mocked(webSearchRuntime.runWebSearch).mockClear();
     await expect(
-      runRegisteredCli({
-        register: registerCapabilityCli as (program: Command) => void,
-        argv: ["capability", "web", "search", "--query", "ping", "--limit", "3x"],
-      }),
+      runCap("capability", "web", "search", "--query", "ping", "--limit", "3x"),
     ).rejects.toThrow("exit 1");
     expectRuntimeErrorContains("--limit must be a positive integer");
     expect(webSearchRuntime.runWebSearch).not.toHaveBeenCalled();
@@ -3599,10 +3191,7 @@ describe("capability cli", () => {
       result: { results: [] },
     } as never);
 
-    await runRegisteredCli({
-      register: registerCapabilityCli as (program: Command) => void,
-      argv: ["infer", "web", "search", "--query", "ping", "--provider", "firecrawl", "--json"],
-    });
+    await runCap("infer", "web", "search", "--query", "ping", "--provider", "firecrawl", "--json");
 
     const { getCapabilityWebSearchCommandSecretTargets } =
       await import("./command-secret-targets.js");
@@ -3675,10 +3264,7 @@ describe("capability cli", () => {
       definition: { execute: vi.fn(async () => ({ content: "ok" })) },
     } as never);
 
-    await runRegisteredCli({
-      register: registerCapabilityCli as (program: Command) => void,
-      argv: ["infer", "web", "fetch", "--url", "https://example.com", "--json"],
-    });
+    await runCap("infer", "web", "fetch", "--url", "https://example.com", "--json");
 
     const { getCapabilityWebFetchCommandSecretTargets } =
       await import("./command-secret-targets.js");
@@ -3737,19 +3323,16 @@ describe("capability cli", () => {
       definition: { execute: vi.fn(async () => ({ content: "ok" })) },
     } as never);
 
-    await runRegisteredCli({
-      register: registerCapabilityCli as (program: Command) => void,
-      argv: [
-        "infer",
-        "web",
-        "fetch",
-        "--url",
-        "https://example.com",
-        "--provider",
-        "firecrawl",
-        "--json",
-      ],
-    });
+    await runCap(
+      "infer",
+      "web",
+      "fetch",
+      "--url",
+      "https://example.com",
+      "--provider",
+      "firecrawl",
+      "--json",
+    );
 
     const { getCapabilityWebFetchCommandSecretTargets } =
       await import("./command-secret-targets.js");
@@ -3794,10 +3377,7 @@ describe("capability cli", () => {
     mocks.isWebSearchProviderConfigured.mockReturnValueOnce(false).mockReturnValueOnce(true);
     mocks.isWebFetchProviderConfigured.mockReturnValueOnce(true);
 
-    await runRegisteredCli({
-      register: registerCapabilityCli as (program: Command) => void,
-      argv: ["capability", "web", "providers", "--json"],
-    });
+    await runCap("capability", "web", "providers", "--json");
 
     expect(mocks.runtime.writeJson).toHaveBeenCalledWith({
       search: [
@@ -3839,10 +3419,7 @@ describe("capability cli", () => {
       { id: "gemini", defaultModel: "gemini-embedding-001", transport: "remote" },
     ]);
 
-    await runRegisteredCli({
-      register: registerCapabilityCli as (program: Command) => void,
-      argv: ["capability", "embedding", "providers", "--json"],
-    });
+    await runCap("capability", "embedding", "providers", "--json");
 
     expect(mocks.runtime.writeJson).toHaveBeenCalledWith([
       {
@@ -3879,10 +3456,7 @@ describe("capability cli", () => {
       { id: "openai-compatible", transport: "remote" },
     ] as never);
 
-    await runRegisteredCli({
-      register: registerCapabilityCli as (program: Command) => void,
-      argv: ["capability", "embedding", "providers", "--json"],
-    });
+    await runCap("capability", "embedding", "providers", "--json");
 
     expect(mocks.runtime.writeJson).toHaveBeenCalledWith([
       {
@@ -3929,10 +3503,7 @@ describe("capability cli", () => {
       { id: "openai-compatible", transport: "remote" },
     ] as never);
 
-    await runRegisteredCli({
-      register: registerCapabilityCli as (program: Command) => void,
-      argv: ["capability", "embedding", "providers", "--json"],
-    });
+    await runCap("capability", "embedding", "providers", "--json");
 
     expect(mocks.runtime.writeJson).toHaveBeenCalledWith([
       {

--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -145,6 +145,14 @@ function setSnapshot(resolved: OpenClawConfig, config: OpenClawConfig) {
   mockReadConfigFileSnapshot.mockResolvedValue(buildSnapshot({ resolved, config }));
 }
 
+function setGatewaySnapshot(secrets?: OpenClawConfig["secrets"]): void {
+  const resolved: OpenClawConfig = {
+    gateway: { port: 18789 },
+    ...(secrets ? { secrets } : {}),
+  };
+  setSnapshot(resolved, resolved);
+}
+
 function setSnapshotOnce(snapshot: ConfigFileSnapshot) {
   mockReadConfigFileSnapshot.mockResolvedValueOnce(snapshot);
 }
@@ -1207,10 +1215,7 @@ describe("config cli", () => {
     });
 
     it("outputs JSON error to stdout when path is not found and --json is set", async () => {
-      const resolved: OpenClawConfig = {
-        gateway: { port: 18789 },
-      };
-      setSnapshot(resolved, resolved);
+      setGatewaySnapshot();
 
       await expect(
         runConfigCommand(["config", "get", "nonexistent.path", "--json"]),
@@ -1224,10 +1229,7 @@ describe("config cli", () => {
 
   describe("config validate", () => {
     it("prints success and exits 0 when config is valid", async () => {
-      const resolved: OpenClawConfig = {
-        gateway: { port: 18789 },
-      };
-      setSnapshot(resolved, resolved);
+      setGatewaySnapshot();
 
       await runConfigCommand(["config", "validate"]);
 
@@ -1586,10 +1588,7 @@ describe("config cli", () => {
 
   describe("config set builders and dry-run", () => {
     it("supports SecretRef builder mode without requiring a value argument", async () => {
-      const resolved: OpenClawConfig = {
-        gateway: { port: 18789 },
-      };
-      setSnapshot(resolved, resolved);
+      setGatewaySnapshot();
 
       await runConfigCommand([
         "config",
@@ -1690,10 +1689,7 @@ describe("config cli", () => {
     });
 
     it("fails early when unsupported mutable paths are assigned SecretRef objects (builder mode)", async () => {
-      const resolved: OpenClawConfig = {
-        gateway: { port: 18789 },
-      };
-      setSnapshot(resolved, resolved);
+      setGatewaySnapshot();
 
       await expect(
         runConfigCommand([
@@ -1715,10 +1711,7 @@ describe("config cli", () => {
     });
 
     it("fails early when parent-object writes include unsupported SecretRef objects", async () => {
-      const resolved: OpenClawConfig = {
-        gateway: { port: 18789 },
-      };
-      setSnapshot(resolved, resolved);
+      setGatewaySnapshot();
 
       await expect(
         runConfigCommand([
@@ -1736,10 +1729,7 @@ describe("config cli", () => {
     });
 
     it("supports provider builder mode under secrets.providers.<alias>", async () => {
-      const resolved: OpenClawConfig = {
-        gateway: { port: 18789 },
-      };
-      setSnapshot(resolved, resolved);
+      setGatewaySnapshot();
 
       await runConfigCommand([
         "config",
@@ -1782,15 +1772,7 @@ describe("config cli", () => {
     });
 
     it("runs resolvability checks in builder dry-run mode without writing", async () => {
-      const resolved: OpenClawConfig = {
-        gateway: { port: 18789 },
-        secrets: {
-          providers: {
-            default: { source: "env" },
-          },
-        },
-      };
-      setSnapshot(resolved, resolved);
+      setGatewaySnapshot({ providers: { default: { source: "env" } } });
 
       await runConfigCommand([
         "config",
@@ -1817,10 +1799,7 @@ describe("config cli", () => {
     });
 
     it("requires schema validation in JSON dry-run mode", async () => {
-      const resolved: OpenClawConfig = {
-        gateway: { port: 18789 },
-      };
-      setSnapshot(resolved, resolved);
+      setGatewaySnapshot();
 
       await expect(
         runConfigCommand([
@@ -1867,15 +1846,7 @@ describe("config cli", () => {
     });
 
     it("fails dry-run when unsupported mutable paths receive SecretRef objects in value/json mode", async () => {
-      const resolved: OpenClawConfig = {
-        gateway: { port: 18789 },
-        secrets: {
-          providers: {
-            default: { source: "env" },
-          },
-        },
-      };
-      setSnapshot(resolved, resolved);
+      setGatewaySnapshot({ providers: { default: { source: "env" } } });
 
       await expect(
         runConfigCommand([
@@ -1894,10 +1865,7 @@ describe("config cli", () => {
     });
 
     it("aggregates policy failures across batch entries", async () => {
-      const resolved: OpenClawConfig = {
-        gateway: { port: 18789 },
-      };
-      setSnapshot(resolved, resolved);
+      setGatewaySnapshot();
 
       await expect(
         runConfigCommand([
@@ -1915,10 +1883,7 @@ describe("config cli", () => {
     });
 
     it("does not duplicate policy errors in --dry-run --json mode for parent-object writes", async () => {
-      const resolved: OpenClawConfig = {
-        gateway: { port: 18789 },
-      };
-      setSnapshot(resolved, resolved);
+      setGatewaySnapshot();
 
       await expect(
         runConfigCommand([
@@ -1948,10 +1913,7 @@ describe("config cli", () => {
     });
 
     it("logs a dry-run note when value mode performs no validation checks", async () => {
-      const resolved: OpenClawConfig = {
-        gateway: { port: 18789 },
-      };
-      setSnapshot(resolved, resolved);
+      setGatewaySnapshot();
 
       await runConfigCommand(["config", "set", "gateway.port", "19001", "--dry-run"]);
 
@@ -1962,15 +1924,7 @@ describe("config cli", () => {
     });
 
     it("supports batch mode for refs/providers in dry-run", async () => {
-      const resolved: OpenClawConfig = {
-        gateway: { port: 18789 },
-        secrets: {
-          providers: {
-            default: { source: "env" },
-          },
-        },
-      };
-      setSnapshot(resolved, resolved);
+      setGatewaySnapshot({ providers: { default: { source: "env" } } });
 
       await runConfigCommand([
         "config",
@@ -1985,18 +1939,7 @@ describe("config cli", () => {
     });
 
     it("skips exec SecretRef resolvability checks in dry-run by default", async () => {
-      const resolved: OpenClawConfig = {
-        gateway: { port: 18789 },
-        secrets: {
-          providers: {
-            runner: {
-              source: "exec",
-              command: "/usr/bin/env",
-            },
-          },
-        },
-      };
-      setSnapshot(resolved, resolved);
+      setGatewaySnapshot({ providers: { runner: { source: "exec", command: "/usr/bin/env" } } });
 
       await runConfigCommand([
         "config",
@@ -2019,18 +1962,7 @@ describe("config cli", () => {
     });
 
     it("allows exec SecretRef resolvability checks in dry-run when --allow-exec is set", async () => {
-      const resolved: OpenClawConfig = {
-        gateway: { port: 18789 },
-        secrets: {
-          providers: {
-            runner: {
-              source: "exec",
-              command: "/usr/bin/env",
-            },
-          },
-        },
-      };
-      setSnapshot(resolved, resolved);
+      setGatewaySnapshot({ providers: { runner: { source: "exec", command: "/usr/bin/env" } } });
 
       await runConfigCommand([
         "config",
@@ -2964,15 +2896,7 @@ describe("config cli", () => {
     });
 
     it("fails dry-run when a builder-assigned SecretRef is unresolved", async () => {
-      const resolved: OpenClawConfig = {
-        gateway: { port: 18789 },
-        secrets: {
-          providers: {
-            default: { source: "env" },
-          },
-        },
-      };
-      setSnapshot(resolved, resolved);
+      setGatewaySnapshot({ providers: { default: { source: "env" } } });
       mockResolveSecretRefValue.mockRejectedValueOnce(new Error("missing env var"));
 
       await expect(
@@ -2994,15 +2918,7 @@ describe("config cli", () => {
     });
 
     it("emits structured JSON for --dry-run --json success", async () => {
-      const resolved: OpenClawConfig = {
-        gateway: { port: 18789 },
-        secrets: {
-          providers: {
-            default: { source: "env" },
-          },
-        },
-      };
-      setSnapshot(resolved, resolved);
+      setGatewaySnapshot({ providers: { default: { source: "env" } } });
 
       await runConfigCommand([
         "config",
@@ -3037,18 +2953,7 @@ describe("config cli", () => {
     });
 
     it("emits skipped exec metadata for --dry-run --json success", async () => {
-      const resolved: OpenClawConfig = {
-        gateway: { port: 18789 },
-        secrets: {
-          providers: {
-            runner: {
-              source: "exec",
-              command: "/usr/bin/env",
-            },
-          },
-        },
-      };
-      setSnapshot(resolved, resolved);
+      setGatewaySnapshot({ providers: { runner: { source: "exec", command: "/usr/bin/env" } } });
 
       await runConfigCommand([
         "config",
@@ -3078,15 +2983,7 @@ describe("config cli", () => {
     });
 
     it("emits structured JSON for --dry-run --json failure", async () => {
-      const resolved: OpenClawConfig = {
-        gateway: { port: 18789 },
-        secrets: {
-          providers: {
-            default: { source: "env" },
-          },
-        },
-      };
-      setSnapshot(resolved, resolved);
+      setGatewaySnapshot({ providers: { default: { source: "env" } } });
       mockResolveSecretRefValue.mockRejectedValueOnce(new Error("missing env var"));
 
       await expect(
@@ -3117,15 +3014,7 @@ describe("config cli", () => {
     });
 
     it("keeps distinct resolvability failures when messages are identical but refs differ", async () => {
-      const resolved: OpenClawConfig = {
-        gateway: { port: 18789 },
-        secrets: {
-          providers: {
-            default: { source: "env" },
-          },
-        },
-      };
-      setSnapshot(resolved, resolved);
+      setGatewaySnapshot({ providers: { default: { source: "env" } } });
 
       await expect(
         runConfigCommand([
@@ -3155,15 +3044,7 @@ describe("config cli", () => {
     });
 
     it("aggregates schema and resolvability failures in --dry-run --json mode", async () => {
-      const resolved: OpenClawConfig = {
-        gateway: { port: 18789 },
-        secrets: {
-          providers: {
-            default: { source: "env" },
-          },
-        },
-      };
-      setSnapshot(resolved, resolved);
+      setGatewaySnapshot({ providers: { default: { source: "env" } } });
       mockResolveSecretRefValue.mockRejectedValue(new Error("missing env var"));
 
       await expect(
@@ -3274,97 +3155,68 @@ describe("config cli", () => {
   });
 
   describe("path hardening", () => {
-    it("rejects blocked prototype-key segments for config get", async () => {
-      await expect(runConfigCommand(["config", "get", "gateway.__proto__.token"])).rejects.toThrow(
-        "Invalid path segment: __proto__",
-      );
-
-      expect(mockReadConfigFileSnapshot).not.toHaveBeenCalled();
-      expect(mockWriteConfigFile).not.toHaveBeenCalled();
-    });
-
-    it("rejects blocked prototype-key segments for config set", async () => {
-      await expect(
-        runConfigCommand(["config", "set", "tools.constructor.profile", '"sandbox"']),
-      ).rejects.toThrow("Invalid path segment: constructor");
-
-      expect(mockReadConfigFileSnapshot).not.toHaveBeenCalled();
-      expect(mockWriteConfigFile).not.toHaveBeenCalled();
-    });
-
-    it("rejects blocked prototype-key segments for config unset", async () => {
-      await expect(
-        runConfigCommand(["config", "unset", "channels.prototype.enabled"]),
-      ).rejects.toThrow("Invalid path segment: prototype");
-
-      expect(mockReadConfigFileSnapshot).not.toHaveBeenCalled();
-      expect(mockWriteConfigFile).not.toHaveBeenCalled();
-    });
-
-    it("rejects impractical array indexes for config set", async () => {
-      const resolved = { agents: { list: [] } } as unknown as OpenClawConfig;
-      setSnapshot(resolved, resolved);
-
-      await expect(
-        runConfigCommand(["config", "set", "agents.list.4294967294.id", '"main"']),
-      ).rejects.toThrow('Expected numeric index for array segment "4294967294"');
-
-      expect(mockWriteConfigFile).not.toHaveBeenCalled();
-    });
-
-    it("rejects signed array indexes for config set", async () => {
-      const resolved = { agents: { list: [{ id: "main" }] } } as unknown as OpenClawConfig;
-      setSnapshot(resolved, resolved);
-
-      await expect(
-        runConfigCommand(["config", "set", "agents.list.+0.id", '"other"']),
-      ).rejects.toThrow('Expected numeric index for array segment "+0"');
-
-      expect(mockWriteConfigFile).not.toHaveBeenCalled();
-    });
-
-    it("rejects double-dot empty segments for config set instead of writing a different key", async () => {
-      await expect(runConfigCommand(["config", "set", "gateway..port", "23456"])).rejects.toThrow(
-        "Invalid path (empty segment): gateway..port",
-      );
-
-      expect(mockReadConfigFileSnapshot).not.toHaveBeenCalled();
-      expect(mockWriteConfigFile).not.toHaveBeenCalled();
-    });
-
-    it("rejects leading-dot empty segments for config get", async () => {
-      await expect(runConfigCommand(["config", "get", ".gateway.port"])).rejects.toThrow(
-        "Invalid path (empty segment): .gateway.port",
-      );
-
-      expect(mockReadConfigFileSnapshot).not.toHaveBeenCalled();
-      expect(mockWriteConfigFile).not.toHaveBeenCalled();
-    });
-
-    it("rejects trailing-dot empty segments for config unset", async () => {
-      await expect(runConfigCommand(["config", "unset", "gateway.port."])).rejects.toThrow(
-        "Invalid path (empty segment): gateway.port.",
-      );
-
-      expect(mockReadConfigFileSnapshot).not.toHaveBeenCalled();
-      expect(mockWriteConfigFile).not.toHaveBeenCalled();
-    });
-
-    it("rejects whitespace-only segments for config set", async () => {
-      await expect(runConfigCommand(["config", "set", "gateway. .port", "23456"])).rejects.toThrow(
-        "Invalid path (empty segment): gateway. .port",
-      );
-
-      expect(mockReadConfigFileSnapshot).not.toHaveBeenCalled();
-      expect(mockWriteConfigFile).not.toHaveBeenCalled();
-    });
-
-    it("rejects an empty segment before a bracket for config set", async () => {
-      await expect(runConfigCommand(["config", "set", "gateway.[port]", "23456"])).rejects.toThrow(
-        "Invalid path (empty segment): gateway.[port]",
-      );
-
-      expect(mockReadConfigFileSnapshot).not.toHaveBeenCalled();
+    it.each([
+      {
+        name: "rejects blocked prototype-key segments for config get",
+        args: ["config", "get", "gateway.__proto__.token"],
+        error: "Invalid path segment: __proto__",
+      },
+      {
+        name: "rejects blocked prototype-key segments for config set",
+        args: ["config", "set", "tools.constructor.profile", '"sandbox"'],
+        error: "Invalid path segment: constructor",
+      },
+      {
+        name: "rejects blocked prototype-key segments for config unset",
+        args: ["config", "unset", "channels.prototype.enabled"],
+        error: "Invalid path segment: prototype",
+      },
+      {
+        name: "rejects impractical array indexes for config set",
+        args: ["config", "set", "agents.list.4294967294.id", '"main"'],
+        error: 'Expected numeric index for array segment "4294967294"',
+        list: [],
+      },
+      {
+        name: "rejects signed array indexes for config set",
+        args: ["config", "set", "agents.list.+0.id", '"other"'],
+        error: 'Expected numeric index for array segment "+0"',
+        list: [{ id: "main" }],
+      },
+      {
+        name: "rejects double-dot empty segments for config set instead of writing a different key",
+        args: ["config", "set", "gateway..port", "23456"],
+        error: "Invalid path (empty segment): gateway..port",
+      },
+      {
+        name: "rejects leading-dot empty segments for config get",
+        args: ["config", "get", ".gateway.port"],
+        error: "Invalid path (empty segment): .gateway.port",
+      },
+      {
+        name: "rejects trailing-dot empty segments for config unset",
+        args: ["config", "unset", "gateway.port."],
+        error: "Invalid path (empty segment): gateway.port.",
+      },
+      {
+        name: "rejects whitespace-only segments for config set",
+        args: ["config", "set", "gateway. .port", "23456"],
+        error: "Invalid path (empty segment): gateway. .port",
+      },
+      {
+        name: "rejects an empty segment before a bracket for config set",
+        args: ["config", "set", "gateway.[port]", "23456"],
+        error: "Invalid path (empty segment): gateway.[port]",
+      },
+    ])("$name", async ({ args, error, list }) => {
+      if (list) {
+        const resolved = { agents: { list } } as unknown as OpenClawConfig;
+        setSnapshot(resolved, resolved);
+      }
+      await expect(runConfigCommand(args)).rejects.toThrow(error);
+      if (!list) {
+        expect(mockReadConfigFileSnapshot).not.toHaveBeenCalled();
+      }
       expect(mockWriteConfigFile).not.toHaveBeenCalled();
     });
 

--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -207,6 +207,14 @@ async function runCronCommand(args: string[]): Promise<void> {
   await program.parseAsync(args, { from: "user" });
 }
 
+function namedCronAddArgs(name: string, ...args: string[]): string[] {
+  return ["--name", name, "--cron", "* * * * *", ...args];
+}
+
+async function runNamedCronAdd(name: string, ...args: string[]): Promise<void> {
+  await runCronCommand(["cron", "add", ...namedCronAddArgs(name, ...args)]);
+}
+
 async function expectCronCommandExit(args: string[]): Promise<void> {
   await expect(runCronCommand(args)).rejects.toThrow("__exit__:1");
 }
@@ -443,13 +451,8 @@ describe("cron cli", () => {
   });
 
   it("trims model and thinking on cron add", { timeout: CRON_CLI_TEST_TIMEOUT_MS }, async () => {
-    await runCronCommand([
-      "cron",
-      "add",
-      "--name",
+    await runNamedCronAdd(
       "Daily",
-      "--cron",
-      "* * * * *",
       "--session",
       "isolated",
       "--message",
@@ -458,7 +461,7 @@ describe("cron cli", () => {
       "  opus  ",
       "--thinking",
       "  low  ",
-    ]);
+    );
 
     const addCall = callGatewayFromCli.mock.calls.find((call) => call[0] === "cron.add");
     const params = addCall?.[2] as {
@@ -470,18 +473,7 @@ describe("cron cli", () => {
   });
 
   it("defaults isolated cron add to announce delivery", async () => {
-    await runCronCommand([
-      "cron",
-      "add",
-      "--name",
-      "Daily",
-      "--cron",
-      "* * * * *",
-      "--session",
-      "isolated",
-      "--message",
-      "hello",
-    ]);
+    await runNamedCronAdd("Daily", "--session", "isolated", "--message", "hello");
 
     const addCall = callGatewayFromCli.mock.calls.find((call) => call[0] === "cron.add");
     const params = addCall?.[2] as { delivery?: { mode?: string } };
@@ -595,32 +587,14 @@ describe("cron cli", () => {
   });
 
   it("infers sessionTarget from payload when --session is omitted", async () => {
-    await runCronCommand([
-      "cron",
-      "add",
-      "--name",
-      "Main reminder",
-      "--cron",
-      "* * * * *",
-      "--system-event",
-      "hi",
-    ]);
+    await runNamedCronAdd("Main reminder", "--system-event", "hi");
 
     let addCall = callGatewayFromCli.mock.calls.find((call) => call[0] === "cron.add");
     let params = addCall?.[2] as { sessionTarget?: string; payload?: { kind?: string } };
     expect(params?.sessionTarget).toBe("main");
     expect(params?.payload?.kind).toBe("systemEvent");
 
-    await runCronCommand([
-      "cron",
-      "add",
-      "--name",
-      "Isolated task",
-      "--cron",
-      "* * * * *",
-      "--message",
-      "hello",
-    ]);
+    await runNamedCronAdd("Isolated task", "--message", "hello");
 
     addCall = callGatewayFromCli.mock.calls.find((call) => call[0] === "cron.add");
     params = addCall?.[2] as { sessionTarget?: string; payload?: { kind?: string } };
@@ -797,40 +771,38 @@ describe("cron cli", () => {
   });
 
   it("includes --account on isolated cron add delivery", async () => {
-    const params = await runCronAddAndGetParams([
-      "--name",
-      "accounted add",
-      "--cron",
-      "* * * * *",
-      "--session",
-      "isolated",
-      "--message",
-      "hello",
-      "--account",
-      "  coordinator  ",
-    ]);
+    const params = await runCronAddAndGetParams(
+      namedCronAddArgs(
+        "accounted add",
+        "--session",
+        "isolated",
+        "--message",
+        "hello",
+        "--account",
+        "  coordinator  ",
+      ),
+    );
     expect(params?.delivery?.mode).toBe("announce");
     expect(params?.delivery?.accountId).toBe("coordinator");
   });
 
   it("includes --thread-id on Telegram cron add delivery", async () => {
-    const params = await runCronAddAndGetParams([
-      "--name",
-      "telegram topic add",
-      "--cron",
-      "* * * * *",
-      "--session",
-      "SESSION:agent:ops:telegram:group:-100123:topic:42",
-      "--message",
-      "hello",
-      "--deliver",
-      "--channel",
-      "telegram",
-      "--to",
-      "-100123",
-      "--thread-id",
-      " 42 ",
-    ]);
+    const params = await runCronAddAndGetParams(
+      namedCronAddArgs(
+        "telegram topic add",
+        "--session",
+        "SESSION:agent:ops:telegram:group:-100123:topic:42",
+        "--message",
+        "hello",
+        "--deliver",
+        "--channel",
+        "telegram",
+        "--to",
+        "-100123",
+        "--thread-id",
+        " 42 ",
+      ),
+    );
 
     expect(params?.sessionTarget).toBe("session:agent:ops:telegram:group:-100123:topic:42");
     expect(params?.delivery?.mode).toBe("announce");
@@ -864,37 +836,22 @@ describe("cron cli", () => {
     );
   });
 
-  it("rejects invalid --thread-id on cron add", async () => {
+  it.each([
+    {
+      name: "rejects invalid --thread-id on cron add",
+      job: "invalid topic add",
+      value: "topic-42",
+    },
+    {
+      name: "rejects negative --thread-id on cron add",
+      job: "invalid negative topic add",
+      value: "-5",
+    },
+  ])("$name", async ({ job, value }) => {
     await expectCronCommandExit([
       "cron",
       "add",
-      "--name",
-      "invalid topic add",
-      "--cron",
-      "* * * * *",
-      "--session",
-      "isolated",
-      "--message",
-      "hello",
-      "--thread-id",
-      "topic-42",
-    ]);
-  });
-
-  it("rejects negative --thread-id on cron add", async () => {
-    await expectCronCommandExit([
-      "cron",
-      "add",
-      "--name",
-      "invalid negative topic add",
-      "--cron",
-      "* * * * *",
-      "--session",
-      "isolated",
-      "--message",
-      "hello",
-      "--thread-id",
-      "-5",
+      ...namedCronAddArgs(job, "--session", "isolated", "--message", "hello", "--thread-id", value),
     ]);
   });
 
@@ -1005,20 +962,15 @@ describe("cron cli", () => {
   });
 
   it("sends agent id on cron add", async () => {
-    await runCronCommand([
-      "cron",
-      "add",
-      "--name",
+    await runNamedCronAdd(
       "Agent pinned",
-      "--cron",
-      "* * * * *",
       "--session",
       "isolated",
       "--message",
       "hi",
       "--agent",
       "ops",
-    ]);
+    );
 
     const addCall = callGatewayFromCli.mock.calls.find((call) => call[0] === "cron.add");
     const params = addCall?.[2] as { agentId?: string };
@@ -1027,33 +979,14 @@ describe("cron cli", () => {
   });
 
   it("warns when --agent is not specified on cron add with --message", async () => {
-    await runCronCommand([
-      "cron",
-      "add",
-      "--name",
-      "No agent",
-      "--cron",
-      "* * * * *",
-      "--message",
-      "hello",
-    ]);
+    await runNamedCronAdd("No agent", "--message", "hello");
 
     expectRuntimeErrorContaining("No --agent specified");
     expectRuntimeErrorContaining("configured default agent");
   });
 
   it("keeps the missing --agent warning off cron add JSON stdout", async () => {
-    await runCronCommand([
-      "cron",
-      "add",
-      "--name",
-      "No agent JSON",
-      "--cron",
-      "* * * * *",
-      "--message",
-      "hello",
-      "--json",
-    ]);
+    await runNamedCronAdd("No agent JSON", "--message", "hello", "--json");
 
     expectRuntimeErrorContaining("No --agent specified");
     const stdout = stdoutText();
@@ -1072,114 +1005,81 @@ describe("cron cli", () => {
   });
 
   it("warns when --agent is blank on cron add with --message", async () => {
-    const params = await runCronAddAndGetParams([
-      "--name",
-      "Blank agent",
-      "--cron",
-      "* * * * *",
-      "--message",
-      "hello",
-      "--agent",
-      "   ",
-    ]);
+    const params = await runCronAddAndGetParams(
+      namedCronAddArgs("Blank agent", "--message", "hello", "--agent", "   "),
+    );
 
     expect(params?.agentId).toBeUndefined();
     expectRuntimeErrorContaining("No --agent specified");
   });
 
   it("does not warn when --system-event is used (no agent needed)", async () => {
-    await runCronCommand([
-      "cron",
-      "add",
-      "--name",
-      "System event",
-      "--cron",
-      "* * * * *",
-      "--system-event",
-      "tick",
-    ]);
+    await runNamedCronAdd("System event", "--system-event", "tick");
 
     expectNoRuntimeErrorContaining("No --agent specified");
   });
 
   it("does not warn when --command is used (no agent needed)", async () => {
-    await runCronCommand([
-      "cron",
-      "add",
-      "--name",
-      "Command",
-      "--cron",
-      "* * * * *",
-      "--command",
-      "printf ok",
-    ]);
+    await runNamedCronAdd("Command", "--command", "printf ok");
 
     expectNoRuntimeErrorContaining("No --agent specified");
   });
 
   it("warns even when --session-key is provided (user should still specify agent explicitly)", async () => {
-    await runCronCommand([
-      "cron",
-      "add",
-      "--name",
+    await runNamedCronAdd(
       "With session key",
-      "--cron",
-      "* * * * *",
       "--message",
       "hello",
       "--session-key",
       "agent:my-agent:my-session",
-    ]);
+    );
 
     expectRuntimeErrorContaining("No --agent specified");
   });
 
   it("sets lightContext on cron add when --light-context is passed", async () => {
-    const params = await runCronAddAndGetParams([
-      "--name",
-      "Light context",
-      "--cron",
-      "* * * * *",
-      "--session",
-      "isolated",
-      "--message",
-      "hello",
-      "--light-context",
-    ]);
+    const params = await runCronAddAndGetParams(
+      namedCronAddArgs(
+        "Light context",
+        "--session",
+        "isolated",
+        "--message",
+        "hello",
+        "--light-context",
+      ),
+    );
 
     expect(params?.payload?.lightContext).toBe(true);
   });
 
   it("splits PowerShell-style space-separated --tools on cron add", async () => {
-    const params = await runCronAddAndGetParams([
-      "--name",
-      "Tools",
-      "--cron",
-      "* * * * *",
-      "--session",
-      "isolated",
-      "--message",
-      "hello",
-      "--tools",
-      "exec read write",
-    ]);
+    const params = await runCronAddAndGetParams(
+      namedCronAddArgs(
+        "Tools",
+        "--session",
+        "isolated",
+        "--message",
+        "hello",
+        "--tools",
+        "exec read write",
+      ),
+    );
 
     expect(params?.payload?.toolsAllow).toEqual(["exec", "read", "write"]);
   });
 
   it("sets fallback models on cron add", async () => {
-    const params = await runCronAddAndGetParams([
-      "--name",
-      "Fallbacks",
-      "--cron",
-      "* * * * *",
-      "--session",
-      "isolated",
-      "--message",
-      "hello",
-      "--fallbacks",
-      "openrouter/gpt-4.1-mini openai/gpt-5",
-    ]);
+    const params = await runCronAddAndGetParams(
+      namedCronAddArgs(
+        "Fallbacks",
+        "--session",
+        "isolated",
+        "--message",
+        "hello",
+        "--fallbacks",
+        "openrouter/gpt-4.1-mini openai/gpt-5",
+      ),
+    );
 
     expect(params?.payload?.fallbacks).toEqual(["openrouter/gpt-4.1-mini", "openai/gpt-5"]);
   });
@@ -1378,12 +1278,11 @@ describe("cron cli", () => {
     expect(patch?.patch?.sessionTarget).toBe("session:Project-Alpha");
   });
 
-  it("rejects invalid --thread-id on cron edit", async () => {
-    await expectCronCommandExit(["cron", "edit", "job-1", "--thread-id", "topic-42"]);
-  });
-
-  it("rejects negative --thread-id on cron edit", async () => {
-    await expectCronCommandExit(["cron", "edit", "job-1", "--thread-id", "-5"]);
+  it.each([
+    { name: "rejects invalid --thread-id on cron edit", value: "topic-42" },
+    { name: "rejects negative --thread-id on cron edit", value: "-5" },
+  ])("$name", async ({ value }) => {
+    await expectCronCommandExit(["cron", "edit", "job-1", "--thread-id", value]);
   });
 
   it("supports --no-deliver on cron edit", async () => {

--- a/src/cli/skills-cli.commands.test.ts
+++ b/src/cli/skills-cli.commands.test.ts
@@ -167,6 +167,29 @@ function expectStatusWorkspaceCall(workspaceDir: string): void {
   expectObjectFields(options, { config: {} });
 }
 
+function primeCalendarInstall(workspaceDir = "/tmp/workspace"): void {
+  installSkillFromClawHubMock.mockResolvedValue({
+    ok: true,
+    slug: "calendar",
+    version: "1.2.3",
+    targetDir: `${workspaceDir}/skills/calendar`,
+  });
+}
+
+function primeCalendarUpdate(workspaceDir = "/tmp/workspace"): void {
+  readTrackedClawHubSkillSlugsMock.mockResolvedValue(["calendar"]);
+  updateSkillsFromClawHubMock.mockResolvedValue([
+    {
+      ok: true,
+      slug: "calendar",
+      previousVersion: "1.2.2",
+      version: "1.2.3",
+      changed: true,
+      targetDir: `${workspaceDir}/skills/calendar`,
+    },
+  ]);
+}
+
 vi.mock("../runtime.js", () => ({
   defaultRuntime: mocks.defaultRuntime,
 }));
@@ -464,12 +487,7 @@ describe("skills cli commands", () => {
   });
 
   it("installs a skill from ClawHub into the active workspace", async () => {
-    installSkillFromClawHubMock.mockResolvedValue({
-      ok: true,
-      slug: "calendar",
-      version: "1.2.3",
-      targetDir: "/tmp/workspace/skills/calendar",
-    });
+    primeCalendarInstall();
 
     await runCommand(["skills", "install", "calendar", "--version", "1.2.3"]);
 
@@ -489,12 +507,7 @@ describe("skills cli commands", () => {
   });
 
   it("passes owner-qualified ClawHub skill refs through to the installer", async () => {
-    installSkillFromClawHubMock.mockResolvedValue({
-      ok: true,
-      slug: "calendar",
-      version: "1.2.3",
-      targetDir: "/tmp/workspace/skills/calendar",
-    });
+    primeCalendarInstall();
 
     await runCommand(["skills", "install", "@demo-owner/calendar"]);
 
@@ -549,41 +562,26 @@ describe("skills cli commands", () => {
     expect(installSkillFromSourceMock).not.toHaveBeenCalled();
   });
 
-  it("documents owner-qualified ClawHub install refs in command help", () => {
-    const skillsCommand = createProgram().commands.find((command) => command.name() === "skills");
-    const installCommand = skillsCommand?.commands.find((command) => command.name() === "install");
-    const output: string[] = [];
+  it.each(["install", "verify"])(
+    "documents owner-qualified ClawHub %s refs in command help",
+    (commandName) => {
+      const skillsCommand = createProgram().commands.find((command) => command.name() === "skills");
+      const command = skillsCommand?.commands.find((entry) => entry.name() === commandName);
+      const output: string[] = [];
 
-    installCommand?.configureOutput({
-      writeOut: (value) => output.push(value),
-      writeErr: (value) => output.push(value),
-    });
-    installCommand?.outputHelp();
-    const help = output.join("");
+      command?.configureOutput({
+        writeOut: (value) => output.push(value),
+        writeErr: (value) => output.push(value),
+      });
+      command?.outputHelp();
+      const help = output.join("");
 
-    expect(help).toContain("<skill-ref>");
-    expect(help).toContain("@owner/slug");
-    expect(help).toContain("openclaw skills install @owner/weather");
-    expect(help).not.toContain("openclaw skills install weather");
-  });
-
-  it("documents owner-qualified ClawHub verify refs in command help", () => {
-    const skillsCommand = createProgram().commands.find((command) => command.name() === "skills");
-    const verifyCommand = skillsCommand?.commands.find((command) => command.name() === "verify");
-    const output: string[] = [];
-
-    verifyCommand?.configureOutput({
-      writeOut: (value) => output.push(value),
-      writeErr: (value) => output.push(value),
-    });
-    verifyCommand?.outputHelp();
-    const help = output.join("");
-
-    expect(help).toContain("<skill-ref>");
-    expect(help).toContain("@owner/slug");
-    expect(help).toContain("openclaw skills verify @owner/weather");
-    expect(help).not.toContain("openclaw skills verify weather");
-  });
+      expect(help).toContain("<skill-ref>");
+      expect(help).toContain("@owner/slug");
+      expect(help).toContain(`openclaw skills ${commandName} @owner/weather`);
+      expect(help).not.toContain(`openclaw skills ${commandName} weather`);
+    },
+  );
 
   it("installs a skill from a git source into the active workspace", async () => {
     installSkillFromSourceMock.mockResolvedValue({
@@ -680,12 +678,7 @@ describe("skills cli commands", () => {
   it("installs a skill into the cwd-inferred agent workspace", async () => {
     routeWorkspaceByAgent();
     resolveAgentIdByWorkspacePathMock.mockReturnValue("writer");
-    installSkillFromClawHubMock.mockResolvedValue({
-      ok: true,
-      slug: "calendar",
-      version: "1.2.3",
-      targetDir: "/tmp/workspace-writer/skills/calendar",
-    });
+    primeCalendarInstall("/tmp/workspace-writer");
 
     await withCwd("/tmp/workspace-writer/project", async () => {
       await runCommand(["skills", "install", "calendar"]);
@@ -703,12 +696,7 @@ describe("skills cli commands", () => {
   it("lets --agent override cwd-inferred workspace for installs", async () => {
     routeWorkspaceByAgent();
     resolveAgentIdByWorkspacePathMock.mockReturnValue("writer");
-    installSkillFromClawHubMock.mockResolvedValue({
-      ok: true,
-      slug: "calendar",
-      version: "1.2.3",
-      targetDir: "/tmp/workspace-main/skills/calendar",
-    });
+    primeCalendarInstall("/tmp/workspace-main");
 
     await withCwd("/tmp/workspace-writer", async () => {
       await runCommand(["skills", "install", "calendar", "--agent", "main"]);
@@ -723,12 +711,7 @@ describe("skills cli commands", () => {
 
   it("honors parent --agent for subcommands", async () => {
     routeWorkspaceByAgent();
-    installSkillFromClawHubMock.mockResolvedValue({
-      ok: true,
-      slug: "calendar",
-      version: "1.2.3",
-      targetDir: "/tmp/workspace-writer/skills/calendar",
-    });
+    primeCalendarInstall("/tmp/workspace-writer");
 
     await runCommand(["skills", "--agent", "writer", "install", "calendar"]);
 
@@ -739,12 +722,7 @@ describe("skills cli commands", () => {
   });
 
   it("installs a skill into the shared global skills directory", async () => {
-    installSkillFromClawHubMock.mockResolvedValue({
-      ok: true,
-      slug: "calendar",
-      version: "1.2.3",
-      targetDir: "/tmp/openclaw-config/skills/calendar",
-    });
+    primeCalendarInstall("/tmp/openclaw-config");
 
     await runCommand(["skills", "install", "calendar", "--global"]);
 
@@ -758,40 +736,19 @@ describe("skills cli commands", () => {
     );
   });
 
-  it("passes --force-install through for ClawHub skill installs", async () => {
-    installSkillFromClawHubMock.mockResolvedValue({
-      ok: true,
-      slug: "calendar",
-      version: "1.2.3",
-      targetDir: "/tmp/workspace/skills/calendar",
-    });
+  it.each([
+    { flag: "--force-install", option: "forceInstall" },
+    { flag: "--acknowledge-clawhub-risk", option: "acknowledgeClawHubRisk" },
+  ])("passes $flag through for ClawHub skill installs", async ({ flag, option }) => {
+    primeCalendarInstall();
 
-    await runCommand(["skills", "install", "calendar", "--force-install"]);
+    await runCommand(["skills", "install", "calendar", flag]);
 
     expect(installSkillFromClawHubMock).toHaveBeenCalledWith(
       expect.objectContaining({
         workspaceDir: "/tmp/workspace",
         slug: "calendar",
-        forceInstall: true,
-      }),
-    );
-  });
-
-  it("passes --acknowledge-clawhub-risk through for ClawHub skill installs", async () => {
-    installSkillFromClawHubMock.mockResolvedValue({
-      ok: true,
-      slug: "calendar",
-      version: "1.2.3",
-      targetDir: "/tmp/workspace/skills/calendar",
-    });
-
-    await runCommand(["skills", "install", "calendar", "--acknowledge-clawhub-risk"]);
-
-    expect(installSkillFromClawHubMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        workspaceDir: "/tmp/workspace",
-        slug: "calendar",
-        acknowledgeClawHubRisk: true,
+        [option]: true,
       }),
     );
   });
@@ -827,36 +784,23 @@ describe("skills cli commands", () => {
     );
   });
 
-  it("rejects using --global and --agent together for installs", async () => {
-    await expect(
-      runCommand(["skills", "install", "calendar", "--global", "--agent", "main"]),
-    ).rejects.toThrow("__exit__:1");
-
-    expect(runtimeErrors).toContain("Use either --global or --agent, not both.");
-    expect(installSkillFromClawHubMock).not.toHaveBeenCalled();
-  });
-
-  it("rejects using parent --agent with install --global", async () => {
-    await expect(
-      runCommand(["skills", "--agent", "writer", "install", "calendar", "--global"]),
-    ).rejects.toThrow("__exit__:1");
-
+  it.each([
+    {
+      name: "rejects using --global and --agent together for installs",
+      args: ["skills", "install", "calendar", "--global", "--agent", "main"],
+    },
+    {
+      name: "rejects using parent --agent with install --global",
+      args: ["skills", "--agent", "writer", "install", "calendar", "--global"],
+    },
+  ])("$name", async ({ args }) => {
+    await expect(runCommand(args)).rejects.toThrow("__exit__:1");
     expect(runtimeErrors).toContain("Use either --global or --agent, not both.");
     expect(installSkillFromClawHubMock).not.toHaveBeenCalled();
   });
 
   it("updates all tracked ClawHub skills", async () => {
-    readTrackedClawHubSkillSlugsMock.mockResolvedValue(["calendar"]);
-    updateSkillsFromClawHubMock.mockResolvedValue([
-      {
-        ok: true,
-        slug: "calendar",
-        previousVersion: "1.2.2",
-        version: "1.2.3",
-        changed: true,
-        targetDir: "/tmp/workspace/skills/calendar",
-      },
-    ]);
+    primeCalendarUpdate();
 
     await runCommand(["skills", "update", "--all"]);
 
@@ -893,49 +837,19 @@ describe("skills cli commands", () => {
     expect(runtimeErrors).toStrictEqual([]);
   });
 
-  it("passes --force-install through for ClawHub skill updates", async () => {
-    readTrackedClawHubSkillSlugsMock.mockResolvedValue(["calendar"]);
-    updateSkillsFromClawHubMock.mockResolvedValue([
-      {
-        ok: true,
-        slug: "calendar",
-        previousVersion: "1.2.2",
-        version: "1.2.3",
-        changed: true,
-        targetDir: "/tmp/workspace/skills/calendar",
-      },
-    ]);
+  it.each([
+    { flag: "--force-install", option: "forceInstall" },
+    { flag: "--acknowledge-clawhub-risk", option: "acknowledgeClawHubRisk" },
+  ])("passes $flag through for ClawHub skill updates", async ({ flag, option }) => {
+    primeCalendarUpdate();
 
-    await runCommand(["skills", "update", "--all", "--force-install"]);
+    await runCommand(["skills", "update", "--all", flag]);
 
     expect(updateSkillsFromClawHubMock).toHaveBeenCalledWith(
       expect.objectContaining({
         workspaceDir: "/tmp/workspace",
-        slug: undefined,
-        forceInstall: true,
-      }),
-    );
-  });
-
-  it("passes --acknowledge-clawhub-risk through for ClawHub skill updates", async () => {
-    readTrackedClawHubSkillSlugsMock.mockResolvedValue(["calendar"]);
-    updateSkillsFromClawHubMock.mockResolvedValue([
-      {
-        ok: true,
-        slug: "calendar",
-        previousVersion: "1.2.2",
-        version: "1.2.3",
-        changed: true,
-        targetDir: "/tmp/workspace/skills/calendar",
-      },
-    ]);
-
-    await runCommand(["skills", "update", "--all", "--acknowledge-clawhub-risk"]);
-
-    expect(updateSkillsFromClawHubMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        workspaceDir: "/tmp/workspace",
-        acknowledgeClawHubRisk: true,
+        ...(option === "forceInstall" ? { slug: undefined } : {}),
+        [option]: true,
       }),
     );
   });
@@ -962,17 +876,7 @@ describe("skills cli commands", () => {
   it("updates tracked ClawHub skills in the cwd-inferred agent workspace", async () => {
     routeWorkspaceByAgent();
     resolveAgentIdByWorkspacePathMock.mockReturnValue("writer");
-    readTrackedClawHubSkillSlugsMock.mockResolvedValue(["calendar"]);
-    updateSkillsFromClawHubMock.mockResolvedValue([
-      {
-        ok: true,
-        slug: "calendar",
-        previousVersion: "1.2.2",
-        version: "1.2.3",
-        changed: true,
-        targetDir: "/tmp/workspace-writer/skills/calendar",
-      },
-    ]);
+    primeCalendarUpdate("/tmp/workspace-writer");
 
     await withCwd("/tmp/workspace-writer", async () => {
       await runCommand(["skills", "update", "--all"]);
@@ -990,17 +894,7 @@ describe("skills cli commands", () => {
   it("lets --agent override cwd-inferred workspace for updates", async () => {
     routeWorkspaceByAgent();
     resolveAgentIdByWorkspacePathMock.mockReturnValue("writer");
-    readTrackedClawHubSkillSlugsMock.mockResolvedValue(["calendar"]);
-    updateSkillsFromClawHubMock.mockResolvedValue([
-      {
-        ok: true,
-        slug: "calendar",
-        previousVersion: "1.2.2",
-        version: "1.2.3",
-        changed: true,
-        targetDir: "/tmp/workspace-main/skills/calendar",
-      },
-    ]);
+    primeCalendarUpdate("/tmp/workspace-main");
 
     await withCwd("/tmp/workspace-writer", async () => {
       await runCommand(["skills", "update", "calendar", "--agent", "main"]);
@@ -1015,47 +909,21 @@ describe("skills cli commands", () => {
     expectLogger(updateOverrideArgs.logger);
   });
 
-  it("updates tracked ClawHub skills in the shared global skills directory", async () => {
-    readTrackedClawHubSkillSlugsMock.mockResolvedValue(["calendar"]);
-    updateSkillsFromClawHubMock.mockResolvedValue([
-      {
-        ok: true,
-        slug: "calendar",
-        previousVersion: "1.2.2",
-        version: "1.2.3",
-        changed: true,
-        targetDir: "/tmp/openclaw-config/skills/calendar",
-      },
-    ]);
-
-    await runCommand(["skills", "update", "--all", "--global"]);
-
-    expect(resolveAgentIdByWorkspacePathMock).not.toHaveBeenCalled();
-    expect(resolveDefaultAgentIdMock).not.toHaveBeenCalled();
-    expect(resolveAgentWorkspaceDirMock).not.toHaveBeenCalled();
-    expect(readTrackedClawHubSkillSlugsMock).toHaveBeenCalledWith("/tmp/openclaw-config");
-    expect(updateSkillsFromClawHubMock).toHaveBeenCalledWith({
-      workspaceDir: "/tmp/openclaw-config",
+  it.each([
+    {
+      name: "updates tracked ClawHub skills in the shared global skills directory",
+      selection: "--all",
       slug: undefined,
-      logger: expect.any(Object),
-      config: {},
-    });
-  });
+    },
+    {
+      name: "updates a single tracked ClawHub skill in the shared global skills directory",
+      selection: "calendar",
+      slug: "calendar",
+    },
+  ])("$name", async ({ selection, slug }) => {
+    primeCalendarUpdate("/tmp/openclaw-config");
 
-  it("updates a single tracked ClawHub skill in the shared global skills directory", async () => {
-    readTrackedClawHubSkillSlugsMock.mockResolvedValue(["calendar"]);
-    updateSkillsFromClawHubMock.mockResolvedValue([
-      {
-        ok: true,
-        slug: "calendar",
-        previousVersion: "1.2.2",
-        version: "1.2.3",
-        changed: true,
-        targetDir: "/tmp/openclaw-config/skills/calendar",
-      },
-    ]);
-
-    await runCommand(["skills", "update", "calendar", "--global"]);
+    await runCommand(["skills", "update", selection, "--global"]);
 
     expect(resolveAgentIdByWorkspacePathMock).not.toHaveBeenCalled();
     expect(resolveDefaultAgentIdMock).not.toHaveBeenCalled();
@@ -1063,7 +931,7 @@ describe("skills cli commands", () => {
     expect(readTrackedClawHubSkillSlugsMock).toHaveBeenCalledWith("/tmp/openclaw-config");
     expect(updateSkillsFromClawHubMock).toHaveBeenCalledWith({
       workspaceDir: "/tmp/openclaw-config",
-      slug: "calendar",
+      slug,
       logger: expect.any(Object),
       config: {},
     });
@@ -1084,21 +952,17 @@ describe("skills cli commands", () => {
     expect(runtimeLogs).toStrictEqual([]);
   });
 
-  it("rejects using --global and --agent together for updates", async () => {
-    await expect(
-      runCommand(["skills", "update", "--all", "--global", "--agent", "main"]),
-    ).rejects.toThrow("__exit__:1");
-
-    expect(runtimeErrors).toContain("Use either --global or --agent, not both.");
-    expect(readTrackedClawHubSkillSlugsMock).not.toHaveBeenCalled();
-    expect(updateSkillsFromClawHubMock).not.toHaveBeenCalled();
-  });
-
-  it("rejects using parent --agent with update --global", async () => {
-    await expect(
-      runCommand(["skills", "--agent", "writer", "update", "--all", "--global"]),
-    ).rejects.toThrow("__exit__:1");
-
+  it.each([
+    {
+      name: "rejects using --global and --agent together for updates",
+      args: ["skills", "update", "--all", "--global", "--agent", "main"],
+    },
+    {
+      name: "rejects using parent --agent with update --global",
+      args: ["skills", "--agent", "writer", "update", "--all", "--global"],
+    },
+  ])("$name", async ({ args }) => {
+    await expect(runCommand(args)).rejects.toThrow("__exit__:1");
     expect(runtimeErrors).toContain("Use either --global or --agent, not both.");
     expect(readTrackedClawHubSkillSlugsMock).not.toHaveBeenCalled();
     expect(updateSkillsFromClawHubMock).not.toHaveBeenCalled();


### PR DESCRIPTION
## What Problem This Solves

The capability, configuration, cron, and skills CLI regression suites repeatedly register the same commands, recreate identical media and ClawHub fixtures, restate scheduled-command arguments, and copy configuration security and secret-provider setup. This makes fail-closed security cases harder to audit and needlessly increases test maintenance.

## Why This Change Was Made

This maintainer-requested, AI-assisted consolidation provides one exact-argument capability command runner, canonical image/video and skill fixtures, shared gateway configuration snapshots, and reusable named cron arguments. It preserves every separately executed prototype-pollution rejection, invalid index, providerless capability, ClawHub risk acknowledgement, invalid cron thread, and Codex app-server fail-closed case. It changes only tests: no production code, CLI arguments, configuration, public behavior, snapshots, or coverage exclusions.

The Codex dependency contract was personally verified directly against the sibling upstream checkout before refactoring its capability test: `codex-rs/app-server/README.md:69`, `codex-rs/app-server-protocol/src/protocol/common.rs:491`, `codex-rs/app-server-protocol/src/protocol/common.rs:831`, `codex-rs/app-server-protocol/src/protocol/v2/thread.rs:56`, `codex-rs/app-server-protocol/src/protocol/v2/turn.rs:71`, `codex-rs/core/src/client.rs:559`, and `codex-rs/core/src/client_common.rs:13`. The existing local Codex simple-completion rejection and all of its no-dispatch assertions remain intact.

## User Impact

No user-visible behavior changes. Contributors and maintainers get smaller and more auditable command, secret-resolution, provider-dispatch, scheduling, and skill-install regression suites.

## Evidence

- Frozen comparison base: `16d2b7e46784c75eb5d57329269e9fd47222d2ef`.
- Test-only reduction: four files, **+968/-1782; 814 fewer lines**.
- Frozen Linux V8 baseline was measured independently for all three config/cron/skills modules and for the capability entry point plus all nested capability production modules; inherited CLI coverage exclusions were explicitly replaced, rather than accepting a 0/0 report.
- Combined before/after regression cases: **434 passed before; 434 passed after**.
- Exact matched V8 lines: **846/1241 before and after**.
- Exact matched V8 branches: **574/852 before and after**.
- Exact matched V8 statements: **854/1255 before and after**.
- Exact matched V8 functions: **173/270 before and after**.
- Config regression suite runtime on the same Testbox: **20.469 s before; 6.622 s after**.
- Remote Linux proof: Blacksmith Testbox `tbx_01kyh0etacraccjsnx5gjhbc42`.
- Remote changed gate: `corepack pnpm check:changed`, including formatting, boundary/ratchet guards, core-test typechecking, and changed-file lint.
- Fresh independent review: `.agents/skills/autoreview/scripts/autoreview --mode uncommitted`.
- AI-assisted work; no private conversation or agent transcript included.
