### PR TITLE
fix(agents): enable tool-loop detection by default + add Anthropic spend-guardrail script

### DIFF
--- a/docs/automation/spend-guardrail.md
+++ b/docs/automation/spend-guardrail.md
@@ -1,0 +1,78 @@
+---
+summary: "Kill-switch guardrail against runaway Anthropic spend on always-on gateways"
+read_when:
+  - Setting up or tuning a daily Anthropic spend cap for a deployed gateway
+  - Investigating an unexpected Anthropic cost spike from an OpenClaw instance
+  - A gateway was unexpectedly stopped and SPEND-PAUSED exists
+title: "Spend Guardrail"
+---
+
+# Spend guardrail
+
+Root cause (Cost Watch, 2026-07-14+): two always-on OpenClaw gateways ran
+Opus-tier models on every unattended heartbeat, with no spend cap and no
+kill switch. One key spent $347-$1,382/day for two weeks before anyone
+noticed — driven by continuous cache-read volume from a stuck-ish context
+re-read on (near-)every turn. `DEFAULT_MODEL` and `tools.loopDetection`
+defaults now guard the _cause_; this script guards the _blast radius_ if
+some other misconfiguration (a manual model override, a new agent, a
+runaway subagent loop) produces the same pattern again.
+
+## What it does
+
+`scripts/spend-guardrail.sh` polls **actual billed spend** (not an
+estimate) since UTC midnight via the Anthropic Admin API
+(`/v1/organizations/usage_report/messages`), converts token usage to USD
+using the same per-model pricing tiers as
+`forge/src/lib/forge/claude-client.ts` (keep both in sync — see
+`latest-llm-models.mdc`), and compares against `SPEND_CAP_USD`.
+
+If the cap is exceeded, it does not just alert — it:
+
+1. Writes `~/.openclaw/SPEND-PAUSED` (the kill-switch marker, same pattern
+   as Forge's `.ralph-pause`).
+2. Runs `launchctl bootout` on the gateway's launchd job — this **stops
+   the gateway** and prevents `RunAtLoad` from restarting it on the next
+   boot, so the runaway can't resume unattended.
+3. Sends a Slack/ntfy alert with the exact resume command.
+
+Subsequent runs no-op (log-only) while `SPEND-PAUSED` exists, so the
+gateway stays down and the alert doesn't repeat every cron tick.
+
+## Install (once per machine)
+
+```bash
+scp scripts/spend-guardrail.sh <host>:~/.openclaw/tools/spend-guardrail.sh
+ssh <host> chmod +x ~/.openclaw/tools/spend-guardrail.sh
+ssh <host> crontab -e
+# add (every 30 min, matching the auth-watchdog cadence):
+*/30 * * * * ANTHROPIC_ADMIN_KEY=sk-ant-admin-... SPEND_CAP_USD=100 ~/.openclaw/tools/spend-guardrail.sh >> /tmp/openclaw-spend-guardrail.log 2>&1
+```
+
+Get a read-only Admin API key at
+`console.anthropic.com/settings/admin-keys` — "Usage & Cost" scope is
+sufficient, no write access needed. Optionally scope the check to just
+this machine's own key(s) via `ANTHROPIC_API_KEY_IDS` (comma-separated
+`apikey_...` ids from the [List API Keys](https://platform.claude.com/docs/en/api/admin/apikeys/list)
+endpoint) — otherwise it checks org-wide spend, which is only meaningful
+if this gateway is the sole consumer of that Admin key's org.
+
+## Resuming after a trip
+
+```bash
+rm ~/.openclaw/SPEND-PAUSED
+sudo launchctl bootstrap system /Library/LaunchDaemons/ai.openclaw.gateway.plist
+```
+
+Investigate the cause first — check `openclaw infer model auth status`,
+recent config changes, and the Admin API usage breakdown by model — before
+resuming, or it will just trip again.
+
+## Tuning `SPEND_CAP_USD`
+
+Set it above your normal daily baseline with headroom for legitimate
+bursts, but well below what you'd consider an incident. For reference, the
+gateways described above ran a healthy baseline in the low tens of
+dollars/day before the regression: check `usage_snapshots` in the
+`noble-people-products` Supabase project (Everything hub's Cost Watch) for
+this gateway's actual historical baseline before picking a number.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1359,7 +1359,13 @@
                   "automation/tasks",
                   "automation/taskflow",
                   "automation/standing-orders",
-                  "automation/hooks"
+                  "automation/hooks",
+                  "automation/troubleshooting",
+                  "automation/webhook",
+                  "automation/gmail-pubsub",
+                  "automation/poll",
+                  "automation/auth-monitoring",
+                  "automation/spend-guardrail"
                 ]
               },
               {

--- a/scripts/spend-guardrail.sh
+++ b/scripts/spend-guardrail.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+# Anthropic Spend Guardrail — the missing kill-switch equivalent to
+# Forge's `.ralph-pause` for OpenClaw's always-on gateways.
+#
+# Root cause this guards against (Cost Watch, 2026-07-14+): two always-on
+# OpenClaw gateways (Mac Mini + grey MacBook) ran Opus-tier models on every
+# 30-min heartbeat with no spend cap and no kill switch. One key alone spent
+# $347-$1,382/day for two weeks straight before anyone noticed, driven by
+# continuous cache-read volume. This script closes that gap: it polls actual
+# billed spend (not estimated) via the Anthropic Admin API, and if a
+# configurable daily cap is exceeded, it STOPS THE GATEWAY — not just alerts.
+#
+# Install (once per machine, matching the auth-watchdog.sh pattern):
+#   cp scripts/spend-guardrail.sh ~/.openclaw/tools/spend-guardrail.sh
+#   chmod +x ~/.openclaw/tools/spend-guardrail.sh
+#   crontab -e   # add:
+#   */30 * * * * ANTHROPIC_ADMIN_KEY=sk-ant-admin-... SPEND_CAP_USD=100 ~/.openclaw/tools/spend-guardrail.sh >> /tmp/openclaw-spend-guardrail.log 2>&1
+#
+# Required env:
+#   ANTHROPIC_ADMIN_KEY    - Admin API key (console.anthropic.com/settings/admin-keys),
+#                            read-only "Usage & Cost" scope is sufficient.
+# Optional env:
+#   ANTHROPIC_API_KEY_IDS  - Comma-separated apikey_... ids to restrict the check to
+#                            this gateway's own key(s). Omit to check org-wide spend
+#                            (only safe if this gateway is the only thing using the org key).
+#   SPEND_CAP_USD          - Daily USD cap before the kill switch trips (default: 100).
+#   GATEWAY_LAUNCHD_LABEL  - launchd label to stop when tripped (default: ai.openclaw.gateway).
+#   GATEWAY_LAUNCHD_DOMAIN - launchd domain (default: system; use gui/$(id -u) for a
+#                            user LaunchAgent instead of a system LaunchDaemon).
+#   NOTIFY_NTFY             - ntfy.sh topic for push notifications.
+#   NOTIFY_SLACK_WEBHOOK    - Slack incoming webhook URL for #agents-dev-style alerts.
+#
+# Reset after a trip (once the runaway cause is fixed):
+#   rm ~/.openclaw/SPEND-PAUSED
+#   sudo launchctl bootstrap system /Library/LaunchDaemons/ai.openclaw.gateway.plist
+#   # or, for a user LaunchAgent: launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/ai.openclaw.gateway.plist
+
+set -euo pipefail
+
+SPEND_CAP_USD="${SPEND_CAP_USD:-100}"
+GATEWAY_LAUNCHD_LABEL="${GATEWAY_LAUNCHD_LABEL:-ai.openclaw.gateway}"
+GATEWAY_LAUNCHD_DOMAIN="${GATEWAY_LAUNCHD_DOMAIN:-system}"
+NOTIFY_NTFY="${NOTIFY_NTFY:-}"
+NOTIFY_SLACK_WEBHOOK="${NOTIFY_SLACK_WEBHOOK:-}"
+KILL_SWITCH_FILE="$HOME/.openclaw/SPEND-PAUSED"
+STATE_FILE="$HOME/.openclaw/tools/.spend-guardrail-state.json"
+
+log() { echo "$(date '+%Y-%m-%d %H:%M:%S') - $1"; }
+
+send_alert() {
+  local message="$1"
+  local priority="${2:-high}"
+
+  log "ALERT: $message"
+
+  if [ -n "$NOTIFY_NTFY" ]; then
+    curl -s -o /dev/null -m 10 \
+      -H "Title: OpenClaw Spend Guardrail" \
+      -H "Priority: $priority" \
+      -H "Tags: warning,moneybag" \
+      -d "$message" \
+      "https://ntfy.sh/$NOTIFY_NTFY" || true
+  fi
+
+  if [ -n "$NOTIFY_SLACK_WEBHOOK" ]; then
+    curl -s -o /dev/null -m 10 -X POST -H "Content-Type: application/json" \
+      -d "$(jq -n --arg text "$message" '{text: $text}')" \
+      "$NOTIFY_SLACK_WEBHOOK" || true
+  fi
+}
+
+if [ -f "$KILL_SWITCH_FILE" ]; then
+  log "Kill switch already tripped ($KILL_SWITCH_FILE exists) — gateway stays stopped. Not re-checking spend."
+  log "To resume: rm $KILL_SWITCH_FILE && sudo launchctl bootstrap $GATEWAY_LAUNCHD_DOMAIN /Library/LaunchDaemons/$GATEWAY_LAUNCHD_LABEL.plist"
+  exit 0
+fi
+
+if [ -z "${ANTHROPIC_ADMIN_KEY:-}" ]; then
+  log "ANTHROPIC_ADMIN_KEY not set — cannot check spend. Skipping (fail open, not closed, to avoid killing the gateway on a config error)."
+  exit 0
+fi
+
+# Since UTC midnight today, matching how Anthropic buckets daily cost.
+STARTING_AT="$(date -u +%Y-%m-%dT00:00:00Z)"
+ENDING_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+QUERY="starting_at=${STARTING_AT}&ending_at=${ENDING_AT}&bucket_width=1d&group_by[]=model"
+if [ -n "${ANTHROPIC_API_KEY_IDS:-}" ]; then
+  IFS=',' read -ra KEY_IDS <<< "$ANTHROPIC_API_KEY_IDS"
+  for kid in "${KEY_IDS[@]}"; do
+    QUERY="${QUERY}&api_key_ids[]=${kid}"
+  done
+fi
+
+RESPONSE=$(curl -sf -m 20 "https://api.anthropic.com/v1/organizations/usage_report/messages?${QUERY}" \
+  -H "anthropic-version: 2023-06-01" \
+  -H "x-api-key: $ANTHROPIC_ADMIN_KEY") || {
+  log "Admin API request failed — skipping this check (fail open)."
+  exit 0
+}
+
+# Per-million-token pricing (USD), mirroring forge/src/lib/forge/claude-client.ts
+# PRICING_PER_MTOK — keep both in sync with latest-llm-models.mdc.
+TOTAL_COST_USD=$(echo "$RESPONSE" | jq '
+  [.data[]?.results[]? | select(.model != null) | {
+    model: .model,
+    input: ((.uncached_input_tokens // 0) + (.cache_creation.ephemeral_5m_input_tokens // 0) + (.cache_creation.ephemeral_1h_input_tokens // 0)),
+    cache_read: (.cache_read_input_tokens // 0),
+    output: (.output_tokens // 0)
+  }] | map(
+    (if (.model | test("opus")) then {in: 5, out: 25, cache: 0.5}
+     elif (.model | test("sonnet")) then {in: 3, out: 15, cache: 0.3}
+     elif (.model | test("haiku")) then {in: 1, out: 5, cache: 0.1}
+     else {in: 3, out: 15, cache: 0.3} end) as $p |
+    (.input / 1000000 * $p.in) + (.cache_read / 1000000 * $p.cache) + (.output / 1000000 * $p.out)
+  ) | add // 0
+')
+
+log "Spend since $STARTING_AT: \$$(printf '%.2f' "$TOTAL_COST_USD") (cap: \$${SPEND_CAP_USD})"
+echo "{\"ts\":\"$(date -u +%FT%TZ)\",\"cost_usd\":$TOTAL_COST_USD,\"cap_usd\":$SPEND_CAP_USD}" > "$STATE_FILE"
+
+if (( $(echo "$TOTAL_COST_USD >= $SPEND_CAP_USD" | bc -l) )); then
+  MESSAGE="OpenClaw spend guardrail TRIPPED on $(hostname): \$$(printf '%.2f' "$TOTAL_COST_USD") spent today, cap is \$${SPEND_CAP_USD}. Stopping ${GATEWAY_LAUNCHD_LABEL} now. Resume with: rm $KILL_SWITCH_FILE && sudo launchctl bootstrap $GATEWAY_LAUNCHD_DOMAIN /Library/LaunchDaemons/${GATEWAY_LAUNCHD_LABEL}.plist"
+
+  mkdir -p "$(dirname "$KILL_SWITCH_FILE")"
+  echo "$MESSAGE" > "$KILL_SWITCH_FILE"
+
+  # The actual kill switch — bootout stops it AND prevents RunAtLoad from
+  # restarting it on the next boot until an operator explicitly re-bootstraps.
+  sudo launchctl bootout "$GATEWAY_LAUNCHD_DOMAIN/$GATEWAY_LAUNCHD_LABEL" 2>&1 || \
+    log "launchctl bootout failed or already stopped — check manually."
+
+  send_alert "$MESSAGE" "urgent"
+  exit 1
+else
+  log "Under cap. No action taken."
+fi

--- a/scripts/spend-guardrail.sh
+++ b/scripts/spend-guardrail.sh
@@ -28,9 +28,14 @@
 #   GATEWAY_LAUNCHD_DOMAIN - launchd domain (default: system; use gui/$(id -u) for a
 #                            user LaunchAgent instead of a system LaunchDaemon).
 #   NOTIFY_NTFY             - ntfy.sh topic for push notifications.
-#   NOTIFY_SLACK_WEBHOOK    - Slack incoming webhook URL for #agents-dev-style alerts.
+#   NOTIFY_SLACK_WEBHOOK    - Slack incoming webhook URL, if configured.
+#   NOTIFY_SLACK_TOKEN      - Slack bot token (xoxb-...) for chat.postMessage,
+#                            matching the pattern already used by monitor.sh.
+#   NOTIFY_SLACK_CHANNEL    - Slack channel id to post to (default: #agents-dev's
+#                            C0B5KNAV0TV, matching monitor.sh/auth-watchdog.sh).
 #
-# Reset after a trip (once the runaway cause is fixed):
+# Reset after a trip (once the runaway cause is fixed) — the script's own
+# alert message includes the exact command for this host, but as reference:
 #   rm ~/.openclaw/SPEND-PAUSED
 #   sudo launchctl bootstrap system /Library/LaunchDaemons/ai.openclaw.gateway.plist
 #   # or, for a user LaunchAgent: launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/ai.openclaw.gateway.plist
@@ -40,8 +45,34 @@ set -euo pipefail
 SPEND_CAP_USD="${SPEND_CAP_USD:-100}"
 GATEWAY_LAUNCHD_LABEL="${GATEWAY_LAUNCHD_LABEL:-ai.openclaw.gateway}"
 GATEWAY_LAUNCHD_DOMAIN="${GATEWAY_LAUNCHD_DOMAIN:-system}"
+# System LaunchDaemons live in /Library/LaunchDaemons and need sudo; user
+# LaunchAgents (domain gui/$UID) live in ~/Library/LaunchAgents and don't.
+if [ "$GATEWAY_LAUNCHD_DOMAIN" = "system" ]; then
+  GATEWAY_PLIST_PATH="${GATEWAY_PLIST_PATH:-/Library/LaunchDaemons/${GATEWAY_LAUNCHD_LABEL}.plist}"
+  SUDO="sudo"
+else
+  GATEWAY_PLIST_PATH="${GATEWAY_PLIST_PATH:-$HOME/Library/LaunchAgents/${GATEWAY_LAUNCHD_LABEL}.plist}"
+  SUDO=""
+fi
 NOTIFY_NTFY="${NOTIFY_NTFY:-}"
 NOTIFY_SLACK_WEBHOOK="${NOTIFY_SLACK_WEBHOOK:-}"
+NOTIFY_SLACK_TOKEN="${NOTIFY_SLACK_TOKEN:-}"
+NOTIFY_SLACK_CHANNEL="${NOTIFY_SLACK_CHANNEL:-C0B5KNAV0TV}"
+OPENCLAW_CONFIG="${OPENCLAW_CONFIG:-$HOME/.openclaw/openclaw.json}"
+
+# Reuse the gateway's own already-authorized Slack bot token (same pattern as
+# auth-watchdog.sh) if no explicit token was passed via env — avoids needing
+# to duplicate the secret into crontab just for this script. Some machines
+# store `channels.slack.botToken` as a secrets-manager reference object
+# (`{"source":"file",...}`) rather than a literal `xoxb-...` string — only
+# use the derived value if it actually looks like a bot token.
+if [ -z "$NOTIFY_SLACK_TOKEN" ] && [ -f "$OPENCLAW_CONFIG" ]; then
+  DERIVED_TOKEN=$(python3 -c 'import json;print(json.load(open("'"$OPENCLAW_CONFIG"'"))["channels"]["slack"]["botToken"])' 2>/dev/null || echo "")
+  case "$DERIVED_TOKEN" in
+    xoxb-*) NOTIFY_SLACK_TOKEN="$DERIVED_TOKEN" ;;
+    *) : ;; # not a literal token (e.g. secrets-manager reference) — leave unset, pass NOTIFY_SLACK_TOKEN explicitly via cron instead
+  esac
+fi
 KILL_SWITCH_FILE="$HOME/.openclaw/SPEND-PAUSED"
 STATE_FILE="$HOME/.openclaw/tools/.spend-guardrail-state.json"
 
@@ -67,11 +98,18 @@ send_alert() {
       -d "$(jq -n --arg text "$message" '{text: $text}')" \
       "$NOTIFY_SLACK_WEBHOOK" || true
   fi
+
+  if [ -n "$NOTIFY_SLACK_TOKEN" ]; then
+    curl -s -o /dev/null -m 10 -X POST "https://slack.com/api/chat.postMessage" \
+      -H "Authorization: Bearer $NOTIFY_SLACK_TOKEN" \
+      -H "Content-Type: application/json; charset=utf-8" \
+      -d "$(jq -n --arg channel "$NOTIFY_SLACK_CHANNEL" --arg text ":rotating_light: $message" '{channel: $channel, text: $text}')" || true
+  fi
 }
 
 if [ -f "$KILL_SWITCH_FILE" ]; then
   log "Kill switch already tripped ($KILL_SWITCH_FILE exists) — gateway stays stopped. Not re-checking spend."
-  log "To resume: rm $KILL_SWITCH_FILE && sudo launchctl bootstrap $GATEWAY_LAUNCHD_DOMAIN /Library/LaunchDaemons/$GATEWAY_LAUNCHD_LABEL.plist"
+  log "To resume: rm $KILL_SWITCH_FILE && $SUDO launchctl bootstrap $GATEWAY_LAUNCHD_DOMAIN $GATEWAY_PLIST_PATH"
   exit 0
 fi
 
@@ -120,14 +158,14 @@ log "Spend since $STARTING_AT: \$$(printf '%.2f' "$TOTAL_COST_USD") (cap: \$${SP
 echo "{\"ts\":\"$(date -u +%FT%TZ)\",\"cost_usd\":$TOTAL_COST_USD,\"cap_usd\":$SPEND_CAP_USD}" > "$STATE_FILE"
 
 if (( $(echo "$TOTAL_COST_USD >= $SPEND_CAP_USD" | bc -l) )); then
-  MESSAGE="OpenClaw spend guardrail TRIPPED on $(hostname): \$$(printf '%.2f' "$TOTAL_COST_USD") spent today, cap is \$${SPEND_CAP_USD}. Stopping ${GATEWAY_LAUNCHD_LABEL} now. Resume with: rm $KILL_SWITCH_FILE && sudo launchctl bootstrap $GATEWAY_LAUNCHD_DOMAIN /Library/LaunchDaemons/${GATEWAY_LAUNCHD_LABEL}.plist"
+  MESSAGE="OpenClaw spend guardrail TRIPPED on $(hostname): \$$(printf '%.2f' "$TOTAL_COST_USD") spent today, cap is \$${SPEND_CAP_USD}. Stopping ${GATEWAY_LAUNCHD_LABEL} now. Resume with: rm $KILL_SWITCH_FILE && $SUDO launchctl bootstrap $GATEWAY_LAUNCHD_DOMAIN $GATEWAY_PLIST_PATH"
 
   mkdir -p "$(dirname "$KILL_SWITCH_FILE")"
   echo "$MESSAGE" > "$KILL_SWITCH_FILE"
 
   # The actual kill switch — bootout stops it AND prevents RunAtLoad from
   # restarting it on the next boot until an operator explicitly re-bootstraps.
-  sudo launchctl bootout "$GATEWAY_LAUNCHD_DOMAIN/$GATEWAY_LAUNCHD_LABEL" 2>&1 || \
+  $SUDO launchctl bootout "$GATEWAY_LAUNCHD_DOMAIN/$GATEWAY_LAUNCHD_LABEL" 2>&1 || \
     log "launchctl bootout failed or already stopped — check manually."
 
   send_alert "$MESSAGE" "urgent"

--- a/src/agents/defaults.test.ts
+++ b/src/agents/defaults.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL, DEFAULT_PROVIDER } from "./defaults.js";
+
+describe("agent defaults", () => {
+  // Regression guard: an Opus-tier Anthropic default here previously ran on
+  // EVERY agent turn — including unattended 30-min heartbeats on always-on
+  // gateways — and was the confirmed dominant driver of a $347-$1,382/day
+  // Anthropic spend spike (Cost Watch, 2026-07-14+) across two machines.
+  // Whatever the current provider/model default is, it must never regress
+  // to an Opus-tier Anthropic model as the install-time/fresh-deploy value —
+  // escalate per-agent/per-session via config instead.
+  it("never defaults the primary agent model to an Opus-tier Anthropic model", () => {
+    if (DEFAULT_PROVIDER === "anthropic") {
+      expect(DEFAULT_MODEL).not.toMatch(/opus/i);
+    }
+  });
+
+  it("keeps a sane provider + context window fallback", () => {
+    expect(DEFAULT_PROVIDER.length).toBeGreaterThan(0);
+    expect(DEFAULT_CONTEXT_TOKENS).toBeGreaterThan(0);
+  });
+});

--- a/src/agents/tool-loop-detection.test.ts
+++ b/src/agents/tool-loop-detection.test.ts
@@ -308,7 +308,12 @@ describe("tool-loop-detection", () => {
   });
 
   describe("detectToolCallLoop", () => {
-    it("is disabled by default", () => {
+    // Regression guard: this used to be disabled by default, which meant a
+    // stuck agent (e.g. an always-on OpenClaw gateway heartbeat) could repeat
+    // expensive tool calls indefinitely with nothing stopping it. Flipped to
+    // enabled-by-default so a fresh deploy is protected without operator
+    // config; explicitly pass `{ enabled: false }` to opt a session out.
+    it("is enabled by default and flags a repeated identical call", () => {
       const state = createState();
 
       for (let i = 0; i < 20; i += 1) {
@@ -316,6 +321,22 @@ describe("tool-loop-detection", () => {
       }
 
       const loopResult = detectToolCallLoop(state, "read", { path: "/same.txt" });
+      expect(loopResult.stuck).toBe(true);
+    });
+
+    it("can still be explicitly disabled per-session", () => {
+      const state = createState();
+
+      for (let i = 0; i < 20; i += 1) {
+        recordToolCall(state, "read", { path: "/same.txt" }, `disabled-${i}`);
+      }
+
+      const loopResult = detectToolCallLoop(
+        state,
+        "read",
+        { path: "/same.txt" },
+        { enabled: false },
+      );
       expect(loopResult.stuck).toBe(false);
     });
 

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -36,13 +36,18 @@ type LoopDetectionResult =
       warningKey?: string;
     };
 
-const TOOL_CALL_HISTORY_SIZE = 30;
-const WARNING_THRESHOLD = 10;
+export const TOOL_CALL_HISTORY_SIZE = 30;
+export const WARNING_THRESHOLD = 10;
 export const UNKNOWN_TOOL_THRESHOLD = 10;
-const CRITICAL_THRESHOLD = 20;
-const GLOBAL_CIRCUIT_BREAKER_THRESHOLD = 30;
+export const CRITICAL_THRESHOLD = 20;
+export const GLOBAL_CIRCUIT_BREAKER_THRESHOLD = 30;
+// Enabled by default — this was previously off, meaning nothing stopped a
+// stuck agent from repeating expensive tool calls indefinitely on every
+// heartbeat. Thresholds below are unchanged and already sane
+// (warn at 10, block at 20/30). Set tools.loopDetection.enabled=false in
+// config to opt out for a specific deployment.
 const DEFAULT_LOOP_DETECTION_CONFIG = {
-  enabled: false,
+  enabled: true,
   historySize: TOOL_CALL_HISTORY_SIZE,
   warningThreshold: WARNING_THRESHOLD,
   unknownToolThreshold: UNKNOWN_TOOL_THRESHOLD,


### PR DESCRIPTION
## Summary

Two always-on OpenClaw gateways I run (Mac Mini + a MacBook, both on 30-min heartbeats) drove a confirmed $347-$1,382/day Anthropic spend spike, root-caused to:

1. Tool-loop detection (`src/agents/tool-loop-detection.ts`) defaulting to **disabled**, so a stuck agent could repeat expensive tool calls indefinitely on every heartbeat with nothing to stop it.
2. No spend cap or kill-switch of any kind on the gateway process itself — an alert-only signal (e.g. a cron reading the Anthropic Admin API) can't stop a runaway loop; only something that can actually `launchctl bootout` the gateway can.

Note: this branch was rebased onto current `main`, which already moved `DEFAULT_MODEL`/`DEFAULT_PROVIDER` off Opus independently (now `openai`/`gpt-5.6-sol`) — I dropped that part of my original patch since it's superseded, and adjusted the regression test in `defaults.test.ts` accordingly (guards against an Opus-tier *Anthropic* default specifically, the empirically-confirmed cost driver, rather than asserting a specific replacement model).

## Changes

- `src/agents/tool-loop-detection.ts`: `DEFAULT_LOOP_DETECTION_CONFIG.enabled` → `true`. Thresholds unchanged (warn 10, block 20/30). Opt out per-deployment via `tools.loopDetection.enabled=false`.
- `src/agents/tool-loop-detection.test.ts`: updated the "disabled by default" test to reflect the new enabled-by-default behavior, added a test confirming it can still be explicitly disabled.
- `src/agents/defaults.test.ts`: new regression test asserting the primary agent model default never regresses to an Opus-tier Anthropic model.
- `scripts/spend-guardrail.sh` (new): polls the Anthropic Admin API for today's actual billed spend; if it exceeds a configurable daily cap (env `SPEND_CAP_USD`), stops the gateway via `launchctl bootout` (system LaunchDaemon or user LaunchAgent, domain-aware) and writes a `SPEND-PAUSED` marker file as a kill-switch so it doesn't restart on its own. Sends an alert via ntfy.sh and/or Slack `chat.postMessage` (token read from `openclaw.json`'s Slack channel config or passed explicitly).
- `docs/automation/spend-guardrail.md` (new) + `docs/docs.json`: documents installation (cron every 30 min), how to resume after a trip, and tuning the cap.

## Test plan

- [x] `src/agents/defaults.test.ts`, `src/agents/tool-loop-detection.test.ts` pass (verified via `vitest run` — full workspace test run is blocked locally by `packageManager: pnpm@11.15.1` requiring Node ≥22.13, unrelated to this change; confirmed the failure reproduces identically on a clean `main` checkout with no changes of mine)
- [x] Live-deployed the config-level equivalent (Sonnet primary model, loop detection on, spend guardrail installed) on both of my own gateways and confirmed via the Anthropic Admin API that spend dropped back to baseline

Made with [Cursor](https://cursor.com)