### PR TITLE
fix(sessions): prevent disappearing usage and stalled cron cleanup

### DIFF
--- a/src/cron/session-reaper.test.ts
+++ b/src/cron/session-reaper.test.ts
@@ -476,6 +476,35 @@ describe("sweepCronRunSessions", () => {
     expect(result.pruned).toBe(0);
   });
 
+  it("sweeps immediately when disabled retention is enabled again", async () => {
+    const now = Date.now();
+    const sessionKey = "agent:main:cron:job1:run:expired-run";
+    await seedSessionEntries(storePath, {
+      [sessionKey]: {
+        sessionId: "expired-run",
+        updatedAt: now - 25 * 3_600_000,
+      },
+    });
+
+    expect(
+      await sweepCronRunSessions({
+        cronConfig: { sessionRetention: false },
+        sessionStorePath: storePath,
+        nowMs: now,
+        log,
+      }),
+    ).toEqual({ swept: false, pruned: 0 });
+
+    expect(
+      await sweepCronRunSessions({
+        sessionStorePath: storePath,
+        nowMs: now + 1_000,
+        log,
+      }),
+    ).toEqual({ swept: true, pruned: 1 });
+    expect(readSessionEntries(storePath)[sessionKey]).toBeUndefined();
+  });
+
   it("throttles sweeps without force", async () => {
     const now = Date.now();
     // First sweep runs
@@ -493,6 +522,30 @@ describe("sweepCronRunSessions", () => {
       log,
     });
     expect(r2.swept).toBe(false);
+  });
+
+  it("shares one throttle for canonical agent and session-store aliases", async () => {
+    const now = Date.now();
+
+    expect(
+      await sweepCronRunSessionsImpl({
+        agentId: "main",
+        defaultAgentId: "main",
+        sessionStorePath: storePath,
+        nowMs: now,
+        log,
+      }),
+    ).toEqual({ swept: true, pruned: 0 });
+
+    expect(
+      await sweepCronRunSessionsImpl({
+        agentId: "MAIN",
+        defaultAgentId: "main",
+        sessionStorePath: `${tmpDir}${path.sep}.${path.sep}sessions.json`,
+        nowMs: now + 1_000,
+        log,
+      }),
+    ).toEqual({ swept: false, pruned: 0 });
   });
 
   it("throttles per store path", async () => {

--- a/src/cron/session-reaper.ts
+++ b/src/cron/session-reaper.ts
@@ -1,11 +1,11 @@
 /** Prunes expired per-run cron sessions and archives unreferenced transcripts. */
+import path from "node:path";
 import { parseDurationMs } from "../cli/parse-duration.js";
 import {
   applySessionEntryLifecycleMutation,
   listSessionEntries,
   type SessionEntryLifecycleRemoval,
 } from "../config/sessions/session-accessor.js";
-import { resolveSqliteTargetFromSessionStorePath } from "../config/sessions/session-sqlite-target.js";
 import { resolveMaintenanceConfig } from "../config/sessions/store-maintenance-runtime.js";
 import type { CronConfig } from "../config/types.cron.js";
 import { formatErrorMessage } from "../infra/errors.js";
@@ -22,7 +22,7 @@ const MIN_SWEEP_INTERVAL_MS = 5 * 60_000; // 5 minutes
 const lastSweepAtMsByTarget = new Map<string, number>();
 
 function reaperTargetKey(agentId: string, storePath: string): string {
-  return `${agentId}\0${storePath}`;
+  return `${normalizeAgentId(agentId)}\0${path.resolve(storePath)}`;
 }
 
 /** Resolves cron run-session retention; `false` disables pruning, bad strings fall back safely. */
@@ -63,6 +63,11 @@ export async function sweepCronRunSessions(params: {
   /** Override for testing — skips the min-interval throttle. */
   force?: boolean;
 }): Promise<ReaperResult> {
+  const retentionMs = resolveRetentionMs(params.cronConfig);
+  if (retentionMs === null) {
+    return { swept: false, pruned: 0 };
+  }
+
   const now = params.nowMs ?? Date.now();
   const storePath = params.sessionStorePath;
   // Shared physical stores still hold agent-scoped rows. The throttle also
@@ -80,22 +85,11 @@ export async function sweepCronRunSessions(params: {
   // not turn frequent timer ticks into an unbounded persistence-error loop.
   lastSweepAtMsByTarget.set(targetKey, now);
 
-  const retentionMs = resolveRetentionMs(params.cronConfig);
-  if (retentionMs === null) {
-    return { swept: false, pruned: 0 };
-  }
-
   let pruned = 0;
   let transcriptCleanupError: unknown;
   try {
     const cutoff = now - retentionMs;
-    const resolvedTarget = resolveSqliteTargetFromSessionStorePath(storePath, {
-      agentId: params.agentId,
-      defaultAgentId: params.defaultAgentId,
-    });
-    const sharedPhysicalOwner = resolvedTarget.shared
-      ? normalizeAgentId(resolvedTarget.agentId ?? params.defaultAgentId)
-      : undefined;
+    const requestedOwner = normalizeAgentId(params.agentId);
     let pendingMediaSessionKeys: Set<string> | undefined;
     const removals: SessionEntryLifecycleRemoval[] = [];
     // The accessor keeps agentId logical for admission checks and resolves a shared
@@ -104,17 +98,11 @@ export async function sweepCronRunSessions(params: {
       agentId: params.agentId,
       storePath,
     })) {
-      const scopedOwner = parseAgentSessionKey(sessionKey)?.agentId;
-      const requestedOwner = normalizeAgentId(params.agentId);
-      if (
-        (scopedOwner && normalizeAgentId(scopedOwner) !== requestedOwner) ||
-        (!scopedOwner &&
-          sharedPhysicalOwner !== undefined &&
-          sharedPhysicalOwner !== requestedOwner)
-      ) {
+      if (!isCronRunSessionKey(sessionKey)) {
         continue;
       }
-      if (!isCronRunSessionKey(sessionKey)) {
+      const scopedOwner = parseAgentSessionKey(sessionKey)?.agentId;
+      if (!scopedOwner || normalizeAgentId(scopedOwner) !== requestedOwner) {
         continue;
       }
       const updatedAt = entry.updatedAt ?? 0;

--- a/src/infra/session-cost-usage-cache.sqlite.test.ts
+++ b/src/infra/session-cost-usage-cache.sqlite.test.ts
@@ -13,6 +13,7 @@ import {
 } from "../state/openclaw-state-db.js";
 import { withEnv } from "../test-utils/env.js";
 import {
+  deleteSessionCostUsageRollupsExcept,
   isSessionCostUsageRefreshRunning,
   readSessionCostUsageRollupRows,
   writeSessionCostUsageRollup,
@@ -77,6 +78,52 @@ describe("session cost usage SQLite cache", () => {
         }),
       ).toBe(true);
       expect(countRegisteredAgentDatabases()).toBe(1);
+    });
+  });
+
+  it.each([
+    { label: "changed totals", refreshedValue: '{"totalTokens":2}' },
+    { label: "unchanged totals at a newer revision", refreshedValue: '{"totalTokens":1}' },
+  ])("preserves a refreshed usage rollup with $label during pruning", ({ refreshedValue }) => {
+    const stateDir = makeTempDir(tempDirs, "openclaw-usage-cache-prune-race-");
+
+    withEnv({ OPENCLAW_STATE_DIR: stateDir }, () => {
+      const agentId = "worker-1";
+      const rollupId = "session.jsonl";
+      const staleValue = '{"totalTokens":1}';
+
+      expect(
+        writeSessionCostUsageRollup({
+          agentId,
+          rollupId,
+          previousValueJson: null,
+          valueJson: staleValue,
+          updatedAt: 1,
+        }),
+      ).toBe(true);
+
+      const liveKeys = new (class extends Set<string> {
+        override has(key: string): boolean {
+          if (key === rollupId) {
+            expect(
+              writeSessionCostUsageRollup({
+                agentId,
+                rollupId,
+                previousValueJson: staleValue,
+                valueJson: refreshedValue,
+                updatedAt: 2,
+              }),
+            ).toBe(true);
+          }
+          return false;
+        }
+      })();
+
+      deleteSessionCostUsageRollupsExcept({ agentId, liveKeys });
+
+      expect(readSessionCostUsageRollupRows(agentId)).toEqual([
+        { key: rollupId, updatedAt: 2, valueJson: refreshedValue },
+      ]);
     });
   });
 });

--- a/src/infra/session-cost-usage-cache.sqlite.ts
+++ b/src/infra/session-cost-usage-cache.sqlite.ts
@@ -178,19 +178,21 @@ export function deleteSessionCostUsageRollupsExcept(params: {
   databasePath?: string;
   liveKeys: ReadonlySet<string>;
 }): void {
-  const existing = readSessionCostUsageRollupRows(params.agentId, params.databasePath)
-    .map((row) => row.key)
-    .filter((key) => !params.liveKeys.has(key));
+  const existing = readSessionCostUsageRollupRows(params.agentId, params.databasePath).filter(
+    (row) => !params.liveKeys.has(row.key),
+  );
   runOpenClawAgentWriteTransaction(
     (database) => {
       const kysely = getNodeSqliteKysely<AgentCacheDatabase>(database.db);
-      for (const key of existing) {
+      for (const row of existing) {
         executeSqliteQuerySync(
           database.db,
           kysely
             .deleteFrom("cache_entries")
             .where("scope", "=", ROLLUP_SCOPE)
-            .where("key", "=", key),
+            .where("key", "=", row.key)
+            .where("value_json", "=", row.valueJson)
+            .where("updated_at", "=", row.updatedAt),
         );
       }
       executeSqliteQuerySync(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users monitoring session usage would see freshly refreshed token and cost totals disappear when usage-cache cleanup raced the refresh. This also resolves expired cron-run sessions remaining on disk after retention is re-enabled, and duplicate cleanup sweeps when equivalent agent or session-store aliases reach the same SQLite store.

## Why This Change Was Made

Fence SQLite usage-rollup deletion against both the originally observed serialized value and its revision timestamp so same-value ABA refreshes survive. Make disabled retention a true no-op, normalize the cron sweep target, and derive cleanup ownership from canonical agent-scoped cron session keys. The change preserves existing SQLite schema versions, released migrations, session and transcript import/export, configuration, SDKs, and Gateway protocols; production code is reduced by 10 lines.

## User Impact

Session usage dashboards retain the latest refreshed token and cost totals. Re-enabling cron-session retention immediately resumes cleanup, equivalent store aliases cannot trigger redundant sweeps, and shared SQLite stores continue to protect sessions belonging to other agents.

## Evidence

- Trusted remote Blacksmith Testbox `tbx_01kyhmnh1re9qh1zg8e94ggj09`: **267 passing tests** on exact commit `e3a8ff8d3fc4bc202d8038b858fccc173402d81b`.
- **260 focused tests across nine files and five Vitest shards:** deterministic changed-value and same-value ABA usage-pruning regressions; retention re-enablement; canonical owner/path throttling; existing usage aggregation, stream errors, Gateway usage, shared SQLite ownership, cleanup races, and all **141** main-session restart-recovery cases.
- **7 real process-isolated Gateway/CLI E2E tests:** `pnpm test test/scripts/sqlite-sessions-transcripts-flip-proof.e2e.test.ts test/cli-state-sqlite.e2e.test.ts`; proves actual Gateway startup/restart, complete agent turn, SQLite-only transcript lifecycle, doctor and compaction, concurrent clients, reset, archived cleanup, shared-session deletion, and destructive-maintenance owner/hardlink/symlink rejection.
- Remote `pnpm check:changed`: **passed**, including core and core-test type checks, four-file format/lint, database-first and unchanged native SQLite schema guards, plugin/SDK boundaries, and zero runtime import cycles.
- Exact independent `gpt-5.6-sol`/`xhigh` frozen-base autoreview: **clean**, no accepted or actionable findings; TruffleHog clean.
- Exact-head hosted pull-request CI: https://github.com/openclaw/openclaw/actions/runs/30262159716
- Production delta: **-10 lines**.
- **AI-assisted:** implemented with Codex and independently reviewed with the repository's explicit `gpt-5.6-sol`/`xhigh` autoreview configuration.
