### PR TITLE
fix(macos): keep polling gateway-executed wizard steps

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -39459,7 +39459,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 460,
+      "line": 470,
       "path": "apps/macos/Sources/OpenClawMacCLI/WizardCommand.swift",
       "source": " [\\(initial)]",
       "surface": "apple",
@@ -39467,7 +39467,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 507,
+      "line": 517,
       "path": "apps/macos/Sources/OpenClawMacCLI/WizardCommand.swift",
       "source": " — \\(option.hint!)",
       "surface": "apple",
@@ -39475,7 +39475,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 514,
+      "line": 524,
       "path": "apps/macos/Sources/OpenClawMacCLI/WizardCommand.swift",
       "source": " [\\(initialIndices.map(String.init).joined(separator: \",\"))]",
       "surface": "apple",

--- a/apps/macos/Sources/OpenClaw/OnboardingAISetup.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingAISetup.swift
@@ -1344,6 +1344,13 @@ extension OnboardingAISetupModel {
         self.authSelection = max(0, options.firstIndex {
             anyCodableEqual($0.value, step?.initialvalue)
         } ?? 0)
+        // Gateway-executed steps render progress and expose no input control, so
+        // no user action would ever ask for the next frame. Keep polling; the
+        // session long-polls until the next update or the terminal result, so a
+        // download reports live instead of freezing on its first frame.
+        if let step, wizardStepExecutor(step) == "gateway" {
+            self.advanceProviderAuth(stepID: nil, value: nil)
+        }
     }
 
     private func reconcileProviderAuthAfterUnknownOutcome(

--- a/apps/macos/Sources/OpenClawMacCLI/WizardCommand.swift
+++ b/apps/macos/Sources/OpenClawMacCLI/WizardCommand.swift
@@ -381,7 +381,10 @@ private func runWizard(client: GatewayWizardClient, opts: WizardCliOptions) asyn
                 fputs("wizard: \(error)\n", stderr)
             }
 
-            if let step = nextResult.step {
+            // Gateway-executed steps (download/install progress) take no answer;
+            // echo the frame and poll, or the run stalls on input that can never
+            // advance the session.
+            if let step = nextResult.step, wizardStepExecutor(step) != "gateway" {
                 let answer = try promptAnswer(for: step)
                 var answerPayload: [String: ProtoAnyCodable] = [
                     "stepId": ProtoAnyCodable(step.id),
@@ -400,6 +403,9 @@ private func runWizard(client: GatewayWizardClient, opts: WizardCliOptions) asyn
                     dumpResult(response)
                 }
             } else {
+                if let step = nextResult.step, !opts.json {
+                    printWizardStepHeader(step)
+                }
                 let response = try await client.request(
                     method: "wizard.next",
                     params: ["sessionId": ProtoAnyCodable(sessionId)])
@@ -429,14 +435,18 @@ private func dumpResult(_ response: ResponseFrame) {
     }
 }
 
-private func promptAnswer(for step: WizardStep) throws -> Any {
-    let type = wizardStepType(step)
+private func printWizardStepHeader(_ step: WizardStep) {
     if let title = step.title, !title.isEmpty {
         print("\n\(title)")
     }
     if let message = step.message, !message.isEmpty {
         print(message)
     }
+}
+
+private func promptAnswer(for step: WizardStep) throws -> Any {
+    let type = wizardStepType(step)
+    printWizardStepHeader(step)
 
     switch type {
     case "note":

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
@@ -372,12 +372,21 @@ private func wizardStartResponse(id: String, sessionID: String) -> Data {
         """.utf8)
 }
 
-private func wizardProgressResponse(id: String, sessionID: String) -> Data {
+private func wizardProgressResponse(id: String, sessionID: String, message: String) -> Data {
     Data(
         """
         {"type":"res","id":"\(id)","ok":true,"payload":{
           "sessionId":"\(sessionID)","done":false,"status":"running",
-          "step":{"id":"download","type":"progress","message":"Downloading model: 25%"}
+          "step":{"id":"download","type":"progress","executor":"gateway","message":"\(message)"}
+        }}
+        """.utf8)
+}
+
+private func wizardDoneResponse(id: String, sessionID: String) -> Data {
+    Data(
+        """
+        {"type":"res","id":"\(id)","ok":true,"payload":{
+          "sessionId":"\(sessionID)","done":true,"status":"done"
         }}
         """.utf8)
 }
@@ -637,8 +646,10 @@ struct OnboardingAISetupTests {
             "openclaw.setup.prepare.start")
     }
 
-    @Test func `prepare action starts shared wizard with the local auth choice`() async throws {
+    @Test func `prepare starts the shared wizard and polls gateway progress`() async throws {
         let recorder = AISetupRequestRecorder()
+        let frames = AISetupSocketGeneration()
+        let completion = AISetupRequestGate()
         let session = GatewayTestWebSocketSession(taskFactory: {
             GatewayTestWebSocketTask(
                 sendHook: { task, message, sendIndex in
@@ -657,9 +668,26 @@ struct OnboardingAISetupTests {
                             sessionID: sessionID)))
                     case "wizard.next":
                         let sessionID = request.params["sessionId"] as? String ?? "prepare-session"
-                        task.emitReceiveSuccess(.data(wizardProgressResponse(
-                            id: request.id,
-                            sessionID: sessionID)))
+                        // Two gateway-executed progress frames, then the terminal
+                        // result: a client that stops after the first frame never
+                        // reaches either follow-up.
+                        switch frames.claim() {
+                        case 0:
+                            task.emitReceiveSuccess(.data(wizardProgressResponse(
+                                id: request.id,
+                                sessionID: sessionID,
+                                message: "Downloading model: 25%")))
+                        case 1:
+                            task.emitReceiveSuccess(.data(wizardProgressResponse(
+                                id: request.id,
+                                sessionID: sessionID,
+                                message: "Downloading model: 80%")))
+                        default:
+                            await completion.wait()
+                            task.emitReceiveSuccess(.data(wizardDoneResponse(
+                                id: request.id,
+                                sessionID: sessionID)))
+                        }
                     default:
                         break
                     }
@@ -685,19 +713,27 @@ struct OnboardingAISetupTests {
         await model.detectAndAutoConnect()
         let option = try #require(model.prepareOptions.first { $0.id == "llama-cpp" })
         model.startProviderPrepare(option)
-        let requests = await waitForAISetupRequests(recorder, count: 3)
+        await completion.waitUntilStarted()
+        let requests = await waitForAISetupRequests(recorder, count: 5)
 
-        #expect(requests.methods == [
+        #expect(Array(requests.methods.prefix(5)) == [
             "openclaw.setup.detect",
             "openclaw.setup.prepare.start",
+            "wizard.next",
+            "wizard.next",
             "wizard.next",
         ])
         #expect(requests.authChoices == ["llama-cpp"])
         #expect(model.isPreparingModel)
-        for _ in 0..<200 where model.authStep.map(wizardStepType) != "progress" {
+        #expect(model.authStep.map(wizardStepType) == "progress")
+        #expect(model.authStep?.message == "Downloading model: 80%")
+
+        await completion.release()
+        for _ in 0..<200 where model.activeAuthOption != nil {
             try? await Task.sleep(nanoseconds: 5_000_000)
         }
-        #expect(model.authStep.map(wizardStepType) == "progress")
+        #expect(model.activeAuthOption == nil)
+        #expect(model.authError == nil)
     }
 
     @Test func `provider auth opens only safe external links`() {

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
@@ -713,7 +713,10 @@ struct OnboardingAISetupTests {
         await model.detectAndAutoConnect()
         let option = try #require(model.prepareOptions.first { $0.id == "llama-cpp" })
         model.startProviderPrepare(option)
-        await completion.waitUntilStarted()
+        // Bounded wait, not `completion.waitUntilStarted()`: a client that stops
+        // polling never reaches the gated frame, and this must fail rather than
+        // hang. Once five requests are recorded the third `wizard.next` is held
+        // at the gate, so the sheet deterministically shows the second frame.
         let requests = await waitForAISetupRequests(recorder, count: 5)
 
         #expect(Array(requests.methods.prefix(5)) == [

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/WizardHelpers.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/WizardHelpers.swift
@@ -57,6 +57,13 @@ public func wizardStepType(_ step: WizardStep) -> String {
     (step.type.value as? String) ?? ""
 }
 
+/// `"gateway"` marks a step the Gateway runs itself (download/install progress).
+/// Those steps carry no answer, so clients must poll for the next frame instead
+/// of waiting for input that will never come.
+public func wizardStepExecutor(_ step: WizardStep) -> String {
+    (step.executor?.value as? String) ?? ""
+}
+
 public func anyCodableString(_ value: AnyCodable?) -> String {
     switch value?.value {
     case let string as String:

--- a/ui/AGENTS.md
+++ b/ui/AGENTS.md
@@ -23,6 +23,10 @@ This directory owns Control UI-specific guidance that should not live in the rep
 - Icons: shared 24x24 Lucide icons go through `strokeIcon()` in `ui/src/components/icons-tools.ts` so stroke presentation attributes stay inline and render inside shadow roots. Icon bodies are `svg\`\``fragments, never`html\`\`` (wrong namespace renders nothing).
 - `pnpm lint:ui:lit` is an opt-in lit-analyzer diagnostic for template bindings (slow, ~9 min; known baseline of pre-existing findings). It is not a CI gate.
 
+## Live Verification
+
+- The Gateway serves the prebuilt bundle from `dist/control-ui`; editing `ui/src` changes nothing live until `pnpm ui:build`. Confirm the served `/assets/index-*.js` hash changed before trusting a live result.
+
 ## Scope
 
 - Keep UI-specific rules here.


### PR DESCRIPTION
## What Problem This Solves

Fixes #113612. On macOS, starting a local-model download from onboarding ("Set up a local model" → llama.cpp) shows `Preparing…` and then freezes forever, even though the Gateway keeps downloading in the background.

`OnboardingAISetupModel.applyAuthWizardResult` stores the returned `WizardStep` and stops. That is correct for steps the user answers (text/select/confirm/note): the sheet renders a control, and `continueProviderAuth()` sends the answer. But gateway-executed steps — the progress frames `WizardSession.pushProgress` emits with `executor: "gateway"` (`src/wizard/session.ts:380`) — carry no input control, so nothing ever asks for the next frame. The session sits on the server long-polling for a client that has stopped calling `wizard.next`.

This is the macOS mirror of the Control UI defect fixed in #113613; the same one-frame freeze, the same cause, a different renderer.

The `openclaw-mac wizard` CLI has the sibling of the same bug: `runWizard` blocks on `promptAnswer` for every step, so a gateway-executed progress frame stops on `Continue? (enter)` and a download only advances when the operator keeps pressing Return.

## Why This Change Was Made

The wire already discriminates the two cases, so the client does not have to guess from step type. `wizardStepExecutor(step) == "gateway"` is the protocol's own signal (`packages/gateway-protocol/src/schema/wizard.ts`), which is why the fix is one branch in the shared apply path rather than a special case for progress steps or for the prepare flow:

- App: after applying a step, re-request immediately when the Gateway owns it. `wizard.next` long-polls, so this renders live progress instead of spinning.
- CLI: skip the prompt for gateway-executed steps, echo the frame, and poll.

Both clients now agree with the Control UI runner on the same rule, and auth flows that push gateway-executed steps get the behavior for free.

## User Impact

macOS onboarding shows real download progress ("Downloading Gemma 4 E4B… 16% (0.8/5.0 GB, 13 MB/s)") and completes the flow, instead of appearing hung until the user cancels. `openclaw-mac wizard` streams progress rather than demanding a keypress per frame.

## Evidence

- `swift test --package-path apps/macos --filter OnboardingAISetupTests` — 85/85 passed.
- `swift build --package-path apps/macos --product openclaw-mac` — build complete.
- Regression test `prepare starts the shared wizard and polls gateway progress` drives the real model against a fake socket: two gateway-executed progress frames, then a gated terminal frame. It asserts three `wizard.next` calls with no user input, that the sheet shows the *second* frame's message, and that the flow terminates cleanly.
- Negative proof: with only `OnboardingAISetup.swift` reverted to `main`, the test fails in 2.5s with 3 issues — `model.authStep?.message` stuck at `"Downloading model: 25%"`, the request sequence short, `model.activeAuthOption` never cleared. That is the reported freeze, reproduced. The wait is deliberately bounded (`waitForAISetupRequests`) rather than gate-blocking, so a client that stops polling fails instead of hanging CI.
- The progress fixture previously omitted `executor`, which is why the existing test passed against a frozen client; it now matches what the Gateway actually sends.
- Codex autoreview (`gpt-5.6-sol`, xhigh) on the branch: clean, no accepted/actionable findings.

Also included: a one-line `ui/AGENTS.md` note that the Gateway serves the prebuilt `dist/control-ui` bundle, so live UI verification needs `pnpm ui:build` first — the trap that briefly masked the fix for #113613.
