### PR TITLE
fix(gateway): stop listing IDENTITY.md as a core file editor tab

### DIFF
--- a/src/gateway/server-methods/agents-mutate.test.ts
+++ b/src/gateway/server-methods/agents-mutate.test.ts
@@ -2947,17 +2947,34 @@ describe("agents.files.list", () => {
 
   // Pins the derivation: a private copy of this list in the gateway is what let a
   // retired file linger in the Control UI as a permanently-missing tab.
-  it("lists exactly the canonical workspace bootstrap filenames", async () => {
+  it("lists the canonical workspace filenames except IDENTITY.md", async () => {
     const names = await listAgentFileNames();
-    expect(names).toStrictEqual([...WORKSPACE_BOOTSTRAP_FILENAMES]);
+    expect(names).toStrictEqual(
+      WORKSPACE_BOOTSTRAP_FILENAMES.filter((name) => name !== "IDENTITY.md"),
+    );
   });
 
   it("lists the canonical filenames without BOOTSTRAP.md once setup completed", async () => {
     mocks.isWorkspaceSetupCompleted.mockResolvedValue(true);
     const names = await listAgentFileNames();
     expect(names).toStrictEqual(
-      WORKSPACE_BOOTSTRAP_FILENAMES.filter((name) => name !== "BOOTSTRAP.md"),
+      WORKSPACE_BOOTSTRAP_FILENAMES.filter(
+        (name) => name !== "IDENTITY.md" && name !== "BOOTSTRAP.md",
+      ),
     );
+  });
+
+  // The identity form owns this file via agents.update; raw writes stay available
+  // so removing the editor tab does not remove the capability.
+  it("still accepts direct IDENTITY.md writes even though it is not listed", async () => {
+    const { respond, promise } = makeCall("agents.files.set", {
+      agentId: "main",
+      name: "IDENTITY.md",
+      content: "- Name: Ada\n",
+    });
+    await promise;
+
+    expectRespondOk(respond, { ok: true });
   });
 
   it("rejects writes to retired HEARTBEAT.md workspace files", async () => {

--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -101,7 +101,13 @@ import type { GatewayRequestHandlers, RespondFn } from "./types.js";
 
 // Derived from the canonical workspace list so retiring a bootstrap file cannot
 // leave the Control UI advertising a file the runtime no longer reads.
-const CORE_FILE_NAMES = WORKSPACE_BOOTSTRAP_FILENAMES;
+// IDENTITY.md is excluded: it is a parsed record that `agents.update` rewrites via
+// mergeIdentityMarkdownContent, so a second freeform editor would clobber fields
+// (Creature/Vibe, unfilled placeholders) that the identity form round-trips.
+// It stays writable through agents.files.set for clients that want raw access.
+const CORE_FILE_NAMES = WORKSPACE_BOOTSTRAP_FILENAMES.filter(
+  (name) => name !== DEFAULT_IDENTITY_FILENAME,
+);
 const CORE_FILE_NAMES_POST_ONBOARDING = CORE_FILE_NAMES.filter(
   (name) => name !== DEFAULT_BOOTSTRAP_FILENAME,
 );
@@ -131,8 +137,10 @@ export const testing = {
   },
 };
 
-// Gateway file mutations are intentionally capped to the workspace files the UI owns.
-const ALLOWED_FILE_NAMES = new Set<string>(CORE_FILE_NAMES);
+// Writes stay capped to canonical workspace files, and deliberately remain wider
+// than the listed core files: IDENTITY.md is not offered as an editor tab but is
+// still writable for clients that manage it directly.
+const ALLOWED_FILE_NAMES = new Set<string>(WORKSPACE_BOOTSTRAP_FILENAMES);
 
 function resolveAgentWorkspaceFileOrRespondError(
   params: Record<string, unknown>,


### PR DESCRIPTION
## What Problem This Solves

`IDENTITY.md` has two writers, and one of them can silently destroy the other's data.

The **Agents → Overview** panel already owns agent identity: it renders a real form (name, emoji, avatar upload) and saves through `agents.update`, which merges the values into `IDENTITY.md` via `mergeIdentityMarkdownContent`. That merge is structural — it preserves fields the form does not expose (`Creature`, `Vibe`) and leaves unfilled placeholder text alone.

The **Agents → Files** panel lists the same file as a raw markdown tab. Saving there calls `agents.files.set`, which overwrites the file wholesale. An operator who edits identity in the Files tab can drop `Creature`/`Vibe` or corrupt the `- Label: value` shape the parser depends on, and the Overview form will then show and re-save the damaged record.

`IDENTITY.md` is not prose like `AGENTS.md` or `SOUL.md`. It is a parsed record with a dedicated API, and it should have exactly one editor.

## Why This Change Was Made

The gateway stops **listing** `IDENTITY.md` among the core files, so no client renders it as a freeform editor tab. It stays in `ALLOWED_FILE_NAMES`, so `agents.files.set` still accepts it for any client that deliberately manages the file directly. No method is removed and no capability is lost — the editor just stops offering a second way to write a file that already has a form.

This is fixed at the gateway rather than in the web UI on purpose: the hazard is protocol-level, not web-specific. Desktop and Android clients render the same `agents.files.list` response and would otherwise keep the clobbering path.

Note this makes the listed set and the writable set intentionally different, where #114436 had just unified them. The comment at each site says why, so a future consolidation does not silently collapse them and remove the raw-write capability.

## User Impact

- Agents → Files no longer shows an `IDENTITY` tab. Identity is edited in Agents → Overview, which already has the fields and round-trips them safely.
- No loss of capability: `agents.files.get` / `agents.files.set` still work for `IDENTITY.md`.
- No change to how identity reaches the agent; `IDENTITY.md` remains a bootstrap file the runtime reads.

## Evidence

```text
src/gateway/server-methods/agents-mutate    93 tests passed (was 92)
tsgo -p tsconfig.core.json                  clean
```

Three tests pin the split, which is the part a future refactor could quietly undo:

- the listed files are the canonical set **minus** `IDENTITY.md`
- with setup completed, that set minus `BOOTSTRAP.md` as well
- `agents.files.set` for `IDENTITY.md` still succeeds despite it not being listed

Without the third test, collapsing `ALLOWED_FILE_NAMES` back onto the listed set would look like tidy-up and would silently remove raw write access.


### Live gateway proof

Session-owned gateway, isolated `OPENCLAW_STATE_DIR`, ephemeral loopback port, paths redacted.
Workspace seeded with `AGENTS.md`, `SOUL.md`, `IDENTITY.md`, `USER.md`, `MEMORY.md`; `BOOTSTRAP.md`
deliberately absent. 4/4 checks passed.

**1. `agents.files.list` pre-onboarding** — `IDENTITY.md` absent, canonical order preserved:

```json
["AGENTS.md","SOUL.md","USER.md","BOOTSTRAP.md","MEMORY.md"]
```

with `BOOTSTRAP.md` carrying `"missing": true`.

**2. `agents.files.list` post-onboarding** — `IDENTITY.md` and `BOOTSTRAP.md` both absent:

```json
["AGENTS.md","SOUL.md","USER.md","MEMORY.md"]
```

**3. `agents.files.set` for `IDENTITY.md` still succeeds**, and `agents.files.get` returns the exact
bytes back. The payload deliberately included the fields a raw overwrite would destroy:

```
- Name: Live Proof Ada
- Creature: Test Fixture
- Vibe: Direct raw write survives delisting
```

**4. `agents.files.set` for an unsupported name is still rejected** — proving the allowlist remains a
real boundary rather than merely widened:

```json
{"ok": false, "error": {"code": "INVALID_REQUEST",
 "message": "unsupported file \"NOPE.md\"", "retryable": false}}
```

Cleanup verified: gateway PID and process group dead, isolated temp state removed, worktree clean.

### Every list-consuming client is form-owned

Checked rather than assumed, since delisting would be harmful to any client that renders the list
without an identity form:

- `ui/src/pages/agents/*` — the web Control UI, the only real consumer. It already owns identity via
  the Overview form (`agents.update` → `mergeIdentityMarkdownContent`).
- `apps/android/.../GatewayProtocol.kt` — declares `AgentsFilesList("agents.files.list")` in a
  protocol enum only; no UI consumes it.
- `apps/shared/OpenClawKit/.../GatewayModels.swift` — generated `Codable` models
  (`AgentsFilesListParams` / `Result`) with no call site in `apps/`.

No client loses the ability to edit identity.

### Maintainer acceptance

The repository maintainer directed this follow-up: identity should have a single editor, because the
Overview form already owns the record and the Files tab was a second, destructive writer for the
same file. Automated review flagged the product question — whether delisting is preferable to
constraining raw edits another way — as needing maintainer confirmation; this is that confirmation.
Raw access is deliberately retained so the change removes a hazard, not a capability.
