### PR TITLE
fix: preserve WhatsApp remote-logout state

### DIFF
--- a/extensions/whatsapp/src/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts
+++ b/extensions/whatsapp/src/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts
@@ -314,6 +314,39 @@ describe("web auto-reply connection", () => {
     expectErrorContaining(runtime.error, "Retry 1/2");
   });
 
+  it("marks an opening-phase remote logout as a terminal disconnect", async () => {
+    vi.mocked(waitForWaConnection).mockRejectedValueOnce({
+      output: { statusCode: 401 },
+    });
+    const listenerFactory = vi.fn(async () => createMockWebListener());
+    const sleep = vi.fn(async () => {});
+    const statuses: Array<{
+      running?: boolean;
+      connected?: boolean;
+      healthState?: string;
+      terminalDisconnect?: boolean;
+    }> = [];
+    const { runtime, run } = startWebAutoReplyMonitor({
+      monitorWebChannelFn: monitorWebChannel as never,
+      listenerFactory,
+      sleep,
+      statusSink: (next) => statuses.push({ ...next }),
+    });
+
+    await expect(run).resolves.toBeUndefined();
+
+    expect(waitForWaConnection).toHaveBeenCalledOnce();
+    expect(listenerFactory).not.toHaveBeenCalled();
+    expect(sleep).not.toHaveBeenCalled();
+    expect(statuses.at(-1)).toMatchObject({
+      running: false,
+      connected: false,
+      healthState: "logged-out",
+      terminalDisconnect: true,
+    });
+    expectErrorContaining(runtime.error, "openclaw channels login --channel whatsapp");
+  });
+
   it("keeps post-open Baileys 428 on the reconnect path", async () => {
     const sleep = vi.fn(async () => {});
     const scripted = createScriptedWebListenerFactory();

--- a/extensions/whatsapp/src/channel.status.test.ts
+++ b/extensions/whatsapp/src/channel.status.test.ts
@@ -1,0 +1,80 @@
+import type { PluginRuntime } from "openclaw/plugin-sdk/core";
+// Whatsapp tests cover runtime-aware linked status projection.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const runtimeMocks = vi.hoisted(() => ({
+  monitorWebChannel: vi.fn(),
+  readWebAuthSnapshot: vi.fn(),
+  readWebAuthState: vi.fn(),
+  readWebSelfId: vi.fn(),
+}));
+
+vi.mock("./channel-runtime-loader.js", () => ({
+  isWhatsAppAuthConfigured: vi.fn(async () => true),
+  loadWhatsAppChannelRuntime: vi.fn(async () => runtimeMocks),
+}));
+
+import { whatsappPlugin } from "./channel.js";
+import { setWhatsAppRuntime } from "./runtime.js";
+
+const account = {
+  accountId: "default",
+  authDir: "/tmp/whatsapp-auth",
+  enabled: true,
+  name: "Default",
+};
+
+describe("WhatsApp channel status", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setWhatsAppRuntime({
+      channel: {},
+      logging: { shouldLogVerbose: () => false },
+    } as unknown as PluginRuntime);
+    runtimeMocks.readWebAuthSnapshot.mockResolvedValue({
+      state: "linked",
+      authAgeMs: 10_000,
+      selfId: { e164: "+15555550100", jid: "15555550100@s.whatsapp.net", lid: null },
+    });
+    runtimeMocks.readWebAuthState.mockResolvedValue("linked");
+    runtimeMocks.readWebSelfId.mockReturnValue({ e164: "+15555550100", jid: null, lid: null });
+    runtimeMocks.monitorWebChannel.mockResolvedValue(undefined);
+  });
+
+  it("does not project cached revoked auth as linked", async () => {
+    const snapshot = {
+      accountId: "default",
+      running: false,
+      connected: false,
+      healthState: "logged-out",
+      lastError: "status=401",
+    };
+
+    const summary = await whatsappPlugin.status?.buildChannelSummary?.({
+      account: account as never,
+      cfg: {} as never,
+      defaultAccountId: "default",
+      snapshot,
+    });
+    const accountSnapshot = await whatsappPlugin.status?.buildAccountSnapshot?.({
+      account: account as never,
+      cfg: {} as never,
+      runtime: snapshot,
+    });
+
+    expect(summary).toMatchObject({
+      configured: true,
+      statusState: "not-linked",
+      linked: false,
+      authAgeMs: null,
+      self: { e164: null, jid: null, lid: null },
+      healthState: "logged-out",
+    });
+    expect(accountSnapshot).toMatchObject({
+      configured: true,
+      statusState: "not-linked",
+      linked: false,
+      healthState: "logged-out",
+    });
+  });
+});

--- a/extensions/whatsapp/src/channel.ts
+++ b/extensions/whatsapp/src/channel.ts
@@ -252,11 +252,13 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> =
                 selfId: { e164: null, jid: null, lid: null },
               };
           const linked =
-            typeof snapshot.linked === "boolean"
-              ? snapshot.linked
-              : auth.state === "unstable"
-                ? undefined
-                : auth.state === "linked";
+            snapshot.healthState === "logged-out"
+              ? false
+              : typeof snapshot.linked === "boolean"
+                ? snapshot.linked
+                : auth.state === "unstable"
+                  ? undefined
+                  : auth.state === "linked";
           const summaryAuthState =
             auth.state === "unstable"
               ? auth.state
@@ -295,12 +297,14 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> =
           };
         },
         resolveAccountSnapshot: ({ account, runtime }) => {
+          const locallyRevoked = runtime?.healthState === "logged-out";
           return {
             accountId: account.accountId,
             name: account.name,
             enabled: account.enabled,
             configured: Boolean(account.authDir),
             extra: {
+              ...(locallyRevoked ? { statusState: "not-linked", linked: false } : {}),
               connected: runtime?.connected ?? false,
               reconnectAttempts: runtime?.reconnectAttempts,
               lastConnectedAt: runtime?.lastConnectedAt ?? null,

--- a/extensions/whatsapp/src/status-issues.test.ts
+++ b/extensions/whatsapp/src/status-issues.test.ts
@@ -32,6 +32,28 @@ describe("collectWhatsAppStatusIssues", () => {
     ]);
   });
 
+  it("reports revoked cached credentials as logged out with relink guidance", () => {
+    const issues = collectWhatsAppStatusIssues([
+      {
+        accountId: "default",
+        enabled: true,
+        linked: false,
+        healthState: "logged-out",
+        lastError: "status=401",
+      },
+    ]);
+
+    expect(issues).toEqual([
+      {
+        channel: "whatsapp",
+        accountId: "default",
+        kind: "auth",
+        message: "Session logged out: status=401",
+        fix: "Run: openclaw channels login (scan QR on the gateway host).",
+      },
+    ]);
+  });
+
   it("reports auth reads that are still stabilizing", () => {
     const issues = collectWhatsAppStatusIssues([
       {

--- a/extensions/whatsapp/src/status-issues.ts
+++ b/extensions/whatsapp/src/status-issues.ts
@@ -74,6 +74,17 @@ export function collectWhatsAppStatusIssues(
         return;
       }
 
+      if (healthState === "logged-out") {
+        issues.push({
+          channel: "whatsapp",
+          accountId,
+          kind: "auth",
+          message: `Session logged out${lastError ? `: ${lastError}` : "."}`,
+          fix: `Run: ${formatCliCommand("openclaw channels login")} (scan QR on the gateway host).`,
+        });
+        return;
+      }
+
       if (!linked) {
         issues.push({
           channel: "whatsapp",
@@ -117,17 +128,6 @@ export function collectWhatsAppStatusIssues(
           kind: "runtime",
           message: `Linked but ${stateLabel}${reconnectAttempts != null ? ` (reconnectAttempts=${reconnectAttempts})` : ""}${lastError ? `: ${lastError}` : "."}`,
           fix: `Run: ${formatCliCommand("openclaw doctor")} (or restart the gateway). If it persists, relink via channels login and check logs.`,
-        });
-        return;
-      }
-
-      if (healthState === "logged-out") {
-        issues.push({
-          channel: "whatsapp",
-          accountId,
-          kind: "auth",
-          message: `Linked session logged out${lastError ? `: ${lastError}` : "."}`,
-          fix: `Run: ${formatCliCommand("openclaw channels login")} (scan QR on the gateway host).`,
         });
         return;
       }

--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -853,7 +853,12 @@ describe("server-channels auto restart", () => {
         setStatus: ChannelGatewayContext["setStatus"];
         accountId: string;
       }) => {
-        setStatus({ accountId, terminalDisconnect: true });
+        setStatus({
+          accountId,
+          terminalDisconnect: true,
+          healthState: "logged-out",
+          lastError: "relink required",
+        });
       },
     );
     installTestRegistry(createTestPlugin({ startAccount }));
@@ -864,7 +869,12 @@ describe("server-channels auto restart", () => {
 
     expect(startAccount).toHaveBeenCalledTimes(1);
     const snapshot = manager.getRuntimeSnapshot();
-    expect(snapshot.channelAccounts.discord?.[DEFAULT_ACCOUNT_ID]?.terminalDisconnect).toBe(true);
+    expect(snapshot.channelAccounts.discord?.[DEFAULT_ACCOUNT_ID]).toMatchObject({
+      terminalDisconnect: true,
+      healthState: "logged-out",
+      lastError: "relink required",
+      restartPending: false,
+    });
   });
 
   it("consumes rejected stop tasks during manual abort", async () => {

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -801,6 +801,11 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
               if (abort.signal.aborted || manuallyStopped.has(rKey) || !isCurrentTask()) {
                 return;
               }
+              if (getRuntime(channelId, id).terminalDisconnect) {
+                // Terminal status carries the operator-facing diagnosis and restart policy.
+                // Do not replace it with a generic clean-exit error before policy consumes it.
+                return;
+              }
               const message = "channel exited without an error";
               setRuntime(channelId, id, { accountId: id, lastError: message });
               log.error?.(`[${id}] ${message}`);


### PR DESCRIPTION
## What Problem This Solves

The existing `terminalDisconnect` lifecycle contract already prevents automatic restarts after terminal WhatsApp disconnects, but a normally resolving channel task could overwrite the actionable logout error with `channel exited without an error`. Status could also present locally cached, remotely revoked credentials as actively linked.

## Why This Change Was Made

This change reuses the existing terminal lifecycle state introduced by #78511 instead of adding another gateway return-value contract. The Gateway preserves terminal diagnostics before its existing restart-policy check. WhatsApp status projections treat `healthState: "logged-out"` as not linked while keeping the account configured, and health output reports the logout before the generic unlinked case.

No new Plugin SDK capability, opt-in flag, or terminal return sentinel is added. Genuine crashes and ordinary channel exits retain the existing restart policy.

## User Impact

After a remote WhatsApp logout, the channel remains stopped with `restartPending: false`, status no longer claims cached revoked credentials are linked, and operators receive the existing `openclaw channels login` relink guidance.

## Evidence

- Blacksmith Testbox `tbx_01kypgv7ewvbxec5p7ysjbbtcs`: WhatsApp status tests, 8/8 passed; opening-phase HTTP 401 E2E, 1/1 passed; Gateway terminal-stop and genuine crash-loop tests, 2/2 passed. Run: https://github.com/openclaw/openclaw/actions/runs/30436850216
- Blacksmith Testbox `tbx_01kyph8hz64h70qbf2y3e9rknn`: explicit seven-path `pnpm check:changed`, including all four typecheck lanes, formatting, SDK baseline, plugin boundaries, dead-code checks, lint, and static guards, passed. Run: https://github.com/openclaw/openclaw/actions/runs/30437342449
- Mandatory autoreview completed with no accepted/actionable findings after preserving terminal diagnostics.

## AI Assistance

Codex assisted with implementation, review, and validation. The final diff and current `main` terminal-disconnect lifecycle were inspected directly.
