### PR TITLE
fix(cli): recover from stale session bindings

### DIFF
--- a/src/agents/command/session-store.test.ts
+++ b/src/agents/command/session-store.test.ts
@@ -3191,18 +3191,17 @@ describe("clearCliSessionInStore", () => {
   it("reports no clear and preserves a replacement CLI binding", async () => {
     await withTempSessionStore(async ({ storePath }) => {
       const sessionKey = "agent:main:explicit:test-clear-cli-replaced";
-      const sessionStore: Record<string, SessionEntry> = {
-        [sessionKey]: {
-          sessionId: "openclaw-session-1",
-          updatedAt: 1,
-          cliSessionBindings: {
-            "claude-cli": { sessionId: "stale-cli-session" },
-          },
+      const sessionEntry: SessionEntry = {
+        sessionId: "openclaw-session-1",
+        updatedAt: 1,
+        cliSessionBindings: {
+          "claude-cli": { sessionId: "stale-cli-session" },
         },
       };
+      const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
       await seedSessionStore(storePath, {
         [sessionKey]: {
-          ...sessionStore[sessionKey],
+          ...sessionEntry,
           updatedAt: 2,
           cliSessionBindings: {
             "claude-cli": { sessionId: "replacement-cli-session" },

--- a/src/agents/command/session-store.test.ts
+++ b/src/agents/command/session-store.test.ts
@@ -3187,5 +3187,46 @@ describe("clearCliSessionInStore", () => {
       expect(loadPersistedSessionEntry(storePath, sessionKey)).toBeUndefined();
     });
   });
+
+  it("reports no clear and preserves a replacement CLI binding", async () => {
+    await withTempSessionStore(async ({ storePath }) => {
+      const sessionKey = "agent:main:explicit:test-clear-cli-replaced";
+      const sessionStore: Record<string, SessionEntry> = {
+        [sessionKey]: {
+          sessionId: "openclaw-session-1",
+          updatedAt: 1,
+          cliSessionBindings: {
+            "claude-cli": { sessionId: "stale-cli-session" },
+          },
+        },
+      };
+      await seedSessionStore(storePath, {
+        [sessionKey]: {
+          ...sessionStore[sessionKey],
+          updatedAt: 2,
+          cliSessionBindings: {
+            "claude-cli": { sessionId: "replacement-cli-session" },
+          },
+        },
+      });
+
+      await expect(
+        clearCliSessionInStore({
+          provider: "claude-cli",
+          sessionKey,
+          sessionStore,
+          storePath,
+          expectedCliSessionId: "stale-cli-session",
+        }),
+      ).resolves.toBeUndefined();
+      expect(sessionStore[sessionKey]?.cliSessionBindings?.["claude-cli"]?.sessionId).toBe(
+        "stale-cli-session",
+      );
+      expect(
+        loadPersistedSessionEntry(storePath, sessionKey)?.cliSessionBindings?.["claude-cli"]
+          ?.sessionId,
+      ).toBe("replacement-cli-session");
+    });
+  });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/agents/command/session-store.ts
+++ b/src/agents/command/session-store.ts
@@ -328,6 +328,7 @@ export async function clearCliSessionInStore(params: {
     return undefined;
   }
 
+  let didClear = false;
   const persisted = await patchSessionEntry(
     {
       storePath,
@@ -349,14 +350,16 @@ export async function clearCliSessionInStore(params: {
       const next = { ...currentEntry };
       clearCliSession(next, provider);
       next.updatedAt = Date.now();
+      didClear = true;
       return next;
     },
     { fallbackEntry: entry },
   );
-  if (persisted) {
+  if (persisted && didClear) {
     sessionStore[sessionKey] = persisted;
+    return persisted;
   }
-  return persisted ?? undefined;
+  return undefined;
 }
 
 /** Clears the one-shot fork marker before the resumed CLI process starts. */

--- a/src/auto-reply/reply/agent-runner-cli-candidate.ts
+++ b/src/auto-reply/reply/agent-runner-cli-candidate.ts
@@ -10,6 +10,10 @@ import {
 } from "../../agents/run-termination.js";
 import { withLocalSessionPlacementTurnAdmission } from "../../agents/session-placement-admission.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import {
+  getGeneratedMediaTaskIdsForSessionKey,
+  hasNewGeneratedMediaTaskForSessionKey,
+} from "../../tasks/task-status-access.js";
 import type { ThinkLevel } from "../thinking.js";
 import type { ReplyPayload } from "../types.js";
 import {
@@ -24,6 +28,7 @@ import {
   keepCliSessionBindingOnlyWhenReused,
   runCliAgentWithLifecycle,
 } from "./agent-runner-cli-dispatch.js";
+import { createCliSessionRecoveryCallbacks } from "./agent-runner-cli-session-recovery.js";
 import type { AgentTurnParams } from "./agent-runner-execution.types.js";
 import type { createAgentTurnPresentation } from "./agent-runner-presentation.js";
 import type { AgentTurnTimingTracker } from "./agent-runner-turn-timing.js";
@@ -77,6 +82,17 @@ export async function runCliFallbackCandidate(params: {
     turn.getActiveSessionEntry(),
     params.cliExecutionProvider,
   );
+  const mediaTaskIdsBefore = getGeneratedMediaTaskIdsForSessionKey(turn.sessionKey);
+  const cliSessionRecovery = createCliSessionRecoveryCallbacks({
+    provider: params.cliExecutionProvider,
+    binding: cliSessionBinding,
+    sessionKey: turn.sessionKey,
+    sessionStore: turn.activeSessionStore,
+    storePath: turn.storePath,
+    getActiveSessionEntry: turn.getActiveSessionEntry,
+    hasCommittedMedia: () =>
+      hasNewGeneratedMediaTaskForSessionKey(turn.sessionKey, mediaTaskIdsBefore),
+  });
   const cliLifecycleStartedAt = Date.now();
   const lifecycleBackstop = createAgentLifecycleTerminalBackstop({
     runId: params.runId,
@@ -217,6 +233,7 @@ export async function runCliFallbackCandidate(params: {
           onFastModeAutoProgress: async (payload) => {
             await turn.opts?.onToolResult?.(payload);
           },
+          onErrorBeforeLifecycle: cliSessionRecovery.onErrorBeforeLifecycle,
           transformResult:
             turn.followupRun.currentInboundEventKind === "room_event"
               ? (resultLocal) =>
@@ -277,6 +294,7 @@ export async function runCliFallbackCandidate(params: {
             ownerNumbers: turn.followupRun.run.ownerNumbers,
             cliSessionId: cliSessionBinding?.sessionId,
             cliSessionBinding,
+            onBeforeFreshCliSessionRetry: cliSessionRecovery.onBeforeFreshCliSessionRetry,
             authProfileId: authProfile.authProfileId,
             bootstrapContextMode: turn.opts?.bootstrapContextMode,
             bootstrapContextRunKind: params.bootstrapContextRunKind,

--- a/src/auto-reply/reply/agent-runner-cli-dispatch.test.ts
+++ b/src/auto-reply/reply/agent-runner-cli-dispatch.test.ts
@@ -3,6 +3,9 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { EmbeddedAgentRunResult } from "../../agents/embedded-agent-runner/types.js";
 import { FailoverError } from "../../agents/failover-error.js";
 import { createAgentRunRestartAbortError } from "../../agents/run-termination.js";
+import type { SessionEntry } from "../../config/sessions.js";
+import { loadSessionEntry, replaceSessionEntry } from "../../config/sessions/session-accessor.js";
+import { useTempSessionsFixture } from "../../config/sessions/test-helpers.js";
 import {
   emitAgentEvent,
   getAgentEventLifecycleGeneration,
@@ -14,6 +17,7 @@ import {
   keepCliSessionBindingOnlyWhenReused,
   runCliAgentWithLifecycle,
 } from "./agent-runner-cli-dispatch.js";
+import { createCliSessionRecoveryCallbacks } from "./agent-runner-cli-session-recovery.js";
 
 type RunCliAgentWithLifecycleParams = Parameters<typeof runCliAgentWithLifecycle>[0];
 type ReasoningTextPayload = Parameters<
@@ -605,6 +609,134 @@ describe("runCliAgentWithLifecycle", () => {
       livenessState: "paused",
       stopReason: "end_turn",
     });
+  });
+});
+
+describe("createCliSessionRecoveryCallbacks", () => {
+  const fixture = useTempSessionsFixture("cli-session-recovery-cas-");
+
+  it("leaves fresh retry policy unchanged when session persistence is unavailable", () => {
+    expect(
+      createCliSessionRecoveryCallbacks({
+        provider: "claude-cli",
+        binding: { sessionId: "storeless" },
+        getActiveSessionEntry: () => undefined,
+        hasCommittedMedia: () => false,
+      }),
+    ).toEqual({});
+  });
+
+  it("does not clear a binding before fresh retry after detached media", async () => {
+    const sessionKey = "media";
+    const mediaSessionId = "media-owned";
+    const activeEntry: SessionEntry = {
+      sessionId: "openclaw-media-session",
+      updatedAt: 1,
+      cliSessionBindings: { "claude-cli": { sessionId: mediaSessionId } },
+    };
+    const sessionStore = { [sessionKey]: activeEntry };
+    await replaceSessionEntry({ sessionKey, storePath: fixture.storePath() }, activeEntry);
+    const callbacks = createCliSessionRecoveryCallbacks({
+      provider: "claude-cli",
+      binding: { sessionId: mediaSessionId },
+      sessionKey,
+      sessionStore,
+      storePath: fixture.storePath(),
+      getActiveSessionEntry: () => activeEntry,
+      hasCommittedMedia: () => true,
+    });
+    expect(
+      await callbacks.onBeforeFreshCliSessionRetry?.({
+        provider: "claude-cli",
+        reason: "session_expired",
+        sessionId: mediaSessionId,
+      }),
+    ).toBe(false);
+    expect(activeEntry.cliSessionBindings?.["claude-cli"]?.sessionId).toBe(mediaSessionId);
+  });
+
+  it("clears the expected fork binding only before a fresh retry", async () => {
+    const sessionKey = "fork";
+    const forkSessionId = "fork-source-cli-session";
+    const activeEntry: SessionEntry = {
+      sessionId: "openclaw-fork-session",
+      updatedAt: 1,
+      cliSessionBindings: {
+        "claude-cli": { sessionId: forkSessionId, forkNextResume: true },
+      },
+    };
+    const sessionStore = { [sessionKey]: activeEntry };
+    await replaceSessionEntry({ sessionKey, storePath: fixture.storePath() }, activeEntry);
+    const callbacks = createCliSessionRecoveryCallbacks({
+      provider: "claude-cli",
+      binding: { sessionId: forkSessionId, forkNextResume: true },
+      sessionKey,
+      sessionStore,
+      storePath: fixture.storePath(),
+      getActiveSessionEntry: () => activeEntry,
+      hasCommittedMedia: () => false,
+    });
+
+    expect(callbacks.onErrorBeforeLifecycle).toBeUndefined();
+    await expect(
+      callbacks.onBeforeFreshCliSessionRetry?.({
+        provider: "claude-cli",
+        reason: "session_expired",
+        sessionId: forkSessionId,
+      }),
+    ).resolves.toBe(true);
+    expect(activeEntry.cliSessionBindings?.["claude-cli"]).toBeUndefined();
+    expect(
+      loadSessionEntry({ sessionKey, storePath: fixture.storePath() })?.cliSessionBindings,
+    ).toBe(undefined);
+  });
+
+  it("preserves a replacement binding installed after callback creation", async () => {
+    const sessionKey = "main";
+    const staleSessionId = "stale-cli-session";
+    const activeEntry: SessionEntry = {
+      sessionId: "openclaw-session",
+      updatedAt: 1,
+      cliSessionBindings: { "claude-cli": { sessionId: staleSessionId } },
+    };
+    const sessionStore = { [sessionKey]: activeEntry };
+    await replaceSessionEntry({ sessionKey, storePath: fixture.storePath() }, activeEntry);
+    const callbacks = createCliSessionRecoveryCallbacks({
+      provider: "claude-cli",
+      binding: { sessionId: staleSessionId },
+      sessionKey,
+      sessionStore,
+      storePath: fixture.storePath(),
+      getActiveSessionEntry: () => activeEntry,
+      hasCommittedMedia: () => false,
+    });
+    await replaceSessionEntry(
+      { sessionKey, storePath: fixture.storePath() },
+      {
+        ...activeEntry,
+        updatedAt: 2,
+        cliSessionBindings: { "claude-cli": { sessionId: "replacement-cli-session" } },
+      },
+    );
+    expect(
+      loadSessionEntry({ sessionKey, storePath: fixture.storePath() })?.cliSessionBindings?.[
+        "claude-cli"
+      ]?.sessionId,
+    ).toBe("replacement-cli-session");
+
+    await expect(
+      callbacks.onBeforeFreshCliSessionRetry?.({
+        provider: "claude-cli",
+        reason: "session_expired",
+        sessionId: staleSessionId,
+      }),
+    ).resolves.toBe(false);
+    expect(activeEntry.cliSessionBindings?.["claude-cli"]?.sessionId).toBe(staleSessionId);
+    expect(
+      loadSessionEntry({ sessionKey, storePath: fixture.storePath() })?.cliSessionBindings?.[
+        "claude-cli"
+      ]?.sessionId,
+    ).toBe("replacement-cli-session");
   });
 });
 

--- a/src/auto-reply/reply/agent-runner-cli-session-recovery.ts
+++ b/src/auto-reply/reply/agent-runner-cli-session-recovery.ts
@@ -1,0 +1,129 @@
+import { isClaudeCliProvider } from "../../agents/cli-runner/helpers.js";
+import type { RunCliAgentParams } from "../../agents/cli-runner/types.js";
+import { clearCliSession, getCliSessionId } from "../../agents/cli-session.js";
+import { clearCliSessionInStore } from "../../agents/command/session-store.js";
+import { isFailoverError } from "../../agents/failover-error.js";
+import type { CliSessionBinding, SessionEntry } from "../../config/sessions.js";
+import { formatErrorMessage, readErrorName } from "../../infra/errors.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
+
+const log = createSubsystemLogger("auto-reply/cli-session-recovery");
+
+type CliSessionRecoveryParams = {
+  provider: string;
+  binding?: CliSessionBinding;
+  sessionKey?: string;
+  sessionStore?: Record<string, SessionEntry>;
+  storePath?: string;
+  getActiveSessionEntry: () => SessionEntry | undefined;
+  hasCommittedMedia: () => boolean;
+};
+
+type CliSessionRecoveryCallbacks = {
+  onErrorBeforeLifecycle?: (error: unknown) => Promise<void>;
+  onBeforeFreshCliSessionRetry?: RunCliAgentParams["onBeforeFreshCliSessionRetry"];
+};
+
+/**
+ * Clears exactly the binding observed by this run, then mirrors the persisted
+ * timestamp into still-matching in-memory entries. A newer binding wins the CAS.
+ */
+async function clearExpectedCliSessionBinding(params: {
+  provider: string;
+  expectedCliSessionId: string;
+  sessionKey?: string;
+  sessionStore?: Record<string, SessionEntry>;
+  storePath?: string;
+  activeSessionEntry?: SessionEntry;
+}): Promise<boolean> {
+  const {
+    provider,
+    expectedCliSessionId,
+    sessionKey,
+    sessionStore,
+    storePath,
+    activeSessionEntry,
+  } = params;
+  if (!sessionKey || !sessionStore || !storePath) {
+    return false;
+  }
+  const storedEntry = sessionStore[sessionKey];
+  if (
+    !storedEntry?.sessionId ||
+    getCliSessionId(storedEntry, provider) !== expectedCliSessionId ||
+    (activeSessionEntry !== undefined &&
+      getCliSessionId(activeSessionEntry, provider) !== undefined &&
+      getCliSessionId(activeSessionEntry, provider) !== expectedCliSessionId)
+  ) {
+    return false;
+  }
+
+  try {
+    const cleared = await clearCliSessionInStore({
+      provider,
+      sessionKey,
+      sessionStore,
+      storePath,
+      expectedSessionId: storedEntry.sessionId,
+      expectedCliSessionId,
+    });
+    if (!cleared) {
+      return false;
+    }
+    const entries = new Set([storedEntry, activeSessionEntry].filter(Boolean));
+    for (const entry of entries) {
+      if (getCliSessionId(entry, provider) === expectedCliSessionId) {
+        clearCliSession(entry, provider);
+        entry.updatedAt = cleared.updatedAt;
+      }
+    }
+    return true;
+  } catch (error) {
+    log.warn(`failed to clear stale CLI session binding: ${formatErrorMessage(error)}`);
+    return false;
+  }
+}
+
+export function createCliSessionRecoveryCallbacks(
+  params: CliSessionRecoveryParams,
+): CliSessionRecoveryCallbacks {
+  const sessionId = params.binding?.sessionId;
+  const { sessionKey, sessionStore, storePath } = params;
+  if (!sessionId || !sessionKey || !sessionStore || !storePath) {
+    return {};
+  }
+
+  const clear = (provider: string, expectedCliSessionId: string) => {
+    // Detached media owns this turn; replaying it fresh can duplicate side effects.
+    if (params.hasCommittedMedia()) {
+      return Promise.resolve(false);
+    }
+    return clearExpectedCliSessionBinding({
+      provider,
+      expectedCliSessionId,
+      sessionKey,
+      sessionStore,
+      storePath,
+      activeSessionEntry: params.getActiveSessionEntry(),
+    });
+  };
+
+  const callbacks: CliSessionRecoveryCallbacks = {
+    onBeforeFreshCliSessionRetry: ({ provider, sessionId: retrySessionId }) =>
+      clear(provider, retrySessionId),
+  };
+  if (params.binding?.forkNextResume === true) {
+    // A fresh retry may clear the exact failed fork binding, but terminal
+    // cleanup must leave an armed fork for its owning lifecycle to recover.
+    return callbacks;
+  }
+  callbacks.onErrorBeforeLifecycle = async (error) => {
+    if (
+      isClaudeCliProvider(params.provider) &&
+      (isFailoverError(error) || readErrorName(error) === "AbortError")
+    ) {
+      await clear(params.provider, sessionId);
+    }
+  };
+  return callbacks;
+}

--- a/src/auto-reply/reply/agent-runner-cli-session-recovery.ts
+++ b/src/auto-reply/reply/agent-runner-cli-session-recovery.ts
@@ -70,7 +70,11 @@ async function clearExpectedCliSessionBinding(params: {
     if (!cleared) {
       return false;
     }
-    const entries = new Set([storedEntry, activeSessionEntry].filter(Boolean));
+    const entries = new Set(
+      [storedEntry, activeSessionEntry].filter(
+        (entry): entry is SessionEntry => entry !== undefined,
+      ),
+    );
     for (const entry of entries) {
       if (getCliSessionId(entry, provider) === expectedCliSessionId) {
         clearCliSession(entry, provider);

--- a/src/auto-reply/reply/agent-runner-execution-cli-sessions.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-cli-sessions.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { SessionEntry } from "../../config/sessions.js";
+import { loadSessionEntry, replaceSessionEntry } from "../../config/sessions/session-accessor.js";
+import { useTempSessionsFixture } from "../../config/sessions/test-helpers.js";
 import type { TemplateContext } from "../templating.js";
 import { SILENT_REPLY_TOKEN } from "../tokens.js";
 import {
@@ -18,6 +20,8 @@ import type { FallbackRunnerParams } from "./agent-runner-execution.test-support
 const state = setupAgentRunnerExecutionTestState();
 
 describe("executeAgentTurn: CLI session routing", () => {
+  const fixture = useTempSessionsFixture("agent-runner-cli-fresh-retry-");
+
   it("forwards the static extra system prompt to CLI backends", async () => {
     state.isCliProviderMock.mockReturnValue(true);
     state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({
@@ -251,6 +255,11 @@ describe("executeAgentTurn: CLI session routing", () => {
         sessionId: "existing-cli-session",
       },
     });
+    const cliRunParams = requireRecord(
+      requireMockCall(state.runCliAgentMock, 0, "CLI run params")[0],
+      "CLI run params",
+    );
+    expect(cliRunParams.onBeforeFreshCliSessionRetry).toBeUndefined();
     if (result.kind !== "success") {
       throw new Error("expected success");
     }
@@ -259,6 +268,74 @@ describe("executeAgentTurn: CLI session routing", () => {
       sessionId: "existing-cli-session",
       authProfileId: "profile",
     });
+  });
+
+  it("clears a persisted stale CLI session before a direct fresh retry succeeds", async () => {
+    state.isCliProviderMock.mockReturnValue(true);
+    state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({
+      result: await params.run("claude-cli", "claude-sonnet-4-6"),
+      provider: "claude-cli",
+      model: "claude-sonnet-4-6",
+      attempts: [],
+    }));
+    const sessionKey = "main";
+    const storePath = fixture.storePath();
+    const staleSessionId = "stale-direct-cli-session";
+    const sessionEntry: SessionEntry = {
+      sessionId: "openclaw-session",
+      updatedAt: 1,
+      cliSessionBindings: {
+        "claude-cli": { sessionId: staleSessionId },
+      },
+      cliSessionIds: { "claude-cli": staleSessionId },
+      claudeCliSessionId: staleSessionId,
+    };
+    const activeSessionStore = { [sessionKey]: sessionEntry };
+    await replaceSessionEntry({ sessionKey, storePath }, structuredClone(sessionEntry));
+    state.runCliAgentMock.mockImplementationOnce(async (rawParams: unknown) => {
+      const cliParams = requireRecord(rawParams, "CLI run params");
+      expect(cliParams.cliSessionId).toBe(staleSessionId);
+      const retry = cliParams.onBeforeFreshCliSessionRetry;
+      if (typeof retry !== "function") {
+        throw new Error("expected a fresh-session retry callback");
+      }
+
+      await expect(
+        retry({
+          provider: "claude-cli",
+          reason: "session_expired",
+          sessionId: staleSessionId,
+        }),
+      ).resolves.toBe(true);
+
+      return {
+        payloads: [{ text: "fresh direct retry succeeded" }],
+        meta: {},
+      };
+    });
+
+    const executeAgentTurn = await getExecuteAgentTurnForTest();
+    const followupRun = createFollowupRun();
+    followupRun.run.provider = "claude-cli";
+    followupRun.run.model = "claude-sonnet-4-6";
+
+    const result = await executeAgentTurn({
+      ...createMinimalRunAgentTurnParams({ followupRun }),
+      sessionKey,
+      activeSessionStore,
+      storePath,
+      getActiveSessionEntry: () => sessionEntry,
+    });
+
+    expect(result.kind).toBe("success");
+    if (result.kind !== "success") {
+      throw new Error("expected fresh retry success");
+    }
+    expect(result.runResult.payloads).toEqual([{ text: "fresh direct retry succeeded" }]);
+    expect(sessionEntry.cliSessionBindings?.["claude-cli"]).toBeUndefined();
+    expect(loadSessionEntry({ sessionKey, storePath })?.cliSessionBindings?.["claude-cli"]).toBe(
+      undefined,
+    );
   });
 
   it("keeps the first CLI session created by a room-event turn", async () => {


### PR DESCRIPTION
Closes #97887

AI-assisted: Codex was used for implementation and adversarial review. I reviewed the resulting code and understand the changed behavior.

## What Problem This Solves

Fixes an issue where inbound conversations using a CLI backend could remain pinned to a stale Claude CLI session after a Gateway restart or failover. Every later message could then retry the same dead session and fail until the persisted session entry was repaired manually.

## Why This Change Was Made

The current unified CLI candidate path now clears the exact persisted binding it observed before a fresh-session retry and after terminal CLI failover or abort errors. Cleanup compares both the OpenClaw session ID and CLI session ID, preserves concurrently installed replacement bindings, leaves storeless callers' retry policy unchanged, and refuses replay after detached media side effects.

Fork-armed bindings retain their outer lifecycle ownership: they may be cleared immediately before a fresh retry, but terminal cleanup does not consume the armed fork.

## User Impact

Inbound channel sessions can recover automatically from stale Claude CLI bindings instead of entering an indefinite failure loop. A newer binding created by another turn is not cleared by an older failed run.

## Evidence

- Candidate head `95d859b3ac8d`, rebased once onto `e1ced6de50bb` and adapted to the current unified runner boundary.
- Node 24 exact-head tests: 94/94 passed across session-store (9), CLI dispatch (26), and CLI execution/session recovery (59).
- Deterministic cases prove one guarded fresh retry after a stale terminal binding, compare-and-clear preservation of a concurrent replacement, no replay after detached media side effects, and unchanged storeless behavior.
- Targeted `oxfmt`, direct `oxlint` on every changed TypeScript file, and `git diff --check` passed.
- A real Gateway plus Claude CLI reproduction remains outstanding; the body does not claim paid-provider live proof.
