### PR TITLE
fix(ui): keep a new-session draft when its catalog agent resolves

### DIFF
--- a/ui/src/pages/new-session/catalog-target.test.ts
+++ b/ui/src/pages/new-session/catalog-target.test.ts
@@ -11,7 +11,13 @@ describe("new-session catalog target", () => {
   const agents = [{ id: "main" }, { id: "research" }];
 
   it("keeps the draft identity stable while target metadata resolves", () => {
-    const pending = { agentId: "main", catalogId: "claude", model: "", catalogLabel: "" };
+    const pending = {
+      agentId: "main",
+      requestedAgentId: "main",
+      catalogId: "claude",
+      model: "",
+      catalogLabel: "",
+    };
     const ready = {
       ...pending,
       model: "anthropic/claude-opus-4-8",
@@ -21,6 +27,22 @@ describe("new-session catalog target", () => {
     expect(routeKey(pending)).toBe(routeKey(ready));
     expect(allowsSelectedAgent(pending, { id: "main" })).toBe(false);
     expect(allowsSelectedAgent(ready, { id: "main" })).toBe(true);
+  });
+
+  it("keeps the draft identity stable while the target agent resolves", () => {
+    const requested = {
+      requestedAgentId: "research",
+      catalogId: "claude",
+      model: "",
+      catalogLabel: "",
+    };
+    const unresolved = { ...requested, agentId: "" };
+    const resolved = { ...requested, agentId: "research" };
+
+    expect(routeKey(unresolved)).toBe(routeKey(resolved));
+    // Only a navigation changes the requested agent or the target.
+    expect(routeKey({ ...resolved, requestedAgentId: "main" })).not.toBe(routeKey(resolved));
+    expect(routeKey({ ...resolved, catalogId: "codex" })).not.toBe(routeKey(resolved));
   });
 
   it("fails closed when the requested creation capability is unavailable", async () => {

--- a/ui/src/pages/new-session/catalog-target.ts
+++ b/ui/src/pages/new-session/catalog-target.ts
@@ -6,8 +6,14 @@ import { t } from "../../i18n/index.ts";
 import { normalizeAgentId } from "../../lib/sessions/session-key.ts";
 import type { NewSessionRouteData } from "./location.ts";
 
+/**
+ * Which draft a new-session route has open. This keys on the requested agent,
+ * not the resolved one: a catalog route resolves its agent through the Gateway
+ * and reports it empty until the roster arrives, so keying on the resolved id
+ * would make that fill-in look like a navigation and discard the draft.
+ */
 export function routeKey(data?: NewSessionRouteData): string {
-  return JSON.stringify([data?.agentId ?? "", data?.catalogId ?? ""]);
+  return JSON.stringify([data?.requestedAgentId ?? "", data?.catalogId ?? ""]);
 }
 
 export function isTarget(data?: NewSessionRouteData): boolean {

--- a/ui/src/pages/new-session/location.ts
+++ b/ui/src/pages/new-session/location.ts
@@ -1,5 +1,8 @@
 export type NewSessionRouteData = {
+  /** The agent the loader resolved; empty until the Gateway can name one. */
   agentId: string;
+  /** The agent the URL asked for, which only a navigation can change. */
+  requestedAgentId: string;
   catalogId: string;
   model: string;
   catalogLabel: string;

--- a/ui/src/pages/new-session/new-session-page.ts
+++ b/ui/src/pages/new-session/new-session-page.ts
@@ -97,6 +97,7 @@ class NewSessionPage extends OpenClawLightDomElement {
   @state() private restoredFolderValidation: "none" | "checking" | "failed" = "none";
 
   private openedFor: string | null = null;
+  private openedAgentId = "";
   private agentsHydrated = false;
   private nodesHydrated = false;
   // Discovery retry provenance separates user choices from Gateway-derived defaults.
@@ -383,11 +384,19 @@ class NewSessionPage extends OpenClawLightDomElement {
       this.agents().length > 0,
     );
     const openKey = catalog.routeKey(this.data);
+    const resolvedAgentId = this.data?.agentId ?? "";
     if (this.openedFor !== openKey) {
       this.openedFor = openKey;
+      this.openedAgentId = resolvedAgentId;
       this.agentsHydrated = agentsReady;
       this.resetDraft();
       return;
+    }
+    if (this.openedAgentId !== resolvedAgentId) {
+      // The route named the target agent after the draft opened, so the page is
+      // still holding the fallback agent it adopted while the id was unknown.
+      this.openedAgentId = resolvedAgentId;
+      this.agentsHydrated = false;
     }
     // A hard reload can land here before agents.list resolves. Once the list
     // arrives, adopt only agent-derived defaults; a full reset would discard

--- a/ui/src/pages/new-session/route.ts
+++ b/ui/src/pages/new-session/route.ts
@@ -11,13 +11,15 @@ async function loadNewSessionData(
   search: string,
 ): Promise<NewSessionRouteData> {
   const requestedLocation = newSessionLocationFromSearch(search);
+  const requestedAgentId = requestedLocation.agentId.trim();
   if (!requestedLocation.catalogId) {
-    return { ...requestedLocation, model: "", catalogLabel: "" };
+    return { ...requestedLocation, requestedAgentId, model: "", catalogLabel: "" };
   }
   const { resolveAgentId, resolveCreateTarget } = await import("./catalog-target.ts");
   const unresolved = (agentId = ""): NewSessionRouteData => ({
     ...requestedLocation,
     agentId,
+    requestedAgentId,
     model: "",
     catalogLabel: "",
   });
@@ -50,7 +52,6 @@ async function loadNewSessionData(
   const availableAgents = listSelectableAgents(agentsList?.agents ?? []);
   const gatewayDefaultId =
     gateway.phase === "connected" && gateway.hello ? gateway.assistantAgentId : null;
-  const requestedAgentId = requestedLocation.agentId.trim();
   if (
     !agentsList &&
     requestedAgentId &&


### PR DESCRIPTION
## What Problem This Solves

Opening a catalog-targeted new session (`/new?agent=<id>&catalog=<id>`) while the Gateway connection is down and typing a prompt loses that prompt the moment the connection comes back. The composer is cleared and the page also keeps showing the fallback agent instead of the one the URL asked for.

Fixes #114398.

## Why This Change Was Made

`updated()` resets the draft whenever `catalog.routeKey(this.data)` changes, and `routeKey` was `[agentId, catalogId]` where `agentId` is the id the *loader resolved*. On the catalog path the loader resolves the agent through the Gateway, and every unverifiable path returns `unresolved()`, which spreads the requested location and then overwrites `agentId` with `""` (`ui/src/pages/new-session/route.ts:19-23`). So the key was `["", "claude"]` while offline and became `["research", "claude"]` on reconnect — a change the user never made, which nonetheless looked like navigation and called `resetDraft()`.

Instrumented transitions from the isolated e2e run, before the fix:

```
routeKey change ["",""]         -> ["research",""]
routeKey change ["research",""] -> ["",""]
routeKey change ["",""]         -> ["","claude"]
routeKey change ["","claude"]   -> ["research","claude"]   <- draft typed here is discarded
```

`routeKey` already excluded `model` and `catalogLabel` so the draft survives catalog metadata resolution — `catalog-target.test.ts` calls that "keeps the draft identity stable while target metadata resolves". The design simply did not anticipate that the agent half of the identity is also derived from resolution.

The fix keys the identity on `requestedAgentId` — what the URL asked for — instead of on the resolved id. Only a navigation can change that, so resolution can never look like one. Note this is the second design here: the first version kept the resolved id and added a predicate that treated an empty-to-named transition as the same route, and ClawSweeper correctly pointed out that such a rule cannot distinguish the loader filling in an agent from a user navigating from `?catalog=x` to `?agent=y&catalog=x`. Rather than narrow the heuristic, this version removes the ambiguity at the source: the route data now carries both ids, the identity uses the requested one, and `routeIdentity`/`isSameRoute` are gone (net −29 lines in `catalog-target.ts`).

Because the page adopted a fallback agent while the resolved id was unknown, a change in the *resolved* id still clears `agentsHydrated` so the existing adoption branch re-derives agent defaults with the real id — without touching what the user typed.

## User Impact

A prompt typed on a catalog-targeted new-session page survives a Gateway reconnect, and the page ends up on the agent the URL named rather than the default one.

## Evidence

`node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/new-session-page.e2e.test.ts`

| State | `resolves a pending catalog target after reconnect without clearing the draft` |
| --- | --- |
| `main` before #114377 | fails: `expected '' to be 'keep this reconnect draft'` |
| this branch | passes |

Whole file on this branch, on top of the merged #114377: **47 passed (47)**. Before #114377 that file was 42/47 on `main`.

Unit: `node scripts/run-vitest.mjs ui/src/pages/new-session` — 121 passed, including a new `catalog-target.test.ts` case asserting the identity is stable across agent resolution but changes for a different requested agent or a different target.
Types: `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.ui.json` clean with the new required `requestedAgentId` field.
