### PR TITLE
fix(tui): prevent cross-session leaks and lost streamed replies

### DIFF
--- a/config/max-lines-baseline.txt
+++ b/config/max-lines-baseline.txt
@@ -982,7 +982,6 @@ src/tui/embedded-backend.ts
 src/tui/tui-command-handlers.test.ts
 src/tui/tui-command-handlers.ts
 src/tui/tui-event-handlers.test.ts
-src/tui/tui-event-handlers.ts
 src/tui/tui-pty-local.e2e.test.ts
 src/tui/tui-session-actions.test.ts
 src/tui/tui.ts

--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -2474,6 +2474,45 @@ describe("tui-event-handlers: handleAgentEvent", () => {
       expect(loadHistory).toHaveBeenCalledTimes(1);
     });
 
+    it.each(["end", "error"] as const)(
+      "releases a displayed client run when its internal agent reports %s",
+      (phase) => {
+        const {
+          state,
+          chatLog,
+          loadHistory,
+          handleChatEvent,
+          handleSessionsChangedEvent,
+          handleSessionMessageEvent,
+        } = createHandlersHarness({ state: { activeChatRunId: "run-client-visible" } });
+
+        handleSessionMessageEvent({
+          sessionKey: state.currentSessionKey,
+        } satisfies SessionMessageEvent);
+        handleChatEvent({
+          runId: "run-client-visible",
+          sessionKey: state.currentSessionKey,
+          state: "final",
+          message: { content: [{ type: "text", text: "keep the aliased reply visible" }] },
+        } satisfies ChatEvent);
+
+        expect(chatLog.finalizeAssistant).toHaveBeenCalledWith(
+          "keep the aliased reply visible",
+          "run-client-visible",
+        );
+        expect(loadHistory).not.toHaveBeenCalled();
+
+        handleSessionsChangedEvent({
+          sessionKey: state.currentSessionKey,
+          runId: "run-internal-agent",
+          clientRunId: "run-client-visible",
+          phase,
+        } satisfies SessionChangedEvent);
+
+        expect(loadHistory).toHaveBeenCalledTimes(1);
+      },
+    );
+
     it("refreshes after a local final when terminal persistence arrives first", () => {
       const {
         state,

--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -794,9 +794,10 @@ describe("tui-event-handlers: handleAgentEvent", () => {
   });
 
   it("protects concurrent lifecycle-confirmed streams from an orphan delta flood", () => {
-    const { state, chatLog, handleAgentEvent, handleChatEvent } = createHandlersHarness({
-      state: { activeChatRunId: null },
-    });
+    const { state, chatLog, setActivityStatus, handleAgentEvent, handleChatEvent } =
+      createHandlersHarness({
+        state: { activeChatRunId: null },
+      });
 
     handleChatEvent({
       runId: "run-first",
@@ -833,6 +834,7 @@ describe("tui-event-handlers: handleAgentEvent", () => {
       state: "final",
       message: { role: "assistant", content: [] },
     } satisfies ChatEvent);
+    expect(state.activeChatRunId).toBe("run-first");
     handleChatEvent({
       runId: "run-first",
       sessionKey: state.currentSessionKey,
@@ -842,6 +844,213 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
     expect(chatLog.finalizeAssistant).toHaveBeenCalledWith("second live response", "run-second");
     expect(chatLog.finalizeAssistant).toHaveBeenCalledWith("first live response", "run-first");
+    expect(state.activeChatRunId).toBeNull();
+    expect(setActivityStatus).toHaveBeenCalledWith("idle");
+  });
+
+  it("promotes the confirmed concurrent run instead of a newer orphan delta", () => {
+    const {
+      state,
+      chatLog,
+      loadHistory,
+      setActivityStatus,
+      handleAgentEvent,
+      handleChatEvent,
+      handleSessionMessageEvent,
+      handleSessionsChangedEvent,
+    } = createHandlersHarness({ state: { activeChatRunId: null } });
+
+    handleChatEvent({
+      runId: "run-first",
+      sessionKey: state.currentSessionKey,
+      state: "delta",
+      message: { content: [{ type: "text", text: "first live response" }] },
+    } satisfies ChatEvent);
+    handleAgentEvent({
+      runId: "run-second",
+      sessionKey: state.currentSessionKey,
+      stream: "lifecycle",
+      data: { phase: "start" },
+    } satisfies AgentEvent);
+    handleChatEvent({
+      runId: "run-second",
+      sessionKey: state.currentSessionKey,
+      state: "delta",
+      message: { content: [{ type: "text", text: "second live response" }] },
+    } satisfies ChatEvent);
+
+    for (let index = 0; index < 500; index += 1) {
+      handleChatEvent({
+        runId: `run-orphan-${index}`,
+        sessionKey: state.currentSessionKey,
+        state: "delta",
+        message: { content: [{ type: "text", text: `orphan ${index}` }] },
+      } satisfies ChatEvent);
+    }
+
+    handleSessionMessageEvent({
+      sessionKey: state.currentSessionKey,
+      updatedAt: 200,
+    } satisfies SessionMessageEvent);
+    expect(loadHistory).not.toHaveBeenCalled();
+
+    handleChatEvent({
+      runId: "run-first",
+      sessionKey: state.currentSessionKey,
+      state: "final",
+      message: { role: "assistant", content: [] },
+    } satisfies ChatEvent);
+    expect(state.activeChatRunId).toBe("run-second");
+
+    handleChatEvent({
+      runId: "run-second",
+      sessionKey: state.currentSessionKey,
+      state: "final",
+      message: { role: "assistant", content: [] },
+    } satisfies ChatEvent);
+
+    expect(chatLog.finalizeAssistant).toHaveBeenCalledWith("first live response", "run-first");
+    expect(chatLog.finalizeAssistant).toHaveBeenCalledWith("second live response", "run-second");
+    expect(state.activeChatRunId).toBeNull();
+    expect(setActivityStatus).toHaveBeenCalledWith("idle");
+
+    for (const runId of ["run-first", "run-second"]) {
+      handleSessionsChangedEvent({
+        sessionKey: state.currentSessionKey,
+        runId,
+        phase: "end",
+      } satisfies SessionChangedEvent);
+    }
+    expect(loadHistory).toHaveBeenCalledTimes(1);
+
+    const displayedDeltaCount = chatLog.updateAssistant.mock.calls.length;
+    handleChatEvent({
+      runId: "run-orphan-499",
+      sessionKey: state.currentSessionKey,
+      state: "delta",
+      message: { content: [{ type: "text", text: "late orphan" }] },
+    } satisfies ChatEvent);
+    expect(state.activeChatRunId).toBeNull();
+    expect(chatLog.updateAssistant).toHaveBeenCalledTimes(displayedDeltaCount);
+
+    handleChatEvent({
+      runId: "run-never-seen-orphan",
+      sessionKey: state.currentSessionKey,
+      state: "delta",
+      message: { content: [{ type: "text", text: "untracked late orphan" }] },
+    } satisfies ChatEvent);
+    expect(state.activeChatRunId).toBeNull();
+    expect(chatLog.updateAssistant).toHaveBeenCalledTimes(displayedDeltaCount);
+  });
+
+  it("keeps a lifecycle-less concurrent response when a confirmed owner finishes", () => {
+    const { state, chatLog, setActivityStatus, handleAgentEvent, handleChatEvent } =
+      createHandlersHarness({ state: { activeChatRunId: null } });
+
+    handleAgentEvent({
+      runId: "run-confirmed",
+      sessionKey: state.currentSessionKey,
+      stream: "lifecycle",
+      data: { phase: "start" },
+    } satisfies AgentEvent);
+    handleChatEvent({
+      runId: "run-confirmed",
+      sessionKey: state.currentSessionKey,
+      state: "delta",
+      message: { content: [{ type: "text", text: "confirmed response" }] },
+    } satisfies ChatEvent);
+    handleChatEvent({
+      runId: "run-without-lifecycle",
+      sessionKey: state.currentSessionKey,
+      seq: 1,
+      state: "delta",
+      message: { content: [{ type: "text", text: "older peer response" }] },
+    } satisfies ChatEvent);
+
+    handleChatEvent({
+      runId: "run-confirmed",
+      sessionKey: state.currentSessionKey,
+      state: "final",
+      message: { role: "assistant", content: [] },
+    } satisfies ChatEvent);
+    expect(state.activeChatRunId).toBe("run-without-lifecycle");
+
+    handleChatEvent({
+      runId: "run-without-lifecycle",
+      sessionKey: state.currentSessionKey,
+      seq: 2,
+      state: "final",
+      message: { role: "assistant", content: [] },
+    } satisfies ChatEvent);
+
+    expect(chatLog.finalizeAssistant).toHaveBeenCalledWith(
+      "older peer response",
+      "run-without-lifecycle",
+    );
+    expect(state.activeChatRunId).toBeNull();
+    expect(setActivityStatus).toHaveBeenCalledWith("idle");
+  });
+
+  it("preserves a sequenced lifecycle-less peer behind a confirmed run handoff", () => {
+    const { state, chatLog, setActivityStatus, handleAgentEvent, handleChatEvent } =
+      createHandlersHarness({ state: { activeChatRunId: null } });
+
+    handleChatEvent({
+      runId: "run-first",
+      sessionKey: state.currentSessionKey,
+      state: "delta",
+      message: { content: [{ type: "text", text: "first live response" }] },
+    } satisfies ChatEvent);
+    handleAgentEvent({
+      runId: "run-confirmed",
+      sessionKey: state.currentSessionKey,
+      stream: "lifecycle",
+      data: { phase: "start" },
+    } satisfies AgentEvent);
+    handleChatEvent({
+      runId: "run-confirmed",
+      sessionKey: state.currentSessionKey,
+      state: "delta",
+      message: { content: [{ type: "text", text: "confirmed response" }] },
+    } satisfies ChatEvent);
+    handleChatEvent({
+      runId: "run-without-lifecycle",
+      sessionKey: state.currentSessionKey,
+      seq: 1,
+      state: "delta",
+      message: { content: [{ type: "text", text: "older peer response" }] },
+    } satisfies ChatEvent);
+    handleChatEvent({
+      runId: "run-orphan",
+      sessionKey: state.currentSessionKey,
+      state: "delta",
+      message: { content: [{ type: "text", text: "unconfirmed orphan" }] },
+    } satisfies ChatEvent);
+
+    handleChatEvent({
+      runId: "run-first",
+      sessionKey: state.currentSessionKey,
+      state: "final",
+      message: { role: "assistant", content: [] },
+    } satisfies ChatEvent);
+    expect(["run-confirmed", "run-without-lifecycle"]).toContain(state.activeChatRunId);
+
+    for (const runId of ["run-confirmed", "run-without-lifecycle"]) {
+      handleChatEvent({
+        runId,
+        sessionKey: state.currentSessionKey,
+        ...(runId === "run-without-lifecycle" ? { seq: 2 } : {}),
+        state: "final",
+        message: { role: "assistant", content: [] },
+      } satisfies ChatEvent);
+    }
+
+    expect(chatLog.finalizeAssistant).toHaveBeenCalledWith(
+      "older peer response",
+      "run-without-lifecycle",
+    );
+    expect(state.activeChatRunId).toBeNull();
+    expect(setActivityStatus).toHaveBeenCalledWith("idle");
   });
 
   it.each([

--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -793,6 +793,132 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     expect(chatLog.updateAssistant).toHaveBeenCalledWith("hello", "run-alias");
   });
 
+  it("protects concurrent lifecycle-confirmed streams from an orphan delta flood", () => {
+    const { state, chatLog, handleAgentEvent, handleChatEvent } = createHandlersHarness({
+      state: { activeChatRunId: null },
+    });
+
+    handleChatEvent({
+      runId: "run-first",
+      sessionKey: state.currentSessionKey,
+      state: "delta",
+      message: { content: [{ type: "text", text: "first live response" }] },
+    } satisfies ChatEvent);
+    handleAgentEvent({
+      runId: "run-second",
+      sessionKey: state.currentSessionKey,
+      stream: "lifecycle",
+      data: { phase: "start" },
+    } satisfies AgentEvent);
+    handleChatEvent({
+      runId: "run-second",
+      sessionKey: state.currentSessionKey,
+      state: "delta",
+      message: { content: [{ type: "text", text: "second live response" }] },
+    } satisfies ChatEvent);
+
+    for (let index = 0; index < 500; index += 1) {
+      handleChatEvent({
+        runId: `run-orphan-${index}`,
+        sessionKey: state.currentSessionKey,
+        state: "delta",
+        message: { content: [{ type: "text", text: `orphan ${index}` }] },
+      } satisfies ChatEvent);
+    }
+
+    expect(state.activeChatRunId).toBe("run-first");
+    handleChatEvent({
+      runId: "run-second",
+      sessionKey: state.currentSessionKey,
+      state: "final",
+      message: { role: "assistant", content: [] },
+    } satisfies ChatEvent);
+    handleChatEvent({
+      runId: "run-first",
+      sessionKey: state.currentSessionKey,
+      state: "final",
+      message: { role: "assistant", content: [] },
+    } satisfies ChatEvent);
+
+    expect(chatLog.finalizeAssistant).toHaveBeenCalledWith("second live response", "run-second");
+    expect(chatLog.finalizeAssistant).toHaveBeenCalledWith("first live response", "run-first");
+  });
+
+  it.each([
+    {
+      provider: "Matrix",
+      selectedSessionKey: "agent:main:matrix:channel:!MixedRoom:example.org",
+      otherSessionKey: "agent:main:matrix:channel:!mixedroom:example.org",
+    },
+    {
+      provider: "Signal",
+      selectedSessionKey: "agent:main:signal:group:AbC123=",
+      otherSessionKey: "agent:main:signal:group:abc123=",
+    },
+  ])(
+    "isolates case-distinct $provider session events across every TUI event surface",
+    ({ selectedSessionKey, otherSessionKey }) => {
+      const {
+        state,
+        chatLog,
+        btw,
+        loadHistory,
+        handleChatEvent,
+        handleAgentEvent,
+        handleBtwEvent,
+        handleSessionsChangedEvent,
+        handleSessionMessageEvent,
+      } = createHandlersHarness({
+        state: {
+          activeChatRunId: null,
+          currentSessionKey: selectedSessionKey,
+          currentSessionId: "selected-session",
+          sessionInfo: { verboseLevel: "on", updatedAt: 100 },
+        },
+      });
+
+      handleChatEvent({
+        runId: "run-other-session",
+        sessionKey: otherSessionKey,
+        state: "delta",
+        message: { content: "message from another conversation" },
+      } satisfies ChatEvent);
+      handleAgentEvent({
+        runId: "run-other-lifecycle",
+        sessionKey: otherSessionKey,
+        stream: "lifecycle",
+        data: { phase: "start" },
+      } satisfies AgentEvent);
+      handleBtwEvent({
+        kind: "btw",
+        runId: "run-other-btw",
+        sessionKey: otherSessionKey,
+        question: "other conversation?",
+        text: "private answer",
+      } satisfies BtwEvent);
+      handleSessionsChangedEvent({
+        sessionKey: otherSessionKey,
+        reason: "reset",
+        sessionId: "other-session",
+        updatedAt: 200,
+      } satisfies SessionChangedEvent);
+      handleSessionMessageEvent({
+        sessionKey: otherSessionKey,
+        agentId: "main",
+        sessionId: "other-session",
+        updatedAt: 200,
+      } satisfies SessionMessageEvent);
+
+      expect(chatLog.updateAssistant).not.toHaveBeenCalled();
+      expect(btw.showResult).not.toHaveBeenCalled();
+      expect(loadHistory).not.toHaveBeenCalled();
+      expect(state.activeChatRunId).toBeNull();
+      expect(state.currentSessionKey).toBe(selectedSessionKey);
+      expect(state.currentSessionId).toBe("selected-session");
+      expect(state.sessionInfo.updatedAt).toBe(100);
+    },
+  );
+
   it("renders BTW results separately without disturbing the active run", () => {
     const { state, btw, setActivityStatus, loadHistory, tui, handleBtwEvent } =
       createHandlersHarness({
@@ -2202,6 +2328,95 @@ describe("tui-event-handlers: handleAgentEvent", () => {
         phase: "end",
       } satisfies SessionChangedEvent);
 
+      expect(loadHistory).toHaveBeenCalledTimes(1);
+    });
+
+    it.each([
+      { firstPersistedRunId: "run-first", secondPersistedRunId: "run-second" },
+      { firstPersistedRunId: "run-second", secondPersistedRunId: "run-first" },
+    ])(
+      "waits for both visible finals when $firstPersistedRunId persists first",
+      ({ firstPersistedRunId, secondPersistedRunId }) => {
+        const {
+          state,
+          chatLog,
+          loadHistory,
+          handleChatEvent,
+          handleSessionsChangedEvent,
+          handleSessionMessageEvent,
+        } = createHandlersHarness({ state: { activeChatRunId: null } });
+
+        for (const runId of ["run-first", "run-second"]) {
+          handleChatEvent({
+            runId,
+            sessionKey: state.currentSessionKey,
+            state: "final",
+            message: { content: [{ type: "text", text: `${runId} visible response` }] },
+          } satisfies ChatEvent);
+        }
+
+        expect(chatLog.finalizeAssistant).toHaveBeenCalledTimes(2);
+        handleSessionMessageEvent({
+          sessionKey: state.currentSessionKey,
+          updatedAt: 200,
+        } satisfies SessionMessageEvent);
+        expect(loadHistory).not.toHaveBeenCalled();
+
+        handleSessionsChangedEvent({
+          sessionKey: state.currentSessionKey,
+          runId: firstPersistedRunId,
+          phase: "end",
+        } satisfies SessionChangedEvent);
+        expect(loadHistory).not.toHaveBeenCalled();
+
+        handleSessionsChangedEvent({
+          sessionKey: state.currentSessionKey,
+          runId: secondPersistedRunId,
+          phase: "end",
+        } satisfies SessionChangedEvent);
+        expect(loadHistory).toHaveBeenCalledTimes(1);
+      },
+    );
+
+    it("coalesces external updates until every concurrently displayed final is persisted", () => {
+      const {
+        state,
+        loadHistory,
+        handleChatEvent,
+        handleSessionsChangedEvent,
+        handleSessionMessageEvent,
+      } = createHandlersHarness({ state: { activeChatRunId: null } });
+
+      for (const runId of ["run-first", "run-second", "run-third"]) {
+        handleChatEvent({
+          runId,
+          sessionKey: state.currentSessionKey,
+          state: "final",
+          message: { content: [{ type: "text", text: `${runId} visible response` }] },
+        } satisfies ChatEvent);
+      }
+
+      for (let index = 0; index < 250; index += 1) {
+        handleSessionMessageEvent({
+          sessionKey: state.currentSessionKey,
+          updatedAt: index,
+        } satisfies SessionMessageEvent);
+      }
+
+      for (const runId of ["run-third", "run-first"]) {
+        handleSessionsChangedEvent({
+          sessionKey: state.currentSessionKey,
+          runId,
+          phase: "end",
+        } satisfies SessionChangedEvent);
+        expect(loadHistory).not.toHaveBeenCalled();
+      }
+
+      handleSessionsChangedEvent({
+        sessionKey: state.currentSessionKey,
+        runId: "run-second",
+        phase: "end",
+      } satisfies SessionChangedEvent);
       expect(loadHistory).toHaveBeenCalledTimes(1);
     });
 

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -393,12 +393,15 @@ export function createEventHandlers(context: EventHandlerContext) {
       return;
     }
 
-    if (evt.runId && (evt.phase === "end" || evt.phase === "error")) {
-      runCoordinator.notePersistedRun(evt.runId);
-      if (pendingNewSessionRunIds.delete(evt.runId)) {
+    const persistedRunId = evt.clientRunId || evt.runId;
+    if (persistedRunId && (evt.phase === "end" || evt.phase === "error")) {
+      runCoordinator.notePersistedRun(persistedRunId);
+      if (pendingNewSessionRunIds.delete(persistedRunId)) {
         if (evt.phase === "end") {
-          const displayedRunIds = finalizedRunsWithDisplay.has(evt.runId) ? [evt.runId] : [];
-          queueHistoryReload([evt.runId], [evt.runId], displayedRunIds);
+          const displayedRunIds = finalizedRunsWithDisplay.has(persistedRunId)
+            ? [persistedRunId]
+            : [];
+          queueHistoryReload([persistedRunId], [persistedRunId], displayedRunIds);
         } else {
           void refreshSessionInfo?.();
         }

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -1,19 +1,16 @@
 // Handles TUI keyboard, paste, backend, and command events.
-import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
-import { classifyFailoverReason, isAuthErrorMessage } from "../agents/embedded-agent-helpers.js";
-import { parseAgentSessionKey } from "../sessions/session-key-utils.js";
-import { formatRawAssistantErrorForUi } from "../shared/assistant-error-format.js";
 import {
   asString,
   extractTextFromMessage,
   isCommandMessage,
   sanitizeRenderableText,
 } from "./tui-formatters.js";
-import { TuiStreamAssembler } from "./tui-stream-assembler.js";
+import { createTuiRunLifecycle } from "./tui-run-lifecycle.js";
+import { matchesSelectedTuiSession } from "./tui-session-events.js";
+import { TuiSessionRunCoordinator } from "./tui-session-run-coordinator.js";
 import {
   clearPendingSubmit,
-  clearPendingSubmitDraft,
   getPendingSubmitAcceptedRunId,
   hasPendingSubmit,
 } from "./tui-submit-state.js";
@@ -85,11 +82,6 @@ type EventHandlerContext = {
   localMode?: boolean;
 };
 
-const DEFAULT_STREAMING_WATCHDOG_MS = 30_000;
-const LIFECYCLE_ERROR_RETRY_GRACE_MS = 15_000;
-const STREAMING_WATCHDOG_USER_MESSAGE =
-  "This response is taking longer than expected. Still waiting for the current run.";
-
 export function createEventHandlers(context: EventHandlerContext) {
   const {
     chatLog,
@@ -108,494 +100,69 @@ export function createEventHandlers(context: EventHandlerContext) {
     clearLocalBtwRunIds,
     localMode,
   } = context;
-  const sessionRuns = new Map<string, number>();
-  const finalizedRuns = new Map<string, number>();
-  const finalizedRunsWithDisplay = new Map<string, number>();
-  const pendingNewSessionRunIds = new Set<string>();
-  const persistedTerminalRunIds = new Map<string, number>();
-  const historyReloadRunIds = new Set<string>();
-  const historyOwnedReloadRunIds = new Set<string>();
-  const historyDisplayedReloadRunIds = new Set<string>();
-  const liveTerminalErrorMessages = new Map<string, string>();
-  const queuedHistoryReloadRunIds = new Set<string>();
-  const deferredHistoryRunEvents = new Map<string, ChatEvent>();
-  let historyReloadInFlight = false;
-  let historyReloadQueued = false;
-  let historyReloadGeneration = 0;
-  const completedRuns = new Map<string, number>();
-  const postFinalizingRuns = new Map<string, number>();
-  let streamAssembler = new TuiStreamAssembler();
-  let lastSessionKey = state.currentSessionKey;
-  let pendingHistoryRefresh = false;
-  let pendingSessionMessageRefresh = false;
-  let pendingSessionMessageRunId: string | null = null;
-  let reconnectPendingRunId: string | null = null;
-  const pendingTerminalLifecycleErrors = new Map<
-    string,
-    { errorMessage: string; timer: ReturnType<typeof setTimeout> }
-  >();
-
-  const streamingWatchdogMs =
-    typeof context.streamingWatchdogMs === "number" &&
-    Number.isFinite(context.streamingWatchdogMs) &&
-    context.streamingWatchdogMs >= 0
-      ? Math.floor(context.streamingWatchdogMs)
-      : DEFAULT_STREAMING_WATCHDOG_MS;
-  let streamingWatchdogTimer: ReturnType<typeof setTimeout> | null = null;
-  let streamingWatchdogRunId: string | null = null;
-
-  const reloadHistoryPreservingTerminalErrors = async (): Promise<TuiHistoryLoadResult> => {
-    if (!loadHistory) {
-      return { loaded: false };
-    }
-    const reloadGeneration = historyReloadGeneration;
-    const result = (await loadHistory()) ?? { loaded: false };
-    if (!result.loaded || reloadGeneration !== historyReloadGeneration) {
-      return result;
-    }
-    let restored = false;
-    for (const [runId, message] of liveTerminalErrorMessages) {
-      if (!finalizedRunsWithDisplay.has(runId)) {
-        continue;
-      }
-      chatLog.addSystem(message);
-      restored = true;
-    }
-    if (restored) {
-      tui.requestRender(true);
-    }
-    return result;
-  };
-
-  const flushPendingHistoryRefreshIfIdle = () => {
-    if (state.activeChatRunId || hasPendingSubmit(state)) {
-      return;
-    }
-    const canRefreshSessionMessage =
-      pendingSessionMessageRefresh && pendingSessionMessageRunId === null;
-    if (!pendingHistoryRefresh && !canRefreshSessionMessage) {
-      return;
-    }
-    pendingHistoryRefresh = false;
-    if (canRefreshSessionMessage) {
-      pendingSessionMessageRefresh = false;
-    }
-    queueHistoryReload();
-  };
-
-  const clearStreamingWatchdog = () => {
-    if (streamingWatchdogTimer) {
-      clearTimeout(streamingWatchdogTimer);
-      streamingWatchdogTimer = null;
-    }
-    streamingWatchdogRunId = null;
-  };
-
-  const clearPendingTerminalLifecycleError = (runId: string) => {
-    const pending = pendingTerminalLifecycleErrors.get(runId);
-    if (!pending) {
-      return;
-    }
-    clearTimeout(pending.timer);
-    pendingTerminalLifecycleErrors.delete(runId);
-  };
-
-  const clearPendingTerminalLifecycleErrors = () => {
-    for (const pending of pendingTerminalLifecycleErrors.values()) {
-      clearTimeout(pending.timer);
-    }
-    pendingTerminalLifecycleErrors.clear();
-  };
-
-  const pauseStreamingWatchdog = () => {
-    clearStreamingWatchdog();
-  };
-
-  const clearTrackedRunState = () => {
-    historyReloadGeneration += 1;
-    pendingNewSessionRunIds.clear();
-    persistedTerminalRunIds.clear();
-    historyReloadRunIds.clear();
-    historyOwnedReloadRunIds.clear();
-    historyDisplayedReloadRunIds.clear();
-    liveTerminalErrorMessages.clear();
-    queuedHistoryReloadRunIds.clear();
-    historyReloadQueued = false;
-    deferredHistoryRunEvents.clear();
-    finalizedRuns.clear();
-    finalizedRunsWithDisplay.clear();
-    completedRuns.clear();
-    sessionRuns.clear();
-    postFinalizingRuns.clear();
-    streamAssembler = new TuiStreamAssembler();
-    pendingHistoryRefresh = false;
-    pendingSessionMessageRefresh = false;
-    pendingSessionMessageRunId = null;
-    clearPendingSubmit(state);
-    reconnectPendingRunId = null;
-    clearLocalRunIds?.();
-    clearLocalBtwRunIds?.();
-    clearPendingTerminalLifecycleErrors();
-    btw.clear();
-    clearStreamingWatchdog();
-  };
-
-  const armStreamingWatchdog = (runId: string) => {
-    if (streamingWatchdogMs <= 0) {
-      return;
-    }
-    if (streamingWatchdogTimer) {
-      clearTimeout(streamingWatchdogTimer);
-    }
-    streamingWatchdogRunId = runId;
-    streamingWatchdogTimer = setTimeout(() => {
-      streamingWatchdogTimer = null;
-      if (streamingWatchdogRunId !== runId || state.activeChatRunId !== runId) {
-        return;
-      }
-      streamingWatchdogRunId = null;
-      if (reconnectPendingRunId === runId) {
-        reconnectPendingRunId = null;
-        state.activeChatRunId = null;
-        state.activityStatus = "idle";
-        setActivityStatus("idle");
-        pendingHistoryRefresh = false;
-        queueHistoryReload();
-        tui.requestRender();
-        return;
-      }
-      chatLog.addPendingSystem(runId, STREAMING_WATCHDOG_USER_MESSAGE);
-      tui.requestRender();
-    }, streamingWatchdogMs);
-    const maybeUnref = (streamingWatchdogTimer as { unref?: () => void }).unref;
-    if (typeof maybeUnref === "function") {
-      maybeUnref.call(streamingWatchdogTimer);
-    }
-  };
-
-  const pruneRunMap = (runs: Map<string, number>) => {
-    if (runs.size <= 200) {
-      return;
-    }
-    const keepUntil = Date.now() - 10 * 60 * 1000;
-    for (const [key, ts] of runs) {
-      if (runs.size <= 150) {
-        break;
-      }
-      if (ts < keepUntil) {
-        runs.delete(key);
-      }
-    }
-    if (runs.size > 200) {
-      for (const key of runs.keys()) {
-        runs.delete(key);
-        if (runs.size <= 150) {
-          break;
-        }
-      }
-    }
-  };
-
-  const syncSessionKey = () => {
-    if (state.currentSessionKey === lastSessionKey) {
-      return;
-    }
-    lastSessionKey = state.currentSessionKey;
-    if (state.activeChatRunId || hasPendingSubmit(state)) {
-      return;
-    }
-    clearTrackedRunState();
-  };
-
-  const resolveAuthErrorHint = (errorMessage: string): string | undefined => {
-    if (!localMode) {
-      return undefined;
-    }
-    const provider = state.sessionInfo.modelProvider?.trim();
-    const failoverReason = classifyFailoverReason(errorMessage, { provider });
-    if (failoverReason === "billing" || failoverReason === "rate_limit") {
-      return undefined;
-    }
-    if (!isAuthErrorMessage(errorMessage)) {
-      return undefined;
-    }
-    return provider
-      ? `auth or provider access failed for ${provider}. Run /auth ${provider} to refresh credentials; if you already re-authed, switch models/providers because this account may still be blocked for inference.`
-      : "auth or provider access failed for the current provider. Run /auth to refresh credentials; if you already re-authed, switch models/providers because this account may still be blocked for inference.";
-  };
-
-  const parseProviderModelRef = (
-    modelRef: unknown,
-  ): { provider: string; model: string } | undefined => {
-    if (typeof modelRef !== "string") {
-      return undefined;
-    }
-    const trimmed = modelRef.trim();
-    const separator = trimmed.indexOf("/");
-    if (separator <= 0 || separator >= trimmed.length - 1) {
-      return undefined;
-    }
-    const provider = trimmed.slice(0, separator).trim();
-    const model = trimmed.slice(separator + 1).trim();
-    return provider && model ? { provider, model } : undefined;
-  };
-
-  const applyFallbackStepModelUpdate = (evt: AgentEvent): boolean => {
-    const data = evt.data ?? {};
-    if (evt.stream !== "lifecycle" || asString(data.phase, "") !== "fallback_step") {
-      return false;
-    }
-    const target = parseProviderModelRef(data.fallbackStepToModel);
-    if (!target) {
-      return false;
-    }
-    state.sessionInfo.modelProvider = target.provider;
-    state.sessionInfo.model = target.model;
-    return true;
-  };
-
-  const noteSessionRun = (runId: string) => {
-    sessionRuns.set(runId, Date.now());
-    pruneRunMap(sessionRuns);
-  };
-
-  const markSubmittedRunRegistered = (runId: string) => {
-    if (
-      pendingSessionMessageRefresh &&
-      pendingSessionMessageRunId === null &&
-      state.pendingSubmit?.runId === runId &&
-      !persistedTerminalRunIds.has(runId)
-    ) {
-      // A transcript invalidation can arrive before Gateway accepts this submit.
-      // Bind it before clearing the draft so a live final survives until persistence.
-      pendingSessionMessageRunId = runId;
-    }
-    clearPendingSubmitDraft(state, runId);
-  };
-
-  const noteFinalizedRun = (runId: string, opts?: { displayedFinal?: boolean }) => {
-    finalizedRuns.set(runId, Date.now());
-    completedRuns.set(runId, Date.now());
-    if (opts?.displayedFinal === true) {
-      finalizedRunsWithDisplay.set(runId, Date.now());
-    }
-    sessionRuns.delete(runId);
-    streamAssembler.drop(runId);
-    pruneRunMap(finalizedRuns);
-    pruneRunMap(finalizedRunsWithDisplay);
-    pruneRunMap(completedRuns);
-    for (const retainedRunId of liveTerminalErrorMessages.keys()) {
-      if (!finalizedRunsWithDisplay.has(retainedRunId)) {
-        liveTerminalErrorMessages.delete(retainedRunId);
-      }
-    }
-  };
-
-  const notePostFinalizingRun = (runId: string) => {
-    postFinalizingRuns.set(runId, Date.now());
-    pruneRunMap(postFinalizingRuns);
-  };
-
-  const clearActiveRunIfMatch = (runId: string) => {
-    if (state.activeChatRunId === runId) {
-      state.activeChatRunId = null;
-    }
-  };
-
-  const promoteMostRecentSessionRun = (): boolean => {
-    if (state.activeChatRunId || sessionRuns.size === 0) {
-      return false;
-    }
-    let nextRunId: string | undefined;
-    let nextSeenAt = -1;
-    for (const [runId, seenAt] of sessionRuns) {
-      if (seenAt > nextSeenAt) {
-        nextRunId = runId;
-        nextSeenAt = seenAt;
-      }
-    }
-    if (!nextRunId) {
-      return false;
-    }
-    // A concurrent run can outlive the active run. Keep the activity owner on
-    // remaining work so terminal cleanup cannot incorrectly return the TUI idle.
-    state.activeChatRunId = nextRunId;
-    clearStreamingWatchdog();
-    setActivityStatus("running");
-    armStreamingWatchdog(nextRunId);
-    return true;
-  };
-
-  const clearStaleStreamingIfNoTrackedRunRemains = () => {
-    const activeRunId = state.activeChatRunId;
-    // A missing active run is the recovery case; only tracked active runs block cleanup.
-    const activeRunIsStillTracked = activeRunId ? sessionRuns.has(activeRunId) : false;
-    if (state.activityStatus !== "streaming" || activeRunIsStillTracked || sessionRuns.size > 0) {
-      return;
-    }
-    state.activeChatRunId = null;
-    state.activityStatus = "idle";
-    setActivityStatus("idle");
-    clearStreamingWatchdog();
-    flushPendingHistoryRefreshIfIdle();
-  };
-
-  const reconnectStreamingWatchdog = () => {
-    clearStreamingWatchdog();
-    const activeRunId = state.activeChatRunId;
-    if (!activeRunId) {
-      reconnectPendingRunId = null;
-      clearStaleStreamingIfNoTrackedRunRemains();
-      return;
-    }
-    if (!sessionRuns.has(activeRunId)) {
-      reconnectPendingRunId = null;
-      state.activeChatRunId = null;
-      state.activityStatus = "idle";
-      setActivityStatus("idle");
-      flushPendingHistoryRefreshIfIdle();
-      return;
-    }
-    reconnectPendingRunId = activeRunId;
-    setActivityStatus("streaming");
-    armStreamingWatchdog(activeRunId);
-  };
-
-  const finalizeRun = (params: {
-    runId: string;
-    wasActiveRun: boolean;
-    status: "idle" | "error";
-    displayedFinal?: boolean;
-  }) => {
-    noteFinalizedRun(params.runId, { displayedFinal: params.displayedFinal });
-    clearActiveRunIfMatch(params.runId);
-    const promotedRemainingRun = promoteMostRecentSessionRun();
-    flushPendingHistoryRefreshIfIdle();
-    if (!promotedRemainingRun) {
-      if (params.wasActiveRun) {
-        setActivityStatus(params.status);
-        clearStreamingWatchdog();
-      } else {
-        if (streamingWatchdogRunId === params.runId) {
-          clearStreamingWatchdog();
-        }
-        clearStaleStreamingIfNoTrackedRunRemains();
-      }
-    }
-    void refreshSessionInfo?.();
-  };
-
-  const terminateRun = (params: {
-    runId: string;
-    wasActiveRun: boolean;
-    status: "aborted" | "error";
-  }) => {
-    completedRuns.set(params.runId, Date.now());
-    pruneRunMap(completedRuns);
-    streamAssembler.drop(params.runId);
-    sessionRuns.delete(params.runId);
-    clearActiveRunIfMatch(params.runId);
-    const promotedRemainingRun = promoteMostRecentSessionRun();
-    flushPendingHistoryRefreshIfIdle();
-    if (!promotedRemainingRun) {
-      if (params.wasActiveRun) {
-        setActivityStatus(params.status);
-        clearStreamingWatchdog();
-      } else if (streamingWatchdogRunId === params.runId) {
-        clearStreamingWatchdog();
-      }
-    }
-    void refreshSessionInfo?.();
-  };
-
-  const renderTerminalRunError = (params: {
-    runId: string;
-    errorMessage: string;
-    requireActiveOrPending?: boolean;
-  }): boolean => {
-    const { runId, errorMessage } = params;
-    const wasActiveRun = state.activeChatRunId === runId;
-    if (
-      params.requireActiveOrPending === true &&
-      !wasActiveRun &&
-      getPendingSubmitAcceptedRunId(state) !== runId
-    ) {
-      return false;
-    }
-    const renderedError = formatRawAssistantErrorForUi(errorMessage);
-    chatLog.dismissPendingSystem(runId);
-    const displayMessage = resolveAuthErrorHint(errorMessage) ?? `run error: ${renderedError}`;
-    liveTerminalErrorMessages.set(runId, displayMessage);
-    chatLog.addSystem(displayMessage);
-    noteFinalizedRun(runId, { displayedFinal: true });
-    terminateRun({ runId, wasActiveRun, status: "error" });
-    maybeRefreshHistoryForRun(runId, { hasDisplayableFinal: true });
-    return true;
-  };
-
-  const renderTerminalLifecycleError = (runId: string, errorMessage: string) => {
-    if (!renderTerminalRunError({ runId, errorMessage, requireActiveOrPending: true })) {
-      return;
-    }
-    tui.requestRender(true);
-  };
-
-  const scheduleTerminalLifecycleError = (runId: string, errorMessage: string) => {
-    clearPendingTerminalLifecycleError(runId);
-    const timer = setTimeout(() => {
-      pendingTerminalLifecycleErrors.delete(runId);
-      renderTerminalLifecycleError(runId, errorMessage);
-    }, LIFECYCLE_ERROR_RETRY_GRACE_MS);
-    timer.unref?.();
-    pendingTerminalLifecycleErrors.set(runId, { errorMessage, timer });
-  };
-
-  const hasConcurrentActiveRun = (runId: string) => {
-    const activeRunId = state.activeChatRunId;
-    return Boolean(activeRunId && activeRunId !== runId);
-  };
-
-  const maybeRefreshHistoryForRun = (
-    runId: string,
-    opts?: {
-      allowLocalWithoutDisplayableFinal?: boolean;
-      hasDisplayableFinal?: boolean;
-      wasPendingChatRun?: boolean;
+  const runCoordinator = new TuiSessionRunCoordinator({
+    state,
+    loadHistory,
+    refreshSessionInfo,
+    restoreTerminalError: (message) => chatLog.addSystem(message),
+    requestRender: (force) => tui.requestRender(force),
+    finalizeHistoryOwnedRun: ({ runId, result, previouslyDisplayed }) => {
+      // Persisted history owns the final row; retain the previous display fact
+      // after a failed rebuild so delayed finals never duplicate or disappear.
+      finalizeRun({
+        runId,
+        wasActiveRun: state.activeChatRunId === runId,
+        status: "idle",
+        displayedFinal: result.loaded || previouslyDisplayed,
+      });
     },
-  ) => {
-    const isPendingChatRun =
-      opts?.wasPendingChatRun === true || getPendingSubmitAcceptedRunId(state) === runId;
-    const isLocalRun = isLocalRunId?.(runId) ?? false;
-    if (isLocalRun) {
-      forgetLocalRunId?.(runId);
-      // Local runs with displayable output do not need a history reload.
-      if (!opts?.allowLocalWithoutDisplayableFinal) {
-        return;
-      }
-      // Defer the reload if a newer run is active so we preserve the pending
-      // user message, then flush once that active run finishes.
-      if (state.activeChatRunId && state.activeChatRunId !== runId) {
-        pendingHistoryRefresh = true;
-        return;
-      }
-    }
-    if (!isPendingChatRun && hasPendingSubmit(state)) {
-      pendingHistoryRefresh = true;
-      return;
-    }
-    // When the final event already produced displayable output, skip the
-    // reload. loadHistory() does clearAll() + rebuild from server, but the
-    // server may not have persisted this message yet, causing the
-    // just-rendered final message to vanish (#87922).
-    if (opts?.hasDisplayableFinal) {
-      return;
-    }
-    if (hasConcurrentActiveRun(runId)) {
-      return;
-    }
-    pendingHistoryRefresh = false;
-    queueHistoryReload();
-  };
+    replayHistoryRunEvent: (event) => handleChatEvent(event),
+  });
+  const {
+    sessionRuns,
+    finalizedRuns,
+    finalizedRunsWithDisplay,
+    pendingNewSessionRunIds,
+    persistedTerminalRunIds,
+    completedRuns,
+    postFinalizingRuns,
+    streamAssembler,
+  } = runCoordinator;
+  const {
+    acknowledgeChatRun,
+    applyFallbackStepModelUpdate,
+    armStreamingWatchdog,
+    clearPendingTerminalLifecycleError,
+    clearStreamingWatchdog,
+    clearStaleStreamingIfNoTrackedRunRemains,
+    clearTrackedRunState,
+    dispose,
+    finalizeRun,
+    flushPendingHistoryRefreshIfIdle,
+    hasConcurrentActiveRun,
+    markSubmittedRunRegistered,
+    maybeRefreshHistoryForRun,
+    pauseStreamingWatchdog,
+    reconnectStreamingWatchdog,
+    renderTerminalRunError,
+    scheduleTerminalLifecycleError,
+    syncSessionKey,
+    terminateRun,
+  } = createTuiRunLifecycle({
+    state,
+    runCoordinator,
+    chatLog,
+    btw,
+    tui,
+    setActivityStatus,
+    refreshSessionInfo,
+    isLocalRunId,
+    forgetLocalRunId,
+    clearLocalRunIds,
+    clearLocalBtwRunIds,
+    streamingWatchdogMs: context.streamingWatchdogMs,
+    localMode,
+  });
 
   const messageHasDisplayableNonTextContent = (message: unknown): boolean => {
     if (!message || typeof message !== "object") {
@@ -636,64 +203,17 @@ export function createEventHandlers(context: EventHandlerContext) {
     return messageHasDisplayableNonTextContent(evt.message);
   };
 
-  const isSameSessionKey = (left: string | undefined, right: string | undefined): boolean => {
-    const normalizedLeft = normalizeLowercaseStringOrEmpty(left);
-    const normalizedRight = normalizeLowercaseStringOrEmpty(right);
-    if (!normalizedLeft || !normalizedRight) {
-      return false;
-    }
-    if (normalizedLeft === normalizedRight) {
-      return true;
-    }
-    const parsedLeft = parseAgentSessionKey(normalizedLeft);
-    const parsedRight = parseAgentSessionKey(normalizedRight);
-    if (parsedLeft && parsedRight) {
-      return parsedLeft.agentId === parsedRight.agentId && parsedLeft.rest === parsedRight.rest;
-    }
-    if (parsedLeft) {
-      return parsedLeft.rest === normalizedRight;
-    }
-    if (parsedRight) {
-      return normalizedLeft === parsedRight.rest;
-    }
-    return false;
-  };
-
-  const isMatchingGlobalAgentEvent = (
-    sessionKey: string | undefined,
-    agentId?: string,
-  ): boolean => {
-    if (normalizeLowercaseStringOrEmpty(sessionKey) !== "global") {
-      return true;
-    }
-    const selectedAgentId = normalizeLowercaseStringOrEmpty(state.currentAgentId);
-    const defaultAgentId = normalizeLowercaseStringOrEmpty(state.agentDefaultId);
-    const eventAgentId = normalizeLowercaseStringOrEmpty(agentId);
-    if (eventAgentId) {
-      return eventAgentId === selectedAgentId;
-    }
-    return selectedAgentId === defaultAgentId;
-  };
-
   const handleChatEvent = (payload: unknown) => {
     if (!payload || typeof payload !== "object") {
       return;
     }
     const evt = payload as ChatEvent;
     syncSessionKey();
-    if (!isSameSessionKey(evt.sessionKey, state.currentSessionKey)) {
+    if (!matchesSelectedTuiSession(state, evt)) {
       return;
     }
-    if (!isMatchingGlobalAgentEvent(evt.sessionKey, evt.agentId)) {
-      return;
-    }
-    if (historyReloadRunIds.has(evt.runId)) {
-      const previous = deferredHistoryRunEvents.get(evt.runId);
-      // Keep the latest delta until a terminal event arrives; terminal state
-      // stays authoritative if a delayed delta follows it.
-      if (!previous || previous.state === "delta" || evt.state !== "delta") {
-        deferredHistoryRunEvents.set(evt.runId, evt);
-      }
+    if (runCoordinator.isHistoryReloadingRun(evt.runId)) {
+      runCoordinator.deferHistoryRunEvent(evt);
       return;
     }
     if (finalizedRuns.has(evt.runId)) {
@@ -713,13 +233,7 @@ export function createEventHandlers(context: EventHandlerContext) {
         }
       }
     }
-    if (reconnectPendingRunId === evt.runId) {
-      reconnectPendingRunId = null;
-    }
-    clearPendingTerminalLifecycleError(evt.runId);
-    chatLog.dismissPendingSystem(evt.runId);
-    noteSessionRun(evt.runId);
-    markSubmittedRunRegistered(evt.runId);
+    acknowledgeChatRun(evt.runId);
     const isPendingChatRun = getPendingSubmitAcceptedRunId(state) === evt.runId;
     const isLocalChatRun = isLocalRunId?.(evt.runId) ?? false;
     const isLocalBtwRun = isLocalBtwRunId?.(evt.runId) ?? false;
@@ -756,7 +270,7 @@ export function createEventHandlers(context: EventHandlerContext) {
       const wasActiveRun = state.activeChatRunId === evt.runId;
       if (!evt.message && isLocalBtwRunLocal) {
         forgetLocalBtwRunId?.(evt.runId);
-        noteFinalizedRun(evt.runId);
+        runCoordinator.noteFinalizedRun(evt.runId);
         clearStaleStreamingIfNoTrackedRunRemains();
         tui.requestRender(true);
         return;
@@ -834,82 +348,11 @@ export function createEventHandlers(context: EventHandlerContext) {
     tui.requestRender();
   };
 
-  const drainHistoryReloadQueue = () => {
-    if (historyReloadInFlight || !historyReloadQueued || !loadHistory) {
-      return;
-    }
-    const reloadGeneration = historyReloadGeneration;
-    const runIds = Array.from(queuedHistoryReloadRunIds);
-    queuedHistoryReloadRunIds.clear();
-    historyReloadQueued = false;
-    historyReloadInFlight = true;
-    const finishReload = (result: TuiHistoryLoadResult) => {
-      if (reloadGeneration !== historyReloadGeneration) {
-        return;
-      }
-      for (const runId of runIds) {
-        historyReloadRunIds.delete(runId);
-        const deferred = deferredHistoryRunEvents.get(runId);
-        deferredHistoryRunEvents.delete(runId);
-        const historyOwned = historyOwnedReloadRunIds.delete(runId);
-        const previouslyDisplayed = historyDisplayedReloadRunIds.delete(runId);
-        const restoredInFlight = result.loaded && result.inFlightRunId === runId;
-        if (historyOwned && !restoredInFlight) {
-          // Rebuilt history owns the final row; after a failed rebuild retain
-          // the pre-reload display fact so late finals neither duplicate nor vanish.
-          finalizeRun({
-            runId,
-            wasActiveRun: state.activeChatRunId === runId,
-            status: "idle",
-            displayedFinal: result.loaded || previouslyDisplayed,
-          });
-        }
-        if (deferred && (!result.loaded || historyOwned || restoredInFlight)) {
-          handleChatEvent(deferred);
-        }
-      }
-    };
-    void reloadHistoryPreservingTerminalErrors()
-      .then(finishReload, () => finishReload({ loaded: false }))
-      .finally(() => {
-        historyReloadInFlight = false;
-        drainHistoryReloadQueue();
-      });
-  };
-
-  function queueHistoryReload(
+  const queueHistoryReload = (
     runIds?: Iterable<string>,
     historyOwnedRunIds: Iterable<string> = [],
     displayedRunIds: Iterable<string> = [],
-  ) {
-    const historyOwned = new Set(historyOwnedRunIds);
-    const displayed = new Set(displayedRunIds);
-    const queuedRunIds = runIds ?? [];
-    if (!loadHistory) {
-      for (const runId of queuedRunIds) {
-        if (historyOwned.has(runId)) {
-          noteFinalizedRun(runId, { displayedFinal: true });
-        }
-      }
-      void refreshSessionInfo?.();
-      return;
-    }
-    if (runIds === undefined) {
-      historyReloadQueued = true;
-    }
-    for (const runId of queuedRunIds) {
-      historyReloadQueued = true;
-      historyReloadRunIds.add(runId);
-      queuedHistoryReloadRunIds.add(runId);
-      if (historyOwned.has(runId)) {
-        historyOwnedReloadRunIds.add(runId);
-      }
-      if (displayed.has(runId)) {
-        historyDisplayedReloadRunIds.add(runId);
-      }
-    }
-    drainHistoryReloadQueue();
-  }
+  ) => runCoordinator.queueHistoryReload(runIds, historyOwnedRunIds, displayedRunIds);
 
   const collectTrackedSessionRunIds = () => {
     const runIds = new Set(sessionRuns.keys());
@@ -934,19 +377,12 @@ export function createEventHandlers(context: EventHandlerContext) {
     }
     const evt = payload as SessionChangedEvent;
     syncSessionKey();
-    if (!isSameSessionKey(evt.sessionKey, state.currentSessionKey)) {
-      return;
-    }
-    if (!isMatchingGlobalAgentEvent(evt.sessionKey, evt.agentId)) {
+    if (!matchesSelectedTuiSession(state, evt)) {
       return;
     }
 
     if (evt.runId && (evt.phase === "end" || evt.phase === "error")) {
-      persistedTerminalRunIds.set(evt.runId, Date.now());
-      pruneRunMap(persistedTerminalRunIds);
-      if (pendingSessionMessageRunId === evt.runId) {
-        pendingSessionMessageRunId = null;
-      }
+      runCoordinator.notePersistedRun(evt.runId);
       if (pendingNewSessionRunIds.delete(evt.runId)) {
         if (evt.phase === "end") {
           const displayedRunIds = finalizedRunsWithDisplay.has(evt.runId) ? [evt.runId] : [];
@@ -1019,19 +455,7 @@ export function createEventHandlers(context: EventHandlerContext) {
     }
     const evt = payload as SessionMessageEvent;
     syncSessionKey();
-    const eventSessionKey = normalizeLowercaseStringOrEmpty(evt.sessionKey);
-    const isUnscopedSessionAlias =
-      eventSessionKey !== "global" && !parseAgentSessionKey(eventSessionKey);
-    const eventAgentId = normalizeLowercaseStringOrEmpty(evt.agentId);
-    const selectedAgentId = normalizeLowercaseStringOrEmpty(state.currentAgentId);
-    const ownsUnscopedSessionAlias = eventAgentId
-      ? eventAgentId === selectedAgentId
-      : selectedAgentId === normalizeLowercaseStringOrEmpty(state.agentDefaultId);
-    if (
-      !isSameSessionKey(evt.sessionKey, state.currentSessionKey) ||
-      !isMatchingGlobalAgentEvent(evt.sessionKey, evt.agentId) ||
-      (isUnscopedSessionAlias && !ownsUnscopedSessionAlias)
-    ) {
+    if (!matchesSelectedTuiSession(state, evt, { requireAliasOwnership: true })) {
       return;
     }
 
@@ -1049,32 +473,11 @@ export function createEventHandlers(context: EventHandlerContext) {
       }
     }
 
-    let displayedRunAwaitingPersistence: string | null = null;
-    for (const runId of finalizedRunsWithDisplay.keys()) {
-      if (!persistedTerminalRunIds.has(runId)) {
-        displayedRunAwaitingPersistence = runId;
-      }
-    }
-
-    if (
-      state.activeChatRunId ||
-      hasPendingSubmit(state) ||
-      pendingSessionMessageRunId ||
-      displayedRunAwaitingPersistence
-    ) {
-      pendingSessionMessageRefresh = true;
-      // Visible chat finals clear the active run before their transcript is committed.
-      // Keep later client updates behind that commit so history cannot erase the final.
-      pendingSessionMessageRunId =
-        state.activeChatRunId ?? pendingSessionMessageRunId ?? displayedRunAwaitingPersistence;
-      if (pendingSessionMessageRunId && persistedTerminalRunIds.has(pendingSessionMessageRunId)) {
-        pendingSessionMessageRunId = null;
-      }
+    if (runCoordinator.deferSessionMessageRefresh()) {
       void refreshSessionInfo?.();
       return;
     }
-
-    queueHistoryReload();
+    flushPendingHistoryRefreshIfIdle();
   };
 
   const handleAgentEvent = (payload: unknown) => {
@@ -1096,17 +499,18 @@ export function createEventHandlers(context: EventHandlerContext) {
       !sessionRuns.has(evt.runId) &&
       !finalizedRuns.has(evt.runId);
     if (
-      isUntrackedRun &&
       evt.stream === "lifecycle" &&
       asString(evt.data?.phase, "") === "start" &&
+      !finalizedRuns.has(evt.runId) &&
       !(isLocalBtwRunId?.(evt.runId) ?? false) &&
-      isSameSessionKey(evt.sessionKey, state.currentSessionKey) &&
-      isMatchingGlobalAgentEvent(evt.sessionKey, evt.agentId)
+      matchesSelectedTuiSession(state, evt)
     ) {
-      noteSessionRun(evt.runId);
+      // Lifecycle start distinguishes another genuine live run from the
+      // bounded orphan-delta pool while the current run owns the status bar.
+      runCoordinator.noteSessionRun(evt.runId, { protectStream: true });
       // Mirror handleChatEvent: side-question (btw) runs never claim the active
       // slot, so a concurrent btw run cannot hijack the main activity indicator.
-      if (!state.activeChatRunId) {
+      if (isUntrackedRun && !state.activeChatRunId) {
         state.activeChatRunId = evt.runId;
       }
     }
@@ -1168,7 +572,7 @@ export function createEventHandlers(context: EventHandlerContext) {
     if (evt.stream === "lifecycle") {
       if (isPendingRun) {
         // Exact run ownership matters: concurrent clients share this event stream.
-        noteSessionRun(evt.runId);
+        runCoordinator.noteSessionRun(evt.runId, { protectStream: true });
         markSubmittedRunRegistered(evt.runId);
         state.activeChatRunId = evt.runId;
         noteLocalRunId?.(evt.runId);
@@ -1195,7 +599,7 @@ export function createEventHandlers(context: EventHandlerContext) {
         setActivityStatus("running");
       }
       if (phase === "finishing") {
-        notePostFinalizingRun(evt.runId);
+        runCoordinator.notePostFinalizingRun(evt.runId);
         if (!canUpdateActivityStatus) {
           return;
         }
@@ -1241,10 +645,7 @@ export function createEventHandlers(context: EventHandlerContext) {
     }
     const evt = payload as BtwEvent;
     syncSessionKey();
-    if (!isSameSessionKey(evt.sessionKey, state.currentSessionKey)) {
-      return;
-    }
-    if (!isMatchingGlobalAgentEvent(evt.sessionKey, evt.agentId)) {
+    if (!matchesSelectedTuiSession(state, evt)) {
       return;
     }
     if (evt.kind !== "btw") {
@@ -1261,23 +662,6 @@ export function createEventHandlers(context: EventHandlerContext) {
       isError: evt.isError,
     });
     tui.requestRender();
-  };
-
-  const dispose = () => {
-    historyReloadGeneration += 1;
-    pendingNewSessionRunIds.clear();
-    persistedTerminalRunIds.clear();
-    historyReloadRunIds.clear();
-    historyOwnedReloadRunIds.clear();
-    historyDisplayedReloadRunIds.clear();
-    liveTerminalErrorMessages.clear();
-    queuedHistoryReloadRunIds.clear();
-    historyReloadQueued = false;
-    pendingSessionMessageRefresh = false;
-    pendingSessionMessageRunId = null;
-    deferredHistoryRunEvents.clear();
-    clearStreamingWatchdog();
-    clearPendingTerminalLifecycleErrors();
   };
 
   const consumeCompletedRunForPendingSend = (runId: string) => {
@@ -1307,4 +691,3 @@ export function createEventHandlers(context: EventHandlerContext) {
     dispose,
   };
 }
-/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -212,6 +212,14 @@ export function createEventHandlers(context: EventHandlerContext) {
     if (!matchesSelectedTuiSession(state, evt)) {
       return;
     }
+    const isSequencedGatewayEvent = Number.isSafeInteger(evt.seq) && (evt.seq ?? -1) >= 0;
+    if (
+      runCoordinator.isRetiredOrphanRun(evt.runId) &&
+      !isSequencedGatewayEvent &&
+      evt.runId !== getPendingSubmitAcceptedRunId(state)
+    ) {
+      return;
+    }
     if (runCoordinator.isHistoryReloadingRun(evt.runId)) {
       runCoordinator.deferHistoryRunEvent(evt);
       return;
@@ -233,7 +241,11 @@ export function createEventHandlers(context: EventHandlerContext) {
         }
       }
     }
-    acknowledgeChatRun(evt.runId);
+    // Gateway chat envelopes require a non-negative sequence, even when a
+    // legacy peer omits agent lifecycle starts; orphan deltas have none.
+    acknowledgeChatRun(evt.runId, {
+      protectStream: isSequencedGatewayEvent,
+    });
     const isPendingChatRun = getPendingSubmitAcceptedRunId(state) === evt.runId;
     const isLocalChatRun = isLocalRunId?.(evt.runId) ?? false;
     const isLocalBtwRun = isLocalBtwRunId?.(evt.runId) ?? false;

--- a/src/tui/tui-pty-harness-fixture-support.ts
+++ b/src/tui/tui-pty-harness-fixture-support.ts
@@ -1,0 +1,89 @@
+// Keeps the fake-terminal fixture's log and opaque-session helpers independently bounded.
+import { readFile } from "node:fs/promises";
+import { sleep } from "./tui-pty-test-support.js";
+
+export type FixtureLogEntry = {
+  method: string;
+  payload?: unknown;
+};
+
+export async function readFixtureLog(logPath: string): Promise<FixtureLogEntry[]> {
+  try {
+    const text = await readFile(logPath, "utf8");
+    return text
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as FixtureLogEntry);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return [];
+    }
+    throw error;
+  }
+}
+
+export async function waitForFixtureLogEntry(
+  logPath: string,
+  predicate: (entry: FixtureLogEntry) => boolean,
+  timeoutMs: number,
+  readPtyOutput?: () => string,
+) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const entries = await readFixtureLog(logPath);
+    const match = entries.find(predicate);
+    if (match) {
+      return match;
+    }
+    await sleep(25);
+  }
+  const entries = await readFixtureLog(logPath);
+  // A swallowed command leaves no RPC; its visible rejection survives only in the terminal.
+  const ptyOutput = readPtyOutput?.() ?? "";
+  throw new Error(
+    `timed out waiting for fixture log entry\n${JSON.stringify(entries, null, 2)}\n${ptyOutput}`,
+  );
+}
+
+export function objectFieldEquals(entry: FixtureLogEntry, field: string, value: unknown) {
+  if (typeof entry.payload !== "object" || entry.payload === null) {
+    return false;
+  }
+  const payload = entry.payload as Record<string, unknown>;
+  return Object.hasOwn(payload, field) && payload[field] === value;
+}
+
+export function buildOpaqueSessionIsolationFixture(): string {
+  return `
+          if (opts.message.startsWith("opaque session isolation proof: ")) {
+            const otherSessionKey = opts.sessionKey.includes(":matrix:")
+              ? opts.sessionKey.replace("!MixedRoomAbCdEf", "!mixedroomabcdef")
+              : opts.sessionKey.replace("AbC123=", "abc123=");
+            const marker = "PTY_FOREIGN_OPAQUE_SESSION_MESSAGE";
+            queueMicrotask(() => {
+              record("foreignSessionEvent", { sessionKey: otherSessionKey, marker });
+              this.onEvent?.({
+                event: "chat",
+                payload: {
+                  runId: "run-foreign-opaque-session",
+                  sessionKey: otherSessionKey,
+                  state: "delta",
+                  message: {
+                    role: "assistant",
+                    content: [{ type: "text", text: marker }],
+                  },
+                },
+              });
+              this.onEvent?.({
+                event: "session.message",
+                payload: {
+                  agentId: "main",
+                  sessionKey: otherSessionKey,
+                  sessionId: "foreign-opaque-session",
+                  updatedAt: Date.now(),
+                },
+              });
+            });
+          }
+  `;
+}

--- a/src/tui/tui-pty-harness-fixture-test-support.ts
+++ b/src/tui/tui-pty-harness-fixture-test-support.ts
@@ -1,4 +1,4 @@
-// Keeps the fake-terminal fixture's log and opaque-session helpers independently bounded.
+// Keeps fake-terminal test-only logs and opaque-session fixtures independently bounded.
 import { readFile } from "node:fs/promises";
 import { sleep } from "./tui-pty-test-support.js";
 

--- a/src/tui/tui-pty-harness.e2e.test.ts
+++ b/src/tui/tui-pty-harness.e2e.test.ts
@@ -237,6 +237,36 @@ async function writeTuiPtyFixtureScript(dir: string) {
             });
             return { runId };
           }
+          if (opts.message.startsWith("opaque session isolation proof: ")) {
+            const otherSessionKey = opts.sessionKey.includes(":matrix:")
+              ? opts.sessionKey.replace("!MixedRoomAbCdEf", "!mixedroomabcdef")
+              : opts.sessionKey.replace("AbC123=", "abc123=");
+            const marker = "PTY_FOREIGN_OPAQUE_SESSION_MESSAGE";
+            queueMicrotask(() => {
+              record("foreignSessionEvent", { sessionKey: otherSessionKey, marker });
+              this.onEvent?.({
+                event: "chat",
+                payload: {
+                  runId: "run-foreign-opaque-session",
+                  sessionKey: otherSessionKey,
+                  state: "delta",
+                  message: {
+                    role: "assistant",
+                    content: [{ type: "text", text: marker }],
+                  },
+                },
+              });
+              this.onEvent?.({
+                event: "session.message",
+                payload: {
+                  agentId: "main",
+                  sessionKey: otherSessionKey,
+                  sessionId: "foreign-opaque-session",
+                  updatedAt: Date.now(),
+                },
+              });
+            });
+          }
           const responseDelayMs =
             opts.message === "slow prompt" ||
             opts.message === "slow reset proof" ||
@@ -978,6 +1008,38 @@ describe.sequential("TUI PTY harness", () => {
       await fixture.waitForLogEntry(
         (entry) => entry.method === "patchSession" && objectFieldEquals(entry, field, level),
       );
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  it.each([
+    {
+      provider: "Matrix",
+      sessionKey: "agent:main:matrix:channel:!MixedRoomAbCdEf:example.org",
+      message: "opaque session isolation proof: Matrix",
+    },
+    {
+      provider: "Signal",
+      sessionKey: "agent:main:signal:group:AbC123=",
+      message: "opaque session isolation proof: Signal",
+    },
+  ])(
+    "keeps case-distinct $provider conversations out of the visible terminal",
+    async ({ sessionKey, message }) => {
+      await fixture.run.write(`/session ${sessionKey}\r`, { delay: false });
+      await fixture.waitForLogEntry(
+        (entry) =>
+          entry.method === "loadHistory" && objectFieldEquals(entry, "sessionKey", sessionKey),
+      );
+
+      const outputOffset = fixture.run.output().length;
+      await fixture.run.write(`${message}\r`, { delay: false });
+      await fixture.waitForLogEntry((entry) => entry.method === "foreignSessionEvent");
+      await fixture.run.waitForOutput(`PTY_RESPONSE: ${message}`);
+
+      const sessionOutput = fixture.run.output().slice(outputOffset);
+      expect(sessionOutput).toContain(`PTY_RESPONSE: ${message}`);
+      expect(sessionOutput).not.toContain("PTY_FOREIGN_OPAQUE_SESSION_MESSAGE");
     },
     TEST_TIMEOUT_MS,
   );

--- a/src/tui/tui-pty-harness.e2e.test.ts
+++ b/src/tui/tui-pty-harness.e2e.test.ts
@@ -1,15 +1,17 @@
 // Exercises the fake-backend TUI PTY harness and visible terminal output.
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  buildOpaqueSessionIsolationFixture,
+  objectFieldEquals,
+  readFixtureLog,
+  waitForFixtureLogEntry,
+  type FixtureLogEntry,
+} from "./tui-pty-harness-fixture-support.js";
 import { sleep, startPty, type PtyRun } from "./tui-pty-test-support.js";
-
-type FixtureLogEntry = {
-  method: string;
-  payload?: unknown;
-};
 
 const activeRuns: PtyRun[] = [];
 const STARTUP_TIMEOUT_MS = 20_000;
@@ -17,53 +19,6 @@ const OUTPUT_TIMEOUT_MS = 2_000;
 const EXIT_TIMEOUT_MS = 4_000;
 const TEST_TIMEOUT_MS = 5_000;
 const STARTUP_TEST_TIMEOUT_MS = 25_000;
-
-async function readFixtureLog(logPath: string): Promise<FixtureLogEntry[]> {
-  try {
-    const text = await readFile(logPath, "utf8");
-    return text
-      .split("\n")
-      .filter(Boolean)
-      .map((line) => JSON.parse(line) as FixtureLogEntry);
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-      return [];
-    }
-    throw error;
-  }
-}
-
-async function waitForFixtureLogEntry(
-  logPath: string,
-  predicate: (entry: FixtureLogEntry) => boolean,
-  timeoutMs = OUTPUT_TIMEOUT_MS,
-  readPtyOutput?: () => string,
-) {
-  const start = Date.now();
-  while (Date.now() - start < timeoutMs) {
-    const entries = await readFixtureLog(logPath);
-    const match = entries.find(predicate);
-    if (match) {
-      return match;
-    }
-    await sleep(25);
-  }
-  const entries = await readFixtureLog(logPath);
-  // A swallowed command leaves no RPC behind, so the RPC log alone cannot say
-  // whether the TUI rejected the input; the terminal output carries that reason.
-  const ptyOutput = readPtyOutput?.() ?? "";
-  throw new Error(
-    `timed out waiting for fixture log entry\n${JSON.stringify(entries, null, 2)}\n${ptyOutput}`,
-  );
-}
-
-function objectFieldEquals(entry: FixtureLogEntry, field: string, value: unknown) {
-  if (typeof entry.payload !== "object" || entry.payload === null) {
-    return false;
-  }
-  const payload = entry.payload as Record<string, unknown>;
-  return Object.hasOwn(payload, field) && payload[field] === value;
-}
 
 async function writeTuiPtyFixtureScript(dir: string) {
   // Temp files sit outside the repo package scope; .mts preserves the ESM contract under tsx.
@@ -237,36 +192,7 @@ async function writeTuiPtyFixtureScript(dir: string) {
             });
             return { runId };
           }
-          if (opts.message.startsWith("opaque session isolation proof: ")) {
-            const otherSessionKey = opts.sessionKey.includes(":matrix:")
-              ? opts.sessionKey.replace("!MixedRoomAbCdEf", "!mixedroomabcdef")
-              : opts.sessionKey.replace("AbC123=", "abc123=");
-            const marker = "PTY_FOREIGN_OPAQUE_SESSION_MESSAGE";
-            queueMicrotask(() => {
-              record("foreignSessionEvent", { sessionKey: otherSessionKey, marker });
-              this.onEvent?.({
-                event: "chat",
-                payload: {
-                  runId: "run-foreign-opaque-session",
-                  sessionKey: otherSessionKey,
-                  state: "delta",
-                  message: {
-                    role: "assistant",
-                    content: [{ type: "text", text: marker }],
-                  },
-                },
-              });
-              this.onEvent?.({
-                event: "session.message",
-                payload: {
-                  agentId: "main",
-                  sessionKey: otherSessionKey,
-                  sessionId: "foreign-opaque-session",
-                  updatedAt: Date.now(),
-                },
-              });
-            });
-          }
+          ${buildOpaqueSessionIsolationFixture()}
           const responseDelayMs =
             opts.message === "slow prompt" ||
             opts.message === "slow reset proof" ||
@@ -562,7 +488,7 @@ async function startTuiFixture(opts: { env?: NodeJS.ProcessEnv } = {}) {
     run,
     logPath,
     waitForLogEntry: async (predicate: (entry: FixtureLogEntry) => boolean, timeoutMs?: number) =>
-      await waitForFixtureLogEntry(logPath, predicate, timeoutMs, run.output),
+      await waitForFixtureLogEntry(logPath, predicate, timeoutMs ?? OUTPUT_TIMEOUT_MS, run.output),
     cleanup: async () => {
       await run.dispose();
       await rm(tempDir, { recursive: true, force: true });

--- a/src/tui/tui-pty-harness.e2e.test.ts
+++ b/src/tui/tui-pty-harness.e2e.test.ts
@@ -10,7 +10,7 @@ import {
   readFixtureLog,
   waitForFixtureLogEntry,
   type FixtureLogEntry,
-} from "./tui-pty-harness-fixture-support.js";
+} from "./tui-pty-harness-fixture-test-support.js";
 import { sleep, startPty, type PtyRun } from "./tui-pty-test-support.js";
 
 const activeRuns: PtyRun[] = [];

--- a/src/tui/tui-pty-local.e2e.test.ts
+++ b/src/tui/tui-pty-local.e2e.test.ts
@@ -1236,6 +1236,17 @@ describe("TUI PTY real backends", () => {
         await fixture.run.waitForOutput("FOLLOWUP_RUN_COMPLETE", LOCAL_OUTPUT_TIMEOUT_MS);
         const followupOffset = fixture.run.output().lastIndexOf("FOLLOWUP_RUN_COMPLETE");
         await waitForOutputAfter(fixture.run, "| idle", followupOffset);
+        console.info(
+          "[behavior-evidence] tui-real-gateway-cross-client",
+          JSON.stringify({
+            transport: "real Gateway WebSocket",
+            terminal: "real PTY",
+            externalMessage: marker,
+            externalMessageRendered: fixture.run.output().includes(marker),
+            followupRendered: fixture.run.output().includes("FOLLOWUP_RUN_COMPLETE"),
+            returnedToIdle: fixture.run.output().slice(followupOffset).includes("| idle"),
+          }),
+        );
         await fixture.run.write("/exit\r", { delay: false });
         expect((await fixture.run.waitForExit()).exitCode).toBe(0);
       } finally {

--- a/src/tui/tui-run-lifecycle.ts
+++ b/src/tui/tui-run-lifecycle.ts
@@ -205,13 +205,13 @@ export function createTuiRunLifecycle(context: TuiRunLifecycleContext) {
     clearPendingSubmitDraft(state, runId);
   };
 
-  const acknowledgeChatRun = (runId: string) => {
+  const acknowledgeChatRun = (runId: string, options?: { protectStream?: boolean }) => {
     if (reconnectPendingRunId === runId) {
       reconnectPendingRunId = null;
     }
     clearPendingTerminalLifecycleError(runId);
     chatLog.dismissPendingSystem(runId);
-    runCoordinator.noteSessionRun(runId);
+    runCoordinator.noteSessionRun(runId, options);
     markSubmittedRunRegistered(runId);
   };
 
@@ -222,17 +222,10 @@ export function createTuiRunLifecycle(context: TuiRunLifecycleContext) {
   };
 
   const promoteMostRecentSessionRun = (): boolean => {
-    if (state.activeChatRunId || sessionRuns.size === 0) {
+    if (state.activeChatRunId) {
       return false;
     }
-    let nextRunId: string | undefined;
-    let nextSeenAt = -1;
-    for (const [runId, seenAt] of sessionRuns) {
-      if (seenAt > nextSeenAt) {
-        nextRunId = runId;
-        nextSeenAt = seenAt;
-      }
-    }
+    const nextRunId = runCoordinator.resolveMostRecentPromotableRun();
     if (!nextRunId) {
       return false;
     }

--- a/src/tui/tui-run-lifecycle.ts
+++ b/src/tui/tui-run-lifecycle.ts
@@ -1,0 +1,428 @@
+// Coordinates active TUI runs, watchdogs, terminal errors, and history refresh.
+import { classifyFailoverReason, isAuthErrorMessage } from "../agents/embedded-agent-helpers.js";
+import { formatRawAssistantErrorForUi } from "../shared/assistant-error-format.js";
+import { asString } from "./tui-formatters.js";
+import type { TuiSessionRunCoordinator } from "./tui-session-run-coordinator.js";
+import {
+  clearPendingSubmit,
+  clearPendingSubmitDraft,
+  getPendingSubmitAcceptedRunId,
+  hasPendingSubmit,
+} from "./tui-submit-state.js";
+import type { AgentEvent, TuiStateAccess } from "./tui-types.js";
+
+const DEFAULT_STREAMING_WATCHDOG_MS = 30_000;
+const LIFECYCLE_ERROR_RETRY_GRACE_MS = 15_000;
+const STREAMING_WATCHDOG_USER_MESSAGE =
+  "This response is taking longer than expected. Still waiting for the current run.";
+
+type TuiRunLifecycleContext = {
+  state: TuiStateAccess;
+  runCoordinator: TuiSessionRunCoordinator;
+  chatLog: {
+    addSystem: (text: string) => void;
+    addPendingSystem: (runId: string, text: string) => void;
+    dismissPendingSystem: (runId: string) => void;
+  };
+  btw: { clear: () => void };
+  tui: { requestRender: (force?: boolean) => void };
+  setActivityStatus: (status: string) => void;
+  refreshSessionInfo?: () => Promise<void>;
+  isLocalRunId?: (runId: string) => boolean;
+  forgetLocalRunId?: (runId: string) => void;
+  clearLocalRunIds?: () => void;
+  clearLocalBtwRunIds?: () => void;
+  streamingWatchdogMs?: number;
+  localMode?: boolean;
+};
+
+/** Gives session resets, concurrent runs, and reconnects one lifecycle owner. */
+export function createTuiRunLifecycle(context: TuiRunLifecycleContext) {
+  const {
+    state,
+    runCoordinator,
+    chatLog,
+    btw,
+    tui,
+    setActivityStatus,
+    refreshSessionInfo,
+    isLocalRunId,
+    forgetLocalRunId,
+    clearLocalRunIds,
+    clearLocalBtwRunIds,
+    localMode,
+  } = context;
+  const { sessionRuns, liveTerminalErrorMessages } = runCoordinator;
+  const pendingTerminalLifecycleErrors = new Map<
+    string,
+    { errorMessage: string; timer: ReturnType<typeof setTimeout> }
+  >();
+  const streamingWatchdogMs =
+    typeof context.streamingWatchdogMs === "number" &&
+    Number.isFinite(context.streamingWatchdogMs) &&
+    context.streamingWatchdogMs >= 0
+      ? Math.floor(context.streamingWatchdogMs)
+      : DEFAULT_STREAMING_WATCHDOG_MS;
+
+  let lastSessionKey = state.currentSessionKey;
+  let reconnectPendingRunId: string | null = null;
+  let streamingWatchdogTimer: ReturnType<typeof setTimeout> | null = null;
+  let streamingWatchdogRunId: string | null = null;
+
+  const flushPendingHistoryRefreshIfIdle = () => {
+    if (
+      state.activeChatRunId ||
+      hasPendingSubmit(state) ||
+      runCoordinator.isSessionMessagePersistencePending
+    ) {
+      return;
+    }
+    if (!runCoordinator.pendingHistoryRefresh && !runCoordinator.hasPendingSessionMessageRefresh) {
+      return;
+    }
+    runCoordinator.pendingHistoryRefresh = false;
+    runCoordinator.consumeSessionMessageRefresh();
+    runCoordinator.queueHistoryReload();
+  };
+
+  const clearStreamingWatchdog = () => {
+    if (streamingWatchdogTimer) {
+      clearTimeout(streamingWatchdogTimer);
+      streamingWatchdogTimer = null;
+    }
+    streamingWatchdogRunId = null;
+  };
+
+  const clearPendingTerminalLifecycleError = (runId: string) => {
+    const pending = pendingTerminalLifecycleErrors.get(runId);
+    if (!pending) {
+      return;
+    }
+    clearTimeout(pending.timer);
+    pendingTerminalLifecycleErrors.delete(runId);
+  };
+
+  const clearPendingTerminalLifecycleErrors = () => {
+    for (const pending of pendingTerminalLifecycleErrors.values()) {
+      clearTimeout(pending.timer);
+    }
+    pendingTerminalLifecycleErrors.clear();
+  };
+
+  const clearTrackedRunState = () => {
+    runCoordinator.clear();
+    clearPendingSubmit(state);
+    reconnectPendingRunId = null;
+    clearLocalRunIds?.();
+    clearLocalBtwRunIds?.();
+    clearPendingTerminalLifecycleErrors();
+    btw.clear();
+    clearStreamingWatchdog();
+  };
+
+  const armStreamingWatchdog = (runId: string) => {
+    if (streamingWatchdogMs <= 0) {
+      return;
+    }
+    if (streamingWatchdogTimer) {
+      clearTimeout(streamingWatchdogTimer);
+    }
+    streamingWatchdogRunId = runId;
+    streamingWatchdogTimer = setTimeout(() => {
+      streamingWatchdogTimer = null;
+      if (streamingWatchdogRunId !== runId || state.activeChatRunId !== runId) {
+        return;
+      }
+      streamingWatchdogRunId = null;
+      if (reconnectPendingRunId === runId) {
+        reconnectPendingRunId = null;
+        state.activeChatRunId = null;
+        state.activityStatus = "idle";
+        setActivityStatus("idle");
+        runCoordinator.pendingHistoryRefresh = false;
+        runCoordinator.queueHistoryReload();
+        tui.requestRender();
+        return;
+      }
+      chatLog.addPendingSystem(runId, STREAMING_WATCHDOG_USER_MESSAGE);
+      tui.requestRender();
+    }, streamingWatchdogMs);
+    streamingWatchdogTimer.unref?.();
+  };
+
+  const syncSessionKey = () => {
+    if (state.currentSessionKey === lastSessionKey) {
+      return;
+    }
+    lastSessionKey = state.currentSessionKey;
+    if (!state.activeChatRunId && !hasPendingSubmit(state)) {
+      clearTrackedRunState();
+    }
+  };
+
+  const resolveAuthErrorHint = (errorMessage: string): string | undefined => {
+    if (!localMode) {
+      return undefined;
+    }
+    const provider = state.sessionInfo.modelProvider?.trim();
+    const failoverReason = classifyFailoverReason(errorMessage, { provider });
+    if (failoverReason === "billing" || failoverReason === "rate_limit") {
+      return undefined;
+    }
+    if (!isAuthErrorMessage(errorMessage)) {
+      return undefined;
+    }
+    return provider
+      ? `auth or provider access failed for ${provider}. Run /auth ${provider} to refresh credentials; if you already re-authed, switch models/providers because this account may still be blocked for inference.`
+      : "auth or provider access failed for the current provider. Run /auth to refresh credentials; if you already re-authed, switch models/providers because this account may still be blocked for inference.";
+  };
+
+  const applyFallbackStepModelUpdate = (event: AgentEvent): boolean => {
+    const data = event.data ?? {};
+    if (event.stream !== "lifecycle" || asString(data.phase, "") !== "fallback_step") {
+      return false;
+    }
+    if (typeof data.fallbackStepToModel !== "string") {
+      return false;
+    }
+    const modelRef = data.fallbackStepToModel.trim();
+    const separator = modelRef.indexOf("/");
+    if (separator <= 0 || separator >= modelRef.length - 1) {
+      return false;
+    }
+    const provider = modelRef.slice(0, separator).trim();
+    const model = modelRef.slice(separator + 1).trim();
+    if (!provider || !model) {
+      return false;
+    }
+    state.sessionInfo.modelProvider = provider;
+    state.sessionInfo.model = model;
+    return true;
+  };
+
+  const markSubmittedRunRegistered = (runId: string) => {
+    runCoordinator.bindRegisteredPendingRun(runId);
+    clearPendingSubmitDraft(state, runId);
+  };
+
+  const acknowledgeChatRun = (runId: string) => {
+    if (reconnectPendingRunId === runId) {
+      reconnectPendingRunId = null;
+    }
+    clearPendingTerminalLifecycleError(runId);
+    chatLog.dismissPendingSystem(runId);
+    runCoordinator.noteSessionRun(runId);
+    markSubmittedRunRegistered(runId);
+  };
+
+  const clearActiveRunIfMatch = (runId: string) => {
+    if (state.activeChatRunId === runId) {
+      state.activeChatRunId = null;
+    }
+  };
+
+  const promoteMostRecentSessionRun = (): boolean => {
+    if (state.activeChatRunId || sessionRuns.size === 0) {
+      return false;
+    }
+    let nextRunId: string | undefined;
+    let nextSeenAt = -1;
+    for (const [runId, seenAt] of sessionRuns) {
+      if (seenAt > nextSeenAt) {
+        nextRunId = runId;
+        nextSeenAt = seenAt;
+      }
+    }
+    if (!nextRunId) {
+      return false;
+    }
+    // Keep concurrent work visible after its previous activity owner ends.
+    state.activeChatRunId = nextRunId;
+    clearStreamingWatchdog();
+    setActivityStatus("running");
+    armStreamingWatchdog(nextRunId);
+    return true;
+  };
+
+  const clearStaleStreamingIfNoTrackedRunRemains = () => {
+    const activeRunId = state.activeChatRunId;
+    const activeRunIsStillTracked = activeRunId ? sessionRuns.has(activeRunId) : false;
+    if (state.activityStatus !== "streaming" || activeRunIsStillTracked || sessionRuns.size > 0) {
+      return;
+    }
+    state.activeChatRunId = null;
+    state.activityStatus = "idle";
+    setActivityStatus("idle");
+    clearStreamingWatchdog();
+    flushPendingHistoryRefreshIfIdle();
+  };
+
+  const reconnectStreamingWatchdog = () => {
+    clearStreamingWatchdog();
+    const activeRunId = state.activeChatRunId;
+    if (!activeRunId) {
+      reconnectPendingRunId = null;
+      clearStaleStreamingIfNoTrackedRunRemains();
+      return;
+    }
+    if (!sessionRuns.has(activeRunId)) {
+      reconnectPendingRunId = null;
+      state.activeChatRunId = null;
+      state.activityStatus = "idle";
+      setActivityStatus("idle");
+      flushPendingHistoryRefreshIfIdle();
+      return;
+    }
+    reconnectPendingRunId = activeRunId;
+    setActivityStatus("streaming");
+    armStreamingWatchdog(activeRunId);
+  };
+
+  const finalizeRun = (params: {
+    runId: string;
+    wasActiveRun: boolean;
+    status: "idle" | "error";
+    displayedFinal?: boolean;
+  }) => {
+    runCoordinator.noteFinalizedRun(params.runId, { displayedFinal: params.displayedFinal });
+    clearActiveRunIfMatch(params.runId);
+    const promotedRemainingRun = promoteMostRecentSessionRun();
+    flushPendingHistoryRefreshIfIdle();
+    if (!promotedRemainingRun) {
+      if (params.wasActiveRun) {
+        setActivityStatus(params.status);
+        clearStreamingWatchdog();
+      } else {
+        if (streamingWatchdogRunId === params.runId) {
+          clearStreamingWatchdog();
+        }
+        clearStaleStreamingIfNoTrackedRunRemains();
+      }
+    }
+    void refreshSessionInfo?.();
+  };
+
+  const terminateRun = (params: {
+    runId: string;
+    wasActiveRun: boolean;
+    status: "aborted" | "error";
+  }) => {
+    runCoordinator.noteCompletedRun(params.runId);
+    runCoordinator.dropSessionRun(params.runId);
+    clearActiveRunIfMatch(params.runId);
+    const promotedRemainingRun = promoteMostRecentSessionRun();
+    flushPendingHistoryRefreshIfIdle();
+    if (!promotedRemainingRun) {
+      if (params.wasActiveRun) {
+        setActivityStatus(params.status);
+        clearStreamingWatchdog();
+      } else if (streamingWatchdogRunId === params.runId) {
+        clearStreamingWatchdog();
+      }
+    }
+    void refreshSessionInfo?.();
+  };
+
+  const hasConcurrentActiveRun = (runId: string) => {
+    const activeRunId = state.activeChatRunId;
+    return Boolean(activeRunId && activeRunId !== runId);
+  };
+
+  const maybeRefreshHistoryForRun = (
+    runId: string,
+    options?: {
+      allowLocalWithoutDisplayableFinal?: boolean;
+      hasDisplayableFinal?: boolean;
+      wasPendingChatRun?: boolean;
+    },
+  ) => {
+    const isPendingChatRun =
+      options?.wasPendingChatRun === true || getPendingSubmitAcceptedRunId(state) === runId;
+    const isLocalRun = isLocalRunId?.(runId) ?? false;
+    if (isLocalRun) {
+      forgetLocalRunId?.(runId);
+      if (!options?.allowLocalWithoutDisplayableFinal) {
+        return;
+      }
+      if (state.activeChatRunId && state.activeChatRunId !== runId) {
+        runCoordinator.pendingHistoryRefresh = true;
+        return;
+      }
+    }
+    if (!isPendingChatRun && hasPendingSubmit(state)) {
+      runCoordinator.pendingHistoryRefresh = true;
+      return;
+    }
+    // A full history rebuild before persistence would erase the displayed final.
+    if (options?.hasDisplayableFinal || hasConcurrentActiveRun(runId)) {
+      return;
+    }
+    runCoordinator.pendingHistoryRefresh = false;
+    runCoordinator.queueHistoryReload();
+  };
+
+  const renderTerminalRunError = (params: {
+    runId: string;
+    errorMessage: string;
+    requireActiveOrPending?: boolean;
+  }): boolean => {
+    const { runId, errorMessage } = params;
+    const wasActiveRun = state.activeChatRunId === runId;
+    if (
+      params.requireActiveOrPending &&
+      !wasActiveRun &&
+      getPendingSubmitAcceptedRunId(state) !== runId
+    ) {
+      return false;
+    }
+    const renderedError = formatRawAssistantErrorForUi(errorMessage);
+    chatLog.dismissPendingSystem(runId);
+    const displayMessage = resolveAuthErrorHint(errorMessage) ?? `run error: ${renderedError}`;
+    liveTerminalErrorMessages.set(runId, displayMessage);
+    chatLog.addSystem(displayMessage);
+    runCoordinator.noteFinalizedRun(runId, { displayedFinal: true });
+    terminateRun({ runId, wasActiveRun, status: "error" });
+    maybeRefreshHistoryForRun(runId, { hasDisplayableFinal: true });
+    return true;
+  };
+
+  const scheduleTerminalLifecycleError = (runId: string, errorMessage: string) => {
+    clearPendingTerminalLifecycleError(runId);
+    const timer = setTimeout(() => {
+      pendingTerminalLifecycleErrors.delete(runId);
+      if (renderTerminalRunError({ runId, errorMessage, requireActiveOrPending: true })) {
+        tui.requestRender(true);
+      }
+    }, LIFECYCLE_ERROR_RETRY_GRACE_MS);
+    timer.unref?.();
+    pendingTerminalLifecycleErrors.set(runId, { errorMessage, timer });
+  };
+
+  const dispose = () => {
+    runCoordinator.clear();
+    clearStreamingWatchdog();
+    clearPendingTerminalLifecycleErrors();
+  };
+
+  return {
+    acknowledgeChatRun,
+    applyFallbackStepModelUpdate,
+    armStreamingWatchdog,
+    clearPendingTerminalLifecycleError,
+    clearStreamingWatchdog,
+    clearStaleStreamingIfNoTrackedRunRemains,
+    clearTrackedRunState,
+    dispose,
+    finalizeRun,
+    flushPendingHistoryRefreshIfIdle,
+    hasConcurrentActiveRun,
+    markSubmittedRunRegistered,
+    maybeRefreshHistoryForRun,
+    pauseStreamingWatchdog: clearStreamingWatchdog,
+    reconnectStreamingWatchdog,
+    renderTerminalRunError,
+    scheduleTerminalLifecycleError,
+    syncSessionKey,
+    terminateRun,
+  };
+}

--- a/src/tui/tui-session-events.test.ts
+++ b/src/tui/tui-session-events.test.ts
@@ -1,0 +1,110 @@
+// Verifies canonical and provider-owned TUI session event routing.
+import { describe, expect, it } from "vitest";
+import { matchesSelectedTuiSession } from "./tui-session-events.js";
+import type { TuiStateAccess } from "./tui-types.js";
+
+function makeState(overrides?: Partial<TuiStateAccess>): TuiStateAccess {
+  return {
+    agentDefaultId: "main",
+    sessionMainKey: "agent:main:main",
+    sessionScope: "global",
+    agents: [],
+    currentAgentId: "main",
+    currentSessionKey: "agent:main:main",
+    currentSessionId: "session-main",
+    activeChatRunId: null,
+    pendingSubmit: null,
+    historyLoaded: true,
+    sessionInfo: {},
+    initialSessionApplied: true,
+    isConnected: true,
+    autoMessageSent: false,
+    toolsExpanded: false,
+    showThinking: false,
+    connectionStatus: "connected",
+    activityStatus: "idle",
+    statusTimeout: null,
+    lastCtrlCAt: 0,
+    ...overrides,
+  };
+}
+
+describe("matchesSelectedTuiSession", () => {
+  it("accepts a selected canonical session and its request-key alias", () => {
+    const state = makeState();
+
+    expect(matchesSelectedTuiSession(state, { sessionKey: "agent:main:main" })).toBe(true);
+    expect(matchesSelectedTuiSession(state, { sessionKey: "main" })).toBe(true);
+  });
+
+  it("rejects the same request key when owned by another canonical agent", () => {
+    expect(matchesSelectedTuiSession(makeState(), { sessionKey: "agent:other:main" })).toBe(false);
+  });
+
+  it.each([
+    {
+      provider: "Matrix",
+      selectedSessionKey: "agent:main:matrix:channel:!MixedRoom:example.org",
+      otherSessionKey: "agent:main:matrix:channel:!mixedroom:example.org",
+    },
+    {
+      provider: "Signal",
+      selectedSessionKey: "agent:main:signal:group:AbC123=",
+      otherSessionKey: "agent:main:signal:group:abc123=",
+    },
+  ])(
+    "preserves case-sensitive $provider conversation ownership",
+    ({ selectedSessionKey, otherSessionKey }) => {
+      const state = makeState({ currentSessionKey: selectedSessionKey });
+
+      expect(matchesSelectedTuiSession(state, { sessionKey: selectedSessionKey })).toBe(true);
+      expect(matchesSelectedTuiSession(state, { sessionKey: otherSessionKey })).toBe(false);
+    },
+  );
+
+  it("requires global session events to belong to the selected agent", () => {
+    const state = makeState({ currentAgentId: "work", currentSessionKey: "global" });
+
+    expect(matchesSelectedTuiSession(state, { sessionKey: "global", agentId: "work" })).toBe(true);
+    expect(matchesSelectedTuiSession(state, { sessionKey: "global", agentId: "main" })).toBe(false);
+    expect(matchesSelectedTuiSession(state, { sessionKey: "global" })).toBe(false);
+  });
+
+  it("accepts legacy global events only for the default agent", () => {
+    expect(
+      matchesSelectedTuiSession(makeState({ currentSessionKey: "global" }), {
+        sessionKey: "global",
+      }),
+    ).toBe(true);
+  });
+
+  it("guards explicit owner claims on unscoped transcript aliases", () => {
+    const state = makeState({ currentAgentId: "work", currentSessionKey: "agent:work:main" });
+
+    expect(
+      matchesSelectedTuiSession(
+        state,
+        { sessionKey: "main", agentId: "work" },
+        { requireAliasOwnership: true },
+      ),
+    ).toBe(true);
+    expect(
+      matchesSelectedTuiSession(
+        state,
+        { sessionKey: "main", agentId: "main" },
+        { requireAliasOwnership: true },
+      ),
+    ).toBe(false);
+    expect(
+      matchesSelectedTuiSession(state, { sessionKey: "main" }, { requireAliasOwnership: true }),
+    ).toBe(false);
+  });
+
+  it("rejects empty and unrelated session events", () => {
+    const state = makeState();
+
+    expect(matchesSelectedTuiSession(state, {})).toBe(false);
+    expect(matchesSelectedTuiSession(state, { sessionKey: "  " })).toBe(false);
+    expect(matchesSelectedTuiSession(state, { sessionKey: "agent:main:other" })).toBe(false);
+  });
+});

--- a/src/tui/tui-session-events.ts
+++ b/src/tui/tui-session-events.ts
@@ -1,0 +1,44 @@
+// Routes Gateway and embedded events to the exact selected TUI conversation.
+import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import { agentSessionKeysMatchByRequestKey, parseAgentSessionKey } from "../routing/session-key.js";
+import type { TuiStateAccess } from "./tui-types.js";
+
+type TuiSessionEvent = {
+  sessionKey?: string;
+  agentId?: string;
+};
+
+/** Preserves opaque peer IDs while guarding canonical, global, and alias ownership. */
+export function matchesSelectedTuiSession(
+  state: TuiStateAccess,
+  event: TuiSessionEvent,
+  options?: { requireAliasOwnership?: boolean },
+): boolean {
+  const eventSessionKey = event.sessionKey?.trim();
+  if (!agentSessionKeysMatchByRequestKey(eventSessionKey, state.currentSessionKey)) {
+    return false;
+  }
+
+  const parsedEvent = parseAgentSessionKey(eventSessionKey);
+  const parsedSelection = parseAgentSessionKey(state.currentSessionKey);
+  if (
+    parsedEvent &&
+    parsedSelection &&
+    normalizeLowercaseStringOrEmpty(parsedEvent.agentId) !==
+      normalizeLowercaseStringOrEmpty(parsedSelection.agentId)
+  ) {
+    return false;
+  }
+
+  const selectedAgentId = normalizeLowercaseStringOrEmpty(state.currentAgentId);
+  const eventAgentId = normalizeLowercaseStringOrEmpty(event.agentId);
+  const defaultAgentId = normalizeLowercaseStringOrEmpty(state.agentDefaultId);
+  const isGlobalSession = normalizeLowercaseStringOrEmpty(eventSessionKey) === "global";
+  const requiresExplicitOwner =
+    isGlobalSession || (options?.requireAliasOwnership === true && !parsedEvent);
+
+  if (!requiresExplicitOwner) {
+    return true;
+  }
+  return eventAgentId ? eventAgentId === selectedAgentId : selectedAgentId === defaultAgentId;
+}

--- a/src/tui/tui-session-run-coordinator.test.ts
+++ b/src/tui/tui-session-run-coordinator.test.ts
@@ -118,6 +118,51 @@ describe("TuiSessionRunCoordinator", () => {
     ).toBe("(no output)");
   });
 
+  it("promotes a lifecycle-confirmed run instead of newer orphan deltas", () => {
+    const { coordinator } = createCoordinator();
+    coordinator.noteSessionRun("run-confirmed", { protectStream: true });
+
+    for (let index = 0; index < 500; index += 1) {
+      coordinator.noteSessionRun(`run-orphan-${index}`);
+    }
+
+    expect(coordinator.resolveMostRecentPromotableRun()).toBe("run-confirmed");
+    coordinator.dropSessionRun("run-confirmed");
+    expect(coordinator.resolveMostRecentPromotableRun()).toBeUndefined();
+    expect(coordinator.isRetiredOrphanRun("run-orphan-499")).toBe(true);
+
+    coordinator.noteSessionRun("run-orphan-499");
+    expect(coordinator.sessionRuns.has("run-orphan-499")).toBe(false);
+
+    coordinator.noteSessionRun("run-orphan-0");
+    coordinator.noteSessionRun("run-never-seen");
+    expect(coordinator.sessionRuns.has("run-orphan-0")).toBe(false);
+    expect(coordinator.sessionRuns.has("run-never-seen")).toBe(false);
+
+    coordinator.noteSessionRun("run-orphan-499", { protectStream: true });
+    expect(coordinator.sessionRuns.has("run-orphan-499")).toBe(true);
+    expect(coordinator.isRetiredOrphanRun("run-orphan-499")).toBe(false);
+
+    coordinator.noteSessionRun("run-orphan-after-reactivation");
+    expect(coordinator.sessionRuns.has("run-orphan-after-reactivation")).toBe(false);
+
+    coordinator.clear();
+    coordinator.noteSessionRun("run-after-session-reset");
+    expect(coordinator.sessionRuns.has("run-after-session-reset")).toBe(true);
+  });
+
+  it("keeps an accepted submit eligible for activity promotion", () => {
+    const { coordinator } = createCoordinator({
+      state: {
+        pendingSubmit: { phase: "accepted", runId: "run-pending", draftText: null },
+      },
+    });
+    coordinator.noteSessionRun("run-pending");
+    coordinator.noteSessionRun("run-orphan");
+
+    expect(coordinator.resolveMostRecentPromotableRun()).toBe("run-pending");
+  });
+
   it("keeps every displayed final behind its own persistence barrier", () => {
     const { coordinator } = createCoordinator();
     coordinator.noteFinalizedRun("run-first", { displayedFinal: true });

--- a/src/tui/tui-session-run-coordinator.test.ts
+++ b/src/tui/tui-session-run-coordinator.test.ts
@@ -1,0 +1,195 @@
+// Covers bounded TUI run ownership and transcript persistence coordination.
+import { describe, expect, it, vi } from "vitest";
+import { TuiSessionRunCoordinator } from "./tui-session-run-coordinator.js";
+import type { ChatEvent, TuiHistoryLoadResult, TuiStateAccess } from "./tui-types.js";
+
+function makeState(overrides?: Partial<TuiStateAccess>): TuiStateAccess {
+  return {
+    agentDefaultId: "main",
+    sessionMainKey: "agent:main:main",
+    sessionScope: "global",
+    agents: [],
+    currentAgentId: "main",
+    currentSessionKey: "agent:main:main",
+    currentSessionId: "session-main",
+    activeChatRunId: null,
+    pendingSubmit: null,
+    historyLoaded: true,
+    sessionInfo: {},
+    initialSessionApplied: true,
+    isConnected: true,
+    autoMessageSent: false,
+    toolsExpanded: false,
+    showThinking: false,
+    connectionStatus: "connected",
+    activityStatus: "idle",
+    statusTimeout: null,
+    lastCtrlCAt: 0,
+    ...overrides,
+  };
+}
+
+function createCoordinator(overrides?: {
+  state?: Partial<TuiStateAccess>;
+  loadHistory?: () => Promise<TuiHistoryLoadResult>;
+}) {
+  const state = makeState(overrides?.state);
+  const loadHistory = vi.fn<() => Promise<TuiHistoryLoadResult>>(
+    overrides?.loadHistory ??
+      (async () => ({
+        loaded: true,
+        inFlightRunId: null,
+      })),
+  );
+  const finalizeHistoryOwnedRun = vi.fn();
+  const replayHistoryRunEvent = vi.fn<(event: ChatEvent) => void>();
+  const restoreTerminalError = vi.fn<(message: string) => void>();
+  const requestRender = vi.fn<(force?: boolean) => void>();
+  const coordinator = new TuiSessionRunCoordinator({
+    state,
+    loadHistory,
+    restoreTerminalError,
+    requestRender,
+    finalizeHistoryOwnedRun,
+    replayHistoryRunEvent,
+  });
+
+  return {
+    coordinator,
+    state,
+    loadHistory,
+    finalizeHistoryOwnedRun,
+    replayHistoryRunEvent,
+    restoreTerminalError,
+    requestRender,
+  };
+}
+
+describe("TuiSessionRunCoordinator", () => {
+  it("keeps the active session run while pruning hundreds of abandoned runs", () => {
+    const { coordinator, state } = createCoordinator({
+      state: { activeChatRunId: "run-live" },
+    });
+    coordinator.noteSessionRun("run-live");
+
+    for (let index = 0; index < 1_000; index += 1) {
+      coordinator.noteSessionRun(`run-orphan-${index}`);
+    }
+
+    expect(state.activeChatRunId).toBe("run-live");
+    expect(coordinator.sessionRuns.has("run-live")).toBe(true);
+    expect(coordinator.sessionRuns.size).toBeLessThanOrEqual(200);
+    expect(coordinator.sessionRuns.has("run-orphan-0")).toBe(false);
+  });
+
+  it("protects lifecycle-confirmed concurrent streams without retaining orphan streams", () => {
+    const { coordinator } = createCoordinator({ state: { activeChatRunId: "run-first" } });
+    const assistantMessage = (value: string) => ({
+      role: "assistant",
+      content: [{ type: "text", text: value }],
+    });
+
+    coordinator.noteSessionRun("run-first", { protectStream: true });
+    coordinator.noteSessionRun("run-second", { protectStream: true });
+    coordinator.streamAssembler.ingestDelta("run-first", assistantMessage("first live"), false);
+    coordinator.streamAssembler.ingestDelta("run-second", assistantMessage("second live"), false);
+
+    for (let index = 0; index < 500; index += 1) {
+      const runId = `run-orphan-${index}`;
+      coordinator.noteSessionRun(runId);
+      coordinator.streamAssembler.ingestDelta(runId, assistantMessage(`orphan ${index}`), false);
+    }
+
+    expect(coordinator.sessionRuns.size).toBeLessThanOrEqual(200);
+    expect(coordinator.sessionRuns.has("run-first")).toBe(true);
+    expect(coordinator.sessionRuns.has("run-second")).toBe(true);
+    expect(
+      coordinator.streamAssembler.finalize("run-second", { role: "assistant", content: [] }, false),
+    ).toBe("second live");
+    expect(
+      coordinator.streamAssembler.finalize("run-first", { role: "assistant", content: [] }, false),
+    ).toBe("first live");
+    expect(
+      coordinator.streamAssembler.finalize(
+        "run-orphan-0",
+        { role: "assistant", content: [] },
+        false,
+      ),
+    ).toBe("(no output)");
+  });
+
+  it("keeps every displayed final behind its own persistence barrier", () => {
+    const { coordinator } = createCoordinator();
+    coordinator.noteFinalizedRun("run-first", { displayedFinal: true });
+    coordinator.noteFinalizedRun("run-second", { displayedFinal: true });
+
+    expect(coordinator.deferSessionMessageRefresh()).toBe(true);
+    coordinator.notePersistedRun("run-second");
+    expect(coordinator.isSessionMessagePersistencePending).toBe(true);
+    coordinator.notePersistedRun("run-first");
+    expect(coordinator.isSessionMessagePersistencePending).toBe(false);
+    expect(coordinator.hasPendingSessionMessageRefresh).toBe(true);
+  });
+
+  it("recognizes persistence that arrives before a visible final", () => {
+    const { coordinator } = createCoordinator();
+    coordinator.notePersistedRun("run-first");
+    coordinator.noteFinalizedRun("run-first", { displayedFinal: true });
+
+    expect(coordinator.deferSessionMessageRefresh()).toBe(false);
+    expect(coordinator.isSessionMessagePersistencePending).toBe(false);
+  });
+
+  it("serializes queued reloads and replays a gated terminal event", async () => {
+    let resolveHistory: ((result: TuiHistoryLoadResult) => void) | undefined;
+    const { coordinator, loadHistory, finalizeHistoryOwnedRun, replayHistoryRunEvent } =
+      createCoordinator({
+        loadHistory: () =>
+          new Promise<TuiHistoryLoadResult>((resolve) => {
+            resolveHistory = resolve;
+          }),
+      });
+    const deferredEvent: ChatEvent = {
+      runId: "run-first",
+      sessionKey: "agent:main:main",
+      state: "final",
+      message: { content: [{ type: "text", text: "persisted reply" }] },
+    };
+
+    coordinator.queueHistoryReload(["run-first"], ["run-first"]);
+    coordinator.deferHistoryRunEvent(deferredEvent);
+    coordinator.queueHistoryReload();
+    expect(loadHistory).toHaveBeenCalledTimes(1);
+
+    resolveHistory?.({ loaded: true, inFlightRunId: null });
+    await vi.waitFor(() => expect(loadHistory).toHaveBeenCalledTimes(2));
+    expect(finalizeHistoryOwnedRun).toHaveBeenCalledWith({
+      runId: "run-first",
+      result: { loaded: true, inFlightRunId: null },
+      previouslyDisplayed: false,
+    });
+    expect(replayHistoryRunEvent).toHaveBeenCalledWith(deferredEvent);
+
+    resolveHistory?.({ loaded: true, inFlightRunId: null });
+  });
+
+  it("discards a stale in-flight reload when the selected session resets", async () => {
+    let resolveHistory: ((result: TuiHistoryLoadResult) => void) | undefined;
+    const { coordinator, finalizeHistoryOwnedRun, replayHistoryRunEvent } = createCoordinator({
+      loadHistory: () =>
+        new Promise<TuiHistoryLoadResult>((resolve) => {
+          resolveHistory = resolve;
+        }),
+    });
+
+    coordinator.queueHistoryReload(["run-stale"], ["run-stale"]);
+    coordinator.clear();
+    resolveHistory?.({ loaded: true, inFlightRunId: null });
+
+    await vi.waitFor(() => {
+      expect(finalizeHistoryOwnedRun).not.toHaveBeenCalled();
+      expect(replayHistoryRunEvent).not.toHaveBeenCalled();
+    });
+    expect(coordinator.isHistoryReloadingRun("run-stale")).toBe(false);
+  });
+});

--- a/src/tui/tui-session-run-coordinator.ts
+++ b/src/tui/tui-session-run-coordinator.ts
@@ -43,7 +43,9 @@ export class TuiSessionRunCoordinator {
   private readonly queuedHistoryReloadRunIds = new Set<string>();
   private readonly deferredHistoryRunEvents = new Map<string, ChatEvent>();
   private readonly sessionMessagePersistenceRunIds = new Set<string>();
-  private readonly lifecycleProtectedStreamRunIds = new Set<string>();
+  private readonly confirmedStreamRunIds = new Set<string>();
+  private readonly retiredOrphanRunIds = new Map<string, number>();
+  private rejectUnconfirmedRuns = false;
   private historyReloadInFlight = false;
   private historyReloadQueued = false;
   private historyReloadGeneration = 0;
@@ -54,7 +56,7 @@ export class TuiSessionRunCoordinator {
       return (
         runId === this.context.state.activeChatRunId ||
         runId === getPendingSubmitAcceptedRunId(this.context.state) ||
-        this.lifecycleProtectedStreamRunIds.has(runId)
+        this.confirmedStreamRunIds.has(runId)
       );
     });
   }
@@ -68,7 +70,7 @@ export class TuiSessionRunCoordinator {
       !protectActiveRun ||
       (runId !== this.context.state.activeChatRunId &&
         runId !== getPendingSubmitAcceptedRunId(this.context.state) &&
-        !this.lifecycleProtectedStreamRunIds.has(runId));
+        !this.confirmedStreamRunIds.has(runId));
 
     for (const [runId, seenAt] of runs) {
       if (runs.size <= RETAINED_TRACKED_RUNS) {
@@ -92,15 +94,22 @@ export class TuiSessionRunCoordinator {
   }
 
   noteSessionRun(runId: string, options?: { protectStream?: boolean }): void {
-    if (options?.protectStream) {
-      this.lifecycleProtectedStreamRunIds.add(runId);
-      if (this.lifecycleProtectedStreamRunIds.size > MAX_TRACKED_RUNS) {
-        for (const protectedRunId of this.lifecycleProtectedStreamRunIds) {
+    const confirmedRun =
+      options?.protectStream === true ||
+      runId === getPendingSubmitAcceptedRunId(this.context.state);
+    if (!confirmedRun && this.isRetiredOrphanRun(runId)) {
+      return;
+    }
+    if (confirmedRun) {
+      this.retiredOrphanRunIds.delete(runId);
+      this.confirmedStreamRunIds.add(runId);
+      if (this.confirmedStreamRunIds.size > MAX_TRACKED_RUNS) {
+        for (const protectedRunId of this.confirmedStreamRunIds) {
           if (
             protectedRunId !== this.context.state.activeChatRunId &&
             protectedRunId !== getPendingSubmitAcceptedRunId(this.context.state)
           ) {
-            this.lifecycleProtectedStreamRunIds.delete(protectedRunId);
+            this.confirmedStreamRunIds.delete(protectedRunId);
             break;
           }
         }
@@ -110,10 +119,57 @@ export class TuiSessionRunCoordinator {
     this.pruneRunMap(this.sessionRuns, true);
   }
 
+  isRetiredOrphanRun(runId: string): boolean {
+    return (
+      this.retiredOrphanRunIds.has(runId) ||
+      (this.rejectUnconfirmedRuns && !this.sessionRuns.has(runId))
+    );
+  }
+
+  resolveMostRecentPromotableRun(): string | undefined {
+    const pendingRunId = getPendingSubmitAcceptedRunId(this.context.state);
+    let nextRunId: string | undefined;
+    let nextSeenAt = -1;
+    let unconfirmedRunId: string | undefined;
+    let unconfirmedSeenAt = -1;
+    for (const [runId, seenAt] of this.sessionRuns) {
+      if (runId !== pendingRunId && !this.confirmedStreamRunIds.has(runId)) {
+        if (seenAt > unconfirmedSeenAt) {
+          unconfirmedRunId = runId;
+          unconfirmedSeenAt = seenAt;
+        }
+        continue;
+      }
+      if (seenAt > nextSeenAt) {
+        nextRunId = runId;
+        nextSeenAt = seenAt;
+      }
+    }
+    // Peers that omit lifecycle starts can still own a visible concurrent turn,
+    // but a confirmed run must always outrank later unconfirmed delta traffic.
+    return nextRunId ?? unconfirmedRunId;
+  }
+
   dropSessionRun(runId: string): void {
     this.sessionRuns.delete(runId);
-    this.lifecycleProtectedStreamRunIds.delete(runId);
+    const completedConfirmedRun = this.confirmedStreamRunIds.delete(runId);
     this.streamAssembler.drop(runId);
+    if (completedConfirmedRun && this.confirmedStreamRunIds.size === 0) {
+      this.rejectUnconfirmedRuns = true;
+      const activeRunId = this.context.state.activeChatRunId;
+      const pendingRunId = getPendingSubmitAcceptedRunId(this.context.state);
+      // Sequenced Gateway deltas, lifecycle starts, and accepted submits are
+      // confirmed separately; leftover orphan deltas cannot reopen completed work.
+      for (const candidateRunId of this.sessionRuns.keys()) {
+        if (candidateRunId === activeRunId || candidateRunId === pendingRunId) {
+          continue;
+        }
+        this.sessionRuns.delete(candidateRunId);
+        this.streamAssembler.drop(candidateRunId);
+        this.retiredOrphanRunIds.set(candidateRunId, Date.now());
+      }
+      this.pruneRunMap(this.retiredOrphanRunIds);
+    }
   }
 
   noteCompletedRun(runId: string): void {
@@ -326,7 +382,9 @@ export class TuiSessionRunCoordinator {
     this.historyDisplayedReloadRunIds.clear();
     this.queuedHistoryReloadRunIds.clear();
     this.deferredHistoryRunEvents.clear();
-    this.lifecycleProtectedStreamRunIds.clear();
+    this.confirmedStreamRunIds.clear();
+    this.retiredOrphanRunIds.clear();
+    this.rejectUnconfirmedRuns = false;
     this.historyReloadQueued = false;
     this.pendingHistoryRefresh = false;
     this.consumeSessionMessageRefresh();

--- a/src/tui/tui-session-run-coordinator.ts
+++ b/src/tui/tui-session-run-coordinator.ts
@@ -1,0 +1,335 @@
+// Owns bounded TUI run state, transcript persistence, and serialized history reloads.
+import { TuiStreamAssembler } from "./tui-stream-assembler.js";
+import { getPendingSubmitAcceptedRunId, hasPendingSubmit } from "./tui-submit-state.js";
+import type { ChatEvent, TuiHistoryLoadResult, TuiStateAccess } from "./tui-types.js";
+
+const MAX_TRACKED_RUNS = 200;
+const RETAINED_TRACKED_RUNS = 150;
+const TRACKED_RUN_RETENTION_MS = 10 * 60 * 1000;
+
+type HistoryOwnedRun = {
+  runId: string;
+  result: TuiHistoryLoadResult;
+  previouslyDisplayed: boolean;
+};
+
+type TuiSessionRunCoordinatorContext = {
+  state: TuiStateAccess;
+  loadHistory?: () => Promise<TuiHistoryLoadResult>;
+  refreshSessionInfo?: () => Promise<void>;
+  restoreTerminalError: (message: string) => void;
+  requestRender: (force?: boolean) => void;
+  finalizeHistoryOwnedRun: (run: HistoryOwnedRun) => void;
+  replayHistoryRunEvent: (event: ChatEvent) => void;
+};
+
+/** Keeps one session's run, persistence, and transcript ownership together. */
+export class TuiSessionRunCoordinator {
+  readonly sessionRuns = new Map<string, number>();
+  readonly finalizedRuns = new Map<string, number>();
+  readonly finalizedRunsWithDisplay = new Map<string, number>();
+  readonly pendingNewSessionRunIds = new Set<string>();
+  readonly persistedTerminalRunIds = new Map<string, number>();
+  readonly liveTerminalErrorMessages = new Map<string, string>();
+  readonly completedRuns = new Map<string, number>();
+  readonly postFinalizingRuns = new Map<string, number>();
+  readonly streamAssembler: TuiStreamAssembler;
+
+  pendingHistoryRefresh = false;
+
+  private readonly historyReloadRunIds = new Set<string>();
+  private readonly historyOwnedReloadRunIds = new Set<string>();
+  private readonly historyDisplayedReloadRunIds = new Set<string>();
+  private readonly queuedHistoryReloadRunIds = new Set<string>();
+  private readonly deferredHistoryRunEvents = new Map<string, ChatEvent>();
+  private readonly sessionMessagePersistenceRunIds = new Set<string>();
+  private readonly lifecycleProtectedStreamRunIds = new Set<string>();
+  private historyReloadInFlight = false;
+  private historyReloadQueued = false;
+  private historyReloadGeneration = 0;
+  private sessionMessageRefreshPending = false;
+
+  constructor(private readonly context: TuiSessionRunCoordinatorContext) {
+    this.streamAssembler = new TuiStreamAssembler((runId) => {
+      return (
+        runId === this.context.state.activeChatRunId ||
+        runId === getPendingSubmitAcceptedRunId(this.context.state) ||
+        this.lifecycleProtectedStreamRunIds.has(runId)
+      );
+    });
+  }
+
+  private pruneRunMap(runs: Map<string, number>, protectActiveRun = false): void {
+    if (runs.size <= MAX_TRACKED_RUNS) {
+      return;
+    }
+    const keepUntil = Date.now() - TRACKED_RUN_RETENTION_MS;
+    const canRemove = (runId: string) =>
+      !protectActiveRun ||
+      (runId !== this.context.state.activeChatRunId &&
+        runId !== getPendingSubmitAcceptedRunId(this.context.state) &&
+        !this.lifecycleProtectedStreamRunIds.has(runId));
+
+    for (const [runId, seenAt] of runs) {
+      if (runs.size <= RETAINED_TRACKED_RUNS) {
+        break;
+      }
+      if (seenAt < keepUntil && canRemove(runId)) {
+        runs.delete(runId);
+      }
+    }
+    if (runs.size <= MAX_TRACKED_RUNS) {
+      return;
+    }
+    for (const runId of runs.keys()) {
+      if (canRemove(runId)) {
+        runs.delete(runId);
+      }
+      if (runs.size <= RETAINED_TRACKED_RUNS) {
+        break;
+      }
+    }
+  }
+
+  noteSessionRun(runId: string, options?: { protectStream?: boolean }): void {
+    if (options?.protectStream) {
+      this.lifecycleProtectedStreamRunIds.add(runId);
+      if (this.lifecycleProtectedStreamRunIds.size > MAX_TRACKED_RUNS) {
+        for (const protectedRunId of this.lifecycleProtectedStreamRunIds) {
+          if (
+            protectedRunId !== this.context.state.activeChatRunId &&
+            protectedRunId !== getPendingSubmitAcceptedRunId(this.context.state)
+          ) {
+            this.lifecycleProtectedStreamRunIds.delete(protectedRunId);
+            break;
+          }
+        }
+      }
+    }
+    this.sessionRuns.set(runId, Date.now());
+    this.pruneRunMap(this.sessionRuns, true);
+  }
+
+  dropSessionRun(runId: string): void {
+    this.sessionRuns.delete(runId);
+    this.lifecycleProtectedStreamRunIds.delete(runId);
+    this.streamAssembler.drop(runId);
+  }
+
+  noteCompletedRun(runId: string): void {
+    this.completedRuns.set(runId, Date.now());
+    this.pruneRunMap(this.completedRuns);
+  }
+
+  noteFinalizedRun(runId: string, options?: { displayedFinal?: boolean }): void {
+    this.finalizedRuns.set(runId, Date.now());
+    this.noteCompletedRun(runId);
+    if (options?.displayedFinal) {
+      this.finalizedRunsWithDisplay.set(runId, Date.now());
+      if (this.sessionMessageRefreshPending && !this.persistedTerminalRunIds.has(runId)) {
+        this.sessionMessagePersistenceRunIds.add(runId);
+      }
+    }
+    this.dropSessionRun(runId);
+    this.pruneRunMap(this.finalizedRuns);
+    this.pruneRunMap(this.finalizedRunsWithDisplay);
+
+    for (const retainedRunId of this.liveTerminalErrorMessages.keys()) {
+      if (!this.finalizedRunsWithDisplay.has(retainedRunId)) {
+        this.liveTerminalErrorMessages.delete(retainedRunId);
+      }
+    }
+    for (const retainedRunId of this.sessionMessagePersistenceRunIds) {
+      if (!this.finalizedRunsWithDisplay.has(retainedRunId) && retainedRunId !== runId) {
+        this.sessionMessagePersistenceRunIds.delete(retainedRunId);
+      }
+    }
+  }
+
+  notePostFinalizingRun(runId: string): void {
+    this.postFinalizingRuns.set(runId, Date.now());
+    this.pruneRunMap(this.postFinalizingRuns);
+  }
+
+  notePersistedRun(runId: string): void {
+    this.persistedTerminalRunIds.set(runId, Date.now());
+    this.pruneRunMap(this.persistedTerminalRunIds);
+    this.sessionMessagePersistenceRunIds.delete(runId);
+  }
+
+  bindRegisteredPendingRun(runId: string): void {
+    if (
+      this.sessionMessageRefreshPending &&
+      this.context.state.pendingSubmit?.runId === runId &&
+      !this.persistedTerminalRunIds.has(runId)
+    ) {
+      // A transcript event may precede submit acceptance and its visible final.
+      this.sessionMessagePersistenceRunIds.add(runId);
+    }
+  }
+
+  deferSessionMessageRefresh(): boolean {
+    this.sessionMessageRefreshPending = true;
+    const activeRunId = this.context.state.activeChatRunId;
+    if (activeRunId && !this.persistedTerminalRunIds.has(activeRunId)) {
+      this.sessionMessagePersistenceRunIds.add(activeRunId);
+    }
+    // All already-visible finals must be durable before a destructive rebuild.
+    for (const runId of this.finalizedRunsWithDisplay.keys()) {
+      if (!this.persistedTerminalRunIds.has(runId)) {
+        this.sessionMessagePersistenceRunIds.add(runId);
+      }
+    }
+    return Boolean(
+      activeRunId ||
+      hasPendingSubmit(this.context.state) ||
+      this.sessionMessagePersistenceRunIds.size,
+    );
+  }
+
+  get hasPendingSessionMessageRefresh(): boolean {
+    return this.sessionMessageRefreshPending;
+  }
+
+  get isSessionMessagePersistencePending(): boolean {
+    return this.sessionMessagePersistenceRunIds.size > 0;
+  }
+
+  consumeSessionMessageRefresh(): void {
+    this.sessionMessageRefreshPending = false;
+    this.sessionMessagePersistenceRunIds.clear();
+  }
+
+  isHistoryReloadingRun(runId: string): boolean {
+    return this.historyReloadRunIds.has(runId);
+  }
+
+  deferHistoryRunEvent(event: ChatEvent): void {
+    const previous = this.deferredHistoryRunEvents.get(event.runId);
+    // A terminal event remains authoritative over a delayed streaming delta.
+    if (!previous || previous.state === "delta" || event.state !== "delta") {
+      this.deferredHistoryRunEvents.set(event.runId, event);
+    }
+  }
+
+  private async loadHistoryPreservingTerminalErrors(): Promise<TuiHistoryLoadResult> {
+    if (!this.context.loadHistory) {
+      return { loaded: false };
+    }
+    const generation = this.historyReloadGeneration;
+    const result = (await this.context.loadHistory()) ?? { loaded: false };
+    if (!result.loaded || generation !== this.historyReloadGeneration) {
+      return result;
+    }
+
+    let restored = false;
+    for (const [runId, message] of this.liveTerminalErrorMessages) {
+      if (this.finalizedRunsWithDisplay.has(runId)) {
+        this.context.restoreTerminalError(message);
+        restored = true;
+      }
+    }
+    if (restored) {
+      this.context.requestRender(true);
+    }
+    return result;
+  }
+
+  private drainHistoryReloadQueue(): void {
+    if (this.historyReloadInFlight || !this.historyReloadQueued || !this.context.loadHistory) {
+      return;
+    }
+
+    const generation = this.historyReloadGeneration;
+    const runIds = Array.from(this.queuedHistoryReloadRunIds);
+    this.queuedHistoryReloadRunIds.clear();
+    this.historyReloadQueued = false;
+    this.historyReloadInFlight = true;
+
+    const finishReload = (result: TuiHistoryLoadResult) => {
+      if (generation !== this.historyReloadGeneration) {
+        return;
+      }
+      for (const runId of runIds) {
+        this.historyReloadRunIds.delete(runId);
+        const deferred = this.deferredHistoryRunEvents.get(runId);
+        this.deferredHistoryRunEvents.delete(runId);
+        const historyOwned = this.historyOwnedReloadRunIds.delete(runId);
+        const previouslyDisplayed = this.historyDisplayedReloadRunIds.delete(runId);
+        const restoredInFlight = result.loaded && result.inFlightRunId === runId;
+
+        if (historyOwned && !restoredInFlight) {
+          this.context.finalizeHistoryOwnedRun({ runId, result, previouslyDisplayed });
+        }
+        if (deferred && (!result.loaded || historyOwned || restoredInFlight)) {
+          this.context.replayHistoryRunEvent(deferred);
+        }
+      }
+    };
+
+    void this.loadHistoryPreservingTerminalErrors()
+      .then(finishReload, () => finishReload({ loaded: false }))
+      .finally(() => {
+        this.historyReloadInFlight = false;
+        this.drainHistoryReloadQueue();
+      });
+  }
+
+  queueHistoryReload(
+    runIds?: Iterable<string>,
+    historyOwnedRunIds: Iterable<string> = [],
+    displayedRunIds: Iterable<string> = [],
+  ): void {
+    const historyOwned = new Set(historyOwnedRunIds);
+    const displayed = new Set(displayedRunIds);
+    const queuedRunIds = runIds ?? [];
+
+    if (!this.context.loadHistory) {
+      for (const runId of queuedRunIds) {
+        if (historyOwned.has(runId)) {
+          this.noteFinalizedRun(runId, { displayedFinal: true });
+        }
+      }
+      void this.context.refreshSessionInfo?.();
+      return;
+    }
+
+    if (runIds === undefined) {
+      this.historyReloadQueued = true;
+    }
+    for (const runId of queuedRunIds) {
+      this.historyReloadQueued = true;
+      this.historyReloadRunIds.add(runId);
+      this.queuedHistoryReloadRunIds.add(runId);
+      if (historyOwned.has(runId)) {
+        this.historyOwnedReloadRunIds.add(runId);
+      }
+      if (displayed.has(runId)) {
+        this.historyDisplayedReloadRunIds.add(runId);
+      }
+    }
+    this.drainHistoryReloadQueue();
+  }
+
+  clear(): void {
+    this.historyReloadGeneration += 1;
+    this.sessionRuns.clear();
+    this.finalizedRuns.clear();
+    this.finalizedRunsWithDisplay.clear();
+    this.pendingNewSessionRunIds.clear();
+    this.persistedTerminalRunIds.clear();
+    this.liveTerminalErrorMessages.clear();
+    this.completedRuns.clear();
+    this.postFinalizingRuns.clear();
+    this.historyReloadRunIds.clear();
+    this.historyOwnedReloadRunIds.clear();
+    this.historyDisplayedReloadRunIds.clear();
+    this.queuedHistoryReloadRunIds.clear();
+    this.deferredHistoryRunEvents.clear();
+    this.lifecycleProtectedStreamRunIds.clear();
+    this.historyReloadQueued = false;
+    this.pendingHistoryRefresh = false;
+    this.consumeSessionMessageRefresh();
+    this.streamAssembler.clear();
+  }
+}

--- a/src/tui/tui-stream-assembler.test.ts
+++ b/src/tui/tui-stream-assembler.test.ts
@@ -181,6 +181,54 @@ describe("TuiStreamAssembler", () => {
     );
   });
 
+  it("protects a paused live stream across thousands of orphaned updates", () => {
+    const assembler = new TuiStreamAssembler((runId) => runId === "run-live");
+    assembler.ingestDelta("run-live", messageWithContent([text("Before the tool call")]), false);
+
+    for (let index = 0; index < 2_000; index += 1) {
+      assembler.ingestDelta(
+        `run-orphan-${index}`,
+        messageWithContent([text(`Draft ${index}`)]),
+        false,
+      );
+    }
+
+    expect(assembler.finalize("run-live", { role: "assistant", content: [] }, false)).toBe(
+      "Before the tool call",
+    );
+    expect(assembler.finalize("run-orphan-0", { role: "assistant", content: [] }, false)).toBe(
+      "(no output)",
+    );
+    expect(assembler.finalize("run-orphan-1999", { role: "assistant", content: [] }, false)).toBe(
+      "Draft 1999",
+    );
+  });
+
+  it("protects concurrent live streams without retaining abandoned runs", () => {
+    const protectedRuns = new Set(["run-first", "run-second"]);
+    const assembler = new TuiStreamAssembler((runId) => protectedRuns.has(runId));
+    assembler.ingestDelta("run-first", messageWithContent([text("First live response")]), false);
+    assembler.ingestDelta("run-second", messageWithContent([text("Second live response")]), false);
+
+    for (let index = 0; index < 500; index += 1) {
+      assembler.ingestDelta(
+        `run-orphan-${index}`,
+        messageWithContent([text(`Draft ${index}`)]),
+        false,
+      );
+    }
+
+    expect(assembler.finalize("run-first", { role: "assistant", content: [] }, false)).toBe(
+      "First live response",
+    );
+    expect(assembler.finalize("run-second", { role: "assistant", content: [] }, false)).toBe(
+      "Second live response",
+    );
+    expect(assembler.finalize("run-orphan-0", { role: "assistant", content: [] }, false)).toBe(
+      "(no output)",
+    );
+  });
+
   it("keeps streamed delta text when incoming tool boundary drops a block", () => {
     const assembler = new TuiStreamAssembler();
     const first = assembler.ingestDelta("run-delta-boundary", TEXT_ONLY_TWO_BLOCKS, false);

--- a/src/tui/tui-stream-assembler.ts
+++ b/src/tui/tui-stream-assembler.ts
@@ -1,5 +1,4 @@
 // Assembles streamed backend events into TUI-visible messages.
-import { pruneMapToMaxSize } from "../infra/map-size.js";
 import {
   composeThinkingAndContent,
   extractContentFromMessage,
@@ -110,7 +109,9 @@ function shouldPreserveBoundaryDroppedText(params: {
 
 /** Assembles assistant stream deltas and final messages into stable TUI display text. */
 export class TuiStreamAssembler {
-  private runs = new Map<string, RunStreamState>();
+  private readonly runs = new Map<string, RunStreamState>();
+
+  constructor(private readonly isProtectedRun?: (runId: string) => boolean) {}
 
   private createRunState(): RunStreamState {
     return {
@@ -133,7 +134,18 @@ export class TuiStreamAssembler {
 
     const state = this.createRunState();
     this.runs.set(runId, state);
-    pruneMapToMaxSize(this.runs, MAX_TRACKED_STREAM_RUNS);
+    if (this.runs.size > MAX_TRACKED_STREAM_RUNS) {
+      // A run can pause while a tool executes; unrelated deltas must not evict
+      // the partial reply that its eventual empty final still needs to render.
+      for (const trackedRunId of this.runs.keys()) {
+        if (this.runs.size <= MAX_TRACKED_STREAM_RUNS) {
+          break;
+        }
+        if (!this.isProtectedRun?.(trackedRunId)) {
+          this.runs.delete(trackedRunId);
+        }
+      }
+    }
     return state;
   }
 
@@ -224,5 +236,10 @@ export class TuiStreamAssembler {
   /** Drops stored stream state for an aborted or discarded run. */
   drop(runId: string) {
     this.runs.delete(runId);
+  }
+
+  /** Clears stream fragments when the selected conversation changes. */
+  clear() {
+    this.runs.clear();
   }
 }

--- a/src/tui/tui-types.ts
+++ b/src/tui/tui-types.ts
@@ -38,6 +38,7 @@ export type ChatEvent = {
   runId: string;
   sessionKey: string;
   agentId?: string;
+  seq?: number;
   state: "delta" | "final" | "aborted" | "error";
   message?: unknown;
   errorMessage?: string;

--- a/src/tui/tui-types.ts
+++ b/src/tui/tui-types.ts
@@ -62,6 +62,7 @@ export type SessionChangedEvent = {
   reason?: string;
   phase?: string;
   runId?: string;
+  clientRunId?: string;
   sessionId?: string;
   updatedAt?: number | null;
 };


### PR DESCRIPTION
Related: #38829, #114443

## What Problem This Solves

Fixes an issue where terminal users could see messages belonging to a different case-sensitive Matrix or Signal conversation, lose paused or concurrently streaming replies under unrelated event floods, leave the terminal permanently busy after a stale run, or erase completed replies when Gateway persistence notifications arrived out of order or used a different internal run ID.

## Why This Change Was Made

Route every TUI event through the canonical case-preserving session-key matcher. Extract focused lifecycle and session-run owners; use the existing Gateway sequence, lifecycle, and accepted-submit contracts to distinguish genuine concurrent streams from bounded orphan traffic; durably reject late orphan events until session reset; and normalize persisted internal/client run IDs before releasing the visible transcript barrier. Extract fake-terminal helpers using the established test-support naming convention and remove the obsolete oversized-handler lint exception. No protocol change, configuration, storage schema, package, or runtime dependency is introduced.

## User Impact

Terminal conversations remain isolated; paused and concurrent replies stay visible; older Gateway peers continue streaming; stale events cannot leave the terminal stuck or reopen a finished response; and messages from another real Gateway client appear without restarting. Transcript refreshes preserve completed replies even when persistence order and internal/client run IDs differ.

## Evidence

- Failing-first regressions for case-distinct conversation leaks, concurrent stream eviction, both terminal ordering races, late/evicted orphan reactivation, and aliased Gateway run persistence.
- Complete TUI suite: 34 files, 772 passing tests on the final PR revision.
- Visible fake-terminal PTY suite: 31 passing scenarios, including Matrix and Signal room isolation.
- Full real terminal/Gateway lane: 47 passing scenarios during implementation, including a real Gateway, separate WebSocket client, reconnect, queueing, cancellation, and real local backend.
- Final exact-revision real Gateway proof: second-client message, visible assistant follow-up, and return to idle.
- Stream stress: 500 to 2,000 unrelated events without losing lifecycle-confirmed, sequenced, or accepted-pending streams.
- Gateway persistence proof: client/internal run aliases, both persistence orders, terminal end and error, and three-run refresh coalescing.
- Exact repository oxlint passes across all touched production, test, and PTY files; the fixture is classified as test-only by the existing Knip support-file contract.
- Fresh independent source-aware review with no actionable findings.
