### PR TITLE
refactor(providers): consolidate catalog and realtime contract tests

### DIFF
--- a/extensions/lmstudio/src/setup.test.ts
+++ b/extensions/lmstudio/src/setup.test.ts
@@ -405,78 +405,54 @@ describe("lmstudio setup", () => {
     ).resolves.toBeNull();
   });
 
-  it("prefers the strongest tool-calling family among installed models", async () => {
-    fetchLmstudioModelsMock.mockResolvedValue({
-      reachable: true,
-      status: 200,
+  it.each([
+    {
+      name: "prefers the strongest tool-calling family among installed models",
       models: [
-        {
-          type: "llm",
-          key: "llama3.3-70b-instruct",
-          max_context_length: 65_536,
-          capabilities: { trained_for_tool_use: true },
-        },
-        {
-          type: "llm",
-          key: "qwen3.5-4b-instruct",
-          max_context_length: 65_536,
-          capabilities: { trained_for_tool_use: true },
-        },
-        {
-          type: "llm",
-          key: "nomic-embed-text",
-          max_context_length: 65_536,
-          capabilities: { trained_for_tool_use: true },
-        },
+        { key: "llama3.3-70b-instruct", max_context_length: 65_536 },
+        { key: "qwen3.5-4b-instruct", max_context_length: 65_536 },
+        { key: "nomic-embed-text", max_context_length: 65_536 },
       ],
-    });
-
-    const result = await prepareAppGuidedLmstudioSetup({ config: {}, env: {} });
-
-    expect(result?.defaultModel).toBe("lmstudio/qwen3.5-4b-instruct");
-  });
-
-  it("skips a preferred model loaded with less than 16k context", async () => {
-    fetchLmstudioModelsMock.mockResolvedValue({
-      reachable: true,
-      status: 200,
+      expectedModel: "lmstudio/qwen3.5-4b-instruct",
+    },
+    {
+      name: "skips a preferred model loaded with less than 16k context",
       models: [
         {
-          type: "llm",
           key: "llama3.3-70b-instruct",
           max_context_length: 65_536,
           loaded_instances: [{ id: "llama", config: { context_length: 32_768 } }],
-          capabilities: { trained_for_tool_use: true },
         },
         {
-          type: "llm",
           key: "qwen3.5-4b-instruct",
           max_context_length: 65_536,
           loaded_instances: [{ id: "qwen", config: { context_length: 8_192 } }],
-          capabilities: { trained_for_tool_use: true },
         },
       ],
-    });
-
-    const result = await prepareAppGuidedLmstudioSetup({ config: {}, env: {} });
-
-    expect(result?.defaultModel).toBe("lmstudio/llama3.3-70b-instruct");
-  });
-
-  it("does not auto-detect a model without measured or advertised context", async () => {
+      expectedModel: "lmstudio/llama3.3-70b-instruct",
+    },
+    {
+      name: "does not auto-detect a model without measured or advertised context",
+      models: [{ key: "qwen3.5-4b-instruct" }],
+      expectedModel: undefined,
+    },
+  ])("$name", async ({ models, expectedModel }) => {
     fetchLmstudioModelsMock.mockResolvedValue({
       reachable: true,
       status: 200,
-      models: [
-        {
-          type: "llm",
-          key: "qwen3.5-4b-instruct",
-          capabilities: { trained_for_tool_use: true },
-        },
-      ],
+      models: models.map((model) => ({
+        type: "llm",
+        capabilities: { trained_for_tool_use: true },
+        ...model,
+      })),
     });
 
-    await expect(prepareAppGuidedLmstudioSetup({ config: {}, env: {} })).resolves.toBeNull();
+    const result = await prepareAppGuidedLmstudioSetup({ config: {}, env: {} });
+    if (expectedModel) {
+      expect(result?.defaultModel).toBe(expectedModel);
+    } else {
+      expect(result).toBeNull();
+    }
   });
 
   it("non-interactive setup discovers catalog and writes LM Studio provider config", async () => {
@@ -633,161 +609,44 @@ describe("lmstudio setup", () => {
     });
   });
 
-  it("non-interactive setup keeps Authorization header auth without writing a synthetic key", async () => {
-    const ctx = buildNonInteractiveContext({
-      config: {
-        auth: {
-          profiles: {
-            "lmstudio:default": {
-              provider: "lmstudio",
-              mode: "api_key",
-            },
-          },
-          order: {
-            lmstudio: ["lmstudio:default"],
-          },
-        },
-        models: {
-          providers: {
-            lmstudio: {
-              baseUrl: "http://localhost:1234/v1",
-              apiKey: "stale-config-key",
-              auth: "api-key",
-              api: "openai-completions",
-              headers: {
-                Authorization: "Bearer proxy-token",
-              },
-              models: [],
-            },
-          },
-        },
-      } as OpenClawConfig,
-      customBaseUrl: "http://localhost:1234/api/v1/",
-      customApiKey: "",
-      customModelId: "qwen3-8b-instruct",
+  it.each([
+    {
+      name: "non-interactive setup keeps Authorization header auth without writing a synthetic key",
       resolvedApiKey: null,
-    });
-
-    const result = await configureLmstudioNonInteractive(ctx);
-
-    expect(removeProviderAuthProfilesWithLockMock).toHaveBeenCalledWith({
-      provider: "lmstudio",
-      agentDir: undefined,
-    });
-    expect(fetchLmstudioModelsMock).toHaveBeenCalledWith({
-      baseUrl: "http://localhost:1234/v1",
-      apiKey: undefined,
-      headers: {
-        Authorization: "Bearer proxy-token",
-      },
-      timeoutMs: 5000,
-    });
-    expect(configureSelfHostedNonInteractiveMock).not.toHaveBeenCalled();
-    expect(resolveAgentModelPrimaryValue(result?.agents?.defaults?.model)).toBe(
-      "lmstudio/qwen3-8b-instruct",
-    );
-    const provider = requireNonInteractiveLmstudioProvider(result);
-    expectRecordFields(provider, "LM Studio provider config", {
-      baseUrl: "http://localhost:1234/v1",
-      api: "openai-completions",
-      headers: {
-        Authorization: "Bearer proxy-token",
-      },
-    });
-    const models = requireProviderModels(provider);
-    expect(models).toHaveLength(1);
-    expectModelFields(models[0], {
-      id: "qwen3-8b-instruct",
-    });
-    expect(provider).not.toHaveProperty("apiKey");
-    expect(provider).not.toHaveProperty("auth");
-    expect(result?.auth).toBeUndefined();
-  });
-
-  it("non-interactive setup clears stale profile auth before switching to Authorization header auth", async () => {
-    const ctx = buildNonInteractiveContext({
-      config: {
-        auth: {
-          profiles: {
-            "lmstudio:default": {
-              provider: "lmstudio",
-              mode: "api_key",
-            },
-          },
-          order: {
-            lmstudio: ["lmstudio:default"],
-          },
-        },
-        models: {
-          providers: {
-            lmstudio: {
-              baseUrl: "http://localhost:1234/v1",
-              apiKey: "stale-config-key",
-              auth: "api-key",
-              api: "openai-completions",
-              headers: {
-                Authorization: "Bearer proxy-token",
-              },
-              models: [],
-            },
-          },
-        },
-      } as OpenClawConfig,
-      customBaseUrl: "http://localhost:1234/api/v1/",
-      customApiKey: "",
-      customModelId: "qwen3-8b-instruct",
+      withProfile: true,
+    },
+    {
+      name: "non-interactive setup clears stale profile auth before switching to Authorization header auth",
       resolvedApiKey: "stale-profile-key",
-      resolvedApiKeySource: "profile",
-    });
-
-    const result = await configureLmstudioNonInteractive(ctx);
-
-    expect(removeProviderAuthProfilesWithLockMock).toHaveBeenCalledWith({
-      provider: "lmstudio",
-      agentDir: undefined,
-    });
-    expect(fetchLmstudioModelsMock).toHaveBeenCalledWith({
-      baseUrl: "http://localhost:1234/v1",
-      apiKey: undefined,
-      headers: {
-        Authorization: "Bearer proxy-token",
-      },
-      timeoutMs: 5000,
-    });
-    expect(configureSelfHostedNonInteractiveMock).not.toHaveBeenCalled();
-    expect(resolveAgentModelPrimaryValue(result?.agents?.defaults?.model)).toBe(
-      "lmstudio/qwen3-8b-instruct",
-    );
-    const provider = requireNonInteractiveLmstudioProvider(result);
-    expectRecordFields(provider, "LM Studio provider config", {
-      baseUrl: "http://localhost:1234/v1",
-      api: "openai-completions",
-      headers: {
-        Authorization: "Bearer proxy-token",
-      },
-    });
-    const models = requireProviderModels(provider);
-    expect(models).toHaveLength(1);
-    expectModelFields(models[0], {
-      id: "qwen3-8b-instruct",
-    });
-    expect(provider).not.toHaveProperty("apiKey");
-    expect(provider).not.toHaveProperty("auth");
-    expect(result?.auth).toBeUndefined();
-  });
-
-  it("non-interactive setup clears env fallback auth before switching to Authorization header auth", async () => {
+      resolvedApiKeySource: "profile" as const,
+      withProfile: true,
+    },
+    {
+      name: "non-interactive setup clears env fallback auth before switching to Authorization header auth",
+      resolvedApiKey: "env-fallback-key",
+      resolvedApiKeySource: "env" as const,
+      withProfile: false,
+    },
+  ])("$name", async ({ resolvedApiKey, resolvedApiKeySource, withProfile }) => {
+    const headers = { Authorization: "Bearer proxy-token" };
     const ctx = buildNonInteractiveContext({
       config: {
+        ...(withProfile
+          ? {
+              auth: {
+                profiles: { "lmstudio:default": { provider: "lmstudio", mode: "api_key" } },
+                order: { lmstudio: ["lmstudio:default"] },
+              },
+            }
+          : {}),
         models: {
           providers: {
             lmstudio: {
               baseUrl: "http://localhost:1234/v1",
+              ...(withProfile ? { apiKey: "stale-config-key" } : {}),
               auth: "api-key",
               api: "openai-completions",
-              headers: {
-                Authorization: "Bearer proxy-token",
-              },
+              headers,
               models: [],
             },
           },
@@ -796,12 +655,11 @@ describe("lmstudio setup", () => {
       customBaseUrl: "http://localhost:1234/api/v1/",
       customApiKey: "",
       customModelId: "qwen3-8b-instruct",
-      resolvedApiKey: "env-fallback-key",
-      resolvedApiKeySource: "env",
+      resolvedApiKey,
+      resolvedApiKeySource,
     });
 
     const result = await configureLmstudioNonInteractive(ctx);
-
     expect(removeProviderAuthProfilesWithLockMock).toHaveBeenCalledWith({
       provider: "lmstudio",
       agentDir: undefined,
@@ -809,9 +667,7 @@ describe("lmstudio setup", () => {
     expect(fetchLmstudioModelsMock).toHaveBeenCalledWith({
       baseUrl: "http://localhost:1234/v1",
       apiKey: undefined,
-      headers: {
-        Authorization: "Bearer proxy-token",
-      },
+      headers: { Authorization: "Bearer proxy-token" },
       timeoutMs: 5000,
     });
     expect(configureSelfHostedNonInteractiveMock).not.toHaveBeenCalled();
@@ -822,15 +678,11 @@ describe("lmstudio setup", () => {
     expectRecordFields(provider, "LM Studio provider config", {
       baseUrl: "http://localhost:1234/v1",
       api: "openai-completions",
-      headers: {
-        Authorization: "Bearer proxy-token",
-      },
+      headers: { Authorization: "Bearer proxy-token" },
     });
     const models = requireProviderModels(provider);
     expect(models).toHaveLength(1);
-    expectModelFields(models[0], {
-      id: "qwen3-8b-instruct",
-    });
+    expectModelFields(models[0], { id: "qwen3-8b-instruct" });
     expect(provider).not.toHaveProperty("apiKey");
     expect(provider).not.toHaveProperty("auth");
     expect(result?.auth).toBeUndefined();
@@ -1469,187 +1321,98 @@ describe("lmstudio setup", () => {
     expect(result?.provider.models?.map((model) => model.id)).toEqual(["qwen3-8b-instruct"]);
   });
 
-  it("discoverLmstudioProvider returns null for unresolved header refs", async () => {
-    const result = await discoverLmstudioProvider(
-      buildDiscoveryContext({
-        config: {
-          models: {
-            providers: {
-              lmstudio: {
-                baseUrl: "http://localhost:1234/v1",
-                api: "openai-completions",
-                headers: {
-                  "X-Proxy-Auth": {
-                    source: "env",
-                    provider: "default",
-                    id: "LMSTUDIO_PROXY_TOKEN",
-                  },
-                },
-                models: [],
-              },
-            },
-          },
-        } as OpenClawConfig,
-        env: {},
-      }),
-    );
-
-    expect(result).toBeNull();
-    expect(discoverLmstudioModelsMock).not.toHaveBeenCalled();
-  });
-
-  it("discoverLmstudioProvider returns null for an unresolved apiKey ref", async () => {
-    const result = await discoverLmstudioProvider(
-      buildDiscoveryContext({
-        config: {
-          models: {
-            providers: {
-              lmstudio: {
-                baseUrl: "http://localhost:1234/v1",
-                api: "openai-completions",
-                apiKey: {
-                  source: "env",
-                  provider: "default",
-                  id: "LMSTUDIO_DISCOVERY_TOKEN",
-                },
-                models: [],
-              },
-            },
-          },
-        } as OpenClawConfig,
-        env: {},
-      }),
-    );
-
-    expect(result).toBeNull();
-    expect(discoverLmstudioModelsMock).not.toHaveBeenCalled();
-  });
-
-  it("discoverLmstudioProvider uses configured direct apiKey for discovery", async () => {
-    discoverLmstudioModelsMock.mockResolvedValueOnce([
-      createModel("qwen3-8b-instruct", "Qwen3 8B"),
-    ]);
-
-    await discoverLmstudioProvider(
-      buildDiscoveryContext({
-        config: {
-          models: {
-            providers: {
-              lmstudio: {
-                baseUrl: "http://localhost:1234/v1",
-                api: "openai-completions",
-                apiKey: "configured-direct-key",
-                models: [],
-              },
-            },
-          },
-        } as OpenClawConfig,
-      }),
-    );
-
-    expect(discoverLmstudioModelsMock).toHaveBeenCalledWith({
-      baseUrl: "http://localhost:1234/v1",
-      apiKey: "configured-direct-key",
-      headers: undefined,
-      quiet: false,
-    });
-  });
-
-  it("discoverLmstudioProvider prefers resolved discoveryApiKey over configured apiKey", async () => {
-    discoverLmstudioModelsMock.mockResolvedValueOnce([
-      createModel("qwen3-8b-instruct", "Qwen3 8B"),
-    ]);
-
-    await discoverLmstudioProvider(
-      buildDiscoveryContext({
-        discoveryApiKey: "resolved-discovery-key",
-        config: {
-          models: {
-            providers: {
-              lmstudio: {
-                baseUrl: "http://localhost:1234/v1",
-                api: "openai-completions",
-                apiKey: "configured-direct-key",
-                models: [],
-              },
-            },
-          },
-        } as OpenClawConfig,
-      }),
-    );
-
-    expect(discoverLmstudioModelsMock).toHaveBeenCalledWith({
-      baseUrl: "http://localhost:1234/v1",
-      apiKey: "resolved-discovery-key",
-      headers: undefined,
-      quiet: false,
-    });
-  });
-
-  it("discoverLmstudioProvider ignores an unresolved apiKey template when discoveryApiKey is resolved", async () => {
-    discoverLmstudioModelsMock.mockResolvedValueOnce([
-      createModel("qwen3-8b-instruct", "Qwen3 8B"),
-    ]);
-
-    await discoverLmstudioProvider(
-      buildDiscoveryContext({
-        discoveryApiKey: "resolved-discovery-key",
-        config: {
-          models: {
-            providers: {
-              lmstudio: {
-                baseUrl: "http://localhost:1234/v1",
-                api: "openai-completions",
-                apiKey: "${LMSTUDIO_API_KEY}",
-                models: [],
-              },
-            },
-          },
-        } as OpenClawConfig,
-        env: {},
-      }),
-    );
-
-    expect(discoverLmstudioModelsMock).toHaveBeenCalledWith({
-      baseUrl: "http://localhost:1234/v1",
-      apiKey: "resolved-discovery-key",
-      headers: undefined,
-      quiet: false,
-    });
-  });
-
-  it("discoverLmstudioProvider suppresses stale discovery apiKey when Authorization header auth is configured", async () => {
-    discoverLmstudioModelsMock.mockResolvedValueOnce([
-      createModel("qwen3-8b-instruct", "Qwen3 8B"),
-    ]);
-
-    await discoverLmstudioProvider(
-      buildDiscoveryContext({
-        discoveryApiKey: "resolved-stale-key",
-        config: {
-          models: {
-            providers: {
-              lmstudio: {
-                baseUrl: "http://localhost:1234/v1",
-                api: "openai-completions",
-                apiKey: "configured-direct-key",
-                headers: {
-                  Authorization: "Bearer custom-token",
-                },
-                models: [],
-              },
-            },
-          },
-        } as OpenClawConfig,
-      }),
-    );
-
-    expect(discoverLmstudioModelsMock).toHaveBeenCalledWith({
-      baseUrl: "http://localhost:1234/v1",
-      apiKey: "",
-      headers: {
-        Authorization: "Bearer custom-token",
+  it.each([
+    {
+      name: "discoverLmstudioProvider returns null for unresolved header refs",
+      providerPatch: {
+        headers: {
+          "X-Proxy-Auth": { source: "env", provider: "default", id: "LMSTUDIO_PROXY_TOKEN" },
+        },
       },
+    },
+    {
+      name: "discoverLmstudioProvider returns null for an unresolved apiKey ref",
+      providerPatch: {
+        apiKey: { source: "env", provider: "default", id: "LMSTUDIO_DISCOVERY_TOKEN" },
+      },
+    },
+  ])("$name", async ({ providerPatch }) => {
+    const result = await discoverLmstudioProvider(
+      buildDiscoveryContext({
+        config: {
+          models: {
+            providers: {
+              lmstudio: {
+                baseUrl: "http://localhost:1234/v1",
+                api: "openai-completions",
+                models: [],
+                ...providerPatch,
+              },
+            },
+          },
+        } as OpenClawConfig,
+        env: {},
+      }),
+    );
+
+    expect(result).toBeNull();
+    expect(discoverLmstudioModelsMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      name: "discoverLmstudioProvider uses configured direct apiKey for discovery",
+      configuredApiKey: "configured-direct-key",
+      expectedApiKey: "configured-direct-key",
+    },
+    {
+      name: "discoverLmstudioProvider prefers resolved discoveryApiKey over configured apiKey",
+      configuredApiKey: "configured-direct-key",
+      discoveryApiKey: "resolved-discovery-key",
+      expectedApiKey: "resolved-discovery-key",
+    },
+    {
+      name: "discoverLmstudioProvider ignores an unresolved apiKey template when discoveryApiKey is resolved",
+      configuredApiKey: "${LMSTUDIO_API_KEY}",
+      discoveryApiKey: "resolved-discovery-key",
+      expectedApiKey: "resolved-discovery-key",
+    },
+    {
+      name: "discoverLmstudioProvider suppresses stale discovery apiKey when Authorization header auth is configured",
+      configuredApiKey: "configured-direct-key",
+      discoveryApiKey: "resolved-stale-key",
+      headers: { Authorization: "Bearer custom-token" },
+      expectedApiKey: "",
+    },
+  ])("$name", async ({ configuredApiKey, discoveryApiKey, headers, expectedApiKey }) => {
+    discoverLmstudioModelsMock.mockResolvedValueOnce([
+      createModel("qwen3-8b-instruct", "Qwen3 8B"),
+    ]);
+
+    await discoverLmstudioProvider(
+      buildDiscoveryContext({
+        discoveryApiKey,
+        config: {
+          models: {
+            providers: {
+              lmstudio: {
+                baseUrl: "http://localhost:1234/v1",
+                api: "openai-completions",
+                apiKey: configuredApiKey,
+                ...(headers ? { headers } : {}),
+                models: [],
+              },
+            },
+          },
+        } as OpenClawConfig,
+        env: {},
+      }),
+    );
+
+    expect(discoverLmstudioModelsMock).toHaveBeenCalledWith({
+      baseUrl: "http://localhost:1234/v1",
+      apiKey: expectedApiKey,
+      headers,
       quiet: false,
     });
   });

--- a/extensions/ollama/index.test.ts
+++ b/extensions/ollama/index.test.ts
@@ -625,7 +625,10 @@ describe("ollama plugin", () => {
     expect(buildOllamaProviderMock).not.toHaveBeenCalled();
   });
 
-  it("treats non-default baseUrl as explicit discovery config", async () => {
+  it.each([
+    { name: "treats non-default baseUrl as explicit discovery config", key: "baseUrl" },
+    { name: "accepts baseURL alias as explicit discovery config", key: "baseURL" },
+  ])("$name", async ({ key }) => {
     const provider = registerProvider();
     buildOllamaProviderMock.mockResolvedValueOnce({
       baseUrl: "http://remote-ollama:11434",
@@ -638,37 +641,7 @@ describe("ollama plugin", () => {
         models: {
           providers: {
             ollama: {
-              baseUrl: "http://remote-ollama:11434",
-              api: "ollama",
-              models: [],
-            },
-          },
-        },
-      },
-      env: { NODE_ENV: "development" },
-      resolveProviderApiKey: () => ({ apiKey: "" }),
-    } as never);
-
-    expect(result).toBeNull();
-    expect(buildOllamaProviderMock).toHaveBeenCalledWith("http://remote-ollama:11434", {
-      quiet: false,
-    });
-  });
-
-  it("accepts baseURL alias as explicit discovery config", async () => {
-    const provider = registerProvider();
-    buildOllamaProviderMock.mockResolvedValueOnce({
-      baseUrl: "http://remote-ollama:11434",
-      api: "ollama",
-      models: [],
-    });
-
-    const result = await provider.catalog.run({
-      config: {
-        models: {
-          providers: {
-            ollama: {
-              baseURL: "http://remote-ollama:11434",
+              [key]: "http://remote-ollama:11434",
               api: "ollama",
               models: [],
             },
@@ -982,96 +955,77 @@ describe("ollama plugin", () => {
     ]);
   });
 
-  it("augments configured Ollama Cloud refs with resolved auth", async () => {
-    const provider = registerProvider();
-    queryOllamaModelShowInfoMock.mockResolvedValueOnce({
-      contextWindow: 1_048_576,
+  it.each([
+    {
+      name: "augments configured Ollama Cloud refs with resolved auth",
+      baseUrl: "https://ollama.com",
+      modelId: "cloud-new:cloud",
+      resolvedApiKey: "cloud-key",
+      expectedApiKey: "cloud-key",
       capabilities: ["completion", "thinking"],
-    });
-
-    const rows = await provider.augmentModelCatalog?.({
-      config: {
-        agents: {
-          defaults: {
-            models: {
-              "ollama/cloud-new:cloud": {},
-            },
-          },
-        },
-        models: {
-          providers: {
-            ollama: {
-              baseUrl: "https://ollama.com",
-              api: "ollama",
-            },
-          },
-        },
-      },
-      env: {},
-      entries: [],
-      resolveProviderApiKey: vi.fn(() => ({ apiKey: "cloud-key" })),
-    } as never);
-
-    expect(queryOllamaModelShowInfoMock).toHaveBeenCalledWith(
-      "https://ollama.com",
-      "cloud-new:cloud",
-      { apiKey: "cloud-key" },
-    );
-    expect(rows).toEqual([
-      expect.objectContaining({
-        provider: "ollama",
-        id: "cloud-new:cloud",
-        reasoning: true,
-        contextWindow: 1_048_576,
-      }),
-    ]);
-  });
-
-  it("augments configured remote Ollama refs with configured auth", async () => {
-    const provider = registerProvider();
-    queryOllamaModelShowInfoMock.mockResolvedValueOnce({
-      contextWindow: 1_048_576,
+    },
+    {
+      name: "augments configured remote Ollama refs with configured auth",
+      baseUrl: "https://ollama.example.test",
+      modelId: "remote-new",
+      configuredApiKey: "remote-key",
+      resolvedApiKey: "",
+      expectedApiKey: "remote-key",
       capabilities: ["completion", "tools", "thinking"],
-    });
-
-    const rows = await provider.augmentModelCatalog?.({
-      config: {
-        agents: {
-          defaults: {
-            models: {
-              "ollama/remote-new": {},
-            },
-          },
-        },
-        models: {
-          providers: {
-            ollama: {
-              baseUrl: "https://ollama.example.test",
-              api: "ollama",
-              apiKey: "remote-key",
-            },
-          },
-        },
-      },
-      env: {},
-      entries: [],
-      resolveProviderApiKey: vi.fn(() => ({ apiKey: "" })),
-    } as never);
-
-    expect(queryOllamaModelShowInfoMock).toHaveBeenCalledWith(
-      "https://ollama.example.test",
-      "remote-new",
-      { apiKey: "remote-key" },
-    );
-    expect(rows).toEqual([
-      expect.objectContaining({
-        provider: "ollama",
-        id: "remote-new",
-        reasoning: true,
+    },
+  ])(
+    "$name",
+    async ({
+      baseUrl,
+      modelId,
+      configuredApiKey,
+      resolvedApiKey,
+      expectedApiKey,
+      capabilities,
+    }) => {
+      const provider = registerProvider();
+      queryOllamaModelShowInfoMock.mockResolvedValueOnce({
         contextWindow: 1_048_576,
-      }),
-    ]);
-  });
+        capabilities,
+      });
+
+      const rows = await provider.augmentModelCatalog?.({
+        config: {
+          agents: {
+            defaults: {
+              models: {
+                [`ollama/${modelId}`]: {},
+              },
+            },
+          },
+          models: {
+            providers: {
+              ollama: {
+                baseUrl,
+                api: "ollama",
+                ...(configuredApiKey ? { apiKey: configuredApiKey } : {}),
+              },
+            },
+          },
+        },
+        env: {},
+        entries: [],
+        resolveProviderApiKey: vi.fn(() => ({ apiKey: resolvedApiKey })),
+      } as never);
+
+      expect(queryOllamaModelShowInfoMock).toHaveBeenCalledWith(baseUrl, modelId, {
+        apiKey: expectedApiKey,
+      });
+      expect(rows).toEqual([
+        expect.objectContaining({
+          provider: "ollama",
+          id: modelId,
+          reasoning: true,
+          contextWindow: 1_048_576,
+        }),
+      ]);
+    },
+  );
 
   it.each(["$OLLAMA_API_KEY", "${OLLAMA_API_KEY}"])(
     "resolves configured Ollama Cloud SecretInput auth string %s",
@@ -1598,68 +1552,45 @@ describe("ollama plugin", () => {
     });
   });
 
-  it("does not mint synthetic auth for empty default-ish provider stubs", () => {
+  it.each([
+    {
+      name: "does not mint synthetic auth for empty default-ish provider stubs",
+      providerPatch: { baseUrl: "http://127.0.0.1:11434" },
+      mintsAuth: false,
+    },
+    {
+      name: "mints synthetic auth for non-default explicit ollama config",
+      providerPatch: { baseUrl: "http://remote-ollama:11434" },
+      mintsAuth: true,
+    },
+    {
+      name: "mints synthetic auth for non-default baseURL alias config",
+      providerPatch: { baseURL: "http://remote-ollama:11434" },
+      mintsAuth: true,
+    },
+    {
+      name: "does not mint synthetic auth for Ollama Cloud baseUrl",
+      providerPatch: { baseUrl: "https://ollama.com" },
+      mintsAuth: false,
+    },
+  ])("$name", ({ providerPatch, mintsAuth }) => {
     const provider = registerProvider();
-
     const auth = provider.resolveSyntheticAuth?.({
       providerConfig: {
-        baseUrl: "http://127.0.0.1:11434",
         api: "ollama",
         models: [],
-      },
-    });
-
-    expect(auth).toBeUndefined();
-  });
-
-  it("mints synthetic auth for non-default explicit ollama config", () => {
-    const provider = registerProvider();
-
-    const auth = provider.resolveSyntheticAuth?.({
-      providerConfig: {
-        baseUrl: "http://remote-ollama:11434",
-        api: "ollama",
-        models: [],
-      },
-    });
-
-    expect(auth).toEqual({
-      apiKey: "ollama-local",
-      source: "models.providers.ollama (synthetic local key)",
-      mode: "api-key",
-    });
-  });
-
-  it("mints synthetic auth for non-default baseURL alias config", () => {
-    const provider = registerProvider();
-
-    const auth = provider.resolveSyntheticAuth?.({
-      providerConfig: {
-        baseURL: "http://remote-ollama:11434",
-        api: "ollama",
-        models: [],
+        ...providerPatch,
       } as never,
     });
-
-    expect(auth).toEqual({
-      apiKey: "ollama-local",
-      source: "models.providers.ollama (synthetic local key)",
-      mode: "api-key",
-    });
-  });
-
-  it("does not mint synthetic auth for Ollama Cloud baseUrl", () => {
-    const provider = registerProvider();
-
-    const auth = provider.resolveSyntheticAuth?.({
-      providerConfig: {
-        baseUrl: "https://ollama.com",
-        api: "ollama",
-        models: [],
-      },
-    });
-
-    expect(auth).toBeUndefined();
+    if (mintsAuth) {
+      expect(auth).toEqual({
+        apiKey: "ollama-local",
+        source: "models.providers.ollama (synthetic local key)",
+        mode: "api-key",
+      });
+    } else {
+      expect(auth).toBeUndefined();
+    }
   });
 
   it("registers ollama-cloud as a hosted provider", async () => {
@@ -1945,7 +1876,26 @@ describe("ollama plugin", () => {
     },
   );
 
-  it("routes createStreamFn to the correct provider baseUrl for ollama2", () => {
+  it.each([
+    {
+      name: "routes createStreamFn to the correct provider baseUrl for ollama2",
+      providerId: "ollama2",
+      baseUrlKey: "baseUrl",
+      expectedBaseUrl: "http://127.0.0.1:11435",
+    },
+    {
+      name: "routes createStreamFn through baseURL alias for custom Ollama providers",
+      providerId: "ollama2",
+      baseUrlKey: "baseURL",
+      expectedBaseUrl: "http://127.0.0.1:11435",
+    },
+    {
+      name: "uses ollama provider baseUrl when provider is ollama (backward compat)",
+      providerId: "ollama",
+      baseUrlKey: "baseUrl",
+      expectedBaseUrl: "http://127.0.0.1:11434",
+    },
+  ])("$name", ({ providerId, baseUrlKey, expectedBaseUrl }) => {
     const provider = registerProvider();
     const config = {
       models: {
@@ -1957,68 +1907,44 @@ describe("ollama plugin", () => {
           },
           ollama2: {
             api: "ollama",
-            baseUrl: "http://127.0.0.1:11435",
+            [baseUrlKey]: "http://127.0.0.1:11435",
             models: [],
           },
         },
       },
     };
-    const model = { id: "llama3.2", provider: "ollama2", api: "ollama", baseUrl: undefined };
+    const model = { id: "llama3.2", provider: providerId, api: "ollama", baseUrl: undefined };
 
-    provider.createStreamFn?.({ config, model, provider: "ollama2" } as never);
+    provider.createStreamFn?.({ config, model, provider: providerId } as never);
 
-    expect(requireConfiguredStreamParams().providerBaseUrl).toBe("http://127.0.0.1:11435");
+    expect(requireConfiguredStreamParams().providerBaseUrl).toBe(expectedBaseUrl);
   });
 
-  it("routes createStreamFn through baseURL alias for custom Ollama providers", () => {
-    const provider = registerProvider();
-    const config = {
-      models: {
-        providers: {
-          ollama2: {
-            api: "ollama",
-            baseURL: "http://127.0.0.1:11435",
-            models: [],
-          },
-        },
-      },
-    };
-    const model = { id: "llama3.2", provider: "ollama2", api: "ollama", baseUrl: undefined };
-
-    provider.createStreamFn?.({ config, model, provider: "ollama2" } as never);
-
-    expect(requireConfiguredStreamParams().providerBaseUrl).toBe("http://127.0.0.1:11435");
-  });
-
-  it("uses ollama provider baseUrl when provider is ollama (backward compat)", () => {
-    const provider = registerProvider();
-    const config = {
-      models: {
-        providers: {
-          ollama: {
-            api: "ollama",
-            baseUrl: "http://127.0.0.1:11434",
-            models: [],
-          },
-          ollama2: {
-            api: "ollama",
-            baseUrl: "http://127.0.0.1:11435",
-            models: [],
-          },
-        },
-      },
-    };
-    const model = { id: "llama3.2", provider: "ollama", api: "ollama", baseUrl: undefined };
-
-    provider.createStreamFn?.({ config, model, provider: "ollama" } as never);
-
-    expect(requireConfiguredStreamParams().providerBaseUrl).toBe("http://127.0.0.1:11434");
-  });
-
-  it("wraps native Ollama payloads with top-level think=false when thinking is off", () => {
-    const { baseStreamFn, payloadSeen } = captureWrappedOllamaPayload("off");
+  it.each([
+    {
+      name: "wraps native Ollama payloads with top-level think=false when thinking is off",
+      thinkingLevel: "off" as const,
+      expectedThink: false,
+    },
+    {
+      name: "wraps native Ollama payloads with top-level think effort when thinking is enabled",
+      thinkingLevel: "low" as const,
+      expectedThink: "low",
+    },
+    {
+      name: "maps native Ollama max thinking to the highest supported wire effort",
+      thinkingLevel: "max" as const,
+      expectedThink: "high",
+    },
+    {
+      name: "does not set think param when thinkingLevel is undefined",
+      thinkingLevel: undefined,
+      expectedThink: undefined,
+    },
+  ])("$name", ({ thinkingLevel, expectedThink }) => {
+    const { baseStreamFn, payloadSeen } = captureWrappedOllamaPayload(thinkingLevel);
     expect(baseStreamFn).toHaveBeenCalledTimes(1);
-    expect(payloadSeen?.think).toBe(false);
+    expect(payloadSeen?.think).toBe(expectedThink);
     expect((payloadSeen?.options as Record<string, unknown> | undefined)?.think).toBeUndefined();
   });
 
@@ -2046,26 +1972,6 @@ describe("ollama plugin", () => {
       levels: [{ id: "off" }, { id: "low" }, { id: "medium" }, { id: "high" }, { id: "max" }],
       defaultLevel: "off",
     });
-  });
-
-  it("wraps native Ollama payloads with top-level think effort when thinking is enabled", () => {
-    const { baseStreamFn, payloadSeen } = captureWrappedOllamaPayload("low");
-    expect(baseStreamFn).toHaveBeenCalledTimes(1);
-    expect(payloadSeen?.think).toBe("low");
-    expect((payloadSeen?.options as Record<string, unknown> | undefined)?.think).toBeUndefined();
-  });
-
-  it("maps native Ollama max thinking to the highest supported wire effort", () => {
-    const { baseStreamFn, payloadSeen } = captureWrappedOllamaPayload("max");
-    expect(baseStreamFn).toHaveBeenCalledTimes(1);
-    expect(payloadSeen?.think).toBe("high");
-    expect((payloadSeen?.options as Record<string, unknown> | undefined)?.think).toBeUndefined();
-  });
-
-  it("does not set think param when thinkingLevel is undefined", () => {
-    const { baseStreamFn, payloadSeen } = captureWrappedOllamaPayload(undefined);
-    expect(baseStreamFn).toHaveBeenCalledTimes(1);
-    expect(payloadSeen?.think).toBeUndefined();
   });
 
   it("registers an image-capable media understanding provider so image tool can route ollama/*", () => {

--- a/extensions/openrouter/index.test.ts
+++ b/extensions/openrouter/index.test.ts
@@ -56,6 +56,54 @@ function createOpenRouterDoneStreamWithoutGeneration() {
   return stream;
 }
 
+async function captureOpenRouterWrappedPayload(params: {
+  modelId: string;
+  thinkingLevel: string;
+  payload: Record<string, unknown>;
+  baseUrl?: string;
+  forwardPayload?: boolean;
+}) {
+  const provider = await registerSingleProviderPlugin(openrouterPlugin);
+  let capturedPayload: Record<string, unknown> | undefined;
+  const baseStreamFn = vi.fn(
+    (
+      ...args: Parameters<import("openclaw/plugin-sdk/agent-core").StreamFn>
+    ): ReturnType<import("openclaw/plugin-sdk/agent-core").StreamFn> => {
+      void args[2]?.onPayload?.(params.payload, args[0]);
+      if (!params.forwardPayload) {
+        capturedPayload = params.payload;
+      }
+      return { async *[Symbol.asyncIterator]() {} } as never;
+    },
+  );
+  const wrapped = provider.wrapStreamFn?.({
+    provider: "openrouter",
+    modelId: params.modelId,
+    streamFn: baseStreamFn,
+    thinkingLevel: params.thinkingLevel,
+  } as never);
+  void wrapped?.(
+    {
+      provider: "openrouter",
+      api: "openai-completions",
+      id: params.modelId,
+      ...(params.baseUrl ? { baseUrl: params.baseUrl } : {}),
+      compat: {},
+    } as never,
+    { messages: [] } as never,
+    (params.forwardPayload
+      ? {
+          onPayload: (payload: unknown) => {
+            capturedPayload = payload as Record<string, unknown>;
+            return payload;
+          },
+        }
+      : {}) as never,
+  );
+  expect(baseStreamFn).toHaveBeenCalledOnce();
+  return capturedPayload;
+}
+
 type OpenRouterManifest = {
   modelCatalog?: {
     discovery?: Record<string, string>;
@@ -837,84 +885,29 @@ describe("openrouter provider hooks", () => {
   });
 
   it("does not inject OpenRouter reasoning for Hunter Alpha", async () => {
-    const provider = await registerSingleProviderPlugin(openrouterPlugin);
-    let capturedPayload: Record<string, unknown> | undefined;
-    const baseStreamFn = vi.fn(
-      (
-        ...args: Parameters<import("openclaw/plugin-sdk/agent-core").StreamFn>
-      ): ReturnType<import("openclaw/plugin-sdk/agent-core").StreamFn> => {
-        void args[2]?.onPayload?.({}, args[0]);
-        return { async *[Symbol.asyncIterator]() {} } as never;
-      },
-    );
-
-    const wrapped = provider.wrapStreamFn?.({
-      provider: "openrouter",
+    const capturedPayload = await captureOpenRouterWrappedPayload({
       modelId: "openrouter/hunter-alpha",
-      streamFn: baseStreamFn,
       thinkingLevel: "high",
-    } as never);
-
-    void wrapped?.(
-      {
-        provider: "openrouter",
-        api: "openai-completions",
-        id: "openrouter/hunter-alpha",
-        compat: {},
-      } as never,
-      { messages: [] } as never,
-      {
-        onPayload: (payload: unknown) => {
-          capturedPayload = payload as Record<string, unknown>;
-          return payload;
-        },
-      } as never,
-    );
-
+      payload: {},
+      forwardPayload: true,
+    });
     expect(capturedPayload).toStrictEqual({});
-    expect(baseStreamFn).toHaveBeenCalledOnce();
   });
 
   it("uses OpenRouter reasoning for DeepSeek V4 replay turns", async () => {
-    const provider = await registerSingleProviderPlugin(openrouterPlugin);
-    let capturedPayload: Record<string, unknown> | undefined;
-    const baseStreamFn = vi.fn(
-      (
-        ...args: Parameters<import("openclaw/plugin-sdk/agent-core").StreamFn>
-      ): ReturnType<import("openclaw/plugin-sdk/agent-core").StreamFn> => {
-        const payload = {
-          messages: [
-            { role: "user", content: "read file" },
-            { role: "assistant", tool_calls: [{ id: "call_1", type: "function" }] },
-            { role: "tool", content: "ok" },
-            { role: "assistant", content: "done" },
-          ],
-        };
-        void args[2]?.onPayload?.(payload, args[0]);
-        capturedPayload = payload;
-        return { async *[Symbol.asyncIterator]() {} } as never;
-      },
-    );
-
-    const wrapped = provider.wrapStreamFn?.({
-      provider: "openrouter",
+    const capturedPayload = await captureOpenRouterWrappedPayload({
       modelId: "deepseek/deepseek-v4-flash",
-      streamFn: baseStreamFn,
       thinkingLevel: "xhigh",
-    } as never);
-
-    void wrapped?.(
-      {
-        provider: "openrouter",
-        api: "openai-completions",
-        id: "deepseek/deepseek-v4-flash",
-        baseUrl: "https://openrouter.ai/api/v1",
-        compat: {},
-      } as never,
-      { messages: [] } as never,
-      {},
-    );
-
+      baseUrl: "https://openrouter.ai/api/v1",
+      payload: {
+        messages: [
+          { role: "user", content: "read file" },
+          { role: "assistant", tool_calls: [{ id: "call_1", type: "function" }] },
+          { role: "tool", content: "ok" },
+          { role: "assistant", content: "done" },
+        ],
+      },
+    });
     expect(capturedPayload?.reasoning).toEqual({ effort: "xhigh" });
     expect(capturedPayload).not.toHaveProperty("thinking");
     expect(capturedPayload).not.toHaveProperty("reasoning_effort");
@@ -927,7 +920,6 @@ describe("openrouter provider hooks", () => {
       { role: "tool", content: "ok" },
       { role: "assistant", content: "done", reasoning_content: "" },
     ]);
-    expect(baseStreamFn).toHaveBeenCalledOnce();
   });
 
   it("clamps OpenRouter DeepSeek V4 reasoning.effort to supported OpenRouter values", async () => {
@@ -979,45 +971,19 @@ describe("openrouter provider hooks", () => {
   });
 
   it("strips disabled OpenRouter DeepSeek V4 reasoning replay fields", async () => {
-    const provider = await registerSingleProviderPlugin(openrouterPlugin);
-    let capturedPayload: Record<string, unknown> | undefined;
-    const baseStreamFn = vi.fn(
-      (
-        ...args: Parameters<import("openclaw/plugin-sdk/agent-core").StreamFn>
-      ): ReturnType<import("openclaw/plugin-sdk/agent-core").StreamFn> => {
-        const payload = {
-          reasoning: { effort: "high" },
-          messages: [{ role: "assistant", content: "done", reasoning_content: "" }],
-        };
-        void args[2]?.onPayload?.(payload, args[0]);
-        capturedPayload = payload;
-        return { async *[Symbol.asyncIterator]() {} } as never;
-      },
-    );
-
-    const wrapped = provider.wrapStreamFn?.({
-      provider: "openrouter",
+    const capturedPayload = await captureOpenRouterWrappedPayload({
       modelId: "openrouter/deepseek/deepseek-v4-pro",
-      streamFn: baseStreamFn,
       thinkingLevel: "off",
-    } as never);
-    void wrapped?.(
-      {
-        provider: "openrouter",
-        api: "openai-completions",
-        id: "openrouter/deepseek/deepseek-v4-pro",
-        baseUrl: "https://openrouter.ai/api/v1",
-        compat: {},
-      } as never,
-      { messages: [] } as never,
-      {},
-    );
-
+      baseUrl: "https://openrouter.ai/api/v1",
+      payload: {
+        reasoning: { effort: "high" },
+        messages: [{ role: "assistant", content: "done", reasoning_content: "" }],
+      },
+    });
     expect(capturedPayload).not.toHaveProperty("reasoning");
     expect(capturedPayload).not.toHaveProperty("thinking");
     expect(capturedPayload).not.toHaveProperty("reasoning_effort");
     expect(capturedPayload?.messages).toEqual([{ role: "assistant", content: "done" }]);
-    expect(baseStreamFn).toHaveBeenCalledOnce();
   });
 
   it("recognizes full OpenRouter DeepSeek V4 refs but skips custom proxy routes", async () => {
@@ -1084,51 +1050,22 @@ describe("openrouter provider hooks", () => {
   });
 
   it("strips OpenRouter-routed Anthropic assistant prefill when reasoning is enabled", async () => {
-    const provider = await registerSingleProviderPlugin(openrouterPlugin);
-    let capturedPayload: Record<string, unknown> | undefined;
-    const baseStreamFn = vi.fn(
-      (
-        ...args: Parameters<import("openclaw/plugin-sdk/agent-core").StreamFn>
-      ): ReturnType<import("openclaw/plugin-sdk/agent-core").StreamFn> => {
-        const payload = {
-          messages: [
-            { role: "user", content: "Return JSON." },
-            { role: "assistant", content: "{" },
-          ],
-        };
-        void args[2]?.onPayload?.(payload, args[0]);
-        capturedPayload = payload;
-        return { async *[Symbol.asyncIterator]() {} } as never;
-      },
-    );
-
-    const wrapped = provider.wrapStreamFn?.({
-      provider: "openrouter",
+    const capturedPayload = await captureOpenRouterWrappedPayload({
       modelId: "anthropic/claude-opus-4.6",
-      streamFn: baseStreamFn,
       thinkingLevel: "high",
-    } as never);
-
-    void wrapped?.(
-      {
-        provider: "openrouter",
-        api: "openai-completions",
-        id: "anthropic/claude-opus-4.6",
-        baseUrl: "https://openrouter.ai/api/v1",
-        compat: {},
-      } as never,
-      { messages: [] } as never,
-      {},
-    );
-
+      baseUrl: "https://openrouter.ai/api/v1",
+      payload: {
+        messages: [
+          { role: "user", content: "Return JSON." },
+          { role: "assistant", content: "{" },
+        ],
+      },
+    });
     expect(capturedPayload?.messages).toEqual([{ role: "user", content: "Return JSON." }]);
     expect(capturedPayload?.reasoning).toEqual({ effort: "high" });
-    expect(baseStreamFn).toHaveBeenCalledOnce();
   });
 
   it("keeps OpenRouter-routed Anthropic tool-use assistant messages when reasoning is enabled", async () => {
-    const provider = await registerSingleProviderPlugin(openrouterPlugin);
-    let capturedPayload: Record<string, unknown> | undefined;
     const messages = [
       { role: "user", content: "Use the tool." },
       {
@@ -1136,39 +1073,14 @@ describe("openrouter provider hooks", () => {
         content: [{ type: "tool_use", id: "toolu_1", name: "lookup", input: {} }],
       },
     ];
-    const baseStreamFn = vi.fn(
-      (
-        ...args: Parameters<import("openclaw/plugin-sdk/agent-core").StreamFn>
-      ): ReturnType<import("openclaw/plugin-sdk/agent-core").StreamFn> => {
-        const payload = { messages: [...messages] };
-        void args[2]?.onPayload?.(payload, args[0]);
-        capturedPayload = payload;
-        return { async *[Symbol.asyncIterator]() {} } as never;
-      },
-    );
-
-    const wrapped = provider.wrapStreamFn?.({
-      provider: "openrouter",
+    const capturedPayload = await captureOpenRouterWrappedPayload({
       modelId: "anthropic/claude-opus-4.6",
-      streamFn: baseStreamFn,
       thinkingLevel: "high",
-    } as never);
-
-    void wrapped?.(
-      {
-        provider: "openrouter",
-        api: "openai-completions",
-        id: "anthropic/claude-opus-4.6",
-        baseUrl: "https://openrouter.ai/api/v1",
-        compat: {},
-      } as never,
-      { messages: [] } as never,
-      {},
-    );
-
+      baseUrl: "https://openrouter.ai/api/v1",
+      payload: { messages: [...messages] },
+    });
     expect(capturedPayload?.messages).toEqual(messages);
     expect(capturedPayload?.reasoning).toEqual({ effort: "high" });
-    expect(baseStreamFn).toHaveBeenCalledOnce();
   });
 
   it("keeps OpenRouter Anthropic prefill when reasoning is disabled or the route is custom", async () => {

--- a/extensions/xai/realtime-voice-provider.test.ts
+++ b/extensions/xai/realtime-voice-provider.test.ts
@@ -126,6 +126,28 @@ function requireSession(socket: FakeWebSocketInstance, index = 0): Record<string
   return session as Record<string, unknown>;
 }
 
+async function openRealtimeBridge(
+  bridge: ReturnType<ReturnType<typeof buildXaiRealtimeVoiceProvider>["createBridge"]>,
+  index = 0,
+  conversationId?: string,
+) {
+  const connecting = bridge.connect();
+  await waitForRealtimeState(() => expect(FakeWebSocket.instances.length).toBe(index + 1));
+  const socket = requireSocket(index);
+  socket.readyState = FakeWebSocket.OPEN;
+  socket.emit("open");
+  if (conversationId) {
+    socket.emit(
+      "message",
+      Buffer.from(
+        JSON.stringify({ type: "conversation.created", conversation: { id: conversationId } }),
+      ),
+    );
+  }
+  socket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+  return { connecting, socket };
+}
+
 describe("buildXaiRealtimeVoiceProvider", () => {
   beforeEach(() => {
     FakeWebSocket.instances = [];
@@ -198,12 +220,7 @@ describe("buildXaiRealtimeVoiceProvider", () => {
       onClearAudio: vi.fn(),
     });
 
-    void bridge.connect();
-    await waitForRealtimeState(() => expect(FakeWebSocket.instances.length).toBe(1));
-    const socket = requireSocket();
-    socket.readyState = FakeWebSocket.OPEN;
-    socket.emit("open");
-    socket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+    const { socket } = await openRealtimeBridge(bridge);
     bridge.close();
 
     const url = socket.args[0] as string;
@@ -237,12 +254,7 @@ describe("buildXaiRealtimeVoiceProvider", () => {
       onClearAudio: vi.fn(),
     });
 
-    void bridge.connect();
-    await waitForRealtimeState(() => expect(FakeWebSocket.instances.length).toBe(1));
-    const socket = requireSocket();
-    socket.readyState = FakeWebSocket.OPEN;
-    socket.emit("open");
-    socket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+    const { socket } = await openRealtimeBridge(bridge);
     bridge.close();
 
     expect(requireSession(socket).resumption).toBeUndefined();
@@ -287,12 +299,7 @@ describe("buildXaiRealtimeVoiceProvider", () => {
       onClearAudio: vi.fn(),
     });
 
-    void bridge.connect();
-    await waitForRealtimeState(() => expect(FakeWebSocket.instances.length).toBe(1));
-    const socket = requireSocket();
-    socket.readyState = FakeWebSocket.OPEN;
-    socket.emit("open");
-    socket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+    const { socket } = await openRealtimeBridge(bridge);
     bridge.close();
 
     const session = requireSession(socket);
@@ -307,62 +314,30 @@ describe("buildXaiRealtimeVoiceProvider", () => {
 
   it("only forwards xAI VAD values accepted by the realtime API", async () => {
     const provider = buildXaiRealtimeVoiceProvider();
-    const invalidThresholdBridge = provider.createBridge({
-      providerConfig: {
-        apiKey: "xai-test", // pragma: allowlist secret
-        vadThreshold: 1,
-        silenceDurationMs: 10_001,
-        prefixPaddingMs: -1,
+    const cases = [
+      {
+        options: { vadThreshold: 1, silenceDurationMs: 10_001, prefixPaddingMs: -1 },
+        expected: { threshold: 0.85, silence_duration_ms: 500, prefix_padding_ms: 333 },
       },
-      onAudio: vi.fn(),
-      onClearAudio: vi.fn(),
-    });
-
-    void invalidThresholdBridge.connect();
-    await waitForRealtimeState(() => expect(FakeWebSocket.instances.length).toBe(1));
-    const invalidThresholdSocket = requireSocket();
-    invalidThresholdSocket.readyState = FakeWebSocket.OPEN;
-    invalidThresholdSocket.emit("open");
-    invalidThresholdSocket.emit(
-      "message",
-      Buffer.from(JSON.stringify({ type: "session.updated" })),
-    );
-    invalidThresholdBridge.close();
-
-    expect(requireSession(invalidThresholdSocket).turn_detection).toEqual(
-      expect.objectContaining({
-        threshold: 0.85,
-        silence_duration_ms: 500,
-        prefix_padding_ms: 333,
-      }),
-    );
-
-    const validThresholdBridge = provider.createBridge({
-      providerConfig: {
-        apiKey: "xai-test", // pragma: allowlist secret
-        vadThreshold: 0.9,
-        silenceDurationMs: 10_000,
-        prefixPaddingMs: 0,
+      {
+        options: { vadThreshold: 0.9, silenceDurationMs: 10_000, prefixPaddingMs: 0 },
+        expected: { threshold: 0.9, silence_duration_ms: 10_000, prefix_padding_ms: 0 },
       },
-      onAudio: vi.fn(),
-      onClearAudio: vi.fn(),
-    });
+    ];
 
-    void validThresholdBridge.connect();
-    await waitForRealtimeState(() => expect(FakeWebSocket.instances.length).toBe(2));
-    const validThresholdSocket = requireSocket(1);
-    validThresholdSocket.readyState = FakeWebSocket.OPEN;
-    validThresholdSocket.emit("open");
-    validThresholdSocket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
-    validThresholdBridge.close();
-
-    expect(requireSession(validThresholdSocket).turn_detection).toEqual(
-      expect.objectContaining({
-        threshold: 0.9,
-        silence_duration_ms: 10_000,
-        prefix_padding_ms: 0,
-      }),
-    );
+    for (const [index, { options, expected }] of cases.entries()) {
+      const bridge = provider.createBridge({
+        providerConfig: {
+          apiKey: "xai-test", // pragma: allowlist secret
+          ...options,
+        },
+        onAudio: vi.fn(),
+        onClearAudio: vi.fn(),
+      });
+      const { socket } = await openRealtimeBridge(bridge, index);
+      bridge.close();
+      expect(requireSession(socket).turn_detection).toEqual(expect.objectContaining(expected));
+    }
   });
 
   it("only forwards reasoning efforts accepted by the xAI Voice Agent API", async () => {
@@ -387,12 +362,7 @@ describe("buildXaiRealtimeVoiceProvider", () => {
       ...callbacks,
     });
 
-    void bridge.connect();
-    await waitForRealtimeState(() => expect(FakeWebSocket.instances.length).toBe(1));
-    const socket = requireSocket();
-    socket.readyState = FakeWebSocket.OPEN;
-    socket.emit("open");
-    socket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+    const { socket } = await openRealtimeBridge(bridge);
     bridge.close();
 
     expect(requireSession(socket).reasoning).toEqual({ effort: "none" });
@@ -408,12 +378,7 @@ describe("buildXaiRealtimeVoiceProvider", () => {
       onTranscript,
     });
 
-    const connecting = bridge.connect();
-    await waitForRealtimeState(() => expect(FakeWebSocket.instances.length).toBe(1));
-    const socket = requireSocket();
-    socket.readyState = FakeWebSocket.OPEN;
-    socket.emit("open");
-    socket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+    const { connecting, socket } = await openRealtimeBridge(bridge);
     await connecting;
 
     socket.emit(
@@ -462,12 +427,7 @@ describe("buildXaiRealtimeVoiceProvider", () => {
       onTranscript,
     });
 
-    const connecting = bridge.connect();
-    await waitForRealtimeState(() => expect(FakeWebSocket.instances.length).toBe(1));
-    const socket = requireSocket();
-    socket.readyState = FakeWebSocket.OPEN;
-    socket.emit("open");
-    socket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+    const { connecting, socket } = await openRealtimeBridge(bridge);
     await connecting;
 
     socket.emit("message", Buffer.from(JSON.stringify({ type: "response.created" })));
@@ -502,373 +462,144 @@ describe("buildXaiRealtimeVoiceProvider", () => {
     expect(onTranscript).toHaveBeenCalledTimes(3);
   });
 
-  it("lets server VAD own interruption before an audio item exists", async () => {
-    vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret
-    const provider = buildXaiRealtimeVoiceProvider();
-    const onClearAudio = vi.fn();
-    const bridge = provider.createBridge({
-      providerConfig: { apiKey: "xai-test" }, // pragma: allowlist secret
-      audioFormat: REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ,
-      onAudio: vi.fn(),
-      onClearAudio,
-    });
+  it.each([
+    {
+      name: "lets server VAD own interruption before an audio item exists",
+      hasAudio: false,
+      timestamp: 1000,
+      expectedActions: [],
+    },
+    {
+      name: "cancels and truncates active response audio on barge-in",
+      hasAudio: true,
+      manual: true,
+      timestamp: 1300,
+      expectedActions: [
+        { type: "response.cancel" },
+        {
+          type: "conversation.item.truncate",
+          item_id: "item_1",
+          content_index: 0,
+          audio_end_ms: 300,
+        },
+      ],
+    },
+    {
+      name: "truncates queued playback on server-VAD barge-in without cancelling xAI",
+      hasAudio: true,
+      timestamp: 1250,
+      expectedActions: [
+        {
+          type: "conversation.item.truncate",
+          item_id: "item_1",
+          content_index: 0,
+          audio_end_ms: 250,
+        },
+      ],
+    },
+    {
+      name: "clears relay playback on server-VAD barge-in after marks are acknowledged",
+      hasAudio: true,
+      acknowledged: true,
+      timestamp: 1250,
+      expectedActions: [],
+    },
+    {
+      name: "does not truncate completed assistant audio on a later user turn",
+      hasAudio: true,
+      acknowledged: true,
+      completed: true,
+      timestamp: 2000,
+      expectedActions: [],
+    },
+    {
+      name: "keeps completed assistant item state so relay playback cancel can truncate it",
+      hasAudio: true,
+      acknowledged: true,
+      completed: true,
+      manual: true,
+      timestamp: 1300,
+      expectedActions: [
+        {
+          type: "conversation.item.truncate",
+          item_id: "item_1",
+          content_index: 0,
+          audio_end_ms: 300,
+        },
+      ],
+    },
+    {
+      name: "lets server VAD interrupt a new response before it produces audio",
+      hasAudio: true,
+      acknowledged: true,
+      completed: true,
+      startNewResponse: true,
+      timestamp: 1500,
+      expectedActions: [],
+    },
+  ])(
+    "$name",
+    async ({
+      hasAudio,
+      acknowledged,
+      completed,
+      startNewResponse,
+      manual,
+      timestamp,
+      expectedActions,
+    }) => {
+      vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret
+      const onAudio = vi.fn();
+      const onClearAudio = vi.fn();
+      const bridge = buildXaiRealtimeVoiceProvider().createBridge({
+        providerConfig: { apiKey: "xai-test" }, // pragma: allowlist secret
+        audioFormat: REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ,
+        onAudio,
+        onClearAudio,
+      });
+      const { socket } = await openRealtimeBridge(bridge);
+      const emit = (event: Record<string, unknown>) =>
+        socket.emit("message", Buffer.from(JSON.stringify(event)));
 
-    void bridge.connect();
-    await waitForRealtimeState(() => expect(FakeWebSocket.instances.length).toBe(1));
-    const socket = requireSocket();
-    socket.readyState = FakeWebSocket.OPEN;
-    socket.emit("open");
-    socket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
-    socket.emit(
-      "message",
-      Buffer.from(
-        JSON.stringify({
-          type: "response.created",
-          response: { id: "resp_1" },
-        }),
-      ),
-    );
-    socket.emit(
-      "message",
-      Buffer.from(JSON.stringify({ type: "input_audio_buffer.speech_started" })),
-    );
-    bridge.close();
-
-    const sentTypes = parseSent(socket).map((event) => event.type);
-    expect(sentTypes).not.toContain("response.cancel");
-    expect(sentTypes).not.toContain("conversation.item.truncate");
-    expect(onClearAudio).toHaveBeenCalledWith("barge-in");
-  });
-
-  it("cancels and truncates active response audio on barge-in", async () => {
-    vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret
-    const provider = buildXaiRealtimeVoiceProvider();
-    const onAudio = vi.fn();
-    const onClearAudio = vi.fn();
-    const bridge = provider.createBridge({
-      providerConfig: { apiKey: "xai-test" }, // pragma: allowlist secret
-      audioFormat: REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ,
-      onAudio,
-      onClearAudio,
-    });
-
-    void bridge.connect();
-    await waitForRealtimeState(() => expect(FakeWebSocket.instances.length).toBe(1));
-    const socket = requireSocket();
-    socket.readyState = FakeWebSocket.OPEN;
-    socket.emit("open");
-    socket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
-    socket.emit(
-      "message",
-      Buffer.from(
-        JSON.stringify({
-          type: "response.created",
-          response: { id: "resp_1" },
-        }),
-      ),
-    );
-    bridge.setMediaTimestamp(1000);
-    socket.emit(
-      "message",
-      Buffer.from(
-        JSON.stringify({
+      emit({ type: "response.created", response: { id: "resp_1" } });
+      if (hasAudio) {
+        bridge.setMediaTimestamp(1000);
+        emit({
           type: "response.output_audio.delta",
           item_id: "item_1",
           delta: Buffer.from("assistant audio").toString("base64"),
-        }),
-      ),
-    );
-    bridge.setMediaTimestamp(1300);
-    bridge.handleBargeIn?.({ audioPlaybackActive: true });
-    bridge.close();
+        });
+      }
+      if (acknowledged) {
+        bridge.acknowledgeMark?.();
+      }
+      if (completed) {
+        emit({ type: "response.done" });
+      }
+      if (startNewResponse) {
+        emit({ type: "response.created", response: { id: "resp_2" } });
+      }
+      bridge.setMediaTimestamp(timestamp);
+      if (manual) {
+        bridge.handleBargeIn?.({ audioPlaybackActive: true });
+      } else {
+        emit({ type: "input_audio_buffer.speech_started" });
+      }
+      bridge.close();
 
-    expect(onAudio).toHaveBeenCalledTimes(1);
-    expect(onClearAudio).toHaveBeenCalledTimes(1);
-    expect(parseSent(socket).slice(-2)).toEqual([
-      { type: "response.cancel" },
-      {
-        type: "conversation.item.truncate",
-        item_id: "item_1",
-        content_index: 0,
-        audio_end_ms: 300,
-      },
-    ]);
-  });
-
-  it("truncates queued playback on server-VAD barge-in without cancelling xAI", async () => {
-    vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret
-    const provider = buildXaiRealtimeVoiceProvider();
-    const onClearAudio = vi.fn();
-    const bridge = provider.createBridge({
-      providerConfig: { apiKey: "xai-test" }, // pragma: allowlist secret
-      audioFormat: REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ,
-      onAudio: vi.fn(),
-      onClearAudio,
-    });
-
-    void bridge.connect();
-    await waitForRealtimeState(() => expect(FakeWebSocket.instances.length).toBe(1));
-    const socket = requireSocket();
-    socket.readyState = FakeWebSocket.OPEN;
-    socket.emit("open");
-    socket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
-    socket.emit(
-      "message",
-      Buffer.from(
-        JSON.stringify({
-          type: "response.created",
-          response: { id: "resp_1" },
-        }),
-      ),
-    );
-    bridge.setMediaTimestamp(1000);
-    socket.emit(
-      "message",
-      Buffer.from(
-        JSON.stringify({
-          type: "response.output_audio.delta",
-          item_id: "item_1",
-          delta: Buffer.from("assistant audio").toString("base64"),
-        }),
-      ),
-    );
-    bridge.setMediaTimestamp(1250);
-    socket.emit(
-      "message",
-      Buffer.from(JSON.stringify({ type: "input_audio_buffer.speech_started" })),
-    );
-    bridge.close();
-
-    const sent = parseSent(socket);
-    expect(sent.map((event) => event.type)).not.toContain("response.cancel");
-    expect(sent.slice(-1)).toEqual([
-      {
-        type: "conversation.item.truncate",
-        item_id: "item_1",
-        content_index: 0,
-        audio_end_ms: 250,
-      },
-    ]);
-    expect(onClearAudio).toHaveBeenCalledWith("barge-in");
-  });
-
-  it("clears relay playback on server-VAD barge-in after marks are acknowledged", async () => {
-    vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret
-    const provider = buildXaiRealtimeVoiceProvider();
-    const onClearAudio = vi.fn();
-    const bridge = provider.createBridge({
-      providerConfig: { apiKey: "xai-test" }, // pragma: allowlist secret
-      audioFormat: REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ,
-      onAudio: vi.fn(),
-      onClearAudio,
-    });
-
-    void bridge.connect();
-    await waitForRealtimeState(() => expect(FakeWebSocket.instances.length).toBe(1));
-    const socket = requireSocket();
-    socket.readyState = FakeWebSocket.OPEN;
-    socket.emit("open");
-    socket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
-    socket.emit(
-      "message",
-      Buffer.from(
-        JSON.stringify({
-          type: "response.created",
-          response: { id: "resp_1" },
-        }),
-      ),
-    );
-    bridge.setMediaTimestamp(1000);
-    socket.emit(
-      "message",
-      Buffer.from(
-        JSON.stringify({
-          type: "response.output_audio.delta",
-          item_id: "item_1",
-          delta: Buffer.from("assistant audio").toString("base64"),
-        }),
-      ),
-    );
-    bridge.acknowledgeMark?.();
-    bridge.setMediaTimestamp(1250);
-    socket.emit(
-      "message",
-      Buffer.from(JSON.stringify({ type: "input_audio_buffer.speech_started" })),
-    );
-    bridge.close();
-
-    const sentTypes = parseSent(socket).map((event) => event.type);
-    expect(sentTypes).not.toContain("response.cancel");
-    expect(sentTypes).not.toContain("conversation.item.truncate");
-    expect(onClearAudio).toHaveBeenCalledWith("barge-in");
-  });
-
-  it("does not truncate completed assistant audio on a later user turn", async () => {
-    vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret
-    const provider = buildXaiRealtimeVoiceProvider();
-    const onClearAudio = vi.fn();
-    const bridge = provider.createBridge({
-      providerConfig: { apiKey: "xai-test" }, // pragma: allowlist secret
-      audioFormat: REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ,
-      onAudio: vi.fn(),
-      onClearAudio,
-    });
-
-    void bridge.connect();
-    await waitForRealtimeState(() => expect(FakeWebSocket.instances.length).toBe(1));
-    const socket = requireSocket();
-    socket.readyState = FakeWebSocket.OPEN;
-    socket.emit("open");
-    socket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
-    socket.emit(
-      "message",
-      Buffer.from(
-        JSON.stringify({
-          type: "response.created",
-          response: { id: "resp_1" },
-        }),
-      ),
-    );
-    bridge.setMediaTimestamp(1000);
-    socket.emit(
-      "message",
-      Buffer.from(
-        JSON.stringify({
-          type: "response.output_audio.delta",
-          item_id: "item_1",
-          delta: Buffer.from("assistant audio").toString("base64"),
-        }),
-      ),
-    );
-    bridge.acknowledgeMark?.();
-    socket.emit("message", Buffer.from(JSON.stringify({ type: "response.done" })));
-    bridge.setMediaTimestamp(2000);
-    socket.emit(
-      "message",
-      Buffer.from(JSON.stringify({ type: "input_audio_buffer.speech_started" })),
-    );
-    bridge.close();
-
-    const sentTypes = parseSent(socket).map((event) => event.type);
-    expect(sentTypes).not.toContain("response.cancel");
-    expect(sentTypes).not.toContain("conversation.item.truncate");
-    expect(onClearAudio).toHaveBeenCalledTimes(1);
-  });
-
-  it("keeps completed assistant item state so relay playback cancel can truncate it", async () => {
-    vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret
-    const provider = buildXaiRealtimeVoiceProvider();
-    const onClearAudio = vi.fn();
-    const bridge = provider.createBridge({
-      providerConfig: { apiKey: "xai-test" }, // pragma: allowlist secret
-      audioFormat: REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ,
-      onAudio: vi.fn(),
-      onClearAudio,
-    });
-
-    void bridge.connect();
-    await waitForRealtimeState(() => expect(FakeWebSocket.instances.length).toBe(1));
-    const socket = requireSocket();
-    socket.readyState = FakeWebSocket.OPEN;
-    socket.emit("open");
-    socket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
-    socket.emit(
-      "message",
-      Buffer.from(
-        JSON.stringify({
-          type: "response.created",
-          response: { id: "resp_1" },
-        }),
-      ),
-    );
-    bridge.setMediaTimestamp(1000);
-    socket.emit(
-      "message",
-      Buffer.from(
-        JSON.stringify({
-          type: "response.output_audio.delta",
-          item_id: "item_1",
-          delta: Buffer.from("assistant audio").toString("base64"),
-        }),
-      ),
-    );
-    bridge.acknowledgeMark?.();
-    socket.emit("message", Buffer.from(JSON.stringify({ type: "response.done" })));
-    bridge.setMediaTimestamp(1300);
-    bridge.handleBargeIn?.({ audioPlaybackActive: true });
-    bridge.close();
-
-    expect(onClearAudio).toHaveBeenCalledTimes(1);
-    expect(parseSent(socket).slice(-1)).toEqual([
-      {
-        type: "conversation.item.truncate",
-        item_id: "item_1",
-        content_index: 0,
-        audio_end_ms: 300,
-      },
-    ]);
-  });
-
-  it("lets server VAD interrupt a new response before it produces audio", async () => {
-    vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret
-    const provider = buildXaiRealtimeVoiceProvider();
-    const onClearAudio = vi.fn();
-    const bridge = provider.createBridge({
-      providerConfig: { apiKey: "xai-test" }, // pragma: allowlist secret
-      audioFormat: REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ,
-      onAudio: vi.fn(),
-      onClearAudio,
-    });
-
-    void bridge.connect();
-    await waitForRealtimeState(() => expect(FakeWebSocket.instances.length).toBe(1));
-    const socket = requireSocket();
-    socket.readyState = FakeWebSocket.OPEN;
-    socket.emit("open");
-    socket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
-    socket.emit(
-      "message",
-      Buffer.from(
-        JSON.stringify({
-          type: "response.created",
-          response: { id: "resp_1" },
-        }),
-      ),
-    );
-    bridge.setMediaTimestamp(1000);
-    socket.emit(
-      "message",
-      Buffer.from(
-        JSON.stringify({
-          type: "response.output_audio.delta",
-          item_id: "item_1",
-          delta: Buffer.from("assistant audio").toString("base64"),
-        }),
-      ),
-    );
-    bridge.acknowledgeMark?.();
-    socket.emit("message", Buffer.from(JSON.stringify({ type: "response.done" })));
-    socket.emit(
-      "message",
-      Buffer.from(
-        JSON.stringify({
-          type: "response.created",
-          response: { id: "resp_2" },
-        }),
-      ),
-    );
-    bridge.setMediaTimestamp(1500);
-    socket.emit(
-      "message",
-      Buffer.from(JSON.stringify({ type: "input_audio_buffer.speech_started" })),
-    );
-    bridge.close();
-
-    const sentTypes = parseSent(socket).map((event) => event.type);
-    expect(sentTypes).not.toContain("response.cancel");
-    expect(sentTypes).not.toContain("conversation.item.truncate");
-    expect(onClearAudio).toHaveBeenCalledWith("barge-in");
-  });
+      expect(onAudio).toHaveBeenCalledTimes(hasAudio ? 1 : 0);
+      expect(onClearAudio).toHaveBeenCalledTimes(1);
+      if (!manual) {
+        expect(onClearAudio).toHaveBeenCalledWith("barge-in");
+      }
+      expect(
+        parseSent(socket).filter(
+          (event) =>
+            event.type === "response.cancel" || event.type === "conversation.item.truncate",
+        ),
+      ).toEqual(expectedActions);
+    },
+  );
 
   it("deduplicates repeated function-call arguments done events", async () => {
     vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret
@@ -881,12 +612,7 @@ describe("buildXaiRealtimeVoiceProvider", () => {
       onToolCall,
     });
 
-    const connecting = bridge.connect();
-    await waitForRealtimeState(() => expect(FakeWebSocket.instances.length).toBe(1));
-    const socket = requireSocket();
-    socket.readyState = FakeWebSocket.OPEN;
-    socket.emit("open");
-    socket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+    const { connecting, socket } = await openRealtimeBridge(bridge);
     await connecting;
 
     socket.emit(
@@ -944,12 +670,7 @@ describe("buildXaiRealtimeVoiceProvider", () => {
       onToolCall: vi.fn(),
     });
 
-    const connecting = bridge.connect();
-    await waitForRealtimeState(() => expect(FakeWebSocket.instances.length).toBe(1));
-    const socket = requireSocket();
-    socket.readyState = FakeWebSocket.OPEN;
-    socket.emit("open");
-    socket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+    const { connecting, socket } = await openRealtimeBridge(bridge);
     await connecting;
 
     for (const callId of ["call_1", "call_2"]) {
@@ -994,12 +715,7 @@ describe("buildXaiRealtimeVoiceProvider", () => {
       onToolCall: vi.fn(),
     });
 
-    const connecting = bridge.connect();
-    await waitForRealtimeState(() => expect(FakeWebSocket.instances.length).toBe(1));
-    const socket = requireSocket();
-    socket.readyState = FakeWebSocket.OPEN;
-    socket.emit("open");
-    socket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+    const { connecting, socket } = await openRealtimeBridge(bridge);
     await connecting;
 
     socket.emit(
@@ -1046,12 +762,7 @@ describe("buildXaiRealtimeVoiceProvider", () => {
       onMark,
     });
 
-    const connecting = bridge.connect();
-    await waitForRealtimeState(() => expect(FakeWebSocket.instances.length).toBe(1));
-    const socket = requireSocket();
-    socket.readyState = FakeWebSocket.OPEN;
-    socket.emit("open");
-    socket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+    const { connecting, socket } = await openRealtimeBridge(bridge);
     await connecting;
 
     socket.emit("message", Buffer.from(JSON.stringify({ type: "response.created" })));
@@ -1102,18 +813,7 @@ describe("buildXaiRealtimeVoiceProvider", () => {
       onToolCall: vi.fn(),
     });
 
-    const connecting = bridge.connect();
-    await waitForRealtimeState(() => expect(FakeWebSocket.instances.length).toBe(1));
-    const firstSocket = requireSocket();
-    firstSocket.readyState = FakeWebSocket.OPEN;
-    firstSocket.emit("open");
-    firstSocket.emit(
-      "message",
-      Buffer.from(
-        JSON.stringify({ type: "conversation.created", conversation: { id: "conv_tools" } }),
-      ),
-    );
-    firstSocket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+    const { connecting, socket: firstSocket } = await openRealtimeBridge(bridge, 0, "conv_tools");
     await connecting;
 
     for (const callId of ["call_1", "call_2"]) {
@@ -1170,18 +870,7 @@ describe("buildXaiRealtimeVoiceProvider", () => {
       onToolCall,
     });
 
-    const connecting = bridge.connect();
-    await waitForRealtimeState(() => expect(FakeWebSocket.instances.length).toBe(1));
-    const firstSocket = requireSocket();
-    firstSocket.readyState = FakeWebSocket.OPEN;
-    firstSocket.emit("open");
-    firstSocket.emit(
-      "message",
-      Buffer.from(
-        JSON.stringify({ type: "conversation.created", conversation: { id: "conv_replay" } }),
-      ),
-    );
-    firstSocket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+    const { connecting, socket: firstSocket } = await openRealtimeBridge(bridge, 0, "conv_replay");
     await connecting;
 
     firstSocket.close(1006, "connection lost");
@@ -1231,18 +920,11 @@ describe("buildXaiRealtimeVoiceProvider", () => {
       onClose,
     });
 
-    const connecting = bridge.connect();
-    await waitForRealtimeState(() => expect(FakeWebSocket.instances.length).toBe(1));
-    const firstSocket = requireSocket();
-    firstSocket.readyState = FakeWebSocket.OPEN;
-    firstSocket.emit("open");
-    firstSocket.emit(
-      "message",
-      Buffer.from(
-        JSON.stringify({ type: "conversation.created", conversation: { id: "conv_lost_output" } }),
-      ),
+    const { connecting, socket: firstSocket } = await openRealtimeBridge(
+      bridge,
+      0,
+      "conv_lost_output",
     );
-    firstSocket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
     await connecting;
     firstSocket.emit(
       "message",
@@ -1284,18 +966,11 @@ describe("buildXaiRealtimeVoiceProvider", () => {
       onToolCall,
     });
 
-    const connecting = bridge.connect();
-    await waitForRealtimeState(() => expect(FakeWebSocket.instances.length).toBe(1));
-    const firstSocket = requireSocket();
-    firstSocket.readyState = FakeWebSocket.OPEN;
-    firstSocket.emit("open");
-    firstSocket.emit(
-      "message",
-      Buffer.from(
-        JSON.stringify({ type: "conversation.created", conversation: { id: "conv_saved_output" } }),
-      ),
+    const { connecting, socket: firstSocket } = await openRealtimeBridge(
+      bridge,
+      0,
+      "conv_saved_output",
     );
-    firstSocket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
     await connecting;
     firstSocket.emit(
       "message",
@@ -1372,18 +1047,11 @@ describe("buildXaiRealtimeVoiceProvider", () => {
       onToolCall: vi.fn(),
     });
 
-    const connecting = bridge.connect();
-    await waitForRealtimeState(() => expect(FakeWebSocket.instances.length).toBe(1));
-    const firstSocket = requireSocket();
-    firstSocket.readyState = FakeWebSocket.OPEN;
-    firstSocket.emit("open");
-    firstSocket.emit(
-      "message",
-      Buffer.from(
-        JSON.stringify({ type: "conversation.created", conversation: { id: "conv_tool_queue" } }),
-      ),
+    const { connecting, socket: firstSocket } = await openRealtimeBridge(
+      bridge,
+      0,
+      "conv_tool_queue",
     );
-    firstSocket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
     await connecting;
 
     for (const callId of ["call_1", "call_2"]) {
@@ -1452,18 +1120,11 @@ describe("buildXaiRealtimeVoiceProvider", () => {
       onClearAudio: vi.fn(),
     });
 
-    const connecting = bridge.connect();
-    await waitForRealtimeState(() => expect(FakeWebSocket.instances.length).toBe(1));
-    const firstSocket = requireSocket();
-    firstSocket.readyState = FakeWebSocket.OPEN;
-    firstSocket.emit("open");
-    firstSocket.emit(
-      "message",
-      Buffer.from(
-        JSON.stringify({ type: "conversation.created", conversation: { id: "conv_text_queue" } }),
-      ),
+    const { connecting, socket: firstSocket } = await openRealtimeBridge(
+      bridge,
+      0,
+      "conv_text_queue",
     );
-    firstSocket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
     await connecting;
 
     firstSocket.close(1006, "connection lost");
@@ -1508,18 +1169,11 @@ describe("buildXaiRealtimeVoiceProvider", () => {
       onClose,
     });
 
-    const connecting = bridge.connect();
-    await waitForRealtimeState(() => expect(FakeWebSocket.instances.length).toBe(1));
-    const firstSocket = requireSocket();
-    firstSocket.readyState = FakeWebSocket.OPEN;
-    firstSocket.emit("open");
-    firstSocket.emit(
-      "message",
-      Buffer.from(
-        JSON.stringify({ type: "conversation.created", conversation: { id: "conv_reconnect" } }),
-      ),
+    const { connecting, socket: firstSocket } = await openRealtimeBridge(
+      bridge,
+      0,
+      "conv_reconnect",
     );
-    firstSocket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
     await connecting;
 
     firstSocket.close(1006, "connection lost");
@@ -1557,18 +1211,7 @@ describe("buildXaiRealtimeVoiceProvider", () => {
       onReady,
     });
 
-    const connecting = bridge.connect();
-    await waitForRealtimeState(() => expect(FakeWebSocket.instances.length).toBe(1));
-    const firstSocket = requireSocket();
-    firstSocket.readyState = FakeWebSocket.OPEN;
-    firstSocket.emit("open");
-    firstSocket.emit(
-      "message",
-      Buffer.from(
-        JSON.stringify({ type: "conversation.created", conversation: { id: "conv_ready" } }),
-      ),
-    );
-    firstSocket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+    const { connecting, socket: firstSocket } = await openRealtimeBridge(bridge, 0, "conv_ready");
     await connecting;
 
     firstSocket.close(1006, "connection lost");
@@ -1596,18 +1239,7 @@ describe("buildXaiRealtimeVoiceProvider", () => {
       onError,
     });
 
-    const connecting = bridge.connect();
-    await waitForRealtimeState(() => expect(FakeWebSocket.instances.length).toBe(1));
-    const firstSocket = requireSocket();
-    firstSocket.readyState = FakeWebSocket.OPEN;
-    firstSocket.emit("open");
-    firstSocket.emit(
-      "message",
-      Buffer.from(
-        JSON.stringify({ type: "conversation.created", conversation: { id: "conv_close" } }),
-      ),
-    );
-    firstSocket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+    const { connecting, socket: firstSocket } = await openRealtimeBridge(bridge, 0, "conv_close");
     await connecting;
 
     firstSocket.close(1006, "connection lost");
@@ -1685,12 +1317,7 @@ describe("buildXaiRealtimeVoiceProvider", () => {
       onClose,
     });
 
-    const connecting = bridge.connect();
-    await waitForRealtimeState(() => expect(FakeWebSocket.instances.length).toBe(1));
-    const socket = requireSocket();
-    socket.readyState = FakeWebSocket.OPEN;
-    socket.emit("open");
-    socket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+    const { connecting, socket } = await openRealtimeBridge(bridge);
     await connecting;
 
     socket.close(1006, "connection lost");
@@ -1720,18 +1347,7 @@ describe("buildXaiRealtimeVoiceProvider", () => {
       onClose,
     });
 
-    const connecting = bridge.connect();
-    await waitForRealtimeState(() => expect(FakeWebSocket.instances.length).toBe(1));
-    const socket = requireSocket();
-    socket.readyState = FakeWebSocket.OPEN;
-    socket.emit("open");
-    socket.emit(
-      "message",
-      Buffer.from(
-        JSON.stringify({ type: "conversation.created", conversation: { id: "conv_default" } }),
-      ),
-    );
-    socket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+    const { connecting, socket } = await openRealtimeBridge(bridge, 0, "conv_default");
     await connecting;
 
     socket.close(1006, "connection lost");
@@ -1790,12 +1406,7 @@ describe("buildXaiRealtimeVoiceProvider", () => {
       onClearAudio: vi.fn(),
     });
 
-    void bridge.connect();
-    await waitForRealtimeState(() => expect(FakeWebSocket.instances.length).toBe(1));
-    const socket = requireSocket();
-    socket.readyState = FakeWebSocket.OPEN;
-    socket.emit("open");
-    socket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+    const { socket } = await openRealtimeBridge(bridge);
     bridge.close();
 
     const session = requireSession(socket);


### PR DESCRIPTION
## What Problem This Solves\n\nProvider setup, catalog, reasoning, authentication, and realtime voice tests repeated large model fixtures and xAI socket/reconnection setup, obscuring which compatibility and security behaviors each scenario actually proves.\n\n## Why This Change Was Made\n\nUse provider-local helpers and individually named case tables to consolidate equivalent setup while preserving every original scenario, production source-coverage count, and provider boundary. No production code, authentication or provider configuration, dependencies, coverage configuration, protected baseline or inventory, or grandfathered lint suppression is changed.\n\n## User Impact\n\nNo runtime or user-visible behavior change. The four provider suites retain all 190 named regression cases, remove a net 808 lines, and complete their measured focused coverage run about 46% faster.\n\n## Evidence\n\n- Pinned before/after baseline: 16d2b7e46784c75eb5d57329269e9fd47222d2ef.\n- Same four existing provider tests: 190 passed before and 190 passed after.\n- Production statements: 1610/6375 before and after.\n- Production branches: 1274/5628 before and after.\n- Production functions: 309/1222 before and after.\n- Production lines: 1594/6300 before and after.\n- Identical focused coverage command on the same remote box: 13.72 seconds before, 7.44 seconds after.\n- Complete remote changed-code gate passed, including grandfathered max-lines ratchet, plugin boundaries, formatting, extension-test TypeScript, and changed-file lint with zero warnings and zero errors; timing JSON confirmed exitCode 0.\n- Fresh independent autoreview passed with no accepted or actionable findings.\n- Protected max-lines baseline and grandfathered OpenRouter suppression are unchanged.\n- AI-assisted refactor; only four existing provider test files are modified.