### PR TITLE
fix(zalo): deliver text when optional media is blank

### DIFF
--- a/extensions/zalo/src/actions.test.ts
+++ b/extensions/zalo/src/actions.test.ts
@@ -74,9 +74,11 @@ describe("zaloMessageActions.handleAction", () => {
     const [url, request] = fetchMock.mock.calls[0] ?? [];
     expect(url).toBe("https://bot-api.zaloplatforms.com/bottest-zalo-token/sendMessage");
     expect(request?.method).toBe("POST");
-    expect(JSON.parse(String(request?.body))).toEqual({
-      chat_id: "dm-chat-blank-media",
-      text: "hello there",
-    });
+    expect(request?.body).toBe(
+      JSON.stringify({
+        chat_id: "dm-chat-blank-media",
+        text: "hello there",
+      }),
+    );
   });
 });

--- a/extensions/zalo/src/actions.test.ts
+++ b/extensions/zalo/src/actions.test.ts
@@ -1,4 +1,5 @@
 // Zalo tests cover actions plugin behavior.
+import http from "node:http";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { zaloMessageActions } from "./actions.js";
 import type { OpenClawConfig } from "./runtime-api.js";
@@ -37,48 +38,89 @@ describe("zaloMessageActions.describeMessageTool", () => {
 describe("zaloMessageActions.handleAction", () => {
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllEnvs();
   });
 
-  it("sends text to the Bot API when the message tool supplies whitespace-only media", async () => {
-    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      Response.json({
-        ok: true,
-        result: { message_id: "z-msg-with-blank-media" },
-      }),
-    );
+  it("sends whitespace-only media as text over the real Bot API HTTP transport", async () => {
     const handleAction = zaloMessageActions.handleAction;
     if (!handleAction) {
       throw new Error("Expected Zalo message action handler");
     }
 
-    await handleAction({
-      channel: "zalo",
-      action: "send",
-      params: {
-        to: "dm-chat-blank-media",
-        message: "hello there",
-        media: "   ",
-      },
-      cfg: {
-        channels: {
-          zalo: {
-            enabled: true,
-            botToken: "test-zalo-token",
+    const requests: Array<{
+      method: string | undefined;
+      path: string | undefined;
+      contentType: string | undefined;
+      body: string;
+    }> = [];
+    const server = http.createServer((request, response) => {
+      let body = "";
+      request.setEncoding("utf8");
+      request.on("data", (chunk: string) => {
+        body += chunk;
+      });
+      request.on("end", () => {
+        requests.push({
+          method: request.method,
+          path: request.url,
+          contentType: request.headers["content-type"],
+          body,
+        });
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end(
+          JSON.stringify({
+            ok: true,
+            result: { message_id: "z-msg-with-blank-media" },
+          }),
+        );
+      });
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    const { port } = server.address() as { port: number };
+    vi.stubEnv("ZALO_API_URL", `http://127.0.0.1:${port}/zalo/`);
+
+    try {
+      const result = await handleAction({
+        channel: "zalo",
+        action: "send",
+        params: {
+          to: "dm-chat-blank-media",
+          message: "hello there",
+          media: "   ",
+        },
+        cfg: {
+          channels: {
+            zalo: {
+              enabled: true,
+              botToken: "test-zalo-token",
+            },
           },
         },
-      },
-      accountId: "default",
-    });
+        accountId: "default",
+      });
 
-    expect(fetchMock).toHaveBeenCalledOnce();
-    const [url, request] = fetchMock.mock.calls[0] ?? [];
-    expect(url).toBe("https://bot-api.zaloplatforms.com/bottest-zalo-token/sendMessage");
-    expect(request?.method).toBe("POST");
-    expect(request?.body).toBe(
-      JSON.stringify({
-        chat_id: "dm-chat-blank-media",
-        text: "hello there",
-      }),
-    );
+      expect(result.details).toEqual({
+        ok: true,
+        to: "dm-chat-blank-media",
+        messageId: "z-msg-with-blank-media",
+      });
+      expect(requests).toEqual([
+        {
+          method: "POST",
+          path: "/zalo/bottest-zalo-token/sendMessage",
+          contentType: "application/json",
+          body: JSON.stringify({
+            chat_id: "dm-chat-blank-media",
+            text: "hello there",
+          }),
+        },
+      ]);
+    } finally {
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
+    }
   });
 });

--- a/extensions/zalo/src/actions.test.ts
+++ b/extensions/zalo/src/actions.test.ts
@@ -1,5 +1,5 @@
 // Zalo tests cover actions plugin behavior.
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { zaloMessageActions } from "./actions.js";
 import type { OpenClawConfig } from "./runtime-api.js";
 
@@ -31,5 +31,52 @@ describe("zaloMessageActions.describeMessageTool", () => {
     });
     expect(zaloMessageActions.supportsAction?.({ action: "send" })).toBe(true);
     expect(zaloMessageActions.supportsAction?.({ action: "react" })).toBe(false);
+  });
+});
+
+describe("zaloMessageActions.handleAction", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("sends text to the Bot API when the message tool supplies whitespace-only media", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      Response.json({
+        ok: true,
+        result: { message_id: "z-msg-with-blank-media" },
+      }),
+    );
+    const handleAction = zaloMessageActions.handleAction;
+    if (!handleAction) {
+      throw new Error("Expected Zalo message action handler");
+    }
+
+    await handleAction({
+      channel: "zalo",
+      action: "send",
+      params: {
+        to: "dm-chat-blank-media",
+        message: "hello there",
+        media: "   ",
+      },
+      cfg: {
+        channels: {
+          zalo: {
+            enabled: true,
+            botToken: "test-zalo-token",
+          },
+        },
+      },
+      accountId: "default",
+    });
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, request] = fetchMock.mock.calls[0] ?? [];
+    expect(url).toBe("https://bot-api.zaloplatforms.com/bottest-zalo-token/sendMessage");
+    expect(request?.method).toBe("POST");
+    expect(JSON.parse(String(request?.body))).toEqual({
+      chat_id: "dm-chat-blank-media",
+      text: "hello there",
+    });
   });
 });

--- a/extensions/zalo/src/send.test.ts
+++ b/extensions/zalo/src/send.test.ts
@@ -106,6 +106,31 @@ describe("zalo send", () => {
     expect(successful.receipt.parts[0]?.kind).toBe("media");
   });
 
+  it("sends text through the message API when the media URL is whitespace", async () => {
+    sendMessageMock.mockResolvedValueOnce({
+      ok: true,
+      result: { message_id: "z-msg-with-blank-media" },
+    });
+
+    const result = await sendMessageZalo("dm-chat-blank-media", "hello there", {
+      token: "zalo-token",
+      mediaUrl: "   ",
+    });
+
+    expect(sendMessageMock).toHaveBeenCalledWith(
+      "zalo-token",
+      {
+        chat_id: "dm-chat-blank-media",
+        text: "hello there",
+      },
+      undefined,
+    );
+    expect(sendPhotoMock).not.toHaveBeenCalled();
+    expect(requireSuccessfulSend(result, "z-msg-with-blank-media").receipt.parts[0]?.kind).toBe(
+      "text",
+    );
+  });
+
   it("fails fast for missing token or blank photo URLs", async () => {
     const missingToken = await sendMessageZalo("dm-chat-3", "hello", {});
     expectFailedSend(missingToken, "No Zalo bot token configured");

--- a/extensions/zalo/src/send.ts
+++ b/extensions/zalo/src/send.ts
@@ -155,7 +155,7 @@ export async function sendMessageZalo(
   }
   const { context } = resolved;
 
-  if (options.mediaUrl) {
+  if (options.mediaUrl && (options.mediaUrl.trim() || !text)) {
     return sendPhotoZalo(context.chatId, options.mediaUrl, {
       ...options,
       token: context.token,


### PR DESCRIPTION
Closes #105078

## What Problem This Solves

Fixes Zalo text sends that incorrectly fail as an invalid photo when the optional media value contains whitespace only.

## Why This Change Was Made

Normalize the owner-local send decision so whitespace-only media cannot override real text. Preserve rejection when whitespace-only media is supplied without any text. Do not add configuration, dependencies, SDK surface, retries, or fallback paths.

## Real Transport Evidence

The action regression uses the existing, independently tested `ZALO_API_URL` alternate-endpoint contract to run a real `node:http` Bot API server bound only to `127.0.0.1`. There is **no mocked, intercepted, or injected fetch**. It exercises the actual production message-tool action, lazy runtime import, account/token resolution, send-decision branch, built-in HTTP client, network TCP request, provider JSON response parsing, and returned delivery receipt.

**Red before:** restore the current-main `if (options.mediaUrl)` branch and execute the same real-HTTP action regression. The action returns `{ ok: false, error: "No photo URL provided" }`; it never sends a text request.

**Green after:** restore the one-line production fix and execute the unchanged real-HTTP regression. The loopback Bot API receives exactly:

```text
POST /zalo/bottest-zalo-token/sendMessage
Content-Type: application/json

{"chat_id":"dm-chat-blank-media","text":"hello there"}
```

The production action parses the actual HTTP response and returns `{ ok: true, to: "dm-chat-blank-media", messageId: "z-msg-with-blank-media" }`. The complete focused send, live-loopback action, and API suite passes **3 files / 28 tests**.

```text
env OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs \
  extensions/zalo/src/send.test.ts \
  extensions/zalo/src/actions.test.ts \
  extensions/zalo/src/api.test.ts

Test Files  3 passed (3)
Tests      28 passed (28)
```

A live Zalo account, provider credentials, and approved external chat target are **not configured**. This is real production transport to a local provider-compatible HTTP server, **not a claim of live Zalo account delivery**; no external messages were sent.

## Additional Validation

- The existing default production Bot API endpoint and alternate-endpoint contract are covered by `extensions/zalo/src/api.test.ts`.
- The intentional blank-photo rejection and valid photo-caption cases remain green.
- Focused type-aware oxlint, oxfmt, and `git diff --check` pass.
- Fresh full-branch Codex autoreview: clean; confidence 0.94.
- AI-assisted; source, provider contract, red-to-green reproduction, and the exact runtime/transport boundary were independently verified.