### PR TITLE
perf(agents): bound subagent spawn preparation concurrency

### DIFF
--- a/src/agents/subagent-spawn-contract.ts
+++ b/src/agents/subagent-spawn-contract.ts
@@ -60,6 +60,7 @@ export type SpawnSubagentContext = {
   inheritedToolAllowlist?: string[];
   inheritedToolDenylist?: string[];
   requesterRunId?: string;
+  abortSignal?: AbortSignal;
 };
 
 export type SpawnSubagentResult = {

--- a/src/agents/subagent-spawn.test.ts
+++ b/src/agents/subagent-spawn.test.ts
@@ -2,7 +2,11 @@
 // persistence, registry registration, and lifecycle event emission.
 import os from "node:os";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { setCommandLaneConcurrency } from "../process/command-queue.js";
+import { resetCommandQueueStateForTest } from "../process/command-queue.test-support.js";
+import { CommandLane } from "../process/lanes.js";
 import { resolveIncognitoOpenClawAgentSqlitePath } from "../state/openclaw-agent-db.paths.js";
+import { createDeferred } from "../test-utils/deferred.js";
 import {
   createSubagentSpawnTestConfig,
   expectPersistedRuntimeModel,
@@ -99,6 +103,8 @@ describe("spawnSubagentDirect seam flow", () => {
   });
 
   beforeEach(() => {
+    resetCommandQueueStateForTest();
+    setCommandLaneConcurrency(CommandLane.SubagentSpawn, 8);
     swarmSchedulerTesting.reset();
     resetSubagentRegistryForTests();
     hoisted.callGatewayMock.mockReset();
@@ -137,8 +143,144 @@ describe("spawnSubagentDirect seam flow", () => {
   });
 
   afterEach(() => {
+    resetCommandQueueStateForTest();
     swarmSchedulerTesting.reset();
     vi.unstubAllEnvs();
+  });
+
+  it("bounds concurrent non-collect spawn preparation", async () => {
+    setCommandLaneConcurrency(CommandLane.SubagentSpawn, 2);
+    const releaseLaunches = createDeferred();
+    let activeLaunches = 0;
+    let peakActiveLaunches = 0;
+    let launchCount = 0;
+    hoisted.callGatewayMock.mockImplementation(async (request: { method?: string }) => {
+      if (request.method !== "agent") {
+        return { ok: true };
+      }
+      const launchId = ++launchCount;
+      activeLaunches += 1;
+      peakActiveLaunches = Math.max(peakActiveLaunches, activeLaunches);
+      await releaseLaunches.promise;
+      activeLaunches -= 1;
+      return { runId: `run-${launchId}`, status: "accepted" };
+    });
+
+    const spawns = Array.from({ length: 5 }, (_, index) =>
+      spawnSubagentDirect(
+        { task: `bounded child ${index}` },
+        { agentSessionKey: "agent:main:main" },
+      ),
+    );
+    await vi.waitFor(() => expect(launchCount).toBe(2));
+
+    expect(peakActiveLaunches).toBe(2);
+    releaseLaunches.resolve();
+    const results = await Promise.all(spawns);
+    expect(results).toHaveLength(5);
+    expect(results.every((result) => result.status === "accepted")).toBe(true);
+    expect(launchCount).toBe(5);
+  });
+
+  it("releases preparation admission after an error", async () => {
+    setCommandLaneConcurrency(CommandLane.SubagentSpawn, 1);
+    let launchCount = 0;
+    hoisted.callGatewayMock.mockImplementation(async (request: { method?: string }) => {
+      if (request.method !== "agent") {
+        return { ok: true };
+      }
+      launchCount += 1;
+      if (launchCount === 1) {
+        throw new Error("dispatch failed");
+      }
+      return { runId: "run-after-error", status: "accepted" };
+    });
+
+    const [failed, accepted] = await Promise.all([
+      spawnSubagentDirect({ task: "failing child" }, { agentSessionKey: "agent:main:main" }),
+      spawnSubagentDirect({ task: "next child" }, { agentSessionKey: "agent:main:main" }),
+    ]);
+
+    expect(failed).toMatchObject({ status: "error", error: "dispatch failed" });
+    expect(accepted).toMatchObject({ status: "accepted", runId: "run-after-error" });
+    expect(launchCount).toBe(2);
+  });
+
+  it("removes an aborted queued preparation without leaking admission", async () => {
+    setCommandLaneConcurrency(CommandLane.SubagentSpawn, 1);
+    const releaseFirstLaunch = createDeferred();
+    let launchCount = 0;
+    hoisted.callGatewayMock.mockImplementation(async (request: { method?: string }) => {
+      if (request.method !== "agent") {
+        return { ok: true };
+      }
+      const launchId = ++launchCount;
+      if (launchId === 1) {
+        await releaseFirstLaunch.promise;
+      }
+      return { runId: `run-${launchId}`, status: "accepted" };
+    });
+
+    const first = spawnSubagentDirect(
+      { task: "first child" },
+      { agentSessionKey: "agent:main:main" },
+    );
+    await vi.waitFor(() => expect(launchCount).toBe(1));
+    const abortController = new AbortController();
+    const abortError = new Error("cancel queued spawn");
+    const aborted = spawnSubagentDirect(
+      { task: "cancelled child" },
+      { agentSessionKey: "agent:main:main", abortSignal: abortController.signal },
+    );
+    const next = spawnSubagentDirect(
+      { task: "next child" },
+      { agentSessionKey: "agent:main:main" },
+    );
+
+    abortController.abort(abortError);
+
+    await expect(aborted).rejects.toBe(abortError);
+    expect(launchCount).toBe(1);
+    releaseFirstLaunch.resolve();
+    await expect(Promise.all([first, next])).resolves.toEqual([
+      expect.objectContaining({ status: "accepted" }),
+      expect.objectContaining({ status: "accepted" }),
+    ]);
+    expect(launchCount).toBe(2);
+  });
+
+  it("leaves collect preparation on the swarm scheduler path", async () => {
+    setCommandLaneConcurrency(CommandLane.SubagentSpawn, 1);
+    hoisted.configOverride = createConfigOverride({
+      tools: { swarm: { enabled: true, maxConcurrent: 1 } },
+    });
+    const releaseFirstLaunch = createDeferred();
+    let launchCount = 0;
+    hoisted.callGatewayMock.mockImplementation(async (request: { method?: string }) => {
+      if (request.method !== "agent") {
+        return { ok: true };
+      }
+      const launchId = ++launchCount;
+      if (launchId === 1) {
+        await releaseFirstLaunch.promise;
+      }
+      return { runId: `run-${launchId}`, status: "accepted" };
+    });
+
+    const direct = spawnSubagentDirect(
+      { task: "blocked direct child" },
+      { agentSessionKey: "agent:main:main" },
+    );
+    await vi.waitFor(() => expect(launchCount).toBe(1));
+    const collector = await spawnSubagentDirect(
+      { task: "independent collector", collect: true, groupId: "admission-test" },
+      { agentSessionKey: "agent:main:main", requesterRunId: "parent-run" },
+    );
+
+    expect(collector.status).toBe("accepted");
+    releaseFirstLaunch.resolve();
+    await direct;
+    await vi.waitFor(() => expect(launchCount).toBe(2));
   });
 
   it("rejects direct swarm parameters while tools.swarm is disabled", async () => {

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -8,10 +8,12 @@ import { isAcpRuntimeSpawnAvailable } from "../acp/runtime/availability.js";
 import type { SubagentSpawnPreparation } from "../context-engine/types.js";
 import { isFastTestRuntimeEnv } from "../infra/env.js";
 import { listRegisteredPluginAgentPromptGuidance } from "../plugins/command-registry-state.js";
+import { enqueueCommandInLane } from "../process/command-queue.js";
 import {
   GatewayDrainingError,
   runWithGatewayIndependentRootWorkContinuation,
 } from "../process/gateway-work-admission.js";
+import { CommandLane } from "../process/lanes.js";
 import { recordSessionCreated, recordSubagentSpawned } from "../sessions/session-state-events.js";
 import {
   runSpawnPipeline,
@@ -70,6 +72,26 @@ export { SUBAGENT_SPAWN_CONTEXT_MODES, SUBAGENT_SPAWN_MODES } from "./subagent-s
 const SUBAGENT_CONTROL_GATEWAY_TIMEOUT_MS = 60_000;
 
 export async function spawnSubagentDirect(
+  params: SpawnSubagentParams,
+  ctx: SpawnSubagentContext,
+): Promise<SpawnSubagentResult> {
+  if (params.collect === true) {
+    // Collect runs retain the swarm scheduler's durable FIFO ownership.
+    return await spawnSubagentPrepared(params, ctx);
+  }
+  // Preparation needs a separate lane from child turns so one FIFO cannot
+  // make every burst item prepare before any dispatched child begins.
+  return await enqueueCommandInLane(
+    CommandLane.SubagentSpawn,
+    async () => {
+      ctx.abortSignal?.throwIfAborted();
+      return await spawnSubagentPrepared(params, ctx);
+    },
+    { queueWaitAbortSignal: ctx.abortSignal },
+  );
+}
+
+async function spawnSubagentPrepared(
   params: SpawnSubagentParams,
   ctx: SpawnSubagentContext,
 ): Promise<SpawnSubagentResult> {

--- a/src/agents/tools/sessions-spawn-tool.test.ts
+++ b/src/agents/tools/sessions-spawn-tool.test.ts
@@ -1286,6 +1286,18 @@ describe("sessions_spawn tool", () => {
     expect(spawnArgs.lightContext).toBe(true);
   });
 
+  it("passes the tool abort signal to subagent preparation", async () => {
+    const tool = createSessionsSpawnTool({
+      agentSessionKey: "agent:main:main",
+    });
+    const abortController = new AbortController();
+
+    await tool.execute("call-abort", { task: "prepare safely" }, abortController.signal);
+
+    const spawnContext = mockCallArg(hoisted.spawnSubagentDirectMock, 0, 1, "spawnSubagentDirect");
+    expect(spawnContext.abortSignal).toBe(abortController.signal);
+  });
+
   it('rejects lightContext when runtime is not "subagent"', async () => {
     registerAcpBackendForTest();
     const tool = createSessionsSpawnTool({

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -285,7 +285,7 @@ export function createSessionsSpawnTool(
       threadAvailable,
       swarmEnabled: swarmConfig.enabled,
     }),
-    execute: async (_toolCallId, args) => {
+    execute: async (_toolCallId, args, signal) => {
       const params = args as Record<PropertyKey, unknown>;
       if (opts?.swarmCollector && params.collect !== true) {
         throw new ToolInputError(
@@ -537,6 +537,7 @@ export function createSessionsSpawnTool(
           inheritedToolAllowlist: opts?.inheritedToolAllowlist,
           inheritedToolDenylist: opts?.inheritedToolDenylist,
           requesterRunId: opts?.requesterRunId,
+          abortSignal: signal,
         },
       );
 

--- a/src/gateway/server-lanes.test.ts
+++ b/src/gateway/server-lanes.test.ts
@@ -4,7 +4,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { DEFAULT_CRON_MAX_CONCURRENT_RUNS } from "../config/cron-limits.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { enqueueCommandInLane, setCommandLaneConcurrency } from "../process/command-queue.js";
+import {
+  enqueueCommandInLane,
+  getCommandLaneSnapshot,
+  setCommandLaneConcurrency,
+} from "../process/command-queue.js";
 import { resetCommandQueueStateForTest } from "../process/command-queue.test-support.js";
 import { CommandLane } from "../process/lanes.js";
 import { createDeferred } from "../test-utils/deferred.js";
@@ -68,6 +72,15 @@ describe("applyGatewayLaneConcurrency", () => {
       releaseRuns.resolve();
       await Promise.all(runs);
     }
+  });
+
+  it("applies one subagent limit to preparation and child turns", () => {
+    applyConfigLaneConcurrency({
+      agents: { defaults: { subagents: { maxConcurrent: 3 } } },
+    } as OpenClawConfig);
+
+    expect(getCommandLaneSnapshot(CommandLane.Subagent).maxConcurrent).toBe(3);
+    expect(getCommandLaneSnapshot(CommandLane.SubagentSpawn).maxConcurrent).toBe(3);
   });
 
   it("keeps the shared nested lane at its default concurrency", async () => {

--- a/src/gateway/server-lanes.ts
+++ b/src/gateway/server-lanes.ts
@@ -69,4 +69,5 @@ export function applyGatewayLaneConcurrency(
   if (!suspendedLaneIds.has(CommandLane.Subagent)) {
     setCommandLaneConcurrency(CommandLane.Subagent, concurrency.subagent);
   }
+  setCommandLaneConcurrency(CommandLane.SubagentSpawn, concurrency.subagent);
 }

--- a/src/process/command-queue.test.ts
+++ b/src/process/command-queue.test.ts
@@ -796,6 +796,31 @@ describe("command queue", () => {
     await expect(first).resolves.toBe("first");
   });
 
+  it("removes an aborted lane waiter without consuming a slot", async () => {
+    const { task: first, release } = enqueueBlockedMainTask(async () => "first");
+    const abortController = new AbortController();
+    const abortError = new Error("cancel queued work");
+    let queuedTaskStarted = false;
+    const queued = enqueueCommandInLane(
+      CommandLane.Main,
+      async () => {
+        queuedTaskStarted = true;
+        return "queued";
+      },
+      { queueWaitAbortSignal: abortController.signal },
+    );
+
+    abortController.abort(abortError);
+
+    await expect(queued).rejects.toBe(abortError);
+    expect(queuedTaskStarted).toBe(false);
+    expectLaneSnapshotFields(CommandLane.Main, { activeCount: 1, queuedCount: 0 });
+
+    release();
+    await expect(first).resolves.toBe("first");
+    await expect(enqueueCommandInLane(CommandLane.Main, async () => "next")).resolves.toBe("next");
+  });
+
   it("keeps draining functional after synchronous onWait failure", async () => {
     const lane = `drain-sync-throw-${Date.now()}-${Math.random().toString(16).slice(2)}`;
     setCommandLaneConcurrency(lane, 1);

--- a/src/process/command-queue.test.ts
+++ b/src/process/command-queue.test.ts
@@ -821,6 +821,30 @@ describe("command queue", () => {
     await expect(enqueueCommandInLane(CommandLane.Main, async () => "next")).resolves.toBe("next");
   });
 
+  it("rejects a lane waiter whose signal aborted before enqueue without consuming a slot", async () => {
+    // An already-aborted signal never dispatches a fresh abort event, so enrollment
+    // must recheck the signal itself or the entry would silently keep its slot.
+    const { task: first, release } = enqueueBlockedMainTask(async () => "first");
+    const abortError = new Error("cancelled before enqueue");
+    let queuedTaskStarted = false;
+    const queued = enqueueCommandInLane(
+      CommandLane.Main,
+      async () => {
+        queuedTaskStarted = true;
+        return "queued";
+      },
+      { queueWaitAbortSignal: AbortSignal.abort(abortError) },
+    );
+
+    await expect(queued).rejects.toBe(abortError);
+    expect(queuedTaskStarted).toBe(false);
+    expectLaneSnapshotFields(CommandLane.Main, { activeCount: 1, queuedCount: 0 });
+
+    release();
+    await expect(first).resolves.toBe("first");
+    await expect(enqueueCommandInLane(CommandLane.Main, async () => "next")).resolves.toBe("next");
+  });
+
   it("keeps draining functional after synchronous onWait failure", async () => {
     const lane = `drain-sync-throw-${Date.now()}-${Math.random().toString(16).slice(2)}`;
     setCommandLaneConcurrency(lane, 1);

--- a/src/process/command-queue.ts
+++ b/src/process/command-queue.ts
@@ -98,6 +98,7 @@ type QueueEntry = {
   taskTimeoutAbortGraceMs?: number;
   taskTimeoutReleaseSignal?: AbortSignal;
   onWait?: (waitMs: number, queuedAhead: number) => void;
+  removeQueueWaitAbortListener?: () => void;
 };
 
 type LaneState = {
@@ -473,6 +474,7 @@ function drainLane(lane: string) {
     try {
       while (state.activeTaskIds.size < state.maxConcurrent && state.queue.length > 0) {
         const entry = state.queue.shift() as QueueEntry;
+        entry.removeQueueWaitAbortListener?.();
         const waitedMs = Date.now() - entry.enqueuedAt;
         if (waitedMs >= entry.warnAfterMs) {
           try {
@@ -571,7 +573,7 @@ export function enqueueCommandInLane<T>(
   const warnAfterMs = opts?.warnAfterMs ?? 2_000;
   const state = getLaneState(cleaned);
   return new Promise<T>((resolve, reject) => {
-    enqueueLaneEntry(state, {
+    const entry: QueueEntry = {
       task: (marker) => task(marker),
       resolve: (value) => resolve(value as T),
       reject,
@@ -587,7 +589,32 @@ export function enqueueCommandInLane<T>(
       taskTimeoutAbortGraceMs: normalizeTaskTimeoutMs(opts?.taskTimeoutAbortGraceMs),
       taskTimeoutReleaseSignal: opts?.taskTimeoutReleaseSignal,
       onWait: opts?.onWait,
-    });
+    };
+    const queueWaitAbortSignal = opts?.queueWaitAbortSignal;
+    const abortQueuedEntry = () => {
+      const index = state.queue.indexOf(entry);
+      if (index < 0 || !queueWaitAbortSignal) {
+        return;
+      }
+      state.queue.splice(index, 1);
+      entry.removeQueueWaitAbortListener?.();
+      entry.reject(
+        queueWaitAbortSignal.reason instanceof Error
+          ? queueWaitAbortSignal.reason
+          : new Error("command lane wait aborted"),
+      );
+    };
+    if (queueWaitAbortSignal) {
+      const onAbort = () => abortQueuedEntry();
+      queueWaitAbortSignal.addEventListener("abort", onAbort, { once: true });
+      entry.removeQueueWaitAbortListener = () =>
+        queueWaitAbortSignal.removeEventListener("abort", onAbort);
+    }
+    enqueueLaneEntry(state, entry);
+    if (queueWaitAbortSignal?.aborted) {
+      abortQueuedEntry();
+      return;
+    }
     logLaneEnqueue(cleaned, getLaneDepth(state));
     drainLane(cleaned);
   });
@@ -653,6 +680,7 @@ export function clearCommandLane(lane: string = CommandLane.Main) {
   const removed = state.queue.length;
   const pending = state.queue.splice(0);
   for (const entry of pending) {
+    entry.removeQueueWaitAbortListener?.();
     entry.reject(new CommandLaneClearedError(cleaned));
   }
   return removed;

--- a/src/process/command-queue.types.ts
+++ b/src/process/command-queue.types.ts
@@ -5,6 +5,8 @@
 export type CommandQueueEnqueueOptions = {
   warnAfterMs?: number;
   onWait?: (waitMs: number, queuedAhead: number) => void;
+  /** Cancels this entry only while it is waiting for a lane slot. */
+  queueWaitAbortSignal?: AbortSignal;
   taskTimeoutMs?: number;
   taskTimeoutProgressAtMs?: () => number | undefined;
   taskTimeoutAbortSignal?: AbortSignal;

--- a/src/process/lanes.ts
+++ b/src/process/lanes.ts
@@ -6,5 +6,6 @@ export const enum CommandLane {
   CronNested = "cron-nested",
   SkillWorkshopReview = "skill-workshop-review",
   Subagent = "subagent",
+  SubagentSpawn = "subagent-spawn",
   Nested = "nested",
 }


### PR DESCRIPTION
## What Problem This Solves

A single assistant response can emit many sessions_spawn calls, and the agent loop runs non-immediate tools concurrently. Normal subagent spawns previously entered their full preparation pipeline without admission control. The existing Subagent command lane only limited the child turn after preparation had completed.

This allowed child planning, model resolution, session initialization, context preparation, attachment materialization, thread binding, and agent RPC dispatch to fan out concurrently on the gateway event loop.

## Why This Change Was Made

Normal subagent preparation now runs through a dedicated SubagentSpawn command lane. Its concurrency is set from the existing resolveSubagentMaxConcurrent configuration result, so this adds no configuration key, environment variable, or default.

The existing command queue already owns FIFO admission, concurrency changes, shutdown rejection, error release, and queue clearing. Reusing it avoids introducing a separate semaphore lifecycle.

The preparation lane is intentionally separate from the Subagent child-turn lane. A shared FIFO could place every queued preparation ahead of the child turns they dispatch, coupling two different lifecycle boundaries and delaying child execution until much of the burst had prepared.

Collect runs bypass the new lane because the swarm scheduler already owns their durable FIFO and collector lifecycle. Applying both limiters would change collect scheduling semantics.

Queued preparations receive the sessions_spawn abort signal. Aborting a waiter removes it before execution, rejects it with the abort reason, and does not consume or leak a slot. Started work releases through the command queue on every resolve or reject path. The lane is released after the gateway agent RPC dispatch returns, not when the child turn finishes.

## User Impact

Large parallel sessions_spawn bursts now have bounded preparation concurrency derived from the existing subagent concurrency setting. This reduces event-loop contention and transient memory growth while preserving successful spawn behavior apart from ordering and timing.

There is no new operator configuration and no SQLite, registry persistence, sweeper, or migration change.

This does not fix the maxChildrenPerAgent admission race. Serialization can narrow that race window, but it does not make the cap atomic or prevent over-admission.

## Evidence

The reported N=64 prototype reduced the headline event-loop stall from 8791 ms to 1720 ms and eliminated 15 health failures, but that run admitted fewer children. The honest equal-work comparison puts the improvement nearer 40 percent. This change uses that equal-work framing and does not claim the confounded headline reduction as its expected gain.

Focused proof after the change:

- Concurrent non-collect burst: peak preparation dispatches remained at the configured limit and every spawn completed.
- Error path: a failed dispatch released admission and the next queued spawn completed.
- Queued abort: the aborted spawn never dispatched and the following spawn completed.
- Collect path: collect scheduling remained independent while the normal preparation lane was occupied.
- Configuration: the existing subagent limit was applied to both preparation and child-turn lanes.
- Tool propagation: sessions_spawn passed its AbortSignal into preparation.

Commands and copied results:

`OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs src/process/command-queue.test.ts src/gateway/server-lanes.test.ts src/agents/subagent-spawn.test.ts src/agents/tools/sessions-spawn-tool.test.ts`

Result: `[test] passed 3 Vitest shards in 7.05s`

`OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs src/agents/subagent-spawn*.test.ts src/agents/swarm-scheduler*.test.ts`

Result: `[test] passed 1 Vitest shard in 6.64s`

Core and core-test tsgo checks, targeted oxlint, formatting, and `git diff --check` also passed.

What was not tested: no live gateway was started or restarted in this worktree. The admission TOCTOU, registry persistence, sweeper behavior, and SQLite behavior were intentionally unchanged and were not validated as fixes.
