### PR TITLE
fix(update): recognize Bun text lockfiles

### DIFF
--- a/src/infra/update-check.test.ts
+++ b/src/infra/update-check.test.ts
@@ -768,6 +768,54 @@ describe("checkUpdateStatus", () => {
     });
   });
 
+  it.each([
+    {
+      name: "text lockfile",
+      lockfiles: ["bun.lock"],
+      expectedLockfile: "bun.lock",
+    },
+    {
+      name: "binary lockfile",
+      lockfiles: ["bun.lockb"],
+      expectedLockfile: "bun.lockb",
+    },
+    {
+      name: "text lockfile when both formats exist",
+      lockfiles: ["bun.lock", "bun.lockb"],
+      expectedLockfile: "bun.lock",
+    },
+  ])("reports dependency status for Bun's $name", async ({ lockfiles, expectedLockfile }) => {
+    await withTempDir({ prefix: "openclaw-update-check-bun-" }, async (root) => {
+      await fs.writeFile(
+        path.join(root, "package.json"),
+        JSON.stringify({ name: "openclaw", packageManager: "bun@1.2.0" }),
+        "utf8",
+      );
+      for (const lockfile of lockfiles) {
+        await fs.writeFile(path.join(root, lockfile), "lock", "utf8");
+      }
+      await fs.mkdir(path.join(root, "node_modules"), { recursive: true });
+
+      const status = await checkUpdateStatus({
+        root,
+        includeRegistry: false,
+        fetchGit: false,
+        timeoutMs: 1000,
+      });
+
+      expect(status).toMatchObject({
+        installKind: "package",
+        packageManager: "bun",
+        deps: {
+          manager: "bun",
+          lockfilePath: path.join(root, expectedLockfile),
+          markerPath: path.join(root, "node_modules"),
+          status: "ok",
+        },
+      });
+    });
+  });
+
   it("detects lockless OpenClaw npm installs despite packed pnpm metadata", async () => {
     await withTempDir({ prefix: "openclaw-update-check-lockless-npm-" }, async (base) => {
       const root = path.join(base, "prefix", "node_modules", "openclaw");

--- a/src/infra/update-check.ts
+++ b/src/infra/update-check.ts
@@ -355,8 +355,11 @@ async function resolveDepsMarker(params: { root: string; manager: PackageManager
     };
   }
   if (params.manager === "bun") {
+    const textLockfilePath = path.join(root, "bun.lock");
     return {
-      lockfilePath: path.join(root, "bun.lockb"),
+      lockfilePath: (await exists(textLockfilePath))
+        ? textLockfilePath
+        : path.join(root, "bun.lockb"),
       markerPath: path.join(root, "node_modules"),
     };
   }


### PR DESCRIPTION
[AI-assisted]
## What Problem This Solves

OpenClaw correctly detects modern Bun package roots, but update status only checks the legacy binary `bun.lockb` marker. A Bun 1.2+ installation that uses `bun.lock` is therefore reported with an unknown dependency state and a misleading lockfile-missing reason.

## Why This Change Was Made

Dependency marker resolution now prefers Bun's current text lockfile when present and falls back to the legacy binary lockfile. The change is limited to selecting the lockfile whose existence and modification time feed the existing dependency-status logic.

### Root Cause

Package-manager detection already accepted both `bun.lock` and `bun.lockb`, while dependency status hard-coded `bun.lockb`. The two owners therefore disagreed about which Bun roots were valid.

## User Impact

Users running current Bun releases receive accurate `ok`, missing, or stale dependency status instead of a false lockfile-missing result. Existing `bun.lockb` installations and npm/pnpm status behavior remain unchanged.

## Evidence

### Provenance

- **Base:** `d4ed57bc8847b2b0a40dc99189bd4d94acbb2fc7`
- **Proof head:** `c3c163eef6a07358375dc52c297e0263cad07bf1`
- **Revalidated:** on the bound base

### Direct behavior

- **Installed Bun CLI behavior (MEASURED)** — Observed: An installable package built from the proof head was installed in an isolated Bun-owned package root with Bun 1.3.14. The installation created `bun.lock`, did not create `bun.lockb`, and the real `openclaw update status --json` path exited 0 with the sanitized result `{"installKind":"package","packageManager":"bun","deps":{"manager":"bun","status":"ok","lockfile":"bun.lock","marker":"node_modules","reason":null}}`. Result: the installed CLI recognized the text lockfile and reported healthy dependencies. Proves a real current-Bun installation crosses package-root discovery, package-manager detection, text-lockfile selection, dependency-marker inspection, and JSON presentation. Preserves the proof used an isolated package root and disclosed no local paths or configuration.

### Automated verification

#### Real Bun installation

```bash
bun install --cwd <packaged-openclaw-root> --no-progress
```

- `bun install --cwd <packaged-openclaw-root> --no-progress` — Bun 1.3.14 installed 839 packages, saved `bun.lock`, and completed the OpenClaw install lifecycle with exit code 0. Proves the proof root was populated by the real Bun installer rather than a filesystem-only harness. Preserves the exact bundled OpenClaw runtime from the proof head remained the executed package.

#### Real installed CLI

```bash
OPENCLAW_STATE_DIR=<isolated-state> OPENCLAW_CONFIG_PATH=<isolated-config> node openclaw.mjs update status --json --timeout 10
```

- `OPENCLAW_STATE_DIR=<isolated-state> OPENCLAW_CONFIG_PATH=<isolated-config> node openclaw.mjs update status --json --timeout 10` — exit code 0 with `packageManager=bun`, `deps.manager=bun`, `deps.status=ok`, `lockfile=bun.lock`, and no dependency reason. Proves the installed CLI consumes the modern text lockfile through the changed production path. Preserves the status command remained read-only and used isolated OpenClaw state and configuration.

#### Focused Bun behavior

```bash
node scripts/run-vitest.mjs src/infra/update-check.test.ts -t 'reports dependency status for Bun' --run
```

- `node scripts/run-vitest.mjs src/infra/update-check.test.ts -t 'reports dependency status for Bun' --run` — 3/3 focused cases passed with 0 failures and 35 unrelated tests skipped. Proves text-only, binary-only, and dual-format Bun roots resolve to the correct dependency marker and `ok` status. Preserves legacy `bun.lockb` compatibility and text-lockfile precedence.

#### Affected update status suite

```bash
node scripts/run-vitest.mjs src/infra/update-check.test.ts --run
```

- `node scripts/run-vitest.mjs src/infra/update-check.test.ts --run` — 38/38 tests passed with 0 failures and 0 skips. Proves the complete update-status suite retains package, registry, dependency-marker, and Git-status behavior. Preserves existing npm, pnpm, missing-marker, stale-marker, and repository-status contracts.

#### Package manager boundary

```bash
node scripts/run-vitest.mjs src/infra/detect-package-manager.test.ts --run
```

- `node scripts/run-vitest.mjs src/infra/detect-package-manager.test.ts --run` — 10/10 tests passed with 0 failures and 0 skips. Proves package-manager detection still recognizes both Bun lockfile formats and the existing npm/pnpm layouts. Preserves the detector's ownership and published-package fallback rules.

#### Static verification

```bash
pnpm exec oxlint src/infra/update-check.ts src/infra/update-check.test.ts
```

- `pnpm exec oxlint src/infra/update-check.ts src/infra/update-check.test.ts` — 0 warnings and 0 errors across the 2 changed files. Proves the bounded implementation and regression tests satisfy the affected lint rules. Preserves the existing TypeScript and repository style contract.
```bash
pnpm exec oxfmt --check src/infra/update-check.ts src/infra/update-check.test.ts
```

- `pnpm exec oxfmt --check src/infra/update-check.ts src/infra/update-check.test.ts` — both changed files matched the canonical formatter. Proves the patch is formatted consistently. Preserves the repository's formatting contract.
```bash
git diff --check origin/main...HEAD
```

- `git diff --check origin/main...HEAD` — completed successfully with no whitespace errors. Proves the committed patch is whitespace-clean. Preserves the bounded two-file diff.

### Preserved boundaries

- Legacy `bun.lockb` roots remain supported by the focused compatibility case.
- When both Bun formats coexist, `bun.lock` is treated as the canonical current marker.
- npm and pnpm dependency-status behavior is unchanged.
- The status check remains read-only and does not create, migrate, or rewrite lockfiles.

### Proof gap

A native legacy-`bun.lockb` installation was not independently run because Bun 1.3.14 creates the current text lockfile. The focused binary-only regression case verifies the retained fallback, while the real installed CLI proof verifies the current Bun path. No claim is made about unrelated Bun runtime behavior or whole-repository regression coverage.

### Artifacts

- None attached.
