### PR TITLE
fix(ui): claim new-session handoffs on the direct chat route

### DIFF
--- a/ui/src/e2e/new-session-page.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.e2e.test.ts
@@ -307,7 +307,8 @@ describeControlUiE2e("Control UI new-session page mocked Gateway E2E", () => {
       await page.waitForURL((url) => url.pathname === controlUiSessionPath(sessionKey), {
         timeout: 30_000,
       });
-      await gateway.waitForRequest("chat.history");
+      // The transcript fetch rides chat.startup or chat.history depending on what
+      // the Gateway advertises, so wait on the rendered rows instead of the method.
       await page.getByText("SKILL.md", { exact: true }).waitFor();
 
       await expect.poll(() => page.locator(".chat-group.user").textContent()).toContain(message);
@@ -347,10 +348,9 @@ describeControlUiE2e("Control UI new-session page mocked Gateway E2E", () => {
       await page.goto(`${server.baseUrl}new`);
       await page.locator(".new-session-page__message").fill(message);
       await page.getByRole("button", { name: "Start thread" }).click();
-      await page.waitForURL((url) => url.searchParams.get("session") === sessionKey, {
+      await page.waitForURL((url) => url.pathname === controlUiSessionPath(sessionKey), {
         timeout: 30_000,
       });
-      await gateway.waitForRequest("chat.history");
       await expect.poll(() => page.locator(".chat-group.user").textContent()).toContain(message);
 
       const socketsBeforeReconnect = await gateway.getSocketCount();
@@ -404,7 +404,9 @@ describeControlUiE2e("Control UI new-session page mocked Gateway E2E", () => {
     const sessionKey = "agent:main:single-image-prompt";
     const message = "testing if dual prompts show";
     const gateway = await installMockGateway(page, {
-      deferredMethods: ["chat.history"],
+      // The transcript bootstrap rides chat.startup while the Gateway advertises it,
+      // so that is the request this scenario holds open to observe reconciliation.
+      deferredMethods: ["chat.startup"],
       methodResponses: {
         "sessions.create": {
           key: sessionKey,
@@ -445,8 +447,6 @@ describeControlUiE2e("Control UI new-session page mocked Gateway E2E", () => {
       await page.waitForURL((url) => url.pathname === controlUiSessionPath(sessionKey), {
         timeout: 30_000,
       });
-      await gateway.waitForRequest("chat.history");
-
       const userRow = page.locator(".chat-group.user");
       const userImage = userRow.locator("img.chat-message-image");
       await expect.poll(() => userRow.count()).toBe(1);
@@ -457,7 +457,7 @@ describeControlUiE2e("Control UI new-session page mocked Gateway E2E", () => {
       await expect.poll(() => userRow.textContent()).toContain(message);
       await expect.poll(() => userRow.textContent()).not.toContain("Attached image");
 
-      await gateway.resolveDeferred("chat.history");
+      await gateway.resolveDeferred("chat.startup");
 
       await expect.poll(() => userRow.count()).toBe(1);
       await expect.poll(() => userImage.count()).toBe(1);

--- a/ui/src/e2e/new-session-page.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.e2e.test.ts
@@ -268,7 +268,7 @@ describeControlUiE2e("Control UI new-session page mocked Gateway E2E", () => {
     const sessionKey = "agent:main:visible-initial-prompt";
     const message = "keep this prompt visible while the agent works";
     const activeOutputTimestamp = Date.now() + 60_000;
-    const gateway = await installMockGateway(page, {
+    await installMockGateway(page, {
       methodResponses: {
         "sessions.create": { key: sessionKey, runStarted: true },
         "chat.history": {

--- a/ui/src/pages/chat/chat-history.ts
+++ b/ui/src/pages/chat/chat-history.ts
@@ -56,7 +56,10 @@ import {
   preserveOptimisticTailMessages,
   readTranscriptSequence,
 } from "./history-merge.ts";
-import { reconcileInitialUserMessageHandoff } from "./initial-turn-handoff.ts";
+import {
+  isPendingInitialUserMessage,
+  reconcileInitialUserMessageHandoff,
+} from "./initial-turn-handoff.ts";
 import {
   controlUiNowMs,
   recordControlUiPerformanceEvent,
@@ -1187,6 +1190,9 @@ async function loadChatHistoryUncached(
       reconciledTerminal.previousMessages,
       reconciledTerminal.currentMessages,
       authoritativeMessages,
+    ).filter(
+      (message) =>
+        !isPendingInitialUserMessage(state.initialUserMessage, state, sessionKey, message),
     );
     state.chatMessages = preserveOptimisticTailMessages(
       authoritativeMessages,

--- a/ui/src/pages/chat/chat-pane-deps.ts
+++ b/ui/src/pages/chat/chat-pane-deps.ts
@@ -277,7 +277,7 @@ export {
   storedChatOutboxScopeKey,
 } from "./composer-persistence.ts";
 export { exportChatMarkdown } from "./export.ts";
-export { admitInitialUserMessageHandoff } from "./initial-turn-handoff.ts";
+export { admitInitialTurnHandoff, admitInitialUserMessageHandoff } from "./initial-turn-handoff.ts";
 export {
   hasAbortableSessionRun,
   reconcileStaleChatRunAfterSessionStatePublication,

--- a/ui/src/pages/chat/chat-pane-lifecycle.ts
+++ b/ui/src/pages/chat/chat-pane-lifecycle.ts
@@ -1,6 +1,8 @@
 import {
   BROWSER_ANNOTATION_EVENT,
+  CHAT_COMPOSER_DRAFT_STORAGE_ERROR,
   WIDGET_PROMPT_EVENT,
+  admitInitialTurnHandoff,
   admitInitialUserMessageHandoff,
   areUiSessionKeysEquivalent,
   chatAttachmentFromDataUrl,
@@ -356,6 +358,24 @@ export abstract class ChatPaneLifecycle extends ChatPaneReset {
       } else if (catalogKey && this.catalogRequestedSessionKey !== this.sessionKey) {
         this.catalogLoadGeneration += 1;
         this.openCatalogSession(catalogKey, this.state);
+      } else if (nextSessionKey) {
+        // A pane routed straight onto the created session never runs the switch
+        // path, so its one-shot handoffs would expire unclaimed: the rejected turn
+        // would vanish instead of offering a retry, and the accepted prompt would
+        // stay hidden until the transcript bootstrap resolved.
+        const rejectedTurn = admitInitialTurnHandoff(this.state, nextSessionKey);
+        const acceptedPrompt = admitInitialUserMessageHandoff(
+          this.state.initialUserMessage,
+          this.state,
+          nextSessionKey,
+        );
+        if (rejectedTurn) {
+          this.state.lastError = CHAT_COMPOSER_DRAFT_STORAGE_ERROR;
+          this.state.chatError = CHAT_COMPOSER_DRAFT_STORAGE_ERROR;
+        }
+        if (rejectedTurn || acceptedPrompt) {
+          this.requestUpdate();
+        }
       }
       this.chatState.restoreCreatedSessionComposer(nextSessionKey);
     }

--- a/ui/src/pages/chat/initial-turn-handoff.test.ts
+++ b/ui/src/pages/chat/initial-turn-handoff.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { createInitialUserMessageHandoff } from "../../app/initial-user-message-handoff.ts";
 import {
   admitInitialUserMessageHandoff,
+  isPendingInitialUserMessage,
   prepareInitialUserMessageHandoff,
   reconcileInitialUserMessageHandoff,
 } from "./initial-turn-handoff.ts";
@@ -80,6 +81,33 @@ describe("initial user message handoff", () => {
     expect(admitInitialUserMessageHandoff(handoff, { chatMessages: [], client }, sessionKey)).toBe(
       false,
     );
+  });
+
+  it("identifies an already-projected prompt so history cannot re-place it", () => {
+    const sessionKey = "agent:main:new-session";
+    const client = {};
+    const handoff = createInitialUserMessageHandoff();
+    prepareInitialUserMessageHandoff(
+      handoff,
+      sessionKey,
+      { text: "keep this above the replies it started", createdAt: 10 },
+      client,
+    );
+
+    const host = { chatMessages: [] as unknown[], client };
+    admitInitialUserMessageHandoff(handoff, host, sessionKey);
+    const projected = host.chatMessages[0];
+
+    expect(isPendingInitialUserMessage(handoff, host, sessionKey, projected)).toBe(true);
+    expect(
+      isPendingInitialUserMessage(handoff, host, sessionKey, {
+        role: "assistant",
+        content: [{ type: "text", text: "reply" }],
+        timestamp: 11,
+      }),
+    ).toBe(false);
+    expect(isPendingInitialUserMessage(handoff, host, "agent:main:other", projected)).toBe(false);
+    expect(isPendingInitialUserMessage(undefined, host, sessionKey, projected)).toBe(false);
   });
 
   it("does not duplicate a first prompt that history already loaded", () => {

--- a/ui/src/pages/chat/initial-turn-handoff.ts
+++ b/ui/src/pages/chat/initial-turn-handoff.ts
@@ -203,6 +203,21 @@ export function admitInitialUserMessageHandoff(
   return true;
 }
 
+/**
+ * The projected prompt is a head row owned by reconcileInitialUserMessageHandoff.
+ * A history merge that re-places it as a late optimistic tail would render the
+ * first turn below the replies it started.
+ */
+export function isPendingInitialUserMessage(
+  handoff: ApplicationInitialUserMessageHandoff | undefined,
+  host: { client?: object | null },
+  sessionKey: string,
+  candidate: unknown,
+): boolean {
+  const message = handoff?.read(sessionKey, host.client ?? null);
+  return Boolean(message && isSameInitialUserMessage(candidate, message));
+}
+
 /** Keeps the accepted prompt projected until authoritative history owns it. */
 export function reconcileInitialUserMessageHandoff(
   handoff: ApplicationInitialUserMessageHandoff,

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -657,6 +657,22 @@ function installControlUiMockGateway(input: {
     return { found: true, value: matchingCase.response };
   }
 
+  /** Transcript fields a scenario configured on chat.history, replayed onto the
+   * chat.startup payload so both bootstrap paths serve the same conversation. */
+  function configuredHistoryTranscript(): Record<string, unknown> {
+    const configured = scenario.methodResponses["chat.history"];
+    if (!isRecord(configured) || responseCases(configured) || responseSequence(configured)) {
+      return {};
+    }
+    const transcript: Record<string, unknown> = {};
+    for (const field of ["messages", "sessionId", "sessionInfo", "inFlightRun", "thinkingLevel"]) {
+      if (hasOwn(configured, field)) {
+        transcript[field] = configured[field];
+      }
+    }
+    return transcript;
+  }
+
   /** Presence slice of the connect snapshot. The self-flagged entry adopts the
    * connecting client's instanceId so presence surfaces resolve "you". */
   function presenceSnapshot(connectParams: unknown): { presence?: unknown[] } {
@@ -1042,6 +1058,10 @@ function installControlUiMockGateway(input: {
           thinkingLevel: null,
           ...(scenario.inFlightRun ? { inFlightRun: scenario.inFlightRun } : {}),
           ...(scenario.sessionInfo ? { sessionInfo: scenario.sessionInfo } : {}),
+          // The transcript bootstrap picks chat.startup whenever the Gateway
+          // advertises it, so a scenario that configures only chat.history would
+          // otherwise have its transcript silently dropped on the startup path.
+          ...configuredHistoryTranscript(),
         };
       case "chat.metadata":
         return {


### PR DESCRIPTION
## What Problem This Solves

Four tests in `ui/src/e2e/new-session-page.e2e.test.ts` have been failing on `main` since #113883 landed path-based session routes. Bisected on a clean Blacksmith Testbox: `cca5b147857d5c~1` green, `cca5b147857d5c` red. Nothing caught it because `test/vitest/vitest.ui-e2e.config.ts` is not referenced by `ci.yml` — only by `package.json` and `mantis-web-ui-chat-proof.yml`, which runs a single unrelated file.

Two of the four are stale test expectations. Two are real product regressions, tracked in #114374.

## Why This Change Was Made

**Stale expectations.** #113883 replaced `?session=<key>` with a `/chat/<key>` path, so `url.searchParams.get("session")` never matches again; the assertion now compares against `controlUiSessionPath(sessionKey)`. Separately, the transcript bootstrap prefers `chat.startup` whenever the Gateway advertises it, so three `waitForRequest("chat.history")` gates could no longer fire and the image test deferred a method the app never calls. Those gates are replaced by the rendered rows they were standing in for, and the deferral moves to `chat.startup`.

`ui/src/test-helpers/control-ui-e2e.ts` gains the other half of that: a scenario that configures only `chat.history` now has its transcript replayed onto the `chat.startup` payload, so both bootstrap paths serve the same conversation instead of one silently returning nothing.

**Product regressions (#114374).** `chat-pane-lifecycle.ts` claimed the two one-shot handoffs — the rejected turn and the accepted prompt — only on the session-*switch* path. Before #113883 every created session went through that path. With deferred session navigation a pane can be routed straight onto the created session key, and then neither handoff is ever admitted: the rejected turn expires against its 60s TTL and the user gets no retry affordance, and the accepted prompt stays invisible until the transcript bootstrap resolves. The fix admits both handoffs on the direct-route branch as well, which is the same seam that already owns them.

Verified by instrumenting the handoff store: `PROBE_PREPARE` fires without a matching `PROBE_CONSUME` on unpatched `main`.

## User Impact

Submitting a new session that the Gateway rejects now surfaces the error and keeps the draft recoverable instead of silently dropping it, and an accepted prompt appears immediately rather than after the transcript loads. The rest is test-only.

## Evidence

Blacksmith Testbox, `pnpm test:ui:e2e ui/src/e2e/new-session-page.e2e.test.ts`:

| State | Result |
| --- | --- |
| `main` @ `736a788cb81d5b` | 37 passed, 4 failed |
| this branch | 40 passed, 1 failed |

The remaining failure is `resolves a pending catalog target after reconnect without clearing the draft`. It is **not** caused by this PR: it fails in isolation on unmodified `main` and at `cca5b147857d5c~1`, so it predates #113883. It passed in `main`'s full-suite run only because an earlier test used to die on a stale URL assertion before completing its offline/online cycle; fixing that assertion removes the masking. Root cause is now identified and filed separately as #114398 — the new-session route loader drops the requested agent id while offline, so `catalog.routeKey` flips from `["","claude"]` to `["research","claude"]` on reconnect and `resetDraft()` wipes the typed message. That gets its own PR.

Chat unit suites covering the touched seam: `chat-page.test.ts`, `route.test.ts`, `chat-pane-board.test.ts` — 62 passed.

Fixes #114374
