### PR TITLE
fix(agents): spawned agents lose tools with alsoAllow-only policy

### DIFF
--- a/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
+++ b/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
@@ -552,6 +552,18 @@ describe("createOpenClawCodingTools", () => {
     expect(inheritedToolAllowlistRef).not.toContain("exec");
   });
 
+  it("does not snapshot additive alsoAllow policies for spawn inheritance", () => {
+    const inheritedToolAllowlistRef: string[] = [];
+
+    createOpenClawCodingTools({
+      config: { tools: { alsoAllow: ["read"], deny: ["exec"] } },
+      inheritedToolAllowlistRef,
+    });
+
+    expect(inheritedToolAllowlistRef).toEqual([]);
+    expect(latestCreateOpenClawToolsOptions().inheritedToolDenylist).toContain("exec");
+  });
+
   it("preserves runtime-allowed message through restrictive profiles", () => {
     const tools = createOpenClawCodingTools({
       config: { tools: { profile: "minimal" } },

--- a/src/agents/tool-policy.test.ts
+++ b/src/agents/tool-policy.test.ts
@@ -12,6 +12,7 @@ import {
   collectExplicitAllowlist,
   DEFAULT_PLUGIN_TOOLS_ALLOWLIST_ENTRY,
   expandToolGroups,
+  hasRestrictiveAllowPolicy,
   normalizeToolName,
   resolveToolProfilePolicy,
   TOOL_GROUPS,
@@ -78,6 +79,19 @@ describe("tool-policy", () => {
     expect(collectExplicitAllowlist([pickSandboxToolPolicy({ alsoAllow: [" * "] })])).toEqual([
       "*",
     ]);
+  });
+
+  it("does not treat additive allow-all policies as restrictive", () => {
+    expect(hasRestrictiveAllowPolicy(pickSandboxToolPolicy({ alsoAllow: ["optional-demo"] }))).toBe(
+      false,
+    );
+    expect(
+      hasRestrictiveAllowPolicy(pickSandboxToolPolicy({ allow: [], alsoAllow: ["optional-demo"] })),
+    ).toBe(false);
+  });
+
+  it("still treats explicit bounded allowlists as restrictive", () => {
+    expect(hasRestrictiveAllowPolicy(pickSandboxToolPolicy({ allow: ["read"] }))).toBe(true);
   });
 });
 

--- a/src/agents/tool-policy.ts
+++ b/src/agents/tool-policy.ts
@@ -55,16 +55,17 @@ const SHIPPED_PLUGIN_POLICY_FAMILY_CORE_TOOLS = new Map<string, readonly string[
 
 /** Returns true when an allow policy is narrower than all/default plugin tools. */
 export function hasRestrictiveAllowPolicy(policy?: { allow?: string[] }): boolean {
-  return (
-    Array.isArray(policy?.allow) &&
-    policy.allow.some((entry) => {
-      const normalized = normalizeToolName(entry);
-      return (
-        Boolean(normalized) &&
-        normalized !== "*" &&
-        normalized !== DEFAULT_PLUGIN_TOOLS_ALLOWLIST_ENTRY
-      );
-    })
+  if (!Array.isArray(policy?.allow)) {
+    return false;
+  }
+  const normalizedAllow = policy.allow.map((entry) => normalizeToolName(entry));
+  // A wildcard remains allow-all when additive entries are present. Treating
+  // those extras as restrictive would unnecessarily cap delegated sessions.
+  if (normalizedAllow.includes("*")) {
+    return false;
+  }
+  return normalizedAllow.some(
+    (entry) => Boolean(entry) && entry !== DEFAULT_PLUGIN_TOOLS_ALLOWLIST_ENTRY,
   );
 }
 


### PR DESCRIPTION
Closes #114529

## What Problem This Solves

Fixes an issue where users spawning a specialized agent could lose target-agent tools when the parent configured `tools.alsoAllow` without a bounded `tools.allow`.

Although that configuration is additive and retains allow-all semantics, it was treated as restrictive and caused the parent's concrete tool surface to be stored as the child's inherited hard allowlist.

## Why This Change Was Made

The restrictive-policy classifier now treats a wildcard as dominant even when additive entries are present. This prevents an unnecessary inherited allowlist snapshot for `alsoAllow`-only policies while preserving the existing parent ceiling for explicit bounded allowlists.

Inherited denylists are unchanged. The change does not add target-agent grants to a restrictive parent snapshot and does not change requester identity or plugin visibility.

## User Impact

Target agents can retain their own authorized tool surface when spawned by an unrestricted parent that uses `tools.alsoAllow`. Parents with explicit bounded allowlists continue to cap their children, and denied tools remain denied.

## Evidence

Before the fix, the new focused assertion failed on current `main`:

```text
FAIL src/agents/tool-policy.test.ts > tool-policy > does not treat additive allow-all policies as restrictive
AssertionError: expected true to be false

Test Files  1 failed (1)
Tests       1 failed | 22 passed (23)
```

After the fix, on the final rebased head:

```text
node scripts/run-vitest.mjs \
  src/agents/tool-policy.test.ts \
  src/agents/agent-tools.create-openclaw-coding-tools.test.ts \
  --reporter=dot

Test Files  2 passed (2)
Tests       107 passed (107)
```

The integration coverage verifies all three security-relevant outcomes:

- additive `alsoAllow` does not populate the spawned-agent inherited allowlist;
- an explicit bounded allowlist remains restrictive;
- a configured deny remains in the inherited denylist.

### Live spawned-agent proof

Executed against exact rebased PR head `0ec8991c2329385b28a9419337758bf95f6f95f7` on top of `upstream/main` `d2dc61cddf` with a freshly started isolated Gateway, the real `sessions_spawn` path, a configured `worker` agent, and the bundled Workboard plugin. A deterministic local model adapter issued the calls; tool-policy resolution, child-session creation, model-facing tool declaration, plugin-tool execution, and transcript persistence all ran through the real Gateway/runtime.

The relevant configuration contained no bounded parent `allow` and no restrictive parent profile:

```json
{
  "parentPolicy": {
    "alsoAllow": ["read"],
    "deny": ["exec"]
  },
  "targetAgentPolicy": {
    "alsoAllow": ["workboard_list"]
  }
}
```

Observed model-boundary assertions:

```text
spawnCallObserved=true
parentTargetToolDeclared=false
targetToolDeclared=true
targetToolCallObserved=true
targetToolResultObserved=true
deniedExecDeclared=false
```

Selected redacted transcript:

```text
PARENT
assistant toolCall:
  sessions_spawn({
    agentId: "worker",
    task: "call the target-only proof tool once and report the result",
    mode: "run"
  })
toolResult:
  status: "accepted"
  childSessionKey: "agent:worker:subagent:<redacted>"

CHILD
assistant toolCall:
  workboard_list({})
toolResult:
  {"cards":[]}
  isError: false
assistant:
  LIVE_CHILD_OK
```

This demonstrates that a tool absent from the parent request but authorized specifically for the target agent survives delegation, while the parent's denied `exec` tool is absent from the child model request.

Additional validation on the patch-equivalent pre-rebase head:

```text
pnpm check
# passed: preflight guards, 79 package-lock validations, TypeScript,
# lint, formatting, policy guards, and import-cycle check

pnpm build
# completed successfully
```

Final-head formatting and diff checks also pass:

```text
./node_modules/.bin/oxfmt --check \
  src/agents/tool-policy.ts \
  src/agents/tool-policy.test.ts \
  src/agents/agent-tools.create-openclaw-coding-tools.test.ts

git diff --check upstream/main...HEAD
```

The exact rebased runtime artifacts used by the live proof were rebuilt without dependency reconciliation:

```text
OPENCLAW_BUILD_ALL_NO_PNPM=1 node scripts/build-all.mjs gatewayWatch
# passed: tsdown, CLI bootstrap import guard, runtime postbuild, and build stamps
```

Exact-head CI after the rebase also passed:

```text
https://github.com/openclaw/openclaw/actions/runs/30276663135

checks-node-compact-small-7  passed (9m44s)
openclaw/ci-gate             passed
57 selected jobs             passed
```

This PR is AI-assisted. The behavior, implementation, security boundary, tests, and generated diff were reviewed and understood before submission. The repository's `$autoreview` skill was not available in the contributor environment, so focused manual review, repository checks, build validation, and the isolated live spawned-agent proof above are used instead.
