### PR TITLE
fix(telegram): release validation stalls in isolated test runs

### DIFF
--- a/extensions/telegram/src/bot-handlers.message-events.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.message-events.runtime.ts
@@ -22,7 +22,7 @@ import type { TelegramContext, TelegramGetChat } from "./bot/types.js";
 import type { TelegramMessageDispatchReplayClaim } from "./message-dispatch-dedupe.js";
 
 export function registerTelegramMessageHandlers(
-  { bot, runtime, shouldSkipUpdate }: RegisterTelegramHandlerParams,
+  { bot, opts, runtime, shouldSkipUpdate }: RegisterTelegramHandlerParams,
   messageRuntime: TelegramHandlerMessageRuntime,
   authorizationRuntime: TelegramHandlerAuthorizationRuntime,
   inboundRuntime: TelegramHandlerInboundRuntime,
@@ -40,6 +40,13 @@ export function registerTelegramMessageHandlers(
   const { authorizeInboundMessage } = authorizationRuntime;
   const { processInboundMessage } = inboundRuntime;
   const getChat: TelegramGetChat = bot.api.getChat.bind(bot.api);
+  const resolveBotUserId = (ctx: { me?: { id?: number } }): number => {
+    const botUserId = ctx.me?.id ?? opts.botInfo?.id;
+    if (botUserId == null) {
+      throw new Error("Telegram bot identity is unavailable");
+    }
+    return botUserId;
+  };
   type InboundTelegramEvent = {
     ctxForDedupe: TelegramUpdateKeyContext;
     ctx: TelegramContext;
@@ -247,15 +254,16 @@ export function registerTelegramMessageHandlers(
       getChat,
     });
     const normalizedMsg = withResolvedTelegramForumFlag(msg, isForum);
+    const botUserId = resolveBotUserId(ctx);
     // Bot-authored message updates can be echoed back by Telegram. Skip them here
     // and rely on the dedicated channel_post handler for channel-originated posts.
-    if (normalizedMsg.from?.id != null && normalizedMsg.from.id === ctx.me?.id) {
+    if (normalizedMsg.from?.id != null && normalizedMsg.from.id === botUserId) {
       return;
     }
     await handleInboundMessageLike({
       ctxForDedupe: ctx,
       ctx: buildSyntheticContext(ctx, normalizedMsg),
-      botUserId: ctx.me.id,
+      botUserId,
       msg: normalizedMsg,
       chatId: normalizedMsg.chat.id,
       isGroup,
@@ -279,7 +287,7 @@ export function registerTelegramMessageHandlers(
       ctxForDedupe: ctx,
       msg,
       requireConfiguredGroup: false,
-      botUserId: ctx.me.id,
+      botUserId: resolveBotUserId(ctx),
     });
   });
 
@@ -298,7 +306,7 @@ export function registerTelegramMessageHandlers(
     await handleInboundMessageLike({
       ctxForDedupe: ctx,
       ctx: buildSyntheticContext(ctx, syntheticMsg),
-      botUserId: ctx.me.id,
+      botUserId: resolveBotUserId(ctx),
       msg: syntheticMsg,
       chatId,
       isGroup: true,
@@ -326,7 +334,7 @@ export function registerTelegramMessageHandlers(
       ctxForDedupe: ctx,
       msg: normalizeChannelPostMessage(post),
       requireConfiguredGroup: true,
-      botUserId: ctx.me.id,
+      botUserId: resolveBotUserId(ctx),
     });
   });
 }

--- a/extensions/telegram/src/bot.create-telegram-bot.channel-post-media.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.channel-post-media.test.ts
@@ -57,8 +57,14 @@ vi.mock("./sticker-cache.js", () => ({
 }));
 
 const harness = await import("./bot.create-telegram-bot.test-harness.js");
-const { getLoadConfigMock, getOnHandler, replySpy, sendMessageSpy, telegramBotDepsForTest } =
-  harness;
+const {
+  getLoadConfigMock,
+  getOnHandler,
+  replySpy,
+  sendMessageSpy,
+  telegramBotDepsForTest,
+  telegramBotInfoForTest,
+} = harness;
 const { createTelegramBotCore: createTelegramBotBase } = await import("./bot-core.js");
 const { runWithTelegramSpooledReplayUpdate, runWithTelegramUpdateProcessingFrame } =
   await import("./bot-processing-outcome.js");
@@ -74,6 +80,7 @@ const TELEGRAM_TEST_TIMINGS = {
   mediaGroupFlushMs: 20,
   textFragmentGapMs: 30,
 } as const;
+const TEXT_FRAGMENT_COALESCE_TEST_GAP_MS = 5_000;
 
 async function withTelegramSpooledReplayUpdate<T>(
   update: object,
@@ -98,8 +105,8 @@ function setOpenChannelPostConfig() {
   });
 }
 
-function getChannelPostHandler() {
-  createTelegramBot({ token: "tok", testTimings: TELEGRAM_TEST_TIMINGS });
+function getChannelPostHandler(testTimings = TELEGRAM_TEST_TIMINGS) {
+  createTelegramBot({ token: "tok", testTimings });
   return getOnHandler("channel_post") as (ctx: Record<string, unknown>) => Promise<void>;
 }
 
@@ -247,6 +254,7 @@ describe("createTelegramBot channel_post media", () => {
   beforeAll(() => {
     createTelegramBot = (opts) =>
       createTelegramBotBase({
+        botInfo: telegramBotInfoForTest,
         ...opts,
         telegramDeps: telegramBotDepsForTest,
       });
@@ -304,7 +312,10 @@ describe("createTelegramBot channel_post media", () => {
 
     const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
     try {
-      const handler = getChannelPostHandler();
+      const handler = getChannelPostHandler({
+        ...TELEGRAM_TEST_TIMINGS,
+        textFragmentGapMs: TEXT_FRAGMENT_COALESCE_TEST_GAP_MS,
+      });
 
       const part1 = "A".repeat(4050);
       const part2 = "B".repeat(50);
@@ -332,10 +343,7 @@ describe("createTelegramBot channel_post media", () => {
       });
 
       expect(replySpy).not.toHaveBeenCalled();
-      await flushChannelPostMediaGroupForDelay(
-        setTimeoutSpy,
-        TELEGRAM_TEST_TIMINGS.textFragmentGapMs,
-      );
+      await flushChannelPostMediaGroupForDelay(setTimeoutSpy, TEXT_FRAGMENT_COALESCE_TEST_GAP_MS);
 
       await vi.waitFor(() => expect(replySpy).toHaveBeenCalledTimes(1));
       const payload = replyPayload() as { RawBody?: string };

--- a/extensions/telegram/src/bot.create-telegram-bot.channel-post-media.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.channel-post-media.test.ts
@@ -2,6 +2,7 @@
 import { setTimeout as delay } from "node:timers/promises";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { telegramBotInfoForTest } from "./bot.create-telegram-bot.test-support.js";
 
 const saveRemoteMedia = vi.fn();
 const saveMediaBuffer = vi.fn();
@@ -57,14 +58,8 @@ vi.mock("./sticker-cache.js", () => ({
 }));
 
 const harness = await import("./bot.create-telegram-bot.test-harness.js");
-const {
-  getLoadConfigMock,
-  getOnHandler,
-  replySpy,
-  sendMessageSpy,
-  telegramBotDepsForTest,
-  telegramBotInfoForTest,
-} = harness;
+const { getLoadConfigMock, getOnHandler, replySpy, sendMessageSpy, telegramBotDepsForTest } =
+  harness;
 const { createTelegramBotCore: createTelegramBotBase } = await import("./bot-core.js");
 const { runWithTelegramSpooledReplayUpdate, runWithTelegramUpdateProcessingFrame } =
   await import("./bot-processing-outcome.js");
@@ -105,7 +100,9 @@ function setOpenChannelPostConfig() {
   });
 }
 
-function getChannelPostHandler(testTimings = TELEGRAM_TEST_TIMINGS) {
+function getChannelPostHandler(
+  testTimings: { mediaGroupFlushMs: number; textFragmentGapMs: number } = TELEGRAM_TEST_TIMINGS,
+) {
   createTelegramBot({ token: "tok", testTimings });
   return getOnHandler("channel_post") as (ctx: Record<string, unknown>) => Promise<void>;
 }

--- a/extensions/telegram/src/bot.create-telegram-bot.media-group-skip-warning.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.media-group-skip-warning.test.ts
@@ -43,8 +43,14 @@ vi.mock("./sticker-cache.js", () => ({
 }));
 
 const harness = await import("./bot.create-telegram-bot.test-harness.js");
-const { getLoadConfigMock, getOnHandler, replySpy, sendMessageSpy, telegramBotDepsForTest } =
-  harness;
+const {
+  getLoadConfigMock,
+  getOnHandler,
+  replySpy,
+  sendMessageSpy,
+  telegramBotDepsForTest,
+  telegramBotInfoForTest,
+} = harness;
 const { createTelegramBotCore: createTelegramBotBase } = await import("./bot-core.js");
 const { MediaFetchError } = await import("./telegram-media.runtime.js");
 
@@ -167,6 +173,7 @@ describe("createTelegramBot media-group skip warning (#55216)", () => {
   beforeAll(() => {
     createTelegramBot = (opts) =>
       createTelegramBotBase({
+        botInfo: telegramBotInfoForTest,
         ...opts,
         telegramDeps: telegramBotDepsForTest,
       });

--- a/extensions/telegram/src/bot.create-telegram-bot.media-group-skip-warning.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.media-group-skip-warning.test.ts
@@ -1,6 +1,7 @@
 // Telegram tests cover bot.create telegram bot.media group skip warning plugin behavior.
 import { setTimeout as delay } from "node:timers/promises";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { telegramBotInfoForTest } from "./bot.create-telegram-bot.test-support.js";
 
 const saveRemoteMedia = vi.fn();
 const saveMediaBuffer = vi.fn();
@@ -43,14 +44,8 @@ vi.mock("./sticker-cache.js", () => ({
 }));
 
 const harness = await import("./bot.create-telegram-bot.test-harness.js");
-const {
-  getLoadConfigMock,
-  getOnHandler,
-  replySpy,
-  sendMessageSpy,
-  telegramBotDepsForTest,
-  telegramBotInfoForTest,
-} = harness;
+const { getLoadConfigMock, getOnHandler, replySpy, sendMessageSpy, telegramBotDepsForTest } =
+  harness;
 const { createTelegramBotCore: createTelegramBotBase } = await import("./bot-core.js");
 const { MediaFetchError } = await import("./telegram-media.runtime.js");
 

--- a/extensions/telegram/src/bot.create-telegram-bot.test-harness.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test-harness.ts
@@ -7,6 +7,7 @@ import type { MockFn } from "openclaw/plugin-sdk/plugin-test-runtime";
 import type { GetReplyOptions, MsgContext } from "openclaw/plugin-sdk/reply-runtime";
 import { beforeEach, vi } from "vitest";
 import type { TelegramBotDeps } from "./bot-deps.js";
+import type { TelegramBotInfo } from "./bot-info.js";
 import { runTelegramChannelInboundEventWithHarness } from "./bot.test-helpers.js";
 
 type AnyMock = ReturnType<typeof vi.fn>;
@@ -30,6 +31,8 @@ type DispatchReplyWithBufferedBlockDispatcherFn =
 type DispatchReplyWithBufferedBlockDispatcherResult = Awaited<
   ReturnType<DispatchReplyWithBufferedBlockDispatcherFn>
 >;
+type DispatchChannelInboundTurnFn =
+  typeof import("openclaw/plugin-sdk/channel-inbound").dispatchChannelInboundTurn;
 type DispatchReplyHarnessParams = Parameters<DispatchReplyWithBufferedBlockDispatcherFn>[0];
 type ReplyPayloadLike = {
   text?: string;
@@ -39,6 +42,22 @@ type ReplyPayloadLike = {
 };
 type ReplySpyResult = ReplyPayloadLike | ReplyPayloadLike[] | undefined;
 type ReplySpy = (ctx: MsgContext, opts?: GetReplyOptions) => Promise<ReplySpyResult>;
+
+export const telegramBotInfoForTest = {
+  id: 9_876_543_210,
+  is_bot: true,
+  first_name: "OpenClaw",
+  username: "openclaw_bot",
+  can_join_groups: true,
+  can_read_all_group_messages: false,
+  can_manage_bots: false,
+  supports_inline_queries: false,
+  supports_join_request_queries: false,
+  can_connect_to_business: false,
+  has_main_web_app: false,
+  has_topics_enabled: false,
+  allows_users_to_create_topics: false,
+} satisfies TelegramBotInfo;
 
 const { sessionStorePath } = vi.hoisted(() => {
   const tempRoot =
@@ -205,6 +224,28 @@ const dispatchReplyHoisted = vi.hoisted(() => ({
 }));
 export const dispatchReplyWithBufferedBlockDispatcher =
   dispatchReplyHoisted.dispatchReplyWithBufferedBlockDispatcher;
+const dispatchChannelInboundTurnForTest: DispatchChannelInboundTurnFn = async (plan) => {
+  const dispatchResult = await dispatchReplyWithBufferedBlockDispatcher({
+    ctx: plan.ctxPayload,
+    cfg: plan.cfg,
+    dispatcherOptions: {
+      ...plan.dispatcherOptions,
+      deliver:
+        "deliverWithProviderMessageSending" in plan.delivery
+          ? plan.delivery.deliverWithProviderMessageSending
+          : plan.delivery.deliver,
+      onError: plan.delivery.onError,
+    },
+    replyOptions: plan.replyOptions,
+  });
+  return {
+    admission: { kind: "dispatch" },
+    dispatched: true,
+    ctxPayload: plan.ctxPayload,
+    routeSessionKey: plan.route.sessionKey,
+    dispatchResult,
+  };
+};
 vi.mock("../../../src/auto-reply/reply/provider-dispatcher.js", () => ({
   dispatchReplyWithBufferedBlockDispatcher:
     dispatchReplyHoisted.dispatchReplyWithBufferedBlockDispatcher,
@@ -505,7 +546,9 @@ const telegramBotRuntimeForTest = {
       runnerHoisted.throttlerSpy as unknown as () => unknown
     )()) as unknown as TelegramBotRuntimeForTest["apiThrottler"],
 };
-export const telegramBotDepsForTest: TelegramBotDeps = {
+export const telegramBotDepsForTest: TelegramBotDeps & {
+  dispatchChannelInboundTurn: DispatchChannelInboundTurnFn;
+} = {
   getRuntimeConfig,
   getSessionEntry: getSessionEntryMock,
   listSessionEntries: listSessionEntriesMock,
@@ -523,6 +566,7 @@ export const telegramBotDepsForTest: TelegramBotDeps = {
     upsertChannelPairingRequest as TelegramBotDeps["upsertChannelPairingRequest"],
   enqueueSystemEvent: enqueueSystemEventSpy as TelegramBotDeps["enqueueSystemEvent"],
   dispatchReplyWithBufferedBlockDispatcher,
+  dispatchChannelInboundTurn: dispatchChannelInboundTurnForTest,
   loadWebMedia: loadWebMedia as TelegramBotDeps["loadWebMedia"],
   buildModelsProviderData: buildModelsProviderData as TelegramBotDeps["buildModelsProviderData"],
   listSkillCommandsForAgents:

--- a/extensions/telegram/src/bot.create-telegram-bot.test-harness.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test-harness.ts
@@ -7,7 +7,6 @@ import type { MockFn } from "openclaw/plugin-sdk/plugin-test-runtime";
 import type { GetReplyOptions, MsgContext } from "openclaw/plugin-sdk/reply-runtime";
 import { beforeEach, vi } from "vitest";
 import type { TelegramBotDeps } from "./bot-deps.js";
-import type { TelegramBotInfo } from "./bot-info.js";
 import { runTelegramChannelInboundEventWithHarness } from "./bot.test-helpers.js";
 
 type AnyMock = ReturnType<typeof vi.fn>;
@@ -31,8 +30,6 @@ type DispatchReplyWithBufferedBlockDispatcherFn =
 type DispatchReplyWithBufferedBlockDispatcherResult = Awaited<
   ReturnType<DispatchReplyWithBufferedBlockDispatcherFn>
 >;
-type DispatchChannelInboundTurnFn =
-  typeof import("openclaw/plugin-sdk/channel-inbound").dispatchChannelInboundTurn;
 type DispatchReplyHarnessParams = Parameters<DispatchReplyWithBufferedBlockDispatcherFn>[0];
 type ReplyPayloadLike = {
   text?: string;
@@ -42,22 +39,6 @@ type ReplyPayloadLike = {
 };
 type ReplySpyResult = ReplyPayloadLike | ReplyPayloadLike[] | undefined;
 type ReplySpy = (ctx: MsgContext, opts?: GetReplyOptions) => Promise<ReplySpyResult>;
-
-export const telegramBotInfoForTest = {
-  id: 9_876_543_210,
-  is_bot: true,
-  first_name: "OpenClaw",
-  username: "openclaw_bot",
-  can_join_groups: true,
-  can_read_all_group_messages: false,
-  can_manage_bots: false,
-  supports_inline_queries: false,
-  supports_join_request_queries: false,
-  can_connect_to_business: false,
-  has_main_web_app: false,
-  has_topics_enabled: false,
-  allows_users_to_create_topics: false,
-} satisfies TelegramBotInfo;
 
 const { sessionStorePath } = vi.hoisted(() => {
   const tempRoot =
@@ -224,28 +205,6 @@ const dispatchReplyHoisted = vi.hoisted(() => ({
 }));
 export const dispatchReplyWithBufferedBlockDispatcher =
   dispatchReplyHoisted.dispatchReplyWithBufferedBlockDispatcher;
-const dispatchChannelInboundTurnForTest: DispatchChannelInboundTurnFn = async (plan) => {
-  const dispatchResult = await dispatchReplyWithBufferedBlockDispatcher({
-    ctx: plan.ctxPayload,
-    cfg: plan.cfg,
-    dispatcherOptions: {
-      ...plan.dispatcherOptions,
-      deliver:
-        "deliverWithProviderMessageSending" in plan.delivery
-          ? plan.delivery.deliverWithProviderMessageSending
-          : plan.delivery.deliver,
-      onError: plan.delivery.onError,
-    },
-    replyOptions: plan.replyOptions,
-  });
-  return {
-    admission: { kind: "dispatch" },
-    dispatched: true,
-    ctxPayload: plan.ctxPayload,
-    routeSessionKey: plan.route.sessionKey,
-    dispatchResult,
-  };
-};
 vi.mock("../../../src/auto-reply/reply/provider-dispatcher.js", () => ({
   dispatchReplyWithBufferedBlockDispatcher:
     dispatchReplyHoisted.dispatchReplyWithBufferedBlockDispatcher,
@@ -546,9 +505,7 @@ const telegramBotRuntimeForTest = {
       runnerHoisted.throttlerSpy as unknown as () => unknown
     )()) as unknown as TelegramBotRuntimeForTest["apiThrottler"],
 };
-export const telegramBotDepsForTest: TelegramBotDeps & {
-  dispatchChannelInboundTurn: DispatchChannelInboundTurnFn;
-} = {
+export const telegramBotDepsForTest: TelegramBotDeps = {
   getRuntimeConfig,
   getSessionEntry: getSessionEntryMock,
   listSessionEntries: listSessionEntriesMock,
@@ -566,7 +523,6 @@ export const telegramBotDepsForTest: TelegramBotDeps & {
     upsertChannelPairingRequest as TelegramBotDeps["upsertChannelPairingRequest"],
   enqueueSystemEvent: enqueueSystemEventSpy as TelegramBotDeps["enqueueSystemEvent"],
   dispatchReplyWithBufferedBlockDispatcher,
-  dispatchChannelInboundTurn: dispatchChannelInboundTurnForTest,
   loadWebMedia: loadWebMedia as TelegramBotDeps["loadWebMedia"],
   buildModelsProviderData: buildModelsProviderData as TelegramBotDeps["buildModelsProviderData"],
   listSkillCommandsForAgents:

--- a/extensions/telegram/src/bot.create-telegram-bot.test-support.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test-support.ts
@@ -1,0 +1,51 @@
+import type { TelegramBotInfo } from "./bot-info.js";
+
+type DispatchReplyWithBufferedBlockDispatcher =
+  typeof import("openclaw/plugin-sdk/reply-dispatch-runtime").dispatchReplyWithBufferedBlockDispatcher;
+type DispatchChannelInboundTurn =
+  typeof import("openclaw/plugin-sdk/channel-inbound").dispatchChannelInboundTurn;
+
+export const telegramBotInfoForTest = {
+  id: 9_876_543_210,
+  is_bot: true,
+  first_name: "OpenClaw",
+  username: "openclaw_bot",
+  can_join_groups: true,
+  can_read_all_group_messages: false,
+  can_manage_bots: false,
+  supports_inline_queries: false,
+  supports_join_request_queries: false,
+  can_connect_to_business: false,
+  has_main_web_app: false,
+  has_topics_enabled: false,
+  allows_users_to_create_topics: false,
+} satisfies TelegramBotInfo;
+
+export function createTelegramNativeCommandTestDeps(
+  dispatchReply: DispatchReplyWithBufferedBlockDispatcher,
+): { dispatchChannelInboundTurn: DispatchChannelInboundTurn } {
+  return {
+    dispatchChannelInboundTurn: async (plan) => {
+      const dispatchResult = await dispatchReply({
+        ctx: plan.ctxPayload,
+        cfg: plan.cfg,
+        dispatcherOptions: {
+          ...plan.dispatcherOptions,
+          deliver:
+            "deliverWithProviderMessageSending" in plan.delivery
+              ? plan.delivery.deliverWithProviderMessageSending
+              : plan.delivery.deliver,
+          onError: plan.delivery.onError,
+        },
+        replyOptions: plan.replyOptions,
+      });
+      return {
+        admission: { kind: "dispatch" },
+        dispatched: true,
+        ctxPayload: plan.ctxPayload,
+        routeSessionKey: plan.route.sessionKey,
+        dispatchResult,
+      };
+    },
+  };
+}

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -65,6 +65,7 @@ const {
   setSessionStoreEntriesForTest,
   setMessageReactionSpy,
   setMyCommandsSpy,
+  telegramBotInfoForTest,
   telegramBotDepsForTest,
   throttlerSpy,
   useSpy,
@@ -435,6 +436,7 @@ describe("createTelegramBot", () => {
     throttlerSpy.mockReset();
     createTelegramBot = (opts) =>
       createTelegramBotBase({
+        botInfo: telegramBotInfoForTest,
         ...opts,
         telegramDeps: telegramBotDepsForTest,
       });

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -17,6 +17,7 @@ import type { GetReplyOptions, MsgContext } from "openclaw/plugin-sdk/reply-runt
 import { withEnvAsync } from "openclaw/plugin-sdk/test-env";
 import { sanitizeTerminalText } from "openclaw/plugin-sdk/test-fixtures";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { telegramBotInfoForTest } from "./bot.create-telegram-bot.test-support.js";
 import {
   createTelegramCallbackContext,
   runTelegramTestMiddlewareChain,
@@ -65,7 +66,6 @@ const {
   setSessionStoreEntriesForTest,
   setMessageReactionSpy,
   setMyCommandsSpy,
-  telegramBotInfoForTest,
   telegramBotDepsForTest,
   throttlerSpy,
   useSpy,

--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -97,6 +97,7 @@ const {
   resolveExecApprovalSpy,
   sendMessageSpy,
   setMyCommandsSpy,
+  telegramBotInfoForTest,
   telegramBotDepsForTest,
   wasSentByBot,
 } = await import("./bot.create-telegram-bot.test-harness.js");
@@ -120,7 +121,6 @@ const FIRE_EMOJI = "\u{1F525}";
 const PARTY_EMOJI = "\u{1F389}";
 const EYES_EMOJI = "\u{1F440}";
 const HEART_EMOJI = "\u{2764}\u{FE0F}";
-
 async function withTelegramSpooledReplayUpdate<T>(
   update: object,
   fn: () => Promise<T>,
@@ -633,6 +633,7 @@ describe("createTelegramBot", () => {
     });
     createTelegramBot = (opts) =>
       createTelegramBotBase({
+        botInfo: telegramBotInfoForTest,
         ...opts,
         telegramDeps: telegramBotDepsForTest,
       });
@@ -4764,7 +4765,7 @@ describe("createTelegramBot", () => {
         chat: { id: 7, type: "private" },
         text: "hey",
         date: 1736380800,
-        from: { id: 999, first_name: "Eve" },
+        from: { id: 123, first_name: "Eve" },
         reply_to_message: {
           message_id: 9001,
           photo: [{ file_id: "reply-photo-1" }],
@@ -5980,21 +5981,21 @@ describe("createTelegramBot", () => {
     {
       name: "keeps unconfigured dm topic commands on the flat dm session",
       messageThreadId: 99,
-      me: undefined,
+      me: { id: 999, has_topics_enabled: false },
       expectedSessionKey: "agent:main:main",
       assertAuthorized: false,
     },
     {
       name: "uses bot topic capability for native dm topic command target sessions",
       messageThreadId: 99,
-      me: { has_topics_enabled: true },
+      me: { id: 999, has_topics_enabled: true },
       expectedSessionKey: "agent:main:main:thread:12345:99",
       assertAuthorized: false,
     },
     {
       name: "allows native DM commands for paired users",
       messageThreadId: undefined,
-      me: undefined,
+      me: { id: 999, has_topics_enabled: false },
       expectedSessionKey: undefined,
       assertAuthorized: true,
     },

--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -21,6 +21,7 @@ import { mockPinnedHostnameResolution } from "openclaw/plugin-sdk/test-env";
 import { createOpenClawTestState, type OpenClawTestState } from "openclaw/plugin-sdk/test-state";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { buildTelegramApprovalCallbackData } from "./approval-callback-data.js";
+import type { TelegramBotDeps } from "./bot-deps.js";
 import {
   createTelegramNativeCommandTestDeps,
   telegramBotInfoForTest,

--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -21,7 +21,10 @@ import { mockPinnedHostnameResolution } from "openclaw/plugin-sdk/test-env";
 import { createOpenClawTestState, type OpenClawTestState } from "openclaw/plugin-sdk/test-state";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { buildTelegramApprovalCallbackData } from "./approval-callback-data.js";
-import type { TelegramBotDeps } from "./bot-deps.js";
+import {
+  createTelegramNativeCommandTestDeps,
+  telegramBotInfoForTest,
+} from "./bot.create-telegram-bot.test-support.js";
 import {
   createTelegramCallbackContext,
   createTelegramReactionContext,
@@ -97,7 +100,6 @@ const {
   resolveExecApprovalSpy,
   sendMessageSpy,
   setMyCommandsSpy,
-  telegramBotInfoForTest,
   telegramBotDepsForTest,
   wasSentByBot,
 } = await import("./bot.create-telegram-bot.test-harness.js");
@@ -631,11 +633,15 @@ describe("createTelegramBot", () => {
         telegram: { dmPolicy: "open", allowFrom: ["*"] },
       },
     });
+    const telegramDeps = {
+      ...telegramBotDepsForTest,
+      ...createTelegramNativeCommandTestDeps(dispatchReplyWithBufferedBlockDispatcher),
+    };
     createTelegramBot = (opts) =>
       createTelegramBotBase({
         botInfo: telegramBotInfoForTest,
         ...opts,
-        telegramDeps: telegramBotDepsForTest,
+        telegramDeps,
       });
   });
 

--- a/extensions/telegram/src/fetch.test.ts
+++ b/extensions/telegram/src/fetch.test.ts
@@ -328,7 +328,9 @@ async function expectPinnedFallbackIpDispatcher(callIndex: number) {
       | ((hostname: string, callback: (err: null, address: string, family: number) => void) => void)
       | undefined
   )?.("api.telegram.org", callback);
-  await new Promise<void>((resolve) => process.nextTick(resolve));
+  await new Promise<void>((resolve) => {
+    process.nextTick(resolve);
+  });
   expect(callback).toHaveBeenCalledWith(null, "149.154.167.220", 4);
 }
 

--- a/extensions/telegram/src/fetch.test.ts
+++ b/extensions/telegram/src/fetch.test.ts
@@ -317,7 +317,7 @@ function expectPinnedIpv4ConnectDispatcher(args: {
   }
 }
 
-function expectPinnedFallbackIpDispatcher(callIndex: number) {
+async function expectPinnedFallbackIpDispatcher(callIndex: number) {
   const dispatcher = getDispatcherFromUndiciCall(callIndex);
   expect(dispatcher?.options?.connect?.family).toBe(4);
   expect(dispatcher?.options?.connect?.autoSelectFamily).toBe(false);
@@ -328,6 +328,7 @@ function expectPinnedFallbackIpDispatcher(callIndex: number) {
       | ((hostname: string, callback: (err: null, address: string, family: number) => void) => void)
       | undefined
   )?.("api.telegram.org", callback);
+  await new Promise<void>((resolve) => process.nextTick(resolve));
   expect(callback).toHaveBeenCalledWith(null, "149.154.167.220", 4);
 }
 
@@ -961,7 +962,7 @@ describe("resolveTelegramFetch", () => {
     expect(thirdDispatcher).toBe(seventhDispatcher);
     expect(eighthDispatcher).toBe(firstDispatcher);
     expect(ninthDispatcher).toBe(firstDispatcher);
-    expectPinnedFallbackIpDispatcher(3);
+    await expectPinnedFallbackIpDispatcher(3);
     expectLoggerMessageContaining(loggerWarn, "fetch fallback: primary connection path failed");
     expectLoggerMessageContaining(
       loggerDebug,
@@ -1027,7 +1028,7 @@ describe("resolveTelegramFetch", () => {
     await resolved("https://api.telegram.org/botx/getMe");
 
     expect(undiciFetch).toHaveBeenCalledTimes(4);
-    expectPinnedFallbackIpDispatcher(3);
+    await expectPinnedFallbackIpDispatcher(3);
     expect(getDispatcherFromUndiciCall(4)).toBe(getDispatcherFromUndiciCall(3));
   });
 

--- a/test/vitest-scoped-config.test.ts
+++ b/test/vitest-scoped-config.test.ts
@@ -714,8 +714,8 @@ describe("scoped vitest configs", () => {
     expectThreadedNonIsolatedRunner(defaultExtensionsConfig);
   });
 
-  it("serializes Telegram extension files that share process globals", () => {
-    expectThreadedNonIsolatedRunner(defaultExtensionTelegramConfig);
+  it("serializes and isolates Telegram extension files with conflicting mocks", () => {
+    expectThreadedIsolatedRunner(defaultExtensionTelegramConfig);
     expect(requireTestConfig(defaultExtensionTelegramConfig).fileParallelism).toBe(false);
   });
 

--- a/test/vitest/vitest.extension-telegram.config.ts
+++ b/test/vitest/vitest.extension-telegram.config.ts
@@ -19,6 +19,7 @@ export function createExtensionTelegramVitestConfig(
       dir: "extensions",
       env,
       fileParallelism: false,
+      isolate: true,
       name: "extension-telegram",
       passWithNoTests: true,
       setupFiles: ["test/setup.extensions.ts"],


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Full Release Validation could hang or fail in the Telegram Plugin Prerelease lane because serial test files still shared mocked module state. Isolated execution then exposed fixtures that omitted the startup bot identity, borrowed a native-command dispatch mock from another file, raced a 30 ms coalescing timer, or assumed a synchronous DNS lookup callback.

## Why This Change Was Made

Telegram test files now run serially with independent module graphs. The shared bot harness supplies realistic startup metadata and a test-owned native-command dispatcher, while message handlers fall back to the already-resolved startup `botInfo` when a synthetic context lacks `ctx.me.id`. Timing and pinned-DNS assertions now follow their actual asynchronous contracts.

## User Impact

Release validation no longer stalls or fails because of cross-file Telegram mock leakage. Runtime behavior is unchanged except that message handlers can use the startup-probed bot identity when grammY context metadata is temporarily unavailable.

## Evidence

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-telegram.config.ts --configLoader runner --reporter=dot` — 176 files and 2,923 tests passed.
- `node scripts/run-vitest.mjs test/vitest-scoped-config.test.ts --reporter=dot` — 97 tests passed.
- `git diff --check` — clean.
- Autoreview: clean, no accepted/actionable findings.

AI-assisted; the complete diff and test behavior were reviewed before submission.
