### PR TITLE
fix(codex): user-home Codex app-servers fail every turn when an OpenAI auth profile exists

### DIFF
--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -141,7 +141,10 @@ user Codex home:
 User-home mode supports a local managed stdio process or the shared Unix-socket
 transport. It uses `$CODEX_HOME` when set and `~/.codex` otherwise, including
 that home's native Codex auth, config, plugins, and thread store. OpenClaw does
-not inject an OpenClaw auth profile into this app-server.
+not inject an OpenClaw auth profile into this app-server, even when the agent's
+model route has a stored OpenAI profile: a subscription route is verified
+against the native account instead. Log in with Codex itself if a turn reports
+missing subscription credentials.
 
 Owner turns gain the `codex_threads` tool: list, search, read, fork, rename,
 archive, and restore native threads. Fork a thread to continue it in

--- a/extensions/codex/src/app-server/auth-bridge.test.ts
+++ b/extensions/codex/src/app-server/auth-bridge.test.ts
@@ -604,6 +604,44 @@ describe("bridgeCodexAppServerStartOptions", () => {
     });
   });
 
+  it("declines every prepared handoff for a user-home app-server", async () => {
+    const authProfileStore: AuthProfileStore = {
+      version: 1,
+      profiles: {
+        "openai:work": {
+          type: "token",
+          provider: "openai",
+          token: "prepared-subscription-token",
+          email: "prepared@example.test",
+        },
+      },
+    };
+
+    await expect(
+      resolveCodexAppServerPreparedAuthHandoff({
+        authRequirement: "subscription",
+        authProfileId: "openai:work",
+        authProfileStore,
+        agentDir: "/tmp/openclaw-agent",
+        homeScope: "user",
+        subscriptionProfileRequiredError: "profile required",
+        subscriptionProfileUnusableError: "profile unusable",
+      }),
+    ).resolves.toEqual({ authProfileId: "openai:work", nativeAuthProfile: true });
+
+    await expect(
+      resolveCodexAppServerPreparedAuthHandoff({
+        authRequirement: "api-key",
+        authProfileId: "openai:work",
+        authProfileStore,
+        agentDir: "/tmp/openclaw-agent",
+        homeScope: "user",
+        subscriptionProfileRequiredError: "profile required",
+        subscriptionProfileUnusableError: "profile unusable",
+      }),
+    ).resolves.toEqual({ authProfileId: "openai:work", nativeAuthProfile: true });
+  });
+
   it("materializes one prepared subscription profile snapshot", async () => {
     const authProfileStore: AuthProfileStore = {
       version: 1,

--- a/extensions/codex/src/app-server/auth-bridge.ts
+++ b/extensions/codex/src/app-server/auth-bridge.ts
@@ -29,6 +29,7 @@ import { ensureCodexComputerUseServiceApp } from "./computer-use-service.js";
 import {
   resolveCodexAppServerUserHomeDir,
   resolveCodexComputerUseConfig,
+  type CodexAppServerHomeScope,
   type CodexAppServerStartOptions,
 } from "./config.js";
 import {
@@ -259,11 +260,17 @@ export async function resolveCodexAppServerPreparedAuthHandoff(params: {
   authProfileId?: string;
   authProfileStore: AuthProfileStore;
   agentDir?: string;
+  homeScope?: CodexAppServerHomeScope;
   config?: AuthProfileOrderConfig;
   subscriptionProfileRequiredError: string;
   subscriptionProfileUnusableError: string;
 }) {
-  if (params.authRequirement === "api-key") {
+  // A user-home app-server owns the operator's native Codex account. Codex persists
+  // api-key logins into CODEX_HOME/auth.json and swaps the live account for external
+  // token logins, so a prepared OpenClaw handoff here would rewrite the account that
+  // Codex CLI and Desktop share. Native homes are verified, never logged into.
+  const usesNativeHome = params.homeScope === "user";
+  if (params.authRequirement === "api-key" && !usesNativeHome) {
     const apiKey = params.resolvedApiKey?.trim();
     if (!apiKey) {
       throw new Error("Prepared Codex API-key route is missing its resolved API key.");
@@ -281,7 +288,7 @@ export async function resolveCodexAppServerPreparedAuthHandoff(params: {
     agentDir: params.agentDir,
     config: params.config,
   });
-  if (params.authRequirement !== "subscription") {
+  if (usesNativeHome || params.authRequirement !== "subscription") {
     return { authProfileId, nativeAuthProfile };
   }
   if (!authProfileId || !nativeAuthProfile) {

--- a/extensions/codex/src/app-server/auth-profile-runtime-contract.test.ts
+++ b/extensions/codex/src/app-server/auth-profile-runtime-contract.test.ts
@@ -489,6 +489,51 @@ describe("Auth profile runtime contract - Codex app-server adapter", () => {
     await run;
   });
 
+  it.each([
+    { label: "a subscription route", authRequirement: "subscription" as const },
+    { label: "a Platform route", authRequirement: "api-key" as const },
+  ])(
+    "keeps a user-home app-server on native Codex auth for $label",
+    async ({ authRequirement }) => {
+      const harness = createCodexAuthProfileHarness({ startMethod: "thread/start" });
+      const sessionFile = path.join(tmpDir, "session.jsonl");
+      const params = createParams(sessionFile, tmpDir);
+      params.agentDir = tmpDir;
+      params.authProfileStore = {
+        version: 1,
+        profiles: {
+          "openai:chatgpt": {
+            type: "oauth",
+            provider: "openai",
+            access: "subscription-token",
+            refresh: "refresh-token",
+            expires: Date.now() + 60 * 60_000,
+          },
+        },
+        order: { openai: ["openai:chatgpt"] },
+      };
+      setPreparedOpenAIRoute(params, authRequirement, "openai:chatgpt");
+
+      const run = runCodexAppServerAttempt(params, {
+        pluginConfig: {
+          appServer: { homeScope: "user" },
+          supervision: { enabled: true },
+        },
+      });
+      await vi.waitFor(
+        () => expect(harness.seenClientOptions).toHaveLength(1),
+        APP_SERVER_START_WAIT,
+      );
+      expect(harness.seenClientOptions[0]).not.toHaveProperty("preparedAuth");
+      expect(harness.seenClientOptions[0]).toMatchObject({
+        startOptions: expect.objectContaining({ homeScope: "user" }),
+      });
+      await harness.waitForMethod("turn/start");
+      await harness.completeTurn();
+      await run;
+    },
+  );
+
   it("fails before profile selection when a prepared Platform route has no key", async () => {
     const harness = createCodexAuthProfileHarness({ startMethod: "thread/start" });
     const sessionFile = path.join(tmpDir, "session.jsonl");

--- a/extensions/codex/src/app-server/compact.ts
+++ b/extensions/codex/src/app-server/compact.ts
@@ -558,8 +558,12 @@ async function compactCodexNativeThread(
   const shouldReleaseDefaultLease = !options.clientFactory;
   const clientFactory = options.clientFactory ?? getLeasedSharedCodexAppServerClient;
   const runtimeAuthPlan = params.runtimeAuthPlan ?? params.runtimePlan?.auth;
+  // A user-home app-server keeps its native Codex account; injecting a prepared key
+  // would rewrite the CODEX_HOME auth that Codex CLI and Desktop share.
   const usesPreparedApiKey =
-    !usesSupervisionConnection && runtimeAuthPlan?.modelRoute?.authRequirement === "api-key";
+    !usesSupervisionConnection &&
+    appServer.start.homeScope !== "user" &&
+    runtimeAuthPlan?.modelRoute?.authRequirement === "api-key";
   const preparedApiKey = usesPreparedApiKey ? params.resolvedApiKey?.trim() : undefined;
   if (usesPreparedApiKey && !preparedApiKey) {
     return {

--- a/extensions/codex/src/app-server/config.ts
+++ b/extensions/codex/src/app-server/config.ts
@@ -6,6 +6,7 @@ export {
 export type {
   CodexAppServerApprovalPolicy,
   CodexAppServerConnectionClass,
+  CodexAppServerHomeScope,
   CodexAppServerRuntimeOptions,
   CodexAppServerSandboxMode,
   CodexAppServerStartOptions,

--- a/extensions/codex/src/app-server/run-attempt-connection.ts
+++ b/extensions/codex/src/app-server/run-attempt-connection.ts
@@ -201,6 +201,9 @@ export async function prepareCodexAttemptConnection({ params, options }: CodexRu
         authProfileId: resolvedStartupAuthProfileId,
         authProfileStore: params.authProfileStore,
         agentDir,
+        ...(pluginConfig.appServer?.homeScope
+          ? { homeScope: pluginConfig.appServer.homeScope }
+          : {}),
         config: params.config,
         subscriptionProfileRequiredError:
           "Prepared Codex subscription route requires a forwarded OpenAI OAuth or token profile.",

--- a/extensions/codex/src/app-server/shared-client.ts
+++ b/extensions/codex/src/app-server/shared-client.ts
@@ -298,6 +298,9 @@ async function resolveCodexAppServerClientStartContext(
     throw new Error("Prepared Codex API-key auth is missing its resolved key.");
   }
   if (preparedAuth && requestedStartOptions.homeScope === "user") {
+    // Backstop for the auth-bridge handoff: an app-server on the operator's native
+    // home persists api-key logins into CODEX_HOME/auth.json and replaces the live
+    // ChatGPT account for token logins, so prepared auth must never reach it.
     throw new Error("Prepared Codex auth requires an isolated app-server home.");
   }
   const preparedAuthRequirement = inferAuthRequirement(preparedAuth);

--- a/extensions/codex/src/app-server/side-question.ts
+++ b/extensions/codex/src/app-server/side-question.ts
@@ -199,6 +199,9 @@ export async function runCodexAppServerSideQuestion(
         authProfileId: preparedRuntimeAuth.plan.forwardedAuthProfileId,
         authProfileStore: preparedRuntimeAuth.authProfileStore,
         agentDir: params.agentDir,
+        ...(pluginConfig.appServer?.homeScope
+          ? { homeScope: pluginConfig.appServer.homeScope }
+          : {}),
         config: params.cfg,
         subscriptionProfileRequiredError:
           "Prepared Codex subscription route requires a scoped native OAuth or token profile.",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators running the Codex plugin with `appServer.homeScope: "user"` (the documented "share threads with Codex Desktop and CLI" mode) would see **every agent turn fail** with:

```
Prepared Codex auth requires an isolated app-server home.
```

The trigger is having a normal stored OpenAI auth profile (created by `openclaw models auth login`) while the agent's model resolves an OpenAI route. Core runtime planning then hands the Codex plugin a prepared subscription (or Platform) auth route, the plugin resolved that route into a prepared auth handoff, and app-server startup rejected it because the connection targets the native Codex home. The gateway is unusable: no turn can start.

On the affected production gateway this reproduces with `homeScope: "user"` plus `supervision.enabled: true`; turning supervision off restores turns, which flips which plugin-config/connection path is live but is not a supported workaround for operators who want supervision.

The behavior also contradicted our own documentation. `docs/plugins/codex-harness.md` states that user-home mode uses that home's "native Codex auth, config, plugins, and thread store" and that "OpenClaw does not inject an OpenClaw auth profile into this app-server." The runtime instead hard-failed whenever such a profile merely existed and produced a prepared route.

## Why This Change Was Made

The guard itself is correct and stays: a user-home app-server owns the operator's real account, and Codex persists api-key logins into `CODEX_HOME/auth.json` (`codex-rs/login/src/auth/manager.rs` `login_with_api_key` -> `save_auth`) while `chatgptAuthTokens` logins replace the live account via `set_external_auth` (`codex-rs/app-server/src/request_processors/account_processor.rs`). Injecting OpenClaw auth there would rewrite the credentials Codex CLI and Desktop share.

The defect was one layer up: `resolveCodexAppServerPreparedAuthHandoff` in `extensions/codex/src/app-server/auth-bridge.ts` never knew about home scope, so it produced prepared auth for a connection that can never accept it. The supervision connection already had this knowledge; the ordinary user-home connection did not. The fix teaches that single owner about home scope, so user-home connections return the native handoff (no prepared auth) for both subscription and Platform routes, exactly as the docs describe. Downstream behavior already works: `shared-client.ts` normalizes user-home clients to `authProfileId: null`, and `applyCodexAppServerAuthProfile` then *verifies* a subscription route against the native account with `account/read` instead of logging in. The same one-sided gap existed in native compaction (`compact.ts`), fixed alongside it. The shared-client throw is kept as a backstop invariant with a comment explaining what it protects.

Alternatives rejected: silently dropping prepared auth inside `shared-client` would have left the rest of the plugin (cache keys, reviewer policy, provider selection) believing an OpenClaw profile was in play, and would have removed the invariant that protects `~/.codex`. Throwing only for explicitly selected profiles was also rejected, since no prepared profile, explicit or default, may be logged into the operator's native home.

## User Impact

Operators can run `appServer.homeScope: "user"` with supervision enabled and a stored OpenAI auth profile: turns now run on the native Codex account instead of failing. If that native home is not logged in, a subscription route still fails with the actionable "Codex subscription auth profile could not produce login credentials." message rather than the misleading isolated-home error. Docs now state that a stored profile is deliberately not injected and that subscription routes are verified against the native account.

## Evidence

Focused tests (`node scripts/run-vitest.mjs`, local, trusted source):

- `extensions/codex/src/app-server/auth-profile-runtime-contract.test.ts` — 11 passed, including the new table-driven regression `keeps a user-home app-server on native Codex auth for a subscription route / a Platform route` (stored OAuth profile + prepared route + `appServer.homeScope: "user"` + `supervision.enabled: true`, the exact production combination).
- `extensions/codex/src/app-server/auth-bridge.test.ts` — 80 passed, including `declines every prepared handoff for a user-home app-server`.
- Siblings: `side-question.test.ts`, `compact.test.ts`, `shared-client.test.ts`, `binding-connection.test.ts` — 168 passed; `run-attempt.test.ts` — 117 passed.

Negative control: with the home-scope check neutered, both new contract tests fail (`Tests 2 failed | 9 passed`), the api-key case failing inside `resolveCodexAppServerPreparedAuthHandoff`, so the regression tests do catch this bug.

`node scripts/check-changed.mjs` delegated to Blacksmith Testbox (lanes: extensions, extensionTests, docs), including `oxfmt --check` clean on all 9 changed files.

Codex protocol behavior was verified directly against the sibling `../codex` checkout (files cited above), not from memory or wrappers.
