### PR TITLE
fix: restore web fetch prerelease validation

### DIFF
--- a/src/plugins/web-fetch-providers.runtime.test.ts
+++ b/src/plugins/web-fetch-providers.runtime.test.ts
@@ -276,6 +276,7 @@ describe("resolvePluginWebFetchProviders", () => {
       config: rawConfig,
       workspaceDir: "/tmp/runtime-workspace",
       env,
+      candidates: [],
       diagnostics: [],
       installRecords: {},
     });


### PR DESCRIPTION
## What Problem This Solves

Restores the release-only Plugin Prerelease gate after plugin registry discovery began threading an explicit candidate list. The stale assertion cancelled run https://github.com/openclaw/openclaw/actions/runs/30274491150 even though the runtime call was correct.

## Why This Change Was Made

The web-fetch runtime test now expects the complete manifest-registry input, including the empty `candidates` list produced for a workspace with no configured load-path plugins. This keeps the assertion aligned with the discovery contract without changing runtime behavior.

## User Impact

No user-visible behavior changes. Release validation no longer reports a false failure for the current plugin discovery contract.

## Evidence

- Before: `src/plugins/web-fetch-providers.runtime.test.ts` failed in `checks-node-agentic-plugins` because the call included `candidates: []`.
- After: `node scripts/run-vitest.mjs src/plugins/web-fetch-providers.runtime.test.ts` — 1 file and 8 tests passed.
- `git diff --check` passed.
- Autoreview: clean, no accepted or actionable findings.

AI-assisted: yes. I reviewed the failing runtime path and the resulting one-line expectation change.
