### PR TITLE
docs: remove retired openai-codex from /login valid args

### DIFF
--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -201,7 +201,7 @@ plugins.
     | `/reasoning [on\|off\|stream]` | Toggle reasoning visibility. Alias: `/reason` |
     | `/elevated [on\|off\|ask\|full]` | Toggle elevated mode. Alias: `/elev` |
     | `/exec host=<auto\|sandbox\|gateway\|node> security=<deny\|allowlist\|full> ask=<off\|on-miss\|always> node=<id>` | Show or set exec defaults |
-    | `/login [codex\|openai\|openai-codex]` | Pair Codex/OpenAI login from a private chat or Web UI session. Owner/admin only |
+    | `/login [codex\|openai]` | Pair Codex/OpenAI login from a private chat or Web UI session. Owner/admin only |
     | `/model [name\|#\|status]` | Show or set the model |
     | `/models [provider] [page] [limit=<n>\|all]` | List configured/auth-available providers or models |
     | `/queue <mode>` | Manage active-run queue behavior. See [Queue](/concepts/queue) and [Queue steering](/concepts/queue-steering) |


### PR DESCRIPTION
## What Problem This Solves

The `/login` slash command docs list `openai-codex` as a valid argument alongside `codex` and `openai`, but `openai-codex` is retired.

## Why This Change Was Made

Per AGENTS.md: "OpenAI Codex is folded into openai. No new/live `openai-codex` provider/plugin/auth/model routes; treat them as legacy input only." Doctor rewrites `openai-codex` to `openai`.

## Evidence

- `src/commands/doctor-auth.ts:41`: `const LEGACY_CODEX_PROVIDER_ID = "openai-codex"`
- `src/commands/doctor/shared/plugin-registry-migration.ts:28`: `openai: ["openai-codex"]`
- Root `AGENTS.md`: explicitly states `openai-codex` is legacy