### PR TITLE
fix: Control UI stalls while loading startup data

### DIFF
--- a/src/gateway/server-methods/models-list-result.plugin-runtime.test.ts
+++ b/src/gateway/server-methods/models-list-result.plugin-runtime.test.ts
@@ -1,0 +1,157 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ModelCatalogEntry, ModelCatalogSnapshot } from "../../agents/model-catalog.types.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+import type { GatewayRequestContext } from "./types.js";
+
+const getCurrentPluginMetadataSnapshotMock = vi.hoisted(() => vi.fn());
+const loadPluginRegistrySnapshotWithMetadataMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../plugins/current-plugin-metadata-snapshot.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../plugins/current-plugin-metadata-snapshot.js")>()),
+  getCurrentPluginMetadataSnapshot: getCurrentPluginMetadataSnapshotMock,
+}));
+
+vi.mock("../../plugins/plugin-registry.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../plugins/plugin-registry.js")>()),
+  loadPluginRegistrySnapshotWithMetadata: loadPluginRegistrySnapshotWithMetadataMock,
+}));
+
+import {
+  buildModelsListResult,
+  createGatewayAgentModelCatalogProjector,
+} from "./models-list-result.js";
+
+function catalogEntry(id: string): ModelCatalogEntry {
+  return { id, name: id, provider: "custom", api: "openai-responses" };
+}
+
+function preparedMetadataSnapshot() {
+  return {
+    index: {
+      plugins: [
+        {
+          enabled: true,
+          syntheticAuthRefs: ["custom"],
+        },
+      ],
+    },
+    plugins: [
+      {
+        modelIdNormalization: {
+          providers: {
+            custom: {
+              aliases: {
+                legacy: "modern",
+              },
+            },
+          },
+        },
+      },
+    ],
+  } as never;
+}
+
+describe("models.list plugin metadata handoff", () => {
+  beforeEach(() => {
+    getCurrentPluginMetadataSnapshotMock.mockReset();
+    loadPluginRegistrySnapshotWithMetadataMock.mockReset();
+  });
+
+  it("reuses one Gateway-owned metadata snapshot across startup projection and browse", async () => {
+    await withOpenClawTestState(
+      {
+        layout: "state-only",
+        prefix: "openclaw-models-list-plugin-runtime-",
+        agentEnv: "main",
+      },
+      async (state) => {
+        const cfg = {
+          agents: {
+            defaults: {
+              workspace: state.workspaceDir,
+              model: { primary: "custom/legacy" },
+              models: {
+                "custom/legacy": {},
+                "custom/another": {},
+              },
+            },
+          },
+        } as OpenClawConfig;
+        const snapshot: ModelCatalogSnapshot = {
+          entries: [catalogEntry("modern"), catalogEntry("another")],
+          routeVariants: [],
+        };
+        getCurrentPluginMetadataSnapshotMock.mockReturnValue(preparedMetadataSnapshot());
+        const projector = createGatewayAgentModelCatalogProjector({
+          cfg,
+          agentId: "main",
+          snapshot,
+        });
+        await projector.projectCatalog();
+
+        const context = {
+          getRuntimeConfig: () => cfg,
+          loadGatewayModelCatalogSnapshot: vi.fn(),
+          logGateway: { debug: vi.fn() },
+        } as unknown as GatewayRequestContext;
+        await buildModelsListResult({
+          context,
+          agentId: "main",
+          params: { view: "configured" },
+          preloadedCatalog: { agentId: "main", config: cfg, snapshot },
+          preloadedOnly: true,
+          catalogProjector: projector,
+        });
+
+        expect(getCurrentPluginMetadataSnapshotMock).toHaveBeenCalledWith({
+          config: cfg,
+          allowWorkspaceScopedSnapshot: true,
+        });
+        expect(loadPluginRegistrySnapshotWithMetadataMock).not.toHaveBeenCalled();
+      },
+    );
+  });
+
+  it("preserves registry fallback when no compatible Gateway snapshot exists", async () => {
+    await withOpenClawTestState(
+      {
+        layout: "state-only",
+        prefix: "openclaw-models-list-plugin-runtime-fallback-",
+        agentEnv: "main",
+      },
+      async (state) => {
+        const cfg = {
+          agents: {
+            defaults: {
+              workspace: state.workspaceDir,
+              model: { primary: "custom/modern" },
+              models: { "custom/modern": {} },
+            },
+          },
+        } as OpenClawConfig;
+        getCurrentPluginMetadataSnapshotMock.mockReturnValue(undefined);
+        loadPluginRegistrySnapshotWithMetadataMock.mockReturnValue({
+          source: "provided",
+          snapshot: {
+            plugins: [
+              {
+                enabled: true,
+                syntheticAuthRefs: ["custom"],
+              },
+            ],
+          },
+        });
+        const projector = createGatewayAgentModelCatalogProjector({
+          cfg,
+          agentId: "main",
+          snapshot: { entries: [catalogEntry("modern")], routeVariants: [] },
+        });
+
+        await projector.projectCatalog();
+
+        expect(loadPluginRegistrySnapshotWithMetadataMock).toHaveBeenCalled();
+      },
+    );
+  });
+});

--- a/src/gateway/server-methods/models-list-result.ts
+++ b/src/gateway/server-methods/models-list-result.ts
@@ -48,6 +48,8 @@ import { resolveProviderIdForAuth } from "../../agents/provider-auth-aliases.js"
 import { resolveDefaultAgentWorkspaceDir } from "../../agents/workspace.js";
 import { getRuntimeConfigSourceSnapshot } from "../../config/config.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { getCurrentPluginMetadataSnapshot } from "../../plugins/current-plugin-metadata-snapshot.js";
+import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
 import { loadPluginRegistrySnapshotWithMetadata } from "../../plugins/plugin-registry.js";
 import { resolveManifestProviderAuthChoices } from "../../plugins/provider-auth-choices.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
@@ -121,8 +123,14 @@ function resolveModelChoiceAgentRuntime(params: {
 
 function listEnabledSyntheticAuthProviderRefs(params: {
   cfg: OpenClawConfig;
+  metadataSnapshot?: PluginMetadataSnapshot;
   workspaceDir: string;
 }): readonly string[] {
+  if (params.metadataSnapshot) {
+    return params.metadataSnapshot.index.plugins
+      .filter((plugin) => plugin.enabled)
+      .flatMap((plugin) => plugin.syntheticAuthRefs ?? []);
+  }
   const result = loadPluginRegistrySnapshotWithMetadata({
     config: params.cfg,
     workspaceDir: params.workspaceDir,
@@ -140,6 +148,7 @@ function createModelsListAuthResolver(params: {
   cfg: OpenClawConfig;
   agentId: string;
   includeOpenAIExternalProfiles: boolean;
+  metadataSnapshot?: PluginMetadataSnapshot;
   workspaceDir: string;
   routeResolverFactory?: typeof createOpenAIModelRoutesResolver;
 }): ModelAuthAvailabilityResolver {
@@ -155,6 +164,7 @@ function createModelsListAuthResolver(params: {
     agentDir,
     workspaceDir: params.workspaceDir,
     env: process.env,
+    metadataSnapshot: params.metadataSnapshot,
     skipSetupProviderFallback: true,
     syntheticAuthProviderRefs: listEnabledSyntheticAuthProviderRefs(params),
     externalCliProviderIds: params.includeOpenAIExternalProfiles ? ["openai"] : [],
@@ -283,6 +293,12 @@ export function createGatewayAgentModelCatalogProjector(params: {
   routeResolverFactory?: typeof createOpenAIModelRoutesResolver;
 }) {
   const defaultModel = resolveAgentEffectiveModelPrimary(params.cfg, params.agentId);
+  // The Gateway owns one process-lifecycle plugin metadata snapshot. Carry it
+  // through the whole projection so per-model normalization cannot rediscover it.
+  const metadataSnapshot = getCurrentPluginMetadataSnapshot({
+    config: params.cfg,
+    allowWorkspaceScopedSnapshot: true,
+  });
   const visibilityPolicy = createModelVisibilityPolicy({
     cfg: params.cfg,
     catalog: params.snapshot.entries,
@@ -290,6 +306,7 @@ export function createGatewayAgentModelCatalogProjector(params: {
     defaultModel,
     agentId: params.agentId,
     ...RUNTIME_MODEL_VISIBILITY_NORMALIZATION,
+    manifestPlugins: metadataSnapshot?.plugins,
   });
   const workspaceDir =
     resolveAgentWorkspaceDir(params.cfg, params.agentId) ?? resolveDefaultAgentWorkspaceDir();
@@ -321,6 +338,7 @@ export function createGatewayAgentModelCatalogProjector(params: {
     includeOpenAIExternalProfiles:
       projectionCatalog.some((entry) => normalizeProviderId(entry.provider) === "openai") ||
       [...visibilityPolicy.configuredKeys].some((key) => key.startsWith("openai/")),
+    metadataSnapshot,
     workspaceDir,
     routeResolverFactory: params.routeResolverFactory,
   });
@@ -334,6 +352,7 @@ export function createGatewayAgentModelCatalogProjector(params: {
   let projectedCatalog: Promise<ModelCatalogEntry[]> | undefined;
   return {
     evaluateEntry,
+    metadataSnapshot,
     projectCatalog: () =>
       (projectedCatalog ??= Promise.all(
         logicalEntries.map(async (entry) => {
@@ -553,6 +572,12 @@ export async function buildModelsListResult(
     resolveDefaultAgentWorkspaceDir();
   const catalog = snapshot.entries;
   const routeVariants = snapshot.routeVariants;
+  const metadataSnapshot =
+    (usedPreloadedCatalog ? params.catalogProjector?.metadataSnapshot : undefined) ??
+    getCurrentPluginMetadataSnapshot({
+      config: cfg,
+      allowWorkspaceScopedSnapshot: true,
+    });
   const includeProviderCapabilities = params.params.includeProviderCapabilities === true;
   const capableProviders = includeProviderCapabilities
     ? apiKeyProviderCapabilities({ cfg, workspaceDir })
@@ -597,6 +622,7 @@ export async function buildModelsListResult(
     defaultModel,
     agentId,
     ...RUNTIME_MODEL_VISIBILITY_NORMALIZATION,
+    manifestPlugins: metadataSnapshot?.plugins,
   });
   const evaluateEntry =
     (usedPreloadedCatalog ? params.catalogProjector?.evaluateEntry : undefined) ??
@@ -609,6 +635,7 @@ export async function buildModelsListResult(
         includeOpenAIExternalProfiles:
           catalog.some((entry) => normalizeProviderId(entry.provider) === "openai") ||
           [...visibilityPolicy.configuredKeys].some((key) => key.startsWith("openai/")),
+        metadataSnapshot,
         workspaceDir,
         routeResolverFactory: params.routeResolverFactory,
       }),


### PR DESCRIPTION
Related: #112591
Related: #77700

## Summary

### High Level TLDR

The Control UI could spend tens of seconds waiting for its startup model/session metadata even though the page assets and Gateway connection were fast. This change reuses the Gateway's already-prepared plugin metadata while projecting the startup model catalog, avoiding thousands of redundant plugin metadata scans.

## What Problem This Solves

Fixes an issue where users opening or reloading the Control UI could wait roughly 20–40 seconds for chat/session startup data when the Gateway had multiple agents and configured model policies.

In the observed production reproduction:

- static Control UI assets loaded in about 33 ms;
- two concurrent `chat.startup` requests each took about 20.5 s;
- `sessions.list` took 42.4 s;
- the startup window emitted 3,873 `plugins.metadata.scan` operations, totaling 28.4 s, plus 3,873 snapshot freezes;
- event-loop delay reached 21.4 s.

## Why This Change Was Made

The Gateway already owns a lifecycle-scoped plugin metadata snapshot. The model catalog projector now carries that snapshot through model visibility normalization, provider auth lookup preparation, synthetic-auth discovery, and the preloaded `models.list` browse path. If no compatible current snapshot exists, the existing registry fallback remains intact.

Scope is limited to Gateway model catalog projection and its regression coverage. It does not add a new cache, config surface, protocol change, or compatibility shim.

## Root Cause

`chat.startup` projects the shared model catalog for every visible agent. The projector enabled manifest/plugin model normalization but did not pass the Gateway-owned manifest records. Each configured model reference therefore fell back to resolving plugin metadata independently. Auth lookup preparation also received no metadata snapshot, causing the same metadata surface to be rediscovered.

The observed before behavior matched this call shape: catalog/session storage reads completed in milliseconds, while thousands of plugin metadata scan/freeze diagnostics occupied nearly the entire request and starved the event loop. The regression was exposed after model visibility normalization became plugin-aware without a prepared snapshot handoff on this Gateway path. Merged PR #114117 fixed the analogous auto-reply model-selection path, but did not migrate `chat.startup` catalog projection.

## User Impact

Control UI startup metadata should become responsive without changing visible model choices, auth availability, or fallback behavior. Other `models.list` consumers also reuse the prepared snapshot when available.

## Real behavior proof

### Before

On a live Linux Gateway built from `3d03c415d19`:

```text
Control UI HTTPS asset: ~33 ms
chat.startup: ~20.5 s (two concurrent requests)
sessions.list: 42.4 s
plugins.metadata.scan: 3,873 calls / 28.4 s
event-loop max delay: 21.4 s
```

### After patch

Focused regression proof:

```text
node scripts/run-vitest.mjs \
  src/gateway/server-methods/models-list-result.plugin-runtime.test.ts \
  src/gateway/server-methods/models-list-result.openai-routes.test.ts

Test Files  2 passed (2)
Tests       23 passed (23)
```

The new regression asserts that startup projection plus preloaded browse performs no plugin registry reload when the Gateway snapshot is available, and separately proves the prior fallback still works when it is unavailable.

Additional handler coverage:

```text
node scripts/run-vitest.mjs src/gateway/server-methods/models.test.ts

Test Files  1 passed (1)
Tests       25 passed (25)
```

Full changed-surface gate:

```text
OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 node scripts/check-changed.mjs -- \
  src/gateway/server-methods/models-list-result.ts \
  src/gateway/server-methods/models-list-result.plugin-runtime.test.ts

exit 0
```

Production build:

```text
pnpm build

[build-all] phase timings: total 1m 39.2s
exit 0
```

Autoreview:

```text
autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.87)
```

The delegated Blacksmith check was attempted first but stopped before executing repository code because the local Blacksmith CLI was not authenticated. Per repository policy for trusted maintainer source, validation fell back to the local checkout.

Live deployment and authenticated Gateway proof:

```text
oc-update --skip-codex

update completed successfully
Gateway: active/running, PID 3962123, NRestarts=0, RPC healthy
Control UI direct asset: HTTP 200 / 18 ms
Control UI public asset: HTTP 200 / 30 ms
build provenance: verified for current main plus managed PR overlays
```

The production updater built current `main` plus this PR as a managed overlay. After restart, an authenticated local backend probe issued the same two concurrent `chat.startup` calls and concurrent `sessions.list` request that exposed the original event-loop starvation:

```text
chat.startup: 2.00 s and 4.01 s
sessions.list: 4.94 s
total concurrent window: 4.94 s

gateway.chat.startup.model_catalog: 44.6 ms average / 55.8 ms max
gateway.sessions.list.model_catalog: 0.50 ms
plugins.metadata.scan: 10 calls / 135.9 ms
plugins.metadata.freeze: 10 calls / 31.4 ms
```

This reduced the observed startup scan count from 3,873 to 10 and removed the 20–42 second request stall. The remaining end-to-end probe time includes three separate authenticated WebSocket connections; the browser normally reuses one connection.

An initial attempt to identify the non-browser probe as the Control UI was rejected by the existing allowed-origin policy before `chat.startup`, as expected. The successful probe used the authenticated local backend client and reached the same Gateway RPC handler without changing or bypassing that policy.

A first deployment was invalidated after a follow-up source-tree health command replaced the packaged Control UI assets and made the page return 503. The updater was rerun, exact production build provenance was re-established, both direct and public UI endpoints returned 200, and all final timings above were captured against the replacement Gateway.

## Evidence

- Exact regression test covers prepared snapshot reuse and incompatible-snapshot fallback.
- Existing OpenAI route/model-list tests remain green.
- Full core changed gate, production build, and autoreview are green.
- No generated build output or changelog changes are included.

## What was not tested

- No cross-platform GUI recording was made. Live proof exercised the production Gateway's authenticated `chat.startup` and `sessions.list` handlers rather than automating a browser with stored operator credentials.
- This change does not address cold Gateway process startup; it is scoped to post-ready Control UI/session model-catalog projection.

AI-assisted: yes. I reviewed the source, tests, live diagnostics, and resulting patch.
