### PR TITLE
fix(cron): preserve one-shots rescheduled during active runs

### DIFF
--- a/src/cron/active-jobs.test.ts
+++ b/src/cron/active-jobs.test.ts
@@ -5,6 +5,7 @@ import {
   hasActiveCronJobs,
   hasActiveCronJobsExceptMarker,
   markCronJobActive,
+  noteActiveCronJobScheduleMutation,
   resetCronActiveJobs,
 } from "./active-jobs.js";
 
@@ -43,5 +44,56 @@ describe("hasActiveCronJobsExceptMarker", () => {
 
     expect(hasActiveCronJobsExceptMarker(staleMarker!)).toBe(true);
     expect(hasActiveCronJobsExceptMarker(replacementMarker!)).toBe(false);
+  });
+});
+
+describe("active cron schedule ownership", () => {
+  it("records durable schedule mutations on the admitted active run", () => {
+    const marker = markCronJobActive("rescheduled-job");
+
+    noteActiveCronJobScheduleMutation("rescheduled-job");
+
+    expect(marker?.scheduleMutated).toBe(true);
+  });
+
+  it("keeps a mutation after the schedule is edited back to its original value", () => {
+    const marker = markCronJobActive("rescheduled-job");
+
+    noteActiveCronJobScheduleMutation("rescheduled-job");
+    noteActiveCronJobScheduleMutation("rescheduled-job");
+
+    expect(marker?.scheduleMutated).toBe(true);
+  });
+
+  it("attributes later edits only to the replacement active run", () => {
+    const retiredMarker = markCronJobActive("rescheduled-job");
+    clearCronJobActive("rescheduled-job", retiredMarker);
+    const replacementMarker = markCronJobActive("rescheduled-job");
+
+    noteActiveCronJobScheduleMutation("rescheduled-job");
+
+    expect(retiredMarker?.scheduleMutated).toBeUndefined();
+    expect(replacementMarker?.scheduleMutated).toBe(true);
+  });
+
+  it("does not create ownership markers for jobs without an active run", () => {
+    noteActiveCronJobScheduleMutation("idle-job");
+
+    expect(hasActiveCronJobs()).toBe(false);
+  });
+
+  it("keeps schedule ownership isolated across concurrent active jobs", () => {
+    const markers = Array.from({ length: 64 }, (_, index) =>
+      markCronJobActive(`rescheduled-job-${index}`),
+    );
+
+    for (let index = 0; index < markers.length; index += 2) {
+      noteActiveCronJobScheduleMutation(`rescheduled-job-${index}`);
+      noteActiveCronJobScheduleMutation(`rescheduled-job-${index}`);
+    }
+
+    for (const [index, marker] of markers.entries()) {
+      expect(marker?.scheduleMutated).toBe(index % 2 === 0 ? true : undefined);
+    }
   });
 });

--- a/src/cron/active-jobs.ts
+++ b/src/cron/active-jobs.ts
@@ -15,6 +15,7 @@ export type CronActiveJobMarker = {
   jobId: string;
   generation: number;
   token: number;
+  scheduleMutated?: true;
   legacy?: boolean;
   preserveAcrossGenerationAdvance?: boolean;
 };
@@ -116,6 +117,20 @@ export function clearCronJobActive(jobId: string, marker?: CronActiveJobMarker) 
     state.activeJobIds?.delete(jobId);
   }
   notifyActiveCronJobWaitersIfEmpty(state);
+}
+
+/** Records a durable schedule edit against the exact run that was active for it. */
+export function noteActiveCronJobScheduleMutation(jobId: string): void {
+  if (!jobId) {
+    return;
+  }
+  const state = getCronActiveJobState();
+  const marker = state.activeJobs.get(jobId);
+  if (marker && isMarkerActiveInGeneration(marker, state.generation)) {
+    // Keep mutation history on the admitted run: A→B→A has the original
+    // schedule value but still belongs to the operator's newer edit.
+    marker.scheduleMutated = true;
+  }
 }
 
 /** Returns whether the given cron job id is currently executing in this process. */

--- a/src/cron/service.read-ops-nonblocking.test.ts
+++ b/src/cron/service.read-ops-nonblocking.test.ts
@@ -77,6 +77,102 @@ function expectCronStatus(
 }
 
 describe("CronService read ops while job is running", () => {
+  it.each([
+    { deleteAfterRun: true, status: "ok" },
+    { deleteAfterRun: false, status: "ok" },
+    { deleteAfterRun: true, status: "error" },
+    { deleteAfterRun: false, status: "error" },
+    { deleteAfterRun: true, status: "skipped" },
+    { deleteAfterRun: false, status: "skipped" },
+  ] as const)(
+    "preserves a rescheduled active one-shot after $status and restart (deleteAfterRun=$deleteAfterRun)",
+    async ({ deleteAfterRun, status }) => {
+      vi.useFakeTimers();
+      const startedAt = Date.parse("2025-12-13T00:00:01.000Z");
+      const rescheduledAt = startedAt + 5 * 60_000;
+      vi.setSystemTime(startedAt - 1_000);
+      const store = await makeStorePath();
+      const isolatedRun = createDeferredIsolatedRun();
+      let resolveFinished: (() => void) | undefined;
+      const finished = new Promise<void>((resolve) => {
+        resolveFinished = resolve;
+      });
+      const cron = new CronService({
+        storePath: store.storePath,
+        cronEnabled: true,
+        log: noopLogger,
+        enqueueSystemEvent: vi.fn(),
+        requestHeartbeat: vi.fn(),
+        runIsolatedAgentJob: isolatedRun.runIsolatedAgentJob,
+        onEvent: (event) => {
+          if (event.action === "finished" && event.status === status) {
+            resolveFinished?.();
+          }
+        },
+      });
+      let restartedCron: CronService | undefined;
+
+      try {
+        await cron.start();
+        const job = await cron.add({
+          name: "rescheduled active one-shot",
+          enabled: true,
+          deleteAfterRun,
+          schedule: { kind: "at", at: new Date(startedAt).toISOString() },
+          sessionTarget: "isolated",
+          wakeMode: "next-heartbeat",
+          payload: { kind: "agentTurn", message: "long task" },
+          delivery: { mode: "none" },
+        });
+
+        vi.setSystemTime(startedAt);
+        await vi.advanceTimersByTimeAsync(1_000);
+        await isolatedRun.runStarted;
+
+        await cron.update(job.id, {
+          schedule: { kind: "at", at: new Date(rescheduledAt).toISOString() },
+        });
+        isolatedRun.completeRun({
+          status,
+          ...(status === "error" ? { error: "original invocation failed" } : {}),
+        });
+        await finished;
+        await cron.status();
+
+        const expected = {
+          id: job.id,
+          enabled: true,
+          schedule: { kind: "at", at: new Date(rescheduledAt).toISOString() },
+          state: { lastStatus: status, nextRunAtMs: rescheduledAt },
+        };
+        const completed = await cron.list({ includeDisabled: true });
+        expect(completed).toHaveLength(1);
+        expect(completed[0]).toMatchObject(expected);
+
+        cron.stop();
+        restartedCron = new CronService({
+          storePath: store.storePath,
+          cronEnabled: true,
+          log: noopLogger,
+          enqueueSystemEvent: vi.fn(),
+          requestHeartbeat: vi.fn(),
+          runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+        });
+        await restartedCron.start();
+
+        const restarted = await restartedCron.list({ includeDisabled: true });
+        expect(restarted).toHaveLength(1);
+        expect(restarted[0]).toMatchObject(expected);
+      } finally {
+        cron.stop();
+        restartedCron?.stop();
+        vi.clearAllTimers();
+        vi.useRealTimers();
+        await store.cleanup();
+      }
+    },
+  );
+
   it("keeps list and status responsive during a long isolated run", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2025-12-13T00:00:00.000Z"));
@@ -160,6 +256,79 @@ describe("CronService read ops while job is running", () => {
       await store.cleanup();
     }
   });
+
+  it.each([true, false])(
+    "preserves an A→B→A schedule edit during a manual run (deleteAfterRun=%s)",
+    async (deleteAfterRun) => {
+      const store = await makeStorePath();
+      const isolatedRun = createDeferredIsolatedRun();
+      const originalAt = Date.parse("2030-01-01T00:05:00.000Z");
+      const intermediateAt = Date.parse("2030-01-01T00:10:00.000Z");
+      const cron = new CronService({
+        storePath: store.storePath,
+        cronEnabled: true,
+        log: noopLogger,
+        enqueueSystemEvent: vi.fn(),
+        requestHeartbeat: vi.fn(),
+        runIsolatedAgentJob: isolatedRun.runIsolatedAgentJob,
+      });
+      let restartedCron: CronService | undefined;
+
+      try {
+        await cron.start();
+        const job = await cron.add({
+          name: "manual reschedule ownership",
+          enabled: true,
+          deleteAfterRun,
+          schedule: { kind: "at", at: new Date(originalAt).toISOString() },
+          sessionTarget: "isolated",
+          wakeMode: "next-heartbeat",
+          payload: { kind: "agentTurn", message: "manual task" },
+          delivery: { mode: "none" },
+        });
+
+        const run = cron.run(job.id, "force");
+        await isolatedRun.runStarted;
+        await cron.update(job.id, {
+          schedule: { kind: "at", at: new Date(intermediateAt).toISOString() },
+        });
+        await cron.update(job.id, {
+          schedule: { kind: "at", at: new Date(originalAt).toISOString() },
+        });
+        isolatedRun.completeRun({ status: "ok", summary: "done" });
+        await expect(run).resolves.toEqual({ ok: true, ran: true });
+
+        const expected = {
+          id: job.id,
+          enabled: true,
+          schedule: { kind: "at", at: new Date(originalAt).toISOString() },
+          state: { lastStatus: "ok", nextRunAtMs: originalAt },
+        };
+        const completed = await cron.list({ includeDisabled: true });
+        expect(completed).toHaveLength(1);
+        expect(completed[0]).toMatchObject(expected);
+
+        cron.stop();
+        restartedCron = new CronService({
+          storePath: store.storePath,
+          cronEnabled: true,
+          log: noopLogger,
+          enqueueSystemEvent: vi.fn(),
+          requestHeartbeat: vi.fn(),
+          runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+        });
+        await restartedCron.start();
+
+        const restarted = await restartedCron.list({ includeDisabled: true });
+        expect(restarted).toHaveLength(1);
+        expect(restarted[0]).toMatchObject(expected);
+      } finally {
+        cron.stop();
+        restartedCron?.stop();
+        await store.cleanup();
+      }
+    },
+  );
 
   it("keeps list and status responsive during manual cron.run execution", async () => {
     const store = await makeStorePath();

--- a/src/cron/service/ops-mutations.ts
+++ b/src/cron/service/ops-mutations.ts
@@ -4,7 +4,7 @@ import {
   AgentDeletionAuthorityRollbackError,
   AgentDeletionCommitUncertainError,
 } from "../../agents/agent-lifecycle-registry.js";
-import { isCronJobActive } from "../active-jobs.js";
+import { isCronJobActive, noteActiveCronJobScheduleMutation } from "../active-jobs.js";
 import { cronSchedulingInputsEqual } from "../schedule-identity.js";
 import { deleteCronJobScratch } from "../scratch-store.js";
 import { createCronStreamSourceIdentity, cronStreamScheduleKey } from "../stream-schedule.js";
@@ -136,9 +136,10 @@ function finalizeUpdatedJob(params: {
 async function persistUpdatedJob(params: {
   state: CronServiceState;
   snapshot: CronRollbackSnapshot;
+  previousJob: CronJob;
   nextJob: CronJob;
 }) {
-  const { state, snapshot, nextJob } = params;
+  const { state, snapshot, previousJob, nextJob } = params;
   if (state.store) {
     const index = state.store.jobs.findIndex((entry) => entry.id === nextJob.id);
     if (index >= 0) {
@@ -147,6 +148,11 @@ async function persistUpdatedJob(params: {
   }
 
   await persistOrRestore(state, snapshot, { suppressScheduledJobId: nextJob.id });
+  if (!cronSchedulingInputsEqual(previousJob, nextJob)) {
+    // Mark only committed edits; a failed SQLite write cannot retire the run's
+    // schedule ownership, and idempotent re-saves must not create a new claim.
+    noteActiveCronJobScheduleMutation(nextJob.id);
+  }
   armTimer(state);
   emit(state, {
     jobId: nextJob.id,
@@ -237,7 +243,7 @@ export async function add(state: CronServiceState, input: CronJobCreate, opts?: 
         schedulingInputsRequested: true,
         scheduleChanged: !isDeepStrictEqual(existing.schedule, nextJob.schedule),
       });
-      await persistUpdatedJob({ state, snapshot, nextJob });
+      await persistUpdatedJob({ state, snapshot, previousJob: existing, nextJob });
       return { ...nextJob, created: false, updated: true, job: nextJob };
     }
 
@@ -337,7 +343,7 @@ export async function updateLoadedJob(params: {
       "pacing" in patch,
     scheduleChanged: patch.schedule !== undefined,
   });
-  await persistUpdatedJob({ state, snapshot, nextJob });
+  await persistUpdatedJob({ state, snapshot, previousJob: job, nextJob });
   return nextJob;
 }
 

--- a/src/cron/service/ops-run-preparation.ts
+++ b/src/cron/service/ops-run-preparation.ts
@@ -68,6 +68,7 @@ export type ActivatedManualRun = Extract<PreparedManualRun, { ran: true }> & {
   startedAt: number;
   taskRunId?: string;
   activeJobMarker?: CronActiveJobMarker;
+  admittedJob: CronJob;
   executionJob: CronJob;
 };
 
@@ -502,6 +503,7 @@ export async function activatePreparedManualRun(
     const activeJobMarker = markManualCronJobActive(state, job);
     // Execute against a snapshot so later reload/merge can preserve delivery
     // target writeback from disk without mutating the running object.
+    const admittedJob = structuredClone(job);
     const executionJob = structuredClone(job);
     if (mode === "force" && executionJob.trigger && !prepared.evaluateTrigger) {
       // Force means run the payload now; strip the gate only from this snapshot
@@ -517,6 +519,7 @@ export async function activatePreparedManualRun(
       runId: prepared.runId ?? taskRunId,
       taskRunId,
       activeJobMarker,
+      admittedJob,
       executionJob,
     } as const;
   });

--- a/src/cron/service/ops-run.ts
+++ b/src/cron/service/ops-run.ts
@@ -24,6 +24,7 @@ import type { CronServiceState, CronWakeMode } from "./state.js";
 import { emit } from "./state.js";
 import { ensureLoaded, persistOrRestore, snapshotStoreForRollback } from "./store.js";
 import { tryFinishCronTaskRunWithoutHistory } from "./task-runs.js";
+import { resolveCronRunScheduleOwnership } from "./timer-outcomes.js";
 import {
   applyJobResult,
   applyScriptRunResult,
@@ -148,6 +149,14 @@ async function finishPreparedManualRun(
         return;
       }
 
+      const scheduleOwnership = resolveCronRunScheduleOwnership({
+        admittedJob: prepared.admittedJob,
+        currentJob: job,
+        activeJobMarker: prepared.activeJobMarker,
+      });
+      const scheduleMode =
+        mode === "force" || scheduleOwnership === "stale" ? "preserve" : "advance";
+
       let shouldDelete = false;
       if (coreResult.status === "ok" && coreResult.triggerEval?.fired === false) {
         // Manual due checks share scheduled quiet-tick semantics: persist the
@@ -160,7 +169,7 @@ async function finishPreparedManualRun(
             endedAt,
             triggerEval: coreResult.triggerEval,
           },
-          { scheduleMode: mode === "force" ? "preserve" : "advance" },
+          { scheduleMode },
         );
       } else {
         shouldDelete = applyJobResult(
@@ -172,15 +181,20 @@ async function finishPreparedManualRun(
             endedAt,
           },
           {
-            scheduleMode: mode === "force" ? "preserve" : "advance",
+            scheduleMode,
+            scheduleOwnership,
             scheduleOwnershipAtMs: prepared.scheduleOwnershipAtMs,
           },
         );
-        applyTriggerRunResult(job, {
-          status: coreResult.status,
-          endedAt,
-          triggerEval: coreResult.triggerEval,
-        });
+        applyTriggerRunResult(
+          job,
+          {
+            status: coreResult.status,
+            endedAt,
+            triggerEval: coreResult.triggerEval,
+          },
+          { scheduleOwnership },
+        );
         applyScriptRunResult(job, coreResult);
 
         // Stream payloads are event-owned by their batch. Generic recurring

--- a/src/cron/service/timer-outcomes.ts
+++ b/src/cron/service/timer-outcomes.ts
@@ -1,7 +1,9 @@
 import { resolveCronTriggerMinIntervalMs } from "../../config/cron-limits.js";
+import type { CronActiveJobMarker } from "../active-jobs.js";
 import { resolvePacedNextRunAtMs } from "../pacing.js";
 import { normalizeCronRunDiagnostics, summarizeCronRunDiagnostics } from "../run-diagnostics.js";
 import { resolveCronRunErrorReason } from "../run-error-reason.js";
+import { cronSchedulingInputsEqual } from "../schedule-identity.js";
 import { computeNextRunAtMs } from "../schedule.js";
 import { createCronStreamSourceIdentity } from "../stream-schedule.js";
 import type { CronJob, CronRunStatus } from "../types.js";
@@ -33,6 +35,20 @@ import {
   shouldRetryDisabledHeartbeatOneShot,
 } from "./timer-trigger.js";
 
+type CronScheduleOwnership = "current" | "stale";
+
+/** Checks both the admitted schedule and edits that may have returned to its original value. */
+export function resolveCronRunScheduleOwnership(params: {
+  admittedJob: CronJob;
+  currentJob: CronJob;
+  activeJobMarker?: CronActiveJobMarker;
+}): CronScheduleOwnership {
+  return params.activeJobMarker?.scheduleMutated === true ||
+    !cronSchedulingInputsEqual(params.admittedJob, params.currentJob)
+    ? "stale"
+    : "current";
+}
+
 /** Applies run outcome state, delivery state, backoff/next-run scheduling, and delete-after-run policy. */
 export function applyJobResult(
   state: CronServiceState,
@@ -41,6 +57,8 @@ export function applyJobResult(
   opts?: {
     // Manual force runs update outcome state but are out-of-band for cadence.
     scheduleMode?: "advance" | "preserve";
+    // An in-flight edit owns all future schedule and one-shot policy.
+    scheduleOwnership?: CronScheduleOwnership;
     // Lane and admission waits must not transfer a pre-deadline manual run's ownership.
     scheduleOwnershipAtMs?: number;
     // Startup replay restores alert cooldown bookkeeping without redelivery.
@@ -48,8 +66,10 @@ export function applyJobResult(
   },
 ): boolean {
   const previousScheduleState = {
+    enabled: job.enabled,
     nextRunAtMs: job.state.nextRunAtMs,
     pacedNextRunAtMs: job.state.pacedNextRunAtMs,
+    forcePreservedNextRunAtMs: job.state.forcePreservedNextRunAtMs,
   };
   job.state.queuedAtMs = undefined;
   job.state.runningAtMs = undefined;
@@ -148,15 +168,24 @@ export function applyJobResult(
     job.schedule.kind === "at" &&
     previousScheduleState.nextRunAtMs !== undefined &&
     previousScheduleState.nextRunAtMs > (opts.scheduleOwnershipAtMs ?? result.startedAt);
+  const ownsSchedule = opts?.scheduleOwnership !== "stale";
   const isOneShotSchedule = job.schedule.kind === "at" || job.schedule.kind === "on-exit";
   const shouldDelete =
+    ownsSchedule &&
     isOneShotSchedule &&
     !preserveOneShotSchedule &&
     job.deleteAfterRun === true &&
     result.status === "ok";
   const retryDisabledHeartbeatOneShot = shouldRetryDisabledHeartbeatOneShot(job, result);
 
-  if (!shouldDelete) {
+  if (!ownsSchedule) {
+    // The completed invocation still owns its outcome, but the latest durable
+    // operator edit owns enablement, cadence, pacing, and future retry policy.
+    job.enabled = previousScheduleState.enabled;
+    job.state.nextRunAtMs = previousScheduleState.nextRunAtMs;
+    job.state.pacedNextRunAtMs = previousScheduleState.pacedNextRunAtMs;
+    job.state.forcePreservedNextRunAtMs = previousScheduleState.forcePreservedNextRunAtMs;
+  } else if (!shouldDelete) {
     if (preserveOneShotSchedule) {
       job.state.nextRunAtMs = previousScheduleState.nextRunAtMs;
       job.state.pacedNextRunAtMs = previousScheduleState.pacedNextRunAtMs;
@@ -416,6 +445,7 @@ function applyTriggerEvaluationState(
 export function applyTriggerRunResult(
   job: CronJob,
   result: { status: CronRunStatus; endedAt: number; triggerEval?: CronTriggerEvalOutcome },
+  opts?: { scheduleOwnership?: CronScheduleOwnership },
 ): void {
   if (!result.triggerEval) {
     return;
@@ -430,7 +460,12 @@ export function applyTriggerRunResult(
   applyTriggerEvaluationState(job, persistedEval, result.endedAt);
   // A once trigger disarms only after the fired payload succeeds. Errors keep
   // it armed so the normal backoff path can evaluate and retry later.
-  if (result.triggerEval.fired && job.trigger?.once === true && result.status === "ok") {
+  if (
+    opts?.scheduleOwnership !== "stale" &&
+    result.triggerEval.fired &&
+    job.trigger?.once === true &&
+    result.status === "ok"
+  ) {
     if (job.schedule.kind === "stream") {
       // Auto-disable is a source retirement just like an explicit disable. Rotate
       // in the same persisted result so queued sibling batches cannot gain admission.
@@ -530,21 +565,36 @@ export function applyOutcomeToStoredJob(
     return undefined;
   }
 
+  const scheduleOwnership = resolveCronRunScheduleOwnership({
+    admittedJob: result.job,
+    currentJob: job,
+    activeJobMarker: result.activeJobMarker,
+  });
+
   if (result.status === "ok" && result.triggerEval && !result.triggerEval.fired) {
     // Quiet trigger ticks intentionally emit no finished event: run history,
     // plugin hooks, and completion notifications represent payload runs only.
-    applyTriggerNoFireResult(state, job, {
-      startedAt: result.startedAt,
-      endedAt: result.endedAt,
-      triggerEval: result.triggerEval,
-    });
+    applyTriggerNoFireResult(
+      state,
+      job,
+      {
+        startedAt: result.startedAt,
+        endedAt: result.endedAt,
+        triggerEval: result.triggerEval,
+      },
+      { scheduleMode: scheduleOwnership === "stale" ? "preserve" : "advance" },
+    );
     job.state.startupCatchupAtMs = undefined;
-    job.state.pacedNextRunAtMs = undefined;
+    if (scheduleOwnership === "current") {
+      // Quiet ticks consume their old pacing slot. Only an in-flight schedule
+      // edit owns a replacement override that must survive finalization.
+      job.state.pacedNextRunAtMs = undefined;
+    }
     return undefined;
   }
 
-  const shouldDelete = applyJobResult(state, job, result);
-  applyTriggerRunResult(job, result);
+  const shouldDelete = applyJobResult(state, job, result, { scheduleOwnership });
+  applyTriggerRunResult(job, result, { scheduleOwnership });
   applyScriptRunResult(job, result);
   job.state.startupCatchupAtMs = undefined;
 

--- a/src/cron/service/timer.pacing.test.ts
+++ b/src/cron/service/timer.pacing.test.ts
@@ -4,6 +4,7 @@ import { createNoopLogger } from "../service.test-harness.js";
 import type { CronJob, CronPacing } from "../types.js";
 import { recomputeNextRunsForMaintenance } from "./jobs.js";
 import { createCronServiceState } from "./state.js";
+import { applyOutcomeToStoredJob } from "./timer-outcomes.js";
 import { applyJobResult } from "./timer.js";
 
 const ENDED_AT = Date.parse("2026-07-18T12:00:00.000Z");
@@ -64,6 +65,48 @@ describe("applyJobResult dynamic cadence", () => {
     expect(job.state.nextRunAtMs).toBe(STARTED_AT + 60 * 60_000);
     expect(job.state.pacedNextRunAtMs).toBeUndefined();
     expect(job.state.forcePreservedNextRunAtMs).toBeUndefined();
+  });
+
+  it("clears the consumed pacing override after a current quiet trigger", () => {
+    const state = makeState();
+    const job = makePacedJob({ min: "15m", max: "4h" });
+    job.state.pacedNextRunAtMs = ENDED_AT + 30 * 60_000;
+    state.store = { version: 1, jobs: [job] };
+    const admittedJob = structuredClone(job);
+
+    applyOutcomeToStoredJob(state, {
+      jobId: job.id,
+      job: admittedJob,
+      status: "ok",
+      startedAt: STARTED_AT,
+      endedAt: ENDED_AT,
+      triggerEval: { fired: false, stateChanged: false },
+    });
+
+    expect(job.state.pacedNextRunAtMs).toBeUndefined();
+  });
+
+  it("preserves an edited pacing override after a stale quiet trigger", () => {
+    const state = makeState();
+    const job = makePacedJob({ min: "15m", max: "4h" });
+    const admittedJob = structuredClone(job);
+    const editedNextRunAtMs = ENDED_AT + 45 * 60_000;
+    job.schedule = { kind: "every", everyMs: 2 * 60 * 60_000, anchorMs: STARTED_AT };
+    job.state.nextRunAtMs = editedNextRunAtMs;
+    job.state.pacedNextRunAtMs = editedNextRunAtMs;
+    state.store = { version: 1, jobs: [job] };
+
+    applyOutcomeToStoredJob(state, {
+      jobId: job.id,
+      job: admittedJob,
+      status: "ok",
+      startedAt: STARTED_AT,
+      endedAt: ENDED_AT,
+      triggerEval: { fired: false, stateChanged: false },
+    });
+
+    expect(job.state.nextRunAtMs).toBe(editedNextRunAtMs);
+    expect(job.state.pacedNextRunAtMs).toBe(editedNextRunAtMs);
   });
 
   it.each([


### PR DESCRIPTION
Closes #111383
Related: #111408

## What Problem This Solves
An active one-shot can be rescheduled while its original execution is in progress. Previously, the old completion could delete the replacement, disable it, replace its future slot with retry/backoff, consume its new pacing, or disarm its trigger. The lost schedule then stayed lost after a Gateway restart.

## Why This Change Was Made
Track successfully persisted scheduling mutations on the exact existing process-local active-run marker. Resolve completion ownership by comparing the original admitted schedule with the current persisted schedule and by checking the marker, so an A→B→A edit is not mistaken for an untouched run. Use this one ownership decision in scheduled, startup catch-up, and manual completion. Stale completions retain the new schedule, enablement, future slot, pacing, and trigger while still recording the original run outcome and delivery metadata.

Mark only scheduling changes after durable persistence. Failed writes, idempotent updates, unrelated edits, idle jobs, and replacement run markers cannot steal ownership. Preserve ordinary unchanged delete, disable, retry, trigger, and quiet-pacing behavior.

This adds no SQLite schema, public configuration, external API, provider policy, or persisted migration. Thanks to @metaforismo for the original investigation in #111408; their contribution is preserved in the Git co-author trailer.

## User Impact
Operators and agents can safely edit active one-shot jobs: replacement schedules survive successful, errored, and skipped original runs and remain correct after Gateway restart.

## Evidence
- Proved six failures against current unmodified production: success/error/skipped × deleteAfterRun true/false.
- Proved all six corrected outcomes through the real scheduler, SQLite persistence, and Gateway restart.
- Proved manual A→B→A schedule edits survive completion and restart for both delete policies.
- Stress-tested 64 simultaneously active run markers; edits affect only their own exact admitted execution.
- Proved idle and replacement markers cannot inherit another run's ownership.
- Proved unchanged quiet triggers consume the old pacing override, while edited quiet triggers retain the replacement pacing and future slot.
- Passed the complete 154-file Linux cron suite on Blacksmith.
- Passed all 246 Gateway cron regression tests and all 139 cron CLI/edit tests on Blacksmith.
- Passed the full changed-code gate: production and test typechecking, lint, formatting, plugin boundaries, dependency and schema guards, and runtime import-cycle checks.
- Passed fresh independent structured autoreview after addressing its concrete quiet-trigger pacing finding.

## ClawSweeper rank-up moves
- **Canonical implementation:** this PR is the canonical fix for #111383. It incorporates and credits @metaforismo's investigation and #111408 as Git co-authorship, then covers the A→B→A, exact-marker identity, manual/startup completion, real SQLite restart, quiet-trigger pacing, and 64-way concurrency gaps. The superseded contributor PR will be closed with thanks after this PR is verified merged.
- **Final-head checks:** the protected merge will not run until CI workflow 30265846333 successfully finishes on reviewed head 7719d61b0f89226829ac7c1eb801e8f6292bf7ce. Full remote Blacksmith cron, Gateway, CLI, and changed-code proof has already passed on that same head.
