### PR TITLE
fix(release): detect missing bundled providers after npm install

### DIFF
--- a/scripts/openclaw-npm-postpublish-verify.ts
+++ b/scripts/openclaw-npm-postpublish-verify.ts
@@ -960,13 +960,22 @@ function readBundledExtensionPackageJsons(packageRoot: string): {
   errors: string[];
 } {
   const extensionsDir = join(packageRoot, "dist", "extensions");
-  if (!existsSync(extensionsDir)) {
-    return { manifests: [], errors: [] };
-  }
-
   const manifests: InstalledBundledExtensionManifestRecord[] = [];
   const errors: string[] = [];
   const expectedPackageIds = collectExpectedBundledExtensionPackageIds();
+
+  // Scan the package contract first: absent bundled directories are invisible
+  // when verification only walks the installed extension root.
+  for (const expectedPackageId of expectedPackageIds) {
+    const packageJsonPath = join(extensionsDir, expectedPackageId, "package.json");
+    if (!existsSync(packageJsonPath)) {
+      errors.push(`installed bundled extension manifest missing: ${packageJsonPath}.`);
+    }
+  }
+
+  if (!existsSync(extensionsDir)) {
+    return { manifests, errors };
+  }
 
   for (const entry of readdirSync(extensionsDir, { withFileTypes: true })) {
     if (!entry.isDirectory()) {
@@ -976,9 +985,6 @@ function readBundledExtensionPackageJsons(packageRoot: string): {
     const extensionDirPath = join(extensionsDir, entry.name);
     const packageJsonPath = join(extensionsDir, entry.name, "package.json");
     if (!existsSync(packageJsonPath)) {
-      if (expectedPackageIds.has(entry.name)) {
-        errors.push(`installed bundled extension manifest missing: ${packageJsonPath}.`);
-      }
       continue;
     }
 

--- a/test/openclaw-npm-postpublish-verify.test.ts
+++ b/test/openclaw-npm-postpublish-verify.test.ts
@@ -4,6 +4,7 @@ import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "nod
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
+import { listBundledPluginPackArtifacts } from "../scripts/lib/bundled-plugin-build-entries.mjs";
 import {
   buildPublishedInstallCommandArgs,
   buildPublishedInstallScenarios,
@@ -565,6 +566,22 @@ describe("collectInstalledPackageErrors", () => {
     return mkdtempSync(join(tmpdir(), "openclaw-postpublish-package-"));
   }
 
+  function writeExpectedBundledExtensionManifests(
+    packageRoot: string,
+    omittedIds: readonly string[] = [],
+  ): void {
+    const omitted = new Set(omittedIds);
+    for (const relativePath of listBundledPluginPackArtifacts()) {
+      const match = /^dist\/extensions\/([^/]+)\/package\.json$/u.exec(relativePath);
+      if (!match || omitted.has(match[1] ?? "")) {
+        continue;
+      }
+      const packageJsonPath = join(packageRoot, relativePath);
+      mkdirSync(dirname(packageJsonPath), { recursive: true });
+      writeFileSync(packageJsonPath, "{}\n", "utf8");
+    }
+  }
+
   it("flags version mismatches", () => {
     const errors = collectInstalledPackageErrors({
       expectedVersion: "2026.3.23-2",
@@ -575,6 +592,83 @@ describe("collectInstalledPackageErrors", () => {
     expect(errors[0]).toBe(
       "installed package version mismatch: expected 2026.3.23-2, found 2026.3.23.",
     );
+  });
+
+  it.each(["ollama", "lmstudio"])(
+    "rejects a missing installed bundled %s provider directory",
+    (providerId) => {
+      const packageRoot = makeInstalledPackageRoot();
+
+      try {
+        writeFileSync(join(packageRoot, "package.json"), '{"version":"2026.3.23"}\n', "utf8");
+        writeExpectedBundledExtensionManifests(packageRoot, [providerId]);
+
+        const missingManifestPath = join(
+          packageRoot,
+          "dist",
+          "extensions",
+          providerId,
+          "package.json",
+        );
+        const expectedError = `installed bundled extension manifest missing: ${missingManifestPath}.`;
+
+        expect(collectInstalledBundledExtensionManifestErrors(packageRoot)).toStrictEqual([
+          expectedError,
+        ]);
+        expect(
+          collectInstalledPackageErrors({
+            expectedVersion: "2026.3.23",
+            installedVersion: "2026.3.23",
+            packageRoot,
+          }),
+        ).toContain(expectedError);
+      } finally {
+        rmSync(packageRoot, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it("rejects an installed package without its bundled extension root", () => {
+    const packageRoot = makeInstalledPackageRoot();
+
+    try {
+      const errors = collectInstalledBundledExtensionManifestErrors(packageRoot);
+
+      expect(errors).toEqual(
+        expect.arrayContaining(
+          ["ollama", "lmstudio"].map(
+            (providerId) =>
+              `installed bundled extension manifest missing: ${join(
+                packageRoot,
+                "dist",
+                "extensions",
+                providerId,
+                "package.json",
+              )}.`,
+          ),
+        ),
+      );
+      for (const excludedId of ["acpx", "qa-channel", "qa-lab"]) {
+        expect(errors.some((error) => error.includes(join("extensions", excludedId)))).toBe(false);
+      }
+    } finally {
+      rmSync(packageRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("does not require excluded external or private plugin package manifests", () => {
+    const packageRoot = makeInstalledPackageRoot();
+
+    try {
+      writeExpectedBundledExtensionManifests(packageRoot);
+      for (const excludedId of ["acpx", "qa-channel", "qa-lab"]) {
+        mkdirSync(join(packageRoot, "dist", "extensions", excludedId), { recursive: true });
+      }
+
+      expect(collectInstalledBundledExtensionManifestErrors(packageRoot)).toStrictEqual([]);
+    } finally {
+      rmSync(packageRoot, { recursive: true, force: true });
+    }
   });
 
   it("requires runtime sidecars for bundled extensions included in the package", () => {
@@ -611,6 +705,7 @@ describe("collectInstalledPackageErrors", () => {
 
     try {
       writeFileSync(join(packageRoot, "package.json"), '{"version":"2026.3.23"}\n', "utf8");
+      writeExpectedBundledExtensionManifests(packageRoot);
       mkdirSync(join(packageRoot, "dist", "extensions", "telegram"), { recursive: true });
       writeFileSync(
         join(packageRoot, "dist", "extensions", "telegram", "package.json"),

--- a/test/release-check.test.ts
+++ b/test/release-check.test.ts
@@ -18,7 +18,10 @@ import {
   WORKSPACE_TEMPLATE_PACK_PATHS,
   createWorkspaceBootstrapSmokeEnv,
 } from "../scripts/lib/workspace-bootstrap-smoke.mjs";
-import { collectInstalledRootDependencyManifestErrors } from "../scripts/openclaw-npm-postpublish-verify.ts";
+import {
+  collectInstalledBundledRuntimeSidecarPaths,
+  collectInstalledRootDependencyManifestErrors,
+} from "../scripts/openclaw-npm-postpublish-verify.ts";
 import {
   collectAppcastSparkleVersionErrors,
   collectBundledExtensionManifestErrors,
@@ -789,8 +792,18 @@ describe("collectMissingPackPaths", () => {
         mkdirSync(dirname(filePath), { recursive: true });
         writeFileSync(filePath, "export {};\n");
       }
-      for (const pluginId of ["image-generation-core", "media-understanding-core"]) {
-        writeFileSync(join(distDir, "extensions", pluginId, "package.json"), "{}\n");
+      for (const relativePath of requiredBundledPluginPackPaths) {
+        if (!/^dist\/extensions\/[^/]+\/package\.json$/u.test(relativePath)) {
+          continue;
+        }
+        const packageJsonPath = join(packageRoot, relativePath);
+        mkdirSync(dirname(packageJsonPath), { recursive: true });
+        writeFileSync(packageJsonPath, "{}\n");
+      }
+      for (const relativePath of collectInstalledBundledRuntimeSidecarPaths(packageRoot)) {
+        const sidecarPath = join(packageRoot, relativePath);
+        mkdirSync(dirname(sidecarPath), { recursive: true });
+        writeFileSync(sidecarPath, "export {};\n");
       }
       writeFileSync(
         join(packageRoot, "package.json"),


### PR DESCRIPTION
## Problem

Post-publish verification could accept an npm installation missing required bundled provider plugin manifests, and its release-test fixture modeled only a subset of the package. This allowed a broken installed Ollama or LM Studio setup to escape the actual release gate.

## Solution

Derive every required bundled plugin manifest from the canonical production packaging contract, fail closed if the installed plugin root or any required manifest is absent, and seed release fixtures from the same required-manifest and runtime-sidecar helpers. Do not hard-code provider IDs, weaken tarball validation, or alter package exclusions.

## User impact

Published OpenClaw installations reliably contain their complete bundled provider runtime. Incomplete or corrupted installed packages are rejected before post-publish success is reported.

## Evidence

Exact freshly pulled base `3c67fcc45d83bb8cd7eb9d7b076ae33e347bece5`; final head `623bb51830e75624774ebf2b0f41ed9a77c63e20`. Real Linux Node 24.18.0 evidence: https://github.com/openclaw/openclaw/actions/runs/30244464614

The canonical production build and self-contained `pnpm pack` produced `openclaw-2026.7.2.tgz` and passed strict tarball integrity. A genuinely isolated `npm install` installed 324 packages, including the real bundled private runtime; the installed CLI reported `OpenClaw 2026.7.2 (623bb51)`.

The actual installed-package production verifier was then run against the intact installed artifact, each individually corrupted provider, the missing entire plugin directory, and the restored package:

```text
{"scenario":"intact","result":"PASS","errorCount":0}
{"scenario":"missing-ollama-manifest","result":"EXPECTED_FAIL_DETECTED","errorCount":1,"sample":["installed bundled extension manifest missing: <isolated-package>/dist/extensions/ollama/package.json."]}
{"scenario":"missing-lmstudio-manifest","result":"EXPECTED_FAIL_DETECTED","errorCount":1,"sample":["installed bundled extension manifest missing: <isolated-package>/dist/extensions/lmstudio/package.json."]}
{"scenario":"missing-extensions-root","result":"EXPECTED_FAIL_DETECTED","errorCount":75}
{"scenario":"intact","result":"PASS","errorCount":0}
PACK-PROOF FOUR-CONTROL COMPLETE sha=623bb51830e75624774ebf2b0f41ed9a77c63e20 intact=PASS missing_ollama=EXPECTED_FAIL missing_lmstudio=EXPECTED_FAIL missing_extensions_root=EXPECTED_FAIL restored=PASS
```

Both affected release suites passed: 108 tests across 2 files. Exact full-branch independent review: clean, confidence 0.94; secret scan clean. The exact-base complete changed-files gate is being rerun after clearing an abandoned task-owned runner lock. AI-assisted; no release-contract weakening, provider-name list, user-state change, database migration, or new paid service.
