### PR TITLE
fix: fall back on raw provider request errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Model fallback for raw provider errors:** classify unprefixed JSON `invalid_request_error` responses through the shared structured error map so schema rejections reach configured model fallbacks without obscuring context, billing, auth, or rate-limit signals. Thanks @sunkencity999. (#99174)
 - **Codex native controls:** stop misclassifying valid thinking/fast runtime controls as provider overrides so Codex routes keep their native controls, while provider-native objects and invalid values stay fail-closed. Thanks @VACInc. (#107588)
 - **State snapshot verification:** run SQLite snapshot verification in a separate process so worker-thread file closes no longer drop the Gateway's POSIX WAL locks, eliminating spurious WAL misses and I/O errors. Thanks @VACInc. (#114016)
 - **Reply latency with model policies:** reuse one immutable plugin-metadata snapshot per model-selection run instead of repeating plugin discovery, cutting reply delay when a model policy is configured. Thanks @VACInc. (#114117)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Model fallback for raw provider errors:** classify unprefixed JSON `invalid_request_error` responses through the shared structured error map so schema rejections reach configured model fallbacks without obscuring context, billing, auth, or rate-limit signals. Thanks @sunkencity999. (#99174)
 - **Codex native controls:** stop misclassifying valid thinking/fast runtime controls as provider overrides so Codex routes keep their native controls, while provider-native objects and invalid values stay fail-closed. Thanks @VACInc. (#107588)
 - **State snapshot verification:** run SQLite snapshot verification in a separate process so worker-thread file closes no longer drop the Gateway's POSIX WAL locks, eliminating spurious WAL misses and I/O errors. Thanks @VACInc. (#114016)
 - **Reply latency with model policies:** reuse one immutable plugin-metadata snapshot per model-selection run instead of repeating plugin discovery, cutting reply delay when a model policy is configured. Thanks @VACInc. (#114117)

--- a/src/agents/embedded-agent-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/embedded-agent-helpers.formatassistanterrortext.test.ts
@@ -146,7 +146,7 @@ describe("formatAssistantErrorText", () => {
     const msg = makeAssistantError(
       '{"type":"error","error":{"message":"SECRET\\nCANARY","type":"invalid_request_error"}}',
     );
-    expect(formatAssistantErrorText(msg)).toBe("LLM error invalid_request_error: SECRET\nCANARY");
+    expect(formatAssistantErrorText(msg)).toBe("LLM request rejected: SECRET\nCANARY");
     expect(formatUserFacingAssistantErrorText(msg)).toBe(
       "LLM request failed: provider rejected the request schema or tool payload.",
     );

--- a/src/agents/embedded-agent-helpers/errors-provider-structured-signals.test.ts
+++ b/src/agents/embedded-agent-helpers/errors-provider-structured-signals.test.ts
@@ -162,6 +162,25 @@ describe("provider failover hook structured signals", () => {
     ).toEqual({ kind: "reason", reason: "billing" });
   });
 
+  it("keeps specific typed API error classifications ahead of invalid-request format", () => {
+    providerRuntimeMocks.classifyProviderPluginError.mockReturnValue(undefined);
+
+    expect(
+      classifyFailoverSignal({
+        provider: "anthropic",
+        errorType: "invalid_request_error",
+        message: "Request size exceeds model context window",
+      }),
+    ).toEqual({ kind: "context_overflow" });
+    expect(
+      classifyFailoverSignal({
+        provider: "anthropic",
+        errorType: "invalid_request_error",
+        message: "You are out of extra usage. Add more at claude.ai/settings/usage",
+      }),
+    ).toEqual({ kind: "reason", reason: "billing" });
+  });
+
   it("lets structured billing details override an ambiguous quota message", () => {
     providerRuntimeMocks.classifyProviderPluginError.mockReturnValue(undefined);
     const message = makeAssistantMessageFixture({

--- a/src/agents/embedded-agent-helpers/errors-provider-structured-signals.test.ts
+++ b/src/agents/embedded-agent-helpers/errors-provider-structured-signals.test.ts
@@ -116,6 +116,52 @@ describe("provider failover hook structured signals", () => {
     ).toBe("billing");
   });
 
+  it("classifies raw and typed invalid-request errors through one core mapping", () => {
+    providerRuntimeMocks.classifyProviderPluginError.mockReturnValue(undefined);
+    const raw =
+      '{"type":"error","error":{"type":"invalid_request_error","message":"messages.27.content.1: thinking blocks cannot be modified"}}';
+
+    expect(classifyFailoverSignal({ provider: "anthropic", message: raw })).toEqual({
+      kind: "reason",
+      reason: "format",
+    });
+    expect(
+      classifyFailoverSignal({
+        provider: "anthropic",
+        errorType: "invalid_request_error",
+        message: "thinking blocks cannot be modified",
+      }),
+    ).toEqual({ kind: "reason", reason: "format" });
+    expect(
+      classifyAssistantFailoverReason(
+        makeAssistantMessageFixture({
+          provider: "anthropic",
+          errorMessage: raw,
+        }),
+      ),
+    ).toBe("format");
+    expect(classifyProviderRuntimeFailureKind(raw)).toBe("schema");
+  });
+
+  it("keeps specific raw API error classifications ahead of invalid-request format", () => {
+    providerRuntimeMocks.classifyProviderPluginError.mockReturnValue(undefined);
+
+    expect(
+      classifyFailoverSignal({
+        provider: "anthropic",
+        message:
+          '{"type":"error","error":{"type":"invalid_request_error","message":"Request size exceeds model context window"}}',
+      }),
+    ).toEqual({ kind: "context_overflow" });
+    expect(
+      classifyFailoverSignal({
+        provider: "anthropic",
+        message:
+          '{"type":"error","error":{"type":"invalid_request_error","message":"You are out of extra usage. Add more at claude.ai/settings/usage"}}',
+      }),
+    ).toEqual({ kind: "reason", reason: "billing" });
+  });
+
   it("lets structured billing details override an ambiguous quota message", () => {
     providerRuntimeMocks.classifyProviderPluginError.mockReturnValue(undefined);
     const message = makeAssistantMessageFixture({

--- a/src/agents/embedded-agent-helpers/errors.ts
+++ b/src/agents/embedded-agent-helpers/errors.ts
@@ -900,9 +900,11 @@ function classifyFailoverReasonFromCode(raw: string | undefined): FailoverReason
   }
 }
 
-function classifyFailoverReasonFromErrorType(raw: string | undefined): FailoverReason | null {
+function classifyCoreFailoverReasonFromErrorType(raw: string | undefined): FailoverReason | null {
   const normalized = normalizeOptionalLowercaseString(raw);
   switch (normalized) {
+    case "invalid_request_error":
+      return "format";
     case "server_error":
     case "upstream_error":
       return "server_error";
@@ -916,7 +918,7 @@ function classifyFailoverReasonFromErrorType(raw: string | undefined): FailoverR
 function classifyFailoverClassificationFromErrorType(
   raw: string | undefined,
 ): FailoverClassification | null {
-  const reason = classifyFailoverReasonFromErrorType(raw);
+  const reason = classifyCoreFailoverReasonFromErrorType(raw);
   return reason ? toReasonClassification(reason) : null;
 }
 
@@ -1129,6 +1131,13 @@ function classifyFailoverClassificationFromMessage(
   );
   if (providerSpecific) {
     return toReasonClassification(providerSpecific);
+  }
+  // Some adapters preserve only the raw JSON response body. Reuse the same
+  // structured type mapping as typed SDK errors after all more-specific text
+  // and provider rules have had a chance to classify the failure.
+  const apiErrorReason = classifyCoreFailoverReasonFromErrorType(parseApiErrorInfo(raw)?.type);
+  if (apiErrorReason) {
+    return toReasonClassification(apiErrorReason);
   }
   return null;
 }

--- a/src/agents/embedded-agent-helpers/errors.ts
+++ b/src/agents/embedded-agent-helpers/errors.ts
@@ -1560,9 +1560,9 @@ export function formatAssistantErrorText(
     );
   }
 
-  const invalidRequest = raw.match(/"type":"invalid_request_error".*?"message":"([^"]+)"/);
-  if (invalidRequest?.[1]) {
-    return `LLM request rejected: ${invalidRequest[1]}`;
+  const apiError = parseApiErrorInfo(raw);
+  if (apiError?.type?.toLowerCase().includes("invalid_request") && apiError.message?.trim()) {
+    return `LLM request rejected: ${apiError.message.trim()}`;
   }
 
   if (

--- a/src/agents/embedded-agent-helpers/errors.ts
+++ b/src/agents/embedded-agent-helpers/errors.ts
@@ -1237,6 +1237,8 @@ export function classifyFailoverSignal(signal: FailoverSignal): FailoverClassifi
     detailClassification,
   );
   const errorTypeClassification = classifyFailoverClassificationFromErrorType(signal.errorType);
+  // Message/detail semantics stay ahead of generic structured types so an
+  // invalid-request wrapper cannot hide billing, context, or provider policy.
   const effectiveMessageClassification = providerPluginReason
     ? toReasonClassification(providerPluginReason)
     : (messageOrDetailClassification ?? errorTypeClassification);

--- a/src/agents/embedded-agent-runner/run/assistant-failover.test.ts
+++ b/src/agents/embedded-agent-runner/run/assistant-failover.test.ts
@@ -578,6 +578,29 @@ describe("handleAssistantFailover", () => {
       expect(err.status).toBe(429);
     });
 
+    it("throws format-classified provider rejections to the outer model fallback", async () => {
+      const rawError =
+        '{"type":"error","error":{"type":"invalid_request_error","message":"thinking blocks cannot be modified"}}';
+      const outcome = await handleAssistantFailover(
+        makeParams({
+          initialDecision: { action: "surface_error", reason: "format" },
+          fallbackConfigured: true,
+          failoverReason: "format",
+          billingFailure: false,
+          lastAssistant: {
+            errorMessage: rawError,
+            model: "claude-haiku-4-5-20251001",
+            provider: "Anthropic",
+          } as Params["lastAssistant"],
+        }),
+      );
+
+      const err = expectThrownFailoverError(outcome);
+      expect(err.reason).toBe("format");
+      expect(err.status).toBe(400);
+      expect(err.rawError).toBe(rawError);
+    });
+
     it("preserves the raw provider error on surfaced failures", async () => {
       const rawError = '  400 {"error":{"message":"credit balance is too low"}}  ';
       const outcome = await handleAssistantFailover(

--- a/src/gateway/server-methods/sessions-messaging.ts
+++ b/src/gateway/server-methods/sessions-messaging.ts
@@ -323,6 +323,35 @@ async function handleSessionSend(params: {
     return;
   }
 
+  const readNextMessageSeq = async () =>
+    (await readSessionMessageCountAsync({
+      agentId: requestedAgentId,
+      sessionEntry: entry,
+      sessionId: entry.sessionId,
+      sessionKey: canonicalKey,
+      storePath,
+    })) + 1;
+  let messageSeq: number | undefined;
+  try {
+    messageSeq = await readNextMessageSeq();
+  } catch (error) {
+    if (!isSessionTranscriptProjectionUnavailableError(error)) {
+      throw error;
+    }
+    // Projection rebuilds are transient and happen before dispatch, so callers
+    // can safely retry the same idempotency key without duplicating a turn.
+    params.respond(
+      false,
+      undefined,
+      errorShape(ErrorCodes.UNAVAILABLE, "session transcript is rebuilding; retry shortly", {
+        details: { method: params.method },
+        retryable: true,
+        retryAfterMs: 250,
+      }),
+    );
+    return;
+  }
+
   let interruptedActiveRun = false;
   if (params.interruptIfActive) {
     const interruptResult = await interruptSessionRunIfActive({
@@ -341,34 +370,21 @@ async function handleSessionSend(params: {
     }
     interruptedActiveRun = interruptResult.interrupted;
   }
-
-  let messageSeq: number;
-  try {
-    messageSeq =
-      (await readSessionMessageCountAsync({
-        agentId: requestedAgentId,
-        sessionEntry: entry,
-        sessionId: entry.sessionId,
-        sessionKey: canonicalKey,
-        storePath,
-      })) + 1;
-  } catch (error) {
-    if (!isSessionTranscriptProjectionUnavailableError(error)) {
-      throw error;
+  if (params.interruptIfActive) {
+    try {
+      // A run can finish before the active check or while an interruption
+      // drains. Refresh after every steer attempt so the pending seq is current.
+      messageSeq = await readNextMessageSeq();
+    } catch (error) {
+      if (!isSessionTranscriptProjectionUnavailableError(error)) {
+        throw error;
+      }
+      // Interruption may already have committed side effects. The sequence is
+      // optional, so preserve delivery and let transcript events reconcile it.
+      messageSeq = undefined;
     }
-    // Projection rebuilds are transient and happen before dispatch, so callers
-    // can safely retry the same idempotency key without duplicating a turn.
-    params.respond(
-      false,
-      undefined,
-      errorShape(ErrorCodes.UNAVAILABLE, "session transcript is rebuilding; retry shortly", {
-        details: { method: params.method },
-        retryable: true,
-        retryAfterMs: 250,
-      }),
-    );
-    return;
   }
+
   let sendAcked = false;
   let sendPayload: unknown;
   let sendCached = false;
@@ -388,7 +404,7 @@ async function handleSessionSend(params: {
         true,
         {
           ...(payload && typeof payload === "object" ? payload : {}),
-          messageSeq,
+          ...(messageSeq !== undefined ? { messageSeq } : {}),
           ...(interruptedActiveRun ? { interruptedActiveRun: true } : {}),
         },
         undefined,

--- a/src/gateway/server-methods/sessions-messaging.ts
+++ b/src/gateway/server-methods/sessions-messaging.ts
@@ -15,6 +15,7 @@ import {
 } from "../../agents/embedded-agent-runner/runs.js";
 import { clearSessionQueues } from "../../auto-reply/reply/queue/cleanup.js";
 import { resolveSessionWorkStartError, type SessionEntry } from "../../config/sessions.js";
+import { isSessionTranscriptProjectionUnavailableError } from "../../config/sessions/session-accessor.js";
 import { parseAgentSessionKey } from "../../routing/session-key.js";
 import { resolveRequestedSessionAgentId as resolveRequestedGlobalAgentId } from "../session-create-service.js";
 import { reactivateCompletedSubagentSession } from "../session-subagent-reactivation.js";
@@ -341,14 +342,33 @@ async function handleSessionSend(params: {
     interruptedActiveRun = interruptResult.interrupted;
   }
 
-  const messageSeq =
-    (await readSessionMessageCountAsync({
-      agentId: requestedAgentId,
-      sessionEntry: entry,
-      sessionId: entry.sessionId,
-      sessionKey: canonicalKey,
-      storePath,
-    })) + 1;
+  let messageSeq: number;
+  try {
+    messageSeq =
+      (await readSessionMessageCountAsync({
+        agentId: requestedAgentId,
+        sessionEntry: entry,
+        sessionId: entry.sessionId,
+        sessionKey: canonicalKey,
+        storePath,
+      })) + 1;
+  } catch (error) {
+    if (!isSessionTranscriptProjectionUnavailableError(error)) {
+      throw error;
+    }
+    // Projection rebuilds are transient and happen before dispatch, so callers
+    // can safely retry the same idempotency key without duplicating a turn.
+    params.respond(
+      false,
+      undefined,
+      errorShape(ErrorCodes.UNAVAILABLE, "session transcript is rebuilding; retry shortly", {
+        details: { method: params.method },
+        retryable: true,
+        retryAfterMs: 250,
+      }),
+    );
+    return;
+  }
   let sendAcked = false;
   let sendPayload: unknown;
   let sendCached = false;

--- a/src/gateway/server-methods/sessions.send-followup-status.test.ts
+++ b/src/gateway/server-methods/sessions.send-followup-status.test.ts
@@ -4,6 +4,7 @@
 
 import { expectDefined } from "@openclaw/normalization-core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SessionTranscriptProjectionUnavailableError } from "../../config/sessions/session-accessor.js";
 import { expectSubagentFollowupReactivation } from "./subagent-followup.test-helpers.js";
 import type { GatewayRequestContext, RespondFn } from "./types.js";
 
@@ -142,6 +143,51 @@ describe("sessions.send completed subagent follow-up status", () => {
       childSessionKey,
       task: "follow-up",
     });
+  });
+
+  it("returns retryable unavailable before dispatch while transcript projection rebuilds", async () => {
+    const sessionKey = "agent:main:main";
+    loadSessionEntryMock.mockReturnValue({
+      cfg: {},
+      canonicalKey: sessionKey,
+      storePath: "/tmp/sessions.json",
+      entry: { sessionId: "sess-rebuilding" },
+    });
+    readSessionMessageCountAsyncMock.mockRejectedValue(
+      new SessionTranscriptProjectionUnavailableError("sess-rebuilding"),
+    );
+
+    const respondMock = vi.fn();
+    await expectDefined(
+      sessionsHandlers["sessions.send"],
+      'sessionsHandlers["sessions.send"] test invariant',
+    )({
+      req: { id: "req-rebuilding" } as never,
+      params: {
+        key: sessionKey,
+        message: "follow-up",
+        idempotencyKey: "retry-safe-send",
+      },
+      respond: respondMock as unknown as RespondFn,
+      context: {
+        chatAbortControllers: new Map(),
+        getRuntimeConfig: () => ({}),
+      } as unknown as GatewayRequestContext,
+      client: null,
+      isWebchatConnect: () => false,
+    });
+
+    expect(respondMock).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        code: "UNAVAILABLE",
+        details: { method: "sessions.send" },
+        retryable: true,
+        retryAfterMs: 250,
+      }),
+    );
+    expect(chatSendMock).not.toHaveBeenCalled();
   });
 
   for (const method of ["sessions.send", "sessions.steer"] as const) {

--- a/src/gateway/server-methods/sessions.send-followup-status.test.ts
+++ b/src/gateway/server-methods/sessions.send-followup-status.test.ts
@@ -14,6 +14,21 @@ const loadGatewaySessionRowMock = vi.fn();
 const getLatestSubagentRunByChildSessionKeyMock = vi.fn();
 const replaceSubagentRunAfterSteerMock = vi.fn();
 const chatSendMock = vi.fn();
+const isEmbeddedAgentRunActiveMock = vi.fn();
+const abortEmbeddedAgentRunMock = vi.fn();
+const waitForEmbeddedAgentRunEndMock = vi.fn();
+
+vi.mock("../../agents/embedded-agent-runner/runs.js", async () => {
+  const actual = await vi.importActual<typeof import("../../agents/embedded-agent-runner/runs.js")>(
+    "../../agents/embedded-agent-runner/runs.js",
+  );
+  return {
+    ...actual,
+    abortEmbeddedAgentRun: (...args: unknown[]) => abortEmbeddedAgentRunMock(...args),
+    isEmbeddedAgentRunActive: (...args: unknown[]) => isEmbeddedAgentRunActiveMock(...args),
+    waitForEmbeddedAgentRunEnd: (...args: unknown[]) => waitForEmbeddedAgentRunEndMock(...args),
+  };
+});
 
 vi.mock("../session-utils.js", async () => {
   const actual = await vi.importActual<typeof import("../session-utils.js")>("../session-utils.js");
@@ -65,6 +80,9 @@ describe("sessions.send completed subagent follow-up status", () => {
     getLatestSubagentRunByChildSessionKeyMock.mockReset();
     replaceSubagentRunAfterSteerMock.mockReset();
     chatSendMock.mockReset();
+    isEmbeddedAgentRunActiveMock.mockReset().mockReturnValue(false);
+    abortEmbeddedAgentRunMock.mockReset();
+    waitForEmbeddedAgentRunEndMock.mockReset().mockResolvedValue(true);
   });
 
   it("reactivates completed subagent sessions before broadcasting sessions.changed", async () => {
@@ -145,49 +163,191 @@ describe("sessions.send completed subagent follow-up status", () => {
     });
   });
 
-  it("returns retryable unavailable before dispatch while transcript projection rebuilds", async () => {
+  for (const method of ["sessions.send", "sessions.steer"] as const) {
+    it(`${method} returns retryable unavailable before side effects while projection rebuilds`, async () => {
+      const sessionKey = "agent:main:main";
+      loadSessionEntryMock.mockReturnValue({
+        cfg: {},
+        canonicalKey: sessionKey,
+        storePath: "/tmp/sessions.json",
+        entry: { sessionId: "sess-rebuilding" },
+      });
+      readSessionMessageCountAsyncMock.mockRejectedValue(
+        new SessionTranscriptProjectionUnavailableError("sess-rebuilding"),
+      );
+
+      const respondMock = vi.fn();
+      await expectDefined(
+        sessionsHandlers[method],
+        "sessionsHandlers[method] test invariant",
+      )({
+        req: { id: "req-rebuilding" } as never,
+        params: {
+          key: sessionKey,
+          message: "follow-up",
+          idempotencyKey: "retry-safe-send",
+        },
+        respond: respondMock as unknown as RespondFn,
+        context: {
+          chatAbortControllers: new Map(),
+          getRuntimeConfig: () => ({}),
+        } as unknown as GatewayRequestContext,
+        client: null,
+        isWebchatConnect: () => false,
+      });
+
+      expect(respondMock).toHaveBeenCalledWith(
+        false,
+        undefined,
+        expect.objectContaining({
+          code: "UNAVAILABLE",
+          details: { method },
+          retryable: true,
+          retryAfterMs: 250,
+        }),
+      );
+      expect(isEmbeddedAgentRunActiveMock).not.toHaveBeenCalled();
+      expect(chatSendMock).not.toHaveBeenCalled();
+    });
+  }
+
+  it("sessions.steer refreshes the pending sequence after an active run drains", async () => {
     const sessionKey = "agent:main:main";
     loadSessionEntryMock.mockReturnValue({
       cfg: {},
       canonicalKey: sessionKey,
       storePath: "/tmp/sessions.json",
-      entry: { sessionId: "sess-rebuilding" },
+      entry: { sessionId: "sess-active" },
     });
-    readSessionMessageCountAsyncMock.mockRejectedValue(
-      new SessionTranscriptProjectionUnavailableError("sess-rebuilding"),
-    );
+    readSessionMessageCountAsyncMock.mockResolvedValueOnce(2).mockResolvedValueOnce(3);
+    isEmbeddedAgentRunActiveMock.mockReturnValue(true);
+    chatSendMock.mockImplementation(async ({ respond }: { respond: RespondFn }) => {
+      respond(true, { runId: "run-steered", status: "started" }, undefined, undefined);
+    });
 
     const respondMock = vi.fn();
     await expectDefined(
-      sessionsHandlers["sessions.send"],
-      'sessionsHandlers["sessions.send"] test invariant',
+      sessionsHandlers["sessions.steer"],
+      'sessionsHandlers["sessions.steer"] test invariant',
     )({
-      req: { id: "req-rebuilding" } as never,
+      req: { id: "req-steer" } as never,
       params: {
         key: sessionKey,
-        message: "follow-up",
-        idempotencyKey: "retry-safe-send",
+        message: "replacement turn",
+        idempotencyKey: "steer-after-drain",
       },
       respond: respondMock as unknown as RespondFn,
       context: {
         chatAbortControllers: new Map(),
+        broadcastToConnIds: vi.fn(),
+        getSessionEventSubscriberConnIds: () => new Set<string>(),
         getRuntimeConfig: () => ({}),
       } as unknown as GatewayRequestContext,
       client: null,
       isWebchatConnect: () => false,
     });
 
-    expect(respondMock).toHaveBeenCalledWith(
-      false,
-      undefined,
-      expect.objectContaining({
-        code: "UNAVAILABLE",
-        details: { method: "sessions.send" },
-        retryable: true,
-        retryAfterMs: 250,
-      }),
-    );
-    expect(chatSendMock).not.toHaveBeenCalled();
+    expect(abortEmbeddedAgentRunMock).toHaveBeenCalledWith("sess-active");
+    expect(waitForEmbeddedAgentRunEndMock).toHaveBeenCalledWith("sess-active", 15_000);
+    expect(readSessionMessageCountAsyncMock).toHaveBeenCalledTimes(2);
+    expect(respondMock.mock.calls.at(0)?.[1]).toMatchObject({
+      runId: "run-steered",
+      messageSeq: 4,
+      interruptedActiveRun: true,
+    });
+  });
+
+  it("sessions.steer refreshes when a run finishes before the active check", async () => {
+    const sessionKey = "agent:main:main";
+    loadSessionEntryMock.mockReturnValue({
+      cfg: {},
+      canonicalKey: sessionKey,
+      storePath: "/tmp/sessions.json",
+      entry: { sessionId: "sess-finished" },
+    });
+    readSessionMessageCountAsyncMock.mockResolvedValueOnce(2).mockResolvedValueOnce(3);
+    isEmbeddedAgentRunActiveMock.mockReturnValue(false);
+    chatSendMock.mockImplementation(async ({ respond }: { respond: RespondFn }) => {
+      respond(true, { runId: "run-raced", status: "started" }, undefined, undefined);
+    });
+
+    const respondMock = vi.fn();
+    await expectDefined(
+      sessionsHandlers["sessions.steer"],
+      'sessionsHandlers["sessions.steer"] test invariant',
+    )({
+      req: { id: "req-raced" } as never,
+      params: {
+        key: sessionKey,
+        message: "replacement turn",
+        idempotencyKey: "steer-after-race",
+      },
+      respond: respondMock as unknown as RespondFn,
+      context: {
+        chatAbortControllers: new Map(),
+        broadcastToConnIds: vi.fn(),
+        getSessionEventSubscriberConnIds: () => new Set<string>(),
+        getRuntimeConfig: () => ({}),
+      } as unknown as GatewayRequestContext,
+      client: null,
+      isWebchatConnect: () => false,
+    });
+
+    expect(abortEmbeddedAgentRunMock).not.toHaveBeenCalled();
+    expect(readSessionMessageCountAsyncMock).toHaveBeenCalledTimes(2);
+    expect(respondMock.mock.calls.at(0)?.[1]).toMatchObject({
+      runId: "run-raced",
+      messageSeq: 4,
+    });
+  });
+
+  it("sessions.steer preserves delivery when projection rebuilds after interruption", async () => {
+    const sessionKey = "agent:main:main";
+    loadSessionEntryMock.mockReturnValue({
+      cfg: {},
+      canonicalKey: sessionKey,
+      storePath: "/tmp/sessions.json",
+      entry: { sessionId: "sess-rebuild-after-interrupt" },
+    });
+    readSessionMessageCountAsyncMock
+      .mockResolvedValueOnce(2)
+      .mockRejectedValueOnce(
+        new SessionTranscriptProjectionUnavailableError("sess-rebuild-after-interrupt"),
+      );
+    isEmbeddedAgentRunActiveMock.mockReturnValue(true);
+    chatSendMock.mockImplementation(async ({ respond }: { respond: RespondFn }) => {
+      respond(true, { runId: "run-after-rebuild", status: "started" }, undefined, undefined);
+    });
+
+    const respondMock = vi.fn();
+    await expectDefined(
+      sessionsHandlers["sessions.steer"],
+      'sessionsHandlers["sessions.steer"] test invariant',
+    )({
+      req: { id: "req-rebuild-after-interrupt" } as never,
+      params: {
+        key: sessionKey,
+        message: "replacement turn",
+        idempotencyKey: "steer-after-rebuild",
+      },
+      respond: respondMock as unknown as RespondFn,
+      context: {
+        chatAbortControllers: new Map(),
+        broadcastToConnIds: vi.fn(),
+        getSessionEventSubscriberConnIds: () => new Set<string>(),
+        getRuntimeConfig: () => ({}),
+      } as unknown as GatewayRequestContext,
+      client: null,
+      isWebchatConnect: () => false,
+    });
+
+    expect(abortEmbeddedAgentRunMock).toHaveBeenCalledWith("sess-rebuild-after-interrupt");
+    expect(chatSendMock).toHaveBeenCalledTimes(1);
+    expect(respondMock.mock.calls.at(0)?.[1]).toMatchObject({
+      runId: "run-after-rebuild",
+      interruptedActiveRun: true,
+    });
+    expect(respondMock.mock.calls.at(0)?.[1]).not.toHaveProperty("messageSeq");
   });
 
   for (const method of ["sessions.send", "sessions.steer"] as const) {

--- a/src/tui/tui-pty-local.e2e.test.ts
+++ b/src/tui/tui-pty-local.e2e.test.ts
@@ -134,10 +134,10 @@ const SESSION_ROLLOVER_BUSY_MESSAGE = "abort the current run before /new";
 function isRetryableGatewayUnavailable(error: unknown): error is Error & {
   retryAfterMs?: number;
 } {
-  return Boolean(
+  return (
     error instanceof Error &&
     (error as { gatewayCode?: unknown }).gatewayCode === "UNAVAILABLE" &&
-    (error as { retryable?: unknown }).retryable === true,
+    (error as { retryable?: unknown }).retryable === true
   );
 }
 

--- a/src/tui/tui-pty-local.e2e.test.ts
+++ b/src/tui/tui-pty-local.e2e.test.ts
@@ -131,6 +131,30 @@ const LOCAL_TEST_TIMEOUT_MS = 150_000;
 const SUBMISSION_SETTLE_MS = 150;
 const SESSION_ROLLOVER_BUSY_MESSAGE = "abort the current run before /new";
 
+function isRetryableGatewayUnavailable(error: unknown): error is Error & {
+  retryAfterMs?: number;
+} {
+  return Boolean(
+    error instanceof Error &&
+    (error as { gatewayCode?: unknown }).gatewayCode === "UNAVAILABLE" &&
+    (error as { retryable?: unknown }).retryable === true,
+  );
+}
+
+async function requestWithUnavailableRetry<T>(request: () => Promise<T>): Promise<T> {
+  const deadline = Date.now() + LOCAL_STARTUP_TIMEOUT_MS;
+  while (true) {
+    try {
+      return await request();
+    } catch (error) {
+      if (!isRetryableGatewayUnavailable(error) || Date.now() >= deadline) {
+        throw error;
+      }
+      await sleep(Math.max(25, Math.min(error.retryAfterMs ?? 25, 1_000)));
+    }
+  }
+}
+
 function createIdempotentCleanup(cleanup: () => Promise<void>) {
   let cleanupPromise: Promise<void> | undefined;
   return () => (cleanupPromise ??= cleanup());
@@ -1189,20 +1213,24 @@ describe("TUI PTY real backends", () => {
         await fixture.run.waitForOutput("FIRST_RUN_ACTIVE", LOCAL_OUTPUT_TIMEOUT_MS);
         const firstReplyOffset = fixture.run.output().lastIndexOf("FIRST_RUN_ACTIVE");
         await waitForOutputAfter(fixture.run, "| idle", firstReplyOffset);
-        externalClient = await connectGatewayClient({
+        const connectedExternalClient = await connectGatewayClient({
           url: fixture.gateway.url,
           token: fixture.gateway.gatewayToken,
           scopes: ["operator.read", "operator.write"],
           clientDisplayName: "tui-external-session-writer",
         });
+        externalClient = connectedExternalClient;
 
         const marker = "EXTERNAL_GATEWAY_SESSION_MESSAGE";
-        await externalClient.request("sessions.send", {
-          key: fixture.sessionKey,
-          message: marker,
-          idempotencyKey: `${fixture.sessionKey}:external-message`,
-          timeoutMs: 30_000,
-        });
+        await requestWithUnavailableRetry(
+          async () =>
+            await connectedExternalClient.request("sessions.send", {
+              key: fixture.sessionKey,
+              message: marker,
+              idempotencyKey: `${fixture.sessionKey}:external-message`,
+              timeoutMs: 30_000,
+            }),
+        );
 
         await fixture.run.waitForOutput(marker, LOCAL_OUTPUT_TIMEOUT_MS);
         await fixture.run.waitForOutput("FOLLOWUP_RUN_COMPLETE", LOCAL_OUTPUT_TIMEOUT_MS);


### PR DESCRIPTION
Closes #99174

## What Problem This Solves

Fixes an issue where users with configured fallback models could receive a terminal provider-schema error instead of a fallback response when an Anthropic-shaped HTTP 400 arrived as an unprefixed JSON body. The same rejection was also retried against the failing model because failover discarded the structured `invalid_request_error` type.

## Why This Change Was Made

Raw JSON bodies and typed SDK errors now use one core error-type mapping. `invalid_request_error` maps to the existing `format` failover lane only after higher-specificity message and provider classifiers run, so context overflow, billing, auth, rate limits, model-not-found errors, and provider-owned codes retain precedence.

This keeps the repair at the shared failover boundary instead of adding an Anthropic-specific regex or a result-level fallback exception. The outer model fallback continues to own candidate advancement.

Exact-head CI also exposed two brittle adjacent paths. Structured invalid-request errors now keep detailed internal diagnostics while the user-facing formatter still redacts them, and `sessions.send` now returns a retryable pre-dispatch error while a transcript projection rebuilds. The real TUI cross-client path retries the same idempotency key, making that user flow robust without risking duplicate turns.

## Maintainer Decisions

- Confirmed: generic provider `invalid_request_error` values should advance configured fallback models through the shared `format` lane after context, billing, auth, rate-limit, model, message/detail, and provider-owned classifications have had precedence.
- Confirmed: retryable transcript-projection failures belong at the `sessions.send` / `sessions.steer` owner boundary before dispatch. After interruption side effects, delivery wins over optional sequence metadata.
- Refreshed review covered the current shared classifier, assistant failover policy, outer fallback loop, internal and user-facing formatters, session message-count reader, send/steer handler, TUI retry client, adjacent tests, and latest `origin/main` behavior.

## User Impact

Provider schema rejections that arrive as raw JSON can advance to a configured fallback model instead of consuming same-model empty-error retries and ending the turn. Installations without fallback models retain the existing terminal error behavior.

Gateway clients sending to a session during a transient transcript rebuild now receive an explicit retryable response instead of a terminal `UNAVAILABLE` error.

## Evidence

- Live Anthropic API probe with the vaulted OpenClaw test credential returned HTTP 400 and `error.type=invalid_request_error`; feeding those exact unprefixed response bytes through this branch returned `live_failover_classification:format`. No credential or provider response text was logged.
- Anthropic's current error contract documents `invalid_request_error` as a request format/content error: https://platform.claude.com/docs/en/api/errors
- 353 focused unit/gateway tests passed across structured error formatting, failover classification and precedence, assistant/outer fallback, and retryable send/steer projection handling.
- The real TUI/Gateway cross-client scenario `renders messages sent by another real Gateway client without restarting` passed with the local model endpoint mocked and the real Gateway/session transport active.
- Focused formatting check passed for all four changed files.
- Exact type-aware oxlint passed for the TUI retry guard after CI identified a redundant boolean conversion.
- Pre-land Codex autoreview flagged typed-error precedence; source inspection showed the precedence was already correct, so the branch now locks it with typed context/billing regressions and an inline invariant. The focused finding-fix review is clean at 0.98 confidence.
- Exact-head CI run 30251842464 exposed one related internal-formatting regression and one TUI transcript-projection race. Both root causes were fixed rather than rerun; the combined hardening autoreview is clean at 0.91 confidence.
- Follow-up review found two steer ordering races: abort-before-failure and stale pending sequence metadata. The final design preflights before side effects, refreshes after every steer attempt, and omits only optional sequence metadata if projection rebuilding recurs after an interruption. Focused review passed at 0.93 confidence; the final whole-branch review is clean at 0.88 confidence.
- The hosted Testbox lease rejected reuse after `main` advanced; per maintainer direction, focused proof ran locally against the matching prepared dependency tree without installing or reconciling dependencies.

This PR is AI-assisted. I reviewed the classifier ordering, fallback ownership, tests, and live provider proof.
