### PR TITLE
fix(ui): keep first turns visible and block browser regressions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1397,6 +1397,31 @@ jobs:
             pnpm --dir ui test --maxWorkers 3
           fi
 
+  checks-ui-e2e:
+    permissions:
+      contents: read
+    name: checks-ui-e2e
+    needs: [preflight]
+    if: needs.preflight.outputs.run_ui_tests == 'true' && needs.preflight.outputs.compatibility_target != 'true'
+    runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'openclaw/openclaw') && 'blacksmith-4vcpu-ubuntu-2404' || 'ubuntu-24.04') }}
+    timeout-minutes: 30
+    steps:
+      - *linux_node_checkout_step
+      - name: Setup Node environment
+        uses: ./.github/actions/setup-node-env
+        with:
+          node-version: "24.x"
+          install-bun: "false"
+          # Fork PRs must never read or write repository-global sticky snapshots.
+          sticky-disk: ${{ github.event_name != 'workflow_dispatch' && github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'openclaw/openclaw') && 'true' || 'false' }}
+          use-actions-cache: ${{ github.event_name != 'workflow_dispatch' && github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'openclaw/openclaw') && 'false' || 'true' }}
+
+      - name: Install Playwright Chromium
+        run: node scripts/ensure-playwright-chromium.mjs
+
+      - name: Test Control UI new-session E2E
+        run: pnpm test:ui:e2e ui/src/e2e/new-session-page.e2e.test.ts
+
   control-ui-i18n:
     permissions:
       contents: read
@@ -3491,6 +3516,7 @@ jobs:
       - build-artifacts
       - native-i18n
       - checks-ui
+      - checks-ui-e2e
       - control-ui-i18n
       - checks-fast-core
       - qa-smoke-ci-profile
@@ -3522,6 +3548,7 @@ jobs:
             build-artifacts=${{ needs.build-artifacts.result }}
             native-i18n=${{ needs.native-i18n.result }}
             checks-ui=${{ needs.checks-ui.result }}
+            checks-ui-e2e=${{ needs.checks-ui-e2e.result }}
             control-ui-i18n=${{ needs.control-ui-i18n.result }}
             checks-fast-core=${{ needs.checks-fast-core.result }}
             qa-smoke-ci-profile=${{ needs.qa-smoke-ci-profile.result }}

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -2055,6 +2055,7 @@ describe("ci workflow guards", () => {
       "checks-fast-plugin-contracts-shard",
       "checks-node-core-test-nondist-shard",
       "checks-ui",
+      "checks-ui-e2e",
       "control-ui-i18n",
       "native-i18n",
       "qa-smoke-ci-profile",
@@ -4278,6 +4279,44 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
     expect(uiTest.run).toContain("pnpm --dir ui test");
   });
 
+  it("gates current Control UI changes on the mocked new-session Chromium E2E", () => {
+    const workflow = readCiWorkflow();
+    const ui = workflow.jobs["checks-ui"];
+    const uiE2e = workflow.jobs["checks-ui-e2e"];
+
+    expect(uiE2e.permissions).toEqual({ contents: "read" });
+    expect(uiE2e.needs).toEqual(["preflight"]);
+    expect(uiE2e.if).toBe(
+      "needs.preflight.outputs.run_ui_tests == 'true' && needs.preflight.outputs.compatibility_target != 'true'",
+    );
+    expect(uiE2e["runs-on"]).toBe(ui["runs-on"]);
+    expect(uiE2e["timeout-minutes"]).toBe(30);
+
+    const uiSetup = expectDefined(
+      ui.steps.find((step: WorkflowStep) => step.name === "Setup Node environment"),
+      "Control UI Node setup",
+    );
+    const uiE2eSetup = expectDefined(
+      uiE2e.steps.find((step: WorkflowStep) => step.name === "Setup Node environment"),
+      "Control UI E2E Node setup",
+    );
+    expect(uiE2eSetup.uses).toBe("./.github/actions/setup-node-env");
+    expect(uiE2eSetup.with).toEqual(uiSetup.with);
+
+    const chromiumInstall = expectDefined(
+      uiE2e.steps.find((step: WorkflowStep) => step.name === "Install Playwright Chromium"),
+      "Control UI E2E Chromium installation",
+    );
+    expect(chromiumInstall.run).toBe("node scripts/ensure-playwright-chromium.mjs");
+
+    const scenario = expectDefined(
+      uiE2e.steps.find((step: WorkflowStep) => step.name === "Test Control UI new-session E2E"),
+      "Control UI new-session E2E regression",
+    );
+    expect(scenario.run).toBe("pnpm test:ui:e2e ui/src/e2e/new-session-page.e2e.test.ts");
+    expect(JSON.stringify(uiE2e)).not.toContain("OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM");
+  });
+
   it("does not rebuild Control UI after build:ci-artifacts", () => {
     const workflow = readCiWorkflow();
     const buildArtifactSteps = workflow.jobs["build-artifacts"].steps;
@@ -4525,6 +4564,7 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
       "build-artifacts",
       "native-i18n",
       "checks-ui",
+      "checks-ui-e2e",
       "control-ui-i18n",
       "checks-fast-core",
       "qa-smoke-ci-profile",
@@ -4598,6 +4638,13 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
       expect(failedSelected.status).not.toBe(0);
       expect(failedSelected.stdout).toContain("checks-ui finished with failure");
       expect(failedSelected.stdout).toContain("macos-swift finished with cancelled");
+
+      const failedUiE2e = runCiGateFixture(
+        "preflight=success\nsecurity-fast=success",
+        "checks-ui=success\nchecks-ui-e2e=failure",
+      );
+      expect(failedUiE2e.status).not.toBe(0);
+      expect(failedUiE2e.stdout).toContain("checks-ui-e2e finished with failure");
     },
   );
 

--- a/ui/src/e2e/new-session-page.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.e2e.test.ts
@@ -113,20 +113,36 @@ async function navigateInApp(page: Page, routeId: string, search = "") {
 }
 
 /**
- * The chat route pushes its base path and then commits the session path. A
- * navigation issued inside that window is replaced by the committed route and
- * rejected as notFound, so wait for the path to settle before leaving again.
+ * Chat first pushes its base path and then commits the canonical session path.
+ * A repeated URL alone cannot prove that the router has finished, so require
+ * the successful active match and browser location to agree before leaving.
  */
 async function waitForCommittedChatRoute(page: Page) {
-  await page.waitForURL((url) => url.pathname.startsWith("/chat"));
-  let previous = "";
+  await page.waitForURL((url) => url.pathname.startsWith("/chat/"));
   await expect
-    .poll(() => {
-      const current = new URL(page.url()).pathname;
-      const settled = current === previous;
-      previous = current;
-      return settled;
-    })
+    .poll(() =>
+      page.evaluate(() => {
+        const app = document.querySelector("openclaw-app") as HTMLElement & {
+          runtime?: {
+            router: {
+              getState: () => {
+                status: string;
+                resolvedLocation: { pathname: string } | null;
+                matches: { routeId: string }[];
+                pendingMatches: unknown[];
+              };
+            };
+          };
+        };
+        const state = app.runtime?.router.getState();
+        return (
+          state?.status === "success" &&
+          state.matches[0]?.routeId === "chat" &&
+          state.resolvedLocation?.pathname === window.location.pathname &&
+          state.pendingMatches.length === 0
+        );
+      }),
+    )
     .toBe(true);
 }
 
@@ -268,10 +284,10 @@ describeControlUiE2e("Control UI new-session page mocked Gateway E2E", () => {
     const sessionKey = "agent:main:visible-initial-prompt";
     const message = "keep this prompt visible while the agent works";
     const activeOutputTimestamp = Date.now() + 60_000;
-    await installMockGateway(page, {
+    const gateway = await installMockGateway(page, {
       methodResponses: {
         "sessions.create": { key: sessionKey, runStarted: true },
-        "chat.history": {
+        "chat.startup": {
           messages: [
             {
               role: "assistant",
@@ -307,8 +323,7 @@ describeControlUiE2e("Control UI new-session page mocked Gateway E2E", () => {
       await page.waitForURL((url) => url.pathname === controlUiSessionPath(sessionKey), {
         timeout: 30_000,
       });
-      // The transcript fetch rides chat.startup or chat.history depending on what
-      // the Gateway advertises, so wait on the rendered rows instead of the method.
+      await gateway.waitForRequest("chat.startup");
       await page.getByText("SKILL.md", { exact: true }).waitFor();
 
       await expect.poll(() => page.locator(".chat-group.user").textContent()).toContain(message);
@@ -337,7 +352,7 @@ describeControlUiE2e("Control UI new-session page mocked Gateway E2E", () => {
     const gateway = await installMockGateway(page, {
       methodResponses: {
         "sessions.create": { key: sessionKey, runStarted: true },
-        "chat.history": {
+        "chat.startup": {
           messages: [],
           sessionId: "reconnected-initial-prompt",
           sessionInfo: { hasActiveRun: true, key: sessionKey, status: "running" },
@@ -351,6 +366,7 @@ describeControlUiE2e("Control UI new-session page mocked Gateway E2E", () => {
       await page.waitForURL((url) => url.pathname === controlUiSessionPath(sessionKey), {
         timeout: 30_000,
       });
+      await gateway.waitForRequest("chat.startup");
       await expect.poll(() => page.locator(".chat-group.user").textContent()).toContain(message);
 
       const socketsBeforeReconnect = await gateway.getSocketCount();
@@ -404,8 +420,6 @@ describeControlUiE2e("Control UI new-session page mocked Gateway E2E", () => {
     const sessionKey = "agent:main:single-image-prompt";
     const message = "testing if dual prompts show";
     const gateway = await installMockGateway(page, {
-      // The transcript bootstrap rides chat.startup while the Gateway advertises it,
-      // so that is the request this scenario holds open to observe reconciliation.
       deferredMethods: ["chat.startup"],
       methodResponses: {
         "sessions.create": {
@@ -414,7 +428,7 @@ describeControlUiE2e("Control UI new-session page mocked Gateway E2E", () => {
           runStarted: true,
           messageSeq: 1,
         },
-        "chat.history": {
+        "chat.startup": {
           messages: [
             {
               role: "user",
@@ -447,6 +461,8 @@ describeControlUiE2e("Control UI new-session page mocked Gateway E2E", () => {
       await page.waitForURL((url) => url.pathname === controlUiSessionPath(sessionKey), {
         timeout: 30_000,
       });
+      await gateway.waitForRequest("chat.startup");
+
       const userRow = page.locator(".chat-group.user");
       const userImage = userRow.locator("img.chat-message-image");
       await expect.poll(() => userRow.count()).toBe(1);
@@ -987,6 +1003,7 @@ describeControlUiE2e("Control UI new-session page mocked Gateway E2E", () => {
       await gateway.deferNext("chat.metadata");
       await gateway.deferNext("worktrees.branches");
       await navigateInApp(page, "new-session");
+      await expect.poll(() => new URL(page.url()).pathname).toBe("/new");
       await expect
         .poll(async () => (await gateway.getRequests("chat.metadata")).length)
         .toBe(metadataRequests + 1);
@@ -1131,6 +1148,7 @@ describeControlUiE2e("Control UI new-session page mocked Gateway E2E", () => {
     const context = await browser.newContext({ locale: "en-US", serviceWorkers: "block" });
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
+      workspace: WORKSPACE,
       workspaceGit: true,
       methodResponses: {
         "agents.list": {
@@ -1242,6 +1260,7 @@ describeControlUiE2e("Control UI new-session page mocked Gateway E2E", () => {
     const context = await browser.newContext({ locale: "en-US", serviceWorkers: "block" });
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
+      workspace: WORKSPACE,
       workspaceGit: true,
       methodResponses: {
         "agents.list": {

--- a/ui/src/pages/chat/chat-pane-lifecycle.test.ts
+++ b/ui/src/pages/chat/chat-pane-lifecycle.test.ts
@@ -11,14 +11,16 @@ import type {
 import { GatewayRequestError, type GatewayBrowserClient } from "../../api/gateway.ts";
 import type { GatewaySessionRow } from "../../api/types.ts";
 import type { ApplicationContext } from "../../app/context.ts";
+import { createInitialUserMessageHandoff } from "../../app/initial-user-message-handoff.ts";
 import type { SessionCapability } from "../../lib/sessions/index.ts";
-import { createTestChatPane } from "./chat-pane.test-support.ts";
+import { createTestChatPane, type TestChatPane } from "./chat-pane.test-support.ts";
 import type { ChatPageHost } from "./chat-state.ts";
 import {
   dismissConfirmedActionPopovers,
   openChatRewindConfirmation,
 } from "./components/chat-message.ts";
 import * as chatThread from "./components/chat-thread.ts";
+import { prepareInitialUserMessageHandoff } from "./initial-turn-handoff.ts";
 
 const SKIP_REWIND_CONFIRM_PREFERENCE = "openclaw:skip-rewind-confirm";
 const confirmationOwners = new Set<HTMLElement>();
@@ -32,6 +34,72 @@ function createDeferred<T>() {
   });
   return { promise, reject, resolve };
 }
+
+describe("chat pane first-turn attachment lifecycle", () => {
+  it("claims the connected client's first message before attaching the pane", () => {
+    const pane = document.createElement("openclaw-chat-pane") as unknown as TestChatPane;
+    const targetSessionKey = "agent:main:created-session";
+    const client = {
+      addEventListener: vi.fn(() => vi.fn()),
+      request: vi.fn(),
+    } as unknown as GatewayBrowserClient;
+    const context = {
+      basePath: "",
+      gateway: { snapshot: { client, hello: null } },
+      config: {
+        current: {
+          assistantIdentity: {
+            agentId: null,
+            name: "Assistant",
+            avatar: null,
+            avatarSource: null,
+            avatarStatus: null,
+            avatarReason: null,
+          },
+          serverVersion: null,
+          localMediaPreviewRoots: [],
+          embedSandboxMode: "strict",
+          allowExternalEmbedUrls: false,
+          terminalEnabled: false,
+        },
+      },
+      agentSelection: { state: { selectedId: "main" } },
+      agents: { state: { agentsList: null } },
+      initialUserMessage: createInitialUserMessageHandoff(),
+      sessions: {},
+    } as unknown as ApplicationContext;
+    prepareInitialUserMessageHandoff(
+      context.initialUserMessage,
+      targetSessionKey,
+      { attachments: [], createdAt: 1, text: "keep the first prompt visible" },
+      client,
+    );
+    pane.sessionKey = targetSessionKey;
+    pane.chatMessagesBySession = new Map();
+    pane.context = context;
+    const stopAfterAttach = new Error("stop after attach");
+    let attachedState: ChatPageHost | undefined;
+    vi.spyOn(pane.chatState, "attach").mockImplementation((state) => {
+      attachedState = state;
+      throw stopAfterAttach;
+    });
+
+    try {
+      expect(() => pane.connectedCallback()).toThrow(stopAfterAttach);
+      expect(attachedState?.client).toBe(client);
+      expect(attachedState?.chatMessages).toEqual([
+        expect.objectContaining({
+          role: "user",
+          content: [
+            expect.objectContaining({ type: "text", text: "keep the first prompt visible" }),
+          ],
+        }),
+      ]);
+    } finally {
+      pane.disconnectedCallback();
+    }
+  });
+});
 
 describe("chat pane session suggestion lifecycle", () => {
   it("does not let a stale add completion clear a newer session operation", async () => {

--- a/ui/src/pages/chat/chat-pane-lifecycle.ts
+++ b/ui/src/pages/chat/chat-pane-lifecycle.ts
@@ -253,6 +253,9 @@ export abstract class ChatPaneLifecycle extends ChatPaneReset {
     if (this.sessionKey) {
       const initialSessionKey = this.setPaneSessionKey(this.sessionKey);
       if (initialSessionKey && !parseCatalogSessionKey(initialSessionKey)) {
+        // First-turn handoffs are scoped to their Gateway client and must be
+        // claimed before attach starts outbox and transcript hydration.
+        pageState.client = this.context.gateway.snapshot.client ?? null;
         const snapshot = readChatSessionSnapshot(pageState.chatMessagesBySession, pageState, {
           sessionKey: initialSessionKey,
         });
@@ -261,6 +264,10 @@ export abstract class ChatPaneLifecycle extends ChatPaneReset {
           pageState.chatHistoryPagination = snapshot.pagination;
           pageState.currentSessionId = snapshot.sessionId;
           pageState.chatDisplayedLeafEntryId = snapshot.displayedLeafEntryId;
+        }
+        if (admitInitialTurnHandoff(pageState, initialSessionKey)) {
+          pageState.lastError = CHAT_COMPOSER_DRAFT_STORAGE_ERROR;
+          pageState.chatError = CHAT_COMPOSER_DRAFT_STORAGE_ERROR;
         }
         admitInitialUserMessageHandoff(pageState.initialUserMessage, pageState, initialSessionKey);
       }

--- a/ui/src/pages/chat/chat-pane.test.ts
+++ b/ui/src/pages/chat/chat-pane.test.ts
@@ -26,6 +26,7 @@ import type { ChatPageHost } from "./chat-state.ts";
 import { createBackgroundTasksProps } from "./components/chat-background-tasks.ts";
 import { createSessionWorkspaceProps } from "./components/chat-session-workspace.ts";
 import type { SidebarContent } from "./components/chat-sidebar.ts";
+import { prepareInitialUserMessageHandoff } from "./initial-turn-handoff.ts";
 import { cacheChatSessionSnapshot, type ChatMessageCache } from "./session-message-cache.ts";
 import { openSlot } from "./sidebar-layout.ts";
 
@@ -470,6 +471,47 @@ describe("chat pane header state", () => {
 });
 
 describe("chat pane initialization", () => {
+  it("claims the connected client's first message before attaching the pane", () => {
+    const pane = document.createElement("openclaw-chat-pane") as unknown as TestChatPane;
+    const targetSessionKey = "agent:main:created-session";
+    const client = {
+      addEventListener: vi.fn(() => vi.fn()),
+      request: vi.fn(),
+    } as unknown as GatewayBrowserClient;
+    const context = createInitializationContext();
+    context.gateway.snapshot.client = client;
+    prepareInitialUserMessageHandoff(
+      context.initialUserMessage,
+      targetSessionKey,
+      { attachments: [], createdAt: 1, text: "keep the first prompt visible" },
+      client,
+    );
+    pane.sessionKey = targetSessionKey;
+    pane.chatMessagesBySession = new Map();
+    pane.context = context;
+    const stopAfterAttach = new Error("stop after attach");
+    let attachedState: ChatPageHost | undefined;
+    vi.spyOn(pane.chatState, "attach").mockImplementation((state) => {
+      attachedState = state;
+      throw stopAfterAttach;
+    });
+
+    try {
+      expect(() => pane.connectedCallback()).toThrow(stopAfterAttach);
+      expect(attachedState?.client).toBe(client);
+      expect(attachedState?.chatMessages).toEqual([
+        expect.objectContaining({
+          role: "user",
+          content: [
+            expect.objectContaining({ type: "text", text: "keep the first prompt visible" }),
+          ],
+        }),
+      ]);
+    } finally {
+      pane.disconnectedCallback();
+    }
+  });
+
   it("sets the pane route before attaching outbox projection", () => {
     const pane = document.createElement("openclaw-chat-pane") as unknown as TestChatPane;
     const targetSessionKey = "agent:main:pane-b";

--- a/ui/src/pages/chat/chat-pane.test.ts
+++ b/ui/src/pages/chat/chat-pane.test.ts
@@ -26,7 +26,6 @@ import type { ChatPageHost } from "./chat-state.ts";
 import { createBackgroundTasksProps } from "./components/chat-background-tasks.ts";
 import { createSessionWorkspaceProps } from "./components/chat-session-workspace.ts";
 import type { SidebarContent } from "./components/chat-sidebar.ts";
-import { prepareInitialUserMessageHandoff } from "./initial-turn-handoff.ts";
 import { cacheChatSessionSnapshot, type ChatMessageCache } from "./session-message-cache.ts";
 import { openSlot } from "./sidebar-layout.ts";
 
@@ -471,47 +470,6 @@ describe("chat pane header state", () => {
 });
 
 describe("chat pane initialization", () => {
-  it("claims the connected client's first message before attaching the pane", () => {
-    const pane = document.createElement("openclaw-chat-pane") as unknown as TestChatPane;
-    const targetSessionKey = "agent:main:created-session";
-    const client = {
-      addEventListener: vi.fn(() => vi.fn()),
-      request: vi.fn(),
-    } as unknown as GatewayBrowserClient;
-    const context = createInitializationContext();
-    context.gateway.snapshot.client = client;
-    prepareInitialUserMessageHandoff(
-      context.initialUserMessage,
-      targetSessionKey,
-      { attachments: [], createdAt: 1, text: "keep the first prompt visible" },
-      client,
-    );
-    pane.sessionKey = targetSessionKey;
-    pane.chatMessagesBySession = new Map();
-    pane.context = context;
-    const stopAfterAttach = new Error("stop after attach");
-    let attachedState: ChatPageHost | undefined;
-    vi.spyOn(pane.chatState, "attach").mockImplementation((state) => {
-      attachedState = state;
-      throw stopAfterAttach;
-    });
-
-    try {
-      expect(() => pane.connectedCallback()).toThrow(stopAfterAttach);
-      expect(attachedState?.client).toBe(client);
-      expect(attachedState?.chatMessages).toEqual([
-        expect.objectContaining({
-          role: "user",
-          content: [
-            expect.objectContaining({ type: "text", text: "keep the first prompt visible" }),
-          ],
-        }),
-      ]);
-    } finally {
-      pane.disconnectedCallback();
-    }
-  });
-
   it("sets the pane route before attaching outbox projection", () => {
     const pane = document.createElement("openclaw-chat-pane") as unknown as TestChatPane;
     const targetSessionKey = "agent:main:pane-b";

--- a/ui/src/test-helpers/control-ui-e2e.mock-gateway.test.ts
+++ b/ui/src/test-helpers/control-ui-e2e.mock-gateway.test.ts
@@ -217,6 +217,51 @@ describe("mock gateway stateful sessions", () => {
     socket.close();
   });
 
+  it("does not publish a rejected session creation to sessions.list", async () => {
+    const sessionKey = "agent:main:rejected-session";
+    const script = createControlUiMockGatewayInitScript({
+      methodResponses: {
+        "sessions.create": {
+          __mockError: { code: "INVALID_REQUEST", message: "session creation rejected" },
+        },
+      },
+    });
+    window.sessionStorage.clear();
+    // oxlint-disable-next-line typescript/no-implied-eval -- Executes the generated init script standalone, proving it captures no module closures.
+    new Function(script)();
+
+    const socket = new WebSocket("ws://mock-gateway");
+    const frames: ResponseFrame[] = [];
+    socket.addEventListener("message", (event) => {
+      frames.push(JSON.parse(String((event as MessageEvent).data)) as ResponseFrame);
+    });
+    await flushMockTimers();
+
+    socket.send(
+      JSON.stringify({
+        type: "req",
+        id: "rejected-create",
+        method: "sessions.create",
+        params: { agentId: "main", key: sessionKey },
+      }),
+    );
+    await flushMockTimers();
+    socket.send(
+      JSON.stringify({
+        type: "req",
+        id: "list-after-rejection",
+        method: "sessions.list",
+        params: { agentId: "main", search: "rejected-session" },
+      }),
+    );
+    await flushMockTimers();
+
+    const listed = frames.find((frame) => frame.id === "list-after-rejection")?.payload;
+    expect(listed).toMatchObject({ count: 1, sessions: [{ key: "main" }] });
+    expect(JSON.stringify(listed)).not.toContain(sessionKey);
+    socket.close();
+  });
+
   it("cycles subscription-scoped session events and stops after unsubscribe", async () => {
     const sessionKey = "agent:main:sidebar-narration-demo";
     const script = createControlUiMockGatewayInitScript({

--- a/ui/src/test-helpers/control-ui-e2e.mock-gateway.test.ts
+++ b/ui/src/test-helpers/control-ui-e2e.mock-gateway.test.ts
@@ -162,6 +162,61 @@ describe("mock gateway stateful config", () => {
 });
 
 describe("mock gateway stateful sessions", () => {
+  it("makes a newly created session visible to the next sessions.list", async () => {
+    const sessionKey = "agent:main:created-session";
+    const script = createControlUiMockGatewayInitScript({
+      methodResponses: {
+        "sessions.create": { key: sessionKey, runStarted: true },
+      },
+    });
+    window.sessionStorage.clear();
+    // oxlint-disable-next-line typescript/no-implied-eval -- Executes the generated init script standalone, proving it captures no module closures.
+    new Function(script)();
+
+    const socket = new WebSocket("ws://mock-gateway");
+    const frames: ResponseFrame[] = [];
+    socket.addEventListener("message", (event) => {
+      frames.push(JSON.parse(String((event as MessageEvent).data)) as ResponseFrame);
+    });
+    await flushMockTimers();
+
+    socket.send(
+      JSON.stringify({
+        type: "req",
+        id: "create-1",
+        method: "sessions.create",
+        params: { agentId: "main" },
+      }),
+    );
+    await flushMockTimers();
+    expect(frames.find((frame) => frame.id === "create-1")?.payload).toEqual({
+      key: sessionKey,
+      runStarted: true,
+    });
+
+    socket.send(
+      JSON.stringify({
+        type: "req",
+        id: "list-1",
+        method: "sessions.list",
+        params: { agentId: "main", search: "created-session" },
+      }),
+    );
+    await flushMockTimers();
+    expect(frames.find((frame) => frame.id === "list-1")?.payload).toMatchObject({
+      count: 2,
+      sessions: [
+        expect.objectContaining({ key: "main" }),
+        expect.objectContaining({
+          key: sessionKey,
+          hasActiveRun: true,
+          status: "running",
+        }),
+      ],
+    });
+    socket.close();
+  });
+
   it("cycles subscription-scoped session events and stops after unsubscribe", async () => {
     const sessionKey = "agent:main:sidebar-narration-demo";
     const script = createControlUiMockGatewayInitScript({

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -763,7 +763,7 @@ function installControlUiMockGateway(input: {
         return row;
       }
       const patch = sessionPatches.get(row.key);
-      const next = patch ? { ...row, ...patch } : { ...row };
+      const next = Object.assign({}, row, patch);
       // Replay group renames/deletes over static fixtures: the real gateway
       // rewrites member categories server-side before the next sessions.list.
       let category = typeof next.category === "string" ? next.category : undefined;

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -436,6 +436,7 @@ function installControlUiMockGateway(input: {
   const requests: BrowserRequest[] = [];
   const methodResponseSequenceIndexes = new Map<string, number>();
   const sessionPatches = new Map<string, Record<string, unknown>>();
+  const createdSessions = new Map<string, Record<string, unknown>>();
   const sessionMessageSubscriptions = new Set<string>();
   const sockets: Array<{ readonly url: string }> = [];
   let deviceAuthMigrationPending = scenario.deviceAuthMigrationPending;
@@ -716,6 +717,26 @@ function installControlUiMockGateway(input: {
     sessionPatches.set(params.key, patch);
   }
 
+  function recordCreatedSession(params: unknown, response: unknown): void {
+    if (!isRecord(response) || typeof response.key !== "string" || !response.key.trim()) {
+      return;
+    }
+    const key = response.key;
+    const label = isRecord(params) && typeof params.label === "string" ? params.label.trim() : "";
+    const {
+      displayName: _defaultDisplayName,
+      label: _defaultLabel,
+      ...defaultSession
+    } = sessionRow();
+    createdSessions.set(key, {
+      ...defaultSession,
+      key,
+      ...(label ? { displayName: label, label } : {}),
+      hasActiveRun: response.runStarted === true,
+      status: response.runStarted === true ? "running" : "done",
+    });
+  }
+
   function applySessionPatches(response: unknown, params: unknown): unknown {
     if (!isRecord(response) || !Array.isArray(response.sessions)) {
       return response;
@@ -726,7 +747,18 @@ function installControlUiMockGateway(input: {
         : isRecord(params) && params.archived === true
           ? "archived"
           : "active";
-    const sessions = response.sessions.map((row) => {
+    const knownSessionKeys = new Set(
+      response.sessions.flatMap((row) =>
+        isRecord(row) && typeof row.key === "string" ? [row.key] : [],
+      ),
+    );
+    // A successful sessions.create commits before its response. Route
+    // resolution must see that same session in the next sessions.list.
+    const sourceSessions = [
+      ...response.sessions,
+      ...[...createdSessions].flatMap(([key, row]) => (knownSessionKeys.has(key) ? [] : [row])),
+    ];
+    const sessions = sourceSessions.map((row) => {
       if (!isRecord(row) || typeof row.key !== "string") {
         return row;
       }
@@ -748,7 +780,11 @@ function installControlUiMockGateway(input: {
       return next;
     });
     if (!scenario.sessionArchiveFiltering) {
-      return { ...response, sessions };
+      return {
+        ...response,
+        ...(createdSessions.size > 0 ? { count: sessions.length } : {}),
+        sessions,
+      };
     }
     const filteredSessions = sessions.filter(
       (row) =>
@@ -928,6 +964,9 @@ function installControlUiMockGateway(input: {
     }
     const configured = configuredResponse(method, params);
     if (configured.found) {
+      if (method === "sessions.create") {
+        recordCreatedSession(params, configured.value);
+      }
       return method === "sessions.list"
         ? applySessionPatches(configured.value, params)
         : configured.value;
@@ -1359,10 +1398,14 @@ function installControlUiMockGateway(input: {
       if (!response) {
         throw new Error(`Deferred mock Gateway response disappeared for ${method}`);
       }
+      const resolvedPayload = payload ?? buildResponse(response.method, response.params);
+      if (response.method === "sessions.create") {
+        recordCreatedSession(response.params, resolvedPayload);
+      }
       response.socket.deliver({
         id: response.id,
         ok: true,
-        payload: payload ?? buildResponse(response.method, response.params),
+        payload: resolvedPayload,
         type: "res",
       });
     },


### PR DESCRIPTION
Related: #114374
Follows #114377 and #114415.

## What Problem This Solves

Fixes an issue where users starting a new Control UI thread could lose or delay the first prompt, hit repeated same-URL navigation while the created session was resolving, or regress during reconnect, catalog, workspace, attachment, or cloud recovery without the required CI gate noticing.

## Why This Change Was Made

Claim each client-owned first-turn handoff before the new chat pane attaches and starts transcript hydration. Make the browser mock obey the real Gateway contract: a successfully created session must be visible to the next session-list request, including deferred cloud recovery, without publishing rejected sessions or inventing a display name that changes the canonical URL. Repair the existing browser fixtures to use the advertised `chat.startup` contract and wait for committed router state.

Add a fork-safe, current-target-only `checks-ui-e2e` job and include it in `openclaw/ci-gate`, so all 47 real-Chromium new-session regressions must pass before UI changes can merge.

## User Impact

The first message appears immediately and remains visible through Gateway reconnects. New-thread navigation settles instead of looping, cloud retry keeps its recovery identity and canonical path, rejected session creation cannot leak into the session catalog, attachments render once, remembered workspaces remain stable, and browser regressions are blocked before merge.

## Evidence

- Exact proposed CI command on a fresh Blacksmith Linux runner: `pnpm test:ui:e2e ui/src/e2e/new-session-page.e2e.test.ts` — **47 passed / 47**. Evidence: https://github.com/openclaw/openclaw/actions/runs/30258585844.
- Hosted `checks-ui-e2e` itself executed and passed: https://github.com/openclaw/openclaw/actions/runs/30258944664/job/89954200766.
- Isolated production-owner suites: `chat-pane-lifecycle.test.ts` and `chat-pane.test.ts` — **59 passed / 59**.
- Stateful mock-Gateway regressions — **8 passed / 8**, proving successful immediate/deferred creation becomes visible while rejected creation never appears in `sessions.list`.
- Workflow guard suite — **90 passed**, 1 expected platform skip, including fork-safe runner/cache parity and proof that a failed Chromium job fails the required aggregate.
- Fresh independent autoreview: no actionable findings; TruffleHog clean.
- Formatting, i18n verification, dependency/policy guards, and core/UI/root type checks verified.