### PR TITLE
fix(cron): bind cron jobs to the durable store session, not the DM policy key

### DIFF
--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -299,9 +299,8 @@ type OpenClawCodingToolsOptions = {
   sandbox?: SandboxContext | null;
   sessionKey?: string;
   /**
-   * The actual live run session key. When the tool set is constructed with a
-   * sandbox/policy session key, this allows `session_status({sessionKey:"current"})`
-   * to resolve to the live run session instead of the stale sandbox key.
+   * The durable store session key for the live run when it differs from the
+   * sandbox/policy session key used to construct the tool set.
    */
   runSessionKey?: string;
   /** Ephemeral session UUID — regenerated on /new and /reset. */

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -101,9 +101,8 @@ export function createOpenClawTools(
     agentSessionKey?: string;
     toolBindings?: Readonly<Record<string, unknown>>;
     /**
-     * The actual live run session key. When the tool is constructed with a sandbox/policy
-     * session key, this allows `session_status({sessionKey:"current"})` to resolve to
-     * the live run session instead of the stale sandbox key.
+     * The durable store session key for the live run when it differs from the
+     * sandbox/policy session key used to construct the tool set.
      */
     runSessionKey?: string;
     agentChannel?: GatewayMessageChannel;
@@ -481,7 +480,10 @@ export function createOpenClawTools(
                 }),
               ]),
           createCronTool({
-            agentSessionKey: options?.agentSessionKey,
+            // attempt-tool-base-prepare preserves the durable store key as runSessionKey.
+            // Cron bindings, wakes, and reminder history need that transcript owner; a
+            // policy-scoped DM key can be empty and cleanup-retired, leaving jobs dangling.
+            agentSessionKey: options?.runSessionKey ?? options?.agentSessionKey,
             agentAccountId: gatewayCallerAccountId,
             currentDeliveryContext: {
               channel: options?.agentChannel,

--- a/src/agents/openclaw-tools.tts-config.test.ts
+++ b/src/agents/openclaw-tools.tts-config.test.ts
@@ -377,6 +377,24 @@ describe("createOpenClawTools cron context wiring", () => {
     mocks.createCronToolOptions.mockClear();
   });
 
+  it.each([
+    ["prefers the durable run session key", "agent:main:main"],
+    ["falls back to the policy session key", undefined],
+  ])("%s for cron bindings", (_label, runSessionKey) => {
+    createOpenClawTools({
+      agentSessionKey: "agent:main:telegram:default:direct:1234",
+      runSessionKey,
+      disableMessageTool: true,
+      disablePluginTools: true,
+    });
+
+    expect(mocks.createCronToolOptions).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentSessionKey: runSessionKey ?? "agent:main:telegram:default:direct:1234",
+      }),
+    );
+  });
+
   it("passes preserved channel delivery context into the cron tool", async () => {
     createOpenClawTools({
       agentSessionKey: "agent:main:matrix:channel:!abcdef1234567890:example.org",


### PR DESCRIPTION
## What Problem This Solves

For main-collapsed DMs, `resolveRuntimePolicySessionKey` deliberately hands tools a peer-scoped **policy** key (`agent:<id>:<channel>:<account>:direct:<peer>`, hardcoded `per-account-channel-peer` scope) so sandbox/tool policy does not leak across DMs. The cron tool wiring passed exactly that key on as the caller session, so on DM turns cron persisted the policy key as a durable binding. Four concrete defects follow (all reproduced live on a dev gateway, 2026-07-27):

1. `sessionTarget:"current"` jobs bind to a session row that is empty — the transcript lives in `agent:<id>:main` — so runs seed a brand-new session instead of the conversation ([session.ts:159-217](../../src/cron/isolated-agent/session.ts)).
2. `isMainScopeStaleDirectSessionKey` in the session cleanup service retires exactly this key shape under `dmScope:"main"`, so the binding target can be garbage-collected out from under the job.
3. The cron tool's `contextMessages` reminder context reads `chat.history` for the empty row and silently yields nothing on DM turns.
4. `wake`'s inferred session key lands the system event on the empty policy lane instead of the conversation lane.

## Why This Change Was Made

The embedded runner already threads the durable store session key through as `runSessionKey` whenever it differs from the sandbox/policy key ([attempt-tool-base-prepare.ts:240-244](../../src/agents/embedded-agent-runner/run/attempt-tool-base-prepare.ts)). The fix prefers it at the cron tool wiring seam: `agentSessionKey: options?.runSessionKey ?? options?.agentSessionKey`, with an invariant comment, plus a tightened doc comment for the `runSessionKey` contract. Deliberately scope-limited to the cron boundary: message-tool and terminal-tool **depend** on the peer-scoped shape (DM delivery inference, PTY ownership isolation) and are untouched.

## User Impact

DM-created reminders, loops, wakes, and reminder-context now bind to the real conversation session (durable, transcript-owning, not subject to stale-key cleanup). Non-DM turns and callers without a divergent policy key see no change (`runSessionKey` is unset there). No config surface changes.

Known remaining gap (next PR in this train): `current`-bound runs still don't import the source conversation's transcript tail — binding durability is fixed here; live context carry lands separately.

## Evidence

- Live before (dev gateway + qa-channel + `openai/gpt-5.6-luna`): a DM-created at-job stored `sessionKey:"agent:main:qa-channel:default:direct:tester"`; `chat.history` for that key returned 0 messages while the transcript lived in `agent:main:main`. After this fix, the same probe produced no stray origin-shaped session row and the job bound to the store key.
- New parameterized wiring test (prefers `runSessionKey`, falls back without it) fails on revert; `openclaw-tools.tts-config.test.ts` + `cron-tool.test.ts`: 178 tests green.
- oxlint clean; numstat +26/−7.
- `$autoreview` (Codex, gpt-5.6-sol): clean, "patch is correct (0.95)".

## Live Proof (redacted, after-fix run on this branch)

Same rig as the before-capture (isolated dev gateway, qa-channel bus, live `openai/gpt-5.6-luna`, DM sender `tester`):

```
[inbound]  In 4 minutes, send exactly: BINDPROOF done. One-line confirm now.

$ cron.list (job created by the model from the DM turn, post-fix)
{"name":"delayed BINDPROOF completion","schedule":{"kind":"at","at":"2026-07-27T08:03:50.000Z"},
 "sessionTarget":"current","sessionKey":"agent:main:main",          <-- durable store session
 "delivery":{"mode":"announce","channel":"qa-channel","to":"dm:tester","bestEffort":true}}

QA DM at 08:03:5xZ:
[outbound] BINDPROOF done.

$ sessions.list => no stray "agent:main:qa-channel:default:direct:tester" row was created (before the fix,
every DM-created current job minted that empty origin-shaped row and bound to it).
```

## Why no doctor migration for existing bindings

The peer-scoped policy key that caused bad bindings comes from `resolveRuntimePolicySessionKey` (`src/auto-reply/reply/runtime-policy-session-key.ts`), which **does not exist in any release tag** — the file was created 2026-07-24 and is absent from `v2026.7.2-beta.5` (verified via `git show v2026.7.2-beta.5:src/auto-reply/reply/runtime-policy-session-key.ts` → path not found). No shipped install can have written a policy-key cron binding; the defect chain is main-only and unreleased. Per repo policy, unreleased state carries no compat contract and gets no migration ("Compatibility is opt-in. 'Shipped' means reachable from a release Git tag"). Operators tracking `main` who created such jobs in the last 3 days can delete/recreate them; steady-state runtime stays canonical-only.
