### PR TITLE
refactor(gateway): consolidate chat history integration tests

### DIFF
--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -36,6 +36,44 @@ import {
 import { agentCommand } from "./test-helpers.runtime-state.js";
 import { installConnectedControlUiServerSuite } from "./test-with-server.js";
 
+function createGatewayHistoryText(role: "user" | "assistant", text: unknown, timestamp: number) {
+  return { role, content: [{ type: "text", text }], timestamp };
+}
+
+function createGatewayHistoryMessageToolCall(
+  id: string,
+  args: Record<string, unknown>,
+  timestamp: number,
+) {
+  return {
+    role: "assistant",
+    content: [{ type: "toolCall", id, name: "message", arguments: args }],
+    timestamp,
+  };
+}
+
+function createGatewayHistoryMessageToolResult(id: string, content: unknown, timestamp: number) {
+  return { role: "toolResult", toolName: "message", toolCallId: id, content, timestamp };
+}
+
+function createGatewayHistoryDeliveryMirror(text: unknown, timestamp: number) {
+  return {
+    role: "assistant",
+    provider: "openclaw",
+    model: "delivery-mirror",
+    content: [{ type: "text", text }],
+    timestamp,
+  };
+}
+
+function hasGatewayHistoryMessageToolMirror(message: unknown) {
+  return Boolean(
+    message &&
+    typeof message === "object" &&
+    (message as { openclawMessageToolMirror?: unknown }).openclawMessageToolMirror,
+  );
+}
+
 installGatewayTestHooks({ scope: "suite" });
 const CHAT_RESPONSE_TIMEOUT_MS = 10_000;
 
@@ -64,32 +102,16 @@ describe("gateway server chat", () => {
   };
 
   const buildNoReplyHistoryFixture = (includeMixedAssistant = false) => [
-    {
-      role: "user",
-      content: [{ type: "text", text: "hello" }],
-      timestamp: 1,
-    },
-    {
-      role: "assistant",
-      content: [{ type: "text", text: "NO_REPLY" }],
-      timestamp: 2,
-    },
-    {
-      role: "assistant",
-      content: [{ type: "text", text: "real reply" }],
-      timestamp: 3,
-    },
+    createGatewayHistoryText("user", "hello", 1),
+    createGatewayHistoryText("assistant", "NO_REPLY", 2),
+    createGatewayHistoryText("assistant", "real reply", 3),
     {
       role: "assistant",
       text: "real text field reply",
       content: "NO_REPLY",
       timestamp: 4,
     },
-    {
-      role: "user",
-      content: [{ type: "text", text: "NO_REPLY" }],
-      timestamp: 5,
-    },
+    createGatewayHistoryText("user", "NO_REPLY", 5),
     ...(includeMixedAssistant
       ? [
           {
@@ -1085,70 +1107,75 @@ describe("gateway server chat", () => {
   test("chat.history mirrors current-session message tool sends before NO_REPLY", async () => {
     const replyText = "Here, love. Eva, not Evo.";
     const historyMessages = await loadChatHistoryWithMessages([
-      {
-        role: "user",
-        content: [{ type: "text", text: "Evo, you there?" }],
-        timestamp: 1,
-      },
-      {
-        role: "assistant",
-        content: [
-          {
-            type: "toolCall",
-            id: "call-message-1",
-            name: "message",
-            arguments: {
-              action: "send",
-              message: replyText,
-            },
-          },
-        ],
-        timestamp: 2,
-      },
-      {
-        role: "toolResult",
-        toolName: "message",
-        toolCallId: "call-message-1",
-        content: { ok: true, messageId: "24268", chatId: "8455538490" },
-        timestamp: 3,
-      },
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "NO_REPLY" }],
-        timestamp: 4,
-      },
+      createGatewayHistoryText("user", "Evo, you there?", 1),
+      createGatewayHistoryMessageToolCall(
+        "call-message-1",
+        { action: "send", message: replyText },
+        2,
+      ),
+      createGatewayHistoryMessageToolResult(
+        "call-message-1",
+        { ok: true, messageId: "24268", chatId: "8455538490" },
+        3,
+      ),
+      createGatewayHistoryText("assistant", "NO_REPLY", 4),
     ]);
 
     expect(collectHistoryTextValues(historyMessages)).toEqual(["Evo, you there?", replyText]);
-    expect(
-      historyMessages.some((message) => {
-        if (!message || typeof message !== "object") {
-          return false;
-        }
-        const entry = message as { role?: unknown; openclawMessageToolMirror?: unknown };
-        return entry.role === "assistant" && Boolean(entry.openclawMessageToolMirror);
-      }),
-    ).toBe(true);
+    expect(historyMessages.some(hasGatewayHistoryMessageToolMirror)).toBe(true);
+  });
+
+  test.each([
+    {
+      name: "chat.history mirrors message success encoded in a result text block",
+      content: [{ type: "text", text: JSON.stringify({ ok: true, messageId: "text-result" }) }],
+      visible: true,
+    },
+    {
+      name: "chat.history mirrors message success encoded in a result content block",
+      content: [
+        { type: "message", content: JSON.stringify({ ok: true, messageId: "content-result" }) },
+      ],
+      visible: true,
+    },
+    {
+      name: "chat.history hides suppressed delivery encoded in a result text block",
+      content: [{ type: "text", text: JSON.stringify({ ok: true, deliveryStatus: "suppressed" }) }],
+      visible: false,
+    },
+    {
+      name: "chat.history hides dry-run delivery encoded in a result content block",
+      content: [{ type: "message", content: JSON.stringify({ ok: true, dryRun: true }) }],
+      visible: false,
+    },
+  ])("$name", async ({ content, visible }) => {
+    const replyText = "Nested message-tool reply.";
+    const historyMessages = await loadChatHistoryWithMessages([
+      createGatewayHistoryMessageToolCall(
+        "call-message-nested-result",
+        { action: "send", message: replyText },
+        1,
+      ),
+      createGatewayHistoryMessageToolResult("call-message-nested-result", content, 2),
+      createGatewayHistoryText("assistant", "NO_REPLY", 3),
+    ]);
+
+    const resultText = content.flatMap((block) => ("text" in block ? [block.text] : []));
+    expect(collectHistoryTextValues(historyMessages)).toEqual([
+      ...resultText,
+      ...(visible ? [replyText] : []),
+    ]);
+    expect(historyMessages.some(hasGatewayHistoryMessageToolMirror)).toBe(visible);
   });
 
   test("chat.history marks message-tool replies held for internal source delivery", async () => {
     const replyText = "Forward this source reply.";
     const historyMessages = await loadChatHistoryWithMessages([
-      {
-        role: "assistant",
-        content: [
-          {
-            type: "toolCall",
-            id: "call-message-internal-source",
-            name: "message",
-            arguments: {
-              action: "send",
-              message: replyText,
-            },
-          },
-        ],
-        timestamp: 1,
-      },
+      createGatewayHistoryMessageToolCall(
+        "call-message-internal-source",
+        { action: "send", message: replyText },
+        1,
+      ),
       {
         role: "toolResult",
         toolName: "message",
@@ -1161,11 +1188,7 @@ describe("gateway server chat", () => {
         },
         timestamp: 2,
       },
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "NO_REPLY" }],
-        timestamp: 3,
-      },
+      createGatewayHistoryText("assistant", "NO_REPLY", 3),
     ]);
 
     const visibleAssistantMessages = historyMessages.filter((message) => {
@@ -1192,56 +1215,23 @@ describe("gateway server chat", () => {
   test("chat.history hides raw delivery-mirror rows but keeps message-tool mirrors", async () => {
     const replyText = "One visible send.";
     const historyMessages = await loadChatHistoryWithMessages([
-      {
-        role: "user",
-        content: [{ type: "text", text: "send once" }],
-        timestamp: 1,
-      },
-      {
-        role: "assistant",
-        content: [
-          {
-            type: "toolCall",
-            id: "call-message-transcript-only",
-            name: "message",
-            arguments: {
-              action: "send",
-              message: replyText,
-            },
-          },
-        ],
-        timestamp: 2,
-      },
-      {
-        role: "toolResult",
-        toolName: "message",
-        toolCallId: "call-message-transcript-only",
-        content: { ok: true, messageId: "24271", chatId: "current-run" },
-        timestamp: 3,
-      },
-      {
-        role: "assistant",
-        provider: "openclaw",
-        model: "delivery-mirror",
-        content: [{ type: "text", text: replyText }],
-        timestamp: 4,
-      },
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "NO_REPLY" }],
-        timestamp: 5,
-      },
+      createGatewayHistoryText("user", "send once", 1),
+      createGatewayHistoryMessageToolCall(
+        "call-message-transcript-only",
+        { action: "send", message: replyText },
+        2,
+      ),
+      createGatewayHistoryMessageToolResult(
+        "call-message-transcript-only",
+        { ok: true, messageId: "24271", chatId: "current-run" },
+        3,
+      ),
+      createGatewayHistoryDeliveryMirror(replyText, 4),
+      createGatewayHistoryText("assistant", "NO_REPLY", 5),
     ]);
 
     expect(collectHistoryTextValues(historyMessages)).toEqual(["send once", replyText]);
-    expect(
-      historyMessages.some(
-        (message) =>
-          Boolean(message) &&
-          typeof message === "object" &&
-          Boolean((message as { openclawMessageToolMirror?: unknown }).openclawMessageToolMirror),
-      ),
-    ).toBe(true);
+    expect(historyMessages.some(hasGatewayHistoryMessageToolMirror)).toBe(true);
     expect(historyMessages).not.toContainEqual(
       expect.objectContaining({ provider: "openclaw", model: "delivery-mirror" }),
     );
@@ -1250,46 +1240,21 @@ describe("gateway server chat", () => {
   test("chat.history keeps message-tool mirrors before silent completion rows", async () => {
     const replyText = "Visible before completion.";
     const historyMessages = await loadChatHistoryWithMessages([
-      {
-        role: "assistant",
-        content: [
-          {
-            type: "toolCall",
-            id: "call-message-before-completion",
-            name: "message",
-            arguments: {
-              action: "send",
-              message: replyText,
-            },
-          },
-        ],
-        timestamp: 1,
-      },
-      {
-        role: "toolResult",
-        toolName: "message",
-        toolCallId: "call-message-before-completion",
-        content: { ok: true, messageId: "24272", chatId: "current-run" },
-        timestamp: 2,
-      },
-      {
-        role: "assistant",
-        provider: "openclaw",
-        model: "delivery-mirror",
-        content: [{ type: "text", text: replyText }],
-        timestamp: 3,
-      },
+      createGatewayHistoryMessageToolCall(
+        "call-message-before-completion",
+        { action: "send", message: replyText },
+        1,
+      ),
+      createGatewayHistoryMessageToolResult(
+        "call-message-before-completion",
+        { ok: true, messageId: "24272", chatId: "current-run" },
+        2,
+      ),
+      createGatewayHistoryDeliveryMirror(replyText, 3),
     ]);
 
     expect(collectHistoryTextValues(historyMessages)).toEqual([replyText]);
-    expect(
-      historyMessages.some(
-        (message) =>
-          Boolean(message) &&
-          typeof message === "object" &&
-          Boolean((message as { openclawMessageToolMirror?: unknown }).openclawMessageToolMirror),
-      ),
-    ).toBe(true);
+    expect(historyMessages.some(hasGatewayHistoryMessageToolMirror)).toBe(true);
     expect(historyMessages).not.toContainEqual(
       expect.objectContaining({ provider: "openclaw", model: "delivery-mirror" }),
     );
@@ -1298,46 +1263,21 @@ describe("gateway server chat", () => {
   test("chat.history hides delivery mirrors that precede successful tool results", async () => {
     const replyText = "Visible after result.";
     const historyMessages = await loadChatHistoryWithMessages([
-      {
-        role: "assistant",
-        content: [
-          {
-            type: "toolCall",
-            id: "call-message-before-result",
-            name: "message",
-            arguments: {
-              action: "send",
-              message: replyText,
-            },
-          },
-        ],
-        timestamp: 1,
-      },
-      {
-        role: "assistant",
-        provider: "openclaw",
-        model: "delivery-mirror",
-        content: [{ type: "text", text: replyText }],
-        timestamp: 2,
-      },
-      {
-        role: "toolResult",
-        toolName: "message",
-        toolCallId: "call-message-before-result",
-        content: { ok: true, messageId: "24273", chatId: "current-run" },
-        timestamp: 3,
-      },
+      createGatewayHistoryMessageToolCall(
+        "call-message-before-result",
+        { action: "send", message: replyText },
+        1,
+      ),
+      createGatewayHistoryDeliveryMirror(replyText, 2),
+      createGatewayHistoryMessageToolResult(
+        "call-message-before-result",
+        { ok: true, messageId: "24273", chatId: "current-run" },
+        3,
+      ),
     ]);
 
     expect(collectHistoryTextValues(historyMessages)).toEqual([replyText]);
-    expect(
-      historyMessages.some(
-        (message) =>
-          Boolean(message) &&
-          typeof message === "object" &&
-          Boolean((message as { openclawMessageToolMirror?: unknown }).openclawMessageToolMirror),
-      ),
-    ).toBe(true);
+    expect(historyMessages.some(hasGatewayHistoryMessageToolMirror)).toBe(true);
     expect(historyMessages).not.toContainEqual(
       expect.objectContaining({ provider: "openclaw", model: "delivery-mirror" }),
     );
@@ -1371,45 +1311,22 @@ describe("gateway server chat", () => {
         ],
         timestamp: 1,
       },
-      {
-        role: "toolResult",
-        toolName: "message",
-        toolCallId: "call-message-first",
-        content: { ok: true, messageId: "24274", chatId: "current-run" },
-        timestamp: 2,
-      },
-      {
-        role: "assistant",
-        provider: "openclaw",
-        model: "delivery-mirror",
-        content: [{ type: "text", text: firstText }],
-        timestamp: 3,
-      },
-      {
-        role: "toolResult",
-        toolName: "message",
-        toolCallId: "call-message-second",
-        content: { ok: true, messageId: "24275", chatId: "current-run" },
-        timestamp: 4,
-      },
-      {
-        role: "assistant",
-        provider: "openclaw",
-        model: "delivery-mirror",
-        content: [{ type: "text", text: secondText }],
-        timestamp: 5,
-      },
+      createGatewayHistoryMessageToolResult(
+        "call-message-first",
+        { ok: true, messageId: "24274", chatId: "current-run" },
+        2,
+      ),
+      createGatewayHistoryDeliveryMirror(firstText, 3),
+      createGatewayHistoryMessageToolResult(
+        "call-message-second",
+        { ok: true, messageId: "24275", chatId: "current-run" },
+        4,
+      ),
+      createGatewayHistoryDeliveryMirror(secondText, 5),
     ]);
 
     expect(collectHistoryTextValues(historyMessages)).toEqual([firstText, secondText]);
-    expect(
-      historyMessages.filter(
-        (message) =>
-          Boolean(message) &&
-          typeof message === "object" &&
-          Boolean((message as { openclawMessageToolMirror?: unknown }).openclawMessageToolMirror),
-      ),
-    ).toHaveLength(2);
+    expect(historyMessages.filter(hasGatewayHistoryMessageToolMirror)).toHaveLength(2);
     expect(historyMessages).not.toContainEqual(
       expect.objectContaining({ provider: "openclaw", model: "delivery-mirror" }),
     );
@@ -1417,13 +1334,7 @@ describe("gateway server chat", () => {
 
   test("chat.history keeps standalone delivery-mirror rows", async () => {
     const historyMessages = await loadChatHistoryWithMessages([
-      {
-        role: "assistant",
-        provider: "openclaw",
-        model: "delivery-mirror",
-        content: [{ type: "text", text: "standalone delivered reply" }],
-        timestamp: 1,
-      },
+      createGatewayHistoryDeliveryMirror("standalone delivered reply", 1),
     ]);
 
     expect(collectHistoryTextValues(historyMessages)).toEqual(["standalone delivered reply"]);
@@ -1432,126 +1343,59 @@ describe("gateway server chat", () => {
   test("chat.history mirrors current-session message tool sends with channel hints", async () => {
     const replyText = "Still the current chat.";
     const historyMessages = await loadChatHistoryWithMessages([
-      {
-        role: "user",
-        content: [{ type: "text", text: "reply here" }],
-        timestamp: 1,
-      },
-      {
-        role: "assistant",
-        content: [
-          {
-            type: "toolCall",
-            id: "call-message-channel-hint",
-            name: "message",
-            arguments: {
-              action: "send",
-              channel: "telegram",
-              message: replyText,
-            },
-          },
-        ],
-        timestamp: 2,
-      },
-      {
-        role: "toolResult",
-        toolName: "message",
-        toolCallId: "call-message-channel-hint",
-        content: { ok: true, messageId: "24270", chatId: "current-run" },
-        timestamp: 3,
-      },
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "NO_REPLY" }],
-        timestamp: 4,
-      },
+      createGatewayHistoryText("user", "reply here", 1),
+      createGatewayHistoryMessageToolCall(
+        "call-message-channel-hint",
+        { action: "send", channel: "telegram", message: replyText },
+        2,
+      ),
+      createGatewayHistoryMessageToolResult(
+        "call-message-channel-hint",
+        { ok: true, messageId: "24270", chatId: "current-run" },
+        3,
+      ),
+      createGatewayHistoryText("assistant", "NO_REPLY", 4),
     ]);
 
     expect(collectHistoryTextValues(historyMessages)).toEqual(["reply here", replyText]);
-    expect(
-      historyMessages.some(
-        (message) =>
-          Boolean(message) &&
-          typeof message === "object" &&
-          Boolean((message as { openclawMessageToolMirror?: unknown }).openclawMessageToolMirror),
-      ),
-    ).toBe(true);
+    expect(historyMessages.some(hasGatewayHistoryMessageToolMirror)).toBe(true);
   });
 
   test("chat.history does not mirror explicitly routed message tool sends", async () => {
     const historyMessages = await loadChatHistoryWithMessages([
-      {
-        role: "user",
-        content: [{ type: "text", text: "send that elsewhere" }],
-        timestamp: 1,
-      },
-      {
-        role: "assistant",
-        content: [
-          {
-            type: "toolCall",
-            id: "call-message-remote",
-            name: "message",
-            arguments: {
-              action: "send",
-              to: "8455538490",
-              message: "Remote-only reply",
-            },
-          },
-        ],
-        timestamp: 2,
-      },
-      {
-        role: "toolResult",
-        toolName: "message",
-        toolCallId: "call-message-remote",
-        content: { ok: true, messageId: "24269", chatId: "8455538490" },
-        timestamp: 3,
-      },
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "NO_REPLY" }],
-        timestamp: 4,
-      },
+      createGatewayHistoryText("user", "send that elsewhere", 1),
+      createGatewayHistoryMessageToolCall(
+        "call-message-remote",
+        { action: "send", to: "8455538490", message: "Remote-only reply" },
+        2,
+      ),
+      createGatewayHistoryMessageToolResult(
+        "call-message-remote",
+        { ok: true, messageId: "24269", chatId: "8455538490" },
+        3,
+      ),
+      createGatewayHistoryText("assistant", "NO_REPLY", 4),
     ]);
 
     expect(collectHistoryTextValues(historyMessages)).toEqual(["send that elsewhere"]);
-    expect(
-      historyMessages.some(
-        (message) =>
-          Boolean(message) &&
-          typeof message === "object" &&
-          Boolean((message as { openclawMessageToolMirror?: unknown }).openclawMessageToolMirror),
-      ),
-    ).toBe(false);
+    expect(historyMessages.some(hasGatewayHistoryMessageToolMirror)).toBe(false);
   });
 
   test("chat.history keeps confirmed current-source sends before a later final", async () => {
     const sourceReply = "Visible reply delivered to Telegram.";
     const laterFinal = "A later run produced this different final.";
     const historyMessages = await loadChatHistoryWithMessages([
-      {
-        role: "user",
-        content: [{ type: "text", text: "reply in this Telegram chat" }],
-        timestamp: 1,
-      },
-      {
-        role: "assistant",
-        content: [
-          {
-            type: "toolCall",
-            id: "call-message-current-source",
-            name: "message",
-            arguments: {
-              action: "send",
-              channel: "telegram",
-              target: "8455538490",
-              message: sourceReply,
-            },
-          },
-        ],
-        timestamp: 2,
-      },
+      createGatewayHistoryText("user", "reply in this Telegram chat", 1),
+      createGatewayHistoryMessageToolCall(
+        "call-message-current-source",
+        {
+          action: "send",
+          channel: "telegram",
+          target: "8455538490",
+          message: sourceReply,
+        },
+        2,
+      ),
       {
         role: "toolResult",
         toolName: "message",
@@ -1565,21 +1409,9 @@ describe("gateway server chat", () => {
         },
         timestamp: 3,
       },
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "NO_REPLY" }],
-        timestamp: 4,
-      },
-      {
-        role: "user",
-        content: [{ type: "text", text: "continue" }],
-        timestamp: 5,
-      },
-      {
-        role: "assistant",
-        content: [{ type: "text", text: laterFinal }],
-        timestamp: 6,
-      },
+      createGatewayHistoryText("assistant", "NO_REPLY", 4),
+      createGatewayHistoryText("user", "continue", 5),
+      createGatewayHistoryText("assistant", laterFinal, 6),
     ]);
 
     expect(collectHistoryTextValues(historyMessages)).toEqual([
@@ -1601,27 +1433,12 @@ describe("gateway server chat", () => {
 
   test("chat.history does not mirror suppressed current-source sends", async () => {
     const historyMessages = await loadChatHistoryWithMessages([
-      {
-        role: "user",
-        content: [{ type: "text", text: "reply here" }],
-        timestamp: 1,
-      },
-      {
-        role: "assistant",
-        content: [
-          {
-            type: "toolCall",
-            id: "call-message-suppressed-current-source",
-            name: "message",
-            arguments: {
-              action: "send",
-              target: "8455538490",
-              message: "Must not appear",
-            },
-          },
-        ],
-        timestamp: 2,
-      },
+      createGatewayHistoryText("user", "reply here", 1),
+      createGatewayHistoryMessageToolCall(
+        "call-message-suppressed-current-source",
+        { action: "send", target: "8455538490", message: "Must not appear" },
+        2,
+      ),
       {
         role: "toolResult",
         toolName: "message",
@@ -1635,11 +1452,7 @@ describe("gateway server chat", () => {
         },
         timestamp: 3,
       },
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "NO_REPLY" }],
-        timestamp: 4,
-      },
+      createGatewayHistoryText("assistant", "NO_REPLY", 4),
     ]);
 
     expect(collectHistoryTextValues(historyMessages)).toEqual(["reply here"]);
@@ -1647,119 +1460,54 @@ describe("gateway server chat", () => {
 
   test("chat.history does not mirror message tool sends from unmatched results", async () => {
     const historyMessages = await loadChatHistoryWithMessages([
-      {
-        role: "user",
-        content: [{ type: "text", text: "reply here" }],
-        timestamp: 1,
-      },
-      {
-        role: "assistant",
-        content: [
-          {
-            type: "toolCall",
-            id: "call-message-expected",
-            name: "message",
-            arguments: {
-              action: "send",
-              message: "Should wait for matching result.",
-            },
-          },
-        ],
-        timestamp: 2,
-      },
+      createGatewayHistoryText("user", "reply here", 1),
+      createGatewayHistoryMessageToolCall(
+        "call-message-expected",
+        { action: "send", message: "Should wait for matching result." },
+        2,
+      ),
       {
         role: "toolResult",
         content: { ok: true, messageId: "wrong-result" },
         timestamp: 3,
       },
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "NO_REPLY" }],
-        timestamp: 4,
-      },
+      createGatewayHistoryText("assistant", "NO_REPLY", 4),
     ]);
 
     expect(collectHistoryTextValues(historyMessages)).toEqual(["reply here"]);
-    expect(
-      historyMessages.some(
-        (message) =>
-          Boolean(message) &&
-          typeof message === "object" &&
-          Boolean((message as { openclawMessageToolMirror?: unknown }).openclawMessageToolMirror),
-      ),
-    ).toBe(false);
+    expect(historyMessages.some(hasGatewayHistoryMessageToolMirror)).toBe(false);
   });
 
   test("chat.history does not mirror dry-run message tool sends", async () => {
     const historyMessages = await loadChatHistoryWithMessages([
-      {
-        role: "user",
-        content: [{ type: "text", text: "preview that" }],
-        timestamp: 1,
-      },
-      {
-        role: "assistant",
-        content: [
-          {
-            type: "toolCall",
-            id: "call-message-dry-run",
-            name: "message",
-            arguments: {
-              action: "send",
-              dryRun: true,
-              message: "Preview-only reply",
-            },
-          },
-        ],
-        timestamp: 2,
-      },
-      {
-        role: "toolResult",
-        toolName: "message",
-        toolCallId: "call-message-dry-run",
-        content: {
-          ok: true,
-          dryRun: true,
-          deliveryStatus: "dry_run",
-        },
-        timestamp: 3,
-      },
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "NO_REPLY" }],
-        timestamp: 4,
-      },
+      createGatewayHistoryText("user", "preview that", 1),
+      createGatewayHistoryMessageToolCall(
+        "call-message-dry-run",
+        { action: "send", dryRun: true, message: "Preview-only reply" },
+        2,
+      ),
+      createGatewayHistoryMessageToolResult(
+        "call-message-dry-run",
+        { ok: true, dryRun: true, deliveryStatus: "dry_run" },
+        3,
+      ),
+      createGatewayHistoryText("assistant", "NO_REPLY", 4),
     ]);
 
     expect(collectHistoryTextValues(historyMessages)).toEqual(["preview that"]);
-    expect(
-      historyMessages.some(
-        (message) =>
-          Boolean(message) &&
-          typeof message === "object" &&
-          Boolean((message as { openclawMessageToolMirror?: unknown }).openclawMessageToolMirror),
-      ),
-    ).toBe(false);
+    expect(historyMessages.some(hasGatewayHistoryMessageToolMirror)).toBe(false);
   });
 
   test("chat.history hides commentary-only assistant entries", async () => {
     const historyMessages = await loadChatHistoryWithMessages([
-      {
-        role: "user",
-        content: [{ type: "text", text: "hello" }],
-        timestamp: 1,
-      },
+      createGatewayHistoryText("user", "hello", 1),
       {
         role: "assistant",
         phase: "commentary",
         content: [{ type: "text", text: "thinking like caveman" }],
         timestamp: 2,
       },
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "real reply" }],
-        timestamp: 3,
-      },
+      createGatewayHistoryText("assistant", "real reply", 3),
     ]);
 
     expect(collectHistoryTextValues(historyMessages)).toEqual(["hello", "real reply"]);
@@ -1767,27 +1515,15 @@ describe("gateway server chat", () => {
 
   test("chat.history hides assistant announce/reply skip-only entries", async () => {
     const historyMessages = await loadChatHistoryWithMessages([
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "ANNOUNCE_SKIP" }],
-        timestamp: 1,
-      },
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "REPLY_SKIP" }],
-        timestamp: 2,
-      },
+      createGatewayHistoryText("assistant", "ANNOUNCE_SKIP", 1),
+      createGatewayHistoryText("assistant", "REPLY_SKIP", 2),
       {
         role: "assistant",
         text: "real text field reply",
         content: "ANNOUNCE_SKIP",
         timestamp: 3,
       },
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "real reply" }],
-        timestamp: 4,
-      },
+      createGatewayHistoryText("assistant", "real reply", 4),
     ]);
     const roleAndText = historyMessages
       .map((message) => {


### PR DESCRIPTION
## What Problem This Solves

Gateway chat-history tests still hand-built the same text, message-tool call, tool-result, delivery-mirror, and mirror-detection fixtures across many cases. That duplication made the suite harder to audit and left four already-supported nested result shapes without direct owner-suite coverage.

## Why This Change Was Made

Rebuild the useful part of the stale refactor on current `main`: keep the fixtures local to the owning Gateway suite, reuse them across the existing history cases, and retain every current assertion and scenario. The already-modernized `gateway-server-chat-b` suite is deliberately untouched.

The four added rows cover message-tool success encoded in nested `text` and `content` blocks plus suppressed and dry-run nested results. Production already handles these forms; the regression here was absent coverage, not broken runtime behavior.

## User Impact

No shipped behavior changes. Maintainers keep every current Gateway regression, gain four direct nested-result cases, and maintain 264 fewer lines of test code.

## Evidence

- Baseline owner suite on current `main`: `node scripts/run-vitest.mjs src/gateway/server.chat.gateway-server-chat.test.ts` — 1 file passed, 51 tests passed; wrapper passed in 48.45s.
- Candidate owner suite on exact head: the same command — 1 file passed, 55 tests passed; wrapper passed in 91.51s including 61s waiting for the shared local test lock.
- Explicit case-presence audit: baseline `0/4`; candidate `4/4` for the four named nested-result rows.
- `node scripts/check-changed.mjs` — passed on Blacksmith Testbox with core-test typecheck, formatting, 245-rule lint, dependency/boundary guards, and zero warnings or errors. Testbox lease `tbx_01kzk1a8t9ws6j9vvv9n51e7j3`; [Actions run](https://github.com/openclaw/openclaw/actions/runs/31308594843).
- Codex-backed autoreview: clean after one round; no accepted/actionable findings.
- `git diff --check` — passed.
- Scope: one Gateway test file, production `+0/-0`, tests `+229/-493` (net `-264`).

ClawSweeper rank-up moves are addressed: the branch was rebuilt on current `main`, all four nested-result regressions are present in the current fixture structure, and the exact-head focused/Testbox evidence is linked above.
