### PR TITLE
fix(cron): completed jobs stay stuck behind slower batch runs

### DIFF
--- a/src/cron/service/timer-catchup.ts
+++ b/src/cron/service/timer-catchup.ts
@@ -1,6 +1,5 @@
 import { markCronJobActive } from "../active-jobs.js";
 import { createCronRunDiagnosticsFromError } from "../run-diagnostics.js";
-import type { CronJob } from "../types.js";
 import { normalizeCronRunErrorText } from "./execution-errors.js";
 import {
   computeJobPreviousRunAtMs,
@@ -33,13 +32,9 @@ import {
 } from "./timer-execution-timeout.js";
 import { executeJobCoreWithTimeout } from "./timer-job-runner.js";
 import {
-  clearActiveMarkersForOutcomes,
   clearUnstartedStartupCatchupReservationMarkers,
-  filterCurrentCronRunOutcomes,
-  finishPersistedQuietCronTaskRuns,
-  finishRetiredCronTaskRuns,
+  createCompletedCronRunOutcomeDrain,
 } from "./timer-outcome-finalization.js";
-import { applyOutcomeToStoredJob } from "./timer-outcomes.js";
 import { collectRunnableJobs, isRunnableJob } from "./timer-runnable.js";
 import { maybeNotifyIsolatedAgentSetupTimeout } from "./timer-scheduler.js";
 
@@ -139,10 +134,23 @@ export async function runMissedJobs(
     return;
   }
 
-  const execution = await executeStartupCatchupPlan(state, plan);
+  const completedOutcomeDrain = createCompletedCronRunOutcomeDrain(state, {
+    discardWhenStopped: true,
+    repairFutureCronNextRunAtMs: false,
+  });
+  const execution = await executeStartupCatchupPlan(state, plan, completedOutcomeDrain);
   let finalizedOutcomes: TimedCronRunOutcome[];
   try {
-    finalizedOutcomes = await applyStartupCatchupOutcomes(state, plan, execution.outcomes);
+    let completedOutcomes: TimedCronRunOutcome[];
+    try {
+      completedOutcomes = await completedOutcomeDrain.flush();
+    } catch (drainError) {
+      // Preserve overflow wake times and release every unstarted reservation
+      // even when a completed sibling's terminal store write has failed.
+      await applyStartupCatchupOutcomes(state, plan, execution.outcomes);
+      throw drainError;
+    }
+    finalizedOutcomes = await applyStartupCatchupOutcomes(state, plan, completedOutcomes);
   } catch (finalizationError) {
     if (execution.ok) {
       try {
@@ -271,6 +279,7 @@ async function planStartupCatchup(
 async function executeStartupCatchupPlan(
   state: CronServiceState,
   plan: StartupCatchupPlan,
+  completedOutcomeDrain: ReturnType<typeof createCompletedCronRunOutcomeDrain>,
 ): Promise<StartupCatchupExecution> {
   const outcomes: TimedCronRunOutcome[] = [];
   try {
@@ -353,7 +362,10 @@ async function executeStartupCatchupPlan(
         break;
       }
       if (admission.value) {
+        // Catch-up execution stays sequential, while completed outcomes
+        // persist in coalesced batches before slower siblings have to drain.
         outcomes.push(admission.value);
+        completedOutcomeDrain.enqueue(admission.value);
       }
     }
   } catch (error) {
@@ -425,103 +437,69 @@ async function applyStartupCatchupOutcomes(
   outcomes: TimedCronRunOutcome[],
 ): Promise<TimedCronRunOutcome[]> {
   const staggerMs = Math.max(0, state.deps.missedJobStaggerMs ?? DEFAULT_MISSED_JOB_STAGGER_MS);
-  try {
-    const currentOutcomes = filterCurrentCronRunOutcomes(outcomes);
-    let finalizedOutcomes: TimedCronRunOutcome[] = [];
-    await locked(state, async () => {
-      // Catch-up runners can rewrite delivery targets or remove their own jobs.
-      // Reload before merging outcomes so the startup snapshot cannot overwrite them.
-      await ensureLoaded(state, {
-        forceReload: true,
-        skipRecompute: true,
-      });
-      if (!state.store) {
-        return;
-      }
-      if (state.stopped) {
-        const rollbackSnapshot = snapshotStoreForRollback(state);
-        finishRetiredCronTaskRuns(state, outcomes, []);
-        const pendingReleases = clearUnstartedStartupCatchupReservationMarkers(
-          state,
-          plan,
-          outcomes,
-        );
-        if (pendingReleases.length > 0) {
-          recomputeNextRunsForMaintenance(state, { repairFutureCronNextRunAtMs: false });
-          await persistOrRestore(state, rollbackSnapshot);
-          for (const pending of pendingReleases) {
-            releaseQueuedCronRun(state, pending.jobId, pending.reservationIdentity);
-          }
-        }
-        return;
-      }
-
-      finalizedOutcomes = filterCurrentCronRunOutcomes(currentOutcomes);
-      finishRetiredCronTaskRuns(state, outcomes, finalizedOutcomes);
+  await locked(state, async () => {
+    // Each completed run is already durable. Reload before releasing or
+    // staggering sibling reservations so their current rows stay authoritative.
+    await ensureLoaded(state, { forceReload: true, skipRecompute: true });
+    if (!state.store) {
+      return;
+    }
+    if (state.stopped) {
       const rollbackSnapshot = snapshotStoreForRollback(state);
       const pendingReleases = clearUnstartedStartupCatchupReservationMarkers(state, plan, outcomes);
-      const removedJobs: CronJob[] = [];
-      for (const result of finalizedOutcomes) {
-        const removedJob = applyOutcomeToStoredJob(state, result);
-        if (removedJob) {
-          removedJobs.push(removedJob);
+      if (pendingReleases.length > 0) {
+        recomputeNextRunsForMaintenance(state, { repairFutureCronNextRunAtMs: false });
+        await persistOrRestore(state, rollbackSnapshot);
+        for (const pending of pendingReleases) {
+          releaseQueuedCronRun(state, pending.jobId, pending.reservationIdentity);
         }
       }
-      if (finalizedOutcomes.length === 0 && plan.deferredJobs.length === 0) {
-        if (pendingReleases.length > 0) {
-          recomputeNextRunsForMaintenance(state, { repairFutureCronNextRunAtMs: false });
-          await persistOrRestore(state, rollbackSnapshot);
-          for (const pending of pendingReleases) {
-            releaseQueuedCronRun(state, pending.jobId, pending.reservationIdentity);
-          }
-        }
-        return;
-      }
+      return;
+    }
 
-      if (plan.deferredJobs.length > 0) {
-        const baseNow = state.deps.nowMs();
-        let offset = staggerMs;
-        for (const deferred of plan.deferredJobs) {
-          const jobId = deferred.jobId;
-          const job = state.store.jobs.find((entry) => entry.id === jobId);
-          if (!job || !isJobEnabled(job)) {
-            continue;
-          }
-          if (typeof deferred.delayMs === "number") {
-            const runAtMs = baseNow + deferred.delayMs + offset - staggerMs;
-            job.state.nextRunAtMs = runAtMs;
-            job.state.startupCatchupAtMs = runAtMs;
-            offset += staggerMs;
-            continue;
-          }
-          const runAtMs = baseNow + offset;
+    const rollbackSnapshot = snapshotStoreForRollback(state);
+    const pendingReleases = clearUnstartedStartupCatchupReservationMarkers(state, plan, outcomes);
+    if (outcomes.length === 0 && plan.deferredJobs.length === 0) {
+      if (pendingReleases.length > 0) {
+        recomputeNextRunsForMaintenance(state, { repairFutureCronNextRunAtMs: false });
+        await persistOrRestore(state, rollbackSnapshot);
+        for (const pending of pendingReleases) {
+          releaseQueuedCronRun(state, pending.jobId, pending.reservationIdentity);
+        }
+      }
+      return;
+    }
+
+    if (plan.deferredJobs.length > 0) {
+      const baseNow = state.deps.nowMs();
+      let offset = staggerMs;
+      for (const deferred of plan.deferredJobs) {
+        const jobId = deferred.jobId;
+        const job = state.store.jobs.find((entry) => entry.id === jobId);
+        if (!job || !isJobEnabled(job)) {
+          continue;
+        }
+        if (typeof deferred.delayMs === "number") {
+          const runAtMs = baseNow + deferred.delayMs + offset - staggerMs;
           job.state.nextRunAtMs = runAtMs;
           job.state.startupCatchupAtMs = runAtMs;
           offset += staggerMs;
+          continue;
         }
-      }
-
-      // Preserve any new past-due nextRunAtMs values that became due while
-      // startup catch-up was running. They should execute on a future tick
-      // instead of being silently advanced. Future repair is disabled here so
-      // startup overflow deferrals survive until their staggered catch-up tick.
-      recomputeNextRunsForMaintenance(state, { repairFutureCronNextRunAtMs: false });
-      await persistOrRestore(state, rollbackSnapshot);
-      for (const pending of pendingReleases) {
-        releaseQueuedCronRun(state, pending.jobId, pending.reservationIdentity);
-      }
-      finishPersistedQuietCronTaskRuns(state, finalizedOutcomes);
-      for (const removedJob of removedJobs) {
-        emit(state, { jobId: removedJob.id, action: "removed", job: removedJob });
-      }
-    });
-    return finalizedOutcomes;
-  } finally {
-    for (const outcome of outcomes) {
-      if (outcome.reservationIdentity) {
-        releaseQueuedCronRun(state, outcome.jobId, outcome.reservationIdentity);
+        const runAtMs = baseNow + offset;
+        job.state.nextRunAtMs = runAtMs;
+        job.state.startupCatchupAtMs = runAtMs;
+        offset += staggerMs;
       }
     }
-    clearActiveMarkersForOutcomes(outcomes);
-  }
+
+    // Startup overflow owns these staggered wake times; repairing future
+    // schedules here would silently move a deferred run to its natural slot.
+    recomputeNextRunsForMaintenance(state, { repairFutureCronNextRunAtMs: false });
+    await persistOrRestore(state, rollbackSnapshot);
+    for (const pending of pendingReleases) {
+      releaseQueuedCronRun(state, pending.jobId, pending.reservationIdentity);
+    }
+  });
+  return outcomes;
 }

--- a/src/cron/service/timer-outcome-finalization.ts
+++ b/src/cron/service/timer-outcome-finalization.ts
@@ -170,7 +170,7 @@ export async function finalizeCompletedCronRunOutcomes(
   }
 }
 
-export function finishPersistedQuietCronTaskRuns(
+function finishPersistedQuietCronTaskRuns(
   state: CronServiceState,
   outcomes: readonly CronTaskRunFinalizationOutcome[],
 ): void {
@@ -181,21 +181,19 @@ export function finishPersistedQuietCronTaskRuns(
   }
 }
 
-export function clearActiveMarkersForOutcomes(
-  outcomes: readonly CronTaskRunFinalizationOutcome[],
-): void {
+function clearActiveMarkersForOutcomes(outcomes: readonly CronTaskRunFinalizationOutcome[]): void {
   for (const outcome of outcomes) {
     clearCronJobActive(outcome.jobId, outcome.activeJobMarker);
   }
 }
 
-export function filterCurrentCronRunOutcomes<T extends CronTaskRunFinalizationOutcome>(
+function filterCurrentCronRunOutcomes<T extends CronTaskRunFinalizationOutcome>(
   outcomes: readonly T[],
 ): T[] {
   return outcomes.filter((outcome) => isCronActiveJobMarkerCurrent(outcome.activeJobMarker));
 }
 
-export function finishRetiredCronTaskRuns<T extends CronTaskRunFinalizationOutcome>(
+function finishRetiredCronTaskRuns<T extends CronTaskRunFinalizationOutcome>(
   state: CronServiceState,
   outcomes: readonly T[],
   currentOutcomes: readonly T[],

--- a/src/cron/service/timer-outcome-finalization.ts
+++ b/src/cron/service/timer-outcome-finalization.ts
@@ -1,9 +1,15 @@
 /** Finalizes cron task rows and active markers after timer outcome persistence. */
 import { clearCronJobActive, isCronActiveJobMarkerCurrent } from "../active-jobs.js";
 import type { CronActiveJobMarker } from "../active-jobs.js";
+import type { CronJob } from "../types.js";
+import { recomputeNextRunsForMaintenance } from "./jobs.js";
+import { locked } from "./locked.js";
 import { clearQueuedCronRunReservationMarker, releaseQueuedCronRun } from "./run-admission.js";
-import type { CronServiceState } from "./state.js";
+import { emit, type CronServiceState } from "./state.js";
+import { ensureLoaded, persistOrRestore, snapshotStoreForRollback } from "./store.js";
 import { tryFinishCronTaskRunWithoutHistory } from "./task-runs.js";
+import type { TimedCronRunOutcome } from "./timer-execution-timeout.js";
+import { applyOutcomeToStoredJob } from "./timer-outcomes.js";
 
 type CronTaskRunFinalizationOutcome = {
   jobId: string;
@@ -20,6 +26,149 @@ type CronTaskRunFinalizationOutcome = {
 type StartupCatchupReservationPlan = {
   candidates: readonly { jobId: string; reservedAtMs: number; reservationIdentity: object }[];
 };
+
+type CompletedCronRunOutcomeFinalizationOptions = {
+  clearOnFailure?: boolean;
+  discardWhenStopped?: boolean;
+  repairFutureCronNextRunAtMs?: boolean;
+};
+
+/** Coalesces terminal cron writes without holding an execution admission slot. */
+export function createCompletedCronRunOutcomeDrain(
+  state: CronServiceState,
+  opts?: CompletedCronRunOutcomeFinalizationOptions,
+) {
+  const pendingOutcomes: TimedCronRunOutcome[] = [];
+  const finalizedOutcomes: TimedCronRunOutcome[] = [];
+  let drainPromise: Promise<void> | undefined;
+  let drainFailure: { error: unknown } | undefined;
+
+  const startDrain = () => {
+    if (drainPromise || pendingOutcomes.length === 0) {
+      return;
+    }
+    // Sibling workers can finish together; yield before snapshotting so one
+    // locked reload and write settles every outcome already in the queue.
+    drainPromise = Promise.resolve()
+      .then(async () => {
+        while (pendingOutcomes.length > 0) {
+          const completed = pendingOutcomes.splice(0);
+          try {
+            finalizedOutcomes.push(
+              ...(await finalizeCompletedCronRunOutcomes(state, completed, opts)),
+            );
+          } catch (error) {
+            // One failed store write cannot abandon sibling outcomes: their
+            // marker and reservation cleanup still belongs to this drain.
+            drainFailure ??= { error };
+          }
+        }
+      })
+      .catch((error: unknown) => {
+        // Keep background failures observed; the owning scheduler propagates
+        // them when it joins the drain before completing its batch.
+        drainFailure ??= { error };
+      })
+      .finally(() => {
+        drainPromise = undefined;
+        if (pendingOutcomes.length > 0) {
+          startDrain();
+        }
+      });
+  };
+
+  return {
+    enqueue(outcome: TimedCronRunOutcome) {
+      pendingOutcomes.push(outcome);
+      startDrain();
+    },
+    async flush(): Promise<TimedCronRunOutcome[]> {
+      for (;;) {
+        const pendingDrain = drainPromise;
+        if (!pendingDrain) {
+          break;
+        }
+        await pendingDrain;
+      }
+      if (drainFailure) {
+        throw drainFailure.error;
+      }
+      return finalizedOutcomes.splice(0);
+    },
+  };
+}
+
+/** Durably finalizes finished work without waiting for unrelated cron runs. */
+export async function finalizeCompletedCronRunOutcomes(
+  state: CronServiceState,
+  outcomes: readonly TimedCronRunOutcome[],
+  opts?: CompletedCronRunOutcomeFinalizationOptions,
+): Promise<TimedCronRunOutcome[]> {
+  if (outcomes.length === 0) {
+    return [];
+  }
+
+  let finalizedOutcomes: TimedCronRunOutcome[] = [];
+  let finalizationSucceeded = false;
+  try {
+    const currentOutcomes = filterCurrentCronRunOutcomes(outcomes);
+    if (currentOutcomes.length === 0) {
+      finishRetiredCronTaskRuns(state, outcomes, currentOutcomes);
+      return [];
+    }
+
+    await locked(state, async () => {
+      await ensureLoaded(state, { forceReload: true, skipRecompute: true });
+      if (state.stopped && opts?.discardWhenStopped) {
+        // A replacement service owns the durable markers after shutdown;
+        // only retire the old run's task row without rewriting its state.
+        finishRetiredCronTaskRuns(state, outcomes, []);
+        finalizationSucceeded = true;
+        return;
+      }
+      finalizedOutcomes = filterCurrentCronRunOutcomes(currentOutcomes);
+      finishRetiredCronTaskRuns(state, outcomes, finalizedOutcomes);
+      if (finalizedOutcomes.length === 0) {
+        return;
+      }
+
+      const rollbackSnapshot = snapshotStoreForRollback(state);
+      const removedJobs: CronJob[] = [];
+      for (const outcome of finalizedOutcomes) {
+        const removedJob = applyOutcomeToStoredJob(state, outcome);
+        if (removedJob) {
+          removedJobs.push(removedJob);
+        }
+      }
+
+      // Preserve sibling jobs that became due while this run was executing.
+      // Startup overflow additionally owns its explicit deferred wake times.
+      recomputeNextRunsForMaintenance(
+        state,
+        opts?.repairFutureCronNextRunAtMs === false
+          ? { repairFutureCronNextRunAtMs: false }
+          : undefined,
+      );
+      await persistOrRestore(state, rollbackSnapshot);
+      finishPersistedQuietCronTaskRuns(state, finalizedOutcomes);
+      for (const removedJob of removedJobs) {
+        emit(state, { jobId: removedJob.id, action: "removed", job: removedJob });
+      }
+    });
+
+    finalizationSucceeded ||= finalizedOutcomes.length > 0;
+    return finalizedOutcomes;
+  } finally {
+    for (const outcome of outcomes) {
+      if (outcome.reservationIdentity) {
+        releaseQueuedCronRun(state, outcome.jobId, outcome.reservationIdentity);
+      }
+    }
+    if (opts?.clearOnFailure !== false || finalizationSucceeded) {
+      clearActiveMarkersForOutcomes(outcomes);
+    }
+  }
+}
 
 export function finishPersistedQuietCronTaskRuns(
   state: CronServiceState,

--- a/src/cron/service/timer-scheduler.ts
+++ b/src/cron/service/timer-scheduler.ts
@@ -41,12 +41,9 @@ import {
 import { executeJobCoreWithTimeout } from "./timer-job-runner.js";
 import { maybeNotifyIsolatedAgentSetupTimeoutWithRecovery } from "./timer-notifications.js";
 import {
-  clearActiveMarkersForOutcomes,
-  filterCurrentCronRunOutcomes,
-  finishPersistedQuietCronTaskRuns,
-  finishRetiredCronTaskRuns,
+  createCompletedCronRunOutcomeDrain,
+  finalizeCompletedCronRunOutcomes,
 } from "./timer-outcome-finalization.js";
-import { applyOutcomeToStoredJob } from "./timer-outcomes.js";
 import { collectRunnableJobs, isRunnableJob } from "./timer-runnable.js";
 
 export function maybeNotifyIsolatedAgentSetupTimeout(
@@ -355,64 +352,8 @@ async function onAdmittedTimer(state: CronServiceState) {
       }
     };
 
-    const finalizeCompletedResults = async (
-      completedResults: readonly TimedCronRunOutcome[],
-      opts?: { clearOnFailure?: boolean },
-    ): Promise<TimedCronRunOutcome[]> => {
-      if (completedResults.length === 0) {
-        return [];
-      }
-      let finalizedResults: TimedCronRunOutcome[] = [];
-      let finalizationSucceeded = false;
-      try {
-        const currentResults = filterCurrentCronRunOutcomes(completedResults);
-        if (currentResults.length === 0) {
-          finishRetiredCronTaskRuns(state, completedResults, currentResults);
-          return [];
-        }
-        await locked(state, async () => {
-          await ensureLoaded(state, { forceReload: true, skipRecompute: true });
-          finalizedResults = filterCurrentCronRunOutcomes(currentResults);
-          finishRetiredCronTaskRuns(state, completedResults, finalizedResults);
-          const rollbackSnapshot = snapshotStoreForRollback(state);
-          const removedJobs: CronJob[] = [];
-          for (const result of finalizedResults) {
-            const removedJob = applyOutcomeToStoredJob(state, result);
-            if (removedJob) {
-              removedJobs.push(removedJob);
-            }
-          }
-          if (finalizedResults.length === 0) {
-            return;
-          }
-
-          // Use maintenance-only recompute to avoid advancing past-due
-          // nextRunAtMs values that became due between findDueJobs and this
-          // locked block.  The full recomputeNextRuns would silently skip
-          // those jobs (advancing nextRunAtMs without execution), causing
-          // daily cron schedules to jump 48 h instead of 24 h (#17852).
-          recomputeNextRunsForMaintenance(state);
-          await persistOrRestore(state, rollbackSnapshot);
-          finishPersistedQuietCronTaskRuns(state, finalizedResults);
-          for (const removedJob of removedJobs) {
-            emit(state, { jobId: removedJob.id, action: "removed", job: removedJob });
-          }
-        });
-        finalizationSucceeded = finalizedResults.length > 0;
-        return finalizedResults;
-      } finally {
-        for (const result of completedResults) {
-          if (result.reservationIdentity) {
-            releaseQueuedCronRun(state, result.jobId, result.reservationIdentity);
-          }
-        }
-        if (opts?.clearOnFailure !== false || finalizationSucceeded) {
-          clearActiveMarkersForOutcomes(completedResults);
-        }
-      }
-    };
-
     const concurrency = Math.min(resolveRunConcurrency(), Math.max(1, dueJobs.length));
+    const completedOutcomeDrain = createCompletedCronRunOutcomeDrain(state);
     const claimedIndexes = new Set<number>();
     let reservationReleaseError: unknown;
     let setupTimeoutNotified = false;
@@ -547,11 +488,14 @@ async function onAdmittedTimer(state: CronServiceState) {
                 throw error;
               }
               if (!result.isolatedAgentSetupTimeout) {
-                return result;
+                // Drain finished state independently: a slow sibling must not
+                // strand outcomes, and store I/O must not own execution slots.
+                completedOutcomeDrain.enqueue(result);
+                return pMapSkip;
               }
               let finalizedResults: TimedCronRunOutcome[];
               try {
-                finalizedResults = await finalizeCompletedResults([result], {
+                finalizedResults = await finalizeCompletedCronRunOutcomes(state, [result], {
                   clearOnFailure: false,
                 });
               } catch {
@@ -588,10 +532,29 @@ async function onAdmittedTimer(state: CronServiceState) {
         { concurrency, stopOnError: false },
       );
     } catch (error) {
+      let finalizationError: unknown;
+      try {
+        await completedOutcomeDrain.flush();
+      } catch (drainError) {
+        finalizationError = drainError;
+      }
       await releaseUnclaimedDueJobReservationsWithRetry();
+      if (finalizationError) {
+        throw finalizationError instanceof Error
+          ? finalizationError
+          : new Error(formatErrorMessage(finalizationError));
+      }
       throw error instanceof AggregateError && error.errors.length > 0 ? error.errors[0] : error;
     }
     let postBatchError = reservationReleaseError;
+    try {
+      await completedOutcomeDrain.flush();
+    } catch (error) {
+      // Finalization errors still need to release every unclaimed durable
+      // reservation before the failed timer batch can exit.
+      postBatchError ??= error;
+      stopAdmittingDueJobs = true;
+    }
     if (stopAdmittingDueJobs) {
       try {
         await releaseUnclaimedDueJobReservationsWithRetry();
@@ -601,7 +564,7 @@ async function onAdmittedTimer(state: CronServiceState) {
     }
 
     if (completedResults.length > 0) {
-      const finalizedResults = await finalizeCompletedResults(completedResults);
+      const finalizedResults = await finalizeCompletedCronRunOutcomes(state, completedResults);
       for (const result of finalizedResults) {
         if (
           !setupTimeoutNotified &&

--- a/src/cron/service/timer.batch-finalization.test.ts
+++ b/src/cron/service/timer.batch-finalization.test.ts
@@ -1,0 +1,532 @@
+// Completed cron work must become durable before unrelated batch work drains.
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createDeferred,
+  createDueIsolatedJob,
+  noopLogger,
+  setupCronRegressionFixtures,
+} from "../../../test/helpers/cron/service-regression-fixtures.js";
+import { DEFAULT_CRON_MAX_CONCURRENT_RUNS } from "../../config/cron-limits.js";
+import { listTaskRecordsUnsorted } from "../../tasks/task-registry.js";
+import { resetTaskRegistryForTests } from "../../tasks/task-runtime.test-helpers.js";
+import { isCronJobActive, markCronJobActive } from "../active-jobs.js";
+import * as cronStoreModule from "../store.js";
+import { loadCronStore, saveCronStore } from "../store.js";
+import type { CronJob } from "../types.js";
+import { createCronServiceState } from "./state.js";
+import {
+  createCompletedCronRunOutcomeDrain,
+  finalizeCompletedCronRunOutcomes,
+} from "./timer-outcome-finalization.js";
+import { runMissedJobs } from "./timer.js";
+import { onTimer } from "./timer.test-support.js";
+
+const fixtures = setupCronRegressionFixtures({
+  prefix: "cron-service-batch-finalization-",
+});
+
+afterEach(() => {
+  resetTaskRegistryForTests();
+});
+
+type BatchTrigger = "scheduled" | "startup";
+
+function createBatchState(params: {
+  storePath: string;
+  nowMs: number;
+  runIsolatedAgentJob: Parameters<typeof createCronServiceState>[0]["runIsolatedAgentJob"];
+  concurrency?: number;
+  onEvent?: Parameters<typeof createCronServiceState>[0]["onEvent"];
+}) {
+  const state = createCronServiceState({
+    cronEnabled: true,
+    storePath: params.storePath,
+    log: noopLogger,
+    nowMs: () => params.nowMs,
+    enqueueSystemEvent: vi.fn(),
+    requestHeartbeat: vi.fn(),
+    runIsolatedAgentJob: params.runIsolatedAgentJob,
+    maxMissedJobsPerRestart: 40,
+    onEvent: params.onEvent,
+  });
+  if (params.concurrency !== undefined) {
+    state.runAdmission.active = DEFAULT_CRON_MAX_CONCURRENT_RUNS - params.concurrency;
+  }
+  return state;
+}
+
+function startBatch(
+  trigger: BatchTrigger,
+  state: ReturnType<typeof createCronServiceState>,
+): Promise<void> {
+  return trigger === "scheduled" ? onTimer(state) : runMissedJobs(state);
+}
+
+function findCronTask(jobId: string) {
+  return listTaskRecordsUnsorted().find(
+    (task) => task.runtime === "cron" && task.sourceId === jobId,
+  );
+}
+
+describe("cron batch outcome finalization", () => {
+  it("coalesces simultaneously finished outcomes into one durable write", async () => {
+    const store = fixtures.makeStorePath();
+    const dueAt = Date.parse("2026-02-06T10:05:01.000Z");
+    const jobs = ["coalesced-first", "coalesced-second"].map((id) => {
+      const job = createDueIsolatedJob({ id, nowMs: dueAt, nextRunAtMs: dueAt });
+      job.state.runningAtMs = dueAt;
+      return job;
+    });
+    await saveCronStore(store.storePath, { version: 1, jobs });
+
+    const save = cronStoreModule.saveCronJobsStore;
+    let terminalWrites = 0;
+    const saveSpy = vi
+      .spyOn(cronStoreModule, "saveCronJobsStore")
+      .mockImplementation(async (...args) => {
+        if (args[1].jobs.some((job) => job.state.lastRunStatus === "ok")) {
+          terminalWrites += 1;
+        }
+        return await save(...args);
+      });
+    const state = createBatchState({
+      storePath: store.storePath,
+      nowMs: dueAt,
+      runIsolatedAgentJob: vi.fn(),
+    });
+    const outcomeDrain = createCompletedCronRunOutcomeDrain(state);
+
+    try {
+      for (const job of jobs) {
+        outcomeDrain.enqueue({
+          jobId: job.id,
+          job,
+          activeJobMarker: markCronJobActive(job.id),
+          status: "ok",
+          startedAt: dueAt,
+          endedAt: dueAt,
+        });
+      }
+
+      expect(await outcomeDrain.flush()).toHaveLength(jobs.length);
+      expect(terminalWrites).toBe(1);
+      for (const job of jobs) {
+        expect(isCronJobActive(job.id)).toBe(false);
+      }
+    } finally {
+      saveSpy.mockRestore();
+    }
+  });
+
+  it("clears retired setup-timeout markers without rewriting stopped-service state", async () => {
+    const store = fixtures.makeStorePath();
+    const dueAt = Date.parse("2026-02-06T10:05:01.250Z");
+    const job = createDueIsolatedJob({
+      id: "stopped-setup-timeout-marker",
+      nowMs: dueAt,
+      nextRunAtMs: dueAt,
+    });
+    job.state.runningAtMs = dueAt;
+    await saveCronStore(store.storePath, { version: 1, jobs: [job] });
+
+    const state = createBatchState({
+      storePath: store.storePath,
+      nowMs: dueAt,
+      runIsolatedAgentJob: vi.fn(),
+    });
+    state.stopped = true;
+    const activeJobMarker = markCronJobActive(job.id);
+
+    expect(
+      await finalizeCompletedCronRunOutcomes(
+        state,
+        [
+          {
+            jobId: job.id,
+            job,
+            activeJobMarker,
+            status: "error",
+            error: "setup timed out before runner start",
+            startedAt: dueAt,
+            endedAt: dueAt,
+          },
+        ],
+        { clearOnFailure: false, discardWhenStopped: true },
+      ),
+    ).toEqual([]);
+    expect(isCronJobActive(job.id)).toBe(false);
+    expect((await loadCronStore(store.storePath)).jobs[0]?.state.runningAtMs).toBe(dueAt);
+  });
+
+  it("persists a completed scheduled run when its service stops during execution", async () => {
+    const store = fixtures.makeStorePath();
+    const dueAt = Date.parse("2026-02-06T10:05:01.375Z");
+    const job = createDueIsolatedJob({
+      id: "scheduled-completion-during-stop",
+      nowMs: dueAt,
+      nextRunAtMs: dueAt,
+    });
+    await saveCronStore(store.storePath, { version: 1, jobs: [job] });
+
+    const runStarted = createDeferred<void>();
+    const releaseRun = createDeferred<{ status: "ok"; summary: string }>();
+    const state = createBatchState({
+      storePath: store.storePath,
+      nowMs: dueAt,
+      runIsolatedAgentJob: vi.fn(async () => {
+        runStarted.resolve();
+        return await releaseRun.promise;
+      }),
+    });
+    const batch = onTimer(state);
+
+    try {
+      await runStarted.promise;
+      state.stopped = true;
+      releaseRun.resolve({ status: "ok", summary: "finished during shutdown" });
+      await batch;
+
+      const persistedJob = (await loadCronStore(store.storePath)).jobs[0];
+      expect(persistedJob?.state.lastRunStatus).toBe("ok");
+      expect(persistedJob?.state.runningAtMs).toBeUndefined();
+      expect(findCronTask(job.id)?.status).toBe("succeeded");
+      expect(state.queuedRunReservationsByJobId.size).toBe(0);
+      expect(isCronJobActive(job.id)).toBe(false);
+    } finally {
+      releaseRun.resolve({ status: "ok", summary: "finished during shutdown" });
+      await batch;
+      if (state.timer) {
+        clearTimeout(state.timer);
+      }
+    }
+  });
+
+  it.each(["scheduled", "startup"] as const)(
+    "releases %s execution admission while terminal persistence is blocked",
+    async (trigger) => {
+      const store = fixtures.makeStorePath();
+      const dueAt = Date.parse("2026-02-06T10:05:01.500Z");
+      const job = createDueIsolatedJob({
+        id: `${trigger}-blocked-terminal-persistence`,
+        nowMs: dueAt,
+        nextRunAtMs: dueAt,
+      });
+      await saveCronStore(store.storePath, { version: 1, jobs: [job] });
+
+      const terminalWriteStarted = createDeferred<void>();
+      const releaseTerminalWrite = createDeferred<void>();
+      const save = cronStoreModule.saveCronJobsStore;
+      const saveSpy = vi
+        .spyOn(cronStoreModule, "saveCronJobsStore")
+        .mockImplementation(async (...args) => {
+          const persistedJob = args[1].jobs.find((entry) => entry.id === job.id);
+          if (persistedJob?.state.lastRunStatus === "ok") {
+            terminalWriteStarted.resolve();
+            await releaseTerminalWrite.promise;
+          }
+          return await save(...args);
+        });
+      const state = createBatchState({
+        storePath: store.storePath,
+        nowMs: dueAt,
+        runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+      });
+
+      const batch = startBatch(trigger, state);
+      try {
+        await terminalWriteStarted.promise;
+        expect(state.runAdmission.active).toBe(0);
+        expect(findCronTask(job.id)?.status).toBe("succeeded");
+        expect((await loadCronStore(store.storePath)).jobs[0]?.state.runningAtMs).toBe(dueAt);
+      } finally {
+        releaseTerminalWrite.resolve();
+        await batch;
+        saveSpy.mockRestore();
+        if (state.timer) {
+          clearTimeout(state.timer);
+        }
+      }
+
+      expect(findCronTask(job.id)?.status).toBe("succeeded");
+      expect(isCronJobActive(job.id)).toBe(false);
+    },
+  );
+
+  it.each(["scheduled", "startup"] as const)(
+    "drains later %s completions after a sibling terminal write fails",
+    async (trigger) => {
+      const store = fixtures.makeStorePath();
+      const dueAt = Date.parse("2026-02-06T10:05:01.750Z");
+      const first = createDueIsolatedJob({
+        id: `${trigger}-failed-terminal-write`,
+        nowMs: dueAt,
+        nextRunAtMs: dueAt,
+      });
+      const second = createDueIsolatedJob({
+        id: `${trigger}-completion-after-terminal-failure`,
+        nowMs: dueAt,
+        nextRunAtMs: dueAt,
+      });
+      await saveCronStore(store.storePath, { version: 1, jobs: [first, second] });
+
+      const terminalWriteFailed = createDeferred<void>();
+      const secondStarted = createDeferred<void>();
+      const releaseSecond = createDeferred<{ status: "ok"; summary: string }>();
+      const save = cronStoreModule.saveCronJobsStore;
+      let rejectedTerminalWrite = false;
+      const saveSpy = vi
+        .spyOn(cronStoreModule, "saveCronJobsStore")
+        .mockImplementation(async (...args) => {
+          const persistedFirst = args[1].jobs.find((job) => job.id === first.id);
+          if (!rejectedTerminalWrite && persistedFirst?.state.lastRunStatus === "ok") {
+            rejectedTerminalWrite = true;
+            terminalWriteFailed.resolve();
+            throw new Error("cron terminal write failed");
+          }
+          return await save(...args);
+        });
+      const state = createBatchState({
+        storePath: store.storePath,
+        nowMs: dueAt,
+        runIsolatedAgentJob: vi.fn(async ({ job }) => {
+          if (job.id === second.id) {
+            secondStarted.resolve();
+            return await releaseSecond.promise;
+          }
+          return { status: "ok" as const, summary: "first completion" };
+        }),
+      });
+
+      const completion = startBatch(trigger, state).then(
+        () => undefined,
+        (error: unknown) => error,
+      );
+      try {
+        await terminalWriteFailed.promise;
+        await secondStarted.promise;
+        releaseSecond.resolve({ status: "ok", summary: "later completion" });
+
+        const failure = await completion;
+        expect(failure).toEqual(expect.objectContaining({ message: "cron terminal write failed" }));
+        const persistedSecond = (await loadCronStore(store.storePath)).jobs.find(
+          (job) => job.id === second.id,
+        );
+        expect(persistedSecond?.state.lastRunStatus).toBe("ok");
+        expect(persistedSecond?.state.runningAtMs).toBeUndefined();
+        expect(state.queuedRunReservationsByJobId.size).toBe(0);
+        expect(isCronJobActive(first.id)).toBe(false);
+        expect(isCronJobActive(second.id)).toBe(false);
+      } finally {
+        releaseSecond.resolve({ status: "ok", summary: "later completion" });
+        await completion;
+        saveSpy.mockRestore();
+        if (state.timer) {
+          clearTimeout(state.timer);
+        }
+      }
+    },
+  );
+
+  it("releases unstarted startup reservations when terminal finalization fails", async () => {
+    const store = fixtures.makeStorePath();
+    const dueAt = Date.parse("2026-02-06T10:05:01.875Z");
+    const first = createDueIsolatedJob({
+      id: "startup-failed-write-before-recovery",
+      nowMs: dueAt,
+      nextRunAtMs: dueAt,
+    });
+    const unstarted = createDueIsolatedJob({
+      id: "startup-unstarted-after-failed-write",
+      nowMs: dueAt,
+      nextRunAtMs: dueAt,
+    });
+    await saveCronStore(store.storePath, { version: 1, jobs: [first, unstarted] });
+
+    const save = cronStoreModule.saveCronJobsStore;
+    let rejectedTerminalWrite = false;
+    const saveSpy = vi
+      .spyOn(cronStoreModule, "saveCronJobsStore")
+      .mockImplementation(async (...args) => {
+        const persistedFirst = args[1].jobs.find((job) => job.id === first.id);
+        if (!rejectedTerminalWrite && persistedFirst?.state.lastRunStatus === "ok") {
+          rejectedTerminalWrite = true;
+          throw new Error("startup terminal write failed");
+        }
+        return await save(...args);
+      });
+    const runIsolatedAgentJob = vi.fn(async () => {
+      state.restartRecoveryPending = true;
+      return { status: "ok" as const, summary: "completed before restart recovery" };
+    });
+    const state = createBatchState({
+      storePath: store.storePath,
+      nowMs: dueAt,
+      runIsolatedAgentJob,
+    });
+
+    try {
+      await expect(runMissedJobs(state)).rejects.toThrow("startup terminal write failed");
+      expect(runIsolatedAgentJob).toHaveBeenCalledOnce();
+      const persistedUnstarted = (await loadCronStore(store.storePath)).jobs.find(
+        (job) => job.id === unstarted.id,
+      );
+      expect(persistedUnstarted?.state.queuedAtMs).toBeUndefined();
+      expect(persistedUnstarted?.state.runningAtMs).toBeUndefined();
+      expect(state.queuedRunReservationsByJobId.size).toBe(0);
+      expect(isCronJobActive(first.id)).toBe(false);
+      expect(isCronJobActive(unstarted.id)).toBe(false);
+    } finally {
+      saveSpy.mockRestore();
+      if (state.timer) {
+        clearTimeout(state.timer);
+      }
+    }
+  });
+
+  it.each([
+    { trigger: "scheduled" as const, concurrency: 1, deleteAfterRun: false },
+    { trigger: "scheduled" as const, concurrency: 1, deleteAfterRun: true },
+    { trigger: "scheduled" as const, concurrency: 2, deleteAfterRun: false },
+    { trigger: "scheduled" as const, concurrency: 2, deleteAfterRun: true },
+    { trigger: "startup" as const, concurrency: 1, deleteAfterRun: false },
+    { trigger: "startup" as const, concurrency: 1, deleteAfterRun: true },
+  ])(
+    "persists a completed $trigger job before its sibling drains (concurrency=$concurrency, deleteAfterRun=$deleteAfterRun)",
+    async ({ trigger, concurrency, deleteAfterRun }) => {
+      const store = fixtures.makeStorePath();
+      const dueAt = Date.parse("2026-02-06T10:05:02.000Z");
+      const first = createDueIsolatedJob({
+        id: `${trigger}-finished-${concurrency}-${deleteAfterRun}`,
+        nowMs: dueAt,
+        nextRunAtMs: dueAt,
+        deleteAfterRun,
+      });
+      const second = createDueIsolatedJob({
+        id: `${trigger}-blocked-${concurrency}-${deleteAfterRun}`,
+        nowMs: dueAt,
+        nextRunAtMs: dueAt,
+      });
+      await saveCronStore(store.storePath, { version: 1, jobs: [first, second] });
+
+      const secondStarted = createDeferred<void>();
+      const releaseSecond = createDeferred<{ status: "ok"; summary: string }>();
+      const events: Array<{ action: string; jobId: string; status?: string }> = [];
+      const state = createBatchState({
+        storePath: store.storePath,
+        nowMs: dueAt,
+        concurrency,
+        onEvent: (event) => events.push(event),
+        runIsolatedAgentJob: vi.fn(async ({ job }) => {
+          if (job.id === second.id) {
+            secondStarted.resolve();
+            return await releaseSecond.promise;
+          }
+          return { status: "ok" as const, summary: "finished first" };
+        }),
+      });
+
+      const batch = startBatch(trigger, state);
+      try {
+        await secondStarted.promise;
+        await vi.waitFor(async () => {
+          const jobs = (await loadCronStore(store.storePath)).jobs;
+          const persistedFirst = jobs.find((job) => job.id === first.id);
+          if (deleteAfterRun) {
+            expect(persistedFirst).toBeUndefined();
+          } else {
+            expect(persistedFirst?.state.lastRunStatus).toBe("ok");
+            expect(persistedFirst?.state.runningAtMs).toBeUndefined();
+          }
+          expect(jobs.find((job) => job.id === second.id)?.state.runningAtMs).toBe(dueAt);
+        });
+
+        expect(findCronTask(first.id)?.status).toBe("succeeded");
+        expect(findCronTask(second.id)?.status).toBe("running");
+        expect(isCronJobActive(first.id)).toBe(false);
+        expect(isCronJobActive(second.id)).toBe(true);
+        expect(events).toContainEqual(
+          expect.objectContaining({ action: "finished", jobId: first.id, status: "ok" }),
+        );
+        if (deleteAfterRun) {
+          expect(events).toContainEqual(
+            expect.objectContaining({ action: "removed", jobId: first.id }),
+          );
+        }
+      } finally {
+        releaseSecond.resolve({ status: "ok", summary: "finished second" });
+        await batch;
+        if (state.timer) {
+          clearTimeout(state.timer);
+        }
+      }
+
+      expect(findCronTask(second.id)?.status).toBe("succeeded");
+      expect(state.queuedRunReservationsByJobId.size).toBe(0);
+    },
+  );
+
+  it.each(["scheduled", "startup"] as const)(
+    "durably finalizes a large %s batch while its final run remains active",
+    async (trigger) => {
+      const store = fixtures.makeStorePath();
+      const dueAt = Date.parse("2026-02-06T10:05:03.000Z");
+      const jobCount = 32;
+      const jobs: CronJob[] = Array.from({ length: jobCount }, (_, index) =>
+        createDueIsolatedJob({
+          id: `${trigger}-stress-${String(index).padStart(2, "0")}`,
+          nowMs: dueAt,
+          nextRunAtMs: dueAt,
+        }),
+      );
+      await saveCronStore(store.storePath, { version: 1, jobs });
+
+      const lastJob = jobs.at(-1);
+      if (!lastJob) {
+        throw new Error("expected a final cron stress-test job");
+      }
+      const finalRunStarted = createDeferred<void>();
+      const releaseFinalRun = createDeferred<{ status: "ok"; summary: string }>();
+      const state = createBatchState({
+        storePath: store.storePath,
+        nowMs: dueAt,
+        runIsolatedAgentJob: vi.fn(async ({ job }) => {
+          if (job.id === lastJob.id) {
+            finalRunStarted.resolve();
+            return await releaseFinalRun.promise;
+          }
+          return { status: "ok" as const, summary: `finished ${job.id}` };
+        }),
+      });
+
+      const batch = startBatch(trigger, state);
+      try {
+        await finalRunStarted.promise;
+        await vi.waitFor(async () => {
+          const persistedJobs = (await loadCronStore(store.storePath)).jobs;
+          expect(
+            persistedJobs.filter(
+              (job) => job.id !== lastJob.id && job.state.lastRunStatus === "ok",
+            ),
+          ).toHaveLength(jobCount - 1);
+          expect(persistedJobs.find((job) => job.id === lastJob.id)?.state.runningAtMs).toBe(dueAt);
+        });
+
+        for (const job of jobs.slice(0, -1)) {
+          expect(findCronTask(job.id)?.status).toBe("succeeded");
+          expect(isCronJobActive(job.id)).toBe(false);
+        }
+        expect(findCronTask(lastJob.id)?.status).toBe("running");
+        expect(isCronJobActive(lastJob.id)).toBe(true);
+      } finally {
+        releaseFinalRun.resolve({ status: "ok", summary: "finished final job" });
+        await batch;
+        if (state.timer) {
+          clearTimeout(state.timer);
+        }
+      }
+
+      expect(findCronTask(lastJob.id)?.status).toBe("succeeded");
+      expect(state.queuedRunReservationsByJobId.size).toBe(0);
+    },
+  );
+});

--- a/src/cron/service/timer.regression.test.ts
+++ b/src/cron/service/timer.regression.test.ts
@@ -2028,7 +2028,8 @@ describe("cron service timer regressions", () => {
       .spyOn(cronStoreModule, "loadCronJobsStoreWithConfigJobs")
       .mockImplementation(async (storePath) => {
         loadCount += 1;
-        if (loadCount === 3) {
+        // The first catch-up outcome now reloads and persists before job two.
+        if (loadCount === 4) {
           throw new Error("startup activation reload failed");
         }
         return await realLoad(storePath);
@@ -2278,7 +2279,7 @@ describe("cron service timer regressions", () => {
 
       const timerPromise = onTimer(state);
       await secondStarted.promise;
-      expect(isCronJobActive(first.id)).toBe(true);
+      expect(isCronJobActive(first.id)).toBe(false);
       expect(isCronJobActive(second.id)).toBe(true);
       await vi.advanceTimersByTimeAsync(60_100);
       now += 60_100;


### PR DESCRIPTION
Related: #100471
Supersedes: #81572

## What Problem This Solves

Fixes an issue where completed cron jobs could remain marked as running, retain queued reservations, delay one-shot deletion, or lose their run history while another job in the same scheduled or restart-catch-up batch was still executing.

## Why This Change Was Made

Adapt Eduardo Piva's original incremental-finalization work in #81572 to the current SQLite-backed, split-module scheduler. Use a shared asynchronous, coalescing completion drain so completed scheduled and startup jobs become durable independently without occupying execution slots or performing one write per concurrently completed job. Preserve shutdown ownership, recovery deferrals, rollback, active-marker identity, timeout notifications, and cleanup after failed writes.

## User Impact

Completed scheduled jobs clear running state and reservations, record history, and remove successful one-shot jobs even when sibling runs block. Missed jobs recover safely after restart, graceful shutdown does not replay a completed job, and failed writes cannot strand sibling reservations.

## Evidence

Head tested: `f8343242233e6a9e871e965e462fe13d35fc5fc2`, synchronized onto the same Blacksmith Testbox lease.

Actual remote terminal output demonstrating scheduled and startup persistence while the final sibling remains running:

```text
$ pnpm test src/cron/service/timer.batch-finalization.test.ts src/cron/service/timer.regression.test.ts src/cron/service.restart-catchup.test.ts src/cron/service/ops.run-admission.test.ts src/cron/service/ops.run-admission-cleanup.test.ts

✓ src/cron/service/timer.batch-finalization.test.ts (16 tests)
  ✓ durably finalizes a large scheduled batch while its final run remains active
  ✓ durably finalizes a large startup batch while its final run remains active
✓ src/cron/service/timer.regression.test.ts (67 tests)
✓ src/cron/service/ops.run-admission.test.ts (18 tests)
✓ src/cron/service.restart-catchup.test.ts (23 tests)
✓ src/cron/service/ops.run-admission-cleanup.test.ts (15 tests)

Test Files  5 passed (5)
     Tests  139 passed (139)
```

The new runtime-backed tests read the actual SQLite cron store while the blocked run is still active and assert the first job's durable `runningAtMs` is cleared, its task record has succeeded, active and queued reservations are released, and `deleteAfterRun` removes a successful one-shot. They run both real scheduled timer admission and real startup catch-up against 32-job batches; all 16 cases pass in eight consecutive repetitions.

Actual head-specific production dead-code proof:

```text
$ pnpm deadcode:dependencies
$ pnpm deadcode:exports
[deadcode] Knip production unused-export scan passed with 0 entries.
[deadcode] Knip full-tree unused-export scan passed with 0 entries.
[deadcode] Knip script unused-export scan passed with 0 entries.
[deadcode] Knip production and full-tree unused-export checks passed with 0 entries.
```

Actual packaged product smoke:

```text
$ pnpm build
[build-all] phase timings: total 2m 1.3s
$ node dist/entry.js cron --help
Usage: openclaw cron [options] [command]
Manage cron jobs (via Gateway)
Commands:
  add      Add a cron job
  disable  Disable a cron job
  edit     Edit a cron job (patch fields)
  enable   Enable a cron job
  get      Get a cron job as JSON
  list     List cron jobs
  rm       Remove a cron job
  run      Run a cron job now (debug)
  runs     Show cron run history
  scratch  Read or replace a cron job’s private scratch
  show     Show a cron job
  status   Show cron scheduler status
```

- `pnpm check:changed`: all formatting, lint, production/test typechecks, plugin boundaries, SQLite schema/database-first guards, and runtime import-cycle checks pass.
- `pnpm test src/cron`: the complete 150-file cron suite passes.
- Gateway, cron CLI, agent-tool, notification, heartbeat, reconciliation, caller-scope, and gateway-protocol integration tests pass across five Vitest shards.
- Fresh `autoreview --mode uncommitted`: clean; no actionable findings.
- The older #81572 approach was compared, adapted to current `main`, and its author is credited directly in the commit.

AI-assisted; manually inspected and independently reviewed.