### PR TITLE
fix(agents): keep core coding tools visible when tool search is enabled

### DIFF
--- a/src/agents/core-tool-factory-descriptors.ts
+++ b/src/agents/core-tool-factory-descriptors.ts
@@ -77,3 +77,13 @@ export type OpenClawCodingToolConstructionPlan = {
 export function resolveCoreToolFactoryFamily(name: string): CoreToolFactoryFamily | undefined {
   return CORE_TOOL_FACTORY_FAMILY_BY_NAME.get(name);
 }
+
+/**
+ * Core coding primitives (file + shell families). Tool-search compaction keeps
+ * these directly visible: hiding them behind search adds a lookup round-trip to
+ * nearly every coding turn.
+ */
+export function isCoreCodingSurfaceToolName(name: string): boolean {
+  const family = CORE_TOOL_FACTORY_FAMILY_BY_NAME.get(name);
+  return family === "base-coding" || family === "shell";
+}

--- a/src/agents/embedded-agent-runner/tool-name-allowlist.test.ts
+++ b/src/agents/embedded-agent-runner/tool-name-allowlist.test.ts
@@ -56,8 +56,9 @@ describe("tool name allowlists", () => {
   });
 
   it("keeps hidden core names available for client conflict admission", () => {
-    // Tool Search hides many built-ins from the visible tool list, but conflict
-    // checks still need the original core names to reject duplicate client tools.
+    // Tool Search hides many built-ins from the visible tool list (core coding
+    // tools like exec stay visible), but conflict checks still need the
+    // original core names to reject duplicate client tools.
     const uncompactedTools = [
       createStubTool(TOOL_SEARCH_CODE_MODE_TOOL_NAME),
       createStubTool("exec"),
@@ -71,7 +72,10 @@ describe("tool name allowlists", () => {
     const names = collectCoreBuiltinToolNames(uncompactedTools);
 
     expect([...names]).toEqual([TOOL_SEARCH_CODE_MODE_TOOL_NAME, "exec", "message"]);
-    expect(compacted.tools.map((tool) => tool.name)).toEqual([TOOL_SEARCH_CODE_MODE_TOOL_NAME]);
+    expect(compacted.tools.map((tool) => tool.name)).toEqual([
+      TOOL_SEARCH_CODE_MODE_TOOL_NAME,
+      "exec",
+    ]);
     expect(
       findClientToolNameConflicts({
         tools: [
@@ -190,7 +194,7 @@ describe("tool name allowlists", () => {
       }),
     );
 
-    expect(visibleAllowlist).toEqual([TOOL_SEARCH_CODE_MODE_TOOL_NAME]);
+    expect(visibleAllowlist).toEqual(["exec", TOOL_SEARCH_CODE_MODE_TOOL_NAME]);
     expect(replayAllowlist).toEqual([
       "client_pick_file",
       "exec",

--- a/src/agents/harness/tool-surface-bridge.test.ts
+++ b/src/agents/harness/tool-surface-bridge.test.ts
@@ -101,6 +101,7 @@ describe("createAgentHarnessToolSurfaceRuntime", () => {
       TOOL_DESCRIBE_RAW_TOOL_NAME,
       TOOL_CALL_RAW_TOOL_NAME,
       "exec",
+      "read",
     ]);
     runtime.cleanup();
   });
@@ -114,11 +115,12 @@ describe("createAgentHarnessToolSurfaceRuntime", () => {
       };
       const runtime = createRuntime(config);
 
+      // Compaction still applies to non-core tools; core coding tools stay visible.
       expect(
         runtime
           .compactTools(tools([TOOL_SEARCH_CODE_MODE_TOOL_NAME, "exec", "read"]))
           .tools.map((tool) => tool.name),
-      ).toEqual([TOOL_SEARCH_CODE_MODE_TOOL_NAME]);
+      ).toEqual([TOOL_SEARCH_CODE_MODE_TOOL_NAME, "exec", "read"]);
       runtime.cleanup();
     } finally {
       testing.setToolSearchCodeModeSupportedForTest(undefined);

--- a/src/agents/tool-search-directory.ts
+++ b/src/agents/tool-search-directory.ts
@@ -3,6 +3,7 @@ import {
   uniqueStrings,
 } from "@openclaw/normalization-core/string-normalization";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { isCoreCodingSurfaceToolName } from "./core-tool-factory-descriptors.js";
 import {
   applyToolCatalogCompaction,
   classifyTool,
@@ -78,8 +79,12 @@ export function applyToolSchemaDirectoryCatalog(params: {
     ...params,
     enabled: config.enabled,
     isVisibleControlTool: (tool) => TOOL_SCHEMA_DIRECTORY_CONTROL_TOOL_NAMES.has(tool.name),
+    // Core file/shell primitives keep full schemas visible alongside hydrated
+    // picks; the unique-name gate defers any cross-source name collision.
     isVisibleCatalogTool: (tool) =>
-      hydrateToolNames.has(tool.name) && uniqueCatalogToolNames.has(tool.name),
+      (hydrateToolNames.has(tool.name) ||
+        (isCoreCodingSurfaceToolName(tool.name) && classifyTool(tool).sourceName === "core")) &&
+      uniqueCatalogToolNames.has(tool.name),
   });
 }
 

--- a/src/agents/tool-search.test.ts
+++ b/src/agents/tool-search.test.ts
@@ -151,6 +151,87 @@ describe("Tool Search", () => {
     expect(catalogRef.current?.entries.map((entry) => entry.name)).toEqual(["fake_lookup"]);
   });
 
+  it("keeps core coding tools visible while still cataloging them", () => {
+    const catalogRef = createToolSearchCatalogRef();
+    const compacted = applyToolSearchCatalog({
+      tools: [
+        fakeTool(TOOL_SEARCH_RAW_TOOL_NAME, "search"),
+        fakeTool(TOOL_DESCRIBE_RAW_TOOL_NAME, "describe"),
+        fakeTool(TOOL_CALL_RAW_TOOL_NAME, "call"),
+        fakeTool("read", "Read files"),
+        fakeTool("edit", "Edit files"),
+        fakeTool("exec", "Run shell"),
+        pluginTool("fake_lookup", "Look up a record"),
+      ],
+      config: { tools: { toolSearch: { enabled: true, mode: "tools" } } } as never,
+      catalogRef,
+    });
+
+    expect(compacted.tools.map((tool) => tool.name)).toEqual([
+      TOOL_SEARCH_RAW_TOOL_NAME,
+      TOOL_DESCRIBE_RAW_TOOL_NAME,
+      TOOL_CALL_RAW_TOOL_NAME,
+      "read",
+      "edit",
+      "exec",
+    ]);
+    // Core tools stay searchable alongside deferred tools (catalog order is deterministic).
+    expect(catalogRef.current?.entries.map((entry) => entry.name)).toEqual([
+      "edit",
+      "exec",
+      "read",
+      "fake_lookup",
+    ]);
+  });
+
+  it("defers plugin tools that reuse a core coding tool name", () => {
+    const catalogRef = createToolSearchCatalogRef();
+    const compacted = applyToolSearchCatalog({
+      tools: [
+        fakeTool(TOOL_SEARCH_RAW_TOOL_NAME, "search"),
+        fakeTool(TOOL_DESCRIBE_RAW_TOOL_NAME, "describe"),
+        fakeTool(TOOL_CALL_RAW_TOOL_NAME, "call"),
+        pluginTool("read", "Plugin tool shadowing a core name"),
+      ],
+      config: { tools: { toolSearch: { enabled: true, mode: "tools" } } } as never,
+      catalogRef,
+    });
+
+    expect(compacted.tools.map((tool) => tool.name)).toEqual([
+      TOOL_SEARCH_RAW_TOOL_NAME,
+      TOOL_DESCRIBE_RAW_TOOL_NAME,
+      TOOL_CALL_RAW_TOOL_NAME,
+    ]);
+    expect(catalogRef.current?.entries.map((entry) => entry.name)).toEqual(["read"]);
+  });
+
+  it("keeps core coding tools visible in schema-directory mode without hydration", () => {
+    const catalogRef = createToolSearchCatalogRef();
+    const compacted = applyToolSchemaDirectoryCatalog({
+      tools: [
+        fakeTool(TOOL_SEARCH_RAW_TOOL_NAME, "search"),
+        fakeTool(TOOL_DESCRIBE_RAW_TOOL_NAME, "describe"),
+        fakeTool(TOOL_CALL_RAW_TOOL_NAME, "call"),
+        fakeTool("write", "Write files"),
+        pluginTool("fake_lookup", "Look up a record"),
+      ],
+      config: { tools: { toolSearch: { enabled: true, mode: "directory" } } } as never,
+      catalogRef,
+      hydrateToolNames: [],
+    });
+
+    expect(compacted.tools.map((tool) => tool.name)).toEqual([
+      TOOL_SEARCH_RAW_TOOL_NAME,
+      TOOL_DESCRIBE_RAW_TOOL_NAME,
+      TOOL_CALL_RAW_TOOL_NAME,
+      "write",
+    ]);
+    expect(catalogRef.current?.entries.map((entry) => entry.name)).toEqual([
+      "write",
+      "fake_lookup",
+    ]);
+  });
+
   it("keeps direct-only tools visible in schema-directory mode", () => {
     const catalogRef = createToolSearchCatalogRef();
     const compacted = applyToolSchemaDirectoryCatalog({

--- a/src/agents/tool-search.ts
+++ b/src/agents/tool-search.ts
@@ -2,11 +2,13 @@
 import { Type } from "typebox";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { HookContext } from "./agent-tools.before-tool-call.js";
+import { isCoreCodingSurfaceToolName } from "./core-tool-factory-descriptors.js";
 import type { AgentToolResult, AgentToolUpdateCallback } from "./runtime/index.js";
 import type { ToolDefinition } from "./sessions/index.js";
 import {
   addClientToolsToToolCatalog,
   applyToolCatalogCompaction,
+  classifyTool,
   reusableCatalogSnapshots,
   resolveCatalog,
   sessionCatalogs,
@@ -108,6 +110,11 @@ export function applyToolSearchCatalog(params: {
     isVisibleControlTool: (tool) =>
       TOOL_SEARCH_CONTROL_TOOL_NAMES.has(tool.name) &&
       shouldExposeControlTool(tool.name, config.mode),
+    // Core file/shell primitives stay in the visible tool list (while remaining
+    // searchable); the source check keeps plugin/MCP tools that reuse a core
+    // name deferred like any other cataloged tool.
+    isVisibleCatalogTool: (tool) =>
+      isCoreCodingSurfaceToolName(tool.name) && classifyTool(tool).sourceName === "core",
   });
 }
 


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where enabling OpenClaw's tool search (`tools.toolSearch`) on the embedded runtime hid the core coding tools — `read`, `write`, `edit`, `exec`, `process`, `apply_patch` — behind `tool_search`/`tool_call` like any other cataloged tool. An agent then had to spend a search round-trip (or fail to discover them at all) before doing the most basic file or shell work, which affects nearly every coding turn.

## Why This Change Was Made

The Codex harness already has this rule (control-path tools stay direct even in searchable mode); the embedded runtime's compaction had no equivalent. The fix declares the core coding surface where core tool identity already lives (`isCoreCodingSurfaceToolName` in src/agents/core-tool-factory-descriptors.ts, families base-coding + shell) and passes it as `isVisibleCatalogTool` — an existing compaction seam — in both search paths: `applyToolSearchCatalog` (modes "tools"/"code") and `applyToolSchemaDirectoryCatalog` (directory mode). Core tools stay in the visible tool list while remaining in the searchable catalog. A source check (`classifyTool(...).sourceName === "core"`) keeps plugin/MCP tools that reuse a core name deferred, and directory mode keeps its unique-name collision gate. Code mode `"only"` is intentionally untouched — hiding everything behind exec/wait is that mode's contract.

## User Impact

Operators who enable tool search to compact large tool inventories no longer degrade basic coding: file and shell primitives keep full schemas in the prompt in all tool-search modes, while the rest of the catalog stays compacted.

## Evidence

- New regression tests in src/agents/tool-search.test.ts: core tools visible + still cataloged in "tools" mode; a plugin tool named `read` stays deferred; directory mode keeps `write` visible without hydration.
- `node scripts/run-vitest.mjs src/agents/tool-search.test.ts` → 93/93 passed (repeated 8x on a quiet machine; one pre-existing load-flaky code-mode timeout test identified and verified green on baseline and isolated runs).
- Local `tsgo` core lane clean, `scripts/run-oxlint.mjs` clean on changed files, oxfmt clean, `git diff --check` clean. (Local fallback used because the remote Testbox backend was unreachable; hosted PR CI provides the full gates.)
- Autoreview (Codex gpt-5.6-sol, xhigh): clean, 0.91 — "preserves source and uniqueness checks so plugin or MCP tools that reuse core names are not incorrectly promoted."
