### PR TITLE
test(vitest): route zod and undici through Bun-safe test resolutions

### DIFF
--- a/test/vitest/vitest.shared.config.ts
+++ b/test/vitest/vitest.shared.config.ts
@@ -161,6 +161,21 @@ export const sharedVitestConfig = {
   resolve: {
     alias: [
       {
+        // Route bare `zod` through a runtime shim (same pattern as the
+        // discord-api-types shims below): zod's own entry re-exports `z` as a
+        // namespace binding, which Bun's linker drops under Vitest's loader
+        // hooks. The shim exposes the identical surface on Node and Bun.
+        find: /^zod$/u,
+        replacement: path.join(repoRoot, "test", "vitest", "zod-runtime.ts"),
+      },
+      {
+        // Bun substitutes its built-in fetch shim for bare `undici`, whose
+        // MockAgent is a non-functional stub; pin the real package so
+        // mock-http interception works. Node resolves to this file anyway.
+        find: /^undici$/u,
+        replacement: path.join(repoRoot, "node_modules", "undici", "index.js"),
+      },
+      {
         find: "discord-api-types/v10",
         replacement: path.join(repoRoot, "test", "vitest", "discord-api-types-v10-runtime.ts"),
       },

--- a/test/vitest/zod-runtime.ts
+++ b/test/vitest/zod-runtime.ts
@@ -1,0 +1,10 @@
+// Test-only zod entry: zod's real index.js re-exports the `z` namespace via
+// `import * as z; export { z }`, which Bun's module linker drops when Vitest's
+// loader hooks are active (named `z` arrives undefined). Re-exporting through a
+// const binding links correctly on both Node and Bun; the exposed surface is
+// identical to `zod` (zod/v4 is the same classic API), so Node is unchanged.
+import * as zNamespace from "zod/v4";
+
+export * from "zod/v4";
+export const z = zNamespace;
+export default zNamespace;


### PR DESCRIPTION
## What Problem This Solves

Running the Vitest suite under the Bun runtime (1.4 canary, Rust rewrite) collapses at module resolution before most tests execute: 258 of 1131 unit-fast test files failed at collection. Two systemic causes, both Bun-vs-Node module-interop differences that hit our test harness through bare specifiers:

1. `import { z } from "zod"` arrives with `z === undefined`. Bun's module linker drops zod's namespace re-export (`import * as z; export { z }`) when Vitest's loader hooks are active, and Bun's static CJS named-export analysis separately misses zod's `exports.z = void 0;` reassignment pattern. ~230 test files import zod transitively.
2. Bare `undici` resolves to Bun's built-in fetch shim whose `MockAgent` is a non-functional stub (`disableNetConnect` undefined), breaking `src/test-utils/mock-http.ts` interception everywhere it is used.

## Why This Change Was Made

Repo policy is "Keep Node + Bun paths working," and Bun 1.4+ can now run OpenClaw (PR #114256). Both fixes use the repo's existing test-resolution pattern (the `discord-api-types-*-runtime.ts` shims already in `test/vitest/vitest.shared.config.ts`):

- New `test/vitest/zod-runtime.ts` exposes zod's identical classic surface through a const binding (`export const z = namespace`) that links correctly on both runtimes; an exact-match alias routes bare `zod` to it.
- An exact-match alias pins bare `undici` to the real installed package file, bypassing Bun's stub. Node resolves to that same file anyway.

Node behavior is unchanged by construction (same module surfaces, same files Node already used). No prod code is touched.

## User Impact

None at runtime; test-infra only. For contributors running tests under Bun: unit-fast goes from 258 failing files (9477/9569 tests passing) to 28 failing files (11962/12088 passing — 2500 additional tests now execute past collection); several smaller shards go fully green. Remaining Bun gaps are documented below and are genuine runtime differences, not harness issues.

## Evidence

- Root causes verified with minimal probes against Bun 1.4.0-canary.1+43d60f69c: direct `bun -e` imports of zod/undici work; only Vitest's hooked/externalized load paths break; `new (require("undici").MockAgent)().disableNetConnect` is `undefined` under bare bun vs `function` via the package file.
- Bun after fix: unit-fast 1101/1131 files pass; infra, process, and several full shards green; `node scripts/test-projects.mjs` sweep shows remaining failures concentrated in gateway-core (~24 genuinely behavioral: PTY, managed-image fs semantics, proxy env scoping) plus a ui-shard hang under Bun — all pre-existing Bun runtime differences out of scope here.
- Node regression proof: `unit-fast` full shard 1129/1131 files, 12083/12088 tests passing with this change (identical to baseline); infra shard 316/319 with the 3 failing files (`gateway-lock`, `backup-create`, `sqlite-snapshot`) reproduced identically on a clean checkout of `main` — local environmental, not related (hosted CI is the arbiter).
- `test/vitest/*-runtime.ts` is already a knip entry pattern, so the new shim needs no dead-code exemptions.
- Codex autoreview: clean (0.99).
