### PR TITLE
refactor(gateway): consolidate RPC test scenarios

### DIFF
--- a/src/gateway/server-methods/send.test.ts
+++ b/src/gateway/server-methods/send.test.ts
@@ -462,6 +462,121 @@ function registerMessageThreadAddressingPlugin(id: ChannelPlugin["id"]): void {
   );
 }
 
+function registerMessageActionPlugin(params: {
+  id?: ChannelPlugin["id"];
+  action?: "send" | "sendAttachment";
+  messageId?: string;
+  chatType?: "direct" | "group";
+  threading?: ChannelPlugin["threading"];
+  registrySuffix: string;
+}): ChannelPlugin {
+  const {
+    id = "telegram",
+    action = "send",
+    messageId,
+    chatType = "direct",
+    threading,
+    registrySuffix,
+  } = params;
+  const plugin: ChannelPlugin = {
+    ...createChannelTestPluginBase({
+      id,
+      capabilities: { chatTypes: [chatType] },
+      config: { resolveAccount: () => ({ enabled: true }), isConfigured: () => true },
+    }),
+    actions: {
+      describeMessageTool: () => ({ actions: [action] }),
+      supportsAction: ({ action: requestedAction }) => requestedAction === action,
+      handleAction: async () => jsonResult({ ok: true, ...(messageId ? { messageId } : {}) }),
+    },
+    ...(threading ? { threading } : {}),
+  };
+  mocks.getChannelPlugin.mockReturnValue(plugin);
+  setActivePluginRegistry(
+    createTestRegistry([{ pluginId: id, source: "test", plugin }]),
+    `send-test-${registrySuffix}`,
+  );
+  return plugin;
+}
+
+async function runTelegramTerminalAction(params: {
+  sessionId: string;
+  idempotencyKey: string;
+  sourceTurnId: string;
+  toolCallId?: string;
+  message?: string;
+  presentation?: Record<string, unknown>;
+  sessionKey?: string;
+  currentMessageId?: string;
+  currentThreadTs?: string;
+  sourceReplyFinal?: boolean;
+}) {
+  const sessionKey = params.sessionKey ?? "agent:main:telegram:direct:chat-123";
+  return runMessageActionRequest(
+    {
+      channel: "telegram",
+      action: "send",
+      params: {
+        to: "chat-123",
+        ...(params.message === undefined ? {} : { message: params.message }),
+        ...(params.presentation === undefined ? {} : { presentation: params.presentation }),
+      },
+      sessionKey,
+      sessionId: params.sessionId,
+      agentId: "main",
+      idempotencyKey: params.idempotencyKey,
+    },
+    {
+      internal: {
+        agentRuntimeIdentity: {
+          kind: "agentRuntime",
+          agentId: "main",
+          sessionKey,
+          messageActionContext: {
+            expiresAtMs: Date.now() + 60_000,
+            sessionId: params.sessionId,
+            sourceReplyFinal: params.sourceReplyFinal ?? true,
+            ...(params.toolCallId === undefined
+              ? {}
+              : { sourceReplyToolCallId: params.toolCallId }),
+            toolContext: {
+              currentChannelProvider: "telegram",
+              currentChannelId: "chat-123",
+              ...(params.currentMessageId === undefined
+                ? {}
+                : { currentMessageId: params.currentMessageId }),
+              ...(params.currentThreadTs === undefined
+                ? {}
+                : { currentThreadTs: params.currentThreadTs }),
+              currentSourceTurnId: params.sourceTurnId,
+            },
+          },
+        },
+      },
+    },
+  );
+}
+
+function startConcurrentGatewayRequest(
+  method: "send" | "poll" | "message.action",
+  params: Record<string, unknown>,
+  context: GatewayRequestContext,
+  respond: ReturnType<typeof vi.fn>,
+  requestId: string,
+) {
+  return expectDefined(
+    sendHandlers[method],
+    "gateway send handler test invariant",
+  )({
+    params: params as never,
+    respond: respond as never,
+    context,
+    req: { type: "req", id: requestId, method },
+    client: null as never,
+    isWebchatConnect: () => false,
+  });
+}
+
 describe("gateway send mirroring", () => {
   let registrySeq = 0;
 
@@ -761,68 +876,83 @@ describe("gateway send mirroring", () => {
     expect(mocks.getRuntimeConfigSourceSnapshot).not.toHaveBeenCalled();
   });
 
-  it("dedupes concurrent message.action requests while inflight", async () => {
+  it.each([
+    {
+      name: "dedupes concurrent message.action requests while inflight",
+      method: "message.action" as const,
+      params: {
+        channel: "slack",
+        action: "poll",
+        params: { question: "Q?" },
+        idempotencyKey: "idem-action-concurrent",
+      },
+      operation: () => mocks.dispatchChannelMessageAction,
+      result: { details: { action: "handled" } },
+      expectedPayload: { action: "handled" },
+    },
+    {
+      name: "dedupes concurrent send requests while inflight",
+      method: "send" as const,
+      params: {
+        to: "channel:C1",
+        message: "hi",
+        channel: "slack",
+        idempotencyKey: "idem-send-concurrent",
+      },
+      operation: () => mocks.deliverOutboundPayloads,
+      result: [{ messageId: "m-concurrent", channel: "slack" }],
+      expectedPayload: { messageId: "m-concurrent", runId: "idem-send-concurrent" },
+    },
+    {
+      name: "dedupes concurrent poll requests while inflight",
+      method: "poll" as const,
+      params: {
+        to: "channel:C1",
+        question: "Q?",
+        options: ["A", "B"],
+        channel: "slack",
+        idempotencyKey: "idem-poll-concurrent",
+      },
+      operation: () => mocks.sendPoll,
+      result: { messageId: "poll-concurrent", pollId: "poll-1" },
+      expectedPayload: {
+        messageId: "poll-concurrent",
+        pollId: "poll-1",
+        runId: "idem-poll-concurrent",
+      },
+    },
+  ])("$name", async ({ method, params, operation, result, expectedPayload }) => {
     const context = makeContext();
-    const firstRespond = vi.fn();
-    const secondRespond = vi.fn();
-    const actionDeferred = createDeferred<{ details: { action: string } }>();
-    mocks.dispatchChannelMessageAction.mockReturnValueOnce(actionDeferred.promise);
+    const responses = [vi.fn(), vi.fn()] as const;
+    const deferred = createDeferred<typeof result>();
+    const operationMock = operation();
+    operationMock.mockReturnValueOnce(deferred.promise as never);
 
-    const firstRequest = expectDefined(
-      sendHandlers["message.action"],
-      'sendHandlers["message.action"] test invariant',
-    )({
-      params: {
-        channel: "slack",
-        action: "poll",
-        params: { question: "Q?" },
-        idempotencyKey: "idem-action-concurrent",
-      } as never,
-      respond: firstRespond,
-      context,
-      req: { type: "req", id: "1", method: "message.action" },
-      client: null as never,
-      isWebchatConnect: () => false,
-    });
+    const requests = responses.map((respond, index) =>
+      Promise.resolve(
+        startConcurrentGatewayRequest(
+          method,
+          structuredClone(params),
+          context,
+          respond,
+          String(index + 1),
+        ),
+      ),
+    );
+    await vi.waitFor(() => expect(operationMock).toHaveBeenCalledOnce());
+    deferred.resolve(result);
+    await Promise.all(requests);
 
-    const secondRequest = expectDefined(
-      sendHandlers["message.action"],
-      'sendHandlers["message.action"] test invariant',
-    )({
-      params: {
-        channel: "slack",
-        action: "poll",
-        params: { question: "Q?" },
-        idempotencyKey: "idem-action-concurrent",
-      } as never,
-      respond: secondRespond,
-      context,
-      req: { type: "req", id: "2", method: "message.action" },
-      client: null as never,
-      isWebchatConnect: () => false,
-    });
-
-    await Promise.resolve();
-    expect(mocks.dispatchChannelMessageAction).toHaveBeenCalledTimes(1);
-
-    actionDeferred.resolve({ details: { action: "handled" } });
-    await Promise.all([firstRequest, secondRequest]);
-
-    expect(mocks.dispatchChannelMessageAction).toHaveBeenCalledTimes(1);
-    expect(firstRespond).toHaveBeenCalledTimes(1);
-    expect(secondRespond).toHaveBeenCalledTimes(1);
-    const firstCall = firstRespondCall(firstRespond);
-    expect(firstCall?.[0]).toBe(true);
-    expect(firstCall?.[1]).toEqual({ action: "handled" });
-    expect(firstCall?.[2]).toBeUndefined();
-    expect(firstCall?.[3]?.channel).toBe("slack");
-    expect(firstCall?.[3]?.cached).toBeUndefined();
-    const secondCall = firstRespondCall(secondRespond);
-    expect(secondCall?.[0]).toBe(true);
-    expect(secondCall?.[1]).toEqual({ action: "handled" });
-    expect(secondCall?.[2]).toBeUndefined();
-    expect(secondCall?.[3]?.channel).toBe("slack");
-    expect(secondCall?.[3]?.cached).toBe(true);
+    expect(operationMock).toHaveBeenCalledOnce();
+    for (const [index, respond] of responses.entries()) {
+      expect(respond).toHaveBeenCalledOnce();
+      const response = firstRespondCall(respond);
+      expect(response[0]).toBe(true);
+      expect(response[1]).toMatchObject(expectedPayload);
+      expect(response[2]).toBeUndefined();
+      expect(response[3]?.channel).toBe("slack");
+      expect(response[3]?.cached).toBe(index === 0 ? undefined : true);
+    }
   });
 
   it("does not share message.action idempotency results across authority origins", async () => {
@@ -914,143 +1044,6 @@ describe("gateway send mirroring", () => {
     );
 
     expect(lastDispatchChannelMessageActionCall()?.conversationReadOrigin).toBe("delegated");
-  });
-
-  it("dedupes concurrent send requests while inflight", async () => {
-    const context = makeContext();
-    const firstRespond = vi.fn();
-    const secondRespond = vi.fn();
-    const deliveryDeferred = createDeferred<Array<{ messageId: string; channel: string }>>();
-    mocks.deliverOutboundPayloads.mockReturnValueOnce(deliveryDeferred.promise);
-
-    const firstRequest = expectDefined(
-      sendHandlers.send,
-      "sendHandlers.send test invariant",
-    )({
-      params: {
-        to: "channel:C1",
-        message: "hi",
-        channel: "slack",
-        idempotencyKey: "idem-send-concurrent",
-      } as never,
-      respond: firstRespond,
-      context,
-      req: { type: "req", id: "1", method: "send" },
-      client: null as never,
-      isWebchatConnect: () => false,
-    });
-
-    const secondRequest = expectDefined(
-      sendHandlers.send,
-      "sendHandlers.send test invariant",
-    )({
-      params: {
-        to: "channel:C1",
-        message: "hi",
-        channel: "slack",
-        idempotencyKey: "idem-send-concurrent",
-      } as never,
-      respond: secondRespond,
-      context,
-      req: { type: "req", id: "2", method: "send" },
-      client: null as never,
-      isWebchatConnect: () => false,
-    });
-
-    await vi.waitFor(() => {
-      expect(mocks.deliverOutboundPayloads).toHaveBeenCalledTimes(1);
-    });
-
-    deliveryDeferred.resolve([{ messageId: "m-concurrent", channel: "slack" }]);
-    await Promise.all([firstRequest, secondRequest]);
-
-    expect(mocks.deliverOutboundPayloads).toHaveBeenCalledTimes(1);
-    expect(firstRespond).toHaveBeenCalledTimes(1);
-    expect(secondRespond).toHaveBeenCalledTimes(1);
-    const firstCall = firstRespondCall(firstRespond);
-    expect(firstCall?.[0]).toBe(true);
-    expect(firstCall?.[1]?.messageId).toBe("m-concurrent");
-    expect(firstCall?.[1]?.runId).toBe("idem-send-concurrent");
-    expect(firstCall?.[2]).toBeUndefined();
-    expect(firstCall?.[3]?.channel).toBe("slack");
-    expect(firstCall?.[3]?.cached).toBeUndefined();
-    const secondCall = firstRespondCall(secondRespond);
-    expect(secondCall?.[0]).toBe(true);
-    expect(secondCall?.[1]?.messageId).toBe("m-concurrent");
-    expect(secondCall?.[1]?.runId).toBe("idem-send-concurrent");
-    expect(secondCall?.[2]).toBeUndefined();
-    expect(secondCall?.[3]?.channel).toBe("slack");
-    expect(secondCall?.[3]?.cached).toBe(true);
-  });
-
-  it("dedupes concurrent poll requests while inflight", async () => {
-    const context = makeContext();
-    const firstRespond = vi.fn();
-    const secondRespond = vi.fn();
-    const pollDeferred = createDeferred<{ messageId: string; pollId: string }>();
-    mocks.sendPoll.mockReturnValueOnce(pollDeferred.promise);
-
-    const firstRequest = expectDefined(
-      sendHandlers.poll,
-      "sendHandlers.poll test invariant",
-    )({
-      params: {
-        to: "channel:C1",
-        question: "Q?",
-        options: ["A", "B"],
-        channel: "slack",
-        idempotencyKey: "idem-poll-concurrent",
-      } as never,
-      respond: firstRespond,
-      context,
-      req: { type: "req", id: "1", method: "poll" },
-      client: null as never,
-      isWebchatConnect: () => false,
-    });
-
-    const secondRequest = expectDefined(
-      sendHandlers.poll,
-      "sendHandlers.poll test invariant",
-    )({
-      params: {
-        to: "channel:C1",
-        question: "Q?",
-        options: ["A", "B"],
-        channel: "slack",
-        idempotencyKey: "idem-poll-concurrent",
-      } as never,
-      respond: secondRespond,
-      context,
-      req: { type: "req", id: "2", method: "poll" },
-      client: null as never,
-      isWebchatConnect: () => false,
-    });
-
-    await Promise.resolve();
-    expect(mocks.sendPoll).toHaveBeenCalledTimes(1);
-
-    pollDeferred.resolve({ messageId: "poll-concurrent", pollId: "poll-1" });
-    await Promise.all([firstRequest, secondRequest]);
-
-    expect(mocks.sendPoll).toHaveBeenCalledTimes(1);
-    expect(firstRespond).toHaveBeenCalledTimes(1);
-    expect(secondRespond).toHaveBeenCalledTimes(1);
-    const firstCall = firstRespondCall(firstRespond);
-    expect(firstCall?.[0]).toBe(true);
-    expect(firstCall?.[1]?.messageId).toBe("poll-concurrent");
-    expect(firstCall?.[1]?.pollId).toBe("poll-1");
-    expect(firstCall?.[1]?.runId).toBe("idem-poll-concurrent");
-    expect(firstCall?.[2]).toBeUndefined();
-    expect(firstCall?.[3]?.channel).toBe("slack");
-    expect(firstCall?.[3]?.cached).toBeUndefined();
-    const secondCall = firstRespondCall(secondRespond);
-    expect(secondCall?.[0]).toBe(true);
-    expect(secondCall?.[1]?.messageId).toBe("poll-concurrent");
-    expect(secondCall?.[1]?.pollId).toBe("poll-1");
-    expect(secondCall?.[1]?.runId).toBe("idem-poll-concurrent");
-    expect(secondCall?.[2]).toBeUndefined();
-    expect(secondCall?.[3]?.channel).toBe("slack");
-    expect(secondCall?.[3]?.cached).toBe(true);
   });
 
   it("accepts media-only sends without message", async () => {
@@ -1147,38 +1140,27 @@ describe("gateway send mirroring", () => {
     expect(response?.[3]?.channel).toBe("slack");
   });
 
-  it("forwards gateway client scopes into outbound delivery", async () => {
-    mockDeliverySuccess("m-scope");
-
+  it.each([
+    {
+      name: "forwards gateway client scopes into outbound delivery",
+      messageId: "m-scope",
+      idempotencyKey: "idem-scope",
+      scopes: ["operator.write"],
+    },
+    {
+      name: "forwards an empty gateway scope array into outbound delivery",
+      messageId: "m-empty-scope",
+      idempotencyKey: "idem-empty-scope",
+      scopes: [],
+    },
+  ])("$name", async ({ messageId, idempotencyKey, scopes }) => {
+    mockDeliverySuccess(messageId);
     await runSendWithClient(
-      {
-        to: "channel:C1",
-        message: "hi",
-        channel: "slack",
-        idempotencyKey: "idem-scope",
-      },
-      { connect: { scopes: ["operator.write"] } },
+      { to: "channel:C1", message: "hi", channel: "slack", idempotencyKey },
+      { connect: { scopes } },
     );
-
     expect(deliveryCall()?.channel).toBe("slack");
-    expect(deliveryCall()?.gatewayClientScopes).toEqual(["operator.write"]);
-  });
-
-  it("forwards an empty gateway scope array into outbound delivery", async () => {
-    mockDeliverySuccess("m-empty-scope");
-
-    await runSendWithClient(
-      {
-        to: "channel:C1",
-        message: "hi",
-        channel: "slack",
-        idempotencyKey: "idem-empty-scope",
-      },
-      { connect: { scopes: [] } },
-    );
-
-    expect(deliveryCall()?.channel).toBe("slack");
-    expect(deliveryCall()?.gatewayClientScopes).toEqual([]);
+    expect(deliveryCall()?.gatewayClientScopes).toEqual(scopes);
   });
 
   it("rejects empty sends when neither text nor media is present", async () => {
@@ -1307,44 +1289,34 @@ describe("gateway send mirroring", () => {
     expect(response?.[2]?.message).toContain("Channel is required");
   });
 
-  it("forwards gateway client scopes into outbound poll delivery", async () => {
+  it.each([
+    {
+      name: "forwards gateway client scopes into outbound poll delivery",
+      idempotencyKey: "idem-poll-scope",
+      scopes: ["operator.admin"],
+    },
+    {
+      name: "forwards an empty gateway scope array into outbound poll delivery",
+      idempotencyKey: "idem-poll-empty-scope",
+      scopes: [],
+    },
+  ])("$name", async ({ idempotencyKey, scopes }) => {
     await runPollWithClient(
       {
         to: "channel:C1",
         question: "Q?",
         options: ["A", "B"],
         channel: "slack",
-        idempotencyKey: "idem-poll-scope",
+        idempotencyKey,
       },
-      { connect: { scopes: ["operator.admin"] } },
+      { connect: { scopes } },
     );
-
     const call = pollCall();
     if (call.cfg === undefined) {
       throw new Error("Expected poll delivery config");
     }
     expect(call.to).toBe("resolved");
-    expect(call.gatewayClientScopes).toEqual(["operator.admin"]);
-  });
-
-  it("forwards an empty gateway scope array into outbound poll delivery", async () => {
-    await runPollWithClient(
-      {
-        to: "channel:C1",
-        question: "Q?",
-        options: ["A", "B"],
-        channel: "slack",
-        idempotencyKey: "idem-poll-empty-scope",
-      },
-      { connect: { scopes: [] } },
-    );
-
-    const call = pollCall();
-    if (call.cfg === undefined) {
-      throw new Error("Expected poll delivery config");
-    }
-    expect(call.to).toBe("resolved");
-    expect(call.gatewayClientScopes).toEqual([]);
+    expect(call.gatewayClientScopes).toEqual(scopes);
   });
 
   it("includes optional poll delivery identifiers in the gateway payload", async () => {
@@ -2173,76 +2145,27 @@ describe("gateway send mirroring", () => {
   });
 
   it("mirrors successful source-conversation message.action sends into the assistant transcript", async () => {
-    const telegramPlugin: ChannelPlugin = {
-      id: "telegram",
-      meta: {
-        id: "telegram",
-        label: "Telegram",
-        selectionLabel: "Telegram",
-        docsPath: "/channels/telegram",
-        blurb: "Telegram source send transcript mirror test plugin.",
-      },
-      capabilities: { chatTypes: ["direct"] },
-      config: {
-        listAccountIds: () => ["default"],
-        resolveAccount: () => ({ enabled: true }),
-        isConfigured: () => true,
-      },
-      actions: {
-        describeMessageTool: () => ({ actions: ["send"] }),
-        supportsAction: ({ action }) => action === "send",
-        handleAction: async () => jsonResult({ ok: true, messageId: "tg-1" }),
-      },
+    registerMessageActionPlugin({
+      messageId: "tg-1",
       threading: {
         resolveCurrentChannelId: ({ to, threadId }) =>
           threadId == null ? to : `${to}:topic:${threadId}`,
       },
-    };
-    mocks.getChannelPlugin.mockReturnValue(telegramPlugin);
-    setActivePluginRegistry(
-      createTestRegistry([{ pluginId: "telegram", source: "test", plugin: telegramPlugin }]),
-      "send-test-source-message-action-mirror",
-    );
+      registrySuffix: "source-message-action-mirror",
+    });
     mocks.dispatchChannelMessageAction.mockResolvedValueOnce(
       jsonResult({ ok: true, messageId: "tg-1" }),
     );
 
     const sessionKey = "agent:main:telegram:direct:chat-123";
-    const { respond } = await runMessageActionRequest(
-      {
-        channel: "telegram",
-        action: "send",
-        params: {
-          to: "chat-123",
-          message: "visible source reply",
-        },
-        sessionKey,
-        sessionId: "session-1",
-        agentId: "main",
-        idempotencyKey: "idem-source-message-action",
-      },
-      {
-        internal: {
-          agentRuntimeIdentity: {
-            kind: "agentRuntime",
-            agentId: "main",
-            sessionKey,
-            messageActionContext: {
-              expiresAtMs: Date.now() + 60_000,
-              sessionId: "session-1",
-              sourceReplyFinal: true,
-              sourceReplyToolCallId: "message-call-1",
-              toolContext: {
-                currentChannelProvider: "telegram",
-                currentChannelId: "chat-123",
-                currentMessageId: "telegram-message-1",
-                currentSourceTurnId: "channel-user:v1:telegram-message-1",
-              },
-            },
-          },
-        },
-      },
-    );
+    const { respond } = await runTelegramTerminalAction({
+      sessionId: "session-1",
+      idempotencyKey: "idem-source-message-action",
+      sourceTurnId: "channel-user:v1:telegram-message-1",
+      toolCallId: "message-call-1",
+      currentMessageId: "telegram-message-1",
+      message: "visible source reply",
+    });
 
     expect(firstRespondCall(respond)[0]).toBe(true);
     expect(mocks.appendAssistantMessageToSessionTranscript).toHaveBeenCalledWith({
@@ -2349,38 +2272,12 @@ describe("gateway send mirroring", () => {
   });
 
   it("rejects a terminal source send without tool-call correlation before dispatch", async () => {
-    const sessionKey = "agent:main:telegram:direct:chat-123";
-
-    const { respond } = await runMessageActionRequest(
-      {
-        channel: "telegram",
-        action: "send",
-        params: { to: "chat-123", message: "uncorrelated terminal" },
-        sessionKey,
-        sessionId: "session-uncorrelated-terminal",
-        agentId: "main",
-        idempotencyKey: "idem-uncorrelated-terminal",
-      },
-      {
-        internal: {
-          agentRuntimeIdentity: {
-            kind: "agentRuntime",
-            agentId: "main",
-            sessionKey,
-            messageActionContext: {
-              expiresAtMs: Date.now() + 60_000,
-              sessionId: "session-uncorrelated-terminal",
-              sourceReplyFinal: true,
-              toolContext: {
-                currentChannelProvider: "telegram",
-                currentChannelId: "chat-123",
-                currentSourceTurnId: "channel-user:v1:uncorrelated-terminal",
-              },
-            },
-          },
-        },
-      },
-    );
+    const { respond } = await runTelegramTerminalAction({
+      sessionId: "session-uncorrelated-terminal",
+      idempotencyKey: "idem-uncorrelated-terminal",
+      sourceTurnId: "channel-user:v1:uncorrelated-terminal",
+      message: "uncorrelated terminal",
+    });
 
     expect(firstRespondCall(respond)[0]).toBe(false);
     expect(firstRespondCall(respond)[2]?.message).toContain(
@@ -2398,39 +2295,13 @@ describe("gateway send mirroring", () => {
     mocks.completeRestartRecoveryTerminalDelivery.mockRejectedValueOnce(
       new Error("receipt store unavailable"),
     );
-    const sessionKey = "agent:main:telegram:direct:chat-123";
-
-    const { respond } = await runMessageActionRequest(
-      {
-        channel: "telegram",
-        action: "send",
-        params: { to: "chat-123", message: "delivered with pending receipt" },
-        sessionKey,
-        sessionId: "session-ambiguous-receipt",
-        agentId: "main",
-        idempotencyKey: "idem-ambiguous-receipt",
-      },
-      {
-        internal: {
-          agentRuntimeIdentity: {
-            kind: "agentRuntime",
-            agentId: "main",
-            sessionKey,
-            messageActionContext: {
-              expiresAtMs: Date.now() + 60_000,
-              sessionId: "session-ambiguous-receipt",
-              sourceReplyFinal: true,
-              sourceReplyToolCallId: "message-call-ambiguous",
-              toolContext: {
-                currentChannelProvider: "telegram",
-                currentChannelId: "chat-123",
-                currentSourceTurnId: "channel-user:v1:ambiguous-receipt",
-              },
-            },
-          },
-        },
-      },
-    );
+    const { respond } = await runTelegramTerminalAction({
+      sessionId: "session-ambiguous-receipt",
+      idempotencyKey: "idem-ambiguous-receipt",
+      sourceTurnId: "channel-user:v1:ambiguous-receipt",
+      toolCallId: "message-call-ambiguous",
+      message: "delivered with pending receipt",
+    });
 
     expect(firstRespondCall(respond)[0]).toBe(true);
     expect(mocks.cancelRestartRecoveryTerminalDelivery).not.toHaveBeenCalled();
@@ -2439,39 +2310,13 @@ describe("gateway send mirroring", () => {
 
   it("blocks a repeated terminal send before provider dispatch", async () => {
     mocks.beginRestartRecoveryTerminalDelivery.mockResolvedValueOnce("blocked");
-    const sessionKey = "agent:main:telegram:direct:chat-123";
-
-    const { respond } = await runMessageActionRequest(
-      {
-        channel: "telegram",
-        action: "send",
-        params: { to: "chat-123", message: "duplicate terminal" },
-        sessionKey,
-        sessionId: "session-duplicate-terminal",
-        agentId: "main",
-        idempotencyKey: "idem-duplicate-terminal",
-      },
-      {
-        internal: {
-          agentRuntimeIdentity: {
-            kind: "agentRuntime",
-            agentId: "main",
-            sessionKey,
-            messageActionContext: {
-              expiresAtMs: Date.now() + 60_000,
-              sessionId: "session-duplicate-terminal",
-              sourceReplyFinal: true,
-              sourceReplyToolCallId: "message-call-duplicate",
-              toolContext: {
-                currentChannelProvider: "telegram",
-                currentChannelId: "chat-123",
-                currentSourceTurnId: "channel-user:v1:duplicate-terminal",
-              },
-            },
-          },
-        },
-      },
-    );
+    const { respond } = await runTelegramTerminalAction({
+      sessionId: "session-duplicate-terminal",
+      idempotencyKey: "idem-duplicate-terminal",
+      sourceTurnId: "channel-user:v1:duplicate-terminal",
+      toolCallId: "message-call-duplicate",
+      message: "duplicate terminal",
+    });
 
     expect(firstRespondCall(respond)[0]).toBe(false);
     expect(mocks.dispatchChannelMessageAction).not.toHaveBeenCalled();
@@ -2482,39 +2327,13 @@ describe("gateway send mirroring", () => {
     mocks.dispatchChannelMessageAction.mockResolvedValueOnce(
       jsonResult({ ok: true, messageId: "tg-live-unclaimed" }),
     );
-    const sessionKey = "agent:main:telegram:direct:chat-123";
-
-    const { respond } = await runMessageActionRequest(
-      {
-        channel: "telegram",
-        action: "send",
-        params: { to: "chat-123", message: "live terminal" },
-        sessionKey,
-        sessionId: "session-live-unclaimed",
-        agentId: "main",
-        idempotencyKey: "idem-live-unclaimed",
-      },
-      {
-        internal: {
-          agentRuntimeIdentity: {
-            kind: "agentRuntime",
-            agentId: "main",
-            sessionKey,
-            messageActionContext: {
-              expiresAtMs: Date.now() + 60_000,
-              sessionId: "session-live-unclaimed",
-              sourceReplyFinal: true,
-              sourceReplyToolCallId: "message-call-live-unclaimed",
-              toolContext: {
-                currentChannelProvider: "telegram",
-                currentChannelId: "chat-123",
-                currentSourceTurnId: "channel-user:v1:live-unclaimed",
-              },
-            },
-          },
-        },
-      },
-    );
+    const { respond } = await runTelegramTerminalAction({
+      sessionId: "session-live-unclaimed",
+      idempotencyKey: "idem-live-unclaimed",
+      sourceTurnId: "channel-user:v1:live-unclaimed",
+      toolCallId: "message-call-live-unclaimed",
+      message: "live terminal",
+    });
 
     expect(firstRespondCall(respond)[0]).toBe(true);
     expect(mocks.dispatchChannelMessageAction).toHaveBeenCalledOnce();
@@ -2533,37 +2352,13 @@ describe("gateway send mirroring", () => {
     });
     const sessionKey = "agent:main:telegram:direct:chat-123";
 
-    const { respond } = await runMessageActionRequest(
-      {
-        channel: "telegram",
-        action: "send",
-        params: { to: "chat-123", message: "delivered but unrecorded" },
-        sessionKey,
-        sessionId: "session-2",
-        agentId: "main",
-        idempotencyKey: "idem-source-message-action-2",
-      },
-      {
-        internal: {
-          agentRuntimeIdentity: {
-            kind: "agentRuntime",
-            agentId: "main",
-            sessionKey,
-            messageActionContext: {
-              expiresAtMs: Date.now() + 60_000,
-              sessionId: "session-2",
-              sourceReplyFinal: true,
-              sourceReplyToolCallId: "message-call-2",
-              toolContext: {
-                currentChannelProvider: "telegram",
-                currentChannelId: "chat-123",
-                currentSourceTurnId: "channel-user:v1:telegram-message-2",
-              },
-            },
-          },
-        },
-      },
-    );
+    const { respond } = await runTelegramTerminalAction({
+      sessionId: "session-2",
+      idempotencyKey: "idem-source-message-action-2",
+      sourceTurnId: "channel-user:v1:telegram-message-2",
+      toolCallId: "message-call-2",
+      message: "delivered but unrecorded",
+    });
 
     expect(firstRespondCall(respond)[0]).toBe(true);
     expect(mocks.completeRestartRecoveryTerminalDelivery).toHaveBeenCalledWith(
@@ -2581,40 +2376,13 @@ describe("gateway send mirroring", () => {
     );
     const sessionKey = "agent:main:telegram:direct:chat-123";
 
-    const { respond } = await runMessageActionRequest(
-      {
-        channel: "telegram",
-        action: "send",
-        params: {
-          to: "chat-123",
-          presentation: { blocks: [{ type: "divider" }] },
-        },
-        sessionKey,
-        sessionId: "session-unmirrorable",
-        agentId: "main",
-        idempotencyKey: "idem-unmirrorable-source-message-action",
-      },
-      {
-        internal: {
-          agentRuntimeIdentity: {
-            kind: "agentRuntime",
-            agentId: "main",
-            sessionKey,
-            messageActionContext: {
-              expiresAtMs: Date.now() + 60_000,
-              sessionId: "session-unmirrorable",
-              sourceReplyFinal: true,
-              sourceReplyToolCallId: "message-call-unmirrorable",
-              toolContext: {
-                currentChannelProvider: "telegram",
-                currentChannelId: "chat-123",
-                currentSourceTurnId: "channel-user:v1:telegram-message-unmirrorable",
-              },
-            },
-          },
-        },
-      },
-    );
+    const { respond } = await runTelegramTerminalAction({
+      sessionId: "session-unmirrorable",
+      idempotencyKey: "idem-unmirrorable-source-message-action",
+      sourceTurnId: "channel-user:v1:telegram-message-unmirrorable",
+      toolCallId: "message-call-unmirrorable",
+      presentation: { blocks: [{ type: "divider" }] },
+    });
 
     expect(firstRespondCall(respond)[0]).toBe(true);
     expect(mocks.appendAssistantMessageToSessionTranscript).not.toHaveBeenCalled();
@@ -2633,38 +2401,15 @@ describe("gateway send mirroring", () => {
     );
     const sessionKey = "agent:main:telegram:group:chat-123:topic:77";
 
-    const { respond } = await runMessageActionRequest(
-      {
-        channel: "telegram",
-        action: "send",
-        params: { to: "chat-123", message: "diverted terminal" },
-        sessionKey,
-        sessionId: "session-diverted",
-        agentId: "main",
-        idempotencyKey: "idem-diverted-terminal",
-      },
-      {
-        internal: {
-          agentRuntimeIdentity: {
-            kind: "agentRuntime",
-            agentId: "main",
-            sessionKey,
-            messageActionContext: {
-              expiresAtMs: Date.now() + 60_000,
-              sessionId: "session-diverted",
-              sourceReplyFinal: true,
-              sourceReplyToolCallId: "message-call-diverted",
-              toolContext: {
-                currentChannelProvider: "telegram",
-                currentChannelId: "chat-123",
-                currentThreadTs: "77",
-                currentSourceTurnId: "channel-user:v1:diverted-terminal",
-              },
-            },
-          },
-        },
-      },
-    );
+    const { respond } = await runTelegramTerminalAction({
+      sessionKey,
+      sessionId: "session-diverted",
+      idempotencyKey: "idem-diverted-terminal",
+      sourceTurnId: "channel-user:v1:diverted-terminal",
+      toolCallId: "message-call-diverted",
+      currentThreadTs: "77",
+      message: "diverted terminal",
+    });
 
     expect(firstRespondCall(respond)[0]).toBe(true);
     expect(mocks.beginRestartRecoveryTerminalDelivery).toHaveBeenCalledOnce();
@@ -2674,38 +2419,17 @@ describe("gateway send mirroring", () => {
   });
 
   it("mirrors a Slack DM send after target resolution strips its user prefix", async () => {
-    const slackPlugin: ChannelPlugin = {
+    registerMessageActionPlugin({
       id: "slack",
-      meta: {
-        id: "slack",
-        label: "Slack",
-        selectionLabel: "Slack",
-        docsPath: "/channels/slack",
-        blurb: "Slack DM transcript mirror test plugin.",
-      },
-      capabilities: { chatTypes: ["direct"] },
-      config: {
-        listAccountIds: () => ["default"],
-        resolveAccount: () => ({ enabled: true }),
-        isConfigured: () => true,
-      },
-      actions: {
-        describeMessageTool: () => ({ actions: ["send"] }),
-        supportsAction: ({ action }) => action === "send",
-        handleAction: async () => jsonResult({ ok: true, messageId: "slack-1" }),
-      },
+      messageId: "slack-1",
       threading: {
         threadAddressing: "message",
         matchesToolContextTarget: ({ target, toolContext }) =>
           target.toLowerCase() ===
           toolContext.currentMessagingTarget?.replace(/^user:/i, "").toLowerCase(),
       },
-    };
-    mocks.getChannelPlugin.mockReturnValue(slackPlugin);
-    setActivePluginRegistry(
-      createTestRegistry([{ pluginId: "slack", source: "test", plugin: slackPlugin }]),
-      "send-test-slack-dm-source-message-action-mirror",
-    );
+      registrySuffix: "slack-dm-source-message-action-mirror",
+    });
     mocks.dispatchChannelMessageAction.mockImplementationOnce(async ({ params }) => {
       params.to = "U123";
       return jsonResult({
@@ -2918,33 +2642,11 @@ describe("gateway send mirroring", () => {
   });
 
   it("waits for source transcript mirroring before responding to message.action", async () => {
-    const telegramPlugin: ChannelPlugin = {
-      id: "telegram",
-      meta: {
-        id: "telegram",
-        label: "Telegram",
-        selectionLabel: "Telegram",
-        docsPath: "/channels/telegram",
-        blurb: "Telegram async source send transcript mirror test plugin.",
-      },
-      capabilities: { chatTypes: ["direct"] },
-      config: {
-        listAccountIds: () => ["default"],
-        resolveAccount: () => ({ enabled: true }),
-        isConfigured: () => true,
-      },
-      actions: {
-        describeMessageTool: () => ({ actions: ["send"] }),
-        supportsAction: ({ action }) => action === "send",
-        handleAction: async () => jsonResult({ ok: true, messageId: "tg-async-1" }),
-      },
-    };
     const mirrorDeferred = createDeferred<SessionTranscriptAppendResult>();
-    mocks.getChannelPlugin.mockReturnValue(telegramPlugin);
-    setActivePluginRegistry(
-      createTestRegistry([{ pluginId: "telegram", source: "test", plugin: telegramPlugin }]),
-      "send-test-source-message-action-async-mirror",
-    );
+    registerMessageActionPlugin({
+      messageId: "tg-async-1",
+      registrySuffix: "source-message-action-async-mirror",
+    });
     mocks.dispatchChannelMessageAction.mockResolvedValueOnce(
       jsonResult({ ok: true, messageId: "tg-async-1" }),
     );
@@ -2989,33 +2691,11 @@ describe("gateway send mirroring", () => {
   });
 
   it("preserves source transcript mirror order before message.action responses", async () => {
-    const telegramPlugin: ChannelPlugin = {
-      id: "telegram",
-      meta: {
-        id: "telegram",
-        label: "Telegram",
-        selectionLabel: "Telegram",
-        docsPath: "/channels/telegram",
-        blurb: "Telegram ordered async source send transcript mirror test plugin.",
-      },
-      capabilities: { chatTypes: ["direct"] },
-      config: {
-        listAccountIds: () => ["default"],
-        resolveAccount: () => ({ enabled: true }),
-        isConfigured: () => true,
-      },
-      actions: {
-        describeMessageTool: () => ({ actions: ["send"] }),
-        supportsAction: ({ action }) => action === "send",
-        handleAction: async () => jsonResult({ ok: true, messageId: "tg-ordered" }),
-      },
-    };
     const firstMirrorDeferred = createDeferred<SessionTranscriptAppendResult>();
-    mocks.getChannelPlugin.mockReturnValue(telegramPlugin);
-    setActivePluginRegistry(
-      createTestRegistry([{ pluginId: "telegram", source: "test", plugin: telegramPlugin }]),
-      "send-test-source-message-action-ordered-async-mirror",
-    );
+    registerMessageActionPlugin({
+      messageId: "tg-ordered",
+      registrySuffix: "source-message-action-ordered-async-mirror",
+    });
     mocks.dispatchChannelMessageAction.mockResolvedValue(
       jsonResult({ ok: true, messageId: "tg-ordered" }),
     );
@@ -3099,36 +2779,14 @@ describe("gateway send mirroring", () => {
   });
 
   it("mirrors presentation-only source-conversation message.action sends", async () => {
-    const telegramPlugin: ChannelPlugin = {
-      id: "telegram",
-      meta: {
-        id: "telegram",
-        label: "Telegram",
-        selectionLabel: "Telegram",
-        docsPath: "/channels/telegram",
-        blurb: "Telegram source send rich transcript mirror test plugin.",
-      },
-      capabilities: { chatTypes: ["direct"] },
-      config: {
-        listAccountIds: () => ["default"],
-        resolveAccount: () => ({ enabled: true }),
-        isConfigured: () => true,
-      },
-      actions: {
-        describeMessageTool: () => ({ actions: ["send"] }),
-        supportsAction: ({ action }) => action === "send",
-        handleAction: async () => jsonResult({ ok: true, messageId: "tg-rich-1" }),
-      },
+    registerMessageActionPlugin({
+      messageId: "tg-rich-1",
       threading: {
         resolveCurrentChannelId: ({ to, threadId }) =>
           threadId == null ? to : `${to}:topic:${threadId}`,
       },
-    };
-    mocks.getChannelPlugin.mockReturnValue(telegramPlugin);
-    setActivePluginRegistry(
-      createTestRegistry([{ pluginId: "telegram", source: "test", plugin: telegramPlugin }]),
-      "send-test-rich-source-message-action-mirror",
-    );
+      registrySuffix: "rich-source-message-action-mirror",
+    });
     mocks.dispatchChannelMessageAction.mockResolvedValueOnce(
       jsonResult({ ok: true, messageId: "tg-rich-1" }),
     );
@@ -3173,32 +2831,10 @@ describe("gateway send mirroring", () => {
   });
 
   it("mirrors title-only source-conversation presentation sends", async () => {
-    const telegramPlugin: ChannelPlugin = {
-      id: "telegram",
-      meta: {
-        id: "telegram",
-        label: "Telegram",
-        selectionLabel: "Telegram",
-        docsPath: "/channels/telegram",
-        blurb: "Telegram source send title-only transcript mirror test plugin.",
-      },
-      capabilities: { chatTypes: ["direct"] },
-      config: {
-        listAccountIds: () => ["default"],
-        resolveAccount: () => ({ enabled: true }),
-        isConfigured: () => true,
-      },
-      actions: {
-        describeMessageTool: () => ({ actions: ["send"] }),
-        supportsAction: ({ action }) => action === "send",
-        handleAction: async () => jsonResult({ ok: true, messageId: "tg-title-1" }),
-      },
-    };
-    mocks.getChannelPlugin.mockReturnValue(telegramPlugin);
-    setActivePluginRegistry(
-      createTestRegistry([{ pluginId: "telegram", source: "test", plugin: telegramPlugin }]),
-      "send-test-title-only-source-message-action-mirror",
-    );
+    registerMessageActionPlugin({
+      messageId: "tg-title-1",
+      registrySuffix: "title-only-source-message-action-mirror",
+    });
     mocks.dispatchChannelMessageAction.mockResolvedValueOnce(
       jsonResult({ ok: true, messageId: "tg-title-1" }),
     );
@@ -3233,36 +2869,15 @@ describe("gateway send mirroring", () => {
   });
 
   it("mirrors auto-threaded Telegram source sends into the topic transcript", async () => {
-    const telegramTopicPlugin: ChannelPlugin = {
-      id: "telegram",
-      meta: {
-        id: "telegram",
-        label: "Telegram",
-        selectionLabel: "Telegram",
-        docsPath: "/channels/telegram",
-        blurb: "Telegram topic source send transcript mirror test plugin.",
-      },
-      capabilities: { chatTypes: ["group"] },
-      config: {
-        listAccountIds: () => ["default"],
-        resolveAccount: () => ({ enabled: true }),
-        isConfigured: () => true,
-      },
-      actions: {
-        describeMessageTool: () => ({ actions: ["send"] }),
-        supportsAction: ({ action }) => action === "send",
-        handleAction: async () => jsonResult({ ok: true, messageId: "tg-topic-1" }),
-      },
+    registerMessageActionPlugin({
+      messageId: "tg-topic-1",
+      chatType: "group",
       threading: {
         resolveCurrentChannelId: ({ to, threadId }) =>
           threadId == null ? to : `${to}:topic:${threadId}`,
       },
-    };
-    mocks.getChannelPlugin.mockReturnValue(telegramTopicPlugin);
-    setActivePluginRegistry(
-      createTestRegistry([{ pluginId: "telegram", source: "test", plugin: telegramTopicPlugin }]),
-      "send-test-topic-source-message-action-mirror",
-    );
+      registrySuffix: "topic-source-message-action-mirror",
+    });
     mocks.dispatchChannelMessageAction.mockResolvedValueOnce(
       jsonResult({ ok: true, messageId: "tg-topic-1" }),
     );
@@ -3297,36 +2912,15 @@ describe("gateway send mirroring", () => {
   });
 
   it("does not mirror topic context when delivery params target the parent chat", async () => {
-    const telegramTopicPlugin: ChannelPlugin = {
-      id: "telegram",
-      meta: {
-        id: "telegram",
-        label: "Telegram",
-        selectionLabel: "Telegram",
-        docsPath: "/channels/telegram",
-        blurb: "Telegram parent send transcript mirror test plugin.",
-      },
-      capabilities: { chatTypes: ["group"] },
-      config: {
-        listAccountIds: () => ["default"],
-        resolveAccount: () => ({ enabled: true }),
-        isConfigured: () => true,
-      },
-      actions: {
-        describeMessageTool: () => ({ actions: ["send"] }),
-        supportsAction: ({ action }) => action === "send",
-        handleAction: async () => jsonResult({ ok: true, messageId: "tg-parent-1" }),
-      },
+    registerMessageActionPlugin({
+      messageId: "tg-parent-1",
+      chatType: "group",
       threading: {
         resolveCurrentChannelId: ({ to, threadId }) =>
           threadId == null ? to : `${to}:topic:${threadId}`,
       },
-    };
-    mocks.getChannelPlugin.mockReturnValue(telegramTopicPlugin);
-    setActivePluginRegistry(
-      createTestRegistry([{ pluginId: "telegram", source: "test", plugin: telegramTopicPlugin }]),
-      "send-test-topic-context-parent-message-action-mirror",
-    );
+      registrySuffix: "topic-context-parent-message-action-mirror",
+    });
     mocks.dispatchChannelMessageAction.mockResolvedValueOnce(
       jsonResult({ ok: true, messageId: "tg-parent-1" }),
     );
@@ -3467,32 +3061,10 @@ describe("gateway send mirroring", () => {
   });
 
   it("passes agent-scoped media roots to gateway message actions", async () => {
-    const mediaActionPlugin: ChannelPlugin = {
-      id: "telegram",
-      meta: {
-        id: "telegram",
-        label: "Telegram",
-        selectionLabel: "Telegram",
-        docsPath: "/channels/telegram",
-        blurb: "Telegram media action dispatch test plugin.",
-      },
-      capabilities: { chatTypes: ["direct"] },
-      config: {
-        listAccountIds: () => ["default"],
-        resolveAccount: () => ({ enabled: true }),
-        isConfigured: () => true,
-      },
-      actions: {
-        describeMessageTool: () => ({ actions: ["sendAttachment"] }),
-        supportsAction: ({ action }) => action === "sendAttachment",
-        handleAction: async () => jsonResult({ ok: true }),
-      },
-    };
-    mocks.getChannelPlugin.mockReturnValue(mediaActionPlugin);
-    setActivePluginRegistry(
-      createTestRegistry([{ pluginId: "telegram", source: "test", plugin: mediaActionPlugin }]),
-      "send-test-message-action-media-roots",
-    );
+    registerMessageActionPlugin({
+      action: "sendAttachment",
+      registrySuffix: "message-action-media-roots",
+    });
 
     const { respond } = await runMessageActionRequest(
       {
@@ -3512,32 +3084,7 @@ describe("gateway send mirroring", () => {
   });
 
   it("materializes buffer-only message.action sends on the gateway before plugin dispatch", async () => {
-    const mediaActionPlugin: ChannelPlugin = {
-      id: "telegram",
-      meta: {
-        id: "telegram",
-        label: "Telegram",
-        selectionLabel: "Telegram",
-        docsPath: "/channels/telegram",
-        blurb: "Telegram media action dispatch test plugin.",
-      },
-      capabilities: { chatTypes: ["direct"] },
-      config: {
-        listAccountIds: () => ["default"],
-        resolveAccount: () => ({ enabled: true }),
-        isConfigured: () => true,
-      },
-      actions: {
-        describeMessageTool: () => ({ actions: ["send"] }),
-        supportsAction: ({ action }) => action === "send",
-        handleAction: async () => jsonResult({ ok: true }),
-      },
-    };
-    mocks.getChannelPlugin.mockReturnValue(mediaActionPlugin);
-    setActivePluginRegistry(
-      createTestRegistry([{ pluginId: "telegram", source: "test", plugin: mediaActionPlugin }]),
-      "send-test-message-action-buffer-materialize",
-    );
+    registerMessageActionPlugin({ registrySuffix: "message-action-buffer-materialize" });
 
     await withTempOpenClawStateDir(async () => {
       const { respond } = await runMessageActionRequest(

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -7,7 +7,6 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { expectDefined } from "@openclaw/normalization-core";
-import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { GATEWAY_CLIENT_IDS } from "../../../packages/gateway-protocol/src/client-info.js";
 import { validateExecApprovalRequestParams } from "../../../packages/gateway-protocol/src/index.js";
@@ -1061,42 +1060,172 @@ describe("sanitizeChatHistoryMessages", () => {
 });
 
 describe("projectRecentChatDisplayMessages", () => {
-  it("projects empty assistant error turns as a generic safe failure", () => {
-    const result = projectRecentChatDisplayMessages([
-      {
-        role: "assistant",
-        content: [],
-        stopReason: "error",
-        errorMessage: "private upstream at secret.internal.example failed",
-        timestamp: 1,
+  const safeFailureContent = [
+    { type: "text", text: "The agent run failed before producing a reply." },
+  ];
+  const privateError = "private upstream at secret.internal.example failed";
+  const displayErrorCases: Array<{
+    name: string;
+    message: Record<string, unknown>;
+    content: Array<Record<string, unknown>>;
+    visibleText?: string;
+  }> = [
+    {
+      name: "projects empty assistant error turns as a generic safe failure",
+      message: { content: [], errorMessage: privateError },
+      content: safeFailureContent,
+    },
+    {
+      name: "projects empty text-block assistant errors as a generic safe failure",
+      message: { content: [{ type: "text", text: "" }], errorMessage: "Connection error." },
+      content: safeFailureContent,
+    },
+    {
+      name: "preserves visible output_text from a failed assistant turn",
+      message: {
+        content: [{ type: "output_text", text: "A partial reply before the run failed." }],
+        errorMessage: "Connection error.",
       },
-    ]);
+      content: [{ type: "output_text", text: "A partial reply before the run failed." }],
+    },
+    {
+      name: "projects thinking-only assistant errors as a generic safe failure",
+      message: {
+        content: [{ type: "thinking", thinking: "private upstream details" }],
+        errorMessage: "Connection error.",
+      },
+      content: safeFailureContent,
+    },
+    {
+      name: "projects reasoning-text-only assistant errors as a generic safe failure",
+      message: {
+        content: [{ type: "reasoning", text: "private upstream details" }],
+        errorMessage: privateError,
+      },
+      content: safeFailureContent,
+    },
+    {
+      name: "projects redacted-thinking-only assistant errors as a generic safe failure",
+      message: {
+        content: [{ type: "redacted_thinking", data: "private upstream details" }],
+        errorMessage: privateError,
+      },
+      content: safeFailureContent,
+    },
+    {
+      name: "projects commentary-phase assistant errors as a visible generic safe failure",
+      message: {
+        phase: "commentary",
+        content: [],
+        text: "private upstream details",
+        errorMessage: "Connection error.",
+      },
+      content: safeFailureContent,
+    },
+    {
+      name: "leaves legacy top-level assistant error text unchanged",
+      message: {
+        content: [],
+        text: "A real reply before the run failed.",
+        errorMessage: "Connection error.",
+      },
+      content: [],
+      visibleText: "A real reply before the run failed.",
+    },
+    {
+      name: "preserves partial error replies without hidden reasoning or diagnostics",
+      message: {
+        content: [
+          { type: "thinking", thinking: "private upstream reasoning" },
+          { type: "text", text: "A partial reply before the run failed." },
+        ],
+        errorMessage: privateError,
+        diagnostics: { provider: "private-provider" },
+      },
+      content: [{ type: "text", text: "A partial reply before the run failed." }],
+    },
+    {
+      name: "projects suppressed error text accompanied by hidden reasoning",
+      message: {
+        content: [
+          { type: "thinking", thinking: "private upstream details" },
+          { type: "text", text: "NO_REPLY" },
+        ],
+        errorMessage: privateError,
+      },
+      content: safeFailureContent,
+    },
+    {
+      name: "projects signature-only commentary errors as a visible generic safe failure",
+      message: {
+        content: [
+          {
+            type: "text",
+            text: "private upstream details",
+            textSignature: JSON.stringify({ v: 1, id: "msg-commentary", phase: "commentary" }),
+          },
+        ],
+        errorMessage: privateError,
+        errorCode: "private_error_code",
+        errorType: "private_error_type",
+        errorBody: "private response body from secret.internal.example",
+        diagnostics: [
+          {
+            type: "provider-error",
+            timestamp: 1,
+            error: { message: "private diagnostic from secret.internal.example" },
+          },
+        ],
+      },
+      content: safeFailureContent,
+    },
+    {
+      name: "preserves attachment-only assistant errors without private diagnostics",
+      message: {
+        content: [
+          { type: "attachment", name: "report.txt", url: "https://example.test/report.txt" },
+        ],
+        errorMessage: privateError,
+        diagnostics: { provider: "private-provider" },
+      },
+      content: [{ type: "attachment", name: "report.txt", url: "https://example.test/report.txt" }],
+    },
+    {
+      name: "preserves tool-bearing assistant errors without hidden reasoning or diagnostics",
+      message: {
+        content: [
+          { type: "thinking", thinking: "private upstream reasoning" },
+          { type: "text", text: "I read the requested file before the run failed." },
+          {
+            type: "toolCall",
+            id: "call-1",
+            name: "read",
+            arguments: { path: "README.md" },
+          },
+        ],
+        errorMessage: privateError,
+        errorBody: "private response body",
+      },
+      content: [{ type: "text", text: "I read the requested file before the run failed." }],
+    },
+  ];
 
+  it.each(displayErrorCases)("$name", ({ message, content, visibleText }) => {
+    const result = projectRecentChatDisplayMessages([
+      { role: "assistant", stopReason: "error", timestamp: 1, ...message },
+    ]);
     expect(result).toEqual([
       {
         role: "assistant",
-        content: [{ type: "text", text: "The agent run failed before producing a reply." }],
+        content,
         stopReason: "error",
         timestamp: 1,
+        ...(visibleText === undefined ? {} : { text: visibleText }),
       },
     ]);
     expect(JSON.stringify(result)).not.toContain("secret.internal.example");
-  });
-
-  it("projects empty text-block assistant errors as a generic safe failure", () => {
-    const result = projectRecentChatDisplayMessages([
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "" }],
-        stopReason: "error",
-        errorMessage: "Connection error.",
-        timestamp: 1,
-      },
-    ]);
-
-    expect(result[0]?.content).toEqual([
-      { type: "text", text: "The agent run failed before producing a reply." },
-    ]);
+    expect(JSON.stringify(result)).not.toContain("private upstream");
+    expect(JSON.stringify(result)).not.toContain("private_error");
   });
 
   it.each([
@@ -1118,136 +1247,6 @@ describe("projectRecentChatDisplayMessages", () => {
     expect(result[0]?.content).toEqual([
       { type: "text", text: "The agent run failed before producing a reply." },
     ]);
-  });
-
-  it("preserves visible output_text from a failed assistant turn", () => {
-    const result = projectRecentChatDisplayMessages([
-      {
-        role: "assistant",
-        content: [{ type: "output_text", text: "A partial reply before the run failed." }],
-        stopReason: "error",
-        errorMessage: "Connection error.",
-        timestamp: 1,
-      },
-    ]);
-
-    expect(result[0]?.content).toEqual([
-      { type: "output_text", text: "A partial reply before the run failed." },
-    ]);
-  });
-
-  it("projects thinking-only assistant errors as a generic safe failure", () => {
-    const result = projectRecentChatDisplayMessages([
-      {
-        role: "assistant",
-        content: [{ type: "thinking", thinking: "private upstream details" }],
-        stopReason: "error",
-        errorMessage: "Connection error.",
-        timestamp: 1,
-      },
-    ]);
-
-    expect(result[0]?.content).toEqual([
-      { type: "text", text: "The agent run failed before producing a reply." },
-    ]);
-  });
-
-  it("projects reasoning-text-only assistant errors as a generic safe failure", () => {
-    const result = projectRecentChatDisplayMessages([
-      {
-        role: "assistant",
-        content: [{ type: "reasoning", text: "private upstream details" }],
-        stopReason: "error",
-        errorMessage: "private upstream at secret.internal.example failed",
-        timestamp: 1,
-      },
-    ]);
-
-    expect(result).toEqual([
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "The agent run failed before producing a reply." }],
-        stopReason: "error",
-        timestamp: 1,
-      },
-    ]);
-    expect(JSON.stringify(result)).not.toContain("secret.internal.example");
-  });
-
-  it("projects redacted-thinking-only assistant errors as a generic safe failure", () => {
-    const result = projectRecentChatDisplayMessages([
-      {
-        role: "assistant",
-        content: [{ type: "redacted_thinking", data: "private upstream details" }],
-        stopReason: "error",
-        errorMessage: "private upstream at secret.internal.example failed",
-        timestamp: 1,
-      },
-    ]);
-
-    expect(result[0]?.content).toEqual([
-      { type: "text", text: "The agent run failed before producing a reply." },
-    ]);
-    expect(JSON.stringify(result[0]?.content)).not.toContain("secret.internal.example");
-  });
-
-  it("projects commentary-phase assistant errors as a visible generic safe failure", () => {
-    const result = projectRecentChatDisplayMessages([
-      {
-        role: "assistant",
-        phase: "commentary",
-        content: [],
-        text: "private upstream details",
-        stopReason: "error",
-        errorMessage: "Connection error.",
-        timestamp: 1,
-      },
-    ]);
-
-    expect(result[0]).not.toHaveProperty("phase");
-    expect(result[0]?.content).toEqual([
-      { type: "text", text: "The agent run failed before producing a reply." },
-    ]);
-    expect(result[0]).not.toHaveProperty("text");
-  });
-
-  it("leaves legacy top-level assistant error text unchanged", () => {
-    const result = projectRecentChatDisplayMessages([
-      {
-        role: "assistant",
-        content: [],
-        text: "A real reply before the run failed.",
-        stopReason: "error",
-        errorMessage: "Connection error.",
-        timestamp: 1,
-      },
-    ]);
-
-    expect(result[0]?.text).toBe("A real reply before the run failed.");
-    expect(result[0]).not.toHaveProperty("errorMessage");
-  });
-
-  it("preserves partial error replies without hidden reasoning or diagnostics", () => {
-    const result = projectRecentChatDisplayMessages([
-      {
-        role: "assistant",
-        content: [
-          { type: "thinking", thinking: "private upstream reasoning" },
-          { type: "text", text: "A partial reply before the run failed." },
-        ],
-        stopReason: "error",
-        errorMessage: "private upstream at secret.internal.example failed",
-        diagnostics: { provider: "private-provider" },
-        timestamp: 1,
-      },
-    ]);
-
-    expect(result[0]?.content).toEqual([
-      { type: "text", text: "A partial reply before the run failed." },
-    ]);
-    expect(result[0]).not.toHaveProperty("diagnostics");
-    expect(result[0]).not.toHaveProperty("errorMessage");
-    expect(JSON.stringify(result)).not.toContain("private upstream");
   });
 
   it.each(["[[reply_to_current]]", "NO_REPLY", STREAM_ERROR_FALLBACK_TEXT])(
@@ -1275,32 +1274,6 @@ describe("projectRecentChatDisplayMessages", () => {
     },
   );
 
-  it("projects suppressed error text accompanied by hidden reasoning", () => {
-    const result = projectRecentChatDisplayMessages([
-      {
-        role: "assistant",
-        content: [
-          { type: "thinking", thinking: "private upstream details" },
-          { type: "text", text: "NO_REPLY" },
-        ],
-        stopReason: "error",
-        errorMessage: "private upstream at secret.internal.example failed",
-        timestamp: 1,
-      },
-    ]);
-
-    expect(result).toEqual([
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "The agent run failed before producing a reply." }],
-        stopReason: "error",
-        timestamp: 1,
-      },
-    ]);
-    expect(JSON.stringify(result)).not.toContain("secret.internal.example");
-    expect(JSON.stringify(result)).not.toContain("private upstream details");
-  });
-
   it.each([undefined, ""])(
     "projects repaired stream errors with errorMessage %j as a generic safe failure",
     (errorMessage) => {
@@ -1326,101 +1299,6 @@ describe("projectRecentChatDisplayMessages", () => {
       expect(JSON.stringify(result)).not.toContain("secret.internal.example");
     },
   );
-
-  it("projects signature-only commentary errors as a visible generic safe failure", () => {
-    const result = projectRecentChatDisplayMessages([
-      {
-        role: "assistant",
-        content: [
-          {
-            type: "text",
-            text: "private upstream details",
-            textSignature: JSON.stringify({
-              v: 1,
-              id: "msg-commentary",
-              phase: "commentary",
-            }),
-          },
-        ],
-        stopReason: "error",
-        errorMessage: "private upstream at secret.internal.example failed",
-        errorCode: "private_error_code",
-        errorType: "private_error_type",
-        errorBody: "private response body from secret.internal.example",
-        diagnostics: [
-          {
-            type: "provider-error",
-            timestamp: 1,
-            error: { message: "private diagnostic from secret.internal.example" },
-          },
-        ],
-        timestamp: 1,
-      },
-    ]);
-
-    expect(result).toEqual([
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "The agent run failed before producing a reply." }],
-        stopReason: "error",
-        timestamp: 1,
-      },
-    ]);
-    expect(JSON.stringify(result)).not.toContain("secret.internal.example");
-    expect(JSON.stringify(result)).not.toContain("private_error");
-  });
-
-  it("preserves attachment-only assistant errors without private diagnostics", () => {
-    const attachment = {
-      type: "attachment",
-      name: "report.txt",
-      url: "https://example.test/report.txt",
-    };
-    const result = projectRecentChatDisplayMessages([
-      {
-        role: "assistant",
-        content: [attachment],
-        stopReason: "error",
-        errorMessage: "private upstream at secret.internal.example failed",
-        diagnostics: { provider: "private-provider" },
-        timestamp: 1,
-      },
-    ]);
-
-    expect(result[0]?.content).toEqual([attachment]);
-    expect(result[0]).not.toHaveProperty("diagnostics");
-    expect(result[0]).not.toHaveProperty("errorMessage");
-  });
-
-  it("preserves tool-bearing assistant errors without hidden reasoning or diagnostics", () => {
-    const toolCall = {
-      type: "toolCall",
-      id: "call-1",
-      name: "read",
-      arguments: { path: "README.md" },
-    };
-    const result = projectRecentChatDisplayMessages([
-      {
-        role: "assistant",
-        content: [
-          { type: "thinking", thinking: "private upstream reasoning" },
-          { type: "text", text: "I read the requested file before the run failed." },
-          toolCall,
-        ],
-        stopReason: "error",
-        errorMessage: "private upstream at secret.internal.example failed",
-        errorBody: "private response body",
-        timestamp: 1,
-      },
-    ]);
-
-    expect(result[0]?.content).toEqual([
-      { type: "text", text: "I read the requested file before the run failed." },
-    ]);
-    expect(result[0]).not.toHaveProperty("errorBody");
-    expect(result[0]).not.toHaveProperty("errorMessage");
-    expect(JSON.stringify(result)).not.toContain("private upstream");
-  });
 
   it("projects sessions_send inter-session turns as forwarded assistant-side display messages", () => {
     const result = projectRecentChatDisplayMessages([
@@ -2459,192 +2337,119 @@ describe("dropPreSessionStartAnnouncePairs (#85648)", () => {
     sourceTool: "subagent_announce",
   };
   const cutoff = 1_700_000_000_000;
+  function recordedMessage(
+    role: "user" | "assistant",
+    text: string,
+    seq: number,
+    recordTimestampMs?: number,
+    announce = false,
+  ) {
+    return {
+      role,
+      content: [{ type: "text", text }],
+      ...(announce ? { provenance: announceProvenance } : {}),
+      __openclaw: { seq, ...(recordTimestampMs === undefined ? {} : { recordTimestampMs }) },
+    };
+  }
+  const announceText = "[Inter-session message] sourceTool=subagent_announce";
 
-  it("drops a pre-cutoff announce user message together with its adjacent assistant reply", () => {
-    const messages = [
-      {
-        role: "user",
-        content: [{ type: "text", text: "real prior" }],
-        __openclaw: { seq: 1, recordTimestampMs: cutoff - 86_400_000 },
-      },
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "real reply" }],
-        __openclaw: { seq: 2, recordTimestampMs: cutoff - 86_400_000 },
-      },
-      {
-        role: "user",
-        content: [{ type: "text", text: "[Inter-session message] sourceTool=subagent_announce" }],
-        provenance: announceProvenance,
-        __openclaw: { seq: 3, recordTimestampMs: cutoff - 1_000 },
-      },
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "fanfic lore-bible summary" }],
-        __openclaw: { seq: 4, recordTimestampMs: cutoff - 1_000 },
-      },
-      {
-        role: "user",
-        content: [{ type: "text", text: "fresh user turn" }],
-        __openclaw: { seq: 5, recordTimestampMs: cutoff + 5_000 },
-      },
-    ];
-    const out = dropPreSessionStartAnnouncePairs(messages, cutoff);
-    expect(out.map((m) => asOptionalRecord(asOptionalRecord(m)?.["__openclaw"])?.["seq"])).toEqual([
-      1, 2, 5,
-    ]);
-  });
-
-  it("drops imported CLI-shaped announce pairs using timestamp and text fallback", () => {
-    const messages = [
-      {
-        role: "user",
-        content: [
-          "[Inter-session message] sourceSession=agent:main:subagent:child sourceChannel=internal sourceTool=subagent_announce",
-          "This content was routed by OpenClaw from another session or internal tool.",
-        ].join("\n"),
-        timestamp: cutoff - 1_000,
-      },
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "stale imported assistant reply" }],
-        timestamp: cutoff - 500,
-      },
-      {
-        role: "user",
-        content: "fresh imported turn",
-        timestamp: cutoff + 1_000,
-      },
-    ];
-    const out = dropPreSessionStartAnnouncePairs(messages, cutoff);
-    expect(out).toEqual([messages[2]]);
-  });
-
-  it("keeps a mid-session announce pair whose timestamp is at or after the cutoff", () => {
-    const messages = [
-      {
-        role: "user",
-        content: [{ type: "text", text: "[Inter-session message] sourceTool=subagent_announce" }],
-        provenance: announceProvenance,
-        __openclaw: { seq: 1, recordTimestampMs: cutoff + 1_000 },
-      },
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "current-session reply" }],
-        __openclaw: { seq: 2, recordTimestampMs: cutoff + 2_000 },
-      },
-    ];
-    const out = dropPreSessionStartAnnouncePairs(messages, cutoff);
-    expect(out).toEqual(messages);
-  });
-
-  it("keeps an adjacent assistant reply when only the announce user predates the cutoff", () => {
-    const messages = [
-      {
-        role: "user",
-        content: [{ type: "text", text: "[Inter-session message] sourceTool=subagent_announce" }],
-        provenance: announceProvenance,
-        __openclaw: { seq: 1, recordTimestampMs: cutoff - 1_000 },
-      },
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "fresh-session reply" }],
-        __openclaw: { seq: 2, recordTimestampMs: cutoff + 1_000 },
-      },
-    ];
-    const out = dropPreSessionStartAnnouncePairs(messages, cutoff);
-    expect(out).toEqual([messages[1]]);
-  });
-
-  it("keeps an adjacent assistant reply when its record timestamp is missing", () => {
-    const messages = [
-      {
-        role: "user",
-        content: [{ type: "text", text: "[Inter-session message] sourceTool=subagent_announce" }],
-        provenance: announceProvenance,
-        __openclaw: { seq: 1, recordTimestampMs: cutoff - 1_000 },
-      },
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "timestampless reply" }],
-        __openclaw: { seq: 2 },
-      },
-    ];
-    const out = dropPreSessionStartAnnouncePairs(messages, cutoff);
-    expect(out).toEqual([messages[1]]);
-  });
-
-  it("returns the input unchanged when sessionStartedAt is undefined", () => {
-    const messages = [
-      {
-        role: "user",
-        content: [{ type: "text", text: "[Inter-session message] sourceTool=subagent_announce" }],
-        provenance: announceProvenance,
-        __openclaw: { seq: 1, recordTimestampMs: cutoff - 1_000 },
-      },
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "would-be-stripped reply" }],
-        __openclaw: { seq: 2, recordTimestampMs: cutoff - 1_000 },
-      },
-    ];
-    const out = dropPreSessionStartAnnouncePairs(messages, undefined);
-    expect(out).toBe(messages);
-  });
-
-  it("drops a trailing pre-cutoff announce user message even with no assistant reply", () => {
-    const messages = [
-      {
-        role: "user",
-        content: [{ type: "text", text: "real prior" }],
-        __openclaw: { seq: 1, recordTimestampMs: cutoff + 1_000 },
-      },
-      {
-        role: "user",
-        content: [{ type: "text", text: "[Inter-session message] sourceTool=subagent_announce" }],
-        provenance: announceProvenance,
-        __openclaw: { seq: 2, recordTimestampMs: cutoff - 1_000 },
-      },
-    ];
-    const out = dropPreSessionStartAnnouncePairs(messages, cutoff);
-    expect(out.map((m) => asOptionalRecord(asOptionalRecord(m)?.["__openclaw"])?.["seq"])).toEqual([
-      1,
-    ]);
-  });
-
-  it("does not drop a normal pre-cutoff user message that is not a subagent_announce", () => {
-    const messages = [
-      {
-        role: "user",
-        content: [{ type: "text", text: "older user turn" }],
-        __openclaw: { seq: 1, recordTimestampMs: cutoff - 1_000 },
-      },
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "older reply" }],
-        __openclaw: { seq: 2, recordTimestampMs: cutoff - 1_000 },
-      },
-    ];
-    const out = dropPreSessionStartAnnouncePairs(messages, cutoff);
-    expect(out).toEqual(messages);
-  });
-
-  it("does not drop a pre-cutoff announce when its record timestamp is missing", () => {
-    const messages = [
-      {
-        role: "user",
-        content: [{ type: "text", text: "[Inter-session message] sourceTool=subagent_announce" }],
-        provenance: announceProvenance,
-        __openclaw: { seq: 1 },
-      },
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "reply" }],
-        __openclaw: { seq: 2 },
-      },
-    ];
-    const out = dropPreSessionStartAnnouncePairs(messages, cutoff);
-    expect(out).toEqual(messages);
+  it.each([
+    {
+      name: "drops a pre-cutoff announce user message together with its adjacent assistant reply",
+      messages: [
+        recordedMessage("user", "real prior", 1, cutoff - 86_400_000),
+        recordedMessage("assistant", "real reply", 2, cutoff - 86_400_000),
+        recordedMessage("user", announceText, 3, cutoff - 1_000, true),
+        recordedMessage("assistant", "fanfic lore-bible summary", 4, cutoff - 1_000),
+        recordedMessage("user", "fresh user turn", 5, cutoff + 5_000),
+      ],
+      keptIndexes: [0, 1, 4],
+    },
+    {
+      name: "drops imported CLI-shaped announce pairs using timestamp and text fallback",
+      messages: [
+        {
+          role: "user",
+          content: [
+            "[Inter-session message] sourceSession=agent:main:subagent:child sourceChannel=internal sourceTool=subagent_announce",
+            "This content was routed by OpenClaw from another session or internal tool.",
+          ].join("\n"),
+          timestamp: cutoff - 1_000,
+        },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "stale imported assistant reply" }],
+          timestamp: cutoff - 500,
+        },
+        { role: "user", content: "fresh imported turn", timestamp: cutoff + 1_000 },
+      ],
+      keptIndexes: [2],
+    },
+    {
+      name: "keeps a mid-session announce pair whose timestamp is at or after the cutoff",
+      messages: [
+        recordedMessage("user", announceText, 1, cutoff + 1_000, true),
+        recordedMessage("assistant", "current-session reply", 2, cutoff + 2_000),
+      ],
+      keptIndexes: [0, 1],
+    },
+    {
+      name: "keeps an adjacent assistant reply when only the announce user predates the cutoff",
+      messages: [
+        recordedMessage("user", announceText, 1, cutoff - 1_000, true),
+        recordedMessage("assistant", "fresh-session reply", 2, cutoff + 1_000),
+      ],
+      keptIndexes: [1],
+    },
+    {
+      name: "keeps an adjacent assistant reply when its record timestamp is missing",
+      messages: [
+        recordedMessage("user", announceText, 1, cutoff - 1_000, true),
+        recordedMessage("assistant", "timestampless reply", 2),
+      ],
+      keptIndexes: [1],
+    },
+    {
+      name: "returns the input unchanged when sessionStartedAt is undefined",
+      messages: [
+        recordedMessage("user", announceText, 1, cutoff - 1_000, true),
+        recordedMessage("assistant", "would-be-stripped reply", 2, cutoff - 1_000),
+      ],
+      sessionStartedAt: undefined,
+      keptIndexes: [0, 1],
+      preservesReference: true,
+    },
+    {
+      name: "drops a trailing pre-cutoff announce user message even with no assistant reply",
+      messages: [
+        recordedMessage("user", "real prior", 1, cutoff + 1_000),
+        recordedMessage("user", announceText, 2, cutoff - 1_000, true),
+      ],
+      keptIndexes: [0],
+    },
+    {
+      name: "does not drop a normal pre-cutoff user message that is not a subagent_announce",
+      messages: [
+        recordedMessage("user", "older user turn", 1, cutoff - 1_000),
+        recordedMessage("assistant", "older reply", 2, cutoff - 1_000),
+      ],
+      keptIndexes: [0, 1],
+    },
+    {
+      name: "does not drop a pre-cutoff announce when its record timestamp is missing",
+      messages: [
+        recordedMessage("user", announceText, 1, undefined, true),
+        recordedMessage("assistant", "reply", 2),
+      ],
+      keptIndexes: [0, 1],
+    },
+  ])("$name", (testCase) => {
+    const sessionStartedAt = "sessionStartedAt" in testCase ? testCase.sessionStartedAt : cutoff;
+    const result = dropPreSessionStartAnnouncePairs(testCase.messages, sessionStartedAt);
+    expect(result).toEqual(testCase.keptIndexes.map((index) => testCase.messages[index]));
+    if ("preservesReference" in testCase) {
+      expect(result).toBe(testCase.messages);
+    }
   });
 });
 
@@ -5030,6 +4835,50 @@ describe("gateway healthHandlers.health cache freshness", () => {
   let healthHandlers: typeof import("./health.js").healthHandlers;
   const contextEngineTestOwner = "plugin:health-test";
 
+  function createHealthSnapshot<T extends Record<string, unknown>>(overrides: T) {
+    return {
+      ok: true,
+      ts: Date.now(),
+      durationMs: 1,
+      channels: {},
+      channelOrder: [] as string[],
+      channelLabels: {} as Record<string, string>,
+      heartbeatSeconds: 0,
+      defaultAgentId: "main",
+      agents: [],
+      sessions: { path: "/tmp/sessions.json", count: 0, recent: [] },
+      ...overrides,
+    };
+  }
+
+  async function requestHealthSnapshot(params: {
+    cached: Record<string, unknown> | null;
+    fresh?: Record<string, unknown>;
+    runtimeSnapshot?: Record<string, unknown>;
+    context?: Record<string, unknown>;
+  }) {
+    const respond = vi.fn();
+    const refreshHealthSnapshot = vi.fn().mockResolvedValue(params.fresh ?? params.cached);
+    await expectDefined(healthHandlers.health, "healthHandlers.health test invariant").call(
+      healthHandlers,
+      {
+        req: {} as never,
+        params: {} as never,
+        respond: respond as never,
+        context: {
+          getHealthCache: () => params.cached,
+          refreshHealthSnapshot,
+          getRuntimeSnapshot: () => params.runtimeSnapshot ?? { channels: {}, channelAccounts: {} },
+          logHealth: { error: vi.fn() },
+          ...params.context,
+        } as never,
+        client: { connect: { role: "operator", scopes: ["operator.read"] } } as never,
+        isWebchatConnect: () => false,
+      },
+    );
+    return { respond, refreshHealthSnapshot };
+  }
+
   beforeAll(async () => {
     ({ healthHandlers } = await import("./health.js"));
   });
@@ -5046,10 +4895,7 @@ describe("gateway healthHandlers.health cache freshness", () => {
   });
 
   it("refreshes cached health when runtime channel lifecycle has changed", async () => {
-    const cached = {
-      ok: true,
-      ts: Date.now(),
-      durationMs: 1,
+    const cached = createHealthSnapshot({
       channels: {
         discord: {
           configured: true,
@@ -5067,11 +4913,7 @@ describe("gateway healthHandlers.health cache freshness", () => {
       },
       channelOrder: ["discord"],
       channelLabels: { discord: "Discord" },
-      heartbeatSeconds: 0,
-      defaultAgentId: "main",
-      agents: [],
-      sessions: { path: "/tmp/sessions.json", count: 0, recent: [] },
-    };
+    });
     const fresh = {
       ...cached,
       ts: cached.ts + 1,
@@ -5090,36 +4932,18 @@ describe("gateway healthHandlers.health cache freshness", () => {
         },
       },
     };
-    const respond = vi.fn();
-    const refreshHealthSnapshot = vi.fn().mockResolvedValue(fresh);
-
-    await expectDefined(healthHandlers.health, "healthHandlers.health test invariant").call(
-      healthHandlers,
-      {
-        req: {} as never,
-        params: {} as never,
-        respond: respond as never,
-        context: {
-          getHealthCache: () => cached,
-          refreshHealthSnapshot,
-          getRuntimeSnapshot: () => ({
-            channels: {},
-            channelAccounts: {
-              discord: {
-                default: {
-                  accountId: "default",
-                  running: true,
-                  connected: true,
-                },
-              },
-            },
-          }),
-          logHealth: { error: vi.fn() },
-        } as never,
-        client: { connect: { role: "operator", scopes: ["operator.read"] } } as never,
-        isWebchatConnect: () => false,
+    const { respond, refreshHealthSnapshot } = await requestHealthSnapshot({
+      cached,
+      fresh,
+      runtimeSnapshot: {
+        channels: {},
+        channelAccounts: {
+          discord: {
+            default: { accountId: "default", running: true, connected: true },
+          },
+        },
       },
-    );
+    });
 
     expect(refreshHealthSnapshot).toHaveBeenCalledWith({
       probe: false,
@@ -5147,40 +4971,13 @@ describe("gateway healthHandlers.health cache freshness", () => {
       utilization: 0,
       cpuCoreRatio: 0,
     };
-    const fresh = {
-      ok: true,
-      ts: Date.now(),
-      durationMs: 1,
-      channels: {},
-      channelOrder: [],
-      channelLabels: {},
-      heartbeatSeconds: 0,
-      defaultAgentId: "main",
-      agents: [],
-      sessions: { path: "/tmp/sessions.json", count: 0, recent: [] },
-      eventLoop,
-    };
-    const respond = vi.fn();
-    const refreshHealthSnapshot = vi.fn().mockResolvedValue(fresh);
+    const fresh = createHealthSnapshot({ eventLoop });
     const getEventLoopHealth = vi.fn(() => replacementEventLoop);
-
-    await expectDefined(healthHandlers.health, "healthHandlers.health test invariant").call(
-      healthHandlers,
-      {
-        req: {} as never,
-        params: {} as never,
-        respond: respond as never,
-        context: {
-          getHealthCache: () => null,
-          refreshHealthSnapshot,
-          getRuntimeSnapshot: () => ({ channels: {}, channelAccounts: {} }),
-          getEventLoopHealth,
-          logHealth: { error: vi.fn() },
-        } as never,
-        client: { connect: { role: "operator", scopes: ["operator.read"] } } as never,
-        isWebchatConnect: () => false,
-      },
-    );
+    const { respond, refreshHealthSnapshot } = await requestHealthSnapshot({
+      cached: null,
+      fresh,
+      context: { getEventLoopHealth },
+    });
 
     expect(refreshHealthSnapshot).toHaveBeenCalledWith({
       probe: false,
@@ -5213,37 +5010,7 @@ describe("gateway healthHandlers.health cache freshness", () => {
       } as OpenClawConfig);
       await contextEngine.assemble({ sessionId: "s1", messages: [] });
 
-      const cached = {
-        ok: true,
-        ts: Date.now(),
-        durationMs: 1,
-        channels: {},
-        channelOrder: [],
-        channelLabels: {},
-        heartbeatSeconds: 0,
-        defaultAgentId: "main",
-        agents: [],
-        sessions: { path: "/tmp/sessions.json", count: 0, recent: [] },
-      };
-      const respond = vi.fn();
-      const refreshHealthSnapshot = vi.fn().mockResolvedValue(cached);
-
-      await expectDefined(healthHandlers.health, "healthHandlers.health test invariant").call(
-        healthHandlers,
-        {
-          req: {} as never,
-          params: {} as never,
-          respond: respond as never,
-          context: {
-            getHealthCache: () => cached,
-            refreshHealthSnapshot,
-            getRuntimeSnapshot: () => ({ channels: {}, channelAccounts: {} }),
-            logHealth: { error: vi.fn() },
-          } as never,
-          client: { connect: { role: "operator", scopes: ["operator.read"] } } as never,
-          isWebchatConnect: () => false,
-        },
-      );
+      const { respond } = await requestHealthSnapshot({ cached: createHealthSnapshot({}) });
 
       const payload = mockCallArg(respond, 0, 1) as
         | {
@@ -5281,43 +5048,14 @@ describe("gateway healthHandlers.health cache freshness", () => {
       const { moveDeliveryQueueEntryToFailed, upsertDeliveryQueueEntry } =
         await import("../../infra/delivery-queue-sqlite.js");
       // The cached snapshot was built before this delivery dead-lettered.
-      const cached = {
-        ok: true,
-        ts: Date.now(),
-        durationMs: 1,
-        channels: {},
-        channelOrder: [],
-        channelLabels: {},
-        heartbeatSeconds: 0,
-        defaultAgentId: "main",
-        agents: [],
-        sessions: { path: "/tmp/sessions.json", count: 0, recent: [] },
-      };
+      const cached = createHealthSnapshot({});
       upsertDeliveryQueueEntry({
         queueName: "outbound",
         entry: { id: "dead-1", enqueuedAt: 1_000, retryCount: 5 },
       });
       moveDeliveryQueueEntryToFailed("outbound", "dead-1");
 
-      const respond = vi.fn();
-      const refreshHealthSnapshot = vi.fn().mockResolvedValue(cached);
-
-      await expectDefined(healthHandlers.health, "healthHandlers.health test invariant").call(
-        healthHandlers,
-        {
-          req: {} as never,
-          params: {} as never,
-          respond: respond as never,
-          context: {
-            getHealthCache: () => cached,
-            refreshHealthSnapshot,
-            getRuntimeSnapshot: () => ({ channels: {}, channelAccounts: {} }),
-            logHealth: { error: vi.fn() },
-          } as never,
-          client: { connect: { role: "operator", scopes: ["operator.read"] } } as never,
-          isWebchatConnect: () => false,
-        },
-      );
+      const { respond } = await requestHealthSnapshot({ cached });
 
       const payload = mockCallArg(respond, 0, 1) as
         | {
@@ -5339,40 +5077,12 @@ describe("gateway healthHandlers.health cache freshness", () => {
   });
 
   it("merges a live disabled config hot-reload status into cached health responses", async () => {
-    const cached = {
-      ok: true,
-      ts: Date.now(),
-      durationMs: 1,
-      channels: {},
-      channelOrder: [],
-      channelLabels: {},
-      heartbeatSeconds: 0,
-      defaultAgentId: "main",
-      agents: [],
-      sessions: { path: "/tmp/sessions.json", count: 0, recent: [] },
-      configReload: { hotReloadStatus: "active" },
-    };
-    const respond = vi.fn();
-    const refreshHealthSnapshot = vi.fn().mockResolvedValue(cached);
+    const cached = createHealthSnapshot({ configReload: { hotReloadStatus: "active" } });
     const getConfigReloaderHotReloadStatus = vi.fn(() => "disabled" as const);
-
-    await expectDefined(healthHandlers.health, "healthHandlers.health test invariant").call(
-      healthHandlers,
-      {
-        req: {} as never,
-        params: {} as never,
-        respond: respond as never,
-        context: {
-          getHealthCache: () => cached,
-          refreshHealthSnapshot,
-          getRuntimeSnapshot: () => ({ channels: {}, channelAccounts: {} }),
-          getConfigReloaderHotReloadStatus,
-          logHealth: { error: vi.fn() },
-        } as never,
-        client: { connect: { role: "operator", scopes: ["operator.read"] } } as never,
-        isWebchatConnect: () => false,
-      },
-    );
+    const { respond } = await requestHealthSnapshot({
+      cached,
+      context: { getConfigReloaderHotReloadStatus },
+    });
 
     const payload = mockCallArg(respond, 0, 1) as
       | { configReload?: { hotReloadStatus?: string } }
@@ -5386,38 +5096,8 @@ describe("gateway healthHandlers.health cache freshness", () => {
   });
 
   it("preserves the cached config hot-reload status when no live accessor is available", async () => {
-    const cached = {
-      ok: true,
-      ts: Date.now(),
-      durationMs: 1,
-      channels: {},
-      channelOrder: [],
-      channelLabels: {},
-      heartbeatSeconds: 0,
-      defaultAgentId: "main",
-      agents: [],
-      sessions: { path: "/tmp/sessions.json", count: 0, recent: [] },
-      configReload: { hotReloadStatus: "disabled" },
-    };
-    const respond = vi.fn();
-    const refreshHealthSnapshot = vi.fn().mockResolvedValue(cached);
-
-    await expectDefined(healthHandlers.health, "healthHandlers.health test invariant").call(
-      healthHandlers,
-      {
-        req: {} as never,
-        params: {} as never,
-        respond: respond as never,
-        context: {
-          getHealthCache: () => cached,
-          refreshHealthSnapshot,
-          getRuntimeSnapshot: () => ({ channels: {}, channelAccounts: {} }),
-          logHealth: { error: vi.fn() },
-        } as never,
-        client: { connect: { role: "operator", scopes: ["operator.read"] } } as never,
-        isWebchatConnect: () => false,
-      },
-    );
+    const cached = createHealthSnapshot({ configReload: { hotReloadStatus: "disabled" } });
+    const { respond } = await requestHealthSnapshot({ cached });
 
     const payload = mockCallArg(respond, 0, 1) as
       | { configReload?: { hotReloadStatus?: string } }
@@ -5426,10 +5106,7 @@ describe("gateway healthHandlers.health cache freshness", () => {
   });
 
   it("refreshes cached health when a runtime account is missing from the cached account summary", async () => {
-    const cached = {
-      ok: true,
-      ts: Date.now(),
-      durationMs: 1,
+    const cached = createHealthSnapshot({
       channels: {
         discord: {
           configured: true,
@@ -5447,11 +5124,7 @@ describe("gateway healthHandlers.health cache freshness", () => {
       },
       channelOrder: ["discord"],
       channelLabels: { discord: "Discord" },
-      heartbeatSeconds: 0,
-      defaultAgentId: "main",
-      agents: [],
-      sessions: { path: "/tmp/sessions.json", count: 0, recent: [] },
-    };
+    });
     const fresh = {
       ...cached,
       ts: cached.ts + 1,
@@ -5470,36 +5143,16 @@ describe("gateway healthHandlers.health cache freshness", () => {
         },
       },
     };
-    const respond = vi.fn();
-    const refreshHealthSnapshot = vi.fn().mockResolvedValue(fresh);
-
-    await expectDefined(healthHandlers.health, "healthHandlers.health test invariant").call(
-      healthHandlers,
-      {
-        req: {} as never,
-        params: {} as never,
-        respond: respond as never,
-        context: {
-          getHealthCache: () => cached,
-          refreshHealthSnapshot,
-          getRuntimeSnapshot: () => ({
-            channels: {},
-            channelAccounts: {
-              discord: {
-                work: {
-                  accountId: "work",
-                  running: true,
-                  connected: true,
-                },
-              },
-            },
-          }),
-          logHealth: { error: vi.fn() },
-        } as never,
-        client: { connect: { role: "operator", scopes: ["operator.read"] } } as never,
-        isWebchatConnect: () => false,
+    const { respond, refreshHealthSnapshot } = await requestHealthSnapshot({
+      cached,
+      fresh,
+      runtimeSnapshot: {
+        channels: {},
+        channelAccounts: {
+          discord: { work: { accountId: "work", running: true, connected: true } },
+        },
       },
-    );
+    });
 
     expect(refreshHealthSnapshot).toHaveBeenCalledWith({
       probe: false,


### PR DESCRIPTION
## What Problem This Solves

Gateway RPC tests duplicated substantial setup and near-identical assertions across message delivery, polling, chat projection, approvals, and gateway health. The repetition made behavior harder to audit and increased test maintenance and execution time.

## Why This Change Was Made

Consolidate only gateway-owned test scaffolding and parameterize genuinely equivalent cases. Preserve every named authorization, empty-scope, idempotency, media, error-redaction, abort, approval, and health-cache scenario. No production files, coverage exclusions, thresholds, snapshots, protocol versions, or security policy are changed.

## User Impact

No production or externally visible behavior changes. Maintainers get 800 fewer net lines, the same 266 distinct gateway scenarios, and a faster measured focused test run.

## Evidence

- Immutable base: b461ae6de88345ddcc69c787d99e6404c2206cba.
- Diff: 695 insertions, 1,495 deletions; 800 net lines removed across two gateway test files.
- Trusted private Linux Testbox; baseline: 266/266 passing, 10.75 seconds; refactor: 266/266 passing, 8.30 seconds.
- V8 production coverage, baseline and candidate exactly equal in all four dimensions:
  - Statements: 1,954/66,492.
  - Branches: 1,658/52,095.
  - Functions: 297/11,001.
  - Lines: 1,944/65,686.
- Complete path-scoped changed gate passed: conflict, environment and max-lines ratchets, formatting, dependency and boundary guards, core-test tsgo, and changed-file lint.
- Fresh independent autoreview: clean; no accepted or actionable findings.
- AI-assisted, manually verified against the unchanged gateway behavior and security-sensitive cases.