### PR TITLE
fix(gateway): deterministic channels.status ordering with probe-contract tests

### DIFF
--- a/src/gateway/server-methods/channels.status.test.ts
+++ b/src/gateway/server-methods/channels.status.test.ts
@@ -249,6 +249,47 @@ describe("channelsHandlers channels.status", () => {
     expect(probeArgs.cfg).toBe(autoEnabledConfig);
   });
 
+  it("runs channel probes concurrently and preserves deterministic status-map order", async () => {
+    vi.useFakeTimers();
+    try {
+      const started: string[] = [];
+      const createDelayedProbe = (id: string) => async () => {
+        started.push(id);
+        await new Promise((resolve) => {
+          setTimeout(resolve, 1000);
+        });
+        return { ok: true };
+      };
+      configureAutoEnabledChannels([
+        createChannelPlugin({ id: "zeta", probeAccount: createDelayedProbe("zeta") }),
+        createChannelPlugin({ id: "alpha", probeAccount: createDelayedProbe("alpha") }),
+      ]);
+      mocks.buildChannelUiCatalog.mockImplementation((plugins: Array<{ id: string }>) => ({
+        order: plugins.map((plugin) => plugin.id),
+        labels: {},
+        detailLabels: {},
+        systemImages: {},
+        entries: {},
+      }));
+      const startedAt = Date.now();
+      const run = runChannelsStatus({ probe: true, timeoutMs: 2000 });
+
+      await vi.advanceTimersByTimeAsync(0);
+      expect(started).toEqual(["alpha", "zeta"]);
+      await vi.advanceTimersByTimeAsync(1000);
+      const payload = await run;
+
+      expect(Date.now() - startedAt).toBe(1000);
+      expect(payload.channelOrder).toEqual(["zeta", "alpha"]);
+      expect(Object.keys(requireRecord(payload.channels, "channels payload"))).toEqual([
+        "alpha",
+        "zeta",
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("filters channel status to a requested channel", async () => {
     const whatsappProbe = vi.fn(async () => ({ ok: true }));
     const imessageProbe = vi.fn(async () => ({ ok: true }));
@@ -314,13 +355,22 @@ describe("channelsHandlers channels.status", () => {
     expect(String(accountProbe.error)).toContain("probe failed");
   });
 
-  it("returns a partial snapshot when a channel probe exceeds the status budget", async () => {
+  it("isolates a timed-out channel probe while another channel succeeds", async () => {
     vi.useFakeTimers();
     try {
       const autoEnabledConfig = { autoEnabled: true };
-      const probeAccount = vi.fn(() => new Promise(() => {}));
+      const hangingProbe = vi.fn(() => new Promise(() => {}));
+      const healthyProbe = vi.fn(async () => ({ ok: true, identity: "healthy" }));
       mocks.applyPluginAutoEnable.mockReturnValue({ config: autoEnabledConfig, changes: [] });
-      mocks.listChannelPlugins.mockReturnValue([createChannelPlugin({ probeAccount })]);
+      mocks.listChannelPlugins.mockReturnValue([
+        createChannelPlugin({ id: "hanging", probeAccount: hangingProbe }),
+        createChannelPlugin({ id: "healthy", probeAccount: healthyProbe }),
+      ]);
+      mocks.buildChannelAccountSnapshot.mockImplementation(async ({ accountId, probe }) => ({
+        accountId,
+        configured: true,
+        probe,
+      }));
       const respond = vi.fn();
       const run = expectDefined(
         channelsHandlers["channels.status"],
@@ -330,15 +380,18 @@ describe("channelsHandlers channels.status", () => {
       await vi.advanceTimersByTimeAsync(1000);
       await run;
 
-      const snapshotArgs = requireRecord(
-        requireFirstCallArg(mocks.buildChannelAccountSnapshot),
-        "snapshot args",
-      );
-      const probe = requireRecord(snapshotArgs.probe, "snapshot probe");
-      expect(probe.timedOut).toBe(true);
       const payload = requireRespondPayload(respond);
+      expect(
+        requireRecord(firstChannelAccount(payload, "hanging").probe, "hanging probe").timedOut,
+      ).toBe(true);
+      expect(requireRecord(firstChannelAccount(payload, "healthy").probe, "healthy probe")).toEqual(
+        {
+          ok: true,
+          identity: "healthy",
+        },
+      );
       expect(payload.partial).toBe(true);
-      expect(payload.warnings).toEqual(["whatsapp:default probe timed out after 1000ms"]);
+      expect(payload.warnings).toEqual(["hanging:default probe timed out after 1000ms"]);
     } finally {
       vi.useRealTimers();
     }

--- a/src/gateway/server-methods/channels.ts
+++ b/src/gateway/server-methods/channels.ts
@@ -361,6 +361,10 @@ export const channelsHandlers: GatewayRequestHandlers = {
     const selectedPlugins = requestedChannel
       ? plugins.filter((plugin) => plugin.id === requestedChannel)
       : plugins;
+    // Preserve registry-defined UI order while stabilizing keyed status maps for prompt-cache input.
+    const statusPlugins = selectedPlugins.toSorted((left, right) =>
+      left.id < right.id ? -1 : left.id > right.id ? 1 : 0,
+    );
     if (rawChannel !== undefined && !requestedChannel) {
       respond(
         false,
@@ -545,7 +549,7 @@ export const channelsHandlers: GatewayRequestHandlers = {
     const accountsMap = payload.channelAccounts as Record<string, unknown>;
     const defaultAccountIdMap = payload.channelDefaultAccountId as Record<string, unknown>;
     const { results: channelResults } = await runTasksWithConcurrency({
-      tasks: selectedPlugins.map((plugin) => async () => {
+      tasks: statusPlugins.map((plugin) => async () => {
         const { accounts, defaultAccountId, defaultAccount, resolvedAccounts } =
           await buildChannelAccounts(plugin.id);
         const fallbackAccount =


### PR DESCRIPTION
## What Problem This Solves

Investigating a 2441ms `channels.status` response on team.openclaw.ai (near-zero CPU in the same window — await-bound). The investigation found the handler **already** probes channels with five-wide bounded concurrency and 1–30s per-probe timeouts; the latency came from a slow probe batch within budget, not a serialization bug. What the investigation did surface: status-map insertion order followed completion order, and none of the concurrency/isolation behavior was locked by tests.

## Why This Change Was Made

- Status-map insertion is now deterministic by channel id (registry-defined UI order preserved in the response) — keyed maps feed prompt-cache inputs, and the repo's determinism rule requires stable ordering for map/registry payloads.
- Regression coverage now locks the existing contract: two 1s probes complete in ~1s (concurrency), stable ordering, and a hanging probe yields its channel's timeout state while peers succeed (isolation). Network/API, socket/process, and filesystem probes stay isolated.

Honest scope note: this is a determinism fix plus contract-locking tests, not a latency change — the concurrency the original evidence asked for already existed.

## User Impact

Stable channel ordering in status payloads (prompt-cache friendly, no UI reorder flicker); the probe concurrency/isolation contract can no longer regress silently.

## Evidence

- Prod diff is 5 lines (`channels.ts`): sort probe tasks by channel id.
- 10/10 focused tests including the new concurrency, ordering, and hanging-probe isolation regressions; re-run post-rebase green.
- oxfmt/oxlint clean; no CHANGELOG edit; no new exports (knip-safe).
- Autoreview (Codex `gpt-5.6-sol`, xhigh): clean.
