### PR TITLE
fix(cron): avoid false agent timeouts while execution lanes are busy

### DIFF
--- a/src/cron/service/agent-watchdog.test.ts
+++ b/src/cron/service/agent-watchdog.test.ts
@@ -25,7 +25,7 @@ describe("cron agent setup watchdog", () => {
     expect(watchdog.observedLaneWait()).toBe(false);
   });
 
-  it("keeps lane-wait evidence after setup timeout fires", async () => {
+  it("starts setup timeout only after lane admission", async () => {
     vi.useFakeTimers();
     const triggerTimeout = vi.fn();
     const watchdog = createCronAgentWatchdog({
@@ -39,9 +39,42 @@ describe("cron agent setup watchdog", () => {
 
     await vi.advanceTimersByTimeAsync(CRON_AGENT_SETUP_WATCHDOG_MS + 1);
 
+    expect(triggerTimeout).not.toHaveBeenCalled();
+    expect(watchdog.observedLaneWait()).toBe(true);
+
     watchdog.noteLaneAdmitted();
 
+    expect(triggerTimeout).not.toHaveBeenCalled();
+    expect(watchdog.observedLaneWait()).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(CRON_AGENT_SETUP_WATCHDOG_MS + 1);
+
     expect(triggerTimeout).toHaveBeenCalledTimes(1);
-    expect(watchdog.observedLaneWait()).toBe(true);
+    expect(watchdog.observedLaneWait()).toBe(false);
+  });
+
+  it("restarts the complete setup budget after repeated lane contention", async () => {
+    vi.useFakeTimers();
+    const triggerTimeout = vi.fn();
+    const watchdog = createCronAgentWatchdog({
+      deferUntilRunner: true,
+      jobTimeoutMs: CRON_AGENT_SETUP_WATCHDOG_MS * 2,
+      triggerTimeout,
+    });
+
+    watchdog.start();
+    for (let attempt = 0; attempt < 12; attempt += 1) {
+      watchdog.noteLaneWait();
+      await vi.advanceTimersByTimeAsync(CRON_AGENT_SETUP_WATCHDOG_MS * 2);
+      expect(triggerTimeout).not.toHaveBeenCalled();
+      watchdog.noteLaneAdmitted();
+      await vi.advanceTimersByTimeAsync(CRON_AGENT_SETUP_WATCHDOG_MS - 1);
+      expect(triggerTimeout).not.toHaveBeenCalled();
+    }
+
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(triggerTimeout).toHaveBeenCalledTimes(1);
+    expect(watchdog.observedLaneWait()).toBe(false);
   });
 });

--- a/src/cron/service/agent-watchdog.ts
+++ b/src/cron/service/agent-watchdog.ts
@@ -69,6 +69,7 @@ export function createCronAgentWatchdog(params: {
   let preExecutionTimeoutId: NodeJS.Timeout | undefined;
   let activeExecution: CronAgentExecutionStarted | undefined;
   let observedLaneWait = false;
+  let waitingForLane = false;
 
   const setTimedOut = (reason: string) => {
     if (state === "timed_out" || state === "disposed") {
@@ -91,6 +92,17 @@ export function createCronAgentWatchdog(params: {
     }
     clearTimeout(setupTimeoutId);
     setupTimeoutId = undefined;
+  };
+  // Queue contention is not runner setup; admission must begin a fresh setup budget.
+  const startSetupTimeout = () => {
+    if (setupTimeoutId || state !== "waiting_for_runner" || waitingForLane) {
+      return;
+    }
+    setupTimeoutId = setTimeout(() => {
+      if (state === "waiting_for_runner" && !waitingForLane) {
+        setTimedOut(setupTimeoutErrorMessage(activeExecution));
+      }
+    }, CRON_AGENT_SETUP_WATCHDOG_MS);
   };
   const clearPreExecutionTimeout = () => {
     if (!preExecutionTimeoutId) {
@@ -138,11 +150,7 @@ export function createCronAgentWatchdog(params: {
   return {
     start: () => {
       if (params.deferUntilRunner) {
-        setupTimeoutId = setTimeout(() => {
-          if (state === "waiting_for_runner") {
-            setTimedOut(setupTimeoutErrorMessage(activeExecution));
-          }
-        }, CRON_AGENT_SETUP_WATCHDOG_MS);
+        startSetupTimeout();
         return;
       }
       startTimeout();
@@ -150,11 +158,15 @@ export function createCronAgentWatchdog(params: {
     noteLaneWait: () => {
       if (state === "waiting_for_runner") {
         observedLaneWait = true;
+        waitingForLane = true;
+        clearSetupTimeout();
       }
     },
     noteLaneAdmitted: () => {
       if (state === "waiting_for_runner") {
         observedLaneWait = false;
+        waitingForLane = false;
+        startSetupTimeout();
       }
     },
     noteRunnerStarted: (info?: CronAgentExecutionStarted) => {

--- a/src/cron/service/timer.regression.test.ts
+++ b/src/cron/service/timer.regression.test.ts
@@ -3039,7 +3039,7 @@ describe("cron service timer regressions", () => {
     }
   });
 
-  it("does not notify setup timeout for cron-nested lane contention", async () => {
+  it("does not spend setup timeout while waiting for cron-nested admission", async () => {
     vi.useFakeTimers();
     try {
       const store = timerRegressionFixtures.makeStorePath();
@@ -3075,25 +3075,32 @@ describe("cron service timer regressions", () => {
         cleanupTimedOutAgentRun: vi.fn(async () => {}),
         onIsolatedAgentSetupTimeout,
         runIsolatedAgentJob: vi.fn(async ({ onLaneWait }) => {
-          onLaneWait?.();
+          onLaneWait?.({ waiting: true });
           return await enqueueCommandInLane(CommandLane.CronNested, async () => {
+            onLaneWait?.({ waiting: false });
             return { status: "ok" as const, summary: "lane released" };
           });
         }),
       });
 
       const timerPromise = onTimer(state);
+      let timerSettled = false;
+      void timerPromise.then(() => {
+        timerSettled = true;
+      });
       await vi.advanceTimersByTimeAsync(60_100);
       now += 60_100;
-      await timerPromise;
 
+      expect(timerSettled).toBe(false);
       expect(onIsolatedAgentSetupTimeout).not.toHaveBeenCalled();
-      const job = requireJob(state, cronJob.id);
-      expect(job.state.lastStatus).toBe("error");
-      expect(job.state.lastError).toContain("setup timed out before runner start");
 
       releaseLane.resolve();
       await laneBlocker;
+      await timerPromise;
+
+      const job = requireJob(state, cronJob.id);
+      expect(job.state.lastStatus).toBe("ok");
+      expect(job.state.lastError).toBeUndefined();
     } finally {
       vi.useRealTimers();
     }


### PR DESCRIPTION
Related: #111666

## What Problem This Solves

Fixes an issue where a scheduled isolated cron job fails with “setup timed out before runner start” even though the agent has not started setup and is only waiting for a busy `cron-nested` execution lane. Under normal concurrency pressure, valid jobs were marked failed after 60 seconds instead of running successfully once the lane became available.

## Why This Change Was Made

Pause the setup watchdog while the runner reports that it is waiting for lane admission, then start a fresh full 60-second setup budget when the lane is actually admitted. Keep the existing independent execution watchdog, genuine pre-run setup timeouts, fallback phase handling, due scheduling, and failure notifications intact.

Maintainer decision: adopt the focused lane-wait repair investigated in #111666; credit its original author in the co-authored commit, but do not import that older, conflicting PR's unrelated operator-cancellation changes or add public outcome/configuration/schema surface.

## User Impact

Busy cron lanes no longer produce false job failures, retries, alerts, or lost work. Actual runner setup stalls still time out normally after admission.

## Evidence

### Reproduced red on current main

Ran the changed regressions against the actual unmodified scheduler production code on Linux Blacksmith Testbox:

```text
FAIL cron agent setup watchdog > starts setup timeout only after lane admission
  expected triggerTimeout not to have been called; got
  "cron: isolated agent setup timed out before runner start"

FAIL cron agent setup watchdog > restarts the complete setup budget after repeated lane contention
  expected triggerTimeout not to have been called

FAIL cron service timer regressions >
  does not spend setup timeout while waiting for cron-nested admission
  expected active scheduled run to remain pending; actual run already settled as an error

Test Files  2 failed (2)
Tests       3 failed | 67 passed (70)
```

### Real scheduler and command-lane proof

The integration regression reserves the actual `CommandLane.CronNested`, starts the real `onTimer(state)` scheduler with a persisted one-shot job, advances past the former 60-second false-timeout deadline, verifies the scheduled run is still pending and no setup alert fired, releases the real command lane, and confirms the persisted job finishes `ok` with no error.

A separate stress regression performs **12 wait/admission cycles**, holding each wait for twice the setup watchdog window, and verifies that each real admission starts a complete fresh timeout budget and that only one timeout is ultimately emitted.

```text
✓ cron service timer regressions (67 tests)
✓ cron one-shot schedule ownership (7 tests)
✓ cron timer pacing (14 tests)
✓ cron agent setup watchdog (3 tests)
✓ gateway cron service (57 tests)
Focused: 148 tests passed

Full cron: 153 test files, 1,697 tests passed
pnpm check:changed: passed
Independent autoreview: clean
```

- Production and test typechecking, formatting, lint, SQLite/schema compatibility, runtime import-cycle, plugin-boundary, and SDK baseline gates: **passed**.
- The previously landed 24-job one-shot stress suite remains green.
- No skipped validation or source/schema/config compatibility surface.
- Original `#111666` investigator credited in the merged commit trailer.

AI-assisted; reproduced red-first, independently reviewed, and verified against real persisted scheduler and command-lane behavior.