### PR TITLE
docs(install): recommend Node 26 as the OpenClaw runtime

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,7 +115,7 @@ Skills own workflows; root owns hard policy and routing.
 
 ## Commands
 
-- Runtime: Node 22.22.3+, 24.15+, or 25.9+; Node 24 recommended. Keep Node + Bun paths working.
+- Runtime: Node 22.22.3+, 24.15+, or 25.9+; Node 26 recommended (CI and release workflows still pin Node 24). Keep Node + Bun paths working.
 - Package manager/runtime: repo defaults only. No swaps without approval.
 - Install: `pnpm install` (keep Bun lock/patches aligned if touched). Agent dependency installation for tests/builds defaults to the selected remote box; do not reconcile a local Codex worktree just to run validation.
 - CLI: `pnpm openclaw ...` or `pnpm dev`; build: `pnpm build`.

--- a/docs/help/faq-first-run.md
+++ b/docs/help/faq-first-run.md
@@ -139,7 +139,7 @@ and troubleshooting see the main [FAQ](/help/faq).
   </Accordion>
 
   <Accordion title="What runtime do I need?">
-    Node **22.22.3+**, **24.15+**, or **25.9+** is required (Node 24 recommended). `pnpm` is the repo package manager.
+    Node **22.22.3+**, **24.15+**, or **25.9+** is required (Node 26 recommended). `pnpm` is the repo package manager.
     Bun can install dependencies and run package scripts, but it cannot run the OpenClaw CLI or Gateway because it lacks `node:sqlite`.
   </Accordion>
 

--- a/docs/install/ansible.md
+++ b/docs/install/ansible.md
@@ -41,7 +41,7 @@ curl -fsSL https://raw.githubusercontent.com/openclaw/openclaw-ansible/main/inst
 1. Tailscale (mesh VPN for secure remote access)
 2. UFW firewall (SSH + Tailscale ports only)
 3. Docker CE + Compose V2 (default agent sandbox backend)
-4. Node.js and pnpm (OpenClaw requires Node 22.22.3+, 24.15+, or 25.9+; Node 24 is recommended)
+4. Node.js and pnpm (OpenClaw requires Node 22.22.3+, 24.15+, or 25.9+; Node 26 is recommended)
 5. OpenClaw, installed host-based, not containerized
 6. A systemd service with security hardening
 

--- a/docs/install/bun.md
+++ b/docs/install/bun.md
@@ -38,7 +38,7 @@ Bun remains usable as an optional package-script runner. The default package man
 
 Bun blocks dependency lifecycle scripts unless explicitly trusted. For this repo, the commonly blocked scripts are not required:
 
-- `baileys` `preinstall`: checks Node major >= 20 (OpenClaw requires Node 22.22.3+, 24.15+, or 25.9+, with Node 24 recommended)
+- `baileys` `preinstall`: checks Node major >= 20 (OpenClaw requires Node 22.22.3+, 24.15+, or 25.9+, with Node 26 recommended)
 - `protobufjs` `postinstall`: emits warnings about incompatible version schemes (no build artifacts)
 
 If you hit a runtime issue that needs these scripts, trust them explicitly:

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -9,7 +9,7 @@ title: "Install"
 
 ## System requirements
 
-- **Node 22.22.3+, 24.15+, or 25.9+** - Node 24 is the default target; the installer script handles this automatically.
+- **Node 22.22.3+, 24.15+, or 25.9+** - Node 26 is recommended; the installer script provisions Node 24 automatically when Node is missing.
 - **macOS, Linux, or Windows** - Windows users can start with the native Windows Hub app, the PowerShell CLI installer, or a WSL2 Gateway. See [Windows](/platforms/windows).
 - `pnpm` is only needed if you build from source.
 

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -9,7 +9,7 @@ title: "Install"
 
 ## System requirements
 
-- **Node 22.22.3+, 24.15+, or 25.9+** - Node 26 is recommended; the installer script provisions Node 24 automatically when Node is missing.
+- **Node 22.22.3+, 24.15+, or 25.9+** - Node 26 is the recommended default; the installer script provisions it automatically when Node is missing.
 - **macOS, Linux, or Windows** - Windows users can start with the native Windows Hub app, the PowerShell CLI installer, or a WSL2 Gateway. See [Windows](/platforms/windows).
 - `pnpm` is only needed if you build from source.
 

--- a/docs/install/installer.md
+++ b/docs/install/installer.md
@@ -15,7 +15,7 @@ OpenClaw ships three installer scripts, served from `openclaw.ai`.
 | [`install-cli.sh`](#install-clish) | macOS / Linux / WSL  | Installs Node + OpenClaw into a local prefix (`~/.openclaw`) via npm or git. No root required. |
 | [`install.ps1`](#installps1)       | Windows (PowerShell) | Installs Node if needed, installs OpenClaw via npm (default) or git, can run onboarding.       |
 
-All three support Node **22.22.3+, 24.15+, or 25.9+**; Node 26 is the default target for fresh installs.
+All three support Node **22.22.3+, 24.15+, or 25.9+**. On macOS and Linux, fresh installs provision Node 26; on Windows, winget/Chocolatey/Scoop install the supported Node LTS line, and the portable fallback downloads Node 26.
 
 ## Quick commands
 

--- a/docs/install/installer.md
+++ b/docs/install/installer.md
@@ -15,7 +15,7 @@ OpenClaw ships three installer scripts, served from `openclaw.ai`.
 | [`install-cli.sh`](#install-clish) | macOS / Linux / WSL  | Installs Node + OpenClaw into a local prefix (`~/.openclaw`) via npm or git. No root required. |
 | [`install.ps1`](#installps1)       | Windows (PowerShell) | Installs Node if needed, installs OpenClaw via npm (default) or git, can run onboarding.       |
 
-All three support Node **22.22.3+, 24.15+, or 25.9+**; Node 24 is the default target for fresh installs.
+All three support Node **22.22.3+, 24.15+, or 25.9+**; Node 26 is the default target for fresh installs.
 
 ## Quick commands
 
@@ -73,7 +73,7 @@ Recommended for most interactive installs on macOS/Linux/WSL.
     Supports macOS and Linux (including WSL).
   </Step>
   <Step title="Ensure Node.js 24 by default">
-    Checks Node version and installs Node 24 if needed (Homebrew on macOS, NodeSource setup scripts on Linux apt/dnf/yum). On macOS, Homebrew is installed only when the installer needs it for Node or Git. Node 22.22.3+, Node 24.15+, and Node 25.9+ are supported; Node 23 is unsupported.
+    Checks Node version and installs Node 26 if needed (Homebrew `node` on macOS, NodeSource setup scripts on Linux apt/dnf/yum). On macOS, Homebrew is installed only when the installer needs it for Node or Git. Node 22.22.3+, Node 24.15+, and Node 25.9+ are supported; Node 23 is unsupported.
     On Alpine/musl Linux, the installer uses apk packages instead of NodeSource and verifies the actual linked SQLite version. Current stable Alpine package streams can provide a new-enough Node with vulnerable system SQLite; when that happens, use an official `node:24-alpine` container or a glibc-based host instead.
   </Step>
   <Step title="Ensure Git">
@@ -300,7 +300,7 @@ by default, plus git-checkout installs under the same prefix flow.
     Requires PowerShell 5+.
   </Step>
   <Step title="Ensure Node.js 24 by default">
-    If missing, attempts install via winget, then Chocolatey, then Scoop. If no package manager is available, the script downloads the official Node.js 24 Windows zip into `%LOCALAPPDATA%\OpenClaw\deps\portable-node` and adds it to the current process and user PATH. Node 22.22.3+, Node 24.15+, and Node 25.9+ are supported; Node 23 is unsupported.
+    If missing, attempts install via winget, then Chocolatey, then Scoop. If no package manager is available, the script downloads the official Node.js 26 Windows zip into `%LOCALAPPDATA%\OpenClaw\deps\portable-node` and adds it to the current process and user PATH. Node 22.22.3+, Node 24.15+, and Node 25.9+ are supported; Node 23 is unsupported.
   </Step>
   <Step title="Install OpenClaw">
     - `npm` method (default): global npm install using the selected `-Tag`, launched from a writable installer temp directory so shells opened in protected folders such as `C:\` still work

--- a/docs/install/node.md
+++ b/docs/install/node.md
@@ -7,7 +7,7 @@ read_when:
   - "npm install -g fails with permissions or PATH issues"
 ---
 
-OpenClaw requires **Node 22.22.3+, Node 24.15+, or Node 25.9+**. **Node 24 is the default and recommended runtime** for installs, CI, and release workflows; Node 22 remains supported via the active LTS line. Node 23 is unsupported. The [installer script](/install#alternative-install-methods) detects and installs Node automatically — use this page when you want to set up Node yourself (versions, PATH, global installs).
+OpenClaw requires **Node 22.22.3+, Node 24.15+, or Node 25.9+** (which includes Node 26). **Node 26 is the recommended runtime** — it starts the Gateway noticeably faster and uses less memory than Node 24. Node 24 remains the default for the installer script, CI, and release workflows; Node 22 remains supported via its LTS line. Node 23 is unsupported. The [installer script](/install#alternative-install-methods) detects and installs Node automatically — use this page when you want to set up Node yourself (versions, PATH, global installs).
 
 ## Check your version
 
@@ -15,7 +15,7 @@ OpenClaw requires **Node 22.22.3+, Node 24.15+, or Node 25.9+**. **Node 24 is th
 node -v
 ```
 
-`v24.15.0` or newer 24.x is the recommended default. `v22.22.3` or newer 22.x is the supported Node 22 LTS path; Node `v25.9.0+` is also supported. Node 23 is unsupported. If Node is missing or outside the supported range, pick an install method below.
+`v26` (any release) is the recommended runtime. `v24.15.0` or newer 24.x is the installer/CI default; `v22.22.3` or newer 22.x is the supported Node 22 LTS path; Node `v25.9.0+` is also supported. Node 23 is unsupported. If Node is missing or outside the supported range, pick an install method below.
 
 ## Install Node
 

--- a/docs/install/node.md
+++ b/docs/install/node.md
@@ -7,7 +7,7 @@ read_when:
   - "npm install -g fails with permissions or PATH issues"
 ---
 
-OpenClaw requires **Node 22.22.3+, Node 24.15+, or Node 25.9+** (which includes Node 26). **Node 26 is the recommended runtime** — it starts the Gateway noticeably faster and uses less memory than Node 24. Node 24 remains the default for the installer script, CI, and release workflows; Node 22 remains supported via its LTS line. Node 23 is unsupported. The [installer script](/install#alternative-install-methods) detects and installs Node automatically — use this page when you want to set up Node yourself (versions, PATH, global installs).
+OpenClaw requires **Node 22.22.3+, Node 24.15+, or Node 25.9+** (which includes Node 26). **Node 26 is the default and recommended runtime** — it starts the Gateway noticeably faster and uses less memory than Node 24, and the installer script provisions it when Node is missing. CI and release workflows still pin Node 24; Node 22 remains supported via its LTS line. Node 23 is unsupported. The [installer script](/install#alternative-install-methods) detects and installs Node automatically — use this page when you want to set up Node yourself (versions, PATH, global installs).
 
 ## Check your version
 
@@ -15,7 +15,7 @@ OpenClaw requires **Node 22.22.3+, Node 24.15+, or Node 25.9+** (which includes 
 node -v
 ```
 
-`v26` (any release) is the recommended runtime. `v24.15.0` or newer 24.x is the installer/CI default; `v22.22.3` or newer 22.x is the supported Node 22 LTS path; Node `v25.9.0+` is also supported. Node 23 is unsupported. If Node is missing or outside the supported range, pick an install method below.
+`v26` (any release) is the recommended default. `v24.15.0` or newer 24.x remains fully supported (and is what CI pins); `v22.22.3` or newer 22.x is the supported Node 22 LTS path; Node `v25.9.0+` is also supported. Node 23 is unsupported. If Node is missing or outside the supported range, pick an install method below.
 
 ## Install Node
 
@@ -34,7 +34,7 @@ node -v
     **Ubuntu / Debian:**
 
     ```bash
-    curl -fsSL https://deb.nodesource.com/setup_24.x | sudo -E bash -
+    curl -fsSL https://deb.nodesource.com/setup_26.x | sudo -E bash -
     sudo apt-get install -y nodejs
     ```
 
@@ -75,8 +75,8 @@ node -v
 Example with fnm:
 
 ```bash
-fnm install 24
-fnm use 24
+fnm install 26
+fnm use 26
 ```
 
   <Warning>

--- a/openclaw.mjs
+++ b/openclaw.mjs
@@ -11,7 +11,7 @@ import { fileURLToPath } from "node:url";
 const MIN_NODE_22 = { major: 22, minor: 22, patch: 3 };
 const MIN_NODE_24 = { major: 24, minor: 15, patch: 0 };
 const MIN_NODE_25 = { major: 25, minor: 9, patch: 0 };
-const RECOMMENDED_NODE_MAJOR = 24;
+const RECOMMENDED_NODE_MAJOR = 26;
 const SUPPORTED_NODE_RANGE = ">=22.22.3 <23, >=24.15.0 <25, or >=25.9.0";
 const COMPILE_CACHE_DISABLED_RESPAWNED_ENV = "OPENCLAW_COMPILE_CACHE_DISABLED_RESPAWNED";
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -409,11 +409,11 @@ function Resolve-PortableNodeDownload {
     $requestTimeouts = Get-WebRequestTimeoutParameters -CommandName "Invoke-RestMethod" -LegacyTimeoutSec 30
     $index = Invoke-RestMethod -Uri "https://nodejs.org/dist/index.json" @requestTimeouts
     $release = $index |
-        Where-Object { $_.version -match '^v24\.' } |
+        Where-Object { $_.version -match '^v26\.' } |
         Select-Object -First 1
 
     if (-not $release -or -not $release.version) {
-        throw "Could not resolve latest Node.js 24 release metadata."
+        throw "Could not resolve latest Node.js 26 release metadata."
     }
 
     $fileKey = "win-$architecture-zip"
@@ -579,7 +579,7 @@ function Install-Node {
     Write-Host ""
     Write-Host "Error: Could not install Node.js automatically." -ForegroundColor Red
     Write-Host ""
-    Write-Host "Please install Node.js 24.15+ manually:" -ForegroundColor Yellow
+    Write-Host "Please install Node.js 26 manually:" -ForegroundColor Yellow
     Write-Host "  https://nodejs.org/en/download/" -ForegroundColor Cyan
     Write-Host ""
     Write-Host "Or install winget (App Installer) from the Microsoft Store." -ForegroundColor Gray

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -16,7 +16,10 @@ MUTED='\033[38;2;90;100;128m'       # text-muted    #5a6480
 NC='\033[0m' # No Color
 
 DEFAULT_TAGLINE="All your chats, one OpenClaw."
-NODE_DEFAULT_MAJOR=24
+NODE_DEFAULT_MAJOR=26
+# Homebrew ships the current Node line as plain "node" (no versioned node@26
+# formula exists); versioned formulas only cover LTS lines like node@24.
+NODE_BREW_FORMULA="node"
 NODE_MIN_MAJOR=22
 NODE_22_MIN_MINOR=22
 NODE_22_MIN_PATCH=3
@@ -1768,8 +1771,11 @@ promote_supported_node_binary() {
         "/usr/bin/node"
         "/usr/local/bin/node"
         "/opt/homebrew/bin/node"
-        "/opt/homebrew/opt/node@${NODE_DEFAULT_MAJOR}/bin/node"
-        "/usr/local/opt/node@${NODE_DEFAULT_MAJOR}/bin/node"
+        "/opt/homebrew/opt/${NODE_BREW_FORMULA}/bin/node"
+        "/usr/local/opt/${NODE_BREW_FORMULA}/bin/node"
+        # Keep-alive for installs provisioned when node@24 was the default.
+        "/opt/homebrew/opt/node@24/bin/node"
+        "/usr/local/opt/node@24/bin/node"
     )
 
     for candidate in "${candidates[@]}"; do
@@ -1826,7 +1832,7 @@ ensure_macos_default_node_active() {
 
     local brew_node_prefix=""
     if command -v brew &> /dev/null; then
-        brew_node_prefix="$(brew --prefix "node@${NODE_DEFAULT_MAJOR}" 2>/dev/null || true)"
+        brew_node_prefix="$(brew --prefix "${NODE_BREW_FORMULA}" 2>/dev/null || true)"
         if [[ -n "$brew_node_prefix" && -x "${brew_node_prefix}/bin/node" ]]; then
             export PATH="${brew_node_prefix}/bin:$PATH"
             refresh_shell_command_cache
@@ -1842,9 +1848,9 @@ ensure_macos_default_node_active() {
     active_version="$(node -v 2>/dev/null || echo "missing")"
 
     if [[ -z "$brew_node_prefix" || ! -x "${brew_node_prefix}/bin/node" ]]; then
-        ui_error "Homebrew node@${NODE_DEFAULT_MAJOR} is not installed on disk"
+        ui_error "Homebrew ${NODE_BREW_FORMULA} is not installed on disk"
         echo "The previous 'brew install' step appears to have failed."
-        echo "Re-run 'brew install node@${NODE_DEFAULT_MAJOR}' directly or rerun the installer with --verbose to see the underlying error."
+        echo "Re-run 'brew install ${NODE_BREW_FORMULA}' directly or rerun the installer with --verbose to see the underlying error."
         return 1
     fi
 
@@ -1990,11 +1996,11 @@ install_node_with_apk() {
 install_node() {
     if [[ "$OS" == "macos" ]]; then
         ui_info "Installing Node.js via Homebrew"
-        if ! run_quiet_step "Installing node@${NODE_DEFAULT_MAJOR}" brew install "node@${NODE_DEFAULT_MAJOR}"; then
-            echo "Re-run with --verbose or run 'brew install node@${NODE_DEFAULT_MAJOR}' directly, then rerun the installer."
+        if ! run_quiet_step "Installing ${NODE_BREW_FORMULA}" brew install "${NODE_BREW_FORMULA}"; then
+            echo "Re-run with --verbose or run 'brew install ${NODE_BREW_FORMULA}' directly, then rerun the installer."
             exit 1
         fi
-        brew link "node@${NODE_DEFAULT_MAJOR}" --overwrite --force 2>/dev/null || true
+        brew link "${NODE_BREW_FORMULA}" --overwrite --force 2>/dev/null || true
         if ! ensure_macos_default_node_active; then
             exit 1
         fi

--- a/test/scripts/install-ps1.test.ts
+++ b/test/scripts/install-ps1.test.ts
@@ -269,6 +269,7 @@ describe("install.ps1 failure handling", () => {
           '  if ($OperationTimeoutSeconds -ne 30) { throw "OperationTimeoutSeconds=$OperationTimeoutSeconds" }',
           "  if ($Uri -eq 'https://nodejs.org/dist/index.json') {",
           "    return @(",
+          "      [pscustomobject]@{ version = 'v26.5.0'; files = @('win-arm64-zip', 'win-x64-zip') },",
           "      [pscustomobject]@{ version = 'v24.17.0'; files = @('win-arm64-zip', 'win-x64-zip') }",
           "    )",
           "  }",
@@ -281,7 +282,7 @@ describe("install.ps1 failure handling", () => {
           "  }",
           "}",
           "$nodeDownload = Resolve-PortableNodeDownload",
-          "if ($nodeDownload.Name -ne 'node-v24.17.0-win-arm64.zip') { throw \"NodeName=$($nodeDownload.Name)\" }",
+          "if ($nodeDownload.Name -ne 'node-v26.5.0-win-arm64.zip') { throw \"NodeName=$($nodeDownload.Name)\" }",
           "$gitDownload = Resolve-PortableGitDownload",
           "if ($gitDownload.Name -ne 'MinGit-2.54.0-arm64.zip') { throw \"GitName=$($gitDownload.Name)\" }",
           "",
@@ -583,7 +584,7 @@ describe("install.ps1 failure handling", () => {
     expect(checkNodeBody).toContain(
       "SQLite 3.51.3+, 3.50.7+ within 3.50.x, or 3.44.6+ within 3.44.x is required",
     );
-    expect(source).toContain("Please install Node.js 24.15+ manually:");
+    expect(source).toContain("Please install Node.js 26 manually:");
   });
 
   runIfPowerShell("accepts only supported Node versions", () => {

--- a/test/scripts/install-sh.test.ts
+++ b/test/scripts/install-sh.test.ts
@@ -533,7 +533,7 @@ NODE
       "error:Alpine apk repositories did not provide Node.js with WAL-reset-safe SQLite",
     );
     expect(result.stdout).toContain(
-      "Use an official node:24-alpine container or a glibc-based host",
+      "Use an official node:26-alpine container or a glibc-based host",
     );
   });
 
@@ -2088,15 +2088,13 @@ describe("install.sh macOS Homebrew Node behavior", () => {
 
   it("stops when Homebrew node installation fails", () => {
     expect(script).toContain(
-      'if ! run_quiet_step "Installing node@${NODE_DEFAULT_MAJOR}" brew install "node@${NODE_DEFAULT_MAJOR}"; then',
+      'if ! run_quiet_step "Installing ${NODE_BREW_FORMULA}" brew install "${NODE_BREW_FORMULA}"; then',
     );
 
     const failedInstallIndex = script.indexOf(
-      'if ! run_quiet_step "Installing node@${NODE_DEFAULT_MAJOR}" brew install "node@${NODE_DEFAULT_MAJOR}"; then',
+      'if ! run_quiet_step "Installing ${NODE_BREW_FORMULA}" brew install "${NODE_BREW_FORMULA}"; then',
     );
-    const brewLinkIndex = script.indexOf(
-      'brew link "node@${NODE_DEFAULT_MAJOR}" --overwrite --force',
-    );
+    const brewLinkIndex = script.indexOf('brew link "${NODE_BREW_FORMULA}" --overwrite --force');
     expect(failedInstallIndex).toBeGreaterThanOrEqual(0);
     expect(brewLinkIndex).toBeGreaterThan(failedInstallIndex);
   });
@@ -2118,7 +2116,7 @@ describe("install.sh macOS Homebrew Node behavior", () => {
 
     expect(result.status).toBe(1);
     expect(result.stdout).toContain(
-      "Re-run with --verbose or run 'brew install node@24' directly, then rerun the installer.",
+      "Re-run with --verbose or run 'brew install node' directly, then rerun the installer.",
     );
     expect(result.stdout).not.toContain("brew:link");
     expect(result.stdout).not.toContain("ensure-called");
@@ -2131,9 +2129,7 @@ describe("install.sh macOS Homebrew Node behavior", () => {
     const pathAdviceIndex = script.indexOf("Add this to your shell profile and restart shell:");
 
     expect(missingNodeGuardIndex).toBeGreaterThanOrEqual(0);
-    expect(script).toContain(
-      'ui_error "Homebrew node@${NODE_DEFAULT_MAJOR} is not installed on disk"',
-    );
+    expect(script).toContain('ui_error "Homebrew ${NODE_BREW_FORMULA} is not installed on disk"');
     expect(script).toContain('echo "  export PATH=\\"${brew_node_prefix}/bin:\\$PATH\\""');
     expect(pathAdviceIndex).toBeGreaterThan(missingNodeGuardIndex);
   });
@@ -2143,7 +2139,7 @@ describe("install.sh macOS Homebrew Node behavior", () => {
       set -euo pipefail
       source "${SCRIPT_PATH}"
       OS=macos
-      missing_prefix="$(mktemp -d)/node@24"
+      missing_prefix="$(mktemp -d)/node"
       brew() {
         if [[ "$1" == "--prefix" ]]; then
           echo "$missing_prefix"
@@ -2160,9 +2156,9 @@ describe("install.sh macOS Homebrew Node behavior", () => {
     `);
 
     expect(result.status).toBe(0);
-    expect(result.stdout).toContain("Homebrew node@24 is not installed on disk");
+    expect(result.stdout).toContain("Homebrew node is not installed on disk");
     expect(result.stdout).toContain("ensure returned failure");
-    expect(result.stdout).not.toContain("Node.js v24 was installed");
+    expect(result.stdout).not.toContain("Node.js v26 was installed");
     expect(result.stdout).not.toContain("Add this to your shell profile");
   });
 


### PR DESCRIPTION
## What Problem This Solves

OpenClaw recommends Node 24 everywhere (CLI nvm hint, install docs, FAQ, contributor guide), but Node 26 is now measurably the better runtime for OpenClaw and is already inside the supported range (`>=25.9.0` clause admits every 26.x). Users following our recommendation get a slower gateway with a larger footprint for no benefit.

## Why This Change Was Made

Benchmarked Node 24.18.0 vs Node 26.5.0 vs Bun 1.4 canary on the same built dist with identical batteries (medians): gateway boot-to-healthy 2.9s on Node 26 vs 6.1s on Node 24; gateway RSS 684 MB vs 996 MB; HTTP/WS serving throughput within noise of each other; sqlite micro-bench within ~5%. This PR flips only the recommendation surfaces:

- `openclaw.mjs`: `RECOMMENDED_NODE_MAJOR` 24 -> 26 (the nvm hint shown on unsupported-runtime exit).
- `docs/install/node.md`, `docs/install/index.md`, `docs/install/ansible.md`, `docs/install/bun.md`, `docs/help/faq-first-run.md`: Node 26 recommended, with the supported range unchanged.
- `AGENTS.md`: contributor runtime line updated, noting CI still pins Node 24.

Deliberately out of scope (docs state this explicitly): the installer default (`scripts/install.sh` `NODE_DEFAULT_MAJOR=24` — Homebrew has no versioned `node@26` formula, so its `node@N` opt paths need rework first), CI/release workflow pins (prompt-snapshot truth is Linux Node 24), and Docker base images. Those are follow-ups; the supported-version floor and guard logic are untouched.

## User Impact

No behavior change for any currently supported runtime. Users on unsupported Node versions now see `nvm install 26` instead of `nvm install 24` in the error hint. Docs steer new manual installs to Node 26 (Homebrew `node` is already 26.5). Node 24 remains fully supported and remains what the installer provisions.

## Evidence

- Benchmark battery (CLI startup, status, doctor, sqlite 50k ins/sel, gateway boot, 500 HTTP, 50 WS) run per runtime with identical client-side measurement; summary table in the PR discussion context above.
- `node scripts/run-vitest.mjs run test/openclaw-launcher.e2e.test.ts` — 43/43 (the unsupported-version message assertions don't pin the recommended major; verified they pass with 26).
- Codex autoreview (`--mode uncommitted`, gpt-5.6-sol): clean, 0 findings, 0.99 confidence.
- `git diff --check` clean; docs edits follow Mintlify link rules (no new links).

## Update: installer default flipped too (Docker-proven)

Follow-up commit `feat(install)` moves fresh provisioning to Node 26 as well:

- `scripts/install.sh`: `NODE_DEFAULT_MAJOR=26`; Homebrew installs the mainline `node` formula via new `NODE_BREW_FORMULA` (no versioned `node@26` formula exists — verified against Homebrew), with legacy `node@24` opt paths kept as detection candidates for existing installs; NodeSource `setup_26.x` verified live (HTTP 200 on both deb and rpm endpoints).
- `scripts/install.ps1`: portable-Node fallback now resolves latest v26 (win zips verified present in nodejs.org dist index); winget/choco/scoop stay on their LTS packages, which remain fully supported.
- Docs updated to match (installer.md, node.md, index.md — including the NodeSource and fnm snippets).

Docker evidence (local OrbStack, linux/arm64):

- Fresh `ubuntu:24.04` (no Node): modified `install.sh --no-onboard --no-prompt` provisioned **Node v26.5.0** via NodeSource apt path, installed released OpenClaw 2026.7.1-2 from npm, and `openclaw --version` runs. Exit 0.
- Fresh `fedora:41`: same via the rpm path — **Node v26.5.0**, OpenClaw installed. Exit 0.
- `bash -n` and `shellcheck -S warning` clean on `install.sh`.
- Known gap: `scripts/test-install-sh-docker.sh` currently fails locally in its packaging step (`npm pack --json` exceeds the harness's hard 1 MiB captured-stdout cap in `scripts/package-openclaw-for-docker.mjs`) before any container runs — unrelated to this diff; CI's Linux docker lanes cover the harness. Windows portable path is verified statically only (metadata + zip availability), not executed.
- Codex autoreview on the installer commit: clean, 0 findings.

## ClawSweeper responses (round 2)

**Maintainer decision on Current-vs-LTS (P1/P2):** the repository owner explicitly directed this switch ("switch our recommendation to node 26", then "use docker to test the installer and flip it too") after reviewing the benchmark. Recommending the Current line until Node 26's LTS promotion (October 2026) is the accepted, deliberate policy; Node 24/22 remain fully supported and CI keeps validating Node 24.

**Windows default-claim accuracy (P2):** fixed — docs/install/installer.md now states the platform-accurate behavior (macOS/Linux provision Node 26; Windows package managers install the supported LTS line; the Windows portable fallback downloads Node 26).

**Inspectable evidence:** raw transcripts from the Docker scenario runs (local OrbStack, linux/arm64, ANSI stripped):

Fresh `ubuntu:24.04`, no Node, modified `install.sh --no-onboard --no-prompt`:

```console
· Installing OpenClaw package
✓ OpenClaw npm package installed
✓ OpenClaw installed

[3/3] Finalizing setup

🦞 OpenClaw installed successfully (2026.7.1-2)!
Home sweet home. Don't worry, I won't rearrange the furniture.

· Skipping onboard (requested); run openclaw onboard later

FAQ: https://docs.openclaw.ai/start/faq
---
v26.5.0
OpenClaw 2026.7.1-2 (0790d9f)
```

Fresh `fedora:41`, same flags (rpm path):

```console
Status: Downloaded newer image for fedora:41
[3/3] Finalizing setup

🦞 OpenClaw installed successfully (2026.7.1-2)!
All done! I promise to only judge your code a little bit.

· Skipping onboard (requested); run openclaw onboard later

FAQ: https://docs.openclaw.ai/start/faq
---
v26.5.0
```

Windows path proof is CI-level: the PowerShell installer suite (test/scripts/install-ps1.test.ts) runs the real `Resolve-PortableNodeDownload` against a v26+v24 dist fixture on the Windows CI lane and asserts the v26 zip is selected; no live Windows host was used.
