### PR TITLE
refactor(cli): consolidate security-sensitive regression fixtures

### DIFF
--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -16,6 +16,18 @@ function runCap(...argv: string[]): Promise<void> {
   return runRegisteredCli({ register: registerCapabilityCli as (program: Command) => void, argv });
 }
 
+function runCapability(domain: string, action: string, ...argv: string[]): Promise<void> {
+  return runCap("capability", domain, action, ...argv);
+}
+
+function primeOpenAiAuthProfile(mode: "api-key" | "token" = "api-key"): void {
+  mocks.resolveApiKeyForProvider.mockResolvedValueOnce({
+    apiKey: mode === "token" ? "profile-openai-token" : "profile-openai-key",
+    source: mode === "token" ? "profile:openai:token" : "profile:openai:qa",
+    mode,
+  });
+}
+
 type LocalAudioSelection = Awaited<ReturnType<typeof inspectLocalAudioSelection>>;
 
 const closeEmbeddingProviderMock = vi.hoisted(() => vi.fn(async () => {}));
@@ -514,9 +526,17 @@ describe("capability cli", () => {
     mocks.resolveMemorySearchConfig.mockReset().mockReturnValue(null);
     mocks.prepareSimpleCompletionModelForAgent.mockClear();
     mocks.completeWithPreparedSimpleCompletionModel.mockClear();
-    mocks.callGateway.mockClear().mockImplementation((async ({ method }: { method: string }) => {
+    mocks.callGateway.mockReset().mockImplementation((async ({ method }: { method: string }) => {
       if (method === "tts.status") {
         return { enabled: true, provider: "openai" };
+      }
+      if (method === "tts.convert") {
+        return {
+          audioPath: "/tmp/gateway-tts.mp3",
+          provider: "openai",
+          outputFormat: "mp3",
+          voiceCompatible: false,
+        };
       }
       if (method === "agent") {
         return {
@@ -565,33 +585,10 @@ describe("capability cli", () => {
         diagnostics: [],
       }));
     mocks.modelsStatusCommand.mockClear();
-    mocks.callGateway.mockImplementation((async ({ method }: { method: string }) => {
-      if (method === "tts.status") {
-        return { enabled: true, provider: "openai" };
-      }
-      if (method === "tts.convert") {
-        return {
-          audioPath: "/tmp/gateway-tts.mp3",
-          provider: "openai",
-          outputFormat: "mp3",
-          voiceCompatible: false,
-        };
-      }
-      if (method === "agent") {
-        return {
-          result: {
-            payloads: [{ text: "gateway reply" }],
-            meta: { agentMeta: { provider: "anthropic", model: "claude-sonnet-4-6" } },
-          },
-        };
-      }
-      return {};
-    }) as never);
   });
 
   async function runModelRunWithModel(model: string, transport: "local" | "gateway") {
-    await runCap(
-      "capability",
+    await runCapability(
       "model",
       "run",
       "--model",
@@ -753,7 +750,7 @@ describe("capability cli", () => {
   });
 
   it("defaults model run to local transport", async () => {
-    await runCap("capability", "model", "run", "--prompt", "hello", "--json");
+    await runCapability("model", "run", "--prompt", "hello", "--json");
 
     expect(mocks.prepareSimpleCompletionModelForAgent).toHaveBeenCalledTimes(1);
     expect(mocks.completeWithPreparedSimpleCompletionModel).toHaveBeenCalledTimes(1);
@@ -763,7 +760,7 @@ describe("capability cli", () => {
   });
 
   it("runs local model probes through the lean completion path", async () => {
-    await runCap("capability", "model", "run", "--prompt", "hello", "--json");
+    await runCapability("model", "run", "--prompt", "hello", "--json");
 
     const preparedParams = firstPreparedModelParams();
     expect(preparedParams?.agentId).toBe("main");
@@ -785,7 +782,7 @@ describe("capability cli", () => {
   });
 
   it("does not enable bundled static catalog fallback without an explicit provider/model override", async () => {
-    await runCap("capability", "model", "run", "--prompt", "hello", "--json");
+    await runCapability("model", "run", "--prompt", "hello", "--json");
 
     const calls = mocks.prepareSimpleCompletionModelForAgent.mock.calls as unknown as Array<
       [Record<string, unknown>]
@@ -801,16 +798,7 @@ describe("capability cli", () => {
     const tempInput = path.join(os.tmpdir(), `openclaw-model-run-image-${Date.now()}.png`);
     await fs.writeFile(tempInput, Buffer.from(PNG_1X1_BASE64, "base64"));
 
-    await runCap(
-      "capability",
-      "model",
-      "run",
-      "--prompt",
-      "describe this",
-      "--file",
-      tempInput,
-      "--json",
-    );
+    await runCapability("model", "run", "--prompt", "describe this", "--file", tempInput, "--json");
 
     const call = firstCompletionCall();
     expect(call?.context?.messages?.[0]?.role).toBe("user");
@@ -845,16 +833,7 @@ describe("capability cli", () => {
       },
     } as never);
 
-    await runCap(
-      "capability",
-      "model",
-      "run",
-      "--model",
-      "openai/gpt-5.5",
-      "--prompt",
-      "hello",
-      "--json",
-    );
+    await runCapability("model", "run", "--model", "openai/gpt-5.5", "--prompt", "hello", "--json");
 
     const call = firstCompletionCall();
     expect(call?.context?.systemPrompt).toBe(
@@ -865,7 +844,7 @@ describe("capability cli", () => {
   });
 
   it("passes thinking overrides to local model probes", async () => {
-    await runCap("capability", "model", "run", "--prompt", "hello", "--thinking", "high", "--json");
+    await runCapability("model", "run", "--prompt", "hello", "--thinking", "high", "--json");
 
     expect(firstCompletionCall()?.options?.reasoning).toBe("high");
   });
@@ -874,8 +853,7 @@ describe("capability cli", () => {
     const tempInput = path.join(os.tmpdir(), `openclaw-model-run-gateway-image-${Date.now()}.png`);
     await fs.writeFile(tempInput, Buffer.from(PNG_1X1_BASE64, "base64"));
 
-    await runCap(
-      "capability",
+    await runCapability(
       "model",
       "run",
       "--prompt",
@@ -905,16 +883,7 @@ describe("capability cli", () => {
     const tempInput = path.join(os.tmpdir(), `openclaw-model-run-image-${Date.now()}.heic`);
     await fs.writeFile(tempInput, Buffer.from("heic-like"));
 
-    await runCap(
-      "capability",
-      "model",
-      "run",
-      "--prompt",
-      "describe this",
-      "--file",
-      tempInput,
-      "--json",
-    );
+    await runCapability("model", "run", "--prompt", "describe this", "--file", tempInput, "--json");
 
     expect(mocks.convertHeicToJpeg).toHaveBeenCalledWith(Buffer.from("heic-like"));
     const call = firstCompletionCall();
@@ -938,16 +907,7 @@ describe("capability cli", () => {
     await fs.writeFile(tempInput, Buffer.from("not really audio"));
 
     await expect(
-      runCap(
-        "capability",
-        "model",
-        "run",
-        "--prompt",
-        "transcribe this",
-        "--file",
-        tempInput,
-        "--json",
-      ),
+      runCapability("model", "run", "--prompt", "transcribe this", "--file", tempInput, "--json"),
     ).rejects.toThrow("exit 1");
 
     expectRuntimeErrorContains("Only image files are supported");
@@ -960,9 +920,9 @@ describe("capability cli", () => {
       content: [],
     } as never);
 
-    await expect(
-      runCap("capability", "model", "run", "--prompt", "hello", "--json"),
-    ).rejects.toThrow("exit 1");
+    await expect(runCapability("model", "run", "--prompt", "hello", "--json")).rejects.toThrow(
+      "exit 1",
+    );
 
     expectRuntimeErrorContains('No text output returned for provider "openai" model "gpt-5.4"');
     expect(mocks.runtime.writeJson).not.toHaveBeenCalled();
@@ -975,9 +935,9 @@ describe("capability cli", () => {
       errorMessage: '{"detail":"Instructions are required"}',
     } as never);
 
-    await expect(
-      runCap("capability", "model", "run", "--prompt", "hello", "--json"),
-    ).rejects.toThrow("exit 1");
+    await expect(runCapability("model", "run", "--prompt", "hello", "--json")).rejects.toThrow(
+      "exit 1",
+    );
 
     expectRuntimeErrorContains('{"detail":"Instructions are required"}');
     expect(mocks.runtime.writeJson).not.toHaveBeenCalled();
@@ -1003,16 +963,7 @@ describe("capability cli", () => {
     } as never);
 
     await expect(
-      runCap(
-        "capability",
-        "model",
-        "run",
-        "--model",
-        "codex/gpt-5.4",
-        "--prompt",
-        "hello",
-        "--json",
-      ),
+      runCapability("model", "run", "--model", "codex/gpt-5.4", "--prompt", "hello", "--json"),
     ).rejects.toThrow("exit 1");
 
     expectRuntimeErrorContains("Codex app-server agent runtime");
@@ -1023,9 +974,9 @@ describe("capability cli", () => {
   it.each(["", "   ", "\n\t"])(
     "rejects empty model run prompts before local dispatch (%j)",
     async (prompt) => {
-      await expect(
-        runCap("capability", "model", "run", "--prompt", prompt, "--json"),
-      ).rejects.toThrow("exit 1");
+      await expect(runCapability("model", "run", "--prompt", prompt, "--json")).rejects.toThrow(
+        "exit 1",
+      );
 
       expectRuntimeErrorContains("--prompt cannot be empty or whitespace-only.");
       expect(mocks.prepareSimpleCompletionModelForAgent).not.toHaveBeenCalled();
@@ -1036,7 +987,7 @@ describe("capability cli", () => {
   );
 
   it("runs gateway model probes in fresh raw sessions without chat-agent prompt policy or tools", async () => {
-    await runCap("capability", "model", "run", "--prompt", "hello", "--gateway", "--json");
+    await runCapability("model", "run", "--prompt", "hello", "--gateway", "--json");
 
     const gatewayCall = firstGatewayCall();
     const sessionId = gatewayCall?.params?.sessionId;
@@ -1051,7 +1002,7 @@ describe("capability cli", () => {
     expect(gatewayCall?.params?.modelRun).toBe(true);
     expect(gatewayCall?.params?.promptMode).toBe("none");
 
-    await runCap("capability", "model", "run", "--prompt", "again", "--gateway", "--json");
+    await runCapability("model", "run", "--prompt", "again", "--gateway", "--json");
 
     const gatewayCalls = mocks.callGateway.mock.calls as unknown as Array<[GatewayCall]>;
     const nextGatewayCall = gatewayCalls[1]?.[0];
@@ -1087,7 +1038,7 @@ describe("capability cli", () => {
       },
     } as never);
 
-    await runCap("capability", "model", "run", "--prompt", "hello", "--gateway", "--json");
+    await runCapability("model", "run", "--prompt", "hello", "--gateway", "--json");
 
     const payload = firstJsonOutput();
     const attempts = payload?.attempts as Array<Record<string, unknown>>;
@@ -1100,8 +1051,7 @@ describe("capability cli", () => {
   });
 
   it("requests admin scope for gateway model probes with provider/model overrides", async () => {
-    await runCap(
-      "capability",
+    await runCapability(
       "model",
       "run",
       "--prompt",
@@ -1170,8 +1120,7 @@ describe("capability cli", () => {
   });
 
   it("passes thinking overrides to gateway model probes", async () => {
-    await runCap(
-      "capability",
+    await runCapability(
       "model",
       "run",
       "--prompt",
@@ -1191,16 +1140,7 @@ describe("capability cli", () => {
 
   it("rejects invalid model run thinking overrides before dispatch", async () => {
     await expect(
-      runCap(
-        "capability",
-        "model",
-        "run",
-        "--prompt",
-        "hello",
-        "--thinking",
-        "turbo-mode",
-        "--json",
-      ),
+      runCapability("model", "run", "--prompt", "hello", "--thinking", "turbo-mode", "--json"),
     ).rejects.toThrow("exit 1");
 
     expectRuntimeErrorContains("Invalid thinking level.");
@@ -1212,7 +1152,7 @@ describe("capability cli", () => {
 
   it("rejects empty model run prompts before gateway dispatch", async () => {
     await expect(
-      runCap("capability", "model", "run", "--prompt", " ", "--gateway", "--json"),
+      runCapability("model", "run", "--prompt", " ", "--gateway", "--json"),
     ).rejects.toThrow("exit 1");
 
     expectRuntimeErrorContains("--prompt cannot be empty or whitespace-only.");
@@ -1221,14 +1161,14 @@ describe("capability cli", () => {
   });
 
   it("defaults tts status to gateway transport", async () => {
-    await runCap("capability", "tts", "status", "--json");
+    await runCapability("tts", "status", "--json");
 
     expect(firstGatewayCall()?.method).toBe("tts.status");
     expect(firstJsonOutput()?.transport).toBe("gateway");
   });
 
   it("routes image describe through media understanding, not generation", async () => {
-    await runCap("capability", "image", "describe", "--file", "photo.jpg", "--json");
+    await runCapability("image", "describe", "--file", "photo.jpg", "--json");
 
     const describeCall = imageDescribeCall();
     expect(path.basename(describeCall?.filePath ?? "")).toBe("photo.jpg");
@@ -1241,7 +1181,7 @@ describe("capability cli", () => {
 
   it("keeps encoded image describe HTTP URLs intact", async () => {
     const mediaUrl = "https://cdn.example.com/clip%2Emp4?download=1#preview";
-    await runCap("capability", "image", "describe", "--file", mediaUrl, "--json");
+    await runCapability("image", "describe", "--file", mediaUrl, "--json");
 
     const describeCall = imageDescribeCall();
     expect(describeCall).toMatchObject({ filePath: mediaUrl, mediaUrl });
@@ -1251,8 +1191,7 @@ describe("capability cli", () => {
   });
 
   it("passes image describe prompts through media understanding", async () => {
-    await runCap(
-      "capability",
+    await runCapability(
       "image",
       "describe",
       "--file",
@@ -1271,14 +1210,7 @@ describe("capability cli", () => {
   });
 
   it("keeps image describe URL files as remote media references", async () => {
-    await runCap(
-      "capability",
-      "image",
-      "describe",
-      "--file",
-      "https://example.com/photo.png",
-      "--json",
-    );
+    await runCapability("image", "describe", "--file", "https://example.com/photo.png", "--json");
 
     const describeCall = imageDescribeCall();
     expect(describeCall?.filePath).toBe("https://example.com/photo.png");
@@ -1288,8 +1220,7 @@ describe("capability cli", () => {
   });
 
   it("uses the explicit media-understanding provider for image describe model overrides", async () => {
-    await runCap(
-      "capability",
+    await runCapability(
       "image",
       "describe",
       "--file",
@@ -1316,8 +1247,7 @@ describe("capability cli", () => {
   });
 
   it("keeps explicit-model image describe URL files as remote media references", async () => {
-    await runCap(
-      "capability",
+    await runCapability(
       "image",
       "describe",
       "--file",
@@ -1336,8 +1266,7 @@ describe("capability cli", () => {
   });
 
   it("keeps explicit-model image describe HTTP URLs as URLs", async () => {
-    await runCap(
-      "capability",
+    await runCapability(
       "image",
       "describe",
       "--file",
@@ -1377,8 +1306,7 @@ describe("capability cli", () => {
         model: "google/gemma-4-31b-it",
       });
 
-    await runCap(
-      "capability",
+    await runCapability(
       "image",
       "describe",
       "--file",
@@ -1435,8 +1363,7 @@ describe("capability cli", () => {
     mocks.prepareImageDescriptionInput.mockRejectedValueOnce(new Error("image file not found"));
 
     await expect(
-      runCap(
-        "capability",
+      runCapability(
         "image",
         "describe",
         "--file",
@@ -1453,8 +1380,7 @@ describe("capability cli", () => {
   });
 
   it("passes describe-many prompts to each image", async () => {
-    await runCap(
-      "capability",
+    await runCapability(
       "image",
       "describe-many",
       "--file",
@@ -1487,7 +1413,7 @@ describe("capability cli", () => {
     } as never);
 
     await expect(
-      runCap("capability", "image", "describe", "--file", "photo.jpg", "--json"),
+      runCapability("image", "describe", "--file", "photo.jpg", "--json"),
     ).rejects.toThrow("exit 1");
     expect(runtimeErrorMessages()).toEqual([
       `Error: No description returned for image: ${path.resolve("photo.jpg")}`,
@@ -1539,8 +1465,7 @@ describe("capability cli", () => {
     await fs.rm(tempOutput, { force: true });
     await fs.rm(tempOutput.replace(/\.png$/, ".jpg"), { force: true });
 
-    await runCap(
-      "capability",
+    await runCapability(
       "image",
       "generate",
       "--prompt",
@@ -1559,8 +1484,7 @@ describe("capability cli", () => {
   it("passes image generation timeout through to runtime", async () => {
     primeGeneratedImage("gpt-image-1", "provider-output.png");
 
-    await runCap(
-      "capability",
+    await runCapability(
       "image",
       "generate",
       "--prompt",
@@ -1577,8 +1501,7 @@ describe("capability cli", () => {
   it("passes image output format and generic background hints through to generation runtime", async () => {
     primeGeneratedImage("gpt-image-1.5", "transparent.png");
 
-    await runCap(
-      "capability",
+    await runCapability(
       "image",
       "generate",
       "--prompt",
@@ -1603,8 +1526,7 @@ describe("capability cli", () => {
   it("passes image quality and OpenAI moderation hints through to generation runtime", async () => {
     primeGeneratedImage("gpt-image-2", "draft.png");
 
-    await runCap(
-      "capability",
+    await runCapability(
       "image",
       "generate",
       "--prompt",
@@ -1631,8 +1553,7 @@ describe("capability cli", () => {
     const inputPath = path.join(os.tmpdir(), `openclaw-image-edit-${Date.now()}.png`);
     await fs.writeFile(inputPath, Buffer.from("png-input"));
 
-    await runCap(
-      "capability",
+    await runCapability(
       "image",
       "edit",
       "--file",
@@ -1674,8 +1595,7 @@ describe("capability cli", () => {
     const inputPath = path.join(os.tmpdir(), `openclaw-image-edit-count-${Date.now()}.png`);
     await fs.writeFile(inputPath, Buffer.from("png-input"));
 
-    await runCap(
-      "capability",
+    await runCapability(
       "image",
       "edit",
       "--file",
@@ -1692,8 +1612,7 @@ describe("capability cli", () => {
 
   it("rejects unsupported image output format and background hints", async () => {
     await expect(
-      runCap(
-        "capability",
+      runCapability(
         "image",
         "generate",
         "--prompt",
@@ -1709,8 +1628,7 @@ describe("capability cli", () => {
 
     mocks.runtime.error.mockClear();
     await expect(
-      runCap(
-        "capability",
+      runCapability(
         "image",
         "generate",
         "--prompt",
@@ -1726,8 +1644,7 @@ describe("capability cli", () => {
 
     mocks.runtime.error.mockClear();
     await expect(
-      runCap(
-        "capability",
+      runCapability(
         "image",
         "generate",
         "--prompt",
@@ -1743,8 +1660,7 @@ describe("capability cli", () => {
 
     mocks.runtime.error.mockClear();
     await expect(
-      runCap(
-        "capability",
+      runCapability(
         "image",
         "generate",
         "--prompt",
@@ -1760,8 +1676,7 @@ describe("capability cli", () => {
 
     mocks.runtime.error.mockClear();
     await expect(
-      runCap(
-        "capability",
+      runCapability(
         "image",
         "generate",
         "--prompt",
@@ -1797,8 +1712,7 @@ describe("capability cli", () => {
     await fs.writeFile(tempInput, Buffer.from(pngBase64, "base64"));
     await fs.rm(tempOutput, { force: true });
 
-    await runCap(
-      "capability",
+    await runCapability(
       "image",
       "edit",
       "--file",
@@ -1831,7 +1745,7 @@ describe("capability cli", () => {
   });
 
   it("reports the expanded image.edit flags in capability inspect", async () => {
-    await runCap("capability", "inspect", "--name", "image.edit", "--json");
+    await runCapability("inspect", "--name", "image.edit", "--json");
 
     expect(firstJsonOutput()?.id).toBe("image.edit");
     expect(firstJsonOutput()?.flags).toEqual([
@@ -1854,7 +1768,7 @@ describe("capability cli", () => {
   });
 
   it("reports the expanded image.generate flags in capability inspect", async () => {
-    await runCap("capability", "inspect", "--name", "image.generate", "--json");
+    await runCapability("inspect", "--name", "image.generate", "--json");
 
     expect(firstJsonOutput()?.id).toBe("image.generate");
     expect(firstJsonOutput()?.flags).toEqual([
@@ -1920,8 +1834,7 @@ describe("capability cli", () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-video-generate-"));
     const outputBase = path.join(tempDir, "result");
 
-    await runCap(
-      "capability",
+    await runCapability(
       "video",
       "generate",
       "--prompt",
@@ -1960,7 +1873,7 @@ describe("capability cli", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     await expect(
-      runCap("capability", "video", "generate", "--prompt", "friendly lobster", "--json"),
+      runCapability("video", "generate", "--prompt", "friendly lobster", "--json"),
     ).rejects.toThrow("exit 1");
 
     expect(fetchMock).not.toHaveBeenCalled();
@@ -1989,7 +1902,7 @@ describe("capability cli", () => {
     );
     vi.stubGlobal("fetch", fetchMock);
 
-    await runCap("capability", "video", "generate", "--prompt", "friendly lobster", "--json");
+    await runCapability("video", "generate", "--prompt", "friendly lobster", "--json");
 
     const fetchCalls = fetchMock.mock.calls as unknown as Array<[string]>;
     expect(fetchCalls[0]?.[0]).toBe("http://127.0.0.2:40123/private-video.mp4");
@@ -2013,8 +1926,7 @@ describe("capability cli", () => {
       ],
     });
 
-    await runCap(
-      "capability",
+    await runCapability(
       "video",
       "generate",
       "--prompt",
@@ -2057,7 +1969,7 @@ describe("capability cli", () => {
     });
 
     await expect(
-      runCap("capability", "video", "generate", "--prompt", "friendly lobster", "--json"),
+      runCapability("video", "generate", "--prompt", "friendly lobster", "--json"),
     ).rejects.toThrow("exit 1");
     expectRuntimeErrorContains("Video asset at index 0 has neither buffer nor url");
   });
@@ -2096,7 +2008,7 @@ describe("capability cli", () => {
 
     // No --output: forces the in-memory buffered fallback path.
     await expect(
-      runCap("capability", "video", "generate", "--prompt", "friendly lobster", "--json"),
+      runCapability("video", "generate", "--prompt", "friendly lobster", "--json"),
     ).rejects.toThrow("exit 1");
 
     // Real path was driven: the provider URL was actually fetched...
@@ -2133,7 +2045,7 @@ describe("capability cli", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     await expect(
-      runCap("capability", "video", "generate", "--prompt", "friendly lobster", "--json"),
+      runCapability("video", "generate", "--prompt", "friendly lobster", "--json"),
     ).rejects.toThrow("exit 1");
 
     expectRuntimeErrorContains("vydra generated video download failed");
@@ -2155,7 +2067,7 @@ describe("capability cli", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     // No --output: in-memory buffered fallback path, under cap.
-    await runCap("capability", "video", "generate", "--prompt", "friendly lobster", "--json");
+    await runCapability("video", "generate", "--prompt", "friendly lobster", "--json");
 
     const fetchCalls = fetchMock.mock.calls as unknown as Array<[string]>;
     expect(fetchCalls[0]?.[0]).toBe("https://example.com/small-video.mp4");
@@ -2191,7 +2103,7 @@ describe("capability cli", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     await expect(
-      runCap("capability", "video", "generate", "--prompt", "friendly lobster", "--json"),
+      runCapability("video", "generate", "--prompt", "friendly lobster", "--json"),
     ).rejects.toThrow("exit 1");
 
     // Cap resolved from config (2 MiB = 2097152), not the 16 MiB default.
@@ -2213,7 +2125,7 @@ describe("capability cli", () => {
     );
     vi.stubGlobal("fetch", fetchMock);
 
-    await runCap("capability", "video", "generate", "--prompt", "friendly lobster", "--json");
+    await runCapability("video", "generate", "--prompt", "friendly lobster", "--json");
 
     const output = firstJsonOutput();
     expect(output?.capability).toBe("video.generate");
@@ -2222,7 +2134,7 @@ describe("capability cli", () => {
 
   it("rejects partial image generate count before provider dispatch", async () => {
     await expect(
-      runCap("capability", "image", "generate", "--prompt", "portrait", "--count", "2x"),
+      runCapability("image", "generate", "--prompt", "portrait", "--count", "2x"),
     ).rejects.toThrow("exit 1");
     expectRuntimeErrorContains("--count must be a positive integer");
     expect(mocks.generateImage).not.toHaveBeenCalled();
@@ -2230,7 +2142,7 @@ describe("capability cli", () => {
 
   it("rejects partial image generate timeout before provider dispatch", async () => {
     await expect(
-      runCap("capability", "image", "generate", "--prompt", "portrait", "--timeout-ms", "1000ms"),
+      runCapability("image", "generate", "--prompt", "portrait", "--timeout-ms", "1000ms"),
     ).rejects.toThrow("exit 1");
     expectRuntimeErrorContains("Invalid --timeout. Use a positive millisecond value");
     expect(mocks.generateImage).not.toHaveBeenCalled();
@@ -2278,7 +2190,7 @@ describe("capability cli", () => {
   });
 
   it("routes audio transcribe through transcription, not realtime", async () => {
-    await runCap("capability", "audio", "transcribe", "--file", "memo.m4a", "--json");
+    await runCapability("audio", "transcribe", "--file", "memo.m4a", "--json");
 
     expect(path.basename(firstAudioTranscriptionCall()?.filePath ?? "")).toBe("memo.m4a");
     const output = firstJsonOutput();
@@ -2298,7 +2210,7 @@ describe("capability cli", () => {
       diagnostics: [],
     } as never);
 
-    await runCap("capability", "audio", "transcribe", "--file", "memo.m4a", "--json");
+    await runCapability("audio", "transcribe", "--file", "memo.m4a", "--json");
 
     expect(firstCommandConfigResolutionCall()).toEqual(
       expect.objectContaining({
@@ -2321,7 +2233,7 @@ describe("capability cli", () => {
     mocks.transcribeAudioFile.mockResolvedValueOnce({ text: undefined } as never);
 
     await expect(
-      runCap("capability", "audio", "transcribe", "--file", "memo.m4a", "--json"),
+      runCapability("audio", "transcribe", "--file", "memo.m4a", "--json"),
     ).rejects.toThrow("exit 1");
     expect(runtimeErrorMessages()).toEqual([
       `Error: No transcript returned for audio: ${path.resolve("memo.m4a")}`,
@@ -2339,7 +2251,7 @@ describe("capability cli", () => {
     } as never);
 
     await expect(
-      runCap("capability", "audio", "transcribe", "--file", "memo.m4a", "--json"),
+      runCapability("audio", "transcribe", "--file", "memo.m4a", "--json"),
     ).rejects.toThrow("exit 1");
     expectRuntimeErrorContains("No audio transcription provider is configured or ready");
     expectRuntimeErrorContains("tools.media.models");
@@ -2351,14 +2263,13 @@ describe("capability cli", () => {
     );
 
     await expect(
-      runCap("capability", "audio", "transcribe", "--file", "memo.m4a", "--json"),
+      runCapability("audio", "transcribe", "--file", "memo.m4a", "--json"),
     ).rejects.toThrow("exit 1");
     expect(runtimeErrorMessages()).toEqual(["Error: Audio transcription response missing text"]);
   });
 
   it("forwards transcription prompt and language hints", async () => {
-    await runCap(
-      "capability",
+    await runCapability(
       "audio",
       "transcribe",
       "--file",
@@ -2377,8 +2288,7 @@ describe("capability cli", () => {
   });
 
   it("uses request-scoped TTS overrides without mutating prefs", async () => {
-    await runCap(
-      "capability",
+    await runCapability(
       "tts",
       "convert",
       "--text",
@@ -2406,14 +2316,9 @@ describe("capability cli", () => {
   it("hydrates local TTS provider config from API-key auth profiles", async () => {
     const rawConfig = { tts: { providers: { openai: { voice: "coral" } } } };
     mocks.loadConfig.mockReturnValue(rawConfig);
-    mocks.resolveApiKeyForProvider.mockResolvedValueOnce({
-      apiKey: "profile-openai-key",
-      source: "profile:openai:qa",
-      mode: "api-key",
-    });
+    primeOpenAiAuthProfile();
 
-    await runCap(
-      "capability",
+    await runCapability(
       "tts",
       "convert",
       "--text",
@@ -2443,13 +2348,9 @@ describe("capability cli", () => {
   it("hydrates local TTS default provider config from API-key auth profiles", async () => {
     const rawConfig = { tts: { provider: "openai" } };
     mocks.loadConfig.mockReturnValue(rawConfig);
-    mocks.resolveApiKeyForProvider.mockResolvedValueOnce({
-      apiKey: "profile-openai-key",
-      source: "profile:openai:qa",
-      mode: "api-key",
-    });
+    primeOpenAiAuthProfile();
 
-    await runCap("capability", "tts", "convert", "--text", "hello", "--json");
+    await runCapability("tts", "convert", "--text", "hello", "--json");
 
     expect(mocks.resolveApiKeyForProvider).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -2469,22 +2370,9 @@ describe("capability cli", () => {
   it("hydrates local TTS channel provider config from API-key auth profiles", async () => {
     const rawConfig = { channels: { discord: { tts: { provider: "openai" } } } };
     mocks.loadConfig.mockReturnValue(rawConfig);
-    mocks.resolveApiKeyForProvider.mockResolvedValueOnce({
-      apiKey: "profile-openai-key",
-      source: "profile:openai:qa",
-      mode: "api-key",
-    });
+    primeOpenAiAuthProfile();
 
-    await runCap(
-      "capability",
-      "tts",
-      "convert",
-      "--text",
-      "hello",
-      "--channel",
-      "discord",
-      "--json",
-    );
+    await runCapability("tts", "convert", "--text", "hello", "--channel", "discord", "--json");
 
     expect(mocks.resolveTtsConfig).toHaveBeenCalledWith(rawConfig, { channelId: "discord" });
     expect(mocks.resolveExplicitTtsOverrides).toHaveBeenCalledWith(
@@ -2509,22 +2397,9 @@ describe("capability cli", () => {
       },
     };
     mocks.loadConfig.mockReturnValue(rawConfig);
-    mocks.resolveApiKeyForProvider.mockResolvedValueOnce({
-      apiKey: "profile-openai-key",
-      source: "profile:openai:qa",
-      mode: "api-key",
-    });
+    primeOpenAiAuthProfile();
 
-    await runCap(
-      "capability",
-      "tts",
-      "convert",
-      "--text",
-      "hello",
-      "--channel",
-      "discord",
-      "--json",
-    );
+    await runCapability("tts", "convert", "--text", "hello", "--channel", "discord", "--json");
 
     const cfg = firstTextToSpeechCall()?.cfg as {
       channels?: {
@@ -2555,22 +2430,9 @@ describe("capability cli", () => {
     mocks.resolveTtsConfig.mockReturnValue({
       providerConfigs: { openai: { apiKey: "config-key", speakerVoice: "nova" } },
     });
-    mocks.resolveApiKeyForProvider.mockResolvedValueOnce({
-      apiKey: "profile-openai-key",
-      source: "profile:openai:qa",
-      mode: "api-key",
-    });
+    primeOpenAiAuthProfile();
 
-    await runCap(
-      "capability",
-      "tts",
-      "convert",
-      "--text",
-      "hello",
-      "--channel",
-      "discord",
-      "--json",
-    );
+    await runCapability("tts", "convert", "--text", "hello", "--channel", "discord", "--json");
 
     const cfg = firstTextToSpeechCall()?.cfg as {
       tts?: { providers?: { openai?: { apiKey?: string } } };
@@ -2586,13 +2448,9 @@ describe("capability cli", () => {
   it("does not hydrate local TTS provider config from token auth profiles", async () => {
     const rawConfig = { tts: { provider: "openai" } };
     mocks.loadConfig.mockReturnValue(rawConfig);
-    mocks.resolveApiKeyForProvider.mockResolvedValueOnce({
-      apiKey: "profile-openai-token",
-      source: "profile:openai:token",
-      mode: "token",
-    });
+    primeOpenAiAuthProfile("token");
 
-    await runCap("capability", "tts", "convert", "--text", "hello", "--json");
+    await runCapability("tts", "convert", "--text", "hello", "--json");
 
     const cfg = firstTextToSpeechCall()?.cfg as {
       tts?: { providers?: { openai?: { apiKey?: string } } };
@@ -2603,14 +2461,9 @@ describe("capability cli", () => {
   it("does not override existing TTS provider API keys with different casing", async () => {
     const rawConfig = { tts: { providers: { OpenAI: { apiKey: "config-key" } } } };
     mocks.loadConfig.mockReturnValue(rawConfig);
-    mocks.resolveApiKeyForProvider.mockResolvedValueOnce({
-      apiKey: "profile-openai-key",
-      source: "profile:openai:qa",
-      mode: "api-key",
-    });
+    primeOpenAiAuthProfile();
 
-    await runCap(
-      "capability",
+    await runCapability(
       "tts",
       "convert",
       "--text",
@@ -2630,14 +2483,9 @@ describe("capability cli", () => {
   it("does not override existing direct TTS provider API keys", async () => {
     const rawConfig = { tts: { openai: { apiKey: "config-key" } } };
     mocks.loadConfig.mockReturnValue(rawConfig);
-    mocks.resolveApiKeyForProvider.mockResolvedValueOnce({
-      apiKey: "profile-openai-key",
-      source: "profile:openai:qa",
-      mode: "api-key",
-    });
+    primeOpenAiAuthProfile();
 
-    await runCap(
-      "capability",
+    await runCapability(
       "tts",
       "convert",
       "--text",
@@ -2658,8 +2506,7 @@ describe("capability cli", () => {
   });
 
   it("disables TTS fallback when explicit provider or voice/model selection is requested", async () => {
-    await runCap(
-      "capability",
+    await runCapability(
       "tts",
       "convert",
       "--text",
@@ -2675,8 +2522,7 @@ describe("capability cli", () => {
   });
 
   it("does not infer and forward a local provider guess for gateway TTS overrides", async () => {
-    await runCap(
-      "capability",
+    await runCapability(
       "tts",
       "convert",
       "--gateway",
@@ -2701,8 +2547,7 @@ describe("capability cli", () => {
     });
 
     await expect(
-      runCap(
-        "capability",
+      runCapability(
         "tts",
         "convert",
         "--gateway",
@@ -2718,7 +2563,7 @@ describe("capability cli", () => {
   });
 
   it("uses only embedding providers for embedding creation", async () => {
-    await runCap("capability", "embedding", "create", "--text", "hello", "--json");
+    await runCapability("embedding", "create", "--text", "hello", "--json");
 
     expect(firstEmbeddingProviderCall()?.provider).toBe("auto");
     expect(firstEmbeddingProviderCall()?.fallback).toBe("none");
@@ -2742,9 +2587,9 @@ describe("capability cli", () => {
       },
     });
 
-    await expect(
-      runCap("capability", "embedding", "create", "--text", "hello", "--json"),
-    ).rejects.toThrow("exit 1");
+    await expect(runCapability("embedding", "create", "--text", "hello", "--json")).rejects.toThrow(
+      "exit 1",
+    );
 
     expect(closeEmbeddingProviderMock).toHaveBeenCalledTimes(2);
     expectRuntimeErrorContains("embedding failed");
@@ -2755,9 +2600,9 @@ describe("capability cli", () => {
       .mockRejectedValueOnce(new Error("close failed"))
       .mockRejectedValueOnce(new Error("close failed"));
 
-    await expect(
-      runCap("capability", "embedding", "create", "--text", "hello", "--json"),
-    ).rejects.toThrow("exit 1");
+    await expect(runCapability("embedding", "create", "--text", "hello", "--json")).rejects.toThrow(
+      "exit 1",
+    );
 
     expect(closeEmbeddingProviderMock).toHaveBeenCalledTimes(2);
     expectRuntimeErrorContains("close failed");
@@ -2773,7 +2618,7 @@ describe("capability cli", () => {
       diagnostics: [],
     } as never);
 
-    await runCap("capability", "model", "run", "--prompt", "hello", "--json");
+    await runCapability("model", "run", "--prompt", "hello", "--json");
 
     expect(firstCommandConfigResolutionCall()).toEqual(
       expect.objectContaining({
@@ -2795,8 +2640,7 @@ describe("capability cli", () => {
   });
 
   it("derives the embedding provider from a provider/model override", async () => {
-    await runCap(
-      "capability",
+    await runCapability(
       "embedding",
       "create",
       "--text",
@@ -2852,7 +2696,7 @@ describe("capability cli", () => {
       },
     );
 
-    await runCap("capability", "model", "auth", "logout", "--provider", "openai", "--json");
+    await runCapability("model", "auth", "logout", "--provider", "openai", "--json");
 
     if (updatedStore === null) {
       throw new Error("expected updated auth store");
@@ -2878,8 +2722,7 @@ describe("capability cli", () => {
   it("removes model auth profiles from the selected agent store", async () => {
     mocks.listProfilesForProvider.mockReturnValue(["openai:default"] as never);
 
-    await runCap(
-      "capability",
+    await runCapability(
       "model",
       "auth",
       "logout",
@@ -2905,7 +2748,7 @@ describe("capability cli", () => {
     mocks.updateAuthProfileStoreWithLock.mockResolvedValueOnce(null as never);
 
     await expect(
-      runCap("capability", "model", "auth", "logout", "--provider", "openai", "--json"),
+      runCapability("model", "auth", "logout", "--provider", "openai", "--json"),
     ).rejects.toThrow("exit 1");
 
     expectRuntimeErrorContains("Failed to remove saved auth profiles for provider openai.");
@@ -2959,7 +2802,7 @@ describe("capability cli", () => {
       { id: "generic", defaultModel: "generic-embed", transport: "remote" },
     ] as never);
 
-    await runCap("capability", "embedding", "providers", "--json");
+    await runCapability("embedding", "providers", "--json");
 
     expect(firstJsonOutput()).toMatchObject([
       { id: "generic", defaultModel: "generic-embed", transport: "remote" },
@@ -2990,7 +2833,7 @@ describe("capability cli", () => {
       ]),
     );
 
-    await runCap("capability", "audio", "providers", "--json");
+    await runCapability("audio", "providers", "--json");
 
     expect(mocks.runtime.writeJson).toHaveBeenCalledWith([
       {
@@ -3047,7 +2890,7 @@ describe("capability cli", () => {
       selected: candidate,
     });
 
-    await runCap("capability", "audio", "providers", "--json");
+    await runCapability("audio", "providers", "--json");
 
     expect(firstJsonOutput()).toEqual([
       {
@@ -3136,7 +2979,7 @@ describe("capability cli", () => {
     const webSearchRuntime = await import("../web-search/runtime.js");
     vi.mocked(webSearchRuntime.runWebSearch).mockClear();
     await expect(
-      runCap("capability", "web", "search", "--query", "ping", "--limit", "3x"),
+      runCapability("web", "search", "--query", "ping", "--limit", "3x"),
     ).rejects.toThrow("exit 1");
     expectRuntimeErrorContains("--limit must be a positive integer");
     expect(webSearchRuntime.runWebSearch).not.toHaveBeenCalled();
@@ -3377,7 +3220,7 @@ describe("capability cli", () => {
     mocks.isWebSearchProviderConfigured.mockReturnValueOnce(false).mockReturnValueOnce(true);
     mocks.isWebFetchProviderConfigured.mockReturnValueOnce(true);
 
-    await runCap("capability", "web", "providers", "--json");
+    await runCapability("web", "providers", "--json");
 
     expect(mocks.runtime.writeJson).toHaveBeenCalledWith({
       search: [
@@ -3419,7 +3262,7 @@ describe("capability cli", () => {
       { id: "gemini", defaultModel: "gemini-embedding-001", transport: "remote" },
     ]);
 
-    await runCap("capability", "embedding", "providers", "--json");
+    await runCapability("embedding", "providers", "--json");
 
     expect(mocks.runtime.writeJson).toHaveBeenCalledWith([
       {
@@ -3456,7 +3299,7 @@ describe("capability cli", () => {
       { id: "openai-compatible", transport: "remote" },
     ] as never);
 
-    await runCap("capability", "embedding", "providers", "--json");
+    await runCapability("embedding", "providers", "--json");
 
     expect(mocks.runtime.writeJson).toHaveBeenCalledWith([
       {
@@ -3503,7 +3346,7 @@ describe("capability cli", () => {
       { id: "openai-compatible", transport: "remote" },
     ] as never);
 
-    await runCap("capability", "embedding", "providers", "--json");
+    await runCapability("embedding", "providers", "--json");
 
     expect(mocks.runtime.writeJson).toHaveBeenCalledWith([
       {

--- a/src/cli/plugins-cli.install.test.ts
+++ b/src/cli/plugins-cli.install.test.ts
@@ -243,30 +243,27 @@ function primeSuccessfulPluginPersistence(pluginId = "demo") {
   return { cfg, enabledCfg };
 }
 
-function primeClawHubPluginInstall(
-  params: Partial<Parameters<typeof createClawHubInstallResult>[0]> & { pin?: boolean } = {},
+function primeSuccessfulClawHubPluginInstall(
+  params: {
+    explicitVersion?: boolean;
+    trust?: Parameters<typeof createClawHubInstallResult>[0]["trust"];
+  } = {},
 ) {
-  const { pin = false, ...overrides } = params;
-  const pluginId = overrides.pluginId ?? "demo";
-  const packageName = overrides.packageName ?? pluginId;
-  const version = overrides.version ?? "1.2.3";
-  const persistence = primeSuccessfulPluginPersistence(pluginId);
-
+  const result = primeSuccessfulPluginPersistence("demo");
   parseClawHubPluginSpec.mockReturnValue({
-    name: packageName,
-    ...(pin ? { version } : {}),
+    name: "demo",
+    ...(params.explicitVersion ? { version: "1.2.3" } : {}),
   });
   installPluginFromClawHub.mockResolvedValue(
     createClawHubInstallResult({
-      pluginId,
-      packageName,
-      version,
+      pluginId: "demo",
+      packageName: "demo",
+      version: "1.2.3",
       channel: "official",
-      ...overrides,
+      ...(params.trust ? { trust: params.trust } : {}),
     }),
   );
-
-  return persistence;
+  return result;
 }
 
 function createPathHookPackInstalledConfig(tmpRoot: string): OpenClawConfig {
@@ -499,10 +496,50 @@ async function runAcknowledgedPluginsInstallCommand(args: string[]): Promise<voi
   await runPluginsCommand(withNonClawHubInstallAcknowledgement(args));
 }
 
+function primeInstallConfigSnapshot(params: {
+  config?: OpenClawConfig;
+  configPath?: string;
+  hash: string;
+  parsed: Record<string, unknown>;
+  includeFileHashesForWrite?: Record<string, string>;
+  includeFileTargetsForWrite?: Record<string, string>;
+}): void {
+  const configPath = params.configPath ?? path.join(process.cwd(), "openclaw.json5");
+  const config = params.config ?? ({} as OpenClawConfig);
+  loadConfig.mockReturnValue(config);
+  readConfigFileSnapshotForWrite.mockResolvedValue({
+    snapshot: {
+      path: configPath,
+      exists: true,
+      raw: JSON.stringify(params.parsed),
+      parsed: params.parsed,
+      resolved: config,
+      sourceConfig: config,
+      runtimeConfig: config,
+      valid: true,
+      config,
+      hash: params.hash,
+      issues: [],
+      warnings: [],
+      legacyIssues: [],
+    },
+    writeOptions: {
+      assertConfigPathForWrite: () => {},
+      expectedConfigPath: configPath,
+      ownedConfigPathForWrite: configPath,
+      ...(params.includeFileHashesForWrite
+        ? { includeFileHashesForWrite: params.includeFileHashesForWrite }
+        : {}),
+      ...(params.includeFileTargetsForWrite
+        ? { includeFileTargetsForWrite: params.includeFileTargetsForWrite }
+        : {}),
+    },
+  });
+}
+
 function primeBlockedPluginConfigMutation(
   params: { blockHooks?: boolean; config?: OpenClawConfig } = {},
 ): void {
-  const configPath = path.join(process.cwd(), "openclaw.json5");
   const externalPluginsPath = path.join(
     path.parse(process.cwd()).root,
     "external-openclaw",
@@ -513,36 +550,16 @@ function primeBlockedPluginConfigMutation(
     "external-openclaw",
     "hooks.json5",
   );
-  const config = params.config ?? ({} as OpenClawConfig);
-  const parsed = {
-    plugins: { $include: externalPluginsPath },
-    ...(params.blockHooks ? { hooks: { $include: externalHooksPath } } : {}),
-  };
-  loadConfig.mockReturnValue(config);
-  readConfigFileSnapshotForWrite.mockResolvedValue({
-    snapshot: {
-      path: configPath,
-      exists: true,
-      raw: JSON.stringify(parsed),
-      parsed,
-      resolved: config,
-      sourceConfig: config,
-      runtimeConfig: config,
-      valid: true,
-      config,
-      hash: "blocked-plugin-config",
-      issues: [],
-      warnings: [],
-      legacyIssues: [],
+  primeInstallConfigSnapshot({
+    config: params.config,
+    hash: "blocked-plugin-config",
+    parsed: {
+      plugins: { $include: externalPluginsPath },
+      ...(params.blockHooks ? { hooks: { $include: externalHooksPath } } : {}),
     },
-    writeOptions: {
-      assertConfigPathForWrite: () => {},
-      expectedConfigPath: configPath,
-      ownedConfigPathForWrite: configPath,
-      includeFileTargetsForWrite: {
-        [externalPluginsPath]: externalPluginsPath,
-        ...(params.blockHooks ? { [externalHooksPath]: externalHooksPath } : {}),
-      },
+    includeFileTargetsForWrite: {
+      [externalPluginsPath]: externalPluginsPath,
+      ...(params.blockHooks ? { [externalHooksPath]: externalHooksPath } : {}),
     },
   });
 }
@@ -553,96 +570,40 @@ function primeNestedPluginConfigMutation(tempRoot: string): void {
   const pluginsRaw = `${JSON.stringify({ entries: { $include: "./entries.json5" } }, null, 2)}\n`;
   const config = { plugins: { entries: {} } } as OpenClawConfig;
   fs.writeFileSync(pluginsPath, pluginsRaw);
-  loadConfig.mockReturnValue(config);
-  readConfigFileSnapshotForWrite.mockResolvedValue({
-    snapshot: {
-      path: configPath,
-      exists: true,
-      raw: JSON.stringify({ plugins: { $include: "./plugins.json5" } }),
-      parsed: { plugins: { $include: "./plugins.json5" } },
-      resolved: config,
-      sourceConfig: config,
-      runtimeConfig: config,
-      valid: true,
-      config,
-      hash: "nested-plugin-config",
-      issues: [],
-      warnings: [],
-      legacyIssues: [],
+  primeInstallConfigSnapshot({
+    config,
+    configPath,
+    hash: "nested-plugin-config",
+    parsed: { plugins: { $include: "./plugins.json5" } },
+    includeFileHashesForWrite: {
+      [pluginsPath]: hashConfigIncludeRaw(pluginsRaw),
     },
-    writeOptions: {
-      assertConfigPathForWrite: () => {},
-      expectedConfigPath: configPath,
-      ownedConfigPathForWrite: configPath,
-      includeFileHashesForWrite: {
-        [pluginsPath]: hashConfigIncludeRaw(pluginsRaw),
-      },
-      includeFileTargetsForWrite: {
-        [pluginsPath]: fs.realpathSync(pluginsPath),
-      },
+    includeFileTargetsForWrite: {
+      [pluginsPath]: fs.realpathSync(pluginsPath),
     },
   });
 }
 
 function primeBlockedRootConfigMutation(config = {} as OpenClawConfig): void {
-  const configPath = path.join(process.cwd(), "openclaw.json5");
-  loadConfig.mockReturnValue(config);
-  readConfigFileSnapshotForWrite.mockResolvedValue({
-    snapshot: {
-      path: configPath,
-      exists: true,
-      raw: JSON.stringify({ $include: "./shared.json5", plugins: {} }),
-      parsed: { $include: "./shared.json5", plugins: {} },
-      resolved: config,
-      sourceConfig: config,
-      runtimeConfig: config,
-      valid: true,
-      config,
-      hash: "blocked-root-config",
-      issues: [],
-      warnings: [],
-      legacyIssues: [],
-    },
-    writeOptions: {
-      assertConfigPathForWrite: () => {},
-      expectedConfigPath: configPath,
-      ownedConfigPathForWrite: configPath,
-    },
+  primeInstallConfigSnapshot({
+    config,
+    hash: "blocked-root-config",
+    parsed: { $include: "./shared.json5", plugins: {} },
   });
 }
 
 function primeBlockedHookConfigMutation(config = {} as OpenClawConfig): void {
-  const configPath = path.join(process.cwd(), "openclaw.json5");
   const externalHooksPath = path.join(
     path.parse(process.cwd()).root,
     "external-openclaw",
     "hooks.json5",
   );
-  const parsed = { hooks: { $include: externalHooksPath } };
-  loadConfig.mockReturnValue(config);
-  readConfigFileSnapshotForWrite.mockResolvedValue({
-    snapshot: {
-      path: configPath,
-      exists: true,
-      raw: JSON.stringify(parsed),
-      parsed,
-      resolved: config,
-      sourceConfig: config,
-      runtimeConfig: config,
-      valid: true,
-      config,
-      hash: "blocked-hook-config",
-      issues: [],
-      warnings: [],
-      legacyIssues: [],
-    },
-    writeOptions: {
-      assertConfigPathForWrite: () => {},
-      expectedConfigPath: configPath,
-      ownedConfigPathForWrite: configPath,
-      includeFileTargetsForWrite: {
-        [externalHooksPath]: externalHooksPath,
-      },
+  primeInstallConfigSnapshot({
+    config,
+    hash: "blocked-hook-config",
+    parsed: { hooks: { $include: externalHooksPath } },
+    includeFileTargetsForWrite: {
+      [externalHooksPath]: externalHooksPath,
     },
   });
 }
@@ -1605,7 +1566,7 @@ describe("plugins cli install", () => {
   );
 
   it("does not show the non-ClawHub warning for explicit ClawHub installs", async () => {
-    primeClawHubPluginInstall();
+    primeSuccessfulClawHubPluginInstall();
     await runPluginsCommand(["plugins", "install", "clawhub:demo"]);
 
     expect(runtimeLogsContain("outside ClawHub review")).toBe(false);
@@ -1613,7 +1574,7 @@ describe("plugins cli install", () => {
   });
 
   it("installs ClawHub plugins and persists source metadata", async () => {
-    const { enabledCfg } = primeClawHubPluginInstall();
+    const { enabledCfg } = primeSuccessfulClawHubPluginInstall();
 
     await runPluginsCommand(["plugins", "install", "clawhub:demo"]);
 
@@ -1646,7 +1607,7 @@ describe("plugins cli install", () => {
   });
 
   it("does not report a ClawHub install when durable persistence fails", async () => {
-    primeClawHubPluginInstall();
+    primeSuccessfulClawHubPluginInstall();
     writeConfigFile.mockRejectedValueOnce(new Error("persistence failed"));
 
     await expect(runPluginsCommand(["plugins", "install", "clawhub:demo"])).rejects.toThrow(
@@ -1657,7 +1618,7 @@ describe("plugins cli install", () => {
   });
 
   it("passes ClawHub risk acknowledgement to explicit ClawHub installs", async () => {
-    primeClawHubPluginInstall({
+    primeSuccessfulClawHubPluginInstall({
       trust: {
         disposition: "review-required",
         scanStatus: "suspicious",
@@ -1720,7 +1681,7 @@ describe("plugins cli install", () => {
 
   it("passes the active profile extensions dir to ClawHub installs", async () => {
     const extensionsDir = useProfileExtensionsDir();
-    primeClawHubPluginInstall();
+    primeSuccessfulClawHubPluginInstall();
 
     await runPluginsCommand(["plugins", "install", "clawhub:demo"]);
 
@@ -1848,7 +1809,7 @@ describe("plugins cli install", () => {
   });
 
   it("passes force through as overwrite mode for ClawHub installs", async () => {
-    primeClawHubPluginInstall();
+    primeSuccessfulClawHubPluginInstall();
 
     await runPluginsCommand(["plugins", "install", "clawhub:demo", "--force"]);
 
@@ -1857,7 +1818,7 @@ describe("plugins cli install", () => {
   });
 
   it("keeps explicit ClawHub versions pinned in install records", async () => {
-    primeClawHubPluginInstall({ pin: true });
+    primeSuccessfulClawHubPluginInstall({ explicitVersion: true });
 
     await runPluginsCommand(["plugins", "install", "clawhub:demo@1.2.3"]);
 

--- a/src/cli/plugins-cli.install.test.ts
+++ b/src/cli/plugins-cli.install.test.ts
@@ -243,6 +243,32 @@ function primeSuccessfulPluginPersistence(pluginId = "demo") {
   return { cfg, enabledCfg };
 }
 
+function primeClawHubPluginInstall(
+  params: Partial<Parameters<typeof createClawHubInstallResult>[0]> & { pin?: boolean } = {},
+) {
+  const { pin = false, ...overrides } = params;
+  const pluginId = overrides.pluginId ?? "demo";
+  const packageName = overrides.packageName ?? pluginId;
+  const version = overrides.version ?? "1.2.3";
+  const persistence = primeSuccessfulPluginPersistence(pluginId);
+
+  parseClawHubPluginSpec.mockReturnValue({
+    name: packageName,
+    ...(pin ? { version } : {}),
+  });
+  installPluginFromClawHub.mockResolvedValue(
+    createClawHubInstallResult({
+      pluginId,
+      packageName,
+      version,
+      channel: "official",
+      ...overrides,
+    }),
+  );
+
+  return persistence;
+}
+
 function createPathHookPackInstalledConfig(tmpRoot: string): OpenClawConfig {
   return {
     hooks: {
@@ -1579,16 +1605,7 @@ describe("plugins cli install", () => {
   );
 
   it("does not show the non-ClawHub warning for explicit ClawHub installs", async () => {
-    primeSuccessfulPluginPersistence("demo");
-    parseClawHubPluginSpec.mockReturnValue({ name: "demo" });
-    installPluginFromClawHub.mockResolvedValue(
-      createClawHubInstallResult({
-        pluginId: "demo",
-        packageName: "demo",
-        version: "1.2.3",
-        channel: "official",
-      }),
-    );
+    primeClawHubPluginInstall();
     await runPluginsCommand(["plugins", "install", "clawhub:demo"]);
 
     expect(runtimeLogsContain("outside ClawHub review")).toBe(false);
@@ -1596,27 +1613,7 @@ describe("plugins cli install", () => {
   });
 
   it("installs ClawHub plugins and persists source metadata", async () => {
-    const cfg = {
-      plugins: {
-        entries: {},
-      },
-    } as OpenClawConfig;
-    const enabledCfg = createEnabledPluginConfig("demo");
-    loadConfig.mockReturnValue(cfg);
-    parseClawHubPluginSpec.mockReturnValue({ name: "demo" });
-    installPluginFromClawHub.mockResolvedValue(
-      createClawHubInstallResult({
-        pluginId: "demo",
-        packageName: "demo",
-        version: "1.2.3",
-        channel: "official",
-      }),
-    );
-    enablePluginInConfig.mockReturnValue({ config: enabledCfg });
-    applyExclusiveSlotSelection.mockReturnValue({
-      config: enabledCfg,
-      warnings: [],
-    });
+    const { enabledCfg } = primeClawHubPluginInstall();
 
     await runPluginsCommand(["plugins", "install", "clawhub:demo"]);
 
@@ -1649,21 +1646,7 @@ describe("plugins cli install", () => {
   });
 
   it("does not report a ClawHub install when durable persistence fails", async () => {
-    loadConfig.mockReturnValue(createEmptyPluginConfig());
-    parseClawHubPluginSpec.mockReturnValue({ name: "demo" });
-    installPluginFromClawHub.mockResolvedValue(
-      createClawHubInstallResult({
-        pluginId: "demo",
-        packageName: "demo",
-        version: "1.2.3",
-        channel: "official",
-      }),
-    );
-    enablePluginInConfig.mockReturnValue({ config: createEnabledPluginConfig("demo") });
-    applyExclusiveSlotSelection.mockReturnValue({
-      config: createEnabledPluginConfig("demo"),
-      warnings: [],
-    });
+    primeClawHubPluginInstall();
     writeConfigFile.mockRejectedValueOnce(new Error("persistence failed"));
 
     await expect(runPluginsCommand(["plugins", "install", "clawhub:demo"])).rejects.toThrow(
@@ -1674,27 +1657,14 @@ describe("plugins cli install", () => {
   });
 
   it("passes ClawHub risk acknowledgement to explicit ClawHub installs", async () => {
-    loadConfig.mockReturnValue(createEmptyPluginConfig());
-    parseClawHubPluginSpec.mockReturnValue({ name: "demo" });
-    installPluginFromClawHub.mockResolvedValue(
-      createClawHubInstallResult({
-        pluginId: "demo",
-        packageName: "demo",
-        version: "1.2.3",
-        channel: "official",
-        trust: {
-          disposition: "review-required",
-          scanStatus: "suspicious",
-          reasons: ["payload_strings"],
-          checkedAt: "2026-05-14T18:00:00.000Z",
-          acknowledgedAt: "2026-05-14T18:00:03.000Z",
-        },
-      }),
-    );
-    enablePluginInConfig.mockReturnValue({ config: createEnabledPluginConfig("demo") });
-    applyExclusiveSlotSelection.mockReturnValue({
-      config: createEnabledPluginConfig("demo"),
-      warnings: [],
+    primeClawHubPluginInstall({
+      trust: {
+        disposition: "review-required",
+        scanStatus: "suspicious",
+        reasons: ["payload_strings"],
+        checkedAt: "2026-05-14T18:00:00.000Z",
+        acknowledgedAt: "2026-05-14T18:00:03.000Z",
+      },
     });
 
     await runPluginsCommand(["plugins", "install", "clawhub:demo", "--acknowledge-clawhub-risk"]);
@@ -1750,24 +1720,7 @@ describe("plugins cli install", () => {
 
   it("passes the active profile extensions dir to ClawHub installs", async () => {
     const extensionsDir = useProfileExtensionsDir();
-    const cfg = createEmptyPluginConfig();
-    const enabledCfg = createEnabledPluginConfig("demo");
-
-    loadConfig.mockReturnValue(cfg);
-    parseClawHubPluginSpec.mockReturnValue({ name: "demo" });
-    installPluginFromClawHub.mockResolvedValue(
-      createClawHubInstallResult({
-        pluginId: "demo",
-        packageName: "demo",
-        version: "1.2.3",
-        channel: "official",
-      }),
-    );
-    enablePluginInConfig.mockReturnValue({ config: enabledCfg });
-    applyExclusiveSlotSelection.mockReturnValue({
-      config: enabledCfg,
-      warnings: [],
-    });
+    primeClawHubPluginInstall();
 
     await runPluginsCommand(["plugins", "install", "clawhub:demo"]);
 
@@ -1895,29 +1848,7 @@ describe("plugins cli install", () => {
   });
 
   it("passes force through as overwrite mode for ClawHub installs", async () => {
-    const cfg = {
-      plugins: {
-        entries: {},
-      },
-    } as OpenClawConfig;
-    const enabledCfg = createEnabledPluginConfig("demo");
-
-    loadConfig.mockReturnValue(cfg);
-    parseClawHubPluginSpec.mockReturnValue({ name: "demo" });
-    installPluginFromClawHub.mockResolvedValue(
-      createClawHubInstallResult({
-        pluginId: "demo",
-        packageName: "demo",
-        version: "1.2.3",
-        channel: "official",
-      }),
-    );
-    enablePluginInConfig.mockReturnValue({ config: enabledCfg });
-    recordPluginInstall.mockReturnValue(enabledCfg);
-    applyExclusiveSlotSelection.mockReturnValue({
-      config: enabledCfg,
-      warnings: [],
-    });
+    primeClawHubPluginInstall();
 
     await runPluginsCommand(["plugins", "install", "clawhub:demo", "--force"]);
 
@@ -1926,28 +1857,7 @@ describe("plugins cli install", () => {
   });
 
   it("keeps explicit ClawHub versions pinned in install records", async () => {
-    const cfg = {
-      plugins: {
-        entries: {},
-      },
-    } as OpenClawConfig;
-    const enabledCfg = createEnabledPluginConfig("demo");
-
-    loadConfig.mockReturnValue(cfg);
-    parseClawHubPluginSpec.mockReturnValue({ name: "demo", version: "1.2.3" });
-    installPluginFromClawHub.mockResolvedValue(
-      createClawHubInstallResult({
-        pluginId: "demo",
-        packageName: "demo",
-        version: "1.2.3",
-        channel: "official",
-      }),
-    );
-    enablePluginInConfig.mockReturnValue({ config: enabledCfg });
-    applyExclusiveSlotSelection.mockReturnValue({
-      config: enabledCfg,
-      warnings: [],
-    });
+    primeClawHubPluginInstall({ pin: true });
 
     await runPluginsCommand(["plugins", "install", "clawhub:demo@1.2.3"]);
 

--- a/src/cli/run-main.exit.test.ts
+++ b/src/cli/run-main.exit.test.ts
@@ -377,11 +377,11 @@ function makeProxyHandle() {
   };
 }
 
-async function withInteractiveTty(fn: () => Promise<void>): Promise<void> {
+async function withCliTty(value: boolean, fn: () => Promise<void>): Promise<void> {
   const stdinDescriptor = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
   const stdoutDescriptor = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
-  Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: true });
-  Object.defineProperty(process.stdout, "isTTY", { configurable: true, value: true });
+  Object.defineProperty(process.stdin, "isTTY", { configurable: true, value });
+  Object.defineProperty(process.stdout, "isTTY", { configurable: true, value });
   try {
     await fn();
   } finally {
@@ -395,6 +395,36 @@ async function withInteractiveTty(fn: () => Promise<void>): Promise<void> {
     } else {
       Reflect.deleteProperty(process.stdout, "isTTY");
     }
+  }
+}
+
+function withInteractiveTty(fn: () => Promise<void>): Promise<void> {
+  return withCliTty(true, fn);
+}
+
+function runBareCli(): Promise<void> {
+  return withInteractiveTty(() => runCli(["node", "openclaw"]));
+}
+
+function primeBareRootConfig(sourceConfig: ConfigSnapshotStub["sourceConfig"]): void {
+  readConfigFileSnapshotMock.mockResolvedValueOnce({ exists: true, valid: true, sourceConfig });
+}
+
+async function expectNonInteractiveBareCliError(
+  message: string,
+  assert?: () => void,
+): Promise<void> {
+  const previousExitCode = process.exitCode;
+  const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  process.exitCode = undefined;
+  try {
+    await withCliTty(false, () => runCli(["node", "openclaw"]));
+    expect(process.exitCode).toBe(1);
+    expect(errorSpy).toHaveBeenCalledWith(message);
+    assert?.();
+  } finally {
+    errorSpy.mockRestore();
+    process.exitCode = previousExitCode;
   }
 }
 
@@ -2693,7 +2723,7 @@ describe("runCli exit behavior", () => {
     },
   ])("$name", async ({ snapshot }) => {
     readConfigFileSnapshotMock.mockResolvedValueOnce(snapshot);
-    await withInteractiveTty(async () => runCli(["node", "openclaw"]));
+    await runBareCli();
 
     expect(readConfigFileSnapshotMock).toHaveBeenCalledOnce();
     expect(setupWizardCommandMock).toHaveBeenCalledWith({});
@@ -2702,43 +2732,20 @@ describe("runCli exit behavior", () => {
   });
 
   it("points noninteractive fresh bare root invocations to onboarding automation", async () => {
-    const previousExitCode = process.exitCode;
-    const stdinDescriptor = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
-    const stdoutDescriptor = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
-    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    process.exitCode = undefined;
     readConfigFileSnapshotMock.mockResolvedValueOnce({
       exists: false,
       valid: true,
       sourceConfig: {},
     });
-    Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: false });
-    Object.defineProperty(process.stdout, "isTTY", { configurable: true, value: false });
 
-    try {
-      await runCli(["node", "openclaw"]);
-
-      expect(process.exitCode).toBe(1);
-      expect(errorSpy).toHaveBeenCalledWith(
-        "Onboarding needs an interactive TTY. Use `openclaw onboard --non-interactive --accept-risk ...` for automation.",
-      );
-      expect(setupWizardCommandMock).not.toHaveBeenCalled();
-      expect(tryRouteCliMock).not.toHaveBeenCalled();
-      expect(buildProgramMock).not.toHaveBeenCalled();
-    } finally {
-      errorSpy.mockRestore();
-      process.exitCode = previousExitCode;
-      if (stdinDescriptor) {
-        Object.defineProperty(process.stdin, "isTTY", stdinDescriptor);
-      } else {
-        Reflect.deleteProperty(process.stdin, "isTTY");
-      }
-      if (stdoutDescriptor) {
-        Object.defineProperty(process.stdout, "isTTY", stdoutDescriptor);
-      } else {
-        Reflect.deleteProperty(process.stdout, "isTTY");
-      }
-    }
+    await expectNonInteractiveBareCliError(
+      "Onboarding needs an interactive TTY. Use `openclaw onboard --non-interactive --accept-risk ...` for automation.",
+      () => {
+        expect(setupWizardCommandMock).not.toHaveBeenCalled();
+        expect(tryRouteCliMock).not.toHaveBeenCalled();
+        expect(buildProgramMock).not.toHaveBeenCalled();
+      },
+    );
   });
 
   it("starts the gateway-backed TUI for bare root invocations when config already exists", async () => {
@@ -2761,9 +2768,7 @@ describe("runCli exit behavior", () => {
     });
 
     await withEnvAsync({ OPENCLAW_GATEWAY_PASSWORD: "gateway-ref-password" }, async () => {
-      await withInteractiveTty(async () => {
-        await runCli(["node", "openclaw"]);
-      });
+      await runBareCli();
     });
 
     expect(readConfigFileSnapshotMock).toHaveBeenCalledTimes(1);
@@ -2801,9 +2806,7 @@ describe("runCli exit behavior", () => {
       detail: "Gateway default agent has no configured model",
     });
 
-    await withInteractiveTty(async () => {
-      await runCli(["node", "openclaw"]);
-    });
+    await runBareCli();
 
     expect(setupWizardCommandMock).not.toHaveBeenCalled();
     expect(runRemoteGatewayInferenceOnboardingMock).toHaveBeenCalledWith({
@@ -2816,21 +2819,15 @@ describe("runCli exit behavior", () => {
   });
 
   it("keeps missing inference setup local for a local Gateway", async () => {
-    readConfigFileSnapshotMock.mockResolvedValueOnce({
-      exists: true,
-      valid: true,
-      sourceConfig: {
-        gateway: { mode: "local" },
-      },
+    primeBareRootConfig({
+      gateway: { mode: "local" },
     });
     probeGatewayConfiguredModelMock.mockResolvedValueOnce({
       kind: "missing-configured-model",
       detail: "Gateway default agent has no configured model",
     });
 
-    await withInteractiveTty(async () => {
-      await runCli(["node", "openclaw"]);
-    });
+    await runBareCli();
 
     expect(setupWizardCommandMock).toHaveBeenCalledWith({});
     expect(runRemoteGatewayInferenceOnboardingMock).not.toHaveBeenCalled();
@@ -2838,69 +2835,36 @@ describe("runCli exit behavior", () => {
   });
 
   it("does not direct non-interactive remote setup into local onboarding", async () => {
-    readConfigFileSnapshotMock.mockResolvedValueOnce({
-      exists: true,
-      valid: true,
-      sourceConfig: {
-        gateway: {
-          mode: "remote",
-          remote: { url: "wss://gateway.example/ws", token: "remote-token" },
-        },
+    primeBareRootConfig({
+      gateway: {
+        mode: "remote",
+        remote: { url: "wss://gateway.example/ws", token: "remote-token" },
       },
     });
     probeGatewayConfiguredModelMock.mockResolvedValueOnce({
       kind: "missing-configured-model",
       detail: "Gateway default agent has no configured model",
     });
-    const previousExitCode = process.exitCode;
-    const stdinDescriptor = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
-    const stdoutDescriptor = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
-    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: false });
-    Object.defineProperty(process.stdout, "isTTY", { configurable: true, value: false });
-
-    try {
-      await runCli(["node", "openclaw"]);
-
-      expect(process.exitCode).toBe(1);
-      expect(errorSpy).toHaveBeenCalledWith(
-        "Remote Gateway inference setup needs an interactive TTY. Re-run `openclaw` in a terminal connected to this Gateway.",
-      );
-      expect(setupWizardCommandMock).not.toHaveBeenCalled();
-      expect(runRemoteGatewayInferenceOnboardingMock).not.toHaveBeenCalled();
-    } finally {
-      errorSpy.mockRestore();
-      process.exitCode = previousExitCode;
-      if (stdinDescriptor) {
-        Object.defineProperty(process.stdin, "isTTY", stdinDescriptor);
-      } else {
-        Reflect.deleteProperty(process.stdin, "isTTY");
-      }
-      if (stdoutDescriptor) {
-        Object.defineProperty(process.stdout, "isTTY", stdoutDescriptor);
-      } else {
-        Reflect.deleteProperty(process.stdout, "isTTY");
-      }
-    }
+    await expectNonInteractiveBareCliError(
+      "Remote Gateway inference setup needs an interactive TTY. Re-run `openclaw` in a terminal connected to this Gateway.",
+      () => {
+        expect(setupWizardCommandMock).not.toHaveBeenCalled();
+        expect(runRemoteGatewayInferenceOnboardingMock).not.toHaveBeenCalled();
+      },
+    );
   });
 
   it("uses the active local gateway lock port for bare root preflight and TUI handoff", async () => {
-    readConfigFileSnapshotMock.mockResolvedValueOnce({
-      exists: true,
-      valid: true,
-      sourceConfig: {
-        gateway: {
-          mode: "local",
-          port: 18789,
-          auth: { mode: "token", token: "configured-token" },
-        },
+    primeBareRootConfig({
+      gateway: {
+        mode: "local",
+        port: 18789,
+        auth: { mode: "token", token: "configured-token" },
       },
     });
     readActiveGatewayLockPortMock.mockResolvedValueOnce(48789);
 
-    await withInteractiveTty(async () => {
-      await runCli(["node", "openclaw"]);
-    });
+    await runBareCli();
 
     expect(probeGatewayConfiguredModelMock).toHaveBeenCalledWith({
       url: "ws://127.0.0.1:48789",
@@ -2913,23 +2877,17 @@ describe("runCli exit behavior", () => {
   });
 
   it("keeps an explicit gateway port ahead of active local lock metadata", async () => {
-    readConfigFileSnapshotMock.mockResolvedValueOnce({
-      exists: true,
-      valid: true,
-      sourceConfig: {
-        gateway: {
-          mode: "local",
-          port: 18789,
-          auth: { mode: "token", token: "configured-token" },
-        },
+    primeBareRootConfig({
+      gateway: {
+        mode: "local",
+        port: 18789,
+        auth: { mode: "token", token: "configured-token" },
       },
     });
     readActiveGatewayLockPortMock.mockResolvedValueOnce(48789);
 
     await withEnvAsync({ OPENCLAW_GATEWAY_PORT: "19001" }, async () => {
-      await withInteractiveTty(async () => {
-        await runCli(["node", "openclaw"]);
-      });
+      await runBareCli();
     });
 
     expect(readActiveGatewayLockPortMock).not.toHaveBeenCalled();
@@ -2940,15 +2898,11 @@ describe("runCli exit behavior", () => {
   });
 
   it("carries the canonical local TLS fingerprint through bare root", async () => {
-    readConfigFileSnapshotMock.mockResolvedValueOnce({
-      exists: true,
-      valid: true,
-      sourceConfig: {
-        gateway: {
-          mode: "local",
-          tls: { enabled: true },
-          auth: { mode: "token", token: "configured-token" },
-        },
+    primeBareRootConfig({
+      gateway: {
+        mode: "local",
+        tls: { enabled: true },
+        auth: { mode: "token", token: "configured-token" },
       },
     });
     loadGatewayTlsRuntimeMock.mockResolvedValueOnce({
@@ -2957,9 +2911,7 @@ describe("runCli exit behavior", () => {
       fingerprintSha256: "sha256:local-self-signed-fingerprint",
     });
 
-    await withInteractiveTty(async () => {
-      await runCli(["node", "openclaw"]);
-    });
+    await runBareCli();
 
     expect(probeGatewayConfiguredModelMock).toHaveBeenCalledWith({
       url: "wss://127.0.0.1:18789",
@@ -2973,21 +2925,15 @@ describe("runCli exit behavior", () => {
   });
 
   it("uses gateway env credentials for bare root gateway preflight", async () => {
-    readConfigFileSnapshotMock.mockResolvedValueOnce({
-      exists: true,
-      valid: true,
-      sourceConfig: {
-        gateway: {
-          mode: "local",
-          auth: { mode: "token" },
-        },
+    primeBareRootConfig({
+      gateway: {
+        mode: "local",
+        auth: { mode: "token" },
       },
     });
 
     await withEnvAsync({ OPENCLAW_GATEWAY_TOKEN: "env-token" }, async () => {
-      await withInteractiveTty(async () => {
-        await runCli(["node", "openclaw"]);
-      });
+      await runBareCli();
     });
 
     expect(probeGatewayConfiguredModelMock).toHaveBeenCalledWith({
@@ -3015,45 +2961,39 @@ describe("runCli exit behavior", () => {
       "process.stdout.write(JSON.stringify({ protocolVersion: 1, values: { PASSWORD_SECRET: 'password-from-exec' } }));", // pragma: allowlist secret
     ].join("");
     await withSecureTestNodeExecPath(async () => {
-      readConfigFileSnapshotMock.mockResolvedValueOnce({
-        exists: true,
-        valid: true,
-        sourceConfig: {
-          secrets: {
-            providers: {
-              tokenprovider: {
-                source: "exec",
-                command: process.execPath,
-                args: ["-e", tokenProgram],
-                allowInsecurePath: true,
-              },
-              passwordprovider: {
-                source: "exec",
-                command: process.execPath,
-                args: ["-e", passwordProgram],
-                allowInsecurePath: true,
-              },
+      primeBareRootConfig({
+        secrets: {
+          providers: {
+            tokenprovider: {
+              source: "exec",
+              command: process.execPath,
+              args: ["-e", tokenProgram],
+              allowInsecurePath: true,
+            },
+            passwordprovider: {
+              source: "exec",
+              command: process.execPath,
+              args: ["-e", passwordProgram],
+              allowInsecurePath: true,
             },
           },
-          gateway: {
-            mode: "local",
-            auth: {
-              mode: "password",
-              token: { source: "exec", provider: "tokenprovider", id: "TOKEN_SECRET" },
-              password: {
-                source: "exec",
-                provider: "passwordprovider",
-                id: "PASSWORD_SECRET",
-              },
+        },
+        gateway: {
+          mode: "local",
+          auth: {
+            mode: "password",
+            token: { source: "exec", provider: "tokenprovider", id: "TOKEN_SECRET" },
+            password: {
+              source: "exec",
+              provider: "passwordprovider",
+              id: "PASSWORD_SECRET",
             },
           },
         },
       });
 
       try {
-        await withInteractiveTty(async () => {
-          await runCli(["node", "openclaw"]);
-        });
+        await runBareCli();
 
         expect(probeGatewayConfiguredModelMock).toHaveBeenCalledWith({
           url: "ws://127.0.0.1:18789",
@@ -3072,24 +3012,18 @@ describe("runCli exit behavior", () => {
   });
 
   it("probes local gateways over loopback even when the gateway advertises a LAN bind", async () => {
-    readConfigFileSnapshotMock.mockResolvedValueOnce({
-      exists: true,
-      valid: true,
-      sourceConfig: {
-        gateway: {
-          mode: "local",
-          bind: "lan",
-          auth: {
-            mode: "token",
-            token: "local-token",
-          },
+    primeBareRootConfig({
+      gateway: {
+        mode: "local",
+        bind: "lan",
+        auth: {
+          mode: "token",
+          token: "local-token",
         },
       },
     });
 
-    await withInteractiveTty(async () => {
-      await runCli(["node", "openclaw"]);
-    });
+    await runBareCli();
 
     expect(readActiveGatewayLockPortMock).toHaveBeenCalledTimes(1);
     expect(probeGatewayConfiguredModelMock).toHaveBeenCalledWith({
@@ -3103,17 +3037,13 @@ describe("runCli exit behavior", () => {
   });
 
   it("falls back to the configured local tailnet gateway URL when loopback is unavailable", async () => {
-    readConfigFileSnapshotMock.mockResolvedValueOnce({
-      exists: true,
-      valid: true,
-      sourceConfig: {
-        gateway: {
-          mode: "local",
-          bind: "tailnet",
-          auth: {
-            mode: "token",
-            token: "local-token",
-          },
+    primeBareRootConfig({
+      gateway: {
+        mode: "local",
+        bind: "tailnet",
+        auth: {
+          mode: "token",
+          token: "local-token",
         },
       },
     });
@@ -3132,9 +3062,7 @@ describe("runCli exit behavior", () => {
       .mockResolvedValueOnce({ kind: "unreachable", detail: "loopback offline" })
       .mockResolvedValueOnce({ kind: "configured" });
 
-    await withInteractiveTty(async () => {
-      await runCli(["node", "openclaw"]);
-    });
+    await runBareCli();
 
     expect(probeGatewayConfiguredModelMock).toHaveBeenNthCalledWith(1, {
       url: "ws://127.0.0.1:18789",
@@ -3151,15 +3079,11 @@ describe("runCli exit behavior", () => {
   });
 
   it("prefers a configured secondary Gateway over a missing-model primary probe", async () => {
-    readConfigFileSnapshotMock.mockResolvedValueOnce({
-      exists: true,
-      valid: true,
-      sourceConfig: {
-        gateway: {
-          mode: "local",
-          bind: "tailnet",
-          auth: { mode: "token", token: "local-token" },
-        },
+    primeBareRootConfig({
+      gateway: {
+        mode: "local",
+        bind: "tailnet",
+        auth: { mode: "token", token: "local-token" },
       },
     });
     resolveControlUiLinksMock.mockImplementation(({ bind }: { bind?: string } = {}) =>
@@ -3174,9 +3098,7 @@ describe("runCli exit behavior", () => {
       })
       .mockResolvedValueOnce({ kind: "configured" });
 
-    await withInteractiveTty(async () => {
-      await runCli(["node", "openclaw"]);
-    });
+    await runBareCli();
 
     expect(setupWizardCommandMock).not.toHaveBeenCalled();
     expect(launchTuiCliMock).toHaveBeenCalledWith(
@@ -3186,16 +3108,12 @@ describe("runCli exit behavior", () => {
   });
 
   it("keeps confirmed missing inference ahead of an unverified secondary Gateway", async () => {
-    readConfigFileSnapshotMock.mockResolvedValueOnce({
-      exists: true,
-      valid: true,
-      sourceConfig: {
-        agents: { defaults: { model: { primary: "openai/local-only-model" } } },
-        gateway: {
-          mode: "local",
-          bind: "tailnet",
-          auth: { mode: "token", token: "local-token" },
-        },
+    primeBareRootConfig({
+      agents: { defaults: { model: { primary: "openai/local-only-model" } } },
+      gateway: {
+        mode: "local",
+        bind: "tailnet",
+        auth: { mode: "token", token: "local-token" },
       },
     });
     resolveControlUiLinksMock.mockImplementation(({ bind }: { bind?: string } = {}) =>
@@ -3213,9 +3131,7 @@ describe("runCli exit behavior", () => {
         detail: "Gateway default agent has no configured model",
       });
 
-    await withInteractiveTty(async () => {
-      await runCli(["node", "openclaw"]);
-    });
+    await runBareCli();
 
     expect(setupWizardCommandMock).toHaveBeenCalledWith({});
     expect(launchTuiCliMock).not.toHaveBeenCalled();
@@ -3223,22 +3139,16 @@ describe("runCli exit behavior", () => {
 
   it("keeps a reachable unverified Gateway ahead of local inference fallback", async () => {
     const url = "ws://127.0.0.1:18789";
-    readConfigFileSnapshotMock.mockResolvedValueOnce({
-      exists: true,
-      valid: true,
-      sourceConfig: {
-        agents: { defaults: { model: { primary: "openai/local-only-model" } } },
-        gateway: { mode: "remote", remote: { url, token: "remote-token" } },
-      },
+    primeBareRootConfig({
+      agents: { defaults: { model: { primary: "openai/local-only-model" } } },
+      gateway: { mode: "remote", remote: { url, token: "remote-token" } },
     });
     probeGatewayConfiguredModelMock.mockResolvedValueOnce({
       kind: "reachable-unverified",
       detail: "config.get: unauthorized",
     });
 
-    await withInteractiveTty(async () => {
-      await runCli(["node", "openclaw"]);
-    });
+    await runBareCli();
 
     expect(setupWizardCommandMock).not.toHaveBeenCalled();
     expect(launchTuiCliMock).toHaveBeenCalledWith(
@@ -3249,21 +3159,15 @@ describe("runCli exit behavior", () => {
 
   it("keeps a configured remote Gateway authoritative across a transient cold-restart probe", async () => {
     const url = "wss://gateway.example/ws";
-    readConfigFileSnapshotMock.mockResolvedValueOnce({
-      exists: true,
-      valid: true,
-      sourceConfig: {
-        gateway: { mode: "remote", remote: { url, token: "remote-token" } },
-      },
+    primeBareRootConfig({
+      gateway: { mode: "remote", remote: { url, token: "remote-token" } },
     });
     probeGatewayConfiguredModelMock.mockResolvedValueOnce({
       kind: "unreachable",
       detail: "gateway restarting",
     });
 
-    await withInteractiveTty(async () => {
-      await runCli(["node", "openclaw"]);
-    });
+    await runBareCli();
 
     expect(setupWizardCommandMock).not.toHaveBeenCalled();
     expect(runRemoteGatewayInferenceOnboardingMock).not.toHaveBeenCalled();
@@ -3274,21 +3178,15 @@ describe("runCli exit behavior", () => {
   });
 
   it("keeps a configured local Gateway authoritative across a transient cold-restart probe", async () => {
-    readConfigFileSnapshotMock.mockResolvedValueOnce({
-      exists: true,
-      valid: true,
-      sourceConfig: {
-        gateway: { mode: "local", auth: { mode: "token", token: "local-token" } },
-      },
+    primeBareRootConfig({
+      gateway: { mode: "local", auth: { mode: "token", token: "local-token" } },
     });
     probeGatewayConfiguredModelMock.mockResolvedValueOnce({
       kind: "unreachable",
       detail: "offline",
     });
 
-    await withInteractiveTty(async () => {
-      await runCli(["node", "openclaw"]);
-    });
+    await runBareCli();
 
     expect(setupWizardCommandMock).not.toHaveBeenCalled();
     expect(launchTuiCliMock).toHaveBeenCalledWith(
@@ -3298,21 +3196,15 @@ describe("runCli exit behavior", () => {
   });
 
   it("starts the local TUI when no Gateway is configured and the default probe is unavailable", async () => {
-    readConfigFileSnapshotMock.mockResolvedValueOnce({
-      exists: true,
-      valid: true,
-      sourceConfig: {
-        agents: { defaults: { model: { primary: "openai/gpt-5.5" } } },
-      },
+    primeBareRootConfig({
+      agents: { defaults: { model: { primary: "openai/gpt-5.5" } } },
     });
     probeGatewayConfiguredModelMock.mockResolvedValueOnce({
       kind: "unreachable",
       detail: "offline",
     });
 
-    await withInteractiveTty(async () => {
-      await runCli(["node", "openclaw"]);
-    });
+    await runBareCli();
 
     expect(launchTuiCliMock).toHaveBeenCalledWith({ deliver: false, local: true }, {});
   });
@@ -3322,24 +3214,18 @@ describe("runCli exit behavior", () => {
     { label: "mDNS", url: "ws://gateway.local:18789" },
     { label: "Tailnet DNS", url: "ws://machine.tail123.ts.net:18789" },
   ])("does not probe a plaintext remote gateway over $label without opt-in", async ({ url }) => {
-    readConfigFileSnapshotMock.mockResolvedValueOnce({
-      exists: true,
-      valid: true,
-      sourceConfig: {
-        gateway: {
-          mode: "remote",
-          remote: {
-            url,
-            token: "remote-token",
-          },
+    primeBareRootConfig({
+      gateway: {
+        mode: "remote",
+        remote: {
+          url,
+          token: "remote-token",
         },
       },
     });
 
     await withEnvAsync({ OPENCLAW_ALLOW_INSECURE_PRIVATE_WS: undefined }, async () => {
-      await withInteractiveTty(async () => {
-        await runCli(["node", "openclaw"]);
-      });
+      await runBareCli();
     });
 
     expect(probeGatewayConfiguredModelMock).not.toHaveBeenCalled();
@@ -3349,24 +3235,18 @@ describe("runCli exit behavior", () => {
 
   it("probes a plaintext remote loopback gateway", async () => {
     const url = "ws://127.0.0.1:18789";
-    readConfigFileSnapshotMock.mockResolvedValueOnce({
-      exists: true,
-      valid: true,
-      sourceConfig: {
-        gateway: {
-          mode: "remote",
-          remote: {
-            url,
-            token: "remote-token",
-          },
+    primeBareRootConfig({
+      gateway: {
+        mode: "remote",
+        remote: {
+          url,
+          token: "remote-token",
         },
       },
     });
 
     await withEnvAsync({ OPENCLAW_ALLOW_INSECURE_PRIVATE_WS: undefined }, async () => {
-      await withInteractiveTty(async () => {
-        await runCli(["node", "openclaw"]);
-      });
+      await runBareCli();
     });
 
     expect(probeGatewayConfiguredModelMock).toHaveBeenCalledWith({
@@ -3382,24 +3262,18 @@ describe("runCli exit behavior", () => {
 
   it("keeps configured remote password authoritative from preflight through TUI launch", async () => {
     const url = "ws://127.0.0.1:18789";
-    readConfigFileSnapshotMock.mockResolvedValueOnce({
-      exists: true,
-      valid: true,
-      sourceConfig: {
-        gateway: {
-          mode: "remote",
-          remote: {
-            url,
-            password: "configured-remote-password", // pragma: allowlist secret
-          },
+    primeBareRootConfig({
+      gateway: {
+        mode: "remote",
+        remote: {
+          url,
+          password: "configured-remote-password", // pragma: allowlist secret
         },
       },
     });
 
     await withEnvAsync({ OPENCLAW_GATEWAY_PASSWORD: "stale-env-password" }, async () => {
-      await withInteractiveTty(async () => {
-        await runCli(["node", "openclaw"]);
-      });
+      await runBareCli();
     });
 
     expect(probeGatewayConfiguredModelMock).toHaveBeenCalledWith({
@@ -3414,24 +3288,20 @@ describe("runCli exit behavior", () => {
 
   it("falls back to gateway env auth when configured remote SecretRefs are unresolved", async () => {
     const url = "ws://127.0.0.1:18789";
-    readConfigFileSnapshotMock.mockResolvedValueOnce({
-      exists: true,
-      valid: true,
-      sourceConfig: {
-        gateway: {
-          mode: "remote",
-          remote: {
-            url,
-            token: {
-              source: "env",
-              provider: "default",
-              id: "MISSING_REMOTE_GATEWAY_TOKEN",
-            },
-            password: {
-              source: "env",
-              provider: "default",
-              id: "MISSING_REMOTE_GATEWAY_PASSWORD",
-            },
+    primeBareRootConfig({
+      gateway: {
+        mode: "remote",
+        remote: {
+          url,
+          token: {
+            source: "env",
+            provider: "default",
+            id: "MISSING_REMOTE_GATEWAY_TOKEN",
+          },
+          password: {
+            source: "env",
+            provider: "default",
+            id: "MISSING_REMOTE_GATEWAY_PASSWORD",
           },
         },
       },
@@ -3445,9 +3315,7 @@ describe("runCli exit behavior", () => {
         OPENCLAW_GATEWAY_PASSWORD: "env-remote-password",
       },
       async () => {
-        await withInteractiveTty(async () => {
-          await runCli(["node", "openclaw"]);
-        });
+        await runBareCli();
       },
     );
 
@@ -3462,24 +3330,18 @@ describe("runCli exit behavior", () => {
 
   it("probes an explicitly allowed plaintext private remote gateway", async () => {
     const url = "ws://192.168.1.10:18789";
-    readConfigFileSnapshotMock.mockResolvedValueOnce({
-      exists: true,
-      valid: true,
-      sourceConfig: {
-        gateway: {
-          mode: "remote",
-          remote: {
-            url,
-            token: "remote-token",
-          },
+    primeBareRootConfig({
+      gateway: {
+        mode: "remote",
+        remote: {
+          url,
+          token: "remote-token",
         },
       },
     });
 
     await withEnvAsync({ OPENCLAW_ALLOW_INSECURE_PRIVATE_WS: "1" }, async () => {
-      await withInteractiveTty(async () => {
-        await runCli(["node", "openclaw"]);
-      });
+      await runBareCli();
     });
 
     expect(probeGatewayConfiguredModelMock).toHaveBeenCalledWith({
@@ -3494,24 +3356,18 @@ describe("runCli exit behavior", () => {
   });
 
   it("forwards the configured TLS pin when probing a remote gateway", async () => {
-    readConfigFileSnapshotMock.mockResolvedValueOnce({
-      exists: true,
-      valid: true,
-      sourceConfig: {
-        gateway: {
-          mode: "remote",
-          remote: {
-            url: "wss://gateway.example.com:18789",
-            token: "remote-token",
-            tlsFingerprint: "sha256:11:22:33:44",
-          },
+    primeBareRootConfig({
+      gateway: {
+        mode: "remote",
+        remote: {
+          url: "wss://gateway.example.com:18789",
+          token: "remote-token",
+          tlsFingerprint: "sha256:11:22:33:44",
         },
       },
     });
 
-    await withInteractiveTty(async () => {
-      await runCli(["node", "openclaw"]);
-    });
+    await runBareCli();
 
     expect(probeGatewayConfiguredModelMock).toHaveBeenCalledWith({
       url: "wss://gateway.example.com:18789",
@@ -3525,24 +3381,18 @@ describe("runCli exit behavior", () => {
   });
 
   it("routes to inference onboarding without probing a public plaintext remote gateway", async () => {
-    readConfigFileSnapshotMock.mockResolvedValueOnce({
-      exists: true,
-      valid: true,
-      sourceConfig: {
-        gateway: {
-          mode: "remote",
-          remote: {
-            url: "ws://gateway.example.com:18789",
-            token: "remote-token",
-          },
+    primeBareRootConfig({
+      gateway: {
+        mode: "remote",
+        remote: {
+          url: "ws://gateway.example.com:18789",
+          token: "remote-token",
         },
       },
     });
 
     await withEnvAsync({ OPENCLAW_ALLOW_INSECURE_PRIVATE_WS: undefined }, async () => {
-      await withInteractiveTty(async () => {
-        await runCli(["node", "openclaw"]);
-      });
+      await runBareCli();
     });
 
     expect(probeGatewayConfiguredModelMock).not.toHaveBeenCalled();
@@ -3590,73 +3440,28 @@ describe("runCli exit behavior", () => {
       sourceConfig: { gateway: { mode: "local" } },
     });
 
-    await withInteractiveTty(async () => {
-      await runCli(["node", "openclaw"]);
-    });
+    await runBareCli();
 
     expect(setupWizardCommandMock).toHaveBeenCalledWith({ classic: true });
     expect(launchTuiCliMock).not.toHaveBeenCalled();
   });
 
   it("points noninteractive invalid config to doctor before onboarding", async () => {
-    const previousExitCode = process.exitCode;
-    const stdinDescriptor = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
-    const stdoutDescriptor = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
-    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    process.exitCode = undefined;
     readConfigFileSnapshotMock.mockResolvedValueOnce({
       exists: true,
       valid: false,
       sourceConfig: { gateway: { mode: "local" } },
     });
-    Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: false });
-    Object.defineProperty(process.stdout, "isTTY", { configurable: true, value: false });
-
-    try {
-      await runCli(["node", "openclaw"]);
-
-      expect(process.exitCode).toBe(1);
-      expect(errorSpy).toHaveBeenCalledWith(
-        "OpenClaw config is invalid. Run `openclaw doctor --fix` before onboarding.",
-      );
-      expect(setupWizardCommandMock).not.toHaveBeenCalled();
-    } finally {
-      errorSpy.mockRestore();
-      process.exitCode = previousExitCode;
-      if (stdinDescriptor) {
-        Object.defineProperty(process.stdin, "isTTY", stdinDescriptor);
-      } else {
-        Reflect.deleteProperty(process.stdin, "isTTY");
-      }
-      if (stdoutDescriptor) {
-        Object.defineProperty(process.stdout, "isTTY", stdoutDescriptor);
-      } else {
-        Reflect.deleteProperty(process.stdout, "isTTY");
-      }
-    }
+    await expectNonInteractiveBareCliError(
+      "OpenClaw config is invalid. Run `openclaw doctor --fix` before onboarding.",
+      () => expect(setupWizardCommandMock).not.toHaveBeenCalled(),
+    );
   });
 
   it("bootstraps env proxy before bare TUI startup", async () => {
     hasEnvHttpProxyAgentConfiguredMock.mockReturnValue(true);
-    const stdinTty = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
-    const stdoutTty = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
-    Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: true });
-    Object.defineProperty(process.stdout, "isTTY", { configurable: true, value: true });
 
-    try {
-      await runCli(["node", "openclaw"]);
-    } finally {
-      if (stdinTty) {
-        Object.defineProperty(process.stdin, "isTTY", stdinTty);
-      } else {
-        delete (process.stdin as { isTTY?: boolean }).isTTY;
-      }
-      if (stdoutTty) {
-        Object.defineProperty(process.stdout, "isTTY", stdoutTty);
-      } else {
-        delete (process.stdout as { isTTY?: boolean }).isTTY;
-      }
-    }
+    await runBareCli();
 
     expect(ensureGlobalUndiciEnvProxyDispatcherMock).toHaveBeenCalledTimes(1);
     expect(launchTuiCliMock).toHaveBeenCalledOnce();

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -20,6 +20,7 @@ import {
   UPDATE_POST_INSTALL_DOCTOR_RESULT_PATH_ENV,
   writeUpdatePostInstallDoctorResult,
 } from "../infra/update-doctor-result.js";
+import { cleanupStaleManagedServiceUpdateHandoffs } from "../infra/update-managed-service-handoff-cleanup.js";
 import type { UpdateRunResult } from "../infra/update-runner.js";
 import { CLAWHUB_INSTALL_ERROR_CODE } from "../plugins/clawhub-error-codes.js";
 import { captureEnv, withEnvAsync } from "../test-utils/env.js";
@@ -43,6 +44,11 @@ const resolveGlobalManager = vi.fn();
 const serviceLoaded = vi.fn();
 const serviceStop = vi.fn();
 const serviceRestart = vi.fn();
+const isDefaultInstallIdentity = vi.hoisted(() =>
+  vi.fn<(env?: NodeJS.ProcessEnv, homedir?: () => string, platform?: NodeJS.Platform) => boolean>(
+    () => true,
+  ),
+);
 const suspendScheduledTaskAutoStartForUpdate = vi.fn();
 const resumeScheduledTaskAutoStartAfterUpdate = vi.fn();
 const prepareRestartScript = vi.fn();
@@ -321,7 +327,12 @@ vi.mock("../config/backup-rotation.js", () => ({
 }));
 
 vi.mock("../daemon/service.js", () => ({
-  readGatewayServiceState: async () => {
+  readGatewayServiceState: async (
+    _service: unknown,
+    args?: {
+      validateEnvBeforeStatusRead?: (env: NodeJS.ProcessEnv) => void;
+    },
+  ) => {
     const command = await serviceReadCommand();
     const env = {
       ...process.env,
@@ -329,6 +340,7 @@ vi.mock("../daemon/service.js", () => ({
         ? (command.environment as NodeJS.ProcessEnv | undefined)
         : undefined),
     };
+    args?.validateEnvBeforeStatusRead?.(env);
     const [loaded, runtime] = await Promise.all([
       serviceLoaded({ env }).catch(() => false),
       serviceReadRuntime(env).catch(() => undefined),
@@ -362,6 +374,15 @@ vi.mock("../daemon/schtasks.js", () => ({
     suspendScheduledTaskAutoStartForUpdate(...args),
   resumeScheduledTaskAutoStartAfterUpdate: (...args: unknown[]) =>
     resumeScheduledTaskAutoStartAfterUpdate(...args),
+}));
+
+vi.mock("../config/paths.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../config/paths.js")>()),
+  isDefaultInstallIdentity: (
+    env?: NodeJS.ProcessEnv,
+    homedir?: () => string,
+    platform?: NodeJS.Platform,
+  ) => isDefaultInstallIdentity(env, homedir, platform),
 }));
 
 vi.mock("../infra/ports.js", () => ({
@@ -511,6 +532,36 @@ describe("update-cli", () => {
     warnings: [],
     legacyIssues: [],
   };
+
+  const clawHubRiskWarning =
+    "╭─ WARNING - ClawHub found security risks in this release ─╮\n" +
+    "│ • Security scan:     suspicious                                      │\n" +
+    "╰───────────────────────────────────────────────────────────────────────╯";
+  const clawHubSuspiciousPayloadWarning =
+    "╭─ WARNING - ClawHub found security risks in this release ─╮\n" +
+    "│ • Security scan:     suspicious                                      │\n" +
+    "│ • Finding:           suspicious payload strings                       │\n" +
+    "╰───────────────────────────────────────────────────────────────────────╯";
+  const clawHubSyncRiskError =
+    "Failed to update demo: Update cancelled; rerun with --acknowledge-clawhub-risk to continue after reviewing the warning. (ClawHub clawhub:demo@1.2.4).";
+
+  const createClawHubRiskRequest = (
+    overrides: Partial<ClawHubRiskAcknowledgementRequest> = {},
+  ): ClawHubRiskAcknowledgementRequest => ({
+    packageName: "demo",
+    version: "1.2.3",
+    trust: {
+      scanStatus: "suspicious",
+      moderationState: null,
+      blockedFromDownload: false,
+      reasons: ["payload_strings"],
+      pending: false,
+      stale: false,
+    },
+    acknowledgementKind: "confirm",
+    warning: clawHubRiskWarning,
+    ...overrides,
+  });
 
   const setTty = (value: boolean | undefined) => {
     Object.defineProperty(process.stdin, "isTTY", {
@@ -958,7 +1009,11 @@ describe("update-cli", () => {
     });
   };
 
-  const pluginSyncResult = (config: OpenClawConfig, changed = false) => ({
+  const pluginSyncResult = (
+    config: OpenClawConfig,
+    changed = false,
+    overrides: { warnings?: string[]; errors?: string[] } = {},
+  ) => ({
     changed,
     config,
     summary: {
@@ -967,6 +1022,7 @@ describe("update-cli", () => {
       switchedToNpm: [],
       warnings: [],
       errors: [],
+      ...overrides,
     },
   });
 
@@ -1043,18 +1099,43 @@ describe("update-cli", () => {
     );
   };
 
-  const setupInstalledPackageAtNodeModules = async (nodeModules: string, version = "2026.4.21") => {
-    const pkgRoot = path.join(nodeModules, "openclaw");
-    const entryPath = path.join(pkgRoot, "dist", "index.js");
-    mockPackageInstallStatus(pkgRoot);
-    await fs.mkdir(path.dirname(entryPath), { recursive: true });
+  const writeOpenClawPackageFixture = async (
+    root: string,
+    version: string,
+    options: { entrySource?: string; sidecars?: boolean; inventory?: boolean } = {},
+  ) => {
+    const entryPath = path.join(root, "dist", "index.js");
+    await fs.mkdir(options.entrySource === undefined ? root : path.dirname(entryPath), {
+      recursive: true,
+    });
     await fs.writeFile(
-      path.join(pkgRoot, "package.json"),
+      path.join(root, "package.json"),
       JSON.stringify({ name: "openclaw", version }),
       "utf-8",
     );
-    await fs.writeFile(entryPath, "export {};\n", "utf-8");
-    await writePackageDistInventory(pkgRoot);
+    if (options.entrySource !== undefined) {
+      await fs.writeFile(entryPath, options.entrySource, "utf-8");
+    }
+    if (options.sidecars) {
+      for (const relativePath of TEST_BUNDLED_RUNTIME_SIDECAR_PATHS) {
+        const absolutePath = path.join(root, relativePath);
+        await fs.mkdir(path.dirname(absolutePath), { recursive: true });
+        await fs.writeFile(absolutePath, "export {};\n", "utf-8");
+      }
+    }
+    if (options.inventory) {
+      await writePackageDistInventory(root);
+    }
+    return entryPath;
+  };
+
+  const setupInstalledPackageAtNodeModules = async (nodeModules: string, version = "2026.4.21") => {
+    const pkgRoot = path.join(nodeModules, "openclaw");
+    mockPackageInstallStatus(pkgRoot);
+    const entryPath = await writeOpenClawPackageFixture(pkgRoot, version, {
+      entrySource: "export {};\n",
+      inventory: true,
+    });
     return { nodeModules, pkgRoot, entryPath };
   };
 
@@ -1073,6 +1154,28 @@ describe("update-cli", () => {
     });
     serviceLoaded.mockResolvedValue(true);
     serviceReadRuntime.mockResolvedValue({ status: "running", pid: 4242, state: "running" });
+  };
+
+  const mockStoppedManagedGitGateway = () => {
+    mockRunningManagedGateway([
+      "node",
+      path.join(process.cwd(), "dist", "index.js"),
+      "gateway",
+      "run",
+    ]);
+    serviceLoaded.mockResolvedValue(false);
+    serviceLoaded.mockResolvedValueOnce(true);
+    serviceReadRuntime.mockResolvedValue({ status: "stopped", pid: null, state: "stopped" });
+    serviceReadRuntime.mockResolvedValueOnce({ status: "running", pid: 4242, state: "running" });
+  };
+
+  const expectFailedManagedGitRestart = (message: string) => {
+    const logs = getLogOutput();
+    expect(serviceStop).toHaveBeenCalledTimes(1);
+    expect(runRestartScript).toHaveBeenCalledTimes(1);
+    expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
+    expect(logs).toContain(message);
+    expect(logs).not.toContain("Gateway: restarted and verified.");
   };
 
   const mockGatewayProbe = (version: string, connId: string) => {
@@ -1285,6 +1388,8 @@ describe("update-cli", () => {
     resolveGlobalManager.mockResolvedValue("npm");
     serviceStop.mockResolvedValue(undefined);
     serviceRestart.mockResolvedValue({ outcome: "completed" });
+    isDefaultInstallIdentity.mockReset();
+    isDefaultInstallIdentity.mockReturnValue(true);
     suspendScheduledTaskAutoStartForUpdate.mockResolvedValue(false);
     resumeScheduledTaskAutoStartAfterUpdate.mockResolvedValue(false);
     serviceLoaded.mockResolvedValue(false);
@@ -1309,22 +1414,8 @@ describe("update-cli", () => {
     formatPortDiagnostics.mockReturnValue(["Port 18789 is already in use."]);
     mockGatewayProbe("1.0.0", "conn-test");
     pathExists.mockResolvedValue(false);
-    syncPluginsForUpdateChannel.mockResolvedValue({
-      changed: false,
-      config: baseConfig,
-      summary: {
-        switchedToBundled: [],
-        switchedToClawHub: [],
-        switchedToNpm: [],
-        warnings: [],
-        errors: [],
-      },
-    });
-    updateNpmInstalledPlugins.mockResolvedValue({
-      changed: false,
-      config: baseConfig,
-      outcomes: [],
-    });
+    syncPluginsForUpdateChannel.mockResolvedValue(pluginSyncResult(baseConfig));
+    updateNpmInstalledPlugins.mockResolvedValue(npmPluginUpdateResult(baseConfig));
     checkShellCompletionStatus.mockResolvedValue({
       shell: "zsh",
       profileInstalled: false,
@@ -2393,10 +2484,7 @@ describe("update-cli", () => {
     vi.mocked(resolveGatewayInstallEntrypoint).mockResolvedValueOnce(
       "/tmp/openclaw-updated-entry.mjs",
     );
-    const trustWarning =
-      "╭─ WARNING - ClawHub found security risks in this release ─╮\n" +
-      "│ • Security scan:     suspicious                                      │\n" +
-      "╰───────────────────────────────────────────────────────────────────────╯";
+    const trustWarning = clawHubRiskWarning;
     const coloredTrustWarning = `\u001b[33m${trustWarning}\u001b[39m`;
     updateNpmInstalledPlugins.mockImplementationOnce(
       async (params: {
@@ -2432,24 +2520,13 @@ describe("update-cli", () => {
   });
 
   it("includes failed ClawHub sync trust warnings in json post-core plugin output", async () => {
-    const trustWarning =
-      "╭─ WARNING - ClawHub found security risks in this release ─╮\n" +
-      "│ • Security scan:     suspicious                                      │\n" +
-      "│ • Finding:           suspicious payload strings                       │\n" +
-      "╰───────────────────────────────────────────────────────────────────────╯";
-    syncPluginsForUpdateChannel.mockResolvedValueOnce({
-      changed: false,
-      config: baseConfig,
-      summary: {
-        switchedToBundled: [],
-        switchedToClawHub: [],
-        switchedToNpm: [],
+    const trustWarning = clawHubSuspiciousPayloadWarning;
+    syncPluginsForUpdateChannel.mockResolvedValueOnce(
+      pluginSyncResult(baseConfig, false, {
         warnings: [trustWarning],
-        errors: [
-          "Failed to update demo: Update cancelled; rerun with --acknowledge-clawhub-risk to continue after reviewing the warning. (ClawHub clawhub:demo@1.2.4).",
-        ],
-      },
-    });
+        errors: [clawHubSyncRiskError],
+      }),
+    );
     vi.mocked(defaultRuntime.writeJson).mockClear();
 
     await updateCommand({ json: true, restart: false });
@@ -2457,33 +2534,18 @@ describe("update-cli", () => {
     const jsonOutput = lastWriteJsonCall() as UpdateRunResult | undefined;
     expect(jsonOutput?.postUpdate?.plugins?.status).toBe("warning");
     expect(jsonOutput?.postUpdate?.plugins?.sync.warnings).toEqual([trustWarning]);
-    expect(jsonOutput?.postUpdate?.plugins?.sync.errors).toEqual([
-      "Failed to update demo: Update cancelled; rerun with --acknowledge-clawhub-risk to continue after reviewing the warning. (ClawHub clawhub:demo@1.2.4).",
-    ]);
+    expect(jsonOutput?.postUpdate?.plugins?.sync.errors).toEqual([clawHubSyncRiskError]);
   });
 
   it("does not print duplicate failed ClawHub sync trust warnings in human post-core output", async () => {
-    const trustWarning =
-      "╭─ WARNING - ClawHub found security risks in this release ─╮\n" +
-      "│ • Security scan:     suspicious                                      │\n" +
-      "│ • Finding:           suspicious payload strings                       │\n" +
-      "╰───────────────────────────────────────────────────────────────────────╯";
+    const trustWarning = clawHubSuspiciousPayloadWarning;
     syncPluginsForUpdateChannel.mockImplementationOnce(
       async (params: { config: OpenClawConfig; logger?: { warn?: (message: string) => void } }) => {
         params.logger?.warn?.(trustWarning);
-        return {
-          changed: false,
-          config: params.config,
-          summary: {
-            switchedToBundled: [],
-            switchedToClawHub: [],
-            switchedToNpm: [],
-            warnings: [trustWarning],
-            errors: [
-              "Failed to update demo: Update cancelled; rerun with --acknowledge-clawhub-risk to continue after reviewing the warning. (ClawHub clawhub:demo@1.2.4).",
-            ],
-          },
-        };
+        return pluginSyncResult(params.config, false, {
+          warnings: [trustWarning],
+          errors: [clawHubSyncRiskError],
+        });
       },
     );
 
@@ -2494,11 +2556,7 @@ describe("update-cli", () => {
   });
 
   it("does not print duplicate ClawHub update trust warnings in human post-core output", async () => {
-    const trustWarning =
-      "╭─ WARNING - ClawHub found security risks in this release ─╮\n" +
-      "│ • Security scan:     suspicious                                      │\n" +
-      "│ • Finding:           suspicious payload strings                       │\n" +
-      "╰───────────────────────────────────────────────────────────────────────╯";
+    const trustWarning = clawHubSuspiciousPayloadWarning;
     updateNpmInstalledPlugins.mockImplementationOnce(
       async (params: { config: OpenClawConfig; logger?: { warn?: (message: string) => void } }) => {
         params.logger?.warn?.(trustWarning);
@@ -2547,17 +2605,7 @@ describe("update-cli", () => {
         installPath,
       },
     });
-    syncPluginsForUpdateChannel.mockResolvedValueOnce({
-      changed: false,
-      config,
-      summary: {
-        switchedToBundled: [],
-        switchedToClawHub: [],
-        switchedToNpm: [],
-        warnings: [],
-        errors: [],
-      },
-    });
+    syncPluginsForUpdateChannel.mockResolvedValueOnce(pluginSyncResult(config));
     pathExists.mockImplementation(async (candidate: string) => candidate === installPath);
     vi.mocked(defaultRuntime.writeJson).mockClear();
 
@@ -2630,11 +2678,7 @@ describe("update-cli", () => {
   });
 
   it("marks unacknowledged ClawHub risk skips as post-update warnings", async () => {
-    const trustWarning =
-      "╭─ WARNING - ClawHub found security risks in this release ─╮\n" +
-      "│ • Security scan:     suspicious                                      │\n" +
-      "│ • Finding:           suspicious payload strings                       │\n" +
-      "╰───────────────────────────────────────────────────────────────────────╯";
+    const trustWarning = clawHubSuspiciousPayloadWarning;
     updateNpmInstalledPlugins.mockResolvedValueOnce({
       changed: false,
       config: baseConfig,
@@ -2818,6 +2862,7 @@ describe("update-cli", () => {
       },
       assert: () => {
         expectNoSideEffects(
+          cleanupStaleManagedServiceUpdateHandoffs,
           replaceConfigFile,
           runGatewayUpdate,
           runDaemonInstall,
@@ -2840,6 +2885,7 @@ describe("update-cli", () => {
       },
       assert: () => {
         expect(defaultRuntime.exit).not.toHaveBeenCalledWith(1);
+        expect(cleanupStaleManagedServiceUpdateHandoffs).not.toHaveBeenCalled();
         expect(runGatewayUpdate).not.toHaveBeenCalled();
         expect(
           launchdUpdateCleanupMocks.disableCurrentOpenClawUpdateLaunchdJob,
@@ -2847,6 +2893,53 @@ describe("update-cli", () => {
       },
     },
   ] as const)("updateCommand dry-run behavior: $name", runUpdateCliScenario);
+
+  it.each([
+    { name: "text", options: { dryRun: true, channel: "beta" } },
+    { name: "JSON", options: { dryRun: true, json: true, channel: "beta" } },
+  ])("reads config without recording observations during a $name dry run", async ({ options }) => {
+    await updateCommand(options);
+
+    expect(readConfigFileSnapshot).toHaveBeenCalledWith({
+      skipPluginValidation: true,
+      observe: false,
+    });
+    expect(cleanupStaleManagedServiceUpdateHandoffs).not.toHaveBeenCalled();
+  });
+
+  it("does not clean managed-service handoffs during a JSON dry run", async () => {
+    await updateCommand({ dryRun: true, json: true, channel: "beta" });
+
+    expect(cleanupStaleManagedServiceUpdateHandoffs).not.toHaveBeenCalled();
+    expectNoSideEffects(replaceConfigFile, runGatewayUpdate, runDaemonInstall);
+    expect(defaultRuntime.writeJson).toHaveBeenCalled();
+  });
+
+  it("does not clean managed-service handoffs before rejecting an invalid timeout", async () => {
+    await updateCommand({ timeout: "" });
+
+    expect(cleanupStaleManagedServiceUpdateHandoffs).not.toHaveBeenCalled();
+    expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
+  });
+
+  it.each([
+    { name: "update", run: async () => await updateCommand({ channel: "" }) },
+    { name: "finalization", run: async () => await updateFinalizeCommand({ channel: "" }) },
+  ])("rejects an explicitly empty $name channel before mutation", async ({ run }) => {
+    await run();
+
+    expect(defaultRuntime.error).toHaveBeenCalledWith(
+      '--channel must be "stable", "extended-stable", "beta", or "dev" (got "")',
+    );
+    expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
+    expectNoSideEffects(
+      cleanupStaleManagedServiceUpdateHandoffs,
+      replaceConfigFile,
+      runGatewayUpdate,
+      doctorCommand,
+      syncPluginsForUpdateChannel,
+    );
+  });
 
   it("refuses an incompatible package target before service stop or install", async () => {
     mockPackageInstallStatus(createCaseDir("openclaw-schema-refusal"));
@@ -3756,18 +3849,10 @@ describe("update-cli", () => {
     const nodeModules = path.join(tempDir, "node_modules");
     const pkgRoot = path.join(nodeModules, "openclaw");
     mockPackageInstallStatus(tempDir);
-    await fs.mkdir(pkgRoot, { recursive: true });
-    await fs.writeFile(
-      path.join(pkgRoot, "package.json"),
-      JSON.stringify({ name: "openclaw", version: "2026.3.23" }),
-      "utf-8",
-    );
-    for (const relativePath of TEST_BUNDLED_RUNTIME_SIDECAR_PATHS) {
-      const absolutePath = path.join(pkgRoot, relativePath);
-      await fs.mkdir(path.dirname(absolutePath), { recursive: true });
-      await fs.writeFile(absolutePath, "export {};\n", "utf-8");
-    }
-    await writePackageDistInventory(pkgRoot);
+    await writeOpenClawPackageFixture(pkgRoot, "2026.3.23", {
+      sidecars: true,
+      inventory: true,
+    });
     readPackageVersion.mockResolvedValue("2026.3.23");
     vi.mocked(runCommandWithTimeout).mockImplementation(async (argv) => {
       if (Array.isArray(argv) && argv[0] === "npm" && argv[1] === "root" && argv[2] === "-g") {
@@ -3807,14 +3892,10 @@ describe("update-cli", () => {
           throw new Error("missing stage prefix");
         }
         const stageRoot = path.join(stagePrefix, "lib", "node_modules", "openclaw");
-        await fs.mkdir(path.join(stageRoot, "dist"), { recursive: true });
-        await fs.writeFile(
-          path.join(stageRoot, "package.json"),
-          JSON.stringify({ name: "openclaw", version: "2026.4.25" }),
-          "utf-8",
-        );
-        await fs.writeFile(path.join(stageRoot, "dist", "index.js"), "export {};\n", "utf-8");
-        await writePackageDistInventory(stageRoot);
+        await writeOpenClawPackageFixture(stageRoot, "2026.4.25", {
+          entrySource: "export {};\n",
+          inventory: true,
+        });
         await fs.writeFile(
           path.join(stageRoot, "dist", "stale-runtime.js"),
           "export {};\n",
@@ -4112,6 +4193,99 @@ describe("update-cli", () => {
     processOffSpy.mockRestore();
   });
 
+  it("does not inspect or mutate a Windows host service from an isolated install", async () => {
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    const tempDir = await createTrackedTempDir("openclaw-update-isolated-service-");
+    const { nodeModules } = await setupInstalledPackageRoot(tempDir);
+    mockRunningManagedGateway();
+    mockFileBackedPathExists();
+    mockNpmGlobalRoot(nodeModules);
+    isDefaultInstallIdentity.mockReturnValue(false);
+
+    await withEnvAsync({ OPENCLAW_HOME: path.join(tempDir, "relocated-home") }, async () => {
+      await updateCommand({ yes: true });
+    });
+    platformSpy.mockRestore();
+
+    expect(isDefaultInstallIdentity).toHaveBeenCalled();
+    expect(serviceReadCommand).not.toHaveBeenCalled();
+    expect(suspendScheduledTaskAutoStartForUpdate).not.toHaveBeenCalled();
+    expect(serviceStop).not.toHaveBeenCalled();
+    expect(prepareRestartScript).not.toHaveBeenCalled();
+    expect(runRestartScript).not.toHaveBeenCalled();
+    expect(runDaemonRestart).not.toHaveBeenCalled();
+    expect(packageInstallCommandCall()).toBeDefined();
+  });
+
+  it.each([
+    {
+      platform: "darwin" as const,
+      envKey: "OPENCLAW_LAUNCHD_LABEL",
+      value: "ai.openclaw.gateway",
+    },
+    {
+      platform: "linux" as const,
+      envKey: "OPENCLAW_SYSTEMD_UNIT",
+      value: "openclaw-gateway.service",
+    },
+    {
+      platform: "win32" as const,
+      envKey: "OPENCLAW_WINDOWS_TASK_NAME",
+      value: "OpenClaw Gateway",
+    },
+  ])(
+    "does not reuse a conflicting $envKey selector from the managed service on $platform",
+    async ({ platform, envKey, value }) => {
+      const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue(platform);
+      const tempDir = await createTrackedTempDir(`openclaw-update-${platform}-selector-`);
+      const home = path.join(tempDir, "home");
+      const stateDir = path.join(home, ".openclaw-work");
+      const { nodeModules } = await setupInstalledPackageRoot(tempDir);
+      serviceReadCommand.mockResolvedValue({
+        programArguments: ["openclaw", "gateway", "run"],
+        environment: {
+          OPENCLAW_PROFILE: "work",
+          [envKey]: value,
+        },
+      });
+      serviceLoaded.mockResolvedValue(true);
+      serviceReadRuntime.mockResolvedValue({ status: "stopped", state: "stopped" });
+      mockFileBackedPathExists();
+      mockNpmGlobalRoot(nodeModules);
+
+      try {
+        await withEnvAsync(
+          {
+            HOME: home,
+            USERPROFILE: undefined,
+            OPENCLAW_HOME: undefined,
+            OPENCLAW_PROFILE: "work",
+            OPENCLAW_STATE_DIR: stateDir,
+            OPENCLAW_CONFIG_PATH: path.join(stateDir, "openclaw.json"),
+            [envKey]: undefined,
+          },
+          async () => {
+            await updateCommand({ yes: true });
+          },
+        );
+      } finally {
+        platformSpy.mockRestore();
+      }
+
+      expect(isDefaultInstallIdentity).toHaveBeenCalled();
+      expect(serviceReadRuntime).not.toHaveBeenCalled();
+      expect(suspendScheduledTaskAutoStartForUpdate).not.toHaveBeenCalled();
+      expect(serviceStop).not.toHaveBeenCalled();
+      expect(serviceRestart).not.toHaveBeenCalled();
+      expect(prepareRestartScript).not.toHaveBeenCalled();
+      expect(runRestartScript).not.toHaveBeenCalled();
+      expect(runDaemonRestart).not.toHaveBeenCalled();
+      expect(packageInstallCommandCall()).toBeUndefined();
+      expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
+      expect(getErrorOutput()).toContain(envKey);
+    },
+  );
+
   it("restores Windows Scheduled Task autostart when service stop fails", async () => {
     const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
     mockPackageInstallStatus(createCaseDir("openclaw-update-stop-failure"));
@@ -4311,23 +4485,7 @@ describe("update-cli", () => {
   });
 
   it("fails managed git restart when the gateway responds but the service stays stopped", async () => {
-    const serviceEntrypoint = path.join(process.cwd(), "dist", "index.js");
-    primeServiceCommand(["node", serviceEntrypoint, "gateway", "run"], {
-      OPENCLAW_SERVICE_MARKER: "openclaw",
-      OPENCLAW_SERVICE_KIND: "gateway",
-    });
-    serviceLoaded.mockResolvedValue(false);
-    serviceLoaded.mockResolvedValueOnce(true);
-    serviceReadRuntime.mockResolvedValue({
-      status: "stopped",
-      pid: null,
-      state: "stopped",
-    });
-    serviceReadRuntime.mockResolvedValueOnce({
-      status: "running",
-      pid: 4242,
-      state: "running",
-    });
+    mockStoppedManagedGitGateway();
     restartHealthTestControl.snapshot = {
       runtime: { status: "stopped", pid: null, state: "stopped" },
       portUsage: {
@@ -4346,45 +4504,19 @@ describe("update-cli", () => {
 
     await updateCommand({ yes: true });
 
-    const logs = getLogOutput();
-    expect(serviceStop).toHaveBeenCalledTimes(1);
-    expect(runRestartScript).toHaveBeenCalledTimes(1);
-    expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
-    expect(logs).toContain(
+    expectFailedManagedGitRestart(
       "Gateway responded, but the managed service did not report running after restart.",
     );
-    expect(logs).not.toContain("Gateway: restarted and verified.");
   });
 
   it("fails managed git restart when the stopped service cannot be restarted", async () => {
-    const serviceEntrypoint = path.join(process.cwd(), "dist", "index.js");
-    primeServiceCommand(["node", serviceEntrypoint, "gateway", "run"], {
-      OPENCLAW_SERVICE_MARKER: "openclaw",
-      OPENCLAW_SERVICE_KIND: "gateway",
-    });
-    serviceLoaded.mockResolvedValue(false);
-    serviceLoaded.mockResolvedValueOnce(true);
-    serviceReadRuntime.mockResolvedValue({
-      status: "stopped",
-      pid: null,
-      state: "stopped",
-    });
-    serviceReadRuntime.mockResolvedValueOnce({
-      status: "running",
-      pid: 4242,
-      state: "running",
-    });
+    mockStoppedManagedGitGateway();
     runRestartScript.mockRejectedValueOnce(new Error("restart unavailable"));
     mockGitUpdateAfterMutation();
 
     await updateCommand({ yes: true });
 
-    const logs = getLogOutput();
-    expect(serviceStop).toHaveBeenCalledTimes(1);
-    expect(runRestartScript).toHaveBeenCalledTimes(1);
-    expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
-    expect(logs).toContain("Gateway: restart failed: Error: restart unavailable");
-    expect(logs).not.toContain("Gateway: restarted and verified.");
+    expectFailedManagedGitRestart("Gateway: restart failed: Error: restart unavailable");
   });
 
   it("stops a managed gateway rooted at the git checkout when switching package installs to dev", async () => {
@@ -4570,13 +4702,14 @@ describe("update-cli", () => {
       "2026.4.23",
     );
     readPackageVersion.mockResolvedValue("2026.4.23");
-    primeNpmChannelTag("latest", "2026.4.23");
-    for (const relativePath of TEST_BUNDLED_RUNTIME_SIDECAR_PATHS) {
-      const absolutePath = path.join(pkgRoot, relativePath);
-      await fs.mkdir(path.dirname(absolutePath), { recursive: true });
-      await fs.writeFile(absolutePath, "export {};\n", "utf-8");
-    }
-    await writePackageDistInventory(pkgRoot);
+    vi.mocked(resolveNpmChannelTag).mockResolvedValue({
+      tag: "latest",
+      version: "2026.4.23",
+    });
+    await writeOpenClawPackageFixture(pkgRoot, "2026.4.23", {
+      sidecars: true,
+      inventory: true,
+    });
     mockFileBackedPathExists();
     mockNpmGlobalRoot(nodeModules);
 
@@ -4602,18 +4735,10 @@ describe("update-cli", () => {
     const pkgRoot = path.join(nodeModules, "openclaw");
     mockPackageInstallStatus(pkgRoot);
     mockCurrentProcessFreshDoctor();
-    await fs.mkdir(pkgRoot, { recursive: true });
-    await fs.writeFile(
-      path.join(pkgRoot, "package.json"),
-      JSON.stringify({ name: "openclaw", version: "9999.0.0" }),
-      "utf-8",
-    );
-    for (const relativePath of TEST_BUNDLED_RUNTIME_SIDECAR_PATHS) {
-      const absolutePath = path.join(pkgRoot, relativePath);
-      await fs.mkdir(path.dirname(absolutePath), { recursive: true });
-      await fs.writeFile(absolutePath, "export {};\n", "utf-8");
-    }
-    await writePackageDistInventory(pkgRoot);
+    await writeOpenClawPackageFixture(pkgRoot, "9999.0.0", {
+      sidecars: true,
+      inventory: true,
+    });
 
     vi.mocked(runCommandWithTimeout).mockImplementation(async (argv) => {
       if (Array.isArray(argv) && argv[0] === "npm" && argv[1] === "root" && argv[2] === "-g") {
@@ -4955,15 +5080,10 @@ describe("update-cli", () => {
         const stageRoot = stagePrefix
           ? path.join(stagePrefix, "lib", "node_modules", "openclaw")
           : serviceRoot;
-        const stageEntryPoint = path.join(stageRoot, "dist", "index.js");
-        await fs.mkdir(path.dirname(stageEntryPoint), { recursive: true });
-        await fs.writeFile(
-          path.join(stageRoot, "package.json"),
-          JSON.stringify({ name: "openclaw", version: "2026.5.20" }),
-          "utf-8",
-        );
-        await fs.writeFile(stageEntryPoint, "export {};\n", "utf-8");
-        await writePackageDistInventory(stageRoot);
+        await writeOpenClawPackageFixture(stageRoot, "2026.5.20", {
+          entrySource: "export {};\n",
+          inventory: true,
+        });
       }
       return commandResult();
     });
@@ -5058,15 +5178,10 @@ describe("update-cli", () => {
         const stageRoot = stagePrefix
           ? path.join(stagePrefix, "lib", "node_modules", "openclaw")
           : root;
-        const stageEntryPoint = path.join(stageRoot, "dist", "index.js");
-        await fs.mkdir(path.dirname(stageEntryPoint), { recursive: true });
-        await fs.writeFile(
-          path.join(stageRoot, "package.json"),
-          JSON.stringify({ name: "openclaw", version: "2026.7.1" }),
-          "utf-8",
-        );
-        await fs.writeFile(stageEntryPoint, "export {};\n", "utf-8");
-        await writePackageDistInventory(stageRoot);
+        await writeOpenClawPackageFixture(stageRoot, "2026.7.1", {
+          entrySource: "export {};\n",
+          inventory: true,
+        });
       }
       return commandResult();
     });
@@ -5124,15 +5239,10 @@ describe("update-cli", () => {
         const stageRoot = stagePrefix
           ? path.join(stagePrefix, "lib", "node_modules", "openclaw")
           : root;
-        const stageEntryPoint = path.join(stageRoot, "dist", "index.js");
-        await fs.mkdir(path.dirname(stageEntryPoint), { recursive: true });
-        await fs.writeFile(
-          path.join(stageRoot, "package.json"),
-          JSON.stringify({ name: "openclaw", version: "2026.5.20" }),
-          "utf-8",
-        );
-        await fs.writeFile(stageEntryPoint, "export {};\n", "utf-8");
-        await writePackageDistInventory(stageRoot);
+        await writeOpenClawPackageFixture(stageRoot, "2026.5.20", {
+          entrySource: "export {};\n",
+          inventory: true,
+        });
       }
       return commandResult();
     });
@@ -5387,23 +5497,18 @@ describe("update-cli", () => {
         config: postDoctorConfig,
         hash: "post-doctor-hash",
       });
-    syncPluginsForUpdateChannel.mockImplementation(async ({ config }) => ({
-      changed: true,
-      config: {
-        ...config,
-        plugins: {
-          ...config.plugins,
-          load: { paths: ["/tmp/openclaw-updated-plugin"] },
+    syncPluginsForUpdateChannel.mockImplementation(async ({ config }) =>
+      pluginSyncResult(
+        {
+          ...config,
+          plugins: {
+            ...config.plugins,
+            load: { paths: ["/tmp/openclaw-updated-plugin"] },
+          },
         },
-      },
-      summary: {
-        switchedToBundled: [],
-        switchedToClawHub: [],
-        switchedToNpm: [],
-        warnings: [],
-        errors: [],
-      },
-    }));
+        true,
+      ),
+    );
     updateNpmInstalledPlugins.mockImplementation(async ({ config }) =>
       npmPluginUpdateResult(config),
     );
@@ -5790,22 +5895,8 @@ describe("update-cli", () => {
         },
       } as OpenClawConfig,
     });
-    syncPluginsForUpdateChannel.mockResolvedValue({
-      changed: false,
-      config: sourceConfig,
-      summary: {
-        switchedToBundled: [],
-        switchedToClawHub: [],
-        switchedToNpm: [],
-        warnings: [],
-        errors: [],
-      },
-    });
-    updateNpmInstalledPlugins.mockResolvedValue({
-      changed: false,
-      config: sourceConfig,
-      outcomes: [],
-    });
+    syncPluginsForUpdateChannel.mockResolvedValue(pluginSyncResult(sourceConfig));
+    updateNpmInstalledPlugins.mockResolvedValue(npmPluginUpdateResult(sourceConfig));
 
     await updateCommand({ channel: "beta", yes: true });
 
@@ -5874,20 +5965,13 @@ describe("update-cli", () => {
 
     confirm.mockClear();
     confirm.mockResolvedValueOnce(true);
-    await syncCall.onClawHubRisk({
-      packageName: "demo\npkg",
-      version: "1.2.3\u001b[2K",
-      trust: {
-        scanStatus: "suspicious",
-        moderationState: null,
-        blockedFromDownload: false,
-        reasons: ["payload_strings"],
-        pending: false,
-        stale: false,
-      },
-      acknowledgementKind: "confirm",
-      warning: "warning",
-    });
+    await syncCall.onClawHubRisk(
+      createClawHubRiskRequest({
+        packageName: "demo\npkg",
+        version: "1.2.3\u001b[2K",
+        warning: "warning",
+      }),
+    );
 
     const message = getConfirmMessage();
     expect(message).toContain("Update ClawHub package");
@@ -5897,10 +5981,7 @@ describe("update-cli", () => {
   });
 
   it("prints ClawHub risk warnings before interactive post-update acknowledgement prompts", async () => {
-    const warning =
-      "╭─ WARNING - ClawHub found security risks in this release ─╮\n" +
-      "│ • Security scan:     suspicious                                      │\n" +
-      "╰───────────────────────────────────────────────────────────────────────╯";
+    const warning = clawHubRiskWarning;
     const syncCall = await setupInteractiveClawHubRisk();
 
     confirm.mockImplementationOnce(async () => {
@@ -5908,27 +5989,11 @@ describe("update-cli", () => {
       expect(logs.some((line) => line.includes(warning))).toBe(true);
       return true;
     });
-    await syncCall.onClawHubRisk({
-      packageName: "demo",
-      version: "1.2.3",
-      trust: {
-        scanStatus: "suspicious",
-        moderationState: null,
-        blockedFromDownload: false,
-        reasons: ["payload_strings"],
-        pending: false,
-        stale: false,
-      },
-      acknowledgementKind: "confirm",
-      warning,
-    });
+    await syncCall.onClawHubRisk(createClawHubRiskRequest({ warning }));
   });
 
   it("does not duplicate ClawHub risk warnings already printed before prompts", async () => {
-    const warning =
-      "╭─ WARNING - ClawHub found security risks in this release ─╮\n" +
-      "│ • Security scan:     suspicious                                      │\n" +
-      "╰───────────────────────────────────────────────────────────────────────╯";
+    const warning = clawHubRiskWarning;
     const syncCall = await setupInteractiveClawHubRisk();
     const logger = syncCall.logger;
     if (
@@ -5943,20 +6008,7 @@ describe("update-cli", () => {
 
     logger.warn(`\u001b[33m${warning}\u001b[39m`);
     confirm.mockResolvedValueOnce(true);
-    await syncCall.onClawHubRisk({
-      packageName: "demo",
-      version: "1.2.3",
-      trust: {
-        scanStatus: "suspicious",
-        moderationState: null,
-        blockedFromDownload: false,
-        reasons: ["payload_strings"],
-        pending: false,
-        stale: false,
-      },
-      acknowledgementKind: "confirm",
-      warning,
-    });
+    await syncCall.onClawHubRisk(createClawHubRiskRequest({ warning }));
 
     const output = getLogOutput();
     const occurrences = output.split(warning).length - 1;
@@ -6026,7 +6078,7 @@ describe("update-cli", () => {
       "Commit, stash, or discard the local changes, then rerun `openclaw update`.",
     );
     expect(serviceStop).not.toHaveBeenCalled();
-    expect(defaultRuntime.exit).toHaveBeenCalledWith(0);
+    expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
   });
   it.each([
     {
@@ -6301,6 +6353,28 @@ describe("update-cli", () => {
     });
     expect(sentinel?.payload.stats?.mode).toBe("npm");
     expect(sentinel?.payload.stats?.after?.version).toBe("2026.4.24");
+  });
+
+  it("does not write a control-plane sentinel when a dry-run preflight fails", async () => {
+    const sentinel = await runControlPlaneUpdate({
+      meta: {
+        sessionKey: "agent:main:webchat:dm:user-123",
+        handoffId: "extended-stable-dry-run",
+        note: "Preview requested from the agent.",
+      },
+      options: { channel: "extended-stable", dryRun: true, yes: true, json: true },
+      beforeUpdate: () => {
+        mockPackageInstallStatus(createCaseDir("openclaw-update"));
+        vi.mocked(resolveExtendedStablePackage).mockResolvedValueOnce({
+          status: "failed",
+          reason: "selector_missing",
+        });
+      },
+    });
+
+    expect(sentinel).toBeNull();
+    expect(cleanupStaleManagedServiceUpdateHandoffs).not.toHaveBeenCalled();
+    expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
   });
 
   it("writes an extended-stable selector failure to the control-plane sentinel", async () => {
@@ -6628,22 +6702,14 @@ describe("update-cli", () => {
       update: { channel: "beta" },
       plugins: { entries: { post: { enabled: true } } },
     } as OpenClawConfig;
-    const preDoctorSnapshot: ConfigFileSnapshot = {
-      ...baseSnapshot,
-      sourceConfig: preDoctorConfig,
-      resolved: preDoctorConfig,
-      runtimeConfig: preDoctorConfig,
-      config: preDoctorConfig,
+    const preDoctorSnapshot = configSnapshot(preDoctorConfig, {
+      parsed: baseSnapshot.parsed,
       hash: "pre-doctor",
-    };
-    const postDoctorSnapshot: ConfigFileSnapshot = {
-      ...baseSnapshot,
-      sourceConfig: postDoctorConfig,
-      resolved: postDoctorConfig,
-      runtimeConfig: postDoctorConfig,
-      config: postDoctorConfig,
+    });
+    const postDoctorSnapshot = configSnapshot(postDoctorConfig, {
+      parsed: baseSnapshot.parsed,
       hash: "post-doctor",
-    };
+    });
     const postDoctorRecords = {
       "post-plugin": {
         source: "npm",
@@ -6656,17 +6722,8 @@ describe("update-cli", () => {
       .mockResolvedValueOnce(postDoctorSnapshot);
     loadInstalledPluginIndexInstallRecords.mockResolvedValueOnce(postDoctorRecords);
     syncPluginsForUpdateChannel.mockImplementationOnce(
-      async (params: { config?: OpenClawConfig }) => ({
-        changed: true,
-        config: params.config ?? baseConfig,
-        summary: {
-          switchedToBundled: [],
-          switchedToClawHub: [],
-          switchedToNpm: [],
-          warnings: [],
-          errors: [],
-        },
-      }),
+      async (params: { config?: OpenClawConfig }) =>
+        pluginSyncResult(params.config ?? baseConfig, true),
     );
 
     await updateFinalizeCommand({ json: true, timeout: "9", restart: false });
@@ -6725,14 +6782,10 @@ describe("update-cli", () => {
     const postDoctorConfig = {
       meta: { lastTouchedVersion: "2026.6.18" },
     } as OpenClawConfig;
-    const postDoctorSnapshot: ConfigFileSnapshot = {
-      ...baseSnapshot,
-      sourceConfig: postDoctorConfig,
-      resolved: postDoctorConfig,
-      runtimeConfig: postDoctorConfig,
-      config: postDoctorConfig,
+    const postDoctorSnapshot = configSnapshot(postDoctorConfig, {
+      parsed: baseSnapshot.parsed,
       hash: "post-doctor",
-    };
+    });
     await fs.mkdir(tempDir, { recursive: true });
     await fs.writeFile(
       sourceConfigPath,
@@ -6764,22 +6817,14 @@ describe("update-cli", () => {
   it("updateFinalizeCommand reapplies requested channel against post-doctor config", async () => {
     const preDoctorConfig = { update: { channel: "stable" } } as OpenClawConfig;
     const postDoctorConfig = { update: { channel: "beta" } } as OpenClawConfig;
-    const preDoctorSnapshot: ConfigFileSnapshot = {
-      ...baseSnapshot,
-      sourceConfig: preDoctorConfig,
-      resolved: preDoctorConfig,
-      runtimeConfig: preDoctorConfig,
-      config: preDoctorConfig,
+    const preDoctorSnapshot = configSnapshot(preDoctorConfig, {
+      parsed: baseSnapshot.parsed,
       hash: "pre-doctor",
-    };
-    const postDoctorSnapshot: ConfigFileSnapshot = {
-      ...baseSnapshot,
-      sourceConfig: postDoctorConfig,
-      resolved: postDoctorConfig,
-      runtimeConfig: postDoctorConfig,
-      config: postDoctorConfig,
+    });
+    const postDoctorSnapshot = configSnapshot(postDoctorConfig, {
+      parsed: baseSnapshot.parsed,
       hash: "post-doctor",
-    };
+    });
     vi.mocked(readConfigFileSnapshot)
       .mockResolvedValueOnce(preDoctorSnapshot)
       .mockResolvedValueOnce(preDoctorSnapshot)
@@ -6798,14 +6843,10 @@ describe("update-cli", () => {
 
   it("updateFinalizeCommand converges on the effective channel from env without persisting update.channel", async () => {
     const noChannelConfig = {} as OpenClawConfig;
-    const noChannelSnapshot: ConfigFileSnapshot = {
-      ...baseSnapshot,
-      sourceConfig: noChannelConfig,
-      resolved: noChannelConfig,
-      runtimeConfig: noChannelConfig,
-      config: noChannelConfig,
+    const noChannelSnapshot = configSnapshot(noChannelConfig, {
+      parsed: baseSnapshot.parsed,
       hash: "no-channel",
-    };
+    });
     vi.mocked(readConfigFileSnapshot).mockResolvedValue(noChannelSnapshot);
     const priorEffective = process.env.OPENCLAW_UPDATE_EFFECTIVE_CHANNEL;
     // Simulate a no-config git/source update whose effective channel is dev.
@@ -6992,6 +7033,7 @@ describe("update-cli", () => {
     expect(cloneCall?.[0]).toEqual([
       "git",
       "clone",
+      "--filter=blob:none",
       "https://github.com/openclaw/openclaw.git",
       checkoutDir,
     ]);

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -541,6 +541,20 @@ describe("update-cli", () => {
     });
   };
 
+  const primeNpmChannelTag = (tag: string, version: string | null): void => {
+    vi.mocked(resolveNpmChannelTag).mockResolvedValue({ tag, version });
+  };
+
+  const primeServiceCommand = (
+    programArguments: Array<string | undefined>,
+    environment?: NodeJS.ProcessEnv,
+  ): void => {
+    serviceReadCommand.mockResolvedValue({
+      programArguments,
+      ...(environment === undefined ? {} : { environment }),
+    });
+  };
+
   const expectUpdateCallChannel = (channel: string) => {
     const call = vi.mocked(runGatewayUpdate).mock.calls[0]?.[0];
     expect(call?.channel).toBe(channel);
@@ -794,9 +808,7 @@ describe("update-cli", () => {
 
   const mockOwnedGitService = () => {
     const serviceEntrypoint = path.join(process.cwd(), "dist", "index.js");
-    serviceReadCommand.mockResolvedValue({
-      programArguments: ["node", serviceEntrypoint, "gateway", "run"],
-    });
+    primeServiceCommand(["node", serviceEntrypoint, "gateway", "run"]);
     pathExists.mockImplementation(
       async (candidate: string) => candidate === path.join(process.cwd(), "package.json"),
     );
@@ -835,10 +847,7 @@ describe("update-cli", () => {
     readPackageVersion.mockResolvedValue("2.0.0");
 
     mockPackageInstallStatus(tempDir);
-    vi.mocked(resolveNpmChannelTag).mockResolvedValue({
-      tag: "latest",
-      version: "0.0.1",
-    });
+    primeNpmChannelTag("latest", "0.0.1");
     vi.mocked(runGatewayUpdate).mockResolvedValue({
       status: "ok",
       mode: "npm",
@@ -889,9 +898,7 @@ describe("update-cli", () => {
       });
     }
     serviceLoaded.mockResolvedValue(true);
-    serviceReadCommand.mockResolvedValue({
-      programArguments: ["node", entrypoints[0], "gateway", "run"],
-    });
+    primeServiceCommand(["node", entrypoints[0], "gateway", "run"]);
     return { root, entrypoints };
   };
 
@@ -1234,10 +1241,7 @@ describe("update-cli", () => {
       version: "2026.6.33",
       packageSpec: "openclaw@2026.6.33",
     });
-    vi.mocked(resolveNpmChannelTag).mockResolvedValue({
-      tag: "latest",
-      version: "9999.0.0",
-    });
+    primeNpmChannelTag("latest", "9999.0.0");
     nodeVersionSatisfiesEngine.mockReturnValue(true);
     vi.mocked(checkUpdateStatus).mockResolvedValue({
       root: "/test/path",
@@ -1788,10 +1792,7 @@ describe("update-cli", () => {
         }),
     });
     readPackageVersion.mockResolvedValue("2026.4.14");
-    vi.mocked(resolveNpmChannelTag).mockResolvedValue({
-      tag: "latest",
-      version: "2026.4.10",
-    });
+    primeNpmChannelTag("latest", "2026.4.10");
     mockCurrentProcessFreshDoctor();
     mockGatewayProbe("2026.4.10", "downgraded-gateway");
 
@@ -1817,7 +1818,7 @@ describe("update-cli", () => {
         }),
     });
     readPackageVersion.mockResolvedValue("2026.4.14");
-    vi.mocked(resolveNpmChannelTag).mockResolvedValue({ tag: "latest", version: "2026.4.10" });
+    primeNpmChannelTag("latest", "2026.4.10");
     mockCurrentProcessFreshDoctor();
 
     await updateCommand({ yes: true, tag: "2026.4.10", restart: false });
@@ -1845,7 +1846,7 @@ describe("update-cli", () => {
     readPackageVersion.mockImplementation(async (pkgRoot: string) =>
       pkgRoot === downgradedRoot ? "2026.4.10" : "2026.4.14",
     );
-    vi.mocked(resolveNpmChannelTag).mockResolvedValue({ tag: "latest", version: "2026.4.10" });
+    primeNpmChannelTag("latest", "2026.4.10");
 
     delete process.env.OPENCLAW_COMPATIBILITY_HOST_VERSION;
     let hostVersionDuringPluginUpdate: string | undefined = "unset";
@@ -3012,9 +3013,8 @@ describe("update-cli", () => {
   it("refuses a package target that changes after the service stops", async () => {
     mockPackageInstallStatus(process.cwd());
     mockOwnedGitService();
-    serviceReadCommand.mockResolvedValue({
-      programArguments: ["node", path.join(process.cwd(), "dist", "index.js"), "gateway", "run"],
-      environment: { OPENCLAW_STATE_DIR: "/managed/state" },
+    primeServiceCommand(["node", path.join(process.cwd(), "dist", "index.js"), "gateway", "run"], {
+      OPENCLAW_STATE_DIR: "/managed/state",
     });
     serviceLoaded.mockResolvedValue(true);
     vi.mocked(fetchNpmPackageTargetStatus).mockResolvedValue({
@@ -3252,10 +3252,7 @@ describe("update-cli", () => {
       ...baseSnapshot,
       config: { update: { channel: "beta" } } as OpenClawConfig,
     });
-    vi.mocked(resolveNpmChannelTag).mockResolvedValue({
-      tag: "latest",
-      version: "1.2.3-1",
-    });
+    primeNpmChannelTag("latest", "1.2.3-1");
     await updateCommand({});
 
     expectPackageInstallSpec("openclaw@1.2.3-1");
@@ -3435,10 +3432,7 @@ describe("update-cli", () => {
     const tempDir = createCaseDir("openclaw-update");
     mockPackageInstallStatus(tempDir);
     readPackageVersion.mockResolvedValue("2026.4.22");
-    vi.mocked(resolveNpmChannelTag).mockResolvedValue({
-      tag: "latest",
-      version: "2026.4.22",
-    });
+    primeNpmChannelTag("latest", "2026.4.22");
 
     await updateCommand({ yes: true });
 
@@ -3458,10 +3452,7 @@ describe("update-cli", () => {
     setTty(false);
     mockPackageInstallStatus(tempDir);
     readPackageVersion.mockResolvedValue("2026.4.22");
-    vi.mocked(resolveNpmChannelTag).mockResolvedValue({
-      tag: "latest",
-      version: null,
-    });
+    primeNpmChannelTag("latest", null);
     mockCurrentProcessFreshDoctor();
 
     await updateCommand({});
@@ -3540,12 +3531,9 @@ describe("update-cli", () => {
 
   it("refuses package updates from inherited gateway service env when --no-restart leaves the gateway running", async () => {
     mockPackageInstallStatus(createCaseDir("openclaw-update"));
-    serviceReadCommand.mockResolvedValue({
-      programArguments: ["openclaw", "gateway", "run"],
-      environment: {
-        OPENCLAW_SERVICE_MARKER: "openclaw",
-        OPENCLAW_SERVICE_KIND: "gateway",
-      },
+    primeServiceCommand(["openclaw", "gateway", "run"], {
+      OPENCLAW_SERVICE_MARKER: "openclaw",
+      OPENCLAW_SERVICE_KIND: "gateway",
     });
     serviceLoaded.mockResolvedValue(true);
 
@@ -3577,12 +3565,9 @@ describe("update-cli", () => {
     "refuses package updates from inherited gateway service env when $name",
     async ({ setupRuntime }) => {
       mockPackageInstallStatus(createCaseDir("openclaw-update"));
-      serviceReadCommand.mockResolvedValue({
-        programArguments: ["openclaw", "gateway", "run"],
-        environment: {
-          OPENCLAW_SERVICE_MARKER: "openclaw",
-          OPENCLAW_SERVICE_KIND: "gateway",
-        },
+      primeServiceCommand(["openclaw", "gateway", "run"], {
+        OPENCLAW_SERVICE_MARKER: "openclaw",
+        OPENCLAW_SERVICE_KIND: "gateway",
       });
       setupRuntime();
 
@@ -3665,10 +3650,7 @@ describe("update-cli", () => {
 
   it("blocks package updates when the target requires a newer Node runtime", async () => {
     mockPackageInstallStatus(createCaseDir("openclaw-update"));
-    vi.mocked(resolveNpmChannelTag).mockResolvedValue({
-      tag: "latest",
-      version: "2026.3.23-2",
-    });
+    primeNpmChannelTag("latest", "2026.3.23-2");
     vi.mocked(fetchNpmPackageTargetStatus).mockResolvedValue({
       target: "latest",
       version: "2026.3.23-2",
@@ -3809,10 +3791,7 @@ describe("update-cli", () => {
     const nodeModules = path.join(prefix, "lib", "node_modules");
     const { pkgRoot } = await setupInstalledPackageAtNodeModules(nodeModules, "2026.4.20");
     readPackageVersion.mockResolvedValue("2026.4.20");
-    vi.mocked(resolveNpmChannelTag).mockResolvedValue({
-      tag: "latest",
-      version: "2026.4.25",
-    });
+    primeNpmChannelTag("latest", "2026.4.25");
     vi.mocked(runCommandWithTimeout).mockImplementation(async (argv) => {
       if (Array.isArray(argv) && argv[0] === "npm" && argv[1] === "root" && argv[2] === "-g") {
         return commandResult({ stdout: `${nodeModules}\n` });
@@ -3861,18 +3840,13 @@ describe("update-cli", () => {
   it("runs old package doctors without fix mode when service ownership is unknown", async () => {
     const tempDir = await createTrackedTempDir("openclaw-update-package-");
     const { nodeModules, pkgRoot, entryPath } = await setupInstalledPackageRoot(tempDir);
-    serviceReadCommand.mockResolvedValue({
-      programArguments: ["openclaw-wrapper", "gateway", "run"],
-    });
+    primeServiceCommand(["openclaw-wrapper", "gateway", "run"]);
     serviceLoaded.mockResolvedValue(true);
     serviceReadRuntime.mockResolvedValue({ status: "stopped", state: "stopped" });
     readPackageVersion.mockImplementation(async (packageRoot: string) =>
       packageRoot === pkgRoot ? "2026.4.21" : "1.0.0",
     );
-    vi.mocked(resolveNpmChannelTag).mockResolvedValue({
-      tag: "latest",
-      version: "2026.4.21",
-    });
+    primeNpmChannelTag("latest", "2026.4.21");
     mockFileBackedPathExists();
     mockNpmGlobalRoot(nodeModules);
 
@@ -3910,10 +3884,7 @@ describe("update-cli", () => {
   it("continues package post-core work for explicit post-update doctor advisories", async () => {
     const tempDir = await createTrackedTempDir("openclaw-update-package-doctor-warning-");
     const { nodeModules, entryPath } = await setupInstalledPackageRoot(tempDir);
-    vi.mocked(resolveNpmChannelTag).mockResolvedValue({
-      tag: "latest",
-      version: "2026.4.21",
-    });
+    primeNpmChannelTag("latest", "2026.4.21");
     mockFileBackedPathExists();
     vi.mocked(runCommandWithTimeout).mockImplementation(async (argv, options) => {
       if (Array.isArray(argv) && argv[0] === "npm" && argv[1] === "root" && argv[2] === "-g") {
@@ -3979,10 +3950,7 @@ describe("update-cli", () => {
   it("fails package updates when the post-update doctor is killed after verification", async () => {
     const tempDir = await createTrackedTempDir("openclaw-update-package-doctor-timeout-");
     const { nodeModules, entryPath } = await setupInstalledPackageRoot(tempDir);
-    vi.mocked(resolveNpmChannelTag).mockResolvedValue({
-      tag: "latest",
-      version: "2026.4.21",
-    });
+    primeNpmChannelTag("latest", "2026.4.21");
     mockFileBackedPathExists();
     vi.mocked(runCommandWithTimeout).mockImplementation(async (argv) => {
       if (Array.isArray(argv) && argv[0] === "npm" && argv[1] === "root" && argv[2] === "-g") {
@@ -4022,10 +3990,7 @@ describe("update-cli", () => {
     const { nodeModules, pkgRoot, entryPath } = await setupInstalledPackageAtNodeModules(
       path.join(tempDir, "lib", "node_modules"),
     );
-    vi.mocked(resolveNpmChannelTag).mockResolvedValue({
-      tag: "latest",
-      version: "2026.5.14",
-    });
+    primeNpmChannelTag("latest", "2026.5.14");
     mockFileBackedPathExists();
     vi.mocked(runCommandWithTimeout).mockImplementation(async (argv) => {
       if (!Array.isArray(argv)) {
@@ -4177,12 +4142,9 @@ describe("update-cli", () => {
   it("preserves both the update and Scheduled Task recovery failures", async () => {
     const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
     mockPackageInstallStatus(createCaseDir("openclaw-update-recovery-failure"));
-    serviceReadCommand.mockResolvedValue({
-      programArguments: ["openclaw", "gateway", "run"],
-      environment: {
-        OPENCLAW_SERVICE_MARKER: "openclaw",
-        OPENCLAW_SERVICE_KIND: "gateway",
-      },
+    primeServiceCommand(["openclaw", "gateway", "run"], {
+      OPENCLAW_SERVICE_MARKER: "openclaw",
+      OPENCLAW_SERVICE_KIND: "gateway",
     });
     serviceReadRuntime.mockResolvedValue({ status: "stopped", state: "stopped" });
     suspendScheduledTaskAutoStartForUpdate.mockResolvedValue(true);
@@ -4225,12 +4187,9 @@ describe("update-cli", () => {
       );
       resumeScheduledTaskAutoStartAfterUpdate.mockResolvedValue(true);
       mockPackageInstallStatus(createCaseDir("openclaw-update-suspension-signal"));
-      serviceReadCommand.mockResolvedValue({
-        programArguments: ["openclaw", "gateway", "run"],
-        environment: {
-          OPENCLAW_SERVICE_MARKER: "openclaw",
-          OPENCLAW_SERVICE_KIND: "gateway",
-        },
+      primeServiceCommand(["openclaw", "gateway", "run"], {
+        OPENCLAW_SERVICE_MARKER: "openclaw",
+        OPENCLAW_SERVICE_KIND: "gateway",
       });
       serviceReadRuntime.mockResolvedValue({ status: "stopped", state: "stopped" });
 
@@ -4265,12 +4224,9 @@ describe("update-cli", () => {
     async (runtimeStatus) => {
       const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
       mockPackageInstallStatus(createCaseDir("openclaw-update-stopped-task"));
-      serviceReadCommand.mockResolvedValue({
-        programArguments: ["openclaw", "gateway", "run"],
-        environment: {
-          OPENCLAW_SERVICE_MARKER: "openclaw",
-          OPENCLAW_SERVICE_KIND: "gateway",
-        },
+      primeServiceCommand(["openclaw", "gateway", "run"], {
+        OPENCLAW_SERVICE_MARKER: "openclaw",
+        OPENCLAW_SERVICE_KIND: "gateway",
       });
       serviceReadRuntime.mockResolvedValue(
         runtimeStatus === "running"
@@ -4356,12 +4312,9 @@ describe("update-cli", () => {
 
   it("fails managed git restart when the gateway responds but the service stays stopped", async () => {
     const serviceEntrypoint = path.join(process.cwd(), "dist", "index.js");
-    serviceReadCommand.mockResolvedValue({
-      programArguments: ["node", serviceEntrypoint, "gateway", "run"],
-      environment: {
-        OPENCLAW_SERVICE_MARKER: "openclaw",
-        OPENCLAW_SERVICE_KIND: "gateway",
-      },
+    primeServiceCommand(["node", serviceEntrypoint, "gateway", "run"], {
+      OPENCLAW_SERVICE_MARKER: "openclaw",
+      OPENCLAW_SERVICE_KIND: "gateway",
     });
     serviceLoaded.mockResolvedValue(false);
     serviceLoaded.mockResolvedValueOnce(true);
@@ -4405,12 +4358,9 @@ describe("update-cli", () => {
 
   it("fails managed git restart when the stopped service cannot be restarted", async () => {
     const serviceEntrypoint = path.join(process.cwd(), "dist", "index.js");
-    serviceReadCommand.mockResolvedValue({
-      programArguments: ["node", serviceEntrypoint, "gateway", "run"],
-      environment: {
-        OPENCLAW_SERVICE_MARKER: "openclaw",
-        OPENCLAW_SERVICE_KIND: "gateway",
-      },
+    primeServiceCommand(["node", serviceEntrypoint, "gateway", "run"], {
+      OPENCLAW_SERVICE_MARKER: "openclaw",
+      OPENCLAW_SERVICE_KIND: "gateway",
     });
     serviceLoaded.mockResolvedValue(false);
     serviceLoaded.mockResolvedValueOnce(true);
@@ -4620,10 +4570,7 @@ describe("update-cli", () => {
       "2026.4.23",
     );
     readPackageVersion.mockResolvedValue("2026.4.23");
-    vi.mocked(resolveNpmChannelTag).mockResolvedValue({
-      tag: "latest",
-      version: "2026.4.23",
-    });
+    primeNpmChannelTag("latest", "2026.4.23");
     for (const relativePath of TEST_BUNDLED_RUNTIME_SIDECAR_PATHS) {
       const absolutePath = path.join(pkgRoot, relativePath);
       await fs.mkdir(path.dirname(absolutePath), { recursive: true });
@@ -4909,9 +4856,7 @@ describe("update-cli", () => {
       "utf-8",
     );
     mockPackageInstallStatus(shellRoot);
-    serviceReadCommand.mockResolvedValue({
-      programArguments: [serviceNode, path.join(serviceRoot, "dist", "index.js"), "gateway"],
-    });
+    primeServiceCommand([serviceNode, path.join(serviceRoot, "dist", "index.js"), "gateway"]);
 
     await updateCommand({ dryRun: true });
 
@@ -4937,10 +4882,8 @@ describe("update-cli", () => {
       "utf-8",
     );
     mockPackageInstallStatus(shellRoot);
-    serviceReadCommand.mockResolvedValue({
-      programArguments: [serviceNode, path.join(serviceRoot, "dist", "index.js"), "gateway"],
-    });
-    vi.mocked(resolveNpmChannelTag).mockResolvedValue({ tag: "latest", version: "2026.5.20" });
+    primeServiceCommand([serviceNode, path.join(serviceRoot, "dist", "index.js"), "gateway"]);
+    primeNpmChannelTag("latest", "2026.5.20");
     vi.mocked(fetchNpmPackageTargetStatus).mockResolvedValue({
       target: "latest",
       version: "2026.5.20",
@@ -4985,14 +4928,9 @@ describe("update-cli", () => {
     await fs.writeFile(entrypoint, "", "utf-8");
     await writePackageDistInventory(serviceRoot);
     mockPackageInstallStatus(shellRoot);
-    serviceReadCommand.mockResolvedValue({
-      programArguments: [serviceNode, entrypoint, "gateway"],
-    });
+    primeServiceCommand([serviceNode, entrypoint, "gateway"]);
     serviceLoaded.mockResolvedValue(true);
-    vi.mocked(resolveNpmChannelTag).mockResolvedValue({
-      tag: "latest",
-      version: "2026.5.20",
-    });
+    primeNpmChannelTag("latest", "2026.5.20");
     mockFileBackedPathExists();
     vi.mocked(runCommandWithTimeout).mockImplementation(async (argv) => {
       if (Array.isArray(argv) && argv[0] === serviceNode && argv[1] === "--version") {
@@ -5046,9 +4984,7 @@ describe("update-cli", () => {
     const serviceNode = "/opt/other-node/bin/node";
     const entrypoint = path.join(root, "dist", "index.js");
     mockPackageInstallStatus(root);
-    serviceReadCommand.mockResolvedValue({
-      programArguments: [serviceNode, entrypoint, "gateway"],
-    });
+    primeServiceCommand([serviceNode, entrypoint, "gateway"]);
 
     await updateCommand({ dryRun: true });
 
@@ -5084,11 +5020,9 @@ describe("update-cli", () => {
     await writePackageDistInventory(root);
     // Same package root for both shell and service.
     mockPackageInstallStatus(root);
-    serviceReadCommand.mockResolvedValue({
-      programArguments: [serviceNode, entrypoint, "gateway"],
-    });
+    primeServiceCommand([serviceNode, entrypoint, "gateway"]);
     serviceLoaded.mockResolvedValue(true);
-    vi.mocked(resolveNpmChannelTag).mockResolvedValue({ tag: "latest", version: "2026.7.1" });
+    primeNpmChannelTag("latest", "2026.7.1");
     vi.mocked(fetchNpmPackageTargetStatus).mockResolvedValue({
       target: "latest",
       version: "2026.7.1",
@@ -5164,14 +5098,9 @@ describe("update-cli", () => {
     await fs.writeFile(entrypoint, "", "utf-8");
     await writePackageDistInventory(root);
     mockPackageInstallStatus(root);
-    serviceReadCommand.mockResolvedValue({
-      programArguments: [serviceNode, entrypoint, "gateway"],
-    });
+    primeServiceCommand([serviceNode, entrypoint, "gateway"]);
     serviceLoaded.mockResolvedValue(true);
-    vi.mocked(resolveNpmChannelTag).mockResolvedValue({
-      tag: "latest",
-      version: "2026.5.20",
-    });
+    primeNpmChannelTag("latest", "2026.5.20");
     mockFileBackedPathExists();
     // The PATH npm returns a DIFFERENT global root (simulates Node-B's npm).
     const nodeBGlobalRoot = path.join(
@@ -6204,9 +6133,7 @@ describe("update-cli", () => {
   it("tries the updated install restart when package service refresh fails", async () => {
     const { updatedRoot, updatedEntrypoint } = setupNpmUpdatedRootRefresh();
     serviceLoaded.mockResolvedValue(true);
-    serviceReadCommand.mockResolvedValue({
-      programArguments: ["node", updatedEntrypoint, "gateway", "run"],
-    });
+    primeServiceCommand(["node", updatedEntrypoint, "gateway", "run"]);
     mockGatewayInstallFailure(updatedEntrypoint);
     mockGatewayProbe("2026.4.24", "updated-gateway");
 
@@ -6246,9 +6173,7 @@ describe("update-cli", () => {
         candidate === updatedEntrypoint || candidate === updatedPackageJson,
     );
     serviceLoaded.mockResolvedValue(true);
-    serviceReadCommand.mockResolvedValue({
-      programArguments: ["node", updatedEntrypoint, "gateway", "run"],
-    });
+    primeServiceCommand(["node", updatedEntrypoint, "gateway", "run"]);
     mockGatewayInstallFailure(updatedEntrypoint);
     mockGatewayProbe("2026.4.24", "matching-old-gateway");
 
@@ -6297,9 +6222,7 @@ describe("update-cli", () => {
       [oldEntrypoint, updatedEntrypoint, oldPackageJson, updatedPackageJson].includes(candidate),
     );
     serviceLoaded.mockResolvedValue(true);
-    serviceReadCommand.mockResolvedValue({
-      programArguments: ["node", oldEntrypoint, "gateway", "run"],
-    });
+    primeServiceCommand(["node", oldEntrypoint, "gateway", "run"]);
     mockGatewayInstallFailure(updatedEntrypoint);
     mockGatewayProbe("2026.4.24", "matching-old-service");
 

--- a/src/commands/model-picker.test.ts
+++ b/src/commands/model-picker.test.ts
@@ -233,16 +233,8 @@ vi.mock("../commands/model-picker.runtime.js", () => ({
 }));
 
 const OPENROUTER_CATALOG = [
-  {
-    provider: "openrouter",
-    id: "auto",
-    name: "OpenRouter Auto",
-  },
-  {
-    provider: "openrouter",
-    id: "meta-llama/llama-3.3-70b:free",
-    name: "Llama 3.3 70B",
-  },
+  catalogModel("openrouter", "auto", "OpenRouter Auto"),
+  catalogModel("openrouter", "meta-llama/llama-3.3-70b:free", "Llama 3.3 70B"),
 ] as const;
 
 function expectRouterModelFiltering(options: Array<{ value: string }>) {
@@ -254,6 +246,19 @@ function expectRouterModelFiltering(options: Array<{ value: string }>) {
 
 function createSelectAllMultiselect() {
   return vi.fn(async (params) => params.options.map((option: { value: string }) => option.value));
+}
+
+function promptDefaultPicker(params: Parameters<typeof promptDefaultModel>[0]) {
+  return promptDefaultModel({
+    allowKeep: false,
+    includeManual: false,
+    ignoreAllowlist: true,
+    ...params,
+  });
+}
+
+function catalogModel(provider: string, id: string, name: string): ModelCatalogEntry {
+  return { provider, id, name };
 }
 
 function configuredTextModel(id: string, name: string) {
@@ -428,12 +433,9 @@ describe("promptDefaultModel", () => {
     const select = vi.fn(async (params) => params.initialValue as never);
     const prompter = makePrompter({ select });
 
-    await promptDefaultModel({
+    await promptDefaultPicker({
       config: { agents: { defaults: {} } } as OpenClawConfig,
       prompter,
-      allowKeep: false,
-      includeManual: false,
-      ignoreAllowlist: true,
     });
 
     const options = pickerOptions(select as MockCallSource);
@@ -462,12 +464,9 @@ describe("promptDefaultModel", () => {
       ]);
       const select = vi.fn(async (params) => params.initialValue as never);
 
-      await promptDefaultModel({
+      await promptDefaultPicker({
         config: { agents: { defaults } } as OpenClawConfig,
         prompter: makePrompter({ select }),
-        allowKeep: false,
-        includeManual: false,
-        ignoreAllowlist: true,
       });
 
       const option = requireOption(pickerOptions(select as MockCallSource), "openai/gpt-5.5");
@@ -493,12 +492,9 @@ describe("promptDefaultModel", () => {
     } as OpenClawConfig;
     const select = vi.fn(async (params) => params.initialValue as never);
 
-    await promptDefaultModel({
+    await promptDefaultPicker({
       config,
       prompter: makePrompter({ select }),
-      allowKeep: false,
-      includeManual: false,
-      ignoreAllowlist: true,
     });
 
     const option = requireOption(pickerOptions(select as MockCallSource), "openai/gpt-5.5");
@@ -537,12 +533,9 @@ describe("promptDefaultModel", () => {
     modelCatalogRouteVariants.value = [platform, chatGPT];
     const select = vi.fn(async (params) => params.initialValue as never);
 
-    await promptDefaultModel({
+    await promptDefaultPicker({
       config: { agents: { defaults: {} } } as OpenClawConfig,
       prompter: makePrompter({ select }),
-      allowKeep: false,
-      includeManual: false,
-      ignoreAllowlist: true,
     });
 
     const option = requireOption(pickerOptions(select as MockCallSource), "openai/gpt-5.5");
@@ -562,12 +555,9 @@ describe("promptDefaultModel", () => {
     const select = vi.fn(async (params) => params.initialValue as never);
     const prompter = makePrompter({ select });
 
-    await promptDefaultModel({
+    await promptDefaultPicker({
       config: { agents: { defaults: { model: { primary: "anthropic/claude-sonnet-4-6" } } } },
       prompter,
-      allowKeep: false,
-      includeManual: false,
-      ignoreAllowlist: true,
     });
 
     const values = optionValues(pickerOptions(select as MockCallSource));
@@ -587,14 +577,11 @@ describe("promptDefaultModel", () => {
     ]);
     const select = vi.fn(async (params) => params.initialValue as never);
 
-    await promptDefaultModel({
+    await promptDefaultPicker({
       config: {
         agents: { defaults: { model: { primary: "anthropic/claude-sonnet-4-6" } } },
       },
       prompter: makePrompter({ select }),
-      allowKeep: false,
-      includeManual: false,
-      ignoreAllowlist: true,
     });
 
     expect(optionValues(pickerOptions(select as MockCallSource))).toEqual([
@@ -618,12 +605,9 @@ describe("promptDefaultModel", () => {
     const select = vi.fn(async (params) => params.initialValue as never);
     const prompter = makePrompter({ select });
 
-    await promptDefaultModel({
+    await promptDefaultPicker({
       config: { agents: { defaults: {} } } as OpenClawConfig,
       prompter,
-      allowKeep: false,
-      includeManual: false,
-      ignoreAllowlist: true,
     });
 
     const values = optionValues(pickerOptions(select as MockCallSource));
@@ -659,12 +643,9 @@ describe("promptDefaultModel", () => {
     ]);
     const select = vi.fn(async (params) => params.initialValue as never);
 
-    await promptDefaultModel({
+    await promptDefaultPicker({
       config: { agents: { defaults: {} } } as OpenClawConfig,
       prompter: makePrompter({ select }),
-      allowKeep: false,
-      includeManual: false,
-      ignoreAllowlist: true,
     });
 
     expect(optionValues(pickerOptions(select as MockCallSource))).toEqual([
@@ -699,12 +680,9 @@ describe("promptDefaultModel", () => {
     const select = vi.fn(async (params) => params.initialValue as never);
     const prompter = makePrompter({ select });
 
-    await promptDefaultModel({
+    await promptDefaultPicker({
       config: { agents: { defaults: {} } } as OpenClawConfig,
       prompter,
-      allowKeep: false,
-      includeManual: false,
-      ignoreAllowlist: true,
     });
 
     const values = optionValues(pickerOptions(select as MockCallSource));
@@ -723,12 +701,9 @@ describe("promptDefaultModel", () => {
     const select = vi.fn(async (params) => params.options[0]?.value as never);
     const prompter = makePrompter({ select });
 
-    const result = await promptDefaultModel({
+    const result = await promptDefaultPicker({
       config: { agents: { defaults: {} } } as OpenClawConfig,
       prompter,
-      allowKeep: false,
-      includeManual: false,
-      ignoreAllowlist: true,
     });
 
     expect(result.model).toBe("google/gemini-3.1-pro-preview");
@@ -764,12 +739,9 @@ describe("promptDefaultModel", () => {
       agents: { defaults: {} },
     } as OpenClawConfig;
 
-    const result = await promptDefaultModel({
+    const result = await promptDefaultPicker({
       config,
       prompter,
-      allowKeep: false,
-      includeManual: false,
-      ignoreAllowlist: true,
     });
 
     expect(loadModelCatalog).not.toHaveBeenCalled();
@@ -783,16 +755,8 @@ describe("promptDefaultModel", () => {
 
   it("treats byteplus plan models as preferred-provider matches", async () => {
     loadModelCatalog.mockResolvedValue([
-      {
-        provider: "openai",
-        id: "gpt-5.5",
-        name: "GPT-5.5",
-      },
-      {
-        provider: "byteplus-plan",
-        id: "ark-code-latest",
-        name: "Ark Coding Plan",
-      },
+      catalogModel("openai", "gpt-5.5", "GPT-5.5"),
+      catalogModel("byteplus-plan", "ark-code-latest", "Ark Coding Plan"),
     ]);
 
     const select = vi.fn(async (params) => params.initialValue as never);
@@ -805,12 +769,10 @@ describe("promptDefaultModel", () => {
       },
     } as OpenClawConfig;
 
-    const result = await promptDefaultModel({
+    const result = await promptDefaultPicker({
       config,
       prompter,
       allowKeep: true,
-      includeManual: false,
-      ignoreAllowlist: true,
       preferredProvider: "byteplus",
     });
 
@@ -828,11 +790,7 @@ describe("promptDefaultModel", () => {
 
   it("shows literal double-prefix labels for providers that preserve literal prefixes", async () => {
     loadModelCatalog.mockResolvedValue([
-      {
-        provider: "nvidia",
-        id: "nvidia/nemotron-3-super-120b-a12b",
-        name: "Nemotron",
-      },
+      catalogModel("nvidia", "nvidia/nemotron-3-super-120b-a12b", "Nemotron"),
     ]);
     resolvePluginProviders.mockReturnValue([
       {
@@ -851,12 +809,10 @@ describe("promptDefaultModel", () => {
       },
     } as OpenClawConfig;
 
-    await promptDefaultModel({
+    await promptDefaultPicker({
       config,
       prompter,
       allowKeep: true,
-      includeManual: false,
-      ignoreAllowlist: true,
     });
 
     const options = pickerOptions(select as MockCallSource);
@@ -870,21 +826,9 @@ describe("promptDefaultModel", () => {
 
   it("does not double-prefix non-literal NVIDIA vendor model labels", async () => {
     loadModelCatalog.mockResolvedValue([
-      {
-        provider: "nvidia",
-        id: "nvidia/nemotron-3-super-120b-a12b",
-        name: "Nemotron",
-      },
-      {
-        provider: "nvidia",
-        id: "minimaxai/minimax-m2.7",
-        name: "MiniMax M2.7",
-      },
-      {
-        provider: "nvidia",
-        id: "z-ai/glm-5.1",
-        name: "GLM 5.1",
-      },
+      catalogModel("nvidia", "nvidia/nemotron-3-super-120b-a12b", "Nemotron"),
+      catalogModel("nvidia", "minimaxai/minimax-m2.7", "MiniMax M2.7"),
+      catalogModel("nvidia", "z-ai/glm-5.1", "GLM 5.1"),
     ]);
     resolvePluginProviders.mockReturnValue([
       {
@@ -896,12 +840,9 @@ describe("promptDefaultModel", () => {
     const select = vi.fn(async (params) => params.initialValue as never);
     const prompter = makePrompter({ select });
 
-    await promptDefaultModel({
+    await promptDefaultPicker({
       config: { agents: { defaults: {} } } as OpenClawConfig,
       prompter,
-      allowKeep: false,
-      includeManual: false,
-      ignoreAllowlist: true,
       preferredProvider: "nvidia",
     });
 
@@ -933,12 +874,11 @@ describe("promptDefaultModel", () => {
       },
     } as OpenClawConfig;
 
-    const result = await promptDefaultModel({
+    const result = await promptDefaultPicker({
       config,
       prompter,
       allowKeep: true,
       includeManual: true,
-      ignoreAllowlist: true,
       preferredProvider: "nvidia",
       browseCatalogOnDemand: true,
     });
@@ -966,12 +906,11 @@ describe("promptDefaultModel", () => {
       },
     } as OpenClawConfig;
 
-    const result = await promptDefaultModel({
+    const result = await promptDefaultPicker({
       config,
       prompter,
       allowKeep: true,
       includeManual: true,
-      ignoreAllowlist: true,
       preferredProvider: "openai",
       browseCatalogOnDemand: true,
     });
@@ -999,12 +938,11 @@ describe("promptDefaultModel", () => {
       },
     } as OpenClawConfig;
 
-    const result = await promptDefaultModel({
+    const result = await promptDefaultPicker({
       config,
       prompter,
       allowKeep: true,
       includeManual: true,
-      ignoreAllowlist: true,
       browseCatalogOnDemand: true,
       loadCatalog: true,
     });
@@ -1023,16 +961,8 @@ describe("promptDefaultModel", () => {
 
   it("loads the full model catalog when browsing without a preferred provider", async () => {
     loadModelCatalog.mockResolvedValue([
-      {
-        provider: "openai",
-        id: "gpt-5.5",
-        name: "GPT-5.5",
-      },
-      {
-        provider: "openai",
-        id: "gpt-5.5-pro",
-        name: "GPT-5.5 Pro",
-      },
+      catalogModel("openai", "gpt-5.5", "GPT-5.5"),
+      catalogModel("openai", "gpt-5.5-pro", "GPT-5.5 Pro"),
     ]);
     const select = vi
       .fn()
@@ -1052,12 +982,11 @@ describe("promptDefaultModel", () => {
       },
     } as OpenClawConfig;
 
-    const result = await promptDefaultModel({
+    const result = await promptDefaultPicker({
       config,
       prompter,
       allowKeep: true,
       includeManual: true,
-      ignoreAllowlist: true,
       browseCatalogOnDemand: true,
     });
 
@@ -1070,16 +999,8 @@ describe("promptDefaultModel", () => {
 
   it("loads the preferred provider catalog when the user chooses to browse", async () => {
     loadPreferredProviderPickerCatalog.mockResolvedValue([
-      {
-        provider: "openai",
-        id: "gpt-5.5",
-        name: "GPT-5.5",
-      },
-      {
-        provider: "openai",
-        id: "gpt-5.5-pro",
-        name: "GPT-5.5 Pro",
-      },
+      catalogModel("openai", "gpt-5.5", "GPT-5.5"),
+      catalogModel("openai", "gpt-5.5-pro", "GPT-5.5 Pro"),
     ]);
     const select = vi
       .fn()
@@ -1099,12 +1020,11 @@ describe("promptDefaultModel", () => {
       },
     } as OpenClawConfig;
 
-    const result = await promptDefaultModel({
+    const result = await promptDefaultPicker({
       config,
       prompter,
       allowKeep: true,
       includeManual: true,
-      ignoreAllowlist: true,
       preferredProvider: "openai",
       browseCatalogOnDemand: true,
     });
@@ -1122,16 +1042,8 @@ describe("promptDefaultModel", () => {
 
   it("scopes on-demand preferred-provider loads before the first model prompt", async () => {
     loadPreferredProviderPickerCatalog.mockResolvedValue([
-      {
-        provider: "nvidia",
-        id: "nvidia/nemotron-3-super-120b-a12b",
-        name: "NVIDIA Nemotron 3 Super 120B",
-      },
-      {
-        provider: "nvidia",
-        id: "moonshotai/kimi-k2.5",
-        name: "Kimi K2.5",
-      },
+      catalogModel("nvidia", "nvidia/nemotron-3-super-120b-a12b", "NVIDIA Nemotron 3 Super 120B"),
+      catalogModel("nvidia", "moonshotai/kimi-k2.5", "Kimi K2.5"),
     ]);
     const select = vi.fn(async (params) => params.options[0]?.value as never);
     const prompter = makePrompter({ select });
@@ -1143,12 +1055,9 @@ describe("promptDefaultModel", () => {
       },
     } as OpenClawConfig;
 
-    const result = await promptDefaultModel({
+    const result = await promptDefaultPicker({
       config,
       prompter,
-      allowKeep: false,
-      includeManual: false,
-      ignoreAllowlist: true,
       preferredProvider: "nvidia",
       browseCatalogOnDemand: true,
     });
@@ -1168,16 +1077,8 @@ describe("promptDefaultModel", () => {
 
   it("preselects the first live provider row when keep-current is disabled", async () => {
     loadPreferredProviderPickerCatalog.mockResolvedValue([
-      {
-        provider: "nvidia",
-        id: "z-ai/glm-5.1",
-        name: "GLM 5.1",
-      },
-      {
-        provider: "nvidia",
-        id: "nvidia/nemotron-3-super-120b-a12b",
-        name: "NVIDIA Nemotron 3 Super 120B",
-      },
+      catalogModel("nvidia", "z-ai/glm-5.1", "GLM 5.1"),
+      catalogModel("nvidia", "nvidia/nemotron-3-super-120b-a12b", "NVIDIA Nemotron 3 Super 120B"),
     ]);
     const select = vi.fn(async (params) => params.initialValue as never);
     const prompter = makePrompter({ select });
@@ -1189,12 +1090,9 @@ describe("promptDefaultModel", () => {
       },
     } as OpenClawConfig;
 
-    const result = await promptDefaultModel({
+    const result = await promptDefaultPicker({
       config,
       prompter,
-      allowKeep: false,
-      includeManual: false,
-      ignoreAllowlist: true,
       preferredProvider: "nvidia",
       browseCatalogOnDemand: true,
     });
@@ -1214,21 +1112,9 @@ describe("promptDefaultModel", () => {
 
   it("keeps on-demand NVIDIA vendor labels single-prefixed after browsing", async () => {
     loadPreferredProviderPickerCatalog.mockResolvedValue([
-      {
-        provider: "nvidia",
-        id: "nvidia/nemotron-3-super-120b-a12b",
-        name: "NVIDIA Nemotron 3 Super 120B",
-      },
-      {
-        provider: "nvidia",
-        id: "minimaxai/minimax-m2.7",
-        name: "MiniMax M2.7",
-      },
-      {
-        provider: "nvidia",
-        id: "z-ai/glm-5.1",
-        name: "GLM 5.1",
-      },
+      catalogModel("nvidia", "nvidia/nemotron-3-super-120b-a12b", "NVIDIA Nemotron 3 Super 120B"),
+      catalogModel("nvidia", "minimaxai/minimax-m2.7", "MiniMax M2.7"),
+      catalogModel("nvidia", "z-ai/glm-5.1", "GLM 5.1"),
     ]);
     resolvePluginProviders.mockReturnValue([
       {
@@ -1242,7 +1128,7 @@ describe("promptDefaultModel", () => {
       .mockResolvedValueOnce("nvidia/nemotron-3-super-120b-a12b");
     const prompter = makePrompter({ select });
 
-    await promptDefaultModel({
+    await promptDefaultPicker({
       config: {
         agents: {
           defaults: {
@@ -1253,7 +1139,6 @@ describe("promptDefaultModel", () => {
       prompter,
       allowKeep: true,
       includeManual: true,
-      ignoreAllowlist: true,
       preferredProvider: "nvidia",
       browseCatalogOnDemand: true,
     });
@@ -1270,21 +1155,9 @@ describe("promptDefaultModel", () => {
 
   it("omits local NVIDIA static fallback rows when browsing live provider rows", async () => {
     loadPreferredProviderPickerCatalog.mockResolvedValue([
-      {
-        provider: "nvidia",
-        id: "nvidia/nemotron-3-super-120b-a12b",
-        name: "NVIDIA Nemotron 3 Super 120B",
-      },
-      {
-        provider: "nvidia",
-        id: "minimaxai/minimax-m2.7",
-        name: "MiniMax M2.7",
-      },
-      {
-        provider: "nvidia",
-        id: "z-ai/glm-5.1",
-        name: "GLM 5.1",
-      },
+      catalogModel("nvidia", "nvidia/nemotron-3-super-120b-a12b", "NVIDIA Nemotron 3 Super 120B"),
+      catalogModel("nvidia", "minimaxai/minimax-m2.7", "MiniMax M2.7"),
+      catalogModel("nvidia", "z-ai/glm-5.1", "GLM 5.1"),
     ]);
     loadStaticManifestCatalogRowsForList.mockReturnValue([
       manifestTextRow("nvidia", "minimaxai/minimax-m2.5", "MiniMax M2.5", "deprecated"),
@@ -1302,7 +1175,7 @@ describe("promptDefaultModel", () => {
       .mockResolvedValueOnce("nvidia/nemotron-3-super-120b-a12b");
     const prompter = makePrompter({ select });
 
-    await promptDefaultModel({
+    await promptDefaultPicker({
       config: {
         agents: {
           defaults: {
@@ -1313,7 +1186,6 @@ describe("promptDefaultModel", () => {
       prompter,
       allowKeep: true,
       includeManual: true,
-      ignoreAllowlist: true,
       preferredProvider: "nvidia",
       browseCatalogOnDemand: true,
     });
@@ -1329,11 +1201,7 @@ describe("promptDefaultModel", () => {
 
   it("uses the configured default agent dir for provider-scoped catalog auth", async () => {
     loadPreferredProviderPickerCatalog.mockResolvedValue([
-      {
-        provider: "nvidia",
-        id: "z-ai/glm-5.1",
-        name: "GLM 5.1",
-      },
+      catalogModel("nvidia", "z-ai/glm-5.1", "GLM 5.1"),
     ]);
     const select = vi.fn(async (params) => params.options[0]?.value as never);
     const prompter = makePrompter({ select });
@@ -1350,12 +1218,9 @@ describe("promptDefaultModel", () => {
       },
     } as OpenClawConfig;
 
-    await promptDefaultModel({
+    await promptDefaultPicker({
       config,
       prompter,
-      allowKeep: false,
-      includeManual: false,
-      ignoreAllowlist: true,
       preferredProvider: "nvidia",
       browseCatalogOnDemand: true,
       env,
@@ -1371,11 +1236,7 @@ describe("promptDefaultModel", () => {
 
   it("supports configuring vLLM during setup", async () => {
     loadModelCatalog.mockResolvedValue([
-      {
-        provider: "anthropic",
-        id: "claude-sonnet-4-6",
-        name: "Claude Sonnet 4.5",
-      },
+      catalogModel("anthropic", "claude-sonnet-4-6", "Claude Sonnet 4.5"),
     ]);
     resolveProviderModelPickerEntries.mockReturnValue([
       { value: "vllm", label: "vLLM (custom)", hint: "Enter vLLM URL + API key + model" },
@@ -1413,13 +1274,10 @@ describe("promptDefaultModel", () => {
     const prompter = makePrompter({ select });
     const config = { agents: { defaults: {} } } as OpenClawConfig;
 
-    const result = await promptDefaultModel({
+    const result = await promptDefaultPicker({
       config,
       prompter,
-      allowKeep: false,
-      includeManual: false,
       includeProviderPluginSetups: true,
-      ignoreAllowlist: true,
       agentDir: "/tmp/openclaw-agent",
       runtime: {} as never,
     });
@@ -1443,13 +1301,7 @@ describe("promptDefaultModel", () => {
   });
 
   it("prefers provider model-picker contributions when the runtime exposes them", async () => {
-    loadModelCatalog.mockResolvedValue([
-      {
-        provider: "openai",
-        id: "gpt-5.5",
-        name: "GPT-5.5",
-      },
-    ]);
+    loadModelCatalog.mockResolvedValue([catalogModel("openai", "gpt-5.5", "GPT-5.5")]);
     providerModelPickerContributionRuntime.enabled = true;
     providerModelPickerContributionRuntime.resolve.mockReturnValue([
       {
@@ -1477,13 +1329,10 @@ describe("promptDefaultModel", () => {
     });
     const prompter = makePrompter({ select });
 
-    await promptDefaultModel({
+    await promptDefaultPicker({
       config: { agents: { defaults: {} } } as OpenClawConfig,
       prompter,
-      allowKeep: false,
-      includeManual: false,
       includeProviderPluginSetups: true,
-      ignoreAllowlist: true,
       agentDir: "/tmp/openclaw-agent",
       runtime: {} as never,
     });
@@ -1505,12 +1354,11 @@ describe("promptDefaultModel", () => {
       },
     } as OpenClawConfig;
 
-    const result = await promptDefaultModel({
+    const result = await promptDefaultPicker({
       config,
       prompter,
       allowKeep: true,
       includeManual: true,
-      ignoreAllowlist: true,
       includeProviderPluginSetups: true,
       loadCatalog: false,
       agentDir: "/tmp/openclaw-agent",
@@ -1529,13 +1377,7 @@ describe("promptDefaultModel", () => {
   });
 
   it("surfaces NVIDIA provider model-picker contributions", async () => {
-    loadModelCatalog.mockResolvedValue([
-      {
-        provider: "openai",
-        id: "gpt-5.4",
-        name: "GPT-5.4",
-      },
-    ]);
+    loadModelCatalog.mockResolvedValue([catalogModel("openai", "gpt-5.4", "GPT-5.4")]);
     providerModelPickerContributionRuntime.enabled = true;
     providerModelPickerContributionRuntime.resolve.mockReturnValue([
       {
@@ -1558,13 +1400,10 @@ describe("promptDefaultModel", () => {
     });
     const prompter = makePrompter({ select });
 
-    await promptDefaultModel({
+    await promptDefaultPicker({
       config: { agents: { defaults: {} } } as OpenClawConfig,
       prompter,
-      allowKeep: false,
-      includeManual: false,
       includeProviderPluginSetups: true,
-      ignoreAllowlist: true,
       agentDir: "/tmp/openclaw-agent",
       runtime: {} as never,
     });
@@ -1579,21 +1418,9 @@ describe("promptDefaultModel", () => {
 describe("promptModelAllowlist", () => {
   it("filters to allowed keys when provided", async () => {
     loadModelCatalog.mockResolvedValue([
-      {
-        provider: "anthropic",
-        id: "claude-opus-4-6",
-        name: "Claude Opus 4.5",
-      },
-      {
-        provider: "anthropic",
-        id: "claude-sonnet-4-6",
-        name: "Claude Sonnet 4.5",
-      },
-      {
-        provider: "openai",
-        id: "gpt-5.5",
-        name: "GPT-5.5",
-      },
+      catalogModel("anthropic", "claude-opus-4-6", "Claude Opus 4.5"),
+      catalogModel("anthropic", "claude-sonnet-4-6", "Claude Sonnet 4.5"),
+      catalogModel("openai", "gpt-5.5", "GPT-5.5"),
     ]);
 
     const multiselect = createSelectAllMultiselect();
@@ -1613,13 +1440,7 @@ describe("promptModelAllowlist", () => {
 
   it("localizes the model allowlist picker", async () => {
     process.env.OPENCLAW_LOCALE = "zh-CN";
-    loadModelCatalog.mockResolvedValue([
-      {
-        provider: "openai",
-        id: "gpt-5.5",
-        name: "GPT-5.5",
-      },
-    ]);
+    loadModelCatalog.mockResolvedValue([catalogModel("openai", "gpt-5.5", "GPT-5.5")]);
 
     const multiselect = createSelectAllMultiselect();
     const prompter = makePrompter({ multiselect });
@@ -1743,13 +1564,7 @@ describe("promptModelAllowlist", () => {
   });
 
   it("uses configured provider models for allowlist picker without loading the full catalog in replace mode", async () => {
-    loadModelCatalog.mockResolvedValue([
-      {
-        provider: "openai",
-        id: "gpt-5.5",
-        name: "GPT-5.5",
-      },
-    ]);
+    loadModelCatalog.mockResolvedValue([catalogModel("openai", "gpt-5.5", "GPT-5.5")]);
 
     const multiselect = createSelectAllMultiselect();
     const prompter = makePrompter({ multiselect });
@@ -1782,21 +1597,9 @@ describe("promptModelAllowlist", () => {
 
   it("scopes the initial allowlist picker to the preferred provider", async () => {
     loadModelCatalog.mockResolvedValue([
-      {
-        provider: "anthropic",
-        id: "claude-sonnet-4-6",
-        name: "Claude Sonnet 4.5",
-      },
-      {
-        provider: "openai",
-        id: "gpt-5.5",
-        name: "GPT-5.5",
-      },
-      {
-        provider: "openai",
-        id: "gpt-5.4-mini",
-        name: "GPT-5.4 Mini",
-      },
+      catalogModel("anthropic", "claude-sonnet-4-6", "Claude Sonnet 4.5"),
+      catalogModel("openai", "gpt-5.5", "GPT-5.5"),
+      catalogModel("openai", "gpt-5.4-mini", "GPT-5.4 Mini"),
     ]);
 
     const multiselect = createSelectAllMultiselect();
@@ -1815,16 +1618,8 @@ describe("promptModelAllowlist", () => {
 
   it("includes stale configured preferred provider models in the scoped cleanup", async () => {
     loadModelCatalog.mockResolvedValue([
-      {
-        provider: "openrouter",
-        id: "meta-llama/llama-3.3-70b:free",
-        name: "Llama 3.3 70B",
-      },
-      {
-        provider: "openai",
-        id: "gpt-5.5",
-        name: "GPT-5.5",
-      },
+      catalogModel("openrouter", "meta-llama/llama-3.3-70b:free", "Llama 3.3 70B"),
+      catalogModel("openai", "gpt-5.5", "GPT-5.5"),
     ]);
 
     const activeModel = "openrouter/meta-llama/llama-3.3-70b:free";
@@ -1918,16 +1713,8 @@ describe("promptModelAllowlist", () => {
 
   it("keeps live preferred-provider rows before configured fallback supplements", async () => {
     loadPreferredProviderPickerCatalog.mockResolvedValue([
-      {
-        provider: "nvidia",
-        id: "minimaxai/minimax-m2.7",
-        name: "MiniMax M2.7",
-      },
-      {
-        provider: "nvidia",
-        id: "nvidia/nemotron-3-super-120b-a12b",
-        name: "Nemotron 3 Super",
-      },
+      catalogModel("nvidia", "minimaxai/minimax-m2.7", "MiniMax M2.7"),
+      catalogModel("nvidia", "nvidia/nemotron-3-super-120b-a12b", "Nemotron 3 Super"),
     ]);
 
     const multiselect = createSelectAllMultiselect();
@@ -1969,36 +1756,12 @@ describe("promptModelAllowlist", () => {
 
   it("keeps provider-scoped live rows authoritative over configured provider supplements", async () => {
     loadPreferredProviderPickerCatalog.mockResolvedValue([
-      {
-        provider: "nvidia",
-        id: "nvidia/nemotron-3-super-120b-a12b",
-        name: "Nemotron 3 Super",
-      },
-      {
-        provider: "nvidia",
-        id: "z-ai/glm-5.1",
-        name: "GLM 5.1",
-      },
-      {
-        provider: "nvidia",
-        id: "minimaxai/minimax-m2.7",
-        name: "MiniMax M2.7",
-      },
-      {
-        provider: "nvidia",
-        id: "moonshotai/kimi-k2.5",
-        name: "Kimi K2.5",
-      },
-      {
-        provider: "nvidia",
-        id: "minimaxai/minimax-m2.5",
-        name: "MiniMax M2.5",
-      },
-      {
-        provider: "nvidia",
-        id: "z-ai/glm5",
-        name: "GLM5",
-      },
+      catalogModel("nvidia", "nvidia/nemotron-3-super-120b-a12b", "Nemotron 3 Super"),
+      catalogModel("nvidia", "z-ai/glm-5.1", "GLM 5.1"),
+      catalogModel("nvidia", "minimaxai/minimax-m2.7", "MiniMax M2.7"),
+      catalogModel("nvidia", "moonshotai/kimi-k2.5", "Kimi K2.5"),
+      catalogModel("nvidia", "minimaxai/minimax-m2.5", "MiniMax M2.5"),
+      catalogModel("nvidia", "z-ai/glm5", "GLM5"),
     ]);
     loadStaticManifestCatalogRowsForList.mockReturnValue([
       manifestTextRow("nvidia", "nvidia/nemotron-3-super-120b-a12b", "Bundled Nemotron 3 Super"),
@@ -2052,16 +1815,8 @@ describe("promptModelAllowlist", () => {
 
   it("keeps custom configured rows after provider-scoped live rows", async () => {
     loadPreferredProviderPickerCatalog.mockResolvedValue([
-      {
-        provider: "nvidia",
-        id: "nvidia/nemotron-3-super-120b-a12b",
-        name: "Nemotron 3 Super",
-      },
-      {
-        provider: "nvidia",
-        id: "z-ai/glm-5.1",
-        name: "GLM 5.1",
-      },
+      catalogModel("nvidia", "nvidia/nemotron-3-super-120b-a12b", "Nemotron 3 Super"),
+      catalogModel("nvidia", "z-ai/glm-5.1", "GLM 5.1"),
     ]);
     loadStaticManifestCatalogRowsForList.mockReturnValue([
       manifestTextRow("nvidia", "nvidia/nemotron-3-super-120b-a12b", "Bundled Nemotron 3 Super"),
@@ -2107,16 +1862,8 @@ describe("promptModelAllowlist", () => {
 
   it("does not re-add configured static rows after filtering deprecated live rows", async () => {
     loadPreferredProviderPickerCatalog.mockResolvedValue([
-      {
-        provider: "nvidia",
-        id: "minimaxai/minimax-m2.5",
-        name: "MiniMax M2.5",
-      },
-      {
-        provider: "nvidia",
-        id: "z-ai/glm5",
-        name: "GLM5",
-      },
+      catalogModel("nvidia", "minimaxai/minimax-m2.5", "MiniMax M2.5"),
+      catalogModel("nvidia", "z-ai/glm5", "GLM5"),
     ]);
     loadStaticManifestCatalogRowsForList.mockReturnValue([
       manifestTextRow("nvidia", "minimaxai/minimax-m2.5", "Bundled MiniMax M2.5", "deprecated"),
@@ -2196,16 +1943,8 @@ describe("promptModelAllowlist", () => {
   it("keeps local no-key provider models visible in allowlist choices", async () => {
     resolveEnvApiKey.mockReturnValue(null);
     loadModelCatalog.mockResolvedValue([
-      {
-        provider: "vllm",
-        id: "meta-llama/Meta-Llama-3-8B-Instruct",
-        name: "Meta Llama",
-      },
-      {
-        provider: "openai",
-        id: "gpt-5.5",
-        name: "GPT-5.5",
-      },
+      catalogModel("vllm", "meta-llama/Meta-Llama-3-8B-Instruct", "Meta Llama"),
+      catalogModel("openai", "gpt-5.5", "GPT-5.5"),
     ]);
 
     const multiselect = createSelectAllMultiselect();
@@ -2232,13 +1971,7 @@ describe("promptModelAllowlist", () => {
   });
 
   it("seeds existing model fallbacks into unscoped allowlist selections", async () => {
-    loadModelCatalog.mockResolvedValue([
-      {
-        provider: "openai",
-        id: "gpt-5.5",
-        name: "GPT-5.5",
-      },
-    ]);
+    loadModelCatalog.mockResolvedValue([catalogModel("openai", "gpt-5.5", "GPT-5.5")]);
 
     const multiselect = vi.fn(async (params) => params.initialValues ?? []);
     const prompter = makePrompter({ multiselect });
@@ -2268,21 +2001,9 @@ describe("promptModelAllowlist", () => {
 
   it("resolves bare fallback seeds against the primary model provider", async () => {
     loadModelCatalog.mockResolvedValue([
-      {
-        provider: "anthropic",
-        id: "claude-opus-4-6",
-        name: "Claude Opus 4.5",
-      },
-      {
-        provider: "anthropic",
-        id: "claude-sonnet-4-6",
-        name: "Claude Sonnet 4.5",
-      },
-      {
-        provider: "openai",
-        id: "claude-sonnet-4-6",
-        name: "Wrong provider",
-      },
+      catalogModel("anthropic", "claude-opus-4-6", "Claude Opus 4.5"),
+      catalogModel("anthropic", "claude-sonnet-4-6", "Claude Sonnet 4.5"),
+      catalogModel("openai", "claude-sonnet-4-6", "Wrong provider"),
     ]);
 
     const multiselect = vi.fn(async (params) => params.initialValues ?? []);
@@ -2356,21 +2077,9 @@ describe("promptModelAllowlist", () => {
 
   it("keeps provider-scoped fallback supplements within scope", async () => {
     loadModelCatalog.mockResolvedValue([
-      {
-        provider: "openai",
-        id: "gpt-5.5",
-        name: "GPT-5.5",
-      },
-      {
-        provider: "openai",
-        id: "gpt-5.4",
-        name: "GPT-5.4",
-      },
-      {
-        provider: "anthropic",
-        id: "claude-sonnet-4-6",
-        name: "Claude Sonnet 4.5",
-      },
+      catalogModel("openai", "gpt-5.5", "GPT-5.5"),
+      catalogModel("openai", "gpt-5.4", "GPT-5.4"),
+      catalogModel("anthropic", "claude-sonnet-4-6", "Claude Sonnet 4.5"),
     ]);
 
     const multiselect = vi.fn(async (params) => params.initialValues ?? []);
@@ -2515,12 +2224,9 @@ describe("router model filtering", () => {
     const allowlistPrompter = makePrompter({ multiselect });
     const config = { agents: { defaults: {} } } as OpenClawConfig;
 
-    await promptDefaultModel({
+    await promptDefaultPicker({
       config,
       prompter: defaultPrompter,
-      allowKeep: false,
-      includeManual: false,
-      ignoreAllowlist: true,
     });
     await promptModelAllowlist({ config, prompter: allowlistPrompter });
 


### PR DESCRIPTION
## What Problem This Solves

Maintainers spend unnecessary time reviewing repeated capability, gateway, update, and model-provider fixtures across security-sensitive CLI regression suites.

## Why This Change Was Made

Consolidate only equivalent fixtures in the four owning test suites while preserving every current named case and assertion contract. The conflict repair keeps the original branch history with one fast-forward commit, drops the superseded plugin-test cleanup by making that blob identical to current `main`, and retains newer stopped-service, npm-channel, and bundled-sidecar coverage.

## User Impact

No production or public CLI behavior changes. The same regression coverage is 714 test lines smaller and easier to review.

## Evidence

- Exact head: `d42f6919382c870e9110fa042c85455f3594c221`, a single direct child of original head `7ba2172c1f288c4acd7d818a8c6c3219132c5fab`; no rebase or force-push.
- Clean synthetic merge against current `main` `86a95b459c94ff7d03b5279d5166b03a39ba1473`: exactly four test files, +504/-1,218, net -714; production delta 0.
- Per-file net delta: capability -157, CLI exit -195, update -68, model picker -294. `src/cli/plugins-cli.install.test.ts` is byte-identical to `main` and absent from the merged diff.
- Compiler-AST parity: all 489 test declarations remain in identical order; all 40 `.each` tables and payloads are equivalent; 30 newer current-main declarations remain. Assertion behavior and timer usage are preserved.
- Blacksmith Testbox `tbx_01kz0ptbrbdbt07v4cyjardect`: 613/613 focused cases passed across all four suites ([run](https://github.com/openclaw/openclaw/actions/runs/30738345151)).
- Blacksmith Testbox `tbx_01kz0qt9bza2q2k5qpvsx6abch`: full `pnpm check:changed` passed on the regenerated merge after current-main fix #117894 ([run](https://github.com/openclaw/openclaw/actions/runs/30738917666)).
- Two independent xhigh reviews are CLEAN/BEST FIX: `commands_wave11_arch_review` and `commands_wave11_semantic_review`.
- OpenAI/Codex provider, backend, auth, catalog filtering, visibility, and default-selection contracts were checked directly at Codex SHA `ee0247f95a6fe2b094ba2253d82cae2a2b4c2dff`: `codex-rs/model-provider-info/src/lib.rs:35`, `:244`, `codex-rs/protocol/src/auth.rs:38`, `codex-rs/models-manager/src/manager.rs:123`, `codex-rs/protocol/src/openai_models.rs:687`, and `codex-rs/app-server/src/models.rs:13`.
