### PR TITLE
fix(gateway): add killSignal SIGKILL to all ps probes in quiescence scripts

### DIFF
--- a/src/gateway/worker-environments/workspace-quiescence-scripts.ts
+++ b/src/gateway/worker-environments/workspace-quiescence-scripts.ts
@@ -3,6 +3,7 @@ const REMOTE_QUIESCENCE_PS_JS = String.raw`function processes() {
     encoding: "utf8",
     maxBuffer: 4 * 1024 * 1024,
     timeout: 2000,
+    killSignal: "SIGKILL",
   });
   const rows = new Map();
   for (const line of output.split("\n")) {
@@ -31,6 +32,8 @@ function processIdentity(pid) {
     const start = require("node:child_process").execFileSync("ps", ["-o", "lstart=", "-p", String(pid)], {
       encoding: "utf8",
       maxBuffer: 4096,
+      timeout: 2000,
+      killSignal: "SIGKILL",
     }).trim();
     return start || null;
   } catch (error) {
@@ -40,7 +43,7 @@ function processIdentity(pid) {
 }
 function processStatus(pid) {
   try {
-    const output = childProcess.execFileSync("ps", ["-o", "stat=,lstart=", "-p", String(pid)], { encoding: "utf8", maxBuffer: 4096, timeout: 2000 }).trim();
+    const output = childProcess.execFileSync("ps", ["-o", "stat=,lstart=", "-p", String(pid)], { encoding: "utf8", maxBuffer: 4096, timeout: 2000, killSignal: "SIGKILL" }).trim();
     const match = /^(\S+)\s+(.+)$/u.exec(output);
     return match ? { state: match[1], start: match[2] } : null;
   } catch (error) {

--- a/src/gateway/worker-environments/workspace-sync-scripts.test.ts
+++ b/src/gateway/worker-environments/workspace-sync-scripts.test.ts
@@ -203,6 +203,23 @@ describe("remote workspace quiescence scripts", () => {
     );
     expect(result.code).not.toBe(0);
   });
+
+  it("every ps probe in REMOTE_QUIESCENCE_PS_JS carries timeout and killSignal SIGKILL", () => {
+    // Structural guard: assert every execFileSync("ps", ...) in the shared
+    // PS fragment carries BOTH timeout AND killSignal: "SIGKILL".
+    const source = REMOTE_WORKSPACE_QUIESCE_JS;
+    const psCallPattern = /execFileSync\("ps",\s*\[[^\]]*\],\s*\{[^}]*\}/g;
+    const matches = [...source.matchAll(psCallPattern)];
+    expect(matches.length).toBeGreaterThanOrEqual(1);
+    for (const match of matches) {
+      const call = match[0]!;
+      expect(call).toContain("timeout:");
+      expect(call).toContain('killSignal: "SIGKILL"');
+    }
+    // Also check RENEW and RESUME scripts embed the shared PS fragment.
+    expect(REMOTE_WORKSPACE_RENEW_QUIESCENCE_JS).toContain('killSignal: "SIGKILL"');
+    expect(REMOTE_WORKSPACE_RESUME_JS).toContain('killSignal: "SIGKILL"');
+  });
 });
 
 describe("remote workspace manifest script", () => {


### PR DESCRIPTION
## What Problem This Solves

Follow-up to #111165, adapted for the refactored `workspace-quiescence-scripts.ts` layout on current `main`.

The quiesce/renew/resume scripts call `ps` via `execFileSync` with timeouts, but the default kill signal (SIGTERM) can be trapped by adversarial or unresponsive children, defeating the timeout and leaving the caller hung on the blocked pipe. This matches the pattern that PR #111165 originally identified.

After the quiescence scripts were refactored into `workspace-quiescence-scripts.ts` (with shared `REMOTE_QUIESCENCE_PS_JS` and `REMOTE_QUIESCENCE_LEASE_JS` fragments), the `processes()` and `processStatus()` calls already carry `timeout: 2000`, and the `processIdentity()` call was the only remaining `ps` probe without a timeout. However, **none** of the three `ps` call sites carried `killSignal: "SIGKILL"`, meaning any timeout could still be defeated by a SIGTERM-trapping child.

## Fix

1. Add `killSignal: "SIGKILL"` to all three `execFileSync("ps", ...)` calls in `REMOTE_QUIESCENCE_PS_JS`:
   - `processes()` — already had `timeout: 2000`, now adds `killSignal: "SIGKILL"`
   - `processIdentity()` — adds `timeout: 2000` (was the only ps call missing a timeout) and `killSignal: "SIGKILL"`
   - `processStatus()` — already had `timeout: 2000`, now adds `killSignal: "SIGKILL"`

2. Since `REMOTE_QUIESCENCE_PS_JS` is embedded into `REMOTE_WORKSPACE_QUIESCE_JS`, `REMOTE_WORKSPACE_RENEW_QUIESCENCE_JS`, and `REMOTE_WORKSPACE_RESUME_JS` via template literal interpolation, the fix propagates to all three scripts automatically.

3. Add a structural guard test asserting every `execFileSync("ps", ...)` in the shared PS fragment carries BOTH `timeout` AND `killSignal: "SIGKILL"`, and verifying RENEW/RESUME scripts embed the fragment.

### Why `killSignal: "SIGKILL"` is required (not the default SIGTERM)

The `ps` command itself never traps SIGTERM, but the quiesce workflow may run on hosts where a sibling worker (or a misbehaving procfs snapshot under load) keeps the child alive past the SIGTERM, so a hard kill is the correct guarantee. This is the same rationale as PR #111165.

### No need for watchdog-internal PS_TIMEOUT_MS declaration

The original PR #111165 had to declare `PS_TIMEOUT_MS` inside `watchdogMain` because it was serialized via `.toString()` and run in a separate Node child process. After the refactoring, `watchdogMain` calls `processIdentity` directly (which is also serialized via `processIdentity.toString()` into the watchdog spawn args), so the shared fragment's timeout/killSignal are naturally available — no duplicate constant needed.

## Differences from #111165

| Aspect | #111165 (original) | This PR (adapted) |
|---|---|---|
| Timeout value | `PS_TIMEOUT_MS = 5000` | Uses existing `timeout: 2000` from main |
| Watchdog PS_TIMEOUT_MS | Duplicate constant inside `watchdogMain` | Not needed — `processIdentity` is serialized from shared fragment |
| File layout | Single `workspace-sync-scripts.ts` | Refactored `workspace-quiescence-scripts.ts` with shared PS fragment |
| `processIdentity` timeout | Added `timeout: 5000` | Added `timeout: 2000` (aligning with existing conventions) |

## Evidence

- Structural guard test passes across all 3 gateway lanes (gateway-core, gateway-server, gateway-client)
- Existing quiescence test suite passes (pre-existing local environment failures unrelated to this change)

## Verification

- [x] Latest `main` checked; `processIdentity()` is the only `ps` call without a timeout, and none have `killSignal`.
- [x] Structural guard added: every ps call site must carry BOTH `timeout` AND `killSignal: "SIGKILL"`.
- [x] Adapted from #111165 to work with the refactored file layout.