### PR TITLE
fix(codex): user-home Codex harness config no longer requires supervision to be enabled

### DIFF
--- a/extensions/codex/index.test.ts
+++ b/extensions/codex/index.test.ts
@@ -256,6 +256,93 @@ describe("codex plugin", () => {
     expect(registration?.[0]({})).toEqual([]);
   });
 
+  it.each([
+    ["supervision is absent", undefined],
+    ["supervision is disabled", { enabled: false }],
+    ["supervision is enabled", { enabled: true }],
+  ] as const)(
+    "keeps live user-home appServer config for an auto-enabled Codex entry when %s",
+    (_label, supervision) => {
+      const registerTool = vi.fn();
+      plugin.register(
+        createTestPluginApi({
+          id: "codex",
+          name: "Codex",
+          source: "test",
+          config: {},
+          pluginConfig: {},
+          // No explicit plugins.entries.codex.enabled: core auto-enables the
+          // plugin from this config block, so the harness must keep honoring it.
+          runtime: createCodexTestRuntime(() => ({
+            plugins: {
+              entries: {
+                codex: {
+                  config: {
+                    appServer: { homeScope: "user" },
+                    ...(supervision ? { supervision } : {}),
+                  },
+                },
+              },
+            },
+          })),
+          registerAgentHarness: vi.fn(),
+          registerCommand: vi.fn(),
+          registerMediaUnderstandingProvider: vi.fn(),
+          registerMigrationProvider: vi.fn(),
+          registerProvider: vi.fn(),
+          registerTool,
+          on: vi.fn(),
+        }),
+      );
+
+      const registration = registerTool.mock.calls.find(
+        ([, options]) => options?.name === "codex_threads",
+      ) as
+        | [(context: { senderIsOwner?: boolean }) => { name: string } | null, { name: string }]
+        | undefined;
+      // codex_threads exists only while user-home scope or supervision is live,
+      // so it proves the plugin config survived the enable-state resolution.
+      expect(registration?.[0]({ senderIsOwner: true })?.name).toBe("codex_threads");
+    },
+  );
+
+  it("drops live plugin config when the Codex entry is explicitly disabled", () => {
+    const registerTool = vi.fn();
+    plugin.register(
+      createTestPluginApi({
+        id: "codex",
+        name: "Codex",
+        source: "test",
+        config: {},
+        pluginConfig: {},
+        runtime: createCodexTestRuntime(() => ({
+          plugins: {
+            entries: {
+              codex: {
+                enabled: false,
+                config: { appServer: { homeScope: "user" } },
+              },
+            },
+          },
+        })),
+        registerAgentHarness: vi.fn(),
+        registerCommand: vi.fn(),
+        registerMediaUnderstandingProvider: vi.fn(),
+        registerMigrationProvider: vi.fn(),
+        registerProvider: vi.fn(),
+        registerTool,
+        on: vi.fn(),
+      }),
+    );
+
+    const registration = registerTool.mock.calls.find(
+      ([, options]) => options?.name === "codex_threads",
+    ) as
+      | [(context: { senderIsOwner?: boolean }) => { name: string } | null, { name: string }]
+      | undefined;
+    expect(registration?.[0]({ senderIsOwner: true })).toBeNull();
+  });
+
   it("activates from live supervision config through a normalized Codex entry id", () => {
     const registerTool = vi.fn();
     plugin.register(

--- a/extensions/codex/index.ts
+++ b/extensions/codex/index.ts
@@ -81,7 +81,12 @@ export default definePluginEntry({
         origin: "bundled",
         config: normalizePluginsConfig(liveConfig.plugins),
         rootConfig: liveConfig,
-        enabledByDefault: readCodexPluginConfig(livePluginConfig).supervision?.enabled === true,
+        // Core auto-enables this bundled plugin whenever the operator declares a
+        // codex config block, so a live block is the plugin-side default. Gating
+        // on a feature flag (supervision) here would silently drop unrelated
+        // harness settings such as appServer.homeScope; feature gates belong in
+        // the feature's own surface (see requireSupervisionEnabled).
+        enabledByDefault: livePluginConfig !== undefined,
       }).enabled;
       if (!enabled) {
         return undefined;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators who share their native Codex home with Codex Desktop and the CLI would silently fall back to agent-scoped Codex state when Codex supervision was not explicitly enabled.

With a config such as `plugins.entries.codex.config.appServer.homeScope: "user"` and no explicit `plugins.entries.codex.enabled: true` (core auto-enables the plugin from the config block), the Codex harness ignored the whole `codex` plugin config: the harness ran against the per-agent Codex home instead of `$CODEX_HOME`/`~/.codex`, native auth was not used, and the owner-only `codex_threads` tool disappeared. Toggling the unrelated `supervision.enabled` flag flipped this behavior, so an operator turning a supervision feature off silently lost their user-home harness configuration.

## Why This Change Was Made

The plugin re-resolves its own effective enable state on every live config read so runtime config changes take effect, but it passed `supervision.enabled === true` as `enabledByDefault`. For a bundled plugin with no explicit entry flag, `enabledByDefault` is the deciding branch in `resolvePluginActivationDecisionShared`, so a feature flag became the gate for the entire plugin config, including `appServer`, `sessionCatalog`, web search, commands, and conversation binding.

The plugin-side default now mirrors what core already does: core auto-enables this bundled plugin whenever the operator declares a `codex` config block (`plugin-tool-configured` auto-enable), so a live config block is the correct plugin-side default. This matches the sibling convention in `extensions/onepassword/index.ts`. Supervision stays gated where it belongs — the supervision tool factory still requires `supervision.enabled === true`, and `requireSupervisionEnabled` still fails supervision calls closed — so no supervision surface becomes reachable that was not reachable before. Every explicit revocation path is unchanged: entry removed, `enabled: false`, `plugins.enabled: false`, denylist, and restrictive allowlist all still drop the live plugin config.

## User Impact

Operators who set `appServer.homeScope: "user"` now get the documented behavior — shared native Codex home, native auth, and the `codex_threads` tool — without also having to enable Codex supervision. Disabling supervision no longer changes unrelated harness configuration. No config migration is needed; setups that already set `enabled: true` behave exactly as before.

## Evidence

Focused tests (`node scripts/run-vitest.mjs extensions/codex/index.test.ts`):

- With the fix: `Tests 26 passed (26)`.
- Reverting only the one-line predicate to the old `supervision?.enabled === true` gate makes exactly the two new regression cases fail, proving they catch the silent fallback:

```
× keeps live user-home appServer config for an auto-enabled Codex entry when supervision is absent
× keeps live user-home appServer config for an auto-enabled Codex entry when supervision is disabled
AssertionError: expected undefined to be 'codex_threads'
```

The new cases assert through `codex_threads`, which is built only when user-home scope or supervision is live, so it proves the plugin config survived enable-state resolution. A negative case asserts an explicitly disabled entry still drops the config.

Changed-surface checks: `node scripts/check-changed.mjs` (delegated Blacksmith Testbox run, exit 0). Formatted with `oxfmt`.
