### PR TITLE
fix(sessions): let agents archive their session after completing a turn

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -7497,6 +7497,8 @@ public struct SessionsAbortParams: Codable, Sendable {
 public struct SessionsPatchParams: Codable, Sendable {
     public let key: String
     public let agentid: String?
+    public let expectedsessionid: String?
+    public let expectedlifecyclerevision: String?
     public let label: AnyCodable?
     public let category: AnyCodable?
     public let boardface: AnyCodable?
@@ -7529,6 +7531,8 @@ public struct SessionsPatchParams: Codable, Sendable {
     public init(
         key: String,
         agentid: String? = nil,
+        expectedsessionid: String? = nil,
+        expectedlifecyclerevision: String? = nil,
         label: AnyCodable? = nil,
         category: AnyCodable? = nil,
         boardface: AnyCodable? = nil,
@@ -7560,6 +7564,8 @@ public struct SessionsPatchParams: Codable, Sendable {
     {
         self.key = key
         self.agentid = agentid
+        self.expectedsessionid = expectedsessionid
+        self.expectedlifecyclerevision = expectedlifecyclerevision
         self.label = label
         self.category = category
         self.boardface = boardface
@@ -7593,6 +7599,8 @@ public struct SessionsPatchParams: Codable, Sendable {
     private enum CodingKeys: String, CodingKey {
         case key
         case agentid = "agentId"
+        case expectedsessionid = "expectedSessionId"
+        case expectedlifecyclerevision = "expectedLifecycleRevision"
         case label
         case category
         case boardface = "boardFace"

--- a/packages/gateway-protocol/src/index.test.ts
+++ b/packages/gateway-protocol/src/index.test.ts
@@ -99,6 +99,29 @@ describe("lazy protocol validators", () => {
     expect(validateSessionsListParams({ face: "dashboard" })).toBe(false);
   });
 
+  it("validates session patch compare-and-swap identity", () => {
+    expect(
+      validateSessionsPatchParams({
+        key: "agent:main:self-archive",
+        archived: true,
+        expectedSessionId: "session-self-archive",
+        expectedLifecycleRevision: "revision-self-archive",
+      }),
+    ).toBe(true);
+    expect(
+      validateSessionsPatchParams({
+        key: "agent:main:self-archive",
+        expectedSessionId: "",
+      }),
+    ).toBe(false);
+    expect(
+      validateSessionsPatchParams({
+        key: "agent:main:self-archive",
+        expectedLifecycleRevision: "",
+      }),
+    ).toBe(false);
+  });
+
   it("keeps validation errors readable on the exported validator", () => {
     expect(validateConnectParams({})).toBe(false);
     expect(formatValidationErrors(validateConnectParams.errors)).toContain("must have required");

--- a/packages/gateway-protocol/src/schema/sessions.ts
+++ b/packages/gateway-protocol/src/schema/sessions.ts
@@ -470,6 +470,9 @@ export const SessionsAbortParamsSchema = closedObject({
 export const SessionsPatchParamsSchema = closedObject({
   key: NonEmptyString,
   agentId: Type.Optional(NonEmptyString),
+  /** Reject the mutation if the session was reset or replaced before it commits. */
+  expectedSessionId: Type.Optional(NonEmptyString),
+  expectedLifecycleRevision: Type.Optional(NonEmptyString),
   label: Type.Optional(Type.Union([SessionLabelString, Type.Null()])),
   /** User-defined organization bucket ("category", not chat-group); null clears it. */
   category: Type.Optional(Type.Union([SessionLabelString, Type.Null()])),

--- a/src/agents/tools/sessions-tool.self-archive.test.ts
+++ b/src/agents/tools/sessions-tool.self-archive.test.ts
@@ -1,0 +1,487 @@
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { loadSessionEntry, upsertSessionEntry } from "../../config/sessions/session-accessor.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { beginSessionWorkAdmission } from "../../sessions/session-lifecycle-admission.js";
+import { withTempDir } from "../../test-helpers/temp-dir.js";
+import { createSessionsTool } from "./sessions-tool.js";
+
+describe("sessions tool self-archive", () => {
+  it("defers self-archiving until the current agent turn has completed", async () => {
+    await withTempDir({ prefix: "openclaw-sessions-tool-self-archive-" }, async (dir) => {
+      const storePath = path.join(dir, "sessions.json");
+      const sessionKey = "agent:main:self-archive";
+      const sessionId = "session-self-archive";
+      const config: OpenClawConfig = { session: { store: storePath } };
+      await upsertSessionEntry(
+        { agentId: "main", sessionKey, storePath },
+        { sessionId, updatedAt: 1 },
+      );
+      const callGateway = vi.fn(async () => ({ ok: true }));
+      const tool = createSessionsTool({
+        agentSessionKey: sessionKey,
+        config,
+        callGateway: callGateway as never,
+      });
+      const admission = await beginSessionWorkAdmission({
+        scope: storePath,
+        identities: [sessionKey, sessionId],
+        assertAllowed: () => {},
+      });
+
+      try {
+        const result = await admission.run(async () => {
+          const pending = await tool.execute("archive-current", {
+            action: "patch",
+            archived: true,
+          });
+          expect(callGateway).not.toHaveBeenCalled();
+          expect(loadSessionEntry({ agentId: "main", sessionKey, storePath })).not.toHaveProperty(
+            "archivedAt",
+          );
+          return pending;
+        });
+
+        expect(result.details).toMatchObject({
+          status: "scheduled",
+          sessionKey,
+        });
+      } finally {
+        admission.release();
+      }
+
+      await vi.waitFor(() => {
+        expect(callGateway).toHaveBeenCalledExactlyOnceWith("sessions.patch", {
+          key: sessionKey,
+          archived: true,
+          expectedSessionId: sessionId,
+        });
+      });
+    });
+  });
+
+  it("applies other self-patch settings before the deferred archive", async () => {
+    await withTempDir({ prefix: "openclaw-sessions-tool-archive-patch-" }, async (dir) => {
+      const storePath = path.join(dir, "sessions.json");
+      const sessionKey = "agent:main:archive-patch";
+      const sessionId = "session-archive-patch";
+      const config: OpenClawConfig = { session: { store: storePath } };
+      await upsertSessionEntry(
+        { agentId: "main", sessionKey, storePath },
+        { sessionId, updatedAt: 1 },
+      );
+      const callGateway = vi.fn(async () => ({ ok: true }));
+      const tool = createSessionsTool({
+        agentSessionKey: sessionKey,
+        config,
+        callGateway: callGateway as never,
+      });
+      const admission = await beginSessionWorkAdmission({
+        scope: storePath,
+        identities: [sessionKey, sessionId],
+        assertAllowed: () => {},
+      });
+
+      try {
+        await admission.run(async () => {
+          const result = await tool.execute("archive-and-label", {
+            action: "patch",
+            label: "Finished research",
+            archived: true,
+          });
+          expect(result.details).toMatchObject({ status: "scheduled", sessionKey });
+          expect(callGateway).toHaveBeenCalledExactlyOnceWith("sessions.patch", {
+            key: sessionKey,
+            label: "Finished research",
+            expectedSessionId: sessionId,
+          });
+        });
+      } finally {
+        admission.release();
+      }
+
+      await vi.waitFor(() => {
+        expect(callGateway.mock.calls).toEqual([
+          [
+            "sessions.patch",
+            { key: sessionKey, label: "Finished research", expectedSessionId: sessionId },
+          ],
+          ["sessions.patch", { key: sessionKey, archived: true, expectedSessionId: sessionId }],
+        ]);
+      });
+    });
+  });
+
+  it("does not apply a deferred archive to a replacement session", async () => {
+    await withTempDir({ prefix: "openclaw-sessions-tool-archive-replacement-" }, async (dir) => {
+      const storePath = path.join(dir, "sessions.json");
+      const sessionKey = "agent:main:archive-replacement";
+      const sessionId = "session-before-reset";
+      const config: OpenClawConfig = { session: { store: storePath } };
+      await upsertSessionEntry(
+        { agentId: "main", sessionKey, storePath },
+        { sessionId, updatedAt: 1 },
+      );
+      const callGateway = vi.fn(async () => ({ ok: true }));
+      const tool = createSessionsTool({
+        agentSessionKey: sessionKey,
+        config,
+        callGateway: callGateway as never,
+      });
+      const admission = await beginSessionWorkAdmission({
+        scope: storePath,
+        identities: [sessionKey, sessionId],
+        assertAllowed: () => {},
+      });
+      let replacementAdmission: Awaited<ReturnType<typeof beginSessionWorkAdmission>> | undefined;
+
+      try {
+        await admission.run(async () => {
+          await tool.execute("archive-before-reset", { action: "patch", archived: true });
+          await upsertSessionEntry(
+            { agentId: "main", sessionKey, storePath },
+            { sessionId: "session-after-reset", updatedAt: 2 },
+          );
+          replacementAdmission = await beginSessionWorkAdmission({
+            scope: storePath,
+            identities: [sessionKey, "session-after-reset"],
+            assertAllowed: () => {},
+          });
+        });
+      } finally {
+        admission.release();
+      }
+
+      try {
+        await new Promise<void>((resolve) => {
+          setImmediate(resolve);
+        });
+        expect(callGateway).not.toHaveBeenCalled();
+        expect(loadSessionEntry({ agentId: "main", sessionKey, storePath })).toMatchObject({
+          sessionId: "session-after-reset",
+        });
+        expect(loadSessionEntry({ agentId: "main", sessionKey, storePath })).not.toHaveProperty(
+          "archivedAt",
+        );
+      } finally {
+        replacementAdmission?.release();
+      }
+    });
+  });
+
+  it("waits for a competing turn before applying a scheduled archive", async () => {
+    await withTempDir({ prefix: "openclaw-sessions-tool-archive-competing-" }, async (dir) => {
+      const storePath = path.join(dir, "sessions.json");
+      const sessionKey = "agent:main:archive-competing";
+      const sessionId = "session-archive-competing";
+      const config: OpenClawConfig = { session: { store: storePath } };
+      await upsertSessionEntry(
+        { agentId: "main", sessionKey, storePath },
+        { sessionId, updatedAt: 1 },
+      );
+      const callGateway = vi.fn(async () => ({ ok: true }));
+      const tool = createSessionsTool({
+        agentSessionKey: sessionKey,
+        config,
+        callGateway: callGateway as never,
+      });
+      const currentAdmission = await beginSessionWorkAdmission({
+        scope: storePath,
+        identities: [sessionKey, sessionId],
+        assertAllowed: () => {},
+      });
+      const competingAdmission = await beginSessionWorkAdmission({
+        scope: storePath,
+        identities: [sessionKey, sessionId],
+        assertAllowed: () => {},
+      });
+
+      try {
+        await currentAdmission.run(async () => {
+          const result = await tool.execute("archive-after-competition", {
+            action: "patch",
+            archived: true,
+          });
+          expect(result.details).toMatchObject({ status: "scheduled", sessionKey });
+        });
+        currentAdmission.release();
+
+        await new Promise<void>((resolve) => {
+          setImmediate(resolve);
+        });
+        expect(callGateway).not.toHaveBeenCalled();
+      } finally {
+        currentAdmission.release();
+        competingAdmission.release();
+      }
+
+      await vi.waitFor(() => {
+        expect(callGateway).toHaveBeenCalledExactlyOnceWith("sessions.patch", {
+          key: sessionKey,
+          archived: true,
+          expectedSessionId: sessionId,
+        });
+      });
+    });
+  });
+
+  it("retries a scheduled archive when a turn races the gateway mutation", async () => {
+    await withTempDir({ prefix: "openclaw-sessions-tool-archive-retry-" }, async (dir) => {
+      const storePath = path.join(dir, "sessions.json");
+      const sessionKey = "agent:main:archive-retry";
+      const sessionId = "session-archive-retry";
+      const config: OpenClawConfig = { session: { store: storePath } };
+      await upsertSessionEntry(
+        { agentId: "main", sessionKey, storePath },
+        { sessionId, updatedAt: 1 },
+      );
+      let competingAdmission: Awaited<ReturnType<typeof beginSessionWorkAdmission>> | undefined;
+      const callGateway = vi.fn(async () => {
+        if (!competingAdmission) {
+          competingAdmission = await beginSessionWorkAdmission({
+            scope: storePath,
+            identities: [sessionKey, sessionId],
+            assertAllowed: () => {},
+          });
+          throw new Error("Cannot archive a session with an active run.");
+        }
+        return { ok: true };
+      });
+      const tool = createSessionsTool({
+        agentSessionKey: sessionKey,
+        config,
+        callGateway: callGateway as never,
+      });
+      const currentAdmission = await beginSessionWorkAdmission({
+        scope: storePath,
+        identities: [sessionKey, sessionId],
+        assertAllowed: () => {},
+      });
+
+      try {
+        await currentAdmission.run(async () => {
+          const result = await tool.execute("archive-after-race", {
+            action: "patch",
+            archived: true,
+          });
+          expect(result.details).toMatchObject({ status: "scheduled", sessionKey });
+        });
+        currentAdmission.release();
+
+        await vi.waitFor(() => {
+          expect(callGateway).toHaveBeenCalledTimes(1);
+          expect(competingAdmission).toBeDefined();
+        });
+      } finally {
+        currentAdmission.release();
+        competingAdmission?.release();
+      }
+
+      await vi.waitFor(() => {
+        expect(callGateway).toHaveBeenCalledTimes(2);
+        expect(callGateway).toHaveBeenLastCalledWith("sessions.patch", {
+          key: sessionKey,
+          archived: true,
+          expectedSessionId: sessionId,
+        });
+      });
+    });
+  });
+
+  it("retries when a competing turn releases before its archive rejection settles", async () => {
+    await withTempDir({ prefix: "openclaw-sessions-tool-archive-release-race-" }, async (dir) => {
+      const storePath = path.join(dir, "sessions.json");
+      const sessionKey = "agent:main:archive-release-race";
+      const sessionId = "session-archive-release-race";
+      const config: OpenClawConfig = { session: { store: storePath } };
+      await upsertSessionEntry(
+        { agentId: "main", sessionKey, storePath },
+        { sessionId, updatedAt: 1 },
+      );
+      let competingTurnFinished = false;
+      const callGateway = vi.fn(async () => {
+        if (!competingTurnFinished) {
+          const competingAdmission = await beginSessionWorkAdmission({
+            scope: storePath,
+            identities: [sessionKey, sessionId],
+            assertAllowed: () => {},
+          });
+          competingAdmission.release();
+          competingTurnFinished = true;
+          throw new Error("Cannot archive a session with an active run.");
+        }
+        return { ok: true };
+      });
+      const tool = createSessionsTool({
+        agentSessionKey: sessionKey,
+        config,
+        callGateway: callGateway as never,
+      });
+      const admission = await beginSessionWorkAdmission({
+        scope: storePath,
+        identities: [sessionKey, sessionId],
+        assertAllowed: () => {},
+      });
+
+      try {
+        await admission.run(async () => {
+          const result = await tool.execute("archive-after-release-race", {
+            action: "patch",
+            archived: true,
+          });
+          expect(result.details).toMatchObject({ status: "scheduled", sessionKey });
+        });
+      } finally {
+        admission.release();
+      }
+
+      await vi.waitFor(() => {
+        expect(callGateway).toHaveBeenCalledTimes(2);
+        expect(callGateway).toHaveBeenLastCalledWith("sessions.patch", {
+          key: sessionKey,
+          archived: true,
+          expectedSessionId: sessionId,
+        });
+      });
+    });
+  });
+
+  it("retries a scheduled archive after a transient gateway failure", async () => {
+    await withTempDir({ prefix: "openclaw-sessions-tool-archive-transport-" }, async (dir) => {
+      const storePath = path.join(dir, "sessions.json");
+      const sessionKey = "agent:main:archive-transport";
+      const sessionId = "session-archive-transport";
+      await upsertSessionEntry(
+        { agentId: "main", sessionKey, storePath },
+        { sessionId, updatedAt: 1 },
+      );
+      const callGateway = vi
+        .fn()
+        .mockRejectedValueOnce(Object.assign(new Error("socket hang up"), { code: "ECONNRESET" }))
+        .mockResolvedValue({ ok: true });
+      const tool = createSessionsTool({
+        agentSessionKey: sessionKey,
+        config: { session: { store: storePath } },
+        callGateway: callGateway as never,
+      });
+      const admission = await beginSessionWorkAdmission({
+        scope: storePath,
+        identities: [sessionKey, sessionId],
+        assertAllowed: () => {},
+      });
+
+      try {
+        await admission.run(async () => {
+          const result = await tool.execute("archive-after-disconnect", {
+            action: "patch",
+            archived: true,
+          });
+          expect(result.details).toMatchObject({ status: "scheduled", sessionKey });
+        });
+      } finally {
+        admission.release();
+      }
+
+      await vi.waitFor(() => {
+        expect(callGateway).toHaveBeenCalledTimes(2);
+        expect(callGateway).toHaveBeenLastCalledWith("sessions.patch", {
+          key: sessionKey,
+          archived: true,
+          expectedSessionId: sessionId,
+        });
+      });
+    });
+  });
+
+  it("keeps retrying a projected active run without abandoning its archive", async () => {
+    vi.useFakeTimers();
+    try {
+      await withTempDir({ prefix: "openclaw-sessions-tool-archive-projected-" }, async (dir) => {
+        const storePath = path.join(dir, "sessions.json");
+        const sessionKey = "agent:main:archive-projected";
+        const sessionId = "session-archive-projected";
+        const config: OpenClawConfig = { session: { store: storePath } };
+        await upsertSessionEntry(
+          { agentId: "main", sessionKey, storePath },
+          { sessionId, updatedAt: 1 },
+        );
+        let attempts = 0;
+        const callGateway = vi.fn(async () => {
+          attempts += 1;
+          if (attempts <= 10) {
+            throw new Error("Cannot archive a session with an active run.");
+          }
+          return { ok: true };
+        });
+        const tool = createSessionsTool({
+          agentSessionKey: sessionKey,
+          config,
+          callGateway: callGateway as never,
+        });
+        const admission = await beginSessionWorkAdmission({
+          scope: storePath,
+          identities: [sessionKey, sessionId],
+          assertAllowed: () => {},
+        });
+
+        try {
+          await admission.run(async () => {
+            const result = await tool.execute("archive-after-projected-run", {
+              action: "patch",
+              archived: true,
+            });
+            expect(result.details).toMatchObject({ status: "scheduled", sessionKey });
+          });
+        } finally {
+          admission.release();
+        }
+
+        await vi.advanceTimersByTimeAsync(30_000);
+        expect(callGateway).toHaveBeenCalledTimes(11);
+        expect(callGateway).toHaveBeenLastCalledWith("sessions.patch", {
+          key: sessionKey,
+          archived: true,
+          expectedSessionId: sessionId,
+        });
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps main-session archive validation on the gateway", async () => {
+    await withTempDir({ prefix: "openclaw-sessions-tool-archive-main-" }, async (dir) => {
+      const storePath = path.join(dir, "sessions.json");
+      const sessionKey = "agent:main:main";
+      const sessionId = "session-main-archive";
+      const config: OpenClawConfig = { session: { store: storePath } };
+      await upsertSessionEntry(
+        { agentId: "main", sessionKey, storePath },
+        { sessionId, updatedAt: 1 },
+      );
+      const callGateway = vi.fn(async () => ({ ok: true }));
+      const tool = createSessionsTool({
+        agentSessionKey: sessionKey,
+        config,
+        callGateway: callGateway as never,
+      });
+      const admission = await beginSessionWorkAdmission({
+        scope: storePath,
+        identities: [sessionKey, sessionId],
+        assertAllowed: () => {},
+      });
+
+      try {
+        await admission.run(async () => {
+          await tool.execute("archive-main", { action: "patch", archived: true });
+          expect(callGateway).toHaveBeenCalledExactlyOnceWith("sessions.patch", {
+            key: sessionKey,
+            archived: true,
+          });
+        });
+      } finally {
+        admission.release();
+      }
+    });
+  });
+});

--- a/src/agents/tools/sessions-tool.ts
+++ b/src/agents/tools/sessions-tool.ts
@@ -3,9 +3,21 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import { Type } from "typebox";
 import { SESSION_AGENT_ATTENTION_ICON_IDS } from "../../../packages/gateway-protocol/src/session-icon.js";
 import { getRuntimeConfig } from "../../config/config.js";
+import { resolveAgentMainSessionKey } from "../../config/sessions/main-session.js";
+import { resolveStorePath } from "../../config/sessions/paths.js";
+import { loadSessionEntry } from "../../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { GatewayTransportError } from "../../gateway/call.js";
 import { withAgentSessionModelPatchOrigin } from "../../gateway/session-model-patch-origin.js";
+import { formatErrorMessage } from "../../infra/errors.js";
+import { isTransientNetworkError } from "../../infra/unhandled-rejections.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { isIncognitoSessionKey, resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
+import {
+  getCurrentSessionWorkAdmissionRelease,
+  getSessionWorkAdmissionRelease,
+  SESSION_ARCHIVE_ACTIVE_RUN_ERROR,
+} from "../../sessions/session-lifecycle-admission.js";
 import { resolveDefaultAgentId } from "../agent-scope-config.js";
 import { stringEnum } from "../schema/typebox.js";
 import type { AnyAgentTool } from "./common.js";
@@ -34,6 +46,8 @@ const ACTIONS = [
 ] as const;
 const GROUP_NAME_MAX_LENGTH = 512;
 const GROUP_NAMES_MAX_ITEMS = 200;
+const SELF_ARCHIVE_MAX_RETRY_DELAY_MS = 5_000;
+const log = createSubsystemLogger("agents/sessions");
 
 const SessionsToolSchema = Type.Object(
   {
@@ -149,7 +163,7 @@ function readGroupNames(value: unknown): string[] {
 async function resolvePatchTarget(
   opts: SessionsToolOptions,
   sessionKey: string | undefined,
-): Promise<{ cfg: OpenClawConfig; key: string }> {
+): Promise<{ cfg: OpenClawConfig; key: string; requesterKey: string }> {
   const context = resolveSessionToolContext(opts);
   const rawKey = sessionKey ?? context.effectiveRequesterKey;
   const resolved = await resolveSessionReference({
@@ -187,7 +201,11 @@ async function resolvePatchTarget(
       throw new ToolAuthorizationError(access.error);
     }
   }
-  return { cfg: context.cfg, key: resolved.key };
+  return {
+    cfg: context.cfg,
+    key: resolved.key,
+    requesterKey: context.effectiveRequesterKey,
+  };
 }
 
 export function createSessionsTool(opts: SessionsToolOptions = {}): AnyAgentTool {
@@ -266,7 +284,7 @@ export function createSessionsTool(opts: SessionsToolOptions = {}): AnyAgentTool
         throw new ToolInputError(`Unknown action: ${action}`);
       }
 
-      const { key } = await resolvePatchTarget(
+      const { cfg, key, requesterKey } = await resolvePatchTarget(
         { ...opts, config: opts.config ?? getRuntimeConfig() },
         normalizeOptionalString(readStringParam(params, "sessionKey")),
       );
@@ -309,12 +327,131 @@ export function createSessionsTool(opts: SessionsToolOptions = {}): AnyAgentTool
           error: "Model patch needs in-process gateway.",
         });
       }
-      const result =
-        patch.model === undefined
-          ? await gatewayCall("sessions.patch", patch)
+      const callSessionPatch = async (sessionPatch: typeof patch) =>
+        sessionPatch.model === undefined
+          ? await gatewayCall("sessions.patch", sessionPatch)
           : await withAgentSessionModelPatchOrigin(
-              async () => await gatewayCall("sessions.patch", patch),
+              async () => await gatewayCall("sessions.patch", sessionPatch),
             );
+
+      if (patch.archived === true && key === requesterKey && key !== "global") {
+        const agentId = resolveAgentIdFromSessionKey(key, resolveDefaultAgentId(cfg));
+        if (key !== resolveAgentMainSessionKey({ cfg, agentId })) {
+          const storePath = resolveStorePath(cfg.session?.store, { agentId });
+          const currentEntry = loadSessionEntry({ agentId, sessionKey: key, storePath });
+          const released = getCurrentSessionWorkAdmissionRelease({
+            scope: storePath,
+            identities: [key, currentEntry?.sessionId],
+          });
+
+          if (currentEntry && released) {
+            const expectedSessionIdentity = {
+              expectedSessionId: currentEntry.sessionId,
+              ...(currentEntry.lifecycleRevision
+                ? { expectedLifecycleRevision: currentEntry.lifecycleRevision }
+                : {}),
+            };
+            const { archived: _archived, ...immediatePatch } = patch;
+            if (Object.keys(immediatePatch).length > 1) {
+              await callSessionPatch({ ...immediatePatch, ...expectedSessionIdentity });
+            }
+
+            // Archive only after the final tool result, transcript, and every
+            // admitted owner have settled. Gateway-owned compare-and-swap
+            // keeps a reset replacement from being archived between checks.
+            void released
+              .then(async () => {
+                const archiveIdentities = [key, currentEntry.sessionId];
+                const archivePatch = {
+                  key,
+                  archived: true,
+                  ...expectedSessionIdentity,
+                };
+                let unobservedRunRetries = 0;
+
+                while (true) {
+                  const latestEntry = loadSessionEntry({ agentId, sessionKey: key, storePath });
+                  if (
+                    latestEntry?.sessionId !== currentEntry.sessionId ||
+                    (expectedSessionIdentity.expectedLifecycleRevision !== undefined &&
+                      latestEntry.lifecycleRevision !==
+                        expectedSessionIdentity.expectedLifecycleRevision)
+                  ) {
+                    return;
+                  }
+
+                  const competingRelease = getSessionWorkAdmissionRelease({
+                    scope: storePath,
+                    identities: archiveIdentities,
+                  });
+                  if (competingRelease) {
+                    unobservedRunRetries = 0;
+                    await competingRelease;
+                    continue;
+                  }
+
+                  try {
+                    await gatewayCall("sessions.patch", archivePatch);
+                    return;
+                  } catch (error) {
+                    // A new turn can enter after the idle check. Wait for that
+                    // admitted owner, or retry a transient gateway disconnect,
+                    // instead of losing an archive that was already scheduled.
+                    const message = formatErrorMessage(error);
+                    const activeRun = message.includes(SESSION_ARCHIVE_ACTIVE_RUN_ERROR);
+                    const retryableGatewayFailure =
+                      error instanceof GatewayTransportError ||
+                      isTransientNetworkError(error) ||
+                      (typeof error === "object" &&
+                        error !== null &&
+                        "retryable" in error &&
+                        error.retryable === true);
+                    if (!activeRun && !retryableGatewayFailure) {
+                      throw error;
+                    }
+                    if (!activeRun) {
+                      log.warn(`retrying deferred self-archive for ${key}: ${message}`);
+                    }
+                    const retryAfterRelease = getSessionWorkAdmissionRelease({
+                      scope: storePath,
+                      identities: archiveIdentities,
+                    });
+                    if (retryAfterRelease) {
+                      unobservedRunRetries = 0;
+                      await retryAfterRelease;
+                    } else {
+                      // Projected work can outlive local admission tracking.
+                      // Cap the interval, not the archive, so it cannot spin or
+                      // abandon a session whose remote turn is still running.
+                      const retryDelayMs = Math.min(
+                        25 * 2 ** Math.min(unobservedRunRetries, 8),
+                        SELF_ARCHIVE_MAX_RETRY_DELAY_MS,
+                      );
+                      await new Promise<void>((resolve) => {
+                        // A pending self-archive must not keep a shutting-down
+                        // gateway alive solely to retry its own transport.
+                        const retryTimer = setTimeout(resolve, retryDelayMs);
+                        retryTimer.unref?.();
+                      });
+                      unobservedRunRetries = Math.min(unobservedRunRetries + 1, 8);
+                    }
+                  }
+                }
+              })
+              .catch((error: unknown) => {
+                log.warn(`deferred self-archive failed for ${key}: ${formatErrorMessage(error)}`);
+              });
+
+            return jsonResult({
+              status: "scheduled",
+              sessionKey: key,
+              message: "Session will be archived after the current agent run finishes.",
+            });
+          }
+        }
+      }
+
+      const result = await callSessionPatch(patch);
       return jsonResult(result);
     },
   };

--- a/src/gateway/server-methods/sessions-mutations.ts
+++ b/src/gateway/server-methods/sessions-mutations.ts
@@ -23,6 +23,7 @@ import {
   isSessionLifecycleMutationActive,
   isSessionWorkAdmissionActive,
   runExclusiveSessionLifecycleMutation,
+  SESSION_ARCHIVE_ACTIVE_RUN_ERROR,
 } from "../../sessions/session-lifecycle-admission.js";
 import { ADMIN_SCOPE } from "../operator-scopes.js";
 import { resolveRequestedSessionAgentId as resolveRequestedGlobalAgentId } from "../session-create-service.js";
@@ -115,7 +116,7 @@ export const sessionMutationHandlers: GatewayRequestHandlers = {
       respond(
         false,
         undefined,
-        errorShape(ErrorCodes.INVALID_REQUEST, "Cannot archive a session with an active run."),
+        errorShape(ErrorCodes.INVALID_REQUEST, SESSION_ARCHIVE_ACTIVE_RUN_ERROR),
       );
       return;
     }
@@ -151,6 +152,13 @@ export const sessionMutationHandlers: GatewayRequestHandlers = {
       ) {
         return null;
       }
+      // applyPatch runs under runExclusiveSessionLifecycleMutation for every
+      // patch, so expected identities also guard non-archive metadata writes.
+      const expectedSessionChanged =
+        (p.expectedSessionId !== undefined &&
+          currentLifecycleEntry?.sessionId !== p.expectedSessionId) ||
+        (p.expectedLifecycleRevision !== undefined &&
+          currentLifecycleEntry?.lifecycleRevision !== p.expectedLifecycleRevision);
       // A reset queued ahead of archive can rotate the row before this mutation starts.
       // Never apply stale destructive intent to the replacement session identity.
       const lifecycleEntryRemoved =
@@ -162,7 +170,7 @@ export const sessionMutationHandlers: GatewayRequestHandlers = {
           : currentLifecycleEntry !== undefined &&
             (currentLifecycleEntry.sessionId !== lifecycleEntry.sessionId ||
               currentLifecycleEntry.lifecycleRevision !== lifecycleEntry.lifecycleRevision));
-      if (lifecycleEntryRemoved || archiveTargetChanged) {
+      if (expectedSessionChanged || lifecycleEntryRemoved || archiveTargetChanged) {
         respond(
           false,
           undefined,
@@ -196,7 +204,7 @@ export const sessionMutationHandlers: GatewayRequestHandlers = {
           respond(
             false,
             undefined,
-            errorShape(ErrorCodes.INVALID_REQUEST, "Cannot archive a session with an active run."),
+            errorShape(ErrorCodes.INVALID_REQUEST, SESSION_ARCHIVE_ACTIVE_RUN_ERROR),
           );
           return null;
         }

--- a/src/gateway/server.sessions.patch-expected-identity.test.ts
+++ b/src/gateway/server.sessions.patch-expected-identity.test.ts
@@ -1,0 +1,145 @@
+// Compare-and-swap session patches must reject reset replacements atomically.
+import { afterEach, expect, test } from "vitest";
+import { loadSessionEntry } from "../config/sessions/session-accessor.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { embeddedRunMock, writeSessionStore } from "./test-helpers.js";
+import {
+  directSessionReq,
+  sessionStoreEntry,
+  setupGatewaySessionsTestHarness,
+} from "./test/server-sessions.test-helpers.js";
+
+const { createSessionStoreDir } = setupGatewaySessionsTestHarness();
+
+afterEach(() => {
+  closeOpenClawStateDatabaseForTest();
+});
+
+test.each([
+  {
+    name: "session id",
+    expected: { expectedSessionId: "sess-before-reset" },
+  },
+  {
+    name: "lifecycle revision",
+    expected: { expectedLifecycleRevision: "revision-before-reset" },
+  },
+])("sessions.patch rejects a stale expected $name atomically", async ({ expected }) => {
+  const { storePath } = await createSessionStoreDir();
+  const sessionKey = "agent:main:subagent:archive-identity";
+  await writeSessionStore({
+    entries: {
+      [sessionKey]: sessionStoreEntry("sess-after-reset", {
+        lifecycleRevision: "revision-after-reset",
+      }),
+    },
+  });
+
+  const archived = await directSessionReq("sessions.patch", {
+    key: sessionKey,
+    archived: true,
+    ...expected,
+  });
+
+  expect(archived).toMatchObject({
+    ok: false,
+    error: { message: `Session ${sessionKey} changed before patch. Retry.` },
+  });
+  expect(loadSessionEntry({ sessionKey, storePath })).toMatchObject({
+    sessionId: "sess-after-reset",
+    lifecycleRevision: "revision-after-reset",
+  });
+  expect(loadSessionEntry({ sessionKey, storePath })).not.toHaveProperty("archivedAt");
+});
+
+test("sessions.patch rejects a replaced identity before projected active-run protection", async () => {
+  const { storePath } = await createSessionStoreDir();
+  const sessionKey = "agent:main:subagent:active-replacement";
+  const replacementSessionId = "sess-active-after-reset";
+  await writeSessionStore({
+    entries: {
+      [sessionKey]: sessionStoreEntry(replacementSessionId, {
+        lifecycleRevision: "revision-after-reset",
+      }),
+    },
+  });
+  embeddedRunMock.activeIds.add(replacementSessionId);
+
+  const archived = await directSessionReq("sessions.patch", {
+    key: sessionKey,
+    archived: true,
+    expectedSessionId: "sess-before-reset",
+  });
+
+  expect(archived).toMatchObject({
+    ok: false,
+    error: { message: `Session ${sessionKey} changed before patch. Retry.` },
+  });
+  expect(loadSessionEntry({ sessionKey, storePath })).toMatchObject({
+    sessionId: replacementSessionId,
+  });
+  expect(loadSessionEntry({ sessionKey, storePath })).not.toHaveProperty("archivedAt");
+});
+
+test.each([
+  {
+    name: "session id",
+    expected: { expectedSessionId: "sess-before-reset" },
+  },
+  {
+    name: "lifecycle revision",
+    expected: { expectedLifecycleRevision: "revision-before-reset" },
+  },
+])("sessions.patch rejects stale $name for metadata mutations", async ({ expected }) => {
+  const { storePath } = await createSessionStoreDir();
+  const sessionKey = "agent:main:subagent:metadata-identity";
+  await writeSessionStore({
+    entries: {
+      [sessionKey]: sessionStoreEntry("sess-after-reset", {
+        lifecycleRevision: "revision-after-reset",
+      }),
+    },
+  });
+
+  const patched = await directSessionReq("sessions.patch", {
+    key: sessionKey,
+    label: "Stale agent request",
+    ...expected,
+  });
+
+  expect(patched).toMatchObject({
+    ok: false,
+    error: { message: `Session ${sessionKey} changed before patch. Retry.` },
+  });
+  expect(loadSessionEntry({ sessionKey, storePath })).toMatchObject({
+    sessionId: "sess-after-reset",
+    lifecycleRevision: "revision-after-reset",
+  });
+  expect(loadSessionEntry({ sessionKey, storePath })).not.toHaveProperty("label");
+});
+
+test("sessions.patch archives the expected session under its lifecycle lock", async () => {
+  const { storePath } = await createSessionStoreDir();
+  const sessionKey = "agent:main:subagent:archive-identity";
+  const sessionId = "sess-expected-archive";
+  const lifecycleRevision = "revision-expected-archive";
+  await writeSessionStore({
+    entries: {
+      [sessionKey]: sessionStoreEntry(sessionId, { lifecycleRevision }),
+    },
+  });
+
+  const archived = await directSessionReq("sessions.patch", {
+    key: sessionKey,
+    archived: true,
+    expectedSessionId: sessionId,
+    expectedLifecycleRevision: lifecycleRevision,
+  });
+
+  expect(archived.ok).toBe(true);
+  expect(loadSessionEntry({ sessionKey, storePath })).toMatchObject({
+    sessionId,
+    lifecycleRevision,
+    archivedAt: expect.any(Number),
+  });
+});

--- a/src/sessions/session-lifecycle-admission.test.ts
+++ b/src/sessions/session-lifecycle-admission.test.ts
@@ -11,8 +11,10 @@ import {
   beginSessionWorkAdmission,
   cancelSessionWorkAdmissionHandoff,
   consumeSessionWorkAdmissionHandoff,
+  getCurrentSessionWorkAdmissionRelease,
   getActiveSessionLifecycleMutationCount,
   getActiveSessionWorkAdmissionCount,
+  getSessionWorkAdmissionRelease,
   hasOnlySessionLifecycleMutationKindActive,
   interruptSessionWorkAdmissions,
   isSessionWorkAdmissionActive,
@@ -39,6 +41,126 @@ it("counts one multi-identity admission once", async () => {
     admission.release();
   }
   expect(getActiveSessionWorkAdmissionCount()).toBe(0);
+});
+
+it("exposes completion only to the matching admitted session turn", async () => {
+  const scope = "store-self-archive-release";
+  const sessionKey = "agent:main:self-archive";
+  const sessionId = "session-self-archive";
+  const admission = await beginSessionWorkAdmission({
+    scope,
+    identities: [sessionKey, sessionId],
+    assertAllowed: () => {},
+  });
+  let settled = false;
+  let release: Promise<void> | undefined;
+
+  try {
+    expect(
+      getCurrentSessionWorkAdmissionRelease({ scope, identities: [sessionKey] }),
+    ).toBeUndefined();
+
+    await admission.run(async () => {
+      expect(
+        getCurrentSessionWorkAdmissionRelease({ scope, identities: ["agent:main:other"] }),
+      ).toBeUndefined();
+      release = getCurrentSessionWorkAdmissionRelease({
+        scope,
+        identities: [sessionKey, sessionId],
+      });
+      expect(release).toBeInstanceOf(Promise);
+      void release?.then(() => {
+        settled = true;
+      });
+      await Promise.resolve();
+      expect(settled).toBe(false);
+    });
+
+    expect(settled).toBe(false);
+  } finally {
+    admission.release();
+  }
+
+  await release;
+  await Promise.resolve();
+  expect(settled).toBe(true);
+});
+
+it("waits for every nested admission that owns the same session", async () => {
+  const scope = "store-self-archive-nested";
+  const sessionKey = "agent:main:nested-self-archive";
+  const outerAdmission = await beginSessionWorkAdmission({
+    scope,
+    identities: [sessionKey, "outer-session"],
+    assertAllowed: () => {},
+  });
+  let release: Promise<void> | undefined;
+  let settled = false;
+
+  try {
+    await outerAdmission.run(async () => {
+      const innerAdmission = await beginSessionWorkAdmission({
+        scope,
+        identities: [sessionKey, "inner-session"],
+        assertAllowed: () => {},
+      });
+
+      try {
+        await innerAdmission.run(async () => {
+          release = getCurrentSessionWorkAdmissionRelease({
+            scope,
+            identities: [sessionKey],
+          });
+          void release?.then(() => {
+            settled = true;
+          });
+        });
+      } finally {
+        innerAdmission.release();
+      }
+
+      await Promise.resolve();
+      expect(settled).toBe(false);
+    });
+    expect(settled).toBe(false);
+  } finally {
+    outerAdmission.release();
+  }
+
+  await release;
+  await Promise.resolve();
+  expect(settled).toBe(true);
+});
+
+it("waits for a competing session admission outside the caller context", async () => {
+  const scope = "store-competing-self-archive";
+  const sessionKey = "agent:main:competing-self-archive";
+  const admission = await beginSessionWorkAdmission({
+    scope,
+    identities: [sessionKey, "competing-session"],
+    assertAllowed: () => {},
+  });
+  let settled = false;
+  let release: Promise<void> | undefined;
+
+  try {
+    expect(
+      getCurrentSessionWorkAdmissionRelease({ scope, identities: [sessionKey] }),
+    ).toBeUndefined();
+    release = getSessionWorkAdmissionRelease({ scope, identities: [sessionKey] });
+    expect(release).toBeInstanceOf(Promise);
+    void release?.then(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+  } finally {
+    admission.release();
+  }
+
+  await release;
+  await Promise.resolve();
+  expect(settled).toBe(true);
 });
 
 it("atomically hands admitted work across an interrupted RPC boundary", async () => {

--- a/src/sessions/session-lifecycle-admission.ts
+++ b/src/sessions/session-lifecycle-admission.ts
@@ -22,6 +22,8 @@ export {
 } from "./session-work-admission-handoff.js";
 
 export const SESSION_WORK_ADMISSION_DRAIN_TIMEOUT_MS = 15_000;
+/** Stable gateway error for an archive rejected by an admitted or projected run. */
+export const SESSION_ARCHIVE_ACTIVE_RUN_ERROR = "Cannot archive a session with an active run.";
 type SessionWorkAdmission = HandoffSessionWorkAdmission & {
   interrupt?: () => void;
   released: Promise<void>;
@@ -338,6 +340,52 @@ export function isCompetingSessionWorkAdmissionActive(
       (admission) => !currentAdmissions?.has(admission),
     ).some(Boolean),
   );
+}
+
+type SessionWorkAdmissionReleaseParams = {
+  scope: string;
+  identities: Iterable<string | undefined>;
+};
+
+function resolveSessionWorkAdmissionRelease(
+  params: SessionWorkAdmissionReleaseParams,
+  ownedAdmissions?: ReadonlySet<SessionWorkAdmission>,
+): Promise<void> | undefined {
+  const matchingAdmissions = new Set<SessionWorkAdmission>();
+  for (const identity of normalizeSessionIdentities(params.scope, params.identities)) {
+    for (const admission of ACTIVE_SESSION_WORK_ADMISSIONS.get(identity) ?? []) {
+      if (!ownedAdmissions || ownedAdmissions.has(admission)) {
+        matchingAdmissions.add(admission);
+      }
+    }
+  }
+  if (matchingAdmissions.size === 0) {
+    return undefined;
+  }
+
+  // A gateway turn can adopt an outer reply admission and open its own inner
+  // admission. Self-archive must wait for both owners to release the session.
+  return Promise.all(Array.from(matchingAdmissions, (admission) => admission.released)).then(
+    () => undefined,
+  );
+}
+
+/** Completion of this caller's admitted turn for the requested session identities. */
+export function getCurrentSessionWorkAdmissionRelease(
+  params: SessionWorkAdmissionReleaseParams,
+): Promise<void> | undefined {
+  const currentAdmissions = CURRENT_SESSION_WORK_ADMISSIONS.getStore();
+  if (!currentAdmissions?.size) {
+    return undefined;
+  }
+  return resolveSessionWorkAdmissionRelease(params, currentAdmissions);
+}
+
+/** Completion of the currently active turns that own a session. */
+export function getSessionWorkAdmissionRelease(
+  params: SessionWorkAdmissionReleaseParams,
+): Promise<void> | undefined {
+  return resolveSessionWorkAdmissionRelease(params);
 }
 
 /** Active session identities for one store/lifecycle scope. */


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users asking an agent to archive its current non-main session receive `Cannot archive a session with an active run` because the model-selected archive tool call runs inside that same active agent turn.

## Why This Change Was Made

The session-lifecycle maintainer explicitly requested this product behavior: special-case agent self-archive, finish the current response, and then archive the session. Schedule only a non-main self-archive after the initiating admission and any competing work have completed; guard immediate metadata and deferred archival with lifecycle-locked session identity and revision; retry genuinely transient Gateway failures with shutdown-safe backoff; and cancel requests if a session is reset. Preserve upstream plugin-ownership authorization, main-session protection, ordinary active-run validation, and generated native Gateway protocol compatibility.

## User Impact

Users can ask an agent to archive its own session. The agent completes its final response and transcript, and the session subsequently appears under Archived without accidentally archiving a reset replacement.

## Evidence

- Reproduced the original failure against a real running Gateway on Blacksmith Testbox, with a deterministic OpenAI-compatible streaming Responses fixture, an actual model-selected `sessions` tool call, and persisted `sessions.list`: the baseline produced the active-run error and left `archived: false`.
- Replayed the exact live scenario on the current-main-compatible implementation: one successful `sessions` tool call, `status: scheduled`, followed by `archived: true`, `hasActiveRun: false`, and `status: done`.
- Passed 166 focused regressions, including the newly landed upstream plugin-ownership cases: `pnpm test packages/gateway-protocol/src/index.test.ts src/agents/tools/sessions-tool.test.ts src/agents/tools/sessions-tool.self-archive.test.ts src/sessions/session-lifecycle-admission.test.ts src/gateway/server.sessions.patch-expected-identity.test.ts src/gateway/server.sessions.delete-lifecycle.test.ts src/gateway/server.sessions.reset-cleanup.test.ts src/gateway/server.sessions.plugin-ownership.test.ts`.
- Regenerated the additive native Swift Gateway protocol model using the canonical schema generator; Android/Kotlin outputs are unchanged.
- Passed remote `pnpm check:changed`, including formatting, production and test type checks, lint, protocol and plugin compatibility, schema, database-first, and runtime import-cycle guards.
- Fresh independent `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --stream-engine-output`: clean; no actionable findings.
- Maintainer decision: the session-lifecycle owner requested and approved deferred self-archive, including waiting for competing work, cancellation on reset, and preserving the completed response.
- AI-assisted; the issue was reproduced, race conditions and transient failures were regression-tested, and live behavior was independently verified.
- Current hosted release-gate blocker is independently verified on the unchanged `main` base: `apps/.i18n/native-source.json` contains 5,317 source entries while both `apps/.i18n/native/zh-CN.json` and `apps/.i18n/native/zh-TW.json` contain only 5,290. These existing localization artifacts are outside this session-lifecycle change; the canonical session and generated-protocol checks pass.