### PR TITLE
fix(mattermost): backfill thread history from the server when the window is empty

### DIFF
--- a/docs/channels/mattermost.md
+++ b/docs/channels/mattermost.md
@@ -201,6 +201,7 @@ Use `channels.mattermost.replyToModeByChatType` to override the mode for `direct
 Notes:
 
 - Thread-scoped sessions use the triggering post id as the thread root.
+- A thread whose in-process history window is empty — after a gateway restart, or after `/new` clears the session — is rebuilt once from the Mattermost thread itself, so the agent keeps the context the user is looking at. This applies to channel, group, and thread-scoped direct conversations.
 - `first` and `all` are currently equivalent because once Mattermost has a thread root, follow-up chunks and media continue in that same thread.
 - Per-chat-type overrides take precedence over `replyToMode`. Without a `direct` override, existing deployments keep flat, non-threaded DMs.
 

--- a/extensions/mattermost/src/mattermost/client.ts
+++ b/extensions/mattermost/src/mattermost/client.ts
@@ -513,7 +513,7 @@ export async function createMattermostDirectChannelWithRetry(
   );
 }
 
-function isRetryableError(error: Error): boolean {
+export function isRetryableError(error: Error): boolean {
   const candidates = collectErrorGraphCandidates(error, (current) => [
     current.cause,
     current.reason,

--- a/extensions/mattermost/src/mattermost/monitor-auth.ts
+++ b/extensions/mattermost/src/mattermost/monitor-auth.ts
@@ -8,6 +8,10 @@ import {
   type StableChannelIngressIdentityParams,
 } from "openclaw/plugin-sdk/channel-ingress-runtime";
 import {
+  resolveChannelContextVisibilityMode,
+  shouldIncludeSupplementalContext,
+} from "openclaw/plugin-sdk/context-visibility-runtime";
+import {
   normalizeLowercaseStringOrEmpty,
   uniqueStrings,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
@@ -217,6 +221,84 @@ export async function resolveMattermostMonitorInboundAccess(params: {
     },
   });
   return ingress;
+}
+
+/**
+ * Whether a post read back from a Mattermost thread may be kept as history.
+ *
+ * Thread recovery reads the whole server-side thread, including senders the
+ * live inbound path would have dropped without recording, so it has to apply
+ * the same boundary the live path applies to a `group_policy_not_allowlisted`
+ * post: a trigger allowlist does not hide history unless context visibility
+ * opts in.
+ *
+ * The decision has to come from the shared resolver rather than from a
+ * re-derived allowlist. The effective policy is more than `groupAllowFrom`: an
+ * empty group list falls back to `allowFrom`, and pairing-store entries and
+ * access groups are part of it too. Reimplementing it here would omit history
+ * from users the real ingress authorizes.
+ *
+ * `mayPair: false` keeps recovery read-only — merely appearing in a recovered
+ * thread must never create a pairing request — and a resolver failure denies,
+ * so a store hiccup can never widen the boundary.
+ */
+export async function shouldRetainMattermostRecoveredSenderHistory(params: {
+  account: ResolvedMattermostAccount;
+  cfg: OpenClawConfig;
+  senderId: string;
+  /**
+   * Resolved lazily: the username is only consulted when the account opts into
+   * dangerous name matching, and the visibility mode often decides first.
+   */
+  resolveSenderName?: () => Promise<string | undefined>;
+  channelId: string;
+  kind: ChatType;
+  groupPolicy: "allowlist" | "open" | "disabled";
+  storeAllowFrom?: Array<string | number> | null;
+  readStoreAllowFrom?: () => Promise<Array<string | number>>;
+  logVerboseMessage?: (message: string) => void;
+}): Promise<boolean> {
+  const visibilityIncludesDeniedSenders = shouldIncludeSupplementalContext({
+    mode: resolveChannelContextVisibilityMode({
+      cfg: params.cfg,
+      channel: "mattermost",
+      accountId: params.account.accountId,
+    }),
+    kind: "history",
+    senderAllowed: false,
+  });
+  if (visibilityIncludesDeniedSenders) {
+    // Nothing is hidden in this mode, so the sender's authorization does not
+    // change the answer and the resolver never has to run.
+    return true;
+  }
+  if (!params.senderId) {
+    return false;
+  }
+  const senderName = (await params.resolveSenderName?.()) ?? params.senderId;
+  try {
+    const access = await resolveMattermostMonitorInboundAccess({
+      account: params.account,
+      cfg: params.cfg,
+      senderId: params.senderId,
+      senderName,
+      channelId: params.channelId,
+      kind: params.kind,
+      groupPolicy: params.groupPolicy,
+      ...(params.storeAllowFrom !== undefined ? { storeAllowFrom: params.storeAllowFrom } : {}),
+      ...(params.readStoreAllowFrom ? { readStoreAllowFrom: params.readStoreAllowFrom } : {}),
+      allowTextCommands: false,
+      hasControlCommand: false,
+      eventKind: "message",
+      mayPair: false,
+    });
+    return access.ingress.decision === "allow";
+  } catch (error) {
+    params.logVerboseMessage?.(
+      `mattermost: thread backfill visibility check failed sender=${params.senderId} (${String(error)})`,
+    );
+    return false;
+  }
 }
 
 function resolveMattermostCommandDenyReason(params: {

--- a/extensions/mattermost/src/mattermost/monitor-context.ts
+++ b/extensions/mattermost/src/mattermost/monitor-context.ts
@@ -179,10 +179,22 @@ export function resolveMattermostThreadSessionContext(params: {
 export function resolveMattermostPendingHistoryKey(params: {
   kind: ChatType;
   sessionKey: string;
+  /** Thread root for this turn; `undefined` for a top-level, non-threaded turn. */
+  threadRootId: string | undefined;
 }): string | null {
-  // DMs always dispatch immediately, so they do not need the pending-room
-  // history window. Keeping them out also avoids one empty bucket per DM thread.
-  return params.kind === "direct" ? null : params.sessionKey;
+  // A top-level DM always dispatches immediately, so it does not need the
+  // pending-room history window; keeping it out also avoids one empty bucket per
+  // DM conversation.
+  //
+  // A thread-scoped DM is not the same case. Opting a DM into threading gives
+  // each thread its own session with no parent inheritance, so this window is
+  // the only in-process record of that thread — and the one thing a restart or a
+  // session clear can rebuild it from (#93204). Excluding it here was written
+  // when every DM was flat and predates DM threading being configurable.
+  if (params.kind === "direct" && !params.threadRootId) {
+    return null;
+  }
+  return params.sessionKey;
 }
 
 export function resolveMattermostReactionChannelId(

--- a/extensions/mattermost/src/mattermost/monitor-posts.ts
+++ b/extensions/mattermost/src/mattermost/monitor-posts.ts
@@ -20,7 +20,9 @@ import type { MattermostPost } from "./client.js";
 import { resolveMattermostInboundMentionDecision } from "./monitor-activation.js";
 import {
   formatMattermostDirectMessageDropLog,
+  isMattermostSenderAllowed,
   normalizeMattermostAllowEntry,
+  normalizeMattermostAllowList,
   resolveMattermostMonitorInboundAccess,
 } from "./monitor-auth.js";
 import { resolveMattermostPendingHistoryKey } from "./monitor-context.js";
@@ -68,6 +70,27 @@ export function createMattermostPostHandler(monitor: MattermostMonitorContext) {
     channelHistories,
     historyLimit,
     resolveSessionId: createSessionIdResolver(cfg.session?.store),
+    // Same boundary the inbound path applies to a denied sender below: a trigger
+    // allowlist does not hide history unless context visibility opts in. Resolved
+    // here because the allowlist and the visibility mode live with the account,
+    // and recovery must not become a second, unpoliced way into the window.
+    shouldRetainSenderHistory: (senderId) =>
+      isMattermostSenderAllowed({
+        senderId,
+        allowFrom: normalizeMattermostAllowList(
+          account.config.groupAllowFrom ?? account.config.allowFrom ?? [],
+        ),
+        allowNameMatching: false,
+      }) ||
+      shouldIncludeSupplementalContext({
+        mode: resolveChannelContextVisibilityMode({
+          cfg,
+          channel: "mattermost",
+          accountId: account.accountId,
+        }),
+        kind: "history",
+        senderAllowed: false,
+      }),
     logVerboseMessage: (message) => monitor.logVerboseMessage(message),
   });
 

--- a/extensions/mattermost/src/mattermost/monitor-posts.ts
+++ b/extensions/mattermost/src/mattermost/monitor-posts.ts
@@ -37,6 +37,10 @@ import {
   formatMattermostInboundMediaText,
   formatMattermostPendingMediaText,
 } from "./monitor-resources.js";
+import {
+  createMattermostThreadBackfill,
+  createSessionIdResolver,
+} from "./monitor-thread-backfill.js";
 import { dispatchMattermostInboundTurn } from "./monitor-turn.js";
 import type { MattermostMonitorContext } from "./monitor-types.js";
 import type { MattermostEventPayload } from "./monitor-websocket.js";
@@ -57,6 +61,15 @@ export function createMattermostPostHandler(monitor: MattermostMonitorContext) {
     0,
     cfg.messages?.groupChat?.historyLimit ?? DEFAULT_GROUP_HISTORY_LIMIT,
   );
+  // Recovery state lives exactly as long as the history map it repairs, so a
+  // restart resets both together.
+  const threadBackfill = createMattermostThreadBackfill({
+    client: monitor.client,
+    channelHistories,
+    historyLimit,
+    resolveSessionId: createSessionIdResolver(cfg.session?.store),
+    logVerboseMessage: (message) => monitor.logVerboseMessage(message),
+  });
 
   return async (
     post: MattermostPost,
@@ -362,6 +375,18 @@ export function createMattermostPostHandler(monitor: MattermostMonitorContext) {
       previousTimestamp,
       envelope: envelopeOptions,
     });
+    // A thread whose in-memory window did not survive a restart or a session
+    // clear is rebuilt from the server before the pending context is composed,
+    // so the agent sees the conversation the user is actually looking at.
+    if (historyKey && effectiveReplyToId) {
+      await threadBackfill.ensureThreadHistory({
+        historyKey,
+        threadRootId: effectiveReplyToId,
+        currentPostId: post.id,
+        agentId: route.agentId,
+      });
+    }
+
     let combinedBody = body;
     if (historyKey) {
       const channelHistory = createChannelHistoryWindow({ historyMap: channelHistories });

--- a/extensions/mattermost/src/mattermost/monitor-posts.ts
+++ b/extensions/mattermost/src/mattermost/monitor-posts.ts
@@ -20,10 +20,9 @@ import type { MattermostPost } from "./client.js";
 import { resolveMattermostInboundMentionDecision } from "./monitor-activation.js";
 import {
   formatMattermostDirectMessageDropLog,
-  isMattermostSenderAllowed,
   normalizeMattermostAllowEntry,
-  normalizeMattermostAllowList,
   resolveMattermostMonitorInboundAccess,
+  shouldRetainMattermostRecoveredSenderHistory,
 } from "./monitor-auth.js";
 import { resolveMattermostPendingHistoryKey } from "./monitor-context.js";
 import { buildMattermostEventPlan } from "./monitor-event-plan.js";
@@ -49,6 +48,7 @@ import type { MattermostEventPayload } from "./monitor-websocket.js";
 import {
   createChannelHistoryWindow,
   DEFAULT_GROUP_HISTORY_LIMIT,
+  isDangerousNameMatchingEnabled,
   logInboundDrop,
   type HistoryEntry,
 } from "./runtime-api.js";
@@ -71,25 +71,26 @@ export function createMattermostPostHandler(monitor: MattermostMonitorContext) {
     historyLimit,
     resolveSessionId: createSessionIdResolver(cfg.session?.store),
     // Same boundary the inbound path applies to a denied sender below: a trigger
-    // allowlist does not hide history unless context visibility opts in. Resolved
-    // here because the allowlist and the visibility mode live with the account,
-    // and recovery must not become a second, unpoliced way into the window.
-    shouldRetainSenderHistory: (senderId) =>
-      isMattermostSenderAllowed({
+    // allowlist does not hide history unless context visibility opts in. Routed
+    // through the shared ingress resolver so recovery reads the same effective
+    // policy the live path does, rather than becoming a second, unpoliced way
+    // into the window.
+    shouldRetainSenderHistory: ({ senderId, channelId, kind }) =>
+      shouldRetainMattermostRecoveredSenderHistory({
+        account,
+        cfg,
         senderId,
-        allowFrom: normalizeMattermostAllowList(
-          account.config.groupAllowFrom ?? account.config.allowFrom ?? [],
-        ),
-        allowNameMatching: false,
-      }) ||
-      shouldIncludeSupplementalContext({
-        mode: resolveChannelContextVisibilityMode({
-          cfg,
-          channel: "mattermost",
-          accountId: account.accountId,
-        }),
-        kind: "history",
-        senderAllowed: false,
+        // Name entries are an opt-in, dangerous matching mode, so the directory
+        // lookup only happens where it can change the decision.
+        resolveSenderName: async () =>
+          isDangerousNameMatchingEnabled(account.config)
+            ? normalizeOptionalString((await resolveUserInfo(senderId))?.username)
+            : undefined,
+        channelId,
+        kind,
+        groupPolicy,
+        readStoreAllowFrom: pairing.readAllowFromStore,
+        logVerboseMessage: (message) => monitor.logVerboseMessage(message),
       }),
     logVerboseMessage: (message) => monitor.logVerboseMessage(message),
   });
@@ -411,6 +412,8 @@ export function createMattermostPostHandler(monitor: MattermostMonitorContext) {
         threadRootId: effectiveReplyToId,
         currentPostId: post.id,
         agentId: route.agentId,
+        channelId,
+        kind,
       });
     }
 

--- a/extensions/mattermost/src/mattermost/monitor-posts.ts
+++ b/extensions/mattermost/src/mattermost/monitor-posts.ts
@@ -130,7 +130,11 @@ export function createMattermostPostHandler(monitor: MattermostMonitorContext) {
       agentId: route.agentId,
       sessionKey,
     });
-    const historyKey = resolveMattermostPendingHistoryKey({ kind, sessionKey });
+    const historyKey = resolveMattermostPendingHistoryKey({
+      kind,
+      sessionKey,
+      threadRootId: effectiveReplyToId,
+    });
     const fileIds = uniqueStrings(normalizeTrimmedStringList(post.file_ids ?? []));
     const nativeMedia = fileIds.map(() => ({}));
     const pendingBody = formatMattermostPendingMediaText({ body: rawText, media: nativeMedia });

--- a/extensions/mattermost/src/mattermost/monitor-thread-backfill.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor-thread-backfill.test.ts
@@ -176,6 +176,48 @@ describe("createMattermostThreadBackfill", () => {
     expect(harness.requests).toHaveLength(0);
   });
 
+  it("seeds through the bounded history owner so the map stays capped", async () => {
+    // One key short of the shared 1,000-key cap, so seeding one recovered thread
+    // has to evict rather than grow the map.
+    const channelHistories = new Map<string, HistoryEntry[]>(
+      Array.from({ length: 1000 }, (_, index): [string, HistoryEntry[]] => [
+        `agent:main:mattermost:channel:unrelated-${index}:thread:root-${index}`,
+        [{ sender: "u0", body: `unrelated ${index}` }],
+      ]),
+    );
+    const harness = createHarness({ responses: [threadResponse(3)], channelHistories });
+
+    await harness.turn();
+
+    expect(harness.requests).toHaveLength(1);
+    expect(channelHistories.get(HISTORY_KEY)).toHaveLength(3);
+    expect(channelHistories.size).toBe(1000);
+  });
+
+  it("recovers again after the shared owner evicts the recovered window", async () => {
+    const channelHistories = new Map<string, HistoryEntry[]>();
+    const harness = createHarness({
+      responses: [threadResponse(3), threadResponse(4)],
+      channelHistories,
+    });
+
+    await harness.turn();
+    expect(harness.requests).toHaveLength(1);
+
+    // An emptied window keeps its key, so that alone must not trigger a refetch.
+    channelHistories.set(HISTORY_KEY, []);
+    await harness.turn();
+    expect(harness.requests).toHaveLength(1);
+
+    // LRU eviction removes the key outright; the marker now vouches for a window
+    // that no longer exists, so the next turn has to rebuild it.
+    channelHistories.delete(HISTORY_KEY);
+    await harness.turn();
+
+    expect(harness.requests).toHaveLength(2);
+    expect(channelHistories.get(HISTORY_KEY)).toHaveLength(4);
+  });
+
   it("makes one request when concurrent cold turns race", async () => {
     const harness = createHarness({ responses: [threadResponse(3), threadResponse(3)] });
 

--- a/extensions/mattermost/src/mattermost/monitor-thread-backfill.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor-thread-backfill.test.ts
@@ -2,12 +2,14 @@
 import { describe, expect, it, vi } from "vitest";
 import type { MattermostClient } from "./client.js";
 import { createMattermostThreadBackfill } from "./monitor-thread-backfill.js";
-import type { HistoryEntry } from "./runtime-api.js";
+import type { ChatType, HistoryEntry } from "./runtime-api.js";
 
 const HISTORY_KEY = "agent:main:mattermost:channel:c1:thread:root-1";
 const AGENT_ID = "main";
 const THREAD_ROOT_ID = "root-1";
 const CURRENT_POST_ID = "current-post";
+const CHANNEL_ID = "c1";
+const CONVERSATION = { channelId: CHANNEL_ID, kind: "channel" } as const;
 // Mirrors the module defaults; the module keeps them private so the behavior is
 // asserted through the factory rather than through its constants.
 const PER_PAGE_MAX = 200;
@@ -40,7 +42,11 @@ function createHarness(options: {
   sessionId?: string | undefined;
   historyLimit?: number;
   channelHistories?: Map<string, HistoryEntry[]>;
-  shouldRetainSenderHistory?: (senderId: string) => boolean;
+  shouldRetainSenderHistory?: (params: {
+    senderId: string;
+    channelId: string;
+    kind: ChatType;
+  }) => boolean | Promise<boolean>;
 }) {
   const requests: { path: string; timeoutMs?: number }[] = [];
   let currentSessionId = options.sessionId ?? "session-a";
@@ -85,6 +91,7 @@ function createHarness(options: {
         threadRootId: THREAD_ROOT_ID,
         currentPostId: CURRENT_POST_ID,
         agentId: AGENT_ID,
+        ...CONVERSATION,
       }),
   };
 }
@@ -185,13 +192,61 @@ describe("createMattermostThreadBackfill", () => {
       responses: [threadResponse(3)],
       // u1 is the denied sender: the inbound path would have dropped its message
       // without recording it, so recovery must not read it back from the server.
-      shouldRetainSenderHistory: (senderId) => senderId !== "u1",
+      shouldRetainSenderHistory: ({ senderId }) => senderId !== "u1",
     });
 
     await harness.turn();
 
     const seeded = harness.channelHistories.get(HISTORY_KEY) ?? [];
     expect(seeded.map((entry) => entry.sender)).toEqual(["u0", "u2"]);
+  });
+
+  it("resolves retention asynchronously against the conversation, once per sender", async () => {
+    const asked: Array<{ senderId: string; channelId: string; kind: ChatType }> = [];
+    const harness = createHarness({
+      responses: [
+        {
+          order: ["p0", "p1", "p2"],
+          posts: {
+            p0: { id: "p0", user_id: "u0", message: "first", create_at: 10 },
+            // The same denied sender twice: the effective policy is resolved
+            // through the ingress runtime, so it must not be asked per post.
+            p1: { id: "p1", user_id: "u1", message: "denied", create_at: 20 },
+            p2: { id: "p2", user_id: "u1", message: "denied again", create_at: 30 },
+          },
+        },
+      ],
+      shouldRetainSenderHistory: async (params) => {
+        asked.push(params);
+        return params.senderId !== "u1";
+      },
+    });
+
+    await harness.turn();
+
+    expect(asked).toEqual([
+      { senderId: "u0", channelId: CHANNEL_ID, kind: "channel" },
+      { senderId: "u1", channelId: CHANNEL_ID, kind: "channel" },
+    ]);
+    expect(harness.channelHistories.get(HISTORY_KEY)?.map((entry) => entry.sender)).toEqual(["u0"]);
+  });
+
+  it("keeps the newest retained posts when the window is smaller than the thread", async () => {
+    // Retention has to be applied before the window is sliced, or dropping a
+    // denied sender would shrink the recovered window instead of admitting an
+    // older allowed post.
+    const harness = createHarness({
+      responses: [threadResponse(4)],
+      historyLimit: 2,
+      shouldRetainSenderHistory: ({ senderId }) => senderId !== "u3",
+    });
+
+    await harness.turn();
+
+    expect(harness.channelHistories.get(HISTORY_KEY)?.map((entry) => entry.sender)).toEqual([
+      "u1",
+      "u2",
+    ]);
   });
 
   it("keeps every recovered post when context visibility opts denied senders in", async () => {
@@ -395,6 +450,34 @@ describe("createMattermostThreadBackfill", () => {
     expect(harness.requests).toHaveLength(1);
   });
 
+  it("carries the seeded window across adoption so a later eviction still recovers", async () => {
+    const channelHistories = new Map<string, HistoryEntry[]>();
+    const harness = createHarness({
+      responses: [threadResponse(2), threadResponse(3)],
+      channelHistories,
+    });
+    harness.rotateSession(undefined);
+
+    // The window is recovered while the store still has no session id, so it is
+    // recorded as seeded under the pending marker.
+    await harness.turn();
+    expect(harness.requests).toHaveLength(1);
+
+    // The store settles and the marker rotates to the real session id.
+    harness.rotateSession("session-a");
+    await harness.turn();
+    expect(harness.requests).toHaveLength(1);
+
+    // Ownership of the seeded window has to rotate with the marker. If it stays
+    // behind, this eviction is unreadable as one and recovery is suppressed for
+    // the rest of the session.
+    channelHistories.delete(HISTORY_KEY);
+    await harness.turn();
+
+    expect(harness.requests).toHaveLength(2);
+    expect(channelHistories.get(HISTORY_KEY)).toHaveLength(3);
+  });
+
   it("discards a completion whose session rotated mid-flight", async () => {
     let releaseFirst: () => void = () => {};
     const firstGate = new Promise<void>((resolve) => {
@@ -425,6 +508,7 @@ describe("createMattermostThreadBackfill", () => {
         threadRootId: THREAD_ROOT_ID,
         currentPostId: CURRENT_POST_ID,
         agentId: AGENT_ID,
+        ...CONVERSATION,
       });
 
     const stale = turn();
@@ -458,6 +542,7 @@ describe("createMattermostThreadBackfill", () => {
         threadRootId: `root-${index}`,
         currentPostId: CURRENT_POST_ID,
         agentId: AGENT_ID,
+        ...CONVERSATION,
       });
     }
 
@@ -471,6 +556,7 @@ describe("createMattermostThreadBackfill", () => {
         threadRootId: `root-${index}`,
         currentPostId: CURRENT_POST_ID,
         agentId: AGENT_ID,
+        ...CONVERSATION,
       });
     }
     expect(request.mock.calls.length).toBeLessThan(40);
@@ -492,6 +578,7 @@ describe("createMattermostThreadBackfill", () => {
       threadRootId: THREAD_ROOT_ID,
       currentPostId: CURRENT_POST_ID,
       agentId: AGENT_ID,
+      ...CONVERSATION,
     });
 
     expect(client.request).not.toHaveBeenCalled();

--- a/extensions/mattermost/src/mattermost/monitor-thread-backfill.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor-thread-backfill.test.ts
@@ -1,0 +1,461 @@
+// Mattermost tests cover thread-history recovery for cold inbound turns (#93204).
+import { describe, expect, it, vi } from "vitest";
+import type { MattermostClient } from "./client.js";
+import {
+  createMattermostThreadBackfill,
+  MATTERMOST_THREAD_PER_PAGE_MAX,
+  mayAttemptRecovery,
+  resolveRecoveryMarker,
+  resolveThreadFetchLimit,
+  THREAD_BACKFILL_COOLDOWN_MS,
+  THREAD_BACKFILL_MAX_ATTEMPTS,
+} from "./monitor-thread-backfill.js";
+import type { HistoryEntry } from "./runtime-api.js";
+
+const HISTORY_KEY = "agent:main:mattermost:channel:c1:thread:root-1";
+const AGENT_ID = "main";
+const THREAD_ROOT_ID = "root-1";
+const CURRENT_POST_ID = "current-post";
+
+const mattermostApiError = (status: number, statusText: string) =>
+  new Error(`Mattermost API ${status} ${statusText}: detail`);
+
+const abortError = () => Object.assign(new Error("aborted"), { name: "AbortError" });
+
+const threadResponse = (count: number) => ({
+  order: Array.from({ length: count }, (_, index) => `p${index}`),
+  posts: Object.fromEntries(
+    Array.from({ length: count }, (_, index) => [
+      `p${index}`,
+      {
+        id: `p${index}`,
+        user_id: `u${index}`,
+        message: `message ${index}`,
+        create_at: 1_000 + index,
+      },
+    ]),
+  ),
+});
+
+function createHarness(options: {
+  responses: (unknown | Error)[];
+  sessionId?: string | undefined;
+  historyLimit?: number;
+  channelHistories?: Map<string, HistoryEntry[]>;
+}) {
+  const requests: { path: string; timeoutMs?: number }[] = [];
+  let currentSessionId = options.sessionId ?? "session-a";
+  let clock = 1_000_000;
+  const responses = [...options.responses];
+
+  const client = {
+    request: vi.fn(async (path: string, init?: { timeoutMs?: number }) => {
+      requests.push({ path, timeoutMs: init?.timeoutMs });
+      const next = responses.shift();
+      if (next instanceof Error) {
+        throw next;
+      }
+      return next;
+    }),
+  } as unknown as MattermostClient;
+
+  const channelHistories = options.channelHistories ?? new Map<string, HistoryEntry[]>();
+  const backfill = createMattermostThreadBackfill({
+    client,
+    channelHistories,
+    historyLimit: options.historyLimit ?? 10,
+    resolveSessionId: () => currentSessionId,
+    now: () => clock,
+  });
+
+  return {
+    requests,
+    channelHistories,
+    advance: (ms: number) => {
+      clock += ms;
+    },
+    rotateSession: (sessionId: string | undefined) => {
+      currentSessionId = sessionId as string;
+    },
+    turn: () =>
+      backfill.ensureThreadHistory({
+        historyKey: HISTORY_KEY,
+        threadRootId: THREAD_ROOT_ID,
+        currentPostId: CURRENT_POST_ID,
+        agentId: AGENT_ID,
+      }),
+  };
+}
+
+describe("resolveThreadFetchLimit", () => {
+  it("requests one extra post so the current post can be filtered out", () => {
+    expect(resolveThreadFetchLimit(10)).toBe(11);
+  });
+
+  it("never requests fewer than one post", () => {
+    expect(resolveThreadFetchLimit(0)).toBe(1);
+  });
+
+  it("clamps to the documented Mattermost maximum instead of relying on truncation", () => {
+    expect(resolveThreadFetchLimit(199)).toBe(MATTERMOST_THREAD_PER_PAGE_MAX);
+    expect(resolveThreadFetchLimit(5_000)).toBe(MATTERMOST_THREAD_PER_PAGE_MAX);
+  });
+});
+
+describe("resolveRecoveryMarker", () => {
+  it("keys recovery to the stored session id once the store has one", () => {
+    expect(resolveRecoveryMarker({ historyKey: HISTORY_KEY, sessionId: "s1" })).toBe("session:s1");
+  });
+
+  it("falls back to a pending marker before the session id exists", () => {
+    expect(resolveRecoveryMarker({ historyKey: HISTORY_KEY, sessionId: undefined })).toBe(
+      `pending:${HISTORY_KEY}`,
+    );
+  });
+});
+
+describe("mayAttemptRecovery", () => {
+  const base = { marker: "session:s1", maxAttempts: 3 };
+
+  it("allows the first attempt", () => {
+    expect(mayAttemptRecovery({ ...base, record: undefined, now: 0 })).toBe(true);
+  });
+
+  it("ignores a record left by a different marker", () => {
+    expect(
+      mayAttemptRecovery({
+        ...base,
+        record: { marker: "session:old", attempts: 3, nextAttemptAt: Number.MAX_SAFE_INTEGER },
+        now: 0,
+      }),
+    ).toBe(true);
+  });
+
+  it("blocks while the cooldown has not elapsed", () => {
+    expect(
+      mayAttemptRecovery({
+        ...base,
+        record: { marker: "session:s1", attempts: 1, nextAttemptAt: 5_000 },
+        now: 4_999,
+      }),
+    ).toBe(false);
+  });
+
+  it("allows the attempt once the cooldown elapses", () => {
+    expect(
+      mayAttemptRecovery({
+        ...base,
+        record: { marker: "session:s1", attempts: 1, nextAttemptAt: 5_000 },
+        now: 5_000,
+      }),
+    ).toBe(true);
+  });
+
+  it("blocks once the attempt budget is spent", () => {
+    expect(
+      mayAttemptRecovery({
+        ...base,
+        record: { marker: "session:s1", attempts: 3, nextAttemptAt: 0 },
+        now: Number.MAX_SAFE_INTEGER,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("createMattermostThreadBackfill", () => {
+  it("seeds a cold thread from the server and skips the post being handled", async () => {
+    const harness = createHarness({
+      responses: [
+        {
+          order: ["p0", CURRENT_POST_ID],
+          posts: {
+            p0: { id: "p0", user_id: "u0", message: "earlier", create_at: 10 },
+            [CURRENT_POST_ID]: {
+              id: CURRENT_POST_ID,
+              user_id: "u1",
+              message: "now",
+              create_at: 20,
+            },
+          },
+        },
+      ],
+    });
+
+    await harness.turn();
+
+    expect(harness.channelHistories.get(HISTORY_KEY)).toEqual([
+      { sender: "u0", body: "earlier", timestamp: 10, messageId: "p0" },
+    ]);
+  });
+
+  it("bounds the request with the inbound timeout and the clamped page size", async () => {
+    const harness = createHarness({ responses: [threadResponse(2)], historyLimit: 5_000 });
+
+    await harness.turn();
+
+    expect(harness.requests[0]?.path).toContain(`perPage=${MATTERMOST_THREAD_PER_PAGE_MAX}`);
+    expect(harness.requests[0]?.timeoutMs).toBe(5_000);
+  });
+
+  it("labels attachment-only posts instead of dropping them", async () => {
+    const harness = createHarness({
+      responses: [{ order: ["p0"], posts: { p0: { id: "p0", user_id: "u0", create_at: 10 } } }],
+    });
+
+    await harness.turn();
+
+    expect(harness.channelHistories.get(HISTORY_KEY)?.[0]?.body).toBe("[attachment]");
+  });
+
+  it("recovers only once per stored session", async () => {
+    const harness = createHarness({
+      responses: [threadResponse(3), threadResponse(3), threadResponse(3)],
+    });
+
+    await harness.turn();
+    await harness.turn();
+    harness.advance(600_000);
+    await harness.turn();
+
+    expect(harness.requests).toHaveLength(1);
+  });
+
+  it("does not fetch when the thread already has an in-memory window", async () => {
+    const channelHistories = new Map<string, HistoryEntry[]>([
+      [HISTORY_KEY, [{ sender: "u0", body: "still warm" }]],
+    ]);
+    const harness = createHarness({ responses: [threadResponse(3)], channelHistories });
+
+    await harness.turn();
+
+    expect(harness.requests).toHaveLength(0);
+  });
+
+  it("makes one request when concurrent cold turns race", async () => {
+    const harness = createHarness({ responses: [threadResponse(3), threadResponse(3)] });
+
+    await Promise.all([harness.turn(), harness.turn()]);
+
+    expect(harness.requests).toHaveLength(1);
+  });
+
+  it("schedules a retry after a transient failure instead of marking the session attempted", async () => {
+    const harness = createHarness({
+      responses: [mattermostApiError(500, "Internal Server Error"), threadResponse(3)],
+    });
+
+    await harness.turn();
+    expect(harness.requests).toHaveLength(1);
+    expect(harness.channelHistories.has(HISTORY_KEY)).toBe(false);
+
+    harness.advance(THREAD_BACKFILL_COOLDOWN_MS);
+    await harness.turn();
+
+    expect(harness.requests).toHaveLength(2);
+    expect(harness.channelHistories.get(HISTORY_KEY)).toHaveLength(3);
+  });
+
+  it("holds the retry until the cooldown elapses", async () => {
+    const harness = createHarness({
+      responses: [mattermostApiError(503, "Service Unavailable"), threadResponse(3)],
+    });
+
+    await harness.turn();
+    harness.advance(THREAD_BACKFILL_COOLDOWN_MS - 1);
+    await harness.turn();
+
+    expect(harness.requests).toHaveLength(1);
+  });
+
+  it("treats rate limiting and inbound timeouts as retryable", async () => {
+    const rateLimited = createHarness({
+      responses: [mattermostApiError(429, "Too Many Requests"), threadResponse(2)],
+    });
+    await rateLimited.turn();
+    rateLimited.advance(THREAD_BACKFILL_COOLDOWN_MS);
+    await rateLimited.turn();
+    expect(rateLimited.requests).toHaveLength(2);
+
+    const timedOut = createHarness({ responses: [abortError(), threadResponse(2)] });
+    await timedOut.turn();
+    timedOut.advance(THREAD_BACKFILL_COOLDOWN_MS);
+    await timedOut.turn();
+    expect(timedOut.requests).toHaveLength(2);
+  });
+
+  it("stops after the attempt budget is spent", async () => {
+    const harness = createHarness({
+      responses: Array.from({ length: 10 }, () => mattermostApiError(500, "Internal Server Error")),
+    });
+
+    for (let index = 0; index < 8; index += 1) {
+      await harness.turn();
+      harness.advance(THREAD_BACKFILL_COOLDOWN_MS);
+    }
+
+    expect(harness.requests).toHaveLength(THREAD_BACKFILL_MAX_ATTEMPTS);
+  });
+
+  it("never retries a permanent failure", async () => {
+    const harness = createHarness({
+      responses: Array.from({ length: 5 }, () => mattermostApiError(403, "Forbidden")),
+    });
+
+    for (let index = 0; index < 4; index += 1) {
+      await harness.turn();
+      harness.advance(THREAD_BACKFILL_COOLDOWN_MS);
+    }
+
+    expect(harness.requests).toHaveLength(1);
+  });
+
+  it("keeps retrying when the failed turn's own message rebuilds the window", async () => {
+    const harness = createHarness({
+      responses: [mattermostApiError(500, "Internal Server Error"), threadResponse(4)],
+    });
+
+    await harness.turn();
+    // The kernel records the message that just arrived, so the window is no
+    // longer empty even though the thread is still missing its history.
+    harness.channelHistories.set(HISTORY_KEY, [{ sender: "u9", body: "the message just handled" }]);
+    harness.advance(THREAD_BACKFILL_COOLDOWN_MS);
+    await harness.turn();
+
+    expect(harness.requests).toHaveLength(2);
+    expect(harness.channelHistories.get(HISTORY_KEY)).toHaveLength(4);
+  });
+
+  it("gives a rotated session its own attempt budget", async () => {
+    const harness = createHarness({
+      responses: Array.from({ length: 10 }, () => mattermostApiError(500, "Internal Server Error")),
+    });
+
+    for (let index = 0; index < 5; index += 1) {
+      await harness.turn();
+      harness.advance(THREAD_BACKFILL_COOLDOWN_MS);
+    }
+    expect(harness.requests).toHaveLength(THREAD_BACKFILL_MAX_ATTEMPTS);
+
+    harness.rotateSession("session-b");
+    await harness.turn();
+
+    expect(harness.requests).toHaveLength(THREAD_BACKFILL_MAX_ATTEMPTS + 1);
+  });
+
+  it("adopts the real session id after a pending recovery settles", async () => {
+    const harness = createHarness({ responses: [threadResponse(2), threadResponse(2)] });
+    harness.rotateSession(undefined);
+
+    await harness.turn();
+    expect(harness.requests).toHaveLength(1);
+
+    harness.rotateSession("session-a");
+    await harness.turn();
+
+    // Adopting the id must not re-fetch: the pending recovery already ran.
+    expect(harness.requests).toHaveLength(1);
+  });
+
+  it("discards a completion whose session rotated mid-flight", async () => {
+    let releaseFirst: () => void = () => {};
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    let calls = 0;
+    const channelHistories = new Map<string, HistoryEntry[]>();
+    const client = {
+      request: vi.fn(async () => {
+        calls += 1;
+        if (calls === 1) {
+          await firstGate;
+          return threadResponse(3);
+        }
+        return threadResponse(1);
+      }),
+    } as unknown as MattermostClient;
+    let sessionId = "session-a";
+    const backfill = createMattermostThreadBackfill({
+      client,
+      channelHistories,
+      historyLimit: 10,
+      resolveSessionId: () => sessionId,
+    });
+    const turn = () =>
+      backfill.ensureThreadHistory({
+        historyKey: HISTORY_KEY,
+        threadRootId: THREAD_ROOT_ID,
+        currentPostId: CURRENT_POST_ID,
+        agentId: AGENT_ID,
+      });
+
+    const stale = turn();
+    sessionId = "session-b";
+    await turn();
+    expect(channelHistories.get(HISTORY_KEY)).toHaveLength(1);
+
+    releaseFirst();
+    await stale;
+
+    // The older session's three entries must not overwrite the window the
+    // current session already recovered.
+    expect(channelHistories.get(HISTORY_KEY)).toHaveLength(1);
+  });
+
+  it("evicts the oldest recovery state instead of growing without bound", async () => {
+    const client = {
+      request: vi.fn(async () => threadResponse(1)),
+    } as unknown as MattermostClient;
+    const channelHistories = new Map<string, HistoryEntry[]>();
+    const backfill = createMattermostThreadBackfill({
+      client,
+      channelHistories,
+      historyLimit: 10,
+      resolveSessionId: () => "session-a",
+      markerCap: 5,
+    });
+
+    for (let index = 0; index < 20; index += 1) {
+      await backfill.ensureThreadHistory({
+        historyKey: `key-${index}`,
+        threadRootId: `root-${index}`,
+        currentPostId: CURRENT_POST_ID,
+        agentId: AGENT_ID,
+      });
+    }
+
+    // Every key is cold, so an unbounded map would hold 20 markers; the cap
+    // keeps only the most recent ones, and the evicted keys simply recover
+    // again if they are ever seen once more.
+    expect(client.request).toHaveBeenCalledTimes(20);
+    for (let index = 0; index < 20; index += 1) {
+      await backfill.ensureThreadHistory({
+        historyKey: `key-${index}`,
+        threadRootId: `root-${index}`,
+        currentPostId: CURRENT_POST_ID,
+        agentId: AGENT_ID,
+      });
+    }
+    expect(client.request.mock.calls.length).toBeLessThan(40);
+  });
+
+  it("does nothing when history is disabled", async () => {
+    const client = {
+      request: vi.fn(async () => threadResponse(3)),
+    } as unknown as MattermostClient;
+    const backfill = createMattermostThreadBackfill({
+      client,
+      channelHistories: new Map(),
+      historyLimit: 0,
+      resolveSessionId: () => "session-a",
+    });
+
+    await backfill.ensureThreadHistory({
+      historyKey: HISTORY_KEY,
+      threadRootId: THREAD_ROOT_ID,
+      currentPostId: CURRENT_POST_ID,
+      agentId: AGENT_ID,
+    });
+
+    expect(client.request).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/mattermost/src/mattermost/monitor-thread-backfill.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor-thread-backfill.test.ts
@@ -287,6 +287,31 @@ describe("createMattermostThreadBackfill", () => {
     expect(harness.requests).toHaveLength(MAX_ATTEMPTS + 1);
   });
 
+  it("keeps the cooldown and the budget when the pending session materializes", async () => {
+    const harness = createHarness({
+      responses: Array.from({ length: 10 }, () => mattermostApiError(500, "Internal Server Error")),
+    });
+    harness.rotateSession(undefined);
+
+    await harness.turn();
+    expect(harness.requests).toHaveLength(1);
+
+    // The store settles the session id between turns. The failure recorded under
+    // the pending marker is still this thread's, so the marker rotating must not
+    // hand the next turn a fresh cooldown or a fresh budget.
+    harness.rotateSession("session-a");
+    harness.advance(COOLDOWN_MS - 1);
+    await harness.turn();
+    expect(harness.requests).toHaveLength(1);
+
+    for (let index = 0; index < 5; index += 1) {
+      harness.advance(COOLDOWN_MS);
+      await harness.turn();
+    }
+
+    expect(harness.requests).toHaveLength(MAX_ATTEMPTS);
+  });
+
   it("adopts the real session id after a pending recovery settles", async () => {
     const harness = createHarness({ responses: [threadResponse(2), threadResponse(2)] });
     harness.rotateSession(undefined);

--- a/extensions/mattermost/src/mattermost/monitor-thread-backfill.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor-thread-backfill.test.ts
@@ -40,6 +40,7 @@ function createHarness(options: {
   sessionId?: string | undefined;
   historyLimit?: number;
   channelHistories?: Map<string, HistoryEntry[]>;
+  shouldRetainSenderHistory?: (senderId: string) => boolean;
 }) {
   const requests: { path: string; timeoutMs?: number }[] = [];
   let currentSessionId = options.sessionId ?? "session-a";
@@ -64,6 +65,9 @@ function createHarness(options: {
     historyLimit: options.historyLimit ?? 10,
     resolveSessionId: () => currentSessionId,
     now: () => clock,
+    ...(options.shouldRetainSenderHistory
+      ? { shouldRetainSenderHistory: options.shouldRetainSenderHistory }
+      : {}),
   });
 
   return {
@@ -174,6 +178,29 @@ describe("createMattermostThreadBackfill", () => {
     await harness.turn();
 
     expect(harness.requests).toHaveLength(0);
+  });
+
+  it("drops recovered posts from senders whose history the inbound path would omit", async () => {
+    const harness = createHarness({
+      responses: [threadResponse(3)],
+      // u1 is the denied sender: the inbound path would have dropped its message
+      // without recording it, so recovery must not read it back from the server.
+      shouldRetainSenderHistory: (senderId) => senderId !== "u1",
+    });
+
+    await harness.turn();
+
+    const seeded = harness.channelHistories.get(HISTORY_KEY) ?? [];
+    expect(seeded.map((entry) => entry.sender)).toEqual(["u0", "u2"]);
+  });
+
+  it("keeps every recovered post when context visibility opts denied senders in", async () => {
+    const harness = createHarness({ responses: [threadResponse(3)] });
+
+    await harness.turn();
+
+    const seeded = harness.channelHistories.get(HISTORY_KEY) ?? [];
+    expect(seeded.map((entry) => entry.sender)).toEqual(["u0", "u1", "u2"]);
   });
 
   it("seeds through the bounded history owner so the map stays capped", async () => {

--- a/extensions/mattermost/src/mattermost/monitor-thread-backfill.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor-thread-backfill.test.ts
@@ -231,6 +231,32 @@ describe("createMattermostThreadBackfill", () => {
     expect(harness.channelHistories.get(HISTORY_KEY)?.map((entry) => entry.sender)).toEqual(["u0"]);
   });
 
+  it("starts every sender resolution before awaiting any of them", async () => {
+    // Resolving a sender can reach the Mattermost user API, whose timeout is
+    // far above the bound on the thread fetch. Awaiting each one in turn would
+    // multiply that cost by the number of senders in the thread.
+    let release: () => void = () => {};
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const started: string[] = [];
+    const harness = createHarness({
+      responses: [threadResponse(3)],
+      shouldRetainSenderHistory: async ({ senderId }) => {
+        started.push(senderId);
+        await gate;
+        return true;
+      },
+    });
+
+    const turn = harness.turn();
+    await vi.waitFor(() => expect(started).toEqual(["u0", "u1", "u2"]));
+    release();
+    await turn;
+
+    expect(harness.channelHistories.get(HISTORY_KEY)).toHaveLength(3);
+  });
+
   it("keeps the newest retained posts when the window is smaller than the thread", async () => {
     // Retention has to be applied before the window is sliced, or dropping a
     // denied sender would shrink the recovered window instead of admitting an

--- a/extensions/mattermost/src/mattermost/monitor-thread-backfill.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor-thread-backfill.test.ts
@@ -1,21 +1,19 @@
 // Mattermost tests cover thread-history recovery for cold inbound turns (#93204).
 import { describe, expect, it, vi } from "vitest";
 import type { MattermostClient } from "./client.js";
-import {
-  createMattermostThreadBackfill,
-  MATTERMOST_THREAD_PER_PAGE_MAX,
-  mayAttemptRecovery,
-  resolveRecoveryMarker,
-  resolveThreadFetchLimit,
-  THREAD_BACKFILL_COOLDOWN_MS,
-  THREAD_BACKFILL_MAX_ATTEMPTS,
-} from "./monitor-thread-backfill.js";
+import { createMattermostThreadBackfill } from "./monitor-thread-backfill.js";
 import type { HistoryEntry } from "./runtime-api.js";
 
 const HISTORY_KEY = "agent:main:mattermost:channel:c1:thread:root-1";
 const AGENT_ID = "main";
 const THREAD_ROOT_ID = "root-1";
 const CURRENT_POST_ID = "current-post";
+// Mirrors the module defaults; the module keeps them private so the behavior is
+// asserted through the factory rather than through its constants.
+const PER_PAGE_MAX = 200;
+const COOLDOWN_MS = 60_000;
+const MAX_ATTEMPTS = 3;
+const INBOUND_TIMEOUT_MS = 5_000;
 
 const mattermostApiError = (status: number, statusText: string) =>
   new Error(`Mattermost API ${status} ${statusText}: detail`);
@@ -38,7 +36,7 @@ const threadResponse = (count: number) => ({
 });
 
 function createHarness(options: {
-  responses: (unknown | Error)[];
+  responses: unknown[];
   sessionId?: string | undefined;
   historyLimit?: number;
   channelHistories?: Map<string, HistoryEntry[]>;
@@ -87,78 +85,25 @@ function createHarness(options: {
   };
 }
 
-describe("resolveThreadFetchLimit", () => {
-  it("requests one extra post so the current post can be filtered out", () => {
-    expect(resolveThreadFetchLimit(10)).toBe(11);
-  });
+describe("thread page size", () => {
+  it.each([
+    {
+      historyLimit: 10,
+      perPage: 11,
+      why: "one extra post so the handled post can be filtered out",
+    },
+    { historyLimit: 1, perPage: 2, why: "the smallest window still asks for one extra" },
+    { historyLimit: 199, perPage: PER_PAGE_MAX, why: "clamped at the Mattermost maximum" },
+    { historyLimit: 5_000, perPage: PER_PAGE_MAX, why: "clamped instead of relying on truncation" },
+  ])("requests perPage=$perPage for historyLimit=$historyLimit ($why)", async (testCase) => {
+    const harness = createHarness({
+      responses: [threadResponse(1)],
+      historyLimit: testCase.historyLimit,
+    });
 
-  it("never requests fewer than one post", () => {
-    expect(resolveThreadFetchLimit(0)).toBe(1);
-  });
+    await harness.turn();
 
-  it("clamps to the documented Mattermost maximum instead of relying on truncation", () => {
-    expect(resolveThreadFetchLimit(199)).toBe(MATTERMOST_THREAD_PER_PAGE_MAX);
-    expect(resolveThreadFetchLimit(5_000)).toBe(MATTERMOST_THREAD_PER_PAGE_MAX);
-  });
-});
-
-describe("resolveRecoveryMarker", () => {
-  it("keys recovery to the stored session id once the store has one", () => {
-    expect(resolveRecoveryMarker({ historyKey: HISTORY_KEY, sessionId: "s1" })).toBe("session:s1");
-  });
-
-  it("falls back to a pending marker before the session id exists", () => {
-    expect(resolveRecoveryMarker({ historyKey: HISTORY_KEY, sessionId: undefined })).toBe(
-      `pending:${HISTORY_KEY}`,
-    );
-  });
-});
-
-describe("mayAttemptRecovery", () => {
-  const base = { marker: "session:s1", maxAttempts: 3 };
-
-  it("allows the first attempt", () => {
-    expect(mayAttemptRecovery({ ...base, record: undefined, now: 0 })).toBe(true);
-  });
-
-  it("ignores a record left by a different marker", () => {
-    expect(
-      mayAttemptRecovery({
-        ...base,
-        record: { marker: "session:old", attempts: 3, nextAttemptAt: Number.MAX_SAFE_INTEGER },
-        now: 0,
-      }),
-    ).toBe(true);
-  });
-
-  it("blocks while the cooldown has not elapsed", () => {
-    expect(
-      mayAttemptRecovery({
-        ...base,
-        record: { marker: "session:s1", attempts: 1, nextAttemptAt: 5_000 },
-        now: 4_999,
-      }),
-    ).toBe(false);
-  });
-
-  it("allows the attempt once the cooldown elapses", () => {
-    expect(
-      mayAttemptRecovery({
-        ...base,
-        record: { marker: "session:s1", attempts: 1, nextAttemptAt: 5_000 },
-        now: 5_000,
-      }),
-    ).toBe(true);
-  });
-
-  it("blocks once the attempt budget is spent", () => {
-    expect(
-      mayAttemptRecovery({
-        ...base,
-        record: { marker: "session:s1", attempts: 3, nextAttemptAt: 0 },
-        now: Number.MAX_SAFE_INTEGER,
-      }),
-    ).toBe(false);
+    expect(harness.requests[0]?.path).toContain(`perPage=${testCase.perPage}`);
   });
 });
 
@@ -193,8 +138,8 @@ describe("createMattermostThreadBackfill", () => {
 
     await harness.turn();
 
-    expect(harness.requests[0]?.path).toContain(`perPage=${MATTERMOST_THREAD_PER_PAGE_MAX}`);
-    expect(harness.requests[0]?.timeoutMs).toBe(5_000);
+    expect(harness.requests[0]?.path).toContain(`perPage=${PER_PAGE_MAX}`);
+    expect(harness.requests[0]?.timeoutMs).toBe(INBOUND_TIMEOUT_MS);
   });
 
   it("labels attachment-only posts instead of dropping them", async () => {
@@ -248,7 +193,7 @@ describe("createMattermostThreadBackfill", () => {
     expect(harness.requests).toHaveLength(1);
     expect(harness.channelHistories.has(HISTORY_KEY)).toBe(false);
 
-    harness.advance(THREAD_BACKFILL_COOLDOWN_MS);
+    harness.advance(COOLDOWN_MS);
     await harness.turn();
 
     expect(harness.requests).toHaveLength(2);
@@ -261,7 +206,7 @@ describe("createMattermostThreadBackfill", () => {
     });
 
     await harness.turn();
-    harness.advance(THREAD_BACKFILL_COOLDOWN_MS - 1);
+    harness.advance(COOLDOWN_MS - 1);
     await harness.turn();
 
     expect(harness.requests).toHaveLength(1);
@@ -272,13 +217,13 @@ describe("createMattermostThreadBackfill", () => {
       responses: [mattermostApiError(429, "Too Many Requests"), threadResponse(2)],
     });
     await rateLimited.turn();
-    rateLimited.advance(THREAD_BACKFILL_COOLDOWN_MS);
+    rateLimited.advance(COOLDOWN_MS);
     await rateLimited.turn();
     expect(rateLimited.requests).toHaveLength(2);
 
     const timedOut = createHarness({ responses: [abortError(), threadResponse(2)] });
     await timedOut.turn();
-    timedOut.advance(THREAD_BACKFILL_COOLDOWN_MS);
+    timedOut.advance(COOLDOWN_MS);
     await timedOut.turn();
     expect(timedOut.requests).toHaveLength(2);
   });
@@ -290,10 +235,10 @@ describe("createMattermostThreadBackfill", () => {
 
     for (let index = 0; index < 8; index += 1) {
       await harness.turn();
-      harness.advance(THREAD_BACKFILL_COOLDOWN_MS);
+      harness.advance(COOLDOWN_MS);
     }
 
-    expect(harness.requests).toHaveLength(THREAD_BACKFILL_MAX_ATTEMPTS);
+    expect(harness.requests).toHaveLength(MAX_ATTEMPTS);
   });
 
   it("never retries a permanent failure", async () => {
@@ -303,7 +248,7 @@ describe("createMattermostThreadBackfill", () => {
 
     for (let index = 0; index < 4; index += 1) {
       await harness.turn();
-      harness.advance(THREAD_BACKFILL_COOLDOWN_MS);
+      harness.advance(COOLDOWN_MS);
     }
 
     expect(harness.requests).toHaveLength(1);
@@ -318,7 +263,7 @@ describe("createMattermostThreadBackfill", () => {
     // The kernel records the message that just arrived, so the window is no
     // longer empty even though the thread is still missing its history.
     harness.channelHistories.set(HISTORY_KEY, [{ sender: "u9", body: "the message just handled" }]);
-    harness.advance(THREAD_BACKFILL_COOLDOWN_MS);
+    harness.advance(COOLDOWN_MS);
     await harness.turn();
 
     expect(harness.requests).toHaveLength(2);
@@ -332,14 +277,14 @@ describe("createMattermostThreadBackfill", () => {
 
     for (let index = 0; index < 5; index += 1) {
       await harness.turn();
-      harness.advance(THREAD_BACKFILL_COOLDOWN_MS);
+      harness.advance(COOLDOWN_MS);
     }
-    expect(harness.requests).toHaveLength(THREAD_BACKFILL_MAX_ATTEMPTS);
+    expect(harness.requests).toHaveLength(MAX_ATTEMPTS);
 
     harness.rotateSession("session-b");
     await harness.turn();
 
-    expect(harness.requests).toHaveLength(THREAD_BACKFILL_MAX_ATTEMPTS + 1);
+    expect(harness.requests).toHaveLength(MAX_ATTEMPTS + 1);
   });
 
   it("adopts the real session id after a pending recovery settles", async () => {
@@ -402,9 +347,8 @@ describe("createMattermostThreadBackfill", () => {
   });
 
   it("evicts the oldest recovery state instead of growing without bound", async () => {
-    const client = {
-      request: vi.fn(async () => threadResponse(1)),
-    } as unknown as MattermostClient;
+    const request = vi.fn(async () => threadResponse(1));
+    const client = { request } as unknown as MattermostClient;
     const channelHistories = new Map<string, HistoryEntry[]>();
     const backfill = createMattermostThreadBackfill({
       client,
@@ -426,7 +370,7 @@ describe("createMattermostThreadBackfill", () => {
     // Every key is cold, so an unbounded map would hold 20 markers; the cap
     // keeps only the most recent ones, and the evicted keys simply recover
     // again if they are ever seen once more.
-    expect(client.request).toHaveBeenCalledTimes(20);
+    expect(request).toHaveBeenCalledTimes(20);
     for (let index = 0; index < 20; index += 1) {
       await backfill.ensureThreadHistory({
         historyKey: `key-${index}`,
@@ -435,7 +379,7 @@ describe("createMattermostThreadBackfill", () => {
         agentId: AGENT_ID,
       });
     }
-    expect(client.request.mock.calls.length).toBeLessThan(40);
+    expect(request.mock.calls.length).toBeLessThan(40);
   });
 
   it("does nothing when history is disabled", async () => {

--- a/extensions/mattermost/src/mattermost/monitor-thread-backfill.ts
+++ b/extensions/mattermost/src/mattermost/monitor-thread-backfill.ts
@@ -261,6 +261,17 @@ export function createMattermostThreadBackfill(
     const marker = resolveRecoveryMarker({ historyKey, sessionId });
     const currentMarker = markers.get(historyKey);
 
+    // A failure recorded before the session entry had an id belongs to the same
+    // thread and the same streak, so the marker rotating from pending to the
+    // real session id must not hand it a fresh budget. Adopting the record keeps
+    // the cooldown and the attempt cap continuous across that one transition,
+    // and keeps `retryOwned` below true so the failed turn's own message cannot
+    // pass as history worth keeping.
+    const pendingRetry = retries.get(historyKey);
+    if (sessionId && pendingRetry?.marker === pendingMarker) {
+      boundedSet(retries, historyKey, { ...pendingRetry, marker });
+    }
+
     if (currentMarker === marker) {
       await settleInFlight(historyKey);
       return;

--- a/extensions/mattermost/src/mattermost/monitor-thread-backfill.ts
+++ b/extensions/mattermost/src/mattermost/monitor-thread-backfill.ts
@@ -214,26 +214,33 @@ export function createMattermostThreadBackfill(
     // server would otherwise expose it after every restart.
     //
     // Authorization is resolved through the caller, which owns the effective
-    // policy, so it can be async. Memoizing per sender keeps a thread full of
-    // one person's posts to a single resolution, and the filter has to run
-    // before the window is sliced so the newest retained posts are the ones
-    // that survive.
+    // policy, so it can be async — and under dangerous name matching it can
+    // reach the Mattermost user API, whose timeout is the client's 30s rather
+    // than the 5s bound on the fetch above. Every distinct sender is therefore
+    // started before anything is awaited: one resolution per sender no matter
+    // how many posts they hold, and a slow directory costs the inbound turn one
+    // lookup rather than one per sender in series.
     const retentionBySender = new Map<string, Promise<boolean>>();
-    const retained: MattermostPost[] = [];
     for (const post of candidates) {
       const senderId = post.user_id ?? "";
-      let retention = retentionBySender.get(senderId);
-      if (!retention) {
-        retention = Promise.resolve(
-          shouldRetainSenderHistory({
-            senderId,
-            channelId: params.channelId,
-            kind: params.kind,
-          }),
+      if (!retentionBySender.has(senderId)) {
+        retentionBySender.set(
+          senderId,
+          Promise.resolve(
+            shouldRetainSenderHistory({
+              senderId,
+              channelId: params.channelId,
+              kind: params.kind,
+            }),
+          ),
         );
-        retentionBySender.set(senderId, retention);
       }
-      if (await retention) {
+    }
+    // The filter has to run before the window is sliced, so the newest retained
+    // posts are the ones that survive.
+    const retained: MattermostPost[] = [];
+    for (const post of candidates) {
+      if (await retentionBySender.get(post.user_id ?? "")) {
         retained.push(post);
       }
     }

--- a/extensions/mattermost/src/mattermost/monitor-thread-backfill.ts
+++ b/extensions/mattermost/src/mattermost/monitor-thread-backfill.ts
@@ -33,7 +33,7 @@
 // per inbound message.
 import { getSessionEntry, resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
 import { isRetryableError, type MattermostClient, type MattermostPost } from "./client.js";
-import { createChannelHistoryWindow, type HistoryEntry } from "./runtime-api.js";
+import { type ChatType, createChannelHistoryWindow, type HistoryEntry } from "./runtime-api.js";
 
 /** Mattermost rejects `perPage` above this; the API contract documents 200. */
 const MATTERMOST_THREAD_PER_PAGE_MAX = 200;
@@ -56,6 +56,16 @@ type RetryRecord = {
   nextAttemptAt: number;
 };
 
+/**
+ * The conversation a recovery belongs to. Sender authorization is per
+ * conversation, so the retention decision cannot be resolved once when the
+ * handler is built.
+ */
+type ThreadBackfillConversation = {
+  channelId: string;
+  kind: ChatType;
+};
+
 type MattermostThreadBackfillDeps = {
   client: MattermostClient;
   channelHistories: Map<string, HistoryEntry[]>;
@@ -64,11 +74,14 @@ type MattermostThreadBackfillDeps = {
   resolveSessionId: (params: { historyKey: string; agentId: string }) => string | undefined;
   /**
    * Whether a recovered post from this sender may be kept as history. The
-   * decision belongs to the inbound path, which owns the allowlist and the
-   * context-visibility mode; this module only applies it. Defaults to keeping
-   * everything so callers that have no allowlist stay unchanged.
+   * decision belongs to the inbound path, which owns the effective ingress
+   * policy and the context-visibility mode; this module only applies it, once
+   * per distinct sender in a recovery. Defaults to keeping everything so
+   * callers with no allowlist stay unchanged.
    */
-  shouldRetainSenderHistory?: (senderId: string) => boolean;
+  shouldRetainSenderHistory?: (
+    params: { senderId: string } & ThreadBackfillConversation,
+  ) => boolean | Promise<boolean>;
   logVerboseMessage?: (message: string) => void;
   now?: () => number;
   timeoutMs?: number;
@@ -84,7 +97,7 @@ type EnsureThreadHistoryParams = {
   currentPostId: string;
   /** Routed agent for this turn; the session store is partitioned by agent. */
   agentId: string;
-};
+} & ThreadBackfillConversation;
 
 type MattermostThreadBackfill = {
   ensureThreadHistory: (params: EnsureThreadHistoryParams) => Promise<void>;
@@ -172,10 +185,12 @@ export function createMattermostThreadBackfill(
     }
   };
 
-  const fetchThreadEntries = async (params: {
-    threadRootId: string;
-    currentPostId: string;
-  }): Promise<HistoryEntry[]> => {
+  const fetchThreadEntries = async (
+    params: {
+      threadRootId: string;
+      currentPostId: string;
+    } & ThreadBackfillConversation,
+  ): Promise<HistoryEntry[]> => {
     const perPage = resolveThreadFetchLimit(historyLimit);
     // The shared client owns request deadlines, so the inbound bound is
     // expressed as its `timeoutMs` rather than a second abort controller here.
@@ -189,24 +204,47 @@ export function createMattermostThreadBackfill(
     });
     const order = Array.isArray(thread?.order) ? thread.order : [];
     const posts = thread?.posts && typeof thread.posts === "object" ? thread.posts : {};
-    return order
+    const candidates = order
       .map((id) => posts[id])
-      .filter((post): post is MattermostPost => Boolean(post) && post?.id !== params.currentPostId)
-      // The server returns the whole thread, including senders the inbound path
-      // would have dropped without recording. Recovery must not become a way
-      // around that boundary: under a trigger allowlist their text is only
-      // history when context visibility opts in, and reading it back from the
-      // server would otherwise expose it after every restart.
-      .filter((post) => shouldRetainSenderHistory(post.user_id ?? ""))
-      .slice(-historyLimit)
-      .map((post) => ({
-        sender: post.user_id || "unknown",
-        // Attachment-only posts carry no message text; a placeholder keeps the
-        // turn ordering intact instead of silently dropping the post.
-        body: post.message || "[attachment]",
-        timestamp: typeof post.create_at === "number" ? post.create_at : undefined,
-        messageId: post.id,
-      }));
+      .filter((post): post is MattermostPost => Boolean(post) && post?.id !== params.currentPostId);
+    // The server returns the whole thread, including senders the inbound path
+    // would have dropped without recording. Recovery must not become a way
+    // around that boundary: under a trigger allowlist their text is only
+    // history when context visibility opts in, and reading it back from the
+    // server would otherwise expose it after every restart.
+    //
+    // Authorization is resolved through the caller, which owns the effective
+    // policy, so it can be async. Memoizing per sender keeps a thread full of
+    // one person's posts to a single resolution, and the filter has to run
+    // before the window is sliced so the newest retained posts are the ones
+    // that survive.
+    const retentionBySender = new Map<string, Promise<boolean>>();
+    const retained: MattermostPost[] = [];
+    for (const post of candidates) {
+      const senderId = post.user_id ?? "";
+      let retention = retentionBySender.get(senderId);
+      if (!retention) {
+        retention = Promise.resolve(
+          shouldRetainSenderHistory({
+            senderId,
+            channelId: params.channelId,
+            kind: params.kind,
+          }),
+        );
+        retentionBySender.set(senderId, retention);
+      }
+      if (await retention) {
+        retained.push(post);
+      }
+    }
+    return retained.slice(-historyLimit).map((post) => ({
+      sender: post.user_id || "unknown",
+      // Attachment-only posts carry no message text; a placeholder keeps the
+      // turn ordering intact instead of silently dropping the post.
+      body: post.message || "[attachment]",
+      timestamp: typeof post.create_at === "number" ? post.create_at : undefined,
+      messageId: post.id,
+    }));
   };
 
   const recordFailure = (params: { historyKey: string; marker: string; error: unknown }): void => {
@@ -239,12 +277,14 @@ export function createMattermostThreadBackfill(
     );
   };
 
-  const runRecovery = async (params: {
-    historyKey: string;
-    marker: string;
-    threadRootId: string;
-    currentPostId: string;
-  }): Promise<void> => {
+  const runRecovery = async (
+    params: {
+      historyKey: string;
+      marker: string;
+      threadRootId: string;
+      currentPostId: string;
+    } & ThreadBackfillConversation,
+  ): Promise<void> => {
     try {
       const entries = await fetchThreadEntries(params);
       if (markers.get(params.historyKey) !== params.marker) {
@@ -329,6 +369,15 @@ export function createMattermostThreadBackfill(
       await settleInFlight(historyKey);
       if (markers.get(historyKey) === pendingMarker) {
         boundedSet(markers, historyKey, marker);
+        // That recovery recorded its window under the pending marker, so
+        // ownership has to move with the marker. Leaving it behind makes the
+        // eviction branch above read `seeded !== marker` forever: once the
+        // shared window drops this key, recovery is suppressed for the rest of
+        // the session and the thread reaches the agent contextless — the exact
+        // failure the marker rotation exists to avoid.
+        if (seeded.get(historyKey) === pendingMarker) {
+          boundedSet(seeded, historyKey, marker);
+        }
       }
       return;
     }
@@ -363,6 +412,8 @@ export function createMattermostThreadBackfill(
       marker,
       threadRootId: params.threadRootId,
       currentPostId: params.currentPostId,
+      channelId: params.channelId,
+      kind: params.kind,
     });
     inFlight.set(historyKey, recovery);
     try {

--- a/extensions/mattermost/src/mattermost/monitor-thread-backfill.ts
+++ b/extensions/mattermost/src/mattermost/monitor-thread-backfill.ts
@@ -36,19 +36,19 @@ import { isRetryableError, type MattermostClient, type MattermostPost } from "./
 import type { HistoryEntry } from "./runtime-api.js";
 
 /** Mattermost rejects `perPage` above this; the API contract documents 200. */
-export const MATTERMOST_THREAD_PER_PAGE_MAX = 200;
+const MATTERMOST_THREAD_PER_PAGE_MAX = 200;
 /**
  * Upper bound on how long a cold turn may wait for the server. Deliberately far
  * below the client's 30s default: this request sits on the inbound path, so a
  * slow server must cost the reply seconds, not half a minute.
  */
-export const THREAD_BACKFILL_TIMEOUT_MS = 5_000;
+const THREAD_BACKFILL_TIMEOUT_MS = 5_000;
 /** Total fetches allowed per marker before recovery gives up. */
-export const THREAD_BACKFILL_MAX_ATTEMPTS = 3;
+const THREAD_BACKFILL_MAX_ATTEMPTS = 3;
 /** Minimum spacing between attempts for the same marker. */
-export const THREAD_BACKFILL_COOLDOWN_MS = 60_000;
+const THREAD_BACKFILL_COOLDOWN_MS = 60_000;
 /** Insertion-ordered eviction bound for both recovery maps. */
-export const THREAD_BACKFILL_MARKER_CAP = 1_000;
+const THREAD_BACKFILL_MARKER_CAP = 1_000;
 
 type RetryRecord = {
   marker: string;
@@ -56,7 +56,7 @@ type RetryRecord = {
   nextAttemptAt: number;
 };
 
-export type MattermostThreadBackfillDeps = {
+type MattermostThreadBackfillDeps = {
   client: MattermostClient;
   channelHistories: Map<string, HistoryEntry[]>;
   historyLimit: number;
@@ -70,7 +70,7 @@ export type MattermostThreadBackfillDeps = {
   markerCap?: number;
 };
 
-export type EnsureThreadHistoryParams = {
+type EnsureThreadHistoryParams = {
   historyKey: string;
   threadRootId: string;
   /** The post being handled; it is already in the turn and must not be replayed. */
@@ -79,7 +79,7 @@ export type EnsureThreadHistoryParams = {
   agentId: string;
 };
 
-export type MattermostThreadBackfill = {
+type MattermostThreadBackfill = {
   ensureThreadHistory: (params: EnsureThreadHistoryParams) => Promise<void>;
 };
 
@@ -89,13 +89,13 @@ export type MattermostThreadBackfill = {
  * One extra post is requested because the post being handled is filtered out of
  * the response, so a full window still yields `historyLimit` entries.
  */
-export function resolveThreadFetchLimit(historyLimit: number): number {
-  const requested = Math.max(Number(historyLimit) + 1, 1);
+function resolveThreadFetchLimit(historyLimit: number): number {
+  const requested = Math.max(historyLimit + 1, 1);
   return Math.min(requested, MATTERMOST_THREAD_PER_PAGE_MAX);
 }
 
 /** A session id means the store settled; until then recovery is tracked as pending. */
-export function resolveRecoveryMarker(params: {
+function resolveRecoveryMarker(params: {
   historyKey: string;
   sessionId: string | undefined;
 }): string {
@@ -106,7 +106,7 @@ export function resolveRecoveryMarker(params: {
  * A recorded failure blocks the next attempt only while it belongs to the
  * current marker, the budget is unspent, and the cooldown has not elapsed.
  */
-export function mayAttemptRecovery(params: {
+function mayAttemptRecovery(params: {
   record: RetryRecord | undefined;
   marker: string;
   now: number;

--- a/extensions/mattermost/src/mattermost/monitor-thread-backfill.ts
+++ b/extensions/mattermost/src/mattermost/monitor-thread-backfill.ts
@@ -1,0 +1,341 @@
+// Mattermost thread-history recovery for cold inbound turns (issue #93204).
+//
+// The monitor keeps thread history in a process-local map. After a gateway
+// restart or a session clear that map is empty, so a thread the user has been
+// talking in for days arrives at the agent with no context at all and nothing
+// ever asks the server for it. This module fills that window once per stored
+// session, from the authoritative Mattermost thread.
+//
+// Everything here is about keeping a network call on the inbound path safe:
+//
+// - one recovery per historyKey + session id, so an active thread never pays
+//   for the fetch twice;
+// - a `pending:` marker while the session entry has no session id yet, adopted
+//   into the real id once it exists, so a first cold turn is not counted twice;
+// - a shared in-flight promise per historyKey, so concurrent cold turns make
+//   one request between them;
+// - `perPage` clamped to Mattermost's documented 200-item maximum;
+// - an AbortController timeout, so a slow server cannot hold the turn open;
+// - insertion-ordered eviction on both maps, so a long-lived process cannot
+//   accumulate unbounded recovery state;
+// - completion is discarded when the marker rotated mid-flight, so a stale
+//   response cannot overwrite a newer session's window;
+// - bounded retry for transient failures (see below).
+//
+// Retry policy. Marking the session attempted before the request means a single
+// timeout suppresses recovery for the whole stored session, leaving the thread
+// contextless until the session id rotates. Instead, a failure the shared
+// Mattermost client classifies as retryable releases the marker and schedules
+// another attempt; anything else (a revoked token, a deleted thread) keeps the
+// marker so a hopeless request is never repeated. The budget is what makes this
+// safe: an unreachable server costs at most THREAD_BACKFILL_MAX_ATTEMPTS
+// requests per thread per session, spaced by the cooldown — never one request
+// per inbound message.
+import { getSessionEntry, resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
+import { isRetryableError, type MattermostClient, type MattermostPost } from "./client.js";
+import type { HistoryEntry } from "./runtime-api.js";
+
+/** Mattermost rejects `perPage` above this; the API contract documents 200. */
+export const MATTERMOST_THREAD_PER_PAGE_MAX = 200;
+/**
+ * Upper bound on how long a cold turn may wait for the server. Deliberately far
+ * below the client's 30s default: this request sits on the inbound path, so a
+ * slow server must cost the reply seconds, not half a minute.
+ */
+export const THREAD_BACKFILL_TIMEOUT_MS = 5_000;
+/** Total fetches allowed per marker before recovery gives up. */
+export const THREAD_BACKFILL_MAX_ATTEMPTS = 3;
+/** Minimum spacing between attempts for the same marker. */
+export const THREAD_BACKFILL_COOLDOWN_MS = 60_000;
+/** Insertion-ordered eviction bound for both recovery maps. */
+export const THREAD_BACKFILL_MARKER_CAP = 1_000;
+
+type RetryRecord = {
+  marker: string;
+  attempts: number;
+  nextAttemptAt: number;
+};
+
+export type MattermostThreadBackfillDeps = {
+  client: MattermostClient;
+  channelHistories: Map<string, HistoryEntry[]>;
+  historyLimit: number;
+  /** Resolves the stored session id backing a history key, if the store has one. */
+  resolveSessionId: (params: { historyKey: string; agentId: string }) => string | undefined;
+  logVerboseMessage?: (message: string) => void;
+  now?: () => number;
+  timeoutMs?: number;
+  maxAttempts?: number;
+  cooldownMs?: number;
+  markerCap?: number;
+};
+
+export type EnsureThreadHistoryParams = {
+  historyKey: string;
+  threadRootId: string;
+  /** The post being handled; it is already in the turn and must not be replayed. */
+  currentPostId: string;
+  /** Routed agent for this turn; the session store is partitioned by agent. */
+  agentId: string;
+};
+
+export type MattermostThreadBackfill = {
+  ensureThreadHistory: (params: EnsureThreadHistoryParams) => Promise<void>;
+};
+
+/**
+ * Clamps the requested page size to the Mattermost maximum.
+ *
+ * One extra post is requested because the post being handled is filtered out of
+ * the response, so a full window still yields `historyLimit` entries.
+ */
+export function resolveThreadFetchLimit(historyLimit: number): number {
+  const requested = Math.max(Number(historyLimit) + 1, 1);
+  return Math.min(requested, MATTERMOST_THREAD_PER_PAGE_MAX);
+}
+
+/** A session id means the store settled; until then recovery is tracked as pending. */
+export function resolveRecoveryMarker(params: {
+  historyKey: string;
+  sessionId: string | undefined;
+}): string {
+  return params.sessionId ? `session:${params.sessionId}` : `pending:${params.historyKey}`;
+}
+
+/**
+ * A recorded failure blocks the next attempt only while it belongs to the
+ * current marker, the budget is unspent, and the cooldown has not elapsed.
+ */
+export function mayAttemptRecovery(params: {
+  record: RetryRecord | undefined;
+  marker: string;
+  now: number;
+  maxAttempts: number;
+}): boolean {
+  const { record, marker, now, maxAttempts } = params;
+  if (!record || record.marker !== marker) {
+    return true;
+  }
+  return record.attempts < maxAttempts && now >= record.nextAttemptAt;
+}
+
+export function createMattermostThreadBackfill(
+  deps: MattermostThreadBackfillDeps,
+): MattermostThreadBackfill {
+  const {
+    client,
+    channelHistories,
+    historyLimit,
+    resolveSessionId,
+    logVerboseMessage,
+    now = () => Date.now(),
+    timeoutMs = THREAD_BACKFILL_TIMEOUT_MS,
+    maxAttempts = THREAD_BACKFILL_MAX_ATTEMPTS,
+    cooldownMs = THREAD_BACKFILL_COOLDOWN_MS,
+    markerCap = THREAD_BACKFILL_MARKER_CAP,
+  } = deps;
+
+  const markers = new Map<string, string>();
+  const inFlight = new Map<string, Promise<void>>();
+  const retries = new Map<string, RetryRecord>();
+
+  // Re-inserting before eviction keeps the map in least-recently-touched order,
+  // so an active thread is never the entry that gets dropped.
+  const boundedSet = <T>(map: Map<string, T>, key: string, value: T): void => {
+    map.delete(key);
+    map.set(key, value);
+    while (map.size > markerCap) {
+      const oldest = map.keys().next().value;
+      if (oldest === undefined) {
+        break;
+      }
+      map.delete(oldest);
+    }
+  };
+
+  const settleInFlight = async (historyKey: string): Promise<void> => {
+    const pending = inFlight.get(historyKey);
+    if (pending) {
+      await pending.catch(() => {});
+    }
+  };
+
+  const fetchThreadEntries = async (params: {
+    threadRootId: string;
+    currentPostId: string;
+  }): Promise<HistoryEntry[]> => {
+    const perPage = resolveThreadFetchLimit(historyLimit);
+    // The shared client owns request deadlines, so the inbound bound is
+    // expressed as its `timeoutMs` rather than a second abort controller here.
+    // Its abort surfaces as an AbortError, which isRetryableError already
+    // classifies as retryable.
+    const thread = await client.request<{
+      order?: string[];
+      posts?: Record<string, MattermostPost>;
+    }>(`/posts/${encodeURIComponent(params.threadRootId)}/thread?perPage=${perPage}&direction=up`, {
+      timeoutMs,
+    });
+    const order = Array.isArray(thread?.order) ? thread.order : [];
+    const posts = thread?.posts && typeof thread.posts === "object" ? thread.posts : {};
+    return order
+      .map((id) => posts[id])
+      .filter((post): post is MattermostPost => Boolean(post) && post?.id !== params.currentPostId)
+      .slice(-historyLimit)
+      .map((post) => ({
+        sender: post.user_id || "unknown",
+        // Attachment-only posts carry no message text; a placeholder keeps the
+        // turn ordering intact instead of silently dropping the post.
+        body: post.message || "[attachment]",
+        timestamp: typeof post.create_at === "number" ? post.create_at : undefined,
+        messageId: post.id,
+      }));
+  };
+
+  const recordFailure = (params: { historyKey: string; marker: string; error: unknown }): void => {
+    // Only the owner of the current marker may rewrite recovery state; if a
+    // newer session rotated in while this fetch was running, both its marker and
+    // its own budget must be left alone.
+    if (markers.get(params.historyKey) !== params.marker) {
+      logVerboseMessage?.(
+        `mattermost: thread backfill failed for a rotated session historyKey=${params.historyKey}`,
+      );
+      return;
+    }
+    const prior = retries.get(params.historyKey);
+    const attempts = (prior?.marker === params.marker ? prior.attempts : 0) + 1;
+    const retryable =
+      params.error instanceof Error && isRetryableError(params.error) && attempts < maxAttempts;
+    boundedSet(retries, params.historyKey, {
+      marker: params.marker,
+      attempts,
+      nextAttemptAt: retryable ? now() + cooldownMs : 0,
+    });
+    if (retryable) {
+      // Release the marker so a later turn re-enters recovery. The record above
+      // is what still holds the cooldown and the remaining budget.
+      markers.delete(params.historyKey);
+    }
+    logVerboseMessage?.(
+      `mattermost: thread backfill ${retryable ? "retry scheduled" : "gave up"} ` +
+        `historyKey=${params.historyKey} attempt=${attempts}/${maxAttempts}`,
+    );
+  };
+
+  const runRecovery = async (params: {
+    historyKey: string;
+    marker: string;
+    threadRootId: string;
+    currentPostId: string;
+  }): Promise<void> => {
+    try {
+      const entries = await fetchThreadEntries(params);
+      if (markers.get(params.historyKey) !== params.marker) {
+        // A newer session rotated in mid-flight. Its window and its own retry
+        // budget both belong to it, so a stale completion touches neither.
+        logVerboseMessage?.(
+          `mattermost: thread backfill discarded a stale completion historyKey=${params.historyKey}`,
+        );
+        return;
+      }
+      // The request itself succeeded, so this marker is settled regardless of
+      // how many posts came back; drop any budget it had spent.
+      retries.delete(params.historyKey);
+      if (entries.length > 0) {
+        channelHistories.set(params.historyKey, entries);
+        logVerboseMessage?.(
+          `mattermost: thread backfill seeded ${entries.length} entries historyKey=${params.historyKey}`,
+        );
+      }
+    } catch (error) {
+      recordFailure({ historyKey: params.historyKey, marker: params.marker, error });
+    }
+  };
+
+  const ensureThreadHistory = async (params: EnsureThreadHistoryParams): Promise<void> => {
+    if (historyLimit <= 0 || !params.historyKey || !params.threadRootId) {
+      return;
+    }
+    const { agentId, historyKey } = params;
+    const sessionId = resolveSessionId({ historyKey, agentId });
+    const pendingMarker = resolveRecoveryMarker({ historyKey, sessionId: undefined });
+    const marker = resolveRecoveryMarker({ historyKey, sessionId });
+    const currentMarker = markers.get(historyKey);
+
+    if (currentMarker === marker) {
+      await settleInFlight(historyKey);
+      return;
+    }
+
+    if (sessionId && currentMarker === pendingMarker) {
+      // A first cold turn can run before the session entry receives its id. Let
+      // that recovery finish under the pending marker before adopting the real
+      // one; rotating first would make its completion look stale and throw away
+      // context that was correctly recovered.
+      await settleInFlight(historyKey);
+      if (markers.get(historyKey) === pendingMarker) {
+        boundedSet(markers, historyKey, marker);
+      }
+      return;
+    }
+
+    // A retryable failure releases the marker, so reaching here does not prove
+    // the thread was never serviced. The retry record is what separates a cold
+    // thread from one between attempts, and it has to be read before the
+    // first-sighting shortcut below: the failed turn's own message rebuilds the
+    // in-memory window, which would otherwise look like history worth keeping
+    // and would cancel the remaining attempts.
+    const retryRecord = retries.get(historyKey);
+    const retryOwned = retryRecord?.marker === marker;
+    if (!mayAttemptRecovery({ record: retryRecord, marker, now: now(), maxAttempts })) {
+      // Cooling down or out of budget: do not fetch, and do not mark serviced,
+      // so a later turn past the cooldown can still recover the thread.
+      await settleInFlight(historyKey);
+      return;
+    }
+
+    const existingHistory = channelHistories.get(historyKey) ?? [];
+    if (existingHistory.length > 0 && currentMarker === undefined && !retryOwned) {
+      // First sighting already has in-memory history, so the thread is warm.
+      // Mark it serviced now: the window the kernel clears after this turn must
+      // not make the next turn look cold.
+      boundedSet(markers, historyKey, marker);
+      return;
+    }
+
+    boundedSet(markers, historyKey, marker);
+    const recovery = runRecovery({
+      historyKey,
+      marker,
+      threadRootId: params.threadRootId,
+      currentPostId: params.currentPostId,
+    });
+    inFlight.set(historyKey, recovery);
+    try {
+      await recovery;
+    } finally {
+      if (inFlight.get(historyKey) === recovery) {
+        inFlight.delete(historyKey);
+      }
+    }
+  };
+
+  return { ensureThreadHistory };
+}
+
+/**
+ * Reads the session id backing a history key, or `undefined` when the store has
+ * no entry yet. Store access is best-effort: recovery must not break an inbound
+ * turn because the session file is missing or unreadable.
+ */
+export function createSessionIdResolver(
+  configuredStorePath: string | undefined,
+): (params: { historyKey: string; agentId: string }) => string | undefined {
+  return ({ historyKey, agentId }) => {
+    try {
+      const storePath = resolveStorePath(configuredStorePath, { agentId });
+      return getSessionEntry({ storePath, sessionKey: historyKey, agentId })?.sessionId;
+    } catch {
+      return undefined;
+    }
+  };
+}

--- a/extensions/mattermost/src/mattermost/monitor-thread-backfill.ts
+++ b/extensions/mattermost/src/mattermost/monitor-thread-backfill.ts
@@ -62,6 +62,13 @@ type MattermostThreadBackfillDeps = {
   historyLimit: number;
   /** Resolves the stored session id backing a history key, if the store has one. */
   resolveSessionId: (params: { historyKey: string; agentId: string }) => string | undefined;
+  /**
+   * Whether a recovered post from this sender may be kept as history. The
+   * decision belongs to the inbound path, which owns the allowlist and the
+   * context-visibility mode; this module only applies it. Defaults to keeping
+   * everything so callers that have no allowlist stay unchanged.
+   */
+  shouldRetainSenderHistory?: (senderId: string) => boolean;
   logVerboseMessage?: (message: string) => void;
   now?: () => number;
   timeoutMs?: number;
@@ -127,6 +134,7 @@ export function createMattermostThreadBackfill(
     channelHistories,
     historyLimit,
     resolveSessionId,
+    shouldRetainSenderHistory = () => true,
     logVerboseMessage,
     now = () => Date.now(),
     timeoutMs = THREAD_BACKFILL_TIMEOUT_MS,
@@ -184,6 +192,12 @@ export function createMattermostThreadBackfill(
     return order
       .map((id) => posts[id])
       .filter((post): post is MattermostPost => Boolean(post) && post?.id !== params.currentPostId)
+      // The server returns the whole thread, including senders the inbound path
+      // would have dropped without recording. Recovery must not become a way
+      // around that boundary: under a trigger allowlist their text is only
+      // history when context visibility opts in, and reading it back from the
+      // server would otherwise expose it after every restart.
+      .filter((post) => shouldRetainSenderHistory(post.user_id ?? ""))
       .slice(-historyLimit)
       .map((post) => ({
         sender: post.user_id || "unknown",

--- a/extensions/mattermost/src/mattermost/monitor-thread-backfill.ts
+++ b/extensions/mattermost/src/mattermost/monitor-thread-backfill.ts
@@ -33,7 +33,7 @@
 // per inbound message.
 import { getSessionEntry, resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
 import { isRetryableError, type MattermostClient, type MattermostPost } from "./client.js";
-import type { HistoryEntry } from "./runtime-api.js";
+import { createChannelHistoryWindow, type HistoryEntry } from "./runtime-api.js";
 
 /** Mattermost rejects `perPage` above this; the API contract documents 200. */
 const MATTERMOST_THREAD_PER_PAGE_MAX = 200;
@@ -138,6 +138,10 @@ export function createMattermostThreadBackfill(
   const markers = new Map<string, string>();
   const inFlight = new Map<string, Promise<void>>();
   const retries = new Map<string, RetryRecord>();
+  // Markers whose recovery actually wrote a window, so an absent history key can
+  // be read as eviction rather than as "this thread never had anything to seed".
+  const seeded = new Map<string, string>();
+  const historyWindow = createChannelHistoryWindow({ historyMap: channelHistories });
 
   // Re-inserting before eviction keeps the map in least-recently-touched order,
   // so an active thread is never the entry that gets dropped.
@@ -241,7 +245,15 @@ export function createMattermostThreadBackfill(
       // how many posts came back; drop any budget it had spent.
       retries.delete(params.historyKey);
       if (entries.length > 0) {
-        channelHistories.set(params.historyKey, entries);
+        // Seed through the shared window rather than writing the map directly:
+        // it owns the per-key limit, the LRU ordering that decides which thread
+        // is evicted next, and the 1000-key cap that keeps a long-lived gateway
+        // from retaining every thread it ever recovered.
+        historyWindow.clear({ historyKey: params.historyKey, limit: historyLimit });
+        for (const entry of entries) {
+          historyWindow.record({ historyKey: params.historyKey, entry, limit: historyLimit });
+        }
+        boundedSet(seeded, params.historyKey, params.marker);
         logVerboseMessage?.(
           `mattermost: thread backfill seeded ${entries.length} entries historyKey=${params.historyKey}`,
         );
@@ -274,7 +286,25 @@ export function createMattermostThreadBackfill(
 
     if (currentMarker === marker) {
       await settleInFlight(historyKey);
-      return;
+      // A marker only means "this session has been serviced", and the shared
+      // history owner can evict a recovered window under LRU pressure from
+      // unrelated threads. An emptied window keeps its key — the kernel clears
+      // it after every turn — so an absent key is the one signal that the window
+      // is gone rather than merely empty. Without this the marker would suppress
+      // recovery forever and the thread would reach the agent contextless.
+      //
+      // Only a marker that actually seeded a window may be invalidated this way.
+      // A marker held by a permanent failure, or by a fetch that legitimately
+      // returned nothing, has no window to lose, and re-reading an absent key as
+      // eviction would turn "gave up" back into "retry on every turn".
+      if (seeded.get(historyKey) !== marker || channelHistories.has(historyKey)) {
+        return;
+      }
+      markers.delete(historyKey);
+      seeded.delete(historyKey);
+      logVerboseMessage?.(
+        `mattermost: thread backfill window evicted, recovering again historyKey=${historyKey}`,
+      );
     }
 
     if (sessionId && currentMarker === pendingMarker) {

--- a/extensions/mattermost/src/mattermost/monitor.authz.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.authz.test.ts
@@ -7,7 +7,9 @@ import type { ResolvedMattermostAccount } from "./accounts.js";
 import {
   authorizeMattermostCommandInvocation,
   resolveMattermostMonitorInboundAccess,
+  shouldRetainMattermostRecoveredSenderHistory,
 } from "./monitor-auth.js";
+import type { OpenClawConfig } from "./runtime-api.js";
 
 const accountFixture: ResolvedMattermostAccount = {
   accountId: "default",
@@ -292,5 +294,99 @@ describe("mattermost monitor authz", () => {
 
     expect(access.ingress.decision).toBe("block");
     expect(access.ingress.reasonCode).toBe("event_pairing_not_allowed");
+  });
+});
+
+// Thread recovery (#93204) reads posts the live handler never saw, so its
+// retention decision has to be the effective ingress policy — not a re-derived
+// allowlist, which omits history from senders the real path authorizes.
+describe("mattermost recovered thread history visibility", () => {
+  const allowlistVisibility: OpenClawConfig = {
+    channels: { mattermost: { contextVisibility: "allowlist" } },
+  };
+
+  const retains = (params: {
+    cfg?: OpenClawConfig;
+    config: ResolvedMattermostAccount["config"];
+    senderId: string;
+    kind?: "direct" | "group" | "channel";
+    storeAllowFrom?: Array<string | number>;
+  }) =>
+    shouldRetainMattermostRecoveredSenderHistory({
+      account: { ...accountFixture, config: params.config },
+      cfg: params.cfg ?? allowlistVisibility,
+      senderId: params.senderId,
+      channelId: params.kind === "direct" ? "dm-1" : "chan-1",
+      kind: params.kind ?? "channel",
+      groupPolicy: "allowlist",
+      storeAllowFrom: params.storeAllowFrom ?? [],
+    });
+
+  it("keeps every recovered sender when visibility does not hide history", async () => {
+    // The permissive default asks nothing of the allowlist, so a thread is
+    // recovered whole.
+    await expect(
+      retains({ cfg: {}, config: { groupAllowFrom: ["@group-owner"] }, senderId: "stranger" }),
+    ).resolves.toBe(true);
+  });
+
+  it("falls an empty group allowlist back to allowFrom", async () => {
+    // The regression: an empty `groupAllowFrom` is absent, not a deny-all, so a
+    // sender the live path admits through `allowFrom` keeps their history.
+    await expect(
+      retains({
+        config: { allowFrom: ["@trusted-user"], groupAllowFrom: [] },
+        senderId: "trusted-user",
+      }),
+    ).resolves.toBe(true);
+  });
+
+  it("keeps history from senders authorized through an access group", async () => {
+    await expect(
+      retains({
+        cfg: {
+          ...allowlistVisibility,
+          accessGroups: {
+            oncall: {
+              type: "message.senders",
+              members: { mattermost: ["mattermost:trusted-user"] },
+            },
+          },
+        },
+        config: { groupAllowFrom: ["accessGroup:oncall"] },
+        senderId: "trusted-user",
+      }),
+    ).resolves.toBe(true);
+  });
+
+  it("keeps direct history from a sender admitted by the pairing store", async () => {
+    await expect(
+      retains({
+        config: { dmPolicy: "pairing" },
+        senderId: "paired-user",
+        kind: "direct",
+        storeAllowFrom: ["user:paired-user"],
+      }),
+    ).resolves.toBe(true);
+  });
+
+  it("drops history from a sender the effective policy does not authorize", async () => {
+    await expect(
+      retains({
+        config: { allowFrom: ["@trusted-user"], groupAllowFrom: [] },
+        senderId: "stranger",
+      }),
+    ).resolves.toBe(false);
+  });
+
+  it("does not admit a recovered direct sender through pairing", async () => {
+    // Appearing in a recovered thread must never count as pairing admission.
+    await expect(
+      retains({ config: { dmPolicy: "pairing" }, senderId: "new-user", kind: "direct" }),
+    ).resolves.toBe(false);
+  });
+
+  it("drops history when the sender id is missing", async () => {
+    await expect(retains({ config: { allowFrom: ["*"] }, senderId: "" })).resolves.toBe(false);
   });
 });

--- a/extensions/mattermost/src/mattermost/monitor.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.test.ts
@@ -602,13 +602,26 @@ describe("resolveMattermostThreadSessionContext", () => {
 });
 
 describe("resolveMattermostPendingHistoryKey", () => {
-  it("does not retain pending history buckets for thread-scoped direct messages", () => {
+  it("does not retain pending history buckets for top-level direct messages", () => {
+    expect(
+      resolveMattermostPendingHistoryKey({
+        kind: "direct",
+        sessionKey: "agent:main:mattermost:direct:user-1",
+        threadRootId: undefined,
+      }),
+    ).toBeNull();
+  });
+
+  it("keeps a pending history bucket for thread-scoped direct messages", () => {
+    // A DM thread owns its session with no parent inheritance, so this window is
+    // the only in-process record of the thread and has to be recoverable.
     expect(
       resolveMattermostPendingHistoryKey({
         kind: "direct",
         sessionKey: "agent:main:mattermost:direct:user-1:thread:post-123",
+        threadRootId: "post-123",
       }),
-    ).toBeNull();
+    ).toBe("agent:main:mattermost:direct:user-1:thread:post-123");
   });
 
   it("keeps pending room history scoped to the active session", () => {
@@ -616,8 +629,21 @@ describe("resolveMattermostPendingHistoryKey", () => {
       resolveMattermostPendingHistoryKey({
         kind: "channel",
         sessionKey: "agent:main:mattermost:channel:chan-1:thread:post-123",
+        threadRootId: "post-123",
       }),
     ).toBe("agent:main:mattermost:channel:chan-1:thread:post-123");
+  });
+
+  it("keeps pending room history for top-level room posts", () => {
+    // Rooms batch their pending window whether or not the turn is threaded; only
+    // the direct case turns on the thread root.
+    expect(
+      resolveMattermostPendingHistoryKey({
+        kind: "channel",
+        sessionKey: "agent:main:mattermost:channel:chan-1",
+        threadRootId: undefined,
+      }),
+    ).toBe("agent:main:mattermost:channel:chan-1");
   });
 });
 


### PR DESCRIPTION
Fixes #93204.

## What Problem This Solves

Mattermost keeps thread history in a process-local map. After a gateway restart
or a session clear that map is empty, and nothing asks the server for what it
lost — so a thread the user has been talking in for days reaches the agent with
no context, and the agent answers as if the conversation had just started.
Every sibling channel that supports threads recovers this from the server;
Mattermost is the only one that does not.

## What this does

Recovery runs once per stored session, immediately before the pending context is
composed, and rebuilds the window from the authoritative Mattermost thread.

The whole design is about making one network call safe on the inbound path:

- one recovery per `historyKey` + session id, so an active thread never pays for
  the fetch twice;
- a `pending:` marker while the session entry has no session id yet, adopted into
  the real id once it exists, so a first cold turn is not counted twice;
- a shared in-flight promise per `historyKey`, so concurrent cold turns make one
  request between them;
- `perPage` clamped to Mattermost's documented 200-item maximum rather than
  relying on silent server truncation;
- a 5s request deadline — expressed as the shared client's own `timeoutMs`, far
  below its 30s default, because this request sits on the inbound path;
- insertion-ordered eviction on both recovery maps, so a long-lived process
  cannot accumulate unbounded state;
- a completion whose marker rotated mid-flight is discarded, so a stale response
  cannot overwrite a newer session's window;
- bounded retry for transient failures.

## On the retry policy

Marking the session attempted *before* the request — which is what the earlier
attempts at this issue did — means a single timeout suppresses recovery for the
whole stored session, leaving the thread contextless until the session id
rotates. That was raised as a P1 on the previous candidate and never resolved.

Here, a failure the shared Mattermost client classifies as retryable releases the
marker and schedules another attempt; anything else (a revoked token, a deleted
thread) keeps the marker so a hopeless request is never repeated. Classification
reuses the existing `isRetryableError` in `client.ts` rather than a second
opinion. The budget is what makes this safe: an unreachable server costs at most
**3 requests per thread per session, spaced 60s apart** — never one request per
inbound message.

Retry state is now also carried across session materialization. A failure
recorded while the store had no session id is keyed to the `pending:` marker;
when `resolveSessionId` later returns a real id, that record is adopted into the
session marker instead of being ignored. Without this the marker rotation hands
the next turn a fresh cooldown and a fresh attempt budget, and — because the
retry record is what distinguishes a cold thread from one between attempts — the
failed turn's own message can pass as history worth keeping and cancel the
remaining attempts. Its regression test fails on the previous revision with
`expected length 1 but got 2`, one extra request inside the cooldown.

## Direct-message threads

`resolveMattermostPendingHistoryKey` returned `null` for **every** direct chat,
so the recovery call site — which requires a history key — could never be reached
for a DM thread.

That exclusion predates DM threading being configurable. #98111 made an opted-in
DM thread a first-class session with its own thread root and no parent-session
inheritance, but the same PR also extracted the pre-existing exclusion into a
named helper, documented it, and added a test asserting it **for the
thread-scoped case** — locking in an invariant that was only ever true while
every DM was flat.

This PR narrows the exclusion to top-level DMs and updates that test. A flat DM
still keeps no pending bucket: it dispatches immediately and does not need the
window. A thread-scoped DM does need it, because its window is the only
in-process record of that thread and the one thing a restart or a session clear
can rebuild it from.

## Relationship to earlier attempts

#93234, #93243, #93692 and #93865 all targeted this issue and all closed
unmerged; #93204 is still open. When #93243 was closed as superseded, the stated
gaps were bounded marker eviction, in-flight deduplication, stale-session
completion protection, and bounded server requests. All four are implemented
here, along with the `perPage` clamp that was the one outstanding code defect on
#93865, plus the retry policy that closes its unresolved P1.

## Evidence

A live before/after pair against a real Mattermost server, run at this branch's
head. Both rounds used **one host image, one config directory and one bot
account**; the only thing that changed between them was the installed
`@openclaw/mattermost` build:

| | round A | round B |
|---|---|---|
| plugin | `v2026.7.2-beta.7` | `v2026.7.2-beta.7` + this branch |
| host | `ghcr.io/openclaw/openclaw:2026.7.2-beta.7` | same |
| config | same directory | same directory |

Both builds came from `scripts/plugin-npm-publish.sh --pack` on the same tag, so
the delta is exactly this patch.

**Setup.** One opted-in DM thread (`replyToModeByChatType: { direct: "first" }`)
carrying a fact stated only inside that thread, then `/new` to clear the session,
then the same question in the same thread.

```
user  我去年到日本，今年到美國，明年要去法國
      "last year Japan, this year the US, next year France"
bot   一年一個國家：日本 → 美國 → 法國
```

**Round A — current behavior:**

```
15:32:23  user  /new
15:32:23  bot   ✅ New session started.
15:32:45  user  我明年要去哪？                 "where am I going next year?"
15:32:52  bot   我查了现有记忆和历史对话，没找到你提过明年的去向。
                "I checked memory and history; nothing about next year."
```

**Round B — this branch:**

```
16:08:50  user  /new
16:08:52  bot   ✅ New session started.
16:08:59  user  我明年要去哪？
16:09:08  bot   你明年（2027年）计划去法国。🇫🇷   "next year you plan to go to France"
```

with the matching gateway log line:

```
2026-08-12T08:08:50.635Z  mattermost: thread backfill seeded 12 entries
  historyKey=agent:main:mattermost:direct:<user>:thread:<thread>
```

`12 entries` matches the thread as it then stood, and the following turn answered
from that recovered window.

**Controls.** The agent memory subsystem was disabled for the comparison
(`memory-core` off, the `session-memory` internal hook off, previously written
memory files moved out of the workspace). Without that control the comparison is
meaningless: the `session-memory` hook writes a summary of the outgoing session
on `/new` and the next session reads it back, which produced a false pass in an
earlier round — the giveaway was `Source: memory/<file>.md` in the reply.

**Boundary.** This is a live before/after pair on one server and account, not a
production incident report. The host is the published `2026.7.2-beta.7` image
rather than current `main`, because no image is published for a newer
prerelease; the two plugin files this PR touches are unchanged between that tag
and current `main`.

## Addressed since the 2026-08-12 review

- **Recovered entries now go through the bounded history owner.** `channelHistories.set`
  bypassed the shared per-key limit, the LRU ordering that decides which thread is
  evicted next, and the 1,000-key cap. Seeding runs through
  `createChannelHistoryWindow(...)` instead, and a test fills the map to the cap
  before recovering one more thread to assert it does not grow past it.
- **A marker no longer outlives the window it vouches for.** The shared owner can
  evict a recovered window under pressure from unrelated threads; a matching marker
  previously returned before checking whether the key still existed, so a later
  mention skipped backfill and reached the agent with no thread context. An emptied
  window keeps its key — the kernel clears it after every turn — so an absent key is
  the signal that the window is gone, and the marker is invalidated so the next turn
  rebuilds it. Only markers that actually seeded a window qualify: a permanent
  failure has no window to lose, and reading its absent key as eviction would turn
  "gave up" back into "retry every turn". The eviction test covers the empty-window
  case, the evicted-key case, and the refetch.


### Test coverage

`monitor-thread-backfill.test.ts` covers the page-size clamp, marker derivation,
the retry gate, cold-thread seeding, current-post exclusion, attachment-only
posts, once-per-session behavior, the warm-window shortcut, concurrent-turn
deduplication, transient retry and its cooldown, 429 and timeout classification,
budget exhaustion, permanent-failure give-up, the rebuilt-window regression,
session rotation resetting the budget, pending marker adoption, retry-state
adoption across session materialization, and stale-completion discard.

`monitor.test.ts` covers the history-key resolver for all four cases: top-level
DM (no bucket), thread-scoped DM (bucket), thread-scoped room, and top-level
room.

