### PR TITLE
fix(cron): silent agentTurn runs no longer report errors after successful tools

### DIFF
--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
@@ -4649,6 +4649,145 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     expect(result.meta.livenessState).toBe("working");
   });
 
+  it("treats reply-optional post-tool empty stops as silent even after side-effecting tools", () => {
+    // Regression: a cron agentTurn without a delivery route ran a successful
+    // replay-unsafe sessions patch and intentionally sent no final text; the run
+    // must finish silent, not as an incomplete-turn error.
+    const sideEffectToolAttempt = makeAttemptResult({
+      assistantTexts: [],
+      toolMetas: [{ toolName: "sessions", meta: "patch archived", replaySafe: false }],
+      lastAssistant: {
+        role: "assistant",
+        stopReason: "stop",
+        provider: "openai",
+        model: "gpt-5.5",
+        content: [{ type: "text", text: "" }],
+      } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+    });
+
+    expect(
+      shouldTreatEmptyAssistantReplyAsSilent({
+        allowEmptyAssistantReplyAsSilent: true,
+        terminalReplyExpectation: "optional",
+        payloadCount: 0,
+        aborted: false,
+        timedOut: false,
+        attempt: sideEffectToolAttempt,
+      }),
+    ).toBe(true);
+    // A required or unspecified terminal reply keeps the ambiguous-failure path.
+    expect(
+      shouldTreatEmptyAssistantReplyAsSilent({
+        allowEmptyAssistantReplyAsSilent: true,
+        terminalReplyExpectation: "required",
+        payloadCount: 0,
+        aborted: false,
+        timedOut: false,
+        attempt: sideEffectToolAttempt,
+      }),
+    ).toBe(false);
+    expect(
+      shouldTreatEmptyAssistantReplyAsSilent({
+        allowEmptyAssistantReplyAsSilent: true,
+        payloadCount: 0,
+        aborted: false,
+        timedOut: false,
+        attempt: sideEffectToolAttempt,
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps reply-optional runs erroring on real failure states", () => {
+    const toolErrorAttempt = makeAttemptResult({
+      assistantTexts: [],
+      toolMetas: [{ toolName: "sessions", meta: "patch failed", replaySafe: false, isError: true }],
+      lastToolError: { toolName: "sessions", error: "patch failed" },
+      lastAssistant: {
+        role: "assistant",
+        stopReason: "stop",
+        provider: "openai",
+        model: "gpt-5.5",
+        content: [{ type: "text", text: "" }],
+      } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+    });
+    const errorStopAttempt = makeAttemptResult({
+      assistantTexts: [],
+      toolMetas: [{ toolName: "sessions", meta: "patch archived", replaySafe: false }],
+      lastAssistant: {
+        role: "assistant",
+        stopReason: "error",
+        provider: "openai",
+        model: "gpt-5.5",
+        content: [],
+      } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+    });
+
+    expect(
+      shouldTreatEmptyAssistantReplyAsSilent({
+        allowEmptyAssistantReplyAsSilent: true,
+        terminalReplyExpectation: "optional",
+        payloadCount: 0,
+        aborted: false,
+        timedOut: false,
+        attempt: toolErrorAttempt,
+      }),
+    ).toBe(false);
+    expect(
+      shouldTreatEmptyAssistantReplyAsSilent({
+        allowEmptyAssistantReplyAsSilent: true,
+        terminalReplyExpectation: "optional",
+        payloadCount: 0,
+        aborted: false,
+        timedOut: false,
+        attempt: errorStopAttempt,
+      }),
+    ).toBe(false);
+    expect(
+      shouldTreatEmptyAssistantReplyAsSilent({
+        allowEmptyAssistantReplyAsSilent: true,
+        terminalReplyExpectation: "optional",
+        payloadCount: 0,
+        aborted: true,
+        timedOut: false,
+        attempt: errorStopAttempt,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns NO_REPLY for reply-optional cron-style runs whose side-effecting tools succeeded", async () => {
+    mockedClassifyFailoverReason.mockReturnValue(null);
+    mockedRunEmbeddedAttempt.mockResolvedValue(
+      makeAttemptResult({
+        assistantTexts: [],
+        toolMetas: [{ toolName: "sessions", meta: "patch archived", replaySafe: false }],
+        itemLifecycle: { startedCount: 1, completedCount: 1, activeCount: 0 },
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "stop",
+          provider: "openai",
+          model: "gpt-5.5",
+          content: [{ type: "text", text: "" }],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
+    );
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      allowEmptyAssistantReplyAsSilent: true,
+      terminalReplyExpectation: "optional",
+      provider: "openai",
+      model: "gpt-5.5",
+      runId: "run-reply-optional-post-tool-silent",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+    expectNoWarnMessageWith("incomplete turn detected");
+    expect(result.payloads).toEqual([{ text: "NO_REPLY" }]);
+    expect(result.meta.error).toBeUndefined();
+    expect(result.meta.terminalReplyKind).toBe("silent-empty");
+    expect(result.meta.livenessState).toBe("working");
+  });
+
   it("keeps retrying and surfacing clean empty assistant turns without the silence flag", async () => {
     mockedClassifyFailoverReason.mockReturnValue(null);
     mockedRunEmbeddedAttempt.mockResolvedValue(

--- a/src/agents/embedded-agent-runner/run/attempt-result.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-result.ts
@@ -347,6 +347,7 @@ export function completeEmbeddedAttemptResult(
     (silentToolResultReplyPayload ? 1 : 0);
   const emptyAssistantReplyIsSilent = shouldTreatEmptyAssistantReplyAsSilent({
     allowEmptyAssistantReplyAsSilent: attempt.allowEmptyAssistantReplyAsSilent,
+    terminalReplyExpectation: attempt.terminalReplyExpectation,
     payloadCount: 0,
     aborted: terminal.aborted,
     timedOut: terminal.timedOut,

--- a/src/agents/embedded-agent-runner/run/incomplete-turn.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn.ts
@@ -667,6 +667,8 @@ function shouldSkipNonVisibleTurnRetry(params: {
   aborted: boolean;
   timedOut: boolean;
   attempt: IncompleteTurnAttempt;
+  /** Reply-optional silent classification tolerates committed side effects; retries never can. */
+  tolerateSideEffects?: boolean;
 }): boolean {
   return Boolean(
     params.aborted ||
@@ -676,7 +678,8 @@ function shouldSkipNonVisibleTurnRetry(params: {
     params.attempt.didSendDeterministicApprovalPrompt ||
     params.attempt.lastToolError ||
     hasAcceptedSessionSpawn(params.attempt.acceptedSessionSpawns) ||
-    resolveAttemptReplayMetadata(params.attempt).hadPotentialSideEffects,
+    (params.tolerateSideEffects !== true &&
+      resolveAttemptReplayMetadata(params.attempt).hadPotentialSideEffects),
   );
 }
 
@@ -684,12 +687,21 @@ function shouldSkipNonVisibleTurnRetry(params: {
 export function shouldTreatEmptyAssistantReplyAsSilent(params: {
   allowEmptyAssistantReplyAsSilent?: boolean;
   onlyExplicitSilentReply?: boolean;
+  terminalReplyExpectation?: "required" | "optional";
   payloadCount: number;
   aborted: boolean;
   timedOut: boolean;
   attempt: IncompleteTurnAttempt;
 }): boolean {
-  if (!params.allowEmptyAssistantReplyAsSilent || shouldSkipNonVisibleTurnRetry(params)) {
+  // "optional" is the run consumer's declaration that no user-facing reply is
+  // owed (e.g. cron without a delivery route). Silence after side-effecting
+  // tools is intentional there; retry is replay-unsafe, so erroring would mark
+  // successful tool-only runs as failures.
+  const terminalReplyOptional = params.terminalReplyExpectation === "optional";
+  if (
+    !params.allowEmptyAssistantReplyAsSilent ||
+    shouldSkipNonVisibleTurnRetry({ ...params, tolerateSideEffects: terminalReplyOptional })
+  ) {
     return false;
   }
   if (hasCommittedMessagingToolDeliveryEvidence(params.attempt)) {
@@ -706,9 +718,10 @@ export function shouldTreatEmptyAssistantReplyAsSilent(params: {
   if (params.onlyExplicitSilentReply) {
     return false;
   }
-  // Post-tool empty stops are ambiguous provider failures, not intentional silence.
-  // Let the retry/incomplete-turn paths decide whether replay is safe.
+  // Post-tool empty stops are ambiguous provider failures when a reply is still
+  // expected; reply-optional runs settle their work in the tools themselves.
   if (
+    !terminalReplyOptional &&
     params.attempt.toolMetas.length > 0 &&
     isEmptyResponseAssistantTurn({
       payloadCount: params.payloadCount,

--- a/src/agents/embedded-agent-runner/run/terminal-resolution.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-resolution.ts
@@ -97,6 +97,7 @@ export function resolveSettledTurnFinalizationRequest(input: {
         : 0;
   const emptyAssistantReplyIsSilent = shouldTreatEmptyAssistantReplyAsSilent({
     allowEmptyAssistantReplyAsSilent: input.runParams.allowEmptyAssistantReplyAsSilent,
+    terminalReplyExpectation: input.runParams.terminalReplyExpectation,
     onlyExplicitSilentReply: false,
     payloadCount,
     aborted: terminalAborted,
@@ -206,6 +207,7 @@ export async function resolveEmbeddedRunTerminal(input: {
   const settledTurnFinalizationAttempted = input.settledTurnFinalizationAttempted;
   const emptyAssistantReplyIsSilent = shouldTreatEmptyAssistantReplyAsSilent({
     allowEmptyAssistantReplyAsSilent: runParams.allowEmptyAssistantReplyAsSilent,
+    terminalReplyExpectation: runParams.terminalReplyExpectation,
     onlyExplicitSilentReply: settledTurnFinalizationAttempted,
     payloadCount,
     aborted: terminalAborted,


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where one-shot cron jobs running an `agentTurn` payload with no delivery route (for example "archive this session after my turn ends — do not send any user-facing message") finished with `outcome=error` and the diagnostic "⚠️ Agent couldn't generate a response. Note: some tool actions may have already been executed — please verify before retrying." even when every tool action succeeded. The run did exactly what it was asked — executed its tools and stayed silent — but cron diagnostics recorded it as a failure. Observed live on 2026-07-27 on a dev gateway while testing session archiving on the Codex harness (gpt-5.6-sol): the cron turn archived the session successfully, then was logged as an error purely because the final assistant message was intentionally empty.

## Why This Change Was Made

Cron already declares its delivery contract per run: `terminalReplyExpectation: "required" | "optional"` (src/cron/isolated-agent/run-executor.ts), where "optional" means no user-facing reply is owed (delivery `none`, webhook, or invalid route). The empty-reply classifier in the embedded runner never consumed that declaration: `shouldTreatEmptyAssistantReplyAsSilent` treated any post-tool empty stop with replay-unsafe side effects as an ambiguous provider failure. This change threads the existing declaration into the classifier: when the run consumer declared the terminal reply optional, a normally-completed run (no abort, no timeout, no tool error, stopReason `stop`) whose tools succeeded is classified as intentional silence (`terminalReplyKind: "silent-empty"`, `NO_REPLY`) instead of an incomplete-turn error. Required or unspecified expectations, tool failures, error stop reasons, aborts, and timeouts keep the existing failure behavior, so genuinely broken runs still surface.

## User Impact

Operators no longer see false `outcome=error` diagnostics for silent cron automation turns whose tool actions succeeded; real failures (tool errors, provider errors, timeouts) still report as errors.

## Evidence

- Regression tests added in src/agents/embedded-agent-runner/run.incomplete-turn.test.ts: reply-optional post-tool empty stop after a replay-unsafe successful tool → silent; same attempt with `required`/unspecified expectation → still error path; tool-error, error-stop, and aborted variants → still error; full `runEmbeddedAgent` run asserts `NO_REPLY` payload, no `meta.error`, `terminalReplyKind: "silent-empty"`.
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run.incomplete-turn.test.ts` → 1 file, 157 tests passed.
- oxfmt --check clean on all four files; `git diff --check` clean.
- Autoreview (Codex, gpt-5.6-sol, xhigh): clean, no accepted/actionable findings — "expectation is propagated through both terminal-resolution paths, and the regression coverage exercises the intended success and failure cases."
