### PR TITLE
fix(release): keep bundled plugin package verification complete

### DIFF
--- a/scripts/openclaw-npm-postpublish-verify.ts
+++ b/scripts/openclaw-npm-postpublish-verify.ts
@@ -60,8 +60,9 @@ type InstalledBundledExtensionManifestRecord = {
 const MAX_BUNDLED_EXTENSION_MANIFEST_BYTES = 1024 * 1024;
 const LEGACY_CONTEXT_ENGINE_UNRESOLVED_RUNTIME_MARKER =
   "Failed to load legacy context engine runtime.";
+const PACKAGED_BUNDLED_PLUGIN_ARTIFACTS = new Set(listBundledPluginPackArtifacts());
 const PUBLISHED_BUNDLED_RUNTIME_SIDECAR_PATHS = BUNDLED_RUNTIME_SIDECAR_PATHS.filter(
-  (relativePath) => listBundledPluginPackArtifacts().includes(relativePath),
+  (relativePath) => PACKAGED_BUNDLED_PLUGIN_ARTIFACTS.has(relativePath),
 );
 const NODE_BUILTIN_MODULES = new Set(builtinModules.map((name) => name.replace(/^node:/u, "")));
 const MAX_INSTALLED_ROOT_PACKAGE_JSON_BYTES = 1024 * 1024;
@@ -946,7 +947,7 @@ export function resolveInstalledBinaryCommandInvocation(
 
 function collectExpectedBundledExtensionPackageIds(): ReadonlySet<string> {
   const ids = new Set<string>();
-  for (const relativePath of listBundledPluginPackArtifacts()) {
+  for (const relativePath of PACKAGED_BUNDLED_PLUGIN_ARTIFACTS) {
     const match = /^dist\/extensions\/([^/]+)\/package\.json$/u.exec(relativePath);
     if (match) {
       ids.add(expectDefined(match[1], "bundled package extension id"));

--- a/scripts/openclaw-npm-postpublish-verify.ts
+++ b/scripts/openclaw-npm-postpublish-verify.ts
@@ -60,7 +60,13 @@ type InstalledBundledExtensionManifestRecord = {
 const MAX_BUNDLED_EXTENSION_MANIFEST_BYTES = 1024 * 1024;
 const LEGACY_CONTEXT_ENGINE_UNRESOLVED_RUNTIME_MARKER =
   "Failed to load legacy context engine runtime.";
-const PACKAGED_BUNDLED_PLUGIN_ARTIFACTS = new Set(listBundledPluginPackArtifacts());
+// Package verification always covers the complete published inventory, even
+// when the invoking build inherited a plugin-selection filter.
+const PACKAGED_BUNDLED_PLUGIN_ARTIFACTS = new Set(
+  listBundledPluginPackArtifacts({
+    env: { ...process.env, OPENCLAW_BUNDLED_PLUGIN_BUILD_IDS: undefined },
+  }),
+);
 const PUBLISHED_BUNDLED_RUNTIME_SIDECAR_PATHS = BUNDLED_RUNTIME_SIDECAR_PATHS.filter(
   (relativePath) => PACKAGED_BUNDLED_PLUGIN_ARTIFACTS.has(relativePath),
 );

--- a/test/openclaw-npm-postpublish-verify.test.ts
+++ b/test/openclaw-npm-postpublish-verify.test.ts
@@ -25,8 +25,10 @@ import {
   verifyNpmProvenanceAttestation,
   verifyNpmRegistrySignatures,
 } from "../scripts/openclaw-npm-postpublish-verify.ts";
+import { withEnv } from "../src/test-utils/env.js";
 
 const INSTALLED_ROOT_DIST_JS_FILE_SCAN_LIMIT = 10_000;
+const requiredBundledPluginPackPaths = listBundledPluginPackArtifacts();
 
 describe("parseOpenClawNpmPostpublishVerifyArgs", () => {
   it("keeps trusted release verification independent from target app dependencies", () => {
@@ -571,7 +573,7 @@ describe("collectInstalledPackageErrors", () => {
     omittedIds: readonly string[] = [],
   ): void {
     const omitted = new Set(omittedIds);
-    for (const relativePath of listBundledPluginPackArtifacts()) {
+    for (const relativePath of requiredBundledPluginPackPaths) {
       const match = /^dist\/extensions\/([^/]+)\/package\.json$/u.exec(relativePath);
       if (!match || omitted.has(match[1] ?? "")) {
         continue;
@@ -651,6 +653,35 @@ describe("collectInstalledPackageErrors", () => {
       for (const excludedId of ["acpx", "qa-channel", "qa-lab"]) {
         expect(errors.some((error) => error.includes(join("extensions", excludedId)))).toBe(false);
       }
+    } finally {
+      rmSync(packageRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps bundled manifest requirements stable after the build filter changes", () => {
+    const packageRoot = makeInstalledPackageRoot();
+
+    try {
+      const expectedErrors = collectInstalledBundledExtensionManifestErrors(packageRoot);
+      const filteredErrors = withEnv({ OPENCLAW_BUNDLED_PLUGIN_BUILD_IDS: "ollama" }, () =>
+        collectInstalledBundledExtensionManifestErrors(packageRoot),
+      );
+
+      expect(filteredErrors).toStrictEqual(expectedErrors);
+      expect(filteredErrors).toEqual(
+        expect.arrayContaining(
+          ["ollama", "lmstudio"].map(
+            (providerId) =>
+              `installed bundled extension manifest missing: ${join(
+                packageRoot,
+                "dist",
+                "extensions",
+                providerId,
+                "package.json",
+              )}.`,
+          ),
+        ),
+      );
     } finally {
       rmSync(packageRoot, { recursive: true, force: true });
     }

--- a/test/openclaw-npm-postpublish-verify.test.ts
+++ b/test/openclaw-npm-postpublish-verify.test.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from "node:child_process";
 import { generateKeyPairSync, sign } from "node:crypto";
 // OpenClaw npm postpublish tests validate postpublish verification behavior.
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
@@ -669,6 +670,50 @@ describe("collectInstalledPackageErrors", () => {
 
       expect(filteredErrors).toStrictEqual(expectedErrors);
       expect(filteredErrors).toEqual(
+        expect.arrayContaining(
+          ["ollama", "lmstudio"].map(
+            (providerId) =>
+              `installed bundled extension manifest missing: ${join(
+                packageRoot,
+                "dist",
+                "extensions",
+                providerId,
+                "package.json",
+              )}.`,
+          ),
+        ),
+      );
+    } finally {
+      rmSync(packageRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("verifies every bundled manifest when the build filter exists before module initialization", () => {
+    const packageRoot = makeInstalledPackageRoot();
+
+    try {
+      const probe = spawnSync(
+        process.execPath,
+        [
+          "--import",
+          "tsx",
+          "--eval",
+          [
+            'import { collectInstalledBundledExtensionManifestErrors } from "./scripts/openclaw-npm-postpublish-verify.ts";',
+            `process.stdout.write(JSON.stringify(collectInstalledBundledExtensionManifestErrors(${JSON.stringify(packageRoot)})));`,
+          ].join("\n"),
+        ],
+        {
+          cwd: process.cwd(),
+          encoding: "utf8",
+          env: { ...process.env, OPENCLAW_BUNDLED_PLUGIN_BUILD_IDS: "ollama" },
+          timeout: 30_000,
+        },
+      );
+
+      expect(probe.error).toBeUndefined();
+      expect(probe.status, probe.stderr).toBe(0);
+      expect(JSON.parse(probe.stdout)).toEqual(
         expect.arrayContaining(
           ["ollama", "lmstudio"].map(
             (providerId) =>


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where release and installed-package verification could silently stop checking bundled plugin manifests and runtime sidecars when a plugin build filter was inherited before verifier startup or changed afterward. The verifier also repeatedly rescanned the bundled plugin inventory.

## Why This Change Was Made

Compute one deterministic complete packaged-plugin inventory with the build-only selection filter explicitly cleared, then reuse that snapshot for published runtime sidecars and required installed manifests. Preserve all other release environment values, root package exclusions, private QA exclusions, provider boundaries, and existing package contracts.

## User Impact

Published OpenClaw installations consistently require every actually packaged bundled plugin, including Ollama and LM Studio. A selected build cannot make release verification silently accept an incomplete package, and package verification avoids repeated synchronous repository scans.

## Evidence

Verified exact head: `07ec13aaa54011f30cc63bd3c65977d439d6d3c3`.

- Exact-head GitHub Actions CI run `30264807650`: passed, including the required `openclaw/ci-gate`, build artifacts, release verification, guards, core and test types, lint, dependencies, and security checks.
- `node scripts/run-vitest.mjs test/openclaw-npm-postpublish-verify.test.ts`: **51 passed**.
- Real fresh Node subprocess, started with `OPENCLAW_BUNDLED_PLUGIN_BUILD_IDS=ollama` already in its inherited environment: verified both the Ollama and LM Studio installed manifests are independently required.
- Same-process post-initialization control: changing the filter after the verifier loads cannot narrow the required inventory.
- Targeted `oxfmt --check` and `git diff --check`: passed.
- Fresh independent whole-branch Codex Sol/high structured review and TruffleHog on the exact head: clean, no actionable findings.
- Additional production-package evidence from parent `cd775c7f104923096f858d721c67128f220ad72b`: Linux Testbox changed gate, **252 release/package tests**, canonical production npm pack, strict bundled-workspace tarball validation, lifecycle-enabled real npm installation, and intact/missing-Ollama/missing-LM-Studio/missing-root corruption controls all passed. The exact-head fresh-process regression above specifically covers the inherited-filter correction added after that parent.

AI-assisted; independently reviewed and verified.