### PR TITLE
fix(browser): connect managed CDP through the correct proxy endpoint

### DIFF
--- a/extensions/browser/src/browser/pw-session-connection.ts
+++ b/extensions/browser/src/browser/pw-session-connection.ts
@@ -3,7 +3,7 @@ import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runti
 import type { Browser, BrowserContext, CDPSession, Page } from "playwright-core";
 import { formatErrorMessage, toErrorObject } from "../infra/errors.js";
 import type { SsrFPolicy } from "../infra/net/ssrf.js";
-import { withNoProxyForCdpUrl } from "./cdp-proxy-bypass.js";
+import { withManagedProxyForCdpUrl, withNoProxyForCdpUrl } from "./cdp-proxy-bypass.js";
 import { PLAYWRIGHT_TARGET_INFO_TIMEOUT_MS } from "./cdp-timeouts.js";
 import {
   assertCdpEndpointAllowed,
@@ -421,9 +421,11 @@ export async function connectBrowser(
         const connectEndpoint = async (target: string) => {
           const headers = getHeadersWithAuth(target);
           const connectionUrl = stripCdpUrlCredentials(target);
-          // Bypass proxy for loopback CDP connections (#31219)
-          return await withNoProxyForCdpUrl(connectionUrl, () =>
-            chromium.connectOverCDP(connectionUrl, { timeout, headers }),
+          // Keep both loopback bypasses active until the Playwright handshake settles.
+          return await withManagedProxyForCdpUrl(connectionUrl, () =>
+            withNoProxyForCdpUrl(connectionUrl, () =>
+              chromium.connectOverCDP(connectionUrl, { timeout, headers }),
+            ),
           );
         };
         let browser: Browser;

--- a/extensions/browser/src/browser/pw-session.connections.test.ts
+++ b/extensions/browser/src/browser/pw-session.connections.test.ts
@@ -4,6 +4,16 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import * as chromeModule from "./chrome.js";
 import { pwAi } from "./pw-ai.js";
 
+const { registerManagedProxyBrowserCdpBypassMock } = vi.hoisted(() => ({
+  registerManagedProxyBrowserCdpBypassMock: vi.fn<(url: string) => (() => void) | undefined>(
+    () => undefined,
+  ),
+}));
+
+vi.mock("openclaw/plugin-sdk/ssrf-runtime-internal", () => ({
+  registerManagedProxyBrowserCdpBypass: registerManagedProxyBrowserCdpBypassMock,
+}));
+
 const {
   closePlaywrightBrowserConnection,
   createPageViaPlaywright,
@@ -222,11 +232,94 @@ function makeMutatingDisconnectBrowser(): BrowserMockBundle & {
 afterEach(async () => {
   connectOverCdpSpy.mockReset();
   getChromeWebSocketUrlSpy.mockReset();
+  registerManagedProxyBrowserCdpBypassMock.mockReset();
+  registerManagedProxyBrowserCdpBypassMock.mockImplementation(() => undefined);
   await closePlaywrightBrowserConnection().catch(() => {});
   vi.useRealTimers();
 });
 
 describe("pw-session connection scoping", () => {
+  it("keeps the exact managed-proxy bypass active through a discovered CDP handshake", async () => {
+    const browser = makeBrowser("A", "https://example.com");
+    const wsUrl = "ws://127.0.0.1:9222/devtools/browser/discovered";
+    const release = vi.fn();
+    registerManagedProxyBrowserCdpBypassMock.mockReturnValue(release);
+    getChromeWebSocketUrlSpy.mockResolvedValue(wsUrl);
+    connectOverCdpSpy.mockImplementationOnce(async () => {
+      expect(registerManagedProxyBrowserCdpBypassMock).toHaveBeenCalledWith(wsUrl);
+      expect(release).not.toHaveBeenCalled();
+      return browser.browser;
+    });
+
+    await expect(listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:9222" })).resolves.toEqual([
+      expect.objectContaining({ targetId: "A" }),
+    ]);
+
+    expect(registerManagedProxyBrowserCdpBypassMock).toHaveBeenCalledOnce();
+    expect(release).toHaveBeenCalledOnce();
+  });
+
+  it("registers only the credential-stripped Playwright CDP endpoint", async () => {
+    const browser = makeBrowser("A", "https://example.com");
+    const cdpUrl = "wss://browser-user:browser-password@browserless.example/devtools/browser/id";
+    connectOverCdpSpy.mockResolvedValue(browser.browser);
+    getChromeWebSocketUrlSpy.mockResolvedValue(null);
+
+    await listPagesViaPlaywright({ cdpUrl });
+
+    expect(registerManagedProxyBrowserCdpBypassMock).toHaveBeenCalledWith(
+      "wss://browserless.example/devtools/browser/id",
+    );
+  });
+
+  it("releases every managed-proxy bypass after failed CDP connection attempts", async () => {
+    const releases: Array<ReturnType<typeof vi.fn>> = [];
+    registerManagedProxyBrowserCdpBypassMock.mockImplementation(() => {
+      const release = vi.fn();
+      releases.push(release);
+      return release;
+    });
+    connectOverCdpSpy.mockRejectedValue(new Error("CDP socket hang up"));
+    getChromeWebSocketUrlSpy.mockResolvedValue(null);
+
+    await expect(listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:9222" })).rejects.toThrow(
+      "CDP socket hang up",
+    );
+
+    expect(registerManagedProxyBrowserCdpBypassMock).toHaveBeenCalledTimes(3);
+    expect(releases).toHaveLength(3);
+    for (const release of releases) {
+      expect(release).toHaveBeenCalledOnce();
+    }
+  });
+
+  it("registers and releases the exact endpoint for both WebSocket connection attempts", async () => {
+    const browser = makeBrowser("A", "https://example.com");
+    const cdpUrl = "ws://127.0.0.1:9222/devtools/browser/original";
+    const discoveredUrl = "ws://127.0.0.1:9222/devtools/browser/discovered";
+    const releases: Array<ReturnType<typeof vi.fn>> = [];
+    registerManagedProxyBrowserCdpBypassMock.mockImplementation(() => {
+      const release = vi.fn();
+      releases.push(release);
+      return release;
+    });
+    getChromeWebSocketUrlSpy.mockResolvedValue(discoveredUrl);
+    connectOverCdpSpy
+      .mockRejectedValueOnce(new Error("stale discovered endpoint"))
+      .mockResolvedValueOnce(browser.browser);
+
+    await expect(listPagesViaPlaywright({ cdpUrl })).resolves.toEqual([
+      expect.objectContaining({ targetId: "A" }),
+    ]);
+
+    expect(registerManagedProxyBrowserCdpBypassMock).toHaveBeenNthCalledWith(1, discoveredUrl);
+    expect(registerManagedProxyBrowserCdpBypassMock).toHaveBeenNthCalledWith(2, cdpUrl);
+    expect(releases).toHaveLength(2);
+    for (const release of releases) {
+      expect(release).toHaveBeenCalledOnce();
+    }
+  });
+
   it("keeps URL credentials out of Playwright and escaped connection errors", async () => {
     const username = "browser-user";
     const password = "browser-password";


### PR DESCRIPTION
## What Problem This Solves
Managed browser sessions can route the local Chrome DevTools Protocol handshake through an HTTP forward proxy, causing real page snapshot requests to fail.

## Why This Change Was Made
Keep the existing exact managed-CDP proxy bypass active throughout Playwright's asynchronous handshake. Ordinary HTTP remains proxied and unrelated loopback requests remain blocked.

## User Impact
A managed browser behind an enabled proxy can open a real page and return an interactive snapshot without relaxing global network or proxy policy.

## Evidence
- Four targeted managed-CDP regressions fail before the change: https://github.com/openclaw/openclaw/actions/runs/30261004333
- All 76 targeted and adjacent browser regressions pass afterward: https://github.com/openclaw/openclaw/actions/runs/30261235527
- Exact-head required CI gate: https://github.com/openclaw/openclaw/actions/runs/30263090204/job/89969135655
- Fresh independent autoreview: no actionable findings.

## Real end-to-end proof
Exact commit `ec3e8ca7292fbb85296667b2a58c4803aa626c12`; trusted 16-vCPU Blacksmith runner, production `pnpm build`, actual Chrome 149, actual OpenClaw gateway, and an instrumented real HTTP forward proxy.

- Live proof run: https://github.com/openclaw/openclaw/actions/runs/30265371696
- Exact runner job: https://github.com/openclaw/openclaw/actions/runs/30265371696/job/89974665241

```text
proxy validate --json --allowed-url http://proxy-proof.openclaw.invalid/ordinary
=> ok: true; external proxy request: HTTP 200
browser --browser-profile proof-local open http://127.0.0.1:29972/
=> managed Chrome started; CDP 127.0.0.1:29974
browser --browser-profile proof-local snapshot --interactive --urls
=> button "Save"
=> link "Docs"
=> Docs -> https://docs.openclaw.ai/browser-cdp-live
ordinaryProxyHits=1; blockedCdpHits=0; blockedOtherLoopbackHits=1
browser stop => running: false
scenario runStatus=succeeded; exitCode=0; duration=34.790s
```

The actual forward proxy observed ordinary outbound traffic, never observed a CDP request, and continued blocking a separate loopback canary. The isolated browser and Testbox were stopped. The Actions runner may finish its cleanup asynchronously; the authoritative scenario result is the successful delegated-run timing JSON.

AI-assisted. Source, dependency contract, regression proof, exact CI, and actual managed-browser behavior were independently reviewed.

Fixes #105306