### PR TITLE
fix(auto-reply): deliver core fallback when a visible turn produces no reply

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.base.test-utils.ts
+++ b/src/auto-reply/reply/dispatch-from-config.base.test-utils.ts
@@ -1016,7 +1016,9 @@ describe("dispatchReplyFromConfig", () => {
         replyResolver: async () => undefined,
       });
 
-      expect(result.queuedFinal).toBe(false);
+      // Direct empty completions get a core no-visible-reply fallback final.
+      expect(result.queuedFinal).toBe(true);
+      expect(result.noVisibleReplyFallbackDelivered).toBe(true);
       await vi.waitFor(
         () => {
           expect(
@@ -1284,8 +1286,9 @@ describe("dispatchReplyFromConfig", () => {
       });
 
       expect(result).toMatchObject({
-        queuedFinal: false,
+        queuedFinal: true,
         counts: { tool: 0, block: 0, final: 0 },
+        noVisibleReplyFallbackDelivered: true,
       });
       expect(replyResolver).toHaveBeenCalledTimes(1);
       expect(replyRunRegistry.get(sessionKey)).toBe(activeOperation);

--- a/src/auto-reply/reply/dispatch-from-config.choose-route.ts
+++ b/src/auto-reply/reply/dispatch-from-config.choose-route.ts
@@ -250,6 +250,9 @@ export async function chooseDispatchRoute(state: PrepareDispatchOperationReadySt
       deliveredBlockContentKeys.add(createBlockReplyContentKey(payload));
     }
   };
+  // Routed blocks bypass dispatcher queue counts entirely; this is the only
+  // settled-delivery fact for them (media-only blocks never touch blockCount).
+  const hasDeliveredRoutedBlockReply = (): boolean => deliveredBlockContentKeys.size > 0;
   const wasReplyDeliveredAsBlock = async (
     payload: ReplyPayload,
     abortSignal?: AbortSignal,
@@ -610,6 +613,7 @@ export async function chooseDispatchRoute(state: PrepareDispatchOperationReadySt
       sendTrackedBlockReply,
       recordRoutedBlockReplyDelivery,
       wasReplyDeliveredAsBlock,
+      hasDeliveredRoutedBlockReply,
       sendFinalPayload,
     },
     {

--- a/src/auto-reply/reply/dispatch-from-config.finalize.ts
+++ b/src/auto-reply/reply/dispatch-from-config.finalize.ts
@@ -40,6 +40,7 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
     flushPendingCommentaryProgress,
     getDispatchAbortSignal,
     getObservedReplyDelivery,
+    hasDeliveredRoutedBlockReply,
     isRoutedReplyDelivered,
     markIdle,
     markInboundDedupeReplayUnsafe,
@@ -303,6 +304,7 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
     !getObservedReplyDelivery() &&
     !emptyFinalAllowedAsSilent &&
     !sawDedupedAgainstBlock &&
+    !hasDeliveredRoutedBlockReply() &&
     state.blockCount === 0 &&
     counts.tool === 0 &&
     counts.block === 0 &&

--- a/src/auto-reply/reply/dispatch-from-config.finalize.ts
+++ b/src/auto-reply/reply/dispatch-from-config.finalize.ts
@@ -13,6 +13,7 @@ import type { ExecuteDispatchReadyState } from "./dispatch-from-config.execute.j
 import {
   createFinalDispatchPayloadDedupeKey,
   formatSuppressedReplyPayloadForLog,
+  NO_VISIBLE_REPLY_FALLBACK_TEXT,
 } from "./dispatch-from-config.payloads.js";
 import {
   clearPendingFinalDeliveryAfterSuccess,
@@ -57,6 +58,7 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
     sessionKey,
     sessionStoreEntry,
     sessionTtsAuto,
+    sourceReplyDeliveryMode,
     suppressAutomaticSourceDelivery,
     suppressDelivery,
     throwIfDispatchOperationAborted,
@@ -109,6 +111,8 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
     getReplyPayloadMetadata(reply)?.deliverDespiteSourceReplySuppression === true &&
     (ctx.InboundEventKind !== "room_event" || explicitCommandTurnCtx);
   const sentFinalPayloadDedupeKeys = new Set<string>();
+  let sawDedupedAgainstBlock = false;
+  let sawVisibleFinalDelivery = false;
   for (const [replyIndex, reply] of replies.entries()) {
     throwIfDispatchOperationAborted();
     // Durable reasoning is a channel-owned lane; generic channels keep the
@@ -143,11 +147,20 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
     sentFinalPayloadDedupeKeys.add(finalPayloadDedupeKey);
     const finalReply = await sendFinalPayload(reply, { deliveryId: String(replyIndex) });
     if (finalReply.dedupedAgainstBlock) {
+      sawDedupedAgainstBlock = true;
       continue;
     }
     attemptedFinalDelivery = true;
     queuedFinal = finalReply.queuedFinal || queuedFinal;
     routedFinalCount += finalReply.routedFinalCount;
+    // Routed drops of empty payloads report ok without sending anything; only a
+    // contentful final proves visibility for the no-visible-reply fallback gate.
+    if (
+      hasOutboundReplyContent(reply, { trimText: true }) &&
+      (finalReply.queuedFinal || finalReply.routedFinalCount > 0)
+    ) {
+      sawVisibleFinalDelivery = true;
+    }
     if (finalReply.queuedFinal) {
       if (finalReply.dispatcherOutcome) {
         finalDeliveries.push({ outcome: finalReply.dispatcherOutcome, payload: reply });
@@ -249,6 +262,7 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
             queuedFinal = result.ok || queuedFinal;
             if (isRoutedReplyDelivered(result)) {
               routedFinalCount += 1;
+              sawVisibleFinalDelivery = true;
             }
             if (!result.ok) {
               logVerbose(
@@ -260,6 +274,7 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
             markInboundDedupeReplayUnsafe();
             const didQueue = dispatcher.sendFinalReply(normalizedTtsOnlyPayload);
             queuedFinal = didQueue || queuedFinal;
+            sawVisibleFinalDelivery = didQueue || sawVisibleFinalDelivery;
           }
         }
       } catch (err) {
@@ -274,7 +289,68 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
   }
 
   await waitForPendingDirectBlockReplyDelivery(getDispatchAbortSignal());
-  const counts = dispatcher.getQueuedCounts();
+  let counts = dispatcher.getQueuedCounts();
+  let noVisibleReplyFallbackDelivered = false;
+  // Visible agent turns must never end silently: empty model completions get a
+  // core fallback final. emptyFinalAllowedAsSilent is the only sanctioned silence.
+  // Routed streamed blocks bypass dispatcher counts, so blockCount and the
+  // deduped-against-block signal must also prove the turn was empty before falling back.
+  if (
+    !suppressDelivery &&
+    !sendPolicyDenied &&
+    sourceReplyDeliveryMode !== "message_tool_only" &&
+    !sawVisibleFinalDelivery &&
+    !getObservedReplyDelivery() &&
+    !emptyFinalAllowedAsSilent &&
+    !sawDedupedAgainstBlock &&
+    state.blockCount === 0 &&
+    counts.tool === 0 &&
+    counts.block === 0 &&
+    counts.final === 0
+  ) {
+    try {
+      throwIfDispatchOperationAborted();
+      const fallbackPayload: ReplyPayload = { text: NO_VISIBLE_REPLY_FALLBACK_TEXT };
+      const result = await routeReplyToOriginating(fallbackPayload, {
+        abortSignal: getDispatchAbortSignal(),
+        kind: "final",
+      });
+      if (result) {
+        // Hook-suppressed results (ok + suppressed) stay undelivered so the
+        // eligibility flag survives for channel-level fallbacks.
+        if (isRoutedReplyDelivered(result)) {
+          queuedFinal = true;
+          noVisibleReplyFallbackDelivered = true;
+          routedFinalCount += 1;
+        } else if (!result.ok) {
+          logVerbose(
+            `dispatch-from-config: route-reply (no-visible-reply fallback) failed: ${result.error ?? "unknown error"}`,
+          );
+        }
+      } else {
+        throwIfDispatchOperationAborted();
+        markInboundDedupeReplayUnsafe();
+        // Queue admission, not settled delivery: a beforeDeliver hook can still
+        // cancel this payload. Accepted tradeoff until a unified visible-delivery
+        // signal exists; every sibling in this function shares the semantics.
+        const didQueue = dispatcher.sendFinalReply(fallbackPayload);
+        if (didQueue) {
+          queuedFinal = true;
+          noVisibleReplyFallbackDelivered = true;
+          // Re-snapshot so the queued fallback is reflected in reported counts,
+          // matching the TTS-only path which enqueues before the snapshot.
+          counts = dispatcher.getQueuedCounts();
+        }
+      }
+    } catch (err) {
+      if (isDispatchReplyOperationAbortedError(err)) {
+        throw err;
+      }
+      logVerbose(
+        `dispatch-from-config: no-visible-reply fallback failed: ${formatErrorMessage(err)}`,
+      );
+    }
+  }
   counts.final += routedFinalCount;
   commitInboundDedupeIfClaimed();
   recordAgentDispatchCompleted("completed");
@@ -293,9 +369,16 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
         ? { sessionMetadataChanges: state.sessionMetadataChangesForResult }
         : {}),
       ...(getObservedReplyDelivery() ? { observedReplyDelivery: true } : {}),
-      ...(!queuedFinal && !getObservedReplyDelivery() && !emptyFinalAllowedAsSilent
+      // Eligibility keys off visible delivery, not queue/route admission: an
+      // empty routed final reports ok without sending, and must not mask a
+      // failed fallback from channel-level recovery.
+      ...(!sawVisibleFinalDelivery &&
+      !noVisibleReplyFallbackDelivered &&
+      !getObservedReplyDelivery() &&
+      !emptyFinalAllowedAsSilent
         ? { noVisibleReplyFallbackEligible: true }
         : {}),
+      ...(noVisibleReplyFallbackDelivered ? { noVisibleReplyFallbackDelivered: true } : {}),
       ...(beforeAgentRunBlocked ? { beforeAgentRunBlocked } : {}),
     }),
   };

--- a/src/auto-reply/reply/dispatch-from-config.hooks-and-send-policy.test-utils.ts
+++ b/src/auto-reply/reply/dispatch-from-config.hooks-and-send-policy.test-utils.ts
@@ -425,6 +425,56 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
     expect(result.noVisibleReplyFallbackEligible).toBeUndefined();
   });
 
+  it("delivers fallback for mentioned group turns even when group silence is allowed", async () => {
+    setNoAbort();
+    const dispatcher = createDispatcher();
+    const replyResolver = vi.fn(async () => undefined);
+    const ctx = buildTestCtx({
+      ChatType: "group",
+      Surface: "telegram",
+      Provider: "telegram",
+      SessionKey: "agent:main:telegram:group:oc_group",
+      WasMentioned: true,
+    });
+
+    // No silentReply config: group default is "allow", but an explicit mention
+    // is a directed turn and must never end silently.
+    const result = await dispatchReplyFromConfig({
+      ctx,
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+    });
+
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({
+      text: NO_VISIBLE_REPLY_FALLBACK_TEXT,
+    });
+    expect(result.noVisibleReplyFallbackDelivered).toBe(true);
+  });
+
+  it("keeps ambient group turns silent under the default group policy", async () => {
+    setNoAbort();
+    const dispatcher = createDispatcher();
+    const replyResolver = vi.fn(async () => undefined);
+    const ctx = buildTestCtx({
+      ChatType: "group",
+      Surface: "telegram",
+      Provider: "telegram",
+      SessionKey: "agent:main:telegram:group:oc_group",
+    });
+
+    const result = await dispatchReplyFromConfig({
+      ctx,
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+    });
+
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+    expect(result.noVisibleReplyFallbackDelivered).toBeUndefined();
+    expect(result.noVisibleReplyFallbackEligible).toBeUndefined();
+  });
+
   it("does not deliver no-visible fallback when silentReply allows empty finals", async () => {
     setNoAbort();
     const dispatcher = createDispatcher();

--- a/src/auto-reply/reply/dispatch-from-config.hooks-and-send-policy.test-utils.ts
+++ b/src/auto-reply/reply/dispatch-from-config.hooks-and-send-policy.test-utils.ts
@@ -5,6 +5,7 @@ import type { SessionBindingRecord } from "../../infra/outbound/session-binding-
 import { setReplyPayloadMetadata } from "../reply-payload.js";
 import type { MsgContext } from "../templating.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
+import { NO_VISIBLE_REPLY_FALLBACK_TEXT } from "./dispatch-from-config.payloads.js";
 import {
   createDispatcher,
   diagnosticMocks,
@@ -387,7 +388,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
     expect(result).toEqual({ queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } });
   });
 
-  it("marks disallowed group silence eligible for no-visible fallback", async () => {
+  it("delivers core no-visible-reply fallback for disallowed empty group turns", async () => {
     setNoAbort();
     const dispatcher = createDispatcher();
     const replyResolver = vi.fn(async () => undefined);
@@ -413,11 +414,381 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
       replyResolver,
     });
 
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({
+      text: NO_VISIBLE_REPLY_FALLBACK_TEXT,
+    });
+    expect(result).toEqual({
+      queuedFinal: true,
+      counts: { tool: 0, block: 0, final: 0 },
+      noVisibleReplyFallbackDelivered: true,
+    });
+    expect(result.noVisibleReplyFallbackEligible).toBeUndefined();
+  });
+
+  it("does not deliver no-visible fallback when silentReply allows empty finals", async () => {
+    setNoAbort();
+    const dispatcher = createDispatcher();
+    const replyResolver = vi.fn(async () => undefined);
+    const ctx = buildTestCtx({
+      ChatType: "group",
+      Surface: "feishu",
+      Provider: "feishu",
+      SessionKey: "agent:main:feishu:group:oc_group",
+    });
+
+    const result = await dispatchReplyFromConfig({
+      ctx,
+      cfg: {
+        agents: {
+          defaults: {
+            silentReply: {
+              group: "allow",
+            },
+          },
+        },
+      } as OpenClawConfig,
+      dispatcher,
+      replyResolver,
+    });
+
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
     expect(result).toEqual({
       queuedFinal: false,
       counts: { tool: 0, block: 0, final: 0 },
-      noVisibleReplyFallbackEligible: true,
     });
+    expect(result.noVisibleReplyFallbackDelivered).toBeUndefined();
+    expect(result.noVisibleReplyFallbackEligible).toBeUndefined();
+  });
+
+  it("does not deliver no-visible fallback when sendPolicy is deny", async () => {
+    setNoAbort();
+    sessionStoreMocks.currentEntry = {
+      sessionId: "s1",
+      updatedAt: 0,
+      sendPolicy: "deny",
+    };
+    const dispatcher = createDispatcher();
+    const replyResolver = vi.fn(async () => undefined);
+    const ctx = buildTestCtx({
+      ChatType: "group",
+      Surface: "telegram",
+      Provider: "telegram",
+      SessionKey: "agent:main:telegram:group:oc_group",
+    });
+
+    const result = await dispatchReplyFromConfig({
+      ctx,
+      cfg: {
+        agents: {
+          defaults: {
+            silentReply: {
+              group: "disallow",
+            },
+          },
+        },
+      } as OpenClawConfig,
+      dispatcher,
+      replyResolver,
+    });
+
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+    expect(result.queuedFinal).toBe(false);
+    expect(result.noVisibleReplyFallbackDelivered).toBeUndefined();
+    expect(result.noVisibleReplyFallbackEligible).toBe(true);
+    expect(result.sendPolicyDenied).toBe(true);
+  });
+
+  it("does not deliver no-visible fallback under message_tool_only source delivery", async () => {
+    setNoAbort();
+    sessionStoreMocks.currentEntry = {
+      sessionId: "s1",
+      updatedAt: 0,
+      sendPolicy: "allow",
+    };
+    const dispatcher = createDispatcher();
+    const replyResolver = vi.fn(async () => undefined);
+    const ctx = buildTestCtx({
+      ChatType: "direct",
+      Surface: "telegram",
+      Provider: "telegram",
+      SessionKey: "agent:main:telegram:direct:user1",
+    });
+
+    const result = await dispatchReplyFromConfig({
+      ctx,
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+      replyOptions: {
+        sourceReplyDeliveryMode: "message_tool_only",
+      },
+    });
+
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+    expect(result.queuedFinal).toBe(false);
+    expect(result.noVisibleReplyFallbackDelivered).toBeUndefined();
+    expect(result.sourceReplyDeliveryMode).toBe("message_tool_only");
+    // Direct silent policy is disallow; eligibility remains for transport fallbacks.
+    expect(result.noVisibleReplyFallbackEligible).toBe(true);
+  });
+
+  it("does not deliver no-visible fallback after observed reply delivery", async () => {
+    setNoAbort();
+    const dispatcher = createDispatcher();
+    const observedReplyDelivery = vi.fn();
+    const replyResolver = vi.fn(async (_ctx: MsgContext, opts?: GetReplyOptions) => {
+      await opts?.onObservedReplyDelivery?.();
+      return undefined;
+    });
+    const ctx = buildTestCtx({
+      ChatType: "group",
+      Surface: "telegram",
+      Provider: "telegram",
+      SessionKey: "agent:main:telegram:group:oc_group",
+    });
+
+    const result = await dispatchReplyFromConfig({
+      ctx,
+      cfg: {
+        agents: {
+          defaults: {
+            silentReply: {
+              group: "disallow",
+            },
+          },
+        },
+      } as OpenClawConfig,
+      dispatcher,
+      replyResolver,
+      replyOptions: {
+        onObservedReplyDelivery: observedReplyDelivery,
+      },
+    });
+
+    expect(observedReplyDelivery).toHaveBeenCalledTimes(1);
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+    expect(result.queuedFinal).toBe(false);
+    expect(result.observedReplyDelivery).toBe(true);
+    expect(result.noVisibleReplyFallbackDelivered).toBeUndefined();
+    expect(result.noVisibleReplyFallbackEligible).toBeUndefined();
+  });
+
+  it("delivers routed fallback when routing drops an empty final without sending", async () => {
+    setNoAbort();
+    mocks.routeReply.mockResolvedValueOnce({ ok: true });
+    mocks.routeReply.mockResolvedValueOnce({ ok: true, messageId: "fallback-1" });
+    const dispatcher = createDispatcher();
+    const replyResolver = vi.fn(async () => ({ text: "" }));
+    const ctx = buildTestCtx({
+      ChatType: "group",
+      Surface: "slack",
+      Provider: "slack",
+      OriginatingChannel: "telegram",
+      OriginatingTo: "telegram:999",
+      SessionKey: "agent:main:slack:group:oc_group",
+    });
+
+    const result = await dispatchReplyFromConfig({
+      ctx,
+      cfg: {
+        agents: {
+          defaults: {
+            silentReply: {
+              group: "disallow",
+            },
+          },
+        },
+      } as OpenClawConfig,
+      dispatcher,
+      replyResolver,
+    });
+
+    // The empty final routes as { ok: true } without sending; the fallback must
+    // still fire instead of trusting route success as visibility.
+    const fallbackCall = mocks.routeReply.mock.calls.find(
+      (call) =>
+        (call[0] as { payload?: { text?: string } }).payload?.text ===
+        NO_VISIBLE_REPLY_FALLBACK_TEXT,
+    );
+    expect(fallbackCall).toBeDefined();
+    expect(result.queuedFinal).toBe(true);
+    expect(result.noVisibleReplyFallbackDelivered).toBe(true);
+  });
+
+  it("keeps eligibility when an empty routed final precedes a suppressed fallback", async () => {
+    setNoAbort();
+    mocks.routeReply.mockResolvedValueOnce({ ok: true });
+    mocks.routeReply.mockResolvedValueOnce({ ok: true, suppressed: true });
+    const dispatcher = createDispatcher();
+    const replyResolver = vi.fn(async () => ({ text: "" }));
+    const ctx = buildTestCtx({
+      ChatType: "group",
+      Surface: "slack",
+      Provider: "slack",
+      OriginatingChannel: "telegram",
+      OriginatingTo: "telegram:999",
+      SessionKey: "agent:main:slack:group:oc_group",
+    });
+
+    const result = await dispatchReplyFromConfig({
+      ctx,
+      cfg: {
+        agents: {
+          defaults: {
+            silentReply: {
+              group: "disallow",
+            },
+          },
+        },
+      } as OpenClawConfig,
+      dispatcher,
+      replyResolver,
+    });
+
+    // Neither the phantom empty route nor the suppressed fallback was visible;
+    // eligibility must survive for channel-level recovery.
+    expect(result.noVisibleReplyFallbackDelivered).toBeUndefined();
+    expect(result.noVisibleReplyFallbackEligible).toBe(true);
+  });
+
+  it("does not report a hook-suppressed routed fallback as delivered", async () => {
+    setNoAbort();
+    mocks.routeReply.mockResolvedValue({ ok: true, suppressed: true });
+    const dispatcher = createDispatcher();
+    const replyResolver = vi.fn(async () => undefined);
+    const ctx = buildTestCtx({
+      ChatType: "group",
+      Surface: "slack",
+      Provider: "slack",
+      OriginatingChannel: "telegram",
+      OriginatingTo: "telegram:999",
+      SessionKey: "agent:main:slack:group:oc_group",
+    });
+
+    const result = await dispatchReplyFromConfig({
+      ctx,
+      cfg: {
+        agents: {
+          defaults: {
+            silentReply: {
+              group: "disallow",
+            },
+          },
+        },
+      } as OpenClawConfig,
+      dispatcher,
+      replyResolver,
+    });
+
+    expect(result.queuedFinal).toBe(false);
+    expect(result.noVisibleReplyFallbackDelivered).toBeUndefined();
+    expect(result.noVisibleReplyFallbackEligible).toBe(true);
+  });
+
+  it("does not deliver no-visible fallback after streamed blocks invisible to dispatcher counts", async () => {
+    setNoAbort();
+    const dispatcher = createDispatcher();
+    const replyResolver = vi.fn(async (_ctx: MsgContext, opts?: GetReplyOptions) => {
+      await opts?.onBlockReply?.({ text: "Streamed answer content." });
+      return undefined;
+    });
+    const ctx = buildTestCtx({
+      ChatType: "group",
+      Surface: "telegram",
+      Provider: "telegram",
+      SessionKey: "agent:main:telegram:group:oc_group",
+    });
+
+    const result = await dispatchReplyFromConfig({
+      ctx,
+      cfg: {
+        agents: {
+          defaults: {
+            silentReply: {
+              group: "disallow",
+            },
+          },
+        },
+      } as OpenClawConfig,
+      dispatcher,
+      replyResolver,
+    });
+
+    // Routed streamed blocks never touch the mock dispatcher counts; blockCount
+    // alone must prove the turn was visible so no misleading fallback is sent.
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalledWith({
+      text: NO_VISIBLE_REPLY_FALLBACK_TEXT,
+    });
+    expect(result.noVisibleReplyFallbackDelivered).toBeUndefined();
+  });
+
+  it("does not deliver no-visible fallback when dispatcher already queued a block", async () => {
+    setNoAbort();
+    const dispatcher = createDispatcher();
+    dispatcher.getQueuedCounts = vi.fn(() => ({ tool: 0, block: 1, final: 0 }));
+    const replyResolver = vi.fn(async () => undefined);
+    const ctx = buildTestCtx({
+      ChatType: "group",
+      Surface: "telegram",
+      Provider: "telegram",
+      SessionKey: "agent:main:telegram:group:oc_group",
+    });
+
+    const result = await dispatchReplyFromConfig({
+      ctx,
+      cfg: {
+        agents: {
+          defaults: {
+            silentReply: {
+              group: "disallow",
+            },
+          },
+        },
+      } as OpenClawConfig,
+      dispatcher,
+      replyResolver,
+    });
+
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+    expect(result.queuedFinal).toBe(false);
+    expect(result.counts.block).toBe(1);
+    expect(result.noVisibleReplyFallbackDelivered).toBeUndefined();
+    expect(result.noVisibleReplyFallbackEligible).toBe(true);
+  });
+
+  it("keeps no-visible fallback eligible when core fallback delivery fails", async () => {
+    setNoAbort();
+    const dispatcher = createDispatcher();
+    dispatcher.sendFinalReply = vi.fn(() => false);
+    const replyResolver = vi.fn(async () => undefined);
+    const ctx = buildTestCtx({
+      ChatType: "group",
+      Surface: "telegram",
+      Provider: "telegram",
+      SessionKey: "agent:main:telegram:group:oc_group",
+    });
+
+    const result = await dispatchReplyFromConfig({
+      ctx,
+      cfg: {
+        agents: {
+          defaults: {
+            silentReply: {
+              group: "disallow",
+            },
+          },
+        },
+      } as OpenClawConfig,
+      dispatcher,
+      replyResolver,
+    });
+
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({
+      text: NO_VISIBLE_REPLY_FALLBACK_TEXT,
+    });
+    expect(result.queuedFinal).toBe(false);
+    expect(result.noVisibleReplyFallbackDelivered).toBeUndefined();
+    expect(result.noVisibleReplyFallbackEligible).toBe(true);
   });
 
   it("suppresses tool result delivery when sendPolicy is deny", async () => {

--- a/src/auto-reply/reply/dispatch-from-config.hooks-and-send-policy.test-utils.ts
+++ b/src/auto-reply/reply/dispatch-from-config.hooks-and-send-policy.test-utils.ts
@@ -575,8 +575,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
 
   it("delivers routed fallback when routing drops an empty final without sending", async () => {
     setNoAbort();
-    mocks.routeReply.mockResolvedValueOnce({ ok: true });
-    mocks.routeReply.mockResolvedValueOnce({ ok: true, messageId: "fallback-1" });
+    mocks.routeReply.mockResolvedValue({ ok: true, messageId: "fallback-1" });
     const dispatcher = createDispatcher();
     const replyResolver = vi.fn(async () => ({ text: "" }));
     const ctx = buildTestCtx({
@@ -617,8 +616,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
 
   it("keeps eligibility when an empty routed final precedes a suppressed fallback", async () => {
     setNoAbort();
-    mocks.routeReply.mockResolvedValueOnce({ ok: true });
-    mocks.routeReply.mockResolvedValueOnce({ ok: true, suppressed: true });
+    mocks.routeReply.mockResolvedValue({ ok: true, suppressed: true });
     const dispatcher = createDispatcher();
     const replyResolver = vi.fn(async () => ({ text: "" }));
     const ctx = buildTestCtx({
@@ -683,6 +681,50 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
     expect(result.queuedFinal).toBe(false);
     expect(result.noVisibleReplyFallbackDelivered).toBeUndefined();
     expect(result.noVisibleReplyFallbackEligible).toBe(true);
+  });
+
+  it("does not deliver no-visible fallback after a routed media-only block", async () => {
+    setNoAbort();
+    mocks.routeReply.mockResolvedValue({ ok: true, messageId: "media-block-1" });
+    const dispatcher = createDispatcher();
+    const replyResolver = vi.fn(async (_ctx: MsgContext, opts?: GetReplyOptions) => {
+      await opts?.onBlockReply?.({ mediaUrl: "https://example.com/seatmap.png" });
+      return undefined;
+    });
+    const ctx = buildTestCtx({
+      ChatType: "group",
+      Surface: "slack",
+      Provider: "slack",
+      OriginatingChannel: "telegram",
+      OriginatingTo: "telegram:999",
+      SessionKey: "agent:main:slack:group:oc_group",
+    });
+
+    const result = await dispatchReplyFromConfig({
+      ctx,
+      cfg: {
+        agents: {
+          defaults: {
+            silentReply: {
+              group: "disallow",
+            },
+          },
+        },
+      } as OpenClawConfig,
+      dispatcher,
+      replyResolver,
+    });
+
+    // A routed media-only block increments neither blockCount (text-only counter)
+    // nor dispatcher counts; the delivered-routed-block fact must suppress the
+    // fallback so users never see failure text after valid media.
+    const fallbackCall = mocks.routeReply.mock.calls.find(
+      (call) =>
+        (call[0] as { payload?: { text?: string } }).payload?.text ===
+        NO_VISIBLE_REPLY_FALLBACK_TEXT,
+    );
+    expect(fallbackCall).toBeUndefined();
+    expect(result.noVisibleReplyFallbackDelivered).toBeUndefined();
   });
 
   it("does not deliver no-visible fallback after streamed blocks invisible to dispatcher counts", async () => {

--- a/src/auto-reply/reply/dispatch-from-config.payloads.ts
+++ b/src/auto-reply/reply/dispatch-from-config.payloads.ts
@@ -15,6 +15,9 @@ import type { ReplyOperation } from "./reply-run-registry.js";
 
 const ttsRuntimeLoader = createLazyImportLoader(() => import("../../tts/tts.runtime.js"));
 
+export const NO_VISIBLE_REPLY_FALLBACK_TEXT =
+  "No reply was generated for this message. This is usually a temporary model failure - please try again.";
+
 export function createFinalDispatchPayloadDedupeKey(payload: ReplyPayload): string {
   const metadata = getReplyPayloadMetadata(payload);
   return JSON.stringify({

--- a/src/auto-reply/reply/dispatch-from-config.prepare-context.ts
+++ b/src/auto-reply/reply/dispatch-from-config.prepare-context.ts
@@ -224,7 +224,11 @@ export async function prepareDispatchOperationContext(state: PrepareDispatchDeli
   const chatType = normalizeChatType(ctx.ChatType);
   const silentReplyConversationType = resolveRoutedPolicyConversationType(ctx);
   const silentReplySurface = normalizeLowercaseStringOrEmpty(ctx.Surface ?? ctx.Provider);
+  // Group silent-reply policy sanctions silence for ambient chatter only. A turn
+  // that explicitly addressed the bot (mention) must never end silently, matching
+  // the hard-coded direct-chat rule in resolveSilentReplyPolicyFromPolicies.
   const emptyFinalAllowedAsSilent =
+    ctx.WasMentioned !== true &&
     silentReplyConversationType !== undefined &&
     resolveSilentReplyPolicyFromPolicies({
       conversationType: silentReplyConversationType,

--- a/src/auto-reply/reply/dispatch-from-config.shared.test-harness.ts
+++ b/src/auto-reply/reply/dispatch-from-config.shared.test-harness.ts
@@ -31,7 +31,14 @@ type PluginTargetedInboundClaimOutcome = Awaited<
 
 const mocks = vi.hoisted(() => ({
   isRoutableChannel: vi.fn((_channel: string | undefined) => true),
-  routeReply: vi.fn(async (_params: unknown) => ({ ok: true, messageId: "mock" })),
+  routeReply: vi.fn(
+    async (
+      _params: unknown,
+    ): Promise<{ ok: boolean; messageId?: string; suppressed?: boolean; error?: string }> => ({
+      ok: true,
+      messageId: "mock",
+    }),
+  ),
   tryFastAbortFromMessage: vi.fn<() => Promise<AbortResult>>(async () => ({
     handled: false,
     aborted: false,

--- a/src/auto-reply/reply/dispatch-from-config.test-harness.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test-harness.ts
@@ -594,6 +594,10 @@ export const describe1BeforeEach0 = () => {
 
 export const describe2BeforeEach0 = () => {
   resetInboundDedupe();
+  // Same routeReply reset as the sibling suite setups: queued once-values and
+  // persistent overrides must not leak between tests.
+  mocks.routeReply.mockReset();
+  mocks.routeReply.mockResolvedValue({ ok: true, messageId: "mock" });
   sessionStoreMocks.currentEntry = undefined;
   sessionBindingMocks.resolveByConversation.mockReset();
   sessionBindingMocks.resolveByConversation.mockReturnValue(null);

--- a/src/auto-reply/reply/dispatch-from-config.types.ts
+++ b/src/auto-reply/reply/dispatch-from-config.types.ts
@@ -15,6 +15,7 @@ export type DispatchFromConfigResult = {
   sendPolicyDenied?: boolean;
   observedReplyDelivery?: boolean;
   noVisibleReplyFallbackEligible?: boolean;
+  noVisibleReplyFallbackDelivered?: boolean;
   beforeAgentRunBlocked?: boolean;
   sessionMetadataChanges?: CommandSessionMetadataChange[];
 };


### PR DESCRIPTION
## What Problem This Solves

When an agent-backed visible channel turn ends with an empty model completion, the user gets nothing: no reply, no error. The gateway logs `visible channel turn dispatched with no queued reply payloads` (`src/channels/turn/execution.ts`) and moves on. On a production Telegram group this reproduced 10+ times in ~4.5 hours (gateway logs: turn runs normally, `outBytes=0` with the empty-string SHA-256, then the zero-payload warning; nothing is sent). The user cannot distinguish "bot is thinking" from "turn silently died".

Core already computes eligibility for a fallback — `noVisibleReplyFallbackEligible` in `src/auto-reply/reply/dispatch-from-config.finalize.ts` — but only the Feishu plugin ever consumed it. Every other channel silently drops the turn.

Related: #109186 / #89095 cover the sibling subagent completion path (PR #96189 adds a fallback there). This PR fixes the direct-turn path, which has no coverage today.

## Why This Change Was Made

A visible agent turn must never end silently; the configured `silentReply` policy is the only sanctioned silence. Instead of asking every channel to reimplement Feishu's consumer, the reply dispatcher itself now delivers the fallback:

- `finalizeDispatchAndAudit` synthesizes a final reply (`NO_VISIBLE_REPLY_FALLBACK_TEXT`) when the turn ends with no queued/routed final, no observed delivery, zero queued tool/block/final counts, silence not allowed by `silentReply` policy, delivery not suppressed, send policy not denied, and source delivery mode not `message_tool_only`. Delivery reuses the existing `routeReplyToOriginating` → `dispatcher.sendFinalReply` path (same shape as the TTS-only fallback in the same function).
- The result reports `noVisibleReplyFallbackDelivered: true`. `noVisibleReplyFallbackEligible` now keys off visible delivery rather than queue/route admission — an empty routed final that reports `ok` without sending no longer masks a failed fallback — and still surfaces whenever nothing visible was delivered, so channel-level transport fallbacks keep working.
- Feishu's consumer is untouched: core success clears `noVisibleReplyFallbackEligible` so the channel leg cannot double-send, and it still recovers when core's fallback fails to queue or is hook-suppressed.
- The zero-payload warning in `src/channels/turn/execution.ts` stays untouched as the backstop invariant signal.

## User Impact

Users on every channel (Telegram, Discord, WhatsApp, …) now receive "No reply was generated for this message. This is usually a temporary model failure - please try again." instead of silence when a model returns an empty completion. Operators keep intentional silence via the existing `silentReply` config; `message_tool_only` agents and `sendPolicy: deny` sessions are unaffected. Feishu behavior is unchanged (fallback now comes from core instead of the plugin).

## Evidence

- `node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-from-config` — 336/336 pass, including 11 new cases: fallback delivered on empty turn; suppressed by `silentReply: allow`, `sendPolicy: deny`, `message_tool_only`, observed streamed delivery, queued/streamed block visibility (including blocks invisible to dispatcher counts); routed empty finals that report `ok` without sending still get the fallback; hook-suppressed routed fallbacks are not reported as delivered; eligibility survives failed/suppressed fallbacks for channel-level recovery.
- `node scripts/run-vitest.mjs extensions/feishu/src/bot` — 184/184 pass (Feishu unchanged).
- `git diff --check` clean; formatted with repo oxfmt.
- Production repro evidence (operator gateway logs, 2026-07-22): repeated `visible channel turn dispatched with no queued reply payloads` on session `agent:main:telegram:group:…` with `outBytes=0`, no outbound send, no error surfaced.


## Real Behavior Proof (live gateway)

Isolated dev gateway built from this branch (`OPENCLAW_STATE_DIR` tempdir, loopback :18939), mock Telegram Bot API capturing every outbound send, mock `openai-completions` provider. Group chat, message explicitly mentions the bot, **default config — no `silentReply` override**.

**Run 1 — empty completion:** model streams role delta + `finish_reason: stop` with zero content. Result: exactly one outbound `sendMessage`, containing exactly the fallback text; no duplicates, nothing else sent.

```json
{ "mode": "empty-completion", "llmCalls": 1, "totalSends": 1, "fallbackCount": 1,
  "fallbackExactlyOnce": true,
  "sends": [ { "method": "sendMessage", "text": "No reply was generated for this message. This is usually a temporary model failure - please try again." } ] }
```

**Run 2 — normal-reply control:** identical setup, model returns a real answer. Result: exactly one normal reply, zero fallbacks.

```json
{ "mode": "normal-reply-control", "llmCalls": 1, "totalSends": 1, "fallbackCount": 0,
  "normalReplyDelivered": true, "noFallbackAfterVisibleReply": true,
  "sends": [ { "method": "sendMessage", "text": "REPLY: 2+2 equals 4." } ] }
```

The media-only routed-block corner (prior review P1) is fixed in-branch — routed block deliveries now count as visible via the settled `deliveredBlockContentKeys` fact — with a focused regression test (`does not deliver no-visible fallback after a routed media-only block`).

**The live proof also caught a product gap unit tests missed:** the default group `silentReply` policy ("allow") swallowed the fallback for *mentioned* group turns — the exact reported production case. Fixed: a mention is a directed turn and is now exempt from sanctioned group silence, mirroring the hard-coded direct-chat rule; ambient group turns keep NO_REPLY silence (both covered by new tests and the live runs above).

## Known Accepted Tradeoffs

Dispatch has no unified settled-delivery signal today; this PR keys the gate off the strongest available visibility facts (contentful routed delivery, settled routed-block deliveries, queued counts, `blockCount`, block dedupe, observed delivery). Three admission-vs-delivery corners remain, shared with every sibling path in `finalizeDispatchAndAudit` (TTS-only fallback, final-reply loop):

- a contentful routed final returning `{ ok: true, suppressed: true }` counts as visible (silent, same as `main` today);
- `blockCount` counts generated blocks, so a failed/suppressed streamed block suppresses the fallback (silent, same as `main` today);
- `dispatcher.sendFinalReply` admission can still be cancelled by a `beforeDeliver` hook after `noVisibleReplyFallbackDelivered` is set (silent, same as `main` today).

In every corner, current `main` behaves identically (silence) — this PR never regresses a delivered reply, and fixes the dominant empty-completion class. The clean fix for all three is one unified visible-delivery signal (turn-ledger contract), tracked as follow-up work rather than another inference layer here.
