### PR TITLE
refactor: consolidate voice and encrypted messaging regressions

### DIFF
--- a/extensions/discord/src/monitor/message-handler.preflight.test.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight.test.ts
@@ -1225,43 +1225,64 @@ describe("preflightDiscordMessage", () => {
     expect(preflight.groupRequireMention).toBe(true);
   });
 
-  it("drops bot messages without mention when allowBots=mentions", async () => {
-    const channelId = "channel-bot-mentions-off";
-    const guildId = "guild-bot-mentions-off";
-    const message = createDiscordMessage({
-      id: "m-bot-mentions-off",
-      channelId,
+  it.each<{
+    name: string;
+    channelId: string;
+    guildId: string;
+    messageId: string;
+    content: string;
+    mentioned?: boolean;
+    accepted: boolean;
+  }>([
+    {
+      name: "drops bot messages without mention when allowBots=mentions",
+      channelId: "channel-bot-mentions-off",
+      guildId: "guild-bot-mentions-off",
+      messageId: "m-bot-mentions-off",
       content: "relay chatter",
-      author: {
-        id: "relay-bot-1",
-        bot: true,
-        username: "Relay",
-      },
-    });
-
-    const result = await runMentionOnlyBotPreflight({ channelId, guildId, message });
-
-    expect(result).toBeNull();
-  });
-
-  it("allows bot messages with explicit mention when allowBots=mentions", async () => {
-    const channelId = "channel-bot-mentions-on";
-    const guildId = "guild-bot-mentions-on";
-    const message = createDiscordMessage({
-      id: "m-bot-mentions-on",
-      channelId,
+      accepted: false,
+    },
+    {
+      name: "allows bot messages with explicit mention when allowBots=mentions",
+      channelId: "channel-bot-mentions-on",
+      guildId: "guild-bot-mentions-on",
+      messageId: "m-bot-mentions-on",
       content: "hi <@openclaw-bot>",
-      mentionedUsers: [{ id: "openclaw-bot" }],
-      author: {
-        id: "relay-bot-1",
-        bot: true,
-        username: "Relay",
-      },
+      mentioned: true,
+      accepted: true,
+    },
+    {
+      name: "still drops bot control commands without a real mention when allowBots=mentions",
+      channelId: "channel-bot-command-no-mention",
+      guildId: "guild-bot-command-no-mention",
+      messageId: "m-bot-command-no-mention",
+      content: "/new incident room",
+      accepted: false,
+    },
+    {
+      name: "still allows bot control commands with an explicit mention when allowBots=mentions",
+      channelId: "channel-bot-command-with-mention",
+      guildId: "guild-bot-command-with-mention",
+      messageId: "m-bot-command-with-mention",
+      content: "<@openclaw-bot> /new incident room",
+      mentioned: true,
+      accepted: true,
+    },
+  ])("$name", async ({ channelId, guildId, messageId, content, mentioned, accepted }) => {
+    const message = createDiscordMessage({
+      id: messageId,
+      channelId,
+      content,
+      ...(mentioned ? { mentionedUsers: [{ id: "openclaw-bot" }] } : {}),
+      author: { id: "relay-bot-1", bot: true, username: "Relay" },
     });
-
     const result = await runMentionOnlyBotPreflight({ channelId, guildId, message });
 
-    expect(expectPreflightResult(result).message.id).toBe("m-bot-mentions-on");
+    if (!accepted) {
+      expect(result).toBeNull();
+      return;
+    }
+    expect(expectPreflightResult(result).message.id).toBe(messageId);
   });
 
   it("hydrates mention metadata from REST when bot mention syntax is present but mentions are missing", async () => {
@@ -1451,45 +1472,6 @@ describe("preflightDiscordMessage", () => {
     });
 
     expect(result).toBeNull();
-  });
-
-  it("still drops bot control commands without a real mention when allowBots=mentions", async () => {
-    const channelId = "channel-bot-command-no-mention";
-    const guildId = "guild-bot-command-no-mention";
-    const message = createDiscordMessage({
-      id: "m-bot-command-no-mention",
-      channelId,
-      content: "/new incident room",
-      author: {
-        id: "relay-bot-1",
-        bot: true,
-        username: "Relay",
-      },
-    });
-
-    const result = await runMentionOnlyBotPreflight({ channelId, guildId, message });
-
-    expect(result).toBeNull();
-  });
-
-  it("still allows bot control commands with an explicit mention when allowBots=mentions", async () => {
-    const channelId = "channel-bot-command-with-mention";
-    const guildId = "guild-bot-command-with-mention";
-    const message = createDiscordMessage({
-      id: "m-bot-command-with-mention",
-      channelId,
-      content: "<@openclaw-bot> /new incident room",
-      mentionedUsers: [{ id: "openclaw-bot" }],
-      author: {
-        id: "relay-bot-1",
-        bot: true,
-        username: "Relay",
-      },
-    });
-
-    const result = await runMentionOnlyBotPreflight({ channelId, guildId, message });
-
-    expect(expectPreflightResult(result).message.id).toBe("m-bot-command-with-mention");
   });
 
   it("routes ordinary guild text control commands through authorization instead of dropping them", async () => {

--- a/extensions/discord/src/monitor/thread-bindings.lifecycle.test.ts
+++ b/extensions/discord/src/monitor/thread-bindings.lifecycle.test.ts
@@ -315,7 +315,23 @@ describe("thread binding lifecycle", () => {
     expect(intro).toContain("\ncwd: /home/bob/clawd\nsession ids: pending");
   });
 
-  it("auto-unfocuses idle-expired bindings and sends inactivity message", async () => {
+  it.each([
+    {
+      name: "auto-unfocuses idle-expired bindings and sends inactivity message",
+      idleTimeoutMs: 60_000,
+      maxAgeMs: 0,
+      introText: "intro",
+      farewellText: "after 1m of inactivity",
+      expectNoProbe: true,
+    },
+    {
+      name: "auto-unfocuses max-age-expired bindings and sends max-age message",
+      idleTimeoutMs: 0,
+      maxAgeMs: 60_000,
+      farewellText: "max age of 1m",
+      expectNoProbe: false,
+    },
+  ])("$name", async ({ idleTimeoutMs, maxAgeMs, introText, farewellText, expectNoProbe }) => {
     vi.useFakeTimers();
     try {
       const manager = createTestThreadBindingManager({
@@ -323,8 +339,8 @@ describe("thread binding lifecycle", () => {
         cfg: EMPTY_DISCORD_TEST_CONFIG,
         persist: false,
         enableSweeper: false,
-        idleTimeoutMs: 60_000,
-        maxAgeMs: 0,
+        idleTimeoutMs,
+        maxAgeMs,
       });
 
       const binding = await manager.bindTarget({
@@ -335,7 +351,7 @@ describe("thread binding lifecycle", () => {
         agentId: "main",
         webhookId: "wh-1",
         webhookToken: "tok-1",
-        introText: "intro",
+        ...(introText ? { introText } : {}),
       });
       expectFields(binding, "binding", {
         threadId: "thread-1",
@@ -348,97 +364,56 @@ describe("thread binding lifecycle", () => {
       await testing.runThreadBindingSweepForAccount("default");
 
       expect(manager.getByThreadId("thread-1")).toBeUndefined();
-      expect(hoisted.restGet).not.toHaveBeenCalled();
+      if (expectNoProbe) {
+        expect(hoisted.restGet).not.toHaveBeenCalled();
+      }
       expect(hoisted.sendWebhookMessageDiscord).not.toHaveBeenCalled();
       expect(hoisted.sendMessageDiscord).toHaveBeenCalledTimes(1);
       const farewell = mockCallArg(hoisted.sendMessageDiscord, 0, 1, "sendMessageDiscord") as
         | string
         | undefined;
-      expect(farewell).toContain("after 1m of inactivity");
+      expect(farewell).toContain(farewellText);
     } finally {
       vi.useRealTimers();
     }
   });
 
-  it("auto-unfocuses max-age-expired bindings and sends max-age message", async () => {
-    vi.useFakeTimers();
-    try {
-      const manager = createTestThreadBindingManager({
-        accountId: "default",
-        cfg: EMPTY_DISCORD_TEST_CONFIG,
-        persist: false,
-        enableSweeper: false,
-        idleTimeoutMs: 0,
-        maxAgeMs: 60_000,
-      });
-
-      const binding = await manager.bindTarget({
-        threadId: "thread-1",
-        channelId: "parent-1",
-        targetKind: "subagent",
-        targetSessionKey: "agent:main:subagent:child",
-        agentId: "main",
-        webhookId: "wh-1",
-        webhookToken: "tok-1",
-      });
-      expectFields(binding, "binding", {
-        threadId: "thread-1",
-        targetSessionKey: "agent:main:subagent:child",
-      });
-      hoisted.sendMessageDiscord.mockClear();
-
-      await vi.advanceTimersByTimeAsync(120_000);
-      await testing.runThreadBindingSweepForAccount("default");
-
-      expect(manager.getByThreadId("thread-1")).toBeUndefined();
-      expect(hoisted.sendMessageDiscord).toHaveBeenCalledTimes(1);
-      const farewell = mockCallArg(hoisted.sendMessageDiscord, 0, 1, "sendMessageDiscord") as
-        | string
-        | undefined;
-      expect(farewell).toContain("max age of 1m");
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  it("keeps binding when thread sweep probe fails transiently", async () => {
+  it.each<{
+    name: string;
+    probeError: unknown;
+    keepsBinding: boolean;
+  }>([
+    {
+      name: "keeps binding when thread sweep probe fails transiently",
+      probeError: new Error("ECONNRESET"),
+      keepsBinding: true,
+    },
+    {
+      name: "unbinds when thread sweep probe reports unknown channel",
+      probeError: { status: 404, rawError: { code: 10003, message: "Unknown Channel" } },
+      keepsBinding: false,
+    },
+  ])("$name", async ({ probeError, keepsBinding }) => {
     vi.useFakeTimers();
     try {
       const manager = createDefaultSweeperManager();
       await bindDefaultThreadTarget(manager);
 
-      hoisted.restGet.mockRejectedValueOnce(new Error("ECONNRESET"));
+      hoisted.restGet.mockRejectedValueOnce(probeError);
 
       await vi.advanceTimersByTimeAsync(120_000);
       await testing.runThreadBindingSweepForAccount("default");
 
-      expectFields(requireBinding(manager, "thread-1"), "thread binding", {
-        threadId: "thread-1",
-        targetSessionKey: "agent:main:subagent:child",
-        webhookId: "wh-1",
-        webhookToken: "tok-1",
-      });
-      expect(hoisted.sendWebhookMessageDiscord).not.toHaveBeenCalled();
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  it("unbinds when thread sweep probe reports unknown channel", async () => {
-    vi.useFakeTimers();
-    try {
-      const manager = createDefaultSweeperManager();
-      await bindDefaultThreadTarget(manager);
-
-      hoisted.restGet.mockRejectedValueOnce({
-        status: 404,
-        rawError: { code: 10003, message: "Unknown Channel" },
-      });
-
-      await vi.advanceTimersByTimeAsync(120_000);
-      await testing.runThreadBindingSweepForAccount("default");
-
-      expect(manager.getByThreadId("thread-1")).toBeUndefined();
+      if (keepsBinding) {
+        expectFields(requireBinding(manager, "thread-1"), "thread binding", {
+          threadId: "thread-1",
+          targetSessionKey: "agent:main:subagent:child",
+          webhookId: "wh-1",
+          webhookToken: "tok-1",
+        });
+      } else {
+        expect(manager.getByThreadId("thread-1")).toBeUndefined();
+      }
       expect(hoisted.sendWebhookMessageDiscord).not.toHaveBeenCalled();
     } finally {
       vi.useRealTimers();

--- a/extensions/matrix/src/matrix/monitor/events.test.ts
+++ b/extensions/matrix/src/matrix/monitor/events.test.ts
@@ -511,108 +511,92 @@ describe("registerMatrixMonitorEvents verification routing", () => {
     expect(onRoomMessage).toHaveBeenCalledWith("!room:example.org", event);
   });
 
-  it("blocks verification request notices when dmPolicy pairing would block the sender", async () => {
-    const { onRoomMessage, sendMessage, roomMessageListener, logVerboseMessage, flushTasks } =
-      createHarness({
-        dmPolicy: "pairing",
+  it.each<{
+    name: string;
+    eventId: string;
+    options: NonNullable<Parameters<typeof createHarness>[0]>;
+    accepted: boolean;
+    storeConsulted?: boolean;
+    blockedLog?: string;
+    expectNoRoomDispatch?: boolean;
+  }>([
+    {
+      name: "blocks verification request notices when dmPolicy pairing would block the sender",
+      eventId: "$req-pairing-blocked",
+      options: { dmPolicy: "pairing" },
+      accepted: false,
+      blockedLog: "matrix: blocked verification sender @alice:example.org (dmPolicy=pairing)",
+      expectNoRoomDispatch: true,
+    },
+    {
+      name: "allows verification notices for pairing-authorized DM senders from the allow store",
+      eventId: "$req-pairing-allowed",
+      options: { dmPolicy: "pairing", storeAllowFrom: ["@alice:example.org"] },
+      accepted: true,
+      storeConsulted: true,
+    },
+    {
+      name: "does not consult the allow store when dmPolicy is open",
+      eventId: "$req-open-policy",
+      options: { dmPolicy: "open" },
+      accepted: true,
+      storeConsulted: false,
+    },
+    {
+      name: "blocks verification notices when Matrix DMs are disabled",
+      eventId: "$req-dm-disabled",
+      options: { dmEnabled: false },
+      accepted: false,
+      blockedLog:
+        "matrix: blocked verification sender @alice:example.org (dmPolicy=open, dmEnabled=false)",
+    },
+  ])(
+    "$name",
+    async ({ eventId, options, accepted, storeConsulted, blockedLog, expectNoRoomDispatch }) => {
+      const {
+        onRoomMessage,
+        sendMessage,
+        roomMessageListener,
+        logVerboseMessage,
+        readStoreAllowFrom,
+        flushTasks,
+      } = createHarness(options);
+      if (!roomMessageListener) {
+        throw new Error("room.message listener was not registered");
+      }
+
+      roomMessageListener("!room:example.org", {
+        event_id: eventId,
+        sender: "@alice:example.org",
+        type: EventType.RoomMessage,
+        origin_server_ts: Date.now(),
+        content: {
+          msgtype: "m.key.verification.request",
+          body: "verification request",
+        },
       });
-    if (!roomMessageListener) {
-      throw new Error("room.message listener was not registered");
-    }
 
-    roomMessageListener("!room:example.org", {
-      event_id: "$req-pairing-blocked",
-      sender: "@alice:example.org",
-      type: EventType.RoomMessage,
-      origin_server_ts: Date.now(),
-      content: {
-        msgtype: "m.key.verification.request",
-        body: "verification request",
-      },
-    });
-
-    await flushTasks();
-    expect(logVerboseMessage).toHaveBeenCalledWith(
-      "matrix: blocked verification sender @alice:example.org (dmPolicy=pairing)",
-    );
-    expect(sendMessage).not.toHaveBeenCalled();
-    expect(onRoomMessage).not.toHaveBeenCalled();
-  });
-
-  it("allows verification notices for pairing-authorized DM senders from the allow store", async () => {
-    const { sendMessage, roomMessageListener, readStoreAllowFrom, flushTasks } = createHarness({
-      dmPolicy: "pairing",
-      storeAllowFrom: ["@alice:example.org"],
-    });
-    if (!roomMessageListener) {
-      throw new Error("room.message listener was not registered");
-    }
-
-    roomMessageListener("!room:example.org", {
-      event_id: "$req-pairing-allowed",
-      sender: "@alice:example.org",
-      type: EventType.RoomMessage,
-      origin_server_ts: Date.now(),
-      content: {
-        msgtype: "m.key.verification.request",
-        body: "verification request",
-      },
-    });
-
-    await flushTasks();
-    expect(sendMessage).toHaveBeenCalledTimes(1);
-    expect(readStoreAllowFrom).toHaveBeenCalled();
-  });
-
-  it("does not consult the allow store when dmPolicy is open", async () => {
-    const { sendMessage, roomMessageListener, readStoreAllowFrom, flushTasks } = createHarness({
-      dmPolicy: "open",
-    });
-    if (!roomMessageListener) {
-      throw new Error("room.message listener was not registered");
-    }
-
-    roomMessageListener("!room:example.org", {
-      event_id: "$req-open-policy",
-      sender: "@alice:example.org",
-      type: EventType.RoomMessage,
-      origin_server_ts: Date.now(),
-      content: {
-        msgtype: "m.key.verification.request",
-        body: "verification request",
-      },
-    });
-
-    await flushTasks();
-    expect(sendMessage).toHaveBeenCalledTimes(1);
-    expect(readStoreAllowFrom).not.toHaveBeenCalled();
-  });
-
-  it("blocks verification notices when Matrix DMs are disabled", async () => {
-    const { sendMessage, roomMessageListener, logVerboseMessage, flushTasks } = createHarness({
-      dmEnabled: false,
-    });
-    if (!roomMessageListener) {
-      throw new Error("room.message listener was not registered");
-    }
-
-    roomMessageListener("!room:example.org", {
-      event_id: "$req-dm-disabled",
-      sender: "@alice:example.org",
-      type: EventType.RoomMessage,
-      origin_server_ts: Date.now(),
-      content: {
-        msgtype: "m.key.verification.request",
-        body: "verification request",
-      },
-    });
-
-    await flushTasks();
-    expect(logVerboseMessage).toHaveBeenCalledWith(
-      "matrix: blocked verification sender @alice:example.org (dmPolicy=open, dmEnabled=false)",
-    );
-    expect(sendMessage).not.toHaveBeenCalled();
-  });
+      await flushTasks();
+      if (blockedLog) {
+        expect(logVerboseMessage).toHaveBeenCalledWith(blockedLog);
+      }
+      if (storeConsulted !== undefined) {
+        if (storeConsulted) {
+          expect(readStoreAllowFrom).toHaveBeenCalled();
+        } else {
+          expect(readStoreAllowFrom).not.toHaveBeenCalled();
+        }
+      }
+      if (!accepted) {
+        expect(sendMessage).not.toHaveBeenCalled();
+        if (expectNoRoomDispatch) {
+          expect(onRoomMessage).not.toHaveBeenCalled();
+        }
+        return;
+      }
+      expect(sendMessage).toHaveBeenCalledTimes(1);
+    },
+  );
 
   it("posts ready-stage guidance for emoji verification", async () => {
     const { sendMessage, roomEventListener, flushTasks } = createHarness();

--- a/extensions/slack/src/action-runtime.test.ts
+++ b/extensions/slack/src/action-runtime.test.ts
@@ -2078,36 +2078,28 @@ describe("handleSlackAction", () => {
     });
   });
 
-  it("uses user token for reads when available", async () => {
-    const token = await resolveReadToken(
-      slackConfig({
-        accounts: {
-          default: {
-            botToken: "xoxb-bot",
-            userToken: "xoxp-user",
-          },
-        },
+  it.each<{
+    name: string;
+    config: OpenClawConfig;
+    operation: "read" | "send";
+    expectedToken?: string;
+  }>([
+    {
+      name: "uses user token for reads when available",
+      config: slackConfig({
+        accounts: { default: { botToken: "xoxb-bot", userToken: "xoxp-user" } },
       }),
-    );
-    expect(token).toBe("xoxp-user");
-  });
-
-  it("falls back to bot token for reads when user token missing", async () => {
-    const token = await resolveReadToken(
-      slackConfig({
-        accounts: {
-          default: {
-            botToken: "xoxb-bot",
-          },
-        },
-      }),
-    );
-    expect(token).toBeUndefined();
-  });
-
-  it("uses bot token for writes when userTokenReadOnly is true", async () => {
-    const token = await resolveSendToken(
-      slackConfig({
+      operation: "read",
+      expectedToken: "xoxp-user",
+    },
+    {
+      name: "falls back to bot token for reads when user token missing",
+      config: slackConfig({ accounts: { default: { botToken: "xoxb-bot" } } }),
+      operation: "read",
+    },
+    {
+      name: "uses bot token for writes when userTokenReadOnly is true",
+      config: slackConfig({
         accounts: {
           default: {
             botToken: "xoxb-bot",
@@ -2116,24 +2108,25 @@ describe("handleSlackAction", () => {
           },
         },
       }),
-    );
-    expect(token).toBeUndefined();
-  });
-
-  it("allows user token writes when bot token is missing", async () => {
-    const token = await resolveSendToken({
-      channels: {
-        slack: {
-          accounts: {
-            default: {
-              userToken: "xoxp-user",
-              userTokenReadOnly: false,
-            },
+      operation: "send",
+    },
+    {
+      name: "allows user token writes when bot token is missing",
+      config: {
+        channels: {
+          slack: {
+            accounts: { default: { userToken: "xoxp-user", userTokenReadOnly: false } },
           },
         },
-      },
-    } as OpenClawConfig);
-    expect(token).toBe("xoxp-user");
+      } as OpenClawConfig,
+      operation: "send",
+      expectedToken: "xoxp-user",
+    },
+  ])("$name", async ({ config, operation, expectedToken }) => {
+    const token = await (operation === "read"
+      ? resolveReadToken(config)
+      : resolveSendToken(config));
+    expect(token).toBe(expectedToken);
   });
 
   it("uses the user token for user-identity writes", async () => {

--- a/extensions/slack/src/monitor/slash.test.ts
+++ b/extensions/slack/src/monitor/slash.test.ts
@@ -1384,41 +1384,51 @@ describe("slack slash commands channel policy", () => {
     expect(respond).not.toHaveBeenCalled();
   });
 
-  it("allows unlisted channels when groupPolicy is open", async () => {
-    const harness = createPolicyHarness({
-      groupPolicy: "open",
-      channelsConfig: { C_LISTED: { requireMention: true } },
-      channelId: "C_UNLISTED",
-      channelName: "unlisted",
-    });
+  it.each<{
+    name: string;
+    policy: NonNullable<Parameters<typeof createPolicyHarness>[0]>;
+    blocked: boolean;
+  }>([
+    {
+      name: "allows unlisted channels when groupPolicy is open",
+      policy: {
+        groupPolicy: "open",
+        channelsConfig: { C_LISTED: { requireMention: true } },
+        channelId: "C_UNLISTED",
+        channelName: "unlisted",
+      },
+      blocked: false,
+    },
+    {
+      name: "blocks explicitly denied channels when groupPolicy is open",
+      policy: {
+        groupPolicy: "open",
+        channelsConfig: { C_DENIED: { enabled: false } },
+        channelId: "C_DENIED",
+        channelName: "denied",
+      },
+      blocked: true,
+    },
+    {
+      name: "blocks unlisted channels when groupPolicy is allowlist",
+      policy: {
+        groupPolicy: "allowlist",
+        channelsConfig: { C_LISTED: { requireMention: true } },
+        channelId: "C_UNLISTED",
+        channelName: "unlisted",
+      },
+      blocked: true,
+    },
+  ])("$name", async ({ policy, blocked }) => {
+    const harness = createPolicyHarness(policy);
     const { respond } = await registerAndRunPolicySlash({ harness });
 
+    if (blocked) {
+      expectChannelBlockedResponse(respond);
+      return;
+    }
     expect(dispatchMock).toHaveBeenCalledTimes(1);
     expect(responseTexts(respond)).not.toContain("This channel is not allowed.");
-  });
-
-  it("blocks explicitly denied channels when groupPolicy is open", async () => {
-    const harness = createPolicyHarness({
-      groupPolicy: "open",
-      channelsConfig: { C_DENIED: { enabled: false } },
-      channelId: "C_DENIED",
-      channelName: "denied",
-    });
-    const { respond } = await registerAndRunPolicySlash({ harness });
-
-    expectChannelBlockedResponse(respond);
-  });
-
-  it("blocks unlisted channels when groupPolicy is allowlist", async () => {
-    const harness = createPolicyHarness({
-      groupPolicy: "allowlist",
-      channelsConfig: { C_LISTED: { requireMention: true } },
-      channelId: "C_UNLISTED",
-      channelName: "unlisted",
-    });
-    const { respond } = await registerAndRunPolicySlash({ harness });
-
-    expectChannelBlockedResponse(respond);
   });
 });
 
@@ -1498,38 +1508,38 @@ describe("slack slash commands access groups", () => {
     expect(dispatchArg?.ctx?.From).toBe("slack:group:G_MPIM");
   });
 
-  it("blocks MPIM slash commands from senders outside the configured allowFrom", async () => {
+  it.each([
+    {
+      name: "blocks MPIM slash commands from senders outside the configured allowFrom",
+      userId: "U_ATTACKER",
+      allowed: false,
+    },
+    {
+      name: "allows MPIM slash commands from senders in the configured allowFrom",
+      userId: "U_OWNER",
+      allowed: true,
+    },
+  ])("$name", async ({ userId, allowed }) => {
     const harness = createPolicyHarness({
       allowFrom: ["U_OWNER"],
       channelId: "G_MPIM",
       channelName: "group-dm",
       resolveChannelName: async () => ({ name: "group-dm", type: "mpim" }),
-      useAccessGroups: false,
+      ...(!allowed ? { useAccessGroups: false } : {}),
     });
     const { respond } = await registerAndRunPolicySlash({
       harness,
-      command: { user_id: "U_ATTACKER" },
+      command: { user_id: userId },
     });
 
-    expect(dispatchMock).not.toHaveBeenCalled();
-    expect(respond).toHaveBeenCalledWith({
-      text: "You are not authorized to use this command here.",
-      response_type: "ephemeral",
-    });
-  });
-
-  it("allows MPIM slash commands from senders in the configured allowFrom", async () => {
-    const harness = createPolicyHarness({
-      allowFrom: ["U_OWNER"],
-      channelId: "G_MPIM",
-      channelName: "group-dm",
-      resolveChannelName: async () => ({ name: "group-dm", type: "mpim" }),
-    });
-    const { respond } = await registerAndRunPolicySlash({
-      harness,
-      command: { user_id: "U_OWNER" },
-    });
-
+    if (!allowed) {
+      expect(dispatchMock).not.toHaveBeenCalled();
+      expect(respond).toHaveBeenCalledWith({
+        text: "You are not authorized to use this command here.",
+        response_type: "ephemeral",
+      });
+      return;
+    }
     expect(dispatchMock).toHaveBeenCalledTimes(1);
     expect(responseTexts(respond)).not.toContain(
       "You are not authorized to use this command here.",


### PR DESCRIPTION
## What Problem This Solves

Current Discord, Matrix, and Slack policy/lifecycle tests repeat equivalent bot-admission, expiry, verification, token-routing, and slash-command setup. The original stacked branch also carried the now-landed #114423 layer and two suites superseded by newer owner refactors.

## Why This Change Was Made

Rebuild only the five surviving plugin-owned suites on current `main`. Named table rows preserve every current assertion and keep timer cleanup and fixtures inside the owning plugin lanes. The inherited #114423 content is gone; Discord voice and Matrix SDK remain excluded because current owner refactors superseded those stale changes.

## User Impact

No shipped behavior changes. Maintainers retain all 307 current regression cases with 56 fewer lines of plugin tests.

## Evidence

- Current-main baseline: Discord 95, Matrix 43, Slack 169 — 307/307 passed.
- Current-main synthetic merge candidate: Discord 95, Matrix 43, Slack 169 — the same 307/307 passed.
- `node scripts/check-changed.mjs` passed on Blacksmith Testbox `tbx_01kzkfvs4cvg5v9b44137t5yxh`: extension test typechecking, formatting, 245-rule lint, dependency/boundary guards, and zero warnings or errors. [Actions run](https://github.com/openclaw/openclaw/actions/runs/31319360292).
- Fresh Codex-backed autoreview passed in one round with no accepted/actionable findings.
- `git diff --check` and a current-main merge-tree check passed.
- Exact-head `pull_request` CI passed at `3e754af197c0b5700ed3dd4c63c4cc9732fb3e22`: [run 31319883908](https://github.com/openclaw/openclaw/actions/runs/31319883908).
- Scope: five plugin test files, production `+0/-0`, tests `+288/-344` (net `-56`).

ClawSweeper's rank-up move is addressed: #114423 is landed, the unrelated current-main `createTempDir` typecheck failure was fixed by `4fec5242439d`, and fresh exact-head CI validates this unchanged patch against current `main`.
