### PR TITLE
fix(test): stop native SQLite worker teardown crashes

### DIFF
--- a/test/vitest-scoped-config.test.ts
+++ b/test/vitest-scoped-config.test.ts
@@ -613,6 +613,10 @@ describe("scoped vitest configs", () => {
     expectForkedIsolatedRunner(defaultInfraConfig);
   });
 
+  it("keeps native SQLite runtime config tests in forked workers", () => {
+    expectForkedNonIsolatedRunner(defaultRuntimeConfig);
+  });
+
   it("keeps process, runtime config, and tooling lanes off the openclaw runtime setup", () => {
     expect(normalizeConfigPaths(requireTestConfig(defaultProcessConfig).setupFiles)).toEqual([
       "test/setup.ts",

--- a/test/vitest/vitest.runtime-config.config.ts
+++ b/test/vitest/vitest.runtime-config.config.ts
@@ -8,6 +8,9 @@ export function createRuntimeConfigVitestConfig(env?: Record<string, string | un
     includeOpenClawRuntimeSetup: false,
     name: "runtime-config",
     passWithNoTests: true,
+    // Native SQLite handles can abort V8 when threaded workers tear down.
+    // Forks keep database lifetimes inside a disposable process.
+    pool: "forks",
   });
   return {
     ...config,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where maintainers and CI running SQLite-backed session/model regression tests on supported Node 24 could intermittently hit `FATAL ERROR: v8::ToLocalChecked Empty MaybeLocal` and abort with exit 134 even after all test assertions passed. Reproduced on two fresh Blacksmith Testbox machines during repeated live Gateway/model stress testing.

## Why This Change Was Made

Keep native SQLite database lifetimes inside disposable forked processes by selecting the existing Vitest `forks` pool only for the runtime/config lane. Add a scoped-config regression assertion that prevents the lane from silently returning to threaded workers. No production behavior, database schema, migrations, provider configuration, or JSON state changes.

## User Impact

Reliable SQLite-backed session, dynamic-model, and Gateway regression coverage without sporadic Node/V8 test-worker crashes. Production runtime and stored user data are unchanged.

## Evidence

- Before: threaded worker teardown reproduced exit 134 on two clean remote runners; all affected SQLite assertions themselves passed.
- After: complete runtime/config lane: **211 files, 2,898 tests passed**.
- Vitest configuration and project routing: **354 regression tests passed**, including the new fork-pool assertion.
- Full Gateway baseline on the exact base: **4,116 core** and **2,493 RPC** tests passed; fresh production build and all 143 public SDK surfaces passed.
- Latest model socket transport, self-archive, Gateway session identity, protocol, plugin manifest, Workboard, and chat regressions passed.
- **16 default-config stress cycles**: **3,824 repeated Gateway/model/SQLite/socket assertions** passed with no V8 abort and no command-line pool override.
- Live dev Gateway: **137 tests passed** across `openai/gpt-5.6`, `anthropic/claude-sonnet-4-6`, `anthropic/claude-haiku-4-5`, and `google/gemini-3.1-pro-preview`; **zero skipped models**.
- `pnpm check:changed -- test/vitest/vitest.runtime-config.config.ts test/vitest-scoped-config.test.ts`: passed, including formatting, lint, script declarations, dependency guards, and test-root typecheck.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted`: clean; no accepted/actionable findings.
