### PR TITLE
test(tooling): publish the gauntlet grandchild pid atomically

### DIFF
--- a/test/scripts/plugin-gateway-gauntlet.test.ts
+++ b/test/scripts/plugin-gateway-gauntlet.test.ts
@@ -723,7 +723,10 @@ const grandchild = spawn(process.execPath, [
   "-e",
   "process.on('SIGTERM', () => {}); setInterval(() => {}, 1000);",
 ], { stdio: "ignore" });
-fs.writeFileSync(process.argv[2], String(grandchild.pid));
+// Publish the pid by rename so the reader never observes a created-but-unwritten
+// or partially written file.
+fs.writeFileSync(process.argv[2] + ".tmp", String(grandchild.pid));
+fs.renameSync(process.argv[2] + ".tmp", process.argv[2]);
 process.on("SIGTERM", () => process.exit(0));
 setInterval(() => {}, 1000);
 `,


### PR DESCRIPTION
## What Problem This Solves

`plugin gateway gauntlet helpers > kills timed-out measured command process groups when the leader exits first` fails intermittently in CI with a NaN pid:

```
AssertionError: expected false to be true
 ❯ test/scripts/plugin-gateway-gauntlet.test.ts:754:49
   expect(Number.isInteger(grandchildPid)).toBe(true);
```

Observed on `checks-node-compact-small-3` in run [30246831941](https://github.com/openclaw/openclaw/actions/runs/30246831941), unrelated to that PR's diff.

## Why This Change Was Made

The spawned script did `fs.writeFileSync(pidPath, String(grandchild.pid))`, which creates the file and then writes its bytes. The test waits on `fs.access(pidPath)`, so it could win the race against the write and read `""`.

The first version of this PR fixed the reader by polling for a parseable pid. ClawSweeper correctly pointed out that this still admits a *partially written* numeric pid — `"123"` out of `"12345"` parses as a valid integer and would then be the wrong process. So the fix moved to the writer instead: publish the pid by writing a temp file and renaming it into place. Rename is atomic, so a reader observes either no file or the complete pid, and both failure modes are closed rather than one being narrowed.

The two sibling cases in the same file are unaffected either way — they gate on a separate ready file the grandchild writes only after being spawned, by which point the parent's write has already returned — so the reader side is left as it was.

## User Impact

None; test-only. Removes a source of spurious red on unrelated PRs.

## Evidence

`node scripts/run-vitest.mjs test/scripts/plugin-gateway-gauntlet.test.ts -t "kills timed-out measured command process groups when the leader exits first"` — 5 consecutive runs, 5 passes, on the atomic-rename version.
