### PR TITLE
fix(sessions): prevent stale and cross-agent observer status after reconnect

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -1819,7 +1819,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2522,
+      "line": 2523,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Chat failed before the run started; try again.",
       "surface": "android",
@@ -1827,7 +1827,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4220,
+      "line": 4221,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Could not stage an attachment for sending.",
       "surface": "android",
@@ -1835,7 +1835,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4253,
+      "line": 4254,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Offline queue is full ($OUTBOX_MAX_QUEUED messages); delete queued items first.",
       "surface": "android",
@@ -1843,7 +1843,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4259,
+      "line": 4260,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Attachments are too large to queue for one message; remove some and try again.",
       "surface": "android",
@@ -1851,7 +1851,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4265,
+      "line": 4266,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Offline attachment storage is full; delete queued items first.",
       "surface": "android",
@@ -1859,7 +1859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4270,
+      "line": 4271,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Gateway health not OK; cannot send",
       "surface": "android",
@@ -1867,7 +1867,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4277,
+      "line": 4278,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Could not queue message for later delivery.",
       "surface": "android",
@@ -1875,7 +1875,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5180,
+      "line": 5181,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Chat failed",
       "surface": "android",
@@ -1883,7 +1883,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5413,
+      "line": 5414,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Event stream interrupted; try refreshing.",
       "surface": "android",
@@ -1891,7 +1891,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5550,
+      "line": 5551,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Timed out waiting for a reply; try again or refresh.",
       "surface": "android",
@@ -1899,7 +1899,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5760,
+      "line": 5761,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Timed out confirming the sent message; refresh to check delivery.",
       "surface": "android",

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
@@ -6880,8 +6880,7 @@ internal fun reconcileSessionObserverProjectionOwner(
   }
 }
 
-private fun normalizedObserverAgentId(agentId: String?): String? =
-  agentId?.trim()?.lowercase()?.takeIf(String::isNotEmpty)
+private fun normalizedObserverAgentId(agentId: String?): String? = agentId?.trim()?.lowercase()?.takeIf(String::isNotEmpty)
 
 private fun reconcileSessionObserverDigest(
   existing: SessionObserverDigest?,

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
@@ -2163,9 +2163,10 @@ class ChatController internal constructor(
     _sessionKey.value = key
     _sessionOwnerAgentId.value = owner
     _sessions.value =
-      clearForeignGlobalObserverDigest(
+      reconcileGlobalObserverDigestOwner(
         _sessions.value,
         activeAgentId = owner ?: resolveAgentIdForSessionKey(key),
+        adoptOwnerless = false,
       )
     applyThinkingMetadata(_sessions.value.firstOrNull { it.key == key })
     _selectedModelRef.value = null
@@ -6811,17 +6812,10 @@ internal fun applySessionObserverDigest(
   digest: SessionObserverDigest,
   activeAgentId: String? = null,
 ): List<ChatSessionEntry> {
-  val digestAgentId =
-    digest.agentId
-      ?.trim()
-      ?.lowercase()
-      ?.takeIf { it.isNotEmpty() }
-  val selectedAgentId =
-    activeAgentId
-      ?.trim()
-      ?.lowercase()
-      ?.takeIf { it.isNotEmpty() }
-  val scopedSessions = clearForeignGlobalObserverDigest(sessions, selectedAgentId)
+  val digestAgentId = normalizedObserverAgentId(digest.agentId)
+  val selectedAgentId = normalizedObserverAgentId(activeAgentId)
+  val scopedSessions =
+    reconcileGlobalObserverDigestOwner(sessions, selectedAgentId, adoptOwnerless = false)
   if (
     digest.sessionKey == "global" &&
     (selectedAgentId == null || digestAgentId == null || selectedAgentId != digestAgentId)
@@ -6845,35 +6839,15 @@ internal fun applySessionObserverDigest(
 internal fun reconcileGlobalObserverDigestOwner(
   sessions: List<ChatSessionEntry>,
   activeAgentId: String?,
-): List<ChatSessionEntry> = reconcileGlobalObserverDigestOwner(sessions, activeAgentId, adoptOwnerless = true)
-
-internal fun clearForeignGlobalObserverDigest(
-  sessions: List<ChatSessionEntry>,
-  activeAgentId: String?,
-): List<ChatSessionEntry> = reconcileGlobalObserverDigestOwner(sessions, activeAgentId, adoptOwnerless = false)
-
-private fun reconcileGlobalObserverDigestOwner(
-  sessions: List<ChatSessionEntry>,
-  activeAgentId: String?,
-  adoptOwnerless: Boolean,
+  adoptOwnerless: Boolean = true,
 ): List<ChatSessionEntry> {
   // A missing owner is transient disconnect state, not a selection change.
   // Callers retain the last verified offline projection until hello supplies an owner.
-  val selectedAgentId =
-    activeAgentId
-      ?.trim()
-      ?.lowercase()
-      ?.takeIf { it.isNotEmpty() }
-      ?: return sessions
+  val selectedAgentId = normalizedObserverAgentId(activeAgentId) ?: return sessions
   val index = sessions.indexOfFirst { it.key == "global" }
   if (index < 0) return sessions
   val session = sessions[index]
-  val digestAgentId =
-    session.observerDigest
-      ?.agentId
-      ?.trim()
-      ?.lowercase()
-      ?.takeIf { it.isNotEmpty() }
+  val digestAgentId = normalizedObserverAgentId(session.observerDigest?.agentId)
   if (digestAgentId == selectedAgentId) return sessions
   return sessions.toMutableList().also {
     it[index] =
@@ -6896,22 +6870,18 @@ internal fun reconcileSessionObserverProjectionOwner(
   val digest = session.observerDigest
   if (session.key != "global" || digest == null) return session
   val owner =
-    ownerAgentId
-      ?.trim()
-      ?.lowercase()
-      ?.takeIf { it.isNotEmpty() }
+    normalizedObserverAgentId(ownerAgentId)
       ?: return session.copy(observerDigest = null, hasObserverDigestMetadata = false)
-  val digestOwner =
-    digest.agentId
-      ?.trim()
-      ?.lowercase()
-      ?.takeIf { it.isNotEmpty() }
+  val digestOwner = normalizedObserverAgentId(digest.agentId)
   return when (digestOwner) {
     null -> session.copy(observerDigest = digest.copy(agentId = owner))
     owner -> session
     else -> session.copy(observerDigest = null, hasObserverDigestMetadata = false)
   }
 }
+
+private fun normalizedObserverAgentId(agentId: String?): String? =
+  agentId?.trim()?.lowercase()?.takeIf(String::isNotEmpty)
 
 private fun reconcileSessionObserverDigest(
   existing: SessionObserverDigest?,

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/SessionObserverDigestTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/SessionObserverDigestTest.kt
@@ -3,7 +3,6 @@ package ai.openclaw.app.ui
 import ai.openclaw.app.chat.ChatSessionAgentStatus
 import ai.openclaw.app.chat.ChatSessionEntry
 import ai.openclaw.app.chat.applySessionObserverDigest
-import ai.openclaw.app.chat.clearForeignGlobalObserverDigest
 import ai.openclaw.app.chat.mergeChatSessionEntry
 import ai.openclaw.app.chat.reconcileGlobalObserverDigestOwner
 import ai.openclaw.app.chat.reconcileSessionObserverProjectionOwner
@@ -162,6 +161,54 @@ class SessionObserverDigestTest {
   }
 
   @Test
+  fun globalReconnectRejectsForeignAndStaleObserverDigests() {
+    val current =
+      SessionObserverDigest(
+        sessionKey = "global",
+        agentId = "work",
+        runId = "run-work",
+        revision = 4,
+        updatedAt = 400,
+        headline = "Current work status",
+        health = "grinding",
+      )
+    val running =
+      ChatSessionEntry(
+        key = "global",
+        updatedAtMs = 100,
+        hasActiveRun = true,
+        activeRunIds = listOf("run-work"),
+        status = "running",
+        observerDigest = current,
+      )
+
+    val foreign =
+      applySessionObserverDigest(
+        listOf(running),
+        current.copy(
+          agentId = "main",
+          revision = 9,
+          updatedAt = 900,
+          headline = "Foreign status",
+        ),
+        activeAgentId = "work",
+      )
+    val replayed =
+      applySessionObserverDigest(
+        foreign,
+        current.copy(
+          revision = 3,
+          updatedAt = 1_000,
+          headline = "Replayed work status",
+        ),
+        activeAgentId = "work",
+      )
+
+    assertEquals("Current work status", replayed.single().observerDigest?.headline)
+    assertEquals(4L, replayed.single().observerDigest?.revision)
+  }
+
+  @Test
   fun changingTheSelectedAgentClearsThePreviousGlobalDigest() {
     val previous =
       ChatSessionEntry(
@@ -182,13 +229,24 @@ class SessionObserverDigestTest {
           ),
       )
 
-    val switched = clearForeignGlobalObserverDigest(listOf(previous), activeAgentId = "work")
+    val switched =
+      reconcileGlobalObserverDigestOwner(
+        listOf(previous),
+        activeAgentId = "work",
+        adoptOwnerless = false,
+      )
     val ownerless =
-      clearForeignGlobalObserverDigest(
+      reconcileGlobalObserverDigestOwner(
         listOf(previous.copy(observerDigest = previous.observerDigest?.copy(agentId = null))),
         activeAgentId = "work",
+        adoptOwnerless = false,
       )
-    val disconnected = clearForeignGlobalObserverDigest(listOf(previous), activeAgentId = null)
+    val disconnected =
+      reconcileGlobalObserverDigestOwner(
+        listOf(previous),
+        activeAgentId = null,
+        adoptOwnerless = false,
+      )
 
     assertNull(switched.single().observerDigest)
     assertNull(ownerless.single().observerDigest)

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebarModel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebarModel.swift
@@ -274,6 +274,16 @@ public enum ChatSessionSidebarModel {
             adoptOwnerless: false)
     }
 
+    static func sessionMatchesActiveAgent(
+        sessionKey: String?,
+        agentId: String?,
+        activeAgentId: String?) -> Bool
+    {
+        guard self.normalized(sessionKey)?.lowercased() == "global" else { return true }
+        guard let owner = self.normalized(agentId)?.lowercased() else { return false }
+        return owner == self.normalized(activeAgentId)?.lowercased()
+    }
+
     private static func reconcilingGlobalObserverDigestOwner(
         in sessions: [OpenClawChatSessionEntry],
         activeAgentId: String?,
@@ -308,10 +318,14 @@ public enum ChatSessionSidebarModel {
     {
         let digest = change.observerDigest
         let present = change.observerDigestPresent
-        let key = change.sessionKey?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        guard key == "global" else { return (digest, present) }
-        guard let owner = self.normalized(change.agentId)?.lowercased(),
-              owner == self.normalized(activeAgentId)?.lowercased()
+        guard self.normalized(change.sessionKey)?.lowercased() == "global" else {
+            return (digest, present)
+        }
+        guard self.sessionMatchesActiveAgent(
+            sessionKey: change.sessionKey,
+            agentId: change.agentId,
+            activeAgentId: activeAgentId),
+            let owner = self.normalized(change.agentId)?.lowercased()
         else { return nil }
         guard let digest else { return (nil, present) }
         let digestOwner = self.normalized(digest.agentId)?.lowercased()

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+TransportEvents.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+TransportEvents.swift
@@ -34,10 +34,14 @@ extension OpenClawChatViewModel {
             let context = self.currentSessionSnapshot()
             Task { await self.pollHealthIfNeeded(force: false, sessionSnapshot: context) }
         case let .sessionsChanged(change):
-            let swarmEvent = self.observeSwarmEvent(change)
             // Broad subscribers see every agent's canonical global row. Gate
             // ownership before the shared-key projection can replace local state.
-            guard self.sessionChangeMatchesActiveAgent(change) else { return }
+            guard ChatSessionSidebarModel.sessionMatchesActiveAgent(
+                sessionKey: change.sessionKey,
+                agentId: change.agentId,
+                activeAgentId: self.activeAgentId)
+            else { return }
+            let swarmEvent = self.observeSwarmEvent(change)
             let ownedSwarmActivityNote = swarmEvent && SelfContainedSwarmHelpers.isActivityNote(change)
             self.applySessionChangeProjection(change, ownedSwarmActivityNote: ownedSwarmActivityNote)
             // Group-catalog mutations from any client arrive as reason "groups"
@@ -138,20 +142,6 @@ extension OpenClawChatViewModel {
             let context = self.currentSessionSnapshot()
             Task { await self.fetchSessions(limit: 50, sessionSnapshot: context) }
         }
-    }
-
-    private func sessionChangeMatchesActiveAgent(_ change: OpenClawChatSessionsChangedEvent) -> Bool {
-        let sessionKey = change.sessionKey?
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-            .lowercased()
-        guard sessionKey == "global" else { return true }
-        let eventAgentId = change.agentId?
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-            .lowercased()
-        let selectedAgentId = self.activeAgentId?
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-            .lowercased()
-        return eventAgentId?.isEmpty == false && eventAgentId == selectedAgentId
     }
 
     private func handleSessionMessageEvent(_ payload: OpenClawSessionMessageEventPayload) {

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatSessionSidebarModelTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatSessionSidebarModelTests.swift
@@ -592,6 +592,54 @@ struct ChatSessionSidebarModelTests {
         #expect(sessions[0].observerDigest?.headline == "Projected")
     }
 
+    @Test func `global reconnect rejects foreign and stale observer projections`() throws {
+        let running = self.entry(
+            key: "global",
+            status: "running",
+            hasActiveRun: true,
+            activeRunIds: ["run-work"],
+            observerDigest: .init(
+                agentId: "work",
+                runId: "run-work",
+                revision: 4,
+                updatedAt: 400,
+                headline: "Current work status",
+                health: "grinding"))
+
+        let foreign = try #require(ChatSessionSidebarModel.applying(
+            sessionChange: .init(
+                sessionKey: "global",
+                agentId: "main",
+                reason: "run-progress",
+                observerDigest: .init(
+                    agentId: "main",
+                    runId: "run-work",
+                    revision: 9,
+                    updatedAt: 900,
+                    headline: "Foreign status",
+                    health: "done")),
+            to: [running],
+            activeAgentId: "work"))
+
+        let replayed = try #require(ChatSessionSidebarModel.applying(
+            sessionChange: .init(
+                sessionKey: "global",
+                agentId: "work",
+                reason: "run-progress",
+                observerDigest: .init(
+                    agentId: "work",
+                    runId: "run-work",
+                    revision: 3,
+                    updatedAt: 1_000,
+                    headline: "Replayed work status",
+                    health: "on-track")),
+            to: foreign,
+            activeAgentId: "work"))
+
+        #expect(replayed[0].observerDigest?.headline == "Current work status")
+        #expect(replayed[0].observerDigest?.revision == 4)
+    }
+
     @Test func `run rollover clears a stale digest before the replacement event`() throws {
         let existing = self.entry(
             key: "agent:main:work",

--- a/src/gateway/server-methods/sessions-subscriptions.ts
+++ b/src/gateway/server-methods/sessions-subscriptions.ts
@@ -6,30 +6,14 @@ import {
   validateSessionsMessagesUnsubscribeParams,
 } from "../../../packages/gateway-protocol/src/index.js";
 import { resolveDefaultAgentId } from "../../agents/agent-scope.js";
-import { normalizeAgentId } from "../../routing/session-key.js";
 import { canReviewOperatorApproval } from "../operator-approval-authorization.js";
 import { APPROVALS_SCOPE } from "../operator-scopes.js";
 import { resolveRequestedSessionAgentId as resolveRequestedGlobalAgentId } from "../session-create-service.js";
+import { sessionObserverScopeKey } from "../session-observer-model.js";
 import { loadSessionEntryReadOnly } from "../session-utils.js";
 import { requireSessionKey } from "./sessions-shared.js";
 import type { GatewayRequestHandlers } from "./types.js";
 import { assertValidParams } from "./validation.js";
-
-function resolveSessionMessageSubscriptionKey(params: {
-  canonicalKey: string;
-  agentId?: string;
-  defaultAgentId?: string;
-}): string {
-  const agentId = params.agentId
-    ? normalizeAgentId(params.agentId)
-    : params.canonicalKey === "global" && params.defaultAgentId
-      ? normalizeAgentId(params.defaultAgentId)
-      : undefined;
-  // Global session message subscriptions need per-agent channels to avoid cross-agent fanout.
-  return params.canonicalKey === "global" && agentId
-    ? `agent:${agentId}:global`
-    : params.canonicalKey;
-}
 
 export const sessionSubscriptionHandlers: GatewayRequestHandlers = {
   "sessions.subscribe": ({ client, context, respond }) => {
@@ -82,11 +66,10 @@ export const sessionSubscriptionHandlers: GatewayRequestHandlers = {
     }
     const requestedAgentId = requestedAgent.agentId;
     const { canonicalKey } = loadSessionEntryReadOnly(key, { agentId: requestedAgentId });
-    const subscriptionKey = resolveSessionMessageSubscriptionKey({
+    const subscriptionKey = sessionObserverScopeKey(
       canonicalKey,
-      agentId: requestedAgentId,
-      defaultAgentId: resolveDefaultAgentId(cfg),
-    });
+      requestedAgentId ?? resolveDefaultAgentId(cfg),
+    );
     if (connId) {
       let approvalReplay;
       if (p.includeApprovals === true) {
@@ -164,11 +147,10 @@ export const sessionSubscriptionHandlers: GatewayRequestHandlers = {
     }
     const requestedAgentId = requestedAgent.agentId;
     const { canonicalKey } = loadSessionEntryReadOnly(key, { agentId: requestedAgentId });
-    const subscriptionKey = resolveSessionMessageSubscriptionKey({
+    const subscriptionKey = sessionObserverScopeKey(
       canonicalKey,
-      agentId: requestedAgentId,
-      defaultAgentId: resolveDefaultAgentId(cfg),
-    });
+      requestedAgentId ?? resolveDefaultAgentId(cfg),
+    );
     if (connId) {
       context.unsubscribeSessionMessageEvents(connId, subscriptionKey);
     }

--- a/ui/src/components/app-sidebar-session-narration.ts
+++ b/ui/src/components/app-sidebar-session-narration.ts
@@ -15,6 +15,7 @@ import type { GatewayEventFrame } from "../api/gateway.ts";
 import { t } from "../i18n/index.ts";
 import { stripHeartbeatTokenForDisplay } from "../lib/chat/heartbeat-display.ts";
 import { extractText } from "../lib/chat/message-extract.ts";
+import { pickFreshestObserverDigest } from "../lib/observer-digest.ts";
 import type { SessionCapability } from "../lib/sessions/index.ts";
 import {
   areUiSessionKeysEquivalent,
@@ -542,11 +543,7 @@ export class SidebarSessionNarrationController {
     this.observeRun(key, runId);
     const digest = { ...record, runId } as unknown as SessionObserverDigest;
     const previous = this.observerDigests.get(key);
-    if (
-      previous &&
-      (previous.revision > digest.revision ||
-        (previous.revision === digest.revision && previous.updatedAt >= digest.updatedAt))
-    ) {
+    if (previous && pickFreshestObserverDigest(previous, digest) === previous) {
       return;
     }
     this.clearNarration(key);

--- a/ui/src/pages/chat/chat-state-events.ts
+++ b/ui/src/pages/chat/chat-state-events.ts
@@ -4,6 +4,7 @@ import { fireFirstReplyConfetti } from "../../components/confetti.ts";
 import { isGitHubPullRequestLink } from "../../components/github-link-hovercard.ts";
 import type { ChatQueueItem } from "../../lib/chat/chat-types.ts";
 import { extractText } from "../../lib/chat/message-extract.ts";
+import { pickFreshestObserverDigest } from "../../lib/observer-digest.ts";
 import {
   readSessionChangedEvent,
   type SessionChangedResult,
@@ -397,14 +398,13 @@ export function handlePageGatewayEvent(state: ChatPageHost, event: GatewayEventF
     }
     const previous = state.observerDigest;
     if (
-      !previous ||
-      previous.runId !== payload.runId ||
-      payload.revision > previous.revision ||
-      (payload.revision === previous.revision && payload.updatedAt > previous.updatedAt)
+      previous?.runId === payload.runId &&
+      pickFreshestObserverDigest(previous, payload) === previous
     ) {
-      state.observerDigest = payload;
-      requestChatPageUpdate(state);
+      return;
     }
+    state.observerDigest = payload;
+    requestChatPageUpdate(state);
     return;
   }
   if (event.event === "agent" || event.event === "session.tool") {

--- a/ui/src/pages/chat/chat-state.test.ts
+++ b/ui/src/pages/chat/chat-state.test.ts
@@ -175,6 +175,56 @@ describe("ChatStateController render lifecycle", () => {
     expect(requestUpdate).toHaveBeenCalledOnce();
   });
 
+  it("keeps a fresher selected-agent digest when reconnect replays stale global events", () => {
+    const requestUpdate = vi.fn();
+    const state = {
+      sessionKey: "global",
+      assistantAgentId: "work",
+      agentsList: { defaultId: "main", scope: "global" },
+      chatRunId: "run-work",
+      observerDigest: {
+        sessionKey: "global",
+        agentId: "work",
+        runId: "run-work",
+        revision: 4,
+        updatedAt: 4_000,
+        headline: "Current work status",
+        health: "grinding" as const,
+      },
+      requestUpdate,
+    } as unknown as ChatPageHost;
+
+    for (const payload of [
+      {
+        sessionKey: "global",
+        agentId: "main",
+        runId: "run-work",
+        revision: 8,
+        updatedAt: 8_000,
+        headline: "Other agent status",
+        health: "done" as const,
+      },
+      {
+        sessionKey: "global",
+        agentId: "work",
+        runId: "run-work",
+        revision: 3,
+        updatedAt: 9_000,
+        headline: "Replayed work status",
+        health: "on-track" as const,
+      },
+    ]) {
+      handlePageGatewayEvent(state, {
+        type: "event",
+        event: "session.observer",
+        payload,
+      });
+    }
+
+    expect(state.observerDigest?.headline).toBe("Current work status");
+    expect(requestUpdate).not.toHaveBeenCalled();
+  });
+
   it("reconciles a selected global alias with its scoped canonical row after reconnect", () => {
     const requestUpdate = vi.fn();
     const state = {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users viewing global sessions in the Control UI, iOS, macOS, or Android could see another agent's observer status, lose the correct session status after switching agents, or have a stale reconnect replay replace the current run's progress.

## Why This Change Was Made

The Gateway now uses its existing canonical observer scope to subscribe and unsubscribe global sessions, while the Control UI uses its existing monotonic observer freshness owner for both the active chat and sidebar. The shared Apple chat client rejects foreign global events before swarm and session projections, and Android consolidates global session ownership and reconnect handling behind one canonical chat-owner policy. This preserves the existing Gateway protocol, generated clients, storage, configuration, and terminal-outcome contracts while deleting a net 48 lines of production code.

## User Impact

Session progress and terminal status stay attached to the correct agent and active run across desktop, browser, iOS, and Android, including agent switches and reconnects. Newer server-confirmed progress is not replaced by older replayed events.

## Evidence

- AI-assisted change, manually verified against the Gateway, all three client implementations, and their focused regressions. No agent transcript is published.
- Blacksmith Testbox `tbx_01kyhn78vdxmxqavm1mm7s46gw`: `pnpm test src/gateway/session-observer.test.ts src/gateway/server.sessions.list-changed.test.ts ui/src/pages/chat/chat-state.test.ts ui/src/components/app-sidebar-session-narration.test.ts ui/src/lib/observer-digest.test.ts` — 63 real Gateway tests and 85 Control UI tests passed.
- Same Testbox, actual Chromium and running Control UI: `node scripts/ensure-playwright-chromium.mjs` and `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/pages/chat/critical-observer-notice.e2e.test.ts` — all 5 real browser scenarios passed, including selected-agent global aliases and cross-agent observer notifications.
- Native Apple chat package: `swift test --package-path apps/shared/OpenClawKit --scratch-path /private/tmp/openclaw-cross-client-observer-swift-87b76d0c --filter ChatSessionSidebarModelTests` — all 36 tests passed, including the new wrong-agent/stale-reconnect regression.
- Canonical native source inventory: `pnpm native:i18n:baseline` and `pnpm native:i18n:verify` — 5,317 entries verified on a fresh Linux Blacksmith Testbox; the identical regenerated source inventory and Android/Apple source counts were independently verified on macOS. Only `apps/.i18n/native-source.json` is updated; no translated platform resources or locale artifacts are generated.
- Blacksmith Testbox `tbx_01kyhqwnpxtnr01gr4rca8f0zq`, exact four-module Android CI formatting gate: `./gradlew --no-daemon --build-cache :app:ktlintCheck :benchmark:ktlintCheck :wear:ktlintCheck :wear-shared:ktlintCheck` — all 36 tasks passed.
- Same Testbox, real Android Play compile and focused wrong-agent/stale-reconnect regression: `./gradlew --no-daemon --build-cache :app:testPlayDebugUnitTest --tests ai.openclaw.app.ui.SessionObserverDigestTest` — all 52 tasks and `SessionObserverDigestTest` passed. Normal exact-head CI additionally verifies the Play, third-party, and Wear variants, plus `macos-swift` and `ios-build`.
- Frozen-base changed validation passed conflict, max-lines, API, plugin-boundary, localization, and both core/UI typechecks. The complete core-lint fan-out is left to the exact-head CI; comparing this frozen branch against the newer local `origin/main` is intentionally avoided because unrelated TUI baseline cleanup landed after the frozen base.
- `git diff --check` passes. No protocol version, schema, generated model, session storage, plugin, native runtime, voice manager, or configuration changes.
- Independent Codex review: `.agents/skills/autoreview/scripts/autoreview --mode branch --base 87b76d0cd0509c71c97a9ebc9ee81e626708e837 --engine codex --model gpt-5.6-sol --thinking xhigh` — TruffleHog clean; no accepted or actionable findings; patch judged correct.

