### PR TITLE
docs: fix tilde paths in CLI output examples

### DIFF
--- a/docs/cli/config.md
+++ b/docs/cli/config.md
@@ -381,7 +381,7 @@ openclaw config set channels.discord.token \
     {
       "ok": true,
       "operations": 1,
-      "configPath": "~/.openclaw/openclaw.json",
+      "configPath": "/home/user/.openclaw/openclaw.json",
       "inputModes": ["builder"],
       "checks": {
         "schema": false,
@@ -398,7 +398,7 @@ openclaw config set channels.discord.token \
     {
       "ok": false,
       "operations": 1,
-      "configPath": "~/.openclaw/openclaw.json",
+      "configPath": "/home/user/.openclaw/openclaw.json",
       "inputModes": ["builder"],
       "checks": {
         "schema": false,


### PR DESCRIPTION
## What Problem This Solves

CLI output examples show `~/.openclaw/openclaw.json`, but the CLI always outputs absolute paths.

## Why This Change Was Made

Test at `src/cli/config-cli.test.ts:2461-2464` asserts `configPath` is absolute and not containing `~`.

## Evidence

- `src/cli/config-cli.test.ts:2461-2464`: `expect(path.isAbsolute(payload.configPath)).toBe(true)` and `expect(payload.configPath).not.toContain('~')`
- Docs now use `/home/user/.openclaw/openclaw.json`