### PR TITLE
fix(control-ui): restore authenticated assistant profile avatars

### DIFF
--- a/ui/src/components/agent-select.test.ts
+++ b/ui/src/components/agent-select.test.ts
@@ -388,18 +388,36 @@ it("aborts a stalled local avatar body after the request deadline", async () => 
   }
 });
 
-it("renders a local avatar image when token auth is not active", async () => {
+it("fetches a local avatar image without a header when token auth is not active", async () => {
+  vi.stubGlobal(
+    "URL",
+    class extends URL {
+      static override createObjectURL = vi.fn(() => "blob:unauthenticated-avatar");
+      static override revokeObjectURL = vi.fn();
+    },
+  );
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok: true,
+    blob: async () => new Blob(["avatar"]),
+  });
+  vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
   const element = await createAgentSelect({
     authToken: null,
     identityById: { alpha: createIdentity("alpha", { avatar: "/avatar/alpha" }) },
   });
 
   try {
-    expect(element.querySelector<HTMLImageElement>("img.agent-select__avatar")?.src).toContain(
-      "/avatar/alpha",
-    );
+    expect(fetchMock).toHaveBeenCalledWith("/avatar/alpha", {
+      signal: expect.any(AbortSignal),
+    });
+    await waitForFast(() => {
+      expect(
+        element.querySelector<HTMLImageElement>("img.agent-select__avatar")?.getAttribute("src"),
+      ).toBe("blob:unauthenticated-avatar");
+    });
   } finally {
     element.remove();
+    vi.unstubAllGlobals();
   }
 });
 

--- a/ui/src/components/agent-select.test.ts
+++ b/ui/src/components/agent-select.test.ts
@@ -12,7 +12,9 @@ customElements.define(AGENT_SELECT_TEST_TAG, class extends AgentSelect {});
 
 afterEach(async () => {
   document.body.replaceChildren();
-  await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  await new Promise<void>((resolve) => {
+    setTimeout(resolve, 0);
+  });
 });
 
 type AgentSelectElement = HTMLElement & {

--- a/ui/src/components/agent-select.test.ts
+++ b/ui/src/components/agent-select.test.ts
@@ -1,6 +1,6 @@
 /* @vitest-environment jsdom */
 
-import { expect, it, vi } from "vitest";
+import { afterEach, expect, it, vi } from "vitest";
 import type { AgentIdentityResult, GatewayAgentRow } from "../api/types.ts";
 import { i18n, t } from "../i18n/index.ts";
 import { waitForFast } from "../test-helpers/wait-for.ts";
@@ -9,6 +9,11 @@ import { AgentSelect, type AgentSelectOption } from "./agent-select.ts";
 const AGENT_SELECT_TEST_TAG = `test-openclaw-agent-select-${crypto.randomUUID()}`;
 
 customElements.define(AGENT_SELECT_TEST_TAG, class extends AgentSelect {});
+
+afterEach(async () => {
+  document.body.replaceChildren();
+  await new Promise<void>((resolve) => setTimeout(resolve, 0));
+});
 
 type AgentSelectElement = HTMLElement & {
   options: AgentSelectOption[];
@@ -179,7 +184,7 @@ it("fetches local avatars with the bearer credential when token auth is active",
     expect(createObjectURL).toHaveBeenCalledTimes(1);
 
     element.remove();
-    expect(revokeObjectURL).toHaveBeenCalledWith("blob:agent-avatar");
+    await waitForFast(() => expect(revokeObjectURL).toHaveBeenCalledWith("blob:agent-avatar"));
   } finally {
     element.remove();
     vi.unstubAllGlobals();
@@ -252,6 +257,7 @@ it("aborts the stale request on auth rotation without duplicating the current fe
     });
   });
   vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+  const avatarCalls = () => fetchMock.mock.calls.filter(([url]) => url === "/avatar/alpha");
 
   const element = await createAgentSelect({
     authToken: "tok",
@@ -259,14 +265,14 @@ it("aborts the stale request on auth rotation without duplicating the current fe
   });
 
   try {
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(avatarCalls()).toHaveLength(1);
     element.authToken = "tok2";
     await element.updateComplete;
-    await waitForFast(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    await waitForFast(() => expect(avatarCalls()).toHaveLength(2));
 
-    expect(pending[0]?.signal.aborted).toBe(true);
+    await waitForFast(() => expect(pending[0]?.signal.aborted).toBe(true));
     expect(
-      fetchMock.mock.calls.map(([, init]) => new Headers(init?.headers).get("Authorization")),
+      avatarCalls().map(([, init]) => new Headers(init?.headers).get("Authorization")),
     ).toEqual(["Bearer tok", "Bearer tok2"]);
 
     // Let the canceled request's rejection settle, then force another render while
@@ -274,7 +280,7 @@ it("aborts the stale request on auth rotation without duplicating the current fe
     await Promise.resolve();
     element.identityById = { ...element.identityById };
     await element.updateComplete;
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(avatarCalls()).toHaveLength(2);
 
     pending[1]?.resolve({
       ok: true,
@@ -337,6 +343,7 @@ it("aborts a stalled local avatar fetch after the request deadline", async () =>
     expect(vi.getTimerCount()).toBe(0);
   } finally {
     element.remove();
+    await vi.runOnlyPendingTimersAsync();
     vi.useRealTimers();
     vi.unstubAllGlobals();
   }
@@ -383,6 +390,7 @@ it("aborts a stalled local avatar body after the request deadline", async () => 
     expect(vi.getTimerCount()).toBe(0);
   } finally {
     element.remove();
+    await vi.runOnlyPendingTimersAsync();
     vi.useRealTimers();
     vi.unstubAllGlobals();
   }

--- a/ui/src/components/agent-select.ts
+++ b/ui/src/components/agent-select.ts
@@ -86,11 +86,6 @@ export class AgentSelect extends OpenClawLightDomElement {
   }
 
   protected override willUpdate(changed: PropertyValues<this>) {
-    // Cached blobs and failures belong to the credential that fetched them;
-    // a rotated token must refetch with the current authorization.
-    if (changed.has("authToken")) {
-      this.avatarLoader.reset();
-    }
     if (changed.has("disabled") && this.disabled) {
       const dropdown = this.querySelector<HTMLElement & { open: boolean }>("wa-dropdown");
       if (dropdown) {
@@ -153,6 +148,10 @@ export class AgentSelect extends OpenClawLightDomElement {
   };
 
   override render() {
+    return this.avatarLoader.withActiveRoutes(() => this.renderContent());
+  }
+
+  private renderContent() {
     const selectedOption = this.options.find((option) => option.value === this.value);
     const missingValueOption: AgentSelectOption | null =
       !selectedOption && this.value

--- a/ui/src/components/agent-select.ts
+++ b/ui/src/components/agent-select.ts
@@ -7,6 +7,7 @@ import { ref } from "lit/directives/ref.js";
 import type { AgentIdentityResult, GatewayAgentRow } from "../api/types.ts";
 import { t } from "../i18n/index.ts";
 import { resolveAgentTextAvatar } from "../lib/agents/display.ts";
+import { AuthenticatedAvatarRouteLoader } from "../lib/authenticated-avatar-route.ts";
 import { deriveAvatarInitial, resolveAgentAvatarUrl } from "../lib/avatar.ts";
 import { OpenClawLightDomElement } from "../lit/openclaw-element.ts";
 import { icons } from "./icons.ts";
@@ -23,11 +24,6 @@ export type AgentSelectOption = {
 };
 
 type WebAwesomeSelectEvent = Event & { detail: { item: Element } };
-type AvatarFetch = { authToken: string; controller: AbortController };
-
-/** Bound local avatar fetches so a stalled Control UI media route cannot pin pending state forever. */
-const AGENT_SELECT_AVATAR_FETCH_TIMEOUT_MS = 30_000;
-
 export function renderAgentSelectAvatar(
   option: AgentSelectOption,
   identity: AgentIdentityResult | null = null,
@@ -78,11 +74,14 @@ export class AgentSelect extends OpenClawLightDomElement {
   @property({ attribute: false }) onSelect: (value: string) => void = () => {};
   @property({ attribute: false }) onCreateAgent: (() => void) | null = null;
 
-  private readonly avatarBlobUrlByRoute = new Map<string, string>();
-  private readonly avatarFetchByRoute = new Map<string, AvatarFetch>();
+  private readonly avatarLoader = new AuthenticatedAvatarRouteLoader(() => {
+    if (this.isConnected) {
+      this.requestUpdate();
+    }
+  });
 
   override disconnectedCallback() {
-    this.resetAvatarState();
+    this.avatarLoader.reset();
     super.disconnectedCallback();
   }
 
@@ -90,7 +89,7 @@ export class AgentSelect extends OpenClawLightDomElement {
     // Cached blobs and failures belong to the credential that fetched them;
     // a rotated token must refetch with the current authorization.
     if (changed.has("authToken")) {
-      this.resetAvatarState();
+      this.avatarLoader.reset();
     }
     if (changed.has("disabled") && this.disabled) {
       const dropdown = this.querySelector<HTMLElement & { open: boolean }>("wa-dropdown");
@@ -100,95 +99,14 @@ export class AgentSelect extends OpenClawLightDomElement {
     }
   }
 
-  private resetAvatarState() {
-    for (const request of this.avatarFetchByRoute.values()) {
-      request.controller.abort();
-    }
-    for (const blobUrl of this.avatarBlobUrlByRoute.values()) {
-      if (blobUrl) {
-        URL.revokeObjectURL(blobUrl);
-      }
-    }
-    this.avatarBlobUrlByRoute.clear();
-    this.avatarFetchByRoute.clear();
-  }
-
-  private ensureLocalAvatar(url: string, authToken: string) {
-    if (this.avatarFetchByRoute.has(url)) {
-      return;
-    }
-    const request: AvatarFetch = { authToken, controller: new AbortController() };
-    this.avatarFetchByRoute.set(url, request);
-    void this.fetchLocalAvatarBlobUrl(url, request).then((blobUrl) => {
-      // Rotation can start a replacement before the aborted request settles.
-      // Only the request still owning this route may clear or cache its state.
-      if (this.avatarFetchByRoute.get(url) !== request) {
-        if (blobUrl) {
-          URL.revokeObjectURL(blobUrl);
-        }
-        return;
-      }
-      if (!this.isConnected || this.authToken !== authToken) {
-        this.avatarFetchByRoute.delete(url);
-        if (blobUrl) {
-          URL.revokeObjectURL(blobUrl);
-        }
-        return;
-      }
-      // Cache the result (including empty miss) before clearing pending so a
-      // concurrent re-render cannot start a second unbounded fetch for the same URL.
-      this.avatarBlobUrlByRoute.set(url, blobUrl);
-      this.avatarFetchByRoute.delete(url);
-      if (blobUrl) {
-        this.requestUpdate();
-      }
-    });
-  }
-
-  private async fetchLocalAvatarBlobUrl(url: string, request: AvatarFetch): Promise<string> {
-    const timeout = setTimeout(
-      () =>
-        request.controller.abort(new DOMException("agent avatar fetch timed out", "TimeoutError")),
-      AGENT_SELECT_AVATAR_FETCH_TIMEOUT_MS,
-    );
-    try {
-      const res = await fetch(url, {
-        headers: { Authorization: `Bearer ${request.authToken}` },
-        signal: request.controller.signal,
-      });
-      if (!res.ok) {
-        return "";
-      }
-      return URL.createObjectURL(await res.blob());
-    } catch {
-      // Timeouts and transport failures share the empty-string miss path so the
-      // picker keeps the text fallback instead of leaving avatarRoutesPending set.
-      return "";
-    } finally {
-      clearTimeout(timeout);
-    }
-  }
-
   private renderAvatar(option: AgentSelectOption) {
     // agents.list projects local files into validated avatarUrl data URLs. Only
     // Agents settings supplies identity.get /avatar routes together with authToken.
     const agentId = option.agent?.id;
     const identity = agentId ? (this.identityById[agentId] ?? null) : null;
     const url = option.agent ? resolveAgentAvatarUrl(option.agent, identity) : null;
-    const imageUrl = url ? this.resolveRenderableAvatarUrl(url) : null;
+    const imageUrl = url ? this.avatarLoader.resolve(url, this.authToken) : null;
     return renderAgentSelectAvatar(option, identity, imageUrl);
-  }
-
-  private resolveRenderableAvatarUrl(url: string): string | null {
-    if (!this.authToken || !url.startsWith("/")) {
-      return url;
-    }
-    const cached = this.avatarBlobUrlByRoute.get(url);
-    if (cached !== undefined) {
-      return cached || null;
-    }
-    this.ensureLocalAvatar(url, this.authToken);
-    return null;
   }
 
   private readonly handleSelect = (event: WebAwesomeSelectEvent) => {

--- a/ui/src/components/app-sidebar-render.ts
+++ b/ui/src/components/app-sidebar-render.ts
@@ -7,6 +7,7 @@ import {
 } from "../app-navigation.ts";
 import { isSessionRouteId } from "../app-route-paths.ts";
 import { sessionHasPendingApproval } from "../app/approval-presentation.ts";
+import { resolveControlUiAuthToken } from "../app/control-ui-auth.ts";
 import { isNativeWebChromeHost } from "../app/native-web-chrome.ts";
 import { readPresenceEntries, resolveCurrentSelfUser } from "../app/user-profile.ts";
 import { CONTROL_UI_BUILD_INFO } from "../build-info.ts";
@@ -84,6 +85,20 @@ export function renderAppSidebarBrand(host: AppSidebarRenderHost) {
   const cardName =
     cardIdentity?.name?.trim() || (cardAgent ? normalizeAgentLabel(cardAgent) : cardAgentId);
   const approvalCount = host.sessionData.approvalBadgeSnapshot().agentCounts.get(cardAgentId) ?? 0;
+  const gateway = host.context?.gateway;
+  const avatarAuthToken = gateway
+    ? resolveControlUiAuthToken({
+        hello: gateway.snapshot.hello,
+        settings: { token: gateway.connection.token },
+        password: gateway.connection.password,
+      })
+    : null;
+  const avatarAuthReady = Boolean(
+    gateway &&
+    (gateway.snapshot.hello ||
+      gateway.connection.token.trim() ||
+      gateway.connection.password.trim()),
+  );
   const cardAvatarText =
     (cardAgent ? resolveAgentTextAvatar(cardAgent, cardIdentity) : cardIdentity?.emoji) ??
     (deriveAvatarInitial(cardName || cardAgentId) || "?");
@@ -97,6 +112,8 @@ export function renderAppSidebarBrand(host: AppSidebarRenderHost) {
         .avatarUrl=${cardAgent
           ? resolveAgentAvatarUrl(cardAgent, cardIdentity)
           : cardIdentity?.avatar}
+        .authToken=${avatarAuthToken}
+        .avatarAuthReady=${avatarAuthReady}
         .avatarText=${cardAvatarText}
         .subtitle=${host.agentChipSubtitle(cardAgentId)}
         .menuOpen=${host.sidebarMenus.agentMenuPosition !== null}

--- a/ui/src/components/app-sidebar-render.ts
+++ b/ui/src/components/app-sidebar-render.ts
@@ -85,7 +85,7 @@ export function renderAppSidebarBrand(host: AppSidebarRenderHost) {
   const cardName =
     cardIdentity?.name?.trim() || (cardAgent ? normalizeAgentLabel(cardAgent) : cardAgentId);
   const approvalCount = host.sessionData.approvalBadgeSnapshot().agentCounts.get(cardAgentId) ?? 0;
-  const gateway = host.context?.gateway;
+  const gateway = host.sessionDataContext?.gateway;
   const avatarAuthToken = gateway
     ? resolveControlUiAuthToken({
         hello: gateway.snapshot.hello,

--- a/ui/src/components/sidebar-agent-card.ts
+++ b/ui/src/components/sidebar-agent-card.ts
@@ -1,4 +1,4 @@
-import { html, nothing, type PropertyValues } from "lit";
+import { html, nothing } from "lit";
 import { property } from "lit/decorators.js";
 import { t } from "../i18n/index.ts";
 import { AuthenticatedAvatarRouteLoader } from "../lib/authenticated-avatar-route.ts";
@@ -35,13 +35,11 @@ class SidebarAgentCard extends OpenClawLightDomContentsElement {
     super.disconnectedCallback();
   }
 
-  protected override willUpdate(changed: PropertyValues<this>) {
-    if (changed.has("authToken") || changed.has("avatarAuthReady")) {
-      this.avatarLoader.reset();
-    }
+  override render() {
+    return this.avatarLoader.withActiveRoutes(() => this.renderContent());
   }
 
-  override render() {
+  private renderContent() {
     const avatarUrl = this.avatarUrl?.startsWith("/")
       ? this.avatarAuthReady
         ? this.avatarLoader.resolve(this.avatarUrl, this.authToken)

--- a/ui/src/components/sidebar-agent-card.ts
+++ b/ui/src/components/sidebar-agent-card.ts
@@ -1,6 +1,7 @@
-import { html, nothing } from "lit";
+import { html, nothing, type PropertyValues } from "lit";
 import { property } from "lit/decorators.js";
 import { t } from "../i18n/index.ts";
+import { AuthenticatedAvatarRouteLoader } from "../lib/authenticated-avatar-route.ts";
 import { OpenClawLightDomContentsElement } from "../lit/openclaw-element.ts";
 import { icons } from "./icons.ts";
 import "./tooltip.ts";
@@ -11,6 +12,8 @@ import "./tooltip.ts";
 class SidebarAgentCard extends OpenClawLightDomContentsElement {
   @property({ attribute: false }) agentName = "";
   @property({ attribute: false }) avatarUrl: string | null = null;
+  @property({ attribute: false }) authToken: string | null = null;
+  @property({ attribute: false }) avatarAuthReady = false;
   @property({ attribute: false }) avatarText = "";
   @property({ attribute: false }) subtitle = "";
   @property({ attribute: false }) menuOpen = false;
@@ -21,7 +24,29 @@ class SidebarAgentCard extends OpenClawLightDomContentsElement {
   @property({ attribute: false }) switcherAvailable = false;
   @property({ attribute: false }) onToggleMenu?: (trigger: HTMLElement) => void;
 
+  private readonly avatarLoader = new AuthenticatedAvatarRouteLoader(() => {
+    if (this.isConnected) {
+      this.requestUpdate();
+    }
+  });
+
+  override disconnectedCallback() {
+    this.avatarLoader.reset();
+    super.disconnectedCallback();
+  }
+
+  protected override willUpdate(changed: PropertyValues<this>) {
+    if (changed.has("authToken") || changed.has("avatarAuthReady")) {
+      this.avatarLoader.reset();
+    }
+  }
+
   override render() {
+    const avatarUrl = this.avatarUrl?.startsWith("/")
+      ? this.avatarAuthReady
+        ? this.avatarLoader.resolve(this.avatarUrl, this.authToken)
+        : null
+      : this.avatarUrl;
     const menuLabel = this.switcherAvailable
       ? t("agentChip.switchAgent")
       : t("agentChip.menuLabel");
@@ -42,9 +67,9 @@ class SidebarAgentCard extends OpenClawLightDomContentsElement {
           @click=${(event: MouseEvent) => this.onToggleMenu?.(event.currentTarget as HTMLElement)}
         >
           <span class="sidebar-agent-card__avatar">
-            ${this.avatarUrl
+            ${avatarUrl
               ? html`<img
-                  src=${this.avatarUrl}
+                  src=${avatarUrl}
                   alt=""
                   aria-hidden="true"
                   loading="lazy"

--- a/ui/src/e2e/profile-page.e2e.test.ts
+++ b/ui/src/e2e/profile-page.e2e.test.ts
@@ -54,12 +54,13 @@ const testPresenceUsers = [
 ];
 
 suite.define(() => {
-  async function openProfilePage(page: Page) {
+  async function openProfilePage(page: Page, methodResponses: Record<string, unknown> = {}) {
     const gateway = await installMockGateway(page, {
       basePath,
       presenceUsers: testPresenceUsers,
       methodResponses: {
         "users.self": { profile: testProfile },
+        ...methodResponses,
       },
     });
     const response = await page.goto(new URL(profilePath, suite.server.baseUrl).href);
@@ -87,6 +88,81 @@ suite.define(() => {
         0,
       );
     });
+  });
+
+  it("renders the protected assistant avatar through an authenticated blob fetch", async () => {
+    await suite.withPage(
+      {
+        ...(captureUiProof
+          ? { recordVideo: { dir: proofDir, size: { width: 1280, height: 800 } } }
+          : {}),
+        viewport: { width: 1280, height: 800 },
+      },
+      async ({ page }) => {
+        const avatarRequests: Array<{ authorization?: string; resourceType: string; url: string }> =
+          [];
+        const avatarUrl = new URL(`${basePath}/avatar/main`, suite.server.baseUrl).href;
+        await page.route(`**${basePath}/avatar/main`, async (route) => {
+          const authorization = route.request().headers().authorization;
+          avatarRequests.push({
+            authorization,
+            resourceType: route.request().resourceType(),
+            url: route.request().url(),
+          });
+          if (authorization !== "Bearer e2e-device-token") {
+            await route.fulfill({ status: 401 });
+            return;
+          }
+          await route.fulfill({
+            body: `<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64"><circle cx="32" cy="32" r="28" fill="#ef4e2f"/><circle cx="23" cy="27" r="4" fill="white"/><circle cx="41" cy="27" r="4" fill="white"/><path d="M20 42c8 6 16 6 24 0" fill="none" stroke="white" stroke-width="4" stroke-linecap="round"/></svg>`,
+            contentType: "image/svg+xml",
+            status: 200,
+          });
+        });
+        const gateway = await openProfilePage(page, {
+          "agent.identity.get": {
+            agentId: "main",
+            name: "Main agent",
+            avatar: `${basePath}/avatar/main`,
+            avatarStatus: "local",
+          },
+          "agents.list": {
+            defaultId: "main",
+            agents: [
+              {
+                id: "main",
+                identity: { name: "Main agent", avatarUrl: `${basePath}/avatar/main` },
+              },
+            ],
+          },
+        });
+
+        await gateway.waitForRequest("agent.identity.get");
+        const image = page.locator(".profile-hero__avatar-image");
+        await image.waitFor({ timeout: 10_000 });
+        await expect.poll(() => image.getAttribute("src")).toMatch(/^blob:/u);
+        await expect
+          .poll(() => image.evaluate((element) => (element as HTMLImageElement).naturalWidth))
+          .toBe(64);
+        expect(avatarRequests.length).toBeGreaterThan(0);
+        expect(new Set(avatarRequests.map((request) => JSON.stringify(request)))).toEqual(
+          new Set([
+            JSON.stringify({
+              authorization: "Bearer e2e-device-token",
+              resourceType: "fetch",
+              url: avatarUrl,
+            }),
+          ]),
+        );
+        if (captureUiProof) {
+          await mkdir(proofDir, { recursive: true });
+          await page.locator(".profile-hero").screenshot({
+            animations: "disabled",
+            path: path.join(proofDir, "06-authenticated-assistant-avatar.png"),
+          });
+        }
+      },
+    );
   });
 
   it("shares one authenticated avatar between the sidebar and profile preview", async () => {

--- a/ui/src/lib/authenticated-avatar-route.test.ts
+++ b/ui/src/lib/authenticated-avatar-route.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, expect, it, vi } from "vitest";
+import { AuthenticatedAvatarRouteLoader } from "./authenticated-avatar-route.ts";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+it("shares pending fetches and revokes the resolved blob on reset", async () => {
+  const createObjectURL = vi.fn(() => "blob:assistant-avatar");
+  const revokeObjectURL = vi.fn();
+  vi.stubGlobal(
+    "URL",
+    class extends URL {
+      static override createObjectURL = createObjectURL;
+      static override revokeObjectURL = revokeObjectURL;
+    },
+  );
+  let release: ((response: Response) => void) | undefined;
+  const fetchMock = vi.fn(
+    () =>
+      new Promise<Response>((resolve) => {
+        release = resolve;
+      }),
+  );
+  vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+  const onUpdate = vi.fn();
+  const loader = new AuthenticatedAvatarRouteLoader(onUpdate);
+
+  expect(loader.resolve("/avatar/main", "token")).toBeNull();
+  expect(loader.resolve("/avatar/main", "token")).toBeNull();
+  expect(fetchMock).toHaveBeenCalledTimes(1);
+  expect(fetchMock).toHaveBeenCalledWith("/avatar/main", {
+    headers: { Authorization: "Bearer token" },
+    signal: expect.any(AbortSignal),
+  });
+
+  release?.({ ok: true, blob: async () => new Blob(["avatar"]) } as Response);
+  await vi.waitFor(() => expect(onUpdate).toHaveBeenCalledTimes(1));
+  expect(loader.resolve("/avatar/main", "token")).toBe("blob:assistant-avatar");
+
+  loader.reset();
+  expect(revokeObjectURL).toHaveBeenCalledWith("blob:assistant-avatar");
+});
+
+it("leaves misses retryable for a later identity update", async () => {
+  vi.stubGlobal(
+    "URL",
+    class extends URL {
+      static override createObjectURL = vi.fn(() => "blob:retried-avatar");
+      static override revokeObjectURL = vi.fn();
+    },
+  );
+  const fetchMock = vi
+    .fn()
+    .mockResolvedValueOnce({ ok: false })
+    .mockResolvedValueOnce({ ok: true, blob: async () => new Blob(["avatar"]) });
+  vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+  const onUpdate = vi.fn();
+  const loader = new AuthenticatedAvatarRouteLoader(onUpdate);
+
+  expect(loader.resolve("/avatar/main", "token")).toBeNull();
+  await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+  await Promise.resolve();
+
+  expect(loader.resolve("/avatar/main", "token")).toBeNull();
+  await vi.waitFor(() => expect(onUpdate).toHaveBeenCalledTimes(1));
+  expect(fetchMock).toHaveBeenCalledTimes(2);
+  expect(loader.resolve("/avatar/main", "token")).toBe("blob:retried-avatar");
+  loader.reset();
+});

--- a/ui/src/lib/authenticated-avatar-route.test.ts
+++ b/ui/src/lib/authenticated-avatar-route.test.ts
@@ -40,7 +40,7 @@ it("shares pending fetches and revokes the resolved blob on reset", async () => 
   expect(loader.resolve("/avatar/main", "token")).toBe("blob:assistant-avatar");
 
   loader.reset();
-  expect(revokeObjectURL).toHaveBeenCalledWith("blob:assistant-avatar");
+  await vi.waitFor(() => expect(revokeObjectURL).toHaveBeenCalledWith("blob:assistant-avatar"));
 });
 
 it("leaves misses retryable for a later identity update", async () => {
@@ -68,4 +68,50 @@ it("leaves misses retryable for a later identity update", async () => {
   expect(fetchMock).toHaveBeenCalledTimes(2);
   expect(loader.resolve("/avatar/main", "token")).toBe("blob:retried-avatar");
   loader.reset();
+});
+
+it("releases resolved and pending routes that leave the active render", async () => {
+  const revokeObjectURL = vi.fn();
+  vi.stubGlobal(
+    "URL",
+    class extends URL {
+      static override createObjectURL = vi.fn(() => "blob:first-avatar");
+      static override revokeObjectURL = revokeObjectURL;
+    },
+  );
+  const pending: Array<{
+    resolve: (response: Response) => void;
+    signal: AbortSignal;
+  }> = [];
+  vi.stubGlobal(
+    "fetch",
+    vi.fn((_url: string, init?: RequestInit) => {
+      const signal = init?.signal;
+      if (!signal) {
+        throw new Error("missing avatar fetch signal");
+      }
+      return new Promise<Response>((resolve, reject) => {
+        pending.push({ resolve, signal });
+        signal.addEventListener("abort", () => reject(new Error("avatar fetch aborted")), {
+          once: true,
+        });
+      });
+    }) as unknown as typeof fetch,
+  );
+  const onUpdate = vi.fn();
+  const loader = new AuthenticatedAvatarRouteLoader(onUpdate);
+
+  expect(loader.withActiveRoutes(() => loader.resolve("/avatar/first", "token"))).toBeNull();
+  pending[0]?.resolve({ ok: true, blob: async () => new Blob(["avatar"]) } as Response);
+  await vi.waitFor(() => expect(onUpdate).toHaveBeenCalledOnce());
+  expect(loader.withActiveRoutes(() => loader.resolve("/avatar/first", "token"))).toBe(
+    "blob:first-avatar",
+  );
+
+  expect(loader.withActiveRoutes(() => loader.resolve("/avatar/second", "token"))).toBeNull();
+  await vi.waitFor(() => expect(revokeObjectURL).toHaveBeenCalledWith("blob:first-avatar"));
+  expect(pending[0]?.signal.aborted).toBe(true);
+
+  loader.withActiveRoutes(() => null);
+  await vi.waitFor(() => expect(pending[1]?.signal.aborted).toBe(true));
 });

--- a/ui/src/lib/authenticated-avatar-route.ts
+++ b/ui/src/lib/authenticated-avatar-route.ts
@@ -1,0 +1,109 @@
+type AvatarRouteEntry = {
+  blobUrl: string | null;
+  consumers: Map<symbol, () => void>;
+  controller: AbortController;
+};
+
+/** Bound protected avatar fetches so a stalled Gateway route cannot pin UI state forever. */
+const AUTHENTICATED_AVATAR_FETCH_TIMEOUT_MS = 30_000;
+const sharedAvatarRoutes = new Map<string, AvatarRouteEntry>();
+
+function avatarRouteKey(url: string, authToken: string | null): string {
+  return `${authToken ?? ""}\0${url}`;
+}
+
+function releaseEntry(key: string, owner: symbol) {
+  const entry = sharedAvatarRoutes.get(key);
+  if (!entry) {
+    return;
+  }
+  entry.consumers.delete(owner);
+  if (entry.consumers.size > 0) {
+    return;
+  }
+  sharedAvatarRoutes.delete(key);
+  entry.controller.abort();
+  if (entry.blobUrl) {
+    URL.revokeObjectURL(entry.blobUrl);
+  }
+}
+
+async function fetchAvatarRoute(
+  key: string,
+  url: string,
+  authToken: string | null,
+  entry: AvatarRouteEntry,
+) {
+  const timeout = setTimeout(
+    () => entry.controller.abort(new DOMException("avatar fetch timed out", "TimeoutError")),
+    AUTHENTICATED_AVATAR_FETCH_TIMEOUT_MS,
+  );
+  let blobUrl: string | null = null;
+  try {
+    const response = await fetch(url, {
+      ...(authToken ? { headers: { Authorization: `Bearer ${authToken}` } } : {}),
+      signal: entry.controller.signal,
+    });
+    if (response.ok) {
+      blobUrl = URL.createObjectURL(await response.blob());
+    }
+  } catch {
+    // A missing image leaves the owning view's existing text/mascot fallback visible.
+  } finally {
+    clearTimeout(timeout);
+  }
+
+  if (sharedAvatarRoutes.get(key) !== entry) {
+    if (blobUrl) {
+      URL.revokeObjectURL(blobUrl);
+    }
+    return;
+  }
+  if (!blobUrl) {
+    // Do not cache misses: a later identity publication may make this stable route valid.
+    sharedAvatarRoutes.delete(key);
+    return;
+  }
+  entry.blobUrl = blobUrl;
+  for (const update of entry.consumers.values()) {
+    update();
+  }
+}
+
+/**
+ * Resolves protected same-origin avatar routes to one browser-local blob shared by all views.
+ * The owning view releases its reference on credential change or disconnect.
+ */
+export class AuthenticatedAvatarRouteLoader {
+  private readonly owner = Symbol("authenticated-avatar-route-owner");
+  private readonly keys = new Set<string>();
+
+  constructor(private readonly onUpdate: () => void) {}
+
+  reset() {
+    for (const key of this.keys) {
+      releaseEntry(key, this.owner);
+    }
+    this.keys.clear();
+  }
+
+  resolve(url: string, authToken: string | null): string | null {
+    if (!url.startsWith("/")) {
+      return url;
+    }
+    const key = avatarRouteKey(url, authToken);
+    let entry = sharedAvatarRoutes.get(key);
+    if (!entry) {
+      entry = {
+        blobUrl: null,
+        consumers: new Map(),
+        controller: new AbortController(),
+      };
+      sharedAvatarRoutes.set(key, entry);
+      void fetchAvatarRoute(key, url, authToken, entry);
+    }
+    entry.consumers.set(this.owner, this.onUpdate);
+    this.keys.add(key);
+    return entry.blobUrl;
+  }
+}

--- a/ui/src/lib/authenticated-avatar-route.ts
+++ b/ui/src/lib/authenticated-avatar-route.ts
@@ -34,10 +34,7 @@ async function fetchAvatarRoute(
   authToken: string | null,
   entry: AvatarRouteEntry,
 ) {
-  const timeout = setTimeout(
-    () => entry.controller.abort(new DOMException("avatar fetch timed out", "TimeoutError")),
-    AUTHENTICATED_AVATAR_FETCH_TIMEOUT_MS,
-  );
+  const timeout = setTimeout(() => entry.controller.abort(), AUTHENTICATED_AVATAR_FETCH_TIMEOUT_MS);
   let blobUrl: string | null = null;
   try {
     const response = await fetch(url, {

--- a/ui/src/lib/authenticated-avatar-route.ts
+++ b/ui/src/lib/authenticated-avatar-route.ts
@@ -2,6 +2,7 @@ type AvatarRouteEntry = {
   blobUrl: string | null;
   consumers: Map<symbol, () => void>;
   controller: AbortController;
+  releaseTimer: ReturnType<typeof setTimeout> | undefined;
 };
 
 /** Bound protected avatar fetches so a stalled Gateway route cannot pin UI state forever. */
@@ -18,14 +19,22 @@ function releaseEntry(key: string, owner: symbol) {
     return;
   }
   entry.consumers.delete(owner);
-  if (entry.consumers.size > 0) {
+  if (entry.consumers.size > 0 || entry.releaseTimer !== undefined) {
     return;
   }
-  sharedAvatarRoutes.delete(key);
-  entry.controller.abort();
-  if (entry.blobUrl) {
-    URL.revokeObjectURL(entry.blobUrl);
-  }
+  // Lit can replace one route consumer with another in a later microtask. Finalize
+  // unowned routes on the next task so the shared request survives that DOM handoff.
+  entry.releaseTimer = setTimeout(() => {
+    entry.releaseTimer = undefined;
+    if (sharedAvatarRoutes.get(key) !== entry || entry.consumers.size > 0) {
+      return;
+    }
+    sharedAvatarRoutes.delete(key);
+    entry.controller.abort();
+    if (entry.blobUrl) {
+      URL.revokeObjectURL(entry.blobUrl);
+    }
+  }, 0);
 }
 
 async function fetchAvatarRoute(
@@ -73,7 +82,7 @@ async function fetchAvatarRoute(
  */
 export class AuthenticatedAvatarRouteLoader {
   private readonly owner = Symbol("authenticated-avatar-route-owner");
-  private readonly keys = new Set<string>();
+  private keys = new Set<string>();
 
   constructor(private readonly onUpdate: () => void) {}
 
@@ -82,6 +91,20 @@ export class AuthenticatedAvatarRouteLoader {
       releaseEntry(key, this.owner);
     }
     this.keys.clear();
+  }
+
+  withActiveRoutes<T>(render: () => T): T {
+    const previousKeys = this.keys;
+    this.keys = new Set();
+    try {
+      return render();
+    } finally {
+      for (const key of previousKeys) {
+        if (!this.keys.has(key)) {
+          releaseEntry(key, this.owner);
+        }
+      }
+    }
   }
 
   resolve(url: string, authToken: string | null): string | null {
@@ -95,9 +118,14 @@ export class AuthenticatedAvatarRouteLoader {
         blobUrl: null,
         consumers: new Map(),
         controller: new AbortController(),
+        releaseTimer: undefined,
       };
       sharedAvatarRoutes.set(key, entry);
       void fetchAvatarRoute(key, url, authToken, entry);
+    }
+    if (entry.releaseTimer !== undefined) {
+      clearTimeout(entry.releaseTimer);
+      entry.releaseTimer = undefined;
     }
     entry.consumers.set(this.owner, this.onUpdate);
     this.keys.add(key);

--- a/ui/src/pages/profile/profile-page.test.ts
+++ b/ui/src/pages/profile/profile-page.test.ts
@@ -38,7 +38,16 @@ function createContext(
   };
   const subscribe = () => () => undefined;
   return {
-    gateway: { snapshot, subscribe },
+    gateway: {
+      snapshot,
+      connection: {
+        gatewayUrl: window.location.origin.replace(/^http/u, "ws"),
+        token: "",
+        bootstrapToken: "",
+        password: "",
+      },
+      subscribe,
+    },
     agents: { subscribe, ensureList: vi.fn(async () => null) },
     agentIdentity: { subscribe, ensure: vi.fn(async () => undefined) },
   } as unknown as ApplicationContext<RouteId>;
@@ -281,7 +290,11 @@ it("falls back to the text avatar when the hero image fails to load", async () =
     agents: [
       {
         id: "main",
-        identity: { name: "Molty", emoji: "🦞", avatarUrl: "/unloadable-avatar.png" },
+        identity: {
+          name: "Molty",
+          emoji: "🦞",
+          avatarUrl: "data:image/png;base64,unloadable",
+        },
       },
     ],
   };
@@ -292,7 +305,7 @@ it("falls back to the text avatar when the hero image fails to load", async () =
 
   await page.updateComplete;
   const image = page.querySelector<HTMLImageElement>(".profile-hero__avatar-image");
-  expect(image?.getAttribute("src")).toBe("/unloadable-avatar.png");
+  expect(image?.getAttribute("src")).toBe("data:image/png;base64,unloadable");
   expect(page.querySelector(".profile-hero__avatar-text")).toBeNull();
 
   image?.dispatchEvent(new Event("error"));
@@ -300,6 +313,60 @@ it("falls back to the text avatar when the hero image fails to load", async () =
 
   expect(page.querySelector(".profile-hero__avatar-image")).toBeNull();
   expect(page.querySelector(".profile-hero__avatar-text")?.textContent).toBe("🦞");
+});
+
+it("fetches a protected hero avatar with the current Control UI credential", async () => {
+  const createObjectURL = vi.fn(() => "blob:hero-avatar");
+  const revokeObjectURL = vi.fn();
+  vi.stubGlobal(
+    "URL",
+    class extends URL {
+      static override createObjectURL = createObjectURL;
+      static override revokeObjectURL = revokeObjectURL;
+    },
+  );
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok: true,
+    blob: async () => new Blob(["avatar"], { type: "image/svg+xml" }),
+  });
+  vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+  const harness = createConnectedContext(vi.fn() as GatewayBrowserClient["request"]);
+  harness.context.gateway.connection.token = "profile-token";
+  const agentsState = harness.context.agents.state as unknown as {
+    agentsList: {
+      defaultId: string;
+      agents: Array<{
+        id: string;
+        identity: { name: string; emoji: string; avatarUrl: string };
+      }>;
+    };
+  };
+  agentsState.agentsList = {
+    defaultId: "main",
+    agents: [
+      {
+        id: "main",
+        identity: { name: "Molty", emoji: "🦞", avatarUrl: "/avatar/main" },
+      },
+    ],
+  };
+  const provider = createApplicationContextProvider(harness.context);
+  const page = document.createElement(PROFILE_PAGE_TEST_TAG) as ProfilePageElement;
+  provider.append(page);
+  document.body.append(provider);
+
+  await waitForFast(() => {
+    expect(fetchMock).toHaveBeenCalledWith("/avatar/main", {
+      headers: { Authorization: "Bearer profile-token" },
+      signal: expect.any(AbortSignal),
+    });
+    expect(
+      page.querySelector<HTMLImageElement>(".profile-hero__avatar-image")?.getAttribute("src"),
+    ).toBe("blob:hero-avatar");
+  });
+
+  page.remove();
+  expect(revokeObjectURL).toHaveBeenCalledWith("blob:hero-avatar");
 });
 
 it("retries the identity bootstrap when users.self returns no profile", async () => {

--- a/ui/src/pages/profile/profile-page.test.ts
+++ b/ui/src/pages/profile/profile-page.test.ts
@@ -366,7 +366,7 @@ it("fetches a protected hero avatar with the current Control UI credential", asy
   });
 
   page.remove();
-  expect(revokeObjectURL).toHaveBeenCalledWith("blob:hero-avatar");
+  await waitForFast(() => expect(revokeObjectURL).toHaveBeenCalledWith("blob:hero-avatar"));
 });
 
 it("retries the identity bootstrap when users.self returns no profile", async () => {

--- a/ui/src/pages/profile/profile-page.ts
+++ b/ui/src/pages/profile/profile-page.ts
@@ -14,6 +14,7 @@ import {
   type ApplicationContext,
   type ApplicationGatewaySnapshot,
 } from "../../app/context.ts";
+import { resolveControlUiAuthToken } from "../../app/control-ui-auth.ts";
 import type { AuthenticatedUser } from "../../app/user-profile.ts";
 import { resolveCurrentSelfUser, userProfileAvatarUrl } from "../../app/user-profile.ts";
 import { icons } from "../../components/icons.ts";
@@ -27,6 +28,7 @@ import {
 } from "../../components/settings-ui.ts";
 import { renderSettingsWorkspace } from "../../components/settings-workspace.ts";
 import { t } from "../../i18n/index.ts";
+import { AuthenticatedAvatarRouteLoader } from "../../lib/authenticated-avatar-route.ts";
 import { resolveAgentAvatarUrl, resolveAssistantTextAvatar } from "../../lib/avatar.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 import { PROFILE_SETTINGS_TARGET_IDS } from "../config/settings-targets.ts";
@@ -59,6 +61,13 @@ export class ProfilePage extends OpenClawLightDomElement {
 
   private client: GatewayBrowserClient | null = null;
   private connected = false;
+  private heroAvatarAuthToken: string | null = null;
+  private heroAvatarAuthReady = false;
+  private readonly heroAvatarLoader = new AuthenticatedAvatarRouteLoader(() => {
+    if (this.isConnected) {
+      this.requestUpdate();
+    }
+  });
   private identityRequestId = 0;
   private subscriptions: Array<() => void> = [];
 
@@ -78,12 +87,29 @@ export class ProfilePage extends OpenClawLightDomElement {
     }
     this.subscriptions = [];
     this.identityRequestId += 1;
+    this.heroAvatarLoader.reset();
+    this.heroAvatarAuthToken = null;
+    this.heroAvatarAuthReady = false;
     this.client = null;
     this.connected = false;
     super.disconnectedCallback();
   }
 
   private applyGatewaySnapshot(snapshot: ApplicationGatewaySnapshot) {
+    const nextHeroAvatarAuthToken = resolveControlUiAuthToken({
+      hello: snapshot.hello,
+      settings: { token: this.context.gateway.connection.token },
+      password: this.context.gateway.connection.password,
+    });
+    if (nextHeroAvatarAuthToken !== this.heroAvatarAuthToken) {
+      this.heroAvatarLoader.reset();
+      this.heroAvatarAuthToken = nextHeroAvatarAuthToken;
+    }
+    this.heroAvatarAuthReady = Boolean(
+      snapshot.hello ||
+      this.context.gateway.connection.token.trim() ||
+      this.context.gateway.connection.password.trim(),
+    );
     const clientChanged = snapshot.client !== this.client;
     const nextConnected = snapshot.phase === "connected";
     const connectionChanged = nextConnected !== this.connected;
@@ -332,15 +358,22 @@ export class ProfilePage extends OpenClawLightDomElement {
   }
 
   private renderAvatar(avatarUrl: string | null, textAvatar: string | null, name: string) {
+    const imageUrl = avatarUrl?.startsWith("/")
+      ? this.heroAvatarAuthReady
+        ? this.heroAvatarLoader.resolve(avatarUrl, this.heroAvatarAuthToken)
+        : null
+      : avatarUrl;
     if (avatarUrl && avatarUrl !== this.failedHeroAvatarUrl) {
-      return html`<img
-        class="profile-hero__avatar-image"
-        src=${avatarUrl}
-        alt=${name}
-        @error=${() => {
-          this.failedHeroAvatarUrl = avatarUrl;
-        }}
-      />`;
+      if (imageUrl) {
+        return html`<img
+          class="profile-hero__avatar-image"
+          src=${imageUrl}
+          alt=${name}
+          @error=${() => {
+            this.failedHeroAvatarUrl = avatarUrl;
+          }}
+        />`;
+      }
     }
     if (textAvatar) {
       return html`<span class="profile-hero__avatar-text">${textAvatar}</span>`;

--- a/ui/src/pages/profile/profile-page.ts
+++ b/ui/src/pages/profile/profile-page.ts
@@ -102,7 +102,6 @@ export class ProfilePage extends OpenClawLightDomElement {
       password: this.context.gateway.connection.password,
     });
     if (nextHeroAvatarAuthToken !== this.heroAvatarAuthToken) {
-      this.heroAvatarLoader.reset();
       this.heroAvatarAuthToken = nextHeroAvatarAuthToken;
     }
     this.heroAvatarAuthReady = Boolean(
@@ -414,6 +413,10 @@ export class ProfilePage extends OpenClawLightDomElement {
   }
 
   override render() {
+    return this.heroAvatarLoader.withActiveRoutes(() => this.renderContent());
+  }
+
+  private renderContent() {
     return html`
       <section class="content-header">
         <div>


### PR DESCRIPTION
Closes #107853

Related: #109690

## What Problem This Solves

Supported assistant avatar routes such as `/avatar/main` and base-path-prefixed variants are intentionally preserved by the Gateway, but Settings Profile assigned them directly to an image element. The Control UI avatar route requires authentication, and a browser image request cannot add the live Bearer credential, so the configured portrait failed and the page fell back.

## Why This Change Was Made

This rewrite extracts AgentSelect's authenticated route-to-blob lifecycle into one shared loader, then uses that owner in AgentSelect, Settings Profile, and the visible Sidebar agent card. Concurrent consumers share a credential-keyed pending request and blob; active render sets release superseded routes; one task-turn handoff lets Lit replace a consumer without aborting a request that its sibling adopts; disconnects release final consumers; timeouts are bounded; and misses remain uncached so later identity publication can retry.

The +127 net production LOC is required by the authenticated-resource security and lifecycle boundary: one owner coordinates credentials, request deduplication, render-set reconciliation, DOM handoff, retryable misses, cross-surface blob ownership, and final abort/revocation while deleting the former AgentSelect-local implementation.

## User Impact

Configured same-origin assistant portraits render in Settings Profile and the Sidebar instead of making unauthenticated image requests. Missing images continue to show the existing text or mascot fallback, SVG portraits remain supported, later identity updates can retry a temporarily unavailable route, and changing/removing an avatar no longer retains obsolete requests or blobs. No config, default, protocol, public API, or Gateway authorization behavior changes.

## Evidence

- Current-main bug: Profile directly bound a route preserved by `src/gateway/assistant-avatar.ts`; `src/gateway/control-ui.ts` authenticates that route before serving bytes.
- Browser red proof: restoring direct-image behavior produced a raw 401 request and fallback; the focused regression timed out waiting for the authenticated blob image.
- Lifecycle red/green proof: the new route replacement/removal regression failed without active-set reconciliation because the first blob was never revoked, then passed with the shared-owner repair.
- Unit/Sidebar proof: loader, AgentSelect, Profile, and AppSidebar tests passed 281/281.
- Chromium proof: Profile and stalled-request scenarios passed 7/7; the latter preserves one credentialed request across Lit's sidebar-to-picker handoff and aborts it at the bounded deadline.
- `node scripts/check-changed.mjs -- <nine changed paths>` passed formatting, dependency, dead-export, i18n, core/UI tsgo, and changed-file lint on Testbox `tbx_01kzmrwfpzh4zz35g1qaxyc54n`; Actions run https://github.com/openclaw/openclaw/actions/runs/31350584588.
- Final Codex autoreview: clean, no accepted/actionable findings, confidence 0.99.
- Production/test delta: production +232/-105 (net +127); tests +303/-15 (net +288).
- ClawSweeper rank-up moves: superseded routes are now reconciled with replacement/removal coverage; exact-head CI is required and will be green before prepare.

![Authenticated assistant avatar rendered from the protected route](https://github.com/user-attachments/assets/d97a1802-f4b3-4810-a2f7-813433315750)
