### PR TITLE
fix(ui): keep readable session titles after sidebar changes

### DIFF
--- a/ui/src/lib/sessions/index.ts
+++ b/ui/src/lib/sessions/index.ts
@@ -1093,7 +1093,12 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
   };
 
   const refreshReplacement = (agentId?: string | null) => {
-    const options = { ...lastListOptions };
+    // Mutation refreshes replace the visible sidebar rows. A foreground probe
+    // that omitted derived titles must not turn readable names back into ids.
+    const options = {
+      ...lastListOptions,
+      includeDerivedTitles: lastListOptions.includeDerivedTitles ?? true,
+    };
     const normalizedAgentId = agentId?.trim();
     if (normalizedAgentId) {
       options.agentId = normalizedAgentId;

--- a/ui/src/lib/sessions/list-options.test.ts
+++ b/ui/src/lib/sessions/list-options.test.ts
@@ -90,6 +90,47 @@ describe("session list replacement options", () => {
     sessions.dispose();
   });
 
+  it("restores derived titles after a foreground refresh omits them", async () => {
+    const key = "agent:main:untitled";
+    const request = vi.fn(async (method: string, params?: unknown) => {
+      if (method === "sessions.list") {
+        const includeDerivedTitles =
+          typeof params === "object" &&
+          params !== null &&
+          "includeDerivedTitles" in params &&
+          params.includeDerivedTitles === true;
+        return sessionsResult(
+          [
+            {
+              key,
+              kind: "direct",
+              updatedAt: 1,
+              label: key,
+              ...(includeDerivedTitles ? { derivedTitle: "Readable planning title" } : {}),
+            },
+          ],
+          1,
+        );
+      }
+      if (method === "sessions.patch") {
+        return { ok: true };
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const sessions = createSessions({ request } as unknown as GatewayBrowserClient, key);
+
+    await sessions.refresh({ agentId: "main", includeDerivedTitles: true, force: true });
+    await sessions.refresh({ agentId: "main", force: true });
+    await sessions.patch(key, { pinned: true }, { agentId: "main" });
+
+    const listCalls = request.mock.calls.filter(([method]) => method === "sessions.list");
+    expect(listCalls).toHaveLength(3);
+    expect(listCalls[1]?.[1]).not.toHaveProperty("includeDerivedTitles");
+    expect(listCalls[2]?.[1]).toMatchObject({ agentId: "main", includeDerivedTitles: true });
+    expect(sessions.state.result?.sessions[0]?.derivedTitle).toBe("Readable planning title");
+    sessions.dispose();
+  });
+
   it("keeps foreground list options across background hydration and mutation refreshes", async () => {
     const key = "agent:main:filtered";
     const request = vi.fn(async (method: string, _params?: unknown) => {


### PR DESCRIPTION
Closes #94529
Related: #96267, #94544

## What Problem This Solves

Fixes an issue where Control UI users would see readable, automatically derived session titles revert to raw identifiers after pinning or changing a sidebar session. The initial sidebar load requested the Gateway's existing derived titles, but an intervening foreground list request could remove that enrichment from the replacement refresh triggered by a session mutation.

## Why This Change Was Made

Keep derived titles on canonical mutation replacement requests by default while preserving explicitly disabled enrichment and all existing session filters. This uses the existing Gateway contract, adds no configuration or protocol surface, and locks the precise un-enriched foreground-load sequence into the session owner's regression tests. It builds on the earlier derived-title work in #96267 and the original contributor proposal #94544.

## User Impact

Session names remain human-readable after users pin or otherwise update sidebar threads. Explicitly configured labels and callers that intentionally disable derived titles retain their existing behavior.

## Evidence

- Before: the existing real Chromium test keeps derived sidebar titles and accessible state after session patch refreshes failed on current main because the post-pin sessions.list request omitted includeDerivedTitles. Independent Testbox baseline: https://github.com/openclaw/openclaw/actions/runs/30252174522.
- After: the same unchanged real Chromium regression passes against the fix, including the actual post-pin Gateway request, visible human-readable sidebar title, and accessible active-thread label. All six focused session-list replacement regressions also pass. Testbox tbx_01kyhd4v69hvqqpxa7e8awq8tb returned exitCode 0 and runStatus succeeded: https://github.com/openclaw/openclaw/actions/runs/30252446605.
- Full path-scoped repository gate passed, including formatting, conflict and dependency guards, Control UI localization verification, core-test and UI tsgo typechecks, and oxlint with zero warnings or errors. Testbox tbx_01kyhd8hv2dchf9gjdw7hndf3w returned exitCode 0 and runStatus succeeded: https://github.com/openclaw/openclaw/actions/runs/30252589849.
- Fresh independent autoreview: clean; TruffleHog clean; no accepted or actionable findings.
- AI-assisted: yes (Codex).