### PR TITLE
perf(skills): build snapshot cache key lazily

### DIFF
--- a/src/skills/runtime/session-snapshot.ts
+++ b/src/skills/runtime/session-snapshot.ts
@@ -82,17 +82,17 @@ export function resolveReusableWorkspaceSkillSnapshot(
     });
   };
 
-  const configFingerprint = fingerprintSkillSnapshotConfig(params.config);
-  const snapshotCacheKey = JSON.stringify([
-    params.workspaceDir,
-    snapshotVersion,
-    params.skillFilter,
-    params.agentId,
-    params.eligibility,
-    configFingerprint,
-  ]);
+  const buildSnapshotCacheKey = () =>
+    JSON.stringify([
+      params.workspaceDir,
+      snapshotVersion,
+      params.skillFilter,
+      params.agentId,
+      params.eligibility,
+      fingerprintSkillSnapshotConfig(params.config),
+    ]);
 
-  const cachedRebuild = (): SkillSnapshot => {
+  const cachedRebuild = (snapshotCacheKey = buildSnapshotCacheKey()): SkillSnapshot => {
     if (resolvedSkillsCache.has(snapshotCacheKey)) {
       return { resolvedSkills: resolvedSkillsCache.get(snapshotCacheKey) } as SkillSnapshot;
     }
@@ -101,7 +101,7 @@ export function resolveReusableWorkspaceSkillSnapshot(
 
   const snapshot =
     !params.existingSnapshot || shouldRefresh
-      ? cacheResolvedSkills(snapshotCacheKey, buildSnapshot())
+      ? cacheResolvedSkills(buildSnapshotCacheKey(), buildSnapshot())
       : params.hydrateExisting === false
         ? params.existingSnapshot
         : hydrateResolvedSkills(params.existingSnapshot, cachedRebuild);


### PR DESCRIPTION
## What Problem This Solves

`resolveReusableWorkspaceSkillSnapshot` built its cache key eagerly on every call, even on the common path where the key is never used. The key construction hashes the entire runtime config. This makes it lazy, so the hash is computed only when the resolved-skills cache is actually read or written.

## Why This Change Was Made

Every inbound message paid a full config redact plus stable-stringify plus SHA-256 to build a cache key that is usually thrown away unused. Now it is built on demand. Same key value, same cache behavior, one file, LOC neutral.

## Root Cause

`fingerprintSkillSnapshotConfig` (`src/skills/runtime/session-snapshot.ts:36`) runs `redactConfigObject` over the whole runtime config, which deep-clones it and evaluates the sensitive-path predicates per key, then `stableStringify` walks the clone sorting keys at every level, then SHA-256 hashes the result. Its only consumer is the key into the 10-entry `resolvedSkillsCache` at `:14`.

That was computed unconditionally at `:85`, before anything decided whether a cache lookup was needed. On the common path it is dead work: `hydrateResolvedSkills` (`src/skills/runtime/snapshot-hydration.ts:17-18`) returns immediately when the snapshot already carries `resolvedSkills`, so its `rebuild` callback, the only thing that needs the key, is never invoked.

The resolver is reached from the inbound reply path via `src/auto-reply/reply/get-reply-run-admission.ts:178` and `src/auto-reply/reply/session-updates.ts:198`, and runs twice on a normal turn. Because it is synchronous on the gateway's single event loop, the cost is paid by unrelated work in the queue as well.

## User Impact

Lower per-message synchronous latency on the gateway event loop; identical cache behavior and key values. No user-visible behavior change beyond reduced overhead.

## What Changed

The eager `configFingerprint` and `snapshotCacheKey` constants become one `buildSnapshotCacheKey()` closure. The build branch calls it directly, since it stores into the cache. `cachedRebuild` takes it as a defaulted parameter, so the key is computed only if `hydrateResolvedSkills` actually invokes the rebuild callback.

The key tuple keeps identical fields in identical order, so any key that is computed is byte-identical to the previous behavior. `hydrateResolvedSkills` declares `rebuild: () => SnapshotRebuild<T>` and calls it with no arguments, so the defaulted parameter cannot be shadowed by a caller.

Deliberately not done: no `WeakMap` keyed on the config object, which would be a scattered request-time cache and could serve a stale fingerprint if a config object were mutated in place; and no substitution of `resolveRuntimeConfigCacheKey`, whose full-config fingerprint would break the intentional secret-rotation equivalence asserted in `src/skills/runtime/session-snapshot.test.ts:220-242`.

## Evidence

### Real behavior proof

Isolated benchmark, Node 25.9, 83,049-byte config with 1,845 scalar keys, 300 samples, measuring one resolver call:

```text
eager path median: 1.412716 ms
lazy path  median: 0.000860 ms
reduction:         1.411856 ms per resolver call
```

The resolver runs about twice per steady reply, so roughly 2.8 ms of synchronous event-loop time per message on a config of that size. Effect scales with config size and disappears entirely on the build path, which still computes the key because it must.

### Verification

```text
node scripts/run-vitest.mjs src/skills/runtime/session-snapshot.test.ts src/auto-reply/reply/session-updates.test.ts
  -> passed 2 Vitest shards, 5 tests
pnpm tsgo:core            -> exit 0
pnpm tsgo:core:test       -> exit 0
targeted oxlint           -> exit 0
targeted oxfmt --check    -> all matched files use the correct format
git diff --check          -> exit 0
git diff --numstat        -> 11 insertions, 11 deletions, 1 file
```

The existing cache-reuse, config-gate invalidation, and secret-rotation tests already cover this behavior and pass unchanged, which is the point: the observable contract is identical. No new test was added because no new behavior exists.

### What was not tested

No live gateway run, no full suite, no build, no provider or channel test. Concurrency behavior is unchanged because nothing about ordering or async boundaries moved. The benchmark above is an isolated measurement of the key-construction path, not an end-to-end latency measurement of a real reply.

