### PR TITLE
fix(qa): isolate Mantis candidate execution

### DIFF
--- a/.github/codex/prompts/mantis-telegram-desktop-proof.md
+++ b/.github/codex/prompts/mantis-telegram-desktop-proof.md
@@ -101,22 +101,16 @@ than Telegram-visible behavior`. Use this manifest shape and do not create
 4. Decide what Telegram message, mock model response, command, callback, button,
    media, or sequence best proves the PR. Use `MANTIS_INSTRUCTIONS` as extra
    maintainer guidance, not as a replacement for reading the PR.
-   For an MCP App channel-action proof, use the trusted runner's
-   `--mcp-app-fixture` option with a Tailscale-capable Crabbox provider and send
-   `mcp app conformance qa check`. This starts the pinned official-SDK fixture
-   and publishes the candidate Gateway through its real Funnel lifecycle. The
-   native Telegram button must open the fixture showing `ready`. Click both
-   `Call app tool` and `Read resource`, then capture `companion-called` and
-   `resource-ok`.
-   Reopen that same Telegram button after its ticket expires and capture the
-   expired state. Do not substitute Control UI, transcript, curl, or a newly
-   minted button for any part of that path.
-5. Use the workflow-prepared detached worktrees under
-   `.artifacts/qa-e2e/mantis/telegram-desktop-proof-worktrees/baseline` and
-   `.artifacts/qa-e2e/mantis/telegram-desktop-proof-worktrees/candidate`.
-   Verify their `HEAD`s match `BASELINE_SHA` and `CANDIDATE_SHA`; do not create,
-   install, rebuild, or replace them. The workflow prepared both with a pinned
-   Node/pnpm toolchain before agent secrets were available.
+   MCP App Funnel proof is not supported by the container-isolated Mantis path.
+   If that is the required scenario, write the capture-infrastructure failure
+   manifest described above without leasing credentials or starting Crabbox;
+   do not pass `--mcp-app-fixture` or weaken the container boundary.
+5. Use the workflow-prepared detached worktrees named by
+   `MANTIS_BASELINE_ROOT` and `MANTIS_CANDIDATE_ROOT`.
+   The workflow already verified their `HEAD`s and then made the worktree root
+   inaccessible to the agent. Do not read, enter, execute, create, install,
+   rebuild, or replace them on the host. The root-owned isolation wrapper is
+   the only execution seam for these prepared builds.
    If `MANTIS_CANDIDATE_TRUST` is `fork-pr-head`, treat the
    candidate worktree as untrusted fork code: do not pass GitHub, OpenAI,
    Crabbox, Convex, or other workflow secrets into candidate runtime commands.
@@ -125,9 +119,16 @@ than Telegram-visible behavior`. Use this manifest shape and do not create
    model key needed for this isolated proof.
 6. In each worktree, run the real-user Telegram Crabbox proof flow from the
    skill with `$OPENCLAW_TELEGRAM_USER_PROOF_CMD`; do not run
-   `pnpm qa:telegram-user:crabbox` directly. The proof command comes from the
-   trusted workflow checkout while the current directory controls which
-   baseline or candidate OpenClaw build is tested. Use
+   `pnpm qa:telegram-user:crabbox` directly. Run it from the trusted workflow
+   checkout and pass
+   `--sut-container --sut-lane baseline --sut-repo-root "$MANTIS_BASELINE_ROOT"`
+   for main and
+   `--sut-container --sut-lane candidate --sut-repo-root "$MANTIS_CANDIDATE_ROOT"`
+   for the PR. Fork heads are rejected without the explicit attested lane and
+   prepared root, and
+   the root-owned wrapper is the only process allowed to mount it. This keeps
+   candidate code away from the host Codex proxy and workflow filesystem while
+   preserving real Telegram network behavior. Use
    `$OPENCLAW_TELEGRAM_USER_DRIVER_SCRIPT`, the workflow-provided `crabbox`
    binary, and the workflow-provided local `ffmpeg`/`ffprobe`; do not generate,
    install, or patch replacement proof tooling during the run. Use the same
@@ -149,14 +150,19 @@ than Telegram-visible behavior`. Use this manifest shape and do not create
 8. Finish each session with `--preview-crop telegram-window`.
 9. Build `${MANTIS_OUTPUT_DIR}/mantis-evidence.json` with:
 
+   Session artifact paths are relative to the trusted workflow checkout, not
+   to the inaccessible SUT mounts. Pass the trusted checkout root for both
+   `--*-repo-root` arguments; use the prepared worktree paths only with
+   `--sut-lane`/`--sut-repo-root` during `start`.
+
    ```bash
    node scripts/mantis/build-telegram-desktop-proof-evidence.mjs \
      --output-dir "$MANTIS_OUTPUT_DIR" \
-     --baseline-repo-root <baseline-worktree> \
+     --baseline-repo-root "$GITHUB_WORKSPACE" \
      --baseline-output-dir <baseline-session-output-dir> \
      --baseline-ref "$BASELINE_REF" \
      --baseline-sha "$BASELINE_SHA" \
-     --candidate-repo-root <candidate-worktree> \
+     --candidate-repo-root "$GITHUB_WORKSPACE" \
      --candidate-output-dir <candidate-session-output-dir> \
      --candidate-ref "$CANDIDATE_REF" \
      --candidate-sha "$CANDIDATE_SHA" \

--- a/.github/workflows/mantis-telegram-desktop-proof.yml
+++ b/.github/workflows/mantis-telegram-desktop-proof.yml
@@ -278,6 +278,9 @@ jobs:
           crabbox media preview --help >/dev/null
 
       - name: Install local proof tools
+        env:
+          BASELINE_SHA: ${{ needs.validate_refs.outputs.baseline_revision }}
+          CANDIDATE_SHA: ${{ needs.validate_refs.outputs.candidate_revision }}
         shell: bash
         run: |
           set -euo pipefail
@@ -306,6 +309,16 @@ jobs:
           sudo install -m 0755 "${RUNNER_TEMP}/mantis-node" /usr/local/lib/mantis-toolchain/node
           sudo install -m 0755 "${RUNNER_TEMP}/mantis-pnpm" /usr/local/lib/mantis-toolchain/pnpm
           sudo install -m 0755 "${RUNNER_TEMP}/openclaw-telegram-user-crabbox-proof" /usr/local/bin/openclaw-telegram-user-crabbox-proof
+          sudo install -m 0755 scripts/mantis/mantis-sut-container.sh /usr/local/sbin/openclaw-mantis-sut-container
+          printf '/tmp/openclaw-mantis-proof-worktrees-%s-%s\n' "$GITHUB_RUN_ID" "$GITHUB_RUN_ATTEMPT" \
+            | sudo tee /etc/openclaw-mantis-sut-worktrees >/dev/null
+          printf 'baseline\t%s\ncandidate\t%s\n' "$BASELINE_SHA" "$CANDIDATE_SHA" \
+            | sudo tee /etc/openclaw-mantis-sut-revisions >/dev/null
+          runtime_parent="/tmp/openclaw-mantis-sut-runtime-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          sudo install -d -m 0711 -o root -g root "$runtime_parent"
+          sudo install -d -m 0700 -o root -g root "$runtime_parent/attestations"
+          printf '%s\n' "$runtime_parent" | sudo tee /etc/openclaw-mantis-sut-runtime-root >/dev/null
+          sudo chmod 0444 /etc/openclaw-mantis-sut-worktrees /etc/openclaw-mantis-sut-revisions /etc/openclaw-mantis-sut-runtime-root
           /usr/local/lib/mantis-toolchain/node --version
           /usr/local/lib/mantis-toolchain/pnpm --version
           /usr/local/bin/openclaw-telegram-user-crabbox-proof --help >/dev/null
@@ -330,7 +343,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          worktree_root="$GITHUB_WORKSPACE/.artifacts/qa-e2e/mantis/telegram-desktop-proof-worktrees"
+          worktree_root="/tmp/openclaw-mantis-proof-worktrees-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           baseline_root="$worktree_root/baseline"
           candidate_root="$worktree_root/candidate"
           toolchain_dir=/usr/local/lib/mantis-toolchain
@@ -372,31 +385,13 @@ jobs:
 
           prepare_worktree "$baseline_root" "${RUNNER_TEMP}/mantis-baseline-home"
           sudo useradd --system --no-create-home --shell /usr/sbin/nologin mantis-builder
-          candidate_home="/tmp/mantis-candidate-home-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          candidate_corepack_home="/tmp/mantis-candidate-corepack-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          sudo install -d -m 0700 -o mantis-builder -g mantis-builder "$candidate_home"
-          sudo install -d -m 0700 -o mantis-builder -g mantis-builder "$candidate_corepack_home"
           sudo chown -R mantis-builder:mantis-builder "$candidate_root"
-          candidate_parent="$(dirname "$candidate_root")"
-          while [ "$candidate_parent" != "/" ]; do
-            sudo setfacl -m u:mantis-builder:--x "$candidate_parent"
-            [ "$candidate_parent" = "/home/runner" ] && break
-            candidate_parent="$(dirname "$candidate_parent")"
-          done
-          sudo -u mantis-builder env -i \
-            CI=1 \
-            COREPACK_HOME="$candidate_corepack_home" \
-            HOME="$candidate_home" \
-            OPENCLAW_BUILD_PRIVATE_QA=1 \
-            OPENCLAW_ENABLE_PRIVATE_QA_CLI=1 \
-            PATH="$toolchain_dir:/usr/bin:/bin" \
-            /bin/bash -c 'cd "$1" && "$2" install --frozen-lockfile && "$2" build' \
-            bash "$candidate_root" "$toolchain_dir/pnpm"
+          sudo /usr/local/sbin/openclaw-mantis-sut-container build "$candidate_root"
           test "$(cat "$candidate_root/.git")" = "$candidate_git_link"
-          git -C "$candidate_root" diff --exit-code
-          git -C "$candidate_root" diff --cached --exit-code
+          git -c safe.directory="$candidate_root" -C "$candidate_root" diff --exit-code
+          git -c safe.directory="$candidate_root" -C "$candidate_root" diff --cached --exit-code
           test "$(git -C "$baseline_root" rev-parse HEAD)" = "$BASELINE_SHA"
-          test "$(git -C "$candidate_root" rev-parse HEAD)" = "$CANDIDATE_SHA"
+          test "$(git -c safe.directory="$candidate_root" -C "$candidate_root" rev-parse HEAD)" = "$CANDIDATE_SHA"
 
       - name: Ensure agent key exists
         env:
@@ -417,10 +412,11 @@ jobs:
             printf '%s\n' 'Defaults env_keep += "CODEX_HOME CODEX_INTERNAL_ORIGINATOR_OVERRIDE"'
             printf '%s\n' 'Defaults env_keep += "BASELINE_REF BASELINE_SHA CANDIDATE_REF CANDIDATE_SHA"'
             printf '%s\n' 'Defaults env_keep += "CRABBOX_ACCESS_CLIENT_ID CRABBOX_ACCESS_CLIENT_SECRET CRABBOX_COORDINATOR CRABBOX_COORDINATOR_TOKEN CRABBOX_AWS_REGION CRABBOX_CAPACITY_REGIONS CRABBOX_LEASE_ID CRABBOX_PROVIDER"'
-            printf '%s\n' 'Defaults env_keep += "GH_TOKEN MANTIS_CANDIDATE_TRUST MANTIS_INSTRUCTIONS MANTIS_OUTPUT_DIR MANTIS_PR_NUMBER"'
+            printf '%s\n' 'Defaults env_keep += "GH_TOKEN GITHUB_WORKSPACE MANTIS_BASELINE_ROOT MANTIS_CANDIDATE_ROOT MANTIS_CANDIDATE_TRUST MANTIS_INSTRUCTIONS MANTIS_OUTPUT_DIR MANTIS_PR_NUMBER"'
             printf '%s\n' 'Defaults env_keep += "MANTIS_NODE_BIN MANTIS_PNPM_BIN"'
             printf '%s\n' 'Defaults env_keep += "OPENCLAW_BUILD_PRIVATE_QA OPENCLAW_ENABLE_PRIVATE_QA_CLI OPENCLAW_QA_CONVEX_SECRET_CI OPENCLAW_QA_CONVEX_SITE_URL OPENCLAW_QA_CREDENTIAL_OWNER_ID OPENCLAW_QA_MANTIS_CRABBOX_COORDINATOR OPENCLAW_QA_MANTIS_CRABBOX_COORDINATOR_TOKEN"'
             printf '%s\n' 'Defaults env_keep += "OPENCLAW_TELEGRAM_USER_CRABBOX_BIN OPENCLAW_TELEGRAM_USER_CRABBOX_PROVIDER OPENCLAW_TELEGRAM_USER_DRIVER_SCRIPT OPENCLAW_TELEGRAM_USER_PROOF_CMD"'
+            printf '%s\n' 'codex ALL=(root) NOPASSWD: /usr/local/sbin/openclaw-mantis-sut-container'
           } | sudo tee /etc/sudoers.d/mantis-codex-env >/dev/null
           sudo chmod 0440 /etc/sudoers.d/mantis-codex-env
           codex_home="/tmp/mantis-codex-home-${GITHUB_RUN_ID}"
@@ -434,6 +430,10 @@ jobs:
             workspace_parent="$(dirname "$workspace_parent")"
           done
           sudo chown -R codex:codex "$GITHUB_WORKSPACE"
+          proof_worktree_root="/tmp/openclaw-mantis-proof-worktrees-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          sudo chown -R root:root "$proof_worktree_root"
+          sudo chmod -R a-w "$proof_worktree_root"
+          sudo chmod 0700 "$proof_worktree_root"
 
       - name: Run Codex Mantis Telegram agent
         uses: openai/codex-action@52fe01ec70a42f454c9d2ebd47598f9fd6893d56
@@ -452,6 +452,8 @@ jobs:
           CRABBOX_PROVIDER: ${{ needs.resolve_request.outputs.crabbox_provider }}
           GH_TOKEN: ${{ github.token }}
           MANTIS_CANDIDATE_TRUST: ${{ needs.validate_refs.outputs.candidate_trust }}
+          MANTIS_BASELINE_ROOT: /tmp/openclaw-mantis-proof-worktrees-${{ github.run_id }}-${{ github.run_attempt }}/baseline
+          MANTIS_CANDIDATE_ROOT: /tmp/openclaw-mantis-proof-worktrees-${{ github.run_id }}-${{ github.run_attempt }}/candidate
           MANTIS_INSTRUCTIONS: ${{ needs.resolve_request.outputs.instructions }}
           MANTIS_NODE_BIN: /usr/local/lib/mantis-toolchain/node
           MANTIS_OUTPUT_DIR: ${{ env.MANTIS_OUTPUT_DIR }}
@@ -525,6 +527,34 @@ jobs:
             fi
           done
           exit "$status"
+
+      - name: Validate root-owned SUT attestations
+        if: ${{ always() }}
+        env:
+          BASELINE_SHA: ${{ needs.validate_refs.outputs.baseline_revision }}
+          CANDIDATE_SHA: ${{ needs.validate_refs.outputs.candidate_revision }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          runtime_parent="$(</etc/openclaw-mantis-sut-runtime-root)"
+          manifest="$MANTIS_OUTPUT_DIR/mantis-evidence.json"
+          test -f "$manifest"
+          for lane in baseline candidate; do
+            lane_status="$(jq -r --arg lane "$lane" '.comparison[$lane].status' "$manifest")"
+            if [[ "$lane" == "baseline" ]]; then
+              expected_sha="$BASELINE_SHA"
+            else
+              expected_sha="$CANDIDATE_SHA"
+            fi
+            jq -e --arg lane "$lane" --arg sha "$expected_sha" \
+              '.comparison[$lane].sha == $sha' "$manifest" >/dev/null
+            if [[ "$lane_status" == "skipped" ]]; then
+              continue
+            fi
+            sudo jq -e --arg lane "$lane" --arg sha "$expected_sha" \
+              '.lane == $lane and .sha == $sha' \
+              "$runtime_parent/attestations/$lane.json" >/dev/null
+          done
 
       - name: Inspect Mantis evidence manifest
         id: inspect

--- a/.github/workflows/mantis-telegram-desktop-proof.yml
+++ b/.github/workflows/mantis-telegram-desktop-proof.yml
@@ -578,7 +578,10 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: mantis-telegram-desktop-proof-${{ github.run_id }}-${{ github.run_attempt }}
-          path: ${{ steps.inspect.outputs.output_dir }}
+          path: |
+            ${{ steps.inspect.outputs.output_dir }}/mantis-evidence.json
+            ${{ steps.inspect.outputs.output_dir }}/baseline
+            ${{ steps.inspect.outputs.output_dir }}/candidate
           retention-days: 14
           if-no-files-found: error
 

--- a/.github/workflows/mantis-telegram-desktop-proof.yml
+++ b/.github/workflows/mantis-telegram-desktop-proof.yml
@@ -119,7 +119,7 @@ jobs:
       - name: Checkout harness ref
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          ref: main
+          ref: ${{ github.workflow_sha }}
           persist-credentials: false
           fetch-depth: 0
 
@@ -246,6 +246,7 @@ jobs:
       - name: Checkout harness ref
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          ref: ${{ github.workflow_sha }}
           persist-credentials: false
           fetch-depth: 0
 
@@ -615,6 +616,7 @@ jobs:
       - name: Checkout harness ref
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          ref: ${{ github.workflow_sha }}
           persist-credentials: false
 
       - name: Setup Node environment

--- a/.github/workflows/mantis-telegram-desktop-proof.yml
+++ b/.github/workflows/mantis-telegram-desktop-proof.yml
@@ -371,11 +371,17 @@ jobs:
 
           prepare_worktree "$baseline_root" "${RUNNER_TEMP}/mantis-baseline-home"
           sudo useradd --system --no-create-home --shell /usr/sbin/nologin mantis-builder
-          candidate_home="${RUNNER_TEMP}/mantis-candidate-home"
-          candidate_corepack_home="${RUNNER_TEMP}/mantis-candidate-corepack"
+          candidate_home="/tmp/mantis-candidate-home-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          candidate_corepack_home="/tmp/mantis-candidate-corepack-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           sudo install -d -m 0700 -o mantis-builder -g mantis-builder "$candidate_home"
           sudo install -d -m 0700 -o mantis-builder -g mantis-builder "$candidate_corepack_home"
           sudo chown -R mantis-builder:mantis-builder "$candidate_root"
+          candidate_parent="$(dirname "$candidate_root")"
+          while [ "$candidate_parent" != "/" ]; do
+            sudo setfacl -m u:mantis-builder:--x "$candidate_parent"
+            [ "$candidate_parent" = "/home/runner" ] && break
+            candidate_parent="$(dirname "$candidate_parent")"
+          done
           sudo -u mantis-builder env -i \
             CI=1 \
             COREPACK_HOME="$candidate_corepack_home" \

--- a/scripts/e2e/telegram-user-crabbox-proof.ts
+++ b/scripts/e2e/telegram-user-crabbox-proof.ts
@@ -86,6 +86,9 @@ type Options = {
   recordSeconds: number;
   remoteCommand: string[];
   sessionFile?: string;
+  sutContainer: boolean;
+  sutLane?: "baseline" | "candidate";
+  sutRepoRoot?: string;
   sutUsername?: string;
   target: string;
   tdlibSha256?: string;
@@ -121,6 +124,8 @@ type LocalSut = {
   gateway: ChildProcess;
   gatewayLog: string;
   funnelBridge?: FunnelBridge;
+  containerName?: string;
+  sutAttestation?: { lane: "baseline" | "candidate"; sha: string };
 };
 
 type SessionFile = {
@@ -143,6 +148,8 @@ type SessionFile = {
   };
   localRoot: string;
   localSut: {
+    containerName?: string;
+    sutAttestation?: { lane: "baseline" | "candidate"; sha: string };
     gatewayLog: string;
     gatewayPid: number;
     mockLog: string;
@@ -228,6 +235,9 @@ function usageText() {
     "  --repo <owner/name>           GitHub repo for publish. Default: openclaw/openclaw.",
     "  --session <path>              Session file from start. Default: <output-dir>/session.json.",
     "  --summary <text>              Artifact publish summary.",
+    "  --sut-container               Isolate the local OpenClaw SUT in Docker.",
+    "  --sut-lane <lane>             Attested prepared lane: baseline or candidate.",
+    "  --sut-repo-root <path>        Prepared SUT checkout mounted by the isolation wrapper.",
     "  --full-artifacts              Publish all session artifacts. Default publishes only the motion GIF.",
     "  --tdlib-sha256 <hex>         Expected SHA-256 for --tdlib-url. Defaults to <url>.sha256.",
     "  --tdlib-url <url>             Linux tdlib archive containing libtdjson.so.",
@@ -342,6 +352,7 @@ export function parseArgs(argvInput: string[]): Options {
     recordFps: 24,
     recordSeconds: 35,
     remoteCommand: [],
+    sutContainer: process.env.MANTIS_CANDIDATE_TRUST === "fork-pr-head",
     target: "linux",
     text: "/status",
     timeoutMs: 90_000,
@@ -442,6 +453,18 @@ export function parseArgs(argvInput: string[]): Options {
       opts.sessionFile = readValue();
     } else if (arg === "--summary") {
       opts.publishSummary = readValue();
+    } else if (arg === "--sut-container") {
+      opts.sutContainer = true;
+    } else if (arg === "--sut-lane") {
+      const lane = readValue();
+      if (lane !== "baseline" && lane !== "candidate") {
+        throw new Error("--sut-lane must be baseline or candidate.");
+      }
+      opts.sutLane = lane;
+      opts.sutContainer = true;
+    } else if (arg === "--sut-repo-root") {
+      opts.sutRepoRoot = readValue();
+      opts.sutContainer = true;
     } else if (arg === "--full-artifacts") {
       opts.publishFullArtifacts = true;
     } else if (arg === "--record-fps") {
@@ -489,6 +512,24 @@ export function parseArgs(argvInput: string[]): Options {
   }
   if (opts.mcpAppFixture && opts.leaseId) {
     throw new Error("--mcp-app-fixture requires a fresh lifecycle-owned Crabbox lease.");
+  }
+  if (opts.mcpAppFixture && opts.sutContainer) {
+    throw new Error("--mcp-app-fixture is unavailable for container-isolated SUT proof.");
+  }
+  if (command === "probe" && opts.sutContainer) {
+    throw new Error("--sut-container requires the held-session start flow.");
+  }
+  if (command !== "start" && opts.sutRepoRoot) {
+    throw new Error("--sut-repo-root is available only for start sessions.");
+  }
+  if (command !== "start" && opts.sutLane) {
+    throw new Error("--sut-lane is available only for start sessions.");
+  }
+  if (Boolean(opts.sutRepoRoot) !== Boolean(opts.sutLane)) {
+    throw new Error("--sut-repo-root and --sut-lane must be provided together.");
+  }
+  if (command === "start" && opts.sutContainer && (!opts.sutRepoRoot || !opts.sutLane)) {
+    throw new Error("container proof requires --sut-repo-root and --sut-lane.");
   }
   return opts;
 }
@@ -1038,16 +1079,64 @@ function killTree(child: ChildProcess | undefined) {
   }
 }
 
-function killPidTree(pid: number | undefined) {
+function killPidTree(pid: number | undefined, signal: NodeJS.Signals = "SIGTERM") {
   if (!pid) {
     return;
   }
   try {
-    process.kill(-pid, "SIGTERM");
+    process.kill(-pid, signal);
   } catch {
     try {
-      process.kill(pid, "SIGTERM");
+      process.kill(pid, signal);
     } catch {}
+  }
+}
+
+export function processTargetExists(target: number) {
+  try {
+    process.kill(target, 0);
+    return true;
+  } catch (error) {
+    const code =
+      error && typeof error === "object" && "code" in error ? String(error.code) : undefined;
+    if (code === "ESRCH") {
+      return false;
+    }
+    if (code === "EPERM") {
+      return true;
+    }
+    throw error;
+  }
+}
+
+function isPidTreeAlive(pid: number) {
+  for (const target of [-pid, pid]) {
+    if (processTargetExists(target)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+async function waitForPidTreeExit(pid: number, timeoutMs: number) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!isPidTreeAlive(pid)) {
+      return true;
+    }
+    await sleep(25);
+  }
+  return !isPidTreeAlive(pid);
+}
+
+async function stopPidTreeAndWait(pid: number) {
+  killPidTree(pid);
+  if (await waitForPidTreeExit(pid, 5_000)) {
+    return;
+  }
+  killPidTree(pid, "SIGKILL");
+  if (!(await waitForPidTreeExit(pid, 2_000))) {
+    throw new Error(`Local SUT process group ${pid} did not exit.`);
   }
 }
 
@@ -1422,6 +1511,187 @@ export async function recordProbeVideo(params: {
   }
 }
 
+export function createContainerizedSutSpawnSpec(params: {
+  codexProxyPort: number;
+  containerName: string;
+  gatewayPort: number;
+  mockPort: number;
+  mockResponseChunkDelayMs?: number;
+  mockResponseText: string;
+  repoRoot: string;
+  runtimeRoot: string;
+  sutLane: "baseline" | "candidate";
+  gatewayEnv: NodeJS.ProcessEnv;
+}) {
+  const containerHome = path.join(params.runtimeRoot, "container-home");
+  fs.mkdirSync(containerHome, { recursive: true });
+  const inputPath = path.join(params.runtimeRoot, "container-input.json");
+  fs.writeFileSync(
+    inputPath,
+    `${JSON.stringify({
+      gatewayPassword: params.gatewayEnv.OPENCLAW_GATEWAY_PASSWORD,
+      mockResponseChunkDelayMs: params.mockResponseChunkDelayMs,
+      mockResponseText: params.mockResponseText,
+      telegramBotToken: params.gatewayEnv.TELEGRAM_BOT_TOKEN,
+    })}\n`,
+    { mode: 0o600 },
+  );
+  return {
+    args: [
+      "-n",
+      "/usr/local/sbin/openclaw-mantis-sut-container",
+      "run",
+      params.containerName,
+      params.sutLane,
+      params.repoRoot,
+      params.runtimeRoot,
+      String(params.gatewayPort),
+      String(params.mockPort),
+      String(params.codexProxyPort),
+    ],
+    command: "sudo",
+    inputPath,
+    options: {
+      cwd: process.cwd(),
+      env: childProcessBaseEnv(),
+      shell: false,
+    } satisfies SpawnOptionsWithoutStdio,
+  };
+}
+
+export function readCodexProxyPort(codexHome: string): number | undefined {
+  let config: string;
+  try {
+    config = fs.readFileSync(path.join(codexHome, "config.toml"), "utf8");
+  } catch {
+    return undefined;
+  }
+  const section = config.match(
+    /\[model_providers\.codex-action-responses-proxy\]([\s\S]*?)(?=\n\[|$)/u,
+  )?.[1];
+  const match = section?.match(/base_url\s*=\s*"http:\/\/127\.0\.0\.1:(\d+)\/v1"/u);
+  if (!match?.[1]) {
+    return undefined;
+  }
+  const port = Number.parseInt(match[1], 10);
+  return Number.isInteger(port) && port > 0 && port <= 65_535 ? port : undefined;
+}
+
+function requireCodexProxyPort() {
+  const codexHome = trimToValue(process.env.CODEX_HOME);
+  if (!codexHome) {
+    throw new Error("Fork SUT isolation requires CODEX_HOME for the proxy boundary check.");
+  }
+  const proxyPort = readCodexProxyPort(codexHome);
+  if (!proxyPort) {
+    throw new Error("Fork SUT isolation could not resolve the Codex Responses proxy port.");
+  }
+  return proxyPort;
+}
+
+type SutContainerAction = "destroy" | "stop";
+
+type SutContainerCommandRunner = (
+  command: string,
+  args: string[],
+  options: {
+    encoding: "utf8";
+    env: NodeJS.ProcessEnv;
+    stdio: "pipe";
+  },
+) => {
+  error?: Error;
+  signal?: NodeJS.Signals | null;
+  status: number | null;
+  stderr?: string;
+};
+
+export function runSutContainerAction(
+  action: SutContainerAction,
+  containerName: string | undefined,
+  runtimeRoot: string | undefined,
+  run: SutContainerCommandRunner = spawnSync,
+) {
+  if (!containerName || !runtimeRoot) {
+    return;
+  }
+  const result = run(
+    "sudo",
+    ["-n", "/usr/local/sbin/openclaw-mantis-sut-container", action, containerName, runtimeRoot],
+    {
+      encoding: "utf8",
+      env: childProcessBaseEnv(),
+      stdio: "pipe",
+    },
+  );
+  if (result.error) {
+    throw new Error(`Failed to ${action} container-isolated SUT: ${result.error.message}`, {
+      cause: result.error,
+    });
+  }
+  if (result.signal) {
+    throw new Error(`Container-isolated SUT ${action} was terminated by ${result.signal}.`);
+  }
+  if (result.status !== 0) {
+    const stderr = result.stderr?.trim().slice(-4_000);
+    throw new Error(
+      `Container-isolated SUT ${action} failed with exit code ${result.status ?? "unknown"}.${stderr ? `\n${stderr}` : ""}`,
+    );
+  }
+}
+
+async function stopLocalSutDaemon(
+  sut:
+    | {
+        containerName?: string;
+        gatewayPid?: number;
+        mockPid?: number;
+        tempRoot?: string;
+      }
+    | undefined,
+) {
+  let containerError: unknown;
+  try {
+    runSutContainerAction("stop", sut?.containerName, sut?.tempRoot);
+  } catch (error) {
+    containerError = error;
+  }
+  const pids = [...new Set([sut?.gatewayPid, sut?.mockPid].filter((pid) => pid !== undefined))];
+  const processResults = await Promise.allSettled(pids.map((pid) => stopPidTreeAndWait(pid)));
+  const processErrors = processResults.flatMap((result) =>
+    result.status === "rejected" ? [result.reason] : [],
+  );
+  if (containerError || processErrors.length > 0) {
+    throw new AggregateError(
+      [...(containerError ? [containerError] : []), ...processErrors],
+      "Local SUT did not quiesce cleanly.",
+    );
+  }
+}
+
+function destroyLocalSutRuntime(sut: { containerName?: string; tempRoot?: string } | undefined) {
+  runSutContainerAction("destroy", sut?.containerName, sut?.tempRoot);
+}
+
+function cleanupFailureMessage(message: string, cleanupErrors: unknown[]) {
+  const details = cleanupErrors.map((error) =>
+    error instanceof Error ? error.message : String(error),
+  );
+  return [message, ...details.map((detail) => `Cleanup failure: ${detail}`)].join("\n");
+}
+
+function preserveLocalSutRuntimeArtifacts(
+  sut: Pick<SessionFile["localSut"], "gatewayLog" | "mockLog" | "requestLog">,
+  outputDir: string,
+) {
+  for (const source of [sut.gatewayLog, sut.mockLog, sut.requestLog]) {
+    const target = path.join(outputDir, path.basename(source));
+    if (path.resolve(source) !== path.resolve(target) && fs.existsSync(source)) {
+      fs.copyFileSync(source, target);
+    }
+  }
+}
+
 async function startLocalSutDaemon(params: {
   funnelBridge?: FunnelBridge;
   gatewayPort: number;
@@ -1437,16 +1707,86 @@ async function startLocalSutDaemon(params: {
   repoRoot: string;
   nodeBin?: string;
   pnpmBin?: string;
+  sutContainer?: boolean;
+  sutLane?: "baseline" | "candidate";
 }) {
   const drained = await drainSutUpdates(params.sutToken);
   const config = writeSutConfig(params);
   const gatewayPassword = params.mcpAppFixture ? randomUUID() : undefined;
-  const requestLog = path.join(params.outputDir, "mock-openai-requests.ndjson");
-  const mockLog = path.join(params.outputDir, "mock-openai.log");
-  const gatewayLog = path.join(params.outputDir, "gateway.log");
+  const runtimeLogRoot = params.sutContainer ? config.tempRoot : params.outputDir;
+  const requestLog = path.join(runtimeLogRoot, "mock-openai-requests.ndjson");
+  const mockLog = path.join(runtimeLogRoot, "mock-openai.log");
+  const gatewayLog = path.join(runtimeLogRoot, "gateway.log");
   let mockPid: number | undefined;
   let gatewayPid: number | undefined;
+  let containerName: string | undefined;
+  let containerInputPath: string | undefined;
   try {
+    if (params.sutContainer) {
+      if (!params.sutLane) {
+        throw new Error("Container-isolated SUT requires an attested lane.");
+      }
+      if (params.funnelBridge) {
+        throw new Error("Container-isolated fork SUT does not support the MCP App Funnel fixture.");
+      }
+      const codexProxyPort = requireCodexProxyPort();
+      containerName = `openclaw-telegram-sut-${randomUUID()}`;
+      const gatewayEnvVars = gatewayEnv({
+        ...config,
+        gatewayPassword,
+        sutToken: params.sutToken,
+      });
+      const spec = createContainerizedSutSpawnSpec({
+        codexProxyPort,
+        containerName,
+        gatewayEnv: gatewayEnvVars,
+        gatewayPort: params.gatewayPort,
+        mockPort: params.mockPort,
+        mockResponseChunkDelayMs: params.mockResponseChunkDelayMs,
+        mockResponseText: params.mockResponseText,
+        repoRoot: params.repoRoot,
+        runtimeRoot: config.tempRoot,
+        sutLane: params.sutLane,
+      });
+      containerInputPath = spec.inputPath;
+      gatewayPid = spawnDaemon({
+        args: spec.args,
+        command: spec.command,
+        cwd: spec.options.cwd ?? params.repoRoot,
+        env: spec.options.env ?? {},
+        logPath: path.join(params.outputDir, "sut-container.log"),
+        shell: spec.options.shell as boolean | undefined,
+      });
+      mockPid = gatewayPid;
+      if (!gatewayPid) {
+        throw new Error("container-isolated SUT did not start.");
+      }
+      await waitForLog(mockLog, /mock-openai listening/u, "mock-openai", 30_000);
+      await waitForLog(gatewayLog, /\[gateway\] ready/u, "gateway", 60_000);
+      const sutAttestation = readJsonFile(path.join(config.tempRoot, "sut-attestation.json")) as {
+        lane?: unknown;
+        sha?: unknown;
+      };
+      if (
+        sutAttestation.lane !== params.sutLane ||
+        typeof sutAttestation.sha !== "string" ||
+        !/^[0-9a-f]{40}$/u.test(sutAttestation.sha)
+      ) {
+        throw new Error("Container-isolated SUT attestation mismatch.");
+      }
+      return {
+        ...config,
+        containerName,
+        drained,
+        gatewayLog,
+        gatewayPid,
+        mockLog,
+        mockPid: gatewayPid,
+        requestLog,
+        sutAttestation: { lane: params.sutLane, sha: sutAttestation.sha },
+        funnelBridge: params.funnelBridge,
+      };
+    }
     mockPid = spawnDaemon({
       command: params.nodeBin ?? process.execPath,
       args: ["scripts/e2e/mock-openai-server.mjs"],
@@ -1497,8 +1837,52 @@ async function startLocalSutDaemon(params: {
       funnelBridge: params.funnelBridge,
     };
   } catch (error) {
-    killPidTree(gatewayPid);
-    killPidTree(mockPid);
+    const cleanupErrors: unknown[] = [];
+    let quiesced = false;
+    try {
+      await stopLocalSutDaemon({
+        containerName,
+        gatewayPid,
+        mockPid,
+        tempRoot: config.tempRoot,
+      });
+      quiesced = true;
+    } catch (cleanupError) {
+      cleanupErrors.push(cleanupError);
+    }
+    if (params.sutContainer) {
+      if (quiesced) {
+        try {
+          preserveLocalSutRuntimeArtifacts({ gatewayLog, mockLog, requestLog }, params.outputDir);
+        } catch (cleanupError) {
+          cleanupErrors.push(cleanupError);
+        }
+      }
+      try {
+        destroyLocalSutRuntime({
+          containerName,
+          tempRoot: config.tempRoot,
+        });
+      } catch (cleanupError) {
+        cleanupErrors.push(cleanupError);
+      }
+    }
+    if (containerInputPath) {
+      try {
+        fs.rmSync(containerInputPath, { force: true });
+      } catch (cleanupError) {
+        cleanupErrors.push(cleanupError);
+      }
+    }
+    if (cleanupErrors.length > 0) {
+      throw new Error(
+        cleanupFailureMessage(
+          "Local SUT startup failed and cleanup was incomplete.",
+          cleanupErrors,
+        ),
+        { cause: error },
+      );
+    }
     throw error;
   }
 }
@@ -2479,8 +2863,10 @@ async function startSession(root: string, opts: Options, outputDir: string) {
       outputDir,
       nodeBin: opts.nodeBin,
       pnpmBin: opts.pnpmBin,
-      repoRoot: root,
+      repoRoot: opts.sutRepoRoot ? path.resolve(root, opts.sutRepoRoot) : root,
       sutToken: credential.sutToken,
+      sutContainer: opts.sutContainer,
+      sutLane: opts.sutLane,
       testerId: credential.testerUserId,
     });
     const recorder = await startRemoteRecording(root, inspect, opts);
@@ -2528,8 +2914,28 @@ async function startSession(root: string, opts: Options, outputDir: string) {
       },
     };
   } catch (error) {
-    killPidTree(localSut?.gatewayPid);
-    killPidTree(localSut?.mockPid);
+    const cleanupErrors: unknown[] = [];
+    let sutQuiesced = false;
+    if (localSut) {
+      try {
+        await stopLocalSutDaemon(localSut);
+        sutQuiesced = true;
+      } catch (cleanupError) {
+        cleanupErrors.push(cleanupError);
+      }
+      if (sutQuiesced) {
+        try {
+          preserveLocalSutRuntimeArtifacts(localSut, outputDir);
+        } catch (cleanupError) {
+          cleanupErrors.push(cleanupError);
+        }
+      }
+      try {
+        destroyLocalSutRuntime(localSut);
+      } catch (cleanupError) {
+        cleanupErrors.push(cleanupError);
+      }
+    }
     if (funnelBridge) {
       await stopTailscaleFunnelBridge(root, funnelBridge).catch(() => {});
     }
@@ -2538,6 +2944,15 @@ async function startSession(root: string, opts: Options, outputDir: string) {
     }
     if (leaseId && createdLease) {
       await stopCrabbox(root, opts, leaseId).catch(() => {});
+    }
+    if (cleanupErrors.length > 0) {
+      throw new Error(
+        cleanupFailureMessage(
+          "Telegram proof startup failed and local SUT cleanup was incomplete.",
+          cleanupErrors,
+        ),
+        { cause: error },
+      );
     }
     throw error;
   }
@@ -2684,6 +3099,7 @@ async function finishSession(root: string, opts: Options, outputDir: string) {
     session: path.relative(root, pathname),
     startedAt: session.createdAt,
     status: "fail",
+    sutAttestation: session.localSut.sutAttestation,
   };
   const videoPath = path.join(session.outputDir, "telegram-user-crabbox-session.mp4");
   const motionVideoPath = path.join(session.outputDir, "telegram-user-crabbox-session-motion.mp4");
@@ -2780,8 +3196,28 @@ async function finishSession(root: string, opts: Options, outputDir: string) {
     };
     summary.status = "pass";
   } finally {
-    killPidTree(session.localSut.gatewayPid);
-    killPidTree(session.localSut.mockPid);
+    let sutQuiesced = false;
+    try {
+      await stopLocalSutDaemon(session.localSut);
+      sutQuiesced = true;
+    } catch (error) {
+      summary.sutStopError = error instanceof Error ? error.message : String(error);
+      summary.status = "fail";
+    }
+    if (sutQuiesced) {
+      try {
+        preserveLocalSutRuntimeArtifacts(session.localSut, session.outputDir);
+      } catch (error) {
+        summary.runtimeArtifactError = error instanceof Error ? error.message : String(error);
+        summary.status = "fail";
+      }
+    }
+    try {
+      destroyLocalSutRuntime(session.localSut);
+    } catch (error) {
+      summary.sutDestroyError = error instanceof Error ? error.message : String(error);
+      summary.status = "fail";
+    }
     if (session.localSut.funnelBridge) {
       await stopTailscaleFunnelBridge(root, session.localSut.funnelBridge).catch(
         (error: unknown) => {

--- a/scripts/mantis/build-telegram-desktop-proof-evidence.mjs
+++ b/scripts/mantis/build-telegram-desktop-proof-evidence.mjs
@@ -112,6 +112,13 @@ function laneStatus(lane) {
   return lane.status === "pass" ? "pass" : "fail";
 }
 
+function requireLaneAttestation(lane, expectedLane, expectedSha) {
+  const attestation = lane.summary.sutAttestation;
+  if (attestation?.lane !== expectedLane || attestation?.sha !== expectedSha) {
+    throw new Error(`SUT attestation mismatch for ${expectedLane}.`);
+  }
+}
+
 function laneArtifactEntries() {
   return LANES.flatMap(({ altPrefix, label, lane }) => [
     {
@@ -207,8 +214,10 @@ export function writeTelegramDesktopProofEvidence(rawArgs = process.argv.slice(2
   for (const key of [
     "baseline_output_dir",
     "baseline_repo_root",
+    "baseline_sha",
     "candidate_output_dir",
     "candidate_repo_root",
+    "candidate_sha",
     "output_dir",
   ]) {
     if (!args[key]) {
@@ -228,6 +237,8 @@ export function writeTelegramDesktopProofEvidence(rawArgs = process.argv.slice(2
     repoRoot: path.resolve(args.candidate_repo_root),
     status: args.candidate_status,
   });
+  requireLaneAttestation(baseline, "baseline", args.baseline_sha);
+  requireLaneAttestation(candidate, "candidate", args.candidate_sha);
   copyLaneArtifacts({ lane: baseline, laneName: "baseline", outputDir });
   copyLaneArtifacts({ lane: candidate, laneName: "candidate", outputDir });
   const manifest = buildTelegramDesktopProofManifest({

--- a/scripts/mantis/mantis-sut-container.sh
+++ b/scripts/mantis/mantis-sut-container.sh
@@ -107,6 +107,11 @@ cancel_runtime_claim() {
   if [[ ! -e "$cancel_path" && ! -L "$cancel_path" ]]; then
     install -o root -g root -m 0400 /dev/null "$cancel_path"
   fi
+}
+
+terminate_runtime_claim() {
+  # cancel_runtime_claim already captured the root-owned PID/PGID/start tuple.
+  # Never reread by name here: delayed cleanup must not target a replacement claim.
   if claim_process_is_active; then
     kill -TERM -- "-$claimed_pgid" 2>/dev/null || true
   fi
@@ -811,8 +816,11 @@ case "$command" in
     [[ "$runtime_source" =~ ^/tmp/openclaw-tg-crabbox-sut-[A-Za-z0-9]+$ ]] \
       || die "invalid runtime source"
     cancel_runtime_claim "$1" "$runtime_source"
-    remove_container_or_fail "$1"
-    cleanup_network "${1}-net"
+    stop_result=0
+    remove_container_or_fail "$1" || stop_result=1
+    cleanup_network "${1}-net" || stop_result=1
+    terminate_runtime_claim
+    exit "$stop_result"
     ;;
   destroy)
     [[ $# -eq 2 ]] || die "destroy expects a container name and runtime root"

--- a/scripts/mantis/mantis-sut-container.sh
+++ b/scripts/mantis/mantis-sut-container.sh
@@ -1,0 +1,857 @@
+#!/bin/bash
+set -euo pipefail
+
+readonly image="node:24-bookworm-slim@sha256:6f7b03f7c2c8e2e784dcf9295400527b9b1270fd37b7e9a7285cf83b6951452d"
+readonly worktree_root_file="/etc/openclaw-mantis-sut-worktrees"
+readonly revisions_file="/etc/openclaw-mantis-sut-revisions"
+readonly runtime_root_file="/etc/openclaw-mantis-sut-runtime-root"
+readonly docker_bin="/usr/bin/docker"
+readonly flock_bin="/usr/bin/flock"
+readonly iptables_bin="/usr/sbin/iptables"
+readonly network_lock_file="/run/lock/openclaw-mantis-sut-network.lock"
+readonly network_state_root="/run/openclaw-mantis-sut-networks"
+
+die() {
+  echo "mantis SUT container: $*" >&2
+  exit 64
+}
+
+require_container_name() {
+  [[ "$1" =~ ^openclaw-telegram-sut-[0-9a-f-]+$ ]] || die "invalid container name"
+}
+
+require_port() {
+  if [[ ! "$1" =~ ^[0-9]+$ ]] || ((10#$1 < 1 || 10#$1 > 65535)); then
+    die "invalid port"
+  fi
+}
+
+require_positive_integer() {
+  [[ "$1" =~ ^[1-9][0-9]*$ ]] || die "invalid positive integer"
+}
+
+runtime_parent_path() {
+  realpath -e "$(<"$runtime_root_file")"
+}
+
+runtime_claim_path() {
+  printf '%s/claims/%s.claim\n' "$(runtime_parent_path)" "$1"
+}
+
+runtime_cancel_path() {
+  printf '%s/claims/%s.cancelled\n' "$(runtime_parent_path)" "$1"
+}
+
+process_start_time() {
+  local stat_text
+  stat_text="$(<"/proc/$1/stat")" || return 1
+  local after_comm="${stat_text##*) }"
+  local fields
+  read -r -a fields <<<"$after_comm"
+  [[ "${fields[19]:-}" =~ ^[0-9]+$ ]] || return 1
+  printf '%s\n' "${fields[19]}"
+}
+
+read_runtime_claim() {
+  local claim_path
+  claim_path="$(runtime_claim_path "$1")"
+  [[ -f "$claim_path" && ! -L "$claim_path" ]] || return 1
+  [[ "$(stat -c %u "$claim_path")" == "0" ]] || return 1
+  [[ "$(stat -c %a "$claim_path")" == "400" ]] || return 1
+  [[ "$(stat -c %h "$claim_path")" == "1" ]] || return 1
+  IFS=$'\t' read -r claimed_runtime claimed_pid claimed_pgid claimed_start <"$claim_path"
+  [[ "$claimed_runtime" =~ ^/tmp/openclaw-tg-crabbox-sut-[A-Za-z0-9]+$ ]] || return 1
+  [[ "$claimed_pid" =~ ^[1-9][0-9]*$ ]] || return 1
+  [[ "$claimed_pgid" =~ ^[1-9][0-9]*$ ]] || return 1
+  [[ "$claimed_start" =~ ^[1-9][0-9]*$ ]] || return 1
+}
+
+claim_process_is_active() {
+  [[ -r "/proc/$claimed_pid/stat" ]] || return 1
+  [[ "$(process_start_time "$claimed_pid")" == "$claimed_start" ]] || return 1
+  local current_pgid
+  current_pgid="$(/usr/bin/ps -o pgid= -p "$claimed_pid" | tr -d ' ')"
+  [[ "$current_pgid" == "$claimed_pgid" ]]
+}
+
+create_runtime_claim() {
+  local container_name="$1"
+  local runtime_source="$2"
+  local runtime_parent
+  runtime_parent="$(runtime_parent_path)"
+  local claim_root="$runtime_parent/claims"
+  install -d -o root -g root -m 0700 "$claim_root"
+  local claim_path="$claim_root/$container_name.claim"
+  local cancel_path="$claim_root/$container_name.cancelled"
+  [[ ! -e "$claim_path" && ! -L "$claim_path" && ! -e "$cancel_path" && ! -L "$cancel_path" ]] \
+    || die "runtime claim already exists"
+  local pgid
+  pgid="$(/usr/bin/ps -o pgid= -p $$ | tr -d ' ')"
+  [[ "$pgid" =~ ^[1-9][0-9]*$ ]] || die "invalid runtime process group"
+  local start_time
+  start_time="$(process_start_time $$)" || die "could not read runtime process identity"
+  local temp
+  temp="$(mktemp -p "$claim_root" .claim.XXXXXX)"
+  printf '%s\t%s\t%s\t%s\n' "$runtime_source" "$$" "$pgid" "$start_time" >"$temp"
+  chmod 0400 "$temp"
+  mv -T "$temp" "$claim_path"
+}
+
+cancel_runtime_claim() {
+  local container_name="$1"
+  local runtime_source="$2"
+  read_runtime_claim "$container_name" || die "missing or invalid runtime claim"
+  [[ "$claimed_runtime" == "$runtime_source" ]] || die "runtime claim path mismatch"
+  local cancel_path
+  cancel_path="$(runtime_cancel_path "$container_name")"
+  if [[ ! -e "$cancel_path" && ! -L "$cancel_path" ]]; then
+    install -o root -g root -m 0400 /dev/null "$cancel_path"
+  fi
+  if claim_process_is_active; then
+    kill -TERM -- "-$claimed_pgid" 2>/dev/null || true
+  fi
+}
+
+require_runtime_claim_active() {
+  [[ ! -e "$(runtime_cancel_path "$1")" && ! -L "$(runtime_cancel_path "$1")" ]] \
+    || die "runtime startup was cancelled"
+}
+
+container_security_args=(
+  --read-only
+  --cap-drop ALL
+  --log-driver none
+  --security-opt no-new-privileges
+  --pids-limit 512
+  --sysctl net.ipv6.conf.all.disable_ipv6=1
+  --tmpfs "/tmp:rw,nosuid,nodev,size=536870912"
+)
+
+build_resource_args=(
+  --cpus 4
+  --memory 16g
+  --memory-swap 16g
+)
+
+runtime_resource_args=(
+  --cpus 4
+  --memory 8g
+  --memory-swap 8g
+)
+
+blocked_networks=(
+  0.0.0.0/8
+  10.0.0.0/8
+  100.64.0.0/10
+  127.0.0.0/8
+  169.254.0.0/16
+  172.16.0.0/12
+  192.168.0.0/16
+  198.18.0.0/15
+  224.0.0.0/4
+  240.0.0.0/4
+)
+
+network_subnet() {
+  "$docker_bin" network inspect "$1" --format '{{(index .IPAM.Config 0).Subnet}}'
+}
+
+network_exists() {
+  local network_name="$1"
+  local names
+  if ! names="$("$docker_bin" network ls --format '{{.Name}}')"; then
+    return 2
+  fi
+  grep -Fxq "$network_name" <<<"$names" && return 0
+  return 1
+}
+
+network_state_path() {
+  [[ "$1" =~ ^[A-Za-z0-9_.-]+$ ]] || die "invalid proof network name"
+  printf '%s/%s.subnet\n' "$network_state_root" "$1"
+}
+
+write_network_state() {
+  local network_name="$1"
+  local subnet="$2"
+  local state_path
+  state_path="$(network_state_path "$network_name")"
+  install -d -o root -g root -m 0700 "$network_state_root"
+  local temp
+  temp="$(mktemp -p "$network_state_root" .subnet.XXXXXX)"
+  printf '%s\n' "$subnet" >"$temp"
+  chmod 0400 "$temp"
+  mv -T "$temp" "$state_path"
+}
+
+remove_iptables_rule() {
+  while true; do
+    if "$iptables_bin" -C "$@" 2>/dev/null; then
+      if ! "$iptables_bin" -D "$@"; then
+        if "$iptables_bin" -C "$@" 2>/dev/null; then
+          return 1
+        else
+          local recheck_result=$?
+          ((recheck_result == 1)) && return 0
+          return "$recheck_result"
+        fi
+      fi
+    else
+      local result=$?
+      ((result == 1)) && return 0
+      return "$result"
+    fi
+  done
+}
+
+with_network_lock() {
+  local operation="$1"
+  shift
+  local lock_fd
+  exec {lock_fd}>"$network_lock_file"
+  "$flock_bin" "$lock_fd"
+  local result=0
+  "$operation" "$@" || result=$?
+  exec {lock_fd}>&-
+  return "$result"
+}
+
+cleanup_network_unlocked() {
+  local network_name="$1"
+  local state_path
+  state_path="$(network_state_path "$network_name")"
+  local subnet=""
+  if [[ -e "$state_path" || -L "$state_path" ]]; then
+    [[ -f "$state_path" && ! -L "$state_path" ]] || return 1
+    [[ "$(stat -c %u "$state_path")" == "0" ]] || return 1
+    [[ "$(stat -c %a "$state_path")" == "400" ]] || return 1
+    subnet="$(<"$state_path")"
+    [[ "$subnet" =~ ^[0-9.]+/[0-9]+$ ]] || return 1
+  fi
+  local exists_result
+  if network_exists "$network_name"; then
+    exists_result=0
+  else
+    exists_result=$?
+  fi
+  if ((exists_result == 1)); then
+    [[ -n "$subnet" ]] || return 0
+  elif ((exists_result != 0)); then
+    return "$exists_result"
+  fi
+  if ((exists_result == 0)); then
+    local inspected_subnet
+    inspected_subnet="$(network_subnet "$network_name")" || return 1
+    [[ "$inspected_subnet" =~ ^[0-9.]+/[0-9]+$ ]] || return 1
+    [[ -z "$subnet" || "$subnet" == "$inspected_subnet" ]] || return 1
+    subnet="$inspected_subnet"
+    write_network_state "$network_name" "$subnet" || return 1
+    if ! "$docker_bin" network rm "$network_name" >/dev/null 2>&1; then
+      if network_exists "$network_name"; then
+        return 1
+      else
+        exists_result=$?
+        ((exists_result == 1)) || return "$exists_result"
+      fi
+    fi
+  fi
+  remove_iptables_rule INPUT -s "$subnet" -j REJECT || return 1
+  for destination in "${blocked_networks[@]}"; do
+    remove_iptables_rule DOCKER-USER -s "$subnet" -d "$destination" -j REJECT || return 1
+  done
+  rm -f "$state_path"
+}
+
+cleanup_network() {
+  with_network_lock cleanup_network_unlocked "$1"
+}
+
+container_exists() {
+  local container_name="$1"
+  local names
+  if ! names="$("$docker_bin" container ls --all --format '{{.Names}}')"; then
+    return 2
+  fi
+  grep -Fxq "$container_name" <<<"$names" && return 0
+  return 1
+}
+
+remove_container_or_fail() {
+  local container_name="$1"
+  local exists_result
+  if container_exists "$container_name"; then
+    exists_result=0
+  else
+    exists_result=$?
+  fi
+  if ((exists_result == 0)); then
+    if ! "$docker_bin" rm --force "$container_name" >/dev/null 2>&1; then
+      if container_exists "$container_name"; then
+        return 1
+      else
+        exists_result=$?
+        ((exists_result == 1)) || return "$exists_result"
+      fi
+    fi
+  elif ((exists_result != 1)); then
+    return "$exists_result"
+  fi
+  if container_exists "$container_name"; then
+    die "candidate container is still running"
+  else
+    exists_result=$?
+    ((exists_result == 1)) || return "$exists_result"
+  fi
+}
+
+create_bounded_filesystem() {
+  local name="$1"
+  local size="$2"
+  local runtime_parent
+  runtime_parent="$(realpath -e "$(<"$runtime_root_file")")"
+  local image_path="$runtime_parent/$name.ext4"
+  local mount_path="$runtime_parent/$name"
+  [[ ! -e "$image_path" && ! -e "$mount_path" ]] || die "bounded filesystem already exists"
+  /usr/bin/truncate -s "$size" "$image_path"
+  if ! /usr/sbin/mkfs.ext4 -q -F "$image_path"; then
+    rm -f "$image_path"
+    return 1
+  fi
+  if ! mkdir "$mount_path"; then
+    rm -f "$image_path"
+    return 1
+  fi
+  if ! /usr/bin/mount -o loop,nodev,nosuid "$image_path" "$mount_path"; then
+    rmdir "$mount_path"
+    rm -f "$image_path"
+    return 1
+  fi
+  printf '%s\t%s\n' "$mount_path" "$image_path"
+}
+
+destroy_bounded_filesystem() {
+  local mount_path="$1"
+  local image_path="$2"
+  if /usr/bin/mountpoint -q "$mount_path"; then
+    /usr/bin/umount "$mount_path"
+  fi
+  rm -rf --one-file-system "$mount_path"
+  rm -f "$image_path"
+}
+
+remove_claimed_runtime_input() {
+  local input_path="$1"
+  local runtime_parent="$2"
+  if [[ -L "$input_path" ]]; then
+    rm -f "$input_path"
+    return
+  fi
+  [[ -e "$input_path" ]] || return 0
+  [[ -d "$input_path" ]] || die "claimed runtime input is not a directory"
+  [[ "$(stat -c %u "$input_path")" == "$(id -u codex)" ]] \
+    || die "claimed runtime input owner mismatch"
+  [[ "$(stat -c %d "$input_path")" == "$(stat -c %d "$runtime_parent")" ]] \
+    || die "claimed runtime input filesystem mismatch"
+  rm -rf --one-file-system "$input_path"
+  [[ ! -e "$input_path" && ! -L "$input_path" ]] || die "failed to remove claimed runtime input"
+}
+
+create_public_only_network_unlocked() {
+  local network_name="$1"
+  cleanup_network_unlocked "$network_name" || return 1
+  if ! "$docker_bin" network create --driver bridge \
+    --opt com.docker.network.bridge.enable_icc=false "$network_name" >/dev/null; then
+    return 1
+  fi
+  local subnet
+  if ! subnet="$(network_subnet "$network_name")"; then
+    cleanup_network_unlocked "$network_name" || true
+    return 1
+  fi
+  if [[ ! "$subnet" =~ ^[0-9.]+/[0-9]+$ ]]; then
+    cleanup_network_unlocked "$network_name" || true
+    return 1
+  fi
+  if ! write_network_state "$network_name" "$subnet"; then
+    cleanup_network_unlocked "$network_name" || true
+    return 1
+  fi
+  if ! "$iptables_bin" -I INPUT 1 -s "$subnet" -j REJECT; then
+    cleanup_network_unlocked "$network_name" || true
+    return 1
+  fi
+  for destination in "${blocked_networks[@]}"; do
+    if ! "$iptables_bin" -I DOCKER-USER 1 -s "$subnet" -d "$destination" -j REJECT; then
+      cleanup_network_unlocked "$network_name" || true
+      return 1
+    fi
+  done
+}
+
+create_public_only_network() {
+  with_network_lock create_public_only_network_unlocked "$1"
+}
+
+require_locked_worktree() {
+  local repo_root="$1"
+  local lane="$2"
+  local worktree_root
+  worktree_root="$(realpath -e "$(<"$worktree_root_file")")"
+  [[ "$(stat -c %u "$worktree_root")" == "0" ]] || die "worktree root is not root-owned"
+  [[ "$(stat -c %a "$worktree_root")" == "700" ]] || die "worktree root mode mismatch"
+  [[ "$lane" == "baseline" || "$lane" == "candidate" ]] || die "invalid proof lane"
+  [[ "$repo_root" == "$worktree_root/$lane" ]] || die "repo root does not match the proof lane"
+  [[ "$(stat -c %u "$repo_root")" == "0" ]] || die "prepared worktree is not root-owned"
+  [[ -z "$(find "$repo_root" -xdev ! -type l -perm /222 -print -quit)" ]] \
+    || die "prepared worktree is writable"
+}
+
+expected_sha_for_lane() {
+  local lane="$1"
+  local expected_sha
+  expected_sha="$(awk -v lane="$lane" '$1 == lane { print $2 }' "$revisions_file")"
+  [[ "$expected_sha" =~ ^[0-9a-f]{40}$ ]] || die "invalid configured proof revision"
+  printf '%s\n' "$expected_sha"
+}
+
+attest_worktree() {
+  local repo_root="$1"
+  local lane="$2"
+  local expected_sha
+  expected_sha="$(expected_sha_for_lane "$lane")"
+  local actual_sha
+  actual_sha="$(/usr/bin/git -c safe.directory="$repo_root" -C "$repo_root" rev-parse HEAD)"
+  [[ "$actual_sha" == "$expected_sha" ]] || die "prepared worktree revision mismatch"
+  printf '%s\n' "$actual_sha"
+}
+
+write_root_attestation() {
+  local destination="$1"
+  local lane="$2"
+  local sha="$3"
+  if [[ -e "$destination" || -L "$destination" ]]; then
+    jq -e --arg lane "$lane" --arg sha "$sha" \
+      '.lane == $lane and .sha == $sha' "$destination" >/dev/null \
+      || die "conflicting SUT attestation"
+    return
+  fi
+  local temp
+  temp="$(mktemp -p "$(dirname "$destination")" .sut-attestation.XXXXXX)"
+  jq -n --arg lane "$lane" --arg sha "$sha" '{lane: $lane, sha: $sha}' >"$temp"
+  chmod 0444 "$temp"
+  mv -T "$temp" "$destination"
+}
+
+lock_runtime_root() {
+  local runtime_source="$1"
+  local container_name="$2"
+  [[ "$runtime_source" =~ ^/tmp/openclaw-tg-crabbox-sut-[A-Za-z0-9]+$ ]] \
+    || die "invalid runtime root"
+  [[ -d "$runtime_source" && ! -L "$runtime_source" ]] || die "runtime root is not a directory"
+  [[ "$(stat -c %u "$runtime_source")" == "$(id -u codex)" ]] || die "runtime root owner mismatch"
+  local runtime_parent
+  runtime_parent="$(realpath -e "$(<"$runtime_root_file")")"
+  [[ "$(stat -c %u "$runtime_parent")" == "0" ]] || die "runtime parent is not root-owned"
+  [[ "$(stat -c %a "$runtime_parent")" == "711" ]] || die "runtime parent mode mismatch"
+  [[ "$(stat -c %d "$runtime_source")" == "$(stat -c %d "$runtime_parent")" ]] \
+    || die "runtime input and quarantine must share a filesystem"
+  local quarantine="$runtime_parent/$container_name-input"
+  [[ ! -e "$quarantine" && ! -L "$quarantine" ]] || die "runtime quarantine already exists"
+  mv -T "$runtime_source" "$quarantine"
+  if [[ ! -d "$quarantine" || -L "$quarantine" ]]; then
+    rm -f "$quarantine"
+    die "quarantined runtime is not a directory"
+  fi
+  if [[ "$(stat -c %u "$quarantine")" != "$(id -u codex)" ]]; then
+    rm -rf --one-file-system "$quarantine"
+    die "quarantined runtime owner mismatch"
+  fi
+  local filesystem
+  if ! filesystem="$(create_bounded_filesystem "$container_name" 2G)"; then
+    rm -rf --one-file-system "$quarantine"
+    die "failed to create the bounded runtime filesystem"
+  fi
+  local safe_runtime="${filesystem%%$'\t'*}"
+  local image_path="${filesystem#*$'\t'}"
+  chown codex:codex "$safe_runtime"
+  chmod 0700 "$safe_runtime"
+  if ! /usr/sbin/runuser -u codex -- \
+    /bin/cp -a --no-dereference "$quarantine/." "$safe_runtime/"; then
+    destroy_bounded_filesystem "$safe_runtime" "$image_path"
+    rm -rf --one-file-system "$quarantine"
+    die "failed to stage the bounded runtime root"
+  fi
+  if ! rm -rf --one-file-system "$quarantine"; then
+    destroy_bounded_filesystem "$safe_runtime" "$image_path"
+    die "failed to remove the quarantined runtime input"
+  fi
+  chown root:root "$safe_runtime"
+  chmod 0755 "$safe_runtime"
+  if ! ln -s "$safe_runtime" "$runtime_source"; then
+    destroy_bounded_filesystem "$safe_runtime" "$image_path"
+    die "failed to publish locked runtime root"
+  fi
+  printf '%s\n' "$safe_runtime"
+}
+
+# The probe must reach Telegram's public edge while every host/private/metadata
+# target remains unreachable through the exact network used by candidate code.
+# shellcheck disable=SC2016
+readonly network_probe_script='
+  const dns = require("node:dns").promises;
+  const net = require("node:net");
+  const connects = (host, port) => new Promise((resolve) => {
+    const socket = net.connect({ host, port });
+    socket.setTimeout(1500);
+    socket.on("connect", () => { socket.destroy(); resolve(true); });
+    socket.on("error", () => resolve(false));
+    socket.on("timeout", () => { socket.destroy(); resolve(false); });
+  });
+  (async () => {
+    const blocked = await Promise.all([
+      connects("codex-host", Number(process.env.PROXY_PORT)),
+      connects("10.0.0.1", 80),
+      connects("100.100.100.200", 80),
+      connects("169.254.169.254", 80),
+      connects("192.168.0.1", 80),
+    ]);
+    if (blocked.some(Boolean)) process.exit(41);
+    const [telegramIp] = await dns.resolve4("api.telegram.org");
+    if (!telegramIp || !(await connects(telegramIp, 443))) process.exit(42);
+  })().catch(() => process.exit(42));
+'
+
+# Candidate lifecycle scripts run only inside the isolated build container.
+# shellcheck disable=SC2016
+readonly build_command='
+  set -eu
+  store=.mantis-pnpm-store
+  cleanup() {
+    rm -rf "$store"
+  }
+  trap cleanup EXIT INT TERM
+  corepack pnpm install --frozen-lockfile --store-dir "$store"
+  corepack pnpm build
+'
+
+run_network_probe() {
+  local network_name="$1"
+  local proxy_port="$2"
+  "$docker_bin" run --rm --network "$network_name" "${container_security_args[@]}" \
+    "${runtime_resource_args[@]}" \
+    --add-host codex-host:host-gateway \
+    --env PROXY_PORT="$proxy_port" \
+    "$image" node -e "$network_probe_script"
+  local subnet
+  subnet="$(network_subnet "$network_name")"
+  local input_packets
+  input_packets="$(
+    "$iptables_bin" -L INPUT -v -n -x \
+      | awk -v source="$subnet" '$3 == "REJECT" && $8 == source { total += $1 } END { print total + 0 }'
+  )"
+  ((input_packets > 0)) || die "host isolation rule did not observe the probe"
+  local private_packets=0
+  for destination in 10.0.0.0/8 100.64.0.0/10 169.254.0.0/16 192.168.0.0/16; do
+    local destination_packets
+    destination_packets="$(
+      "$iptables_bin" -L DOCKER-USER -v -n -x \
+        | awk -v source="$subnet" -v destination="$destination" \
+          '$3 == "REJECT" && $8 == source && $9 == destination { total += $1 } END { print total + 0 }'
+    )"
+    private_packets=$((private_packets + destination_packets))
+  done
+  ((private_packets > 0)) || die "private-network isolation rules did not observe the probe"
+}
+
+# The variables in this program are expanded inside the container, not here.
+# shellcheck disable=SC2016
+readonly sut_command='
+  set -eu
+  mock_pid=""
+  gateway_pid=""
+  cleanup() {
+    exit_code=$?
+    trap - EXIT INT TERM
+    if [ -n "$gateway_pid" ]; then kill "$gateway_pid" 2>/dev/null || true; fi
+    if [ -n "$mock_pid" ]; then kill "$mock_pid" 2>/dev/null || true; fi
+    wait 2>/dev/null || true
+    exit "$exit_code"
+  }
+  trap cleanup EXIT INT TERM
+  node scripts/e2e/mock-openai-server.mjs >"$MOCK_LOG" 2>&1 &
+  mock_pid=$!
+  attempt=0
+  until grep -q "mock-openai listening" "$MOCK_LOG" 2>/dev/null; do
+    kill -0 "$mock_pid" 2>/dev/null || exit 1
+    attempt=$((attempt + 1))
+    [ "$attempt" -lt 100 ] || exit 1
+    sleep 0.1
+  done
+  node openclaw.mjs gateway --port "$OPENCLAW_GATEWAY_PORT" >"$GATEWAY_LOG" 2>&1 &
+  gateway_pid=$!
+  wait "$gateway_pid"
+'
+
+command="${1:-}"
+shift || true
+case "$command" in
+  build)
+    [[ "${SUDO_USER:-}" == "runner" ]] || die "build is restricted to the workflow runner"
+    [[ $# -eq 1 ]] || die "build expects the candidate worktree"
+    worktree_root="$(realpath -e "$(<"$worktree_root_file")")"
+    candidate_root="$(realpath -e "$1")"
+    [[ "$candidate_root" == "$worktree_root/candidate" ]] || die "unexpected candidate worktree"
+    [[ "$(stat -c %u "$candidate_root")" == "$(id -u mantis-builder)" ]] || die "candidate owner mismatch"
+    [[ -f "$candidate_root/.git" && ! -L "$candidate_root/.git" ]] \
+      || die "candidate Git link is not a regular file"
+    [[ "$(stat -c %h "$candidate_root/.git")" == "1" ]] \
+      || die "candidate Git link must not be hard-linked"
+    (("$(stat -c %s "$candidate_root/.git")" <= 4096)) || die "candidate Git link is too large"
+    candidate_git_link="$(<"$candidate_root/.git")"
+    [[ "$candidate_git_link" == "gitdir: "* ]] || die "candidate Git link is invalid"
+    candidate_sha="$(attest_worktree "$candidate_root" candidate)"
+
+    container_name="openclaw-mantis-build-$$"
+    runtime_parent="$(realpath -e "$(<"$runtime_root_file")")"
+    build_mount="$runtime_parent/${container_name}-fs"
+    build_image="$runtime_parent/${container_name}-fs.ext4"
+    network_name="${container_name}-net"
+    published_root="$worktree_root/.candidate-built-$$"
+    [[ ! -e "$published_root" && ! -L "$published_root" ]] \
+      || die "candidate publish directory already exists"
+    # shellcheck disable=SC2329
+    cleanup_build() {
+      local result=0
+      remove_container_or_fail "$container_name" || result=$?
+      cleanup_network "$network_name" || result=$?
+      destroy_bounded_filesystem "$build_mount" "$build_image" || result=$?
+      if [[ -n "${published_root:-}" && ( -e "$published_root" || -L "$published_root" ) ]]; then
+        rm -rf --one-file-system "$published_root" || result=$?
+      fi
+      return "$result"
+    }
+    trap cleanup_build EXIT INT TERM
+    create_bounded_filesystem "${container_name}-fs" 10G >/dev/null
+    isolated_root="$build_mount/repo"
+    mkdir "$isolated_root"
+    /bin/cp -a "$candidate_root/." "$isolated_root/"
+    chown -R mantis-builder:mantis-builder "$isolated_root"
+    create_public_only_network "$network_name"
+    run_network_probe "$network_name" 9
+    /usr/bin/timeout --signal=TERM --kill-after=30s 30m \
+      "$docker_bin" run --rm --init --name "$container_name" --network "$network_name" \
+      "${container_security_args[@]}" "${build_resource_args[@]}" \
+      --mount "type=bind,src=$isolated_root,dst=$candidate_root" \
+      --workdir "$candidate_root" \
+      --user "$(id -u mantis-builder):$(id -g mantis-builder)" \
+      --env CI=1 \
+      --env COREPACK_HOME=/tmp/corepack \
+      --env GIT_COMMIT="$candidate_sha" \
+      --env HOME=/tmp/home \
+      --env OPENCLAW_BUILD_PRIVATE_QA=1 \
+      --env OPENCLAW_ENABLE_PRIVATE_QA_CLI=1 \
+      "$image" sh -c "$build_command"
+    build_result=$?
+    remove_container_or_fail "$container_name"
+    cleanup_network "$network_name"
+    build_size_mb="$(du -sm "$isolated_root" | awk '{print $1}')"
+    ((build_size_mb <= 8192)) || die "candidate build output exceeds 8 GiB"
+    [[ -f "$isolated_root/.git" && ! -L "$isolated_root/.git" ]] \
+      || die "isolated Git link is not a regular file"
+    [[ "$(stat -c %h "$isolated_root/.git")" == "1" ]] \
+      || die "isolated Git link must not be hard-linked"
+    (("$(stat -c %s "$isolated_root/.git")" <= 4096)) || die "isolated Git link is too large"
+    [[ "$(<"$isolated_root/.git")" == "$candidate_git_link" ]] \
+      || die "isolated Git link changed during build"
+    mkdir -m 0755 "$published_root"
+    /bin/cp -a --no-dereference "$isolated_root/." "$published_root/"
+    [[ -f "$published_root/.git" && ! -L "$published_root/.git" ]] \
+      || die "published Git link is not a regular file"
+    [[ "$(<"$published_root/.git")" == "$candidate_git_link" ]] \
+      || die "published Git link mismatch"
+    rm -rf --one-file-system "$candidate_root"
+    mv -T "$published_root" "$candidate_root"
+    published_root=""
+    destroy_bounded_filesystem "$build_mount" "$build_image"
+    trap - EXIT INT TERM
+    exit "$build_result"
+    ;;
+  check)
+    [[ $# -eq 1 ]] || die "check expects a proxy port"
+    require_port "$1"
+    network_name="openclaw-mantis-check-$$"
+    create_public_only_network "$network_name"
+    # shellcheck disable=SC2329
+    cleanup_check() {
+      cleanup_network "$network_name"
+    }
+    trap cleanup_check EXIT INT TERM
+    run_network_probe "$network_name" "$1"
+    check_result=$?
+    cleanup_network "$network_name"
+    trap - EXIT INT TERM
+    exit "$check_result"
+    ;;
+  run)
+    [[ $# -eq 7 ]] \
+      || die "run expects name, lane, repo root, runtime root, gateway port, mock port, and proxy port"
+    container_name="$1"
+    lane="$2"
+    repo_root="$(realpath -e "$3")"
+    runtime_source="$4"
+    gateway_port="$5"
+    mock_port="$6"
+    proxy_port="$7"
+    require_container_name "$container_name"
+    require_port "$gateway_port"
+    require_port "$mock_port"
+    require_port "$proxy_port"
+    [[ "$runtime_source" =~ ^/tmp/openclaw-tg-crabbox-sut-[A-Za-z0-9]+$ ]] \
+      || die "invalid runtime root"
+    create_runtime_claim "$container_name" "$runtime_source"
+
+    require_locked_worktree "$repo_root" "$lane"
+    attested_sha="$(attest_worktree "$repo_root" "$lane")"
+    require_runtime_claim_active "$container_name"
+    safe_runtime="$(lock_runtime_root "$runtime_source" "$container_name")"
+    require_runtime_claim_active "$container_name"
+
+    input_file="$safe_runtime/container-input.json"
+    trap 'rm -f "${input_file:-}"' EXIT
+    [[ -f "$input_file" && ! -L "$input_file" ]] || die "invalid container input"
+    [[ "$(stat -c %u "$input_file")" == "$(id -u codex)" ]] || die "container input owner mismatch"
+    [[ "$(stat -c %a "$input_file")" == "600" ]] || die "container input mode mismatch"
+    [[ "$(stat -c %h "$input_file")" == "1" ]] || die "container input must not be hard-linked"
+    for name in gateway.log mock-openai.log mock-openai-requests.ndjson sut-attestation.json; do
+      [[ ! -e "$safe_runtime/$name" && ! -L "$safe_runtime/$name" ]] \
+        || die "runtime output was pre-created"
+    done
+    write_root_attestation "$safe_runtime/sut-attestation.json" "$lane" "$attested_sha"
+    runtime_parent="$(realpath -e "$(<"$runtime_root_file")")"
+    write_root_attestation "$runtime_parent/attestations/$lane.json" "$lane" "$attested_sha"
+    success_marker="$(jq -er '.mockResponseText | strings' "$input_file")"
+    telegram_bot_token="$(jq -er '.telegramBotToken | strings' "$input_file")"
+    export SUCCESS_MARKER="$success_marker"
+    export TELEGRAM_BOT_TOKEN="$telegram_bot_token"
+    mock_response_chunk_delay_ms="$(jq -r '.mockResponseChunkDelayMs // ""' "$input_file")"
+    gateway_password="$(jq -r '.gatewayPassword // ""' "$input_file")"
+    rm -f "$input_file"
+    trap - EXIT
+
+    gateway_log="$runtime_source/gateway.log"
+    mock_log="$runtime_source/mock-openai.log"
+    request_log="$runtime_source/mock-openai-requests.ndjson"
+    install -T -o codex -g codex -m 0600 /dev/null "$safe_runtime/gateway.log"
+    install -T -o codex -g codex -m 0600 /dev/null "$safe_runtime/mock-openai.log"
+    install -T -o codex -g codex -m 0600 /dev/null "$safe_runtime/mock-openai-requests.ndjson"
+    export CI=1
+    export GATEWAY_LOG="$gateway_log"
+    export GIT_COMMIT="$attested_sha"
+    export HOME="$runtime_source/container-home"
+    export MOCK_LOG="$mock_log"
+    export MOCK_PORT="$mock_port"
+    export MOCK_REQUEST_LOG="$request_log"
+    export NODE_DISABLE_COMPILE_CACHE=1
+    export OPENAI_API_KEY=sk-openclaw-e2e-mock
+    export OPENCLAW_BUILD_PRIVATE_QA=1
+    export OPENCLAW_CONFIG_PATH="$runtime_source/openclaw.json"
+    export OPENCLAW_ENABLE_PRIVATE_QA_CLI=1
+    export OPENCLAW_GATEWAY_PORT="$gateway_port"
+    export OPENCLAW_STATE_DIR="$runtime_source/state"
+    if [[ -n "$mock_response_chunk_delay_ms" ]]; then
+      require_positive_integer "$mock_response_chunk_delay_ms"
+      export MOCK_RESPONSE_CHUNK_DELAY_MS="$mock_response_chunk_delay_ms"
+    fi
+    if [[ -n "$gateway_password" ]]; then
+      export OPENCLAW_GATEWAY_PASSWORD="$gateway_password"
+    fi
+
+    forwarded_env=(
+      CI GATEWAY_LOG GIT_COMMIT HOME MOCK_LOG MOCK_PORT MOCK_REQUEST_LOG NODE_DISABLE_COMPILE_CACHE
+      OPENAI_API_KEY OPENCLAW_BUILD_PRIVATE_QA OPENCLAW_CONFIG_PATH
+      OPENCLAW_ENABLE_PRIVATE_QA_CLI OPENCLAW_GATEWAY_PORT OPENCLAW_STATE_DIR
+      SUCCESS_MARKER TELEGRAM_BOT_TOKEN
+    )
+    [[ -z "${MOCK_RESPONSE_CHUNK_DELAY_MS:-}" ]] || forwarded_env+=(MOCK_RESPONSE_CHUNK_DELAY_MS)
+    [[ -z "${OPENCLAW_GATEWAY_PASSWORD:-}" ]] || forwarded_env+=(OPENCLAW_GATEWAY_PASSWORD)
+    docker_env=()
+    for name in "${forwarded_env[@]}"; do
+      docker_env+=(--env "$name")
+    done
+
+    network_name="${container_name}-net"
+    create_public_only_network "$network_name"
+    # shellcheck disable=SC2329
+    cleanup_run() {
+      local result=0
+      remove_container_or_fail "$container_name" || result=$?
+      cleanup_network "$network_name" || result=$?
+      return "$result"
+    }
+    trap cleanup_run EXIT INT TERM
+    run_network_probe "$network_name" "$proxy_port"
+    require_runtime_claim_active "$container_name"
+      "$docker_bin" run --rm --init --name "$container_name" --network "$network_name" \
+      "${container_security_args[@]}" "${runtime_resource_args[@]}" \
+      --mount "type=bind,src=$repo_root,dst=$repo_root,readonly" \
+      --mount "type=bind,src=$safe_runtime,dst=$runtime_source" \
+      --workdir "$repo_root" \
+      --user "$(id -u codex):$(id -g codex)" \
+      "${docker_env[@]}" \
+      "$image" sh -c "$sut_command"
+    run_result=$?
+    cleanup_network "$network_name"
+    trap - EXIT INT TERM
+    exit "$run_result"
+    ;;
+  stop)
+    [[ $# -eq 2 ]] || die "stop expects a container name and runtime root"
+    require_container_name "$1"
+    runtime_source="$2"
+    [[ "$runtime_source" =~ ^/tmp/openclaw-tg-crabbox-sut-[A-Za-z0-9]+$ ]] \
+      || die "invalid runtime source"
+    cancel_runtime_claim "$1" "$runtime_source"
+    remove_container_or_fail "$1"
+    cleanup_network "${1}-net"
+    ;;
+  destroy)
+    [[ $# -eq 2 ]] || die "destroy expects a container name and runtime root"
+    require_container_name "$1"
+    runtime_source="$2"
+    [[ "$runtime_source" =~ ^/tmp/openclaw-tg-crabbox-sut-[A-Za-z0-9]+$ ]] \
+      || die "invalid runtime source"
+    read_runtime_claim "$1" || die "missing or invalid runtime claim"
+    [[ "$claimed_runtime" == "$runtime_source" ]] || die "runtime claim path mismatch"
+    claim_process_is_active && die "refusing to destroy an active runtime claim"
+    runtime_parent="$(runtime_parent_path)"
+    runtime_root="$runtime_parent/$1"
+    if container_exists "$1"; then
+      die "refusing to destroy a running SUT container"
+    else
+      exists_result=$?
+      ((exists_result == 1)) || exit "$exists_result"
+    fi
+    if network_exists "${1}-net"; then
+      die "refusing to destroy an active SUT network"
+    else
+      exists_result=$?
+      ((exists_result == 1)) || exit "$exists_result"
+    fi
+    network_state="$(network_state_path "${1}-net")"
+    [[ ! -e "$network_state" && ! -L "$network_state" ]] \
+      || die "refusing to destroy runtime with pending network cleanup"
+    if [[ -L "$runtime_source" ]]; then
+      [[ "$(readlink "$runtime_source")" == "$runtime_root" ]] \
+        || die "invalid locked runtime symlink"
+      rm -f "$runtime_source"
+    else
+      remove_claimed_runtime_input "$runtime_source" "$runtime_parent"
+    fi
+    remove_claimed_runtime_input "$runtime_parent/$1-input" "$runtime_parent"
+    if [[ -e "$runtime_root" || -L "$runtime_root" || -e "$runtime_parent/$1.ext4" ]]; then
+      destroy_bounded_filesystem "$runtime_root" "$runtime_parent/$1.ext4"
+    fi
+    rm -f "$(runtime_cancel_path "$1")" "$(runtime_claim_path "$1")"
+    ;;
+  *) die "expected build, check, run, stop, or destroy" ;;
+esac

--- a/test/scripts/mantis-build-telegram-desktop-proof-evidence.test.ts
+++ b/test/scripts/mantis-build-telegram-desktop-proof-evidence.test.ts
@@ -17,7 +17,7 @@ afterEach(() => {
   }
 });
 
-function makeLane(name: string) {
+function makeLane(name: "baseline" | "candidate", sha: string) {
   const repo = mkdtempSync(path.join(tmpdir(), `mantis-telegram-${name}-repo-`));
   tempDirs.push(repo);
   const outputDir = path.join(repo, ".artifacts", "qa-e2e", name);
@@ -40,6 +40,7 @@ function makeLane(name: string) {
       },
       report: path.relative(repo, report),
       status: "pass",
+      sutAttestation: { lane: name, sha },
     }),
   );
   return { outputDir, repo };
@@ -47,8 +48,10 @@ function makeLane(name: string) {
 
 describe("scripts/mantis/build-telegram-desktop-proof-evidence", () => {
   it("builds paired native Telegram Desktop GIF evidence for PR comments", () => {
-    const baseline = makeLane("baseline");
-    const candidate = makeLane("candidate");
+    const baselineSha = "a".repeat(40);
+    const candidateSha = "b".repeat(40);
+    const baseline = makeLane("baseline", baselineSha);
+    const candidate = makeLane("candidate", candidateSha);
     const outputDir = mkdtempSync(path.join(tmpdir(), "mantis-telegram-proof-"));
     tempDirs.push(outputDir);
 
@@ -62,7 +65,7 @@ describe("scripts/mantis/build-telegram-desktop-proof-evidence", () => {
       "--baseline-ref",
       "main",
       "--baseline-sha",
-      "aaa",
+      baselineSha,
       "--candidate-repo-root",
       candidate.repo,
       "--candidate-output-dir",
@@ -70,7 +73,7 @@ describe("scripts/mantis/build-telegram-desktop-proof-evidence", () => {
       "--candidate-ref",
       "refs/pull/1/head",
       "--candidate-sha",
-      "bbb",
+      candidateSha,
       "--scenario-label",
       "telegram-desktop-proof",
     ]);
@@ -96,9 +99,11 @@ describe("scripts/mantis/build-telegram-desktop-proof-evidence", () => {
 
     expect(body).toContain("<!-- mantis-telegram-desktop-proof -->");
     expect(body).toContain("## Mantis Telegram Desktop Proof");
-    expect(body).toContain("- Baseline: `pass` at `aaa`, expected baseline visual proof captured");
     expect(body).toContain(
-      "- Candidate: `pass` at `bbb`, expected candidate visual proof captured",
+      `- Baseline: \`pass\` at \`${baselineSha}\`, expected baseline visual proof captured`,
+    );
+    expect(body).toContain(
+      `- Candidate: \`pass\` at \`${candidateSha}\`, expected candidate visual proof captured`,
     );
     expect(body).toContain(`- Artifact: ${artifactUrl}`);
     expect(body).toContain('<table width="100%">');
@@ -113,5 +118,33 @@ describe("scripts/mantis/build-telegram-desktop-proof-evidence", () => {
     );
     expect(body).not.toContain("undefined/");
     expect(body).not.toContain("| Main | This PR |");
+  });
+
+  it("rejects a candidate session that attests the baseline lane", () => {
+    const baselineSha = "a".repeat(40);
+    const candidateSha = "b".repeat(40);
+    const baseline = makeLane("baseline", baselineSha);
+    const candidate = makeLane("baseline", baselineSha);
+    const outputDir = mkdtempSync(path.join(tmpdir(), "mantis-telegram-proof-mismatch-"));
+    tempDirs.push(outputDir);
+
+    expect(() =>
+      writeTelegramDesktopProofEvidence([
+        "--output-dir",
+        outputDir,
+        "--baseline-repo-root",
+        baseline.repo,
+        "--baseline-output-dir",
+        baseline.outputDir,
+        "--baseline-sha",
+        baselineSha,
+        "--candidate-repo-root",
+        candidate.repo,
+        "--candidate-output-dir",
+        candidate.outputDir,
+        "--candidate-sha",
+        candidateSha,
+      ]),
+    ).toThrow("SUT attestation mismatch for candidate.");
   });
 });

--- a/test/scripts/mantis-telegram-desktop-proof-workflow.test.ts
+++ b/test/scripts/mantis-telegram-desktop-proof-workflow.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import { parse } from "yaml";
 
 const PROOF_SCRIPT = "scripts/e2e/telegram-user-crabbox-proof.ts";
+const SUT_CONTAINER_WRAPPER = "scripts/mantis/mantis-sut-container.sh";
 const CREDENTIAL_SCRIPT = "scripts/e2e/telegram-user-credential.ts";
 const USER_DRIVER = "scripts/e2e/telegram-user-driver.py";
 const QA_LAB_RUNTIME_API = "extensions/qa-lab/runtime-api.ts";
@@ -191,8 +192,9 @@ describe("Mantis Telegram Desktop proof workflow", () => {
 
     expect(proofScript).toContain("let mockPid: number | undefined;");
     expect(proofScript).toContain("let gatewayPid: number | undefined;");
-    expect(proofScript).toContain("killPidTree(gatewayPid);");
-    expect(proofScript).toContain("killPidTree(mockPid);");
+    expect(proofScript).toContain("await stopLocalSutDaemon({");
+    expect(proofScript).toContain("tempRoot: config.tempRoot,");
+    expect(proofScript).toContain("Local SUT startup failed and cleanup was incomplete.");
     expect(proofScript).toContain("throw error;");
   });
 
@@ -332,6 +334,7 @@ describe("Mantis Telegram Desktop proof workflow", () => {
       "OPENCLAW_TELEGRAM_USER_CRABBOX_BIN OPENCLAW_TELEGRAM_USER_CRABBOX_PROVIDER OPENCLAW_TELEGRAM_USER_DRIVER_SCRIPT OPENCLAW_TELEGRAM_USER_PROOF_CMD",
     );
     expect(prepare.run).toContain("MANTIS_CANDIDATE_TRUST");
+    expect(prepare.run).toContain("MANTIS_BASELINE_ROOT MANTIS_CANDIDATE_ROOT");
     expect(prepare.run).toContain("MANTIS_NODE_BIN MANTIS_PNPM_BIN");
 
     const prompt = readFileSync(PROMPT, "utf8");
@@ -341,10 +344,8 @@ describe("Mantis Telegram Desktop proof workflow", () => {
     expect(prompt).toContain("`--mock-response-chunk-delay-ms 1200`");
     expect(prompt).toContain("do not run\n   `pnpm qa:telegram-user:crabbox` directly");
     expect(prompt).toContain("Let `start` return or fail on its\n   own");
-    expect(prompt).toContain("`--mcp-app-fixture` option");
-    expect(prompt).toContain("mcp app conformance qa check");
-    expect(prompt).toContain("`companion-called` and\n   `resource-ok`");
-    expect(prompt).toContain("Reopen that same Telegram button after its ticket expires");
+    expect(prompt).toContain("MCP App Funnel proof is not supported");
+    expect(prompt).toContain("do not pass `--mcp-app-fixture`");
     expect(prompt).toContain(
       "Use a long\n   command timeout for `start`, `send`, `view`, and `finish`",
     );
@@ -358,18 +359,19 @@ describe("Mantis Telegram Desktop proof workflow", () => {
     expect(run).toContain('git fetch --no-tags origin "pull/${MANTIS_PR_NUMBER}/head"');
     expect(run).toContain('git worktree add --detach "$baseline_root" "$BASELINE_SHA"');
     expect(run).toContain('git worktree add --detach "$candidate_root" "$CANDIDATE_SHA"');
-    expect(run.match(/env -i/gu)).toHaveLength(3);
+    expect(run.match(/env -i/gu)).toHaveLength(2);
     expect(run).toContain('"$toolchain_dir/pnpm" install --frozen-lockfile');
     expect(run).toContain('"$toolchain_dir/pnpm" build');
-    expect(run).toContain("sudo -u mantis-builder env -i");
     expect(run).toContain('sudo chown -R mantis-builder:mantis-builder "$candidate_root"');
     expect(run).toContain(
-      'candidate_home="/tmp/mantis-candidate-home-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"',
+      'sudo /usr/local/sbin/openclaw-mantis-sut-container build "$candidate_root"',
     );
-    expect(run).toContain("sudo setfacl -m u:mantis-builder:--x");
-    expect(run).toContain('[ "$candidate_parent" = "/home/runner" ] && break');
+    expect(run).not.toContain("sudo -u mantis-builder");
+    expect(run).not.toContain("sudo setfacl");
     expect(run).toContain('test "$(cat "$candidate_root/.git")" = "$candidate_git_link"');
-    expect(run).toContain('git -C "$candidate_root" diff --exit-code');
+    expect(run).toContain(
+      'git -c safe.directory="$candidate_root" -C "$candidate_root" diff --exit-code',
+    );
     expect(run).not.toContain("GH_TOKEN");
     expect(run).not.toContain("OPENAI_API_KEY");
     expect(run).not.toContain("CRABBOX_");
@@ -514,9 +516,98 @@ describe("Mantis Telegram Desktop proof workflow", () => {
 
   it("does not pass the full workflow environment into the local Telegram SUT", () => {
     const proofScript = readFileSync(PROOF_SCRIPT, "utf8");
+    const prompt = readFileSync(PROMPT, "utf8");
+    const workflow = readFileSync(WORKFLOW, "utf8");
+    const wrapper = readFileSync(SUT_CONTAINER_WRAPPER, "utf8");
     expect(proofScript).toContain("function childProcessBaseEnv()");
     expect(proofScript).toContain("...childProcessBaseEnv()");
     expect(proofScript).not.toContain("...process.env,\n    OPENAI_API_KEY");
     expect(proofScript).not.toContain("...process.env,\n    MOCK_PORT");
+    expect(proofScript).toContain('process.env.MANTIS_CANDIDATE_TRUST === "fork-pr-head"');
+    expect(wrapper).toContain("network create --driver bridge");
+    expect(wrapper).toContain("--cap-drop ALL");
+    expect(wrapper).toContain("--log-driver none");
+    expect(wrapper).toContain("--memory 8g");
+    expect(wrapper).toContain("--cpus 4");
+    expect(wrapper).toContain("--memory 16g");
+    expect(proofScript).toContain("requireCodexProxyPort");
+    expect(proofScript).toContain("preserveLocalSutRuntimeArtifacts");
+    const finishSession = proofScript.slice(proofScript.indexOf("async function finishSession"));
+    expect(finishSession.indexOf("stopLocalSutDaemon(session.localSut)")).toBeLessThan(
+      finishSession.indexOf("preserveLocalSutRuntimeArtifacts(session.localSut"),
+    );
+    expect(finishSession.indexOf("preserveLocalSutRuntimeArtifacts(session.localSut")).toBeLessThan(
+      finishSession.indexOf("destroyLocalSutRuntime(session.localSut)"),
+    );
+    expect(prompt).toContain(
+      '`--sut-container --sut-lane baseline --sut-repo-root "$MANTIS_BASELINE_ROOT"`',
+    );
+    expect(prompt).toContain(
+      '`--sut-container --sut-lane candidate --sut-repo-root "$MANTIS_CANDIDATE_ROOT"`',
+    );
+    expect(prompt).toContain('--baseline-repo-root "$GITHUB_WORKSPACE"');
+    expect(prompt).toContain('--candidate-repo-root "$GITHUB_WORKSPACE"');
+    expect(workflow).toContain(
+      "sudo install -m 0755 scripts/mantis/mantis-sut-container.sh /usr/local/sbin/openclaw-mantis-sut-container",
+    );
+    expect(workflow).toContain(
+      "codex ALL=(root) NOPASSWD: /usr/local/sbin/openclaw-mantis-sut-container",
+    );
+    expect(workflow).not.toContain("NOPASSWD:SETENV:");
+    expect(workflow).toContain("/etc/openclaw-mantis-sut-revisions");
+    expect(workflow).toContain("Validate root-owned SUT attestations");
+    expect(workflow).toContain('"$runtime_parent/attestations/$lane.json"');
+    const attestationValidation = workflowStep("Validate root-owned SUT attestations").run ?? "";
+    expect(attestationValidation.indexOf(".comparison[$lane].sha == $sha")).toBeLessThan(
+      attestationValidation.indexOf('if [[ "$lane_status" == "skipped" ]]'),
+    );
+    expect(attestationValidation.indexOf('if [[ "$lane_status" == "skipped" ]]')).toBeLessThan(
+      attestationValidation.indexOf('"$runtime_parent/attestations/$lane.json"'),
+    );
+    expect(workflow).toContain('sudo chmod 0700 "$proof_worktree_root"');
+    expect(workflow).toContain('sudo chown -R root:root "$proof_worktree_root"');
+    expect(wrapper).toContain("#!/bin/bash");
+    expect(wrapper).toContain('readonly docker_bin="/usr/bin/docker"');
+    expect(wrapper).toContain('readonly flock_bin="/usr/bin/flock"');
+    expect(wrapper).toContain('readonly iptables_bin="/usr/sbin/iptables"');
+    expect(wrapper).toContain("100.64.0.0/10");
+    expect(wrapper).toContain("169.254.0.0/16");
+    expect(wrapper).toContain("api.telegram.org");
+    expect(wrapper).toContain('--network "$network_name"');
+    expect(wrapper).toContain('"$worktree_root/candidate"');
+    expect(wrapper).toContain('"${SUDO_USER:-}" == "runner"');
+    expect(wrapper).toContain("corepack pnpm install --frozen-lockfile");
+    expect(wrapper).toContain('published_root="$worktree_root/.candidate-built-$$"');
+    expect(wrapper).toContain('/bin/cp -a --no-dereference "$isolated_root/." "$published_root/"');
+    expect(wrapper).toContain('rm -rf --one-file-system "$candidate_root"');
+    expect(wrapper).not.toContain('/bin/cp -a "$isolated_root/." "$candidate_root/"');
+    expect(wrapper).toContain('filesystem="$(create_bounded_filesystem "$container_name" 2G)"');
+    expect(wrapper).toContain('mv -T "$runtime_source" "$quarantine"');
+    expect(wrapper).toContain("/usr/sbin/runuser -u codex --");
+    expect(wrapper).toContain('/bin/cp -a --no-dereference "$quarantine/." "$safe_runtime/"');
+    expect(wrapper).not.toContain('/bin/cp -a "$runtime_source/." "$safe_runtime/"');
+    expect(wrapper).toContain('create_bounded_filesystem "${container_name}-fs" 10G');
+    expect(wrapper).toContain('ln -s "$safe_runtime" "$runtime_source"');
+    expect(wrapper).toContain("refusing to destroy a running SUT container");
+    expect(wrapper).toContain('destroy_bounded_filesystem "$runtime_root"');
+    expect(wrapper).toContain('create_runtime_claim "$container_name" "$runtime_source"');
+    expect(wrapper).toContain('cancel_runtime_claim "$1" "$runtime_source"');
+    expect(wrapper).toContain("refusing to destroy an active runtime claim");
+    expect(wrapper).toContain("refusing to destroy runtime with pending network cleanup");
+    expect(wrapper).toContain('remove_claimed_runtime_input "$runtime_parent/$1-input"');
+    expect(wrapper).toContain('*) die "expected build, check, run, stop, or destroy"');
+    expect(wrapper).toContain("install -T -o codex -g codex -m 0600");
+    expect(wrapper).toContain('attested_sha="$(attest_worktree "$repo_root" "$lane")"');
+    expect(wrapper).toContain("sut-attestation.json");
+    expect(wrapper.match(/run_network_probe "\$network_name"/gu)).toHaveLength(3);
+    expect(wrapper).toContain("host isolation rule did not observe the probe");
+    expect(wrapper).toContain("remove_container_or_fail");
+    expect(wrapper).toContain('if network_exists "$network_name"; then');
+    expect(wrapper).toContain("with_network_lock create_public_only_network_unlocked");
+    expect(wrapper).toContain("with_network_lock cleanup_network_unlocked");
+    expect(wrapper).toContain('readonly network_state_root="/run/openclaw-mantis-sut-networks"');
+    expect(wrapper).toContain('write_network_state "$network_name" "$subnet"');
+    expect(wrapper).toContain('rm -f "$state_path"');
+    expect(wrapper).not.toContain("/var/run/docker.sock");
   });
 });

--- a/test/scripts/mantis-telegram-desktop-proof-workflow.test.ts
+++ b/test/scripts/mantis-telegram-desktop-proof-workflow.test.ts
@@ -350,6 +350,11 @@ describe("Mantis Telegram Desktop proof workflow", () => {
     expect(run).toContain('"$toolchain_dir/pnpm" build');
     expect(run).toContain("sudo -u mantis-builder env -i");
     expect(run).toContain('sudo chown -R mantis-builder:mantis-builder "$candidate_root"');
+    expect(run).toContain(
+      'candidate_home="/tmp/mantis-candidate-home-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"',
+    );
+    expect(run).toContain("sudo setfacl -m u:mantis-builder:--x");
+    expect(run).toContain('[ "$candidate_parent" = "/home/runner" ] && break');
     expect(run).toContain('test "$(cat "$candidate_root/.git")" = "$candidate_git_link"');
     expect(run).toContain('git -C "$candidate_root" diff --exit-code');
     expect(run).not.toContain("GH_TOKEN");

--- a/test/scripts/mantis-telegram-desktop-proof-workflow.test.ts
+++ b/test/scripts/mantis-telegram-desktop-proof-workflow.test.ts
@@ -21,7 +21,7 @@ type WorkflowStep = {
   name?: string;
   run?: string;
   uses?: string;
-  with?: Record<string, string>;
+  with?: Record<string, boolean | string>;
 };
 
 type WorkflowJob = {
@@ -92,6 +92,19 @@ describe("Mantis Telegram Desktop proof workflow", () => {
 
     expect(workflow.env?.PNPM_VERSION).toBeUndefined();
     expect(liveWorkflow.env?.PNPM_VERSION).toBeUndefined();
+  });
+
+  it("pins every harness checkout to the dispatched workflow revision", () => {
+    const workflow = parse(readFileSync(WORKFLOW, "utf8")) as Workflow;
+    const checkouts = Object.values(workflow.jobs ?? {}).flatMap((job) =>
+      (job.steps ?? []).filter((step) => step.name === "Checkout harness ref"),
+    );
+
+    expect(checkouts).toHaveLength(3);
+    for (const checkout of checkouts) {
+      expect(checkout.with?.ref).toBe("${{ github.workflow_sha }}");
+      expect(checkout.with?.["persist-credentials"]).toBe(false);
+    }
   });
 
   it("serializes all Mantis Telegram account runs without workflow concurrency cancellation", () => {

--- a/test/scripts/mantis-telegram-desktop-proof-workflow.test.ts
+++ b/test/scripts/mantis-telegram-desktop-proof-workflow.test.ts
@@ -566,6 +566,13 @@ describe("Mantis Telegram Desktop proof workflow", () => {
     );
     expect(workflow).toContain('sudo chmod 0700 "$proof_worktree_root"');
     expect(workflow).toContain('sudo chown -R root:root "$proof_worktree_root"');
+    const uploadPaths = String(
+      workflowStep("Upload Mantis Telegram desktop artifacts").with?.path ?? "",
+    );
+    expect(uploadPaths).toContain("/mantis-evidence.json");
+    expect(uploadPaths).toContain("/baseline");
+    expect(uploadPaths).toContain("/candidate");
+    expect(uploadPaths).not.toContain("session.json");
     expect(wrapper).toContain("#!/bin/bash");
     expect(wrapper).toContain('readonly docker_bin="/usr/bin/docker"');
     expect(wrapper).toContain('readonly flock_bin="/usr/bin/flock"');
@@ -592,6 +599,8 @@ describe("Mantis Telegram Desktop proof workflow", () => {
     expect(wrapper).toContain('destroy_bounded_filesystem "$runtime_root"');
     expect(wrapper).toContain('create_runtime_claim "$container_name" "$runtime_source"');
     expect(wrapper).toContain('cancel_runtime_claim "$1" "$runtime_source"');
+    expect(wrapper).toContain("terminate_runtime_claim");
+    expect(wrapper).toContain("Never reread by name here");
     expect(wrapper).toContain("refusing to destroy an active runtime claim");
     expect(wrapper).toContain("refusing to destroy runtime with pending network cleanup");
     expect(wrapper).toContain('remove_claimed_runtime_input "$runtime_parent/$1-input"');

--- a/test/scripts/telegram-user-crabbox-proof.test.ts
+++ b/test/scripts/telegram-user-crabbox-proof.test.ts
@@ -11,9 +11,12 @@ import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coerci
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   COMMAND_TIMEOUT_MS,
+  createContainerizedSutSpawnSpec,
   createCrabboxWarmupArgs,
   createOpenClawGatewaySpawnSpec,
   parseArgs,
+  processTargetExists,
+  readCodexProxyPort,
   readLogTail,
   readTelegramUserProofLogTailBytes,
   recordProbeVideo,
@@ -24,6 +27,7 @@ import {
   renderSelectDesktopChat,
   renderTailscaleSshProxy,
   runCommand,
+  runSutContainerAction,
   signalCommandTree,
   stageFullSessionArtifacts,
   startLocalSut,
@@ -87,6 +91,7 @@ async function waitFor(predicate: () => boolean, timeoutMs = 5_000): Promise<voi
 
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.unstubAllEnvs();
   for (const dir of tempDirs.splice(0)) {
     fs.rmSync(dir, { force: true, recursive: true });
   }
@@ -125,6 +130,138 @@ describe("telegram user Crabbox proof log polling", () => {
     expect(spec.args).toEqual(["openclaw", "gateway", "--port", "19042"]);
     expect(spec.options.cwd).toBe("/repo");
     expect(spec.options.shell).toBe(false);
+  });
+
+  it("routes fork SUT startup through the root-owned validating wrapper", () => {
+    const repoRoot = makeTempDir();
+    const runtimeRoot = makeTempDir();
+    const spec = createContainerizedSutSpawnSpec({
+      codexProxyPort: 43123,
+      containerName: "openclaw-telegram-sut-test",
+      gatewayEnv: {
+        TELEGRAM_BOT_TOKEN: "telegram-burner-token",
+      },
+      gatewayPort: 19042,
+      mockPort: 19043,
+      mockResponseText: "streamed response",
+      repoRoot,
+      runtimeRoot,
+      sutLane: "candidate",
+    });
+
+    expect(spec.command).toBe("sudo");
+    expect(spec.args).toContain("/usr/local/sbin/openclaw-mantis-sut-container");
+    expect(spec.args).toContain("run");
+    expect(spec.args).toContain("candidate");
+    expect(spec.args).not.toContain("docker");
+    expect(spec.args.join("\n")).not.toContain("--preserve-env");
+    expect(spec.args.join("\n")).not.toContain("CODEX_HOME");
+    expect(spec.options.env).not.toHaveProperty("CODEX_HOME");
+    expect(spec.options.env).not.toHaveProperty("OPENAI_API_KEY");
+    expect(spec.options.env).not.toHaveProperty("TELEGRAM_BOT_TOKEN");
+    expect(fs.statSync(spec.inputPath).mode & 0o777).toBe(0o600);
+    expect(JSON.parse(fs.readFileSync(spec.inputPath, "utf8"))).toEqual({
+      mockResponseText: "streamed response",
+      telegramBotToken: "telegram-burner-token",
+    });
+  });
+
+  it("reads only the loopback Responses proxy port from Codex config", () => {
+    const codexHome = makeTempDir();
+    fs.writeFileSync(
+      path.join(codexHome, "config.toml"),
+      '[model_providers.codex-action-responses-proxy]\nbase_url = "http://127.0.0.1:43123/v1"\n',
+    );
+    expect(readCodexProxyPort(codexHome)).toBe(43123);
+    fs.writeFileSync(
+      path.join(codexHome, "config.toml"),
+      '[model_providers.codex-action-responses-proxy]\nbase_url = "https://api.openai.com/v1"\n',
+    );
+    expect(readCodexProxyPort(codexHome)).toBeUndefined();
+  });
+
+  it("requires successful privileged SUT teardown commands", () => {
+    const run = vi.fn(() => ({ signal: null, status: 0, stderr: "" }));
+    runSutContainerAction(
+      "stop",
+      "openclaw-telegram-sut-test",
+      "/tmp/openclaw-tg-crabbox-sut-test",
+      run,
+    );
+    expect(run).toHaveBeenCalledWith(
+      "sudo",
+      [
+        "-n",
+        "/usr/local/sbin/openclaw-mantis-sut-container",
+        "stop",
+        "openclaw-telegram-sut-test",
+        "/tmp/openclaw-tg-crabbox-sut-test",
+      ],
+      expect.objectContaining({ encoding: "utf8", stdio: "pipe" }),
+    );
+
+    expect(() =>
+      runSutContainerAction(
+        "destroy",
+        "openclaw-telegram-sut-test",
+        "/tmp/openclaw-tg-crabbox-sut-test",
+        () => ({ signal: null, status: 1, stderr: "destroy failed" }),
+      ),
+    ).toThrow("destroy failed with exit code 1.\ndestroy failed");
+    expect(() =>
+      runSutContainerAction(
+        "stop",
+        "openclaw-telegram-sut-test",
+        "/tmp/openclaw-tg-crabbox-sut-test",
+        () => ({ signal: "SIGKILL", status: null, stderr: "" }),
+      ),
+    ).toThrow("stop was terminated by SIGKILL");
+    expect(() =>
+      runSutContainerAction(
+        "stop",
+        "openclaw-telegram-sut-test",
+        "/tmp/openclaw-tg-crabbox-sut-test",
+        () => ({ error: new Error("spawn failed"), status: null }),
+      ),
+    ).toThrow("Failed to stop container-isolated SUT: spawn failed");
+  });
+
+  it("treats permission-denied process probes as alive", () => {
+    const kill = vi.spyOn(process, "kill");
+    kill.mockImplementation(() => {
+      throw Object.assign(new Error("not permitted"), { code: "EPERM" });
+    });
+    expect(processTargetExists(1234)).toBe(true);
+
+    kill.mockImplementation(() => {
+      throw Object.assign(new Error("gone"), { code: "ESRCH" });
+    });
+    expect(processTargetExists(1234)).toBe(false);
+
+    kill.mockImplementation(() => {
+      throw Object.assign(new Error("unexpected"), { code: "EINVAL" });
+    });
+    expect(() => processTargetExists(1234)).toThrow("unexpected");
+  });
+
+  it("forces fork candidates into the isolated SUT container", () => {
+    vi.stubEnv("MANTIS_CANDIDATE_TRUST", "fork-pr-head");
+    expect(() => parseArgs(["start"])).toThrow(
+      "container proof requires --sut-repo-root and --sut-lane.",
+    );
+    expect(
+      parseArgs(["start", "--sut-lane", "candidate", "--sut-repo-root", "/prepared/candidate"]),
+    ).toMatchObject({
+      sutContainer: true,
+      sutLane: "candidate",
+      sutRepoRoot: "/prepared/candidate",
+    });
+    expect(() => parseArgs([])).toThrow("--sut-container requires the held-session start flow.");
+    vi.stubEnv("MANTIS_CANDIDATE_TRUST", "open-pr-head");
+    expect(parseArgs(["start"]).sutContainer).toBe(false);
+    expect(() => parseArgs(["start", "--sut-container"])).toThrow(
+      "container proof requires --sut-repo-root and --sut-lane.",
+    );
   });
 
   it("allows cold remote setup to outlive ordinary command timeouts", () => {
@@ -240,6 +377,16 @@ describe("telegram user Crabbox proof log polling", () => {
     expect(() => parseArgs(["--mcp-app-fixture"])).toThrow(
       "--mcp-app-fixture is available only for start sessions.",
     );
+    expect(() =>
+      parseArgs([
+        "start",
+        "--mcp-app-fixture",
+        "--sut-lane",
+        "baseline",
+        "--sut-repo-root",
+        "/prepared/baseline",
+      ]),
+    ).toThrow("--mcp-app-fixture is unavailable for container-isolated SUT proof.");
     expect(() => parseArgs(["start", "--mcp-app-fixture", "--id", "cbx_reused"])).toThrow(
       "--mcp-app-fixture requires a fresh lifecycle-owned Crabbox lease.",
     );


### PR DESCRIPTION
Related: #114429
Related: #114125

## What Problem This Solves

Repairs Mantis Telegram proof when the candidate is a worktree and makes that proof safe for fork code. The prior harness could fail on workspace traversal or stale toolchain/config injection, and its candidate install/runtime shared a host with the credentialed Codex Responses proxy.

## Why This Change Was Made

The harness now builds and runs candidate code in root-mediated, resource-bounded Docker containers. Candidate source is read-only at runtime; build/runtime writes live on capped ext4 loop filesystems; Docker logs are disabled; outbound traffic is limited to public networks and verified against the exact network counters; host, RFC1918, CGNAT, link-local, and metadata routes are rejected.

The wrapper binds every run to root-owned lane/SHA attestations, atomically quarantines the agent-owned runtime input, copies it only as the unprivileged user, publishes build output through a fresh destination, and uses claim/cancellation plus retryable network/subnet ledgers for teardown. `linkPreview:false` is now a supported proof input, and the pinned harness toolchain/config works from prepared worktrees.

## User Impact

Maintainer-dispatched Telegram Desktop proof can safely install, build, and run fork candidates from prepared worktrees, including streamed-link-preview scenarios. This changes QA infrastructure only.

## Evidence

- Main defect proof for the old harness: run 30250804602 reached candidate preparation and failed with `Permission denied`; run 30253412586 crossed worktree preparation but was stopped when fork code was found beside the credentialed Responses proxy.
- `node scripts/run-vitest.mjs test/scripts/mantis-build-telegram-desktop-proof-evidence.test.ts test/scripts/mantis-telegram-desktop-proof-workflow.test.ts test/scripts/telegram-user-crabbox-proof.test.ts` — 67 passed on the final local diff.
- `bash -n` + ShellCheck + actionlint + `git diff --check` — passed on the final diff.
- Testbox 30265805897 — malicious destination-symlink publish probe left the root-owned target unchanged; isolated build and changed gates passed.
- Testbox 30269438297 — two consecutive exact public-only network/counter probes passed and left no subnet ledger.
- Testbox 30266921728 — hosted focused suites: 67 passed.
- Codex autoreview — no accepted/actionable findings on the final diff.
- Independent adversarial refuter — `NO-ACTIONABLE-OBJECTION` on the final diff.
