### PR TITLE
fix(cli): preserve Windows PATH delimiters in node status

### DIFF
--- a/src/cli/nodes-cli/register.status.ts
+++ b/src/cli/nodes-cli/register.status.ts
@@ -80,7 +80,12 @@ function formatNodeVersions(node: {
   return parts.length > 0 ? parts.join(" · ") : null;
 }
 
-function formatPathEnv(raw?: string): string | null {
+function isWindowsNodePlatform(platform?: string): boolean {
+  const normalized = normalizeOptionalLowercaseString(platform) ?? "";
+  return normalized === "win32" || normalized === "windows";
+}
+
+function formatPathEnv(raw?: string, platform?: string): string | null {
   if (typeof raw !== "string") {
     return null;
   }
@@ -88,9 +93,12 @@ function formatPathEnv(raw?: string): string | null {
   if (!trimmed) {
     return null;
   }
-  const parts = trimmed.split(":").filter(Boolean);
+  const delimiter = isWindowsNodePlatform(platform) ? ";" : ":";
+  const parts = trimmed.split(delimiter).filter(Boolean);
   const display =
-    parts.length <= 3 ? trimmed : `${parts.slice(0, 2).join(":")}:…:${parts.slice(-1)[0]}`;
+    parts.length <= 3
+      ? trimmed
+      : `${parts.slice(0, 2).join(delimiter)}${delimiter}…${delimiter}${parts.slice(-1)[0]}`;
   return shortenHomeInString(display);
 }
 
@@ -298,7 +306,7 @@ export function registerNodesStatusCommands(nodes: Command) {
           const rows = filtered.map((n) => {
             const perms = formatPermissions(n.permissions);
             const versions = formatNodeVersions(n);
-            const pathEnv = formatPathEnv(n.pathEnv);
+            const pathEnv = formatPathEnv(n.pathEnv, n.platform);
             const client = formatClientLabel(n);
             const lastActive = formatLastActive(now, n.lastActiveAtMs);
             const detailParts = [

--- a/src/cli/program.nodes-basic.e2e.test.ts
+++ b/src/cli/program.nodes-basic.e2e.test.ts
@@ -471,6 +471,47 @@ describe("cli program (nodes basics)", () => {
     ).toBe(true);
   });
 
+  it.each([
+    {
+      platform: "win32",
+      pathEnv: "C:\\one;D:\\two;E:\\three;F:\\four",
+      expectedPath: "path: C:\\one;D:\\two;…;F:\\four",
+      rejectedPath: "path: C:\\one;D:…:\\four",
+    },
+    {
+      platform: "windows",
+      pathEnv: "C:\\one;D:\\two;E:\\three;F:\\four",
+      expectedPath: "path: C:\\one;D:\\two;…;F:\\four",
+      rejectedPath: "path: C:\\one;D:…:\\four",
+    },
+    {
+      platform: "linux",
+      pathEnv: "/one:/two:/three:/four",
+      expectedPath: "path: /one:/two:…:/four",
+      rejectedPath: "path: /one:/two:/three:/four",
+    },
+  ])("renders $platform node PATH entries with their platform delimiter", async (fixture) => {
+    callGateway.mockResolvedValue({
+      ts: Date.now(),
+      nodes: [
+        {
+          nodeId: `${fixture.platform}-node`,
+          displayName: `${fixture.platform} node`,
+          platform: fixture.platform,
+          pathEnv: fixture.pathEnv,
+          paired: true,
+          connected: true,
+        },
+      ],
+    });
+
+    await runProgram(["nodes", "status"]);
+
+    const output = getRuntimeOutput();
+    expect(output).toContain(fixture.expectedPath);
+    expect(output).not.toContain(fixture.rejectedPath);
+  });
+
   it("keeps connection age adjacent to connection status before pending approval", async () => {
     callGateway.mockResolvedValue({
       ts: Date.now(),


### PR DESCRIPTION
[AI-assisted]
## What Problem This Solves

`openclaw nodes status` compacted every node PATH with a colon separator. For Windows nodes, drive-letter colons were therefore mistaken for PATH boundaries and the displayed value was mangled.

## Why This Change Was Made

The status renderer already receives each node's reported platform, so PATH compaction now selects the delimiter from that node-owned value: semicolon for `win32`/`windows`, and the existing colon fallback for every other platform. The rendering boundary is the narrowest owner of this presentation behavior.

## User Impact

Windows node PATH details remain readable and compact without corrupting drive letters. Linux and other POSIX-style node output, JSON status output, gateway calls, authentication, node selection, and stored node data are unchanged.

## Evidence

### Provenance

- **Base:** `2bd485825215d91a8de2db0ff7e5cdbb34a1e82e`
- **Proof head:** `759b3ee5b04949bc96af37c8cf516c3d661271cf`
- **Revalidated:** on the bound base

### Direct behavior

- **Native Windows transport (MEASURED)** — Observed: An isolated native Windows Gateway, native Windows headless node, and native Windows CLI all ran from the exact proof-head runtime. The node connected over a real WebSocket transport and reported platform `windows`, connected `true`, and the controlled PATH <code>C&#58;&#92;a;D&#58;&#92;b;E&#58;&#92;c;F&#58;&#92;d</code>; the runtime entry SHA-256 matched the source runtime entry. Result: PASS on the real Windows-owned node-to-Gateway-to-CLI path. Proves the deployed Windows node supplies both its Windows platform identity and semicolon-delimited PATH through the live Gateway record consumed by the status CLI. Preserves isolation from installed services, user configuration, and the existing Gateway.
- **Redacted Windows terminal transcript (MEASURED)** — Observed: Command: `openclaw nodes status --connected`. Sanitized Detail cell, joined across terminal wrapping: <code>path&#58;C&#58;&#92;a;D&#58;&#92;b;…;F&#58;&#92;d</code>. The pre-fix mangled shape <code>path&#58;C&#58;&#92;a;D&#58;…&#58;&#92;d</code> was absent. Result: the real native Windows CLI preserved all drive-letter colons and compacted the four PATH entries with semicolons. Proves the user-visible terminal renderer selects the delimiter reported by the target Windows node instead of splitting drive letters. Preserves a transcript containing only controlled paths and no private host, account, endpoint, token, or device identifier.

### Automated verification

#### Focused CLI behavior

```bash
node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts src/cli/program.nodes-basic.e2e.test.ts -t platform --reporter=verbose
```

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts src/cli/program.nodes-basic.e2e.test.ts -t platform --reporter=verbose` — PASS (3 passed, 25 skipped). Proves both recognized Windows platform spellings use semicolons and Linux continues to use colons in user-visible output. Preserves the surrounding node-status program registration and controlled Gateway boundary.

#### Nodes CLI regression

```bash
node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts src/cli/program.nodes-basic.e2e.test.ts
```

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts src/cli/program.nodes-basic.e2e.test.ts` — PASS (28 passed, 0 failed). Proves the complete affected nodes CLI E2E surface remains green. Preserves node listing, status filtering, detail rendering, RPC routing, and error behavior covered by that suite.

#### Changed-scope verification

```bash
env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 pnpm check:changed
```

- `env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 pnpm check:changed` — PASS (core and coreTests lanes; typecheck, lint, formatting, import-cycle, schema, and repository guards completed with exit 0). Proves the repository-classified changed scope satisfies its canonical static and compatibility gates. Preserves the broader Core contracts outside the focused CLI behavior.

#### Patch hygiene

```bash
git diff --check 2bd485825215d91a8de2db0ff7e5cdbb34a1e82e...759b3ee5b04949bc96af37c8cf516c3d661271cf
```

- `git diff --check 2bd485825215d91a8de2db0ff7e5cdbb34a1e82e...759b3ee5b04949bc96af37c8cf516c3d661271cf` — PASS (no output). Proves the exact reviewed commit contains no whitespace errors. Preserves repository patch formatting.

### Preserved boundaries

- JSON status output remains unchanged because PATH formatting is used only by the terminal detail renderer.
- Gateway RPC selection, authentication, node filtering, and terminal sanitization remain on their existing paths.
- Unknown or absent platform values retain the previous colon-delimited fallback.
- No persistence, configuration, protocol, security, timing, or concurrency contract changes.

### Proof gap

No remaining proof gap exists for the scoped PATH-rendering behavior. The exact proof head was exercised through a real native Windows node, Gateway transport, and native CLI output. Long-lived service installation and external deployment are separate, unchanged concerns and were not run; no claim about those unrelated scenarios is made.

### Artifacts

- None attached.