### PR TITLE
fix(gateway): respect configured tools.media.image.maxBytes for image attachments

### DIFF
--- a/src/gateway/chat-attachments.test.ts
+++ b/src/gateway/chat-attachments.test.ts
@@ -32,6 +32,7 @@ import {
   parseMessageWithAttachments,
   persistInboundImagesForTranscript,
   resolveChatAttachmentMaxBytes,
+  resolveChatAttachmentMaxImageBytes,
   stripImageMediaMarkers,
   UnsupportedAttachmentError,
 } from "./chat-attachments.js";
@@ -578,6 +579,23 @@ describe("resolveChatAttachmentMaxBytes", () => {
   });
 });
 
+describe("resolveChatAttachmentMaxImageBytes", () => {
+  const MB = 1024 * 1024;
+
+  it("prioritises tools.media.image.maxBytes when configured", () => {
+    const cfg = {
+      tools: { media: { image: { maxBytes: 12 * MB } } },
+      agents: { defaults: { mediaMaxMb: 50 } },
+    } as unknown as OpenClawConfig;
+    expect(resolveChatAttachmentMaxImageBytes(cfg)).toBe(12 * MB);
+  });
+
+  it("falls back to agents.defaults.mediaMaxMb when image maxBytes is unset", () => {
+    const cfg = { agents: { defaults: { mediaMaxMb: 15 } } } as unknown as OpenClawConfig;
+    expect(resolveChatAttachmentMaxImageBytes(cfg)).toBe(15 * MB);
+  });
+});
+
 describe("attachment validation", () => {
   it("rejects invalid base64 content", async () => {
     const bad: ChatAttachment = {
@@ -611,5 +629,50 @@ describe("attachment validation", () => {
     } finally {
       fromSpy.mockRestore();
     }
+  });
+
+  it("respects configured maxImageBytes over default 6MB limit", async () => {
+    const customMaxImageBytes = 10 * 1024 * 1024; // 10MB
+    let base64Len = Math.ceil((7 * 1024 * 1024 * 4) / 3);
+    base64Len += (4 - (base64Len % 4)) % 4;
+    const pngHeader = PNG_1x1.slice(0, 64);
+    const sevenMbImageB64 = `${pngHeader}${"A".repeat(base64Len - pngHeader.length)}`;
+    const att: ChatAttachment = {
+      type: "image",
+      mimeType: "image/png",
+      fileName: "7mb.png",
+      content: sevenMbImageB64,
+    };
+
+    const parsed = await parseMessageWithAttachments("hello", [att], {
+      maxBytes: 20 * 1024 * 1024,
+      maxImageBytes: customMaxImageBytes,
+      log: { warn: () => {} },
+    });
+
+    try {
+      expect(parsed.offloadedRefs).toHaveLength(1);
+      expect(parsed.offloadedRefs[0]?.mimeType).toBe("image/png");
+    } finally {
+      await cleanupOffloadedRefs(parsed.offloadedRefs);
+    }
+
+    let overLimitLen = Math.ceil((12 * 1024 * 1024 * 4) / 3);
+    overLimitLen += (4 - (overLimitLen % 4)) % 4;
+    const twelveMbImageB64 = `${pngHeader}${"A".repeat(overLimitLen - pngHeader.length)}`;
+    const overAtt: ChatAttachment = {
+      type: "image",
+      mimeType: "image/png",
+      fileName: "12mb.png",
+      content: twelveMbImageB64,
+    };
+
+    await expect(
+      parseMessageWithAttachments("hello", [overAtt], {
+        maxBytes: 20 * 1024 * 1024,
+        maxImageBytes: customMaxImageBytes,
+        log: { warn: () => {} },
+      }),
+    ).rejects.toThrow(/image exceeds size limit/i);
   });
 });

--- a/src/gateway/chat-attachments.ts
+++ b/src/gateway/chat-attachments.ts
@@ -151,6 +151,27 @@ export function resolveChatAttachmentMaxBytes(cfg: OpenClawConfig): number {
   return Math.floor(mb * 1024 * 1024);
 }
 
+/** Resolve the maximum decoded attachment size accepted for chat image inputs. */
+export function resolveChatAttachmentMaxImageBytes(cfg: OpenClawConfig): number {
+  const configuredImageBytes = cfg.tools?.media?.image?.maxBytes;
+  if (
+    typeof configuredImageBytes === "number" &&
+    Number.isFinite(configuredImageBytes) &&
+    configuredImageBytes > 0
+  ) {
+    return Math.floor(configuredImageBytes);
+  }
+  const configuredMediaMb = cfg.agents?.defaults?.mediaMaxMb;
+  if (
+    typeof configuredMediaMb === "number" &&
+    Number.isFinite(configuredMediaMb) &&
+    configuredMediaMb > 0
+  ) {
+    return Math.floor(configuredMediaMb * 1024 * 1024);
+  }
+  return MAX_IMAGE_BYTES;
+}
+
 type UnsupportedAttachmentReason =
   | "empty-payload"
   | "text-only-image"
@@ -335,6 +356,7 @@ export async function parseMessageWithAttachments(
   attachments: ChatAttachment[] | undefined,
   opts?: {
     maxBytes?: number;
+    maxImageBytes?: number;
     log?: AttachmentLog;
     supportsImages?: boolean;
     supportsInlineImages?: boolean;
@@ -342,6 +364,7 @@ export async function parseMessageWithAttachments(
   },
 ): Promise<ParsedMessageWithImages> {
   const maxBytes = opts?.maxBytes ?? DEFAULT_CHAT_ATTACHMENT_MAX_MB * 1024 * 1024;
+  const maxImageBytes = opts?.maxImageBytes ?? MAX_IMAGE_BYTES;
   const log = opts?.log;
   const shouldForceImageOffload = opts?.supportsImages === false;
   const supportsInlineImages = opts?.supportsInlineImages !== false;
@@ -432,15 +455,15 @@ export async function parseMessageWithAttachments(
         );
       }
       // Agent-side hydration (loadImageFromRef via optimizeAndClampImage / GIF
-      // direct compare) caps at MAX_IMAGE_BYTES. Accepting images above that
+      // direct compare) caps at maxImageBytes. Accepting images above that
       // would offload a file the runner later drops to null — a successful
       // response with a silently missing image. Reject here so the client
       // sees an explicit 4xx. Non-image attachments keep the full maxBytes
       // ceiling because their host path (media facts → Read/Bash) doesn't
       // load into the model.
-      if (isImage && sizeBytes > MAX_IMAGE_BYTES) {
+      if (isImage && sizeBytes > maxImageBytes) {
         throw new Error(
-          `attachment ${label}: image exceeds size limit (${sizeBytes} > ${MAX_IMAGE_BYTES} bytes)`,
+          `attachment ${label}: image exceeds size limit (${sizeBytes} > ${maxImageBytes} bytes)`,
         );
       }
 

--- a/src/gateway/server-methods/agent-content-phase.ts
+++ b/src/gateway/server-methods/agent-content-phase.ts
@@ -34,6 +34,7 @@ import {
   logAttachmentFailure,
   parseMessageWithAttachments,
   resolveChatAttachmentMaxBytes,
+  resolveChatAttachmentMaxImageBytes,
   type ChatAttachment,
 } from "../chat-attachments.js";
 import {
@@ -125,6 +126,7 @@ export async function prepareAgentContentPhase(params: {
     try {
       const parsed = await parseMessageWithAttachments(message, params.normalizedAttachments, {
         maxBytes: resolveChatAttachmentMaxBytes(params.cfg),
+        maxImageBytes: resolveChatAttachmentMaxImageBytes(params.cfg),
         log: params.context.logGateway,
         supportsInlineImages,
         acceptNonImage: false,

--- a/src/gateway/server-methods/chat-send-attachments.ts
+++ b/src/gateway/server-methods/chat-send-attachments.ts
@@ -20,6 +20,7 @@ import {
   logAttachmentFailure,
   parseMessageWithAttachments,
   resolveChatAttachmentMaxBytes,
+  resolveChatAttachmentMaxImageBytes,
   stripImageMediaMarkers,
   UnsupportedAttachmentError,
 } from "../chat-attachments.js";
@@ -218,6 +219,7 @@ export async function prepareChatSendAttachments(params: {
             explicitOriginTargetsPlugin;
           const parsed = await parseMessageWithAttachments(inboundMessage, normalizedAttachments, {
             maxBytes: resolveChatAttachmentMaxBytes(cfg),
+            maxImageBytes: resolveChatAttachmentMaxImageBytes(cfg),
             log: context.logGateway,
             supportsImages,
             acceptNonImage: true,

--- a/src/gateway/server-node-events.runtime.ts
+++ b/src/gateway/server-node-events.runtime.ts
@@ -24,6 +24,7 @@ export {
   parseMessageWithAttachments,
   persistInboundImagesForTranscript,
   resolveChatAttachmentMaxBytes,
+  resolveChatAttachmentMaxImageBytes,
 } from "./chat-attachments.js";
 export { normalizeRpcAttachmentsToChatAttachments } from "./server-methods/attachment-normalize.js";
 export {

--- a/src/gateway/server-node-events.test.ts
+++ b/src/gateway/server-node-events.test.ts
@@ -107,6 +107,7 @@ const runtimeMocks = vi.hoisted(() => ({
   registerApnsRegistration: registerApnsRegistrationMock,
   requestHeartbeat: vi.fn(),
   resolveChatAttachmentMaxBytes: vi.fn(() => 20 * 1024 * 1024),
+  resolveChatAttachmentMaxImageBytes: vi.fn(() => 6 * 1024 * 1024),
   resolveGatewayModelSupportsImages: vi.fn(
     async ({
       loadGatewayModelCatalog,

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -44,6 +44,7 @@ import {
   registerApnsRegistration,
   requestHeartbeat,
   resolveChatAttachmentMaxBytes,
+  resolveChatAttachmentMaxImageBytes,
   resolveGatewayModelSupportsImages,
   resolveOutboundTarget,
   resolveSessionAgentId,
@@ -707,6 +708,7 @@ export const handleNodeEvent = async (
         try {
           const parsed = await parseMessageWithAttachments(message, normalizedAttachments, {
             maxBytes: resolveChatAttachmentMaxBytes(cfg),
+            maxImageBytes: resolveChatAttachmentMaxImageBytes(cfg),
             log: ctx.logGateway,
             supportsInlineImages,
             // server-node-events dispatches via agentCommandFromIngress which

--- a/src/media/configured-max-bytes.ts
+++ b/src/media/configured-max-bytes.ts
@@ -8,6 +8,14 @@ type GeneratedMediaKind = Extract<MediaKind, "audio" | "image" | "video">;
 
 /** Resolves the global generated-media byte cap from the user-facing MB config value. */
 export function resolveConfiguredMediaMaxBytes(cfg?: OpenClawConfig): number | undefined {
+  const configuredImageBytes = cfg?.tools?.media?.image?.maxBytes;
+  if (
+    typeof configuredImageBytes === "number" &&
+    Number.isFinite(configuredImageBytes) &&
+    configuredImageBytes > 0
+  ) {
+    return Math.floor(configuredImageBytes);
+  }
   const configured = cfg?.agents?.defaults?.mediaMaxMb;
   if (typeof configured === "number" && Number.isFinite(configured) && configured > 0) {
     return Math.floor(configured * MB);


### PR DESCRIPTION
Resolves #114102

## What Problem This Solves

Gateway chat attachment normalization rejects images above the hard-coded 6 MB `MAX_IMAGE_BYTES` ceiling, even when an operator configures a larger image limit. The configured value therefore cannot govern images entering through these gateway paths.

## Changes

1. Added `resolveChatAttachmentMaxImageBytes(cfg)` in `src/gateway/chat-attachments.ts`, resolving `tools.media.image.maxBytes`, then `agents.defaults.mediaMaxMb`, with the existing 6 MB constant as fallback.
2. Updated `parseMessageWithAttachments` to accept `maxImageBytes` and enforce that resolved limit.
3. Updated gateway attachment handlers (`chat-send-attachments.ts`, `agent-content-phase.ts`, and `server-node-events.ts`) to pass the resolved value.
4. Updated `resolveConfiguredMediaMaxBytes` in `src/media/configured-max-bytes.ts` to respect `tools.media.image.maxBytes`.
5. Added unit coverage for accepting images between the default and configured ceilings and rejecting images above the configured ceiling.
6. Exported the resolver through the server-node-events runtime barrel and aligned its test mock.

## Evidence

- `pnpm exec vitest run src/gateway/chat-attachments.test.ts src/gateway/server-node-events.test.ts`
  - 4 test files passed
  - 166 tests passed
- Current exact-head CI has passed `check-prod-types`, `check-test-types`, `check-lint`, and the gateway runtime boundary check.
- `pnpm exec oxlint src/gateway/server-node-events.runtime.ts src/gateway/server-node-events.test.ts` passed locally.
- `pnpm exec oxfmt --check src/gateway/server-node-events.runtime.ts src/gateway/server-node-events.test.ts` passed locally.
