### PR TITLE
fix(control-ui): make Quick Config fast mode persist

### DIFF
--- a/ui/src/e2e/config-quick-thinking-persistence.e2e.test.ts
+++ b/ui/src/e2e/config-quick-thinking-persistence.e2e.test.ts
@@ -18,8 +18,20 @@ const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? descri
 let browser: Browser;
 let server: ControlUiE2eServer;
 
-function configResponse(thinkingDefault: "low" | "high", hash: string) {
-  const config = { agents: { defaults: { model: "openai/gpt-5.5", thinkingDefault } } };
+function configResponse(
+  thinkingDefault: "low" | "high",
+  hash: string,
+  fastModeDefault?: boolean | "auto",
+) {
+  const config = {
+    agents: {
+      defaults: {
+        model: "openai/gpt-5.5",
+        thinkingDefault,
+        ...(fastModeDefault === undefined ? {} : { fastModeDefault }),
+      },
+    },
+  };
   return {
     config,
     hash,
@@ -165,4 +177,56 @@ describeControlUiE2e("Control UI General settings thinking persistence mocked Ga
       await context.close();
     }
   });
+
+  it.each([
+    { initial: false, initialLabel: "Standard", next: true, nextLabel: "Fast" },
+    { initial: true, initialLabel: "Fast", next: "auto" as const, nextLabel: "Auto" },
+    { initial: "auto" as const, initialLabel: "Auto", next: false, nextLabel: "Standard" },
+  ])(
+    "persists agents.defaults.fastModeDefault from $initialLabel to $nextLabel",
+    async ({ initial, initialLabel, next, nextLabel }) => {
+      const context = await browser.newContext({
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1280 },
+      });
+      const page = await context.newPage();
+      const initialConfig = configResponse("low", "hash-1", initial);
+      const gateway = await installMockGateway(page, {
+        methodResponses: { "config.get": initialConfig },
+      });
+
+      try {
+        const response = await page.goto(`${server.baseUrl}config`);
+        expect(response?.status()).toBe(200);
+
+        const modelCard = page.locator("#settings-general-model");
+        const initialButton = modelCard.getByRole("radio", { name: initialLabel, exact: true });
+        await initialButton.waitFor();
+        expect(await initialButton.getAttribute("aria-checked")).toBe("true");
+
+        await modelCard.getByRole("radio", { name: nextLabel, exact: true }).click();
+
+        const raw = requestRaw(await gateway.waitForRequest("config.set"));
+        expect(raw).toEqual({
+          agents: {
+            defaults: {
+              model: "openai/gpt-5.5",
+              thinkingDefault: "low",
+              fastModeDefault: next,
+            },
+          },
+        });
+        expect(raw.agents).not.toHaveProperty("defaults.fastMode");
+
+        const reloadResponse = await page.reload();
+        expect(reloadResponse?.status()).toBe(200);
+        const persistedButton = modelCard.getByRole("radio", { name: nextLabel, exact: true });
+        await persistedButton.waitFor();
+        expect(await persistedButton.getAttribute("aria-checked")).toBe("true");
+      } finally {
+        await context.close();
+      }
+    },
+  );
 });

--- a/ui/src/pages/config/config-page.ts
+++ b/ui/src/pages/config/config-page.ts
@@ -1087,7 +1087,7 @@ export class ConfigPage extends OpenClawLightDomElement {
     const model = resolveModelPrimary(agentsDefaults?.model) ?? "default";
     const thinkingLevel =
       typeof agentsDefaults?.thinkingDefault === "string" ? agentsDefaults.thinkingDefault : "off";
-    const fastMode = agentsDefaults?.fastMode;
+    const fastMode = agentsDefaults?.fastModeDefault;
     const appConfig = this.context.config.current;
     return renderQuickSettings({
       locale: isSupportedLocale(this.settings.locale) ? this.settings.locale : i18n.getLocale(),
@@ -1122,7 +1122,7 @@ export class ConfigPage extends OpenClawLightDomElement {
       onThinkingChange: (level) =>
         runtimeConfig.patchForm(["agents", "defaults", "thinkingDefault"], level),
       onFastModeChange: (mode: FastMode) =>
-        runtimeConfig.patchForm(["agents", "defaults", "fastMode"], mode),
+        runtimeConfig.patchForm(["agents", "defaults", "fastModeDefault"], mode),
     });
   }
 


### PR DESCRIPTION
Closes #104501

## What Problem This Solves

Fixes an issue where users changing Fast mode in Control UI Quick Config would see their setting revert, fail gateway config validation, or see an existing Fast or Auto default displayed incorrectly. The existing gateway contract accepts agents.defaults.fastModeDefault, while Quick Config previously read and submitted the rejected agents.defaults.fastMode key.

## Why This Change Was Made

Use the existing canonical fastModeDefault field for both Quick Config display and config.set persistence. Preserve the existing global schema, all three Fast/Auto/Standard modes, model handling, thinking defaults, and the current owner boundary; add no alias, migration, new configuration surface, or compatibility fallback.

## User Impact

Fast, Auto, and Standard now display the saved gateway setting, submit only the accepted canonical configuration field, and remain selected after a complete page reload. Object-form model display and thinking-level persistence continue to work.

## Evidence

- Baseline reproduced against unchanged origin/main in real Chromium on Blacksmith Testbox tbx_01kyhenc6fsh8633bxr12c2j2z: all three exact user flows failed; the actual config.set request included rejected fastMode and preserved the old fastModeDefault. https://github.com/openclaw/openclaw/actions/runs/30254358199
- Fixed product proved in real Chromium on Blacksmith Testbox tbx_01kyhet6ynf1kcc3jax8ha23vb: 9/9 browser cases pass, including all three false/true/auto changes, exact config.set payload without a legacy key, visible state after full reload, five model forms, and canonical thinking persistence; all 14 Quick Config unit tests also pass. Wrapper exitCode 0, runStatus succeeded. https://github.com/openclaw/openclaw/actions/runs/30254543297
- Full changed-file gate on Blacksmith Testbox tbx_01kyhezkpkg85bd98s59v936na: format, i18n, both core/UI tsgo lanes, and lint; wrapper exitCode 0, runStatus succeeded. https://github.com/openclaw/openclaw/actions/runs/30254751597
- AI-assisted. Fresh structured autoreview of the exact two-file change exited 0 with no actionable findings.
- Delegated Blacksmith one-shot Actions leases may show cancelled after successful external lease cleanup; the real Chromium output and wrapper timing JSON are authoritative.