### PR TITLE
feat(skills): enable self-learning review for Codex sessions

### DIFF
--- a/docs/tools/self-learning.md
+++ b/docs/tools/self-learning.md
@@ -132,8 +132,11 @@ Experience review is deliberately delayed and bounded:
 - If any agent or reply run is still active, review waits another 30 seconds.
 - Only one experience review runs at a time.
 - Delayed review is process-local Gateway work. The Gateway must remain running
-  through the idle window; one-shot local and CLI-backed runtimes do not retain
-  enough trajectory and tool-availability context to schedule it.
+  through the idle window. CLI-backed harnesses can schedule review only when
+  they report the resolved model, exact model-iteration count, and actual
+  `skill_workshop` availability. The Codex app-server harness reports those
+  facts for its `openai/*` sessions; runtimes with missing facts still fail
+  closed.
 
 The foreground answer is never delayed for learning. A failed or ineligible
 turn does not start experience review, although direct user corrections can
@@ -145,6 +148,12 @@ The background reviewer receives only the current turn, starting at its most
 recent user message. The rendered trajectory is capped at 60,000 characters;
 when necessary, OpenClaw keeps the first message and the newest evidence and
 marks the omitted middle.
+
+For Codex app-server sessions, OpenClaw counts unique upstream response
+completions as model iterations and uses the harness's frozen current-turn
+projection. The harness also attempts to mirror that projection into the agent's
+SQLite transcript before delayed review is scheduled; the reviewer does not
+need to reread the database.
 
 The reviewer reuses the resolved provider and model. It reuses the foreground
 auth profile when that identity is available and disables model fallbacks. The

--- a/extensions/codex/src/app-server/event-projector-usage.ts
+++ b/extensions/codex/src/app-server/event-projector-usage.ts
@@ -1,5 +1,5 @@
 import { normalizeUsage } from "openclaw/plugin-sdk/agent-harness-runtime";
-import { readNonNegativeInteger, readNumber } from "./event-projector-values.js";
+import { readNonNegativeInteger, readNumber, readString } from "./event-projector-values.js";
 import { isJsonObject, type JsonObject } from "./protocol.js";
 
 function readTokenCount(record: JsonObject, key: string): number | undefined {
@@ -109,4 +109,29 @@ export function normalizeCodexResponseTokenUsage(
       totalTokens,
     },
   };
+}
+
+export class CodexResponseCompletionProjection {
+  // Replayed notifications keep one upstream response equal to one model iteration.
+  private readonly responseIds = new Set<string>();
+  usage: ReturnType<typeof normalizeUsage>;
+
+  get modelIterations(): number {
+    return this.responseIds.size;
+  }
+
+  clear(): void {
+    this.usage = undefined;
+  }
+
+  record(params: JsonObject): void {
+    const responseId = readString(params, "responseId");
+    if (responseId) {
+      this.responseIds.add(responseId);
+    }
+    const usage = isJsonObject(params.usage) ? params.usage : undefined;
+    // Every provider completion replaces the prior response snapshot. A final
+    // response with missing or malformed usage must leave freshness unknown.
+    this.usage = usage ? normalizeCodexResponseTokenUsage(usage) : undefined;
+  }
 }

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -29,7 +29,7 @@ import { buildCodexMessagesSnapshot } from "./event-projector-snapshot.js";
 import { CodexToolProgressProjection } from "./event-projector-tool-progress.js";
 import { CodexToolTranscriptProjection } from "./event-projector-tool-transcript.js";
 import {
-  normalizeCodexResponseTokenUsage,
+  CodexResponseCompletionProjection,
   normalizeCodexThreadTokenUsage,
   projectCodexThreadUsageUpdate,
 } from "./event-projector-usage.js";
@@ -106,7 +106,7 @@ export class CodexAppServerEventProjector {
   private synthesizedMissingToolResultError: string | null = null;
   private aborted = false;
   private tokenUsage: ReturnType<typeof normalizeCodexThreadTokenUsage>;
-  private responseUsage: ReturnType<typeof normalizeCodexResponseTokenUsage>;
+  private readonly responseCompletions = new CodexResponseCompletionProjection();
   private completedCompactionCount = 0;
   private lastTranscriptTimestamp = 0;
 
@@ -288,13 +288,13 @@ export class CodexAppServerEventProjector {
         await this.handleTurnCompleted(params);
         break;
       case "rawResponse/completed":
-        this.handleRawResponseCompleted(params);
+        this.responseCompletions.record(params);
         break;
       case "rawResponseItem/completed":
         await this.handleRawResponseItemCompleted(params);
         break;
       case "error":
-        this.responseUsage = undefined;
+        this.responseCompletions.clear();
         if (params.willRetry === true) {
           break;
         }
@@ -334,7 +334,9 @@ export class CodexAppServerEventProjector {
     // A terminal timeout must not publish exact usage, but the timeout watcher
     // can still recover a completed assistant. Keep the snapshot masked until
     // recovery clears the abort instead of destroying it in markTimedOut().
-    const projectedUsage = this.aborted ? this.tokenUsage : (this.responseUsage ?? this.tokenUsage);
+    const projectedUsage = this.aborted
+      ? this.tokenUsage
+      : (this.responseCompletions.usage ?? this.tokenUsage);
     const hasAssistantItemText = this.assistantProjection.hasAssistantItemTextForSynthesis();
     const legacyFailClosed =
       !this.completedTurn || this.completedTurn.status !== "completed" || hasAssistantItemText;
@@ -416,6 +418,9 @@ export class CodexAppServerEventProjector {
       ...(agentHarnessResultClassification ? { agentHarnessResultClassification } : {}),
       bootstrapPromptWarningSignaturesSeen: this.params.bootstrapPromptWarningSignaturesSeen,
       bootstrapPromptWarningSignature: this.params.bootstrapPromptWarningSignature,
+      ...(this.responseCompletions.modelIterations > 0
+        ? { modelIterations: this.responseCompletions.modelIterations }
+        : {}),
       messagesSnapshot,
       assistantTexts,
       toolMetas,
@@ -483,7 +488,7 @@ export class CodexAppServerEventProjector {
 
   markAborted(): void {
     this.aborted = true;
-    this.responseUsage = undefined;
+    this.responseCompletions.clear();
   }
 
   isCompacting(): boolean {
@@ -594,13 +599,6 @@ export class CodexAppServerEventProjector {
     });
   }
 
-  private handleRawResponseCompleted(params: JsonObject): void {
-    const usage = isJsonObject(params.usage) ? params.usage : undefined;
-    // Every provider completion replaces the prior response snapshot. A final
-    // response with missing or malformed usage must leave freshness unknown.
-    this.responseUsage = usage ? normalizeCodexResponseTokenUsage(usage) : undefined;
-  }
-
   private async handleTurnCompleted(params: JsonObject): Promise<void> {
     const turn = readCodexTurn(params.turn);
     if (!turn || turn.id !== this.turnId) {
@@ -608,7 +606,7 @@ export class CodexAppServerEventProjector {
     }
     this.completedTurn = turn;
     if (turn.status !== "completed") {
-      this.responseUsage = undefined;
+      this.responseCompletions.clear();
     }
     if (turn.status === "failed") {
       const usageLimitMessage = formatCodexUsageLimitErrorMessage({

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -334,9 +334,8 @@ export class CodexAppServerEventProjector {
     // A terminal timeout must not publish exact usage, but the timeout watcher
     // can still recover a completed assistant. Keep the snapshot masked until
     // recovery clears the abort instead of destroying it in markTimedOut().
-    const projectedUsage = this.aborted
-      ? this.tokenUsage
-      : (this.responseCompletions.usage ?? this.tokenUsage);
+    const completedUsage = this.responseCompletions.usage ?? this.tokenUsage;
+    const projectedUsage = this.aborted ? this.tokenUsage : completedUsage;
     const hasAssistantItemText = this.assistantProjection.hasAssistantItemTextForSynthesis();
     const legacyFailClosed =
       !this.completedTurn || this.completedTurn.status !== "completed" || hasAssistantItemText;

--- a/extensions/codex/src/app-server/event-projector.usage.test.ts
+++ b/extensions/codex/src/app-server/event-projector.usage.test.ts
@@ -83,6 +83,18 @@ describe("CodexAppServerEventProjector usage projection", () => {
     });
   });
 
+  it("counts unique upstream responses as model iterations", async () => {
+    const projector = await createProjector();
+
+    for (const responseId of ["response-1", "response-1", "response-2"]) {
+      await projector.handleNotification(
+        forCurrentTurn("rawResponse/completed", { responseId, usage: null }),
+      );
+    }
+
+    expect(projector.buildResult(buildEmptyToolTelemetry()).modelIterations).toBe(2);
+  });
+
   it("keeps cumulative-only thread usage unknown", async () => {
     const projector = await createProjector();
 

--- a/extensions/codex/src/app-server/run-attempt-finalize.ts
+++ b/extensions/codex/src/app-server/run-attempt-finalize.ts
@@ -17,6 +17,7 @@ import {
   resolveCodexAppServerReplayBlockedReason,
 } from "./attempt-results.js";
 import { attemptTerminal, type EmbeddedRunAttemptResult } from "./attempt-terminal.js";
+import { flattenCodexDynamicToolFunctions } from "./protocol.js";
 import { readCodexRateLimitsRevision, readRecentCodexRateLimits } from "./rate-limit-cache.js";
 import type { CodexAttemptActiveTurn } from "./run-attempt-active-turn.js";
 import type { CodexAttemptLifecycleController } from "./run-attempt-lifecycle-controller.js";
@@ -433,7 +434,31 @@ export async function finalizeCodexAttempt(
       ...(finalPromptError ? { error: formatErrorMessage(finalPromptError) } : {}),
       durationMs: Date.now() - attemptStartedAt,
     },
-    ctx: hookContext,
+    ctx: {
+      ...hookContext,
+      modelProviderId: resourceState.thread.modelProvider ?? effectiveRuntimeProviderId,
+      modelId: resourceState.thread.model ?? effectiveRuntimeModelId,
+      authProfileId: resourceState.thread.authProfileId ?? startupAuthProfileId,
+      modelIterations: result.modelIterations ?? 0,
+      skillWorkshopAvailable: flattenCodexDynamicToolFunctions(
+        attemptTools.toolBridge.availableSpecs,
+      ).some((tool) => tool.name === "skill_workshop"),
+      compacted: (result.compactionCount ?? 0) > 0,
+      messageChannel: params.messageChannel,
+      messageProvider: params.messageProvider,
+      chatType: params.chatType,
+      agentAccountId: params.agentAccountId,
+      groupId: params.groupId,
+      groupChannel: params.groupChannel,
+      groupSpace: params.groupSpace,
+      memberRoleIds: params.memberRoleIds,
+      spawnedBy: params.spawnedBy,
+      senderId: params.senderId ?? undefined,
+      senderName: params.senderName,
+      senderUsername: params.senderUsername,
+      senderE164: params.senderE164,
+      senderIsOwner: params.senderIsOwner,
+    },
     hookRunner,
   });
   state.shouldDelayNativeHookRelayUnregister =

--- a/src/agents/embedded-agent-runner/run/types.ts
+++ b/src/agents/embedded-agent-runner/run/types.ts
@@ -240,6 +240,8 @@ export type EmbeddedRunAttemptResult = {
   bootstrapPromptWarningSignature?: string;
   systemPromptReport?: SessionSystemPromptReport;
   finalPromptText?: string;
+  /** Exact provider-response count when the harness can observe model iterations directly. */
+  modelIterations?: number;
   messagesSnapshot: AgentMessage[];
   /**
    * Complete application transcript frozen through a settled tool boundary.

--- a/src/agents/harness/agent-end-side-effects.ts
+++ b/src/agents/harness/agent-end-side-effects.ts
@@ -17,6 +17,7 @@ type BaseAgentEndSideEffectsParams = Parameters<typeof runAgentHarnessAgentEndHo
 type AgentEndSideEffectsParams = Omit<BaseAgentEndSideEffectsParams, "ctx"> & {
   ctx: BaseAgentEndSideEffectsParams["ctx"] & {
     authProfileId?: string;
+    modelIterations?: number;
     skillWorkshopAvailable?: boolean;
     compacted?: boolean;
     messageChannel?: string | null;

--- a/src/skills/workshop/experience-review.test.ts
+++ b/src/skills/workshop/experience-review.test.ts
@@ -19,6 +19,7 @@ function completedRun(
     skillWorkshopAvailable?: boolean;
     compacted?: boolean;
     modelMetadata?: boolean;
+    modelIterations?: number;
   } = {},
 ): SkillExperienceReviewParams {
   const iterations = options.iterations ?? 10;
@@ -53,6 +54,9 @@ function completedRun(
             authProfileId: "openai:work",
           }),
       skillWorkshopAvailable: options.skillWorkshopAvailable ?? true,
+      ...(options.modelIterations === undefined
+        ? {}
+        : { modelIterations: options.modelIterations }),
       compacted: options.compacted,
       trigger: "user",
     },
@@ -89,6 +93,36 @@ describe("skill experience review scheduler", () => {
       ctx: { authProfileId: "openai:work" },
     });
     expect(runReview.mock.calls[0]?.[0]).not.toHaveProperty("event");
+    scheduler.clear();
+  });
+
+  it("uses exact harness iterations for a Codex-style projected trajectory", async () => {
+    vi.useFakeTimers();
+    const runReview = vi.fn().mockResolvedValue(undefined);
+    const scheduler = createSkillExperienceReviewScheduler({
+      isSystemActive: () => false,
+      runReview,
+    });
+
+    scheduler.schedule(completedRun({ iterations: 1, modelIterations: 10 }));
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    expect(runReview).toHaveBeenCalledWith(expect.objectContaining({ modelIterations: 10 }));
+    scheduler.clear();
+  });
+
+  it("does not infer iterations when a harness explicitly reports none", async () => {
+    vi.useFakeTimers();
+    const runReview = vi.fn().mockResolvedValue(undefined);
+    const scheduler = createSkillExperienceReviewScheduler({
+      isSystemActive: () => false,
+      runReview,
+    });
+
+    scheduler.schedule(completedRun({ iterations: 10, modelIterations: 0 }));
+    await vi.runAllTimersAsync();
+
+    expect(runReview).not.toHaveBeenCalled();
     scheduler.clear();
   });
 

--- a/src/skills/workshop/experience-review.ts
+++ b/src/skills/workshop/experience-review.ts
@@ -40,6 +40,7 @@ type ExperienceReviewAgentContext = {
   modelProviderId?: string;
   modelId?: string;
   authProfileId?: string;
+  modelIterations?: number;
   skillWorkshopAvailable?: boolean;
   compacted?: boolean;
   trigger?: string;
@@ -298,7 +299,15 @@ export function createSkillExperienceReviewScheduler(deps: ExperienceReviewSched
       }
 
       const turnMessages = currentTurnMessages(params.event.messages);
-      const modelIterations = countModelIterations(turnMessages);
+      // Native harnesses can report exact provider iterations even when their
+      // transcript projection has a different assistant-message cardinality.
+      const reportedModelIterations = params.ctx.modelIterations;
+      const modelIterations =
+        reportedModelIterations === undefined
+          ? countModelIterations(turnMessages)
+          : Number.isSafeInteger(reportedModelIterations) && reportedModelIterations >= 0
+            ? reportedModelIterations
+            : 0;
       if (params.event.success && modelIterations >= EXPERIENCE_REVIEW_MIN_MODEL_ITERATIONS) {
         if (!existing && pendingBySession.size >= EXPERIENCE_REVIEW_MAX_PENDING) {
           const oldest = pendingBySession.entries().next().value as


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where self-learning was enabled but successful, substantial `openai/*` sessions running through the Codex app-server harness never scheduled delayed experience review. Deterministic correction capture still worked, but this mainstream OpenAI-key route could not autonomously propose reusable procedures.

## Why This Change Was Made

The Codex harness now reports the runtime facts the shared scheduler already requires: its resolved thread provider/model and auth profile, actual `skill_workshop` exposure, compaction state, and an exact model-iteration count derived from unique upstream `rawResponse/completed` events. It continues to use the harness's frozen current-turn transcript projection, which is mirrored to SQLite before agent-end scheduling; no new transcript reader, config surface, gateway protocol, or schema change is introduced.

Unknown or incomplete runtimes still fail closed. In particular, an explicitly missing Codex response count is reported as zero, and delayed review remains ineligible when model identity or Workshop availability is absent.

## User Impact

Operators who enable self-learning can now receive delayed Skill Workshop proposals after eligible Codex app-server sessions serving `openai/*` models. The existing success, ten-iteration, idle-window, sandbox, tool-policy, and compaction gates remain unchanged.

## Evidence

- Live baseline before this change: Codex app-server sessions never scheduled experience review, while deterministic correction capture worked.
- `node scripts/run-vitest.mjs src/skills/workshop/experience-review.test.ts extensions/codex/src/app-server/event-projector.usage.test.ts`: 29 tests passed on the rebased head.
- `node scripts/check-changed.mjs -- <9 changed files>`: passed all selected typecheck, core/extension lint, SDK surface, max-lines, import-cycle, schema, and database-first guards on Blacksmith Testbox ([run 30254863840](https://github.com/openclaw/openclaw/actions/runs/30254863840)).
- Required broad local command `node scripts/run-vitest.mjs src/skills/workshop extensions/codex` exposed the existing order-dependent Codex test `uses human approval instead of Guardian for auto exec on custom model providers`; that exact test passed when isolated. Runtime-artifact tests also required unsetting an ambient `NODE_PATH` and then passed 4/4 in isolation.
- Autoreview: clean, no accepted/actionable findings.

AI-assisted with Codex. I reviewed the implementation and understand the runtime/result, tool-availability, transcript, and fail-closed boundaries changed here.
