### PR TITLE
refactor(ai): unify Responses transport factories

### DIFF
--- a/packages/ai/src/transports/openai-responses-client.ts
+++ b/packages/ai/src/transports/openai-responses-client.ts
@@ -222,7 +222,8 @@ function createResponsesTransportExecutor(config: ResponsesTransportExecutorOpti
           model,
           {
             ...config.pricingOptions?.(responsesOptions),
-            firstEventTimeoutMs: getFirstStreamEventTimeoutMs(options) ?? config.firstEventTimeoutMs,
+            firstEventTimeoutMs:
+              getFirstStreamEventTimeoutMs(options) ?? config.firstEventTimeoutMs,
             abortFirstEventStream: firstEventAbort.abort,
             onFirstEventTimeout: getFirstStreamEventTimeoutHandler(options),
             signal: options?.signal,

--- a/packages/ai/src/transports/openai-responses-client.ts
+++ b/packages/ai/src/transports/openai-responses-client.ts
@@ -105,7 +105,32 @@ export function createOpenAIResponsesClient(
   });
 }
 
-export function createOpenAIResponsesTransportStreamFn(): StreamFn {
+type ResponsesPricingOptions = Pick<
+  NonNullable<Parameters<typeof processResponsesStream>[4]>,
+  "serviceTier" | "applyServiceTierPricing"
+>;
+type ResponsesStreamParams = Parameters<
+  typeof createResponsesStreamWithEncryptedContentRetry
+>[0] & {
+  requestOptions: ReturnType<typeof buildOpenAISdkRequestOptions>;
+};
+
+type ResponsesTransportExecutorOptions = {
+  outputApi?: AssistantMessage["api"];
+  firstEventTimeoutMs?: number;
+  streamRequest?: boolean;
+  createClient: typeof createOpenAIResponsesClient;
+  buildRequest: (
+    model: Model,
+    context: Context,
+    options: OpenAIResponsesOptions | undefined,
+    metadata?: Record<string, string>,
+  ) => ReturnType<typeof buildOpenAIResponsesParams>;
+  createResponseStream: (params: ResponsesStreamParams) => Promise<AsyncIterable<unknown>>;
+  pricingOptions?: (options: OpenAIResponsesOptions | undefined) => ResponsesPricingOptions;
+};
+
+function createResponsesTransportExecutor(config: ResponsesTransportExecutorOptions): StreamFn {
   return (model, context, options) => {
     const responsesOptions = options as OpenAIResponsesOptions | undefined;
     const eventStream = createAssistantMessageEventStream();
@@ -114,7 +139,7 @@ export function createOpenAIResponsesTransportStreamFn(): StreamFn {
       const output: AssistantMessage = {
         role: "assistant" as const,
         content: [],
-        api: model.api,
+        api: config.outputApi ?? model.api,
         provider: model.provider,
         model: model.id,
         usage: {
@@ -137,7 +162,7 @@ export function createOpenAIResponsesTransportStreamFn(): StreamFn {
           attempt: 1,
           transport: "stream",
         });
-        const client = createOpenAIResponsesClient(
+        const client = config.createClient(
           model,
           context,
           apiKey,
@@ -145,12 +170,7 @@ export function createOpenAIResponsesTransportStreamFn(): StreamFn {
           turnState?.headers,
           options?.sessionId,
         );
-        let params = buildOpenAIResponsesParams(
-          model,
-          context,
-          responsesOptions,
-          turnState?.metadata,
-        );
+        let params = config.buildRequest(model, context, responsesOptions, turnState?.metadata);
         const nextParams = await options?.onPayload?.(params, model);
         if (nextParams !== undefined) {
           params = nextParams as typeof params;
@@ -172,16 +192,18 @@ export function createOpenAIResponsesTransportStreamFn(): StreamFn {
         }
         const requestStartedAt = Date.now();
         firstEventAbort = createFirstStreamEventAbortController(options?.signal);
-        const requestOptions = buildOpenAISdkRequestOptions(model, firstEventAbort.signal, {
-          stream: true,
-        });
+        const requestOptions = buildOpenAISdkRequestOptions(
+          model,
+          firstEventAbort.signal,
+          config.streamRequest ? { stream: true } : undefined,
+        );
         emitModelTransportDebug(
           log,
           `[responses] start provider=${model.provider} api=${model.api} model=${model.id} ` +
             `baseUrl=${formatModelTransportDebugBaseUrl(model.baseUrl)} timeoutMs=${safeDebugValue(requestOptions?.timeout)} ` +
             `apiKey=${apiKey ? "present" : "missing"} ${summarizeResponsesPayload(params)}`,
         );
-        const responseStream = await createResponsesStreamWithEncryptedContentRetry({
+        const responseStream = await config.createResponseStream({
           client,
           request: params,
           requestOptions,
@@ -199,9 +221,8 @@ export function createOpenAIResponsesTransportStreamFn(): StreamFn {
           stream,
           model,
           {
-            serviceTier: responsesOptions?.serviceTier,
-            applyServiceTierPricing,
-            firstEventTimeoutMs: getFirstStreamEventTimeoutMs(options),
+            ...config.pricingOptions?.(responsesOptions),
+            firstEventTimeoutMs: getFirstStreamEventTimeoutMs(options) ?? config.firstEventTimeoutMs,
             abortFirstEventStream: firstEventAbort.abort,
             onFirstEventTimeout: getFirstStreamEventTimeoutHandler(options),
             signal: options?.signal,
@@ -238,133 +259,35 @@ export function createOpenAIResponsesTransportStreamFn(): StreamFn {
   };
 }
 
+export function createOpenAIResponsesTransportStreamFn(): StreamFn {
+  return createResponsesTransportExecutor({
+    streamRequest: true,
+    createClient: createOpenAIResponsesClient,
+    buildRequest: buildOpenAIResponsesParams,
+    createResponseStream: createResponsesStreamWithEncryptedContentRetry,
+    pricingOptions: (options) => ({ serviceTier: options?.serviceTier, applyServiceTierPricing }),
+  });
+}
+
 export function createAzureOpenAIResponsesTransportStreamFn(): StreamFn {
-  return (model, context, options) => {
-    const responsesOptions = options as OpenAIResponsesOptions | undefined;
-    const eventStream = createAssistantMessageEventStream();
-    const stream = eventStream as unknown as { push(event: unknown): void; end(): void };
-    void (async () => {
-      const output: AssistantMessage = {
-        role: "assistant" as const,
-        content: [],
-        api: "azure-openai-responses",
-        provider: model.provider,
-        model: model.id,
-        usage: {
-          input: 0,
-          output: 0,
-          cacheRead: 0,
-          cacheWrite: 0,
-          totalTokens: 0,
-          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-        },
-        stopReason: "stop",
-        timestamp: Date.now(),
-      };
-      let firstEventAbort: ReturnType<typeof createFirstStreamEventAbortController> | undefined;
-      try {
-        const apiKey = options?.apiKey || getEnvApiKey(model.provider) || "";
-        const turnState = resolveProviderTransportTurnState(model, {
-          sessionId: options?.sessionId,
-          turnId: randomUUID(),
-          attempt: 1,
-          transport: "stream",
-        });
-        const client = createAzureOpenAIClient(
-          model,
-          context,
-          apiKey,
-          options?.headers,
-          turnState?.headers,
-        );
-        const deploymentName = resolveAzureDeploymentName(model);
-        let params = buildAzureOpenAIResponsesParams(
-          model,
-          context,
-          responsesOptions,
-          deploymentName,
-          turnState?.metadata,
-        );
-        const nextParams = await options?.onPayload?.(params, model);
-        if (nextParams !== undefined) {
-          params = nextParams as typeof params;
-        }
-        if (!isOpenAICodexResponsesModel(model)) {
-          params = mergeTransportMetadata(params, turnState?.metadata);
-        }
-        params = sanitizeOpenAICodexResponsesParams(
-          model,
-          params as Record<string, unknown>,
-        ) as typeof params;
-        params = sanitizeResponsesImagePayload(params as Record<string, unknown>) as typeof params;
-        if (
-          (options as { openclawCodeModeToolSurface?: unknown } | undefined)
-            ?.openclawCodeModeToolSurface === true
-        ) {
-          enforceCodeModeResponsesToolSurface(params);
-          assertCodeModeResponsesToolSurface(params);
-        }
-        const requestStartedAt = Date.now();
-        firstEventAbort = createFirstStreamEventAbortController(options?.signal);
-        const requestOptions = buildOpenAISdkRequestOptions(model, firstEventAbort.signal);
-        emitModelTransportDebug(
-          log,
-          `[responses] start provider=${model.provider} api=${model.api} model=${model.id} ` +
-            `baseUrl=${formatModelTransportDebugBaseUrl(model.baseUrl)} timeoutMs=${safeDebugValue(requestOptions?.timeout)} ` +
-            `apiKey=${apiKey ? "present" : "missing"} ${summarizeResponsesPayload(params)}`,
-        );
-        const responseStream = (await client.responses.create(
-          params as never,
-          requestOptions,
-        )) as unknown as AsyncIterable<unknown>;
-        emitModelTransportDebug(
-          log,
-          `[responses] headers provider=${model.provider} api=${model.api} model=${model.id} ` +
-            `elapsedMs=${Date.now() - requestStartedAt}`,
-        );
-        stream.push({ type: "start", partial: output as never });
-        await processResponsesStream(
-          observeResponsesStream(responseStream, model),
-          output,
-          stream,
-          model,
-          {
-            firstEventTimeoutMs:
-              getFirstStreamEventTimeoutMs(options) ?? AZURE_RESPONSES_FIRST_EVENT_TIMEOUT_MS,
-            abortFirstEventStream: firstEventAbort.abort,
-            onFirstEventTimeout: getFirstStreamEventTimeoutHandler(options),
-            signal: options?.signal,
-            reasoningReplayMetadata: buildOpenAIResponsesReasoningReplayMetadata(model, {
-              authProfileId: responsesOptions?.authProfileId,
-              sessionId: options?.sessionId,
-            }),
-          },
-        );
-        if (options?.signal?.aborted) {
-          throw transportAbortError(options.signal);
-        }
-        if (output.stopReason === "aborted" || output.stopReason === "error") {
-          throw new Error("An unknown error occurred");
-        }
-        stream.push({ type: "done", reason: output.stopReason as never, message: output as never });
-        stream.end();
-      } catch (error) {
-        if (error instanceof ResponsesStreamFailure && error.observation) {
-          logResponsesFailedNoDetails(error.observation);
-        }
-        log.warn(
-          `[responses] error provider=${model.provider} api=${model.api} model=${model.id} ` +
-            summarizeOpenAITransportError(error),
-        );
-        assignTransportErrorDetails(output, error, options?.signal);
-        stream.push({ type: "error", reason: output.stopReason as never, error: output as never });
-        stream.end();
-      } finally {
-        firstEventAbort?.dispose();
-      }
-    })();
-    return eventStream as unknown as ReturnType<StreamFn>;
-  };
+  return createResponsesTransportExecutor({
+    outputApi: "azure-openai-responses",
+    firstEventTimeoutMs: AZURE_RESPONSES_FIRST_EVENT_TIMEOUT_MS,
+    createClient: createAzureOpenAIClient,
+    buildRequest: (model, context, options, metadata) =>
+      buildAzureOpenAIResponsesParams(
+        model,
+        context,
+        options,
+        resolveAzureDeploymentName(model),
+        metadata,
+      ),
+    createResponseStream: async ({ client, request, requestOptions }) =>
+      (await client.responses.create(
+        request as never,
+        requestOptions,
+      )) as unknown as AsyncIterable<unknown>,
+  });
 }
 
 function normalizeAzureBaseUrl(baseUrl: string): string {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

The AI package maintained parallel OpenAI Responses transport factories whose setup and execution behavior had converged. Keeping two implementations increased the chance of retry, stream-observation, or request-option behavior drifting between otherwise signature-compatible entry points.

## Why This Change Was Made

This introduces one `createResponsesTransportExecutor` implementation and leaves the existing public wrappers thin and signature-compatible. The executor preserves the current differences between OpenAI and Azure: output API labeling, deployment resolution, streaming request hints, response creation, pricing, and Azure's default first-event timeout. The newer stream-observation and reasoning-replay metadata behavior from `main` is shared by both paths.

## User Impact

No intended user-visible behavior change. Both Responses transport entry points retain their signatures and behavior with 76 fewer lines of duplicate implementation on the current layout.

## Evidence

- Exact head: `8199fbbfebf969218e7d92f57707c00591508e6e`.
- Current diff: 66 insertions, 142 deletions (net -76 LOC).
- Original transport proof: 160/160 tests passed; moved provider proof: 140/140 passed.
- Post-conflict focused proof: 23/23 tests passed across transport parity, Azure Responses, and OpenAI Responses suites.
- Exact-head hosted CI passed: run 30241490726.
- Live OpenAI Responses proof passed 4/4 real-provider tests on the exact head using `gpt-5.6-luna`.
- Azure live proof is still blocked because no approved Azure credential, endpoint, and deployment configuration is available in the validation environment. This PR must remain parked unless an AI-area maintainer explicitly accepts that gap or supplies an approved proof route.
- Original `node scripts/check-changed.mjs` passed on Blacksmith Testbox.
- Fresh post-conflict autoreview was clean with no accepted/actionable findings (confidence 0.89); the formatting-only follow-up rereview was clean at confidence 1.0. TruffleHog was clean.
- Codex dependency contract inspected directly at `codex-rs/codex-api/src/sse/responses.rs:34` and `codex-rs/core/src/client.rs:1940` in `openai/codex`.
