### PR TITLE
fix(ci): run required Testbox checks when draft PRs become ready

### DIFF
--- a/.github/workflows/ci-check-testbox.yml
+++ b/.github/workflows/ci-check-testbox.yml
@@ -11,6 +11,7 @@ on:
         description: "Maximum GitHub job runtime for long Testbox commands"
         default: 120
   pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
     paths:
       - ".github/workflows/**"
 

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -888,6 +888,13 @@ describe("ci workflow guards", () => {
   it("keeps Testbox pull request validation off leased runner capacity", () => {
     const workflow = readTestboxWorkflow();
 
+    expect(workflow.on.pull_request).toEqual({
+      types: ["opened", "reopened", "synchronize", "ready_for_review"],
+      paths: [".github/workflows/**"],
+    });
+    expect(workflow.jobs.check.if).toBe(
+      "${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}",
+    );
     expect(workflow.jobs.check["runs-on"]).toBe(
       "${{ github.event_name == 'pull_request' && 'ubuntu-24.04' || 'blacksmith-16vcpu-ubuntu-2404' }}",
     );


### PR DESCRIPTION
Related: #114356

## What Problem This Solves

Fixes an issue where a PR opened as a draft and then marked ready permanently lacks the required Blacksmith validation, causing the protected maintainer landing command to fail despite every ordinary CI check passing.

## Why This Change Was Made

Explicitly retain GitHub's default pull-request events and add `ready_for_review` to the existing Testbox workflow. Preserve the workflow path filter, draft guard, permissions, concurrency, GitHub-hosted PR runner, and manually dispatched lease isolation.

## User Impact

Ready PRs receive their mandatory Testbox validation automatically and can be landed normally without empty commits, manual lease dispatch, or bypassing protected checks.

## Evidence

- Before: parsed workflow regression fails because `ready_for_review` never triggers; 88 surrounding checks pass.
- After: 274 workflow, hosted-gate, package and prepare regression tests pass.
- Full `pnpm check:workflows`, actionlint and zizmor pass.
- Exact existing draft-skip condition and runners are asserted in the regression.
- Remote proof run: https://github.com/openclaw/openclaw/actions/runs/30242325999.
- Canonical formatting, isolated-worktree autoreview and TruffleHog pass.
- AI-assisted.