### PR TITLE
fix(cron): prevent local model preflight socket leaks

### DIFF
--- a/src/cron/isolated-agent/model-preflight.runtime.test.ts
+++ b/src/cron/isolated-agent/model-preflight.runtime.test.ts
@@ -1,5 +1,6 @@
 // Runtime model preflight tests cover provider/model checks before cron execution.
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { withTestTimeout } from "../../../test/helpers/promise.js";
 
 const { fetchWithSsrFGuardMock } = vi.hoisted(() => ({
   fetchWithSsrFGuardMock: vi.fn(),
@@ -85,6 +86,148 @@ describe("preflightCronModelProvider", () => {
     const request = requireFetchPreflightRequest();
     expect(request.url).toBe("http://127.0.0.1:8000/v1/models");
     expect(request.timeoutMs).toBe(2500);
+  });
+
+  it("starts unread-body cancellation before release without waiting for a split stream", async () => {
+    const cleanupOrder: string[] = [];
+    const cancel = vi.fn(() => {
+      cleanupOrder.push("cancel");
+      return new Promise<void>(() => {});
+    });
+    const release = vi.fn(async () => {
+      cleanupOrder.push("release");
+    });
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      response: { status: 200, bodyUsed: false, body: { cancel } },
+      release,
+    });
+    const cfg = {
+      models: {
+        providers: {
+          vllm: {
+            api: "openai-completions" as const,
+            baseUrl: "http://127.0.0.1:8000/v1",
+            models: [],
+          },
+        },
+      },
+    };
+
+    const result = await withTestTimeout(
+      preflightCronModelProvider({ cfg, provider: "vllm", model: "llama" }),
+      1_000,
+      "cron provider preflight waited for unread response-body cancellation",
+    );
+    const cached = await preflightCronModelProvider({
+      cfg,
+      provider: "vllm",
+      model: "llama-cached",
+    });
+
+    expect(result).toEqual({ status: "available" });
+    expect(cached).toEqual({ status: "available" });
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(release).toHaveBeenCalledOnce();
+    expect(fetchWithSsrFGuardMock).toHaveBeenCalledOnce();
+    expect(cleanupOrder).toEqual(["cancel", "release"]);
+  });
+
+  it("keeps a reachable provider available when response cancellation rejects", async () => {
+    const cancel = vi.fn(async () => {
+      throw new Error("provider response was already closed");
+    });
+    const release = vi.fn(async () => {});
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      response: { status: 401, bodyUsed: false, body: { cancel } },
+      release,
+    });
+
+    const result = await preflightCronModelProvider({
+      cfg: {
+        models: {
+          providers: {
+            vllm: {
+              api: "openai-completions",
+              baseUrl: "http://127.0.0.1:8000/v1",
+              models: [],
+            },
+          },
+        },
+      },
+      provider: "vllm",
+      model: "llama",
+    });
+
+    expect(result).toEqual({ status: "available" });
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(release).toHaveBeenCalledOnce();
+  });
+
+  it("does not cancel a response body that has already been consumed", async () => {
+    const cancel = vi.fn(async () => {});
+    const release = vi.fn(async () => {});
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      response: { status: 200, bodyUsed: true, body: { cancel } },
+      release,
+    });
+
+    const result = await preflightCronModelProvider({
+      cfg: {
+        models: {
+          providers: {
+            vllm: {
+              api: "openai-completions",
+              baseUrl: "http://127.0.0.1:8000/v1",
+              models: [],
+            },
+          },
+        },
+      },
+      provider: "vllm",
+      model: "llama",
+    });
+
+    expect(result).toEqual({ status: "available" });
+    expect(cancel).not.toHaveBeenCalled();
+    expect(release).toHaveBeenCalledOnce();
+  });
+
+  it("cancels and releases every response during concurrent local-provider probes", async () => {
+    const cancel = vi.fn(async () => {});
+    const release = vi.fn(async () => {});
+    fetchWithSsrFGuardMock.mockImplementation(async () => ({
+      response: { status: 200, bodyUsed: false, body: { cancel } },
+      release,
+    }));
+
+    const results = await withTestTimeout(
+      Promise.all(
+        Array.from({ length: 32 }, (_, index) =>
+          preflightCronModelProvider({
+            cfg: {
+              models: {
+                providers: {
+                  vllm: {
+                    api: "openai-completions",
+                    baseUrl: `http://127.0.0.1:${18_000 + index}/v1`,
+                    models: [],
+                  },
+                },
+              },
+            },
+            provider: "vllm",
+            model: `model-${index}`,
+          }),
+        ),
+      ),
+      1_000,
+      "concurrent cron provider preflights did not release their response bodies",
+    );
+
+    expect(results).toEqual(Array.from({ length: 32 }, () => ({ status: "available" })));
+    expect(fetchWithSsrFGuardMock).toHaveBeenCalledTimes(32);
+    expect(cancel).toHaveBeenCalledTimes(32);
+    expect(release).toHaveBeenCalledTimes(32);
   });
 
   it("marks unreachable local Ollama endpoints unavailable and caches the result", async () => {

--- a/src/cron/isolated-agent/model-preflight.runtime.transport.test.ts
+++ b/src/cron/isolated-agent/model-preflight.runtime.transport.test.ts
@@ -1,0 +1,162 @@
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { withTestTimeout } from "../../../test/helpers/promise.js";
+import {
+  preflightCronModelProvider,
+  resetCronModelProviderPreflightCacheForTest,
+} from "./model-preflight.runtime.js";
+
+type StreamingProviderServer = {
+  baseUrl: string;
+  requestedPaths: string[];
+  socketClosures: Promise<void>[];
+};
+
+const activeServers = new Set<Server>();
+
+async function startStreamingProviderServer(status = 200): Promise<StreamingProviderServer> {
+  const requestedPaths: string[] = [];
+  const socketClosures: Promise<void>[] = [];
+  const server = createServer((request, response) => {
+    requestedPaths.push(request.url ?? "");
+    socketClosures.push(
+      new Promise<void>((resolve) => {
+        request.socket.once("close", resolve);
+      }),
+    );
+    response.writeHead(status, { "content-type": "application/json" });
+    // Keep the real HTTP response open: the probe needs only its status.
+    response.write('{"models":[');
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.removeListener("error", reject);
+      resolve();
+    });
+  });
+  activeServers.add(server);
+  const address = server.address() as AddressInfo;
+
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    requestedPaths,
+    socketClosures,
+  };
+}
+
+describe("local cron provider preflight HTTP transport", () => {
+  beforeEach(() => {
+    resetCronModelProviderPreflightCacheForTest();
+  });
+
+  afterEach(async () => {
+    resetCronModelProviderPreflightCacheForTest();
+    const servers = [...activeServers];
+    activeServers.clear();
+    await Promise.all(
+      servers.map(async (server) => {
+        server.closeAllConnections();
+        await new Promise<void>((resolve, reject) => {
+          server.close((error) => {
+            if (error) {
+              reject(error);
+              return;
+            }
+            resolve();
+          });
+        });
+      }),
+    );
+  });
+
+  it.each([
+    {
+      label: "OpenAI-compatible /models",
+      provider: "vllm",
+      api: "openai-completions" as const,
+      basePath: "/v1",
+      expectedPath: "/v1/models",
+      status: 401,
+    },
+    {
+      label: "Ollama /api/tags",
+      provider: "ollama",
+      api: "ollama" as const,
+      basePath: "",
+      expectedPath: "/api/tags",
+      status: 200,
+    },
+  ])("closes a never-ending $label response", async (scenario) => {
+    const server = await startStreamingProviderServer(scenario.status);
+
+    const result = await withTestTimeout(
+      preflightCronModelProvider({
+        cfg: {
+          models: {
+            providers: {
+              [scenario.provider]: {
+                api: scenario.api,
+                baseUrl: `${server.baseUrl}${scenario.basePath}`,
+                models: [],
+              },
+            },
+          },
+        },
+        provider: scenario.provider,
+        model: "streaming-model",
+      }),
+      2_500,
+      `cron ${scenario.label} preflight stalled on a never-ending response body`,
+    );
+
+    expect(result).toEqual({ status: "available" });
+    expect(server.requestedPaths).toEqual([scenario.expectedPath]);
+    expect(server.socketClosures).toHaveLength(1);
+    await withTestTimeout(
+      Promise.all(server.socketClosures),
+      2_500,
+      `cron ${scenario.label} preflight left its real HTTP socket open`,
+    );
+  });
+
+  it("closes every socket during a concurrent burst of streaming probes", async () => {
+    const server = await startStreamingProviderServer();
+    const probeCount = 24;
+
+    const results = await withTestTimeout(
+      Promise.all(
+        Array.from({ length: probeCount }, (_, index) =>
+          preflightCronModelProvider({
+            cfg: {
+              models: {
+                providers: {
+                  vllm: {
+                    api: "openai-completions",
+                    baseUrl: `${server.baseUrl}/v1/provider-${index}`,
+                    models: [],
+                  },
+                },
+              },
+            },
+            provider: "vllm",
+            model: `streaming-model-${index}`,
+          }),
+        ),
+      ),
+      5_000,
+      "concurrent cron provider preflights stalled on streaming HTTP responses",
+    );
+
+    expect(results).toEqual(Array.from({ length: probeCount }, () => ({ status: "available" })));
+    expect(server.requestedPaths).toHaveLength(probeCount);
+    expect(server.socketClosures).toHaveLength(probeCount);
+    await withTestTimeout(
+      Promise.all(server.socketClosures),
+      5_000,
+      "concurrent cron provider preflights left streaming HTTP sockets open",
+    );
+  });
+});

--- a/src/cron/isolated-agent/model-preflight.runtime.ts
+++ b/src/cron/isolated-agent/model-preflight.runtime.ts
@@ -254,6 +254,11 @@ async function probeLocalProviderEndpoint(params: {
     // have the full provider context.
     void response.status;
   } finally {
+    // Captured responses can tee their body, so awaiting branch cancellation
+    // would hang the cron probe; start cancellation before closing the agent.
+    if (!response.bodyUsed) {
+      void response.body?.cancel().catch(() => undefined);
+    }
     await release();
   }
 }


### PR DESCRIPTION
Related: #111226

## What Problem This Solves

Fixes an issue where scheduled jobs using local Ollama or OpenAI-compatible model providers could leak an HTTP connection, stall provider preflight, or eventually exhaust connections when the provider returns a response body that does not finish.

## Why This Change Was Made

A reachability probe needs the existing GET response status, not the response body. Start cancellation of unread response streams before releasing the SSRF-safe dispatcher, matching the canonical guarded-fetch redirect cleanup. Do not await cancellation: HTTP capture can tee the body and leave one cancellation promise pending. Preserve every HTTP status as reachable, ignore asynchronous cancellation errors, and leave existing probe URLs, timeouts, five-minute cache, fallback policy, and configuration unchanged.

Original finding and cleanup approach by @hugenshen in #111226; preserved as a Git co-author. This change additionally proves real HTTP socket closure for both provider protocols and concurrent streaming responses.

## User Impact

Cron jobs using Ollama or local OpenAI-compatible providers no longer accumulate stalled provider connections. Existing authentication failures still reach the normal model runner, cached provider results remain unchanged, and captured response streams cannot hang scheduled jobs.

## Evidence

- Red-first: three new regressions fail on current main, including all 32 concurrent unread-body probes.
- Real loopback HTTP: never-ending Ollama /api/tags and OpenAI-compatible /v1/models responses both close their actual request sockets. The 401 response remains available, preserving status-only reachability.
- Real socket stress: all 24 simultaneously streaming provider requests finish and close.
- Mocked stress: all 32 simultaneous unique provider probes cancel and release exactly once.
- Split-stream cancellation that never resolves: preflight and cached reuse both complete without waiting.
- Rejected cancellation: provider remains available and dispatcher is released.
- Consumed body: no redundant cancellation.
- Linux Blacksmith Testbox: all 154 cron files / 1,715 tests pass.
- Linux Blacksmith Testbox: complete changed-code gate passes, including formatting, lint, core types, test types, dependency and ownership boundaries.
- Independent structured autoreview: clean, no actionable findings.

## ClawSweeper rank-up moves

- Canonical implementation: select this PR as the sole landing path; close #111226 as superseded after the merge and retain @hugenshen as a Git co-author.
- Rebase: intentionally skipped. The selected head is mergeable, has a successful exact-head openclaw/ci-gate and protected Testbox proof, and repository policy treats behind-main drift as advisory. Rebasing solely to refresh main would invalidate the proven head without resolving a conflict or an actual failure.
