### PR TITLE
refactor: consolidate provider streaming and discovery tests

### DIFF
--- a/extensions/amazon-bedrock/discovery.test.ts
+++ b/extensions/amazon-bedrock/discovery.test.ts
@@ -23,13 +23,51 @@ const baseActiveAnthropicSummary = {
   modelLifecycle: { status: "ACTIVE" },
 };
 
-function mockSingleActiveSummary(overrides: Partial<typeof baseActiveAnthropicSummary> = {}): void {
+function buildActiveAnthropicSummary(
+  modelId: string,
+  modelName: string,
+  inputModalities: string[] = ["TEXT"],
+): typeof baseActiveAnthropicSummary {
+  return { ...baseActiveAnthropicSummary, modelId, modelName, inputModalities };
+}
+
+function mockBedrockDiscovery(
+  modelSummaries: Record<string, unknown>[],
+  inferenceProfileSummaries: Record<string, unknown>[] = [],
+): void {
   sendMock
-    .mockResolvedValueOnce({
-      modelSummaries: [{ ...baseActiveAnthropicSummary, ...overrides }],
-    })
-    // ListInferenceProfiles response (empty — no inference profiles in basic tests).
-    .mockResolvedValueOnce({ inferenceProfileSummaries: [] });
+    .mockResolvedValueOnce({ modelSummaries })
+    .mockResolvedValueOnce({ inferenceProfileSummaries });
+}
+
+function buildBedrockProfile(
+  inferenceProfileId: string,
+  inferenceProfileName: string,
+  foundationModels: string[] = [],
+  options: {
+    region?: string;
+    type?: "SYSTEM_DEFINED" | "APPLICATION";
+    status?: "ACTIVE" | "LEGACY";
+    arn?: string;
+  } = {},
+): Record<string, unknown> {
+  const region = options.region ?? "us-east-1";
+  return {
+    inferenceProfileId,
+    inferenceProfileName,
+    ...(options.arn ? { inferenceProfileArn: options.arn } : {}),
+    status: options.status ?? "ACTIVE",
+    type: options.type ?? "SYSTEM_DEFINED",
+    models: foundationModels.map((model) => ({
+      modelArn: model.startsWith("arn:")
+        ? model
+        : `arn:aws:bedrock:${region}::foundation-model/${model}`,
+    })),
+  };
+}
+
+function mockSingleActiveSummary(overrides: Partial<typeof baseActiveAnthropicSummary> = {}): void {
+  mockBedrockDiscovery([{ ...baseActiveAnthropicSummary, ...overrides }]);
 }
 
 function expectModelFields(model: unknown, expected: Record<string, unknown>): void {
@@ -54,48 +92,40 @@ describe("bedrock discovery", () => {
   });
 
   it("filters to active streaming text models and maps modalities", async () => {
-    sendMock
-      .mockResolvedValueOnce({
-        modelSummaries: [
-          {
-            modelId: "anthropic.claude-3-7-sonnet-20250219-v1:0",
-            modelName: "Claude 3.7 Sonnet",
-            providerName: "anthropic",
-            inputModalities: ["TEXT", "IMAGE"],
-            outputModalities: ["TEXT"],
-            responseStreamingSupported: true,
-            modelLifecycle: { status: "ACTIVE" },
-          },
-          {
-            modelId: "anthropic.claude-3-haiku-20240307-v1:0",
-            modelName: "Claude 3 Haiku",
-            providerName: "anthropic",
-            inputModalities: ["TEXT"],
-            outputModalities: ["TEXT"],
-            responseStreamingSupported: false,
-            modelLifecycle: { status: "ACTIVE" },
-          },
-          {
-            modelId: "meta.llama3-8b-instruct-v1:0",
-            modelName: "Llama 3 8B",
-            providerName: "meta",
-            inputModalities: ["TEXT"],
-            outputModalities: ["TEXT"],
-            responseStreamingSupported: true,
-            modelLifecycle: { status: "INACTIVE" },
-          },
-          {
-            modelId: "amazon.titan-embed-text-v1",
-            modelName: "Titan Embed",
-            providerName: "amazon",
-            inputModalities: ["TEXT"],
-            outputModalities: ["EMBEDDING"],
-            responseStreamingSupported: true,
-            modelLifecycle: { status: "ACTIVE" },
-          },
-        ],
-      })
-      .mockResolvedValueOnce({ inferenceProfileSummaries: [] });
+    mockBedrockDiscovery([
+      buildActiveAnthropicSummary(
+        "anthropic.claude-3-7-sonnet-20250219-v1:0",
+        "Claude 3.7 Sonnet",
+        ["TEXT", "IMAGE"],
+      ),
+      {
+        modelId: "anthropic.claude-3-haiku-20240307-v1:0",
+        modelName: "Claude 3 Haiku",
+        providerName: "anthropic",
+        inputModalities: ["TEXT"],
+        outputModalities: ["TEXT"],
+        responseStreamingSupported: false,
+        modelLifecycle: { status: "ACTIVE" },
+      },
+      {
+        modelId: "meta.llama3-8b-instruct-v1:0",
+        modelName: "Llama 3 8B",
+        providerName: "meta",
+        inputModalities: ["TEXT"],
+        outputModalities: ["TEXT"],
+        responseStreamingSupported: true,
+        modelLifecycle: { status: "INACTIVE" },
+      },
+      {
+        modelId: "amazon.titan-embed-text-v1",
+        modelName: "Titan Embed",
+        providerName: "amazon",
+        inputModalities: ["TEXT"],
+        outputModalities: ["EMBEDDING"],
+        responseStreamingSupported: true,
+        modelLifecycle: { status: "ACTIVE" },
+      },
+    ]);
 
     const models = await discoverBedrockModels({ region: "us-east-1", clientFactory });
     expect(models).toHaveLength(1);
@@ -137,26 +167,17 @@ describe("bedrock discovery", () => {
   });
 
   it("keeps the conservative fallback for unknown inference profiles", async () => {
-    sendMock
-      .mockResolvedValueOnce({
-        modelSummaries: [],
-      })
-      .mockResolvedValueOnce({
-        inferenceProfileSummaries: [
-          {
-            inferenceProfileId: "jp.example.unknown-text-v1:0",
-            inferenceProfileName: "JP Example Unknown Text",
-            status: "ACTIVE",
-            type: "SYSTEM_DEFINED",
-            models: [
-              {
-                modelArn:
-                  "arn:aws:bedrock:ap-northeast-1::foundation-model/example.unknown-text-v1:0",
-              },
-            ],
-          },
-        ],
-      });
+    mockBedrockDiscovery(
+      [],
+      [
+        buildBedrockProfile(
+          "jp.example.unknown-text-v1:0",
+          "JP Example Unknown Text",
+          ["example.unknown-text-v1:0"],
+          { region: "ap-northeast-1" },
+        ),
+      ],
+    );
 
     const models = await discoverBedrockModels({ region: "ap-northeast-1", clientFactory });
 
@@ -185,25 +206,7 @@ describe("bedrock discovery", () => {
   ])(
     "marks known $label inference profile fallbacks as reasoning capable",
     async ({ profileId, profileName, foundationId }) => {
-      sendMock
-        .mockResolvedValueOnce({
-          modelSummaries: [],
-        })
-        .mockResolvedValueOnce({
-          inferenceProfileSummaries: [
-            {
-              inferenceProfileId: profileId,
-              inferenceProfileName: profileName,
-              status: "ACTIVE",
-              type: "SYSTEM_DEFINED",
-              models: [
-                {
-                  modelArn: `arn:aws:bedrock:us-east-1::foundation-model/${foundationId}`,
-                },
-              ],
-            },
-          ],
-        });
+      mockBedrockDiscovery([], [buildBedrockProfile(profileId, profileName, [foundationId])]);
 
       const models = await discoverBedrockModels({ region: "us-east-1", clientFactory });
 
@@ -219,21 +222,14 @@ describe("bedrock discovery", () => {
   );
 
   it("applies the Opus 5 contract to inference-profile-only discovery", async () => {
-    sendMock.mockResolvedValueOnce({ modelSummaries: [] }).mockResolvedValueOnce({
-      inferenceProfileSummaries: [
-        {
-          inferenceProfileId: "global.anthropic.claude-opus-5",
-          inferenceProfileName: "Global Claude Opus 5",
-          status: "ACTIVE",
-          type: "SYSTEM_DEFINED",
-          models: [
-            {
-              modelArn: "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-opus-5",
-            },
-          ],
-        },
+    mockBedrockDiscovery(
+      [],
+      [
+        buildBedrockProfile("global.anthropic.claude-opus-5", "Global Claude Opus 5", [
+          "anthropic.claude-opus-5",
+        ]),
       ],
-    });
+    );
 
     const models = await discoverBedrockModels({ region: "us-east-1", clientFactory });
 
@@ -249,21 +245,14 @@ describe("bedrock discovery", () => {
   });
 
   it("applies the Sonnet 5 contract to inference-profile-only discovery", async () => {
-    sendMock.mockResolvedValueOnce({ modelSummaries: [] }).mockResolvedValueOnce({
-      inferenceProfileSummaries: [
-        {
-          inferenceProfileId: "global.anthropic.claude-sonnet-5",
-          inferenceProfileName: "Global Claude Sonnet 5",
-          status: "ACTIVE",
-          type: "SYSTEM_DEFINED",
-          models: [
-            {
-              modelArn: "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-sonnet-5",
-            },
-          ],
-        },
+    mockBedrockDiscovery(
+      [],
+      [
+        buildBedrockProfile("global.anthropic.claude-sonnet-5", "Global Claude Sonnet 5", [
+          "anthropic.claude-sonnet-5",
+        ]),
       ],
-    });
+    );
 
     const models = await discoverBedrockModels({ region: "us-east-1", clientFactory });
 
@@ -279,26 +268,14 @@ describe("bedrock discovery", () => {
   });
 
   it("skips Mythos Preview inference profiles because Mantle owns that route", async () => {
-    sendMock
-      .mockResolvedValueOnce({
-        modelSummaries: [],
-      })
-      .mockResolvedValueOnce({
-        inferenceProfileSummaries: [
-          {
-            inferenceProfileId: "us.anthropic.claude-mythos-preview",
-            inferenceProfileName: "US Claude Mythos Preview",
-            status: "ACTIVE",
-            type: "SYSTEM_DEFINED",
-            models: [
-              {
-                modelArn:
-                  "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-mythos-preview",
-              },
-            ],
-          },
-        ],
-      });
+    mockBedrockDiscovery(
+      [],
+      [
+        buildBedrockProfile("us.anthropic.claude-mythos-preview", "US Claude Mythos Preview", [
+          "anthropic.claude-mythos-preview",
+        ]),
+      ],
+    );
 
     const models = await discoverBedrockModels({ region: "us-east-1", clientFactory });
 
@@ -306,26 +283,17 @@ describe("bedrock discovery", () => {
   });
 
   it("normalizes region-prefixed versioned model ids when resolving context windows", async () => {
-    sendMock
-      .mockResolvedValueOnce({
-        modelSummaries: [],
-      })
-      .mockResolvedValueOnce({
-        inferenceProfileSummaries: [
-          {
-            inferenceProfileId: "jp.anthropic.claude-sonnet-4-6",
-            inferenceProfileName: "JP Claude Sonnet 4.6",
-            status: "ACTIVE",
-            type: "SYSTEM_DEFINED",
-            models: [
-              {
-                modelArn:
-                  "arn:aws:bedrock:ap-northeast-1::foundation-model/anthropic.claude-sonnet-4-6",
-              },
-            ],
-          },
-        ],
-      });
+    mockBedrockDiscovery(
+      [],
+      [
+        buildBedrockProfile(
+          "jp.anthropic.claude-sonnet-4-6",
+          "JP Claude Sonnet 4.6",
+          ["anthropic.claude-sonnet-4-6"],
+          { region: "ap-northeast-1" },
+        ),
+      ],
+    );
 
     const models = await discoverBedrockModels({ region: "ap-northeast-1", clientFactory });
 
@@ -336,36 +304,14 @@ describe("bedrock discovery", () => {
   });
 
   it("uses 1M context window for dotted Claude Opus 4.8 Bedrock refs", async () => {
-    sendMock
-      .mockResolvedValueOnce({
-        modelSummaries: [
-          {
-            modelId: "anthropic.claude-opus-4.8-v1:0",
-            modelName: "Claude Opus 4.8",
-            providerName: "anthropic",
-            inputModalities: ["TEXT"],
-            outputModalities: ["TEXT"],
-            responseStreamingSupported: true,
-            modelLifecycle: { status: "ACTIVE" },
-          },
-        ],
-      })
-      .mockResolvedValueOnce({
-        inferenceProfileSummaries: [
-          {
-            inferenceProfileId: "us.anthropic.claude-opus-4.8-v1:0",
-            inferenceProfileName: "US Claude Opus 4.8",
-            status: "ACTIVE",
-            type: "SYSTEM_DEFINED",
-            models: [
-              {
-                modelArn:
-                  "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-opus-4.8-v1:0",
-              },
-            ],
-          },
-        ],
-      });
+    mockBedrockDiscovery(
+      [buildActiveAnthropicSummary("anthropic.claude-opus-4.8-v1:0", "Claude Opus 4.8")],
+      [
+        buildBedrockProfile("us.anthropic.claude-opus-4.8-v1:0", "US Claude Opus 4.8", [
+          "anthropic.claude-opus-4.8-v1:0",
+        ]),
+      ],
+    );
 
     const models = await discoverBedrockModels({ region: "us-east-1", clientFactory });
 
@@ -388,35 +334,19 @@ describe("bedrock discovery", () => {
   });
 
   it("applies Fable limits and reasoning metadata to foundation and profile models", async () => {
-    sendMock
-      .mockResolvedValueOnce({
-        modelSummaries: [
-          {
-            modelId: "anthropic.claude-fable-5",
-            modelName: "Claude Fable 5",
-            providerName: "anthropic",
-            inputModalities: ["TEXT", "IMAGE"],
-            outputModalities: ["TEXT"],
-            responseStreamingSupported: true,
-            modelLifecycle: { status: "ACTIVE" },
-          },
-        ],
-      })
-      .mockResolvedValueOnce({
-        inferenceProfileSummaries: [
-          {
-            inferenceProfileId: "company-fable",
-            inferenceProfileName: "Company Fable",
-            status: "ACTIVE",
-            type: "APPLICATION",
-            models: [
-              {
-                modelArn: "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-fable-5",
-              },
-            ],
-          },
-        ],
-      });
+    mockBedrockDiscovery(
+      [
+        buildActiveAnthropicSummary("anthropic.claude-fable-5", "Claude Fable 5", [
+          "TEXT",
+          "IMAGE",
+        ]),
+      ],
+      [
+        buildBedrockProfile("company-fable", "Company Fable", ["anthropic.claude-fable-5"], {
+          type: "APPLICATION",
+        }),
+      ],
+    );
 
     const models = await discoverBedrockModels({ region: "us-east-1", clientFactory });
     const expected = {
@@ -449,11 +379,8 @@ describe("bedrock discovery", () => {
   });
 
   it("skips cache when refreshInterval expiry overflows", async () => {
-    sendMock
-      .mockResolvedValueOnce({ modelSummaries: [baseActiveAnthropicSummary] })
-      .mockResolvedValueOnce({ inferenceProfileSummaries: [] })
-      .mockResolvedValueOnce({ modelSummaries: [baseActiveAnthropicSummary] })
-      .mockResolvedValueOnce({ inferenceProfileSummaries: [] });
+    mockSingleActiveSummary();
+    mockSingleActiveSummary();
 
     await discoverBedrockModels({
       region: "us-east-1",
@@ -471,11 +398,8 @@ describe("bedrock discovery", () => {
   });
 
   it("skips cache when refreshInterval is 0", async () => {
-    sendMock
-      .mockResolvedValueOnce({ modelSummaries: [baseActiveAnthropicSummary] })
-      .mockResolvedValueOnce({ inferenceProfileSummaries: [] })
-      .mockResolvedValueOnce({ modelSummaries: [baseActiveAnthropicSummary] })
-      .mockResolvedValueOnce({ inferenceProfileSummaries: [] });
+    mockSingleActiveSummary();
+    mockSingleActiveSummary();
 
     await discoverBedrockModels({
       region: "us-east-1",
@@ -544,74 +468,41 @@ describe("bedrock discovery", () => {
   });
 
   it("discovers inference profiles and inherits foundation model capabilities", async () => {
-    sendMock
-      .mockResolvedValueOnce({
-        modelSummaries: [
+    const foundationId = "anthropic.claude-sonnet-4-6";
+    mockBedrockDiscovery(
+      [buildActiveAnthropicSummary(foundationId, "Claude Sonnet 4.6", ["TEXT", "IMAGE"])],
+      [
+        buildBedrockProfile(
+          "us.anthropic.claude-sonnet-4-6",
+          "US Anthropic Claude Sonnet 4.6",
+          [foundationId, "arn:aws:bedrock:us-west-2::foundation-model/anthropic.claude-sonnet-4-6"],
           {
-            modelId: "anthropic.claude-sonnet-4-6",
-            modelName: "Claude Sonnet 4.6",
-            providerName: "anthropic",
-            inputModalities: ["TEXT", "IMAGE"],
-            outputModalities: ["TEXT"],
-            responseStreamingSupported: true,
-            modelLifecycle: { status: "ACTIVE" },
+            arn: "arn:aws:bedrock:us-east-1::inference-profile/us.anthropic.claude-sonnet-4-6",
           },
-        ],
-      })
-      .mockResolvedValueOnce({
-        inferenceProfileSummaries: [
+        ),
+        buildBedrockProfile(
+          "eu.anthropic.claude-sonnet-4-6",
+          "EU Anthropic Claude Sonnet 4.6",
+          [foundationId],
           {
-            inferenceProfileId: "us.anthropic.claude-sonnet-4-6",
-            inferenceProfileName: "US Anthropic Claude Sonnet 4.6",
-            inferenceProfileArn:
-              "arn:aws:bedrock:us-east-1::inference-profile/us.anthropic.claude-sonnet-4-6",
-            status: "ACTIVE",
-            type: "SYSTEM_DEFINED",
-            models: [
-              {
-                modelArn: "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-sonnet-4-6",
-              },
-              {
-                modelArn: "arn:aws:bedrock:us-west-2::foundation-model/anthropic.claude-sonnet-4-6",
-              },
-            ],
+            region: "eu-west-1",
+            arn: "arn:aws:bedrock:eu-west-1::inference-profile/eu.anthropic.claude-sonnet-4-6",
           },
+        ),
+        buildBedrockProfile(
+          "global.anthropic.claude-sonnet-4-6",
+          "Global Anthropic Claude Sonnet 4.6",
+          [foundationId],
           {
-            inferenceProfileId: "eu.anthropic.claude-sonnet-4-6",
-            inferenceProfileName: "EU Anthropic Claude Sonnet 4.6",
-            inferenceProfileArn:
-              "arn:aws:bedrock:eu-west-1::inference-profile/eu.anthropic.claude-sonnet-4-6",
-            status: "ACTIVE",
-            type: "SYSTEM_DEFINED",
-            models: [
-              {
-                modelArn: "arn:aws:bedrock:eu-west-1::foundation-model/anthropic.claude-sonnet-4-6",
-              },
-            ],
+            arn: "arn:aws:bedrock:us-east-1::inference-profile/global.anthropic.claude-sonnet-4-6",
           },
-          {
-            inferenceProfileId: "global.anthropic.claude-sonnet-4-6",
-            inferenceProfileName: "Global Anthropic Claude Sonnet 4.6",
-            inferenceProfileArn:
-              "arn:aws:bedrock:us-east-1::inference-profile/global.anthropic.claude-sonnet-4-6",
-            status: "ACTIVE",
-            type: "SYSTEM_DEFINED",
-            models: [
-              {
-                modelArn: "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-sonnet-4-6",
-              },
-            ],
-          },
-          // Inactive profile should be filtered out.
-          {
-            inferenceProfileId: "ap.anthropic.claude-sonnet-4-6",
-            inferenceProfileName: "AP Claude Sonnet 4.6",
-            status: "LEGACY",
-            type: "SYSTEM_DEFINED",
-            models: [],
-          },
-        ],
-      });
+        ),
+        // Inactive profile should be filtered out.
+        buildBedrockProfile("ap.anthropic.claude-sonnet-4-6", "AP Claude Sonnet 4.6", [], {
+          status: "LEGACY",
+        }),
+      ],
+    );
 
     const models = await discoverBedrockModels({ region: "us-east-1", clientFactory });
 
@@ -660,35 +551,21 @@ describe("bedrock discovery", () => {
   });
 
   it("keeps matching inference profiles when provider filters are enabled", async () => {
-    sendMock
-      .mockResolvedValueOnce({
-        modelSummaries: [
-          {
-            modelId: "anthropic.claude-sonnet-4-6",
-            modelName: "Claude Sonnet 4.6",
-            providerName: "anthropic",
-            inputModalities: ["TEXT", "IMAGE"],
-            outputModalities: ["TEXT"],
-            responseStreamingSupported: true,
-            modelLifecycle: { status: "ACTIVE" },
-          },
-        ],
-      })
-      .mockResolvedValueOnce({
-        inferenceProfileSummaries: [
-          {
-            inferenceProfileId: "global.anthropic.claude-sonnet-4-6",
-            inferenceProfileName: "Global Anthropic Claude Sonnet 4.6",
-            status: "ACTIVE",
-            type: "SYSTEM_DEFINED",
-            models: [
-              {
-                modelArn: "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-sonnet-4-6",
-              },
-            ],
-          },
-        ],
-      });
+    mockBedrockDiscovery(
+      [
+        buildActiveAnthropicSummary("anthropic.claude-sonnet-4-6", "Claude Sonnet 4.6", [
+          "TEXT",
+          "IMAGE",
+        ]),
+      ],
+      [
+        buildBedrockProfile(
+          "global.anthropic.claude-sonnet-4-6",
+          "Global Anthropic Claude Sonnet 4.6",
+          ["anthropic.claude-sonnet-4-6"],
+        ),
+      ],
+    );
 
     const models = await discoverBedrockModels({
       region: "us-east-1",
@@ -703,35 +580,22 @@ describe("bedrock discovery", () => {
   });
 
   it("prefers backing model ARNs for application profiles with region-like ids", async () => {
-    sendMock
-      .mockResolvedValueOnce({
-        modelSummaries: [
-          {
-            modelId: "anthropic.claude-sonnet-4-6",
-            modelName: "Claude Sonnet 4.6",
-            providerName: "anthropic",
-            inputModalities: ["TEXT", "IMAGE"],
-            outputModalities: ["TEXT"],
-            responseStreamingSupported: true,
-            modelLifecycle: { status: "ACTIVE" },
-          },
-        ],
-      })
-      .mockResolvedValueOnce({
-        inferenceProfileSummaries: [
-          {
-            inferenceProfileId: "us.my-prod-profile",
-            inferenceProfileName: "Prod Claude Profile",
-            status: "ACTIVE",
-            type: "APPLICATION",
-            models: [
-              {
-                modelArn: "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-sonnet-4-6",
-              },
-            ],
-          },
-        ],
-      });
+    mockBedrockDiscovery(
+      [
+        buildActiveAnthropicSummary("anthropic.claude-sonnet-4-6", "Claude Sonnet 4.6", [
+          "TEXT",
+          "IMAGE",
+        ]),
+      ],
+      [
+        buildBedrockProfile(
+          "us.my-prod-profile",
+          "Prod Claude Profile",
+          ["anthropic.claude-sonnet-4-6"],
+          { type: "APPLICATION" },
+        ),
+      ],
+    );
 
     const models = await discoverBedrockModels({ region: "us-east-1", clientFactory });
     const profile = models.find((model) => model.id === "us.my-prod-profile");
@@ -745,26 +609,17 @@ describe("bedrock discovery", () => {
   });
 
   it("uses the resolved base model id for application-profile context fallback", async () => {
-    sendMock
-      .mockResolvedValueOnce({
-        modelSummaries: [],
-      })
-      .mockResolvedValueOnce({
-        inferenceProfileSummaries: [
-          {
-            inferenceProfileId: "us.my-prod-profile",
-            inferenceProfileName: "Prod Claude Profile",
-            status: "ACTIVE",
-            type: "APPLICATION",
-            models: [
-              {
-                modelArn:
-                  "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-opus-4-6-v1",
-              },
-            ],
-          },
-        ],
-      });
+    mockBedrockDiscovery(
+      [],
+      [
+        buildBedrockProfile(
+          "us.my-prod-profile",
+          "Prod Claude Profile",
+          ["anthropic.claude-opus-4-6-v1"],
+          { type: "APPLICATION" },
+        ),
+      ],
+    );
 
     const models = await discoverBedrockModels({ region: "us-east-1", clientFactory });
 
@@ -855,42 +710,33 @@ describe("bedrock discovery", () => {
 
   // Ported from #65449 by @alickgithub2 — extended to also cover apac. prefix
   it("resolves au. and apac. prefixes for regional inference profiles", async () => {
-    sendMock
-      .mockResolvedValueOnce({
-        modelSummaries: [
+    mockBedrockDiscovery(
+      [
+        buildActiveAnthropicSummary("anthropic.claude-sonnet-4-6", "Claude Sonnet 4.6", [
+          "TEXT",
+          "IMAGE",
+        ]),
+      ],
+      [
+        // Empty model ARNs intentionally force the regional prefix fallback.
+        buildBedrockProfile(
+          "au.anthropic.claude-sonnet-4-6",
+          "AU Anthropic Claude Sonnet 4.6",
+          [],
           {
-            modelId: "anthropic.claude-sonnet-4-6",
-            modelName: "Claude Sonnet 4.6",
-            providerName: "anthropic",
-            inputModalities: ["TEXT", "IMAGE"],
-            outputModalities: ["TEXT"],
-            responseStreamingSupported: true,
-            modelLifecycle: { status: "ACTIVE" },
+            arn: "arn:aws:bedrock:ap-southeast-2::inference-profile/au.anthropic.claude-sonnet-4-6",
           },
-        ],
-      })
-      .mockResolvedValueOnce({
-        inferenceProfileSummaries: [
+        ),
+        buildBedrockProfile(
+          "apac.anthropic.claude-sonnet-4-6",
+          "APAC Anthropic Claude Sonnet 4.6",
+          [],
           {
-            inferenceProfileId: "au.anthropic.claude-sonnet-4-6",
-            inferenceProfileName: "AU Anthropic Claude Sonnet 4.6",
-            inferenceProfileArn:
-              "arn:aws:bedrock:ap-southeast-2::inference-profile/au.anthropic.claude-sonnet-4-6",
-            status: "ACTIVE",
-            type: "SYSTEM_DEFINED",
-            models: [], // no ARNs — forces the prefix-regex fallback
+            arn: "arn:aws:bedrock:ap-northeast-1::inference-profile/apac.anthropic.claude-sonnet-4-6",
           },
-          {
-            inferenceProfileId: "apac.anthropic.claude-sonnet-4-6",
-            inferenceProfileName: "APAC Anthropic Claude Sonnet 4.6",
-            inferenceProfileArn:
-              "arn:aws:bedrock:ap-northeast-1::inference-profile/apac.anthropic.claude-sonnet-4-6",
-            status: "ACTIVE",
-            type: "SYSTEM_DEFINED",
-            models: [],
-          },
-        ],
-      });
+        ),
+      ],
+    );
 
     const models = await discoverBedrockModels({ region: "ap-southeast-2", clientFactory });
 

--- a/extensions/amazon-bedrock/index.test.ts
+++ b/extensions/amazon-bedrock/index.test.ts
@@ -238,6 +238,32 @@ function runtimePluginConfig(config?: Record<string, unknown>): OpenClawConfig {
   } as OpenClawConfig;
 }
 
+function buildBedrockCachePayload(
+  text = "Hello",
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    ...overrides,
+    system: [{ text: "You are helpful." }],
+    messages: [{ role: "user", content: [{ text }] }],
+  };
+}
+
+async function callBedrockConverse(
+  extraParams: Record<string, unknown>,
+  payload: Record<string, unknown> = {},
+  modelId = NON_ANTHROPIC_MODEL,
+): Promise<Record<string, unknown>> {
+  return callWrappedStream(
+    await registerWithConfig(),
+    modelId,
+    { api: "bedrock-converse-stream", provider: "amazon-bedrock", id: modelId } as never,
+    runtimePluginConfig(),
+    extraParams,
+    payload,
+  );
+}
+
 const requireRecord = createRequireRecord("record", "expected-label-record");
 
 function requireArray(value: unknown, label: string): unknown[] {
@@ -902,26 +928,12 @@ describe("amazon-bedrock provider plugin", () => {
     } as never;
 
     it("injects serviceTier for valid camelCase value ('flex')", async () => {
-      const provider = await registerWithConfig(undefined);
-      const result = await callWrappedStream(
-        provider,
-        NON_ANTHROPIC_MODEL,
-        CONVERSE_MODEL_DESCRIPTOR,
-        runtimePluginConfig(undefined),
-        { serviceTier: "flex" },
-      );
+      const result = await callBedrockConverse({ serviceTier: "flex" });
       expectPayloadServiceTier(result, "flex");
     });
 
     it("injects serviceTier for valid snake_case value ('priority')", async () => {
-      const provider = await registerWithConfig(undefined);
-      const result = await callWrappedStream(
-        provider,
-        NON_ANTHROPIC_MODEL,
-        CONVERSE_MODEL_DESCRIPTOR,
-        runtimePluginConfig(undefined),
-        { service_tier: "priority" },
-      );
+      const result = await callBedrockConverse({ service_tier: "priority" });
       expectPayloadServiceTier(result, "priority");
     });
 
@@ -940,33 +952,15 @@ describe("amazon-bedrock provider plugin", () => {
     });
 
     it("does not inject serviceTier when value is invalid", async () => {
-      const provider = await registerWithConfig(undefined);
-      const result = await callWrappedStream(
-        provider,
-        NON_ANTHROPIC_MODEL,
-        CONVERSE_MODEL_DESCRIPTOR,
-        runtimePluginConfig(undefined),
-        { serviceTier: "not-a-tier" },
-      );
+      const result = await callBedrockConverse({ serviceTier: "not-a-tier" });
       expect(result).not.toHaveProperty("capturedPayload");
     });
 
     it.each(["fable", "opus", "sonnet"])(
       "omits unsupported service tiers for Claude %s 5",
       async (family) => {
-        const provider = await registerWithConfig(undefined);
         const modelId = `us.anthropic.claude-${family}-5`;
-        const result = await callWrappedStream(
-          provider,
-          modelId,
-          {
-            api: "bedrock-converse-stream",
-            provider: "amazon-bedrock",
-            id: modelId,
-          } as never,
-          runtimePluginConfig(undefined),
-          { serviceTier: "flex" },
-        );
+        const result = await callBedrockConverse({ serviceTier: "flex" }, {}, modelId);
         expect(result).not.toHaveProperty("capturedPayload");
       },
     );
@@ -974,30 +968,14 @@ describe("amazon-bedrock provider plugin", () => {
     it.each(["fable", "opus", "sonnet"])(
       "keeps the standard service tier for Claude %s 5",
       async (family) => {
-        const provider = await registerWithConfig(undefined);
         const modelId = `us.anthropic.claude-${family}-5`;
-        const result = await callWrappedStream(
-          provider,
-          modelId,
-          {
-            api: "bedrock-converse-stream",
-            provider: "amazon-bedrock",
-            id: modelId,
-          } as never,
-          runtimePluginConfig(undefined),
-          { serviceTier: "default" },
-        );
+        const result = await callBedrockConverse({ serviceTier: "default" }, {}, modelId);
         expectPayloadServiceTier(result, "default");
       },
     );
 
     it("does not overwrite caller-provided serviceTier in payload", async () => {
-      const provider = await registerWithConfig(undefined);
-      const result = await callWrappedStream(
-        provider,
-        NON_ANTHROPIC_MODEL,
-        CONVERSE_MODEL_DESCRIPTOR,
-        runtimePluginConfig(undefined),
+      const result = await callBedrockConverse(
         { serviceTier: "flex" },
         { serviceTier: { type: "priority" } },
       );
@@ -1072,10 +1050,7 @@ describe("amazon-bedrock provider plugin", () => {
       },
     ])("$name", async ({ options, expectedCachePoint, verifyUserMessage }) => {
       const provider = await registerWithConfig(undefined);
-      const payload: Record<string, unknown> = {
-        system: [{ text: "You are helpful." }],
-        messages: [{ role: "user", content: [{ text: "Hello" }] }],
-      };
+      const payload = buildBedrockCachePayload();
       await callWrappedStreamWithPayload(
         provider,
         APP_INFERENCE_PROFILE_ARN,
@@ -1127,10 +1102,7 @@ describe("amazon-bedrock provider plugin", () => {
 
     it("does not inject cache points for regular Anthropic model IDs handled by the shared runtime", async () => {
       const provider = await registerWithConfig(undefined);
-      const payload: Record<string, unknown> = {
-        system: [{ text: "You are helpful." }],
-        messages: [{ role: "user", content: [{ text: "Hello" }] }],
-      };
+      const payload = buildBedrockCachePayload();
 
       // Regular model IDs contain "claude" so the shared runtime handles caching natively.
       // wrapStreamFn should not install an onPayload hook for these.
@@ -1156,10 +1128,7 @@ describe("amazon-bedrock provider plugin", () => {
     it("does not inject cache points for older Claude models not in the shared runtime cache list", async () => {
       const provider = await registerWithConfig(undefined);
       const oldClaudeModel = "anthropic.claude-3-opus-20240229-v1:0";
-      const payload: Record<string, unknown> = {
-        system: [{ text: "You are helpful." }],
-        messages: [{ role: "user", content: [{ text: "Hello" }] }],
-      };
+      const payload = buildBedrockCachePayload();
 
       // Claude 3 Opus is not in the shared runtime supportsPromptCaching list, but it's
       // also not an application inference profile — we should not inject.
@@ -1226,10 +1195,7 @@ describe("amazon-bedrock provider plugin", () => {
         ],
       });
       const provider = await registerWithConfig(undefined);
-      const payload: Record<string, unknown> = {
-        system: [{ text: "You are helpful." }],
-        messages: [{ role: "user", content: [{ text: "Hello" }] }],
-      };
+      const payload = buildBedrockCachePayload();
 
       await callWrappedStreamWithPayload(
         provider,
@@ -1258,11 +1224,9 @@ describe("amazon-bedrock provider plugin", () => {
         ],
       });
       const provider = await registerWithConfig(undefined);
-      const payload: Record<string, unknown> = {
+      const payload = buildBedrockCachePayload("Hello", {
         inferenceConfig: { temperature: 0.3, maxTokens: 10 },
-        system: [{ text: "You are helpful." }],
-        messages: [{ role: "user", content: [{ text: "Hello" }] }],
-      };
+      });
 
       await callWrappedStreamWithPayload(
         provider,
@@ -1286,11 +1250,9 @@ describe("amazon-bedrock provider plugin", () => {
         ],
       });
       const provider = await registerWithConfig(undefined);
-      const payload: Record<string, unknown> = {
+      const payload = buildBedrockCachePayload("Hello", {
         inferenceConfig: { temperature: 0.3, maxTokens: 10 },
-        system: [{ text: "You are helpful." }],
-        messages: [{ role: "user", content: [{ text: "Hello" }] }],
-      };
+      });
 
       await callWrappedStreamWithPayload(
         provider,
@@ -1323,10 +1285,7 @@ describe("amazon-bedrock provider plugin", () => {
         ],
       });
       const provider = await registerWithConfig(undefined);
-      const payload: Record<string, unknown> = {
-        system: [{ text: "You are helpful." }],
-        messages: [{ role: "user", content: [{ text: "Hello" }] }],
-      };
+      const payload = buildBedrockCachePayload();
 
       await callWrappedStreamWithPayload(
         provider,
@@ -1352,14 +1311,8 @@ describe("amazon-bedrock provider plugin", () => {
         ],
       });
       const provider = await registerWithConfig(undefined);
-      const firstPayload: Record<string, unknown> = {
-        system: [{ text: "You are helpful." }],
-        messages: [{ role: "user", content: [{ text: "Hello" }] }],
-      };
-      const secondPayload: Record<string, unknown> = {
-        system: [{ text: "You are helpful." }],
-        messages: [{ role: "user", content: [{ text: "Hello again" }] }],
-      };
+      const firstPayload = buildBedrockCachePayload();
+      const secondPayload = buildBedrockCachePayload("Hello again");
 
       await callWrappedStreamWithPayload(
         provider,
@@ -1403,14 +1356,8 @@ describe("amazon-bedrock provider plugin", () => {
           },
         );
         const provider = await registerWithConfig(undefined);
-        const firstPayload: Record<string, unknown> = {
-          system: [{ text: "You are helpful." }],
-          messages: [{ role: "user", content: [{ text: "Hello" }] }],
-        };
-        const secondPayload: Record<string, unknown> = {
-          system: [{ text: "You are helpful." }],
-          messages: [{ role: "user", content: [{ text: "Hello again" }] }],
-        };
+        const firstPayload = buildBedrockCachePayload();
+        const secondPayload = buildBedrockCachePayload("Hello again");
 
         const firstRequest = callWrappedStreamWithPayload(
           provider,
@@ -1460,11 +1407,9 @@ describe("amazon-bedrock provider plugin", () => {
         const provider = await registerWithConfig(undefined);
         const controller = new AbortController();
         const reason = new Error(`caller cancelled ${index}`);
-        const payload: Record<string, unknown> = {
+        const payload = buildBedrockCachePayload("Hello", {
           inferenceConfig: { temperature: 0.3 },
-          system: [{ text: "You are helpful." }],
-          messages: [{ role: "user", content: [{ text: "Hello" }] }],
-        };
+        });
 
         const request = callWrappedStreamWithPayload(
           provider,
@@ -1498,10 +1443,7 @@ describe("amazon-bedrock provider plugin", () => {
           modelId,
           makeAppInferenceProfileDescriptor(modelId),
           { cacheRetention: "short", signal: controller.signal },
-          {
-            system: [{ text: "You are helpful." }],
-            messages: [{ role: "user", content: [{ text: "Hello" }] }],
-          },
+          buildBedrockCachePayload(),
         ),
       ).rejects.toBe(reason);
 

--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -102,11 +102,23 @@ function buildGeminiUserParams(
   );
 }
 
-async function runGeminiStreamResult(params: {
-  model?: Model<"google-generative-ai">;
-  context?: Parameters<ReturnType<typeof createGoogleGenerativeAiTransportStreamFn>>[1];
-  options?: Record<string, unknown>;
-}) {
+function buildGeminiReplayParams(messages: Record<string, unknown>[]) {
+  return buildGoogleGenerativeAiParams(
+    buildGeminiModel({
+      id: "gemini-3.1-pro-preview",
+      name: "Gemini 3.1 Pro Preview",
+    }),
+    { messages } as never,
+  );
+}
+
+async function runGeminiStreamResult(
+  params: {
+    model?: Model<"google-generative-ai">;
+    context?: Parameters<ReturnType<typeof createGoogleGenerativeAiTransportStreamFn>>[1];
+    options?: Record<string, unknown>;
+  } = {},
+) {
   const streamFn = createGoogleGenerativeAiTransportStreamFn();
   const stream = await Promise.resolve(
     streamFn(
@@ -159,9 +171,25 @@ async function useGoogleAuthorizedUserCredentials(
   return credentialsPath;
 }
 
+async function useGoogleAuthLibraryCredentials(label: string, token?: string): Promise<void> {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), `openclaw-google-vertex-${label}-`));
+  vi.stubEnv("GOOGLE_APPLICATION_CREDENTIALS", "");
+  vi.stubEnv("HOME", path.join(tempDir, "home"));
+  vi.stubEnv("APPDATA", "");
+  if (token !== undefined) {
+    googleAuthGetAccessTokenMock.mockResolvedValueOnce(token);
+  }
+}
+
 function buildSseResponse(events: unknown[]): Response {
   const sse = `${events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("")}data: [DONE]\n\n`;
   return buildRawSseResponse(sse);
+}
+
+function mockGoogleTextResponse(text = "ok"): void {
+  guardedFetchMock.mockResolvedValueOnce(
+    buildSseResponse([{ candidates: [{ content: { parts: [{ text }] }, finishReason: "STOP" }] }]),
+  );
 }
 
 function buildRateLimitResponse(): Response {
@@ -472,19 +500,12 @@ describe("google transport stream", () => {
     );
 
     const model = attachModelProviderRequestTransport(
-      {
+      buildGeminiModel({
         id: "gemini-3.1-pro-preview",
         name: "Gemini 3.1 Pro Preview",
-        api: "google-generative-ai",
-        provider: "google",
         baseUrl: "https://generativelanguage.googleapis.com",
-        reasoning: true,
-        input: ["text"],
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-        contextWindow: 128000,
-        maxTokens: 8192,
         headers: { "X-Provider": "google" },
-      } satisfies Model<"google-generative-ai">,
+      }),
       {
         proxy: {
           mode: "explicit-proxy",
@@ -788,17 +809,7 @@ describe("google transport stream", () => {
       ]),
     );
 
-    const streamFn = createGoogleGenerativeAiTransportStreamFn();
-    const stream = await Promise.resolve(
-      streamFn(
-        buildGeminiModel(),
-        {
-          messages: [{ role: "user", content: "hello", timestamp: 0 }],
-        } as Parameters<typeof streamFn>[1],
-        { apiKey: "gemini-key-1" } as Parameters<typeof streamFn>[2],
-      ),
-    );
-    const result = await stream.result();
+    const result = await runGeminiStreamResult({ options: { apiKey: "gemini-key-1" } });
 
     expect(result.stopReason).toBe("stop");
     expect(result.content).toEqual([{ type: "text", text: "recovered" }]);
@@ -886,24 +897,13 @@ describe("google transport stream", () => {
       ]),
     );
 
-    const streamFn = createGoogleGenerativeAiTransportStreamFn();
-    const stream = await Promise.resolve(
-      streamFn(
-        buildGeminiModel(),
-        {
-          messages: [{ role: "user", content: "hello", timestamp: 0 }],
-          tools: [
-            {
-              name: "lookup",
-              description: "Look up a value",
-              parameters: { type: "object" },
-            },
-          ],
-        } as Parameters<typeof streamFn>[1],
-        { apiKey: "gemini-api-key" } as Parameters<typeof streamFn>[2],
-      ),
-    );
-    const result = await stream.result();
+    const result = await runGeminiStreamResult({
+      context: {
+        messages: [{ role: "user", content: "hello", timestamp: 0 }],
+        tools: [{ name: "lookup", description: "Look up a value", parameters: { type: "object" } }],
+      } as Parameters<ReturnType<typeof createGoogleGenerativeAiTransportStreamFn>>[1],
+      options: { apiKey: "gemini-api-key" },
+    });
 
     expect(result.stopReason).toBe("length");
     expect(result.content).toEqual([expect.objectContaining({ type: "toolCall", name: "lookup" })]);
@@ -957,19 +957,12 @@ describe("google transport stream", () => {
       ]),
     );
 
-    const streamFn = createGoogleGenerativeAiTransportStreamFn();
-    const stream = await Promise.resolve(
-      streamFn(
-        buildGeminiModel({
-          id: "gemini-3.1-pro-preview",
-          name: "Gemini 3.1 Pro Preview",
-        }),
-        {
-          messages: [{ role: "user", content: "hello", timestamp: 0 }],
-        } as never,
-      ),
-    );
-    const result = await stream.result();
+    const result = await runGeminiStreamResult({
+      model: buildGeminiModel({
+        id: "gemini-3.1-pro-preview",
+        name: "Gemini 3.1 Pro Preview",
+      }),
+    });
 
     expect(result.content).toEqual([
       {
@@ -1014,13 +1007,7 @@ describe("google transport stream", () => {
       ]),
     );
 
-    const streamFn = createGoogleGenerativeAiTransportStreamFn();
-    const stream = await Promise.resolve(
-      streamFn(buildGeminiModel(), {
-        messages: [{ role: "user", content: "hello", timestamp: 0 }],
-      } as never),
-    );
-    const result = await stream.result();
+    const result = await runGeminiStreamResult();
     const toolCalls = result.content.filter((block) => block.type === "toolCall");
 
     expect(toolCalls).toHaveLength(2);
@@ -1061,19 +1048,12 @@ describe("google transport stream", () => {
       ]),
     );
 
-    const streamFn = createGoogleGenerativeAiTransportStreamFn();
-    const stream = await Promise.resolve(
-      streamFn(
-        buildGeminiModel({
-          id: "gemini-3.1-pro-preview",
-          name: "Gemini 3.1 Pro Preview",
-        }),
-        {
-          messages: [{ role: "user", content: "hello", timestamp: 0 }],
-        } as never,
-      ),
-    );
-    const result = await stream.result();
+    const result = await runGeminiStreamResult({
+      model: buildGeminiModel({
+        id: "gemini-3.1-pro-preview",
+        name: "Gemini 3.1 Pro Preview",
+      }),
+    });
 
     expect(result.content[0]).toMatchObject({
       type: "toolCall",
@@ -1092,20 +1072,7 @@ describe("google transport stream", () => {
   it("wraps malformed Gemini SSE JSON", async () => {
     guardedFetchMock.mockResolvedValueOnce(buildRawSseResponse("data: {not json\n\n"));
 
-    const streamFn = createGoogleGenerativeAiTransportStreamFn();
-    const stream = await Promise.resolve(
-      streamFn(
-        buildGeminiModel(),
-        {
-          messages: [{ role: "user", content: "hello", timestamp: 0 }],
-        } as unknown as Parameters<typeof streamFn>[1],
-        {
-          apiKey: "gemini-api-key",
-        } as Parameters<typeof streamFn>[2],
-      ),
-    );
-
-    const result = await stream.result();
+    const result = await runGeminiStreamResult({ options: { apiKey: "gemini-api-key" } });
 
     expect(result.stopReason).toBe("error");
     expect(result.errorMessage).toBe("Google SSE stream returned malformed JSON");
@@ -1204,20 +1171,7 @@ describe("google transport stream", () => {
       }),
     );
 
-    const streamFn = createGoogleGenerativeAiTransportStreamFn();
-    const stream = await Promise.resolve(
-      streamFn(
-        buildGeminiModel(),
-        {
-          messages: [{ role: "user", content: "hello", timestamp: 0 }],
-        } as unknown as Parameters<typeof streamFn>[1],
-        {
-          apiKey: "gemini-api-key",
-        } as Parameters<typeof streamFn>[2],
-      ),
-    );
-
-    const result = await stream.result();
+    const result = await runGeminiStreamResult({ options: { apiKey: "gemini-api-key" } });
 
     expect(result.stopReason).toBe("error");
     expect(result.errorMessage).toBe("Google SSE stream returned malformed JSON");
@@ -1255,31 +1209,23 @@ describe("google transport stream", () => {
           ]),
         );
 
-      const model = buildGeminiModel({
-        id: "gemini-3.1-pro-preview",
-        name: "Gemini 3.1 Pro Preview",
+      const result = await runGeminiStreamResult({
+        model: buildGeminiModel({
+          id: "gemini-3.1-pro-preview",
+          name: "Gemini 3.1 Pro Preview",
+        }),
+        context: {
+          messages: [{ role: "user", content: "hello", timestamp: 0 }],
+          tools: [
+            {
+              name: "lookup",
+              description: "Look up a value",
+              parameters: { type: "object", properties: { q: { type: "string" } } },
+            },
+          ],
+        } as Parameters<ReturnType<typeof createGoogleGenerativeAiTransportStreamFn>>[1],
+        options: { reasoning: "high" },
       });
-      const streamFn = createGoogleGenerativeAiTransportStreamFn();
-      const stream = await Promise.resolve(
-        streamFn(
-          model,
-          {
-            messages: [{ role: "user", content: "hello", timestamp: 0 }],
-            tools: [
-              {
-                name: "lookup",
-                description: "Look up a value",
-                parameters: {
-                  type: "object",
-                  properties: { q: { type: "string" } },
-                },
-              },
-            ],
-          } as never,
-          { reasoning: "high" } as never,
-        ),
-      );
-      const result = await stream.result();
 
       expect(result.content).toEqual([{ type: "text", text: "recovered" }]);
       expect(guardedFetchMock).toHaveBeenCalledTimes(2);
@@ -1370,21 +1316,13 @@ describe("google transport stream", () => {
       }),
     );
 
-    const model = buildGeminiModel({
-      id: "gemini-3.1-pro-preview",
-      name: "Gemini 3.1 Pro Preview",
+    const result = await runGeminiStreamResult({
+      model: buildGeminiModel({
+        id: "gemini-3.1-pro-preview",
+        name: "Gemini 3.1 Pro Preview",
+      }),
+      options: { reasoning: "high" },
     });
-    const streamFn = createGoogleGenerativeAiTransportStreamFn();
-    const stream = await Promise.resolve(
-      streamFn(
-        model,
-        {
-          messages: [{ role: "user", content: "hello", timestamp: 0 }],
-        } as never,
-        { reasoning: "high" } as never,
-      ),
-    );
-    const result = await stream.result();
 
     expect(result.content).toEqual([{ type: "text", text: "first second" }]);
     expect(guardedFetchMock).toHaveBeenCalledTimes(1);
@@ -1415,19 +1353,10 @@ describe("google transport stream", () => {
       },
     );
 
-    const streamFn = createGoogleGenerativeAiTransportStreamFn();
-    const stream = await Promise.resolve(
-      streamFn(
-        model,
-        {
-          messages: [{ role: "user", content: "hello", timestamp: 0 }],
-        } as Parameters<typeof streamFn>[1],
-        {
-          apiKey: JSON.stringify({ token: "oauth-token", projectId: "demo" }),
-        } as Parameters<typeof streamFn>[2],
-      ),
-    );
-    await stream.result();
+    await runGeminiStreamResult({
+      model,
+      options: { apiKey: JSON.stringify({ token: "oauth-token", projectId: "demo" }) },
+    });
 
     const guardedCall = requireMockCall(guardedFetchMock, 0, "guarded fetch");
     expect(typeof guardedCall[0]).toBe("string");
@@ -1477,11 +1406,7 @@ describe("google transport stream", () => {
   );
 
   it("resolves non-file Vertex ADC through google-auth-library without OAuth refresh fetch", async () => {
-    const tempDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-google-vertex-authlib-"));
-    vi.stubEnv("GOOGLE_APPLICATION_CREDENTIALS", "");
-    vi.stubEnv("HOME", path.join(tempDir, "home"));
-    vi.stubEnv("APPDATA", "");
-    googleAuthGetAccessTokenMock.mockResolvedValueOnce("ya29.google-auth-token");
+    await useGoogleAuthLibraryCredentials("authlib", "ya29.google-auth-token");
     const tokenFetchMock = vi.fn();
 
     await expect(resolveGoogleVertexAuthorizedUserHeaders(tokenFetchMock)).resolves.toEqual({
@@ -1558,12 +1483,7 @@ describe("google transport stream", () => {
   });
 
   it("bounds google-auth-library ADC token resolution at the Vertex owner", async () => {
-    const tempDir = await mkdtemp(
-      path.join(os.tmpdir(), "openclaw-google-vertex-authlib-timeout-"),
-    );
-    vi.stubEnv("GOOGLE_APPLICATION_CREDENTIALS", "");
-    vi.stubEnv("HOME", path.join(tempDir, "home"));
-    vi.stubEnv("APPDATA", "");
+    await useGoogleAuthLibraryCredentials("authlib-timeout");
     vi.useFakeTimers();
     googleAuthGetAccessTokenMock
       .mockReturnValueOnce(new Promise(() => {}))
@@ -1586,12 +1506,9 @@ describe("google transport stream", () => {
   });
 
   it("does not cache google-auth ADC tokens when fallback expiry would exceed Date range", async () => {
-    const tempDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-google-vertex-authlib-expiry-"));
+    await useGoogleAuthLibraryCredentials("authlib-expiry");
     vi.useFakeTimers();
     vi.setSystemTime(new Date(8_640_000_000_000_000));
-    vi.stubEnv("GOOGLE_APPLICATION_CREDENTIALS", "");
-    vi.stubEnv("HOME", path.join(tempDir, "home"));
-    vi.stubEnv("APPDATA", "");
     googleAuthGetAccessTokenMock
       .mockResolvedValueOnce("ya29.first-token")
       .mockResolvedValueOnce("ya29.second-token");
@@ -1609,36 +1526,13 @@ describe("google transport stream", () => {
   });
 
   it("uses google-auth-library bearer auth for Google Vertex credential marker requests", async () => {
-    const tempDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-google-vertex-authlib-stream-"));
-    vi.stubEnv("GOOGLE_APPLICATION_CREDENTIALS", "");
-    vi.stubEnv("HOME", path.join(tempDir, "home"));
-    vi.stubEnv("APPDATA", "");
+    await useGoogleAuthLibraryCredentials("authlib-stream", "ya29.transport-token");
     vi.stubEnv("GOOGLE_CLOUD_PROJECT", "vertex-project");
     vi.stubEnv("GOOGLE_CLOUD_LOCATION", "us-central1");
-    googleAuthGetAccessTokenMock.mockResolvedValueOnce("ya29.transport-token");
     const tokenFetchMock = vi.fn();
-    guardedFetchMock.mockResolvedValueOnce(
-      buildSseResponse([
-        {
-          candidates: [{ content: { parts: [{ text: "ok" }] }, finishReason: "STOP" }],
-        },
-      ]),
-    );
+    mockGoogleTextResponse();
 
-    const streamFn = createGoogleVertexTransportStreamFn();
-    const stream = await Promise.resolve(
-      streamFn(
-        buildGoogleVertexModel(),
-        {
-          messages: [{ role: "user", content: "hello", timestamp: 0 }],
-        } as Parameters<typeof streamFn>[1],
-        {
-          apiKey: "gcp-vertex-credentials",
-          fetch: tokenFetchMock,
-        } as Parameters<typeof streamFn>[2],
-      ),
-    );
-    await stream.result();
+    await runGoogleVertexStreamResult({ fetch: tokenFetchMock });
 
     expect(tokenFetchMock).not.toHaveBeenCalled();
     const guardedCall = requireMockCall(guardedFetchMock, 0, "guarded fetch");
@@ -1750,28 +1644,12 @@ describe("google transport stream", () => {
     vi.stubEnv("GOOGLE_CLOUD_LOCATION", "us-central1");
     googleAuthGetAccessTokenMock.mockResolvedValueOnce("ya29.transport-token");
     const tokenFetchMock = vi.fn();
-    guardedFetchMock.mockResolvedValueOnce(
-      buildSseResponse([
-        {
-          candidates: [{ content: { parts: [{ text: "ok" }] }, finishReason: "STOP" }],
-        },
-      ]),
-    );
+    mockGoogleTextResponse();
 
-    const streamFn = createGoogleVertexTransportStreamFn();
-    const stream = await Promise.resolve(
-      streamFn(
-        buildGoogleVertexModel({ id: "google/gemini-3.1-pro-preview" }),
-        {
-          messages: [{ role: "user", content: "hello", timestamp: 0 }],
-        } as Parameters<typeof streamFn>[1],
-        {
-          apiKey: "gcp-vertex-credentials",
-          fetch: tokenFetchMock,
-        } as Parameters<typeof streamFn>[2],
-      ),
-    );
-    await stream.result();
+    await runGoogleVertexStreamResult({
+      model: buildGoogleVertexModel({ id: "google/gemini-3.1-pro-preview" }),
+      fetch: tokenFetchMock,
+    });
 
     // The provider prefix must be stripped from the Vertex model path, matching
     // resolveGoogleModelPath; otherwise the id becomes models/google%2F... (404).
@@ -1792,13 +1670,7 @@ describe("google transport stream", () => {
         headers: { "content-type": "application/json" },
       }),
     );
-    guardedFetchMock.mockResolvedValueOnce(
-      buildSseResponse([
-        {
-          candidates: [{ content: { parts: [{ text: "ok" }] }, finishReason: "STOP" }],
-        },
-      ]),
-    );
+    mockGoogleTextResponse();
 
     const result = await runGoogleVertexStreamResult({ fetch: tokenFetchMock });
 
@@ -1877,13 +1749,7 @@ describe("google transport stream", () => {
         },
       ),
     );
-    guardedFetchMock.mockResolvedValueOnce(
-      buildSseResponse([
-        {
-          candidates: [{ content: { parts: [{ text: "ok" }] }, finishReason: "STOP" }],
-        },
-      ]),
-    );
+    mockGoogleTextResponse();
 
     await runGoogleVertexStreamResult({ fetch: tokenFetchMock });
 
@@ -1977,28 +1843,9 @@ describe("google transport stream", () => {
         headers: { "content-type": "application/json" },
       }),
     );
-    guardedFetchMock.mockResolvedValueOnce(
-      buildSseResponse([
-        {
-          candidates: [{ content: { parts: [{ text: "ok" }] }, finishReason: "STOP" }],
-        },
-      ]),
-    );
+    mockGoogleTextResponse();
 
-    const streamFn = createGoogleVertexTransportStreamFn();
-    const stream = await Promise.resolve(
-      streamFn(
-        buildGoogleVertexModel(),
-        {
-          messages: [{ role: "user", content: "hello", timestamp: 0 }],
-        } as Parameters<typeof streamFn>[1],
-        {
-          apiKey: "gcp-vertex-credentials",
-          fetch: tokenFetchMock,
-        } as Parameters<typeof streamFn>[2],
-      ),
-    );
-    await stream.result();
+    await runGoogleVertexStreamResult({ fetch: tokenFetchMock });
 
     const tokenCall = requireMockCall(tokenFetchMock, 0, "token fetch");
     expect(tokenCall[0]).toBe("https://oauth2.googleapis.com/token");
@@ -2195,18 +2042,11 @@ describe("google transport stream", () => {
   });
 
   it("does not re-attach replayed Gemini thought signatures to a different tool-call part", () => {
-    const model = buildGeminiModel({
-      id: "gemini-3.1-pro-preview",
-      name: "Gemini 3.1 Pro Preview",
-    });
-
-    const params = buildGoogleGenerativeAiParams(model, {
-      messages: [
-        googleToolCallAssistantTurn({ thoughtSignature: "Y2FsbF9zaWdfcmVwbGF5XzE=" }),
-        toolResultTurn(),
-        googleToolCallAssistantTurn({ timestamp: 2, args: { q: "hello-again" } }),
-      ],
-    } as never);
+    const params = buildGeminiReplayParams([
+      googleToolCallAssistantTurn({ thoughtSignature: "Y2FsbF9zaWdfcmVwbGF5XzE=" }),
+      toolResultTurn(),
+      googleToolCallAssistantTurn({ timestamp: 2, args: { q: "hello-again" } }),
+    ]);
 
     expect(getLastModelTurn(params.contents)).toMatchObject({
       role: "model",
@@ -2220,30 +2060,20 @@ describe("google transport stream", () => {
   });
 
   it("does not replay tool-call thought signatures from a different provider route", () => {
-    const model = buildGeminiModel({
-      id: "gemini-3.1-pro-preview",
-      name: "Gemini 3.1 Pro Preview",
-    });
-
     // Prior turn came from an Anthropic route — its signature looks valid base64
     // but must NOT be replayed into a Gemini request.
-    const params = buildGoogleGenerativeAiParams(model, {
-      messages: [
-        googleToolCallAssistantTurn({
-          provider: "anthropic",
-          api: "anthropic",
-          model: "claude-sonnet-4",
-          id: "call_foreign",
-          // Plausible-looking base64 from a non-Gemini provider.
-          thoughtSignature: "bXNnXzAxWEZEVURZSmdBQUNjblNNMlRUZ1FzQQ==",
-        }),
-        toolResultTurn("call_foreign"),
-        {
-          role: "user",
-          content: [{ type: "text", text: "Continue." }],
-        },
-      ],
-    } as never);
+    const params = buildGeminiReplayParams([
+      googleToolCallAssistantTurn({
+        provider: "anthropic",
+        api: "anthropic",
+        model: "claude-sonnet-4",
+        id: "call_foreign",
+        // Plausible-looking base64 from a non-Gemini provider.
+        thoughtSignature: "bXNnXzAxWEZEVURZSmdBQUNjblNNMlRUZ1FzQQ==",
+      }),
+      toolResultTurn("call_foreign"),
+      { role: "user", content: [{ type: "text", text: "Continue." }] },
+    ]);
 
     // The foreign signature should not be replayed into the Gemini payload.
     // Gemini 3 still needs the documented skip fallback for unsigned function
@@ -2264,23 +2094,16 @@ describe("google transport stream", () => {
   });
 
   it("does not replay prior Gemini thought signatures onto a later foreign route", () => {
-    const model = buildGeminiModel({
-      id: "gemini-3.1-pro-preview",
-      name: "Gemini 3.1 Pro Preview",
-    });
-
-    const params = buildGoogleGenerativeAiParams(model, {
-      messages: [
-        googleToolCallAssistantTurn({ thoughtSignature: "Y2FsbF9zaWdfZ29vZ2xlXzE=" }),
-        toolResultTurn(),
-        googleToolCallAssistantTurn({
-          provider: "anthropic",
-          api: "anthropic",
-          model: "claude-sonnet-4",
-          timestamp: 2,
-        }),
-      ],
-    } as never);
+    const params = buildGeminiReplayParams([
+      googleToolCallAssistantTurn({ thoughtSignature: "Y2FsbF9zaWdfZ29vZ2xlXzE=" }),
+      toolResultTurn(),
+      googleToolCallAssistantTurn({
+        provider: "anthropic",
+        api: "anthropic",
+        model: "claude-sonnet-4",
+        timestamp: 2,
+      }),
+    ]);
 
     const modelTurns = params.contents.filter(isModelTurnWithParts);
     expect(modelTurns).toHaveLength(2);
@@ -2319,44 +2142,37 @@ describe("google transport stream", () => {
   });
 
   it("adds skip-validator fallback to unsigned sibling Gemini 3 tool calls", () => {
-    const model = buildGeminiModel({
-      id: "gemini-3.1-pro-preview",
-      name: "Gemini 3.1 Pro Preview",
-    });
-
-    const params = buildGoogleGenerativeAiParams(model, {
-      messages: [
-        {
-          role: "assistant",
-          provider: "google",
-          api: "google-generative-ai",
-          model: "gemini-3.1-pro-preview",
-          stopReason: "toolUse",
-          timestamp: 0,
-          content: [
-            {
-              type: "toolCall",
-              id: "call_math",
-              name: "math_eval",
-              arguments: { expression: "17*23" },
-              thoughtSignature: "cmVhbF9zaWdfMQ==",
-            },
-            {
-              type: "toolCall",
-              id: "call_lookup",
-              name: "lookup_fact",
-              arguments: { key: "beta" },
-            },
-            {
-              type: "toolCall",
-              id: "call_transform",
-              name: "string_transform",
-              arguments: { text: "claw", mode: "reverse" },
-            },
-          ],
-        },
-      ],
-    } as never);
+    const params = buildGeminiReplayParams([
+      {
+        role: "assistant",
+        provider: "google",
+        api: "google-generative-ai",
+        model: "gemini-3.1-pro-preview",
+        stopReason: "toolUse",
+        timestamp: 0,
+        content: [
+          {
+            type: "toolCall",
+            id: "call_math",
+            name: "math_eval",
+            arguments: { expression: "17*23" },
+            thoughtSignature: "cmVhbF9zaWdfMQ==",
+          },
+          {
+            type: "toolCall",
+            id: "call_lookup",
+            name: "lookup_fact",
+            arguments: { key: "beta" },
+          },
+          {
+            type: "toolCall",
+            id: "call_transform",
+            name: "string_transform",
+            arguments: { text: "claw", mode: "reverse" },
+          },
+        ],
+      },
+    ]);
 
     const parts = (params.contents[0] as { parts: Array<Record<string, unknown>> }).parts;
     expect(parts).toHaveLength(3);
@@ -2440,18 +2256,12 @@ describe("google transport stream", () => {
   });
 
   it("builds direct Gemini payloads without negative fallback thinking budgets", () => {
-    const model = {
+    const model = buildGeminiModel({
       id: "custom-gemini-model",
       name: "Custom Gemini",
-      api: "google-generative-ai",
       provider: "custom-google",
       baseUrl: "https://proxy.example.com/gemini/v1beta",
-      reasoning: true,
-      input: ["text"],
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-      contextWindow: 128000,
-      maxTokens: 8192,
-    } satisfies Model<"google-generative-ai">;
+    });
 
     const params = buildGoogleGenerativeAiParams(
       model,
@@ -2576,17 +2386,9 @@ describe("google transport stream", () => {
   );
 
   it("maps explicit Gemini 3 thinking budgets to thinkingLevel", () => {
-    const params = buildGoogleGenerativeAiParams(
-      buildGeminiModel({ id: "gemini-3-flash-preview" }),
-      {
-        messages: [{ role: "user", content: "hello", timestamp: 0 }],
-      } as never,
-      {
-        thinking: {
-          enabled: true,
-          budgetTokens: 8192,
-        },
-      } as never,
+    const params = buildGeminiUserParams(
+      { id: "gemini-3-flash-preview" },
+      { thinking: { enabled: true, budgetTokens: 8192 } },
     );
 
     const generationConfig = requireGenerationConfig(params);
@@ -2599,14 +2401,9 @@ describe("google transport stream", () => {
   });
 
   it("keeps adaptive Gemini 3 thinking on provider dynamic defaults", () => {
-    const params = buildGoogleGenerativeAiParams(
-      buildGeminiModel({ id: "gemini-3-flash-preview" }),
-      {
-        messages: [{ role: "user", content: "hello", timestamp: 0 }],
-      } as never,
-      {
-        reasoning: "adaptive",
-      } as never,
+    const params = buildGeminiUserParams(
+      { id: "gemini-3-flash-preview" },
+      { reasoning: "adaptive" },
     );
 
     const generationConfig = requireGenerationConfig(params);
@@ -2617,15 +2414,7 @@ describe("google transport stream", () => {
   });
 
   it("maps adaptive Gemini 2.5 thinking to dynamic thinkingBudget", () => {
-    const params = buildGoogleGenerativeAiParams(
-      buildGeminiModel({ id: "gemini-2.5-flash" }),
-      {
-        messages: [{ role: "user", content: "hello", timestamp: 0 }],
-      } as never,
-      {
-        reasoning: "adaptive",
-      } as never,
-    );
+    const params = buildGeminiUserParams({ id: "gemini-2.5-flash" }, { reasoning: "adaptive" });
 
     const generationConfig = requireGenerationConfig(params);
     expect(requireThinkingConfig(generationConfig)).toEqual({
@@ -2635,17 +2424,9 @@ describe("google transport stream", () => {
   });
 
   it("normalizes explicit Gemini 3 Pro thinking levels", () => {
-    const params = buildGoogleGenerativeAiParams(
-      buildGeminiModel({ id: "gemini-3.1-pro-preview" }),
-      {
-        messages: [{ role: "user", content: "hello", timestamp: 0 }],
-      } as never,
-      {
-        thinking: {
-          enabled: true,
-          level: "MINIMAL",
-        },
-      } as never,
+    const params = buildGeminiUserParams(
+      { id: "gemini-3.1-pro-preview" },
+      { thinking: { enabled: true, level: "MINIMAL" } },
     );
 
     const generationConfig = requireGenerationConfig(params);
@@ -2689,11 +2470,8 @@ describe("google transport stream", () => {
   });
 
   it("includes cachedContent in direct Gemini payloads when requested", () => {
-    const params = buildGoogleGenerativeAiParams(
-      buildGeminiModel(),
-      {
-        messages: [{ role: "user", content: "hello", timestamp: 0 }],
-      } as never,
+    const params = buildGeminiUserParams(
+      {},
       {
         cachedContent: "cachedContents/prebuilt-context",
       },
@@ -2995,13 +2773,7 @@ describe("google transport stream", () => {
     ["gemini-2.5-flash", "medium", 8192],
     ["gemini-2.5-pro", "medium", 8192],
   ] as const)("%s with reasoning=%s uses thinkingBudget %i", (id, reasoning, expectedBudget) => {
-    const params = buildGoogleGenerativeAiParams(
-      buildGeminiModel({ id }),
-      {
-        messages: [{ role: "user", content: "hello", timestamp: 0 }],
-      } as never,
-      { reasoning },
-    );
+    const params = buildGeminiUserParams({ id }, { reasoning });
 
     const generationConfig = requireGenerationConfig(params);
     expect(requireThinkingConfig(generationConfig)).toEqual({
@@ -3103,23 +2875,17 @@ describe("google transport stream", () => {
       ]),
     );
 
-    const model = buildGeminiModel({
-      id: "gemini-3.1-pro-preview",
-      name: "Gemini 3.1 Pro Preview",
+    const result = await runGeminiStreamResult({
+      model: buildGeminiModel({
+        id: "gemini-3.1-pro-preview",
+        name: "Gemini 3.1 Pro Preview",
+      }),
+      context: {
+        systemPrompt: "You are a helpful assistant.",
+        messages: [{ role: "user", content: "hello", timestamp: 0 }],
+      } as Parameters<ReturnType<typeof createGoogleGenerativeAiTransportStreamFn>>[1],
+      options: { reasoning: "high" },
     });
-
-    const streamFn = createGoogleGenerativeAiTransportStreamFn();
-    const stream = await Promise.resolve(
-      streamFn(
-        model,
-        {
-          systemPrompt: "You are a helpful assistant.",
-          messages: [{ role: "user", content: "hello", timestamp: 0 }],
-        } as never,
-        { reasoning: "high" },
-      ),
-    );
-    const result = await stream.result();
 
     expect(result.content).toEqual([
       { type: "thinking", thinking: "draft", thinkingSignature: "c2lnXzE=" },


### PR DESCRIPTION
## What Problem This Solves

Bedrock discovery/runtime and Google transport tests repeated equivalent profile, cache, payload, replay, and streaming fixtures. Ollama’s original scope has already been superseded by #118419.

## Why This Change Was Made

Rebuild three current provider-owner suites on `main`, extend the existing Bedrock summary fixture, and reuse Google helpers landed by #114424. Ordered one-shot responses, cache reset, fresh streams, SSE framing, abort, usage, and tool-order cases remain.

## User Impact

No provider runtime behavior changes. All 214 current cases remain while tests are 446 lines smaller.

## Evidence

- Baseline and exact-head candidate both pass 3 files / 214 tests (61.03s including 46s lock wait vs 13.75s).
- Initial focused run exposed skipped Bedrock helper definitions; restored owner-local payload/converse helpers and reran clean.
- `node scripts/check-changed.mjs` passed extension typecheck, formatting, 245-rule lint and all guards. Testbox `tbx_01kzke1kyr4r05acm36n47xjb7`; [run](https://github.com/openclaw/openclaw/actions/runs/31317962904).
- Autoreview clean after one round; `git diff --check` passed.
- Scope: three provider tests, production `+0/-0`, tests `+472/-918` (net `-446`). Ollama excluded.
