### PR TITLE
fix(cron): current-bound runs carry a bounded tail of the source conversation

### DIFF
--- a/src/cron/isolated-agent/run-current-context.test.ts
+++ b/src/cron/isolated-agent/run-current-context.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from "vitest";
+import { buildCurrentConversationContextBlock } from "./run-current-context.js";
+
+const sourceSessionEntry = {
+  sessionId: "source-session",
+  updatedAt: 0,
+};
+
+async function buildContext(messages: unknown[]) {
+  return await buildCurrentConversationContextBlock(
+    {
+      agentId: "main",
+      sourceSessionEntry,
+      sourceSessionKey: "agent:main:telegram:direct:42",
+      storePath: "/tmp/store.sqlite",
+    },
+    { readSessionMessages: vi.fn().mockResolvedValue(messages) },
+  );
+}
+
+describe("buildCurrentConversationContextBlock", () => {
+  it("keeps recent user and assistant text while filtering other roles and empty content", async () => {
+    await expect(
+      buildContext([
+        { role: "system", content: "system prompt" },
+        { role: "user", content: " first\n fact " },
+        { role: "tool", content: "tool result" },
+        { role: "assistant", content: [{ type: "text", text: "noted" }] },
+        { role: "assistant", content: [{ type: "toolCall", name: "search" }] },
+        { role: "user", content: "  " },
+      ]),
+    ).resolves.toBe("Recent conversation:\n- User: first fact\n- Assistant: noted");
+  });
+
+  it("projects raw transcript envelopes and assistant phases before truncation", async () => {
+    await expect(
+      buildContext([
+        {
+          role: "user",
+          content:
+            'Conversation info: ⟦openclaw:ctx⟧\n```json\n{"message_id":"123"}\n```\n\nActual user fact',
+        },
+        ...Array.from({ length: 15 }, () => ({ role: "toolResult", content: "tool output" })),
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "text",
+              text: "internal reasoning",
+              textSignature: JSON.stringify({
+                v: 1,
+                id: "item_commentary",
+                phase: "commentary",
+              }),
+            },
+            {
+              type: "text",
+              text: "Visible answer",
+              textSignature: JSON.stringify({
+                v: 1,
+                id: "item_final",
+                phase: "final_answer",
+              }),
+            },
+          ],
+        },
+      ]),
+    ).resolves.toBe("Recent conversation:\n- User: Actual user fact\n- Assistant: Visible answer");
+  });
+
+  it("caps lines and drops the oldest messages first to fit the count and block limits", async () => {
+    const context = await buildContext(
+      Array.from({ length: 12 }, (_, index) => ({
+        role: index % 2 === 0 ? "user" : "assistant",
+        content: `${index}:${"x".repeat(300)}`,
+      })),
+    );
+
+    expect(context).toBeDefined();
+    const lines = context?.split("\n") ?? [];
+    expect(context?.length).toBeLessThanOrEqual(1400);
+    expect(lines.slice(1).every((line) => line.length <= 220)).toBe(true);
+    expect(lines.some((line) => line.startsWith("- User: 0:"))).toBe(false);
+    expect(lines.some((line) => line.startsWith("- Assistant: 5:"))).toBe(false);
+    expect(lines.some((line) => line.startsWith("- User: 6:"))).toBe(true);
+    expect(lines.some((line) => line.startsWith("- Assistant: 11:"))).toBe(true);
+    expect(context?.indexOf("- User: 6:")).toBeLessThan(context?.indexOf("- Assistant: 11:") ?? -1);
+  });
+
+  it("returns undefined for empty or unreadable transcripts", async () => {
+    await expect(buildContext([])).resolves.toBeUndefined();
+    await expect(
+      buildCurrentConversationContextBlock(
+        {
+          agentId: "main",
+          sourceSessionEntry,
+          sourceSessionKey: "agent:main:telegram:direct:42",
+          storePath: "/tmp/store.sqlite",
+        },
+        { readSessionMessages: vi.fn().mockRejectedValue(new Error("unreadable")) },
+      ),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/src/cron/isolated-agent/run-current-context.ts
+++ b/src/cron/isolated-agent/run-current-context.ts
@@ -1,0 +1,87 @@
+/** Bounded source-conversation context for current-bound cron runs. */
+import type { SessionEntry } from "../../config/sessions.js";
+import { projectChatDisplayMessages } from "../../gateway/chat-display-projection.js";
+import { readSessionMessagesAsync } from "../../gateway/session-transcript-readers.js";
+import { extractTextFromChatContent } from "../../shared/chat-content.js";
+import { truncateUtf16Safe } from "../../utils.js";
+
+const CURRENT_CONTEXT_MAX_MESSAGES = 10;
+const CURRENT_CONTEXT_RAW_MESSAGES_MAX = CURRENT_CONTEXT_MAX_MESSAGES * 20 + 20;
+const CURRENT_CONTEXT_READ_MAX_BYTES = 256 * 1024;
+const CURRENT_CONTEXT_MAX_LINE_CHARS = 220;
+const CURRENT_CONTEXT_MAX_BLOCK_CHARS = 1400;
+const CURRENT_CONTEXT_HEADER = "Recent conversation:";
+
+type ReadSessionMessages = typeof readSessionMessagesAsync;
+
+function truncateContextLine(role: "user" | "assistant", text: string): string {
+  const label = role === "user" ? "User" : "Assistant";
+  const prefix = `- ${label}: `;
+  const textLimit = CURRENT_CONTEXT_MAX_LINE_CHARS - prefix.length;
+  if (text.length <= textLimit) {
+    return `${prefix}${text}`;
+  }
+  const truncated = truncateUtf16Safe(text, textLimit - 3).trimEnd();
+  return `${prefix}${truncated}...`;
+}
+
+function formatCurrentConversationContext(messages: unknown[]): string | undefined {
+  const lines = projectChatDisplayMessages(messages, {
+    maxChars: CURRENT_CONTEXT_MAX_LINE_CHARS,
+  })
+    .flatMap((message) => {
+      if (!message || typeof message !== "object" || Array.isArray(message)) {
+        return [];
+      }
+      const record = message as { role?: unknown; content?: unknown };
+      if (record.role !== "user" && record.role !== "assistant") {
+        return [];
+      }
+      const text = extractTextFromChatContent(record.content);
+      return text ? [truncateContextLine(record.role, text)] : [];
+    })
+    .slice(-CURRENT_CONTEXT_MAX_MESSAGES);
+
+  while (
+    lines.length > 0 &&
+    `${CURRENT_CONTEXT_HEADER}\n${lines.join("\n")}`.length > CURRENT_CONTEXT_MAX_BLOCK_CHARS
+  ) {
+    lines.shift();
+  }
+  return lines.length > 0 ? `${CURRENT_CONTEXT_HEADER}\n${lines.join("\n")}` : undefined;
+}
+
+export async function buildCurrentConversationContextBlock(
+  params: {
+    agentId: string;
+    sourceSessionEntry: SessionEntry;
+    sourceSessionKey: string;
+    storePath: string;
+  },
+  deps: { readSessionMessages?: ReadSessionMessages } = {},
+): Promise<string | undefined> {
+  const sessionId = params.sourceSessionEntry.sessionId?.trim();
+  if (!sessionId) {
+    return undefined;
+  }
+  try {
+    const messages = await (deps.readSessionMessages ?? readSessionMessagesAsync)(
+      {
+        agentId: params.agentId,
+        sessionEntry: params.sourceSessionEntry,
+        sessionId,
+        sessionKey: params.sourceSessionKey,
+        storePath: params.storePath,
+      },
+      {
+        mode: "recent",
+        maxBytes: CURRENT_CONTEXT_READ_MAX_BYTES,
+        maxLines: CURRENT_CONTEXT_RAW_MESSAGES_MAX,
+        maxMessages: CURRENT_CONTEXT_RAW_MESSAGES_MAX,
+      },
+    );
+    return formatCurrentConversationContext(Array.isArray(messages) ? messages : []);
+  } catch {
+    return undefined;
+  }
+}

--- a/src/cron/isolated-agent/run-prepare.ts
+++ b/src/cron/isolated-agent/run-prepare.ts
@@ -31,6 +31,7 @@ import { isDetachedCronSessionTarget } from "../session-target.js";
 import type { CronJob, CronRunDiagnostics } from "../types.js";
 import { resolveCronModelSelection, resolveCronModelSelectionOwner } from "./model-selection.js";
 import { buildCronAgentDefaultsConfig, resolveCronActiveRuntimeConfig } from "./run-config.js";
+import { buildCurrentConversationContextBlock } from "./run-current-context.js";
 import {
   appendCronDeliveryInstruction,
   canPromptForMessageTool,
@@ -507,7 +508,22 @@ export async function prepareCronRunContext(params: {
     });
 
   const { formattedTime, timeLine } = resolveCronStyleNow(runtimeCfg, now);
-  const message = resolveCronAgentTurnMessage(input);
+  const originalMessage = resolveCronAgentTurnMessage(input);
+  const sourceSessionEntry = sourceSessionKey ? cronSession.store[sourceSessionKey] : undefined;
+  // Current jobs run detached for token hygiene; this bounded tail preserves the
+  // conversation-bound contract without unbounded seeding or transcript continuation.
+  const currentConversationContext =
+    input.job.sessionTarget === "current" && agentPayload && sourceSessionKey && sourceSessionEntry
+      ? await buildCurrentConversationContextBlock({
+          agentId,
+          sourceSessionEntry,
+          sourceSessionKey,
+          storePath: cronSession.storePath,
+        })
+      : undefined;
+  const message = currentConversationContext
+    ? `${currentConversationContext}\n\n${originalMessage}`
+    : originalMessage;
   const base = `[cron:${input.job.id} ${input.job.name}] ${message}`.trim();
   const isExternalHook =
     hookExternalContentSource !== undefined || isExternalHookSession(baseSessionKey);

--- a/src/cron/isolated-agent/run.current-context.test.ts
+++ b/src/cron/isolated-agent/run.current-context.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { makeIsolatedAgentJobFixture, makeIsolatedAgentParamsFixture } from "./job-fixtures.js";
+import { setupRunCronIsolatedAgentTurnSuite } from "./run.suite-helpers.js";
+import {
+  loadRunCronIsolatedAgentTurn,
+  makeCronSession,
+  makeCronSessionEntry,
+  mockRunCronFallbackPassthrough,
+  readSessionMessagesAsyncMock,
+  resolveCronSessionMock,
+  runEmbeddedAgentMock,
+} from "./run.test-harness.js";
+
+const runCronIsolatedAgentTurn = await loadRunCronIsolatedAgentTurn();
+const sourceSessionKey = "agent:default:telegram:direct:42";
+
+function embeddedPrompt(): string {
+  const prompt = runEmbeddedAgentMock.mock.calls[0]?.[0]?.prompt;
+  if (typeof prompt !== "string") {
+    throw new Error("expected embedded run prompt");
+  }
+  return prompt;
+}
+
+describe("runCronIsolatedAgentTurn — current conversation context", () => {
+  setupRunCronIsolatedAgentTurnSuite({ fast: true });
+
+  it("prepends the bound source conversation to a current-target payload", async () => {
+    mockRunCronFallbackPassthrough();
+    const sourceSessionEntry = makeCronSessionEntry({ sessionId: "source-session" });
+    resolveCronSessionMock.mockReturnValue(
+      makeCronSession({ store: { [sourceSessionKey]: sourceSessionEntry } }),
+    );
+    readSessionMessagesAsyncMock.mockResolvedValue([
+      { role: "user", content: "Otters hold hands while sleeping." },
+      { role: "assistant", content: "Got it." },
+    ]);
+
+    const result = await runCronIsolatedAgentTurn(
+      makeIsolatedAgentParamsFixture({
+        job: makeIsolatedAgentJobFixture({
+          sessionKey: sourceSessionKey,
+          sessionTarget: "current",
+          payload: { kind: "agentTurn", message: "Summarize the animal fact." },
+        }),
+      }),
+    );
+
+    expect(result.status).toBe("ok");
+    expect(readSessionMessagesAsyncMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionEntry: sourceSessionEntry,
+        sessionId: "source-session",
+        sessionKey: sourceSessionKey,
+      }),
+      { mode: "recent", maxBytes: 256 * 1024, maxLines: 220, maxMessages: 220 },
+    );
+    expect(embeddedPrompt()).toContain(
+      "Recent conversation:\n- User: Otters hold hands while sleeping.\n- Assistant: Got it.\n\nSummarize the animal fact.",
+    );
+  });
+
+  it("leaves isolated-target payloads unchanged", async () => {
+    mockRunCronFallbackPassthrough();
+    resolveCronSessionMock.mockReturnValue(
+      makeCronSession({
+        store: {
+          [sourceSessionKey]: makeCronSessionEntry({ sessionId: "source-session" }),
+        },
+      }),
+    );
+    readSessionMessagesAsyncMock.mockResolvedValue([
+      { role: "user", content: "This must not be carried." },
+    ]);
+
+    const result = await runCronIsolatedAgentTurn(
+      makeIsolatedAgentParamsFixture({
+        job: makeIsolatedAgentJobFixture({
+          sessionKey: sourceSessionKey,
+          sessionTarget: "isolated",
+          payload: { kind: "agentTurn", message: "Run independently." },
+        }),
+      }),
+    );
+
+    expect(result.status).toBe("ok");
+    expect(readSessionMessagesAsyncMock).not.toHaveBeenCalled();
+    expect(embeddedPrompt()).toContain("Run independently.");
+    expect(embeddedPrompt()).not.toContain("Recent conversation:");
+  });
+});

--- a/src/cron/isolated-agent/run.test-harness.ts
+++ b/src/cron/isolated-agent/run.test-harness.ts
@@ -101,6 +101,7 @@ export const cleanupBrowserSessionsForLifecycleEndMock = createMock();
 export const callGatewayMock = createMock();
 export const ensureRuntimePluginsLoadedMock = createMock();
 export const hasUsableWebSearchProviderMock = createMock();
+export const readSessionMessagesAsyncMock = createMock();
 export const classifyEmbeddedAgentRunResultForModelFallbackMock = createMock();
 export const mergeEmbeddedAgentRunResultForModelFallbackExhaustionMock = createMock();
 
@@ -362,6 +363,10 @@ vi.mock("../../browser-lifecycle-cleanup.js", () => ({
 
 vi.mock("../../gateway/call.runtime.js", () => ({
   callGateway: callGatewayMock,
+}));
+
+vi.mock("../../gateway/session-transcript-readers.js", () => ({
+  readSessionMessagesAsync: readSessionMessagesAsyncMock,
 }));
 
 vi.mock("../../config/sessions/session-accessor.js", async () => {
@@ -847,6 +852,8 @@ export function resetRunCronIsolatedAgentTurnHarness(): void {
     (params?: { runtimeWebSearch?: { selectedProvider?: string } }) =>
       Boolean(params?.runtimeWebSearch?.selectedProvider),
   );
+  readSessionMessagesAsyncMock.mockReset();
+  readSessionMessagesAsyncMock.mockResolvedValue([]);
 }
 
 export function clearFastTestEnv(): string | undefined {


### PR DESCRIPTION
## What Problem This Solves

`sessionTarget:"current"` promises conversation-bound scheduled work, and the cron tool description says the run "carries this chat's context" — but current-bound agentTurn jobs run in a detached per-run session (`resolveCronSession` `forceNew`) and only carry sanitized session *preferences* from the bound source session, never its transcript. Live probe on a dev gateway (2026-07-27): user asks "in 3 minutes, summarize the two facts I'm about to tell you", sends two facts, and the fired run replies:

> "I couldn't retrieve the two animal facts from the available conversation context."

## Why This Change Was Made

At run-prepare time, current-bound agentTurn runs now prepend a bounded tail of the bound source conversation to the run message:

```
Recent conversation:
- User: …
- Assistant: …

<original payload message>
```

- Read via the existing gateway transcript reader (`readSessionMessagesAsync`, layering precedent already established from `src/agents` consumers), projected through `projectChatDisplayMessages`, user/assistant roles only.
- Hard caps: 10 messages, 220 chars/line, 1,400 chars total, 256 KB / bounded-line transcript read; oldest lines dropped first.
- Injected per run at fire time, so recurring and paced `current` loops see live context on every run.
- Failure-isolated: unreadable/empty transcripts run exactly as before (no block, no error). No new config surface.
- Detached execution is preserved on purpose (token hygiene; no transcript continuation, no writes to the source session) — the bounded tail *is* the conversation-bound contract. `session:<key>` targets already continue their transcript natively; `isolated` stays fully detached; both unchanged.

## User Impact

"Remind me later / check this periodically" jobs created in a conversation now actually know what that conversation was about at fire time — including facts sent after the job was created. This completes the train started by the `current` default (#114328) and the durable-binding fix (#114421).

## Evidence

- Live before (pre-fix build): S3 probe FAIL — "I couldn't retrieve the two animal facts from the available conversation context."
- Live after (this branch, same rig — isolated dev gateway, qa-channel bus, `openai/gpt-5.6-luna`): job `{"name":"delayed animal-facts summary 3","at":"2026-07-27T08:43:40.000Z","sessionKey":"agent:main:main"}`; both facts were sent AFTER job creation; the fired run delivered:

  > "Axolotls can regrow their hearts, while pistol shrimp snap louder than a gunshot."

- Unit tests: context-block builder (role filtering, truncation caps, oldest-first dropping, unreadable→undefined); run-pipeline tests via the existing harness prove a current job gets the block and an isolated job does not (14 focused tests green; Codex sweep 6 files / 43 tests).
- oxlint clean; numstat +306/−1 (87 prod lines + tests).
- `$autoreview` (Codex, gpt-5.6-sol): clean on the stacked branch; rerun on the rebased branch before landing.
