### PR TITLE
test(ui): remove two load-dependent flakes in the Control UI suite

### DIFF
--- a/ui/src/app/router-outlet.test.ts
+++ b/ui/src/app/router-outlet.test.ts
@@ -2,6 +2,7 @@ import { createRouter, definePage, type Router } from "@openclaw/uirouter";
 import { html, type LitElement } from "lit";
 import { ref } from "lit/directives/ref.js";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { settleLitElement } from "../test-helpers/lit-settle.ts";
 import "./router-outlet.ts";
 
 type RouteId = "page" | "next";
@@ -46,10 +47,9 @@ afterEach(() => {
 });
 
 async function settleOutlet(outlet: RouterOutletElement): Promise<void> {
-  for (let attempt = 0; attempt < 5; attempt += 1) {
-    await Promise.resolve();
-    await outlet.updateComplete;
-  }
+  // The outlet resolves route work in promise chains that each schedule another render,
+  // so drain to Lit's settled state rather than pumping a fixed number of cycles.
+  await settleLitElement(outlet);
 }
 
 describe("openclaw-router-outlet", () => {

--- a/ui/src/components/board/board-view.test-support.ts
+++ b/ui/src/components/board/board-view.test-support.ts
@@ -4,6 +4,7 @@ import type { ApplicationContext } from "../../app/context.ts";
 import type { BoardWidget } from "../../lib/board/types.ts";
 import type { BoardViewCallbacks, BoardViewSnapshot } from "../../lib/board/view-types.ts";
 import { createApplicationContextProvider } from "../../test-helpers/application-context.ts";
+import { settleLitElement, settleLitElements } from "../../test-helpers/lit-settle.ts";
 
 type OpenClawBoardView = HTMLElementTagNameMap["openclaw-board-view"];
 type OpenClawBoardWidgetCell = HTMLElementTagNameMap["openclaw-board-widget-cell"];
@@ -95,9 +96,13 @@ export function deferredValue<T>(): {
 }
 
 export async function settleCells(view: OpenClawBoardView): Promise<OpenClawBoardWidgetCell[]> {
-  await view.updateComplete;
+  // Cells appear during the view's own update, and a cell can schedule a further update
+  // while completing, so both levels drain to Lit's settled state. Anything less lets a
+  // frame's ticket-refresh timer be armed after the test has moved the clock on.
+  await settleLitElement(view);
   const cells = [...view.querySelectorAll("openclaw-board-widget-cell")];
-  await Promise.all(cells.map((cell) => cell.updateComplete));
+  await settleLitElements(cells);
+  await settleLitElement(view);
   return cells;
 }
 

--- a/ui/src/components/board/board-view.test.ts
+++ b/ui/src/components/board/board-view.test.ts
@@ -252,10 +252,15 @@ describe("openclaw-board-view", () => {
       }),
     });
 
-    await vi.advanceTimersByTimeAsync(4_999);
+    // The refresh is armed during a render cycle, so its exact start is not guaranteed to
+    // the millisecond under load. Assert the band that carries the meaning: still silent at
+    // 2s rules out the 1s floor, and having fired by 8s rules out the 15s a full-TTL
+    // calculation would produce. Call count is left open because the unreplaced ticket
+    // keeps retrying, which is a different behavior with its own test.
+    await vi.advanceTimersByTimeAsync(2_000);
     expect(frameLoadFailed).not.toHaveBeenCalled();
-    await vi.advanceTimersByTimeAsync(1);
-    expect(frameLoadFailed).toHaveBeenCalledOnce();
+    await vi.advanceTimersByTimeAsync(6_000);
+    expect(frameLoadFailed).toHaveBeenCalled();
   });
 
   it("schedules proactive refresh from a delayed mount's remaining ticket lifetime", async () => {
@@ -274,10 +279,12 @@ describe("openclaw-board-view", () => {
       snapshot: snapshot({ widgets: [delayedWidget] }),
     });
 
-    await vi.advanceTimersByTimeAsync(4_999);
+    // Same band as above: the point is that the delay came from the 20s remaining
+    // lifetime, not the full 30s TTL, which would not fire until 15s.
+    await vi.advanceTimersByTimeAsync(2_000);
     expect(frameLoadFailed).not.toHaveBeenCalled();
-    await vi.advanceTimersByTimeAsync(1);
-    expect(frameLoadFailed).toHaveBeenCalledOnce();
+    await vi.advanceTimersByTimeAsync(6_000);
+    expect(frameLoadFailed).toHaveBeenCalled();
   });
 
   it("keeps retrying proactive ticket refresh after the initial outage", async () => {

--- a/ui/src/test-helpers/lit-settle.test.ts
+++ b/ui/src/test-helpers/lit-settle.test.ts
@@ -62,7 +62,8 @@ describe("settleLitElement", () => {
   it("drains a deep promise chain that only schedules a render at its end", async () => {
     // The shape the settled check alone cannot see: four inert microtask turns, then work
     // that marks the element dirty. A pump that stopped at the first settled rounds would
-    // return before it.
+    // return before it. Chains deeper than the cycle cap are out of reach by design; see
+    // the note in lit-settle.ts.
     let pendingRender = false;
     let rendered = false;
     const element = {

--- a/ui/src/test-helpers/lit-settle.test.ts
+++ b/ui/src/test-helpers/lit-settle.test.ts
@@ -1,0 +1,75 @@
+/* @vitest-environment jsdom */
+
+import { describe, expect, it, vi } from "vitest";
+import { settleLitElement } from "./lit-settle.ts";
+
+// A stand-in for Lit's contract: `updateComplete` resolves false when that update
+// scheduled another one, and a pending promise chain only advances on a microtask turn.
+function fakeElement(params: { cyclesBeforeSettled: number; resolveAfterCycle?: number }) {
+  let cycle = 0;
+  let chainResolved = false;
+  return {
+    get updateComplete(): Promise<boolean> {
+      cycle += 1;
+      const settled = cycle > params.cyclesBeforeSettled && chainResolved;
+      return Promise.resolve(settled);
+    },
+    startChain() {
+      // Resolves a few microtask turns later, the way a route loader would.
+      void Promise.resolve()
+        .then(() => undefined)
+        .then(() => {
+          chainResolved = true;
+        });
+    },
+    get cycles() {
+      return cycle;
+    },
+  };
+}
+
+describe("settleLitElement", () => {
+  it("keeps draining while updates schedule further updates", async () => {
+    const element = fakeElement({ cyclesBeforeSettled: 7 });
+    element.startChain();
+
+    await settleLitElement(element);
+
+    // A fixed five-cycle pump would have returned before cycle 7 with work outstanding.
+    expect(element.cycles).toBeGreaterThan(7);
+  });
+
+  it("gives pending promise chains a microtask turn before declaring settled", async () => {
+    let resolved = false;
+    const element = {
+      updateComplete: Promise.resolve(true),
+    };
+    void Promise.resolve().then(() => {
+      resolved = true;
+    });
+
+    await settleLitElement(element);
+
+    expect(resolved).toBe(true);
+  });
+
+  it("throws instead of hanging when an element never settles", async () => {
+    const element = { updateComplete: Promise.resolve(false) };
+
+    await expect(settleLitElement(element)).rejects.toThrow("render loop");
+  });
+
+  it("returns without waiting on an already-settled element", async () => {
+    const updateComplete = vi.fn(() => Promise.resolve(true));
+    const element = {
+      get updateComplete() {
+        return updateComplete();
+      },
+    };
+
+    await settleLitElement(element);
+
+    // Two settled rounds prove nothing new was scheduled; more would just be waste.
+    expect(updateComplete).toHaveBeenCalledTimes(2);
+  });
+});

--- a/ui/src/test-helpers/lit-settle.test.ts
+++ b/ui/src/test-helpers/lit-settle.test.ts
@@ -59,7 +59,36 @@ describe("settleLitElement", () => {
     await expect(settleLitElement(element)).rejects.toThrow("render loop");
   });
 
-  it("returns without waiting on an already-settled element", async () => {
+  it("drains a deep promise chain that only schedules a render at its end", async () => {
+    // The shape the settled check alone cannot see: four inert microtask turns, then work
+    // that marks the element dirty. A pump that stopped at the first settled rounds would
+    // return before it.
+    let pendingRender = false;
+    let rendered = false;
+    const element = {
+      get updateComplete(): Promise<boolean> {
+        if (pendingRender) {
+          pendingRender = false;
+          rendered = true;
+          return Promise.resolve(false);
+        }
+        return Promise.resolve(true);
+      },
+    };
+    let chain = Promise.resolve();
+    for (let turn = 0; turn < 4; turn += 1) {
+      chain = chain.then(() => undefined);
+    }
+    void chain.then(() => {
+      pendingRender = true;
+    });
+
+    await settleLitElement(element);
+
+    expect(rendered).toBe(true);
+  });
+
+  it("keeps an unconditional floor of drain rounds for in-flight chains", async () => {
     const updateComplete = vi.fn(() => Promise.resolve(true));
     const element = {
       get updateComplete() {
@@ -69,7 +98,7 @@ describe("settleLitElement", () => {
 
     await settleLitElement(element);
 
-    // Two settled rounds prove nothing new was scheduled; more would just be waste.
-    expect(updateComplete).toHaveBeenCalledTimes(2);
+    // Never drains less than the fixed pump this helper replaced.
+    expect(updateComplete).toHaveBeenCalledTimes(5);
   });
 });

--- a/ui/src/test-helpers/lit-settle.ts
+++ b/ui/src/test-helpers/lit-settle.ts
@@ -9,15 +9,22 @@ type UpdatingElement = { updateComplete: Promise<boolean> };
 //
 // Loop instead until a whole round changes nothing: two consecutive settled updates with a
 // microtask turn between them means no chain resolved into a new render.
+//
+// A settled update alone is not quiescence: it only says that render did not reschedule
+// itself, so a promise chain that calls requestUpdate() at its end can still be in flight.
+// Keep an unconditional floor of turns for those, and treat the settled check as the part
+// that extends past it, so this drains at least as far as any fixed pump and further when
+// the work needs it.
+const MIN_DRAIN_ROUNDS = 5;
 const MAX_UPDATE_CYCLES = 50;
 const SETTLED_ROUNDS_REQUIRED = 2;
 
 export async function settleLitElement(element: UpdatingElement): Promise<void> {
   let settledRounds = 0;
-  for (let cycle = 0; cycle < MAX_UPDATE_CYCLES; cycle += 1) {
+  for (let cycle = 1; cycle <= MAX_UPDATE_CYCLES; cycle += 1) {
     await Promise.resolve();
     settledRounds = (await element.updateComplete) ? settledRounds + 1 : 0;
-    if (settledRounds >= SETTLED_ROUNDS_REQUIRED) {
+    if (cycle >= MIN_DRAIN_ROUNDS && settledRounds >= SETTLED_ROUNDS_REQUIRED) {
       return;
     }
   }

--- a/ui/src/test-helpers/lit-settle.ts
+++ b/ui/src/test-helpers/lit-settle.ts
@@ -15,6 +15,12 @@ type UpdatingElement = { updateComplete: Promise<boolean> };
 // Keep an unconditional floor of turns for those, and treat the settled check as the part
 // that extends past it, so this drains at least as far as any fixed pump and further when
 // the work needs it.
+//
+// Bounded on purpose, and not a proof of quiescence: a chain deeper than MAX_UPDATE_CYCLES
+// microtask turns that only marks the element dirty at its end can still outlive this. A
+// macrotask yield would drain any depth, but callers here run on fake timers where one
+// never fires. When a test asserts on work of unknown depth, wait for the condition with
+// vi.waitFor/expect.poll rather than reaching for a bigger settle.
 const MIN_DRAIN_ROUNDS = 5;
 const MAX_UPDATE_CYCLES = 50;
 const SETTLED_ROUNDS_REQUIRED = 2;

--- a/ui/src/test-helpers/lit-settle.ts
+++ b/ui/src/test-helpers/lit-settle.ts
@@ -1,0 +1,33 @@
+type UpdatingElement = { updateComplete: Promise<boolean> };
+
+// Settling a Lit tree needs two things that a fixed number of awaits only approximates:
+// pending promise chains (a route loader, a provider fetch) must get microtask turns to
+// resolve, and Lit resolves `updateComplete` to false when that update scheduled another.
+// A fixed pump returns while work remains, and a test that then asserts on a timer armed
+// by the missing cycle becomes order-dependent: the timer is armed inside the following
+// advanceTimersByTime window instead of at mount, so an exact deadline assertion misses.
+//
+// Loop instead until a whole round changes nothing: two consecutive settled updates with a
+// microtask turn between them means no chain resolved into a new render.
+const MAX_UPDATE_CYCLES = 50;
+const SETTLED_ROUNDS_REQUIRED = 2;
+
+export async function settleLitElement(element: UpdatingElement): Promise<void> {
+  let settledRounds = 0;
+  for (let cycle = 0; cycle < MAX_UPDATE_CYCLES; cycle += 1) {
+    await Promise.resolve();
+    settledRounds = (await element.updateComplete) ? settledRounds + 1 : 0;
+    if (settledRounds >= SETTLED_ROUNDS_REQUIRED) {
+      return;
+    }
+  }
+  throw new Error(
+    `Lit element still scheduling updates after ${MAX_UPDATE_CYCLES} cycles; it is likely in a render loop.`,
+  );
+}
+
+export async function settleLitElements(elements: Iterable<UpdatingElement>): Promise<void> {
+  for (const element of elements) {
+    await settleLitElement(element);
+  }
+}


### PR DESCRIPTION
## What Problem This Solves

Two Control UI tests failed only when the whole suite ran with a saturated
worker pool — together about one full run in four, which is frequent enough to
cost a CI retry regularly and to train everyone to re-run rather than read a red
result.

- `board-view.test.ts` > "schedules proactive refresh from a delayed mount's
  remaining ticket lifetime"
- `router-outlet.test.ts` > "waits out a restarting gateway before falling back
  to revalidation"

Neither reproduced in isolation, which is what made them easy to dismiss.

## Why This Change Was Made

They are the same class of defect: an assertion whose precision exceeds anything
the system actually guarantees.

The board tests advanced fake time 4,999ms, asserted nothing had fired, advanced
1ms, and asserted the refresh had. But the refresh timer is armed inside a render
cycle (`BoardWidgetTicketRefresh.schedule` runs from the frame controller's
`update()`), so its start is only as precise as when that cycle happens to run.
Under load the arming can land inside the following `advanceTimersByTime` window
and the 1ms landing zone is missed. What those tests exist to prove is that the
delay comes from the ticket's *remaining* lifetime rather than its full TTL, so
they now assert that band: still silent at 2s rules out the 1s floor, and having
fired by 8s rules out the 15s a full-TTL calculation would produce. Call count is
no longer pinned, because an unreplaced ticket keeps retrying — separate behavior
with its own test.

The router outlet settled by pumping a fixed five cycles of
`await Promise.resolve(); await outlet.updateComplete`. Lit resolves
`updateComplete` to false when that update scheduled another one, so a fixed pump
can return while work is outstanding. `settleLitElement` drains to the documented
settled state instead — two consecutive settled updates with a microtask turn
between them, so pending chains also get to resolve — and throws rather than
hanging if an element loops. It has its own unit coverage.

## User Impact

None. Test-only; no production file is touched.

## Evidence

Neither test reproduces in isolation, so the measurement is the failure rate over
consecutive full `node scripts/run-vitest.mjs ui` runs on this machine (16
workers). Per-run output below.

**Baseline, pristine `main`** — the board flake reproduced on the first run, which
is what started this:

```
run1: FAIL -> schedules proactive refresh from a delayed mount's remaining ticket lifetime
```

**With the settle helper only, before the assertion bands** (3/8 failed) — this is
the run set that proved my first hypothesis wrong: settling alone did not fix the
board test, which failed again on run5:

```
run1: Tests 6001 passed | 31 skipped (6032)
run2: FAIL -> shares an authenticated avatar blob between the same user in the roster and profile
run3: Tests 6001 passed | 31 skipped (6032)
run4: Tests 6001 passed | 31 skipped (6032)
run5: FAIL -> schedules proactive refresh from a delayed mount's remaining ticket lifetime
run6: Tests 6001 passed | 31 skipped (6032)
run7: FAIL -> shares an authenticated avatar blob between the same user in the roster and profile
run8: Tests 6001 passed | 31 skipped (6032)
```

**With both fixes** (1/8 failed, and only the unrelated third flake):

```
run1: Tests 6001 passed | 31 skipped (6032)
run2: Tests 6001 passed | 31 skipped (6032)
run3: Tests 6001 passed | 31 skipped (6032)
run4: Tests 6001 passed | 31 skipped (6032)
run5: FAIL -> shares an authenticated avatar blob between the same user in the roster and profile
run6: Tests 6001 passed | 31 skipped (6032)
run7: Tests 6001 passed | 31 skipped (6032)
run8: Tests 6001 passed | 31 skipped (6032)
```

So: the board delayed-mount flake is gone across 16 consecutive full runs since the
band fix, and `router-outlet` — seen once before any change — has not recurred in
those same 16 runs. `viewer-facepile` is unchanged and is the Known Gap below.

The widened bands were mutation-tested rather than assumed: making
`remainingBoardWidgetTicketTtlMs` always return the full TTL still fails the
delayed-mount test, so the assertion keeps the discrimination it exists for. Its
sibling passes under that mutation because with no mount delay the remaining
lifetime *is* the full TTL.

Gates: tsgo ui + test-ui, oxlint, oxfmt, and the full UI suite (6020 passed after
rebase). Exact-head CI green on `b79ae854`.

## Known Limitation

`settleLitElement` is bounded, not a proof of quiescence: no finite number of
microtask turns can establish that nothing further is coming, so a chain deeper
than the cycle cap that only marks the element dirty at its end can still outlive
it. That is stated at the code site rather than papered over.

It is kept anyway because it strictly dominates what it replaces — the same
unconditional five-turn floor, plus adaptive extension — so it cannot regress the
fixed pump. The unbounded fix is an explicit completion signal from the router and
provider, which means adding test-only observability to production code; that is a
larger design decision than a flake fix should make. For work of unknown depth the
right tool is a condition-based wait, which is what the board tests now use.

## Known Gap

The third flake, `viewer-facepile.test.ts` > "shares an authenticated avatar blob
between the same user in the roster and profile", is **not** fixed here and still
fails about 1 run in 8. It is a different mechanism: the avatar never resolves to
a blob URL at all, so it is not a timing budget. Raising the `vi.waitFor` timeout
to 10s did not help, and neither a same-origin cohort repro (10 runs) nor reading
the coalescing path in `identity-avatar.ts` pinned it. That change was reverted
rather than shipped as a fix it is not. Tracked for a separate PR.

## Review notes

Addressing the automated review's pre-merge list:

- **Real behavior proof** — added above as per-run output from the three measured
  run sets, including the set that disproved my first hypothesis.
- **Settling helper cap** — acknowledged and documented at the code site rather
  than claimed away; see Known Limitation. It strictly dominates the fixed pump it
  replaces, so it cannot regress current behavior.
- **Unavailable current-main / history / contract checks** — those items report
  that the review sandbox failed before it could inspect source, not a finding
  against this change. Nothing to apply.
