### PR TITLE
refactor: consolidate messaging plugin regression tests

### DIFF
--- a/extensions/discord/src/actions/runtime.test.ts
+++ b/extensions/discord/src/actions/runtime.test.ts
@@ -2893,11 +2893,40 @@ describe("handleDiscordGuildAction - channel management", () => {
     expect(createChannelDiscord).toHaveBeenCalled();
   });
 
-  it("uses thread permissions for Discord sender thread edits", async () => {
+  it.each<{
+    name: string;
+    params: { archived?: boolean; locked?: boolean };
+    previouslyLocked?: boolean;
+    permissions: bigint[];
+  }>([
+    {
+      name: "uses thread permissions for Discord sender thread edits",
+      params: { archived: true },
+      permissions: [PermissionFlagsBits.ManageThreads],
+    },
+    {
+      name: "requires ManageThreads for Discord sender thread unlocks",
+      params: { locked: false },
+      permissions: [PermissionFlagsBits.ManageThreads],
+    },
+    {
+      name: "requires ManageThreads to reopen locked Discord sender threads",
+      params: { archived: false },
+      previouslyLocked: true,
+      permissions: [PermissionFlagsBits.ManageThreads],
+    },
+    {
+      name: "allows SendMessagesInThreads for unlocked Discord sender thread reopens",
+      params: { archived: false },
+      previouslyLocked: false,
+      permissions: [PermissionFlagsBits.ManageThreads, PermissionFlagsBits.SendMessagesInThreads],
+    },
+  ])("$name", async ({ params, previouslyLocked, permissions }) => {
     const threadChannel = {
       id: "T1",
       type: ChannelType.GuildPublicThread,
       guild_id: "G1",
+      ...(previouslyLocked === undefined ? {} : { thread_metadata: { locked: previouslyLocked } }),
     };
     fetchChannelInfoDiscord
       .mockResolvedValueOnce(threadChannel)
@@ -2905,7 +2934,7 @@ describe("handleDiscordGuildAction - channel management", () => {
 
     await handleGuildAction(
       "channelEdit",
-      { channelId: "T1", archived: true, senderUserId: "sender-1" },
+      { channelId: "T1", senderUserId: "sender-1", ...params },
       channelsEnabled,
     );
 
@@ -2913,87 +2942,7 @@ describe("handleDiscordGuildAction - channel management", () => {
       "G1",
       "T1",
       "sender-1",
-      [PermissionFlagsBits.ManageThreads],
-      { cfg: DISCORD_TEST_CFG },
-    );
-    expect(editChannelDiscord).toHaveBeenCalled();
-  });
-
-  it("requires ManageThreads for Discord sender thread unlocks", async () => {
-    const threadChannel = {
-      id: "T1",
-      type: ChannelType.GuildPublicThread,
-      guild_id: "G1",
-    };
-    fetchChannelInfoDiscord
-      .mockResolvedValueOnce(threadChannel)
-      .mockResolvedValueOnce(threadChannel);
-
-    await handleGuildAction(
-      "channelEdit",
-      { channelId: "T1", locked: false, senderUserId: "sender-1" },
-      channelsEnabled,
-    );
-
-    expect(hasAnyChannelPermissionDiscord).toHaveBeenCalledWith(
-      "G1",
-      "T1",
-      "sender-1",
-      [PermissionFlagsBits.ManageThreads],
-      { cfg: DISCORD_TEST_CFG },
-    );
-    expect(editChannelDiscord).toHaveBeenCalled();
-  });
-
-  it("requires ManageThreads to reopen locked Discord sender threads", async () => {
-    const threadChannel = {
-      id: "T1",
-      type: ChannelType.GuildPublicThread,
-      guild_id: "G1",
-      thread_metadata: { locked: true },
-    };
-    fetchChannelInfoDiscord
-      .mockResolvedValueOnce(threadChannel)
-      .mockResolvedValueOnce(threadChannel);
-
-    await handleGuildAction(
-      "channelEdit",
-      { channelId: "T1", archived: false, senderUserId: "sender-1" },
-      channelsEnabled,
-    );
-
-    expect(hasAnyChannelPermissionDiscord).toHaveBeenCalledWith(
-      "G1",
-      "T1",
-      "sender-1",
-      [PermissionFlagsBits.ManageThreads],
-      { cfg: DISCORD_TEST_CFG },
-    );
-    expect(editChannelDiscord).toHaveBeenCalled();
-  });
-
-  it("allows SendMessagesInThreads for unlocked Discord sender thread reopens", async () => {
-    const threadChannel = {
-      id: "T1",
-      type: ChannelType.GuildPublicThread,
-      guild_id: "G1",
-      thread_metadata: { locked: false },
-    };
-    fetchChannelInfoDiscord
-      .mockResolvedValueOnce(threadChannel)
-      .mockResolvedValueOnce(threadChannel);
-
-    await handleGuildAction(
-      "channelEdit",
-      { channelId: "T1", archived: false, senderUserId: "sender-1" },
-      channelsEnabled,
-    );
-
-    expect(hasAnyChannelPermissionDiscord).toHaveBeenCalledWith(
-      "G1",
-      "T1",
-      "sender-1",
-      [PermissionFlagsBits.ManageThreads, PermissionFlagsBits.SendMessagesInThreads],
+      permissions,
       { cfg: DISCORD_TEST_CFG },
     );
     expect(editChannelDiscord).toHaveBeenCalled();

--- a/extensions/matrix/src/matrix/monitor/handler.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.test.ts
@@ -645,28 +645,6 @@ describe("matrix monitor handler pairing account scope", () => {
     expect(enqueueSystemEvent).not.toHaveBeenCalled();
   });
 
-  it("drops room messages from configured Matrix bot accounts when allowBots is off", async () => {
-    const { handler, recordInboundSession } = createMatrixHandlerTestHarness({
-      isDirectMessage: false,
-      configuredBotUserIds: new Set(["@ops:example.org"]),
-      roomsConfig: {
-        "!room:example.org": { requireMention: false },
-      },
-      getMemberDisplayName: async () => "ops-bot",
-    });
-
-    await handler(
-      "!room:example.org",
-      createMatrixTextMessageEvent({
-        eventId: "$bot-off",
-        sender: "@ops:example.org",
-        body: "hello from bot",
-      }),
-    );
-
-    expect(recordInboundSession).not.toHaveBeenCalled();
-  });
-
   it("accepts room messages from configured Matrix bot accounts when allowBots is true", async () => {
     const { handler, recordInboundSession, runPrepared } = createMatrixHandlerTestHarness({
       isDirectMessage: false,
@@ -706,118 +684,112 @@ describe("matrix monitor handler pairing account scope", () => {
     });
   });
 
-  it("does not treat unconfigured Matrix users as bots when allowBots is off", async () => {
-    const { handler, resolveAgentRoute, recordInboundSession } = createMatrixHandlerTestHarness({
-      isDirectMessage: false,
-      configuredBotUserIds: new Set(["@ops:example.org"]),
-      roomsConfig: {
-        "!room:example.org": { requireMention: false },
-      },
-      getMemberDisplayName: async () => "human",
-    });
-
-    await handler(
-      "!room:example.org",
-      createMatrixTextMessageEvent({
-        eventId: "$non-bot",
-        sender: "@alice:example.org",
-        body: "hello from human",
-      }),
-    );
-
-    expect(resolveAgentRoute).toHaveBeenCalled();
-    expect(recordInboundSession).toHaveBeenCalled();
-  });
-
-  it('drops configured Matrix bot room messages without a mention when allowBots="mentions"', async () => {
-    const { handler, recordInboundSession } = createMatrixHandlerTestHarness({
-      isDirectMessage: false,
-      accountAllowBots: "mentions",
-      configuredBotUserIds: new Set(["@ops:example.org"]),
-      roomsConfig: {
-        "!room:example.org": { requireMention: false },
-      },
-      mentionRegexes: [/@bot/i],
-      getMemberDisplayName: async () => "ops-bot",
-    });
-
-    await handler(
-      "!room:example.org",
-      createMatrixTextMessageEvent({
-        eventId: "$bot-mentions-off",
-        sender: "@ops:example.org",
-        body: "hello from bot",
-      }),
-    );
-
-    expect(recordInboundSession).not.toHaveBeenCalled();
-  });
-
-  it('accepts configured Matrix bot room messages with a mention when allowBots="mentions"', async () => {
-    const { handler, recordInboundSession } = createMatrixHandlerTestHarness({
-      isDirectMessage: false,
-      accountAllowBots: "mentions",
-      configuredBotUserIds: new Set(["@ops:example.org"]),
-      roomsConfig: {
-        "!room:example.org": { requireMention: false },
-      },
-      mentionRegexes: [/@bot/i],
-      getMemberDisplayName: async () => "ops-bot",
-    });
-
-    await handler(
-      "!room:example.org",
-      createMatrixTextMessageEvent({
-        eventId: "$bot-mentions-on",
-        sender: "@ops:example.org",
-        body: "hello @bot",
-        mentions: { user_ids: ["@bot:example.org"] },
-      }),
-    );
-
-    expect(recordInboundSession).toHaveBeenCalled();
-  });
-
-  it('accepts configured Matrix bot DMs without a mention when allowBots="mentions"', async () => {
-    const { handler, recordInboundSession } = createMatrixHandlerTestHarness({
+  it.each<{
+    name: string;
+    eventId: string;
+    sender: string;
+    body: string;
+    accepted: boolean;
+    accountAllowBots?: boolean | "mentions";
+    mentions?: { user_ids: string[] };
+    roomAllowBots?: boolean;
+    isDirectMessage?: boolean;
+    verifyRoute?: boolean;
+  }>([
+    {
+      name: "drops room messages from configured Matrix bot accounts when allowBots is off",
+      eventId: "$bot-off",
+      sender: "@ops:example.org",
+      body: "hello from bot",
+      accepted: false,
+    },
+    {
+      name: "does not treat unconfigured Matrix users as bots when allowBots is off",
+      eventId: "$non-bot",
+      sender: "@alice:example.org",
+      body: "hello from human",
+      accepted: true,
+      verifyRoute: true,
+    },
+    {
+      name: 'drops configured Matrix bot room messages without a mention when allowBots="mentions"',
+      eventId: "$bot-mentions-off",
+      sender: "@ops:example.org",
+      body: "hello from bot",
+      accountAllowBots: "mentions" as const,
+      accepted: false,
+    },
+    {
+      name: 'accepts configured Matrix bot room messages with a mention when allowBots="mentions"',
+      eventId: "$bot-mentions-on",
+      sender: "@ops:example.org",
+      body: "hello @bot",
+      mentions: { user_ids: ["@bot:example.org"] },
+      accountAllowBots: "mentions" as const,
+      accepted: true,
+    },
+    {
+      name: 'accepts configured Matrix bot DMs without a mention when allowBots="mentions"',
+      eventId: "$bot-dm-mentions",
+      sender: "@ops:example.org",
+      body: "hello from dm bot",
+      accountAllowBots: "mentions" as const,
       isDirectMessage: true,
-      accountAllowBots: "mentions",
-      configuredBotUserIds: new Set(["@ops:example.org"]),
-      getMemberDisplayName: async () => "ops-bot",
-    });
-
-    await handler(
-      "!dm:example.org",
-      createMatrixTextMessageEvent({
-        eventId: "$bot-dm-mentions",
-        sender: "@ops:example.org",
-        body: "hello from dm bot",
-      }),
-    );
-
-    expect(recordInboundSession).toHaveBeenCalled();
-  });
-
-  it("lets room-level allowBots override a permissive account default", async () => {
-    const { handler, recordInboundSession } = createMatrixHandlerTestHarness({
-      isDirectMessage: false,
+      accepted: true,
+    },
+    {
+      name: "lets room-level allowBots override a permissive account default",
+      eventId: "$bot-room-override",
+      sender: "@ops:example.org",
+      body: "hello from bot",
       accountAllowBots: true,
+      roomAllowBots: false,
+      accepted: false,
+    },
+  ])("$name", async (scenario) => {
+    const isDirectMessage = scenario.isDirectMessage ?? false;
+    const roomId = isDirectMessage ? "!dm:example.org" : "!room:example.org";
+    const { handler, resolveAgentRoute, recordInboundSession } = createMatrixHandlerTestHarness({
+      isDirectMessage,
+      ...(scenario.accountAllowBots === undefined
+        ? {}
+        : { accountAllowBots: scenario.accountAllowBots }),
       configuredBotUserIds: new Set(["@ops:example.org"]),
-      roomsConfig: {
-        "!room:example.org": { requireMention: false, allowBots: false },
-      },
-      getMemberDisplayName: async () => "ops-bot",
+      ...(isDirectMessage
+        ? {}
+        : {
+            roomsConfig: {
+              "!room:example.org": {
+                requireMention: false,
+                ...(scenario.roomAllowBots === undefined
+                  ? {}
+                  : { allowBots: scenario.roomAllowBots }),
+              },
+            },
+          }),
+      ...(scenario.accountAllowBots === "mentions" && !isDirectMessage
+        ? { mentionRegexes: [/@bot/i] }
+        : {}),
+      getMemberDisplayName: async () => (scenario.verifyRoute ? "human" : "ops-bot"),
     });
 
     await handler(
-      "!room:example.org",
+      roomId,
       createMatrixTextMessageEvent({
-        eventId: "$bot-room-override",
-        sender: "@ops:example.org",
-        body: "hello from bot",
+        eventId: scenario.eventId,
+        sender: scenario.sender,
+        body: scenario.body,
+        ...(scenario.mentions ? { mentions: scenario.mentions } : {}),
       }),
     );
 
+    if (scenario.accepted) {
+      expect(recordInboundSession).toHaveBeenCalled();
+      if (scenario.verifyRoute) {
+        expect(resolveAgentRoute).toHaveBeenCalled();
+      }
+      return;
+    }
     expect(recordInboundSession).not.toHaveBeenCalled();
   });
 
@@ -3606,7 +3578,16 @@ describe("matrix monitor handler draft streaming", () => {
     await finish();
   });
 
-  it("redacts partial previews before normal final delivery for unchanged Matrix mentions", async () => {
+  it.each([
+    {
+      name: "redacts partial previews before normal final delivery for unchanged Matrix mentions",
+      finalText: "hello @alice:example.org",
+    },
+    {
+      name: "redacts partial previews before normal final delivery for changed Matrix mentions",
+      finalText: "hello @alice:example.org!",
+    },
+  ])("$name", async ({ finalText }) => {
     const { dispatch, redactEventMock } = createStreamingHarness({
       blockStreamingEnabled: true,
       streaming: "partial",
@@ -3618,7 +3599,7 @@ describe("matrix monitor handler draft streaming", () => {
       expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(1);
     });
 
-    await deliver({ text: "hello @alice:example.org" }, { kind: "final" });
+    await deliver({ text: finalText }, { kind: "final" });
 
     expect(editMessageMatrixMock).not.toHaveBeenCalled();
     expect(redactEventMock).toHaveBeenCalledWith("!room:example.org", "$draft1");
@@ -3628,33 +3609,7 @@ describe("matrix monitor handler draft streaming", () => {
       "deliver replies params",
     );
     const replies = requireArray(deliverParams.replies, "delivered replies");
-    expect(requireRecord(replies[0], "delivered reply").text).toBe("hello @alice:example.org");
-    await finish();
-  });
-
-  it("redacts partial previews before normal final delivery for changed Matrix mentions", async () => {
-    const { dispatch, redactEventMock } = createStreamingHarness({
-      blockStreamingEnabled: true,
-      streaming: "partial",
-    });
-    const { deliver, opts, finish } = await dispatch();
-
-    opts.onPartialReply?.({ text: "hello @alice:example.org" });
-    await waitForMatrixState(() => {
-      expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(1);
-    });
-
-    await deliver({ text: "hello @alice:example.org!" }, { kind: "final" });
-
-    expect(editMessageMatrixMock).not.toHaveBeenCalled();
-    expect(redactEventMock).toHaveBeenCalledWith("!room:example.org", "$draft1");
-    expect(deliverMatrixRepliesMock).toHaveBeenCalledTimes(1);
-    const deliverParams = requireRecord(
-      callArg(deliverMatrixRepliesMock, 0, 0, "deliver replies params"),
-      "deliver replies params",
-    );
-    const replies = requireArray(deliverParams.replies, "delivered replies");
-    expect(requireRecord(replies[0], "delivered reply").text).toBe("hello @alice:example.org!");
+    expect(requireRecord(replies[0], "delivered reply").text).toBe(finalText);
     await finish();
   });
 
@@ -4691,97 +4646,45 @@ describe("matrix monitor handler draft streaming", () => {
 });
 
 describe("matrix monitor handler block streaming config", () => {
-  it("keeps final-only delivery when draft streaming is off by default", async () => {
-    let capturedDisableBlockStreaming: boolean | undefined;
-
-    const { handler } = createMatrixHandlerTestHarness({
+  it.each<{
+    name: string;
+    streaming: "off" | "partial" | "quiet";
+    blockStreamingEnabled?: boolean;
+    disableBlockStreaming: boolean;
+  }>([
+    {
+      name: "keeps final-only delivery when draft streaming is off by default",
       streaming: "off",
-      dispatchInboundMessage: vi.fn(
-        async (args: { replyOptions?: { disableBlockStreaming?: boolean } }) => {
-          capturedDisableBlockStreaming = args.replyOptions?.disableBlockStreaming;
-          return { queuedFinal: false, counts: { final: 0, block: 0, tool: 0 } };
-        },
-      ) as never,
-    });
-
-    await handler(
-      "!room:example.org",
-      createMatrixTextMessageEvent({ eventId: "$msg1", body: "hello" }),
-    );
-
-    expect(capturedDisableBlockStreaming).toBe(true);
-  });
-
-  it("keeps block streaming disabled when partial previews are on and block streaming is off", async () => {
-    let capturedDisableBlockStreaming: boolean | undefined;
-
-    const { handler } = createMatrixHandlerTestHarness({
+      disableBlockStreaming: true,
+    },
+    {
+      name: "keeps block streaming disabled when partial previews are on and block streaming is off",
       streaming: "partial",
-      dispatchInboundMessage: vi.fn(
-        async (args: { replyOptions?: { disableBlockStreaming?: boolean } }) => {
-          capturedDisableBlockStreaming = args.replyOptions?.disableBlockStreaming;
-          return { queuedFinal: false, counts: { final: 0, block: 0, tool: 0 } };
-        },
-      ) as never,
-    });
-
-    await handler(
-      "!room:example.org",
-      createMatrixTextMessageEvent({ eventId: "$msg1", body: "hello" }),
-    );
-
-    expect(capturedDisableBlockStreaming).toBe(true);
-  });
-
-  it("keeps block streaming disabled when quiet previews are on and block streaming is off", async () => {
-    let capturedDisableBlockStreaming: boolean | undefined;
-
-    const { handler } = createMatrixHandlerTestHarness({
+      disableBlockStreaming: true,
+    },
+    {
+      name: "keeps block streaming disabled when quiet previews are on and block streaming is off",
       streaming: "quiet",
-      dispatchInboundMessage: vi.fn(
-        async (args: { replyOptions?: { disableBlockStreaming?: boolean } }) => {
-          capturedDisableBlockStreaming = args.replyOptions?.disableBlockStreaming;
-          return { queuedFinal: false, counts: { final: 0, block: 0, tool: 0 } };
-        },
-      ) as never,
-    });
-
-    await handler(
-      "!room:example.org",
-      createMatrixTextMessageEvent({ eventId: "$msg1", body: "hello" }),
-    );
-
-    expect(capturedDisableBlockStreaming).toBe(true);
-  });
-
-  it("allows shared block streaming when partial previews and block streaming are both enabled", async () => {
-    let capturedDisableBlockStreaming: boolean | undefined;
-
-    const { handler } = createMatrixHandlerTestHarness({
+      disableBlockStreaming: true,
+    },
+    {
+      name: "allows shared block streaming when partial previews and block streaming are both enabled",
       streaming: "partial",
       blockStreamingEnabled: true,
-      dispatchInboundMessage: vi.fn(
-        async (args: { replyOptions?: { disableBlockStreaming?: boolean } }) => {
-          capturedDisableBlockStreaming = args.replyOptions?.disableBlockStreaming;
-          return { queuedFinal: false, counts: { final: 0, block: 0, tool: 0 } };
-        },
-      ) as never,
-    });
-
-    await handler(
-      "!room:example.org",
-      createMatrixTextMessageEvent({ eventId: "$msg1", body: "hello" }),
-    );
-
-    expect(capturedDisableBlockStreaming).toBe(false);
-  });
-
-  it("uses shared block streaming when explicitly enabled for Matrix", async () => {
+      disableBlockStreaming: false,
+    },
+    {
+      name: "uses shared block streaming when explicitly enabled for Matrix",
+      streaming: "off",
+      blockStreamingEnabled: true,
+      disableBlockStreaming: false,
+    },
+  ])("$name", async ({ streaming, blockStreamingEnabled, disableBlockStreaming }) => {
     let capturedDisableBlockStreaming: boolean | undefined;
 
     const { handler } = createMatrixHandlerTestHarness({
-      streaming: "off",
-      blockStreamingEnabled: true,
+      streaming,
+      ...(blockStreamingEnabled === undefined ? {} : { blockStreamingEnabled }),
       dispatchInboundMessage: vi.fn(
         async (args: { replyOptions?: { disableBlockStreaming?: boolean } }) => {
           capturedDisableBlockStreaming = args.replyOptions?.disableBlockStreaming;
@@ -4795,7 +4698,7 @@ describe("matrix monitor handler block streaming config", () => {
       createMatrixTextMessageEvent({ eventId: "$msg1", body: "hello" }),
     );
 
-    expect(capturedDisableBlockStreaming).toBe(false);
+    expect(capturedDisableBlockStreaming).toBe(disableBlockStreaming);
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/extensions/slack/src/monitor/events/interactions.test.ts
+++ b/extensions/slack/src/monitor/events/interactions.test.ts
@@ -2368,13 +2368,86 @@ describe("registerSlackInteractionEvents", () => {
     });
   });
 
-  it("blocks block actions from users outside configured channel users allowlist", async () => {
-    enqueueSystemEventMock.mockClear();
-    const { ctx, app, getHandler } = createContext({
-      channelsConfig: {
-        C1: { users: ["U_ALLOWED"] },
+  it.each([
+    {
+      name: "blocks block actions from users outside configured channel users allowlist",
+      overrides: { channelsConfig: { C1: { users: ["U_ALLOWED"] } } },
+      senderId: "U_DENIED",
+      channelId: "C1",
+      timestamp: "201.202",
+      allowed: false,
+    },
+    {
+      name: "blocks channel block actions when sender is outside configured global allowFrom",
+      overrides: { allowFrom: ["U_OWNER"] },
+      senderId: "U_ATTACKER",
+      channelId: "C1",
+      timestamp: "250.251",
+      allowed: false,
+    },
+    {
+      name: "allows channel block actions when channel users allowlist authorizes the sender",
+      overrides: {
+        allowFrom: ["U_OWNER"],
+        channelsConfig: { C1: { users: ["U_ALLOWED"] } },
       },
-    });
+      senderId: "U_ALLOWED",
+      channelId: "C1",
+      timestamp: "260.261",
+      allowed: true,
+    },
+    {
+      name: "blocks wildcard global allowFrom from bypassing configured channel users",
+      overrides: {
+        allowFrom: ["*"],
+        channelsConfig: { C1: { users: ["U_ALLOWED"] } },
+      },
+      senderId: "U_ATTACKER",
+      channelId: "C1",
+      timestamp: "270.271",
+      allowed: false,
+    },
+    {
+      name: "keeps channel block actions open when no allowlists are configured",
+      overrides: { allowFrom: [] },
+      senderId: "U_ANYONE",
+      channelId: "C1",
+      timestamp: "305.306",
+      allowed: true,
+    },
+    {
+      name: "blocks DM block actions when sender is not in allowFrom",
+      overrides: { dmPolicy: "allowlist" as const, allowFrom: ["U_OWNER"] },
+      senderId: "U_ATTACKER",
+      channelId: "D222",
+      timestamp: "301.302",
+      allowed: false,
+    },
+    {
+      name: "blocks MPIM block actions when sender is outside configured allowFrom",
+      overrides: {
+        allowFrom: ["U_OWNER"],
+        resolveChannelName: async () => ({ name: "group-dm", type: "mpim" as const }),
+      },
+      senderId: "U_ATTACKER",
+      channelId: "G_MPIM",
+      timestamp: "311.312",
+      allowed: false,
+    },
+    {
+      name: "allows MPIM block actions when sender is in configured allowFrom",
+      overrides: {
+        allowFrom: ["U_OWNER"],
+        resolveChannelName: async () => ({ name: "group-dm", type: "mpim" as const }),
+      },
+      senderId: "U_OWNER",
+      channelId: "G_MPIM",
+      timestamp: "313.314",
+      allowed: true,
+    },
+  ])("$name", async ({ overrides, senderId, channelId, timestamp, allowed }) => {
+    enqueueSystemEventMock.mockClear();
+    const { ctx, app, getHandler } = createContext(overrides);
     registerSlackInteractionEvents({ ctx: ctx as never });
     const handler = getHandler();
 
@@ -2384,10 +2457,10 @@ describe("registerSlackInteractionEvents", () => {
       ack,
       respond,
       body: {
-        user: { id: "U_DENIED" },
-        channel: { id: "C1" },
+        user: { id: senderId },
+        channel: { id: channelId },
         message: {
-          ts: "201.202",
+          ts: timestamp,
           blocks: [{ type: "actions", block_id: "verify_block", elements: [] }],
         },
       },
@@ -2399,269 +2472,18 @@ describe("registerSlackInteractionEvents", () => {
     });
 
     expect(ack).toHaveBeenCalled();
+    if (allowed) {
+      expect(enqueueSystemEventMock).toHaveBeenCalledTimes(1);
+      expect(app.client.chat.update).toHaveBeenCalledTimes(1);
+      expect(respond).not.toHaveBeenCalled();
+      return;
+    }
     expect(enqueueSystemEventMock).not.toHaveBeenCalled();
     expect(app.client.chat.update).not.toHaveBeenCalled();
     expect(respond).toHaveBeenCalledWith({
       text: "You are not authorized to use this control.",
       response_type: "ephemeral",
     });
-  });
-
-  it("blocks channel block actions when sender is outside configured global allowFrom", async () => {
-    enqueueSystemEventMock.mockClear();
-    const { ctx, app, getHandler } = createContext({
-      allowFrom: ["U_OWNER"],
-    });
-    registerSlackInteractionEvents({ ctx: ctx as never });
-    const handler = getHandler();
-
-    const ack = vi.fn().mockResolvedValue(undefined);
-    const respond = vi.fn().mockResolvedValue(undefined);
-    await handler({
-      ack,
-      respond,
-      body: {
-        user: { id: "U_ATTACKER" },
-        channel: { id: "C1" },
-        message: {
-          ts: "250.251",
-          blocks: [{ type: "actions", block_id: "verify_block", elements: [] }],
-        },
-      },
-      action: {
-        type: "button",
-        action_id: "openclaw:verify",
-        block_id: "verify_block",
-      },
-    });
-
-    expect(ack).toHaveBeenCalled();
-    expect(enqueueSystemEventMock).not.toHaveBeenCalled();
-    expect(app.client.chat.update).not.toHaveBeenCalled();
-    expect(respond).toHaveBeenCalledWith({
-      text: "You are not authorized to use this control.",
-      response_type: "ephemeral",
-    });
-  });
-
-  it("allows channel block actions when channel users allowlist authorizes the sender", async () => {
-    enqueueSystemEventMock.mockClear();
-    const { ctx, app, getHandler } = createContext({
-      allowFrom: ["U_OWNER"],
-      channelsConfig: {
-        C1: { users: ["U_ALLOWED"] },
-      },
-    });
-    registerSlackInteractionEvents({ ctx: ctx as never });
-    const handler = getHandler();
-
-    const ack = vi.fn().mockResolvedValue(undefined);
-    const respond = vi.fn().mockResolvedValue(undefined);
-    await handler({
-      ack,
-      respond,
-      body: {
-        user: { id: "U_ALLOWED" },
-        channel: { id: "C1" },
-        message: {
-          ts: "260.261",
-          blocks: [{ type: "actions", block_id: "verify_block", elements: [] }],
-        },
-      },
-      action: {
-        type: "button",
-        action_id: "openclaw:verify",
-        block_id: "verify_block",
-      },
-    });
-
-    expect(ack).toHaveBeenCalled();
-    expect(enqueueSystemEventMock).toHaveBeenCalledTimes(1);
-    expect(app.client.chat.update).toHaveBeenCalledTimes(1);
-    expect(respond).not.toHaveBeenCalled();
-  });
-
-  it("blocks wildcard global allowFrom from bypassing configured channel users", async () => {
-    enqueueSystemEventMock.mockClear();
-    const { ctx, app, getHandler } = createContext({
-      allowFrom: ["*"],
-      channelsConfig: {
-        C1: { users: ["U_ALLOWED"] },
-      },
-    });
-    registerSlackInteractionEvents({ ctx: ctx as never });
-    const handler = getHandler();
-
-    const ack = vi.fn().mockResolvedValue(undefined);
-    const respond = vi.fn().mockResolvedValue(undefined);
-    await handler({
-      ack,
-      respond,
-      body: {
-        user: { id: "U_ATTACKER" },
-        channel: { id: "C1" },
-        message: {
-          ts: "270.271",
-          blocks: [{ type: "actions", block_id: "verify_block", elements: [] }],
-        },
-      },
-      action: {
-        type: "button",
-        action_id: "openclaw:verify",
-        block_id: "verify_block",
-      },
-    });
-
-    expect(ack).toHaveBeenCalled();
-    expect(enqueueSystemEventMock).not.toHaveBeenCalled();
-    expect(app.client.chat.update).not.toHaveBeenCalled();
-    expect(respond).toHaveBeenCalledWith({
-      text: "You are not authorized to use this control.",
-      response_type: "ephemeral",
-    });
-  });
-
-  it("keeps channel block actions open when no allowlists are configured", async () => {
-    enqueueSystemEventMock.mockClear();
-    const { ctx, app, getHandler } = createContext({ allowFrom: [] });
-    registerSlackInteractionEvents({ ctx: ctx as never });
-    const handler = getHandler();
-
-    const ack = vi.fn().mockResolvedValue(undefined);
-    const respond = vi.fn().mockResolvedValue(undefined);
-    await handler({
-      ack,
-      respond,
-      body: {
-        user: { id: "U_ANYONE" },
-        channel: { id: "C1" },
-        message: {
-          ts: "305.306",
-          blocks: [{ type: "actions", block_id: "verify_block", elements: [] }],
-        },
-      },
-      action: {
-        type: "button",
-        action_id: "openclaw:verify",
-        block_id: "verify_block",
-      },
-    });
-
-    expect(ack).toHaveBeenCalled();
-    expect(enqueueSystemEventMock).toHaveBeenCalledTimes(1);
-    expect(app.client.chat.update).toHaveBeenCalledTimes(1);
-    expect(respond).not.toHaveBeenCalled();
-  });
-
-  it("blocks DM block actions when sender is not in allowFrom", async () => {
-    enqueueSystemEventMock.mockClear();
-    const { ctx, app, getHandler } = createContext({
-      dmPolicy: "allowlist",
-      allowFrom: ["U_OWNER"],
-    });
-    registerSlackInteractionEvents({ ctx: ctx as never });
-    const handler = getHandler();
-
-    const ack = vi.fn().mockResolvedValue(undefined);
-    const respond = vi.fn().mockResolvedValue(undefined);
-    await handler({
-      ack,
-      respond,
-      body: {
-        user: { id: "U_ATTACKER" },
-        channel: { id: "D222" },
-        message: {
-          ts: "301.302",
-          blocks: [{ type: "actions", block_id: "verify_block", elements: [] }],
-        },
-      },
-      action: {
-        type: "button",
-        action_id: "openclaw:verify",
-        block_id: "verify_block",
-      },
-    });
-
-    expect(ack).toHaveBeenCalled();
-    expect(enqueueSystemEventMock).not.toHaveBeenCalled();
-    expect(app.client.chat.update).not.toHaveBeenCalled();
-    expect(respond).toHaveBeenCalledWith({
-      text: "You are not authorized to use this control.",
-      response_type: "ephemeral",
-    });
-  });
-
-  it("blocks MPIM block actions when sender is outside configured allowFrom", async () => {
-    enqueueSystemEventMock.mockClear();
-    const { ctx, app, getHandler } = createContext({
-      allowFrom: ["U_OWNER"],
-      resolveChannelName: async () => ({ name: "group-dm", type: "mpim" }),
-    });
-    registerSlackInteractionEvents({ ctx: ctx as never });
-    const handler = getHandler();
-
-    const ack = vi.fn().mockResolvedValue(undefined);
-    const respond = vi.fn().mockResolvedValue(undefined);
-    await handler({
-      ack,
-      respond,
-      body: {
-        user: { id: "U_ATTACKER" },
-        channel: { id: "G_MPIM" },
-        message: {
-          ts: "311.312",
-          blocks: [{ type: "actions", block_id: "verify_block", elements: [] }],
-        },
-      },
-      action: {
-        type: "button",
-        action_id: "openclaw:verify",
-        block_id: "verify_block",
-      },
-    });
-
-    expect(ack).toHaveBeenCalled();
-    expect(enqueueSystemEventMock).not.toHaveBeenCalled();
-    expect(app.client.chat.update).not.toHaveBeenCalled();
-    expect(respond).toHaveBeenCalledWith({
-      text: "You are not authorized to use this control.",
-      response_type: "ephemeral",
-    });
-  });
-
-  it("allows MPIM block actions when sender is in configured allowFrom", async () => {
-    enqueueSystemEventMock.mockClear();
-    const { ctx, app, getHandler } = createContext({
-      allowFrom: ["U_OWNER"],
-      resolveChannelName: async () => ({ name: "group-dm", type: "mpim" }),
-    });
-    registerSlackInteractionEvents({ ctx: ctx as never });
-    const handler = getHandler();
-
-    const ack = vi.fn().mockResolvedValue(undefined);
-    const respond = vi.fn().mockResolvedValue(undefined);
-    await handler({
-      ack,
-      respond,
-      body: {
-        user: { id: "U_OWNER" },
-        channel: { id: "G_MPIM" },
-        message: {
-          ts: "313.314",
-          blocks: [{ type: "actions", block_id: "verify_block", elements: [] }],
-        },
-      },
-      action: {
-        type: "button",
-        action_id: "openclaw:verify",
-        block_id: "verify_block",
-      },
-    });
-
-    expect(ack).toHaveBeenCalled();
-    expect(enqueueSystemEventMock).toHaveBeenCalledTimes(1);
-    expect(app.client.chat.update).toHaveBeenCalledTimes(1);
-    expect(respond).not.toHaveBeenCalled();
   });
 
   it("ignores malformed action payloads after ack and logs warning", async () => {

--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -3009,9 +3009,13 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     expectDeliverReplyCall(0, FINAL_REPLY_TEXT);
   });
 
-  it("starts native Slack progress from typed plan steps", async () => {
-    await dispatchNativeProgressScenario({
-      finalPayload: { text: FINAL_REPLY_TEXT },
+  it.each<{
+    name: string;
+    events: typeof mockedReplyOptionEvents;
+    updates: Parameters<typeof expectNativeProgressStart>[0];
+  }>([
+    {
+      name: "starts native Slack progress from typed plan steps",
       events: [
         {
           kind: "plan",
@@ -3024,19 +3028,15 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
           ],
         },
       ],
-    });
-
-    expectNativeProgressStart([
-      planUpdate("Executing the checklist."),
-      taskUpdate("plan_step_1", "Inspect", "complete"),
-      taskUpdate("plan_step_2", "Patch", "in_progress"),
-      taskUpdate("plan_step_3", "Test", "pending"),
-    ]);
-  });
-
-  it("keeps plan explanation in native chunks alongside a fresh preamble", async () => {
-    await dispatchNativeProgressScenario({
-      finalPayload: { text: FINAL_REPLY_TEXT },
+      updates: [
+        planUpdate("Executing the checklist."),
+        taskUpdate("plan_step_1", "Inspect", "complete"),
+        taskUpdate("plan_step_2", "Patch", "in_progress"),
+        taskUpdate("plan_step_3", "Test", "pending"),
+      ],
+    },
+    {
+      name: "keeps plan explanation in native chunks alongside a fresh preamble",
       events: [
         {
           kind: "item",
@@ -3051,17 +3051,13 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
           steps: [{ step: "Patch", status: "in_progress" }],
         },
       ],
-    });
-
-    expectNativeProgressStart([
-      planUpdate("Checking the workspace — Executing the checklist."),
-      taskUpdate("plan_step_1", "Patch", "in_progress"),
-    ]);
-  });
-
-  it("starts native Slack progress from an explanation-only plan", async () => {
-    await dispatchNativeProgressScenario({
-      finalPayload: { text: FINAL_REPLY_TEXT },
+      updates: [
+        planUpdate("Checking the workspace — Executing the checklist."),
+        taskUpdate("plan_step_1", "Patch", "in_progress"),
+      ],
+    },
+    {
+      name: "starts native Slack progress from an explanation-only plan",
       events: [
         {
           kind: "plan",
@@ -3070,12 +3066,21 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
           steps: [],
         },
       ],
+      updates: [
+        planUpdate("Reviewing the implementation."),
+        taskUpdate(
+          expect.any(String),
+          "Update Plan — Reviewing the implementation.",
+          "in_progress",
+        ),
+      ],
+    },
+  ])("$name", async ({ events, updates }) => {
+    await dispatchNativeProgressScenario({
+      finalPayload: { text: FINAL_REPLY_TEXT },
+      events,
     });
-
-    expectNativeProgressStart([
-      planUpdate("Reviewing the implementation."),
-      taskUpdate(expect.any(String), "Update Plan — Reviewing the implementation.", "in_progress"),
-    ]);
+    expectNativeProgressStart(updates);
   });
 
   it("starts native Slack progress from a retained headline when tool rows are hidden", async () => {
@@ -4897,7 +4902,16 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     expect(deliverRepliesMock).toHaveBeenCalledTimes(1);
   });
 
-  it("routes pending native stream text through chunked sender when finalize fails before the SDK buffer flushes", async () => {
+  it.each([
+    {
+      name: "routes pending native stream text through chunked sender when finalize fails before the SDK buffer flushes",
+      slackCode: "user_not_found",
+    },
+    {
+      name: "routes pending native stream text through chunked sender for unexpected finalize failures",
+      slackCode: "method_not_supported_for_channel_type",
+    },
+  ])("$name", async ({ slackCode }) => {
     mockedNativeStreaming = true;
     const session = {
       channel: "C123",
@@ -4908,7 +4922,7 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     };
     startSlackStreamMock.mockResolvedValueOnce(session);
     stopSlackStreamMock.mockRejectedValueOnce(
-      new TestSlackStreamNotDeliveredError(FINAL_REPLY_TEXT, "user_not_found"),
+      new TestSlackStreamNotDeliveredError(FINAL_REPLY_TEXT, slackCode),
     );
 
     await dispatchPreparedSlackMessage(createPreparedSlackMessage());
@@ -4916,36 +4930,13 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     expect(postMessageMock).not.toHaveBeenCalled();
     expect(deliverRepliesMock).toHaveBeenCalledTimes(1);
     expectDeliverReplyCall(0, FINAL_REPLY_TEXT);
-    expect(session.stopped).toBe(true);
-  });
-
-  it("routes pending native stream text through chunked sender for unexpected finalize failures", async () => {
-    mockedNativeStreaming = true;
-    const session = {
-      channel: "C123",
-      threadTs: THREAD_TS,
-      stopped: false,
-      delivered: false,
-      pendingText: FINAL_REPLY_TEXT,
-    };
-    startSlackStreamMock.mockResolvedValueOnce(session);
-    stopSlackStreamMock.mockRejectedValueOnce(
-      new TestSlackStreamNotDeliveredError(
-        FINAL_REPLY_TEXT,
-        "method_not_supported_for_channel_type",
-      ),
-    );
-
-    await dispatchPreparedSlackMessage(createPreparedSlackMessage());
-
-    expect(postMessageMock).not.toHaveBeenCalled();
-    expect(deliverRepliesMock).toHaveBeenCalledTimes(1);
     expect(deliverRepliesMock).toHaveBeenCalledWith(
       expect.objectContaining({
         replyThreadTs: THREAD_TS,
         replies: [expect.objectContaining({ text: FINAL_REPLY_TEXT })],
       }),
     );
+    // Failed native streams must stop before either fallback can deliver the buffered reply.
     expect(session.stopped).toBe(true);
   });
 

--- a/extensions/slack/src/monitor/message-handler/prepare.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.test.ts
@@ -1698,38 +1698,24 @@ describe("slack prepareSlackMessage inbound contract", () => {
     expect(prepared.ctxPayload.RawBody).toContain("[Forwarded message from Bob]\nForwarded hello");
   });
 
-  it("recovers full Slack DM text from top-level rich text blocks when text is only a preview", async () => {
-    const preview = "Yo Molty what is uppppp ".repeat(7).slice(0, 160);
-    const fullText = `${preview}and this tail should still reach the agent`;
-
-    const prepared = await prepareWithDefaultCtx(
-      createSlackMessage({
-        text: preview,
-        blocks: [
-          {
-            type: "rich_text",
-            block_id: "b1",
-            elements: [
-              {
-                type: "rich_text_section",
-                elements: [{ type: "text", text: fullText }],
-              },
-            ],
-          },
-        ],
-      }),
-    );
-
-    assertPrepared(prepared);
-    expect(prepared.ctxPayload.RawBody).toBe(fullText);
-    expect(prepared.ctxPayload.BodyForAgent).toContain(fullText);
-  });
-
-  it("recovers full Slack DM text when rich text differs from a truncated preview", async () => {
-    const fullText = `First paragraph ${"keeps going ".repeat(14)}
+  it.each([
+    {
+      name: "recovers full Slack DM text from top-level rich text blocks when text is only a preview",
+      createText: () => {
+        const preview = "Yo Molty what is uppppp ".repeat(7).slice(0, 160);
+        return { preview, fullText: `${preview}and this tail should still reach the agent` };
+      },
+    },
+    {
+      name: "recovers full Slack DM text when rich text differs from a truncated preview",
+      createText: () => {
+        const fullText = `First paragraph ${"keeps going ".repeat(14)}
 Second paragraph should still reach the agent after Slack's preview cutoff.`;
-    const preview = `${fullText.slice(0, 200).replace(/\n/g, " ")}...`;
-
+        return { preview: `${fullText.slice(0, 200).replace(/\n/g, " ")}...`, fullText };
+      },
+    },
+  ])("$name", async ({ createText }) => {
+    const { preview, fullText } = createText();
     const prepared = await prepareWithDefaultCtx(
       createSlackMessage({
         text: preview,
@@ -2583,7 +2569,18 @@ Second paragraph should still reach the agent after Slack's preview cutoff.`;
     expect(prepared.ctxPayload.From).toBe("slack:group:G123");
   });
 
-  it("blocks MPIM messages from senders outside the configured allowFrom", async () => {
+  it.each([
+    {
+      name: "blocks MPIM messages from senders outside the configured allowFrom",
+      user: "U_ATTACKER",
+      allowed: false,
+    },
+    {
+      name: "allows MPIM messages from senders in the configured allowFrom",
+      user: "U_OWNER",
+      allowed: true,
+    },
+  ])("$name", async ({ user, allowed }) => {
     const ctx = createReplyToAllSlackCtx();
     ctx.allowFrom = ["U_OWNER"];
     const prepared = await prepareMessageWith(
@@ -2592,26 +2589,14 @@ Second paragraph should still reach the agent after Slack's preview cutoff.`;
       createSlackMessage({
         channel: "G123",
         channel_type: "mpim",
-        user: "U_ATTACKER",
+        user,
       }),
     );
 
-    expect(prepared).toBeNull();
-  });
-
-  it("allows MPIM messages from senders in the configured allowFrom", async () => {
-    const ctx = createReplyToAllSlackCtx();
-    ctx.allowFrom = ["U_OWNER"];
-    const prepared = await prepareMessageWith(
-      ctx,
-      createSlackAccount({ replyToMode: "all" }),
-      createSlackMessage({
-        channel: "G123",
-        channel_type: "mpim",
-        user: "U_OWNER",
-      }),
-    );
-
+    if (!allowed) {
+      expect(prepared).toBeNull();
+      return;
+    }
     assertPrepared(prepared);
     expect(prepared.ctxPayload.ChatType).toBe("group");
   });

--- a/extensions/slack/src/send.blocks.test.ts
+++ b/extensions/slack/src/send.blocks.test.ts
@@ -1420,24 +1420,18 @@ describe("sendMessageSlack blocks", () => {
     expect(client.chat.postMessage).toHaveBeenCalledTimes(1);
   });
 
-  it("derives fallback text from image blocks", async () => {
-    const client = createSlackSendTestClient();
-    await sendMessageSlack("channel:C123", "", {
-      token: "xoxb-test",
-      cfg: SLACK_TEST_CFG,
-      client,
+  it.each<{
+    name: string;
+    blocks: NonNullable<Parameters<typeof sendMessageSlack>[2]["blocks"]>;
+    fallbackText: string;
+  }>([
+    {
+      name: "derives fallback text from image blocks",
       blocks: [{ type: "image", image_url: "https://example.com/a.png", alt_text: "Build chart" }],
-    });
-
-    expect(postedMessage(client).text).toBe("Build chart");
-  });
-
-  it("derives fallback text from video blocks", async () => {
-    const client = createSlackSendTestClient();
-    await sendMessageSlack("channel:C123", "", {
-      token: "xoxb-test",
-      cfg: SLACK_TEST_CFG,
-      client,
+      fallbackText: "Build chart",
+    },
+    {
+      name: "derives fallback text from video blocks",
       blocks: [
         {
           type: "video",
@@ -1447,21 +1441,23 @@ describe("sendMessageSlack blocks", () => {
           alt_text: "demo",
         },
       ],
-    });
-
-    expect(postedMessage(client).text).toBe("Release demo");
-  });
-
-  it("derives fallback text from file blocks", async () => {
+      fallbackText: "Release demo",
+    },
+    {
+      name: "derives fallback text from file blocks",
+      blocks: [{ type: "file", source: "remote", external_id: "F123" }],
+      fallbackText: "Shared a file",
+    },
+  ])("$name", async ({ blocks, fallbackText }) => {
     const client = createSlackSendTestClient();
     await sendMessageSlack("channel:C123", "", {
       token: "xoxb-test",
       cfg: SLACK_TEST_CFG,
       client,
-      blocks: [{ type: "file", source: "remote", external_id: "F123" }],
+      blocks,
     });
 
-    expect(postedMessage(client).text).toBe("Shared a file");
+    expect(postedMessage(client).text).toBe(fallbackText);
   });
 
   it("caps long fallback text while preserving blocks", async () => {
@@ -1491,72 +1487,53 @@ describe("sendMessageSlack blocks", () => {
     expect(post.text).toHaveLength(SLACK_TEXT_LIMIT);
   });
 
-  it("rejects blocks combined with mediaUrl", async () => {
-    const client = createSlackSendTestClient();
-    await expect(
-      sendMessageSlack("channel:C123", "hi", {
-        token: "xoxb-test",
-        cfg: SLACK_TEST_CFG,
-        client,
+  it.each<{
+    name: string;
+    options: Partial<Parameters<typeof sendMessageSlack>[2]>;
+    error: RegExp;
+  }>([
+    {
+      name: "rejects blocks combined with mediaUrl",
+      options: {
         mediaUrl: "https://example.com/image.png",
         blocks: [{ type: "divider" }],
-      }),
-    ).rejects.toThrow(/does not support blocks with mediaUrl/i);
-    expect(client.chat.postMessage).not.toHaveBeenCalled();
-  });
-
-  it("rejects replyBroadcast combined with mediaUrl", async () => {
-    const client = createSlackSendTestClient();
-    await expect(
-      sendMessageSlack("channel:C123", "hi", {
-        token: "xoxb-test",
-        cfg: SLACK_TEST_CFG,
-        client,
+      },
+      error: /does not support blocks with mediaUrl/i,
+    },
+    {
+      name: "rejects replyBroadcast combined with mediaUrl",
+      options: {
         mediaUrl: "https://example.com/image.png",
         threadTs: "171234.100",
         replyBroadcast: true,
-      }),
-    ).rejects.toThrow(/replyBroadcast is only supported for text or block thread replies/i);
-    expect(client.chat.postMessage).not.toHaveBeenCalled();
-  });
-
-  it("rejects empty blocks arrays from runtime callers", async () => {
+      },
+      error: /replyBroadcast is only supported for text or block thread replies/i,
+    },
+    {
+      name: "rejects empty blocks arrays from runtime callers",
+      options: { blocks: [] },
+      error: /must contain at least one block/i,
+    },
+    {
+      name: "rejects blocks arrays above Slack max count",
+      options: { blocks: Array.from({ length: 51 }, () => ({ type: "divider" })) },
+      error: /cannot exceed 50 items/i,
+    },
+    {
+      name: "rejects blocks missing type from runtime callers",
+      options: { blocks: [{} as { type: string }] },
+      error: /non-empty string type/i,
+    },
+  ])("$name", async ({ options, error }) => {
     const client = createSlackSendTestClient();
     await expect(
       sendMessageSlack("channel:C123", "hi", {
         token: "xoxb-test",
         cfg: SLACK_TEST_CFG,
         client,
-        blocks: [],
+        ...options,
       }),
-    ).rejects.toThrow(/must contain at least one block/i);
-    expect(client.chat.postMessage).not.toHaveBeenCalled();
-  });
-
-  it("rejects blocks arrays above Slack max count", async () => {
-    const client = createSlackSendTestClient();
-    const blocks = Array.from({ length: 51 }, () => ({ type: "divider" }));
-    await expect(
-      sendMessageSlack("channel:C123", "hi", {
-        token: "xoxb-test",
-        cfg: SLACK_TEST_CFG,
-        client,
-        blocks,
-      }),
-    ).rejects.toThrow(/cannot exceed 50 items/i);
-    expect(client.chat.postMessage).not.toHaveBeenCalled();
-  });
-
-  it("rejects blocks missing type from runtime callers", async () => {
-    const client = createSlackSendTestClient();
-    await expect(
-      sendMessageSlack("channel:C123", "hi", {
-        token: "xoxb-test",
-        cfg: SLACK_TEST_CFG,
-        client,
-        blocks: [{} as { type: string }],
-      }),
-    ).rejects.toThrow(/non-empty string type/i);
+    ).rejects.toThrow(error);
     expect(client.chat.postMessage).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Discord, Matrix, and Slack regression suites repeated equivalent permission, bot-admission, streaming, fallback, thread-policy, and block-validation setup. That duplication made the transport security and delivery cases harder to audit as the suites evolved.

## Why This Change Was Made

Rebuild the useful fixture/table consolidation on current `main`, keeping every helper plugin- and file-local. Only setup-equivalent current cases are parameterized; newer cases whose fixtures diverged remain explicit. Every current named scenario and assertion is preserved.

## User Impact

No shipped behavior changes. Maintainers retain all 704 current Discord, Matrix, and Slack cases with identical source coverage while maintaining 373 fewer lines of plugin tests.

## Evidence

- Baseline focused suites: Discord 149, Matrix 148, Slack 407 — 704/704 passed; wrapper 24.43s.
- Candidate exact head: Discord 149, Matrix 148, Slack 407 — 704/704 passed; wrapper 17.90s after the final rebase.
- Current-main/candidate V8 coverage is byte-for-byte identical in all 12 metrics:
  - Discord: statements `2915/59430`, branches `429/51395`, functions `265/10187`, lines `2895/58614`.
  - Matrix: statements `7318/112715`, branches `2258/99639`, functions `979/19490`, lines `7251/111186`.
  - Slack: statements `9467/109429`, branches `3958/96027`, functions `1458/19213`, lines `9360/107916`.
- `node scripts/check-changed.mjs` on the final six-file branch passed on Blacksmith Testbox with extension-test typecheck, formatting, 245-rule lint, dependency/boundary guards, and zero warnings or errors. Testbox lease `tbx_01kzk7sneh8n8ng295y2gzczqq`; [Actions run](https://github.com/openclaw/openclaw/actions/runs/31313277083).
- Codex-backed autoreview: clean after one round; no accepted/actionable findings.
- `git diff --check` — passed.
- Scope: six plugin-owned test files, production `+0/-0`, tests `+397/-770` (net `-373`).

ClawSweeper rank-up moves are addressed: the consolidation was rebuilt against current `main`, all current named assertions remain, and focused plus current-main coverage-equivalence proof is attached above.
