### PR TITLE
refactor(ui): unify user avatar rendering

### DIFF
--- a/ui/src/components/identity-avatar-view.test.ts
+++ b/ui/src/components/identity-avatar-view.test.ts
@@ -1,0 +1,161 @@
+/* @vitest-environment jsdom */
+
+import { html, render } from "lit";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resolveAvatarInitials, setAvatarGatewayOrigin } from "../lib/identity-avatar.ts";
+import {
+  identityAvatarClass,
+  renderIdentityAvatarImage,
+  resolveIdentityAvatarView,
+  type IdentityAvatarView,
+} from "./identity-avatar-view.ts";
+
+function renderAvatar(view: IdentityAvatarView, container: HTMLElement): void {
+  render(
+    html`<span class=${identityAvatarClass("test-avatar", view)}>
+      ${renderIdentityAvatarImage({
+        view,
+        fallbackSelector: ".test-avatar",
+        className: "test-avatar__image",
+        alt: "Ada Lovelace",
+        ariaHidden: true,
+      })}
+    </span>`,
+    container,
+  );
+}
+
+afterEach(() => {
+  document.body.replaceChildren();
+  setAvatarGatewayOrigin(null);
+  vi.restoreAllMocks();
+});
+
+describe("shared identity avatar view", () => {
+  it("derives fallback initials and colors from the canonical user identity", () => {
+    const identity = {
+      id: "profile-riley",
+      name: "Riley",
+      username: "riley@example.test",
+    };
+
+    const view = resolveIdentityAvatarView(identity);
+
+    expect(view.fallback).toEqual(resolveAvatarInitials(identity));
+    expect(view.fallback.initials).toBe("R");
+    expect(view.imageUrl).toBeNull();
+    expect(view.pending).toBe(false);
+  });
+
+  it("keeps hostile avatar origins out of the shared authenticated renderer", () => {
+    setAvatarGatewayOrigin("https://gateway.example.test", "Bearer avatar-token");
+    const fetchAvatar = vi.spyOn(globalThis, "fetch");
+
+    const view = resolveIdentityAvatarView({
+      id: "profile-mallory",
+      name: "Mallory",
+      profileAvatarUrl: "https://evil.example/api/users/profile-mallory/avatar",
+    });
+
+    expect(view.fallback.initials).toBe("M");
+    expect(view.imageUrl).toBeNull();
+    expect(view.pending).toBe(false);
+    expect(fetchAvatar).not.toHaveBeenCalled();
+  });
+
+  it("shares authenticated loading and reconciles image fallback events", async () => {
+    setAvatarGatewayOrigin("https://gateway.example.test", "Bearer avatar-token");
+    const fetchAvatar = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(new Uint8Array([1, 2, 3]), {
+        headers: { "content-type": "image/png" },
+      }),
+    );
+    vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:shared-identity-avatar");
+
+    const view = resolveIdentityAvatarView({
+      id: "profile-ada",
+      name: "Ada Lovelace",
+      profileAvatarUrl: "/api/users/profile-ada/avatar?v=7",
+    });
+    const container = document.createElement("div");
+    document.body.append(container);
+    renderAvatar(view, container);
+
+    const wrapper = container.querySelector<HTMLElement>(".test-avatar");
+    expect(view.pending).toBe(true);
+    expect(wrapper?.classList.contains("is-fallback")).toBe(true);
+
+    const image = await vi.waitFor(() => {
+      const element = container.querySelector<HTMLImageElement>(".test-avatar__image");
+      expect(element?.getAttribute("src")).toBe("blob:shared-identity-avatar");
+      return element!;
+    });
+    expect(image.getAttribute("alt")).toBe("Ada Lovelace");
+    expect(image.getAttribute("aria-hidden")).toBe("true");
+    expect(image.getAttribute("referrerpolicy")).toBe("no-referrer");
+    expect(fetchAvatar).toHaveBeenCalledOnce();
+    expect(fetchAvatar).toHaveBeenCalledWith(
+      "https://gateway.example.test/api/users/profile-ada/avatar?v=7",
+      expect.objectContaining({ headers: { Authorization: "Bearer avatar-token" } }),
+    );
+
+    image.dispatchEvent(new Event("load"));
+    expect(wrapper?.classList.contains("is-fallback")).toBe(false);
+
+    image.dispatchEvent(new Event("error"));
+    expect(wrapper?.classList.contains("is-fallback")).toBe(true);
+
+    image.dispatchEvent(new Event("load"));
+    expect(wrapper?.classList.contains("is-fallback")).toBe(false);
+  });
+
+  it("retains its existing image while a newer avatar revision loads", async () => {
+    setAvatarGatewayOrigin("https://gateway.example.test", "Bearer avatar-token");
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      async () =>
+        new Response(new Uint8Array([1, 2, 3]), {
+          headers: { "content-type": "image/png" },
+        }),
+    );
+    vi.spyOn(URL, "createObjectURL")
+      .mockReturnValueOnce("blob:identity-avatar-v1")
+      .mockReturnValueOnce("blob:identity-avatar-v2");
+
+    const identity = { id: "profile-ada", name: "Ada Lovelace" };
+    const container = document.createElement("div");
+    document.body.append(container);
+    renderAvatar(
+      resolveIdentityAvatarView({
+        ...identity,
+        profileAvatarUrl: "/api/users/profile-ada/avatar?v=1",
+      }),
+      container,
+    );
+
+    const firstImage = await vi.waitFor(() => {
+      const image = container.querySelector<HTMLImageElement>(".test-avatar__image");
+      expect(image?.getAttribute("src")).toBe("blob:identity-avatar-v1");
+      return image!;
+    });
+    firstImage.dispatchEvent(new Event("load"));
+
+    renderAvatar(
+      resolveIdentityAvatarView({
+        ...identity,
+        profileAvatarUrl: "/api/users/profile-ada/avatar?v=2",
+      }),
+      container,
+    );
+    expect(container.querySelector(".test-avatar")?.classList.contains("is-fallback")).toBe(true);
+
+    const secondImage = await vi.waitFor(() => {
+      const image = container.querySelector<HTMLImageElement>(".test-avatar__image");
+      expect(image?.getAttribute("src")).toBe("blob:identity-avatar-v2");
+      return image!;
+    });
+    expect(secondImage).toBe(firstImage);
+
+    secondImage.dispatchEvent(new Event("load"));
+    expect(container.querySelector(".test-avatar")?.classList.contains("is-fallback")).toBe(false);
+  });
+});

--- a/ui/src/components/identity-avatar-view.ts
+++ b/ui/src/components/identity-avatar-view.ts
@@ -1,0 +1,80 @@
+import { html, nothing } from "lit";
+import { live } from "lit/directives/live.js";
+import { until } from "lit/directives/until.js";
+import {
+  resolveAvatar,
+  resolveAvatarImageUrl,
+  resolveAvatarInitials,
+  settleAvatarImageUrl,
+  type IdentityAvatarInput,
+  type ResolvedIdentityAvatar,
+} from "../lib/identity-avatar.ts";
+
+type IdentityAvatarFallback = Extract<ResolvedIdentityAvatar, { kind: "initials" }>;
+
+export type IdentityAvatarView = {
+  fallback: IdentityAvatarFallback;
+  imageUrl: string | Promise<string | null> | null;
+  pending: boolean;
+};
+
+/** Resolve one user identity consistently across the roster, profile, and chat. */
+export function resolveIdentityAvatarView(identity: IdentityAvatarInput): IdentityAvatarView {
+  const avatar = resolveAvatar(identity);
+  const fallback = avatar.kind === "initials" ? avatar : resolveAvatarInitials(identity);
+  const imageUrl = avatar.kind === "profile" ? resolveAvatarImageUrl(avatar.url) : null;
+  return {
+    fallback,
+    imageUrl,
+    pending: imageUrl !== null && typeof imageUrl !== "string",
+  };
+}
+
+/** Reconcile image-event fallback mutations without replacing an existing image. */
+export function identityAvatarClass(className: string, view: IdentityAvatarView) {
+  return live(`${className}${view.pending ? " is-fallback" : ""}`);
+}
+
+function settleIdentityAvatarImage(event: Event, fallbackSelector: string, failed: boolean): void {
+  const image = event.currentTarget;
+  if (!(image instanceof HTMLImageElement)) {
+    return;
+  }
+  // All user-avatar surfaces share blob settlement and fallback transitions;
+  // revoking a pending image or retaining a previous error breaks reused DOM.
+  settleAvatarImageUrl(image.getAttribute("src"));
+  image.closest<HTMLElement>(fallbackSelector)?.classList.toggle("is-fallback", failed);
+}
+
+/** Render the shared authenticated user image with its canonical event lifecycle. */
+export function renderIdentityAvatarImage({
+  view,
+  fallbackSelector,
+  className,
+  alt = "",
+  ariaHidden = false,
+}: {
+  view: IdentityAvatarView;
+  fallbackSelector: string;
+  className?: string;
+  alt?: string;
+  ariaHidden?: boolean;
+}) {
+  if (!view.imageUrl) {
+    return nothing;
+  }
+  return html`<img
+    class=${className ?? nothing}
+    src=${typeof view.imageUrl === "string"
+      ? view.imageUrl
+      : until(
+          view.imageUrl.then((url) => url ?? nothing),
+          nothing,
+        )}
+    alt=${alt}
+    aria-hidden=${ariaHidden ? "true" : nothing}
+    referrerpolicy="no-referrer"
+    @error=${(event: Event) => settleIdentityAvatarImage(event, fallbackSelector, true)}
+    @load=${(event: Event) => settleIdentityAvatarImage(event, fallbackSelector, false)}
+  />`;
+}

--- a/ui/src/components/viewer-facepile.test.ts
+++ b/ui/src/components/viewer-facepile.test.ts
@@ -1,8 +1,10 @@
 /* @vitest-environment jsdom */
 
+import { render } from "lit";
 import { afterEach, expect, it, vi } from "vitest";
 import type { ControlUiBuildInfo } from "../build-info.ts";
-import { setAvatarGatewayOrigin } from "../lib/identity-avatar.ts";
+import { resolveAvatarInitials, setAvatarGatewayOrigin } from "../lib/identity-avatar.ts";
+import { renderChatAuthorAvatar } from "../pages/chat/components/chat-author-avatar.ts";
 import {
   hasMultiplePresenceIdentities,
   hasSessionPresenceViewers,
@@ -20,6 +22,41 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
+it("uses the same user initials and identity hue in the roster and attributed chat", async () => {
+  const user: PresenceViewer = {
+    id: "profile-riley",
+    name: "Riley",
+    email: "riley@example.test",
+    watchedSessions: [],
+  };
+  const viewerAvatar = document.createElement("openclaw-viewer-avatar") as ViewerAvatarElement;
+  viewerAvatar.user = user;
+  document.body.append(viewerAvatar);
+
+  const chat = document.createElement("div");
+  document.body.append(chat);
+  render(renderChatAuthorAvatar({ id: user.id, name: user.name, username: user.email }), chat);
+
+  const expected = resolveAvatarInitials({
+    id: user.id,
+    name: user.name,
+    username: user.email,
+  });
+  await vi.waitFor(async () => {
+    await viewerAvatar.updateComplete;
+    const rosterInitials = viewerAvatar.querySelector(".viewer-avatar > span");
+    const chatInitials = chat.querySelector(".chat-author-avatar__initials");
+    expect(rosterInitials?.textContent?.trim()).toBe(expected.initials);
+    expect(chatInitials?.textContent?.trim()).toBe(expected.initials);
+    expect(rosterInitials?.getAttribute("style")).toContain(
+      `hsl(${expected.colorSeed % 360} 48% 42%)`,
+    );
+    expect(chatInitials?.getAttribute("style")).toContain(
+      `--chat-author-avatar-hue: ${expected.colorSeed % 360}`,
+    );
+  });
+});
+
 it("uses the shared resolver and rejects cross-origin presence avatar metadata", async () => {
   const avatar = document.createElement("openclaw-viewer-avatar") as ViewerAvatarElement;
   avatar.user = {
@@ -33,7 +70,7 @@ it("uses the shared resolver and rejects cross-origin presence avatar metadata",
   await vi.waitFor(async () => {
     await avatar.updateComplete;
     expect(avatar.querySelector("img")).toBeNull();
-    expect(avatar.textContent?.trim()).toBe("MA");
+    expect(avatar.textContent?.trim()).toBe("M");
   });
 });
 

--- a/ui/src/components/viewer-facepile.ts
+++ b/ui/src/components/viewer-facepile.ts
@@ -1,17 +1,15 @@
 import { html, nothing } from "lit";
 import { property } from "lit/decorators.js";
-import { live } from "lit/directives/live.js";
-import { until } from "lit/directives/until.js";
 import type { PresenceEntry } from "../api/types.ts";
 import { CONTROL_UI_BUILD_INFO, type ControlUiBuildInfo } from "../build-info.ts";
 import { t } from "../i18n/index.ts";
-import {
-  resolveAvatar,
-  resolveAvatarImageUrl,
-  settleAvatarImageUrl,
-  type ResolvedIdentityAvatar,
-} from "../lib/identity-avatar.ts";
 import { OpenClawLightDomContentsElement } from "../lit/openclaw-element.ts";
+import {
+  identityAvatarClass,
+  renderIdentityAvatarImage,
+  resolveIdentityAvatarView,
+  type IdentityAvatarView,
+} from "./identity-avatar-view.ts";
 import { renderSidebarServerDetails } from "./sidebar-build-chip-format.ts";
 import "./tooltip.ts";
 
@@ -117,66 +115,16 @@ export function presenceViewerLabel(user: PresenceViewer): string {
   return user.name ?? user.email ?? user.id;
 }
 
-function initialsFor(user: PresenceViewer): string {
-  const label = presenceViewerLabel(user);
-  const words = label
-    .replace(/@.*$/u, "")
-    .split(/[^\p{L}\p{N}]+/u)
-    .filter(Boolean);
-  if (words.length > 1) {
-    return `${words[0]?.[0] ?? ""}${words.at(-1)?.[0] ?? ""}`.toUpperCase();
+function renderViewerAvatar(view: IdentityAvatarView) {
+  const fallback = html`<span
+    class=${view.imageUrl ? "viewer-avatar__fallback" : nothing}
+    style=${`background: hsl(${view.fallback.colorSeed % 360} 48% 42%)`}
+    >${view.fallback.initials}</span
+  >`;
+  if (!view.imageUrl) {
+    return fallback;
   }
-  return (words[0] ?? label).slice(0, 2).toUpperCase();
-}
-
-function avatarColor(userId: string): string {
-  let hash = 2166136261;
-  for (const character of userId) {
-    hash ^= character.codePointAt(0) ?? 0;
-    hash = Math.imul(hash, 16777619);
-  }
-  return `hsl(${(hash >>> 0) % 360} 48% 42%)`;
-}
-
-function renderAvatarInitials(user: PresenceViewer) {
-  return html`<span style=${`background: ${avatarColor(user.id)}`}>${initialsFor(user)}</span>`;
-}
-
-function renderViewerAvatar(
-  user: PresenceViewer,
-  avatar: ResolvedIdentityAvatar,
-  imageUrl: string | Promise<string | null> | null,
-) {
-  if (avatar.kind === "initials" || !imageUrl) {
-    return renderAvatarInitials(user);
-  }
-  return html`<img
-      src=${typeof imageUrl === "string"
-        ? imageUrl
-        : until(
-            imageUrl.then((url) => url ?? nothing),
-            nothing,
-          )}
-      alt=""
-      referrerpolicy="no-referrer"
-      @error=${(event: Event) => {
-        const image = event.currentTarget;
-        if (image instanceof HTMLImageElement) {
-          settleAvatarImageUrl(image.getAttribute("src"));
-          image.closest<HTMLElement>(".viewer-avatar")?.classList.add("is-fallback");
-        }
-      }}
-      @load=${(event: Event) => {
-        const image = event.currentTarget;
-        if (image instanceof HTMLImageElement) {
-          settleAvatarImageUrl(image.getAttribute("src"));
-          image.closest<HTMLElement>(".viewer-avatar")?.classList.remove("is-fallback");
-        }
-      }}
-    />
-    <span class="viewer-avatar__fallback" style=${`background: ${avatarColor(user.id)}`}
-      >${initialsFor(user)}</span
-    >`;
+  return html`${renderIdentityAvatarImage({ view, fallbackSelector: ".viewer-avatar" })}${fallback}`;
 }
 
 export type ViewerAvatarVariant = "session" | "footer" | "profile";
@@ -191,22 +139,18 @@ class ViewerAvatar extends OpenClawLightDomContentsElement {
       return nothing;
     }
     const label = presenceViewerLabel(user);
-    const avatar = resolveAvatar({
+    const view = resolveIdentityAvatarView({
       id: user.id,
       name: user.name,
       username: user.email,
       profileAvatarUrl: user.avatarUrl,
     });
-    const imageUrl = avatar.kind === "initials" ? null : resolveAvatarImageUrl(avatar.url);
-    const pending = imageUrl !== null && typeof imageUrl !== "string";
-    // Image events toggle fallback imperatively; live() compares actual DOM so
-    // a changed avatar restores initials without replacing its existing image.
     return html`<span
-      class=${live(`viewer-avatar viewer-avatar--${this.variant}${pending ? " is-fallback" : ""}`)}
+      class=${identityAvatarClass(`viewer-avatar viewer-avatar--${this.variant}`, view)}
       data-viewer-id=${user.id}
       aria-label=${label}
     >
-      ${renderViewerAvatar(user, avatar, imageUrl)}
+      ${renderViewerAvatar(view)}
     </span>`;
   }
 }

--- a/ui/src/e2e/chat-attributed-identity.e2e.test.ts
+++ b/ui/src/e2e/chat-attributed-identity.e2e.test.ts
@@ -107,6 +107,8 @@ describeControlUiE2e("Control UI attributed chat identity", () => {
     const userGroups = page.locator(".chat-group.user");
     await expect(userGroups).toHaveCount(2);
     await expect(page.locator(".chat-avatar.user")).toHaveCount(2);
+    await expect(page.locator(".chat-avatar.user")).toHaveText(["R", "C"]);
+    await expect(page.locator(".sidebar-identity-card openclaw-viewer-avatar")).toContainText("R");
 
     await expect(
       page.locator(".chat-group-footer--persistent-identity .chat-sender-name"),

--- a/ui/src/e2e/profile-page.e2e.test.ts
+++ b/ui/src/e2e/profile-page.e2e.test.ts
@@ -257,13 +257,31 @@ describeControlUiE2e("Control UI profile page mocked Gateway E2E", () => {
       };
     }, gatewayUrl);
     const avatarRequests: Array<{ authorization?: string; url: string }> = [];
+    let releaseRevisedAvatar: (() => void) | undefined;
+    const revisedAvatarReady = new Promise<void>((resolve) => {
+      releaseRevisedAvatar = resolve;
+    });
     // Profile images require the same bearer auth as gateway RPCs. One cached
     // blob keeps the sidebar and preview inside the Control UI's image CSP.
     await page.route(`**/api/users/${testProfile.id}/avatar*`, async (route) => {
+      const revision = new URL(route.request().url()).searchParams.get("v");
       avatarRequests.push({
         authorization: route.request().headers().authorization,
         url: route.request().url(),
       });
+      if (revision === "3") {
+        // Hold the real response so Chromium can prove pending fallback and
+        // stable image-node identity before the replacement finishes loading.
+        await revisedAvatarReady;
+      }
+      if (revision === "4") {
+        await route.fulfill({
+          body: JSON.stringify({ ok: false, error: { type: "not_found" } }),
+          contentType: "application/json",
+          status: 404,
+        });
+        return;
+      }
       await route.fulfill({
         body: Buffer.from(
           "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/a6kAAAAASUVORK5CYII=",
@@ -273,7 +291,7 @@ describeControlUiE2e("Control UI profile page mocked Gateway E2E", () => {
         status: 200,
       });
     });
-    await installMockGateway(page, {
+    const gateway = await installMockGateway(page, {
       presenceUsers: testPresenceUsers,
       methodResponses: {
         "usage.cost": usageCostResponse,
@@ -326,6 +344,101 @@ describeControlUiE2e("Control UI profile page mocked Gateway E2E", () => {
         await page.screenshot({
           animations: "disabled",
           path: path.join(proofDir, "03-authenticated-user-avatar-cache.png"),
+        });
+      }
+
+      const originalSidebarImage = await sidebarAvatar.elementHandle();
+      expect(originalSidebarImage).not.toBeNull();
+      const connect = await gateway.waitForRequest("connect");
+      const selfInstanceId = (connect.params as { client?: { instanceId?: string } } | undefined)
+        ?.client?.instanceId;
+      expect(selfInstanceId).toBeTruthy();
+      const publishAvatarRevision = async (revision: number) => {
+        await gateway.emitGatewayEvent("presence", {
+          presence: [
+            {
+              instanceId: selfInstanceId,
+              mode: "webchat",
+              reason: "connect",
+              user: {
+                id: testProfile.id,
+                name: testProfile.displayName,
+                email: testProfile.emails[0],
+                avatarUrl: `/api/users/${testProfile.id}/avatar?v=${revision}`,
+              },
+              watchedSessions: [],
+            },
+          ],
+        });
+      };
+
+      await publishAvatarRevision(3);
+      await expect.poll(() => avatarRequests.length).toBe(2);
+      expect(
+        await originalSidebarImage?.evaluate((image) =>
+          image.closest(".viewer-avatar")?.classList.contains("is-fallback"),
+        ),
+      ).toBe(true);
+      expect(await originalSidebarImage?.evaluate((image) => image.isConnected)).toBe(true);
+
+      releaseRevisedAvatar?.();
+      await expect
+        .poll(() => sidebarAvatar.evaluate((image) => (image as HTMLImageElement).naturalWidth))
+        .toBe(1);
+      const revisedImageUrl = await sidebarAvatar.getAttribute("src");
+      expect(revisedImageUrl).toMatch(/^blob:/u);
+      expect(revisedImageUrl).not.toBe(imageUrl);
+      expect(await originalSidebarImage?.evaluate((image) => image.getAttribute("src"))).toBe(
+        revisedImageUrl,
+      );
+      expect(
+        await sidebarAvatar.evaluate((image) =>
+          image.closest(".viewer-avatar")?.classList.contains("is-fallback"),
+        ),
+      ).toBe(false);
+      expect(avatarRequests[1]).toEqual({
+        authorization: "Bearer e2e-device-token",
+        url: expect.stringContaining(`/api/users/${testProfile.id}/avatar?v=3`),
+      });
+      if (captureUiProof) {
+        await page.screenshot({
+          animations: "disabled",
+          path: path.join(proofDir, "04-authenticated-user-avatar-revision.png"),
+        });
+      }
+
+      const missingAvatarResponse = page.waitForResponse(
+        (candidateResponse) =>
+          candidateResponse.url().includes(`/api/users/${testProfile.id}/avatar?v=4`) &&
+          candidateResponse.status() === 404,
+      );
+      await publishAvatarRevision(4);
+      await missingAvatarResponse;
+      await expect.poll(() => avatarRequests.length).toBe(3);
+      await expect.poll(() => sidebarAvatar.getAttribute("src")).toBeNull();
+      await expect
+        .poll(() =>
+          sidebarAvatar.evaluate((image) =>
+            image.closest(".viewer-avatar")?.classList.contains("is-fallback"),
+          ),
+        )
+        .toBe(true);
+      await expect
+        .poll(async () =>
+          (
+            await page.locator(".sidebar-identity-card .viewer-avatar__fallback").textContent()
+          )?.trim(),
+        )
+        .toBe("TP");
+      expect(await originalSidebarImage?.evaluate((image) => image.isConnected)).toBe(true);
+      expect(avatarRequests[2]).toEqual({
+        authorization: "Bearer e2e-device-token",
+        url: expect.stringContaining(`/api/users/${testProfile.id}/avatar?v=4`),
+      });
+      if (captureUiProof) {
+        await page.screenshot({
+          animations: "disabled",
+          path: path.join(proofDir, "05-authenticated-user-avatar-missing.png"),
         });
       }
     } finally {

--- a/ui/src/pages/chat/chat-avatar.ts
+++ b/ui/src/pages/chat/chat-avatar.ts
@@ -1,7 +1,5 @@
 // Control UI chat module implements chat avatar behavior.
-import { html, nothing } from "lit";
-import { live } from "lit/directives/live.js";
-import { until } from "lit/directives/until.js";
+import { html } from "lit";
 import type { GatewayHelloOk } from "../../api/gateway.ts";
 import { normalizeBasePath } from "../../app-route-paths.ts";
 import { resolveControlUiAuthHeader } from "../../app/control-ui-auth.ts";
@@ -10,6 +8,11 @@ import {
   resolveLocalUserAvatarUrl,
   resolveLocalUserName,
 } from "../../app/user-identity.ts";
+import {
+  identityAvatarClass,
+  renderIdentityAvatarImage,
+  resolveIdentityAvatarView,
+} from "../../components/identity-avatar-view.ts";
 import type { AssistantIdentity } from "../../lib/assistant-identity.ts";
 import {
   assistantAvatarFallbackUrl,
@@ -19,13 +22,6 @@ import {
 import { normalizeRoleForGrouping } from "../../lib/chat/message-normalizer.ts";
 import type { SenderIdentity } from "../../lib/chat/sender-label.ts";
 import { formatSenderLabel } from "../../lib/chat/sender-label.ts";
-import {
-  resolveAvatar,
-  resolveAvatarImageUrl,
-  resolveAvatarInitials,
-  resolveIdentityHue,
-  settleAvatarImageUrl,
-} from "../../lib/identity-avatar.ts";
 import {
   DEFAULT_AGENT_ID,
   isUiGlobalSessionKey,
@@ -46,49 +42,27 @@ export function renderChatAvatar(
   // upload → gateway Gravatar proxy → initials), not the local viewer's.
   if (normalized === "user" && sender) {
     const label = formatSenderLabel(sender) ?? "";
-    const initials = resolveAvatarInitials(sender);
+    const view = resolveIdentityAvatarView(sender);
     const initialsAvatar = html`<div
       class="chat-avatar user chat-avatar--sender-initials"
-      style=${`background: hsl(${resolveIdentityHue(sender)} 48% 42%)`}
+      style=${`background: hsl(${view.fallback.colorSeed % 360} 48% 42%)`}
       aria-label="${label}"
     >
-      ${initials.initials}
+      ${view.fallback.initials}
     </div>`;
-    const resolved = resolveAvatar(sender);
-    if (resolved.kind === "initials") {
-      return initialsAvatar;
-    }
-    const imageUrl = resolveAvatarImageUrl(resolved.url);
-    if (!imageUrl) {
+    if (!view.imageUrl) {
       return initialsAvatar;
     }
     // The derived route may 404 (no upload, no Gravatar); swap to initials
     // instead of a broken image. Lit reuses DOM parts, so a load must clear a
     // prior sender's error state.
-    return html`<span
-      class=${live(`chat-avatar-slot${typeof imageUrl === "string" ? "" : " is-fallback"}`)}
-    >
-      <img
-        class="chat-avatar user"
-        src=${typeof imageUrl === "string"
-          ? imageUrl
-          : until(
-              imageUrl.then((url) => url ?? nothing),
-              nothing,
-            )}
-        alt="${label}"
-        @error=${(event: Event) => {
-          const image = event.currentTarget as HTMLImageElement;
-          settleAvatarImageUrl(image.getAttribute("src"));
-          image.closest(".chat-avatar-slot")?.classList.add("is-fallback");
-        }}
-        @load=${(event: Event) => {
-          const image = event.currentTarget as HTMLImageElement;
-          settleAvatarImageUrl(image.getAttribute("src"));
-          image.closest(".chat-avatar-slot")?.classList.remove("is-fallback");
-        }}
-      />
-      ${initialsAvatar}
+    return html`<span class=${identityAvatarClass("chat-avatar-slot", view)}>
+      ${renderIdentityAvatarImage({
+        view,
+        fallbackSelector: ".chat-avatar-slot",
+        className: "chat-avatar user",
+        alt: label,
+      })}${initialsAvatar}
     </span>`;
   }
   const assistantName = assistant?.name?.trim() || "Assistant";

--- a/ui/src/pages/chat/components/chat-author-avatar.ts
+++ b/ui/src/pages/chat/components/chat-author-avatar.ts
@@ -1,15 +1,12 @@
 import { html, nothing, type TemplateResult } from "lit";
-import { live } from "lit/directives/live.js";
-import { until } from "lit/directives/until.js";
-import { formatSenderLabel } from "../../../lib/chat/sender-label.ts";
 import {
-  resolveAvatar,
-  resolveAvatarImageUrl,
-  resolveAvatarInitials,
-  settleAvatarImageUrl,
-  type IdentityAvatarInput,
-  type ResolvedIdentityAvatar,
-} from "../../../lib/identity-avatar.ts";
+  identityAvatarClass,
+  renderIdentityAvatarImage,
+  resolveIdentityAvatarView,
+  type IdentityAvatarView,
+} from "../../../components/identity-avatar-view.ts";
+import { formatSenderLabel } from "../../../lib/chat/sender-label.ts";
+import type { IdentityAvatarInput, ResolvedIdentityAvatar } from "../../../lib/identity-avatar.ts";
 
 function renderInitialsAvatar(
   avatar: Extract<ResolvedIdentityAvatar, { kind: "initials" }>,
@@ -27,42 +24,17 @@ function renderInitialsAvatar(
   `;
 }
 
-function renderResolvedAvatar(
-  fallback: Extract<ResolvedIdentityAvatar, { kind: "initials" }>,
-  imageUrl: string | Promise<string | null> | null,
-): TemplateResult {
-  if (!imageUrl) {
-    return renderInitialsAvatar(fallback);
+function renderResolvedAvatar(view: IdentityAvatarView): TemplateResult {
+  if (!view.imageUrl) {
+    return renderInitialsAvatar(view.fallback);
   }
   return html`
-    <img
-      class="chat-author-avatar__image"
-      src=${typeof imageUrl === "string"
-        ? imageUrl
-        : until(
-            imageUrl.then((url) => url ?? nothing),
-            nothing,
-          )}
-      alt=""
-      aria-hidden="true"
-      @error=${(event: Event) => {
-        const image = event.currentTarget;
-        if (image instanceof HTMLImageElement) {
-          settleAvatarImageUrl(image.getAttribute("src"));
-          image.closest<HTMLElement>(".chat-author-avatar")?.classList.add("is-fallback");
-        }
-      }}
-      @load=${(event: Event) => {
-        // Lit reuses DOM parts across renders; a prior sender's error state
-        // must not hide a successfully loaded avatar for the next source.
-        const image = event.currentTarget;
-        if (image instanceof HTMLImageElement) {
-          settleAvatarImageUrl(image.getAttribute("src"));
-          image.closest<HTMLElement>(".chat-author-avatar")?.classList.remove("is-fallback");
-        }
-      }}
-    />
-    ${renderInitialsAvatar(fallback, true)}
+    ${renderIdentityAvatarImage({
+      view,
+      fallbackSelector: ".chat-author-avatar",
+      className: "chat-author-avatar__image",
+      ariaHidden: true,
+    })}${renderInitialsAvatar(view.fallback, true)}
   `;
 }
 
@@ -74,16 +46,10 @@ export function renderChatAuthorAvatar(
   if (!sender || !label) {
     return nothing;
   }
-  const fallback = resolveAvatarInitials(sender);
-  const avatar = resolveAvatar(sender);
-  const imageUrl = avatar.kind === "initials" ? null : resolveAvatarImageUrl(avatar.url);
-  const pending = imageUrl !== null && typeof imageUrl !== "string";
-  const resolved =
-    avatar.kind === "initials"
-      ? renderInitialsAvatar(avatar)
-      : renderResolvedAvatar(fallback, imageUrl);
+  const view = resolveIdentityAvatarView(sender);
+  const resolved = renderResolvedAvatar(view);
   return html`<span
-    class=${live(`chat-author-avatar${pending ? " is-fallback" : ""}`)}
+    class=${identityAvatarClass("chat-author-avatar", view)}
     role="img"
     aria-label=${label}
     title=${label}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the same person could show different avatar initials or identity colors in the online-user list, profile, and shared chat because each Control UI surface independently rendered user avatars and image fallback events.

Follow-up to #114444.

## Why This Change Was Made

Give user avatars one narrow presentation owner: `ui/src/components/identity-avatar-view.ts`. The shared view resolves the canonical user identity, derives one set of initials and hue, uses the existing origin-pinned authenticated gateway avatar cache, and owns async image rendering, stable DOM updates, blob settlement, and load/error fallback. Keep gateway storage and caching, assistant/agent avatars, and plugin icons unchanged.

## User Impact

The same person now looks the same in the sidebar, online roster, Settings profile, and attributed chat. Single-name users have matching initials everywhere. A changed avatar updates the existing image without flicker or stale fallback; a missing image reliably returns to the same initials and color.

## Evidence

- **Before/after regression:** on current `main`, the same `Riley` user renders `RI` in the roster and `R` in chat; the new cross-surface test fails before the refactor and passes afterward.
- **Focused UI proof:** 9 test files, **404 tests passing**, including direct shared-renderer tests, the complete sidebar suite, durable profile identities, hostile-origin/no-credential-forwarding coverage, credential rotation, revision invalidation, cached image lifecycle, fallback, and chat/profile consumers.
- **Real Chromium proof on Blacksmith Testbox:** 2 files, **6 tests passing**. The actual Gateway CSP scenario proves one authenticated cached image shared by Settings and the sidebar. It then publishes a real Gateway presence revision, deliberately holds the revised HTTP response, verifies visible pending initials and the identical retained sidebar `<img>`, releases and decodes the revised PNG, and finally waits for an actual HTTP 404 plus settled removed `src` before proving the initials fallback. The attributed-chat scenario separately verifies matching roster/chat initials.
- **Blacksmith remote provider:** `blacksmith-testbox`, lease `tbx_01kyhe6v3tre5r0qrbmvfprm8e`; remote Chromium proof completed with `exitCode=0`.
- **Full changed-code gate on the same Testbox:** **passing**, including UI/core typechecks, type-aware lint, formatter, conflict/security/dependency/i18n guards via `corepack pnpm check:changed`; Blacksmith returned `exitCode=0`.
- **Independent structured autoreview and TruffleHog:** clean; final verdict `patch is correct (0.91)`.
- Generated screenshots and recordings remain external to the git diff under the Control UI E2E proof directories.

AI-assisted; implementation, Lit lifecycle, origin and credential boundaries, regression tests, and real-browser behavior independently reviewed.