### PR TITLE
test(google-meet): include machine output in descriptor contract

### DIFF
--- a/extensions/google-meet/index.test.ts
+++ b/extensions/google-meet/index.test.ts
@@ -1281,6 +1281,7 @@ describe("google-meet plugin", () => {
             name: "googlemeet",
             description: "Join and manage Google Meet calls",
             hasSubcommands: true,
+            machineOutput: expect.any(Function),
           },
         ],
       },


### PR DESCRIPTION
Related: #113654

## What Problem This Solves

Fixes a release-only Plugin Prerelease failure where the Google Meet integration test still expected the pre-#113654 CLI descriptor shape after `machineOutput` became part of that descriptor.

## Why This Change Was Made

The integration assertion now verifies that the registered descriptor exposes a callable `machineOutput` predicate. The focused CLI output-mode tests continue to own the predicate's command-level behavior.

## User Impact

No product behavior changes. Full Release Validation can verify the already-landed machine-readable Google Meet CLI behavior without a stale descriptor assertion.

## Evidence

- `node scripts/run-vitest.mjs extensions/google-meet/index.test.ts -t "advertises only the googlemeet CLI descriptor" --reporter=dot` — passed.
- `node scripts/run-vitest.mjs extensions/google-meet/src/cli-output-mode.test.ts --reporter=dot` — 6 tests passed.
- `git diff --check` — clean.
- Autoreview: clean, no accepted/actionable findings.

AI-assisted; the one-line contract update and owning predicate tests were reviewed before submission.
