### PR TITLE
feat: render model-authored collapsible details

### DIFF
--- a/extensions/telegram/src/outbound-adapter.sanitize.test.ts
+++ b/extensions/telegram/src/outbound-adapter.sanitize.test.ts
@@ -36,6 +36,7 @@ describe("telegramOutbound.sanitizeText", () => {
       accountId: "default",
     });
     expect(sanitized).not.toContain("<details>");
+    expect(sanitized).toContain("**More**\n\nbody");
     expect(sanitized).toContain("• done");
   });
 
@@ -62,5 +63,21 @@ describe("telegramOutbound.sanitizeText", () => {
       payload: { text: islandText },
     });
     expect(sanitized).not.toContain("<details>");
+    expect(sanitized).toContain("**More**\n\nbody");
+  });
+
+  it("advertises native details preservation only for rich accounts", () => {
+    expect(
+      telegramOutbound.preserveMarkdownDetails?.({
+        cfg: { channels: { telegram: { richMessages: true } } } as never,
+        accountId: "default",
+      }),
+    ).toBe(true);
+    expect(
+      telegramOutbound.preserveMarkdownDetails?.({
+        cfg: { channels: { telegram: {} } } as never,
+        accountId: "default",
+      }),
+    ).toBe(false);
   });
 });

--- a/extensions/telegram/src/outbound-adapter.ts
+++ b/extensions/telegram/src/outbound-adapter.ts
@@ -413,6 +413,9 @@ export function createTelegramOutboundAdapter(
     chunkerMode: "markdown",
     extractMarkdownImages: true,
     textChunkLimit: TELEGRAM_TEXT_CHUNK_LIMIT,
+    preserveMarkdownDetails: ({ cfg, accountId }) =>
+      mergeTelegramAccountConfig(cfg, accountId ?? resolveDefaultTelegramAccountId(cfg))
+        .richMessages === true,
     // Default Telegram delivery reparses this result as Markdown; use its bold
     // and strike delimiters. Rich accounts must keep the agent's HTML islands
     // (<details>, <tg-math-block>, checkbox lists) intact — the blocks emitter

--- a/src/channels/plugins/outbound.types.ts
+++ b/src/channels/plugins/outbound.types.ts
@@ -173,6 +173,8 @@ export type ChannelOutboundAdapter = {
   chunkedTextFormatting?: OutboundDeliveryFormattingOptions;
   /** Lift remote Markdown image syntax in text into outbound media attachments. */
   extractMarkdownImages?: boolean;
+  /** Preserve model-authored Markdown details blocks for a native channel renderer. */
+  preserveMarkdownDetails?: (params: { cfg: OpenClawConfig; accountId?: string | null }) => boolean;
   textChunkLimit?: number;
   /**
    * Reserve the exact provider id used by the next single-message send.

--- a/src/infra/outbound/deliver-channel.ts
+++ b/src/infra/outbound/deliver-channel.ts
@@ -249,6 +249,11 @@ function createPluginHandler(
     chunkerMode,
     chunkedTextFormatting: outbound?.chunkedTextFormatting,
     textChunkLimit: outbound?.textChunkLimit,
+    preserveMarkdownDetails:
+      outbound?.preserveMarkdownDetails?.({
+        cfg: params.cfg,
+        accountId: params.accountId,
+      }) === true,
     supportsMedia: Boolean(messageMedia ?? sendMedia),
     sanitizeText: outbound?.sanitizeText
       ? (payload) =>

--- a/src/infra/outbound/deliver-contracts.ts
+++ b/src/infra/outbound/deliver-contracts.ts
@@ -61,6 +61,7 @@ export type ChannelHandler = {
   chunkerMode?: "text" | "markdown";
   chunkedTextFormatting?: OutboundDeliveryFormattingOptions;
   textChunkLimit?: number;
+  preserveMarkdownDetails?: boolean;
   supportsMedia: boolean;
   sanitizeText?: (payload: ReplyPayload) => string;
   normalizePayload?: (payload: ReplyPayload) => ReplyPayload | null;

--- a/src/infra/outbound/deliver-payload.ts
+++ b/src/infra/outbound/deliver-payload.ts
@@ -23,6 +23,7 @@ import type {
   NormalizedPayloadForChannelDelivery,
 } from "./deliver-contracts.js";
 import type { OutboundDeliveryResult, OutboundPayloadDeliveryKind } from "./deliver-types.js";
+import { flattenMarkdownDetails } from "./markdown-details.js";
 import type { DeliveryMirror } from "./mirror.js";
 import {
   summarizeOutboundPayloadForTransport,
@@ -125,6 +126,12 @@ export function normalizePayloadsForChannelDelivery(
   const normalizedPayloads: NormalizedPayloadForChannelDelivery[] = [];
   for (const entry of plan) {
     let sanitizedPayload = stripInternalRuntimeScaffoldingFromPayload(entry.payload);
+    if (!handler.preserveMarkdownDetails && sanitizedPayload.text) {
+      sanitizedPayload = {
+        ...sanitizedPayload,
+        text: flattenMarkdownDetails(sanitizedPayload.text),
+      };
+    }
     if (handler.sanitizeText && sanitizedPayload.text) {
       if (!handler.shouldSkipPlainTextSanitization?.(sanitizedPayload)) {
         sanitizedPayload = {

--- a/src/infra/outbound/markdown-details.test.ts
+++ b/src/infra/outbound/markdown-details.test.ts
@@ -92,7 +92,19 @@ describe("flattenMarkdownDetails", () => {
   });
 
   it("leaves literal details examples inside code unchanged", () => {
-    const markdown = "`<details>inline</details>`\n\n```html\n<details>block</details>\n```";
+    const markdown = [
+      "`<details>inline</details>`",
+      "",
+      "```html",
+      "<details>block</details>",
+      "```",
+      "",
+      "    <details>indented</details>",
+      "",
+      "- item",
+      "",
+      "      <details>list-indented</details>",
+    ].join("\n");
     expect(flattenMarkdownDetails(markdown)).toBe(markdown);
   });
 

--- a/src/infra/outbound/markdown-details.test.ts
+++ b/src/infra/outbound/markdown-details.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import { flattenMarkdownDetails } from "./markdown-details.js";
+
+describe("flattenMarkdownDetails", () => {
+  it("flattens details blocks into portable markdown", () => {
+    expect(
+      flattenMarkdownDetails(
+        "<details open><summary>Why this works</summary>**Bold** body\n\n- one\n- two</details>",
+      ),
+    ).toBe("**Why this works**\n\n**Bold** body\n\n- one\n- two");
+  });
+
+  it("uses the default label when summary is missing or empty", () => {
+    expect(flattenMarkdownDetails("<details>body</details>")).toBe("**Details**\n\nbody");
+    expect(flattenMarkdownDetails("<details><summary> </summary>body</details>")).toBe(
+      "**Details**\n\nbody",
+    );
+  });
+
+  it("flattens nested details recursively", () => {
+    expect(
+      flattenMarkdownDetails(
+        "<details><summary>Outer</summary>before\n\n<details><summary>Inner</summary>deep</details>\n\nafter</details>",
+      ),
+    ).toBe("**Outer**\n\nbefore\n\n**Inner**\n\ndeep\n\nafter");
+  });
+
+  it("preserves indentation in the first body block", () => {
+    expect(
+      flattenMarkdownDetails("<details><summary>Example</summary>\n    const x = 1;\n</details>"),
+    ).toBe("**Example**\n\n    const x = 1;");
+  });
+
+  it("preserves block boundaries around flattened details", () => {
+    expect(flattenMarkdownDetails("before<details>inside</details>after")).toBe(
+      "before\n\n**Details**\n\ninside\n\nafter",
+    );
+    expect(flattenMarkdownDetails("<details>inside</details>\nafter")).toBe(
+      "**Details**\n\ninside\n\nafter",
+    );
+  });
+
+  it("preserves list and blockquote containers around flattened details", () => {
+    expect(flattenMarkdownDetails("- <details><summary>A</summary>body</details>")).toBe(
+      "- **A**\n\n  body",
+    );
+    expect(flattenMarkdownDetails("> <details><summary>A</summary>body</details>")).toBe(
+      "> **A**\n>\n> body",
+    );
+  });
+
+  it("keeps a two-space-indented details block in its list item", () => {
+    expect(flattenMarkdownDetails("  - <details><summary>A</summary>body</details>")).toBe(
+      "  - **A**\n\n    body",
+    );
+    expect(flattenMarkdownDetails(">   - <details><summary>A</summary>body</details>")).toBe(
+      ">   - **A**\n>\n>     body",
+    );
+  });
+
+  it("does not duplicate multiline container prefixes", () => {
+    expect(
+      flattenMarkdownDetails("> <details>\n> <summary>A</summary>\n>\n> body\n> </details>"),
+    ).toBe("> **A**\n>\n> body");
+    expect(
+      flattenMarkdownDetails("10. <details>\n    <summary>A</summary>\n\n    body\n    </details>"),
+    ).toBe("10. **A**\n\n    body");
+  });
+
+  it("bounds rendering of deeply nested details", () => {
+    let markdown = "deep body";
+    for (let index = 0; index < 128; index += 1) {
+      markdown = `<details><summary>Level ${index}</summary>${markdown}</details>`;
+    }
+
+    const flattened = flattenMarkdownDetails(markdown);
+
+    expect(flattened).toContain("deep body");
+    expect(flattened).not.toContain("<details>");
+  });
+
+  it("flattens unterminated details without leaking structural tags", () => {
+    expect(flattenMarkdownDetails("<details><summary>More</summary>partial")).toBe(
+      "**More**\n\npartial",
+    );
+  });
+
+  it("closes an unterminated summary with its containing details", () => {
+    expect(flattenMarkdownDetails("<details><summary>More</details>after")).toBe(
+      "**More**\n\nafter",
+    );
+  });
+
+  it("leaves literal details examples inside code unchanged", () => {
+    const markdown = "`<details>inline</details>`\n\n```html\n<details>block</details>\n```";
+    expect(flattenMarkdownDetails(markdown)).toBe(markdown);
+  });
+
+  it("does not flatten custom elements with details-like names", () => {
+    const markdown = "<details-widget>body</details-widget>";
+    expect(flattenMarkdownDetails(markdown)).toBe(markdown);
+  });
+});

--- a/src/infra/outbound/markdown-details.test.ts
+++ b/src/infra/outbound/markdown-details.test.ts
@@ -112,4 +112,9 @@ describe("flattenMarkdownDetails", () => {
     const markdown = "<details-widget>body</details-widget>";
     expect(flattenMarkdownDetails(markdown)).toBe(markdown);
   });
+
+  it("leaves backslash-escaped disclosure tags unchanged", () => {
+    const markdown = "\\<details>literal\\</details>";
+    expect(flattenMarkdownDetails(markdown)).toBe(markdown);
+  });
 });

--- a/src/infra/outbound/markdown-details.ts
+++ b/src/infra/outbound/markdown-details.ts
@@ -150,8 +150,8 @@ export function flattenMarkdownDetails(text: string): string {
 
   const root: DetailsNode[] = [];
   const stack: Array<Extract<DetailsNode, { type: "details" | "summary" }>> = [];
-  // Accepted tradeoff: four-space-indented literal tags may flatten as details.
-  // Fenced and inline code stay protected; models normally author code fences.
+  // CommonMark code ownership protects fenced, inline, and indented examples,
+  // including indentation relative to list containers.
   const codeRegions = findCodeRegions(text);
   let cursor = 0;
   for (const match of text.matchAll(DETAILS_TAG_RE)) {

--- a/src/infra/outbound/markdown-details.ts
+++ b/src/infra/outbound/markdown-details.ts
@@ -1,0 +1,191 @@
+import { findCodeRegions, isInsideCode } from "../../shared/text/code-regions.js";
+
+const MAX_DETAILS_RENDER_DEPTH = 32;
+
+type DetailsNode =
+  | string
+  | {
+      type: "details" | "summary";
+      children: DetailsNode[];
+    };
+
+const DETAILS_TAG_RE = /<\s*(\/?)\s*(details|summary)(?=\s|>)[^>]*>/gi;
+
+function appendNode(target: DetailsNode[], node: DetailsNode): void {
+  const previous = target.at(-1);
+  if (typeof previous === "string" && typeof node === "string") {
+    target[target.length - 1] = previous + node;
+    return;
+  }
+  target.push(node);
+}
+
+function trimMarkdownBlankLines(value: string): string {
+  return value.replace(/^(?:[ \t]*\r?\n)+/, "").replace(/(?:\r?\n[ \t]*)+$/, "");
+}
+
+type MarkdownContainerLayout = { blankPrefix: string; continuationPrefix: string };
+
+function resolveMarkdownContainerLayout(rendered: string): MarkdownContainerLayout | null {
+  const currentLine = rendered.slice(rendered.lastIndexOf("\n") + 1);
+  if (/^[ \t]+$/.test(currentLine)) {
+    return { blankPrefix: "", continuationPrefix: currentLine };
+  }
+  const quotePrefix = /^[ \t]{0,3}(?:>\s?)+/.exec(currentLine)?.[0] ?? "";
+  const remainder = currentLine.slice(quotePrefix.length);
+  if (quotePrefix && !remainder) {
+    return { blankPrefix: quotePrefix.trimEnd(), continuationPrefix: quotePrefix };
+  }
+  const listMarker = /^ {0,3}(?:[-+*]|\d{1,9}[.)])[ \t]+$/.exec(remainder)?.[0];
+  if (listMarker) {
+    return {
+      blankPrefix: quotePrefix.trimEnd(),
+      continuationPrefix: quotePrefix + " ".repeat(listMarker.length),
+    };
+  }
+  return null;
+}
+
+function renderInMarkdownContainer(block: string, layout: MarkdownContainerLayout): string {
+  return block
+    .split("\n")
+    .map((line, index) => {
+      if (index === 0) {
+        return line;
+      }
+      return line ? layout.continuationPrefix + line : layout.blankPrefix;
+    })
+    .join("\n");
+}
+
+function stripMarkdownContainerLayout(block: string, layout: MarkdownContainerLayout): string {
+  return block
+    .split("\n")
+    .map((line) => {
+      if (line === layout.blankPrefix) {
+        return "";
+      }
+      return line.startsWith(layout.continuationPrefix)
+        ? line.slice(layout.continuationPrefix.length)
+        : line;
+    })
+    .join("\n");
+}
+
+function collectDetailsText(nodes: readonly DetailsNode[]): string {
+  let text = "";
+  const pending = [...nodes].toReversed();
+  while (pending.length > 0) {
+    const node = pending.pop();
+    if (typeof node === "string") {
+      text += node;
+    } else if (node) {
+      pending.push(...node.children.toReversed());
+    }
+  }
+  return text;
+}
+
+function renderDetailsNodes(nodes: readonly DetailsNode[], depth = 0): string {
+  let rendered = "";
+  for (const [index, node] of nodes.entries()) {
+    if (typeof node === "string") {
+      rendered += node;
+      continue;
+    }
+    if (node.type === "summary") {
+      rendered +=
+        depth >= MAX_DETAILS_RENDER_DEPTH
+          ? collectDetailsText(node.children)
+          : renderDetailsNodes(node.children, depth + 1);
+      continue;
+    }
+
+    const summary = node.children.find(
+      (child): child is Exclude<DetailsNode, string> =>
+        typeof child !== "string" && child.type === "summary",
+    );
+    const bodyNodes = node.children.filter((child) => child !== summary);
+    const container = resolveMarkdownContainerLayout(rendered);
+    const renderedBody =
+      depth >= MAX_DETAILS_RENDER_DEPTH
+        ? collectDetailsText(bodyNodes)
+        : renderDetailsNodes(bodyNodes, depth + 1);
+    const body = trimMarkdownBlankLines(
+      container ? stripMarkdownContainerLayout(renderedBody, container) : renderedBody,
+    );
+    const label = summary
+      ? (depth >= MAX_DETAILS_RENDER_DEPTH
+          ? collectDetailsText(summary.children)
+          : renderDetailsNodes(summary.children, depth + 1)
+        ).trim()
+      : "Details";
+    const heading = `**${label || "Details"}**`;
+    const block = body ? `${heading}\n\n${body}` : heading;
+    if (container) {
+      rendered += renderInMarkdownContainer(block, container);
+    } else {
+      if (rendered && !rendered.endsWith("\n\n")) {
+        rendered += rendered.endsWith("\n") ? "\n" : "\n\n";
+      }
+      rendered += block;
+    }
+    const next = nodes[index + 1];
+    if (
+      next !== undefined &&
+      next !== "" &&
+      (typeof next !== "string" || !next.startsWith("\n\n"))
+    ) {
+      rendered += typeof next === "string" && next.startsWith("\n") ? "\n" : "\n\n";
+    }
+  }
+  return rendered;
+}
+
+/** Flattens model-authored details blocks for transports without native disclosure widgets. */
+export function flattenMarkdownDetails(text: string): string {
+  if (!/<\s*\/?\s*(?:details|summary)(?=\s|>)/i.test(text)) {
+    return text;
+  }
+
+  const root: DetailsNode[] = [];
+  const stack: Array<Extract<DetailsNode, { type: "details" | "summary" }>> = [];
+  // Accepted tradeoff: four-space-indented literal tags may flatten as details.
+  // Fenced and inline code stay protected; models normally author code fences.
+  const codeRegions = findCodeRegions(text);
+  let cursor = 0;
+  for (const match of text.matchAll(DETAILS_TAG_RE)) {
+    const start = match.index ?? 0;
+    if (isInsideCode(start, codeRegions)) {
+      continue;
+    }
+
+    const target = stack.at(-1)?.children ?? root;
+    appendNode(target, text.slice(cursor, start));
+    cursor = start + match[0].length;
+
+    const type = match[2]?.toLowerCase();
+    if (type !== "details" && type !== "summary") {
+      continue;
+    }
+    if (match[1]) {
+      if (
+        type === "details" &&
+        stack.at(-1)?.type === "summary" &&
+        stack.at(-2)?.type === "details"
+      ) {
+        stack.pop();
+      }
+      if (stack.at(-1)?.type === type) {
+        stack.pop();
+      }
+      continue;
+    }
+
+    const node = { type, children: [] } satisfies Exclude<DetailsNode, string>;
+    appendNode(target, node);
+    stack.push(node);
+  }
+  appendNode(stack.at(-1)?.children ?? root, text.slice(cursor));
+  return renderDetailsNodes(root);
+}

--- a/src/infra/outbound/markdown-details.ts
+++ b/src/infra/outbound/markdown-details.ts
@@ -11,6 +11,14 @@ type DetailsNode =
 
 const DETAILS_TAG_RE = /<\s*(\/?)\s*(details|summary)(?=\s|>)[^>]*>/gi;
 
+function isEscapedMarkdownCharacter(text: string, index: number): boolean {
+  let backslashes = 0;
+  for (let cursor = index - 1; cursor >= 0 && text.charAt(cursor) === "\\"; cursor -= 1) {
+    backslashes += 1;
+  }
+  return backslashes % 2 === 1;
+}
+
 function appendNode(target: DetailsNode[], node: DetailsNode): void {
   const previous = target.at(-1);
   if (typeof previous === "string" && typeof node === "string") {
@@ -156,7 +164,7 @@ export function flattenMarkdownDetails(text: string): string {
   let cursor = 0;
   for (const match of text.matchAll(DETAILS_TAG_RE)) {
     const start = match.index ?? 0;
-    if (isInsideCode(start, codeRegions)) {
+    if (isEscapedMarkdownCharacter(text, start) || isInsideCode(start, codeRegions)) {
       continue;
     }
 

--- a/src/infra/outbound/sanitize-text.ts
+++ b/src/infra/outbound/sanitize-text.ts
@@ -1,3 +1,4 @@
+import { flattenMarkdownDetails } from "./markdown-details.js";
 // Plain-text sanitization strips internal runtime scaffolding and converts a
 // conservative subset of model-produced HTML into channel-friendly text.
 import { stripInternalRuntimeScaffolding } from "./protocol-scaffolding.js";
@@ -32,7 +33,7 @@ function stripRemainingHtmlTags(text: string): string {
 export function sanitizeForPlainText(text: string, options: { style?: "markdown" } = {}): string {
   const boldMarker = options.style === "markdown" ? "**" : "*";
   const strikeMarker = options.style === "markdown" ? "~~" : "~";
-  const converted = stripInternalRuntimeScaffolding(text)
+  const converted = flattenMarkdownDetails(stripInternalRuntimeScaffolding(text))
     // Preserve angle-bracket autolinks as plain URLs before tag stripping.
     .replace(/<((?:https?:\/\/|mailto:)[^<>\s]+)>/gi, "$1")
     // Normalize attributes once; conversions below only need exact bare tag names.

--- a/ui/src/components/markdown-details.test.ts
+++ b/ui/src/components/markdown-details.test.ts
@@ -329,6 +329,37 @@ describe("details line-start contract", () => {
     expect([...fragment.children]).toHaveLength(1);
   });
 
+  it("keeps disclosure-shaped inline code on a structural line literal", () => {
+    const html = toSanitizedMarkdownHtml(
+      "<details><summary>A</summary>`literal </details>` still inside</details>",
+    );
+    const fragment = htmlFragment(html);
+    const details = fragment.querySelector("details");
+
+    expect(details?.querySelector("code")?.textContent).toBe("literal </details>");
+    expect(details?.textContent).toContain("still inside");
+    expect(fragment.querySelectorAll("details")).toHaveLength(1);
+  });
+
+  it("keeps escaped disclosure tags on a structural line literal", () => {
+    const html = toSanitizedMarkdownHtml(
+      "<details><summary>A</summary>\\</details> still inside</details>",
+    );
+    const fragment = htmlFragment(html);
+    const details = fragment.querySelector("details");
+
+    expect(details?.textContent).toContain("</details> still inside");
+    expect(fragment.querySelectorAll("details")).toHaveLength(1);
+  });
+
+  it("does not repair disclosure-shaped indented code while streaming", () => {
+    const html = toStreamingMarkdownHtml("before\n\n    <details>\n    <summary>literal");
+    const code = htmlFragment(html).querySelector("code");
+
+    expect(code?.textContent).toBe("<details>\n<summary>literal\n");
+    expect(code?.textContent).not.toContain("</summary>");
+  });
+
   it("keeps streaming details intact across an inline prose close tag", () => {
     const html = toStreamingMarkdownHtml(
       "<details>\n<summary>A</summary>\nliteral </details> text\n\nstill inside",

--- a/ui/src/components/markdown-details.test.ts
+++ b/ui/src/components/markdown-details.test.ts
@@ -1,0 +1,366 @@
+import { describe, expect, it } from "vitest";
+import { toSanitizedMarkdownHtml, toStreamingMarkdownHtml } from "./markdown.ts";
+
+function htmlFragment(html: string): DocumentFragment {
+  return document.createRange().createContextualFragment(html);
+}
+
+describe("model-authored details blocks", () => {
+  it("renders block-level details with nested markdown", () => {
+    const html = toSanitizedMarkdownHtml(
+      [
+        "<details open>",
+        "",
+        "<summary>Optional depth</summary>",
+        "",
+        "**Bold body**",
+        "",
+        "- one",
+        "- two",
+        "",
+        "> quoted body",
+        "",
+        "```ts",
+        "const value = 1;",
+        "```",
+        "</details>",
+      ].join("\n"),
+    );
+    const fragment = htmlFragment(html);
+    const details = fragment.querySelector("details");
+
+    expect(details?.hasAttribute("open")).toBe(true);
+    expect(details?.querySelector("summary")?.textContent).toBe("Optional depth");
+    expect(details?.querySelector("strong")?.textContent).toBe("Bold body");
+    expect([...(details?.querySelectorAll("li") ?? [])].map((item) => item.textContent)).toEqual([
+      "one",
+      "two",
+    ]);
+    expect(details?.querySelector("blockquote")?.textContent?.trim()).toBe("quoted body");
+    expect(details?.querySelector("code.language-ts")?.textContent).toContain("const value = 1;");
+  });
+
+  it("renders a compact details block while escaping HTML in its body", () => {
+    const html = toSanitizedMarkdownHtml(
+      "<details><summary>More</summary>**bold** <script>nope</script></details>",
+    );
+    const fragment = htmlFragment(html);
+
+    expect(fragment.querySelector("details summary")?.textContent).toBe("More");
+    expect(fragment.querySelector("details strong")?.textContent).toBe("bold");
+    expect(fragment.querySelector("script")).toBeNull();
+    expect(fragment.querySelector("details")?.textContent).toContain("<script>nope</script>");
+  });
+
+  it("keeps large runs of disclosure tags literal inside fenced code", () => {
+    const count = 2_000;
+    const literals = Array.from({ length: count }, () => "</details>").join("\n");
+    const html = toSanitizedMarkdownHtml(
+      `<details><summary>Examples</summary>\n\n\`\`\`html\n${literals}\n\`\`\`\n\n</details>`,
+    );
+    const code = htmlFragment(html).querySelector("details code");
+
+    expect(code?.textContent?.match(/<\/details>/g)).toHaveLength(count);
+  });
+
+  it("caps deeply nested details at 32 tags on one line", () => {
+    let markdown = "deep body";
+    for (let index = 0; index < 48; index += 1) {
+      markdown = `<details><summary>Level ${index}</summary>${markdown}</details>`;
+    }
+
+    const html = toSanitizedMarkdownHtml(markdown);
+    const fragment = htmlFragment(html);
+
+    expect(fragment.querySelectorAll("details")).toHaveLength(32);
+    expect(fragment.textContent).toContain("<details>");
+  });
+
+  it("caps deeply nested details across lines", () => {
+    const lines: string[] = [];
+    for (let index = 0; index < 48; index += 1) {
+      lines.push("<details>", `<summary>Level ${index}</summary>`, "");
+    }
+    lines.push("deep body");
+    for (let index = 0; index < 48; index += 1) {
+      lines.push("", "</details>");
+    }
+
+    const html = toSanitizedMarkdownHtml(lines.join("\n"));
+    const fragment = htmlFragment(html);
+
+    expect(fragment.querySelectorAll("details")).toHaveLength(32);
+    expect(fragment.textContent).toContain("<details>");
+  });
+
+  it("applies the depth cap to every opener on a matched line", () => {
+    const markdown = `${Array.from({ length: 24 }, () => "<details><details>").join("\n\n")}\n\ndeep body`;
+    const html = toSanitizedMarkdownHtml(markdown);
+    const fragment = htmlFragment(html);
+
+    expect(fragment.querySelectorAll("details")).toHaveLength(32);
+    expect(fragment.textContent).toContain("<details>");
+  });
+
+  it("escapes unsupported openers while continuing to scan later valid tags", () => {
+    const html = toSanitizedMarkdownHtml(
+      '<details><summary>Outer</summary><details class="x">inner</details>after</details>',
+    );
+    const fragment = htmlFragment(html);
+    const details = fragment.querySelectorAll("details");
+
+    expect(details).toHaveLength(1);
+    expect(details[0]?.textContent).toContain('<details class="x">');
+    expect(details[0]?.textContent).not.toContain("after");
+    expect(fragment.textContent).toContain("after</details>");
+    expect(html).not.toContain("&lt;details&gt;&lt;summary&gt;Outer");
+  });
+
+  it("keeps an unterminated details block in the repaired streaming tail", () => {
+    const html = toStreamingMarkdownHtml(
+      "Intro\n\n<details open>\n<summary>More</summary>\n\n**partial body",
+    );
+    const fragment = htmlFragment(html);
+    const details = fragment.querySelector("details");
+
+    expect(fragment.querySelector("p")?.textContent).toBe("Intro");
+    expect(details?.hasAttribute("open")).toBe(true);
+    expect(details?.querySelector("summary")?.textContent).toBe("More");
+    expect(details?.querySelector("strong")?.textContent).toBe("partial body");
+    expect(html).not.toContain("&lt;details");
+    expect(html).not.toContain("&lt;/details");
+    expect(details?.textContent).not.toContain("</details>");
+  });
+
+  it("repairs an unterminated summary while streaming", () => {
+    const html = toStreamingMarkdownHtml("<details>\n<summary>Still arriving");
+    const fragment = htmlFragment(html);
+
+    expect(fragment.querySelector("details summary")?.textContent).toBe("Still arriving");
+    expect(html).not.toContain("&lt;summary");
+  });
+
+  it("keeps completed code fences inside an open details streaming tail", () => {
+    const html = toStreamingMarkdownHtml(
+      "<details>\n<summary>Logs</summary>\n\n~~~ts\nconst value = 1;\n~~~\n\nstill streaming",
+    );
+    const fragment = htmlFragment(html);
+    const details = fragment.querySelector("details");
+
+    expect(details?.querySelector("code.language-ts")?.textContent).toContain("const value = 1;");
+    expect(details?.textContent).toContain("still streaming");
+    expect([...fragment.children]).toHaveLength(1);
+  });
+
+  it("repairs prose after a closed fence and details block without a blank line", () => {
+    const html = toStreamingMarkdownHtml(
+      "<details>\n<summary>Logs</summary>\n\n```ts\nconst value = 1;\n```\n</details>\ncontinuing **now",
+    );
+    const fragment = htmlFragment(html);
+
+    expect(fragment.querySelector("details code.language-ts")?.textContent).toContain(
+      "const value = 1;",
+    );
+    expect(fragment.querySelector("p:last-child strong")?.textContent).toBe("now");
+  });
+
+  it("repairs an unterminated summary after a closed fence and details block", () => {
+    const html = toStreamingMarkdownHtml(
+      "<details>\n<summary>Logs</summary>\n\n```ts\nconst value = 1;\n```\n</details>\n<details>\n<summary>Still arriving",
+    );
+    const details = htmlFragment(html).querySelectorAll("details");
+
+    expect(details).toHaveLength(2);
+    expect(details[1]?.querySelector("summary")?.textContent).toBe("Still arriving");
+    expect(html).not.toContain("&lt;summary");
+  });
+
+  it("stabilizes a completed details block before the live markdown tail", () => {
+    const html = toStreamingMarkdownHtml(
+      "<details><summary>Done</summary>fixed</details>\n\ncontinuing **now",
+    );
+    const fragment = htmlFragment(html);
+
+    expect(fragment.querySelector("details summary")?.textContent).toBe("Done");
+    expect(fragment.querySelector("details p")?.textContent).toBe("fixed");
+    expect(fragment.querySelector("p:last-child strong")?.textContent).toBe("now");
+  });
+
+  it("keeps a closed disclosure and its continuation in the same list item", () => {
+    const html = toStreamingMarkdownHtml(
+      "- <details>\n  <summary>Logs</summary>\n\n  body\n  </details>\n  continuing **now",
+    );
+    const fragment = htmlFragment(html);
+    const listItem = fragment.querySelector("li");
+
+    expect(listItem?.querySelector("details")?.textContent).toContain("body");
+    expect(listItem?.querySelector("strong")?.textContent).toBe("now");
+    expect(fragment.querySelector(":scope > p")).toBeNull();
+  });
+});
+
+describe("multi-token details shapes", () => {
+  it("parses body blocks normally after an opener and summary share a line", () => {
+    const html = toSanitizedMarkdownHtml(
+      "<details><summary>More</summary>\nbody **one**\n\nbody two\n</details>",
+    );
+    const details = htmlFragment(html).querySelector("details");
+
+    expect(details?.querySelector("summary")?.textContent).toBe("More");
+    expect(details?.querySelector("strong")?.textContent).toBe("one");
+    expect(details?.querySelectorAll("p")).toHaveLength(2);
+  });
+
+  it("renders a summary authored after a blank line", () => {
+    const html = toSanitizedMarkdownHtml(
+      "<details>\n\n<summary>Authored label</summary>\n\nbody\n</details>",
+    );
+    const details = htmlFragment(html).querySelector("details");
+
+    expect(details?.querySelector("summary")?.textContent).toBe("Authored label");
+    expect(details?.textContent).toContain("body");
+  });
+
+  it("renders details when body text follows the summary without a blank line", () => {
+    const html = toSanitizedMarkdownHtml(
+      "<details>\n<summary>More</summary>\nfirst line\n\nsecond paragraph\n</details>",
+    );
+    const fragment = htmlFragment(html);
+    const details = fragment.querySelector("details");
+
+    expect(details?.querySelector("summary")?.textContent).toBe("More");
+    expect(details?.textContent).toContain("first line");
+    expect(details?.textContent).toContain("second paragraph");
+    expect(html).not.toContain("&lt;details");
+  });
+
+  it("renders markdown following a closed details block from the same token", () => {
+    const html = toSanitizedMarkdownHtml("<details><summary>A</summary>a</details>\ncontinuing");
+    const fragment = htmlFragment(html);
+
+    expect(fragment.querySelector("details summary")?.textContent).toBe("A");
+    expect(fragment.querySelector("details")?.textContent).toContain("a");
+    expect(fragment.lastElementChild?.textContent).toBe("continuing");
+    expect(html).not.toContain("&lt;details");
+  });
+
+  it("renders consecutive details blocks without a blank line", () => {
+    const html = toSanitizedMarkdownHtml(
+      "<details><summary>A</summary>a</details>\n<details><summary>B</summary>b</details>",
+    );
+    const details = htmlFragment(html).querySelectorAll("details");
+
+    expect([...details].map((entry) => entry.querySelector("summary")?.textContent)).toEqual([
+      "A",
+      "B",
+    ]);
+    expect([...details].map((entry) => entry.textContent?.trim())).toEqual(["Aa", "Bb"]);
+  });
+
+  it("renders more than 32 sibling details blocks and their trailing markdown", () => {
+    const siblings = Array.from(
+      { length: 40 },
+      (_, index) => `<details><summary>Sibling ${index}</summary>body ${index}</details>`,
+    ).join("\n");
+    const html = toSanitizedMarkdownHtml(`${siblings}\ntrailing **done**`);
+    const fragment = htmlFragment(html);
+    const details = fragment.querySelectorAll("details");
+
+    expect(details).toHaveLength(40);
+    expect(details[39]?.querySelector("summary")?.textContent).toBe("Sibling 39");
+    expect(fragment.lastElementChild?.querySelector("strong")?.textContent).toBe("done");
+    expect(html).not.toContain("&lt;details");
+  });
+
+  it("renders markdown following a standalone details close token", () => {
+    const html = toSanitizedMarkdownHtml(
+      "<details>\n<summary>A</summary>\n\nbody\n\n</details>\ncontinuing",
+    );
+    const fragment = htmlFragment(html);
+    const details = fragment.querySelector("details");
+
+    expect(details?.textContent).toContain("body");
+    expect(details?.textContent).not.toContain("continuing");
+    expect(fragment.lastElementChild?.textContent).toBe("continuing");
+    expect(html).not.toContain("&lt;/details");
+  });
+
+  it("renders details when body text starts without a summary", () => {
+    const html = toSanitizedMarkdownHtml("<details>\nfirst line\n\nsecond paragraph\n</details>");
+    const fragment = htmlFragment(html);
+    const details = fragment.querySelector("details");
+
+    expect(details?.querySelector("summary")).toBeNull();
+    expect(details?.textContent).toContain("first line");
+    expect(details?.textContent).toContain("second paragraph");
+    expect(html).not.toContain("&lt;details");
+  });
+});
+
+describe("details line-start contract", () => {
+  it("keeps inline-code, prose, and task-item occurrences escaped", () => {
+    const html = toSanitizedMarkdownHtml(
+      [
+        "`<details><summary>code</summary>body</details>`",
+        "",
+        "prose <details><summary>inline</summary>body</details>",
+        "",
+        "- [ ] <details><summary>task</summary>body</details>",
+      ].join("\n"),
+    );
+    const fragment = htmlFragment(html);
+
+    expect(fragment.querySelector("details")).toBeNull();
+    expect(fragment.querySelector("code")?.textContent).toContain("<details>");
+    expect(fragment.querySelector("li")?.textContent).toContain("<details>");
+    expect(fragment.textContent).toContain("prose <details>");
+  });
+
+  it("keeps an open streaming details block intact across inline code", () => {
+    const code = "`literal </details> marker`";
+    const html = toStreamingMarkdownHtml(
+      `<details>\n<summary>Example</summary>\n${code}\n\nstill inside`,
+    );
+    const fragment = htmlFragment(html);
+    const details = fragment.querySelector("details");
+
+    expect(details?.textContent).toContain("literal </details> marker");
+    expect(details?.textContent).toContain("still inside");
+    expect([...fragment.children]).toHaveLength(1);
+  });
+
+  it("keeps streaming details intact across an inline prose close tag", () => {
+    const html = toStreamingMarkdownHtml(
+      "<details>\n<summary>A</summary>\nliteral </details> text\n\nstill inside",
+    );
+    const fragment = htmlFragment(html);
+    const details = fragment.querySelector("details");
+
+    expect(details?.textContent).toContain("literal </details> text");
+    expect(details?.textContent).toContain("still inside");
+    expect([...fragment.children]).toHaveLength(1);
+  });
+
+  it.each([
+    ["list item", "- <details>\n  <summary>A</summary>\n\n  still inside"],
+    ["blockquote", "> <details>\n> <summary>A</summary>\n>\n> still inside"],
+  ])("keeps streaming details intact inside a %s container", (_name, markdown) => {
+    const html = toStreamingMarkdownHtml(markdown);
+    const details = htmlFragment(html).querySelector("details");
+
+    expect(details?.querySelector("summary")?.textContent).toBe("A");
+    expect(details?.textContent).toContain("still inside");
+    expect(html).not.toContain("&lt;details");
+  });
+
+  it("keeps streaming details intact on a wide list continuation indent", () => {
+    const html = toStreamingMarkdownHtml(
+      "1.  item\n    <details>\n    <summary>A</summary>\n\n    still inside",
+    );
+    const details = htmlFragment(html).querySelector("details");
+
+    expect(details?.querySelector("summary")?.textContent).toBe("A");
+    expect(details?.textContent).toContain("still inside");
+    expect(html).not.toContain("&lt;details");
+  });
+});

--- a/ui/src/components/markdown-details.ts
+++ b/ui/src/components/markdown-details.ts
@@ -1,5 +1,6 @@
 import type MarkdownIt from "markdown-it";
 import type StateBlock from "markdown-it/lib/rules_block/state_block.mjs";
+import { findMarkdownCodeSpans } from "../../../packages/markdown-core/src/reasoning-tags.js";
 
 export const MAX_MARKDOWN_DETAILS_DEPTH = 32;
 const DISCLOSURE_TAG_RE = /<\/?(?:details|summary)(?=[\s>])[^>]*>/gi;
@@ -25,6 +26,21 @@ type MarkdownDisclosureTagKind =
   | "summary_open"
   | "summary_close";
 
+function isEscapedMarkdownCharacter(text: string, index: number): boolean {
+  let backslashes = 0;
+  for (let cursor = index - 1; cursor >= 0 && text.charAt(cursor) === "\\"; cursor -= 1) {
+    backslashes += 1;
+  }
+  return backslashes % 2 === 1;
+}
+
+function isInsideMarkdownCode(
+  index: number,
+  codeSpans: ReadonlyArray<readonly [number, number]>,
+): boolean {
+  return codeSpans.some(([start, end]) => index >= start && index < end);
+}
+
 export function markdownDisclosureTagKind(raw: string): MarkdownDisclosureTagKind | null {
   const detailsOpen = DETAILS_OPEN_RE.exec(raw);
   if (detailsOpen) {
@@ -40,7 +56,11 @@ export function markdownDisclosureTagKind(raw: string): MarkdownDisclosureTagKin
 }
 
 /** Disclosure markup is structural only when it starts the current Markdown block line. */
-export function scanMarkdownDisclosureLine(line: string): MarkdownDisclosureTag[] | null {
+export function scanMarkdownDisclosureLine(
+  line: string,
+  codeSpans: ReadonlyArray<readonly [number, number]> = findMarkdownCodeSpans(line),
+  lineOffset = 0,
+): MarkdownDisclosureTag[] | null {
   const first = /^[ \t]*<\/?(?:details|summary)(?=[\s>])/i.exec(line);
   if (!first) {
     return null;
@@ -48,9 +68,15 @@ export function scanMarkdownDisclosureLine(line: string): MarkdownDisclosureTag[
   const tags: MarkdownDisclosureTag[] = [];
   for (const match of line.matchAll(DISCLOSURE_TAG_RE)) {
     const start = match.index ?? 0;
+    if (
+      isEscapedMarkdownCharacter(line, start) ||
+      isInsideMarkdownCode(lineOffset + start, codeSpans)
+    ) {
+      continue;
+    }
     tags.push({ end: start + match[0].length, raw: match[0], start });
   }
-  return tags;
+  return tags.length > 0 ? tags : null;
 }
 
 function pushInlineParagraph(state: StateBlock, content: string, line: number): void {

--- a/ui/src/components/markdown-details.ts
+++ b/ui/src/components/markdown-details.ts
@@ -82,11 +82,11 @@ function detailsBlockRule(
   _endLine: number,
   silent: boolean,
 ): boolean {
-  if (state.sCount[startLine] - state.blkIndent >= 4) {
+  if ((state.sCount[startLine] ?? 0) - state.blkIndent >= 4) {
     return false;
   }
-  const start = state.bMarks[startLine] + state.tShift[startLine];
-  const end = state.eMarks[startLine];
+  const start = (state.bMarks[startLine] ?? 0) + (state.tShift[startLine] ?? 0);
+  const end = state.eMarks[startLine] ?? state.src.length;
   const line = state.src.slice(start, end);
   const tags = scanMarkdownDisclosureLine(line);
   if (!tags) {

--- a/ui/src/components/markdown-details.ts
+++ b/ui/src/components/markdown-details.ts
@@ -98,7 +98,7 @@ function detailsBlockRule(
 
   const stack = (state[DETAILS_STACK] ??= []);
   const kinds = tags.map((tag) => markdownDisclosureTagKind(tag.raw));
-  const nextSummaryClose = new Array<number>(tags.length).fill(-1);
+  const nextSummaryClose = Array.from({ length: tags.length }, () => -1);
   let nearestSummaryClose = -1;
   for (let index = tags.length - 1; index >= 0; index -= 1) {
     nextSummaryClose[index] = nearestSummaryClose;

--- a/ui/src/components/markdown-details.ts
+++ b/ui/src/components/markdown-details.ts
@@ -1,0 +1,190 @@
+import type MarkdownIt from "markdown-it";
+import type StateBlock from "markdown-it/lib/rules_block/state_block.mjs";
+
+export const MAX_MARKDOWN_DETAILS_DEPTH = 32;
+const DISCLOSURE_TAG_RE = /<\/?(?:details|summary)(?=[\s>])[^>]*>/gi;
+const DETAILS_OPEN_RE = /^<details( open)?>$/i;
+const DETAILS_CLOSE_RE = /^<\/details>$/i;
+const SUMMARY_OPEN_RE = /^<summary>$/i;
+const SUMMARY_CLOSE_RE = /^<\/summary>$/i;
+const DETAILS_STACK = Symbol("markdownDetailsStack");
+
+type DetailsFrame = { hasSummary: boolean };
+type DetailsBlockState = StateBlock & { [DETAILS_STACK]?: DetailsFrame[] };
+
+export type MarkdownDisclosureTag = {
+  end: number;
+  raw: string;
+  start: number;
+};
+
+export type MarkdownDisclosureTagKind =
+  | "details_open"
+  | "details_open_expanded"
+  | "details_close"
+  | "summary_open"
+  | "summary_close";
+
+export function markdownDisclosureTagKind(raw: string): MarkdownDisclosureTagKind | null {
+  const detailsOpen = DETAILS_OPEN_RE.exec(raw);
+  if (detailsOpen) {
+    return detailsOpen[1] ? "details_open_expanded" : "details_open";
+  }
+  if (DETAILS_CLOSE_RE.test(raw)) {
+    return "details_close";
+  }
+  if (SUMMARY_OPEN_RE.test(raw)) {
+    return "summary_open";
+  }
+  return SUMMARY_CLOSE_RE.test(raw) ? "summary_close" : null;
+}
+
+/** Disclosure markup is structural only when it starts the current Markdown block line. */
+export function scanMarkdownDisclosureLine(line: string): MarkdownDisclosureTag[] | null {
+  const first = /^[ \t]*<\/?(?:details|summary)(?=[\s>])/i.exec(line);
+  if (!first) {
+    return null;
+  }
+  const tags: MarkdownDisclosureTag[] = [];
+  for (const match of line.matchAll(DISCLOSURE_TAG_RE)) {
+    const start = match.index ?? 0;
+    tags.push({ end: start + match[0].length, raw: match[0], start });
+  }
+  return tags;
+}
+
+function pushInlineParagraph(state: StateBlock, content: string, line: number): void {
+  if (!content.trim()) {
+    return;
+  }
+  const open = state.push("paragraph_open", "p", 1);
+  open.map = [line, line + 1];
+  const inline = state.push("inline", "", 0);
+  inline.content = content;
+  inline.map = [line, line + 1];
+  inline.children = [];
+  state.push("paragraph_close", "p", -1);
+}
+
+function pushSummary(state: StateBlock, label: string, line: number): void {
+  const open = state.push("summary_open", "summary", 1);
+  open.map = [line, line + 1];
+  const inline = state.push("inline", "", 0);
+  inline.content = label;
+  inline.map = [line, line + 1];
+  inline.children = [];
+  state.push("summary_close", "summary", -1);
+}
+
+function detailsBlockRule(
+  state: DetailsBlockState,
+  startLine: number,
+  _endLine: number,
+  silent: boolean,
+): boolean {
+  if (state.sCount[startLine] - state.blkIndent >= 4) {
+    return false;
+  }
+  const start = state.bMarks[startLine] + state.tShift[startLine];
+  const end = state.eMarks[startLine];
+  const line = state.src.slice(start, end);
+  const tags = scanMarkdownDisclosureLine(line);
+  if (!tags) {
+    return false;
+  }
+  if (silent) {
+    return true;
+  }
+
+  const stack = (state[DETAILS_STACK] ??= []);
+  const kinds = tags.map((tag) => markdownDisclosureTagKind(tag.raw));
+  const nextSummaryClose = new Array<number>(tags.length).fill(-1);
+  let nearestSummaryClose = -1;
+  for (let index = tags.length - 1; index >= 0; index -= 1) {
+    nextSummaryClose[index] = nearestSummaryClose;
+    if (kinds[index] === "summary_close") {
+      nearestSummaryClose = index;
+    }
+  }
+  let cursor = 0;
+  let pendingText = "";
+  const flushText = () => {
+    pushInlineParagraph(state, pendingText, startLine);
+    pendingText = "";
+  };
+
+  for (let index = 0; index < tags.length; index += 1) {
+    const tag = tags[index];
+    if (!tag) {
+      continue;
+    }
+    pendingText += line.slice(cursor, tag.start);
+
+    const kind = kinds[index];
+    if (
+      (kind === "details_open" || kind === "details_open_expanded") &&
+      stack.length < MAX_MARKDOWN_DETAILS_DEPTH
+    ) {
+      flushText();
+      const token = state.push("details_open", "details", 1);
+      if (kind === "details_open_expanded") {
+        token.attrSet("open", "");
+      }
+      stack.push({ hasSummary: false });
+    } else if (kind === "details_close" && stack.length > 0) {
+      flushText();
+      state.push("details_close", "details", -1);
+      stack.pop();
+    } else if (kind === "summary_open") {
+      const frame = stack.at(-1);
+      const closeIndex = nextSummaryClose[index] ?? -1;
+      const close = closeIndex >= 0 ? tags[closeIndex] : undefined;
+      if (frame && !frame.hasSummary && close) {
+        flushText();
+        pushSummary(state, line.slice(tag.end, close.start), startLine);
+        frame.hasSummary = true;
+        cursor = close.end;
+        index = closeIndex;
+        continue;
+      }
+      pendingText += tag.raw;
+    } else {
+      pendingText += tag.raw;
+    }
+    cursor = tag.end;
+  }
+  pendingText += line.slice(cursor);
+  flushText();
+  state.line = startLine + 1;
+  return true;
+}
+
+export function installMarkdownDetails(markdownParser: MarkdownIt): void {
+  markdownParser.block.ruler.before("html_block", "details_block", detailsBlockRule, {
+    alt: ["paragraph", "reference", "blockquote"],
+  });
+
+  // Streaming can end with open details; balance only our structured tokens at EOF.
+  markdownParser.core.ruler.after("block", "details_balance", (state) => {
+    let depth = 0;
+    for (const token of state.tokens) {
+      if (token.type === "details_open") {
+        depth += 1;
+      } else if (token.type === "details_close") {
+        depth = Math.max(0, depth - 1);
+      }
+    }
+    while (depth > 0) {
+      const token = new state.Token("details_close", "details", -1);
+      token.block = true;
+      state.tokens.push(token);
+      depth -= 1;
+    }
+  });
+
+  markdownParser.renderer.rules.details_open = (tokens, index) =>
+    tokens[index]?.attrGet("open") === null ? "<details>" : "<details open>";
+  markdownParser.renderer.rules.details_close = () => "</details>\n";
+  markdownParser.renderer.rules.summary_open = () => "<summary>";
+  markdownParser.renderer.rules.summary_close = () => "</summary>";
+}

--- a/ui/src/components/markdown-details.ts
+++ b/ui/src/components/markdown-details.ts
@@ -12,13 +12,13 @@ const DETAILS_STACK = Symbol("markdownDetailsStack");
 type DetailsFrame = { hasSummary: boolean };
 type DetailsBlockState = StateBlock & { [DETAILS_STACK]?: DetailsFrame[] };
 
-export type MarkdownDisclosureTag = {
+type MarkdownDisclosureTag = {
   end: number;
   raw: string;
   start: number;
 };
 
-export type MarkdownDisclosureTagKind =
+type MarkdownDisclosureTagKind =
   | "details_open"
   | "details_open_expanded"
   | "details_close"

--- a/ui/src/components/markdown-parser.ts
+++ b/ui/src/components/markdown-parser.ts
@@ -6,6 +6,7 @@ import {
   installAssistantTranscriptRoleMarkdown,
 } from "./markdown-assistant-transcript.ts";
 import { markdownCodeBlockCopyText, renderMarkdownCodeBlock } from "./markdown-code-blocks.ts";
+import { installMarkdownDetails } from "./markdown-details.ts";
 import {
   isHostLocalMarkdownFileHref,
   MARKDOWN_FILE_LINK_SCAN_RE,
@@ -50,6 +51,7 @@ export function createMarkdownParser(): MarkdownIt {
   // markdown-it uses <s> tags; we added "s" to the sanitizer allowlist.
   markdownParser.enable("strikethrough");
   installAssistantTranscriptRoleMarkdown(markdownParser, escapeMarkdownHtml);
+  installMarkdownDetails(markdownParser);
 
   // Disable fuzzy link detection to prevent bare filenames like "README.md"
   // from being auto-linked as "http://README.md". URLs with explicit protocol

--- a/ui/src/components/markdown-streaming.ts
+++ b/ui/src/components/markdown-streaming.ts
@@ -1,9 +1,17 @@
 import remend, { type RemendOptions } from "remend";
+import {
+  markdownDisclosureTagKind,
+  MAX_MARKDOWN_DETAILS_DEPTH,
+  scanMarkdownDisclosureLine,
+} from "./markdown-details.ts";
 
 const FENCE_OPEN_RE = /^[ \t]{0,3}(`{3,}|~{3,})/;
 const FENCE_CONTAINER_PREFIX_RE = /^[ \t]{0,3}(?:(?:>\s?)|(?:(?:[-+*]|\d{1,9}[.)])[ \t]+))/;
 
-function stripFenceContainerPrefixes(line: string): string {
+type DetailsFrame = { hasSummary: boolean };
+type FenceMarker = { length: number; marker: "`" | "~" };
+
+function stripMarkdownContainerPrefixes(line: string): string {
   let current = line;
   for (let index = 0; index < 8; index += 1) {
     const next = current.replace(FENCE_CONTAINER_PREFIX_RE, "");
@@ -15,47 +23,82 @@ function stripFenceContainerPrefixes(line: string): string {
   return current;
 }
 
-function getFenceMarker(line: string): { marker: "`" | "~"; length: number } | null {
-  const match = FENCE_OPEN_RE.exec(stripFenceContainerPrefixes(line));
-  if (!match) {
-    return null;
-  }
-  const fence = match[1];
-  if (!fence) {
-    return null;
-  }
-  const marker = fence.charAt(0) as "`" | "~";
-  return { marker, length: fence.length };
+function getFenceMarker(line: string): FenceMarker | null {
+  const fence = FENCE_OPEN_RE.exec(stripMarkdownContainerPrefixes(line))?.[1];
+  return fence ? { length: fence.length, marker: fence.charAt(0) as FenceMarker["marker"] } : null;
 }
 
-function isFenceClose(line: string, fence: { marker: "`" | "~"; length: number }): boolean {
-  const trimmed = stripFenceContainerPrefixes(line).trimEnd();
+function isFenceClose(line: string, fence: FenceMarker): boolean {
+  const trimmed = stripMarkdownContainerPrefixes(line).trimEnd();
   const match = FENCE_OPEN_RE.exec(trimmed);
-  if (!match) {
+  const marker = match?.[1];
+  if (!match || !marker) {
     return false;
   }
-  const markerText = match[1];
-  if (!markerText) {
+  return (
+    marker.charAt(0) === fence.marker &&
+    marker.length >= fence.length &&
+    trimmed.slice(match[0].length).trim() === ""
+  );
+}
+
+function updateDetailsStack(
+  line: string,
+  stack: DetailsFrame[],
+  allowPendingSummary: boolean,
+): boolean {
+  const tags = scanMarkdownDisclosureLine(stripMarkdownContainerPrefixes(line));
+  if (!tags) {
     return false;
   }
-  const marker = markerText.charAt(0);
-  if (marker !== fence.marker || markerText.length < fence.length) {
-    return false;
+  const kinds = tags.map((tag) => markdownDisclosureTagKind(tag.raw));
+  const nextSummaryClose = new Array<number>(tags.length).fill(-1);
+  let nearestSummaryClose = -1;
+  for (let index = tags.length - 1; index >= 0; index -= 1) {
+    nextSummaryClose[index] = nearestSummaryClose;
+    if (kinds[index] === "summary_close") {
+      nearestSummaryClose = index;
+    }
   }
-  return trimmed.slice(match[0].length).trim() === "";
+  for (let index = 0; index < tags.length; index += 1) {
+    const kind = kinds[index];
+    if (
+      (kind === "details_open" || kind === "details_open_expanded") &&
+      stack.length < MAX_MARKDOWN_DETAILS_DEPTH
+    ) {
+      stack.push({ hasSummary: false });
+    } else if (kind === "details_close" && stack.length > 0) {
+      stack.pop();
+    } else if (kind === "summary_open") {
+      const frame = stack.at(-1);
+      if (!frame || frame.hasSummary) {
+        continue;
+      }
+      const closeIndex = nextSummaryClose[index] ?? -1;
+      if (closeIndex >= 0) {
+        frame.hasSummary = true;
+        index = closeIndex;
+      } else if (allowPendingSummary) {
+        return true;
+      }
+    }
+  }
+  return false;
 }
 
 type StreamingMarkdownSplit = {
-  /** Offset just past the last blank line outside a code fence; the prefix is block-stable. */
+  /** Offset just past the last blank line outside a fence/details block; the prefix is stable. */
   boundary: number;
-  /** True when the text after the boundary contains a code fence that has not closed yet. */
-  tailHasOpenFence: boolean;
+  /** Absolute offset where remend may start, or null while a fence remains open. */
+  tailRepairStart: number | null;
 };
 
 export function splitStableStreamingMarkdown(markdownLocal: string): StreamingMarkdownSplit {
   let boundary = 0;
   let index = 0;
-  let openFence: { marker: "`" | "~"; length: number } | null = null;
+  let openFence: FenceMarker | null = null;
+  const detailsStack: DetailsFrame[] = [];
+  let lastFenceOffset = 0;
 
   while (index < markdownLocal.length) {
     const nextLineBreak = markdownLocal.indexOf("\n", index);
@@ -65,7 +108,10 @@ export function splitStableStreamingMarkdown(markdownLocal: string): StreamingMa
     if (openFence) {
       if (isFenceClose(line, openFence)) {
         openFence = null;
-        boundary = lineEnd;
+        lastFenceOffset = lineEnd;
+        if (detailsStack.length === 0) {
+          boundary = lineEnd;
+        }
       }
       index = lineEnd;
       continue;
@@ -74,32 +120,51 @@ export function splitStableStreamingMarkdown(markdownLocal: string): StreamingMa
     const openingFence = getFenceMarker(line);
     if (openingFence) {
       openFence = openingFence;
+      lastFenceOffset = lineEnd;
       index = lineEnd;
       continue;
     }
 
-    if (line.trim() === "") {
+    updateDetailsStack(line, detailsStack, false);
+    if (line.trim() === "" && detailsStack.length === 0) {
       boundary = lineEnd;
     }
     index = lineEnd;
   }
 
-  return { boundary, tailHasOpenFence: openFence !== null };
+  return {
+    boundary,
+    tailRepairStart: openFence ? null : Math.max(boundary, lastFenceOffset),
+  };
 }
 
 // Streaming-tail repair config: math is not rendered by this pipeline, so
 // completing `$$` would inject visible characters into ordinary prose.
 const streamingRemendOptions = { katex: false, linkMode: "text-only" } satisfies RemendOptions;
 
-// Renders the in-flight block live. remend closes/strips unterminated inline
-// constructs (`**bold`, half links, …) so partially streamed markup styles
-// immediately instead of flashing raw markers. Inside an open code fence the
-// tail is code, not prose: skip remend (it only understands top-level ```
-// fences) and let markdown-it auto-close the fence at end of input (CommonMark
-// allows unterminated fences), so code streams with live highlighting.
-// Invariant: the tail never contains a *closed* fence — the split boundary
-// advances past every fence close — so remend (which cannot see ~~~ fences)
-// never runs across completed fenced code.
-export function repairStreamingMarkdownTail(tail: string): string {
-  return remend(tail, streamingRemendOptions);
+// Preserve completed fences verbatim while repairing only the prose after them.
+export function repairStreamingMarkdownTail(tail: string, repairStart = 0): string {
+  const repaired =
+    tail.slice(0, repairStart) + remend(tail.slice(repairStart), streamingRemendOptions);
+  const detailsStack: DetailsFrame[] = [];
+  let openFence: FenceMarker | null = null;
+  let pendingSummary = false;
+  let index = 0;
+  while (index < repaired.length) {
+    const nextLineBreak = repaired.indexOf("\n", index);
+    const lineEnd = nextLineBreak === -1 ? repaired.length : nextLineBreak + 1;
+    const line = repaired.slice(index, nextLineBreak === -1 ? lineEnd : nextLineBreak);
+    if (openFence) {
+      if (isFenceClose(line, openFence)) {
+        openFence = null;
+      }
+    } else {
+      openFence = getFenceMarker(line);
+      if (!openFence) {
+        pendingSummary = updateDetailsStack(line, detailsStack, lineEnd === repaired.length);
+      }
+    }
+    index = lineEnd;
+  }
+  return pendingSummary ? `${repaired}</summary>` : repaired;
 }

--- a/ui/src/components/markdown-streaming.ts
+++ b/ui/src/components/markdown-streaming.ts
@@ -1,4 +1,5 @@
 import remend, { type RemendOptions } from "remend";
+import { findMarkdownCodeSpans } from "../../../packages/markdown-core/src/reasoning-tags.js";
 import {
   markdownDisclosureTagKind,
   MAX_MARKDOWN_DETAILS_DEPTH,
@@ -10,26 +11,29 @@ const FENCE_CONTAINER_PREFIX_RE = /^[ \t]{0,3}(?:(?:>\s?)|(?:(?:[-+*]|\d{1,9}[.)
 
 type DetailsFrame = { hasSummary: boolean };
 type FenceMarker = { length: number; marker: "`" | "~" };
+type StrippedMarkdownLine = { content: string; offset: number };
 
-function stripMarkdownContainerPrefixes(line: string): string {
+function stripMarkdownContainerPrefixes(line: string): StrippedMarkdownLine {
   let current = line;
+  let offset = 0;
   for (let index = 0; index < 8; index += 1) {
-    const next = current.replace(FENCE_CONTAINER_PREFIX_RE, "");
-    if (next === current) {
-      return current;
+    const match = FENCE_CONTAINER_PREFIX_RE.exec(current)?.[0];
+    if (!match) {
+      return { content: current, offset };
     }
-    current = next;
+    current = current.slice(match.length);
+    offset += match.length;
   }
-  return current;
+  return { content: current, offset };
 }
 
 function getFenceMarker(line: string): FenceMarker | null {
-  const fence = FENCE_OPEN_RE.exec(stripMarkdownContainerPrefixes(line))?.[1];
+  const fence = FENCE_OPEN_RE.exec(stripMarkdownContainerPrefixes(line).content)?.[1];
   return fence ? { length: fence.length, marker: fence.charAt(0) as FenceMarker["marker"] } : null;
 }
 
 function isFenceClose(line: string, fence: FenceMarker): boolean {
-  const trimmed = stripMarkdownContainerPrefixes(line).trimEnd();
+  const trimmed = stripMarkdownContainerPrefixes(line).content.trimEnd();
   const match = FENCE_OPEN_RE.exec(trimmed);
   const marker = match?.[1];
   if (!match || !marker) {
@@ -46,8 +50,15 @@ function updateDetailsStack(
   line: string,
   stack: DetailsFrame[],
   allowPendingSummary: boolean,
+  codeSpans: ReadonlyArray<readonly [number, number]>,
+  lineOffset: number,
 ): boolean {
-  const tags = scanMarkdownDisclosureLine(stripMarkdownContainerPrefixes(line));
+  const stripped = stripMarkdownContainerPrefixes(line);
+  const tags = scanMarkdownDisclosureLine(
+    stripped.content,
+    codeSpans,
+    lineOffset + stripped.offset,
+  );
   if (!tags) {
     return false;
   }
@@ -98,6 +109,7 @@ export function splitStableStreamingMarkdown(markdownLocal: string): StreamingMa
   let index = 0;
   let openFence: FenceMarker | null = null;
   const detailsStack: DetailsFrame[] = [];
+  const codeSpans = findMarkdownCodeSpans(markdownLocal);
   let lastFenceOffset = 0;
 
   while (index < markdownLocal.length) {
@@ -125,7 +137,7 @@ export function splitStableStreamingMarkdown(markdownLocal: string): StreamingMa
       continue;
     }
 
-    updateDetailsStack(line, detailsStack, false);
+    updateDetailsStack(line, detailsStack, false, codeSpans, index);
     if (line.trim() === "" && detailsStack.length === 0) {
       boundary = lineEnd;
     }
@@ -147,6 +159,7 @@ export function repairStreamingMarkdownTail(tail: string, repairStart = 0): stri
   const repaired =
     tail.slice(0, repairStart) + remend(tail.slice(repairStart), streamingRemendOptions);
   const detailsStack: DetailsFrame[] = [];
+  const codeSpans = findMarkdownCodeSpans(repaired);
   let openFence: FenceMarker | null = null;
   let pendingSummary = false;
   let index = 0;
@@ -161,7 +174,13 @@ export function repairStreamingMarkdownTail(tail: string, repairStart = 0): stri
     } else {
       openFence = getFenceMarker(line);
       if (!openFence) {
-        pendingSummary = updateDetailsStack(line, detailsStack, lineEnd === repaired.length);
+        pendingSummary = updateDetailsStack(
+          line,
+          detailsStack,
+          lineEnd === repaired.length,
+          codeSpans,
+          index,
+        );
       }
     }
     index = lineEnd;

--- a/ui/src/components/markdown-streaming.ts
+++ b/ui/src/components/markdown-streaming.ts
@@ -52,7 +52,7 @@ function updateDetailsStack(
     return false;
   }
   const kinds = tags.map((tag) => markdownDisclosureTagKind(tag.raw));
-  const nextSummaryClose = new Array<number>(tags.length).fill(-1);
+  const nextSummaryClose = Array.from({ length: tags.length }, () => -1);
   let nearestSummaryClose = -1;
   for (let index = tags.length - 1; index >= 0; index -= 1) {
     nextSummaryClose[index] = nearestSummaryClose;

--- a/ui/src/components/markdown.test.ts
+++ b/ui/src/components/markdown.test.ts
@@ -354,7 +354,7 @@ describe("toSanitizedMarkdownHtml", () => {
       );
     });
 
-    it("escapes details/summary injection in task items", () => {
+    it("keeps details escaped when they are inline inside a task item", () => {
       const html = toSanitizedMarkdownHtml("- [ ] <details><summary>x</summary>y</details>");
       expect(html).toBe(
         '<ul class="contains-task-list">\n<li class="task-list-item"><input class="task-list-item-checkbox" disabled="" type="checkbox"> &lt;details&gt;&lt;summary&gt;x&lt;/summary&gt;y&lt;/details&gt;</li>\n</ul>\n',

--- a/ui/src/components/markdown.ts
+++ b/ui/src/components/markdown.ts
@@ -63,6 +63,7 @@ const allowedAttrs = [
   "class",
   "disabled",
   "href",
+  "open",
   "rel",
   "target",
   "title",
@@ -572,15 +573,19 @@ export function toStreamingMarkdownHtml(
   }
   const input = formatTruncatedMarkdownInput(trimmedInput);
 
-  const { boundary, tailHasOpenFence } = splitStableStreamingMarkdown(input);
+  const { boundary, tailRepairStart } = splitStableStreamingMarkdown(input);
   const stableMarkdown = input.slice(0, boundary);
   const streamingTail = input.slice(boundary);
   const stableHtml = boundary > 0 ? toSanitizedMarkdownHtml(stableMarkdown, options) : "";
   if (!streamingTail.trim()) {
     return stableHtml;
   }
-  const tailHtml = tailHasOpenFence
-    ? renderSanitizedMarkdown(streamingTail, renderOptions)
-    : renderSanitizedMarkdown(repairStreamingMarkdownTail(streamingTail), renderOptions);
+  const tailHtml =
+    tailRepairStart === null
+      ? renderSanitizedMarkdown(streamingTail, renderOptions)
+      : renderSanitizedMarkdown(
+          repairStreamingMarkdownTail(streamingTail, tailRepairStart - boundary),
+          renderOptions,
+        );
   return `${stableHtml}${tailHtml}`;
 }


### PR DESCRIPTION
## What Problem This Solves

Models cannot currently tuck optional depth behind a disclosure. Raw `<details>` tags leak as literal text everywhere except Telegram rich mode, making longer answers noisier and exposing markup that users should never have to see.

## Why This Change Was Made

This user-requested feature lets models author collapsible sections. The Control UI and Telegram rich mode preserve native disclosures, while every other channel safely flattens them into readable Markdown instead of exposing raw tags.

AI-assisted: yes (Claude and Codex).

## User Impact

The Control UI now renders model-authored `<details>` and `<summary>` blocks natively, including while responses stream. Telegram rich mode is unchanged. All other channels show `**Summary**` followed by the body instead of literal disclosure tags.

This is a release-note-worthy feature.

## Evidence

- Autoreview clean via Codex `gpt-5.6-sol` at xhigh after 9 rounds, including the block-rule redesign. A fresh post-rebase rerun was also clean with no accepted/actionable findings.
- Focused suites: 111 Control UI markdown tests, 13 outbound disclosure-flattener tests, and 5 Telegram sanitize tests.
- Full local changed gate exited 0 across all lanes. It ran locally because the Blacksmith backend was unreachable.
- Commits:
  - `cb347732cd4` `feat: render model-authored collapsible details in web UI and flatten for plain channels`
  - `5bd53474ecc` `fix: guard markdown-it line-index access in details block rule`
  - `9dc0e1ed0f4` `fix: satisfy no-new-array lint in disclosure scanners`
