### PR TITLE
fix(ui): show background tasks per chat session

### DIFF
--- a/src/gateway/server-methods/tasks.test.ts
+++ b/src/gateway/server-methods/tasks.test.ts
@@ -163,7 +163,7 @@ describe("tasks gateway handlers", () => {
     const { calls, payload } = await runTaskHandler("tasks.list", {
       status: "running",
       agentId: "main",
-      sessionKey: "agent:main:main",
+      sessionKey: "main",
     });
 
     expect(calls[0]?.[0]).toBe(true);

--- a/src/gateway/server-methods/tasks.ts
+++ b/src/gateway/server-methods/tasks.ts
@@ -11,6 +11,8 @@ import {
   validateTasksGetParams,
   validateTasksListParams,
 } from "../../../packages/gateway-protocol/src/index.js";
+import { resolveDefaultAgentId } from "../../agents/agent-scope.js";
+import { canonicalizeMainSessionAlias } from "../../config/sessions.js";
 import { parseAgentSessionKey } from "../../routing/session-key.js";
 import { getTaskById, listTaskRecordsUnsorted } from "../../tasks/runtime-internal.js";
 import { cancelDetachedTaskRunById } from "../../tasks/task-executor.js";
@@ -86,7 +88,7 @@ function parseCursor(cursor: string | undefined): number | null {
 // Control UI task methods expose the stable gateway protocol shape; helpers
 // above keep runtime registry details out of the wire result.
 export const tasksHandlers: GatewayRequestHandlers = {
-  "tasks.list": ({ params, respond }) => {
+  "tasks.list": ({ params, respond, context }) => {
     if (!validateTasksListParams(params)) {
       respond(
         false,
@@ -109,6 +111,19 @@ export const tasksHandlers: GatewayRequestHandlers = {
     }
     const statusFilter = normalizeTaskStatusFilter(params.status);
     const limit = Math.min(params.limit ?? DEFAULT_TASKS_LIST_LIMIT, MAX_TASKS_LIST_LIMIT);
+    const requestedSessionKey = normalizeOptionalString(params.sessionKey);
+    let sessionKey: string | undefined;
+    if (requestedSessionKey) {
+      const cfg = context.getRuntimeConfig();
+      sessionKey = canonicalizeMainSessionAlias({
+        cfg,
+        agentId:
+          parseAgentSessionKey(requestedSessionKey)?.agentId ??
+          normalizeOptionalString(params.agentId) ??
+          resolveDefaultAgentId(cfg),
+        sessionKey: requestedSessionKey,
+      });
+    }
     // The ledger view pages by last activity so an old long-running task that
     // just finished still surfaces on the first page instead of hiding behind
     // newer-created records. Start from a cloned insertion-order snapshot so
@@ -118,9 +133,7 @@ export const tasksHandlers: GatewayRequestHandlers = {
         if (statusFilter && !statusFilter.has(task.status)) {
           return false;
         }
-        return (
-          taskMatchesAgent(task, params.agentId) && taskMatchesSession(task, params.sessionKey)
-        );
+        return taskMatchesAgent(task, params.agentId) && taskMatchesSession(task, sessionKey);
       })
       .toSorted((left, right) => {
         const updatedDiff = taskUpdatedAt(right) - taskUpdatedAt(left);

--- a/ui/src/pages/chat/background-tasks.e2e.test.ts
+++ b/ui/src/pages/chat/background-tasks.e2e.test.ts
@@ -16,6 +16,7 @@ const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM 
 const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
 const artifactDir = path.resolve(process.cwd(), ".artifacts/control-ui-e2e/chat-background-tasks");
 const baseTime = Date.now();
+const chatSessionKey = "agent:main:main";
 
 const runningSubagent = {
   id: "task-subagent",
@@ -25,6 +26,7 @@ const runningSubagent = {
   status: "running",
   title: "Map model routing code",
   agentId: "main",
+  ownerKey: chatSessionKey,
   childSessionKey: "agent:main:subagent:routing",
   createdAt: baseTime - 5_000,
   updatedAt: baseTime,
@@ -42,6 +44,7 @@ const queuedCron = {
   status: "queued",
   title: "Nightly cleanup",
   agentId: "main",
+  ownerKey: chatSessionKey,
   sessionKey: "agent:main:cron:cleanup",
   createdAt: baseTime - 10_000,
   updatedAt: baseTime - 1_000,
@@ -55,6 +58,7 @@ const finishedCli = {
   status: "failed",
   title: "Generate media index",
   agentId: "main",
+  ownerKey: chatSessionKey,
   sessionKey: "agent:main:cli:media",
   createdAt: baseTime - 30_000,
   updatedAt: baseTime - 20_000,
@@ -69,6 +73,7 @@ const runningExec = {
   status: "running",
   title: "CLI command",
   agentId: "main",
+  ownerKey: chatSessionKey,
   createdAt: baseTime - 2_000,
   updatedAt: baseTime,
   startedAt: baseTime - 2_000,
@@ -175,7 +180,8 @@ describeControlUiE2e("Control UI chat background-tasks rail mocked Gateway E2E",
       const listRequests = await gateway.getRequests("tasks.list");
       expect(listRequests.length).toBeGreaterThanOrEqual(2);
       for (const request of listRequests) {
-        expect((request.params as { agentId?: string }).agentId).toBe("main");
+        expect(request.params).toMatchObject({ sessionKey: "main" });
+        expect(request.params).not.toHaveProperty("agentId");
       }
       await page.screenshot({ path: path.join(artifactDir, "01-rail-open.png"), fullPage: true });
 

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -1713,7 +1713,7 @@ describe("chat composer workbench", () => {
 
   it("moves the background-tasks rail to a bottom strip on narrow panes", () => {
     const backgroundTasks = {
-      agentId: "main",
+      sessionKey: "agent:main:main",
       statusRowId: "chat-tasks-status-test",
       collapsed: false,
       narrowLayout: false,
@@ -1751,7 +1751,7 @@ describe("chat composer workbench", () => {
 
   it("shows the running-tasks status row after the turn settles, not while working", () => {
     const backgroundTasks = {
-      agentId: "main",
+      sessionKey: "agent:main:main",
       statusRowId: "chat-tasks-status-test",
       collapsed: true,
       narrowLayout: false,

--- a/ui/src/pages/chat/components/chat-background-tasks-concurrency.test.ts
+++ b/ui/src/pages/chat/components/chat-background-tasks-concurrency.test.ts
@@ -22,6 +22,7 @@ function makeTask(overrides: Partial<TaskSummary> & { id: string }): TaskSummary
     runtime: "subagent",
     agentId: "main",
     title: "Investigate concurrent sessions",
+    sessionKey: "agent:main:current",
     createdAt: 1_000,
     updatedAt: 2_000,
     startedAt: 1_500,
@@ -128,7 +129,11 @@ describe("background tasks concurrent snapshots", () => {
     handleBackgroundTasksEvent(refresh.host, test.event);
     handleBackgroundTasksEvent(refresh.host, {
       action: "upserted",
-      task: makeTask({ id: "task-other-agent", agentId: "writer", updatedAt: 4_000 }),
+      task: makeTask({
+        id: "task-other-session",
+        sessionKey: "agent:main:other",
+        updatedAt: 4_000,
+      }),
     });
     refresh.resolveActive({ tasks: test.stale });
     refresh.resolveRecent({ tasks: test.stale });

--- a/ui/src/pages/chat/components/chat-background-tasks.test.ts
+++ b/ui/src/pages/chat/components/chat-background-tasks.test.ts
@@ -30,6 +30,7 @@ function makeTask(overrides: Partial<TaskSummary> & { id: string }): TaskSummary
     runtime: "subagent",
     agentId: "main",
     title: "Map codebase",
+    sessionKey: "agent:main:current",
     createdAt: 1_000,
     updatedAt: 2_000,
     startedAt: 1_500,
@@ -73,11 +74,11 @@ afterEach(() => {
 });
 
 describe("background tasks rail state", () => {
-  it("loads agent-scoped tasks eagerly while the rail is collapsed", async () => {
+  it("loads session-scoped tasks eagerly while the rail is collapsed", async () => {
     const { host, request } = createHost({
       request: (method, params) => {
         expect(method).toBe("tasks.list");
-        expect((params as { agentId?: string }).agentId).toBe("main");
+        expect((params as { sessionKey?: string }).sessionKey).toBe("agent:main:current");
         return Promise.resolve({ tasks: [makeTask({ id: "task-1" })] });
       },
     });
@@ -141,19 +142,21 @@ describe("background tasks rail state", () => {
     expect(props.tasks?.map((task) => task.id)).toEqual(["task-1"]);
   });
 
-  it("keeps expansion across agent switches and reloads the new scope", async () => {
+  it("keeps expansion across session switches and reloads the new scope", async () => {
     const { host, request } = createHost();
     createBackgroundTasksProps(host, openSession).onToggleCollapsed();
     createBackgroundTasksProps(host, openSession);
     await flushAsync();
 
-    host.sessionKey = "agent:research:current";
+    host.sessionKey = "agent:main:another-thread";
     const props = createBackgroundTasksProps(host, openSession);
     expect(props.collapsed).toBe(false);
-    expect(props.agentId).toBe("research");
+    expect(props.sessionKey).toBe("agent:main:another-thread");
     expect(props.tasks).toBeNull();
     await flushAsync();
-    expect(request.mock.calls.at(-1)?.[1]).toMatchObject({ agentId: "research" });
+    expect(request.mock.calls.at(-1)?.[1]).toMatchObject({
+      sessionKey: "agent:main:another-thread",
+    });
   });
 
   it("surfaces cancellation refusals through the rail props", async () => {
@@ -458,27 +461,27 @@ describe("background tasks rail events", () => {
     });
   });
 
-  it("ignores upserts for other agents", async () => {
+  it("ignores upserts for other sessions, including the same agent", async () => {
     const { host } = await loadedHost([makeTask({ id: "task-1" })]);
 
     handleBackgroundTasksEvent(host, {
       action: "upserted",
-      task: makeTask({ id: "task-2", agentId: "other" }),
+      task: makeTask({ id: "task-2", sessionKey: "agent:main:another-thread" }),
     });
 
     const props = createBackgroundTasksProps(host, openSession);
     expect(props.tasks?.map((task) => task.id)).toEqual(["task-1"]);
   });
 
-  it("matches legacy tasks through their owner key like the gateway filter", async () => {
+  it("matches tasks through their owner key like the gateway filter", async () => {
     const { host } = await loadedHost([makeTask({ id: "task-1" })]);
 
     handleBackgroundTasksEvent(host, {
       action: "upserted",
       task: {
         ...makeTask({ id: "task-owner", updatedAt: 9_000 }),
-        agentId: undefined,
-        ownerKey: "agent:main:owner",
+        ownerKey: "agent:main:current",
+        sessionKey: "agent:main:child-task",
       },
     });
 
@@ -540,7 +543,7 @@ describe("background tasks rail rendering", () => {
     document.body.append(container);
     render(
       html`${renderBackgroundTasksRail({
-        agentId: "main",
+        sessionKey: "agent:main:current",
         statusRowId: "chat-tasks-status-test",
         collapsed: false,
         narrowLayout: false,
@@ -606,7 +609,7 @@ describe("background tasks rail rendering", () => {
     document.body.append(container);
     render(
       html`${renderBackgroundTasksRail({
-        agentId: "main",
+        sessionKey: "agent:main:current",
         statusRowId: "chat-tasks-status-test",
         collapsed: false,
         narrowLayout: false,
@@ -664,7 +667,7 @@ describe("background tasks rail rendering", () => {
     document.body.append(container);
     render(
       html`${renderBackgroundTasksRail({
-        agentId: "main",
+        sessionKey: "agent:main:current",
         statusRowId: "chat-tasks-status-test",
         collapsed: false,
         narrowLayout: false,
@@ -725,7 +728,7 @@ describe("background tasks rail rendering", () => {
     document.body.append(container);
     render(
       html`${renderBackgroundTasksRail({
-        agentId: "main",
+        sessionKey: "agent:main:current",
         statusRowId: "chat-tasks-status-test",
         collapsed: false,
         narrowLayout: false,
@@ -761,7 +764,7 @@ describe("background tasks rail rendering", () => {
     document.body.append(container);
     render(
       html`${renderBackgroundTasksRail({
-        agentId: "main",
+        sessionKey: "agent:main:current",
         statusRowId: "chat-tasks-status-test",
         collapsed: false,
         narrowLayout: false,
@@ -797,7 +800,7 @@ describe("background tasks rail rendering", () => {
 describe("running-tasks status row", () => {
   function makeProps(overrides: Partial<BackgroundTasksProps>): BackgroundTasksProps {
     return {
-      agentId: "main",
+      sessionKey: "agent:main:current",
       statusRowId: "chat-tasks-status-test",
       collapsed: true,
       narrowLayout: false,

--- a/ui/src/pages/chat/components/chat-background-tasks.ts
+++ b/ui/src/pages/chat/components/chat-background-tasks.ts
@@ -6,7 +6,8 @@ import { icons } from "../../../components/icons.ts";
 import "../../../components/tooltip.ts";
 import { t } from "../../../i18n/index.ts";
 import type { SessionScopeHost } from "../../../lib/sessions/index.ts";
-import { parseAgentSessionKey } from "../../../lib/sessions/session-key.ts";
+import { canonicalUiSessionKeyForPersistence } from "../../../lib/sessions/session-key.ts";
+import { normalizeOptionalString } from "../../../lib/string-coerce.ts";
 import {
   applyTaskEvent,
   isActiveTask,
@@ -23,7 +24,6 @@ import {
 import { renderTaskDetail, renderTaskRow } from "./chat-background-task-row.ts";
 import { newestTaskSnapshot } from "./chat-background-tasks-shared.ts";
 import type { BackgroundTasksProps } from "./chat-background-tasks.types.ts";
-import { paneSessionAgentId } from "./chat-session-workspace.ts";
 
 export { STATUS_TONES } from "./chat-background-tasks-shared.ts";
 export type { BackgroundTasksProps } from "./chat-background-tasks.types.ts";
@@ -34,12 +34,11 @@ type BackgroundTaskEventBuffer = {
   requestId: number;
   client: GatewayBrowserClient;
   connectionEpoch: number | undefined;
-  agentId: string;
+  sessionKey: string;
   events: BackgroundTaskLoadEvent[];
 };
 
 type BackgroundTasksState = {
-  agentId: string;
   cancellingTaskIds: Set<string>;
   collapsed: boolean;
   connectionClient: GatewayBrowserClient | null;
@@ -53,6 +52,7 @@ type BackgroundTasksState = {
   pendingTaskEvents: BackgroundTaskEventBuffer | null;
   pendingReload: boolean;
   requestId: number;
+  sessionKey: string;
   // wa-tooltip anchors by document id, so the status row's id must stay unique
   // per pane: two panes on the same agent would otherwise cross-anchor.
   statusRowId: string;
@@ -69,7 +69,6 @@ export type BackgroundTasksHost = {
   connected: boolean;
   connectionEpoch?: number;
   hello: GatewayHelloOk | null;
-  assistantAgentId?: string | null;
   agentsList?: SessionScopeHost["agentsList"];
   backgroundTasksState?: BackgroundTasksState;
   requestUpdate?: () => void;
@@ -84,10 +83,13 @@ const RECENT_TASKS_LIMIT = 100;
 let nextStatusRowId = 0;
 
 function getBackgroundTasksState(host: BackgroundTasksHost): BackgroundTasksState {
-  const agentId = paneSessionAgentId(host);
+  const sessionKey =
+    canonicalUiSessionKeyForPersistence(host, host.sessionKey) ||
+    normalizeOptionalString(host.sessionKey) ||
+    host.sessionKey;
   const current = host.backgroundTasksState;
   if (
-    current?.agentId === agentId &&
+    current?.sessionKey === sessionKey &&
     current.connectionClient === host.client &&
     current.connectionEpoch === host.connectionEpoch
   ) {
@@ -95,10 +97,9 @@ function getBackgroundTasksState(host: BackgroundTasksHost): BackgroundTasksStat
   }
   nextStatusRowId += 1;
   const next: BackgroundTasksState = {
-    agentId,
     cancellingTaskIds: new Set(),
-    // The pane is an agent-level view; keep the open/collapsed choice across
-    // agent switches and only reload the task list for the new scope.
+    // Keep presentation choices across thread switches while discarding all
+    // task data and private details from the previous session scope.
     collapsed: current?.collapsed ?? true,
     // The pane increments this epoch even when a reconnect reuses its client.
     // Old snapshots and private task details must never enter the new scope.
@@ -113,6 +114,7 @@ function getBackgroundTasksState(host: BackgroundTasksHost): BackgroundTasksStat
     pendingTaskEvents: null,
     pendingReload: false,
     requestId: 0,
+    sessionKey,
     statusRowId: `chat-tasks-status-${nextStatusRowId}`,
     tasks: null,
     selectedTaskId: null,
@@ -146,23 +148,23 @@ function loadBackgroundTasks(
     requestId,
     client,
     connectionEpoch: state.connectionEpoch,
-    agentId: state.agentId,
+    sessionKey: state.sessionKey,
     events: [],
   };
   state.pendingTaskEvents = eventBuffer;
   state.loading = true;
   state.error = null;
   state.pendingReload = false;
-  const agentId = state.agentId;
+  const sessionKey = state.sessionKey;
   void (async () => {
     try {
       const [activePayload, recentPayload] = await Promise.all([
         client.request("tasks.list", {
-          agentId,
+          sessionKey,
           status: ["queued", "running"],
           limit: ACTIVE_TASKS_LIMIT,
         }),
-        client.request("tasks.list", { agentId, limit: RECENT_TASKS_LIMIT }),
+        client.request("tasks.list", { sessionKey, limit: RECENT_TASKS_LIMIT }),
       ]);
       const active = normalizeTasksListResult(activePayload);
       const recent = normalizeTasksListResult(recentPayload);
@@ -217,16 +219,17 @@ function loadBackgroundTasks(
   })();
 }
 
-function taskMatchesAgentScope(task: TaskSummary, agentId: string): boolean {
-  // Mirrors the gateway's tasks.list agent filter: an explicit task agentId is
-  // authoritative; legacy records fall back to agent-style requester/child/
-  // owner keys. Dropping ownerKey here would make owner-scoped legacy rows
-  // load but never receive live event updates.
-  if (task.agentId) {
-    return task.agentId === agentId;
-  }
+function taskMatchesSessionScope(
+  host: BackgroundTasksHost,
+  task: TaskSummary,
+  sessionKey: string,
+): boolean {
+  // Mirror the gateway's session filter so requester, child, and owner views
+  // receive the same live events as their tasks.list snapshots.
   return [task.sessionKey, task.childSessionKey, task.ownerKey].some(
-    (key) => key !== undefined && parseAgentSessionKey(key)?.agentId === agentId,
+    (key) =>
+      canonicalUiSessionKeyForPersistence(host, key) === sessionKey ||
+      normalizeOptionalString(key) === sessionKey,
   );
 }
 
@@ -243,8 +246,8 @@ function bufferBackgroundTaskEvent(
     buffer.requestId !== state.requestId ||
     buffer.client !== host.client ||
     buffer.connectionEpoch !== host.connectionEpoch ||
-    buffer.agentId !== state.agentId ||
-    (event.action === "upserted" && !taskMatchesAgentScope(event.task, state.agentId))
+    buffer.sessionKey !== state.sessionKey ||
+    (event.action === "upserted" && !taskMatchesSessionScope(host, event.task, state.sessionKey))
   ) {
     return false;
   }
@@ -253,7 +256,7 @@ function bufferBackgroundTaskEvent(
 }
 
 /** Apply a gateway `task` event to the pane's snapshot. Events for other
- * agents are ignored; a registry restore forces a refetch. */
+ * sessions are ignored; a registry restore forces a refetch. */
 export function handleBackgroundTasksEvent(host: BackgroundTasksHost, payload: unknown) {
   const state = host.backgroundTasksState;
   if (
@@ -267,7 +270,7 @@ export function handleBackgroundTasksEvent(host: BackgroundTasksHost, payload: u
   if (!event) {
     return;
   }
-  if (event.action === "upserted" && !taskMatchesAgentScope(event.task, state.agentId)) {
+  if (event.action === "upserted" && !taskMatchesSessionScope(host, event.task, state.sessionKey)) {
     return;
   }
   const bufferedEvent = bufferBackgroundTaskEvent(host, state, event);
@@ -504,7 +507,7 @@ export function createBackgroundTasksProps(
     loadBackgroundTasks(host, state);
   }
   return {
-    agentId: state.agentId,
+    sessionKey: state.sessionKey,
     statusRowId: state.statusRowId,
     collapsed: state.collapsed,
     narrowLayout: opts.narrowLayout === true,
@@ -534,7 +537,7 @@ export function createBackgroundTasksProps(
 }
 
 /** Active-count badge shown on the collapsed-rail toggles; 0 until the task
- * list has loaded for the pane's agent. */
+ * list has loaded for the pane's session. */
 function backgroundTasksActiveCount(props: BackgroundTasksProps | undefined): number {
   return props?.tasks?.filter(isActiveTask).length ?? 0;
 }
@@ -637,7 +640,7 @@ export function renderBackgroundTasksRail(
             `
           : html`
               <div class="chat-tasks-rail__title">
-                <span class="chat-tasks-rail__eyebrow">${backgroundTasks.agentId}</span>
+                <span class="chat-tasks-rail__eyebrow">${backgroundTasks.sessionKey}</span>
                 <strong>${t("chat.backgroundTasks.title")}</strong>
               </div>
               <div class="chat-tasks-rail__actions">

--- a/ui/src/pages/chat/components/chat-background-tasks.types.ts
+++ b/ui/src/pages/chat/components/chat-background-tasks.types.ts
@@ -1,7 +1,7 @@
 import type { TaskSummary } from "../../../lib/tasks/data.ts";
 
 export type BackgroundTasksProps = {
-  agentId: string;
+  sessionKey: string;
   statusRowId: string;
   collapsed: boolean;
   /** Pane too narrow for a side rail: presentation moves to a bottom strip
@@ -11,7 +11,7 @@ export type BackgroundTasksProps = {
   canCancel: boolean;
   loading: boolean;
   error: string | null;
-  /** null until the first load for this agent finished. */
+  /** null until the first load for this session finished. */
   tasks: TaskSummary[] | null;
   selectedTaskId: string | null;
   taskDetails: ReadonlyMap<string, TaskSummary>;

--- a/ui/src/pages/chat/components/chat-session-workspace.ts
+++ b/ui/src/pages/chat/components/chat-session-workspace.ts
@@ -111,9 +111,8 @@ export type SessionWorkspaceHost = {
 };
 
 /** Agent owning the pane's current session: explicit key scope first, then the
- * assistant/default agent. Shared by the workspace and background-tasks rails
- * so both scope their gateway queries the same way. */
-export function paneSessionAgentId(state: SessionScopeHostWithKey): string {
+ * assistant/default agent. */
+function paneSessionAgentId(state: SessionScopeHostWithKey): string {
   const normalizedKey = normalizeOptionalString(state.sessionKey)?.toLowerCase();
   const activeAgentId =
     normalizedKey === "global" ? null : resolveAgentIdFromSessionKey(state.sessionKey);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users viewing background tasks in Chat would see tasks for the entire agent instead of only the current session/thread. Switching between two threads owned by the same agent could therefore show unrelated running and finished work.

## Why This Change Was Made

The chat rail now keys snapshots and live task events to the canonical chat session, and requests `tasks.list` with `sessionKey` rather than `agentId`. The gateway canonicalizes configured main-session aliases before filtering, so the UI's `main` alias still matches task records stored under `agent:<id>:<mainKey>`. The global Tasks page remains unchanged.

## User Impact

Each chat thread now shows only the background work associated with that thread, including requester-, child-, and owner-linked tasks, while other threads stay isolated.

AI-assisted change; implementation and proof were reviewed against the session-key and task-ledger contracts.

## Evidence

- `node scripts/run-vitest.mjs src/gateway/server-methods/tasks.test.ts ui/src/pages/chat/components/chat-background-tasks.test.ts ui/src/pages/chat/components/chat-background-tasks-concurrency.test.ts` — 48 tests passed.
- `node scripts/run-vitest.mjs ui/src/pages/chat/chat-view.test.ts` — 201 tests passed.
- Mocked Control UI browser E2E: `background-tasks.e2e.test.ts` — 2 tests passed; verifies both eager `tasks.list` requests carry the chat session key and no `agentId`, then exercises live completion and cancel UI.
- `node scripts/check-changed.mjs` — green for `core`, `coreTests`, and `ui`, including formatting, i18n, typecheck, lint, API/boundary, and guard lanes.
- `CI=1 pnpm build` — passed on the rebased PR head, including Control UI production build and performance checks.
- Autoreview found no accepted/actionable defect. One suggested blank-filter guard was rejected because `TasksListParamsSchema` validates `sessionKey` as `NonEmptyString` before the handler executes.

### Browser proof and limitation

- Mantis browser proof passed on exact head `f4d9615e18c`: [run 30250700926](https://github.com/openclaw/openclaw/actions/runs/30250700926), [screenshot](https://artifacts.openclaw.ai/mantis/web-ui-chat-proof/pr-114433/run-30250700926-1/web-ui-chat.png), and [video](https://artifacts.openclaw.ai/mantis/web-ui-chat-proof/pr-114433/run-30250700926-1/web-ui-chat.webm). The workflow published evidence successfully; its overall failure is only a 403 deleting the temporary workflow reaction.
- Limitation: the repository Mantis web-chat scenario uses a mocked Gateway and cannot create a real two-session task ledger. A real Crabbox/Testbox backend was unavailable in this environment. The closest contract proof is the focused gateway handler test, session/concurrency/live-event UI tests, mocked browser task flow, exact-head production build, and fully green exact-head CI.
