### PR TITLE
fix(telegram): keep media-less unmentioned group messages on the canonical mention gate

### DIFF
--- a/extensions/telegram/src/bot-handlers.inbound-media-group.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.inbound-media-group.runtime.ts
@@ -16,7 +16,7 @@ import { KeyedAsyncQueue } from "openclaw/plugin-sdk/keyed-async-queue";
 import { danger, warn } from "openclaw/plugin-sdk/runtime-env";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import { firstDefined, type NormalizedAllowFrom } from "./bot-access.js";
-import { isRecoverableMediaGroupError } from "./bot-handlers.media.js";
+import { hasInboundMedia, isRecoverableMediaGroupError } from "./bot-handlers.media.js";
 import type { TelegramHandlerMessageRuntime } from "./bot-handlers.message.runtime.js";
 import type { TelegramMediaRef } from "./bot-message-context.js";
 import type { TelegramAmbientTranscriptWatermark } from "./bot-message-context.types.js";
@@ -114,7 +114,11 @@ export function createTelegramInboundMediaGroupRuntime(
     const mayNeedDownload =
       !textParts.text.trim() &&
       Boolean(msg.audio ?? msg.voice ?? documentMime?.startsWith("audio/"));
-    if (!isGroup || mayNeedDownload) {
+    // Media-less messages have nothing to skip-download. They must reach the
+    // canonical mention gate (bot-message-context.body), which records group
+    // history, fires ingest hooks, and settles an explicit skipped result;
+    // consuming them here tombstones the ingress row without any trace.
+    if (!isGroup || !hasInboundMedia(msg) || mayNeedDownload) {
       return false;
     }
     const sessionState = resolveTelegramSessionState({

--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -2861,6 +2861,16 @@ describe("createTelegramBot", () => {
         type: "chat_window",
       },
     ]);
+    // Media-less unmentioned messages must reach the canonical mention gate so
+    // the rolling group history window records them (not just the reply cache).
+    expect(payload.InboundHistory).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          body: "Please run the maintenance step later.",
+          sender: "Requester id:111",
+        }),
+      ]),
+    );
   });
 
   it("excludes ambient transcript rows from live group conversation context", async () => {

--- a/extensions/telegram/src/telegram-ingress-drain.test.ts
+++ b/extensions/telegram/src/telegram-ingress-drain.test.ts
@@ -109,4 +109,38 @@ describe("createTelegramIngressMonitor", () => {
       await monitor.stop();
     });
   });
+
+  it("logs a diagnostic when dispatch records no outcome and defers no participant", async () => {
+    await withTempState(async (stateDir) => {
+      const queue = createChannelIngressQueueForTests<TelegramSpooledUpdatePayload>({
+        channelId: "telegram",
+        accountId: "default",
+        stateDir,
+      });
+      const eventId = "3".padStart(16, "0");
+      const payload = updatePayload(3);
+      const laneKey = telegramSpooledUpdateLaneKey(payload.update);
+      await queue.enqueue(eventId, payload, { laneKey });
+
+      const logs: string[] = [];
+      const monitor = createTelegramIngressMonitor({
+        queue,
+        cfg,
+        accountId: "default",
+        dispatch: async () => {},
+        onLog: (message) => logs.push(message),
+      });
+
+      monitor.start();
+      await monitor.waitForIdle();
+
+      // Silent consumption still completes (skip semantics), but must leave a trace.
+      const status = await queue.enqueue(eventId, payload, { laneKey });
+      expect(status.kind).toBe("completed");
+      expect(
+        logs.some((line) => line.includes("completed without a recorded processing outcome")),
+      ).toBe(true);
+      await monitor.stop();
+    });
+  });
 });

--- a/extensions/telegram/src/telegram-ingress-drain.ts
+++ b/extensions/telegram/src/telegram-ingress-drain.ts
@@ -191,6 +191,14 @@ export function createTelegramIngressMonitor(params: CreateTelegramIngressMonito
             };
           }
         }
+        if (!participant) {
+          // A dispatched update that records no outcome and defers no participant
+          // was consumed silently; completing here tombstones the spool row with
+          // attempts=0 and no trace, so keep a diagnostic trail for regressions.
+          params.onLog?.(
+            `telegram ingress: update ${resolveTelegramUpdateId(update) ?? "unknown"} completed without a recorded processing outcome`,
+          );
+        }
         await lifecycle.onAdopted();
         return { kind: "completed" };
       } catch (error) {


### PR DESCRIPTION
## What Problem This Solves

Issue #114561 reported a second Telegram group update being silently lost after the first turn: received, spooled, offset persisted, `resolveAgentRoute` logged twice, then nothing — and the ingress row tombstoned `status=completed, attempts=0` ~42ms after receipt.

Root cause (corrects the issue's diagnosis): the lost update in the repro had **no mention entity** (`gw.log` shows update 9001 with `entities:[{type:"mention"...}]`, update 9002 with none), and `requireMention` defaults to true for groups, so no reply was ever owed. The real defect is *how* the message was consumed: `shouldSkipMediaDownloadForUnaddressedMentionGroup` (`extensions/telegram/src/bot-handlers.inbound-media-group.runtime.ts`, from #81785) fires for **any** unmentioned group message — including pure text with nothing to download — and silently returns from `processInboundMessage` (`extensions/telegram/src/bot-handlers.inbound.runtime.ts`) before the dispatch pipeline. That bypasses the canonical mention gate (`extensions/telegram/src/bot-message-context.body.ts`), which:

- records the message into the rolling group-history window (`recordTelegramGroupHistoryEntry`) — so later mentioned turns lose ambient context,
- fires the group `ingest` internal hook,
- logs the skip, and
- settles an explicit `{kind:"skipped"}` processing result.

With no recorded result and no deferred participant, the durable ingress drain's absent-result fallthrough (`extensions/telegram/src/telegram-ingress-drain.ts` `deliver()`) completed the spool row silently — the exact `completed, attempts=0` signature in the issue. The two `resolveAgentRoute` lines are the two `resolveTelegramSessionState` calls (one in `handleInboundMessageLike`, one inside the fast-path predicate).

The fast path also duplicates the mention decision with weaker inputs than the canonical gate (no `providerMentionPatterns` / conversation policy in `buildMentionRegexes`, no rich-text or transcript matching), so a message addressed via configured mention patterns could be consumed with no recourse.

## Why This Change Was Made

- Restrict the pre-download fast path to messages that actually carry inbound media (`hasInboundMedia`), which is its stated purpose from #81785: avoid downloading media bytes for unaddressed group media. Media-less messages now flow to the canonical mention gate, restoring group-history recording, ingest hooks, the skip log, and an explicit skipped result settled through the spool participant.
- Add a drain-side diagnostic when a dispatched update completes with no recorded outcome and no deferred participant. The full invariant from the issue ("absent result must not tombstone") is not implementable at the drain without auditing every legitimate no-op handler path (bot-echoed messages, deduped updates, unhandled update kinds would wedge into retry/dead-letter noise); that audit belongs in a separate change. This diagnostic makes any future silent consumer greppable instead of invisible.

Known retained tradeoff (from #81785, unchanged): unaddressed group messages *with* media still skip before download and are not recorded into group history.

## User Impact

- Unmentioned group text messages are again recorded into the rolling group-history window, so a later mention sees the ambient conversation; group `ingest` hooks fire for them again.
- Messages addressed via configured mention patterns (without a native `@mention` entity) can no longer be silently consumed by the weaker fast-path mention check.
- The "received then vanished" signature from #114561 now leaves an explicit trail: canonical `skipping group message` log, ingress `dropped after Nms` debug line, and an explicitly skipped spool result.
- No change for DMs, mentioned messages, media albums, or groups with `requireMention: false`.

## Evidence

- Repro evidence for the corrected diagnosis: issue #114561's own verbose run shows update 9002 logged with no `entities` and the two routing lines coming from the fast path; reproduced deterministically with a mock Bot API + mock provider gateway.
- Focused tests:
  - `extensions/telegram/src/telegram-ingress-drain.test.ts` — new test: absent-outcome completion emits the diagnostic (plus existing tombstone/failed-retryable tests).
  - `extensions/telegram/src/bot.test.ts` — "keeps skipped group messages in default recent group history context" extended to assert the skipped message lands in `InboundHistory` (fails without the fix).
  - `bot.create-telegram-bot.channel-post-media.test.ts` + `bot.create-telegram-bot.media-group-skip-warning.test.ts` — media fast-path behavior unchanged (21 passed).
- Live gateway proof on this branch's dist (isolated `OPENCLAW_STATE_DIR`, mock Bot API + mock `openai-completions`, two-turn run with the second update armed at +75s):
  - Second update **with** mention entity: dispatched normally — second model call fired and the visible send `REPLY: 2+2 equals 4.` was delivered (`totalSends=2`). Mentioned second updates were never the loss vector.
  - Second update **without** mention (the issue's actual repro shape): no reply owed and none sent, but the previously silent vanish is now an explicit trail — `telegram ingress: chatId=-100777001 dropped after 6ms buffer=inbound-debounce` — with the spool row settled through the explicit skipped participant path; the new absent-outcome drain diagnostic fires in neither run.
- Pre-existing local failures on clean `origin/main` (44bcaa263c7), unrelated to this diff: `bot.test.ts` "excludes ambient transcript rows from live group conversation context" and three native-command tests in `bot.create-telegram-bot.test.ts` (timeout-scale, reproduced on pristine checkout).

## Real Telegram Proof (real bots, real group)

Requested by review: proof from a real setup rather than a mocked Bot API. Run against production Telegram with the dedicated QA driver/SUT bot pair in the shared QA group (ids redacted), gateway started from this branch's checkout, mock `openai-responses` provider with request logging (`requireMention: true` on the group — the exact default-shaped config from #114561):

1. **Unmentioned group text** (`History marker HM-id2ed1: the maintenance window moved to Friday.`): no reply from the SUT bot within a 20s observation window (`sutRepliedToMarker=false`), and no model request fired (request log unchanged) — correct requireMention behavior, now via the canonical gate.
2. **Mentioned probe** (`@<sut> Please answer with OPENCLAW_E2E_OK only.`): threaded reply `OPENCLAW_E2E_OK` to the probe message in ~3s.
3. **History restoration (the fix's core claim)**: the mentioned turn's model request context contains the phase-1 unmentioned marker text — with exactly one model request total (`mockRequests=1`). Without this fix, media-less unmentioned messages never reach `recordTelegramGroupHistoryEntry`, so the marker would be absent.

```json
{ "phaseA_noReplyToUnmentioned": true,
  "phaseB_mentionedProbePassed": true,
  "phaseC_markerInMentionedTurnContext": true,
  "mockRequests": 1, "pass": true }
```

Fixes #114561

