### PR TITLE
docs: remove retired diagnostics.cacheTrace detail fields from docs

### DIFF
--- a/docs/reference/prompt-caching.md
+++ b/docs/reference/prompt-caching.md
@@ -221,20 +221,15 @@ Why the assertions differ: Anthropic exposes explicit cache breakpoints and movi
 diagnostics:
   cacheTrace:
     enabled: true
-    filePath: "~/.openclaw/logs/cache-trace.jsonl" # optional
-    includeMessages: false # default true
-    includePrompt: false # default true
-    includeSystem: false # default true
 ```
+
+The `filePath` and content filters (`includeMessages`, `includePrompt`, `includeSystem`) were removed in a past release. Use the environment variables below instead.
 
 Defaults:
 
-| Key               | Default                                      |
-| ----------------- | -------------------------------------------- |
-| `filePath`        | `$OPENCLAW_STATE_DIR/logs/cache-trace.jsonl` |
-| `includeMessages` | `true`                                       |
-| `includePrompt`   | `true`                                       |
-| `includeSystem`   | `true`                                       |
+| Key       | Default                    |
+| --------- | -------------------------- |
+| `enabled` | `false`                    |
 
 ### Env toggles (one-off debugging)
 

--- a/docs/reference/prompt-caching.md
+++ b/docs/reference/prompt-caching.md
@@ -223,13 +223,13 @@ diagnostics:
     enabled: true
 ```
 
-The `filePath` and content filters (`includeMessages`, `includePrompt`, `includeSystem`) were removed in a past release.
+These fields (`filePath`, `includeMessages`, `includePrompt`, `includeSystem`) are retired. The config schema accepts only `enabled`; `openclaw doctor --fix` strips the rest.
 
 Defaults:
 
-| Key       | Default                    |
-| --------- | -------------------------- |
-| `enabled` | `false`                    |
+| Key       | Default |
+| --------- | ------- |
+| `enabled` | `false` |
 
 ### What to inspect
 

--- a/docs/reference/prompt-caching.md
+++ b/docs/reference/prompt-caching.md
@@ -223,7 +223,7 @@ diagnostics:
     enabled: true
 ```
 
-The `filePath` and content filters (`includeMessages`, `includePrompt`, `includeSystem`) were removed in a past release. Use the environment variables below instead.
+The `filePath` and content filters (`includeMessages`, `includePrompt`, `includeSystem`) were removed in a past release.
 
 Defaults:
 
@@ -231,19 +231,9 @@ Defaults:
 | --------- | -------------------------- |
 | `enabled` | `false`                    |
 
-### Env toggles (one-off debugging)
-
-| Variable                             | Effect                               |
-| ------------------------------------ | ------------------------------------ |
-| `OPENCLAW_CACHE_TRACE=1`             | Enables cache tracing                |
-| `OPENCLAW_CACHE_TRACE_FILE=path`     | Overrides output path                |
-| `OPENCLAW_CACHE_TRACE_MESSAGES=0\|1` | Toggles full message payload capture |
-| `OPENCLAW_CACHE_TRACE_PROMPT=0\|1`   | Toggles prompt text capture          |
-| `OPENCLAW_CACHE_TRACE_SYSTEM=0\|1`   | Toggles system prompt capture        |
-
 ### What to inspect
 
-- Cache trace events are JSONL with staged snapshots like `session:loaded`, `prompt:before`, `stream:context`, and `session:after`.
+- Cache trace events track staged snapshots like `session:loaded`, `prompt:before`, `stream:context`, and `session:after`.
 - Per-turn cache token impact is visible in normal usage surfaces: `cacheRead` and `cacheWrite` show up in `/usage tokens`, `/status`, session usage summaries, and custom `messages.usageTemplate` layouts.
 - For Anthropic, expect both `cacheRead` and `cacheWrite` when caching is active.
 - For OpenAI, expect `cacheRead` on cache hits; `cacheWrite` is populated only on Responses API payloads that include it (see [OpenAI](#openai-direct-api) above).

--- a/docs/reference/prompt-caching.md
+++ b/docs/reference/prompt-caching.md
@@ -223,7 +223,7 @@ diagnostics:
     enabled: true
 ```
 
-These fields (`filePath`, `includeMessages`, `includePrompt`, `includeSystem`) are retired. The config schema accepts only `enabled`; `openclaw doctor --fix` strips the rest.
+These fields (`filePath`, `includeMessages`, `includePrompt`, `includeSystem`) are retired from the JSON config schema, which accepts only `enabled`; `openclaw doctor --fix` strips the rest.
 
 Defaults:
 
@@ -231,9 +231,21 @@ Defaults:
 | --------- | ------- |
 | `enabled` | `false` |
 
+### Env toggles (environment-only one-off debugging)
+
+The environment controls remain active runtime overrides; they are not part of the JSON config schema.
+
+| Variable                             | Effect                               |
+| ------------------------------------ | ------------------------------------ |
+| `OPENCLAW_CACHE_TRACE=1`             | Enables cache tracing                |
+| `OPENCLAW_CACHE_TRACE_FILE=path`     | Overrides output path                |
+| `OPENCLAW_CACHE_TRACE_MESSAGES=0\|1` | Toggles full message payload capture |
+| `OPENCLAW_CACHE_TRACE_PROMPT=0\|1`   | Toggles prompt text capture          |
+| `OPENCLAW_CACHE_TRACE_SYSTEM=0\|1`   | Toggles system prompt capture        |
+
 ### What to inspect
 
-- Cache trace events track staged snapshots like `session:loaded`, `prompt:before`, `stream:context`, and `session:after`.
+- Cache trace events are JSONL with staged snapshots like `session:loaded`, `prompt:before`, `stream:context`, and `session:after`, written by default to `<state-dir>/logs/cache-trace.jsonl`.
 - Per-turn cache token impact is visible in normal usage surfaces: `cacheRead` and `cacheWrite` show up in `/usage tokens`, `/status`, session usage summaries, and custom `messages.usageTemplate` layouts.
 - For Anthropic, expect both `cacheRead` and `cacheWrite` when caching is active.
 - For OpenAI, expect `cacheRead` on cache hits; `cacheWrite` is populated only on Responses API payloads that include it (see [OpenAI](#openai-direct-api) above).


### PR DESCRIPTION
## What Problem This Solves

The `diagnostics.cacheTrace` config in `docs/reference/prompt-caching.md` still documents `filePath`, `includeMessages`, `includePrompt`, and `includeSystem` fields — all of which were retired.

## Why This Change Was Made

The runtime schema only accepts `{ enabled?: boolean }`. Doctor proactively strips extra fields. Showing retired fields misleads users.

## Evidence

- `src/config/zod-schema.root-shape.ts:97`: `z.strictObject({ enabled: z.boolean().optional() })`
- `src/commands/doctor/shared/legacy-config-migrations.runtime.retired.ts:236-243`: strips extra fields
- `src/config/dead-config-keys.test.ts:76`: `diagnostics.cacheTrace.filePath` listed as dead