### PR TITLE
fix: prevent Anthropic live Gateway verification timeouts

### DIFF
--- a/src/gateway/gateway-models.profiles.live.test.ts
+++ b/src/gateway/gateway-models.profiles.live.test.ts
@@ -70,6 +70,7 @@ import {
 import type { ModelsConfig, ModelProviderConfig, OpenClawConfig } from "../config/types.js";
 import { isTruthyEnvValue } from "../infra/env.js";
 import type { ModelRegistry } from "../llm/model-registry.js";
+import { redactSecrets } from "../logging/redact.js";
 import { normalizeGoogleModelId } from "../plugin-sdk/google-model-id.js";
 import { resolveProviderThinkingProfile } from "../plugins/provider-runtime.js";
 import { LEGACY_IMPLICIT_AGENT_ID as DEFAULT_AGENT_ID } from "../routing/session-key.js";
@@ -2653,7 +2654,9 @@ async function runAnthropicRefusalProbe(params: {
     client: params.client,
     sessionKey: params.sessionKey,
     idempotencyKey: `idem-${randomUUID()}-refusal`,
-    message: `Reply with the single word ok. Test token: ${magic}`,
+    // Credential redaction masks values after "token:", including the
+    // nonce needed to correlate this probe with its persisted user turn.
+    message: `Reply with the single word ok. Test trigger: ${magic}`,
     thinkingLevel: params.thinkingLevel,
     context: `${params.label}: refusal-probe`,
     modelKey: params.modelKey,
@@ -3374,13 +3377,28 @@ describe("latestAssistantTextAfterBaseline", () => {
 
   it("correlates Anthropic refusal probes after the runtime scrubs their trigger", () => {
     const nonce = "0123456789abcdef0123456789abcdef";
-    const expected = `Reply with ok. ${ANTHROPIC_MAGIC_STRING_TRIGGER_REFUSAL}_${nonce}`;
-    const scrubbed = `Reply with ok. ANTHROPIC MAGIC STRING TRIGGER REFUSAL (redacted)_${nonce}`;
+    const expected = `Reply with the single word ok. Test trigger: ${ANTHROPIC_MAGIC_STRING_TRIGGER_REFUSAL}_${nonce}`;
+    const scrubbed = `Reply with the single word ok. Test trigger: ANTHROPIC MAGIC STRING TRIGGER REFUSAL (redacted)_${nonce}`;
+    const redacted = redactSecrets(expected);
 
     expect(matchesLiveProbeUserText(scrubbed, expected)).toBe(true);
+    expect(redacted).toContain(nonce);
+    expect(matchesLiveProbeUserText(redacted, expected)).toBe(true);
+    expect(
+      sessionMessagesAfterNextUserTurn(
+        [
+          { role: "user", content: "previous turn" },
+          { role: "assistant", content: "previous reply", stopReason: "stop" },
+          { role: "user", content: redacted },
+          { role: "assistant", content: "ok", stopReason: "stop" },
+        ],
+        2,
+        expected,
+      ),
+    ).toEqual([{ role: "assistant", content: "ok", stopReason: "stop" }]);
     expect(
       matchesLiveProbeUserText(
-        "Reply with ok. ANTHROPIC MAGIC STRING TRIGGER REFUSAL (redacted)_ffffffffffffffffffffffffffffffff",
+        "Reply with the single word ok. Test trigger: ANTHROPIC MAGIC STRING TRIGGER REFUSAL (redacted)_ffffffffffffffffffffffffffffffff",
         expected,
       ),
     ).toBe(false);

--- a/src/gateway/session-transcript-readers.test.ts
+++ b/src/gateway/session-transcript-readers.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import {
   persistSessionTranscriptTurn,
   upsertSessionEntry,
@@ -20,6 +20,8 @@ import {
   type SessionTranscriptReadScope,
 } from "./session-transcript-readers.js";
 
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
 describe("session transcript reader facade", () => {
   let tempDir: string;
   let storePath: string;
@@ -27,7 +29,7 @@ describe("session transcript reader facade", () => {
 
   beforeEach(() => {
     envSnapshot = captureEnv(["OPENCLAW_STATE_DIR"]);
-    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-transcript-readers-"));
+    tempDir = tempDirs.make("openclaw-transcript-readers-");
     storePath = path.join(tempDir, "sessions.json");
     setTestEnvValue("OPENCLAW_STATE_DIR", tempDir);
   });
@@ -36,7 +38,6 @@ describe("session transcript reader facade", () => {
     closeOpenClawAgentDatabasesForTest();
     closeOpenClawStateDatabaseForTest();
     envSnapshot.restore();
-    fs.rmSync(tempDir, { recursive: true, force: true });
   });
 
   function writeTranscript(sessionId: string, events: unknown[]): SessionTranscriptReadScope {


### PR DESCRIPTION
Related: #114451

## What Problem This Solves

Fixes two verified Gateway issues: release and dev-Gateway model verification incorrectly reporting working Anthropic Sonnet and Haiku models as failed, and the full hosted Gateway shard intermittently failing SQLite transcript teardown with `ENOTEMPTY`.

## Why This Change Was Made

The production transcript redactor correctly treats the old `Test token:` label as a credential field and masks the entire refusal marker, including the unique suffix that identifies the live user turn. Name the value `Test trigger:` instead so normal security redaction stays enabled and the durable nonce remains available for exact turn correlation. Extend the existing regression test to verify the actual production redactor, scrubbed provider prompts, previous-turn isolation, and the final assistant reply.

The exact hosted Gateway-core shard also proved that the transcript-reader test's one-shot temporary-directory removal races SQLite transcript worker shutdown. Replace its bespoke directory creation and teardown with the existing `useAutoCleanupTempDirTracker(afterEach)` helper, which already owns bounded, retry-safe cleanup across Gateway tests. This removes the duplicate teardown rather than introducing another storage path or runtime fallback.

## User Impact

Live Anthropic Gateway verification no longer waits for a response that has already been generated and persisted, and parallel Gateway regression tests no longer fail due to transcript cleanup races. No production provider behavior, security policy, config, SQLite schema, runtime storage, or retired JSON-state path is changed.

## Evidence

- Fresh exact-head real-provider proof on Blacksmith Testbox `tbx_01kyhge8bj5z10whfbh16m4ekk`, using the normal credential-hydrated Gateway live suite; the following terminal excerpt contains no credentials:

  ```text
  [live] [all-models] running 2 models (thinking=high)
  [live] [all-models] 1/2 anthropic/claude-sonnet-4-6: refusal-probe
  ok
  still ok.
  [live] [all-models] 1/2 anthropic/claude-sonnet-4-6: model: completed after 40s
  [live] [all-models] 1/2 anthropic/claude-sonnet-4-6: done
  [live] [all-models] 2/2 anthropic/claude-haiku-4-5: refusal-probe
  ok
  still ok
  [live] [all-models] 2/2 anthropic/claude-haiku-4-5: model: completed after 25s
  [live] [all-models] 2/2 anthropic/claude-haiku-4-5: done
  Test Files  1 passed (1)
  Tests       137 passed (137)
  exitCode=0 runStatus=succeeded
  ```

- Before: the official real-provider Anthropic Gateway release lane fails for both `anthropic/claude-sonnet-4-6` and `anthropic/claude-haiku-4-5` with a reproducible refusal-probe transcript timeout, while SQLite already contains the correct `ok` reply.
- After: both real Anthropic models complete the prompt, file-read, refusal, and `still ok` follow-up probes; all 137 live-suite tests pass.
- Real `openai/gpt-5.6`: all 137 live-suite tests pass, including prompt, file read, shell execution, tool-only turns, and SQLite transcript persistence.
- Real `google/gemini-3.1-pro-preview`: all 137 live-suite tests pass, including prompt, file read, shell execution, image understanding, and SQLite transcript persistence.
- Expanded 25-file provider, Gateway, agent, workspace, doctor, model-picker, and SQLite regression matrix passes across seven Vitest shards.
- All 21 real model-list CLI E2E tests pass, including side-effect-free dynamic model discovery.
- All 12 Gateway/model/SQLite concurrency stress passes succeed: 131 regression assertions per pass, 1,572 repeated assertions total, including concurrent 100,000-message transcript reconciliation and SQLite cleanup races.
- Reproduced the actual hosted `checks-node-compact-large-2` failure: `src/gateway/session-transcript-readers.test.ts` fails with `ENOTEMPTY` while removing a directory used by asynchronous SQLite transcript projection.
- The complete hosted-equivalent Gateway-core shard passes on Blacksmith after switching to the canonical shared temporary-directory cleanup helper.
- Eight additional parallel SQLite transcript cleanup-race stress passes succeed.
- Exact-head hosted CI run [30256887143](https://github.com/openclaw/openclaw/actions/runs/30256887143) completes successfully, including the previously failing Gateway-core shard.
- Production-format validation passes; independent review of each fix reports no actionable findings.
- AI-assisted; no private session transcript is included.
