### PR TITLE
fix(openai): restrict device-code retries to transient transport errors

### DIFF
--- a/extensions/openai/openai-chatgpt-device-code.test.ts
+++ b/extensions/openai/openai-chatgpt-device-code.test.ts
@@ -337,6 +337,82 @@ describe("loginOpenAICodexDeviceCode", () => {
     expect(fetchMock).toHaveBeenCalledTimes(4);
   });
 
+  it("retries a network TypeError during authorization poll within the overall deadline", async () => {
+    vi.useFakeTimers();
+    const accessToken = createJwt({
+      exp: Math.floor(Date.now() / 1000) + 600,
+    });
+    let pollAttempts = 0;
+    const fetchMock = vi.fn<typeof fetch>(async (input, init) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      if (url.endsWith("/api/accounts/deviceauth/usercode")) {
+        return createJsonResponse({
+          device_auth_id: "device-auth-123",
+          user_code: "CODE-12345",
+          interval: "0",
+        });
+      }
+      if (url.endsWith("/api/accounts/deviceauth/token")) {
+        pollAttempts += 1;
+        if (pollAttempts === 1) {
+          throw new TypeError("fetch failed (DNS resolution failure)");
+        }
+        return createJsonResponse({
+          authorization_code: "authorization-code-123",
+          code_verifier: "code-verifier-123",
+        });
+      }
+      if (url.endsWith("/oauth/token")) {
+        return createJsonResponse({
+          access_token: accessToken,
+          refresh_token: "refresh-token-123",
+          expires_in: 600,
+        });
+      }
+      throw new Error(`unexpected OpenAI device-code URL: ${url}`);
+    });
+
+    const login = loginOpenAICodexDeviceCode({
+      fetchFn: fetchMock,
+      onVerification: async () => {},
+    });
+    await vi.advanceTimersByTimeAsync(0);
+
+    const resolved = expect(login).resolves.toMatchObject({ refresh: "refresh-token-123" });
+    await vi.advanceTimersByTimeAsync(30_000);
+    await resolved;
+    expect(pollAttempts).toBe(2);
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+  });
+
+  it("propagates a terminal polling error immediately instead of retrying", async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn<typeof fetch>(async (input, init) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      if (url.endsWith("/api/accounts/deviceauth/usercode")) {
+        return createJsonResponse({
+          device_auth_id: "device-auth-123",
+          user_code: "CODE-12345",
+          interval: "0",
+        });
+      }
+      if (url.endsWith("/api/accounts/deviceauth/token")) {
+        throw new Error("unexpected provider protocol error");
+      }
+      throw new Error(`unexpected OpenAI device-code URL: ${url}`);
+    });
+
+    const login = loginOpenAICodexDeviceCode({
+      fetchFn: fetchMock,
+      onVerification: async () => {},
+    });
+    login.catch(() => {});
+    await vi.advanceTimersByTimeAsync(0);
+
+    await expect(login).rejects.toThrow("unexpected provider protocol error");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
   it("aborts device-code polling without another request", async () => {
     vi.useFakeTimers();
     const controller = new AbortController();

--- a/extensions/openai/openai-chatgpt-device-code.ts
+++ b/extensions/openai/openai-chatgpt-device-code.ts
@@ -121,6 +121,20 @@ function isDeviceCodeOperationTimeoutError(error: unknown): boolean {
   return error instanceof Error && (error.name === "TimeoutError" || error.name === "AbortError");
 }
 
+function isDeviceCodeTransientTransportError(error: unknown): boolean {
+  // Timeout/abort errors from the fetch timeout mechanism.
+  if (isDeviceCodeOperationTimeoutError(error)) {
+    return true;
+  }
+  // TypeError from fetch (DNS resolution failure, socket hangup, connection
+  // refused, TLS failure, etc.) — these are transient network conditions that
+  // may resolve on retry within the 15-minute authorization deadline.
+  if (error instanceof TypeError) {
+    return true;
+  }
+  return false;
+}
+
 function rethrowIfDeviceCodeCallerAborted(signal: AbortSignal | undefined, error: unknown): void {
   if (signal?.aborted) {
     throw signal.reason instanceof Error ? signal.reason : error;
@@ -299,8 +313,11 @@ async function pollOpenAICodexDeviceCode(params: {
       });
     } catch (error) {
       rethrowIfDeviceCodeCallerAborted(params.signal, error);
-      // A stalled poll is transient; keep the overall 15-minute authorization deadline.
-      if (isDeviceCodeOperationTimeoutError(error)) {
+      // Transient transport errors (timeout, DNS resolution failure, socket
+      // hangup, connection refused, etc.) should not abort the 15-minute
+      // authorization flow. The deadline above bounds retry. Terminal provider,
+      // protocol, or programming errors still propagate immediately.
+      if (isDeviceCodeTransientTransportError(error)) {
         continue;
       }
       throw error;


### PR DESCRIPTION
Closes #114086
Replaces #114093

## What Problem This Solves

Fixes an issue where users authorizing via OpenAI Codex device code would see the entire 15-minute OAuth flow aborted if a transient network error (DNS resolution failure, socket hangup, etc.) occurred during polling.

## Why This Change Was Made

The polling loop already has a 15-minute deadline that bounds retry and guarantees termination. However, the original fix (#114093) used an unconditional `continue` that retried all errors, potentially masking terminal provider/protocol failures as a delayed 15-minute timeout.

This change adds `isDeviceCodeTransientTransportError` which retries only:
- `TimeoutError` / `AbortError` (timeout/abort from the fetch timeout mechanism)
- `TypeError` (network-level failures: DNS, TCP, TLS, etc.)

Terminal provider, protocol, or programming errors still propagate immediately.

## User Impact

Users no longer need to restart the entire Codex device authorization flow when a brief network hiccup occurs. Terminal errors remain visible immediately.

## Evidence

- 17/17 unit tests pass (2 new tests added: TypeError retry, terminal error propagation)
- No unhandled rejections in test output
- `extension-provider-openai` suite passes

## AI-Assisted

- [x] AI-assisted (Claude Fable 5 via Claude Code CLI)
- [x] Confirmed understanding of the code change
- [x] Ran existing tests