### PR TITLE
fix(cli): prevent policy-blocked plugin enable mutations

### DIFF
--- a/src/cli/plugins-cli.policy.test.ts
+++ b/src/cli/plugins-cli.policy.test.ts
@@ -8,6 +8,7 @@ import {
   refreshPluginRegistry,
   resetPluginsCliTestState,
   runtimeErrors,
+  runtimeLogs,
   runPluginsCommand,
   writeConfigFile,
 } from "./plugins-cli-test-helpers.js";
@@ -91,6 +92,40 @@ describe("plugins cli policy mutations", () => {
       policyPluginIds: ["alpha"],
       reason: "policy-changed",
     });
+  });
+
+  it.each([
+    {
+      policy: "globally disabled plugins",
+      plugins: { enabled: false },
+      reason: "plugins disabled",
+    },
+    {
+      policy: "a plugin denylist",
+      plugins: { deny: ["alpha"] },
+      reason: "blocked by denylist",
+    },
+    {
+      policy: "a restrictive plugin allowlist",
+      plugins: { allow: ["other-plugin"] },
+      reason: "blocked by allowlist",
+    },
+  ])("does not mutate plugin state when $policy blocks enablement", async ({ plugins, reason }) => {
+    const sourceConfig = { plugins } as OpenClawConfig;
+    loadConfig.mockReturnValue(sourceConfig);
+    enablePluginInConfig.mockReturnValue({
+      config: sourceConfig,
+      enabled: false,
+      pluginId: "alpha",
+      reason,
+    });
+    mockPluginRegistry(["alpha"]);
+
+    await runPluginsCommand(["plugins", "enable", "alpha"]);
+
+    expect(writeConfigFile).not.toHaveBeenCalled();
+    expect(refreshPluginRegistry).not.toHaveBeenCalled();
+    expect(runtimeLogs).toContain(`Plugin "alpha" could not be enabled (${reason}).`);
   });
 
   it("refuses plugin enablement in Nix mode before config mutation", async () => {

--- a/src/cli/plugins-cli.runtime.ts
+++ b/src/cli/plugins-cli.runtime.ts
@@ -203,9 +203,6 @@ async function runPluginsEnableCommandUnlocked(idInput: string): Promise<void> {
   const { enableExplicitlySelectedPluginInConfig } = await import("../plugins/enable.js");
   const { normalizePluginId } = await loadPluginsConfigState();
   const { buildPluginRegistrySnapshotReport } = await loadPluginsStatus();
-  const { applySlotSelectionForPlugin } = await loadPluginSlotSelection();
-  const { logSlotWarnings } = await loadPluginsCommandHelpers();
-  const { refreshPluginRegistryAfterConfigMutation } = await loadPluginsRegistryRefresh();
   const snapshot = await readConfigFileSnapshot();
   const cfg = (snapshot.sourceConfig ?? snapshot.config) as OpenClawConfig;
   const report = buildPluginRegistrySnapshotReport({ config: cfg });
@@ -216,6 +213,19 @@ async function runPluginsEnableCommandUnlocked(idInput: string): Promise<void> {
   const enableResult = enableExplicitlySelectedPluginInConfig(cfg, id, {
     updateChannelConfig: false,
   });
+  // A blocked request must not displace the active slot or rewrite persisted state.
+  if (!enableResult.enabled) {
+    defaultRuntime.log(
+      theme.warn(
+        `Plugin "${id}" could not be enabled (${enableResult.reason ?? "unknown reason"}).`,
+      ),
+    );
+    return;
+  }
+
+  const { applySlotSelectionForPlugin } = await loadPluginSlotSelection();
+  const { logSlotWarnings } = await loadPluginsCommandHelpers();
+  const { refreshPluginRegistryAfterConfigMutation } = await loadPluginsRegistryRefresh();
   let next: OpenClawConfig = enableResult.config;
   const slotResult = applySlotSelectionForPlugin(next, id);
   next = slotResult.config;
@@ -233,13 +243,7 @@ async function runPluginsEnableCommandUnlocked(idInput: string): Promise<void> {
     },
   });
   logSlotWarnings(slotResult.warnings);
-  if (enableResult.enabled) {
-    defaultRuntime.log(`Enabled plugin "${id}". Restart the gateway to apply.`);
-    return;
-  }
-  defaultRuntime.log(
-    theme.warn(`Plugin "${id}" could not be enabled (${enableResult.reason ?? "unknown reason"}).`),
-  );
+  defaultRuntime.log(`Enabled plugin "${id}". Restart the gateway to apply.`);
 }
 
 /** Disable a plugin in config and refresh the registry snapshot for the changed policy. */


### PR DESCRIPTION
Closes #114322

## What Problem This Solves

`openclaw plugins enable <id>` applied exclusive-slot selection, rewrote `openclaw.json`, and refreshed the persisted plugin registry even when global policy, a denylist, or a restrictive allowlist refused to enable the plugin. A rejected request could therefore displace the active memory plugin while printing that nothing was enabled.

## Why This Change Was Made

Decide whether plugin policy permits the request before loading slot-selection or registry-mutation modules. Preserve the existing denial message and successful-enable behavior. This matches the existing fail-before-mutation contract in `setManagedPluginEnabled` and avoids changing plugin IDs, manifests, public SDKs, config schema, or migration behavior.

This intentionally fixes only #114322. Draft #114323 combines this problem with two independent manifest/canonicalization issues; those remain separate rather than bundling compatibility-sensitive changes into a CLI safety fix.

## User Impact

Denied plugin enable commands no longer change saved configuration, exclusive memory slots, or the plugin registry. Successful enable, install, uninstall, aliases, and existing warning output retain their prior behavior.

## Before-fix proof

Added one parameterized regression covering globally disabled plugins, a denylisted plugin, and a restrictive allowlist. On current `main`, all three fail because `writeConfigFile` is called despite the policy rejection:

```text
FAIL globally disabled plugins: expected writeConfigFile not to be called; called once
FAIL plugin denylist: expected writeConfigFile not to be called; called once
FAIL restrictive allowlist: expected writeConfigFile not to be called; called once
Test Files  1 failed
Tests       3 failed | 10 passed
```

## Exact built-CLI behavior proof

Blacksmith Testbox `tbx_01kyhety2f6750qx7pah9e9qyv`; isolated temporary config and memory slot; actual `node openclaw.mjs plugins enable memory-core` after a fresh product build:

```text
PASS trusted main base: 0680dfc6a9a920b835ba8b388f1534a3f2087a04
PASS built CLI with policy fix
PASS globally disabled: plugins disabled; config byte-identical; memory slot remains none
PASS denylisted: blocked by denylist; config byte-identical; memory slot remains none
PASS restrictive allowlist: blocked by allowlist; config byte-identical; memory slot remains none
RESULT 3/3 real built plugin enable denial policies preserve configuration and memory slot
```

## Verification

- 270 plugin/CLI tests passed across nine files and three Vitest projects:
  - `src/cli/plugins-cli.policy.test.ts`
  - `src/cli/plugins-cli.install.test.ts`
  - `src/cli/plugins-cli.uninstall.test.ts`
  - `src/cli/plugins-cli.registry.test.ts`
  - `src/cli/plugins-cli.lazy.test.ts`
  - `src/cli/plugins-config.test.ts`
  - `src/plugins/enable.test.ts`
  - `src/plugins/slots.test.ts`
  - `src/plugins/management-service.test.ts`
- `pnpm build`: passed on the same Testbox before the built-CLI proof.
- `oxfmt --check` and `git diff --check`: passed.
- Fresh independent Codex autoreview: no actionable findings; correctness confidence `0.96`.

### Full remote changed-code gate

`pnpm check:changed -- src/cli/plugins-cli.runtime.ts src/cli/plugins-cli.policy.test.ts` passed on Blacksmith Testbox `tbx_01kyhety2f6750qx7pah9e9qyv`: production and test `tsgo`, targeted formatting and lint (0 warnings, 0 errors), plugin SDK/boundary guards, database-first and native-state guards, dependency pins, import cycles, webhook and pairing authorization checks. Wrapper result: `exitCode=0`, `runStatus=succeeded`.

AI-assisted: Codex.
