### PR TITLE
[AI-assisted] docs(tools): fix broken gemini and pi alias links in ACP setup docs

### DIFF
--- a/docs/tools/acp-agents-setup.md
+++ b/docs/tools/acp-agents-setup.md
@@ -37,7 +37,7 @@ Built-in acpx harness aliases (from the pinned `acpx` dependency):
 | `cursor`     | [Cursor CLI](https://cursor.com/docs/cli/acp) (`cursor-agent acp`)                                     |
 | `droid`      | [Factory Droid](https://www.factory.ai)                                                                |
 | `fast-agent` | [fast-agent](https://fast-agent.ai)                                                                    |
-| `gemini`     | [Gemini CLI](https://github.com/google/gemini-cli)                                                     |
+| `gemini`     | [Gemini CLI](https://github.com/google-gemini/gemini-cli)                                              |
 | `iflow`      | [iFlow CLI](https://github.com/iflow-ai/iflow-cli)                                                     |
 | `kilocode`   | [Kilocode](https://kilocode.ai)                                                                        |
 | `kimi`       | [Kimi CLI](https://github.com/MoonshotAI/kimi-cli)                                                     |
@@ -45,7 +45,7 @@ Built-in acpx harness aliases (from the pinned `acpx` dependency):
 | `mux`        | [Mux](https://mux.coder.com)                                                                           |
 | `opencode`   | [OpenCode](https://opencode.ai)                                                                        |
 | `openclaw`   | OpenClaw ACP bridge (native `openclaw acp`)                                                            |
-| `pi`         | [Pi Coding Agent](https://github.com/mariozechner/pi)                                                  |
+| `pi`         | [Pi Coding Agent](https://github.com/earendil-works/pi)                                                |
 | `qoder`      | [Qoder CLI](https://docs.qoder.com/cli/acp)                                                            |
 | `qwen`       | [Qwen Code](https://github.com/QwenLM/qwen-code)                                                       |
 | `trae`       | [Trae CLI](https://docs.trae.cn/cli)                                                                   |


### PR DESCRIPTION
[AI-assisted]

## What Problem This Solves

The built-in acpx harness alias table in `docs/tools/acp-agents-setup.md` links two aliases to GitHub repositories that no longer exist, so a user setting up the `gemini` or `pi` ACP agent and clicking the alias link lands on a GitHub **404**:

| Alias | Link in docs | HTTP | Should point to |
| --- | --- | --- | --- |
| `gemini` | `https://github.com/google/gemini-cli` | **404** | `https://github.com/google-gemini/gemini-cli` (official Gemini CLI) |
| `pi` | `https://github.com/mariozechner/pi` | **404** | `https://github.com/earendil-works/pi` (Pi coding agent) |

This is the same alias table whose `copilot` row was fixed in #114057; this PR fixes the two remaining broken alias links.

## Triage / Root cause

The aliases are described as coming "from the pinned `acpx` dependency" (0.12.0). Those two URLs originate in the `acpx` README and were mirrored into this docs table verbatim. Both referenced repos moved/renamed, so the mirrored URLs now 404:

- **`gemini`** — the official Gemini CLI repo lives at `google-gemini/gemini-cli` (the `google/gemini-cli` org path was never valid).
- **`pi`** — the Pi coding agent moved from `mariozechner/pi` to `earendil-works/pi`; the codebase already migrated its npm packages the same way (`@mariozechner/pi-*` → `@earendil-works/pi-*`, #79587).

## Fix

Two one-line URL swaps in the alias table, plus formatter-mandated column re-padding:

- `github.com/google/gemini-cli` → `github.com/google-gemini/gemini-cli`
- `github.com/mariozechner/pi` → `github.com/earendil-works/pi`

## Evidence

- Old URLs (live-verified, browser UA, `-L`):
  - `https://github.com/google/gemini-cli` → **HTTP 404**
  - `https://github.com/mariozechner/pi` → **HTTP 404** (and `gh api users/mariozechner/repos` returns no public repos)
- New URLs (live-verified):
  - `https://github.com/google-gemini/gemini-cli` → **HTTP 200** — `gh api repos/google-gemini/gemini-cli`: "An open-source AI agent that brings the power of Gemini directly into your terminal", 106k★, not archived.
  - `https://github.com/earendil-works/pi` → **HTTP 200** — `gh api repos/earendil-works/pi`: "AI agent toolkit: unified LLM API, agent loop, TUI, coding agent CLI", 78.8k★.
- Product-surface verification for `pi` (not just a 200): the acpx `pi` alias invokes the `pi-acp` adapter; the `svkozak/pi-acp` README explicitly links the Pi coding agent to `https://github.com/earendil-works/pi` ("ACP adapter for [`pi`](https://github.com/earendil-works/pi) coding agent"). The codebase corroborates this with its `@mariozechner/pi-*` → `@earendil-works/pi-*` package migration (#79587).
- Verified the full table: every other alias URL returns 200 (or an auth-walled 403 for SPA dashboards like `claude.ai/code`); only `gemini` and `pi` were broken.
- Formatter: re-ran the repo's pinned `oxfmt@0.60.0` via `oxfmt --write --threads=1 --config .oxfmtrc.jsonc` on this file; the only change is the two URL swaps plus the table-cell re-padding oxfmt applies.

## Notes / Risks

- The root URLs still exist in the `acpx` package README (0.12.0 and 0.12.1); this PR fixes only the OpenClaw docs mirror (a separate upstream fix in `openclaw/acpx` would clear the source).
- The table is hand-maintained in this repo (no generator writes it); the only script that references the page (`scripts/generate-plugin-inventory-doc.mjs`) just lists the slug in an inventory, it does not emit the table.
- No code or behavior change; docs-only.
