### PR TITLE
fix(discord): preserve attachment content types

### DIFF
--- a/extensions/discord/src/internal/payload.ts
+++ b/extensions/discord/src/internal/payload.ts
@@ -5,6 +5,7 @@ import { Embed } from "./embeds.js";
 export type MessagePayloadFile = {
   name: string;
   data: Blob | Uint8Array | ArrayBuffer;
+  contentType?: string;
   description?: string;
   duration_secs?: number;
   waveform?: string;

--- a/extensions/discord/src/monitor/native-command-reply.test.ts
+++ b/extensions/discord/src/monitor/native-command-reply.test.ts
@@ -1,11 +1,17 @@
 // Discord tests cover native command reply plugin behavior.
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Container, TextDisplay } from "../internal/discord.js";
+import { createDiscordLoopbackRest } from "../send.test-harness.js";
 import {
   deliverDiscordInteractionReply,
   hasRenderableReplyPayload,
   settleDiscordInteractionWithoutVisibleReply,
 } from "./native-command-reply.js";
+
+const loadWebMediaMock = vi.hoisted(() => vi.fn());
+vi.mock("openclaw/plugin-sdk/web-media", () => ({
+  loadWebMedia: loadWebMediaMock,
+}));
 
 function createInteraction() {
   return {
@@ -15,6 +21,10 @@ function createInteraction() {
 }
 
 describe("deliverDiscordInteractionReply", () => {
+  beforeEach(() => {
+    loadWebMediaMock.mockReset();
+  });
+
   it("sends component-only native command replies as follow-ups", async () => {
     const interaction = createInteraction();
     const components = [new Container([new TextDisplay("Pick a model")])];
@@ -66,6 +76,45 @@ describe("deliverDiscordInteractionReply", () => {
       components,
     });
     expect(interaction.followUp).not.toHaveBeenCalled();
+  });
+
+  it("sends the detected WebP media type across a real interaction multipart request", async () => {
+    const loopback = await createDiscordLoopbackRest();
+    loadWebMediaMock.mockResolvedValue({
+      buffer: Buffer.from("webp"),
+      fileName: "sticker.webp",
+      contentType: "image/webp",
+      kind: "image",
+    });
+    const interaction = {
+      reply: vi.fn(async (data: unknown) =>
+        loopback.rest.post("/interactions/123/token/callback", {
+          body: { type: 4, data },
+        }),
+      ),
+      followUp: vi.fn(),
+    };
+
+    try {
+      await deliverDiscordInteractionReply({
+        interaction: interaction as never,
+        payload: {
+          text: "sticker",
+          mediaUrls: ["file:///tmp/sticker.webp"],
+        },
+        textLimit: 2000,
+        preferFollowUp: false,
+        chunkMode: "length",
+      });
+
+      const upload = loopback.requests.find((request) => request.method === "POST");
+      expect(upload?.path).toContain("/interactions/123/token/callback");
+      expect(upload?.contentType).toMatch(/^multipart\/form-data; boundary=/);
+      expect(upload?.body).toContain('name="files[0]"; filename="sticker.webp"');
+      expect(upload?.body).toContain("Content-Type: image/webp");
+    } finally {
+      await loopback.close();
+    }
   });
 });
 

--- a/extensions/discord/src/monitor/native-command-reply.ts
+++ b/extensions/discord/src/monitor/native-command-reply.ts
@@ -12,6 +12,7 @@ import { chunkDiscordTextWithMode } from "../chunk.js";
 import type {
   ButtonInteraction,
   CommandInteraction,
+  MessagePayloadFile,
   StringSelectMenuInteraction,
   TopLevelComponents,
 } from "../internal/discord.js";
@@ -106,7 +107,7 @@ export async function deliverDiscordInteractionReply(params: {
   let payloadDelivered = false;
   const sendMessage = async (
     content: string,
-    files?: { name: string; data: Buffer }[],
+    files?: MessagePayloadFile[],
     components?: TopLevelComponents[],
   ) => {
     const contentPayload = content ? { content } : {};
@@ -118,13 +119,7 @@ export async function deliverDiscordInteractionReply(params: {
             ...(params.responseEphemeral !== undefined
               ? { ephemeral: params.responseEphemeral }
               : {}),
-            files: files.map((file) => {
-              if (file.data instanceof Blob) {
-                return { name: file.name, data: file.data };
-              }
-              const arrayBuffer = Uint8Array.from(file.data).buffer;
-              return { name: file.name, data: new Blob([arrayBuffer]) };
-            }),
+            files,
           }
         : {
             ...contentPayload,
@@ -174,6 +169,7 @@ export async function deliverDiscordInteractionReply(params: {
         return {
           name: loaded.fileName ?? "upload",
           data: loaded.buffer,
+          contentType: loaded.contentType,
         };
       }),
     );

--- a/extensions/discord/src/send.components.test.ts
+++ b/extensions/discord/src/send.components.test.ts
@@ -1,7 +1,7 @@
 // Discord tests cover send.components plugin behavior.
 import { ChannelType, MessageFlags } from "discord-api-types/v10";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { makeDiscordRest } from "./send.test-harness.js";
+import { createDiscordLoopbackRest, makeDiscordRest } from "./send.test-harness.js";
 
 const loadConfigMock = vi.hoisted(() => vi.fn(() => ({ session: { dmScope: "main" } })));
 
@@ -52,6 +52,7 @@ function resetClassicMocks(): void {
   loadOutboundMediaFromUrlMock.mockResolvedValue({
     buffer: Buffer.from("media"),
     fileName: "report.pdf",
+    contentType: "application/pdf",
   });
   vi.clearAllMocks();
 }
@@ -410,6 +411,36 @@ describe("sendDiscordComponentMessage classic message downgrade", () => {
     expect(modals[0]?.title).toBe("Feedback");
     expect(modals[0]?.fields).toHaveLength(1);
     expect(modals[0]?.fields?.[0]?.label).toBe("Notes");
+  });
+
+  it("sends the detected PDF media type across a real component multipart request", async () => {
+    const loopback = await createDiscordLoopbackRest();
+    try {
+      await sendDiscordComponentMessage(
+        "channel:789",
+        {
+          text: "report",
+          modal: {
+            title: "Feedback",
+            fields: [{ type: "text", label: "Notes" }],
+          },
+        },
+        {
+          cfg: DISCORD_TEST_CFG,
+          rest: loopback.rest,
+          token: "test-token",
+          mediaUrl: "https://example.com/report.pdf",
+        },
+      );
+
+      const upload = loopback.requests.find((request) => request.method === "POST");
+      expect(upload?.path).toContain("/channels/789/messages");
+      expect(upload?.contentType).toMatch(/^multipart\/form-data; boundary=/);
+      expect(upload?.body).toContain('name="files[0]"; filename="report.pdf"');
+      expect(upload?.body).toContain("Content-Type: application/pdf");
+    } finally {
+      await loopback.close();
+    }
   });
 
   it("treats bare numeric component send targets as channels", async () => {

--- a/extensions/discord/src/send.components.ts
+++ b/extensions/discord/src/send.components.ts
@@ -220,7 +220,7 @@ async function buildDiscordComponentPayload(params: {
     const filenameOverride = params.opts.filename?.trim();
     resolvedFileName = filenameOverride || media.fileName || "upload";
     spec = withImplicitComponentAttachmentBlock(spec, resolvedFileName);
-    files = [{ data: media.buffer, name: resolvedFileName }];
+    files = [{ data: media.buffer, name: resolvedFileName, contentType: media.contentType }];
   }
 
   const attachmentNames = extractComponentAttachmentNames(spec);

--- a/extensions/discord/src/send.sends-basic-channel-messages.test.ts
+++ b/extensions/discord/src/send.sends-basic-channel-messages.test.ts
@@ -3,7 +3,11 @@ import { ChannelType, MessageFlags, PermissionFlagsBits, Routes } from "discord-
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { Container, TextDisplay } from "./internal/discord.js";
-import { discordWebMediaMockFactory, makeDiscordRest } from "./send.test-harness.js";
+import {
+  createDiscordLoopbackRest,
+  discordWebMediaMockFactory,
+  makeDiscordRest,
+} from "./send.test-harness.js";
 
 vi.mock("openclaw/plugin-sdk/web-media", () => discordWebMediaMockFactory());
 
@@ -725,6 +729,26 @@ describe("sendMessageDiscord", () => {
     expect(loadWebMedia).toHaveBeenCalledWith("file:///tmp/photo.jpg", {
       maxBytes: 100 * 1024 * 1024,
     });
+  });
+
+  it("sends the detected JPEG media type across a real loopback multipart request", async () => {
+    const loopback = await createDiscordLoopbackRest();
+    try {
+      await sendMessageDiscord("channel:789", "photo", {
+        rest: loopback.rest,
+        token: "test-token",
+        cfg: DISCORD_TEST_CFG,
+        mediaUrl: "file:///tmp/photo.jpg",
+      });
+
+      const upload = loopback.requests.find((request) => request.method === "POST");
+      expect(upload?.path).toContain("/channels/789/messages");
+      expect(upload?.contentType).toMatch(/^multipart\/form-data; boundary=/);
+      expect(upload?.body).toContain('name="files[0]"; filename="photo.jpg"');
+      expect(upload?.body).toContain("Content-Type: image/jpeg");
+    } finally {
+      await loopback.close();
+    }
   });
 
   it("preserves text when Discord rejects an upload with error 40005", async () => {

--- a/extensions/discord/src/send.shared.ts
+++ b/extensions/discord/src/send.shared.ts
@@ -466,6 +466,7 @@ async function sendDiscordMedia(params: DiscordMediaSendParams) {
       {
         data: media.buffer,
         name: resolvedFileName,
+        contentType: media.contentType,
       },
     ],
   });

--- a/extensions/discord/src/send.test-harness.ts
+++ b/extensions/discord/src/send.test-harness.ts
@@ -1,6 +1,8 @@
 // Discord plugin module implements send harness behavior.
+import { createServer } from "node:http";
 import type { MockFn } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { vi } from "vitest";
+import { RequestClient } from "./internal/discord.js";
 
 type DiscordWebMediaMockFactoryResult = {
   loadWebMedia: MockFn;
@@ -15,6 +17,66 @@ type DiscordRestFactoryResult = {
   patchMock: MockFn;
   deleteMock: MockFn;
 };
+
+type DiscordLoopbackRequest = {
+  body: string;
+  contentType: string | undefined;
+  method: string | undefined;
+  path: string | undefined;
+};
+
+export async function createDiscordLoopbackRest(): Promise<{
+  rest: RequestClient;
+  requests: DiscordLoopbackRequest[];
+  close: () => Promise<void>;
+}> {
+  const requests: DiscordLoopbackRequest[] = [];
+  const server = createServer((request, response) => {
+    const chunks: Buffer[] = [];
+    request.on("data", (chunk: Buffer) => chunks.push(chunk));
+    request.on("error", (error) => response.destroy(error));
+    request.on("end", () => {
+      requests.push({
+        body: Buffer.concat(chunks).toString("utf8"),
+        contentType: request.headers["content-type"],
+        method: request.method,
+        path: request.url,
+      });
+      response.writeHead(200, { "Content-Type": "application/json" });
+      response.end(
+        JSON.stringify(
+          request.method === "GET"
+            ? { id: "789", type: 0 }
+            : { id: "loopback-message", channel_id: "789" },
+        ),
+      );
+    });
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.removeListener("error", reject);
+      resolve();
+    });
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    server.close();
+    throw new Error("Discord loopback server did not bind to a TCP port");
+  }
+  return {
+    rest: new RequestClient("test-token", {
+      baseUrl: `http://127.0.0.1:${address.port}`,
+      queueRequests: false,
+    }),
+    requests,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+        server.closeIdleConnections();
+      }),
+  };
+}
 
 export function discordWebMediaMockFactory(): DiscordWebMediaMockFactoryResult {
   return {


### PR DESCRIPTION
Closes #41256
Related: #41265

## What Problem This Solves

Discord's media loaders already detect attachment MIME types, but standard messages, component messages, and native interaction replies discarded that fact before multipart serialization. All three production paths therefore emitted `application/octet-stream` file parts for known JPEG, PDF, and WebP media.

## Why This Change Was Made

The repair moves MIME ownership to Discord's existing payload/REST boundary. `MessagePayloadFile` now carries optional `contentType`; all three producers pass their original raw buffer plus that detected type; and `internal/rest-body.ts` remains the single bytes-to-Blob/multipart writer. Native interactions use the same nested `data.files` serializer on current main, so their duplicate early Buffer-to-untyped-Blob conversion was deleted as well.

This applies the prior ClawSweeper payload-owner finding while improving on its native exception: Carbon is no longer in the runtime, and the repo-owned interaction client routes replies, edits, and follow-ups through the same serializer. Sticker uploads already use the same raw-buffer-plus-content-type pattern.

The stale PR's unrelated WebP optimizer tests were removed. Current main already preserves valid in-limit static and animated WebP bytes; that behavior did not need a second production path or another 86 lines of tests to repair this Discord multipart defect.

Production LOC: +7/-9 (net -2). Tests/harness: +169/-3.

## User Impact

Discord receives standard, component, and native-interaction attachments with their detected JPEG, PDF, WebP, or other MIME type instead of `application/octet-stream`, without copying allowed-size buffers before the canonical multipart boundary. Filenames and bytes remain unchanged.

## Evidence

- Before the production change: `node scripts/run-vitest.mjs extensions/discord/src/send.sends-basic-channel-messages.test.ts extensions/discord/src/send.components.test.ts extensions/discord/src/monitor/native-command-reply.test.ts` sent actual multipart HTTP over 127.0.0.1 and failed exactly 3 MIME assertions. The captured file parts were JPEG/PDF/WebP fixtures labeled `application/octet-stream`; 91 sibling tests passed.
- After the production change: the identical command passed 3 files / 94 tests. The captured on-wire file parts were `image/jpeg`, `application/pdf`, and `image/webp` for the standard, component, and interaction paths respectively.
- `node scripts/check-changed.mjs` passed on Blacksmith Testbox `tbx_01kzk3zn1tb7v4sm03rns7sh5j` (Actions run `31310505347`): formatting, extension production/test typechecks, lint, dead-code, dependency, Plugin SDK/boundary, database-first, media-helper, and import-cycle guards all passed.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted` completed clean in one Codex-backed round with no accepted/actionable findings.
- Official Discord multipart examples attach a per-file `Content-Type`; pinned undici emits `application/octet-stream` for an untyped Blob and the Blob's MIME type when present. The rewritten loopback proof exercises that exact wire contract.

Behavior-validator contract: each production Discord send surface must put the loader-detected MIME type on the actual multipart file part while preserving the filename and bytes. All three observable loopback HTTP tasks pass. This is real TCP runtime proof, not an authenticated Discord SaaS claim.

ClawSweeper rank-up moves: `contentType` is carried through `MessagePayloadFile`, raw buffers reach the canonical serializer, all three loopback paths were rerun, and the branch was rewritten from current main. The suggested native-only early Blob conversion was intentionally skipped because the current repo-owned interaction client serializes nested files through the same canonical writer; keeping that exception would preserve duplicate allocation/policy. A fresh review is requested because the durable review is older than 12 hours and reviewed the discarded head.

Credits: thanks to @skidder for #41256 and the original work in #41265, and to @jackal092927 and @zheliu2 for earlier focused implementations. All three remain commit co-authors.

AI-assisted: yes; current-main behavior, dependency contracts, owner boundaries, red/green wire output, and sibling surfaces were independently inspected.
