### PR TITLE
feat(ui): offer normally-absent core files instead of flagging them missing

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -11318,6 +11318,7 @@ public struct AgentsFileEntry: Codable, Sendable {
     public let name: String
     public let path: String
     public let missing: Bool
+    public let expectedabsent: Bool?
     public let size: Int?
     public let updatedatms: Int?
     public let content: String?
@@ -11326,6 +11327,7 @@ public struct AgentsFileEntry: Codable, Sendable {
         name: String,
         path: String,
         missing: Bool,
+        expectedabsent: Bool? = nil,
         size: Int? = nil,
         updatedatms: Int? = nil,
         content: String? = nil)
@@ -11333,6 +11335,7 @@ public struct AgentsFileEntry: Codable, Sendable {
         self.name = name
         self.path = path
         self.missing = missing
+        self.expectedabsent = expectedabsent
         self.size = size
         self.updatedatms = updatedatms
         self.content = content
@@ -11342,6 +11345,7 @@ public struct AgentsFileEntry: Codable, Sendable {
         case name
         case path
         case missing
+        case expectedabsent = "expectedAbsent"
         case size
         case updatedatms = "updatedAtMs"
         case content

--- a/packages/gateway-protocol/src/schema/agents-models-skills.ts
+++ b/packages/gateway-protocol/src/schema/agents-models-skills.ts
@@ -169,6 +169,10 @@ export const AgentsFileEntrySchema = closedObject({
   name: NonEmptyString,
   path: NonEmptyString,
   missing: Type.Boolean(),
+  // True when absence is a normal workspace state (optional profile files, and
+  // MEMORY.md before anything is written). Editors should offer these for
+  // creation rather than flagging them as faults.
+  expectedAbsent: Type.Optional(Type.Boolean()),
   size: Type.Optional(Type.Integer({ minimum: 0 })),
   updatedAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
   content: Type.Optional(Type.String()),

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -236,6 +236,15 @@ const OPTIONAL_BOOTSTRAP_FILENAMES: ReadonlySet<string> = new Set([
   DEFAULT_USER_FILENAME,
 ]);
 
+/**
+ * Bootstrap files whose absence is a normal workspace state rather than a fault:
+ * the optional profile files, plus MEMORY.md which only appears once memory is
+ * written. Editors should offer these for creation instead of flagging them.
+ */
+export function isExpectedAbsentBootstrapFile(name: string): boolean {
+  return OPTIONAL_BOOTSTRAP_FILENAMES.has(name) || name === DEFAULT_MEMORY_FILENAME;
+}
+
 export const WORKSPACE_VANISHED_ERROR_CODE = "WORKSPACE_VANISHED";
 
 export class WorkspaceVanishedError extends Error {

--- a/src/gateway/server-methods/agents-mutate.test.ts
+++ b/src/gateway/server-methods/agents-mutate.test.ts
@@ -3058,6 +3058,31 @@ describe("agents.files.list", () => {
     expect(soul).not.toHaveProperty("expectedAbsent");
   });
 
+  // Clients merge the get response over the listed entry, so dropping the flag here
+  // made a picked optional file re-render as a fault in the Control UI.
+  it("carries expectedAbsent through agents.files.get for a missing file", async () => {
+    agentsTesting.setDepsForTests({
+      root: makeRootForTest({
+        read: async () => {
+          throw new FsSafeError("not-found", "no such file");
+        },
+      }),
+    });
+
+    const { respond, promise } = makeCall("agents.files.get", {
+      agentId: "main",
+      name: "SOUL.md",
+    });
+    await promise;
+
+    const result = firstRespondResult(respond);
+    expectRecordFields((result as { file: unknown }).file, {
+      name: "SOUL.md",
+      missing: true,
+      expectedAbsent: true,
+    });
+  });
+
   it("reports unreadable workspace files as present in list responses", async () => {
     const rootOpen = vi.fn(async () => {
       throw createErrnoError("EACCES");

--- a/src/gateway/server-methods/agents-mutate.test.ts
+++ b/src/gateway/server-methods/agents-mutate.test.ts
@@ -3014,6 +3014,50 @@ describe("agents.files.list", () => {
     expect(names).toContain("BOOTSTRAP.md");
   });
 
+  // The editor renders a missing-file fault only when absence is unexpected; the
+  // optional profile files and MEMORY.md are normal to be absent and are offered
+  // for creation instead.
+  it("marks normally-absent bootstrap files as expected", async () => {
+    const rootStat = vi.fn(async () => {
+      throw createEnoentError();
+    });
+    agentsTesting.setDepsForTests({ root: makeRootForTest({ stat: rootStat }) });
+
+    const { respond, promise } = makeCall("agents.files.list", { agentId: "main" });
+    await promise;
+
+    const result = firstRespondResult(respond);
+    const files = (
+      result as { files: Array<{ name: string; missing: boolean; expectedAbsent?: boolean }> }
+    ).files;
+    const expectedAbsentNames = files
+      .filter((file) => file.expectedAbsent === true)
+      .map((file) => file.name);
+    expect(files.every((file) => file.missing)).toBe(true);
+    expect(expectedAbsentNames).toStrictEqual(["SOUL.md", "USER.md", "MEMORY.md"]);
+  });
+
+  it("omits expectedAbsent for files that exist", async () => {
+    const rootStat = vi.fn(async ({ relativePath }: Record<string, unknown>) => {
+      if (relativePath === "SOUL.md") {
+        return { isFile: true, isSymbolicLink: false, mtimeMs: 1234, nlink: 1, size: 9 };
+      }
+      throw createEnoentError();
+    });
+    agentsTesting.setDepsForTests({ root: makeRootForTest({ stat: rootStat }) });
+
+    const { respond, promise } = makeCall("agents.files.list", { agentId: "main" });
+    await promise;
+
+    const result = firstRespondResult(respond);
+    const files = (
+      result as { files: Array<{ name: string; missing: boolean; expectedAbsent?: boolean }> }
+    ).files;
+    const soul = files.find((file) => file.name === "SOUL.md");
+    expectRecordFields(soul, { name: "SOUL.md", missing: false });
+    expect(soul).not.toHaveProperty("expectedAbsent");
+  });
+
   it("reports unreadable workspace files as present in list responses", async () => {
     const rootOpen = vi.fn(async () => {
       throw createErrnoError("EACCES");

--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -772,7 +772,14 @@ function respondWorkspaceFileMissing(params: {
     {
       agentId: params.agentId,
       workspace: params.workspaceDir,
-      file: { name: params.name, path: params.filePath, missing: true },
+      // Clients merge this entry over the listed one, so it must carry the same
+      // absence classification or a picked optional file re-renders as a fault.
+      file: {
+        name: params.name,
+        path: params.filePath,
+        missing: true,
+        expectedAbsent: isExpectedAbsentBootstrapFile(params.name),
+      },
     },
     undefined,
   );

--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -59,6 +59,7 @@ import {
   DEFAULT_BOOTSTRAP_FILENAME,
   DEFAULT_IDENTITY_FILENAME,
   ensureAgentWorkspace,
+  isExpectedAbsentBootstrapFile,
   isWorkspaceSetupCompleted,
   WORKSPACE_BOOTSTRAP_FILENAMES,
 } from "../../agents/workspace.js";
@@ -244,6 +245,7 @@ async function listAgentFiles(workspaceDir: string, options?: { hideBootstrap?: 
     name: string;
     path: string;
     missing: boolean;
+    expectedAbsent?: boolean;
     size?: number;
     updatedAtMs?: number;
   }> = [];
@@ -256,6 +258,7 @@ async function listAgentFiles(workspaceDir: string, options?: { hideBootstrap?: 
       name,
       path: path.join(workspaceDir, name),
       missing: true,
+      expectedAbsent: isExpectedAbsentBootstrapFile(name),
     }));
   }
 
@@ -272,7 +275,12 @@ async function listAgentFiles(workspaceDir: string, options?: { hideBootstrap?: 
         updatedAtMs: meta.updatedAtMs,
       });
     } else {
-      files.push({ name, path: filePath, missing: true });
+      files.push({
+        name,
+        path: filePath,
+        missing: true,
+        expectedAbsent: isExpectedAbsentBootstrapFile(name),
+      });
     }
   }
 

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -369,6 +369,9 @@ export type AgentFileEntry = {
   name: string;
   path: string;
   missing: boolean;
+  // Absence is a normal workspace state (optional profile files, MEMORY.md before
+  // anything is written); the editor offers these for creation instead of flagging them.
+  expectedAbsent?: boolean;
   size?: number;
   updatedAtMs?: number;
   content?: string;

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -951,6 +951,8 @@ export const en: TranslationMap = {
       notCreatedYet: "Not Created Yet",
       updatedUnknown: "Updated Unknown",
       missingHint: "This file is missing. Saving will create it in the agent workspace.",
+      addFile: "Add file…",
+      createHint: "This file does not exist yet. Saving will create it in the agent workspace.",
       content: "Content",
       words: "{count} words",
       lines: "lines",

--- a/ui/src/pages/agents/panels-status-files.ts
+++ b/ui/src/pages/agents/panels-status-files.ts
@@ -5,6 +5,7 @@ import { html, nothing } from "lit";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import { marked } from "marked";
 import type {
+  AgentFileEntry,
   AgentsFilesListResult,
   ChannelAccountSnapshot,
   ChannelsStatusSnapshot,
@@ -390,6 +391,12 @@ export function renderAgentFiles(params: {
   const list = params.agentFilesList?.agentId === params.agentId ? params.agentFilesList : null;
   const files = list?.files ?? [];
   const active = params.agentFileActive ?? null;
+  // Files whose absence is a normal workspace state stay out of the tab strip until
+  // the operator picks them; only a genuinely faulty absence is badged as missing.
+  const isCreatable = (file: AgentFileEntry) =>
+    file.missing && file.expectedAbsent === true && file.name !== active;
+  const tabFiles = files.filter((file) => !isCreatable(file));
+  const creatableFiles = files.filter(isCreatable);
   const activeEntry = active ? (files.find((file) => file.name === active) ?? null) : null;
   const baseContent = active ? (params.agentFileContents[active] ?? "") : "";
   const draft = active ? (params.agentFileDrafts[active] ?? baseContent) : "";
@@ -450,20 +457,21 @@ export function renderAgentFiles(params: {
           : html`
               <div class="agents-panel-body">
                 <div class="agent-tabs">
-                  ${files.map((file) => {
+                  ${tabFiles.map((file) => {
                     const isActive = active === file.name;
                     const label = file.name.replace(/\.md$/i, "");
+                    const isFault = file.missing && file.expectedAbsent !== true;
                     // File reads are serialized; changing the active tab mid-read would
                     // expose an editor whose content request was never accepted.
                     return html`
                       <button
-                        class="agent-tab ${isActive ? "active" : ""} ${file.missing
+                        class="agent-tab ${isActive ? "active" : ""} ${isFault
                           ? "agent-tab--missing"
                           : ""}"
                         ?disabled=${params.agentFilesLoading}
                         @click=${() => params.onSelectFile(file.name)}
                       >
-                        ${label}${file.missing
+                        ${label}${isFault
                           ? html`
                               <span class="agent-tab-badge">${t("agents.files.missing")}</span>
                             `
@@ -471,6 +479,32 @@ export function renderAgentFiles(params: {
                       </button>
                     `;
                   })}
+                  ${creatableFiles.length === 0
+                    ? nothing
+                    : html`
+                        <select
+                          class="agent-tab-add"
+                          aria-label=${t("agents.files.addFile")}
+                          .value=${""}
+                          ?disabled=${params.agentFilesLoading}
+                          @change=${(e: Event) => {
+                            const select = e.target as HTMLSelectElement;
+                            const name = select.value;
+                            select.value = "";
+                            if (name) {
+                              params.onSelectFile(name);
+                            }
+                          }}
+                        >
+                          <option value="">${t("agents.files.addFile")}</option>
+                          ${creatableFiles.map(
+                            (file) =>
+                              html`<option value=${file.name}>
+                                ${file.name.replace(/\.md$/i, "")}
+                              </option>`,
+                          )}
+                        </select>
+                      `}
                 </div>
                 ${!activeEntry
                   ? html`<div class="muted">${t("agents.files.selectFile")}</div>`
@@ -509,7 +543,11 @@ export function renderAgentFiles(params: {
                         </div>
                       </div>
                       ${activeEntry.missing
-                        ? html`<div class="callout info">${t("agents.files.missingHint")}</div>`
+                        ? html`<div class="callout info">
+                            ${activeEntry.expectedAbsent === true
+                              ? t("agents.files.createHint")
+                              : t("agents.files.missingHint")}
+                          </div>`
                         : nothing}
                       <label class="field agent-file-field">
                         <span>${t("agents.files.content")}</span>

--- a/ui/src/pages/agents/view.test.ts
+++ b/ui/src/pages/agents/view.test.ts
@@ -544,6 +544,119 @@ describe("renderAgentFiles", () => {
     expect(onSelectFile).not.toHaveBeenCalled();
   });
 
+  // A missing SOUL.md is a normal workspace state, so it belongs in the add picker
+  // instead of a permanently-badged MISSING tab; a missing AGENTS.md is a real fault.
+  it("offers normally-absent files in the add picker and badges only real faults", () => {
+    const container = document.createElement("div");
+    const onSelectFile = vi.fn();
+
+    render(
+      renderAgentFiles({
+        agentId: "alpha",
+        agentFilesList: {
+          agentId: "alpha",
+          workspace: "/tmp/workspace",
+          files: [
+            { name: "AGENTS.md", path: "/tmp/workspace/AGENTS.md", missing: true },
+            {
+              name: "SOUL.md",
+              path: "/tmp/workspace/SOUL.md",
+              missing: true,
+              expectedAbsent: true,
+            },
+            {
+              name: "MEMORY.md",
+              path: "/tmp/workspace/MEMORY.md",
+              missing: true,
+              expectedAbsent: true,
+            },
+          ],
+        },
+        agentFilesLoading: false,
+        agentFilesError: null,
+        agentFileActive: "AGENTS.md",
+        agentFileContents: { "AGENTS.md": "" },
+        agentFileDrafts: { "AGENTS.md": "" },
+        agentFileSaving: false,
+        onLoadFiles: () => undefined,
+        onSelectFile,
+        onFileDraftChange: () => undefined,
+        onFileReset: () => undefined,
+        onFileSave: () => undefined,
+      }),
+      container,
+    );
+
+    const tabLabels = Array.from(container.querySelectorAll<HTMLButtonElement>(".agent-tab")).map(
+      (tab) => directText(tab),
+    );
+    expect(tabLabels).toStrictEqual(["AGENTS"]);
+    expect(container.querySelectorAll(".agent-tab--missing")).toHaveLength(1);
+
+    const picker = container.querySelector<HTMLSelectElement>(".agent-tab-add");
+    expect(picker).not.toBeNull();
+    expect(Array.from(picker?.options ?? []).map((option) => option.value)).toStrictEqual([
+      "",
+      "SOUL.md",
+      "MEMORY.md",
+    ]);
+
+    if (!picker) {
+      throw new Error("expected add picker");
+    }
+    picker.value = "SOUL.md";
+    picker.dispatchEvent(new Event("change"));
+    expect(onSelectFile).toHaveBeenCalledWith("SOUL.md");
+    // The picker is an action, not a selection: it resets so the same file can be
+    // re-picked after the operator switches tabs.
+    expect(picker.value).toBe("");
+  });
+
+  it("shows the picked file as a tab with a create hint", () => {
+    const container = document.createElement("div");
+
+    render(
+      renderAgentFiles({
+        agentId: "alpha",
+        agentFilesList: {
+          agentId: "alpha",
+          workspace: "/tmp/workspace",
+          files: [
+            { name: "AGENTS.md", path: "/tmp/workspace/AGENTS.md", missing: false },
+            {
+              name: "SOUL.md",
+              path: "/tmp/workspace/SOUL.md",
+              missing: true,
+              expectedAbsent: true,
+            },
+          ],
+        },
+        agentFilesLoading: false,
+        agentFilesError: null,
+        agentFileActive: "SOUL.md",
+        agentFileContents: { "SOUL.md": "" },
+        agentFileDrafts: { "SOUL.md": "" },
+        agentFileSaving: false,
+        onLoadFiles: () => undefined,
+        onSelectFile: () => undefined,
+        onFileDraftChange: () => undefined,
+        onFileReset: () => undefined,
+        onFileSave: () => undefined,
+      }),
+      container,
+    );
+
+    const tabLabels = Array.from(container.querySelectorAll<HTMLButtonElement>(".agent-tab")).map(
+      (tab) => directText(tab),
+    );
+    expect(tabLabels).toStrictEqual(["AGENTS", "SOUL"]);
+    expect(container.querySelector(".agent-tab-add")).toBeNull();
+    expect(container.querySelectorAll(".agent-tab--missing")).toHaveLength(0);
+    expect(container.querySelector(".callout.info")?.textContent?.trim()).toBe(
+      "This file does not exist yet. Saving will create it in the agent workspace.",
+    );
+  });
+
   it("renders the upgraded markdown preview structure with file metadata", () => {
     const container = document.createElement("div");
 

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -3723,6 +3723,21 @@ td.data-table-key-col {
   opacity: 0.5;
 }
 
+.agent-tab-add {
+  border: 1px dashed var(--border);
+  border-radius: var(--radius-sm);
+  padding: 6px 10px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--muted);
+  background: transparent;
+}
+
+.agent-tab-add:hover {
+  color: var(--text);
+  border-color: var(--accent);
+}
+
 .agent-tab-badge {
   margin-left: 4px;
   font-size: 12px; /* was 9px */


### PR DESCRIPTION
## What Problem This Solves

The Agents → Files editor in the Control UI renders every core workspace file as
a tab, and any file that has not been written yet gets a `MISSING` badge. On a
perfectly healthy workspace that means most of the strip is badged as broken:
`SOUL.md` and `USER.md` are optional profile files, and `MEMORY.md` only appears
once the agent has written memory. Nothing is wrong, but the editor reports a
fault.

This is the last part of the core-files papercut that started with the retired
`HEARTBEAT.md` tab (#113621, #113966, #114436). Retiring stale entries fixed the
list; this fixes the state that is *supposed* to be absent.

## Why This Change Was Made

Absence is only a fault for files the runtime requires. `agents.files.list` now
distinguishes the two cases with an optional `expectedAbsent` flag, derived from
the canonical workspace set (`OPTIONAL_BOOTSTRAP_FILENAMES` plus `MEMORY.md`) so
it cannot drift from the runtime's own notion of which files are optional.

The editor then does the obvious thing with that signal: expected-absent files
stay out of the tab strip and are offered through an "Add file…" picker that
creates the file on save. A missing required file — `AGENTS.md` — still renders
as a badged fault tab, which is the case the badge was actually for.

`agents.files.get` carries the same flag. Clients merge the get response over
the listed entry, so a get that dropped it made a file picked from the picker
immediately re-render as a `MISSING` fault. That one was found by the live run
below, not by the unit tests.

## User Impact

The core-files editor shows the files that exist plus any genuine fault, and
offers the rest for creation. No RPC shape breaks: `expectedAbsent` is optional
and additive, and clients that ignore it render exactly as before.

## Evidence

**Live Control UI run** against a session-owned dev gateway (isolated
`OPENCLAW_STATE_DIR`, seeded workspace containing only `AGENTS.md`):

1. Files tab renders `AGENTS` plus `BOOTSTRAP missing`, and an `Add file…`
   picker offering exactly `["SOUL.md", "USER.md", "MEMORY.md"]` — the three
   normally-absent files. No `MISSING` badge for any of them.
2. Picking `SOUL.md` selects it as an ordinary tab (no fault badge) with the
   callout `This file does not exist yet. Saving will create it in the agent
   workspace.` `BOOTSTRAP` keeps its `missing` badge throughout.
3. Typing content and pressing Save creates the file on disk
   (`-rw------- 48 SOUL.md`), the callout disappears, `SOUL` stays a normal tab,
   and the picker narrows to `["USER.md", "MEMORY.md"]`.

Before this change, every one of those five entries rendered as a badged
`MISSING` tab.

**Automated proof:**

- `node scripts/run-vitest.mjs src/gateway/server-methods/agents-mutate` — 96 passed, including new cases pinning `expectedAbsent` for `SOUL.md`/`USER.md`/`MEMORY.md` in `agents.files.list`, its absence for files that exist, and its presence in a missing-file `agents.files.get`.
- `node scripts/run-vitest.mjs ui/src/pages/agents/view.test.ts` — 16 passed, including new coverage that a missing `AGENTS.md` is badged while `SOUL.md`/`MEMORY.md` move into the picker, that picking one selects it as a tab with the create hint, and that the picker resets after use.
- `tsgo` core / ui / test-ui lanes clean; `oxlint` and `oxfmt` clean on the changed files.
- Protocol bindings regenerated (`protocol-gen`, `-swift`, `-kotlin`); only the Swift model moved.
- Autoreview (`codex`, `gpt-5.6-sol`, xhigh): clean on both the initial change and the `agents.files.get` follow-up.
- Non-`en` locale bundles are intentionally untouched; `pnpm ui:i18n:sync` defers to the `control-ui-locale-refresh` workflow after merge.

Screenshots are omitted deliberately: the only rendered surface here is a local
dev workspace whose paths are session-scoped scratch directories, so the
DOM/filesystem transcript above is the redacted form of the same proof.
