### PR TITLE
fix(agents): prevent canceled and timed-out runs from staying stuck

### DIFF
--- a/src/agents/agent-run-terminal-outcome.test.ts
+++ b/src/agents/agent-run-terminal-outcome.test.ts
@@ -274,6 +274,53 @@ describe("agent run terminal outcome", () => {
 
     expect(mergeAgentRunTerminalOutcome(timeout, earlierCompletion)).toBe(earlierCompletion);
   });
+
+  it("keeps the first proven sticky outcome regardless of callback ordering", () => {
+    const timeout = buildAgentRunTerminalOutcome({
+      status: "timeout",
+      timeoutPhase: "provider",
+      endedAt: 200,
+    });
+    const earlierCancellation = buildAgentRunTerminalOutcome({
+      status: "error",
+      stopReason: "rpc",
+      endedAt: 190,
+    });
+    const laterCancellation = buildAgentRunTerminalOutcome({
+      status: "error",
+      stopReason: "restart",
+      endedAt: 210,
+    });
+
+    for (const [current, incoming] of [
+      [timeout, earlierCancellation],
+      [earlierCancellation, timeout],
+    ]) {
+      expect(mergeAgentRunTerminalOutcome(current, incoming)).toBe(earlierCancellation);
+    }
+    for (const [current, incoming] of [
+      [timeout, laterCancellation],
+      [laterCancellation, timeout],
+    ]) {
+      expect(mergeAgentRunTerminalOutcome(current, incoming)).toBe(timeout);
+    }
+  });
+
+  it("keeps explicit provider timeout attribution ahead of simultaneous cancellation", () => {
+    const timeout = buildAgentRunTerminalOutcome({
+      status: "timeout",
+      timeoutPhase: "provider",
+      endedAt: 200,
+    });
+    const cancellation = buildAgentRunTerminalOutcome({
+      status: "error",
+      stopReason: "rpc",
+      endedAt: 200,
+    });
+
+    expect(mergeAgentRunTerminalOutcome(timeout, cancellation)).toBe(timeout);
+    expect(mergeAgentRunTerminalOutcome(cancellation, timeout)).toBe(timeout);
+  });
 });
 
 describe("agent run attempt terminal", () => {

--- a/src/agents/agent-run-terminal-outcome.test.ts
+++ b/src/agents/agent-run-terminal-outcome.test.ts
@@ -295,13 +295,13 @@ describe("agent run terminal outcome", () => {
     for (const [current, incoming] of [
       [timeout, earlierCancellation],
       [earlierCancellation, timeout],
-    ]) {
+    ] as const) {
       expect(mergeAgentRunTerminalOutcome(current, incoming)).toBe(earlierCancellation);
     }
     for (const [current, incoming] of [
       [timeout, laterCancellation],
       [laterCancellation, timeout],
-    ]) {
+    ] as const) {
       expect(mergeAgentRunTerminalOutcome(current, incoming)).toBe(timeout);
     }
   });
@@ -335,7 +335,7 @@ describe("agent run attempt terminal", () => {
     for (const [current, incoming] of [
       [toolExecution, compaction],
       [compaction, toolExecution],
-    ]) {
+    ] as const) {
       const terminal = mergeAgentRunAttemptTerminal(current, incoming);
       expect(terminal).toEqual(compaction);
       expect(projectAgentRunAttemptTerminal(terminal).timedOut).toBe(false);

--- a/src/agents/agent-run-terminal-outcome.test.ts
+++ b/src/agents/agent-run-terminal-outcome.test.ts
@@ -324,6 +324,24 @@ describe("agent run terminal outcome", () => {
 });
 
 describe("agent run attempt terminal", () => {
+  it("merges observation-only timeout phases without creating a run timeout", () => {
+    const toolExecution = {
+      kind: "timeout",
+      phase: "tool_execution",
+      source: "observation",
+    } as const;
+    const compaction = { kind: "timeout", phase: "compaction", source: "observation" } as const;
+
+    for (const [current, incoming] of [
+      [toolExecution, compaction],
+      [compaction, toolExecution],
+    ]) {
+      const terminal = mergeAgentRunAttemptTerminal(current, incoming);
+      expect(terminal).toEqual(compaction);
+      expect(projectAgentRunAttemptTerminal(terminal).timedOut).toBe(false);
+    }
+  });
+
   it("keeps timeout phase and source precedence in the canonical owner", () => {
     const failure = new Error("provider failed while aborting");
     const failed = mergeAgentRunAttemptTerminal(

--- a/src/agents/agent-run-terminal-outcome.ts
+++ b/src/agents/agent-run-terminal-outcome.ts
@@ -233,7 +233,14 @@ export function mergeAgentRunAttemptTerminal(
         ? incoming
         : current;
     if (selected.source === "observation") {
-      return withAgentRunAttemptFailure({ kind: "timeout", phase, source: "observation" }, failure);
+      const observationPhase =
+        current.phase === "compaction" || incoming.phase === "compaction"
+          ? "compaction"
+          : "tool_execution";
+      return withAgentRunAttemptFailure(
+        { kind: "timeout", phase: observationPhase, source: "observation" },
+        failure,
+      );
     }
     return withAgentRunAttemptFailure(
       {

--- a/src/agents/agent-run-terminal-outcome.ts
+++ b/src/agents/agent-run-terminal-outcome.ts
@@ -224,43 +224,22 @@ export function mergeAgentRunAttemptTerminal(
       : withAgentRunAttemptFailure(incoming, failure);
   }
   if (current.kind === "timeout" && incoming.kind === "timeout") {
-    if (current.source === "observation" && incoming.source === "observation") {
-      const phase =
-        ATTEMPT_TIMEOUT_PHASE_RANK[incoming.phase] > ATTEMPT_TIMEOUT_PHASE_RANK[current.phase]
-          ? incoming.phase
-          : current.phase;
-      return withAgentRunAttemptFailure({ kind: "timeout", phase, source: "observation" }, failure);
-    }
     const phase =
       ATTEMPT_TIMEOUT_PHASE_RANK[incoming.phase] > ATTEMPT_TIMEOUT_PHASE_RANK[current.phase]
         ? incoming.phase
         : current.phase;
-    let source: AgentRunAttemptTimeoutSource;
-    if (current.source === "observation") {
-      if (incoming.source === "observation") {
-        const observationPhase =
-          ATTEMPT_TIMEOUT_PHASE_RANK[incoming.phase] > ATTEMPT_TIMEOUT_PHASE_RANK[current.phase]
-            ? incoming.phase
-            : current.phase;
-        return withAgentRunAttemptFailure(
-          { kind: "timeout", phase: observationPhase, source: "observation" },
-          failure,
-        );
-      }
-      source = incoming.source;
-    } else if (incoming.source === "observation") {
-      source = current.source;
-    } else {
-      source =
-        ATTEMPT_TIMEOUT_SOURCE_RANK[incoming.source] > ATTEMPT_TIMEOUT_SOURCE_RANK[current.source]
-          ? incoming.source
-          : current.source;
+    const selected =
+      ATTEMPT_TIMEOUT_SOURCE_RANK[incoming.source] > ATTEMPT_TIMEOUT_SOURCE_RANK[current.source]
+        ? incoming
+        : current;
+    if (selected.source === "observation") {
+      return withAgentRunAttemptFailure({ kind: "timeout", phase, source: "observation" }, failure);
     }
     return withAgentRunAttemptFailure(
       {
         kind: "timeout",
         phase,
-        source,
+        source: selected.source,
         ...((hasAgentRunAttemptTimeoutAbort(current) ||
           hasAgentRunAttemptTimeoutAbort(incoming)) && { aborted: true as const }),
       },
@@ -476,13 +455,6 @@ function isHardAgentRunTimeoutPhase(value: unknown): value is AgentRunTimeoutPha
   return phase !== undefined && HARD_TIMEOUT_PHASES.has(phase);
 }
 
-/** True when an existing outcome is a hard timeout. */
-function isHardAgentRunTimeoutOutcome(
-  outcome: AgentRunTerminalOutcome | undefined | null,
-): boolean {
-  return outcome?.reason === "hard_timeout";
-}
-
 /** True when an outcome should not be overwritten by ordinary later status. */
 export function isStickyAgentRunTerminalOutcome(
   outcome: AgentRunTerminalOutcome | undefined | null,
@@ -641,7 +613,6 @@ export function buildAgentRunTerminalOutcomeFromAttempt(input: {
   });
 }
 
-/** Builds a terminal outcome from a wait result, ignoring pending/unknown status. */
 /** Builds a terminal outcome from wait paths where status may still be pending/unknown. */
 export function buildAgentRunTerminalOutcomeFromWaitResult(
   wait: AgentRunTerminalWaitInput | undefined,
@@ -674,7 +645,6 @@ function completedBeforeOrAtTimeout(params: {
   );
 }
 
-/** Merges terminal outcomes while preserving cancellation and hard-timeout ownership. */
 /** Merges later terminal observations without overwriting sticky cancellation/hard-timeout state. */
 export function mergeAgentRunTerminalOutcome(
   current: AgentRunTerminalOutcome | undefined,
@@ -684,11 +654,29 @@ export function mergeAgentRunTerminalOutcome(
     return incoming;
   }
   if (current.reason === "cancelled") {
+    // A cancellation callback can arrive before the already-recorded provider
+    // timeout; timestamps, not callback ordering, identify the terminal owner.
+    if (
+      incoming.reason === "hard_timeout" &&
+      typeof incoming.endedAt === "number" &&
+      typeof current.endedAt === "number" &&
+      incoming.endedAt <= current.endedAt
+    ) {
+      return incoming;
+    }
     return current;
   }
   // A hard timeout owns the run unless later evidence proves completion ended
   // before that timeout; late abort/error cleanup must not downgrade it.
-  if (isHardAgentRunTimeoutOutcome(current)) {
+  if (current.reason === "hard_timeout") {
+    if (
+      incoming.reason === "cancelled" &&
+      typeof incoming.endedAt === "number" &&
+      typeof current.endedAt === "number" &&
+      incoming.endedAt < current.endedAt
+    ) {
+      return incoming;
+    }
     return completedBeforeOrAtTimeout({ completed: incoming, timeout: current })
       ? incoming
       : current;
@@ -696,7 +684,7 @@ export function mergeAgentRunTerminalOutcome(
   if (incoming.reason === "cancelled") {
     return incoming;
   }
-  if (isHardAgentRunTimeoutOutcome(incoming)) {
+  if (incoming.reason === "hard_timeout") {
     return completedBeforeOrAtTimeout({ completed: current, timeout: incoming })
       ? current
       : incoming;

--- a/src/agents/embedded-agent-runner/run/attempt-execution-settle.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-execution-settle.test.ts
@@ -326,6 +326,24 @@ describe("runEmbeddedAttemptSettledPhase", () => {
     );
   });
 
+  it("releases the active run when backend cleanup throws during a failed prompt", async () => {
+    const fixture = createFixture();
+    const failure = new Error("prompt failed");
+    mocks.runPrompt.mockRejectedValueOnce(failure);
+    fixture.detachBackend.mockImplementationOnce(() => {
+      fixture.order.push("detach-backend");
+      throw new Error("backend detach failed");
+    });
+
+    await expect(runEmbeddedAttemptSettledPhase(fixture.input)).rejects.toBe(failure);
+
+    expect(mocks.clearActiveEmbeddedRun).toHaveBeenCalledOnce();
+    expect(fixture.removeAbortSignalListener).toHaveBeenCalledOnce();
+    expect(mocks.logError).toHaveBeenCalledWith(
+      expect.stringContaining("backend detach failed, possible resource leak"),
+    );
+  });
+
   it("re-arms delivered children only after a yielded requester becomes idle", async () => {
     const fixture = createFixture();
     mocks.completeResult.mockImplementationOnce(() => {

--- a/src/agents/embedded-agent-runner/run/attempt-execution-settle.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-execution-settle.test.ts
@@ -344,6 +344,34 @@ describe("runEmbeddedAttemptSettledPhase", () => {
     );
   });
 
+  it("reports a backend cleanup failure after releasing a successful run", async () => {
+    const fixture = createFixture();
+    const failure = new Error("backend detach failed");
+    fixture.detachBackend.mockImplementationOnce(() => {
+      fixture.order.push("detach-backend");
+      throw failure;
+    });
+
+    await expect(runEmbeddedAttemptSettledPhase(fixture.input)).rejects.toBe(failure);
+
+    expect(mocks.clearActiveEmbeddedRun).toHaveBeenCalledOnce();
+    expect(fixture.removeAbortSignalListener).toHaveBeenCalledOnce();
+  });
+
+  it("reports active-run cleanup failure after releasing the abort listener", async () => {
+    const fixture = createFixture();
+    const failure = new Error("active run cleanup failed");
+    mocks.clearActiveEmbeddedRun.mockImplementationOnce(() => {
+      fixture.order.push("clear-active-run");
+      throw failure;
+    });
+
+    await expect(runEmbeddedAttemptSettledPhase(fixture.input)).rejects.toBe(failure);
+
+    expect(fixture.detachBackend).toHaveBeenCalledOnce();
+    expect(fixture.removeAbortSignalListener).toHaveBeenCalledOnce();
+  });
+
   it("re-arms delivered children only after a yielded requester becomes idle", async () => {
     const fixture = createFixture();
     mocks.completeResult.mockImplementationOnce(() => {

--- a/src/agents/embedded-agent-runner/run/attempt-execution-settle.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-execution-settle.ts
@@ -34,7 +34,7 @@ type StreamCleanupInput = {
   unsubscribe: () => void;
 };
 
-function cleanupEmbeddedAttemptStreamExecution(input: StreamCleanupInput): unknown {
+function cleanupEmbeddedAttemptStreamExecution(input: StreamCleanupInput): Error | undefined {
   const { attempt, state } = input;
   const terminal = projectAgentRunAttemptTerminal(state.terminal);
   input.clearAttemptTimeoutTimers();
@@ -49,7 +49,7 @@ function cleanupEmbeddedAttemptStreamExecution(input: StreamCleanupInput): unkno
   }
   // Every release belongs to this owner; one broken callback must not strand
   // the active run or mask the prompt failure that caused teardown.
-  let firstCleanupError: unknown;
+  let firstCleanupError: Error | undefined;
   for (const [name, cleanup] of [
     ["unsubscribe", input.unsubscribe],
     ["backend detach", () => attempt.replyOperation?.detachBackend(input.queueHandle)],
@@ -68,7 +68,7 @@ function cleanupEmbeddedAttemptStreamExecution(input: StreamCleanupInput): unkno
     try {
       cleanup();
     } catch (error) {
-      firstCleanupError ??= error;
+      firstCleanupError ??= error instanceof Error ? error : new Error(String(error));
       log.error(
         `CRITICAL: ${name} failed, possible resource leak: runId=${attempt.runId} ${String(error)}`,
       );
@@ -162,7 +162,7 @@ export async function runEmbeddedAttemptSettledPhase(
   let sessionIdUsed = activeSession.sessionId;
   let sessionFileUsed: string | undefined = attempt.sessionFile;
   let preflightRecovery: EmbeddedRunAttemptResult["preflightRecovery"];
-  let streamPhaseCompleted = false;
+  let cleanupError: Error | undefined;
   const readTerminal = () => projectAgentRunAttemptTerminal(state.terminal);
   const setFailure = (error: unknown, source: AgentRunAttemptFailureSource | null) => {
     state.terminal = setAgentRunAttemptTerminalFailure(
@@ -400,9 +400,8 @@ export async function runEmbeddedAttemptSettledPhase(
     });
     sessionIdUsed = afterTurn.sessionIdUsed;
     sessionFileUsed = afterTurn.sessionFileUsed;
-    streamPhaseCompleted = true;
   } finally {
-    const cleanupError = cleanupEmbeddedAttemptStreamExecution({
+    cleanupError = cleanupEmbeddedAttemptStreamExecution({
       attempt,
       clearAttemptTimeoutTimers,
       isProbeSession,
@@ -411,9 +410,10 @@ export async function runEmbeddedAttemptSettledPhase(
       state,
       unsubscribe,
     });
-    if (streamPhaseCompleted && cleanupError !== undefined) {
-      throw cleanupError;
-    }
+  }
+
+  if (cleanupError !== undefined) {
+    throw cleanupError;
   }
 
   const beforeAgentFinalizeRevisionReason = getBeforeAgentFinalizeRevisionReason();

--- a/src/agents/embedded-agent-runner/run/attempt-execution-settle.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-execution-settle.ts
@@ -34,7 +34,7 @@ type StreamCleanupInput = {
   unsubscribe: () => void;
 };
 
-function cleanupEmbeddedAttemptStreamExecution(input: StreamCleanupInput): void {
+function cleanupEmbeddedAttemptStreamExecution(input: StreamCleanupInput): unknown {
   const { attempt, state } = input;
   const terminal = projectAgentRunAttemptTerminal(state.terminal);
   input.clearAttemptTimeoutTimers();
@@ -49,6 +49,7 @@ function cleanupEmbeddedAttemptStreamExecution(input: StreamCleanupInput): void 
   }
   // Every release belongs to this owner; one broken callback must not strand
   // the active run or mask the prompt failure that caused teardown.
+  let firstCleanupError: unknown;
   for (const [name, cleanup] of [
     ["unsubscribe", input.unsubscribe],
     ["backend detach", () => attempt.replyOperation?.detachBackend(input.queueHandle)],
@@ -67,11 +68,13 @@ function cleanupEmbeddedAttemptStreamExecution(input: StreamCleanupInput): void 
     try {
       cleanup();
     } catch (error) {
+      firstCleanupError ??= error;
       log.error(
         `CRITICAL: ${name} failed, possible resource leak: runId=${attempt.runId} ${String(error)}`,
       );
     }
   }
+  return firstCleanupError;
 }
 
 export async function runEmbeddedAttemptSettledPhase(
@@ -159,6 +162,7 @@ export async function runEmbeddedAttemptSettledPhase(
   let sessionIdUsed = activeSession.sessionId;
   let sessionFileUsed: string | undefined = attempt.sessionFile;
   let preflightRecovery: EmbeddedRunAttemptResult["preflightRecovery"];
+  let streamPhaseCompleted = false;
   const readTerminal = () => projectAgentRunAttemptTerminal(state.terminal);
   const setFailure = (error: unknown, source: AgentRunAttemptFailureSource | null) => {
     state.terminal = setAgentRunAttemptTerminalFailure(
@@ -396,8 +400,9 @@ export async function runEmbeddedAttemptSettledPhase(
     });
     sessionIdUsed = afterTurn.sessionIdUsed;
     sessionFileUsed = afterTurn.sessionFileUsed;
+    streamPhaseCompleted = true;
   } finally {
-    cleanupEmbeddedAttemptStreamExecution({
+    const cleanupError = cleanupEmbeddedAttemptStreamExecution({
       attempt,
       clearAttemptTimeoutTimers,
       isProbeSession,
@@ -406,6 +411,9 @@ export async function runEmbeddedAttemptSettledPhase(
       state,
       unsubscribe,
     });
+    if (streamPhaseCompleted && cleanupError !== undefined) {
+      throw cleanupError;
+    }
   }
 
   const beforeAgentFinalizeRevisionReason = getBeforeAgentFinalizeRevisionReason();

--- a/src/agents/embedded-agent-runner/run/attempt-execution-settle.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-execution-settle.ts
@@ -47,22 +47,31 @@ function cleanupEmbeddedAttemptStreamExecution(input: StreamCleanupInput): void 
       `run cleanup: runId=${attempt.runId} sessionId=${attempt.sessionId} aborted=${terminal.aborted} timedOut=${terminal.timedOut}`,
     );
   }
-  try {
-    input.unsubscribe();
-  } catch (error) {
-    // A throwing unsubscribe indicates a resource leak, but must not mask the run error.
-    log.error(
-      `CRITICAL: unsubscribe failed, possible resource leak: runId=${attempt.runId} ${String(error)}`,
-    );
+  // Every release belongs to this owner; one broken callback must not strand
+  // the active run or mask the prompt failure that caused teardown.
+  for (const [name, cleanup] of [
+    ["unsubscribe", input.unsubscribe],
+    ["backend detach", () => attempt.replyOperation?.detachBackend(input.queueHandle)],
+    [
+      "active run cleanup",
+      () =>
+        clearActiveEmbeddedRun(
+          attempt.sessionId,
+          input.queueHandle,
+          attempt.sessionKey,
+          attempt.sessionFile,
+        ),
+    ],
+    ["abort listener cleanup", input.removeAttemptAbortSignalListener],
+  ] as const) {
+    try {
+      cleanup();
+    } catch (error) {
+      log.error(
+        `CRITICAL: ${name} failed, possible resource leak: runId=${attempt.runId} ${String(error)}`,
+      );
+    }
   }
-  attempt.replyOperation?.detachBackend(input.queueHandle);
-  clearActiveEmbeddedRun(
-    attempt.sessionId,
-    input.queueHandle,
-    attempt.sessionKey,
-    attempt.sessionFile,
-  );
-  input.removeAttemptAbortSignalListener();
 }
 
 export async function runEmbeddedAttemptSettledPhase(

--- a/src/agents/embedded-agent-runner/runs.force-clear-terminal.test.ts
+++ b/src/agents/embedded-agent-runner/runs.force-clear-terminal.test.ts
@@ -6,6 +6,7 @@ import { clearRuntimeConfigSnapshot, setRuntimeConfigSnapshot } from "../../conf
 import { loadSessionEntry, upsertSessionEntry } from "../../config/sessions/session-accessor.js";
 import {
   abortAndDrainEmbeddedAgentRun,
+  clearActiveEmbeddedRun,
   isEmbeddedAgentRunHandleActive,
   setActiveEmbeddedRun,
 } from "./runs.js";
@@ -76,6 +77,38 @@ describe("force-clear terminal state persistence", () => {
     expect(entry?.abortedLastRun).toBe(true);
     expect(entry?.endedAt).toBeGreaterThanOrEqual(startedAt);
     expect(entry?.runtimeMs).toBe(12_345);
+  });
+
+  it("keeps the persisted killed state when the force-cleared owner finishes late", async () => {
+    const sessionKey = "agent:main:force-clear-late-completion";
+    const sessionId = "session-force-clear-late-completion";
+    const startedAt = Date.now() - 60_000;
+    const handle = createRunHandle();
+
+    await upsertSessionEntry(
+      { sessionKey, storePath },
+      { sessionId, updatedAt: startedAt, startedAt, status: "running" },
+    );
+    setActiveEmbeddedRun(sessionId, handle, sessionKey);
+
+    await expect(
+      abortAndDrainEmbeddedAgentRun({
+        sessionId,
+        sessionKey,
+        forceClear: true,
+        reason: "stuck_recovery",
+        settleMs: 0,
+      }),
+    ).resolves.toMatchObject({ forceCleared: true });
+
+    clearActiveEmbeddedRun(sessionId, handle, sessionKey);
+
+    expect(isEmbeddedAgentRunHandleActive(sessionId)).toBe(false);
+    expect(loadSessionEntry({ sessionKey, storePath })).toMatchObject({
+      sessionId,
+      status: "killed",
+      abortedLastRun: true,
+    });
   });
 
   it("does not fail when the session entry is absent", async () => {

--- a/src/gateway/server-methods/agent-job.ts
+++ b/src/gateway/server-methods/agent-job.ts
@@ -419,13 +419,13 @@ export function setGatewayDedupeEntry(params: {
     incomingObservation.state === "terminal"
       ? terminalOutcomeFromSnapshot(incomingObservation.snapshot)
       : undefined;
-  if (existingOutcome && isStickyAgentRunTerminalOutcome(existingOutcome) && !incomingOutcome) {
+  if (
+    existingOutcome &&
+    isStickyAgentRunTerminalOutcome(existingOutcome) &&
+    (!incomingOutcome ||
+      mergeAgentRunTerminalOutcome(existingOutcome, incomingOutcome) === existingOutcome)
+  ) {
     return;
-  }
-  if (existingOutcome && incomingOutcome && isStickyAgentRunTerminalOutcome(existingOutcome)) {
-    if (mergeAgentRunTerminalOutcome(existingOutcome, incomingOutcome) === existingOutcome) {
-      return;
-    }
   }
 
   params.dedupe.set(params.key, params.entry);
@@ -453,7 +453,10 @@ function getFreshestDedupeSnapshot(
   const agent = snapshotsBySource.get("agent");
   const chat = snapshotsBySource.get("chat");
   if (agent && chat) {
-    return chat.recordedAt > agent.recordedAt ? chat : agent;
+    // Dedupe source freshness must not bypass the canonical sticky run outcome.
+    return chat.recordedAt > agent.recordedAt
+      ? mergeSnapshot(agent, chat)
+      : mergeSnapshot(chat, agent);
   }
   return agent ?? chat;
 }

--- a/src/gateway/server-methods/agent-wait-dedupe.test.ts
+++ b/src/gateway/server-methods/agent-wait-dedupe.test.ts
@@ -87,4 +87,58 @@ describe("agent.wait gateway dedupe observations", () => {
       expect.objectContaining({ runId, status: "ok", endedAt: 200 }),
     );
   });
+
+  it.each([
+    {
+      name: "late completion",
+      payload: { status: "ok", startedAt: 100, endedAt: 300 },
+      expected: { status: "timeout", endedAt: 200, timeoutPhase: "provider" },
+    },
+    {
+      name: "late restart cancellation",
+      payload: { status: "error", startedAt: 100, endedAt: 300, stopReason: "restart" },
+      expected: { status: "timeout", endedAt: 200, timeoutPhase: "provider" },
+    },
+    {
+      name: "earlier user cancellation",
+      payload: { status: "error", startedAt: 100, endedAt: 150, stopReason: "rpc" },
+      expected: { status: "error", endedAt: 150, stopReason: "rpc" },
+    },
+  ])("merges $name across agent and chat observations", async ({ name, payload, expected }) => {
+    for (const timeoutFirst of [true, false]) {
+      const runId = `run-cross-source-${name.replaceAll(" ", "-")}-${timeoutFirst}`;
+      const dedupe = new Map<string, DedupeEntry>();
+      const timeout = {
+        dedupe,
+        key: `agent:${runId}`,
+        entry: {
+          ts: 200,
+          ok: false,
+          payload: {
+            runId,
+            status: "timeout",
+            startedAt: 100,
+            endedAt: 200,
+            timeoutPhase: "provider",
+          },
+        },
+      };
+      const other = {
+        dedupe,
+        key: `chat:${runId}`,
+        entry: { ts: 300, ok: payload.status === "ok", payload: { runId, ...payload } },
+      };
+
+      for (const observation of timeoutFirst ? [timeout, other] : [other, timeout]) {
+        setGatewayDedupeEntry(observation);
+      }
+
+      const waiter = waitThroughGateway({ runId, timeoutMs: 0 });
+      await waiter.promise;
+      expect(waiter.respond).toHaveBeenCalledWith(
+        true,
+        expect.objectContaining({ runId, ...expected }),
+      );
+    }
+  });
 });


### PR DESCRIPTION
Related: #112166

## What Problem This Solves

Fixes an issue where users cancelling, restarting, or timing out an agent run could see a completed or active session reappear when the same run reported late terminal callbacks through different Gateway sources. A backend teardown failure could also leave the run registered and block the next message.

## Why This Change Was Made

Resolve cancellation versus provider timeout once from the canonical terminal outcome and the actual completion timestamps. Make both Gateway observation sources use that outcome, and let one embedded teardown owner attempt every resource release even when an earlier release throws. Preserve the force-cleared terminal persistence and replacement-owner guards introduced in #112166.

## User Impact

Cancelled and timed-out runs remain terminal, real earlier user cancellations remain authoritative, restarted sessions do not revive stale work, and users can start a new message after an interrupted or failed backend cleanup. No configuration, protocol, provider, observer, or storage contract changes.

## Evidence

- Final commit `e377a986c4b18435cf9ed7ece285c6c79c3f42bc`, verified remotely on Blacksmith Testbox `tbx_01kyhms4v5ncsc1vhn7x874bk3`.
- 140 lifecycle and cross-surface tests passed across 10 focused files and 4 Vitest shards, covering canonical timeout/cancel ordering in both callback directions, late restart/completion, embedded cleanup failures, Gateway agent/chat dedupe, `chat.abort` persistence, and auto-reply restart and terminal failure projections.
- 3 real isolated Gateway WebSocket cancellation and restart scenarios passed: `chat.abort`, `sessions.abort`, and restart-drain dispatch rejection.
- Full `pnpm check:changed` passed: all seven files formatted, production and core-test typechecks, type-aware core lint, plugin and SDK boundaries, and database/schema/import-cycle guards; remote timing JSON exit code 0.
- Fresh independent `autoreview --mode branch --engine codex --model gpt-5.6-sol --thinking xhigh`: clean, with no accepted or actionable findings.
- Explicit regression confirms a late completion cannot undo the persisted killed state from #112166.

AI-assisted: implemented and validated with Codex; the changes and test evidence were reviewed against the actual lifecycle and Gateway call paths.
