### PR TITLE
perf(gateway): yield between transcript delta pages during cold touched-files folds

### DIFF
--- a/src/gateway/server-methods/sessions-files.touched-files.test.ts
+++ b/src/gateway/server-methods/sessions-files.touched-files.test.ts
@@ -153,6 +153,75 @@ describe("sessions.files touched-file folds", () => {
     });
   });
 
+  it("yields between SQLite pages and shares one concurrent fold per session", async () => {
+    useSqliteSession(hoisted.loadSessionEntry, workspaceRoot, "sess-touched-singleflight");
+    let otherWorkRan = false;
+    setImmediate(() => {
+      otherWorkRan = true;
+    });
+    hoisted.readSessionTranscriptVisibleMessageDelta.mockImplementation((_scope, limits) => {
+      if (limits.cursor !== undefined) {
+        expect(limits.cursor).toBe("singleflight-page-1");
+        expect(otherWorkRan).toBe(true);
+      }
+      return {
+        kind: "page",
+        cursor: limits.cursor === undefined ? "singleflight-page-1" : "singleflight-final",
+        events: [],
+        hasMore: limits.cursor === undefined,
+        serializedBytes: 100,
+      };
+    });
+
+    const params = { sessionKey: "agent:main:main" };
+    const first = invokeSessionFilesHandler("sessions.files.list", params);
+    const second = invokeSessionFilesHandler("sessions.files.list", params);
+
+    expect(hoisted.readSessionTranscriptVisibleMessageDelta).toHaveBeenCalledTimes(1);
+    for (const result of await Promise.all([first, second])) {
+      expectOkPayload(result);
+    }
+    expect(hoisted.readSessionTranscriptVisibleMessageDelta).toHaveBeenCalledTimes(2);
+  });
+
+  it("lets a different session finish while a multi-page fold is yielded", async () => {
+    hoisted.resolveAgentWorkspaceDir.mockReturnValue(undefined);
+    hoisted.loadSessionEntry.mockImplementation((sessionKey: string) => {
+      const sessionId = sessionKey.endsWith(":slow") ? "sess-touched-slow" : "sess-touched-fast";
+      const storePath = path.join(workspaceRoot, `${sessionId}.sqlite`);
+      return {
+        canonicalKey: sessionKey,
+        cfg: {},
+        storePath,
+        entry: { sessionId, sessionFile: `sqlite:main:${sessionId}:${storePath}` },
+      };
+    });
+    hoisted.readSessionTranscriptVisibleMessageDelta.mockImplementation((scope, limits) => {
+      const isSlow = scope.sessionId === "sess-touched-slow";
+      return {
+        kind: "page",
+        cursor: isSlow ? "slow-final" : "fast-final",
+        events: [],
+        hasMore: isSlow && limits.cursor === undefined,
+        serializedBytes: 100,
+      };
+    });
+
+    let slowFinished = false;
+    const slow = invokeSessionFilesHandler("sessions.files.list", {
+      sessionKey: "agent:main:slow",
+    }).then((result) => {
+      slowFinished = true;
+      return result;
+    });
+    expectOkPayload(
+      await invokeSessionFilesHandler("sessions.files.list", { sessionKey: "agent:main:fast" }),
+    );
+
+    expect(slowFinished).toBe(false);
+    expectOkPayload(await slow);
+  });
+
   it("isolates touched-file folds for the same session across stores", async () => {
     const sessionId = "sess-touched-multi-store";
     const firstStorePath = path.join(workspaceRoot, "store-a.sqlite");

--- a/src/gateway/server-methods/sessions-files.ts
+++ b/src/gateway/server-methods/sessions-files.ts
@@ -96,6 +96,8 @@ const SEARCH_SKIP_DIRS = new Set([
 // Request latency must not scale with transcript size: delta resets rebuild the
 // fold, while this process-local LRU cap bounds retained session state.
 const touchedFilesCache = new Map<string, TouchedFilesCacheEntry>();
+// Page yields let other requests interleave, so singleflight keeps one cache-mutating fold per key.
+const touchedFilesFolds = new Map<string, Promise<Map<string, TouchedFile>>>();
 
 function readTouchedFilesCache(key: string): TouchedFilesCacheEntry | undefined {
   const cached = touchedFilesCache.get(key);
@@ -230,10 +232,10 @@ function collectTouchedFilesFromMessage(message: unknown, files: Map<string, Tou
   }
 }
 
-function loadSqliteTouchedFiles(
+async function foldSqliteTouchedFiles(
   scope: SessionTranscriptReadScope,
   cacheKey: string,
-): Map<string, TouchedFile> {
+): Promise<Map<string, TouchedFile>> {
   let cached = readTouchedFilesCache(cacheKey);
   let cursor = cached?.cursor;
   let files = cached?.files ?? new Map<string, TouchedFile>();
@@ -271,6 +273,26 @@ function loadSqliteTouchedFiles(
     if (delta.requiredBytes !== undefined) {
       maxBytes = delta.requiredBytes;
     }
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+  }
+}
+
+async function loadSqliteTouchedFiles(
+  scope: SessionTranscriptReadScope,
+  cacheKey: string,
+): Promise<Map<string, TouchedFile>> {
+  const inFlight = touchedFilesFolds.get(cacheKey);
+  if (inFlight) {
+    return inFlight;
+  }
+  const fold = foldSqliteTouchedFiles(scope, cacheKey);
+  touchedFilesFolds.set(cacheKey, fold);
+  try {
+    return await fold;
+  } finally {
+    touchedFilesFolds.delete(cacheKey);
   }
 }
 
@@ -624,7 +646,7 @@ async function loadSessionFiles(params: {
   const target = resolveTranscriptReadTarget(scope);
   // Entry-scoped reads without an explicit sessionFile always resolve to a canonical SQLite marker.
   // Legacy transcript files are doctor-owned migration debt, not a runtime read path.
-  const files = loadSqliteTouchedFiles(
+  const files = await loadSqliteTouchedFiles(
     toTranscriptReadScope(target),
     `${agentId}\0${entry.sessionId}\0${target.storePath ?? ""}`,
   );


### PR DESCRIPTION
## What Problem This Solves

After #114401 deployed to team.openclaw.ai, repeat `sessions.files.list` calls are sub-second, but COLD folds of very large transcripts (gateway boot, delta reset) still ran 14-66 seconds of uninterrupted synchronous work — the fold loop pages through the transcript delta with no yield, so every other gateway request stalls behind a cold fold.

## Why This Change Was Made

The fold is already paginated (1000 messages / 1MB per page); it just never yielded. `foldSqliteTouchedFiles` now awaits a `setImmediate` macrotask between pages so pending requests interleave with cold folds. Because pages can now interleave, a per-cache-key singleflight map keeps exactly one cache-mutating fold per session — concurrent requests for the same session share the fold; different sessions proceed independently. Single-page (warm/small) folds return without ever yielding, so the hot path is unchanged.

## User Impact

A giant session's first Files-panel load no longer freezes the rest of the Control UI (session lists, chat, board polling) for tens of seconds after a gateway restart. No response-shape change.

## Evidence

- Production journal post-#114401 deploy: cold folds at 14.5s/22.2s/24.4s/66.1s with correlated latency spikes on unrelated methods; warm repeats 463ms-2.7s (context: https://github.com/openclaw/openclaw/pull/114257#issuecomment-5088264732)
- `node scripts/run-vitest.mjs src/gateway/server-methods/sessions-files.test.ts src/gateway/server-methods/sessions-files.touched-files.test.ts` — 41 tests passing, including new regressions: concurrent same-session calls share one fold (delta reader not called twice for page 1), different sessions don't serialize behind each other
- tsgo core lane clean; autoreview (Codex gpt-5.6-sol, xhigh) clean
