### PR TITLE
fix(cron): preserve future one-shots during manual runs

### DIFF
--- a/src/cron/service.one-shot-schedule-ownership.test.ts
+++ b/src/cron/service.one-shot-schedule-ownership.test.ts
@@ -1,0 +1,317 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  clearCommandLane,
+  enqueueCommandInLane,
+  setCommandLaneConcurrency,
+} from "../process/command-queue.js";
+import { CommandLane } from "../process/lanes.js";
+import { CronService } from "./service.js";
+import { createDeferred, setupCronServiceSuite } from "./service.test-harness.js";
+import type { CronEvent, CronServiceDeps } from "./service/state.js";
+import { loadCronStore } from "./store.js";
+
+const { logger, makeStorePath } = setupCronServiceSuite({
+  prefix: "cron-one-shot-schedule-ownership-",
+  baseTimeIso: "2026-07-27T12:00:00.000Z",
+});
+
+type IsolatedOutcome =
+  | { status: "ok"; summary: string }
+  | { status: "error"; error: string }
+  | { status: "skipped"; error: string };
+
+function createCron(params: {
+  storePath: string;
+  runIsolatedAgentJob: CronServiceDeps["runIsolatedAgentJob"];
+  onEvent?: (event: CronEvent) => void;
+}) {
+  return new CronService({
+    storePath: params.storePath,
+    cronEnabled: true,
+    log: logger,
+    enqueueSystemEvent: vi.fn(),
+    requestHeartbeat: vi.fn(),
+    runIsolatedAgentJob: params.runIsolatedAgentJob,
+    ...(params.onEvent ? { onEvent: params.onEvent } : {}),
+  });
+}
+
+async function addOneShot(params: {
+  cron: CronService;
+  name: string;
+  atMs: number;
+  deleteAfterRun?: boolean;
+}) {
+  return await params.cron.add({
+    name: params.name,
+    enabled: true,
+    ...(params.deleteAfterRun === undefined ? {} : { deleteAfterRun: params.deleteAfterRun }),
+    schedule: { kind: "at", at: new Date(params.atMs).toISOString() },
+    sessionTarget: "isolated",
+    wakeMode: "next-heartbeat",
+    payload: { kind: "agentTurn", message: "verify one-shot schedule ownership" },
+    delivery: { mode: "none" },
+  });
+}
+
+async function expectFutureOneShot(params: {
+  cron: CronService;
+  storePath: string;
+  jobId: string;
+  atMs: number;
+  status: IsolatedOutcome["status"];
+}) {
+  const expected = {
+    id: params.jobId,
+    enabled: true,
+    schedule: { kind: "at", at: new Date(params.atMs).toISOString() },
+    state: {
+      lastRunStatus: params.status,
+      lastStatus: params.status,
+      nextRunAtMs: params.atMs,
+    },
+  };
+  const listed = await params.cron.list({ includeDisabled: true });
+  const listedJob = listed.find((job) => job.id === params.jobId);
+  expect(listedJob).toMatchObject(expected);
+  expect(listedJob?.state.runningAtMs).toBeUndefined();
+  const durable = await loadCronStore(params.storePath);
+  const durableJob = durable.jobs.find((job) => job.id === params.jobId);
+  expect(durableJob).toMatchObject(expected);
+  expect(durableJob?.state.runningAtMs).toBeUndefined();
+}
+
+describe("cron one-shot schedule ownership", () => {
+  it.each([
+    { label: "successful", outcome: { status: "ok", summary: "done" } },
+    { label: "failed", outcome: { status: "error", error: "temporary provider failure" } },
+    { label: "skipped", outcome: { status: "skipped", error: "temporarily unavailable" } },
+  ] satisfies Array<{ label: string; outcome: IsolatedOutcome }>)(
+    "keeps the future scheduled fire after a $label manual run",
+    async ({ outcome }) => {
+      const store = await makeStorePath();
+      const events: CronEvent[] = [];
+      const cron = createCron({
+        storePath: store.storePath,
+        runIsolatedAgentJob: vi.fn(async () => outcome),
+        onEvent: (event) => events.push(event),
+      });
+
+      try {
+        await cron.start();
+        const atMs = Date.now() + 60 * 60_000;
+        const job = await addOneShot({ cron, name: `manual ${outcome.status}`, atMs });
+
+        await expect(cron.run(job.id, "force")).resolves.toEqual({ ok: true, ran: true });
+
+        await expectFutureOneShot({
+          cron,
+          storePath: store.storePath,
+          jobId: job.id,
+          atMs,
+          status: outcome.status,
+        });
+        expect(events.some((event) => event.jobId === job.id && event.action === "removed")).toBe(
+          false,
+        );
+      } finally {
+        cron.stop();
+      }
+    },
+  );
+
+  it("keeps the future scheduled fire after a queued manual run", async () => {
+    const store = await makeStorePath();
+    const finished = createDeferred<void>();
+    const events: CronEvent[] = [];
+    const cron = createCron({
+      storePath: store.storePath,
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const, summary: "done" })),
+      onEvent: (event) => {
+        events.push(event);
+        if (event.action === "finished") {
+          finished.resolve();
+        }
+      },
+    });
+
+    try {
+      await cron.start();
+      const atMs = Date.now() + 60 * 60_000;
+      const job = await addOneShot({ cron, name: "queued manual one-shot", atMs });
+
+      await expect(cron.enqueueRun(job.id, "force")).resolves.toMatchObject({
+        ok: true,
+        enqueued: true,
+      });
+      await finished.promise;
+      await cron.status();
+
+      await expectFutureOneShot({
+        cron,
+        storePath: store.storePath,
+        jobId: job.id,
+        atMs,
+        status: "ok",
+      });
+      expect(events.some((event) => event.jobId === job.id && event.action === "removed")).toBe(
+        false,
+      );
+    } finally {
+      cron.stop();
+    }
+  });
+
+  it("preserves a manual run accepted before its scheduled fire but admitted afterward", async () => {
+    const store = await makeStorePath();
+    const finished = createDeferred<void>();
+    const blockerStarted = createDeferred<void>();
+    const releaseBlocker = createDeferred<void>();
+    const cron = createCron({
+      storePath: store.storePath,
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const, summary: "done" })),
+      onEvent: (event) => {
+        if (event.action === "finished") {
+          finished.resolve();
+        }
+      },
+    });
+
+    clearCommandLane(CommandLane.Cron);
+    setCommandLaneConcurrency(CommandLane.Cron, 1);
+    const blocker = enqueueCommandInLane(CommandLane.Cron, async () => {
+      blockerStarted.resolve();
+      await releaseBlocker.promise;
+    });
+
+    try {
+      await blockerStarted.promise;
+      await cron.start();
+      cron.pauseScheduling();
+      const atMs = Date.now() + 1_000;
+      const job = await addOneShot({ cron, name: "manual queued across deadline", atMs });
+
+      await expect(cron.enqueueRun(job.id, "force")).resolves.toMatchObject({
+        ok: true,
+        enqueued: true,
+      });
+      vi.setSystemTime(new Date(atMs + 1));
+      releaseBlocker.resolve();
+      await blocker;
+      await finished.promise;
+      await cron.status();
+
+      await expectFutureOneShot({
+        cron,
+        storePath: store.storePath,
+        jobId: job.id,
+        atMs,
+        status: "ok",
+      });
+    } finally {
+      releaseBlocker.resolve();
+      await blocker;
+      cron.stop();
+      clearCommandLane(CommandLane.Cron);
+    }
+  });
+
+  it("consumes a manually verified one-shot only when its scheduled occurrence fires", async () => {
+    const store = await makeStorePath();
+    const removed = createDeferred<void>();
+    const runIsolatedAgentJob = vi.fn(async () => ({
+      status: "ok" as const,
+      summary: "done",
+    }));
+    const cron = createCron({
+      storePath: store.storePath,
+      runIsolatedAgentJob,
+      onEvent: (event) => {
+        if (event.action === "removed") {
+          removed.resolve();
+        }
+      },
+    });
+
+    try {
+      await cron.start();
+      const atMs = Date.now() + 1_000;
+      const job = await addOneShot({ cron, name: "manual then scheduled one-shot", atMs });
+
+      await expect(cron.run(job.id, "force")).resolves.toEqual({ ok: true, ran: true });
+      expect(runIsolatedAgentJob).toHaveBeenCalledTimes(1);
+      await expectFutureOneShot({
+        cron,
+        storePath: store.storePath,
+        jobId: job.id,
+        atMs,
+        status: "ok",
+      });
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      await removed.promise;
+      await cron.status();
+
+      expect(runIsolatedAgentJob).toHaveBeenCalledTimes(2);
+      expect(
+        (await cron.list({ includeDisabled: true })).find((entry) => entry.id === job.id),
+      ).toBe(undefined);
+      expect((await loadCronStore(store.storePath)).jobs.find((entry) => entry.id === job.id)).toBe(
+        undefined,
+      );
+    } finally {
+      cron.stop();
+    }
+  });
+
+  it("preserves every scheduled one-shot in a concurrent queued manual batch", async () => {
+    const store = await makeStorePath();
+    const completions = new Map<string, ReturnType<typeof createDeferred<void>>>();
+    const cron = createCron({
+      storePath: store.storePath,
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const, summary: "done" })),
+      onEvent: (event) => {
+        if (event.action === "finished") {
+          completions.get(event.jobId)?.resolve();
+        }
+      },
+    });
+
+    try {
+      await cron.start();
+      const atMs = Date.now() + 60 * 60_000;
+      const jobs = [];
+      for (let index = 0; index < 24; index += 1) {
+        const job = await addOneShot({ cron, name: `queued one-shot ${index}`, atMs });
+        completions.set(job.id, createDeferred<void>());
+        jobs.push(job);
+      }
+
+      const acknowledgements = await Promise.all(
+        jobs.map(async (job) => await cron.enqueueRun(job.id, "force")),
+      );
+      expect(acknowledgements).toHaveLength(jobs.length);
+      for (const acknowledgement of acknowledgements) {
+        expect(acknowledgement).toMatchObject({ ok: true, enqueued: true });
+      }
+      await Promise.all([...completions.values()].map(async (completion) => completion.promise));
+      await cron.status();
+
+      const listed = await cron.list({ includeDisabled: true });
+      const durable = await loadCronStore(store.storePath);
+      expect(listed).toHaveLength(jobs.length);
+      expect(durable.jobs).toHaveLength(jobs.length);
+      for (const job of jobs) {
+        for (const stored of [listed, durable.jobs]) {
+          expect(stored.find((entry) => entry.id === job.id)).toMatchObject({
+            id: job.id,
+            enabled: true,
+            state: { lastRunStatus: "ok", nextRunAtMs: atMs },
+          });
+        }
+      }
+    } finally {
+      cron.stop();
+    }
+  });
+});

--- a/src/cron/service/ops-run-preparation.ts
+++ b/src/cron/service/ops-run-preparation.ts
@@ -52,6 +52,7 @@ type PreparedManualRun =
       terminalTracker?: ManualRunTerminalTracker;
       owningCronLaneTaskMarker?: CommandLaneTaskMarker;
       reservationAt: number;
+      scheduleOwnershipAtMs: number;
       reservationIdentity: object;
       wasEnabled: boolean;
       payload?: CronPayload;
@@ -72,6 +73,7 @@ export type ActivatedManualRun = Extract<PreparedManualRun, { ran: true }> & {
 
 export type ManualRunOptions = {
   runId?: string;
+  scheduleOwnershipAtMs?: number;
   payload?: CronPayload;
   terminalTracker?: ManualRunTerminalTracker;
   owningCronLaneTaskMarker?: CommandLaneTaskMarker;
@@ -379,6 +381,7 @@ export async function prepareManualRun(
       terminalTracker: opts?.terminalTracker,
       owningCronLaneTaskMarker: opts?.owningCronLaneTaskMarker,
       reservationAt,
+      scheduleOwnershipAtMs: opts?.scheduleOwnershipAtMs ?? reservationAt,
       reservationIdentity,
       wasEnabled: isJobEnabled(job),
       ...(opts?.payload ? { payload: structuredClone(opts.payload) } : {}),

--- a/src/cron/service/ops-run.ts
+++ b/src/cron/service/ops-run.ts
@@ -171,7 +171,10 @@ async function finishPreparedManualRun(
             startedAt,
             endedAt,
           },
-          { scheduleMode: mode === "force" ? "preserve" : "advance" },
+          {
+            scheduleMode: mode === "force" ? "preserve" : "advance",
+            scheduleOwnershipAtMs: prepared.scheduleOwnershipAtMs,
+          },
         );
         applyTriggerRunResult(job, {
           status: coreResult.status,
@@ -339,7 +342,8 @@ export async function enqueueRun(state: CronServiceState, id: string, mode?: "du
     return disposition;
   }
 
-  const runId = `manual:${id}:${state.deps.nowMs()}:${nextManualRunId++}`;
+  const scheduleOwnershipAtMs = state.deps.nowMs();
+  const runId = `manual:${id}:${scheduleOwnershipAtMs}:${nextManualRunId++}`;
   const terminalTracker: ManualRunTerminalTracker = { emitted: false };
   void runWithGatewayIndependentRootWorkContinuation(() =>
     enqueueCommandInLane(
@@ -347,6 +351,7 @@ export async function enqueueRun(state: CronServiceState, id: string, mode?: "du
       async (owningCronLaneTaskMarker) => {
         const result = await run(state, id, mode, {
           runId,
+          scheduleOwnershipAtMs,
           terminalTracker,
           owningCronLaneTaskMarker,
         });

--- a/src/cron/service/timer-outcomes.ts
+++ b/src/cron/service/timer-outcomes.ts
@@ -41,6 +41,8 @@ export function applyJobResult(
   opts?: {
     // Manual force runs update outcome state but are out-of-band for cadence.
     scheduleMode?: "advance" | "preserve";
+    // Lane and admission waits must not transfer a pre-deadline manual run's ownership.
+    scheduleOwnershipAtMs?: number;
     // Startup replay restores alert cooldown bookkeeping without redelivery.
     replayFailureAlertAtMs?: number;
   },
@@ -138,14 +140,28 @@ export function applyJobResult(
     job.state.lastFailureAlertAtMs = undefined;
   }
 
-  // The gateway watcher disables on-exit jobs before firing; successful removal here
-  // completes the same deleteAfterRun contract as a one-shot at schedule.
+  // An operator force-run borrows a future at-schedule; it cannot consume,
+  // disable, or retry that scheduled occurrence. On-exit watchers also use
+  // force, but their terminal callback owns and must retire the watched job.
+  const preserveOneShotSchedule =
+    opts?.scheduleMode === "preserve" &&
+    job.schedule.kind === "at" &&
+    previousScheduleState.nextRunAtMs !== undefined &&
+    previousScheduleState.nextRunAtMs > (opts.scheduleOwnershipAtMs ?? result.startedAt);
   const isOneShotSchedule = job.schedule.kind === "at" || job.schedule.kind === "on-exit";
-  const shouldDelete = isOneShotSchedule && job.deleteAfterRun === true && result.status === "ok";
+  const shouldDelete =
+    isOneShotSchedule &&
+    !preserveOneShotSchedule &&
+    job.deleteAfterRun === true &&
+    result.status === "ok";
   const retryDisabledHeartbeatOneShot = shouldRetryDisabledHeartbeatOneShot(job, result);
 
   if (!shouldDelete) {
-    if (job.schedule.kind === "at") {
+    if (preserveOneShotSchedule) {
+      job.state.nextRunAtMs = previousScheduleState.nextRunAtMs;
+      job.state.pacedNextRunAtMs = previousScheduleState.pacedNextRunAtMs;
+      job.state.forcePreservedNextRunAtMs = previousScheduleState.nextRunAtMs;
+    } else if (job.schedule.kind === "at") {
       if (retryDisabledHeartbeatOneShot) {
         const retryDecision = resolveDisabledHeartbeatOneShotRetryDecision({
           cronConfig: state.deps.cronConfig,


### PR DESCRIPTION
Closes #83538
Supersedes #83933

## What Problem This Solves

Fixes an issue where operators manually verifying a future one-shot cron job would silently lose the actual scheduled occurrence. Successful manual runs deleted delete-after-run jobs; failed and skipped runs disabled their scheduled occurrence. A manually enqueued run could also cross the scheduled deadline while waiting in a command lane and accidentally consume the scheduled job.

## Why This Change Was Made

Treat a force-run accepted before a future one-shot as out-of-band verification, carry its original schedule-ownership timestamp through both command-lane and execution-admission queues, and restore the original durable scheduled occurrence after every manual result. Preserve the existing behavior for already-due one-shots, required-delivery retries, timer and startup execution, and on-exit watchers. No configuration, schema, public API, protocol, or storage-format changes.

Maintainer decision: adopt this narrow, existing-boundary ownership repair instead of the broader new run-origin/config/schema model in #83933. Jerry-Xin's investigation is explicitly credited in the co-authored commit.

## User Impact

Operators can safely run or enqueue a future one-shot for verification without deleting, disabling, or retrying away its real scheduled execution. The scheduled occurrence still runs exactly once and retains its normal delete-after-run behavior. Already-due manual jobs retain their existing behavior.

## Evidence

### Real packaged Gateway and CLI proof

Built and installed the actual PR package into the production Docker image, started a real Gateway, and ran the public cron CLI against its SQLite-backed state. The complete live transcript (no credentials):

```json
{"step":"created","id":"ffe1a972-86c8-4723-b552-1fdad4df1391","enabled":true,"deleteAfterRun":true,"at":"2026-07-27T10:08:07.176Z","nextRunAtMs":1785146887176}
{"step":"manual-run","completed":true,"status":"ok"}
{"step":"after-manual-run","enabled":true,"deleteAfterRun":true,"nextRunAtMs":1785146887176,"lastRunStatus":"ok"}
{"step":"after-failed-manual-run","enabled":true,"deleteAfterRun":true,"nextRunAtMs":1785146950104,"lastRunStatus":"error"}
{"step":"after-scheduled-fire","jobRemoved":true,"successfulRuns":2,"summaries":["one-shot-manual-and-scheduled-ok","one-shot-manual-and-scheduled-ok"]}
```

`LIVE_ONE_SHOT_PROOF_OK`

The two successful history entries are exactly the manual verification and the subsequent real scheduled occurrence; the failing manual run was independently verified against another future one-shot.

### Red/green regression and stress evidence

- Reproduced all four original failure paths on `main`: successful, failed, skipped, and queued manual force runs.
- Added SQLite-backed tests for all outcomes; durable reload; the actual later scheduled fire; 24 concurrently queued one-shots; and a real cron command-lane block where an accepted manual run starts only after the scheduled deadline.
- `pnpm test src/cron`: **153 files, 1,696 tests passed**.
- Real gateway cron suite: **101 tests passed**.
- Public CLI suite: **131 tests passed**.
- Gateway cron protocol validators: **25 tests passed**.
- `pnpm check:changed`: **passed**, including formatting, production and test typechecks, lint, database/schema, import-cycle, SDK, and compatibility guards.
- `pnpm build`: **passed**.
- `pnpm test:docker:cron-cli`: **passed**; real packaged Gateway startup and restart, 10-case persisted operator-authority matrix, public cron CRUD, manual run, execution history, and cleanup.
- Fresh independent `autoreview --mode uncommitted`: **clean**.
- All hosted PR CI checks: **passed**.

AI-assisted; all fixes, live proof, and regression cases were independently reviewed and validated.