### PR TITLE
test(browser): include machine output in descriptor contract

### DIFF
--- a/extensions/browser/index.test.ts
+++ b/extensions/browser/index.test.ts
@@ -344,6 +344,7 @@ describe("browser plugin", () => {
           name: "browser",
           description: "Manage OpenClaw's dedicated browser (Chrome/Chromium)",
           hasSubcommands: true,
+          machineOutput: expect.any(Function),
         },
       ],
     });


### PR DESCRIPTION
Related: #113654

## What Problem This Solves

Fixes a release-only Plugin Prerelease failure where the Browser integration test still expected the old CLI descriptor shape after `machineOutput` became part of that descriptor.

## Why This Change Was Made

The integration assertion now verifies that the registered descriptor exposes a callable `machineOutput` predicate. The Browser CLI tests continue to own the predicate's command-level behavior.

## User Impact

No product behavior changes. Full Release Validation can verify the already-landed machine-readable Browser CLI behavior without a stale descriptor assertion.

## Evidence

- `node scripts/run-vitest.mjs extensions/browser/index.test.ts -t "registers CLI descriptors" --reporter=dot` — passed.
- `node scripts/run-vitest.mjs extensions/browser/src/cli/browser-cli.lazy.test.ts --reporter=dot` — 15 tests passed.
- `git diff --check` — clean.
- Autoreview: clean, no accepted/actionable findings.

AI-assisted; the one-line contract update and owning predicate tests were reviewed before submission.
