### PR TITLE
fix(ui): recover offline-selected locales once the gateway reconnects

### DIFF
--- a/ui/src/app/app-host.test.ts
+++ b/ui/src/app/app-host.test.ts
@@ -27,6 +27,16 @@ import type {
 import { shouldMergeChatChrome } from "./mobile-nav-layout.ts";
 import { resolveOnboardingMode } from "./onboarding-mode.ts";
 import { resetServerUiPrefsSync } from "./server-prefs.ts";
+import { scheduleStaleChunkReload } from "./stale-chunk-reload.ts";
+
+vi.mock("./stale-chunk-reload.ts", async () => {
+  const actual =
+    await vi.importActual<typeof import("./stale-chunk-reload.ts")>("./stale-chunk-reload.ts");
+  return {
+    ...actual,
+    scheduleStaleChunkReload: vi.fn(async () => true),
+  };
+});
 
 type AppLifecycleState = {
   loginToken: string;
@@ -52,6 +62,13 @@ type ShellInitializationState = {
 type ShellGatewaySynchronizationState = {
   outboxStoreImport: { load: () => Promise<unknown> };
   synchronizeGateway: (snapshot: ApplicationGatewaySnapshot) => void;
+};
+
+type I18nRecoveryWiring = {
+  localeLoadRecovery?: {
+    isUnrecoverableError: (error: unknown) => boolean;
+    onUnrecoverableLocaleLoad?: (locale: string) => void;
+  };
 };
 
 type ShellServerPreferencesState = {
@@ -270,6 +287,21 @@ describe("OpenClaw app lifecycle", () => {
 });
 
 describe("OpenClaw shell source initialization", () => {
+  it("delegates repeated locale import failures to guarded stale-chunk recovery", () => {
+    const scheduleReload = vi.mocked(scheduleStaleChunkReload);
+    scheduleReload.mockClear();
+    const recovery = (i18n as unknown as I18nRecoveryWiring).localeLoadRecovery;
+
+    expect(
+      recovery?.isUnrecoverableError(
+        new Error("Failed to fetch dynamically imported module: /assets/fr-abc123.js"),
+      ),
+    ).toBe(true);
+    recovery?.onUnrecoverableLocaleLoad?.("fr");
+
+    expect(scheduleReload).toHaveBeenCalledOnce();
+  });
+
   it("retries a pending locale once when the Gateway becomes connected", () => {
     const retryPendingLocale = vi.spyOn(i18n, "retryPendingLocale").mockImplementation(() => {});
     const shell = document.createElement(

--- a/ui/src/app/app-host.test.ts
+++ b/ui/src/app/app-host.test.ts
@@ -14,6 +14,7 @@ import {
   TERMINAL_PANEL_TOGGLE_EVENT,
   UI_COMMAND_EVENT,
 } from "../components/panel-toggle-contract.ts";
+import { i18n } from "../i18n/index.ts";
 import { createStorageMock } from "../test-helpers/storage.ts";
 import { selectShellRouteState } from "./app-host-route-state.ts";
 import { resetAppHostTestGlobals, type ShellKeyboardState } from "./app-host.test-support.ts";
@@ -46,6 +47,11 @@ type ShellInitializationState = {
     snapshot: ApplicationGatewaySnapshot,
     runtimeConfig: ApplicationContext["runtimeConfig"],
   ) => void;
+};
+
+type ShellGatewaySynchronizationState = {
+  outboxStoreImport: { load: () => Promise<unknown> };
+  synchronizeGateway: (snapshot: ApplicationGatewaySnapshot) => void;
 };
 
 type ShellServerPreferencesState = {
@@ -264,6 +270,32 @@ describe("OpenClaw app lifecycle", () => {
 });
 
 describe("OpenClaw shell source initialization", () => {
+  it("retries a pending locale once when the Gateway becomes connected", () => {
+    const retryPendingLocale = vi.spyOn(i18n, "retryPendingLocale").mockImplementation(() => {});
+    const shell = document.createElement(
+      "openclaw-app-shell",
+    ) as unknown as ShellGatewaySynchronizationState;
+    shell.outboxStoreImport = { load: vi.fn(async () => undefined) };
+    const reconnecting = {
+      client: null,
+      phase: "reconnecting",
+      sessionKey: "",
+    } as ApplicationGatewaySnapshot;
+    const connected = {
+      client: {} as GatewayBrowserClient,
+      phase: "connected",
+      sessionKey: "",
+    } as ApplicationGatewaySnapshot;
+
+    shell.synchronizeGateway(reconnecting);
+    shell.synchronizeGateway(connected);
+    shell.synchronizeGateway({ ...connected });
+    shell.synchronizeGateway({ ...connected });
+
+    expect(retryPendingLocale).toHaveBeenCalledOnce();
+    retryPendingLocale.mockRestore();
+  });
+
   it("clears retained presentation and source ownership when its context epoch ends", () => {
     const shell = document.createElement("openclaw-app-shell") as unknown as ShellEpochState;
     const client = {} as GatewayBrowserClient;

--- a/ui/src/app/app-host.ts
+++ b/ui/src/app/app-host.ts
@@ -124,6 +124,7 @@ import {
   normalizeCatalogOpenTarget,
   setSettingsChangeListener,
 } from "./settings.ts";
+import { isStaleChunkImportError, scheduleStaleChunkReload } from "./stale-chunk-reload.ts";
 
 type AppSidebarElement = HTMLElement & {
   dismissTransientMenus: () => boolean;
@@ -137,6 +138,16 @@ const EMPTY_OUTBOX_COUNT_FOR_SESSION = () => 0;
 const PALETTE_SHORTCUT = /Mac|iP(hone|ad|od)/i.test(globalThis.navigator?.platform ?? "")
   ? "⌘K"
   : "Ctrl K";
+
+i18n.setLocaleLoadRecovery({
+  isUnrecoverableError: isStaleChunkImportError,
+  onUnrecoverableLocaleLoad: () => {
+    // Chrome 149 and WebKit can pin network-failed dynamic imports for the document. Keep the
+    // in-place retry for engines that refetch; repeat failures use the guarded stale-chunk reload
+    // owner instead of adding a locale-specific reload path.
+    void scheduleStaleChunkReload();
+  },
+});
 
 type StoredOutboxScopeHost = {
   settings: { gatewayUrl?: string | null };

--- a/ui/src/app/app-host.ts
+++ b/ui/src/app/app-host.ts
@@ -527,6 +527,7 @@ class OpenClawShell extends OpenClawLightDomElement {
   private sessionKeyClient: GatewayBrowserClient | null = null;
   private runtimeConfigClient: GatewayBrowserClient | null = null;
   private runtimeConfigSource: ApplicationContext["runtimeConfig"] | null = null;
+  private previousGatewayPhase: ApplicationContext["gateway"]["snapshot"]["phase"] | null = null;
   private sidebarWorkboardSnapshot = EMPTY_SIDEBAR_WORKBOARD_SNAPSHOT;
   private sidebarWorkboardRuntime: SidebarWorkboardRuntime | null = null;
   private sidebarWorkboardHost: ApplicationContext["workboard"] | null = null;
@@ -794,6 +795,7 @@ class OpenClawShell extends OpenClawLightDomElement {
     this.sessionKeyClient = null;
     this.runtimeConfigClient = null;
     this.runtimeConfigSource = null;
+    this.previousGatewayPhase = null;
     this.disposeSidebarWorkboard();
     if (this.agentRosterRefreshTimer !== null) {
       globalThis.clearTimeout(this.agentRosterRefreshTimer);
@@ -1433,9 +1435,14 @@ class OpenClawShell extends OpenClawLightDomElement {
   }
 
   private synchronizeGateway(snapshot: ApplicationContext["gateway"]["snapshot"]) {
+    const previousPhase = this.previousGatewayPhase;
+    this.previousGatewayPhase = snapshot.phase;
     this.updateGatewaySessionKey(snapshot);
     this.ensureAgentsList(snapshot);
     this.ensureRuntimeConfig(snapshot);
+    if (previousPhase !== "connected" && snapshot.phase === "connected") {
+      i18n.retryPendingLocale();
+    }
     this.syncSidebarWorkboard();
     // Chunks are usually served by the gateway, so a failed idle load of the
     // outbox module recovers on reconnect, not only on a browser online event.

--- a/ui/src/e2e/locale-offline-retry.e2e.test.ts
+++ b/ui/src/e2e/locale-offline-retry.e2e.test.ts
@@ -1,0 +1,134 @@
+// Control UI tests prove locale chunk recovery through a real browser reconnect.
+import { chromium, type Browser, type BrowserContext, type Page, type Route } from "playwright";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  canRunPlaywrightChromium,
+  installMockGateway,
+  resolvePlaywrightChromiumExecutablePath,
+  startControlUiE2eServer,
+  type ControlUiE2eServer,
+  type MockGatewayControls,
+} from "../test-helpers/control-ui-e2e.ts";
+
+const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
+const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
+const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
+const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const frenchLocaleModule = /\/src\/i18n\/locales\/fr\.ts(?:\?.*)?$/;
+
+let browser: Browser;
+let server: ControlUiE2eServer;
+
+async function createContext(): Promise<BrowserContext> {
+  return browser.newContext({
+    locale: "en-US",
+    serviceWorkers: "block",
+    viewport: { height: 900, width: 1280 },
+  });
+}
+
+async function gatewayPhase(page: Page): Promise<string | undefined> {
+  return page.evaluate(() => {
+    const app = document.querySelector("openclaw-app") as HTMLElement & {
+      runtime?: { context: { gateway: { snapshot: { phase: string } } } };
+    };
+    return app.runtime?.context.gateway.snapshot.phase;
+  });
+}
+
+async function documentMarker(page: Page): Promise<string | undefined> {
+  return page.evaluate(
+    () => (window as Window & { localeRetryDocumentMarker?: string }).localeRetryDocumentMarker,
+  );
+}
+
+async function reconnect(page: Page, gateway: MockGatewayControls): Promise<void> {
+  const socketCountBefore = await gateway.getSocketCount();
+  await gateway.closeLatest(1001, "proxy idle timeout");
+  await gateway.setOnline(false);
+  await expect.poll(() => gatewayPhase(page)).toBe("reconnecting");
+  await expect
+    .poll(() => gateway.getSocketCount(), { timeout: 10_000 })
+    .toBeGreaterThan(socketCountBefore);
+  await gateway.setOnline(true);
+  await expect.poll(() => gatewayPhase(page)).toBe("connected");
+}
+
+describeControlUiE2e("Control UI offline locale retry", () => {
+  beforeAll(async () => {
+    if (!chromiumAvailable) {
+      throw new Error(
+        `Playwright Chromium is not available at ${chromiumExecutablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
+      );
+    }
+    server = await startControlUiE2eServer();
+    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
+  });
+
+  afterAll(async () => {
+    await browser?.close();
+    await server?.close();
+  });
+
+  it("applies a locale whose first chunk request failed after the Gateway reconnects", async () => {
+    const context = await createContext();
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page);
+    let abortedLocaleRequests = 0;
+    const abortFrenchLocale = async (route: Route) => {
+      abortedLocaleRequests += 1;
+      await route.abort("internetdisconnected");
+    };
+    await page.route(frenchLocaleModule, abortFrenchLocale);
+    let navigationCount = 0;
+
+    try {
+      const response = await page.goto(`${server.baseUrl}settings/general`);
+      expect(response?.status()).toBe(200);
+      page.on("framenavigated", (frame) => {
+        if (frame === page.mainFrame()) {
+          navigationCount += 1;
+        }
+      });
+      await page.locator(".settings-row__title", { hasText: "Language" }).waitFor();
+      await page.evaluate(() => {
+        (window as Window & { localeRetryDocumentMarker?: string }).localeRetryDocumentMarker =
+          "same-document";
+      });
+
+      const languageSelect = page
+        .locator(".settings-row", { hasText: "Language" })
+        .locator("wa-select");
+      await languageSelect.evaluate((element) => {
+        (element as HTMLElement & { value: string }).value = "fr";
+        element.dispatchEvent(new Event("change", { bubbles: true, composed: true }));
+      });
+
+      await expect.poll(() => abortedLocaleRequests).toBe(1);
+      await page.locator(".settings-row__title", { hasText: "Language" }).waitFor();
+      await page.locator(".settings-page").waitFor();
+      expect(await documentMarker(page)).toBe("same-document");
+      expect(navigationCount).toBe(0);
+
+      await page.unroute(frenchLocaleModule, abortFrenchLocale);
+      await reconnect(page, gateway);
+
+      await page
+        .locator(".settings-row__title", { hasText: "Langue" })
+        .waitFor({ timeout: 10_000 });
+      expect(await documentMarker(page)).toBeUndefined();
+      expect(navigationCount).toBe(1);
+      expect(
+        await page.evaluate(() =>
+          sessionStorage.getItem("openclaw.controlUi.staleChunkReloadBuildId"),
+        ),
+      ).toBe("e2e");
+      await page.waitForTimeout(500);
+      expect(navigationCount).toBe(1);
+      expect(new URL(page.url()).pathname).toBe("/settings/general");
+    } finally {
+      await page.unroute(frenchLocaleModule, abortFrenchLocale);
+      await context.close();
+    }
+  });
+});

--- a/ui/src/i18n/lib/translate.test-support.ts
+++ b/ui/src/i18n/lib/translate.test-support.ts
@@ -1,0 +1,24 @@
+import type { i18n } from "./translate.ts";
+import "./translate.ts";
+import type { Locale, TranslationMap } from "./types.ts";
+
+type LocaleTranslationLoader = (locale: Locale) => Promise<TranslationMap | null>;
+type TranslateTestApi = {
+  createI18nManager(loadLocaleTranslation: LocaleTranslationLoader): typeof i18n;
+};
+
+function getTestApi(): TranslateTestApi {
+  const api = (globalThis as Record<PropertyKey, unknown>)[
+    Symbol.for("openclaw.i18nManagerTestApi")
+  ];
+  if (!api) {
+    throw new Error("i18n manager test API is unavailable");
+  }
+  return api as TranslateTestApi;
+}
+
+export function createI18nManagerForTesting(
+  loadLocaleTranslation: LocaleTranslationLoader,
+): typeof i18n {
+  return getTestApi().createI18nManager(loadLocaleTranslation);
+}

--- a/ui/src/i18n/lib/translate.test.ts
+++ b/ui/src/i18n/lib/translate.test.ts
@@ -1,0 +1,173 @@
+// @vitest-environment node
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createStorageMock } from "../../test-helpers/storage.ts";
+import { en } from "../locales/en.ts";
+import type { Locale, TranslationMap } from "./types.ts";
+
+vi.mock("./registry.ts", async () => {
+  const actual = await vi.importActual<typeof import("./registry.ts")>("./registry.ts");
+  return {
+    ...actual,
+    loadLazyLocaleTranslation: vi.fn(),
+  };
+});
+
+import { loadLazyLocaleTranslation } from "./registry.ts";
+import { i18n } from "./translate.ts";
+
+type I18nInternals = {
+  locale: Locale;
+  localeRequestGeneration: number;
+  pendingLocale: Locale | null;
+  subscribers: Set<(locale: Locale) => void>;
+  translations: Partial<Record<Locale, TranslationMap>>;
+};
+
+const internals = i18n as unknown as I18nInternals;
+const loadTranslation = vi.mocked(loadLazyLocaleTranslation);
+const german = { common: { health: "Gesundheit" } } satisfies TranslationMap;
+const spanish = { common: { health: "Salud" } } satisfies TranslationMap;
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
+}
+
+describe("I18nManager pending locale retry", () => {
+  beforeEach(() => {
+    vi.stubGlobal("localStorage", createStorageMock());
+    vi.stubGlobal("navigator", { language: "en-US" } as Navigator);
+    loadTranslation.mockReset();
+    internals.locale = "en";
+    internals.localeRequestGeneration = 0;
+    internals.pendingLocale = null;
+    internals.subscribers.clear();
+    internals.translations = { en };
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("applies and notifies when a failed locale load is retried after recovery", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    loadTranslation.mockRejectedValueOnce(new Error("gateway unavailable"));
+    loadTranslation.mockResolvedValueOnce(german);
+    const subscriber = vi.fn();
+    const unsubscribe = i18n.subscribe(subscriber);
+
+    await i18n.setLocale("de");
+
+    expect(i18n.getLocale()).toBe("en");
+    expect(internals.pendingLocale).toBe("de");
+    expect(subscriber).not.toHaveBeenCalled();
+
+    i18n.retryPendingLocale();
+    await vi.waitFor(() => expect(i18n.getLocale()).toBe("de"));
+
+    expect(subscriber).toHaveBeenCalledExactlyOnceWith("de");
+    expect(internals.pendingLocale).toBeNull();
+    unsubscribe();
+  });
+
+  it("does nothing when no locale load is pending", () => {
+    const subscriber = vi.fn();
+    const unsubscribe = i18n.subscribe(subscriber);
+
+    i18n.retryPendingLocale();
+
+    expect(loadTranslation).not.toHaveBeenCalled();
+    expect(i18n.getLocale()).toBe("en");
+    expect(subscriber).not.toHaveBeenCalled();
+    unsubscribe();
+  });
+
+  it("clears an abandoned pending target after another locale succeeds", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    loadTranslation.mockRejectedValueOnce(new Error("gateway unavailable"));
+    loadTranslation.mockResolvedValueOnce(spanish);
+
+    await i18n.setLocale("de");
+    await i18n.setLocale("es");
+    i18n.retryPendingLocale();
+
+    expect(i18n.getLocale()).toBe("es");
+    expect(internals.pendingLocale).toBeNull();
+    expect(loadTranslation).toHaveBeenCalledTimes(2);
+  });
+
+  it("records a repeat failure so a later retry can still recover", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    loadTranslation
+      .mockRejectedValueOnce(new Error("gateway unavailable"))
+      .mockRejectedValueOnce(new Error("gateway still unavailable"))
+      .mockResolvedValueOnce(german);
+
+    await i18n.setLocale("de");
+    i18n.retryPendingLocale();
+    await vi.waitFor(() => {
+      expect(loadTranslation).toHaveBeenCalledTimes(2);
+      expect(internals.pendingLocale).toBe("de");
+    });
+
+    i18n.retryPendingLocale();
+    await vi.waitFor(() => expect(i18n.getLocale()).toBe("de"));
+
+    expect(loadTranslation).toHaveBeenCalledTimes(3);
+    expect(internals.pendingLocale).toBeNull();
+  });
+
+  it("ignores an older failure after a newer locale succeeds", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const germanLoad = deferred<TranslationMap | null>();
+    const spanishLoad = deferred<TranslationMap | null>();
+    loadTranslation
+      .mockReturnValueOnce(germanLoad.promise)
+      .mockReturnValueOnce(spanishLoad.promise);
+
+    const setGerman = i18n.setLocale("de");
+    const setSpanish = i18n.setLocale("es");
+    spanishLoad.resolve(spanish);
+    await setSpanish;
+    germanLoad.reject(new Error("late German failure"));
+    await setGerman;
+    i18n.retryPendingLocale();
+
+    expect(i18n.getLocale()).toBe("es");
+    expect(internals.pendingLocale).toBeNull();
+    expect(loadTranslation).toHaveBeenCalledTimes(2);
+  });
+
+  it("preserves a newer failed target when an older load succeeds late", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const germanLoad = deferred<TranslationMap | null>();
+    const spanishLoad = deferred<TranslationMap | null>();
+    loadTranslation
+      .mockReturnValueOnce(germanLoad.promise)
+      .mockReturnValueOnce(spanishLoad.promise)
+      .mockResolvedValueOnce(spanish);
+
+    const setGerman = i18n.setLocale("de");
+    const setSpanish = i18n.setLocale("es");
+    spanishLoad.reject(new Error("Spanish load failed"));
+    await setSpanish;
+    germanLoad.resolve(german);
+    await setGerman;
+
+    expect(i18n.getLocale()).toBe("en");
+    expect(internals.pendingLocale).toBe("es");
+
+    i18n.retryPendingLocale();
+    await vi.waitFor(() => expect(i18n.getLocale()).toBe("es"));
+
+    expect(loadTranslation).toHaveBeenCalledTimes(3);
+    expect(internals.pendingLocale).toBeNull();
+  });
+});

--- a/ui/src/i18n/lib/translate.test.ts
+++ b/ui/src/i18n/lib/translate.test.ts
@@ -49,6 +49,7 @@ describe("I18nManager pending locale retry", () => {
     internals.pendingLocale = null;
     internals.subscribers.clear();
     internals.translations = { en };
+    i18n.setLocaleLoadRecovery(undefined);
   });
 
   afterEach(() => {
@@ -122,6 +123,55 @@ describe("I18nManager pending locale retry", () => {
 
     expect(loadTranslation).toHaveBeenCalledTimes(3);
     expect(internals.pendingLocale).toBeNull();
+  });
+
+  it("persists and reports a repeated module-import failure while keeping it pending", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const persistedLocalesAtHook: Array<string | null> = [];
+    const onUnrecoverableLocaleLoad = vi.fn(() => {
+      persistedLocalesAtHook.push(localStorage.getItem("openclaw.i18n.locale"));
+    });
+    i18n.setLocaleLoadRecovery({
+      isUnrecoverableError: (error) =>
+        error instanceof Error &&
+        /failed to fetch dynamically imported module/i.test(error.message),
+      onUnrecoverableLocaleLoad,
+    });
+    loadTranslation
+      .mockRejectedValueOnce(new Error("gateway unavailable"))
+      .mockRejectedValueOnce(
+        new Error("Failed to fetch dynamically imported module: /assets/fr-abc123.js"),
+      );
+
+    await i18n.setLocale("fr");
+    i18n.retryPendingLocale();
+    await vi.waitFor(() => expect(loadTranslation).toHaveBeenCalledTimes(2));
+
+    expect(onUnrecoverableLocaleLoad).toHaveBeenCalledExactlyOnceWith("fr");
+    expect(persistedLocalesAtHook).toEqual(["fr"]);
+    expect(localStorage.getItem("openclaw.i18n.locale")).toBe("fr");
+    expect(internals.pendingLocale).toBe("fr");
+  });
+
+  it("does not report a repeated non-import failure", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const onUnrecoverableLocaleLoad = vi.fn();
+    i18n.setLocaleLoadRecovery({
+      isUnrecoverableError: (error) =>
+        error instanceof Error &&
+        /failed to fetch dynamically imported module/i.test(error.message),
+      onUnrecoverableLocaleLoad,
+    });
+    loadTranslation
+      .mockRejectedValueOnce(new Error("gateway unavailable"))
+      .mockRejectedValueOnce(new Error("request failed"));
+
+    await i18n.setLocale("fr");
+    i18n.retryPendingLocale();
+    await vi.waitFor(() => expect(loadTranslation).toHaveBeenCalledTimes(2));
+
+    expect(onUnrecoverableLocaleLoad).not.toHaveBeenCalled();
+    expect(internals.pendingLocale).toBe("fr");
   });
 
   it("ignores an older failure after a newer locale succeeds", async () => {

--- a/ui/src/i18n/lib/translate.test.ts
+++ b/ui/src/i18n/lib/translate.test.ts
@@ -2,7 +2,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createStorageMock } from "../../test-helpers/storage.ts";
-import { createI18nManagerForTesting } from "./translate.ts";
+import { createI18nManagerForTesting } from "./translate.test-support.ts";
 import type { Locale, TranslationMap } from "./types.ts";
 
 type I18nInternals = {

--- a/ui/src/i18n/lib/translate.test.ts
+++ b/ui/src/i18n/lib/translate.test.ts
@@ -2,32 +2,25 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createStorageMock } from "../../test-helpers/storage.ts";
-import { en } from "../locales/en.ts";
+import { createI18nManagerForTesting } from "./translate.ts";
 import type { Locale, TranslationMap } from "./types.ts";
 
-vi.mock("./registry.ts", async () => {
-  const actual = await vi.importActual<typeof import("./registry.ts")>("./registry.ts");
-  return {
-    ...actual,
-    loadLazyLocaleTranslation: vi.fn(),
-  };
-});
-
-import { loadLazyLocaleTranslation } from "./registry.ts";
-import { i18n } from "./translate.ts";
-
 type I18nInternals = {
-  locale: Locale;
-  localeRequestGeneration: number;
   pendingLocale: Locale | null;
-  subscribers: Set<(locale: Locale) => void>;
-  translations: Partial<Record<Locale, TranslationMap>>;
 };
 
-const internals = i18n as unknown as I18nInternals;
-const loadTranslation = vi.mocked(loadLazyLocaleTranslation);
 const german = { common: { health: "Gesundheit" } } satisfies TranslationMap;
 const spanish = { common: { health: "Salud" } } satisfies TranslationMap;
+
+function createManager() {
+  const loadTranslation = vi.fn<(locale: Locale) => Promise<TranslationMap | null>>();
+  const manager = createI18nManagerForTesting(loadTranslation);
+  return {
+    internals: manager as unknown as I18nInternals,
+    loadTranslation,
+    manager,
+  };
+}
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
@@ -43,13 +36,6 @@ describe("I18nManager pending locale retry", () => {
   beforeEach(() => {
     vi.stubGlobal("localStorage", createStorageMock());
     vi.stubGlobal("navigator", { language: "en-US" } as Navigator);
-    loadTranslation.mockReset();
-    internals.locale = "en";
-    internals.localeRequestGeneration = 0;
-    internals.pendingLocale = null;
-    internals.subscribers.clear();
-    internals.translations = { en };
-    i18n.setLocaleLoadRecovery(undefined);
   });
 
   afterEach(() => {
@@ -58,20 +44,21 @@ describe("I18nManager pending locale retry", () => {
   });
 
   it("applies and notifies when a failed locale load is retried after recovery", async () => {
+    const { internals, loadTranslation, manager } = createManager();
     vi.spyOn(console, "error").mockImplementation(() => {});
     loadTranslation.mockRejectedValueOnce(new Error("gateway unavailable"));
     loadTranslation.mockResolvedValueOnce(german);
     const subscriber = vi.fn();
-    const unsubscribe = i18n.subscribe(subscriber);
+    const unsubscribe = manager.subscribe(subscriber);
 
-    await i18n.setLocale("de");
+    await manager.setLocale("de");
 
-    expect(i18n.getLocale()).toBe("en");
+    expect(manager.getLocale()).toBe("en");
     expect(internals.pendingLocale).toBe("de");
     expect(subscriber).not.toHaveBeenCalled();
 
-    i18n.retryPendingLocale();
-    await vi.waitFor(() => expect(i18n.getLocale()).toBe("de"));
+    manager.retryPendingLocale();
+    await vi.waitFor(() => expect(manager.getLocale()).toBe("de"));
 
     expect(subscriber).toHaveBeenCalledExactlyOnceWith("de");
     expect(internals.pendingLocale).toBeNull();
@@ -79,59 +66,73 @@ describe("I18nManager pending locale retry", () => {
   });
 
   it("does nothing when no locale load is pending", () => {
+    const { loadTranslation, manager } = createManager();
     const subscriber = vi.fn();
-    const unsubscribe = i18n.subscribe(subscriber);
+    const unsubscribe = manager.subscribe(subscriber);
 
-    i18n.retryPendingLocale();
+    manager.retryPendingLocale();
 
     expect(loadTranslation).not.toHaveBeenCalled();
-    expect(i18n.getLocale()).toBe("en");
+    expect(manager.getLocale()).toBe("en");
     expect(subscriber).not.toHaveBeenCalled();
     unsubscribe();
   });
 
+  it("uses a pre-warmed locale without invoking the loader", async () => {
+    const { loadTranslation, manager } = createManager();
+    manager.registerTranslation("de", german);
+
+    await manager.setLocale("de");
+
+    expect(manager.getLocale()).toBe("de");
+    expect(loadTranslation).not.toHaveBeenCalled();
+  });
+
   it("clears an abandoned pending target after another locale succeeds", async () => {
+    const { internals, loadTranslation, manager } = createManager();
     vi.spyOn(console, "error").mockImplementation(() => {});
     loadTranslation.mockRejectedValueOnce(new Error("gateway unavailable"));
     loadTranslation.mockResolvedValueOnce(spanish);
 
-    await i18n.setLocale("de");
-    await i18n.setLocale("es");
-    i18n.retryPendingLocale();
+    await manager.setLocale("de");
+    await manager.setLocale("es");
+    manager.retryPendingLocale();
 
-    expect(i18n.getLocale()).toBe("es");
+    expect(manager.getLocale()).toBe("es");
     expect(internals.pendingLocale).toBeNull();
     expect(loadTranslation).toHaveBeenCalledTimes(2);
   });
 
   it("records a repeat failure so a later retry can still recover", async () => {
+    const { internals, loadTranslation, manager } = createManager();
     vi.spyOn(console, "error").mockImplementation(() => {});
     loadTranslation
       .mockRejectedValueOnce(new Error("gateway unavailable"))
       .mockRejectedValueOnce(new Error("gateway still unavailable"))
       .mockResolvedValueOnce(german);
 
-    await i18n.setLocale("de");
-    i18n.retryPendingLocale();
+    await manager.setLocale("de");
+    manager.retryPendingLocale();
     await vi.waitFor(() => {
       expect(loadTranslation).toHaveBeenCalledTimes(2);
       expect(internals.pendingLocale).toBe("de");
     });
 
-    i18n.retryPendingLocale();
-    await vi.waitFor(() => expect(i18n.getLocale()).toBe("de"));
+    manager.retryPendingLocale();
+    await vi.waitFor(() => expect(manager.getLocale()).toBe("de"));
 
     expect(loadTranslation).toHaveBeenCalledTimes(3);
     expect(internals.pendingLocale).toBeNull();
   });
 
   it("persists and reports a repeated module-import failure while keeping it pending", async () => {
+    const { internals, loadTranslation, manager } = createManager();
     vi.spyOn(console, "error").mockImplementation(() => {});
     const persistedLocalesAtHook: Array<string | null> = [];
     const onUnrecoverableLocaleLoad = vi.fn(() => {
       persistedLocalesAtHook.push(localStorage.getItem("openclaw.i18n.locale"));
     });
-    i18n.setLocaleLoadRecovery({
+    manager.setLocaleLoadRecovery({
       isUnrecoverableError: (error) =>
         error instanceof Error &&
         /failed to fetch dynamically imported module/i.test(error.message),
@@ -143,8 +144,8 @@ describe("I18nManager pending locale retry", () => {
         new Error("Failed to fetch dynamically imported module: /assets/fr-abc123.js"),
       );
 
-    await i18n.setLocale("fr");
-    i18n.retryPendingLocale();
+    await manager.setLocale("fr");
+    manager.retryPendingLocale();
     await vi.waitFor(() => expect(loadTranslation).toHaveBeenCalledTimes(2));
 
     expect(onUnrecoverableLocaleLoad).toHaveBeenCalledExactlyOnceWith("fr");
@@ -154,9 +155,10 @@ describe("I18nManager pending locale retry", () => {
   });
 
   it("does not report a repeated non-import failure", async () => {
+    const { internals, loadTranslation, manager } = createManager();
     vi.spyOn(console, "error").mockImplementation(() => {});
     const onUnrecoverableLocaleLoad = vi.fn();
-    i18n.setLocaleLoadRecovery({
+    manager.setLocaleLoadRecovery({
       isUnrecoverableError: (error) =>
         error instanceof Error &&
         /failed to fetch dynamically imported module/i.test(error.message),
@@ -166,8 +168,8 @@ describe("I18nManager pending locale retry", () => {
       .mockRejectedValueOnce(new Error("gateway unavailable"))
       .mockRejectedValueOnce(new Error("request failed"));
 
-    await i18n.setLocale("fr");
-    i18n.retryPendingLocale();
+    await manager.setLocale("fr");
+    manager.retryPendingLocale();
     await vi.waitFor(() => expect(loadTranslation).toHaveBeenCalledTimes(2));
 
     expect(onUnrecoverableLocaleLoad).not.toHaveBeenCalled();
@@ -175,6 +177,7 @@ describe("I18nManager pending locale retry", () => {
   });
 
   it("ignores an older failure after a newer locale succeeds", async () => {
+    const { internals, loadTranslation, manager } = createManager();
     vi.spyOn(console, "error").mockImplementation(() => {});
     const germanLoad = deferred<TranslationMap | null>();
     const spanishLoad = deferred<TranslationMap | null>();
@@ -182,20 +185,21 @@ describe("I18nManager pending locale retry", () => {
       .mockReturnValueOnce(germanLoad.promise)
       .mockReturnValueOnce(spanishLoad.promise);
 
-    const setGerman = i18n.setLocale("de");
-    const setSpanish = i18n.setLocale("es");
+    const setGerman = manager.setLocale("de");
+    const setSpanish = manager.setLocale("es");
     spanishLoad.resolve(spanish);
     await setSpanish;
     germanLoad.reject(new Error("late German failure"));
     await setGerman;
-    i18n.retryPendingLocale();
+    manager.retryPendingLocale();
 
-    expect(i18n.getLocale()).toBe("es");
+    expect(manager.getLocale()).toBe("es");
     expect(internals.pendingLocale).toBeNull();
     expect(loadTranslation).toHaveBeenCalledTimes(2);
   });
 
   it("preserves a newer failed target when an older load succeeds late", async () => {
+    const { internals, loadTranslation, manager } = createManager();
     vi.spyOn(console, "error").mockImplementation(() => {});
     const germanLoad = deferred<TranslationMap | null>();
     const spanishLoad = deferred<TranslationMap | null>();
@@ -204,18 +208,18 @@ describe("I18nManager pending locale retry", () => {
       .mockReturnValueOnce(spanishLoad.promise)
       .mockResolvedValueOnce(spanish);
 
-    const setGerman = i18n.setLocale("de");
-    const setSpanish = i18n.setLocale("es");
+    const setGerman = manager.setLocale("de");
+    const setSpanish = manager.setLocale("es");
     spanishLoad.reject(new Error("Spanish load failed"));
     await setSpanish;
     germanLoad.resolve(german);
     await setGerman;
 
-    expect(i18n.getLocale()).toBe("en");
+    expect(manager.getLocale()).toBe("en");
     expect(internals.pendingLocale).toBe("es");
 
-    i18n.retryPendingLocale();
-    await vi.waitFor(() => expect(i18n.getLocale()).toBe("es"));
+    manager.retryPendingLocale();
+    await vi.waitFor(() => expect(manager.getLocale()).toBe("es"));
 
     expect(loadTranslation).toHaveBeenCalledTimes(3);
     expect(internals.pendingLocale).toBeNull();

--- a/ui/src/i18n/lib/translate.ts
+++ b/ui/src/i18n/lib/translate.ts
@@ -11,6 +11,10 @@ import {
 import type { Locale, TranslationMap } from "./types.ts";
 
 type Subscriber = (locale: Locale) => void;
+type LocaleLoadRecovery = {
+  isUnrecoverableError: (error: unknown) => boolean;
+  onUnrecoverableLocaleLoad?: (locale: Locale) => void;
+};
 
 export { SUPPORTED_LOCALES, isSupportedLocale };
 
@@ -24,6 +28,7 @@ class I18nManager {
   private pendingLocale: Locale | null = null;
   // Only the latest selection may update retry state or become active after an async chunk load.
   private localeRequestGeneration = 0;
+  private localeLoadRecovery: LocaleLoadRecovery | undefined;
 
   constructor() {
     this.loadLocale();
@@ -79,6 +84,10 @@ class I18nManager {
   }
 
   public async setLocale(locale: Locale) {
+    return this.applyLocale(locale, false);
+  }
+
+  private async applyLocale(locale: Locale, retrying: boolean) {
     const requestGeneration = ++this.localeRequestGeneration;
     const needsTranslationLoad = locale !== DEFAULT_LOCALE && !this.translations[locale];
     if (this.locale === locale && !needsTranslationLoad) {
@@ -98,8 +107,13 @@ class I18nManager {
         }
         this.translations[locale] = translation;
       } catch (e) {
-        if (this.localeRequestGeneration === requestGeneration) {
+        const isCurrentRequest = this.localeRequestGeneration === requestGeneration;
+        if (isCurrentRequest) {
           this.pendingLocale = locale;
+        }
+        if (retrying && isCurrentRequest && this.localeLoadRecovery?.isUnrecoverableError(e)) {
+          this.persistLocale(locale);
+          this.localeLoadRecovery.onUnrecoverableLocaleLoad?.(locale);
         }
         console.error(`Failed to load locale: ${locale}`, e);
         return;
@@ -121,7 +135,13 @@ class I18nManager {
     }
     const target = this.pendingLocale;
     this.pendingLocale = null;
-    void this.setLocale(target);
+    void this.applyLocale(target, true);
+  }
+
+  public setLocaleLoadRecovery(recovery: LocaleLoadRecovery | undefined): void {
+    // Keep this leaf independent of app-level stale-chunk policy; the app injects both the
+    // error classifier and guarded recovery action.
+    this.localeLoadRecovery = recovery;
   }
 
   public registerTranslation(locale: Locale, map: TranslationMap) {

--- a/ui/src/i18n/lib/translate.ts
+++ b/ui/src/i18n/lib/translate.ts
@@ -15,6 +15,7 @@ type LocaleLoadRecovery = {
   isUnrecoverableError: (error: unknown) => boolean;
   onUnrecoverableLocaleLoad?: (locale: Locale) => void;
 };
+type LocaleTranslationLoader = (locale: Locale) => Promise<TranslationMap | null>;
 
 export { SUPPORTED_LOCALES, isSupportedLocale };
 
@@ -30,7 +31,9 @@ class I18nManager {
   private localeRequestGeneration = 0;
   private localeLoadRecovery: LocaleLoadRecovery | undefined;
 
-  constructor() {
+  constructor(
+    private readonly loadLocaleTranslation: LocaleTranslationLoader = loadLazyLocaleTranslation,
+  ) {
     this.loadLocale();
   }
 
@@ -98,7 +101,7 @@ class I18nManager {
     if (needsTranslationLoad) {
       this.pendingLocale = locale;
       try {
-        const translation = await loadLazyLocaleTranslation(locale);
+        const translation = await this.loadLocaleTranslation(locale);
         if (!translation) {
           if (this.localeRequestGeneration === requestGeneration) {
             this.pendingLocale = locale;
@@ -193,6 +196,12 @@ class I18nManager {
 
     return value;
   }
+}
+
+export function createI18nManagerForTesting(
+  loadLocaleTranslation: LocaleTranslationLoader,
+): I18nManager {
+  return new I18nManager(loadLocaleTranslation);
 }
 
 export const i18n = new I18nManager();

--- a/ui/src/i18n/lib/translate.ts
+++ b/ui/src/i18n/lib/translate.ts
@@ -18,6 +18,12 @@ class I18nManager {
   private locale: Locale = DEFAULT_LOCALE;
   private translations: Partial<Record<Locale, TranslationMap>> = { [DEFAULT_LOCALE]: en };
   private subscribers: Set<Subscriber> = new Set();
+  // Locale chunks are served by the gateway, so a selection made while disconnected can fail.
+  // Preserve the target for the next connected transition; otherwise the chrome silently stays
+  // in the old language forever.
+  private pendingLocale: Locale | null = null;
+  // Only the latest selection may update retry state or become active after an async chunk load.
+  private localeRequestGeneration = 0;
 
   constructor() {
     this.loadLocale();
@@ -73,27 +79,49 @@ class I18nManager {
   }
 
   public async setLocale(locale: Locale) {
+    const requestGeneration = ++this.localeRequestGeneration;
     const needsTranslationLoad = locale !== DEFAULT_LOCALE && !this.translations[locale];
     if (this.locale === locale && !needsTranslationLoad) {
+      this.pendingLocale = null;
       return;
     }
 
     if (needsTranslationLoad) {
+      this.pendingLocale = locale;
       try {
         const translation = await loadLazyLocaleTranslation(locale);
         if (!translation) {
+          if (this.localeRequestGeneration === requestGeneration) {
+            this.pendingLocale = locale;
+          }
           return;
         }
         this.translations[locale] = translation;
       } catch (e) {
+        if (this.localeRequestGeneration === requestGeneration) {
+          this.pendingLocale = locale;
+        }
         console.error(`Failed to load locale: ${locale}`, e);
         return;
       }
     }
 
+    if (this.localeRequestGeneration !== requestGeneration) {
+      return;
+    }
+    this.pendingLocale = null;
     this.locale = locale;
     this.persistLocale(locale);
     this.notify();
+  }
+
+  public retryPendingLocale(): void {
+    if (this.pendingLocale === null || this.pendingLocale === this.locale) {
+      return;
+    }
+    const target = this.pendingLocale;
+    this.pendingLocale = null;
+    void this.setLocale(target);
   }
 
   public registerTranslation(locale: Locale, map: TranslationMap) {

--- a/ui/src/i18n/lib/translate.ts
+++ b/ui/src/i18n/lib/translate.ts
@@ -198,11 +198,13 @@ class I18nManager {
   }
 }
 
-export function createI18nManagerForTesting(
-  loadLocaleTranslation: LocaleTranslationLoader,
-): I18nManager {
-  return new I18nManager(loadLocaleTranslation);
-}
-
 export const i18n = new I18nManager();
 export const t = (key: string, params?: Record<string, string>) => i18n.t(key, params);
+
+if (typeof process !== "undefined" && (process.env?.VITEST || process.env?.NODE_ENV === "test")) {
+  (globalThis as Record<PropertyKey, unknown>)[Symbol.for("openclaw.i18nManagerTestApi")] = {
+    createI18nManager(loadLocaleTranslation: LocaleTranslationLoader) {
+      return new I18nManager(loadLocaleTranslation);
+    },
+  };
+}


### PR DESCRIPTION
## What Problem This Solves

Selecting a non-English language in the Control UI while the Gateway is
unreachable leaves the chrome stuck in the old language permanently.
`i18n.setLocale` swallows the failed lazy locale-chunk import
(`catch → console.error → return`) and nothing ever retries — even after the
connection returns and the preference is persisted server-side. Proven live
during the PR #114286 Testbox proof: a page selected Français offline,
`ui.prefs.locale=fr` persisted after reconnect, but that page stayed English
until a manual reload. Pre-existing on `main`, independent of #114286.

## Why This Change Was Made

Locale chunks are served by the Gateway, so an offline selection fails at
fetch time — and empirically (Chrome 149, verified in this PR's e2e; WebKit
per Vite's documented limitation) the failed dynamic import stays pinned for
the document, so a bare same-specifier retry cannot recover. The fix layers
recovery across the existing owners:

- The translator (i18n leaf) records the pending target locale on every
  failed load — covering both change events and boot-time failures — and
  exposes `retryPendingLocale()` plus an injected recovery contract, staying
  independent of app-level policy. A request-generation fence also stops a
  slow stale chunk load from clobbering a newer selection.
- app-host retries once on the offline→connected transition (edge-detected,
  so connected-state snapshot chatter cannot hammer the loader). Engines
  whose module map refetches recover in place.
- If the retry fails with a module-import error, the translator persists the
  intended locale and defers to the existing guarded stale-chunk reload
  owner (`scheduleStaleChunkReload`: cooldown + per-build guard) — no new
  reload policy. The post-reload boot then applies the persisted locale
  against the reachable Gateway.

## User Impact

Picking a language while disconnected now applies automatically once the
Gateway is reachable again — at most one guarded page reload on engines that
pin failed imports — instead of silently staying in the old language until a
manual reload.

## Evidence

- Unit/wiring: 36 tests green (`ui/src/i18n/lib/translate.test.ts`,
  `ui/src/app/app-host.test.ts`) — failed-load recording, retry success,
  repeat-failure classification, persist-before-reload, intent supersession,
  request-generation race ordering, exactly-once reconnect-edge wiring.
- Real-Chromium e2e `ui/src/e2e/locale-offline-retry.e2e.test.ts` (Chrome
  149, route-aborted locale chunk): chrome stays English during the failure,
  exactly one guarded reload after reconnect, French renders after boot, no
  reload loop. This run is also the empirical proof that Chrome pins the
  failed import (an earlier in-place-retry-only design failed exactly there).
- `check-changed` (formatting, guards, i18n verification, core/UI
  typechecks, lint) passed remotely on Blacksmith Testbox, exit 0.
- Structured review (gpt-5.6-sol, xhigh): clean, `patch is correct (0.93)`,
  no actionable findings.
- AI-assisted (Codex implementation from maintainer specs; design, review,
  and verification by maintainer session).
