### PR TITLE
perf(sessions): cache branch summaries behind a transcript watermark

### DIFF
--- a/src/config/sessions/session-accessor.sqlite-message-cut.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-message-cut.test.ts
@@ -1,6 +1,9 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
-import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  openOpenClawAgentDatabase,
+} from "../../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
 import {
   deliveryContextFromSession,
@@ -19,15 +22,51 @@ import {
   switchSessionBranch,
   upsertSessionEntry,
 } from "./session-accessor.js";
+import { listSqliteSessionBranches } from "./session-accessor.sqlite.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 const agentId = "main";
 const sessionKey = "agent:main:message-cut";
 
 afterEach(() => {
+  vi.restoreAllMocks();
   closeOpenClawAgentDatabasesForTest();
   closeOpenClawStateDatabaseForTest();
 });
+
+function trackFullTranscriptLoads(env: NodeJS.ProcessEnv): () => number {
+  const database = openOpenClawAgentDatabase({ agentId, env });
+  const prepare = vi.spyOn(database.db, "prepare");
+  return () =>
+    prepare.mock.calls.filter(
+      ([sql]) =>
+        sql.includes('select "event_json" from "transcript_events"') &&
+        sql.includes('order by "seq" asc'),
+    ).length;
+}
+
+async function createSiblingSession(params: {
+  env: NodeJS.ProcessEnv;
+  headline: string;
+  sessionId: string;
+  sessionKey: string;
+}) {
+  const scope = { agentId, ...params };
+  await upsertSessionEntry(scope, { sessionId: params.sessionId, updatedAt: Date.now() });
+  await appendTranscriptEvent(scope, {
+    type: "session",
+    id: params.sessionId,
+    version: 3,
+    timestamp: "2026-07-18T01:00:00.000Z",
+  });
+  await appendTranscriptMessage(scope, {
+    eventId: `${params.sessionId}-user`,
+    message: { role: "user", content: params.headline },
+    now: Date.parse("2026-07-18T01:00:01.000Z"),
+    parentId: null,
+  });
+  return scope;
+}
 
 async function createSession(options: { activeLeafTarget?: string } = {}) {
   const stateDir = tempDirs.make("openclaw-message-cut-");
@@ -127,6 +166,140 @@ async function createSession(options: { activeLeafTarget?: string } = {}) {
 }
 
 describe("SQLite session message cuts", () => {
+  it("reuses branch summaries while the transcript watermark is unchanged", async () => {
+    const { env } = await createSession();
+    const fullTranscriptLoads = trackFullTranscriptLoads(env);
+
+    const first = await listSqliteSessionBranches({ agentId, env, sessionKey });
+    expect(fullTranscriptLoads()).toBe(1);
+
+    const second = await listSqliteSessionBranches({ agentId, env, sessionKey });
+    expect(second).toEqual(first);
+    expect(fullTranscriptLoads()).toBe(1);
+    if (second.status !== "ok" || !second.branches[0]) {
+      throw new Error("expected cached branch list result");
+    }
+    second.branches[0].headline = "caller mutation";
+
+    await expect(listSqliteSessionBranches({ agentId, env, sessionKey })).resolves.toEqual(first);
+    expect(fullTranscriptLoads()).toBe(1);
+  });
+
+  it("recomputes branch summaries after an append advances the watermark", async () => {
+    const { env, scope } = await createSession();
+    const fullTranscriptLoads = trackFullTranscriptLoads(env);
+
+    const before = await listSqliteSessionBranches({ agentId, env, sessionKey });
+    expect(fullTranscriptLoads()).toBe(1);
+    await appendTranscriptMessage(scope, {
+      eventId: "assistant-3",
+      message: { role: "assistant", content: "third answer" },
+      now: Date.parse("2026-07-18T00:00:07.000Z"),
+      parentId: "assistant-2",
+    });
+
+    const after = await listSqliteSessionBranches({ agentId, env, sessionKey });
+    expect(fullTranscriptLoads()).toBe(2);
+    expect(after).not.toEqual(before);
+    expect(after.status).toBe("ok");
+    if (after.status !== "ok") {
+      throw new Error("expected branch list result");
+    }
+    expect(after.branches.find((branch) => branch.active)).toMatchObject({
+      leafEntryId: "assistant-3",
+      headline: "third answer",
+    });
+  });
+
+  it.each(["rewind", "switch", "fork"] as const)(
+    "%s invalidates the source cache and lists the resulting branch",
+    async (mode) => {
+      const { env, scope } = await createSession();
+      const aliasKey = `${sessionKey}:alias`;
+      const targetKey = `${sessionKey}:fork`;
+      const sourceEntry = loadSessionEntry(scope);
+      if (!sourceEntry) {
+        throw new Error("expected source session entry");
+      }
+      await upsertSessionEntry({ agentId, env, sessionKey: aliasKey }, sourceEntry);
+      const fullTranscriptLoads = trackFullTranscriptLoads(env);
+      await listSqliteSessionBranches({ agentId, env, sessionKey });
+
+      const result =
+        mode === "rewind"
+          ? await rewindSessionToMessage({ agentId, env, entryId: "user-2", sessionKey })
+          : mode === "switch"
+            ? await switchSessionBranch({
+                agentId,
+                env,
+                leafEntryId: "off-path-user",
+                sessionKey,
+              })
+            : await forkSessionAtMessage({
+                agentId,
+                env,
+                entryId: "user-2",
+                sessionKey,
+                targetKey,
+              });
+      expect(result.status).toBe("created");
+
+      const loadsBeforeAliasRead = fullTranscriptLoads();
+      await listSqliteSessionBranches({ agentId, env, sessionKey: aliasKey });
+      expect(fullTranscriptLoads()).toBe(loadsBeforeAliasRead + 1);
+
+      const listed = await listSqliteSessionBranches({
+        agentId,
+        env,
+        sessionKey: mode === "fork" ? targetKey : sessionKey,
+      });
+      expect(listed.status).toBe("ok");
+      if (listed.status !== "ok") {
+        throw new Error("expected branch list result");
+      }
+      expect(listed.branches.find((branch) => branch.active)).toMatchObject({
+        leafEntryId: mode === "switch" ? "off-path-user" : "assistant-1",
+      });
+    },
+  );
+
+  it("keeps branch summaries isolated between sessions in the same store", async () => {
+    const { env } = await createSession();
+    const sibling = await createSiblingSession({
+      env,
+      headline: "sibling prompt",
+      sessionId: "message-cut-sibling",
+      sessionKey: `${sessionKey}:sibling`,
+    });
+    const fullTranscriptLoads = trackFullTranscriptLoads(env);
+
+    const source = await listSqliteSessionBranches({ agentId, env, sessionKey });
+    const other = await listSqliteSessionBranches(sibling);
+    expect(fullTranscriptLoads()).toBe(2);
+    expect(source.status).toBe("ok");
+    if (source.status !== "ok") {
+      throw new Error("expected source branch list result");
+    }
+    expect(source.branches.find((branch) => branch.active)).toMatchObject({
+      leafEntryId: "assistant-2",
+      headline: "second answer",
+    });
+    expect(other).toEqual({
+      status: "ok",
+      branches: [
+        {
+          active: true,
+          headline: "sibling prompt",
+          leafEntryId: "message-cut-sibling-user",
+          messageCount: 1,
+          updatedAt: "2026-07-18T01:00:01.000Z",
+        },
+      ],
+    });
+    await expect(listSqliteSessionBranches({ agentId, env, sessionKey })).resolves.toEqual(source);
+    expect(fullTranscriptLoads()).toBe(2);
+  });
+
   it("lists every DAG tip with active state, headline, count, and timestamp", async () => {
     const { env } = await createSession({ activeLeafTarget: "assistant-1" });
 

--- a/src/config/sessions/session-accessor.sqlite-message-cut.ts
+++ b/src/config/sessions/session-accessor.sqlite-message-cut.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { asOptionalRecord as asRecord } from "@openclaw/normalization-core/record-coerce";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
+import { executeSqliteQueryTakeFirstSync } from "../../infra/kysely-sync.js";
 import { extractAssistantVisibleText } from "../../shared/chat-message-content.js";
 import {
   openOpenClawAgentDatabase,
@@ -18,6 +19,7 @@ import { emitCommittedSessionIdentityDiff } from "./session-accessor.sqlite-iden
 import { loadSqliteTranscriptEventsFromDatabase } from "./session-accessor.sqlite-read.js";
 import {
   formatSqliteSessionMarkerForScope,
+  getSessionKysely,
   normalizeSqliteSessionKey,
   resolveSqliteScope,
   runExclusiveSqliteSessionWrite,
@@ -62,6 +64,80 @@ type SessionTranscriptMutationResult =
 type SessionTranscriptMutationMode = "fork" | "rewind" | "switch";
 
 const BRANCH_HEADLINE_MAX_CHARS = 120;
+const SESSION_BRANCH_CACHE_MAX_ENTRIES = 32;
+
+type SessionBranchCacheEntry = {
+  branches: SessionBranchSummary[];
+  generation: string | null;
+  maxSeq: number | null;
+};
+
+// Branch listing must not scale with transcript size on every request. Appends advance max(seq),
+// while every in-place or replacement path rotates generation; cap the validated LRU at 32 sessions.
+const sessionBranchCache = new Map<string, SessionBranchCacheEntry>();
+
+function sessionBranchCacheKey(databasePath: string, sessionId: string): string {
+  return `${databasePath}\0${sessionId}`;
+}
+
+function cloneSessionBranchSummaries(branches: readonly SessionBranchSummary[]) {
+  return branches.map((branch) => ({ ...branch }));
+}
+
+function readSessionBranchWatermark(
+  database: OpenClawAgentDatabase,
+  sessionId: string,
+): Pick<SessionBranchCacheEntry, "generation" | "maxSeq"> {
+  const db = getSessionKysely(database.db);
+  const maxSeq = executeSqliteQueryTakeFirstSync(
+    database.db,
+    db
+      .selectFrom("transcript_events")
+      .select((eb) => eb.fn.max<number>("seq").as("max_seq"))
+      .where("session_id", "=", sessionId),
+  )?.max_seq;
+  const generation = executeSqliteQueryTakeFirstSync(
+    database.db,
+    db
+      .selectFrom("transcript_rewrite_watermarks")
+      .select("generation")
+      .where("session_id", "=", sessionId),
+  )?.generation;
+  return { generation: generation ?? null, maxSeq: maxSeq ?? null };
+}
+
+function loadSessionBranchSummaries(
+  database: OpenClawAgentDatabase,
+  sessionId: string,
+): SessionBranchSummary[] {
+  const cacheKey = sessionBranchCacheKey(database.path, sessionId);
+  const watermark = readSessionBranchWatermark(database, sessionId);
+  const cached = sessionBranchCache.get(cacheKey);
+  if (cached?.generation === watermark.generation && cached.maxSeq === watermark.maxSeq) {
+    sessionBranchCache.delete(cacheKey);
+    sessionBranchCache.set(cacheKey, cached);
+    return cloneSessionBranchSummaries(cached.branches);
+  }
+
+  const branches = summarizeSessionBranches(
+    loadSqliteTranscriptEventsFromDatabase(database, sessionId),
+  );
+  sessionBranchCache.delete(cacheKey);
+  sessionBranchCache.set(cacheKey, { ...watermark, branches });
+  if (sessionBranchCache.size > SESSION_BRANCH_CACHE_MAX_ENTRIES) {
+    const oldestKey = sessionBranchCache.keys().next().value;
+    if (oldestKey !== undefined) {
+      sessionBranchCache.delete(oldestKey);
+    }
+  }
+  return cloneSessionBranchSummaries(branches);
+}
+
+function invalidateSessionBranchCache(databasePath: string, sessionIds: readonly string[]): void {
+  for (const sessionId of uniqueStrings(sessionIds)) {
+    sessionBranchCache.delete(sessionBranchCacheKey(databasePath, sessionId));
+  }
+}
 
 export async function listSqliteSessionBranches(
   params: SessionBranchListParams,
@@ -85,8 +161,10 @@ export async function listSqliteSessionBranches(
     ) {
       return { status: "unsupported-storage" };
     }
-    const events = loadSqliteTranscriptEventsFromDatabase(database, currentEntry.sessionId);
-    return { status: "ok", branches: summarizeSessionBranches(events) };
+    return {
+      status: "ok",
+      branches: loadSessionBranchSummaries(database, currentEntry.sessionId),
+    };
   } catch {
     return { status: "failed" };
   }
@@ -141,16 +219,17 @@ async function mutateSqliteSessionAtMessage(
     ...(params.storePath ? { storePath: params.storePath } : {}),
   });
   return await runExclusiveSqliteSessionWrite(resolved, async () => {
-    let result: SessionTranscriptMutationResult = { status: "failed" };
     let previousIdentity = new Map<string, SessionEntry>();
     let currentIdentity = new Map<string, SessionEntry>();
-    runOpenClawAgentWriteTransaction((database) => {
+    let databasePath: string | undefined;
+    const result = runOpenClawAgentWriteTransaction((database) => {
+      databasePath = database.path;
       const identityKeys = uniqueStrings([
         ...collectSessionEntryLookupKeys(database, sourceKey),
         ...collectSessionEntryLookupKeys(database, targetKey),
       ]);
       previousIdentity = readSqliteSessionIdentitySnapshot(database, identityKeys);
-      result = mutateSqliteSessionAtMessageInTransaction(database, resolved, {
+      const mutationResult = mutateSqliteSessionAtMessageInTransaction(database, resolved, {
         entryId: params.entryId,
         canonicalSourceKey,
         creation: params.creation,
@@ -159,7 +238,16 @@ async function mutateSqliteSessionAtMessage(
         targetKey,
       });
       currentIdentity = readSqliteSessionIdentitySnapshot(database, identityKeys);
+      return mutationResult;
     }, toDatabaseOptions(resolved));
+    if (result.status === "created" && databasePath) {
+      invalidateSessionBranchCache(databasePath, [
+        ...[...previousIdentity.values()].flatMap((entry) =>
+          entry.sessionId ? [entry.sessionId] : [],
+        ),
+        ...(result.entry.sessionId ? [result.entry.sessionId] : []),
+      ]);
+    }
     emitCommittedSessionIdentityDiff(previousIdentity, currentIdentity);
     return result;
   });


### PR DESCRIPTION
## What Problem This Solves

`sessions.branches.list` on production (team.openclaw.ai) averaged **1459ms across 791 calls** in a 24.6h window. `listSqliteSessionBranches` loaded and `JSON.parse`d every transcript event row for the session, then scanned the full tree — on every request, synchronously — even though the Control UI calls this on every session switch and the branch summary almost never changes between calls.

## Why This Change Was Made

Branch listing must not scale with transcript size on every request. This adds a module-local, 32-entry LRU of computed `SessionBranchSummary[]` keyed by database path + sessionId, validated by a cheap two-query watermark (`max(seq)` on `transcript_events` plus the `transcript_rewrite_watermarks` generation — the same validity model the visible-message delta API uses). Appends advance `max(seq)`; rewrites and replacements rotate the generation, so any transcript change forces a recompute. Successful rewind/switch/fork mutations in the same module additionally invalidate affected session entries post-commit as same-module hygiene. Returned summaries are cloned so callers cannot mutate cached state. Response shape, ordering, and headline logic are byte-identical.

## User Impact

Session switching in the Control UI stops paying a full-transcript parse for the branch dropdown; repeat listings return in single-digit milliseconds. No behavior change.

## Evidence

- Production journal (24.6h): `sessions.branches.list` n=791, avg 1459ms, max 3735ms; context in https://github.com/openclaw/openclaw/pull/114257#issuecomment-5088264732
- `node scripts/run-vitest.mjs src/config/sessions/session-accessor.sqlite-message-cut.test.ts` — 19/19, with new regressions: cache reuse skips the event load, append invalidates, rewind/switch/fork invalidate, caller mutation isolation, cross-session isolation
- tsgo core lane clean (only the known pre-existing `@openclaw/session-url-contract` worktree error); autoreview (Codex gpt-5.6-sol, xhigh) clean, "patch is correct (0.9)"
