### PR TITLE
fix(skills): show workshop skills in new sessions without restart

### DIFF
--- a/src/cli/skills-cli.ts
+++ b/src/cli/skills-cli.ts
@@ -121,6 +121,7 @@ type ResolveSkillsWorkspaceOptions = {
 type ResolvedSkillsWorkspace = ReturnType<typeof resolveSkillsWorkspace>;
 
 const GATEWAY_SKILLS_STATUS_TIMEOUT_MS = 1_500;
+const GATEWAY_SKILLS_MUTATION_TIMEOUT_MS = 10_000;
 
 function resolveSkillsWorkspace(options?: ResolveSkillsWorkspaceOptions): {
   config: ReturnType<typeof getRuntimeConfig>;
@@ -400,25 +401,42 @@ async function runSkillProposalApply(
   resolved: ResolvedSkillsWorkspace,
   proposalId: string,
 ): Promise<SkillProposalApplyResult> {
+  const { callGateway, isGatewayTransportError } = await import("../gateway/call.js");
   try {
-    const { callGateway } = await import("../gateway/call.js");
-    return await callGateway<SkillProposalApplyResult>({
+    // Decide offline fallback before dispatching the non-idempotent mutation.
+    // Once a Gateway answers, apply failures must never be replayed locally.
+    await callGateway({
       config: resolved.config,
-      method: "skills.proposals.apply",
-      params: { agentId: resolved.agentId, proposalId },
+      method: "health",
+      params: {},
       timeoutMs: GATEWAY_SKILLS_STATUS_TIMEOUT_MS,
       clientName: GATEWAY_CLIENT_NAMES.CLI,
       mode: GATEWAY_CLIENT_MODES.CLI,
+      requiredMethods: ["skills.proposals.apply"],
     });
   } catch (err) {
-    if (resolved.config.gateway?.mode === "remote") {
+    if (
+      resolved.config.gateway?.mode === "remote" ||
+      !isGatewayTransportError(err) ||
+      err.kind !== "closed" ||
+      err.code !== 1006
+    ) {
       throw err;
     }
+    return await applySkillProposal({
+      workspaceDir: resolved.workspaceDir,
+      config: resolved.config,
+      proposalId,
+    });
   }
-  return await applySkillProposal({
-    workspaceDir: resolved.workspaceDir,
+
+  return await callGateway<SkillProposalApplyResult>({
     config: resolved.config,
-    proposalId,
+    method: "skills.proposals.apply",
+    params: { agentId: resolved.agentId, proposalId },
+    timeoutMs: GATEWAY_SKILLS_MUTATION_TIMEOUT_MS,
+    clientName: GATEWAY_CLIENT_NAMES.CLI,
+    mode: GATEWAY_CLIENT_MODES.CLI,
   });
 }
 

--- a/src/cli/skills-cli.ts
+++ b/src/cli/skills-cli.ts
@@ -55,6 +55,7 @@ import {
   reviseSkillProposal,
 } from "../skills/workshop/service.js";
 import type {
+  SkillProposalApplyResult,
   SkillProposalManifest,
   SkillProposalReadResult,
   SkillProposalSupportFileInput,
@@ -393,6 +394,32 @@ async function runSkillCuratorMutation(method: "pin" | "restore" | "unpin", skil
     return unpinCuratedSkill(skill);
   }
   return restoreCuratedSkill(skill);
+}
+
+async function runSkillProposalApply(
+  resolved: ResolvedSkillsWorkspace,
+  proposalId: string,
+): Promise<SkillProposalApplyResult> {
+  try {
+    const { callGateway } = await import("../gateway/call.js");
+    return await callGateway<SkillProposalApplyResult>({
+      config: resolved.config,
+      method: "skills.proposals.apply",
+      params: { agentId: resolved.agentId, proposalId },
+      timeoutMs: GATEWAY_SKILLS_STATUS_TIMEOUT_MS,
+      clientName: GATEWAY_CLIENT_NAMES.CLI,
+      mode: GATEWAY_CLIENT_MODES.CLI,
+    });
+  } catch (err) {
+    if (resolved.config.gateway?.mode === "remote") {
+      throw err;
+    }
+  }
+  return await applySkillProposal({
+    workspaceDir: resolved.workspaceDir,
+    config: resolved.config,
+    proposalId,
+  });
 }
 
 async function readSkillProposalInput(options: {
@@ -1031,8 +1058,8 @@ export function registerSkillsCli(program: Command) {
     .action(
       async (proposalId: string, opts: { json?: boolean; agent?: string }, command: Command) => {
         try {
-          const { config, workspaceDir } = resolveSkillsWorkspaceForCommand(command.parent, opts);
-          const applied = await applySkillProposal({ workspaceDir, config, proposalId });
+          const resolved = resolveSkillsWorkspaceForCommand(command.parent, opts);
+          const applied = await runSkillProposalApply(resolved, proposalId);
           if (opts.json) {
             defaultRuntime.writeJson(applied);
             return;

--- a/src/cli/skills-cli.workshop-cache.test.ts
+++ b/src/cli/skills-cli.workshop-cache.test.ts
@@ -28,7 +28,10 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("../runtime.js", () => ({ defaultRuntime: mocks.defaultRuntime }));
-vi.mock("../gateway/call.js", () => ({ callGateway: mocks.callGateway }));
+vi.mock("../gateway/call.js", () => ({
+  callGateway: mocks.callGateway,
+  isGatewayTransportError: () => false,
+}));
 vi.mock("../config/config.js", () => ({
   getRuntimeConfig: () => mocks.config,
   resetConfigRuntimeState: () => undefined,
@@ -48,7 +51,12 @@ describe("skills workshop CLI gateway snapshot invalidation", () => {
     mocks.workspaceDir = await tempDirs.make("openclaw-skills-cli-workshop-cache-");
     delete mocks.config.gateway;
     mocks.gatewayApply = undefined;
+    mocks.defaultRuntime.error.mockClear();
+    mocks.defaultRuntime.exit.mockClear();
     mocks.callGateway.mockReset().mockImplementation(async (request) => {
+      if (request.method === "health") {
+        return {};
+      }
       if (!mocks.gatewayApply) {
         throw new Error("gateway unavailable");
       }
@@ -121,5 +129,35 @@ describe("skills workshop CLI gateway snapshot invalidation", () => {
       watch: false,
     }).snapshot;
     expect(newSession.skills.map((skill) => skill.name)).toContain("gateway-visible");
+  });
+
+  it("does not replay a dispatched gateway apply failure in the CLI process", async () => {
+    const workshop = await import("../skills/workshop/service.js");
+    const proposal = await workshop.proposeCreateSkill({
+      workspaceDir: mocks.workspaceDir,
+      name: "Single Dispatch",
+      description: "Apply only in the process that owns snapshot state",
+      content: "# Single Dispatch\n\nDo not replay this mutation.\n",
+    });
+    mocks.gatewayApply = async () => {
+      throw new Error("gateway apply failed");
+    };
+
+    vi.resetModules();
+    const { registerSkillsCli } = await import("./skills-cli.js");
+    const program = new Command();
+    program.exitOverride();
+    registerSkillsCli(program);
+    await expect(
+      program.parseAsync(["skills", "workshop", "apply", proposal.record.id], { from: "user" }),
+    ).rejects.toThrow("__exit__:1");
+
+    expect(mocks.callGateway.mock.calls.map(([request]) => request.method)).toEqual([
+      "health",
+      "skills.proposals.apply",
+    ]);
+    await expect(workshop.inspectSkillProposal(proposal.record.id)).resolves.toMatchObject({
+      record: { status: "pending" },
+    });
   });
 });

--- a/src/cli/skills-cli.workshop-cache.test.ts
+++ b/src/cli/skills-cli.workshop-cache.test.ts
@@ -1,0 +1,125 @@
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../test-utils/openclaw-test-state.js";
+import { createTrackedTempDirs } from "../test-utils/tracked-temp-dirs.js";
+
+const tempDirs = createTrackedTempDirs();
+let testState: OpenClawTestState;
+
+const mocks = vi.hoisted(() => ({
+  callGateway: vi.fn(),
+  config: {} as { gateway?: { mode: "local" | "remote" } },
+  gatewayApply: undefined as
+    | ((request: { method: string; params?: { proposalId?: string } }) => Promise<unknown>)
+    | undefined,
+  workspaceDir: "",
+  defaultRuntime: {
+    log: vi.fn(),
+    error: vi.fn(),
+    writeStdout: vi.fn(),
+    writeJson: vi.fn(),
+    exit: vi.fn((code: number) => {
+      throw new Error(`__exit__:${code}`);
+    }),
+  },
+}));
+
+vi.mock("../runtime.js", () => ({ defaultRuntime: mocks.defaultRuntime }));
+vi.mock("../gateway/call.js", () => ({ callGateway: mocks.callGateway }));
+vi.mock("../config/config.js", () => ({
+  getRuntimeConfig: () => mocks.config,
+  resetConfigRuntimeState: () => undefined,
+}));
+vi.mock("../agents/agent-scope.js", () => ({
+  resolveAgentIdByWorkspacePath: () => undefined,
+  resolveDefaultAgentId: () => "main",
+  resolveAgentWorkspaceDir: () => mocks.workspaceDir,
+}));
+
+describe("skills workshop CLI gateway snapshot invalidation", () => {
+  beforeEach(async () => {
+    testState = await createOpenClawTestState({
+      layout: "state-only",
+      prefix: "openclaw-skills-cli-workshop-cache-",
+    });
+    mocks.workspaceDir = await tempDirs.make("openclaw-skills-cli-workshop-cache-");
+    delete mocks.config.gateway;
+    mocks.gatewayApply = undefined;
+    mocks.callGateway.mockReset().mockImplementation(async (request) => {
+      if (!mocks.gatewayApply) {
+        throw new Error("gateway unavailable");
+      }
+      return await mocks.gatewayApply(request);
+    });
+    vi.resetModules();
+  });
+
+  afterEach(async () => {
+    await testState.cleanup();
+    await tempDirs.cleanup();
+    vi.resetModules();
+  });
+
+  it("applies through the gateway process that owns the cached session skill index", async () => {
+    // This first module graph stands in for the long-running Gateway process.
+    const gatewaySnapshots = await import("../skills/runtime/session-snapshot.js");
+    const gatewayRefreshState = await import("../skills/runtime/refresh-state.js");
+    const gatewayWorkshop = await import("../skills/workshop/service.js");
+    const proposal = await gatewayWorkshop.proposeCreateSkill({
+      workspaceDir: mocks.workspaceDir,
+      name: "Gateway Visible",
+      description: "Visible in sessions without restarting the gateway",
+      content: "# Gateway Visible\n\nUse the newly applied workflow.\n",
+    });
+    const beforeApply = gatewaySnapshots.resolveReusableWorkspaceSkillSnapshot({
+      workspaceDir: mocks.workspaceDir,
+      config: mocks.config,
+      watch: false,
+    }).snapshot;
+    expect(beforeApply.skills.map((skill) => skill.name)).not.toContain("gateway-visible");
+
+    // Session persistence strips resolvedSkills; the Gateway rehydrates that field
+    // from its process cache when the snapshot version has not advanced.
+    const { resolvedSkills: _runtimeOnly, ...persistedSnapshot } = beforeApply;
+    const beforeVersion = gatewayRefreshState.getSkillsSnapshotVersion(mocks.workspaceDir);
+    mocks.gatewayApply = async (request) => {
+      expect(request.method).toBe("skills.proposals.apply");
+      return await gatewayWorkshop.applySkillProposal({
+        workspaceDir: mocks.workspaceDir,
+        config: mocks.config,
+        proposalId: request.params?.proposalId ?? "",
+      });
+    };
+
+    // A fresh module graph models the short-lived CLI process. Direct application
+    // here would bump only the CLI's refresh-state map, leaving the Gateway stale.
+    vi.resetModules();
+    const { registerSkillsCli } = await import("./skills-cli.js");
+    const program = new Command();
+    program.exitOverride();
+    registerSkillsCli(program);
+    await program.parseAsync(["skills", "workshop", "apply", proposal.record.id], {
+      from: "user",
+    });
+
+    expect(mocks.callGateway).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "skills.proposals.apply",
+        params: { agentId: "main", proposalId: proposal.record.id },
+      }),
+    );
+    expect(gatewayRefreshState.getSkillsSnapshotVersion(mocks.workspaceDir)).toBeGreaterThan(
+      beforeVersion,
+    );
+    const newSession = gatewaySnapshots.resolveReusableWorkspaceSkillSnapshot({
+      workspaceDir: mocks.workspaceDir,
+      config: mocks.config,
+      existingSnapshot: persistedSnapshot,
+      watch: false,
+    }).snapshot;
+    expect(newSession.skills.map((skill) => skill.name)).toContain("gateway-visible");
+  });
+});

--- a/src/cli/skills-cli.workshop.test.ts
+++ b/src/cli/skills-cli.workshop.test.ts
@@ -46,6 +46,12 @@ vi.mock("../runtime.js", () => ({
   defaultRuntime: mocks.defaultRuntime,
 }));
 
+vi.mock("../gateway/call.js", () => ({
+  callGateway: vi.fn(async () => {
+    throw new Error("gateway unavailable");
+  }),
+}));
+
 vi.mock("../terminal/links.js", () => ({
   formatDocsLink: () => "docs.openclaw.ai/cli/skills",
 }));

--- a/src/cli/skills-cli.workshop.test.ts
+++ b/src/cli/skills-cli.workshop.test.ts
@@ -48,8 +48,9 @@ vi.mock("../runtime.js", () => ({
 
 vi.mock("../gateway/call.js", () => ({
   callGateway: vi.fn(async () => {
-    throw new Error("gateway unavailable");
+    throw Object.assign(new Error("gateway unavailable"), { kind: "closed", code: 1006 });
   }),
+  isGatewayTransportError: () => true,
 }));
 
 vi.mock("../terminal/links.js", () => ({

--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -2223,7 +2223,9 @@ describe("callGateway error details", () => {
         method: "secrets.resolve",
         requiredMethods: ["secrets.resolve"],
       }),
-    ).rejects.toThrow(/does not support required method "secrets\.resolve"/i);
+    ).rejects.toThrow(
+      /does not support required method "secrets\.resolve".*update or restart the active gateway/i,
+    );
   });
 });
 

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -882,7 +882,7 @@ function ensureGatewaySupportsRequiredMethods(params: {
     throw new Error(
       [
         `active gateway does not support required method "${method}" for "${params.attemptedMethod}".`,
-        "Update the gateway or run without SecretRefs.",
+        "Update or restart the active gateway and try again.",
       ].join(" "),
     );
   }

--- a/src/skills/runtime/session-snapshot.ts
+++ b/src/skills/runtime/session-snapshot.ts
@@ -11,6 +11,8 @@ import { getSkillsSnapshotVersion, shouldRefreshSnapshotForVersion } from "./ref
 import { ensureSkillsWatcher } from "./refresh.js";
 import { hydrateResolvedSkills } from "./snapshot-hydration.js";
 
+// Skill mutation owners must bump refresh-state after changing visible skills.
+// The versioned key then rebuilds new-session snapshots without hot-path polling.
 const resolvedSkillsCache = new Map<string, SkillSnapshot["resolvedSkills"]>();
 const RESOLVED_SKILLS_CACHE_MAX = 10;
 

--- a/src/skills/runtime/session-snapshot.ts
+++ b/src/skills/runtime/session-snapshot.ts
@@ -11,8 +11,8 @@ import { getSkillsSnapshotVersion, shouldRefreshSnapshotForVersion } from "./ref
 import { ensureSkillsWatcher } from "./refresh.js";
 import { hydrateResolvedSkills } from "./snapshot-hydration.js";
 
-// Skill mutation owners must bump refresh-state after changing visible skills.
-// The versioned key then rebuilds new-session snapshots without hot-path polling.
+// The resolved index is gateway-process state. Mutation RPCs and watcher events
+// must bump that same process's version so a new-session key cannot reuse it.
 const resolvedSkillsCache = new Map<string, SkillSnapshot["resolvedSkills"]>();
 const RESOLVED_SKILLS_CACHE_MAX = 10;
 

--- a/src/skills/workshop/curator.test.ts
+++ b/src/skills/workshop/curator.test.ts
@@ -19,6 +19,7 @@ import {
   buildWorkspaceSkillSnapshot,
   loadVisibleWorkspaceSkillEntries,
 } from "../loading/workspace.js";
+import { resolveReusableWorkspaceSkillSnapshot } from "../runtime/session-snapshot.js";
 import type {
   SkillProposalManifest,
   SkillProposalManifestEntry,
@@ -366,6 +367,14 @@ describe("skill curator lifecycle", () => {
     addAppliedSkill({ name: "Unused Archive", appliedAtMs: nowMs - ARCHIVE_AFTER_MS - 1 });
     await runSkillCuratorSweep({ env: process.env, nowMs });
 
+    const agentDir = path.join(rootDir, "agent");
+    const archivedSnapshot = resolveReusableWorkspaceSkillSnapshot({
+      workspaceDir: agentDir,
+      config: {},
+      watch: false,
+    }).snapshot;
+    expect(archivedSnapshot.skills.map((skill) => skill.name)).not.toContain("Deep Archive");
+
     await recordSkillUsage({
       skillFile: path.join(rootDir, "agent", "skills", "dormant", "SKILL.md"),
       skillName: "Dormant",
@@ -392,6 +401,13 @@ describe("skill curator lifecycle", () => {
     ).toMatchObject({
       state: "active",
     });
+    const restoredSnapshot = resolveReusableWorkspaceSkillSnapshot({
+      workspaceDir: agentDir,
+      config: {},
+      existingSnapshot: archivedSnapshot,
+      watch: false,
+    }).snapshot;
+    expect(restoredSnapshot.skills.map((skill) => skill.name)).toContain("Deep Archive");
     expect(
       restoreCuratedSkill("unused-archive", { env: process.env, nowMs: nowMs + 3 }),
     ).toMatchObject({ state: "active" });
@@ -613,9 +629,22 @@ describe("skill curator lifecycle", () => {
     const nowMs = Date.UTC(2026, 0, 1);
     addAppliedSkill({ name: "Archived Skill", appliedAtMs: nowMs - ARCHIVE_AFTER_MS - 1 });
     addAppliedSkill({ name: "Stale Skill", appliedAtMs: nowMs - STALE_AFTER_MS - 1 });
+    const agentDir = path.join(rootDir, "agent");
+    const beforeArchiveSnapshot = resolveReusableWorkspaceSkillSnapshot({
+      workspaceDir: agentDir,
+      config: {},
+      watch: false,
+    }).snapshot;
+    expect(beforeArchiveSnapshot.skills.map((skill) => skill.name)).toContain("Archived Skill");
     await runSkillCuratorSweep({ env: process.env, nowMs });
 
-    const agentDir = path.join(rootDir, "agent");
+    const newSessionSnapshot = resolveReusableWorkspaceSkillSnapshot({
+      workspaceDir: agentDir,
+      config: {},
+      existingSnapshot: beforeArchiveSnapshot,
+      watch: false,
+    }).snapshot;
+    expect(newSessionSnapshot.skills.map((skill) => skill.name)).not.toContain("Archived Skill");
     const manualAgentDir = path.join(rootDir, "manual-agent");
     writeSkill(agentDir, "archived-skill", "Archived Skill");
     writeSkill(agentDir, "stale-skill", "Stale Skill");

--- a/src/skills/workshop/curator.ts
+++ b/src/skills/workshop/curator.ts
@@ -16,6 +16,7 @@ import {
   type OpenClawStateDatabaseOptions,
 } from "../../state/openclaw-state-db.js";
 import { normalizeSkillIndexName } from "../discovery/skill-index.js";
+import { bumpSkillsSnapshotVersion } from "../runtime/refresh-state.js";
 import { readSkillProposalManifest, readSkillProposalRecord } from "./store.js";
 import type { SkillProposalRecord } from "./types.js";
 
@@ -440,6 +441,9 @@ async function runSkillCuratorSweep(
 
       return { stale, archived, pinnedSkipped };
     }, options);
+    if (result.archived > 0) {
+      bumpSkillsSnapshotVersion({ reason: "workshop" });
+    }
     const sweepResult: SkillCuratorSweepResult = {
       examined: curated.length,
       ...result,
@@ -611,6 +615,7 @@ export function restoreCuratedSkill(skill: string, options: CuratorOptions = {})
   if (!firstSkillFile) {
     throw new Error(`Archived curated skill not found: ${skill}`);
   }
+  bumpSkillsSnapshotVersion({ reason: "workshop", changedPath: firstSkillFile });
   // Archive and restore are snapshot-bound transitions: running sessions retain
   // their current skill snapshot until a new session or agent run builds one.
   return getSkillCuratorStatus(options).skills.find((entry) => entry.skillFile === firstSkillFile)!;

--- a/src/skills/workshop/service.test.ts
+++ b/src/skills/workshop/service.test.ts
@@ -12,7 +12,6 @@ import {
   getSkillsSnapshotVersion,
   resetSkillsRefreshStateForTest,
 } from "../runtime/refresh-state.js";
-import { resolveReusableWorkspaceSkillSnapshot } from "../runtime/session-snapshot.js";
 import { writeSkill } from "../test-support/e2e-test-helpers.js";
 import { renderProposalMarkdown } from "./frontmatter.js";
 import {
@@ -109,13 +108,6 @@ describe("skill workshop proposals", () => {
     );
     expect(proposal.content).toContain("date: ");
 
-    const beforeApplySnapshot = resolveReusableWorkspaceSkillSnapshot({
-      workspaceDir,
-      config: {},
-      watch: false,
-    }).snapshot;
-    expect(beforeApplySnapshot.skills.map((skill) => skill.name)).not.toContain("weather-helper");
-
     const listed = await listSkillProposals();
     expect(listed.proposals).toHaveLength(1);
     expect(listed.proposals[0]).toMatchObject({
@@ -132,13 +124,6 @@ describe("skill workshop proposals", () => {
     });
     expect(getSkillsSnapshotVersion(workspaceDir)).toBeGreaterThan(beforeVersion);
     expect(applied.targetSkillFile).toBe(proposal.record.target.skillFile);
-    const newSessionSnapshot = resolveReusableWorkspaceSkillSnapshot({
-      workspaceDir,
-      config: {},
-      existingSnapshot: beforeApplySnapshot,
-      watch: false,
-    }).snapshot;
-    expect(newSessionSnapshot.skills.map((skill) => skill.name)).toContain("weather-helper");
     await expect(fs.readFile(applied.targetSkillFile, "utf8")).resolves.toBe(
       '---\nname: "weather-helper"\ndescription: "Check weather before planning outdoor tasks"\n---\n\n# Weather Helper\n\nUse the weather provider before answering.\n',
     );

--- a/src/skills/workshop/service.test.ts
+++ b/src/skills/workshop/service.test.ts
@@ -12,6 +12,7 @@ import {
   getSkillsSnapshotVersion,
   resetSkillsRefreshStateForTest,
 } from "../runtime/refresh-state.js";
+import { resolveReusableWorkspaceSkillSnapshot } from "../runtime/session-snapshot.js";
 import { writeSkill } from "../test-support/e2e-test-helpers.js";
 import { renderProposalMarkdown } from "./frontmatter.js";
 import {
@@ -108,6 +109,13 @@ describe("skill workshop proposals", () => {
     );
     expect(proposal.content).toContain("date: ");
 
+    const beforeApplySnapshot = resolveReusableWorkspaceSkillSnapshot({
+      workspaceDir,
+      config: {},
+      watch: false,
+    }).snapshot;
+    expect(beforeApplySnapshot.skills.map((skill) => skill.name)).not.toContain("weather-helper");
+
     const listed = await listSkillProposals();
     expect(listed.proposals).toHaveLength(1);
     expect(listed.proposals[0]).toMatchObject({
@@ -124,6 +132,13 @@ describe("skill workshop proposals", () => {
     });
     expect(getSkillsSnapshotVersion(workspaceDir)).toBeGreaterThan(beforeVersion);
     expect(applied.targetSkillFile).toBe(proposal.record.target.skillFile);
+    const newSessionSnapshot = resolveReusableWorkspaceSkillSnapshot({
+      workspaceDir,
+      config: {},
+      existingSnapshot: beforeApplySnapshot,
+      watch: false,
+    }).snapshot;
+    expect(newSessionSnapshot.skills.map((skill) => skill.name)).toContain("weather-helper");
     await expect(fs.readFile(applied.targetSkillFile, "utf8")).resolves.toBe(
       '---\nname: "weather-helper"\ndescription: "Check weather before planning outdoor tasks"\n---\n\n# Weather Helper\n\nUse the weather provider before answering.\n',
     );


### PR DESCRIPTION
## What Problem This Solves

Fixes a process-ownership gap where `openclaw skills workshop apply` could write a skill in the short-lived CLI process while a running Gateway kept reusing its process-local resolved skill index. A new session could then omit the applied skill until the Gateway restarted.

Curator archive and restore transitions had the same new-session invalidation requirement.

## Root Cause

`applySkillProposal` on `main` already calls `bumpSkillsSnapshotVersion` after the workspace write. The earlier report was therefore literally correct, but incomplete: the snapshot version and `resolvedSkillsCache` are process-local. The CLI called `applySkillProposal` directly, so it advanced the CLI process's version rather than the running Gateway's version.

The Gateway session path persists the lightweight skill catalog without `resolvedSkills`, then rehydrates that runtime-only field from a version-keyed process cache. Without a Gateway-local version bump, the old cache key remained reusable. Restarting the Gateway replaced both the cache and its initial version, which explains the live symptom.

The workspace loader itself is not stale: `buildWorkspaceSkillSnapshot` scans `workspace/skills` when a rebuild is selected. Plugin metadata, connected node skills, node-host startup skill inventory, and node plugin-tool snapshots are separate process-lifetime surfaces; none owns workshop workspace files.

## What Changed

- `openclaw skills workshop apply` now probes the Gateway with a read-only health call and required-method check, then dispatches `skills.proposals.apply` to the running Gateway so the mutation advances the cache version in the owning process.
- Offline local fallback is selected before dispatch and only for an abnormal pre-dispatch local transport close. Once a Gateway answers, mutation failures are never replayed locally.
- Curator sweeps bump the skill snapshot version after archive transitions, and restore bumps it after the SQLite transition succeeds.
- The regression test uses two isolated module graphs to model a long-running Gateway and a short-lived CLI. It strips runtime-only `resolvedSkills` as persistence does, primes the Gateway cache, applies through the CLI, and then resolves the next session through the same cached path.

## User Impact

Workshop-applied skills appear in subsequent sessions without restarting the Gateway. Curator-archived skills disappear from new snapshots, and restored skills reappear. Existing in-flight session snapshots remain stable.

AI-assisted change; implementation and tests were reviewed with the repository autoreview workflow.

## Evidence

Exact regression against current `origin/main` (`95a1420d978`) with the new test file only:

```text
FAIL src/cli/skills-cli.workshop-cache.test.ts
AssertionError: expected "vi.fn()" to be called
Number of calls: 0
Test Files  1 failed (1)
Tests       1 failed (1)
```

The same test on this branch passes, and the final focused run is clean:

```text
Test Files  4 passed (4)
Tests       54 passed (54)
[test] passed 2 Vitest shards in 35.16s
```

Changed-file gate:

```text
[check:changed] lanes=core, coreTests
Found 0 warnings and 0 errors.
Import cycle check: 0 runtime value cycle(s).
blacksmith run summary sync=delegated command=6m4.537s total=6m7.704s exit=0
```

Blacksmith Testbox run: https://github.com/openclaw/openclaw/actions/runs/30253350024

Final autoreview:

```text
autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.97)
```
