### PR TITLE
fix(plugins): enforce manifest kinds for exclusive slots

### DIFF
--- a/src/plugins/manifest.json5-tolerance.test.ts
+++ b/src/plugins/manifest.json5-tolerance.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import JSON5 from "json5";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { resolveMemorySlotDecision } from "./config-state.js";
 import { loadPluginManifest } from "./manifest.js";
 import { cleanupTrackedTempDirs, makeTrackedTempDir } from "./test-helpers/fs-fixtures.js";
 
@@ -119,6 +120,100 @@ describe("loadPluginManifest JSON5 tolerance", () => {
     expect(result.ok).toBe(true);
     if (result.ok) {
       expect(result.manifest.id).toBe("unquoted-keys");
+    }
+  });
+
+  it.each([
+    {
+      name: "a supported memory kind",
+      rawKind: "memory",
+      expectedKind: "memory",
+    },
+    {
+      name: "a supported context-engine kind",
+      rawKind: "context-engine",
+      expectedKind: "context-engine",
+    },
+    {
+      name: "both supported kinds in declaration order",
+      rawKind: ["context-engine", "memory"],
+      expectedKind: ["context-engine", "memory"],
+    },
+    {
+      name: "duplicate memory kinds collapsed into one kind",
+      rawKind: ["memory", "memory"],
+      expectedKind: "memory",
+    },
+    {
+      name: "duplicate context-engine kinds collapsed into one kind",
+      rawKind: ["context-engine", "context-engine"],
+      expectedKind: "context-engine",
+    },
+    {
+      name: "supported kinds filtered from invalid and duplicate array entries",
+      rawKind: ["memory", "unknown-kind", 42, "memory", "context-engine", null],
+      expectedKind: ["memory", "context-engine"],
+    },
+    {
+      name: "a valid memory kind retained alongside invalid entries",
+      rawKind: ["unknown-kind", 42, "memory", null],
+      expectedKind: "memory",
+    },
+    {
+      name: "an unsupported scalar kind",
+      rawKind: "unknown-kind",
+      expectedKind: undefined,
+    },
+    {
+      name: "an array containing only unsupported kinds",
+      rawKind: ["unknown-kind", 42, null],
+      expectedKind: undefined,
+    },
+  ])("normalizes $name", ({ rawKind, expectedKind }) => {
+    const dir = makeTempDir();
+    fs.writeFileSync(
+      path.join(dir, "openclaw.plugin.json"),
+      JSON.stringify({
+        id: "kind-normalization",
+        kind: rawKind,
+        configSchema: { type: "object" },
+      }),
+      "utf-8",
+    );
+
+    const result = loadPluginManifest(dir, false);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.manifest.kind).toEqual(expectedKind);
+    }
+  });
+
+  it("keeps duplicate memory declarations subject to the exclusive memory slot", () => {
+    const dir = makeTempDir();
+    fs.writeFileSync(
+      path.join(dir, "openclaw.plugin.json"),
+      JSON.stringify({
+        id: "duplicate-memory",
+        kind: ["memory", "memory"],
+        configSchema: { type: "object" },
+      }),
+      "utf-8",
+    );
+
+    const result = loadPluginManifest(dir, false);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.manifest.kind).toBe("memory");
+      expect(
+        resolveMemorySlotDecision({
+          id: result.manifest.id,
+          kind: result.manifest.kind,
+          slot: "memory-core",
+          selectedId: "memory-core",
+        }),
+      ).toEqual({ enabled: false, reason: 'memory slot set to "memory-core"' });
     }
   });
 

--- a/src/plugins/manifest.ts
+++ b/src/plugins/manifest.ts
@@ -29,6 +29,7 @@ const PLUGIN_MANIFEST_FILENAMES = [PLUGIN_MANIFEST_FILENAME] as const;
 const MAX_PLUGIN_MANIFEST_BYTES = 256 * 1024;
 const MAX_PLUGIN_MANIFEST_LOAD_CACHE_ENTRIES = 512;
 const CORE_RESERVED_PLUGIN_IDS = new Set(["node-mcp"]);
+const VALID_PLUGIN_KINDS: ReadonlySet<string> = new Set<PluginKind>(["memory", "context-engine"]);
 
 export function isCoreReservedPluginId(id: string): boolean {
   return CORE_RESERVED_PLUGIN_IDS.has(normalizePluginPolicyId(id));
@@ -109,13 +110,18 @@ function setCachedPluginManifestLoadResult(
 }
 
 function parsePluginKind(raw: unknown): PluginKind | PluginKind[] | undefined {
-  if (typeof raw === "string") {
-    return raw as PluginKind;
+  const values = typeof raw === "string" ? [raw] : Array.isArray(raw) ? raw : [];
+  const kinds: PluginKind[] = [];
+  for (const value of values) {
+    if (typeof value !== "string" || !VALID_PLUGIN_KINDS.has(value)) {
+      continue;
+    }
+    const kind = value as PluginKind;
+    if (!kinds.includes(kind)) {
+      kinds.push(kind);
+    }
   }
-  if (Array.isArray(raw) && raw.length > 0 && raw.every((k) => typeof k === "string")) {
-    return raw.length === 1 ? (raw[0] as PluginKind) : (raw as PluginKind[]);
-  }
-  return undefined;
+  return kinds.length === 0 ? undefined : kinds.length === 1 ? kinds[0] : kinds;
 }
 
 export function loadPluginManifest(


### PR DESCRIPTION
Closes #114321
Related: #114323

## What Problem This Solves

Fixes an issue where plugin users could load a memory plugin outside the configured exclusive memory slot when its manifest repeated the `memory` kind. Unsupported or malformed kind declarations could also hide supported capabilities or expose metadata outside the documented plugin-kind contract.

## Why This Change Was Made

Normalize kinds at the canonical manifest parsing boundary to the two documented and typed values, `memory` and `context-engine`. Preserve valid declaration order and supported dual-kind behavior, discard unsupported or non-string entries, and collapse duplicates into the established scalar form. This is intentionally limited to manifest normalization; it adds no configuration, migrations, provider routes, plugin SDK contracts, or protocol changes.

## User Impact

Duplicate memory declarations now obey the selected memory slot. Existing valid single-kind and dual-kind plugins retain their behavior, and malformed metadata no longer obscures valid capabilities. Snapshot listing continues to represent configured enablement; runtime inspection represents actual slot enforcement.

## Evidence

Six added regression cases fail against the pre-fix main; all ten added normalization/slot cases pass after the fix.

Remote Linux/Node validation: **479 passing tests across 10 test files** covering manifest parsing, manifest registries, installed manifests, memory/dual-kind slot policy, runtime loader, CLI metadata, bundled plugin contracts, and configuration validation.

A complete `pnpm build` passed, including CLI bootstrap guards, all 143 plugin SDK subpaths, production Control UI build, 662 precompressed assets, and UI performance budgets.

The built, packaged CLI was exercised against real temporary plugin manifests through both `openclaw plugins list --json` and `openclaw plugins inspect <id> --runtime --json`. Actual terminal output:

```json
{"scenario":"packaged CLI duplicate memory kind","result":"pass","canonicalKind":"memory","snapshotReflectsConfiguredEnablement":true,"runtimeStatus":"disabled","exclusiveMemorySlotEnforced":true}
{"scenario":"packaged CLI malformed mixed kinds","result":"pass","canonicalKinds":["memory","context-engine"],"invalidKindsRemoved":true,"declarationOrderPreserved":true,"validDualKindPluginRemainsLoaded":true}
{"scenario":"packaged CLI unsupported scalar kind","result":"pass","unsupportedKindRemoved":true,"pluginRemainsLoaded":true}
```

Independent fresh Codex autoreview: no actionable findings; confidence **0.96**.

The complete remote `pnpm check:changed -- src/plugins/manifest.ts src/plugins/manifest.json5-tolerance.test.ts` gate passed, including both `tsgo` typechecks, zero-error/warning lint, formatting, plugin boundaries, dependency pins, SDK contract, import-cycle, schema, storage, and repository guards. Exact-head hosted CI is required before landing.

Maintainer compatibility decision: accepting only the two existing documented `PluginKind` values and collapsing duplicate declarations is intentional. Valid existing scalar declarations, ordered dual-kind declarations, runtime slot selection, snapshot semantics, and malformed-kind-free plugins retain their established behavior.

The original reporter is credited in the commit co-author trailer; the related broad draft is linked without importing its unrelated changes.