### PR TITLE
fix(release): repair plugin prerelease contract gates

### DIFF
--- a/extensions/copilot/src/tool-bridge.test.ts
+++ b/extensions/copilot/src/tool-bridge.test.ts
@@ -266,8 +266,8 @@ describe("createCopilotToolBridge", () => {
         toolSearchCatalogExecutor: expect.any(Function),
       }),
     );
-    expect(result.sourceTools.map((tool) => tool.name)).toEqual(["tool_search_code"]);
-    expect(result.sdkTools.map((tool) => tool.name)).toEqual(["tool_search_code"]);
+    expect(result.sourceTools.map((tool) => tool.name)).toEqual(["tool_search_code", "read"]);
+    expect(result.sdkTools.map((tool) => tool.name)).toEqual(["tool_search_code", "read"]);
   });
 
   it("keeps tool_search controls visible when a narrow allowlist is active", async () => {
@@ -294,8 +294,8 @@ describe("createCopilotToolBridge", () => {
       sessionId: "session-1",
     });
 
-    expect(result.sourceTools.map((tool) => tool.name)).toEqual(["tool_search_code"]);
-    expect(result.sdkTools.map((tool) => tool.name)).toEqual(["tool_search_code"]);
+    expect(result.sourceTools.map((tool) => tool.name)).toEqual(["tool_search_code", "read"]);
+    expect(result.sdkTools.map((tool) => tool.name)).toEqual(["tool_search_code", "read"]);
   });
 
   it("filters the hidden tool_search catalog before compacting narrowed tools", async () => {

--- a/extensions/slack/src/monitor.tool-result.test.ts
+++ b/extensions/slack/src/monitor.tool-result.test.ts
@@ -686,34 +686,46 @@ describe("monitorSlackProvider tool results", () => {
     );
   });
 
-  it("keeps ack reaction when no reply is delivered and status reactions are disabled", async () => {
+  it("keeps ack reaction after sending the missing-reply fallback when status reactions are disabled", async () => {
     replyMock.mockResolvedValue(undefined);
     setMentionGatedAckConfig(false);
     mockGeneralChannelInfo();
     await runMentionGatedChannelMessage();
 
-    expect(sendMock).not.toHaveBeenCalled();
-    await vi.waitFor(() => expect(reactMock).toHaveBeenCalledTimes(1), { timeout: 5_000 });
-    expect(reactMock).toHaveBeenCalledWith({
-      channel: "C1",
-      timestamp: "456",
-      name: "eyes",
-    });
+    expect(sendMock).toHaveBeenCalledTimes(1);
+    expect(firstMockArg(sendMock, "send", 1)).toBe(
+      "PFX No reply was generated for this message. This is usually a temporary model failure - please try again.",
+    );
+    await vi.waitFor(
+      () =>
+        expect(reactMock).toHaveBeenCalledWith({
+          channel: "C1",
+          timestamp: "456",
+          name: "eyes",
+        }),
+      { timeout: 5_000 },
+    );
   });
 
-  it("keeps ack reaction when no reply is delivered and status reactions are enabled", async () => {
+  it("keeps ack reaction after sending the missing-reply fallback when status reactions are enabled", async () => {
     replyMock.mockResolvedValue(undefined);
     setMentionGatedAckConfig(true);
     mockGeneralChannelInfo();
     await runMentionGatedChannelMessage();
 
-    expect(sendMock).not.toHaveBeenCalled();
-    await vi.waitFor(() => expect(reactMock).toHaveBeenCalledTimes(1), { timeout: 5_000 });
-    expect(reactMock).toHaveBeenCalledWith({
-      channel: "C1",
-      timestamp: "456",
-      name: "eyes",
-    });
+    expect(sendMock).toHaveBeenCalledTimes(1);
+    expect(firstMockArg(sendMock, "send", 1)).toBe(
+      "PFX No reply was generated for this message. This is usually a temporary model failure - please try again.",
+    );
+    await vi.waitFor(
+      () =>
+        expect(reactMock).toHaveBeenCalledWith({
+          channel: "C1",
+          timestamp: "456",
+          name: "eyes",
+        }),
+      { timeout: 5_000 },
+    );
   });
 
   it("keeps status reactions for mentioned message-tool-only channel turns", async () => {

--- a/src/gateway/session-create-service.ts
+++ b/src/gateway/session-create-service.ts
@@ -606,6 +606,23 @@ export async function createGatewaySession(params: {
     key: targetSessionKey,
     agentId,
   });
+  if (explicitTargetKey && !params.initialEntry) {
+    // A trusted initializer holds the lifecycle fence through afterCreate. Waiting
+    // on that fence would deadlock callers that must reject its visible pending row.
+    const pendingEntry = resolveSessionEntryAccessTarget({
+      cfg: params.cfg,
+      sessionKey: creationTarget.canonicalKey,
+    }).entry;
+    if (pendingEntry?.initializationPending === true) {
+      return {
+        ok: false,
+        error: errorShape(
+          ErrorCodes.UNAVAILABLE,
+          `Session ${creationTarget.canonicalKey} is still initializing; retry creation later.`,
+        ),
+      };
+    }
+  }
   const agentMainSessionKey = resolveAgentMainSessionKey({ cfg: params.cfg, agentId });
   // Durable dashboard sessions parent to main for flow-up notices and sidebar threads.
   // Incognito roots omit durable lineage so notices cannot cross the storage boundary.


### PR DESCRIPTION
## What Problem This Solves

Fixes three failures exposed only by Full Release Validation's Plugin Prerelease sweep: ordinary session creation could wait forever behind a trusted initializer, Slack tests still expected mentioned turns with no model reply to remain silent, and Copilot tool-search tests omitted the now-always-visible `read` tool.

## Why This Change Was Made

Explicit session creates now fail fast when the persisted target row is visibly still initializing, while retaining the authoritative under-lock check for races. Slack and Copilot assertions are aligned with their already-landed runtime contracts instead of weakening those contracts.

Maintainer decision: accept the existing retryable `UNAVAILABLE` caller contract for explicit creates during trusted initialization; the fix makes that result prompt instead of waiting behind the initializer.

## User Impact

Concurrent session creation returns a clear retryable error instead of hanging behind trusted initialization. Mentioned Slack turns retain their user-visible missing-reply fallback, and Copilot keeps `read` directly available alongside tool search.

## Evidence

- `node scripts/run-vitest.mjs src/plugins/runtime/runtime-agent.test.ts --reporter=dot` — 24 tests passed.
- `node scripts/run-vitest.mjs extensions/slack/src/monitor.tool-result.test.ts --reporter=dot` — 29 tests passed.
- `node scripts/run-vitest.mjs extensions/copilot/src/tool-bridge.test.ts --reporter=dot` — 77 tests passed.
- Actual runtime + SQLite lifecycle proof (no mocks): an explicit ordinary create returned `UNAVAILABLE` in 2ms while trusted initialization was pending; after finalization cleared `initializationPending`, retry succeeded and reused the same session.
- `git diff --check` — clean.
- Autoreview: clean, no accepted/actionable findings.

AI-assisted; the full changed functions, owning tests, and lifecycle boundary were reviewed before submission.
