### PR TITLE
test(agents): cover context-window resolvers

### DIFF
--- a/src/agents/context-resolution.test.ts
+++ b/src/agents/context-resolution.test.ts
@@ -1,0 +1,214 @@
+// Covers the two exported context-window resolvers: the Anthropic fixed-window
+// gate (provider/model arms + the Claude-CLI 1M opt-in) and the cache/config
+// token resolver (configured window, override capping, unscoped lookup).
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import {
+  resolveAnthropicFixedContextWindow,
+  resolveContextTokensForModelFromCache,
+} from "./context-resolution.js";
+
+const ONE_M = 1_000_000;
+
+describe("resolveAnthropicFixedContextWindow", () => {
+  // Each row pins a distinct contract arm: provider gate, per-family windows,
+  // the mythos direct-API restriction, and the Claude-CLI 1M opt-in rules.
+  const cases: Array<{
+    name: string;
+    provider: string;
+    model: string;
+    options?: { claudeCli1M?: boolean };
+    expected: number | undefined;
+  }> = [
+    {
+      name: "non-Anthropic provider is not gated here",
+      provider: "openai",
+      model: "gpt-5.6",
+      expected: undefined,
+    },
+    {
+      name: "the provider gate wins even for a 1M-capable Claude id",
+      provider: "openai",
+      model: "claude-opus-5",
+      expected: undefined,
+    },
+    {
+      name: "anthropic Opus 4.x reports 1M",
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+      expected: ONE_M,
+    },
+    {
+      name: "anthropic-vertex reports its 1M window",
+      provider: "anthropic-vertex",
+      model: "claude-opus-4-7",
+      expected: ONE_M,
+    },
+    {
+      name: "a non-1M Claude model stays uncapped",
+      provider: "anthropic",
+      model: "claude-3-5-sonnet-20241022",
+      expected: undefined,
+    },
+    {
+      name: "Fable 5 is 1M even on Claude CLI without [1m]",
+      provider: "claude-cli",
+      model: "claude-fable-5",
+      expected: ONE_M,
+    },
+    {
+      name: "Opus 5 is natively 1M on Claude CLI",
+      provider: "claude-cli",
+      model: "claude-opus-5",
+      expected: ONE_M,
+    },
+    {
+      name: "the Opus 5 alias resolves to 1M",
+      provider: "anthropic",
+      model: "opus-5",
+      expected: ONE_M,
+    },
+    {
+      name: "Sonnet 5 reports 1M",
+      provider: "anthropic",
+      model: "claude-sonnet-5",
+      expected: ONE_M,
+    },
+    {
+      name: "Mythos 5 is 1M on the direct API",
+      provider: "anthropic",
+      model: "claude-mythos-5",
+      expected: ONE_M,
+    },
+    {
+      name: "Mythos 5 is direct-API only, not on Claude CLI",
+      provider: "claude-cli",
+      model: "claude-mythos-5",
+      expected: undefined,
+    },
+    {
+      name: "Claude CLI without [1m] or opt-in keeps its discovered window",
+      provider: "claude-cli",
+      model: "claude-opus-4-6",
+      expected: undefined,
+    },
+    {
+      name: "the [1m] model suffix unlocks 1M on Claude CLI",
+      provider: "claude-cli",
+      model: "claude-opus-4-6[1m]",
+      expected: ONE_M,
+    },
+    {
+      name: "the claudeCli1M opt-in unlocks 1M on Claude CLI",
+      provider: "claude-cli",
+      model: "claude-opus-4-6",
+      options: { claudeCli1M: true },
+      expected: ONE_M,
+    },
+  ];
+
+  for (const { name, provider, model, options, expected } of cases) {
+    it(name, () => {
+      expect(resolveAnthropicFixedContextWindow(provider, model, options)).toBe(expected);
+    });
+  }
+});
+
+describe("resolveContextTokensForModelFromCache", () => {
+  // Injected lookups keep the process-local discovery cache out of the test so
+  // only the resolver's config/override branches are exercised.
+  const noCache = () => undefined;
+
+  function configWithModel(entry: {
+    id: string;
+    contextTokens?: number;
+    contextWindow?: number;
+  }): OpenClawConfig {
+    return {
+      models: { providers: { openai: { models: [entry] } } },
+    } as unknown as OpenClawConfig;
+  }
+
+  it("returns a configured provider contextTokens value", () => {
+    const result = resolveContextTokensForModelFromCache(
+      {
+        cfg: configWithModel({ id: "gpt-5", contextTokens: 500_000 }),
+        provider: "openai",
+        model: "gpt-5",
+      },
+      noCache,
+      noCache,
+    );
+    expect(result).toBe(500_000);
+  });
+
+  it("caps the configured contextTokens with a smaller override", () => {
+    const result = resolveContextTokensForModelFromCache(
+      {
+        cfg: configWithModel({ id: "gpt-5", contextTokens: 500_000 }),
+        provider: "openai",
+        model: "gpt-5",
+        contextTokensOverride: 200_000,
+      },
+      noCache,
+      noCache,
+    );
+    expect(result).toBe(200_000);
+  });
+
+  it("returns a configured contextWindow value when no cap applies", () => {
+    const result = resolveContextTokensForModelFromCache(
+      {
+        cfg: configWithModel({ id: "gpt-5", contextWindow: 400_000 }),
+        provider: "openai",
+        model: "gpt-5",
+      },
+      noCache,
+      noCache,
+    );
+    expect(result).toBe(400_000);
+  });
+
+  it("skips the unscoped model lookup when allowUnscopedModelLookup is false", () => {
+    // With the flag off the resolver must not consult the raw discovery key, so
+    // the lookup that would otherwise return 999_000 is never reached.
+    const result = resolveContextTokensForModelFromCache(
+      {
+        provider: "openai",
+        model: "gpt-5",
+        allowUnscopedModelLookup: false,
+        fallbackContextTokens: 128_000,
+      },
+      (modelId) => (modelId === "gpt-5" ? 999_000 : undefined),
+      noCache,
+    );
+    expect(result).toBe(128_000);
+  });
+
+  it("uses the raw discovery key for a model-only (provider-less) resolution", () => {
+    const result = resolveContextTokensForModelFromCache(
+      { model: "gpt-5" },
+      (modelId) => (modelId === "gpt-5" ? 777_000 : undefined),
+      noCache,
+    );
+    expect(result).toBe(777_000);
+  });
+
+  it("prefers the override over the fallback when nothing is discovered", () => {
+    const result = resolveContextTokensForModelFromCache(
+      { model: "unknown-model", contextTokensOverride: 42_000, fallbackContextTokens: 64_000 },
+      noCache,
+      noCache,
+    );
+    expect(result).toBe(42_000);
+  });
+
+  it("falls back to fallbackContextTokens when nothing else resolves", () => {
+    const result = resolveContextTokensForModelFromCache(
+      { model: "unknown-model", fallbackContextTokens: 64_000 },
+      noCache,
+      noCache,
+    );
+    expect(result).toBe(64_000);
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

`src/agents/context-resolution.ts` exports two resolvers that decide a model's effective context window, and both shipped with **no direct test coverage**:

- **`resolveAnthropicFixedContextWindow(provider, model, options)`** — the gate that decides whether a Claude model reports a fixed 1M-token window. It carries several subtle, easy-to-regress arms: the provider allow-list (`anthropic` / `anthropic-vertex` / `claude-cli` only), the per-family windows (Fable 5, Mythos 5, Opus 5, Sonnet 5, the `opus-5` alias, Opus/Sonnet 4.x), the **Mythos-5 direct-API-only** restriction (1M on `anthropic` but *not* on `claude-cli`), and the **Claude-CLI 1M opt-in** (only unlocked by a `[1m]` model suffix or the `claudeCli1M` option). It is reachable from `src/agents/context.ts:333` / `:343`.
- **`resolveContextTokensForModelFromCache(params, lookupContextTokens?, lookupContextWindow?)`** — resolves the effective token cap from configured provider/model context values, the discovery cache, an explicit override, and a fallback. Reachable from `src/agents/context.ts:361` and `src/commands/status.summary.runtime.ts:13`.

A regression in any of these — dropping the provider gate, letting Mythos 5 report 1M on the CLI, forgetting the CLI `[1m]` opt-in, or letting an override fail to cap a configured window — would not be caught before merge.

## Why This Change Was Made

Coverage-only. This adds one new file, `src/agents/context-resolution.test.ts` (+214, no production code touched), pinning both resolvers' current `main` behavior. The Anthropic-window arm is table-driven so each contract branch has a named case; the cache/config resolver is exercised through its injected `lookupContextTokens` / `lookupContextWindow` parameters, so the process-local discovery cache stays out of the test and only the config/override branches run. No new config, defaults, dependencies, or behavior — the diff is a single test file.

## User Impact

No user-visible or runtime change. For maintainers, the context-window resolution contract now regresses loudly instead of silently: a future edit that breaks the provider gate, the Mythos-5 direct-API restriction, the Claude-CLI `[1m]` opt-in, the override cap, or the unscoped-lookup short-circuit will fail this suite.

## Evidence

**Refreshed 2026-08-01 — rebased onto current `main` (`0cec56df2`)** per the ClawSweeper review note. The resolver under test, `src/agents/context-resolution.ts`, is **byte-identical** on the new base and the previously-reviewed base (blob `d9ec0f971f4e7c23c614814b33b6db1e554dc17c` on both), so the pinned behavior is unchanged — the refresh re-verifies the exact suite against today's `main`.

Linux, Node 22.22, `pnpm install` from source, branched off current `main` (`0cec56df2`). Run with the repo's `node scripts/run-vitest.mjs` harness.

**21/21 pass on current `main`:**

```text
$ node scripts/run-vitest.mjs src/agents/context-resolution.test.ts
 Test Files  1 passed (1)
      Tests  21 passed (21)
```

**Non-vacuous — the suite bites when the target is mutated** (each mutation applied to `context-resolution.ts` on current `main`, suite re-run, then reverted byte-identical):

| Mutation to `context-resolution.ts` | Result |
| --- | --- |
| drop the non-Anthropic provider gate | 1 fail (re-verified 2026-08-01) |
| remove the Claude-CLI `[1m]` opt-in gate | 2 fail |
| widen the Mythos-5 scope to include `claude-cli` | 1 fail |
| break the `!supportsClaude1MContext` gate | 1 fail |
| remove the `allowUnscopedModelLookup` short-circuit | 1 fail |
| *(reverted — control)* | **21 pass** |

**Scope note:** one new `*.test.ts` file under `src/agents/`, `+214 / -0`, no production code touched. The tests drive the real exported functions (the identity helpers from `@openclaw/llm-core` run unmocked), so they exercise the production path callers actually hit.

**Related:** none — coverage mined from the module itself; no linked issue.

---

_AI-assisted contribution._