### PR TITLE
fix(plugins): prevent bundled discovery loss and out-of-scope activation

### DIFF
--- a/src/agents/model-auth.test.ts
+++ b/src/agents/model-auth.test.ts
@@ -1,4 +1,5 @@
 // Verifies provider auth resolution, synthetic auth, and auth header behavior.
+import { fileURLToPath } from "node:url";
 import type { Model } from "openclaw/plugin-sdk/llm";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ModelProviderConfig } from "../config/config.js";
@@ -17,11 +18,34 @@ import {
 } from "./provider-request-config.js";
 
 vi.mock("../plugins/plugin-registry.js", () => ({
-  loadPluginRegistrySnapshotWithMetadata: () => ({
-    source: "derived",
-    snapshot: { plugins: [] },
-    diagnostics: [],
-  }),
+  loadPluginRegistrySnapshotWithMetadata: () => {
+    const rootDir = fileURLToPath(new URL("../../extensions/ollama/", import.meta.url));
+    return {
+      source: "derived",
+      snapshot: {
+        plugins: [
+          {
+            pluginId: "ollama",
+            manifestPath: fileURLToPath(
+              new URL("../../extensions/ollama/openclaw.plugin.json", import.meta.url),
+            ),
+            manifestHash: "ollama-model-auth-fixture",
+            rootDir,
+            origin: "bundled",
+            enabled: true,
+            startup: {
+              sidecar: false,
+              memory: false,
+              deferConfiguredChannelFullLoadUntilAfterListen: false,
+              agentHarnesses: [],
+            },
+            compat: [],
+          },
+        ],
+      },
+      diagnostics: [],
+    };
+  },
   loadPluginManifestRegistryForPluginRegistry: () => ({
     diagnostics: [],
     plugins: [

--- a/src/agents/model-selection.plugin-runtime.test.ts
+++ b/src/agents/model-selection.plugin-runtime.test.ts
@@ -26,9 +26,14 @@ vi.mock("./provider-model-normalization.runtime.js", () => ({
     normalizeProviderModelIdWithPluginMock(params),
 }));
 
-vi.mock("../plugins/current-plugin-metadata-snapshot.js", () => ({
-  getCurrentPluginMetadataSnapshot: getCurrentPluginMetadataSnapshotMock,
-}));
+vi.mock("../plugins/current-plugin-metadata-snapshot.js", async () => {
+  const { clearCurrentPluginMetadataSnapshot } =
+    await import("../plugins/current-plugin-metadata-state.js");
+  return {
+    clearCurrentPluginMetadataSnapshot,
+    getCurrentPluginMetadataSnapshot: getCurrentPluginMetadataSnapshotMock,
+  };
+});
 
 vi.mock("./model-catalog.runtime.js", () => ({
   loadManifestModelCatalog: () => [],

--- a/src/auto-reply/reply/commands-models.test.ts
+++ b/src/auto-reply/reply/commands-models.test.ts
@@ -138,9 +138,14 @@ vi.mock("../../agents/provider-model-normalization.runtime.js", () => ({
     normalizeProviderModelIdWithRuntimeMock(params),
 }));
 
-vi.mock("../../plugins/current-plugin-metadata-snapshot.js", () => ({
-  getCurrentPluginMetadataSnapshot: () => pluginMetadataMocks.snapshot,
-}));
+vi.mock("../../plugins/current-plugin-metadata-snapshot.js", async () => {
+  const { clearCurrentPluginMetadataSnapshot } =
+    await import("../../plugins/current-plugin-metadata-state.js");
+  return {
+    clearCurrentPluginMetadataSnapshot,
+    getCurrentPluginMetadataSnapshot: () => pluginMetadataMocks.snapshot,
+  };
+});
 
 const telegramModelsTestPlugin: ChannelPlugin = {
   ...createChannelTestPluginBase({

--- a/src/auto-reply/reply/commands-models.test.ts
+++ b/src/auto-reply/reply/commands-models.test.ts
@@ -12,9 +12,7 @@ import {
 import { buildModelsProviderData, handleModelsCommand } from "./commands-models.js";
 import type { HandleCommandsParams } from "./commands-types.js";
 
-const modelCatalogMocks = vi.hoisted(() => ({
-  loadModelCatalog: vi.fn(),
-}));
+const modelCatalogMocks = vi.hoisted(() => ({ loadModelCatalog: vi.fn() }));
 
 const modelAuthLabelMocks = vi.hoisted(() => ({
   resolveModelAuthLabel: vi.fn<(params: unknown) => string | undefined>(() => undefined),
@@ -139,8 +137,9 @@ vi.mock("../../agents/provider-model-normalization.runtime.js", () => ({
 }));
 
 vi.mock("../../plugins/current-plugin-metadata-snapshot.js", async () => ({
-  clearCurrentPluginMetadataSnapshot: (await import("../../plugins/current-plugin-metadata-state.js"))
-    .clearCurrentPluginMetadataSnapshot,
+  clearCurrentPluginMetadataSnapshot: (
+    await import("../../plugins/current-plugin-metadata-state.js")
+  ).clearCurrentPluginMetadataSnapshot,
   getCurrentPluginMetadataSnapshot: () => pluginMetadataMocks.snapshot,
 }));
 

--- a/src/auto-reply/reply/commands-models.test.ts
+++ b/src/auto-reply/reply/commands-models.test.ts
@@ -138,14 +138,11 @@ vi.mock("../../agents/provider-model-normalization.runtime.js", () => ({
     normalizeProviderModelIdWithRuntimeMock(params),
 }));
 
-vi.mock("../../plugins/current-plugin-metadata-snapshot.js", async () => {
-  const { clearCurrentPluginMetadataSnapshot } =
-    await import("../../plugins/current-plugin-metadata-state.js");
-  return {
-    clearCurrentPluginMetadataSnapshot,
-    getCurrentPluginMetadataSnapshot: () => pluginMetadataMocks.snapshot,
-  };
-});
+vi.mock("../../plugins/current-plugin-metadata-snapshot.js", async () => ({
+  clearCurrentPluginMetadataSnapshot: (await import("../../plugins/current-plugin-metadata-state.js"))
+    .clearCurrentPluginMetadataSnapshot,
+  getCurrentPluginMetadataSnapshot: () => pluginMetadataMocks.snapshot,
+}));
 
 const telegramModelsTestPlugin: ChannelPlugin = {
   ...createChannelTestPluginBase({

--- a/src/plugins/current-plugin-metadata-snapshot.test.ts
+++ b/src/plugins/current-plugin-metadata-snapshot.test.ts
@@ -12,6 +12,7 @@ import {
 } from "./current-plugin-metadata-snapshot.js";
 import { resolveInstalledPluginIndexPolicyHash } from "./installed-plugin-index-policy.js";
 import { writePersistedInstalledPluginIndexSync } from "./installed-plugin-index-store.js";
+import { clearPluginMetadataLifecycleCaches } from "./plugin-metadata-lifecycle.js";
 import type { PluginMetadataSnapshot } from "./plugin-metadata-snapshot.js";
 
 function createSnapshot(
@@ -305,6 +306,15 @@ describe("current plugin metadata snapshot", () => {
     clearCurrentPluginMetadataSnapshot();
 
     expect(getCurrentPluginMetadataSnapshot()).toBeUndefined();
+  });
+
+  it("clears the complete current snapshot when its metadata lifecycle is invalidated", () => {
+    const config = { plugins: { allow: ["demo"] } };
+    setCurrentPluginMetadataSnapshot(createSnapshot({ config }), { config });
+
+    clearPluginMetadataLifecycleCaches();
+
+    expect(getCurrentPluginMetadataSnapshot({ config })).toBeUndefined();
   });
 
   it("keeps derived registry snapshots as the current process snapshot", () => {

--- a/src/plugins/current-plugin-metadata-snapshot.ts
+++ b/src/plugins/current-plugin-metadata-snapshot.ts
@@ -35,12 +35,6 @@ function resolvePluginMetadataControlPlaneFingerprint(
   });
 }
 
-export function isReusableCurrentPluginMetadataSnapshot(
-  _snapshot: PluginMetadataSnapshot,
-): boolean {
-  return true;
-}
-
 // Single-slot Gateway-owned handoff. Replace or clear it at lifecycle boundaries;
 // never accumulate historical metadata snapshots here.
 export function setCurrentPluginMetadataSnapshot(

--- a/src/plugins/current-plugin-metadata-snapshot.ts
+++ b/src/plugins/current-plugin-metadata-snapshot.ts
@@ -2,7 +2,7 @@
 import { setCurrentManifestModelIdNormalizationRecords } from "@openclaw/model-catalog-core/provider-model-id-normalization";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
-  clearCurrentPluginMetadataSnapshotState,
+  currentPluginMetadataConfigIdentityCache,
   getCurrentPluginMetadataSnapshotState,
   setCurrentPluginMetadataSnapshotState,
 } from "./current-plugin-metadata-state.js";
@@ -11,7 +11,6 @@ import {
   resolvePluginControlPlaneFingerprint,
   type ResolvePluginControlPlaneContextParams,
 } from "./plugin-control-plane-context.js";
-import { registerPluginMetadataProcessMemoLifecycleClear } from "./plugin-metadata-lifecycle.js";
 import type {
   PluginMetadataSnapshot,
   PluginMetadataSnapshotPluginIdScope,
@@ -19,9 +18,7 @@ import type {
 import { normalizePluginIdScope, serializePluginIdScope } from "./plugin-scope.js";
 
 type CurrentPluginMetadataSnapshotState = ReturnType<typeof getCurrentPluginMetadataSnapshotState>;
-let currentPluginMetadataConfigIdentityCache = new WeakSet<OpenClawConfig>();
-
-registerPluginMetadataProcessMemoLifecycleClear(clearCurrentPluginMetadataSnapshot);
+export { clearCurrentPluginMetadataSnapshot } from "./current-plugin-metadata-state.js";
 
 function resolvePluginMetadataControlPlaneFingerprint(
   config?: OpenClawConfig,
@@ -44,7 +41,7 @@ export function setCurrentPluginMetadataSnapshot(
     workspaceDir?: string;
   } = {},
 ): void {
-  currentPluginMetadataConfigIdentityCache = new WeakSet();
+  currentPluginMetadataConfigIdentityCache.clear();
   const compatiblePolicyHashes = snapshot
     ? options.compatibleConfigs?.map((config) => resolveInstalledPluginIndexPolicyHash(config))
     : undefined;
@@ -109,12 +106,6 @@ export function setCurrentPluginMetadataSnapshot(
   }
 }
 
-export function clearCurrentPluginMetadataSnapshot(): void {
-  currentPluginMetadataConfigIdentityCache = new WeakSet();
-  setCurrentManifestModelIdNormalizationRecords(undefined);
-  clearCurrentPluginMetadataSnapshotState();
-}
-
 export function captureCurrentPluginMetadataSnapshotState(): CurrentPluginMetadataSnapshotState {
   return getCurrentPluginMetadataSnapshotState();
 }
@@ -122,7 +113,7 @@ export function captureCurrentPluginMetadataSnapshotState(): CurrentPluginMetada
 export function restoreCurrentPluginMetadataSnapshotState(
   state: CurrentPluginMetadataSnapshotState,
 ): void {
-  currentPluginMetadataConfigIdentityCache = new WeakSet();
+  currentPluginMetadataConfigIdentityCache.clear();
   const snapshot = state.snapshot as PluginMetadataSnapshot | undefined;
   const defaultDiscoveryConfigFingerprint = snapshot
     ? resolvePluginMetadataControlPlaneFingerprint(

--- a/src/plugins/current-plugin-metadata-snapshot.ts
+++ b/src/plugins/current-plugin-metadata-snapshot.ts
@@ -21,9 +21,7 @@ import { normalizePluginIdScope, serializePluginIdScope } from "./plugin-scope.j
 type CurrentPluginMetadataSnapshotState = ReturnType<typeof getCurrentPluginMetadataSnapshotState>;
 let currentPluginMetadataConfigIdentityCache = new WeakSet<OpenClawConfig>();
 
-registerPluginMetadataProcessMemoLifecycleClear(() => {
-  setCurrentManifestModelIdNormalizationRecords(undefined);
-});
+registerPluginMetadataProcessMemoLifecycleClear(clearCurrentPluginMetadataSnapshot);
 
 function resolvePluginMetadataControlPlaneFingerprint(
   config?: OpenClawConfig,

--- a/src/plugins/current-plugin-metadata-state.ts
+++ b/src/plugins/current-plugin-metadata-state.ts
@@ -1,8 +1,25 @@
 // Holds current plugin metadata snapshots for process-scoped consumers.
+import { setCurrentManifestModelIdNormalizationRecords } from "@openclaw/model-catalog-core/provider-model-id-normalization";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+
 let currentPluginMetadataSnapshot: unknown;
 let currentPluginMetadataSnapshotConfigFingerprint: string | undefined;
 let currentPluginMetadataSnapshotCompatiblePolicyHashes: readonly string[] | undefined;
 let currentPluginMetadataSnapshotCompatibleConfigFingerprints: readonly string[] | undefined;
+let currentPluginMetadataConfigIdentities = new WeakSet<OpenClawConfig>();
+
+/** Owns config identity reuse for the current immutable metadata snapshot. */
+export const currentPluginMetadataConfigIdentityCache = {
+  add(config: OpenClawConfig): void {
+    currentPluginMetadataConfigIdentities.add(config);
+  },
+  clear(): void {
+    currentPluginMetadataConfigIdentities = new WeakSet();
+  },
+  has(config: OpenClawConfig): boolean {
+    return currentPluginMetadataConfigIdentities.has(config);
+  },
+};
 
 /** Stores the process-current plugin metadata snapshot and compatible config fingerprints. */
 export function setCurrentPluginMetadataSnapshotState(
@@ -22,11 +39,18 @@ export function setCurrentPluginMetadataSnapshotState(
 }
 
 /** Clears the process-current plugin metadata snapshot. */
-export function clearCurrentPluginMetadataSnapshotState(): void {
+function clearCurrentPluginMetadataSnapshotState(): void {
   currentPluginMetadataSnapshot = undefined;
   currentPluginMetadataSnapshotConfigFingerprint = undefined;
   currentPluginMetadataSnapshotCompatiblePolicyHashes = undefined;
   currentPluginMetadataSnapshotCompatibleConfigFingerprints = undefined;
+}
+
+/** Clears the snapshot, its identity cache, and process-wide model normalization. */
+export function clearCurrentPluginMetadataSnapshot(): void {
+  currentPluginMetadataConfigIdentityCache.clear();
+  setCurrentManifestModelIdNormalizationRecords(undefined);
+  clearCurrentPluginMetadataSnapshotState();
 }
 
 /** Returns the process-current plugin metadata snapshot state. */

--- a/src/plugins/plugin-metadata-lifecycle.ts
+++ b/src/plugins/plugin-metadata-lifecycle.ts
@@ -1,5 +1,5 @@
 /** Coordinates plugin metadata snapshot and process memo cache lifecycle resets. */
-import { clearCurrentPluginMetadataSnapshotState } from "./current-plugin-metadata-state.js";
+import { clearCurrentPluginMetadataSnapshot } from "./current-plugin-metadata-state.js";
 
 const pluginMetadataProcessMemoClears = new Set<() => void>();
 
@@ -12,7 +12,7 @@ export function registerPluginMetadataProcessMemoLifecycleClear(
 
 /** Clears plugin metadata snapshots and registered process memo caches. */
 export function clearPluginMetadataLifecycleCaches(): void {
-  clearCurrentPluginMetadataSnapshotState();
+  clearCurrentPluginMetadataSnapshot();
   for (const clearProcessMemo of pluginMetadataProcessMemoClears) {
     clearProcessMemo();
   }

--- a/src/plugins/plugin-metadata-snapshot.test.ts
+++ b/src/plugins/plugin-metadata-snapshot.test.ts
@@ -17,6 +17,7 @@ const {
   loadPluginRegistrySnapshotWithMetadata,
   loadPluginManifestRegistry,
   loadPluginManifestRegistryForInstalledIndex,
+  loadInstalledPluginIndexWithDiscovery,
 } = vi.hoisted(() => {
   // Shared plugin workers must load this graph after this file's mocks are installed.
   vi.resetModules();
@@ -24,6 +25,7 @@ const {
     loadPluginRegistrySnapshotWithMetadata: vi.fn(),
     loadPluginManifestRegistry: vi.fn(),
     loadPluginManifestRegistryForInstalledIndex: vi.fn(),
+    loadInstalledPluginIndexWithDiscovery: vi.fn(),
   };
 });
 
@@ -50,6 +52,15 @@ vi.mock("./manifest-registry-installed.js", async (importOriginal) => {
     ...actual,
     loadPluginManifestRegistryForInstalledIndex: (params: unknown) =>
       loadPluginManifestRegistryForInstalledIndex(params),
+  };
+});
+
+vi.mock("./installed-plugin-index.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./installed-plugin-index.js")>();
+  return {
+    ...actual,
+    loadInstalledPluginIndexWithDiscovery: (params: unknown) =>
+      loadInstalledPluginIndexWithDiscovery(params),
   };
 });
 
@@ -108,7 +119,12 @@ describe("plugin metadata snapshot", () => {
     loadPluginManifestRegistry.mockReset();
     loadPluginManifestRegistry.mockReturnValue({ plugins: [], diagnostics: [] });
     loadPluginManifestRegistryForInstalledIndex.mockReset();
+    loadInstalledPluginIndexWithDiscovery.mockReset();
     loadPluginManifestRegistryForInstalledIndex.mockReturnValue(makeManifestRegistry());
+    loadInstalledPluginIndexWithDiscovery.mockReturnValue({
+      index: makeIndex(),
+      discovery: { candidates: [], diagnostics: [] },
+    });
   });
 
   afterEach(() => {
@@ -316,12 +332,69 @@ describe("plugin metadata snapshot", () => {
       diagnostics: [],
       discovery,
     });
+    loadPluginManifestRegistryForInstalledIndex.mockReturnValue({
+      plugins: [],
+      diagnostics: [],
+    });
 
     const snapshot = loadPluginMetadataSnapshot({ config: {}, env: {} });
 
-    expect(loadPluginManifestRegistry).toHaveBeenCalledWith(expect.objectContaining({ discovery }));
-    expect(loadPluginManifestRegistryForInstalledIndex).not.toHaveBeenCalled();
+    expect(loadPluginManifestRegistry).not.toHaveBeenCalled();
+    expect(loadPluginManifestRegistryForInstalledIndex).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({
+        index: expect.objectContaining({ plugins: [] }),
+        includeDisabled: true,
+      }),
+    );
     expect(snapshot.discovery).toBe(discovery);
+  });
+
+  it("keeps an empty installed index authoritative without rediscovering plugins", () => {
+    const index = makeIndex();
+    index.plugins = [];
+    loadPluginRegistrySnapshotWithMetadata.mockReturnValue({
+      source: "persisted",
+      snapshot: index,
+      diagnostics: [],
+    });
+    loadPluginManifestRegistryForInstalledIndex.mockReturnValue({
+      plugins: [],
+      diagnostics: [],
+    });
+
+    const snapshot = loadPluginMetadataSnapshot({ config: {}, env: {}, index });
+
+    expect(snapshot.plugins).toEqual([]);
+    expect(snapshot.index.plugins).toEqual([]);
+    expect(loadPluginManifestRegistryForInstalledIndex).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({
+        index: expect.objectContaining({ plugins: [] }),
+        includeDisabled: true,
+      }),
+    );
+    expect(loadInstalledPluginIndexWithDiscovery).not.toHaveBeenCalled();
+  });
+
+  it("bootstraps bundled discovery when no registry snapshot is available", () => {
+    loadPluginRegistrySnapshotWithMetadata.mockReturnValue(undefined);
+
+    const snapshot = loadPluginMetadataSnapshot({ config: {}, env: {} });
+
+    expect(snapshot.plugins.map((plugin) => plugin.id)).toEqual(["demo"]);
+    expect(snapshot.registrySource).toBe("derived");
+    expect(snapshot.index.plugins.map((plugin) => plugin.pluginId)).toEqual(["demo"]);
+    expect(loadInstalledPluginIndexWithDiscovery).toHaveBeenCalledExactlyOnceWith({
+      config: {},
+      env: {},
+    });
+    expect(loadPluginManifestRegistryForInstalledIndex).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({
+        index: expect.objectContaining({
+          plugins: [expect.objectContaining({ pluginId: "demo" })],
+        }),
+        includeDisabled: true,
+      }),
+    );
   });
 
   it("reuses the lifecycle-owned current snapshot", () => {
@@ -368,6 +441,43 @@ describe("plugin metadata snapshot", () => {
       "pluginIds",
     );
   });
+
+  it.each([
+    { scope: "explicit empty", pluginIds: [], expectedPluginIds: [] },
+    { scope: "explicit owner", pluginIds: ["demo"], expectedPluginIds: ["demo"] },
+  ])(
+    "does not reuse an unscoped lifecycle graph for an $scope request",
+    ({ pluginIds, expectedPluginIds }) => {
+      const config = {};
+      const index = makeIndex();
+      index.policyHash = resolveInstalledPluginIndexPolicyHash(config);
+      loadPluginRegistrySnapshotWithMetadata.mockReturnValue({
+        source: "provided",
+        snapshot: index,
+        diagnostics: [],
+      });
+      const unscoped = loadPluginMetadataSnapshot({ config, env: {}, index });
+      setCurrentPluginMetadataSnapshot(unscoped, { config, env: {} });
+      loadPluginManifestRegistryForInstalledIndex.mockClear();
+      loadPluginManifestRegistryForInstalledIndex.mockImplementation(
+        (params: { pluginIds?: readonly string[] }) => ({
+          ...makeManifestRegistry(),
+          plugins: makeManifestRegistry().plugins.filter(
+            (plugin) => params.pluginIds === undefined || params.pluginIds.includes(plugin.id),
+          ),
+        }),
+      );
+
+      const scoped = resolvePluginMetadataSnapshot({ config, env: {}, pluginIds });
+
+      expect(scoped).not.toBe(unscoped);
+      expect(scoped.pluginIds).toEqual(pluginIds);
+      expect(scoped.plugins.map((plugin) => plugin.id)).toEqual(expectedPluginIds);
+      expect(loadPluginManifestRegistryForInstalledIndex).toHaveBeenCalledExactlyOnceWith(
+        expect.objectContaining({ pluginIds }),
+      );
+    },
+  );
 
   it("prepares provider endpoint and request facts", () => {
     const index = makeIndex();

--- a/src/plugins/plugin-metadata-snapshot.ts
+++ b/src/plugins/plugin-metadata-snapshot.ts
@@ -7,12 +7,15 @@ import {
 import { getCurrentPluginMetadataSnapshot } from "./current-plugin-metadata-snapshot.js";
 import { hashJson } from "./installed-plugin-index-hash.js";
 import { resolveInstalledPluginIndexPolicyHash } from "./installed-plugin-index-policy.js";
-import type { InstalledPluginIndex } from "./installed-plugin-index.js";
+import {
+  loadInstalledPluginIndexWithDiscovery,
+  type InstalledPluginIndex,
+} from "./installed-plugin-index.js";
 import {
   loadPluginManifestRegistryForInstalledIndex,
   resolveInstalledManifestRegistryIndexFingerprint,
 } from "./manifest-registry-installed.js";
-import { loadPluginManifestRegistry, type PluginManifestRecord } from "./manifest-registry.js";
+import type { PluginManifestRecord } from "./manifest-registry.js";
 import { resolvePluginControlPlaneFingerprint } from "./plugin-control-plane-context.js";
 import { buildPluginMetadataProviderFacts } from "./plugin-metadata-provider-facts.js";
 import type {
@@ -374,40 +377,29 @@ function loadPluginMetadataSnapshotImpl(
 ): PluginMetadataSnapshot {
   const totalStartedAt = performance.now();
   const registryStartedAt = performance.now();
-  const registryResult = loadPluginRegistrySnapshotWithMetadata({
-    config: params.config,
-    workspaceDir: params.workspaceDir,
-    ...(params.stateDir ? { stateDir: params.stateDir } : {}),
-    env: params.env,
-    ...(params.preferPersisted !== undefined ? { preferPersisted: params.preferPersisted } : {}),
-    ...(params.index ? { index: params.index } : {}),
-  }) ?? {
-    source: "derived" as const,
-    snapshot: { plugins: [] },
-    diagnostics: [],
-  };
+  const registryResult =
+    loadPluginRegistrySnapshotWithMetadata({
+      config: params.config,
+      workspaceDir: params.workspaceDir,
+      ...(params.stateDir ? { stateDir: params.stateDir } : {}),
+      env: params.env,
+      ...(params.preferPersisted !== undefined ? { preferPersisted: params.preferPersisted } : {}),
+      ...(params.index ? { index: params.index } : {}),
+    }) ?? deriveBootstrapPluginRegistrySnapshot(params);
   const registrySnapshotMs = performance.now() - registryStartedAt;
   const index = normalizeInstalledPluginIndex(registryResult.snapshot);
   const pluginIds = resolvePluginMetadataSnapshotPluginIds({ params, index });
   const manifestStartedAt = performance.now();
-  const manifestRegistry =
-    index.plugins.length === 0
-      ? loadPluginManifestRegistry({
-          config: params.config,
-          workspaceDir: params.workspaceDir,
-          env: params.env,
-          diagnostics: [...index.diagnostics],
-          installRecords: index.installRecords,
-          ...(registryResult.discovery ? { discovery: registryResult.discovery } : {}),
-        })
-      : loadPluginManifestRegistryForInstalledIndex({
-          index,
-          config: params.config,
-          workspaceDir: params.workspaceDir,
-          env: params.env,
-          ...(pluginIds !== undefined ? { pluginIds } : {}),
-          includeDisabled: true,
-        });
+  // Empty installed indexes are authoritative; bootstrap first derives a real
+  // index so every manifest and scope follows the same immutable graph.
+  const manifestRegistry = loadPluginManifestRegistryForInstalledIndex({
+    index,
+    config: params.config,
+    workspaceDir: params.workspaceDir,
+    env: params.env,
+    ...(pluginIds !== undefined ? { pluginIds } : {}),
+    includeDisabled: true,
+  });
   const manifestRegistryMs = performance.now() - manifestStartedAt;
   const normalizePluginId = createPluginRegistryIdNormalizer(index, { manifestRegistry });
   const byPluginId = new Map(manifestRegistry.plugins.map((plugin) => [plugin.id, plugin]));
@@ -446,4 +438,14 @@ function loadPluginMetadataSnapshotImpl(
     },
     discovery: registryResult.discovery,
   };
+}
+
+function deriveBootstrapPluginRegistrySnapshot(params: LoadPluginMetadataSnapshotParams): {
+  source: "derived";
+  snapshot: InstalledPluginIndex;
+  diagnostics: [];
+  discovery: ReturnType<typeof loadInstalledPluginIndexWithDiscovery>["discovery"];
+} {
+  const { index, discovery } = loadInstalledPluginIndexWithDiscovery(params);
+  return { source: "derived", snapshot: index, diagnostics: [], discovery };
 }

--- a/src/plugins/plugin-registry-snapshot.test.ts
+++ b/src/plugins/plugin-registry-snapshot.test.ts
@@ -576,6 +576,39 @@ describe("loadPluginRegistrySnapshotWithMetadata", () => {
     expect(statFile).not.toHaveBeenCalled();
   });
 
+  it("retains only the current process-lifecycle registry graph", () => {
+    const tempRoot = makeTempDir();
+    const env = { ...createHermeticEnv(tempRoot), OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" };
+    const firstWorkspace = path.join(tempRoot, "first-workspace");
+    const secondWorkspace = path.join(tempRoot, "second-workspace");
+
+    const first = loadPluginRegistrySnapshotWithMetadata({
+      config: {},
+      env,
+      workspaceDir: firstWorkspace,
+    });
+    const second = loadPluginRegistrySnapshotWithMetadata({
+      config: {},
+      env,
+      workspaceDir: secondWorkspace,
+    });
+    const refreshedFirst = loadPluginRegistrySnapshotWithMetadata({
+      config: {},
+      env,
+      workspaceDir: firstWorkspace,
+    });
+
+    expect(second).not.toBe(first);
+    expect(refreshedFirst).not.toBe(first);
+    expect(
+      loadPluginRegistrySnapshotWithMetadata({
+        config: {},
+        env,
+        workspaceDir: firstWorkspace,
+      }),
+    ).toBe(refreshedFirst);
+  });
+
   it("refreshes workspace plugin discovery on explicit metadata invalidation", () => {
     const tempRoot = makeTempDir();
     const workspaceDir = path.join(tempRoot, "workspace");

--- a/src/plugins/plugin-registry-snapshot.ts
+++ b/src/plugins/plugin-registry-snapshot.ts
@@ -9,7 +9,10 @@ import { resolveBundledPluginsDir } from "./bundled-dir.js";
 import { buildLegacyBundledRootPath } from "./bundled-load-path-aliases.js";
 import { listBundledSourceOverlayDirs } from "./bundled-source-overlays.js";
 import { normalizePluginsConfig } from "./config-state.js";
-import { getCurrentPluginMetadataSnapshot } from "./current-plugin-metadata-snapshot.js";
+import {
+  clearCurrentPluginMetadataSnapshot,
+  getCurrentPluginMetadataSnapshot,
+} from "./current-plugin-metadata-snapshot.js";
 import { discoverConfiguredPluginLoadPaths, type PluginDiscoveryResult } from "./discovery.js";
 import { fileSignatureMatches, hashJson } from "./installed-plugin-index-hash.js";
 import { hasOptionalMissingPluginManifestFile } from "./installed-plugin-index-manifest.js";
@@ -84,6 +87,8 @@ let pluginRegistrySnapshotMemo: PluginRegistrySnapshotMemo | undefined;
 
 function clearLoadPluginRegistrySnapshotMemo(): void {
   pluginRegistrySnapshotMemo = undefined;
+  // A retired registry must not leave its published metadata graph behind.
+  clearCurrentPluginMetadataSnapshot();
 }
 
 registerPluginMetadataProcessMemoLifecycleClear(clearLoadPluginRegistrySnapshotMemo);

--- a/src/plugins/plugin-registry-snapshot.ts
+++ b/src/plugins/plugin-registry-snapshot.ts
@@ -60,7 +60,6 @@ type PluginRegistrySnapshotResult = {
   discovery?: PluginDiscoveryResult;
 };
 
-const MAX_PLUGIN_REGISTRY_SNAPSHOT_MEMOS = 8;
 const REGISTRY_SNAPSHOT_MEMO_ENV_KEYS = [
   "APPDATA",
   "HOME",
@@ -81,10 +80,10 @@ type PluginRegistrySnapshotMemo = {
   result: PluginRegistrySnapshotResult;
 };
 
-let pluginRegistrySnapshotMemos: PluginRegistrySnapshotMemo[] = [];
+let pluginRegistrySnapshotMemo: PluginRegistrySnapshotMemo | undefined;
 
 function clearLoadPluginRegistrySnapshotMemo(): void {
-  pluginRegistrySnapshotMemos = [];
+  pluginRegistrySnapshotMemo = undefined;
 }
 
 registerPluginMetadataProcessMemoLifecycleClear(clearLoadPluginRegistrySnapshotMemo);
@@ -144,19 +143,9 @@ function resolvePluginRegistrySnapshotMemoKey(
 function findPluginRegistrySnapshotMemo(
   key: string | undefined,
 ): PluginRegistrySnapshotResult | undefined {
-  if (!key) {
-    return undefined;
-  }
-  const index = pluginRegistrySnapshotMemos.findIndex((memo) => memo.key === key);
-  if (index === -1) {
-    return undefined;
-  }
-  const [memo] = pluginRegistrySnapshotMemos.splice(index, 1);
-  if (!memo) {
-    return undefined;
-  }
-  pluginRegistrySnapshotMemos.unshift(memo);
-  return memo.result;
+  return key && pluginRegistrySnapshotMemo?.key === key
+    ? pluginRegistrySnapshotMemo.result
+    : undefined;
 }
 
 function rememberPluginRegistrySnapshotMemo(
@@ -166,10 +155,7 @@ function rememberPluginRegistrySnapshotMemo(
   if (!key) {
     return result;
   }
-  pluginRegistrySnapshotMemos = [
-    { key, result },
-    ...pluginRegistrySnapshotMemos.filter((memo) => memo.key !== key),
-  ].slice(0, MAX_PLUGIN_REGISTRY_SNAPSHOT_MEMOS);
+  pluginRegistrySnapshotMemo = { key, result };
   return result;
 }
 

--- a/src/plugins/runtime/load-context.test.ts
+++ b/src/plugins/runtime/load-context.test.ts
@@ -26,7 +26,6 @@ const loadPluginMetadataSnapshotMock = vi.fn((): MetadataSnapshotMock => metadat
 const isPluginMetadataSnapshotCompatibleMock = vi.fn(() => true);
 const getCurrentPluginMetadataSnapshotMock = vi.fn(() => undefined);
 const setCurrentPluginMetadataSnapshotMock = vi.fn();
-const clearCurrentPluginMetadataSnapshotMock = vi.fn();
 
 let resolvePluginRuntimeLoadContext: typeof import("./load-context.js").resolvePluginRuntimeLoadContext;
 let buildPluginRuntimeLoadOptions: typeof import("./load-context.js").buildPluginRuntimeLoadOptions;
@@ -54,11 +53,7 @@ vi.mock("../plugin-metadata-snapshot.js", () => ({
 }));
 
 vi.mock("../current-plugin-metadata-snapshot.js", () => ({
-  clearCurrentPluginMetadataSnapshot: clearCurrentPluginMetadataSnapshotMock,
   getCurrentPluginMetadataSnapshot: getCurrentPluginMetadataSnapshotMock,
-  isReusableCurrentPluginMetadataSnapshot: (
-    _snapshot: typeof metadataSnapshot & { registrySource?: "derived" },
-  ) => true,
   setCurrentPluginMetadataSnapshot: setCurrentPluginMetadataSnapshotMock,
 }));
 
@@ -78,7 +73,6 @@ describe("resolvePluginRuntimeLoadContext", () => {
     loadPluginMetadataSnapshotMock.mockClear();
     getCurrentPluginMetadataSnapshotMock.mockClear();
     setCurrentPluginMetadataSnapshotMock.mockClear();
-    clearCurrentPluginMetadataSnapshotMock.mockClear();
     resolveAgentWorkspaceDirMock.mockClear();
     resolveDefaultAgentIdMock.mockClear();
 
@@ -167,7 +161,6 @@ describe("resolvePluginRuntimeLoadContext", () => {
       env: { HOME: "/tmp/openclaw-home" },
       workspaceDir: "/resolved-workspace",
     });
-    expect(clearCurrentPluginMetadataSnapshotMock).not.toHaveBeenCalled();
   });
 
   it("uses the source runtime snapshot for plugin activation source config", () => {
@@ -260,6 +253,26 @@ describe("resolvePluginRuntimeLoadContext", () => {
     expect(buildPluginRuntimeLoadOptions(context).installRecords).toEqual({
       demo: { source: "registry", version: "1.0.0" },
     });
+  });
+
+  it.each([
+    { scope: "explicit empty", pluginIds: [] },
+    { scope: "explicit owner", pluginIds: ["demo"] },
+  ])("keeps $scope plugin metadata scoped before activation", ({ pluginIds }) => {
+    const config = { plugins: {} };
+    const env = { HOME: "/tmp/openclaw-home" } as NodeJS.ProcessEnv;
+    loadPluginMetadataSnapshotMock.mockReturnValueOnce({ ...metadataSnapshot, pluginIds });
+
+    resolvePluginRuntimeLoadContext({ config, env, onlyPluginIds: pluginIds });
+
+    expect(loadPluginMetadataSnapshotMock).toHaveBeenCalledExactlyOnceWith({
+      allowWorkspaceScopedCurrent: true,
+      config,
+      env,
+      pluginIds,
+      workspaceDir: "/resolved-workspace",
+    });
+    expect(setCurrentPluginMetadataSnapshotMock).not.toHaveBeenCalled();
   });
 
   it("builds plugin load options from the shared runtime context", () => {

--- a/src/plugins/runtime/load-context.ts
+++ b/src/plugins/runtime/load-context.ts
@@ -10,11 +10,7 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { PluginInstallRecord } from "../../config/types.plugins.js";
 import { createSubsystemLogger } from "../../logging.js";
 import { resolvePluginActivationSourceConfig } from "../activation-source-config.js";
-import {
-  clearCurrentPluginMetadataSnapshot,
-  isReusableCurrentPluginMetadataSnapshot,
-  setCurrentPluginMetadataSnapshot,
-} from "../current-plugin-metadata-snapshot.js";
+import { setCurrentPluginMetadataSnapshot } from "../current-plugin-metadata-snapshot.js";
 import { extractPluginInstallRecordsFromInstalledPluginIndex } from "../installed-plugin-index-install-records.js";
 import type { PluginLoadOptions } from "../loader.js";
 import type { PluginManifestRegistry } from "../manifest-registry.js";
@@ -143,6 +139,7 @@ type PluginRuntimeLoadContextOptions = {
   activationSourceConfig?: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
   workspaceDir?: string;
+  onlyPluginIds?: readonly string[];
   logger?: PluginLogger;
   manifestRegistry?: PluginManifestRegistry;
 };
@@ -172,6 +169,7 @@ export function resolvePluginRuntimeLoadContext(
           env,
           workspaceDir: rawWorkspaceDir,
           allowWorkspaceScopedCurrent: true,
+          ...(options?.onlyPluginIds !== undefined ? { pluginIds: options.onlyPluginIds } : {}),
         })
       : undefined;
   const manifestRegistry = options?.manifestRegistry ?? initialMetadataSnapshot?.manifestRegistry;
@@ -206,23 +204,21 @@ export function resolvePluginRuntimeLoadContext(
             workspaceDir,
             allowWorkspaceScopedCurrent: true,
             ...(initialMetadataSnapshot ? { index: initialMetadataSnapshot.index } : {}),
+            ...(options?.onlyPluginIds !== undefined ? { pluginIds: options.onlyPluginIds } : {}),
           });
   const finalManifestRegistry = options?.manifestRegistry ?? metadataSnapshot?.manifestRegistry;
   const installRecords = metadataSnapshot
     ? extractPluginInstallRecordsFromInstalledPluginIndex(metadataSnapshot.index)
     : undefined;
-  if (metadataSnapshot) {
-    // Reusable snapshots stay available to later manifest-policy lookups for this runtime load.
-    if (isReusableCurrentPluginMetadataSnapshot(metadataSnapshot)) {
-      setCurrentPluginMetadataSnapshot(metadataSnapshot, {
-        config: rawConfig,
-        compatibleConfigs: [config, activationSourceConfig],
-        env,
-        workspaceDir,
-      });
-    } else {
-      clearCurrentPluginMetadataSnapshot();
-    }
+  if (metadataSnapshot && metadataSnapshot.pluginIds === undefined) {
+    // Scoped graphs are request-local; publishing one would hide other installed
+    // providers from process-wide model normalization and later runtime loads.
+    setCurrentPluginMetadataSnapshot(metadataSnapshot, {
+      config: rawConfig,
+      compatibleConfigs: [config, activationSourceConfig],
+      env,
+      workspaceDir,
+    });
   }
   return {
     rawConfig,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where fresh or newly repaired OpenClaw installs could lose their bundled plugins during registry bootstrap, while explicitly scoped plugin requests could rediscover or activate unrelated installed plugins. Repeated control-plane lookups also retained multiple historical plugin registry graphs instead of one process-stable snapshot.

## Why This Change Was Made

Derive bootstrap metadata from the same manifest-backed installed-plugin index used by persisted registries, make resolved empty indexes authoritative, preserve requested plugin scopes before activation, and publish only complete unscoped metadata to the process-wide registry. Replace the historical registry LRU with one lifecycle-owned immutable graph without changing plugin manifests, SDK exports, database schemas, configuration, protocol versions, dependencies, or plugin ownership.

## User Impact

Fresh installs continue to discover their bundled plugins; registry refresh keeps the same installed plugin inventory; disabled or empty plugin scopes stay empty; single-plugin requests do not load unrelated plugin owners or corrupt process-wide model/provider metadata. Production code decreases by 22 lines.

## Evidence

- Blacksmith Testbox `tbx_01kyhmqhparwmrc2jpe84hekta`: 326 passing focused tests across 12 plugin, index, manifest, discovery, runtime, activation, loader, and Plugin SDK test files.
- Full Plugin SDK public surface gate: 316 total SDK entrypoints, 143 public package entrypoints, zero forbidden package-exported subpaths.
- Changed-files gate passed, including production/test type checks, formatting, plugin ownership boundaries, runtime import cycles, and database/schema guards.
- Production `pnpm build` and canonical self-contained package tarball integrity check passed.
- Installed the actual package with npm into an isolated prefix and state directory. The installed OpenClaw CLI discovered 75 bundled plugins on first run, refreshed its persisted plugin registry, and rediscovered the same 75 plugin IDs afterward.
- Regression coverage separately proves absent-registry bootstrap, authoritative persisted empty indexes, owner and empty activation scopes, current-graph isolation, and lifecycle cache replacement.
- Independent Codex `gpt-5.6-sol` review at `xhigh` reasoning: no accepted or actionable findings after fixing the two confirmed scoped/bootstrap defects.

AI-assisted: implementation and verification performed with Codex; no agent prompts, private logs, or transcripts are included.
