### PR TITLE
fix(windows): make scheduled task stop locale-independent

### DIFF
--- a/src/daemon/schtasks-control.ts
+++ b/src/daemon/schtasks-control.ts
@@ -28,6 +28,7 @@ import {
   assertSchtasksAvailable,
   hasScheduledTaskRunningEvidence,
   isRegisteredScheduledTask,
+  isScheduledTaskDefinitelyNotRunning,
   isStartupEntryInstalled,
   launchFallbackTaskScript,
   normalizeTaskResultCode,
@@ -181,10 +182,6 @@ export async function runScheduledTaskOrThrow(params: {
   return "direct-fallback";
 }
 
-function isTaskNotRunning(res: { stdout: string; stderr: string; code: number }): boolean {
-  return normalizeLowercaseStringOrEmpty(res.stderr || res.stdout).includes("not running");
-}
-
 function parseScheduledTaskXmlEnabled(output: string): boolean | null {
   const normalized = output.replace(/^\uFEFF/u, "").replaceAll(String.fromCharCode(0), "");
   const settings = /<Settings(?:\s[^>]*)?>([\s\S]*?)<\/Settings>/iu.exec(normalized)?.[1];
@@ -280,7 +277,7 @@ export async function stopScheduledTask({
   }
   const taskName = resolveTaskName(effectiveEnv);
   const res = await execSchtasks(["/End", "/TN", taskName]);
-  if (res.code !== 0 && !isTaskNotRunning(res)) {
+  if (res.code !== 0 && !isScheduledTaskDefinitelyNotRunning(taskName)) {
     throw new Error(`schtasks end failed: ${res.stderr || res.stdout}`.trim());
   }
   reportMutation("schtasks-stop");

--- a/src/daemon/schtasks-runtime.ts
+++ b/src/daemon/schtasks-runtime.ts
@@ -317,12 +317,17 @@ export async function resolveFallbackRuntime(
   };
 }
 
-export function probeScheduledTaskExists(taskName: string): boolean | null {
+type ScheduledTaskStateProbe =
+  | { status: "found"; state: number | null }
+  | { status: "missing" }
+  | { status: "unknown" };
+
+function probeScheduledTaskState(taskName: string): ScheduledTaskStateProbe {
   const encodedTaskName = Buffer.from(taskName, "utf8").toString("base64");
   const script = [
     "$ErrorActionPreference='Stop'",
     `$taskName=[Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('${encodedTaskName}'))`,
-    "try { $service=New-Object -ComObject 'Schedule.Service'; $service.Connect(); $null=$service.GetFolder('\\').GetTask($taskName); exit 0 } catch { $exception=$_.Exception; while($null -ne $exception.InnerException){$exception=$exception.InnerException}; [Console]::Out.Write($exception.HResult); exit 1 }",
+    "try { $service=New-Object -ComObject 'Schedule.Service'; $service.Connect(); $task=$service.GetFolder('\\').GetTask($taskName); [Console]::Out.Write([int]$task.State); exit 0 } catch { $exception=$_.Exception; while($null -ne $exception.InnerException){$exception=$exception.InnerException}; [Console]::Out.Write($exception.HResult); exit 1 }",
   ].join("; ");
   const probe = spawnSync(
     getWindowsPowerShellExePath(),
@@ -335,14 +340,35 @@ export function probeScheduledTaskExists(taskName: string): boolean | null {
     { encoding: "utf8", timeout: 5_000, windowsHide: true },
   );
   if (probe.error) {
-    return null;
+    return { status: "unknown" };
   }
   if (probe.status === 0) {
-    return true;
+    const rawState = probe.stdout.trim();
+    const state = /^\d+$/.test(rawState) ? Number.parseInt(rawState, 10) : null;
+    return {
+      status: "found",
+      state,
+    };
   }
   const hresult = Number.parseInt(probe.stdout.trim(), 10);
   // Only the locale-independent missing task/folder HRESULT values prove absence.
-  return hresult === -2147024894 || hresult === -2147024893 ? false : null;
+  return hresult === -2147024894 || hresult === -2147024893
+    ? { status: "missing" }
+    : { status: "unknown" };
+}
+
+export function probeScheduledTaskExists(taskName: string): boolean | null {
+  const probe = probeScheduledTaskState(taskName);
+  return probe.status === "found" ? true : probe.status === "missing" ? false : null;
+}
+
+export function isScheduledTaskDefinitelyNotRunning(taskName: string): boolean {
+  const probe = probeScheduledTaskState(taskName);
+  if (probe.status !== "found") {
+    return false;
+  }
+  // TASK_STATE_DISABLED and TASK_STATE_READY both prove no instance is queued or running.
+  return probe.state === 1 || probe.state === 3;
 }
 
 export async function readWindowsStartupFallbackRuntimeForUpdate(

--- a/src/daemon/schtasks.stop.test.ts
+++ b/src/daemon/schtasks.stop.test.ts
@@ -105,6 +105,18 @@ function expectGatewayTermination(pid: number) {
   expect(killProcessTree).toHaveBeenCalledWith(pid, { graceMs: 300 });
 }
 
+function setTaskStateProbeResult(state: number) {
+  const stdout = String(state);
+  spawnSync.mockReturnValueOnce({
+    pid: 0,
+    output: [null, stdout, ""],
+    stdout,
+    stderr: "",
+    status: 0,
+    signal: null,
+  });
+}
+
 async function withPreparedGatewayTask(
   run: (context: { env: Record<string, string>; stdout: PassThrough }) => Promise<void>,
 ) {
@@ -335,6 +347,99 @@ describe("Scheduled Task stop/restart cleanup", () => {
       );
     });
   });
+
+  it.each([
+    { state: 1, label: "disabled" },
+    { state: 3, label: "ready" },
+  ])("accepts a localized /End failure when COM proves the task is $label", async ({ state }) => {
+    await withPreparedGatewayTask(async ({ env, stdout }) => {
+      const onMutation = vi.fn();
+      schtasksResponses.push(
+        { ...SUCCESS_RESPONSE },
+        { ...SUCCESS_RESPONSE },
+        {
+          code: 1,
+          stdout: "",
+          stderr: "FEHLER: Die Aufgabe wird derzeit nicht ausgeführt.",
+        },
+      );
+      setTaskStateProbeResult(state);
+
+      await expect(stopScheduledTask({ env, stdout, onMutation })).resolves.toBeUndefined();
+
+      expect(schtasksCalls).toEqual([
+        ["/Query"],
+        ["/Query", "/TN", "OpenClaw Gateway"],
+        ["/End", "/TN", "OpenClaw Gateway"],
+      ]);
+      expect(spawnSync).toHaveBeenCalledOnce();
+      expect(onMutation).toHaveBeenCalledWith({ mode: "schtasks-stop" });
+    });
+  });
+
+  it.each([
+    { state: 0, label: "unknown" },
+    { state: 2, label: "queued" },
+    { state: 4, label: "running" },
+  ])("fails closed after a localized /End failure when the task is $label", async ({ state }) => {
+    await withPreparedGatewayTask(async ({ env, stdout }) => {
+      const onMutation = vi.fn();
+      schtasksResponses.push(
+        { ...SUCCESS_RESPONSE },
+        { ...SUCCESS_RESPONSE },
+        {
+          code: 1,
+          stdout: "",
+          stderr: "FEHLER: Die Aufgabe konnte nicht beendet werden.",
+        },
+      );
+      setTaskStateProbeResult(state);
+
+      await expect(stopScheduledTask({ env, stdout, onMutation })).rejects.toThrow(
+        "schtasks end failed: FEHLER: Die Aufgabe konnte nicht beendet werden.",
+      );
+
+      expect(spawnSync).toHaveBeenCalledOnce();
+      expect(onMutation).not.toHaveBeenCalled();
+    });
+  });
+
+  it.each([
+    { label: "malformed", status: 0, probeOutput: "3 trailing output" },
+    { label: "missing", status: 1, probeOutput: "-2147024894" },
+    { label: "unavailable", status: 1, probeOutput: "-2147024891" },
+  ])(
+    "fails closed after a localized /End failure when the state probe is $label",
+    async ({ status, probeOutput }) => {
+      await withPreparedGatewayTask(async ({ env, stdout }) => {
+        const onMutation = vi.fn();
+        schtasksResponses.push(
+          { ...SUCCESS_RESPONSE },
+          { ...SUCCESS_RESPONSE },
+          {
+            code: 1,
+            stdout: "",
+            stderr: "FEHLER: Der Aufgabenstatus ist nicht verfügbar.",
+          },
+        );
+        spawnSync.mockReturnValueOnce({
+          pid: 0,
+          output: [null, probeOutput, ""],
+          stdout: probeOutput,
+          stderr: "",
+          status,
+          signal: null,
+        });
+
+        await expect(stopScheduledTask({ env, stdout, onMutation })).rejects.toThrow(
+          "schtasks end failed: FEHLER: Der Aufgabenstatus ist nicht verfügbar.",
+        );
+
+        expect(spawnSync).toHaveBeenCalledOnce();
+        expect(onMutation).not.toHaveBeenCalled();
+      });
+    },
+  );
 
   it("kills lingering verified gateway listeners after schtasks stop", async () => {
     await withPreparedGatewayTask(async ({ env, stdout }) => {


### PR DESCRIPTION
[AI-assisted]
## What Problem This Solves

On non-English Windows installations, stopping an already idle OpenClaw Scheduled Task can fail because the nonzero `schtasks /End` response is accepted only when its localized output contains the English phrase `not running`. The localized error is otherwise propagated even when Task Scheduler proves that no task instance is queued or running.

## Why This Change Was Made

After a nonzero `/End` result, the stop path now queries the registered task through the existing PowerShell/Task Scheduler COM boundary and uses its numeric state instead of display text. It continues only for DISABLED or READY and remains fail-closed for UNKNOWN, QUEUED, RUNNING, missing tasks, malformed output, and probe failures.

### Root Cause

The previous guard parsed localized command output at the service-control layer. Windows already exposes a locale-independent integer through [`RegisteredTask.State`](https://learn.microsoft.com/en-us/windows/win32/taskschd/registeredtask-state), backed by the documented [`TASK_STATE`](https://learn.microsoft.com/en-us/windows/win32/api/taskschd/ne-taskschd-task_state) enum, so the existing COM existence probe was extended to return that state.

## User Impact

Windows users can stop or update OpenClaw reliably on localized systems when the registered task is already inactive. Real or ambiguous stop failures remain visible instead of being mistaken for a successful stop.

## Evidence

### Provenance

- **Base:** `b937638d8b5aedba129cb7525494f46bcbd27dbb`
- **Proof head:** `b953fc8538ac7cf142109eafebc55f1cdb454ebb`
- **Revalidated:** on the bound base

### Direct behavior

- **Native Windows production stop (MEASURED)** — Observed: An isolated, harmless ONLOGON proof task was created and disabled on localized German Windows. COM reported numeric state `1` (DISABLED). The exact production bundle built from the proof head was then imported with native Windows Node 24.18.0 and `stopScheduledTask` resolved with mutation `{ "mode": "schtasks-stop" }` and sanitized output `Stopped Scheduled Task: <proof-task>`. Result: The production stop path exited `0`, COM still reported state `1`, and the proof task was deleted with absence confirmed afterward. Proves the committed stop implementation runs end-to-end across native Windows Task Scheduler, the built production module, mutation reporting, and user-visible output. Preserves the fixture never ran an OpenClaw command, used a unique task identity, did not touch any existing task or gateway, and was removed immediately after proof.
- **Native Windows scheduler behavior (MEASURED)** — Observed: Direct `schtasks /End` calls against isolated READY (`3`) and DISABLED (`1`) fixtures returned localized success with exit `0` on this Windows version; the numeric COM state remained unchanged. Result: The host exercised the native success branch rather than emitting the older localized nonzero not-running response. Proves the live Windows result and its branch selection are recorded instead of inferring that the compatibility fallback ran. Preserves the nonzero compatibility branch remains independently covered by focused tests, and the direct proof makes no unsupported claim about reproducing it on this host.

### Automated verification

#### Focused stop behavior

```bash
pnpm exec vitest run src/daemon/schtasks.stop.test.ts
```

- `pnpm exec vitest run src/daemon/schtasks.stop.test.ts` — 28 tests passed. Proves localized nonzero `/End` results convert to success for DISABLED and READY while UNKNOWN, QUEUED, RUNNING, missing, malformed, and unavailable states fail closed. Preserves mutation reporting and cleanup begin only after a successful `/End` or a proven inactive state.

#### Scheduled Task regression suite

```bash
pnpm exec vitest run src/daemon/schtasks.stop.test.ts src/daemon/schtasks.test.ts src/daemon/schtasks.install.test.ts src/daemon/schtasks.startup-fallback.test.ts src/daemon/schtasks-exec.test.ts
```

- `pnpm exec vitest run src/daemon/schtasks.stop.test.ts src/daemon/schtasks.test.ts src/daemon/schtasks.install.test.ts src/daemon/schtasks.startup-fallback.test.ts src/daemon/schtasks-exec.test.ts` — 139 tests passed across five files. Proves the state-probe refactor integrates with install, stop, startup-fallback, execution, and runtime behavior. Preserves successful stop, startup-folder fallback, task existence, and restart behavior remain covered.

#### Changed-scope validation

```bash
OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 pnpm check:changed
```

- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 pnpm check:changed` — all selected core and core-test checks completed successfully. Proves the committed production and test changes pass formatting, guardrails, Core typecheck, Core test typecheck, lint, and import-cycle validation. Preserves repository-wide changed-scope contracts and static boundaries.

#### Production build

```bash
pnpm build
```

- `pnpm build` — completed successfully. Proves the exact proof head produces the production JavaScript bundle used by the native Windows runtime proof. Preserves the runtime observation is bound to built PR code rather than a source-only harness.

### Preserved boundaries

- A successful `schtasks /End` response does not launch the COM fallback probe.
- Only TASK_STATE_DISABLED and TASK_STATE_READY can convert a nonzero `/End` response into idempotent success.
- TASK_STATE_UNKNOWN, TASK_STATE_QUEUED, TASK_STATE_RUNNING, missing tasks, malformed state output, and probe failures still throw before mutation reporting or cleanup.
- The existing task-existence caller retains its `true`, `false`, or unknown contract.
- The Task Scheduler COM query is read-only, and the task name remains base64-encoded across the PowerShell command boundary.

### Proof gap

A live compatibility-branch run was not run because this Windows version returns exit `0` when `/End` targets both READY and DISABLED tasks; the isolated run therefore could not naturally reproduce a localized nonzero `/End` response. That branch is covered by the focused fault-injection tests against numeric states `1`, `3`, `0`, `2`, and `4`, plus missing, malformed, and unavailable probe results; the native run separately proves the built production stop path and real COM state surface.

### Artifacts

- None attached.

### Maintainer refresh (July 27, 2026)

- **Final refreshed base:** `1af330548a6441adde0f20a718624eafe7ac0d2a`
- **Final refreshed head:** `ef311323e43`
- `node scripts/run-vitest.mjs src/daemon/schtasks.stop.test.ts src/daemon/schtasks.test.ts src/daemon/schtasks.install.test.ts src/daemon/schtasks.startup-fallback.test.ts src/daemon/schtasks-exec.test.ts` — 139 tests passed on the final head.
- `oxfmt`, targeted `oxlint`, and `git diff --check` passed on the final head.
- Fresh Codex autoreview on the final branch diff: no accepted/actionable findings; correctness confidence 0.93.
- Testbox changed-scope core/core-test validation passed against base `1a5d71ee6bb` before four disjoint PRs landed; the final rebase touched only unrelated CLI, gateway, infra update-check, and UI files, and the scheduler-focused suite was rerun afterward.
- The prior `checks-node-compact-small-7` failure was an unrelated 30-second timeout in `src/cli/help-exit.process.test.ts`; the rerun on refreshed head `bddc9dbe5a4` passed, including `checks-windows-node-test`.