### PR TITLE
fix(telegram): preserve every caption in incoming media albums

### DIFF
--- a/extensions/telegram/src/bot-handlers.inbound-media-group.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.inbound-media-group.runtime.ts
@@ -23,6 +23,7 @@ import type { TelegramAmbientTranscriptWatermark } from "./bot-message-context.t
 import type { RegisterTelegramHandlerParams } from "./bot-native-commands.js";
 import type { TelegramSpooledReplayDeferredParticipant } from "./bot-processing-outcome.js";
 import { MEDIA_GROUP_TIMEOUT_MS, type MediaGroupEntry } from "./bot-updates.js";
+import { renderTelegramTextEntities } from "./bot/body-helpers.js";
 import { resolveMedia } from "./bot/delivery.resolve-media.js";
 import { getTelegramTextParts, hasBotMention, resolveTelegramPrimaryMedia } from "./bot/helpers.js";
 import type { TelegramContext } from "./bot/types.js";
@@ -94,6 +95,8 @@ export function createTelegramInboundMediaGroupRuntime(
     createSpooledReplayParticipantForBufferedWork,
     spooledReplayOptions,
     resolveTelegramSessionState,
+    buildSyntheticTextMessage,
+    buildSyntheticContext,
     processMessageWithReplyChain,
   } = messageRuntime;
   const timeoutMs =
@@ -217,11 +220,103 @@ export function createTelegramInboundMediaGroupRuntime(
         settleSpooledReplayParticipants(entry.spooledReplayParticipants, { kind: "skipped" });
         return;
       }
-      if (await shouldSkipMediaDownloadForUnaddressedMentionGroup({ ...entry, ...primary })) {
+      // Gate on original captions: album labels and rendered links must not
+      // change anchored mentions or turn private link targets into mentions.
+      let shouldSkipMediaGroup = true;
+      for (const item of entry.messages) {
+        if (!(await shouldSkipMediaDownloadForUnaddressedMentionGroup({ ...entry, ...item }))) {
+          shouldSkipMediaGroup = false;
+          break;
+        }
+      }
+      if (shouldSkipMediaGroup) {
         releaseDispatchDedupeClaims(entry.dispatchDedupeClaims);
         settleSpooledReplayParticipants(entry.spooledReplayParticipants, { kind: "skipped" });
         return;
       }
+      const albumCaptions = entry.messages.flatMap(({ msg }, index) => {
+        const { text, entities } = getTelegramTextParts(msg);
+        const caption = renderTelegramTextEntities(text, entities).trim();
+        return caption ? [{ index, caption }] : [];
+      });
+      const primaryTextParts = getTelegramTextParts(primary.msg);
+      const primaryText = primaryTextParts.text;
+      const preservePrimaryControlCommand = hasControlCommand(primaryText, entry.authorizationCfg, {
+        botUsername: primary.ctx.me?.username,
+      });
+      const primaryCommandLength = primaryText.match(/^\/\S+/u)?.[0].length;
+      // Keep command parsing anchored at byte zero without dropping rich
+      // entities that begin after or span the original command prefix.
+      const primaryCommandCaption =
+        preservePrimaryControlCommand && primaryCommandLength !== undefined
+          ? `${primaryText.slice(0, primaryCommandLength)}${renderTelegramTextEntities(
+              primaryText.slice(primaryCommandLength),
+              primaryTextParts.entities.flatMap((entity) => {
+                const start = Math.max(entity.offset, primaryCommandLength);
+                const end = entity.offset + entity.length;
+                return end > start
+                  ? [
+                      {
+                        ...entity,
+                        offset: start - primaryCommandLength,
+                        length: end - start,
+                      },
+                    ]
+                  : [];
+              }),
+            )}`
+          : primaryText;
+      // The primary is the first text-bearing item, so its control command
+      // stays at byte zero even when earlier album items have no caption.
+      // Single-caption turns remain byte-for-byte stable.
+      const dispatchMessage =
+        albumCaptions.length > 1
+          ? buildSyntheticTextMessage({
+              base: primary.msg,
+              text: albumCaptions
+                .map(({ index, caption }) =>
+                  preservePrimaryControlCommand && entry.messages[index]?.msg === primary.msg
+                    ? primaryCommandCaption
+                    : `Media ${index + 1}: ${caption}`,
+                )
+                .join("\n"),
+            })
+          : primary.msg;
+      const dispatchContext =
+        dispatchMessage === primary.msg
+          ? primary.ctx
+          : buildSyntheticContext(primary.ctx, dispatchMessage);
+      const botUsername = primary.ctx.me?.username?.trim().toLowerCase();
+      const albumMentionRegexes =
+        entry.isGroup && dispatchMessage !== primary.msg
+          ? buildMentionRegexes(
+              entry.authorizationCfg,
+              resolveTelegramSessionState({
+                chatId: entry.chatId,
+                isGroup: entry.isGroup,
+                isForum: entry.isForum,
+                resolvedThreadId: entry.resolvedThreadId,
+                messageThreadId: entry.resolvedThreadId ?? entry.dmThreadId,
+                senderId: entry.senderId,
+                runtimeCfg: entry.authorizationCfg,
+              }).agentId,
+            )
+          : [];
+      const preserveAlbumMention =
+        entry.isGroup &&
+        dispatchMessage !== primary.msg &&
+        entry.messages.some(({ msg }) => {
+          const { text, entities } = getTelegramTextParts(msg);
+          return matchesMentionWithExplicit({
+            text,
+            mentionRegexes: albumMentionRegexes,
+            explicit: {
+              hasAnyMention: entities.some((entity) => entity.type === "mention"),
+              isExplicitlyMentioned: botUsername ? hasBotMention(msg, botUsername) : false,
+              canResolveExplicit: Boolean(botUsername),
+            },
+          });
+        });
       const allMedia: TelegramMediaRef[] = [];
       const selection = new Map<string, "include" | "exclude">();
       let materializedCount = 0;
@@ -283,12 +378,17 @@ export function createTelegramInboundMediaGroupRuntime(
         }).catch(() => {});
       }
       const result = await processMessageWithReplyChain({
-        ctx: primary.ctx,
-        msg: primary.msg,
+        ctx: dispatchContext,
+        msg: dispatchMessage,
         allMedia,
         promptContextMessageSelection: selection,
         storeAllowFrom: entry.storeAllowFrom,
         options: {
+          // Rendered link targets can expose an @username that was not visible
+          // in the original caption; preserve both true and false group facts.
+          ...(entry.isGroup && dispatchMessage !== primary.msg
+            ? { forceWasMentioned: preserveAlbumMention }
+            : {}),
           ...promptContextBoundaryOptions(
             entry.promptContextMinTimestampMs,
             entry.promptContextAmbientWatermark,

--- a/extensions/telegram/src/bot-message-context.body.ts
+++ b/extensions/telegram/src/bot-message-context.body.ts
@@ -323,7 +323,7 @@ export async function resolveTelegramInboundBody(params: {
     },
     transcript: preflightTranscript,
   });
-  const wasMentioned = options?.forceWasMentioned === true ? true : computedWasMentioned;
+  const wasMentioned = options?.forceWasMentioned ?? computedWasMentioned;
 
   if (isGroup && commandGate.shouldBlockControlCommand) {
     logInboundDrop({

--- a/extensions/telegram/src/bot.create-telegram-bot.channel-post-media.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.channel-post-media.test.ts
@@ -653,6 +653,103 @@ describe("createTelegramBot channel_post media", () => {
     }
   });
 
+  it.each([
+    {
+      name: "a native username mention",
+      firstCaption: "Before",
+      caption: "@openclaw_bot after",
+      entities: [{ type: "mention" as const, offset: 0, length: 13 }],
+      messageOffset: 0,
+      addressed: true,
+    },
+    {
+      name: "an anchored configured mention",
+      firstCaption: "Before",
+      caption: "hey bot after",
+      entities: [],
+      messageOffset: 2,
+      addressed: true,
+    },
+    {
+      name: "an anchored configured mention on the primary image",
+      firstCaption: "hey bot before",
+      caption: "After",
+      entities: [],
+      messageOffset: 4,
+      addressed: true,
+    },
+    {
+      name: "a bot username hidden in a link target",
+      firstCaption: "Before",
+      caption: "Read more",
+      entities: [
+        {
+          type: "text_link" as const,
+          offset: 0,
+          length: 9,
+          url: "https://example.test/@openclaw_bot",
+        },
+      ],
+      messageOffset: 6,
+      addressed: false,
+    },
+  ])(
+    "checks original album captions for $name",
+    async ({ firstCaption, caption, entities, messageOffset, addressed }) => {
+      loadConfig.mockReturnValue({
+        messages: { groupChat: { mentionPatterns: ["^hey bot"] } },
+        channels: {
+          telegram: {
+            groupPolicy: "open",
+            groups: { "*": { requireMention: true } },
+          },
+        },
+      });
+      const fetchSpy = createImageFetchSpy();
+      const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+
+      try {
+        createTelegramBot({ token: "tok", testTimings: TELEGRAM_TEST_TIMINGS });
+        const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
+
+        await Promise.all(
+          [firstCaption, caption].map((albumCaption, index) =>
+            handler({
+              message: {
+                chat: { id: -100456, type: "supergroup", title: "Ops Chat" },
+                from: { id: 55, is_bot: false, first_name: "Ada" },
+                message_id: 110690 + messageOffset + index,
+                date: 1736380800 + index,
+                caption: albumCaption,
+                ...(index === 1 ? { caption_entities: entities } : {}),
+                media_group_id: `mentioned-caption-album-${messageOffset}`,
+                photo: [{ file_id: `mentioned-album-photo-${index + 1}` }],
+              },
+              me: { id: 999, username: "openclaw_bot" },
+              getFile: async () => ({
+                file_path: `photos/mentioned-album-photo-${index + 1}.jpg`,
+              }),
+            }),
+          ),
+        );
+
+        await flushChannelPostMediaGroup(setTimeoutSpy);
+        if (addressed) {
+          await waitForMockCalls(replySpy, 1);
+          expect(replySpy).toHaveBeenCalledOnce();
+          expect(replyPayload().Body).toContain(`Media 1: ${firstCaption}\nMedia 2: ${caption}`);
+        } else {
+          expect(replySpy).not.toHaveBeenCalled();
+          expect(fetchSpy).not.toHaveBeenCalled();
+        }
+        expect(saveRemoteMedia).toHaveBeenCalledTimes(addressed ? 2 : 0);
+      } finally {
+        setTimeoutSpy.mockRestore();
+        fetchSpy.mockRestore();
+      }
+    },
+  );
+
   it("notifies mentioned requireMention groups when media download fails", async () => {
     loadConfig.mockReturnValue({
       channels: {

--- a/extensions/telegram/src/bot.media.downloads-media-file-path-no-file-download.e2e.test.ts
+++ b/extensions/telegram/src/bot.media.downloads-media-file-path-no-file-download.e2e.test.ts
@@ -436,6 +436,17 @@ describe("telegram media groups", () => {
   it(
     "handles same-group buffering and separate-group independence",
     async () => {
+      const originalLoadConfig = telegramBotDepsForTest.getRuntimeConfig;
+      telegramBotDepsForTest.getRuntimeConfig = (() => ({
+        channels: {
+          telegram: {
+            dmPolicy: "open",
+            allowFrom: ["*"],
+            groupPolicy: "open",
+            groups: { "*": { requireMention: false } },
+          },
+        },
+      })) as typeof telegramBotDepsForTest.getRuntimeConfig;
       const runtimeError = vi.fn();
       const { handler, replySpy } = await createBotHandlerWithOptions({ runtimeError });
       const fetchSpy = mockTelegramPngDownload();
@@ -449,6 +460,44 @@ describe("telegram media groups", () => {
 
       try {
         for (const scenario of [
+          {
+            messages: [
+              {
+                chat: { id: -100456, type: "supergroup" as const, title: "Ops Chat" },
+                from: { id: 777, is_bot: false, first_name: "Ada" },
+                message_id: 141,
+                caption: "Before",
+                date: 1736380800,
+                media_group_id: "album-hidden-mention",
+                photo: [{ file_id: "hidden-mention-photo1" }],
+                filePath: "photos/hidden-mention-photo1.jpg",
+              },
+              {
+                chat: { id: -100456, type: "supergroup" as const, title: "Ops Chat" },
+                from: { id: 777, is_bot: false, first_name: "Ada" },
+                message_id: 142,
+                caption: "Read more",
+                caption_entities: [
+                  {
+                    type: "text_link" as const,
+                    offset: 0,
+                    length: 9,
+                    url: "https://example.test/@openclaw_bot",
+                  },
+                ],
+                date: 1736380801,
+                media_group_id: "album-hidden-mention",
+                photo: [{ file_id: "hidden-mention-photo2" }],
+                filePath: "photos/hidden-mention-photo2.jpg",
+              },
+            ],
+            expectedReplyCount: 1,
+            assert: (replySpyLocal: ReturnType<typeof vi.fn>) => {
+              const payload = replyPayload(replySpyLocal);
+              expect(payload.Body).toContain("[Read more](https://example.test/@openclaw_bot)");
+              expect(payload.WasMentioned).toBe(false);
+            },
+          },
           {
             messages: [
               {
@@ -475,7 +524,93 @@ describe("telegram media groups", () => {
             assert: (replySpyLocal: ReturnType<typeof vi.fn>) => {
               const payload = replyPayload(replySpyLocal);
               expect(payload?.Body).toContain("Here are my photos");
+              expect(payload?.Body).not.toContain("Media 1:");
               expect(payload?.MediaPaths).toHaveLength(2);
+            },
+          },
+          {
+            messages: [
+              {
+                chat: { id: 42, type: "private" as const },
+                from: { id: 777, is_bot: false, first_name: "Ada" },
+                message_id: 121,
+                caption: "Before",
+                date: 1736380800,
+                media_group_id: "album-sparse-captions",
+                photo: [{ file_id: "sparse-photo1" }],
+                filePath: "photos/sparse-photo1.jpg",
+              },
+              {
+                chat: { id: 42, type: "private" as const },
+                from: { id: 777, is_bot: false, first_name: "Ada" },
+                message_id: 122,
+                date: 1736380801,
+                media_group_id: "album-sparse-captions",
+                photo: [{ file_id: "sparse-photo2" }],
+                filePath: "photos/sparse-photo2.jpg",
+              },
+              {
+                chat: { id: 42, type: "private" as const },
+                from: { id: 777, is_bot: false, first_name: "Ada" },
+                message_id: 123,
+                caption: "After",
+                date: 1736380802,
+                media_group_id: "album-sparse-captions",
+                photo: [{ file_id: "sparse-photo3" }],
+                filePath: "photos/sparse-photo3.jpg",
+              },
+            ],
+            expectedReplyCount: 1,
+            assert: (replySpyLocal: ReturnType<typeof vi.fn>) => {
+              const payload = replyPayload(replySpyLocal);
+              expect(payload.Body).toContain("Media 1: Before");
+              expect(payload.Body).toContain("Media 3: After");
+              expect(payload.Body).not.toContain("Media 2:");
+              expect(payload.MediaPaths).toHaveLength(3);
+            },
+          },
+          {
+            messages: [
+              {
+                chat: { id: 42, type: "private" as const },
+                from: { id: 777, is_bot: false, first_name: "Ada" },
+                message_id: 131,
+                date: 1736380800,
+                media_group_id: "album-control-command",
+                photo: [{ file_id: "command-photo1" }],
+                filePath: "photos/command-photo1.jpg",
+              },
+              {
+                chat: { id: 42, type: "private" as const },
+                from: { id: 777, is_bot: false, first_name: "Ada" },
+                message_id: 132,
+                caption: "/status\nRead more",
+                caption_entities: [
+                  { type: "bold" as const, offset: 0, length: 7 },
+                  { type: "text_link" as const, offset: 8, length: 9, url: "https://e.test/s" },
+                ],
+                date: 1736380801,
+                media_group_id: "album-control-command",
+                photo: [{ file_id: "command-photo2" }],
+                filePath: "photos/command-photo2.jpg",
+              },
+              {
+                chat: { id: 42, type: "private" as const },
+                from: { id: 777, is_bot: false, first_name: "Ada" },
+                message_id: 133,
+                caption: "Details",
+                date: 1736380802,
+                media_group_id: "album-control-command",
+                photo: [{ file_id: "command-photo3" }],
+                filePath: "photos/command-photo3.jpg",
+              },
+            ],
+            expectedReplyCount: 1,
+            assert: (replySpyLocal: ReturnType<typeof vi.fn>) => {
+              const payload = replyPayload(replySpyLocal);
+              expect(payload.Body).toContain(
+                "/status\n[Read more](https://e.test/s)\nMedia 3: Details",
+              );
             },
           },
           {
@@ -535,6 +670,7 @@ describe("telegram media groups", () => {
           scenario.assert(replySpy);
         }
       } finally {
+        telegramBotDepsForTest.getRuntimeConfig = originalLoadConfig;
         setTimeoutSpy.mockRestore();
         clearTimeoutSpy.mockRestore();
         fetchSpy.mockRestore();
@@ -585,6 +721,8 @@ describe("telegram media groups", () => {
               chat: { id: 42, type: "private" as const },
               from: { id: 777, is_bot: false, first_name: "Ada" },
               message_id: 302,
+              caption: "Before: kitchen",
+              caption_entities: [{ type: "bold" as const, offset: 8, length: 7 }],
               date: 1736380801,
               media_group_id: "album-context",
               photo: [{ file_id: "album-photo-2" }],
@@ -596,6 +734,8 @@ describe("telegram media groups", () => {
               chat: { id: 42, type: "private" as const },
               from: { id: 777, is_bot: false, first_name: "Ada" },
               message_id: 303,
+              caption: "After: kitchen",
+              caption_entities: [{ type: "italic" as const, offset: 7, length: 7 }],
               date: 1736380802,
               media_group_id: "album-context",
               photo: [{ file_id: "album-photo-3" }],
@@ -620,7 +760,11 @@ describe("telegram media groups", () => {
 
         expect(runtimeError).not.toHaveBeenCalled();
         const payload = replyPayload(replySpy);
-        expect(payload.Body).toContain("Here is the complete album");
+        expect(payload.Body).toContain("Media 1: Here is the complete album");
+        expect(payload.Body).toContain("Media 2: Before: **kitchen**");
+        expect(payload.Body).toContain("Media 3: After: _kitchen_");
+        expect(payload.Body.indexOf("Media 1:")).toBeLessThan(payload.Body.indexOf("Media 2:"));
+        expect(payload.Body.indexOf("Media 2:")).toBeLessThan(payload.Body.indexOf("Media 3:"));
         expect(payload.MediaPaths).toEqual(savedPaths);
         const messagesById = conversationMessages(payload);
         expect(messagesById.get("302")?.media_path).toBe("media://inbound/album-context-2.png");


### PR DESCRIPTION
## What Problem This Solves

Telegram media albums can contain a different caption for each photo, but only the first caption reached the agent. Users lost the descriptions needed to understand and correlate the remaining images.

Closes #110690

## Why This Change Was Made

The Telegram Bot API and the pinned grammY 1.45.1 dependency expose captions and caption entities on each album message. Aggregate all captioned messages in message-id order using the existing private Telegram synthetic-message and context seams.

Preserve original album positions, rich bold/italic/link entities, unchanged single-caption behavior, original-caption group mention authorization, and the raw control-command prefix. Keep rich entities after formatted commands and prevent rendered private link destinations from fabricating bot mentions in always-on groups. No public API, plugin SDK, configuration, dependency, migration, or product-surface changes.

## User Impact

Agents receive every caption and the associated media without losing formatting, command dispatch, media association, or group safety.

## Evidence

- Exact reviewed head: 06468c391b6e710ed590084100fbd5d76e243343.
- Reproduced the original three-image album failure against actual mocked Telegram Bot API ingress; verified red to green.
- Independently reproduced and corrected a fabricated mention from a hidden text-link destination; verified red to green.
- Independently reproduced and corrected a bold formatted primary slash command with a rich linked suffix; verified red to green.
- Blacksmith Testbox: 113 of 113 tests pass across 10 Telegram ingress, album, mention, DM, topic, thread-binding, and existing forced-mention suites.
- Fresh exact-head independent autoreview: clean, no accepted or actionable findings.
- Existing local oxfmt, oxlint, max-lines, git diff check, and worktree-safe changed-lane classification: pass; exactly four private Telegram files, extensions plus extension-test lanes only.
- The final remote changed gate did not run: Blacksmith workspace synchronization timed out twice before starting the command. This draft requests the native exact-head hosted full CI; success is not claimed while checks are pending.
- Official Telegram Bot API and pinned grammY 1.45.1 types and behavior inspected directly.
- Live external Telegram delivery was not tested because no TELEGRAM_BOT_TOKEN is available.

## Related Contributor Work

Thanks to @lsr911-code for #110761 and @chenyangjun-xy for #111139. Both attempts informed the independently verified regression and remain open; this change additionally protects rich entities, mention authorization, false mentions, control commands, and the actual Bot API ingress.