### PR TITLE
fix(media): reject malformed provider binary payloads

### DIFF
--- a/extensions/google/music-generation-provider.test.ts
+++ b/extensions/google/music-generation-provider.test.ts
@@ -149,6 +149,32 @@ describe("google music generation provider", () => {
     expect(lastGoogleGenAIConfig().apiKey).toBe("google-key");
   });
 
+  it.each([
+    ["invalid alphabet", "not-base64!"],
+    ["non-canonical pad bits", "ZE=="],
+  ])("rejects %s in inline audio", async (_scenario, data) => {
+    mockGoogleAuth();
+    generateContentMock.mockResolvedValue({
+      candidates: [
+        {
+          content: { parts: [{ inlineData: { data, mimeType: "audio/mpeg" } }] },
+          finishReason: "STOP",
+        },
+      ],
+    });
+
+    await expect(
+      buildGoogleMusicGenerationProvider().generateMusic({
+        provider: "google",
+        model: "lyria-3-clip-preview",
+        prompt: "upbeat synthpop anthem",
+        cfg: {},
+      }),
+    ).rejects.toThrow("Generated music asset contains malformed base64 audio data");
+
+    expect(generateContentMock).toHaveBeenCalledTimes(1);
+  });
+
   it("retries once when Lyria returns an unblocked text-only response", async () => {
     mockGoogleAuth();
     generateContentMock

--- a/extensions/google/music-generation-provider.ts
+++ b/extensions/google/music-generation-provider.ts
@@ -1,5 +1,6 @@
 // Google provider module implements model/runtime integration.
 import { extensionForMime } from "openclaw/plugin-sdk/media-mime";
+import { generatedMusicAssetFromBase64 } from "openclaw/plugin-sdk/music-generation";
 import type {
   GeneratedMusicAsset,
   MusicGenerationProvider,
@@ -94,15 +95,17 @@ function extractTracks(params: { payload: GoogleGenerateMusicResponse; model: st
         normalizeOptionalString(inline?.mimeType) ||
         normalizeOptionalString(inline?.mime_type) ||
         "audio/mpeg";
-      tracks.push({
-        buffer: Buffer.from(data, "base64"),
-        mimeType,
-        fileName: resolveTrackFileName({
-          index: tracks.length,
+      tracks.push(
+        generatedMusicAssetFromBase64({
+          base64: data,
           mimeType,
-          model: params.model,
+          fileName: resolveTrackFileName({
+            index: tracks.length,
+            mimeType,
+            model: params.model,
+          }),
         }),
-      });
+      );
     }
   }
   return { tracks, lyrics };

--- a/extensions/google/realtime-voice-provider.test.ts
+++ b/extensions/google/realtime-voice-provider.test.ts
@@ -1122,6 +1122,53 @@ describe("buildGoogleRealtimeVoiceProvider", () => {
     expect(requireFirstAudio(onAudio)).toEqual(pcm24k);
   });
 
+  it.each([
+    ["invalid alphabet", "not-base64!"],
+    ["non-canonical pad bits", "ZE=="],
+  ])("terminates the session for %s in output audio", async (_scenario, data) => {
+    const provider = buildGoogleRealtimeVoiceProvider();
+    const onAudio = vi.fn();
+    const onError = vi.fn();
+    const onClose = vi.fn();
+    const onTranscript = vi.fn();
+    const bridge = provider.createBridge({
+      providerConfig: { apiKey: "gemini-key" },
+      audioFormat: REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ,
+      onAudio,
+      onClearAudio: vi.fn(),
+      onError,
+      onClose,
+      onTranscript,
+    });
+
+    await bridge.connect();
+    lastConnectParams().callbacks.onmessage({
+      setupComplete: { sessionId: "session-1" },
+      serverContent: {
+        outputTranscription: { text: "finalize me" },
+        modelTurn: {
+          parts: [{ inlineData: { mimeType: "audio/pcm;rate=24000", data } }],
+        },
+      },
+    });
+
+    expect(onAudio).not.toHaveBeenCalled();
+    expect(onTranscript.mock.calls).toEqual([
+      ["assistant", "finalize me", false],
+      ["assistant", "finalize me", true],
+    ]);
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "Google Live stream returned malformed base64 audio data",
+      }),
+    );
+    expect(onClose).toHaveBeenCalledWith("error");
+    expect(session.close).toHaveBeenCalledTimes(1);
+    await expect(bridge.connect()).rejects.toThrow(
+      "Google Live stream returned malformed base64 audio data",
+    );
+  });
+
   it("uses official output transcription instead of model-turn text", async () => {
     const provider = buildGoogleRealtimeVoiceProvider();
     const onTranscript = vi.fn();

--- a/extensions/google/realtime-voice-provider.ts
+++ b/extensions/google/realtime-voice-provider.ts
@@ -18,6 +18,7 @@ import {
   type ThinkingConfig,
   TurnCoverage,
 } from "@google/genai";
+import { canonicalizeBase64 } from "openclaw/plugin-sdk/media-runtime";
 import {
   resolveExpiresAtMsFromDurationMs,
   timestampMsToIsoString,
@@ -468,6 +469,8 @@ class GoogleRealtimeVoiceBridge implements RealtimeVoiceBridge {
   private reconnectAttempts = 0;
   private reconnectTimer: ReturnType<typeof setTimeout> | undefined;
   private hasConnectedSession = false;
+  private terminalError: Error | undefined;
+  private terminalCloseNotified = false;
   private readonly pendingTranscripts: Record<RealtimeVoiceRole, string> = {
     user: "",
     assistant: "",
@@ -480,6 +483,9 @@ class GoogleRealtimeVoiceBridge implements RealtimeVoiceBridge {
   }
 
   async connect(): Promise<void> {
+    if (this.terminalError) {
+      throw this.terminalError;
+    }
     const canResumeSession =
       this.config.sessionResumption !== false && Boolean(this.resumptionHandle);
     if (this.hasConnectedSession && !canResumeSession) {
@@ -534,6 +540,10 @@ class GoogleRealtimeVoiceBridge implements RealtimeVoiceBridge {
           this.sessionConfigured = false;
           this.pendingFunctionNames.clear();
           this.session = null;
+          if (this.terminalError) {
+            this.notifyTerminalClose();
+            return;
+          }
           if (this.intentionallyClosed) {
             this.config.onClose?.("completed");
             return;
@@ -788,7 +798,12 @@ class GoogleRealtimeVoiceBridge implements RealtimeVoiceBridge {
 
     for (const part of content.modelTurn?.parts ?? []) {
       if (part.inlineData?.data) {
-        const pcm = Buffer.from(part.inlineData.data, "base64");
+        const canonicalAudio = canonicalizeBase64(part.inlineData.data);
+        if (!canonicalAudio) {
+          this.failConnection(new Error("Google Live stream returned malformed base64 audio data"));
+          return;
+        }
+        const pcm = Buffer.from(canonicalAudio, "base64");
         const sampleRate = parsePcmSampleRate(part.inlineData.mimeType);
         const audio = this.toOutputAudio(pcm, sampleRate);
         if (audio.length > 0) {
@@ -843,6 +858,41 @@ class GoogleRealtimeVoiceBridge implements RealtimeVoiceBridge {
   private resetPendingTranscripts(): void {
     this.pendingTranscripts.user = "";
     this.pendingTranscripts.assistant = "";
+  }
+
+  private failConnection(error: Error): void {
+    if (this.terminalError) {
+      return;
+    }
+    this.terminalError = error;
+    this.intentionallyClosed = true;
+    this.connected = false;
+    this.sessionConfigured = false;
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = undefined;
+    }
+    this.pendingFunctionNames.clear();
+    this.flushPendingTranscripts();
+    const session = this.session;
+    this.session = null;
+    try {
+      this.config.onError?.(error);
+    } finally {
+      try {
+        session?.close();
+      } finally {
+        this.notifyTerminalClose();
+      }
+    }
+  }
+
+  private notifyTerminalClose(): void {
+    if (this.terminalCloseNotified) {
+      return;
+    }
+    this.terminalCloseNotified = true;
+    this.config.onClose?.("error");
   }
 
   private handleToolCall(toolCall: LiveServerToolCall): void {

--- a/extensions/google/video-generation-provider.test.ts
+++ b/extensions/google/video-generation-provider.test.ts
@@ -211,6 +211,33 @@ describe("google video generation provider", () => {
     expect(httpOptions).not.toHaveProperty("apiVersion");
   });
 
+  it.each([
+    ["invalid alphabet", "not-base64!"],
+    ["non-canonical pad bits", "ZE=="],
+  ])("rejects %s in inline video bytes", async (_scenario, videoBytes) => {
+    vi.spyOn(providerAuthRuntime, "resolveApiKeyForProvider").mockResolvedValue({
+      apiKey: "google-key",
+      source: "env",
+      mode: "api-key",
+    });
+    generateVideosMock.mockResolvedValue({
+      done: true,
+      response: {
+        generatedVideos: [{ video: { videoBytes, mimeType: "video/mp4" } }],
+      },
+    });
+
+    await expect(
+      buildGoogleVideoGenerationProvider().generateVideo({
+        provider: "google",
+        model: "veo-3.1-fast-generate-preview",
+        prompt: "A tiny robot watering a windowsill garden",
+        cfg: {},
+        durationSeconds: 3,
+      }),
+    ).rejects.toThrow("Google video generation returned malformed base64 video data");
+  });
+
   it("rejects inline video bytes that exceed the configured media cap", async () => {
     vi.spyOn(providerAuthRuntime, "resolveApiKeyForProvider").mockResolvedValue({
       apiKey: "google-key",

--- a/extensions/google/video-generation-provider.ts
+++ b/extensions/google/video-generation-provider.ts
@@ -1,5 +1,6 @@
 // Google provider module implements model/runtime integration.
 import { resolveGeneratedMediaMaxBytes } from "openclaw/plugin-sdk/media-generation-runtime";
+import { canonicalizeBase64 } from "openclaw/plugin-sdk/media-runtime";
 import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runtime";
 import {
   createProviderOperationDeadline,
@@ -564,7 +565,11 @@ export function buildGoogleVideoGenerationProvider(): VideoGenerationProvider {
             | { videoBytes?: string; uri?: string; mimeType?: string }
             | undefined;
           if (inline?.videoBytes) {
-            const buffer = Buffer.from(inline.videoBytes, "base64");
+            const canonicalVideo = canonicalizeBase64(inline.videoBytes);
+            if (!canonicalVideo) {
+              throw new Error("Google video generation returned malformed base64 video data");
+            }
+            const buffer = Buffer.from(canonicalVideo, "base64");
             assertGeneratedVideoBufferWithinLimit(buffer, maxVideoBytes);
             return {
               buffer,

--- a/extensions/memory-lancedb/embeddings.ts
+++ b/extensions/memory-lancedb/embeddings.ts
@@ -4,6 +4,7 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { toErrorObject } from "openclaw/plugin-sdk/error-runtime";
 import { resolveGlobalSingleton } from "openclaw/plugin-sdk/global-singleton";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
+import { canonicalizeBase64 } from "openclaw/plugin-sdk/media-runtime";
 import type { MemoryEmbeddingProvider } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
 import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
 import { ensureGlobalUndiciEnvProxyDispatcher } from "openclaw/plugin-sdk/runtime-env";
@@ -439,7 +440,11 @@ export function normalizeEmbeddingVector(value: unknown): number[] {
   }
 
   if (typeof value === "string") {
-    const bytes = Buffer.from(value, "base64");
+    const canonicalEmbedding = canonicalizeBase64(value);
+    if (!canonicalEmbedding) {
+      throw new Error("Base64 embedding response is malformed");
+    }
+    const bytes = Buffer.from(canonicalEmbedding, "base64");
     if (bytes.byteLength % Float32Array.BYTES_PER_ELEMENT !== 0) {
       throw new Error("Base64 embedding response has invalid byte length");
     }

--- a/extensions/memory-lancedb/index.test.ts
+++ b/extensions/memory-lancedb/index.test.ts
@@ -3261,6 +3261,15 @@ describe("memory plugin e2e", () => {
     expect(() => normalizeEmbeddingVector("abc")).toThrow(
       "Base64 embedding response has invalid byte length",
     );
+    expect(() => normalizeEmbeddingVector("!!!!")).toThrow(
+      "Base64 embedding response is malformed",
+    );
+    expect(() => normalizeEmbeddingVector("ZE==")).toThrow(
+      "Base64 embedding response is malformed",
+    );
+    expect(() => normalizeEmbeddingVector("AQIDBE==")).toThrow(
+      "Base64 embedding response is malformed",
+    );
     expect(() => normalizeEmbeddingVector(undefined)).toThrow(
       "Embedding response is missing a vector",
     );

--- a/extensions/openai/realtime-voice-provider.test.ts
+++ b/extensions/openai/realtime-voice-provider.test.ts
@@ -1944,6 +1944,55 @@ describe("buildOpenAIRealtimeVoiceProvider", () => {
     );
   });
 
+  it.each([
+    ["invalid alphabet", "not-base64!"],
+    ["non-canonical pad bits", "ZE=="],
+  ])("terminates the session for %s in output audio", async (_scenario, delta) => {
+    const provider = buildOpenAIRealtimeVoiceProvider();
+    const onAudio = vi.fn();
+    const onError = vi.fn();
+    const onClose = vi.fn();
+    const bridge = provider.createBridge({
+      providerConfig: { apiKey: "sk-test" }, // pragma: allowlist secret
+      onAudio,
+      onClearAudio: vi.fn(),
+      onError,
+      onClose,
+    });
+    const connecting = bridge.connect();
+    const socket = FakeWebSocket.instances[0];
+    if (!socket) {
+      throw new Error("expected bridge to create a websocket");
+    }
+    socket.readyState = FakeWebSocket.OPEN;
+    socket.emit("open");
+    socket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+    await connecting;
+
+    socket.emit(
+      "message",
+      Buffer.from(
+        JSON.stringify({
+          type: "response.output_audio.delta",
+          item_id: "item_1",
+          delta,
+        }),
+      ),
+    );
+
+    expect(onAudio).not.toHaveBeenCalled();
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "OpenAI realtime stream returned malformed base64 audio data",
+      }),
+    );
+    expect(onClose).toHaveBeenCalledWith("error");
+    expect(socket.closed).toBe(true);
+    await expect(bridge.connect()).rejects.toThrow(
+      "OpenAI realtime stream returned malformed base64 audio data",
+    );
+  });
+
   it("forwards Codex-compatible legacy realtime audio and transcript events", async () => {
     const provider = buildOpenAIRealtimeVoiceProvider();
     const onAudio = vi.fn();

--- a/extensions/openai/realtime-voice-provider.ts
+++ b/extensions/openai/realtime-voice-provider.ts
@@ -1,6 +1,7 @@
 // Openai provider module implements model/runtime integration.
 import { execFileSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
+import { canonicalizeBase64 } from "openclaw/plugin-sdk/media-runtime";
 import {
   isProviderAuthProfileConfigured,
   resolveProviderAuthProfileApiKey,
@@ -489,8 +490,16 @@ function readRealtimeErrorEventId(error: unknown): string | undefined {
   return typeof eventId === "string" ? eventId : undefined;
 }
 
+class OpenAIRealtimeMalformedAudioError extends Error {}
+
 function base64ToBuffer(b64: string): Buffer {
-  return Buffer.from(b64, "base64");
+  const canonicalAudio = canonicalizeBase64(b64);
+  if (!canonicalAudio) {
+    throw new OpenAIRealtimeMalformedAudioError(
+      "OpenAI realtime stream returned malformed base64 audio data",
+    );
+  }
+  return Buffer.from(canonicalAudio, "base64");
 }
 
 class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
@@ -527,6 +536,8 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
   private reconnectReason: string | undefined;
   private activeConnectionReason: string | undefined;
   private reconnectAbortController = new AbortController();
+  private terminalError: Error | undefined;
+  private terminalCloseNotified = false;
   private readonly audioFormat: RealtimeVoiceAudioFormat;
 
   constructor(private readonly config: OpenAIRealtimeVoiceBridgeConfig) {
@@ -534,6 +545,9 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
   }
 
   async connect(): Promise<void> {
+    if (this.terminalError) {
+      throw this.terminalError;
+    }
     this.intentionallyClosed = false;
     if (this.reconnectAbortController.signal.aborted) {
       this.reconnectAbortController = new AbortController();
@@ -725,6 +739,11 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
               settleResolve();
             }
           } catch (error) {
+            if (error instanceof OpenAIRealtimeMalformedAudioError) {
+              settleReject(error);
+              this.failConnection(error, ws);
+              return;
+            }
             console.error("[openai] realtime event parse failed:", error);
           }
         });
@@ -766,6 +785,13 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
           const wasSessionConfigured = this.sessionConfigured;
           this.connected = false;
           this.sessionConfigured = false;
+          if (this.terminalError) {
+            if (this.ws === ws) {
+              this.ws = null;
+            }
+            this.notifyTerminalClose();
+            return;
+          }
           if (this.intentionallyClosed) {
             settleResolve();
             this.config.onClose?.("completed");
@@ -1419,6 +1445,35 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
     this.lastAssistantItemId = null;
     this.toolCallBuffers.clear();
     this.deliveredToolCallKeys.clear();
+  }
+
+  private failConnection(error: OpenAIRealtimeMalformedAudioError, ws: WebSocket): void {
+    if (this.terminalError) {
+      return;
+    }
+    this.terminalError = error;
+    this.intentionallyClosed = true;
+    this.reconnectAbortController.abort();
+    this.connected = false;
+    this.sessionConfigured = false;
+    this.resetRealtimeSessionState();
+    try {
+      this.config.onError?.(error);
+    } finally {
+      if (ws.readyState !== WebSocket.CLOSED) {
+        ws.close(1002, "Malformed audio payload");
+      } else {
+        this.notifyTerminalClose();
+      }
+    }
+  }
+
+  private notifyTerminalClose(): void {
+    if (this.terminalCloseNotified) {
+      return;
+    }
+    this.terminalCloseNotified = true;
+    this.config.onClose?.("error");
   }
 
   private sendMark(): void {

--- a/src/music-generation/provider-assets.test.ts
+++ b/src/music-generation/provider-assets.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { generatedMusicAssetFromBase64 } from "./provider-assets.js";
+
+describe("generatedMusicAssetFromBase64", () => {
+  it.each([
+    ["invalid alphabet", "not-base64!"],
+    ["non-canonical pad bits", "ZE=="],
+  ])("rejects %s", (_scenario, base64) => {
+    expect(() => generatedMusicAssetFromBase64({ base64, mimeType: "audio/mpeg" })).toThrow(
+      "Generated music asset contains malformed base64 audio data",
+    );
+  });
+});

--- a/src/music-generation/provider-assets.ts
+++ b/src/music-generation/provider-assets.ts
@@ -1,4 +1,5 @@
 // Validates and normalizes provider asset attachments for music generation.
+import { canonicalizeBase64 } from "@openclaw/media-core/base64";
 import { maxBytesForKind } from "@openclaw/media-core/constants";
 import { extensionForMime } from "@openclaw/media-core/mime";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
@@ -84,9 +85,13 @@ export function generatedMusicAssetFromBase64(params: {
   index?: number;
   fileName?: string;
 }): GeneratedMusicAsset {
+  const canonicalAudio = canonicalizeBase64(params.base64);
+  if (!canonicalAudio) {
+    throw new Error("Generated music asset contains malformed base64 audio data");
+  }
   const ext = extensionForMime(params.mimeType)?.replace(/^\./u, "") || "mp3";
   return {
-    buffer: Buffer.from(params.base64, "base64"),
+    buffer: Buffer.from(canonicalAudio, "base64"),
     mimeType: params.mimeType,
     fileName: params.fileName ?? `track-${(params.index ?? 0) + 1}.${ext}`,
   };


### PR DESCRIPTION
Related: #114041
Related: #114392

## What Problem This Solves

Fixes an issue where malformed model/provider binary payloads could be silently decoded into corrupted audio, video, music, or embedding data. The remaining Google/OpenAI realtime and Google music gaps accepted invalid alphabets and non-canonical base64 pad bits; the same sweep found Google inline video, the shared generated-music decoder, and OpenAI-compatible LanceDB embeddings.

## Why This Change Was Made

Every in-scope provider output now passes through the canonical shared base64 validator before decoding. Google music delegates to the shared generated-music asset owner. Malformed Google Live and OpenAI Realtime audio is terminal for that bridge instance: pending Google transcripts finalize, error/close callbacks fire once, and reconnect is disabled. Adjacent browser/CDP screenshots, channel/telephony frames, tool/user data URLs, and internal persisted chunks were inventoried but are separate non-model-provider boundaries.

The provider generation/realtime inventory is now closed: DeepInfra video, Google speech/realtime/video/music, Inworld TTS, MiniMax image plus strict music hex, OpenAI image/realtime, OpenRouter music, Volcengine TTS, xAI TTS/realtime, and Xiaomi speech all use strict canonical/contract-specific decoding; ElevenLabs and core OpenAI-compatible speech consume bounded raw HTTP binary. The additional OpenAI-compatible embedding response path is strict as well.

## User Impact

Users now get a clear provider error instead of corrupted generated media, invalid embedding vectors, or a realtime stream that continues after unusable audio. Valid canonical, unpadded, and whitespace-normalized provider payloads continue to work.

## Evidence

- Reproduced on `origin/main` (`c7842b271311`): invalid alphabets and non-canonical pad bits were emitted/returned as decoded bytes by Google Live, OpenAI Realtime, Google music, Google video, and the shared music decoder. LanceDB additionally accepted `!!!!` as an empty vector and `AQIDBE==` as a non-canonical four-byte payload.
- Official contracts checked: `@google/genai` 2.12.0 marks `Blob.data` and `Video.videoBytes` as base64; `openai` 6.48.0 marks realtime audio deltas as base64 and embeddings support `encoding_format: "base64"`.
- Real provider proof on patch-equivalent head: Google Live returned 645 audio bytes and OpenAI Realtime returned 3,200 audio bytes on https://github.com/openclaw/openclaw/actions/runs/30254445590.
- Exact rebased patch proof on `740b40a2a736`: https://github.com/openclaw/openclaw/actions/runs/30256059891 passed 78 Google, 73 OpenAI, 138 LanceDB, and 10 shared media tests, then the full `check:changed` typecheck/lint/guard matrix.
- Stable patch ID before/after rebase: `69f5d923afff3777e4a82add6b21a0fe6341571d`.
- Independent adversarial refuter: `NO-ACTIONABLE-OBJECTION`.
- Codex autoreview: clean, no accepted/actionable findings. An initial false finding inferred that the unchanged validator lacked pad-bit checks; the explicit 8/8 shared-helper proof and supplied source contract cleared the rerun.

Production LOC is +129/-12. The non-realtime decoders are small canonicalization swaps; the net growth is the two provider-specific terminal lifecycle paths required to prevent reconnects, duplicate close notifications, and dropped pending Google transcripts.
