### PR TITLE
fix(agents): prevent opaque shell commands bypassing auto-review

### DIFF
--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -766,6 +766,7 @@ export async function processGatewayAllowlist(
     const autoReviewArgv =
       allowlistEval.segments.length === 1 &&
       autoReviewSegment !== undefined &&
+      autoReviewSegment.resolution?.policyBlocked !== true &&
       // Shell startup can execute unreviewed profile code before its bound payload.
       !isBlockedShellWrapperCommand(autoReviewSegment.argv) &&
       (autoReviewSegment.raw === undefined ||

--- a/src/agents/bash-tools.exec-host-node-phases.ts
+++ b/src/agents/bash-tools.exec-host-node-phases.ts
@@ -649,6 +649,7 @@ export async function analyzeNodeApprovalRequirement(params: {
   const autoReviewArgv =
     autoReviewBindingEval.segments.length === 1 &&
     autoReviewSegment !== undefined &&
+    autoReviewSegment.resolution?.policyBlocked !== true &&
     !isBlockedShellWrapperCommand(autoReviewSegment.argv) &&
     (autoReviewSegment.raw === undefined ||
       autoReviewSegment.raw.trim() === autoReviewBindingCommand.trim())

--- a/src/agents/exec-auto-review.stress.test.ts
+++ b/src/agents/exec-auto-review.stress.test.ts
@@ -127,6 +127,16 @@ describe.runIf(process.platform !== "win32")("exec auto-review shell stress", ()
     ["PowerShell encoded flag", ["pwsh", "-EncodedCommand", "ZQBjAGgAbwA="], true],
     ["PowerShell encoded abbreviation", ["pwsh", "/ec", "ZQBjAGgAbwA="], true],
     ["PowerShell encoded prefix", ["pwsh", "-en", "ZQBjAGgAbwA="], true],
+    [
+      "PowerShell encoded-arguments alias",
+      ["pwsh", "-NoProfile", "-ea", "ZQBjAGgAbwA=", "-Command", "Get-Date"],
+      true,
+    ],
+    [
+      "PowerShell slash-prefixed encoded-arguments alias",
+      ["pwsh", "/NoProfile", "/ea", "ZQBjAGgAbwA=", "/Command", "Get-Date"],
+      true,
+    ],
     ["PowerShell default-profile command", ["pwsh", "-Command", "Write-Output safe"], true],
     ["PowerShell implicit script profile", ["pwsh", "./safe.ps1"], true],
     ["PowerShell interactive default profile", ["pwsh"], true],
@@ -328,6 +338,18 @@ describe.runIf(process.platform !== "win32")("exec auto-review shell stress", ()
     [
       "PowerShell opaque encoded arguments",
       "pwsh -NoProfile -EncodedArguments ZQBjAGgAbwA= -Command 'Write-Output safe'",
+    ],
+    [
+      "PowerShell encoded-arguments alias",
+      "pwsh -NoProfile -ea ZQBjAGgAbwA= -Command 'Write-Output safe'",
+    ],
+    [
+      "PowerShell slash-prefixed encoded-arguments alias",
+      "pwsh /NoProfile /ea ZQBjAGgAbwA= /Command 'Write-Output safe'",
+    ],
+    [
+      "PowerShell encoded-arguments alias inside transparent carrier",
+      "env -- pwsh -NoProfile -ea ZQBjAGgAbwA= -Command 'Write-Output safe'",
     ],
     [
       "PowerShell remoting server despite disabled profiles",

--- a/src/agents/exec-auto-review.stress.test.ts
+++ b/src/agents/exec-auto-review.stress.test.ts
@@ -86,9 +86,10 @@ function chooseSeeded<T>(random: () => number, values: readonly T[]): T {
 }
 
 describe.runIf(process.platform !== "win32")("exec auto-review shell stress", () => {
-  it("keeps explicit and positional profile-free PowerShell script boundaries distinct", () => {
+  it("keeps mutable PowerShell script entry points outside auto-review", () => {
     const positionalScript = ["pwsh", "-NoProfile", "./safe.ps1"];
     const explicitScript = ["pwsh", "-NoProfile", "-File", "./safe.ps1"];
+    const delimitedScript = ["pwsh", "-NoProfile", "--", "./safe.ps1"];
     const consoleScript = [
       "powershell",
       "-NoProfile",
@@ -106,12 +107,17 @@ describe.runIf(process.platform !== "win32")("exec auto-review shell stress", ()
       command: "./safe.ps1",
       valueTokenIndex: 3,
     });
+    expect(resolvePowerShellInlineCommandMatch(delimitedScript)).toEqual({
+      command: null,
+      valueTokenIndex: null,
+    });
     expect(resolvePowerShellInlineCommandMatch(consoleScript)).toEqual({
       command: "Get-Date",
       valueTokenIndex: 5,
     });
-    expect(isBlockedShellWrapperCommand(positionalScript)).toBe(false);
-    expect(isBlockedShellWrapperCommand(explicitScript)).toBe(false);
+    expect(isBlockedShellWrapperCommand(positionalScript)).toBe(true);
+    expect(isBlockedShellWrapperCommand(explicitScript)).toBe(true);
+    expect(isBlockedShellWrapperCommand(delimitedScript)).toBe(true);
     expect(isBlockedShellWrapperCommand(consoleScript)).toBe(true);
   });
 
@@ -198,7 +204,13 @@ describe.runIf(process.platform !== "win32")("exec auto-review shell stress", ()
       ["pwsh", "-NoProfile", "-Command", "Write-Output safe"],
       false,
     ],
-    ["PowerShell profile-free positional script", ["pwsh", "-NoProfile", "./safe.ps1"], false],
+    ["PowerShell profile-free positional script", ["pwsh", "-NoProfile", "./safe.ps1"], true],
+    [
+      "PowerShell profile-free explicit script",
+      ["pwsh", "-NoProfile", "-File", "./safe.ps1"],
+      true,
+    ],
+    ["PowerShell profile-free delimited script", ["pwsh", "-NoProfile", "--", "./safe.ps1"], true],
     ["PowerShell abbreviated profile-free command", ["pwsh", "-nop", "-c", "Get-Date"], false],
   ])("classifies %s using the canonical shell policy", (_name, argv, blocked) => {
     expect(isBlockedShellWrapperCommand(argv)).toBe(blocked);
@@ -286,6 +298,9 @@ describe.runIf(process.platform !== "win32")("exec auto-review shell stress", ()
     ["PowerShell profile-free interactive session", "pwsh -NoProfile"],
     ["PowerShell profile-free positional stdin", "pwsh -NoProfile -"],
     ["PowerShell profile-free delimited stdin", "pwsh -NoProfile -- -"],
+    ["PowerShell profile-free positional script", "pwsh -NoProfile ./safe.ps1"],
+    ["PowerShell profile-free explicit script", "pwsh -NoProfile -File ./safe.ps1"],
+    ["PowerShell profile-free delimited script", "pwsh -NoProfile -- ./safe.ps1"],
     [
       "Windows PowerShell console startup despite disabled profiles",
       "powershell -NoProfile -PSConsoleFile ./evil.psc1 -Command 'Write-Output safe'",
@@ -426,9 +441,6 @@ describe.runIf(process.platform !== "win32")("exec auto-review shell stress", ()
     "pwsh -NoProfile -Command 'Write-Output safe'",
     "pwsh -nop -c 'Write-Output safe'",
     "pwsh /NoProfile /c 'Write-Output safe'",
-    "pwsh -NoProfile ./safe.ps1",
-    "pwsh -NoProfile -File ./safe.ps1",
-    "pwsh -NoProfile -- ./safe.ps1",
   ])("preserves ordinary reviewable command: %s", async (command) => {
     for (const host of ["gateway", "node", "codex-app-server"] as const) {
       await expect(

--- a/src/agents/exec-auto-review.stress.test.ts
+++ b/src/agents/exec-auto-review.stress.test.ts
@@ -1,0 +1,479 @@
+import { describe, expect, it, vi } from "vitest";
+import { resolveDispatchWrapperTrustPlan } from "../infra/dispatch-wrapper-resolution.js";
+import type { ExecAutoReviewInput } from "../infra/exec-auto-review.js";
+import { isBlockedShellWrapperCommand } from "../infra/exec-wrapper-resolution.js";
+import { resolvePowerShellInlineCommandMatch } from "../infra/shell-inline-command.js";
+import { buildExecAutoReviewInputForShellCommand } from "../plugin-sdk/agent-harness-exec-review-runtime.js";
+import { createModelExecAutoReviewer } from "./exec-auto-reviewer.js";
+
+const baselineInput: ExecAutoReviewInput = {
+  command: "git status",
+  argv: ["git", "status"],
+  resolvedPath: "/usr/bin/git",
+  cwd: "/repo",
+  envKeys: [],
+  host: "gateway",
+  reason: "approval-required",
+  analysis: {
+    parsed: true,
+    allowlistMatched: false,
+    inlineEval: false,
+  },
+};
+
+type StressCompletionRequest = {
+  context: { messages: Array<{ content: string }> };
+  options: { signal?: AbortSignal };
+};
+
+type StressCompletionResult = {
+  stopReason: "stop";
+  content: Array<{ type: "text"; text: string }>;
+};
+
+function createStressReviewer(params: {
+  complete: (request: StressCompletionRequest) => Promise<StressCompletionResult>;
+  timeoutMs?: number;
+}) {
+  const prepare = vi.fn(async () => ({
+    selection: { provider: "openrouter", modelId: "reviewer", agentDir: "/agent" },
+    model: { provider: "openrouter", id: "reviewer", api: "openai" as const },
+    auth: { apiKey: "redacted", mode: "env" as const },
+  }));
+  const complete = vi.fn(params.complete);
+  const reviewer = createModelExecAutoReviewer({
+    cfg: {},
+    ...(params.timeoutMs === undefined ? {} : { reviewer: { timeoutMs: params.timeoutMs } }),
+    deps: {
+      prepareSimpleCompletionModelForAgent:
+        prepare as unknown as typeof import("./simple-completion-runtime.js").prepareSimpleCompletionModelForAgent,
+      completeWithPreparedSimpleCompletionModel:
+        complete as unknown as typeof import("./simple-completion-runtime.js").completeWithPreparedSimpleCompletionModel,
+    },
+  });
+  return { reviewer, prepare, complete };
+}
+
+function modelResponse(decision: "allow" | "ask", risk: "low" | "medium") {
+  return {
+    stopReason: "stop" as const,
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify({ decision, risk, rationale: "stress fixture" }),
+      },
+    ],
+  };
+}
+
+function createSeededRandom(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let value = state;
+    value = Math.imul(value ^ (value >>> 15), value | 1);
+    value ^= value + Math.imul(value ^ (value >>> 7), value | 61);
+    return ((value ^ (value >>> 14)) >>> 0) / 4_294_967_296;
+  };
+}
+
+function chooseSeeded<T>(random: () => number, values: readonly T[]): T {
+  const selected = values[Math.floor(random() * values.length)];
+  if (selected === undefined) {
+    throw new Error("stress corpus must contain at least one value");
+  }
+  return selected;
+}
+
+describe.runIf(process.platform !== "win32")("exec auto-review shell stress", () => {
+  it("keeps explicit and positional profile-free PowerShell script boundaries distinct", () => {
+    const positionalScript = ["pwsh", "-NoProfile", "./safe.ps1"];
+    const explicitScript = ["pwsh", "-NoProfile", "-File", "./safe.ps1"];
+    const consoleScript = [
+      "powershell",
+      "-NoProfile",
+      "-pscf",
+      "./evil.psc1",
+      "-Command",
+      "Get-Date",
+    ];
+
+    expect(resolvePowerShellInlineCommandMatch(positionalScript)).toEqual({
+      command: null,
+      valueTokenIndex: null,
+    });
+    expect(resolvePowerShellInlineCommandMatch(explicitScript)).toEqual({
+      command: "./safe.ps1",
+      valueTokenIndex: 3,
+    });
+    expect(resolvePowerShellInlineCommandMatch(consoleScript)).toEqual({
+      command: "Get-Date",
+      valueTokenIndex: 5,
+    });
+    expect(isBlockedShellWrapperCommand(positionalScript)).toBe(false);
+    expect(isBlockedShellWrapperCommand(explicitScript)).toBe(false);
+    expect(isBlockedShellWrapperCommand(consoleScript)).toBe(true);
+  });
+
+  it.each<[string, string[], boolean]>([
+    ["Fish short initializer", ["fish", "-C", "echo startup", "-c", "echo payload"], true],
+    ["Fish long initializer", ["fish", "--init-command=echo startup", "-c", "echo payload"], true],
+    ["PowerShell encoded flag", ["pwsh", "-EncodedCommand", "ZQBjAGgAbwA="], true],
+    ["PowerShell encoded abbreviation", ["pwsh", "/ec", "ZQBjAGgAbwA="], true],
+    ["PowerShell encoded prefix", ["pwsh", "-en", "ZQBjAGgAbwA="], true],
+    ["PowerShell default-profile command", ["pwsh", "-Command", "Write-Output safe"], true],
+    ["PowerShell implicit script profile", ["pwsh", "./safe.ps1"], true],
+    ["PowerShell interactive default profile", ["pwsh"], true],
+    ["PowerShell profile-free interactive session", ["pwsh", "-NoProfile"], true],
+    ["PowerShell profile-free positional stdin", ["pwsh", "-NoProfile", "-"], true],
+    [
+      "PowerShell login with profiles disabled",
+      ["pwsh", "-Login", "-NoProfile", "-Command", "Write-Output safe"],
+      true,
+    ],
+    [
+      "PowerShell session configuration despite disabled profiles",
+      ["pwsh", "-NoProfile", "-ConfigurationFile", "/tmp/evil.pssc", "-Command", "Get-Date"],
+      true,
+    ],
+    [
+      "PowerShell named session configuration despite disabled profiles",
+      ["pwsh", "-NoProfile", "-ConfigurationName", "Unreviewed", "-Command", "Get-Date"],
+      true,
+    ],
+    ["PowerShell stdin command", ["pwsh", "-NoProfile", "-Command", "-"], true],
+    ["PowerShell stdin script", ["pwsh", "-NoProfile", "-File", "-"], true],
+    [
+      "Windows PowerShell console startup despite disabled profiles",
+      ["powershell", "-NoProfile", "-PSConsoleFile", "./evil.psc1", "-Command", "Get-Date"],
+      true,
+    ],
+    [
+      "PowerShell option value resembling a profile switch",
+      ["pwsh", "-WorkingDir", "/nop", "-Command", "Write-Output safe"],
+      true,
+    ],
+    [
+      "PowerShell profile-free command",
+      ["pwsh", "-NoProfile", "-Command", "Write-Output safe"],
+      false,
+    ],
+    ["PowerShell profile-free positional script", ["pwsh", "-NoProfile", "./safe.ps1"], false],
+    ["PowerShell abbreviated profile-free command", ["pwsh", "-nop", "-c", "Get-Date"], false],
+  ])("classifies %s using the canonical shell policy", (_name, argv, blocked) => {
+    expect(isBlockedShellWrapperCommand(argv)).toBe(blocked);
+  });
+
+  it.each<[string, string[]]>([
+    ["semantic environment mutation", ["env", "BASH_ENV=/tmp/stress", "bash", "-c", "echo safe"]],
+    ["opaque privileged wrapper", ["sudo", "bash", "-c", "echo safe"]],
+  ])("preserves the blocked dispatch policy for %s", (_name, argv) => {
+    expect(resolveDispatchWrapperTrustPlan(argv)).toMatchObject({ policyBlocked: true });
+  });
+
+  it("fails closed for 4,096 seeded login and interactive wrapper chains", () => {
+    const random = createSeededRandom(0x20260727);
+    const shells = ["bash", "sh", "dash", "zsh", "ksh", "mksh", "yash"] as const;
+    const startupOptions = [
+      ["-lc"],
+      ["-cl"],
+      ["-l", "-c"],
+      ["--login", "-c"],
+      ["-ic"],
+      ["-i", "-c"],
+      ["--interactive", "-c"],
+    ] as const;
+    const dispatchWrappers = [
+      ["env", "--"],
+      ["nice", "-n", "5"],
+      ["nohup", "--"],
+      ["timeout", "5s"],
+      ["stdbuf", "-o", "L"],
+      ["time", "-p"],
+    ] as const;
+
+    for (let index = 0; index < 4_096; index += 1) {
+      const argv = [
+        chooseSeeded(random, shells),
+        ...chooseSeeded(random, startupOptions),
+        `echo auto-review-stress-${index}`,
+      ];
+      const wrapperDepth = Math.floor(random() * 7);
+      for (let depth = 0; depth < wrapperDepth; depth += 1) {
+        argv.unshift(...chooseSeeded(random, dispatchWrappers));
+      }
+
+      const trustPlan = resolveDispatchWrapperTrustPlan(argv);
+      expect(
+        trustPlan.policyBlocked || isBlockedShellWrapperCommand(trustPlan.argv),
+        `startup wrapper escaped at seed 0x20260727, case ${index}: ${JSON.stringify(argv)}`,
+      ).toBe(true);
+    }
+  });
+
+  it.each([
+    ["bash combined login", "bash -lc 'echo startup'"],
+    ["bash reversed login flags", "bash -cl 'echo startup'"],
+    ["bash separate login flags", "bash -l -c 'echo startup'"],
+    ["bash long login", "bash --login -c 'echo startup'"],
+    ["bash combined interactive", "bash -ic 'echo startup'"],
+    ["bash separate interactive", "bash -i -c 'echo startup'"],
+    ["bash long interactive", "bash --interactive -c 'echo startup'"],
+    ["POSIX login", "sh -lc 'echo startup'"],
+    ["absolute POSIX login", "/bin/sh -lc 'echo startup'"],
+    ["dash login", "dash -l -c 'echo startup'"],
+    ["zsh interactive", "zsh -i -c 'echo startup'"],
+    ["fish init command", "fish -C 'echo startup' -c 'echo payload'"],
+    ["fish long init command", "fish --init-command='echo startup' -c 'echo payload'"],
+    ["Nushell login", "nu --login -c 'echo startup'"],
+    ["Nushell interactive", "nu --interactive -c 'echo startup'"],
+    ["Nushell custom config", "nu --config /tmp/auto-review-stress.nu -c 'echo startup'"],
+    ["BusyBox shell", "busybox sh -lc 'echo startup'"],
+    ["Toybox shell", "toybox sh -lc 'echo startup'"],
+    ["env passthrough", "env -- bash -lc 'echo startup'"],
+    ["env startup mutation", "env BASH_ENV=/tmp/auto-review-stress bash -c 'echo startup'"],
+    ["nice carrier", "nice -n 5 bash -lc 'echo startup'"],
+    ["nohup carrier", "nohup -- bash -lc 'echo startup'"],
+    ["timeout carrier", "timeout 5s bash -lc 'echo startup'"],
+    ["nested carriers", "nohup -- nice -n 5 env -- bash -lc 'echo startup'"],
+    ["opaque privileged carrier", "sudo bash -lc 'echo startup'"],
+    ["PowerShell default profile", "pwsh -Command 'Write-Output safe'"],
+    ["Windows PowerShell default profile", "powershell -Command 'Write-Output safe'"],
+    ["PowerShell positional script profile", "pwsh ./safe.ps1"],
+    ["Windows PowerShell positional script profile", "powershell ./safe.ps1"],
+    ["PowerShell explicit file profile", "pwsh -File ./safe.ps1"],
+    ["PowerShell interactive default profile", "pwsh"],
+    ["PowerShell profile-free interactive session", "pwsh -NoProfile"],
+    ["PowerShell profile-free positional stdin", "pwsh -NoProfile -"],
+    ["PowerShell profile-free delimited stdin", "pwsh -NoProfile -- -"],
+    [
+      "Windows PowerShell console startup despite disabled profiles",
+      "powershell -NoProfile -PSConsoleFile ./evil.psc1 -Command 'Write-Output safe'",
+    ],
+    [
+      "Windows PowerShell abbreviated console startup",
+      "powershell -NoProfile -pscf ./evil.psc1 -Command 'Write-Output safe'",
+    ],
+    [
+      "PowerShell session configuration despite disabled profiles",
+      "pwsh -NoProfile -ConfigurationFile /tmp/evil.pssc -Command 'Write-Output safe'",
+    ],
+    [
+      "PowerShell named session configuration despite disabled profiles",
+      "pwsh -NoProfile -ConfigurationName Unreviewed -Command 'Write-Output safe'",
+    ],
+    [
+      "PowerShell custom settings despite disabled profiles",
+      "pwsh -NoProfile -SettingsFile /tmp/evil.json -Command 'Write-Output safe'",
+    ],
+    [
+      "PowerShell custom IPC despite disabled profiles",
+      "pwsh -NoProfile -CustomPipeName unreviewed -Command 'Write-Output safe'",
+    ],
+    [
+      "PowerShell opaque encoded arguments",
+      "pwsh -NoProfile -EncodedArguments ZQBjAGgAbwA= -Command 'Write-Output safe'",
+    ],
+    ["PowerShell stdin command", "pwsh -NoProfile -Command -"],
+    ["PowerShell stdin script", "pwsh -NoProfile -File -"],
+    [
+      "PowerShell interactive execution despite disabled profiles",
+      "pwsh -NoProfile -Interactive -Command 'Write-Output safe'",
+    ],
+    [
+      "PowerShell persistent interactive session",
+      "pwsh -NoProfile -NoExit -Command 'Write-Output safe'",
+    ],
+    ["PowerShell abbreviated default profile", "pwsh /c 'Write-Output safe'"],
+    ["PowerShell login profile", "pwsh -Login -Command 'Write-Output safe'"],
+    ["PowerShell abbreviated login profile", "pwsh -l -Command 'Write-Output safe'"],
+    [
+      "PowerShell login despite disabled PowerShell profiles",
+      "pwsh -Login -NoProfile -Command 'Write-Output safe'",
+    ],
+    [
+      "PowerShell login after disabled PowerShell profiles",
+      "pwsh -NoProfile -Login -Command 'Write-Output safe'",
+    ],
+    [
+      "PowerShell login before a profile-free positional script",
+      "pwsh -Login -NoProfile ./safe.ps1",
+    ],
+    [
+      "PowerShell profile-load-time flag without profile suppression",
+      "pwsh -NoProfileLoadTime -Command 'Write-Output safe'",
+    ],
+    [
+      "PowerShell option value resembling a profile switch",
+      "pwsh -WorkingDir /nop -Command 'Write-Output safe'",
+    ],
+    [
+      "PowerShell default profile inside transparent carrier",
+      "env -- pwsh -Command 'Write-Output safe'",
+    ],
+    ["PowerShell encoded command", "pwsh -EncodedCommand ZQBjAGgAbwAgAHAAdwBuAGUAZAA="],
+    ["PowerShell abbreviated encoded command", "pwsh /ec ZQBjAGgAbwAgAHAAdwBuAGUAZAA="],
+    ["PowerShell short encoded command", "pwsh -e ZQBjAGgAbwAgAHAAdwBuAGUAZAA="],
+    ["PowerShell prefix encoded command", "pwsh -en ZQBjAGgAbwAgAHAAdwBuAGUAZAA="],
+    ["PowerShell long slash encoded command", "pwsh /EncodedCommand ZQBjAGgAbwAgAHAAdwBuAGUAZAA="],
+    [
+      "PowerShell encoded command after startup flags",
+      "pwsh -NoProfile -EncodedCommand ZQBjAGgAbwAgAHAAdwBuAGUAZAA=",
+    ],
+    [
+      "PowerShell encoded command after valued options",
+      "pwsh -win hidden -if XML /ec ZQBjAGgAbwAgAHAAdwBuAGUAZAA=",
+    ],
+    [
+      "PowerShell encoded command inside transparent carrier",
+      "env -- pwsh /ec ZQBjAGgAbwAgAHAAdwBuAGUAZAA=",
+    ],
+    ["multiple commands", "echo safe && bash -lc 'echo startup'"],
+    ["unterminated command", "bash -lc 'echo startup"],
+  ])("keeps %s outside plugin auto-review", async (_name, command) => {
+    for (const host of ["gateway", "node", "codex-app-server"] as const) {
+      await expect(
+        buildExecAutoReviewInputForShellCommand({
+          command,
+          cwd: process.cwd(),
+          host,
+        }),
+      ).resolves.toBeUndefined();
+    }
+  });
+
+  it.each([
+    "node --version",
+    "git status",
+    "printf safe",
+    "pwsh -NoProfile -Command 'Write-Output safe'",
+    "pwsh -nop -c 'Write-Output safe'",
+    "pwsh /NoProfile /c 'Write-Output safe'",
+    "pwsh -NoProfile ./safe.ps1",
+    "pwsh -NoProfile -File ./safe.ps1",
+    "pwsh -NoProfile -- ./safe.ps1",
+  ])("preserves ordinary reviewable command: %s", async (command) => {
+    for (const host of ["gateway", "node", "codex-app-server"] as const) {
+      await expect(
+        buildExecAutoReviewInputForShellCommand({
+          command,
+          cwd: process.cwd(),
+          host,
+        }),
+      ).resolves.toMatchObject({ command, host });
+    }
+  });
+});
+
+describe("exec auto-review concurrency stress", () => {
+  it("keeps 256 concurrent approvals independently bound and single-use", async () => {
+    const { reviewer, prepare, complete } = createStressReviewer({
+      complete: async () => modelResponse("allow", "low"),
+    });
+
+    const decisions = await Promise.all(
+      Array.from({ length: 256 }, (_unused, index) =>
+        Promise.resolve(
+          reviewer({
+            ...baselineInput,
+            command: `git status --case=${index}`,
+            argv: ["git", "status", `--case=${index}`],
+          }),
+        ),
+      ),
+    );
+
+    expect(decisions).toHaveLength(256);
+    expect(decisions.every((decision) => decision.decision === "allow-once")).toBe(true);
+    expect(prepare).toHaveBeenCalledTimes(256);
+    expect(complete).toHaveBeenCalledTimes(256);
+  });
+
+  it("never leaks allow authority between 128 mixed concurrent model outcomes", async () => {
+    const { reviewer, prepare, complete } = createStressReviewer({
+      complete: async (request) => {
+        const prompt = request.context.messages[0]?.content ?? "";
+        const match = /--case=(\d+)/.exec(prompt);
+        const index = Number(match?.[1]);
+        await Promise.resolve();
+        switch (index % 4) {
+          case 0:
+            return modelResponse("allow", "low");
+          case 1:
+            return modelResponse("allow", "medium");
+          case 2:
+            return modelResponse("ask", "medium");
+          default:
+            throw new Error("stress provider failure");
+        }
+      },
+    });
+
+    const decisions = await Promise.all(
+      Array.from({ length: 128 }, (_unused, index) =>
+        Promise.resolve(
+          reviewer({
+            ...baselineInput,
+            command: `git status --case=${index}`,
+            argv: ["git", "status", `--case=${index}`],
+          }),
+        ),
+      ),
+    );
+
+    for (const [index, decision] of decisions.entries()) {
+      expect(decision.decision, `concurrent case ${index}`).toBe(
+        index % 4 === 0 ? "allow-once" : "ask",
+      );
+    }
+    expect(prepare).toHaveBeenCalledTimes(128);
+    expect(complete).toHaveBeenCalledTimes(128);
+  });
+
+  it("aborts every timed-out provider during 64 concurrent approval requests", async () => {
+    vi.useFakeTimers();
+    try {
+      const observedSignals: AbortSignal[] = [];
+      const { reviewer, prepare, complete } = createStressReviewer({
+        timeoutMs: 1_000,
+        complete: async (request) => {
+          const signal = request.options.signal;
+          if (!signal) {
+            throw new Error("review completion must receive an abort signal");
+          }
+          observedSignals.push(signal);
+          return await new Promise<StressCompletionResult>((_resolve, reject) => {
+            signal.addEventListener("abort", () => reject(new Error("stress timeout")), {
+              once: true,
+            });
+          });
+        },
+      });
+
+      const pending = Promise.all(
+        Array.from({ length: 64 }, (_unused, index) =>
+          Promise.resolve(
+            reviewer({
+              ...baselineInput,
+              command: `git status --case=${index}`,
+              argv: ["git", "status", `--case=${index}`],
+            }),
+          ),
+        ),
+      );
+
+      await vi.advanceTimersByTimeAsync(1_001);
+      const decisions = await pending;
+
+      expect(decisions).toHaveLength(64);
+      expect(decisions.every((decision) => decision.decision === "ask")).toBe(true);
+      expect(observedSignals).toHaveLength(64);
+      expect(observedSignals.every((signal) => signal.aborted)).toBe(true);
+      expect(prepare).toHaveBeenCalledTimes(64);
+      expect(complete).toHaveBeenCalledTimes(64);
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/agents/exec-auto-review.stress.test.ts
+++ b/src/agents/exec-auto-review.stress.test.ts
@@ -141,6 +141,46 @@ describe.runIf(process.platform !== "win32")("exec auto-review shell stress", ()
       ["pwsh", "-NoProfile", "-ConfigurationName", "Unreviewed", "-Command", "Get-Date"],
       true,
     ],
+    [
+      "PowerShell remoting server despite disabled profiles",
+      ["pwsh", "-NoProfile", "-ServerMode", "-Command", "Get-Date"],
+      true,
+    ],
+    [
+      "PowerShell abbreviated remoting server",
+      ["pwsh", "-NoProfile", "-s", "-Command", "Get-Date"],
+      true,
+    ],
+    [
+      "PowerShell socket remoting server",
+      ["pwsh", "-NoProfile", "-SocketServerMode", "-Command", "Get-Date"],
+      true,
+    ],
+    [
+      "PowerShell abbreviated socket remoting server",
+      ["pwsh", "-NoProfile", "-so", "-Command", "Get-Date"],
+      true,
+    ],
+    [
+      "PowerShell named-pipe remoting server",
+      ["pwsh", "-NoProfile", "-NamedPipeServerMode", "-Command", "Get-Date"],
+      true,
+    ],
+    [
+      "PowerShell abbreviated named-pipe remoting server",
+      ["pwsh", "-NoProfile", "-nam", "-Command", "Get-Date"],
+      true,
+    ],
+    [
+      "Windows PowerShell V2 socket remoting server",
+      ["powershell", "-NoProfile", "-V2SocketServerMode", "-Command", "Get-Date"],
+      true,
+    ],
+    [
+      "Windows PowerShell abbreviated V2 socket remoting server",
+      ["powershell", "-NoProfile", "-v2so", "-Command", "Get-Date"],
+      true,
+    ],
     ["PowerShell stdin command", ["pwsh", "-NoProfile", "-Command", "-"], true],
     ["PowerShell stdin script", ["pwsh", "-NoProfile", "-File", "-"], true],
     [
@@ -273,6 +313,43 @@ describe.runIf(process.platform !== "win32")("exec auto-review shell stress", ()
     [
       "PowerShell opaque encoded arguments",
       "pwsh -NoProfile -EncodedArguments ZQBjAGgAbwA= -Command 'Write-Output safe'",
+    ],
+    [
+      "PowerShell remoting server despite disabled profiles",
+      "pwsh -NoProfile -ServerMode -Command 'Write-Output safe'",
+    ],
+    ["PowerShell abbreviated remoting server", "pwsh -NoProfile -s -Command 'Write-Output safe'"],
+    [
+      "PowerShell socket remoting server",
+      "pwsh -NoProfile -SocketServerMode -Command 'Write-Output safe'",
+    ],
+    [
+      "PowerShell abbreviated socket remoting server",
+      "pwsh -NoProfile -so -Command 'Write-Output safe'",
+    ],
+    [
+      "PowerShell named-pipe remoting server",
+      "pwsh -NoProfile -NamedPipeServerMode -Command 'Write-Output safe'",
+    ],
+    [
+      "PowerShell abbreviated named-pipe remoting server",
+      "pwsh -NoProfile -nam -Command 'Write-Output safe'",
+    ],
+    [
+      "Windows PowerShell V2 socket remoting server",
+      "powershell -NoProfile -V2SocketServerMode -Command 'Write-Output safe'",
+    ],
+    [
+      "Windows PowerShell abbreviated V2 socket remoting server",
+      "powershell -NoProfile -v2so -Command 'Write-Output safe'",
+    ],
+    [
+      "PowerShell slash-prefixed socket remoting server",
+      "pwsh /NoProfile /so /Command 'Write-Output safe'",
+    ],
+    [
+      "PowerShell remoting server inside transparent carrier",
+      "env -- pwsh -NoProfile -ServerMode -Command 'Write-Output safe'",
     ],
     ["PowerShell stdin command", "pwsh -NoProfile -Command -"],
     ["PowerShell stdin script", "pwsh -NoProfile -File -"],

--- a/src/infra/shell-inline-command.ts
+++ b/src/infra/shell-inline-command.ts
@@ -283,20 +283,19 @@ export function hasPowerShellProfileStartupBeforeInlineCommand(
   valueTokenIndex: number | null = resolvePowerShellInlineCommandMatch(argv).valueTokenIndex,
 ): boolean {
   let profilesDisabled = false;
-  // PowerShell defaults positional scripts to -File and bare argv to an
-  // interactive session; both still load profiles before execution.
+  // Positional scripts and bare sessions have no reviewable inline payload;
+  // never bind mutable script contents or future stdin to a command approval.
   const commandFlagIndex = valueTokenIndex === null ? argv.length : valueTokenIndex - 1;
   for (let index = 1; index < commandFlagIndex;) {
     const rawToken = argv[index] ?? "";
     if (rawToken === "--") {
-      const positionalPayload = argv[index + 1]?.trim();
-      return !profilesDisabled || !positionalPayload || positionalPayload === "-";
+      return true;
     }
     if (rawToken === "-") {
       return true;
     }
     if (!isPowerShellOptionToken(rawToken)) {
-      return !profilesDisabled;
+      return true;
     }
     const token = normalizeLowercaseStringOrEmpty(rawToken);
     if (POWERSHELL_UNREVIEWED_STARTUP_FLAGS.has(token)) {

--- a/src/infra/shell-inline-command.ts
+++ b/src/infra/shell-inline-command.ts
@@ -45,6 +45,7 @@ const POWERSHELL_UNREVIEWED_STARTUP_FLAGS = new Set([
   ...expandPowerShellSwitchPrefixForms("configurationname", "config"),
   ...expandPowerShellSwitchPrefixForms("custompipename", "cus"),
   ...expandPowerShellSwitchPrefixForms("encodedarguments", "encodeda"),
+  ...expandPowerShellSwitchForms(["ea"]),
   ...expandPowerShellSwitchPrefixForms("interactive", "i"),
   ...expandPowerShellSwitchPrefixForms("login", "l"),
   ...expandPowerShellSwitchPrefixForms("namedpipeservermode", "nam"),

--- a/src/infra/shell-inline-command.ts
+++ b/src/infra/shell-inline-command.ts
@@ -39,12 +39,29 @@ const POWERSHELL_COMMAND_FLAGS = [
 ];
 const POWERSHELL_FILE_FLAGS = expandPowerShellSwitchPrefixForms("file", "f");
 const POWERSHELL_INLINE_FILE_FLAGS = new Set(POWERSHELL_FILE_FLAGS);
+const POWERSHELL_NO_PROFILE_FLAGS = new Set(expandPowerShellSwitchPrefixForms("noprofile", "nop"));
+const POWERSHELL_UNREVIEWED_STARTUP_FLAGS = new Set([
+  ...expandPowerShellSwitchPrefixForms("configurationfile", "conf"),
+  ...expandPowerShellSwitchPrefixForms("configurationname", "config"),
+  ...expandPowerShellSwitchPrefixForms("custompipename", "cus"),
+  ...expandPowerShellSwitchPrefixForms("encodedarguments", "encodeda"),
+  ...expandPowerShellSwitchPrefixForms("interactive", "i"),
+  ...expandPowerShellSwitchPrefixForms("login", "l"),
+  ...expandPowerShellSwitchPrefixForms("noexit", "noe"),
+  ...expandPowerShellSwitchPrefixForms("psconsolefile", "pscf"),
+  ...expandPowerShellSwitchForms(["pscf"]),
+  ...expandPowerShellSwitchPrefixForms("settingsfile", "settings"),
+  ...expandPowerShellSwitchPrefixForms("sshservermode", "ssh"),
+]);
+const POWERSHELL_INLINE_ENCODED_COMMAND_FLAGS = new Set([
+  ...expandPowerShellSwitchPrefixForms("encodedcommand", "e"),
+  ...expandPowerShellSwitchPrefixForms("ec", "e"),
+]);
 
 const POWERSHELL_INLINE_COMMAND_FLAGS = new Set([
   ...POWERSHELL_COMMAND_FLAGS,
   ...POWERSHELL_FILE_FLAGS,
-  ...expandPowerShellSwitchPrefixForms("encodedcommand", "e"),
-  ...expandPowerShellSwitchPrefixForms("ec", "e"),
+  ...POWERSHELL_INLINE_ENCODED_COMMAND_FLAGS,
 ]);
 
 const POWERSHELL_INLINE_REST_COMMAND_FLAGS = new Set(POWERSHELL_COMMAND_FLAGS);
@@ -64,7 +81,7 @@ const POWERSHELL_OPTIONS_WITH_SEPARATE_VALUES = new Set([
   ...expandPowerShellSwitchPrefixForms("version", "v"),
   ...expandPowerShellSwitchPrefixForms("windowstyle", "w"),
   ...expandPowerShellSwitchPrefixForms("workingdirectory", "w"),
-  ...expandPowerShellSwitchForms(["ea", "ep", "if", "of", "wd"]),
+  ...expandPowerShellSwitchForms(["ea", "ep", "if", "of", "pscf", "wd"]),
 ]);
 
 const POSIX_SHELL_OPTIONS_WITH_SEPARATE_VALUES = new Set([
@@ -256,6 +273,41 @@ export function resolvePowerShellInlineCommandMatch(argv: string[]): {
   });
 }
 
+/** Detect default PowerShell profiles or OS login startup before a command. */
+export function hasPowerShellProfileStartupBeforeInlineCommand(
+  argv: string[],
+  valueTokenIndex: number | null = resolvePowerShellInlineCommandMatch(argv).valueTokenIndex,
+): boolean {
+  let profilesDisabled = false;
+  // PowerShell defaults positional scripts to -File and bare argv to an
+  // interactive session; both still load profiles before execution.
+  const commandFlagIndex = valueTokenIndex === null ? argv.length : valueTokenIndex - 1;
+  for (let index = 1; index < commandFlagIndex;) {
+    const rawToken = argv[index] ?? "";
+    if (rawToken === "--") {
+      const positionalPayload = argv[index + 1]?.trim();
+      return !profilesDisabled || !positionalPayload || positionalPayload === "-";
+    }
+    if (rawToken === "-") {
+      return true;
+    }
+    if (!isPowerShellOptionToken(rawToken)) {
+      return !profilesDisabled;
+    }
+    const token = normalizeLowercaseStringOrEmpty(rawToken);
+    if (POWERSHELL_UNREVIEWED_STARTUP_FLAGS.has(token)) {
+      return true;
+    }
+    if (POWERSHELL_NO_PROFILE_FLAGS.has(token)) {
+      profilesDisabled = true;
+    }
+    index += POWERSHELL_OPTIONS_WITH_SEPARATE_VALUES.has(token) ? 2 : 1;
+  }
+
+  // A switch-only PowerShell invocation remains an interactive stdin reader.
+  return valueTokenIndex === null || !profilesDisabled;
+}
+
 /** Return true when a PowerShell flag consumes the rest of argv as command text. */
 export function isPowerShellInlineRestCommandFlag(token: string): boolean {
   return POWERSHELL_INLINE_REST_COMMAND_FLAGS.has(normalizeLowercaseStringOrEmpty(token));
@@ -264,6 +316,11 @@ export function isPowerShellInlineRestCommandFlag(token: string): boolean {
 /** Return true when a PowerShell flag treats the next token as script file text. */
 export function isPowerShellInlineFileCommandFlag(token: string): boolean {
   return POWERSHELL_INLINE_FILE_FLAGS.has(normalizeLowercaseStringOrEmpty(token));
+}
+
+/** Return true when a PowerShell flag executes an opaque encoded command. */
+export function isPowerShellInlineEncodedCommandFlag(token: string): boolean {
+  return POWERSHELL_INLINE_ENCODED_COMMAND_FLAGS.has(normalizeLowercaseStringOrEmpty(token));
 }
 
 /** Detect POSIX interactive startup before an inline command flag. */

--- a/src/infra/shell-inline-command.ts
+++ b/src/infra/shell-inline-command.ts
@@ -47,11 +47,15 @@ const POWERSHELL_UNREVIEWED_STARTUP_FLAGS = new Set([
   ...expandPowerShellSwitchPrefixForms("encodedarguments", "encodeda"),
   ...expandPowerShellSwitchPrefixForms("interactive", "i"),
   ...expandPowerShellSwitchPrefixForms("login", "l"),
+  ...expandPowerShellSwitchPrefixForms("namedpipeservermode", "nam"),
   ...expandPowerShellSwitchPrefixForms("noexit", "noe"),
   ...expandPowerShellSwitchPrefixForms("psconsolefile", "pscf"),
   ...expandPowerShellSwitchForms(["pscf"]),
+  ...expandPowerShellSwitchPrefixForms("servermode", "s"),
   ...expandPowerShellSwitchPrefixForms("settingsfile", "settings"),
+  ...expandPowerShellSwitchPrefixForms("socketservermode", "so"),
   ...expandPowerShellSwitchPrefixForms("sshservermode", "ssh"),
+  ...expandPowerShellSwitchPrefixForms("v2socketservermode", "v2so"),
 ]);
 const POWERSHELL_INLINE_ENCODED_COMMAND_FLAGS = new Set([
   ...expandPowerShellSwitchPrefixForms("encodedcommand", "e"),

--- a/src/infra/shell-wrapper-resolution.ts
+++ b/src/infra/shell-wrapper-resolution.ts
@@ -13,6 +13,7 @@ import {
   hasPosixInteractiveStartupBeforeInlineCommand,
   hasPosixLoginStartupBeforeInlineCommand,
   isPowerShellInlineEncodedCommandFlag,
+  isPowerShellInlineFileCommandFlag,
   NUSHELL_INLINE_COMMAND_FLAGS,
   POSIX_INLINE_COMMAND_FLAGS,
   resolveInlineCommandMatch,
@@ -578,13 +579,14 @@ export function isBlockedShellWrapperCommand(argv: string[], rawCommand?: string
   }
   if (wrapper.kind === "powershell") {
     const { command, valueTokenIndex } = resolvePowerShellInlineCommandMatch(candidate.argv);
-    // Profiles and login scripts run before the payload; encoded flags hide
-    // that payload entirely. Require a human unless startup is explicitly off.
+    // Profiles run before the payload; encoded commands and mutable script
+    // files have no content bound to the approval. Escalate each to a human.
     if (
       hasPowerShellProfileStartupBeforeInlineCommand(candidate.argv, valueTokenIndex) ||
       (valueTokenIndex !== null &&
         (command === "-" ||
-          isPowerShellInlineEncodedCommandFlag(candidate.argv[valueTokenIndex - 1] ?? "")))
+          isPowerShellInlineEncodedCommandFlag(candidate.argv[valueTokenIndex - 1] ?? "") ||
+          isPowerShellInlineFileCommandFlag(candidate.argv[valueTokenIndex - 1] ?? "")))
     ) {
       return true;
     }

--- a/src/infra/shell-wrapper-resolution.ts
+++ b/src/infra/shell-wrapper-resolution.ts
@@ -9,8 +9,10 @@ import { normalizeExecutableToken } from "./exec-wrapper-tokens.js";
 import {
   hasFishAttachedCommandOption,
   hasFishInitCommandOption,
+  hasPowerShellProfileStartupBeforeInlineCommand,
   hasPosixInteractiveStartupBeforeInlineCommand,
   hasPosixLoginStartupBeforeInlineCommand,
+  isPowerShellInlineEncodedCommandFlag,
   NUSHELL_INLINE_COMMAND_FLAGS,
   POSIX_INLINE_COMMAND_FLAGS,
   resolveInlineCommandMatch,
@@ -574,12 +576,29 @@ export function isBlockedShellWrapperCommand(argv: string[], rawCommand?: string
   if (!wrapper) {
     return false;
   }
-  if (
-    wrapper.kind === "posix" &&
-    baseExecutable === "nu" &&
-    hasNushellStartupOptionBeforeInlineCommand(candidate.argv)
-  ) {
-    return true;
+  if (wrapper.kind === "powershell") {
+    const { command, valueTokenIndex } = resolvePowerShellInlineCommandMatch(candidate.argv);
+    // Profiles and login scripts run before the payload; encoded flags hide
+    // that payload entirely. Require a human unless startup is explicitly off.
+    if (
+      hasPowerShellProfileStartupBeforeInlineCommand(candidate.argv, valueTokenIndex) ||
+      (valueTokenIndex !== null &&
+        (command === "-" ||
+          isPowerShellInlineEncodedCommandFlag(candidate.argv[valueTokenIndex - 1] ?? "")))
+    ) {
+      return true;
+    }
+  }
+  if (wrapper.kind === "posix") {
+    // Startup options can consume their own payload before -c is reachable.
+    // Classify them first so profile/init execution never disappears as an
+    // unrecognized shell invocation.
+    if (
+      (baseExecutable === "fish" && hasFishInitCommandOption(candidate.argv)) ||
+      (baseExecutable === "nu" && hasNushellStartupOptionBeforeInlineCommand(candidate.argv))
+    ) {
+      return true;
+    }
   }
   if (wrapper.kind === "posix" && OPAQUE_STARTUP_FILE_SHELL_WRAPPERS.has(baseExecutable)) {
     return true;

--- a/src/node-host/invoke-system-run.ts
+++ b/src/node-host/invoke-system-run.ts
@@ -695,6 +695,7 @@ async function evaluateSystemRunPolicyPhase(
     const autoReviewArgv =
       segments.length === 1 &&
       autoReviewSegment !== undefined &&
+      autoReviewSegment.resolution?.policyBlocked !== true &&
       // Check the reviewed inner command so safe node transport remains usable.
       !isBlockedShellWrapperCommand(autoReviewSegment.argv) &&
       directAutoReviewArgvMatchesRequest &&

--- a/src/plugin-sdk/agent-harness-exec-review-runtime.ts
+++ b/src/plugin-sdk/agent-harness-exec-review-runtime.ts
@@ -65,8 +65,8 @@ export async function buildExecAutoReviewInputForShellCommand(params: {
   if (!boundSingleCommand) {
     return undefined;
   }
-  // Startup files are outside the reviewed command and cannot be auto-approved.
-  if (isBlockedShellWrapperCommand(segment.argv)) {
+  // Blocked carriers and startup files execute outside the reviewed payload.
+  if (segment.resolution?.policyBlocked === true || isBlockedShellWrapperCommand(segment.argv)) {
     return undefined;
   }
   if (


### PR DESCRIPTION
Related: #114519

## What Problem This Solves

Fixes an issue where users relying on automatic command review could inadvertently approve unreviewed Fish startup initialization, environment-modifying or privileged dispatch wrappers, PowerShell startup and login profiles including positional scripts and interactive sessions, hidden PowerShell session or Windows console configuration, externally controlled PowerShell remoting servers, stdin payloads, or opaque base64-encoded PowerShell scripts. These commands can run behavior that the reviewed command text does not faithfully represent.

## Why This Change Was Made

Use the existing canonical shell and dispatch trust decisions consistently at every gateway, node, direct system-run, and plugin-owned review boundary. Recognize Fish startup options before inline-command extraction, and classify PowerShell profile, login, and encoded-command flags through the existing canonical PowerShell option parser. Preserve ordinary shell transport, explicitly profile-free PowerShell commands, independently bound single-use approvals, human escalation, and the upstream Codex Guardian contract.

## User Impact

Commands with opaque startup, environment changes, privileged carriers, PowerShell or operating-system login profiles, or encoded scripts now require human approval instead of receiving an automatic approval. Ordinary supported commands and explicitly profile-free PowerShell remain eligible for review; no settings, environment variables, dependencies, persistent state, or protocol changes are introduced.

## Evidence

- Regression-first remote execution reproduced the original Fish, `BASH_ENV`, and `sudo` bypasses; full, abbreviated, and startup-prefixed PowerShell encoded commands; default, login, positional, and interactive PowerShell profiles; session configuration, custom settings/IPC, encoded arguments and their upstream-supported `-ea` alias, and stdin payloads; and 18 real remoting-server and abbreviation bypasses despite `-NoProfile`.
- The permanent 125-case stress suite covers 4,096 deterministically generated nested shell-wrapper attacks, hostile-command review for gateway, node, and Codex app-server hosts, positional and interactive PowerShell startup, session and Windows console configuration, all four PowerShell remoting-server transports and their upstream-supported abbreviations, opaque encoded arguments including `-ea`, slash-prefixed aliases and nested carriers, hidden stdin, canonical parser classification, mutable positional, explicit, and delimiter-based script files, safe `-NoProfile` inline commands, misleading PowerShell option values, and preserved ordinary command behavior.
- Concurrent stress verifies 256 independently bound single-use approvals, 128 mixed allow/ask/provider-failure responses without authority leakage, and cancellation of all 64 timed-out reviewer requests.
- Ten consecutive remote stress passes exercise 40,960 generated wrapper attacks and 4,480 concurrent review and cancellation requests.
- All 690 focused regressions pass across PowerShell parsing, shell wrapper resolution, gateway, node, direct system-run, plugin review, reviewer behavior, and all 82 Codex approval-bridge tests.
- The exact published head passes `pnpm check:changed`, including formatting, all four core/plugin typecheck lanes, core/plugin lint, SDK export and boundary gates, dependency and runtime guards; `pnpm build` also passes, including all 143 public plugin SDK subpaths and the complete production Control UI/performance checks.
- Exact-head GitHub CI is green, including the required `openclaw/ci-gate` merge check.
- Verified Microsoft PowerShell's official startup contract: https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_pwsh?view=powershell-7.6, https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_profiles?view=powershell-7.6, and https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_session_configuration_files?view=powershell-7.6.
- Directly verified every remoting-server flag and its shortest accepted abbreviation against the pinned upstream PowerShell parser and its own regression tests: https://github.com/PowerShell/PowerShell/blob/463ef4374ad598f396e9438580761157ea840376/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs and https://github.com/PowerShell/PowerShell/blob/463ef4374ad598f396e9438580761157ea840376/test/xUnit/csharp/test_CommandLineParser.cs.
- Independent security review identified the PowerShell profile startup, externally controlled remoting, mutable-script approval, and encoded-argument alias gaps; each was independently verified against the pinned upstream PowerShell parser, fixed at the canonical owner boundary, and permanently regression-tested. Fresh final-head Codex autoreview is clean, with no accepted or actionable findings.
- Directly verified upstream Guardian contract: `codex-rs/protocol/src/config_types.rs:159`, `codex-rs/app-server-protocol/src/protocol/v2/shared.rs:224`, and `codex-rs/core/src/guardian/review.rs:192`; canonical `auto_review`, input-only `guardian_subagent` compatibility, and activation under on-request/granular approval are unchanged.

Before the PowerShell profile fix, the real remote cross-host approval path demonstrated the bypass:

```text
$ pnpm test src/agents/exec-auto-review.stress.test.ts
FAIL  classifies PowerShell default-profile command using the canonical shell policy
FAIL  classifies PowerShell login with profiles disabled using the canonical shell policy
FAIL  keeps PowerShell default profile outside plugin auto-review
FAIL  keeps Windows PowerShell default profile outside plugin auto-review
FAIL  keeps PowerShell abbreviated default profile outside plugin auto-review
FAIL  keeps PowerShell login profile outside plugin auto-review
FAIL  keeps PowerShell login despite disabled PowerShell profiles outside plugin auto-review
FAIL  keeps PowerShell login after disabled PowerShell profiles outside plugin auto-review
FAIL  keeps PowerShell profile-load-time flag without profile suppression outside plugin auto-review
FAIL  keeps PowerShell default profile inside transparent carrier outside plugin auto-review
Tests: 10 failed | 53 passed (63)
```

After the fix, the same real approval builder runs each hostile command through gateway, node, and Codex app-server hosts while preserving legitimate profile-free commands:

```text
$ pnpm test src/agents/exec-auto-review.stress.test.ts
PASS  classifies Fish short initializer using the canonical shell policy
PASS  classifies PowerShell default-profile command using the canonical shell policy
PASS  classifies PowerShell login with profiles disabled using the canonical shell policy
PASS  classifies PowerShell option value resembling a profile switch using the canonical shell policy
PASS  classifies PowerShell implicit script profile using the canonical shell policy
PASS  classifies PowerShell interactive default profile using the canonical shell policy
PASS  classifies PowerShell session configuration despite disabled profiles using the canonical shell policy
PASS  classifies PowerShell named session configuration despite disabled profiles using the canonical shell policy
PASS  classifies PowerShell stdin command using the canonical shell policy
PASS  classifies PowerShell stdin script using the canonical shell policy
PASS  classifies Windows PowerShell console startup despite disabled profiles using the canonical shell policy
PASS  keeps env startup mutation outside plugin auto-review
PASS  keeps opaque privileged carrier outside plugin auto-review
PASS  keeps PowerShell default profile outside plugin auto-review
PASS  keeps Windows PowerShell default profile outside plugin auto-review
PASS  keeps PowerShell positional script profile outside plugin auto-review
PASS  keeps Windows PowerShell positional script profile outside plugin auto-review
PASS  keeps PowerShell interactive default profile outside plugin auto-review
PASS  keeps PowerShell session configuration despite disabled profiles outside plugin auto-review
PASS  keeps PowerShell named session configuration despite disabled profiles outside plugin auto-review
PASS  keeps PowerShell custom settings despite disabled profiles outside plugin auto-review
PASS  keeps PowerShell custom IPC despite disabled profiles outside plugin auto-review
PASS  keeps PowerShell remoting server despite disabled profiles outside plugin auto-review
PASS  keeps PowerShell abbreviated remoting server outside plugin auto-review
PASS  keeps PowerShell socket remoting server outside plugin auto-review
PASS  keeps PowerShell abbreviated socket remoting server outside plugin auto-review
PASS  keeps PowerShell named-pipe remoting server outside plugin auto-review
PASS  keeps PowerShell abbreviated named-pipe remoting server outside plugin auto-review
PASS  keeps Windows PowerShell V2 socket remoting server outside plugin auto-review
PASS  keeps Windows PowerShell abbreviated V2 socket remoting server outside plugin auto-review
PASS  keeps PowerShell slash-prefixed socket remoting server outside plugin auto-review
PASS  keeps PowerShell remoting server inside transparent carrier outside plugin auto-review
PASS  keeps PowerShell opaque encoded arguments outside plugin auto-review
PASS  keeps PowerShell encoded-arguments alias outside plugin auto-review
PASS  keeps PowerShell slash-prefixed encoded-arguments alias outside plugin auto-review
PASS  keeps PowerShell encoded-arguments alias inside transparent carrier outside plugin auto-review
PASS  keeps PowerShell stdin command outside plugin auto-review
PASS  keeps PowerShell stdin script outside plugin auto-review
PASS  keeps Windows PowerShell console startup despite disabled profiles outside plugin auto-review
PASS  keeps Windows PowerShell abbreviated console startup outside plugin auto-review
PASS  keeps PowerShell login despite disabled PowerShell profiles outside plugin auto-review
PASS  keeps PowerShell encoded command outside plugin auto-review
PASS  preserves ordinary reviewable command: node --version
PASS  preserves ordinary reviewable command: git status
PASS  preserves ordinary reviewable command: pwsh -NoProfile -Command 'Write-Output safe'
PASS  preserves ordinary reviewable command: pwsh /NoProfile /c 'Write-Output safe'
PASS  keeps PowerShell profile-free positional script outside plugin auto-review
PASS  keeps PowerShell profile-free explicit script outside plugin auto-review
PASS  keeps PowerShell profile-free delimited script outside plugin auto-review
PASS  keeps 256 concurrent approvals independently bound and single-use
PASS  never leaks allow authority between 128 mixed concurrent model outcomes
PASS  aborts every timed-out provider during 64 concurrent approval requests
Tests: 125 passed (125)

$ pnpm test <10 affected gateway, node, shell, plugin, and Codex test files>
unit-fast:          202 passed
unit-fast-isolated:  97 passed
agents:             309 passed
extension-codex:     82 passed
Total:              690 passed
```
