### PR TITLE
fix(cua-computer): reject malformed desktop screenshots

### DIFF
--- a/extensions/cua-computer/src/commands.test.ts
+++ b/extensions/cua-computer/src/commands.test.ts
@@ -149,6 +149,19 @@ describe("cua-computer screen.snapshot", () => {
     expect(encode).not.toHaveBeenCalled();
   });
 
+  it("rejects malformed native PNG base64 before image processing", async () => {
+    const malformed = desktopResult();
+    malformed.content[0] = { type: "image", data: "%%%not-base64!!", mimeType: "image/png" };
+    const { driver } = createDriver({ desktop: () => malformed });
+    const { processor, encode } = createProcessor();
+    const { snapshot } = commandSet(driver, processor);
+
+    await expect(snapshot.handle("{}")).rejects.toThrow(
+      "COMPUTER_DRIVER_ERROR: get_desktop_state returned malformed PNG base64",
+    );
+    expect(encode).not.toHaveBeenCalled();
+  });
+
   it("rejects non-primary screen indexes", async () => {
     const { driver } = createDriver();
     const { snapshot } = commandSet(driver);

--- a/extensions/cua-computer/src/commands.test.ts
+++ b/extensions/cua-computer/src/commands.test.ts
@@ -149,9 +149,12 @@ describe("cua-computer screen.snapshot", () => {
     expect(encode).not.toHaveBeenCalled();
   });
 
-  it("rejects malformed native PNG base64 before image processing", async () => {
+  it.each([
+    { name: "invalid alphabet", data: "%%%not-base64!!" },
+    { name: "non-canonical pad bits", data: "ZE==" },
+  ])("rejects native PNG base64 with $name before image processing", async ({ data }) => {
     const malformed = desktopResult();
-    malformed.content[0] = { type: "image", data: "%%%not-base64!!", mimeType: "image/png" };
+    malformed.content[0] = { type: "image", data, mimeType: "image/png" };
     const { driver } = createDriver({ desktop: () => malformed });
     const { processor, encode } = createProcessor();
     const { snapshot } = commandSet(driver, processor);

--- a/extensions/cua-computer/src/commands.ts
+++ b/extensions/cua-computer/src/commands.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { canonicalizeBase64 } from "openclaw/plugin-sdk/media-runtime";
 import type { OpenClawPluginNodeHostCommand } from "openclaw/plugin-sdk/plugin-entry";
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 import { createRastermill } from "rastermill";
@@ -145,7 +146,11 @@ function desktopPng(result: CuaToolResult): Buffer {
   if (!image) {
     throw new Error("COMPUTER_DRIVER_ERROR: get_desktop_state returned no PNG image");
   }
-  return Buffer.from(image.data, "base64");
+  const canonicalPng = canonicalizeBase64(image.data);
+  if (!canonicalPng) {
+    throw new Error("COMPUTER_DRIVER_ERROR: get_desktop_state returned malformed PNG base64");
+  }
+  return Buffer.from(canonicalPng, "base64");
 }
 
 function screenSize(result: CuaToolResult): CuaScreenSize {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Linux and Windows computer-use snapshots could accept corrupted base64 image data from the desktop driver and pass the damaged bytes into screenshot processing.

## Why This Change Was Made

Desktop PNG payloads are now validated with the shared media base64 validator before decoding. Invalid driver output fails at the `screen.snapshot` boundary with a clear driver error, while valid payloads keep the existing behavior.

## User Impact

Computer-use users get an immediate, actionable capture error instead of a later image-processing failure or a corrupted screenshot.

## Evidence

- Production module boundary: `createCuaComputerCommands` → `screen.snapshot`, with only the unavailable `cua-driver` process boundary replaced by a fixture.
- `node scripts/run-vitest.mjs extensions/cua-computer/src/commands.test.ts`: 31 tests passed.

```text
Base:
malformed: accepted
valid: accepted

Fixed:
malformed: COMPUTER_DRIVER_ERROR: get_desktop_state returned malformed PNG base64
valid: accepted
```

<details>
<summary>proof-live.ts</summary>

```ts
import { createCuaComputerCommands } from "./extensions/cua-computer/src/commands.ts";

function desktopResult(data: string) {
  return {
    content: [{ type: "image", data, mimeType: "image/png" }],
    structuredContent: {
      platform: "linux",
      display: "primary",
      screenshot_width: 100,
      screenshot_height: 100,
      screen_width: 100,
      screen_height: 100,
      scale_factor: 1,
    },
  };
}

async function runCase(label: string, data: string) {
  const driver = {
    generation: 1,
    isAvailable: () => true,
    resetAvailabilityCache: () => {},
    dispose: async () => {},
    callTool: async () => desktopResult(data),
  };
  const imageProcessor = {
    encode: async () => {
      throw new Error("unexpected image processing");
    },
  };
  const command = createCuaComputerCommands({
    platform: "linux",
    driver,
    imageProcessor,
  }).find((entry) => entry.command === "screen.snapshot");
  if (!command) {
    throw new Error("screen.snapshot command missing");
  }
  try {
    await command.handle('{"format":"png","maxWidth":200}');
    console.log(`${label}: accepted`);
  } catch (error) {
    console.log(`${label}: ${error instanceof Error ? error.message : String(error)}`);
  }
}

await runCase("malformed", "%%%not-base64!!");
await runCase("valid", Buffer.from("native-png").toString("base64"));
```

</details>

AI-assisted: built with Codex
