### PR TITLE
fix(heartbeat): suppress thinking-only heartbeat acknowledgements

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-injection.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-injection.test.ts
@@ -216,7 +216,14 @@ describe("embedded attempt context injection", () => {
       { role: "user", content: "real question", timestamp: 1 } as AgentMessage,
       { role: "assistant", content: "real answer", timestamp: 2 } as unknown as AgentMessage,
       { role: "user", content: HEARTBEAT_PROMPT, timestamp: 3 } as AgentMessage,
-      { role: "assistant", content: "HEARTBEAT_OK", timestamp: 4 } as unknown as AgentMessage,
+      {
+        role: "assistant",
+        content: [
+          { type: "reasoning", text: "Checking the heartbeat." },
+          { type: "text", text: "HEARTBEAT_OK" },
+        ],
+        timestamp: 4,
+      } as unknown as AgentMessage,
     ];
 
     const heartbeatFiltered = filterHeartbeatTranscriptArtifacts(

--- a/src/auto-reply/heartbeat-filter.test.ts
+++ b/src/auto-reply/heartbeat-filter.test.ts
@@ -13,6 +13,12 @@ import {
 } from "./heartbeat.js";
 import { MESSAGE_TOOL_DELIVERY_HINTS } from "./reply/delivery-hints.js";
 
+const HIDDEN_REASONING_BLOCKS = [
+  ["thinking", { type: "thinking", thinking: "Checking the heartbeat." }],
+  ["reasoning", { type: "reasoning", text: "Checking the heartbeat." }],
+  ["redacted thinking", { type: "redacted_thinking", data: "opaque-reasoning" }],
+] as const;
+
 describe("isHeartbeatUserMessage", () => {
   it("matches heartbeat prompts", () => {
     expect(
@@ -93,17 +99,17 @@ describe("isHeartbeatOkResponse", () => {
     ).toBe(true);
   });
 
-  it.each([
-    ["thinking", { type: "thinking", thinking: "Checking the heartbeat." }],
-    ["redacted thinking", { type: "redacted_thinking", data: "opaque-reasoning" }],
-  ])("matches acknowledgements with hidden %s blocks", (_label, thinkingBlock) => {
-    expect(
-      isHeartbeatOkResponse({
-        role: "assistant",
-        content: [thinkingBlock, { type: "text", text: "HEARTBEAT_OK" }],
-      }),
-    ).toBe(true);
-  });
+  it.each(HIDDEN_REASONING_BLOCKS)(
+    "matches acknowledgements with hidden %s blocks",
+    (_label, reasoningBlock) => {
+      expect(
+        isHeartbeatOkResponse({
+          role: "assistant",
+          content: [reasoningBlock, { type: "text", text: "HEARTBEAT_OK" }],
+        }),
+      ).toBe(true);
+    },
+  );
 
   it("preserves meaningful or non-text responses", () => {
     expect(
@@ -170,24 +176,24 @@ describe("filterHeartbeatTranscriptArtifacts", () => {
     ]);
   });
 
-  it.each([
-    ["thinking", { type: "thinking", thinking: "Checking the heartbeat." }],
-    ["redacted thinking", { type: "redacted_thinking", data: "opaque-reasoning" }],
-  ])("removes no-op heartbeat pairs with hidden %s blocks", (_label, thinkingBlock) => {
-    const nextUserMessage = { role: "user", content: "What time is it?" };
-    const messages = [
-      { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT },
-      {
-        role: "assistant",
-        content: [thinkingBlock, { type: "text", text: "HEARTBEAT_OK" }],
-      },
-      nextUserMessage,
-    ];
+  it.each(HIDDEN_REASONING_BLOCKS)(
+    "removes no-op heartbeat pairs with hidden %s blocks",
+    (_label, reasoningBlock) => {
+      const nextUserMessage = { role: "user", content: "What time is it?" };
+      const messages = [
+        { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT },
+        {
+          role: "assistant",
+          content: [reasoningBlock, { type: "text", text: "HEARTBEAT_OK" }],
+        },
+        nextUserMessage,
+      ];
 
-    expect(filterHeartbeatTranscriptArtifacts(messages, undefined, HEARTBEAT_PROMPT)).toEqual([
-      nextUserMessage,
-    ]);
-  });
+      expect(filterHeartbeatTranscriptArtifacts(messages, undefined, HEARTBEAT_PROMPT)).toEqual([
+        nextUserMessage,
+      ]);
+    },
+  );
 
   it("removes OpenAI Responses input/output text heartbeat pairs", () => {
     for (const deliveryHint of MESSAGE_TOOL_DELIVERY_HINTS) {

--- a/src/auto-reply/heartbeat-filter.ts
+++ b/src/auto-reply/heartbeat-filter.ts
@@ -269,9 +269,13 @@ function resolveMessageText(content: unknown): { text: string; hasNonTextContent
       hasNonTextContent = true;
       continue;
     }
-    // Provider thinking is not user-visible output; it must not keep a
+    // Provider thinking/reasoning is not user-visible output; it must not keep a
     // no-op heartbeat acknowledgement in future model request history.
-    if (block.type === "thinking" || block.type === "redacted_thinking") {
+    if (
+      block.type === "thinking" ||
+      block.type === "reasoning" ||
+      block.type === "redacted_thinking"
+    ) {
       continue;
     }
     if (block.type !== "text" && block.type !== "input_text" && block.type !== "output_text") {

--- a/src/gateway/session-history-state.test.ts
+++ b/src/gateway/session-history-state.test.ts
@@ -688,7 +688,14 @@ describe("SessionHistorySseState", () => {
           content: `${HEARTBEAT_PROMPT}\nWhen reading HEARTBEAT.md, use workspace file /tmp/HEARTBEAT.md (exact case). Do not read docs/heartbeat.md.`,
           __openclaw: { seq: 1 },
         },
-        assistantTextMessage("HEARTBEAT_OK", 2),
+        {
+          role: "assistant",
+          content: [
+            { type: "reasoning", text: "Checking the heartbeat." },
+            { type: "text", text: "HEARTBEAT_OK" },
+          ],
+          __openclaw: { seq: 2 },
+        },
         {
           role: "user",
           content: HEARTBEAT_PROMPT,


### PR DESCRIPTION
Closes #113912
Fixes #95796

## What Problem This Solves

Heartbeat acknowledgements containing a raw provider `reasoning` block were treated as substantive output. That could expose `HEARTBEAT_OK` in visible Gateway history and keep the completed heartbeat turn in the next model request.

## Why This Change Was Made

The existing heartbeat classifier already ignores private `thinking` and `redacted_thinking` blocks. It now includes their `reasoning` sibling, matching Gateway projection and provider transport normalization. Tool calls, media, meaningful text, and visible alerts remain substantive.

This rewrite preserves #113924's producer-recorded cron `deliveryDisposition` flow. It does not restore the deleted heartbeat-policy predicates or add downstream re-derivation.

## User Impact

Reasoning-enabled heartbeat acknowledgements remain silent and no longer consume later model context, while real heartbeat alerts and structured output remain visible.

## Evidence

- Before the production change: `node scripts/run-vitest.mjs src/auto-reply/heartbeat-filter.test.ts src/gateway/session-history-state.test.ts src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-injection.test.ts` failed the two new raw-`reasoning` classifier/transcript cases; 38 sibling heartbeat-filter cases passed.
- After the production change: the same command passed 3 shards: heartbeat filter 40/40, Gateway history 26/26, embedded context engine 12/12.
- `node scripts/check-changed.mjs` passed remotely on Blacksmith Testbox `tbx_01kzk667mh8xb30xs6ns294p3m` in 8m24s. It covered core production/test typechecks, format, lint, API baseline, dependency and architecture guards, dead-code scans, and runtime import cycles. Run: https://github.com/openclaw/openclaw/actions/runs/31312095534
- `git diff --check` passed.
- Fresh Codex-backed autoreview passed with no accepted or actionable findings.
- Production delta: +6/-2. Test delta: +50/-30.

### ClawSweeper rank-up moves

- Applied: rewrote on current main while preserving `thinking` and `redacted_thinking` coverage and adding `reasoning`.
- Applied: reran focused classifier, Gateway visible-history, and next-turn context proof on the rewritten head.
