### PR TITLE
fix(agents): compact tool search drops arguments and bypasses validation

### DIFF
--- a/docs/tools/tool-search.md
+++ b/docs/tools/tool-search.md
@@ -166,9 +166,19 @@ const calendarCreate = await openclaw.tools.describe("mcp:calendar:create_event"
 
 Calls a selected tool through OpenClaw and returns the raw `{ tool, result }`
 envelope. JSON-returning tools normally place their value in
-`result.details`. If a trusted tool declares `outputSchema`, OpenClaw compiles
-the schema before execution and validates final `details` after normal tool
-hooks before returning the catalog call.
+`result.details`. OpenClaw validates a trusted core or plugin tool's declared
+input schema before execution. Missing required arguments, incorrect types,
+and forbidden properties return actionable tool errors instead of executing
+the tool; misspelled properties include a suggested parameter when available.
+If a trusted tool also declares `outputSchema`, OpenClaw compiles that schema
+before execution and validates final `details` after normal tool hooks before
+returning the catalog call. MCP and client-owned schemas remain deferred to
+their owning execution boundary.
+
+In structured mode, `tool_call` also repairs flattened target arguments from
+local models. It preserves target fields such as `id` and `name`, and rejects
+ambiguous tool selectors instead of calling the wrong tool. Nest target
+arguments under `args` when a target field matches another cataloged tool.
 
 ```js
 await openclaw.tools.call(calendarCreate.id, {

--- a/extensions/qa-lab/src/tool-search-gateway.fixture.test.ts
+++ b/extensions/qa-lab/src/tool-search-gateway.fixture.test.ts
@@ -293,6 +293,11 @@ describe("tool search gateway e2e lane result", () => {
       expect(result.providerInputSnippet).toBe(inputPrefix);
       expect(result.providerToolOutputSnippet).toBe(toolOutputPrefix);
       expect(fetchMock).toHaveBeenCalledTimes(3);
+      const laneConfig = JSON.parse(await fs.readFile(configPath, "utf8")) as {
+        memory?: { search?: Record<string, unknown> };
+      };
+      expect(laneConfig.memory?.search).toMatchObject({ enabled: false });
+      expect(laneConfig.memory?.search).not.toHaveProperty("sync");
     } finally {
       await fs.rm(tempRoot, { force: true, recursive: true });
     }

--- a/extensions/qa-lab/src/tool-search-gateway.fixture.ts
+++ b/extensions/qa-lab/src/tool-search-gateway.fixture.ts
@@ -263,12 +263,6 @@ function applyLaneConfig(
     search: {
       ...memorySearch,
       enabled: false,
-      sync: {
-        ...(memorySearch.sync && typeof memorySearch.sync === "object" ? memorySearch.sync : {}),
-        onSearch: false,
-        onSessionStart: false,
-        watch: false,
-      },
     },
   };
 

--- a/src/agents/agent-tools.before-tool-call.wrapper.ts
+++ b/src/agents/agent-tools.before-tool-call.wrapper.ts
@@ -43,6 +43,7 @@ import type {
   HookContext,
   HookOutcome,
 } from "./agent-tools.before-tool-call.types.js";
+import { validateToolExecutionParams } from "./agent-tools.execution-validation.js";
 import {
   BEFORE_TOOL_CALL_DIAGNOSTIC_OPTIONS,
   BEFORE_TOOL_CALL_HOOK_CONTEXT,
@@ -66,6 +67,7 @@ type BeforeToolCallWrapperOptions = {
   approvalMode?: "request" | "report" | "deny";
   emitDiagnostics: boolean;
 };
+type ForwardedToolExecution = (...args: unknown[]) => ReturnType<AnyAgentTool["execute"]>;
 const MAX_TRACKED_ADJUSTED_PARAMS = 1024;
 
 /** Run tool-owned preparation while retaining the exact prepared object. */
@@ -276,7 +278,7 @@ export function wrapToolWithBeforeToolCallHook(
   const toolContentPolicy = resolveDiagnosticModelContentCapturePolicy(ctx?.config);
   const wrappedTool: AnyAgentTool = {
     ...tool,
-    execute: async (toolCallId, params, signal, onUpdate) => {
+    execute: async (toolCallId, params, signal, onUpdate, ...executionArgs: unknown[]) => {
       const toolCallOrdinal = ctx?.allocateToolOutcomeOrdinal?.(toolCallId);
       const preExecutionStartedAt = Date.now();
       const normalizedToolName = normalizeToolName(toolName || "tool");
@@ -425,6 +427,9 @@ export function wrapToolWithBeforeToolCallHook(
           adjustedParams: outcome.params,
           finalizerMode: "wrapped",
         });
+        // Hooks can repair or rewrite arguments; only the final execution
+        // shape is safe to validate, after vetoes but before side effects.
+        await validateToolExecutionParams(toolCallId, executeParams);
       } catch (error) {
         recordPreExecutionError(error, outcome.params ?? hookParams, "tool_preparation");
         throw tagBeforeToolCallFailure(error, signal);
@@ -440,7 +445,13 @@ export function wrapToolWithBeforeToolCallHook(
       }
       const startedAt = Date.now();
       try {
-        const result = await execute(toolCallId, executeParams, signal, onUpdate);
+        const result = await (execute as ForwardedToolExecution)(
+          toolCallId,
+          executeParams,
+          signal,
+          onUpdate,
+          ...executionArgs,
+        );
         const durationMs = Date.now() - startedAt;
         const terminalPresentation = resolveToolTerminalPresentation({
           tool,
@@ -519,10 +530,22 @@ export function wrapToolWithBeforeToolCallHook(
     },
   };
   const executeWithHooks = wrappedTool.execute;
-  wrappedTool.execute = async (toolCallId, params, signal, onUpdate) => {
+  wrappedTool.execute = async (
+    toolCallId,
+    params,
+    signal,
+    onUpdate,
+    ...executionArgs: unknown[]
+  ) => {
     recordToolExecutionTracked(toolCallId, ctx?.runId);
     try {
-      return await executeWithHooks(toolCallId, params, signal, onUpdate);
+      return await (executeWithHooks as ForwardedToolExecution)(
+        toolCallId,
+        params,
+        signal,
+        onUpdate,
+        ...executionArgs,
+      );
     } finally {
       // Timeout observers may consume this while the call is still pending. The
       // wrapper owns final cleanup; every pre-body settle records the separate

--- a/src/agents/agent-tools.execution-validation.ts
+++ b/src/agents/agent-tools.execution-validation.ts
@@ -1,0 +1,29 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+type ToolExecutionValidator = (params: unknown) => void | Promise<void>;
+type ScopedToolExecutionValidator = {
+  toolCallId: string;
+  validate: ToolExecutionValidator;
+};
+
+const executionValidators = new AsyncLocalStorage<ScopedToolExecutionValidator>();
+
+/** Keep per-call validation inside the policy wrapper's final execution boundary. */
+export async function runWithToolExecutionValidation<T>(
+  toolCallId: string,
+  validator: ToolExecutionValidator,
+  execute: () => Promise<T>,
+): Promise<T> {
+  return await executionValidators.run({ toolCallId, validate: validator }, execute);
+}
+
+/** Validate hook-adjusted arguments without leaking a validator into concurrent calls. */
+export async function validateToolExecutionParams(
+  toolCallId: string,
+  params: unknown,
+): Promise<void> {
+  const scopedValidator = executionValidators.getStore();
+  if (scopedValidator?.toolCallId === toolCallId) {
+    await scopedValidator.validate(params);
+  }
+}

--- a/src/agents/tool-search-code-mode.ts
+++ b/src/agents/tool-search-code-mode.ts
@@ -24,7 +24,7 @@ export async function runCodeMode(params: {
   signal?: AbortSignal;
   onUpdate?: AgentToolUpdateCallback;
 }) {
-  const runtime = new ToolSearchRuntime(params.ctx, params.config);
+  const runtime = new ToolSearchRuntime(params.ctx, params.config, { validateInput: true });
   const logs: string[] = [];
   const value = await runCodeModeChild({
     code: params.code,

--- a/src/agents/tool-search-runtime.test.ts
+++ b/src/agents/tool-search-runtime.test.ts
@@ -1,0 +1,555 @@
+import { Type } from "typebox";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  initializeGlobalHookRunner,
+  resetGlobalHookRunner,
+} from "../plugins/hook-runner-global.js";
+import { createMockPluginRegistry } from "../plugins/hooks.test-fixtures.js";
+import { wrapToolWithBeforeToolCallHook } from "./agent-tools.before-tool-call.js";
+import { readToolSearchCallArgs } from "./tool-search-runtime.js";
+import type { ToolSearchCatalogEntry } from "./tool-search-types.js";
+import {
+  createToolSearchCatalogRef,
+  createToolSearchTools,
+  registerHeadlessToolSearchCatalog,
+  resolveToolSearchConfig,
+  TOOL_CALL_RAW_TOOL_NAME,
+  TOOL_SEARCH_CODE_MODE_TOOL_NAME,
+  ToolSearchRuntime,
+} from "./tool-search.js";
+import { jsonResult, type AnyAgentTool } from "./tools/common.js";
+
+afterEach(() => {
+  resetGlobalHookRunner();
+});
+
+function fakeTool(name: string, parameters = Type.Object({})): AnyAgentTool {
+  return {
+    name,
+    label: name,
+    description: `Run ${name}`,
+    parameters,
+    execute: vi.fn(async (_toolCallId, input) => jsonResult({ input })),
+  };
+}
+
+function createRuntime(tools: AnyAgentTool[]) {
+  const catalogRef = createToolSearchCatalogRef();
+  registerHeadlessToolSearchCatalog({ catalogRef, tools });
+  const config = { tools: { toolSearch: { enabled: true, mode: "tools" } } } as never;
+  return {
+    catalogRef,
+    config,
+    runtime: new ToolSearchRuntime({ catalogRef }, resolveToolSearchConfig(config), {
+      validateInput: true,
+    }),
+  };
+}
+
+describe("Tool Search flattened call arguments", () => {
+  it.each([
+    {
+      label: "canonical id",
+      arguments: { id: "inspect_resource", command: "list", timeout_ms: 5_000 },
+      expected: { command: "list", timeout_ms: 5_000 },
+    },
+    {
+      label: "toolId selector with a target id",
+      arguments: { toolId: "inspect_resource", id: "record-7" },
+      expected: { id: "record-7" },
+    },
+    {
+      label: "canonical id with a target name",
+      arguments: { id: "inspect_resource", name: "record-name" },
+      expected: { name: "record-name" },
+    },
+    {
+      label: "name selector with a target id",
+      arguments: { name: "inspect_resource", id: "record-7" },
+      expected: { id: "record-7" },
+    },
+    {
+      label: "explicit args precedence",
+      arguments: {
+        id: "inspect_resource",
+        args: { command: "nested" },
+        command: "flattened",
+      },
+      expected: { command: "nested" },
+    },
+    {
+      label: "explicit input precedence",
+      arguments: {
+        id: "inspect_resource",
+        input: { command: "nested" },
+        command: "flattened",
+      },
+      expected: { command: "nested" },
+    },
+    {
+      label: "null wrapper arguments",
+      arguments: { id: "inspect_resource", args: null, input: null, command: "flattened" },
+      expected: { command: "flattened" },
+    },
+    {
+      label: "bare selector",
+      arguments: { id: "inspect_resource" },
+      expected: {},
+    },
+    {
+      label: "redundant matching selectors",
+      arguments: { id: "inspect_resource", toolId: "inspect_resource", name: "inspect_resource" },
+      expected: {},
+    },
+  ])("preserves target arguments for $label", ({ arguments: args, expected }) => {
+    const { catalogRef } = createRuntime([fakeTool("inspect_resource")]);
+
+    expect(readToolSearchCallArgs(args, catalogRef.current)).toEqual({
+      id: "inspect_resource",
+      input: expected,
+    });
+  });
+
+  it.each([
+    {
+      label: "toolId selector with a required target id",
+      arguments: { toolId: "inspect_resource", id: "record-7" },
+      parameters: Type.Object({ id: Type.String() }, { additionalProperties: false }),
+      expected: { id: "record-7" },
+    },
+    {
+      label: "id selector with a required target name",
+      arguments: { id: "inspect_resource", name: "record-name" },
+      parameters: Type.Object({ name: Type.String() }, { additionalProperties: false }),
+      expected: { name: "record-name" },
+    },
+    {
+      label: "name selector with a required target id",
+      arguments: { name: "inspect_resource", id: "record-7" },
+      parameters: Type.Object({ id: Type.String() }, { additionalProperties: false }),
+      expected: { id: "record-7" },
+    },
+    {
+      label: "redundant selectors for a strict no-argument tool",
+      arguments: { id: "inspect_resource", toolId: "inspect_resource", name: "inspect_resource" },
+      parameters: Type.Object({}, { additionalProperties: false }),
+      expected: {},
+    },
+  ])(
+    "dispatches $label through the real structured tool",
+    async ({ arguments: args, parameters, expected }) => {
+      const target = fakeTool("inspect_resource", parameters);
+      const { catalogRef, config } = createRuntime([target]);
+      const callTool = createToolSearchTools({ catalogRef, config }).find(
+        (tool) => tool.name === TOOL_CALL_RAW_TOOL_NAME,
+      );
+
+      expect(callTool).toBeDefined();
+      await callTool!.execute("structured-call", args);
+
+      expect(target.execute).toHaveBeenCalledOnce();
+      expect(vi.mocked(target.execute).mock.calls[0]?.[1]).toEqual(expected);
+    },
+  );
+
+  it("rejects flattened selectors that identify different catalog tools", async () => {
+    const intended = fakeTool("inspect_resource");
+    const colliding = fakeTool("search");
+    const { catalogRef, config } = createRuntime([intended, colliding]);
+    const callTool = createToolSearchTools({ catalogRef, config }).find(
+      (tool) => tool.name === TOOL_CALL_RAW_TOOL_NAME,
+    );
+
+    expect(callTool).toBeDefined();
+    await expect(
+      callTool!.execute("ambiguous-call", { name: "inspect_resource", id: "search" }),
+    ).rejects.toThrow("Ambiguous tool selectors");
+    expect(intended.execute).not.toHaveBeenCalled();
+    expect(colliding.execute).not.toHaveBeenCalled();
+  });
+
+  it("rejects a single selector shared by multiple catalog tools", async () => {
+    const first = fakeTool("shared_search");
+    const second = fakeTool("shared_search");
+    const { catalogRef, config } = createRuntime([first]);
+    const baseEntry = catalogRef.current?.entries[0];
+    expect(baseEntry).toBeDefined();
+    catalogRef.current!.entries = [
+      { ...baseEntry!, id: "openclaw:first:shared_search", tool: first },
+      { ...baseEntry!, id: "openclaw:second:shared_search", tool: second },
+    ];
+    const callTool = createToolSearchTools({ catalogRef, config }).find(
+      (tool) => tool.name === TOOL_CALL_RAW_TOOL_NAME,
+    );
+
+    expect(callTool).toBeDefined();
+    await expect(
+      callTool!.execute("duplicate-name-call", { name: "shared_search" }),
+    ).rejects.toThrow("Ambiguous tool selectors");
+    expect(first.execute).not.toHaveBeenCalled();
+    expect(second.execute).not.toHaveBeenCalled();
+  });
+
+  it("keeps explicit nested arguments ahead of flattened selector aliases", async () => {
+    const intended = fakeTool(
+      "inspect_resource",
+      Type.Object({ instruction: Type.String() }, { additionalProperties: false }),
+    );
+    const colliding = fakeTool("search");
+    const { catalogRef, config } = createRuntime([intended, colliding]);
+    const callTool = createToolSearchTools({ catalogRef, config }).find(
+      (tool) => tool.name === TOOL_CALL_RAW_TOOL_NAME,
+    );
+
+    expect(callTool).toBeDefined();
+    await callTool!.execute("nested-call", {
+      id: "inspect_resource",
+      name: "search",
+      args: { instruction: "run" },
+    });
+
+    expect(intended.execute).toHaveBeenCalledOnce();
+    expect(vi.mocked(intended.execute).mock.calls[0]?.[1]).toEqual({ instruction: "run" });
+    expect(colliding.execute).not.toHaveBeenCalled();
+  });
+});
+
+describe("Tool Search input schemas", () => {
+  it("validates arguments after a policy hook repairs them", async () => {
+    const hook = vi.fn(async () => ({ params: { instruction: "repaired" } }));
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([{ hookName: "before_tool_call", handler: hook }]),
+    );
+    const target = fakeTool(
+      "strict_instruction",
+      Type.Object({ instruction: Type.String() }, { additionalProperties: false }),
+    );
+    const { runtime } = createRuntime([target]);
+
+    await expect(runtime.call("strict_instruction", {})).resolves.toMatchObject({
+      result: { details: { input: { instruction: "repaired" } } },
+    });
+    expect(hook).toHaveBeenCalledOnce();
+    expect(target.execute).toHaveBeenCalledOnce();
+    expect(vi.mocked(target.execute).mock.calls[0]?.[1]).toEqual({ instruction: "repaired" });
+  });
+
+  it("rejects invalid hook-adjusted arguments before target execution", async () => {
+    const hook = vi.fn(async () => ({ params: { instruction: 42 } }));
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([{ hookName: "before_tool_call", handler: hook }]),
+    );
+    const target = fakeTool(
+      "strict_instruction",
+      Type.Object({ instruction: Type.String() }, { additionalProperties: false }),
+    );
+    const { runtime } = createRuntime([target]);
+
+    await expect(runtime.call("strict_instruction", { instruction: "valid" })).rejects.toThrow(
+      "instruction",
+    );
+    expect(hook).toHaveBeenCalledOnce();
+    expect(target.execute).not.toHaveBeenCalled();
+  });
+
+  it("lets policy hooks block invalid arguments before schema validation", async () => {
+    const hook = vi.fn(async () => ({ block: true, blockReason: "blocked by policy" }));
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([{ hookName: "before_tool_call", handler: hook }]),
+    );
+    const target = fakeTool(
+      "strict_instruction",
+      Type.Object({ instruction: Type.String() }, { additionalProperties: false }),
+    );
+    const { runtime } = createRuntime([target]);
+
+    await expect(runtime.call("strict_instruction", {})).resolves.toMatchObject({
+      result: { details: { status: "blocked", reason: "blocked by policy" } },
+    });
+    expect(hook).toHaveBeenCalledOnce();
+    expect(target.execute).not.toHaveBeenCalled();
+  });
+
+  it("does not apply a parent tool's schema to nested wrapped tool calls", async () => {
+    const nested = fakeTool(
+      "nested_instruction",
+      Type.Object({ marker: Type.String() }, { additionalProperties: false }),
+    );
+    const wrappedNested = wrapToolWithBeforeToolCallHook(nested);
+    const target = fakeTool(
+      "strict_instruction",
+      Type.Object({ instruction: Type.String() }, { additionalProperties: false }),
+    );
+    target.execute = vi.fn(async () =>
+      wrappedNested.execute("nested-policy-call", { marker: "nested" }),
+    );
+    const { runtime } = createRuntime([target]);
+
+    await expect(runtime.call("strict_instruction", { instruction: "run" })).resolves.toMatchObject(
+      {
+        result: { details: { input: { marker: "nested" } } },
+      },
+    );
+    expect(target.execute).toHaveBeenCalledOnce();
+    expect(nested.execute).toHaveBeenCalledOnce();
+    expect(vi.mocked(nested.execute).mock.calls[0]?.[1]).toEqual({ marker: "nested" });
+  });
+
+  it.each([
+    {
+      label: "missing required argument",
+      input: {},
+      expected: "instruction",
+    },
+    {
+      label: "wrong argument type",
+      input: { instruction: 42 },
+      expected: "instruction",
+    },
+    {
+      label: "unexpected argument",
+      input: { instruction: "run", unexpected: true },
+      expected: "unexpected",
+    },
+  ])("rejects a trusted tool's $label before execution", async ({ input, expected }) => {
+    const target = fakeTool(
+      "strict_instruction",
+      Type.Object({ instruction: Type.String() }, { additionalProperties: false }),
+    );
+    const { runtime } = createRuntime([target]);
+
+    await expect(runtime.call("strict_instruction", input)).rejects.toThrow(expected);
+    expect(target.execute).not.toHaveBeenCalled();
+  });
+
+  it("suggests a near-miss parameter without executing the tool", async () => {
+    const target = fakeTool(
+      "strict_instruction",
+      Type.Object({ instruction: Type.String() }, { additionalProperties: false }),
+    );
+    const { runtime } = createRuntime([target]);
+
+    await expect(runtime.call("strict_instruction", { instructions: "run" })).rejects.toThrow(
+      "Did you mean: instruction?",
+    );
+    expect(target.execute).not.toHaveBeenCalled();
+  });
+
+  it("fails before side effects when a trusted input schema is invalid", async () => {
+    const target = fakeTool("invalid_input", { type: "sting" } as never);
+    const { runtime } = createRuntime([target]);
+
+    await expect(runtime.call("invalid_input", {})).rejects.toThrow("invalid inputSchema");
+    expect(target.execute).not.toHaveBeenCalled();
+  });
+
+  it("does not reuse another catalog's validator for the same tool id", async () => {
+    const first = fakeTool(
+      "shared_instruction",
+      Type.Object({ before: Type.String() }, { additionalProperties: false }),
+    );
+    const second = fakeTool(
+      "shared_instruction",
+      Type.Object({ after: Type.String() }, { additionalProperties: false }),
+    );
+    const firstRuntime = createRuntime([first]).runtime;
+    const secondRuntime = createRuntime([second]).runtime;
+
+    await expect(firstRuntime.call("shared_instruction", { before: "run" })).resolves.toBeDefined();
+    await expect(secondRuntime.call("shared_instruction", { after: "run" })).resolves.toBeDefined();
+    await expect(secondRuntime.call("shared_instruction", { before: "run" })).rejects.toThrow(
+      "after",
+    );
+    expect(first.execute).toHaveBeenCalledOnce();
+    expect(second.execute).toHaveBeenCalledOnce();
+  });
+
+  it("recompiles a trusted schema after its constraints change in place", async () => {
+    const parameters = {
+      type: "object",
+      properties: { before: { type: "string" } } as Record<string, { type: string }>,
+      required: ["before"],
+      additionalProperties: false,
+    };
+    const target = fakeTool("mutable_instruction", parameters as never);
+    const { runtime } = createRuntime([target]);
+
+    await expect(runtime.call("mutable_instruction", { before: "run" })).resolves.toBeDefined();
+    parameters.properties = { after: { type: "string" } };
+    parameters.required = ["after"];
+
+    await expect(runtime.call("mutable_instruction", { after: "run" })).resolves.toBeDefined();
+    await expect(runtime.call("mutable_instruction", { before: "run" })).rejects.toThrow("after");
+    expect(target.execute).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns invalid arguments to isolated Tool Search code without executing them", async () => {
+    const target = fakeTool(
+      "strict_instruction",
+      Type.Object({ instruction: Type.String() }, { additionalProperties: false }),
+    );
+    const { catalogRef, config } = createRuntime([target]);
+    const codeTool = createToolSearchTools({ catalogRef, config }).find(
+      (tool) => tool.name === TOOL_SEARCH_CODE_MODE_TOOL_NAME,
+    );
+
+    expect(codeTool).toBeDefined();
+    const result = await codeTool!.execute("invalid-code-call", {
+      code: `
+        try {
+          await openclaw.tools.call("strict_instruction", { instructions: "run" });
+          return { executed: true };
+        } catch (error) {
+          return { error: error.message };
+        }
+      `,
+    });
+
+    expect(result.details).toMatchObject({
+      ok: true,
+      value: { error: expect.stringContaining("Did you mean: instruction?") },
+    });
+    expect(target.execute).not.toHaveBeenCalled();
+  });
+
+  it.each(["mcp", "client"] as const)(
+    "does not traverse an untrusted %s schema during dispatch",
+    async (source) => {
+      const target = fakeTool("external_instruction");
+      const hostileSchema = new Proxy(
+        {},
+        {
+          get: () => {
+            throw new Error("untrusted tool schema must remain deferred");
+          },
+          ownKeys: () => {
+            throw new Error("untrusted tool schema must remain deferred");
+          },
+        },
+      );
+      const entry: ToolSearchCatalogEntry = {
+        id: `${source}:external:external_instruction`,
+        source,
+        sourceName: "external",
+        name: target.name,
+        description: target.description,
+        parameters: hostileSchema,
+        tool: target,
+      };
+      const catalogRef = createToolSearchCatalogRef();
+      catalogRef.current = {
+        entries: [entry],
+        searchCount: 0,
+        describeCount: 0,
+        callCount: 0,
+      };
+      const runtime = new ToolSearchRuntime(
+        { catalogRef },
+        resolveToolSearchConfig({ tools: { toolSearch: { mode: "tools" } } } as never),
+        { validateInput: true },
+      );
+
+      await expect(runtime.call(target.name, { unexpected: true })).resolves.toMatchObject({
+        result: { details: { input: { unexpected: true } } },
+      });
+      expect(target.execute).toHaveBeenCalledOnce();
+    },
+  );
+});
+
+describe("Tool Search catalog indexing", () => {
+  it("keeps other ranked results when an exact match allows multiple hits", async () => {
+    const { runtime } = createRuntime([fakeTool("orchard"), fakeTool("orchard_records")]);
+
+    await expect(runtime.search("orchard", { limit: 2 })).resolves.toEqual([
+      expect.objectContaining({ name: "orchard" }),
+      expect.objectContaining({ name: "orchard_records" }),
+    ]);
+  });
+
+  it("does not traverse a large catalog's schemas during repeated exact searches", async () => {
+    const readSchemaDescription = vi.fn((index: number) => `Search record ${index}`);
+    const tools = Array.from({ length: 512 }, (_, index) =>
+      fakeTool(`stress_tool_${String(index).padStart(3, "0")}`, {
+        type: "object",
+        get description() {
+          return readSchemaDescription(index);
+        },
+        properties: {},
+      } as never),
+    );
+    const { runtime } = createRuntime(tools);
+    readSchemaDescription.mockClear();
+
+    for (let index = 0; index < 64; index += 1) {
+      const name = `stress_tool_${String(index).padStart(3, "0")}`;
+      await expect(runtime.search(name, { limit: 1 })).resolves.toEqual([
+        expect.objectContaining({ name }),
+      ]);
+    }
+
+    expect(readSchemaDescription).not.toHaveBeenCalled();
+  });
+
+  it("rebuilds the search index when the session catalog is replaced", async () => {
+    const first = fakeTool("orchard_alpha");
+    const second = fakeTool("meteor_beta");
+    const { catalogRef, runtime } = createRuntime([first]);
+
+    await expect(runtime.search("orchard_alpha")).resolves.toEqual([
+      expect.objectContaining({ name: "orchard_alpha" }),
+    ]);
+    registerHeadlessToolSearchCatalog({ catalogRef, tools: [second] });
+
+    await expect(runtime.search("meteor_beta")).resolves.toEqual([
+      expect.objectContaining({ name: "meteor_beta" }),
+    ]);
+    await expect(runtime.search("orchard_alpha")).resolves.toEqual([]);
+  });
+
+  it("rebuilds the search index when tools are appended to the same catalog", async () => {
+    const { catalogRef, runtime } = createRuntime([fakeTool("orchard_alpha")]);
+    const added = createRuntime([fakeTool("meteor_beta")]);
+    const addedEntry = added.catalogRef.current?.entries[0];
+
+    expect(addedEntry).toBeDefined();
+    await expect(runtime.search("meteor_beta")).resolves.toEqual([]);
+    catalogRef.current!.entries.push(addedEntry!);
+
+    await expect(runtime.search("meteor_beta")).resolves.toEqual([
+      expect.objectContaining({ name: "meteor_beta" }),
+    ]);
+  });
+
+  it("rebuilds the search index when indexed metadata changes in place", async () => {
+    const { catalogRef, runtime } = createRuntime([fakeTool("orchard_alpha")]);
+    const entry = catalogRef.current?.entries[0];
+
+    expect(entry).toBeDefined();
+    await expect(runtime.search("meteor")).resolves.toEqual([]);
+    entry!.description = "Track the current meteor forecast";
+
+    await expect(runtime.search("meteor")).resolves.toEqual([
+      expect.objectContaining({ name: "orchard_alpha" }),
+    ]);
+  });
+
+  it("rebuilds the search index when a parameter description changes in place", async () => {
+    const parameters = {
+      type: "object",
+      description: "Search an orchard",
+      properties: {},
+    };
+    const { runtime } = createRuntime([fakeTool("indexed_resource", parameters as never)]);
+
+    await expect(runtime.search("orchard")).resolves.toEqual([
+      expect.objectContaining({ name: "indexed_resource" }),
+    ]);
+    parameters.description = "Search a meteor";
+
+    await expect(runtime.search("meteor")).resolves.toEqual([
+      expect.objectContaining({ name: "indexed_resource" }),
+    ]);
+    await expect(runtime.search("orchard")).resolves.toEqual([]);
+  });
+});

--- a/src/agents/tool-search-runtime.ts
+++ b/src/agents/tool-search-runtime.ts
@@ -4,7 +4,13 @@ import {
   uniqueStrings,
 } from "@openclaw/normalization-core/string-normalization";
 import { getPluginToolMeta } from "../plugins/tools.js";
-import { isPreExecutionBlockedToolResult } from "./agent-tools.before-tool-call.js";
+import { levenshteinDistance } from "../shared/levenshtein-distance.js";
+import {
+  isPreExecutionBlockedToolResult,
+  isToolWrappedWithBeforeToolCallHook,
+  wrapToolWithBeforeToolCallHook,
+} from "./agent-tools.before-tool-call.js";
+import { runWithToolExecutionValidation } from "./agent-tools.execution-validation.js";
 import { getChannelAgentToolMeta } from "./channel-tool-metadata.js";
 import type { AgentToolResult } from "./runtime/index.js";
 import { isAgentToolReplaySafe } from "./tool-replay-safety.js";
@@ -49,12 +55,13 @@ function describeEntry(entry: ToolSearchCatalogEntry) {
  * "Send a message" through its `channel` parameter. Codex and the Claude API
  * tool-search tools index argument metadata for the same reason.
  */
-function toolSearchEntryText(entry: ToolSearchCatalogEntry): string {
+function toolSearchEntryText(entry: ToolSearchCatalogEntry, parameterText?: string): string {
   // Only first-party schemas are walked. MCP and client parameters are untrusted
   // and deliberately never traversed: compactToolSearchCatalogEntry reports them
   // as "unknown" for the same reason, and a client may hand us a lazy object that
   // throws on property access.
-  const parameters = entry.source === "openclaw" ? readParameterText(entry.parameters) : "";
+  const parameters =
+    parameterText ?? (entry.source === "openclaw" ? readParameterText(entry.parameters) : "");
   return [entry.name, entry.id, entry.label ?? "", entry.description, parameters]
     .filter(Boolean)
     .join(" ");
@@ -220,12 +227,53 @@ export function readToolSearchArgs(
   };
 }
 
-export function readToolSearchCallArgs(args: unknown): { id: string; input: unknown } {
+export function readToolSearchCallArgs(
+  args: unknown,
+  catalog?: ToolSearchCatalogSession,
+): { id: string; input: unknown } {
   const params = asToolParamsRecord(args);
-  return {
-    id: readToolSearchId(params),
-    input: params.args ?? params.input ?? {},
-  };
+  const nestedInput = params.args ?? params.input;
+  if (nestedInput != null) {
+    return { id: readToolSearchId(params), input: nestedInput };
+  }
+
+  const selectorKeys = ["id", "toolId", "name"] as const;
+  const matchingSelectors = catalog
+    ? selectorKeys.flatMap((key) => {
+        const value = params[key];
+        if (typeof value !== "string") {
+          return [];
+        }
+        const matches = catalog.entries.filter(
+          (entry) => entry.id === value || entry.name === value,
+        );
+        return matches.length > 0 ? [{ key, matches }] : [];
+      })
+    : [];
+  const matchedToolIds = new Set(
+    matchingSelectors.flatMap(({ matches }) => matches.map((entry) => entry.id)),
+  );
+  if (matchedToolIds.size > 1) {
+    throw new ToolInputError(
+      "Ambiguous tool selectors: pass the target tool id and nest target arguments under args.",
+    );
+  }
+  const matchingSelector = matchingSelectors[0]?.key;
+  const selector = matchingSelector ?? selectorKeys.find((key) => params[key] != null);
+  const id = readToolSearchId(selector ? { [selector]: params[selector] } : params);
+
+  // Remove every alias that actually identifies the selected catalog tool;
+  // unmatched id/name fields can still be required arguments of that tool.
+  const wrapperKeys = new Set<string>([
+    "args",
+    "input",
+    ...matchingSelectors.map(({ key }) => key),
+    ...(matchingSelector ? [] : [selector ?? "id"]),
+  ]);
+  const flattenedInput = Object.fromEntries(
+    Object.entries(params).filter(([key]) => !wrapperKeys.has(key)),
+  );
+  return { id, input: flattenedInput };
 }
 
 function getTelemetry(catalog: ToolSearchCatalogSession) {
@@ -242,35 +290,136 @@ function getTelemetry(catalog: ToolSearchCatalogSession) {
   };
 }
 
+type CatalogSchemaName = "inputSchema" | "outputSchema";
+type CatalogSchemaValidation = ReturnType<
+  typeof import("../plugins/schema-validator.js").validateJsonSchemaValue
+>;
+type CachedToolSearchIndex = {
+  entries: Array<
+    Pick<
+      ToolSearchCatalogEntry,
+      "id" | "source" | "name" | "label" | "description" | "parameters"
+    > & {
+      entry: ToolSearchCatalogEntry;
+      parameterText: string;
+    }
+  >;
+  index: ReturnType<typeof buildLexicalIndex<ToolSearchCatalogEntry>>;
+};
+
+function matchesCachedToolSearchIndex(
+  cached: CachedToolSearchIndex,
+  entries: readonly ToolSearchCatalogEntry[],
+): boolean {
+  return (
+    cached.entries.length === entries.length &&
+    entries.every((entry, index) => {
+      const snapshot = cached.entries[index];
+      return (
+        snapshot?.entry === entry &&
+        snapshot.id === entry.id &&
+        snapshot.source === entry.source &&
+        snapshot.name === entry.name &&
+        snapshot.label === entry.label &&
+        snapshot.description === entry.description &&
+        snapshot.parameters === entry.parameters &&
+        snapshot.parameterText ===
+          (entry.source === "openclaw" ? readParameterText(entry.parameters) : "")
+      );
+    })
+  );
+}
+
 let schemaValidatorModulePromise:
   | Promise<typeof import("../plugins/schema-validator.js")>
   | undefined;
+const catalogSchemaCacheIds = new WeakMap<object, number>();
+let nextCatalogSchemaCacheId = 0;
 
-async function validateCatalogOutputValue(
+function getCatalogSchemaCacheKey(
   entry: ToolSearchCatalogEntry,
+  schemaName: CatalogSchemaName,
+  schema: unknown,
+): string {
+  const prefix = `tool-${schemaName === "inputSchema" ? "input" : "output"}:${entry.id}`;
+  if (typeof schema !== "object" || schema === null) {
+    return `${prefix}:${String(schema)}`;
+  }
+  let schemaCacheId = catalogSchemaCacheIds.get(schema);
+  if (schemaCacheId === undefined) {
+    schemaCacheId = nextCatalogSchemaCacheId++;
+    catalogSchemaCacheIds.set(schema, schemaCacheId);
+  }
+  // Trusted schemas can be edited in place, so object identity alone cannot
+  // safely reuse a compiled validator after its constraints have changed.
+  return `${prefix}:${schemaCacheId}:${JSON.stringify(schema)}`;
+}
+
+async function validateCatalogSchemaValue(
+  entry: ToolSearchCatalogEntry,
+  schemaName: CatalogSchemaName,
   value: unknown,
-): Promise<
-  ReturnType<typeof import("../plugins/schema-validator.js").validateJsonSchemaValue> | undefined
-> {
-  if (!entry.outputSchema) {
+): Promise<CatalogSchemaValidation | undefined> {
+  const schema = schemaName === "inputSchema" ? entry.parameters : entry.outputSchema;
+  if (entry.source !== "openclaw" || !schema) {
     return undefined;
   }
   try {
     schemaValidatorModulePromise ??= import("../plugins/schema-validator.js");
     const { validateJsonSchemaValue } = await schemaValidatorModulePromise;
     return validateJsonSchemaValue({
-      schema: entry.outputSchema as never,
-      cacheKey: `tool-output:${entry.id}`,
+      schema: schema as never,
+      cacheKey: getCatalogSchemaCacheKey(entry, schemaName, schema),
       value,
     });
   } catch (error) {
-    throw new Error(`Tool "${entry.id}" has an invalid outputSchema.`, { cause: error });
+    throw new Error(`Tool "${entry.id}" has an invalid ${schemaName}.`, { cause: error });
+  }
+}
+
+function formatCatalogInputError(
+  entry: ToolSearchCatalogEntry,
+  errors: import("../plugins/schema-validator.js").JsonSchemaValidationError[],
+  value: unknown,
+): string {
+  const schema = isRecord(entry.parameters) ? entry.parameters : undefined;
+  const propertyNames = isRecord(schema?.properties) ? Object.keys(schema.properties) : [];
+  const knownProperties = new Set(propertyNames);
+  const unexpectedProperties =
+    schema?.additionalProperties === false && isRecord(value)
+      ? Object.keys(value).filter((name) => !knownProperties.has(name))
+      : errors.flatMap((error) => (error.additionalProperty ? [error.additionalProperty] : []));
+  const suggestions = uniqueStrings(
+    unexpectedProperties.flatMap((unexpected) => {
+      const nearest = propertyNames
+        .map((name) => ({ name, distance: levenshteinDistance(unexpected, name) }))
+        .filter(
+          ({ distance }) => distance <= Math.min(3, Math.max(1, Math.ceil(unexpected.length / 3))),
+        )
+        .toSorted(
+          (left, right) => left.distance - right.distance || left.name.localeCompare(right.name),
+        )[0];
+      return nearest ? [nearest.name] : [];
+    }),
+  ).slice(0, 3);
+  const details = errors.map((error) => error.text).join("; ");
+  const hint = suggestions.length > 0 ? ` Did you mean: ${suggestions.join(", ")}?` : "";
+  return `Invalid arguments for tool "${entry.id}": ${details}.${hint}`;
+}
+
+async function assertCatalogInputMatchesSchema(
+  entry: ToolSearchCatalogEntry,
+  value: unknown,
+): Promise<void> {
+  const validation = await validateCatalogSchemaValue(entry, "inputSchema", value);
+  if (validation && !validation.ok) {
+    throw new ToolInputError(formatCatalogInputError(entry, validation.errors, value));
   }
 }
 
 async function assertCatalogOutputSchemaIsValid(entry: ToolSearchCatalogEntry): Promise<void> {
   // Compile before execution so a bad contract cannot follow a successful side effect.
-  await validateCatalogOutputValue(entry, undefined);
+  await validateCatalogSchemaValue(entry, "outputSchema", undefined);
 }
 
 async function assertCatalogOutputMatchesSchema(
@@ -288,7 +437,11 @@ async function assertCatalogOutputMatchesSchema(
         : "Tool call blocked by policy";
     throw new Error(`Tool "${entry.id}" was blocked before execution: ${reason}`);
   }
-  const validation = await validateCatalogOutputValue(entry, unwrapToolResultValue(result));
+  const validation = await validateCatalogSchemaValue(
+    entry,
+    "outputSchema",
+    unwrapToolResultValue(result),
+  );
   if (!validation || validation.ok) {
     return;
   }
@@ -305,10 +458,15 @@ function sanitizeToolCallIdPart(value: string): string {
 
 export class ToolSearchRuntime {
   private callSequence = 0;
+  private readonly searchIndexes = new WeakMap<
+    ToolSearchCatalogSession,
+    Map<boolean, CachedToolSearchIndex>
+  >();
 
   constructor(
     private readonly ctx: ToolSearchToolContext,
     private readonly config: ToolSearchConfig,
+    private readonly options: { validateInput?: boolean } = {},
   ) {}
 
   search = async (query: string, options?: { limit?: number } & CatalogVisibilityOptions) => {
@@ -320,15 +478,43 @@ export class ToolSearchRuntime {
     // a description of one. BM25 alone can rank a shorter entry that merely
     // mentions the word above it, and the limit then drops the tool asked for.
     const exact = query.trim().toLowerCase();
-    const index = buildLexicalIndex(
-      entries.map((entry) => ({
-        value: entry,
-        terms: tokenizeDocument(toolSearchEntryText(entry)),
-      })),
-    );
     const isExact = (entry: ToolSearchCatalogEntry) =>
       entry.name.toLowerCase() === exact || entry.id.toLowerCase() === exact;
-    const ranked = scoreLexical(index, tokenizeQuery(query))
+    const exactMatches = entries.filter(isExact);
+    // An unambiguous exact lookup never needs schema traversal or a BM25 index.
+    if (limit === 1 && exactMatches.length === 1) {
+      return exactMatches.slice(0, limit).map((entry) => compactToolSearchCatalogEntry(entry));
+    }
+    const includeMcp = options?.includeMcp !== false;
+    let catalogIndexes = this.searchIndexes.get(catalog);
+    if (!catalogIndexes) {
+      catalogIndexes = new Map();
+      this.searchIndexes.set(catalog, catalogIndexes);
+    }
+    let cachedIndex = catalogIndexes.get(includeMcp);
+    if (!cachedIndex || !matchesCachedToolSearchIndex(cachedIndex, entries)) {
+      const indexedEntries = entries.map((entry) => ({
+        entry,
+        id: entry.id,
+        source: entry.source,
+        name: entry.name,
+        label: entry.label,
+        description: entry.description,
+        parameters: entry.parameters,
+        parameterText: entry.source === "openclaw" ? readParameterText(entry.parameters) : "",
+      }));
+      cachedIndex = {
+        entries: indexedEntries,
+        index: buildLexicalIndex(
+          indexedEntries.map(({ entry, parameterText }) => ({
+            value: entry,
+            terms: tokenizeDocument(toolSearchEntryText(entry, parameterText)),
+          })),
+        ),
+      };
+      catalogIndexes.set(includeMcp, cachedIndex);
+    }
+    const ranked = scoreLexical(cachedIndex.index, tokenizeQuery(query))
       .toSorted(
         (a, b) =>
           Number(isExact(b.value)) - Number(isExact(a.value)) ||
@@ -417,6 +603,7 @@ export class ToolSearchRuntime {
     },
   ) => {
     catalog.callCount += 1;
+    const normalizedInput = input ?? {};
     await assertCatalogOutputSchemaIsValid(entry);
     const parentId = sanitizeToolCallIdPart(options?.parentToolCallId ?? "direct");
     const toolCallId = `tool_search_code:${parentId}:${entry.name}:${++this.callSequence}`;
@@ -440,18 +627,31 @@ export class ToolSearchRuntime {
       await assertCatalogOutputMatchesSchema(entry, snapshot);
       return snapshot;
     };
-    const result = await executeTool({
-      tool: entry.tool,
-      toolName: entry.name,
-      source: entry.source,
-      sourceName: entry.sourceName,
-      toolCallId,
-      parentToolCallId: options?.parentToolCallId,
-      input: input ?? {},
-      signal: options?.signal ?? this.ctx.abortSignal,
-      onUpdate: options?.onUpdate,
-      acceptResultBeforeProjection,
-    });
+    const validateInput = this.options.validateInput && entry.source === "openclaw";
+    const executionTool =
+      validateInput && !isToolWrappedWithBeforeToolCallHook(entry.tool as never)
+        ? wrapToolWithBeforeToolCallHook(entry.tool as never)
+        : entry.tool;
+    const runExecution = async () =>
+      await executeTool({
+        tool: executionTool,
+        toolName: entry.name,
+        source: entry.source,
+        sourceName: entry.sourceName,
+        toolCallId,
+        parentToolCallId: options?.parentToolCallId,
+        input: normalizedInput,
+        signal: options?.signal ?? this.ctx.abortSignal,
+        onUpdate: options?.onUpdate,
+        acceptResultBeforeProjection,
+      });
+    const result = validateInput
+      ? await runWithToolExecutionValidation(
+          toolCallId,
+          async (finalInput) => await assertCatalogInputMatchesSchema(entry, finalInput),
+          runExecution,
+        )
+      : await runExecution();
     const acceptedResult = await acceptResultBeforeProjection(result);
     return { tool: compactToolSearchCatalogEntry(entry), result: acceptedResult };
   };

--- a/src/agents/tool-search.ts
+++ b/src/agents/tool-search.ts
@@ -8,6 +8,7 @@ import {
   addClientToolsToToolCatalog,
   applyToolCatalogCompaction,
   reusableCatalogSnapshots,
+  resolveCatalog,
   sessionCatalogs,
 } from "./tool-search-catalog.js";
 import {
@@ -132,7 +133,7 @@ export function addClientToolsToToolSearchCatalog(params: {
 /** Create Tool Search control tools for the current run/session context. */
 export function createToolSearchTools(ctx: ToolSearchToolContext): AnyAgentTool[] {
   const config = resolveToolSearchConfig(ctx.runtimeConfig ?? ctx.config);
-  const runtime = new ToolSearchRuntime(ctx, config);
+  const runtime = new ToolSearchRuntime(ctx, config, { validateInput: true });
   return [
     {
       name: TOOL_SEARCH_CODE_MODE_TOOL_NAME,
@@ -207,7 +208,7 @@ export function createToolSearchTools(ctx: ToolSearchToolContext): AnyAgentTool[
         signal?: AbortSignal,
         onUpdate?: AgentToolUpdateCallback,
       ): Promise<AgentToolResult<unknown>> => {
-        const call = readToolSearchCallArgs(args);
+        const call = readToolSearchCallArgs(args, resolveCatalog(ctx));
         return jsonResult(
           await runtime.call(call.id, call.input, {
             parentToolCallId: toolCallId,


### PR DESCRIPTION
Closes #96115
Closes #111704
Supersedes #96127

## What Problem This Solves

Fixes an issue where users relying on compact Tool Search or local-model tool calls repeatedly hit missing-parameter failures when a model flattened target arguments into tool_call. Also fixes invalid trusted-tool calls reaching execution, stale results when trusted schemas mutate, and a Gateway E2E failure caused by retired memory configuration.

## Why This Change Was Made

Preserves nested target arguments while recovering flattened arguments and rejecting ambiguous selectors. Validates trusted OpenClaw tools only after policy hooks finish repairing, rewriting, or blocking the final arguments; scopes validation to the exact call so nested and concurrent tools remain isolated. Preserves deferred MCP/client schemas and generic Code Mode, fingerprints mutable trusted schemas, caches and invalidates the lexical index, and skips indexing for exact single-result searches.

## User Impact

Local models and compact/code-mode agents can reliably discover and execute the intended plugin tool without losing legitimate id or name arguments. Invalid trusted calls produce actionable typo-aware errors without side effects, and policy hooks, approvals, nested tools, and untrusted external tools retain their contracts. The real Tool Search Gateway scenario starts and passes against current configuration.

## Evidence

- Reproduced 15 failing regression cases on the original baseline.
- 418 focused Linux Testbox tests pass across Tool Search, ranking, Code Mode, hook policies, adapters, Codex dynamic tools, and QA Lab.
- Added direct regression coverage for flattened arguments, duplicate and colliding selectors, hook repair/rewrite/veto, nested-tool isolation, mutable schemas, strict argument validation, and hostile MCP/client schemas.
- Stress-tested 512 catalog tools across 64 exact searches: zero schema traversals instead of 32,768.
- Real Gateway/mock-provider proof: `pnpm openclaw qa suite --provider-mode mock-openai --scenario tool-search-gateway-e2e --output-dir .artifacts/qa-e2e/tool-search-hardening-landed-20260727`.
- Full changed-code gate passed: core and plugin typechecks, complete lint, formatting, plugin/SDK/dependency boundaries, database guards, and zero runtime import cycles.
- Fresh independent autoreview: clean.
- Verified the upstream Codex protocol and cached BM25 behavior in `codex-rs/protocol/src/dynamic_tools.rs`, `codex-rs/core/src/tools/handlers/tool_search.rs`, `codex-rs/core/src/tools/handlers/tool_search_spec.rs`, `codex-rs/tools/src/tool_search.rs`, and `codex-rs/tools/src/dynamic_tool.rs`.

Thanks to @cbertucci33 for #96115, @hanZeng-08 for #96127, and @pallaoro for #111704. AI-assisted; independently reviewed and Testbox-validated.