### PR TITLE
refactor(tests): simplify inbound and reply lifecycle coverage

### DIFF
--- a/src/auto-reply/heartbeat-filter.test.ts
+++ b/src/auto-reply/heartbeat-filter.test.ts
@@ -13,6 +13,33 @@ import {
 } from "./heartbeat.js";
 import { MESSAGE_TOOL_DELIVERY_HINTS } from "./reply/delivery-hints.js";
 
+function createHeartbeatAttentionOutcome() {
+  return {
+    outcome: "needs_attention",
+    notify: true,
+    summary: "Build is blocked.",
+    notificationText: "Build is blocked on missing credentials.",
+  };
+}
+
+function createHeartbeatNoChangeMessage() {
+  return {
+    role: "assistant",
+    content: [
+      {
+        type: "toolCall",
+        id: "call_heartbeat",
+        name: "heartbeat_respond",
+        arguments: {
+          outcome: "no_change",
+          notify: false,
+          summary: "No visible update.",
+        },
+      },
+    ],
+  };
+}
+
 const HIDDEN_REASONING_BLOCKS = [
   ["thinking", { type: "thinking", thinking: "Checking the heartbeat." }],
   ["reasoning", { type: "reasoning", text: "Checking the heartbeat." }],
@@ -276,21 +303,7 @@ describe("filterHeartbeatTranscriptArtifacts", () => {
         toolCallId: "call_bash",
         content: [{ type: "text", text: "checked HEARTBEAT.md" }],
       },
-      {
-        role: "assistant",
-        content: [
-          {
-            type: "toolCall",
-            id: "call_heartbeat",
-            name: "heartbeat_respond",
-            arguments: {
-              outcome: "no_change",
-              notify: false,
-              summary: "No visible update.",
-            },
-          },
-        ],
-      },
+      createHeartbeatNoChangeMessage(),
       {
         role: "toolResult",
         toolCallId: "call_heartbeat",
@@ -307,21 +320,7 @@ describe("filterHeartbeatTranscriptArtifacts", () => {
   it("removes full default response-tool prompt spans", () => {
     const messages = [
       { role: "user", content: HEARTBEAT_RESPONSE_TOOL_PROMPT },
-      {
-        role: "assistant",
-        content: [
-          {
-            type: "toolCall",
-            id: "call_heartbeat",
-            name: "heartbeat_respond",
-            arguments: {
-              outcome: "no_change",
-              notify: false,
-              summary: "No visible update.",
-            },
-          },
-        ],
-      },
+      createHeartbeatNoChangeMessage(),
       {
         role: "toolResult",
         toolCallId: "call_heartbeat",
@@ -391,21 +390,7 @@ describe("filterHeartbeatTranscriptArtifacts", () => {
   it("removes assistant continuations after heartbeat response-tool results", () => {
     const messages = [
       { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT },
-      {
-        role: "assistant",
-        content: [
-          {
-            type: "toolCall",
-            id: "call_heartbeat",
-            name: "heartbeat_respond",
-            arguments: {
-              outcome: "no_change",
-              notify: false,
-              summary: "No visible update.",
-            },
-          },
-        ],
-      },
+      createHeartbeatNoChangeMessage(),
       {
         role: "toolResult",
         toolCallId: "call_heartbeat",
@@ -443,12 +428,7 @@ describe("filterHeartbeatTranscriptArtifacts", () => {
             type: "toolCall",
             id: "call_heartbeat",
             name: "heartbeat_respond",
-            arguments: {
-              outcome: "needs_attention",
-              notify: true,
-              summary: "Build is blocked.",
-              notificationText: "Build is blocked on missing credentials.",
-            },
+            arguments: createHeartbeatAttentionOutcome(),
           },
         ],
       },
@@ -475,12 +455,7 @@ describe("filterHeartbeatTranscriptArtifacts", () => {
             type: "toolCall",
             id: "call_heartbeat",
             name: "heartbeat_respond",
-            arguments: {
-              outcome: "needs_attention",
-              notify: true,
-              summary: "Build is blocked.",
-              notificationText: "Build is blocked on missing credentials.",
-            },
+            arguments: createHeartbeatAttentionOutcome(),
           },
         ],
       },
@@ -509,12 +484,7 @@ describe("filterHeartbeatTranscriptArtifacts", () => {
             id: "call_heartbeat",
             function: {
               name: "heartbeat_respond",
-              arguments: JSON.stringify({
-                outcome: "needs_attention",
-                notify: true,
-                summary: "Build is blocked.",
-                notificationText: "Build is blocked on missing credentials.",
-              }),
+              arguments: JSON.stringify(createHeartbeatAttentionOutcome()),
             },
           },
         ],
@@ -544,12 +514,7 @@ describe("filterHeartbeatTranscriptArtifacts", () => {
             id: "fc_item_123",
             call_id: "call_heartbeat",
             name: "heartbeat_respond",
-            arguments: JSON.stringify({
-              outcome: "needs_attention",
-              notify: true,
-              summary: "Build is blocked.",
-              notificationText: "Build is blocked on missing credentials.",
-            }),
+            arguments: JSON.stringify(createHeartbeatAttentionOutcome()),
           },
         ],
       },
@@ -581,12 +546,7 @@ describe("filterHeartbeatTranscriptArtifacts", () => {
             type: "tool_use",
             id: "toolu_heartbeat",
             name: "heartbeat_respond",
-            input: {
-              outcome: "needs_attention",
-              notify: true,
-              summary: "Build is blocked.",
-              notificationText: "Build is blocked on missing credentials.",
-            },
+            input: createHeartbeatAttentionOutcome(),
           },
         ],
       },
@@ -618,12 +578,7 @@ describe("filterHeartbeatTranscriptArtifacts", () => {
             type: "tool_use",
             id: "toolu_heartbeat",
             name: "heartbeat_respond",
-            input: {
-              outcome: "needs_attention",
-              notify: true,
-              summary: "Build is blocked.",
-              notificationText: "Build is blocked on missing credentials.",
-            },
+            input: createHeartbeatAttentionOutcome(),
           },
         ],
       },
@@ -656,12 +611,7 @@ describe("filterHeartbeatTranscriptArtifacts", () => {
             type: "toolCall",
             id: "call_heartbeat",
             name: "heartbeat_respond",
-            arguments: {
-              outcome: "needs_attention",
-              notify: true,
-              summary: "Build is blocked.",
-              notificationText: "Build is blocked on missing credentials.",
-            },
+            arguments: createHeartbeatAttentionOutcome(),
           },
         ],
       },
@@ -683,12 +633,7 @@ describe("filterHeartbeatTranscriptArtifacts", () => {
             type: "toolCall",
             id: "call_heartbeat",
             name: "heartbeat_respond",
-            arguments: {
-              outcome: "needs_attention",
-              notify: true,
-              summary: "Build is blocked.",
-              notificationText: "Build is blocked on missing credentials.",
-            },
+            arguments: createHeartbeatAttentionOutcome(),
           },
         ],
       },
@@ -716,12 +661,7 @@ describe("filterHeartbeatTranscriptArtifacts", () => {
             type: "tool_use",
             id: "toolu_heartbeat",
             name: "heartbeat_respond",
-            input: {
-              outcome: "needs_attention",
-              notify: true,
-              summary: "Build is blocked.",
-              notificationText: "Build is blocked on missing credentials.",
-            },
+            input: createHeartbeatAttentionOutcome(),
           },
         ],
       },
@@ -754,12 +694,7 @@ describe("filterHeartbeatTranscriptArtifacts", () => {
             type: "tool_use",
             id: "toolu_heartbeat",
             name: "heartbeat_respond",
-            input: {
-              outcome: "needs_attention",
-              notify: true,
-              summary: "Build is blocked.",
-              notificationText: "Build is blocked on missing credentials.",
-            },
+            input: createHeartbeatAttentionOutcome(),
           },
         ],
       },
@@ -797,12 +732,7 @@ describe("filterHeartbeatTranscriptArtifacts", () => {
             type: "toolCall",
             id: "call_heartbeat",
             name: "heartbeat_respond",
-            arguments: {
-              outcome: "needs_attention",
-              notify: true,
-              summary: "Build is blocked.",
-              notificationText: "Build is blocked on missing credentials.",
-            },
+            arguments: createHeartbeatAttentionOutcome(),
           },
         ],
       },
@@ -925,21 +855,7 @@ describe("filterHeartbeatTranscriptArtifacts", () => {
   it("does not remove across a real user message", () => {
     const messages = [
       { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT },
-      {
-        role: "assistant",
-        content: [
-          {
-            type: "toolCall",
-            id: "call_heartbeat",
-            name: "heartbeat_respond",
-            arguments: {
-              outcome: "no_change",
-              notify: false,
-              summary: "No visible update.",
-            },
-          },
-        ],
-      },
+      createHeartbeatNoChangeMessage(),
       {
         role: "toolResult",
         toolCallId: "call_heartbeat",

--- a/src/auto-reply/heartbeat.test.ts
+++ b/src/auto-reply/heartbeat.test.ts
@@ -9,6 +9,14 @@ import {
 } from "./heartbeat.js";
 import { HEARTBEAT_TOKEN } from "./tokens.js";
 
+function createSkippedHeartbeatOutcome() {
+  return {
+    shouldSkip: true,
+    text: "",
+    didStrip: true,
+  };
+}
+
 describe("stripHeartbeatToken", () => {
   it("skips empty or token-only replies", () => {
     expect(stripHeartbeatToken(undefined, { mode: "heartbeat" })).toEqual({
@@ -21,32 +29,24 @@ describe("stripHeartbeatToken", () => {
       text: "",
       didStrip: false,
     });
-    expect(stripHeartbeatToken(HEARTBEAT_TOKEN, { mode: "heartbeat" })).toEqual({
-      shouldSkip: true,
-      text: "",
-      didStrip: true,
-    });
+    expect(stripHeartbeatToken(HEARTBEAT_TOKEN, { mode: "heartbeat" })).toEqual(
+      createSkippedHeartbeatOutcome(),
+    );
   });
 
   it("drops heartbeats with small junk in heartbeat mode", () => {
-    expect(stripHeartbeatToken("HEARTBEAT_OK 🦞", { mode: "heartbeat" })).toEqual({
-      shouldSkip: true,
-      text: "",
-      didStrip: true,
-    });
-    expect(stripHeartbeatToken(`🦞 ${HEARTBEAT_TOKEN}`, { mode: "heartbeat" })).toEqual({
-      shouldSkip: true,
-      text: "",
-      didStrip: true,
-    });
+    expect(stripHeartbeatToken("HEARTBEAT_OK 🦞", { mode: "heartbeat" })).toEqual(
+      createSkippedHeartbeatOutcome(),
+    );
+    expect(stripHeartbeatToken(`🦞 ${HEARTBEAT_TOKEN}`, { mode: "heartbeat" })).toEqual(
+      createSkippedHeartbeatOutcome(),
+    );
   });
 
   it("drops short remainder in heartbeat mode", () => {
-    expect(stripHeartbeatToken(`ALERT ${HEARTBEAT_TOKEN}`, { mode: "heartbeat" })).toEqual({
-      shouldSkip: true,
-      text: "",
-      didStrip: true,
-    });
+    expect(stripHeartbeatToken(`ALERT ${HEARTBEAT_TOKEN}`, { mode: "heartbeat" })).toEqual(
+      createSkippedHeartbeatOutcome(),
+    );
   });
 
   it("keeps heartbeat replies when remaining content exceeds threshold", () => {
@@ -84,19 +84,15 @@ describe("stripHeartbeatToken", () => {
   });
 
   it("strips HTML-wrapped heartbeat tokens", () => {
-    expect(stripHeartbeatToken(`<b>${HEARTBEAT_TOKEN}</b>`, { mode: "heartbeat" })).toEqual({
-      shouldSkip: true,
-      text: "",
-      didStrip: true,
-    });
+    expect(stripHeartbeatToken(`<b>${HEARTBEAT_TOKEN}</b>`, { mode: "heartbeat" })).toEqual(
+      createSkippedHeartbeatOutcome(),
+    );
   });
 
   it("strips markdown-wrapped heartbeat tokens", () => {
-    expect(stripHeartbeatToken(`**${HEARTBEAT_TOKEN}**`, { mode: "heartbeat" })).toEqual({
-      shouldSkip: true,
-      text: "",
-      didStrip: true,
-    });
+    expect(stripHeartbeatToken(`**${HEARTBEAT_TOKEN}**`, { mode: "heartbeat" })).toEqual(
+      createSkippedHeartbeatOutcome(),
+    );
   });
 
   it("removes markup-wrapped token and keeps trailing content", () => {
@@ -112,21 +108,15 @@ describe("stripHeartbeatToken", () => {
   });
 
   it("strips trailing punctuation only when directly after the token", () => {
-    expect(stripHeartbeatToken(`${HEARTBEAT_TOKEN}.`, { mode: "heartbeat" })).toEqual({
-      shouldSkip: true,
-      text: "",
-      didStrip: true,
-    });
-    expect(stripHeartbeatToken(`${HEARTBEAT_TOKEN}!!!`, { mode: "heartbeat" })).toEqual({
-      shouldSkip: true,
-      text: "",
-      didStrip: true,
-    });
-    expect(stripHeartbeatToken(`${HEARTBEAT_TOKEN}---`, { mode: "heartbeat" })).toEqual({
-      shouldSkip: true,
-      text: "",
-      didStrip: true,
-    });
+    expect(stripHeartbeatToken(`${HEARTBEAT_TOKEN}.`, { mode: "heartbeat" })).toEqual(
+      createSkippedHeartbeatOutcome(),
+    );
+    expect(stripHeartbeatToken(`${HEARTBEAT_TOKEN}!!!`, { mode: "heartbeat" })).toEqual(
+      createSkippedHeartbeatOutcome(),
+    );
+    expect(stripHeartbeatToken(`${HEARTBEAT_TOKEN}---`, { mode: "heartbeat" })).toEqual(
+      createSkippedHeartbeatOutcome(),
+    );
   });
 
   it("strips a sentence-ending token and keeps trailing punctuation", () => {
@@ -149,11 +139,7 @@ describe("stripHeartbeatToken", () => {
           mode: "heartbeat",
         },
       ),
-    ).toEqual({
-      shouldSkip: true,
-      text: "",
-      didStrip: true,
-    });
+    ).toEqual(createSkippedHeartbeatOutcome());
   });
 
   it("preserves trailing punctuation on text before the token", () => {

--- a/src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts
@@ -132,6 +132,10 @@ const createHandleInlineActionsInput = (params: {
   };
 };
 
+function runTestInlineActions(params: Parameters<typeof createHandleInlineActionsInput>[0]) {
+  return handleInlineActions(createHandleInlineActionsInput(params));
+}
+
 async function expectInlineActionSkipped(params: {
   ctx: ReturnType<typeof buildTestCtx>;
   typing: TypingController;
@@ -139,7 +143,7 @@ async function expectInlineActionSkipped(params: {
   command?: Partial<HandleInlineActionsInput["command"]>;
   overrides?: Partial<Omit<HandleInlineActionsInput, "ctx" | "sessionCtx" | "typing" | "command">>;
 }) {
-  const result = await handleInlineActions(createHandleInlineActionsInput(params));
+  const result = await runTestInlineActions(params);
   expect(result).toEqual({ kind: "reply", reply: undefined });
   expect(params.typing.cleanup).toHaveBeenCalledTimes(1);
   expect(handleCommandsMock).not.toHaveBeenCalled();
@@ -151,23 +155,21 @@ async function runInlineStatusAction(storePath?: string) {
     Body: "/status",
     CommandBody: "/status",
   });
-  const result = await handleInlineActions(
-    createHandleInlineActionsInput({
-      ctx,
-      typing,
-      cleanedBody: stripInlineStatus("/status").cleaned,
-      command: {
-        isAuthorizedSender: true,
-        rawBodyNormalized: "/status",
-        commandBodyNormalized: "/status",
-      },
-      overrides: {
-        allowTextCommands: true,
-        inlineStatusRequested: true,
-        ...(storePath ? { storePath } : {}),
-      },
-    }),
-  );
+  const result = await runTestInlineActions({
+    ctx,
+    typing,
+    cleanedBody: stripInlineStatus("/status").cleaned,
+    command: {
+      isAuthorizedSender: true,
+      rawBodyNormalized: "/status",
+      commandBodyNormalized: "/status",
+    },
+    overrides: {
+      allowTextCommands: true,
+      inlineStatusRequested: true,
+      ...(storePath ? { storePath } : {}),
+    },
+  });
 
   return { result, typing };
 }
@@ -273,24 +275,22 @@ describe("handleInlineActions", () => {
       return { shouldContinue: true };
     });
 
-    const result = await handleInlineActions(
-      createHandleInlineActionsInput({
-        ctx,
-        typing,
-        cleanedBody: "/goal build the thing",
-        command: {
-          isAuthorizedSender: true,
-          rawBodyNormalized: "/goal build the thing",
-          commandBodyNormalized: "/goal build the thing",
-        },
-        overrides: {
-          allowTextCommands: true,
-          opts: {
-            onSessionMetadataChanges,
-          } as unknown as HandleInlineActionsInput["opts"],
-        },
-      }),
-    );
+    const result = await runTestInlineActions({
+      ctx,
+      typing,
+      cleanedBody: "/goal build the thing",
+      command: {
+        isAuthorizedSender: true,
+        rawBodyNormalized: "/goal build the thing",
+        commandBodyNormalized: "/goal build the thing",
+      },
+      overrides: {
+        allowTextCommands: true,
+        opts: {
+          onSessionMetadataChanges,
+        } as unknown as HandleInlineActionsInput["opts"],
+      },
+    });
 
     expect(result.kind).toBe("continue");
     expect(onSessionMetadataChanges).toHaveBeenCalledWith([
@@ -310,17 +310,15 @@ describe("handleInlineActions", () => {
       { assistantMessageIndex: 7 },
     );
 
-    const result = await handleInlineActions(
-      createHandleInlineActionsInput({
-        ctx,
-        typing,
-        cleanedBody: "keep going",
-        overrides: {
-          directiveAck,
-          opts: { onBlockReply } as HandleInlineActionsInput["opts"],
-        },
-      }),
-    );
+    const result = await runTestInlineActions({
+      ctx,
+      typing,
+      cleanedBody: "keep going",
+      overrides: {
+        directiveAck,
+        opts: { onBlockReply } as HandleInlineActionsInput["opts"],
+      },
+    });
 
     expect(result.kind).toBe("continue");
     expect(onBlockReply).toHaveBeenCalledTimes(1);
@@ -346,22 +344,20 @@ describe("handleInlineActions", () => {
     });
     const agentDir = "/tmp/inline-agent";
 
-    const result = await handleInlineActions(
-      createHandleInlineActionsInput({
-        ctx,
-        typing,
-        cleanedBody: "/status",
-        command: {
-          isAuthorizedSender: true,
-          senderId: "sender-1",
-          abortKey: "sender-1",
-        },
-        overrides: {
-          cfg: { commands: { text: true } },
-          agentDir,
-        },
-      }),
-    );
+    const result = await runTestInlineActions({
+      ctx,
+      typing,
+      cleanedBody: "/status",
+      command: {
+        isAuthorizedSender: true,
+        senderId: "sender-1",
+        abortKey: "sender-1",
+      },
+      overrides: {
+        cfg: { commands: { text: true } },
+        agentDir,
+      },
+    });
 
     expect(result).toEqual({ kind: "reply", reply: { text: "done" } });
     expect(handleCommandsMock).toHaveBeenCalledTimes(1);
@@ -378,32 +374,30 @@ describe("handleInlineActions", () => {
       CommandBody: "/status",
     });
 
-    const result = await handleInlineActions(
-      createHandleInlineActionsInput({
-        ctx,
-        typing,
-        cleanedBody: "/status",
-        command: {
-          isAuthorizedSender: true,
-          rawBodyNormalized: "/status",
-          commandBodyNormalized: "/status",
-        },
-        overrides: {
-          allowTextCommands: true,
-          cfg: { commands: { text: true } },
-          sessionEntry: {
-            sessionId: "wrapper-session",
+    const result = await runTestInlineActions({
+      ctx,
+      typing,
+      cleanedBody: "/status",
+      command: {
+        isAuthorizedSender: true,
+        rawBodyNormalized: "/status",
+        commandBodyNormalized: "/status",
+      },
+      overrides: {
+        allowTextCommands: true,
+        cfg: { commands: { text: true } },
+        sessionEntry: {
+          sessionId: "wrapper-session",
+          updatedAt: Date.now(),
+        } as SessionEntry,
+        sessionStore: {
+          "s:main": {
+            sessionId: "target-session",
             updatedAt: Date.now(),
           } as SessionEntry,
-          sessionStore: {
-            "s:main": {
-              sessionId: "target-session",
-              updatedAt: Date.now(),
-            } as SessionEntry,
-          },
         },
-      }),
-    );
+      },
+    });
 
     expect(result).toEqual({ kind: "reply", reply: { text: "done" } });
     const commandArgs = mockObjectArg(handleCommandsMock, "handleCommands");
@@ -440,34 +434,32 @@ describe("handleInlineActions", () => {
       ParentSessionKey: "ctx-parent",
     });
 
-    const result = await handleInlineActions(
-      createHandleInlineActionsInput({
-        ctx,
-        typing,
-        cleanedBody: stripInlineStatus("/status").cleaned,
-        command: {
-          isAuthorizedSender: true,
-          rawBodyNormalized: "/status",
-          commandBodyNormalized: "/status",
-        },
-        overrides: {
-          allowTextCommands: true,
-          inlineStatusRequested: true,
-          sessionEntry: {
-            sessionId: "wrapper-session",
+    const result = await runTestInlineActions({
+      ctx,
+      typing,
+      cleanedBody: stripInlineStatus("/status").cleaned,
+      command: {
+        isAuthorizedSender: true,
+        rawBodyNormalized: "/status",
+        commandBodyNormalized: "/status",
+      },
+      overrides: {
+        allowTextCommands: true,
+        inlineStatusRequested: true,
+        sessionEntry: {
+          sessionId: "wrapper-session",
+          updatedAt: Date.now(),
+          parentSessionKey: "wrapper-parent",
+        } as SessionEntry,
+        sessionStore: {
+          "s:main": {
+            sessionId: "target-session",
             updatedAt: Date.now(),
-            parentSessionKey: "wrapper-parent",
+            parentSessionKey: "target-parent",
           } as SessionEntry,
-          sessionStore: {
-            "s:main": {
-              sessionId: "target-session",
-              updatedAt: Date.now(),
-              parentSessionKey: "target-parent",
-            } as SessionEntry,
-          },
         },
-      }),
-    );
+      },
+    });
 
     expect(result).toEqual({ kind: "reply", reply: undefined });
     const statusArgs = mockObjectArg(buildStatusReplyMock, "buildStatusReply");
@@ -489,26 +481,24 @@ describe("handleInlineActions", () => {
       WasMentioned: true,
     });
 
-    const result = await handleInlineActions(
-      createHandleInlineActionsInput({
-        ctx,
-        typing,
-        cleanedBody: "<@123>",
-        command: {
-          surface: "discord",
-          channel: "discord",
-          channelId: "discord",
-          isAuthorizedSender: true,
-          rawBodyNormalized: "<@123> /status",
-          commandBodyNormalized: "<@123> /status",
-        },
-        overrides: {
-          allowTextCommands: true,
-          inlineStatusRequested: true,
-          isGroup: true,
-        },
-      }),
-    );
+    const result = await runTestInlineActions({
+      ctx,
+      typing,
+      cleanedBody: "<@123>",
+      command: {
+        surface: "discord",
+        channel: "discord",
+        channelId: "discord",
+        isAuthorizedSender: true,
+        rawBodyNormalized: "<@123> /status",
+        commandBodyNormalized: "<@123> /status",
+      },
+      overrides: {
+        allowTextCommands: true,
+        inlineStatusRequested: true,
+        isGroup: true,
+      },
+    });
 
     expect(result).toEqual({ kind: "reply", reply: undefined });
     expect(buildStatusReplyMock).toHaveBeenCalledTimes(1);
@@ -527,26 +517,24 @@ describe("handleInlineActions", () => {
       WasMentioned: true,
     });
 
-    const result = await handleInlineActions(
-      createHandleInlineActionsInput({
-        ctx,
-        typing,
-        cleanedBody: "<@123> what's next?",
-        command: {
-          surface: "discord",
-          channel: "discord",
-          channelId: "discord",
-          isAuthorizedSender: true,
-          rawBodyNormalized: "<@123> /status what's next?",
-          commandBodyNormalized: "<@123> /status what's next?",
-        },
-        overrides: {
-          allowTextCommands: true,
-          inlineStatusRequested: true,
-          isGroup: true,
-        },
-      }),
-    );
+    const result = await runTestInlineActions({
+      ctx,
+      typing,
+      cleanedBody: "<@123> what's next?",
+      command: {
+        surface: "discord",
+        channel: "discord",
+        channelId: "discord",
+        isAuthorizedSender: true,
+        rawBodyNormalized: "<@123> /status what's next?",
+        commandBodyNormalized: "<@123> /status what's next?",
+      },
+      overrides: {
+        allowTextCommands: true,
+        inlineStatusRequested: true,
+        isGroup: true,
+      },
+    });
 
     expect(result).toEqual({
       kind: "continue",
@@ -674,21 +662,19 @@ describe("handleInlineActions", () => {
       MessageSid: "43",
     });
 
-    const result = await handleInlineActions(
-      createHandleInlineActionsInput({
-        ctx,
-        typing,
-        cleanedBody: "new message",
-        command: {
-          rawBodyNormalized: "new message",
-          commandBodyNormalized: "new message",
-        },
-        overrides: {
-          sessionEntry,
-          sessionStore,
-        },
-      }),
-    );
+    const result = await runTestInlineActions({
+      ctx,
+      typing,
+      cleanedBody: "new message",
+      command: {
+        rawBodyNormalized: "new message",
+        commandBodyNormalized: "new message",
+      },
+      overrides: {
+        sessionEntry,
+        sessionStore,
+      },
+    });
 
     expect(result).toEqual({
       kind: "continue",
@@ -747,23 +733,21 @@ describe("handleInlineActions", () => {
     });
     const skillCommands = officeHoursSkillCommands();
 
-    const result = await handleInlineActions(
-      createHandleInlineActionsInput({
-        ctx,
-        typing,
-        cleanedBody: "/office_hours build me a deployment plan",
-        command: {
-          isAuthorizedSender: true,
-          rawBodyNormalized: "/office_hours build me a deployment plan",
-          commandBodyNormalized: "/office_hours build me a deployment plan",
-        },
-        overrides: {
-          allowTextCommands: true,
-          cfg: { commands: { text: true } },
-          skillCommands,
-        },
-      }),
-    );
+    const result = await runTestInlineActions({
+      ctx,
+      typing,
+      cleanedBody: "/office_hours build me a deployment plan",
+      command: {
+        isAuthorizedSender: true,
+        rawBodyNormalized: "/office_hours build me a deployment plan",
+        commandBodyNormalized: "/office_hours build me a deployment plan",
+      },
+      overrides: {
+        allowTextCommands: true,
+        cfg: { commands: { text: true } },
+        skillCommands,
+      },
+    });
 
     expect(result).toEqual({ kind: "reply", reply: { text: "done" } });
     expect(ctx.Body).toBe(
@@ -785,23 +769,21 @@ describe("handleInlineActions", () => {
     const skillCommands = officeHoursSkillCommands();
     listSkillCommandsForWorkspaceMock.mockReturnValue(skillCommands);
 
-    const result = await handleInlineActions(
-      createHandleInlineActionsInput({
-        ctx,
-        typing,
-        cleanedBody: "/skill office_hours build me a deployment plan",
-        command: {
-          isAuthorizedSender: true,
-          rawBodyNormalized: "/skill office_hours build me a deployment plan",
-          commandBodyNormalized: "/skill office_hours build me a deployment plan",
-        },
-        overrides: {
-          allowTextCommands: true,
-          cfg: { commands: { text: true } },
-          skillCommands: [],
-        },
-      }),
-    );
+    const result = await runTestInlineActions({
+      ctx,
+      typing,
+      cleanedBody: "/skill office_hours build me a deployment plan",
+      command: {
+        isAuthorizedSender: true,
+        rawBodyNormalized: "/skill office_hours build me a deployment plan",
+        commandBodyNormalized: "/skill office_hours build me a deployment plan",
+      },
+      overrides: {
+        allowTextCommands: true,
+        cfg: { commands: { text: true } },
+        skillCommands: [],
+      },
+    });
 
     expect(result).toEqual({ kind: "reply", reply: { text: "done" } });
     expect(listSkillCommandsForWorkspaceMock).toHaveBeenCalledOnce();
@@ -834,23 +816,21 @@ describe("handleInlineActions", () => {
       },
     ];
 
-    const result = await handleInlineActions(
-      createHandleInlineActionsInput({
-        ctx,
-        typing,
-        cleanedBody: original,
-        command: {
-          isAuthorizedSender: true,
-          rawBodyNormalized: original,
-          commandBodyNormalized: original,
-        },
-        overrides: {
-          allowTextCommands: true,
-          cfg: { commands: { text: true } },
-          skillCommands,
-        },
-      }),
-    );
+    const result = await runTestInlineActions({
+      ctx,
+      typing,
+      cleanedBody: original,
+      command: {
+        isAuthorizedSender: true,
+        rawBodyNormalized: original,
+        commandBodyNormalized: original,
+      },
+      overrides: {
+        allowTextCommands: true,
+        cfg: { commands: { text: true } },
+        skillCommands,
+      },
+    });
 
     expect(result.kind).toBe("continue");
     if (result.kind !== "continue") {
@@ -885,23 +865,21 @@ describe("handleInlineActions", () => {
       Surface: "webchat",
     });
 
-    const result = await handleInlineActions(
-      createHandleInlineActionsInput({
-        ctx,
-        typing,
-        cleanedBody: original,
-        command: {
-          isAuthorizedSender: true,
-          rawBodyNormalized: original,
-          commandBodyNormalized: original,
-        },
-        overrides: {
-          allowTextCommands: true,
-          cfg: { commands: { text: true } },
-          skillCommands,
-        },
-      }),
-    );
+    const result = await runTestInlineActions({
+      ctx,
+      typing,
+      cleanedBody: original,
+      command: {
+        isAuthorizedSender: true,
+        rawBodyNormalized: original,
+        commandBodyNormalized: original,
+      },
+      overrides: {
+        allowTextCommands: true,
+        cfg: { commands: { text: true } },
+        skillCommands,
+      },
+    });
 
     expect(result).toEqual({
       kind: "reply",
@@ -916,30 +894,28 @@ describe("handleInlineActions", () => {
     const original = "Review with $office_hours.";
     const ctx = buildTestCtx({ Body: original, CommandBody: original });
 
-    const result = await handleInlineActions(
-      createHandleInlineActionsInput({
-        ctx,
-        typing,
-        cleanedBody: original,
-        command: {
-          isAuthorizedSender: true,
-          rawBodyNormalized: original,
-          commandBodyNormalized: original,
-        },
-        overrides: {
-          allowTextCommands: true,
-          cfg: { commands: { text: true } },
-          skillCommands: [
-            {
-              name: "office_hours",
-              skillName: "office-hours",
-              description: "Engineering office hours",
-              modelVisible: true,
-            },
-          ],
-        },
-      }),
-    );
+    const result = await runTestInlineActions({
+      ctx,
+      typing,
+      cleanedBody: original,
+      command: {
+        isAuthorizedSender: true,
+        rawBodyNormalized: original,
+        commandBodyNormalized: original,
+      },
+      overrides: {
+        allowTextCommands: true,
+        cfg: { commands: { text: true } },
+        skillCommands: [
+          {
+            name: "office_hours",
+            skillName: "office-hours",
+            description: "Engineering office hours",
+            modelVisible: true,
+          },
+        ],
+      },
+    });
 
     expect(result.kind).toBe("continue");
     if (result.kind !== "continue") {
@@ -956,24 +932,22 @@ describe("handleInlineActions", () => {
     const skillCommands = officeHoursSkillCommands();
     listSkillCommandsForWorkspaceMock.mockReturnValue(skillCommands);
 
-    await handleInlineActions(
-      createHandleInlineActionsInput({
-        ctx,
-        typing,
-        cleanedBody: "/office_hours help",
-        command: {
-          isAuthorizedSender: true,
-          rawBodyNormalized: "/office_hours help",
-          commandBodyNormalized: "/office_hours help",
-        },
-        overrides: {
-          allowTextCommands: true,
-          cfg: { commands: { text: true } },
-          execOverrides: { security: "deny" },
-          skillCommands,
-        },
-      }),
-    );
+    await runTestInlineActions({
+      ctx,
+      typing,
+      cleanedBody: "/office_hours help",
+      command: {
+        isAuthorizedSender: true,
+        rawBodyNormalized: "/office_hours help",
+        commandBodyNormalized: "/office_hours help",
+      },
+      overrides: {
+        allowTextCommands: true,
+        cfg: { commands: { text: true } },
+        execOverrides: { security: "deny" },
+        skillCommands,
+      },
+    });
 
     expect(listSkillCommandsForWorkspaceMock).toHaveBeenCalledWith(
       expect.objectContaining({ execOverrides: { security: "deny" } }),
@@ -1008,27 +982,25 @@ describe("handleInlineActions", () => {
       },
     ];
 
-    const result = await handleInlineActions(
-      createHandleInlineActionsInput({
-        ctx,
-        typing,
-        cleanedBody: "/spawn_subagent investigate",
-        command: {
-          isAuthorizedSender: true,
-          senderId: "sender-1",
-          senderIsOwner: true,
-          abortKey: "sender-1",
-          rawBodyNormalized: "/spawn_subagent investigate",
-          commandBodyNormalized: "/spawn_subagent investigate",
-        },
-        overrides: {
-          cfg: { commands: { text: true } },
-          agentId: "named-worker",
-          allowTextCommands: true,
-          skillCommands,
-        },
-      }),
-    );
+    const result = await runTestInlineActions({
+      ctx,
+      typing,
+      cleanedBody: "/spawn_subagent investigate",
+      command: {
+        isAuthorizedSender: true,
+        senderId: "sender-1",
+        senderIsOwner: true,
+        abortKey: "sender-1",
+        rawBodyNormalized: "/spawn_subagent investigate",
+        commandBodyNormalized: "/spawn_subagent investigate",
+      },
+      overrides: {
+        cfg: { commands: { text: true } },
+        agentId: "named-worker",
+        allowTextCommands: true,
+        skillCommands,
+      },
+    });
 
     expect(result).toEqual({ kind: "reply", reply: { text: "✅ Done." } });
     expect(
@@ -1067,26 +1039,24 @@ describe("handleInlineActions", () => {
       },
     ];
 
-    const result = await handleInlineActions(
-      createHandleInlineActionsInput({
-        ctx,
-        typing,
-        cleanedBody: "/set_profile display name",
-        command: {
-          isAuthorizedSender: true,
-          senderId: "sender-1",
-          senderIsOwner: true,
-          abortKey: "sender-1",
-          rawBodyNormalized: "/set_profile display name",
-          commandBodyNormalized: "/set_profile display name",
-        },
-        overrides: {
-          cfg: { commands: { text: true } },
-          allowTextCommands: true,
-          skillCommands,
-        },
-      }),
-    );
+    const result = await runTestInlineActions({
+      ctx,
+      typing,
+      cleanedBody: "/set_profile display name",
+      command: {
+        isAuthorizedSender: true,
+        senderId: "sender-1",
+        senderIsOwner: true,
+        abortKey: "sender-1",
+        rawBodyNormalized: "/set_profile display name",
+        commandBodyNormalized: "/set_profile display name",
+      },
+      overrides: {
+        cfg: { commands: { text: true } },
+        allowTextCommands: true,
+        skillCommands,
+      },
+    });
 
     expect(result).toEqual({ kind: "reply", reply: { text: "✅ Done." } });
     const toolsArgs = mockObjectArg(createOpenClawToolsMock, "createOpenClawTools");
@@ -1148,45 +1118,43 @@ describe("handleInlineActions", () => {
       },
     ];
 
-    const result = await handleInlineActions(
-      createHandleInlineActionsInput({
-        ctx,
-        typing,
-        cleanedBody: "/set_profile display name",
-        command: {
-          isAuthorizedSender: true,
-          senderId: "sender-1",
-          senderIsOwner: true,
-          abortKey: "sender-1",
-          rawBodyNormalized: "/set_profile display name",
-          commandBodyNormalized: "/set_profile display name",
-        },
-        overrides: {
-          cfg: {
-            commands: { text: true },
-            tools: {
-              loopDetection: {
-                enabled: true,
-              },
+    const result = await runTestInlineActions({
+      ctx,
+      typing,
+      cleanedBody: "/set_profile display name",
+      command: {
+        isAuthorizedSender: true,
+        senderId: "sender-1",
+        senderIsOwner: true,
+        abortKey: "sender-1",
+        rawBodyNormalized: "/set_profile display name",
+        commandBodyNormalized: "/set_profile display name",
+      },
+      overrides: {
+        cfg: {
+          commands: { text: true },
+          tools: {
+            loopDetection: {
+              enabled: true,
             },
           },
-          agentId: "main",
-          allowTextCommands: true,
-          opts: { abortSignal: abortController.signal },
-          skillCommands,
-          sessionEntry: {
-            sessionId: "wrapper-session",
+        },
+        agentId: "main",
+        allowTextCommands: true,
+        opts: { abortSignal: abortController.signal },
+        skillCommands,
+        sessionEntry: {
+          sessionId: "wrapper-session",
+          updatedAt: 0,
+        },
+        sessionStore: {
+          "s:main": {
+            sessionId: "target-session",
             updatedAt: 0,
           },
-          sessionStore: {
-            "s:main": {
-              sessionId: "target-session",
-              updatedAt: 0,
-            },
-          },
         },
-      }),
-    );
+      },
+    });
 
     expect(result).toEqual({
       kind: "reply",
@@ -1234,26 +1202,24 @@ describe("handleInlineActions", () => {
       },
     ];
 
-    const result = await handleInlineActions(
-      createHandleInlineActionsInput({
-        ctx,
-        typing,
-        cleanedBody: "/send_status hello",
-        command: {
-          isAuthorizedSender: true,
-          senderId: "sender-1",
-          senderIsOwner: true,
-          abortKey: "sender-1",
-          rawBodyNormalized: "/send_status hello",
-          commandBodyNormalized: "/send_status hello",
-        },
-        overrides: {
-          cfg: { commands: { text: true }, tools: { deny: ["message"] } },
-          allowTextCommands: true,
-          skillCommands,
-        },
-      }),
-    );
+    const result = await runTestInlineActions({
+      ctx,
+      typing,
+      cleanedBody: "/send_status hello",
+      command: {
+        isAuthorizedSender: true,
+        senderId: "sender-1",
+        senderIsOwner: true,
+        abortKey: "sender-1",
+        rawBodyNormalized: "/send_status hello",
+        commandBodyNormalized: "/send_status hello",
+      },
+      overrides: {
+        cfg: { commands: { text: true }, tools: { deny: ["message"] } },
+        allowTextCommands: true,
+        skillCommands,
+      },
+    });
 
     expect(result).toEqual({
       kind: "reply",
@@ -1295,26 +1261,24 @@ describe("handleInlineActions", () => {
       },
     ];
 
-    const result = await handleInlineActions(
-      createHandleInlineActionsInput({
-        ctx,
-        typing,
-        cleanedBody: "/send_status hello",
-        command: {
-          isAuthorizedSender: true,
-          senderId: "sender-1",
-          senderIsOwner: true,
-          abortKey: "sender-1",
-          rawBodyNormalized: "/send_status hello",
-          commandBodyNormalized: "/send_status hello",
-        },
-        overrides: {
-          cfg: { commands: { text: true }, tools: { allow: ["sessions_list"] } },
-          allowTextCommands: true,
-          skillCommands,
-        },
-      }),
-    );
+    const result = await runTestInlineActions({
+      ctx,
+      typing,
+      cleanedBody: "/send_status hello",
+      command: {
+        isAuthorizedSender: true,
+        senderId: "sender-1",
+        senderIsOwner: true,
+        abortKey: "sender-1",
+        rawBodyNormalized: "/send_status hello",
+        commandBodyNormalized: "/send_status hello",
+      },
+      overrides: {
+        cfg: { commands: { text: true }, tools: { allow: ["sessions_list"] } },
+        allowTextCommands: true,
+        skillCommands,
+      },
+    });
 
     expect(result).toEqual({
       kind: "reply",
@@ -1352,29 +1316,27 @@ describe("handleInlineActions", () => {
       },
     ];
 
-    const result = await handleInlineActions(
-      createHandleInlineActionsInput({
-        ctx,
-        typing,
-        cleanedBody: "/send_status hello",
-        command: {
-          isAuthorizedSender: true,
-          senderId: "sender-1",
-          senderIsOwner: true,
-          abortKey: "sender-1",
-          rawBodyNormalized: "/send_status hello",
-          commandBodyNormalized: "/send_status hello",
+    const result = await runTestInlineActions({
+      ctx,
+      typing,
+      cleanedBody: "/send_status hello",
+      command: {
+        isAuthorizedSender: true,
+        senderId: "sender-1",
+        senderIsOwner: true,
+        abortKey: "sender-1",
+        rawBodyNormalized: "/send_status hello",
+        commandBodyNormalized: "/send_status hello",
+      },
+      overrides: {
+        cfg: {
+          commands: { text: true },
+          tools: { toolsBySender: { "id:sender-1": { deny: ["message"] } } },
         },
-        overrides: {
-          cfg: {
-            commands: { text: true },
-            tools: { toolsBySender: { "id:sender-1": { deny: ["message"] } } },
-          },
-          allowTextCommands: true,
-          skillCommands,
-        },
-      }),
-    );
+        allowTextCommands: true,
+        skillCommands,
+      },
+    });
 
     expect(result).toEqual({
       kind: "reply",
@@ -1411,26 +1373,24 @@ describe("handleInlineActions", () => {
       },
     ];
 
-    const result = await handleInlineActions(
-      createHandleInlineActionsInput({
-        ctx,
-        typing,
-        cleanedBody: "/send_conversation hello",
-        command: {
-          isAuthorizedSender: true,
-          senderId: "allowed-user",
-          senderIsOwner: false,
-          abortKey: "allowed-user",
-          rawBodyNormalized: "/send_conversation hello",
-          commandBodyNormalized: "/send_conversation hello",
-        },
-        overrides: {
-          cfg: { commands: { text: true } },
-          allowTextCommands: true,
-          skillCommands,
-        },
-      }),
-    );
+    const result = await runTestInlineActions({
+      ctx,
+      typing,
+      cleanedBody: "/send_conversation hello",
+      command: {
+        isAuthorizedSender: true,
+        senderId: "allowed-user",
+        senderIsOwner: false,
+        abortKey: "allowed-user",
+        rawBodyNormalized: "/send_conversation hello",
+        commandBodyNormalized: "/send_conversation hello",
+      },
+      overrides: {
+        cfg: { commands: { text: true } },
+        allowTextCommands: true,
+        skillCommands,
+      },
+    });
 
     expect(result).toEqual({
       kind: "reply",
@@ -1483,31 +1443,29 @@ describe("handleInlineActions", () => {
         },
       ];
 
-      const result = await handleInlineActions(
-        createHandleInlineActionsInput({
-          ctx,
-          typing,
-          cleanedBody: "/spawn_subagent investigate",
-          command: {
-            isAuthorizedSender: true,
-            senderId: "sender-1",
-            senderIsOwner: true,
-            abortKey: "sender-1",
-            rawBodyNormalized: "/spawn_subagent investigate",
-            commandBodyNormalized: "/spawn_subagent investigate",
+      const result = await runTestInlineActions({
+        ctx,
+        typing,
+        cleanedBody: "/spawn_subagent investigate",
+        command: {
+          isAuthorizedSender: true,
+          senderId: "sender-1",
+          senderIsOwner: true,
+          abortKey: "sender-1",
+          rawBodyNormalized: "/spawn_subagent investigate",
+          commandBodyNormalized: "/spawn_subagent investigate",
+        },
+        overrides: {
+          cfg: {
+            commands: { text: true },
+            session: { store: storeTemplate },
+            agents: { defaults: { subagents: { maxSpawnDepth: 2 } } },
           },
-          overrides: {
-            cfg: {
-              commands: { text: true },
-              session: { store: storeTemplate },
-              agents: { defaults: { subagents: { maxSpawnDepth: 2 } } },
-            },
-            sessionKey: "agent:main:acp:leaf",
-            allowTextCommands: true,
-            skillCommands,
-          },
-        }),
-      );
+          sessionKey: "agent:main:acp:leaf",
+          allowTextCommands: true,
+          skillCommands,
+        },
+      });
 
       expect(result).toEqual({
         kind: "reply",
@@ -1547,30 +1505,28 @@ describe("handleInlineActions", () => {
       },
     ];
 
-    const result = await handleInlineActions(
-      createHandleInlineActionsInput({
-        ctx,
-        typing,
-        cleanedBody: "/list_sessions now",
-        command: {
-          isAuthorizedSender: true,
-          senderId: "sender-1",
-          senderIsOwner: true,
-          abortKey: "sender-1",
-          rawBodyNormalized: "/list_sessions now",
-          commandBodyNormalized: "/list_sessions now",
+    const result = await runTestInlineActions({
+      ctx,
+      typing,
+      cleanedBody: "/list_sessions now",
+      command: {
+        isAuthorizedSender: true,
+        senderId: "sender-1",
+        senderIsOwner: true,
+        abortKey: "sender-1",
+        rawBodyNormalized: "/list_sessions now",
+        commandBodyNormalized: "/list_sessions now",
+      },
+      overrides: {
+        cfg: {
+          commands: { text: true },
+          agents: { defaults: { sandbox: { mode: "all" } } },
         },
-        overrides: {
-          cfg: {
-            commands: { text: true },
-            agents: { defaults: { sandbox: { mode: "all" } } },
-          },
-          sessionKey: "agent:main:thread",
-          allowTextCommands: true,
-          skillCommands,
-        },
-      }),
-    );
+        sessionKey: "agent:main:thread",
+        allowTextCommands: true,
+        skillCommands,
+      },
+    });
 
     expect(result).toEqual({ kind: "reply", reply: { text: "listed" } });
     expect(createOpenClawToolsMock).toHaveBeenCalledWith(
@@ -1593,25 +1549,23 @@ describe("handleInlineActions", () => {
       CommandBody: "/compact",
     });
 
-    const result = await handleInlineActions(
-      createHandleInlineActionsInput({
-        ctx,
-        typing,
-        cleanedBody: "/compact",
-        command: {
-          isAuthorizedSender: true,
-          senderId: "sender-1",
-          senderIsOwner: true,
-          abortKey: "sender-1",
-          rawBodyNormalized: "/compact",
-          commandBodyNormalized: "/compact",
-        },
-        overrides: {
-          cfg: { commands: { text: true } },
-          allowTextCommands: true,
-        },
-      }),
-    );
+    const result = await runTestInlineActions({
+      ctx,
+      typing,
+      cleanedBody: "/compact",
+      command: {
+        isAuthorizedSender: true,
+        senderId: "sender-1",
+        senderIsOwner: true,
+        abortKey: "sender-1",
+        rawBodyNormalized: "/compact",
+        commandBodyNormalized: "/compact",
+      },
+      overrides: {
+        cfg: { commands: { text: true } },
+        allowTextCommands: true,
+      },
+    });
 
     expect(result.kind).toBe("reply");
     if (result.kind !== "reply") {

--- a/src/auto-reply/reply/get-reply-native-slash-fast-path.test.ts
+++ b/src/auto-reply/reply/get-reply-native-slash-fast-path.test.ts
@@ -47,6 +47,34 @@ const createTypingController = (): TypingController => ({
   cleanup: vi.fn(),
 });
 
+type NativeSlashFastReplyParams = Parameters<typeof maybeResolveNativeSlashCommandFastReply>[0];
+type NativeSlashFastReplyDefaultKey =
+  | "agentDir"
+  | "agentCfg"
+  | "defaultProvider"
+  | "defaultModel"
+  | "aliasIndex"
+  | "provider"
+  | "model"
+  | "workspaceDir";
+
+function runTestNativeSlashFastReply(
+  overrides: Omit<NativeSlashFastReplyParams, NativeSlashFastReplyDefaultKey> &
+    Partial<Pick<NativeSlashFastReplyParams, NativeSlashFastReplyDefaultKey>>,
+) {
+  return maybeResolveNativeSlashCommandFastReply({
+    agentDir: "/tmp/agent",
+    agentCfg: undefined,
+    defaultProvider: "openai",
+    defaultModel: "gpt-5.5",
+    aliasIndex: { byKey: new Map(), byAlias: new Map() },
+    provider: "openai",
+    model: "gpt-5.5",
+    workspaceDir: "/tmp/workspace",
+    ...overrides,
+  });
+}
+
 describe("maybeResolveNativeSlashCommandFastReply", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
@@ -83,7 +111,7 @@ describe("maybeResolveNativeSlashCommandFastReply", () => {
     handleCommandsMock.mockResolvedValue(response);
     const commandName = body.slice(1).split(/\s+/, 1)[0] ?? "";
     const typing = createTypingController();
-    const result = await maybeResolveNativeSlashCommandFastReply({
+    const result = await runTestNativeSlashFastReply({
       ctx: buildTestCtx({
         Body: body,
         BodyForAgent: body,
@@ -113,15 +141,8 @@ describe("maybeResolveNativeSlashCommandFastReply", () => {
           } as OpenClawConfig),
       ),
       agentId: "main",
-      agentDir: "/tmp/agent",
       agentCfg: config?.agents?.defaults,
       commandAuthorized: true,
-      defaultProvider: "openai",
-      defaultModel: "gpt-5.5",
-      aliasIndex: { byKey: new Map(), byAlias: new Map() },
-      provider: "openai",
-      model: "gpt-5.5",
-      workspaceDir: "/tmp/workspace",
       typing,
     });
 
@@ -261,7 +282,7 @@ describe("maybeResolveNativeSlashCommandFastReply", () => {
       );
 
       const typing = createTypingController();
-      const result = await maybeResolveNativeSlashCommandFastReply({
+      const result = await runTestNativeSlashFastReply({
         ctx: buildTestCtx({
           Body: "/compact",
           CommandBody: "/compact",
@@ -296,15 +317,8 @@ describe("maybeResolveNativeSlashCommandFastReply", () => {
           { runtimeMode: "full" },
         ),
         agentId: "main",
-        agentDir: "/tmp/agent",
         agentCfg: configuredCap !== undefined ? { contextTokens: configuredCap } : undefined,
         commandAuthorized: true,
-        defaultProvider: "openai",
-        defaultModel: "gpt-5.5",
-        aliasIndex: { byKey: new Map(), byAlias: new Map() },
-        provider: "openai",
-        model: "gpt-5.5",
-        workspaceDir: "/tmp/workspace",
         typing,
       });
 
@@ -460,7 +474,7 @@ describe("maybeResolveNativeSlashCommandFastReply", () => {
         },
       );
 
-      const result = await maybeResolveNativeSlashCommandFastReply({
+      const result = await runTestNativeSlashFastReply({
         ctx: buildTestCtx({
           Body: "/compact",
           CommandBody: "/compact",
@@ -522,11 +536,7 @@ describe("maybeResolveNativeSlashCommandFastReply", () => {
           { runtimeMode: "full" },
         ),
         agentId: targetAgentId,
-        agentDir: "/tmp/agent",
-        agentCfg: undefined,
         commandAuthorized: transportAuthorized,
-        defaultProvider: "openai",
-        defaultModel: "gpt-5.5",
         aliasIndex: {
           byKey: new Map(),
           byAlias: new Map(
@@ -543,9 +553,6 @@ describe("maybeResolveNativeSlashCommandFastReply", () => {
               : [],
           ),
         },
-        provider: "openai",
-        model: "gpt-5.5",
-        workspaceDir: "/tmp/workspace",
         typing: createTypingController(),
       });
 
@@ -603,7 +610,7 @@ describe("maybeResolveNativeSlashCommandFastReply", () => {
       },
     );
 
-    const result = await maybeResolveNativeSlashCommandFastReply({
+    const result = await runTestNativeSlashFastReply({
       ctx: buildTestCtx({
         Body: "/status",
         CommandBody: "/status",
@@ -630,15 +637,7 @@ describe("maybeResolveNativeSlashCommandFastReply", () => {
         channels: { modelByChannel: { telegram: { "123": "openai/gpt-5.5" } } },
       } as OpenClawConfig),
       agentId: "main",
-      agentDir: "/tmp/agent",
-      agentCfg: undefined,
       commandAuthorized: true,
-      defaultProvider: "openai",
-      defaultModel: "gpt-5.5",
-      aliasIndex: { byKey: new Map(), byAlias: new Map() },
-      provider: "openai",
-      model: "gpt-5.5",
-      workspaceDir: "/tmp/workspace",
       typing: createTypingController(),
     });
 
@@ -718,7 +717,7 @@ describe("maybeResolveNativeSlashCommandFastReply", () => {
       },
     });
 
-    const result = await maybeResolveNativeSlashCommandFastReply({
+    const result = await runTestNativeSlashFastReply({
       ctx,
       cfg: markCompleteReplyConfig({
         session: {
@@ -726,15 +725,7 @@ describe("maybeResolveNativeSlashCommandFastReply", () => {
         },
       } as OpenClawConfig),
       agentId: "dev",
-      agentDir: "/tmp/agent",
-      agentCfg: undefined,
       commandAuthorized: true,
-      defaultProvider: "openai",
-      defaultModel: "gpt-5.5",
-      aliasIndex: { byKey: new Map(), byAlias: new Map() },
-      provider: "openai",
-      model: "gpt-5.5",
-      workspaceDir: "/tmp/workspace",
       typing,
     });
 
@@ -773,7 +764,7 @@ describe("maybeResolveNativeSlashCommandFastReply", () => {
       },
     });
 
-    const result = await maybeResolveNativeSlashCommandFastReply({
+    const result = await runTestNativeSlashFastReply({
       ctx,
       cfg: markCompleteReplyConfig({
         session: {
@@ -781,15 +772,7 @@ describe("maybeResolveNativeSlashCommandFastReply", () => {
         },
       } as OpenClawConfig),
       agentId: "dev",
-      agentDir: "/tmp/agent",
-      agentCfg: undefined,
       commandAuthorized: true,
-      defaultProvider: "openai",
-      defaultModel: "gpt-5.5",
-      aliasIndex: { byKey: new Map(), byAlias: new Map() },
-      provider: "openai",
-      model: "gpt-5.5",
-      workspaceDir: "/tmp/workspace",
       typing,
     });
 
@@ -814,7 +797,7 @@ describe("maybeResolveNativeSlashCommandFastReply", () => {
       reply: { text: "You are not authorized to use this command." },
     });
 
-    const result = await maybeResolveNativeSlashCommandFastReply({
+    const result = await runTestNativeSlashFastReply({
       ctx: buildTestCtx({
         Body: `/${commandName}`,
         CommandBody: `/${commandName}`,
@@ -840,15 +823,7 @@ describe("maybeResolveNativeSlashCommandFastReply", () => {
           : {}),
       } as OpenClawConfig),
       agentId: "main",
-      agentDir: "/tmp/agent",
-      agentCfg: undefined,
       commandAuthorized: authorized,
-      defaultProvider: "openai",
-      defaultModel: "gpt-5.5",
-      aliasIndex: { byKey: new Map(), byAlias: new Map() },
-      provider: "openai",
-      model: "gpt-5.5",
-      workspaceDir: "/tmp/workspace",
       typing: createTypingController(),
     });
 
@@ -907,7 +882,7 @@ describe("maybeResolveNativeSlashCommandFastReply", () => {
       return { shouldContinue: false, reply: { text: "ok" } };
     });
 
-    const result = await maybeResolveNativeSlashCommandFastReply({
+    const result = await runTestNativeSlashFastReply({
       ctx: buildTestCtx({
         Body: "/compact",
         CommandBody: "/compact",
@@ -924,15 +899,7 @@ describe("maybeResolveNativeSlashCommandFastReply", () => {
       }),
       cfg: markCompleteReplyConfig({ session: { store: storePath } } as OpenClawConfig),
       agentId: "main",
-      agentDir: "/tmp/agent",
-      agentCfg: undefined,
       commandAuthorized: true,
-      defaultProvider: "openai",
-      defaultModel: "gpt-5.5",
-      aliasIndex: { byKey: new Map(), byAlias: new Map() },
-      provider: "openai",
-      model: "gpt-5.5",
-      workspaceDir: "/tmp/workspace",
       typing: createTypingController(),
     });
 
@@ -956,7 +923,7 @@ describe("maybeResolveNativeSlashCommandFastReply", () => {
     await replaceSessionEntry({ sessionKey, storePath }, archivedEntry as SessionEntry);
     const persistedArchivedEntry = loadExactSessionEntry({ sessionKey, storePath })?.entry;
 
-    const result = await maybeResolveNativeSlashCommandFastReply({
+    const result = await runTestNativeSlashFastReply({
       ctx: buildTestCtx({
         Body: "/compact",
         CommandBody: "/compact",
@@ -974,15 +941,7 @@ describe("maybeResolveNativeSlashCommandFastReply", () => {
       }),
       cfg: markCompleteReplyConfig({ session: { store: storePath } } as OpenClawConfig),
       agentId: "main",
-      agentDir: "/tmp/agent",
-      agentCfg: undefined,
       commandAuthorized: true,
-      defaultProvider: "openai",
-      defaultModel: "gpt-5.5",
-      aliasIndex: { byKey: new Map(), byAlias: new Map() },
-      provider: "openai",
-      model: "gpt-5.5",
-      workspaceDir: "/tmp/workspace",
       typing: createTypingController(),
     });
 
@@ -1017,7 +976,7 @@ describe("maybeResolveNativeSlashCommandFastReply", () => {
     const nowSpy = vi.spyOn(Date, "now").mockReturnValue(100);
 
     try {
-      await maybeResolveNativeSlashCommandFastReply({
+      await runTestNativeSlashFastReply({
         ctx: buildTestCtx({
           Body: "/compact",
           CommandBody: "/compact",
@@ -1035,15 +994,7 @@ describe("maybeResolveNativeSlashCommandFastReply", () => {
         }),
         cfg: markCompleteReplyConfig({ session: { store: storePath } } as OpenClawConfig),
         agentId: "main",
-        agentDir: "/tmp/agent",
-        agentCfg: undefined,
         commandAuthorized: true,
-        defaultProvider: "openai",
-        defaultModel: "gpt-5.5",
-        aliasIndex: { byKey: new Map(), byAlias: new Map() },
-        provider: "openai",
-        model: "gpt-5.5",
-        workspaceDir: "/tmp/workspace",
         typing: createTypingController(),
       });
     } finally {

--- a/src/auto-reply/reply/reply-media-paths.test.ts
+++ b/src/auto-reply/reply/reply-media-paths.test.ts
@@ -75,6 +75,20 @@ function expectAgentScopedMediaAccessCall(): Record<string, unknown> {
   return requireRecord(call[0], "agent scoped media access request");
 }
 
+function createTestReplyMediaNormalizer(
+  overrides: Omit<
+    Parameters<typeof createReplyMediaPathNormalizer>[0],
+    "cfg" | "sessionKey" | "workspaceDir"
+  > = {},
+) {
+  return createReplyMediaPathNormalizer({
+    cfg: {},
+    sessionKey: "session-key",
+    workspaceDir: "/tmp/agent-workspace",
+    ...overrides,
+  });
+}
+
 describe("createReplyMediaPathNormalizer", () => {
   beforeEach(() => {
     ensureSandboxWorkspaceForSession.mockReset().mockResolvedValue(null);
@@ -95,11 +109,7 @@ describe("createReplyMediaPathNormalizer", () => {
   });
 
   it("stages workspace-relative media through shared outbound attachment loading", async () => {
-    const normalize = createReplyMediaPathNormalizer({
-      cfg: {},
-      sessionKey: "session-key",
-      workspaceDir: "/tmp/agent-workspace",
-    });
+    const normalize = createTestReplyMediaNormalizer();
 
     const result = await normalize({
       mediaUrls: ["./out/photo.png"],
@@ -116,11 +126,7 @@ describe("createReplyMediaPathNormalizer", () => {
   });
 
   it("preserves reply metadata when media normalization clones the payload", async () => {
-    const normalize = createReplyMediaPathNormalizer({
-      cfg: {},
-      sessionKey: "session-key",
-      workspaceDir: "/tmp/agent-workspace",
-    });
+    const normalize = createTestReplyMediaNormalizer();
     const payload = setReplyPayloadMetadata(
       {
         text: "Here is the image",
@@ -153,11 +159,7 @@ describe("createReplyMediaPathNormalizer", () => {
       workspaceDir: "/tmp/sandboxes/session-1",
       containerWorkdir: "/workspace",
     });
-    const normalize = createReplyMediaPathNormalizer({
-      cfg: {},
-      sessionKey: "session-key",
-      workspaceDir: "/tmp/agent-workspace",
-    });
+    const normalize = createTestReplyMediaNormalizer();
 
     const result = await normalize({
       mediaUrls: ["./out/photo.png", "file:///workspace/screens/final.png"],
@@ -185,11 +187,7 @@ describe("createReplyMediaPathNormalizer", () => {
       containerWorkdir: "/workspace",
     });
     resolveOutboundAttachmentFromUrl.mockRejectedValueOnce(new Error("media too large"));
-    const normalize = createReplyMediaPathNormalizer({
-      cfg: {},
-      sessionKey: "session-key",
-      workspaceDir: "/tmp/agent-workspace",
-    });
+    const normalize = createTestReplyMediaNormalizer();
 
     const result = await normalize({
       mediaUrls: ["./out/photo.png"],
@@ -206,11 +204,7 @@ describe("createReplyMediaPathNormalizer", () => {
   });
 
   it("drops host file URLs when no sandbox mapping applies", async () => {
-    const normalize = createReplyMediaPathNormalizer({
-      cfg: {},
-      sessionKey: "session-key",
-      workspaceDir: "/tmp/agent-workspace",
-    });
+    const normalize = createTestReplyMediaNormalizer();
 
     const result = await normalize({
       mediaUrls: ["file:///Users/peter/Documents/report.pdf"],
@@ -225,11 +219,7 @@ describe("createReplyMediaPathNormalizer", () => {
       workspaceDir: "/tmp/sandboxes/session-1",
       containerWorkdir: "/workspace",
     });
-    const normalize = createReplyMediaPathNormalizer({
-      cfg: {},
-      sessionKey: "session-key",
-      workspaceDir: "/tmp/agent-workspace",
-    });
+    const normalize = createTestReplyMediaNormalizer();
 
     const result = await normalize({
       mediaUrls: ["file:///Users/peter/Documents/report.pdf"],
@@ -326,11 +316,7 @@ describe("createReplyMediaPathNormalizer", () => {
   });
 
   it("drops workspace-relative media paths that escape the agent workspace", async () => {
-    const normalize = createReplyMediaPathNormalizer({
-      cfg: {},
-      sessionKey: "session-key",
-      workspaceDir: "/tmp/agent-workspace",
-    });
+    const normalize = createTestReplyMediaNormalizer();
 
     const result = await normalize({
       mediaUrls: ["../../etc/passwd"],
@@ -345,11 +331,7 @@ describe("createReplyMediaPathNormalizer", () => {
       workspaceDir: "/tmp/sandboxes/session-1",
       containerWorkdir: "/workspace",
     });
-    const normalize = createReplyMediaPathNormalizer({
-      cfg: {},
-      sessionKey: "session-key",
-      workspaceDir: "/tmp/agent-workspace",
-    });
+    const normalize = createTestReplyMediaNormalizer();
 
     const result = await normalize({
       mediaUrls: ["../../etc/passwd"],
@@ -361,11 +343,7 @@ describe("createReplyMediaPathNormalizer", () => {
 
   it("keeps managed generated media under the shared media root", async () => {
     setTestEnvValue("OPENCLAW_STATE_DIR", "/Users/peter/.openclaw");
-    const normalize = createReplyMediaPathNormalizer({
-      cfg: {},
-      sessionKey: "session-key",
-      workspaceDir: "/tmp/agent-workspace",
-    });
+    const normalize = createTestReplyMediaNormalizer();
 
     const result = await normalize({
       mediaUrls: ["/Users/peter/.openclaw/media/tool-image-generation/generated.png"],
@@ -383,11 +361,7 @@ describe("createReplyMediaPathNormalizer", () => {
       containerWorkdir: "/workspace",
     });
     setTestEnvValue("OPENCLAW_STATE_DIR", "/Users/peter/.openclaw");
-    const normalize = createReplyMediaPathNormalizer({
-      cfg: {},
-      sessionKey: "session-key",
-      workspaceDir: "/tmp/agent-workspace",
-    });
+    const normalize = createTestReplyMediaNormalizer();
 
     const result = await normalize({
       mediaUrls: ["/Users/peter/.openclaw/media/outbound/generated.png"],
@@ -412,11 +386,7 @@ describe("createReplyMediaPathNormalizer", () => {
       await fs.writeFile(outsideFile, "secret", "utf8");
       await fs.symlink(outsideFile, symlinkPath);
       setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);
-      const normalize = createReplyMediaPathNormalizer({
-        cfg: {},
-        sessionKey: "session-key",
-        workspaceDir: "/tmp/agent-workspace",
-      });
+      const normalize = createTestReplyMediaNormalizer();
 
       const result = await normalize({
         mediaUrls: [symlinkPath],
@@ -435,11 +405,7 @@ describe("createReplyMediaPathNormalizer", () => {
     resolveOutboundAttachmentFromUrl.mockRejectedValueOnce(
       new Error("Local media path is not under an allowed directory"),
     );
-    const normalize = createReplyMediaPathNormalizer({
-      cfg: {},
-      sessionKey: "session-key",
-      workspaceDir: "/tmp/agent-workspace",
-    });
+    const normalize = createTestReplyMediaNormalizer();
 
     const result = await normalize({
       mediaUrls: ["/Users/peter/secrets/photo.png"],
@@ -450,11 +416,7 @@ describe("createReplyMediaPathNormalizer", () => {
 
   it("keeps reply text and appends a warning when all reply media is dropped", async () => {
     resolveOutboundAttachmentFromUrl.mockRejectedValueOnce(new Error("file not found"));
-    const normalize = createReplyMediaPathNormalizer({
-      cfg: {},
-      sessionKey: "session-key",
-      workspaceDir: "/tmp/agent-workspace",
-    });
+    const normalize = createTestReplyMediaNormalizer();
 
     const result = await normalize({
       text: "WA_MEDIA_DM_07",
@@ -467,11 +429,7 @@ describe("createReplyMediaPathNormalizer", () => {
 
   it("keeps surviving media and appends a warning when some reply media is dropped", async () => {
     resolveOutboundAttachmentFromUrl.mockRejectedValueOnce(new Error("file not found"));
-    const normalize = createReplyMediaPathNormalizer({
-      cfg: {},
-      sessionKey: "session-key",
-      workspaceDir: "/tmp/agent-workspace",
-    });
+    const normalize = createTestReplyMediaNormalizer();
 
     const result = await normalize({
       text: "Here is the surviving attachment",
@@ -484,11 +442,7 @@ describe("createReplyMediaPathNormalizer", () => {
 
   it("returns a warning-only text reply when media-only output is dropped upstream", async () => {
     resolveOutboundAttachmentFromUrl.mockRejectedValueOnce(new Error("file not found"));
-    const normalize = createReplyMediaPathNormalizer({
-      cfg: {},
-      sessionKey: "session-key",
-      workspaceDir: "/tmp/agent-workspace",
-    });
+    const normalize = createTestReplyMediaNormalizer();
 
     const result = await normalize({
       mediaUrls: ["./out/missing.png"],

--- a/src/auto-reply/reply/reply-run-registry.test.ts
+++ b/src/auto-reply/reply/reply-run-registry.test.ts
@@ -80,6 +80,16 @@ async function queueReplyMessageInjectionTarget(
   return await beginReplyMessageInjectionTarget(...args).outcome;
 }
 
+async function withFakeReplyTimers<T>(run: () => Promise<T>): Promise<T> {
+  vi.useFakeTimers();
+  try {
+    return await run();
+  } finally {
+    await vi.runOnlyPendingTimersAsync();
+    vi.useRealTimers();
+  }
+}
+
 describe("reply run registry", () => {
   afterEach(() => {
     testing.resetReplyRunRegistry();
@@ -89,8 +99,7 @@ describe("reply run registry", () => {
   });
 
   it("keeps ownership stable by sessionKey while sessionId rotates", async () => {
-    vi.useFakeTimers();
-    try {
+    await withFakeReplyTimers(async () => {
       const operation = createTestReplyOperation({
         sessionId: "session-old",
       });
@@ -114,10 +123,7 @@ describe("reply run registry", () => {
       operation.complete();
 
       await expect(oldWaitPromise).resolves.toBe(true);
-    } finally {
-      await vi.runOnlyPendingTimersAsync();
-      vi.useRealTimers();
-    }
+    });
   });
 
   it("treats queued reply operations as non-abortable for compaction", () => {
@@ -659,8 +665,7 @@ describe("reply run registry", () => {
   });
 
   it("bounds retained ownership when stale cancellation awaits terminal completion", async () => {
-    vi.useFakeTimers();
-    try {
+    await withFakeReplyTimers(async () => {
       const operation = createTestReplyOperation({ sessionId: "session-cancel-pending-bound" });
       operation.setPhase("running");
       operation.attachBackend({
@@ -679,15 +684,11 @@ describe("reply run registry", () => {
       await vi.advanceTimersByTimeAsync(1);
       expect(replyRunRegistry.get("agent:main:main")).toBeUndefined();
       expect(afterClear).toHaveBeenCalledWith("session-cancel-pending-bound");
-    } finally {
-      await vi.runOnlyPendingTimersAsync();
-      vi.useRealTimers();
-    }
+    });
   });
 
   it("bounds retained ownership when stale cancellation throws undefined", async () => {
-    vi.useFakeTimers();
-    try {
+    await withFakeReplyTimers(async () => {
       const operation = createTestReplyOperation({ sessionId: "session-undefined-cancel" });
       operation.setPhase("running");
       operation.attachBackend({
@@ -710,10 +711,7 @@ describe("reply run registry", () => {
       await vi.advanceTimersByTimeAsync(1);
       expect(replyRunRegistry.get("agent:main:main")).toBeUndefined();
       expect(afterClear).toHaveBeenCalledWith("session-undefined-cancel");
-    } finally {
-      await vi.runOnlyPendingTimersAsync();
-      vi.useRealTimers();
-    }
+    });
   });
 
   it("keeps a reentrant completion fenced when cancel then throws", async () => {
@@ -814,8 +812,7 @@ describe("reply run registry", () => {
   });
 
   it("keeps follow-up admission blocked until slow delivery settles", async () => {
-    vi.useFakeTimers();
-    try {
+    await withFakeReplyTimers(async () => {
       const operation = createTestReplyOperation({
         sessionId: "hung-session",
       });
@@ -848,15 +845,11 @@ describe("reply run registry", () => {
         respectFollowupAdmissionBarrier: true,
       });
       next.complete();
-    } finally {
-      await vi.runOnlyPendingTimersAsync();
-      vi.useRealTimers();
-    }
+    });
   });
 
   it("fences every durable alias until successor handoff settles", async () => {
-    vi.useFakeTimers();
-    try {
+    await withFakeReplyTimers(async () => {
       const requestKey = "agent:main:telegram:alias:request";
       const canonicalKey = "agent:main:telegram:alias:canonical";
       const adoptedKey = "agent:main:telegram:alias:adopted";
@@ -915,10 +908,7 @@ describe("reply run registry", () => {
       });
       const successor = createTestReplyOperation({ sessionKey: canonicalKey });
       successor.complete();
-    } finally {
-      await vi.runOnlyPendingTimersAsync();
-      vi.useRealTimers();
-    }
+    });
   });
 
   it("stops a successor wait when its signal aborts", async () => {
@@ -941,8 +931,7 @@ describe("reply run registry", () => {
   });
 
   it("extends a hung delivery barrier only while bounded owner work remains active", async () => {
-    vi.useFakeTimers();
-    try {
+    await withFakeReplyTimers(async () => {
       const operation = createTestReplyOperation({
         sessionId: "active-owner-session",
       });
@@ -962,15 +951,11 @@ describe("reply run registry", () => {
       await vi.waitFor(() => {
         expect(afterClear).toHaveBeenCalledWith("active-owner-session");
       });
-    } finally {
-      await vi.runOnlyPendingTimersAsync();
-      vi.useRealTimers();
-    }
+    });
   });
 
   it("keeps follow-up admission blocked during an unsettled inter-block delay", async () => {
-    vi.useFakeTimers();
-    try {
+    await withFakeReplyTimers(async () => {
       const operation = createTestReplyOperation({
         sessionKey: "agent:main:mattermost:direct:user-1",
         sessionId: "mattermost-delivery-session",
@@ -1007,15 +992,11 @@ describe("reply run registry", () => {
         respectFollowupAdmissionBarrier: true,
       });
       followup.complete();
-    } finally {
-      await vi.runOnlyPendingTimersAsync();
-      vi.useRealTimers();
-    }
+    });
   });
 
   it("eventually releases a permanently hung delivery barrier at the default timeout", async () => {
-    vi.useFakeTimers();
-    try {
+    await withFakeReplyTimers(async () => {
       const operation = createTestReplyOperation({
         sessionId: "hung-session",
       });
@@ -1035,10 +1016,7 @@ describe("reply run registry", () => {
         respectFollowupAdmissionBarrier: true,
       });
       next.complete();
-    } finally {
-      await vi.runOnlyPendingTimersAsync();
-      vi.useRealTimers();
-    }
+    });
   });
 
   it("retains failed operations until final delivery completes", () => {
@@ -1178,8 +1156,7 @@ describe("reply run registry", () => {
   });
 
   it("force-releases a running aborted operation when the owner never returns", async () => {
-    vi.useFakeTimers();
-    try {
+    await withFakeReplyTimers(async () => {
       const cancel = vi.fn();
       const operation = createTestReplyOperation({
         sessionKey: "agent:main:hung-abort",
@@ -1216,15 +1193,11 @@ describe("reply run registry", () => {
       if (next.status === "owned") {
         next.operation.complete();
       }
-    } finally {
-      await vi.runOnlyPendingTimersAsync();
-      vi.useRealTimers();
-    }
+    });
   });
 
   it("keeps late owner complete harmless after forced terminal release", async () => {
-    vi.useFakeTimers();
-    try {
+    await withFakeReplyTimers(async () => {
       const operation = createTestReplyOperation({
         sessionKey: "agent:main:late-complete",
         sessionId: "session-late-complete",
@@ -1239,15 +1212,11 @@ describe("reply run registry", () => {
 
       expect(replyRunRegistry.isActive("agent:main:late-complete")).toBe(false);
       expect(afterClear).toHaveBeenCalledTimes(1);
-    } finally {
-      await vi.runOnlyPendingTimersAsync();
-      vi.useRealTimers();
-    }
+    });
   });
 
   it("force-releases retained failures when the owner never completes", async () => {
-    vi.useFakeTimers();
-    try {
+    await withFakeReplyTimers(async () => {
       const operation = createTestReplyOperation({
         sessionKey: "agent:main:retained-hung-failure",
         sessionId: "session-retained-hung-failure",
@@ -1262,10 +1231,7 @@ describe("reply run registry", () => {
       expect(replyRunRegistry.get("agent:main:retained-hung-failure")).toBeUndefined();
       expect(afterClear).toHaveBeenCalledTimes(1);
       expect(operation.result).toMatchObject({ kind: "failed", code: "run_failed" });
-    } finally {
-      await vi.runOnlyPendingTimersAsync();
-      vi.useRealTimers();
-    }
+    });
   });
 
   it("keeps run_stalled attribution and ownership when cancel re-enters abortByUser", () => {
@@ -1292,8 +1258,7 @@ describe("reply run registry", () => {
   });
 
   it("cancels terminal settle when the owner clears state first", async () => {
-    vi.useFakeTimers();
-    try {
+    await withFakeReplyTimers(async () => {
       const warnSpy = vi.spyOn(diagnosticLogger, "warn").mockImplementation(() => undefined);
       const operation = createTestReplyOperation({
         sessionKey: "agent:main:owner-clears",
@@ -1309,10 +1274,7 @@ describe("reply run registry", () => {
       expect(warnSpy).not.toHaveBeenCalledWith(
         expect.stringContaining("reply run terminal settle: forced release"),
       );
-    } finally {
-      await vi.runOnlyPendingTimersAsync();
-      vi.useRealTimers();
-    }
+    });
   });
 
   it("force-clears retained failed operations", () => {
@@ -1337,8 +1299,7 @@ describe("reply run registry", () => {
   });
 
   it("force-clears a running operation after abort without backend cleanup", async () => {
-    vi.useFakeTimers();
-    try {
+    await withFakeReplyTimers(async () => {
       const cancel = vi.fn();
       const operation = createTestReplyOperation({
         sessionId: "session-running",
@@ -1361,10 +1322,7 @@ describe("reply run registry", () => {
 
       expect(isReplyRunActiveForSessionId("session-running")).toBe(false);
       await expect(waitPromise).resolves.toBe(true);
-    } finally {
-      await vi.runOnlyPendingTimersAsync();
-      vi.useRealTimers();
-    }
+    });
   });
 
   it("rejects aborts while the attached backend is finalizing", () => {
@@ -1451,8 +1409,7 @@ describe("reply run registry", () => {
   });
 
   it("expires finalization when its owner stops making progress", async () => {
-    vi.useFakeTimers();
-    try {
+    await withFakeReplyTimers(async () => {
       const afterClear = vi.fn();
       const operation = createTestReplyOperation({
         sessionKey: "agent:main:hung-finalization",
@@ -1475,15 +1432,11 @@ describe("reply run registry", () => {
       expect(operation.phase).toBe("failed");
       expect(operation.abortSignal.aborted).toBe(true);
       expect(afterClear).toHaveBeenCalledTimes(1);
-    } finally {
-      await vi.runOnlyPendingTimersAsync();
-      vi.useRealTimers();
-    }
+    });
   });
 
   it("renews finalization from owner progress", async () => {
-    vi.useFakeTimers();
-    try {
+    await withFakeReplyTimers(async () => {
       const operation = createTestReplyOperation({
         sessionKey: "agent:main:progressing-finalization",
         sessionId: "session-progressing-finalization",
@@ -1502,15 +1455,11 @@ describe("reply run registry", () => {
 
       expect(replyRunRegistry.get("agent:main:progressing-finalization")).toBeUndefined();
       expect(operation.result).toEqual({ kind: "failed", code: "run_stalled" });
-    } finally {
-      await vi.runOnlyPendingTimersAsync();
-      vi.useRealTimers();
-    }
+    });
   });
 
   it("preserves bounded work that starts before finalization", async () => {
-    vi.useFakeTimers();
-    try {
+    await withFakeReplyTimers(async () => {
       const operation = createTestReplyOperation({
         sessionKey: "agent:main:pre-finalization-work",
         sessionId: "session-pre-finalization-work",
@@ -1527,15 +1476,11 @@ describe("reply run registry", () => {
       await vi.advanceTimersByTimeAsync(30_000);
       expect(replyRunRegistry.get("agent:main:pre-finalization-work")).toBeUndefined();
       expect(operation.result).toEqual({ kind: "failed", code: "run_stalled" });
-    } finally {
-      await vi.runOnlyPendingTimersAsync();
-      vi.useRealTimers();
-    }
+    });
   });
 
   it("does not shorten bounded work when ordinary activity renews", async () => {
-    vi.useFakeTimers();
-    try {
+    await withFakeReplyTimers(async () => {
       const operation = createTestReplyOperation({
         sessionKey: "agent:main:overlapping-finalization-work",
         sessionId: "session-overlapping-finalization-work",
@@ -1553,15 +1498,11 @@ describe("reply run registry", () => {
       await vi.advanceTimersByTimeAsync(15_000);
       expect(replyRunRegistry.get("agent:main:overlapping-finalization-work")).toBeUndefined();
       expect(operation.result).toEqual({ kind: "failed", code: "run_stalled" });
-    } finally {
-      await vi.runOnlyPendingTimersAsync();
-      vi.useRealTimers();
-    }
+    });
   });
 
   it("honors a bounded extended finalization lease", async () => {
-    vi.useFakeTimers();
-    try {
+    await withFakeReplyTimers(async () => {
       const operation = createTestReplyOperation({
         sessionKey: "agent:main:extended-finalization",
         sessionId: "session-extended-finalization",
@@ -1576,15 +1517,11 @@ describe("reply run registry", () => {
       await vi.advanceTimersByTimeAsync(REPLY_RUN_FINALIZATION_SETTLE_TIMEOUT_MS);
       expect(replyRunRegistry.get("agent:main:extended-finalization")).toBeUndefined();
       expect(operation.result).toEqual({ kind: "failed", code: "run_stalled" });
-    } finally {
-      await vi.runOnlyPendingTimersAsync();
-      vi.useRealTimers();
-    }
+    });
   });
 
   it("keeps late finalization cleanup from clearing a successor", async () => {
-    vi.useFakeTimers();
-    try {
+    await withFakeReplyTimers(async () => {
       const operation = createTestReplyOperation({
         sessionKey: "agent:main:late-finalization",
         sessionId: "session-late-finalization",
@@ -1601,15 +1538,11 @@ describe("reply run registry", () => {
 
       expect(replyRunRegistry.get("agent:main:late-finalization")).toBe(successor);
       successor.complete();
-    } finally {
-      await vi.runOnlyPendingTimersAsync();
-      vi.useRealTimers();
-    }
+    });
   });
 
   it("clamps oversized wait timers instead of resolving idle waits immediately", async () => {
-    vi.useFakeTimers();
-    try {
+    await withFakeReplyTimers(async () => {
       const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
       const operation = createTestReplyOperation({
         sessionId: "session-running",
@@ -1623,15 +1556,11 @@ describe("reply run registry", () => {
       expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
       operation.complete();
       await expect(waitPromise).resolves.toBe(true);
-    } finally {
-      await vi.runOnlyPendingTimersAsync();
-      vi.useRealTimers();
-    }
+    });
   });
 
   it("waits for reply-run completion without a timer when requested", async () => {
-    vi.useFakeTimers();
-    try {
+    await withFakeReplyTimers(async () => {
       const operation = createTestReplyOperation({
         sessionKey: "agent:main:unbounded",
         sessionId: "session-unbounded",
@@ -1643,10 +1572,7 @@ describe("reply run registry", () => {
       expect(setTimeoutSpy).not.toHaveBeenCalled();
       operation.complete();
       await expect(waitPromise).resolves.toBe(true);
-    } finally {
-      await vi.runOnlyPendingTimersAsync();
-      vi.useRealTimers();
-    }
+    });
   });
 
   it("queues messages only through the active running backend", async () => {

--- a/src/auto-reply/reply/reply-state.test.ts
+++ b/src/auto-reply/reply/reply-state.test.ts
@@ -65,6 +65,10 @@ async function createCompactionSessionFixture(entry: SessionEntry) {
   return { storePath, sessionKey, sessionStore };
 }
 
+function requireStoredSession(stored: Record<string, SessionEntry>, sessionKey: string) {
+  return expectDefined(stored[sessionKey], "stored[sessionKey] test invariant");
+}
+
 describe("history helpers", () => {
   function createHistoryMapWithTwoEntries() {
     const historyMap = new Map<string, { sender: string; body: string }[]>();
@@ -505,9 +509,7 @@ describe("incrementCompactionCount", () => {
     expect(count).toBe(3);
 
     const stored = { [sessionKey]: await loadStoredEntry(storePath, sessionKey) };
-    expect(
-      expectDefined(stored[sessionKey], "stored[sessionKey] test invariant").compactionCount,
-    ).toBe(3);
+    expect(requireStoredSession(stored, sessionKey).compactionCount).toBe(3);
   });
 
   it("persists incognito compaction metadata only in the scoped store", async () => {
@@ -564,19 +566,11 @@ describe("incrementCompactionCount", () => {
     });
 
     const stored = { [sessionKey]: await loadStoredEntry(storePath, sessionKey) };
-    expect(
-      expectDefined(stored[sessionKey], "stored[sessionKey] test invariant").compactionCount,
-    ).toBe(1);
-    expect(expectDefined(stored[sessionKey], "stored[sessionKey] test invariant").totalTokens).toBe(
-      12_000,
-    );
+    expect(requireStoredSession(stored, sessionKey).compactionCount).toBe(1);
+    expect(requireStoredSession(stored, sessionKey).totalTokens).toBe(12_000);
     // input/output cleared since we only have the total estimate
-    expect(
-      expectDefined(stored[sessionKey], "stored[sessionKey] test invariant").inputTokens,
-    ).toBeUndefined();
-    expect(
-      expectDefined(stored[sessionKey], "stored[sessionKey] test invariant").outputTokens,
-    ).toBeUndefined();
+    expect(requireStoredSession(stored, sessionKey).inputTokens).toBeUndefined();
+    expect(requireStoredSession(stored, sessionKey).outputTokens).toBeUndefined();
   });
 
   it("accepts zero tokensAfter as a fresh post-compaction total", async () => {
@@ -600,21 +594,11 @@ describe("incrementCompactionCount", () => {
     });
 
     const stored = { [sessionKey]: await loadStoredEntry(storePath, sessionKey) };
-    expect(
-      expectDefined(stored[sessionKey], "stored[sessionKey] test invariant").compactionCount,
-    ).toBe(1);
-    expect(expectDefined(stored[sessionKey], "stored[sessionKey] test invariant").totalTokens).toBe(
-      0,
-    );
-    expect(
-      expectDefined(stored[sessionKey], "stored[sessionKey] test invariant").totalTokensFresh,
-    ).toBe(true);
-    expect(
-      expectDefined(stored[sessionKey], "stored[sessionKey] test invariant").inputTokens,
-    ).toBeUndefined();
-    expect(
-      expectDefined(stored[sessionKey], "stored[sessionKey] test invariant").outputTokens,
-    ).toBeUndefined();
+    expect(requireStoredSession(stored, sessionKey).compactionCount).toBe(1);
+    expect(requireStoredSession(stored, sessionKey).totalTokens).toBe(0);
+    expect(requireStoredSession(stored, sessionKey).totalTokensFresh).toBe(true);
+    expect(requireStoredSession(stored, sessionKey).inputTokens).toBeUndefined();
+    expect(requireStoredSession(stored, sessionKey).outputTokens).toBeUndefined();
   });
 
   it("prefers explicit compactionTokensAfter over last-call usage for run accounting", async () => {
@@ -641,12 +625,8 @@ describe("incrementCompactionCount", () => {
     });
 
     const stored = { [sessionKey]: await loadStoredEntry(storePath, sessionKey) };
-    expect(expectDefined(stored[sessionKey], "stored[sessionKey] test invariant").totalTokens).toBe(
-      12_000,
-    );
-    expect(
-      expectDefined(stored[sessionKey], "stored[sessionKey] test invariant").totalTokensFresh,
-    ).toBe(true);
+    expect(requireStoredSession(stored, sessionKey).totalTokens).toBe(12_000);
+    expect(requireStoredSession(stored, sessionKey).totalTokensFresh).toBe(true);
   });
 
   it("preserves zero compactionTokensAfter for run accounting", async () => {
@@ -673,12 +653,8 @@ describe("incrementCompactionCount", () => {
     });
 
     const stored = { [sessionKey]: await loadStoredEntry(storePath, sessionKey) };
-    expect(expectDefined(stored[sessionKey], "stored[sessionKey] test invariant").totalTokens).toBe(
-      0,
-    );
-    expect(
-      expectDefined(stored[sessionKey], "stored[sessionKey] test invariant").totalTokensFresh,
-    ).toBe(true);
+    expect(requireStoredSession(stored, sessionKey).totalTokens).toBe(0);
+    expect(requireStoredSession(stored, sessionKey).totalTokensFresh).toBe(true);
   });
 
   it("falls back to last-call usage when run compactionTokensAfter is non-finite", async () => {
@@ -705,12 +681,8 @@ describe("incrementCompactionCount", () => {
     });
 
     const stored = { [sessionKey]: await loadStoredEntry(storePath, sessionKey) };
-    expect(expectDefined(stored[sessionKey], "stored[sessionKey] test invariant").totalTokens).toBe(
-      90_000,
-    );
-    expect(
-      expectDefined(stored[sessionKey], "stored[sessionKey] test invariant").totalTokensFresh,
-    ).toBe(true);
+    expect(requireStoredSession(stored, sessionKey).totalTokens).toBe(90_000);
+    expect(requireStoredSession(stored, sessionKey).totalTokensFresh).toBe(true);
   });
 
   it("ignores non-finite tokensAfter values", async () => {
@@ -732,15 +704,9 @@ describe("incrementCompactionCount", () => {
     });
 
     const stored = { [sessionKey]: await loadStoredEntry(storePath, sessionKey) };
-    expect(
-      expectDefined(stored[sessionKey], "stored[sessionKey] test invariant").compactionCount,
-    ).toBe(1);
-    expect(expectDefined(stored[sessionKey], "stored[sessionKey] test invariant").totalTokens).toBe(
-      180_000,
-    );
-    expect(
-      expectDefined(stored[sessionKey], "stored[sessionKey] test invariant").totalTokensFresh,
-    ).toBe(false);
+    expect(requireStoredSession(stored, sessionKey).compactionCount).toBe(1);
+    expect(requireStoredSession(stored, sessionKey).totalTokens).toBe(180_000);
+    expect(requireStoredSession(stored, sessionKey).totalTokensFresh).toBe(false);
   });
 
   it("increments compaction count by an explicit amount", async () => {
@@ -757,9 +723,7 @@ describe("incrementCompactionCount", () => {
     expect(count).toBe(4);
 
     const stored = { [sessionKey]: await loadStoredEntry(storePath, sessionKey) };
-    expect(
-      expectDefined(stored[sessionKey], "stored[sessionKey] test invariant").compactionCount,
-    ).toBe(4);
+    expect(requireStoredSession(stored, sessionKey).compactionCount).toBe(4);
   });
 
   it("updates sessionId when newSessionId is provided", async () => {
@@ -779,12 +743,8 @@ describe("incrementCompactionCount", () => {
     });
 
     const stored = { [sessionKey]: await loadStoredEntry(storePath, sessionKey) };
-    expect(expectDefined(stored[sessionKey], "stored[sessionKey] test invariant").sessionId).toBe(
-      "new-session-id",
-    );
-    expect(
-      expectDefined(stored[sessionKey], "stored[sessionKey] test invariant").compactionCount,
-    ).toBe(2);
+    expect(requireStoredSession(stored, sessionKey).sessionId).toBe("new-session-id");
+    expect(requireStoredSession(stored, sessionKey).compactionCount).toBe(2);
   });
 
   it("keeps sessionId when newSessionId matches current sessionId", async () => {
@@ -804,12 +764,8 @@ describe("incrementCompactionCount", () => {
     });
 
     const stored = { [sessionKey]: await loadStoredEntry(storePath, sessionKey) };
-    expect(expectDefined(stored[sessionKey], "stored[sessionKey] test invariant").sessionId).toBe(
-      "same-id",
-    );
-    expect(
-      expectDefined(stored[sessionKey], "stored[sessionKey] test invariant").compactionCount,
-    ).toBe(1);
+    expect(requireStoredSession(stored, sessionKey).sessionId).toBe("same-id");
+    expect(requireStoredSession(stored, sessionKey).compactionCount).toBe(1);
   });
 
   it("marks totalTokens stale when tokensAfter is not provided", async () => {
@@ -830,15 +786,9 @@ describe("incrementCompactionCount", () => {
     });
 
     const stored = { [sessionKey]: await loadStoredEntry(storePath, sessionKey) };
-    expect(
-      expectDefined(stored[sessionKey], "stored[sessionKey] test invariant").compactionCount,
-    ).toBe(1);
+    expect(requireStoredSession(stored, sessionKey).compactionCount).toBe(1);
     // totalTokens unchanged
-    expect(expectDefined(stored[sessionKey], "stored[sessionKey] test invariant").totalTokens).toBe(
-      180_000,
-    );
-    expect(
-      expectDefined(stored[sessionKey], "stored[sessionKey] test invariant").totalTokensFresh,
-    ).toBe(false);
+    expect(requireStoredSession(stored, sessionKey).totalTokens).toBe(180_000);
+    expect(requireStoredSession(stored, sessionKey).totalTokensFresh).toBe(false);
   });
 });

--- a/src/auto-reply/reply/reply-turn-admission.test.ts
+++ b/src/auto-reply/reply/reply-turn-admission.test.ts
@@ -83,6 +83,10 @@ function createSessionStore(entries: Record<string, object>): string {
   return storePath;
 }
 
+function createSessionStoreFor(sessionKey: string, sessionId: string) {
+  return createSessionStore({ [sessionKey]: { sessionId, updatedAt: Date.now() } });
+}
+
 async function readSessionEntry(
   storePath: string,
   sessionKey: string,
@@ -115,9 +119,7 @@ describe("reply turn admission", () => {
   it("rejects a reply when an archive commits before admission", async () => {
     const sessionKey = "agent:main:telegram:topic:archived";
     const sessionId = "session-before-archive";
-    const storePath = createSessionStore({
-      [sessionKey]: { sessionId, updatedAt: Date.now() },
-    });
+    const storePath = createSessionStoreFor(sessionKey, sessionId);
     const mutationStarted = createDeferred();
     const releaseMutation = createDeferred();
     const mutation = runExclusiveSessionLifecycleMutation({
@@ -151,9 +153,7 @@ describe("reply turn admission", () => {
   it("rejects a reply when deletion commits before admission", async () => {
     const sessionKey = "agent:main:telegram:topic:deleted";
     const sessionId = "session-before-delete";
-    const storePath = createSessionStore({
-      [sessionKey]: { sessionId, updatedAt: Date.now() },
-    });
+    const storePath = createSessionStoreFor(sessionKey, sessionId);
     const mutationStarted = createDeferred();
     const releaseMutation = createDeferred();
     const mutation = runExclusiveSessionLifecycleMutation({
@@ -187,9 +187,7 @@ describe("reply turn admission", () => {
     const sessionKey = "agent:main:telegram:topic:reset";
     const sessionId = "session-before-reset";
     const nextSessionId = "session-after-reset";
-    const storePath = createSessionStore({
-      [sessionKey]: { sessionId, updatedAt: Date.now() },
-    });
+    const storePath = createSessionStoreFor(sessionKey, sessionId);
     const mutationStarted = createDeferred();
     const releaseMutation = createDeferred();
     const mutation = runExclusiveSessionLifecycleMutation({
@@ -226,9 +224,7 @@ describe("reply turn admission", () => {
     const sessionKey = "agent:main:telegram:topic:reset-expected";
     const sessionId = "session-before-reset";
     const nextSessionId = "session-after-reset";
-    const storePath = createSessionStore({
-      [sessionKey]: { sessionId, updatedAt: Date.now() },
-    });
+    const storePath = createSessionStoreFor(sessionKey, sessionId);
     const mutationStarted = createDeferred();
     const releaseMutation = createDeferred();
     const mutation = runExclusiveSessionLifecycleMutation({
@@ -260,9 +256,7 @@ describe("reply turn admission", () => {
   it("drops queued work when reset cleanup cancels admission", async () => {
     const sessionKey = "agent:main:telegram:topic:queued-reset";
     const sessionId = "session-before-reset";
-    const storePath = createSessionStore({
-      [sessionKey]: { sessionId, updatedAt: Date.now() },
-    });
+    const storePath = createSessionStoreFor(sessionKey, sessionId);
     const mutationStarted = createDeferred();
     const releaseMutation = createDeferred();
     const abortController = new AbortController();
@@ -326,9 +320,7 @@ describe("reply turn admission", () => {
   it("holds lifecycle admission until a running reply operation clears", async () => {
     const sessionKey = "agent:main:telegram:topic:running-reset";
     const sessionId = "session-before-reset";
-    const storePath = createSessionStore({
-      [sessionKey]: { sessionId, updatedAt: Date.now() },
-    });
+    const storePath = createSessionStoreFor(sessionKey, sessionId);
     const admission = await admitTestReplyTurn({
       sessionKey,
       sessionId,
@@ -818,9 +810,7 @@ describe("reply turn admission", () => {
   it("holds interrupted queued reply work until its owner exits", async () => {
     const sessionKey = "agent:main:telegram:topic:queued-delete";
     const sessionId = "session-before-delete";
-    const storePath = createSessionStore({
-      [sessionKey]: { sessionId, updatedAt: Date.now() },
-    });
+    const storePath = createSessionStoreFor(sessionKey, sessionId);
     const admission = await admitTestReplyTurn({
       sessionKey,
       sessionId,
@@ -866,9 +856,7 @@ describe("reply turn admission", () => {
   it("excludes the initiating reply admission from an in-band lifecycle mutation", async () => {
     const sessionKey = "agent:main:telegram:topic:in-band-reset";
     const sessionId = "session-before-reset";
-    const storePath = createSessionStore({
-      [sessionKey]: { sessionId, updatedAt: Date.now() },
-    });
+    const storePath = createSessionStoreFor(sessionKey, sessionId);
     const admission = await admitTestReplyTurn({
       sessionKey,
       sessionId,
@@ -901,9 +889,7 @@ describe("reply turn admission", () => {
   it("skips an aborted reply waiting behind a lifecycle mutation", async () => {
     const sessionKey = "agent:main:telegram:topic:aborted";
     const sessionId = "session-before-abort";
-    const storePath = createSessionStore({
-      [sessionKey]: { sessionId, updatedAt: Date.now() },
-    });
+    const storePath = createSessionStoreFor(sessionKey, sessionId);
     const mutationStarted = createDeferred();
     const releaseMutation = createDeferred();
     const mutation = runExclusiveSessionLifecycleMutation({
@@ -1182,9 +1168,7 @@ describe("reply turn admission", () => {
     const sessionKey = "agent:main:telegram:topic:compaction";
     const sessionId = "pre-compact-session";
     const nextSessionId = "post-compact-session";
-    const storePath = createSessionStore({
-      [sessionKey]: { sessionId, updatedAt: Date.now() },
-    });
+    const storePath = createSessionStoreFor(sessionKey, sessionId);
     const active = createTestReplyOperation({
       sessionKey,
       sessionId,
@@ -1220,9 +1204,7 @@ describe("reply turn admission", () => {
     const sessionKey = "agent:main:telegram:topic:compaction-before-admission";
     const sessionId = "pre-compact-session";
     const nextSessionId = "post-compact-session";
-    const storePath = createSessionStore({
-      [sessionKey]: { sessionId, updatedAt: Date.now() },
-    });
+    const storePath = createSessionStoreFor(sessionKey, sessionId);
     const active = createTestReplyOperation({
       sessionKey,
       sessionId,
@@ -1254,9 +1236,7 @@ describe("reply turn admission", () => {
     const sessionKey = "agent:main:telegram:topic:late-compaction-owner";
     const sessionId = "pre-compact-session";
     const nextSessionId = "post-compact-session";
-    const storePath = createSessionStore({
-      [sessionKey]: { sessionId, updatedAt: Date.now() },
-    });
+    const storePath = createSessionStoreFor(sessionKey, sessionId);
     const active = createTestReplyOperation({
       sessionKey,
       sessionId,
@@ -1325,9 +1305,7 @@ describe("reply turn admission", () => {
     const sessionKey = "agent:main:telegram:topic:compaction-terminal-outcome";
     const sessionId = "pre-compact-session";
     const nextSessionId = "post-compact-session";
-    const storePath = createSessionStore({
-      [sessionKey]: { sessionId, updatedAt: Date.now() },
-    });
+    const storePath = createSessionStoreFor(sessionKey, sessionId);
     const active = createTestReplyOperation({
       sessionKey,
       sessionId,

--- a/src/auto-reply/reply/route-reply.test.ts
+++ b/src/auto-reply/reply/route-reply.test.ts
@@ -142,16 +142,22 @@ function lastDeliveryPayload(index = 0): Record<string, unknown> {
   return payload as Record<string, unknown>;
 }
 
+function routeTestReply(
+  overrides: Omit<Parameters<typeof routeReply>[0], "cfg"> &
+    Partial<Pick<Parameters<typeof routeReply>[0], "cfg">>,
+) {
+  return routeReply({ cfg: {} as never, ...overrides });
+}
+
 async function expectSlackNoDelivery(
   payload: Parameters<typeof routeReply>[0]["payload"],
   overrides: Partial<Parameters<typeof routeReply>[0]> = {},
 ) {
   mocks.deliverOutboundPayloads.mockClear();
-  const res = await routeReply({
+  const res = await routeTestReply({
     payload,
     channel: "slack",
     to: "channel:C123",
-    cfg: {} as never,
     ...overrides,
   });
   expect(res.ok).toBe(true);
@@ -224,11 +230,10 @@ describe("routeReply", () => {
   it("skips sends when abort signal is already aborted", async () => {
     const controller = new AbortController();
     controller.abort();
-    const res = await routeReply({
+    const res = await routeTestReply({
       payload: { text: "hi" },
       channel: "slack",
       to: "channel:C123",
-      cfg: {} as never,
       abortSignal: controller.signal,
     });
     expect(res.ok).toBe(false);
@@ -255,11 +260,10 @@ describe("routeReply", () => {
   });
 
   it("does not drop payloads that merely start with the silent token", async () => {
-    const res = await routeReply({
+    const res = await routeTestReply({
       payload: { text: `${SILENT_REPLY_TOKEN} -- (why am I here?)` },
       channel: "slack",
       to: "channel:C123",
-      cfg: {} as never,
     });
     expect(res.ok).toBe(true);
     expectLastDeliveryFields({
@@ -270,14 +274,13 @@ describe("routeReply", () => {
   });
 
   it("passes replayable reply payload hook context to routed delivery", async () => {
-    const res = await routeReply({
+    const res = await routeTestReply({
       payload: { text: "hello" },
       channel: "telegram",
       to: "chat-1",
       accountId: "acct-1",
       sessionKey: "agent:test",
       requesterSenderId: "sender-1",
-      cfg: {} as never,
       replyKind: "block",
       runId: "run-1",
     });
@@ -312,12 +315,11 @@ describe("routeReply", () => {
       },
     );
 
-    const res = await routeReply({
+    const res = await routeTestReply({
       payload,
       channel: "slack",
       to: "channel:C123",
       threadId: "111.000",
-      cfg: {} as never,
     });
 
     expect(res.ok).toBe(true);
@@ -343,7 +345,7 @@ describe("routeReply", () => {
       },
     );
 
-    const res = await routeReply({
+    const res = await routeTestReply({
       payload,
       channel: "slack",
       to: "channel:C123",
@@ -352,7 +354,6 @@ describe("routeReply", () => {
         chatType: "channel",
         replyToMode: "off",
       },
-      cfg: {} as never,
     });
 
     expect(res.ok).toBe(true);
@@ -377,7 +378,7 @@ describe("routeReply", () => {
       },
     );
 
-    const res = await routeReply({
+    const res = await routeTestReply({
       payload,
       channel: "slack",
       to: "channel:C123",
@@ -385,7 +386,6 @@ describe("routeReply", () => {
         chatType: "channel",
         replyToMode: "off",
       },
-      cfg: {} as never,
     });
 
     expect(res.ok).toBe(true);
@@ -397,7 +397,7 @@ describe("routeReply", () => {
   });
 
   it("uses explicit reply policy when routed blocks have no payload metadata", async () => {
-    const res = await routeReply({
+    const res = await routeTestReply({
       payload: { text: "hello", replyToId: "999.000" },
       channel: "slack",
       to: "channel:C123",
@@ -406,7 +406,6 @@ describe("routeReply", () => {
         chatType: "channel",
         replyToMode: "off",
       },
-      cfg: {} as never,
       replyKind: "block",
     });
 
@@ -418,7 +417,7 @@ describe("routeReply", () => {
   });
 
   it("honors Slack policy that clears a top-level reply target", async () => {
-    const res = await routeReply({
+    const res = await routeTestReply({
       payload: { text: "hello", replyToId: "999.000" },
       channel: "slack",
       to: "channel:C123",
@@ -426,7 +425,6 @@ describe("routeReply", () => {
         chatType: "channel",
         replyToMode: "off",
       },
-      cfg: {} as never,
       replyKind: "block",
     });
 
@@ -439,7 +437,7 @@ describe("routeReply", () => {
   });
 
   it("honors Mattermost policy that clears direct-message reply targets", async () => {
-    const res = await routeReply({
+    const res = await routeTestReply({
       payload: { text: "hello", replyToId: "post-1" },
       channel: "mattermost",
       to: "user:U123",
@@ -447,7 +445,6 @@ describe("routeReply", () => {
         chatType: "direct",
         replyToMode: "all",
       },
-      cfg: {} as never,
       replyKind: "block",
     });
 
@@ -460,7 +457,7 @@ describe("routeReply", () => {
   });
 
   it("preserves explicit Mattermost reply targets over the ambient thread", async () => {
-    const res = await routeReply({
+    const res = await routeTestReply({
       payload: {
         text: "hello",
         replyToId: "other-root",
@@ -473,7 +470,6 @@ describe("routeReply", () => {
         chatType: "channel",
         replyToMode: "all",
       },
-      cfg: {} as never,
     });
 
     expect(res.ok).toBe(true);
@@ -485,11 +481,10 @@ describe("routeReply", () => {
   });
 
   it("preserves reply targets when an adapter returns undefined", async () => {
-    const res = await routeReply({
+    const res = await routeTestReply({
       payload: { text: "hello", replyToId: "msg-internal-1" },
       channel: "slack",
       to: "channel:C123",
-      cfg: {} as never,
     });
 
     expect(res.ok).toBe(true);
@@ -500,12 +495,11 @@ describe("routeReply", () => {
   });
 
   it("leaves message_sending enforcement to routed durable delivery", async () => {
-    const res = await routeReply({
+    const res = await routeTestReply({
       payload: { text: "secret" },
       channel: "telegram",
       to: "chat-1",
       accountId: "acct-1",
-      cfg: {} as never,
     });
 
     expect(res.ok).toBe(true);
@@ -543,11 +537,10 @@ describe("routeReply", () => {
       },
     );
 
-    const res = await routeReply({
+    const res = await routeTestReply({
       payload: { text: "hello" },
       channel: "telegram",
       to: "chat-1",
-      cfg: {} as never,
     });
 
     expect(res).toEqual({
@@ -583,11 +576,10 @@ describe("routeReply", () => {
       },
     );
 
-    const res = await routeReply({
+    const res = await routeTestReply({
       payload: { text: "hello" },
       channel: "telegram",
       to: "chat-1",
-      cfg: {} as never,
     });
 
     expect(res).toEqual({
@@ -615,11 +607,10 @@ describe("routeReply", () => {
       },
     );
 
-    const res = await routeReply({
+    const res = await routeTestReply({
       payload: { text: "hello" },
       channel: "telegram",
       to: "chat-1",
-      cfg: {} as never,
     });
 
     expect(res).toEqual({
@@ -643,7 +634,7 @@ describe("routeReply", () => {
       },
     } as unknown as OpenClawConfig;
 
-    const res = await routeReply({
+    const res = await routeTestReply({
       payload: { text: "native command response" },
       channel: "slack",
       to: "channel:C123",
@@ -687,7 +678,7 @@ describe("routeReply", () => {
     const cfg = {
       channels: { slack: { responsePrefix: "[openclaw]" } },
     } as unknown as OpenClawConfig;
-    await routeReply({
+    await routeTestReply({
       payload: { text: "hi" },
       channel: "slack",
       to: "channel:C123",
@@ -707,7 +698,7 @@ describe("routeReply", () => {
         },
       },
     } as unknown as OpenClawConfig;
-    await routeReply({
+    await routeTestReply({
       payload: { text: "hi" },
       channel: "slack",
       to: "channel:C123",
@@ -745,7 +736,7 @@ describe("routeReply", () => {
       },
       messages: {},
     } as unknown as OpenClawConfig;
-    await routeReply({
+    await routeTestReply({
       payload: { text: "hi" },
       channel: "slack",
       to: "channel:C123",
@@ -756,12 +747,11 @@ describe("routeReply", () => {
   });
 
   it("uses threadId for Slack when replyToId is missing", async () => {
-    await routeReply({
+    await routeTestReply({
       payload: { text: "hi" },
       channel: "slack",
       to: "channel:C123",
       threadId: "456.789",
-      cfg: {} as never,
     });
     expectLastDeliveryFields({
       channel: "slack",
@@ -771,12 +761,11 @@ describe("routeReply", () => {
   });
 
   it("passes thread id to Telegram sends", async () => {
-    await routeReply({
+    await routeTestReply({
       payload: { text: "hi" },
       channel: "telegram",
       to: "telegram:123",
       threadId: 42,
-      cfg: {} as never,
     });
     expectLastDeliveryFields({
       channel: "telegram",
@@ -786,11 +775,10 @@ describe("routeReply", () => {
   });
 
   it("formats BTW replies prominently on routed sends", async () => {
-    await routeReply({
+    await routeTestReply({
       payload: { text: "323", btw: { question: "what is 17 * 19?" } },
       channel: "slack",
       to: "channel:C123",
-      cfg: {} as never,
     });
     expectLastDeliveryFields({
       channel: "slack",
@@ -799,11 +787,10 @@ describe("routeReply", () => {
   });
 
   it("formats BTW replies prominently on routed discord sends", async () => {
-    await routeReply({
+    await routeTestReply({
       payload: { text: "323", btw: { question: "what is 17 * 19?" } },
       channel: "discord",
       to: "channel:123456",
-      cfg: {} as never,
     });
     expectLastDeliveryFields({
       channel: "discord",
@@ -812,11 +799,10 @@ describe("routeReply", () => {
   });
 
   it("passes replyToId to Telegram sends", async () => {
-    await routeReply({
+    await routeTestReply({
       payload: { text: "hi", replyToId: "123" },
       channel: "telegram",
       to: "telegram:123",
-      cfg: {} as never,
     });
     expectLastDeliveryFields({
       channel: "telegram",
@@ -826,11 +812,10 @@ describe("routeReply", () => {
   });
 
   it("preserves audioAsVoice on routed outbound payloads", async () => {
-    await routeReply({
+    await routeTestReply({
       payload: { text: "voice caption", mediaUrl: "file:///tmp/clip.mp3", audioAsVoice: true },
       channel: "slack",
       to: "channel:C123",
-      cfg: {} as never,
     });
     expect(mocks.deliverOutboundPayloads).toHaveBeenCalledTimes(1);
     expectLastDeliveryFields({
@@ -843,11 +828,10 @@ describe("routeReply", () => {
   });
 
   it("uses replyToId as threadTs for Slack", async () => {
-    await routeReply({
+    await routeTestReply({
       payload: { text: "hi", replyToId: "1710000000.0001" },
       channel: "slack",
       to: "channel:C123",
-      cfg: {} as never,
     });
     expectLastDeliveryFields({
       channel: "slack",
@@ -857,12 +841,11 @@ describe("routeReply", () => {
   });
 
   it("uses threadId as threadTs for Slack when replyToId is missing", async () => {
-    await routeReply({
+    await routeTestReply({
       payload: { text: "hi" },
       channel: "slack",
       to: "channel:C123",
       threadId: "1710000000.9999",
-      cfg: {} as never,
     });
     expectLastDeliveryFields({
       channel: "slack",
@@ -872,12 +855,11 @@ describe("routeReply", () => {
   });
 
   it("uses Slack threadId when routed replyToId is an internal message id", async () => {
-    await routeReply({
+    await routeTestReply({
       payload: { text: "hi", replyToId: "msg-internal-1" },
       channel: "slack",
       to: "channel:C123",
       threadId: "1710000000.9999",
-      cfg: {} as never,
     });
     expectLastDeliveryFields({
       channel: "slack",
@@ -887,7 +869,7 @@ describe("routeReply", () => {
   });
 
   it("uses threadId as replyToId for Mattermost when replyToId is missing", async () => {
-    await routeReply({
+    await routeTestReply({
       payload: { text: "hi" },
       channel: "mattermost",
       to: "channel:CHAN1",
@@ -911,11 +893,10 @@ describe("routeReply", () => {
   });
 
   it("preserves multiple mediaUrls as a single outbound payload", async () => {
-    await routeReply({
+    await routeTestReply({
       payload: { text: "caption", mediaUrls: ["a", "b"] },
       channel: "slack",
       to: "channel:C123",
-      cfg: {} as never,
     });
     expectLastDeliveryFields({
       channel: "slack",
@@ -925,12 +906,11 @@ describe("routeReply", () => {
   });
 
   it("routes WhatsApp with the account id intact", async () => {
-    await routeReply({
+    await routeTestReply({
       payload: { text: "hi" },
       channel: "whatsapp",
       to: "+15551234567",
       accountId: "acc-1",
-      cfg: {} as never,
     });
     expectLastDeliveryFields({
       channel: "whatsapp",
@@ -947,7 +927,7 @@ describe("routeReply", () => {
         },
       },
     } as unknown as OpenClawConfig;
-    await routeReply({
+    await routeTestReply({
       payload: { text: "hi" },
       channel: "msteams",
       to: "conversation:19:abc@thread.tacv2",
@@ -962,14 +942,13 @@ describe("routeReply", () => {
   });
 
   it("passes mirror data when sessionKey is set", async () => {
-    await routeReply({
+    await routeTestReply({
       payload: { text: "hi" },
       channel: "slack",
       to: "channel:C123",
       sessionKey: "agent:main:main",
       isGroup: true,
       groupId: "channel:C123",
-      cfg: {} as never,
     });
     const mirror = lastDelivery().mirror as Record<string, unknown>;
     expect(mirror.sessionKey).toBe("agent:main:main");
@@ -979,13 +958,12 @@ describe("routeReply", () => {
   });
 
   it("skips mirror data when mirror is false", async () => {
-    await routeReply({
+    await routeTestReply({
       payload: { text: "hi" },
       channel: "slack",
       to: "channel:C123",
       sessionKey: "agent:main:main",
       mirror: false,
-      cfg: {} as never,
     });
     expectLastDeliveryFields({
       mirror: undefined,

--- a/src/channels/inbound-event/context.test.ts
+++ b/src/channels/inbound-event/context.test.ts
@@ -36,6 +36,12 @@ function createBaseContextParams(
   };
 }
 
+function buildTestInboundEventContext(
+  overrides: Partial<BuildChannelInboundEventContextParams> = {},
+) {
+  return buildChannelInboundEventContext(createBaseContextParams(overrides));
+}
+
 describe("resolveInboundSupplementalSenderAllowed", () => {
   it.each([
     {
@@ -276,14 +282,12 @@ describe("buildChannelInboundEventContext", () => {
   });
 
   it("preserves channel-owned hook context without rendering it as prompt text", () => {
-    const ctx = buildChannelInboundEventContext(
-      createBaseContextParams({
-        channelContext: {
-          sender: { id: "sender-1", customSenderField: "sender-meta" },
-          chat: { id: "chat-1", customChatField: "chat-meta" },
-        },
-      }),
-    );
+    const ctx = buildTestInboundEventContext({
+      channelContext: {
+        sender: { id: "sender-1", customSenderField: "sender-meta" },
+        chat: { id: "chat-1", customChatField: "chat-meta" },
+      },
+    });
 
     expect(ctx.ChannelContext).toEqual({
       sender: { id: "sender-1", customSenderField: "sender-meta" },
@@ -294,66 +298,56 @@ describe("buildChannelInboundEventContext", () => {
   });
 
   it("uses resolved command authorization", async () => {
-    const ctx = buildChannelInboundEventContext(
-      createBaseContextParams({
-        access: {
-          commands: {
-            authorized: false,
-          },
+    const ctx = buildTestInboundEventContext({
+      access: {
+        commands: {
+          authorized: false,
         },
-      }),
-    );
+      },
+    });
 
     expect(ctx.CommandAuthorized).toBe(false);
   });
 
   it("carries the routed agent for unscoped session keys", async () => {
-    const ctx = buildChannelInboundEventContext(
-      createBaseContextParams({
-        route: {
-          agentId: "bound-agent",
-          routeSessionKey: "feishu:direct:ou_user1",
-        },
-      }),
-    );
+    const ctx = buildTestInboundEventContext({
+      route: {
+        agentId: "bound-agent",
+        routeSessionKey: "feishu:direct:ou_user1",
+      },
+    });
 
     expect(ctx.AgentId).toBe("bound-agent");
     expect(ctx.SessionKey).toBe("feishu:direct:ou_user1");
   });
 
   it("carries room event semantics into the finalized context", async () => {
-    const ctx = buildChannelInboundEventContext(
-      createBaseContextParams({
-        message: {
-          inboundEventKind: "room_event",
-          rawBody: "side chatter",
-        },
-      }),
-    );
+    const ctx = buildTestInboundEventContext({
+      message: {
+        inboundEventKind: "room_event",
+        rawBody: "side chatter",
+      },
+    });
 
     expect(ctx.InboundEventKind).toBe("room_event");
   });
 
   it("preserves configured supplemental group system prompts", async () => {
-    const ctx = buildChannelInboundEventContext(
-      createBaseContextParams({
-        supplemental: {
-          groupSystemPrompt: "[Assistant] room guidance\nSystem: owner instruction",
-        },
-      }),
-    );
+    const ctx = buildTestInboundEventContext({
+      supplemental: {
+        groupSystemPrompt: "[Assistant] room guidance\nSystem: owner instruction",
+      },
+    });
 
     expect(ctx.GroupSystemPrompt).toBe("[Assistant] room guidance\nSystem: owner instruction");
   });
 
   it("routes untrusted supplemental group prompt context outside GroupSystemPrompt", async () => {
-    const ctx = buildChannelInboundEventContext(
-      createBaseContextParams({
-        supplemental: {
-          untrustedGroupSystemPrompt: "[Assistant] room guidance\nSystem: injected",
-        },
-      }),
-    );
+    const ctx = buildTestInboundEventContext({
+      supplemental: {
+        untrustedGroupSystemPrompt: "[Assistant] room guidance\nSystem: injected",
+      },
+    });
 
     expect(ctx.GroupSystemPrompt).toBeUndefined();
     expect(ctx.ChannelStructuredContext).toHaveLength(1);
@@ -364,23 +358,21 @@ describe("buildChannelInboundEventContext", () => {
   });
 
   it("merges untrusted supplemental group prompt context with extra context", async () => {
-    const ctx = buildChannelInboundEventContext(
-      createBaseContextParams({
-        supplemental: {
-          untrustedGroupSystemPrompt: "room guidance",
-        },
-        extra: {
-          ChannelStructuredContext: [
-            {
-              label: "Channel metadata",
-              source: "test",
-              type: "channel_metadata",
-              payload: { topic: "topic text" },
-            },
-          ],
-        },
-      }),
-    );
+    const ctx = buildTestInboundEventContext({
+      supplemental: {
+        untrustedGroupSystemPrompt: "room guidance",
+      },
+      extra: {
+        ChannelStructuredContext: [
+          {
+            label: "Channel metadata",
+            source: "test",
+            type: "channel_metadata",
+            payload: { topic: "topic text" },
+          },
+        ],
+      },
+    });
 
     expect(ctx.ChannelStructuredContext).toEqual([
       {
@@ -398,26 +390,24 @@ describe("buildChannelInboundEventContext", () => {
   });
 
   it("preserves deprecated-only structured context sources", () => {
-    const ctx = buildChannelInboundEventContext(
-      createBaseContextParams({
-        supplemental: {
-          untrustedContext: [
-            {
-              label: "Deprecated supplemental metadata",
-              payload: { source: "supplemental" },
-            },
-          ],
-        },
-        extra: {
-          UntrustedStructuredContext: [
-            {
-              label: "Deprecated extra metadata",
-              payload: { source: "extra" },
-            },
-          ],
-        },
-      }),
-    );
+    const ctx = buildTestInboundEventContext({
+      supplemental: {
+        untrustedContext: [
+          {
+            label: "Deprecated supplemental metadata",
+            payload: { source: "supplemental" },
+          },
+        ],
+      },
+      extra: {
+        UntrustedStructuredContext: [
+          {
+            label: "Deprecated extra metadata",
+            payload: { source: "extra" },
+          },
+        ],
+      },
+    });
 
     expect(ctx.ChannelStructuredContext).toEqual([
       {
@@ -433,38 +423,36 @@ describe("buildChannelInboundEventContext", () => {
   });
 
   it("prefers channel-named structured context sources over deprecated names", () => {
-    const ctx = buildChannelInboundEventContext(
-      createBaseContextParams({
-        supplemental: {
-          channelStructuredContext: [
-            {
-              label: "Current supplemental metadata",
-              payload: { source: "supplemental" },
-            },
-          ],
-          untrustedContext: [
-            {
-              label: "Deprecated supplemental metadata",
-              payload: { source: "supplemental" },
-            },
-          ],
-        },
-        extra: {
-          ChannelStructuredContext: [
-            {
-              label: "Current extra metadata",
-              payload: { source: "extra" },
-            },
-          ],
-          UntrustedStructuredContext: [
-            {
-              label: "Deprecated extra metadata",
-              payload: { source: "extra" },
-            },
-          ],
-        },
-      }),
-    );
+    const ctx = buildTestInboundEventContext({
+      supplemental: {
+        channelStructuredContext: [
+          {
+            label: "Current supplemental metadata",
+            payload: { source: "supplemental" },
+          },
+        ],
+        untrustedContext: [
+          {
+            label: "Deprecated supplemental metadata",
+            payload: { source: "supplemental" },
+          },
+        ],
+      },
+      extra: {
+        ChannelStructuredContext: [
+          {
+            label: "Current extra metadata",
+            payload: { source: "extra" },
+          },
+        ],
+        UntrustedStructuredContext: [
+          {
+            label: "Deprecated extra metadata",
+            payload: { source: "extra" },
+          },
+        ],
+      },
+    });
 
     expect(ctx.ChannelStructuredContext).toEqual([
       {
@@ -480,35 +468,31 @@ describe("buildChannelInboundEventContext", () => {
   });
 
   it("keeps explicitly empty channel structured context ahead of the deprecated alias", () => {
-    const ctx = buildChannelInboundEventContext(
-      createBaseContextParams({
-        extra: {
-          ChannelStructuredContext: [],
-          UntrustedStructuredContext: [{ label: "stale", payload: {} }],
-        },
-      }),
-    );
+    const ctx = buildTestInboundEventContext({
+      extra: {
+        ChannelStructuredContext: [],
+        UntrustedStructuredContext: [{ label: "stale", payload: {} }],
+      },
+    });
 
     expect(ctx.ChannelStructuredContext).toEqual([]);
     expect(Object.hasOwn(ctx, "UntrustedStructuredContext")).toBe(false);
   });
 
   it("keeps deprecated structured context when a group prompt also contributes", () => {
-    const ctx = buildChannelInboundEventContext(
-      createBaseContextParams({
-        supplemental: {
-          untrustedGroupSystemPrompt: "room guidance",
-        },
-        extra: {
-          UntrustedStructuredContext: [
-            {
-              label: "Deprecated channel metadata",
-              payload: { topic: "topic text" },
-            },
-          ],
-        },
-      }),
-    );
+    const ctx = buildTestInboundEventContext({
+      supplemental: {
+        untrustedGroupSystemPrompt: "room guidance",
+      },
+      extra: {
+        UntrustedStructuredContext: [
+          {
+            label: "Deprecated channel metadata",
+            payload: { topic: "topic text" },
+          },
+        ],
+      },
+    });
 
     expect(ctx.ChannelStructuredContext).toEqual([
       {
@@ -524,20 +508,18 @@ describe("buildChannelInboundEventContext", () => {
   });
 
   it("preserves thread-addressable origins alongside flat reply targets", async () => {
-    const ctx = buildChannelInboundEventContext(
-      createBaseContextParams({
-        conversation: {
-          kind: "group",
-          id: "room-1",
-          threadId: "topic-42",
-        },
-        reply: {
-          to: "test:room:room-1",
-          originatingTo: "test:room:room-1:topic:topic-42",
-          messageThreadId: "topic-42",
-        },
-      }),
-    );
+    const ctx = buildTestInboundEventContext({
+      conversation: {
+        kind: "group",
+        id: "room-1",
+        threadId: "topic-42",
+      },
+      reply: {
+        to: "test:room:room-1",
+        originatingTo: "test:room:room-1:topic:topic-42",
+        messageThreadId: "topic-42",
+      },
+    });
 
     expect(ctx.To).toBe("test:room:room-1");
     expect(ctx.OriginatingTo).toBe("test:room:room-1:topic:topic-42");
@@ -545,23 +527,21 @@ describe("buildChannelInboundEventContext", () => {
   });
 
   it("derives command turns from normalized command facts", async () => {
-    const ctx = buildChannelInboundEventContext(
-      createBaseContextParams({
-        message: {
-          rawBody: "/status",
-          commandBody: "/status",
+    const ctx = buildTestInboundEventContext({
+      message: {
+        rawBody: "/status",
+        commandBody: "/status",
+      },
+      command: {
+        kind: "text-slash",
+        name: "status",
+      },
+      access: {
+        commands: {
+          authorized: true,
         },
-        command: {
-          kind: "text-slash",
-          name: "status",
-        },
-        access: {
-          commands: {
-            authorized: true,
-          },
-        },
-      }),
-    );
+      },
+    });
 
     expect(ctx.CommandTurn).toEqual({
       kind: "text-slash",
@@ -575,24 +555,22 @@ describe("buildChannelInboundEventContext", () => {
   });
 
   it("keeps explicit command turns ahead of normalized command facts", async () => {
-    const ctx = buildChannelInboundEventContext(
-      createBaseContextParams({
-        message: {
-          rawBody: "/status",
-          commandBody: "/status",
-        },
-        command: {
-          kind: "native",
-          authorized: true,
-        },
-        commandTurn: {
-          kind: "normal",
-          source: "message",
-          authorized: false,
-          body: "hello",
-        },
-      }),
-    );
+    const ctx = buildTestInboundEventContext({
+      message: {
+        rawBody: "/status",
+        commandBody: "/status",
+      },
+      command: {
+        kind: "native",
+        authorized: true,
+      },
+      commandTurn: {
+        kind: "normal",
+        source: "message",
+        authorized: false,
+        body: "hello",
+      },
+    });
 
     expect(ctx.CommandTurn).toEqual({
       kind: "normal",
@@ -606,30 +584,28 @@ describe("buildChannelInboundEventContext", () => {
   });
 
   it("filters supplemental context with channel visibility policy", async () => {
-    const ctx = buildChannelInboundEventContext(
-      createBaseContextParams({
-        supplemental: {
-          quote: {
-            id: "quote-1",
-            body: "quoted",
-            sender: "Quoted User",
-            senderAllowed: false,
-            isQuote: true,
-          },
-          forwarded: {
-            from: "Forwarded User",
-            fromId: "f1",
-            senderAllowed: false,
-          },
-          thread: {
-            starterBody: "thread starter",
-            historyBody: "thread history",
-            senderAllowed: false,
-          },
+    const ctx = buildTestInboundEventContext({
+      supplemental: {
+        quote: {
+          id: "quote-1",
+          body: "quoted",
+          sender: "Quoted User",
+          senderAllowed: false,
+          isQuote: true,
         },
-        contextVisibility: "allowlist",
-      }),
-    );
+        forwarded: {
+          from: "Forwarded User",
+          fromId: "f1",
+          senderAllowed: false,
+        },
+        thread: {
+          starterBody: "thread starter",
+          historyBody: "thread history",
+          senderAllowed: false,
+        },
+      },
+      contextVisibility: "allowlist",
+    });
 
     expect(ctx.ReplyToBody).toBeUndefined();
     expect(ctx.ReplyToSender).toBeUndefined();
@@ -639,24 +615,22 @@ describe("buildChannelInboundEventContext", () => {
   });
 
   it("keeps quoted context in allowlist_quote mode", async () => {
-    const ctx = buildChannelInboundEventContext(
-      createBaseContextParams({
-        supplemental: {
-          quote: {
-            id: "quote-1",
-            body: "quoted",
-            sender: "Quoted User",
-            senderAllowed: false,
-            isQuote: true,
-          },
-          thread: {
-            starterBody: "thread starter",
-            senderAllowed: false,
-          },
+    const ctx = buildTestInboundEventContext({
+      supplemental: {
+        quote: {
+          id: "quote-1",
+          body: "quoted",
+          sender: "Quoted User",
+          senderAllowed: false,
+          isQuote: true,
         },
-        contextVisibility: "allowlist_quote",
-      }),
-    );
+        thread: {
+          starterBody: "thread starter",
+          senderAllowed: false,
+        },
+      },
+      contextVisibility: "allowlist_quote",
+    });
 
     expect(ctx.ReplyToBody).toBe("quoted");
     expect(ctx.ReplyToSender).toBe("Quoted User");
@@ -664,27 +638,25 @@ describe("buildChannelInboundEventContext", () => {
   });
 
   it("drops supplemental context with unknown sender allow state in restrictive modes", async () => {
-    const ctx = buildChannelInboundEventContext(
-      createBaseContextParams({
-        supplemental: {
-          quote: {
-            id: "quote-1",
-            body: "quoted",
-            sender: "Quoted User",
-            isQuote: true,
-          },
-          forwarded: {
-            from: "Forwarded User",
-            fromId: "f1",
-          },
-          thread: {
-            starterBody: "thread starter",
-            historyBody: "thread history",
-          },
+    const ctx = buildTestInboundEventContext({
+      supplemental: {
+        quote: {
+          id: "quote-1",
+          body: "quoted",
+          sender: "Quoted User",
+          isQuote: true,
         },
-        contextVisibility: "allowlist_quote",
-      }),
-    );
+        forwarded: {
+          from: "Forwarded User",
+          fromId: "f1",
+        },
+        thread: {
+          starterBody: "thread starter",
+          historyBody: "thread history",
+        },
+      },
+      contextVisibility: "allowlist_quote",
+    });
 
     expect(ctx.ReplyToBody).toBeUndefined();
     expect(ctx.ReplyToSender).toBeUndefined();

--- a/src/channels/message/ingress-queue.test.ts
+++ b/src/channels/message/ingress-queue.test.ts
@@ -44,6 +44,10 @@ async function withTempState<T>(fn: (stateDir: string) => Promise<T>): Promise<T
   }
 }
 
+function openIngressStateDatabase(stateDir: string) {
+  return openOpenClawStateDatabase({ env: { OPENCLAW_STATE_DIR: stateDir } });
+}
+
 describe("channel ingress queue", () => {
   afterEach(() => {
     closeOpenClawStateDatabaseForTest();
@@ -554,9 +558,7 @@ describe("channel ingress queue", () => {
       await queue.release("retry", { lastError: "stale retry text", releasedAt: 26 });
       await queue.complete("retry", { completedAt: 27 });
 
-      const database = openOpenClawStateDatabase({
-        env: { OPENCLAW_STATE_DIR: stateDir },
-      });
+      const database = openIngressStateDatabase(stateDir);
       const kysely = getNodeSqliteKysely<ChannelIngressTestDatabase>(database.db);
       const rows = executeSqliteQuerySync(
         database.db,
@@ -612,9 +614,7 @@ describe("channel ingress queue", () => {
         completed_at: number;
       }>,
     ) {
-      const { db } = openOpenClawStateDatabase({
-        env: { OPENCLAW_STATE_DIR: stateDir },
-      });
+      const { db } = openIngressStateDatabase(stateDir);
       const kysely = getNodeSqliteKysely<ChannelIngressTestDatabase>(db);
       const claimValue = overrides.claim_token ?? null;
       executeSqliteQuerySync(
@@ -740,9 +740,7 @@ describe("channel ingress queue", () => {
         await queue.complete("comp-1", { metadata: { handler: "worker" }, completedAt: 150 });
 
         // Corrupt the completed_metadata_json
-        const { db } = openOpenClawStateDatabase({
-          env: { OPENCLAW_STATE_DIR: stateDir },
-        });
+        const { db } = openIngressStateDatabase(stateDir);
         db.prepare(
           `UPDATE channel_ingress_events
              SET completed_metadata_json = ?
@@ -769,9 +767,7 @@ describe("channel ingress queue", () => {
         });
         // Override the bad row's received_at to be earlier.
         {
-          const { db } = openOpenClawStateDatabase({
-            env: { OPENCLAW_STATE_DIR: stateDir },
-          });
+          const { db } = openIngressStateDatabase(stateDir);
           db.prepare(
             `UPDATE channel_ingress_events SET received_at = ? WHERE queue_name = ? AND event_id = ?`,
           ).run(earlyTime, '["test","account"]', "bad-claim");
@@ -782,7 +778,7 @@ describe("channel ingress queue", () => {
         expect(claimed).not.toBeNull();
         expect(claimed!.id).toBe("good-1");
 
-        const database = openOpenClawStateDatabase({ env: { OPENCLAW_STATE_DIR: stateDir } });
+        const database = openIngressStateDatabase(stateDir);
         const failed = executeSqliteQueryTakeFirstSync(
           database.db,
           getNodeSqliteKysely<ChannelIngressTestDatabase>(database.db)
@@ -826,7 +822,7 @@ describe("channel ingress queue", () => {
 
         await expect(queue.claimNext({ scanLimit: 200 })).resolves.toBeNull();
 
-        const database = openOpenClawStateDatabase({ env: { OPENCLAW_STATE_DIR: stateDir } });
+        const database = openIngressStateDatabase(stateDir);
         const counts = executeSqliteQuerySync(
           database.db,
           getNodeSqliteKysely<ChannelIngressTestDatabase>(database.db)
@@ -860,7 +856,7 @@ describe("channel ingress queue", () => {
         expect(goodClaim).not.toBeNull();
         expect(goodClaim!.payload.text).toBe("hello");
 
-        const database = openOpenClawStateDatabase({ env: { OPENCLAW_STATE_DIR: stateDir } });
+        const database = openIngressStateDatabase(stateDir);
         const failed = executeSqliteQueryTakeFirstSync(
           database.db,
           getNodeSqliteKysely<ChannelIngressTestDatabase>(database.db)
@@ -901,9 +897,7 @@ describe("channel ingress queue", () => {
         }
 
         // Verify the corrupt row was actually tombstoned in the DB.
-        const { db } = openOpenClawStateDatabase({
-          env: { OPENCLAW_STATE_DIR: stateDir },
-        });
+        const { db } = openIngressStateDatabase(stateDir);
         const row = executeSqliteQuerySync(
           db,
           getNodeSqliteKysely<ChannelIngressTestDatabase>(db)
@@ -935,9 +929,7 @@ describe("channel ingress queue", () => {
           "Corrupt payload_json in claimed channel ingress event",
         );
 
-        const { db } = openOpenClawStateDatabase({
-          env: { OPENCLAW_STATE_DIR: stateDir },
-        });
+        const { db } = openIngressStateDatabase(stateDir);
         const row = executeSqliteQueryTakeFirstSync(
           db,
           getNodeSqliteKysely<ChannelIngressTestDatabase>(db)
@@ -975,9 +967,7 @@ describe("channel ingress queue", () => {
         expect(recovered).toBe(1);
 
         // The corrupt claimed row should now be tombstoned as failed.
-        const { db } = openOpenClawStateDatabase({
-          env: { OPENCLAW_STATE_DIR: stateDir },
-        });
+        const { db } = openIngressStateDatabase(stateDir);
         const row = executeSqliteQuerySync(
           db,
           getNodeSqliteKysely<ChannelIngressTestDatabase>(db)
@@ -1030,9 +1020,7 @@ describe("channel ingress queue", () => {
           },
         });
 
-        const { db } = openOpenClawStateDatabase({
-          env: { OPENCLAW_STATE_DIR: stateDir },
-        });
+        const { db } = openIngressStateDatabase(stateDir);
         const row = executeSqliteQueryTakeFirstSync(
           db,
           getNodeSqliteKysely<ChannelIngressTestDatabase>(db)


### PR DESCRIPTION
## What Problem This Solves

Inbound replies, native slash commands, attachment normalization, reply lifecycle admission, heartbeat filtering, and SQLite ingress accumulated repeated setup and cleanup scaffolding. The duplication made the protected authorization, sender, session ownership, heartbeat, timer, and durable-state cases harder to review and easier to update inconsistently.

## Why This Change Was Made

Consolidate repeated setup into typed, file-local helpers in each owning suite. This keeps lane ownership intact, preserves fresh fixture construction and distinct timer/SQLite cleanup semantics, and avoids a cross-lane shared fixture that changed-file classification might miss.

The two fake-timer cases with different finalization behavior remain inline. SQLite close/reset behavior is unchanged, and the three nested OpenAI model facts caught by the first candidate run remain explicit in their fixtures and assertions.

## User Impact

No production or user-visible behavior changes. Developers retain every current regression case and assertion with less duplicated test policy to maintain.

## Evidence

- Rebased head: `9924d81869ff8a2b602c51ff70defb937d545487` on `a39c24463e9778ab65c8e45b4c44f3a80b88f8e0`.
- Patch identity remained stable across the final rebase: `49379ba2bd6d9d3e1f7864de271e59964bd892ff`.
- Scope: 11 test files, production `+0/-0`, tests `+979/-1426` (net `-447`).
- Ordered test declarations: `409 -> 409`, with identical per-file fingerprints.
- Assertion sites: `1009 -> 1009` `expect(...)` calls.
- Baseline cohort: 436/436 passed.
- Exact-head cohort command:

```text
node scripts/run-vitest.mjs src/auto-reply/heartbeat-filter.test.ts src/auto-reply/heartbeat.test.ts src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts src/auto-reply/reply/get-reply-native-slash-fast-path.test.ts src/auto-reply/reply/reply-media-paths.test.ts src/auto-reply/reply/reply-run-registry.test.ts src/auto-reply/reply/reply-state.test.ts src/auto-reply/reply/reply-turn-admission.test.ts src/auto-reply/reply/route-reply.test.ts src/channels/inbound-event/context.test.ts src/channels/message/ingress-queue.test.ts

Test Files  2 passed (2)
Tests       70 passed (70)
Test Files  7 passed (7)
Tests       303 passed (303)
Test Files  2 passed (2)
Tests       63 passed (63)
[test] passed 3 Vitest shards in 85.31s
```

- `node scripts/check-changed.mjs` passed remotely on the patch-identical pre-rebase tree: core-test typecheck, formatting, guards, and lint with 0 warnings and 0 errors.
- `git diff --check origin/main..HEAD` passed.
- Codex-backed autoreview completed with no accepted or actionable findings on the identical patch.

The Codex-adjacent native-slash regression remains contract-checked against current sibling Rust source:

- `codex-rs/utils/cli/src/shared_options.rs:9-24` defines the global model option.
- `codex-rs/exec/src/cli.rs:139-158,161-244` marks the model option global and defines resume session-id and `--last` parsing.
- `codex-rs/exec/src/lib.rs:733-766,1465-1593` preserves last/session prompt handling, UUID/name lookup, pagination, cwd filtering, and provider filtering for `--last`.
- `codex-rs/cli/src/main.rs:320-347,1264-1291,2463-2497` defines the interactive resume surface, dispatch, and resume-scoped flag/override merging.

ClawSweeper rank-up moves addressed: the branch is rebased onto current main, every current named regression remains present, exact-head terminal proof is included above, and a fresh exact-head review is requested after this update.
