### PR TITLE
fix: honor outbound hooks in Control UI chat replies

### DIFF
--- a/src/auto-reply/dispatch.test.ts
+++ b/src/auto-reply/dispatch.test.ts
@@ -79,6 +79,7 @@ const {
   dispatchInboundMessage,
   dispatchInboundMessageWithDispatcher,
   dispatchInboundMessageWithBufferedDispatcher,
+  dispatchInboundMessageWithProjectedDispatcher,
   withReplyDispatcher,
 } = await import("./dispatch.js");
 const { recordReplyUsageState } = await import("./reply/reply-usage-state.js");
@@ -114,6 +115,24 @@ function requireReplyDispatcherOptions(index = 0): Parameters<CreateReplyDispatc
     throw new Error(`expected createReplyDispatcher call ${index}`);
   }
   return call[0] as Parameters<CreateReplyDispatcherFn>[0];
+}
+
+async function installProjectedBeforeDeliver(
+  overrides: Partial<Parameters<typeof dispatchInboundMessageWithProjectedDispatcher>[0]> = {},
+): Promise<ReplyDispatchBeforeDeliver> {
+  hoisted.createReplyDispatcherMock.mockReturnValueOnce(createDispatcher([]));
+  hoisted.dispatchReplyFromConfigMock.mockResolvedValueOnce({ text: "ok" });
+  await dispatchInboundMessageWithProjectedDispatcher({
+    ctx: buildTestCtx({ Surface: "webchat", SessionKey: "agent:test:main" }),
+    cfg: {} as OpenClawConfig,
+    dispatcherOptions: { deliver: async () => undefined },
+    ...overrides,
+  });
+  const beforeDeliver = requireReplyDispatcherOptions().beforeDeliver;
+  if (!beforeDeliver) {
+    throw new Error("expected projected beforeDeliver hook");
+  }
+  return beforeDeliver;
 }
 
 describe("withReplyDispatcher", () => {
@@ -573,6 +592,156 @@ describe("withReplyDispatcher", () => {
     );
   });
 
+  it("runs media-aware projected modifiers once in order", async () => {
+    const order: string[] = [];
+    const runReplyPayloadSending = vi.fn(async ({ payload }: { payload: { text?: string } }) => {
+      order.push("reply_payload_sending");
+      return {
+        payload: {
+          ...payload,
+          text: "reply rewrite",
+          mediaUrls: ["media://reply.png"],
+        },
+      };
+    });
+    const runMessageSending = vi.fn(async () => {
+      order.push("message_sending");
+      return { content: "message rewrite" };
+    });
+    hoisted.deriveInboundMessageHookContextMock.mockReturnValue({
+      channelId: "webchat",
+      accountId: "acct-web",
+      conversationId: "main",
+      isGroup: false,
+      from: "main",
+    });
+    hoisted.getGlobalHookRunnerMock.mockReturnValue({
+      hasHooks: vi.fn(
+        (hookName?: string) =>
+          hookName === "reply_payload_sending" || hookName === "message_sending",
+      ),
+      runMessageSending,
+      runReplyPayloadSending,
+    });
+    const onSessionMetadataChanges = vi.fn();
+    const beforeDeliver = await installProjectedBeforeDeliver({
+      ctx: buildTestCtx({
+        Surface: "webchat",
+        SessionKey: "agent:test:main",
+        OriginatingTo: "main",
+      }),
+      cfg: {} as OpenClawConfig,
+      dispatcherOptions: { deliver: async () => undefined },
+      onSessionMetadataChanges,
+      replyOptions: { runId: "run-web" },
+      replyResolver: async () => ({ text: "ok" }),
+    });
+    const payload = await beforeDeliver(
+      setReplyPayloadMetadata({ text: "original" }, { assistantMessageIndex: 7 }),
+      { kind: "final" },
+    );
+
+    expect(order).toEqual(["reply_payload_sending", "message_sending"]);
+    expect(runReplyPayloadSending).toHaveBeenCalledOnce();
+    expect(runMessageSending).toHaveBeenCalledOnce();
+    expect(runMessageSending).toHaveBeenCalledWith(
+      {
+        to: "main",
+        content: "reply rewrite",
+        replyToId: undefined,
+        threadId: undefined,
+        metadata: {
+          channel: "webchat",
+          accountId: "acct-web",
+          mediaUrls: ["media://reply.png"],
+        },
+      },
+      {
+        channelId: "webchat",
+        accountId: "acct-web",
+        conversationId: "main",
+        sessionKey: "agent:test:main",
+      },
+    );
+    expect(payload).toEqual({
+      text: "message rewrite",
+      mediaUrls: ["media://reply.png"],
+    });
+    expect(payload ? getReplyPayloadMetadata(payload) : undefined).toEqual({
+      assistantMessageIndex: 7,
+    });
+    expect(hoisted.dispatchReplyFromConfigMock.mock.calls[0]?.[0]?.onSessionMetadataChanges).toBe(
+      onSessionMetadataChanges,
+    );
+  });
+
+  it("cancels media-only projected payloads before delivery", async () => {
+    const runMessageSending = vi.fn(async () => ({ cancel: true }));
+    hoisted.deriveInboundMessageHookContextMock.mockReturnValue({
+      channelId: "webchat",
+      conversationId: "main",
+      isGroup: false,
+      from: "main",
+    });
+    hoisted.getGlobalHookRunnerMock.mockReturnValue({
+      hasHooks: vi.fn(
+        (hookName?: string) =>
+          hookName === "reply_payload_sending" || hookName === "message_sending",
+      ),
+      runMessageSending,
+      runReplyPayloadSending: vi.fn(async ({ payload }: { payload: { text?: string } }) => ({
+        payload: { ...payload, text: undefined, mediaUrls: ["media://only.png"] },
+      })),
+    });
+    const beforeDeliver = await installProjectedBeforeDeliver();
+    await expect(beforeDeliver({ text: "original" }, { kind: "final" })).resolves.toBeNull();
+    expect(runMessageSending).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: "",
+        metadata: expect.objectContaining({ mediaUrls: ["media://only.png"] }),
+      }),
+      expect.anything(),
+    );
+  });
+
+  it("keeps projected delivery best-effort when message hooks fail", async () => {
+    const runMessageSending = vi.fn(async () => {
+      throw new Error("hook failed");
+    });
+    hoisted.getGlobalHookRunnerMock.mockReturnValue({
+      hasHooks: vi.fn((hookName?: string) => hookName === "message_sending"),
+      runMessageSending,
+      runReplyPayloadSending: vi.fn(async () => undefined),
+    });
+    const beforeDeliver = await installProjectedBeforeDeliver();
+    await expect(beforeDeliver({ text: "original" }, { kind: "block" })).resolves.toEqual({
+      text: "original",
+    });
+    expect(runMessageSending).toHaveBeenCalledOnce();
+  });
+
+  it("suppresses projected payloads emptied by message hooks", async () => {
+    hoisted.getGlobalHookRunnerMock.mockReturnValue({
+      hasHooks: vi.fn((hookName?: string) => hookName === "message_sending"),
+      runMessageSending: vi.fn(async () => ({ content: "  " })),
+      runReplyPayloadSending: vi.fn(async () => undefined),
+    });
+    const beforeDeliver = await installProjectedBeforeDeliver();
+    await expect(beforeDeliver({ text: "original" }, { kind: "final" })).resolves.toBeNull();
+  });
+
+  it("stops projected delivery before message hooks when reply hooks cancel", async () => {
+    const runMessageSending = vi.fn(async () => ({ content: "unreachable" }));
+    hoisted.getGlobalHookRunnerMock.mockReturnValue({
+      hasHooks: vi.fn(() => true),
+      runMessageSending,
+      runReplyPayloadSending: vi.fn(async () => ({ cancel: true })),
+    });
+    const beforeDeliver = await installProjectedBeforeDeliver();
+    await expect(beforeDeliver({ text: "original" }, { kind: "final" })).resolves.toBeNull();
+    expect(runMessageSending).not.toHaveBeenCalled();
+  });
+
   it("suppresses inbound dispatcher delivery when reply_payload_sending empties the payload", async () => {
     const runReplyPayloadSending = vi.fn(async ({ payload }: { payload: { text?: string } }) => ({
       payload: {
@@ -580,9 +749,13 @@ describe("withReplyDispatcher", () => {
         text: "",
       },
     }));
+    const runMessageSending = vi.fn(async () => ({ content: "must not run" }));
     hoisted.getGlobalHookRunnerMock.mockReturnValue({
-      hasHooks: vi.fn((hookName?: string) => hookName === "reply_payload_sending"),
-      runMessageSending: vi.fn(async () => undefined),
+      hasHooks: vi.fn(
+        (hookName?: string) =>
+          hookName === "reply_payload_sending" || hookName === "message_sending",
+      ),
+      runMessageSending,
       runReplyPayloadSending,
     });
     hoisted.createReplyDispatcherMock.mockReturnValueOnce(createDispatcher([]));
@@ -608,6 +781,7 @@ describe("withReplyDispatcher", () => {
     );
 
     expect(payload).toBeNull();
+    expect(runMessageSending).not.toHaveBeenCalled();
   });
 
   it("installs reply_payload_sending hooks on prebuilt dispatchers", async () => {

--- a/src/auto-reply/dispatch.ts
+++ b/src/auto-reply/dispatch.ts
@@ -10,6 +10,7 @@ import {
 import {
   buildInboundReplyPayloadSendingBeforeDeliver,
   buildLegacyInboundMessageSendingBeforeDeliver,
+  buildProjectedInboundMessageSendingBeforeDeliver,
   type ReplyPayloadSuppressedObserver,
 } from "../infra/outbound/deliver-hooks.js";
 import { isOutboundDeliveryError } from "../infra/outbound/deliver-types.js";
@@ -669,15 +670,20 @@ export async function dispatchInboundMessageWithRoutedChannelDispatcher(
   });
 }
 
-/** Creates a plain dispatcher, installs global send hooks, and dispatches the inbound message. */
-export async function dispatchInboundMessageWithDispatcher(params: {
+type PlainInboundDispatcherParams = {
   ctx: MsgContext | FinalizedMsgContext;
   cfg: OpenClawConfig;
   dispatcherOptions: ReplyDispatcherOptions;
   toolsAllow?: string[];
   replyOptions?: InternalDispatchReplyOptions;
   replyResolver?: InternalGetReplyFromConfig;
-}): Promise<DispatchInboundResult> {
+  onSessionMetadataChanges?: (changes: CommandSessionMetadataChange[]) => void;
+};
+
+async function dispatchInboundMessageWithPlainDispatcherCore(
+  params: PlainInboundDispatcherParams,
+  messageSending: "legacy" | "projected",
+): Promise<DispatchInboundResult> {
   const silentReplyContext = resolveDispatcherSilentReplyContext(params.ctx, params.cfg);
   const replyPayloadRunState = {
     runId: params.replyOptions?.runId,
@@ -686,9 +692,13 @@ export async function dispatchInboundMessageWithDispatcher(params: {
     params.ctx,
     replyPayloadRunState,
   );
+  const messageSendingBeforeDeliver =
+    messageSending === "projected"
+      ? buildProjectedInboundMessageSendingBeforeDeliver(params.ctx)
+      : buildLegacyInboundMessageSendingBeforeDeliver(params.ctx);
   const globalBeforeDeliver = composeReplyDispatchBeforeDeliver(
     replyPayloadBeforeDeliver,
-    buildLegacyInboundMessageSendingBeforeDeliver(params.ctx),
+    messageSendingBeforeDeliver,
   );
   const composedBeforeDeliver = params.dispatcherOptions.beforeDeliver
     ? composeReplyDispatchBeforeDeliver(
@@ -713,5 +723,33 @@ export async function dispatchInboundMessageWithDispatcher(params: {
     replyResolver: params.replyResolver,
     replyOptions: params.replyOptions,
     replyPayloadRunState,
+    onSessionMetadataChanges: params.onSessionMetadataChanges,
   });
+}
+
+/** Creates a plain dispatcher, installs global send hooks, and dispatches the inbound message. */
+export async function dispatchInboundMessageWithDispatcher(params: {
+  ctx: MsgContext | FinalizedMsgContext;
+  cfg: OpenClawConfig;
+  dispatcherOptions: ReplyDispatcherOptions;
+  toolsAllow?: string[];
+  replyOptions?: InternalDispatchReplyOptions;
+  replyResolver?: InternalGetReplyFromConfig;
+}): Promise<DispatchInboundResult> {
+  return await dispatchInboundMessageWithPlainDispatcherCore(params, "legacy");
+}
+
+type ProjectedOptions = Omit<ReplyDispatcherOptions, "beforeDeliver" | "beforeDeliverOptions">;
+
+/** Creates a core-owned dispatcher whose modifiers fence projected output capture. */
+export async function dispatchInboundMessageWithProjectedDispatcher(params: {
+  ctx: MsgContext | FinalizedMsgContext;
+  cfg: OpenClawConfig;
+  dispatcherOptions: ProjectedOptions;
+  toolsAllow?: string[];
+  replyOptions?: InternalDispatchReplyOptions;
+  replyResolver?: InternalGetReplyFromConfig;
+  onSessionMetadataChanges?: (changes: CommandSessionMetadataChange[]) => void;
+}): Promise<DispatchInboundResult> {
+  return await dispatchInboundMessageWithPlainDispatcherCore(params, "projected");
 }

--- a/src/gateway/server-methods/chat-send-handler.ts
+++ b/src/gateway/server-methods/chat-send-handler.ts
@@ -8,7 +8,7 @@ import { ErrorCodes, errorShape } from "../../../packages/gateway-protocol/src/i
 import { resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import { resolveProviderIdForAuth } from "../../agents/provider-auth-aliases.js";
 import { createAgentRunRestartAbortError } from "../../agents/run-termination.js";
-import { dispatchInboundMessage } from "../../auto-reply/dispatch.js";
+import { dispatchInboundMessageWithProjectedDispatcher } from "../../auto-reply/dispatch.js";
 import {
   clearAgentRunContext,
   getAgentEventLifecycleGeneration,
@@ -333,7 +333,7 @@ export const handleChatSend: GatewayRequestHandlers["chat.send"] = async ({
       : undefined;
 
     let agentRunStarted = false;
-    const { deliveredReplies, dispatcher, hasAppendedWebchatAgentMedia, onModelSelected } =
+    const { deliveredReplies, dispatcherOptions, hasAppendedWebchatAgentMedia, onModelSelected } =
       createChatSendReplyDispatch({
         accountId,
         isAgentRunStarted: () => agentRunStarted,
@@ -397,10 +397,10 @@ export const handleChatSend: GatewayRequestHandlers["chat.send"] = async ({
             if (replyContextFieldsPromise) {
               applyChatSendReplyContextFields(ctx, await replyContextFieldsPromise);
             }
-            const dispatchResult = await dispatchInboundMessage({
+            const dispatchResult = await dispatchInboundMessageWithProjectedDispatcher({
               ctx,
               cfg,
-              dispatcher,
+              dispatcherOptions,
               onSessionMetadataChanges: (changes) => {
                 for (const change of changes) {
                   emitSessionsChanged(context, change);

--- a/src/gateway/server-methods/chat-send-reply-dispatch.test.ts
+++ b/src/gateway/server-methods/chat-send-reply-dispatch.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { setReplyPayloadMetadata } from "../../auto-reply/reply-payload.js";
+import { createReplyDispatcher } from "../../auto-reply/reply/reply-dispatcher.js";
 import {
   buildTranscriptReplyText,
   createChatSendReplyDispatch,
@@ -59,13 +60,15 @@ describe("createChatSendReplyDispatch", () => {
       { beforeAgentRunBlocked: true },
     );
 
-    dispatch.dispatcher.sendBlockReply(blockedPayload);
-    dispatch.dispatcher.sendToolResult({
+    const dispatcher = createReplyDispatcher(dispatch.dispatcherOptions);
+    dispatcher.sendBlockReply(blockedPayload);
+    dispatcher.sendToolResult({
       text: "tool summary",
       mediaUrl: "https://example.test/audio.mp3",
     });
-    dispatch.dispatcher.sendFinalReply({ text: "done" });
-    await dispatch.dispatcher.waitForIdle();
+    dispatcher.sendFinalReply({ text: "done" });
+    dispatcher.markComplete();
+    await dispatcher.waitForIdle();
 
     expect(markBlocked).toHaveBeenCalledOnce();
     expect(dispatch.deliveredReplies).toEqual([
@@ -79,5 +82,40 @@ describe("createChatSendReplyDispatch", () => {
       },
       { payload: { text: "done" }, kind: "final" },
     ]);
+  });
+
+  it("keeps every capture and media side effect behind beforeDeliver cancellation", async () => {
+    const markBlocked = vi.fn();
+    const dispatch = createChatSendReplyDispatch({
+      accountId: undefined,
+      isAgentRunStarted: () => true,
+      logGateway: { warn: vi.fn() } as never,
+      session: {
+        agentId: "main",
+        backingSessionId: undefined,
+        cfg: {},
+        clientRunId: "run-cancel",
+        sessionKey: "agent:main:main",
+        sessionLoadOptions: undefined,
+      },
+      userTurnRecorder: { markBlocked },
+    });
+    const dispatcher = createReplyDispatcher({
+      ...dispatch.dispatcherOptions,
+      beforeDeliver: async () => null,
+    });
+
+    dispatcher.sendBlockReply(
+      setReplyPayloadMetadata({ text: "blocked" }, { beforeAgentRunBlocked: true }),
+    );
+    dispatcher.sendToolResult({ mediaUrl: "https://example.test/tool.png" });
+    dispatcher.sendFinalReply({ mediaUrl: "https://example.test/final.png" });
+    dispatcher.markComplete();
+    await dispatcher.waitForIdle();
+
+    expect(dispatch.deliveredReplies).toEqual([]);
+    expect(dispatch.hasAppendedWebchatAgentMedia()).toBe(false);
+    expect(markBlocked).not.toHaveBeenCalled();
+    expect(dispatcher.getCancelledCounts?.()).toEqual({ tool: 1, block: 1, final: 1 });
   });
 });

--- a/src/gateway/server-methods/chat-send-reply-dispatch.ts
+++ b/src/gateway/server-methods/chat-send-reply-dispatch.ts
@@ -1,7 +1,7 @@
 import { isAudioFileName } from "@openclaw/media-core/mime";
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
 import { getReplyPayloadMetadata, type ReplyPayload } from "../../auto-reply/reply-payload.js";
-import { createReplyDispatcher } from "../../auto-reply/reply/reply-dispatcher.js";
+import type { ReplyDispatcherOptions } from "../../auto-reply/reply/reply-dispatcher.js";
 import {
   appendLocalMediaParentRoots,
   getAgentScopedMediaLocalRoots,
@@ -92,7 +92,7 @@ export function buildTranscriptReplyText(payloads: ReplyPayload[]): string {
   return chunks.join("\n\n").trim();
 }
 
-/** Build the live reply dispatcher and capture payloads for post-dispatch projection. */
+/** Build delivery options and capture state for the core-owned webchat dispatcher. */
 export function createChatSendReplyDispatch(params: {
   accountId: string | undefined;
   isAgentRunStarted: () => boolean;
@@ -240,7 +240,7 @@ export function createChatSendReplyDispatch(params: {
       `webchat transcript append failed for media reply: ${appended.error ?? "unknown error"}`,
     );
   };
-  const dispatcher = createReplyDispatcher({
+  const dispatcherOptions: ReplyDispatcherOptions = {
     ...replyPipeline,
     onError: (err) => {
       logGateway.warn(`webchat dispatch failed: ${formatForLog(err)}`);
@@ -270,10 +270,10 @@ export function createChatSendReplyDispatch(params: {
           break;
       }
     },
-  });
+  };
   return {
     deliveredReplies,
-    dispatcher,
+    dispatcherOptions,
     hasAppendedWebchatAgentMedia: () => appendedWebchatAgentMedia,
     onModelSelected,
   };

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -36,6 +36,10 @@ import { normalizeSessionDeliveryState } from "../../utils/delivery-context.shar
 import { createChatRunState } from "../server-chat-state.js";
 import type { GatewayRequestContext } from "./types.js";
 
+type ProjectedDispatchParams = Parameters<
+  typeof import("../../auto-reply/dispatch.js").dispatchInboundMessageWithProjectedDispatcher
+>[0];
+
 const mockState = vi.hoisted(() => ({
   config: {} as Record<string, unknown>,
   transcriptPath: "",
@@ -207,8 +211,28 @@ vi.mock("../session-utils.js", async () => {
   };
 });
 
-vi.mock("../../auto-reply/dispatch.js", () => ({
-  dispatchInboundMessage: vi.fn(
+const dispatchInboundMessageMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../auto-reply/dispatch.js", async () => {
+  const { createReplyDispatcher } = await vi.importActual<
+    typeof import("../../auto-reply/reply/reply-dispatcher.js")
+  >("../../auto-reply/reply/reply-dispatcher.js");
+  return {
+    dispatchInboundMessage: dispatchInboundMessageMock,
+    dispatchInboundMessageWithProjectedDispatcher: vi.fn(
+      async (params: ProjectedDispatchParams) => {
+        const { dispatcherOptions, ...dispatchParams } = params;
+        return await dispatchInboundMessageMock({
+          ...dispatchParams,
+          dispatcher: createReplyDispatcher(dispatcherOptions),
+        });
+      },
+    ),
+  };
+});
+
+dispatchInboundMessageMock.mockImplementation(
+  vi.fn(
     async (params: {
       ctx: MsgContext;
       dispatcher: {
@@ -337,7 +361,7 @@ vi.mock("../../auto-reply/dispatch.js", () => ({
       };
     },
   ),
-}));
+);
 
 vi.mock("../../infra/outbound/session-binding-service.js", async () => {
   const actual = await vi.importActual<

--- a/src/gateway/test-helpers.mocks.ts
+++ b/src/gateway/test-helpers.mocks.ts
@@ -2,6 +2,7 @@
 // Centralizes Vitest mock wiring for agent, channel, plugin, and runtime seams.
 import path from "node:path";
 import { vi } from "vitest";
+import { createReplyDispatcher } from "../auto-reply/reply/reply-dispatcher.js";
 import { getTestPluginRegistry } from "./test-helpers.plugin-registry.js";
 import {
   agentCommand,
@@ -72,6 +73,20 @@ function createDispatchInboundMessageMockExports(
             typeof actual.dispatchInboundMessage
           >)
         : actual.dispatchInboundMessage(...args);
+    },
+    dispatchInboundMessageWithProjectedDispatcher: (
+      ...args: Parameters<typeof actual.dispatchInboundMessageWithProjectedDispatcher>
+    ) => {
+      const impl = gatewayTestHoisted.dispatchInboundMessage.getMockImplementation();
+      if (!impl) {
+        return actual.dispatchInboundMessageWithProjectedDispatcher(...args);
+      }
+      const [params] = args;
+      const { dispatcherOptions, ...dispatchParams } = params;
+      return gatewayTestHoisted.dispatchInboundMessage({
+        ...dispatchParams,
+        dispatcher: createReplyDispatcher(dispatcherOptions),
+      }) as ReturnType<typeof actual.dispatchInboundMessageWithProjectedDispatcher>;
     },
   };
 }

--- a/src/infra/outbound/deliver-hooks.ts
+++ b/src/infra/outbound/deliver-hooks.ts
@@ -17,6 +17,7 @@ import {
 import { hasOutboundReplyContent } from "../../plugin-sdk/reply-payload.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { formatErrorMessage } from "../errors.js";
+import { normalizeEmptyPayloadForDelivery } from "./deliver-payload.js";
 import {
   OutboundDeliveryError,
   type OutboundDeliveryFailureStage,
@@ -25,7 +26,10 @@ import {
   type OutboundPayloadDeliverySuppressionReason,
 } from "./deliver-types.js";
 import type { QueuedReplyPayloadSendingHook } from "./delivery-queue.js";
-import type { NormalizedOutboundPayload } from "./payloads.js";
+import {
+  summarizeOutboundPayloadForTransport,
+  type NormalizedOutboundPayload,
+} from "./payloads.js";
 
 export { createMessageSentEmitter } from "./message-sent-hook.js";
 
@@ -93,6 +97,34 @@ export function buildLegacyInboundMessageSendingBeforeDeliver(
         : copyReplyPayloadMetadata(payload, { ...payload, text: result.content });
     },
   );
+}
+
+/** Run media-aware message policy before a core owner can capture projected output. */
+export function buildProjectedInboundMessageSendingBeforeDeliver(
+  ctx: MsgContext | FinalizedMsgContext,
+): ReplyDispatchBeforeDeliver {
+  const finalized = finalizeInboundContext(ctx);
+  const hookCtx = deriveInboundMessageHookContext(finalized);
+  const replyTarget = resolveInboundReplyHookTarget(finalized, hookCtx);
+  return markReplyDispatchBeforeDeliverDeadlineOwned(async (payload) => {
+    const hookRunner = getGlobalHookRunner();
+    const hookResult = await applyMessageSendingHook({
+      hookRunner,
+      enabled: hookRunner?.hasHooks("message_sending") ?? false,
+      payload,
+      payloadSummary: summarizeOutboundPayloadForTransport(payload),
+      to: replyTarget,
+      channel: hookCtx.channelId,
+      accountId: hookCtx.accountId,
+      replyToId: payload.replyToId ?? finalized.ReplyToIdFull ?? finalized.ReplyToId,
+      threadId: finalized.MessageThreadId,
+      sessionKey: finalized.SessionKey,
+    });
+    if (hookResult.cancelled) {
+      return null;
+    }
+    return normalizeEmptyPayloadForDelivery(hookResult.payload);
+  });
 }
 
 export async function applyMessageSendingHook(params: {


### PR DESCRIPTION
Related: #101026

## What Problem This Solves

Fixes an issue where Control UI chat replies bypassed `message_sending` after
`reply_payload_sending`, so plugins could not rewrite or cancel the content that became
visible in WebChat and durable in chat history. Media-only cancellation had the same
gap.

## Why This Change Was Made

The core auto-reply owner now provides an internal projected-dispatch mode that composes
both modifying hooks before delivery. Gateway supplies delivery/capture options to that
owner, keeping WebChat capture and transcript-media side effects behind cancellation
without changing the shipped Plugin SDK constructors, protocol, config, or storage.

## User Impact

Plugin `message_sending` policy now applies consistently to Control UI replies. Rewrites
become the exact visible and durable content, while text and media cancellation produce
no assistant message, preview, or history entry.

AI-assisted: yes. I reviewed the implementation and ran the repository's independent
autoreview workflow; it reported no accepted or actionable findings.

## Maintainer Policy Decision

Accepted: Control UI chat is an outbound reply surface and should honor the established
plugin outbound-hook contract.

- Installed `message_sending` handlers may rewrite Control UI replies before WebChat
  visibility and durable capture. This compatibility change is intentional.
- Cancellation intentionally suppresses both the visible assistant reply and its durable
  history/transcript-media side effects. Persisting content that policy cancelled would
  make visible and durable state disagree.
- Hook exceptions remain best-effort/fail-open; a failing plugin does not suppress the
  reply.
- The merge-risk labels remain useful descriptions of the intentional behavior change,
  but these two semantics are not unresolved design questions.

## Evidence

- Live before/after on frozen base `b699a93c87101df3afe29bbcbe69852859c29cdf`
  using a real built Gateway, production plugin loader, built Control UI, Chromium, and
  isolated state (only the external model was mocked):
  - Baseline: all three rows ran `reply_payload_sending` once and
    `message_sending` zero times; reply-only rewritten text, forbidden cancellation
    text, and forbidden media projection were visible and durable.
  - Candidate: rewrite ran exactly
    `reply_payload_sending → message_sending` once each and displayed/persisted the
    exact composed `MS:RPS:…` content.
  - Candidate text and media-only cancellation each ran both hooks exactly once; UI
    assistant counts and `chat.history` assistant counts stayed unchanged, and no media
    placeholder, image, or forbidden text appeared.
  - Blacksmith Testbox `tbx_01kygzrtwzs2qjkcxr98cwp561`; workflow run
    https://github.com/openclaw/openclaw/actions/runs/30239066110. Sanitized trace,
    screenshots, recording, and Gateway logs were preserved locally and visually
    inspected.
- Focused tests: 185/185 assertions passed across auto-reply dispatch, the Gateway
  capture owner, and the full `chat.send` directive/finalization suite.
- Frozen-base `pnpm check:changed`: passed, including core/core-test typechecks,
  targeted lint, formatting, SDK API baseline, plugin boundaries, import cycles, and
  repository guards.
- `pnpm plugin-sdk:surface:check`: passed; no public SDK surface change.
- `pnpm build`: passed, including package bundles, SDK export/declaration checks, and
  the production Control UI build.
- Fresh `autoreview --mode uncommitted`: clean, confidence 0.87.

### Exact-head sibling regression matrix

The following rows were rerun on PR head
`e92d33e053547d499ce752645a57bbd316bfac5e` against frozen integration base
`30ba6bc9de04b56e4d7cf8014a09dfc5cc483601`. No product or branch changes were made
during this validation.

| Surface | Evidence | Result | Inspectable observation |
| --- | --- | --- | --- |
| Control UI, no hooks | Live disposable | PASS | Built Control UI and Gateway rendered and persisted exactly one assistant reply. |
| Control UI, throwing hooks | Live disposable | PASS | `reply_payload_sending → message_sending`, once each; both exceptions failed open and one reply remained visible and durable. |
| Legacy Plugin SDK dispatcher | Production-loaded contract probe | PASS | Default composition and custom `beforeDeliver` precedence were preserved. This is contract evidence, not a separate user-facing-impact claim. |
| Matrix ordinary auto-reply with media | Live disposable Tuwunel | PASS | Production Matrix plugin emitted media event `$WCNbQxi7gp2aTQtpVBrqgtvdosL-9Se4SWSHAPU4pUY` and final text event `$eeX7BD5q29SN4srSRdYyKBj1rKyHz-jGxFVa_8DkGtk`; provider readback matched; modifying hooks ran once each. |
| Telegram provider-owned finalization | Live external bot + signed-in human Desktop | PASS | `reply_payload_sending → message_sending → native finalization → message_sent`; final content matched Desktop and provider message ID `459`. |
| Telegram durable/message-tool send | Live external bot + signed-in human Desktop | PASS | `message_sending → native send → message_sent`; final content matched CLI/trace/Desktop and provider message ID `457`. |

Primary Crabbox records:

- Control UI and legacy dispatcher: https://crabbox.openclaw.ai/portal/runs/run_0c46bd10b939
- Matrix: https://crabbox.openclaw.ai/portal/runs/run_c55fa263b500
- Telegram provider finalization: https://crabbox.openclaw.ai/portal/runs/run_a52b3eda5929

Sanitized exact-head lifecycle records:

```text
Control UI hook failure: reply_payload_sending, message_sending; visible=1; durable=1
Matrix: reply_payload_sending, message_sending; mediaEvents=1; finalTextEvents=1
Telegram finalization: reply_payload_sending, message_sending, message_sent(id=459, success=true)
Telegram durable: message_sending, message_sent(id=457, success=true)
```

No Bot API token, OpenAI key, bearer token, private prompt content, or leased
`telegram-user` credential appears in the published evidence. Telegram UI screenshots
remain private because the Desktop chrome contains unrelated personal chat metadata.

Residual scope: this compact matrix brackets the shared behavior with a core-managed
transport (Matrix) and a provider-owned finalization transport (Telegram). Mattermost,
Discord, Slack, Feishu/Lark, and WhatsApp were not rerun on this exact head because this
PR does not change their delivery entry points.
