### PR TITLE
perf(codex): reduce cold-start delay before first response

### DIFF
--- a/extensions/codex/src/app-server/run-attempt-client-prewarm.test.ts
+++ b/extensions/codex/src/app-server/run-attempt-client-prewarm.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  debug: vi.fn(),
+  getLeasedSharedCodexAppServerClient: vi.fn(),
+  getSharedCodexAppServerClient: vi.fn(),
+}));
+
+vi.mock("openclaw/plugin-sdk/agent-harness-runtime", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("openclaw/plugin-sdk/agent-harness-runtime")>()),
+  embeddedAgentLog: { debug: mocks.debug },
+}));
+
+vi.mock("./shared-client.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./shared-client.js")>()),
+  getLeasedSharedCodexAppServerClient: mocks.getLeasedSharedCodexAppServerClient,
+  getSharedCodexAppServerClient: mocks.getSharedCodexAppServerClient,
+}));
+
+const { prewarmCodexAttemptClient } = await import("./run-attempt-client-prewarm.js");
+
+function createInput(params?: {
+  attemptClientFactory?: () => Promise<never>;
+  clientFactory?: () => Promise<never>;
+  runtimeArtifactRequest?: { expected?: { id: string; fingerprint: string } };
+}) {
+  return {
+    authProfileStore: { kind: "test-store" },
+    authBindingFingerprint: "auth-fingerprint",
+    connection: {
+      agentDir: "/tmp/openclaw-agent",
+      appServer: {
+        requestTimeoutMs: 12_345,
+        start: { command: "codex", args: ["app-server"] },
+      },
+      attemptClientFactory:
+        params?.attemptClientFactory ?? mocks.getLeasedSharedCodexAppServerClient,
+      options: params?.clientFactory ? { clientFactory: params.clientFactory } : {},
+      params: { config: { agents: { defaults: { workspace: "/tmp/workspace" } } } },
+      pluginConfig: { appServer: { enabled: true } },
+      runAbortController: new AbortController(),
+      runtimeArtifactRequest: params?.runtimeArtifactRequest,
+      startupAuthRequirement: "subscription",
+      startupClientAuthProfileId: "profile-1",
+      startupPreparedAuth: undefined,
+    },
+  } as unknown as Parameters<typeof prewarmCodexAttemptClient>[0];
+}
+
+describe("Codex attempt client prewarm", () => {
+  beforeEach(() => {
+    mocks.debug.mockReset();
+    mocks.getSharedCodexAppServerClient.mockReset();
+    mocks.getSharedCodexAppServerClient.mockResolvedValue({});
+  });
+
+  it("starts the shared client before the attempt needs its lease", () => {
+    const input = createInput();
+
+    prewarmCodexAttemptClient(input);
+
+    expect(mocks.getSharedCodexAppServerClient).toHaveBeenCalledWith({
+      startOptions: { command: "codex", args: ["app-server"] },
+      pluginConfig: { appServer: { enabled: true } },
+      authProfileId: "profile-1",
+      authRequirement: "subscription",
+      authProfileStore: { kind: "test-store" },
+      authBindingFingerprint: "auth-fingerprint",
+      agentDir: "/tmp/openclaw-agent",
+      config: { agents: { defaults: { workspace: "/tmp/workspace" } } },
+      timeoutMs: 12_345,
+      abandonSignal: input.connection.runAbortController.signal,
+    });
+  });
+
+  it.each([
+    ["a custom client factory", { clientFactory: async () => await new Promise<never>(() => {}) }],
+    [
+      "an alternate attempt client factory",
+      { attemptClientFactory: async () => await new Promise<never>(() => {}) },
+    ],
+    ["runtime artifact capture", { runtimeArtifactRequest: {} }],
+  ])("skips %s", (_label, options) => {
+    prewarmCodexAttemptClient(createInput(options));
+
+    expect(mocks.getSharedCodexAppServerClient).not.toHaveBeenCalled();
+  });
+
+  it("leaves failures for the canonical startup path", async () => {
+    const error = new Error("cold start failed");
+    mocks.getSharedCodexAppServerClient.mockRejectedValue(error);
+
+    prewarmCodexAttemptClient(createInput());
+    await vi.waitFor(() => {
+      expect(mocks.debug).toHaveBeenCalledWith("codex app-server client prewarm failed", { error });
+    });
+  });
+});

--- a/extensions/codex/src/app-server/run-attempt-client-prewarm.ts
+++ b/extensions/codex/src/app-server/run-attempt-client-prewarm.ts
@@ -1,0 +1,56 @@
+import { embeddedAgentLog } from "openclaw/plugin-sdk/agent-harness-runtime";
+import type { CodexAttemptConnection } from "./run-attempt-connection.js";
+import {
+  getLeasedSharedCodexAppServerClient,
+  getSharedCodexAppServerClient,
+  type CodexAppServerClientOptions,
+} from "./shared-client.js";
+
+/** Starts the shared process while tools and prompt context are still being prepared. */
+export function prewarmCodexAttemptClient(params: {
+  connection: CodexAttemptConnection;
+  authProfileStore: CodexAppServerClientOptions["authProfileStore"];
+  authBindingFingerprint: string | undefined;
+}): void {
+  const { connection, authProfileStore, authBindingFingerprint } = params;
+  const {
+    appServer,
+    attemptClientFactory,
+    options,
+    pluginConfig,
+    runtimeArtifactRequest,
+    startupAuthRequirement,
+    startupClientAuthProfileId,
+    startupPreparedAuth,
+    agentDir,
+    params: runParams,
+    runAbortController,
+  } = connection;
+  if (
+    options.clientFactory ||
+    attemptClientFactory !== getLeasedSharedCodexAppServerClient ||
+    runtimeArtifactRequest
+  ) {
+    return;
+  }
+  // The real startup later leases this same keyed client. Beginning the
+  // non-leased acquire now removes process/auth initialization from the cold path.
+  void getSharedCodexAppServerClient({
+    startOptions: appServer.start,
+    pluginConfig,
+    ...(startupPreparedAuth
+      ? { preparedAuth: startupPreparedAuth }
+      : { authProfileId: startupClientAuthProfileId }),
+    authRequirement: startupAuthRequirement,
+    authProfileStore,
+    authBindingFingerprint,
+    agentDir,
+    config: runParams.config,
+    timeoutMs: appServer.requestTimeoutMs,
+    abandonSignal: runAbortController.signal,
+  }).catch((error: unknown) => {
+    // Startup owns the actionable retry/error. Prewarm failure only restores
+    // the old serialized path and must not fail the turn early.
+    embeddedAgentLog.debug("codex app-server client prewarm failed", { error });
+  });
+}

--- a/extensions/codex/src/app-server/run-attempt-runtime.ts
+++ b/extensions/codex/src/app-server/run-attempt-runtime.ts
@@ -18,6 +18,7 @@ import {
   shouldEnableCodexAppServerNativeToolSurface,
 } from "./dynamic-tool-build.js";
 import { resolveCodexProviderWebSearchSupport } from "./provider-capabilities.js";
+import { prewarmCodexAttemptClient } from "./run-attempt-client-prewarm.js";
 import type { CodexAttemptConnection } from "./run-attempt-connection.js";
 import { resolveCodexAppServerThreadModelSelection } from "./thread-lifecycle.js";
 import { resolveCodexWebSearchPlan } from "./web-search.js";
@@ -53,6 +54,11 @@ export async function prepareCodexAttemptRuntime(connection: CodexAttemptConnect
         })
       : undefined;
   const attemptAuthProfileStore = preparedAuthBinding?.authProfileStore ?? params.authProfileStore;
+  prewarmCodexAttemptClient({
+    connection,
+    authProfileStore: attemptAuthProfileStore,
+    authBindingFingerprint: preparedAuthBinding?.fingerprint,
+  });
   const effectiveContextWindowInfo = usesSupervisionConnection
     ? undefined
     : params.contextWindowInfo;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users starting a cold Codex-backed turn wait for the app-server process and authentication setup only after OpenClaw has finished preparing tools, context, and the prompt.

## Why This Change Was Made

OpenClaw now starts the standard shared Codex app-server client as soon as the attempt's authentication binding is ready, overlapping that independent startup with the remaining attempt preparation. The canonical leased acquisition still owns startup errors and retries; custom client factories and runtime-artifact capture retain their existing paths.

## User Impact

Cold Codex-backed turns can reach the first model response sooner. Warm/shared-client behavior and nonstandard client paths are unchanged.

## Evidence

- `node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt-client-prewarm.test.ts extensions/codex/src/app-server/shared-client.test.ts` — 58 tests passed.
- `pnpm build` — passed, including plugin assets, unified/package bundles, SDK export checks, and Control UI production build.
- Targeted Oxfmt, OXLint, and `git diff --check` — passed.
- Autoreview (`gpt-5.6-sol`, high reasoning) — clean; no accepted/actionable findings.
- The changed-gate wrapper could not delegate because the selected Crabbox binary failed its version/help sanity check. Per repository policy, trusted-source proof fell back to the local commands above.

AI-assisted: yes. I understand the implementation and verified the shared-client ownership and failure-handling boundaries.
