### PR TITLE
fix(release): make advisory acceptance summaries portable on macOS

### DIFF
--- a/.github/workflows/openclaw-release-checks.yml
+++ b/.github/workflows/openclaw-release-checks.yml
@@ -2191,17 +2191,19 @@ jobs:
           release_check_result() {
             local name="$1"
             local fallback="$2"
+            # Skipped lanes produce no status variants; Bash 3 treats an empty
+            # array expansion as unbound when nounset is enabled.
+            if [[ "$fallback" == "skipped" ]]; then
+              printf 'skipped\n'
+              return
+            fi
             local saw=0
             local saw_failure=0
             local saw_cancelled=0
             local saw_skipped=0
-            local variants=()
-            if [[ "$fallback" != "skipped" ]]; then
-              if [[ "$name" == "qa_lab_parity_lane_release_checks" ]]; then
-                variants=(candidate baseline)
-              else
-                variants=("")
-              fi
+            local variants=("")
+            if [[ "$name" == "qa_lab_parity_lane_release_checks" ]]; then
+              variants=(candidate baseline)
             fi
             for variant in "${variants[@]}"; do
               suffix=""
@@ -2223,10 +2225,6 @@ jobs:
                 *) saw_failure=1 ;;
               esac
             done
-            if [[ "$fallback" == "skipped" ]]; then
-              printf 'skipped\n'
-              return
-            fi
             if [[ "$saw_failure" == "1" ]]; then
               printf 'failure\n'
             elif [[ "$saw_cancelled" == "1" ]]; then

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -331,11 +331,17 @@ function runOpenClawNpmTrustedRefGuard(overrides: Record<string, string>) {
   }
   const binDir = tempDirs.make("openclaw-npm-trusted-ref-");
   const gitPath = `${binDir}/git`;
+  const timeoutPath = `${binDir}/timeout`;
   writeFileSync(
     gitPath,
     `#!/bin/sh\nif [ "$1" = "fetch" ]; then exit 0; fi\nif [ "$1" = "merge-base" ]; then [ "\${MOCK_WORKFLOW_ANCESTOR}" = "true" ]; exit $?; fi\nexit 2\n`,
   );
   chmodSync(gitPath, 0o755);
+  writeFileSync(
+    timeoutPath,
+    `#!/bin/sh\n[ "$1" = "--signal=TERM" ] && [ "$2" = "--kill-after=10s" ] && [ "$3" = "120s" ] || exit 2\nshift 3\nexec "$@"\n`,
+  );
+  chmodSync(timeoutPath, 0o755);
   return spawnSync("bash", ["-c", script], {
     encoding: "utf8",
     env: {


### PR DESCRIPTION
Related: #114356

## What Problem This Solves

Fixes an issue where seven release acceptance tests fail on a standard macOS installation because its default Bash rejects an empty nounset-protected array and the local fixture assumes GNU `timeout` is installed.

## Why This Change Was Made

Return immediately for explicitly skipped advisory release lanes before expanding an empty Bash array. Mock the production timeout command only in the isolated workflow-guard test and verify its exact security-critical flags.

## User Impact

Release acceptance now runs correctly on the stock macOS shell; release timeouts, artifact identity, child failures, security and publication guards are unchanged.

## Evidence

- Reproduced the baseline on actual macOS system Bash 3.2 with neither `timeout` nor `gtimeout` installed: 84 passed, 7 failed.
- Reran the exact pushed PR head on the same machine: all 91 package-acceptance workflow tests pass.
- Parsed the exact release workflow and verified its actual summary script with macOS Bash 3.2 `bash -n`.
- Verified the test-only timeout mock rejects any change to `--signal=TERM --kill-after=10s 120s`; the production release timeout remains intact.
- Canonical formatting, whitespace, independent Codex autoreview, and TruffleHog all pass.
- Exact-head hosted [CI](https://github.com/openclaw/openclaw/actions/runs/30242707499), [Blacksmith Testbox](https://github.com/openclaw/openclaw/actions/runs/30242707539), [Blacksmith ARM Testbox](https://github.com/openclaw/openclaw/actions/runs/30242707535), and [Blacksmith Build Artifacts Testbox](https://github.com/openclaw/openclaw/actions/runs/30242707538) are green.
- Separate pre-existing Telegram-specific failures are intentionally out of scope.
- AI-assisted.

### Exact-head macOS terminal proof

The dependency location below is redacted; no real credentials, private host paths, IP addresses, or non-public endpoints are included.

```text
$ git rev-parse HEAD
8585168dce5b29a0f62047a8d535e46c798f214d

$ bash --version
GNU bash, version 3.2.57(1)-release (arm64-apple-darwin26)

$ for tool in timeout gtimeout; do
>   if command -v "$tool" >/dev/null 2>&1; then
>     printf '%s=present\n' "$tool"
>   else
>     printf '%s=not-installed\n' "$tool"
>   fi
> done
timeout=not-installed
gtimeout=not-installed

$ PNPM_CONFIG_MODULES_DIR='<existing trusted dependencies>' \
> OPENCLAW_VITEST_MAX_WORKERS=1 \
> node scripts/run-vitest.mjs test/scripts/package-acceptance-workflow.test.ts
[test] starting test/vitest/vitest.tooling.config.ts

 Test Files  1 passed (1)
      Tests  91 passed (91)
   Duration  3.16s (transform 40ms, setup 37ms, import 65ms,
             tests 2.91s, environment 0ms)

[test] passed 1 Vitest shard in 7.14s
```