### PR TITLE
test(plugins): refresh process-stable metadata explicitly

### DIFF
--- a/src/plugins/bundled-package-channel-metadata.test.ts
+++ b/src/plugins/bundled-package-channel-metadata.test.ts
@@ -11,6 +11,7 @@ vi.mock("./bundled-dir.js", () => ({
 
 import { resolveBundledPluginsDir } from "./bundled-dir.js";
 import { findBundledPackageChannelMetadata } from "./bundled-package-channel-metadata.js";
+import { clearPluginMetadataLifecycleCaches } from "./plugin-metadata-lifecycle.js";
 
 const tempDirs: string[] = [];
 const originalBundledPluginsDir = process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;
@@ -28,6 +29,7 @@ afterEach(() => {
     process.env.OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR = originalTrustBundledPluginsDir;
   }
   cleanupTempDirs(tempDirs);
+  clearPluginMetadataLifecycleCaches();
   vi.restoreAllMocks();
   vi.mocked(resolveBundledPluginsDir).mockReset();
 });
@@ -80,7 +82,7 @@ describe("bundled package channel metadata", () => {
     });
   });
 
-  it("reflects package channel metadata edits on the next read", () => {
+  it("reflects package channel metadata edits after the metadata lifecycle is cleared", () => {
     const root = makeTempRepoRoot(tempDirs, "bpcm-fresh-");
     const extensionsRoot = path.join(root, "dist", "extensions");
     const packagePath = path.join(extensionsRoot, "matrix", "package.json");
@@ -117,6 +119,7 @@ describe("bundled package channel metadata", () => {
       },
     });
 
+    clearPluginMetadataLifecycleCaches();
     expect(findBundledPackageChannelMetadata("matrix")?.label).toBe("After");
   });
 });

--- a/src/plugins/plugin-registry.test.ts
+++ b/src/plugins/plugin-registry.test.ts
@@ -856,7 +856,7 @@ describe("plugin registry facade", () => {
     expect(manifestReadsAfterSecond).toBe(manifestReadsAfterFirst);
   });
 
-  it("does not reuse the process registry memo after profile extensions change", () => {
+  it("reloads profile extensions after the metadata lifecycle is cleared", () => {
     const stateDir = makeTempDir();
     const configDir = makeTempDir();
     const extensionsDir = path.join(configDir, "extensions");
@@ -872,6 +872,7 @@ describe("plugin registry facade", () => {
     const secondRoot = path.join(extensionsDir, "second");
     fs.mkdirSync(secondRoot, { recursive: true });
     createCandidate(secondRoot, "second");
+    clearPluginMetadataLifecycleCaches();
     const second = loadPluginRegistrySnapshotWithMetadata({ stateDir, env });
 
     expect(first.source).toBe("derived");
@@ -921,7 +922,7 @@ describe("plugin registry facade", () => {
     expectSnapshotPluginIds(second.snapshot, ["second"]);
   });
 
-  it("does not reuse the process registry memo after the persisted registry file changes", async () => {
+  it("reloads externally changed persisted state after the metadata lifecycle is cleared", async () => {
     const stateDir = makeTempDir();
     const env = hermeticEnv();
     await writePersistedInstalledPluginIndex(createPersistableIndex("first"), { stateDir });
@@ -947,6 +948,7 @@ describe("plugin registry facade", () => {
       },
       { env: { ...env, OPENCLAW_STATE_DIR: stateDir } },
     );
+    clearPluginMetadataLifecycleCaches();
     const second = loadPluginRegistrySnapshotWithMetadata({ stateDir, env });
 
     expect(first.source).toBe("persisted");


### PR DESCRIPTION
## What Problem This Solves

Resolves release-only Plugin Prerelease failures where tests expected plugin metadata to refresh immediately after direct filesystem or SQLite mutations, even though plugin metadata is intentionally process-stable.

## Why This Change Was Made

The tests now exercise the supported lifecycle boundary: mutate metadata, explicitly clear plugin metadata lifecycle caches, then assert the next read observes the change. Bundled channel metadata cleanup also clears the lifecycle cache between tests.

AI-assisted: yes.

## User Impact

No runtime product change. Release validation now tests the documented restart/reload contract instead of relying on unsupported request-time filesystem freshness.

## Evidence

- `node scripts/run-vitest.mjs src/plugins/plugin-registry.test.ts src/plugins/bundled-package-channel-metadata.test.ts` — 24 tests passed
- `CI=true node scripts/run-vitest.mjs run --config test/vitest/vitest.plugins.config.ts` — the three lifecycle failures are gone; remaining local-only failures were unrelated macOS `/var` canonicalization and npm pack scan behavior
- `git diff --check`
- Autoreview: clean, no accepted/actionable findings
- Reproduced twice in Plugin Prerelease child run 30251065917 before the fix

