### PR TITLE
feat(ui): resolve session URLs through the gateway with best-effort slug matching

### DIFF
--- a/docs/web/dashboards.md
+++ b/docs/web/dashboards.md
@@ -24,6 +24,9 @@ thread's `/dashboard/<agent>/<sessionRef>` URL.
 
 The Chat or Dashboard face preference is stored server-side per thread. It
 therefore follows you when you connect to the same gateway from another device.
+Opening a thread from the sidebar, Sessions, Tasks, Workboard, or Worktrees
+applies that stored face even when the thread is outside the page of sessions
+already loaded by the browser.
 The active dashboard tab and remembered chat-dock position remain per-device UI
 state, so each browser can keep its own working layout.
 

--- a/docs/web/urls.md
+++ b/docs/web/urls.md
@@ -87,6 +87,14 @@ the reconstructed session key. The remaining literal segments are authoritative
 too. A slug, when present, is always decorative; literal-key forms do not
 synthesize one.
 
+As a best-effort convenience, an unescaped one-segment literal that does not
+resolve as an exact session key is also checked against display-name slugs. One
+exact slug match is replaced in the address bar with its full
+`/<namespace>/<agentId>/<slug>-<shortId>` reference. If several sessions share
+the slug, the UI shows the same disambiguation view used for short-id ties
+instead of guessing. Exact short-id and literal-key references always win over
+slug matching.
+
 If one short id matches more than one session, the UI does not guess. It shows a
 small disambiguation view with the matching display names, agents, and longer id
 prefixes. Use a longer prefix to make the URL unique. Resolution examines at

--- a/packages/session-url-contract/src/index.ts
+++ b/packages/session-url-contract/src/index.ts
@@ -82,7 +82,7 @@ function isReservedSessionRest(rest: string, mainKey: string | undefined): boole
   );
 }
 
-function controlUiSessionSlug(displayName: string | undefined | null): string {
+export function controlUiSessionSlug(displayName: string | undefined | null): string {
   const tokens = (displayName ?? "")
     .toLowerCase()
     .replace(/[^a-z0-9]+/gu, "-")

--- a/packages/session-url-contract/src/parse.ts
+++ b/packages/session-url-contract/src/parse.ts
@@ -11,6 +11,7 @@ export type ControlUiSessionPathTarget =
       kind: "literal";
       agentId: string;
       sessionKey: string;
+      slugCandidate?: string;
     };
 
 const SHORT_SESSION_REF_RE = /^(?:.*-)?([0-9a-f]{8,32})$/iu;
@@ -127,7 +128,7 @@ export function parseControlUiSessionPath(
     const shortId = segment.match(SHORT_SESSION_REF_RE)?.[1]?.toLowerCase();
     return shortId
       ? { namespace, kind: "short", agentId, shortId }
-      : { namespace, kind: "literal", agentId, sessionKey };
+      : { namespace, kind: "literal", agentId, sessionKey, slugCandidate: segment };
   }
   return null;
 }

--- a/ui/src/app/app-host.test.ts
+++ b/ui/src/app/app-host.test.ts
@@ -15,6 +15,7 @@ import {
   UI_COMMAND_EVENT,
 } from "../components/panel-toggle-contract.ts";
 import { i18n } from "../i18n/index.ts";
+import { SESSION_FACE_PREFERENCE_PARAM } from "../lib/sessions/route-navigation.ts";
 import { createStorageMock } from "../test-helpers/storage.ts";
 import { selectShellRouteState } from "./app-host-route-state.ts";
 import { resetAppHostTestGlobals, type ShellKeyboardState } from "./app-host.test-support.ts";
@@ -907,7 +908,12 @@ describe("OpenClaw shell keyboard shortcuts", () => {
     expect(setSessionKey).toHaveBeenCalledWith(
       "agent:main:dashboard:12345678-90ab-cdef-1234-567890abcdef",
     );
-    expect(navigate).toHaveBeenCalledWith("chat", { pathname: "/chat/main/12345678" });
+    // The pushed command names a session the UI has not cached, so its face is a guess
+    // and the navigation is marked for the chat loader to re-derive from the gateway.
+    expect(navigate).toHaveBeenCalledWith("chat", {
+      pathname: "/chat/main/12345678",
+      search: `?${SESSION_FACE_PREFERENCE_PARAM}=1`,
+    });
     expect(uiCommandEvent).toHaveBeenLastCalledWith(
       expect.objectContaining({
         detail: {

--- a/ui/src/app/app-host.ts
+++ b/ui/src/app/app-host.ts
@@ -839,7 +839,15 @@ class OpenClawShell extends OpenClawLightDomElement {
               const face = resolveSessionPreferredFaceForKey(context, sessionKey);
               // Ambiguous one-segment keys intentionally fall back to /chat;
               // the removed query deep-link format is not a compatibility path.
-              this.navigate(face, sessionNavigationTarget({ context, face, sessionKey }).options);
+              this.navigate(
+                face,
+                sessionNavigationTarget({
+                  context,
+                  face,
+                  sessionKey,
+                  preferenceDerivedFace: true,
+                }).options,
+              );
             },
           }),
         );
@@ -901,7 +909,12 @@ class OpenClawShell extends OpenClawLightDomElement {
     const face = resolveSessionPreferredFaceForKey(context, command.sessionKey);
     this.navigate(
       face,
-      sessionNavigationTarget({ context, face, sessionKey: command.sessionKey }).options,
+      sessionNavigationTarget({
+        context,
+        face,
+        sessionKey: command.sessionKey,
+        preferenceDerivedFace: true,
+      }).options,
     );
   };
 
@@ -1765,7 +1778,15 @@ class OpenClawShell extends OpenClawLightDomElement {
             .onSelectSession=${(sessionKey: string) => {
               context.gateway.setSessionKey(sessionKey);
               const face = resolveSessionPreferredFaceForKey(context, sessionKey);
-              this.navigate(face, sessionNavigationTarget({ context, face, sessionKey }).options);
+              this.navigate(
+                face,
+                sessionNavigationTarget({
+                  context,
+                  face,
+                  sessionKey,
+                  preferenceDerivedFace: true,
+                }).options,
+              );
             }}
             .onSlashCommand=${this.handleCommandPaletteSlashCommand}
           ></openclaw-command-palette>`

--- a/ui/src/components/app-sidebar-render.ts
+++ b/ui/src/components/app-sidebar-render.ts
@@ -145,6 +145,7 @@ export function renderAppSidebarHomeRow(host: AppSidebarRenderHost) {
         basePath: host.basePath,
         row: mainRow ?? undefined,
         mainKey: parseAgentSessionKey(mainKey)?.rest,
+        preferenceDerivedFace: true,
       }).href}
       class="nav-item nav-item--home ${active ? "nav-item--active" : ""}"
       aria-current=${active ? "page" : nothing}

--- a/ui/src/components/app-sidebar-session-navigation-logic.ts
+++ b/ui/src/components/app-sidebar-session-navigation-logic.ts
@@ -132,6 +132,7 @@ export function buildSidebarSessionNavigationState(input: {
         basePath: context?.basePath ?? "",
         row,
         mainKey,
+        preferenceDerivedFace: true,
       }).href,
       active: row.key === navigation.activeRowKey,
       visuallyActive: input.highlightCurrentSession && row.key === navigation.currentSessionKey,

--- a/ui/src/components/app-sidebar-session-navigation.ts
+++ b/ui/src/components/app-sidebar-session-navigation.ts
@@ -293,6 +293,7 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
       basePath: this.basePath,
       row: this.findSidebarSessionByKey(sessionKey),
       mainKey: this.sessionMainKey(),
+      preferenceDerivedFace: true,
     });
     this.context?.gateway.setSessionKey(sessionKey);
     this.onNavigate?.(face, target.options);
@@ -432,6 +433,7 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
       basePath: this.basePath,
       row: this.findSidebarSessionByKey(sessionKey),
       mainKey: this.sessionMainKey(),
+      preferenceDerivedFace: true,
     });
     this.context?.gateway.setSessionKey(sessionKey);
     if (isSessionRouteId(this.activeRouteId)) {

--- a/ui/src/lib/sessions/route-navigation.test.ts
+++ b/ui/src/lib/sessions/route-navigation.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { buildCatalogSessionKey } from "./catalog-key.ts";
-import { resolveSessionPreferredFace, sessionNavigationTarget } from "./route-navigation.ts";
+import {
+  resolveSessionPreferredFace,
+  SESSION_FACE_PREFERENCE_PARAM,
+  sessionNavigationTarget,
+} from "./route-navigation.ts";
 
 describe("sessionNavigationTarget", () => {
   it("defaults generic opens to chat and honors a stored dashboard preference", () => {
@@ -68,5 +72,39 @@ describe("sessionNavigationTarget", () => {
       href: "/chat/research/telegram/12345",
       options: { pathname: "/chat/research/telegram/12345" },
     });
+  });
+
+  it("marks an uncached preference-derived face for in-app navigation but keeps href shareable", () => {
+    const target = sessionNavigationTarget({
+      face: "chat",
+      sessionKey: "agent:main:dashboard:12345678-90ab-cdef-1234-567890abcdef",
+      fallbackAgentId: "main",
+      preferenceDerivedFace: true,
+    });
+
+    // href gets copied and shared, so it stays the clean best-guess path; only the
+    // in-app navigation carries the marker that lets the loader re-derive the face.
+    expect(target.href).toBe("/chat/main/12345678");
+    expect(target.options).toEqual({
+      pathname: "/chat/main/12345678",
+      search: `?${SESSION_FACE_PREFERENCE_PARAM}=1`,
+    });
+  });
+
+  it("leaves a cached row unmarked because its stored face is already authoritative", () => {
+    const row = {
+      key: "agent:main:dashboard:12345678-90ab-cdef-1234-567890abcdef",
+      displayName: "Release Notes",
+    };
+    const target = sessionNavigationTarget({
+      face: "chat",
+      sessionKey: row.key,
+      fallbackAgentId: "main",
+      row,
+      preferenceDerivedFace: true,
+    });
+
+    expect(target.href).toBe("/chat/main/release-notes-12345678");
+    expect(target.options).toEqual({ pathname: "/chat/main/release-notes-12345678" });
   });
 });

--- a/ui/src/lib/sessions/route-navigation.ts
+++ b/ui/src/lib/sessions/route-navigation.ts
@@ -14,6 +14,8 @@ import {
   resolveUiDefaultAgentId,
 } from "./session-key.ts";
 
+export const SESSION_FACE_PREFERENCE_PARAM = "__openclawSessionFacePreference";
+
 type ContextSessionNavigationTargetParams<TRouteId extends string> = {
   context: ApplicationContext<TRouteId>;
   face: BoardFace;
@@ -24,6 +26,7 @@ type ContextSessionNavigationTargetParams<TRouteId extends string> = {
   row?: never;
   mainKey?: never;
   shortIdLength?: number;
+  preferenceDerivedFace?: boolean;
 };
 
 type ExplicitSessionNavigationTargetParams = {
@@ -36,6 +39,7 @@ type ExplicitSessionNavigationTargetParams = {
   mainKey?: string | null;
   shortIdLength?: number;
   agentId?: never;
+  preferenceDerivedFace?: boolean;
 };
 
 type SessionNavigationTarget = {
@@ -49,14 +53,20 @@ export function resolveSessionPreferredFace(
   return row?.boardFace === "dashboard" ? "dashboard" : "chat";
 }
 
+export function findUiSessionRow<TRouteId extends string>(
+  context: Pick<ApplicationContext<TRouteId>, "sessions">,
+  sessionKey: string,
+): GatewaySessionRow | undefined {
+  return context.sessions.state.result?.sessions.find((candidate) =>
+    areUiSessionKeysEquivalent(candidate.key, sessionKey),
+  );
+}
+
 export function resolveSessionPreferredFaceForKey<TRouteId extends string>(
   context: Pick<ApplicationContext<TRouteId>, "sessions">,
   sessionKey: string,
 ): BoardFace {
-  const row = context.sessions.state.result?.sessions.find((candidate) =>
-    areUiSessionKeysEquivalent(candidate.key, sessionKey),
-  );
-  return resolveSessionPreferredFace(row);
+  return resolveSessionPreferredFace(findUiSessionRow(context, sessionKey));
 }
 
 export function resolveSessionNavigationAgentId<TRouteId extends string>(
@@ -115,9 +125,7 @@ export function sessionNavigationTarget<TRouteId extends string>(
     fallbackAgentId = resolveSessionNavigationAgentId(context, params.agentId);
     basePath = context.basePath;
     mainKey = resolveUiConfiguredMainKey(defaults);
-    row = context.sessions.state.result?.sessions.find((candidate) =>
-      areUiSessionKeysEquivalent(candidate.key, sessionKey),
-    );
+    row = findUiSessionRow(context, sessionKey);
   } else {
     fallbackAgentId = params.fallbackAgentId;
     basePath = params.basePath ?? "";
@@ -138,6 +146,18 @@ export function sessionNavigationTarget<TRouteId extends string>(
     ...(catalogKey ? { mainKey } : { row, mainKey }),
   });
   const search = catalogKey ? catalogSessionSearch(catalogKey) : undefined;
-  const options = search ? { pathname, search } : { pathname };
+  // A cached row carries the authoritative boardFace, so the caller's face is already
+  // correct. Only an uncached key made it a guess: mark the in-app navigation so the
+  // chat loader re-derives the face from the gateway and replaces the URL. The marker
+  // stays out of `href` because that string gets copied and shared, and a shared link
+  // should keep the clean best-guess path.
+  const navigationParams = new URLSearchParams(search ?? "");
+  if (params.preferenceDerivedFace && !row) {
+    navigationParams.set(SESSION_FACE_PREFERENCE_PARAM, "1");
+  }
+  const serializedNavigation = navigationParams.toString();
+  const options = serializedNavigation
+    ? { pathname, search: `?${serializedNavigation}` }
+    : { pathname };
   return { href: `${pathname}${search ?? ""}`, options };
 }

--- a/ui/src/lib/sessions/route-navigation.ts
+++ b/ui/src/lib/sessions/route-navigation.ts
@@ -148,9 +148,14 @@ export function sessionNavigationTarget<TRouteId extends string>(
   const search = catalogKey ? catalogSessionSearch(catalogKey) : undefined;
   // A cached row carries the authoritative boardFace, so the caller's face is already
   // correct. Only an uncached key made it a guess: mark the in-app navigation so the
-  // chat loader re-derives the face from the gateway and replaces the URL. The marker
-  // stays out of `href` because that string gets copied and shared, and a shared link
-  // should keep the clean best-guess path.
+  // chat loader re-derives the face from the gateway and replaces the URL.
+  //
+  // The marker stays out of `href` on purpose. That string is what users hover, copy,
+  // and share, and it must not carry an internal parameter. The accepted cost is that
+  // alternate activation (middle-click, open-in-new-tab, modified click) follows the
+  // clean guessed path and can land on the other face for an uncached session, exactly
+  // as every open did before gateway resolution existed. The face is one click to
+  // change and the change persists, so this is a smaller win, not a regression.
   const navigationParams = new URLSearchParams(search ?? "");
   if (params.preferenceDerivedFace && !row) {
     navigationParams.set(SESSION_FACE_PREFERENCE_PARAM, "1");

--- a/ui/src/pages/chat/chat-page.test.ts
+++ b/ui/src/pages/chat/chat-page.test.ts
@@ -408,6 +408,30 @@ describe("chat page split layout host", () => {
     );
   });
 
+  it("replaces into the canonical face namespace without adding history", async () => {
+    const page = new ChatPage();
+    const navigation = setNavigationContext(page);
+    // The loader resolved this session to its stored dashboard face while the route was
+    // matched under /chat, so the replacement has to be routed by the resolved face.
+    page.data = {
+      sessionKey: WORK_SESSION_KEY,
+      face: "dashboard",
+      canonicalLocation: {
+        pathname: "/dashboard/main/deploy-monitor-12345678",
+        search: "",
+        hash: "",
+      },
+    };
+    document.body.append(page);
+    await page.updateComplete;
+
+    expect(navigation.replace).toHaveBeenCalledWith("dashboard", {
+      pathname: "/dashboard/main/deploy-monitor-12345678",
+      search: "",
+      hash: "",
+    });
+  });
+
   it("keeps catalog identity when consuming a route draft", async () => {
     const page = new ChatPage();
     const navigation = setNavigationContext(page);

--- a/ui/src/pages/chat/chat-page.ts
+++ b/ui/src/pages/chat/chat-page.ts
@@ -123,6 +123,8 @@ export class ChatPage extends OpenClawLightDomElement {
       (!this.layout || activePane?.sessionKey === data.sessionKey);
     if (changedProperties.has("data")) {
       if (data?.canonicalLocation) {
+        // data.face is the loader's resolved face, which may differ from the namespace
+        // this route was matched under; replacing under it moves the URL to that board.
         this.context.replace(data.face ?? "chat", data.canonicalLocation);
         return;
       }

--- a/ui/src/pages/chat/route-loader.ts
+++ b/ui/src/pages/chat/route-loader.ts
@@ -27,6 +27,9 @@ import {
 
 const SESSION_REF_SEARCH_LIMIT = 20;
 const SESSION_REF_SEARCH_MAX_PAGES = 5;
+// A uuid's first block is the longest run that is contiguous in both the hyphenated
+// stored key and the hyphen-stripped short id used in URLs.
+const UUID_FIRST_BLOCK_LENGTH = 8;
 const SESSION_UUID_SUFFIX_RE = /([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/iu;
 
 type SessionCandidate = {
@@ -114,19 +117,27 @@ function uniqueShortIdPrefix(
   return uuid;
 }
 
+// The gateway matches `search` as a plain substring of the stored key, id, and title
+// fields, so every needle here has to be a run that literally appears in one of them.
+// sessionReferenceMatches still applies the exact rule per row, so a loose needle only
+// widens the candidate set; too narrow a needle loses the session entirely.
 function sessionReferenceSearchText(search: SessionReferenceSearch): string {
-  if (search.kind !== "slug") {
+  if (search.kind === "exact") {
     return search.value;
   }
-  // The gateway matches `search` as a plain substring, and controlUiSessionSlug builds
-  // every token from a contiguous alphanumeric run of the lowercased display name. So a
-  // single token always matches server-side, while the joined slug would miss any name
-  // whose separators were punctuation ("Fix: auth bug" -> "fix-auth-bug"). Use the
-  // longest token as the most selective needle; sessionReferenceMatches still requires
-  // the full slug to be equal, so a loose needle only widens the candidate set.
-  return search.value
-    .split("-")
-    .reduce((longest, token) => (token.length > longest.length ? token : longest), "");
+  if (search.kind === "slug") {
+    // controlUiSessionSlug builds every token from a contiguous alphanumeric run of the
+    // lowercased display name, so one token always matches while the joined slug would
+    // miss any name whose separators were punctuation ("Fix: auth bug" -> "fix-auth-bug").
+    // The longest token is the most selective of those.
+    return search.value
+      .split("-")
+      .reduce((longest, token) => (token.length > longest.length ? token : longest), "");
+  }
+  // Short ids are compared hyphen-stripped, but the stored key holds a hyphenated uuid,
+  // so only its first block survives as a contiguous substring. Anything longer (from a
+  // disambiguation link or a canonicalized slug) would match nothing server-side.
+  return search.value.slice(0, UUID_FIRST_BLOCK_LENGTH);
 }
 
 function sessionReferenceMatches(
@@ -553,13 +564,16 @@ export async function loadChatRoute(
           };
         }
         if (slugResolution?.kind === "unique") {
+          // No shortId: a resolved slug canonicalizes to the same short reference every
+          // other surface links to, so `/chat/main/deploy-monitor` settles on
+          // `/chat/main/deploy-monitor-6db92d48` rather than a full uuid. A later
+          // first-block collision lands in the disambiguation view like any short link.
           const resolved = resolvedSessionRouteData({
             context,
             location: routeLocation,
             face,
             row: slugResolution.session,
             preferenceDerived,
-            shortId: sessionKeyUuid(slugResolution.session.key) ?? undefined,
           });
           return resolved ?? notFound({ routeId: face });
         }

--- a/ui/src/pages/chat/route-loader.ts
+++ b/ui/src/pages/chat/route-loader.ts
@@ -1,3 +1,4 @@
+import { controlUiSessionSlug } from "@openclaw/session-url-contract";
 import type { RouteLocation } from "@openclaw/uirouter";
 import { notFound } from "@openclaw/uirouter";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
@@ -13,7 +14,12 @@ import {
   catalogSessionKeyFromSearch,
 } from "../../lib/sessions/catalog-key.ts";
 import {
+  findUiSessionRow,
+  SESSION_FACE_PREFERENCE_PARAM,
+} from "../../lib/sessions/route-navigation.ts";
+import {
   buildAgentMainSessionKey,
+  areUiSessionKeysEquivalent,
   parseAgentSessionKey,
   resolveAgentIdFromSessionKey,
   resolveUiConfiguredMainKey,
@@ -64,14 +70,19 @@ export function locationWithoutDraft(location: RouteLocation): RouteLocation {
   return { ...location, search: search ? `?${search}` : "" };
 }
 
-type SessionPrefixResolution =
+type SessionReferenceResolution =
   | { kind: "not-found" }
   | { kind: "unique"; session: GatewaySessionRow }
   | { kind: "ambiguous"; sessions: GatewaySessionRow[]; truncated: boolean };
 
+type SessionReferenceSearch =
+  | { kind: "short"; value: string }
+  | { kind: "exact"; value: string }
+  | { kind: "slug"; value: string };
+
 const resolutionCache = new WeakMap<
   GatewayBrowserClient,
-  Map<string, Promise<SessionPrefixResolution | null>>
+  Map<string, Promise<SessionReferenceResolution | null>>
 >();
 
 function sessionKeyUuid(sessionKey: string): string | null {
@@ -103,47 +114,89 @@ function uniqueShortIdPrefix(
   return uuid;
 }
 
-function sessionPrefixMatches(result: SessionsListResult, shortId: string): GatewaySessionRow[] {
-  const prefix = shortId.toLowerCase().replaceAll("-", "");
-  return result.sessions.filter((row) => {
-    const keyUuid = sessionKeyUuid(row.key);
-    return keyUuid?.startsWith(prefix) === true;
-  });
+function sessionReferenceSearchText(search: SessionReferenceSearch): string {
+  if (search.kind !== "slug") {
+    return search.value;
+  }
+  // The gateway matches `search` as a plain substring, and controlUiSessionSlug builds
+  // every token from a contiguous alphanumeric run of the lowercased display name. So a
+  // single token always matches server-side, while the joined slug would miss any name
+  // whose separators were punctuation ("Fix: auth bug" -> "fix-auth-bug"). Use the
+  // longest token as the most selective needle; sessionReferenceMatches still requires
+  // the full slug to be equal, so a loose needle only widens the candidate set.
+  return search.value
+    .split("-")
+    .reduce((longest, token) => (token.length > longest.length ? token : longest), "");
 }
 
-async function querySessionPrefix(
+function sessionReferenceMatches(
+  result: SessionsListResult,
+  search: SessionReferenceSearch,
+): GatewaySessionRow[] {
+  if (search.kind === "exact") {
+    return result.sessions.filter((row) => areUiSessionKeysEquivalent(row.key, search.value));
+  }
+  if (search.kind === "slug") {
+    return result.sessions.filter(
+      (row) =>
+        sessionKeyUuid(row.key) !== null && controlUiSessionSlug(row.displayName) === search.value,
+    );
+  }
+  const prefix = search.value.toLowerCase().replaceAll("-", "");
+  return result.sessions.filter((row) => sessionKeyUuid(row.key)?.startsWith(prefix) === true);
+}
+
+function incompleteSessionReferenceResolution(
+  search: SessionReferenceSearch,
+  sessions: GatewaySessionRow[],
+): SessionReferenceResolution {
+  if (search.kind === "slug" && sessions.length === 0) {
+    // Slugs are best-effort: the bounded zero-match contract is a 404, while an
+    // incomplete exact-key search must retain the authoritative literal route.
+    return { kind: "not-found" };
+  }
+  return { kind: "ambiguous", sessions, truncated: true };
+}
+
+async function querySessionReference(
   context: ApplicationContext,
-  shortId: string,
+  search: SessionReferenceSearch,
   signal: AbortSignal,
-): Promise<SessionPrefixResolution> {
+): Promise<SessionReferenceResolution | null> {
   const client = await waitForGatewayClient(context.gateway, signal);
   let cache = resolutionCache.get(client);
   if (!cache) {
     cache = new Map();
     resolutionCache.set(client, cache);
   }
-  let pending = cache.get(shortId);
+  const cacheKey = `${search.kind}:${search.value}`;
+  let pending = cache.get(cacheKey);
   if (!pending) {
-    pending = querySessionPrefixPages(context, shortId);
-    cache.set(shortId, pending);
+    pending = querySessionReferencePages(context, search);
+    cache.set(cacheKey, pending);
   }
   try {
-    const resolved = await pending;
-    if (!resolved) {
-      throw new Error("Session list unavailable while resolving URL.");
-    }
-    return resolved;
+    return await pending;
   } finally {
-    if (cache.get(shortId) === pending) {
-      cache.delete(shortId);
+    if (cache.get(cacheKey) === pending) {
+      cache.delete(cacheKey);
     }
   }
 }
 
-async function querySessionPrefixPages(
+function requireSessionReferenceResolution(
+  resolution: SessionReferenceResolution | null,
+): SessionReferenceResolution {
+  if (!resolution) {
+    throw new Error("Session list unavailable while resolving URL.");
+  }
+  return resolution;
+}
+
+async function querySessionReferencePages(
   context: ApplicationContext,
-  shortId: string,
-): Promise<SessionPrefixResolution | null> {
+  search: SessionReferenceSearch,
+): Promise<SessionReferenceResolution | null> {
   const matches = new Map<string, GatewaySessionRow>();
   let offset = 0;
   for (let page = 0; ; page += 1) {
@@ -151,16 +204,19 @@ async function querySessionPrefixPages(
       archivedFilter: "all",
       includeDerivedTitles: true,
       limit: SESSION_REF_SEARCH_LIMIT,
-      search: shortId,
+      search: sessionReferenceSearchText(search),
       ...(offset > 0 ? { offset } : {}),
     });
     if (!result) {
       return null;
     }
-    for (const session of sessionPrefixMatches(result, shortId)) {
+    for (const session of sessionReferenceMatches(result, search)) {
       matches.set(session.key, session);
     }
     const sessions = [...matches.values()];
+    if (search.kind === "exact" && sessions[0]) {
+      return { kind: "unique", session: sessions[0] };
+    }
     if (sessions.length > 1) {
       return { kind: "ambiguous", sessions, truncated: result.hasMore === true };
     }
@@ -169,11 +225,11 @@ async function querySessionPrefixPages(
       return session ? { kind: "unique", session } : { kind: "not-found" };
     }
     if (page === SESSION_REF_SEARCH_MAX_PAGES - 1) {
-      return { kind: "ambiguous", sessions, truncated: true };
+      return incompleteSessionReferenceResolution(search, sessions);
     }
     const nextOffset = result.nextOffset ?? offset + result.sessions.length;
     if (nextOffset <= offset) {
-      return { kind: "ambiguous", sessions, truncated: true };
+      return incompleteSessionReferenceResolution(search, sessions);
     }
     offset = nextOffset;
   }
@@ -181,6 +237,25 @@ async function querySessionPrefixPages(
 
 function draftFromLocation(location: RouteLocation): string | undefined {
   return new URLSearchParams(location.search).get("draft") || undefined;
+}
+
+function isPreferenceDerivedFace(location: RouteLocation): boolean {
+  return new URLSearchParams(location.search).get(SESSION_FACE_PREFERENCE_PARAM) === "1";
+}
+
+function locationWithoutSearchParam(location: RouteLocation, key: string): RouteLocation {
+  const params = new URLSearchParams(location.search);
+  params.delete(key);
+  const search = params.toString();
+  return { ...location, search: search ? `?${search}` : "" };
+}
+
+function locationWithoutFacePreference(location: RouteLocation): RouteLocation {
+  return locationWithoutSearchParam(location, SESSION_FACE_PREFERENCE_PARAM);
+}
+
+function preferredFace(row: Pick<GatewaySessionRow, "boardFace">): BoardFace {
+  return row.boardFace === "dashboard" ? "dashboard" : "chat";
 }
 
 function configuredMainKey(context: ApplicationContext): string {
@@ -213,18 +288,54 @@ function canonicalMainLocation(
     return null;
   }
   const pathname = pathForSession(face, parsed.agentId, sessionKey, context.basePath, { mainKey });
-  return pathname && pathname !== location.pathname ? { ...location, pathname } : null;
+  return pathname && pathname !== location.pathname
+    ? { ...locationWithoutFacePreference(location), pathname }
+    : null;
+}
+
+function canonicalSessionLocation(params: {
+  context: ApplicationContext;
+  location: RouteLocation;
+  face: BoardFace;
+  row: GatewaySessionRow;
+  shortIdLength?: number;
+}): RouteLocation | null | undefined {
+  const face = params.face;
+  const agentId = resolveAgentIdFromSessionKey(params.row.key);
+  const pathname = pathForSession(face, agentId, params.row.key, params.context.basePath, {
+    displayName: params.row.displayName,
+    mainKey: configuredMainKey(params.context),
+    shortIdLength: params.shortIdLength,
+  });
+  if (!pathname) {
+    return undefined;
+  }
+  const location = locationWithoutFacePreference(params.location);
+  const changed =
+    pathname !== params.location.pathname || location.search !== params.location.search;
+  return changed ? { ...location, pathname } : null;
 }
 
 function targetFromLocation(context: ApplicationContext, location: RouteLocation) {
   const mainKey = configuredMainKey(context);
   const direct = sessionRefFromPath(location.pathname, context.basePath, mainKey);
   if (direct) {
-    return { target: direct, normalized: false };
+    return { target: direct, location };
   }
   const internalPath = new URLSearchParams(location.search).get(INTERNAL_SESSION_PATH_PARAM);
-  const target = internalPath ? sessionRefFromPath(internalPath, context.basePath, mainKey) : null;
-  return target ? { target, normalized: true } : null;
+  if (!internalPath) {
+    return null;
+  }
+  const target = sessionRefFromPath(internalPath, context.basePath, mainKey);
+  return target
+    ? {
+        target,
+        location: {
+          ...locationWithoutSearchParam(location, INTERNAL_SESSION_PATH_PARAM),
+          pathname: internalPath,
+        },
+      }
+    : null;
 }
 
 function mainSessionKey(
@@ -240,8 +351,10 @@ function mainSessionKey(
 function candidatesForResolution(
   context: ApplicationContext,
   face: BoardFace,
-  resolution: Extract<SessionPrefixResolution, { kind: "ambiguous" }>,
+  resolution: Extract<SessionReferenceResolution, { kind: "ambiguous" }>,
   draft: string | undefined,
+  preferenceDerived: boolean,
+  fullId: boolean,
 ): SessionCandidate[] {
   const resolvedRows = resolution.sessions.flatMap((row) => {
     const uuid = sessionKeyUuid(row.key);
@@ -249,12 +362,13 @@ function candidatesForResolution(
   });
   const uuids = resolvedRows.map(({ uuid }) => uuid);
   return resolvedRows.flatMap(({ row, uuid }) => {
-    const prefix = uniqueShortIdPrefix(uuid, uuids, resolution.truncated);
+    const prefix = fullId ? uuid : uniqueShortIdPrefix(uuid, uuids, resolution.truncated);
     if (!prefix) {
       return [];
     }
     const agentId = resolveAgentIdFromSessionKey(row.key);
-    const href = pathForSession(face, agentId, row.key, context.basePath, {
+    const candidateFace = preferenceDerived ? preferredFace(row) : face;
+    const href = pathForSession(candidateFace, agentId, row.key, context.basePath, {
       displayName: row.displayName,
       mainKey: configuredMainKey(context),
       shortIdLength: prefix.length,
@@ -272,6 +386,38 @@ function candidatesForResolution(
   });
 }
 
+function resolvedSessionRouteData(params: {
+  context: ApplicationContext;
+  location: RouteLocation;
+  face: BoardFace;
+  row: GatewaySessionRow;
+  preferenceDerived: boolean;
+  shortId?: string;
+}): Extract<ChatRouteData, { kind: "session" }> | null {
+  // The loader owns face resolution: a preference-derived open adopts the row's stored
+  // face, so the page renders that board directly and replaces the URL with the matching
+  // namespace instead of re-deriving a face from the path it was handed.
+  const face = params.preferenceDerived ? preferredFace(params.row) : params.face;
+  const canonicalLocation = canonicalSessionLocation({
+    context: params.context,
+    location: params.location,
+    face,
+    row: params.row,
+    ...(params.shortId ? { shortIdLength: params.shortId.length } : {}),
+  });
+  if (canonicalLocation === undefined) {
+    return null;
+  }
+  return {
+    kind: "session",
+    sessionKey: params.row.key,
+    draft: draftFromLocation(params.location),
+    face,
+    ...(params.shortId && params.shortId.length > 8 ? { shortId: params.shortId } : {}),
+    ...(canonicalLocation ? { canonicalLocation } : {}),
+  };
+}
+
 export async function loadChatRoute(
   context: ApplicationContext,
   location: RouteLocation,
@@ -283,47 +429,173 @@ export async function loadChatRoute(
     return notFound({ routeId: face });
   }
   const { target } = resolvedTarget;
-  const catalogKey = catalogSessionKeyFromSearch(location.search);
+  const routeLocation = resolvedTarget.location;
+  const preferenceDerived = isPreferenceDerivedFace(routeLocation);
+  const catalogKey = catalogSessionKeyFromSearch(routeLocation.search);
   if (target.kind === "main" && catalogKey) {
+    const sessionKey = buildCatalogSessionKey(catalogKey);
+    let canonicalLocation = preferenceDerived ? locationWithoutFacePreference(routeLocation) : null;
+    let resolvedFace = face;
+    if (preferenceDerived) {
+      const resolution = await querySessionReference(
+        context,
+        { kind: "exact", value: sessionKey },
+        signal,
+      );
+      if (resolution?.kind === "unique") {
+        resolvedFace = preferredFace(resolution.session);
+        const pathname = pathForSession(
+          resolvedFace,
+          target.agentId,
+          mainSessionKey(context, target),
+          context.basePath,
+          { mainKey: configuredMainKey(context) },
+        );
+        if (pathname) {
+          canonicalLocation = { ...locationWithoutFacePreference(routeLocation), pathname };
+        }
+      }
+    }
     return {
       kind: "session",
-      sessionKey: buildCatalogSessionKey(catalogKey),
+      sessionKey,
       agentId: target.agentId,
-      draft: draftFromLocation(location),
-      face,
+      draft: draftFromLocation(routeLocation),
+      face: resolvedFace,
+      // Non-null only on a preference-derived open, where it always at least drops the
+      // marker from the URL.
+      ...(canonicalLocation ? { canonicalLocation } : {}),
     };
   }
   if (target.kind === "main") {
     await waitForGatewayClient(context.gateway, signal);
+    const sessionKey = mainSessionKey(context, target);
+    if (preferenceDerived) {
+      const resolution = await querySessionReference(
+        context,
+        { kind: "exact", value: sessionKey },
+        signal,
+      );
+      if (resolution?.kind === "unique") {
+        const resolved = resolvedSessionRouteData({
+          context,
+          location: routeLocation,
+          face,
+          row: resolution.session,
+          preferenceDerived,
+        });
+        return resolved ?? notFound({ routeId: face });
+      }
+    }
+    const canonicalLocation = preferenceDerived
+      ? locationWithoutFacePreference(routeLocation)
+      : null;
     return {
       kind: "session",
-      sessionKey: mainSessionKey(context, target),
-      draft: draftFromLocation(location),
+      sessionKey,
+      draft: draftFromLocation(routeLocation),
       face,
+      ...(canonicalLocation && canonicalLocation.search !== routeLocation.search
+        ? { canonicalLocation }
+        : {}),
     };
   }
   if (target.kind === "literal") {
-    const defaultsKnown = hasConfiguredMainKey(context);
+    let defaultsKnown = hasConfiguredMainKey(context);
+    const needsGatewayResolution = preferenceDerived || Boolean(target.slugCandidate);
+    if (!defaultsKnown && needsGatewayResolution) {
+      await waitForGatewayClient(context.gateway, signal);
+      defaultsKnown = hasConfiguredMainKey(context);
+      if (defaultsKnown) {
+        return await loadChatRoute(context, routeLocation, face, signal);
+      }
+    }
+    if (needsGatewayResolution) {
+      // Any single non-short-id segment is a slug candidate, so a plain literal route
+      // would otherwise pay a sessions.list round-trip on every open. A cached row is
+      // already proof the segment is a real key, which settles the exact lookup for
+      // free; only genuinely unknown references reach the gateway.
+      const cachedRow = defaultsKnown ? findUiSessionRow(context, target.sessionKey) : undefined;
+      const exactResolution = cachedRow
+        ? ({ kind: "unique", session: cachedRow } as const)
+        : await querySessionReference(context, { kind: "exact", value: target.sessionKey }, signal);
+      if (exactResolution?.kind === "unique") {
+        const resolved = resolvedSessionRouteData({
+          context,
+          location: routeLocation,
+          face,
+          row: exactResolution.session,
+          preferenceDerived,
+        });
+        return resolved ?? notFound({ routeId: face });
+      }
+      if (target.slugCandidate && exactResolution?.kind === "not-found") {
+        const slugResolution = await querySessionReference(
+          context,
+          { kind: "slug", value: target.slugCandidate },
+          signal,
+        );
+        if (slugResolution?.kind === "not-found") {
+          return notFound({ routeId: face });
+        }
+        if (slugResolution?.kind === "ambiguous") {
+          return {
+            kind: "ambiguous",
+            shortId: target.slugCandidate,
+            candidates: candidatesForResolution(
+              context,
+              face,
+              slugResolution,
+              draftFromLocation(routeLocation),
+              preferenceDerived,
+              true,
+            ),
+            truncated: slugResolution.truncated,
+            face,
+          };
+        }
+        if (slugResolution?.kind === "unique") {
+          const resolved = resolvedSessionRouteData({
+            context,
+            location: routeLocation,
+            face,
+            row: slugResolution.session,
+            preferenceDerived,
+            shortId: sessionKeyUuid(slugResolution.session.key) ?? undefined,
+          });
+          return resolved ?? notFound({ routeId: face });
+        }
+      }
+    }
     const canonicalLocation = defaultsKnown
-      ? canonicalMainLocation(context, location, face, target.sessionKey)
+      ? canonicalMainLocation(context, routeLocation, face, target.sessionKey)
       : null;
     const parsed = parseAgentSessionKey(target.sessionKey);
     const canonicalLocationReady =
       !defaultsKnown && parsed
         ? waitForGatewayClient(context.gateway, signal)
-            .then(() => canonicalMainLocation(context, location, face, target.sessionKey))
+            .then(() => canonicalMainLocation(context, routeLocation, face, target.sessionKey))
             .catch(() => null)
         : undefined;
+    const preferenceLocation = preferenceDerived
+      ? locationWithoutFacePreference(routeLocation)
+      : null;
     return {
       kind: "session",
       sessionKey: target.sessionKey,
-      draft: draftFromLocation(location),
+      draft: draftFromLocation(routeLocation),
       face,
-      ...(canonicalLocation ? { canonicalLocation } : {}),
+      ...(canonicalLocation
+        ? { canonicalLocation }
+        : preferenceLocation && preferenceLocation.search !== routeLocation.search
+          ? { canonicalLocation: preferenceLocation }
+          : {}),
       ...(canonicalLocationReady ? { canonicalLocationReady } : {}),
     };
   }
-  const resolution = await querySessionPrefix(context, target.shortId, signal);
+  const resolution = requireSessionReferenceResolution(
+    await querySessionReference(context, { kind: "short", value: target.shortId }, signal),
+  );
   if (resolution.kind === "not-found") {
     return notFound({ routeId: face });
   }
@@ -331,29 +603,25 @@ export async function loadChatRoute(
     return {
       kind: "ambiguous",
       shortId: target.shortId,
-      candidates: candidatesForResolution(context, face, resolution, draftFromLocation(location)),
+      candidates: candidatesForResolution(
+        context,
+        face,
+        resolution,
+        draftFromLocation(routeLocation),
+        preferenceDerived,
+        false,
+      ),
       truncated: resolution.truncated,
       face,
     };
   }
-  const row = resolution.session;
-  const agentId = resolveAgentIdFromSessionKey(row.key);
-  const canonicalPath = pathForSession(face, agentId, row.key, context.basePath, {
-    displayName: row.displayName,
-    mainKey: configuredMainKey(context),
-    shortIdLength: target.shortId.length,
-  });
-  if (!canonicalPath) {
-    return notFound({ routeId: face });
-  }
-  return {
-    kind: "session",
-    sessionKey: row.key,
-    draft: draftFromLocation(location),
+  const resolved = resolvedSessionRouteData({
+    context,
+    location: routeLocation,
     face,
-    ...(target.shortId.length > 8 ? { shortId: target.shortId } : {}),
-    ...(!resolvedTarget.normalized && location.pathname !== canonicalPath
-      ? { canonicalLocation: { ...location, pathname: canonicalPath } }
-      : {}),
-  };
+    row: resolution.session,
+    preferenceDerived,
+    shortId: target.shortId,
+  });
+  return resolved ?? notFound({ routeId: face });
 }

--- a/ui/src/pages/chat/route-loader.ts
+++ b/ui/src/pages/chat/route-loader.ts
@@ -354,7 +354,6 @@ function candidatesForResolution(
   resolution: Extract<SessionReferenceResolution, { kind: "ambiguous" }>,
   draft: string | undefined,
   preferenceDerived: boolean,
-  fullId: boolean,
 ): SessionCandidate[] {
   const resolvedRows = resolution.sessions.flatMap((row) => {
     const uuid = sessionKeyUuid(row.key);
@@ -362,7 +361,7 @@ function candidatesForResolution(
   });
   const uuids = resolvedRows.map(({ uuid }) => uuid);
   return resolvedRows.flatMap(({ row, uuid }) => {
-    const prefix = fullId ? uuid : uniqueShortIdPrefix(uuid, uuids, resolution.truncated);
+    const prefix = uniqueShortIdPrefix(uuid, uuids, resolution.truncated);
     if (!prefix) {
       return [];
     }
@@ -548,7 +547,6 @@ export async function loadChatRoute(
               slugResolution,
               draftFromLocation(routeLocation),
               preferenceDerived,
-              true,
             ),
             truncated: slugResolution.truncated,
             face,
@@ -609,7 +607,6 @@ export async function loadChatRoute(
         resolution,
         draftFromLocation(routeLocation),
         preferenceDerived,
-        false,
       ),
       truncated: resolution.truncated,
       face,

--- a/ui/src/pages/chat/route-resolution.test.ts
+++ b/ui/src/pages/chat/route-resolution.test.ts
@@ -214,8 +214,8 @@ describe("gateway-backed session route resolution", () => {
       kind: "session",
       sessionKey: storedRow.key,
       canonicalLocation: {
-        pathname:
-          "/chat/roboclaw/default-mode-with-rare-surprises-1234567890abcdef1234567890abcdef",
+        // Canonicalizes to the same short reference every other surface links to.
+        pathname: "/chat/roboclaw/default-mode-with-rare-surprises-12345678",
       },
     });
     expect(list.mock.calls.map(([options]) => options?.search)).toEqual([
@@ -298,8 +298,8 @@ describe("gateway-backed session route resolution", () => {
       kind: "session",
       sessionKey: storedRow.key,
       canonicalLocation: {
-        pathname:
-          "/chat/roboclaw/default-mode-with-rare-surprises-1234567890abcdef1234567890abcdef",
+        // Canonicalizes to the same short reference every other surface links to.
+        pathname: "/chat/roboclaw/default-mode-with-rare-surprises-12345678",
       },
     });
   });

--- a/ui/src/pages/chat/route-resolution.test.ts
+++ b/ui/src/pages/chat/route-resolution.test.ts
@@ -1,0 +1,446 @@
+// @vitest-environment node
+import { describe, expect, it, vi } from "vitest";
+import type { GatewaySessionRow, SessionsListResult } from "../../api/types.ts";
+import { INTERNAL_SESSION_PATH_PARAM } from "../../app-route-paths.ts";
+import type { ApplicationContext } from "../../app/context.ts";
+import { buildCatalogSessionKey } from "../../lib/sessions/catalog-key.ts";
+import {
+  resolveSessionPreferredFaceForKey,
+  sessionNavigationTarget,
+} from "../../lib/sessions/route-navigation.ts";
+import { loadChatRoute } from "./route-loader.ts";
+
+const uuid = "12345678-90ab-cdef-1234-567890abcdef";
+const sessionKey = `agent:roboclaw:thread:${uuid}`;
+
+function row(overrides: Partial<GatewaySessionRow> = {}): GatewaySessionRow {
+  return {
+    key: sessionKey,
+    kind: "direct",
+    updatedAt: 1,
+    displayName: "Default mode with rare surprises",
+    sessionId: "fedcba98-7654-3210-fedc-ba9876543210",
+    ...overrides,
+  };
+}
+
+function result(
+  sessions: GatewaySessionRow[],
+  options: Pick<SessionsListResult, "hasMore" | "nextOffset" | "offset"> = {},
+): SessionsListResult {
+  return {
+    ts: 1,
+    path: "sessions.json",
+    count: sessions.length,
+    defaults: { modelProvider: null, model: null, contextTokens: null },
+    sessions,
+    ...options,
+  };
+}
+
+function contextFor(
+  listResult: (options: { search?: string; offset?: number }) => SessionsListResult | null,
+  cachedSessions: GatewaySessionRow[] = [],
+) {
+  const client = {};
+  const list = vi.fn(async (options: { search?: string; offset?: number } = {}) =>
+    listResult(options),
+  );
+  const context = {
+    basePath: "",
+    gateway: {
+      snapshot: { phase: "connected", client, hello: null },
+      subscribe: vi.fn(() => () => undefined),
+    },
+    agents: { state: { agentsList: { mainKey: "main" } } },
+    agentSelection: { state: { selectedId: "roboclaw" } },
+    sessions: { state: { result: result(cachedSessions) }, list },
+  } as unknown as ApplicationContext;
+  return { context, list };
+}
+
+// The router navigates with `options`, not the shareable `href`, so route-loader
+// coverage has to start from the same location the app actually pushes.
+function targetLocation(target: ReturnType<typeof sessionNavigationTarget>) {
+  return { pathname: target.options.pathname, search: target.options.search ?? "", hash: "" };
+}
+
+describe("gateway-backed session route resolution", () => {
+  it("applies an uncached stored face to a preference-derived open", async () => {
+    const dashboardRow = row({ boardFace: "dashboard" });
+    const { context } = contextFor(() => result([dashboardRow]));
+    const face = resolveSessionPreferredFaceForKey(context, dashboardRow.key);
+    const target = sessionNavigationTarget({
+      context,
+      face,
+      sessionKey: dashboardRow.key,
+      preferenceDerivedFace: true,
+    });
+
+    expect(face).toBe("chat");
+    expect(target.options.pathname).toBe("/chat/roboclaw/12345678");
+    await expect(
+      loadChatRoute(context, targetLocation(target), face, new AbortController().signal),
+    ).resolves.toMatchObject({
+      kind: "session",
+      sessionKey: dashboardRow.key,
+      // The loader adopts the stored face, so the page renders the dashboard board and
+      // replaces the URL into the matching namespace.
+      face: "dashboard",
+      canonicalLocation: {
+        pathname: "/dashboard/roboclaw/default-mode-with-rare-surprises-12345678",
+        search: "",
+      },
+    });
+  });
+
+  it("keeps a preference-derived main route usable when its optional lookup is unavailable", async () => {
+    const { context } = contextFor(() => null);
+    const target = sessionNavigationTarget({
+      context,
+      face: "chat",
+      sessionKey: "agent:roboclaw:main",
+      preferenceDerivedFace: true,
+    });
+
+    await expect(
+      loadChatRoute(context, targetLocation(target), "chat", new AbortController().signal),
+    ).resolves.toEqual({
+      kind: "session",
+      sessionKey: "agent:roboclaw:main",
+      draft: undefined,
+      face: "chat",
+      canonicalLocation: { pathname: "/chat/roboclaw", search: "", hash: "" },
+    });
+  });
+
+  it("applies face canonicalization through the router's normalized location", async () => {
+    const dashboardRow = row({ boardFace: "dashboard" });
+    const { context } = contextFor(() => result([dashboardRow]));
+    const target = sessionNavigationTarget({
+      context,
+      face: "chat",
+      sessionKey: dashboardRow.key,
+      preferenceDerivedFace: true,
+    });
+    const search = new URLSearchParams(targetLocation(target).search);
+    search.set(INTERNAL_SESSION_PATH_PARAM, target.options.pathname);
+
+    await expect(
+      loadChatRoute(
+        context,
+        { pathname: "/chat", search: `?${search.toString()}`, hash: "" },
+        "chat",
+        new AbortController().signal,
+      ),
+    ).resolves.toMatchObject({
+      kind: "session",
+      sessionKey: dashboardRow.key,
+      canonicalLocation: {
+        pathname: "/dashboard/roboclaw/default-mode-with-rare-surprises-12345678",
+        search: "",
+      },
+    });
+  });
+
+  it("applies an uncached stored face to a preference-derived catalog open", async () => {
+    const catalogKey = buildCatalogSessionKey({
+      catalogId: "claude",
+      hostId: "gateway:local",
+      threadId: "thread-1",
+    });
+    const catalogRow = row({ key: catalogKey, boardFace: "dashboard" });
+    const { context } = contextFor(() => result([catalogRow]));
+    const target = sessionNavigationTarget({
+      face: "chat",
+      sessionKey: catalogKey,
+      fallbackAgentId: "roboclaw",
+      preferenceDerivedFace: true,
+    });
+
+    await expect(
+      loadChatRoute(context, targetLocation(target), "chat", new AbortController().signal),
+    ).resolves.toEqual({
+      kind: "session",
+      sessionKey: catalogKey,
+      agentId: "roboclaw",
+      draft: undefined,
+      face: "dashboard",
+      canonicalLocation: {
+        pathname: "/dashboard/roboclaw",
+        search: "?catalog=claude&host=gateway%3Alocal&thread=thread-1",
+        hash: "",
+      },
+    });
+  });
+
+  it("never lets a stored preference rewrite an explicitly chosen face", async () => {
+    for (const [face, storedFace] of [
+      ["chat", "dashboard"],
+      ["dashboard", "chat"],
+    ] as const) {
+      const storedRow = row({ boardFace: storedFace });
+      const { context } = contextFor(() => result([storedRow]));
+      const pathname = `/${face}/roboclaw/default-mode-with-rare-surprises-12345678`;
+      const loaded = await loadChatRoute(
+        context,
+        { pathname, search: "", hash: "" },
+        face,
+        new AbortController().signal,
+      );
+
+      expect(loaded).toMatchObject({ kind: "session", sessionKey: storedRow.key, face });
+      expect(loaded).not.toHaveProperty("canonicalLocation");
+    }
+  });
+
+  it("resolves an exact display-name slug and canonicalizes it to a full reference", async () => {
+    const storedRow = row();
+    const { context, list } = contextFor(({ search }) =>
+      search === "surprises" ? result([storedRow]) : result([]),
+    );
+    const loaded = await loadChatRoute(
+      context,
+      {
+        pathname: "/chat/roboclaw/default-mode-with-rare-surprises",
+        search: "",
+        hash: "",
+      },
+      "chat",
+      new AbortController().signal,
+    );
+
+    expect(loaded).toMatchObject({
+      kind: "session",
+      sessionKey: storedRow.key,
+      canonicalLocation: {
+        pathname:
+          "/chat/roboclaw/default-mode-with-rare-surprises-1234567890abcdef1234567890abcdef",
+      },
+    });
+    expect(list.mock.calls.map(([options]) => options?.search)).toEqual([
+      "agent:roboclaw:default-mode-with-rare-surprises",
+      "surprises",
+    ]);
+  });
+
+  it("resolves a slug whose display name separators were punctuation", async () => {
+    // The gateway search is a plain substring match, so a joined "fix auth bug" needle
+    // would never match "Fix: auth bug"; the longest slug token still does.
+    const storedRow = row({ displayName: "Fix: auth bug" });
+    const { context, list } = contextFor(({ search }) =>
+      search === "auth" ? result([storedRow]) : result([]),
+    );
+    const loaded = await loadChatRoute(
+      context,
+      { pathname: "/chat/roboclaw/fix-auth-bug", search: "", hash: "" },
+      "chat",
+      new AbortController().signal,
+    );
+
+    expect(loaded).toMatchObject({ kind: "session", sessionKey: storedRow.key });
+    expect(list.mock.calls.map(([options]) => options?.search)).toEqual([
+      "agent:roboclaw:fix-auth-bug",
+      "auth",
+    ]);
+  });
+
+  it("waits for cold gateway defaults before resolving a display-name slug", async () => {
+    type GatewayListener = Parameters<ApplicationContext["gateway"]["subscribe"]>[0];
+    let listener: GatewayListener | null = null;
+    let snapshot = {
+      phase: "connecting",
+      client: null,
+      hello: null,
+    } as unknown as ApplicationContext["gateway"]["snapshot"];
+    const storedRow = row();
+    const list = vi.fn(async (options: { search?: string } = {}) =>
+      options.search === "surprises" ? result([storedRow]) : result([]),
+    );
+    const context = {
+      basePath: "",
+      gateway: {
+        get snapshot() {
+          return snapshot;
+        },
+        subscribe: (next: GatewayListener) => {
+          listener = next;
+          return () => undefined;
+        },
+      },
+      agents: { state: { agentsList: null } },
+      sessions: { state: { result: result([]) }, list },
+    } as unknown as ApplicationContext;
+    const pending = loadChatRoute(
+      context,
+      {
+        pathname: "/chat/roboclaw/default-mode-with-rare-surprises",
+        search: "",
+        hash: "",
+      },
+      "chat",
+      new AbortController().signal,
+    );
+    await Promise.resolve();
+
+    snapshot = {
+      phase: "connected",
+      client: {},
+      hello: { snapshot: { sessionDefaults: { mainKey: "main" } } },
+    } as unknown as ApplicationContext["gateway"]["snapshot"];
+    const connectedListener = listener as GatewayListener | null;
+    if (!connectedListener) {
+      throw new Error("expected gateway readiness subscription");
+    }
+    connectedListener(snapshot);
+
+    await expect(pending).resolves.toMatchObject({
+      kind: "session",
+      sessionKey: storedRow.key,
+      canonicalLocation: {
+        pathname:
+          "/chat/roboclaw/default-mode-with-rare-surprises-1234567890abcdef1234567890abcdef",
+      },
+    });
+  });
+
+  it("returns slug ties to the existing disambiguation view", async () => {
+    const rows = [
+      row({ key: "agent:roboclaw:thread:12345678-0aaa-4000-8000-000000000001" }),
+      row({ key: "agent:research:thread:12345678-0bbb-4000-8000-000000000002" }),
+    ];
+    const { context } = contextFor(({ search }) =>
+      search === "surprises" ? result(rows) : result([]),
+    );
+    const loaded = await loadChatRoute(
+      context,
+      {
+        pathname: "/chat/roboclaw/default-mode-with-rare-surprises",
+        search: "",
+        hash: "",
+      },
+      "chat",
+      new AbortController().signal,
+    );
+
+    expect(loaded).toMatchObject({
+      kind: "ambiguous",
+      shortId: "default-mode-with-rare-surprises",
+      truncated: false,
+      candidates: [{ agentId: "roboclaw" }, { agentId: "research" }],
+    });
+    if (!("kind" in loaded) || loaded.kind !== "ambiguous") {
+      throw new Error("expected slug disambiguation");
+    }
+    expect(loaded.candidates.map((candidate) => candidate.href)).toEqual([
+      "/chat/roboclaw/default-mode-with-rare-surprises-123456780aaa40008000000000000001",
+      "/chat/research/default-mode-with-rare-surprises-123456780bbb40008000000000000002",
+    ]);
+  });
+
+  it("prefers an exact literal key over slug matches", async () => {
+    const literal = row({
+      key: "agent:roboclaw:default-mode-with-rare-surprises",
+      displayName: "Literal session",
+    });
+    const slug = row();
+    const { context, list } = contextFor(() => result([slug, literal]));
+    const loaded = await loadChatRoute(
+      context,
+      {
+        pathname: "/chat/roboclaw/default-mode-with-rare-surprises",
+        search: "",
+        hash: "",
+      },
+      "chat",
+      new AbortController().signal,
+    );
+
+    expect(loaded).toMatchObject({ kind: "session", sessionKey: literal.key });
+    expect(list).toHaveBeenCalledOnce();
+  });
+
+  it("prefers a short-id shape over a display-name slug", async () => {
+    const short = row({ key: "agent:roboclaw:thread:deadbeef-0aaa-4000-8000-000000000001" });
+    const slug = row({
+      key: "agent:roboclaw:thread:12345678-0bbb-4000-8000-000000000002",
+      displayName: "Default mode deadbeef",
+    });
+    const { context, list } = contextFor(() => result([slug, short]));
+    const loaded = await loadChatRoute(
+      context,
+      { pathname: "/chat/roboclaw/default-mode-deadbeef", search: "", hash: "" },
+      "chat",
+      new AbortController().signal,
+    );
+
+    expect(loaded).toMatchObject({ kind: "session", sessionKey: short.key });
+    expect(list).toHaveBeenCalledOnce();
+    expect(list).toHaveBeenCalledWith(expect.objectContaining({ search: "deadbeef" }));
+  });
+
+  it("returns not found when neither a literal key nor slug resolves", async () => {
+    const { context, list } = contextFor(() => result([]));
+    const loaded = await loadChatRoute(
+      context,
+      { pathname: "/chat/roboclaw/unknown-thread", search: "", hash: "" },
+      "chat",
+      new AbortController().signal,
+    );
+
+    expect(loaded).not.toHaveProperty("kind", "session");
+    expect(list).toHaveBeenCalledTimes(2);
+  });
+
+  it("resolves a cached literal without a gateway round-trip", async () => {
+    const literal = row({ key: "agent:roboclaw:standup", displayName: "Standup" });
+    const { context, list } = contextFor(() => result([literal]), [literal]);
+    const loaded = await loadChatRoute(
+      context,
+      { pathname: "/chat/roboclaw/standup", search: "", hash: "" },
+      "chat",
+      new AbortController().signal,
+    );
+
+    expect(loaded).toMatchObject({ kind: "session", sessionKey: literal.key });
+    expect(list).not.toHaveBeenCalled();
+  });
+
+  it("keeps an authoritative literal usable when best-effort lookup is unavailable", async () => {
+    const { context, list } = contextFor(() => null);
+    const loaded = await loadChatRoute(
+      context,
+      { pathname: "/chat/roboclaw/existing-literal", search: "", hash: "" },
+      "chat",
+      new AbortController().signal,
+    );
+
+    expect(loaded).toEqual({
+      kind: "session",
+      sessionKey: "agent:roboclaw:existing-literal",
+      draft: undefined,
+      face: "chat",
+    });
+    expect(list).toHaveBeenCalledOnce();
+  });
+
+  it("keeps an authoritative literal when its exact search is truncated", async () => {
+    const { context, list } = contextFor(({ offset = 0 }) =>
+      result([], { hasMore: true, nextOffset: offset + 20, offset }),
+    );
+    const loaded = await loadChatRoute(
+      context,
+      { pathname: "/chat/roboclaw/existing-literal", search: "", hash: "" },
+      "chat",
+      new AbortController().signal,
+    );
+
+    expect(loaded).toEqual({
+      kind: "session",
+      sessionKey: "agent:roboclaw:existing-literal",
+      draft: undefined,
+      face: "chat",
+    });
+    expect(list).toHaveBeenCalledTimes(5);
+  });
+});

--- a/ui/src/pages/chat/route-resolution.test.ts
+++ b/ui/src/pages/chat/route-resolution.test.ts
@@ -332,9 +332,11 @@ describe("gateway-backed session route resolution", () => {
     if (!("kind" in loaded) || loaded.kind !== "ambiguous") {
       throw new Error("expected slug disambiguation");
     }
+    // Slug ties reuse the short-id disambiguation prefix instead of a full uuid, so the
+    // offered links stay as short as uniqueness allows.
     expect(loaded.candidates.map((candidate) => candidate.href)).toEqual([
-      "/chat/roboclaw/default-mode-with-rare-surprises-123456780aaa40008000000000000001",
-      "/chat/research/default-mode-with-rare-surprises-123456780bbb40008000000000000002",
+      "/chat/roboclaw/default-mode-with-rare-surprises-123456780a",
+      "/chat/research/default-mode-with-rare-surprises-123456780b",
     ]);
   });
 

--- a/ui/src/pages/chat/route.test.ts
+++ b/ui/src/pages/chat/route.test.ts
@@ -123,7 +123,7 @@ describe("loadChatRoute", () => {
     expect(list).not.toHaveBeenCalled();
   });
 
-  it("queries the full supplied prefix so longer disambiguation links can resolve", async () => {
+  it("queries the first uuid block so longer disambiguation links can resolve", async () => {
     const target = row({ key: "agent:main:dashboard:12345678-0aaa-4000-8000-000000000001" });
     const { context, list } = contextFor(result([target]));
     await expect(
@@ -140,8 +140,11 @@ describe("loadChatRoute", () => {
       face: "chat",
       shortId: "123456780a",
     });
-    expect(list).toHaveBeenCalledWith(expect.objectContaining({ search: "123456780a" }));
-    expect(list).not.toHaveBeenCalledWith(expect.objectContaining({ search: "12345678" }));
+    // Stored keys hold a hyphenated uuid, so "123456780a" is not a substring of anything
+    // the gateway searches. Only the first block survives as a needle; the full prefix is
+    // still applied per row, so the longer link resolves instead of 404ing.
+    expect(list).toHaveBeenCalledWith(expect.objectContaining({ search: "12345678" }));
+    expect(list).not.toHaveBeenCalledWith(expect.objectContaining({ search: "123456780a" }));
   });
 
   it("stops prefix pagination at the fixed bound and reports an incomplete result", async () => {

--- a/ui/src/pages/chat/route.test.ts
+++ b/ui/src/pages/chat/route.test.ts
@@ -381,14 +381,62 @@ describe("loadChatRoute", () => {
     expect(list).not.toHaveBeenCalled();
   });
 
+  it("reclassifies a slug-shaped path after cold defaults reveal the main key", async () => {
+    type GatewayListener = Parameters<ApplicationContext["gateway"]["subscribe"]>[0];
+    let listener: GatewayListener | null = null;
+    let snapshot = {
+      phase: "connecting",
+      client: null,
+      hello: null,
+    } as unknown as ApplicationContext["gateway"]["snapshot"];
+    const context = {
+      basePath: "",
+      gateway: {
+        get snapshot() {
+          return snapshot;
+        },
+        subscribe: (next: GatewayListener) => {
+          listener = next;
+          return () => undefined;
+        },
+      },
+      agents: { state: { agentsList: null } },
+    } as unknown as ApplicationContext;
+    const pending = loadChatRoute(
+      context,
+      { pathname: "/chat/research/workspace", search: "", hash: "" },
+      "chat",
+      new AbortController().signal,
+    );
+    let settled = false;
+    void pending.then(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    snapshot = {
+      phase: "connected",
+      client: {},
+      hello: { snapshot: { sessionDefaults: { mainKey: "workspace" } } },
+    } as unknown as ApplicationContext["gateway"]["snapshot"];
+    const connectedListener = listener as GatewayListener | null;
+    if (!connectedListener) {
+      throw new Error("expected gateway readiness subscription");
+    }
+    connectedListener(snapshot);
+
+    await expect(pending).resolves.toEqual({
+      kind: "session",
+      sessionKey: "agent:research:workspace",
+      draft: undefined,
+      face: "chat",
+      canonicalLocation: { pathname: "/chat/research", search: "", hash: "" },
+    });
+  });
+
   it("canonicalizes a literal configured-main route after cold defaults arrive", async () => {
     for (const [pathname, targetSessionKey, mainKey, expectedCanonicalLocation] of [
-      [
-        "/chat/research/workspace",
-        "agent:research:workspace",
-        "workspace",
-        { pathname: "/chat/research", search: "", hash: "" },
-      ],
       [
         "/chat/research/team/primary",
         "agent:research:team:primary",

--- a/ui/src/pages/sessions/sessions-page.ts
+++ b/ui/src/pages/sessions/sessions-page.ts
@@ -1404,6 +1404,7 @@ class SessionsPage extends OpenClawLightDomElement {
                 face,
                 sessionKey,
                 agentId: this.sessionPathAgentId(sessionKey, context),
+                preferenceDerivedFace: true,
               }).options,
               hash: "",
             });

--- a/ui/src/pages/sessions/view.ts
+++ b/ui/src/pages/sessions/view.ts
@@ -1516,6 +1516,7 @@ function renderRows(row: GatewaySessionRow, props: SessionsProps) {
         basePath: props.basePath,
         row,
         mainKey: props.mainKey,
+        preferenceDerivedFace: true,
       }).href
     : null;
   const displayKind = resolveSessionDisplayKind(row);

--- a/ui/src/pages/tasks/tasks-page.ts
+++ b/ui/src/pages/tasks/tasks-page.ts
@@ -12,6 +12,7 @@ import { hasOperatorWriteAccess } from "../../app/operator-access.ts";
 import { renderAgentScopeControl } from "../../components/agent-scope-control.ts";
 import { t } from "../../i18n/index.ts";
 import {
+  findUiSessionRow,
   resolveSessionPreferredFaceForKey,
   resolveSessionNavigationAgentId,
   sessionNavigationTarget,
@@ -383,7 +384,7 @@ class TasksPage extends OpenClawLightDomElement {
         error: this.error,
         tasks: this.tasks,
         cancellingTaskIds: this.cancellingTaskIds,
-        sessionFace: (sessionKey) => resolveSessionPreferredFaceForKey(this.context, sessionKey),
+        sessionRow: (sessionKey) => findUiSessionRow(this.context, sessionKey),
         onCancel: (taskId) => void this.cancelTask(taskId),
         onNavigateToChat: (sessionKey) => {
           const face = resolveSessionPreferredFaceForKey(this.context, sessionKey);
@@ -393,6 +394,7 @@ class TasksPage extends OpenClawLightDomElement {
               context: this.context,
               face,
               sessionKey,
+              preferenceDerivedFace: true,
             }).options,
           );
         },

--- a/ui/src/pages/tasks/view.ts
+++ b/ui/src/pages/tasks/view.ts
@@ -1,10 +1,13 @@
 import { html, nothing } from "lit";
 import { repeat } from "lit/directives/repeat.js";
+import type { GatewaySessionRow } from "../../api/types.ts";
 import { icon, type IconName } from "../../components/icons.ts";
 import { t } from "../../i18n/index.ts";
-import type { BoardFace } from "../../lib/board/settings.ts";
 import { formatMs, formatRelativeTimestamp } from "../../lib/format.ts";
-import { sessionNavigationTarget } from "../../lib/sessions/route-navigation.ts";
+import {
+  resolveSessionPreferredFace,
+  sessionNavigationTarget,
+} from "../../lib/sessions/route-navigation.ts";
 import {
   partitionTasks,
   taskDetail,
@@ -27,7 +30,7 @@ type TasksProps = {
   error: string | null;
   tasks: TaskSummary[];
   cancellingTaskIds: ReadonlySet<string>;
-  sessionFace: (sessionKey: string) => BoardFace;
+  sessionRow: (sessionKey: string) => GatewaySessionRow | undefined;
   onCancel: (taskId: string) => void;
   onNavigateToChat: (sessionKey: string) => void;
 };
@@ -37,13 +40,15 @@ function renderSessionLink(task: TaskSummary, props: TasksProps) {
   if (!sessionKey) {
     return nothing;
   }
-  const face = props.sessionFace(sessionKey);
+  const row = props.sessionRow(sessionKey);
   const href = sessionNavigationTarget({
-    face,
+    face: resolveSessionPreferredFace(row),
     sessionKey,
     fallbackAgentId: props.agentId,
     basePath: props.basePath,
     mainKey: props.mainKey,
+    row,
+    preferenceDerivedFace: true,
   }).href;
   return html`<a
     class="session-link"

--- a/ui/src/pages/workboard/workboard-page.ts
+++ b/ui/src/pages/workboard/workboard-page.ts
@@ -383,7 +383,12 @@ class WorkboardPage extends OpenClawLightDomElement {
         onOpenSession: (sessionKey) => {
           const face = resolveSessionPreferredFaceForKey(context, sessionKey);
           context.navigate(face, {
-            ...sessionNavigationTarget({ context, face, sessionKey }).options,
+            ...sessionNavigationTarget({
+              context,
+              face,
+              sessionKey,
+              preferenceDerivedFace: true,
+            }).options,
             hash: "",
           });
         },

--- a/ui/src/pages/worktrees/worktrees-page.test.ts
+++ b/ui/src/pages/worktrees/worktrees-page.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { WorktreeRecord } from "../../../../packages/gateway-protocol/src/index.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { ApplicationContext, ApplicationGatewaySnapshot } from "../../app/context.ts";
+import { SESSION_FACE_PREFERENCE_PARAM } from "../../lib/sessions/route-navigation.ts";
 import { waitForFast } from "../../test-helpers/wait-for.ts";
 import "./worktrees-page.ts";
 
@@ -112,6 +113,47 @@ afterEach(() => {
 });
 
 describe("WorktreesPage lifecycle", () => {
+  it("navigates a session-owned worktree with the face-preference marker", async () => {
+    // The owner key comes from a worktree record, not the cached session page, so its
+    // face is a guess: the in-app click must carry the marker while href stays clean.
+    const request = vi.fn(async (method: string) =>
+      method === "worktrees.list"
+        ? {
+            worktrees: [
+              {
+                ...worktree(),
+                ownerKind: "session" as const,
+                ownerId: "agent:main:thread:12345678-90ab-cdef-1234-567890abcdef",
+              },
+            ],
+          }
+        : {},
+    );
+    const context = {
+      ...contextWithGateway(gatewayWithClient({ request } as unknown as GatewayBrowserClient)),
+      // No cached sessions: the owner key is only known to the worktree record.
+      sessions: { state: { result: undefined } },
+      agents: { state: { agentsList: { mainKey: "main" } } },
+      agentSelection: { state: { selectedId: "main" } },
+    } as unknown as ApplicationContext;
+    const page = document.createElement("openclaw-worktrees-page") as WorktreesPageTestElement;
+    page.context = context;
+    document.body.append(page);
+    await waitForFast(() => expect(page.records.length).toBe(1));
+    await page.updateComplete;
+
+    const link = [...page.querySelectorAll("a")].find((anchor) =>
+      anchor.getAttribute("href")?.includes("12345678"),
+    );
+    expect(link?.getAttribute("href")).toBe("/chat/main/12345678");
+    link?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+
+    expect(context.navigate).toHaveBeenCalledWith("chat", {
+      pathname: "/chat/main/12345678",
+      search: `?${SESSION_FACE_PREFERENCE_PARAM}=1`,
+    });
+  });
+
   it("serializes list refreshes and row mutations", async () => {
     const record = worktree();
     const removedRecord = {

--- a/ui/src/pages/worktrees/worktrees-page.ts
+++ b/ui/src/pages/worktrees/worktrees-page.ts
@@ -5,6 +5,7 @@ import type { WorktreeRecord } from "../../../../packages/gateway-protocol/src/i
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import { titleForRoute } from "../../app-navigation.ts";
 import { applicationContext, type ApplicationContext } from "../../app/context.ts";
+import { shouldHandleNavigationClick } from "../../components/app-sidebar-nav-menus.ts";
 import { renderSessionsHubHeader } from "../../components/sessions-hub-header.ts";
 import {
   renderSettingsEmpty,
@@ -345,13 +346,26 @@ class WorktreesPage extends OpenClawLightDomElement {
   private renderOwner(record: WorktreeRecord) {
     if (record.ownerKind === "session" && record.ownerId) {
       const face = resolveSessionPreferredFaceForKey(this.context, record.ownerId);
-      const href = sessionNavigationTarget({
+      const target = sessionNavigationTarget({
         context: this.context,
         face,
         sessionKey: record.ownerId,
         preferenceDerivedFace: true,
-      }).href;
-      return html`<a href=${href} title=${record.ownerId}>${t("worktrees.ownerSession")}</a>`;
+      });
+      // The clean href stays shareable; the in-app click navigates with the options so an
+      // uncached owner still carries the marker that resolves its stored face.
+      return html`<a
+        href=${target.href}
+        title=${record.ownerId}
+        @click=${(event: MouseEvent) => {
+          if (!shouldHandleNavigationClick(event)) {
+            return;
+          }
+          event.preventDefault();
+          this.context.navigate(face, target.options);
+        }}
+        >${t("worktrees.ownerSession")}</a
+      >`;
     }
     if (record.ownerKind === "workboard") {
       return html`<span title=${record.ownerId ?? ""}>${t("worktrees.ownerWorkboard")}</span>`;

--- a/ui/src/pages/worktrees/worktrees-page.ts
+++ b/ui/src/pages/worktrees/worktrees-page.ts
@@ -349,6 +349,7 @@ class WorktreesPage extends OpenClawLightDomElement {
         context: this.context,
         face,
         sessionKey: record.ownerId,
+        preferenceDerivedFace: true,
       }).href;
       return html`<a href=${href} title=${record.ownerId}>${t("worktrees.ownerSession")}</a>`;
     }

--- a/ui/src/test-helpers/app-sidebar-cases/agent-menu.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/agent-menu.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import { SESSION_FACE_PREFERENCE_PARAM } from "../../lib/sessions/route-navigation.ts";
 import {
   createGateway,
   createGatewayHarness,
@@ -76,10 +77,12 @@ describe("AppSidebar agent chip", () => {
     );
     await sidebar.updateComplete;
 
-    // No cached sessions for the other agent: resume falls back to its main key.
+    // No cached sessions for the other agent: resume falls back to its main key, and
+    // the uncached face is a guess, so navigation is marked for gateway re-derivation.
     expect(setSessionKey).toHaveBeenCalledWith("agent:research:main");
     expect(onNavigate).toHaveBeenCalledWith("chat", {
       pathname: "/chat/research",
+      search: `?${SESSION_FACE_PREFERENCE_PARAM}=1`,
     });
     expect(sidebar.querySelector(".sidebar-agent-menu")).toBeNull();
   });

--- a/ui/src/test-helpers/app-sidebar-cases/basics.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/basics.ts
@@ -6,6 +6,7 @@ import {
   clearSessionBoardAvailability,
   recordSessionBoardAvailability,
 } from "../../lib/board/provider.ts";
+import { SESSION_FACE_PREFERENCE_PARAM } from "../../lib/sessions/route-navigation.ts";
 import {
   createGateway,
   createGatewayHarness,
@@ -483,9 +484,12 @@ describe("AppSidebar agent chip", () => {
     );
     await sidebar.updateComplete;
 
+    // Uncached agent main session: the face is a guess, so the navigation carries the
+    // marker that lets the chat loader re-derive it from the gateway.
     expect(setSessionKey).toHaveBeenCalledWith("agent:settings:main");
     expect(onNavigate).toHaveBeenCalledWith("chat", {
       pathname: "/chat/settings",
+      search: `?${SESSION_FACE_PREFERENCE_PARAM}=1`,
     });
     expect(onNavigate).not.toHaveBeenCalledWith("config");
   });


### PR DESCRIPTION
## What Problem This Solves

Session URLs resolved a thread's board face from whatever page of sessions the
browser happened to have cached. A thread outside that page fell back to chat,
so a dashboard thread opened as chat when it was reached from the command
palette, a pushed `ui.command`, a task, a worktree, or any deep link. The stored
`boardFace` from #114262 was durable and cross-device, but only actually applied
to threads the sidebar had already loaded.

The reference itself was also strict. `/chat/<agent>/<slug>-<shortId>` resolved,
but the bare `/chat/<agent>/<slug>` a person would actually type or remember did
not.

## Why This Change Was Made

The face question only has teeth when the row is unknown, so the fix is scoped to
that case rather than to every navigation.

`sessionNavigationTarget` already looks the row up to build the path. When it
finds one, that row carries the authoritative `boardFace` and nothing more is
needed — the URL stays clean and no request is made. When it does not, the face
is a guess, and the navigation (never the shareable `href`) carries an internal
marker. The chat loader sees the marker, resolves the row through the gateway,
adopts the stored face, and replaces the URL into the matching namespace. An
explicitly chosen `/chat` or `/dashboard` link is never rewritten, because only a
guess is ever marked.

Keeping the marker out of `href` matters: that string is what users hover, copy, and
share, and it must not carry an internal parameter. The accepted cost is that alternate
activation — middle-click, open-in-new-tab, modified click — follows the clean guessed
path and can land on the other face for an uncached session, exactly as every open did
before. The face is one click to change and that change persists, so this is a smaller
win than the intercepted click path, not a regression.

One-segment references now resolve short id, then literal key, then display-name
slug. Ties reuse the existing disambiguation view rather than guessing. A resolved
slug canonicalizes to the same short reference every other surface links to.

Both lookups had to account for how the gateway actually searches — `sessions.list`
matches `search` as a plain substring over stored keys and titles:

- Slug lookup sends the longest slug token, not the joined slug. `controlUiSessionSlug`
  builds every token from a contiguous alphanumeric run of the display name, so a token
  always matches, while `"fix auth bug"` would never have matched `Fix: auth bug`.
- Short-id lookup sends only the first uuid block. Stored keys hold a hyphenated uuid,
  so a hyphen-stripped reference past that block is a substring of nothing. This was a
  live bug for the disambiguation links already on `main`, which offer prefixes longer
  than eight characters and could not resolve.

In both cases the exact rule is still applied per row, so the wider needle only grows
the candidate set.

## User Impact

Opening a thread from the sidebar, Sessions, Tasks, Workboard, Worktrees, the
command palette, or a pushed command lands on the face that thread is actually
stored with, whether or not the browser had loaded it. `/chat/main/deploy-monitor`
resolves and canonicalizes itself. Shared links are unchanged and stay clean.

## Evidence

Verified in a browser against a full `pnpm build`, served by an isolated gateway
(own `OPENCLAW_STATE_DIR`, free port, seeded threads) — never the operator's
instance:

| Case | Input | Result |
| --- | --- | --- |
| Slug, punctuated name | `/chat/main/fix-auth-bug` | → `/chat/main/fix-auth-bug-aa11bb22`, "Fix: auth bug" |
| Slug, plain name | `/chat/main/weekly-standup` | → `/chat/main/weekly-standup-11223344` |
| Reference past first block | `/chat/main/fix-auth-bug-aa11bb220000` | resolves (404'd before the fix) |
| Full 32-char reference | `/chat/main/deploy-monitor-6db92d48…61a1` | resolves |
| Stored face, uncached | `/chat/main/6db92d48` + marker | → `/dashboard/main/deploy-monitor-6db92d48` |
| Explicit face | `/chat/main/deploy-monitor-6db92d48` | stays on `/chat` |
| Slug tie | `/chat/main/release-notes` | disambiguation view, short-id links |
| Tie candidate | `/chat/main/release-notes-cc33dd44` | resolves |
| Unknown slug | `/chat/main/no-such-session-here` | not found |
| Cached click | sidebar "Weekly standup" | clean URL, no marker, no request |
| Cached dashboard row | sidebar "Deploy monitor" | `href` is `/dashboard/...` directly |

Gates: `tsgo` ui/core/extensions/test-ui/test-packages, `pnpm build`, oxlint,
oxfmt, import cycles, knip deadcode, docs map, i18n verify, and the full UI +
contract suites (5931 passed). Codex autoreview run to clean.
