### PR TITLE
test(providers): consolidate Fal and xAI contract fixtures

### DIFF
--- a/extensions/fal/image-generation-provider.test.ts
+++ b/extensions/fal/image-generation-provider.test.ts
@@ -9,6 +9,24 @@ const { fetchWithSsrFGuardMock } = vi.hoisted(() => ({
 import { buildFalImageGenerationProvider } from "./image-generation-provider.js";
 import { setFalFetchGuardForTesting } from "./test-support.js";
 
+type FalImageRequest = Parameters<
+  ReturnType<typeof buildFalImageGenerationProvider>["generateImage"]
+>[0];
+
+type FalValidationCase = {
+  name: string;
+  request: Omit<FalImageRequest, "provider" | "cfg">;
+  error: string;
+  expectsNoFetch?: true;
+};
+
+function falReferenceImages(count: number): NonNullable<FalImageRequest["inputImages"]> {
+  return Array.from({ length: count }, () => ({
+    buffer: Buffer.from("ref"),
+    mimeType: "image/png",
+  }));
+}
+
 function expectFalJsonPost(params: { call: number; url: string; body: Record<string, unknown> }) {
   const request = fetchWithSsrFGuardMock.mock.calls[params.call - 1]?.[0];
   if (!request) {
@@ -33,9 +51,33 @@ function expectFalDownload(params: { call: number; url: string; timeoutMs?: numb
   });
 }
 
+function mockFalGeneratedImage(fileName: string, data: string): void {
+  fetchWithSsrFGuardMock
+    .mockResolvedValueOnce({
+      response: new Response(
+        JSON.stringify({ images: [{ url: `https://v3.fal.media/files/example/${fileName}` }] }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+      release: vi.fn(async () => {}),
+    })
+    .mockResolvedValueOnce({
+      response: new Response(Buffer.from(data), {
+        status: 200,
+        headers: { "content-type": "image/png" },
+      }),
+      release: vi.fn(async () => {}),
+    });
+}
+
 describe("fal image-generation provider", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
+      apiKey: "fal-test-key",
+      source: "env",
+      mode: "api-key",
+    });
+    setFalFetchGuardForTesting(fetchWithSsrFGuardMock);
   });
 
   afterEach(() => {
@@ -74,12 +116,6 @@ describe("fal image-generation provider", () => {
   });
 
   it("generates image buffers from the fal sync API", async () => {
-    vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
-      apiKey: "fal-test-key",
-      source: "env",
-      mode: "api-key",
-    });
-    setFalFetchGuardForTesting(fetchWithSsrFGuardMock);
     const releaseRequest = vi.fn(async () => {});
     const releaseDownload = vi.fn(async () => {});
     fetchWithSsrFGuardMock
@@ -216,12 +252,6 @@ describe("fal image-generation provider", () => {
   });
 
   it("releases a timed-out generated image download", async () => {
-    vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
-      apiKey: "fal-test-key",
-      source: "env",
-      mode: "api-key",
-    });
-    setFalFetchGuardForTesting(fetchWithSsrFGuardMock);
     const releaseDownload = vi.fn(async () => {});
     fetchWithSsrFGuardMock
       .mockResolvedValueOnce({
@@ -257,12 +287,6 @@ describe("fal image-generation provider", () => {
   });
 
   it("rejects generated image downloads that exceed the configured media cap", async () => {
-    vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
-      apiKey: "fal-test-key",
-      source: "env",
-      mode: "api-key",
-    });
-    setFalFetchGuardForTesting(fetchWithSsrFGuardMock);
     fetchWithSsrFGuardMock
       .mockResolvedValueOnce({
         response: new Response(
@@ -296,12 +320,6 @@ describe("fal image-generation provider", () => {
   });
 
   it("wraps wrong-shape successful fal image responses", async () => {
-    vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
-      apiKey: "fal-test-key",
-      source: "env",
-      mode: "api-key",
-    });
-    setFalFetchGuardForTesting(fetchWithSsrFGuardMock);
     fetchWithSsrFGuardMock.mockResolvedValueOnce({
       response: new Response(
         JSON.stringify({ images: { url: "https://example.test/image.png" } }),
@@ -325,32 +343,7 @@ describe("fal image-generation provider", () => {
   });
 
   it("uses image-to-image endpoint and data-uri input for edits", async () => {
-    vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
-      apiKey: "fal-test-key",
-      source: "env",
-      mode: "api-key",
-    });
-    setFalFetchGuardForTesting(fetchWithSsrFGuardMock);
-    fetchWithSsrFGuardMock
-      .mockResolvedValueOnce({
-        response: new Response(
-          JSON.stringify({
-            images: [{ url: "https://v3.fal.media/files/example/edited.png" }],
-          }),
-          {
-            status: 200,
-            headers: { "Content-Type": "application/json" },
-          },
-        ),
-        release: vi.fn(async () => {}),
-      })
-      .mockResolvedValueOnce({
-        response: new Response(Buffer.from("edited-data"), {
-          status: 200,
-          headers: { "content-type": "image/png" },
-        }),
-        release: vi.fn(async () => {}),
-      });
+    mockFalGeneratedImage("edited.png", "edited-data");
 
     const provider = buildFalImageGenerationProvider();
     await provider.generateImage({
@@ -382,32 +375,7 @@ describe("fal image-generation provider", () => {
   });
 
   it("routes GPT Image 2 edits through /edit with image_urls", async () => {
-    vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
-      apiKey: "fal-test-key",
-      source: "env",
-      mode: "api-key",
-    });
-    setFalFetchGuardForTesting(fetchWithSsrFGuardMock);
-    fetchWithSsrFGuardMock
-      .mockResolvedValueOnce({
-        response: new Response(
-          JSON.stringify({
-            images: [{ url: "https://v3.fal.media/files/example/gpt-edited.png" }],
-          }),
-          {
-            status: 200,
-            headers: { "Content-Type": "application/json" },
-          },
-        ),
-        release: vi.fn(async () => {}),
-      })
-      .mockResolvedValueOnce({
-        response: new Response(Buffer.from("gpt-edited-data"), {
-          status: 200,
-          headers: { "content-type": "image/png" },
-        }),
-        release: vi.fn(async () => {}),
-      });
+    mockFalGeneratedImage("gpt-edited.png", "gpt-edited-data");
 
     const provider = buildFalImageGenerationProvider();
     await provider.generateImage({
@@ -439,32 +407,7 @@ describe("fal image-generation provider", () => {
   });
 
   it("allows GPT Image 2 edits up to 10 reference images", async () => {
-    vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
-      apiKey: "fal-test-key",
-      source: "env",
-      mode: "api-key",
-    });
-    setFalFetchGuardForTesting(fetchWithSsrFGuardMock);
-    fetchWithSsrFGuardMock
-      .mockResolvedValueOnce({
-        response: new Response(
-          JSON.stringify({
-            images: [{ url: "https://v3.fal.media/files/example/gpt-edited.png" }],
-          }),
-          {
-            status: 200,
-            headers: { "Content-Type": "application/json" },
-          },
-        ),
-        release: vi.fn(async () => {}),
-      })
-      .mockResolvedValueOnce({
-        response: new Response(Buffer.from("gpt-edited-data"), {
-          status: 200,
-          headers: { "content-type": "image/png" },
-        }),
-        release: vi.fn(async () => {}),
-      });
+    mockFalGeneratedImage("gpt-edited.png", "gpt-edited-data");
 
     const inputImages = Array.from({ length: 10 }, (_, index) => ({
       buffer: Buffer.from(`ref-${index + 1}`),
@@ -494,57 +437,133 @@ describe("fal image-generation provider", () => {
     });
   });
 
-  it("rejects GPT Image 2 edits above 10 reference images", async () => {
-    vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
-      apiKey: "fal-test-key",
-      source: "env",
-      mode: "api-key",
-    });
-    setFalFetchGuardForTesting(fetchWithSsrFGuardMock);
-
-    const provider = buildFalImageGenerationProvider();
-    await expect(
-      provider.generateImage({
-        provider: "fal",
+  it.each([
+    {
+      name: "rejects GPT Image 2 edits above 10 reference images",
+      request: {
         model: "openai/gpt-image-2",
         prompt: "too many references",
-        cfg: {},
-        inputImages: Array.from({ length: 11 }, () => ({
-          buffer: Buffer.from("ref"),
-          mimeType: "image/png",
-        })),
-      }),
-    ).rejects.toThrow("fal GPT Image edit supports at most 10 reference images");
-    expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
-  });
+        inputImages: falReferenceImages(11),
+      },
+      error: "fal GPT Image edit supports at most 10 reference images",
+      expectsNoFetch: true,
+    },
+    {
+      name: "rejects Krea-only aspect ratios for Nano Banana 2",
+      request: {
+        model: "fal-ai/nano-banana-2",
+        prompt: "unsupported ratio",
+        aspectRatio: "2.35:1",
+      },
+      error: "fal Nano Banana 2 supports aspectRatio values",
+      expectsNoFetch: true,
+    },
+    {
+      name: "rejects Krea-only aspect ratios for Nano Banana 2 Lite",
+      request: {
+        model: "google/nano-banana-2-lite",
+        prompt: "unsupported ratio",
+        aspectRatio: "2.35:1",
+      },
+      error: "fal Nano Banana 2 Lite supports aspectRatio values",
+      expectsNoFetch: true,
+    },
+    {
+      name: "rejects Nano Banana 2 Lite edits above 14 reference images",
+      request: {
+        model: "google/nano-banana-2-lite",
+        prompt: "too many references",
+        inputImages: falReferenceImages(15),
+      },
+      error: "fal Nano Banana 2 Lite supports at most 14 reference images",
+      expectsNoFetch: true,
+    },
+    {
+      name: "rejects 4K resolution for Grok Imagine edits",
+      request: {
+        model: "xai/grok-imagine-image",
+        prompt: "too big",
+        aspectRatio: "1:1",
+        resolution: "4K",
+        inputImages: [{ buffer: Buffer.from("src"), mimeType: "image/png" }],
+      },
+      error: "fal Grok Imagine supports resolution values: 1K, 2K",
+      expectsNoFetch: true,
+    },
+    {
+      name: "rejects Nano Banana ratios for Grok Imagine",
+      request: {
+        model: "xai/grok-imagine-image",
+        prompt: "unsupported ratio",
+        aspectRatio: "21:9",
+      },
+      error: "fal Grok Imagine supports aspectRatio values",
+      expectsNoFetch: true,
+    },
+    {
+      name: "rejects Grok Imagine edits above 3 reference images",
+      request: {
+        model: "xai/grok-imagine-image",
+        prompt: "too many references",
+        inputImages: falReferenceImages(4),
+      },
+      error: "fal Grok Imagine supports at most 3 reference images",
+      expectsNoFetch: true,
+    },
+    {
+      name: "rejects multi-image count for Krea 2 single-image endpoints",
+      request: {
+        model: "krea/v2/medium/text-to-image",
+        prompt: "too many outputs",
+        count: 2,
+      },
+      error: "supports one output image per request",
+    },
+    {
+      name: "rejects output format overrides for Krea 2",
+      request: {
+        model: "krea/v2/medium/text-to-image",
+        prompt: "jpeg please",
+        outputFormat: "jpeg",
+      },
+      error: "does not support outputFormat overrides",
+    },
+    {
+      name: "rejects multi-image for Flux edit",
+      request: {
+        model: "fal-ai/flux/dev",
+        prompt: "combine these",
+        inputImages: [
+          { buffer: Buffer.from("one"), mimeType: "image/png" },
+          { buffer: Buffer.from("two"), mimeType: "image/png" },
+        ],
+      },
+      error: "at most one reference image",
+    },
+    {
+      name: "rejects aspect ratio for Flux edit",
+      request: {
+        model: "fal-ai/flux/dev",
+        prompt: "make it widescreen",
+        aspectRatio: "16:9",
+        inputImages: [{ buffer: Buffer.from("one"), mimeType: "image/png" }],
+      },
+      error: "does not support aspectRatio overrides",
+    },
+  ] satisfies FalValidationCase[])(
+    "$name",
+    async ({ request, error, expectsNoFetch }: FalValidationCase) => {
+      await expect(
+        buildFalImageGenerationProvider().generateImage({ provider: "fal", cfg: {}, ...request }),
+      ).rejects.toThrow(error);
+      if (expectsNoFetch) {
+        expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
+      }
+    },
+  );
 
   it("routes Nano Banana 2 text generation with native resolution", async () => {
-    vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
-      apiKey: "fal-test-key",
-      source: "env",
-      mode: "api-key",
-    });
-    setFalFetchGuardForTesting(fetchWithSsrFGuardMock);
-    fetchWithSsrFGuardMock
-      .mockResolvedValueOnce({
-        response: new Response(
-          JSON.stringify({
-            images: [{ url: "https://v3.fal.media/files/example/nb2-wide.png" }],
-          }),
-          {
-            status: 200,
-            headers: { "Content-Type": "application/json" },
-          },
-        ),
-        release: vi.fn(async () => {}),
-      })
-      .mockResolvedValueOnce({
-        response: new Response(Buffer.from("nb2-wide-data"), {
-          status: 200,
-          headers: { "content-type": "image/png" },
-        }),
-        release: vi.fn(async () => {}),
-      });
+    mockFalGeneratedImage("nb2-wide.png", "nb2-wide-data");
 
     const provider = buildFalImageGenerationProvider();
     await provider.generateImage({
@@ -570,32 +589,7 @@ describe("fal image-generation provider", () => {
   });
 
   it("does not synthesize Nano Banana 2 aspect ratio from resolution alone", async () => {
-    vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
-      apiKey: "fal-test-key",
-      source: "env",
-      mode: "api-key",
-    });
-    setFalFetchGuardForTesting(fetchWithSsrFGuardMock);
-    fetchWithSsrFGuardMock
-      .mockResolvedValueOnce({
-        response: new Response(
-          JSON.stringify({
-            images: [{ url: "https://v3.fal.media/files/example/nb2-auto.png" }],
-          }),
-          {
-            status: 200,
-            headers: { "Content-Type": "application/json" },
-          },
-        ),
-        release: vi.fn(async () => {}),
-      })
-      .mockResolvedValueOnce({
-        response: new Response(Buffer.from("nb2-auto-data"), {
-          status: 200,
-          headers: { "content-type": "image/png" },
-        }),
-        release: vi.fn(async () => {}),
-      });
+    mockFalGeneratedImage("nb2-auto.png", "nb2-auto-data");
 
     const provider = buildFalImageGenerationProvider();
     await provider.generateImage({
@@ -622,32 +616,7 @@ describe("fal image-generation provider", () => {
     { model: "fal-ai/nano-banana", resolution: undefined },
     { model: "fal-ai/nano-banana-2", resolution: "2K" as const },
   ])("routes $model edits through /edit with model geometry", async ({ model, resolution }) => {
-    vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
-      apiKey: "fal-test-key",
-      source: "env",
-      mode: "api-key",
-    });
-    setFalFetchGuardForTesting(fetchWithSsrFGuardMock);
-    fetchWithSsrFGuardMock
-      .mockResolvedValueOnce({
-        response: new Response(
-          JSON.stringify({
-            images: [{ url: "https://v3.fal.media/files/example/nb2-edited.png" }],
-          }),
-          {
-            status: 200,
-            headers: { "Content-Type": "application/json" },
-          },
-        ),
-        release: vi.fn(async () => {}),
-      })
-      .mockResolvedValueOnce({
-        response: new Response(Buffer.from("nb2-edited-data"), {
-          status: 200,
-          headers: { "content-type": "image/png" },
-        }),
-        release: vi.fn(async () => {}),
-      });
+    mockFalGeneratedImage("nb2-edited.png", "nb2-edited-data");
 
     const provider = buildFalImageGenerationProvider();
     await provider.generateImage({
@@ -692,13 +661,6 @@ describe("fal image-generation provider", () => {
       error: "fal Nano Banana 2 supports at most 14 reference images",
     },
   ])("rejects $model edits above its reference limit", async ({ model, inputCount, error }) => {
-    vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
-      apiKey: "fal-test-key",
-      source: "env",
-      mode: "api-key",
-    });
-    setFalFetchGuardForTesting(fetchWithSsrFGuardMock);
-
     const provider = buildFalImageGenerationProvider();
     await expect(
       provider.generateImage({
@@ -715,54 +677,8 @@ describe("fal image-generation provider", () => {
     expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
   });
 
-  it("rejects Krea-only aspect ratios for Nano Banana 2", async () => {
-    vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
-      apiKey: "fal-test-key",
-      source: "env",
-      mode: "api-key",
-    });
-    setFalFetchGuardForTesting(fetchWithSsrFGuardMock);
-
-    const provider = buildFalImageGenerationProvider();
-    await expect(
-      provider.generateImage({
-        provider: "fal",
-        model: "fal-ai/nano-banana-2",
-        prompt: "unsupported ratio",
-        cfg: {},
-        aspectRatio: "2.35:1",
-      }),
-    ).rejects.toThrow("fal Nano Banana 2 supports aspectRatio values");
-    expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
-  });
-
   it("routes Nano Banana 2 Lite edits through /edit with image_urls", async () => {
-    vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
-      apiKey: "fal-test-key",
-      source: "env",
-      mode: "api-key",
-    });
-    setFalFetchGuardForTesting(fetchWithSsrFGuardMock);
-    fetchWithSsrFGuardMock
-      .mockResolvedValueOnce({
-        response: new Response(
-          JSON.stringify({
-            images: [{ url: "https://v3.fal.media/files/example/nb2-lite-edited.png" }],
-          }),
-          {
-            status: 200,
-            headers: { "Content-Type": "application/json" },
-          },
-        ),
-        release: vi.fn(async () => {}),
-      })
-      .mockResolvedValueOnce({
-        response: new Response(Buffer.from("nb2-lite-edited-data"), {
-          status: 200,
-          headers: { "content-type": "image/png" },
-        }),
-        release: vi.fn(async () => {}),
-      });
+    mockFalGeneratedImage("nb2-lite-edited.png", "nb2-lite-edited-data");
 
     const provider = buildFalImageGenerationProvider();
     await provider.generateImage({
@@ -793,37 +709,9 @@ describe("fal image-generation provider", () => {
     });
   });
 
-  it("rejects Krea-only aspect ratios for Nano Banana 2 Lite", async () => {
-    vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
-      apiKey: "fal-test-key",
-      source: "env",
-      mode: "api-key",
-    });
-    setFalFetchGuardForTesting(fetchWithSsrFGuardMock);
-
-    const provider = buildFalImageGenerationProvider();
-    await expect(
-      provider.generateImage({
-        provider: "fal",
-        model: "google/nano-banana-2-lite",
-        prompt: "unsupported ratio",
-        cfg: {},
-        aspectRatio: "2.35:1",
-      }),
-    ).rejects.toThrow("fal Nano Banana 2 Lite supports aspectRatio values");
-    expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
-  });
-
   it.each(["1K", "2K", "4K"] as const)(
     "rejects %s resolution overrides for Nano Banana 2 Lite",
     async (resolution) => {
-      vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
-        apiKey: "fal-test-key",
-        source: "env",
-        mode: "api-key",
-      });
-      setFalFetchGuardForTesting(fetchWithSsrFGuardMock);
-
       const provider = buildFalImageGenerationProvider();
       await expect(
         provider.generateImage({
@@ -839,30 +727,6 @@ describe("fal image-generation provider", () => {
       expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
     },
   );
-
-  it("rejects Nano Banana 2 Lite edits above 14 reference images", async () => {
-    vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
-      apiKey: "fal-test-key",
-      source: "env",
-      mode: "api-key",
-    });
-    setFalFetchGuardForTesting(fetchWithSsrFGuardMock);
-
-    const provider = buildFalImageGenerationProvider();
-    await expect(
-      provider.generateImage({
-        provider: "fal",
-        model: "google/nano-banana-2-lite",
-        prompt: "too many references",
-        cfg: {},
-        inputImages: Array.from({ length: 15 }, () => ({
-          buffer: Buffer.from("ref"),
-          mimeType: "image/png",
-        })),
-      }),
-    ).rejects.toThrow("fal Nano Banana 2 Lite supports at most 14 reference images");
-    expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
-  });
 
   it.each([
     {
@@ -891,32 +755,7 @@ describe("fal image-generation provider", () => {
       },
     },
   ])("keeps $label text-to-image on its base endpoint", async (testCase) => {
-    vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
-      apiKey: "fal-test-key",
-      source: "env",
-      mode: "api-key",
-    });
-    setFalFetchGuardForTesting(fetchWithSsrFGuardMock);
-    fetchWithSsrFGuardMock
-      .mockResolvedValueOnce({
-        response: new Response(
-          JSON.stringify({
-            images: [{ url: "https://v3.fal.media/files/example/generated.png" }],
-          }),
-          {
-            status: 200,
-            headers: { "Content-Type": "application/json" },
-          },
-        ),
-        release: vi.fn(async () => {}),
-      })
-      .mockResolvedValueOnce({
-        response: new Response(Buffer.from("generated-data"), {
-          status: 200,
-          headers: { "content-type": "image/png" },
-        }),
-        release: vi.fn(async () => {}),
-      });
+    mockFalGeneratedImage("generated.png", "generated-data");
 
     const provider = buildFalImageGenerationProvider();
     await provider.generateImage({
@@ -936,32 +775,7 @@ describe("fal image-generation provider", () => {
   });
 
   it("routes Grok Imagine edits through /edit with lowercase resolution", async () => {
-    vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
-      apiKey: "fal-test-key",
-      source: "env",
-      mode: "api-key",
-    });
-    setFalFetchGuardForTesting(fetchWithSsrFGuardMock);
-    fetchWithSsrFGuardMock
-      .mockResolvedValueOnce({
-        response: new Response(
-          JSON.stringify({
-            images: [{ url: "https://v3.fal.media/files/example/grok-edited.png" }],
-          }),
-          {
-            status: 200,
-            headers: { "Content-Type": "application/json" },
-          },
-        ),
-        release: vi.fn(async () => {}),
-      })
-      .mockResolvedValueOnce({
-        response: new Response(Buffer.from("grok-edited-data"), {
-          status: 200,
-          headers: { "content-type": "image/png" },
-        }),
-        release: vi.fn(async () => {}),
-      });
+    mockFalGeneratedImage("grok-edited.png", "grok-edited-data");
 
     const provider = buildFalImageGenerationProvider();
     await provider.generateImage({
@@ -988,101 +802,8 @@ describe("fal image-generation provider", () => {
     });
   });
 
-  it("rejects 4K resolution for Grok Imagine edits", async () => {
-    vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
-      apiKey: "fal-test-key",
-      source: "env",
-      mode: "api-key",
-    });
-    setFalFetchGuardForTesting(fetchWithSsrFGuardMock);
-
-    const provider = buildFalImageGenerationProvider();
-    await expect(
-      provider.generateImage({
-        provider: "fal",
-        model: "xai/grok-imagine-image",
-        prompt: "too big",
-        cfg: {},
-        aspectRatio: "1:1",
-        resolution: "4K",
-        inputImages: [{ buffer: Buffer.from("src"), mimeType: "image/png" }],
-      }),
-    ).rejects.toThrow("fal Grok Imagine supports resolution values: 1K, 2K");
-    expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
-  });
-
-  it("rejects Nano Banana ratios for Grok Imagine", async () => {
-    vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
-      apiKey: "fal-test-key",
-      source: "env",
-      mode: "api-key",
-    });
-    setFalFetchGuardForTesting(fetchWithSsrFGuardMock);
-
-    const provider = buildFalImageGenerationProvider();
-    await expect(
-      provider.generateImage({
-        provider: "fal",
-        model: "xai/grok-imagine-image",
-        prompt: "unsupported ratio",
-        cfg: {},
-        aspectRatio: "21:9",
-      }),
-    ).rejects.toThrow("fal Grok Imagine supports aspectRatio values");
-    expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
-  });
-
-  it("rejects Grok Imagine edits above 3 reference images", async () => {
-    vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
-      apiKey: "fal-test-key",
-      source: "env",
-      mode: "api-key",
-    });
-    setFalFetchGuardForTesting(fetchWithSsrFGuardMock);
-
-    const provider = buildFalImageGenerationProvider();
-    await expect(
-      provider.generateImage({
-        provider: "fal",
-        model: "xai/grok-imagine-image",
-        prompt: "too many references",
-        cfg: {},
-        inputImages: Array.from({ length: 4 }, () => ({
-          buffer: Buffer.from("ref"),
-          mimeType: "image/png",
-        })),
-      }),
-    ).rejects.toThrow("fal Grok Imagine supports at most 3 reference images");
-    expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
-  });
-
   it("preserves an explicit Grok Imagine /quality/edit model path", async () => {
-    vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
-      apiKey: "fal-test-key",
-      source: "env",
-      mode: "api-key",
-    });
-    setFalFetchGuardForTesting(fetchWithSsrFGuardMock);
-    fetchWithSsrFGuardMock
-      .mockResolvedValueOnce({
-        response: new Response(
-          JSON.stringify({
-            images: [{ url: "https://v3.fal.media/files/example/grok-explicit.png" }],
-          }),
-          {
-            status: 200,
-            headers: { "Content-Type": "application/json" },
-          },
-        ),
-        release: vi.fn(async () => {}),
-      })
-      .mockResolvedValueOnce({
-        response: new Response(Buffer.from("grok-explicit-data"), {
-          status: 200,
-          headers: { "content-type": "image/png" },
-        }),
-        release: vi.fn(async () => {}),
-      });
+    mockFalGeneratedImage("grok-explicit.png", "grok-explicit-data");
 
     const provider = buildFalImageGenerationProvider();
     await provider.generateImage({
@@ -1106,32 +827,7 @@ describe("fal image-generation provider", () => {
   });
 
   it("preserves exact custom Fal edit endpoints", async () => {
-    vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
-      apiKey: "fal-test-key",
-      source: "env",
-      mode: "api-key",
-    });
-    setFalFetchGuardForTesting(fetchWithSsrFGuardMock);
-    fetchWithSsrFGuardMock
-      .mockResolvedValueOnce({
-        response: new Response(
-          JSON.stringify({
-            images: [{ url: "https://v3.fal.media/files/example/custom-edit.png" }],
-          }),
-          {
-            status: 200,
-            headers: { "Content-Type": "application/json" },
-          },
-        ),
-        release: vi.fn(async () => {}),
-      })
-      .mockResolvedValueOnce({
-        response: new Response(Buffer.from("custom-edit-data"), {
-          status: 200,
-          headers: { "content-type": "image/png" },
-        }),
-        release: vi.fn(async () => {}),
-      });
+    mockFalGeneratedImage("custom-edit.png", "custom-edit-data");
 
     const provider = buildFalImageGenerationProvider();
     await provider.generateImage({
@@ -1155,32 +851,7 @@ describe("fal image-generation provider", () => {
   });
 
   it("maps aspect ratio for text generation without forcing a square default", async () => {
-    vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
-      apiKey: "fal-test-key",
-      source: "env",
-      mode: "api-key",
-    });
-    setFalFetchGuardForTesting(fetchWithSsrFGuardMock);
-    fetchWithSsrFGuardMock
-      .mockResolvedValueOnce({
-        response: new Response(
-          JSON.stringify({
-            images: [{ url: "https://v3.fal.media/files/example/wide.png" }],
-          }),
-          {
-            status: 200,
-            headers: { "Content-Type": "application/json" },
-          },
-        ),
-        release: vi.fn(async () => {}),
-      })
-      .mockResolvedValueOnce({
-        response: new Response(Buffer.from("wide-data"), {
-          status: 200,
-          headers: { "content-type": "image/png" },
-        }),
-        release: vi.fn(async () => {}),
-      });
+    mockFalGeneratedImage("wide.png", "wide-data");
 
     const provider = buildFalImageGenerationProvider();
     await provider.generateImage({
@@ -1204,32 +875,7 @@ describe("fal image-generation provider", () => {
   });
 
   it("combines resolution and aspect ratio for text generation", async () => {
-    vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
-      apiKey: "fal-test-key",
-      source: "env",
-      mode: "api-key",
-    });
-    setFalFetchGuardForTesting(fetchWithSsrFGuardMock);
-    fetchWithSsrFGuardMock
-      .mockResolvedValueOnce({
-        response: new Response(
-          JSON.stringify({
-            images: [{ url: "https://v3.fal.media/files/example/portrait.png" }],
-          }),
-          {
-            status: 200,
-            headers: { "Content-Type": "application/json" },
-          },
-        ),
-        release: vi.fn(async () => {}),
-      })
-      .mockResolvedValueOnce({
-        response: new Response(Buffer.from("portrait-data"), {
-          status: 200,
-          headers: { "content-type": "image/png" },
-        }),
-        release: vi.fn(async () => {}),
-      });
+    mockFalGeneratedImage("portrait.png", "portrait-data");
 
     const provider = buildFalImageGenerationProvider();
     await provider.generateImage({
@@ -1254,32 +900,7 @@ describe("fal image-generation provider", () => {
   });
 
   it("uses Krea 2 native aspect-ratio and creativity payload schema", async () => {
-    vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
-      apiKey: "fal-test-key",
-      source: "env",
-      mode: "api-key",
-    });
-    setFalFetchGuardForTesting(fetchWithSsrFGuardMock);
-    fetchWithSsrFGuardMock
-      .mockResolvedValueOnce({
-        response: new Response(
-          JSON.stringify({
-            images: [{ url: "https://v3.fal.media/files/example/krea.png" }],
-          }),
-          {
-            status: 200,
-            headers: { "Content-Type": "application/json" },
-          },
-        ),
-        release: vi.fn(async () => {}),
-      })
-      .mockResolvedValueOnce({
-        response: new Response(Buffer.from("krea-data"), {
-          status: 200,
-          headers: { "content-type": "image/png" },
-        }),
-        release: vi.fn(async () => {}),
-      });
+    mockFalGeneratedImage("krea.png", "krea-data");
 
     const provider = buildFalImageGenerationProvider();
     const result = await provider.generateImage({
@@ -1308,32 +929,7 @@ describe("fal image-generation provider", () => {
   });
 
   it("passes reference images to Krea 2 as style references without edit suffix", async () => {
-    vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
-      apiKey: "fal-test-key",
-      source: "env",
-      mode: "api-key",
-    });
-    setFalFetchGuardForTesting(fetchWithSsrFGuardMock);
-    fetchWithSsrFGuardMock
-      .mockResolvedValueOnce({
-        response: new Response(
-          JSON.stringify({
-            images: [{ url: "https://v3.fal.media/files/example/krea-style.png" }],
-          }),
-          {
-            status: 200,
-            headers: { "Content-Type": "application/json" },
-          },
-        ),
-        release: vi.fn(async () => {}),
-      })
-      .mockResolvedValueOnce({
-        response: new Response(Buffer.from("krea-style-data"), {
-          status: 200,
-          headers: { "content-type": "image/png" },
-        }),
-        release: vi.fn(async () => {}),
-      });
+    mockFalGeneratedImage("krea-style.png", "krea-style-data");
 
     const provider = buildFalImageGenerationProvider();
     await provider.generateImage({
@@ -1364,32 +960,7 @@ describe("fal image-generation provider", () => {
   });
 
   it("maps Krea 2 size hints to the closest native aspect ratio", async () => {
-    vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
-      apiKey: "fal-test-key",
-      source: "env",
-      mode: "api-key",
-    });
-    setFalFetchGuardForTesting(fetchWithSsrFGuardMock);
-    fetchWithSsrFGuardMock
-      .mockResolvedValueOnce({
-        response: new Response(
-          JSON.stringify({
-            images: [{ url: "https://v3.fal.media/files/example/krea-sized.png" }],
-          }),
-          {
-            status: 200,
-            headers: { "Content-Type": "application/json" },
-          },
-        ),
-        release: vi.fn(async () => {}),
-      })
-      .mockResolvedValueOnce({
-        response: new Response(Buffer.from("krea-sized-data"), {
-          status: 200,
-          headers: { "content-type": "image/png" },
-        }),
-        release: vi.fn(async () => {}),
-      });
+    mockFalGeneratedImage("krea-sized.png", "krea-sized-data");
 
     const provider = buildFalImageGenerationProvider();
     await provider.generateImage({
@@ -1412,12 +983,6 @@ describe("fal image-generation provider", () => {
   });
 
   it("rejects Krea 2 resolution hints instead of dropping them", async () => {
-    vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
-      apiKey: "fal-test-key",
-      source: "env",
-      mode: "api-key",
-    });
-
     const provider = buildFalImageGenerationProvider();
     await expect(
       provider.generateImage({
@@ -1440,93 +1005,7 @@ describe("fal image-generation provider", () => {
     ).rejects.toThrow("fal Krea 2 supports aspectRatio but not resolution overrides");
   });
 
-  it("rejects multi-image count for Krea 2 single-image endpoints", async () => {
-    vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
-      apiKey: "fal-test-key",
-      source: "env",
-      mode: "api-key",
-    });
-
-    const provider = buildFalImageGenerationProvider();
-    await expect(
-      provider.generateImage({
-        provider: "fal",
-        model: "krea/v2/medium/text-to-image",
-        prompt: "too many outputs",
-        cfg: {},
-        count: 2,
-      }),
-    ).rejects.toThrow("supports one output image per request");
-  });
-
-  it("rejects output format overrides for Krea 2", async () => {
-    vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
-      apiKey: "fal-test-key",
-      source: "env",
-      mode: "api-key",
-    });
-
-    const provider = buildFalImageGenerationProvider();
-    await expect(
-      provider.generateImage({
-        provider: "fal",
-        model: "krea/v2/medium/text-to-image",
-        prompt: "jpeg please",
-        cfg: {},
-        outputFormat: "jpeg",
-      }),
-    ).rejects.toThrow("does not support outputFormat overrides");
-  });
-
-  it("rejects multi-image for Flux edit", async () => {
-    vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
-      apiKey: "fal-test-key",
-      source: "env",
-      mode: "api-key",
-    });
-
-    const provider = buildFalImageGenerationProvider();
-    await expect(
-      provider.generateImage({
-        provider: "fal",
-        model: "fal-ai/flux/dev",
-        prompt: "combine these",
-        cfg: {},
-        inputImages: [
-          { buffer: Buffer.from("one"), mimeType: "image/png" },
-          { buffer: Buffer.from("two"), mimeType: "image/png" },
-        ],
-      }),
-    ).rejects.toThrow("at most one reference image");
-  });
-
-  it("rejects aspect ratio for Flux edit", async () => {
-    vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
-      apiKey: "fal-test-key",
-      source: "env",
-      mode: "api-key",
-    });
-
-    const provider = buildFalImageGenerationProvider();
-    await expect(
-      provider.generateImage({
-        provider: "fal",
-        model: "fal-ai/flux/dev",
-        prompt: "make it widescreen",
-        cfg: {},
-        aspectRatio: "16:9",
-        inputImages: [{ buffer: Buffer.from("one"), mimeType: "image/png" }],
-      }),
-    ).rejects.toThrow("does not support aspectRatio overrides");
-  });
-
   it("blocks private-network image download URLs through the SSRF guard", async () => {
-    vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
-      apiKey: "fal-test-key",
-      source: "env",
-      mode: "api-key",
-    });
-    setFalFetchGuardForTesting(fetchWithSsrFGuardMock);
     const blocked = new Error("Blocked: resolves to private/internal/special-use IP address");
     fetchWithSsrFGuardMock
       .mockResolvedValueOnce({
@@ -1560,12 +1039,6 @@ describe("fal image-generation provider", () => {
   });
 
   it("does not auto-whitelist trusted private relay hosts from a configured baseUrl", async () => {
-    vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
-      apiKey: "fal-test-key",
-      source: "env",
-      mode: "api-key",
-    });
-    setFalFetchGuardForTesting(fetchWithSsrFGuardMock);
     fetchWithSsrFGuardMock
       .mockResolvedValueOnce({
         response: new Response(

--- a/extensions/xai/realtime-voice-provider.test.ts
+++ b/extensions/xai/realtime-voice-provider.test.ts
@@ -126,6 +126,24 @@ function requireSession(socket: FakeWebSocketInstance, index = 0): Record<string
   return session as Record<string, unknown>;
 }
 
+type XaiRealtimeBridgeParams = Parameters<
+  ReturnType<typeof buildXaiRealtimeVoiceProvider>["createBridge"]
+>[0];
+
+function createXaiRealtimeBridge(params: Partial<XaiRealtimeBridgeParams> = {}) {
+  const { providerConfig, ...callbacks } = params;
+  return buildXaiRealtimeVoiceProvider().createBridge({
+    providerConfig: { apiKey: "xai-test", ...providerConfig }, // pragma: allowlist secret
+    onAudio: vi.fn(),
+    onClearAudio: vi.fn(),
+    ...callbacks,
+  });
+}
+
+function emitRealtimeMessage(socket: FakeWebSocketInstance, event: Record<string, unknown>): void {
+  socket.emit("message", Buffer.from(JSON.stringify(event)));
+}
+
 async function openRealtimeBridge(
   bridge: ReturnType<ReturnType<typeof buildXaiRealtimeVoiceProvider>["createBridge"]>,
   index = 0,
@@ -137,14 +155,12 @@ async function openRealtimeBridge(
   socket.readyState = FakeWebSocket.OPEN;
   socket.emit("open");
   if (conversationId) {
-    socket.emit(
-      "message",
-      Buffer.from(
-        JSON.stringify({ type: "conversation.created", conversation: { id: conversationId } }),
-      ),
-    );
+    emitRealtimeMessage(socket, {
+      type: "conversation.created",
+      conversation: { id: conversationId },
+    });
   }
-  socket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+  emitRealtimeMessage(socket, { type: "session.updated" });
   return { connecting, socket };
 }
 
@@ -186,14 +202,7 @@ describe("buildXaiRealtimeVoiceProvider", () => {
   });
 
   it("does not advertise continuing realtime tool results", () => {
-    const provider = buildXaiRealtimeVoiceProvider();
-    const bridge = provider.createBridge({
-      providerConfig: { apiKey: "xai-test" }, // pragma: allowlist secret
-      onAudio: vi.fn(),
-      onClearAudio: vi.fn(),
-    });
-
-    expect(bridge.supportsToolResultContinuation).toBe(false);
+    expect(createXaiRealtimeBridge().supportsToolResultContinuation).toBe(false);
   });
 
   it("requires xAI credentials for native realtime websocket bridges", async () => {
@@ -247,13 +256,7 @@ describe("buildXaiRealtimeVoiceProvider", () => {
 
   it("does not enable xAI session resumption by default", async () => {
     vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret
-    const provider = buildXaiRealtimeVoiceProvider();
-    const bridge = provider.createBridge({
-      providerConfig: { apiKey: "xai-test" }, // pragma: allowlist secret
-      onAudio: vi.fn(),
-      onClearAudio: vi.fn(),
-    });
-
+    const bridge = createXaiRealtimeBridge();
     const { socket } = await openRealtimeBridge(bridge);
     bridge.close();
 
@@ -291,12 +294,8 @@ describe("buildXaiRealtimeVoiceProvider", () => {
 
   it("sends nested xAI session.update audio formats for g711 bridges", async () => {
     vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret
-    const provider = buildXaiRealtimeVoiceProvider();
-    const bridge = provider.createBridge({
-      providerConfig: { apiKey: "xai-test" }, // pragma: allowlist secret
+    const bridge = createXaiRealtimeBridge({
       audioFormat: { encoding: "g711_ulaw", sampleRateHz: 8000, channels: 1 },
-      onAudio: vi.fn(),
-      onClearAudio: vi.fn(),
     });
 
     const { socket } = await openRealtimeBridge(bridge);
@@ -369,48 +368,23 @@ describe("buildXaiRealtimeVoiceProvider", () => {
   });
 
   it("treats xAI input transcription updates as replacements until completed", async () => {
-    const provider = buildXaiRealtimeVoiceProvider();
     const onTranscript = vi.fn();
-    const bridge = provider.createBridge({
-      providerConfig: { apiKey: "xai-test" }, // pragma: allowlist secret
-      onAudio: vi.fn(),
-      onClearAudio: vi.fn(),
-      onTranscript,
-    });
+    const bridge = createXaiRealtimeBridge({ onTranscript });
 
     const { connecting, socket } = await openRealtimeBridge(bridge);
     await connecting;
 
-    socket.emit(
-      "message",
-      Buffer.from(
-        JSON.stringify({
-          type: "conversation.item.input_audio_transcription.updated",
-          item_id: "item_1",
-          transcript: "open",
-        }),
-      ),
-    );
-    socket.emit(
-      "message",
-      Buffer.from(
-        JSON.stringify({
-          type: "conversation.item.input_audio_transcription.updated",
-          item_id: "item_1",
-          transcript: "open claw",
-        }),
-      ),
-    );
-    socket.emit(
-      "message",
-      Buffer.from(
-        JSON.stringify({
-          type: "conversation.item.input_audio_transcription.completed",
-          item_id: "item_1",
-          transcript: "OpenClaw",
-        }),
-      ),
-    );
+    for (const [suffix, transcript] of [
+      ["updated", "open"],
+      ["updated", "open claw"],
+      ["completed", "OpenClaw"],
+    ] as const) {
+      emitRealtimeMessage(socket, {
+        type: `conversation.item.input_audio_transcription.${suffix}`,
+        item_id: "item_1",
+        transcript,
+      });
+    }
     bridge.close();
 
     expect(onTranscript).toHaveBeenCalledOnce();
@@ -418,42 +392,21 @@ describe("buildXaiRealtimeVoiceProvider", () => {
   });
 
   it("buffers assistant transcript deltas and finalizes them when done has no text", async () => {
-    const provider = buildXaiRealtimeVoiceProvider();
     const onTranscript = vi.fn();
-    const bridge = provider.createBridge({
-      providerConfig: { apiKey: "xai-test" }, // pragma: allowlist secret
-      onAudio: vi.fn(),
-      onClearAudio: vi.fn(),
-      onTranscript,
-    });
+    const bridge = createXaiRealtimeBridge({ onTranscript });
 
     const { connecting, socket } = await openRealtimeBridge(bridge);
     await connecting;
 
-    socket.emit("message", Buffer.from(JSON.stringify({ type: "response.created" })));
-    socket.emit(
-      "message",
-      Buffer.from(
-        JSON.stringify({
-          type: "response.output_audio_transcript.delta",
-          delta: "Hello ",
-        }),
-      ),
-    );
-    socket.emit(
-      "message",
-      Buffer.from(
-        JSON.stringify({
-          type: "response.output_audio_transcript.delta",
-          delta: "OpenClaw",
-        }),
-      ),
-    );
-    socket.emit(
-      "message",
-      Buffer.from(JSON.stringify({ type: "response.output_audio_transcript.done" })),
-    );
-    socket.emit("message", Buffer.from(JSON.stringify({ type: "response.done" })));
+    for (const event of [
+      { type: "response.created" },
+      { type: "response.output_audio_transcript.delta", delta: "Hello " },
+      { type: "response.output_audio_transcript.delta", delta: "OpenClaw" },
+      { type: "response.output_audio_transcript.done" },
+      { type: "response.done" },
+    ]) {
+      emitRealtimeMessage(socket, event);
+    }
     bridge.close();
 
     expect(onTranscript).toHaveBeenNthCalledWith(1, "assistant", "Hello ", false);
@@ -551,15 +504,13 @@ describe("buildXaiRealtimeVoiceProvider", () => {
       vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret
       const onAudio = vi.fn();
       const onClearAudio = vi.fn();
-      const bridge = buildXaiRealtimeVoiceProvider().createBridge({
-        providerConfig: { apiKey: "xai-test" }, // pragma: allowlist secret
+      const bridge = createXaiRealtimeBridge({
         audioFormat: REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ,
         onAudio,
         onClearAudio,
       });
       const { socket } = await openRealtimeBridge(bridge);
-      const emit = (event: Record<string, unknown>) =>
-        socket.emit("message", Buffer.from(JSON.stringify(event)));
+      const emit = (event: Record<string, unknown>) => emitRealtimeMessage(socket, event);
 
       emit({ type: "response.created", response: { id: "resp_1" } });
       if (hasAudio) {
@@ -603,53 +554,32 @@ describe("buildXaiRealtimeVoiceProvider", () => {
 
   it("deduplicates repeated function-call arguments done events", async () => {
     vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret
-    const provider = buildXaiRealtimeVoiceProvider();
     const onToolCall = vi.fn();
-    const bridge = provider.createBridge({
-      providerConfig: { apiKey: "xai-test" }, // pragma: allowlist secret
-      onAudio: vi.fn(),
-      onClearAudio: vi.fn(),
-      onToolCall,
-    });
+    const bridge = createXaiRealtimeBridge({ onToolCall });
 
     const { connecting, socket } = await openRealtimeBridge(bridge);
     await connecting;
 
-    socket.emit(
-      "message",
-      Buffer.from(
-        JSON.stringify({
-          type: "response.function_call_arguments.delta",
-          item_id: "item_tool_1",
-          name: "openclaw_agent_consult",
-          call_id: "call_1",
-          delta: JSON.stringify({ question: "delegate this" }),
-        }),
-      ),
-    );
-    socket.emit(
-      "message",
-      Buffer.from(
-        JSON.stringify({
-          type: "response.function_call_arguments.done",
-          item_id: "item_tool_1",
-          name: "openclaw_agent_consult",
-          call_id: "call_1",
-        }),
-      ),
-    );
-    socket.emit(
-      "message",
-      Buffer.from(
-        JSON.stringify({
-          type: "response.function_call_arguments.done",
-          item_id: "item_tool_1",
-          name: "openclaw_agent_consult",
-          call_id: "call_1",
-          arguments: JSON.stringify({ question: "delegate this" }),
-        }),
-      ),
-    );
+    const toolCall = {
+      item_id: "item_tool_1",
+      name: "openclaw_agent_consult",
+      call_id: "call_1",
+    };
+    for (const event of [
+      {
+        type: "response.function_call_arguments.delta",
+        ...toolCall,
+        delta: JSON.stringify({ question: "delegate this" }),
+      },
+      { type: "response.function_call_arguments.done", ...toolCall },
+      {
+        type: "response.function_call_arguments.done",
+        ...toolCall,
+        arguments: JSON.stringify({ question: "delegate this" }),
+      },
+    ]) {
+      emitRealtimeMessage(socket, event);
+    }
 
     expect(onToolCall).toHaveBeenCalledTimes(1);
     expect(onToolCall).toHaveBeenCalledWith({
@@ -662,30 +592,19 @@ describe("buildXaiRealtimeVoiceProvider", () => {
 
   it("waits for all parallel tool results before sending response.create", async () => {
     vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret
-    const provider = buildXaiRealtimeVoiceProvider();
-    const bridge = provider.createBridge({
-      providerConfig: { apiKey: "xai-test" }, // pragma: allowlist secret
-      onAudio: vi.fn(),
-      onClearAudio: vi.fn(),
-      onToolCall: vi.fn(),
-    });
+    const bridge = createXaiRealtimeBridge({ onToolCall: vi.fn() });
 
     const { connecting, socket } = await openRealtimeBridge(bridge);
     await connecting;
 
     for (const callId of ["call_1", "call_2"]) {
-      socket.emit(
-        "message",
-        Buffer.from(
-          JSON.stringify({
-            type: "response.function_call_arguments.done",
-            item_id: `item_${callId}`,
-            name: "openclaw_agent_consult",
-            call_id: callId,
-            arguments: JSON.stringify({ question: callId }),
-          }),
-        ),
-      );
+      emitRealtimeMessage(socket, {
+        type: "response.function_call_arguments.done",
+        item_id: `item_${callId}`,
+        name: "openclaw_agent_consult",
+        call_id: callId,
+        arguments: JSON.stringify({ question: callId }),
+      });
     }
 
     await bridge.submitToolResult("call_1", { text: "first" });
@@ -707,29 +626,18 @@ describe("buildXaiRealtimeVoiceProvider", () => {
 
   it("does not send unsupported interim willContinue tool results to xAI", async () => {
     vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret
-    const provider = buildXaiRealtimeVoiceProvider();
-    const bridge = provider.createBridge({
-      providerConfig: { apiKey: "xai-test" }, // pragma: allowlist secret
-      onAudio: vi.fn(),
-      onClearAudio: vi.fn(),
-      onToolCall: vi.fn(),
-    });
+    const bridge = createXaiRealtimeBridge({ onToolCall: vi.fn() });
 
     const { connecting, socket } = await openRealtimeBridge(bridge);
     await connecting;
 
-    socket.emit(
-      "message",
-      Buffer.from(
-        JSON.stringify({
-          type: "response.function_call_arguments.done",
-          item_id: "item_call_1",
-          name: "openclaw_agent_consult",
-          call_id: "call_1",
-          arguments: JSON.stringify({ question: "call_1" }),
-        }),
-      ),
-    );
+    emitRealtimeMessage(socket, {
+      type: "response.function_call_arguments.done",
+      item_id: "item_call_1",
+      name: "openclaw_agent_consult",
+      call_id: "call_1",
+      arguments: JSON.stringify({ question: "call_1" }),
+    });
 
     await bridge.submitToolResult("call_1", { status: "working" }, { willContinue: true });
     expect(parseSent(socket).filter((event) => event.type === "conversation.item.create")).toEqual(
@@ -752,15 +660,8 @@ describe("buildXaiRealtimeVoiceProvider", () => {
 
   it("defers response.create for tool results until queued playback marks drain", async () => {
     vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret
-    const provider = buildXaiRealtimeVoiceProvider();
     const onMark = vi.fn();
-    const bridge = provider.createBridge({
-      providerConfig: { apiKey: "xai-test" }, // pragma: allowlist secret
-      onAudio: vi.fn(),
-      onClearAudio: vi.fn(),
-      onToolCall: vi.fn(),
-      onMark,
-    });
+    const bridge = createXaiRealtimeBridge({ onToolCall: vi.fn(), onMark });
 
     const { connecting, socket } = await openRealtimeBridge(bridge);
     await connecting;
@@ -805,11 +706,8 @@ describe("buildXaiRealtimeVoiceProvider", () => {
   it("preserves pending parallel tool calls across resumed reconnects", async () => {
     vi.useFakeTimers();
     vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret
-    const provider = buildXaiRealtimeVoiceProvider();
-    const bridge = provider.createBridge({
-      providerConfig: { apiKey: "xai-test", sessionResumption: true }, // pragma: allowlist secret
-      onAudio: vi.fn(),
-      onClearAudio: vi.fn(),
+    const bridge = createXaiRealtimeBridge({
+      providerConfig: { sessionResumption: true },
       onToolCall: vi.fn(),
     });
 
@@ -861,12 +759,9 @@ describe("buildXaiRealtimeVoiceProvider", () => {
   it("delivers a tool call first observed in resumed item replay", async () => {
     vi.useFakeTimers();
     vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret
-    const provider = buildXaiRealtimeVoiceProvider();
     const onToolCall = vi.fn();
-    const bridge = provider.createBridge({
-      providerConfig: { apiKey: "xai-test", sessionResumption: true }, // pragma: allowlist secret
-      onAudio: vi.fn(),
-      onClearAudio: vi.fn(),
+    const bridge = createXaiRealtimeBridge({
+      providerConfig: { sessionResumption: true },
       onToolCall,
     });
 
@@ -907,14 +802,11 @@ describe("buildXaiRealtimeVoiceProvider", () => {
   it("fails closed when a tool output was not acknowledged before reconnect", async () => {
     vi.useFakeTimers();
     vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret
-    const provider = buildXaiRealtimeVoiceProvider();
     const onToolCall = vi.fn();
     const onEvent = vi.fn();
     const onClose = vi.fn();
-    const bridge = provider.createBridge({
-      providerConfig: { apiKey: "xai-test", sessionResumption: true }, // pragma: allowlist secret
-      onAudio: vi.fn(),
-      onClearAudio: vi.fn(),
+    const bridge = createXaiRealtimeBridge({
+      providerConfig: { sessionResumption: true },
       onToolCall,
       onEvent,
       onClose,
@@ -957,12 +849,9 @@ describe("buildXaiRealtimeVoiceProvider", () => {
   it("does not retry a tool output acknowledged by resumed item replay", async () => {
     vi.useFakeTimers();
     vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret
-    const provider = buildXaiRealtimeVoiceProvider();
     const onToolCall = vi.fn();
-    const bridge = provider.createBridge({
-      providerConfig: { apiKey: "xai-test", sessionResumption: true }, // pragma: allowlist secret
-      onAudio: vi.fn(),
-      onClearAudio: vi.fn(),
+    const bridge = createXaiRealtimeBridge({
+      providerConfig: { sessionResumption: true },
       onToolCall,
     });
 
@@ -1039,11 +928,8 @@ describe("buildXaiRealtimeVoiceProvider", () => {
   it("queues tool results submitted while a resumed session is reconnecting", async () => {
     vi.useFakeTimers();
     vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret
-    const provider = buildXaiRealtimeVoiceProvider();
-    const bridge = provider.createBridge({
-      providerConfig: { apiKey: "xai-test", sessionResumption: true }, // pragma: allowlist secret
-      onAudio: vi.fn(),
-      onClearAudio: vi.fn(),
+    const bridge = createXaiRealtimeBridge({
+      providerConfig: { sessionResumption: true },
       onToolCall: vi.fn(),
     });
 
@@ -1113,12 +999,7 @@ describe("buildXaiRealtimeVoiceProvider", () => {
   it("queues text turns submitted while a resumed session is reconnecting", async () => {
     vi.useFakeTimers();
     vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret
-    const provider = buildXaiRealtimeVoiceProvider();
-    const bridge = provider.createBridge({
-      providerConfig: { apiKey: "xai-test", sessionResumption: true }, // pragma: allowlist secret
-      onAudio: vi.fn(),
-      onClearAudio: vi.fn(),
-    });
+    const bridge = createXaiRealtimeBridge({ providerConfig: { sessionResumption: true } });
 
     const { connecting, socket: firstSocket } = await openRealtimeBridge(
       bridge,
@@ -1158,13 +1039,10 @@ describe("buildXaiRealtimeVoiceProvider", () => {
   it("exhausts reconnect attempts when websocket opens without session setup", async () => {
     vi.useFakeTimers();
     vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret
-    const provider = buildXaiRealtimeVoiceProvider();
     const onEvent = vi.fn();
     const onClose = vi.fn();
-    const bridge = provider.createBridge({
-      providerConfig: { apiKey: "xai-test", sessionResumption: true }, // pragma: allowlist secret
-      onAudio: vi.fn(),
-      onClearAudio: vi.fn(),
+    const bridge = createXaiRealtimeBridge({
+      providerConfig: { sessionResumption: true },
       onEvent,
       onClose,
     });
@@ -1202,12 +1080,9 @@ describe("buildXaiRealtimeVoiceProvider", () => {
   it("does not replay ready callbacks after reconnect", async () => {
     vi.useFakeTimers();
     vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret
-    const provider = buildXaiRealtimeVoiceProvider();
     const onReady = vi.fn();
-    const bridge = provider.createBridge({
-      providerConfig: { apiKey: "xai-test", sessionResumption: true }, // pragma: allowlist secret
-      onAudio: vi.fn(),
-      onClearAudio: vi.fn(),
+    const bridge = createXaiRealtimeBridge({
+      providerConfig: { sessionResumption: true },
       onReady,
     });
 
@@ -1270,12 +1145,7 @@ describe("buildXaiRealtimeVoiceProvider", () => {
   it("enables xAI session resumption and reconnects with the created conversation id", async () => {
     vi.useFakeTimers();
     vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret
-    const provider = buildXaiRealtimeVoiceProvider();
-    const bridge = provider.createBridge({
-      providerConfig: { apiKey: "xai-test", sessionResumption: true }, // pragma: allowlist secret
-      onAudio: vi.fn(),
-      onClearAudio: vi.fn(),
-    });
+    const bridge = createXaiRealtimeBridge({ providerConfig: { sessionResumption: true } });
 
     const connecting = bridge.connect();
     await waitForRealtimeState(() => expect(FakeWebSocket.instances.length).toBe(1));
@@ -1306,13 +1176,10 @@ describe("buildXaiRealtimeVoiceProvider", () => {
   it("fails closed instead of reconnecting without a conversation id", async () => {
     vi.useFakeTimers();
     vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret
-    const provider = buildXaiRealtimeVoiceProvider();
     const onEvent = vi.fn();
     const onClose = vi.fn();
-    const bridge = provider.createBridge({
-      providerConfig: { apiKey: "xai-test", sessionResumption: true }, // pragma: allowlist secret
-      onAudio: vi.fn(),
-      onClearAudio: vi.fn(),
+    const bridge = createXaiRealtimeBridge({
+      providerConfig: { sessionResumption: true },
       onEvent,
       onClose,
     });
@@ -1336,13 +1203,9 @@ describe("buildXaiRealtimeVoiceProvider", () => {
   it("fails closed instead of reconnecting when xAI session resumption is disabled", async () => {
     vi.useFakeTimers();
     vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret
-    const provider = buildXaiRealtimeVoiceProvider();
     const onEvent = vi.fn();
     const onClose = vi.fn();
-    const bridge = provider.createBridge({
-      providerConfig: { apiKey: "xai-test" }, // pragma: allowlist secret
-      onAudio: vi.fn(),
-      onClearAudio: vi.fn(),
+    const bridge = createXaiRealtimeBridge({
       onEvent,
       onClose,
     });
@@ -1366,14 +1229,8 @@ describe("buildXaiRealtimeVoiceProvider", () => {
   it("does not retry after startup websocket errors", async () => {
     vi.useFakeTimers();
     vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret
-    const provider = buildXaiRealtimeVoiceProvider();
     const onClose = vi.fn();
-    const bridge = provider.createBridge({
-      providerConfig: { apiKey: "xai-test" }, // pragma: allowlist secret
-      onAudio: vi.fn(),
-      onClearAudio: vi.fn(),
-      onClose,
-    });
+    const bridge = createXaiRealtimeBridge({ onClose });
 
     const connecting = bridge.connect();
     await waitForRealtimeState(() => expect(FakeWebSocket.instances.length).toBe(1));

--- a/extensions/xai/web-search.test.ts
+++ b/extensions/xai/web-search.test.ts
@@ -112,6 +112,16 @@ function installXaiWebSearchFetch() {
   return mockFetch;
 }
 
+function requireXaiWebSearchTool(
+  params: Parameters<ReturnType<typeof createXaiWebSearchProvider>["createTool"]>[0],
+) {
+  const tool = createXaiWebSearchProvider().createTool(params);
+  if (!tool) {
+    throw new Error("Expected xAI web search tool");
+  }
+  return tool;
+}
+
 function firstFetchUrl(mockFetch: ReturnType<typeof installXaiWebSearchFetch>) {
   const [call] = mockFetch.mock.calls;
   if (!call) {
@@ -174,6 +184,18 @@ function expectCatalogEntry(
   if (expected.cost) {
     expect(entry?.cost).toEqual(expected.cost);
   }
+}
+
+function resolveForwardXaiModel(modelId: string) {
+  return resolveXaiForwardCompatModel({
+    providerId: "xai",
+    ctx: {
+      provider: "xai",
+      modelId,
+      modelRegistry: { find: () => null } as never,
+      providerConfig: { api: "openai-responses", baseUrl: "https://api.x.ai/v1" },
+    },
+  });
 }
 
 afterEach(() => {
@@ -294,8 +316,7 @@ describe("xai web search config resolution", () => {
       profileId: "xai:default",
     });
     const mockFetch = installXaiWebSearchFetch();
-    const provider = createXaiWebSearchProvider();
-    const tool = provider.createTool({
+    const tool = requireXaiWebSearchTool({
       config: {
         agents: {
           list: [{ id: "main", default: true, agentDir: "/tmp/openclaw-xai-main-agent" }],
@@ -313,10 +334,6 @@ describe("xai web search config resolution", () => {
         },
       },
     });
-    if (!tool) {
-      throw new Error("Expected xAI web search tool");
-    }
-
     await tool.execute({ query: "OpenClaw Grok OAuth web search" });
 
     expect(providerAuthRuntimeMocks.resolveApiKeyForProvider).toHaveBeenCalledWith(
@@ -336,8 +353,7 @@ describe("xai web search config resolution", () => {
       profileId: "xai:active",
     });
     const mockFetch = installXaiWebSearchFetch();
-    const provider = createXaiWebSearchProvider();
-    const tool = provider.createTool({
+    const tool = requireXaiWebSearchTool({
       agentDir: "/tmp/openclaw-xai-active-agent",
       config: {
         agents: {
@@ -348,10 +364,6 @@ describe("xai web search config resolution", () => {
         },
       },
     });
-    if (!tool) {
-      throw new Error("Expected xAI web search tool");
-    }
-
     await tool.execute({ query: "OpenClaw Grok active agent OAuth web search" });
 
     expect(providerAuthRuntimeMocks.resolveApiKeyForProvider).toHaveBeenCalledWith(
@@ -391,8 +403,7 @@ describe("xai web search config resolution", () => {
         }),
       );
     global.fetch = withFetchPreconnect(mockFetch);
-    const provider = createXaiWebSearchProvider();
-    const tool = provider.createTool({
+    const tool = requireXaiWebSearchTool({
       config: {
         agents: {
           list: [{ id: "main", default: true, agentDir: "/tmp/openclaw-xai-main-agent" }],
@@ -406,10 +417,6 @@ describe("xai web search config resolution", () => {
         },
       },
     });
-    if (!tool) {
-      throw new Error("Expected xAI web search tool");
-    }
-
     const result = await tool.execute({ query: "OpenClaw Grok OAuth refresh test" });
 
     expect(result.content).toContain("Fresh OAuth Grok answer");
@@ -460,8 +467,7 @@ describe("xai web search config resolution", () => {
         }),
       );
     global.fetch = withFetchPreconnect(mockFetch);
-    const provider = createXaiWebSearchProvider();
-    const tool = provider.createTool({
+    const tool = requireXaiWebSearchTool({
       config: {
         agents: {
           list: [{ id: "main", default: true, agentDir: "/tmp/openclaw-xai-main-agent" }],
@@ -475,10 +481,6 @@ describe("xai web search config resolution", () => {
         },
       },
     });
-    if (!tool) {
-      throw new Error("Expected xAI web search tool");
-    }
-
     const result = await tool.execute({ query: "OpenClaw Grok API fallback test" });
 
     expect(result.content).toContain("API key fallback Grok answer");
@@ -555,8 +557,7 @@ describe("xai web search config resolution", () => {
         }),
       );
     global.fetch = withFetchPreconnect(mockFetch);
-    const provider = createXaiWebSearchProvider();
-    const tool = provider.createTool({
+    const tool = requireXaiWebSearchTool({
       config: {
         agents: {
           list: [{ id: "main", default: true, agentDir: "/tmp/openclaw-xai-main-agent" }],
@@ -570,10 +571,6 @@ describe("xai web search config resolution", () => {
         },
       },
     });
-    if (!tool) {
-      throw new Error("Expected xAI web search tool");
-    }
-
     const result = await tool.execute({ query: "OpenClaw Grok profile fallback test" });
 
     expect(result.content).toContain("Profile API key Grok answer");
@@ -618,8 +615,7 @@ describe("xai web search config resolution", () => {
         }),
       );
     global.fetch = withFetchPreconnect(mockFetch);
-    const provider = createXaiWebSearchProvider();
-    const tool = provider.createTool({
+    const tool = requireXaiWebSearchTool({
       config: {
         agents: {
           list: [{ id: "main", default: true, agentDir: "/tmp/openclaw-xai-main-agent" }],
@@ -633,10 +629,6 @@ describe("xai web search config resolution", () => {
         },
       },
     });
-    if (!tool) {
-      throw new Error("Expected xAI web search tool");
-    }
-
     const result = await tool.execute({ query: "OpenClaw Grok API-key fallback test" });
 
     expect(result.content).toContain("Env fallback Grok answer");
@@ -1159,66 +1151,11 @@ describe("xai provider models", () => {
   });
 
   it("builds forward-compatible runtime models for newer Grok ids", () => {
-    const grok41 = resolveXaiForwardCompatModel({
-      providerId: "xai",
-      ctx: {
-        provider: "xai",
-        modelId: "grok-4-1-fast",
-        modelRegistry: { find: () => null } as never,
-        providerConfig: {
-          api: "openai-responses",
-          baseUrl: "https://api.x.ai/v1",
-        },
-      },
-    });
-    const grok420 = resolveXaiForwardCompatModel({
-      providerId: "xai",
-      ctx: {
-        provider: "xai",
-        modelId: "grok-4.20-0309-reasoning",
-        modelRegistry: { find: () => null } as never,
-        providerConfig: {
-          api: "openai-responses",
-          baseUrl: "https://api.x.ai/v1",
-        },
-      },
-    });
-    const grok43Alias = resolveXaiForwardCompatModel({
-      providerId: "xai",
-      ctx: {
-        provider: "xai",
-        modelId: "grok-4.3-latest",
-        modelRegistry: { find: () => null } as never,
-        providerConfig: {
-          api: "openai-responses",
-          baseUrl: "https://api.x.ai/v1",
-        },
-      },
-    });
-    const grok45Alias = resolveXaiForwardCompatModel({
-      providerId: "xai",
-      ctx: {
-        provider: "xai",
-        modelId: "grok-4.5-latest",
-        modelRegistry: { find: () => null } as never,
-        providerConfig: {
-          api: "openai-responses",
-          baseUrl: "https://api.x.ai/v1",
-        },
-      },
-    });
-    const grok3Mini = resolveXaiForwardCompatModel({
-      providerId: "xai",
-      ctx: {
-        provider: "xai",
-        modelId: "grok-3-mini-fast",
-        modelRegistry: { find: () => null } as never,
-        providerConfig: {
-          api: "openai-responses",
-          baseUrl: "https://api.x.ai/v1",
-        },
-      },
-    });
+    const grok41 = resolveForwardXaiModel("grok-4-1-fast");
+    const grok420 = resolveForwardXaiModel("grok-4.20-0309-reasoning");
+    const grok43Alias = resolveForwardXaiModel("grok-4.3-latest");
+    const grok45Alias = resolveForwardXaiModel("grok-4.5-latest");
+    const grok3Mini = resolveForwardXaiModel("grok-3-mini-fast");
 
     expect(grok41?.provider).toBe("xai");
     expect(grok41?.id).toBe("grok-4-1-fast");
@@ -1281,18 +1218,7 @@ describe("xai provider models", () => {
   });
 
   it("refuses the unsupported multi-agent endpoint ids", () => {
-    const model = resolveXaiForwardCompatModel({
-      providerId: "xai",
-      ctx: {
-        provider: "xai",
-        modelId: "grok-4.20-multi-agent-experimental-beta-0304",
-        modelRegistry: { find: () => null } as never,
-        providerConfig: {
-          api: "openai-responses",
-          baseUrl: "https://api.x.ai/v1",
-        },
-      },
-    });
+    const model = resolveForwardXaiModel("grok-4.20-multi-agent-experimental-beta-0304");
 
     expect(model).toBeUndefined();
   });


### PR DESCRIPTION
## What Problem This Solves
Fal image-generation and xAI realtime/web-search tests repeatedly reconstruct the same API-auth mocks, SSRF-guarded image responses, websocket bridge state, model-registry context, and error fixtures. That repetition obscures the security, validation, reconnection, and model-routing contracts actually under test and adds maintenance and execution overhead.

## Why This Change Was Made
- Extract typed, provider-local Fal image-response and validation fixtures; preserve each of the original named rejection cases and its fetch-guard assertion.
- Consolidate xAI realtime bridge/event setup while preserving callback ordering, reconnect, queued tool result, transcript, and cancellation scenarios.
- Reuse typed xAI web-search/model lookup setup without weakening OAuth fallback, request, alias, or unsupported-model assertions.
- Change provider-owned tests only: 322 insertions, 1,066 deletions, 744 net lines removed. No production, dependency, config, coverage, ratchet, snapshot, or ignore-list changes.

## User Impact
No runtime or product behavior changes. Provider contract tests are smaller, easier to audit, and retain their existing coverage and all 247 baseline scenarios.

## Evidence
- Immutable fork base: `b461ae6de88345ddcc69c787d99e6404c2206cba`.
- Correct Fal media Vitest lane: **43/43 passed**; exact before/after V8 statements `229/547`, branches `206/488`, functions `31/88`, and lines `227/543`.
- Correct provider Vitest lane: **204/204 passed**; exact before/after V8 statements `1723/6922`, branches `1277/6116`, functions `334/1310`, and lines `1706/6843`.
- Independent fresh autoreview: clean, score `0.96`, no accepted/actionable findings.
- Full remote `node scripts/check-changed.mjs --base b461ae6de88345ddcc69c787d99e6404c2206cba`: passed; timing JSON `exitCode=0`; extension test `tsgo`, targeted oxlint `0 warnings / 0 errors`, formatting, plugin boundaries, dependency pins, conflict-marker and duplicate guards all passed.
- Ratchets unchanged: `OPENCLAW_* 520/520`; max-lines `1052` grandfathered suppressions.
- AI assistance: implementation and remote validation were agent-assisted and independently autoreviewed.