### PR TITLE
fix(auto-reply): normalize newline-delimited silent tokens

### DIFF
--- a/src/auto-reply/reply/pending-final-delivery.test.ts
+++ b/src/auto-reply/reply/pending-final-delivery.test.ts
@@ -58,14 +58,15 @@ describe("sanitizePendingFinalDeliveryText", () => {
     expect(sanitizePendingFinalDeliveryText(text)).toBe(expected);
   });
 
-  it.each(["!", "?", ",", ";", ":"])(
-    "strips a sentence-attached recovery token while preserving %j",
-    (punctuation) => {
-      expect(sanitizePendingFinalDeliveryText(`Done as requested${punctuation}NO_REPLY`)).toBe(
-        `Done as requested${punctuation}`,
-      );
-    },
-  );
+  it.each([
+    "Done as requested!NO_REPLY",
+    "question?NO_REPLY",
+    "note,NO_REPLY",
+    "item;NO_REPLY",
+    "label:NO_REPLY",
+  ])("preserves punctuation-attached silent-token literals in recovery: %j", (text) => {
+    expect(sanitizePendingFinalDeliveryText(text)).toBe(text);
+  });
 
   it("strips repeated trailing silent tokens from recovery text", () => {
     expect(sanitizePendingFinalDeliveryText("Done. NO_REPLY NO_REPLY")).toBe("Done.");

--- a/src/auto-reply/reply/pending-final-delivery.test.ts
+++ b/src/auto-reply/reply/pending-final-delivery.test.ts
@@ -43,6 +43,47 @@ describe("sanitizePendingFinalDeliveryText", () => {
     expect(sanitizePendingFinalDeliveryText("HEARTBEAT_OK NO_REPLY")).toBe("HEARTBEAT_OK");
   });
 
+  it.each([
+    ["NO_REPLY\n\nThe user is saying hello", "The user is saying hello"],
+    ["NO_REPLY\r\nThe user is saying hello", "The user is saying hello"],
+    ["NO_REPLY NO_REPLY\nThe user is saying hello", "The user is saying hello"],
+    ["NO_REPLY\n✅ Done", "✅ Done"],
+    ["NO_REPLY\n- Done", "- Done"],
+    ["NO_REPLY\n—note", "—note"],
+    ["NO_REPLY\n: explanation", ": explanation"],
+    ["NO_REPLY\n**Done**", "**Done**"],
+    ['NO_REPLY\n"Hello"', '"Hello"'],
+    ["NO_REPLY\n```ts\nconst done = true;\n```", "```ts\nconst done = true;\n```"],
+  ])("strips newline-separated leading silent tokens from recovery text: %j", (text, expected) => {
+    expect(sanitizePendingFinalDeliveryText(text)).toBe(expected);
+  });
+
+  it.each(["!", "?", ",", ";", ":"])(
+    "strips a sentence-attached recovery token while preserving %j",
+    (punctuation) => {
+      expect(sanitizePendingFinalDeliveryText(`Done as requested${punctuation}NO_REPLY`)).toBe(
+        `Done as requested${punctuation}`,
+      );
+    },
+  );
+
+  it("strips repeated trailing silent tokens from recovery text", () => {
+    expect(sanitizePendingFinalDeliveryText("Done. NO_REPLY NO_REPLY")).toBe("Done.");
+  });
+
+  it.each([
+    "interject.NO_REPLY",
+    "The example is interject.NO_REPLY",
+    "Done as requested.NO_REPLY",
+    "NO_REPLY NO_REPLY: explanation",
+    "NO_REPLY\nNO_REPLY: explanation",
+    "NO_REPLY\nNO_REPLY—note",
+    "NO_REPLY\nNO_REPLY-note",
+    "NO_REPLY\nNO_REPLY -- nope",
+  ])("preserves substantive dotted and punctuation-start recovery literals: %j", (text) => {
+    expect(sanitizePendingFinalDeliveryText(text)).toBe(text);
+  });
+
   it("preserves heartbeat ack text for ack-aware classification", () => {
     expect(sanitizePendingFinalDeliveryText("HEARTBEAT_OK short")).toBe("HEARTBEAT_OK short");
   });

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -229,15 +229,15 @@ describe("normalizeReplyPayload", () => {
     expect(expectNormalizedReply(normalizeReplyPayload({ text })).text).toBe(expected);
   });
 
-  it.each(["!", "?", ",", ";", ":"])(
-    "strips a sentence-attached trailing silent token while preserving %j",
-    (punctuation) => {
-      const text = `Done as requested${punctuation}NO_REPLY`;
-      expect(expectNormalizedReply(normalizeReplyPayload({ text })).text).toBe(
-        `Done as requested${punctuation}`,
-      );
-    },
-  );
+  it.each([
+    "Done as requested!NO_REPLY",
+    "question?NO_REPLY",
+    "note,NO_REPLY",
+    "item;NO_REPLY",
+    "label:NO_REPLY",
+  ])("preserves punctuation-attached silent-token literals in delivery: %j", (text) => {
+    expect(expectNormalizedReply(normalizeReplyPayload({ text })).text).toBe(text);
+  });
 
   it("strips repeated trailing silent tokens from visible replies", () => {
     expect(

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -214,6 +214,50 @@ describe("normalizeReplyPayload", () => {
     expect(expectNormalizedReply(result).text).toBe("The user is saying hello");
   });
 
+  it.each([
+    ["NO_REPLY\n\nThe user is saying hello", "The user is saying hello"],
+    ["NO_REPLY\r\nThe user is saying hello", "The user is saying hello"],
+    ["NO_REPLY NO_REPLY\nThe user is saying hello", "The user is saying hello"],
+    ["NO_REPLY\n✅ Done", "✅ Done"],
+    ["NO_REPLY\n- Done", "- Done"],
+    ["NO_REPLY\n—note", "—note"],
+    ["NO_REPLY\n: explanation", ": explanation"],
+    ["NO_REPLY\n**Done**", "**Done**"],
+    ['NO_REPLY\n"Hello"', '"Hello"'],
+    ["NO_REPLY\n```ts\nconst done = true;\n```", "```ts\nconst done = true;\n```"],
+  ])("strips newline-separated leading silent tokens: %j", (text, expected) => {
+    expect(expectNormalizedReply(normalizeReplyPayload({ text })).text).toBe(expected);
+  });
+
+  it.each(["!", "?", ",", ";", ":"])(
+    "strips a sentence-attached trailing silent token while preserving %j",
+    (punctuation) => {
+      const text = `Done as requested${punctuation}NO_REPLY`;
+      expect(expectNormalizedReply(normalizeReplyPayload({ text })).text).toBe(
+        `Done as requested${punctuation}`,
+      );
+    },
+  );
+
+  it("strips repeated trailing silent tokens from visible replies", () => {
+    expect(
+      expectNormalizedReply(normalizeReplyPayload({ text: "Done. NO_REPLY NO_REPLY" })).text,
+    ).toBe("Done.");
+  });
+
+  it.each([
+    "interject.NO_REPLY",
+    "The example is interject.NO_REPLY",
+    "Done as requested.NO_REPLY",
+    "NO_REPLY NO_REPLY: explanation",
+    "NO_REPLY\nNO_REPLY: explanation",
+    "NO_REPLY\nNO_REPLY—note",
+    "NO_REPLY\nNO_REPLY-note",
+    "NO_REPLY\nNO_REPLY -- nope",
+  ])("preserves substantive dotted and punctuation-start silent-token literals: %j", (text) => {
+    expect(expectNormalizedReply(normalizeReplyPayload({ text })).text).toBe(text);
+  });
+
   it("keeps NO_REPLY when used as leading substantive text", () => {
     const result = normalizeReplyPayload({ text: "NO_REPLY -- nope" });
     expect(expectNormalizedReply(result).text).toBe("NO_REPLY -- nope");

--- a/src/auto-reply/tokens.test.ts
+++ b/src/auto-reply/tokens.test.ts
@@ -215,12 +215,29 @@ describe("stripSilentToken", () => {
     expect(stripSilentToken("😄 NO_REPLY")).toBe("😄");
   });
 
+  it.each(["!", "?", ",", ";", ":"])(
+    "strips a trailing silent token without consuming sentence punctuation %j",
+    (punctuation) => {
+      expect(stripSilentToken(`Done as requested${punctuation}NO_REPLY`)).toBe(
+        `Done as requested${punctuation}`,
+      );
+    },
+  );
+
   it("does not strip embedded token suffix without whitespace delimiter", () => {
     expect(stripSilentToken("interject.NO_REPLY")).toBe("interject.NO_REPLY");
+    expect(stripSilentToken("The example is interject.NO_REPLY")).toBe(
+      "The example is interject.NO_REPLY",
+    );
+    expect(stripSilentToken("Done as requested.NO_REPLY")).toBe("Done as requested.NO_REPLY");
   });
 
   it("strips only trailing occurrence", () => {
     expect(stripSilentToken("NO_REPLY ok NO_REPLY")).toBe("NO_REPLY ok");
+  });
+
+  it("strips every adjacent trailing silent token", () => {
+    expect(stripSilentToken("Done. NO_REPLY NO_REPLY")).toBe("Done.");
   });
 
   it("returns empty string when only token remains", () => {
@@ -281,6 +298,33 @@ describe("startsWithSilentToken", () => {
     expect(startsWithSilentToken("NO_REPLY—note")).toBe(false);
     expect(startsWithSilentToken("NO_REPLY")).toBe(false);
     expect(startsWithSilentToken("  NO_REPLY  ")).toBe(false);
+  });
+
+  it.each([
+    "NO_REPLY\n\nThe user is saying hello",
+    "NO_REPLY\r\nThe user is saying hello",
+    "NO_REPLY NO_REPLY\nThe user is saying hello",
+    "NO_REPLY\n✅ Done",
+    "NO_REPLY\n- Done",
+    "NO_REPLY\n—note",
+    "NO_REPLY\n: explanation",
+    "NO_REPLY\n**Done**",
+    'NO_REPLY\n"Hello"',
+    "NO_REPLY\n```ts\nconst done = true;\n```",
+  ])("matches newline-separated leading silent tokens: %j", (text) => {
+    expect(startsWithSilentToken(text)).toBe(true);
+  });
+
+  it.each([
+    "NO_REPLY NO_REPLY: explanation",
+    "NO_REPLY\nNO_REPLY: explanation",
+    "NO_REPLY\nNO_REPLY—note",
+    "NO_REPLY\nNO_REPLY-note",
+    "NO_REPLY\nNO_REPLY -- nope",
+    "\nNO_REPLY explanation",
+    "NO_REPLY\nNO_REPLY explanation",
+  ])("preserves repeated tokens before substantive punctuation: %j", (text) => {
+    expect(startsWithSilentToken(text)).toBe(false);
   });
 });
 

--- a/src/auto-reply/tokens.test.ts
+++ b/src/auto-reply/tokens.test.ts
@@ -215,14 +215,15 @@ describe("stripSilentToken", () => {
     expect(stripSilentToken("😄 NO_REPLY")).toBe("😄");
   });
 
-  it.each(["!", "?", ",", ";", ":"])(
-    "strips a trailing silent token without consuming sentence punctuation %j",
-    (punctuation) => {
-      expect(stripSilentToken(`Done as requested${punctuation}NO_REPLY`)).toBe(
-        `Done as requested${punctuation}`,
-      );
-    },
-  );
+  it.each([
+    "Done as requested!NO_REPLY",
+    "question?NO_REPLY",
+    "note,NO_REPLY",
+    "item;NO_REPLY",
+    "label:NO_REPLY",
+  ])("preserves punctuation-attached silent-token literals: %j", (text) => {
+    expect(stripSilentToken(text)).toBe(text);
+  });
 
   it("does not strip embedded token suffix without whitespace delimiter", () => {
     expect(stripSilentToken("interject.NO_REPLY")).toBe("interject.NO_REPLY");

--- a/src/auto-reply/tokens.ts
+++ b/src/auto-reply/tokens.ts
@@ -37,7 +37,10 @@ function getSilentTrailingRegex(token: string): RegExp {
     return cached;
   }
   const escaped = escapeRegExp(token);
-  const regex = new RegExp(`(?:^|\\s+|\\*+)${escaped}\\s*$`, "i");
+  // A full stop can also be part of a substantive dotted identifier, so it
+  // cannot safely delimit an unannotated sentinel. Preserve other sentence
+  // punctuation and consume repeated, whitespace-delimited sentinel tokens.
+  const regex = new RegExp(`(?:^|\\s+|\\*+|(?<=[!?,;:]))${escaped}(?:\\s+${escaped})*\\s*$`, "i");
   silentTrailingRegexByToken.set(token, regex);
   return regex;
 }
@@ -258,8 +261,9 @@ function getSilentLeadingRegex(token: string): RegExp {
     return cached;
   }
   const escaped = escapeRegExp(token);
-  // Match one or more leading occurrences of the token, each optionally followed by whitespace
-  const regex = new RegExp(`^(?:\\s*${escaped})+\\s*`, "i");
+  // Keep the final separator distinct: earlier blank lines or spacing between
+  // repeated sentinels do not establish a boundary for the visible remainder.
+  const regex = new RegExp(`^\\s*${escaped}((?:\\s*${escaped})*)(\\s*)`, "i");
   silentLeadingRegexByToken.set(token, regex);
   return regex;
 }
@@ -284,7 +288,16 @@ export function startsWithSilentToken(
   if (!text) {
     return false;
   }
-  return getSilentLeadingAttachedRegex(token).test(text);
+  if (getSilentLeadingAttachedRegex(token).test(text)) {
+    return true;
+  }
+  const leading = getSilentLeadingRegex(token).exec(text);
+  // Only the separator after the final sentinel establishes a boundary; a
+  // leading blank line must not turn same-line token mentions into controls.
+  if (!leading || !/[\r\n]/.test(leading[2] ?? "")) {
+    return false;
+  }
+  return text.slice(leading[0].length).trimStart().length > 0;
 }
 
 export function isSilentReplyPrefixText(

--- a/src/auto-reply/tokens.ts
+++ b/src/auto-reply/tokens.ts
@@ -37,10 +37,9 @@ function getSilentTrailingRegex(token: string): RegExp {
     return cached;
   }
   const escaped = escapeRegExp(token);
-  // A full stop can also be part of a substantive dotted identifier, so it
-  // cannot safely delimit an unannotated sentinel. Preserve other sentence
-  // punctuation and consume repeated, whitespace-delimited sentinel tokens.
-  const regex = new RegExp(`(?:^|\\s+|\\*+|(?<=[!?,;:]))${escaped}(?:\\s+${escaped})*\\s*$`, "i");
+  // Keep main's whitespace/Markdown boundaries: punctuation-attached tokens
+  // can be visible text. Consume repeated tokens only after a real delimiter.
+  const regex = new RegExp(`(?:^|\\s+|\\*+)${escaped}(?:\\s+${escaped})*\\s*$`, "i");
   silentTrailingRegexByToken.set(token, regex);
   return regex;
 }


### PR DESCRIPTION
Closes #103735.

## What Problem This Solves

Fixes an issue where users receiving a normal agent reply could see an internal `NO_REPLY` sentinel before the actual message when the sentinel was separated from the content by a newline. The same leak affected a final reply recovered after a gateway restart.

## Why This Change Was Made

Normalize leading silent sentinels only when the separator after the final repeated token contains a newline, and normalize repeated whitespace-delimited trailing sentinels at safe sentence boundaries. Keep ordinary same-line text, dotted identifiers, meaningful punctuation, Markdown, emoji, quoted strings, and code intact. Bare `.NO_REPLY` remains deliberately out of scope because a dotted identifier cannot be distinguished from a sentence without further context.

Thanks to @qingminglong for independently identifying the leading-newline case in #114127.

## User Impact

Users receive the intended reply without internal control tokens in both ordinary delivery and restart-recovered pending final delivery. Existing substantive messages and dotted identifiers are preserved.

## Evidence

- Fresh independently reproduced **current published head `a2d1a284adb712d9fe42c99f9276718d045c401c`** on dedicated Blacksmith Testbox `tbx_01kyj20x9j44asrtz7vpa2myb4`: **374 / 374 tests passed** across all eight shared-owner, ordinary-delivery, pending-final recovery, and sibling suites. [Exact-head Linux proof](https://github.com/openclaw/openclaw/actions/runs/30278689988); delegated timing JSON reports `exitCode=0`, and the one-shot lease stopped successfully.
- Fresh independent whole-branch `gpt-5.6-sol` **xhigh** review on that same exact head: **clean**, no actionable findings.
- The earlier-head validation below is retained as historical evidence; the current-head run above additionally proves the latest punctuation-boundary repair.

- Reproduced the reported failure against unchanged `main`: 20 targeted token, ordinary-delivery, and restart-recovery assertions failed while 76 existing and control assertions passed.
- Tested exact pushed head `ae41a60b72bb1075177da51aa4cb5a3362f814c1` on an isolated trusted Linux Testbox: **374 / 374 tests passed** across all eight actual shared-owner and sibling suites:
  - `src/auto-reply/tokens.test.ts` (82).
  - `src/auto-reply/reply/pending-final-delivery.test.ts` (35).
  - `src/infra/outbound/payloads.test.ts` (38).
  - `src/auto-reply/reply/block-streaming.test.ts` (6).
  - `src/auto-reply/reply/reply-utils.test.ts` (101).
  - `src/auto-reply/reply/route-reply.test.ts` (40).
  - `src/auto-reply/reply/dispatch-from-config.pending-final.test.ts` (5).
  - `src/auto-reply/reply/agent-runner-payloads.test.ts` (67).
- Directly executed both actual production entry points, `normalizeReplyPayload` and `sanitizePendingFinalDeliveryText`, against **16 independently checked reported, repeated-token, newline, emoji, Markdown, quoted, dotted-identifier, and punctuation cases** on that exact head; all passed.
- Re-verified the exact pushed Git SHA on a fresh isolated Linux Testbox before running the **complete `pnpm check:changed`: PASS**, including changed-file formatting, core and core-test type checks, lint, import-cycle/boundary checks, and repository guardrails.
- Independently ran **330 / 330 additional actual subagent, task-lifecycle, bounded skill-discovery, context-window, and terminal-outcome regression tests** against the same verified exact head.
- Fresh Codex branch autoreview: **clean**, no actionable findings.
- `git diff --check origin/main...HEAD`: clean.
- The repository-hosted exact-head required CI is reported separately by GitHub; a Testbox provisioning workflow is not represented as that required PR gate.
