### PR TITLE
fix(ui): keep sidebar catalogs stable after empty refresh responses

### DIFF
--- a/ui/src/components/app-sidebar-session-catalog-live.ts
+++ b/ui/src/components/app-sidebar-session-catalog-live.ts
@@ -475,7 +475,7 @@ export async function refreshSessionCatalogsLive(params: {
   const revisionIsCurrent = () => requestIsCurrent() && revision === params.currentRevision();
   try {
     const result = await live.requestList(client, params.agentId, progressId);
-    if (!requestIsCurrent()) {
+    if (!requestIsCurrent() || !result?.catalogs) {
       return;
     }
     refetchOwner = live.beginRefetch(params.pageDepths.size > 0);

--- a/ui/src/test-helpers/app-sidebar-cases/catalog-pages.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/catalog-pages.ts
@@ -400,7 +400,7 @@ describe("AppSidebar session catalog pagination", () => {
         .mockResolvedValueOnce(
           catalogPage([{ threadId: "thread-3", name: "Reappeared" }], "page-2"),
         )
-        .mockResolvedValueOnce(catalogErrorPage("Replay failed"));
+        .mockResolvedValue(catalogErrorPage("Replay failed"));
       const gateway = createGatewayHarness({ request } as unknown as GatewayBrowserClient);
       gateway.publish({
         hello: {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the sidebar session-catalog refresh could log a `TypeError` and mark a refresh as failed when a catalog-list response had no payload. This also removes the warning reproduced by the app-sidebar test suite after a replay failure and subsequent adaptive refresh.

## Why This Change Was Made

The gateway method contract returns `{ catalogs: [...] }`, but the method-agnostic transport can represent an omitted response payload. The sidebar now preserves its current catalog snapshot for that defensive case, and the replay-failure test now supplies its intended structured fallback response for later timer-driven refreshes.

## User Impact

Sidebar catalogs stay stable instead of surfacing a spurious refresh failure when a response has no catalog payload. There is no visual layout change.

AI-assisted: yes. The change was traced through the gateway handler, protocol schema, browser transport, sidebar controller, and focused tests.

## Evidence

- Before: `node scripts/run-vitest.mjs ui/src/components/app-sidebar.test.ts` passed 192 tests but logged `Session catalog refresh failed TypeError: Cannot read properties of undefined (reading 'catalogs')` in the replay-failure case.
- After: the same focused target passed all 192 tests on Blacksmith Testbox with that warning absent.
- ClawSweeper rank-up move applied: current-main PR CI run [30244410693](https://github.com/openclaw/openclaw/actions/runs/30244410693) completed successfully; its `checks-ui` merge-tree job passed 433 files / 6,050 tests with `Session catalog refresh failed` appearing 0 times.
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted`: clean, no accepted/actionable findings.
