### PR TITLE
fix(browser): prevent duplicate tab closes during concurrent shutdown

### DIFF
--- a/extensions/browser/src/browser/session-tab-process-state.ts
+++ b/extensions/browser/src/browser/session-tab-process-state.ts
@@ -12,6 +12,7 @@ export type VolatileSessionTab = SessionTabInteractionIdentity & {
 };
 
 const volatileStateSymbol = Symbol.for("openclaw.browser.session-tabs.volatile");
+const volatileCleanupStateSymbol = Symbol.for("openclaw.browser.session-tabs.volatile-cleanup");
 const activeDurableStateSymbol = Symbol.for("openclaw.browser.session-tabs.active-durable-keys");
 const coldNativeActivityStateSymbol = Symbol.for(
   "openclaw.browser.session-tabs.cold-native-activity",
@@ -31,6 +32,15 @@ export function volatileTabsBySession(): Map<string, Map<string, VolatileSession
   };
   state[volatileStateSymbol] ??= new Map();
   return state[volatileStateSymbol];
+}
+
+/** Keeps one in-flight volatile target close shared across Browser plugin bundles. */
+export function volatileTabCleanupByTarget(): Map<string, Promise<number>> {
+  const state = globalThis as typeof globalThis & {
+    [volatileCleanupStateSymbol]?: Map<string, Promise<number>>;
+  };
+  state[volatileCleanupStateSymbol] ??= new Map();
+  return state[volatileCleanupStateSymbol];
 }
 
 export function deleteVolatileSessionTab(sessionKey: string, tabKey: string): void {

--- a/extensions/browser/src/browser/session-tab-registry.concurrent.test.ts
+++ b/extensions/browser/src/browser/session-tab-registry.concurrent.test.ts
@@ -1,0 +1,78 @@
+import { importFreshModule } from "openclaw/plugin-sdk/test-fixtures";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CloseTab, RegistryModule } from "./session-tab-registry.sqlite.test-helpers.js";
+
+const processStateSymbols = [
+  "openclaw.browser.session-tabs.volatile",
+  "openclaw.browser.session-tabs.volatile-cleanup",
+  "openclaw.browser.session-tabs.volatile-aliases",
+  "openclaw.browser.session-tabs.exact-volatile-aliases",
+];
+
+function clearProcessLocalTabState(): void {
+  const state = globalThis as Record<symbol, unknown>;
+  for (const name of processStateSymbols) {
+    delete state[Symbol.for(name)];
+  }
+}
+
+describe("volatile session tab cleanup across Browser plugin bundles", () => {
+  let freshModuleCounter = 0;
+
+  async function freshRegistry(label: string): Promise<RegistryModule> {
+    freshModuleCounter += 1;
+    return await importFreshModule<RegistryModule>(
+      import.meta.url,
+      `./session-tab-registry.js?concurrent=${label}-${freshModuleCounter}`,
+    );
+  }
+
+  beforeEach(clearProcessLocalTabState);
+  afterEach(clearProcessLocalTabState);
+
+  it("shares one close attempt and releases a failed reservation for retry", async () => {
+    const first = await freshRegistry("first");
+    const duplicate = await freshRegistry("duplicate");
+    first.trackSessionBrowserTab({
+      sessionKey: "agent:main:main",
+      targetId: "bridge-tab",
+      baseUrl: "http://127.0.0.1:9999",
+      profile: "remote",
+    });
+
+    let failClose!: () => void;
+    const failedClose = new Promise<void>((_resolve, reject) => {
+      failClose = () => reject(new Error("network down"));
+    });
+    const closeTab = vi.fn<CloseTab>(async () => await failedClose);
+    const onWarn = vi.fn();
+    const firstAttempts = [first, duplicate].map((registry) =>
+      registry.closeTrackedBrowserTabsForSessions({
+        sessionKeys: ["agent:main:main"],
+        closeTab,
+        onWarn,
+      }),
+    );
+    failClose();
+    await expect(Promise.all(firstAttempts)).resolves.toEqual([0, 0]);
+    expect(closeTab).toHaveBeenCalledOnce();
+    expect(onWarn).toHaveBeenCalledOnce();
+
+    let finishRetry!: () => void;
+    const retryGate = new Promise<void>((resolve) => {
+      finishRetry = resolve;
+    });
+    const retry = vi.fn<CloseTab>(async () => await retryGate);
+    const retries = [duplicate, first].map((registry) =>
+      registry.closeTrackedBrowserTabsForSessions({
+        sessionKeys: ["agent:main:main"],
+        closeTab: retry,
+      }),
+    );
+    finishRetry();
+    const retryResults = await Promise.all(retries);
+
+    expect(retry).toHaveBeenCalledOnce();
+    expect(retryResults.reduce((total, closed) => total + closed, 0)).toBe(1);
+  });
+});

--- a/extensions/browser/src/browser/session-tab-registry.extension-cleanup.test.ts
+++ b/extensions/browser/src/browser/session-tab-registry.extension-cleanup.test.ts
@@ -56,6 +56,7 @@ function clearProcessLocalTabState(): void {
   const state = globalThis as Record<symbol, unknown>;
   for (const name of [
     "openclaw.browser.session-tabs.volatile",
+    "openclaw.browser.session-tabs.volatile-cleanup",
     "openclaw.browser.session-tabs.active-durable-keys",
     "openclaw.browser.session-tabs.cold-native-activity",
     "openclaw.browser.session-tabs.interaction-storage-keys",

--- a/extensions/browser/src/browser/session-tab-registry.sqlite.test.ts
+++ b/extensions/browser/src/browser/session-tab-registry.sqlite.test.ts
@@ -45,6 +45,7 @@ function clearProcessLocalTabState(): void {
   const state = globalThis as Record<symbol, unknown>;
   for (const name of [
     "openclaw.browser.session-tabs.volatile",
+    "openclaw.browser.session-tabs.volatile-cleanup",
     "openclaw.browser.session-tabs.active-durable-keys",
     "openclaw.browser.session-tabs.cold-native-activity",
     "openclaw.browser.session-tabs.interaction-storage-keys",

--- a/extensions/browser/src/browser/session-tab-registry.test.ts
+++ b/extensions/browser/src/browser/session-tab-registry.test.ts
@@ -90,6 +90,32 @@ describe("session tab registry", () => {
     );
   });
 
+  it("coalesces overlapping lifecycle and sweep cleanup for one volatile target", async () => {
+    trackSessionBrowserTab({
+      sessionKey: "agent:main:main",
+      targetId: "shared-tab",
+      baseUrl: "http://127.0.0.1:9222",
+      profile: "openclaw",
+      now: 1_000,
+    });
+    let finishClose!: () => void;
+    const closeGate = new Promise<void>((resolve) => {
+      finishClose = resolve;
+    });
+    const closeTab = vi.fn(async () => await closeGate);
+
+    const lifecycle = closeTrackedBrowserTabsForSessions({
+      sessionKeys: ["agent:main:main"],
+      closeTab,
+    });
+    const sweep = sweepTrackedBrowserTabs({ now: 10_000, idleMs: 1, closeTab });
+    finishClose();
+    const results = await Promise.all([lifecycle, sweep]);
+
+    expect(closeTab).toHaveBeenCalledOnce();
+    expect(results.reduce((total, closed) => total + closed, 0)).toBe(1);
+  });
+
   it("untracks a specific tab and never adopts unknown user tabs", async () => {
     trackSessionBrowserTab({ sessionKey: "agent:main:main", targetId: "tab-a" });
     trackSessionBrowserTab({ sessionKey: "agent:main:main", targetId: "tab-b" });

--- a/extensions/browser/src/browser/session-tab-registry.ts
+++ b/extensions/browser/src/browser/session-tab-registry.ts
@@ -40,6 +40,7 @@ import {
   rememberColdNativeActivity,
   type SessionTabInteractionIdentity as InteractionIdentity,
   type VolatileSessionTab as VolatileTab,
+  volatileTabCleanupByTarget,
   volatileTabsBySession,
 } from "./session-tab-process-state.js";
 import {
@@ -619,28 +620,48 @@ async function performVolatileCleanup(
   if (cleanupKind === "sweep" && !sameVolatileTab(tab, candidate)) {
     return 0;
   }
-  try {
-    if (params.closeTab) {
-      await params.closeTab({
-        targetId: tab.targetId,
-        ...(tab.baseUrl ? { baseUrl: tab.baseUrl } : {}),
-        ...(tab.profile ? { profile: tab.profile } : {}),
-      });
-    } else {
-      await browserCloseTabByRawTargetId(tab.baseUrl, tab.targetId, {
-        profile: tab.profile,
-      });
-    }
-  } catch (error) {
-    if (isIgnorableTabCloseError(error)) {
-      deleteVolatileTarget(tab);
-      return 0;
-    }
-    params.onWarn?.(`failed to close tracked browser tab ${tab.targetId}: ${String(error)}`);
+  const inFlight = volatileTabCleanupByTarget();
+  const targetKey = volatileId(tab);
+  const existing = inFlight.get(targetKey);
+  if (existing) {
+    await existing;
     return 0;
   }
-  deleteVolatileTarget(tab);
-  return 1;
+
+  // Promise callbacks start in a microtask, so ownership is published before
+  // the close callback can issue the irreversible provider operation.
+  const cleanup = Promise.resolve().then(async () => {
+    try {
+      if (params.closeTab) {
+        await params.closeTab({
+          targetId: tab.targetId,
+          ...(tab.baseUrl ? { baseUrl: tab.baseUrl } : {}),
+          ...(tab.profile ? { profile: tab.profile } : {}),
+        });
+      } else {
+        await browserCloseTabByRawTargetId(tab.baseUrl, tab.targetId, {
+          profile: tab.profile,
+        });
+      }
+    } catch (error) {
+      if (isIgnorableTabCloseError(error)) {
+        deleteVolatileTarget(tab);
+        return 0;
+      }
+      params.onWarn?.(`failed to close tracked browser tab ${tab.targetId}: ${String(error)}`);
+      return 0;
+    }
+    deleteVolatileTarget(tab);
+    return 1;
+  });
+  inFlight.set(targetKey, cleanup);
+  try {
+    return await cleanup;
+  } finally {
+    if (inFlight.get(targetKey) === cleanup) {
+      inFlight.delete(targetKey);
+    }
+  }
 }
 
 async function closeTrackedTabs(


### PR DESCRIPTION
## What Problem This Solves

Concurrent browser lifecycle cleanup and idle sweeping could both resolve the same process-local tracked tab before either close completed. Each caller then issued the physical close and could report the same tab as closed, because volatile ownership was deleted only after the await.

The linked issue #106621's Windows profile-directory deletion theory was separately disproved and is already closed. This PR fixes only the independently reproduced volatile target close/accounting race; it does not change or claim filesystem profile cleanup.

## Why This Change Was Made

Volatile tab state is owned by the Browser plugin and already shared across duplicate loaded plugin bundles through `Symbol.for` process state. The same owner now publishes one target-keyed in-flight cleanup promise before the close operation begins. Followers await that attempt but return zero, so shutdown does not finish early and only the owner reports the close. The reservation is released after success or failure, preserving retry after transient errors.

Durable SQLite tab ownership and cleanup claims are unchanged.

## User Impact

- Lifecycle shutdown and idle sweep close a volatile browser target at most once when they overlap.
- Duplicate Browser plugin bundles share the same cleanup ownership.
- Closed-tab counts remain truthful: one physical close contributes one reported close.
- A transient close failure remains retryable.
- No configuration, default, command, public/plugin API, SQLite schema/version, protocol, filesystem profile, or security boundary changes.

## Evidence

- Regression before the production fix:
  - `node scripts/run-vitest.mjs extensions/browser/src/browser/session-tab-registry.test.ts`
  - 1 failed, 8 passed; the lifecycle/sweep close callback ran twice.
  - The equivalent duplicate-bundle failure/retry regression also failed because the close callback ran twice.
- Regression after the fix:
  - `node scripts/run-vitest.mjs extensions/browser/src/browser/session-tab-registry.test.ts` — 9 passed.
  - `node scripts/run-vitest.mjs extensions/browser/src/browser/session-tab-registry.concurrent.test.ts` — 1 passed.
  - `node scripts/run-vitest.mjs extensions/browser/src/browser/session-tab-registry.sqlite.test.ts` — 25 passed.
  - `node scripts/run-vitest.mjs extensions/browser/src/browser/session-tab-registry.extension-cleanup.test.ts` — 2 passed.
- Changed-file gate:
  - `node scripts/check-changed.mjs`
  - Passed on Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/31320993794
- Autoreview: clean after one round; no accepted/actionable findings.
- Production delta: +50/-19. Tests: +106/-0.

Rank-up moves applied: the branch was rewritten from current main; the exact registry owner, lifecycle-versus-sweep overlap, duplicate-bundle sharing, follower counts, transient failure release, retry, durable sibling boundary, and required checks are covered. No live browser/profile filesystem behavior is claimed.

Release-note context: overlapping browser shutdown and idle cleanup now share one volatile target close and report accurate cleanup counts.
