### PR TITLE
fix(linux): recover from a corrupt Gateway device identity

### DIFF
--- a/apps/linux/src-tauri/src/gateway_device_identity.rs
+++ b/apps/linux/src-tauri/src/gateway_device_identity.rs
@@ -4,8 +4,8 @@ use ed25519_dalek::{Signer, SigningKey};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
-use std::fs::{self, OpenOptions};
-use std::io::Write;
+use std::fs::{self, File, OpenOptions};
+use std::io::{Read, Write};
 #[cfg(unix)]
 use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 use std::path::{Path, PathBuf};
@@ -27,6 +27,9 @@ pub(crate) const CLIENT_SCOPES: [&str; 5] = [
 ];
 
 const IDENTITY_VERSION: u8 = 1;
+// A valid identity is well under 1 KiB; 64 KiB leaves ample JSON headroom while
+// preventing a damaged or replaced credential file from causing an unbounded read.
+const MAX_IDENTITY_BYTES: u64 = 64 * 1024;
 
 #[derive(Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -40,6 +43,16 @@ struct StoredGatewayIdentity {
     device_token: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     device_token_gateway: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct StoredGatewayIdentityVersion {
+    version: u8,
+}
+
+enum DecodeIdentityError {
+    VersionMismatch { found: u8 },
+    Malformed(String),
 }
 
 impl Drop for StoredGatewayIdentity {
@@ -106,17 +119,23 @@ impl GatewayAuth {
 
 impl GatewayDeviceIdentityStore {
     pub(crate) fn load_or_create(path: PathBuf) -> Result<Self, String> {
-        let identity = if path.exists() {
-            enforce_private_permissions(&path)?;
-            let bytes = Zeroizing::new(
-                fs::read(&path)
-                    .map_err(|error| format!("Could not read Gateway device identity: {error}"))?,
-            );
-            decode_identity(&bytes)?
-        } else {
-            let identity = generate_identity()?;
-            write_identity(&path, &identity.stored)?;
-            identity
+        let identity = match fs::symlink_metadata(&path) {
+            Ok(_) => {
+                let metadata = fs::metadata(&path).map_err(|error| {
+                    format!("Could not inspect Gateway device identity: {error}")
+                })?;
+                load_existing_identity(&path, &metadata)?
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                let identity = generate_identity()?;
+                write_identity(&path, &identity.stored)?;
+                identity
+            }
+            Err(error) => {
+                return Err(format!(
+                    "Could not inspect Gateway device identity: {error}"
+                ));
+            }
         };
         Ok(Self { path, identity })
     }
@@ -302,23 +321,38 @@ fn generate_identity() -> Result<GatewayDeviceIdentity, String> {
     })
 }
 
-fn decode_identity(bytes: &[u8]) -> Result<GatewayDeviceIdentity, String> {
-    let stored = serde_json::from_slice::<StoredGatewayIdentity>(bytes)
-        .map_err(|error| format!("Gateway device identity is invalid: {error}"))?;
-    if stored.version != IDENTITY_VERSION {
-        return Err("Gateway device identity has an unsupported version.".to_string());
+fn decode_identity(bytes: &[u8]) -> Result<GatewayDeviceIdentity, DecodeIdentityError> {
+    let version = serde_json::from_slice::<StoredGatewayIdentityVersion>(bytes)
+        .map_err(|error| {
+            DecodeIdentityError::Malformed(format!("Gateway device identity is invalid: {error}"))
+        })?
+        .version;
+    if version != IDENTITY_VERSION {
+        return Err(DecodeIdentityError::VersionMismatch { found: version });
     }
-    let signing_key_bytes = Zeroizing::new(decode_key(&stored.private_key, "private")?);
-    let public_key = decode_key(&stored.public_key, "public")?;
+    let stored = serde_json::from_slice::<StoredGatewayIdentity>(bytes).map_err(|error| {
+        DecodeIdentityError::Malformed(format!("Gateway device identity is invalid: {error}"))
+    })?;
+    let signing_key_bytes = Zeroizing::new(
+        decode_key(&stored.private_key, "private").map_err(DecodeIdentityError::Malformed)?,
+    );
+    let public_key =
+        decode_key(&stored.public_key, "public").map_err(DecodeIdentityError::Malformed)?;
     let signing_key = SigningKey::from_bytes(&signing_key_bytes);
     if signing_key.verifying_key().to_bytes() != public_key {
-        return Err("Gateway device identity keypair is invalid.".to_string());
+        return Err(DecodeIdentityError::Malformed(
+            "Gateway device identity keypair is invalid.".to_string(),
+        ));
     }
     if stored.device_id != device_id(&public_key) {
-        return Err("Gateway device identity fingerprint is invalid.".to_string());
+        return Err(DecodeIdentityError::Malformed(
+            "Gateway device identity fingerprint is invalid.".to_string(),
+        ));
     }
     if stored.device_token.is_some() != stored.device_token_gateway.is_some() {
-        return Err("Gateway device token binding is invalid.".to_string());
+        return Err(DecodeIdentityError::Malformed(
+            "Gateway device token binding is invalid.".to_string(),
+        ));
     }
     Ok(GatewayDeviceIdentity { stored })
 }
@@ -345,6 +379,70 @@ fn unix_time_ms() -> Result<u64, String> {
         .map_err(|error| format!("Could not read system time: {error}"))
 }
 
+fn load_existing_identity(
+    path: &Path,
+    metadata: &fs::Metadata,
+) -> Result<GatewayDeviceIdentity, String> {
+    if !metadata.is_file() {
+        return Err("Gateway device identity path is not a regular file.".to_string());
+    }
+    enforce_private_permissions(path)?;
+
+    if metadata.len() > MAX_IDENTITY_BYTES {
+        return quarantine_and_regenerate(path, format!("file exceeds {MAX_IDENTITY_BYTES} bytes"));
+    }
+
+    let file = File::open(path)
+        .map_err(|error| format!("Could not read Gateway device identity: {error}"))?;
+    let mut bytes = Zeroizing::new(Vec::with_capacity(metadata.len() as usize));
+    file.take(MAX_IDENTITY_BYTES + 1)
+        .read_to_end(&mut bytes)
+        .map_err(|error| format!("Could not read Gateway device identity: {error}"))?;
+    if bytes.len() as u64 > MAX_IDENTITY_BYTES {
+        return quarantine_and_regenerate(path, format!("file exceeds {MAX_IDENTITY_BYTES} bytes"));
+    }
+
+    match decode_identity(&bytes) {
+        Ok(identity) => Ok(identity),
+        Err(DecodeIdentityError::VersionMismatch { found }) => Err(format!(
+            "Gateway device identity was written by a different version of OpenClaw \
+             (identity version {found}; this build supports {IDENTITY_VERSION}); \
+             this build will not replace it."
+        )),
+        Err(DecodeIdentityError::Malformed(error)) => quarantine_and_regenerate(path, error),
+    }
+}
+
+fn quarantine_and_regenerate(
+    path: &Path,
+    corruption_reason: String,
+) -> Result<GatewayDeviceIdentity, String> {
+    let file_name = path
+        .file_name()
+        .ok_or_else(|| "Gateway device identity path has no file name.".to_string())?
+        .to_string_lossy();
+    let quarantine_path = path.with_file_name(format!(
+        "{file_name}.corrupt-{}-{}",
+        unix_time_ms()?,
+        Uuid::new_v4()
+    ));
+    // GatewayClient holds its identity mutex here, and the Tauri single-instance plugin
+    // runs before setup, so no supported app path can replace this file between read and rename.
+    // Rename the configured path, not its resolved target: a corrupt symlink is quarantined
+    // while its target credential bytes remain untouched for recovery.
+    fs::rename(path, &quarantine_path).map_err(|error| {
+        format!("Could not quarantine corrupt Gateway device identity: {error}")
+    })?;
+    eprintln!(
+        "Gateway device identity was corrupt ({corruption_reason}); quarantined at {}",
+        quarantine_path.display()
+    );
+
+    let identity = generate_identity()?;
+    write_identity(path, &identity.stored)?;
+    Ok(identity)
+}
+
 fn write_identity(path: &Path, identity: &StoredGatewayIdentity) -> Result<(), String> {
     let bytes = Zeroizing::new(
         serde_json::to_vec(identity)
@@ -356,40 +454,25 @@ fn write_identity(path: &Path, identity: &StoredGatewayIdentity) -> Result<(), S
     fs::create_dir_all(parent)
         .map_err(|error| format!("Could not create Gateway device identity directory: {error}"))?;
 
-    #[cfg(unix)]
-    {
-        let temp_path = parent.join(format!(".gateway-device-{}.tmp", Uuid::new_v4()));
-        let write_result = (|| -> std::io::Result<()> {
-            let mut file = OpenOptions::new()
-                .write(true)
-                .create_new(true)
-                .mode(0o600)
-                .open(&temp_path)?;
-            file.write_all(&bytes)?;
-            file.sync_all()?;
-            fs::rename(&temp_path, path)?;
-            fs::set_permissions(path, fs::Permissions::from_mode(0o600))?;
-            Ok(())
-        })();
-        if let Err(error) = write_result {
-            let _ = fs::remove_file(&temp_path);
-            return Err(format!(
-                "Could not persist Gateway device identity: {error}"
-            ));
-        }
-    }
-
-    #[cfg(not(unix))]
-    {
-        let mut file = OpenOptions::new()
-            .write(true)
-            .create(true)
-            .truncate(true)
-            .open(path)
-            .map_err(|error| format!("Could not persist Gateway device identity: {error}"))?;
-        file.write_all(&bytes)
-            .and_then(|_| file.sync_all())
-            .map_err(|error| format!("Could not persist Gateway device identity: {error}"))?;
+    let temp_path = parent.join(format!(".gateway-device-{}.tmp", Uuid::new_v4()));
+    let write_result = (|| -> std::io::Result<()> {
+        let mut options = OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        options.mode(0o600);
+        let mut file = options.open(&temp_path)?;
+        file.write_all(&bytes)?;
+        file.sync_all()?;
+        fs::rename(&temp_path, path)?;
+        #[cfg(unix)]
+        fs::set_permissions(path, fs::Permissions::from_mode(0o600))?;
+        Ok(())
+    })();
+    if let Err(error) = write_result {
+        let _ = fs::remove_file(&temp_path);
+        return Err(format!(
+            "Could not persist Gateway device identity: {error}"
+        ));
     }
 
     Ok(())
@@ -405,6 +488,96 @@ fn enforce_private_permissions(path: &Path) -> Result<(), String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(unix)]
+    use std::os::unix::fs::{symlink, MetadataExt};
+
+    fn quarantined_identity_paths(directory: &Path) -> Vec<PathBuf> {
+        fs::read_dir(directory)
+            .expect("read identity fixture directory")
+            .filter_map(Result::ok)
+            .map(|entry| entry.path())
+            .filter(|entry| {
+                entry.file_name().is_some_and(|name| {
+                    name.to_string_lossy()
+                        .starts_with("quickchat-gateway-device.json.corrupt-")
+                })
+            })
+            .collect()
+    }
+
+    fn assert_corrupt_identity_recovers(original_bytes: &[u8]) {
+        let directory = std::env::temp_dir().join(format!(
+            "openclaw-linux-corrupt-gateway-identity-test-{}",
+            Uuid::new_v4()
+        ));
+        fs::create_dir_all(&directory).expect("create identity fixture directory");
+        let path = directory.join("quickchat-gateway-device.json");
+        fs::write(&path, original_bytes).expect("write corrupt identity fixture");
+
+        let recovered = GatewayDeviceIdentityStore::load_or_create(path.clone())
+            .expect("recover corrupt identity");
+        let reloaded = GatewayDeviceIdentityStore::load_or_create(path.clone())
+            .expect("reload recovered identity");
+
+        assert_eq!(
+            recovered.identity.stored.device_id,
+            reloaded.identity.stored.device_id
+        );
+        assert_eq!(
+            recovered.identity.stored.private_key,
+            reloaded.identity.stored.private_key
+        );
+        let quarantined = quarantined_identity_paths(&directory);
+        assert_eq!(quarantined.len(), 1);
+        assert_eq!(
+            fs::read(&quarantined[0]).expect("read quarantined identity"),
+            original_bytes
+        );
+
+        fs::remove_dir_all(directory).expect("remove identity fixture");
+    }
+
+    fn assert_version_mismatch_is_preserved(version: u8) {
+        let directory = std::env::temp_dir().join(format!(
+            "openclaw-linux-version-mismatch-identity-test-{}",
+            Uuid::new_v4()
+        ));
+        let path = directory.join("quickchat-gateway-device.json");
+        let mut stored = generate_identity().expect("generate identity").stored;
+        stored.version = version;
+        write_identity(&path, &stored).expect("write version-mismatched identity");
+        let original_bytes = fs::read(&path).expect("read version-mismatched identity");
+        #[cfg(unix)]
+        let original_inode = fs::metadata(&path)
+            .expect("version-mismatched identity metadata")
+            .ino();
+
+        let error = GatewayDeviceIdentityStore::load_or_create(path.clone())
+            .err()
+            .expect("version mismatch should fail");
+
+        assert!(error.contains("written by a different version of OpenClaw"));
+        assert!(error.contains("this build will not replace it"));
+        assert_eq!(
+            fs::read(&path).expect("reread version-mismatched identity"),
+            original_bytes
+        );
+        #[cfg(unix)]
+        assert_eq!(
+            fs::metadata(&path)
+                .expect("version-mismatched identity metadata")
+                .ino(),
+            original_inode
+        );
+        assert!(quarantined_identity_paths(&directory).is_empty());
+        assert_eq!(
+            fs::read_dir(&directory)
+                .expect("read identity fixture directory")
+                .count(),
+            1
+        );
+        fs::remove_dir_all(directory).expect("remove identity fixture");
+    }
 
     #[test]
     fn v3_signature_payload_matches_gateway_fixture_bytes() {
@@ -464,6 +637,173 @@ mod tests {
             0o600
         );
 
+        fs::remove_dir_all(directory).expect("remove identity fixture");
+    }
+
+    #[test]
+    fn empty_identity_file_is_quarantined_and_recovered() {
+        assert_corrupt_identity_recovers(b"");
+    }
+
+    #[test]
+    fn truncated_identity_json_is_quarantined_and_recovered() {
+        assert_corrupt_identity_recovers(br#"{"version":1"#);
+    }
+
+    #[test]
+    fn wrong_shape_identity_json_is_quarantined_and_recovered() {
+        assert_corrupt_identity_recovers(br#"["not", "an", "identity"]"#);
+    }
+
+    #[test]
+    fn oversized_identity_file_is_quarantined_and_recovered() {
+        let original_bytes = vec![b'x'; MAX_IDENTITY_BYTES as usize + 1];
+        assert_corrupt_identity_recovers(&original_bytes);
+    }
+
+    #[test]
+    fn newer_identity_version_is_rejected_without_replacement() {
+        assert_version_mismatch_is_preserved(
+            IDENTITY_VERSION
+                .checked_add(1)
+                .expect("newer identity version"),
+        );
+    }
+
+    #[test]
+    fn older_identity_version_is_rejected_without_replacement() {
+        assert_version_mismatch_is_preserved(
+            IDENTITY_VERSION
+                .checked_sub(1)
+                .expect("older identity version"),
+        );
+    }
+
+    #[test]
+    fn identity_directory_is_a_hard_error_without_quarantine() {
+        let directory = std::env::temp_dir().join(format!(
+            "openclaw-linux-gateway-identity-directory-test-{}",
+            Uuid::new_v4()
+        ));
+        let path = directory.join("quickchat-gateway-device.json");
+        fs::create_dir_all(&path).expect("create identity path as directory");
+
+        let error = GatewayDeviceIdentityStore::load_or_create(path.clone())
+            .err()
+            .expect("directory identity path should fail");
+
+        assert!(error.contains("not a regular file"));
+        assert!(path.is_dir());
+        assert!(fs::read_dir(&directory)
+            .expect("read identity fixture directory")
+            .filter_map(Result::ok)
+            .all(|entry| !entry.file_name().to_string_lossy().contains(".corrupt-")));
+        fs::remove_dir_all(directory).expect("remove identity fixture");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn valid_symlinked_identity_loads_without_quarantine() {
+        let directory = std::env::temp_dir().join(format!(
+            "openclaw-linux-valid-symlink-identity-test-{}",
+            Uuid::new_v4()
+        ));
+        fs::create_dir_all(&directory).expect("create identity fixture directory");
+        let target = directory.join("identity-target.json");
+        let path = directory.join("quickchat-gateway-device.json");
+        let original = GatewayDeviceIdentityStore::load_or_create(target.clone())
+            .expect("create target identity");
+        symlink(&target, &path).expect("create identity symlink");
+
+        let loaded = GatewayDeviceIdentityStore::load_or_create(path.clone())
+            .expect("load symlinked identity");
+
+        assert_eq!(
+            loaded.identity.stored.device_id,
+            original.identity.stored.device_id
+        );
+        assert!(fs::symlink_metadata(&path)
+            .expect("identity symlink metadata")
+            .file_type()
+            .is_symlink());
+        assert!(quarantined_identity_paths(&directory).is_empty());
+        fs::remove_dir_all(directory).expect("remove identity fixture");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn corrupt_symlinked_identity_quarantines_link_and_recovers() {
+        let directory = std::env::temp_dir().join(format!(
+            "openclaw-linux-corrupt-symlink-identity-test-{}",
+            Uuid::new_v4()
+        ));
+        fs::create_dir_all(&directory).expect("create identity fixture directory");
+        let target = directory.join("identity-target.json");
+        let path = directory.join("quickchat-gateway-device.json");
+        let original_bytes = br#"{"version":1"#;
+        fs::write(&target, original_bytes).expect("write corrupt target identity");
+        symlink(&target, &path).expect("create identity symlink");
+
+        let recovered = GatewayDeviceIdentityStore::load_or_create(path.clone())
+            .expect("recover symlinked identity");
+        let reloaded = GatewayDeviceIdentityStore::load_or_create(path.clone())
+            .expect("reload recovered identity");
+
+        assert_eq!(
+            recovered.identity.stored.device_id,
+            reloaded.identity.stored.device_id
+        );
+        assert!(fs::symlink_metadata(&path)
+            .expect("recovered identity metadata")
+            .is_file());
+        assert_eq!(
+            fs::read(&target).expect("read target identity"),
+            original_bytes
+        );
+        let quarantined = quarantined_identity_paths(&directory);
+        assert_eq!(quarantined.len(), 1);
+        assert!(fs::symlink_metadata(&quarantined[0])
+            .expect("quarantined symlink metadata")
+            .file_type()
+            .is_symlink());
+        assert_eq!(
+            fs::read_link(&quarantined[0]).expect("read quarantined link"),
+            target
+        );
+        assert_eq!(
+            fs::metadata(&path)
+                .expect("recovered identity metadata")
+                .permissions()
+                .mode()
+                & 0o777,
+            0o600
+        );
+        fs::remove_dir_all(directory).expect("remove identity fixture");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn dangling_identity_symlink_is_a_hard_error_without_quarantine() {
+        let directory = std::env::temp_dir().join(format!(
+            "openclaw-linux-dangling-symlink-identity-test-{}",
+            Uuid::new_v4()
+        ));
+        fs::create_dir_all(&directory).expect("create identity fixture directory");
+        let target = directory.join("missing-identity-target.json");
+        let path = directory.join("quickchat-gateway-device.json");
+        symlink(&target, &path).expect("create dangling identity symlink");
+
+        let error = GatewayDeviceIdentityStore::load_or_create(path.clone())
+            .err()
+            .expect("dangling identity symlink should fail");
+
+        assert!(error.contains("Could not inspect Gateway device identity"));
+        assert!(fs::symlink_metadata(&path)
+            .expect("dangling identity symlink metadata")
+            .file_type()
+            .is_symlink());
+        assert!(!target.exists());
+        assert!(quarantined_identity_paths(&directory).is_empty());
         fs::remove_dir_all(directory).expect("remove identity fixture");
     }
 


### PR DESCRIPTION
## Problem

A corrupt `quickchat-gateway-device.json` bricked Quick Chat permanently, with no way out from inside the app.

`GatewayDeviceIdentityStore::load_or_create` reads the file if it exists and generates a fresh identity if it does not — but the "create" branch only ever ran on **absence**:

```rust
let identity = if path.exists() {
    let bytes = fs::read(&path)?;
    decode_identity(&bytes)?      // hard error, nothing recovers from here
} else {
    generate_identity()?          // only reached when the file is missing
};
```

A file that exists but does not decode — zero bytes, truncated, garbage — returned `Err` forever. Every Quick Chat connection then failed *before* opening a socket, and the driver classified it as an ordinary "gateway down" and retried indefinitely, hiding the real cause. Nothing surfaced that a local file was at fault, and the only fix was knowing to delete it by hand.

Reaching that state needed nothing exotic: `write_identity` truncated the live file before rewriting it, so a crash, a full disk, or power loss mid-write left exactly this.

## Fix

**Quarantine, never delete.** A regular file whose contents fail to decode is renamed aside (`<name>.corrupt-<millis>-<uuid>`) and a fresh identity takes its place. Renaming rather than deleting is the point: the old file may still hold a recoverable device token, and silently destroying credentials would be a worse bug than the one being fixed. The quarantine path is logged.

**Only genuine corruption recovers.** Permission errors, IO errors, and a non-regular path stay hard errors — those are environmental, and quarantining them would mask a real problem.

**Version mismatches are not corruption.** `decode_identity` now returns a typed error, so an identity written by a *different* build hard-errors and is left byte-for-byte intact rather than being replaced. This matters on rollback: a newer build bumps the version, the older build cannot parse it, and silently generating a replacement would lose the device token and force re-approval at the Gateway — while the quarantined original would never be read back. A clear error the user can act on beats silent credential replacement.

**Bounded reads.** Capped at 64 KiB for what is well under 1 KiB of JSON; an implausibly large file is treated as corrupt.

**Corruption is now much harder to create.** `write_identity` writes to a private temp file in the same directory, fsyncs, and renames over the target, so it is no longer possible to truncate the live credential and then fail.

**Symlinks keep working.** Presence is detected with `symlink_metadata` (so a dangling link is not mistaken for absence) while usability is checked with `metadata`, which follows links — matching the previous behaviour of `path.exists()` and `set_permissions`. A corrupt symlink quarantines the link itself and leaves its target bytes untouched; a dangling link is a hard error.

## Proof

```
cargo test --locked --all-targets     # 87 passed; 0 failed
cargo fmt --check                     # clean
```

**Mutation-checked** at each stage: disabling recovery failed the empty/truncated/wrong-shape/oversized tests; forcing link metadata failed the symlink tests; routing version mismatches through quarantine failed the version tests.

Tests cover empty, truncated, wrong-shape and oversized files recovering to a usable identity with the original bytes preserved; a directory and a dangling symlink erroring without quarantine; a symlink to a valid identity loading untouched; a symlink to a corrupt identity recovering; and newer/older version files erroring with the file left byte-identical and no replacement written.
