### PR TITLE
fix(skills): persist workshop apply reason; correct Skill Workshop docs

### DIFF
--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -10459,6 +10459,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: Review past sessions manually
   - H2: What OpenClaw can learn
   - H2: When experience review runs
+  - H2: Runtime support
   - H2: What the reviewer receives
   - H2: Proposal safety
   - H2: Review learned proposals

--- a/docs/tools/self-learning.md
+++ b/docs/tools/self-learning.md
@@ -142,6 +142,15 @@ The foreground answer is never delayed for learning. A failed or ineligible
 turn does not start experience review, although direct user corrections can
 still be offered as a suggestion when autonomy is disabled.
 
+## Runtime support
+
+Delayed experience review requires the runtime to report its resolved model and
+actual `skill_workshop` availability. The embedded runner and the Codex
+app-server harness provide those facts; Codex also reports its exact model
+iteration count. Other CLI-backed runtimes fail closed until they provide the
+same runtime facts. Deterministic correction capture and `/learn` still work on
+those runtimes.
+
 ## What the reviewer receives
 
 The background reviewer receives only the current turn, starting at its most

--- a/docs/tools/skill-workshop.md
+++ b/docs/tools/skill-workshop.md
@@ -10,10 +10,9 @@ sidebarTitle: "Skill Workshop"
 ---
 
 Skill Workshop is OpenClaw's governed path for creating and updating workspace
-skills. Agents and operators never write `SKILL.md` directly through this
-path — they create a **proposal** (pending draft with content, target
-binding, scanner state, hashes, and rollback metadata) that becomes a live
-skill only when applied.
+skills. Through this path, agents and operators create a **proposal** (pending
+draft with content, target binding, scanner state, hashes, and rollback
+metadata) that becomes a live skill only when applied.
 
 Skill Workshop writes workspace skills only. It never touches bundled,
 plugin, ClawHub, extra-root, managed, personal-agent, or system skills.
@@ -29,7 +28,9 @@ plugin, ClawHub, extra-root, managed, personal-agent, or system skills.
 - **No clobber:** create fails if the target skill already exists.
 - **Hash bound:** update proposals bind to the current target hash and go
   `stale` if the live skill changes before apply.
-- **Scanner gated:** apply reruns the security scanner before writing.
+- **Scanner gated:** apply reruns the security scanner before writing. Only
+  critical findings block apply; warn-level findings remain visible but do not
+  block it.
 - **Recoverable:** apply writes rollback metadata before touching live files.
 - **Consistent surfaces:** chat, CLI, and Gateway all call the same service.
 
@@ -49,11 +50,11 @@ Only a `pending` proposal can be revised, applied, rejected, or quarantined.
 ## Lifecycle curation
 
 The Gateway tracks aggregate skill usage in the shared state database. Once a
-day, it reviews skills created and applied by Skill Workshop. Skills unused for
-more than 30 days become `stale`; after 90 days they become `archived` and are
-left out of new agent skill snapshots. Archived skill files remain unchanged on
-disk. Manually authored skills are never curated; only skills created by Skill
-Workshop proposals enter lifecycle curation.
+day, it reviews applied skills created through agent autocapture. Skills unused
+for more than 30 days become `stale`; after 90 days they become `archived` and
+are left out of new agent skill snapshots. Archived skill files remain
+unchanged on disk. Operator-created skills, including proposals created through
+the CLI or Gateway/Control UI, are treated as manual and never curated.
 
 Pinned skills bypass lifecycle transitions. A stale skill returns to `active`
 after it is used and the next sweep runs. Archived skills return only through an
@@ -215,9 +216,9 @@ Other parameters apply depending on the action:
 | `reason`                   | `apply`, `reject`, `quarantine`                      | Optional                                                             |
 | `query`, `status`, `limit` | `list`                                               | Filter/paginate; `limit` max 50, default 20                          |
 
-Agents must use `skill_workshop` for generated skill work. They must not
-create or change proposal files through `write`, `edit`, `exec`, shell
-commands, or direct filesystem operations.
+Agents must use `skill_workshop` for generated skill work and must not create or
+change skill or proposal files directly. This rule is advisory and
+prompt-enforced. A hard guard is not currently possible at the tool-policy seam.
 
 <Note>
 `skill_workshop` is a built-in agent tool and is included in
@@ -374,13 +375,13 @@ proposals remain listed with a previous-workspace marker instead of disappearing
 
 ## Limits
 
-| Limit                           | Value                                                             |
-| ------------------------------- | ----------------------------------------------------------------- |
-| Description                     | 160 bytes                                                         |
-| Proposal body                   | `skills.workshop.maxSkillBytes` (default 40,000; maximum 200,000) |
-| Support files                   | 64 per proposal                                                   |
-| Support file size               | 256 KiB each, 2 MiB total                                         |
-| Pending + quarantined proposals | `skills.workshop.maxPending` per workspace (default 50)           |
+| Limit                           | Value                                                                        |
+| ------------------------------- | ---------------------------------------------------------------------------- |
+| Description                     | 160 bytes                                                                    |
+| Proposal body                   | `skills.workshop.maxSkillBytes` (default 40,000; hard ceiling 200,000 bytes) |
+| Support files                   | 64 per proposal                                                              |
+| Support file size               | 256 KiB each, 2 MiB total                                                    |
+| Pending + quarantined proposals | `skills.workshop.maxPending` per workspace (default 50)                      |
 
 ## Troubleshooting
 

--- a/src/skills/workshop/service.test.ts
+++ b/src/skills/workshop/service.test.ts
@@ -157,6 +157,30 @@ describe("skill workshop proposals", () => {
     expect((await inspectSkillProposal(proposal.record.id))?.record.status).toBe("applied");
   });
 
+  it("persists the reason when applying a proposal", async () => {
+    const workspaceDir = await makeWorkspace();
+    const proposal = await proposeCreateSkill({
+      workspaceDir,
+      name: "Reviewed Skill",
+      description: "Proposal approved after review",
+      content: "# Reviewed Skill\n\nUse the reviewed workflow.\n",
+    });
+
+    const applied = await applySkillProposal({
+      workspaceDir,
+      proposalId: proposal.record.id,
+      reason: "  approved after operator review  ",
+    });
+
+    expect(applied.record.statusReason).toBe("approved after operator review");
+    await expect(inspectSkillProposal(proposal.record.id)).resolves.toMatchObject({
+      record: {
+        status: "applied",
+        statusReason: "approved after operator review",
+      },
+    });
+  });
+
   it.runIf(process.platform !== "win32")(
     "applies updates through opted-in trusted workspace skills symlink targets",
     async () => {

--- a/src/skills/workshop/service.ts
+++ b/src/skills/workshop/service.ts
@@ -612,6 +612,7 @@ export async function applySkillProposal(
       status: "applied",
       updatedAt: now,
       appliedAt: now,
+      statusReason: normalizeOptionalString(input.reason),
       scan,
     };
     await updateSkillProposalRecord({


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where an optional reason supplied while applying a Skill Workshop proposal was discarded instead of being retained with the applied proposal. It also corrects Workshop and self-learning documentation that overstated curation scope, scanner blocking behavior, direct-write enforcement, runtime support, and the proposal-size ceiling.

## Why This Change Was Made

Apply now normalizes and stores its reason through the same `statusReason` field used by reject and quarantine, with focused persistence coverage. The docs now describe the implemented ownership and runtime boundaries rather than broader intended behavior.

The companion enforcement-guard investigation concluded that a hard direct-write guard is not currently possible at the tool-policy seam, so this PR documents the rule as advisory and does not add enforcement.

AI-assisted: yes. The patch was inspected and validated before submission.

## User Impact

Operators can inspect why an applied proposal was accepted, and the public docs now accurately explain which skills are curated, which scanner findings block apply, where delayed experience review works, and the actual 200,000-byte configured maximum.

## Evidence

- `node scripts/run-vitest.mjs src/skills/workshop/service.test.ts`: 1 test file passed, 36 tests passed.
- `node scripts/check-changed.mjs -- src/skills/workshop/service.ts src/skills/workshop/service.test.ts docs/tools/skill-workshop.md docs/tools/self-learning.md`: passed on Blacksmith Testbox, including core and core-test typechecks, lint, formatting, and repository guards ([run](https://github.com/openclaw/openclaw/actions/runs/30252165667)).
- `git diff --check`: passed.
- `pnpm docs:list`: passed and confirmed both edited pages in the documentation index.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted`: clean, with no accepted or actionable findings.
