### PR TITLE
fix: sessions_yield acknowledgment never reaches users on spawn-and-yield turns

### DIFF
--- a/extensions/codex/src/app-server/dynamic-tool-build.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.ts
@@ -99,7 +99,7 @@ type DynamicToolBuildParams = {
   ignoreRuntimePlan?: boolean;
   /** Host fact resolver; injectable only for focused plugin contract tests. */
   isHostScopedToolActive?: (toolName: string) => boolean;
-  onYieldDetected: () => void;
+  onYieldDetected: (message?: string) => void;
   onCodexAppServerEvent?: (event: CodexDynamicToolBuildEvent) => void;
   onPersistentWebSearchPolicyResolved?: (allowed: boolean) => void;
   onWebSearchPolicyResolved?: (allowed: boolean) => void;
@@ -323,7 +323,7 @@ export async function buildDynamicTools(input: DynamicToolBuildParams) {
     enableHeartbeatTool: params.trigger === "heartbeat" || input.forceHeartbeatTool === true,
     forceHeartbeatTool: params.trigger === "heartbeat" || input.forceHeartbeatTool === true,
     onYield: (message) => {
-      input.onYieldDetected();
+      input.onYieldDetected(message);
       input.onCodexAppServerEvent?.({
         stream: "codex_app_server.tool",
         data: { name: "sessions_yield", message },

--- a/extensions/codex/src/app-server/event-projector.commentary.test.ts
+++ b/extensions/codex/src/app-server/event-projector.commentary.test.ts
@@ -563,4 +563,32 @@ describe("CodexAppServerEventProjector commentary projection", () => {
 
     expect(result.yieldDetected).toBe(true);
   });
+
+  it("carries the sessions_yield message into attempt results", () => {
+    const projector = new CodexAppServerEventProjector(
+      {
+        prompt: "hello",
+        sessionId: "session-1",
+        sessionFile: "/tmp/session.jsonl",
+        workspaceDir: "/tmp",
+        runId: "run-1",
+        provider: "openai",
+        modelId: "gpt-5.4-codex",
+        model: createCodexTestModel(),
+        thinkLevel: "medium",
+      } as EmbeddedRunAttemptParams,
+      THREAD_ID,
+      TURN_ID,
+    );
+
+    const result = projector.buildResult(buildEmptyToolTelemetry(), {
+      yieldDetected: true,
+      yieldMessage: "On it — spawned a subagent, will report back.",
+    });
+
+    expect(result.yieldMessage).toBe("On it — spawned a subagent, will report back.");
+
+    const noMessage = projector.buildResult(buildEmptyToolTelemetry(), { yieldDetected: true });
+    expect(noMessage.yieldMessage).toBeUndefined();
+  });
 });

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -441,10 +441,7 @@ export class CodexAppServerEventProjector {
       ...(this.completedCompactionCount > 0
         ? { compactionCount: this.completedCompactionCount }
         : {}),
-      replayMetadata: {
-        hadPotentialSideEffects,
-        replaySafe: !hadPotentialSideEffects,
-      },
+      replayMetadata: { hadPotentialSideEffects, replaySafe: !hadPotentialSideEffects },
       itemLifecycle: {
         startedCount: this.activeItemIds.size + this.completedItemIds.size,
         completedCount: this.completedItemIds.size,
@@ -766,4 +763,3 @@ export class CodexAppServerEventProjector {
 function isHookNotificationMethod(method: string): method is "hook/started" | "hook/completed" {
   return method === "hook/started" || method === "hook/completed";
 }
-/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -322,7 +322,7 @@ export class CodexAppServerEventProjector {
 
   buildResult(
     toolTelemetry: CodexAppServerToolTelemetry,
-    options?: { yieldDetected?: boolean },
+    options?: { yieldDetected?: boolean; yieldMessage?: string },
   ): EmbeddedRunAttemptResult {
     // Result construction runs after the notification queue drains. Close any
     // tool lacking a terminal item so audit consumers never retain an open action.
@@ -451,6 +451,7 @@ export class CodexAppServerEventProjector {
         activeCount: this.activeItemIds.size,
       },
       yieldDetected: options?.yieldDetected || false,
+      ...(options?.yieldMessage ? { yieldMessage: options.yieldMessage } : {}),
       didSendDeterministicApprovalPrompt:
         this.eventProjection.guardianReviewCount > 0 ? false : undefined,
     };

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -766,3 +766,4 @@ export class CodexAppServerEventProjector {
 function isHookNotificationMethod(method: string): method is "hook/started" | "hook/completed" {
   return method === "hook/started" || method === "hook/completed";
 }
+/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/extensions/codex/src/app-server/run-attempt-finalize.ts
+++ b/extensions/codex/src/app-server/run-attempt-finalize.ts
@@ -145,6 +145,7 @@ export async function finalizeCodexAttempt(
   }
   const result = activeProjector.buildResult(toolBridge.telemetry, {
     yieldDetected: toolState.yieldDetected,
+    yieldMessage: toolState.yieldMessage,
   });
   const projectedTerminal = attemptTerminal.project(result.terminal);
   const effectiveTimedOut = state.timedOut && !recoveredTurnWatchTimeout;

--- a/extensions/codex/src/app-server/run-attempt-tool-setup.ts
+++ b/extensions/codex/src/app-server/run-attempt-tool-setup.ts
@@ -63,6 +63,7 @@ export async function prepareCodexAttemptTools(runtime: CodexAttemptRuntime) {
   }
   const toolState = {
     yieldDetected: false,
+    yieldMessage: undefined as string | undefined,
     persistentWebSearchAllowed: undefined as boolean | undefined,
     webSearchAllowed: false,
   };
@@ -121,8 +122,11 @@ export async function prepareCodexAttemptTools(runtime: CodexAttemptRuntime) {
     sessionAgentId,
     pluginConfig,
     profilerEnabled,
-    onYieldDetected: () => {
+    onYieldDetected: (message: string | undefined) => {
       toolState.yieldDetected = true;
+      if (message) {
+        toolState.yieldMessage = message;
+      }
     },
     onCodexAppServerEvent: (event: Parameters<typeof emitCodexAppServerEvent>[1]) => {
       void emitCodexAppServerEvent(params, event);

--- a/src/agents/embedded-agent-runner/run/attempt-execution-settle.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-execution-settle.ts
@@ -434,6 +434,7 @@ export async function runEmbeddedAttemptSettledPhase(
       promptCache: sessionRuntimeState.promptCache,
       contextBudgetStatus,
       yieldDetected: input.lifecycle.readYieldState().yieldDetected,
+      yieldMessage: input.lifecycle.readYieldState().yieldMessage ?? undefined,
       didDeliverSourceReplyViaMessageTool: hasDeliveredSourceReply(),
     },
     clientToolCallSlots,

--- a/src/agents/embedded-agent-runner/run/attempt-result.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-result.test.ts
@@ -10,6 +10,7 @@ function completeResult(params?: {
     completed: boolean;
   }>;
   pendingToolMediaReply?: { mediaUrls?: string[]; audioAsVoice?: boolean };
+  yieldMessage?: string | null;
   toolMetas?: Array<{
     toolName: string;
     meta?: string;
@@ -58,7 +59,8 @@ function completeResult(params?: {
       terminal: { kind: "ok" },
       sessionIdUsed: "session-1",
       messagesSnapshot: [],
-      yieldDetected: false,
+      yieldDetected: params?.yieldMessage != null,
+      yieldMessage: params?.yieldMessage ?? undefined,
       didDeliverSourceReplyViaMessageTool: false,
       diagnosticTrace: { traceId: "trace-1", spanId: "span-1" },
     } as never,
@@ -133,6 +135,15 @@ describe("attempt result projection", () => {
     expect(completeResult({ pendingToolMediaReply: { audioAsVoice: true } }).toolAudioAsVoice).toBe(
       true,
     );
+  });
+
+  it("carries the sessions_yield acknowledgment message onto the result", () => {
+    expect(completeResult().yieldMessage).toBeUndefined();
+    expect(completeResult({ yieldMessage: null }).yieldMessage).toBeUndefined();
+    expect(
+      completeResult({ yieldMessage: "On it — spawned a subagent, will report back." })
+        .yieldMessage,
+    ).toBe("On it — spawned a subagent, will report back.");
   });
 
   it("projects the latest MCP App channel view without result data", () => {

--- a/src/agents/embedded-agent-runner/run/attempt-result.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-result.ts
@@ -57,6 +57,7 @@ type EmbeddedAttemptResultState = Pick<
   | "promptCache"
   | "contextBudgetStatus"
   | "yieldDetected"
+  | "yieldMessage"
   | "didDeliverSourceReplyViaMessageTool"
 > & {
   diagnosticTrace: DiagnosticTraceContext;
@@ -407,6 +408,7 @@ export function completeEmbeddedAttemptResult(
     compactionTokensAfter: getLastCompactionTokensAfter(),
     clientToolCalls,
     yieldDetected: state.yieldDetected || undefined,
+    yieldMessage: state.yieldMessage || undefined,
   };
   return finalizeEmbeddedAttempt({
     result,

--- a/src/agents/embedded-agent-runner/run/terminal-resolution.delivery-state.test.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-resolution.delivery-state.test.ts
@@ -12,4 +12,22 @@ describe("copyAttemptDeliveryState", () => {
       } as never).latestMcpAppChannelView,
     ).toEqual({ viewId: "view-latest" });
   });
+
+  it("carries the sessions_yield acknowledgment message into the run result", () => {
+    expect(
+      copyAttemptDeliveryState({
+        messagingToolSentTexts: [],
+        messagingToolSentMediaUrls: [],
+        messagingToolSentTargets: [],
+        yieldMessage: "On it — spawned a subagent, will report back.",
+      } as never).yieldMessage,
+    ).toBe("On it — spawned a subagent, will report back.");
+    expect(
+      copyAttemptDeliveryState({
+        messagingToolSentTexts: [],
+        messagingToolSentMediaUrls: [],
+        messagingToolSentTargets: [],
+      } as never).yieldMessage,
+    ).toBeUndefined();
+  });
 });

--- a/src/agents/embedded-agent-runner/run/terminal-resolution.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-resolution.ts
@@ -633,5 +633,6 @@ export function copyAttemptDeliveryState(attempt: EmbeddedRunAttemptResult) {
     heartbeatToolResponse: attempt.heartbeatToolResponse,
     successfulCronAdds: attempt.successfulCronAdds,
     acceptedSessionSpawns: attempt.acceptedSessionSpawns,
+    yieldMessage: attempt.yieldMessage,
   };
 }

--- a/src/agents/embedded-agent-runner/run/types.ts
+++ b/src/agents/embedded-agent-runner/run/types.ts
@@ -316,6 +316,12 @@ export type EmbeddedRunAttemptResult = {
     describe: number;
     call: number;
   };
+  /**
+   * Model-provided sessions_yield acknowledgment message, captured when the
+   * yield aborts the attempt. Consumed per attempt by the reply pipeline; it
+   * is emitted only when the source turn produced no other visible delivery.
+   */
+  yieldMessage?: string;
   replayMetadata: EmbeddedRunReplayMetadata;
   /**
    * Replay metadata for this attempt before prior session state is accumulated.

--- a/src/agents/embedded-agent-runner/types.ts
+++ b/src/agents/embedded-agent-runner/types.ts
@@ -263,6 +263,10 @@ export type EmbeddedAgentRunResult = {
   heartbeatToolResponse?: HeartbeatToolResponse;
   // Count of successful cron.add tool calls in this run.
   successfulCronAdds?: number;
+  // Model-provided sessions_yield acknowledgment for an otherwise silent
+  // yielded turn. Emitted at most once, only when the source turn has no
+  // other visible delivery (spawns/cron alone do not count as visible).
+  yieldMessage?: string;
 };
 
 export type EmbeddedAgentCompactResult = {

--- a/src/auto-reply/reply/agent-runner-result-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-result-payloads.ts
@@ -12,6 +12,7 @@ import {
   createChildDiagnosticTraceContext,
   freezeDiagnosticTraceContext,
 } from "../../infra/diagnostic-trace-context.js";
+import { isSubagentSessionKey } from "../../routing/session-key.js";
 import { estimateUsageCost, resolveModelCostConfig } from "../../utils/usage-format.js";
 import { buildFallbackClearedNotice, buildFallbackNotice } from "../fallback-state.js";
 import {
@@ -174,6 +175,32 @@ export async function prepareReplyAgentPayloads(state: {
       isRoomEvent: false,
     });
     return recovery.kind === "diagnostic" ? recovery.payload : undefined;
+  };
+  const buildYieldAcknowledgmentPayload = (): ReplyPayload | undefined => {
+    // A spawn-and-yield (or cron-and-yield) turn produces no payloads of its
+    // own, and spawns/cron adds count as outbound-delivery evidence even
+    // though nothing visible reaches the source conversation — without this,
+    // the model's sessions_yield acknowledgment is silently dropped (#107788).
+    const yieldMessage = runResult.yieldMessage?.trim();
+    if (!yieldMessage || isHeartbeat || followupRun.run.silentExpected === true) {
+      return undefined;
+    }
+    // Internal sessions have no external reply lane; the acknowledgment must
+    // not leak into a subagent transcript as if it were a user-facing reply.
+    if (isSubagentSessionKey(sessionKey)) {
+      return undefined;
+    }
+    // Suppress only when the source conversation already received a visible
+    // reply through the block stream or a messaging-tool send. Spawns and
+    // cron adds deliver nothing to the source, so they must not suppress the
+    // acknowledgment.
+    if (successfulSourceReplyDelivery || completedSourceReplyDelivery) {
+      return undefined;
+    }
+    if (blockReplyPipeline?.didStream() && !blockReplyPipeline.isAborted()) {
+      return undefined;
+    }
+    return { text: yieldMessage };
   };
   // Route-aware message-tool delivery attests observed delivery in every mode:
   // an automatic-mode turn answered via the message tool plus NO_REPLY must not
@@ -358,6 +385,13 @@ export async function prepareReplyAgentPayloads(state: {
       return {
         kind: "return" as const,
         value: returnWithQueuedFollowupDrain(strandedRetryDiagnostic),
+      };
+    }
+    const yieldAcknowledgmentPayload = buildYieldAcknowledgmentPayload();
+    if (yieldAcknowledgmentPayload) {
+      return {
+        kind: "return" as const,
+        value: await returnPreparedFallbackPayload(yieldAcknowledgmentPayload),
       };
     }
     return { kind: "return" as const, value: returnWithQueuedFollowupDrain(undefined) };

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -348,6 +348,7 @@ describe("runReplyAgent auto-compaction token update", () => {
     sessionEntry: Record<string, unknown>;
     config?: Record<string, unknown>;
     sessionFile?: string;
+    sessionKey?: string;
     workspaceDir?: string;
   }) {
     const typing = createMockTypingController();
@@ -366,7 +367,7 @@ describe("runReplyAgent auto-compaction token update", () => {
         agentId: "main",
         agentDir: "/tmp/agent",
         sessionId: "session",
-        sessionKey: "main",
+        sessionKey: params.sessionKey ?? "main",
         messageProvider: "whatsapp",
         sessionFile: params.sessionFile ?? "/tmp/session.jsonl",
         workspaceDir: params.workspaceDir ?? "/tmp",
@@ -390,10 +391,12 @@ describe("runReplyAgent auto-compaction token update", () => {
     options?: {
       agentEvents?: Array<{ stream: string; data: Record<string, unknown> }>;
       config?: OpenClawConfig;
+      isHeartbeat?: boolean;
+      sessionKey?: string;
       onBlockReply?: (payload: unknown) => Promise<void> | void;
     },
   ) {
-    const sessionKey = "main";
+    const sessionKey = options?.sessionKey ?? "main";
     const sessionEntry = {
       sessionId: "session",
       updatedAt: Date.now(),
@@ -427,6 +430,7 @@ describe("runReplyAgent auto-compaction token update", () => {
       storePath: "",
       sessionEntry,
       config: options?.config,
+      sessionKey,
     });
     return runReplyAgent({
       commandBody: "hello",
@@ -437,7 +441,14 @@ describe("runReplyAgent auto-compaction token update", () => {
       shouldFollowup: false,
       isActive: false,
       isStreaming: false,
-      opts: options?.onBlockReply ? { onBlockReply: options.onBlockReply } : undefined,
+      opts: options?.onBlockReply
+        ? {
+            onBlockReply: options.onBlockReply,
+            ...(options?.isHeartbeat ? { isHeartbeat: true } : {}),
+          }
+        : options?.isHeartbeat
+          ? { isHeartbeat: true }
+          : undefined,
       typing,
       sessionCtx,
       sessionEntry,
@@ -632,6 +643,56 @@ describe("runReplyAgent auto-compaction token update", () => {
         acceptedSessionSpawns: [{ runId: "child-run", childSessionKey: "agent:main:child" }],
         meta: { agentMeta: {} },
       }),
+    ).toBeUndefined();
+  });
+
+  it("delivers the sessions_yield acknowledgment on an otherwise silent spawn-and-yield turn", async () => {
+    const result = await runEmptyDirectReply({
+      acceptedSessionSpawns: [{ runId: "child-run", childSessionKey: "agent:main:child" }],
+      yieldMessage: "On it — spawned a subagent, will report back.",
+      meta: { agentMeta: {}, yielded: true },
+    });
+
+    expect(requireRecord(result, "yield acknowledgment").text).toBe(
+      "On it — spawned a subagent, will report back.",
+    );
+  });
+
+  it("suppresses the yield acknowledgment when the source already received a visible reply", async () => {
+    expect(
+      await runEmptyDirectReply({
+        didSendViaMessagingTool: true,
+        messagingToolSentTexts: ["already replied visibly"],
+        messagingToolSentTargets: [{ to: "+15550001111", provider: "whatsapp" }],
+        yieldMessage: "On it — spawned a subagent, will report back.",
+        meta: { agentMeta: {}, yielded: true },
+      }),
+    ).toBeUndefined();
+  });
+
+  it("suppresses the yield acknowledgment for heartbeat runs", async () => {
+    expect(
+      await runEmptyDirectReply(
+        {
+          acceptedSessionSpawns: [{ runId: "child-run", childSessionKey: "agent:main:child" }],
+          yieldMessage: "On it — spawned a subagent, will report back.",
+          meta: { agentMeta: {}, yielded: true },
+        },
+        { isHeartbeat: true },
+      ),
+    ).toBeUndefined();
+  });
+
+  it("suppresses the yield acknowledgment for subagent sessions", async () => {
+    expect(
+      await runEmptyDirectReply(
+        {
+          acceptedSessionSpawns: [{ runId: "child-run", childSessionKey: "agent:main:child" }],
+          yieldMessage: "On it — spawned a subagent, will report back.",
+          meta: { agentMeta: {}, yielded: true },
+        },
+        { sessionKey: "agent:main:subagent:child-run" },
+      ),
     ).toBeUndefined();
   });
 


### PR DESCRIPTION
Closes #107788

## What Problem This Solves

Fixes an issue where users messaging the agent on any channel would see complete silence for several minutes when the model answered with `sessions_spawn` + `sessions_yield`: the model's yield acknowledgment (e.g. "On it — spawned a subagent, will report back") was captured by the agent harnesses but discarded before reply construction, so the turn ended with no visible reply until the subagent's completion announce.

## Why This Change Was Made

The root cause spans both harness result contracts: the embedded runner and the Codex app-server harness each recorded only a `yieldDetected` boolean, and the reply pipeline's empty-payload exit therefore had no message to deliver. Spawn/cron side effects also count as "outbound delivery" evidence, so the existing empty-reply guards treated the turn as handled. Following the fix shape in the issue's clawsweeper review, the yield message now travels as an optional attempt-result fact (`EmbeddedRunAttemptResult.yieldMessage`) through both harnesses onto the run result, and the canonical reply pipeline emits it once — only when the source turn produced no other visible delivery. Suppression deliberately uses source-conversation evidence only (block stream, messaging-tool sends): spawns and cron adds deliver nothing to the source and must not suppress the acknowledgment, otherwise the canonical spawn-and-yield case would stay silent. Heartbeat, silent-expected, and subagent sessions never surface the message, so internal yield context cannot leak into external replies. The message is consumed per attempt from the existing yield lifecycle state — no registry or cache, so stale text cannot leak across turns or sessions.

## User Impact

Users now see the agent's own acknowledgment immediately on spawn-and-yield turns instead of minutes of unexplained silence. Turns that yielded without a message, or where a reply already reached the conversation, are unchanged (the pre-existing "spawn-only empty replies stay silent" behavior is covered by regression tests and still holds).

## Evidence

New and updated tests, all passing on this branch:

```
$ node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt-result.test.ts src/agents/embedded-agent-runner/run/terminal-resolution.delivery-state.test.ts
 Test Files  2 passed (2)   Tests  7 passed (7)

$ node scripts/run-vitest.mjs extensions/codex/src/app-server/event-projector.commentary.test.ts
 Test Files  1 passed (1)   Tests  15 passed (15)

$ node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
 Test Files  1 passed (1)   Tests  78 passed (78)
```

The 78 include four new regression tests: acknowledgment delivered on an otherwise silent spawn-and-yield turn; suppressed when the source already received a visible reply; suppressed for heartbeat runs; suppressed for subagent sessions. `extensions/codex/src/app-server/run-attempt.test.ts` passes 116/117 in a full parallel run, with the single failure a 134s watchdog-style test exceeding its 120s timeout under load — it passes in isolation (75s). The pre-existing `agent-runner.runreplyagent.e2e.test.ts` shard shows the same 16 failed | 101 passed split with identical failure signatures on pristine `main` (verified by stashing this change and re-running), so it is upstream breakage unrelated to this PR. `git diff --check` is clean. A full local `tsc --noEmit` was not possible on the author's 15 GB machine (heap exhaustion); the change reuses the exact optional-field patterns of adjacent compiling code and relies on CI for the full typecheck.
