### PR TITLE
fix(codex): account and trace every provider response

### DIFF
--- a/extensions/codex/src/app-server/attempt-diagnostics.test.ts
+++ b/extensions/codex/src/app-server/attempt-diagnostics.test.ts
@@ -46,28 +46,33 @@ describe("Codex app-server attempt diagnostics", () => {
     });
 
     diagnostics.emitStarted();
-    diagnostics.emitResponseCompleted({
+    diagnostics.recordResponseCompleted({
       responseId: "response-1",
-      completedAtMs: 1_100,
+      completedAtMs: 1_090,
       usage: { input: 80, output: 20, total: 100 },
     });
-    diagnostics.recordToolCompleted(1_200);
-    diagnostics.emitResponseCompleted({
+    diagnostics.recordToolStarted("tool-1", 1_100);
+    diagnostics.recordToolCompleted("tool-1", 1_200);
+    diagnostics.recordToolStarted("tool-2", 1_500);
+    diagnostics.recordToolCompleted("tool-2", 1_550);
+    // Codex can deliver this response completion after the tool triggered by
+    // that response has already finished. Pairing by response/tool order keeps
+    // the provider span bounded by the tool start instead of overlapping it.
+    diagnostics.recordResponseCompleted({
       responseId: "response-2",
-      completedAtMs: 1_500,
+      completedAtMs: 1_570,
       usage: { input: 220, output: 30, cacheRead: 50, reasoningTokens: 10, total: 300 },
     });
-    diagnostics.emitResponseCompleted({
+    diagnostics.recordResponseCompleted({
       responseId: "response-2",
-      completedAtMs: 1_550,
+      completedAtMs: 1_575,
       usage: { input: 1, output: 1, total: 2 },
     });
-    diagnostics.recordToolCompleted(1_550);
-    diagnostics.emitResponseCompleted({
+    diagnostics.recordResponseCompleted({
       responseId: "response-3",
-      completedAtMs: 1_575,
+      completedAtMs: 1_600,
     });
-    now = 1_600;
+    now = 1_650;
     diagnostics.emitCompleted({
       attemptUsage: {
         input: 300,
@@ -88,7 +93,8 @@ describe("Codex app-server attempt diagnostics", () => {
     expect(completed[0]).toMatchObject({
       callId: "run-1:codex-model:1:response:1",
       observationUnit: "request",
-      durationMs: 100,
+      durationMs: 90,
+      sourceTimestampMs: 1_090,
       usage: { input: 80, output: 20, total: 100 },
       trace: { traceId: trace.traceId, parentSpanId: trace.spanId },
     });
@@ -96,6 +102,7 @@ describe("Codex app-server attempt diagnostics", () => {
       callId: "run-1:codex-model:1:response:2",
       observationUnit: "request",
       durationMs: 300,
+      sourceTimestampMs: 1_500,
       usage: {
         input: 220,
         output: 30,
@@ -109,13 +116,14 @@ describe("Codex app-server attempt diagnostics", () => {
     expect(completed[2]).toMatchObject({
       callId: "run-1:codex-model:1:response:3",
       observationUnit: "request",
-      durationMs: 25,
+      durationMs: 50,
+      sourceTimestampMs: 1_600,
     });
     expect(completed[2]).not.toHaveProperty("usage");
     expect(completed[3]).toMatchObject({
       callId: "run-1:codex-model:1",
       observationUnit: "turn",
-      durationMs: 600,
+      durationMs: 650,
       usage: {
         input: 300,
         output: 50,
@@ -124,6 +132,60 @@ describe("Codex app-server attempt diagnostics", () => {
         total: 400,
       },
     });
+  });
+
+  it("collapses sequential tools emitted by one provider response", async () => {
+    const events: DiagnosticEventPayload[] = [];
+    const unsubscribe = onInternalDiagnosticEvent((event) => {
+      if (event.type === "model.call.completed" && event.observationUnit === "request") {
+        events.push(event);
+      }
+    });
+    let now = 1_000;
+    const diagnostics = createCodexModelCallDiagnosticEmitter({
+      baseFields: {
+        runId: "run-sequential-tools",
+        callId: "run-sequential-tools:codex-model:1",
+        provider: "openai",
+        model: "gpt-5",
+      },
+      capture: {},
+      tools: [],
+      buildInputMessages: () => [],
+      buildSystemPrompt: () => undefined,
+      now: () => now,
+    });
+
+    diagnostics.emitStarted();
+    diagnostics.recordToolStarted("tool-1", 1_100);
+    diagnostics.recordToolCompleted("tool-1", 1_200);
+    diagnostics.recordToolStarted("tool-2", 1_201);
+    diagnostics.recordToolCompleted("tool-2", 1_300);
+    diagnostics.recordResponseCompleted({
+      responseId: "response-1",
+      completedAtMs: 1_350,
+      usage: { total: 10 },
+    });
+    diagnostics.recordResponseCompleted({
+      responseId: "response-2",
+      completedAtMs: 1_500,
+      usage: { total: 20 },
+    });
+    now = 1_550;
+    diagnostics.emitCompleted({});
+    await waitForDiagnosticEventsDrained();
+    unsubscribe();
+
+    expect(
+      events.map((event) => ({
+        durationMs: "durationMs" in event ? event.durationMs : undefined,
+        sourceTimestampMs: "sourceTimestampMs" in event ? event.sourceTimestampMs : undefined,
+        total: "usage" in event ? event.usage?.total : undefined,
+      })),
+    ).toEqual([
+      { durationMs: 100, sourceTimestampMs: 1_100, total: 10 },
+      { durationMs: 200, sourceTimestampMs: 1_500, total: 20 },
+    ]);
   });
 
   it("redacts plugin thread config eligibility log data", () => {

--- a/extensions/codex/src/app-server/attempt-diagnostics.test.ts
+++ b/extensions/codex/src/app-server/attempt-diagnostics.test.ts
@@ -1,10 +1,131 @@
 // Codex tests cover attempt diagnostics plugin behavior.
-import { describe, expect, it } from "vitest";
-import { buildCodexPluginThreadConfigEligibilityLogData } from "./attempt-diagnostics.js";
+import {
+  createDiagnosticTraceContext,
+  onInternalDiagnosticEvent,
+  resetDiagnosticEventsForTest,
+  waitForDiagnosticEventsDrained,
+  type DiagnosticEventPayload,
+} from "openclaw/plugin-sdk/diagnostic-runtime";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  buildCodexPluginThreadConfigEligibilityLogData,
+  createCodexModelCallDiagnosticEmitter,
+} from "./attempt-diagnostics.js";
 import { resolveCodexPluginsPolicy } from "./config.js";
 import { buildCodexPluginAppCacheKey } from "./plugin-app-cache-key.js";
 
 describe("Codex app-server attempt diagnostics", () => {
+  afterEach(() => resetDiagnosticEventsForTest());
+
+  it("projects response-level model calls between tool boundaries", async () => {
+    const events: DiagnosticEventPayload[] = [];
+    const unsubscribe = onInternalDiagnosticEvent((event) => {
+      if (event.type.startsWith("model.call.")) {
+        events.push(event);
+      }
+    });
+    let now = 1_000;
+    const trace = createDiagnosticTraceContext();
+    const diagnostics = createCodexModelCallDiagnosticEmitter({
+      baseFields: {
+        runId: "run-1",
+        callId: "run-1:codex-model:1",
+        sessionId: "session-1",
+        provider: "openai",
+        model: "gpt-5",
+        api: "openai-chatgpt-responses",
+        transport: "stdio",
+        observationUnit: "turn",
+        trace,
+      },
+      capture: {},
+      tools: [],
+      buildInputMessages: () => [],
+      buildSystemPrompt: () => undefined,
+      now: () => now,
+    });
+
+    diagnostics.emitStarted();
+    diagnostics.emitResponseCompleted({
+      responseId: "response-1",
+      completedAtMs: 1_100,
+      usage: { input: 80, output: 20, total: 100 },
+    });
+    diagnostics.recordToolCompleted(1_200);
+    diagnostics.emitResponseCompleted({
+      responseId: "response-2",
+      completedAtMs: 1_500,
+      usage: { input: 220, output: 30, cacheRead: 50, reasoningTokens: 10, total: 300 },
+    });
+    diagnostics.emitResponseCompleted({
+      responseId: "response-2",
+      completedAtMs: 1_550,
+      usage: { input: 1, output: 1, total: 2 },
+    });
+    diagnostics.recordToolCompleted(1_550);
+    diagnostics.emitResponseCompleted({
+      responseId: "response-3",
+      completedAtMs: 1_575,
+    });
+    now = 1_600;
+    diagnostics.emitCompleted({
+      attemptUsage: {
+        input: 300,
+        output: 50,
+        cacheRead: 50,
+        reasoningTokens: 10,
+        total: 400,
+      },
+    });
+    await waitForDiagnosticEventsDrained();
+    unsubscribe();
+
+    const completed = events.filter(
+      (event): event is Extract<DiagnosticEventPayload, { type: "model.call.completed" }> =>
+        event.type === "model.call.completed",
+    );
+    expect(completed).toHaveLength(4);
+    expect(completed[0]).toMatchObject({
+      callId: "run-1:codex-model:1:response:1",
+      observationUnit: "request",
+      durationMs: 100,
+      usage: { input: 80, output: 20, total: 100 },
+      trace: { traceId: trace.traceId, parentSpanId: trace.spanId },
+    });
+    expect(completed[1]).toMatchObject({
+      callId: "run-1:codex-model:1:response:2",
+      observationUnit: "request",
+      durationMs: 300,
+      usage: {
+        input: 220,
+        output: 30,
+        cacheRead: 50,
+        reasoningTokens: 10,
+        total: 300,
+      },
+      trace: { traceId: trace.traceId, parentSpanId: trace.spanId },
+    });
+    expect(completed[0]?.trace?.spanId).not.toBe(completed[1]?.trace?.spanId);
+    expect(completed[2]).toMatchObject({
+      callId: "run-1:codex-model:1:response:3",
+      observationUnit: "request",
+      durationMs: 25,
+    });
+    expect(completed[2]).not.toHaveProperty("usage");
+    expect(completed[3]).toMatchObject({
+      callId: "run-1:codex-model:1",
+      observationUnit: "turn",
+      durationMs: 600,
+      usage: {
+        input: 300,
+        output: 50,
+        cacheRead: 50,
+        reasoningTokens: 10,
+        total: 400,
+      },
+    });
+  });
+
   it("redacts plugin thread config eligibility log data", () => {
     const appServer = {
       start: {

--- a/extensions/codex/src/app-server/attempt-diagnostics.ts
+++ b/extensions/codex/src/app-server/attempt-diagnostics.ts
@@ -4,8 +4,11 @@
  */
 import { createHash } from "node:crypto";
 import {
+  createChildDiagnosticTraceContext,
   emitTrustedDiagnosticEventWithPrivateData,
+  freezeDiagnosticTraceContext,
   type DiagnosticModelCallContent,
+  type DiagnosticTraceContext,
 } from "openclaw/plugin-sdk/diagnostic-runtime";
 import type { CodexAppServerRuntimeOptions, resolveCodexPluginsPolicy } from "./config.js";
 
@@ -104,6 +107,36 @@ type CodexModelCallDiagnosticTool = {
   parameters?: unknown;
 };
 
+type CodexModelCallUsage = {
+  input?: number;
+  output?: number;
+  cacheRead?: number;
+  cacheWrite?: number;
+  reasoningTokens?: number;
+  total?: number;
+};
+
+type CodexResponseDiagnostic = {
+  responseId: string;
+  usage?: CodexModelCallUsage;
+  completedAtMs?: number;
+};
+
+function diagnosticUsage(usage: CodexModelCallUsage | undefined): CodexModelCallUsage | undefined {
+  if (!usage) {
+    return undefined;
+  }
+  const projected = {
+    input: usage.input,
+    output: usage.output,
+    cacheRead: usage.cacheRead,
+    cacheWrite: usage.cacheWrite,
+    reasoningTokens: usage.reasoningTokens,
+    total: usage.total,
+  };
+  return Object.values(projected).some((value) => value !== undefined) ? projected : undefined;
+}
+
 /**
  * Creates lifecycle emitters for trusted model-call diagnostics with optional
  * private payload capture.
@@ -121,10 +154,15 @@ export function createCodexModelCallDiagnosticEmitter(params: {
   const toolDefinitions = params.capture.toolDefinitions
     ? buildCodexDiagnosticToolDefinitions(params.tools)
     : undefined;
+  const turnCallId = String(params.baseFields.callId);
+  const turnTrace = params.baseFields.trace as DiagnosticTraceContext | undefined;
   let startedAt = now();
   let started = false;
   let terminalEmitted = false;
   let requestPayloadBytes: number | undefined;
+  let responseSequence = 0;
+  let nextResponseStartedAt = startedAt;
+  const completedResponseIds = new Set<string>();
 
   const privateData = (modelContent: DiagnosticModelCallContent | undefined) =>
     modelContent && Object.keys(modelContent).length > 0 ? { modelContent } : undefined;
@@ -145,6 +183,7 @@ export function createCodexModelCallDiagnosticEmitter(params: {
     },
     emitStarted(): void {
       startedAt = now();
+      nextResponseStartedAt = startedAt;
       started = true;
       emitTrustedDiagnosticEventWithPrivateData(
         {
@@ -154,17 +193,23 @@ export function createCodexModelCallDiagnosticEmitter(params: {
         privateData(buildContent()),
       );
     },
-    emitCompleted(result: { assistantTexts?: unknown; lastAssistant?: unknown }): void {
+    emitCompleted(result: {
+      assistantTexts?: unknown;
+      lastAssistant?: unknown;
+      attemptUsage?: CodexModelCallUsage;
+    }): void {
       if (!started || terminalEmitted) {
         return;
       }
       terminalEmitted = true;
+      const usage = diagnosticUsage(result.attemptUsage);
       emitTrustedDiagnosticEventWithPrivateData(
         {
           type: "model.call.completed",
           ...params.baseFields,
           durationMs: Math.max(0, now() - startedAt),
           ...requestPayloadBytesField(),
+          ...(usage ? { usage } : {}),
         } as TrustedDiagnosticEventInput,
         privateData({
           ...buildContent(),
@@ -177,6 +222,50 @@ export function createCodexModelCallDiagnosticEmitter(params: {
             : {}),
         }),
       );
+    },
+    recordToolCompleted(completedAtMs = now()): void {
+      if (!started || terminalEmitted || !Number.isFinite(completedAtMs)) {
+        return;
+      }
+      nextResponseStartedAt = Math.max(nextResponseStartedAt, completedAtMs);
+    },
+    emitResponseCompleted(response: CodexResponseDiagnostic): void {
+      if (
+        !started ||
+        terminalEmitted ||
+        !response.responseId ||
+        completedResponseIds.has(response.responseId)
+      ) {
+        return;
+      }
+      const usage = diagnosticUsage(response.usage);
+      completedResponseIds.add(response.responseId);
+      responseSequence += 1;
+      const completedAtMs =
+        response.completedAtMs !== undefined && Number.isFinite(response.completedAtMs)
+          ? response.completedAtMs
+          : now();
+      const responseStartedAt = Math.min(nextResponseStartedAt, completedAtMs);
+      nextResponseStartedAt = completedAtMs;
+      const responseTrace = turnTrace
+        ? freezeDiagnosticTraceContext(createChildDiagnosticTraceContext(turnTrace))
+        : undefined;
+      // App-server exposes response completion but no matching request-start event.
+      // A completed-only diagnostic lets the OTel recorder backdate the span from
+      // this duration instead of tracking a zero-length synthetic start.
+      emitTrustedDiagnosticEventWithPrivateData({
+        type: "model.call.completed",
+        ...params.baseFields,
+        callId: `${turnCallId}:response:${responseSequence}`,
+        observationUnit: "request",
+        ...(responseTrace ? { trace: responseTrace } : {}),
+        durationMs: Math.max(0, completedAtMs - responseStartedAt),
+        upstreamRequestIdHash: fingerprintCodexLogValue(
+          "openclaw:codex:response-id:v1",
+          response.responseId,
+        ),
+        ...(usage ? { usage } : {}),
+      } as TrustedDiagnosticEventInput);
     },
     emitError(error: unknown, fields: { failureKind?: CodexModelCallFailureKind } = {}): void {
       if (!started || terminalEmitted) {

--- a/extensions/codex/src/app-server/attempt-diagnostics.ts
+++ b/extensions/codex/src/app-server/attempt-diagnostics.ts
@@ -122,6 +122,11 @@ type CodexResponseDiagnostic = {
   completedAtMs?: number;
 };
 
+type CodexModelCallInterval = {
+  startedAtMs: number;
+  completedAtMs: number;
+};
+
 function diagnosticUsage(usage: CodexModelCallUsage | undefined): CodexModelCallUsage | undefined {
   if (!usage) {
     return undefined;
@@ -161,8 +166,12 @@ export function createCodexModelCallDiagnosticEmitter(params: {
   let terminalEmitted = false;
   let requestPayloadBytes: number | undefined;
   let responseSequence = 0;
-  let nextResponseStartedAt = startedAt;
+  let currentResponseStartedAt: number | undefined = startedAt;
+  let responseDiagnosticsEmitted = false;
   const completedResponseIds = new Set<string>();
+  const completedResponses: CodexResponseDiagnostic[] = [];
+  const activeToolCallIds = new Set<string>();
+  const responseIntervals: CodexModelCallInterval[] = [];
 
   const privateData = (modelContent: DiagnosticModelCallContent | undefined) =>
     modelContent && Object.keys(modelContent).length > 0 ? { modelContent } : undefined;
@@ -176,6 +185,84 @@ export function createCodexModelCallDiagnosticEmitter(params: {
   };
   const requestPayloadBytesField = () =>
     requestPayloadBytes !== undefined ? { requestPayloadBytes } : {};
+  const emitResponseDiagnostics = (terminalAtMs: number): void => {
+    if (responseDiagnosticsEmitted) {
+      return;
+    }
+    responseDiagnosticsEmitted = true;
+    if (completedResponses.length === 0) {
+      return;
+    }
+    const intervals = [...responseIntervals];
+    if (currentResponseStartedAt !== undefined) {
+      const lastCompletedAt = completedResponses.at(-1)?.completedAtMs ?? terminalAtMs;
+      intervals.push({
+        startedAtMs: currentResponseStartedAt,
+        completedAtMs: Math.max(currentResponseStartedAt, lastCompletedAt),
+      });
+    }
+    // One provider response may request several tools. If those tools execute
+    // sequentially, a tiny tool-to-tool gap looks like a model interval. Remove
+    // the shortest surplus gaps before pairing lifecycle intervals by order.
+    while (intervals.length > completedResponses.length) {
+      let shortestIndex = 0;
+      for (let index = 1; index < intervals.length; index += 1) {
+        const shortest = intervals[shortestIndex];
+        const candidate = intervals[index];
+        if (
+          shortest &&
+          candidate &&
+          candidate.completedAtMs - candidate.startedAtMs <
+            shortest.completedAtMs - shortest.startedAtMs
+        ) {
+          shortestIndex = index;
+        }
+      }
+      intervals.splice(shortestIndex, 1);
+    }
+    const projectedIntervals =
+      intervals.length === completedResponses.length
+        ? intervals
+        : completedResponses.map((response, index) => {
+            const previousCompletedAt =
+              index === 0 ? startedAt : (completedResponses[index - 1]?.completedAtMs ?? startedAt);
+            const responseCompletedAt = response.completedAtMs ?? terminalAtMs;
+            return {
+              startedAtMs: previousCompletedAt,
+              completedAtMs: Math.max(previousCompletedAt, responseCompletedAt),
+            };
+          });
+    for (const [index, response] of completedResponses.entries()) {
+      const interval = projectedIntervals[index];
+      if (!interval) {
+        continue;
+      }
+      const responseCompletedAt = response.completedAtMs ?? terminalAtMs;
+      const completedAtMs = Math.max(
+        interval.startedAtMs,
+        Math.min(interval.completedAtMs, responseCompletedAt),
+      );
+      const usage = diagnosticUsage(response.usage);
+      const responseTrace = turnTrace
+        ? freezeDiagnosticTraceContext(createChildDiagnosticTraceContext(turnTrace))
+        : undefined;
+      responseSequence += 1;
+      emitTrustedDiagnosticEventWithPrivateData({
+        type: "model.call.completed",
+        ...params.baseFields,
+        callId: `${turnCallId}:response:${responseSequence}`,
+        observationUnit: "request",
+        ...(responseTrace ? { trace: responseTrace } : {}),
+        durationMs: Math.max(0, completedAtMs - interval.startedAtMs),
+        sourceTimestampMs: completedAtMs,
+        upstreamRequestIdHash: fingerprintCodexLogValue(
+          "openclaw:codex:response-id:v1",
+          response.responseId,
+        ),
+        ...(usage ? { usage } : {}),
+      } as TrustedDiagnosticEventInput);
+    }
+  };
 
   return {
     setRequestPayloadBytes(bytes: number | undefined): void {
@@ -183,7 +270,7 @@ export function createCodexModelCallDiagnosticEmitter(params: {
     },
     emitStarted(): void {
       startedAt = now();
-      nextResponseStartedAt = startedAt;
+      currentResponseStartedAt = startedAt;
       started = true;
       emitTrustedDiagnosticEventWithPrivateData(
         {
@@ -201,13 +288,15 @@ export function createCodexModelCallDiagnosticEmitter(params: {
       if (!started || terminalEmitted) {
         return;
       }
+      const completedAtMs = now();
+      emitResponseDiagnostics(completedAtMs);
       terminalEmitted = true;
       const usage = diagnosticUsage(result.attemptUsage);
       emitTrustedDiagnosticEventWithPrivateData(
         {
           type: "model.call.completed",
           ...params.baseFields,
-          durationMs: Math.max(0, now() - startedAt),
+          durationMs: Math.max(0, completedAtMs - startedAt),
           ...requestPayloadBytesField(),
           ...(usage ? { usage } : {}),
         } as TrustedDiagnosticEventInput,
@@ -223,13 +312,40 @@ export function createCodexModelCallDiagnosticEmitter(params: {
         }),
       );
     },
-    recordToolCompleted(completedAtMs = now()): void {
-      if (!started || terminalEmitted || !Number.isFinite(completedAtMs)) {
+    recordToolStarted(toolCallId: string, startedAtMs = now()): void {
+      if (
+        !started ||
+        terminalEmitted ||
+        !toolCallId ||
+        activeToolCallIds.has(toolCallId) ||
+        !Number.isFinite(startedAtMs)
+      ) {
         return;
       }
-      nextResponseStartedAt = Math.max(nextResponseStartedAt, completedAtMs);
+      if (activeToolCallIds.size === 0 && currentResponseStartedAt !== undefined) {
+        responseIntervals.push({
+          startedAtMs: currentResponseStartedAt,
+          completedAtMs: Math.max(currentResponseStartedAt, startedAtMs),
+        });
+        currentResponseStartedAt = undefined;
+      }
+      activeToolCallIds.add(toolCallId);
     },
-    emitResponseCompleted(response: CodexResponseDiagnostic): void {
+    recordToolCompleted(toolCallId: string, completedAtMs = now()): void {
+      if (
+        !started ||
+        terminalEmitted ||
+        !toolCallId ||
+        !Number.isFinite(completedAtMs) ||
+        !activeToolCallIds.delete(toolCallId)
+      ) {
+        return;
+      }
+      if (activeToolCallIds.size === 0) {
+        currentResponseStartedAt = completedAtMs;
+      }
+    },
+    recordResponseCompleted(response: CodexResponseDiagnostic): void {
       if (
         !started ||
         terminalEmitted ||
@@ -238,45 +354,25 @@ export function createCodexModelCallDiagnosticEmitter(params: {
       ) {
         return;
       }
-      const usage = diagnosticUsage(response.usage);
       completedResponseIds.add(response.responseId);
-      responseSequence += 1;
       const completedAtMs =
         response.completedAtMs !== undefined && Number.isFinite(response.completedAtMs)
           ? response.completedAtMs
           : now();
-      const responseStartedAt = Math.min(nextResponseStartedAt, completedAtMs);
-      nextResponseStartedAt = completedAtMs;
-      const responseTrace = turnTrace
-        ? freezeDiagnosticTraceContext(createChildDiagnosticTraceContext(turnTrace))
-        : undefined;
-      // App-server exposes response completion but no matching request-start event.
-      // A completed-only diagnostic lets the OTel recorder backdate the span from
-      // this duration instead of tracking a zero-length synthetic start.
-      emitTrustedDiagnosticEventWithPrivateData({
-        type: "model.call.completed",
-        ...params.baseFields,
-        callId: `${turnCallId}:response:${responseSequence}`,
-        observationUnit: "request",
-        ...(responseTrace ? { trace: responseTrace } : {}),
-        durationMs: Math.max(0, completedAtMs - responseStartedAt),
-        upstreamRequestIdHash: fingerprintCodexLogValue(
-          "openclaw:codex:response-id:v1",
-          response.responseId,
-        ),
-        ...(usage ? { usage } : {}),
-      } as TrustedDiagnosticEventInput);
+      completedResponses.push({ ...response, completedAtMs });
     },
     emitError(error: unknown, fields: { failureKind?: CodexModelCallFailureKind } = {}): void {
       if (!started || terminalEmitted) {
         return;
       }
+      const completedAtMs = now();
+      emitResponseDiagnostics(completedAtMs);
       terminalEmitted = true;
       emitTrustedDiagnosticEventWithPrivateData(
         {
           type: "model.call.error",
           ...params.baseFields,
-          durationMs: Math.max(0, now() - startedAt),
+          durationMs: Math.max(0, completedAtMs - startedAt),
           errorCategory: fields.failureKind ?? "error",
           ...(fields.failureKind ? { failureKind: fields.failureKind } : {}),
           ...requestPayloadBytesField(),

--- a/extensions/codex/src/app-server/bounded-turn.test.ts
+++ b/extensions/codex/src/app-server/bounded-turn.test.ts
@@ -105,6 +105,17 @@ function createClientFactory(
     terminalStatus?: "completed" | "interrupted";
     assistantDelta?: string;
     completeTurn?: boolean;
+    responseUsages?: Array<{
+      responseId: string;
+      usage: {
+        totalTokens: number;
+        inputTokens: number;
+        cachedInputTokens: number;
+        cacheWriteInputTokens: number;
+        outputTokens: number;
+        reasoningOutputTokens: number;
+      };
+    }>;
   } = {},
 ) {
   const methods: string[] = [];
@@ -160,11 +171,8 @@ function createClientFactory(
               },
             });
           }
-          handler({
-            method: "rawResponse/completed",
-            params: {
-              threadId: "thread-finalizer",
-              turnId: "turn-finalizer",
+          const responseUsages = options.responseUsages ?? [
+            {
               responseId: "response-finalizer",
               usage: {
                 totalTokens: 12,
@@ -175,7 +183,17 @@ function createClientFactory(
                 reasoningOutputTokens: 0,
               },
             },
-          });
+          ];
+          for (const response of responseUsages) {
+            handler({
+              method: "rawResponse/completed",
+              params: {
+                threadId: "thread-finalizer",
+                turnId: "turn-finalizer",
+                ...response,
+              },
+            });
+          }
           handler({
             method: "turn/completed",
             params: {
@@ -359,7 +377,32 @@ describe("runBoundedCodexAppServerTurn settled finalization isolation", () => {
   });
 
   it("attests ring-zero and injects frozen history before starting the final turn", async () => {
-    const fake = createClientFactory();
+    const fake = createClientFactory({
+      responseUsages: [
+        {
+          responseId: "response-finalizer-1",
+          usage: {
+            totalTokens: 12,
+            inputTokens: 8,
+            cachedInputTokens: 2,
+            cacheWriteInputTokens: 1,
+            outputTokens: 4,
+            reasoningOutputTokens: 1,
+          },
+        },
+        {
+          responseId: "response-finalizer-2",
+          usage: {
+            totalTokens: 20,
+            inputTokens: 15,
+            cachedInputTokens: 3,
+            cacheWriteInputTokens: 2,
+            outputTokens: 5,
+            reasoningOutputTokens: 2,
+          },
+        },
+      ],
+    });
     const historyItems: JsonValue[] = [
       { type: "function_call", call_id: "call-1", name: "message", arguments: "{}" },
       { type: "function_call_output", call_id: "call-1", output: "sent" },
@@ -382,11 +425,12 @@ describe("runBoundedCodexAppServerTurn settled finalization isolation", () => {
       text: "The message was sent successfully.",
       model: "gpt-5.4",
       usage: {
-        input: 5,
-        output: 4,
-        cacheRead: 2,
-        cacheWrite: 1,
-        total: 12,
+        input: 15,
+        output: 9,
+        cacheRead: 5,
+        cacheWrite: 3,
+        reasoningTokens: 3,
+        total: 32,
       },
     });
 

--- a/extensions/codex/src/app-server/bounded-turn.ts
+++ b/extensions/codex/src/app-server/bounded-turn.ts
@@ -14,6 +14,7 @@ import {
 } from "./attempt-notifications.js";
 import type { CodexAppServerClient } from "./client.js";
 import { resolveCodexAppServerRuntimeOptions } from "./config.js";
+import { CodexResponseUsageProjection } from "./event-projector-response-usage.js";
 import { normalizeCodexResponseTokenUsage } from "./event-projector-usage.js";
 import { readModelListResult } from "./models.js";
 import { mergeCodexThreadConfigs } from "./plugin-thread-config.js";
@@ -463,7 +464,7 @@ function createCodexBoundedTurnCollector(threadId: string, taskLabel: string) {
   let turnId: string | undefined;
   let completedTurn: CodexTurn | undefined;
   let promptError: string | undefined;
-  let responseUsage: ReturnType<typeof normalizeCodexResponseTokenUsage>;
+  const responseUsageProjection = new CodexResponseUsageProjection();
   const pending: CodexServerNotification[] = [];
   const completedItems = new Map<string, CodexThreadItem>();
   const assistantTextByItem = new Map<string, string>();
@@ -513,9 +514,7 @@ function createCodexBoundedTurnCollector(threadId: string, taskLabel: string) {
       return;
     }
     if (notification.method === "rawResponse/completed") {
-      const usage = isJsonObject(params.usage) ? params.usage : undefined;
-      // Exact per-response usage replaces any earlier response in this turn.
-      responseUsage = usage ? normalizeCodexResponseTokenUsage(usage) : undefined;
+      responseUsageProjection.handleCompleted(params);
       return;
     }
     if (notification.method === "turn/completed") {
@@ -526,8 +525,10 @@ function createCodexBoundedTurnCollector(threadId: string, taskLabel: string) {
     }
     if (notification.method === "error") {
       if (isRetryableErrorNotification(notification.params)) {
+        responseUsageProjection.markRetryableError();
         return;
       }
+      responseUsageProjection.invalidate();
       promptError =
         readCodexErrorNotification(notification.params)?.error.message ??
         `codex app-server ${taskLabel} turn failed`;
@@ -580,6 +581,10 @@ function createCodexBoundedTurnCollector(threadId: string, taskLabel: string) {
       if (!text) {
         throw new Error(`Codex app-server ${taskLabel} turn returned no text.`);
       }
+      const responseUsage = responseUsageProjection.project({
+        aborted: false,
+        fallback: undefined,
+      }).attemptUsage;
       return { text, items, ...(responseUsage ? { usage: responseUsage } : {}) };
     },
   };

--- a/extensions/codex/src/app-server/event-projector-contracts.ts
+++ b/extensions/codex/src/app-server/event-projector-contracts.ts
@@ -1,0 +1,17 @@
+import type {
+  HeartbeatToolResponse,
+  MessagingToolSend,
+  MessagingToolSourceReplyPayload,
+} from "openclaw/plugin-sdk/agent-harness-runtime";
+export type CodexAppServerToolTelemetry = {
+  didSendViaMessagingTool: boolean;
+  didDeliverSourceReplyViaMessageTool?: boolean;
+  messagingToolSentTexts: string[];
+  messagingToolSentMediaUrls: string[];
+  messagingToolSentTargets: MessagingToolSend[];
+  messagingToolSourceReplyPayloads?: MessagingToolSourceReplyPayload[];
+  heartbeatToolResponse?: HeartbeatToolResponse;
+  toolMediaUrls?: string[];
+  toolAudioAsVoice?: boolean;
+  successfulCronAdds?: number;
+};

--- a/extensions/codex/src/app-server/event-projector-native-tool-lifecycle.ts
+++ b/extensions/codex/src/app-server/event-projector-native-tool-lifecycle.ts
@@ -37,6 +37,7 @@ type CodexNativeToolLifecycleContext = Pick<
 
 type CodexNativeToolLifecycleProjectorOptions = {
   runAbortSignal?: AbortSignal;
+  onToolCompleted?: (completedAtMs: number) => void;
 };
 
 type CodexNativePreToolUseFailureRecord = {
@@ -229,6 +230,7 @@ export class CodexNativeToolLifecycleProjector {
     const startedAt = this.startedAtByItem.get(toolCallId);
     this.startedAtByItem.delete(toolCallId);
     const endedAt = options.sourceTimestampMs ?? Date.now();
+    this.options.onToolCompleted?.(endedAt);
     const durationMs =
       options.itemDurationMs ?? (startedAt === undefined ? 0 : Math.max(0, endedAt - startedAt));
     if (preToolUseFailure) {

--- a/extensions/codex/src/app-server/event-projector-native-tool-lifecycle.ts
+++ b/extensions/codex/src/app-server/event-projector-native-tool-lifecycle.ts
@@ -37,7 +37,8 @@ type CodexNativeToolLifecycleContext = Pick<
 
 type CodexNativeToolLifecycleProjectorOptions = {
   runAbortSignal?: AbortSignal;
-  onToolCompleted?: (completedAtMs: number) => void;
+  onToolStarted?: (toolCallId: string, startedAtMs: number) => void;
+  onToolCompleted?: (toolCallId: string, completedAtMs: number) => void;
 };
 
 type CodexNativePreToolUseFailureRecord = {
@@ -230,7 +231,7 @@ export class CodexNativeToolLifecycleProjector {
     const startedAt = this.startedAtByItem.get(toolCallId);
     this.startedAtByItem.delete(toolCallId);
     const endedAt = options.sourceTimestampMs ?? Date.now();
-    this.options.onToolCompleted?.(endedAt);
+    this.options.onToolCompleted?.(toolCallId, endedAt);
     const durationMs =
       options.itemDurationMs ?? (startedAt === undefined ? 0 : Math.max(0, endedAt - startedAt));
     if (preToolUseFailure) {
@@ -357,8 +358,10 @@ export class CodexNativeToolLifecycleProjector {
     if (this.activeItems.has(toolCallId)) {
       return;
     }
-    this.startedAtByItem.set(toolCallId, sourceTimestampMs ?? Date.now());
+    const startedAt = sourceTimestampMs ?? Date.now();
+    this.startedAtByItem.set(toolCallId, startedAt);
     this.activeItems.set(toolCallId, { toolName, unfinishedStatus });
+    this.options.onToolStarted?.(toolCallId, startedAt);
     emitTrustedDiagnosticEvent({
       type: "tool.execution.started",
       ...this.buildBase(toolCallId, toolName),

--- a/extensions/codex/src/app-server/event-projector-options.ts
+++ b/extensions/codex/src/app-server/event-projector-options.ts
@@ -1,3 +1,4 @@
+import type { CodexCompletedResponseUsage } from "./event-projector-response-usage.js";
 import type { CodexThreadItem, JsonValue } from "./protocol.js";
 import type { CodexRemoteWorkspaceFileReader } from "./remote-workspace-media.js";
 import type { CodexTrajectoryRecorder } from "./trajectory.js";
@@ -5,6 +6,10 @@ import type { CodexTrajectoryRecorder } from "./trajectory.js";
 export type CodexAppServerEventProjectorOptions = {
   nativePostToolUseRelayEnabled?: boolean;
   onNativeToolResultRecorded?: () => void | Promise<void>;
+  onToolCompleted?: (completedAtMs: number) => void;
+  onRawResponseCompleted?: (
+    response: CodexCompletedResponseUsage & { completedAtMs: number },
+  ) => void;
   prepareNativeMcpAppResultDetails?: (item: CodexThreadItem) => Promise<unknown>;
   readRecentRateLimits?: () => JsonValue | undefined;
   runAbortSignal?: AbortSignal;

--- a/extensions/codex/src/app-server/event-projector-options.ts
+++ b/extensions/codex/src/app-server/event-projector-options.ts
@@ -6,7 +6,8 @@ import type { CodexTrajectoryRecorder } from "./trajectory.js";
 export type CodexAppServerEventProjectorOptions = {
   nativePostToolUseRelayEnabled?: boolean;
   onNativeToolResultRecorded?: () => void | Promise<void>;
-  onToolCompleted?: (completedAtMs: number) => void;
+  onToolStarted?: (toolCallId: string, startedAtMs: number) => void;
+  onToolCompleted?: (toolCallId: string, completedAtMs: number) => void;
   onRawResponseCompleted?: (
     response: CodexCompletedResponseUsage & { completedAtMs: number },
   ) => void;

--- a/extensions/codex/src/app-server/event-projector-response-usage.ts
+++ b/extensions/codex/src/app-server/event-projector-response-usage.ts
@@ -5,7 +5,7 @@ import {
 import { readNonEmptyString } from "./event-projector-values.js";
 import { isJsonObject, type JsonObject } from "./protocol.js";
 
-export type CodexResponseUsage = ReturnType<typeof normalizeCodexResponseTokenUsage>;
+type CodexResponseUsage = ReturnType<typeof normalizeCodexResponseTokenUsage>;
 
 export type CodexCompletedResponseUsage = {
   responseId: string;

--- a/extensions/codex/src/app-server/event-projector-response-usage.ts
+++ b/extensions/codex/src/app-server/event-projector-response-usage.ts
@@ -1,0 +1,72 @@
+import {
+  accumulateCodexResponseTokenUsage,
+  normalizeCodexResponseTokenUsage,
+} from "./event-projector-usage.js";
+import { readNonEmptyString } from "./event-projector-values.js";
+import { isJsonObject, type JsonObject } from "./protocol.js";
+
+type ResponseUsage = ReturnType<typeof normalizeCodexResponseTokenUsage>;
+
+export class CodexResponseUsageProjection {
+  private latest: ResponseUsage;
+  private accumulated: ResponseUsage;
+  private readonly completedResponseIds = new Set<string>();
+  private aggregationComplete = true;
+
+  get modelIterations(): number {
+    return this.completedResponseIds.size;
+  }
+
+  handleCompleted(params: JsonObject): void {
+    const responseId = readNonEmptyString(params, "responseId");
+    if (responseId && this.completedResponseIds.has(responseId)) {
+      return;
+    }
+    const usage = isJsonObject(params.usage) ? params.usage : undefined;
+    const normalizedUsage = usage ? normalizeCodexResponseTokenUsage(usage) : undefined;
+    // The latest exact response owns context freshness. Attempt accounting is
+    // separately deduplicated because one turn can call the provider around tools.
+    this.latest = normalizedUsage;
+    if (responseId) {
+      this.completedResponseIds.add(responseId);
+    }
+    if (!responseId || !normalizedUsage) {
+      this.aggregationComplete = false;
+      return;
+    }
+    if (!this.aggregationComplete) {
+      return;
+    }
+    this.accumulated = accumulateCodexResponseTokenUsage(this.accumulated, normalizedUsage);
+  }
+
+  markRetryableError(): void {
+    this.latest = undefined;
+    if (this.accumulated) {
+      this.accumulated = {
+        ...this.accumulated,
+        contextUsage: { state: "unavailable" },
+      };
+    }
+  }
+
+  invalidate(): void {
+    this.latest = undefined;
+    this.accumulated = undefined;
+    this.aggregationComplete = false;
+  }
+
+  project(params: { aborted: boolean; fallback: ResponseUsage }): {
+    assistantUsage: ResponseUsage;
+    attemptUsage: ResponseUsage;
+  } {
+    const assistantUsage = params.aborted ? params.fallback : (this.latest ?? params.fallback);
+    // Top-level attempt buckets account for every exact response. The nested
+    // context snapshot still belongs only to the final response.
+    const attemptUsage =
+      params.aborted || !this.aggregationComplete
+        ? params.fallback
+        : (this.accumulated ?? assistantUsage);
+    return { assistantUsage, attemptUsage };
+  }
+}

--- a/extensions/codex/src/app-server/event-projector-response-usage.ts
+++ b/extensions/codex/src/app-server/event-projector-response-usage.ts
@@ -5,11 +5,16 @@ import {
 import { readNonEmptyString } from "./event-projector-values.js";
 import { isJsonObject, type JsonObject } from "./protocol.js";
 
-type ResponseUsage = ReturnType<typeof normalizeCodexResponseTokenUsage>;
+export type CodexResponseUsage = ReturnType<typeof normalizeCodexResponseTokenUsage>;
+
+export type CodexCompletedResponseUsage = {
+  responseId: string;
+  usage?: NonNullable<CodexResponseUsage>;
+};
 
 export class CodexResponseUsageProjection {
-  private latest: ResponseUsage;
-  private accumulated: ResponseUsage;
+  private latest: CodexResponseUsage;
+  private accumulated: CodexResponseUsage;
   private readonly completedResponseIds = new Set<string>();
   private aggregationComplete = true;
 
@@ -17,27 +22,30 @@ export class CodexResponseUsageProjection {
     return this.completedResponseIds.size;
   }
 
-  handleCompleted(params: JsonObject): void {
+  handleCompleted(params: JsonObject): CodexCompletedResponseUsage | undefined {
     const responseId = readNonEmptyString(params, "responseId");
     if (responseId && this.completedResponseIds.has(responseId)) {
-      return;
+      return undefined;
     }
     const usage = isJsonObject(params.usage) ? params.usage : undefined;
     const normalizedUsage = usage ? normalizeCodexResponseTokenUsage(usage) : undefined;
     // The latest exact response owns context freshness. Attempt accounting is
     // separately deduplicated because one turn can call the provider around tools.
     this.latest = normalizedUsage;
-    if (responseId) {
-      this.completedResponseIds.add(responseId);
-    }
-    if (!responseId || !normalizedUsage) {
+    if (!responseId) {
       this.aggregationComplete = false;
-      return;
+      return undefined;
+    }
+    this.completedResponseIds.add(responseId);
+    if (!normalizedUsage) {
+      this.aggregationComplete = false;
+      return { responseId };
     }
     if (!this.aggregationComplete) {
-      return;
+      return { responseId, usage: normalizedUsage };
     }
     this.accumulated = accumulateCodexResponseTokenUsage(this.accumulated, normalizedUsage);
+    return { responseId, usage: normalizedUsage };
   }
 
   markRetryableError(): void {
@@ -56,9 +64,9 @@ export class CodexResponseUsageProjection {
     this.aggregationComplete = false;
   }
 
-  project(params: { aborted: boolean; fallback: ResponseUsage }): {
-    assistantUsage: ResponseUsage;
-    attemptUsage: ResponseUsage;
+  project(params: { aborted: boolean; fallback: CodexResponseUsage }): {
+    assistantUsage: CodexResponseUsage;
+    attemptUsage: CodexResponseUsage;
   } {
     const assistantUsage = params.aborted ? params.fallback : (this.latest ?? params.fallback);
     // Top-level attempt buckets account for every exact response. The nested

--- a/extensions/codex/src/app-server/event-projector-usage.ts
+++ b/extensions/codex/src/app-server/event-projector-usage.ts
@@ -1,5 +1,5 @@
 import { normalizeUsage } from "openclaw/plugin-sdk/agent-harness-runtime";
-import { readNonNegativeInteger, readNumber, readString } from "./event-projector-values.js";
+import { readNonNegativeInteger, readNumber } from "./event-projector-values.js";
 import { isJsonObject, type JsonObject } from "./protocol.js";
 
 function readTokenCount(record: JsonObject, key: string): number | undefined {
@@ -57,6 +57,7 @@ export function normalizeCodexThreadTokenUsage(
     input,
     output: readNumber(record, "outputTokens"),
     cacheRead,
+    reasoningTokens: readNumber(record, "reasoningOutputTokens"),
     total: readNumber(record, "totalTokens"),
   });
   return usage ? { ...usage, contextUsage: { state: "unavailable" } } : undefined;
@@ -93,14 +94,15 @@ export function normalizeCodexResponseTokenUsage(
     output,
     cacheRead,
     cacheWrite,
+    reasoningTokens: reasoningOutput,
     total: totalTokens,
   });
   if (!usage) {
     return undefined;
   }
 
-  // `rawResponse/completed` is exact for one provider response. The projector
-  // replaces this snapshot on every response so the final one owns freshness.
+  // `rawResponse/completed` is exact for one provider response. Its context
+  // snapshot belongs to that response even when accounting sums several calls.
   return {
     ...usage,
     contextUsage: {
@@ -111,27 +113,23 @@ export function normalizeCodexResponseTokenUsage(
   };
 }
 
-export class CodexResponseCompletionProjection {
-  // Replayed notifications keep one upstream response equal to one model iteration.
-  private readonly responseIds = new Set<string>();
-  usage: ReturnType<typeof normalizeUsage>;
-
-  get modelIterations(): number {
-    return this.responseIds.size;
+export function accumulateCodexResponseTokenUsage(
+  current: ReturnType<typeof normalizeUsage>,
+  next: NonNullable<ReturnType<typeof normalizeUsage>>,
+): ReturnType<typeof normalizeUsage> {
+  const usage = normalizeUsage({
+    input: (current?.input ?? 0) + (next.input ?? 0),
+    output: (current?.output ?? 0) + (next.output ?? 0),
+    cacheRead: (current?.cacheRead ?? 0) + (next.cacheRead ?? 0),
+    cacheWrite: (current?.cacheWrite ?? 0) + (next.cacheWrite ?? 0),
+    reasoningTokens: (current?.reasoningTokens ?? 0) + (next.reasoningTokens ?? 0),
+    total: (current?.total ?? 0) + (next.total ?? 0),
+  });
+  if (!usage) {
+    return undefined;
   }
-
-  clear(): void {
-    this.usage = undefined;
-  }
-
-  record(params: JsonObject): void {
-    const responseId = readString(params, "responseId");
-    if (responseId) {
-      this.responseIds.add(responseId);
-    }
-    const usage = isJsonObject(params.usage) ? params.usage : undefined;
-    // Every provider completion replaces the prior response snapshot. A final
-    // response with missing or malformed usage must leave freshness unknown.
-    this.usage = usage ? normalizeCodexResponseTokenUsage(usage) : undefined;
-  }
+  return {
+    ...usage,
+    ...(next.contextUsage ? { contextUsage: { ...next.contextUsage } } : {}),
+  };
 }

--- a/extensions/codex/src/app-server/event-projector.dynamic-tools.test.ts
+++ b/extensions/codex/src/app-server/event-projector.dynamic-tools.test.ts
@@ -19,9 +19,11 @@ registerCodexEventProjectorTestLifecycle();
 
 describe("CodexAppServerEventProjector dynamic tool projection", () => {
   it("records dynamic OpenClaw tool calls in mirrored transcript snapshots", async () => {
+    const onToolCompleted = vi.fn();
     const projector = await createProjector(undefined, {
       resolveDynamicToolResultContentSource: (toolName) =>
         toolName === "browser" ? "network" : undefined,
+      onToolCompleted,
     });
 
     projector.recordDynamicToolCall({
@@ -75,6 +77,8 @@ describe("CodexAppServerEventProjector dynamic tool projection", () => {
     ).toMatchObject({
       turnTainted: true,
     });
+    expect(onToolCompleted).toHaveBeenCalledOnce();
+    expect(onToolCompleted).toHaveBeenCalledWith(expect.any(Number));
   });
 
   it("retains MCP App preview details in mirrored dynamic tool results", async () => {

--- a/extensions/codex/src/app-server/event-projector.dynamic-tools.test.ts
+++ b/extensions/codex/src/app-server/event-projector.dynamic-tools.test.ts
@@ -19,10 +19,12 @@ registerCodexEventProjectorTestLifecycle();
 
 describe("CodexAppServerEventProjector dynamic tool projection", () => {
   it("records dynamic OpenClaw tool calls in mirrored transcript snapshots", async () => {
+    const onToolStarted = vi.fn();
     const onToolCompleted = vi.fn();
     const projector = await createProjector(undefined, {
       resolveDynamicToolResultContentSource: (toolName) =>
         toolName === "browser" ? "network" : undefined,
+      onToolStarted,
       onToolCompleted,
     });
 
@@ -77,8 +79,10 @@ describe("CodexAppServerEventProjector dynamic tool projection", () => {
     ).toMatchObject({
       turnTainted: true,
     });
+    expect(onToolStarted).toHaveBeenCalledOnce();
+    expect(onToolStarted).toHaveBeenCalledWith("call-browser-1", expect.any(Number));
     expect(onToolCompleted).toHaveBeenCalledOnce();
-    expect(onToolCompleted).toHaveBeenCalledWith(expect.any(Number));
+    expect(onToolCompleted).toHaveBeenCalledWith("call-browser-1", expect.any(Number));
   });
 
   it("retains MCP App preview details in mirrored dynamic tool results", async () => {

--- a/extensions/codex/src/app-server/event-projector.native-audit.test.ts
+++ b/extensions/codex/src/app-server/event-projector.native-audit.test.ts
@@ -876,8 +876,9 @@ describe("CodexAppServerEventProjector native tool audit projection", () => {
     async (_, item, toolName) => {
       const diagnosticEvents: DiagnosticEventPayload[] = [];
       const unsubscribe = onInternalDiagnosticEvent((event) => diagnosticEvents.push(event));
+      const onToolStarted = vi.fn();
       const onToolCompleted = vi.fn();
-      const projector = await createProjector(undefined, { onToolCompleted });
+      const projector = await createProjector(undefined, { onToolStarted, onToolCompleted });
 
       try {
         await projector.handleNotification(
@@ -903,7 +904,8 @@ describe("CodexAppServerEventProjector native tool audit projection", () => {
         { type: "tool.execution.completed", toolName },
       ]);
       expect(JSON.stringify(diagnosticEvents)).not.toContain("sensitive");
-      expect(onToolCompleted).toHaveBeenCalledWith(1_750_000_000_042);
+      expect(onToolStarted).toHaveBeenCalledWith(item.id, 1_750_000_000_000);
+      expect(onToolCompleted).toHaveBeenCalledWith(item.id, 1_750_000_000_042);
     },
   );
 

--- a/extensions/codex/src/app-server/event-projector.native-audit.test.ts
+++ b/extensions/codex/src/app-server/event-projector.native-audit.test.ts
@@ -876,7 +876,8 @@ describe("CodexAppServerEventProjector native tool audit projection", () => {
     async (_, item, toolName) => {
       const diagnosticEvents: DiagnosticEventPayload[] = [];
       const unsubscribe = onInternalDiagnosticEvent((event) => diagnosticEvents.push(event));
-      const projector = await createProjector();
+      const onToolCompleted = vi.fn();
+      const projector = await createProjector(undefined, { onToolCompleted });
 
       try {
         await projector.handleNotification(
@@ -902,6 +903,7 @@ describe("CodexAppServerEventProjector native tool audit projection", () => {
         { type: "tool.execution.completed", toolName },
       ]);
       expect(JSON.stringify(diagnosticEvents)).not.toContain("sensitive");
+      expect(onToolCompleted).toHaveBeenCalledWith(1_750_000_000_042);
     },
   );
 

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -7,13 +7,11 @@ import {
   runAgentHarnessBeforeCompactionHook,
   type BeforeToolCallFailureDisposition,
   type EmbeddedRunAttemptParams,
-  type HeartbeatToolResponse,
-  type MessagingToolSend,
-  type MessagingToolSourceReplyPayload,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { attemptTerminal, type AttemptFailureSource } from "./attempt-terminal.js";
 import type { EmbeddedRunAttemptResult } from "./attempt-terminal.js";
 import { CodexAssistantProjection } from "./event-projector-assistant.js";
+import type { CodexAppServerToolTelemetry } from "./event-projector-contracts.js";
 import { CodexProjectionDiagnostics } from "./event-projector-diagnostics.js";
 import { CodexEventProjection } from "./event-projector-events.js";
 import {
@@ -62,19 +60,6 @@ export { shouldEmitTranscriptToolProgress } from "./event-projector-tool-progres
 
 type ApprovalFailure = Exclude<BeforeToolCallFailureDisposition, "blocked">;
 
-type CodexAppServerToolTelemetry = {
-  didSendViaMessagingTool: boolean;
-  didDeliverSourceReplyViaMessageTool?: boolean;
-  messagingToolSentTexts: string[];
-  messagingToolSentMediaUrls: string[];
-  messagingToolSentTargets: MessagingToolSend[];
-  messagingToolSourceReplyPayloads?: MessagingToolSourceReplyPayload[];
-  heartbeatToolResponse?: HeartbeatToolResponse;
-  toolMediaUrls?: string[];
-  toolAudioAsVoice?: boolean;
-  successfulCronAdds?: number;
-};
-
 export class CodexAppServerEventProjector {
   private readonly assistantProjection: CodexAssistantProjection;
   private readonly reasoningProjection: CodexReasoningProjection;
@@ -112,6 +97,7 @@ export class CodexAppServerEventProjector {
       turnId,
       {
         runAbortSignal: options.runAbortSignal,
+        onToolCompleted: options.onToolCompleted,
       },
     );
     this.generatedMediaProjection = new CodexGeneratedMediaProjection(params.config, {
@@ -282,7 +268,12 @@ export class CodexAppServerEventProjector {
         await this.handleTurnCompleted(params);
         break;
       case "rawResponse/completed":
-        this.responseUsageProjection.handleCompleted(params);
+        {
+          const response = this.responseUsageProjection.handleCompleted(params);
+          if (response) {
+            this.options.onRawResponseCompleted?.({ ...response, completedAtMs: Date.now() });
+          }
+        }
         break;
       case "rawResponseItem/completed":
         await this.handleRawResponseItemCompleted(params);
@@ -480,6 +471,7 @@ export class CodexAppServerEventProjector {
     this.toolProgressProjection.recordDynamicToolResult(params);
     const source = this.options.resolveDynamicToolResultContentSource?.(params.tool);
     this.toolTranscriptProjection.recordDynamicToolResult(params, source);
+    this.options.onToolCompleted?.(Date.now());
   }
 
   markTimedOut(): void {

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -26,11 +26,11 @@ import { CodexGeneratedMediaProjection } from "./event-projector-media.js";
 import { CodexNativeToolLifecycleProjector } from "./event-projector-native-tool-lifecycle.js";
 import type { CodexAppServerEventProjectorOptions } from "./event-projector-options.js";
 import { CodexReasoningProjection } from "./event-projector-reasoning.js";
+import { CodexResponseUsageProjection } from "./event-projector-response-usage.js";
 import { buildCodexMessagesSnapshot } from "./event-projector-snapshot.js";
 import { CodexToolProgressProjection } from "./event-projector-tool-progress.js";
 import { CodexToolTranscriptProjection } from "./event-projector-tool-transcript.js";
 import {
-  CodexResponseCompletionProjection,
   normalizeCodexThreadTokenUsage,
   projectCodexThreadUsageUpdate,
 } from "./event-projector-usage.js";
@@ -95,7 +95,7 @@ export class CodexAppServerEventProjector {
   private synthesizedMissingToolResultError: string | null = null;
   private aborted = false;
   private tokenUsage: ReturnType<typeof normalizeCodexThreadTokenUsage>;
-  private readonly responseCompletions = new CodexResponseCompletionProjection();
+  private readonly responseUsageProjection = new CodexResponseUsageProjection();
   private completedCompactionCount = 0;
   private lastTranscriptTimestamp = 0;
 
@@ -282,16 +282,17 @@ export class CodexAppServerEventProjector {
         await this.handleTurnCompleted(params);
         break;
       case "rawResponse/completed":
-        this.responseCompletions.record(params);
+        this.responseUsageProjection.handleCompleted(params);
         break;
       case "rawResponseItem/completed":
         await this.handleRawResponseItemCompleted(params);
         break;
       case "error":
-        this.responseCompletions.clear();
         if (params.willRetry === true) {
+          this.responseUsageProjection.markRetryableError();
           break;
         }
+        this.responseUsageProjection.invalidate();
         this.promptError = this.formatCodexErrorMessage(params) ?? "codex app-server error";
         this.promptErrorSource = "prompt";
         break;
@@ -328,8 +329,10 @@ export class CodexAppServerEventProjector {
     // A terminal timeout must not publish exact usage, but the timeout watcher
     // can still recover a completed assistant. Keep the snapshot masked until
     // recovery clears the abort instead of destroying it in markTimedOut().
-    const completedUsage = this.responseCompletions.usage ?? this.tokenUsage;
-    const projectedUsage = this.aborted ? this.tokenUsage : completedUsage;
+    const { assistantUsage: projectedUsage, attemptUsage } = this.responseUsageProjection.project({
+      aborted: this.aborted,
+      fallback: this.tokenUsage,
+    });
     const hasAssistantItemText = this.assistantProjection.hasAssistantItemTextForSynthesis();
     const legacyFailClosed =
       !this.completedTurn || this.completedTurn.status !== "completed" || hasAssistantItemText;
@@ -416,8 +419,8 @@ export class CodexAppServerEventProjector {
       ...(agentHarnessResultClassification ? { agentHarnessResultClassification } : {}),
       bootstrapPromptWarningSignaturesSeen: this.params.bootstrapPromptWarningSignaturesSeen,
       bootstrapPromptWarningSignature: this.params.bootstrapPromptWarningSignature,
-      ...(this.responseCompletions.modelIterations > 0
-        ? { modelIterations: this.responseCompletions.modelIterations }
+      ...(this.responseUsageProjection.modelIterations > 0
+        ? { modelIterations: this.responseUsageProjection.modelIterations }
         : {}),
       messagesSnapshot,
       assistantTexts,
@@ -440,7 +443,7 @@ export class CodexAppServerEventProjector {
       toolAudioAsVoice: toolTelemetry.toolAudioAsVoice,
       successfulCronAdds: toolTelemetry.successfulCronAdds,
       cloudCodeAssistFormatError: false,
-      attemptUsage: projectedUsage,
+      attemptUsage,
       ...(this.completedCompactionCount > 0
         ? { compactionCount: this.completedCompactionCount }
         : {}),
@@ -487,7 +490,7 @@ export class CodexAppServerEventProjector {
 
   markAborted(): void {
     this.aborted = true;
-    this.responseCompletions.clear();
+    this.responseUsageProjection.invalidate();
   }
 
   isCompacting(): boolean {
@@ -605,7 +608,7 @@ export class CodexAppServerEventProjector {
     }
     this.completedTurn = turn;
     if (turn.status !== "completed") {
-      this.responseCompletions.clear();
+      this.responseUsageProjection.invalidate();
     }
     if (turn.status === "failed") {
       const usageLimitMessage = formatCodexUsageLimitErrorMessage({

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -97,6 +97,7 @@ export class CodexAppServerEventProjector {
       turnId,
       {
         runAbortSignal: options.runAbortSignal,
+        onToolStarted: options.onToolStarted,
         onToolCompleted: options.onToolCompleted,
       },
     );
@@ -455,6 +456,7 @@ export class CodexAppServerEventProjector {
 
   recordDynamicToolCall(params: { callId: string; tool: string; arguments?: JsonValue }): void {
     this.toolTranscriptProjection.recordDynamicToolCall(params);
+    this.options.onToolStarted?.(params.callId, Date.now());
   }
 
   recordDynamicToolResult(params: {
@@ -471,7 +473,7 @@ export class CodexAppServerEventProjector {
     this.toolProgressProjection.recordDynamicToolResult(params);
     const source = this.options.resolveDynamicToolResultContentSource?.(params.tool);
     this.toolTranscriptProjection.recordDynamicToolResult(params, source);
-    this.options.onToolCompleted?.(Date.now());
+    this.options.onToolCompleted?.(params.callId, Date.now());
   }
 
   markTimedOut(): void {

--- a/extensions/codex/src/app-server/event-projector.usage.test.ts
+++ b/extensions/codex/src/app-server/event-projector.usage.test.ts
@@ -95,6 +95,144 @@ describe("CodexAppServerEventProjector usage projection", () => {
     expect(projector.buildResult(buildEmptyToolTelemetry()).modelIterations).toBe(2);
   });
 
+  it("accumulates distinct raw responses while keeping the final response fresh", async () => {
+    const projector = await createProjector();
+
+    await projector.handleNotification(agentMessageDelta("done"));
+    await projector.handleNotification(
+      forCurrentTurn("rawResponse/completed", {
+        responseId: "response-1",
+        usage: {
+          totalTokens: 12,
+          inputTokens: 5,
+          cachedInputTokens: 2,
+          outputTokens: 7,
+          reasoningOutputTokens: 3,
+        },
+      }),
+    );
+    await projector.handleNotification(
+      forCurrentTurn("rawResponse/completed", {
+        responseId: "response-2",
+        usage: {
+          totalTokens: 20,
+          inputTokens: 14,
+          cachedInputTokens: 4,
+          cacheWriteInputTokens: 2,
+          outputTokens: 6,
+          reasoningOutputTokens: 2,
+        },
+      }),
+    );
+
+    const result = projector.buildResult(buildEmptyToolTelemetry());
+
+    expectUsageFields(result.attemptUsage, {
+      input: 11,
+      output: 13,
+      cacheRead: 6,
+      cacheWrite: 2,
+      total: 32,
+    });
+    expect(result.attemptUsage?.reasoningTokens).toBe(5);
+    expect(result.attemptUsage?.contextUsage).toEqual({
+      state: "available",
+      promptTokens: 14,
+      totalTokens: 20,
+    });
+    expectUsageFields(result.lastAssistant?.usage, {
+      input: 8,
+      output: 6,
+      cacheRead: 4,
+      cacheWrite: 2,
+      total: 20,
+    });
+    expect(result.lastAssistant?.usage.contextUsage).toEqual({
+      state: "available",
+      promptTokens: 14,
+      totalTokens: 20,
+    });
+  });
+
+  it("deduplicates raw responses by response id", async () => {
+    const projector = await createProjector();
+    const usage = {
+      totalTokens: 12,
+      inputTokens: 5,
+      cachedInputTokens: 2,
+      outputTokens: 7,
+      reasoningOutputTokens: 1,
+    };
+
+    await projector.handleNotification(
+      forCurrentTurn("rawResponse/completed", { responseId: "response-1", usage }),
+    );
+    await projector.handleNotification(
+      forCurrentTurn("rawResponse/completed", { responseId: "response-1", usage }),
+    );
+
+    const result = projector.buildResult(buildEmptyToolTelemetry());
+    expectUsageFields(result.attemptUsage, { input: 3, output: 7, cacheRead: 2, total: 12 });
+    expect(result.attemptUsage?.reasoningTokens).toBe(1);
+  });
+
+  it("does not publish a partial aggregate when a response id is missing", async () => {
+    const projector = await createProjector();
+
+    await projector.handleNotification(agentMessageDelta("done"));
+    await projector.handleNotification(
+      forCurrentTurn("thread/tokenUsage/updated", {
+        tokenUsage: {
+          last: {
+            totalTokens: 12,
+            inputTokens: 5,
+            cachedInputTokens: 2,
+            outputTokens: 7,
+          },
+        },
+      }),
+    );
+    await projector.handleNotification(
+      forCurrentTurn("rawResponse/completed", {
+        responseId: "response-1",
+        usage: {
+          totalTokens: 12,
+          inputTokens: 5,
+          cachedInputTokens: 2,
+          outputTokens: 7,
+          reasoningOutputTokens: 0,
+        },
+      }),
+    );
+    await projector.handleNotification(
+      forCurrentTurn("rawResponse/completed", {
+        usage: {
+          totalTokens: 20,
+          inputTokens: 14,
+          cachedInputTokens: 4,
+          outputTokens: 6,
+          reasoningOutputTokens: 2,
+        },
+      }),
+    );
+
+    const result = projector.buildResult(buildEmptyToolTelemetry());
+
+    expectUsageFields(result.attemptUsage, { input: 3, output: 7, cacheRead: 2, total: 12 });
+    expect(result.attemptUsage?.contextUsage).toEqual({ state: "unavailable" });
+    expectUsageFields(result.lastAssistant?.usage, {
+      input: 10,
+      output: 6,
+      cacheRead: 4,
+      total: 20,
+    });
+    expect(result.lastAssistant?.usage.contextUsage).toEqual({
+      state: "available",
+      promptTokens: 14,
+      totalTokens: 20,
+    });
+  });
+
   it("keeps cumulative-only thread usage unknown", async () => {
     const projector = await createProjector();
 
@@ -113,6 +251,7 @@ describe("CodexAppServerEventProjector usage projection", () => {
             inputTokens: 5,
             cachedInputTokens: 2,
             outputTokens: 7,
+            reasoningOutputTokens: 2,
           },
         },
       }),
@@ -123,6 +262,7 @@ describe("CodexAppServerEventProjector usage projection", () => {
     expect(result.assistantTexts).toEqual(["done"]);
     expectUsageFields(result.attemptUsage, { input: 3, output: 7, cacheRead: 2, total: 12 });
     expect(result.attemptUsage?.contextUsage).toEqual({ state: "unavailable" });
+    expect(result.attemptUsage?.reasoningTokens).toBe(2);
     expectUsageFields(result.lastAssistant?.usage, {
       input: 3,
       output: 7,
@@ -232,7 +372,7 @@ describe("CodexAppServerEventProjector usage projection", () => {
     },
   );
 
-  it("invalidates exact response usage on retryable errors and explicit aborts", async () => {
+  it("keeps completed response accounting across retries and clears it on abort", async () => {
     const projector = await createProjector();
     const exactUsage = {
       totalTokens: 12,
@@ -251,7 +391,14 @@ describe("CodexAppServerEventProjector usage projection", () => {
     await projector.handleNotification(
       forCurrentTurn("error", { error: { message: "retry" }, willRetry: true }),
     );
-    expect(projector.buildResult(buildEmptyToolTelemetry()).attemptUsage).toBeUndefined();
+    const retrying = projector.buildResult(buildEmptyToolTelemetry());
+    expectUsageFields(retrying.attemptUsage, {
+      input: 3,
+      output: 7,
+      cacheRead: 2,
+      total: 12,
+    });
+    expect(retrying.attemptUsage?.contextUsage).toEqual({ state: "unavailable" });
 
     await projector.handleNotification(
       forCurrentTurn("rawResponse/completed", {
@@ -259,6 +406,19 @@ describe("CodexAppServerEventProjector usage projection", () => {
         usage: exactUsage,
       }),
     );
+    const recovered = projector.buildResult(buildEmptyToolTelemetry());
+    expectUsageFields(recovered.attemptUsage, {
+      input: 6,
+      output: 14,
+      cacheRead: 4,
+      total: 24,
+    });
+    expect(recovered.attemptUsage?.contextUsage).toEqual({
+      state: "available",
+      promptTokens: 5,
+      totalTokens: 12,
+    });
+
     projector.markAborted();
     expect(projector.buildResult(buildEmptyToolTelemetry()).attemptUsage).toBeUndefined();
   });

--- a/extensions/codex/src/app-server/event-projector.usage.test.ts
+++ b/extensions/codex/src/app-server/event-projector.usage.test.ts
@@ -96,7 +96,8 @@ describe("CodexAppServerEventProjector usage projection", () => {
   });
 
   it("accumulates distinct raw responses while keeping the final response fresh", async () => {
-    const projector = await createProjector();
+    const onRawResponseCompleted = vi.fn();
+    const projector = await createProjector(undefined, { onRawResponseCompleted });
 
     await projector.handleNotification(agentMessageDelta("done"));
     await projector.handleNotification(
@@ -152,6 +153,29 @@ describe("CodexAppServerEventProjector usage projection", () => {
       promptTokens: 14,
       totalTokens: 20,
     });
+    expect(onRawResponseCompleted).toHaveBeenCalledTimes(2);
+    expect(onRawResponseCompleted.mock.calls).toEqual([
+      [
+        expect.objectContaining({
+          responseId: "response-1",
+          usage: expect.objectContaining({ input: 3, output: 7, cacheRead: 2, total: 12 }),
+          completedAtMs: expect.any(Number),
+        }),
+      ],
+      [
+        expect.objectContaining({
+          responseId: "response-2",
+          usage: expect.objectContaining({
+            input: 8,
+            output: 6,
+            cacheRead: 4,
+            cacheWrite: 2,
+            total: 20,
+          }),
+          completedAtMs: expect.any(Number),
+        }),
+      ],
+    ]);
   });
 
   it("deduplicates raw responses by response id", async () => {
@@ -296,7 +320,8 @@ describe("CodexAppServerEventProjector usage projection", () => {
       },
     ],
   ])("keeps %s response usage unknown", async (_label, usage) => {
-    const projector = await createProjector();
+    const onRawResponseCompleted = vi.fn();
+    const projector = await createProjector(undefined, { onRawResponseCompleted });
 
     await projector.handleNotification(agentMessageDelta("done"));
     await projector.handleNotification(
@@ -308,6 +333,13 @@ describe("CodexAppServerEventProjector usage projection", () => {
     expect(result.assistantTexts).toEqual(["done"]);
     expect(result.attemptUsage).toBeUndefined();
     expect(result.lastAssistant?.usage.contextUsage).toBeUndefined();
+    expect(onRawResponseCompleted).toHaveBeenCalledWith(
+      expect.objectContaining({
+        responseId: "response-1",
+        completedAtMs: expect.any(Number),
+      }),
+    );
+    expect(onRawResponseCompleted.mock.calls[0]?.[0]).not.toHaveProperty("usage");
   });
 
   it("clears prior response usage when the final response omits usage", async () => {

--- a/extensions/codex/src/app-server/run-attempt-active-turn.ts
+++ b/extensions/codex/src/app-server/run-attempt-active-turn.ts
@@ -112,10 +112,12 @@ export async function activateCodexAttemptTurn(
       trajectoryRecorder,
       resolveDynamicToolResultContentSource: toolBridge.resultContentSourceForTool,
       onNativeToolResultRecorded: maybeAnnounceFastModeAutoOff,
-      onToolCompleted: (completedAtMs) =>
-        requestRuntime.codexModelCallDiagnostics.recordToolCompleted(completedAtMs),
+      onToolStarted: (toolCallId, startedAtMs) =>
+        requestRuntime.codexModelCallDiagnostics.recordToolStarted(toolCallId, startedAtMs),
+      onToolCompleted: (toolCallId, completedAtMs) =>
+        requestRuntime.codexModelCallDiagnostics.recordToolCompleted(toolCallId, completedAtMs),
       onRawResponseCompleted: (response) =>
-        requestRuntime.codexModelCallDiagnostics.emitResponseCompleted(response),
+        requestRuntime.codexModelCallDiagnostics.recordResponseCompleted(response),
       ...(prepareNativeMcpAppResultDetails ? { prepareNativeMcpAppResultDetails } : {}),
       upstreamUserText: turnState.codexTurnPromptText,
       onContextCompacted: () => {

--- a/extensions/codex/src/app-server/run-attempt-active-turn.ts
+++ b/extensions/codex/src/app-server/run-attempt-active-turn.ts
@@ -18,6 +18,7 @@ import { readBoundedCodexRemoteWorkspaceFile } from "./remote-workspace-media.js
 import type { CodexAttemptLifecycleController } from "./run-attempt-lifecycle-controller.js";
 import type { CodexAttemptNotificationController } from "./run-attempt-notification-controller.js";
 import type { CodexAttemptResources } from "./run-attempt-resources.js";
+import type { prepareCodexAttemptTurnRequest } from "./run-attempt-turn-request.js";
 import type { CodexAttemptTurnState } from "./run-attempt-turn-state.js";
 import {
   createCodexAppServerUserMessagePersistenceNotifier,
@@ -31,6 +32,7 @@ export async function activateCodexAttemptTurn(
   lifecycle: CodexAttemptLifecycleController,
   notifications: CodexAttemptNotificationController,
   turn: CodexTurnStartResponse,
+  requestRuntime: Awaited<ReturnType<typeof prepareCodexAttemptTurnRequest>>,
 ) {
   const {
     prompt,
@@ -110,6 +112,10 @@ export async function activateCodexAttemptTurn(
       trajectoryRecorder,
       resolveDynamicToolResultContentSource: toolBridge.resultContentSourceForTool,
       onNativeToolResultRecorded: maybeAnnounceFastModeAutoOff,
+      onToolCompleted: (completedAtMs) =>
+        requestRuntime.codexModelCallDiagnostics.recordToolCompleted(completedAtMs),
+      onRawResponseCompleted: (response) =>
+        requestRuntime.codexModelCallDiagnostics.emitResponseCompleted(response),
       ...(prepareNativeMcpAppResultDetails ? { prepareNativeMcpAppResultDetails } : {}),
       upstreamUserText: turnState.codexTurnPromptText,
       onContextCompacted: () => {

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -62,6 +62,7 @@ export async function runCodexAppServerAttempt(
     lifecycle,
     notifications,
     turnStart.turn,
+    turnRequest,
   );
 
   try {

--- a/extensions/diagnostics-otel/src/service-recorders-model.ts
+++ b/extensions/diagnostics-otel/src/service-recorders-model.ts
@@ -135,16 +135,17 @@ export function createModelRecorders(runtime: DiagnosticsRecorderRuntime) {
     assignModelCallPromptStatsAttrs(spanAttrs, evt);
     assignModelCallUsageAttrs(spanAttrs, evt);
     assignOtelModelContentAttributes(spanAttrs, modelContent, contentCapturePolicy);
+    const completedAtMs = positiveFiniteNumber(evt.sourceTimestampMs) ?? evt.ts;
     const span =
       takeTrackedTrustedSpan(evt, metadata) ??
       spanWithDuration(modelCallSpanName(evt), spanAttrs, evt.durationMs, {
         kind: modelCallSpanKind(),
         parentContext: activeTrustedParentContext(evt, metadata),
-        endTimeMs: evt.ts,
+        endTimeMs: completedAtMs,
       });
     setSpanAttrs(span, spanAttrs);
     addUpstreamRequestIdSpanEvent(span, evt.upstreamRequestIdHash);
-    span.end(evt.ts);
+    span.end(completedAtMs);
   };
 
   const recordModelCallError = (

--- a/extensions/diagnostics-otel/src/service.test.ts
+++ b/extensions/diagnostics-otel/src/service.test.ts
@@ -2926,6 +2926,23 @@ describe("diagnostics-otel service", () => {
     );
   });
 
+  test("backdates completed-only model call spans to the source completion time", async () => {
+    await startOtelService({ traces: true, metrics: true });
+
+    await emitTrustedAndFlush({
+      type: "model.call.completed",
+      ...MODEL_CALL_FIXTURE,
+      durationMs: 250,
+      sourceTimestampMs: 5_000,
+      trace: createTestTrace(MODEL_CALL_SPAN_ID, CHILD_SPAN_ID),
+    });
+
+    const modelCallOptions = startedSpanOptions("openclaw.model.call");
+    expect(modelCallOptions?.startTime).toBe(4_750);
+    const span = telemetryState.spans.find((candidate) => candidate.name === "openclaw.model.call");
+    expect(span?.end).toHaveBeenCalledWith(5_000);
+  });
+
   test("exports trusted context assembly spans without prompt content", async () => {
     await startOtelService({ traces: true, metrics: true });
 

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -643,6 +643,8 @@ export type DiagnosticModelCallStartedEvent = DiagnosticModelCallBaseEvent & {
 export type DiagnosticModelCallCompletedEvent = DiagnosticModelCallBaseEvent & {
   type: "model.call.completed";
   durationMs: number;
+  /** Authoritative completion time when a historical request span is emitted later. */
+  sourceTimestampMs?: number;
   requestPayloadBytes?: number;
   responseStreamBytes?: number;
   timeToFirstByteMs?: number;


### PR DESCRIPTION
## What Problem This Solves

Codex app-server can emit more than one `rawResponse/completed` notification during a single turn, especially around tool handoffs.

OpenClaw previously had two related observability gaps:

- `attemptUsage` retained only the final provider response, under-counting multi-response turns.
- Codex diagnostics emitted only one turn-level model-call span. Consumers that reconstructed individual LLM calls from transcript timestamps could place the LLM span after its tool call and make several calls overlap until the final answer.

## Why This Change Was Made

- Accumulate exact `rawResponse/completed` usage once per `responseId` for attempt-level accounting.
- Keep the final response's usage and `contextUsage` as the assistant/current-context snapshot, so summed billing buckets do not inflate the active context window.
- Emit one request-level `model.call.completed` diagnostic per unique response.
  - Response samples and tool lifecycle boundaries are buffered and paired by order at turn completion.
  - A tool start closes the current LLM interval; completion of the final active tool opens the next LLM interval.
  - This remains correct when Codex delivers `rawResponse/completed` after the tool triggered by that response has already run.
  - Parallel tools form one tool phase. When one provider response emits several sequential tools, the shortest surplus tool-to-tool gap is discarded instead of being reported as an LLM call.
- Add `sourceTimestampMs` to completed model-call diagnostics so the OTel recorder can backdate completed-only request spans to their real completion time.
- Attach exact per-response usage to request spans when present, while still emitting a timing span when Codex omits optional usage.
- Attach accumulated `attemptUsage` to the turn-level model span.
- Hash the upstream response ID before exposing it in diagnostics and deduplicate repeated completion notifications.
- Map `reasoningOutputTokens` into `reasoningTokens`.
- Reuse the same response accumulator in bounded/settled-turn paths.
- Fail closed to thread-last usage when an exact response aggregate becomes incomplete.

Transcript timestamps are intentionally unchanged: an assistant tool-call message records when the model produced the tool call, not when that provider request began. Per-response diagnostics now own the LLM timing boundary.

The assistant-completion idle timeout configuration is not part of this PR: `#97233` already exposed `appServer.turnAssistantCompletionIdleTimeoutMs` on current `main`.

This change was AI-assisted. I reviewed the diff and validated the event contract directly against `openai/codex` app-server source and a real app-server turn.

## User Impact

- Token and cost accounting is accurate for Codex turns containing multiple upstream responses.
- Current-context reporting continues to reflect only the latest provider response.
- OTel consumers can render:

  `LLM request -> tool execution -> LLM request -> tool execution -> final LLM request`

  without deriving LLM starts from assistant-message timestamps.

## Upstream Codex Contract

Checked against immutable `openai/codex@95637f7056835fea66bdd0044414af480fc0fd74`:

- [`rawResponse/completed` is emitted once per upstream Responses API completion with exact, non-accumulated usage](https://github.com/openai/codex/blob/95637f7056835fea66bdd0044414af480fc0fd74/codex-rs/app-server/README.md#L1450)
- [`response_id` is required and `token_usage` is optional](https://github.com/openai/codex/blob/95637f7056835fea66bdd0044414af480fc0fd74/codex-rs/protocol/src/protocol.rs#L1820-L1827)
- [The sampling loop alternates provider responses with tool work](https://github.com/openai/codex/blob/95637f7056835fea66bdd0044414af480fc0fd74/codex-rs/core/src/session/turn.rs#L137-L149)
- [`RawResponseCompleted` is emitted when the provider response completes](https://github.com/openai/codex/blob/95637f7056835fea66bdd0044414af480fc0fd74/codex-rs/core/src/session/turn.rs#L2348-L2360)

## Evidence

### Real App-Server Proof

Ran the local authenticated Codex CLI (`0.146.0-alpha.3.1`) as `codex app-server --listen stdio://` with raw events enabled. The prompt required two separate sequential shell calls followed by `DONE`. The proof script used an ephemeral thread and redacted response/tool IDs.

Observed lifecycle, relative to model-turn start:

```text
LLM response-1   0ms .. 8878ms      total=23030
tool-1                 8913ms
LLM response-2         8913ms .. 11874ms   total=23125
tool-2                           11896ms
LLM response-3                   11896ms .. 13492ms   total=23178
turn terminal                                      13496ms
```

No LLM request span overlaps either tool phase. In this run each shell command completed within the millisecond resolution of the captured events.

Redacted projected output:

```json
{
  "rawResponses": [
    {
      "responseId": "response-1",
      "usage": {
        "inputTokens": 22967,
        "cachedInputTokens": 0,
        "outputTokens": 63,
        "totalTokens": 23030
      }
    },
    {
      "responseId": "response-2",
      "usage": {
        "inputTokens": 23078,
        "cachedInputTokens": 22272,
        "outputTokens": 47,
        "totalTokens": 23125
      }
    },
    {
      "responseId": "response-3",
      "usage": {
        "inputTokens": 23173,
        "cachedInputTokens": 22272,
        "outputTokens": 5,
        "totalTokens": 23178
      }
    }
  ],
  "projected": {
    "attemptUsage": {
      "input": 24674,
      "cacheRead": 44544,
      "output": 115,
      "total": 69333
    },
    "latestResponseUsage": {
      "input": 901,
      "cacheRead": 22272,
      "output": 5,
      "total": 23178
    }
  },
  "requestSpanDurationsMs": [8878, 2961, 1596]
}
```

The accounting invariant holds:

```text
23030 + 23125 + 23178 = 69333
```

The latest context remains response 3 (`23178`), while turn accounting reports all three responses (`69333`).

### Additional Verification

- Final affected-surface tests:
  - 5 files passed, 182 tests passed.
  - Covers multi-response accumulation/deduplication, delayed response completion, sequential-tool gap collapse, native/dynamic tool boundaries, and OTel source-time backdating.
- Production and test typechecks passed for core and extensions.
- Targeted core/extension lint and formatting passed for all changed files.
- Repository guards passed:
  - max-lines and environment-variable ratchets
  - plugin SDK API baseline, exports, and surface budget
  - deprecated API usage and plugin boundary report
  - guarded/plugin-SDK wildcard re-exports
  - runtime sidecar baseline/loaders
  - dependency pins/package patches
  - import cycles and conflict markers
- `run-attempt` focused lane:
  - 143 tests passed, 4 tests failed.
  - The same four SQLite settled-turn/context-engine assertions were reproduced unchanged on latest `origin/main` before this timing change, so they are current baseline failures rather than regressions from this PR.
