### PR TITLE
perf(boards): hydrate board.get widgets from one store snapshot

### DIFF
--- a/src/boards/board-store.parity.test.ts
+++ b/src/boards/board-store.parity.test.ts
@@ -87,6 +87,19 @@ describe.each([
       revision: 1,
       sha256: expect.stringMatching(/^[a-f0-9]{64}$/u),
     });
+    expect(store.getSnapshotWithHtmlDocuments("agent:main:board")).toMatchObject({
+      snapshot: { revision: 1 },
+      htmlDocuments: new Map([
+        [
+          "weather",
+          expect.objectContaining({
+            html: "<p>one</p>",
+            revision: 1,
+            sha256: expect.stringMatching(/^[a-f0-9]{64}$/u),
+          }),
+        ],
+      ]),
+    });
 
     // Legacy clients omit heightMode on resize; explicit user sizing must pin.
     const resized = store.applyOps("agent:main:board", [

--- a/src/boards/board-store.ts
+++ b/src/boards/board-store.ts
@@ -34,9 +34,14 @@ export type BoardWidgetMcpAppDocument = {
   interactive: boolean;
 };
 export type BoardWidgetDocument = BoardWidgetHtmlDocument | BoardWidgetMcpAppDocument;
+export type BoardSnapshotWithHtmlDocuments = {
+  snapshot: BoardSnapshot;
+  htmlDocuments: ReadonlyMap<string, BoardWidgetHtmlDocument>;
+};
 
 export interface BoardStore {
   getSnapshot(sessionKey: string): BoardSnapshot;
+  getSnapshotWithHtmlDocuments(sessionKey: string): BoardSnapshotWithHtmlDocuments;
   applyOps(sessionKey: string, ops: readonly BoardOp[]): BoardSnapshot;
   putWidget(params: BoardWidgetMaterializedPutParams): BoardSnapshot;
   grant(
@@ -86,6 +91,22 @@ export function cloneBoardSnapshot(snapshot: BoardSnapshot): BoardSnapshot {
           }
         : {}),
     })),
+  };
+}
+
+function cloneBoardWidgetHtmlDocument(document: BoardWidgetHtmlDocument): BoardWidgetHtmlDocument {
+  return {
+    ...document,
+    ...(document.declared
+      ? {
+          declared: {
+            ...(document.declared.netOrigins
+              ? { netOrigins: [...document.declared.netOrigins] }
+              : {}),
+            ...(document.declared.tools ? { tools: [...document.declared.tools] } : {}),
+          },
+        }
+      : {}),
   };
 }
 
@@ -333,6 +354,20 @@ export class InMemoryBoardStore implements BoardStore {
     );
   }
 
+  getSnapshotWithHtmlDocuments(sessionKey: string): BoardSnapshotWithHtmlDocuments {
+    const stored = this.boards.get(sessionKey);
+    const htmlDocuments = new Map<string, BoardWidgetHtmlDocument>();
+    for (const [name, document] of stored?.documents ?? []) {
+      if ("html" in document) {
+        htmlDocuments.set(name, cloneBoardWidgetHtmlDocument(document));
+      }
+    }
+    return {
+      snapshot: cloneBoardSnapshot(stored?.snapshot ?? emptyBoardSnapshot(sessionKey)),
+      htmlDocuments,
+    };
+  }
+
   applyOps(sessionKey: string, ops: readonly BoardOp[]): BoardSnapshot {
     const current = this.boards.get(sessionKey);
     const snapshot = current?.snapshot ?? emptyBoardSnapshot(sessionKey);
@@ -430,21 +465,7 @@ export class InMemoryBoardStore implements BoardStore {
     if (!document) {
       return undefined;
     }
-    return "html" in document
-      ? {
-          ...document,
-          ...(document.declared
-            ? {
-                declared: {
-                  ...(document.declared.netOrigins
-                    ? { netOrigins: [...document.declared.netOrigins] }
-                    : {}),
-                  ...(document.declared.tools ? { tools: [...document.declared.tools] } : {}),
-                },
-              }
-            : {}),
-        }
-      : undefined;
+    return "html" in document ? cloneBoardWidgetHtmlDocument(document) : undefined;
   }
 
   readWidgetMcpApp(sessionKey: string, name: string): BoardWidgetMcpAppDocument | undefined {

--- a/src/boards/sqlite-board-store.ts
+++ b/src/boards/sqlite-board-store.ts
@@ -28,6 +28,7 @@ import {
   createBoardGrantSnapshot,
   createBoardWidgetPutSnapshot,
   type BoardStore,
+  type BoardSnapshotWithHtmlDocuments,
   type BoardWidgetHtmlDocument,
   type BoardWidgetMcpAppDocument,
 } from "./board-store.js";
@@ -159,6 +160,27 @@ function readStoredBoard(database: BoardDatabaseHandle, sessionKey: string): Sto
     },
     { databaseLabel: database.path, operationLabel: "board.read" },
   );
+}
+
+function rowToHtmlDocument(
+  row: Pick<
+    SelectedBoardWidgetRow,
+    "content_kind" | "html" | "revision" | "sha256" | "view_generation" | "grant_state" | "manifest"
+  >,
+): BoardWidgetHtmlDocument | undefined {
+  if (row.content_kind !== "html" || row.html === null || row.view_generation === null) {
+    return undefined;
+  }
+  const manifest = parseManifest(row.manifest);
+  const declared = manifest.declared;
+  return {
+    html: Buffer.from(row.html).toString("utf8"),
+    revision: row.revision,
+    sha256: row.sha256,
+    viewGeneration: row.view_generation,
+    grantState: effectiveGrantState(row.grant_state as BoardWidget["grantState"], manifest),
+    ...(declared ? { declared } : {}),
+  };
 }
 
 function upsertTabs(
@@ -375,6 +397,33 @@ export class SqliteBoardStore implements BoardStore {
     );
   }
 
+  getSnapshotWithHtmlDocuments(sessionKey: string): BoardSnapshotWithHtmlDocuments {
+    const resolved = this.resolve(sessionKey);
+    const result = withOpenClawAgentDatabaseReadOnly(
+      (database) =>
+        hasSession(database, resolved.sessionKey) && boardTablesPresent(database)
+          ? readStoredBoard(database, resolved.sessionKey)
+          : undefined,
+      {
+        agentId: resolved.agentId,
+        ...(resolved.path ? { path: resolved.path } : {}),
+        env: this.options.env,
+      },
+    );
+    const stored = result.found ? result.value : undefined;
+    const htmlDocuments = new Map<string, BoardWidgetHtmlDocument>();
+    for (const row of stored?.widgetRows ?? []) {
+      const document = rowToHtmlDocument(row);
+      if (document) {
+        htmlDocuments.set(row.name, document);
+      }
+    }
+    return {
+      snapshot: cloneBoardSnapshot(stored?.snapshot ?? emptyBoardSnapshot(resolved.sessionKey)),
+      htmlDocuments,
+    };
+  }
+
   applyOps(sessionKey: string, ops: readonly BoardOp[]): BoardSnapshot {
     if (ops.length === 0) {
       return this.getSnapshot(sessionKey);
@@ -587,19 +636,7 @@ export class SqliteBoardStore implements BoardStore {
         if (!row) {
           return undefined;
         }
-        if (row.content_kind === "html" && row.html !== null && row.view_generation !== null) {
-          const manifest = parseManifest(row.manifest);
-          const declared = manifest.declared;
-          return {
-            html: Buffer.from(row.html).toString("utf8"),
-            revision: row.revision,
-            sha256: row.sha256,
-            viewGeneration: row.view_generation,
-            grantState: effectiveGrantState(row.grant_state as BoardWidget["grantState"], manifest),
-            ...(declared ? { declared } : {}),
-          };
-        }
-        return undefined;
+        return rowToHtmlDocument(row);
       },
       {
         agentId: resolved.agentId,

--- a/src/gateway/server-methods/board.test.ts
+++ b/src/gateway/server-methods/board.test.ts
@@ -200,6 +200,27 @@ describe("board gateway methods", () => {
     expect(snapshot.widgets[0]).toMatchObject({ sandboxPort: 18790 });
   });
 
+  it("prepares HTML widget documents with the snapshot instead of rereading the store", async () => {
+    const { invoke, store } = createHarness();
+    await invoke("board.widget.put", {
+      sessionKey: "agent:main:main",
+      name: "first",
+      content: { kind: "html", html: "<p>first</p>" },
+    });
+    await invoke("board.widget.put", {
+      sessionKey: "agent:main:main",
+      name: "second",
+      content: { kind: "html", html: "<p>second</p>" },
+    });
+    const preparedRead = vi.spyOn(store, "getSnapshotWithHtmlDocuments");
+    const documentRead = vi.spyOn(store, "readWidgetHtml");
+
+    await invoke("board.get", { sessionKey: "agent:main:main" });
+
+    expect(preparedRead).toHaveBeenCalledOnce();
+    expect(documentRead).not.toHaveBeenCalled();
+  });
+
   it("applies updates and broadcasts board.changed", async () => {
     const { invoke, broadcast } = createHarness();
     const response = await invoke("board.update", {

--- a/src/gateway/server-methods/board.ts
+++ b/src/gateway/server-methods/board.ts
@@ -135,13 +135,15 @@ export function createBoardHandlers(
         invalidParams("board.get", validateBoardGetParams.errors, respond);
         return;
       }
-      const snapshot = store.getSnapshot(params.sessionKey);
+      const { snapshot, htmlDocuments } = store.getSnapshotWithHtmlDocuments(params.sessionKey);
       let sandboxPort = context.getMcpAppSandboxPort?.();
+      let sandboxOrigin: string | undefined;
+      let sandboxOriginResolved = false;
       for (const widget of snapshot.widgets) {
         if (widget.grantState !== "none" && widget.grantState !== "granted") {
           continue;
         }
-        const document = store.readWidgetHtml(snapshot.sessionKey, widget.name);
+        const document = htmlDocuments.get(widget.name);
         if (!document || document.revision !== widget.revision) {
           continue;
         }
@@ -170,9 +172,13 @@ export function createBoardHandlers(
         if (sandboxPort !== undefined) {
           widget.sandboxUrl = buildBoardWidgetSandboxPath(document);
           widget.sandboxPort = sandboxPort;
-          const configuredOrigin = context.getRuntimeConfig?.().mcp?.apps?.sandboxOrigin;
-          if (configuredOrigin) {
-            widget.sandboxOrigin = new URL(configuredOrigin).origin;
+          if (!sandboxOriginResolved) {
+            const configuredOrigin = context.getRuntimeConfig?.().mcp?.apps?.sandboxOrigin;
+            sandboxOrigin = configuredOrigin ? new URL(configuredOrigin).origin : undefined;
+            sandboxOriginResolved = true;
+          }
+          if (sandboxOrigin) {
+            widget.sandboxOrigin = sandboxOrigin;
           }
         }
       }


### PR DESCRIPTION
## What Problem This Solves

`board.get` is the Control UI's second-most-called method on team.openclaw.ai — 275 calls in 4h at avg 197ms (max 877ms), polled continuously by the workboard surface. Per request the handler read the board store once for the snapshot and then **once more per admitted HTML widget** to hydrate documents: `1 + H` store reads (SQLite enumeration + conversion) for `H` widgets.

## Why This Change Was Made

One combined snapshot-and-HTML-documents read (`BoardSnapshotWithHtmlDocuments`) serves the whole request: the gateway handler hydrates every admitted widget from the single snapshot instead of re-reading the store per widget. Document conversion and cloning semantics are unchanged; sandbox-origin caching stays request-local; memory and SQLite board stores keep parity (new parity regressions). RPC count and response shape are unchanged; fresh view tickets remain intact, so no protocol or revision short-circuit was introduced.

## User Impact

Board polling latency approaches a single snapshot-read cost; the win scales with widget count. Empty boards unchanged.

## Evidence

- Production call stats above (journal per-method histogram).
- Board gateway tests 28/28; board store parity 33/33 (memory vs SQLite); focused re-run post-rebase: 2 shards green.
- Changed gate: typechecks, format, max-lines, architecture guards passed (worker run); oxlint 0 findings; no CHANGELOG edit; new export consumed by 4 prod modules (knip-safe).
- Autoreview (Codex `gpt-5.6-sol`, xhigh): clean, "patch is correct (0.94)".
