### PR TITLE
fix(ui): keep active preambles visible when opening sessions

### DIFF
--- a/src/gateway/server-methods/sessions-subscriptions.ts
+++ b/src/gateway/server-methods/sessions-subscriptions.ts
@@ -122,11 +122,17 @@ export const sessionSubscriptionHandlers: GatewayRequestHandlers = {
       } else {
         context.subscribeSessionMessageEvents(connId, subscriptionKey);
       }
+      // Subscribe first, then snapshot. A later live item update stays ordered
+      // after this replay on the same WebSocket connection.
+      const preambleReplay = context.sessionObserver?.getPreambleReplay(subscriptionKey);
       respond(
         true,
         {
           subscribed: true,
           key: canonicalKey,
+          // `null` is an authoritative empty snapshot; omission is reserved
+          // for servers that do not expose replay support.
+          ...(context.sessionObserver ? { preambleReplay: preambleReplay ?? null } : {}),
           ...(p.includeApprovals === true
             ? {
                 approvalReplay,

--- a/src/gateway/server-methods/sessions.messages-subscribe-approvals.test.ts
+++ b/src/gateway/server-methods/sessions.messages-subscribe-approvals.test.ts
@@ -44,6 +44,13 @@ function createContext(params: {
   replayError?: Error;
   globalScope?: boolean;
   agents?: Array<{ id: string; default?: boolean }>;
+  observerAvailable?: boolean;
+  preambleReplay?: {
+    runId: string;
+    itemId?: string;
+    progressText: string;
+    updatedAt: number;
+  };
 }) {
   const rollbackSubscription = vi.fn();
   const subscribeSessionMessageEvents = vi.fn(() => rollbackSubscription);
@@ -54,6 +61,7 @@ function createContext(params: {
     return params.replay;
   });
   const logError = vi.fn();
+  const getPreambleReplay = vi.fn(() => params.preambleReplay);
   const context = {
     getRuntimeConfig: () => ({
       agents: { list: params.agents ?? [{ id: "main", default: true }] },
@@ -61,10 +69,12 @@ function createContext(params: {
     }),
     listSessionPendingApprovals,
     logGateway: { error: logError },
+    ...(params.observerAvailable === false ? {} : { sessionObserver: { getPreambleReplay } }),
     subscribeSessionMessageEvents,
   } as unknown as GatewayRequestContext;
   return {
     context,
+    getPreambleReplay,
     listSessionPendingApprovals,
     logError,
     rollbackSubscription,
@@ -96,6 +106,34 @@ describe("sessions.messages.subscribe approval opt-in", () => {
   beforeEach(() => {
     loadSessionEntryMock.mockReset();
     loadSessionEntryMock.mockImplementation((sessionKey: string) => ({ canonicalKey: sessionKey }));
+  });
+
+  it("returns the active preamble after installing the message subscription", async () => {
+    const preambleReplay = {
+      runId: "run-1",
+      itemId: "commentary-1",
+      progressText: "Checking the gateway subscription handoff",
+      updatedAt: 42,
+    };
+    const { context, getPreambleReplay, subscribeSessionMessageEvents } = createContext({
+      preambleReplay,
+    });
+
+    const respond = await subscribe({
+      body: { key: "agent:main:session-1" },
+      client: createClient({ scopes: ["operator.read"], connId: "conn-chat" }),
+      context,
+    });
+
+    expect(subscribeSessionMessageEvents).toHaveBeenCalledWith("conn-chat", "agent:main:session-1");
+    expect(subscribeSessionMessageEvents.mock.invocationCallOrder[0]).toBeLessThan(
+      getPreambleReplay.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+    );
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      { subscribed: true, key: "agent:main:session-1", preambleReplay },
+      undefined,
+    );
   });
 
   it("allows an admin without a paired device and uses the exact scoped subscription key", async () => {
@@ -131,7 +169,7 @@ describe("sessions.messages.subscribe approval opt-in", () => {
     });
     expect(respond).toHaveBeenCalledWith(
       true,
-      { subscribed: true, key: "global", approvalReplay },
+      { subscribed: true, key: "global", preambleReplay: null, approvalReplay },
       undefined,
     );
   });
@@ -159,7 +197,7 @@ describe("sessions.messages.subscribe approval opt-in", () => {
     );
     expect(respond).toHaveBeenCalledWith(
       true,
-      { subscribed: true, key: "agent:main:child", approvalReplay },
+      { subscribed: true, key: "agent:main:child", preambleReplay: null, approvalReplay },
       undefined,
     );
   });
@@ -196,7 +234,7 @@ describe("sessions.messages.subscribe approval opt-in", () => {
     );
   });
 
-  it("keeps the non-approval response shape and skips replay", async () => {
+  it("returns an authoritative empty preamble snapshot without approval replay", async () => {
     loadSessionEntryMock.mockReturnValueOnce({ canonicalKey: "agent:main:child" });
     const { context, listSessionPendingApprovals, subscribeSessionMessageEvents } = createContext(
       {},
@@ -216,10 +254,28 @@ describe("sessions.messages.subscribe approval opt-in", () => {
     ]);
     expect(respond).toHaveBeenCalledWith(
       true,
-      { subscribed: true, key: "agent:main:child" },
+      { subscribed: true, key: "agent:main:child", preambleReplay: null },
       undefined,
     );
     expect(respond.mock.calls[0]?.[1]).not.toHaveProperty("approvalReplay");
+  });
+
+  it("omits the preamble snapshot when observer replay support is unavailable", async () => {
+    loadSessionEntryMock.mockReturnValueOnce({ canonicalKey: "agent:main:child" });
+    const { context, getPreambleReplay } = createContext({ observerAvailable: false });
+
+    const respond = await subscribe({
+      body: { key: "child" },
+      client: createClient({ scopes: ["operator.read"] }),
+      context,
+    });
+
+    expect(getPreambleReplay).not.toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      { subscribed: true, key: "agent:main:child" },
+      undefined,
+    );
   });
 
   it.each([

--- a/src/gateway/session-observer-contract.ts
+++ b/src/gateway/session-observer-contract.ts
@@ -17,10 +17,18 @@ export type SessionObserverCompanionSnapshot = {
   notes: Array<{ sequence: number; text: string }>;
 };
 
+export type SessionPreambleReplay = {
+  runId: string;
+  itemId?: string;
+  progressText: string;
+  updatedAt: number;
+};
+
 export type SessionObserverService = {
   handleEvent: (event: SessionObserverEvent) => void;
   setConnectionVisibility: (connId: string, visible: boolean) => void;
   removeConnection: (connId: string) => void;
   getCompanionSnapshot: (sessionKey: string) => SessionObserverCompanionSnapshot;
+  getPreambleReplay: (sessionKey: string) => SessionPreambleReplay | undefined;
   dispose: () => void;
 };

--- a/src/gateway/session-observer-model.ts
+++ b/src/gateway/session-observer-model.ts
@@ -28,6 +28,7 @@ import type {
   SessionEventSubscriberRegistry,
   SessionMessageSubscriberRegistry,
 } from "./server-chat-state.js";
+import type { SessionPreambleReplay } from "./session-observer-contract.js";
 
 const HEADLINE_MAX_CHARS = 120;
 const ASSESSMENT_MAX_CHARS = 320;
@@ -61,6 +62,7 @@ export type SessionObserverState = SessionActivityNoteState & {
   lastDigestNoteSequence: number;
   lastPreambleHeadline?: string;
   lastPublishedPreambleHeadline?: string;
+  preambleReplay?: SessionPreambleReplay;
   previousDigest?: SessionObserverDigest;
   preparedPromise?: Promise<PreparedModel>;
   activeController?: AbortController;
@@ -83,6 +85,7 @@ export type DormantSessionObserverRun = Pick<
   | "digestCount"
   | "consecutiveFailures"
   | "lastPreambleHeadline"
+  | "preambleReplay"
   | "planProgress"
   | "previousDigest"
 >;
@@ -185,6 +188,7 @@ export function createDormantSessionObserverRun(
     ...(state.lastPublishedPreambleHeadline
       ? { lastPreambleHeadline: state.lastPublishedPreambleHeadline }
       : {}),
+    ...(state.preambleReplay ? { preambleReplay: state.preambleReplay } : {}),
     planProgress: state.planProgress,
     previousDigest: state.previousDigest,
   };

--- a/src/gateway/session-observer-preamble.test.ts
+++ b/src/gateway/session-observer-preamble.test.ts
@@ -98,6 +98,73 @@ describe("session observer preamble publisher", () => {
     publisher.dispose();
   });
 
+  it.each([undefined, "commentary-1"])(
+    "clears a replay with item id %s when an empty update omits identity",
+    (itemId) => {
+      const session = state("Earlier headline");
+      const publisher = createSessionObserverPreamblePublisher({
+        now: () => 1_000,
+        setTimeoutFn: setTimeout,
+        clearTimeoutFn: clearTimeout,
+        isCurrent: () => true,
+        publish: vi.fn(),
+      });
+      const preamble = (sequence: number, progressText: string) => ({
+        runId: "run-1",
+        seq: sequence,
+        stream: "item" as const,
+        ts: 1_000 + sequence,
+        sessionKey: session.sessionKey,
+        agentId: session.agentId,
+        data: {
+          kind: "preamble" as const,
+          ...(sequence === 1 && itemId ? { itemId } : {}),
+          progressText,
+        },
+      });
+
+      publisher.handle(session, preamble(1, "Checking files"));
+      expect(session.preambleReplay?.progressText).toBe("Checking files");
+
+      publisher.handle(session, preamble(2, ""));
+      expect(session.preambleReplay).toBeUndefined();
+      publisher.dispose();
+    },
+  );
+
+  it("clears an itemless replay when the empty update introduces identity", () => {
+    const session = state("Earlier headline");
+    const publisher = createSessionObserverPreamblePublisher({
+      now: () => 1_000,
+      setTimeoutFn: setTimeout,
+      clearTimeoutFn: clearTimeout,
+      isCurrent: () => true,
+      publish: vi.fn(),
+    });
+
+    publisher.handle(session, {
+      runId: "run-1",
+      seq: 1,
+      stream: "item",
+      ts: 1_001,
+      sessionKey: session.sessionKey,
+      agentId: session.agentId,
+      data: { kind: "preamble", progressText: "Checking files" },
+    });
+    publisher.handle(session, {
+      runId: "run-1",
+      seq: 2,
+      stream: "item",
+      ts: 1_002,
+      sessionKey: session.sessionKey,
+      agentId: session.agentId,
+      data: { kind: "preamble", itemId: "commentary-1", progressText: "" },
+    });
+
+    expect(session.preambleReplay).toBeUndefined();
+    publisher.dispose();
+  });
+
   it("remembers a preamble that matches a restored digest", () => {
     const session = state("Checking files");
     const publish = vi.fn();
@@ -195,7 +262,7 @@ describe("session observer preamble publisher", () => {
       ts: Date.now(),
       sessionKey: original.sessionKey,
       agentId: original.agentId,
-      data: { kind: "preamble" as const, progressText },
+      data: { kind: "preamble" as const, itemId: "commentary-1", progressText },
     });
 
     publisher.handle(original, preamble(1, "Published headline"));
@@ -205,6 +272,12 @@ describe("session observer preamble publisher", () => {
     publisher.clear(original);
 
     expect(dormant.lastPreambleHeadline).toBe("Published headline");
+    expect(dormant.preambleReplay).toEqual({
+      runId: "run-1",
+      itemId: "commentary-1",
+      progressText: "Queued headline",
+      updatedAt: 1_100,
+    });
     const revived = state("Published headline");
     revived.lastPreambleHeadline = dormant.lastPreambleHeadline;
     publisher.handle(revived, {

--- a/src/gateway/session-observer-preamble.ts
+++ b/src/gateway/session-observer-preamble.ts
@@ -1,9 +1,11 @@
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { SessionObserverDigest } from "../../packages/gateway-protocol/src/schema/sessions.js";
 import { normalizeSessionPreambleText } from "../agents/session-preamble.js";
 import type { SessionObserverEvent } from "./session-observer-contract.js";
 import type { SessionObserverState } from "./session-observer-model.js";
 
 const PREAMBLE_HEADLINE_MAX_CHARS = 120;
+const PREAMBLE_REPLAY_MAX_CHARS = 8_000;
 const PREAMBLE_PUBLISH_INTERVAL_MS = 2_000;
 
 type PreambleEntry = {
@@ -71,13 +73,34 @@ export function createSessionObserverPreamblePublisher(params: {
       if (event.stream !== "item" || event.data.kind !== "preamble") {
         return false;
       }
-      const headline = normalizeSessionPreambleText(
-        event.data.progressText,
-        PREAMBLE_HEADLINE_MAX_CHARS,
-      );
+      const rawProgressText =
+        typeof event.data.progressText === "string" ? event.data.progressText.trim() : "";
+      const rawItemId =
+        typeof event.data.itemId === "string"
+          ? event.data.itemId.trim()
+          : typeof event.data.id === "string"
+            ? event.data.id.trim()
+            : "";
+      const headline = normalizeSessionPreambleText(rawProgressText, PREAMBLE_HEADLINE_MAX_CHARS);
       if (!headline) {
+        if (
+          state.preambleReplay &&
+          (!rawItemId || !state.preambleReplay.itemId || state.preambleReplay.itemId === rawItemId)
+        ) {
+          state.preambleReplay = undefined;
+        }
         return true;
       }
+      // Keep the full item snapshot for a selected-session handoff. The digest
+      // headline is intentionally truncated and cannot reconstruct Chat text.
+      state.preambleReplay = {
+        runId: state.runId,
+        ...(rawItemId ? { itemId: rawItemId } : {}),
+        // Match the existing bounded Chat history projection while retaining
+        // far more context than the 120-character sidebar headline.
+        progressText: truncateUtf16Safe(rawProgressText, PREAMBLE_REPLAY_MAX_CHARS),
+        updatedAt: event.ts,
+      };
       const existing = entries.get(state);
       const previousHeadline =
         state.lastPreambleHeadline ??

--- a/src/gateway/session-observer-replay.test.ts
+++ b/src/gateway/session-observer-replay.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createHarness,
+  event,
+  resetSessionObserverEventSequence,
+} from "./session-observer.test-utils.js";
+
+afterEach(() => {
+  vi.useRealTimers();
+  resetSessionObserverEventSequence();
+});
+
+function preamble(runId: string, progressText: string) {
+  return event({
+    runId,
+    stream: "item",
+    data: { kind: "preamble", progressText },
+  });
+}
+
+describe("session observer preamble replay selection", () => {
+  it("does not replay an older dormant run after the latest run clears its preamble", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const harness = createHarness();
+
+    harness.observer.handleEvent(preamble("run-1", "Older progress"));
+    harness.observer.handleEvent(preamble("run-2", "Latest progress"));
+    harness.observer.handleEvent(preamble("run-2", ""));
+    harness.observer.removeConnection("conn-1");
+
+    expect(harness.observer.getPreambleReplay("agent:main:session-1")).toBeUndefined();
+    harness.observer.dispose();
+  });
+
+  it("does not expose an older replay after the latest run terminates", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const harness = createHarness({ utilityModelRef: null });
+
+    harness.observer.handleEvent(preamble("run-1", "Older progress"));
+    harness.observer.handleEvent(preamble("run-2", "Latest progress"));
+    harness.observer.handleEvent(
+      event({
+        runId: "run-2",
+        stream: "lifecycle",
+        data: { phase: "end", startedAt: 1_000, endedAt: 41_000 },
+      }),
+    );
+
+    expect(harness.observer.getPreambleReplay("agent:main:session-1")).toBeUndefined();
+
+    harness.observer.handleEvent(preamble("run-3", "New progress"));
+    expect(harness.observer.getPreambleReplay("agent:main:session-1")).toEqual(
+      expect.objectContaining({ runId: "run-3", progressText: "New progress" }),
+    );
+    harness.observer.dispose();
+  });
+
+  it("does not dormantize an older active replay after a newer unseen run terminates", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const harness = createHarness({ utilityModelRef: null });
+
+    harness.observer.handleEvent(preamble("run-1", "Older active progress"));
+    harness.observer.handleEvent(
+      event({
+        runId: "run-2",
+        stream: "lifecycle",
+        data: { phase: "end", startedAt: 2_000, endedAt: 42_000 },
+      }),
+    );
+
+    harness.observer.removeConnection("conn-1");
+    expect(harness.observer.getPreambleReplay("agent:main:session-1")).toBeUndefined();
+    harness.observer.dispose();
+  });
+});

--- a/src/gateway/session-observer.test.ts
+++ b/src/gateway/session-observer.test.ts
@@ -55,6 +55,7 @@ describe("session observer", () => {
         stream: "item",
         data: {
           kind: "preamble",
+          itemId: "commentary-1",
           phase: "update",
           progressText: "**Checking** the [gateway](https://example.com) [[reply_to_current]]",
         },
@@ -71,6 +72,16 @@ describe("session observer", () => {
       runId: "run-1",
     });
     expect(harness.persistDigest).toHaveBeenCalledOnce();
+    expect(harness.observer.getPreambleReplay("agent:main:session-1")).toEqual({
+      runId: "run-1",
+      itemId: "commentary-1",
+      progressText: "**Checking** the [gateway](https://example.com) [[reply_to_current]]",
+      updatedAt: 1_000,
+    });
+    harness.observer.removeConnection("conn-1");
+    expect(harness.observer.getPreambleReplay("agent:main:session-1")).toEqual(
+      expect.objectContaining({ itemId: "commentary-1" }),
+    );
     harness.observer.dispose();
   });
 

--- a/src/gateway/session-observer.ts
+++ b/src/gateway/session-observer.ts
@@ -94,6 +94,23 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
       notes: [],
     };
   };
+  const latestDormantRunForSession = (sessionKey: string) => {
+    let latest: DormantSessionObserverRun | undefined;
+    for (const run of dormantRuns.values()) {
+      // Dormant map order is the recency tie-breaker when runs share a start timestamp.
+      if (run.sessionKey === sessionKey && (!latest || run.startedAt >= latest.startedAt)) {
+        latest = run;
+      }
+    }
+    return latest;
+  };
+  const getPreambleReplay = (sessionKey: string) => {
+    const activeState = states.get(sessionKey);
+    if (activeState) {
+      return activeState.terminalHealth ? undefined : activeState.preambleReplay;
+    }
+    return latestDormantRunForSession(sessionKey)?.preambleReplay;
+  };
   const audience = createSessionObserverAudience({
     subscribers: deps.subscribers,
     sessionEventSubscribers: deps.sessionEventSubscribers,
@@ -578,6 +595,34 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
       }
       return;
     }
+    const stateAtEventStart = states.get(sessionKey);
+    const latestDormantAtEventStart = stateAtEventStart
+      ? undefined
+      : latestDormantRunForSession(sessionKey);
+    const terminalStartedAt = readFiniteNumber(event.data.startedAt);
+    const latestKnownStartedAt =
+      stateAtEventStart?.startedAt ?? latestDormantAtEventStart?.startedAt;
+    const terminalEndsLatestRun =
+      terminal &&
+      (stateAtEventStart?.runId === event.runId ||
+        (!stateAtEventStart &&
+          (latestDormantAtEventStart?.runId === event.runId ||
+            latestDormantAtEventStart === undefined)) ||
+        (terminalStartedAt !== undefined &&
+          latestKnownStartedAt !== undefined &&
+          terminalStartedAt > latestKnownStartedAt));
+    if (terminalEndsLatestRun) {
+      // Terminal states are intentionally not dormant. Clear only their older
+      // transient replay payloads so deleting the latest run cannot expose stale text.
+      if (stateAtEventStart) {
+        stateAtEventStart.preambleReplay = undefined;
+      }
+      for (const run of dormantRuns.values()) {
+        if (run.sessionKey === sessionKey) {
+          run.preambleReplay = undefined;
+        }
+      }
+    }
     const agentId = eventAgentId || knownRun?.agentId;
     if (terminal) {
       contextlessTerminalRuns.delete(event.runId);
@@ -723,6 +768,7 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
       }
     },
     getCompanionSnapshot,
+    getPreambleReplay,
     dispose() {
       disposed = true;
       preamblePublisher.dispose();

--- a/ui/src/e2e/chat-flow.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.e2e.test.ts
@@ -39,6 +39,12 @@ const channelStopProofDir = path.join(
   "control-ui-e2e",
   "channel-stop",
 );
+const preambleHandoffProofDir = path.join(
+  process.cwd(),
+  ".artifacts",
+  "control-ui-e2e",
+  "preamble-handoff",
+);
 
 let server: ControlUiE2eServer;
 // Browser contexts preserve test isolation; keep one process warm for this file.
@@ -3995,6 +4001,100 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
           textOverflow: getComputedStyle(label).textOverflow,
         })),
       ).toEqual({ textIndent: "0px", textOverflow: "ellipsis" });
+    } finally {
+      await closeBrowserContext(context);
+    }
+  });
+
+  it("hands a background session preamble from the sidebar into Chat", async () => {
+    if (captureUiProofEnabled) {
+      await mkdir(preambleHandoffProofDir, { recursive: true });
+    }
+    const context = await newBrowserContext({
+      locale: "en-US",
+      ...(captureUiProofEnabled
+        ? { recordVideo: { dir: preambleHandoffProofDir, size: { height: 900, width: 1280 } } }
+        : {}),
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const sessionKey = "agent:main:session-b";
+    const runId = "run-session-b";
+    const preamble = "Checking the gateway subscription handoff";
+    const updatedAt = Date.now();
+    const sessions = chatSessionListResponse([
+      {
+        key: "agent:main:session-a",
+        kind: "direct",
+        label: "Session A",
+        updatedAt: updatedAt + 1,
+      },
+      {
+        key: sessionKey,
+        kind: "direct",
+        label: "Session B",
+        updatedAt,
+        hasActiveRun: true,
+        status: "running",
+        activeRunIds: [runId],
+        observerDigest: {
+          sessionKey,
+          runId,
+          revision: 1,
+          updatedAt,
+          headline: preamble,
+          health: "on-track",
+        },
+      },
+    ]);
+    await installMockGateway(page, {
+      methodResponses: {
+        "sessions.list": sessions,
+        "sessions.messages.subscribe": {
+          cases: [
+            {
+              match: { key: sessionKey },
+              response: {
+                key: sessionKey,
+                preambleReplay: {
+                  runId,
+                  itemId: "commentary-1",
+                  progressText: preamble,
+                  updatedAt,
+                },
+              },
+            },
+          ],
+        },
+      },
+      sessionKey: "agent:main:session-a",
+    });
+
+    try {
+      await page.goto(`${server.baseUrl}chat`);
+      const row = page.locator(`.sidebar-recent-session[data-session-key="${sessionKey}"]`);
+      await row.locator(".sidebar-recent-session__subtitle").getByText(preamble).waitFor({
+        timeout: 10_000,
+      });
+      if (captureUiProofEnabled) {
+        await page.screenshot({
+          fullPage: true,
+          path: path.join(preambleHandoffProofDir, "sidebar.png"),
+        });
+      }
+
+      await row.locator("a.sidebar-recent-session__link").click();
+
+      await page.locator(".chat-thread-inner").getByText(preamble, { exact: true }).waitFor({
+        timeout: 10_000,
+      });
+      if (captureUiProofEnabled) {
+        await page.screenshot({
+          fullPage: true,
+          path: path.join(preambleHandoffProofDir, "chat.png"),
+        });
+      }
     } finally {
       await closeBrowserContext(context);
     }

--- a/ui/src/lib/chat/chat-types.ts
+++ b/ui/src/lib/chat/chat-types.ts
@@ -72,6 +72,8 @@ export type ChatStreamSegment = {
   runId?: string;
   toolCallId?: string;
   itemId?: string;
+  /** Identifies preamble snapshots so optional item IDs can appear or disappear safely. */
+  preamble?: true;
 };
 
 export function streamSegmentHasItemId(segment: { itemId?: unknown }): boolean {

--- a/ui/src/lib/sessions/index.ts
+++ b/ui/src/lib/sessions/index.ts
@@ -189,6 +189,15 @@ type SessionCreateReconciliation = "blocking" | "background";
 export type SessionMessageSubscription = {
   key: string;
   agentId?: string | null;
+  /** `null` is an authoritative empty snapshot; `undefined` means unsupported. */
+  preambleReplay?: SessionPreambleReplay | null;
+};
+
+export type SessionPreambleReplay = {
+  runId: string;
+  itemId?: string;
+  progressText: string;
+  updatedAt: number;
 };
 
 export type SessionCapability = {
@@ -541,9 +550,40 @@ async function requestSessionMessageSubscription(
     result && typeof result === "object" && typeof (result as { key?: unknown }).key === "string"
       ? (result as { key: string }).key.trim()
       : "";
+  const hasPreambleReplay =
+    result !== null &&
+    typeof result === "object" &&
+    Object.prototype.hasOwnProperty.call(result, "preambleReplay");
+  const replayCandidate =
+    hasPreambleReplay &&
+    result &&
+    typeof result === "object" &&
+    (result as { preambleReplay?: unknown }).preambleReplay !== null
+      ? (result as { preambleReplay?: Record<string, unknown> }).preambleReplay
+      : undefined;
+  const replayRunId =
+    typeof replayCandidate?.runId === "string" ? replayCandidate.runId.trim() : "";
+  const replayProgressText =
+    typeof replayCandidate?.progressText === "string" ? replayCandidate.progressText.trim() : "";
+  const replayUpdatedAt = replayCandidate?.updatedAt;
+  const replayItemId =
+    typeof replayCandidate?.itemId === "string" ? replayCandidate.itemId.trim() : "";
+  const preambleReplay =
+    replayRunId &&
+    replayProgressText &&
+    typeof replayUpdatedAt === "number" &&
+    Number.isFinite(replayUpdatedAt)
+      ? {
+          runId: replayRunId,
+          ...(replayItemId ? { itemId: replayItemId } : {}),
+          progressText: replayProgressText,
+          updatedAt: replayUpdatedAt,
+        }
+      : undefined;
   return {
     key: subscribedKey || key.trim(),
     agentId: options.agentId?.trim() || null,
+    ...(hasPreambleReplay ? { preambleReplay: preambleReplay ?? null } : {}),
   };
 }
 
@@ -602,18 +642,26 @@ async function acquireSessionMessageSubscription(
     (candidate) =>
       candidate.agentId === agentId && areUiSessionKeysEquivalent(candidate.key, normalizedKey),
   );
+  let result: Promise<SessionMessageSubscription>;
   if (!entry) {
-    const result = requestSessionMessageSubscription(client, normalizedKey, { agentId });
+    result = requestSessionMessageSubscription(client, normalizedKey, { agentId });
     entry = { key: normalizedKey, agentId, owners: 0, result };
     registry.add(entry);
     void result.catch(() => registry.delete(entry!));
+  } else {
+    // The sidebar may already own this transport subscription. Renewing the
+    // idempotent subscribe request gives a newly opened Chat the latest replay.
+    result = entry.result.then(() =>
+      requestSessionMessageSubscription(client, normalizedKey, { agentId }),
+    );
   }
   entry.owners += 1;
   try {
-    const resolved = await entry.result;
+    const resolved = await result;
     const subscription: SessionMessageSubscription = {
       key: resolved.key,
       agentId: resolved.agentId ?? null,
+      ...(resolved.preambleReplay !== undefined ? { preambleReplay: resolved.preambleReplay } : {}),
     };
     sessionMessageSubscriptionOwners.set(subscription, { client, entry, registry, onRelease });
     return subscription;

--- a/ui/src/lib/sessions/message-subscription.test.ts
+++ b/ui/src/lib/sessions/message-subscription.test.ts
@@ -1,0 +1,105 @@
+// @vitest-environment node
+import { describe, expect, it, vi } from "vitest";
+import type { GatewayBrowserClient, GatewayHelloOk } from "../../api/gateway.ts";
+import { createSessionCapability } from "./index.ts";
+
+describe("session message subscriptions", () => {
+  it("does not refresh while the shared initial subscription is pending", async () => {
+    let rejectInitial: (reason: Error) => void = () => undefined;
+    const initial = new Promise<never>((_resolve, reject) => {
+      rejectInitial = reject;
+    });
+    let subscribeCount = 0;
+    const request = vi.fn((method: string) => {
+      if (method === "sessions.messages.unsubscribe") {
+        return Promise.resolve({ unsubscribed: true });
+      }
+      if (method !== "sessions.messages.subscribe") {
+        throw new Error(`Unexpected request: ${method}`);
+      }
+      subscribeCount += 1;
+      if (subscribeCount === 1) {
+        return initial;
+      }
+      return Promise.resolve({ subscribed: true, key: "agent:main:session-1" });
+    });
+    const client = { request } as unknown as GatewayBrowserClient;
+    const gateway = {
+      snapshot: {
+        client,
+        phase: "connected" as const,
+        sessionKey: "agent:main:main",
+        assistantAgentId: "main",
+        hello: null as GatewayHelloOk | null,
+      },
+      subscribe: () => () => undefined,
+      subscribeEvents: () => () => undefined,
+    };
+    const sessions = createSessionCapability(gateway);
+
+    const first = sessions.subscribeMessages("agent:main:session-1");
+    const second = sessions.subscribeMessages("agent:main:session-1");
+    expect(request).toHaveBeenCalledTimes(1);
+
+    rejectInitial(new Error("initial subscribe failed"));
+    await expect(first).rejects.toThrow("initial subscribe failed");
+    await expect(second).rejects.toThrow("initial subscribe failed");
+    expect(request).toHaveBeenCalledTimes(1);
+
+    const recovered = await sessions.subscribeMessages("agent:main:session-1");
+    expect(request).toHaveBeenCalledTimes(2);
+    await sessions.unsubscribeMessages(recovered);
+    sessions.dispose();
+  });
+
+  it("refreshes and preserves a preamble replay when the sidebar already owns the subscription", async () => {
+    let subscribeCount = 0;
+    const request = vi.fn(async (method: string) => {
+      if (method !== "sessions.messages.subscribe") {
+        throw new Error(`Unexpected request: ${method}`);
+      }
+      subscribeCount += 1;
+      return {
+        subscribed: true,
+        key: "agent:main:session-1",
+        preambleReplay: {
+          runId: "run-1",
+          itemId: "commentary-1",
+          progressText:
+            subscribeCount === 1
+              ? "Checking the gateway"
+              : "Checking the gateway subscription handoff",
+          updatedAt: subscribeCount === 1 ? 41 : 42,
+        },
+      };
+    });
+    const client = { request } as unknown as GatewayBrowserClient;
+    const gateway = {
+      snapshot: {
+        client,
+        phase: "connected" as const,
+        sessionKey: "agent:main:main",
+        assistantAgentId: "main",
+        hello: null as GatewayHelloOk | null,
+      },
+      subscribe: () => () => undefined,
+      subscribeEvents: () => () => undefined,
+    };
+    const sessions = createSessionCapability(gateway);
+
+    const sidebarSubscription = await sessions.subscribeMessages("agent:main:session-1");
+    await expect(sessions.subscribeMessages("agent:main:session-1")).resolves.toEqual({
+      key: "agent:main:session-1",
+      agentId: null,
+      preambleReplay: {
+        runId: "run-1",
+        itemId: "commentary-1",
+        progressText: "Checking the gateway subscription handoff",
+        updatedAt: 42,
+      },
+    });
+    expect(request).toHaveBeenCalledTimes(2);
+    await sessions.unsubscribeMessages(sidebarSubscription);
+    sessions.dispose();
+  });
+});

--- a/ui/src/pages/chat/chat-history.test.ts
+++ b/ui/src/pages/chat/chat-history.test.ts
@@ -4,6 +4,7 @@ import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import {
   loadChatHistory,
   rewindChatHistory,
+  syncSelectedSessionMessageSubscription,
   switchChatHistoryBranch,
   type ChatHistoryResult,
   type ChatState,
@@ -79,6 +80,235 @@ function activeHistory(
     },
   } satisfies ChatHistoryResult;
 }
+
+describe("selected-session preamble handoff", () => {
+  it("renders the replay in Chat and replaces it by item id", async () => {
+    const state = createState({}) as TestState & {
+      chatSessionMessageSubscriptionRequestedKey: string | null;
+      chatSessionMessageSubscription: null;
+    };
+    state.sessionKey = "agent:main:session-1";
+    state.chatSessionMessageSubscriptionRequestedKey = null;
+    state.chatSessionMessageSubscription = null;
+    state.chatStreamSegments = [
+      { text: "Assistant text", ts: 40 },
+      { text: "Stale preamble", ts: 41, itemId: "commentary-old", preamble: true },
+    ];
+    state.sessions = {
+      subscribeMessages: vi.fn().mockResolvedValue({
+        key: state.sessionKey,
+        agentId: null,
+        preambleReplay: {
+          runId: "run-1",
+          itemId: "commentary-1",
+          progressText: "Checking the gateway subscription handoff [[reply_to_current]]",
+          updatedAt: 42,
+        },
+      }),
+      unsubscribeMessages: vi.fn().mockResolvedValue(undefined),
+      setModelOverride: vi.fn(),
+    } as never;
+
+    await syncSelectedSessionMessageSubscription(state as never);
+
+    expect(state.chatStreamSegments).toEqual([
+      { text: "Assistant text", ts: 40 },
+      {
+        text: "Checking the gateway subscription handoff",
+        ts: 42,
+        runId: "run-1",
+        itemId: "commentary-1",
+        preamble: true,
+      },
+    ]);
+    handleAgentEvent(state, {
+      runId: "run-1",
+      seq: 2,
+      stream: "item",
+      ts: 43,
+      sessionKey: state.sessionKey,
+      data: {
+        kind: "preamble",
+        itemId: "commentary-1",
+        progressText: "Checking the gateway subscription handoff and tests",
+      },
+    });
+    expect(state.chatStreamSegments).toEqual([
+      { text: "Assistant text", ts: 40 },
+      {
+        text: "Checking the gateway subscription handoff and tests",
+        ts: 42,
+        runId: "run-1",
+        itemId: "commentary-1",
+        preamble: true,
+      },
+    ]);
+  });
+
+  it("clears a stale preamble when the authoritative subscription replay is empty", async () => {
+    const state = createState({}) as TestState & {
+      chatSessionMessageSubscriptionRequestedKey: string | null;
+      chatSessionMessageSubscription: null;
+    };
+    state.sessionKey = "agent:main:session-1";
+    state.chatSessionMessageSubscriptionRequestedKey = null;
+    state.chatSessionMessageSubscription = null;
+    state.chatStreamSegments = [
+      { text: "Assistant text", ts: 41 },
+      { text: "Disconnected preamble", ts: 42, itemId: "commentary-1", preamble: true },
+    ];
+    state.sessions = {
+      subscribeMessages: vi.fn().mockResolvedValue({
+        key: state.sessionKey,
+        agentId: null,
+        preambleReplay: null,
+      }),
+      unsubscribeMessages: vi.fn().mockResolvedValue(undefined),
+      setModelOverride: vi.fn(),
+    } as never;
+
+    await syncSelectedSessionMessageSubscription(state as never);
+
+    expect(state.chatStreamSegments).toEqual([{ text: "Assistant text", ts: 41 }]);
+    expect(state.requestUpdate).toHaveBeenCalledOnce();
+  });
+
+  it("preserves live preamble state when replay support is unavailable", async () => {
+    const state = createState({}) as TestState & {
+      chatSessionMessageSubscriptionRequestedKey: string | null;
+      chatSessionMessageSubscription: null;
+    };
+    state.sessionKey = "agent:main:session-1";
+    state.chatSessionMessageSubscriptionRequestedKey = null;
+    state.chatSessionMessageSubscription = null;
+    state.chatStreamSegments = [
+      { text: "Live preamble", ts: 42, itemId: "commentary-1", preamble: true },
+    ];
+    state.sessions = {
+      subscribeMessages: vi.fn().mockResolvedValue({
+        key: state.sessionKey,
+        agentId: null,
+      }),
+      unsubscribeMessages: vi.fn().mockResolvedValue(undefined),
+      setModelOverride: vi.fn(),
+    } as never;
+
+    await syncSelectedSessionMessageSubscription(state as never);
+
+    expect(state.chatStreamSegments).toEqual([
+      { text: "Live preamble", ts: 42, itemId: "commentary-1", preamble: true },
+    ]);
+    expect(state.requestUpdate).not.toHaveBeenCalled();
+  });
+
+  it("clears an itemless replay without removing assistant stream text", async () => {
+    const state = createState({}) as TestState & {
+      chatSessionMessageSubscriptionRequestedKey: string | null;
+      chatSessionMessageSubscription: null;
+    };
+    state.sessionKey = "agent:main:session-1";
+    state.chatSessionMessageSubscriptionRequestedKey = null;
+    state.chatSessionMessageSubscription = null;
+    state.chatStreamSegments = [{ text: "Assistant text", ts: 41 }];
+    state.sessions = {
+      subscribeMessages: vi.fn().mockResolvedValue({
+        key: state.sessionKey,
+        agentId: null,
+        preambleReplay: {
+          runId: "run-1",
+          progressText: "Checking files",
+          updatedAt: 42,
+        },
+      }),
+      unsubscribeMessages: vi.fn().mockResolvedValue(undefined),
+      setModelOverride: vi.fn(),
+    } as never;
+
+    await syncSelectedSessionMessageSubscription(state as never);
+
+    expect(state.chatStreamSegments).toEqual([
+      { text: "Assistant text", ts: 41 },
+      { text: "Checking files", ts: 42, runId: "run-1", preamble: true },
+    ]);
+    handleAgentEvent(state, {
+      runId: "run-1",
+      seq: 2,
+      stream: "item",
+      ts: 43,
+      sessionKey: state.sessionKey,
+      data: { kind: "preamble", progressText: "Checking files and tests" },
+    });
+    expect(state.chatStreamSegments).toEqual([
+      { text: "Assistant text", ts: 41 },
+      { text: "Checking files and tests", ts: 42, runId: "run-1", preamble: true },
+    ]);
+    handleAgentEvent(state, {
+      runId: "run-1",
+      seq: 3,
+      stream: "item",
+      ts: 44,
+      sessionKey: state.sessionKey,
+      data: {
+        kind: "preamble",
+        itemId: "commentary-1",
+        progressText: "Checking files, tests, and identity",
+      },
+    });
+    expect(state.chatStreamSegments).toEqual([
+      { text: "Assistant text", ts: 41 },
+      {
+        text: "Checking files, tests, and identity",
+        ts: 42,
+        runId: "run-1",
+        itemId: "commentary-1",
+        preamble: true,
+      },
+    ]);
+    handleAgentEvent(state, {
+      runId: "run-1",
+      seq: 4,
+      stream: "item",
+      ts: 45,
+      sessionKey: state.sessionKey,
+      data: { kind: "preamble", progressText: "Finishing verification" },
+    });
+    expect(state.chatStreamSegments).toEqual([
+      { text: "Assistant text", ts: 41 },
+      { text: "Finishing verification", ts: 42, runId: "run-1", preamble: true },
+    ]);
+    handleAgentEvent(state, {
+      runId: "run-1",
+      seq: 5,
+      stream: "item",
+      ts: 46,
+      sessionKey: state.sessionKey,
+      data: {
+        kind: "preamble",
+        itemId: "commentary-2",
+        progressText: "Final identity-bearing update",
+      },
+    });
+    expect(state.chatStreamSegments).toEqual([
+      { text: "Assistant text", ts: 41 },
+      {
+        text: "Final identity-bearing update",
+        ts: 42,
+        runId: "run-1",
+        itemId: "commentary-2",
+        preamble: true,
+      },
+    ]);
+    handleAgentEvent(state, {
+      runId: "run-1",
+      seq: 6,
+      stream: "item",
+      ts: 47,
+      sessionKey: state.sessionKey,
+      data: { kind: "preamble", progressText: "" },
+    });
+    expect(state.chatStreamSegments).toEqual([{ text: "Assistant text", ts: 41 }]);
+  });
+});
 
 describe("rewindChatHistory", () => {
   it("clears the cached snapshot, refetches, and returns the composer text", async () => {

--- a/ui/src/pages/chat/chat-history.ts
+++ b/ui/src/pages/chat/chat-history.ts
@@ -11,6 +11,7 @@ import type {
 } from "../../api/types.ts";
 import type { ApplicationInitialUserMessageHandoff } from "../../app/context.ts";
 import type { ChatAttachment, ChatQueueItem } from "../../lib/chat/chat-types.ts";
+import type { ChatStreamSegment } from "../../lib/chat/chat-types.ts";
 import {
   isAssistantHeartbeatAckForDisplay,
   stripHeartbeatTokenForDisplay,
@@ -86,7 +87,11 @@ import {
   visibleCurrentAssistantStreamTail,
 } from "./stream-reconciliation.ts";
 import { reconcileAuthoritativeTerminalHistory } from "./terminal-message-identity.ts";
-import { normalizePlanSnapshot, type PlanStatus } from "./tool-stream.ts";
+import {
+  applyPreambleProgressSnapshot,
+  normalizePlanSnapshot,
+  type PlanStatus,
+} from "./tool-stream.ts";
 
 const SILENT_REPLY_PATTERN = /^\s*NO_REPLY\s*$/;
 const SYNTHETIC_TRANSCRIPT_REPAIR_RESULT =
@@ -319,6 +324,7 @@ export type ChatState = {
   chatBranchesConnectionEpoch?: number | null;
   chatBranchesLoading?: boolean;
   requestUpdate?: () => void;
+  chatStreamSegments?: ChatStreamSegment[];
 };
 
 type ChatAgentsListSnapshot = Partial<Omit<AgentsListResult, "agents">> & {
@@ -664,6 +670,21 @@ export async function syncSelectedSessionMessageSubscription(
     }
     state.chatSessionMessageSubscriptionRequestedKey = nextKey;
     state.chatSessionMessageSubscription = subscribed;
+    if (subscribed.preambleReplay !== undefined && Array.isArray(state.chatStreamSegments)) {
+      // The gateway subscribes before taking this snapshot, so later live
+      // updates remain ordered after it. Reconcile instead of merging stale UI state.
+      const streamHost = state as { chatStreamSegments: ChatStreamSegment[] };
+      applyPreambleProgressSnapshot(streamHost, { text: "" });
+      if (subscribed.preambleReplay) {
+        applyPreambleProgressSnapshot(streamHost, {
+          text: subscribed.preambleReplay.progressText,
+          itemId: subscribed.preambleReplay.itemId,
+          runId: subscribed.preambleReplay.runId,
+          ts: subscribed.preambleReplay.updatedAt,
+        });
+      }
+      state.requestUpdate?.();
+    }
   } catch (err) {
     if (isCurrent()) {
       state.sessionsError = String(err);

--- a/ui/src/pages/chat/tool-stream-fallback.node.test.ts
+++ b/ui/src/pages/chat/tool-stream-fallback.node.test.ts
@@ -299,6 +299,7 @@ describe("app-tool-stream fallback lifecycle handling", () => {
         ts: TOOL_STREAM_TEST_NOW,
         runId: "run-1",
         itemId: "msg-preamble-1",
+        preamble: true,
       },
     ]);
     expect(host.chatStream).toBeNull();
@@ -320,6 +321,35 @@ describe("app-tool-stream fallback lifecycle handling", () => {
         itemId: "msg-preamble-1",
         progressText: "Checking",
       },
+    });
+    handleAgentEvent(host, {
+      runId: "run-1",
+      seq: 2,
+      stream: "item",
+      ts: Date.now(),
+      sessionKey: "main",
+      data: {
+        kind: "preamble",
+        itemId: "msg-preamble-1",
+        progressText: "",
+      },
+    });
+
+    expect(host.chatStreamSegments).toEqual([]);
+    vi.useRealTimers();
+  });
+
+  it("clears itemless preamble progress when the empty update introduces identity", () => {
+    useToolStreamFakeTimers();
+    const host = createHost({ chatRunId: "run-1" });
+
+    handleAgentEvent(host, {
+      runId: "run-1",
+      seq: 1,
+      stream: "item",
+      ts: Date.now(),
+      sessionKey: "main",
+      data: { kind: "preamble", progressText: "Checking" },
     });
     handleAgentEvent(host, {
       runId: "run-1",

--- a/ui/src/pages/chat/tool-stream.ts
+++ b/ui/src/pages/chat/tool-stream.ts
@@ -22,6 +22,13 @@ type AgentEventPayload = {
   data: Record<string, unknown>;
 };
 
+type PreambleProgressSnapshot = {
+  text: string;
+  itemId?: string;
+  runId?: string;
+  ts?: number;
+};
+
 type SessionOperationEventPayload = {
   operationId?: string;
   operation?: string;
@@ -791,9 +798,6 @@ function readPreambleProgressEvent(
         : null;
   const itemId = rawItemId?.trim();
   const progressText = normalizePreambleProgressText(data.progressText);
-  if (!progressText && !itemId) {
-    return null;
-  }
   return {
     text: progressText,
     ...(itemId ? { itemId } : {}),
@@ -814,39 +818,68 @@ function handlePreambleProgressEvent(host: ToolStreamHost, payload: AgentEventPa
   if (!progress) {
     return false;
   }
-  if (progress.itemId && !progress.text.trim()) {
-    host.chatStreamSegments = host.chatStreamSegments.filter(
-      (segment) => segment.itemId !== progress.itemId,
-    );
-    return true;
+  applyPreambleProgressSnapshot(host, { ...progress, runId: payload.runId, ts: payload.ts });
+  return true;
+}
+
+export function applyPreambleProgressSnapshot(
+  host: Pick<ToolStreamHost, "chatStreamSegments">,
+  progress: PreambleProgressSnapshot,
+): void {
+  const text = normalizePreambleProgressText(progress.text);
+  if (!text && !progress.itemId) {
+    host.chatStreamSegments = host.chatStreamSegments.filter((segment) => !segment.preamble);
+    return;
   }
-  const existingIndex = progress.itemId
+  if (progress.itemId && !text) {
+    host.chatStreamSegments = host.chatStreamSegments.filter(
+      (segment) => segment.itemId !== progress.itemId && !(segment.preamble && !segment.itemId),
+    );
+    return;
+  }
+  const exactItemIndex = progress.itemId
     ? host.chatStreamSegments.findIndex((segment) => segment.itemId === progress.itemId)
     : -1;
+  const existingIndex =
+    exactItemIndex >= 0
+      ? exactItemIndex
+      : host.chatStreamSegments.findIndex(
+          (segment) => segment.preamble && (!progress.itemId || !segment.itemId),
+        );
   if (existingIndex >= 0) {
     const existing = host.chatStreamSegments[existingIndex];
     if (!existing) {
-      return true;
+      return;
     }
-    host.chatStreamSegments = host.chatStreamSegments.map((segment, index) =>
-      index === existingIndex ? { ...segment, text: progress.text, runId: payload.runId } : segment,
-    );
-    return true;
+    host.chatStreamSegments = host.chatStreamSegments.map((segment, index) => {
+      if (index !== existingIndex) {
+        return segment;
+      }
+      const { itemId: _previousItemId, ...rest } = existing;
+      return {
+        ...rest,
+        text,
+        preamble: true,
+        ...(progress.runId ? { runId: progress.runId } : {}),
+        ...(progress.itemId ? { itemId: progress.itemId } : {}),
+      };
+    });
+    return;
   }
   const last = host.chatStreamSegments[host.chatStreamSegments.length - 1];
-  if (!progress.itemId && last && !last.toolCallId && last.text === progress.text) {
-    return true;
+  if (!progress.itemId && last && !last.toolCallId && last.text === text) {
+    return;
   }
   host.chatStreamSegments = [
     ...host.chatStreamSegments,
     {
-      text: progress.text,
-      ts: Date.now(),
-      runId: payload.runId,
+      text,
+      ts: progress.ts ?? Date.now(),
+      preamble: true,
+      ...(progress.runId ? { runId: progress.runId } : {}),
       ...(progress.itemId ? { itemId: progress.itemId } : {}),
     },
   ];
-  return true;
 }
 
 function parsePlanSteps(value: unknown): PlanStatus["steps"] {


### PR DESCRIPTION
Related context: #113084

## What Problem This Solves

Fixes an issue where users opening a background session during an active preamble could lose the sidebar text without receiving the full preamble in Chat. The selected thread could appear blank or show only a later fragment such as a single word.

## Why This Change Was Made

The Gateway now retains a bounded full preamble snapshot with the session observer and returns it only after installing the selected-session message subscription. Control UI treats that response as an authoritative handoff, reconciles it with later item updates, and handles optional item identity without duplicating or retaining stale preambles. The broader cross-client telemetry work in #113084 is not required for this focused handoff fix.

## User Impact

When users open a running session, the active progress text moves from the sidebar into Chat intact and continues updating there. Completed or cleared preambles no longer reappear from older runs.

## Evidence

- Gateway replay/terminal lifecycle regressions: 55 tests passed.
- Control UI subscription/history/stream regressions: 42 tests passed.
- Focused mocked-Gateway Playwright flow: 1 passed, 56 skipped; verifies the full preamble is visible in the sidebar, then visible in Chat after clicking the session.
- Fresh visual proof generated locally: sidebar state, selected Chat state, and a recorded video under `.artifacts/control-ui-e2e/preamble-handoff/` (not committed).
- Production and test TypeScript lanes passed for core and Control UI.
- `oxfmt --check` and `git diff --check` passed.
- Structured Codex autoreview completed; accepted replay lifecycle findings were fixed and regression-tested.
- Trusted-source local fallback was used because the installed Crabbox/Testbox wrapper failed its binary sanity check.

AI-assisted: yes. I reviewed the complete change and understand the Gateway replay and Control UI reconciliation paths.
