### PR TITLE
docs: fix controlUi.root config using unexpanded tilde

### DIFF
--- a/docs/start/getting-started.md
+++ b/docs/start/getting-started.md
@@ -106,7 +106,7 @@ Then set:
   "gateway": {
     "controlUi": {
       "enabled": true,
-      "root": "~/.openclaw/control-ui-custom"
+      "root": "${HOME}/.openclaw/control-ui-custom"
     }
   }
 }


### PR DESCRIPTION
## What Problem This Solves

The `controlUi.root` config example uses `~/.openclaw/...`, but `path.resolve()` does not expand tilde — produces a literal `~` directory.

## Why This Change Was Made

Tilde is shell expansion, not Node.js path primitive. OpenClaw's env var substitution (`${HOME}`) is the correct way.

## Evidence

- `path.resolve('~/.openclaw/foo')` returns `<cwd>/~/.openclaw/foo`, not the home directory
- OpenClaw's env var substitution parses `${HOME}` correctly