### PR TITLE
refactor: unify doctor repairs and configure setup

### DIFF
--- a/src/commands/configure.wizard.test.ts
+++ b/src/commands/configure.wizard.test.ts
@@ -185,6 +185,7 @@ vi.mock("../config/mutate.js", async () => {
 
 import { ConfigMutationConflictError } from "../config/mutate.js";
 import { WizardCancelledError } from "../wizard/prompts.js";
+import { maybeInstallDaemon } from "./configure.daemon.js";
 import { runConfigureWizard } from "./configure.wizard.js";
 
 const EMPTY_CONFIG_SNAPSHOT = {
@@ -350,6 +351,91 @@ describe("runConfigureWizard", () => {
     }));
     mocks.guardCancel.mockReset();
     mocks.guardCancel.mockImplementation((value: unknown) => value);
+  });
+
+  it("runs selected sections in canonical order and commits their combined config once", async () => {
+    setupBaseWizardState();
+    queueWizardPrompts({ select: ["local", "configure"], confirm: [] });
+    const events: string[] = [];
+    mocks.promptAuthConfig.mockImplementationOnce(async (cfg: OpenClawConfig) => {
+      events.push("model");
+      return cfg;
+    });
+    mocks.promptGatewayConfig.mockImplementationOnce(async (cfg: OpenClawConfig) => {
+      events.push("gateway");
+      return { config: cfg, port: 18789 };
+    });
+    mocks.setupChannels.mockImplementationOnce(async (cfg: OpenClawConfig) => {
+      events.push("channels");
+      return cfg;
+    });
+    mocks.writeConfigFile.mockImplementationOnce(async () => {
+      events.push("commit");
+    });
+
+    await runConfigureWizard(
+      { command: "configure", sections: ["channels", "gateway", "model"] },
+      createRuntime(),
+    );
+
+    expect(events).toEqual(["model", "gateway", "channels", "commit"]);
+    expect(mocks.writeConfigFile).toHaveBeenCalledOnce();
+  });
+
+  it("commits every interactive section before running the next section", async () => {
+    setupBaseWizardState();
+    queueWizardPrompts({
+      select: ["local", "model", "gateway", "channels", "configure", "__continue"],
+      confirm: [],
+    });
+    const events: string[] = [];
+    mocks.promptAuthConfig.mockImplementationOnce(async (cfg: OpenClawConfig) => {
+      events.push("model");
+      return cfg;
+    });
+    mocks.promptGatewayConfig.mockImplementationOnce(async (cfg: OpenClawConfig) => {
+      events.push("gateway");
+      return { config: cfg, port: 18789 };
+    });
+    mocks.setupChannels.mockImplementationOnce(async (cfg: OpenClawConfig) => {
+      events.push("channels");
+      return cfg;
+    });
+    for (let index = 0; index < 3; index += 1) {
+      mocks.writeConfigFile.mockImplementationOnce(async () => {
+        events.push("commit");
+      });
+    }
+
+    await runConfigureWizard({ command: "configure" }, createRuntime());
+
+    expect(events).toEqual(["model", "commit", "gateway", "commit", "channels", "commit"]);
+    expect(mocks.writeConfigFile).toHaveBeenCalledTimes(3);
+  });
+
+  it("commits selected gateway config before installing its configured daemon port", async () => {
+    setupBaseWizardState();
+    queueWizardPrompts({ select: ["local"], confirm: [] });
+    const events: string[] = [];
+    mocks.promptGatewayConfig.mockImplementationOnce(async (cfg: OpenClawConfig) => {
+      events.push("gateway");
+      return { config: cfg, port: 18991 };
+    });
+    mocks.writeConfigFile.mockImplementationOnce(async () => {
+      events.push("commit");
+    });
+    vi.mocked(maybeInstallDaemon).mockImplementationOnce(async () => {
+      events.push("daemon");
+    });
+
+    await runConfigureWizard(
+      { command: "configure", sections: ["daemon", "gateway"] },
+      createRuntime(),
+    );
+
+    expect(events).toEqual(["gateway", "commit", "daemon"]);
+    expect(maybeInstallDaemon).toHaveBeenCalledWith(expect.objectContaining({ port: 18991 }));
+    expect(mocks.clackText).not.toHaveBeenCalled();
   });
 
   it("persists gateway.mode=local when only the run mode is selected", async () => {

--- a/src/commands/configure.wizard.ts
+++ b/src/commands/configure.wizard.ts
@@ -693,70 +693,83 @@ export async function runConfigureWizard(
       gatewayPort = parsePort(portInput) ?? gatewayPort;
     };
 
-    if (selectedSections) {
-      const selected = selectedSections;
-      if (!selected || selected.length === 0) {
-        outro("No configuration changes selected.");
-        return;
-      }
-
-      if (selected.includes("workspace")) {
+    let didConfigureGateway = false;
+    const sectionActions = {
+      workspace: async () => {
         await configureWorkspace();
         await provisionWorkspace();
-      }
-
-      if (selected.includes("model")) {
+      },
+      model: async () => {
         nextConfig = await promptAuthConfig(nextConfig, runtime, prompter);
-      }
-
-      if (selected.includes("web")) {
+      },
+      web: async () => {
         nextConfig = await promptWebToolsConfig(nextConfig, runtime, prompter);
-      }
-
-      if (selected.includes("gateway")) {
+      },
+      gateway: async () => {
         const gateway = await promptGatewayConfig(nextConfig, runtime);
         nextConfig = gateway.config;
         gatewayPort = gateway.port;
-      }
-
-      if (selected.includes("channels")) {
-        await configureChannelsSection();
-      }
-
-      if (selected.includes("plugins")) {
+        didConfigureGateway = true;
+      },
+      channels: configureChannelsSection,
+      plugins: async () => {
         const { configurePluginConfig } = await loadSetupPluginConfigModule();
         nextConfig = await configurePluginConfig({
           config: nextConfig,
           prompter,
           workspaceDir: resolveSetupTarget().workspaceDir,
         });
-      }
-
-      if (selected.includes("skills")) {
+      },
+      skills: async () => {
         nextConfig = await setupSkills(
           nextConfig,
           resolveSetupTarget().workspaceDir,
           runtime,
           prompter,
         );
+      },
+      daemon: async () => {
+        if (!didConfigureGateway) {
+          await promptDaemonPort();
+        }
+        await maybeInstallDaemon({ runtime, port: gatewayPort });
+      },
+      health: async () => {
+        await runGatewayHealthCheck({ cfg: nextConfig, runtime, port: gatewayPort });
+      },
+    } satisfies Record<WizardSection, () => Promise<void>>;
+
+    if (selectedSections) {
+      if (selectedSections.length === 0) {
+        outro("No configuration changes selected.");
+        return;
+      }
+
+      // Section flags retain their canonical setup order regardless of flag order;
+      // the complete config is committed once before service or health effects.
+      for (const section of [
+        "workspace",
+        "model",
+        "web",
+        "gateway",
+        "channels",
+        "plugins",
+        "skills",
+      ] as const) {
+        if (selectedSections.includes(section)) {
+          await sectionActions[section]();
+        }
       }
 
       await persistConfig();
 
-      if (selected.includes("daemon")) {
-        if (!selected.includes("gateway")) {
-          await promptDaemonPort();
+      for (const section of ["daemon", "health"] as const) {
+        if (selectedSections.includes(section)) {
+          await sectionActions[section]();
         }
-
-        await maybeInstallDaemon({ runtime, port: gatewayPort });
-      }
-
-      if (selected.includes("health")) {
-        await runGatewayHealthCheck({ cfg: nextConfig, runtime, port: gatewayPort });
       }
     } else {
       let ranSection = false;
-      let didConfigureGateway = false;
 
       while (true) {
         const choice = await promptConfigureSection(runtime, ranSection);
@@ -764,68 +777,10 @@ export async function runConfigureWizard(
           break;
         }
         ranSection = true;
-
-        if (choice === "workspace") {
-          await configureWorkspace();
-          await provisionWorkspace();
+        await sectionActions[choice]();
+        if (choice !== "daemon" && choice !== "health") {
+          // Interactive setup commits each section before showing another prompt.
           await persistConfig();
-        }
-
-        if (choice === "model") {
-          nextConfig = await promptAuthConfig(nextConfig, runtime, prompter);
-          await persistConfig();
-        }
-
-        if (choice === "web") {
-          nextConfig = await promptWebToolsConfig(nextConfig, runtime, prompter);
-          await persistConfig();
-        }
-
-        if (choice === "gateway") {
-          const gateway = await promptGatewayConfig(nextConfig, runtime);
-          nextConfig = gateway.config;
-          gatewayPort = gateway.port;
-          didConfigureGateway = true;
-          await persistConfig();
-        }
-
-        if (choice === "channels") {
-          await configureChannelsSection();
-          await persistConfig();
-        }
-
-        if (choice === "plugins") {
-          const { configurePluginConfig } = await loadSetupPluginConfigModule();
-          nextConfig = await configurePluginConfig({
-            config: nextConfig,
-            prompter,
-            workspaceDir: resolveSetupTarget().workspaceDir,
-          });
-          await persistConfig();
-        }
-
-        if (choice === "skills") {
-          nextConfig = await setupSkills(
-            nextConfig,
-            resolveSetupTarget().workspaceDir,
-            runtime,
-            prompter,
-          );
-          await persistConfig();
-        }
-
-        if (choice === "daemon") {
-          if (!didConfigureGateway) {
-            await promptDaemonPort();
-          }
-          await maybeInstallDaemon({
-            runtime,
-            port: gatewayPort,
-          });
-        }
-
-        if (choice === "health") {
-          await runGatewayHealthCheck({ cfg: nextConfig, runtime, port: gatewayPort });
         }
       }
 

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -23,7 +23,11 @@ import {
   applyLegacyCompatibilityStep,
   applyUnknownConfigKeyStep,
 } from "./doctor/shared/config-flow-steps.js";
-import { applyDoctorConfigMutation } from "./doctor/shared/config-mutation-state.js";
+import {
+  applyDoctorConfigMutation,
+  type DoctorConfigMutationResult,
+  type DoctorConfigMutationState,
+} from "./doctor/shared/config-mutation-state.js";
 import { materializeDefaultAgentRoles } from "./doctor/shared/default-agent-role-materialization.js";
 import { isSingleTopLevelIncludeMigration } from "./doctor/shared/include-migration-ownership.js";
 import { normalizeCompatibilityConfigValues } from "./doctor/shared/legacy-config-core-migrate.js";
@@ -152,26 +156,44 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
   });
   const snapshot = preflight.snapshot;
   const baseCfg = preflight.baseConfig;
-  let cfg: OpenClawConfig = baseCfg;
-  let candidate = structuredClone(baseCfg);
-  let pendingChanges = false;
-  let fixHints: string[] = [];
+  let state: DoctorConfigMutationState = {
+    cfg: baseCfg,
+    candidate: structuredClone(baseCfg),
+    pendingChanges: false,
+    fixHints: [],
+  };
   let shouldRepairCronCodexModelRefsAfterConfigWrite = false;
   const doctorFixCommand = formatCliCommand("openclaw doctor --fix");
+  const applyConfigMutation = (
+    mutation: DoctorConfigMutationResult & { warnings?: string[] },
+    options: { fixHint: string; sanitize?: boolean; emitWarnings?: boolean },
+  ): void => {
+    emitDoctorChangesPanel(
+      mutation.changes,
+      shouldRepair,
+      options.sanitize ? { sanitize: true } : {},
+    );
+    if (options.emitWarnings && mutation.warnings?.length) {
+      emitDoctorNotes({ note, warningNotes: mutation.warnings });
+    }
+    state = applyDoctorConfigMutation({
+      state,
+      mutation,
+      shouldRepair,
+      fixHint: options.fixHint,
+    });
+  };
   const sourceMeta = (snapshot.sourceConfig as { meta?: { lastTouchedVersion?: unknown } })?.meta;
   const sourceLastTouchedVersion =
     typeof sourceMeta?.lastTouchedVersion === "string" ? sourceMeta.lastTouchedVersion : undefined;
 
   const legacyStep = applyLegacyCompatibilityStep({
     snapshot,
-    state: { cfg, candidate, pendingChanges, fixHints },
+    state,
     shouldRepair,
     doctorFixCommand,
   });
-  cfg = legacyStep.state.cfg;
-  candidate = legacyStep.state.candidate;
-  pendingChanges = pendingChanges || legacyStep.state.pendingChanges;
-  fixHints = legacyStep.state.fixHints;
+  state = legacyStep.state;
   const legacyMigrationPartiallyValid = legacyStep.partiallyValid === true;
   const rosterMigrationNeeded = [snapshot.sourceConfigBeforeMigrations, snapshot.parsed].some(
     (source) => source !== undefined && migratePersistedImplicitMainRoster(source).changed,
@@ -179,13 +201,13 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
   const includeOwnsRoster = configIncludeOwnsAgentRoster(snapshot);
   if (snapshot.exists && rosterMigrationNeeded && !includeOwnsRoster) {
     // Runtime roster normalization is read-only; doctor --fix owns persistence.
-    const migrated = migratePersistedImplicitMainRoster(candidate).config as OpenClawConfig;
+    const migrated = migratePersistedImplicitMainRoster(state.candidate).config as OpenClawConfig;
     const migratedRoster = readAgentRosterProperty(migrated);
     const migratedEntries = migratedRoster?.kind === "entries" ? migratedRoster.value : undefined;
-    const { list: _legacyList, ...candidateAgents } = candidate.agents ?? {};
+    const { list: _legacyList, ...candidateAgents } = state.candidate.agents ?? {};
     const rosterRepair = {
       config: {
-        ...candidate,
+        ...state.candidate,
         agents: {
           ...candidateAgents,
           entries: migratedEntries as NonNullable<OpenClawConfig["agents"]>["entries"],
@@ -193,52 +215,35 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
       },
       changes: ["Persisted agents.entries with exactly one explicit default agent."],
     };
-    emitDoctorChangesPanel(rosterRepair.changes, shouldRepair);
-    ({ cfg, candidate, pendingChanges, fixHints } = applyDoctorConfigMutation({
-      state: { cfg, candidate, pendingChanges, fixHints },
-      mutation: rosterRepair,
-      shouldRepair,
+    applyConfigMutation(rosterRepair, {
       fixHint: `Run "${doctorFixCommand}" to persist the explicit agent roster.`,
-    }));
+    });
   }
-  const defaultRoleMaterialization = materializeDefaultAgentRoles(candidate);
-  if (defaultRoleMaterialization.changes.length > 0) {
-    emitDoctorChangesPanel(defaultRoleMaterialization.changes, shouldRepair);
-    ({ cfg, candidate, pendingChanges, fixHints } = applyDoctorConfigMutation({
-      state: { cfg, candidate, pendingChanges, fixHints },
-      mutation: defaultRoleMaterialization,
-      shouldRepair,
-      fixHint: `Run "${doctorFixCommand}" to persist explicit ambient agent targets.`,
-    }));
-  }
+  applyConfigMutation(materializeDefaultAgentRoles(state.candidate), {
+    fixHint: `Run "${doctorFixCommand}" to persist explicit ambient agent targets.`,
+  });
   const { collectBlockedLegacyOpenAICodexProviderPlan } =
     await import("./doctor/shared/legacy-config-migrations.runtime.models.js");
-  const blockedCodexProviderPlan = collectBlockedLegacyOpenAICodexProviderPlan(candidate);
+  const blockedCodexProviderPlan = collectBlockedLegacyOpenAICodexProviderPlan(state.candidate);
   const blockedCodexModelIdentities = new Set(blockedCodexProviderPlan.blockedModelIdentities);
   if (preflight.cronCodexRuntimePolicyTargets?.length) {
     const { repairCronCodexRuntimePolicies } =
       await import("./doctor/cron/runtime-policy-migration.js");
     const cronRuntimeRepair = repairCronCodexRuntimePolicies({
-      cfg: candidate,
+      cfg: state.candidate,
       targets: preflight.cronCodexRuntimePolicyTargets,
       blockedModelIdentities: blockedCodexModelIdentities,
     });
-    emitDoctorChangesPanel(cronRuntimeRepair.changes, shouldRepair);
-    if (cronRuntimeRepair.warnings.length > 0) {
-      emitDoctorNotes({ note, warningNotes: cronRuntimeRepair.warnings });
-    }
+    applyConfigMutation(cronRuntimeRepair, {
+      fixHint: `Run "${doctorFixCommand}" to preserve migrated cron runtime policy.`,
+      emitWarnings: true,
+    });
     const blockedTargets = new Set(
       cronRuntimeRepair.blockedTargets.map(cronCodexRuntimePolicyTargetKey),
     );
     shouldRepairCronCodexModelRefsAfterConfigWrite = preflight.cronCodexRuntimePolicyTargets.some(
       (target) => !blockedTargets.has(cronCodexRuntimePolicyTargetKey(target)),
     );
-    ({ cfg, candidate, pendingChanges, fixHints } = applyDoctorConfigMutation({
-      state: { cfg, candidate, pendingChanges, fixHints },
-      mutation: cronRuntimeRepair,
-      shouldRepair,
-      fixHint: `Run "${doctorFixCommand}" to preserve migrated cron runtime policy.`,
-    }));
   }
   const pluginLegacyIssues = await (async () => {
     if (snapshot.parsed === snapshot.sourceConfig) {
@@ -265,9 +270,9 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
   if (
     pluginIssueLines.length > 0 &&
     !shouldRepair &&
-    !fixHints.includes(`Run "${doctorFixCommand}" to migrate legacy config keys.`)
+    !state.fixHints.includes(`Run "${doctorFixCommand}" to migrate legacy config keys.`)
   ) {
-    fixHints.push(`Run "${doctorFixCommand}" to migrate legacy config keys.`);
+    state.fixHints.push(`Run "${doctorFixCommand}" to migrate legacy config keys.`);
   }
   if (legacyIssueLines.length > 0) {
     note(legacyIssueLines.join("\n"), "Legacy config keys detected");
@@ -283,66 +288,53 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
       "Legacy config keys detected",
     );
   }
-  const hookTransformsDirWarnings = collectInvalidHookTransformsDirWarnings(cfg, snapshot.path);
+  const hookTransformsDirWarnings = collectInvalidHookTransformsDirWarnings(
+    state.cfg,
+    snapshot.path,
+  );
   if (hookTransformsDirWarnings.length > 0) {
     note(sanitizeDoctorNote(hookTransformsDirWarnings.join("\n")), "Doctor warnings");
   }
-  const unsupportedInternalHookEntryWarnings = collectUnsupportedInternalHookEntryWarnings(cfg);
+  const unsupportedInternalHookEntryWarnings = collectUnsupportedInternalHookEntryWarnings(
+    state.cfg,
+  );
   if (unsupportedInternalHookEntryWarnings.length > 0) {
     note(sanitizeDoctorNote(unsupportedInternalHookEntryWarnings.join("\n")), "Doctor warnings");
   }
 
-  const normalized = normalizeCompatibilityConfigValues(candidate, {
+  const normalized = normalizeCompatibilityConfigValues(state.candidate, {
     blockedModelIdentities: blockedCodexModelIdentities,
   });
-  if (normalized.changes.length > 0) {
-    emitDoctorChangesPanel(normalized.changes, shouldRepair);
-    ({ cfg, candidate, pendingChanges, fixHints } = applyDoctorConfigMutation({
-      state: { cfg, candidate, pendingChanges, fixHints },
-      mutation: normalized,
-      shouldRepair,
-      fixHint: `Run "${doctorFixCommand}" to apply these changes.`,
-    }));
-  }
+  applyConfigMutation(normalized, {
+    fixHint: `Run "${doctorFixCommand}" to apply these changes.`,
+  });
 
-  const pluginActivationSourceConfig = candidate;
+  const pluginActivationSourceConfig = state.candidate;
   const { applyPluginAutoEnable } = await import("../config/plugin-auto-enable.js");
-  const autoEnable = applyPluginAutoEnable({ config: candidate, env: process.env });
-  if (autoEnable.changes.length > 0) {
-    emitDoctorChangesPanel(autoEnable.changes, shouldRepair);
-    ({ cfg, candidate, pendingChanges, fixHints } = applyDoctorConfigMutation({
-      state: { cfg, candidate, pendingChanges, fixHints },
-      mutation: autoEnable,
-      shouldRepair,
-      fixHint: `Run "${doctorFixCommand}" to apply these changes.`,
-    }));
-  }
+  applyConfigMutation(applyPluginAutoEnable({ config: state.candidate, env: process.env }), {
+    fixHint: `Run "${doctorFixCommand}" to apply these changes.`,
+  });
 
   const { repairStaleAgentModelRefs } =
     await import("./doctor/shared/stale-agent-model-ref-repair.js");
-  const staleAgentModelRepair = repairStaleAgentModelRefs(candidate, { env: process.env });
-  emitDoctorChangesPanel(staleAgentModelRepair.changes, shouldRepair, { sanitize: true });
-  if (staleAgentModelRepair.warnings.length > 0) {
-    emitDoctorNotes({ note, warningNotes: staleAgentModelRepair.warnings });
-  }
-  ({ cfg, candidate, pendingChanges, fixHints } = applyDoctorConfigMutation({
-    state: { cfg, candidate, pendingChanges, fixHints },
-    mutation: staleAgentModelRepair,
-    shouldRepair,
+  const staleAgentModelRepair = repairStaleAgentModelRefs(state.candidate, { env: process.env });
+  applyConfigMutation(staleAgentModelRepair, {
     fixHint: `Run "${doctorFixCommand}" to remove stale agent model references.`,
-  }));
+    sanitize: true,
+    emitWarnings: true,
+  });
 
   const { collectPluginToolAllowlistWarnings } =
     await import("./doctor/shared/plugin-tool-allowlist-warnings.js");
   const pluginToolAllowlistWarnings = collectPluginToolAllowlistWarnings({
-    cfg: candidate,
+    cfg: state.candidate,
     env: process.env,
   });
   if (pluginToolAllowlistWarnings.length > 0) {
     note(sanitizeDoctorNote(pluginToolAllowlistWarnings.join("\n")), "Doctor warnings");
   }
 
-  const hasConfiguredChannels = collectConfiguredChannelIds(candidate).length > 0;
+  const hasConfiguredChannels = collectConfiguredChannelIds(state.candidate).length > 0;
   let collectMutableAllowlistWarnings:
     | typeof import("./doctor/shared/channel-doctor.js").collectChannelDoctorMutableAllowlistWarnings
     | undefined;
@@ -350,7 +342,7 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
     const channelDoctor = await import("./doctor/shared/channel-doctor.js");
     collectMutableAllowlistWarnings = channelDoctor.collectChannelDoctorMutableAllowlistWarnings;
     const channelDoctorSequence = await channelDoctor.runChannelDoctorConfigSequences({
-      cfg: candidate,
+      cfg: state.candidate,
       env: process.env,
       shouldRepair,
     });
@@ -361,42 +353,31 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
     });
 
     for (const staleCleanup of await channelDoctor.collectChannelDoctorStaleConfigMutations(
-      candidate,
+      state.candidate,
       { env: process.env },
     )) {
-      if (staleCleanup.changes.length === 0) {
-        continue;
-      }
-      emitDoctorChangesPanel(staleCleanup.changes, shouldRepair, { sanitize: true });
-      ({ cfg, candidate, pendingChanges, fixHints } = applyDoctorConfigMutation({
-        state: { cfg, candidate, pendingChanges, fixHints },
-        mutation: staleCleanup,
-        shouldRepair,
+      applyConfigMutation(staleCleanup, {
         fixHint: `Run "${doctorFixCommand}" to remove stale channel plugin references.`,
-      }));
+        sanitize: true,
+      });
     }
   }
 
   const { repairHooksTokenReuseGatewayAuth } =
     await import("./doctor/shared/hooks-token-reuse-repair.js");
-  const hooksTokenReuseRepair = await repairHooksTokenReuseGatewayAuth(candidate, process.env);
-  emitDoctorChangesPanel(hooksTokenReuseRepair.changes, shouldRepair);
-  ({ cfg, candidate, pendingChanges, fixHints } = applyDoctorConfigMutation({
-    state: { cfg, candidate, pendingChanges, fixHints },
-    mutation: hooksTokenReuseRepair,
-    shouldRepair,
+  applyConfigMutation(await repairHooksTokenReuseGatewayAuth(state.candidate, process.env), {
     fixHint: `Run "${doctorFixCommand}" to rotate hooks.token away from Gateway auth.`,
-  }));
+  });
 
   if (shouldRepair) {
     const { runDoctorRepairSequence } = await import("./doctor/repair-sequencing.js");
     const repairSequence = await runDoctorRepairSequence({
-      state: { cfg, candidate, pendingChanges, fixHints },
+      state,
       doctorFixCommand,
       env: process.env,
       blockedCodexProviderPlan,
     });
-    ({ cfg, candidate, pendingChanges, fixHints } = repairSequence.state);
+    state = repairSequence.state;
     if (repairSequence.authProfilesRepaired) {
       await refreshGatewayAuthStateAfterAuthProfileRepair();
     }
@@ -408,7 +389,7 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
   } else {
     const { collectDoctorPreviewNotes } = await import("./doctor/shared/preview-warnings.js");
     const previewNotes = await collectDoctorPreviewNotes({
-      cfg: candidate,
+      cfg: state.candidate,
       activationSourceConfig: pluginActivationSourceConfig,
       doctorFixCommand,
       env: process.env,
@@ -424,7 +405,7 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
 
   const mutableAllowlistWarnings = collectMutableAllowlistWarnings
     ? await collectMutableAllowlistWarnings({
-        cfg: candidate,
+        cfg: state.candidate,
         env: process.env,
       })
     : [];
@@ -433,11 +414,11 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
   }
 
   const unknownStep = applyUnknownConfigKeyStep({
-    state: { cfg, candidate, pendingChanges, fixHints },
+    state,
     shouldRepair,
     doctorFixCommand,
   });
-  ({ cfg, candidate, pendingChanges, fixHints } = unknownStep.state);
+  state = unknownStep.state;
   if (unknownStep.removed.length > 0 || unknownStep.repairs.length > 0) {
     const lines = [
       ...unknownStep.removed.map((pathLocal) => `- ${pathLocal}`),
@@ -450,15 +431,15 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
   }
 
   const finalized = await finalizeDoctorConfigFlow({
-    cfg,
-    candidate,
-    pendingChanges,
+    cfg: state.cfg,
+    candidate: state.candidate,
+    pendingChanges: state.pendingChanges,
     shouldRepair,
-    fixHints,
+    fixHints: state.fixHints,
     confirm: params.confirm,
     note,
   });
-  cfg = finalized.cfg;
+  const cfg = finalized.cfg;
   const singleTopLevelIncludeWrite =
     finalized.shouldWriteConfig &&
     isSingleTopLevelIncludeMigration({

--- a/src/commands/doctor/repair-sequencing.test.ts
+++ b/src/commands/doctor/repair-sequencing.test.ts
@@ -325,6 +325,34 @@ describe("doctor repair sequencing", () => {
     expect(result.warningNotes).toContain("Migration warning.");
   });
 
+  it("sanitizes ordered plugin repair changes, warnings, notices, and migration notes", async () => {
+    mocks.repairMissingConfiguredPluginInstalls.mockResolvedValueOnce({
+      changes: ["Installed \u001B[31mplugin\u001B[0m\r\nnext."],
+      warnings: ["Plugin \u001B[31mwarning\u001B[0m\r\nnext."],
+      notices: ["Plugin \u001B[31mnotice\u001B[0m\r\nnext."],
+    });
+    mocks.migrateLegacyOnboardingRecommendationsScope.mockReturnValueOnce({
+      changes: ["Migrated \u001B[31mrecommendations\u001B[0m\r\nnext."],
+      warnings: ["Migration \u001B[31mwarning\u001B[0m\r\nnext."],
+    });
+    const candidate = {} as OpenClawConfig;
+
+    const result = await runDoctorRepairSequence({
+      state: { cfg: candidate, candidate, pendingChanges: false, fixHints: [] },
+      doctorFixCommand: "openclaw doctor --fix",
+    });
+
+    expect(result.changeNotes).toEqual(["Installed pluginnext.", "Migrated recommendationsnext."]);
+    expect(result.warningNotes).toEqual([
+      "Plugin warningnext.",
+      "Plugin noticenext.",
+      "Migration warningnext.",
+    ]);
+    const emittedNotes = [...result.changeNotes, ...result.warningNotes].join("\n");
+    expect(emittedNotes).not.toContain("\u001B");
+    expect(emittedNotes).not.toContain("\r");
+  });
+
   it("applies ordered repairs and sanitizes empty-allowlist warnings", async () => {
     const result = await runDoctorRepairSequence({
       state: {

--- a/src/commands/doctor/repair-sequencing.ts
+++ b/src/commands/doctor/repair-sequencing.ts
@@ -63,6 +63,20 @@ export async function runDoctorRepairSequence(params: {
   const warningNotes: string[] = [];
   const env = params.env ?? process.env;
   const sanitizeLines = (lines: string[]) => lines.map((line) => sanitizeForLog(line)).join("\n");
+  const appendNotes = (notes: string[], lines: string[] | undefined): void => {
+    if (lines && lines.length > 0) {
+      notes.push(sanitizeLines(lines));
+    }
+  };
+  const appendRepairNotes = (repair: {
+    changes: string[];
+    warnings?: string[];
+    notices?: string[];
+  }): void => {
+    appendNotes(changeNotes, repair.changes);
+    appendNotes(warningNotes, repair.warnings);
+    appendNotes(warningNotes, repair.notices);
+  };
 
   const applyMutation = (mutation: {
     config: DoctorConfigMutationState["candidate"];
@@ -70,15 +84,31 @@ export async function runDoctorRepairSequence(params: {
     warnings?: string[];
   }) => {
     if (mutation.changes.length > 0) {
-      changeNotes.push(sanitizeLines(mutation.changes));
+      appendNotes(changeNotes, mutation.changes);
       state = applyDoctorConfigMutation({
         state,
         mutation,
         shouldRepair: true,
       });
     }
-    if (mutation.warnings && mutation.warnings.length > 0) {
-      warningNotes.push(sanitizeLines(mutation.warnings));
+    appendNotes(warningNotes, mutation.warnings);
+  };
+  type RepairStage = (config: DoctorConfigMutationState["candidate"]) =>
+    | {
+        config: DoctorConfigMutationState["candidate"];
+        changes: string[];
+        warnings?: string[];
+      }
+    | Promise<{
+        config: DoctorConfigMutationState["candidate"];
+        changes: string[];
+        warnings?: string[];
+      }>;
+  const applyRepairStages = async (stages: readonly RepairStage[]): Promise<void> => {
+    for (const repair of stages) {
+      // Each descriptor consumes the previous repair's candidate; changing the
+      // order can break owner repairs, allowlist inheritance, or upgrade safety.
+      applyMutation(await repair(state.candidate));
     }
   };
 
@@ -131,7 +161,7 @@ export async function runDoctorRepairSequence(params: {
     env,
   });
   if (missingConfiguredPluginInstallRepair.changes.length > 0) {
-    changeNotes.push(sanitizeLines(missingConfiguredPluginInstallRepair.changes));
+    appendNotes(changeNotes, missingConfiguredPluginInstallRepair.changes);
     applyMutation(applyPluginAutoEnable({ config: state.candidate, env }));
     const repairedPluginIds = missingConfiguredPluginInstallRepair.repairedPluginIds ?? [];
     if (repairedPluginIds.length > 0) {
@@ -160,13 +190,8 @@ export async function runDoctorRepairSequence(params: {
       }
     }
   }
-  if (missingConfiguredPluginInstallRepair.warnings.length > 0) {
-    warningNotes.push(sanitizeLines(missingConfiguredPluginInstallRepair.warnings));
-  }
-  const missingConfiguredPluginInstallNotices = missingConfiguredPluginInstallRepair.notices ?? [];
-  if (missingConfiguredPluginInstallNotices.length > 0) {
-    warningNotes.push(sanitizeLines(missingConfiguredPluginInstallNotices));
-  }
+  appendNotes(warningNotes, missingConfiguredPluginInstallRepair.warnings);
+  appendNotes(warningNotes, missingConfiguredPluginInstallRepair.notices);
   const failedPluginIds = missingConfiguredPluginInstallRepair.failedPluginIds ?? [];
   const hasUnscopedInstallRepairWarnings =
     missingConfiguredPluginInstallRepair.warnings.length > 0 && failedPluginIds.length === 0;
@@ -180,71 +205,45 @@ export async function runDoctorRepairSequence(params: {
       }),
     );
   }
-  applyMutation(maybeRepairInvalidPluginConfig(state.candidate));
-  applyMutation(await maybeRepairAllowlistPolicyAllowFrom(state.candidate));
-  applyMutation(maybeRepairOpenPolicyAllowFrom(state.candidate));
-  applyMutation(maybeRepairGroupAllowFromFallback(state.candidate));
-  applyMutation(maybeRepairStaleSubagentAllowlists(state.candidate));
+  await applyRepairStages([
+    maybeRepairInvalidPluginConfig,
+    maybeRepairAllowlistPolicyAllowFrom,
+    maybeRepairOpenPolicyAllowFrom,
+    maybeRepairGroupAllowFromFallback,
+    maybeRepairStaleSubagentAllowlists,
+  ]);
 
   const emptyAllowlistWarnings = scanEmptyAllowlistPolicyWarnings(state.candidate, {
     doctorFixCommand: params.doctorFixCommand,
     ...createChannelDoctorEmptyAllowlistPolicyHooks({ cfg: state.candidate, env }),
   });
-  if (emptyAllowlistWarnings.length > 0) {
-    warningNotes.push(sanitizeLines(emptyAllowlistWarnings));
-  }
+  appendNotes(warningNotes, emptyAllowlistWarnings);
 
-  applyMutation(maybeRepairLegacyToolsBySenderKeys(state.candidate));
-  applyMutation(maybeRepairExecSafeBinProfiles(state.candidate));
-  const pluginDependencyCleanup = await cleanupLegacyPluginDependencyState({ env });
-  if (pluginDependencyCleanup.changes.length > 0) {
-    changeNotes.push(sanitizeLines(pluginDependencyCleanup.changes));
-  }
-  if (pluginDependencyCleanup.warnings.length > 0) {
-    warningNotes.push(sanitizeLines(pluginDependencyCleanup.warnings));
-  }
-  const onboardingRecommendationsMigration = migrateLegacyOnboardingRecommendationsScope({
-    cfg: state.candidate,
-    env,
-  });
-  if (onboardingRecommendationsMigration.changes.length > 0) {
-    changeNotes.push(sanitizeLines(onboardingRecommendationsMigration.changes));
-  }
-  if (onboardingRecommendationsMigration.warnings.length > 0) {
-    warningNotes.push(sanitizeLines(onboardingRecommendationsMigration.warnings));
-  }
+  await applyRepairStages([maybeRepairLegacyToolsBySenderKeys, maybeRepairExecSafeBinProfiles]);
+  appendRepairNotes(await cleanupLegacyPluginDependencyState({ env }));
+  appendRepairNotes(
+    migrateLegacyOnboardingRecommendationsScope({
+      cfg: state.candidate,
+      env,
+    }),
+  );
   const legacyOAuthSidecarRepair = await maybeRepairLegacyOAuthSidecarProfiles({
     cfg: state.candidate,
     prompter: { confirmAutoFix: async () => true },
     emitNotes: false,
     env,
   });
-  if (legacyOAuthSidecarRepair.changes.length > 0) {
-    changeNotes.push(sanitizeLines(legacyOAuthSidecarRepair.changes));
-  }
-  if (legacyOAuthSidecarRepair.warnings.length > 0) {
-    warningNotes.push(sanitizeLines(legacyOAuthSidecarRepair.warnings));
-  }
+  appendRepairNotes(legacyOAuthSidecarRepair);
   const openAIAuthProviderRepair = await maybeRepairOpenAICodexAuthProfileStores({
     cfg: state.candidate,
     env,
   });
-  if (openAIAuthProviderRepair.changes.length > 0) {
-    changeNotes.push(sanitizeLines(openAIAuthProviderRepair.changes));
-  }
-  if (openAIAuthProviderRepair.warnings.length > 0) {
-    warningNotes.push(sanitizeLines(openAIAuthProviderRepair.warnings));
-  }
+  appendRepairNotes(openAIAuthProviderRepair);
   const staleOAuthShadowRepair = await repairStaleOAuthProfileShadows({
     cfg: state.candidate,
     env,
   });
-  if (staleOAuthShadowRepair.changes.length > 0) {
-    changeNotes.push(sanitizeLines(staleOAuthShadowRepair.changes));
-  }
-  if (staleOAuthShadowRepair.warnings.length > 0) {
-    warningNotes.push(sanitizeLines(staleOAuthShadowRepair.warnings));
-  }
+  appendRepairNotes(staleOAuthShadowRepair);
   const authProfileSqliteMigration = await maybeMigrateAuthProfileJsonStoresToSqlite({
     cfg: state.candidate,
     prompter: { confirmAutoFix: async () => true },
@@ -260,12 +259,7 @@ export async function runDoctorRepairSequence(params: {
       shouldRepair: true,
     });
   }
-  if (authProfileSqliteMigration.changes.length > 0) {
-    changeNotes.push(sanitizeLines(authProfileSqliteMigration.changes));
-  }
-  if (authProfileSqliteMigration.warnings.length > 0) {
-    warningNotes.push(sanitizeLines(authProfileSqliteMigration.warnings));
-  }
+  appendRepairNotes(authProfileSqliteMigration);
   const staleAuthOrderRepair = maybeRepairStaleConfiguredAuthOrders({
     cfg: state.candidate,
     env,
@@ -281,9 +275,7 @@ export async function runDoctorRepairSequence(params: {
     cfg: state.candidate,
     env,
   });
-  if (activeToolSchemaWarnings.length > 0) {
-    warningNotes.push(sanitizeLines(activeToolSchemaWarnings));
-  }
+  appendNotes(warningNotes, activeToolSchemaWarnings);
 
   return { state, changeNotes, warningNotes, authProfilesRepaired };
 }


### PR DESCRIPTION
## What Problem This Solves

Configuration and repair workflows could silently diverge because interactive setup and section-filtered setup each owned their own copy of every action and write boundary. Doctor also rebuilt the same configuration mutation state in several repair paths and accumulated owner changes, warnings, and notices inconsistently. These duplicated decision surfaces make setup side-effect order, configuration persistence, owner-repair ordering, and safe terminal output unnecessarily difficult to maintain.

## Why This Change Was Made

Give all nine setup sections one typed, canonical action table; execute explicitly selected sections in their existing canonical order and persist their mutations once before daemon or health side effects. Drive doctor repairs through the existing canonical configuration mutation state and one explicitly ordered owner-repair pipeline. Sanitize each grouped owner change, warning, and notice consistently while preserving existing warning chronology, public flags, SecretRefs, migrations, and plugin ownership.

The three production modules delete 270 lines and add 198, a net reduction of **72 production lines**. This change does not introduce or modify configuration keys, environment variables, SQLite schemas, gateway protocols, provider routes, or public plugin SDK surfaces.

## User Impact

Existing interactive and noninteractive setup, onboarding, and doctor commands retain their public behavior. Explicit setup reliably completes configuration writes before dependent daemon and health actions; repeated or reordered section flags cannot change the canonical setup order. Doctor applies owner repairs in their existing required order and prevents grouped plugin output from introducing terminal escape sequences or carriage-return overwrite sequences. Focused regression tests lock down each of these invariants.

## Evidence

Validated the complete exact patch on an isolated Blacksmith Testbox:

- **544/544 tests passed across 26 suites and all six Vitest shards**, including setup and maintenance CLI registration, noninteractive onboarding, configuration guards, configure ordering and write boundaries, doctor configuration flow and legacy migrations, owner repair and plugin doctor contracts, safe-bin and SecretRef paths, health contributions, and release/upgrade survivor baselines.
- `pnpm check:changed -- src/commands/configure.wizard.ts src/commands/configure.wizard.test.ts src/commands/doctor-config-flow.ts src/commands/doctor/repair-sequencing.ts src/commands/doctor/repair-sequencing.test.ts`: passed, including production and test TypeScript checks, formatting, lint with zero warnings, plugin/ownership boundaries, native schema and database-first guards, sidecar-loader and runtime import-cycle checks.
- `pnpm deadcode:dependencies`: passed for both production and full-tree Knip configurations.
- `pnpm deadcode:unused-files`: passed with zero production or full-tree unused files.
- `pnpm deadcode:exports`: passed with zero production, full-tree, or script unused exports.
- `pnpm build`: passed, including the packaged CLI, bundled plugin assets, all 142 public plugin SDK subpaths, production Control UI, and startup performance budgets.
- Real packaged `node openclaw.mjs` smoke against fresh isolated state: noninteractive onboarding with suppressed gateway-token output; config validation before repair; `doctor --non-interactive`; `doctor --fix --non-interactive`; config validation after repair; and both `configure --help` and `onboard --help` all passed.
- Fresh exact-patch `autoreview --mode uncommitted`: clean; no accepted or actionable findings; secret scan clean.
