### PR TITLE
fix(read): explain directory paths

### DIFF
--- a/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
+++ b/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
@@ -9,6 +9,7 @@ import path from "node:path";
 import type { AgentTool, AgentToolResult } from "openclaw/plugin-sdk/agent-core";
 import { Type } from "typebox";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { replaceSessionEntry } from "../config/sessions/session-accessor.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -57,6 +58,7 @@ const tinyPngBuffer = Buffer.from(
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO2f7z8AAAAASUVORK5CYII=",
   "base64",
 );
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 const XAI_UNSUPPORTED_SCHEMA_KEYWORDS = new Set(["minContains", "maxContains"]);
 function collectActionValues(schema: unknown, values: Set<string>): void {
   if (!schema || typeof schema !== "object") {
@@ -2571,6 +2573,23 @@ describe("createOpenClawCodingTools read behavior", () => {
       await fs.rm(outsidePath, { force: true });
       await fs.rm(tmpDir, { recursive: true, force: true });
     }
+  });
+
+  it("rejects sandbox directory reads before calling the bridge read operation", async () => {
+    const tmpDir = tempDirs.make("openclaw-sbx-directory-");
+    const directoryName = "notes";
+    await fs.mkdir(path.join(tmpDir, directoryName));
+    const hostBridge = createHostSandboxFsBridge(tmpDir);
+    const readFile = vi.fn(hostBridge.readFile.bind(hostBridge));
+    const readTool = createSandboxedReadTool({
+      root: tmpDir,
+      bridge: { ...hostBridge, readFile },
+    });
+
+    await expect(readTool.execute("sandbox-directory", { path: directoryName })).rejects.toThrow(
+      `Read requires a file path, but ${directoryName} is a directory. List the directory, then read a specific file.`,
+    );
+    expect(readFile).not.toHaveBeenCalled();
   });
 
   it("auto-pages read output across chunks when context window budget allows", async () => {

--- a/src/agents/agent-tools.read.ts
+++ b/src/agents/agent-tools.read.ts
@@ -1090,6 +1090,9 @@ async function assertSandboxFileExists(params: SandboxToolParams, absolutePath: 
   if (!stat) {
     throw createFsAccessError("ENOENT", absolutePath);
   }
+  if (stat.type === "directory") {
+    throw createFsAccessError("EISDIR", absolutePath);
+  }
 }
 
 function expandTildeToOsHome(filePath: string): string {

--- a/src/agents/sessions/tools/read.test.ts
+++ b/src/agents/sessions/tools/read.test.ts
@@ -119,6 +119,17 @@ describe("read tool", () => {
     );
   });
 
+  it("explains that directory paths must be listed before reading a file", async () => {
+    const tempDir = tempDirs.make("openclaw-read-directory-");
+    const tool = createReadToolDefinition(tempDir);
+
+    await expect(
+      tool.execute("call-directory", { path: "." }, undefined, undefined, {} as never),
+    ).rejects.toThrow(
+      "Read requires a file path, but . is a directory. List the directory, then read a specific file.",
+    );
+  });
+
   it("shell-quotes the long-first-line fallback path", async () => {
     // The fallback command is shown to the model; quote the path so suggested
     // follow-up commands cannot execute path text as shell syntax.

--- a/src/agents/sessions/tools/read.ts
+++ b/src/agents/sessions/tools/read.ts
@@ -3,7 +3,7 @@ import { access as fsAccess, readFile as fsReadFile } from "node:fs/promises";
 import { basename, dirname, isAbsolute, relative, resolve as resolvePath, sep } from "node:path";
 import { Text } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
-import { toErrorObject } from "../../../infra/errors.js";
+import { hasErrnoCode, toErrorObject } from "../../../infra/errors.js";
 import { decodeWindowsTextFileBuffer } from "../../../infra/windows-encoding.js";
 import type { ImageContent, Model, TextContent } from "../../../llm/types.js";
 import {
@@ -119,6 +119,16 @@ function createReadDetails(
   }
   return { kind: "text", content: text };
 }
+
+function normalizeReadError(error: unknown, filePath: string): Error {
+  if (hasErrnoCode(error, "EISDIR")) {
+    return new Error(
+      `Read requires a file path, but ${filePath} is a directory. List the directory, then read a specific file.`,
+    );
+  }
+  return toErrorObject(error, "Non-Error rejection");
+}
+
 interface CompactReadClassification {
   kind: "docs" | "resource" | "skill";
   label: string;
@@ -481,7 +491,7 @@ export function createReadToolDefinition(
           } catch (error: unknown) {
             signal?.removeEventListener("abort", onAbort);
             if (!aborted) {
-              reject(toErrorObject(error, "Non-Error rejection"));
+              reject(normalizeReadError(error, path));
             }
           }
         })();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users or agents that passed a directory to the read tool received a raw `EISDIR` failure with no useful recovery direction. The same path could behave differently between local and sandbox-backed reads.

## Why This Change Was Made

Normalize the filesystem's real `EISDIR` result at the read-tool error boundary, and reject directories at the sandbox bridge owner before its file-read operation. Both paths now return the same actionable instruction without adding a new read API, config surface, or fallback path.

## User Impact

Directory mistakes now explain that read requires a file path and tell the agent to list the directory before choosing a file. Ordinary file reads are unchanged.

## Evidence

- Final rewritten head: `949e7b76fd71fc324e27b6f208ff8edc7711746d`, based on `63651a1878f3d9d6b6de1cb9d2ac3789e5528562`.
- Focused regressions: `node scripts/run-vitest.mjs src/agents/sessions/tools/read.test.ts src/agents/agent-tools.create-openclaw-coding-tools.test.ts` -> 131/131 passed on the final rebased diff.
- Stress proof: the same two-file lane passed three bounded repetitions, 393/393 assertions.
- Core and core-test typechecks passed; the core-test rerun used a full, deep-linked GWT after the sparse GWT correctly exposed a missing workspace link rather than a code failure.
- `oxfmt`, focused `oxlint`, temp-directory policy, `git diff --check`, and TruffleHog passed.
- Exact-base branch autoreview: no findings, patch correct, confidence 0.99.
- The remote Testbox attempt was cancelled after its GitHub checkout stalled before repository code or tests ran; local fallback followed repository policy.
- Production delta: +15/-2; tests: +30/-0.

Co-authored with the original contributor. AI-assisted; all changes and evidence were reviewed by the maintainer.
