### PR TITLE
refactor(tests): consolidate CLI command surface fixtures

### DIFF
--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -490,6 +490,10 @@ async function runConfigCommand(args: string[]) {
   await sharedProgram.parseAsync(args, { from: "user" });
 }
 
+function runConfigSet(...args: string[]) {
+  return runConfigCommand(["config", "set", ...args]);
+}
+
 let ExitError: new (code: number, message?: string) => Error;
 
 describe("config cli", () => {
@@ -561,7 +565,7 @@ describe("config cli", () => {
       };
       setSnapshot(resolved, runtimeMerged);
 
-      await runConfigCommand(["config", "set", "gateway.auth.mode", "token"]);
+      await runConfigSet("gateway.auth.mode", "token");
 
       expect(mockWriteConfigFile).toHaveBeenCalledTimes(1);
       const written = firstWrittenConfig();
@@ -593,7 +597,7 @@ describe("config cli", () => {
       } as OpenClawConfig;
       setSnapshot(resolved, runtimeMerged);
 
-      await runConfigCommand(["config", "set", "channels.telegram.dmPolicy", "pairing"]);
+      await runConfigSet("channels.telegram.dmPolicy", "pairing");
 
       expect(mockWriteConfigFile).toHaveBeenCalledTimes(1);
       expect(requireWriteOptions().explicitSetPaths).toEqual([
@@ -650,7 +654,7 @@ describe("config cli", () => {
       } as unknown as OpenClawConfig;
       setSnapshot(resolved, runtimeMerged);
 
-      await runConfigCommand(["config", "set", "gateway.auth.mode", "token"]);
+      await runConfigSet("gateway.auth.mode", "token");
 
       expect(mockWriteConfigFile).toHaveBeenCalledTimes(1);
       const written = firstWrittenConfig();
@@ -746,9 +750,9 @@ describe("config cli", () => {
         ],
       });
 
-      await expect(
-        runConfigCommand(["config", "set", "agents.defaults.model.primary", "missing/nope"]),
-      ).rejects.toThrow(ExitError);
+      await expect(runConfigSet("agents.defaults.model.primary", "missing/nope")).rejects.toThrow(
+        ExitError,
+      );
 
       expect(mockWriteConfigFile).not.toHaveBeenCalled();
       expectErrorIncludes('Cannot set model reference "missing/nope"');
@@ -766,7 +770,7 @@ describe("config cli", () => {
         errors: [],
       });
 
-      await runConfigCommand(["config", "set", "agents.defaults.model.primary", "${MODEL_REF}"]);
+      await runConfigSet("agents.defaults.model.primary", "${MODEL_REF}");
 
       expect(firstWrittenConfig().agents?.defaults?.model).toEqual({
         primary: "${MODEL_REF}",
@@ -924,7 +928,7 @@ describe("config cli", () => {
       };
       setSnapshot(resolved, resolved);
 
-      await runConfigCommand(["config", "set", "gateway.port", "18790"]);
+      await runConfigSet("gateway.port", "18790");
 
       expect(mockWriteConfigFile).toHaveBeenCalledTimes(1);
       const agent = firstWrittenConfig().agents?.list?.[0];
@@ -958,7 +962,7 @@ describe("config cli", () => {
       };
       setSnapshot(resolved, resolved);
 
-      await runConfigCommand(["config", "set", "gateway.port", "18790"]);
+      await runConfigSet("gateway.port", "18790");
 
       expect(mockWriteConfigFile).toHaveBeenCalledTimes(1);
       expect(firstWrittenConfig().models?.providers?.google?.models?.[0]?.id).toBe(
@@ -1005,7 +1009,7 @@ describe("config cli", () => {
       };
       setSnapshot(resolved, resolved);
 
-      await runConfigCommand(["config", "set", "gateway.port", "18790"]);
+      await runConfigSet("gateway.port", "18790");
 
       expect(firstWrittenConfig().models?.providers?.myproxy?.models?.[0]?.id).toBe(
         "vendor/modern-model",
@@ -1216,7 +1220,7 @@ describe("config cli", () => {
       };
       setSnapshot(resolved, resolved);
 
-      await runConfigCommand(["config", "set", "gateway.auth.mode", "token"]);
+      await runConfigSet("gateway.auth.mode", "token");
 
       expect(mockWriteConfigFile).toHaveBeenCalledTimes(1);
       const written = firstWrittenConfig();
@@ -1240,7 +1244,7 @@ describe("config cli", () => {
       };
       setSnapshot(resolved, resolved);
 
-      await runConfigCommand(["config", "set", "gateway.auth.mode", "password"]);
+      await runConfigSet("gateway.auth.mode", "password");
 
       expect(mockWriteConfigFile).toHaveBeenCalledTimes(1);
       const written = firstWrittenConfig();
@@ -1690,7 +1694,7 @@ describe("config cli", () => {
       const resolved: OpenClawConfig = { gateway: { port: 18789 } };
       setSnapshot(resolved, resolved);
 
-      await runConfigCommand(["config", "set", "gateway.auth.mode", "{bad"]);
+      await runConfigSet("gateway.auth.mode", "{bad");
 
       expect(mockWriteConfigFile).toHaveBeenCalledTimes(1);
       const written = firstWrittenConfig();
@@ -1698,9 +1702,9 @@ describe("config cli", () => {
     });
 
     it("throws when strict parsing is enabled via --strict-json", async () => {
-      await expect(
-        runConfigCommand(["config", "set", "gateway.auth.mode", "{bad", "--strict-json"]),
-      ).rejects.toThrow(ExitError);
+      await expect(runConfigSet("gateway.auth.mode", "{bad", "--strict-json")).rejects.toThrow(
+        ExitError,
+      );
 
       expect(mockWriteConfigFile).not.toHaveBeenCalled();
       expect(mockReadConfigFileSnapshot).not.toHaveBeenCalled();
@@ -1709,18 +1713,16 @@ describe("config cli", () => {
     });
 
     it("keeps --json as a strict parsing alias", async () => {
-      await expect(
-        runConfigCommand(["config", "set", "gateway.auth.mode", "{bad", "--json"]),
-      ).rejects.toThrow(ExitError);
+      await expect(runConfigSet("gateway.auth.mode", "{bad", "--json")).rejects.toThrow(ExitError);
 
       expect(mockWriteConfigFile).not.toHaveBeenCalled();
       expect(mockReadConfigFileSnapshot).not.toHaveBeenCalled();
     });
 
     it("rejects JSON5-only object syntax when strict parsing is enabled", async () => {
-      await expect(
-        runConfigCommand(["config", "set", "gateway.auth", "{mode:'token'}", "--strict-json"]),
-      ).rejects.toThrow(ExitError);
+      await expect(runConfigSet("gateway.auth", "{mode:'token'}", "--strict-json")).rejects.toThrow(
+        ExitError,
+      );
 
       expect(mockWriteConfigFile).not.toHaveBeenCalled();
       expect(mockReadConfigFileSnapshot).not.toHaveBeenCalled();
@@ -1868,7 +1870,7 @@ describe("config cli", () => {
       const resolved: OpenClawConfig = {};
       setSnapshot(resolved, resolved);
 
-      await runConfigCommand(["config", "set", "agents.list.0.id", '"tech"', "--strict-json"]);
+      await runConfigSet("agents.list.0.id", '"tech"', "--strict-json");
 
       expect(mockWriteConfigFile).toHaveBeenCalledTimes(1);
       const written = firstWrittenConfig() as {
@@ -2126,7 +2128,7 @@ describe("config cli", () => {
     it("logs a dry-run note when value mode performs no validation checks", async () => {
       setGatewaySnapshot();
 
-      await runConfigCommand(["config", "set", "gateway.port", "19001", "--dry-run"]);
+      await runConfigSet("gateway.port", "19001", "--dry-run");
 
       expect(mockWriteConfigFile).not.toHaveBeenCalled();
       expect(mockResolveSecretRefValue).not.toHaveBeenCalled();
@@ -2206,7 +2208,7 @@ describe("config cli", () => {
         `openclaw-config-batch-nonexistent-${Date.now()}-${Math.random().toString(16).slice(2)}.json`,
       );
       await expect(
-        runConfigCommand(["config", "set", "--batch-file", nonexistentBatchPath, "--allow-exec"]),
+        runConfigSet("--batch-file", nonexistentBatchPath, "--allow-exec"),
       ).rejects.toThrow(ExitError);
 
       expect(mockWriteConfigFile).not.toHaveBeenCalled();
@@ -2343,9 +2345,7 @@ describe("config cli", () => {
     });
 
     it("rejects empty inline batches before reading or rewriting config", async () => {
-      await expect(runConfigCommand(["config", "set", "--batch-json", "[]"])).rejects.toThrow(
-        ExitError,
-      );
+      await expect(runConfigSet("--batch-json", "[]")).rejects.toThrow(ExitError);
 
       expect(mockReadConfigFileSnapshot).not.toHaveBeenCalled();
       expect(mockWriteConfigFile).not.toHaveBeenCalled();
@@ -2356,9 +2356,7 @@ describe("config cli", () => {
     it("rejects empty batch files before reading or rewriting config", async () => {
       const pathname = writeTempJson5File("openclaw-config-batch-empty", []);
       try {
-        await expect(runConfigCommand(["config", "set", "--batch-file", pathname])).rejects.toThrow(
-          ExitError,
-        );
+        await expect(runConfigSet("--batch-file", pathname)).rejects.toThrow(ExitError);
       } finally {
         fs.rmSync(pathname, { force: true });
       }
@@ -2379,7 +2377,7 @@ describe("config cli", () => {
       );
       fs.writeFileSync(pathname, '[{"path":"gateway.auth.mode","value":"token"}]', "utf8");
       try {
-        await runConfigCommand(["config", "set", "--batch-file", pathname]);
+        await runConfigSet("--batch-file", pathname);
       } finally {
         fs.rmSync(pathname, { force: true });
       }
@@ -2422,7 +2420,7 @@ describe("config cli", () => {
         "utf8",
       );
       try {
-        await runConfigCommand(["config", "set", "--batch-file", pathname]);
+        await runConfigSet("--batch-file", pathname);
       } finally {
         fs.rmSync(pathname, { force: true });
       }
@@ -2447,9 +2445,7 @@ describe("config cli", () => {
       );
       fs.writeFileSync(pathname, '{"path":"gateway.auth.mode","value":"token"}', "utf8");
       try {
-        await expect(runConfigCommand(["config", "set", "--batch-file", pathname])).rejects.toThrow(
-          ExitError,
-        );
+        await expect(runConfigSet("--batch-file", pathname)).rejects.toThrow(ExitError);
       } finally {
         fs.rmSync(pathname, { force: true });
       }
@@ -3792,7 +3788,7 @@ describe("config cli", () => {
       };
       setSnapshot(resolved, resolved);
 
-      await runConfigCommand(["config", "set", "agents.list[1].id", "renamed"]);
+      await runConfigSet("agents.list[1].id", "renamed");
 
       expect(mockWriteConfigFile).toHaveBeenCalledTimes(1);
       const written = firstWrittenConfig();
@@ -4412,7 +4408,7 @@ describe("config cli", () => {
       };
       setSnapshot(resolved, withRuntimeDefaults(resolved));
 
-      await runConfigCommand(["config", "set", "gateway.auth.mode", "token"]);
+      await runConfigSet("gateway.auth.mode", "token");
 
       expectLogIncludes("Restart the gateway to apply.");
       expectLogExcludes("Change will apply without restarting the gateway.");
@@ -4428,7 +4424,7 @@ describe("config cli", () => {
       } as unknown as OpenClawConfig;
       setSnapshot(resolved, resolved);
 
-      await runConfigCommand(["config", "set", "plugins.entries.canvas.enabled", "false"]);
+      await runConfigSet("plugins.entries.canvas.enabled", "false");
 
       expectLogIncludes("Updated plugins.entries.canvas.enabled");
       expectLogIncludes("Restart the gateway to apply.");

--- a/src/cli/daemon-cli/status.gather.test.ts
+++ b/src/cli/daemon-cli/status.gather.test.ts
@@ -330,6 +330,10 @@ function callArg(mock: { mock: { calls: unknown[][] } }, index = 0): unknown {
   return call[0];
 }
 
+function gatherStatus(overrides: Partial<Parameters<typeof gatherDaemonStatus>[0]> = {}) {
+  return gatherDaemonStatus({ rpc: {}, probe: true, deep: false, ...overrides });
+}
+
 describe("gatherDaemonStatus", () => {
   let envSnapshot: ReturnType<typeof captureEnv>;
 
@@ -449,11 +453,7 @@ describe("gatherDaemonStatus", () => {
   });
 
   it("uses wss probe URL and forwards TLS fingerprint when daemon TLS is enabled", async () => {
-    const status = await gatherDaemonStatus({
-      rpc: {},
-      probe: true,
-      deep: false,
-    });
+    const status = await gatherStatus();
 
     expect(loadGatewayTlsRuntime).toHaveBeenCalledTimes(1);
     const probeInput = callArg(callGatewayStatusProbe) as {
@@ -483,11 +483,7 @@ describe("gatherDaemonStatus", () => {
   });
 
   it("batches daemon and CLI port status inspection when ports differ", async () => {
-    await gatherDaemonStatus({
-      rpc: {},
-      probe: true,
-      deep: false,
-    });
+    await gatherStatus();
 
     expect(inspectPortUsages).toHaveBeenCalledWith(
       [19001, 18789],
@@ -508,11 +504,7 @@ describe("gatherDaemonStatus", () => {
       },
     });
 
-    const status = await gatherDaemonStatus({
-      rpc: {},
-      probe: false,
-      deep: false,
-    });
+    const status = await gatherStatus({ probe: false });
 
     expect(status.service.gatewayHeap).toMatchObject({ appliedMiB: 6144 });
     expect(status.service.gatewayHeap?.memorySource).toMatch(/^(constrained|physical)$/u);
@@ -527,11 +519,7 @@ describe("gatherDaemonStatus", () => {
       details: ["Windows reports LocalFirewallRules as N/A (GPO-store only)."],
     });
 
-    const status = await gatherDaemonStatus({
-      rpc: {},
-      probe: false,
-      deep: true,
-    });
+    const status = await gatherStatus({ probe: false, deep: true });
 
     expect(inspectWindowsGatewayFirewall).toHaveBeenCalledWith(
       expect.objectContaining({ bind: "lan", mode: "quick", port: 19001 }),
@@ -550,11 +538,7 @@ describe("gatherDaemonStatus", () => {
       version: "2026.5.7",
     });
 
-    const status = await gatherDaemonStatus({
-      rpc: {},
-      probe: true,
-      deep: false,
-    });
+    const status = await gatherStatus();
 
     expect(status.gateway?.version).toBe("2026.5.7");
     expect(status.rpc?.version).toBe("2026.5.7");
@@ -562,12 +546,7 @@ describe("gatherDaemonStatus", () => {
   });
 
   it("forwards requireRpc and configPath to the daemon probe", async () => {
-    await gatherDaemonStatus({
-      rpc: {},
-      probe: true,
-      requireRpc: true,
-      deep: false,
-    });
+    await gatherStatus({ requireRpc: true });
 
     const probeInput = callArg(callGatewayStatusProbe) as {
       requireRpc?: boolean;
@@ -582,11 +561,7 @@ describe("gatherDaemonStatus", () => {
       programArguments: ["/bin/node", "cli", "gateway", "--port", "19001"],
     });
 
-    await gatherDaemonStatus({
-      rpc: {},
-      probe: true,
-      deep: false,
-    });
+    await gatherStatus();
 
     expect(readConfigFileSnapshotCalls).toHaveBeenCalledTimes(1);
     expect(readConfigFileSnapshotCalls).toHaveBeenCalledWith("/tmp/openclaw-cli/openclaw.json");
@@ -601,11 +576,7 @@ describe("gatherDaemonStatus", () => {
       },
     };
 
-    const status = await gatherDaemonStatus({
-      rpc: {},
-      probe: true,
-      deep: false,
-    });
+    const status = await gatherStatus();
 
     expect(resolveGatewayBindHost).toHaveBeenCalledWith("loopback", undefined);
     expect(status.gateway?.bindMode).toBe("loopback");
@@ -626,11 +597,7 @@ describe("gatherDaemonStatus", () => {
       error: "connect ECONNREFUSED override.example:18790",
     });
 
-    const status = await gatherDaemonStatus({
-      rpc: { url: rawUrl },
-      probe: true,
-      deep: false,
-    });
+    const status = await gatherStatus({ rpc: { url: rawUrl } });
 
     expect(loadGatewayTlsRuntime).not.toHaveBeenCalled();
     const probeInput = callArg(callGatewayStatusProbe) as {
@@ -659,12 +626,7 @@ describe("gatherDaemonStatus", () => {
     serviceReadCommand.mockResolvedValueOnce(null);
     serviceIsLoaded.mockResolvedValueOnce(false);
 
-    const status = await gatherDaemonStatus({
-      rpc: {},
-      probe: true,
-      requireRpc: true,
-      deep: true,
-    });
+    const status = await gatherStatus({ requireRpc: true, deep: true });
 
     expect(status.gateway?.probeUrl).toBe("ws://127.0.0.1:18789");
     expect((callArg(callGatewayStatusProbe) as { url?: string }).url).toBe("ws://127.0.0.1:18789");
@@ -697,12 +659,7 @@ describe("gatherDaemonStatus", () => {
         error: "connect ECONNREFUSED 127.0.0.1:18900",
       });
 
-      const status = await gatherDaemonStatus({
-        rpc: {},
-        probe: true,
-        requireRpc: true,
-        deep: true,
-      });
+      const status = await gatherStatus({ requireRpc: true, deep: true });
 
       expect(status.gateway?.probeUrl).toBe("ws://127.0.0.1:18900");
       expect((callArg(callGatewayStatusProbe) as { url?: string }).url).toBe(
@@ -740,11 +697,7 @@ describe("gatherDaemonStatus", () => {
       throw new Error("uv_interface_addresses failed");
     });
 
-    const status = await gatherDaemonStatus({
-      rpc: {},
-      probe: true,
-      deep: false,
-    });
+    const status = await gatherStatus();
 
     expect(status.gateway?.bindMode).toBe("tailnet");
     expect(status.gateway?.bindHost).toBe("127.0.0.1");
@@ -767,11 +720,7 @@ describe("gatherDaemonStatus", () => {
       detail: env?.OPENCLAW_GATEWAY_PORT ?? "missing-port",
     }));
 
-    const status = await gatherDaemonStatus({
-      rpc: {},
-      probe: false,
-      deep: false,
-    });
+    const status = await gatherStatus({ probe: false });
 
     expect(
       serviceReadRuntime.mock.calls.some(([env]) => env?.OPENCLAW_GATEWAY_PORT === "19001"),
@@ -794,7 +743,7 @@ describe("gatherDaemonStatus", () => {
       throw new Error("systemctl show timed out");
     });
 
-    const status = await gatherDaemonStatus({
+    const status = await gatherStatus({
       rpc: { timeout: "100", json: true },
       probe: false,
       deep: true,
@@ -849,11 +798,7 @@ describe("gatherDaemonStatus", () => {
       detail: "Gateway service install not supported on aix",
     });
 
-    const status = await gatherDaemonStatus({
-      rpc: {},
-      probe: false,
-      deep: false,
-    });
+    const status = await gatherStatus({ probe: false });
 
     expect(status.service.command).toBeNull();
     expect(status.service.loaded).toBe(false);
@@ -878,11 +823,7 @@ describe("gatherDaemonStatus", () => {
       supervisorMode: "launchd",
     });
 
-    const status = await gatherDaemonStatus({
-      rpc: {},
-      probe: false,
-      deep: true,
-    });
+    const status = await gatherStatus({ probe: false, deep: true });
 
     const handoffInput = callArg(readGatewayRestartHandoffSync) as NodeJS.ProcessEnv;
     expect(handoffInput.OPENCLAW_STATE_DIR).toBe("/tmp/openclaw-daemon");
@@ -914,11 +855,7 @@ describe("gatherDaemonStatus", () => {
         },
       ]);
 
-      const status = await gatherDaemonStatus({
-        rpc: {},
-        probe: false,
-        deep: true,
-      });
+      const status = await gatherStatus({ probe: false, deep: true });
 
       const staleScanEnv = findStaleOpenClawUpdateLaunchdJobs.mock.calls[0]?.[0];
       expect(staleScanEnv?.OPENCLAW_STATE_DIR).toBe("/tmp/openclaw-daemon");
@@ -938,11 +875,7 @@ describe("gatherDaemonStatus", () => {
   );
 
   it("does not read restart handoffs during normal status", async () => {
-    await gatherDaemonStatus({
-      rpc: {},
-      probe: false,
-      deep: false,
-    });
+    await gatherStatus({ probe: false });
 
     expect(readGatewayRestartHandoffSync).not.toHaveBeenCalled();
     expect(findStaleOpenClawUpdateLaunchdJobs).not.toHaveBeenCalled();
@@ -964,11 +897,7 @@ describe("gatherDaemonStatus", () => {
       ],
     });
 
-    const status = await gatherDaemonStatus({
-      rpc: {},
-      probe: false,
-      deep: true,
-    });
+    const status = await gatherStatus({ probe: false, deep: true });
 
     expect(inspectPortConnections).toHaveBeenCalledWith(19001);
     expect(status.connections?.established).toEqual([
@@ -992,11 +921,7 @@ describe("gatherDaemonStatus", () => {
       },
     };
 
-    const status = await gatherDaemonStatus({
-      rpc: {},
-      probe: false,
-      deep: true,
-    });
+    const status = await gatherStatus({ probe: false, deep: true });
 
     expect(inspectPortConnections).not.toHaveBeenCalled();
     expect(inspectWindowsGatewayFirewall).not.toHaveBeenCalled();
@@ -1029,11 +954,7 @@ describe("gatherDaemonStatus", () => {
     });
 
     try {
-      const status = await gatherDaemonStatus({
-        rpc: {},
-        probe: false,
-        deep: false,
-      });
+      const status = await gatherStatus({ probe: false });
 
       expect(readConfigFileSnapshotCalls).not.toHaveBeenCalled();
       expect(loadConfigCalls).not.toHaveBeenCalled();
@@ -1079,11 +1000,7 @@ describe("gatherDaemonStatus", () => {
     });
 
     try {
-      const status = await gatherDaemonStatus({
-        rpc: {},
-        probe: false,
-        deep: true,
-      });
+      const status = await gatherStatus({ probe: false, deep: true });
 
       expect(createConfigIOCalls).toHaveBeenCalledWith(configPath, "full");
       expect(readConfigFileSnapshotCalls).toHaveBeenCalledWith(configPath);
@@ -1111,11 +1028,7 @@ describe("gatherDaemonStatus", () => {
     };
     setTestEnvValue("DAEMON_GATEWAY_PASSWORD", "daemon-secretref-password"); // pragma: allowlist secret
 
-    await gatherDaemonStatus({
-      rpc: {},
-      probe: true,
-      deep: false,
-    });
+    await gatherStatus();
 
     expect((callArg(callGatewayStatusProbe) as { password?: string }).password).toBe(
       "daemon-secretref-password",
@@ -1140,11 +1053,7 @@ describe("gatherDaemonStatus", () => {
     };
     setTestEnvValue("DAEMON_GATEWAY_TOKEN", "daemon-secretref-token");
 
-    await gatherDaemonStatus({
-      rpc: {},
-      probe: true,
-      deep: false,
-    });
+    await gatherStatus();
 
     expect((callArg(callGatewayStatusProbe) as { token?: string }).token).toBe(
       "daemon-secretref-token",
@@ -1168,12 +1077,7 @@ describe("gatherDaemonStatus", () => {
       },
     };
 
-    const status = await gatherDaemonStatus({
-      rpc: {},
-      probe: true,
-      deep: false,
-      allowExecSecretRefs: false,
-    });
+    const status = await gatherStatus({ allowExecSecretRefs: false });
 
     expect(resolveGatewayProbeAuthSafeWithSecretInputsCalls).not.toHaveBeenCalled();
     const probeInput = callArg(callGatewayStatusProbe) as {
@@ -1208,12 +1112,7 @@ describe("gatherDaemonStatus", () => {
       },
     };
 
-    await gatherDaemonStatus({
-      rpc: {},
-      probe: true,
-      deep: false,
-      allowExecSecretRefs: false,
-    });
+    await gatherStatus({ allowExecSecretRefs: false });
 
     expect(resolveGatewayProbeAuthSafeWithSecretInputsCalls).toHaveBeenCalledTimes(1);
     const probeInput = callArg(callGatewayStatusProbe) as { token?: string; password?: string };
@@ -1240,12 +1139,7 @@ describe("gatherDaemonStatus", () => {
       },
     };
 
-    const status = await gatherDaemonStatus({
-      rpc: {},
-      probe: true,
-      deep: false,
-      allowExecSecretRefs: false,
-    });
+    const status = await gatherStatus({ allowExecSecretRefs: false });
 
     expect(status.rpc?.authWarning).toBeUndefined();
     expect(resolveGatewayProbeAuthSafeWithSecretInputsCalls).toHaveBeenCalledTimes(1);
@@ -1272,11 +1166,7 @@ describe("gatherDaemonStatus", () => {
       },
     };
 
-    await gatherDaemonStatus({
-      rpc: {},
-      probe: true,
-      deep: false,
-    });
+    await gatherStatus();
 
     const probeInput = callArg(callGatewayStatusProbe) as { token?: string; password?: string };
     expect(probeInput.token).toBe("daemon-token");
@@ -1300,11 +1190,7 @@ describe("gatherDaemonStatus", () => {
       },
     };
 
-    const status = await gatherDaemonStatus({
-      rpc: {},
-      probe: true,
-      deep: false,
-    });
+    const status = await gatherStatus();
 
     const probeInput = callArg(callGatewayStatusProbe) as { token?: string; password?: string };
     expect(probeInput.token).toBeUndefined();
@@ -1334,11 +1220,7 @@ describe("gatherDaemonStatus", () => {
       url: "wss://127.0.0.1:19001",
     });
 
-    const status = await gatherDaemonStatus({
-      rpc: {},
-      probe: true,
-      deep: false,
-    });
+    const status = await gatherStatus();
 
     expect(status.rpc?.ok).toBe(false);
     expect(status.rpc?.authWarning).toContain(
@@ -1365,11 +1247,7 @@ describe("gatherDaemonStatus", () => {
     setTestEnvValue("OPENCLAW_GATEWAY_TOKEN", "env-token");
     setTestEnvValue("OPENCLAW_GATEWAY_PASSWORD", "env-password"); // pragma: allowlist secret
 
-    await gatherDaemonStatus({
-      rpc: {},
-      probe: true,
-      deep: false,
-    });
+    await gatherStatus();
 
     const probeInput = callArg(callGatewayStatusProbe) as { token?: string; password?: string };
     expect(probeInput.token).toBeUndefined();
@@ -1377,11 +1255,7 @@ describe("gatherDaemonStatus", () => {
   });
 
   it("skips TLS runtime loading when probe is disabled", async () => {
-    const status = await gatherDaemonStatus({
-      rpc: {},
-      probe: false,
-      deep: false,
-    });
+    const status = await gatherStatus({ probe: false });
 
     expect(loadGatewayTlsRuntime).not.toHaveBeenCalled();
     expect(callGatewayStatusProbe).not.toHaveBeenCalled();
@@ -1406,11 +1280,7 @@ describe("gatherDaemonStatus", () => {
       staleGatewayPids: [9000],
     });
 
-    const status = await gatherDaemonStatus({
-      rpc: {},
-      probe: true,
-      deep: false,
-    });
+    const status = await gatherStatus();
 
     expect((callArg(inspectGatewayRestart) as { port?: number }).port).toBe(19001);
     expect(status.health).toEqual({
@@ -1442,11 +1312,7 @@ describe("gatherDaemonStatus", () => {
       "parse/handle error: Error: ENOSPC: no space left on device, write",
     );
 
-    const status = await gatherDaemonStatus({
-      rpc: {},
-      probe: true,
-      deep: false,
-    });
+    const status = await gatherStatus();
 
     expect(readLastGatewayErrorLine).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -1469,11 +1335,7 @@ describe("gatherDaemonStatus", () => {
       error: "gateway closed (1000): ",
     });
 
-    const status = await gatherDaemonStatus({
-      rpc: { url: "wss://remote.example:18790" },
-      probe: true,
-      deep: false,
-    });
+    const status = await gatherStatus({ rpc: { url: "wss://remote.example:18790" } });
 
     expect(readLastGatewayErrorLine).not.toHaveBeenCalled();
     expect(status.lastError).toBeUndefined();
@@ -1493,11 +1355,7 @@ describe("gatherDaemonStatus", () => {
       error: "gateway closed (1000): ",
     });
 
-    const status = await gatherDaemonStatus({
-      rpc: {},
-      probe: true,
-      deep: false,
-    });
+    const status = await gatherStatus();
 
     expect(readLastGatewayErrorLine).not.toHaveBeenCalled();
     expect(status.lastError).toBeUndefined();
@@ -1521,11 +1379,7 @@ describe("gatherDaemonStatus", () => {
       },
     } as never);
 
-    const status = await gatherDaemonStatus({
-      rpc: {},
-      probe: true,
-      deep: true,
-    });
+    const status = await gatherStatus({ deep: true });
 
     expect(status.pluginVersionDrift?.gatewayVersion).toBe("2026.5.4");
     expect(status.pluginVersionDrift?.drifts).toEqual([]);
@@ -1546,22 +1400,14 @@ describe("gatherDaemonStatus", () => {
       },
     } as never);
 
-    const status = await gatherDaemonStatus({
-      rpc: {},
-      probe: true,
-      deep: true,
-    });
+    const status = await gatherStatus({ deep: true });
 
     expect(status.pluginVersionDrift?.gatewayVersion).toBe("2026.5.4");
     expect(status.pluginVersionDrift?.drifts.map((d) => d.pluginId)).toEqual(["whatsapp"]);
   });
 
   it("reads install records from the merged daemon service environment, not the CLI process env", async () => {
-    await gatherDaemonStatus({
-      rpc: {},
-      probe: true,
-      deep: true,
-    });
+    await gatherStatus({ deep: true });
 
     // The mock daemon service command sets OPENCLAW_STATE_DIR=/tmp/openclaw-daemon,
     // distinct from the CLI process OPENCLAW_STATE_DIR=/tmp/openclaw-cli. Drift
@@ -1584,11 +1430,7 @@ describe("gatherDaemonStatus", () => {
       },
     } as never);
 
-    const status = await gatherDaemonStatus({
-      rpc: {},
-      probe: true,
-      deep: false,
-    });
+    const status = await gatherStatus();
 
     expect(loadInstalledPluginIndexInstallRecords).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/src/cli/devices-cli.test.ts
+++ b/src/cli/devices-cli.test.ts
@@ -105,14 +105,15 @@ function pairedDevice(overrides: Record<string, unknown> = {}) {
   };
 }
 
+function primeGatewayPairing(pending: unknown[], paired: unknown[] = []) {
+  return callGateway.mockResolvedValueOnce({ pending, paired });
+}
+
 function mockGatewayPairingList(
   pendingOverrides: Record<string, unknown> = {},
   pairedOverrides: Record<string, unknown> = {},
 ) {
-  callGateway.mockResolvedValueOnce({
-    pending: [pendingDevice(pendingOverrides)],
-    paired: [pairedDevice(pairedOverrides)],
-  });
+  primeGatewayPairing([pendingDevice(pendingOverrides)], [pairedDevice(pairedOverrides)]);
 }
 
 function rejectGatewayForLocalFallback(message = "gateway closed (1008): pairing required") {
@@ -200,12 +201,9 @@ function hasGatewayMethod(method: string): boolean {
 
 describe("devices cli approve", () => {
   it("uses admin scope when approving an admin-scope request", async () => {
-    callGateway
-      .mockResolvedValueOnce({
-        pending: [pendingDevice({ requestId: "req-123", scopes: ["operator.admin"] })],
-        paired: [],
-      })
-      .mockResolvedValueOnce({ device: { deviceId: "device-1" } });
+    primeGatewayPairing([
+      pendingDevice({ requestId: "req-123", scopes: ["operator.admin"] }),
+    ]).mockResolvedValueOnce({ device: { deviceId: "device-1" } });
 
     await runDevicesApprove(["req-123"]);
 
@@ -219,17 +217,12 @@ describe("devices cli approve", () => {
   });
 
   it("keeps pairing scope for non-admin device approvals", async () => {
-    callGateway
-      .mockResolvedValueOnce({
-        pending: [
-          pendingDevice({
-            requestId: "req-pairing",
-            scopes: ["operator.pairing"],
-          }),
-        ],
-        paired: [],
-      })
-      .mockResolvedValueOnce({ device: { deviceId: "device-1" } });
+    primeGatewayPairing([
+      pendingDevice({
+        requestId: "req-pairing",
+        scopes: ["operator.pairing"],
+      }),
+    ]).mockResolvedValueOnce({ device: { deviceId: "device-1" } });
 
     await runDevicesApprove(["req-pairing"]);
 
@@ -241,11 +234,7 @@ describe("devices cli approve", () => {
   });
 
   it("retries explicit approval with admin scope when a paired-device session is ownership-denied", async () => {
-    callGateway
-      .mockResolvedValueOnce({
-        pending: [],
-        paired: [],
-      })
+    primeGatewayPairing([])
       .mockRejectedValueOnce(new Error("GatewayClientRequestError: device pairing approval denied"))
       .mockResolvedValueOnce({ device: { deviceId: "device-2" } });
 
@@ -265,21 +254,19 @@ describe("devices cli approve", () => {
   });
 
   it("uses admin scope when a repair approval would inherit an admin token", async () => {
-    callGateway
-      .mockResolvedValueOnce({
-        pending: [
-          pendingDevice({
-            requestId: "req-repair",
-            scopes: [],
-          }),
-        ],
-        paired: [
-          pairedDevice({
-            tokens: [{ role: "operator", scopes: ["operator.admin"] }],
-          }),
-        ],
-      })
-      .mockResolvedValueOnce({ device: { deviceId: "device-1" } });
+    primeGatewayPairing(
+      [
+        pendingDevice({
+          requestId: "req-repair",
+          scopes: [],
+        }),
+      ],
+      [
+        pairedDevice({
+          tokens: [{ role: "operator", scopes: ["operator.admin"] }],
+        }),
+      ],
+    ).mockResolvedValueOnce({ device: { deviceId: "device-1" } });
 
     await runDevicesApprove(["req-repair"]);
 
@@ -291,21 +278,19 @@ describe("devices cli approve", () => {
   });
 
   it("inherits non-admin operator token scopes when a repair approval omits explicit scopes", async () => {
-    callGateway
-      .mockResolvedValueOnce({
-        pending: [
-          pendingDevice({
-            requestId: "req-read-repair",
-            scopes: [],
-          }),
-        ],
-        paired: [
-          pairedDevice({
-            tokens: [{ role: "operator", scopes: ["operator.read"] }],
-          }),
-        ],
-      })
-      .mockResolvedValueOnce({ device: { deviceId: "device-1" } });
+    primeGatewayPairing(
+      [
+        pendingDevice({
+          requestId: "req-read-repair",
+          scopes: [],
+        }),
+      ],
+      [
+        pairedDevice({
+          tokens: [{ role: "operator", scopes: ["operator.read"] }],
+        }),
+      ],
+    ).mockResolvedValueOnce({ device: { deviceId: "device-1" } });
 
     await runDevicesApprove(["req-read-repair"]);
 
@@ -317,21 +302,19 @@ describe("devices cli approve", () => {
   });
 
   it("falls back to paired scopes when a repair approval omits explicit scopes and no operator token is stored", async () => {
-    callGateway
-      .mockResolvedValueOnce({
-        pending: [
-          pendingDevice({
-            requestId: "req-read-repair-scopes",
-            scopes: [],
-          }),
-        ],
-        paired: [
-          pairedDevice({
-            scopes: ["operator.read"],
-          }),
-        ],
-      })
-      .mockResolvedValueOnce({ device: { deviceId: "device-1" } });
+    primeGatewayPairing(
+      [
+        pendingDevice({
+          requestId: "req-read-repair-scopes",
+          scopes: [],
+        }),
+      ],
+      [
+        pairedDevice({
+          scopes: ["operator.read"],
+        }),
+      ],
+    ).mockResolvedValueOnce({ device: { deviceId: "device-1" } });
 
     await runDevicesApprove(["req-read-repair-scopes"]);
 

--- a/src/cli/logs-cli.test.ts
+++ b/src/cli/logs-cli.test.ts
@@ -124,6 +124,26 @@ async function runLogsCli(argv: string[]) {
   });
 }
 
+function createGatewayCloseError(params: {
+  code: number;
+  reason: string;
+  message: string;
+  url?: string;
+  urlSource?: "cli" | "local loopback";
+}) {
+  return new GatewayTransportError({
+    kind: "closed",
+    code: params.code,
+    reason: params.reason,
+    connectionDetails: {
+      url: params.url ?? "ws://127.0.0.1:18789",
+      urlSource: params.urlSource ?? "local loopback",
+      message: "",
+    },
+    message: params.message,
+  });
+}
+
 function captureStdoutWrites() {
   const writes: string[] = [];
   vi.spyOn(process.stdout, "write").mockImplementation((chunk: unknown) => {
@@ -381,15 +401,9 @@ describe("logs cli", () => {
 
   it("falls back to the configured Gateway file log on loopback gateway close errors", async () => {
     callGatewayFromCli.mockRejectedValueOnce(
-      new GatewayTransportError({
-        kind: "closed",
+      createGatewayCloseError({
         code: 1000,
         reason: "no close reason",
-        connectionDetails: {
-          url: "ws://127.0.0.1:18789",
-          urlSource: "local loopback",
-          message: "",
-        },
         message: "gateway closed (1000 normal closure): no close reason",
       }),
     );
@@ -436,15 +450,9 @@ describe("logs cli", () => {
   describe("--follow retry behavior", () => {
     it("uses the active systemd journal for implicit local follow failures", async () => {
       vi.spyOn(process, "platform", "get").mockReturnValue("linux");
-      const closeError = new GatewayTransportError({
-        kind: "closed",
+      const closeError = createGatewayCloseError({
         code: 1006,
         reason: "abnormal closure",
-        connectionDetails: {
-          url: "ws://127.0.0.1:18789",
-          urlSource: "local loopback",
-          message: "",
-        },
         message: "gateway closed (1006 abnormal closure): abnormal closure",
       });
       callGatewayFromCli.mockRejectedValueOnce(closeError).mockRejectedValueOnce(closeError);
@@ -521,15 +529,9 @@ describe("logs cli", () => {
       });
       callGatewayFromCli
         .mockRejectedValueOnce(
-          new GatewayTransportError({
-            kind: "closed",
+          createGatewayCloseError({
             code: 1006,
             reason: "abnormal closure",
-            connectionDetails: {
-              url: "ws://127.0.0.1:18789",
-              urlSource: "local loopback",
-              message: "",
-            },
             message: "gateway closed (1006 abnormal closure): abnormal closure",
           }),
         )
@@ -583,15 +585,9 @@ describe("logs cli", () => {
 
     it("keeps journal polling responsive while a Gateway recovery probe is pending", async () => {
       vi.spyOn(process, "platform", "get").mockReturnValue("linux");
-      const closeError = new GatewayTransportError({
-        kind: "closed",
+      const closeError = createGatewayCloseError({
         code: 1006,
         reason: "abnormal closure",
-        connectionDetails: {
-          url: "ws://127.0.0.1:18789",
-          urlSource: "local loopback",
-          message: "",
-        },
         message: "gateway closed (1006 abnormal closure): abnormal closure",
       });
       const pendingProbe = new Promise<never>(() => {
@@ -659,15 +655,9 @@ describe("logs cli", () => {
       vi.spyOn(Date.prototype, "toISOString").mockImplementation(
         () => timestamps.shift() ?? "2026-06-01T00:00:08.000Z",
       );
-      const closeError = new GatewayTransportError({
-        kind: "closed",
+      const closeError = createGatewayCloseError({
         code: 1006,
         reason: "abnormal closure",
-        connectionDetails: {
-          url: "ws://127.0.0.1:18789",
-          urlSource: "local loopback",
-          message: "",
-        },
         message: "gateway closed (1006 abnormal closure): abnormal closure",
       });
       callGatewayFromCli
@@ -730,15 +720,9 @@ describe("logs cli", () => {
 
     it("emits source meta records in --follow --json when fallback recovers", async () => {
       vi.spyOn(process, "platform", "get").mockReturnValue("linux");
-      const closeError = new GatewayTransportError({
-        kind: "closed",
+      const closeError = createGatewayCloseError({
         code: 1006,
         reason: "abnormal closure",
-        connectionDetails: {
-          url: "ws://127.0.0.1:18789",
-          urlSource: "local loopback",
-          message: "",
-        },
         message: "gateway closed (1006 abnormal closure): abnormal closure",
       });
       callGatewayFromCli
@@ -809,15 +793,9 @@ describe("logs cli", () => {
 
     it("keeps journal cursor across repeated fallback before Gateway recovery", async () => {
       vi.spyOn(process, "platform", "get").mockReturnValue("linux");
-      const closeError = new GatewayTransportError({
-        kind: "closed",
+      const closeError = createGatewayCloseError({
         code: 1006,
         reason: "abnormal closure",
-        connectionDetails: {
-          url: "ws://127.0.0.1:18789",
-          urlSource: "local loopback",
-          message: "",
-        },
         message: "gateway closed (1006 abnormal closure): abnormal closure",
       });
       callGatewayFromCli
@@ -893,15 +871,9 @@ describe("logs cli", () => {
     });
 
     it("retries loopback close errors in --follow mode instead of tailing fallback files", async () => {
-      const closeError = new GatewayTransportError({
-        kind: "closed",
+      const closeError = createGatewayCloseError({
         code: 1006,
         reason: "abnormal closure",
-        connectionDetails: {
-          url: "ws://127.0.0.1:18789",
-          urlSource: "local loopback",
-          message: "",
-        },
         message: "gateway closed (1006 abnormal closure): abnormal closure",
       });
       for (let i = 0; i <= 8; i += 1) {
@@ -924,15 +896,10 @@ describe("logs cli", () => {
     it("exits after exhausting max retries in --follow mode with explicit URL", async () => {
       // Explicit --url bypasses shouldUseLocalLogsFallback so close errors reach the retry path.
       // initial attempt + 8 retries = 9 total calls before fatal exit.
-      const closeError = new GatewayTransportError({
-        kind: "closed",
+      const closeError = createGatewayCloseError({
         code: 1006,
         reason: "abnormal closure",
-        connectionDetails: {
-          url: "ws://127.0.0.1:18789",
-          urlSource: "cli",
-          message: "",
-        },
+        urlSource: "cli",
         message: "gateway closed (1006 abnormal closure): abnormal closure",
       });
       for (let i = 0; i <= 8; i += 1) {
@@ -952,15 +919,11 @@ describe("logs cli", () => {
     it("retries on transient close errors in --follow mode with explicit URL (no local fallback)", async () => {
       callGatewayFromCli
         .mockRejectedValueOnce(
-          new GatewayTransportError({
-            kind: "closed",
+          createGatewayCloseError({
             code: 1006,
             reason: "abnormal closure",
-            connectionDetails: {
-              url: "ws://remote.example.com:18789",
-              urlSource: "cli",
-              message: "",
-            },
+            url: "ws://remote.example.com:18789",
+            urlSource: "cli",
             message: "gateway closed (1006 abnormal closure): abnormal closure",
           }),
         )
@@ -993,15 +956,11 @@ describe("logs cli", () => {
     it("emits notice JSON records for retry and reconnect in --follow --json mode", async () => {
       callGatewayFromCli
         .mockRejectedValueOnce(
-          new GatewayTransportError({
-            kind: "closed",
+          createGatewayCloseError({
             code: 1006,
             reason: "abnormal closure",
-            connectionDetails: {
-              url: "ws://remote.example.com:18789",
-              urlSource: "cli",
-              message: "",
-            },
+            url: "ws://remote.example.com:18789",
+            urlSource: "cli",
             message: "gateway closed (1006 abnormal closure): abnormal closure",
           }),
         )
@@ -1043,11 +1002,10 @@ describe("logs cli", () => {
 
     it("exits immediately on pairing-required close errors in --follow mode with explicit URL", async () => {
       callGatewayFromCli.mockRejectedValueOnce(
-        new GatewayTransportError({
-          kind: "closed",
+        createGatewayCloseError({
           code: 1008,
           reason: "pairing required",
-          connectionDetails: { url: "ws://127.0.0.1:18789", urlSource: "cli", message: "" },
+          urlSource: "cli",
           message: "gateway closed (1008 policy violation): pairing required",
         }),
       );
@@ -1064,11 +1022,10 @@ describe("logs cli", () => {
 
     it("exits immediately on app-defined auth errors (4xxx) in --follow mode with explicit URL", async () => {
       callGatewayFromCli.mockRejectedValueOnce(
-        new GatewayTransportError({
-          kind: "closed",
+        createGatewayCloseError({
           code: 4001,
           reason: "unauthorized",
-          connectionDetails: { url: "ws://127.0.0.1:18789", urlSource: "cli", message: "" },
+          urlSource: "cli",
           message: "gateway closed (4001 unauthorized): unauthorized",
         }),
       );
@@ -1108,11 +1065,10 @@ describe("logs cli", () => {
 
     it("routes terminal reset to stderr in --follow --json so stdout stays parseable JSON in a PTY", async () => {
       callGatewayFromCli.mockRejectedValueOnce(
-        new GatewayTransportError({
-          kind: "closed",
+        createGatewayCloseError({
           code: 4001,
           reason: "unauthorized",
-          connectionDetails: { url: "ws://127.0.0.1:18789", urlSource: "cli", message: "" },
+          urlSource: "cli",
           message: "gateway closed (4001 unauthorized): unauthorized",
         }),
       );
@@ -1153,15 +1109,9 @@ describe("logs cli", () => {
 
   it("does not use local fallback for explicit Gateway URLs", async () => {
     callGatewayFromCli.mockRejectedValueOnce(
-      new GatewayTransportError({
-        kind: "closed",
+      createGatewayCloseError({
         code: 1000,
         reason: "no close reason",
-        connectionDetails: {
-          url: "ws://127.0.0.1:18789",
-          urlSource: "local loopback",
-          message: "",
-        },
         message: "gateway closed (1000 normal closure): no close reason",
       }),
     );

--- a/src/cli/plugins-cli.uninstall.test.ts
+++ b/src/cli/plugins-cli.uninstall.test.ts
@@ -33,6 +33,31 @@ const ALPHA_INSTALL_PATH = installedPluginRoot(CLI_STATE_ROOT, "alpha");
 const ORIGINAL_OPENCLAW_NIX_MODE = process.env.OPENCLAW_NIX_MODE;
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
+function primeUninstallPlan(
+  config: OpenClawConfig,
+  overrides: {
+    actions?: Record<string, boolean>;
+    directoryRemoval?: { target: string } | null;
+  } = {},
+): void {
+  planPluginUninstall.mockReturnValue({
+    ok: true,
+    config,
+    actions: {
+      entry: true,
+      install: true,
+      allowlist: false,
+      denylist: false,
+      loadPath: false,
+      memorySlot: false,
+      contextEngineSlot: false,
+      ...overrides.actions,
+      directory: overrides.actions?.directory ?? false,
+    },
+    directoryRemoval: overrides.directoryRemoval ?? null,
+  });
+}
+
 function expectRuntimeLogIncludes(fragment: string) {
   expect(runtimeLogs.join("\n")).toContain(fragment);
 }
@@ -125,21 +150,7 @@ describe("plugins cli uninstall", () => {
       plugins: [{ id: "alpha", name: "alpha" }],
       diagnostics: [],
     });
-    planPluginUninstall.mockReturnValue({
-      ok: true,
-      config: {} as OpenClawConfig,
-      actions: {
-        entry: true,
-        install: true,
-        allowlist: false,
-        denylist: false,
-        loadPath: false,
-        memorySlot: false,
-        contextEngineSlot: true,
-        directory: false,
-      },
-      directoryRemoval: null,
-    });
+    primeUninstallPlan({} as OpenClawConfig, { actions: { contextEngineSlot: true } });
 
     await runPluginsCommand(["plugins", "uninstall", "alpha", "--dry-run"]);
 
@@ -180,21 +191,7 @@ describe("plugins cli uninstall", () => {
       plugins: [{ id: "alpha", name: "alpha" }],
       diagnostics: [],
     });
-    planPluginUninstall.mockReturnValue({
-      ok: true,
-      config: nextConfig,
-      actions: {
-        entry: true,
-        install: true,
-        allowlist: false,
-        denylist: false,
-        loadPath: false,
-        memorySlot: false,
-        contextEngineSlot: false,
-        directory: false,
-      },
-      directoryRemoval: null,
-    });
+    primeUninstallPlan(nextConfig);
 
     await runPluginsCommand(["plugins", "uninstall", "alpha", "--force", "--keep-files"]);
 
@@ -262,21 +259,7 @@ describe("plugins cli uninstall", () => {
       ],
       diagnostics: [],
     });
-    planPluginUninstall.mockReturnValue({
-      ok: true,
-      config: nextConfig,
-      actions: {
-        entry: true,
-        install: true,
-        allowlist: false,
-        denylist: false,
-        loadPath: false,
-        memorySlot: false,
-        contextEngineSlot: false,
-        directory: false,
-      },
-      directoryRemoval: null,
-    });
+    primeUninstallPlan(nextConfig);
 
     await runPluginsCommand(["plugins", "uninstall", "calendar", "--force", "--keep-files"]);
 
@@ -354,21 +337,8 @@ describe("plugins cli uninstall", () => {
         plugins: [{ id: "alpha", name: "alpha" }],
         diagnostics: [],
       });
-      planPluginUninstall.mockReturnValue({
-        ok: true,
-        config: { plugins: { entries: {}, installs: {} } } as OpenClawConfig,
-        actions: {
-          entry: true,
-          install: true,
-          allowlist: false,
-          denylist: false,
-          loadPath: false,
-          memorySlot: false,
-          contextEngineSlot: false,
-          channelConfig: false,
-          directory: false,
-        },
-        directoryRemoval: null,
+      primeUninstallPlan({ plugins: { entries: {}, installs: {} } } as OpenClawConfig, {
+        actions: { channelConfig: false },
       });
       persistClawPackageRef(
         {
@@ -421,21 +391,7 @@ describe("plugins cli uninstall", () => {
       plugins: [{ id: "alpha", name: "alpha" }],
       diagnostics: [],
     });
-    planPluginUninstall.mockReturnValue({
-      ok: true,
-      config: { plugins: { entries: {}, installs: {} } } as OpenClawConfig,
-      actions: {
-        entry: true,
-        install: true,
-        allowlist: false,
-        denylist: false,
-        loadPath: false,
-        memorySlot: false,
-        contextEngineSlot: false,
-        directory: false,
-      },
-      directoryRemoval: null,
-    });
+    primeUninstallPlan({ plugins: { entries: {}, installs: {} } } as OpenClawConfig);
     promptYesNo.mockRejectedValueOnce(new PromptInputClosedError());
 
     await expect(runPluginsCommand(["plugins", "uninstall", "alpha"])).rejects.toThrow(
@@ -485,21 +441,7 @@ describe("plugins cli uninstall", () => {
       plugins: [{ id: "alpha", name: "alpha" }],
       diagnostics: [],
     });
-    planPluginUninstall.mockReturnValue({
-      ok: true,
-      config: nextConfig,
-      actions: {
-        entry: true,
-        install: true,
-        allowlist: false,
-        denylist: false,
-        loadPath: false,
-        memorySlot: false,
-        contextEngineSlot: false,
-        directory: false,
-      },
-      directoryRemoval: null,
-    });
+    primeUninstallPlan(nextConfig);
     replaceConfigFile.mockRejectedValueOnce(new Error("config changed"));
 
     await expect(
@@ -548,21 +490,7 @@ describe("plugins cli uninstall", () => {
       plugins: [{ id: "alpha", name: "alpha" }],
       diagnostics: [],
     });
-    planPluginUninstall.mockReturnValue({
-      ok: true,
-      config: nextConfig,
-      actions: {
-        entry: true,
-        install: true,
-        allowlist: false,
-        denylist: false,
-        loadPath: false,
-        memorySlot: false,
-        contextEngineSlot: false,
-        directory: false,
-      },
-      directoryRemoval: { target: ALPHA_INSTALL_PATH },
-    });
+    primeUninstallPlan(nextConfig, { directoryRemoval: { target: ALPHA_INSTALL_PATH } });
     applyPluginUninstallDirectoryRemoval.mockResolvedValue({
       directoryRemoved: true,
       warnings: [],
@@ -611,19 +539,7 @@ describe("plugins cli uninstall", () => {
       plugins: [{ id: "alpha", name: "alpha" }],
       diagnostics: [],
     });
-    planPluginUninstall.mockReturnValue({
-      ok: true,
-      config: { plugins: { entries: {}, installs: {} } } as OpenClawConfig,
-      actions: {
-        entry: true,
-        install: true,
-        allowlist: false,
-        denylist: false,
-        loadPath: false,
-        memorySlot: false,
-        contextEngineSlot: false,
-        directory: false,
-      },
+    primeUninstallPlan({ plugins: { entries: {}, installs: {} } } as OpenClawConfig, {
       directoryRemoval: { target: installPath },
     });
     applyPluginUninstallDirectoryRemoval.mockResolvedValue({
@@ -665,21 +581,14 @@ describe("plugins cli uninstall", () => {
       plugins: [],
       diagnostics: [],
     });
-    planPluginUninstall.mockReturnValue({
-      ok: true,
-      config: nextConfig,
+    primeUninstallPlan(nextConfig, {
       actions: {
         entry: false,
         install: false,
         allowlist: true,
         denylist: true,
-        loadPath: false,
-        memorySlot: false,
-        contextEngineSlot: false,
         channelConfig: false,
-        directory: false,
       },
-      directoryRemoval: null,
     });
 
     await runPluginsCommand(["plugins", "uninstall", "alpha", "--force"]);
@@ -704,21 +613,8 @@ describe("plugins cli uninstall", () => {
       plugins: [],
       diagnostics: [],
     });
-    planPluginUninstall.mockReturnValue({
-      ok: true,
-      config: nextConfig,
-      actions: {
-        entry: true,
-        install: false,
-        allowlist: false,
-        denylist: false,
-        loadPath: false,
-        memorySlot: false,
-        contextEngineSlot: false,
-        channelConfig: false,
-        directory: false,
-      },
-      directoryRemoval: null,
+    primeUninstallPlan(nextConfig, {
+      actions: { install: false, channelConfig: false },
     });
 
     await runPluginsCommand(["plugins", "uninstall", "alpha", "--force"]);
@@ -850,22 +746,7 @@ describe("plugins cli uninstall", () => {
       plugins: [],
       diagnostics: [],
     });
-    planPluginUninstall.mockReturnValue({
-      ok: true,
-      config: nextConfig,
-      actions: {
-        entry: true,
-        install: true,
-        allowlist: false,
-        denylist: false,
-        loadPath: false,
-        memorySlot: false,
-        contextEngineSlot: false,
-        channelConfig: true,
-        directory: false,
-      },
-      directoryRemoval: null,
-    });
+    primeUninstallPlan(nextConfig, { actions: { channelConfig: true } });
 
     await runPluginsCommand(["plugins", "uninstall", "alpha", "--force", "--keep-files"]);
 

--- a/src/cli/plugins-cli.update.test.ts
+++ b/src/cli/plugins-cli.update.test.ts
@@ -164,6 +164,14 @@ function primeBlockedUpdateConfig(section: "hooks" | "plugins", config: OpenClaw
   });
 }
 
+function primePluginUpdate(
+  config: OpenClawConfig,
+  outcomes: Awaited<ReturnType<typeof updateNpmInstalledPlugins>>["outcomes"] = [],
+  changed = false,
+): void {
+  updateNpmInstalledPlugins.mockResolvedValue({ config, changed, outcomes });
+}
+
 function primeBravePluginRecordUpdate(config: OpenClawConfig) {
   const previousRecords = {
     brave: {
@@ -183,17 +191,17 @@ function primeBravePluginRecordUpdate(config: OpenClawConfig) {
     },
   } as const;
   setInstalledPluginIndexInstallRecords(previousRecords);
-  updateNpmInstalledPlugins.mockResolvedValue({
-    config: {
+  primePluginUpdate(
+    {
       ...config,
       plugins: {
         ...config.plugins,
         installs: nextRecords,
       },
     } as OpenClawConfig,
-    changed: true,
-    outcomes: [{ pluginId: "brave", status: "updated", message: "Updated brave." }],
-  });
+    [{ pluginId: "brave", status: "updated", message: "Updated brave." }],
+    true,
+  );
   return { previousRecords, nextRecords };
 }
 
@@ -216,18 +224,14 @@ async function expectSkippedClawHubPluginUpdate(params: {
   } as OpenClawConfig;
   loadConfig.mockReturnValue(config);
   setInstalledPluginIndexInstallRecords(config.plugins?.installs ?? {});
-  updateNpmInstalledPlugins.mockResolvedValue({
-    outcomes: [
-      {
-        pluginId: "demo",
-        status: "skipped",
-        code: params.code,
-        message: params.message,
-      },
-    ],
-    changed: false,
-    config,
-  });
+  primePluginUpdate(config, [
+    {
+      pluginId: "demo",
+      status: "skipped",
+      code: params.code,
+      message: params.message,
+    },
+  ]);
   updateNpmInstalledHookPacks.mockResolvedValue({ outcomes: [], changed: false, config });
 
   await expect(runPluginsCommand(["plugins", "update", "demo"])).rejects.toThrow("__exit__:1");
@@ -292,17 +296,13 @@ describe("plugins cli update", () => {
     });
     loadConfig.mockReturnValue(config);
     setInstalledPluginIndexInstallRecords(config.plugins?.installs ?? {});
-    updateNpmInstalledPlugins.mockResolvedValue({
-      config,
-      changed: false,
-      outcomes: [
-        {
-          pluginId: "alpha",
-          status: "updated",
-          message: "Would update alpha: 1.0.0 -> 1.1.0.",
-        },
-      ],
-    });
+    primePluginUpdate(config, [
+      {
+        pluginId: "alpha",
+        status: "updated",
+        message: "Would update alpha: 1.0.0 -> 1.1.0.",
+      },
+    ]);
     const lifecycleLease = await import("../plugins/plugin-lifecycle-lease.js");
     const acquireLease = vi.spyOn(lifecycleLease, "withPluginLifecycleLease");
 
@@ -331,11 +331,9 @@ describe("plugins cli update", () => {
   ])("rejects untracked update target $id $args", async ({ id, args }) => {
     const config = {} as OpenClawConfig;
     primeUpdateConfigSnapshot({ config });
-    updateNpmInstalledPlugins.mockResolvedValue({
-      config,
-      changed: false,
-      outcomes: [{ pluginId: id, status: "skipped", message: `No install record for "${id}".` }],
-    });
+    primePluginUpdate(config, [
+      { pluginId: id, status: "skipped", message: `No install record for "${id}".` },
+    ]);
 
     await expect(runPluginsCommand(["plugins", "update", id, ...args])).rejects.toThrow(
       "__exit__:1",
@@ -394,11 +392,7 @@ describe("plugins cli update", () => {
         resolvedName: "@acme/demo-hooks",
       },
     });
-    updateNpmInstalledPlugins.mockResolvedValue({
-      config: cfg,
-      changed: false,
-      outcomes: [],
-    });
+    primePluginUpdate(cfg);
     updateNpmInstalledHookPacks.mockResolvedValue({
       config: nextConfig,
       changed: true,
@@ -523,17 +517,13 @@ describe("plugins cli update", () => {
       },
     });
     setInstalledPluginIndexInstallRecords(persistedRecords);
-    updateNpmInstalledPlugins.mockResolvedValue({
-      config: {
-        ...cfg,
-        plugins: {
-          ...cfg.plugins,
-          installs: persistedRecords,
-        },
-      } as OpenClawConfig,
-      changed: false,
-      outcomes: [],
-    });
+    primePluginUpdate({
+      ...cfg,
+      plugins: {
+        ...cfg.plugins,
+        installs: persistedRecords,
+      },
+    } as OpenClawConfig);
 
     await runPluginsCommand(["plugins", "update", "alpha"]);
 
@@ -588,17 +578,17 @@ describe("plugins cli update", () => {
     } as OpenClawConfig;
     primeBlockedUpdateConfig("plugins", cfg);
     setInstalledPluginIndexInstallRecords(pluginRecords ?? {});
-    updateNpmInstalledPlugins.mockResolvedValue({
-      config: nextConfig,
-      changed: true,
-      outcomes: [
+    primePluginUpdate(
+      nextConfig,
+      [
         {
           pluginId: "@openclaw/voice-call",
           status: "updated",
           message: "Updated @openclaw/voice-call.",
         },
       ],
-    });
+      true,
+    );
 
     await runPluginsCommand(["plugins", "update", "--all"]);
 
@@ -634,11 +624,11 @@ describe("plugins cli update", () => {
     } as OpenClawConfig;
     primeBlockedUpdateConfig("plugins", cfg);
     setInstalledPluginIndexInstallRecords(pluginRecords);
-    updateNpmInstalledPlugins.mockResolvedValue({
-      config: nextConfig,
-      changed: true,
-      outcomes: [{ pluginId, status: "updated", message: `Updated ${pluginId}.` }],
-    });
+    primePluginUpdate(
+      nextConfig,
+      [{ pluginId, status: "updated", message: `Updated ${pluginId}.` }],
+      true,
+    );
 
     await runPluginsCommand(["plugins", "update", pluginId]);
 
@@ -726,11 +716,11 @@ describe("plugins cli update", () => {
     } as OpenClawConfig;
     primeUpdateConfigSnapshot({ config: cfg });
     setInstalledPluginIndexInstallRecords(previousRecords);
-    updateNpmInstalledPlugins.mockResolvedValue({
-      config: nextConfig,
-      changed: true,
-      outcomes: [{ pluginId: "brave", status: "updated", message: "Updated brave." }],
-    });
+    primePluginUpdate(
+      nextConfig,
+      [{ pluginId: "brave", status: "updated", message: "Updated brave." }],
+      true,
+    );
 
     await runPluginsCommand(["plugins", "update", "brave"]);
 
@@ -1159,11 +1149,9 @@ describe("plugins cli update", () => {
     } as OpenClawConfig;
     primeBlockedUpdateConfig("plugins", cfg);
     setInstalledPluginIndexInstallRecords(cfg.plugins?.installs ?? {});
-    updateNpmInstalledPlugins.mockResolvedValue({
-      config: cfg,
-      changed: false,
-      outcomes: [{ pluginId: "linked", status: "skipped", message: "Skipping linked." }],
-    });
+    primePluginUpdate(cfg, [
+      { pluginId: "linked", status: "skipped", message: "Skipping linked." },
+    ]);
 
     await runPluginsCommand(["plugins", "update", "--all"]);
 
@@ -1188,17 +1176,13 @@ describe("plugins cli update", () => {
         installPath: "/tmp/demo",
       },
     });
-    updateNpmInstalledPlugins.mockResolvedValue({
-      config: cfg,
-      changed: false,
-      outcomes: [
-        {
-          pluginId: "demo",
-          status: "skipped",
-          message: 'Skipping "demo" (missing ClawHub package metadata).',
-        },
-      ],
-    });
+    primePluginUpdate(cfg, [
+      {
+        pluginId: "demo",
+        status: "skipped",
+        message: 'Skipping "demo" (missing ClawHub package metadata).',
+      },
+    ]);
 
     await runPluginsCommand(["plugins", "update", "demo"]);
 
@@ -1242,11 +1226,7 @@ describe("plugins cli update", () => {
     });
     loadConfig.mockReturnValue(config);
     setInstalledPluginIndexInstallRecords(config.plugins?.installs ?? {});
-    updateNpmInstalledPlugins.mockResolvedValue({
-      config,
-      changed: false,
-      outcomes: [],
-    });
+    primePluginUpdate(config);
 
     await runPluginsCommand([
       "plugins",
@@ -1290,11 +1270,7 @@ describe("plugins cli update", () => {
       config.update = { channel: updateChannel };
       loadConfig.mockReturnValue(config);
       setInstalledPluginIndexInstallRecords(config.plugins?.installs ?? {});
-      updateNpmInstalledPlugins.mockResolvedValue({
-        config,
-        changed: false,
-        outcomes: [],
-      });
+      primePluginUpdate(config);
 
       await runPluginsCommand(["plugins", "update", "codex"]);
 
@@ -1316,11 +1292,7 @@ describe("plugins cli update", () => {
     });
     loadConfig.mockReturnValue(config);
     setInstalledPluginIndexInstallRecords(config.plugins?.installs ?? {});
-    updateNpmInstalledPlugins.mockResolvedValue({
-      config,
-      changed: false,
-      outcomes: [],
-    });
+    primePluginUpdate(config);
 
     await runPluginsCommand(["plugins", "update", "codex"]);
 
@@ -1341,11 +1313,7 @@ describe("plugins cli update", () => {
     config.update = { channel: "beta" };
     loadConfig.mockReturnValue(config);
     setInstalledPluginIndexInstallRecords(config.plugins?.installs ?? {});
-    updateNpmInstalledPlugins.mockResolvedValue({
-      config,
-      changed: false,
-      outcomes: [],
-    });
+    primePluginUpdate(config);
 
     await runPluginsCommand(["plugins", "update", "--all"]);
 
@@ -1364,11 +1332,7 @@ describe("plugins cli update", () => {
     });
     loadConfig.mockReturnValue(config);
     setInstalledPluginIndexInstallRecords(config.plugins?.installs ?? {});
-    updateNpmInstalledPlugins.mockResolvedValue({
-      config,
-      changed: false,
-      outcomes: [],
-    });
+    primePluginUpdate(config);
 
     await runPluginsCommand(["plugins", "update", "--all"]);
 
@@ -1387,11 +1351,7 @@ describe("plugins cli update", () => {
     config.update = { channel: "extended-stable" };
     loadConfig.mockReturnValue(config);
     setInstalledPluginIndexInstallRecords(config.plugins?.installs ?? {});
-    updateNpmInstalledPlugins.mockResolvedValue({
-      config,
-      changed: false,
-      outcomes: [],
-    });
+    primePluginUpdate(config);
 
     await runPluginsCommand(["plugins", "update", "--all"]);
 
@@ -1411,11 +1371,7 @@ describe("plugins cli update", () => {
     });
     loadConfig.mockReturnValue(config);
     setInstalledPluginIndexInstallRecords(config.plugins?.installs ?? {});
-    updateNpmInstalledPlugins.mockResolvedValue({
-      config,
-      changed: false,
-      outcomes: [],
-    });
+    primePluginUpdate(config);
 
     await runPluginsCommand([
       "plugins",
@@ -1441,11 +1397,7 @@ describe("plugins cli update", () => {
     });
     loadConfig.mockReturnValue(config);
     setInstalledPluginIndexInstallRecords(config.plugins?.installs ?? {});
-    updateNpmInstalledPlugins.mockResolvedValue({
-      config,
-      changed: false,
-      outcomes: [],
-    });
+    primePluginUpdate(config);
 
     await runPluginsCommand(["plugins", "update", "openclaw-codex-app-server", "--dry-run"]);
 
@@ -1494,11 +1446,11 @@ describe("plugins cli update", () => {
       },
     });
     setInstalledPluginIndexInstallRecords(cfg.plugins?.installs ?? {});
-    updateNpmInstalledPlugins.mockResolvedValue({
-      outcomes: [{ pluginId: "alpha", status: "updated", message: "Updated alpha -> 1.1.0" }],
-      changed: true,
-      config: nextRuntimeConfig,
-    });
+    primePluginUpdate(
+      nextRuntimeConfig,
+      [{ pluginId: "alpha", status: "updated", message: "Updated alpha -> 1.1.0" }],
+      true,
+    );
     updateNpmInstalledHookPacks.mockResolvedValue({
       outcomes: [],
       changed: false,
@@ -1562,14 +1514,14 @@ describe("plugins cli update", () => {
     } as OpenClawConfig;
     loadConfig.mockReturnValue(cfg);
     setInstalledPluginIndexInstallRecords(cfg.plugins?.installs ?? {});
-    updateNpmInstalledPlugins.mockResolvedValue({
-      outcomes: [
+    primePluginUpdate(
+      nextConfig,
+      [
         { pluginId: "alpha", status: "updated", message: "Updated alpha -> 1.1.0" },
         { pluginId: "beta", status: "error", message: "Failed to update beta: registry timeout" },
       ],
-      changed: true,
-      config: nextConfig,
-    });
+      true,
+    );
     updateNpmInstalledHookPacks.mockResolvedValue({
       outcomes: [],
       changed: false,
@@ -1626,11 +1578,7 @@ describe("plugins cli update", () => {
         resolvedName: "@acme/demo-hooks",
       },
     });
-    updateNpmInstalledPlugins.mockResolvedValue({
-      config: cfg,
-      changed: false,
-      outcomes: [],
-    });
+    primePluginUpdate(cfg);
     updateNpmInstalledHookPacks.mockResolvedValue({
       config: cfg,
       changed: false,

--- a/src/cli/skills-cli.commands.test.ts
+++ b/src/cli/skills-cli.commands.test.ts
@@ -128,6 +128,24 @@ const {
   runtimeErrors,
 } = mocks;
 
+function primeSkillVerification(overrides: Record<string, unknown> = {}) {
+  return fetchClawHubSkillVerificationMock.mockResolvedValueOnce({
+    schema: "clawhub.skill.verify.v1",
+    ok: true,
+    decision: "pass",
+    reasons: [],
+    skill: { slug: "agentreceipt" },
+    publisher: null,
+    version: { version: "1.2.3" },
+    card: { available: true },
+    artifact: null,
+    provenance: null,
+    security: { status: "clean" },
+    signature: { status: "unsigned" },
+    ...overrides,
+  });
+}
+
 function mockCall(mock: unknown, index = 0): Array<unknown> {
   const calls = (mock as { mock?: { calls?: Array<Array<unknown>> } }).mock?.calls ?? [];
   const call = calls.at(index);
@@ -1089,14 +1107,9 @@ describe("skills cli commands", () => {
     const verifiedSourceUrl =
       "https://github.com/openclaw/skills/tree/0123456789abcdef0123456789abcdef01234567/agentreceipt";
     readVerifiedClawHubSkillSourceUrlMock.mockReturnValueOnce(verifiedSourceUrl);
-    fetchClawHubSkillVerificationMock.mockResolvedValueOnce({
-      schema: "clawhub.skill.verify.v1",
-      ok: true,
-      decision: "pass",
-      reasons: [],
+    primeSkillVerification({
       skill: { slug: "agentreceipt", displayName: "Agent Receipt" },
       publisher: { handle: "openclaw" },
-      version: { version: "1.2.3" },
       card: {
         available: true,
         url: "https://private.example.com/clawhub/api/v1/skills/agentreceipt/card?version=1.2.3",
@@ -1106,8 +1119,6 @@ describe("skills cli commands", () => {
         bundleFingerprints: ["generated-bundle-fingerprint"],
       },
       provenance,
-      security: { status: "clean" },
-      signature: { status: "unsigned" },
     });
 
     await runCommand(["skills", "verify", "agentreceipt"]);
@@ -1121,14 +1132,9 @@ describe("skills cli commands", () => {
   });
 
   it("fetches generated Skill Card markdown for --card", async () => {
-    fetchClawHubSkillVerificationMock.mockResolvedValueOnce({
-      schema: "clawhub.skill.verify.v1",
-      ok: true,
-      decision: "pass",
-      reasons: [],
+    primeSkillVerification({
       skill: { slug: "agentreceipt", displayName: "Agent Receipt" },
       publisher: { handle: "openclaw" },
-      version: { version: "1.2.3" },
       card: {
         available: true,
         url: "https://cards.example.test/generated/agentreceipt.md",
@@ -1137,9 +1143,6 @@ describe("skills cli commands", () => {
         sourceFingerprint: "source-fingerprint",
         bundleFingerprints: ["generated-bundle-fingerprint"],
       },
-      provenance: null,
-      security: { status: "clean" },
-      signature: { status: "unsigned" },
     });
 
     await runCommand(["skills", "verify", "agentreceipt", "--tag", "latest", "--card"]);
@@ -1160,19 +1163,11 @@ describe("skills cli commands", () => {
   });
 
   it("fails --card when the verified Skill Card is unavailable", async () => {
-    fetchClawHubSkillVerificationMock.mockResolvedValueOnce({
-      schema: "clawhub.skill.verify.v1",
+    primeSkillVerification({
       ok: false,
       decision: "fail",
       reasons: ["card.missing"],
-      skill: { slug: "agentreceipt" },
-      publisher: null,
-      version: { version: "1.2.3" },
       card: { available: false },
-      artifact: null,
-      provenance: null,
-      security: { status: "clean" },
-      signature: { status: "unsigned" },
     });
 
     await expect(runCommand(["skills", "verify", "agentreceipt", "--card"])).rejects.toThrow(
@@ -1188,20 +1183,7 @@ describe("skills cli commands", () => {
     { label: "missing card", card: null },
     { label: "missing card URL", card: { available: true } },
   ])("fails --card when the verification response has $label metadata", async ({ card }) => {
-    fetchClawHubSkillVerificationMock.mockResolvedValueOnce({
-      schema: "clawhub.skill.verify.v1",
-      ok: true,
-      decision: "pass",
-      reasons: [],
-      skill: { slug: "agentreceipt" },
-      publisher: null,
-      version: { version: "1.2.3" },
-      card,
-      artifact: null,
-      provenance: null,
-      security: { status: "clean" },
-      signature: { status: "unsigned" },
-    });
+    primeSkillVerification({ card });
 
     await expect(runCommand(["skills", "verify", "agentreceipt", "--card"])).rejects.toThrow(
       "__exit__:1",
@@ -1215,19 +1197,11 @@ describe("skills cli commands", () => {
   });
 
   it("exits non-zero when the ClawHub verification envelope fails", async () => {
-    fetchClawHubSkillVerificationMock.mockResolvedValueOnce({
-      schema: "clawhub.skill.verify.v1",
+    primeSkillVerification({
       ok: false,
       decision: "fail",
       reasons: ["security.status_not_clean"],
-      skill: { slug: "agentreceipt" },
-      publisher: null,
-      version: { version: "1.2.3" },
-      card: { available: true },
-      artifact: null,
-      provenance: null,
       security: { status: "malicious" },
-      signature: { status: "unsigned" },
     });
 
     await expect(runCommand(["skills", "verify", "agentreceipt"])).rejects.toThrow("__exit__:1");
@@ -1241,22 +1215,13 @@ describe("skills cli commands", () => {
     { label: "unknown decision", ok: true, decision: "quarantined" },
     { label: "non-boolean ok", ok: "false", decision: "pass" },
   ])("fails closed for malformed verification envelopes with $label", async ({ ok, decision }) => {
-    fetchClawHubSkillVerificationMock.mockResolvedValueOnce({
-      schema: "clawhub.skill.verify.v1",
+    primeSkillVerification({
       ok,
       decision,
-      reasons: [],
-      skill: { slug: "agentreceipt" },
-      publisher: null,
-      version: { version: "1.2.3" },
       card: {
         available: true,
         url: "https://private.example.com/clawhub/api/v1/skills/agentreceipt/card?version=1.2.3",
       },
-      artifact: null,
-      provenance: null,
-      security: { status: "clean" },
-      signature: { status: "unsigned" },
     });
 
     await expect(runCommand(["skills", "verify", "agentreceipt"])).rejects.toThrow("__exit__:1");

--- a/src/commands/models/list.list-command.forward-compat.test.ts
+++ b/src/commands/models/list.list-command.forward-compat.test.ts
@@ -148,6 +148,18 @@ function createRuntime() {
   return { log: vi.fn(), error: vi.fn() };
 }
 
+function primeModelRegistry(
+  models: unknown[],
+  availableKeys?: Set<string>,
+  registryModels: unknown[] = models,
+) {
+  return mocks.loadModelRegistry.mockResolvedValueOnce({
+    models,
+    availableKeys,
+    registry: { getAll: () => registryModels },
+  });
+}
+
 function lastPrintedRows<T>() {
   const calls = mocks.printModelTable.mock.calls;
   return (calls[calls.length - 1]?.[0] ?? []) as T[];
@@ -625,37 +637,19 @@ describe("modelsListCommand forward-compat", () => {
 
     it("falls back to registry rows for unknown provider filters without --all", async () => {
       mocks.resolveConfiguredEntries.mockReturnValueOnce({ entries: [] });
-      mocks.loadModelRegistry.mockResolvedValueOnce({
-        models: [
-          {
-            provider: "google",
-            id: "gemini-2.5-pro",
-            name: "Gemini 2.5 Pro",
-            api: "google-gemini",
-            baseUrl: "https://generativelanguage.googleapis.com/v1beta",
-            input: ["text", "image"],
-            contextWindow: 1_048_576,
-            maxTokens: 65_536,
-            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-          },
-        ],
-        availableKeys: undefined,
-        registry: {
-          getAll: () => [
-            {
-              provider: "google",
-              id: "gemini-2.5-pro",
-              name: "Gemini 2.5 Pro",
-              api: "google-gemini",
-              baseUrl: "https://generativelanguage.googleapis.com/v1beta",
-              input: ["text", "image"],
-              contextWindow: 1_048_576,
-              maxTokens: 65_536,
-              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-            },
-          ],
+      primeModelRegistry([
+        {
+          provider: "google",
+          id: "gemini-2.5-pro",
+          name: "Gemini 2.5 Pro",
+          api: "google-gemini",
+          baseUrl: "https://generativelanguage.googleapis.com/v1beta",
+          input: ["text", "image"],
+          contextWindow: 1_048_576,
+          maxTokens: 65_536,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
         },
-      });
+      ]);
       const runtime = createRuntime();
 
       await modelsListCommand({ json: true, provider: "google" }, runtime as never);
@@ -683,13 +677,7 @@ describe("modelsListCommand forward-compat", () => {
         id: "gpt-5.3-codex-spark",
         name: "GPT-5.3 Codex Spark",
       };
-      mocks.loadModelRegistry.mockResolvedValueOnce({
-        models: [currentModel],
-        availableKeys: undefined,
-        registry: {
-          getAll: () => [currentModel, suppressedModel],
-        },
-      });
+      primeModelRegistry([currentModel], undefined, [currentModel, suppressedModel]);
       const runtime = createRuntime();
 
       await modelsListCommand({ json: true, provider: "openai" }, runtime as never);
@@ -1192,8 +1180,8 @@ describe("modelsListCommand forward-compat", () => {
           contextWindow: 1_000_000,
         },
       ]);
-      mocks.loadModelRegistry.mockResolvedValueOnce({
-        models: [
+      primeModelRegistry(
+        [
           {
             provider: "openai",
             id: "gpt-5.4",
@@ -1206,11 +1194,9 @@ describe("modelsListCommand forward-compat", () => {
             cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
           },
         ],
-        availableKeys: new Set(),
-        registry: {
-          getAll: () => [],
-        },
-      });
+        new Set(),
+        [],
+      );
       mocks.resolveModelWithRegistry.mockImplementation(
         ({ provider, modelId }: { provider: string; modelId: string }) =>
           provider === "openai" && modelId === "gpt-5.4"
@@ -1250,25 +1236,16 @@ describe("modelsListCommand forward-compat", () => {
 
     it("does not load broad provider runtime catalogs for unfiltered all-model lists", async () => {
       mocks.resolveConfiguredEntries.mockReturnValueOnce({ entries: [] });
-      mocks.loadModelRegistry.mockResolvedValueOnce({
-        models: [
+      primeModelRegistry(
+        [
           {
             ...OPENAI_CODEX_MODEL,
             api: "openai-responses",
             baseUrl: "https://api.openai.com/v1",
           },
         ],
-        availableKeys: new Set(["openai/gpt-5.4"]),
-        registry: {
-          getAll: () => [
-            {
-              ...OPENAI_CODEX_MODEL,
-              api: "openai-responses",
-              baseUrl: "https://api.openai.com/v1",
-            },
-          ],
-        },
-      });
+        new Set(["openai/gpt-5.4"]),
+      );
       mocks.loadModelCatalog.mockResolvedValueOnce([
         {
           provider: "moonshot",
@@ -1303,13 +1280,7 @@ describe("modelsListCommand forward-compat", () => {
 
     it("falls back to registry-backed rows when the fast-path catalog is empty", async () => {
       mocks.resolveConfiguredEntries.mockReturnValueOnce({ entries: [] });
-      mocks.loadModelRegistry.mockResolvedValueOnce({
-        models: [{ ...OPENAI_CODEX_MODEL }],
-        availableKeys: new Set(["openai/gpt-5.4"]),
-        registry: {
-          getAll: () => [{ ...OPENAI_CODEX_MODEL }],
-        },
-      });
+      primeModelRegistry([{ ...OPENAI_CODEX_MODEL }], new Set(["openai/gpt-5.4"]));
       const runtime = createRuntime();
 
       await modelsListCommand({ all: true, provider: "openai", json: true }, runtime as never);
@@ -1330,37 +1301,19 @@ describe("modelsListCommand forward-compat", () => {
 
     it("falls back to registry rows for provider filters without catalog coverage", async () => {
       mocks.resolveConfiguredEntries.mockReturnValueOnce({ entries: [] });
-      mocks.loadModelRegistry.mockResolvedValueOnce({
-        models: [
-          {
-            provider: "anthropic",
-            id: "claude-opus-4-7",
-            name: "Claude Opus 4.7",
-            api: "anthropic-messages",
-            baseUrl: "https://api.anthropic.com/v1",
-            input: ["text", "image"],
-            contextWindow: 1_000_000,
-            maxTokens: 64_000,
-            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-          },
-        ],
-        availableKeys: undefined,
-        registry: {
-          getAll: () => [
-            {
-              provider: "anthropic",
-              id: "claude-opus-4-7",
-              name: "Claude Opus 4.7",
-              api: "anthropic-messages",
-              baseUrl: "https://api.anthropic.com/v1",
-              input: ["text", "image"],
-              contextWindow: 1_000_000,
-              maxTokens: 64_000,
-              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-            },
-          ],
+      primeModelRegistry([
+        {
+          provider: "anthropic",
+          id: "claude-opus-4-7",
+          name: "Claude Opus 4.7",
+          api: "anthropic-messages",
+          baseUrl: "https://api.anthropic.com/v1",
+          input: ["text", "image"],
+          contextWindow: 1_000_000,
+          maxTokens: 64_000,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
         },
-      });
+      ]);
       const runtime = createRuntime();
 
       await modelsListCommand({ all: true, provider: "anthropic", json: true }, runtime as never);
@@ -1374,13 +1327,7 @@ describe("modelsListCommand forward-compat", () => {
 
     it("includes provider-owned supplemental catalog rows with provider filters", async () => {
       mocks.resolveConfiguredEntries.mockReturnValueOnce({ entries: [] });
-      mocks.loadModelRegistry.mockResolvedValueOnce({
-        models: [],
-        availableKeys: new Set(["opencode-go/deepseek-v4-pro"]),
-        registry: {
-          getAll: () => [],
-        },
-      });
+      primeModelRegistry([], new Set(["opencode-go/deepseek-v4-pro"]));
       mocks.loadModelCatalog.mockResolvedValueOnce([
         {
           provider: "opencode-go",
@@ -1415,13 +1362,7 @@ describe("modelsListCommand forward-compat", () => {
 
     it("includes synthetic codex gpt-5.4 in --all output when catalog supports it", async () => {
       mocks.resolveConfiguredEntries.mockReturnValueOnce({ entries: [] });
-      mocks.loadModelRegistry.mockResolvedValueOnce({
-        models: [],
-        availableKeys: new Set(["openai/gpt-5.4"]),
-        registry: {
-          getAll: () => [],
-        },
-      });
+      primeModelRegistry([], new Set(["openai/gpt-5.4"]));
       mocks.loadModelCatalog.mockResolvedValueOnce([
         {
           provider: "openai",
@@ -1462,8 +1403,8 @@ describe("modelsListCommand forward-compat", () => {
         },
         order: {},
       });
-      mocks.loadModelRegistry.mockResolvedValueOnce({
-        models: [
+      primeModelRegistry(
+        [
           {
             provider: "openai",
             id: "gpt-5.5",
@@ -1476,23 +1417,8 @@ describe("modelsListCommand forward-compat", () => {
             cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
           },
         ],
-        availableKeys: new Set(["openai/gpt-5.5"]),
-        registry: {
-          getAll: () => [
-            {
-              provider: "openai",
-              id: "gpt-5.5",
-              name: "GPT-5.5",
-              api: "openai-chatgpt-responses",
-              baseUrl: "https://chatgpt.com/backend-api",
-              input: ["text", "image"],
-              contextWindow: 272000,
-              maxTokens: 128000,
-              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-            },
-          ],
-        },
-      });
+        new Set(["openai/gpt-5.5"]),
+      );
       mocks.resolveModelWithRegistry.mockImplementation(
         ({ provider, modelId }: { provider: string; modelId: string }) =>
           provider === "openai" && modelId === "gpt-5.5"
@@ -1575,8 +1501,8 @@ describe("modelsListCommand forward-compat", () => {
   describe("provider filter matching", () => {
     it("matches discovered providers against exact provider filters", async () => {
       mocks.resolveConfiguredEntries.mockReturnValueOnce({ entries: [] });
-      mocks.loadModelRegistry.mockResolvedValueOnce({
-        models: [
+      primeModelRegistry(
+        [
           {
             provider: "z.ai",
             id: "glm-4.5",
@@ -1589,23 +1515,8 @@ describe("modelsListCommand forward-compat", () => {
             cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
           },
         ],
-        availableKeys: new Set(["z.ai/glm-4.5"]),
-        registry: {
-          getAll: () => [
-            {
-              provider: "z.ai",
-              id: "glm-4.5",
-              name: "GLM-4.5",
-              api: "openai-responses",
-              baseUrl: "https://api.z.ai/v1",
-              input: ["text"],
-              contextWindow: 128_000,
-              maxTokens: 16_384,
-              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-            },
-          ],
-        },
-      });
+        new Set(["z.ai/glm-4.5"]),
+      );
 
       const runtime = createRuntime();
 


### PR DESCRIPTION
## What Problem This Solves

Eight CLI and model-list regression suites repeatedly construct the same command prefixes, daemon options, pairing payloads, transport-close errors, plugin lifecycle outcomes, ClawHub verification envelopes, and model-registry snapshots. That duplicated setup makes the owner-lane tests harder to review and maintain without adding coverage.

## Why This Change Was Made

This rewrite re-derives the consolidation against current `main` instead of replaying the stale branch. Each fixture remains local to the suite that owns its assertions, including the newer device-pairing helper boundary. Every existing test case and assertion is preserved; there are no production, config, protocol, dependency, snapshot, baseline, or Vitest-routing changes.

The model-list fixture remains consistent with the upstream Codex contract checked directly in current Rust source:

- `codex-rs/app-server-protocol/src/protocol/common.rs:895-899` binds `model/list`.
- `codex-rs/app-server-protocol/src/protocol/v2/model.rs:43-55,130-135` defines cursor, limit, `includeHidden`, `data`, and `nextCursor`.
- `codex-rs/app-server/src/request_processors/catalog_processor.rs:258-307` defaults hidden models off and owns cursor pagination.
- `codex-rs/app-server/src/models.rs:12-24` uses `OnlineIfUncached` and filters `show_in_picker`.
- `codex-rs/models-manager/src/manager.rs:34-48,53-70,85-105,350-407` owns the endpoint contract, refresh strategies, catalog construction, and cache-first online fallback.
- `codex-rs/model-provider/src/models_endpoint.rs:38-114,126-143` owns the provider `/models` route and five-second refresh timeout.
- `codex-rs/core/src/client.rs:160-162,1390-1450,1800-1855` independently routes inference through `/responses` with WebSocket-to-HTTP fallback.
- `codex-rs/core/src/config/mod.rs:4137-4140` defaults the ChatGPT backend base URL.

## User Impact

Runtime behavior is unchanged. Maintainers keep the same CLI, daemon, device, logs, plugin, skill-verification, and model-list coverage with 524 fewer test lines and one canonical fixture flow per owner suite.

## Evidence

- Rebased base: `75a454469de93e6267e0e740de56fc72378a9d2b`
- Immutable head: `2a15dfcb92899c5c3314ef5e81d160b6096d3771`
- Diff: eight test-only files, `+378/-902` (net `-524`); production `+0/-0`
- Stable patch ID before and after the current-main rebase: `edbd832e8dad4c4143c85f809895f3973b6622b9`
- Focused owner-lane proof: 8/8 files passed, 491/491 tests (CLI 452; commands-light 39)
- Case and assertion parity against current `main`: config 146/412, daemon 40/155, devices 46/137, logs 34/123, uninstall 15/59, update 40/148, skills 52/155, models 37/82
- Remote changed-file gate: conflict, environment, max-lines, dependency, formatting, deprecated-API, plugin-boundary, package-patch, dead-code, temp-directory, core-test typecheck, and changed-file lint checks passed; lint reported 0 warnings and 0 errors
- Codex-backed autoreview: clean with no accepted or actionable findings
- ClawSweeper rank-up moves addressed: current-main rewrite/rebase completed, focused terminal evidence refreshed, and this body now describes the exact head
