### PR TITLE
refactor(agents): consolidate lifecycle regression coverage

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
@@ -18,6 +18,7 @@ import {
   withOwnedSessionTranscriptWrites,
 } from "../../../config/sessions/transcript-write-context.js";
 import { appendExactAssistantMessageToSessionTranscript } from "../../../config/sessions/transcript.js";
+import { createDeferred } from "../../../shared/deferred.js";
 import { OPENCLAW_TRANSCRIPT_ARTIFACT_API } from "../../../shared/transcript-only-openclaw-assistant.js";
 import { normalizeSessionDeliveryState } from "../../../utils/delivery-context.shared.js";
 import { guardSessionManager } from "../../session-tool-result-guard-wrapper.js";
@@ -42,6 +43,45 @@ const lockOptions = {
   staleMs: 1_800_000,
   maxHoldMs: 300_000,
 };
+
+function appendTestAssistantMessage(
+  manager: SessionManager,
+  text: string,
+  timestamp = 2,
+  model = "sonnet-4.6",
+) {
+  return manager.appendMessage({
+    role: "assistant",
+    content: [{ type: "text", text }],
+    api: "messages",
+    provider: model === "session-lock-test" ? "openclaw" : "anthropic",
+    model,
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: "stop",
+    timestamp,
+  });
+}
+
+async function createMockSessionLockController(
+  sessionFile: string,
+  overrides: Partial<Parameters<typeof createEmbeddedAttemptSessionLockController>[0]> = {},
+) {
+  const release = vi.fn(async () => {});
+  const acquire = vi.fn(async () => ({ release }));
+  const controller = await createEmbeddedAttemptSessionLockController({
+    acquireSessionWriteLock: acquire,
+    lockOptions: { ...lockOptions, sessionFile },
+    ...overrides,
+  });
+  return { controller, acquire, release };
+}
 
 const tempDirs: string[] = [];
 const autoTempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -86,62 +126,44 @@ function cloneBigIntStatWith(
 }
 
 describe("embedded attempt session lock lifecycle", () => {
-  it("recognizes an unchanged session file trusted by the previous prompt release", async () => {
+  it.each([
+    {
+      name: "recognizes an unchanged session file trusted by the previous prompt release",
+      trusted: true,
+    },
+    {
+      name: "does not trust a session file changed after the previous prompt release",
+      append: "external",
+      trusted: false,
+    },
+    { name: "publishes a known owned append for the next attempt", append: "owned", trusted: true },
+  ])("$name", async ({ append, trusted }) => {
     const sessionFile = await createTempSessionFile();
     const options = { ...lockOptions, sessionFile };
     const first = await createEmbeddedAttemptSessionLockController({
       acquireSessionWriteLock,
       lockOptions: options,
     });
-
     expect(await first.readTrustedCurrentSessionFileSnapshot()).toBeUndefined();
+    if (append === "owned") {
+      await fs.appendFile(sessionFile, '{"type":"message","id":"owned"}\n', "utf8");
+      first.refreshAfterOwnedSessionWrite();
+    }
     await first.releaseForPrompt();
     await first.dispose();
-
+    if (append === "external") {
+      await fs.appendFile(sessionFile, '{"type":"message","id":"external"}\n', "utf8");
+    }
     const second = await createEmbeddedAttemptSessionLockController({
       acquireSessionWriteLock,
       lockOptions: options,
     });
-    expect(await second.readTrustedCurrentSessionFileSnapshot()).toBeDefined();
-    await second.dispose();
-  });
-
-  it("does not trust a session file changed after the previous prompt release", async () => {
-    const sessionFile = await createTempSessionFile();
-    const options = { ...lockOptions, sessionFile };
-    const first = await createEmbeddedAttemptSessionLockController({
-      acquireSessionWriteLock,
-      lockOptions: options,
-    });
-    await first.releaseForPrompt();
-    await first.dispose();
-    await fs.appendFile(sessionFile, '{"type":"message","id":"external"}\n', "utf8");
-
-    const second = await createEmbeddedAttemptSessionLockController({
-      acquireSessionWriteLock,
-      lockOptions: options,
-    });
-    expect(await second.readTrustedCurrentSessionFileSnapshot()).toBeUndefined();
-    await second.dispose();
-  });
-
-  it("publishes a known owned append for the next attempt", async () => {
-    const sessionFile = await createTempSessionFile();
-    const options = { ...lockOptions, sessionFile };
-    const first = await createEmbeddedAttemptSessionLockController({
-      acquireSessionWriteLock,
-      lockOptions: options,
-    });
-    await fs.appendFile(sessionFile, '{"type":"message","id":"owned"}\n', "utf8");
-    first.refreshAfterOwnedSessionWrite();
-    await first.releaseForPrompt();
-    await first.dispose();
-
-    const second = await createEmbeddedAttemptSessionLockController({
-      acquireSessionWriteLock,
-      lockOptions: options,
-    });
-    expect(await second.readTrustedCurrentSessionFileSnapshot()).toBeDefined();
+    const snapshot = await second.readTrustedCurrentSessionFileSnapshot();
+    if (trusted) {
+      expect(snapshot).toBeDefined();
+    } else {
+      expect(snapshot).toBeUndefined();
+    }
     await second.dispose();
   });
 
@@ -296,95 +318,55 @@ describe("embedded attempt session lock lifecycle", () => {
     expect(release).toHaveBeenCalledTimes(1);
   });
 
-  it("waits for pending timeout abort release before dispose resolves (#86816)", async () => {
-    let markHeldReleaseStarted!: () => void;
-    const heldReleaseStarted = new Promise<void>((resolve) => {
-      markHeldReleaseStarted = resolve;
-    });
-    let unblockHeldRelease!: () => void;
-    const heldReleaseCanFinish = new Promise<void>((resolve) => {
-      unblockHeldRelease = resolve;
-    });
+  it.each([
+    {
+      name: "waits for pending timeout abort release before dispose resolves (#86816)",
+      complete: (
+        controller: Awaited<ReturnType<typeof createEmbeddedAttemptSessionLockController>>,
+      ) => controller.dispose(),
+    },
+    {
+      name: "waits for pending timeout abort release before prompt release resolves (#86816)",
+      complete: (
+        controller: Awaited<ReturnType<typeof createEmbeddedAttemptSessionLockController>>,
+      ) => controller.releaseForPrompt(),
+    },
+  ])("$name", async ({ complete }) => {
+    // createDeferred defaults to void; an explicit type argument fails the lint ratchet.
+    const started = createDeferred();
+    const finish = createDeferred();
     const release = vi.fn(async () => {
-      markHeldReleaseStarted();
-      await heldReleaseCanFinish;
+      started.resolve();
+      await finish.promise;
     });
-    const acquireSessionWriteLockLocal25 = vi.fn(async () => ({ release }));
     const controller = await createEmbeddedAttemptSessionLockController({
-      acquireSessionWriteLock: acquireSessionWriteLockLocal25,
+      acquireSessionWriteLock: vi.fn(async () => ({ release })),
       lockOptions,
     });
-
     const abortRelease = controller.releaseHeldLockForAbort();
-    await heldReleaseStarted;
-    let disposeSettled = false;
-    const dispose = controller.dispose().then(() => {
-      disposeSettled = true;
+    await started.promise;
+    let settled = false;
+    const completion = complete(controller).then(() => {
+      settled = true;
     });
     await Promise.resolve();
-
-    expect(disposeSettled).toBe(false);
-
-    unblockHeldRelease();
-    await abortRelease;
-    await dispose;
-
-    expect(release).toHaveBeenCalledTimes(1);
-  });
-
-  it("waits for pending timeout abort release before prompt release resolves (#86816)", async () => {
-    let markHeldReleaseStarted!: () => void;
-    const heldReleaseStarted = new Promise<void>((resolve) => {
-      markHeldReleaseStarted = resolve;
-    });
-    let unblockHeldRelease!: () => void;
-    const heldReleaseCanFinish = new Promise<void>((resolve) => {
-      unblockHeldRelease = resolve;
-    });
-    const release = vi.fn(async () => {
-      markHeldReleaseStarted();
-      await heldReleaseCanFinish;
-    });
-    const acquireSessionWriteLockLocal24 = vi.fn(async () => ({ release }));
-    const controller = await createEmbeddedAttemptSessionLockController({
-      acquireSessionWriteLock: acquireSessionWriteLockLocal24,
-      lockOptions,
-    });
-
-    const abortRelease = controller.releaseHeldLockForAbort();
-    await heldReleaseStarted;
-    let promptReleaseSettled = false;
-    const promptRelease = controller.releaseForPrompt().then(() => {
-      promptReleaseSettled = true;
-    });
-    await Promise.resolve();
-
-    expect(promptReleaseSettled).toBe(false);
-
-    unblockHeldRelease();
-    await abortRelease;
-    await promptRelease;
-
-    expect(release).toHaveBeenCalledTimes(1);
+    expect(settled).toBe(false);
+    finish.resolve();
+    await Promise.all([abortRelease, completion]);
+    expect(release).toHaveBeenCalledOnce();
   });
 
   it("waits for pending timeout abort release before prompt reacquire (#86816)", async () => {
     const events: string[] = [];
-    let markHeldReleaseStarted!: () => void;
-    const heldReleaseStarted = new Promise<void>((resolve) => {
-      markHeldReleaseStarted = resolve;
-    });
-    let unblockHeldRelease!: () => void;
-    const heldReleaseCanFinish = new Promise<void>((resolve) => {
-      unblockHeldRelease = resolve;
-    });
+    const heldReleaseStarted = createDeferred();
+    const heldReleaseCanFinish = createDeferred();
     const acquireSessionWriteLockLocal23 = vi
       .fn()
       .mockResolvedValueOnce({
         release: vi.fn(async () => {
           events.push("held-release-start");
-          markHeldReleaseStarted();
-          await heldReleaseCanFinish;
+          heldReleaseStarted.resolve();
+          await heldReleaseCanFinish.promise;
           events.push("held-release-end");
         }),
       })
@@ -399,13 +381,13 @@ describe("embedded attempt session lock lifecycle", () => {
     });
 
     const abortRelease = controller.releaseHeldLockForAbort();
-    await heldReleaseStarted;
+    await heldReleaseStarted.promise;
     const reacquire = controller.reacquireAfterPrompt();
     await Promise.resolve();
 
     expect(acquireSessionWriteLockLocal23).toHaveBeenCalledTimes(1);
 
-    unblockHeldRelease();
+    heldReleaseCanFinish.resolve();
     await abortRelease;
     await reacquire;
     await controller.dispose();
@@ -421,20 +403,14 @@ describe("embedded attempt session lock lifecycle", () => {
       acquireSessionWriteLock: acquireSessionWriteLockLocal22,
       lockOptions,
     });
-    let finishWrite!: () => void;
-    const writeCanFinish = new Promise<void>((resolve) => {
-      finishWrite = resolve;
-    });
-    let markWriteStarted!: () => void;
-    const writeStarted = new Promise<void>((resolve) => {
-      markWriteStarted = resolve;
-    });
+    const writeCanFinish = createDeferred();
+    const writeStarted = createDeferred();
 
     const activeWrite = controller.withSessionWriteLock(async () => {
-      markWriteStarted();
-      await writeCanFinish;
+      writeStarted.resolve();
+      await writeCanFinish.promise;
     });
-    await writeStarted;
+    await writeStarted.promise;
 
     let abortReleaseSettled = false;
     const abortRelease = controller.releaseHeldLockForAbort().then(() => {
@@ -445,7 +421,7 @@ describe("embedded attempt session lock lifecycle", () => {
     expect(release).not.toHaveBeenCalled();
     expect(abortReleaseSettled).toBe(false);
 
-    finishWrite();
+    writeCanFinish.resolve();
     await activeWrite;
     await abortRelease;
 
@@ -460,13 +436,10 @@ describe("embedded attempt session lock lifecycle", () => {
       acquireSessionWriteLock: acquireSessionWriteLockLocal21,
       lockOptions,
     });
-    let finishWrite!: () => void;
-    const writeCanFinish = new Promise<void>((resolve) => {
-      finishWrite = resolve;
-    });
+    const writeCanFinish = createDeferred();
 
     const activeWrite = controller.withSessionWriteLock(async () => {
-      await writeCanFinish;
+      await writeCanFinish.promise;
     });
     let abortReleaseSettled = false;
     const abortRelease = controller.releaseHeldLockForAbort().then(() => {
@@ -477,7 +450,7 @@ describe("embedded attempt session lock lifecycle", () => {
     expect(release).not.toHaveBeenCalled();
     expect(abortReleaseSettled).toBe(false);
 
-    finishWrite();
+    writeCanFinish.resolve();
     await activeWrite;
     await abortRelease;
 
@@ -491,20 +464,14 @@ describe("embedded attempt session lock lifecycle", () => {
       acquireSessionWriteLock: acquireSessionWriteLockLocal20,
       lockOptions,
     });
-    let finishWrite!: () => void;
-    const writeCanFinish = new Promise<void>((resolve) => {
-      finishWrite = resolve;
-    });
-    let markWriteStarted!: () => void;
-    const writeStarted = new Promise<void>((resolve) => {
-      markWriteStarted = resolve;
-    });
+    const writeCanFinish = createDeferred();
+    const writeStarted = createDeferred();
 
     const activeWrite = controller.withSessionWriteLock(async () => {
-      markWriteStarted();
-      await writeCanFinish;
+      writeStarted.resolve();
+      await writeCanFinish.promise;
     });
-    await writeStarted;
+    await writeStarted.promise;
 
     let cleanupAcquired = false;
     const cleanupLockPromise = controller.acquireForCleanup().then((lock) => {
@@ -516,7 +483,7 @@ describe("embedded attempt session lock lifecycle", () => {
     expect(cleanupAcquired).toBe(false);
     expect(release).not.toHaveBeenCalled();
 
-    finishWrite();
+    writeCanFinish.resolve();
     await activeWrite;
     const cleanupLock = await cleanupLockPromise;
     await cleanupLock.release();
@@ -526,21 +493,15 @@ describe("embedded attempt session lock lifecycle", () => {
 
   it("reacquires cleanup lock when timeout abort already released the held lock (#86816)", async () => {
     const events: string[] = [];
-    let markHeldReleaseStarted!: () => void;
-    const heldReleaseStarted = new Promise<void>((resolve) => {
-      markHeldReleaseStarted = resolve;
-    });
-    let unblockHeldRelease!: () => void;
-    const heldReleaseCanFinish = new Promise<void>((resolve) => {
-      unblockHeldRelease = resolve;
-    });
+    const heldReleaseStarted = createDeferred();
+    const heldReleaseCanFinish = createDeferred();
     const acquireSessionWriteLockLocal19 = vi
       .fn()
       .mockResolvedValueOnce({
         release: vi.fn(async () => {
           events.push("held-release-start");
-          markHeldReleaseStarted();
-          await heldReleaseCanFinish;
+          heldReleaseStarted.resolve();
+          await heldReleaseCanFinish.promise;
           events.push("held-release-end");
         }),
       })
@@ -555,13 +516,13 @@ describe("embedded attempt session lock lifecycle", () => {
     });
 
     const abortRelease = controller.releaseHeldLockForAbort();
-    await heldReleaseStarted;
+    await heldReleaseStarted.promise;
     const cleanupLockPromise = controller.acquireForCleanup();
     await Promise.resolve();
 
     expect(acquireSessionWriteLockLocal19).toHaveBeenCalledTimes(1);
 
-    unblockHeldRelease();
+    heldReleaseCanFinish.resolve();
     await abortRelease;
     const cleanupLock = await cleanupLockPromise;
     await cleanupLock.release();
@@ -572,29 +533,17 @@ describe("embedded attempt session lock lifecycle", () => {
 
   it("keeps cleanup waiting while timeout abort owns the held-lock drain (#86816)", async () => {
     const events: string[] = [];
-    let finishWrite!: () => void;
-    const writeCanFinish = new Promise<void>((resolve) => {
-      finishWrite = resolve;
-    });
-    let markWriteStarted!: () => void;
-    const writeStarted = new Promise<void>((resolve) => {
-      markWriteStarted = resolve;
-    });
-    let markHeldReleaseStarted!: () => void;
-    const heldReleaseStarted = new Promise<void>((resolve) => {
-      markHeldReleaseStarted = resolve;
-    });
-    let unblockHeldRelease!: () => void;
-    const heldReleaseCanFinish = new Promise<void>((resolve) => {
-      unblockHeldRelease = resolve;
-    });
+    const writeCanFinish = createDeferred();
+    const writeStarted = createDeferred();
+    const heldReleaseStarted = createDeferred();
+    const heldReleaseCanFinish = createDeferred();
     const acquireSessionWriteLockLocal18 = vi
       .fn()
       .mockResolvedValueOnce({
         release: vi.fn(async () => {
           events.push("held-release-start");
-          markHeldReleaseStarted();
-          await heldReleaseCanFinish;
+          heldReleaseStarted.resolve();
+          await heldReleaseCanFinish.promise;
           events.push("held-release-end");
         }),
       })
@@ -609,22 +558,22 @@ describe("embedded attempt session lock lifecycle", () => {
     });
 
     const activeWrite = controller.withSessionWriteLock(async () => {
-      markWriteStarted();
-      await writeCanFinish;
+      writeStarted.resolve();
+      await writeCanFinish.promise;
     });
-    await writeStarted;
+    await writeStarted.promise;
     const abortRelease = controller.releaseHeldLockForAbort();
     const cleanupLockPromise = controller.acquireForCleanup();
 
-    finishWrite();
+    writeCanFinish.resolve();
     await activeWrite;
-    await heldReleaseStarted;
+    await heldReleaseStarted.promise;
     await Promise.resolve();
 
     expect(acquireSessionWriteLockLocal18).toHaveBeenCalledTimes(1);
     expect(events).toEqual(["held-release-start"]);
 
-    unblockHeldRelease();
+    heldReleaseCanFinish.resolve();
     await abortRelease;
     const cleanupLock = await cleanupLockPromise;
     await cleanupLock.release();
@@ -675,12 +624,11 @@ describe("embedded attempt session lock lifecycle", () => {
 
   it("keeps the session fence active after releasing for sessions_yield abort cleanup", async () => {
     const sessionFile = await createTempSessionFile();
-    const release = vi.fn(async () => {});
-    const acquireSessionWriteLockLocal15 = vi.fn(async () => ({ release }));
-    const controller = await createEmbeddedAttemptSessionLockController({
-      acquireSessionWriteLock: acquireSessionWriteLockLocal15,
-      lockOptions: { ...lockOptions, sessionFile },
-    });
+    const {
+      controller,
+      release,
+      acquire: acquireSessionWriteLockLocal15,
+    } = await createMockSessionLockController(sessionFile);
 
     await controller.releaseHeldLockForAbort();
     await fs.appendFile(sessionFile, '{"type":"message","id":"abort-takeover"}\n', "utf8");
@@ -756,12 +704,7 @@ describe("embedded attempt session lock lifecycle", () => {
 
   it("rejects post-prompt writes when another owner advances the session file", async () => {
     const sessionFile = await createTempSessionFile();
-    const release = vi.fn(async () => {});
-    const acquireSessionWriteLockLocal12 = vi.fn(async () => ({ release }));
-    const controller = await createEmbeddedAttemptSessionLockController({
-      acquireSessionWriteLock: acquireSessionWriteLockLocal12,
-      lockOptions: { ...lockOptions, sessionFile },
-    });
+    const { controller, release } = await createMockSessionLockController(sessionFile);
 
     await controller.releaseForPrompt();
     await fs.appendFile(sessionFile, '{"type":"message","id":"takeover"}\n', "utf8");
@@ -961,23 +904,7 @@ describe("embedded attempt session lock lifecycle", () => {
     tempDirs.push(dir);
     const initialManager = SessionManager.create(dir, dir);
     initialManager.appendMessage({ role: "user", content: "question", timestamp: 1 });
-    const baseAnswerId = initialManager.appendMessage({
-      role: "assistant",
-      content: [{ type: "text", text: "base answer" }],
-      api: "messages",
-      provider: "anthropic",
-      model: "sonnet-4.6",
-      usage: {
-        input: 0,
-        output: 0,
-        cacheRead: 0,
-        cacheWrite: 0,
-        totalTokens: 0,
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-      },
-      stopReason: "stop",
-      timestamp: 2,
-    });
+    const baseAnswerId = appendTestAssistantMessage(initialManager, "base answer");
     const sessionFile = initialManager.getSessionFile();
     if (!sessionFile) {
       throw new Error("expected persisted session file");
@@ -1042,23 +969,7 @@ describe("embedded attempt session lock lifecycle", () => {
     tempDirs.push(dir);
     const initialManager = SessionManager.create(dir, dir);
     initialManager.appendMessage({ role: "user", content: "question", timestamp: 1 });
-    const baseAnswerId = initialManager.appendMessage({
-      role: "assistant",
-      content: [{ type: "text", text: "base answer" }],
-      api: "messages",
-      provider: "anthropic",
-      model: "sonnet-4.6",
-      usage: {
-        input: 0,
-        output: 0,
-        cacheRead: 0,
-        cacheWrite: 0,
-        totalTokens: 0,
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-      },
-      stopReason: "stop",
-      timestamp: 2,
-    });
+    const baseAnswerId = appendTestAssistantMessage(initialManager, "base answer");
     const sessionFile = initialManager.getSessionFile();
     if (!sessionFile) {
       throw new Error("expected persisted session file");
@@ -1197,23 +1108,7 @@ describe("embedded attempt session lock lifecycle", () => {
       content: "question",
       timestamp: 1,
     });
-    const rootId = initialManager.appendMessage({
-      role: "assistant",
-      content: [{ type: "text", text: "first answer" }],
-      api: "messages",
-      provider: "anthropic",
-      model: "sonnet-4.6",
-      usage: {
-        input: 0,
-        output: 0,
-        cacheRead: 0,
-        cacheWrite: 0,
-        totalTokens: 0,
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-      },
-      stopReason: "stop",
-      timestamp: 2,
-    });
+    const rootId = appendTestAssistantMessage(initialManager, "first answer");
     const sessionFile = initialManager.getSessionFile();
     if (!sessionFile) {
       throw new Error("expected persisted session file");
@@ -1237,23 +1132,7 @@ describe("embedded attempt session lock lifecycle", () => {
     metadataManager.appendSessionInfo("session title");
 
     await controller.withSessionWriteLock(() => {
-      staleManager.appendMessage({
-        role: "assistant",
-        content: [{ type: "text", text: "answer" }],
-        api: "messages",
-        provider: "anthropic",
-        model: "sonnet-4.6",
-        usage: {
-          input: 0,
-          output: 0,
-          cacheRead: 0,
-          cacheWrite: 0,
-          totalTokens: 0,
-          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-        },
-        stopReason: "stop",
-        timestamp: 3,
-      });
+      appendTestAssistantMessage(staleManager, "answer", 3);
     });
     (
       staleManager as unknown as {
@@ -1656,12 +1535,11 @@ describe("embedded attempt session lock lifecycle", () => {
 
   it("refreshes the prompt fence after an owned write throws", async () => {
     const sessionFile = await createTempSessionFile();
-    const release = vi.fn(async () => {});
-    const acquireSessionWriteLockLocal9 = vi.fn(async () => ({ release }));
-    const controller = await createEmbeddedAttemptSessionLockController({
-      acquireSessionWriteLock: acquireSessionWriteLockLocal9,
-      lockOptions: { ...lockOptions, sessionFile },
-    });
+    const {
+      controller,
+      release,
+      acquire: acquireSessionWriteLockLocal9,
+    } = await createMockSessionLockController(sessionFile);
 
     await controller.releaseForPrompt();
     await expect(
@@ -1679,29 +1557,25 @@ describe("embedded attempt session lock lifecycle", () => {
 
   it("does not reuse a released lock from inherited async context", async () => {
     const sessionFile = await createTempSessionFile();
-    let resumeDetached!: () => void;
-    const detachedGate = new Promise<void>((resolve) => {
-      resumeDetached = resolve;
-    });
-    const release = vi.fn(async () => {});
-    const acquireSessionWriteLockLocal8 = vi.fn(async () => ({ release }));
-    const controller = await createEmbeddedAttemptSessionLockController({
-      acquireSessionWriteLock: acquireSessionWriteLockLocal8,
-      lockOptions: { ...lockOptions, sessionFile },
-    });
+    const detachedGate = createDeferred();
+    const {
+      controller,
+      release,
+      acquire: acquireSessionWriteLockLocal8,
+    } = await createMockSessionLockController(sessionFile);
 
     await controller.releaseForPrompt();
     let detachedWrite!: Promise<void>;
     await controller.withSessionWriteLock(async () => {
       detachedWrite = (async () => {
-        await detachedGate;
+        await detachedGate.promise;
         await controller.withSessionWriteLock(async () => {
           await fs.appendFile(sessionFile, '{"type":"message","id":"detached-owned"}\n', "utf8");
         });
       })();
     });
 
-    resumeDetached();
+    detachedGate.resolve();
     await detachedWrite;
     await expect(controller.withSessionWriteLock(() => "finalize")).resolves.toBe("finalize");
 
@@ -1712,12 +1586,11 @@ describe("embedded attempt session lock lifecycle", () => {
 
   it("keeps post-provider transcript writes owned after prompt stream returns", async () => {
     const sessionFile = await createTempSessionFile();
-    const release = vi.fn(async () => {});
-    const acquireSessionWriteLockLocal7 = vi.fn(async () => ({ release }));
-    const controller = await createEmbeddedAttemptSessionLockController({
-      acquireSessionWriteLock: acquireSessionWriteLockLocal7,
-      lockOptions: { ...lockOptions, sessionFile },
-    });
+    const {
+      controller,
+      release,
+      acquire: acquireSessionWriteLockLocal7,
+    } = await createMockSessionLockController(sessionFile);
 
     await controller.releaseForPrompt();
     await controller.reacquireAfterPrompt();
@@ -1734,12 +1607,11 @@ describe("embedded attempt session lock lifecycle", () => {
 
   it("still rejects external edits before the prompt stream lock is reacquired", async () => {
     const sessionFile = await createTempSessionFile();
-    const release = vi.fn(async () => {});
-    const acquireSessionWriteLockLocal6 = vi.fn(async () => ({ release }));
-    const controller = await createEmbeddedAttemptSessionLockController({
-      acquireSessionWriteLock: acquireSessionWriteLockLocal6,
-      lockOptions: { ...lockOptions, sessionFile },
-    });
+    const {
+      controller,
+      release,
+      acquire: acquireSessionWriteLockLocal6,
+    } = await createMockSessionLockController(sessionFile);
 
     await controller.releaseForPrompt();
     await fs.appendFile(sessionFile, '{"type":"message","id":"external"}\n', "utf8");
@@ -1754,12 +1626,11 @@ describe("embedded attempt session lock lifecycle", () => {
 
   it("allows ctime-only fingerprint drift while the prompt lock is released", async () => {
     const sessionFile = await createTempSessionFile();
-    const release = vi.fn(async () => {});
-    const acquireSessionWriteLockLocalCtimeDrift = vi.fn(async () => ({ release }));
-    const controller = await createEmbeddedAttemptSessionLockController({
-      acquireSessionWriteLock: acquireSessionWriteLockLocalCtimeDrift,
-      lockOptions: { ...lockOptions, sessionFile },
-    });
+    const {
+      controller,
+      release,
+      acquire: acquireSessionWriteLockLocalCtimeDrift,
+    } = await createMockSessionLockController(sessionFile);
 
     await controller.releaseForPrompt();
 
@@ -1790,12 +1661,11 @@ describe("embedded attempt session lock lifecycle", () => {
     await fs.utimes(sessionFile, oldTime, oldTime);
     const before = await fs.stat(sessionFile, { bigint: true });
     const originalBytes = await fs.readFile(sessionFile);
-    const release = vi.fn(async () => {});
-    const acquireSessionWriteLockLocalIdenticalRewrite = vi.fn(async () => ({ release }));
-    const controller = await createEmbeddedAttemptSessionLockController({
-      acquireSessionWriteLock: acquireSessionWriteLockLocalIdenticalRewrite,
-      lockOptions: { ...lockOptions, sessionFile },
-    });
+    const {
+      controller,
+      release,
+      acquire: acquireSessionWriteLockLocalIdenticalRewrite,
+    } = await createMockSessionLockController(sessionFile);
 
     await controller.releaseForPrompt();
     await fs.writeFile(sessionFile, originalBytes);
@@ -1864,12 +1734,11 @@ describe("embedded attempt session lock lifecycle", () => {
 
   it("trusts owned writes after accepting ctime-only fingerprint drift", async () => {
     const sessionFile = await createTempSessionFile();
-    const release = vi.fn(async () => {});
-    const acquireSessionWriteLockLocalOwnedAfterDrift = vi.fn(async () => ({ release }));
-    const controller = await createEmbeddedAttemptSessionLockController({
-      acquireSessionWriteLock: acquireSessionWriteLockLocalOwnedAfterDrift,
-      lockOptions: { ...lockOptions, sessionFile },
-    });
+    const {
+      controller,
+      release,
+      acquire: acquireSessionWriteLockLocalOwnedAfterDrift,
+    } = await createMockSessionLockController(sessionFile);
 
     await controller.releaseForPrompt();
 
@@ -2008,12 +1877,7 @@ describe("embedded attempt session lock lifecycle", () => {
     const oldTime = new Date("2020-01-01T00:00:00.000Z");
     await fs.utimes(sessionFile, oldTime, oldTime);
     const before = await fs.stat(sessionFile, { bigint: true });
-    const release = vi.fn(async () => {});
-    const acquireSessionWriteLockLocalOversizeDrift = vi.fn(async () => ({ release }));
-    const controller = await createEmbeddedAttemptSessionLockController({
-      acquireSessionWriteLock: acquireSessionWriteLockLocalOversizeDrift,
-      lockOptions: { ...lockOptions, sessionFile },
-    });
+    const { controller } = await createMockSessionLockController(sessionFile);
 
     await controller.releaseForPrompt();
     const newTime = new Date("2021-01-01T00:00:00.000Z");
@@ -2032,12 +1896,11 @@ describe("embedded attempt session lock lifecycle", () => {
 
   it("still rejects external edits after the prompt stream lock is reacquired", async () => {
     const sessionFile = await createTempSessionFile();
-    const release = vi.fn(async () => {});
-    const acquireSessionWriteLockLocal5 = vi.fn(async () => ({ release }));
-    const controller = await createEmbeddedAttemptSessionLockController({
-      acquireSessionWriteLock: acquireSessionWriteLockLocal5,
-      lockOptions: { ...lockOptions, sessionFile },
-    });
+    const {
+      controller,
+      release,
+      acquire: acquireSessionWriteLockLocal5,
+    } = await createMockSessionLockController(sessionFile);
 
     await controller.releaseForPrompt();
     await controller.reacquireAfterPrompt();
@@ -2057,12 +1920,11 @@ describe("embedded attempt session lock lifecycle", () => {
 
   it("refreshes the prompt fence after an owned transcript mirror append", async () => {
     const sessionFile = await createTempSessionFile();
-    const release = vi.fn(async () => {});
-    const acquireSessionWriteLockLocal4 = vi.fn(async () => ({ release }));
-    const controller = await createEmbeddedAttemptSessionLockController({
-      acquireSessionWriteLock: acquireSessionWriteLockLocal4,
-      lockOptions: { ...lockOptions, sessionFile },
-    });
+    const {
+      controller,
+      release,
+      acquire: acquireSessionWriteLockLocal4,
+    } = await createMockSessionLockController(sessionFile);
 
     await controller.releaseForPrompt();
     await withOwnedSessionTranscriptWrites(
@@ -2088,12 +1950,7 @@ describe("embedded attempt session lock lifecycle", () => {
 
   it("authorizes entry-cache advancement only under the exact trusted file lock", async () => {
     const sessionFile = await createTempSessionFile();
-    const release = vi.fn(async () => {});
-    const acquireSessionWriteLockLocal = vi.fn(async () => ({ release }));
-    const controller = await createEmbeddedAttemptSessionLockController({
-      acquireSessionWriteLock: acquireSessionWriteLockLocal,
-      lockOptions: { ...lockOptions, sessionFile },
-    });
+    const { controller } = await createMockSessionLockController(sessionFile);
 
     await controller.releaseForPrompt();
     const stat = await fs.stat(sessionFile, { bigint: true });
@@ -2172,12 +2029,7 @@ describe("embedded attempt session lock lifecycle", () => {
 
   it("refreshes the prompt fence after an owned session manager append", async () => {
     const sessionFile = await createTempSessionFile();
-    const release = vi.fn(async () => {});
-    const acquireSessionWriteLockLocal3 = vi.fn(async () => ({ release }));
-    const controller = await createEmbeddedAttemptSessionLockController({
-      acquireSessionWriteLock: acquireSessionWriteLockLocal3,
-      lockOptions: { ...lockOptions, sessionFile },
-    });
+    const { controller } = await createMockSessionLockController(sessionFile);
 
     await controller.releaseForPrompt();
     await fs.appendFile(sessionFile, '{"type":"message","id":"owned-session-manager"}\n', "utf8");
@@ -2189,12 +2041,7 @@ describe("embedded attempt session lock lifecycle", () => {
 
   it("refreshes the prompt fence after an owned session manager compaction append", async () => {
     const sessionFile = await createTempSessionFile();
-    const release = vi.fn(async () => {});
-    const acquireSessionWriteLockLocal2 = vi.fn(async () => ({ release }));
-    const controller = await createEmbeddedAttemptSessionLockController({
-      acquireSessionWriteLock: acquireSessionWriteLockLocal2,
-      lockOptions: { ...lockOptions, sessionFile },
-    });
+    const { controller } = await createMockSessionLockController(sessionFile);
     const sessionManager = guardSessionManager(SessionManager.open(sessionFile), {
       withCompactionPersistence: (append, validateAppend) =>
         controller.withOwnedSessionFileWrite(append, validateAppend),
@@ -2204,23 +2051,7 @@ describe("embedded attempt session lock lifecycle", () => {
       content: "old question",
       timestamp: 1,
     });
-    sessionManager.appendMessage({
-      role: "assistant",
-      content: [{ type: "text", text: "old answer" }],
-      api: "messages",
-      provider: "openclaw",
-      model: "session-lock-test",
-      usage: {
-        input: 0,
-        output: 0,
-        cacheRead: 0,
-        cacheWrite: 0,
-        totalTokens: 0,
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-      },
-      stopReason: "stop",
-      timestamp: 2,
-    });
+    appendTestAssistantMessage(sessionManager, "old answer", 2, "session-lock-test");
 
     await controller.releaseForPrompt();
     sessionManager.appendCompaction("threshold summary", firstKeptEntryId, 160_001);
@@ -2267,12 +2098,7 @@ describe("embedded attempt session lock lifecycle", () => {
 
   it("still rejects unowned external compaction appends before the prompt stream lock is reacquired", async () => {
     const sessionFile = await createTempSessionFile();
-    const release = vi.fn(async () => {});
-    const acquireSessionWriteLockLocal1 = vi.fn(async () => ({ release }));
-    const controller = await createEmbeddedAttemptSessionLockController({
-      acquireSessionWriteLock: acquireSessionWriteLockLocal1,
-      lockOptions: { ...lockOptions, sessionFile },
-    });
+    const { controller } = await createMockSessionLockController(sessionFile);
 
     await controller.releaseForPrompt();
     await fs.appendFile(
@@ -2297,12 +2123,7 @@ describe("embedded attempt session lock lifecycle", () => {
 
   it("still rejects an external edit that happens before an owned session manager compaction append", async () => {
     const sessionFile = await createTempSessionFile();
-    const release = vi.fn(async () => {});
-    const acquireSessionWriteLockLocal0 = vi.fn(async () => ({ release }));
-    const controller = await createEmbeddedAttemptSessionLockController({
-      acquireSessionWriteLock: acquireSessionWriteLockLocal0,
-      lockOptions: { ...lockOptions, sessionFile },
-    });
+    const { controller } = await createMockSessionLockController(sessionFile);
     const sessionManager = guardSessionManager(SessionManager.open(sessionFile), {
       withCompactionPersistence: (append, validateAppend) =>
         controller.withOwnedSessionFileWrite(append, validateAppend),
@@ -2312,23 +2133,7 @@ describe("embedded attempt session lock lifecycle", () => {
       content: "old question",
       timestamp: 1,
     });
-    sessionManager.appendMessage({
-      role: "assistant",
-      content: [{ type: "text", text: "old answer" }],
-      api: "messages",
-      provider: "openclaw",
-      model: "session-lock-test",
-      usage: {
-        input: 0,
-        output: 0,
-        cacheRead: 0,
-        cacheWrite: 0,
-        totalTokens: 0,
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-      },
-      stopReason: "stop",
-      timestamp: 2,
-    });
+    appendTestAssistantMessage(sessionManager, "old answer", 2, "session-lock-test");
 
     await controller.releaseForPrompt();
     await fs.appendFile(sessionFile, '{"type":"message","id":"external-edit"}\n', "utf8");
@@ -2342,12 +2147,7 @@ describe("embedded attempt session lock lifecycle", () => {
 
   it("still rejects an external edit interleaved inside an owned session manager compaction append", async () => {
     const sessionFile = await createTempSessionFile();
-    const release = vi.fn(async () => {});
-    const acquireSessionWriteLockLocal30 = vi.fn(async () => ({ release }));
-    const controller = await createEmbeddedAttemptSessionLockController({
-      acquireSessionWriteLock: acquireSessionWriteLockLocal30,
-      lockOptions: { ...lockOptions, sessionFile },
-    });
+    const { controller } = await createMockSessionLockController(sessionFile);
     const sessionManager = guardSessionManager(SessionManager.open(sessionFile), {
       withCompactionPersistence: (append, validateAppend) =>
         controller.withOwnedSessionFileWrite(() => {
@@ -2360,23 +2160,7 @@ describe("embedded attempt session lock lifecycle", () => {
       content: "old question",
       timestamp: 1,
     });
-    sessionManager.appendMessage({
-      role: "assistant",
-      content: [{ type: "text", text: "old answer" }],
-      api: "messages",
-      provider: "openclaw",
-      model: "session-lock-test",
-      usage: {
-        input: 0,
-        output: 0,
-        cacheRead: 0,
-        cacheWrite: 0,
-        totalTokens: 0,
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-      },
-      stopReason: "stop",
-      timestamp: 2,
-    });
+    appendTestAssistantMessage(sessionManager, "old answer", 2, "session-lock-test");
 
     await controller.releaseForPrompt();
     sessionManager.appendCompaction("threshold summary", firstKeptEntryId, 160_001);
@@ -2412,23 +2196,7 @@ describe("embedded attempt session lock lifecycle", () => {
         content: "new question",
         timestamp: 1,
       });
-      sessionManager.appendMessage({
-        role: "assistant",
-        content: [{ type: "text", text: "new answer" }],
-        api: "messages",
-        provider: "openclaw",
-        model: "session-lock-test",
-        usage: {
-          input: 0,
-          output: 0,
-          cacheRead: 0,
-          cacheWrite: 0,
-          totalTokens: 0,
-          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-        },
-        stopReason: "stop",
-        timestamp: 2,
-      });
+      appendTestAssistantMessage(sessionManager, "new answer", 2, "session-lock-test");
       return entryId;
     });
 
@@ -2454,23 +2222,7 @@ describe("embedded attempt session lock lifecycle", () => {
       content: "old question",
       timestamp: 1,
     });
-    sessionManager.appendMessage({
-      role: "assistant",
-      content: [{ type: "text", text: "old answer" }],
-      api: "messages",
-      provider: "openclaw",
-      model: "session-lock-test",
-      usage: {
-        input: 0,
-        output: 0,
-        cacheRead: 0,
-        cacheWrite: 0,
-        totalTokens: 0,
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-      },
-      stopReason: "stop",
-      timestamp: 2,
-    });
+    appendTestAssistantMessage(sessionManager, "old answer", 2, "session-lock-test");
     await firstController.releaseForPrompt();
 
     const secondController = await createEmbeddedAttemptSessionLockController({
@@ -2588,14 +2340,8 @@ describe("embedded attempt session lock lifecycle", () => {
     });
     await controller.releaseForPrompt();
 
-    let releaseFirstWrite!: () => void;
-    const firstWriteCanFinish = new Promise<void>((resolve) => {
-      releaseFirstWrite = resolve;
-    });
-    let markFirstWriteStarted!: () => void;
-    const firstWriteStarted = new Promise<void>((resolve) => {
-      markFirstWriteStarted = resolve;
-    });
+    const firstWriteCanFinish = createDeferred();
+    const firstWriteStarted = createDeferred();
     const appendOwnedAssistant = async (id: string): Promise<string> => {
       await fs.appendFile(
         sessionFile,
@@ -2618,8 +2364,8 @@ describe("embedded attempt session lock lifecycle", () => {
     await controller.withSessionWriteLock(async () => {
       const firstWrite = controller.withSessionWriteLock(
         async () => {
-          markFirstWriteStarted();
-          await firstWriteCanFinish;
+          firstWriteStarted.resolve();
+          await firstWriteCanFinish.promise;
           return await appendOwnedAssistant("owned-first");
         },
         {
@@ -2627,7 +2373,7 @@ describe("embedded attempt session lock lifecycle", () => {
           resolvePublishedEntries: (id) => [{ kind: "id", id }],
         },
       );
-      await firstWriteStarted;
+      await firstWriteStarted.promise;
       const secondWrite = controller.withSessionWriteLock(
         () => appendOwnedAssistant("owned-second"),
         {
@@ -2635,7 +2381,7 @@ describe("embedded attempt session lock lifecycle", () => {
           resolvePublishedEntries: (id) => [{ kind: "id", id }],
         },
       );
-      releaseFirstWrite();
+      firstWriteCanFinish.resolve();
       await Promise.all([firstWrite, secondWrite]);
     });
 
@@ -2660,14 +2406,8 @@ describe("embedded attempt session lock lifecycle", () => {
     });
     await controller.releaseForPrompt();
 
-    let releaseNestedWrite!: () => void;
-    const nestedWriteCanFinish = new Promise<void>((resolve) => {
-      releaseNestedWrite = resolve;
-    });
-    let markNestedWriteStarted!: () => void;
-    const nestedWriteStarted = new Promise<void>((resolve) => {
-      markNestedWriteStarted = resolve;
-    });
+    const nestedWriteCanFinish = createDeferred();
+    const nestedWriteStarted = createDeferred();
     let parentSettled = false;
     const parentWrite = controller
       .withSessionWriteLock(
@@ -2689,8 +2429,8 @@ describe("embedded attempt session lock lifecycle", () => {
           );
           void controller.withSessionWriteLock(
             async () => {
-              markNestedWriteStarted();
-              await nestedWriteCanFinish;
+              nestedWriteStarted.resolve();
+              await nestedWriteCanFinish.promise;
               await controller.withSessionWriteLock(
                 async () => {
                   await fs.appendFile(
@@ -2718,7 +2458,7 @@ describe("embedded attempt session lock lifecycle", () => {
             },
             { publishOwnedWrite: true },
           );
-          await nestedWriteStarted;
+          await nestedWriteStarted.promise;
           return "parent-publication";
         },
         {
@@ -2730,12 +2470,12 @@ describe("embedded attempt session lock lifecycle", () => {
         parentSettled = true;
       });
 
-    await nestedWriteStarted;
+    await nestedWriteStarted.promise;
     await new Promise<void>((resolve) => {
       setImmediate(resolve);
     });
     const settledBeforeNestedWrite = parentSettled;
-    releaseNestedWrite();
+    nestedWriteCanFinish.resolve();
     await parentWrite;
 
     expect(settledBeforeNestedWrite).toBe(false);
@@ -2761,21 +2501,15 @@ describe("embedded attempt session lock lifecycle", () => {
     });
     await controller.releaseForPrompt();
 
-    let releasePublication!: () => void;
-    const publicationCanFinish = new Promise<void>((resolve) => {
-      releasePublication = resolve;
-    });
-    let markPublicationStarted!: () => void;
-    const publicationStarted = new Promise<void>((resolve) => {
-      markPublicationStarted = resolve;
-    });
+    const publicationCanFinish = createDeferred();
+    const publicationStarted = createDeferred();
     let outerSettled = false;
     const outerWrite = controller
       .withSessionWriteLock(async () => {
         void controller.withSessionWriteLock(
           async () => {
-            markPublicationStarted();
-            await publicationCanFinish;
+            publicationStarted.resolve();
+            await publicationCanFinish.promise;
             await fs.appendFile(
               sessionFile,
               `${JSON.stringify({
@@ -2798,18 +2532,18 @@ describe("embedded attempt session lock lifecycle", () => {
             resolvePublishedEntries: (id) => [{ kind: "id", id }],
           },
         );
-        await publicationStarted;
+        await publicationStarted.promise;
       })
       .finally(() => {
         outerSettled = true;
       });
 
-    await publicationStarted;
+    await publicationStarted.promise;
     await new Promise<void>((resolve) => {
       setImmediate(resolve);
     });
     const settledBeforePublication = outerSettled;
-    releasePublication();
+    publicationCanFinish.resolve();
     await outerWrite;
 
     expect(settledBeforePublication).toBe(false);
@@ -2821,14 +2555,8 @@ describe("embedded attempt session lock lifecycle", () => {
   it("reacquires the lock for inherited publications that start during fence merge", async () => {
     const sessionFile = await createTempSessionFile();
     const mergedIds: string[] = [];
-    let markFirstMergeStarted!: () => void;
-    const firstMergeStarted = new Promise<void>((resolve) => {
-      markFirstMergeStarted = resolve;
-    });
-    let releaseFirstMerge!: () => void;
-    const firstMergeCanFinish = new Promise<void>((resolve) => {
-      releaseFirstMerge = resolve;
-    });
+    const firstMergeStarted = createDeferred();
+    const firstMergeCanFinish = createDeferred();
     let mergeCount = 0;
     const controller = await createEmbeddedAttemptSessionLockController({
       acquireSessionWriteLock,
@@ -2836,8 +2564,8 @@ describe("embedded attempt session lock lifecycle", () => {
       mergePromptReleasedSessionEntries: async (entries) => {
         mergeCount += 1;
         if (mergeCount === 1) {
-          markFirstMergeStarted();
-          await firstMergeCanFinish;
+          firstMergeStarted.resolve();
+          await firstMergeCanFinish.promise;
         }
         for (const entry of entries) {
           if (entry.type !== "prompt_released_opaque") {
@@ -2872,7 +2600,7 @@ describe("embedded attempt session lock lifecycle", () => {
     const parentWrite = controller.withSessionWriteLock(
       async () => {
         lateWrite = (async () => {
-          await firstMergeStarted;
+          await firstMergeStarted.promise;
           return await controller.withSessionWriteLock(
             async () => {
               lateWriteRan = true;
@@ -2892,12 +2620,12 @@ describe("embedded attempt session lock lifecycle", () => {
       },
     );
 
-    await firstMergeStarted;
+    await firstMergeStarted.promise;
     await new Promise<void>((resolve) => {
       setImmediate(resolve);
     });
     expect(lateWriteRan).toBe(false);
-    releaseFirstMerge();
+    firstMergeCanFinish.resolve();
     await expect(parentWrite).resolves.toBe("parent-publication");
     await expect(lateWrite).resolves.toBe("late-inherited");
 
@@ -2916,14 +2644,8 @@ describe("embedded attempt session lock lifecycle", () => {
     });
     await controller.releaseForPrompt();
 
-    let releaseFirstWrite!: () => void;
-    const firstWriteCanFinish = new Promise<void>((resolve) => {
-      releaseFirstWrite = resolve;
-    });
-    let markFirstWriteStarted!: () => void;
-    const firstWriteStarted = new Promise<void>((resolve) => {
-      markFirstWriteStarted = resolve;
-    });
+    const firstWriteCanFinish = createDeferred();
+    const firstWriteStarted = createDeferred();
     let secondWriteRan = false;
     const appendAssistant = async (id: string): Promise<string> => {
       await fs.appendFile(
@@ -2948,8 +2670,8 @@ describe("embedded attempt session lock lifecycle", () => {
       controller.withSessionWriteLock(async () => {
         const firstWrite = controller.withSessionWriteLock(
           async () => {
-            markFirstWriteStarted();
-            await firstWriteCanFinish;
+            firstWriteStarted.resolve();
+            await firstWriteCanFinish.promise;
             await appendAssistant("interleaved-external");
             return await appendAssistant("owned-entry");
           },
@@ -2958,7 +2680,7 @@ describe("embedded attempt session lock lifecycle", () => {
             resolvePublishedEntries: (id) => [{ kind: "id", id }],
           },
         );
-        await firstWriteStarted;
+        await firstWriteStarted.promise;
         const secondWrite = controller.withSessionWriteLock(
           async () => {
             secondWriteRan = true;
@@ -2969,7 +2691,7 @@ describe("embedded attempt session lock lifecycle", () => {
             resolvePublishedEntries: (id) => [{ kind: "id", id }],
           },
         );
-        releaseFirstWrite();
+        firstWriteCanFinish.resolve();
         const results = await Promise.allSettled([firstWrite, secondWrite]);
         expect(results.map((result) => result.status)).toEqual(["rejected", "rejected"]);
       }),
@@ -3024,14 +2746,11 @@ describe("embedded attempt session lock lifecycle", () => {
     });
     await controller.releaseForPrompt();
 
-    let releaseDelayedWrite!: () => void;
-    const delayedWriteCanStart = new Promise<void>((resolve) => {
-      releaseDelayedWrite = resolve;
-    });
+    const delayedWriteCanStart = createDeferred();
     let delayedWrite!: Promise<string>;
     await controller.withSessionWriteLock(
       async () => {
-        delayedWrite = delayedWriteCanStart.then(() =>
+        delayedWrite = delayedWriteCanStart.promise.then(() =>
           controller.withSessionWriteLock(() => "delayed-write"),
         );
         await fs.appendFile(
@@ -3057,7 +2776,7 @@ describe("embedded attempt session lock lifecycle", () => {
       },
     );
 
-    releaseDelayedWrite();
+    delayedWriteCanStart.resolve();
     await expect(delayedWrite).resolves.toBe("delayed-write");
     expect(acquireSessionWriteLockLocal).toHaveBeenCalledTimes(3);
     expect(controller.hasSessionTakeover()).toBe(false);
@@ -3242,10 +2961,7 @@ describe("embedded attempt session lock lifecycle", () => {
   it("waits for active retained writers before releasing a takeover lock", async () => {
     const sessionFile = await createTempSessionFile();
     const events: string[] = [];
-    let markActiveWriteStarted!: () => void;
-    const activeWriteStarted = new Promise<void>((resolve) => {
-      markActiveWriteStarted = resolve;
-    });
+    const activeWriteStarted = createDeferred();
     let releaseActiveWrite!: () => void;
     const activeWriteCanFinish = new Promise<void>((resolve) => {
       releaseActiveWrite = () => {
@@ -3269,11 +2985,11 @@ describe("embedded attempt session lock lifecycle", () => {
     const activeWriteResult = Promise.allSettled([
       controller.withSessionWriteLock(async () => {
         events.push("active-start");
-        markActiveWriteStarted();
+        activeWriteStarted.resolve();
         await activeWriteCanFinish;
       }),
     ]).then(([result]) => result);
-    await activeWriteStarted;
+    await activeWriteStarted.promise;
     await fs.appendFile(sessionFile, '{"type":"message","id":"external"}\n', "utf8");
 
     let takeoverSettled = false;
@@ -3408,17 +3124,11 @@ describe("embedded attempt session lock lifecycle", () => {
     const reacquisitionCanFinish = new Promise<{ release(): Promise<void> }>((resolve) => {
       finishReacquisition = resolve;
     });
-    let markFenceValidationStarted!: () => void;
-    const fenceValidationStarted = new Promise<void>((resolve) => {
-      markFenceValidationStarted = resolve;
-    });
-    let finishFenceValidation!: () => void;
-    const fenceValidationCanFinish = new Promise<void>((resolve) => {
-      finishFenceValidation = resolve;
-    });
+    const fenceValidationStarted = createDeferred();
+    const fenceValidationCanFinish = createDeferred();
     const mergePromptReleasedSessionEntries = vi.fn(async () => {
-      markFenceValidationStarted();
-      await fenceValidationCanFinish;
+      fenceValidationStarted.resolve();
+      await fenceValidationCanFinish.promise;
     });
     const acquireSessionWriteLockLocal = vi
       .fn()
@@ -3458,7 +3168,7 @@ describe("embedded attempt session lock lifecycle", () => {
     expect(cleanupSettled).toBe(false);
     expect(acquireSessionWriteLockLocal).toHaveBeenCalledTimes(2);
     finishReacquisition({ release: releaseReacquired });
-    await fenceValidationStarted;
+    await fenceValidationStarted.promise;
     await new Promise<void>((resolve) => {
       setImmediate(resolve);
     });
@@ -3467,7 +3177,7 @@ describe("embedded attempt session lock lifecycle", () => {
     expect(releaseReacquired).not.toHaveBeenCalled();
     expect(mergePromptReleasedSessionEntries).toHaveBeenCalledTimes(1);
 
-    finishFenceValidation();
+    fenceValidationCanFinish.resolve();
     await reacquire;
     const cleanupLock = await cleanupLockPromise;
     expect(releaseReacquired).not.toHaveBeenCalled();
@@ -3794,18 +3504,12 @@ describe("embedded attempt session lock lifecycle", () => {
     });
     await controller.releaseForPrompt();
 
-    let releaseHookAppend!: () => void;
-    const hookCanAppend = new Promise<void>((resolve) => {
-      releaseHookAppend = resolve;
-    });
-    let markHookHasLock!: () => void;
-    const hookHasLock = new Promise<void>((resolve) => {
-      markHookHasLock = resolve;
-    });
+    const hookCanAppend = createDeferred();
+    const hookHasLock = createDeferred();
 
     const hookAppend = controller.withSessionWriteLock(async () => {
-      markHookHasLock();
-      await hookCanAppend;
+      hookHasLock.resolve();
+      await hookCanAppend.promise;
       await appendSessionTranscriptMessage({
         transcriptPath: sessionFile,
         message: {
@@ -3814,7 +3518,7 @@ describe("embedded attempt session lock lifecycle", () => {
         },
       });
     });
-    await hookHasLock;
+    await hookHasLock.promise;
 
     const promptAppend = withOwnedSessionTranscriptWrites(
       {
@@ -3834,7 +3538,7 @@ describe("embedded attempt session lock lifecycle", () => {
     await new Promise<void>((resolve) => {
       setTimeout(resolve, 25);
     });
-    releaseHookAppend();
+    hookCanAppend.resolve();
     await Promise.all([hookAppend, promptAppend]);
 
     const cleanupLock = await controller.acquireForCleanup();

--- a/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
@@ -55,6 +55,15 @@ function endTool(ctx: ToolHandlerContext, event: ToolExecutionEndEvent) {
   return handleToolExecutionEnd(ctx, { type: "tool_execution_end", ...event });
 }
 
+async function executeTool(
+  ctx: ToolHandlerContext,
+  event: ToolExecutionStartEvent & Omit<ToolExecutionEndEvent, "toolName" | "toolCallId">,
+) {
+  const { toolName, toolCallId, args, ...completion } = event;
+  await startTool(ctx, { toolName, toolCallId, args });
+  await endTool(ctx, { toolName, toolCallId, ...completion });
+}
+
 function updateTool(ctx: ToolHandlerContext, event: ToolExecutionUpdateEvent) {
   return handleToolExecutionUpdate(ctx, {
     type: "tool_execution_update",
@@ -65,6 +74,19 @@ function updateTool(ctx: ToolHandlerContext, event: ToolExecutionUpdateEvent) {
 }
 
 const pendingAskUserFinishes = new Set<() => Promise<void>>();
+
+function createBasicAskUserArgs() {
+  return {
+    questions: [
+      {
+        id: "target",
+        header: "Target",
+        question: "Where next?",
+        options: [{ label: "Staging" }, { label: "Production" }],
+      },
+    ],
+  };
+}
 
 async function activateAskUserPrompt(toolCallId: string, args: unknown) {
   let questionId: string | undefined;
@@ -472,16 +494,7 @@ describe("handleToolExecutionStart read path checks", () => {
           releaseFlush = resolve;
         }),
     );
-    const args = {
-      questions: [
-        {
-          id: "target",
-          header: "Target",
-          question: "Where next?",
-          options: [{ label: "Staging" }, { label: "Production" }],
-        },
-      ],
-    };
+    const args = createBasicAskUserArgs();
 
     const pending = startTool(ctx, {
       toolName: "ask_user",
@@ -513,16 +526,7 @@ describe("handleToolExecutionStart read path checks", () => {
           throw failure;
         });
       }
-      const args = {
-        questions: [
-          {
-            id: "target",
-            header: "Target",
-            question: "Where next?",
-            options: [{ label: "Staging" }, { label: "Production" }],
-          },
-        ],
-      };
+      const args = createBasicAskUserArgs();
 
       expect(() =>
         startTool(ctx, {
@@ -545,16 +549,7 @@ describe("handleToolExecutionStart read path checks", () => {
     const { ctx } = createTestContext();
     const onToolResult = vi.fn();
     ctx.params.onToolResult = onToolResult;
-    const args = {
-      questions: [
-        {
-          id: "target",
-          header: "Target",
-          question: "Where next?",
-          options: [{ label: "Staging" }, { label: "Production" }],
-        },
-      ],
-    };
+    const args = createBasicAskUserArgs();
 
     await startTool(ctx, {
       toolName: "ask_user",
@@ -586,25 +581,12 @@ describe("handleToolExecutionStart read path checks", () => {
     const { ctx } = createTestContext();
     const onToolResult = vi.fn();
     ctx.params.onToolResult = onToolResult;
-    const args = {
-      questions: [
-        {
-          id: "target",
-          header: "Target",
-          question: "Where next?",
-          options: [{ label: "Staging" }, { label: "Production" }],
-        },
-      ],
-    };
+    const args = createBasicAskUserArgs();
 
-    await startTool(ctx, {
+    await executeTool(ctx, {
       toolName: "ask_user",
       toolCallId: "ask-denied",
       args,
-    });
-    await endTool(ctx, {
-      toolName: "ask_user",
-      toolCallId: "ask-denied",
       isError: true,
       result: { content: [{ type: "text", text: "denied" }] },
     });
@@ -930,14 +912,10 @@ describe("handleToolExecutionStart read path checks", () => {
   it("keeps an unmarked catalog tool named wait visible", async () => {
     const { ctx, onAgentEvent } = createTestContext();
 
-    await startTool(ctx, {
+    await executeTool(ctx, {
       toolName: "wait",
       toolCallId: "tool-catalog-wait",
       args: {},
-    });
-    await endTool(ctx, {
-      toolName: "wait",
-      toolCallId: "tool-catalog-wait",
       isError: false,
       result: { details: { status: "completed" } },
     });
@@ -955,15 +933,10 @@ describe("handleToolExecutionStart read path checks", () => {
 describe("handleToolExecutionEnd cron mutation tracking", () => {
   it("increments successfulCronAdds when cron add succeeds", async () => {
     const { ctx } = createTestContext();
-    await startTool(ctx, {
+    await executeTool(ctx, {
       toolName: "cron",
       toolCallId: "tool-cron-1",
       args: { action: "add", job: { name: "reminder" } },
-    });
-
-    await endTool(ctx, {
-      toolName: "cron",
-      toolCallId: "tool-cron-1",
       isError: false,
       result: { details: { status: "ok" } },
     });
@@ -974,15 +947,10 @@ describe("handleToolExecutionEnd cron mutation tracking", () => {
 
   it("does not increment successfulCronAdds when cron add fails", async () => {
     const { ctx } = createTestContext();
-    await startTool(ctx, {
+    await executeTool(ctx, {
       toolName: "cron",
       toolCallId: "tool-cron-2",
       args: { action: "add", job: { name: "reminder" } },
-    });
-
-    await endTool(ctx, {
-      toolName: "cron",
-      toolCallId: "tool-cron-2",
       isError: true,
       result: { details: { status: "error" } },
     });
@@ -1015,15 +983,10 @@ describe("handleToolExecutionEnd cron mutation tracking", () => {
     ["exec", "openclaw cron add --at +1h --message 'follow up' 2>&1"],
   ] as const)("increments successfulCronAdds when %s runs %s", async (toolName, command) => {
     const { ctx } = createTestContext();
-    await startTool(ctx, {
+    await executeTool(ctx, {
       toolName,
       toolCallId: "tool-shell-cron-add",
       args: { command },
-    });
-
-    await endTool(ctx, {
-      toolName,
-      toolCallId: "tool-shell-cron-add",
       isError: false,
       result: {
         details: {
@@ -1040,17 +1003,12 @@ describe("handleToolExecutionEnd cron mutation tracking", () => {
 
   it("does not increment successfulCronAdds when shell cron add fails", async () => {
     const { ctx } = createTestContext();
-    await startTool(ctx, {
+    await executeTool(ctx, {
       toolName: "exec",
       toolCallId: "tool-exec-cron-add-failed",
       args: {
         command: "openclaw cron add --at +1h --message 'follow up' --name reminder",
       },
-    });
-
-    await endTool(ctx, {
-      toolName: "exec",
-      toolCallId: "tool-exec-cron-add-failed",
       isError: false,
       result: {
         details: {
@@ -1086,15 +1044,10 @@ describe("handleToolExecutionEnd cron mutation tracking", () => {
     ["openclaw cron add --bad &>>/tmp/cron.log", "a bash-only append redirection"],
   ])("does not count %s (%s)", async (command) => {
     const { ctx } = createTestContext();
-    await startTool(ctx, {
+    await executeTool(ctx, {
       toolName: "exec",
       toolCallId: "tool-exec-not-cron-add",
       args: { command },
-    });
-
-    await endTool(ctx, {
-      toolName: "exec",
-      toolCallId: "tool-exec-not-cron-add",
       isError: false,
       result: {
         details: {
@@ -1111,15 +1064,10 @@ describe("handleToolExecutionEnd cron mutation tracking", () => {
 
   it("keeps pre-execution cron failures replay-safe", async () => {
     const { ctx } = createTestContext();
-    await startTool(ctx, {
+    await executeTool(ctx, {
       toolName: "cron",
       toolCallId: "tool-cron-invalid",
       args: { action: "add" },
-    });
-
-    await endTool(ctx, {
-      toolName: "cron",
-      toolCallId: "tool-cron-invalid",
       isError: true,
       executionStarted: false,
       result: { details: { status: "error", error: "job required" } },
@@ -1136,15 +1084,10 @@ describe("handleToolExecutionEnd cron mutation tracking", () => {
     const { ctx } = createTestContext();
     const toolCallId = "tool-cron-aborted-before-execution";
     recordToolExecutionTracked(toolCallId, "run-test");
-    await startTool(ctx, {
+    await executeTool(ctx, {
       toolName: "cron",
       toolCallId,
       args: { action: "add", job: { name: "reminder" } },
-    });
-
-    await endTool(ctx, {
-      toolName: "cron",
-      toolCallId,
       isError: true,
       result: { details: { status: "error", error: "tool timed out" } },
     });
@@ -1160,15 +1103,10 @@ describe("handleToolExecutionEnd cron mutation tracking", () => {
     const { ctx } = createTestContext();
     const toolCallId = "tool-cron-cancelled-before-body";
     recordToolExecutionTracked(toolCallId, "run-test");
-    await startTool(ctx, {
+    await executeTool(ctx, {
       toolName: "cron",
       toolCallId,
       args: { action: "add", job: { name: "reminder" } },
-    });
-
-    await endTool(ctx, {
-      toolName: "cron",
-      toolCallId,
       isError: true,
       executionStarted: true,
       result: { details: { status: "error", error: "cancelled before tool body" } },
@@ -1184,15 +1122,10 @@ describe("handleToolExecutionEnd cron mutation tracking", () => {
   it("keeps a policy-blocked cron mutation replay-safe", async () => {
     const { ctx } = createTestContext();
     const toolCallId = "tool-cron-blocked";
-    await startTool(ctx, {
+    await executeTool(ctx, {
       toolName: "cron",
       toolCallId,
       args: { action: "add", job: { name: "reminder" } },
-    });
-
-    await endTool(ctx, {
-      toolName: "cron",
-      toolCallId,
       isError: false,
       result: buildBlockedToolResult({
         reason: "blocked by policy",
@@ -1211,15 +1144,10 @@ describe("handleToolExecutionEnd cron mutation tracking", () => {
   it("keeps executed mutations replay-unsafe when middleware rewrites the result as blocked", async () => {
     const { ctx } = createTestContext();
     const toolCallId = "tool-cron-rewritten-blocked";
-    await startTool(ctx, {
+    await executeTool(ctx, {
       toolName: "cron",
       toolCallId,
       args: { action: "add", job: { name: "reminder" } },
-    });
-
-    await endTool(ctx, {
-      toolName: "cron",
-      toolCallId,
       isError: true,
       result: {
         content: [{ type: "text", text: "blocked by middleware" }],
@@ -1254,14 +1182,10 @@ describe("handleToolExecutionEnd cron mutation tracking", () => {
         { name: toolName, execute: vi.fn() } as never,
         "run-test",
       );
-      await startTool(ctx, {
+      await executeTool(ctx, {
         toolName,
         toolCallId,
         args: { action },
-      });
-      await endTool(ctx, {
-        toolName,
-        toolCallId,
         isError: false,
         result: { details: { ok: true } },
       });
@@ -1272,14 +1196,10 @@ describe("handleToolExecutionEnd cron mutation tracking", () => {
 
   it("does not trust replay-safe names without concrete instance provenance", async () => {
     const { ctx } = createTestContext();
-    await startTool(ctx, {
+    await executeTool(ctx, {
       toolName: "search",
       toolCallId: "tool-shadowed-search",
       args: { query: "scheduler" },
-    });
-    await endTool(ctx, {
-      toolName: "search",
-      toolCallId: "tool-shadowed-search",
       isError: false,
       result: { matches: [] },
     });
@@ -1437,15 +1357,10 @@ describe("handleToolExecutionEnd mutating failure recovery", () => {
   it("marks middleware failures on the last tool error", async () => {
     const { ctx } = createTestContext();
 
-    await startTool(ctx, {
+    await executeTool(ctx, {
       toolName: "exec",
       toolCallId: "tool-exec-middleware-error",
       args: { cmd: "echo ok" },
-    });
-
-    await endTool(ctx, {
-      toolName: "exec",
-      toolCallId: "tool-exec-middleware-error",
       isError: false,
       result: {
         content: [
@@ -1470,26 +1385,18 @@ describe("handleToolExecutionEnd mutating failure recovery", () => {
   it("preserves an unresolved mutation across a later read failure", async () => {
     const { ctx } = createTestContext();
 
-    await startTool(ctx, {
+    await executeTool(ctx, {
       toolName: "write",
       toolCallId: "tool-write-failed",
       args: { path: "/tmp/demo.txt", content: "updated" },
-    });
-    await endTool(ctx, {
-      toolName: "write",
-      toolCallId: "tool-write-failed",
       isError: true,
       result: { error: "permission denied" },
     });
 
-    await startTool(ctx, {
+    await executeTool(ctx, {
       toolName: "read",
       toolCallId: "tool-read-failed",
       args: { path: "/tmp/missing.txt" },
-    });
-    await endTool(ctx, {
-      toolName: "read",
-      toolCallId: "tool-read-failed",
       isError: true,
       result: { error: "file not found" },
     });
@@ -1504,7 +1411,7 @@ describe("handleToolExecutionEnd mutating failure recovery", () => {
   it("clears edit failure when the retry succeeds through common file path aliases", async () => {
     const { ctx } = createTestContext();
 
-    await startTool(ctx, {
+    await executeTool(ctx, {
       toolName: "edit",
       toolCallId: "tool-edit-1",
       args: {
@@ -1512,18 +1419,13 @@ describe("handleToolExecutionEnd mutating failure recovery", () => {
         old_string: "beta stale",
         new_string: "beta fixed",
       },
-    });
-
-    await endTool(ctx, {
-      toolName: "edit",
-      toolCallId: "tool-edit-1",
       isError: true,
       result: { error: "Could not find the exact text in /tmp/demo.txt" },
     });
 
     expect(ctx.state.lastToolError?.toolName).toBe("edit");
 
-    await startTool(ctx, {
+    await executeTool(ctx, {
       toolName: "edit",
       toolCallId: "tool-edit-2",
       args: {
@@ -1531,11 +1433,6 @@ describe("handleToolExecutionEnd mutating failure recovery", () => {
         oldText: "beta",
         newText: "beta fixed",
       },
-    });
-
-    await endTool(ctx, {
-      toolName: "edit",
-      toolCallId: "tool-edit-2",
       isError: false,
       result: { ok: true },
     });
@@ -1547,15 +1444,10 @@ describe("handleToolExecutionEnd mutating failure recovery", () => {
     const { ctx, onAgentEvent } = createTestContext();
     const error =
       'Validation failed for tool "edit":\n  - edits: must have required properties edits\n\nReceived arguments:\n{"path":"secret.txt","contents":"PTY_PLANTED_SECRET"}';
-    await startTool(ctx, {
+    await executeTool(ctx, {
       toolName: "edit",
       toolCallId: "tool-edit-validation",
       args: { path: "secret.txt" },
-    });
-
-    await endTool(ctx, {
-      toolName: "edit",
-      toolCallId: "tool-edit-validation",
       isError: true,
       executionStarted: false,
       errorKind: "argument-validation",
@@ -1576,15 +1468,10 @@ describe("handleToolExecutionEnd mutating failure recovery", () => {
     const { ctx, onAgentEvent } = createTestContext();
     const error =
       'Validation failed for tool "edit":\n  - secret tool output\n\nReceived arguments:\n{}';
-    await startTool(ctx, {
+    await executeTool(ctx, {
       toolName: "edit",
       toolCallId: "tool-edit-spoof",
       args: {},
-    });
-
-    await endTool(ctx, {
-      toolName: "edit",
-      toolCallId: "tool-edit-spoof",
       isError: true,
       executionStarted: true,
       result: { details: { status: "error", error } },
@@ -1600,7 +1487,7 @@ describe("handleToolExecutionEnd mutating failure recovery", () => {
   it("marks successful mutating tool results as replay-invalid for terminal lifecycle truth", async () => {
     const { ctx } = createTestContext();
 
-    await startTool(ctx, {
+    await executeTool(ctx, {
       toolName: "edit",
       toolCallId: "tool-edit-side-effect",
       args: {
@@ -1608,11 +1495,6 @@ describe("handleToolExecutionEnd mutating failure recovery", () => {
         old_string: "beta",
         new_string: "gamma",
       },
-    });
-
-    await endTool(ctx, {
-      toolName: "edit",
-      toolCallId: "tool-edit-side-effect",
       isError: false,
       result: { ok: true },
     });
@@ -1626,15 +1508,10 @@ describe("handleToolExecutionEnd mutating failure recovery", () => {
   it("keeps failed mutating tool attempts replay-invalid", async () => {
     const { ctx } = createTestContext();
 
-    await startTool(ctx, {
+    await executeTool(ctx, {
       toolName: "exec",
       toolCallId: "tool-exec-partial-failure",
       args: { command: "printf changed > /tmp/demo.txt && false" },
-    });
-
-    await endTool(ctx, {
-      toolName: "exec",
-      toolCallId: "tool-exec-partial-failure",
       isError: true,
       result: { error: "Command exited with code 1" },
     });
@@ -1648,14 +1525,10 @@ describe("handleToolExecutionEnd mutating failure recovery", () => {
   it("keeps unclassified interactive tool calls replay-invalid", async () => {
     const { ctx } = createTestContext();
 
-    await startTool(ctx, {
+    await executeTool(ctx, {
       toolName: "browser",
       toolCallId: "tool-browser-click",
       args: { action: "act", kind: "click", ref: "e12" },
-    });
-    await endTool(ctx, {
-      toolName: "browser",
-      toolCallId: "tool-browser-click",
       isError: false,
       result: { details: { ok: true } },
     });
@@ -1678,14 +1551,10 @@ describe("handleToolExecutionEnd mutating failure recovery", () => {
       job: { name: "rewritten mutation" },
     });
 
-    await startTool(ctx, {
+    await executeTool(ctx, {
       toolName: "cron",
       toolCallId,
       args: { action: "status" },
-    });
-    await endTool(ctx, {
-      toolName: "cron",
-      toolCallId,
       isError: false,
       result: { ok: true },
     });
@@ -1742,14 +1611,10 @@ describe("handleToolExecutionEnd mutating failure recovery", () => {
       mediaUrl: "/tmp/rewritten.png",
     });
 
-    await startTool(ctx, {
+    await executeTool(ctx, {
       toolName: "message",
       toolCallId,
       args: { action: "status" },
-    });
-    await endTool(ctx, {
-      toolName: "message",
-      toolCallId,
       isError: false,
       result: { details: { messageId: "message-rewritten" } },
     });
@@ -1772,7 +1637,7 @@ describe("handleToolExecutionEnd mutating failure recovery", () => {
     const { ctx } = createTestContext();
     const toolCallId = "tool-message-rich-content";
 
-    await startTool(ctx, {
+    await executeTool(ctx, {
       toolName: "message",
       toolCallId,
       args: {
@@ -1784,10 +1649,6 @@ describe("handleToolExecutionEnd mutating failure recovery", () => {
           blocks: [{ type: "buttons", buttons: [{ label: "OK", value: "ok" }] }],
         }),
       },
-    });
-    await endTool(ctx, {
-      toolName: "message",
-      toolCallId,
       isError: false,
       result: { details: { messageId: "message-rich" } },
     });
@@ -1806,7 +1667,7 @@ describe("handleToolExecutionEnd mutating failure recovery", () => {
     const { ctx } = createTestContext();
     const toolCallId = "tool-message-reply-target";
 
-    await startTool(ctx, {
+    await executeTool(ctx, {
       toolName: "message",
       toolCallId,
       args: {
@@ -1815,10 +1676,6 @@ describe("handleToolExecutionEnd mutating failure recovery", () => {
         target: "chat-reply",
         message: "visible reply",
       },
-    });
-    await endTool(ctx, {
-      toolName: "message",
-      toolCallId,
       isError: false,
       result: { ok: true },
     });
@@ -1838,7 +1695,7 @@ describe("handleToolExecutionEnd mutating failure recovery", () => {
     const { ctx } = createTestContext();
     const toolCallId = "tool-message-thread-create-target";
 
-    await startTool(ctx, {
+    await executeTool(ctx, {
       toolName: "message",
       toolCallId,
       args: {
@@ -1847,10 +1704,6 @@ describe("handleToolExecutionEnd mutating failure recovery", () => {
         target: "chat-thread",
         message: "new thread",
       },
-    });
-    await endTool(ctx, {
-      toolName: "message",
-      toolCallId,
       isError: false,
       result: { ok: true, thread: { id: "thread-1" } },
     });
@@ -1871,7 +1724,7 @@ describe("handleToolExecutionEnd mutating failure recovery", () => {
     const { ctx } = createTestContext();
     const toolCallId = `tool-message-reply-${result.status ?? "dry-run"}`;
 
-    await startTool(ctx, {
+    await executeTool(ctx, {
       toolName: "message",
       toolCallId,
       args: {
@@ -1880,10 +1733,6 @@ describe("handleToolExecutionEnd mutating failure recovery", () => {
         target: "chat-reply",
         message: "visible reply",
       },
-    });
-    await endTool(ctx, {
-      toolName: "message",
-      toolCallId,
       isError: false,
       result,
     });
@@ -1896,7 +1745,7 @@ describe("handleToolExecutionEnd mutating failure recovery", () => {
   it("does not treat text or media arguments on non-messaging tools as delivery", async () => {
     const { ctx } = createTestContext();
 
-    await startTool(ctx, {
+    await executeTool(ctx, {
       toolName: "cron",
       toolCallId: "tool-cron-wake",
       args: {
@@ -1904,10 +1753,6 @@ describe("handleToolExecutionEnd mutating failure recovery", () => {
         text: "not an outbound message",
         mediaUrl: "/tmp/not-an-outbound-message.png",
       },
-    });
-    await endTool(ctx, {
-      toolName: "cron",
-      toolCallId: "tool-cron-wake",
       isError: false,
       result: { details: { status: "ok" } },
     });
@@ -1920,18 +1765,13 @@ describe("handleToolExecutionEnd mutating failure recovery", () => {
   it("marks successful legacy subagents control actions as replay-invalid", async () => {
     const { ctx } = createTestContext();
 
-    await startTool(ctx, {
+    await executeTool(ctx, {
       toolName: "subagents",
       toolCallId: "tool-subagents-kill",
       args: {
         action: "kill",
         target: "worker-1",
       },
-    });
-
-    await endTool(ctx, {
-      toolName: "subagents",
-      toolCallId: "tool-subagents-kill",
       isError: false,
       result: { status: "ok", action: "kill", target: "worker-1" },
     });
@@ -1945,17 +1785,12 @@ describe("handleToolExecutionEnd mutating failure recovery", () => {
   it("keeps action-dependent subagents calls replay-unsafe", async () => {
     const { ctx } = createTestContext();
 
-    await startTool(ctx, {
+    await executeTool(ctx, {
       toolName: "subagents",
       toolCallId: "tool-subagents-list",
       args: {
         action: "list",
       },
-    });
-
-    await endTool(ctx, {
-      toolName: "subagents",
-      toolCallId: "tool-subagents-list",
       isError: false,
       result: { status: "ok", action: "list", total: 0, text: "no active subagents." },
     });
@@ -1970,14 +1805,10 @@ describe("handleToolExecutionEnd mutating failure recovery", () => {
     const { ctx } = createTestContext();
     ctx.params.replaySafeToolNames = new Set(["search"]);
 
-    await startTool(ctx, {
+    await executeTool(ctx, {
       toolName: "search",
       toolCallId: "tool-search",
       args: { query: "scheduler" },
-    });
-    await endTool(ctx, {
-      toolName: "search",
-      toolCallId: "tool-search",
       isError: false,
       result: { matches: [] },
     });
@@ -1994,7 +1825,7 @@ describe("handleToolExecutionEnd mutating failure recovery", () => {
   it("keeps successful mutating retries replay-invalid after an earlier tool failure", async () => {
     const { ctx } = createTestContext();
 
-    await startTool(ctx, {
+    await executeTool(ctx, {
       toolName: "edit",
       toolCallId: "tool-edit-fail-first",
       args: {
@@ -2002,16 +1833,11 @@ describe("handleToolExecutionEnd mutating failure recovery", () => {
         old_string: "beta stale",
         new_string: "gamma",
       },
-    });
-
-    await endTool(ctx, {
-      toolName: "edit",
-      toolCallId: "tool-edit-fail-first",
       isError: true,
       result: { error: "Could not find the exact text in /tmp/demo.txt" },
     });
 
-    await startTool(ctx, {
+    await executeTool(ctx, {
       toolName: "edit",
       toolCallId: "tool-edit-retry-success",
       args: {
@@ -2019,11 +1845,6 @@ describe("handleToolExecutionEnd mutating failure recovery", () => {
         old_string: "beta",
         new_string: "gamma",
       },
-    });
-
-    await endTool(ctx, {
-      toolName: "edit",
-      toolCallId: "tool-edit-retry-success",
       isError: false,
       result: { ok: true },
     });
@@ -2132,10 +1953,10 @@ describe("handleToolExecutionEnd timeout metadata", () => {
   ])("$name", async ({ toolCallId, args, meta, warning }) => {
     const { ctx } = createTestContext();
     ctx.params.toolProgressDetail = "raw";
-    await startTool(ctx, { toolName: "exec", toolCallId, args });
-    await endTool(ctx, {
+    await executeTool(ctx, {
       toolName: "exec",
       toolCallId,
+      args,
       isError: true,
       result: {
         error: "Command exited with code 1",
@@ -2419,15 +2240,10 @@ describe("handleToolExecutionEnd exec approval prompts", () => {
   it("emits approval + blocked command item events when exec needs approval", async () => {
     const { ctx, onAgentEvent } = createTestContext();
 
-    await startTool(ctx, {
+    await executeTool(ctx, {
       toolName: "exec",
       toolCallId: "tool-exec-approval-events",
       args: { command: "npm test" },
-    });
-
-    await endTool(ctx, {
-      toolName: "exec",
-      toolCallId: "tool-exec-approval-events",
       isError: false,
       result: {
         details: {
@@ -2733,15 +2549,10 @@ describe("handleToolExecutionEnd derived tool events", () => {
   it("emits command output events for exec results", async () => {
     const { ctx, onAgentEvent } = createTestContext();
 
-    await startTool(ctx, {
+    await executeTool(ctx, {
       toolName: "exec",
       toolCallId: "tool-exec-output",
       args: { command: "ls" },
-    });
-
-    await endTool(ctx, {
-      toolName: "exec",
-      toolCallId: "tool-exec-output",
       isError: false,
       result: {
         details: {
@@ -2772,15 +2583,10 @@ describe("handleToolExecutionEnd derived tool events", () => {
   it("emits patch summary events for apply_patch results", async () => {
     const { ctx, onAgentEvent } = createTestContext();
 
-    await startTool(ctx, {
+    await executeTool(ctx, {
       toolName: "apply_patch",
       toolCallId: "tool-patch-summary",
       args: { patch: "*** Begin Patch" },
-    });
-
-    await endTool(ctx, {
-      toolName: "apply_patch",
-      toolCallId: "tool-patch-summary",
       isError: false,
       result: {
         details: {
@@ -2970,7 +2776,7 @@ describe("messaging tool media URL tracking", () => {
       },
     });
 
-    await startTool(ctx, {
+    await executeTool(ctx, {
       toolName: "message",
       toolCallId: "tool-mattermost-name",
       args: {
@@ -2979,10 +2785,6 @@ describe("messaging tool media URL tracking", () => {
         to: "town-square",
         content: "hi",
       },
-    });
-    await endTool(ctx, {
-      toolName: "message",
-      toolCallId: "tool-mattermost-name",
       isError: false,
       result: {
         status: "sent",
@@ -3082,11 +2884,9 @@ describe("messaging tool media URL tracking", () => {
     });
   });
 
-  it("commits upload-file args as message delivery evidence", async () => {
-    const { ctx } = createTestContext();
-
-    const startEvt: ToolExecutionStartEvent = {
-      toolName: "message",
+  it.each([
+    {
+      name: "commits upload-file args as message delivery evidence",
       toolCallId: "tool-upload-file",
       args: {
         action: "upload-file",
@@ -3095,36 +2895,12 @@ describe("messaging tool media URL tracking", () => {
         message: "track ready",
         path: "/tmp/generated-song.mp3",
       },
-    };
-    await startTool(ctx, startEvt);
-
-    expect(ctx.state.pendingMessagingMediaUrls.get("tool-upload-file")).toEqual([
-      "/tmp/generated-song.mp3",
-    ]);
-
-    const endEvt: ToolExecutionEndEvent = {
-      toolName: "message",
-      toolCallId: "tool-upload-file",
-      isError: false,
-      result: { ok: true },
-    };
-    await endTool(ctx, endEvt);
-
-    expect(ctx.state.messagingToolSentMediaUrls).toEqual(["/tmp/generated-song.mp3"]);
-    expectRecordFields(requireSingleMessagingTarget(ctx), "messaging target", {
       provider: "discord",
-      to: "channel:123",
-      text: "track ready",
       mediaUrls: ["/tmp/generated-song.mp3"],
-    });
-    expect(ctx.state.pendingMessagingMediaUrls.has("tool-upload-file")).toBe(false);
-  });
-
-  it("commits message attachment aliases as delivery evidence", async () => {
-    const { ctx } = createTestContext();
-
-    const startEvt: ToolExecutionStartEvent = {
-      toolName: "message",
+      verifyPendingMedia: true,
+    },
+    {
+      name: "commits message attachment aliases as delivery evidence",
       toolCallId: "tool-attachment-aliases",
       args: {
         action: "send",
@@ -3133,26 +2909,43 @@ describe("messaging tool media URL tracking", () => {
         media: "/tmp/generated-song.mp3",
         attachments: [{ filePath: "/tmp/generated-cover.png" }],
       },
-    };
-    await startTool(ctx, startEvt);
-
-    const endEvt: ToolExecutionEndEvent = {
+      mediaUrls: ["/tmp/generated-song.mp3", "/tmp/generated-cover.png"],
+    },
+    {
+      name: "commits sendAttachment args as message delivery evidence",
+      toolCallId: "tool-send-attachment",
+      args: {
+        action: "sendAttachment",
+        provider: "discord",
+        to: "channel:123",
+        content: "track ready",
+        filePath: "/tmp/generated-song.mp3",
+      },
+      provider: "discord",
+      mediaUrls: ["/tmp/generated-song.mp3"],
+    },
+  ])("$name", async ({ toolCallId, args, provider, mediaUrls, verifyPendingMedia }) => {
+    const { ctx } = createTestContext();
+    await startTool(ctx, { toolName: "message", toolCallId, args });
+    if (verifyPendingMedia) {
+      expect(ctx.state.pendingMessagingMediaUrls.get(toolCallId)).toEqual(mediaUrls);
+    }
+    await endTool(ctx, {
       toolName: "message",
-      toolCallId: "tool-attachment-aliases",
+      toolCallId,
       isError: false,
       result: { ok: true },
-    };
-    await endTool(ctx, endEvt);
-
-    expect(ctx.state.messagingToolSentMediaUrls).toEqual([
-      "/tmp/generated-song.mp3",
-      "/tmp/generated-cover.png",
-    ]);
+    });
+    expect(ctx.state.messagingToolSentMediaUrls).toEqual(mediaUrls);
     expectRecordFields(requireSingleMessagingTarget(ctx), "messaging target", {
+      ...(provider === undefined ? {} : { provider }),
       to: "channel:123",
       text: "track ready",
-      mediaUrls: ["/tmp/generated-song.mp3", "/tmp/generated-cover.png"],
+      mediaUrls,
     });
+    if (verifyPendingMedia) {
+      expect(ctx.state.pendingMessagingMediaUrls.has(toolCallId)).toBe(false);
+    }
   });
 
   it("commits internal-ui source replies from successful message sends", async () => {
@@ -3198,14 +2991,10 @@ describe("messaging tool media URL tracking", () => {
   it("does not commit dry-run or external message sends as internal-ui source replies", async () => {
     const { ctx } = createTestContext();
 
-    await startTool(ctx, {
+    await executeTool(ctx, {
       toolName: "message",
       toolCallId: "tool-dry-run-source-reply",
       args: { action: "send", message: "preview" },
-    });
-    await endTool(ctx, {
-      toolName: "message",
-      toolCallId: "tool-dry-run-source-reply",
       isError: false,
       result: {
         details: {
@@ -3217,14 +3006,10 @@ describe("messaging tool media URL tracking", () => {
       },
     });
 
-    await startTool(ctx, {
+    await executeTool(ctx, {
       toolName: "message",
       toolCallId: "tool-external-source-reply",
       args: { action: "send", to: "channel:123", message: "sent externally" },
-    });
-    await endTool(ctx, {
-      toolName: "message",
-      toolCallId: "tool-external-source-reply",
       isError: false,
       result: {
         details: {
@@ -3236,39 +3021,6 @@ describe("messaging tool media URL tracking", () => {
     });
 
     expect(ctx.state.messagingToolSourceReplyPayloads).toHaveLength(0);
-  });
-
-  it("commits sendAttachment args as message delivery evidence", async () => {
-    const { ctx } = createTestContext();
-
-    const startEvt: ToolExecutionStartEvent = {
-      toolName: "message",
-      toolCallId: "tool-send-attachment",
-      args: {
-        action: "sendAttachment",
-        provider: "discord",
-        to: "channel:123",
-        content: "track ready",
-        filePath: "/tmp/generated-song.mp3",
-      },
-    };
-    await startTool(ctx, startEvt);
-
-    const endEvt: ToolExecutionEndEvent = {
-      toolName: "message",
-      toolCallId: "tool-send-attachment",
-      isError: false,
-      result: { ok: true },
-    };
-    await endTool(ctx, endEvt);
-
-    expect(ctx.state.messagingToolSentMediaUrls).toEqual(["/tmp/generated-song.mp3"]);
-    expectRecordFields(requireSingleMessagingTarget(ctx), "messaging target", {
-      provider: "discord",
-      to: "channel:123",
-      text: "track ready",
-      mediaUrls: ["/tmp/generated-song.mp3"],
-    });
   });
 
   it("trims messagingToolSentMediaUrls to 200 on commit (FIFO)", async () => {
@@ -3383,15 +3135,10 @@ describe("control UI credential redaction (issue #72283)", () => {
   it("redacts secrets in exec aggregated stdout before emitting command_output", async () => {
     const { ctx, onAgentEvent } = createTestContext();
 
-    await startTool(ctx, {
+    await executeTool(ctx, {
       toolName: "exec",
       toolCallId: "tool-exec-secret",
       args: { command: "cat ~/.openclaw/openclaw.json" },
-    });
-
-    await endTool(ctx, {
-      toolName: "exec",
-      toolCallId: "tool-exec-secret",
       isError: false,
       result: {
         details: {

--- a/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts
+++ b/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts
@@ -1077,190 +1077,133 @@ describe("subscribeEmbeddedAgentSession", () => {
     expect(onReasoningEnd).toHaveBeenCalledTimes(1);
   });
 
-  it("emits delta chunks in agent events for streaming assistant text", () => {
+  it.each([
+    {
+      name: "emits delta chunks in agent events for streaming assistant text",
+      chunks: ["Hello", " world"],
+      expected: [
+        { text: "Hello", delta: "Hello" },
+        { text: "Hello world", delta: " world" },
+      ],
+    },
+    {
+      name: "drops malformed streamed reasoning before orphan close tags when final text follows",
+      chunks: ["private chain of thought </think> Visible answer"],
+      expected: [{ text: "Visible answer", delta: "Visible answer" }],
+    },
+    {
+      name: "replaces leaked MiniMax reasoning when its orphan close arrives in a later delta",
+      chunks: ["private chain", "</mm:think>Visible answer"],
+      expected: [
+        { text: "private chain", delta: "private chain" },
+        { text: "Visible answer", delta: "", replace: true },
+      ],
+    },
+    {
+      name: "replaces malformed streamed reasoning when orphan close tags split across deltas",
+      chunks: ["private chain of thought </thi", "nk> Visible answer"],
+      expected: [{ text: "Visible answer" }],
+      noReplacement: true,
+    },
+    {
+      name: "preserves visible text before a split orphan close when no final text follows",
+      chunks: ["Done ", "</thi", "nk>"],
+      expected: [{ text: "Done" }],
+    },
+    {
+      name: "preserves media directives when orphan close replacement has no text",
+      chunks: ["private chain of thought </thi", "nk>\nMEDIA:/tmp/a.png\n"],
+      messageEnd: "private chain of thought </think>\nMEDIA:/tmp/a.png\n",
+      last: { text: "", mediaUrls: ["/tmp/a.png"] },
+      noReplacement: true,
+    },
+    {
+      name: "preserves block tag literals inside fenced code split across deltas",
+      chunks: ["```xml\n", "<thinking>literal</thinking>\n", "```"],
+      textEnd: "```xml\n<thinking>literal</thinking>\n```",
+      last: { text: "```xml\n<thinking>literal</thinking>\n```" },
+    },
+    {
+      name: "does not infer a fence from a chunk-local line start before reasoning tags",
+      chunks: ["abc", "~~~xml\n<think>secret"],
+      first: { text: "abc" },
+      last: { text: "abc~~~xml" },
+      redacted: "secret",
+    },
+    {
+      name: "preserves split fenced code openers while stripping later reasoning",
+      chunks: ["``", "`xml\n<thinking>literal</thinking>\n```\n<think>secret</think>answer"],
+      last: { text: "```xml\n<thinking>literal</thinking>\n```\nanswer" },
+    },
+    {
+      name: "preserves long fenced code openers split after three markers",
+      chunks: ["```", "`\n<thinking>literal</thinking>\n```\n````"],
+      textEnd: "````\n<thinking>literal</thinking>\n```\n````",
+      last: { text: "````\n<thinking>literal</thinking>\n```\n````" },
+    },
+    {
+      name: "keeps close tag literals inside hidden fenced code stripped across deltas",
+      chunks: ["<think>\n```ts\nliteral ", "</think> still private"],
+      expected: [],
+    },
+    {
+      name: "does not carry hidden fenced code state into visible text",
+      chunks: ["<think>\n```ts\nscratch", "\n```\n</think>Visible answer"],
+      last: { text: "Visible answer" },
+    },
+    {
+      name: "preserves block tag literals inside tilde fenced code split across deltas",
+      chunks: ["~~~xml\n", "<thinking>literal</thinking>\n", "~~~"],
+      textEnd: "~~~xml\n<thinking>literal</thinking>\n~~~",
+      last: { text: "~~~xml\n<thinking>literal</thinking>\n~~~" },
+    },
+  ] satisfies Array<{
+    name: string;
+    chunks: string[];
+    expected?: Array<Record<string, unknown>>;
+    first?: Record<string, unknown>;
+    last?: Record<string, unknown>;
+    messageEnd?: string;
+    textEnd?: string;
+    noReplacement?: boolean;
+    redacted?: string;
+  }>)("$name", (scenario) => {
     const { emit, onAgentEvent } = createAgentEventHarness();
-
     emit({ type: "message_start", message: { role: "assistant" } });
-    emit({
-      type: "message_update",
-      message: { role: "assistant" },
-      assistantMessageEvent: { type: "text_delta", delta: "Hello" },
-    });
-    emit({
-      type: "message_update",
-      message: { role: "assistant" },
-      assistantMessageEvent: { type: "text_delta", delta: " world" },
-    });
-
+    for (const chunk of scenario.chunks) {
+      emitAssistantTextDelta(emit, chunk);
+    }
+    if (scenario.textEnd !== undefined) {
+      emitAssistantTextEnd(emit, scenario.textEnd);
+    }
+    if (scenario.messageEnd !== undefined) {
+      emit({
+        type: "message_end",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: scenario.messageEnd }],
+        } as AssistantMessage,
+      });
+    }
     const payloads = extractAgentEventPayloads(onAgentEvent.mock.calls);
-    expect(payloads[0]?.text).toBe("Hello");
-    expect(payloads[0]?.delta).toBe("Hello");
-    expect(payloads[1]?.text).toBe("Hello world");
-    expect(payloads[1]?.delta).toBe(" world");
-  });
-
-  it("drops malformed streamed reasoning before orphan close tags when final text follows", () => {
-    const { emit, onAgentEvent } = createAgentEventHarness();
-
-    emit({ type: "message_start", message: { role: "assistant" } });
-    emitAssistantTextDelta(emit, "private chain of thought </think> Visible answer");
-
-    const payloads = extractAgentEventPayloads(onAgentEvent.mock.calls);
-    expect(payloads).toHaveLength(1);
-    expect(payloads[0]?.text).toBe("Visible answer");
-    expect(payloads[0]?.delta).toBe("Visible answer");
-  });
-
-  it("replaces leaked MiniMax reasoning when its orphan close arrives in a later delta", () => {
-    const { emit, onAgentEvent } = createAgentEventHarness();
-
-    emit({ type: "message_start", message: { role: "assistant" } });
-    emitAssistantTextDelta(emit, "private chain");
-    emitAssistantTextDelta(emit, "</mm:think>Visible answer");
-
-    const payloads = extractAgentEventPayloads(onAgentEvent.mock.calls);
-    expect(payloads).toMatchObject([
-      { text: "private chain", delta: "private chain" },
-      { text: "Visible answer", delta: "", replace: true },
-    ]);
-  });
-
-  it("replaces malformed streamed reasoning when orphan close tags split across deltas", () => {
-    const { emit, onAgentEvent } = createAgentEventHarness();
-
-    emit({ type: "message_start", message: { role: "assistant" } });
-    emitAssistantTextDelta(emit, "private chain of thought </thi");
-    emitAssistantTextDelta(emit, "nk> Visible answer");
-
-    const payloads = extractAgentEventPayloads(onAgentEvent.mock.calls);
-    expect(payloads).toHaveLength(1);
-    expect(payloads[0]?.text).toBe("Visible answer");
-    expect(payloads[0]?.replace).toBeUndefined();
-  });
-
-  it("preserves visible text before a split orphan close when no final text follows", () => {
-    const { emit, onAgentEvent } = createAgentEventHarness();
-
-    emit({ type: "message_start", message: { role: "assistant" } });
-    emitAssistantTextDelta(emit, "Done ");
-    emitAssistantTextDelta(emit, "</thi");
-    emitAssistantTextDelta(emit, "nk>");
-
-    const payloads = extractAgentEventPayloads(onAgentEvent.mock.calls);
-    expect(payloads).toHaveLength(1);
-    expect(payloads[0]?.text).toBe("Done");
-  });
-
-  it("preserves media directives when orphan close replacement has no text", () => {
-    const { emit, onAgentEvent } = createAgentEventHarness();
-
-    emit({ type: "message_start", message: { role: "assistant" } });
-    emitAssistantTextDelta(emit, "private chain of thought </thi");
-    emitAssistantTextDelta(emit, "nk>\nMEDIA:/tmp/a.png\n");
-    emit({
-      type: "message_end",
-      message: {
-        role: "assistant",
-        content: [{ type: "text", text: "private chain of thought </think>\nMEDIA:/tmp/a.png\n" }],
-      } as AssistantMessage,
-    });
-
-    const payloads = extractAgentEventPayloads(onAgentEvent.mock.calls);
-    expect(payloads.at(-1)).toMatchObject({
-      text: "",
-      mediaUrls: ["/tmp/a.png"],
-    });
-    expect(payloads.at(-1)?.replace).toBeUndefined();
-  });
-
-  it("preserves block tag literals inside fenced code split across deltas", () => {
-    const { emit, onAgentEvent } = createAgentEventHarness();
-    const finalText = "```xml\n<thinking>literal</thinking>\n```";
-
-    emit({ type: "message_start", message: { role: "assistant" } });
-    emitAssistantTextDelta(emit, "```xml\n");
-    emitAssistantTextDelta(emit, "<thinking>literal</thinking>\n");
-    emitAssistantTextDelta(emit, "```");
-    emitAssistantTextEnd(emit, finalText);
-
-    const payloads = extractAgentEventPayloads(onAgentEvent.mock.calls);
-    expect(payloads.at(-1)?.text).toBe(finalText);
-  });
-
-  it("does not infer a fence from a chunk-local line start before reasoning tags", () => {
-    const { emit, onAgentEvent } = createAgentEventHarness();
-
-    emit({ type: "message_start", message: { role: "assistant" } });
-    emitAssistantTextDelta(emit, "abc");
-    emitAssistantTextDelta(emit, "~~~xml\n<think>secret");
-
-    const payloads = extractAgentEventPayloads(onAgentEvent.mock.calls);
-    expect(payloads[0]?.text).toBe("abc");
-    expect(payloads.at(-1)?.text).toBe("abc~~~xml");
-    expect(payloads.some((payload) => String(payload.text).includes("secret"))).toBe(false);
-  });
-
-  it("preserves split fenced code openers while stripping later reasoning", () => {
-    const { emit, onAgentEvent } = createAgentEventHarness();
-
-    emit({ type: "message_start", message: { role: "assistant" } });
-    emitAssistantTextDelta(emit, "``");
-    emitAssistantTextDelta(
-      emit,
-      "`xml\n<thinking>literal</thinking>\n```\n<think>secret</think>answer",
-    );
-
-    const payloads = extractAgentEventPayloads(onAgentEvent.mock.calls);
-    expect(payloads.at(-1)?.text).toBe("```xml\n<thinking>literal</thinking>\n```\nanswer");
-  });
-
-  it("preserves long fenced code openers split after three markers", () => {
-    const { emit, onAgentEvent } = createAgentEventHarness();
-    const finalText = "````\n<thinking>literal</thinking>\n```\n````";
-
-    emit({ type: "message_start", message: { role: "assistant" } });
-    emitAssistantTextDelta(emit, "```");
-    emitAssistantTextDelta(emit, "`\n<thinking>literal</thinking>\n```\n````");
-    emitAssistantTextEnd(emit, finalText);
-
-    const payloads = extractAgentEventPayloads(onAgentEvent.mock.calls);
-    expect(payloads.at(-1)?.text).toBe(finalText);
-  });
-
-  it("keeps close tag literals inside hidden fenced code stripped across deltas", () => {
-    const { emit, onAgentEvent } = createAgentEventHarness();
-
-    emit({ type: "message_start", message: { role: "assistant" } });
-    emitAssistantTextDelta(emit, "<think>\n```ts\nliteral ");
-    emitAssistantTextDelta(emit, "</think> still private");
-
-    const payloads = extractAgentEventPayloads(onAgentEvent.mock.calls);
-    expect(payloads).toHaveLength(0);
-  });
-
-  it("does not carry hidden fenced code state into visible text", () => {
-    const { emit, onAgentEvent } = createAgentEventHarness();
-
-    emit({ type: "message_start", message: { role: "assistant" } });
-    emitAssistantTextDelta(emit, "<think>\n```ts\nscratch");
-    emitAssistantTextDelta(emit, "\n```\n</think>Visible answer");
-
-    const payloads = extractAgentEventPayloads(onAgentEvent.mock.calls);
-    expect(payloads.at(-1)?.text).toBe("Visible answer");
-  });
-
-  it("preserves block tag literals inside tilde fenced code split across deltas", () => {
-    const { emit, onAgentEvent } = createAgentEventHarness();
-    const finalText = "~~~xml\n<thinking>literal</thinking>\n~~~";
-
-    emit({ type: "message_start", message: { role: "assistant" } });
-    emitAssistantTextDelta(emit, "~~~xml\n");
-    emitAssistantTextDelta(emit, "<thinking>literal</thinking>\n");
-    emitAssistantTextDelta(emit, "~~~");
-    emitAssistantTextEnd(emit, finalText);
-
-    const payloads = extractAgentEventPayloads(onAgentEvent.mock.calls);
-    expect(payloads.at(-1)?.text).toBe(finalText);
+    if (scenario.expected !== undefined) {
+      expect(payloads).toHaveLength(scenario.expected.length);
+      expect(payloads).toMatchObject(scenario.expected);
+    }
+    if (scenario.first !== undefined) {
+      expect(payloads[0]).toMatchObject(scenario.first);
+    }
+    if (scenario.last !== undefined) {
+      expect(payloads.at(-1)).toMatchObject(scenario.last);
+    }
+    if (scenario.noReplacement) {
+      expect(payloads.at(-1)?.replace).toBeUndefined();
+    }
+    if (scenario.redacted !== undefined) {
+      expect(payloads.some((payload) => String(payload.text).includes(scenario.redacted))).toBe(
+        false,
+      );
+    }
   });
 
   it("emits agent events on message_end for non-streaming assistant text", () => {

--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -97,6 +97,10 @@ function createGatewayMock(response: Record<string, unknown> = {}) {
   }) as unknown as typeof runtimeCallGateway;
 }
 
+function createPayloadGatewayMock(...payloads: Record<string, unknown>[]) {
+  return createGatewayMock({ result: { payloads } });
+}
+
 function createInProcessGatewayMock(response: Record<string, unknown> = {}) {
   return vi.fn(async () => response) as unknown as typeof runtimeDispatchGatewayMethodInProcess;
 }
@@ -1036,11 +1040,7 @@ describe("deliverSubagentAnnouncement active requester steering", () => {
       gatewayHealth: "live" as const,
       errorMessage: "active session ended before queued steering message was committed",
     }));
-    const callGateway = createGatewayMock({
-      result: {
-        payloads: [{ text: "child completion output" }],
-      },
-    });
+    const callGateway = createPayloadGatewayMock({ text: "child completion output" });
     let activityChecks = 0;
     testing.setDepsForTest({
       callGateway,
@@ -1090,11 +1090,7 @@ describe("deliverSubagentAnnouncement active requester steering", () => {
       reason: "stale_run" as const,
       gatewayHealth: "live" as const,
     }));
-    const callGateway = createGatewayMock({
-      result: {
-        payloads: [{ text: "child completion output" }],
-      },
-    });
+    const callGateway = createPayloadGatewayMock({ text: "child completion output" });
     testing.setDepsForTest({
       callGateway,
       getRequesterSessionActivity: () => ({
@@ -1303,11 +1299,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
   });
 
   it("does not directly deliver failed subagent placeholder output", async () => {
-    const callGateway = createGatewayMock({
-      result: {
-        payloads: [],
-      },
-    });
+    const callGateway = createPayloadGatewayMock();
     const sendMessage = createSendMessageMock();
 
     const result = await deliverDiscordDirectMessageCompletion({
@@ -1332,11 +1324,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
 
   it("directly delivers unprefixed direct targets recognized by the channel grammar", async () => {
     registerDirectTargetTestChannel("qa-channel");
-    const callGateway = createGatewayMock({
-      result: {
-        payloads: [],
-      },
-    });
+    const callGateway = createPayloadGatewayMock();
     const sendMessage = createSendMessageMock();
 
     const result = await deliverSlackChannelAnnouncement({
@@ -1369,11 +1357,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
   });
 
   it("does not raw-send channel completions just because the requester key is direct", async () => {
-    const callGateway = createGatewayMock({
-      result: {
-        payloads: [],
-      },
-    });
+    const callGateway = createPayloadGatewayMock();
     const sendMessage = createSendMessageMock();
 
     const result = await deliverSlackChannelAnnouncement({
@@ -1791,11 +1775,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
   });
 
   it("keeps announce-agent delivery primary for dormant completion events with child output", async () => {
-    const callGateway = createGatewayMock({
-      result: {
-        payloads: [{ text: "requester voice completion" }],
-      },
-    });
+    const callGateway = createPayloadGatewayMock({ text: "requester voice completion" });
     const sendMessage = createSendMessageMock();
     const result = await deliverSlackThreadAnnouncement({
       callGateway,
@@ -1884,11 +1864,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
   });
 
   it("does not raw-send grouped child results when requester-agent output is empty", async () => {
-    const callGateway = createGatewayMock({
-      result: {
-        payloads: [],
-      },
-    });
+    const callGateway = createPayloadGatewayMock();
     const sendMessage = createSendMessageMock();
     const result = await deliverSlackThreadAnnouncement({
       callGateway,
@@ -1915,11 +1891,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
   });
 
   it("treats stale thread subagent completions as delivered after parent handoff", async () => {
-    const callGateway = createGatewayMock({
-      result: {
-        payloads: [],
-      },
-    });
+    const callGateway = createPayloadGatewayMock();
     const sendMessage = createSendMessageMock();
     const queueEmbeddedAgentMessageWithOutcome = createQueueOutcomeSequenceMock([
       "transcript_commit_wait_unsupported",
@@ -2069,11 +2041,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
   });
 
   it("falls back to requester-agent handoff when an active Telegram requester cannot be woken", async () => {
-    const callGateway = createGatewayMock({
-      result: {
-        payloads: [{ text: "child completion output" }],
-      },
-    });
+    const callGateway = createPayloadGatewayMock({ text: "child completion output" });
     const sendMessage = createSendMessageMock();
     const queueEmbeddedAgentMessageWithOutcome = createQueueOutcomeMock(false);
     const result = await deliverTelegramDirectMessageCompletion({
@@ -2124,11 +2092,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
   });
 
   it("does not restart an abandoned requester session for late completion delivery", async () => {
-    const callGateway = createGatewayMock({
-      result: {
-        payloads: [{ text: "child completion output" }],
-      },
-    });
+    const callGateway = createPayloadGatewayMock({ text: "child completion output" });
     const sendMessage = createSendMessageMock();
     const queueEmbeddedAgentMessageWithOutcome = createQueueOutcomeMock(true);
     const result = await deliverTelegramDirectMessageCompletion({
@@ -2169,11 +2133,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
   });
 
   it("uses steer fallback when a completion handoff has no visible output", async () => {
-    const callGateway = createGatewayMock({
-      result: {
-        payloads: [],
-      },
-    });
+    const callGateway = createPayloadGatewayMock();
     const queueEmbeddedAgentMessageWithOutcome = vi
       .fn<QueueEmbeddedAgentMessageWithOutcome>()
       .mockImplementationOnce((sessionId: string) => ({
@@ -2216,11 +2176,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
   });
 
   it("does not fail stale thread subagent completions only because the parent stayed private", async () => {
-    const callGateway = createGatewayMock({
-      result: {
-        payloads: [],
-      },
-    });
+    const callGateway = createPayloadGatewayMock();
     const sendMessage = createSendMessageMock();
     const queueEmbeddedAgentMessageWithOutcome = createQueueOutcomeSequenceMock([
       "transcript_commit_wait_unsupported",
@@ -2244,11 +2200,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
   });
 
   it("keeps generated media DMs on the session agent loop when the first turn has no output", async () => {
-    const callGateway = createGatewayMock({
-      result: {
-        payloads: [],
-      },
-    });
+    const callGateway = createPayloadGatewayMock();
     const sendMessage = createSendMessageMock();
     const result = await deliverDiscordDirectMessageCompletion({
       callGateway,
@@ -2273,7 +2225,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
   it.each([
     {
       name: "fails closed when durable agent-loop persistence is unavailable",
-      createCallGateway: () => createGatewayMock({ result: { payloads: [] } }),
+      createCallGateway: () => createPayloadGatewayMock(),
       event: { childSessionId: "task-123" },
     },
     {
@@ -2287,7 +2239,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     },
     {
       name: "fails closed after cancellation when persistence is unavailable",
-      createCallGateway: () => createGatewayMock({ result: { payloads: [] } }),
+      createCallGateway: () => createPayloadGatewayMock(),
       event: { childSessionKey: "music_generate:task-cancelled-persistence" },
       aborted: true,
     },
@@ -2330,7 +2282,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     },
     {
       name: "does not deliver a no-output notice after ambiguous persistence failure",
-      createCallGateway: () => createGatewayMock({ result: { payloads: [] } }),
+      createCallGateway: () => createPayloadGatewayMock(),
       event: {
         childSessionKey: "music_generate:task-failed-empty",
         status: "error" as const,
@@ -2369,7 +2321,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     },
     {
       name: "does not report successful generation after ambiguous persistence failure",
-      createCallGateway: () => createGatewayMock({ result: { payloads: [] } }),
+      createCallGateway: () => createPayloadGatewayMock(),
       event: {
         childSessionKey: "music_generate:task-empty-success",
         result: "generation completed without a resolved attachment",
@@ -2437,7 +2389,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       claimed: false,
       status,
     });
-    const callGateway = createGatewayMock({ result: { payloads: [] } });
+    const callGateway = createPayloadGatewayMock();
     const sendMessage = createSendMessageMock();
 
     const result = await deliverDiscordDirectMessageCompletion({
@@ -2462,7 +2414,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
   it("keeps an aborted durable handoff pending for retry", async () => {
     const controller = new AbortController();
     controller.abort();
-    const callGateway = createGatewayMock({ result: { payloads: [] } });
+    const callGateway = createPayloadGatewayMock();
 
     const result = await deliverDiscordDirectMessageCompletion({
       callGateway,
@@ -2642,7 +2594,42 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     }
   });
 
-  it("accepts generated media completion DMs from requester-agent delivery evidence", async () => {
+  it.each([
+    {
+      name: "accepts generated media completion DMs from requester-agent delivery evidence",
+      sourceTool: "music_generate",
+      text: "The track is ready.",
+      mediaUrls: ["/tmp/generated-night-drive.mp3"],
+      internalEvents: musicCompletionEvents({
+        replyInstruction:
+          "Tell the user the music is ready. If visible source delivery requires the message tool, send it there with the generated media attached.",
+      }),
+    },
+    {
+      name: "accepts generated image completion DMs from requester-agent delivery evidence",
+      sourceTool: "image_generate",
+      text: "The image is ready.",
+      mediaUrls: ["/tmp/generated-robot.png"],
+      internalEvents: imageCompletionEvents({
+        taskLabel: "small watercolor robot",
+        result: "Generated 1 image.\nMEDIA:/tmp/generated-robot.png",
+        mediaUrls: ["/tmp/generated-robot.png"],
+        replyInstruction: "Tell the user the image is ready and send it through the message tool.",
+      }),
+    },
+    {
+      name: "accepts failed generated media completion notices without requiring message-tool delivery",
+      sourceTool: "music_generate",
+      text: "Music generation failed: provider failed.",
+      internalEvents: musicCompletionEvents({
+        status: "error",
+        statusLabel: "failed",
+        result: "provider failed",
+        mediaUrls: undefined,
+        replyInstruction: "Deliver the failure through the message tool.",
+      }),
+    },
+  ])("$name", async ({ sourceTool, text, mediaUrls, internalEvents }) => {
     const callGateway = createGatewayMock({
       result: {
         payloads: [],
@@ -2652,8 +2639,8 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
             provider: "discord",
             accountId: "acct-1",
             to: "dm:U123",
-            text: "The track is ready.",
-            mediaUrls: ["/tmp/generated-night-drive.mp3"],
+            text,
+            ...(mediaUrls ? { mediaUrls } : {}),
           },
         ],
       },
@@ -2662,13 +2649,9 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     const result = await deliverDiscordDirectMessageCompletion({
       callGateway,
       sendMessage,
-      sourceTool: "music_generate",
-      internalEvents: musicCompletionEvents({
-        replyInstruction:
-          "Tell the user the music is ready. If visible source delivery requires the message tool, send it there with the generated media attached.",
-      }),
+      sourceTool,
+      internalEvents,
     });
-
     expectDeliveryPath(result, "direct");
     expectDiscordDirectAgentParams(callGateway);
     expect(sendMessage).not.toHaveBeenCalled();
@@ -2725,83 +2708,9 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     expect(sendMessage).not.toHaveBeenCalled();
   });
 
-  it("accepts generated image completion DMs from requester-agent delivery evidence", async () => {
-    const callGateway = createGatewayMock({
-      result: {
-        payloads: [],
-        messagingToolSentTargets: [
-          {
-            tool: "message",
-            provider: "discord",
-            accountId: "acct-1",
-            to: "dm:U123",
-            text: "The image is ready.",
-            mediaUrls: ["/tmp/generated-robot.png"],
-          },
-        ],
-      },
-    });
-    const sendMessage = createSendMessageMock();
-    const result = await deliverDiscordDirectMessageCompletion({
-      callGateway,
-      sendMessage,
-      sourceTool: "image_generate",
-      internalEvents: imageCompletionEvents({
-        taskLabel: "small watercolor robot",
-        result: "Generated 1 image.\nMEDIA:/tmp/generated-robot.png",
-        mediaUrls: ["/tmp/generated-robot.png"],
-        replyInstruction: "Tell the user the image is ready and send it through the message tool.",
-      }),
-    });
-
-    expectDeliveryPath(result, "direct");
-    expectDiscordDirectAgentParams(callGateway);
-    expect(sendMessage).not.toHaveBeenCalled();
-  });
-
-  it("accepts failed generated media completion notices without requiring message-tool delivery", async () => {
-    const callGateway = createGatewayMock({
-      result: {
-        payloads: [],
-        messagingToolSentTargets: [
-          {
-            tool: "message",
-            provider: "discord",
-            accountId: "acct-1",
-            to: "dm:U123",
-            text: "Music generation failed: provider failed.",
-          },
-        ],
-      },
-    });
-    const sendMessage = createSendMessageMock();
-    const result = await deliverDiscordDirectMessageCompletion({
-      callGateway,
-      sendMessage,
-      sourceTool: "music_generate",
-      internalEvents: musicCompletionEvents({
-        status: "error",
-        statusLabel: "failed",
-        result: "provider failed",
-        mediaUrls: undefined,
-        replyInstruction: "Deliver the failure through the message tool.",
-      }),
-    });
-
-    expectDeliveryPath(result, "direct");
-    expectDiscordDirectAgentParams(callGateway);
-    expect(sendMessage).not.toHaveBeenCalled();
-  });
-
   it("directly delivers generated media when the announce agent replies text-only", async () => {
-    const callGateway = createGatewayMock({
-      result: {
-        payloads: [
-          {
-            text: "The track is ready.",
-          },
-        ],
-      },
+    const callGateway = createPayloadGatewayMock({
+      text: "The track is ready.",
     });
     const sendMessage = createSendMessageMock();
     const result = await deliverDiscordDirectMessageCompletion({
@@ -2836,10 +2745,8 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
   });
 
   it("allows visible direct delivery for media generation failure summaries without generated media", async () => {
-    const callGateway = createGatewayMock({
-      result: {
-        payloads: [{ text: "Music generation failed. Provider timed out." }],
-      },
+    const callGateway = createPayloadGatewayMock({
+      text: "Music generation failed. Provider timed out.",
     });
     const result = await deliverDiscordDirectMessageCompletion({
       callGateway,
@@ -2858,14 +2765,8 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
   });
 
   it("queues generated media group completions that miss required message-tool delivery", async () => {
-    const callGateway = createGatewayMock({
-      result: {
-        payloads: [
-          {
-            text: "The track is ready.",
-          },
-        ],
-      },
+    const callGateway = createPayloadGatewayMock({
+      text: "The track is ready.",
     });
     const sendMessage = createSendMessageMock();
     const result = await deliverSlackChannelAnnouncement({
@@ -2889,63 +2790,33 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     );
   });
 
-  it("accepts targetless current-chat message-tool media delivery", async () => {
-    const callGateway = createGatewayMock({
-      result: {
+  it.each([
+    {
+      name: "accepts targetless current-chat message-tool media delivery",
+      gatewayResult: {
         payloads: [],
         messagingToolSentMediaUrls: ["/tmp/generated-night-drive.mp3"],
       },
-    });
-    const sendMessage = createSendMessageMock();
-    const result = await deliverSlackChannelAnnouncement({
-      callGateway,
-      sendMessage,
       directIdempotencyKey: "announce-channel-media-targetless-message-tool",
-      sourceTool: "music_generate",
-      runtimeConfig: { messages: { groupChat: { visibleReplies: "message_tool" } } },
-      internalEvents: musicCompletionEvents({
-        replyInstruction: "Tell the user the music is ready and send it through the message tool.",
-      }),
-    });
-
-    expectDeliveryPath(result, "direct");
-    expect(sendMessage).not.toHaveBeenCalled();
-  });
-
-  it("does not resend generated media when delivery evidence uses an equivalent file URL", async () => {
-    const callGateway = createGatewayMock({
-      result: {
+      requiresMessageTool: true,
+      replyInstruction: "Tell the user the music is ready and send it through the message tool.",
+    },
+    {
+      name: "does not resend generated media when delivery evidence uses an equivalent file URL",
+      gatewayResult: {
         payloads: [],
         messagingToolSentMediaUrls: ["file:///tmp/generated%20night%20drive.mp3"],
       },
-    });
-    const sendMessage = createSendMessageMock();
-    const result = await deliverSlackChannelAnnouncement({
-      callGateway,
-      sendMessage,
       directIdempotencyKey: "announce-channel-media-normalized-message-tool",
-      sourceTool: "music_generate",
-      runtimeConfig: { messages: { groupChat: { visibleReplies: "message_tool" } } },
-      internalEvents: musicCompletionEvents({
-        result: "Generated 1 track.\nMEDIA:/tmp/generated night drive.mp3",
-        mediaUrls: ["/tmp/generated night drive.mp3"],
-        replyInstruction: "Tell the user the music is ready and send it through the message tool.",
-      }),
-    });
-
-    expectDeliveryPath(result, "direct");
-    expect(sendMessage).not.toHaveBeenCalled();
-  });
-
-  it("accepts payload-only generated media when message tool sent text only", async () => {
-    const callGateway = createGatewayMock({
-      result: {
-        payloads: [
-          {
-            text: "The track is ready.",
-            mediaUrls: ["/tmp/generated-night-drive.mp3"],
-          },
-        ],
+      requiresMessageTool: true,
+      musicResult: "Generated 1 track.\nMEDIA:/tmp/generated night drive.mp3",
+      mediaUrls: ["/tmp/generated night drive.mp3"],
+      replyInstruction: "Tell the user the music is ready and send it through the message tool.",
+    },
+    {
+      name: "accepts payload-only generated media when message tool sent text only",
+      gatewayResult: {
+        payloads: [{ text: "The track is ready.", mediaUrls: ["/tmp/generated-night-drive.mp3"] }],
         messagingToolSentTargets: [
           {
             tool: "message",
@@ -2956,25 +2827,63 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
           },
         ],
       },
-    });
-    const sendMessage = createSendMessageMock();
-    const result = await deliverSlackChannelAnnouncement({
-      callGateway,
-      sendMessage,
       directIdempotencyKey: "announce-channel-media-text-only-message-tool",
-      sourceTool: "music_generate",
-      internalEvents: musicCompletionEvents({
-        replyInstruction: "Tell the user the music is ready and send it through the message tool.",
-      }),
-    });
+      replyInstruction: "Tell the user the music is ready and send it through the message tool.",
+    },
+    {
+      name: "does not fallback for generated media group completions when message tool evidence exists",
+      gatewayResult: {
+        payloads: [],
+        didSendViaMessagingTool: false,
+        messagingToolSentTargets: [
+          {
+            tool: "message",
+            provider: "slack",
+            accountId: "acct-1",
+            to: "channel:C123",
+            text: "The track is ready.",
+            mediaUrls: ["/tmp/generated-night-drive.mp3"],
+          },
+        ],
+      },
+      directIdempotencyKey: "announce-channel-media-message-tool-evidence",
+      replyInstruction: "Deliver the generated music through the message tool.",
+    },
+  ])(
+    "$name",
+    async ({
+      gatewayResult,
+      directIdempotencyKey,
+      requiresMessageTool,
+      musicResult,
+      mediaUrls,
+      replyInstruction,
+    }) => {
+      const callGateway = createGatewayMock({ result: gatewayResult });
+      const sendMessage = createSendMessageMock();
+      const result = await deliverSlackChannelAnnouncement({
+        callGateway,
+        sendMessage,
+        directIdempotencyKey,
+        sourceTool: "music_generate",
+        ...(requiresMessageTool
+          ? { runtimeConfig: { messages: { groupChat: { visibleReplies: "message_tool" } } } }
+          : {}),
+        internalEvents: musicCompletionEvents({
+          ...(musicResult === undefined ? {} : { result: musicResult }),
+          ...(mediaUrls === undefined ? {} : { mediaUrls }),
+          replyInstruction,
+        }),
+      });
+      expectDeliveryPath(result, "direct");
+      expect(sendMessage).not.toHaveBeenCalled();
+    },
+  );
 
-    expectDeliveryPath(result, "direct");
-    expect(sendMessage).not.toHaveBeenCalled();
-  });
-
-  it("directly delivers only missing generated media after partial message-tool delivery", async () => {
-    const callGateway = createGatewayMock({
-      result: {
+  it.each([
+    {
+      name: "directly delivers only missing generated media after partial message-tool delivery",
+      gatewayResult: {
         payloads: [],
         messagingToolSentTargets: [
           {
@@ -2987,23 +2896,54 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
           },
         ],
       },
-    });
+      directIdempotencyKey: "announce-channel-media-partial-message-tool",
+      replyInstruction:
+        "Tell the user the images are ready and send them through the message tool.",
+    },
+    {
+      name: "directly delivers only missing generated media after partial automatic delivery",
+      gatewayResult: {
+        payloads: [
+          { text: "The first image is ready.", mediaUrls: ["/tmp/generated-robot-1.png"] },
+        ],
+      },
+      directIdempotencyKey: "announce-channel-media-partial-automatic",
+      replyInstruction: "Tell the user the images are ready and include the generated media.",
+    },
+    {
+      name: "directly delivers generated media suppressed by automatic final delivery",
+      gatewayResult: {
+        payloads: [
+          { text: "First image", mediaUrls: ["/tmp/generated-robot-1.png"] },
+          { text: "Second image", mediaUrls: ["/tmp/generated-robot-2.png"] },
+        ],
+        deliveryStatus: {
+          status: "sent",
+          payloadOutcomes: [
+            { index: 0, status: "sent", resultCount: 1 },
+            { index: 1, status: "suppressed", reason: "cancelled_by_message_sending_hook" },
+          ],
+        },
+      },
+      directIdempotencyKey: "announce-channel-media-automatic-suppressed",
+      replyInstruction: "Tell the user the images are ready and include the generated media.",
+    },
+  ])("$name", async ({ gatewayResult, directIdempotencyKey, replyInstruction }) => {
+    const callGateway = createGatewayMock({ result: gatewayResult });
     const sendMessage = createSendMessageMock();
     const result = await deliverSlackChannelAnnouncement({
       callGateway,
       sendMessage,
-      directIdempotencyKey: "announce-channel-media-partial-message-tool",
+      directIdempotencyKey,
       sourceTool: "image_generate",
       internalEvents: imageCompletionEvents({
         taskLabel: "two proof images",
         result:
           "Generated 2 images.\nMEDIA:/tmp/generated-robot-1.png\nMEDIA:/tmp/generated-robot-2.png",
         mediaUrls: ["/tmp/generated-robot-1.png", "/tmp/generated-robot-2.png"],
-        replyInstruction:
-          "Tell the user the images are ready and send them through the message tool.",
+        replyInstruction,
       }),
     });
-
     expectDeliveryPath(result, "direct");
     expect(sendMessage).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -3012,7 +2952,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
         to: "channel:C123",
         content: "The generated image is ready.",
         mediaUrls: ["/tmp/generated-robot-2.png"],
-        idempotencyKey: "announce-channel-media-partial-message-tool:generated-media-direct",
+        idempotencyKey: `${directIdempotencyKey}:generated-media-direct`,
       }),
     );
   });
@@ -3059,45 +2999,6 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     expect(sessionDeliveryQueueMocks.scheduleSessionDelivery).not.toHaveBeenCalled();
   });
 
-  it("directly delivers only missing generated media after partial automatic delivery", async () => {
-    const callGateway = createGatewayMock({
-      result: {
-        payloads: [
-          {
-            text: "The first image is ready.",
-            mediaUrls: ["/tmp/generated-robot-1.png"],
-          },
-        ],
-      },
-    });
-    const sendMessage = createSendMessageMock();
-    const result = await deliverSlackChannelAnnouncement({
-      callGateway,
-      sendMessage,
-      directIdempotencyKey: "announce-channel-media-partial-automatic",
-      sourceTool: "image_generate",
-      internalEvents: imageCompletionEvents({
-        taskLabel: "two proof images",
-        result:
-          "Generated 2 images.\nMEDIA:/tmp/generated-robot-1.png\nMEDIA:/tmp/generated-robot-2.png",
-        mediaUrls: ["/tmp/generated-robot-1.png", "/tmp/generated-robot-2.png"],
-        replyInstruction: "Tell the user the images are ready and include the generated media.",
-      }),
-    });
-
-    expectDeliveryPath(result, "direct");
-    expect(sendMessage).toHaveBeenCalledWith(
-      expect.objectContaining({
-        channel: "slack",
-        accountId: "acct-1",
-        to: "channel:C123",
-        content: "The generated image is ready.",
-        mediaUrls: ["/tmp/generated-robot-2.png"],
-        idempotencyKey: "announce-channel-media-partial-automatic:generated-media-direct",
-      }),
-    );
-  });
-
   it("retries the session agent when automatic generated-media delivery fails", async () => {
     const callGateway = createGatewayMock({
       result: {
@@ -3132,60 +3033,6 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     expect(sendMessage).not.toHaveBeenCalled();
     expect(sessionDeliveryQueueMocks.scheduleSessionDelivery).toHaveBeenCalledWith(
       "session-delivery-media",
-    );
-  });
-
-  it("directly delivers generated media suppressed by automatic final delivery", async () => {
-    const callGateway = createGatewayMock({
-      result: {
-        payloads: [
-          {
-            text: "First image",
-            mediaUrls: ["/tmp/generated-robot-1.png"],
-          },
-          {
-            text: "Second image",
-            mediaUrls: ["/tmp/generated-robot-2.png"],
-          },
-        ],
-        deliveryStatus: {
-          status: "sent",
-          payloadOutcomes: [
-            { index: 0, status: "sent", resultCount: 1 },
-            {
-              index: 1,
-              status: "suppressed",
-              reason: "cancelled_by_message_sending_hook",
-            },
-          ],
-        },
-      },
-    });
-    const sendMessage = createSendMessageMock();
-    const result = await deliverSlackChannelAnnouncement({
-      callGateway,
-      sendMessage,
-      directIdempotencyKey: "announce-channel-media-automatic-suppressed",
-      sourceTool: "image_generate",
-      internalEvents: imageCompletionEvents({
-        taskLabel: "two proof images",
-        result:
-          "Generated 2 images.\nMEDIA:/tmp/generated-robot-1.png\nMEDIA:/tmp/generated-robot-2.png",
-        mediaUrls: ["/tmp/generated-robot-1.png", "/tmp/generated-robot-2.png"],
-        replyInstruction: "Tell the user the images are ready and include the generated media.",
-      }),
-    });
-
-    expectDeliveryPath(result, "direct");
-    expect(sendMessage).toHaveBeenCalledWith(
-      expect.objectContaining({
-        channel: "slack",
-        accountId: "acct-1",
-        to: "channel:C123",
-        content: "The generated image is ready.",
-        mediaUrls: ["/tmp/generated-robot-2.png"],
-        idempotencyKey: "announce-channel-media-automatic-suppressed:generated-media-direct",
-      }),
     );
   });
 
@@ -3260,11 +3107,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
   });
 
   it("keeps generated media queued when direct fallback fails before delivery", async () => {
-    const callGateway = createGatewayMock({
-      result: {
-        payloads: [],
-      },
-    });
+    const callGateway = createPayloadGatewayMock();
     const sendMessage = vi.fn(async () => {
       throw new Error("bot blocked before upload");
     }) as unknown as typeof runtimeSendMessage;
@@ -3289,11 +3132,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
   });
 
   it("does not attempt raw media fallback before the session agent delivers anything", async () => {
-    const callGateway = createGatewayMock({
-      result: {
-        payloads: [],
-      },
-    });
+    const callGateway = createPayloadGatewayMock();
     const sendMessage = vi.fn(async () => {
       throw new OutboundDeliveryError("second upload failed", {
         cause: new Error("second upload failed"),
@@ -3817,10 +3656,8 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
   });
 
   it("directly delivers stale isolated cron run media failure completions", async () => {
-    const callGateway = createGatewayMock({
-      result: {
-        payloads: [{ text: "Image generation failed. Provider timed out." }],
-      },
+    const callGateway = createPayloadGatewayMock({
+      text: "Image generation failed. Provider timed out.",
     });
     const sendMessage = createSendMessageMock();
     const queueEmbeddedAgentMessageWithOutcome = createQueueOutcomeMock(true);
@@ -3868,14 +3705,8 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
   ])(
     "uses automatic delivery for generated media completions in $name sessions",
     async ({ requesterSessionKey, origin }) => {
-      const callGateway = createGatewayMock({
-        result: {
-          payloads: [
-            {
-              text: "The track is ready.",
-            },
-          ],
-        },
+      const callGateway = createPayloadGatewayMock({
+        text: "The track is ready.",
       });
       const sendMessage = createSendMessageMock();
       const result = await deliverSlackChannelAnnouncement({
@@ -3913,80 +3744,32 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     },
   );
 
-  it("does not fallback for generated media group completions when message tool evidence exists", async () => {
-    const callGateway = createGatewayMock({
-      result: {
-        payloads: [],
-        didSendViaMessagingTool: false,
-        messagingToolSentTargets: [
-          {
-            tool: "message",
-            provider: "slack",
-            accountId: "acct-1",
-            to: "channel:C123",
-            text: "The track is ready.",
-            mediaUrls: ["/tmp/generated-night-drive.mp3"],
-          },
-        ],
-      },
-    });
-    const sendMessage = createSendMessageMock();
-    const result = await deliverSlackChannelAnnouncement({
-      callGateway,
-      sendMessage,
-      directIdempotencyKey: "announce-channel-media-message-tool-evidence",
-      sourceTool: "music_generate",
-      internalEvents: musicCompletionEvents({
-        replyInstruction: "Deliver the generated music through the message tool.",
-      }),
-    });
-
-    expectDeliveryPath(result, "direct");
-    expect(sendMessage).not.toHaveBeenCalled();
-  });
-
-  it("preserves pending announce delivery without direct generated media fallback", async () => {
-    const callGateway = createGatewayMock({
-      runId: "video_generate:task-123:ok",
-      status: "accepted",
-      acceptedAt: Date.now(),
-    });
-    const sendMessage = createSendMessageMock();
-    const result = await deliverSlackChannelAnnouncement({
-      callGateway,
-      sendMessage,
+  it.each([
+    {
+      name: "preserves pending announce delivery without direct generated media fallback",
       directIdempotencyKey: "announce-channel-media-pending",
-      sourceTool: "video_generate",
-      internalEvents: taskCompletionEvents({
-        source: "video_generation",
-        childSessionKey: "video_generate:task-123",
-        childSessionId: "task-123",
-        announceType: "video generation task",
-        taskLabel: "lobster trailer",
-        result: "Generated 1 video.\nMEDIA:/tmp/lobster-trailer.mp4",
-        mediaUrls: ["/tmp/lobster-trailer.mp4"],
-        replyInstruction: "Deliver the generated video through the message tool.",
-      }),
-    });
-
-    expectDeliveryPath(result, "direct");
-    expect(callGateway).toHaveBeenCalledTimes(1);
-    expect(sendMessage).not.toHaveBeenCalled();
-  });
-
-  it("does not race pending announce delivery with direct generated media fallback", async () => {
+      failsIfFallbackRuns: false,
+    },
+    {
+      name: "does not race pending announce delivery with direct generated media fallback",
+      directIdempotencyKey: "announce-channel-media-pending-fallback-fails",
+      failsIfFallbackRuns: true,
+    },
+  ])("$name", async ({ directIdempotencyKey, failsIfFallbackRuns }) => {
     const callGateway = createGatewayMock({
       runId: "video_generate:task-123:ok",
       status: "accepted",
       acceptedAt: Date.now(),
     });
-    const sendMessage = vi.fn(async () => {
-      throw new Error("temporary channel upload failure");
-    }) as unknown as typeof runtimeSendMessage;
+    const sendMessage = failsIfFallbackRuns
+      ? (vi.fn(async () => {
+          throw new Error("temporary channel upload failure");
+        }) as unknown as typeof runtimeSendMessage)
+      : createSendMessageMock();
     const result = await deliverSlackChannelAnnouncement({
       callGateway,
       sendMessage,
-      directIdempotencyKey: "announce-channel-media-pending-fallback-fails",
+      directIdempotencyKey,
       sourceTool: "video_generate",
       internalEvents: taskCompletionEvents({
         source: "video_generation",
@@ -3999,7 +3782,6 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
         replyInstruction: "Deliver the generated video through the message tool.",
       }),
     });
-
     expectDeliveryPath(result, "direct");
     expect(callGateway).toHaveBeenCalledTimes(1);
     expect(sendMessage).not.toHaveBeenCalled();
@@ -4028,11 +3810,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
   });
 
   it("does not fail stale channel subagent completions only because the parent stayed private", async () => {
-    const callGateway = createGatewayMock({
-      result: {
-        payloads: [],
-      },
-    });
+    const callGateway = createPayloadGatewayMock();
     const sendMessage = createSendMessageMock();
     const queueEmbeddedAgentMessageWithOutcome = createQueueOutcomeSequenceMock([
       "transcript_commit_wait_unsupported",
@@ -4088,11 +3866,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
   });
 
   it("fails configured channel subagent completions when parent skips required message tool", async () => {
-    const callGateway = createGatewayMock({
-      result: {
-        payloads: [{ text: "The subagent is done." }],
-      },
-    });
+    const callGateway = createPayloadGatewayMock({ text: "The subagent is done." });
     const queueEmbeddedAgentMessageWithOutcome = createQueueOutcomeMock(false);
     const result = await deliverSlackChannelAnnouncement({
       callGateway,
@@ -4115,11 +3889,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
   });
 
   it("delivers Telegram forum-topic subagent completions through the normal parent handoff", async () => {
-    const callGateway = createGatewayMock({
-      result: {
-        payloads: [{ text: "The delegated task is complete." }],
-      },
-    });
+    const callGateway = createPayloadGatewayMock({ text: "The delegated task is complete." });
 
     const result = await deliverTelegramDirectMessageCompletion({
       callGateway,
@@ -4220,11 +3990,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
   });
 
   it("falls back to the external requester route when completion origin is internal", async () => {
-    const callGateway = createGatewayMock({
-      result: {
-        payloads: [{ text: "child completion output" }],
-      },
-    });
+    const callGateway = createPayloadGatewayMock({ text: "child completion output" });
     const result = await deliverSlackChannelAnnouncement({
       callGateway,
       directIdempotencyKey: "announce-channel-internal-origin",


### PR DESCRIPTION
## What Problem This Solves

Agent session locking, streamed reasoning, message-tool lifecycle, and completion delivery relied on duplicated fixtures and hand-built async gates. The duplication increased maintenance cost and obscured the actual timeout, cancellation, redaction, delivery, and replay invariants.

## Why This Change Was Made

Consolidate repeated lifecycle fixtures, use the canonical void-default deferred helper, and parameterize only scenarios that preserve every original test name, exact event order, assertion, and owner boundary. No production behavior, coverage threshold, exclusion, baseline, configuration, or provider surface changes.

## User Impact

No user-visible behavior change. Developers retain all 436 existing agent regression cases and exact production coverage while the four test files shrink by 840 net lines.

## Evidence

- Immutable head: 967349e500db525c2ce28dce91422f2362b8d5cf; frozen parent: b461ae6de88345ddcc69c787d99e6404c2206cba.
- Exact formatted diff: four agent test files, 689 additions, 1,529 deletions; net 840 lines removed.
- Announcement, session locks, and streaming: all original 297 named tests pass. Frozen V8 production coverage is identical before and after: statements 2817/4901, branches 2510/4965, functions 438/728, lines 2801/4868.
- Message-tool handlers: all original 139 named tests pass. Independently frozen V8 production coverage is identical before and after: statements 584/1228, branches 591/1350, functions 84/164, lines 584/1223.
- Both coverage comparisons use the same frozen owner-specific production-file sets, provider, reporters, and test-only exclusions before and after.
- Full remote core-test changed gate passes: formatting, repository guards, strict test typechecking, and four-file 245-rule oxlint with zero warnings and zero errors; Blacksmith Testbox elapsed 48.268 seconds.
- Fresh high-reasoning structured autoreview passes with no accepted or actionable findings; added-content TruffleHog scan is clean.
- The default void deferred contract was checked directly in src/shared/deferred.ts, and is covered by both passing strict TypeScript and lint gates.
