### PR TITLE
fix(openai): materialize proxy subscription routes

### DIFF
--- a/extensions/openai/openai-provider.test.ts
+++ b/extensions/openai/openai-provider.test.ts
@@ -1012,6 +1012,43 @@ describe("buildOpenAIProvider", () => {
     expect(new Headers(request?.init?.headers).get("ChatGPT-Account-ID")).toBeNull();
   });
 
+  it("discovers proxy models from a materialized token without reloading its SecretRef", async () => {
+    const proxyBaseUrl = "http://127.0.0.1:7862/backend-api/codex";
+    const fetchGuard: LiveModelCatalogFetchGuard = vi.fn(async (params) => ({
+      response: Response.json({
+        models: [
+          {
+            slug: "gpt-5.6-sol",
+            display_name: "GPT-5.6 Sol",
+            visibility: "list",
+            supported_reasoning_levels: ["high", "xhigh"],
+          },
+        ],
+      }),
+      finalUrl: params.url,
+      release: async () => undefined,
+    }));
+
+    const provider = await runCatalogWithFetchGuard({
+      auth: {
+        mode: "token",
+        apiKey: "materialized-loopback-capability",
+        profileId: "openai:mlclaw",
+        source: "profile",
+      },
+      codexProxyBaseUrl: proxyBaseUrl,
+      fetchGuard,
+    });
+
+    expect(provider.models).toEqual([
+      expect.objectContaining({ id: "gpt-5.6-sol", baseUrl: proxyBaseUrl }),
+    ]);
+    expect(mocks.resolveApiKeyForProvider).not.toHaveBeenCalled();
+    expect(
+      new Headers(vi.mocked(fetchGuard).mock.calls[0]?.[0].init?.headers).get("Authorization"),
+    ).toBe("Bearer materialized-loopback-capability");
+  });
+
   it("rejects remote Codex proxy URLs before sending a token", async () => {
     const fetchGuard: LiveModelCatalogFetchGuard = vi.fn();
 
@@ -1811,6 +1848,70 @@ describe("buildOpenAIProvider", () => {
         config,
       } as never),
     ).toMatchObject({ effort: "xhigh", transport: "sse" });
+  });
+
+  it("warms credential-scoped proxy metadata before dynamic model materialization", async () => {
+    const proxyBaseUrl = "http://127.0.0.1:7862/backend-api/codex";
+    mocks.resolveApiKeyForProvider.mockResolvedValue({
+      mode: "token",
+      apiKey: "materialized-loopback-capability",
+      source: "profile:openai:mlclaw",
+      profileId: "openai:mlclaw",
+    });
+    mocks.resolveProviderAuthProfileMetadata.mockReturnValue({ profileId: "openai:mlclaw" });
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      Response.json({
+        models: [
+          {
+            slug: "gpt-5.6-sol",
+            display_name: "GPT-5.6 Sol",
+            visibility: "list",
+            supported_reasoning_levels: ["high", "xhigh"],
+          },
+        ],
+      }),
+    );
+    const provider = buildOpenAIProvider();
+    const context = {
+      provider: "openai",
+      modelId: "gpt-5.6-sol",
+      modelRegistry: { find: () => null },
+      agentDir: "/tmp/openai-agent",
+      workspaceDir: "/tmp/openai-workspace",
+      authProfileId: "openai:mlclaw",
+      authProfileMode: "token",
+      providerConfig: {
+        api: "openai-chatgpt-responses",
+        baseUrl: proxyBaseUrl,
+        models: [],
+      },
+      config: {
+        models: {
+          providers: {
+            openai: {
+              params: { codexProxyBaseUrl: proxyBaseUrl },
+            },
+          },
+        },
+      },
+    } as never;
+
+    try {
+      await provider.prepareDynamicModel?.(context);
+      expect(provider.resolveDynamicModel?.(context)).toMatchObject({
+        provider: "openai",
+        id: "gpt-5.6-sol",
+        name: "GPT-5.6 Sol",
+        api: "openai-chatgpt-responses",
+        baseUrl: proxyBaseUrl,
+      });
+      expect(fetchSpy).toHaveBeenCalledOnce();
+      expect(new Headers(fetchSpy.mock.calls[0]?.[1]?.headers).get("Authorization")).toBe(
+        "Bearer materialized-loopback-capability",
+      );
+    } finally {
+      fetchSpy.mockRestore();
+    }
   });
 
   it("keeps loopback proxy capabilities out of remote usage endpoints", () => {

--- a/extensions/openai/openai-provider.test.ts
+++ b/extensions/openai/openai-provider.test.ts
@@ -1012,43 +1012,6 @@ describe("buildOpenAIProvider", () => {
     expect(new Headers(request?.init?.headers).get("ChatGPT-Account-ID")).toBeNull();
   });
 
-  it("discovers proxy models from a materialized token without reloading its SecretRef", async () => {
-    const proxyBaseUrl = "http://127.0.0.1:7862/backend-api/codex";
-    const fetchGuard: LiveModelCatalogFetchGuard = vi.fn(async (params) => ({
-      response: Response.json({
-        models: [
-          {
-            slug: "gpt-5.6-sol",
-            display_name: "GPT-5.6 Sol",
-            visibility: "list",
-            supported_reasoning_levels: ["high", "xhigh"],
-          },
-        ],
-      }),
-      finalUrl: params.url,
-      release: async () => undefined,
-    }));
-
-    const provider = await runCatalogWithFetchGuard({
-      auth: {
-        mode: "token",
-        apiKey: "materialized-loopback-capability",
-        profileId: "openai:mlclaw",
-        source: "profile",
-      },
-      codexProxyBaseUrl: proxyBaseUrl,
-      fetchGuard,
-    });
-
-    expect(provider.models).toEqual([
-      expect.objectContaining({ id: "gpt-5.6-sol", baseUrl: proxyBaseUrl }),
-    ]);
-    expect(mocks.resolveApiKeyForProvider).not.toHaveBeenCalled();
-    expect(
-      new Headers(vi.mocked(fetchGuard).mock.calls[0]?.[0].init?.headers).get("Authorization"),
-    ).toBe("Bearer materialized-loopback-capability");
-  });
-
   it("rejects remote Codex proxy URLs before sending a token", async () => {
     const fetchGuard: LiveModelCatalogFetchGuard = vi.fn();
 
@@ -1859,7 +1822,7 @@ describe("buildOpenAIProvider", () => {
       profileId: "openai:mlclaw",
     });
     mocks.resolveProviderAuthProfileMetadata.mockReturnValue({ profileId: "openai:mlclaw" });
-    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
       Response.json({
         models: [
           {
@@ -1871,6 +1834,7 @@ describe("buildOpenAIProvider", () => {
         ],
       }),
     );
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(1_000_000);
     const provider = buildOpenAIProvider();
     const context = {
       provider: "openai",
@@ -1905,11 +1869,16 @@ describe("buildOpenAIProvider", () => {
         api: "openai-chatgpt-responses",
         baseUrl: proxyBaseUrl,
       });
+      await provider.prepareDynamicModel?.(context);
       expect(fetchSpy).toHaveBeenCalledOnce();
+      nowSpy.mockReturnValue(1_060_001);
+      await provider.prepareDynamicModel?.(context);
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
       expect(new Headers(fetchSpy.mock.calls[0]?.[1]?.headers).get("Authorization")).toBe(
         "Bearer materialized-loopback-capability",
       );
     } finally {
+      nowSpy.mockRestore();
       fetchSpy.mockRestore();
     }
   });

--- a/extensions/openai/openai-provider.ts
+++ b/extensions/openai/openai-provider.ts
@@ -70,11 +70,42 @@ import { resolveUnifiedOpenAIThinkingProfile } from "./thinking-policy.js";
 
 const PROVIDER_ID = "openai";
 const OPENAI_CODEX_DYNAMIC_MODEL_TTL_MS = 60_000;
+const OPENAI_CODEX_DYNAMIC_MODEL_CACHE_MAX = 256;
 
 type PreparedCodexModel = {
   expiresAt: number;
   model: ProviderRuntimeModel;
 };
+
+function readPreparedCodexModel(
+  cache: Map<string, PreparedCodexModel>,
+  key: string,
+): ProviderRuntimeModel | undefined {
+  const prepared = cache.get(key);
+  if (!prepared) return undefined;
+  if (prepared.expiresAt <= Date.now()) {
+    cache.delete(key);
+    return undefined;
+  }
+  return prepared.model;
+}
+
+function writePreparedCodexModel(
+  cache: Map<string, PreparedCodexModel>,
+  key: string,
+  model: ProviderRuntimeModel,
+): void {
+  const now = Date.now();
+  for (const [candidateKey, candidate] of cache) {
+    if (candidate.expiresAt <= now) cache.delete(candidateKey);
+  }
+  while (cache.size >= OPENAI_CODEX_DYNAMIC_MODEL_CACHE_MAX) {
+    const oldestKey = cache.keys().next().value;
+    if (oldestKey === undefined) break;
+    cache.delete(oldestKey);
+  }
+  cache.set(key, { expiresAt: now + OPENAI_CODEX_DYNAMIC_MODEL_TTL_MS, model });
+}
 
 function preparedCodexModelKey(ctx: ProviderResolveDynamicModelContext): string {
   return [
@@ -1012,21 +1043,18 @@ export function buildOpenAIProvider(): ProviderPlugin {
         try {
           const { resolveApiKeyForProvider, resolveProviderAuthProfileMetadata } =
             await import("openclaw/plugin-sdk/provider-auth-runtime");
-          const runtimeAuth =
-            auth.mode === "token" && auth.apiKey
-              ? auth
-              : await resolveApiKeyForProvider({
-                  provider: PROVIDER_ID,
-                  cfg: ctx.config,
-                  ...(ctx.agentDir ? { agentDir: ctx.agentDir } : {}),
-                  ...(ctx.workspaceDir ? { workspaceDir: ctx.workspaceDir } : {}),
-                  ...(auth.profileId
-                    ? {
-                        profileId: auth.profileId,
-                        lockedProfile: true,
-                      }
-                    : {}),
-                });
+          const runtimeAuth = await resolveApiKeyForProvider({
+            provider: PROVIDER_ID,
+            cfg: ctx.config,
+            ...(ctx.agentDir ? { agentDir: ctx.agentDir } : {}),
+            ...(ctx.workspaceDir ? { workspaceDir: ctx.workspaceDir } : {}),
+            ...(auth.profileId
+              ? {
+                  profileId: auth.profileId,
+                  lockedProfile: true,
+                }
+              : {}),
+          });
           if (runtimeAuth && isCodexCatalogAuthMode(runtimeAuth.mode) && runtimeAuth.apiKey) {
             const metadata = resolveProviderAuthProfileMetadata({
               provider: PROVIDER_ID,
@@ -1089,7 +1117,7 @@ export function buildOpenAIProvider(): ProviderPlugin {
         return;
       }
       const key = preparedCodexModelKey(ctx);
-      if ((preparedCodexModels.get(key)?.expiresAt ?? 0) > Date.now()) {
+      if (readPreparedCodexModel(preparedCodexModels, key)) {
         return;
       }
       const { resolveApiKeyForProvider, resolveProviderAuthProfileMetadata } =
@@ -1123,25 +1151,20 @@ export function buildOpenAIProvider(): ProviderPlugin {
         (candidate) => normalizeOpenAIModelRouteId(candidate.id) === modelId,
       );
       if (model) {
-        preparedCodexModels.set(key, {
-          expiresAt: Date.now() + OPENAI_CODEX_DYNAMIC_MODEL_TTL_MS,
-          model: {
-            ...model,
-            provider: PROVIDER_ID,
-            api: model.api ?? "openai-chatgpt-responses",
-            baseUrl: model.baseUrl ?? provider.baseUrl,
-            input: model.input.filter(
-              (input): input is "text" | "image" => input === "text" || input === "image",
-            ),
-          },
+        writePreparedCodexModel(preparedCodexModels, key, {
+          ...model,
+          provider: PROVIDER_ID,
+          api: model.api ?? "openai-chatgpt-responses",
+          baseUrl: model.baseUrl ?? provider.baseUrl,
+          input: model.input.filter(
+            (input): input is "text" | "image" => input === "text" || input === "image",
+          ),
         });
       }
     },
     resolveDynamicModel: (ctx) => {
-      const prepared = preparedCodexModels.get(preparedCodexModelKey(ctx));
-      if (prepared && prepared.expiresAt > Date.now()) {
-        return prepared.model;
-      }
+      const prepared = readPreparedCodexModel(preparedCodexModels, preparedCodexModelKey(ctx));
+      if (prepared) return prepared;
       return shouldResolveDynamicModelThroughCodex(ctx)
         ? codexHooks.resolveDynamicModel?.(withOpenAICodexProxyRoute(ctx))
         : resolveOpenAIGptForwardCompatModel(ctx);

--- a/extensions/openai/openai-provider.ts
+++ b/extensions/openai/openai-provider.ts
@@ -69,6 +69,22 @@ import {
 import { resolveUnifiedOpenAIThinkingProfile } from "./thinking-policy.js";
 
 const PROVIDER_ID = "openai";
+const OPENAI_CODEX_DYNAMIC_MODEL_TTL_MS = 60_000;
+
+type PreparedCodexModel = {
+  expiresAt: number;
+  model: ProviderRuntimeModel;
+};
+
+function preparedCodexModelKey(ctx: ProviderResolveDynamicModelContext): string {
+  return [
+    ctx.agentDir ?? "",
+    ctx.workspaceDir ?? "",
+    ctx.authProfileId ?? "",
+    resolveOpenAICodexProxyBaseUrl(ctx.config) ?? "",
+    normalizeOpenAIModelRouteId(ctx.modelId),
+  ].join("\u0000");
+}
 
 // OpenAI-native error codes stay with the OpenAI provider hook.
 function classifyOpenAiFailoverCode(code: string | undefined) {
@@ -957,6 +973,7 @@ export function buildOpenAIProvider(): ProviderPlugin {
   const codexHooks = buildOpenAICodexProviderHooks();
   const codexResponsesHooks = buildOpenAIResponsesProviderHooks();
   const responsesHooks = buildOpenAIResponsesProviderHooks({ transport: "sse" });
+  const preparedCodexModels = new Map<string, PreparedCodexModel>();
   return {
     id: PROVIDER_ID,
     label: "OpenAI",
@@ -995,18 +1012,21 @@ export function buildOpenAIProvider(): ProviderPlugin {
         try {
           const { resolveApiKeyForProvider, resolveProviderAuthProfileMetadata } =
             await import("openclaw/plugin-sdk/provider-auth-runtime");
-          const runtimeAuth = await resolveApiKeyForProvider({
-            provider: PROVIDER_ID,
-            cfg: ctx.config,
-            ...(ctx.agentDir ? { agentDir: ctx.agentDir } : {}),
-            ...(ctx.workspaceDir ? { workspaceDir: ctx.workspaceDir } : {}),
-            ...(auth.profileId
-              ? {
-                  profileId: auth.profileId,
-                  lockedProfile: true,
-                }
-              : {}),
-          });
+          const runtimeAuth =
+            auth.mode === "token" && auth.apiKey
+              ? auth
+              : await resolveApiKeyForProvider({
+                  provider: PROVIDER_ID,
+                  cfg: ctx.config,
+                  ...(ctx.agentDir ? { agentDir: ctx.agentDir } : {}),
+                  ...(ctx.workspaceDir ? { workspaceDir: ctx.workspaceDir } : {}),
+                  ...(auth.profileId
+                    ? {
+                        profileId: auth.profileId,
+                        lockedProfile: true,
+                      }
+                    : {}),
+                });
           if (runtimeAuth && isCodexCatalogAuthMode(runtimeAuth.mode) && runtimeAuth.apiKey) {
             const metadata = resolveProviderAuthProfileMetadata({
               provider: PROVIDER_ID,
@@ -1061,10 +1081,71 @@ export function buildOpenAIProvider(): ProviderPlugin {
       order: "simple",
       run: async () => ({ providers: { [PROVIDER_ID]: OPENAI_MANIFEST_PROVIDER } }),
     },
-    resolveDynamicModel: (ctx) =>
-      shouldResolveDynamicModelThroughCodex(ctx)
+    prepareDynamicModel: async (ctx) => {
+      if (
+        !shouldResolveDynamicModelThroughCodex(ctx) ||
+        !resolveOpenAICodexProxyBaseUrl(ctx.config)
+      ) {
+        return;
+      }
+      const key = preparedCodexModelKey(ctx);
+      if ((preparedCodexModels.get(key)?.expiresAt ?? 0) > Date.now()) {
+        return;
+      }
+      const { resolveApiKeyForProvider, resolveProviderAuthProfileMetadata } =
+        await import("openclaw/plugin-sdk/provider-auth-runtime");
+      const runtimeAuth = await resolveApiKeyForProvider({
+        provider: PROVIDER_ID,
+        cfg: ctx.config ?? {},
+        ...(ctx.agentDir ? { agentDir: ctx.agentDir } : {}),
+        ...(ctx.workspaceDir ? { workspaceDir: ctx.workspaceDir } : {}),
+        ...(ctx.authProfileId ? { profileId: ctx.authProfileId, lockedProfile: true } : {}),
+      });
+      if (!runtimeAuth?.apiKey || !isCodexCatalogAuthMode(runtimeAuth.mode)) {
+        return;
+      }
+      const metadata = resolveProviderAuthProfileMetadata({
+        provider: PROVIDER_ID,
+        cfg: ctx.config ?? {},
+        ...(ctx.agentDir ? { agentDir: ctx.agentDir } : {}),
+        ...((runtimeAuth.profileId ?? ctx.authProfileId)
+          ? { profileId: runtimeAuth.profileId ?? ctx.authProfileId }
+          : {}),
+      });
+      const provider = await buildOpenAICodexLiveProviderConfig({
+        discoveryApiKey: runtimeAuth.apiKey,
+        accountId: metadata.accountId,
+        baseUrl: resolveOpenAICodexProxyBaseUrl(ctx.config),
+        auth: runtimeAuth.mode,
+      });
+      const modelId = normalizeOpenAIModelRouteId(ctx.modelId);
+      const model = provider.models.find(
+        (candidate) => normalizeOpenAIModelRouteId(candidate.id) === modelId,
+      );
+      if (model) {
+        preparedCodexModels.set(key, {
+          expiresAt: Date.now() + OPENAI_CODEX_DYNAMIC_MODEL_TTL_MS,
+          model: {
+            ...model,
+            provider: PROVIDER_ID,
+            api: model.api ?? "openai-chatgpt-responses",
+            baseUrl: model.baseUrl ?? provider.baseUrl,
+            input: model.input.filter(
+              (input): input is "text" | "image" => input === "text" || input === "image",
+            ),
+          },
+        });
+      }
+    },
+    resolveDynamicModel: (ctx) => {
+      const prepared = preparedCodexModels.get(preparedCodexModelKey(ctx));
+      if (prepared && prepared.expiresAt > Date.now()) {
+        return prepared.model;
+      }
+      return shouldResolveDynamicModelThroughCodex(ctx)
         ? codexHooks.resolveDynamicModel?.(withOpenAICodexProxyRoute(ctx))
-        : resolveOpenAIGptForwardCompatModel(ctx),
+        : resolveOpenAIGptForwardCompatModel(ctx);
+    },
     preferRuntimeResolvedModel: (ctx) => codexHooks.preferRuntimeResolvedModel?.(ctx) ?? false,
     normalizeResolvedModel: (ctx) => {
       if (!isOpenAIProvider(ctx.provider)) {

--- a/extensions/openai/provider-policy-api.ts
+++ b/extensions/openai/provider-policy-api.ts
@@ -11,6 +11,7 @@ import type {
 } from "openclaw/plugin-sdk/provider-model-types";
 import {
   classifyOpenAIBaseUrl,
+  normalizeOpenAICodexLoopbackBaseUrl,
   OPENAI_API_BASE_URL,
   OPENAI_CODEX_RESPONSES_BASE_URL,
 } from "./base-url.js";
@@ -304,10 +305,13 @@ function resolveSingleObservedModelRoute(
     },
     sourceBaseUrl,
   );
+  const codexProxyBaseUrl = normalizeOpenAICodexLoopbackBaseUrl(
+    context.configuredProviderParams?.codexProxyBaseUrl,
+  );
   const chatGPTRoute = withRuntimePolicy(
     {
       api: OPENAI_CHATGPT_RESPONSES_API,
-      baseUrl: OPENAI_CODEX_RESPONSES_BASE_URL,
+      baseUrl: codexProxyBaseUrl ?? OPENAI_CODEX_RESPONSES_BASE_URL,
       authRequirement: "subscription",
       requestTransportOverrides,
     },

--- a/src/agents/openai-model-routes.test.ts
+++ b/src/agents/openai-model-routes.test.ts
@@ -28,6 +28,37 @@ describe("OpenAI model route adapter", () => {
     });
   });
 
+  it("projects a configured loopback proxy onto subscription route selection", () => {
+    expect(
+      resolveOpenAIModelRoutes({
+        provider: "openai",
+        modelId: "gpt-5.4",
+        config: {
+          models: {
+            providers: {
+              openai: {
+                params: {
+                  codexProxyBaseUrl: "http://127.0.0.1:7862/backend-api/codex",
+                },
+              },
+            },
+          },
+        } as unknown as OpenClawConfig,
+        env: {},
+      }),
+    ).toMatchObject({
+      kind: "routes",
+      routes: [
+        { api: "openai-responses", authRequirement: "api-key" },
+        {
+          api: "openai-chatgpt-responses",
+          baseUrl: "http://127.0.0.1:7862/backend-api/codex",
+          authRequirement: "subscription",
+        },
+      ],
+    });
+  });
+
   it("ignores other providers", () => {
     expect(resolveOpenAIModelRoutes({ provider: "anthropic", modelId: "gpt-5.5" })).toBeNull();
   });

--- a/src/commands/doctor/shared/codex-route-model-ref.ts
+++ b/src/commands/doctor/shared/codex-route-model-ref.ts
@@ -26,7 +26,8 @@ export function readLegacyDefaultsRuntime(defaults: unknown): AgentRuntimePolicy
   return asAgentRuntimePolicyConfig(asMutableRecord(defaults)?.agentRuntime);
 }
 
-const LEGACY_CODEX_PROVIDER_IDS = new Set(["codex", "openai-codex"]);
+const MLCLAW_CODEX_PROVIDER_ID = "mlclaw-codex";
+const LEGACY_CODEX_PROVIDER_IDS = new Set(["codex", "openai-codex", MLCLAW_CODEX_PROVIDER_ID]);
 
 export type LegacyCodexModelIdentity = string;
 
@@ -110,6 +111,16 @@ export function isBlockedLegacyCodexModelPair(params: {
     Boolean(providerIdentity && params.blockedModelIdentities.has(providerIdentity)) ||
     Boolean(modelIdentity && params.blockedModelIdentities.has(modelIdentity))
   );
+}
+
+export function isMlclawCodexProviderId(provider: unknown): boolean {
+  return normalizeString(provider) === MLCLAW_CODEX_PROVIDER_ID;
+}
+
+export function isMlclawCodexModelRef(model: unknown): boolean {
+  if (typeof model !== "string") return false;
+  const normalized = splitTrailingAuthProfile(model).model.trim().toLowerCase();
+  return normalized.startsWith(`${MLCLAW_CODEX_PROVIDER_ID}/`);
 }
 
 export function isLegacyCodexProviderId(provider: unknown): boolean {

--- a/src/commands/doctor/shared/codex-route-session-repair.ts
+++ b/src/commands/doctor/shared/codex-route-session-repair.ts
@@ -14,6 +14,8 @@ import {
   isBlockedLegacyCodexModelRef,
   isOpenAICodexModelRef,
   isLegacyCodexProviderId,
+  isMlclawCodexModelRef,
+  isMlclawCodexProviderId,
   isProviderlessModelRef,
   normalizeRuntimeString,
   toCanonicalOpenAIModelRef,
@@ -113,7 +115,10 @@ function clearStaleCodexFallbackNotice(
   return true;
 }
 
-function preserveRepairedSessionRuntimeIntent(entry: SessionEntry): boolean {
+function preserveRepairedSessionRuntimeIntent(
+  entry: SessionEntry,
+  forceOpenClawRuntime: boolean,
+): boolean {
   const harnessRuntime = normalizeRuntimeString(entry.agentHarnessId);
   const overrideRuntime = normalizeRuntimeString(entry.agentRuntimeOverride);
   let changed = false;
@@ -121,7 +126,12 @@ function preserveRepairedSessionRuntimeIntent(entry: SessionEntry): boolean {
     delete entry.agentHarnessId;
     changed = true;
   }
-  if (overrideRuntime !== "openclaw" && entry.agentRuntimeOverride !== "codex") {
+  if (forceOpenClawRuntime) {
+    if (overrideRuntime !== "openclaw") {
+      entry.agentRuntimeOverride = "openclaw";
+      changed = true;
+    }
+  } else if (overrideRuntime !== "openclaw" && entry.agentRuntimeOverride !== "codex") {
     entry.agentRuntimeOverride = "codex";
     changed = true;
   }
@@ -179,6 +189,11 @@ function repairCodexSessionStoreRoutes(params: {
     if (!entry || isValidAgentHarnessSessionStoreEntry(sessionKey, entry)) {
       continue;
     }
+    const forceOpenClawRuntime =
+      isMlclawCodexProviderId(entry.modelProvider) ||
+      isMlclawCodexModelRef(entry.model) ||
+      isMlclawCodexProviderId(entry.providerOverride) ||
+      isMlclawCodexModelRef(entry.modelOverride);
     const changedRuntimeModelRoute = rewriteSessionModelPair({
       entry,
       providerKey: "modelProvider",
@@ -205,7 +220,7 @@ function repairCodexSessionStoreRoutes(params: {
       params.blockedModelIdentities,
     );
     const changedRuntimePins = changedModelRoute
-      ? preserveRepairedSessionRuntimeIntent(entry)
+      ? preserveRepairedSessionRuntimeIntent(entry, forceOpenClawRuntime)
       : false;
     if (!changedModelRoute && !changedFallbackNotice && !changedRuntimePins) {
       continue;

--- a/src/commands/doctor/shared/codex-route-warnings.test.ts
+++ b/src/commands/doctor/shared/codex-route-warnings.test.ts
@@ -4050,6 +4050,34 @@ describe("collectCodexRouteWarnings", () => {
     expect(expectDefined(store.other, "store.other test invariant").agentHarnessId).toBe("codex");
   });
 
+  it("moves ML Claw session overrides to the native OpenAI runtime", () => {
+    const store: Record<string, SessionEntry> = {
+      main: {
+        sessionId: "s-mlclaw",
+        updatedAt: 1,
+        modelProvider: "mlclaw-codex",
+        model: "gpt-5.4",
+        providerOverride: "mlclaw-codex",
+        modelOverride: "mlclaw-codex/gpt-5.4",
+        modelOverrideSource: "user",
+      },
+    };
+
+    const result = repairCodexSessionStoreRoutes({ store, now: 123 });
+
+    expect(result).toEqual({ changed: true, sessionKeys: ["main"] });
+    expect(store.main).toMatchObject({
+      modelProvider: "openai",
+      model: "gpt-5.4",
+      providerOverride: "openai",
+      modelOverride: "gpt-5.4",
+      modelOverrideSource: "user",
+      modelOverrideRouteResolution: "resolved",
+      agentRuntimeOverride: "openclaw",
+      updatedAt: 123,
+    });
+  });
+
   it("repairs shipped codex namespace session route refs", () => {
     const store: Record<string, SessionEntry> = {
       main: {

--- a/src/plugin-sdk/provider-model-types.ts
+++ b/src/plugin-sdk/provider-model-types.ts
@@ -59,6 +59,8 @@ export type ProviderResolveModelRoutesContext = {
   requestTransportOverrides?: ProviderRouteOverridePresence;
   configuredModel?: ProviderModelRouteSource;
   configuredProvider?: ProviderModelRouteSource;
+  /** Provider-owned non-model parameters that can affect concrete route construction. */
+  configuredProviderParams?: Readonly<Record<string, unknown>>;
   /** Environment view; the provider owns interpretation of its variables. */
   env?: Readonly<Record<string, string | undefined>>;
   /** Physical route facts for one logical model; input order is not preference. */

--- a/src/plugins/provider-model-routes.ts
+++ b/src/plugins/provider-model-routes.ts
@@ -87,6 +87,7 @@ export function createProviderModelRoutesResolver(params: {
   const configuredProvider = providerConfig
     ? { api: providerConfig.api, baseUrl: providerConfig.baseUrl }
     : undefined;
+  const configuredProviderParams = providerConfig?.params;
   const normalizeConfiguredModelId = (modelId: string) =>
     normalizeModelId(provider, modelId, surface);
   const canonicalizeModelId = (modelId: string) =>
@@ -144,6 +145,7 @@ export function createProviderModelRoutesResolver(params: {
         requestTransportOverrides,
         ...(configuredModel ? { configuredModel } : {}),
         ...(configuredProvider ? { configuredProvider } : {}),
+        ...(configuredProviderParams ? { configuredProviderParams } : {}),
         env,
         ...(observedRoutes && observedRoutes.length > 0 ? { observedRoutes } : {}),
       }) ?? null


### PR DESCRIPTION
## Summary

SecretRef-backed OpenAI token profiles could select the subscription route but could not run a model through the configured loopback proxy.
This change makes the proxy URL part of route selection and warms account-scoped model metadata before embedded inference.
The opaque token stays in OpenClaw's prepared secret runtime and is never added to model metadata or persistent configuration.

## What Changed

The prepared route and the resolved model now agree on the same concrete loopback endpoint.
Dynamic model resolution can also fetch the selected account's live Codex catalog before retrying materialization.

- Added provider-owned parameters to the secret-free route policy context.
- Made the OpenAI subscription route use a validated `codexProxyBaseUrl` when configured.
- Added a short-lived, profile-scoped metadata cache for async Codex catalog warm-up.
- Reused already materialized token credentials during catalog discovery instead of reloading their SecretRefs.
- Kept API-key route selection and Platform endpoints unchanged.
- Extended the bounded doctor migration to move persisted `mlclaw-codex/*` session overrides onto native `openai/*` routes with the embedded OpenClaw runtime.

## Testing

Focused route, provider, and type suites pass.
A real local Gateway smoke test also passed with a persisted environment SecretRef, an opaque loopback capability, `openai/gpt-5.6-sol`, SSE inference, and a full Gateway restart.

- `pnpm exec vitest run src/agents/openai-model-routes.test.ts extensions/openai/provider-policy-api.test.ts extensions/openai/openai-provider.test.ts`
- `pnpm check:test-types`
- `pnpm exec vitest run src/commands/doctor/shared/codex-route-warnings.test.ts` (129 tests)
- Local Gateway smoke: two catalog requests and two Responses requests across the initial run and restart; both returned `MLCLAW_NATIVE_OPENAI_OK`.

## Risks

The new cache contains model metadata only, never credentials.
It is keyed by agent directory, workspace, auth profile, proxy URL, and model id, and expires after 60 seconds.
Invalid or remote proxy URLs still fail through the existing strict loopback validator before credentials are sent.

Closes #114603.
Follow-up to #114555.
