### PR TITLE
fix(ai): notify idle watchdog of OpenAI completions stream activity (#113323)

### DIFF
--- a/packages/ai/src/transports/openai-completions-transport.ts
+++ b/packages/ai/src/transports/openai-completions-transport.ts
@@ -39,6 +39,7 @@ import {
   type PendingCommentaryTags,
 } from "../utils/assistant-text-phase.js";
 import { createAssistantMessageEventStream } from "../utils/event-stream.js";
+import { notifyLlmRequestActivity } from "../utils/llm-request-activity.js";
 import { createDeepSeekTextFilter } from "./deepseek-text-filter.js";
 import {
   buildGuardedModelFetch,
@@ -625,6 +626,10 @@ async function processOpenAICompletionsStream(
   });
   for await (const rawChunk of guardedStream) {
     throwIfModelStreamAborted(options?.signal);
+    // Notify the idle-timeout watchdog that the provider is still active.
+    // This must run before reasoning-output filtering so that hidden
+    // thinking deltas (emitReasoning=false) still refresh the watchdog.
+    notifyLlmRequestActivity(options?.signal);
     chunkPushedEvent = false;
     if (!rawChunk || typeof rawChunk !== "object") {
       await cooperativeScheduler.afterEvent();


### PR DESCRIPTION
## Summary

- Add `notifyLlmRequestActivity` call to the OpenAI completions transport's `pushStreamEvent` so the idle-timeout watchdog can detect reasoning-token streaming.

## What Problem This Solves

The OpenAI completions transport (`createOpenAICompletionsTransportStreamFn`) never called `notifyLlmRequestActivity`. The Anthropic transport calls it on every buffered event, but the OpenAI completions path was missing this notification. As a result, reasoning models served via OpenAI-compatible endpoints (e.g. vLLM with `--reasoning-parser`) that emit only `thinking_delta` events before any `content` were misclassified as idle by the `streamWithIdleTimeout` watchdog and aborted with `LLM idle timeout (120s): no response from model`.

## User Impact

- **Before:** Agent runs on local reasoning models (Nemotron, Qwen with reasoning) abort with idle timeout during the reasoning phase, even though the provider is actively streaming thinking tokens.
- **After:** The idle watchdog receives activity notifications on every streamed event (including reasoning deltas), preventing false idle detection.

## Origin / follow-up

Fixes #113323.

## Evidence

```bash
node scripts/run-vitest.mjs run packages/ai/src/transports/provider-transport-stream.test.ts
# 8/8 tests passed
```

## Regression Test Plan

- Existing `llm-idle-timeout.test.ts` tests verify the watchdog behavior is unchanged.
- The `notifyLlmRequestActivity` call is a no-op when no listener is registered (no signal or no idle-timeout wrapper), so non-idle-timeout paths are unaffected.

## Merge risk

Low. One import + one function call in an existing push path. No new control flow, no config surface, no behavioral change for paths without an idle-timeout wrapper.

## What was not changed

- OpenAI responses client (`openai-responses-client.ts`) — it has a different streaming path and was not reported in the issue.
- Idle timeout calculation logic — unchanged.

Fixes #113323
