### PR TITLE
test: speed up measured CI hotspots

### DIFF
--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -702,78 +702,8 @@ function createQueuedRun(
 }
 
 describe("createFollowupRunner reply-lane admission", () => {
-  it("drops stale active-goal context after the persisted goal completes", async () => {
-    runEmbeddedAgentMock.mockResolvedValueOnce({ payloads: [], meta: {} });
-    const storePath = path.join(
-      tmpdir(),
-      `openclaw-followup-completed-goal-${crypto.randomUUID()}.json`,
-    );
-    const activeEntry: SessionEntry = {
-      sessionId: "session-completed-goal",
-      updatedAt: 1,
-      goal: {
-        schemaVersion: 1,
-        id: "goal-1",
-        objective: "Publish the release evidence",
-        status: "active",
-        createdAt: 1,
-        updatedAt: 1,
-        tokenStart: 0,
-        tokensUsed: 0,
-        continuationTurns: 0,
-      },
-    };
-    const completedEntry: SessionEntry = {
-      ...activeEntry,
-      updatedAt: 2,
-      goal: { ...activeEntry.goal!, status: "complete", updatedAt: 2 },
-    };
-    registerFollowupTestSessionStore(storePath, { main: completedEntry });
-    admitReplyTurnMock.mockResolvedValueOnce({
-      status: "admitted",
-      operation: createReplyOperationForTest({
-        sessionKey: "main",
-        sessionId: completedEntry.sessionId,
-        resetTriggered: false,
-      }),
-    });
-    const runner = createFollowupRunner({
-      typing: createMockTypingController(),
-      typingMode: "instant",
-      sessionEntry: activeEntry,
-      sessionStore: { main: activeEntry },
-      sessionKey: "main",
-      storePath,
-      defaultModel: "anthropic/claude",
-    });
-
-    await runner(
-      createQueuedRun({
-        currentInboundContext: {
-          injectedGoalContexts: [
-            "Active goal: Publish the release evidence — advance it or update its status (get_goal/update_goal).",
-          ],
-          text: [
-            "Conversation info:",
-            "Active goal: Publish the release evidence — advance it or update its status (get_goal/update_goal).",
-            "Current message:\nmessage_id=next-turn",
-          ].join("\n\n"),
-        },
-        run: {
-          sessionId: "session-completed-goal",
-          sessionKey: "main",
-          provider: "anthropic",
-          model: "claude",
-        },
-      }),
-    );
-
-    const call = requireLastMockCallArg(runEmbeddedAgentMock, "run embedded agent");
-    const context = requireRecord(call.currentInboundContext, "current inbound context");
-    expect(context.text).toContain("Current message:\nmessage_id=next-turn");
-    expect(context.text).not.toContain("Active goal:");
-  }, 300_000);
-
+  // Goal-context text refresh is covered directly in inbound-meta.test.ts; the
+  // admission-time composition boundary is covered in get-reply-run.media-only.test.ts.
   it("keeps the originating client caps on queued embedded runs", async () => {
     // Regression: the queued path built runEmbeddedAgent params inline and
     // dropped run.clientCaps, so capability-gated tools vanished after drain.

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -708,16 +708,18 @@ describe("createFollowupRunner reply-lane admission", () => {
     // Regression: the queued path built runEmbeddedAgent params inline and
     // dropped run.clientCaps, so capability-gated tools vanished after drain.
     runEmbeddedAgentMock.mockResolvedValueOnce({ payloads: [], meta: {} });
-    const storePath = "/tmp/openclaw-followup-client-caps.json";
-    const sessionEntry: SessionEntry = { sessionId: "session-client-caps", updatedAt: 1 };
-    registerFollowupTestSessionStore(storePath, { main: sessionEntry });
+    admitReplyTurnMock.mockResolvedValueOnce({
+      status: "admitted",
+      operation: createReplyOperationForTest({
+        sessionKey: "main",
+        sessionId: "session-client-caps",
+        resetTriggered: false,
+      }),
+    });
     const runner = createFollowupRunner({
       typing: createMockTypingController(),
       typingMode: "instant",
-      sessionEntry,
-      sessionStore: { main: sessionEntry },
       sessionKey: "main",
-      storePath,
       defaultModel: "anthropic/claude",
     });
 
@@ -735,7 +737,8 @@ describe("createFollowupRunner reply-lane admission", () => {
 
     const call = requireLastMockCallArg(runEmbeddedAgentMock, "run embedded agent");
     expect(call.clientCaps).toEqual(["tool-events", "inline-widgets"]);
-  });
+    // Constrained CI workers charge this file's cold module-reset pause to its first test.
+  }, 300_000);
 
   it("adopts a matching admission-time model lock for queued execution", async () => {
     const storePath = "/tmp/openclaw-followup-admission-model-lock.json";

--- a/src/cli/gateway-cli.coverage.test.ts
+++ b/src/cli/gateway-cli.coverage.test.ts
@@ -7,7 +7,8 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { withEnvOverride } from "../config/test-helpers.js";
 import { GatewayLockError } from "../infra/gateway-lock.js";
 import { registerGatewayCli } from "./gateway-cli.js";
-import type { GatewayCliDependencies } from "./gateway-cli/register.js";
+
+type GatewayCliDependencies = Parameters<typeof registerGatewayCli>[1];
 
 type DiscoveredBeacon = Awaited<
   ReturnType<typeof import("../infra/bonjour-discovery.js").discoverGatewayBeacons>

--- a/src/cli/gateway-cli.coverage.test.ts
+++ b/src/cli/gateway-cli.coverage.test.ts
@@ -2,21 +2,16 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { expectDefined } from "@openclaw/normalization-core";
 import { Command } from "commander";
-import { SessionManager } from "openclaw/plugin-sdk/agent-sessions";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { withEnvOverride } from "../config/test-helpers.js";
-import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { testApi as usageTestApi, usageHandlers } from "../gateway/server-methods/usage.js";
 import { GatewayLockError } from "../infra/gateway-lock.js";
 import { registerGatewayCli } from "./gateway-cli.js";
+import type { GatewayCliDependencies } from "./gateway-cli/register.js";
 
 type DiscoveredBeacon = Awaited<
   ReturnType<typeof import("../infra/bonjour-discovery.js").discoverGatewayBeacons>
 >[number];
-type UsageCostHandlerArgs = Parameters<(typeof usageHandlers)["usage.cost"]>[0];
-
 const defaultCallGateway = async (): Promise<unknown> => ({ ok: true });
 const callGateway = vi.fn<(opts: unknown) => Promise<unknown>>(defaultCallGateway);
 const formatGatewayClientRequestErrorJson = vi.fn();
@@ -129,10 +124,10 @@ vi.mock("../infra/ports.js", () => ({
 
 let gatewayProgram: Command;
 
-function createGatewayProgram() {
+function createGatewayProgram(deps?: GatewayCliDependencies) {
   const program = new Command();
   program.exitOverride();
-  registerGatewayCli(program);
+  registerGatewayCli(program, deps);
   return program;
 }
 
@@ -298,104 +293,53 @@ describe("gateway-cli coverage", () => {
     );
   });
 
-  it("waits for real all-agent usage caches before printing totals", async () => {
-    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-usage-cost-cli-"));
-    const config = {
-      agents: {
-        list: [{ id: "main", default: true }, { id: "dev" }],
+  it("waits for refreshing all-agent usage caches before printing totals", async () => {
+    const settleSleep = vi.fn(async (_ms: number) => {});
+    gatewayProgram = createGatewayProgram({
+      usageCostSettle: {
+        now: () => 0,
+        sleep: settleSleep,
       },
-      session: {},
-    } as OpenClawConfig;
-    const seedUsage = (agentId: string, totalTokens: number, totalCost: number) => {
-      const sessionsDir = path.join(stateDir, "agents", agentId, "sessions");
-      fs.mkdirSync(sessionsDir, { recursive: true });
-      const session = SessionManager.create(sessionsDir, sessionsDir);
-      session.appendMessage({
-        role: "assistant",
-        content: [{ type: "text", text: "done" }],
-        api: "openai-responses",
-        provider: "openai",
-        model: "gpt-5.4",
-        usage: {
-          input: totalTokens,
-          output: 0,
-          cacheRead: 0,
-          cacheWrite: 0,
-          totalTokens,
-          cost: {
-            input: totalCost,
-            output: 0,
-            cacheRead: 0,
-            cacheWrite: 0,
-            total: totalCost,
-          },
-        },
-        stopReason: "stop",
-        timestamp: Date.now(),
+    });
+    callGateway
+      .mockResolvedValueOnce({
+        cacheStatus: { status: "refreshing", cachedFiles: 0, pendingFiles: 2 },
+      })
+      .mockResolvedValueOnce({
+        totals: { totalTokens: 100, totalCost: 0.1 },
+        cacheStatus: { status: "fresh", cachedFiles: 2, pendingFiles: 0 },
       });
-    };
 
-    try {
-      await withEnvOverride({ OPENCLAW_STATE_DIR: stateDir }, async () => {
-        seedUsage("main", 30, 0.03);
-        seedUsage("dev", 70, 0.07);
-        usageTestApi.costUsageCache.clear();
-        const observedStatuses: Array<string | undefined> = [];
-        callGateway.mockImplementation(async (raw) => {
-          const request = raw as { method?: string; params?: Record<string, unknown> };
-          if (request.method !== "usage.cost") {
-            return { ok: true };
-          }
-          return await new Promise((resolve, reject) => {
-            const respond: UsageCostHandlerArgs["respond"] = (ok, payload, error) => {
-              if (!ok) {
-                reject(new Error(error?.message ?? "usage.cost failed"));
-                return;
-              }
-              const summary = payload as { cacheStatus?: { status?: string } };
-              observedStatuses.push(summary.cacheStatus?.status);
-              resolve(payload);
-            };
-            const result = expectDefined(
-              usageHandlers["usage.cost"],
-              'usageHandlers["usage.cost"] test invariant',
-            )({
-              respond,
-              params: request.params ?? {},
-              context: { getRuntimeConfig: () => config },
-            } as unknown as UsageCostHandlerArgs);
-            Promise.resolve(result).catch(reject);
-          });
-        });
+    await runGatewayCommand(["gateway", "usage-cost", "--all-agents", "--days", "7", "--json"]);
 
-        await runGatewayCommand(["gateway", "usage-cost", "--all-agents", "--days", "7", "--json"]);
-
-        expect(observedStatuses[0]).toBe("refreshing");
-        expect(observedStatuses.at(-1)).toBe("fresh");
-        expect(callGateway.mock.calls.length).toBeGreaterThanOrEqual(2);
-        const costCalls = callGateway.mock.calls.map(
-          ([raw]) => raw as { method?: string; timeoutMs?: number },
-        );
-        expect(costCalls.every((call) => call.method === "usage.cost")).toBe(true);
-        expect(costCalls.every((call) => (call.timeoutMs ?? 0) > 0)).toBe(true);
-        expect(costCalls.every((call) => (call.timeoutMs ?? 0) <= 10_000)).toBe(true);
-        expect(costCalls[0]?.timeoutMs).toBe(10_000);
-        expect(defaultRuntime.writeJson).toHaveBeenCalledWith(
-          expect.objectContaining({
-            totals: expect.objectContaining({ totalTokens: 100, totalCost: 0.1 }),
-            cacheStatus: expect.objectContaining({ status: "fresh" }),
-          }),
-        );
-      });
-    } finally {
-      usageTestApi.costUsageCache.clear();
-      fs.rmSync(stateDir, { recursive: true, force: true });
-    }
+    expect(callGateway).toHaveBeenCalledTimes(2);
+    expect(settleSleep).toHaveBeenCalledOnce();
+    expect(settleSleep).toHaveBeenCalledWith(250);
+    const costCalls = callGateway.mock.calls.map(
+      ([raw]) => raw as { method?: string; timeoutMs?: number },
+    );
+    expect(costCalls.every((call) => call.method === "usage.cost")).toBe(true);
+    expect(costCalls.every((call) => call.timeoutMs === 10_000)).toBe(true);
+    expect(defaultRuntime.writeJson).toHaveBeenCalledWith(
+      expect.objectContaining({
+        totals: expect.objectContaining({ totalTokens: 100, totalCost: 0.1 }),
+        cacheStatus: expect.objectContaining({ status: "fresh" }),
+      }),
+    );
   });
 
   it.each(["refreshing", "partial", "stale"] as const)(
     "uses --timeout as the command-wide usage-cost settle budget for %s caches",
     async (status) => {
+      let now = 0;
+      gatewayProgram = createGatewayProgram({
+        usageCostSettle: {
+          now: () => now,
+          sleep: async (ms) => {
+            now += ms;
+          },
+        },
+      });
       callGateway.mockResolvedValue({
         cacheStatus: { status, cachedFiles: 0, pendingFiles: 1 },
       });

--- a/src/cli/gateway-cli/register.ts
+++ b/src/cli/gateway-cli/register.ts
@@ -60,6 +60,13 @@ const DEFAULT_USAGE_COST_TIMEOUT_MS = 5 * 60_000;
 const USAGE_COST_SETTLE_INITIAL_POLL_MS = 250;
 const USAGE_COST_SETTLE_MAX_POLL_MS = 5_000;
 
+export type GatewayCliDependencies = {
+  usageCostSettle?: {
+    now: () => number;
+    sleep: (ms: number) => Promise<void>;
+  };
+};
+
 function loadConfigModule() {
   return configModuleLoader.load();
 }
@@ -126,15 +133,19 @@ function parseGatewayCallParams(value = "{}"): unknown {
 async function loadSettledCostUsageSummary(
   rpcOpts: GatewayRpcOpts,
   params: { days: number; agentId?: string; agentScope?: "all" },
+  deps: NonNullable<GatewayCliDependencies["usageCostSettle"]> = {
+    now: Date.now,
+    sleep,
+  },
 ): Promise<CostUsageSummary> {
   const timeoutMs = parseTimeoutMsWithFallback(rpcOpts.timeout, DEFAULT_USAGE_COST_TIMEOUT_MS, {
     invalidType: "error",
   });
-  const deadline = Date.now() + timeoutMs;
+  const deadline = deps.now() + timeoutMs;
   let lastSummary: CostUsageSummary | undefined;
   let pollMs = USAGE_COST_SETTLE_INITIAL_POLL_MS;
   for (;;) {
-    const remainingBeforeCallMs = deadline - Date.now();
+    const remainingBeforeCallMs = deadline - deps.now();
     if (remainingBeforeCallMs <= 0) {
       throw createUsageCostSettleTimeoutError(lastSummary);
     }
@@ -149,13 +160,13 @@ async function loadSettledCostUsageSummary(
       return summary;
     }
 
-    const remainingMs = deadline - Date.now();
+    const remainingMs = deadline - deps.now();
     if (remainingMs <= 0) {
       throw createUsageCostSettleTimeoutError(summary);
     }
     // The usage-cost timeout is the whole command budget. Each transport call
     // remains capped separately so one unresponsive RPC cannot consume it all.
-    await sleep(Math.min(pollMs, remainingMs));
+    await deps.sleep(Math.min(pollMs, remainingMs));
     pollMs = Math.min(pollMs * 2, USAGE_COST_SETTLE_MAX_POLL_MS);
   }
 }
@@ -559,7 +570,7 @@ async function writeSupportExportFromCli(opts: {
   }
 }
 
-export function registerGatewayCli(program: Command) {
+export function registerGatewayCli(program: Command, deps: GatewayCliDependencies = {}) {
   const gateway = addGatewayRunCommand(
     program
       .command("gateway")
@@ -633,11 +644,15 @@ export function registerGatewayCli(program: Command) {
             if (agentId && opts.allAgents) {
               throw new Error("Use --agent or --all-agents, not both");
             }
-            const summary = await loadSettledCostUsageSummary(rpcOpts, {
-              days,
-              ...(agentId ? { agentId } : {}),
-              ...(opts.allAgents ? { agentScope: "all" } : {}),
-            });
+            const summary = await loadSettledCostUsageSummary(
+              rpcOpts,
+              {
+                days,
+                ...(agentId ? { agentId } : {}),
+                ...(opts.allAgents ? { agentScope: "all" } : {}),
+              },
+              deps.usageCostSettle,
+            );
             if (rpcOpts.json) {
               defaultRuntime.writeJson(summary);
               return;

--- a/src/cli/gateway-cli/register.ts
+++ b/src/cli/gateway-cli/register.ts
@@ -60,7 +60,7 @@ const DEFAULT_USAGE_COST_TIMEOUT_MS = 5 * 60_000;
 const USAGE_COST_SETTLE_INITIAL_POLL_MS = 250;
 const USAGE_COST_SETTLE_MAX_POLL_MS = 5_000;
 
-export type GatewayCliDependencies = {
+type GatewayCliDependencies = {
   usageCostSettle?: {
     now: () => number;
     sleep: (ms: number) => Promise<void>;

--- a/src/cli/help-exit.process.test.ts
+++ b/src/cli/help-exit.process.test.ts
@@ -257,13 +257,13 @@ describe("CLI help process exit", () => {
         registry === "core"
           ? await registerCoreCliByName(program, createProgramContext(), group, argv)
           : await registerSubCliByName(program, group, argv);
-      const error = await program
+      const parseResult = await program
         .parseAsync(argv.slice(2), { from: "user" })
-        .catch((error) => error);
+        .catch((cause: unknown) => cause);
 
       expect(registered).toBe(true);
-      expect(error).toBeInstanceOf(CommanderError);
-      expect(error).toMatchObject({ code: "commander.helpDisplayed", exitCode: 0 });
+      expect(parseResult).toBeInstanceOf(CommanderError);
+      expect(parseResult).toMatchObject({ code: "commander.helpDisplayed", exitCode: 0 });
       expect(stderr).toBe("");
       expect(stdout).toContain(`Usage: openclaw ${usageCommand} [options] [command]`);
     },

--- a/src/cli/help-exit.process.test.ts
+++ b/src/cli/help-exit.process.test.ts
@@ -4,24 +4,28 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { promisify } from "node:util";
+import { Command, CommanderError } from "commander";
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { registerCoreCliByName } from "./program/command-registry.js";
+import { createProgramContext } from "./program/context.js";
+import { registerSubCliByName } from "./program/register.subclis.js";
 
 const execFileAsync = promisify(execFile);
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 const CHILD_PROCESS_TIMEOUT_MS = 30_000;
 const LAZY_GROUP_HELP_CASES = [
-  { group: "backup", usageCommand: "backup" },
-  { group: "capability", usageCommand: "infer|capability" },
-  { group: "channels", usageCommand: "channels" },
-  { group: "clawbot", usageCommand: "clawbot" },
-  { group: "daemon", usageCommand: "daemon" },
-  { group: "hooks", usageCommand: "hooks" },
-  { group: "infer", usageCommand: "infer|capability" },
-  { group: "migrate", usageCommand: "migrate" },
-  { group: "node", usageCommand: "node" },
-  { group: "security", usageCommand: "security" },
-  { group: "update", usageCommand: "update" },
+  { group: "backup", usageCommand: "backup", registry: "core" },
+  { group: "capability", usageCommand: "infer|capability", registry: "subcli" },
+  { group: "channels", usageCommand: "channels", registry: "subcli" },
+  { group: "clawbot", usageCommand: "clawbot", registry: "subcli" },
+  { group: "daemon", usageCommand: "daemon", registry: "subcli" },
+  { group: "hooks", usageCommand: "hooks", registry: "subcli" },
+  { group: "infer", usageCommand: "infer|capability", registry: "subcli" },
+  { group: "migrate", usageCommand: "migrate", registry: "core" },
+  { group: "node", usageCommand: "node", registry: "subcli" },
+  { group: "security", usageCommand: "security", registry: "subcli" },
+  { group: "update", usageCommand: "update", registry: "subcli" },
 ] as const;
 
 async function createHelpProcessFixture(
@@ -199,35 +203,22 @@ type CliProcessFailure = Error & {
   stderr?: string;
   stdout?: string;
 };
-
-async function runCliProcessExpectFailure(args: string[]): Promise<CliProcessFailure> {
-  try {
-    await runCliProcess({ args });
-  } catch (error) {
-    return error as CliProcessFailure;
-  }
-  throw new Error(`expected CLI process failure for ${args.join(" ")}`);
-}
-
 describe("CLI help process exit", () => {
-  it.each([
-    { args: ["--help"], usage: "Usage: openclaw [options] [command]" },
-    { args: ["path", "--help"], usage: "Usage: openclaw path [options] [command]" },
-  ])("exits promptly after $args", async ({ args, usage }) => {
-    const result = await runCliProcess({ args, forbidTlsImport: true });
+  it("exits promptly after root --help", async () => {
+    const result = await runCliProcess({ args: ["--help"], forbidTlsImport: true });
 
     expect(result.stderr).toBe("");
-    expect(result.stdout).toContain(usage);
+    expect(result.stdout).toContain("Usage: openclaw [options] [command]");
   });
 
-  it.each(LAZY_GROUP_HELP_CASES)("exits promptly after $group --help", async (testCase) => {
-    const { group, usageCommand } = testCase;
-    const result = await runCliProcess({ args: [group, "--help"], keepAlive: true });
+  // One lazy process is representative by design; the matrix below exercises
+  // both core and sub-CLI registrars without multiplying Node+tsx launches.
+  it("exits promptly after a lazy group --help", async () => {
+    const result = await runCliProcess({ args: ["backup", "--help"], keepAlive: true });
 
     expect(result.stderr).toBe("");
-    expect(result.stdout).toContain(`Usage: openclaw ${usageCommand} [options] [command]`);
+    expect(result.stdout).toContain("Usage: openclaw backup [options] [command]");
   });
-
   it("flushes explicitly requested entry traces on precomputed help", async () => {
     const result = await runCliProcess({
       args: ["gateway", "--help"],
@@ -244,20 +235,56 @@ describe("CLI help process exit", () => {
       ]),
     );
   });
-});
 
-describe("route-first CLI process rejection", () => {
-  it.each([
-    { name: "health", args: ["health", "--wat"], option: "--wat" },
-    { name: "status", args: ["status", "--wat"], option: "--wat" },
-    { name: "sessions", args: ["sessions", "--wat"], option: "--wat" },
-    { name: "agents list", args: ["agents", "list", "--wat"], option: "--wat" },
-    { name: "bare agents", args: ["agents", "--wat"], option: "--wat" },
-  ])("rejects unknown $name options with a nonzero exit", async ({ args, option }) => {
-    const failure = await runCliProcessExpectFailure(args);
+  it.each(LAZY_GROUP_HELP_CASES)(
+    "renders in-process help for $group",
+    async ({ group, usageCommand, registry }) => {
+      let stdout = "";
+      let stderr = "";
+      const program = new Command()
+        .name("openclaw")
+        .exitOverride()
+        .configureOutput({
+          writeOut: (value) => {
+            stdout += value;
+          },
+          writeErr: (value) => {
+            stderr += value;
+          },
+        });
+      const argv = ["node", "openclaw", group, "--help"];
+      const registered =
+        registry === "core"
+          ? await registerCoreCliByName(program, createProgramContext(), group, argv)
+          : await registerSubCliByName(program, group, argv);
+      const error = await program
+        .parseAsync(argv.slice(2), { from: "user" })
+        .catch((error) => error);
 
-    expect(failure.code).toBe(1);
-    expect(failure.stderr).toContain(`does not recognize option "${option}"`);
+      expect(registered).toBe(true);
+      expect(error).toBeInstanceOf(CommanderError);
+      expect(error).toMatchObject({ code: "commander.helpDisplayed", exitCode: 0 });
+      expect(stderr).toBe("");
+      expect(stdout).toContain(`Usage: openclaw ${usageCommand} [options] [command]`);
+    },
+  );
+
+  // Keep the process budget to root plus one core lazy group. Route-first
+  // rejection is decomposed across route-args/routes and error-output tests.
+  it("keeps the lazy help table exhaustive", () => {
+    expect(LAZY_GROUP_HELP_CASES.map(({ group }) => group)).toEqual([
+      "backup",
+      "capability",
+      "channels",
+      "clawbot",
+      "daemon",
+      "hooks",
+      "infer",
+      "migrate",
+      "node",
+      "security",
+      "update",
+    ]);
   });
 });
 

--- a/src/commands/doctor-config-preflight.state-migration.test.ts
+++ b/src/commands/doctor-config-preflight.state-migration.test.ts
@@ -197,7 +197,8 @@ vi.mock("../config/io.js", () => ({
 
 vi.mock("../../packages/terminal-core/src/note.js", () => ({ note }));
 
-const { runDoctorConfigPreflight } = await import("./doctor-config-preflight.js");
+const { mapStartupPluginQuarantineRefresh, runDoctorConfigPreflight } =
+  await import("./doctor-config-preflight.js");
 
 describe("runDoctorConfigPreflight state migration", () => {
   beforeEach(() => {
@@ -477,13 +478,12 @@ describe("runDoctorConfigPreflight state migration", () => {
     expect(startupMigrationLeaseRelease).toHaveBeenCalledOnce();
   });
 
-  it("refreshes plugin quarantine without repair when the checkpoint is current", async () => {
-    planStartupPluginConvergence.mockResolvedValueOnce({
-      required: true,
-      installRecords: { discord: { source: "npm", installPath: "/plugins/discord" } },
-    });
-    runActivePluginPayloadSmokeCheck.mockResolvedValueOnce({
-      checked: ["discord"],
+  it("maps active payload failures into refreshed plugin quarantine", () => {
+    const result = mapStartupPluginQuarantineRefresh({
+      cfg: {
+        gateway: { mode: "local", port: 19091 },
+        plugins: { entries: { discord: { enabled: true } } },
+      },
       failures: [
         {
           pluginId: "discord",
@@ -493,64 +493,23 @@ describe("runDoctorConfigPreflight state migration", () => {
         },
       ],
     });
-    readConfigFileSnapshot.mockResolvedValueOnce({
-      exists: true,
-      valid: true,
-      config: {
-        gateway: { mode: "local", port: 19091 },
-        plugins: { entries: { discord: { enabled: true } } },
-      },
-      sourceConfig: {
-        gateway: { mode: "local", port: 19091 },
-        plugins: { entries: { discord: { enabled: true } } },
-      },
-      parsed: {
-        gateway: { mode: "local", port: 19091 },
-        plugins: { entries: { discord: { enabled: true } } },
-      },
-      legacyIssues: [],
-      warnings: [],
-      issues: [],
-    });
 
-    await runDoctorConfigPreflight({
-      migrateLegacyConfig: false,
-      invalidConfigNote: false,
-      requireStartupMigrationCheckpoint: true,
-    });
-
-    expect(acquireStartupMigrationLease).not.toHaveBeenCalled();
-    expect(recordSuccessfulStartupMigrations).not.toHaveBeenCalled();
-    expect(autoMigrateLegacyStateDir).not.toHaveBeenCalled();
-    expect(repairLegacyCronStoreWithoutPrompt).not.toHaveBeenCalled();
-    expect(autoMigrateLegacyState).not.toHaveBeenCalled();
-    expect(autoMigrateLegacyTaskStateSidecars).not.toHaveBeenCalled();
-    expect(runPostCorePluginConvergence).not.toHaveBeenCalled();
-    expect(runActivePluginPayloadSmokeCheck).toHaveBeenCalledWith({
-      cfg: {
-        gateway: { mode: "local", port: 19091 },
-        plugins: { entries: { discord: { enabled: true } } },
-      },
-      records: { discord: { source: "npm", installPath: "/plugins/discord" } },
-      env: process.env,
-    });
-    expect(listActiveDegradedPlugins()).toMatchObject([
+    expect(result.blockingDiagnostic).toBeNull();
+    expect(result.quarantinedPlugins).toMatchObject([
       {
         pluginId: "discord",
         state: "configured-unavailable",
         diagnostic: { reason: "missing-main-entry" },
       },
     ]);
-    expect(readConfigFileSnapshot).toHaveBeenCalledOnce();
   });
 
-  it("keeps ownerless payload failures blocking when the checkpoint is current", async () => {
-    planStartupPluginConvergence.mockResolvedValueOnce({
-      required: true,
-      installRecords: { discord: { source: "npm" } },
-    });
-    runActivePluginPayloadSmokeCheck.mockResolvedValueOnce({
-      checked: ["discord"],
+  it("maps active ownerless payload failures into blocking diagnostics", () => {
+    const result = mapStartupPluginQuarantineRefresh({
+      cfg: {
+        gateway: { mode: "local", port: 19091 },
+        plugins: { entries: { discord: { enabled: true } } },
+      },
       failures: [
         {
           pluginId: "discord",
@@ -559,36 +518,37 @@ describe("runDoctorConfigPreflight state migration", () => {
         },
       ],
     });
-    readConfigFileSnapshot.mockResolvedValueOnce({
-      exists: true,
-      valid: true,
-      config: {
-        gateway: { mode: "local", port: 19091 },
-        plugins: { entries: { discord: { enabled: true } } },
+
+    expect(result.quarantinedPlugins).toEqual([]);
+    expect(result.blockingDiagnostic?.messages).toEqual([
+      expect.stringContaining("Install path is missing from the plugin install record."),
+    ]);
+  });
+
+  it("clears stale plugin quarantine through the current-checkpoint preflight", async () => {
+    setActiveDegradedPlugins([
+      {
+        pluginId: "stale-plugin",
+        state: "configured-unavailable",
+        diagnostic: {
+          kind: "plugin-verification",
+          reason: "missing-main-entry",
+          detail: "index.js",
+          installPath: "/plugins/stale-plugin",
+        },
       },
-      sourceConfig: {
-        gateway: { mode: "local", port: 19091 },
-        plugins: { entries: { discord: { enabled: true } } },
-      },
-      parsed: {
-        gateway: { mode: "local", port: 19091 },
-        plugins: { entries: { discord: { enabled: true } } },
-      },
-      legacyIssues: [],
-      warnings: [],
-      issues: [],
+    ]);
+    planStartupPluginConvergence.mockResolvedValueOnce({ required: false, installRecords: {} });
+
+    await runDoctorConfigPreflight({
+      migrateLegacyConfig: false,
+      invalidConfigNote: false,
+      requireStartupMigrationCheckpoint: true,
     });
 
-    await expect(
-      runDoctorConfigPreflight({
-        migrateLegacyConfig: false,
-        invalidConfigNote: false,
-        requireStartupMigrationCheckpoint: true,
-      }),
-    ).rejects.toThrow("Install path is missing from the plugin install record.");
-
-    expect(runPostCorePluginConvergence).not.toHaveBeenCalled();
     expect(listActiveDegradedPlugins()).toEqual([]);
+    expect(runActivePluginPayloadSmokeCheck).not.toHaveBeenCalled();
+    expect(recordSuccessfulStartupMigrations).not.toHaveBeenCalled();
   });
 
   it("keeps ownerless install-record failures blocking", async () => {

--- a/src/commands/doctor-config-preflight.ts
+++ b/src/commands/doctor-config-preflight.ts
@@ -311,18 +311,13 @@ async function refreshStartupPluginQuarantine(params: {
       env: params.env,
     }),
   );
-  const quarantinedPlugins = buildStartupPluginQuarantine({
+  const result = mapStartupPluginQuarantineRefresh({
     cfg: params.cfg,
     failures: smoke.failures,
   });
-  const blockingFailures = smoke.failures.filter(
-    (failure) =>
-      !failure.installPath &&
-      isStartupPluginVerificationFailureActive({ cfg: params.cfg, failure }),
-  );
-  if (quarantinedPlugins.length > 0) {
+  if (result.quarantinedPlugins.length > 0) {
     note(
-      quarantinedPlugins
+      result.quarantinedPlugins
         .map(
           (plugin) =>
             `- ${formatStartupPluginSmokeFailure({
@@ -338,6 +333,20 @@ async function refreshStartupPluginQuarantine(params: {
       "Doctor warnings",
     );
   }
+  return result;
+}
+
+/** Map payload verification failures into startup quarantine and blocking diagnostics. */
+export function mapStartupPluginQuarantineRefresh(params: {
+  cfg: OpenClawConfig;
+  failures: readonly PluginPayloadSmokeFailure[];
+}): StartupPluginConvergenceResult {
+  const quarantinedPlugins = buildStartupPluginQuarantine(params);
+  const blockingFailures = params.failures.filter(
+    (failure) =>
+      !failure.installPath &&
+      isStartupPluginVerificationFailureActive({ cfg: params.cfg, failure }),
+  );
   return {
     blockingDiagnostic:
       blockingFailures.length > 0

--- a/src/gateway/session-model-patch-origin.ts
+++ b/src/gateway/session-model-patch-origin.ts
@@ -8,6 +8,7 @@ import { resolveSessionModelRef } from "../agents/session-model-ref.js";
 import type { SessionEntry } from "../config/sessions.js";
 import { createAgentPatchedSessionModelFallback } from "../config/sessions/session-model-fallback.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
 
 const agentSessionModelPatch = new AsyncLocalStorage<boolean>();
 
@@ -24,6 +25,7 @@ export function shouldPreserveSessionAuthProfileOverride(params: {
   entry: SessionEntry;
   currentProvider: string;
   provider: string;
+  metadataSnapshot?: Pick<PluginMetadataSnapshot, "plugins">;
 }): boolean {
   const profileOverride = normalizeOptionalString(params.entry.authProfileOverride);
   const provider = normalizeOptionalLowercaseString(params.provider);
@@ -32,10 +34,14 @@ export function shouldPreserveSessionAuthProfileOverride(params: {
   }
   const resolvesToTargetProvider = (rawProvider: string | undefined): boolean => {
     const candidate = normalizeOptionalLowercaseString(rawProvider);
+    const lookupParams = {
+      config: params.cfg,
+      ...(params.metadataSnapshot ? { metadataSnapshot: params.metadataSnapshot } : {}),
+    };
     return Boolean(
       candidate &&
-      resolveProviderIdForAuth(candidate, { config: params.cfg }) ===
-        resolveProviderIdForAuth(provider, { config: params.cfg }),
+      resolveProviderIdForAuth(candidate, lookupParams) ===
+        resolveProviderIdForAuth(provider, lookupParams),
     );
   };
   const delimiterIndex = profileOverride.indexOf(":");

--- a/src/gateway/sessions-patch.test.ts
+++ b/src/gateway/sessions-patch.test.ts
@@ -5,6 +5,7 @@ import type { SessionCreatedActor } from "../../packages/gateway-protocol/src/in
 import { resetProviderAuthAliasMapCacheForTest } from "../agents/provider-auth-aliases.test-support.js";
 import type { OpenClawConfig } from "../config/config.js";
 import type { SessionEntry } from "../config/sessions.js";
+import type { PluginManifestRecord } from "../plugins/manifest-registry.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../plugins/runtime.js";
 import { AGENT_HARNESS_SESSION_KEY_RESERVED_MESSAGE } from "../sessions/agent-harness-session-key.js";
@@ -32,6 +33,30 @@ const OPENAI_GPT_ID = "gpt-5.4";
 const EMPTY_CFG = {} as OpenClawConfig;
 
 type ApplySessionsPatchArgs = Parameters<typeof applySessionsPatchToStore>[0];
+type ProviderAuthMetadataSnapshot = NonNullable<
+  ApplySessionsPatchArgs["providerAuthMetadataSnapshot"]
+>;
+
+const EMPTY_PROVIDER_AUTH_METADATA_SNAPSHOT = {
+  plugins: [],
+} satisfies ProviderAuthMetadataSnapshot;
+const BYTEPLUS_PROVIDER_AUTH_METADATA_SNAPSHOT = {
+  plugins: [
+    {
+      id: "byteplus",
+      channels: [],
+      providers: ["byteplus", "byteplus-plan"],
+      cliBackends: [],
+      skills: [],
+      hooks: [],
+      origin: "bundled",
+      rootDir: "/plugins/byteplus",
+      source: "test",
+      manifestPath: "/plugins/byteplus/openclaw.plugin.json",
+      providerAuthAliases: { "byteplus-plan": "byteplus" },
+    } satisfies PluginManifestRecord,
+  ],
+} satisfies ProviderAuthMetadataSnapshot;
 
 async function runPatch(params: {
   patch: ApplySessionsPatchArgs["patch"];
@@ -40,6 +65,7 @@ async function runPatch(params: {
   storeKey?: string;
   agentId?: string;
   loadGatewayModelCatalog?: ApplySessionsPatchArgs["loadGatewayModelCatalog"];
+  providerAuthMetadataSnapshot?: ApplySessionsPatchArgs["providerAuthMetadataSnapshot"];
   archivedBy?: SessionCreatedActor;
 }) {
   return applySessionsPatchToStore({
@@ -49,6 +75,7 @@ async function runPatch(params: {
     agentId: params.agentId,
     patch: params.patch,
     loadGatewayModelCatalog: params.loadGatewayModelCatalog,
+    providerAuthMetadataSnapshot: params.providerAuthMetadataSnapshot,
     archivedBy: params.archivedBy,
   });
 }
@@ -124,6 +151,7 @@ async function applyMainModelPatch(params: {
   cfg?: OpenClawConfig;
   model: string | null;
   catalogRefs?: string[];
+  providerAuthMetadataSnapshot?: ProviderAuthMetadataSnapshot;
 }) {
   return expectPatchOk(
     await runPatch({
@@ -132,6 +160,8 @@ async function applyMainModelPatch(params: {
       patch: { key: MAIN_SESSION_KEY, model: params.model },
       loadGatewayModelCatalog:
         params.catalogRefs === undefined ? undefined : loadCatalog(...params.catalogRefs),
+      providerAuthMetadataSnapshot:
+        params.providerAuthMetadataSnapshot ?? EMPTY_PROVIDER_AUTH_METADATA_SNAPSHOT,
     }),
   );
 }
@@ -711,6 +741,7 @@ describe("gateway sessions patch", () => {
       store,
       model: "byteplus-plan/ark-code-latest",
       catalogRefs: ["byteplus-plan/ark-code-latest"],
+      providerAuthMetadataSnapshot: BYTEPLUS_PROVIDER_AUTH_METADATA_SNAPSHOT,
     });
     expectModelSelection(entry, "byteplus-plan", "ark-code-latest");
     expectAuthOverride(entry, { profile: "byteplus:work", compactionCount: 2 });

--- a/src/gateway/sessions-patch.ts
+++ b/src/gateway/sessions-patch.ts
@@ -36,6 +36,7 @@ import {
 import type { SessionEntry } from "../config/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizeExecTarget } from "../infra/exec-approvals.js";
+import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
 import {
   isSubagentSessionKey,
   normalizeAgentId,
@@ -139,6 +140,7 @@ export async function projectSessionsPatchEntry(params: {
   patch: SessionsPatchParams;
   archivedBy?: SessionCreatedActor;
   loadGatewayModelCatalog?: () => Promise<ModelCatalogEntry[]>;
+  providerAuthMetadataSnapshot?: Pick<PluginMetadataSnapshot, "plugins">;
   /** Exact harness owner authorized to project its new reserved session row. */
   authorizedAgentHarnessId?: string;
 }): Promise<{ ok: true; entry: SessionEntry } | { ok: false; error: ErrorShape }> {
@@ -529,6 +531,9 @@ export async function projectSessionsPatchEntry(params: {
           currentProvider: next.providerOverride ?? next.modelProvider ?? resolvedDefault.provider,
           entry: next,
           provider: resolvedDefault.provider,
+          ...(params.providerAuthMetadataSnapshot
+            ? { metadataSnapshot: params.providerAuthMetadataSnapshot }
+            : {}),
         }),
       });
       delete next.liveModelSwitchPending;
@@ -574,6 +579,9 @@ export async function projectSessionsPatchEntry(params: {
           currentProvider: next.providerOverride ?? next.modelProvider ?? resolvedDefault.provider,
           entry: next,
           provider: resolved.provider,
+          ...(params.providerAuthMetadataSnapshot
+            ? { metadataSnapshot: params.providerAuthMetadataSnapshot }
+            : {}),
         }),
         markLiveSwitchPending: true,
       });
@@ -668,6 +676,7 @@ export async function applySessionsPatchToStore(params: {
   patch: SessionsPatchParams;
   archivedBy?: SessionCreatedActor;
   loadGatewayModelCatalog?: () => Promise<ModelCatalogEntry[]>;
+  providerAuthMetadataSnapshot?: Pick<PluginMetadataSnapshot, "plugins">;
   /** Exact harness owner authorized to project its new reserved session row. */
   authorizedAgentHarnessId?: string;
 }): Promise<{ ok: true; entry: SessionEntry } | { ok: false; error: ErrorShape }> {
@@ -680,6 +689,7 @@ export async function applySessionsPatchToStore(params: {
     patch: params.patch,
     archivedBy: params.archivedBy,
     loadGatewayModelCatalog: params.loadGatewayModelCatalog,
+    providerAuthMetadataSnapshot: params.providerAuthMetadataSnapshot,
     authorizedAgentHarnessId: params.authorizedAgentHarnessId,
   });
   if (projected.ok) {

--- a/src/plugin-sdk/api-baseline.test.ts
+++ b/src/plugin-sdk/api-baseline.test.ts
@@ -2,7 +2,7 @@
  * Tests the plugin SDK public API baseline.
  */
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 import { publicPluginSdkEntrypoints } from "../../scripts/lib/plugin-sdk-entries.mjs";
 import {
   computePluginSdkApiBaselineHashFileContent,
@@ -10,10 +10,32 @@ import {
   normalizePluginSdkApiDeclarationText,
   normalizePluginSdkApiSourcePath,
   renderPluginSdkApiBaseline,
+  renderPluginSdkApiBaselineModules,
   type PluginSdkApiBaselineRender,
 } from "./api-baseline.js";
 
+const TEST_ENTRYPOINTS = [
+  "agent-harness-runtime",
+  "approval-gateway-runtime",
+  "channel-policy",
+  "core",
+  "infra-runtime",
+  "provider-auth",
+  "provider-catalog-live-runtime",
+  "provider-oauth-runtime",
+  "provider-selection-runtime",
+  "provider-web-search-config-contract",
+  "realtime-voice",
+  "sqlite-runtime-testing",
+] as const;
+
 describe("Plugin SDK API baseline", () => {
+  let rendered: PluginSdkApiBaselineRender;
+
+  beforeAll(async () => {
+    rendered = await renderPluginSdkApiBaseline({ entrypoints: TEST_ENTRYPOINTS });
+  });
+
   it("normalizes declaration import paths to repo-relative paths", () => {
     const repoRoot = process.cwd();
     const modelCatalogPath = path.join(repoRoot, "src", "agents", "agent-model-discovery");
@@ -66,26 +88,16 @@ describe("Plugin SDK API baseline", () => {
     expect(normalizePluginSdkApiSourcePath(repoRoot, sourcePath)).toBe("src/plugin-sdk/core.ts");
   });
 
-  it("renders complete declarations for the canonical public entrypoint inventory", async () => {
+  it("renders complete declarations for the canonical public entrypoint inventory", () => {
     expect(listPluginSdkApiBaselineEntrypoints()).toEqual(publicPluginSdkEntrypoints);
 
-    const rendered = await renderPluginSdkApiBaseline({
-      entrypoints: [
-        "agent-harness-runtime",
-        "approval-gateway-runtime",
-        "infra-runtime",
-        "provider-catalog-live-runtime",
-        "provider-oauth-runtime",
-        "provider-selection-runtime",
-        "provider-web-search-config-contract",
-        "realtime-voice",
-        "sqlite-runtime-testing",
-      ],
-    });
     const findDeclaration = (exportName: string) =>
       rendered.baseline.modules
         .flatMap((moduleSurface) => moduleSurface.exports)
-        .find((exportSurface) => exportSurface.exportName === exportName)?.declaration;
+        .find(
+          (exportSurface) =>
+            exportSurface.exportName === exportName && exportSurface.declaration !== null,
+        )?.declaration;
 
     expect(rendered.baseline.modules.find((entry) => entry.entrypoint === "infra-runtime")).toEqual(
       expect.objectContaining({
@@ -124,42 +136,34 @@ describe("Plugin SDK API baseline", () => {
     expect(rendered.jsonl).not.toContain('"sourceLine":');
   });
 
-  it("renders snapshots independently of entrypoint discovery order", async () => {
-    const entrypoints = ["core", "provider-auth", "channel-policy"];
-    const forward = await renderPluginSdkApiBaseline({ entrypoints });
-    const reverse = await renderPluginSdkApiBaseline({ entrypoints: entrypoints.toReversed() });
+  it("renders snapshots independently of entrypoint discovery order", () => {
+    const reverse = renderPluginSdkApiBaselineModules(rendered.baseline.modules.toReversed());
 
-    expect(reverse.json).toBe(forward.json);
-    expect(reverse.jsonl).toBe(forward.jsonl);
+    expect(reverse.json).toBe(rendered.json);
+    expect(reverse.jsonl).toBe(rendered.jsonl);
   });
 
   it("hashes entrypoints independently so unrelated API changes merge", () => {
-    const moduleSurface = (entrypoint: string, declaration: string) => ({
-      category: null,
-      entrypoint,
-      exports: [
-        {
-          declaration,
-          exportName: `${entrypoint}Export`,
-          kind: "function" as const,
-          source: { path: `src/plugin-sdk/${entrypoint}.ts` },
-        },
-      ],
-      importSpecifier: `openclaw/plugin-sdk/${entrypoint}`,
-      source: { path: `src/plugin-sdk/${entrypoint}.ts` },
-    });
-    const render = (declaration: string): PluginSdkApiBaselineRender => ({
-      baseline: {
-        generatedBy: "scripts/generate-plugin-sdk-api-baseline.ts",
-        modules: [moduleSurface("alpha", declaration), moduleSurface("beta", "stable")],
-      },
-      json: "",
-      jsonl: "",
-    });
-    const before = computePluginSdkApiBaselineHashFileContent(render("before")).split("\n");
-    const after = computePluginSdkApiBaselineHashFileContent(render("after")).split("\n");
+    const target = rendered.baseline.modules[0];
+    expect(target?.exports.length).toBeGreaterThan(0);
+    const changed = renderPluginSdkApiBaselineModules(
+      rendered.baseline.modules.map((moduleSurface) =>
+        moduleSurface === target
+          ? {
+              ...moduleSurface,
+              exports: moduleSurface.exports.map((exportSurface, index) =>
+                index === 0
+                  ? { ...exportSurface, declaration: `${exportSurface.declaration ?? ""} changed` }
+                  : exportSurface,
+              ),
+            }
+          : moduleSurface,
+      ),
+    );
+    const before = computePluginSdkApiBaselineHashFileContent(rendered).split("\n");
+    const after = computePluginSdkApiBaselineHashFileContent(changed).split("\n");
 
     expect(after[0]).not.toBe(before[0]);
-    expect(after[1]).toBe(before[1]);
+    expect(after.slice(1)).toEqual(before.slice(1));
   });
 });

--- a/src/plugin-sdk/api-baseline.ts
+++ b/src/plugin-sdk/api-baseline.ts
@@ -682,21 +682,28 @@ export async function renderPluginSdkApiBaseline(params?: {
   const entrypoints = params?.entrypoints ?? listPluginSdkApiBaselineEntrypoints();
   validateMetadata();
   const { checker, printer, program } = createCompilerContext(repoRoot, entrypoints);
-  const modules = entrypoints
-    .map((entrypoint) =>
-      buildModuleSurface({
-        checker,
-        printer,
-        program,
-        repoRoot,
-        entrypoint,
-      }),
-    )
-    .toSorted((left, right) => compareText(left.importSpecifier, right.importSpecifier));
+  const modules = entrypoints.map((entrypoint) =>
+    buildModuleSurface({
+      checker,
+      printer,
+      program,
+      repoRoot,
+      entrypoint,
+    }),
+  );
 
+  return renderPluginSdkApiBaselineModules(modules);
+}
+
+/** Serialize discovered SDK modules in canonical order without rebuilding declarations. */
+export function renderPluginSdkApiBaselineModules(
+  modules: readonly PluginSdkApiModule[],
+): PluginSdkApiBaselineRender {
   const baseline: PluginSdkApiBaseline = {
     generatedBy: GENERATED_BY,
-    modules,
+    modules: [...modules].toSorted((left, right) =>
+      compareText(left.importSpecifier, right.importSpecifier),
+    ),
   };
 
   return {

--- a/test/plugins/bundled-provider-auth-literal-parity.test.ts
+++ b/test/plugins/bundled-provider-auth-literal-parity.test.ts
@@ -34,6 +34,7 @@ type ParityCase = {
 };
 
 type PluginRegister = (api: ReturnType<typeof createCapturedPluginRegistration>["api"]) => void;
+type CapturedPluginRegistration = ReturnType<typeof createCapturedPluginRegistration>;
 
 type PluginEntryModule = {
   default?: {
@@ -161,19 +162,34 @@ const probeAgentDir = mkdtempSync(path.join(tmpdir(), "openclaw-auth-parity-"));
 // Keep at least five imports in flight, but leave CPU headroom on larger CI runners.
 const PLUGIN_LOAD_CONCURRENCY = Math.max(5, Math.min(12, availableParallelism()));
 const parityPluginIds = [...new Set(parityCases.map((entry) => entry.pluginId))];
-const registerResultByPluginId = new Map<string, Promise<PromiseSettledResult<PluginRegister>>>();
+const registrationResultByPluginId = new Map<
+  string,
+  Promise<PromiseSettledResult<CapturedPluginRegistration>>
+>();
 
 beforeAll(() => {
-  // Bound only module loading. Auth probes stay serial because provider setup
-  // can log or inspect the shared probe directory.
+  // Load and register each plugin once. Auth probes stay serial because
+  // provider setup can log or inspect the shared probe directory.
   const limitPluginLoad = pLimit(PLUGIN_LOAD_CONCURRENCY);
   for (const pluginId of parityPluginIds) {
     // Settle each preload independently so one hung or rejected plugin cannot
     // suppress parity coverage for plugins that loaded successfully.
-    registerResultByPluginId.set(
+    registrationResultByPluginId.set(
       pluginId,
-      limitPluginLoad(() => loadPluginRegister(pluginId)).then(
-        (value): PromiseFulfilledResult<PluginRegister> => ({ status: "fulfilled", value }),
+      limitPluginLoad(async () => {
+        const register = await loadPluginRegister(pluginId);
+        const captured = createCapturedPluginRegistration({
+          id: pluginId,
+          name: pluginId,
+          source: `bundled:${pluginId}`,
+        });
+        register(captured.api);
+        return captured;
+      }).then(
+        (value): PromiseFulfilledResult<CapturedPluginRegistration> => ({
+          status: "fulfilled",
+          value,
+        }),
         (reason): PromiseRejectedResult => ({ status: "rejected", reason }),
       ),
     );
@@ -194,23 +210,17 @@ describe("bundled provider manifest↔runtime auth literal parity", () => {
     "$pluginId $providerId/$methodId optionKey=$optionKey",
     { timeout: PARITY_TIMEOUT_MS },
     async (parityCase) => {
-      const registerResultPromise = registerResultByPluginId.get(parityCase.pluginId);
-      if (!registerResultPromise) {
+      const registrationResultPromise = registrationResultByPluginId.get(parityCase.pluginId);
+      if (!registrationResultPromise) {
         throw new Error(`bundled plugin ${parityCase.pluginId} was not preloaded`);
       }
-      const registerResult = await registerResultPromise;
-      if (registerResult.status === "rejected") {
-        throw new Error(`bundled plugin ${parityCase.pluginId} preload failed`, {
-          cause: registerResult.reason,
+      const registrationResult = await registrationResultPromise;
+      if (registrationResult.status === "rejected") {
+        throw new Error(`bundled plugin ${parityCase.pluginId} preload or registration failed`, {
+          cause: registrationResult.reason,
         });
       }
-      const register = registerResult.value;
-      const captured = createCapturedPluginRegistration({
-        id: parityCase.pluginId,
-        name: parityCase.pluginId,
-        source: `bundled:${parityCase.pluginId}`,
-      });
-      register(captured.api);
+      const captured = registrationResult.value;
 
       const provider = findRegisteredProvider(captured.providers, parityCase.providerId);
       if (!provider) {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Several frequently run CI test files spent disproportionate time on repeated process startup, rendering, plugin registration, timing waits, and integration setup. The slowest touched files took about 494 seconds in aggregate, lengthening feedback without adding distinct coverage.

## Why This Change Was Made

This preserves the measured safety coverage while replacing redundant integration setup with direct owner-level assertions, reusing stable rendered or registered fixtures, and injecting deterministic timing/auth metadata where the integration behavior is covered elsewhere. The incomplete-turn suite was restored byte-for-byte after review showed that its proposed composition matrix lost unique retry and side-effect regressions.

## User Impact

No production behavior change. CI feedback for these measured hotspots falls from roughly 494 seconds to roughly 185 seconds across the optimized files, while the intentionally retained suite keeps its unique safety coverage.

## Evidence

| Hotspot | Before | After | Tests |
|---|---:|---:|---:|
| Followup runner | 169.061s | 106.393s | 152 -> 151 |
| Incomplete turn (restored/skipped) | 149.528s | unchanged | 154 -> 154 |
| CLI help | 39.926s | 11.400s | 18 -> 14 |
| Gateway CLI | 45.416s | 2.569s | 32 -> 32 |
| SDK baseline | 18.222s | 6.133s | 6 -> 6 |
| Provider parity | 23.965s | 24.565s | 72 -> 72 |
| Doctor preflight | 36.821s | 22.779s | 26 -> 27 |
| Sessions patch | 11.369s | 10.718s | 87 -> 87 |

- Item 1 removes only the stale-active-goal completion case; direct and admission-refresh coverage remains.
- CLI help retains two process smokes; lazy-command help is parsed in-process, while route rejection stays in owner suites.
- Provider parity achieves one registration per plugin; module loading still dominates, explaining the flat timing.
- All focused after-tests passed.
- Final diff: 348 insertions, 398 deletions across 12 files (net -50 LOC).
- `node scripts/check-changed.mjs` passed on Blacksmith Testbox `tbx_01kygytwk8v5sz0tdfhnrzfg7d`, Actions run 30238364480.
- Final `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` was clean with no actionable findings.
