### PR TITLE
docs(agents): make sessions tool archive/pin capabilities discoverable

### DIFF
--- a/src/agents/tool-catalog.ts
+++ b/src/agents/tool-catalog.ts
@@ -160,7 +160,7 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
   {
     id: "sessions",
     label: "sessions",
-    description: "Session settings and groups",
+    description: "Session settings: label, pin, archive, groups",
     sectionId: "sessions",
     profiles: ["coding", "messaging"],
     includeInOpenClawGroup: true,

--- a/src/agents/tools/sessions-tool.ts
+++ b/src/agents/tools/sessions-tool.ts
@@ -185,7 +185,7 @@ export function createSessionsTool(opts: SessionsToolOptions = {}): AnyAgentTool
     label: "Sessions",
     name: "sessions",
     description:
-      "Session settings and groups. patch/group_list/group_set/group_rename/group_delete.",
+      "Session settings and groups: patch label/icon/status, pin, archive/restore, model/thinking override; group_list/group_set/group_rename/group_delete.",
     parameters: SessionsToolSchema,
     execute: async (_toolCallId, rawArgs) => {
       const params = rawArgs as Record<string, unknown>;


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where agents on the Codex harness could not discover that session archiving is available to them. With `codexDynamicToolsLoading: "searchable"` (the default), OpenClaw tools are deferred behind Codex `tool_search`, so the model only sees a tool if a keyword search matches its name, description, or parameter text. The `sessions` tool's description ("Session settings and groups. patch/group_list/group_set/group_rename/group_delete.") never mentioned archive, pin, status, icon, or model override — so a live agent on team.openclaw.ai, asked to archive its session, concluded "No session-archive mutation tool is exposed here" and gave up (or worked around it via the CLI), even though the tool existed in the running build.

## Why This Change Was Made

The one-line tool description now enumerates the real capability surface of `action: "patch"` (label/icon/status, pin, archive/restore, model/thinking override) alongside the group actions, and the tool-catalog entry gets a matching short summary. This makes the tool findable both by Codex's BM25 tool search and by a model reading tool summaries. No behavior change — descriptions only.

## User Impact

Agents asked to archive, pin, or relabel a session on the Codex harness now find and use the `sessions` tool instead of claiming the capability does not exist or shelling out to the CLI.

## Evidence

- Live test on an isolated dev gateway (source checkout, `openai/gpt-5.6-sol` on the Codex app-server harness with `codexDynamicToolsLoading: "searchable"`, `tools.sessions.visibility: "all"` mirroring the affected deployment):
  - "Archive the session with key agent:main:qa-archive-1" → model called `sessions_list`, then `sessions {action:"patch", sessionKey:"agent:main:qa-archive-1", archived:true}` → `ok:true`, session archived.
  - "Please archive this current session now" → model called `sessions {action:"patch", archived:true}`, was correctly blocked by the active-run guard ("Cannot archive a session with an active run."), then scheduled a one-shot cron that archived the session immediately after the turn ended → `archived:true` verified via `sessions.list {archived:"all"}`.
- Focused test: `node scripts/run-vitest.mjs src/agents/tools/sessions-tool.test.ts` → 13 passed.
- `oxfmt --check` clean on both files; `git diff --check` clean.
- Autoreview (Codex, gpt-5.6-sol): clean, no accepted/actionable findings.
