### PR TITLE
fix(cli-compaction): treat no_compactable_entries as a benign compaction skip (#114385)

### DIFF
--- a/src/agents/command/cli-compaction.test.ts
+++ b/src/agents/command/cli-compaction.test.ts
@@ -104,6 +104,75 @@ describe("runCliTurnCompactionLifecycle", () => {
     await fs.rm(tmpDir, { recursive: true, force: true });
   });
 
+  it("accepts no compactable entries only from a successful compaction result", async () => {
+    const sessionEntry: SessionEntry = {
+      sessionId: "session-no-compactable-entries",
+      updatedAt: Date.now(),
+      sessionFile: "unused.jsonl",
+      contextTokens: 1_000,
+      totalTokens: 950,
+      totalTokensFresh: true,
+    };
+    const runLifecycle = (
+      ok: boolean,
+      reason = "no real conversation messages",
+      compacted = false,
+    ) => {
+      setCliCompactionTestDeps({
+        openSessionManager: () => ({ getBranch: () => [] }) as never,
+        ensureContextEnginesInitialized: () => {},
+        resolveContextEngine: async () => ({
+          info: { id: "test", name: "Test" },
+          async ingest() {
+            return { ingested: false };
+          },
+          async assemble(params) {
+            return { messages: params.messages, estimatedTokens: 0 };
+          },
+          async compact() {
+            return { ok, compacted, reason };
+          },
+        }),
+        createPreparedEmbeddedAgentSettingsManager: async () => ({
+          getCompactionReserveTokens: () => 200,
+          getCompactionKeepRecentTokens: () => 0,
+          applyOverrides: () => {},
+        }),
+        applyAgentAutoCompactionGuard: async () => ({ supported: true, disabled: false }),
+        shouldPreemptivelyCompactBeforePrompt: () => ({
+          route: "fits",
+          shouldCompact: false,
+          estimatedPromptTokens: 600,
+          promptBudgetBeforeReserve: 800,
+          overflowTokens: 0,
+          toolResultReducibleChars: 0,
+          effectiveReserveTokens: 200,
+        }),
+        resolveLiveToolResultMaxChars: () => 20_000,
+      });
+      return runCliTurnCompactionLifecycle({
+        cfg: {} as OpenClawConfig,
+        sessionId: sessionEntry.sessionId,
+        sessionKey: "agent:main:no-compactable-entries",
+        sessionEntry,
+        sessionAgentId: "main",
+        workspaceDir: tmpDir,
+        agentDir: tmpDir,
+        provider: "test-provider",
+        model: "test-model",
+      });
+    };
+
+    await expect(runLifecycle(true)).resolves.toBe(sessionEntry);
+    await expect(runLifecycle(false)).rejects.toThrow(
+      "CLI transcript compaction failed for test-provider/test-model: no real conversation messages",
+    );
+    await expect(runLifecycle(false, "already under target")).resolves.toBe(sessionEntry);
+    await expect(runLifecycle(false, "contradictory result", true)).rejects.toThrow(
+      "CLI transcript compaction failed for test-provider/test-model: contradictory result",
+    );
+  });
+
   it("compacts over-budget CLI transcripts and clears external CLI resume state", async () => {
     const sessionKey = "agent:main:cli";
     const sessionId = "session-cli";
@@ -732,7 +801,18 @@ describe("runCliTurnCompactionLifecycle", () => {
     expect(compactCalls).toHaveLength(1);
   });
 
-  it("surfaces nonrecoverable native harness CLI compaction failures", async () => {
+  it.each([
+    {
+      name: "a normal failed result",
+      compacted: false,
+      reason: "timed out waiting for codex app-server compaction",
+    },
+    {
+      name: "a contradictory compacted failure",
+      compacted: true,
+      reason: "contradictory native result",
+    },
+  ])("surfaces nonrecoverable native harness CLI compaction failures for $name", async (result) => {
     const sessionKey = "agent:main:codex-native-failure";
     const sessionId = "session-codex-native-failure";
     const sessionFile = path.join(tmpDir, "session-codex-native-failure.jsonl");
@@ -755,8 +835,8 @@ describe("runCliTurnCompactionLifecycle", () => {
     const ensureSelectedAgentHarnessPlugin = vi.fn(async () => undefined);
     const compactAgentHarnessSession = vi.fn(async () => ({
       ok: false,
-      compacted: false,
-      reason: "timed out waiting for codex app-server compaction",
+      compacted: result.compacted,
+      reason: result.reason,
     }));
     const recordCliCompactionInStore = vi.fn();
     setCliCompactionTestDeps({
@@ -795,9 +875,7 @@ describe("runCliTurnCompactionLifecycle", () => {
         provider: "codex",
         model: "gpt-5.5",
       }),
-    ).rejects.toThrow(
-      "CLI native harness compaction failed for codex/gpt-5.5: timed out waiting for codex app-server compaction",
-    );
+    ).rejects.toThrow(`CLI native harness compaction failed for codex/gpt-5.5: ${result.reason}`);
 
     expect(compactAgentHarnessSession).toHaveBeenCalledTimes(1);
     expect(compactCalls).toHaveLength(0);
@@ -1857,70 +1935,6 @@ describe("runCliTurnCompactionLifecycle", () => {
     expect(compactAgentHarnessSession).toHaveBeenCalledTimes(1);
     expect(compactCalls).toHaveLength(0);
     expect(recordCliCompactionInStore).toHaveBeenCalledTimes(1);
-  });
-
-  it("treats 'no real conversation messages' as a benign compaction skip without failureReason", async () => {
-    const sessionId = "session-no-real-msg";
-    const sessionKey = "agent:main:test";
-    const storePath = path.join(tmpDir, "sessions.json");
-    const sessionFile = path.join(tmpDir, `${sessionId}.jsonl`);
-    await writeSessionFile({ sessionFile, sessionId });
-
-    const sessionEntry: SessionEntry = {
-      sessionId,
-      sessionFile,
-      updatedAt: 1,
-    };
-    await persistSessionEntry({ sessionKey, storePath, entry: sessionEntry });
-
-    const compactCalls: Array<Parameters<ContextEngine["compact"]>[0]> = [];
-    const contextEngine = {
-      ...buildContextEngine({ compactCalls }),
-      async compact() {
-        return {
-          ok: true as const,
-          compacted: false as const,
-          reason: "no real conversation messages",
-        };
-      },
-    };
-
-    setCliCompactionTestDeps({
-      resolveCliBackendConfig: () => null,
-      resolveCliContextEngine: () => contextEngine,
-      readSessionTokens: () => ({
-        tokenCount: 9500,
-        modelContextWindow: 10_000,
-      }),
-      resolveCliCompactionPolicy: () => ({
-        compactionBudget: 2000,
-        route: "must_compact",
-        shouldCompact: true,
-        estimatedPromptTokens: 9500,
-        promptBudgetBeforeReserve: 8000,
-        overflowTokens: 1500,
-        toolResultReducibleChars: 0,
-        effectiveReserveTokens: 2000,
-      }),
-      resolveLiveToolResultMaxChars: () => 20_000,
-      applyAgentAutoCompactionGuard: vi.fn(async () => ({ supported: false })),
-    });
-
-    const result = await runCliTurnCompactionLifecycle({
-      cfg: {} as OpenClawConfig,
-      sessionId,
-      sessionKey,
-      sessionEntry,
-      sessionStore: storePath,
-      storePath,
-      sessionAgentId: "main",
-      workspaceDir: tmpDir,
-      agentDir: tmpDir,
-      provider: "openai",
-      model: "gpt-5.5",
-    });
-
-    expect(result).toEqual(sessionEntry);
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/agents/command/cli-compaction.test.ts
+++ b/src/agents/command/cli-compaction.test.ts
@@ -1858,5 +1858,69 @@ describe("runCliTurnCompactionLifecycle", () => {
     expect(compactCalls).toHaveLength(0);
     expect(recordCliCompactionInStore).toHaveBeenCalledTimes(1);
   });
+
+  it("treats 'no real conversation messages' as a benign compaction skip without failureReason", async () => {
+    const sessionId = "session-no-real-msg";
+    const sessionKey = "agent:main:test";
+    const storePath = path.join(tmpDir, "sessions.json");
+    const sessionFile = path.join(tmpDir, `${sessionId}.jsonl`);
+    await writeSessionFile({ sessionFile, sessionId });
+
+    const sessionEntry: SessionEntry = {
+      sessionId,
+      sessionFile,
+      updatedAt: 1,
+    };
+    await persistSessionEntry({ sessionKey, storePath, entry: sessionEntry });
+
+    const compactCalls: Array<Parameters<ContextEngine["compact"]>[0]> = [];
+    const contextEngine = {
+      ...buildContextEngine({ compactCalls }),
+      async compact() {
+        return {
+          ok: true as const,
+          compacted: false as const,
+          reason: "no real conversation messages",
+        };
+      },
+    };
+
+    setCliCompactionTestDeps({
+      resolveCliBackendConfig: () => null,
+      resolveCliContextEngine: () => contextEngine,
+      readSessionTokens: () => ({
+        tokenCount: 9500,
+        modelContextWindow: 10_000,
+      }),
+      resolveCliCompactionPolicy: () => ({
+        compactionBudget: 2000,
+        route: "must_compact",
+        shouldCompact: true,
+        estimatedPromptTokens: 9500,
+        promptBudgetBeforeReserve: 8000,
+        overflowTokens: 1500,
+        toolResultReducibleChars: 0,
+        effectiveReserveTokens: 2000,
+      }),
+      resolveLiveToolResultMaxChars: () => 20_000,
+      applyAgentAutoCompactionGuard: vi.fn(async () => ({ supported: false })),
+    });
+
+    const result = await runCliTurnCompactionLifecycle({
+      cfg: {} as OpenClawConfig,
+      sessionId,
+      sessionKey,
+      sessionEntry,
+      sessionStore: storePath,
+      storePath,
+      sessionAgentId: "main",
+      workspaceDir: tmpDir,
+      agentDir: tmpDir,
+      provider: "openai",
+      model: "gpt-5.5",
+    });
+
+    expect(result).toEqual(sessionEntry);
+  });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/agents/command/cli-compaction.ts
+++ b/src/agents/command/cli-compaction.ts
@@ -22,7 +22,10 @@ import {
   resolveEffectiveCompactionMode,
 } from "../agent-settings.js";
 import { resolveCliBackendConfig as resolveCliBackendConfigImpl } from "../cli-backends.js";
-import { classifyCompactionReason } from "../embedded-agent-runner/compact-reasons.js";
+import {
+  isBenignCompactionSkipReason,
+  isBenignCompactionSkipResult,
+} from "../embedded-agent-runner/compact-reasons.js";
 import { buildEmbeddedCompactionRuntimeContext } from "../embedded-agent-runner/compaction-runtime-context.js";
 import {
   compactContextEngineWithSafetyTimeout,
@@ -206,15 +209,6 @@ function isUnsupportedNativeHarnessCompaction(
   return result?.ok === false && result.failure?.reason === "unsupported_harness_compaction";
 }
 
-function isBenignCliCompactionNoopReason(reason: string | undefined): boolean {
-  const classification = classifyCompactionReason(reason);
-  return (
-    classification === "below_threshold" ||
-    classification === "already_compacted_recently" ||
-    classification === "no_compactable_entries"
-  );
-}
-
 function isIntentionalNativeAutoCompactionSkip(
   result: EmbeddedAgentCompactResult | undefined,
 ): boolean {
@@ -389,7 +383,7 @@ async function compactCliTranscript(params: {
     );
   } catch (error) {
     const reason = error instanceof Error ? error.message : String(error);
-    if (isBenignCliCompactionNoopReason(reason)) {
+    if (isBenignCompactionSkipReason(reason)) {
       log.info(
         `CLI transcript compaction skipped for ${params.provider}/${params.model}: ${reason}`,
       );
@@ -402,9 +396,9 @@ async function compactCliTranscript(params: {
     };
   }
 
-  if (!compactResult.compacted) {
+  if (!compactResult.ok || !compactResult.compacted) {
     const reason = compactResult.reason;
-    if (isBenignCliCompactionNoopReason(reason)) {
+    if (isBenignCompactionSkipResult(compactResult)) {
       log.info(
         `CLI transcript compaction skipped for ${params.provider}/${params.model}: ${reason}`,
       );
@@ -552,9 +546,9 @@ async function compactNativeHarnessCliTranscript(params: {
     };
   }
 
-  if (!result?.compacted) {
+  if (!result?.ok || !result.compacted) {
     const reason = result?.reason;
-    if (isBenignCliCompactionNoopReason(reason)) {
+    if (result && isBenignCompactionSkipResult(result)) {
       log.info(
         `CLI native harness compaction skipped for ${params.provider}/${params.model}: ${reason}`,
       );

--- a/src/agents/command/cli-compaction.ts
+++ b/src/agents/command/cli-compaction.ts
@@ -208,7 +208,11 @@ function isUnsupportedNativeHarnessCompaction(
 
 function isBenignCliCompactionNoopReason(reason: string | undefined): boolean {
   const classification = classifyCompactionReason(reason);
-  return classification === "below_threshold" || classification === "already_compacted_recently";
+  return (
+    classification === "below_threshold" ||
+    classification === "already_compacted_recently" ||
+    classification === "no_compactable_entries"
+  );
 }
 
 function isIntentionalNativeAutoCompactionSkip(
@@ -399,7 +403,7 @@ async function compactCliTranscript(params: {
   }
 
   if (!compactResult.compacted) {
-    const reason = compactResult.reason ?? "nothing to compact";
+    const reason = compactResult.reason;
     if (isBenignCliCompactionNoopReason(reason)) {
       log.info(
         `CLI transcript compaction skipped for ${params.provider}/${params.model}: ${reason}`,
@@ -407,7 +411,7 @@ async function compactCliTranscript(params: {
       return { compacted: false };
     }
     log.warn(
-      `CLI transcript compaction did not reduce context for ${params.provider}/${params.model}: ${reason}`,
+      `CLI transcript compaction did not reduce context for ${params.provider}/${params.model}: ${reason ?? "compaction did not reduce context"}`,
     );
     return {
       compacted: false,
@@ -549,7 +553,7 @@ async function compactNativeHarnessCliTranscript(params: {
   }
 
   if (!result?.compacted) {
-    const reason = result?.reason ?? "nothing to compact";
+    const reason = result?.reason;
     if (isBenignCliCompactionNoopReason(reason)) {
       log.info(
         `CLI native harness compaction skipped for ${params.provider}/${params.model}: ${reason}`,

--- a/src/agents/embedded-agent-runner/compact-reasons.test.ts
+++ b/src/agents/embedded-agent-runner/compact-reasons.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from "vitest";
 import {
   classifyCompactionReason,
   formatUnknownCompactionReasonDetail,
+  isBenignCompactionSkipResult,
+  isBenignCompactionSkipReason,
   resolveCompactionFailureReason,
 } from "./compact-reasons.js";
 
@@ -58,6 +60,30 @@ describe("classifyCompactionReason", () => {
   it("keeps unclassified provider errors in the stable unknown bucket", () => {
     expect(classifyCompactionReason("No API provider registered for api: ollama")).toBe("unknown");
   });
+});
+
+describe("isBenignCompactionSkipReason", () => {
+  it.each(["already under target", "already compacted recently"])(
+    "keeps the established %s skip contract",
+    (reason) => {
+      expect(isBenignCompactionSkipReason(reason)).toBe(true);
+    },
+  );
+
+  it("requires an explicit successful-result opt-in for empty transcripts", () => {
+    const reason = "no real conversation messages";
+    expect(isBenignCompactionSkipReason(reason)).toBe(false);
+    expect(isBenignCompactionSkipResult({ ok: true, compacted: false, reason })).toBe(true);
+    expect(isBenignCompactionSkipResult({ ok: false, compacted: false, reason })).toBe(false);
+    expect(isBenignCompactionSkipResult({ ok: true, compacted: true, reason })).toBe(false);
+  });
+
+  it.each([undefined, "Compaction timed out", "No API provider registered for api: ollama"])(
+    "does not hide the failure reason %s",
+    (reason) => {
+      expect(isBenignCompactionSkipResult({ ok: true, compacted: false, reason })).toBe(false);
+    },
+  );
 });
 
 describe("formatUnknownCompactionReasonDetail", () => {

--- a/src/agents/embedded-agent-runner/compact-reasons.ts
+++ b/src/agents/embedded-agent-runner/compact-reasons.ts
@@ -76,6 +76,27 @@ export function classifyCompactionReason(reason?: string): string {
   return "unknown";
 }
 
+/** Return whether a classified reason represents an intentional compaction no-op. */
+export function isBenignCompactionSkipReason(reason?: string): boolean {
+  const classification = classifyCompactionReason(reason);
+  return classification === "below_threshold" || classification === "already_compacted_recently";
+}
+
+/** Return whether a compaction result is an intentional no-op rather than a failure. */
+export function isBenignCompactionSkipResult(result: {
+  ok: boolean;
+  compacted: boolean;
+  reason?: string;
+}): boolean {
+  if (result.compacted) {
+    return false;
+  }
+  return (
+    isBenignCompactionSkipReason(result.reason) ||
+    (result.ok && classifyCompactionReason(result.reason) === "no_compactable_entries")
+  );
+}
+
 /** Sanitize an unknown reason into a short log/metric-safe detail suffix. */
 export function formatUnknownCompactionReasonDetail(reason?: string): string | undefined {
   const sanitized = sanitizeForLog((reason ?? "").replace(/\s+/g, " "))

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -1401,6 +1401,34 @@ describe("runMemoryFlushIfNeeded", () => {
     expect(incrementCompactionCountMock).not.toHaveBeenCalled();
     expect(onCompactionNotice).toHaveBeenNthCalledWith(1, "start");
     expect(onCompactionNotice).toHaveBeenNthCalledWith(2, "skipped");
+
+    onCompactionNotice.mockClear();
+    compactEmbeddedAgentSessionMock.mockResolvedValueOnce({
+      ok: false,
+      compacted: false,
+      reason: "no real conversation messages",
+    });
+    await expect(
+      runPreflightCompactionIfNeeded({
+        cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
+        followupRun: createTestFollowupRun({
+          sessionId: "session",
+          sessionFile,
+          sessionKey: "agent:main:main",
+        }),
+        defaultModel: "anthropic/claude-opus-4-6",
+        agentCfgContextTokens: 100,
+        sessionEntry,
+        sessionStore: { "agent:main:main": sessionEntry },
+        sessionKey: "agent:main:main",
+        storePath: path.join(rootDir, "sessions.json"),
+        isHeartbeat: false,
+        replyOperation: createReplyOperation(),
+        onCompactionNotice,
+      }),
+    ).rejects.toThrow("Preflight compaction required but failed: no real conversation messages");
+    expect(onCompactionNotice).toHaveBeenNthCalledWith(1, "start");
+    expect(onCompactionNotice).toHaveBeenNthCalledWith(2, "incomplete");
   });
 
   it("fails when required preflight context-engine compaction is deferred to background maintenance", async () => {

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -9,7 +9,7 @@ import {
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { resolveBootstrapWarningSignaturesSeen } from "../../agents/bootstrap-budget.js";
 import { estimateMessagesTokens } from "../../agents/compaction.js";
-import { classifyCompactionReason } from "../../agents/embedded-agent-runner/compact-reasons.js";
+import { isBenignCompactionSkipResult } from "../../agents/embedded-agent-runner/compact-reasons.js";
 import { runEmbeddedAgentEntry } from "../../agents/embedded-agent-runner/run-entry.js";
 import { isCliRuntimeAliasForProvider } from "../../agents/model-runtime-aliases.js";
 import { isCliProvider } from "../../agents/model-selection.js";
@@ -218,18 +218,6 @@ function resolveEffectivePromptTokens(
   // Flush gating projects the next input context by adding the previous
   // completion and the current user prompt estimate.
   return base + output + estimate;
-}
-
-function isPreflightCompactionSkipReason(reason?: string): boolean {
-  const classification = classifyCompactionReason(reason);
-  // Preflight compaction is a guardrail, not a hard dependency. These classes
-  // mean the context engine found nothing useful to compact, so the reply should
-  // continue instead of surfacing a generic user-facing failure.
-  return (
-    classification === "below_threshold" ||
-    classification === "no_compactable_entries" ||
-    classification === "already_compacted_recently"
-  );
 }
 
 function resolveMemoryFlushModelFallbackOptions(
@@ -1014,7 +1002,7 @@ export async function runPreflightCompactionIfNeeded(params: {
 
     if (!result?.ok) {
       const reason = result?.reason ?? "not_compacted";
-      if (isPreflightCompactionSkipReason(reason)) {
+      if (result && isBenignCompactionSkipResult(result)) {
         await notifyTerminalCompaction("skipped");
         logVerbose(`preflightCompaction skipped: sessionKey=${params.sessionKey} reason=${reason}`);
         return entry ?? params.sessionEntry;
@@ -1026,7 +1014,7 @@ export async function runPreflightCompactionIfNeeded(params: {
 
     if (!result.compacted) {
       const reason = normalizeOptionalString(result.reason) ?? "not_compacted";
-      if (isPreflightCompactionSkipReason(reason)) {
+      if (isBenignCompactionSkipResult(result)) {
         await notifyTerminalCompaction("skipped");
         logVerbose(`preflightCompaction skipped: sessionKey=${params.sessionKey} reason=${reason}`);
         return entry ?? params.sessionEntry;

--- a/src/auto-reply/reply/commands-compact.test.ts
+++ b/src/auto-reply/reply/commands-compact.test.ts
@@ -317,6 +317,33 @@ describe("handleCompactCommand", () => {
     expect(vi.mocked(incrementCompactionCount)).not.toHaveBeenCalled();
   });
 
+  it("does not hide a failed manual compaction with an empty-transcript reason", async () => {
+    vi.mocked(compactEmbeddedAgentSession).mockResolvedValueOnce({
+      ok: false,
+      compacted: false,
+      reason: "no real conversation messages",
+    });
+
+    const result = await handleCompactCommand(
+      {
+        ...buildCompactParams("/compact", {
+          commands: { text: true },
+          channels: { whatsapp: { allowFrom: ["*"] } },
+        } as OpenClawConfig),
+        sessionEntry: {
+          sessionId: "session-1",
+          updatedAt: Date.now(),
+        },
+      } as HandleCommandsParams,
+      true,
+    );
+
+    expect(result?.reply?.text).toBe(
+      "⚙️ Compaction failed: nothing compactable in this session yet • Context 12.1k",
+    );
+    expect(vi.mocked(incrementCompactionCount)).not.toHaveBeenCalled();
+  });
+
   it("treats already_compacted_recently manual compaction as skipped", async () => {
     vi.mocked(compactEmbeddedAgentSession).mockResolvedValueOnce({
       ok: false,

--- a/src/auto-reply/reply/commands-compact.ts
+++ b/src/auto-reply/reply/commands-compact.ts
@@ -6,7 +6,10 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 import { resolveAgentDir, resolveSessionAgentId } from "../../agents/agent-scope.js";
 import { resolveContextTokensForModel } from "../../agents/context.js";
-import { classifyCompactionReason } from "../../agents/embedded-agent-runner/compact-reasons.js";
+import {
+  classifyCompactionReason,
+  isBenignCompactionSkipResult,
+} from "../../agents/embedded-agent-runner/compact-reasons.js";
 import { resolveAgentHarnessPolicy } from "../../agents/harness/policy.js";
 import {
   OPENAI_CODEX_PROVIDER_ID,
@@ -51,17 +54,6 @@ function extractCompactInstructions(params: {
     rest = rest.slice(1).trimStart();
   }
   return rest.length ? rest : undefined;
-}
-
-function isCompactionSkipReason(reason?: string): boolean {
-  const classification = classifyCompactionReason(reason);
-  // Manual /compact mirrors preflight semantics: already-small sessions are a
-  // successful no-op, not a failed compaction.
-  return (
-    classification === "no_compactable_entries" ||
-    classification === "below_threshold" ||
-    classification === "already_compacted_recently"
-  );
 }
 
 function formatCompactionReason(reason?: string): string | undefined {
@@ -298,7 +290,7 @@ export const handleCompactCommand: CommandHandler = async (params) => {
   });
 
   const compactLabel =
-    result.ok || isCompactionSkipReason(result.reason)
+    result.ok || isBenignCompactionSkipResult(result)
       ? result.compacted
         ? result.result?.tokensBefore != null && result.result?.tokensAfter != null
           ? `Compacted (${runtime.formatTokenCount(result.result.tokensBefore)} → ${runtime.formatTokenCount(result.result.tokensAfter)})`


### PR DESCRIPTION
Fixes #114385

## What Problem This Solves

Current main turns a successful empty-transcript compaction result — `{ ok: true, compacted: false, reason: "no real conversation messages" }` — into `CLI transcript compaction failed`. That can block caller flows such as subagent completion delivery even though the compaction owner correctly reported that there was genuinely nothing to compact.

## Fix

Move benign/no-op classification to the canonical owner in `src/agents/compact-reasons.ts` and make it result-aware. `no_compactable_entries` is benign only for `{ ok: true, compacted: false }`. Failed results, exceptions, undefined or unknown outcomes, timeout/guard/provider errors, and contradictory `{ ok: false, compacted: true }` states remain failures. Existing below-threshold and already-compacted compatibility remains benign.

CLI context/native compaction, manual `/compact`, and memory preflight now share that owner. Success side effects require both `ok` and `compacted`, so the change cannot mask a failed empty-candidate computation.

## Evidence

- Exact head: `a38bd75bacd9d7405f91f3ef87a0e9837732fec4`.
- Current-main production lifecycle probe reproduced the thrown CLI failure for the successful no-real-messages result.
- Focused Blacksmith Testbox proof: 110 tests passed across CLI compaction, canonical reason ownership, manual `/compact`, and memory preflight.
- Failure-masking coverage includes failed empty results, contradictory compacted failures, exceptions, undefined/unknown outcomes, timeout, guard, and provider failures.
- `git diff --check` passed.
- Autoreview: clean.
- Independent adversarial review: `NO-ACTIONABLE-OBJECTION`.
- Exact-head hosted CI is required before merge.

ClawSweeper rank-up moves: exact-head `check-test-types` is required before merge. A separate end-to-end completion-delivery transcript is intentionally omitted because the corrected shared lifecycle result is the decision boundary used by that caller; the production lifecycle reproduction and 110-test sibling suite exercise the changed branch without adding a caller-specific bypass.

#114386 changes compaction estimation and trigger timing only; the two fixes are independently landable.

AI-assisted: yes. The maintainer rewrite was reviewed against current main, the canonical terminal-state owner, sibling compaction consumers, and contributor credit is preserved.
