### PR TITLE
refactor(gateway): derive the agent core-files list from the canonical workspace set

### DIFF
--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -186,13 +186,21 @@ async function loadTemplate(name: string): Promise<string> {
   }
 }
 
-export type WorkspaceBootstrapFileName =
-  | typeof DEFAULT_AGENTS_FILENAME
-  | typeof DEFAULT_SOUL_FILENAME
-  | typeof DEFAULT_IDENTITY_FILENAME
-  | typeof DEFAULT_USER_FILENAME
-  | typeof DEFAULT_BOOTSTRAP_FILENAME
-  | typeof DEFAULT_MEMORY_FILENAME;
+/**
+ * Canonical bootstrap filenames in prompt order. Single source for the runtime
+ * validation set, the name union, and the Control UI core-files list; a private
+ * copy anywhere else silently drifts when a file is retired.
+ */
+export const WORKSPACE_BOOTSTRAP_FILENAMES = [
+  DEFAULT_AGENTS_FILENAME,
+  DEFAULT_SOUL_FILENAME,
+  DEFAULT_IDENTITY_FILENAME,
+  DEFAULT_USER_FILENAME,
+  DEFAULT_BOOTSTRAP_FILENAME,
+  DEFAULT_MEMORY_FILENAME,
+] as const;
+
+export type WorkspaceBootstrapFileName = (typeof WORKSPACE_BOOTSTRAP_FILENAMES)[number];
 
 export type WorkspaceBootstrapFile = {
   name: WorkspaceBootstrapFileName;
@@ -220,14 +228,7 @@ export type WorkspacePatternFile = {
 };
 
 /** Set of recognized bootstrap filenames for runtime validation */
-const VALID_BOOTSTRAP_NAMES: ReadonlySet<string> = new Set([
-  DEFAULT_AGENTS_FILENAME,
-  DEFAULT_SOUL_FILENAME,
-  DEFAULT_IDENTITY_FILENAME,
-  DEFAULT_USER_FILENAME,
-  DEFAULT_BOOTSTRAP_FILENAME,
-  DEFAULT_MEMORY_FILENAME,
-]);
+const VALID_BOOTSTRAP_NAMES: ReadonlySet<string> = new Set(WORKSPACE_BOOTSTRAP_FILENAMES);
 
 const OPTIONAL_BOOTSTRAP_FILENAMES: ReadonlySet<string> = new Set([
   DEFAULT_SOUL_FILENAME,

--- a/src/gateway/server-methods/agents-mutate.test.ts
+++ b/src/gateway/server-methods/agents-mutate.test.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { AgentDeletionAuthorityRollbackError } from "../../agents/agent-lifecycle-registry.js";
+import { WORKSPACE_BOOTSTRAP_FILENAMES } from "../../agents/workspace.js";
 import { FsSafeError } from "../../infra/fs-safe.js";
 /* ------------------------------------------------------------------ */
 /* Mocks                                                              */
@@ -2942,6 +2943,21 @@ describe("agents.files.list", () => {
   it("does not expose retired HEARTBEAT.md workspace files", async () => {
     const names = await listAgentFileNames();
     expect(names).not.toContain("HEARTBEAT.md");
+  });
+
+  // Pins the derivation: a private copy of this list in the gateway is what let a
+  // retired file linger in the Control UI as a permanently-missing tab.
+  it("lists exactly the canonical workspace bootstrap filenames", async () => {
+    const names = await listAgentFileNames();
+    expect(names).toStrictEqual([...WORKSPACE_BOOTSTRAP_FILENAMES]);
+  });
+
+  it("lists the canonical filenames without BOOTSTRAP.md once setup completed", async () => {
+    mocks.isWorkspaceSetupCompleted.mockResolvedValue(true);
+    const names = await listAgentFileNames();
+    expect(names).toStrictEqual(
+      WORKSPACE_BOOTSTRAP_FILENAMES.filter((name) => name !== "BOOTSTRAP.md"),
+    );
   });
 
   it("rejects writes to retired HEARTBEAT.md workspace files", async () => {

--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -56,14 +56,11 @@ import {
   prepareWorkspaceStateDeletion,
 } from "../../agents/workspace-state-store.js";
 import {
-  DEFAULT_AGENTS_FILENAME,
   DEFAULT_BOOTSTRAP_FILENAME,
   DEFAULT_IDENTITY_FILENAME,
-  DEFAULT_MEMORY_FILENAME,
-  DEFAULT_SOUL_FILENAME,
-  DEFAULT_USER_FILENAME,
   ensureAgentWorkspace,
   isWorkspaceSetupCompleted,
+  WORKSPACE_BOOTSTRAP_FILENAMES,
 } from "../../agents/workspace.js";
 import { applyAgentConfig } from "../../commands/agents.config.js";
 import {
@@ -102,14 +99,10 @@ import {
 import { loadOptionalServerMethodModelCatalog } from "./optional-model-catalog.js";
 import type { GatewayRequestHandlers, RespondFn } from "./types.js";
 
-const BOOTSTRAP_FILE_NAMES = [
-  DEFAULT_AGENTS_FILENAME,
-  DEFAULT_SOUL_FILENAME,
-  DEFAULT_IDENTITY_FILENAME,
-  DEFAULT_USER_FILENAME,
-  DEFAULT_BOOTSTRAP_FILENAME,
-] as const;
-const BOOTSTRAP_FILE_NAMES_POST_ONBOARDING = BOOTSTRAP_FILE_NAMES.filter(
+// Derived from the canonical workspace list so retiring a bootstrap file cannot
+// leave the Control UI advertising a file the runtime no longer reads.
+const CORE_FILE_NAMES = WORKSPACE_BOOTSTRAP_FILENAMES;
+const CORE_FILE_NAMES_POST_ONBOARDING = CORE_FILE_NAMES.filter(
   (name) => name !== DEFAULT_BOOTSTRAP_FILENAME,
 );
 
@@ -138,10 +131,8 @@ export const testing = {
   },
 };
 
-const MEMORY_FILE_NAMES = [DEFAULT_MEMORY_FILENAME] as const;
-
 // Gateway file mutations are intentionally capped to the workspace files the UI owns.
-const ALLOWED_FILE_NAMES = new Set<string>([...BOOTSTRAP_FILE_NAMES, ...MEMORY_FILE_NAMES]);
+const ALLOWED_FILE_NAMES = new Set<string>(CORE_FILE_NAMES);
 
 function resolveAgentWorkspaceFileOrRespondError(
   params: Record<string, unknown>,
@@ -252,10 +243,7 @@ async function listAgentFiles(workspaceDir: string, options?: { hideBootstrap?: 
   const workspaceRoot = await openWorkspaceRootSafely(workspaceDir);
   if (!workspaceRoot) {
     // Keep the UI shape stable when the workspace path is missing or unsafe.
-    const missingNames = [
-      ...(options?.hideBootstrap ? BOOTSTRAP_FILE_NAMES_POST_ONBOARDING : BOOTSTRAP_FILE_NAMES),
-      DEFAULT_MEMORY_FILENAME,
-    ];
+    const missingNames = options?.hideBootstrap ? CORE_FILE_NAMES_POST_ONBOARDING : CORE_FILE_NAMES;
     return missingNames.map((name) => ({
       name,
       path: path.join(workspaceDir, name),
@@ -263,10 +251,8 @@ async function listAgentFiles(workspaceDir: string, options?: { hideBootstrap?: 
     }));
   }
 
-  const bootstrapFileNames = options?.hideBootstrap
-    ? BOOTSTRAP_FILE_NAMES_POST_ONBOARDING
-    : BOOTSTRAP_FILE_NAMES;
-  for (const name of bootstrapFileNames) {
+  const coreFileNames = options?.hideBootstrap ? CORE_FILE_NAMES_POST_ONBOARDING : CORE_FILE_NAMES;
+  for (const name of coreFileNames) {
     const filePath = path.join(workspaceDir, name);
     const meta = await statWorkspaceFileSafely(workspaceRoot, workspaceDir, name);
     if (meta) {
@@ -280,27 +266,6 @@ async function listAgentFiles(workspaceDir: string, options?: { hideBootstrap?: 
     } else {
       files.push({ name, path: filePath, missing: true });
     }
-  }
-
-  const primaryMeta = await statWorkspaceFileSafely(
-    workspaceRoot,
-    workspaceDir,
-    DEFAULT_MEMORY_FILENAME,
-  );
-  if (primaryMeta) {
-    files.push({
-      name: DEFAULT_MEMORY_FILENAME,
-      path: path.join(workspaceDir, DEFAULT_MEMORY_FILENAME),
-      missing: false,
-      size: primaryMeta.size,
-      updatedAtMs: primaryMeta.updatedAtMs,
-    });
-  } else {
-    files.push({
-      name: DEFAULT_MEMORY_FILENAME,
-      path: path.join(workspaceDir, DEFAULT_MEMORY_FILENAME),
-      missing: true,
-    });
   }
 
   return files;


### PR DESCRIPTION
## What Problem This Solves

The Control UI's **Agents → Files** list was maintained separately from the workspace bootstrap set the runtime actually reads, so the two could drift silently. That drift is what produced #113621: `HEARTBEAT.md` had been retired from the runtime, but the gateway kept its own copy of the filename list, so the editor rendered a `HEARTBEAT` tab that was permanently badged **MISSING** and could never be satisfied.

Fixing that instance did not fix the class. Before this change `main` still defined the same fact three times:

- `BOOTSTRAP_FILE_NAMES` in `src/gateway/server-methods/agents.ts` (gateway's private copy)
- `VALID_BOOTSTRAP_NAMES` in `src/agents/workspace.ts` (runtime validation)
- the `WorkspaceBootstrapFileName` union (types)

Retiring a file meant remembering all three. The gateway copy is the one that drifted last time.

## Why This Change Was Made

One exported canonical list, `WORKSPACE_BOOTSTRAP_FILENAMES`, in prompt order. The validation set is now `new Set(...)` over it, the name union is `(typeof ...)[number]`, and the gateway imports it instead of keeping its own. A future retirement is a one-line edit in one place, and the Control UI cannot advertise a file the runtime no longer reads.

Because `MEMORY.md` is last in the canonical order, `listAgentFiles` no longer needs its separate unrolled stat/push block — the existing loop covers it. That removed ~20 duplicated lines plus `MEMORY_FILE_NAMES` and three imports that lost their only consumers.

No behavior change: the list content and its order are identical, and `BOOTSTRAP.md` is still hidden once workspace setup has completed.

## User Impact

None visible. This is a structural change that makes the previous papercut unrepresentable rather than fixed-once.

## Evidence

Two new tests pin the derivation, which is the part that matters — the pre-existing coverage only asserted that one specific retired filename was absent, so it verified a symptom already noticed rather than the invariant:

- `agents.files.list` returns **exactly** `WORKSPACE_BOOTSTRAP_FILENAMES`
- with setup completed, exactly that list minus `BOOTSTRAP.md`

Reintroducing a private copy in the gateway now fails these.

```text
src/gateway/server-methods/agents-mutate    92 tests passed (was 90)
src/agents/workspace                        80 tests passed + 2
tsgo -p tsconfig.core.json                  clean
```

`git diff --numstat`: production **net −34 lines**, tests net +16.


### Live before/after proof

Real gateway `agents.files.list` RPC on both commits against the **same** seeded workspace
(`AGENTS.md`, `SOUL.md`, `IDENTITY.md`, `USER.md`, `MEMORY.md` present; `BOOTSTRAP.md` deliberately
absent to exercise the `missing: true` shape). Session-owned gateway, isolated `OPENCLAW_STATE_DIR`,
ephemeral port, paths redacted.

Because this is a consolidation with no intended behavior change, the meaningful claim is that the
response is unchanged — so the "before" side is the evidence, not a formality.

Pre-onboarding — identical on `origin/main@4029070c3dc` and head `48ca2c4499f`:

```json
[{"name":"AGENTS.md","missing":false},
 {"name":"SOUL.md","missing":false},
 {"name":"IDENTITY.md","missing":false},
 {"name":"USER.md","missing":false},
 {"name":"BOOTSTRAP.md","missing":true},
 {"name":"MEMORY.md","missing":false}]
```

Post-onboarding — identical on both, `BOOTSTRAP.md` correctly dropped:

```json
[{"name":"AGENTS.md","missing":false},
 {"name":"SOUL.md","missing":false},
 {"name":"IDENTITY.md","missing":false},
 {"name":"USER.md","missing":false},
 {"name":"MEMORY.md","missing":false}]
```

Both variants match element-for-element including order, which also confirms that folding the
removed unrolled `MEMORY.md` block into the shared loop preserved its trailing position.

### Guard-run failures on this head were infrastructure

Five check failures across two rounds were all GitHub-side, not code, and are green after re-run
with no code change:

- `actionlint`, `no-tabs` — exit 124 during git checkout: `checkout fetch ... timed out on attempt 1;
  retrying`, then attempt 2, then `fetch-pack: unexpected disconnect while reading sideband packet`.
  Neither linter executed. This PR touches no workflow files.
- `check-guards` — exit 124 wall-clock timeout after a retried `pnpm install`; every check it reached
  passed first (`242 declaration contracts match`, `tool-display snapshot is up to date`,
  `[dup:check] target coverage ok`).
- `security-sensitive-guard-detect` — GitHub's own API returned
  `500 Internal Server Error: Sorry, this diff is temporarily unavailable due to heavy server load.`
- `openclaw/ci-gate` — downstream of the above.

Current state: `failing=0`, `openclaw/ci-gate` SUCCESS.
