### PR TITLE
fix(cli): show deviceId column in devices list output (#114279) [AI-assisted]

### DIFF
--- a/src/cli/devices-cli.runtime.ts
+++ b/src/cli/devices-cli.runtime.ts
@@ -934,6 +934,7 @@ export async function runDevicesListCommand(opts: DevicesRpcOpts): Promise<void>
         width: tableWidth,
         columns: [
           { key: "Device", header: "Device", minWidth: 16, flex: true },
+          { key: "DeviceId", header: "DeviceId", minWidth: 24, flex: true },
           { key: "Roles", header: "Roles", minWidth: 12, flex: true },
           { key: "Scopes", header: "Scopes", minWidth: 12, flex: true },
           { key: "Tokens", header: "Tokens", minWidth: 12, flex: true },
@@ -943,6 +944,7 @@ export async function runDevicesListCommand(opts: DevicesRpcOpts): Promise<void>
           Device: sanitizeForLog(
             device.operatorLabel || device.displayName || device.clientId || device.deviceId,
           ),
+          DeviceId: device.deviceId ? sanitizeForLog(device.deviceId) : "",
           Roles: device.roles?.length
             ? device.roles.map((role) => sanitizeForLog(role)).join(", ")
             : "",


### PR DESCRIPTION
## What Problem This Solves

`openclaw devices list` omits the deviceId column from its table output, but `openclaw devices remove <deviceId>` requires the deviceId as a positional argument. When multiple paired devices share the same displayName, users cannot identify which deviceId to pass to the remove command.

Fixes #114279

## Why This Change Was Made

The Device column already shows the best available name (operatorLabel > displayName > clientId > deviceId), but the raw deviceId is never exposed in the table. Adding a dedicated DeviceId column makes the identifier discoverable without changing any existing column semantics.

## User Impact

- `openclaw devices list` now includes a DeviceId column showing each paired device's identifier
- Users can copy the deviceId directly from the list output for use with `devices remove <deviceId>`
- No existing column behavior changed

## Evidence

Before: devices list showed Device, Roles, Scopes, Tokens, IP — no way to get the deviceId needed by `devices remove`.

After: a DeviceId column is now present in the table output, displaying `device.deviceId`.

Focused test results:

```text
$ node scripts/run-vitest.mjs src/cli/devices-cli.test.ts
Test Files  1 passed (1)
     Tests  51 passed (51)
```

```text
$ node scripts/run-vitest.mjs src/cli/devices-cli.runtime.timeout.test.ts
Test Files  1 passed (1)
      Tests  8 passed (8)
```

AI-assisted. I have reviewed and understand the change.