### PR TITLE
fix: harden cron delivery and Workboard dispatch

### DIFF
--- a/extensions/workboard/src/change-events.test.ts
+++ b/extensions/workboard/src/change-events.test.ts
@@ -6,6 +6,56 @@ import type { WorkboardStore } from "./store.js";
 afterEach(() => vi.useRealTimers());
 
 describe("createWorkboardChangeEventService", () => {
+  it("keeps repeated starts on one change subscription and reconciliation timer", async () => {
+    vi.useFakeTimers();
+    const listeners = new Set<(change: WorkboardChange) => void>();
+    const unsubscribe = vi.fn((listener: (change: WorkboardChange) => void) => {
+      listeners.delete(listener);
+    });
+    const reconcileExternalChanges = vi.fn();
+    const subscribeChanges = vi.fn((listener: (change: WorkboardChange) => void) => {
+      listeners.add(listener);
+      return () => unsubscribe(listener);
+    });
+    const announceChangeEpoch = vi.fn();
+    const store = {
+      subscribeChanges,
+      announceChangeEpoch,
+      reconcileExternalChanges,
+    } as unknown as WorkboardStore;
+    const emit = vi.fn();
+    const service = createWorkboardChangeEventService(store);
+    const context = {
+      config: {},
+      stateDir: "/tmp/workboard-change-events-test",
+      gatewayEvents: { emit },
+      logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    } satisfies Parameters<typeof service.start>[0];
+
+    for (let attempt = 0; attempt < 25; attempt += 1) {
+      await service.start(context);
+    }
+
+    expect(subscribeChanges).toHaveBeenCalledOnce();
+    expect(announceChangeEpoch).toHaveBeenCalledOnce();
+    expect(listeners.size).toBe(1);
+
+    for (const listener of listeners) {
+      listener({ epoch: "epoch-a", revision: 1 });
+    }
+    expect(emit).toHaveBeenCalledOnce();
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(reconcileExternalChanges).toHaveBeenCalledTimes(5);
+
+    await service.stop?.(context);
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(reconcileExternalChanges).toHaveBeenCalledTimes(5);
+    expect(unsubscribe).toHaveBeenCalledOnce();
+    expect(listeners.size).toBe(0);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
   it("announces its epoch, forwards changes, and reconciles external commits", async () => {
     vi.useFakeTimers();
     let listener: ((change: WorkboardChange) => void) | undefined;

--- a/extensions/workboard/src/change-events.ts
+++ b/extensions/workboard/src/change-events.ts
@@ -12,7 +12,7 @@ export function createWorkboardChangeEventService(store: WorkboardStore): OpenCl
     id: "workboard-change-events",
     start(ctx) {
       const gatewayEvents = ctx.gatewayEvents;
-      if (!gatewayEvents) {
+      if (!gatewayEvents || unsubscribe) {
         return;
       }
       const emit = (change: WorkboardChange) => {

--- a/extensions/workboard/src/dispatcher-ownership.test.ts
+++ b/extensions/workboard/src/dispatcher-ownership.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it, vi } from "vitest";
+import { dispatchAndStartWorkboardCards } from "./dispatcher.js";
+import type { PersistedWorkboardCard, WorkboardKeyedStore } from "./persistence-types.js";
+import { WorkboardStore } from "./store.js";
+
+function createMemoryStore(): WorkboardKeyedStore {
+  const entries = new Map<string, PersistedWorkboardCard>();
+  return {
+    async register(key, value) {
+      entries.set(key, value);
+    },
+    async lookup(key) {
+      return entries.get(key);
+    },
+    async delete(key) {
+      return entries.delete(key);
+    },
+    async entries() {
+      return [...entries].map(([key, value]) => ({ key, value }));
+    },
+  };
+}
+
+describe("Workboard dispatcher ownership", () => {
+  it("falls back to one default owner for persisted blank and unassigned agents", async () => {
+    const keyed = createMemoryStore();
+    const store = new WorkboardStore(keyed);
+    const blankAgent = await store.create({
+      title: "Blank agent worker",
+      status: "ready",
+      priority: "urgent",
+      workspaceAccess: { unrestricted: true },
+    });
+    await keyed.register(blankAgent.id, {
+      version: 1,
+      card: { ...blankAgent, agentId: "" },
+    });
+    const unassigned = await store.create({
+      title: "Unassigned worker",
+      status: "ready",
+      workspaceAccess: { unrestricted: true },
+    });
+    const run = vi.fn().mockResolvedValue({ runId: "run-default-owner" });
+
+    const result = await dispatchAndStartWorkboardCards({
+      store,
+      subagent: { run },
+      options: { now: 10, maxStarts: 3 },
+    });
+
+    expect(result.started).toEqual([
+      expect.objectContaining({ cardId: blankAgent.id, runId: "run-default-owner" }),
+    ]);
+    expect(run).toHaveBeenCalledOnce();
+    await expect(store.get(blankAgent.id)).resolves.toMatchObject({
+      status: "running",
+      metadata: { claim: { ownerId: "workboard-dispatcher" } },
+    });
+    await expect(store.get(unassigned.id)).resolves.toMatchObject({ status: "ready" });
+  });
+
+  it("bounds failed worker attempts without draining the ready queue", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    const cards = [];
+    for (let index = 0; index < 5; index += 1) {
+      cards.push(
+        await store.create({
+          title: `Queued worker ${index + 1}`,
+          status: "ready",
+          agentId: `worker-${index + 1}`,
+          workspaceAccess: { unrestricted: true },
+        }),
+      );
+    }
+    const run = vi.fn().mockRejectedValue(new Error("provider unavailable"));
+
+    const result = await dispatchAndStartWorkboardCards({
+      store,
+      subagent: { run },
+      options: { now: 10, maxStarts: 1 },
+    });
+
+    expect(run).toHaveBeenCalledTimes(2);
+    expect(result.started).toEqual([]);
+    expect(result.startFailures.map((failure) => failure.cardId)).toEqual([
+      cards[0]?.id,
+      cards[1]?.id,
+    ]);
+    await expect(Promise.all(cards.map((card) => store.get(card.id)))).resolves.toMatchObject([
+      { status: "blocked" },
+      { status: "blocked" },
+      { status: "ready" },
+      { status: "ready" },
+      { status: "ready" },
+    ]);
+  });
+
+  it("tries a healthy owner before retrying a failed owner's queued cards", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    const failed = await store.create({
+      title: "Failing urgent worker",
+      status: "ready",
+      priority: "urgent",
+      agentId: "unavailable-worker",
+      workspaceAccess: { unrestricted: true },
+    });
+    const deferred = await store.create({
+      title: "Another unavailable worker card",
+      status: "ready",
+      priority: "high",
+      agentId: "unavailable-worker",
+      workspaceAccess: { unrestricted: true },
+    });
+    const healthy = await store.create({
+      title: "Healthy independent worker",
+      status: "ready",
+      agentId: "healthy-worker",
+      workspaceAccess: { unrestricted: true },
+    });
+    const run = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("provider unavailable"))
+      .mockResolvedValueOnce({ runId: "run-healthy-owner" });
+
+    const result = await dispatchAndStartWorkboardCards({
+      store,
+      subagent: { run },
+      options: { now: 10, maxStarts: 1 },
+    });
+
+    expect(run).toHaveBeenCalledTimes(2);
+    expect(result.started).toEqual([
+      expect.objectContaining({ cardId: healthy.id, runId: "run-healthy-owner" }),
+    ]);
+    expect(result.startFailures).toEqual([
+      expect.objectContaining({ cardId: failed.id, error: "provider unavailable" }),
+    ]);
+    await expect(store.get(failed.id)).resolves.toMatchObject({ status: "blocked" });
+    await expect(store.get(deferred.id)).resolves.toMatchObject({ status: "ready" });
+    await expect(store.get(healthy.id)).resolves.toMatchObject({ status: "running" });
+  });
+
+  it("preserves priority order among available owners when workers start successfully", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    const urgent = await store.create({
+      title: "Urgent primary worker",
+      status: "ready",
+      priority: "urgent",
+      agentId: "primary-worker",
+      workspaceAccess: { unrestricted: true },
+    });
+    const sameOwner = await store.create({
+      title: "Second primary worker card",
+      status: "ready",
+      priority: "high",
+      agentId: "primary-worker",
+      workspaceAccess: { unrestricted: true },
+    });
+    const high = await store.create({
+      title: "High-priority independent worker",
+      status: "ready",
+      priority: "high",
+      agentId: "independent-worker",
+      workspaceAccess: { unrestricted: true },
+    });
+    const normal = await store.create({
+      title: "Normal-priority independent worker",
+      status: "ready",
+      agentId: "normal-worker",
+      workspaceAccess: { unrestricted: true },
+    });
+    const run = vi
+      .fn()
+      .mockResolvedValueOnce({ runId: "run-urgent" })
+      .mockResolvedValueOnce({ runId: "run-high" });
+
+    const result = await dispatchAndStartWorkboardCards({
+      store,
+      subagent: { run },
+      options: { now: 10, maxStarts: 2 },
+    });
+
+    expect(result.started.map((entry) => entry.cardId)).toEqual([urgent.id, high.id]);
+    expect(run).toHaveBeenCalledTimes(2);
+    await expect(store.get(sameOwner.id)).resolves.toMatchObject({ status: "ready" });
+    await expect(store.get(normal.id)).resolves.toMatchObject({ status: "ready" });
+  });
+});

--- a/extensions/workboard/src/dispatcher.test.ts
+++ b/extensions/workboard/src/dispatcher.test.ts
@@ -847,6 +847,108 @@ describe("dispatchAndStartWorkboardCards", () => {
     });
   });
 
+  it("shares one worker slot across cards dispatched with the same explicit owner", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    const first = await store.create({
+      title: "First shared worker",
+      status: "ready",
+      priority: "urgent",
+      agentId: "alpha",
+      workspaceAccess: { unrestricted: true },
+    });
+    const second = await store.create({
+      title: "Second shared worker",
+      status: "ready",
+      agentId: "beta",
+      workspaceAccess: { unrestricted: true },
+    });
+    const run = vi.fn().mockResolvedValue({ runId: "run-shared" });
+
+    const result = await dispatchAndStartWorkboardCards({
+      store,
+      subagent: { run },
+      options: { now: 10, maxStarts: 3, ownerId: " shared-worker " },
+    });
+
+    expect(result.started).toEqual([
+      expect.objectContaining({ cardId: first.id, runId: "run-shared" }),
+    ]);
+    expect(run).toHaveBeenCalledOnce();
+    await expect(store.get(first.id)).resolves.toMatchObject({
+      status: "running",
+      metadata: { claim: { ownerId: "shared-worker" } },
+    });
+    await expect(store.get(second.id)).resolves.toMatchObject({ status: "ready" });
+  });
+
+  it("counts the active claim owner when checking worker capacity", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    const running = await store.create({
+      title: "Already claimed worker",
+      status: "running",
+      agentId: "alpha",
+      workspaceAccess: { unrestricted: true },
+    });
+    await store.claim(running.id, { ownerId: "shared-worker", token: "shared-token" });
+    const ready = await store.create({
+      title: "Waiting for the shared owner",
+      status: "ready",
+      agentId: "beta",
+      workspaceAccess: { unrestricted: true },
+    });
+    const run = vi.fn();
+
+    const result = await dispatchAndStartWorkboardCards({
+      store,
+      subagent: { run },
+      options: { now: 10, maxStarts: 3, ownerId: "shared-worker" },
+    });
+
+    expect(result.started).toEqual([]);
+    expect(run).not.toHaveBeenCalled();
+    await expect(store.get(ready.id)).resolves.toMatchObject({ status: "ready" });
+  });
+
+  it.each(["worker", "other-worker"])(
+    "starts recoverable work after a higher-priority worker fails (next owner: %s)",
+    async (nextOwner) => {
+      const store = new WorkboardStore(createMemoryStore());
+      const failed = await store.create({
+        title: "Unavailable urgent worker",
+        status: "ready",
+        priority: "urgent",
+        agentId: "worker",
+        workspaceAccess: { unrestricted: true },
+      });
+      const recovered = await store.create({
+        title: "Recoverable queued worker",
+        status: "ready",
+        agentId: nextOwner,
+        workspaceAccess: { unrestricted: true },
+      });
+      const run = vi
+        .fn()
+        .mockRejectedValueOnce(new Error("model unavailable"))
+        .mockResolvedValueOnce({ runId: "run-recovered" });
+
+      const result = await dispatchAndStartWorkboardCards({
+        store,
+        subagent: { run },
+        options: { now: 10, maxStarts: 1 },
+      });
+
+      expect(run).toHaveBeenCalledTimes(2);
+      expect(result.started).toEqual([
+        expect.objectContaining({ cardId: recovered.id, runId: "run-recovered" }),
+      ]);
+      expect(result.startFailures).toEqual([
+        expect.objectContaining({ cardId: failed.id, error: "model unavailable" }),
+      ]);
+      await expect(store.get(failed.id)).resolves.toMatchObject({ status: "blocked" });
+      await expect(store.get(recovered.id)).resolves.toMatchObject({ status: "running" });
+    },
+  );
+
   it("does not let review cards consume an agent running slot", async () => {
     const store = new WorkboardStore(createMemoryStore());
     await store.create({

--- a/extensions/workboard/src/dispatcher.ts
+++ b/extensions/workboard/src/dispatcher.ts
@@ -224,10 +224,15 @@ function sortReadyCards(a: WorkboardCard, b: WorkboardCard): number {
   );
 }
 
+function resolveDispatchOwner(card: WorkboardCard, ownerOverride?: string): string {
+  return ownerOverride || card.metadata?.claim?.ownerId || card.agentId || DEFAULT_DISPATCH_OWNER;
+}
+
 function selectStartableCards(
   cards: WorkboardCard[],
   limit: number,
   candidates: WorkboardCard[] = cards,
+  ownerOverride?: string,
 ): WorkboardCard[] {
   if (limit <= 0) {
     return [];
@@ -236,29 +241,33 @@ function selectStartableCards(
   for (const card of cards) {
     const consumesOwnerSlot =
       card.status === "running" ||
-      Boolean(card.metadata?.claim) ||
+      (card.status !== "done" && Boolean(card.metadata?.claim)) ||
       card.execution?.status === "running";
     if (!consumesOwnerSlot || cardIsArchived(card)) {
       continue;
     }
-    const owner = card.agentId ?? DEFAULT_DISPATCH_OWNER;
+    const owner = resolveDispatchOwner(card);
     runningByOwner.set(owner, (runningByOwner.get(owner) ?? 0) + 1);
   }
   const selected: WorkboardCard[] = [];
+  const fallback: WorkboardCard[] = [];
+  const selectedOwners = new Set<string>();
   for (const card of candidates
     .filter((entry) => entry.status === "ready" && !entry.metadata?.claim && !cardIsArchived(entry))
     .toSorted(sortReadyCards)) {
-    const owner = card.agentId ?? DEFAULT_DISPATCH_OWNER;
+    const owner = resolveDispatchOwner(card, ownerOverride);
     if ((runningByOwner.get(owner) ?? 0) > 0) {
       continue;
     }
-    selected.push(card);
-    runningByOwner.set(owner, 1);
-    if (selected.length >= limit) {
-      break;
+    if (selectedOwners.has(owner)) {
+      fallback.push(card);
+      continue;
     }
+    selectedOwners.add(owner);
+    selected.push(card);
   }
-  return selected;
+  // Try each owner before a failed owner's extra cards consume the outage budget.
+  return [...selected, ...fallback];
 }
 
 export async function dispatchAndStartWorkboardCards(params: {
@@ -278,9 +287,22 @@ export async function dispatchAndStartWorkboardCards(params: {
   const startFailures: WorkboardStartFailure[] = [];
   const cards = await params.store.list();
   const candidates = await params.store.list({ boardId });
+  const ownerOverride = params.options?.ownerId?.trim() || undefined;
+  const startedOwners = new Set<string>();
+  // Allow one fallback per worker slot without draining the queue during an outage.
+  const maxAttempts = maxStarts * 2;
+  let acceptedStarts = 0;
+  let attemptedStarts = 0;
 
-  for (const card of selectStartableCards(cards, maxStarts, candidates)) {
-    const ownerId = params.options?.ownerId?.trim() || card.agentId || DEFAULT_DISPATCH_OWNER;
+  for (const card of selectStartableCards(cards, maxStarts, candidates, ownerOverride)) {
+    const ownerId = resolveDispatchOwner(card, ownerOverride);
+    if (acceptedStarts >= maxStarts || attemptedStarts >= maxAttempts) {
+      break;
+    }
+    if (startedOwners.has(ownerId)) {
+      continue;
+    }
+    attemptedStarts += 1;
     const sessionKey = buildSessionKey(card);
     let claimValue = "";
     let materializedWorkspace: WorkboardWorkspace | undefined;
@@ -426,6 +448,8 @@ export async function dispatchAndStartWorkboardCards(params: {
         ...(runCwd ? { cwd: runCwd } : {}),
       });
       runStarted = true;
+      acceptedStarts += 1;
+      startedOwners.add(ownerId);
       const updated = await params.store.update(card.id, {
         sessionKey,
         runId: run.runId,

--- a/extensions/workboard/src/store.test.ts
+++ b/extensions/workboard/src/store.test.ts
@@ -3087,6 +3087,30 @@ describe("WorkboardStore", () => {
     });
   });
 
+  it("does not mutate archived ready cards during repeated dispatch", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    const card = await store.create({
+      title: "Archived ready work",
+      status: "ready",
+    });
+    const archived = await store.archive(card.id, true);
+    const changes = vi.fn();
+    store.subscribeChanges(changes);
+
+    for (let attempt = 0; attempt < 25; attempt += 1) {
+      await expect(store.dispatch(10 + attempt)).resolves.toEqual({
+        promoted: [],
+        reclaimed: [],
+        blocked: [],
+        orchestrated: [],
+        count: 0,
+      });
+    }
+
+    await expect(store.get(card.id)).resolves.toEqual(archived);
+    expect(changes).not.toHaveBeenCalled();
+  });
+
   it("applies auto orchestration dispatch caps per board", async () => {
     const boards = createMemoryStore<PersistedWorkboardBoard>();
     const store = new WorkboardStore(createMemoryStore(), { boards });

--- a/extensions/workboard/src/store.ts
+++ b/extensions/workboard/src/store.ts
@@ -138,7 +138,7 @@ export class WorkboardStore extends WorkboardNotificationStore {
           });
           blocked.push(latest);
         }
-        if (latest.status === "ready") {
+        if (latest.status === "ready" && !latest.metadata?.archivedAt) {
           latest = await this.recordDispatch(latest, now);
         }
         if (await this.shouldAutoOrchestrate(latest)) {

--- a/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
@@ -2088,6 +2088,34 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     expect(deliverOutboundPayloads).toHaveBeenCalledTimes(2);
   });
 
+  it.each(["structured", "threaded"] as const)(
+    "retries proven-not-sent %s cron delivery without duplicating a message",
+    async (deliveryKind) => {
+      vi.stubEnv("OPENCLAW_TEST_FAST", "1");
+      vi.mocked(deliverOutboundPayloads)
+        .mockRejectedValueOnce(
+          new PlatformMessageNotDispatchedError("upload stopped before final dispatch", {
+            cause: new Error("gateway upload failed"),
+          }),
+        )
+        .mockResolvedValueOnce([{ ok: true } as never]);
+
+      const params = makeBaseParams({ synthesizedText: "Retry without duplicating." });
+      if (deliveryKind === "structured") {
+        params.deliveryPayloadHasStructuredContent = true;
+      } else {
+        params.resolvedDelivery = makeResolvedDelivery({ threadId: "42" });
+      }
+
+      const state = await dispatchCronDelivery(params);
+
+      expect(state.result).toBeUndefined();
+      expect(state.deliveryAttempted).toBe(true);
+      expect(state.delivered).toBe(true);
+      expect(deliverOutboundPayloads).toHaveBeenCalledTimes(2);
+    },
+  );
+
   it("does not retry ambiguous direct announce send errors", async () => {
     vi.stubEnv("OPENCLAW_TEST_FAST", "1");
     vi.mocked(deliverOutboundPayloads).mockRejectedValueOnce(

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -561,7 +561,7 @@ export async function dispatchCronDelivery(
 
   const deliverViaDirectAndCleanup = async (
     delivery: SuccessfulCronDeliveryTarget,
-    options?: { retryTransient?: boolean },
+    options: { retryTransient?: boolean } = { retryTransient: true },
   ): Promise<RunCronAgentTurnResult | null> => {
     try {
       return await deliverViaDirect(delivery, options);

--- a/src/gateway/server-cron-notifications.test.ts
+++ b/src/gateway/server-cron-notifications.test.ts
@@ -13,7 +13,11 @@ import {
 import { setActiveDegradedSecretOwners } from "../secrets/runtime-degraded-state.js";
 
 const mocks = vi.hoisted(() => ({
-  fetchWithSsrFGuard: vi.fn(async (_request: unknown) => ({ release: vi.fn() })),
+  fetchWithSsrFGuard: vi.fn(async (_request: unknown) => ({
+    response: new Response(null, { status: 204 }),
+    finalUrl: "https://example.invalid/cron",
+    release: vi.fn(async () => {}),
+  })),
   sendFailureNotificationAnnounce: vi.fn(),
   sendCronAnnouncePayloadStrict: vi.fn(),
 }));
@@ -88,7 +92,11 @@ describe("dispatchGatewayCronFinishedNotifications", () => {
   beforeEach(() => {
     resetGatewayWorkAdmission();
     vi.clearAllMocks();
-    mocks.fetchWithSsrFGuard.mockImplementation(async () => ({ release: vi.fn() }));
+    mocks.fetchWithSsrFGuard.mockImplementation(async () => ({
+      response: new Response(null, { status: 204 }),
+      finalUrl: "https://example.invalid/cron",
+      release: vi.fn(async () => {}),
+    }));
     mocks.sendFailureNotificationAnnounce.mockResolvedValue(undefined);
     mocks.sendCronAnnouncePayloadStrict.mockResolvedValue(undefined);
   });
@@ -102,7 +110,11 @@ describe("dispatchGatewayCronFinishedNotifications", () => {
     const deferred = createVoidDeferred();
     mocks.fetchWithSsrFGuard.mockImplementationOnce(async () => {
       await deferred.promise;
-      return { release: vi.fn() };
+      return {
+        response: new Response(null, { status: 204 }),
+        finalUrl: "https://example.invalid/cron",
+        release: vi.fn(async () => {}),
+      };
     });
     const job = createWebhookJob({
       mode: "webhook",
@@ -174,6 +186,130 @@ describe("dispatchGatewayCronFinishedNotifications", () => {
     await waitForFast(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
   });
 
+  it.each([400, 401, 429, 500, 503])(
+    "reports and releases an unsuccessful completion webhook (HTTP %i)",
+    async (status) => {
+      const release = vi.fn(async () => {});
+      mocks.fetchWithSsrFGuard.mockResolvedValueOnce({
+        response: new Response(null, { status }),
+        finalUrl: "https://example.invalid/cron",
+        release,
+      });
+      const logger = { warn: vi.fn() };
+      const job = createWebhookJob({
+        mode: "webhook",
+        to: "https://example.invalid/cron?token=must-not-be-logged",
+      });
+
+      dispatchGatewayCronFinishedNotifications({
+        evt: { jobId: job.id, action: "finished", status: "ok", summary: "done" },
+        job,
+        deps: {} as CliDeps,
+        logger,
+        resolveCronAgent: () => ({ agentId: "main", cfg: {} }),
+      });
+
+      await waitForFast(() =>
+        expect(logger.warn).toHaveBeenCalledWith(
+          expect.objectContaining({
+            jobId: job.id,
+            source: "delivery",
+            err: expect.stringContaining(String(status)),
+            webhookUrl: "https://example.invalid/cron",
+          }),
+          "cron: webhook delivery failed",
+        ),
+      );
+      expect(release).toHaveBeenCalledOnce();
+      expect(JSON.stringify(logger.warn.mock.calls)).not.toContain("must-not-be-logged");
+      await waitForFast(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
+    },
+  );
+
+  it("delivers a failed cron webhook even when the run produced no summary", async () => {
+    const logger = { warn: vi.fn() };
+    const job = createWebhookJob({
+      mode: "webhook",
+      to: "https://example.invalid/cron",
+    });
+
+    dispatchGatewayCronFinishedNotifications({
+      evt: {
+        jobId: job.id,
+        action: "finished",
+        status: "error",
+        error: "provider unavailable",
+      },
+      job,
+      deps: {} as CliDeps,
+      logger,
+      resolveCronAgent: () => ({ agentId: "main", cfg: {} }),
+    });
+
+    await waitForFast(() => expect(mocks.fetchWithSsrFGuard).toHaveBeenCalledOnce());
+    expect(webhookRequestBody()).toMatchObject({
+      jobId: job.id,
+      action: "finished",
+      status: "error",
+      error: "provider unavailable",
+    });
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it("applies the webhook timeout to guarded network preflight", async () => {
+    const job = createWebhookJob({
+      mode: "webhook",
+      to: "https://example.invalid/cron",
+    });
+
+    dispatchGatewayCronFinishedNotifications({
+      evt: { jobId: job.id, action: "finished", status: "ok", summary: "done" },
+      job,
+      deps: {} as CliDeps,
+      logger: { warn: vi.fn() },
+      resolveCronAgent: () => ({ agentId: "main", cfg: {} }),
+    });
+
+    await waitForFast(() =>
+      expect(mocks.fetchWithSsrFGuard).toHaveBeenCalledWith(
+        expect.objectContaining({ timeoutMs: 10_000 }),
+      ),
+    );
+  });
+
+  it("delivers a failed completion-destination webhook without a summary", async () => {
+    const logger = { warn: vi.fn() };
+    const job = createWebhookJob({
+      mode: "announce",
+      completionDestination: {
+        mode: "webhook",
+        to: "https://example.invalid/completion",
+      },
+    });
+
+    dispatchGatewayCronFinishedNotifications({
+      evt: {
+        jobId: job.id,
+        action: "finished",
+        status: "error",
+        error: "provider unavailable",
+      },
+      job,
+      deps: {} as CliDeps,
+      logger,
+      resolveCronAgent: () => ({ agentId: "main", cfg: {} }),
+    });
+
+    await waitForFast(() => expect(mocks.fetchWithSsrFGuard).toHaveBeenCalledOnce());
+    expect(webhookRequestBody()).toMatchObject({
+      jobId: job.id,
+      action: "finished",
+      status: "error",
+      error: "provider unavailable",
+    });
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
   it("independently admits immediate failure alerts", async () => {
     const deferred = createVoidDeferred();
     mocks.sendCronAnnouncePayloadStrict.mockImplementationOnce(async () => {
@@ -227,7 +363,11 @@ describe("dispatchGatewayCronFinishedNotifications", () => {
     const deferred = createVoidDeferred();
     mocks.fetchWithSsrFGuard.mockImplementationOnce(async () => {
       await deferred.promise;
-      return { release: vi.fn() };
+      return {
+        response: new Response(null, { status: 204 }),
+        finalUrl: "https://example.invalid/failure",
+        release: vi.fn(async () => {}),
+      };
     });
     const job = createWebhookJob({
       mode: "announce",

--- a/src/gateway/server-cron-notifications.ts
+++ b/src/gateway/server-cron-notifications.ts
@@ -207,14 +207,11 @@ async function postCronWebhook(params: {
   logger: CronLogger;
 }): Promise<void> {
   const abortController = new AbortController();
-  const timeout = setTimeout(() => {
-    abortController.abort();
-  }, CRON_WEBHOOK_TIMEOUT_MS);
-
   try {
     assertSecretOwnerAvailable("capability", "cron-webhook");
     const result = await fetchWithSsrFGuard({
       url: params.webhookUrl,
+      timeoutMs: CRON_WEBHOOK_TIMEOUT_MS,
       init: {
         method: "POST",
         headers: buildCronWebhookHeaders(params.webhookToken),
@@ -222,7 +219,13 @@ async function postCronWebhook(params: {
         signal: abortController.signal,
       },
     });
-    await result.release();
+    try {
+      if (!result.response.ok) {
+        throw new Error(`Webhook request failed with HTTP ${result.response.status}`);
+      }
+    } finally {
+      await result.release();
+    }
   } catch (err) {
     if (err instanceof SsrFBlockedError) {
       params.logger.warn(
@@ -243,8 +246,6 @@ async function postCronWebhook(params: {
         params.failedLog,
       );
     }
-  } finally {
-    clearTimeout(timeout);
   }
 }
 
@@ -383,7 +384,7 @@ export function dispatchGatewayCronFinishedNotifications(params: {
 
   // Script notify is carried as the completion summary, so its absence uses
   // the same silent-summary suppression path as NO_REPLY output.
-  if (completionSummary) {
+  if (completionSummary || params.evt.status === "error") {
     for (const webhookTarget of webhookTargets) {
       const payload = buildCronFinishedWebhookPayload(redactedWebhookEvent);
       // Completion notification fanout is best-effort; the cron service has

--- a/src/gateway/server-cron.test.ts
+++ b/src/gateway/server-cron.test.ts
@@ -1582,7 +1582,11 @@ describe("buildGatewayCronService", () => {
       notify: "queue changed",
       stateChanged: false,
     });
-    fetchWithSsrFGuardMock.mockResolvedValueOnce({ release: vi.fn() });
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      response: new Response(null, { status: 204 }),
+      finalUrl: "https://example.invalid/cron",
+      release: vi.fn(async () => {}),
+    });
 
     const state = buildGatewayCronService({
       cfg,

--- a/ui/src/lib/workboard/index.test.ts
+++ b/ui/src/lib/workboard/index.test.ts
@@ -1304,6 +1304,26 @@ describe("workboard controller", () => {
     expect(client.request).toHaveBeenCalledWith("workboard.cards.dispatch", {});
   });
 
+  it("limits dispatch to the selected named board", async () => {
+    state.boardFilter = "ops";
+    state.boards = [{ id: "ops", total: 1, active: 1, archived: 0, byStatus: { ready: 1 } }];
+    const client = createClient({
+      "workboard.cards.dispatch": {
+        promoted: [],
+        reclaimed: [],
+        blocked: [],
+        orchestrated: [],
+        count: 0,
+      },
+      "workboard.cards.list": { cards: [sampleCard], statuses: ["todo", "done"] },
+      "tasks.list": { tasks: [] },
+    });
+
+    await dispatchWorkboard({ host, client: client as never });
+
+    expect(client.request).toHaveBeenCalledWith("workboard.cards.dispatch", { boardId: "ops" });
+  });
+
   it("clears stale refresh errors after a successful dispatch reload", async () => {
     state.lastRefreshError = "poll unavailable";
     const client = createClient({
@@ -2570,6 +2590,36 @@ describe("workboard controller", () => {
     expect(state.cards[0]).toMatchObject({ id: "card-2", title: "Write tests" });
     expect(state.draftOpen).toBe(false);
     expect(state.draftSessionKey).toBe("");
+  });
+
+  it("creates cards on the selected named board", async () => {
+    state.boardFilter = "ops";
+    state.boards = [{ id: "ops", total: 0, active: 0, archived: 0, byStatus: {} }];
+    state.draftTitle = "Investigate operations alert";
+    const created = {
+      ...sampleCard,
+      id: "card-ops",
+      title: "Investigate operations alert",
+      metadata: { automation: { boardId: "ops" } },
+    } satisfies WorkboardCard;
+    const client = createClient({ "workboard.cards.create": { card: created } });
+
+    await saveWorkboardCardDraft({ host, client: client as never });
+
+    expect(client.request).toHaveBeenCalledWith("workboard.cards.create", {
+      title: "Investigate operations alert",
+      notes: "",
+      status: "todo",
+      priority: "normal",
+      labels: [],
+      agentId: "",
+      sessionKey: "",
+      boardId: "ops",
+    });
+    expect(state.cards[0]).toMatchObject({
+      id: "card-ops",
+      metadata: { automation: { boardId: "ops" } },
+    });
   });
 
   it("creates template-backed cards through the save action", async () => {

--- a/ui/src/lib/workboard/mutations.ts
+++ b/ui/src/lib/workboard/mutations.ts
@@ -18,7 +18,14 @@ import {
   type WorkboardHost,
 } from "./runtime.ts";
 import { applyTaskSummariesToState, listWorkboardTasks } from "./task-links.ts";
-import type { WorkboardDispatchSummary, WorkboardStatus } from "./types.ts";
+import type { WorkboardDispatchSummary, WorkboardStatus, WorkboardUiState } from "./types.ts";
+
+function selectedBoardParams(state: Pick<WorkboardUiState, "boards" | "boardFilter">): {
+  boardId?: string;
+} {
+  const boardId = state.boards.find((board) => board.id === state.boardFilter)?.id;
+  return boardId ? { boardId } : {};
+}
 
 function normalizeDispatchSummary(value: unknown): WorkboardDispatchSummary {
   const countArray = (key: string) =>
@@ -54,7 +61,10 @@ async function createWorkboardCard(params: {
   state.error = null;
   params.requestUpdate?.();
   try {
-    const payload = await params.client.request("workboard.cards.create", draftPayload(state));
+    const payload = await params.client.request("workboard.cards.create", {
+      ...draftPayload(state),
+      ...selectedBoardParams(state),
+    });
     replaceCard(state, normalizeCardPayload(payload));
     resetDraftState(state);
   } catch (error) {
@@ -287,7 +297,10 @@ export async function dispatchWorkboard(params: {
   state.lastDispatchSummary = null;
   params.requestUpdate?.();
   try {
-    const dispatchResult = await params.client.request("workboard.cards.dispatch", {});
+    const dispatchResult = await params.client.request(
+      "workboard.cards.dispatch",
+      selectedBoardParams(state),
+    );
     const payload = await params.client.request("workboard.cards.list", {});
     const normalized = normalizeCardsPayload(payload);
     state.cards = normalized.cards;


### PR DESCRIPTION
Related: #108361

## What Problem This Solves

Fixes an issue where scheduled jobs could silently drop failed webhook notifications, skip retrying proven-unsent threaded or media deliveries, or omit failure notifications when no summary was available. Fixes an issue where Workboard users creating or dispatching work from a named board affected the wrong board, while failed worker starts, blank or stale claim owners, archived cards, repeated service starts, and provider outages could stall work, drain the queue, or create unnecessary events and timers.

## Why This Change Was Made

Use existing guarded-fetch timeout and direct-delivery retry contracts, preserve plugin-owned board selection and claim ownership, and bound fallback launch attempts during outages. Keep the implementation within existing gateway, cron, Workboard plugin, and UI boundaries without new dependencies, configuration, protocol versions, SQLite schemas, or migrations.

## User Impact

Cron failure webhooks now reject unsuccessful HTTP responses and notify configured destinations even without summaries. Safe-to-retry direct notifications are retried. Named-board creation and dispatch stay on the selected board. Workboard recovers after a failed launch, respects explicit and default claim owners, limits outage retries, avoids mutating archived cards, and prevents duplicate change-service timers.

## Evidence

- Established a clean baseline at ac6009eab195ec09394170c57f8ddef054f6fbac on an isolated Blacksmith Testbox.
- Reproduced webhook failures red-first for HTTP 400, 401, 429, 500, and 503, plus failed runs without summaries.
- Reproduced named-board creation and dispatch failures red-first.
- Passed 616 focused cron, gateway, durable SQLite delivery and recovery, Workboard plugin, and Workboard UI regression tests.
- Rebased onto the current mainline durable cron-delivery refactor and verified 88 SQLite and delivery-recovery regressions.
- Passed all five real-Chromium Workboard lifecycle, board selection, persisted routing, and plugin visibility scenarios.
- Stress-tested 25 repeated archived dispatches and 25 repeated change-service starts, persisted blank-agent ownership, bounded provider outages, cross-owner fairness, normal successful-start priority, claim-owner capacity, and recovery after failed worker launches.
- Passed repository formatting, core and UI type-checks, core and UI lint, extension and extension-test type-checks, SDK contract and plugin-boundary checks, and focused extension lint.
- Completed a fresh independent autoreview with no accepted or actionable findings.
- AI-assisted implementation and independently reviewed proof.