### PR TITLE
chore(process): drop Bun spawn-encoding workaround (fixed upstream)

### DIFF
--- a/src/process/exec-spawn.ts
+++ b/src/process/exec-spawn.ts
@@ -69,14 +69,6 @@ export function spawnCommandWithInvocation<
   invocation: ReturnType<typeof resolveSafeChildProcessInvocation>;
 } {
   const { baseEnv, env, windowsVerbatimArguments, ...execaOptions } = options;
-  // Bun workaround (oven-sh/bun#36049): execa forwards its whole options object to
-  // child_process.spawn. Node ignores the extra `encoding` key there, but Bun's
-  // spawn feeds it into its stream constructor and throws ERR_UNKNOWN_ENCODING for
-  // execa's "buffer". Clearing it under Bun means buffered results arrive as utf8
-  // strings instead of Buffers; callers already normalize via Buffer.from. Binary-
-  // exact output paths are unverified under Bun. Remove once the Bun issue is fixed.
-  const dropBufferEncodingForBun =
-    Boolean(process.versions.bun) && execaOptions.encoding === "buffer";
   const commandEnv = resolveCommandEnv({ argv, baseEnv, env });
   const invocation = resolveSafeChildProcessInvocation({
     argv,
@@ -86,7 +78,6 @@ export function spawnCommandWithInvocation<
   });
   const child = execa(invocation.command, invocation.args, {
     ...execaOptions,
-    ...(dropBufferEncodingForBun ? { encoding: undefined } : {}),
     env: commandEnv,
     extendEnv: false,
     shell: false,


### PR DESCRIPTION
## What Problem This Solves

`src/process/exec-spawn.ts` carries a temporary Bun workaround (`dropBufferEncodingForBun`, added in #114256): execa forwards `encoding: "buffer"` into `child_process.spawn`, and Bun used to consume that option and throw `ERR_UNKNOWN_ENCODING`, so we cleared it under Bun at the cost of utf8-decoded (not byte-exact) buffered exec output there. The code comment's removal condition — "Remove once the Bun issue is fixed" — is now met.

## Why This Change Was Made

Upstream fixed it: oven-sh/bun#36049 is closed COMPLETED via oven-sh/bun#36050 (merged 2026-07-27T06:04Z) — Bun's `spawn` now ignores `options.encoding` entirely, matching Node. Verified against the canary built from the fix's merge commit (`1.4.0-canary.1+6c12afd8e`): `spawn("echo", ["hi"], { encoding: "buffer" })` emits `<Buffer 68 69 0a>` and exits 0. This PR deletes the workaround (net -9 lines, no replacement logic). Binary-exact exec output under Bun is restored as a side effect.

## User Impact

None on Node (the deleted branch was Bun-gated). Bun users on canaries >= 6c12afd8e get byte-exact buffered exec output; older Bun canaries would regress to the pre-workaround `ERR_UNKNOWN_ENCODING` — acceptable because Bun support is experimental and tracking-canary by nature (shipped in no OpenClaw release with Bun-runtime support beyond experimental).

## Evidence

- Fix verification on `1.4.0-canary.1+6c12afd8e`: the exact #36049 repro now passes.
- `node scripts/run-vitest.mjs run src/process/exec` — 2 shards passed (Node behavior unchanged).
- Bun (fixed canary) `vitest run src/process/exec.test.ts` — 38 passed, 1 skipped, **including "preserves binary output and nonzero exit details"**, which failed under the workaround's utf8 fallback.
- Bun `openclaw.mjs doctor` with a fresh isolated `OPENCLAW_STATE_DIR` — "Doctor complete." (child-process spawns exercised end-to-end). A stale local scratch state dir shows an unrelated known Bun readonly-WAL open quirk; Node completes on the same dir.
- Codex autoreview: clean (0.99).

## ClawSweeper responses

**"Retain the workaround / add a runtime minimum" (P1 x3) — consciously skipped, maintainer-accepted tradeoff.** The exposure is real but narrow and self-healing: it affects only Bun 1.4 *canaries* older than 6c12afd8e (2026-07-27). Bun 1.4 has no stable release — every affected user is by definition tracking canary builds, and `bun upgrade --canary` is both the expected posture and the fix. A runtime minimum is not implementable soundly: canary version strings (`1.4.0-canary.1+<commit>`) carry no orderable component, so any gate would be a hash allowlist or a spawn-probe at startup — permanent complexity in a hot startup path to protect a transient window of prerelease builds of an explicitly experimental runtime (docs/install/bun.md: Node remains the supported runtime). Repo policy is to name such tradeoffs rather than encode defensive branches for them; the failure mode for a stale canary is a loud, actionable upstream error (`ERR_UNKNOWN_ENCODING`, fixed by upgrading), not silent corruption — and keeping the workaround has its own ongoing cost (silently non-byte-exact exec output under Bun, which is a data-correctness defect rather than a crash).
