### PR TITLE
fix(agents): harden exec auto-review shell approval

### DIFF
--- a/src/agents/bash-tools.exec-host-gateway.test.ts
+++ b/src/agents/bash-tools.exec-host-gateway.test.ts
@@ -849,6 +849,25 @@ describe("processGatewayAllowlist", () => {
     expect(JSON.stringify(captured.events)).not.toContain("allowed");
   });
 
+  it.runIf(process.platform !== "win32").each(["bash", "sh", "/bin/sh"])(
+    "keeps %s login-shell startup outside model auto-review",
+    async (shell) => {
+      const payload = "echo auto-review-startup-proof";
+      const command = `${shell} -lc "${payload}"`;
+      await configurePlanBackedCommand({ command });
+
+      const result = await runGatewayAllowlist({
+        command,
+        ask: "on-miss",
+        autoReview: true,
+      });
+
+      expect(defaultExecAutoReviewerMock).not.toHaveBeenCalled();
+      expect(createAndRegisterDefaultExecApprovalRequestMock).toHaveBeenCalledTimes(1);
+      expect(result.pendingResult?.details.status).toBe("approval-pending");
+    },
+  );
+
   it("does not execute after cancellation wins during auto-review", async () => {
     const command = "echo ok";
     await configurePlanBackedCommand({ command });

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -40,6 +40,7 @@ import {
   type ExecAutoReviewInput,
 } from "../infra/exec-auto-review.js";
 import type { SafeBinProfile } from "../infra/exec-safe-bin-policy.js";
+import { isBlockedShellWrapperCommand } from "../infra/exec-wrapper-resolution.js";
 import {
   GatewayDrainingError,
   runWithGatewayIndependentRootWorkAdmission,
@@ -764,9 +765,12 @@ export async function processGatewayAllowlist(
     const [autoReviewSegment] = allowlistEval.segments;
     const autoReviewArgv =
       allowlistEval.segments.length === 1 &&
-      (autoReviewSegment?.raw === undefined ||
+      autoReviewSegment !== undefined &&
+      // Shell startup can execute unreviewed profile code before its bound payload.
+      !isBlockedShellWrapperCommand(autoReviewSegment.argv) &&
+      (autoReviewSegment.raw === undefined ||
         autoReviewSegment.raw.trim() === params.command.trim())
-        ? autoReviewSegment?.argv
+        ? autoReviewSegment.argv
         : undefined;
     const autoReviewHasBoundCommand = analysisOk && autoReviewArgv !== undefined;
     // A model approval is valid only for the executable resolved during review;

--- a/src/agents/bash-tools.exec-host-node-phases.ts
+++ b/src/agents/bash-tools.exec-host-node-phases.ts
@@ -26,6 +26,7 @@ import {
   resolveAllowAlwaysPatternCoverage,
   type AllowAlwaysPattern,
 } from "../infra/exec-approvals.js";
+import { isBlockedShellWrapperCommand } from "../infra/exec-wrapper-resolution.js";
 import { buildNodeShellCommand } from "../infra/node-shell.js";
 import {
   parsePreparedSystemRunPayload,
@@ -643,6 +644,16 @@ export async function analyzeNodeApprovalRequirement(params: {
       // Fall back to requiring approval if node approvals cannot be fetched.
     }
   }
+  const [autoReviewSegment] = autoReviewBindingEval.segments;
+  // Review the semantic node payload, not the ordinary outer transport shell.
+  const autoReviewArgv =
+    autoReviewBindingEval.segments.length === 1 &&
+    autoReviewSegment !== undefined &&
+    !isBlockedShellWrapperCommand(autoReviewSegment.argv) &&
+    (autoReviewSegment.raw === undefined ||
+      autoReviewSegment.raw.trim() === autoReviewBindingCommand.trim())
+      ? autoReviewSegment.argv
+      : undefined;
   return {
     analysisOk,
     allowlistSatisfied,
@@ -663,11 +674,6 @@ export async function analyzeNodeApprovalRequirement(params: {
       runtimePayload: inlineEvalHit !== null,
       preparedCoverage: params.prepared.allowAlwaysCoverage,
     }),
-    autoReviewArgv:
-      autoReviewBindingEval.segments.length === 1 &&
-      (autoReviewBindingEval.segments.at(0)?.raw === undefined ||
-        autoReviewBindingEval.segments.at(0)?.raw.trim() === autoReviewBindingCommand.trim())
-        ? autoReviewBindingEval.segments.at(0)?.argv
-        : undefined,
+    autoReviewArgv,
   };
 }

--- a/src/agents/bash-tools.exec-host-node.test.ts
+++ b/src/agents/bash-tools.exec-host-node.test.ts
@@ -1690,96 +1690,97 @@ describe("executeNodeHostCommand", () => {
     expectSystemRunInvoke({ invokeTimeoutMs: 35_000, runTimeoutMs: 30_000 });
   });
 
-  it("keeps non-transport login shells approval-gated", async () => {
-    const loginPlan = {
-      argv: ["bash", "-lc", "./scripts/check_mail.sh --limit 5"],
-      cwd: "/tmp/work",
-      commandText: `bash -lc "./scripts/check_mail.sh --limit 5"`,
-      commandPreview: "./scripts/check_mail.sh --limit 5",
-      agentId: "prepared-agent",
-      sessionKey: "prepared-session",
-    };
-    parsePreparedSystemRunPayloadMock.mockReturnValue({
-      plan: loginPlan,
-      execPolicy: { security: "full", ask: "off" },
-    });
-    const nodeAllowlist = [{ pattern: "./scripts/check_mail.sh" }];
-    resolveExecApprovalsFromFileMock.mockReturnValue({
-      allowlist: nodeAllowlist,
-      file: { version: 1, agents: {} },
-      agent: {
-        security: "full",
-        ask: "off",
-        askFallback: "deny",
-        autoAllowSkills: false,
-      },
-    });
-    evaluateShellAllowlistMock.mockImplementation(
-      (params?: { command?: string; allowlist?: unknown[] }) => {
+  it.each(["bash", "sh", "/bin/sh"])(
+    "keeps non-transport %s login shells outside model auto-review",
+    async (shell) => {
+      const payload = "./scripts/check_mail.sh --limit 5";
+      const loginCommand = `${shell} -lc "${payload}"`;
+      const loginPlan = {
+        argv: ["/bin/sh", "-lc", loginCommand],
+        cwd: "/tmp/work",
+        commandText: `/bin/sh -lc "${loginCommand.replaceAll('"', '\\"')}"`,
+        commandPreview: loginCommand,
+        agentId: "prepared-agent",
+        sessionKey: "prepared-session",
+      };
+      parsePreparedSystemRunPayloadMock.mockReturnValue({
+        plan: loginPlan,
+        execPolicy: { security: "full", ask: "off" },
+      });
+      resolveExecApprovalsFromFileMock.mockReturnValue({
+        allowlist: [],
+        file: { version: 1, agents: {} },
+        agent: {
+          security: "full",
+          ask: "off",
+          askFallback: "deny",
+          autoAllowSkills: false,
+        },
+      });
+      evaluateShellAllowlistMock.mockImplementation((params?: { command?: string }) => {
         const command = params?.command ?? "";
-        const hasNodeAllowlist = Array.isArray(params?.allowlist) && params.allowlist.length > 0;
-        const semanticMatch = command === "./scripts/check_mail.sh --limit 5";
         return {
-          allowlistMatches: semanticMatch && hasNodeAllowlist ? [{}] : [],
+          allowlistMatches: [],
           analysisOk: true,
-          allowlistSatisfied: semanticMatch && hasNodeAllowlist,
+          allowlistSatisfied: false,
           segments: [
-            command.startsWith("bash")
+            command === loginPlan.commandText
               ? {
                   resolution: null,
-                  argv: ["bash", "-lc", "./scripts/check_mail.sh --limit 5"],
-                  raw: `bash -lc "./scripts/check_mail.sh --limit 5"`,
+                  argv: ["/bin/sh", "-lc", loginCommand],
+                  raw: loginPlan.commandText,
                 }
-              : {
-                  resolution: null,
-                  argv: ["./scripts/check_mail.sh", "--limit", "5"],
-                  raw: "./scripts/check_mail.sh --limit 5",
-                },
+              : command === loginCommand
+                ? {
+                    resolution: null,
+                    argv: [shell, "-lc", payload],
+                    raw: loginCommand,
+                  }
+                : {
+                    resolution: null,
+                    argv: ["./scripts/check_mail.sh", "--limit", "5"],
+                    raw: payload,
+                  },
           ],
-          segmentAllowlistEntries: semanticMatch && hasNodeAllowlist ? [{}] : [],
+          segmentAllowlistEntries: [],
         };
-      },
-    );
-    requiresExecApprovalMock.mockImplementation(
-      (params?: { allowlistSatisfied?: boolean; durableApprovalSatisfied?: boolean }) =>
-        params?.allowlistSatisfied !== true && params?.durableApprovalSatisfied !== true,
-    );
-    const autoReviewer = vi.fn<ExecAutoReviewer>(async () => ({
-      decision: "ask",
-      risk: "medium",
-      rationale: "login shell needs human approval",
-    }));
-    resolveExecHostApprovalContextMock.mockReturnValue({
-      approvals: { allowlist: [], file: { version: 1, agents: {} } },
-      hostSecurity: "allowlist",
-      hostAsk: "on-miss",
-      askFallback: "deny",
-    });
+      });
+      requiresExecApprovalMock.mockImplementation(
+        (params?: { allowlistSatisfied?: boolean; durableApprovalSatisfied?: boolean }) =>
+          params?.allowlistSatisfied !== true && params?.durableApprovalSatisfied !== true,
+      );
+      const autoReviewer = vi.fn<ExecAutoReviewer>(async () => ({
+        decision: "allow-once",
+        risk: "low",
+        rationale: "unsafe startup wrapper must not reach the reviewer",
+      }));
+      resolveExecHostApprovalContextMock.mockReturnValue({
+        approvals: { allowlist: [], file: { version: 1, agents: {} } },
+        hostSecurity: "allowlist",
+        hostAsk: "on-miss",
+        askFallback: "deny",
+      });
 
-    const result = await executeNodeHostCommand({
-      command: "./scripts/check_mail.sh --limit 5",
-      workdir: "/tmp/work",
-      env: {},
-      security: "allowlist",
-      ask: "on-miss",
-      autoReview: true,
-      autoReviewer,
-      defaultTimeoutSec: 30,
-      approvalRunningNoticeMs: 0,
-      warnings: [],
-      agentId: "requested-agent",
-      sessionKey: "requested-session",
-    });
+      const result = await executeNodeHostCommand({
+        command: loginCommand,
+        workdir: "/tmp/work",
+        env: {},
+        security: "allowlist",
+        ask: "on-miss",
+        autoReview: true,
+        autoReviewer,
+        defaultTimeoutSec: 30,
+        approvalRunningNoticeMs: 0,
+        warnings: [],
+        agentId: "requested-agent",
+        sessionKey: "requested-session",
+      });
 
-    expect(result.details?.status).toBe("approval-pending");
-    expect(autoReviewer).toHaveBeenCalledWith(
-      expect.objectContaining({
-        command: `bash -lc "./scripts/check_mail.sh --limit 5"`,
-        argv: ["bash", "-lc", "./scripts/check_mail.sh --limit 5"],
-      }),
-    );
-    expect(createAndRegisterDefaultExecApprovalRequestMock).toHaveBeenCalled();
-  });
+      expect(result.details?.status).toBe("approval-pending");
+      expect(autoReviewer).not.toHaveBeenCalled();
+      expect(createAndRegisterDefaultExecApprovalRequestMock).toHaveBeenCalled();
+    },
+  );
 
   it("requires human approval when prepared shell payload has multiple commands", async () => {
     const chainPlan = {

--- a/src/agents/exec-auto-reviewer.test.ts
+++ b/src/agents/exec-auto-reviewer.test.ts
@@ -21,6 +21,37 @@ const input = {
   },
 };
 
+function createReviewerHarness(decision: "allow" | "ask" = "allow") {
+  const prepare = vi.fn(async () => ({
+    selection: { provider: "openrouter", modelId: "reviewer", agentDir: "/agent" },
+    model: { provider: "openrouter", id: "reviewer", api: "openai" as const },
+    auth: { apiKey: "redacted", mode: "env" as const },
+  }));
+  const complete = vi.fn(async () => ({
+    stopReason: "stop" as const,
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify({
+          decision,
+          risk: decision === "allow" ? "low" : "medium",
+          rationale: "reviewer fixture",
+        }),
+      },
+    ],
+  }));
+  const reviewer = createModelExecAutoReviewer({
+    cfg: {},
+    deps: {
+      prepareSimpleCompletionModelForAgent:
+        prepare as unknown as typeof import("./simple-completion-runtime.js").prepareSimpleCompletionModelForAgent,
+      completeWithPreparedSimpleCompletionModel:
+        complete as unknown as typeof import("./simple-completion-runtime.js").completeWithPreparedSimpleCompletionModel,
+    },
+  });
+  return { reviewer, prepare, complete };
+}
+
 async function reviewExecResponse(text: string) {
   const prepare = vi.fn(async () => ({
     selection: { provider: "openrouter", modelId: "reviewer", agentDir: "/agent" },
@@ -534,5 +565,98 @@ describe("createModelExecAutoReviewer", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("keeps repeated gateway reviews bound to one-shot approval", async () => {
+    const { reviewer, prepare, complete } = createReviewerHarness();
+
+    await expect(reviewer(input)).resolves.toMatchObject({
+      decision: "allow-once",
+      risk: "low",
+    });
+    await expect(reviewer(input)).resolves.toMatchObject({
+      decision: "allow-once",
+      risk: "low",
+    });
+
+    expect(prepare).toHaveBeenCalledTimes(2);
+    expect(complete).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps simultaneous gateway approvals one-shot under concurrency", async () => {
+    const { reviewer, prepare, complete } = createReviewerHarness();
+
+    const decisions = await Promise.all(
+      Array.from({ length: 24 }, () => Promise.resolve(reviewer(input))),
+    );
+
+    expect(decisions).toHaveLength(24);
+    expect(decisions).toEqual(
+      Array.from({ length: 24 }, () =>
+        expect.objectContaining({ decision: "allow-once", risk: "low" }),
+      ),
+    );
+    expect(prepare).toHaveBeenCalledTimes(24);
+    expect(complete).toHaveBeenCalledTimes(24);
+  });
+
+  it.each([
+    ["resolved executable", { resolvedPath: "/tmp/shadow/git" }],
+    ["working directory", { cwd: "/other-repo" }],
+    ["environment", { envKeys: ["REVIEW_SCOPE"] }],
+    ["approval reason", { reason: "allowlist-miss" as const }],
+    ["agent", { agent: { id: "other-agent", sessionKey: "agent:other:main" } }],
+    ["command analysis", { analysis: { ...input.analysis, durableApprovalMatched: true } }],
+  ])("does not reuse a gateway review across a changed %s", async (_label, changes) => {
+    const { reviewer, prepare, complete } = createReviewerHarness();
+
+    await reviewer(input);
+    await reviewer({ ...input, ...changes });
+
+    expect(prepare).toHaveBeenCalledTimes(2);
+    expect(complete).toHaveBeenCalledTimes(2);
+  });
+
+  it("never caches reviews without a bound gateway executable", async () => {
+    const { reviewer, prepare, complete } = createReviewerHarness();
+    const unbound = { ...input, resolvedPath: undefined };
+
+    await reviewer(unbound);
+    await reviewer(unbound);
+
+    expect(prepare).toHaveBeenCalledTimes(2);
+    expect(complete).toHaveBeenCalledTimes(2);
+  });
+
+  it("never reuses gateway review authority for a node-host request", async () => {
+    const { reviewer, prepare, complete } = createReviewerHarness();
+    const nodeInput = { ...input, host: "node" as const };
+
+    await reviewer(nodeInput);
+    await reviewer(nodeInput);
+
+    expect(prepare).toHaveBeenCalledTimes(2);
+    expect(complete).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not cache decisions requiring human approval", async () => {
+    const { reviewer, prepare, complete } = createReviewerHarness("ask");
+
+    await expect(reviewer(input)).resolves.toMatchObject({ decision: "ask" });
+    await expect(reviewer(input)).resolves.toMatchObject({ decision: "ask" });
+
+    expect(prepare).toHaveBeenCalledTimes(2);
+    expect(complete).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retain failed reviewer completions", async () => {
+    const { reviewer, prepare, complete } = createReviewerHarness();
+    complete.mockRejectedValueOnce(new Error("reviewer temporarily unavailable"));
+
+    await expect(reviewer(input)).resolves.toMatchObject({ decision: "ask" });
+    await expect(reviewer(input)).resolves.toMatchObject({ decision: "allow-once" });
+
+    expect(prepare).toHaveBeenCalledTimes(2);
+    expect(complete).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/node-host/invoke-system-run.test.ts
+++ b/src/node-host/invoke-system-run.test.ts
@@ -29,6 +29,7 @@ import {
 } from "../infra/exec-approvals.js";
 import type { ExecAutoReviewer } from "../infra/exec-auto-review.js";
 import type { ExecHostResponse } from "../infra/exec-host.js";
+import { formatExecCommand } from "../infra/system-run-command.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import { withEnvAsync } from "../test-utils/env.js";
@@ -807,6 +808,51 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
       clearRuntimeConfigSnapshot();
     }
   });
+
+  it.runIf(process.platform !== "win32").each(["bash", "sh", "/bin/sh"])(
+    "does not auto-review direct %s login-shell startup",
+    async (shell) => {
+      const tmp = createFixtureDir("openclaw-system-run-auto-review-login-");
+      setRuntimeConfigSnapshot({ tools: { exec: { mode: "auto" } } });
+      try {
+        const autoReviewer = vi.fn<ExecAutoReviewer>(() => ({
+          decision: "allow-once",
+          rationale: "unsafe startup wrapper must not reach the reviewer",
+          risk: "low",
+        }));
+        const loginCommand = `${shell} -lc "echo auto-review-startup-proof"`;
+        const command = ["/bin/sh", "-lc", loginCommand];
+        // The real plan builder already rejects this wrapper. Exercise the
+        // node trust boundary against a hostile, otherwise well-formed plan.
+        const approvalPlan = {
+          argv: command,
+          cwd: tmp,
+          commandText: formatExecCommand(command),
+          agentId: "main",
+          sessionKey: "agent:main:main",
+        } satisfies SystemRunApprovalPlan;
+
+        const invoke = await runSystemInvoke({
+          preferMacAppExecHost: false,
+          command,
+          rawCommand: approvalPlan.commandText,
+          cwd: tmp,
+          systemRunPlan: approvalPlan,
+          resolveExecSecurity: resolveProductionExecSecurity,
+          resolveExecAsk: resolveProductionExecAsk,
+          autoReviewer,
+        });
+
+        expect(autoReviewer).not.toHaveBeenCalled();
+        expect(invoke.runCommand).not.toHaveBeenCalled();
+        expectInvokeErrorMessage(invoke.sendInvokeResult, {
+          message: "SYSTEM_RUN_DENIED: approval required",
+        });
+      } finally {
+        clearRuntimeConfigSnapshot();
+      }
+    },
+  );
 
   it("does not auto-review direct system.run security audit suppression edits", async () => {
     const tmp = createFixtureDir("openclaw-system-run-auto-review-suppression-");

--- a/src/node-host/invoke-system-run.ts
+++ b/src/node-host/invoke-system-run.ts
@@ -39,6 +39,7 @@ import { applyExecPolicyLayer } from "../infra/exec-policy.js";
 import { resolveExecSafeBinRuntimePolicy } from "../infra/exec-safe-bin-runtime-policy.js";
 import {
   extractEnvAssignmentKeysFromDispatchWrappers,
+  isBlockedShellWrapperCommand,
   isShellWrapperInvocation,
   resolveShellWrapperTransportArgv,
 } from "../infra/exec-wrapper-resolution.js";
@@ -693,11 +694,14 @@ async function evaluateSystemRunPolicyPhase(
       parsed.shellPayload !== null || argvArraysMatch(autoReviewSegment?.argv, parsed.argv);
     const autoReviewArgv =
       segments.length === 1 &&
+      autoReviewSegment !== undefined &&
+      // Check the reviewed inner command so safe node transport remains usable.
+      !isBlockedShellWrapperCommand(autoReviewSegment.argv) &&
       directAutoReviewArgvMatchesRequest &&
       (parsed.shellPayload === null ||
-        (autoReviewSegment?.raw !== undefined &&
+        (autoReviewSegment.raw !== undefined &&
           autoReviewSegment.raw.trim() === parsed.shellPayload.trim()))
-        ? autoReviewSegment?.argv
+        ? autoReviewSegment.argv
         : undefined;
     const canAutoReviewApprovalMiss =
       !fallbackRequest &&

--- a/src/plugin-sdk/agent-harness-exec-review-runtime.test.ts
+++ b/src/plugin-sdk/agent-harness-exec-review-runtime.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { buildExecAutoReviewInputForShellCommand } from "./agent-harness-exec-review-runtime.js";
+
+describe("agent harness exec auto-review input", () => {
+  it.runIf(process.platform !== "win32").each(["bash", "sh", "/bin/sh"])(
+    "does not bind %s login-shell startup as a reviewable command",
+    async (shell) => {
+      await expect(
+        buildExecAutoReviewInputForShellCommand({
+          command: `${shell} -lc "echo auto-review-startup-proof"`,
+          cwd: process.cwd(),
+          host: "codex-app-server",
+        }),
+      ).resolves.toBeUndefined();
+    },
+  );
+
+  it("preserves ordinary single-command auto-review input", async () => {
+    await expect(
+      buildExecAutoReviewInputForShellCommand({
+        command: "node --version",
+        cwd: process.cwd(),
+        host: "codex-app-server",
+      }),
+    ).resolves.toMatchObject({
+      command: "node --version",
+      argv: ["node", "--version"],
+      host: "codex-app-server",
+      reason: "approval-required",
+    });
+  });
+});

--- a/src/plugin-sdk/agent-harness-exec-review-runtime.ts
+++ b/src/plugin-sdk/agent-harness-exec-review-runtime.ts
@@ -37,10 +37,12 @@ export async function buildExecAutoReviewInputForShellCommand(params: {
     { commandRequiresSecurityAuditSuppressionApproval, evaluateShellAllowlistWithAuthorization },
     { detectUnsafeExecControlShellCommand },
     { detectPolicyInlineEval },
+    { isBlockedShellWrapperCommand },
   ] = await Promise.all([
     import("../infra/exec-approvals.js"),
     import("../infra/exec-control-command-guard.js"),
     import("../infra/command-analysis/policy.js"),
+    import("../infra/exec-wrapper-resolution.js"),
   ]);
   const command = params.command.trim();
   const host: ExecAutoReviewHost = params.host;
@@ -61,6 +63,10 @@ export async function buildExecAutoReviewInputForShellCommand(params: {
     segment !== undefined &&
     segment.raw.trim() === command;
   if (!boundSingleCommand) {
+    return undefined;
+  }
+  // Startup files are outside the reviewed command and cannot be auto-approved.
+  if (isBlockedShellWrapperCommand(segment.argv)) {
     return undefined;
   }
   if (


### PR DESCRIPTION
Closes #113282
Related: #114175, #102249, #102369

## What Problem This Solves

Fixes an issue where users running commands with `tools.exec.mode: "auto"` could have login-shell startup code executed without explicit approval. The same approval bypass existed across gateway execution, gateway-to-node execution, direct `system.run`, and plugin agent-harness review input.

## Why This Change Was Made

Reuse the existing canonical shell-startup classifier at all four auto-review boundaries. Inspect each semantic inner command so ordinary node transport and existing allowlisted execution remain unchanged. Preserve one-shot reviewer authorization: do not memoize or coalesce `allow-once` decisions because a path can resolve to changed executable contents between requests.

The implementation incorporates the useful sibling coverage explored in #114175 and also closes its direct node-host trust-boundary gap. The reviewer-cost proposal in #102249 remains a separate problem; #102369 cannot be landed safely without an immutable executable-identity and explicit reusable-authorization contract.

## User Impact

Startup-capable `bash`, `sh`, and `/bin/sh` wrappers now require explicit human approval in auto mode. Ordinary commands, transport shells, existing Codex Guardian approval behavior, cancellation, exact executable binding, and one-shot execution semantics are preserved.

## Evidence

- Regression-first Linux Testbox proof: the unchanged SDK helper incorrectly auto-approved all three login-shell variants; unchanged reviewer concurrency produced 24 independent completions, confirming that reusing one-shot authority would change the security contract.
- Focused Linux Testbox proof: 527 tests across shell-wrapper resolution, gateway execution, gateway-to-node execution, direct node execution, node plan preparation, reviewer stress and failure handling, plugin-harness input, and the Codex approval bridge.
- Adversarial coverage: `bash`, `sh`, `/bin/sh`, nested hostile prepared plans, ordinary node transport, 24 simultaneous approvals, changed executable paths and approval contexts, unbound requests, node-host isolation, human-review decisions, provider failures, and existing cancellation/revocation tests.
- Full Linux Testbox `pnpm check:changed`: passed all core and extension typechecks, all core and plugin lint shards, plugin SDK exports and surface baselines, runtime import-cycle checks, and the database, native-state, and authorization guards.
- Full Linux Testbox `pnpm build`: passed bundled plugins, the unified production runtime, all 142 public plugin SDK subpath declarations, production UI, and startup/performance guards.
- Fresh structured `autoreview --mode uncommitted`: clean; no accepted or actionable findings.
- Formatted touched files with the repository's existing `oxfmt` binary; `git diff --check` passes.
- AI-assisted implementation; maintainer reviewed the actual upstream Codex contracts in `codex-rs/protocol/src/config_types.rs`, `codex-rs/app-server-protocol/src/protocol/v2/shared.rs`, and `codex-rs/core/src/guardian/review.rs`; `auto_review` remains canonical and legacy `guardian_subagent` is input-only.
