### PR TITLE
Gateway: harden hosted wizard lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -328,6 +328,7 @@ Docs: https://docs.openclaw.ai
 - **Signal native quote replies:** preserve the active inbound message as a native quote across agent, explicit, durable, and chunked sends while keeping reply-mode policy inside the Signal plugin. (#105347) Thanks @jesse-merhi.
 - **Media-store remote downloads:** bound response-header waits and stalled bodies, close abandoned redirect and error responses, and remove partial temp files so hung sources cannot pin callers. (#104624) Thanks @hugenshen.
 - **Cron llama.cpp tool schemas:** keep the model-facing cron declaration schema compatible with llama.cpp while retaining gateway and runtime nonblank validation. Fixes #107449. (#108360) Thanks @lee-xydt.
+- **Hosted channel setup lifecycle:** abort reversible setup on cancellation or idle expiry, and retain owner-bound locked work through reconnect, reset, and eviction until recovery completes.
 
 ## 2026.7.1
 

--- a/extensions/buzz/src/setup-surface.test.ts
+++ b/extensions/buzz/src/setup-surface.test.ts
@@ -371,11 +371,13 @@ describe("Buzz guided setup", () => {
     });
     const prompter = createPrompter();
     vi.mocked(prompter.multiselect).mockResolvedValue([ROOM_A]);
+    const abortController = new AbortController();
 
     const result = await wizard.configure({
       cfg: {} as OpenClawConfig,
       runtime: createRuntime(),
       prompter,
+      options: { abortSignal: abortController.signal },
       accountOverrides: {},
       shouldPromptAccountIds: false,
       forceAllowFrom: false,
@@ -384,10 +386,16 @@ describe("Buzz guided setup", () => {
     expect(discoverRooms).toHaveBeenCalledOnce();
     const expectedPrivateKey = nip19.nsecEncode(GENERATED_KEY);
     expect(discoverRooms).toHaveBeenCalledWith(
-      expect.objectContaining({ privateKey: expectedPrivateKey }),
+      expect.objectContaining({
+        privateKey: expectedPrivateKey,
+        signal: abortController.signal,
+      }),
     );
     expect(waitForRoomAccess).toHaveBeenCalledWith(
-      expect.objectContaining({ privateKey: expectedPrivateKey }),
+      expect.objectContaining({
+        privateKey: expectedPrivateKey,
+        signal: abortController.signal,
+      }),
     );
     expect(result.cfg.channels?.buzz?.enabled).toBe(true);
     expect(result.cfg.channels?.buzz?.defaultTo).toBe(ROOM_A);

--- a/extensions/buzz/src/setup-surface.ts
+++ b/extensions/buzz/src/setup-surface.ts
@@ -341,6 +341,7 @@ export function createBuzzSetupWizard(
             relayUrl,
             privateKey,
             ...(authTag ? { authTag } : {}),
+            ...(options?.abortSignal ? { signal: options.abortSignal } : {}),
           });
           discoveryError =
             rooms.length === 0 ? "No authorized rooms were returned for this bot." : undefined;
@@ -364,6 +365,7 @@ export function createBuzzSetupWizard(
             relayUrl,
             privateKey,
             ...(authTag ? { authTag } : {}),
+            ...(options?.abortSignal ? { signal: options.abortSignal } : {}),
           });
           progress.stop(
             discoveredRooms.length > 0
@@ -371,6 +373,9 @@ export function createBuzzSetupWizard(
               : "Buzz room access wait expired",
           );
         } catch (error) {
+          if (options?.abortSignal?.aborted) {
+            throw options.abortSignal.reason instanceof Error ? options.abortSignal.reason : error;
+          }
           progress.stop("Buzz room access check failed");
           await prompter.note(
             error instanceof Error ? error.message : String(error),

--- a/src/channels/plugins/setup-wizard-types.ts
+++ b/src/channels/plugins/setup-wizard-types.ts
@@ -307,8 +307,12 @@ export type SetupChannelsOptions = {
   beforePersistentEffect?: () => Promise<void>;
   /** Cancels reversible setup work when the controlling hosted session stops. */
   abortSignal?: AbortSignal;
-  /** Reports a canonical channel as soon as the user enters its setup flow. */
-  onChannelSelected?: (channel: ChannelId) => void;
+  /** Reports channel identity immediately before setup crosses a durable-effect boundary. */
+  onChannelSelected?: (channel: ChannelId, aliases?: readonly string[]) => void;
+  /** Reports channel identities whose in-memory changes are ready for the caller to commit. */
+  onPendingChannelEffects?: (
+    channels: ReadonlyArray<{ channel: ChannelId; aliases?: readonly string[] }>,
+  ) => void;
   onSelection?: (selection: ChannelId[]) => void;
   onPostWriteHook?: (hook: ChannelOnboardingPostWriteHook) => void;
   accountIds?: Partial<Record<ChannelId, string>>;

--- a/src/channels/plugins/setup-wizard-types.ts
+++ b/src/channels/plugins/setup-wizard-types.ts
@@ -307,6 +307,8 @@ export type SetupChannelsOptions = {
   beforePersistentEffect?: () => Promise<void>;
   /** Cancels reversible setup work when the controlling hosted session stops. */
   abortSignal?: AbortSignal;
+  /** Reports a canonical channel as soon as the user enters its setup flow. */
+  onChannelSelected?: (channel: ChannelId) => void;
   onSelection?: (selection: ChannelId[]) => void;
   onPostWriteHook?: (hook: ChannelOnboardingPostWriteHook) => void;
   accountIds?: Partial<Record<ChannelId, string>>;

--- a/src/channels/plugins/setup-wizard-types.ts
+++ b/src/channels/plugins/setup-wizard-types.ts
@@ -305,6 +305,8 @@ export type SetupChannelsOptions = {
   allowSignalInstall?: boolean;
   /** Revalidate host authority immediately before an installer or other durable effect. */
   beforePersistentEffect?: () => Promise<void>;
+  /** Cancels reversible setup work when the controlling hosted session stops. */
+  abortSignal?: AbortSignal;
   onSelection?: (selection: ChannelId[]) => void;
   onPostWriteHook?: (hook: ChannelOnboardingPostWriteHook) => void;
   accountIds?: Partial<Record<ChannelId, string>>;

--- a/src/commands/channels.add.test.ts
+++ b/src/commands/channels.add.test.ts
@@ -571,6 +571,40 @@ describe("channelsAddCommand", () => {
     expect(configMocks.writeConfigFile).toHaveBeenCalledWith(configured);
   });
 
+  it("does not bind a targeted channel abandoned before another channel commits", async () => {
+    const config: OpenClawConfig = { channels: {} };
+    const configured: OpenClawConfig = {
+      channels: {
+        discord: { enabled: true },
+      },
+    };
+    const onResolvedChannel = vi.fn();
+    configMocks.readConfigFileSnapshot.mockResolvedValue({
+      ...baseConfigSnapshot,
+      sourceConfig: config,
+      config,
+    });
+    channelWizardMocks.setupChannels.mockImplementationOnce(async (...args: unknown[]) => {
+      const options = args[3] as SetupChannelsOptions;
+      options.onPendingChannelEffects?.([{ channel: "discord" }]);
+      options.onSelection?.(["discord"]);
+      return configured;
+    });
+
+    await runChannelsSetupWizard(
+      {
+        channel: "lifecycle-chat",
+        onResolvedChannel,
+        beforePersistentEffect: async () => undefined,
+      },
+      runtime,
+      channelWizardMocks.prompter,
+    );
+
+    expect(onResolvedChannel).toHaveBeenCalledOnce();
+    expect(onResolvedChannel).toHaveBeenCalledWith("discord", undefined);
+  });
+
   it("persists an accepted plugin install after setup returns to an empty selection", async () => {
     const config: OpenClawConfig = { channels: {} };
     const installedConfig: OpenClawConfig = {

--- a/src/commands/channels.add.test.ts
+++ b/src/commands/channels.add.test.ts
@@ -24,6 +24,7 @@ import { baseConfigSnapshot, createTestRuntime } from "./test-runtime-config-hel
 
 let channelsAddCommand: typeof import("./channels/add.js").channelsAddCommand;
 let runChannelsSetupWizard: typeof import("./channels/add-wizard.js").runChannelsSetupWizard;
+type SetupChannels = typeof import("./onboard-channels.js").setupChannels;
 
 const catalogMocks = vi.hoisted(() => ({
   getChannelPluginCatalogEntry: vi.fn(),
@@ -60,7 +61,7 @@ const channelWizardMocks = vi.hoisted(() => {
   };
   return {
     prompter,
-    setupChannels: vi.fn(async (...args: unknown[]) => args[0] as OpenClawConfig),
+    setupChannels: vi.fn<SetupChannels>(async (cfg) => cfg),
   };
 });
 
@@ -385,8 +386,6 @@ type SignalSetupInput = ChannelSetupInput & { signalNumber?: string };
 type NextcloudTalkSetupInput = ChannelSetupInput & { secretFile?: string };
 type MatrixSetupInput = ChannelSetupInput & { initialSyncLimit?: number };
 type PreparedChatSetupInput = ChannelSetupInput & { workspace?: string };
-type SetupChannelsOptions =
-  import("../channels/plugins/setup-wizard-types.js").SetupChannelsOptions;
 
 function createSignalPlugin(
   afterAccountConfigWritten: SignalAfterAccountConfigWritten,
@@ -488,9 +487,7 @@ describe("channelsAddCommand", () => {
     channelWizardMocks.prompter.select.mockClear();
     channelWizardMocks.prompter.text.mockClear();
     channelWizardMocks.setupChannels.mockClear();
-    channelWizardMocks.setupChannels.mockImplementation(
-      async (...args: unknown[]) => args[0] as OpenClawConfig,
-    );
+    channelWizardMocks.setupChannels.mockImplementation(async (cfg) => cfg);
     setMinimalChannelsAddRegistryForTests();
   });
 
@@ -547,17 +544,29 @@ describe("channelsAddCommand", () => {
     const beforePersistentEffect = vi.fn(async () => {
       events.push("guard");
     });
+    pluginInstallRecordCommitMocks.commitConfigWithPendingPluginInstalls.mockImplementationOnce(
+      async (params: { nextConfig: unknown }) => {
+        events.push("commit");
+        await configMocks.writeConfigFile(params.nextConfig);
+        return {
+          config: params.nextConfig,
+          installRecords: {},
+          movedInstallRecords: false,
+        };
+      },
+    );
     configMocks.readConfigFileSnapshot.mockResolvedValue({
       ...baseConfigSnapshot,
       sourceConfig: config,
       config,
     });
-    channelWizardMocks.setupChannels.mockImplementationOnce(async (...args: unknown[]) => {
-      const options = args[3] as SetupChannelsOptions;
-      options.onPendingChannelEffects?.([{ channel: "twitch", aliases: ["twitch-chat"] }]);
-      options.onSelection?.(["twitch"]);
-      return configured;
-    });
+    channelWizardMocks.setupChannels.mockImplementationOnce(
+      async (_cfg, _runtime, _prompter, options) => {
+        options.onPendingChannelEffects?.([{ channel: "twitch", aliases: ["twitch-chat"] }]);
+        options.onSelection?.(["twitch"]);
+        return configured;
+      },
+    );
 
     await runChannelsSetupWizard(
       { onResolvedChannel, beforePersistentEffect },
@@ -567,7 +576,7 @@ describe("channelsAddCommand", () => {
 
     expect(onResolvedChannel).toHaveBeenCalledOnce();
     expect(onResolvedChannel).toHaveBeenCalledWith("twitch", ["twitch-chat"]);
-    expect(events).toEqual(["guard", "identity"]);
+    expect(events).toEqual(["guard", "identity", "commit"]);
     expect(configMocks.writeConfigFile).toHaveBeenCalledWith(configured);
   });
 
@@ -584,12 +593,13 @@ describe("channelsAddCommand", () => {
       sourceConfig: config,
       config,
     });
-    channelWizardMocks.setupChannels.mockImplementationOnce(async (...args: unknown[]) => {
-      const options = args[3] as SetupChannelsOptions;
-      options.onPendingChannelEffects?.([{ channel: "discord" }]);
-      options.onSelection?.(["discord"]);
-      return configured;
-    });
+    channelWizardMocks.setupChannels.mockImplementationOnce(
+      async (_cfg, _runtime, _prompter, options) => {
+        options.onPendingChannelEffects?.([{ channel: "discord" }]);
+        options.onSelection?.(["discord"]);
+        return configured;
+      },
+    );
 
     await runChannelsSetupWizard(
       {

--- a/src/commands/channels.add.test.ts
+++ b/src/commands/channels.add.test.ts
@@ -54,7 +54,9 @@ const channelWizardMocks = vi.hoisted(() => {
     confirm: vi.fn(async () => false),
     note: vi.fn(async () => undefined),
     select: vi.fn(),
+    multiselect: vi.fn(),
     text: vi.fn(),
+    progress: vi.fn(() => ({ update: vi.fn(), stop: vi.fn() })),
   };
   return {
     prompter,

--- a/src/commands/channels.add.test.ts
+++ b/src/commands/channels.add.test.ts
@@ -385,6 +385,8 @@ type SignalSetupInput = ChannelSetupInput & { signalNumber?: string };
 type NextcloudTalkSetupInput = ChannelSetupInput & { secretFile?: string };
 type MatrixSetupInput = ChannelSetupInput & { initialSyncLimit?: number };
 type PreparedChatSetupInput = ChannelSetupInput & { workspace?: string };
+type SetupChannelsOptions =
+  import("../channels/plugins/setup-wizard-types.js").SetupChannelsOptions;
 
 function createSignalPlugin(
   afterAccountConfigWritten: SignalAfterAccountConfigWritten,
@@ -529,6 +531,44 @@ describe("channelsAddCommand", () => {
     );
 
     expect(setupOptions().abortSignal).toBe(abortController.signal);
+  });
+
+  it("binds browse-all channel aliases immediately before config commit", async () => {
+    const config: OpenClawConfig = { channels: {} };
+    const configured: OpenClawConfig = {
+      channels: {
+        twitch: { enabled: true },
+      },
+    };
+    const events: string[] = [];
+    const onResolvedChannel = vi.fn((_channel: string, _aliases?: readonly string[]) => {
+      events.push("identity");
+    });
+    const beforePersistentEffect = vi.fn(async () => {
+      events.push("guard");
+    });
+    configMocks.readConfigFileSnapshot.mockResolvedValue({
+      ...baseConfigSnapshot,
+      sourceConfig: config,
+      config,
+    });
+    channelWizardMocks.setupChannels.mockImplementationOnce(async (...args: unknown[]) => {
+      const options = args[3] as SetupChannelsOptions;
+      options.onPendingChannelEffects?.([{ channel: "twitch", aliases: ["twitch-chat"] }]);
+      options.onSelection?.(["twitch"]);
+      return configured;
+    });
+
+    await runChannelsSetupWizard(
+      { onResolvedChannel, beforePersistentEffect },
+      runtime,
+      channelWizardMocks.prompter,
+    );
+
+    expect(onResolvedChannel).toHaveBeenCalledOnce();
+    expect(onResolvedChannel).toHaveBeenCalledWith("twitch", ["twitch-chat"]);
+    expect(events).toEqual(["guard", "identity"]);
+    expect(configMocks.writeConfigFile).toHaveBeenCalledWith(configured);
   });
 
   it("persists an accepted plugin install after setup returns to an empty selection", async () => {

--- a/src/commands/channels.add.test.ts
+++ b/src/commands/channels.add.test.ts
@@ -23,6 +23,7 @@ import {
 import { baseConfigSnapshot, createTestRuntime } from "./test-runtime-config-helpers.js";
 
 let channelsAddCommand: typeof import("./channels/add.js").channelsAddCommand;
+let runChannelsSetupWizard: typeof import("./channels/add-wizard.js").runChannelsSetupWizard;
 
 const catalogMocks = vi.hoisted(() => ({
   getChannelPluginCatalogEntry: vi.fn(),
@@ -428,6 +429,7 @@ async function runSignalAddCommand(
 describe("channelsAddCommand", () => {
   beforeAll(async () => {
     ({ channelsAddCommand } = await import("./channels/add.js"));
+    ({ runChannelsSetupWizard } = await import("./channels/add-wizard.js"));
   });
 
   beforeEach(async () => {
@@ -507,6 +509,24 @@ describe("channelsAddCommand", () => {
     expect(setupOptions().promptAccountIds).toBe(true);
     expect(configMocks.writeConfigFile).not.toHaveBeenCalled();
     expect(channelWizardMocks.prompter.outro).toHaveBeenCalledWith("No channel changes made.");
+  });
+
+  it("forwards the hosted cancellation signal through the default Gateway runner", async () => {
+    const abortController = new AbortController();
+    const config: OpenClawConfig = { channels: {} };
+    configMocks.readConfigFileSnapshot.mockResolvedValue({
+      ...baseConfigSnapshot,
+      sourceConfig: config,
+      config,
+    });
+
+    await runChannelsSetupWizard(
+      { abortSignal: abortController.signal },
+      runtime,
+      channelWizardMocks.prompter,
+    );
+
+    expect(setupOptions().abortSignal).toBe(abortController.signal);
   });
 
   it("persists an accepted plugin install after setup returns to an empty selection", async () => {

--- a/src/commands/channels.add.test.ts
+++ b/src/commands/channels.add.test.ts
@@ -562,8 +562,8 @@ describe("channelsAddCommand", () => {
     });
     channelWizardMocks.setupChannels.mockImplementationOnce(
       async (_cfg, _runtime, _prompter, options) => {
-        options.onPendingChannelEffects?.([{ channel: "twitch", aliases: ["twitch-chat"] }]);
-        options.onSelection?.(["twitch"]);
+        options?.onPendingChannelEffects?.([{ channel: "twitch", aliases: ["twitch-chat"] }]);
+        options?.onSelection?.(["twitch"]);
         return configured;
       },
     );
@@ -595,8 +595,8 @@ describe("channelsAddCommand", () => {
     });
     channelWizardMocks.setupChannels.mockImplementationOnce(
       async (_cfg, _runtime, _prompter, options) => {
-        options.onPendingChannelEffects?.([{ channel: "discord" }]);
-        options.onSelection?.(["discord"]);
+        options?.onPendingChannelEffects?.([{ channel: "discord" }]);
+        options?.onSelection?.(["discord"]);
         return configured;
       },
     );

--- a/src/commands/channels/add-wizard.ts
+++ b/src/commands/channels/add-wizard.ts
@@ -21,16 +21,11 @@ async function loadOnboardChannels(): Promise<OnboardChannelsModule> {
   return await import("../onboard-channels.js");
 }
 
-type ResolvedInitialWizardChannel = {
-  id: ChannelChoice;
-  aliases: string[];
-};
-
 /** Resolve a raw channel name/alias against the installed setup entries. */
-export async function resolveInitialWizardChannelDetails(
+export async function resolveInitialWizardChannel(
   raw: string,
   cfg: OpenClawConfig,
-): Promise<ResolvedInitialWizardChannel | undefined> {
+): Promise<ChannelChoice | undefined> {
   const normalized = normalizeOptionalLowercaseString(raw);
   if (!normalized) {
     return undefined;
@@ -44,26 +39,14 @@ export async function resolveInitialWizardChannelDetails(
     installedPlugins: listActiveChannelSetupPlugins(),
     workspaceDir: resolveAgentWorkspaceDir(cfg, resolveDefaultAgentId(cfg)),
   });
-  const entry =
+  return (
     resolved.entries.find((entry) => normalizeOptionalLowercaseString(entry.id) === normalized) ??
     resolved.entries.find((entry) =>
       (entry.meta.aliases ?? []).some(
         (alias) => normalizeOptionalLowercaseString(alias) === normalized,
       ),
-    );
-  return entry
-    ? {
-        id: entry.id,
-        aliases: [...(entry.meta.aliases ?? [])],
-      }
-    : undefined;
-}
-
-export async function resolveInitialWizardChannel(
-  raw: string,
-  cfg: OpenClawConfig,
-): Promise<ChannelChoice | undefined> {
-  return (await resolveInitialWizardChannelDetails(raw, cfg))?.id;
+    )
+  )?.id;
 }
 
 type ChannelsAddWizardFlowParams = {
@@ -89,9 +72,6 @@ type ChannelsAddWizardFlowParams = {
 /** Run the interactive channel-setup flow and persist the resulting config. */
 export async function runChannelsAddWizardFlow(params: ChannelsAddWizardFlowParams): Promise<void> {
   const { cfg, baseHash, runtime, prompter } = params;
-  if (params.initialChannel) {
-    params.onResolvedChannel?.(params.initialChannel);
-  }
   const [{ buildAgentSummaries }, onboardChannels] = await Promise.all([
     import("../agents.config.js"),
     loadOnboardChannels(),
@@ -326,13 +306,9 @@ export async function runChannelsSetupWizard(
     );
   }
   const cfg = (snapshot.sourceConfig ?? snapshot.config) as OpenClawConfig;
-  const resolvedInitialChannel = opts.channel
-    ? await resolveInitialWizardChannelDetails(opts.channel, cfg)
+  const initialChannel = opts.channel
+    ? await resolveInitialWizardChannel(opts.channel, cfg)
     : undefined;
-  const initialChannel = resolvedInitialChannel?.id;
-  if (resolvedInitialChannel) {
-    opts.onResolvedChannel?.(resolvedInitialChannel.id, resolvedInitialChannel.aliases);
-  }
   await runChannelsAddWizardFlow({
     cfg,
     ...(snapshot.hash !== undefined ? { baseHash: snapshot.hash } : {}),

--- a/src/commands/channels/add-wizard.ts
+++ b/src/commands/channels/add-wizard.ts
@@ -112,6 +112,9 @@ export async function runChannelsAddWizardFlow(params: ChannelsAddWizardFlowPara
       : {}),
     ...(params.abortSignal ? { abortSignal: params.abortSignal } : {}),
     ...(params.deferDeviceLinkToClient ? { deferDeviceLinkToClient: true } : {}),
+    ...(params.onResolvedChannel
+      ? { onChannelSelected: (channel: ChannelChoice) => params.onResolvedChannel?.(channel) }
+      : {}),
     onPostWriteHook: (hook) => {
       postWriteHooks.collect(hook);
     },

--- a/src/commands/channels/add-wizard.ts
+++ b/src/commands/channels/add-wizard.ts
@@ -56,6 +56,7 @@ type ChannelsAddWizardFlowParams = {
   prompter: WizardPrompter;
   initialChannel?: ChannelChoice;
   beforePersistentEffect?: () => Promise<void>;
+  abortSignal?: AbortSignal;
   /**
    * The controlling client completes device linking itself after config is
    * written (e.g. the Control UI renders the WhatsApp QR via web.login.*), so
@@ -87,6 +88,7 @@ export async function runChannelsAddWizardFlow(params: ChannelsAddWizardFlowPara
     ...(params.beforePersistentEffect
       ? { beforePersistentEffect: params.beforePersistentEffect }
       : {}),
+    ...(params.abortSignal ? { abortSignal: params.abortSignal } : {}),
     ...(params.deferDeviceLinkToClient ? { deferDeviceLinkToClient: true } : {}),
     onPostWriteHook: (hook) => {
       postWriteHooks.collect(hook);
@@ -260,6 +262,8 @@ export async function runChannelsSetupWizard(
     onConfigured?: (accounts: Array<{ channel: string; accountId: string }>) => void;
     /** Revalidate/lock cancellation immediately before durable effects. */
     beforePersistentEffect?: () => Promise<void>;
+    /** Cancels reversible setup work when the remote wizard stops. */
+    abortSignal?: AbortSignal;
   },
   runtime: RuntimeEnv,
   prompter: WizardPrompter,
@@ -283,5 +287,6 @@ export async function runChannelsSetupWizard(
     deferDeviceLinkToClient: true,
     ...(opts.onConfigured ? { onConfigured: opts.onConfigured } : {}),
     ...(opts.beforePersistentEffect ? { beforePersistentEffect: opts.beforePersistentEffect } : {}),
+    ...(opts.abortSignal ? { abortSignal: opts.abortSignal } : {}),
   });
 }

--- a/src/commands/channels/add-wizard.ts
+++ b/src/commands/channels/add-wizard.ts
@@ -49,24 +49,32 @@ export async function resolveInitialWizardChannel(
   )?.id;
 }
 
-type ChannelsAddWizardFlowParams = {
+export type HostedChannelSetupLifecycleOptions = {
+  onConfigured?: (accounts: Array<{ channel: ChannelChoice; accountId: string }>) => void;
+  onResolvedChannel?: (channel: ChannelChoice, aliases?: readonly string[]) => void;
+  /** Revalidate/lock cancellation immediately before durable effects. */
+  beforePersistentEffect?: () => Promise<void>;
+  /** Cancels reversible setup work when the remote wizard stops. */
+  abortSignal?: AbortSignal;
+};
+
+export type RunChannelsSetupWizardOptions = HostedChannelSetupLifecycleOptions & {
+  /** Raw channel id or alias supplied by the remote client. */
+  channel?: string;
+};
+
+type ChannelsAddWizardFlowParams = HostedChannelSetupLifecycleOptions & {
   cfg: OpenClawConfig;
   baseHash?: string;
   runtime: RuntimeEnv;
   prompter: WizardPrompter;
   initialChannel?: ChannelChoice;
-  beforePersistentEffect?: () => Promise<void>;
-  abortSignal?: AbortSignal;
   /**
    * The controlling client completes device linking itself after config is
    * written (e.g. the Control UI renders the WhatsApp QR via web.login.*), so
    * setup surfaces must skip terminal-interactive login flows.
    */
   deferDeviceLinkToClient?: boolean;
-  /** Reports the channel accounts actually configured, after config commit. */
-  onConfigured?: (accounts: Array<{ channel: string; accountId: string }>) => void;
-  /** Reports the canonical single channel selected for this setup operation. */
-  onResolvedChannel?: (channel: string, aliases?: readonly string[]) => void;
 };
 
 /** Run the interactive channel-setup flow and persist the resulting config. */
@@ -287,15 +295,7 @@ export async function runChannelsAddWizardFlow(params: ChannelsAddWizardFlowPara
  * must never call runtime.exit — failures throw and surface as wizard errors.
  */
 export async function runChannelsSetupWizard(
-  opts: {
-    channel?: string;
-    onConfigured?: (accounts: Array<{ channel: string; accountId: string }>) => void;
-    onResolvedChannel?: (channel: string, aliases?: readonly string[]) => void;
-    /** Revalidate/lock cancellation immediately before durable effects. */
-    beforePersistentEffect?: () => Promise<void>;
-    /** Cancels reversible setup work when the remote wizard stops. */
-    abortSignal?: AbortSignal;
-  },
+  opts: RunChannelsSetupWizardOptions,
   runtime: RuntimeEnv,
   prompter: WizardPrompter,
 ): Promise<void> {

--- a/src/commands/channels/add-wizard.ts
+++ b/src/commands/channels/add-wizard.ts
@@ -21,11 +21,16 @@ async function loadOnboardChannels(): Promise<OnboardChannelsModule> {
   return await import("../onboard-channels.js");
 }
 
+type ResolvedInitialWizardChannel = {
+  id: ChannelChoice;
+  aliases: string[];
+};
+
 /** Resolve a raw channel name/alias against the installed setup entries. */
-export async function resolveInitialWizardChannel(
+export async function resolveInitialWizardChannelDetails(
   raw: string,
   cfg: OpenClawConfig,
-): Promise<ChannelChoice | undefined> {
+): Promise<ResolvedInitialWizardChannel | undefined> {
   const normalized = normalizeOptionalLowercaseString(raw);
   if (!normalized) {
     return undefined;
@@ -39,14 +44,26 @@ export async function resolveInitialWizardChannel(
     installedPlugins: listActiveChannelSetupPlugins(),
     workspaceDir: resolveAgentWorkspaceDir(cfg, resolveDefaultAgentId(cfg)),
   });
-  return (
+  const entry =
     resolved.entries.find((entry) => normalizeOptionalLowercaseString(entry.id) === normalized) ??
     resolved.entries.find((entry) =>
       (entry.meta.aliases ?? []).some(
         (alias) => normalizeOptionalLowercaseString(alias) === normalized,
       ),
-    )
-  )?.id;
+    );
+  return entry
+    ? {
+        id: entry.id,
+        aliases: [...(entry.meta.aliases ?? [])],
+      }
+    : undefined;
+}
+
+export async function resolveInitialWizardChannel(
+  raw: string,
+  cfg: OpenClawConfig,
+): Promise<ChannelChoice | undefined> {
+  return (await resolveInitialWizardChannelDetails(raw, cfg))?.id;
 }
 
 type ChannelsAddWizardFlowParams = {
@@ -66,7 +83,7 @@ type ChannelsAddWizardFlowParams = {
   /** Reports the channel accounts actually configured, after config commit. */
   onConfigured?: (accounts: Array<{ channel: string; accountId: string }>) => void;
   /** Reports the canonical single channel selected for this setup operation. */
-  onResolvedChannel?: (channel: string) => void;
+  onResolvedChannel?: (channel: string, aliases?: readonly string[]) => void;
 };
 
 /** Run the interactive channel-setup flow and persist the resulting config. */
@@ -269,7 +286,7 @@ export async function runChannelsSetupWizard(
   opts: {
     channel?: string;
     onConfigured?: (accounts: Array<{ channel: string; accountId: string }>) => void;
-    onResolvedChannel?: (channel: string) => void;
+    onResolvedChannel?: (channel: string, aliases?: readonly string[]) => void;
     /** Revalidate/lock cancellation immediately before durable effects. */
     beforePersistentEffect?: () => Promise<void>;
     /** Cancels reversible setup work when the remote wizard stops. */
@@ -285,9 +302,13 @@ export async function runChannelsSetupWizard(
     );
   }
   const cfg = (snapshot.sourceConfig ?? snapshot.config) as OpenClawConfig;
-  const initialChannel = opts.channel
-    ? await resolveInitialWizardChannel(opts.channel, cfg)
+  const resolvedInitialChannel = opts.channel
+    ? await resolveInitialWizardChannelDetails(opts.channel, cfg)
     : undefined;
+  const initialChannel = resolvedInitialChannel?.id;
+  if (resolvedInitialChannel) {
+    opts.onResolvedChannel?.(resolvedInitialChannel.id, resolvedInitialChannel.aliases);
+  }
   await runChannelsAddWizardFlow({
     cfg,
     ...(snapshot.hash !== undefined ? { baseHash: snapshot.hash } : {}),

--- a/src/commands/channels/add-wizard.ts
+++ b/src/commands/channels/add-wizard.ts
@@ -98,6 +98,12 @@ export async function runChannelsAddWizardFlow(params: ChannelsAddWizardFlowPara
   ]);
   const postWriteHooks = onboardChannels.createChannelOnboardingPostWriteHookCollector();
   let selection: ChannelChoice[] = [];
+  const pendingChannelEffects = new Map<string, readonly string[] | undefined>();
+  const rememberPendingChannelEffect = (channel: string, aliases?: readonly string[]) => {
+    if (aliases?.length || !pendingChannelEffects.has(channel)) {
+      pendingChannelEffects.set(channel, aliases);
+    }
+  };
   const accountIds: Partial<Record<ChannelChoice, string>> = {};
   const resolvedPlugins = new Map<ChannelChoice, ChannelSetupPlugin>();
   await prompter.intro("Channel setup");
@@ -113,8 +119,16 @@ export async function runChannelsAddWizardFlow(params: ChannelsAddWizardFlowPara
     ...(params.abortSignal ? { abortSignal: params.abortSignal } : {}),
     ...(params.deferDeviceLinkToClient ? { deferDeviceLinkToClient: true } : {}),
     ...(params.onResolvedChannel
-      ? { onChannelSelected: (channel: ChannelChoice) => params.onResolvedChannel?.(channel) }
+      ? {
+          onChannelSelected: (channel: ChannelChoice, aliases?: readonly string[]) =>
+            params.onResolvedChannel?.(channel, aliases),
+        }
       : {}),
+    onPendingChannelEffects: (channels) => {
+      for (const { channel, aliases } of channels) {
+        rememberPendingChannelEffect(channel, aliases);
+      }
+    },
     onPostWriteHook: (hook) => {
       postWriteHooks.collect(hook);
     },
@@ -123,9 +137,11 @@ export async function runChannelsAddWizardFlow(params: ChannelsAddWizardFlowPara
     skipStatusNote: true,
     onSelection: (value) => {
       selection = value;
-      const resolvedChannel = value.length === 1 ? value[0] : undefined;
-      if (resolvedChannel) {
-        params.onResolvedChannel?.(resolvedChannel);
+      for (const channel of value) {
+        const aliases =
+          resolvedPlugins.get(channel)?.meta.aliases ??
+          getLoadedChannelPlugin(channel)?.meta.aliases;
+        rememberPendingChannelEffect(channel, aliases);
       }
     },
     onAccountId: (channel, accountId) => {
@@ -137,6 +153,11 @@ export async function runChannelsAddWizardFlow(params: ChannelsAddWizardFlowPara
   });
   const commitWizardConfig = async (config: OpenClawConfig) => {
     await params.beforePersistentEffect?.();
+    // The lock and identity update stay adjacent so failed guards cannot make
+    // reversible browse-all choices look like committed channel work.
+    for (const [channel, aliases] of pendingChannelEffects) {
+      params.onResolvedChannel?.(channel, aliases);
+    }
     const committed = await commitConfigWithPendingPluginInstalls({
       nextConfig: config,
       ...(baseHash !== undefined ? { baseHash } : {}),

--- a/src/commands/channels/add-wizard.ts
+++ b/src/commands/channels/add-wizard.ts
@@ -65,11 +65,16 @@ type ChannelsAddWizardFlowParams = {
   deferDeviceLinkToClient?: boolean;
   /** Reports the channel accounts actually configured, after config commit. */
   onConfigured?: (accounts: Array<{ channel: string; accountId: string }>) => void;
+  /** Reports the canonical single channel selected for this setup operation. */
+  onResolvedChannel?: (channel: string) => void;
 };
 
 /** Run the interactive channel-setup flow and persist the resulting config. */
 export async function runChannelsAddWizardFlow(params: ChannelsAddWizardFlowParams): Promise<void> {
   const { cfg, baseHash, runtime, prompter } = params;
+  if (params.initialChannel) {
+    params.onResolvedChannel?.(params.initialChannel);
+  }
   const [{ buildAgentSummaries }, onboardChannels] = await Promise.all([
     import("../agents.config.js"),
     loadOnboardChannels(),
@@ -98,6 +103,10 @@ export async function runChannelsAddWizardFlow(params: ChannelsAddWizardFlowPara
     skipStatusNote: true,
     onSelection: (value) => {
       selection = value;
+      const resolvedChannel = value.length === 1 ? value[0] : undefined;
+      if (resolvedChannel) {
+        params.onResolvedChannel?.(resolvedChannel);
+      }
     },
     onAccountId: (channel, accountId) => {
       accountIds[channel] = accountId;
@@ -260,6 +269,7 @@ export async function runChannelsSetupWizard(
   opts: {
     channel?: string;
     onConfigured?: (accounts: Array<{ channel: string; accountId: string }>) => void;
+    onResolvedChannel?: (channel: string) => void;
     /** Revalidate/lock cancellation immediately before durable effects. */
     beforePersistentEffect?: () => Promise<void>;
     /** Cancels reversible setup work when the remote wizard stops. */
@@ -286,6 +296,7 @@ export async function runChannelsSetupWizard(
     ...(initialChannel ? { initialChannel } : {}),
     deferDeviceLinkToClient: true,
     ...(opts.onConfigured ? { onConfigured: opts.onConfigured } : {}),
+    ...(opts.onResolvedChannel ? { onResolvedChannel: opts.onResolvedChannel } : {}),
     ...(opts.beforePersistentEffect ? { beforePersistentEffect: opts.beforePersistentEffect } : {}),
     ...(opts.abortSignal ? { abortSignal: opts.abortSignal } : {}),
   });

--- a/src/flows/channel-setup-navigation.test.ts
+++ b/src/flows/channel-setup-navigation.test.ts
@@ -4,6 +4,29 @@ import { WizardCancelledError } from "../wizard/prompts.js";
 import { runScopedChannelStep } from "./channel-setup-navigation.js";
 
 describe("channel setup navigation", () => {
+  it("reports channel identity immediately before the durable-effect guard", async () => {
+    const events: string[] = [];
+
+    await runScopedChannelStep({
+      prompter: createWizardPrompter(),
+      options: {
+        beforePersistentEffect: async () => {
+          events.push("guard");
+        },
+      },
+      runner: async (_prompter, options) => {
+        events.push("runner");
+        await options.beforePersistentEffect?.();
+        events.push("effect");
+      },
+      onPersistentEffect: () => {
+        events.push("identity");
+      },
+    });
+
+    expect(events).toEqual(["runner", "guard", "identity", "effect"]);
+  });
+
   it("settles reversible setup work when the controlling session aborts", async () => {
     const abortController = new AbortController();
     const reason = new WizardCancelledError();

--- a/src/flows/channel-setup-navigation.test.ts
+++ b/src/flows/channel-setup-navigation.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from "vitest";
+import { createWizardPrompter } from "../../test/helpers/wizard-prompter.js";
+import { WizardCancelledError } from "../wizard/prompts.js";
+import { runScopedChannelStep } from "./channel-setup-navigation.js";
+
+describe("channel setup navigation", () => {
+  it("settles reversible setup work when the controlling session aborts", async () => {
+    const abortController = new AbortController();
+    const reason = new WizardCancelledError();
+    let finishWork: (() => void) | undefined;
+    const runner = vi.fn(
+      () =>
+        new Promise<string>((resolve) => {
+          finishWork = () => resolve("late result");
+        }),
+    );
+
+    const task = runScopedChannelStep({
+      prompter: createWizardPrompter(),
+      options: { abortSignal: abortController.signal },
+      runner,
+    });
+    await vi.waitFor(() => expect(runner).toHaveBeenCalledOnce());
+
+    abortController.abort(reason);
+
+    await expect(task).rejects.toBe(reason);
+    finishWork?.();
+  });
+});

--- a/src/flows/channel-setup-navigation.ts
+++ b/src/flows/channel-setup-navigation.ts
@@ -60,9 +60,11 @@ export async function runScopedChannelStep<T>(params: ScopedChannelStepParams<T>
       params.runner(scopedPrompter, {
         ...params.options,
         beforePersistentEffect: async () => {
-          params.onPersistentEffect?.();
           scopedPrompter.disableBackNavigation?.();
           await params.options?.beforePersistentEffect?.();
+          // Publish recovery identity only after cancellation is locked; a
+          // rejected guard must leave the reversible channel choice unbound.
+          params.onPersistentEffect?.();
         },
       }),
     ),
@@ -78,6 +80,7 @@ export async function ensureChannelSetupPluginInstalledWithNavigation(params: {
   install: ChannelPluginInstallParams;
   prompter: WizardPrompter;
   options?: SetupChannelsOptions;
+  onPersistentEffect?: () => void;
 }) {
   let persistentEffectStarted = false;
   const outcome = await runScopedChannelStep({
@@ -91,6 +94,7 @@ export async function ensureChannelSetupPluginInstalledWithNavigation(params: {
       }),
     onPersistentEffect: () => {
       persistentEffectStarted = true;
+      params.onPersistentEffect?.();
     },
   });
   return { ...outcome, persistentEffectStarted };

--- a/src/flows/channel-setup-navigation.ts
+++ b/src/flows/channel-setup-navigation.ts
@@ -1,7 +1,7 @@
 import type { SetupChannelsOptions } from "../channels/plugins/setup-wizard-types.js";
 import { ensureChannelSetupPluginInstalled } from "../commands/channel-setup/plugin-install.js";
 import { runWizardWithPromptNavigationScope } from "../wizard/navigation-prompter.js";
-import type { WizardPrompter } from "../wizard/prompts.js";
+import { WizardCancelledError, type WizardPrompter } from "../wizard/prompts.js";
 
 type ScopedChannelStepParams<T> = {
   prompter: WizardPrompter;
@@ -10,16 +10,62 @@ type ScopedChannelStepParams<T> = {
   onPersistentEffect?: () => void;
 };
 
+function cancellationReason(signal: AbortSignal): Error {
+  return signal.reason instanceof Error ? signal.reason : new WizardCancelledError();
+}
+
+async function runWithSetupCancellation<T>(
+  signal: AbortSignal | undefined,
+  runner: () => Promise<T>,
+): Promise<T> {
+  if (!signal) {
+    return await runner();
+  }
+  if (signal.aborted) {
+    throw cancellationReason(signal);
+  }
+  return await new Promise<T>((resolve, reject) => {
+    let settled = false;
+    const settle = (result: { value: T } | { error: unknown }) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      signal.removeEventListener("abort", onAbort);
+      if ("error" in result) {
+        // Preserve adapter errors and cancellation reasons without rewriting them.
+        // oxlint-disable-next-line typescript/prefer-promise-reject-errors
+        reject(result.error);
+      } else {
+        resolve(result.value);
+      }
+    };
+    const onAbort = () => settle({ error: cancellationReason(signal) });
+    signal.addEventListener("abort", onAbort, { once: true });
+    void Promise.resolve()
+      .then(runner)
+      .then(
+        (value) => settle({ value }),
+        (error: unknown) => settle({ error }),
+      );
+    if (signal.aborted) {
+      onAbort();
+    }
+  });
+}
+
 export async function runScopedChannelStep<T>(params: ScopedChannelStepParams<T>) {
   return await runWizardWithPromptNavigationScope(params.prompter, async (scopedPrompter) =>
-    params.runner(scopedPrompter, {
-      ...params.options,
-      beforePersistentEffect: async () => {
-        params.onPersistentEffect?.();
-        scopedPrompter.disableBackNavigation?.();
-        await params.options?.beforePersistentEffect?.();
-      },
-    }),
+    runWithSetupCancellation(params.options?.abortSignal, async () =>
+      params.runner(scopedPrompter, {
+        ...params.options,
+        beforePersistentEffect: async () => {
+          params.onPersistentEffect?.();
+          scopedPrompter.disableBackNavigation?.();
+          await params.options?.beforePersistentEffect?.();
+        },
+      }),
+    ),
   );
 }
 

--- a/src/flows/channel-setup.test.ts
+++ b/src/flows/channel-setup.test.ts
@@ -430,6 +430,7 @@ describe("setupChannels workspace shadow exclusion", () => {
     );
     const select = vi.fn().mockResolvedValueOnce("custom-chat").mockResolvedValueOnce("__done__");
     const abortController = new AbortController();
+    const onChannelSelected = vi.fn();
 
     const next = await setupChannels(
       {} as never,
@@ -444,9 +445,11 @@ describe("setupChannels workspace shadow exclusion", () => {
         skipConfirm: true,
         skipDmPolicyPrompt: true,
         abortSignal: abortController.signal,
+        onChannelSelected,
       },
     );
 
+    expect(onChannelSelected).toHaveBeenCalledWith("custom-chat");
     expect(loadChannelSetupPluginRegistrySnapshotForChannel).not.toHaveBeenCalled();
     const configureInput = callArg<{
       cfg?: unknown;

--- a/src/flows/channel-setup.test.ts
+++ b/src/flows/channel-setup.test.ts
@@ -399,27 +399,43 @@ describe("setupChannels workspace shadow exclusion", () => {
         configured: false,
         statusLines: [],
       })),
-      configure: vi.fn(async ({ cfg }: { cfg: Record<string, unknown> }) => ({
-        cfg: {
-          ...cfg,
-          channels: {
-            "custom-chat": { token: "secret" },
-          },
+      configure: vi.fn(
+        async ({
+          cfg,
+          options,
+        }: {
+          cfg: Record<string, unknown>;
+          options?: { beforePersistentEffect?: () => Promise<void> };
+        }) => {
+          await options?.beforePersistentEffect?.();
+          return {
+            cfg: {
+              ...cfg,
+              channels: {
+                "custom-chat": { token: "secret" },
+              },
+            },
+          };
         },
-      })),
+      ),
     };
-    const activePlugin = makeSetupPlugin({
-      id: "custom-chat",
-      label: "Custom Chat",
-      setupWizard,
-    });
+    const activePlugin = {
+      ...makeSetupPlugin({
+        id: "custom-chat",
+        label: "Custom Chat",
+        setupWizard,
+      }),
+      meta: makeMeta("custom-chat", "Custom Chat", { aliases: ["custom-chat-alias"] }),
+    };
     listActiveChannelSetupPlugins.mockReturnValue([activePlugin]);
     resolveChannelSetupEntries.mockReturnValue(
       makeChannelSetupEntries({
         entries: [
           {
             id: "custom-chat",
-            meta: makeMeta("custom-chat", "Custom Chat"),
+            meta: makeMeta("custom-chat", "Custom Chat", {
+              aliases: ["custom-chat-alias"],
+            }),
           },
         ],
         installedCatalogEntries: [],
@@ -449,7 +465,7 @@ describe("setupChannels workspace shadow exclusion", () => {
       },
     );
 
-    expect(onChannelSelected).toHaveBeenCalledWith("custom-chat");
+    expect(onChannelSelected).toHaveBeenCalledWith("custom-chat", ["custom-chat-alias"]);
     expect(loadChannelSetupPluginRegistrySnapshotForChannel).not.toHaveBeenCalled();
     const configureInput = callArg<{
       cfg?: unknown;
@@ -752,6 +768,7 @@ describe("setupChannels workspace shadow exclusion", () => {
     const confirm = vi.fn(async () => {
       throw new WizardNavigationError("back");
     });
+    const onChannelSelected = vi.fn();
     const cfg = { channels: { telegram: { botToken: "keep" } } } as OpenClawConfig;
 
     const result = await setupChannels(
@@ -766,6 +783,7 @@ describe("setupChannels workspace shadow exclusion", () => {
         deferStatusUntilSelection: true,
         skipConfirm: true,
         skipDmPolicyPrompt: true,
+        onChannelSelected,
       },
     );
 
@@ -776,6 +794,7 @@ describe("setupChannels workspace shadow exclusion", () => {
       }),
     );
     expect(loadChannelSetupPluginRegistrySnapshotForChannel).not.toHaveBeenCalled();
+    expect(onChannelSelected).not.toHaveBeenCalled();
     expect(result).toEqual(cfg);
   });
 

--- a/src/flows/channel-setup.test.ts
+++ b/src/flows/channel-setup.test.ts
@@ -429,6 +429,7 @@ describe("setupChannels workspace shadow exclusion", () => {
       }),
     );
     const select = vi.fn().mockResolvedValueOnce("custom-chat").mockResolvedValueOnce("__done__");
+    const abortController = new AbortController();
 
     const next = await setupChannels(
       {} as never,
@@ -442,17 +443,23 @@ describe("setupChannels workspace shadow exclusion", () => {
         deferStatusUntilSelection: true,
         skipConfirm: true,
         skipDmPolicyPrompt: true,
+        abortSignal: abortController.signal,
       },
     );
 
     expect(loadChannelSetupPluginRegistrySnapshotForChannel).not.toHaveBeenCalled();
-    expect(callArg<{ cfg?: unknown }>(setupWizard.configure).cfg).toEqual({
+    const configureInput = callArg<{
+      cfg?: unknown;
+      options?: { abortSignal?: AbortSignal };
+    }>(setupWizard.configure);
+    expect(configureInput.cfg).toEqual({
       plugins: {
         entries: {
           "custom-chat": { enabled: true },
         },
       },
     });
+    expect(configureInput.options?.abortSignal).toBe(abortController.signal);
     expect(next).toEqual({
       plugins: {
         entries: {

--- a/src/flows/channel-setup.ts
+++ b/src/flows/channel-setup.ts
@@ -272,6 +272,10 @@ export async function setupChannels(
   };
 
   const selection: ChannelChoice[] = [];
+  const pendingChannelEffects = new Map<
+    ChannelChoice,
+    { channel: ChannelChoice; aliases?: readonly string[] }
+  >();
   let finishSetupRequested = false;
   const addSelection = (channel: ChannelChoice) => {
     if (!selection.includes(channel)) {
@@ -324,6 +328,24 @@ export async function setupChannels(
       catalogById: resolved.installableCatalogById,
       installedCatalogById: resolved.installedCatalogById,
     };
+  };
+  const resolveChannelEffectIdentity = (
+    channel: ChannelChoice,
+    aliases?: readonly string[],
+  ): { channel: ChannelChoice; aliases?: readonly string[] } => {
+    const resolvedAliases =
+      aliases ??
+      getVisibleChannelPlugin(channel)?.meta.aliases ??
+      getChannelEntries().entries.find((entry) => entry.id === channel)?.meta.aliases;
+    return resolvedAliases?.length ? { channel, aliases: resolvedAliases } : { channel };
+  };
+  const reportChannelPersistentEffect = (channel: ChannelChoice, aliases?: readonly string[]) => {
+    const identity = resolveChannelEffectIdentity(channel, aliases);
+    if (identity.aliases) {
+      options?.onChannelSelected?.(identity.channel, identity.aliases);
+    } else {
+      options?.onChannelSelected?.(identity.channel);
+    }
   };
 
   // Decorates the runtime status map with synthetic `selectionHint` entries for
@@ -614,12 +636,12 @@ export async function setupChannels(
 
   const ensureChannelSetupPluginInstalledWithNavigation = async (
     install: Parameters<typeof runPluginInstallWithNavigation>[0]["install"],
-  ) => await runPluginInstallWithNavigation({ install, prompter, options });
+    onPersistentEffect: () => void,
+  ) => await runPluginInstallWithNavigation({ install, prompter, options, onPersistentEffect });
 
-  const handleChannelChoice = async (
+  const handleChannelChoiceInner = async (
     channel: ChannelChoice,
   ): Promise<"done" | "retry_selection"> => {
-    options?.onChannelSelected?.(channel);
     const cfgBeforeChoice = next;
     let cfgOnBack = cfgBeforeChoice;
     const scopedPluginsBeforeChoice = new Map(scopedPluginsById);
@@ -718,13 +740,16 @@ export async function setupChannels(
     const installedCatalogEntry = installedCatalogById.get(channel);
     if (catalogEntry) {
       const workspaceDir = resolveWorkspaceDir();
-      const installOutcome = await ensureChannelSetupPluginInstalledWithNavigation({
-        cfg: next,
-        entry: catalogEntry,
-        runtime,
-        workspaceDir,
-        autoConfirmSingleSource: true,
-      });
+      const installOutcome = await ensureChannelSetupPluginInstalledWithNavigation(
+        {
+          cfg: next,
+          entry: catalogEntry,
+          runtime,
+          workspaceDir,
+          autoConfirmSingleSource: true,
+        },
+        () => reportChannelPersistentEffect(channel, catalogEntry.meta.aliases),
+      );
       if (installOutcome.status === "back") {
         return returnToSelection();
       }
@@ -761,13 +786,16 @@ export async function setupChannels(
           return "done";
         }
         const workspaceDir = resolveWorkspaceDir();
-        const installOutcome = await ensureChannelSetupPluginInstalledWithNavigation({
-          cfg: next,
-          entry: installedCatalogEntry,
-          runtime,
-          workspaceDir,
-          autoConfirmSingleSource: true,
-        });
+        const installOutcome = await ensureChannelSetupPluginInstalledWithNavigation(
+          {
+            cfg: next,
+            entry: installedCatalogEntry,
+            runtime,
+            workspaceDir,
+            autoConfirmSingleSource: true,
+          },
+          () => reportChannelPersistentEffect(channel, installedCatalogEntry.meta.aliases),
+        );
         if (installOutcome.status === "back") {
           return returnToSelection();
         }
@@ -822,13 +850,16 @@ export async function setupChannels(
           return "done";
         }
         const workspaceDir = resolveWorkspaceDir();
-        const installOutcome = await ensureChannelSetupPluginInstalledWithNavigation({
-          cfg: next,
-          entry: fallbackCatalogEntry,
-          runtime,
-          workspaceDir,
-          autoConfirmSingleSource: true,
-        });
+        const installOutcome = await ensureChannelSetupPluginInstalledWithNavigation(
+          {
+            cfg: next,
+            entry: fallbackCatalogEntry,
+            runtime,
+            workspaceDir,
+            autoConfirmSingleSource: true,
+          },
+          () => reportChannelPersistentEffect(channel, fallbackCatalogEntry.meta.aliases),
+        );
         if (installOutcome.status === "back") {
           return returnToSelection();
         }
@@ -870,6 +901,7 @@ export async function setupChannels(
             configured,
             label,
           }),
+        () => reportChannelPersistentEffect(channel),
       );
       if (outcome.status === "back") {
         return returnToSelection();
@@ -884,6 +916,7 @@ export async function setupChannels(
       const outcome = await runScopedChannelStep(
         async (scopedPrompter, scopedOptions) =>
           await handleConfiguredChannel(channel, label, scopedPrompter, scopedOptions),
+        () => reportChannelPersistentEffect(channel),
       );
       if (outcome.status === "back") {
         return returnToSelection();
@@ -893,11 +926,22 @@ export async function setupChannels(
     const outcome = await runScopedChannelStep(
       async (scopedPrompter, scopedOptions) =>
         await configureChannel(channel, scopedPrompter, scopedOptions),
+      () => reportChannelPersistentEffect(channel),
     );
     if (outcome.status === "back") {
       return returnToSelection();
     }
     return "done";
+  };
+  const handleChannelChoice = async (
+    channel: ChannelChoice,
+  ): Promise<"done" | "retry_selection"> => {
+    const cfgBeforeChoice = next;
+    const outcome = await handleChannelChoiceInner(channel);
+    if (outcome === "done" && next !== cfgBeforeChoice) {
+      pendingChannelEffects.set(channel, resolveChannelEffectIdentity(channel));
+    }
+    return outcome;
   };
 
   // Targeted setup finishes after success, but Back must re-enter the shared
@@ -968,6 +1012,9 @@ export async function setupChannels(
     }
   }
 
+  if (pendingChannelEffects.size > 0) {
+    options?.onPendingChannelEffects?.([...pendingChannelEffects.values()]);
+  }
   options?.onSelection?.(selection);
 
   const selectedLines = resolveChannelSelectionNoteLines({

--- a/src/flows/channel-setup.ts
+++ b/src/flows/channel-setup.ts
@@ -619,6 +619,7 @@ export async function setupChannels(
   const handleChannelChoice = async (
     channel: ChannelChoice,
   ): Promise<"done" | "retry_selection"> => {
+    options?.onChannelSelected?.(channel);
     const cfgBeforeChoice = next;
     let cfgOnBack = cfgBeforeChoice;
     const scopedPluginsBeforeChoice = new Map(scopedPluginsById);

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -938,7 +938,7 @@ function createRequestGatewayMethodRegistry(
 export async function handleGatewayRequest(
   opts: GatewayRequestOptions & { extraHandlers?: GatewayRequestHandlers },
 ): Promise<void> {
-  const { req, respond, client, isWebchatConnect, context } = opts;
+  const { req, respond, client, isWebchatConnect, isConnectionActive, context } = opts;
   // Prefer the caller-attached registry when it owns the requested method so plugin dispatch
   // metadata newer than global runtime state still authorizes and dispatches correctly. When the
   // attached snapshot does not own the method, rebuild from the live plugin registry so plugin RPC
@@ -1084,6 +1084,7 @@ export async function handleGatewayRequest(
       params: (req.params ?? {}) as Record<string, unknown>,
       client,
       isWebchatConnect,
+      ...(isConnectionActive ? { isConnectionActive } : {}),
       respond,
       context,
       ...(sessionMutation.authorization

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -938,7 +938,7 @@ function createRequestGatewayMethodRegistry(
 export async function handleGatewayRequest(
   opts: GatewayRequestOptions & { extraHandlers?: GatewayRequestHandlers },
 ): Promise<void> {
-  const { req, respond, client, isWebchatConnect, isConnectionActive, context } = opts;
+  const { req, respond, client, isWebchatConnect, context } = opts;
   // Prefer the caller-attached registry when it owns the requested method so plugin dispatch
   // metadata newer than global runtime state still authorizes and dispatches correctly. When the
   // attached snapshot does not own the method, rebuild from the live plugin registry so plugin RPC
@@ -1084,7 +1084,6 @@ export async function handleGatewayRequest(
       params: (req.params ?? {}) as Record<string, unknown>,
       client,
       isWebchatConnect,
-      ...(isConnectionActive ? { isConnectionActive } : {}),
       respond,
       context,
       ...(sessionMutation.authorization

--- a/src/gateway/server-methods/hosted-session-owner.ts
+++ b/src/gateway/server-methods/hosted-session-owner.ts
@@ -1,0 +1,24 @@
+import type { GatewayClient } from "./types.js";
+
+export type HostedSessionOwner =
+  | { kind: "stable"; key: string }
+  | { kind: "connection"; key: string }
+  | { kind: "none" };
+
+/** Resolve the strongest server-authenticated identity available to a hosted session. */
+export function resolveGatewayHostedSessionOwner(client: GatewayClient | null): HostedSessionOwner {
+  const userId = client?.authenticatedUserId?.trim();
+  if (userId) {
+    return { kind: "stable", key: `user:${userId}` };
+  }
+  const deviceId = client?.connect.device?.id.trim();
+  if (deviceId) {
+    return { kind: "stable", key: `device:${deviceId}` };
+  }
+  const sharedAuthGeneration = client?.sharedGatewaySessionGeneration?.trim();
+  if (client?.usesSharedGatewayAuth && sharedAuthGeneration) {
+    return { kind: "stable", key: `shared-auth:${sharedAuthGeneration}` };
+  }
+  const connId = client?.connId?.trim();
+  return connId ? { kind: "connection", key: `connection:${connId}` } : { kind: "none" };
+}

--- a/src/gateway/server-methods/hosted-session-owner.ts
+++ b/src/gateway/server-methods/hosted-session-owner.ts
@@ -1,7 +1,7 @@
 import type { GatewayClient } from "./types.js";
 
 export type HostedSessionOwner =
-  | { kind: "stable"; key: string }
+  | { kind: "stable"; key: string; continuityKey: string }
   | { kind: "connection"; key: string }
   | { kind: "none" };
 
@@ -9,15 +9,21 @@ export type HostedSessionOwner =
 export function resolveGatewayHostedSessionOwner(client: GatewayClient | null): HostedSessionOwner {
   const userId = client?.authenticatedUserId?.trim();
   if (userId) {
-    return { kind: "stable", key: `user:${userId}` };
+    const key = `user:${userId}`;
+    return { kind: "stable", key, continuityKey: key };
   }
   const deviceId = client?.connect.device?.id.trim();
   if (deviceId) {
-    return { kind: "stable", key: `device:${deviceId}` };
+    const key = `device:${deviceId}`;
+    return { kind: "stable", key, continuityKey: key };
   }
   const sharedAuthGeneration = client?.sharedGatewaySessionGeneration?.trim();
   if (client?.usesSharedGatewayAuth && sharedAuthGeneration) {
-    return { kind: "stable", key: `shared-auth:${sharedAuthGeneration}` };
+    return {
+      kind: "stable",
+      key: `shared-auth:${sharedAuthGeneration}`,
+      continuityKey: "shared-auth",
+    };
   }
   const connId = client?.connId?.trim();
   return connId ? { kind: "connection", key: `connection:${connId}` } : { kind: "none" };

--- a/src/gateway/server-methods/shared-types.ts
+++ b/src/gateway/server-methods/shared-types.ts
@@ -317,8 +317,6 @@ export type GatewayRequestOptions = {
   req: RequestFrame;
   client: GatewayClient | null;
   isWebchatConnect: (params: ConnectParams | null | undefined) => boolean;
-  /** Reports whether the request transport can still receive its eventual response. */
-  isConnectionActive?: () => boolean;
   respond: RespondFn;
   context: GatewayRequestContext;
   methodRegistry?: GatewayMethodRegistryView;
@@ -336,8 +334,6 @@ export type GatewayRequestHandlerOptions = {
   params: Record<string, unknown>;
   client: GatewayClient | null;
   isWebchatConnect: (params: ConnectParams | null | undefined) => boolean;
-  /** Reports whether the request transport can still receive its eventual response. */
-  isConnectionActive?: () => boolean;
   respond: RespondFn;
   context: GatewayRequestContext;
   sessionMutationAuthorization?: SessionMutationAuthorization;

--- a/src/gateway/server-methods/shared-types.ts
+++ b/src/gateway/server-methods/shared-types.ts
@@ -317,6 +317,8 @@ export type GatewayRequestOptions = {
   req: RequestFrame;
   client: GatewayClient | null;
   isWebchatConnect: (params: ConnectParams | null | undefined) => boolean;
+  /** Reports whether the request transport can still receive its eventual response. */
+  isConnectionActive?: () => boolean;
   respond: RespondFn;
   context: GatewayRequestContext;
   methodRegistry?: GatewayMethodRegistryView;
@@ -334,6 +336,8 @@ export type GatewayRequestHandlerOptions = {
   params: Record<string, unknown>;
   client: GatewayClient | null;
   isWebchatConnect: (params: ConnectParams | null | undefined) => boolean;
+  /** Reports whether the request transport can still receive its eventual response. */
+  isConnectionActive?: () => boolean;
   respond: RespondFn;
   context: GatewayRequestContext;
   sessionMutationAuthorization?: SessionMutationAuthorization;

--- a/src/gateway/server-methods/shared-types.ts
+++ b/src/gateway/server-methods/shared-types.ts
@@ -20,6 +20,7 @@ import type {
 import type { SystemAgentApprovalRequestPayload } from "../../infra/system-agent-approvals.js";
 import type { createSubsystemLogger } from "../../logging/subsystem.js";
 import type { RuntimePluginToolGrant } from "../../plugins/runtime/tool-grant.js";
+import type { SystemAgentChatReply } from "../../system-agent/chat-contract.js";
 import type { SystemAgentOperation } from "../../system-agent/operation-types.js";
 import type { WizardSession } from "../../wizard/session.js";
 import type { AgentRuntimeIdentity } from "../agent-runtime-identity-token.js";
@@ -125,17 +126,9 @@ type SystemAgentHistoryTurn = {
   text: string;
 };
 
-type GatewaySystemAgentReply = {
-  text: string;
-  action: "none" | "exit" | "open-tui" | "open-setup";
-  sensitive?: boolean;
-  wizardInputPending?: boolean;
-  question?: SystemAgentChatQuestion;
-};
-
 type GatewaySystemAgentSession = {
   engine: {
-    handle: (message: string) => Promise<GatewaySystemAgentReply>;
+    handle: (message: string) => Promise<SystemAgentChatReply>;
     seedHistory: (turns: readonly SystemAgentHistoryTurn[]) => void;
     historyLength: () => number;
     historySince: (index: number) => SystemAgentHistoryTurn[];
@@ -147,7 +140,7 @@ type GatewaySystemAgentSession = {
     /** False while an irreversible hosted wizard still owns unfinished work. */
     dispose: () => Promise<boolean>;
     hasLockedHostedWizard: () => boolean;
-    resumeLockedHostedWizard: () => Promise<GatewaySystemAgentReply | null>;
+    resumeLockedHostedWizard: () => Promise<SystemAgentChatReply | null>;
   };
   welcome: string;
   welcomeQuestion?: SystemAgentChatQuestion;

--- a/src/gateway/server-methods/shared-types.ts
+++ b/src/gateway/server-methods/shared-types.ts
@@ -66,6 +66,9 @@ export type GatewayClient = {
   /** Client id verified against the server-approved device pairing record. */
   pairedClientId?: string;
   authenticatedUserId?: string;
+  /** Shared-auth identity survives reconnects until the Gateway credential rotates. */
+  usesSharedGatewayAuth?: boolean;
+  sharedGatewaySessionGeneration?: string;
   authenticatedUserProfile?: {
     profileId: string;
     displayName: string | null;

--- a/src/gateway/server-methods/shared-types.ts
+++ b/src/gateway/server-methods/shared-types.ts
@@ -122,14 +122,17 @@ type SystemAgentHistoryTurn = {
   text: string;
 };
 
+type GatewaySystemAgentReply = {
+  text: string;
+  action: "none" | "exit" | "open-tui" | "open-setup";
+  sensitive?: boolean;
+  wizardInputPending?: boolean;
+  question?: SystemAgentChatQuestion;
+};
+
 type GatewaySystemAgentSession = {
   engine: {
-    handle: (message: string) => Promise<{
-      text: string;
-      action: "none" | "exit" | "open-tui" | "open-setup";
-      sensitive?: boolean;
-      question?: SystemAgentChatQuestion;
-    }>;
+    handle: (message: string) => Promise<GatewaySystemAgentReply>;
     seedHistory: (turns: readonly SystemAgentHistoryTurn[]) => void;
     historyLength: () => number;
     historySince: (index: number) => SystemAgentHistoryTurn[];
@@ -138,7 +141,10 @@ type GatewaySystemAgentSession = {
       decision: "allow-once" | "allow-always" | "deny" | null,
       proposalHash: string,
     ) => Promise<unknown>;
-    dispose: () => Promise<void>;
+    /** False while an irreversible hosted wizard still owns unfinished work. */
+    dispose: () => Promise<boolean>;
+    hasLockedHostedWizard: () => boolean;
+    resumeLockedHostedWizard: () => Promise<GatewaySystemAgentReply | null>;
   };
   welcome: string;
   welcomeQuestion?: SystemAgentChatQuestion;

--- a/src/gateway/server-methods/system-agent-greeting-welcome.test.ts
+++ b/src/gateway/server-methods/system-agent-greeting-welcome.test.ts
@@ -47,6 +47,8 @@ type FakeEngine = {
   getPendingOperatorProposal: ReturnType<typeof vi.fn>;
   resolveOperatorApproval: ReturnType<typeof vi.fn>;
   dispose: ReturnType<typeof vi.fn>;
+  hasLockedHostedWizard: ReturnType<typeof vi.fn>;
+  resumeLockedHostedWizard: ReturnType<typeof vi.fn>;
   loadOverview: ReturnType<typeof vi.fn>;
   noteAssistantMessage: ReturnType<typeof vi.fn>;
   planGreeting: ReturnType<typeof vi.fn>;
@@ -63,7 +65,9 @@ function makeEngine(): FakeEngine {
     historySince: vi.fn((index: number) => history.slice(index)),
     getPendingOperatorProposal: vi.fn(() => null),
     resolveOperatorApproval: vi.fn(async () => null),
-    dispose: vi.fn(async () => undefined),
+    dispose: vi.fn(async () => true),
+    hasLockedHostedWizard: vi.fn(() => false),
+    resumeLockedHostedWizard: vi.fn(async () => null),
     loadOverview: vi.fn(async () => ({})),
     noteAssistantMessage: vi.fn((text: string) => {
       history.push({ role: "assistant", text });

--- a/src/gateway/server-methods/system-agent-session-lifecycle.ts
+++ b/src/gateway/server-methods/system-agent-session-lifecycle.ts
@@ -38,7 +38,13 @@ export function resolveSystemAgentSessionOwnerKey(params: {
     return delegationKey;
   }
   const owner = resolveGatewayHostedSessionOwner(params.client);
-  return owner.kind === "stable" ? owner.continuityKey : undefined;
+  // Ordinary auth-none chats are connection-scoped even though they cannot
+  // recover across reconnects. Stable owners use continuity for recovery.
+  return owner.kind === "stable"
+    ? owner.continuityKey
+    : owner.kind === "connection"
+      ? owner.key
+      : undefined;
 }
 
 /** Transfer one exact owner's retained wizard when its client rotates session ids. */

--- a/src/gateway/server-methods/system-agent-session-lifecycle.ts
+++ b/src/gateway/server-methods/system-agent-session-lifecycle.ts
@@ -40,6 +40,20 @@ function listUniqueSystemAgentSessions(sessions: SystemAgentSessionMap) {
   return [...new Set(sessions.values())];
 }
 
+/** Whether this owner has locked work outside the currently bound session. */
+function hasOtherLockedSystemAgentWizard(params: {
+  sessions: SystemAgentSessionMap;
+  ownerKey: string;
+  exclude?: SystemAgentSession;
+}): boolean {
+  return listUniqueSystemAgentSessions(params.sessions).some(
+    (candidate) =>
+      candidate !== params.exclude &&
+      candidate.ownerKey === params.ownerKey &&
+      candidate.engine.hasLockedHostedWizard(),
+  );
+}
+
 export function resolveSystemAgentSessionOwnerKey(params: {
   delegation?: { agentId?: string; sessionKey?: string };
   client: GatewayClient | null;
@@ -60,13 +74,41 @@ export function resolveSystemAgentSessionOwnerKey(params: {
 }
 
 /** Transfer one exact owner's retained wizard when its client rotates session ids. */
-export function adoptLockedSystemAgentWizard(params: {
+export async function adoptLockedSystemAgentWizard(params: {
   sessions: SystemAgentSessionMap;
   sessionId: string;
   ownerKey: string;
   reset: boolean;
   allowAdoption: boolean;
-}): LockedWizardAdoption {
+  context: GatewayRequestContext;
+  boundSession?: SystemAgentSession;
+}): Promise<LockedWizardAdoption> {
+  if (
+    params.boundSession &&
+    hasOtherLockedSystemAgentWizard({
+      sessions: params.sessions,
+      ownerKey: params.ownerKey,
+      exclude: params.boundSession,
+    })
+  ) {
+    if (params.reset) {
+      return { kind: "reset-refused" };
+    }
+    if (!params.allowAdoption) {
+      return { kind: "welcome-required" };
+    }
+    if (
+      !(await resetSystemAgentSession({
+        sessions: params.sessions,
+        sessionId: params.sessionId,
+        context: params.context,
+      }))
+    ) {
+      return { kind: "reset-refused" };
+    }
+  } else if (params.boundSession) {
+    return { kind: "none" };
+  }
   const retainedSessions = listUniqueSystemAgentSessions(params.sessions).filter(
     (candidate) =>
       candidate.ownerKey === params.ownerKey && candidate.engine.hasLockedHostedWizard(),

--- a/src/gateway/server-methods/system-agent-session-lifecycle.ts
+++ b/src/gateway/server-methods/system-agent-session-lifecycle.ts
@@ -1,0 +1,86 @@
+import { resolveSystemAgentDelegationKey } from "../../system-agent/delegation-session.js";
+import type { GatewayClient, GatewayRequestContext } from "./types.js";
+
+type SystemAgentSessionMap = GatewayRequestContext["systemAgentSessions"];
+
+type LockedWizardAdoption =
+  | { kind: "none" }
+  | { kind: "adopted" }
+  | { kind: "ambiguous" }
+  | { kind: "reset-refused" };
+
+export function resolveSystemAgentSessionOwnerKey(params: {
+  delegation?: { agentId?: string; sessionKey?: string };
+  client: GatewayClient | null;
+}): string | undefined {
+  const delegationKey = resolveSystemAgentDelegationKey(params.delegation);
+  if (delegationKey !== undefined) {
+    // Host-asserted delegation owns its agent/session tuple across reconnects.
+    return delegationKey;
+  }
+  // Prefer stable authenticated principals, then verified device and connection identity.
+  const userId = params.client?.authenticatedUserId?.trim();
+  if (userId) {
+    return `user:${userId}`;
+  }
+  const deviceId = params.client?.connect.device?.id.trim();
+  if (deviceId) {
+    return `device:${deviceId}`;
+  }
+  const connId = params.client?.connId?.trim();
+  return connId ? `connection:${connId}` : undefined;
+}
+
+/** Transfer one exact owner's retained wizard when its client rotates session ids. */
+export function adoptLockedSystemAgentWizard(params: {
+  sessions: SystemAgentSessionMap;
+  sessionId: string;
+  ownerKey: string;
+  reset: boolean;
+}): LockedWizardAdoption {
+  const retainedEntries = [...params.sessions.entries()].filter(
+    ([candidateId, candidate]) =>
+      candidateId !== params.sessionId &&
+      candidate.ownerKey === params.ownerKey &&
+      candidate.engine.hasLockedHostedWizard(),
+  );
+  if (retainedEntries.length > 1) {
+    return { kind: "ambiguous" };
+  }
+  const retainedEntry = retainedEntries[0];
+  if (!retainedEntry) {
+    return { kind: "none" };
+  }
+  if (params.reset) {
+    return { kind: "reset-refused" };
+  }
+  const [retainedSessionId, retainedSession] = retainedEntry;
+  params.sessions.delete(retainedSessionId);
+  params.sessions.set(params.sessionId, retainedSession);
+  return { kind: "adopted" };
+}
+
+/** Evict the oldest disposable session while preserving every locked wizard owner. */
+export async function evictOldestSystemAgentSession(
+  sessions: SystemAgentSessionMap,
+  context: GatewayRequestContext,
+  maxSessions: number,
+): Promise<boolean> {
+  if (sessions.size < maxSessions) {
+    return true;
+  }
+  const oldestFirst = [...sessions.entries()].toSorted(([, left], [, right]) => {
+    return left.lastUsedAt - right.lastUsedAt;
+  });
+  for (const [key, session] of oldestFirst) {
+    if (!(await session.engine.dispose())) {
+      continue;
+    }
+    if (session.pendingApproval) {
+      context.systemAgentApprovalManager?.expire(session.pendingApproval.id, "session-evicted");
+    }
+    sessions.delete(key);
+    return true;
+  }
+  return false;
+}

--- a/src/gateway/server-methods/system-agent-session-lifecycle.ts
+++ b/src/gateway/server-methods/system-agent-session-lifecycle.ts
@@ -20,7 +20,7 @@ export function resolveSystemAgentSessionOwnerKey(params: {
     return delegationKey;
   }
   const owner = resolveGatewayHostedSessionOwner(params.client);
-  return owner.kind === "stable" ? owner.key : undefined;
+  return owner.kind === "stable" ? owner.continuityKey : undefined;
 }
 
 /** Transfer one exact owner's retained wizard when its client rotates session ids. */

--- a/src/gateway/server-methods/system-agent-session-lifecycle.ts
+++ b/src/gateway/server-methods/system-agent-session-lifecycle.ts
@@ -1,8 +1,11 @@
 import { resolveSystemAgentDelegationKey } from "../../system-agent/delegation-session.js";
+import { acknowledgeSystemAgentGreetingDelivery } from "../../system-agent/greeting.js";
 import { resolveGatewayHostedSessionOwner } from "./hosted-session-owner.js";
 import type { GatewayClient, GatewayRequestContext } from "./types.js";
 
 type SystemAgentSessionMap = GatewayRequestContext["systemAgentSessions"];
+type SystemAgentSession =
+  SystemAgentSessionMap extends Map<string, infer Session> ? Session : never;
 
 type LockedWizardAdoption =
   | { kind: "none" }
@@ -15,13 +18,22 @@ const MAX_SYSTEM_AGENT_SESSION_ALIASES = 4;
 
 export function deleteSystemAgentSessionAliases(
   sessions: SystemAgentSessionMap,
-  target: SystemAgentSessionMap extends Map<string, infer Session> ? Session : never,
+  target: SystemAgentSession,
 ): void {
   for (const [candidateId, candidate] of sessions) {
     if (candidate === target) {
       sessions.delete(candidateId);
     }
   }
+}
+
+export function acknowledgeDeliveredSystemAgentWelcome(session: SystemAgentSession): void {
+  const auditSequence = session.welcomeAuditSequence;
+  if (auditSequence === undefined) {
+    return;
+  }
+  acknowledgeSystemAgentGreetingDelivery({ auditSequence });
+  delete session.welcomeAuditSequence;
 }
 
 function listUniqueSystemAgentSessions(sessions: SystemAgentSessionMap) {

--- a/src/gateway/server-methods/system-agent-session-lifecycle.ts
+++ b/src/gateway/server-methods/system-agent-session-lifecycle.ts
@@ -1,4 +1,5 @@
 import { resolveSystemAgentDelegationKey } from "../../system-agent/delegation-session.js";
+import { resolveGatewayHostedSessionOwner } from "./hosted-session-owner.js";
 import type { GatewayClient, GatewayRequestContext } from "./types.js";
 
 type SystemAgentSessionMap = GatewayRequestContext["systemAgentSessions"];
@@ -18,17 +19,8 @@ export function resolveSystemAgentSessionOwnerKey(params: {
     // Host-asserted delegation owns its agent/session tuple across reconnects.
     return delegationKey;
   }
-  // Prefer stable authenticated principals, then verified device and connection identity.
-  const userId = params.client?.authenticatedUserId?.trim();
-  if (userId) {
-    return `user:${userId}`;
-  }
-  const deviceId = params.client?.connect.device?.id.trim();
-  if (deviceId) {
-    return `device:${deviceId}`;
-  }
-  const connId = params.client?.connId?.trim();
-  return connId ? `connection:${connId}` : undefined;
+  const owner = resolveGatewayHostedSessionOwner(params.client);
+  return owner.kind === "stable" ? owner.key : undefined;
 }
 
 /** Transfer one exact owner's retained wizard when its client rotates session ids. */
@@ -60,6 +52,26 @@ export function adoptLockedSystemAgentWizard(params: {
   return { kind: "adopted" };
 }
 
+/** Retire a resettable session only after synchronously excluding locked work. */
+export async function resetSystemAgentSession(params: {
+  sessions: SystemAgentSessionMap;
+  sessionId: string;
+  context: GatewayRequestContext;
+}): Promise<boolean> {
+  const existing = params.sessions.get(params.sessionId);
+  if (existing?.engine.hasLockedHostedWizard()) {
+    return false;
+  }
+  params.sessions.delete(params.sessionId);
+  if (existing?.pendingApproval) {
+    params.context.systemAgentApprovalManager?.expire(existing.pendingApproval.id, "session-reset");
+  }
+  if (existing && !(await existing.engine.dispose())) {
+    throw new Error("Disposable OpenClaw session became cancellation-locked during reset.");
+  }
+  return true;
+}
+
 /** Evict the oldest disposable session while preserving every locked wizard owner. */
 export async function evictOldestSystemAgentSession(
   sessions: SystemAgentSessionMap,
@@ -73,13 +85,18 @@ export async function evictOldestSystemAgentSession(
     return left.lastUsedAt - right.lastUsedAt;
   });
   for (const [key, session] of oldestFirst) {
-    if (!(await session.engine.dispose())) {
+    if (session.engine.hasLockedHostedWizard()) {
       continue;
     }
+    // Remove authority before cleanup yields so a concurrent approval callback
+    // cannot pass its session-identity check while this session is retiring.
+    sessions.delete(key);
     if (session.pendingApproval) {
       context.systemAgentApprovalManager?.expire(session.pendingApproval.id, "session-evicted");
     }
-    sessions.delete(key);
+    if (!(await session.engine.dispose())) {
+      throw new Error("Disposable OpenClaw session became cancellation-locked during eviction.");
+    }
     return true;
   }
   return false;

--- a/src/gateway/server-methods/system-agent-session-lifecycle.ts
+++ b/src/gateway/server-methods/system-agent-session-lifecycle.ts
@@ -8,7 +8,25 @@ type LockedWizardAdoption =
   | { kind: "none" }
   | { kind: "adopted" }
   | { kind: "ambiguous" }
-  | { kind: "reset-refused" };
+  | { kind: "reset-refused" }
+  | { kind: "welcome-required" };
+
+const MAX_SYSTEM_AGENT_SESSION_ALIASES = 4;
+
+function deleteSystemAgentSessionAliases(
+  sessions: SystemAgentSessionMap,
+  target: SystemAgentSessionMap extends Map<string, infer Session> ? Session : never,
+): void {
+  for (const [candidateId, candidate] of sessions) {
+    if (candidate === target) {
+      sessions.delete(candidateId);
+    }
+  }
+}
+
+function listUniqueSystemAgentSessions(sessions: SystemAgentSessionMap) {
+  return [...new Set(sessions.values())];
+}
 
 export function resolveSystemAgentSessionOwnerKey(params: {
   delegation?: { agentId?: string; sessionKey?: string };
@@ -29,26 +47,38 @@ export function adoptLockedSystemAgentWizard(params: {
   sessionId: string;
   ownerKey: string;
   reset: boolean;
+  allowAdoption: boolean;
 }): LockedWizardAdoption {
-  const retainedEntries = [...params.sessions.entries()].filter(
-    ([candidateId, candidate]) =>
-      candidateId !== params.sessionId &&
-      candidate.ownerKey === params.ownerKey &&
-      candidate.engine.hasLockedHostedWizard(),
+  const retainedSessions = listUniqueSystemAgentSessions(params.sessions).filter(
+    (candidate) =>
+      candidate.ownerKey === params.ownerKey && candidate.engine.hasLockedHostedWizard(),
   );
-  if (retainedEntries.length > 1) {
+  if (retainedSessions.length > 1) {
     return { kind: "ambiguous" };
   }
-  const retainedEntry = retainedEntries[0];
-  if (!retainedEntry) {
+  const retainedSession = retainedSessions[0];
+  if (!retainedSession) {
     return { kind: "none" };
   }
   if (params.reset) {
     return { kind: "reset-refused" };
   }
-  const [retainedSessionId, retainedSession] = retainedEntry;
-  params.sessions.delete(retainedSessionId);
+  if (!params.allowAdoption) {
+    return { kind: "welcome-required" };
+  }
+  // A successful welcome-only request is the protocol-free recovery
+  // handshake. Keep prior ids as aliases so an original tab cannot lose its
+  // locked state merely because another same-owner surface reconnects.
   params.sessions.set(params.sessionId, retainedSession);
+  const aliases = [...params.sessions.entries()]
+    .filter(([, candidate]) => candidate === retainedSession)
+    .map(([candidateId]) => candidateId);
+  for (const staleAlias of aliases.slice(
+    0,
+    Math.max(0, aliases.length - MAX_SYSTEM_AGENT_SESSION_ALIASES),
+  )) {
+    params.sessions.delete(staleAlias);
+  }
   return { kind: "adopted" };
 }
 
@@ -62,7 +92,9 @@ export async function resetSystemAgentSession(params: {
   if (existing?.engine.hasLockedHostedWizard()) {
     return false;
   }
-  params.sessions.delete(params.sessionId);
+  if (existing) {
+    deleteSystemAgentSessionAliases(params.sessions, existing);
+  }
   if (existing?.pendingApproval) {
     params.context.systemAgentApprovalManager?.expire(existing.pendingApproval.id, "session-reset");
   }
@@ -78,19 +110,18 @@ export async function evictOldestSystemAgentSession(
   context: GatewayRequestContext,
   maxSessions: number,
 ): Promise<boolean> {
-  if (sessions.size < maxSessions) {
+  const uniqueSessions = listUniqueSystemAgentSessions(sessions);
+  if (uniqueSessions.length < maxSessions) {
     return true;
   }
-  const oldestFirst = [...sessions.entries()].toSorted(([, left], [, right]) => {
-    return left.lastUsedAt - right.lastUsedAt;
-  });
-  for (const [key, session] of oldestFirst) {
+  const oldestFirst = uniqueSessions.toSorted((left, right) => left.lastUsedAt - right.lastUsedAt);
+  for (const session of oldestFirst) {
     if (session.engine.hasLockedHostedWizard()) {
       continue;
     }
     // Remove authority before cleanup yields so a concurrent approval callback
     // cannot pass its session-identity check while this session is retiring.
-    sessions.delete(key);
+    deleteSystemAgentSessionAliases(sessions, session);
     if (session.pendingApproval) {
       context.systemAgentApprovalManager?.expire(session.pendingApproval.id, "session-evicted");
     }

--- a/src/gateway/server-methods/system-agent-session-lifecycle.ts
+++ b/src/gateway/server-methods/system-agent-session-lifecycle.ts
@@ -13,7 +13,7 @@ type LockedWizardAdoption =
 
 const MAX_SYSTEM_AGENT_SESSION_ALIASES = 4;
 
-function deleteSystemAgentSessionAliases(
+export function deleteSystemAgentSessionAliases(
   sessions: SystemAgentSessionMap,
   target: SystemAgentSessionMap extends Map<string, infer Session> ? Session : never,
 ): void {

--- a/src/gateway/server-methods/system-agent-session-ownership.test.ts
+++ b/src/gateway/server-methods/system-agent-session-ownership.test.ts
@@ -439,6 +439,16 @@ describe("openclaw.chat session ownership", () => {
     expect(call).toMatchObject({ ok: false, error: { code: "INVALID_REQUEST" } });
   });
 
+  it("keeps device-less auth-none chats scoped to their connection", async () => {
+    const sessions = new Map<string, SystemAgentChatSession>();
+    const client = makeClient({ connId: "auth-none-connection" });
+
+    const call = await callChat(makeContext(sessions), { sessionId: "auth-none" }, client);
+
+    expect(call.ok).toBe(true);
+    expect(sessions.get("auth-none")?.ownerKey).toBe("connection:auth-none-connection");
+  });
+
   it("keeps explicit delegation authoritative across connection identities", async () => {
     const sessions = new Map<string, SystemAgentChatSession>();
     const context = makeContext(sessions);

--- a/src/gateway/server-methods/system-agent-session-ownership.test.ts
+++ b/src/gateway/server-methods/system-agent-session-ownership.test.ts
@@ -11,6 +11,11 @@ const setupInferenceMocks = vi.hoisted(() => ({ verifySetupInference: vi.fn() })
 const delegatedInferenceMocks = vi.hoisted(() => ({
   verifySystemAgentInferenceWithFallback: vi.fn(),
 }));
+const transcriptMocks = vi.hoisted(() => ({
+  appendTranscriptReset: vi.fn(),
+  appendTranscriptTurn: vi.fn(),
+  readTranscriptTail: vi.fn(() => []),
+}));
 
 vi.mock("../../system-agent/setup-inference.js", () => ({
   verifySetupInference: setupInferenceMocks.verifySetupInference,
@@ -19,11 +24,7 @@ vi.mock("../../system-agent/inference-fallback.js", () => ({
   verifySystemAgentInferenceWithFallback:
     delegatedInferenceMocks.verifySystemAgentInferenceWithFallback,
 }));
-vi.mock("../../system-agent/transcript-store.js", () => ({
-  appendTranscriptReset: vi.fn(),
-  appendTranscriptTurn: vi.fn(),
-  readTranscriptTail: vi.fn(() => []),
-}));
+vi.mock("../../system-agent/transcript-store.js", () => transcriptMocks);
 // Ownership tests exercise fresh-session creation; keep the caretaker greeting
 // deterministic so identity behavior is the only variable under test.
 vi.mock("../../system-agent/greeting.js", () => ({
@@ -100,8 +101,14 @@ function makeClient(params: {
 
 const defaultClient = makeClient({ connId: "conn-test", deviceId: "device-test" });
 
-function makeContext(sessions: Map<string, SystemAgentChatSession>): GatewayRequestContext {
-  return { systemAgentSessions: sessions } as unknown as GatewayRequestContext;
+function makeContext(
+  sessions: Map<string, SystemAgentChatSession>,
+  systemAgentApprovalManager?: { expire: ReturnType<typeof vi.fn> },
+): GatewayRequestContext {
+  return {
+    systemAgentSessions: sessions,
+    ...(systemAgentApprovalManager ? { systemAgentApprovalManager } : {}),
+  } as unknown as GatewayRequestContext;
 }
 
 function seededSession(params?: {
@@ -378,6 +385,7 @@ describe("openclaw.chat session responses", () => {
   it("refuses reset while a hosted wizard owns locked work", async () => {
     const engine = makeEngine();
     engine.dispose.mockResolvedValue(false);
+    engine.hasLockedHostedWizard.mockReturnValue(true);
     const sessions = new Map<string, SystemAgentChatSession>([
       ["locked", seededSession({ engine })],
     ]);
@@ -389,14 +397,18 @@ describe("openclaw.chat session responses", () => {
       error: { code: "INVALID_REQUEST" },
     });
     expect(sessions.get("locked")?.engine).toBe(engine);
-    expect(engine.dispose).toHaveBeenCalledOnce();
+    expect(engine.dispose).not.toHaveBeenCalled();
   });
 
   it("evicts the oldest disposable session and keeps locked work owned", async () => {
     const sessions = new Map<string, SystemAgentChatSession>();
     const locked = makeEngine();
     locked.dispose.mockResolvedValue(false);
-    sessions.set("locked-oldest", seededSession({ engine: locked }));
+    locked.hasLockedHostedWizard.mockReturnValue(true);
+    sessions.set(
+      "locked-oldest",
+      seededSession({ engine: locked, ownerKey: "device:other-device" }),
+    );
     for (let index = 1; index < 8; index += 1) {
       const engine = makeEngine();
       sessions.set(`candidate-${index}`, seededSession({ engine, ownerKey: "device:device-test" }));
@@ -411,7 +423,7 @@ describe("openclaw.chat session responses", () => {
     expect(sessions.has("candidate-1")).toBe(false);
     expect(sessions.has("replacement")).toBe(true);
     expect(sessions.size).toBe(8);
-    expect(locked.dispose).toHaveBeenCalledOnce();
+    expect(locked.dispose).not.toHaveBeenCalled();
   });
 
   it("rejects a new session when every eviction candidate owns locked work", async () => {
@@ -419,15 +431,56 @@ describe("openclaw.chat session responses", () => {
     for (let index = 0; index < 8; index += 1) {
       const engine = makeEngine();
       engine.dispose.mockResolvedValue(false);
-      sessions.set(`locked-${index}`, seededSession({ engine }));
+      engine.hasLockedHostedWizard.mockReturnValue(true);
+      sessions.set(
+        `locked-${index}`,
+        seededSession({ engine, ownerKey: `device:locked-device-${index}` }),
+      );
     }
+    transcriptMocks.appendTranscriptTurn.mockClear();
+    const replacementHistory = [{ role: "assistant" as const, text: "welcome text" }];
 
-    const call = await callChat(makeContext(sessions), { sessionId: "replacement" });
+    const callPromise = callChat(makeContext(sessions), { sessionId: "replacement" });
+    await vi.waitFor(() => expect(createdEngines).toHaveLength(1));
+    expectDefined(createdEngines[0], "replacement engine").historySince.mockReturnValue(
+      replacementHistory,
+    );
+    const call = await callPromise;
 
     expect(call).toMatchObject({ ok: false, error: { code: "UNAVAILABLE" } });
     expect(sessions.size).toBe(8);
     expect(sessions.has("replacement")).toBe(false);
     expect(expectDefined(createdEngines[0], "replacement engine").dispose).toHaveBeenCalledOnce();
+    expect(transcriptMocks.appendTranscriptTurn).not.toHaveBeenCalled();
+  });
+
+  it("revokes an evicted session before asynchronous cleanup yields", async () => {
+    let releaseCleanup!: () => void;
+    const cleanupGate = new Promise<void>((resolve) => {
+      releaseCleanup = resolve;
+    });
+    const sessions = new Map<string, SystemAgentChatSession>();
+    const candidate = seededSession();
+    candidate.pendingApproval = { id: "approval-1", proposalHash: "hash-1" };
+    candidate.engine.dispose.mockImplementation(async () => {
+      await cleanupGate;
+      return true;
+    });
+    sessions.set("candidate", candidate);
+    for (let index = 1; index < 8; index += 1) {
+      const session = seededSession();
+      session.lastUsedAt = index;
+      sessions.set(`existing-${index}`, session);
+    }
+    const expire = vi.fn();
+
+    const call = callChat(makeContext(sessions, { expire }), { sessionId: "replacement" });
+    await vi.waitFor(() => expect(candidate.engine.dispose).toHaveBeenCalledOnce());
+
+    expect(sessions.has("candidate")).toBe(false);
+    expect(expire).toHaveBeenCalledWith("approval-1", "session-evicted");
+    releaseCleanup();
+    expect((await call).ok).toBe(true);
   });
 
   it("retains locked work when inference failure cleanup refuses disposal", async () => {

--- a/src/gateway/server-methods/system-agent-session-ownership.test.ts
+++ b/src/gateway/server-methods/system-agent-session-ownership.test.ts
@@ -89,11 +89,16 @@ function makeEngine(): FakeEngine {
 }
 
 const createdEngines = vi.hoisted(() => [] as FakeEngine[]);
+const createdEngineOptions = vi.hoisted(() => [] as Array<{ allowHostedChannelSetup?: boolean }>);
 
 vi.mock("../../system-agent/chat-engine.js", () => ({
-  SystemAgentChatEngine: function FakeSystemAgentChatEngine(this: FakeEngine) {
+  SystemAgentChatEngine: function FakeSystemAgentChatEngine(
+    this: FakeEngine,
+    options: { allowHostedChannelSetup?: boolean },
+  ) {
     const engine = makeEngine();
     createdEngines.push(engine);
+    createdEngineOptions.push(options);
     Object.assign(this, engine);
   },
 }));
@@ -170,6 +175,7 @@ async function callChat(
 
 beforeEach(() => {
   createdEngines.length = 0;
+  createdEngineOptions.length = 0;
   setupInferenceMocks.verifySetupInference.mockResolvedValue({ ok: true, binding: {} });
   delegatedInferenceMocks.verifySystemAgentInferenceWithFallback.mockResolvedValue({
     ok: true,
@@ -532,6 +538,7 @@ describe("openclaw.chat session ownership", () => {
 
     expect(call.ok).toBe(true);
     expect(sessions.get("auth-none")?.ownerKey).toBe("connection:auth-none-connection");
+    expect(createdEngineOptions[0]?.allowHostedChannelSetup).toBe(false);
   });
 
   it("keeps explicit delegation authoritative across connection identities", async () => {
@@ -543,6 +550,7 @@ describe("openclaw.chat session ownership", () => {
       { sessionId: "delegated", delegation },
       makeClient({ connId: "conn-owner", deviceId: "device-owner" }),
     );
+    expect(createdEngineOptions[0]?.allowHostedChannelSetup).toBe(true);
     const handle = expectDefined(createdEngines[0], "created delegated engine").handle;
 
     const resumed = await callChat(

--- a/src/gateway/server-methods/system-agent-session-ownership.test.ts
+++ b/src/gateway/server-methods/system-agent-session-ownership.test.ts
@@ -566,6 +566,26 @@ describe("openclaw.chat session responses", () => {
     expect(engine.dispose).toHaveBeenCalledOnce();
   });
 
+  it("removes every reconnect alias after inference failure cleanup", async () => {
+    const engine = makeEngine();
+    engine.handle.mockRejectedValue(new SystemAgentInferenceUnavailableError("conversation"));
+    const session = seededSession({ engine });
+    const sessions = new Map<string, SystemAgentChatSession>([
+      ["original", session],
+      ["reconnected", session],
+    ]);
+
+    const call = await callChat(makeContext(sessions), {
+      sessionId: "reconnected",
+      message: "continue",
+    });
+
+    expect(call).toMatchObject({ ok: false, error: { code: "UNAVAILABLE" } });
+    expect(engine.dispose).toHaveBeenCalledOnce();
+    expect(sessions.has("original")).toBe(false);
+    expect(sessions.has("reconnected")).toBe(false);
+  });
+
   it("returns the stored welcome when no message is sent", async () => {
     const sessions = new Map<string, SystemAgentChatSession>([["s1", seededSession()]]);
     const call = await callChat(makeContext(sessions), { sessionId: "s1" });

--- a/src/gateway/server-methods/system-agent-session-ownership.test.ts
+++ b/src/gateway/server-methods/system-agent-session-ownership.test.ts
@@ -186,7 +186,7 @@ describe("openclaw.chat session ownership", () => {
         wizardInputPending: true,
       },
     });
-    expect(sessions.has("old-session")).toBe(false);
+    expect(sessions.has("old-session")).toBe(true);
     expect(sessions.get("new-session")?.engine).toBe(retained);
     expect(retained.resumeLockedHostedWizard).toHaveBeenCalledOnce();
     expect(createdEngines).toHaveLength(0);
@@ -202,6 +202,33 @@ describe("openclaw.chat session ownership", () => {
       },
     });
     expect(retained.resumeLockedHostedWizard).toHaveBeenCalledTimes(2);
+    expect(createdEngines).toHaveLength(0);
+
+    const original = await callChat(makeContext(sessions), {
+      sessionId: "old-session",
+      message: "yes",
+    });
+
+    expect(original.ok).toBe(true);
+    expect(retained.handle).toHaveBeenCalledWith("yes");
+  });
+
+  it("requires a welcome handshake before aliasing a locked wizard", async () => {
+    const retained = makeEngine();
+    retained.hasLockedHostedWizard.mockReturnValue(true);
+    const sessions = new Map<string, SystemAgentChatSession>([
+      ["old-session", seededSession({ engine: retained })],
+    ]);
+
+    const call = await callChat(makeContext(sessions), {
+      sessionId: "unproven-session",
+      message: "yes",
+    });
+
+    expect(call).toMatchObject({ ok: false, error: { code: "INVALID_REQUEST" } });
+    expect(sessions.has("old-session")).toBe(true);
+    expect(sessions.has("unproven-session")).toBe(false);
+    expect(retained.handle).not.toHaveBeenCalled();
     expect(createdEngines).toHaveLength(0);
   });
 

--- a/src/gateway/server-methods/system-agent-session-ownership.test.ts
+++ b/src/gateway/server-methods/system-agent-session-ownership.test.ts
@@ -3,6 +3,7 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resetCommandQueueStateForTest } from "../../process/command-queue.test-support.js";
+import { SystemAgentInferenceUnavailableError } from "../../system-agent/inference-error.js";
 import { systemAgentHandlers, type SystemAgentChatSession } from "./system-agent.js";
 import type { GatewayClient, GatewayRequestContext, RespondFn } from "./types.js";
 
@@ -45,6 +46,8 @@ type FakeEngine = {
   getPendingOperatorProposal: ReturnType<typeof vi.fn>;
   resolveOperatorApproval: ReturnType<typeof vi.fn>;
   dispose: ReturnType<typeof vi.fn>;
+  hasLockedHostedWizard: ReturnType<typeof vi.fn>;
+  resumeLockedHostedWizard: ReturnType<typeof vi.fn>;
   loadOverview: ReturnType<typeof vi.fn>;
   noteAssistantMessage: ReturnType<typeof vi.fn>;
 };
@@ -57,7 +60,9 @@ function makeEngine(): FakeEngine {
     historySince: vi.fn(() => []),
     getPendingOperatorProposal: vi.fn(() => null),
     resolveOperatorApproval: vi.fn(async () => null),
-    dispose: vi.fn(async () => undefined),
+    dispose: vi.fn(async () => true),
+    hasLockedHostedWizard: vi.fn(() => false),
+    resumeLockedHostedWizard: vi.fn(async () => null),
     loadOverview: vi.fn(async () => ({})),
     noteAssistantMessage: vi.fn(),
   };
@@ -145,6 +150,81 @@ afterEach(() => {
 });
 
 describe("openclaw.chat session ownership", () => {
+  it("adopts one locked wizard only for its exact owner after the session id changes", async () => {
+    const retained = makeEngine();
+    retained.hasLockedHostedWizard.mockReturnValue(true);
+    retained.resumeLockedHostedWizard.mockResolvedValue({
+      text: "Retry validation?",
+      action: "none",
+      wizardInputPending: true,
+    });
+    const sessions = new Map<string, SystemAgentChatSession>([
+      ["old-session", seededSession({ engine: retained })],
+    ]);
+
+    const call = await callChat(makeContext(sessions), { sessionId: "new-session" });
+
+    expect(call).toMatchObject({
+      ok: true,
+      payload: {
+        sessionId: "new-session",
+        reply: "Retry validation?",
+        wizardInputPending: true,
+      },
+    });
+    expect(sessions.has("old-session")).toBe(false);
+    expect(sessions.get("new-session")?.engine).toBe(retained);
+    expect(retained.resumeLockedHostedWizard).toHaveBeenCalledOnce();
+    expect(createdEngines).toHaveLength(0);
+  });
+
+  it("does not adopt a locked wizard owned by another caller", async () => {
+    const retained = makeEngine();
+    retained.hasLockedHostedWizard.mockReturnValue(true);
+    const sessions = new Map<string, SystemAgentChatSession>([
+      [
+        "owner-session",
+        seededSession({
+          engine: retained,
+          ownerKey: "user:owner@example.com",
+        }),
+      ],
+    ]);
+
+    const call = await callChat(
+      makeContext(sessions),
+      { sessionId: "attacker-session" },
+      makeClient({
+        connId: "attacker-connection",
+        authenticatedUserId: "attacker@example.com",
+      }),
+    );
+
+    expect(call.ok).toBe(true);
+    expect(sessions.get("owner-session")?.engine).toBe(retained);
+    expect(sessions.get("attacker-session")?.engine).not.toBe(retained);
+    expect(retained.resumeLockedHostedWizard).not.toHaveBeenCalled();
+  });
+
+  it("refuses ambiguous adoption when one owner has multiple locked wizards", async () => {
+    const first = makeEngine();
+    const second = makeEngine();
+    first.hasLockedHostedWizard.mockReturnValue(true);
+    second.hasLockedHostedWizard.mockReturnValue(true);
+    const sessions = new Map<string, SystemAgentChatSession>([
+      ["first", seededSession({ engine: first })],
+      ["second", seededSession({ engine: second })],
+    ]);
+
+    const call = await callChat(makeContext(sessions), { sessionId: "replacement" });
+
+    expect(call).toMatchObject({ ok: false, error: { code: "INVALID_REQUEST" } });
+    expect(sessions.has("first")).toBe(true);
+    expect(sessions.has("second")).toBe(true);
+    expect(sessions.has("replacement")).toBe(false);
+    expect(createdEngines).toHaveLength(0);
+  });
+
   it("binds a new non-delegated session and rejects another principal", async () => {
     const sessions = new Map<string, SystemAgentChatSession>();
     const context = makeContext(sessions);
@@ -295,6 +375,79 @@ describe("openclaw.chat session ownership", () => {
 });
 
 describe("openclaw.chat session responses", () => {
+  it("refuses reset while a hosted wizard owns locked work", async () => {
+    const engine = makeEngine();
+    engine.dispose.mockResolvedValue(false);
+    const sessions = new Map<string, SystemAgentChatSession>([
+      ["locked", seededSession({ engine })],
+    ]);
+
+    const call = await callChat(makeContext(sessions), { sessionId: "locked", reset: true });
+
+    expect(call).toMatchObject({
+      ok: false,
+      error: { code: "INVALID_REQUEST" },
+    });
+    expect(sessions.get("locked")?.engine).toBe(engine);
+    expect(engine.dispose).toHaveBeenCalledOnce();
+  });
+
+  it("evicts the oldest disposable session and keeps locked work owned", async () => {
+    const sessions = new Map<string, SystemAgentChatSession>();
+    const locked = makeEngine();
+    locked.dispose.mockResolvedValue(false);
+    sessions.set("locked-oldest", seededSession({ engine: locked }));
+    for (let index = 1; index < 8; index += 1) {
+      const engine = makeEngine();
+      sessions.set(`candidate-${index}`, seededSession({ engine, ownerKey: "device:device-test" }));
+      const session = expectDefined(sessions.get(`candidate-${index}`), "eviction candidate");
+      session.lastUsedAt = index;
+    }
+
+    const call = await callChat(makeContext(sessions), { sessionId: "replacement" });
+
+    expect(call.ok).toBe(true);
+    expect(sessions.has("locked-oldest")).toBe(true);
+    expect(sessions.has("candidate-1")).toBe(false);
+    expect(sessions.has("replacement")).toBe(true);
+    expect(sessions.size).toBe(8);
+    expect(locked.dispose).toHaveBeenCalledOnce();
+  });
+
+  it("rejects a new session when every eviction candidate owns locked work", async () => {
+    const sessions = new Map<string, SystemAgentChatSession>();
+    for (let index = 0; index < 8; index += 1) {
+      const engine = makeEngine();
+      engine.dispose.mockResolvedValue(false);
+      sessions.set(`locked-${index}`, seededSession({ engine }));
+    }
+
+    const call = await callChat(makeContext(sessions), { sessionId: "replacement" });
+
+    expect(call).toMatchObject({ ok: false, error: { code: "UNAVAILABLE" } });
+    expect(sessions.size).toBe(8);
+    expect(sessions.has("replacement")).toBe(false);
+    expect(expectDefined(createdEngines[0], "replacement engine").dispose).toHaveBeenCalledOnce();
+  });
+
+  it("retains locked work when inference failure cleanup refuses disposal", async () => {
+    const engine = makeEngine();
+    engine.handle.mockRejectedValue(new SystemAgentInferenceUnavailableError("conversation"));
+    engine.dispose.mockResolvedValue(false);
+    const sessions = new Map<string, SystemAgentChatSession>([
+      ["locked", seededSession({ engine })],
+    ]);
+
+    const call = await callChat(makeContext(sessions), {
+      sessionId: "locked",
+      message: "continue",
+    });
+
+    expect(call).toMatchObject({ ok: false, error: { code: "UNAVAILABLE" } });
+    expect(sessions.get("locked")?.engine).toBe(engine);
+    expect(engine.dispose).toHaveBeenCalledOnce();
+  });
+
   it("returns the stored welcome when no message is sent", async () => {
     const sessions = new Map<string, SystemAgentChatSession>([["s1", seededSession()]]);
     const call = await callChat(makeContext(sessions), { sessionId: "s1" });

--- a/src/gateway/server-methods/system-agent-session-ownership.test.ts
+++ b/src/gateway/server-methods/system-agent-session-ownership.test.ts
@@ -213,6 +213,39 @@ describe("openclaw.chat session ownership", () => {
     expect(retained.handle).toHaveBeenCalledWith("yes");
   });
 
+  it("persists a terminal wizard reply generated during recovery only once", async () => {
+    const retained = makeEngine();
+    const history = [
+      { role: "user" as const, text: "connect matrix" },
+      { role: "assistant" as const, text: "Applying channel setup." },
+    ];
+    retained.hasLockedHostedWizard.mockReturnValue(true);
+    retained.historyLength.mockImplementation(() => history.length);
+    retained.historySince.mockImplementation((index: number) => history.slice(index));
+    retained.resumeLockedHostedWizard.mockImplementation(async () => {
+      if (history.length === 2) {
+        history.push({ role: "assistant", text: "Done — matrix is configured." });
+      }
+      return { text: "Done — matrix is configured.", action: "none" };
+    });
+    const sessions = new Map<string, SystemAgentChatSession>([
+      ["old-session", seededSession({ engine: retained })],
+    ]);
+
+    const first = await callChat(makeContext(sessions), { sessionId: "new-session" });
+    const retry = await callChat(makeContext(sessions), { sessionId: "new-session" });
+
+    expect(first.payload).toMatchObject({ reply: "Done — matrix is configured." });
+    expect(retry.payload).toMatchObject({ reply: "Done — matrix is configured." });
+    expect(transcriptMocks.appendTranscriptTurn).toHaveBeenCalledOnce();
+    expect(transcriptMocks.appendTranscriptTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        role: "assistant",
+        text: "Done — matrix is configured.",
+      }),
+    );
+  });
+
   it("requires a welcome handshake before aliasing a locked wizard", async () => {
     const retained = makeEngine();
     retained.hasLockedHostedWizard.mockReturnValue(true);

--- a/src/gateway/server-methods/system-agent-session-ownership.test.ts
+++ b/src/gateway/server-methods/system-agent-session-ownership.test.ts
@@ -490,10 +490,7 @@ describe("openclaw.chat session responses", () => {
     const candidateEngine = makeEngine();
     const candidate = seededSession({ engine: candidateEngine });
     candidate.pendingApproval = { id: "approval-1", proposalHash: "hash-1" };
-    candidateEngine.dispose.mockImplementation(async () => {
-      await cleanupGate;
-      return true;
-    });
+    candidateEngine.dispose.mockReturnValue(cleanupGate.then(() => true));
     sessions.set("candidate", candidate);
     for (let index = 1; index < 8; index += 1) {
       const session = seededSession();

--- a/src/gateway/server-methods/system-agent-session-ownership.test.ts
+++ b/src/gateway/server-methods/system-agent-session-ownership.test.ts
@@ -190,6 +190,19 @@ describe("openclaw.chat session ownership", () => {
     expect(sessions.get("new-session")?.engine).toBe(retained);
     expect(retained.resumeLockedHostedWizard).toHaveBeenCalledOnce();
     expect(createdEngines).toHaveLength(0);
+
+    const retry = await callChat(makeContext(sessions), { sessionId: "new-session" });
+
+    expect(retry).toMatchObject({
+      ok: true,
+      payload: {
+        sessionId: "new-session",
+        reply: "Retry validation?",
+        wizardInputPending: true,
+      },
+    });
+    expect(retained.resumeLockedHostedWizard).toHaveBeenCalledTimes(2);
+    expect(createdEngines).toHaveLength(0);
   });
 
   it("does not adopt a locked wizard owned by another caller", async () => {

--- a/src/gateway/server-methods/system-agent-session-ownership.test.ts
+++ b/src/gateway/server-methods/system-agent-session-ownership.test.ts
@@ -1,9 +1,11 @@
 // System-agent session tests cover caller ownership and response projection.
 
 import { expectDefined } from "@openclaw/normalization-core";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, type Mocked, vi } from "vitest";
 import { resetCommandQueueStateForTest } from "../../process/command-queue.test-support.js";
+import type { SystemAgentChatEngine } from "../../system-agent/chat-engine.js";
 import { SystemAgentInferenceUnavailableError } from "../../system-agent/inference-error.js";
+import type { SystemAgentOverview } from "../../system-agent/overview.js";
 import { systemAgentHandlers, type SystemAgentChatSession } from "./system-agent.js";
 import type { GatewayClient, GatewayRequestContext, RespondFn } from "./types.js";
 
@@ -39,20 +41,35 @@ vi.mock("../../system-agent/greeting.js", () => ({
   resolveSystemAgentGreeting: vi.fn(async () => ({ text: "welcome text", source: "template" })),
 }));
 
-type FakeEngine = {
-  handle: ReturnType<typeof vi.fn>;
-  seedHistory: ReturnType<typeof vi.fn>;
-  historyLength: ReturnType<typeof vi.fn>;
-  historySince: ReturnType<typeof vi.fn>;
-  getPendingOperatorProposal: ReturnType<typeof vi.fn>;
-  resolveOperatorApproval: ReturnType<typeof vi.fn>;
-  dispose: ReturnType<typeof vi.fn>;
-  hasLockedHostedWizard: ReturnType<typeof vi.fn>;
-  resumeLockedHostedWizard: ReturnType<
-    typeof vi.fn<SystemAgentChatSession["engine"]["resumeLockedHostedWizard"]>
-  >;
-  loadOverview: ReturnType<typeof vi.fn>;
-  noteAssistantMessage: ReturnType<typeof vi.fn>;
+type FakeEngine = Mocked<
+  Pick<
+    SystemAgentChatEngine,
+    | "handle"
+    | "seedHistory"
+    | "historyLength"
+    | "historySince"
+    | "getPendingOperatorProposal"
+    | "resolveOperatorApproval"
+    | "dispose"
+    | "hasLockedHostedWizard"
+    | "resumeLockedHostedWizard"
+    | "loadOverview"
+    | "noteAssistantMessage"
+  >
+>;
+
+const testOverview: SystemAgentOverview = {
+  config: { path: "openclaw.json", exists: true, valid: true, issues: [], hash: "test" },
+  agents: [],
+  defaultAgentId: "main",
+  tools: {
+    codex: { command: "codex", found: false },
+    claude: { command: "claude", found: false },
+    gemini: { command: "gemini", found: false },
+    apiKeys: { openai: false, anthropic: false },
+  },
+  gateway: { url: "ws://127.0.0.1", source: "test", reachable: true },
+  references: { docsUrl: "https://docs.openclaw.ai", sourceUrl: "https://github.com/openclaw" },
 };
 
 function makeEngine(): FakeEngine {
@@ -65,10 +82,8 @@ function makeEngine(): FakeEngine {
     resolveOperatorApproval: vi.fn(async () => null),
     dispose: vi.fn(async () => true),
     hasLockedHostedWizard: vi.fn(() => false),
-    resumeLockedHostedWizard: vi.fn<SystemAgentChatSession["engine"]["resumeLockedHostedWizard"]>(
-      async () => null,
-    ),
-    loadOverview: vi.fn(async () => ({})),
+    resumeLockedHostedWizard: vi.fn(async () => null),
+    loadOverview: vi.fn(async () => testOverview),
     noteAssistantMessage: vi.fn(),
   };
 }
@@ -131,7 +146,7 @@ function seededSession(params?: {
     welcome: "welcome text",
     lastUsedAt: 1,
     ownerKey: params?.ownerKey ?? "device:device-test",
-  } as unknown as SystemAgentChatSession;
+  };
 }
 
 async function callChat(
@@ -215,6 +230,33 @@ describe("openclaw.chat session ownership", () => {
 
     expect(original.ok).toBe(true);
     expect(retained.handle).toHaveBeenCalledWith("yes");
+  });
+
+  it("bounds reconnect aliases while preserving the newest session ids", async () => {
+    const retained = makeEngine();
+    retained.hasLockedHostedWizard.mockReturnValue(true);
+    retained.resumeLockedHostedWizard.mockResolvedValue({
+      text: "Retry validation?",
+      action: "none",
+      wizardInputPending: true,
+    });
+    const sessions = new Map<string, SystemAgentChatSession>([
+      ["original", seededSession({ engine: retained })],
+    ]);
+
+    for (let index = 1; index <= 5; index += 1) {
+      const call = await callChat(makeContext(sessions), { sessionId: `reconnect-${index}` });
+      expect(call.ok).toBe(true);
+    }
+
+    expect([...sessions.keys()]).toEqual([
+      "reconnect-2",
+      "reconnect-3",
+      "reconnect-4",
+      "reconnect-5",
+    ]);
+    expect(new Set(sessions.values())).toEqual(new Set([sessions.get("reconnect-5")]));
+    expect(retained.resumeLockedHostedWizard).toHaveBeenCalledTimes(5);
   });
 
   it("persists a terminal wizard reply generated during recovery only once", async () => {
@@ -514,6 +556,49 @@ describe("openclaw.chat session responses", () => {
     expect(engine.dispose).not.toHaveBeenCalled();
   });
 
+  it("revokes every reconnect alias before reset cleanup yields", async () => {
+    let releaseCleanup!: () => void;
+    const cleanupGate = new Promise<void>((resolve) => {
+      releaseCleanup = resolve;
+    });
+    const engine = makeEngine();
+    engine.dispose.mockReturnValue(cleanupGate.then(() => true));
+    const session = seededSession({ engine });
+    const sessions = new Map<string, SystemAgentChatSession>([
+      ["original", session],
+      ["reconnected", session],
+    ]);
+
+    const call = callChat(makeContext(sessions), { sessionId: "reconnected", reset: true });
+    await vi.waitFor(() => expect(engine.dispose).toHaveBeenCalledOnce());
+
+    expect(sessions.has("original")).toBe(false);
+    expect(sessions.has("reconnected")).toBe(false);
+    releaseCleanup();
+    expect((await call).ok).toBe(true);
+    expect(sessions.get("reconnected")?.engine).not.toBe(engine);
+  });
+
+  it("counts reconnect aliases as one session for capacity", async () => {
+    const sessions = new Map<string, SystemAgentChatSession>();
+    const aliased = seededSession();
+    sessions.set("original", aliased);
+    sessions.set("reconnect-1", aliased);
+    sessions.set("reconnect-2", aliased);
+    for (let index = 1; index <= 6; index += 1) {
+      sessions.set(`existing-${index}`, seededSession());
+    }
+
+    const call = await callChat(makeContext(sessions), { sessionId: "replacement" });
+
+    expect(call.ok).toBe(true);
+    expect(sessions.has("original")).toBe(true);
+    expect(sessions.has("reconnect-1")).toBe(true);
+    expect(sessions.has("reconnect-2")).toBe(true);
+    expect(aliased.engine.dispose).not.toHaveBeenCalled();
+    expect(new Set(sessions.values()).size).toBe(8);
+  });
+
   it("evicts the oldest disposable session and keeps locked work owned", async () => {
     const sessions = new Map<string, SystemAgentChatSession>();
     const locked = makeEngine();
@@ -579,6 +664,7 @@ describe("openclaw.chat session responses", () => {
     candidate.pendingApproval = { id: "approval-1", proposalHash: "hash-1" };
     candidateEngine.dispose.mockReturnValue(cleanupGate.then(() => true));
     sessions.set("candidate", candidate);
+    sessions.set("candidate-reconnected", candidate);
     for (let index = 1; index < 8; index += 1) {
       const session = seededSession();
       session.lastUsedAt = index;
@@ -590,9 +676,11 @@ describe("openclaw.chat session responses", () => {
     await vi.waitFor(() => expect(candidate.engine.dispose).toHaveBeenCalledOnce());
 
     expect(sessions.has("candidate")).toBe(false);
+    expect(sessions.has("candidate-reconnected")).toBe(false);
     expect(expire).toHaveBeenCalledWith("approval-1", "session-evicted");
     releaseCleanup();
     expect((await call).ok).toBe(true);
+    expect(sessions.size).toBe(8);
   });
 
   it("retains locked work when inference failure cleanup refuses disposal", async () => {

--- a/src/gateway/server-methods/system-agent-session-ownership.test.ts
+++ b/src/gateway/server-methods/system-agent-session-ownership.test.ts
@@ -48,7 +48,9 @@ type FakeEngine = {
   resolveOperatorApproval: ReturnType<typeof vi.fn>;
   dispose: ReturnType<typeof vi.fn>;
   hasLockedHostedWizard: ReturnType<typeof vi.fn>;
-  resumeLockedHostedWizard: ReturnType<typeof vi.fn>;
+  resumeLockedHostedWizard: ReturnType<
+    typeof vi.fn<SystemAgentChatSession["engine"]["resumeLockedHostedWizard"]>
+  >;
   loadOverview: ReturnType<typeof vi.fn>;
   noteAssistantMessage: ReturnType<typeof vi.fn>;
 };
@@ -63,7 +65,9 @@ function makeEngine(): FakeEngine {
     resolveOperatorApproval: vi.fn(async () => null),
     dispose: vi.fn(async () => true),
     hasLockedHostedWizard: vi.fn(() => false),
-    resumeLockedHostedWizard: vi.fn(async () => null),
+    resumeLockedHostedWizard: vi.fn<SystemAgentChatSession["engine"]["resumeLockedHostedWizard"]>(
+      async () => null,
+    ),
     loadOverview: vi.fn(async () => ({})),
     noteAssistantMessage: vi.fn(),
   };

--- a/src/gateway/server-methods/system-agent-session-ownership.test.ts
+++ b/src/gateway/server-methods/system-agent-session-ownership.test.ts
@@ -311,6 +311,45 @@ describe("openclaw.chat session ownership", () => {
     expect(createdEngines).toHaveLength(0);
   });
 
+  it("blocks a bound sibling turn and adopts the owner's locked wizard on welcome", async () => {
+    const retained = makeEngine();
+    retained.hasLockedHostedWizard.mockReturnValue(true);
+    retained.resumeLockedHostedWizard.mockResolvedValue({
+      text: "Retry validation?",
+      action: "none",
+      wizardInputPending: true,
+    });
+    const sibling = makeEngine();
+    const sessions = new Map<string, SystemAgentChatSession>([
+      ["locked-session", seededSession({ engine: retained })],
+      ["sibling-session", seededSession({ engine: sibling })],
+    ]);
+    const context = makeContext(sessions);
+
+    const blocked = await callChat(context, {
+      sessionId: "sibling-session",
+      message: "connect telegram",
+    });
+
+    expect(blocked).toMatchObject({ ok: false, error: { code: "INVALID_REQUEST" } });
+    expect(sibling.handle).not.toHaveBeenCalled();
+    expect(sibling.dispose).not.toHaveBeenCalled();
+
+    const recovered = await callChat(context, { sessionId: "sibling-session" });
+
+    expect(recovered).toMatchObject({
+      ok: true,
+      payload: {
+        sessionId: "sibling-session",
+        reply: "Retry validation?",
+        wizardInputPending: true,
+      },
+    });
+    expect(sibling.dispose).toHaveBeenCalledOnce();
+    expect(sessions.get("sibling-session")?.engine).toBe(retained);
+    expect(retained.resumeLockedHostedWizard).toHaveBeenCalledOnce();
+  });
+
   it("does not adopt a locked wizard owned by another caller", async () => {
     const retained = makeEngine();
     retained.hasLockedHostedWizard.mockReturnValue(true);

--- a/src/gateway/server-methods/system-agent-session-ownership.test.ts
+++ b/src/gateway/server-methods/system-agent-session-ownership.test.ts
@@ -88,6 +88,7 @@ function makeClient(params: {
   connId: string;
   deviceId?: string;
   authenticatedUserId?: string;
+  sharedAuthGeneration?: string;
 }): GatewayClient {
   return {
     connId: params.connId,
@@ -96,6 +97,12 @@ function makeClient(params: {
       ...(params.deviceId ? { device: { id: params.deviceId } } : {}),
     },
     ...(params.authenticatedUserId ? { authenticatedUserId: params.authenticatedUserId } : {}),
+    ...(params.sharedAuthGeneration
+      ? {
+          usesSharedGatewayAuth: true,
+          sharedGatewaySessionGeneration: params.sharedAuthGeneration,
+        }
+      : {}),
   } as GatewayClient;
 }
 
@@ -333,6 +340,26 @@ describe("openclaw.chat session ownership", () => {
     expect(handle).toHaveBeenCalledWith("continue");
   });
 
+  it("lets shared-auth sessions resume after credential rotation", async () => {
+    const sessions = new Map<string, SystemAgentChatSession>();
+    const context = makeContext(sessions);
+    await callChat(
+      context,
+      { sessionId: "shared-auth-reconnect" },
+      makeClient({ connId: "conn-old", sharedAuthGeneration: "generation-old" }),
+    );
+    const handle = expectDefined(createdEngines[0], "created system-agent engine").handle;
+
+    const resumed = await callChat(
+      context,
+      { sessionId: "shared-auth-reconnect", message: "continue" },
+      makeClient({ connId: "conn-new", sharedAuthGeneration: "generation-new" }),
+    );
+
+    expect(resumed.ok).toBe(true);
+    expect(handle).toHaveBeenCalledWith("continue");
+  });
+
   it("rejects non-delegated chat without a server-authenticated identity", async () => {
     const call = await callChat(makeContext(new Map()), { sessionId: "anonymous" }, null);
 
@@ -460,9 +487,10 @@ describe("openclaw.chat session responses", () => {
       releaseCleanup = resolve;
     });
     const sessions = new Map<string, SystemAgentChatSession>();
-    const candidate = seededSession();
+    const candidateEngine = makeEngine();
+    const candidate = seededSession({ engine: candidateEngine });
     candidate.pendingApproval = { id: "approval-1", proposalHash: "hash-1" };
-    candidate.engine.dispose.mockImplementation(async () => {
+    candidateEngine.dispose.mockImplementation(async () => {
       await cleanupGate;
       return true;
     });

--- a/src/gateway/server-methods/system-agent.test.ts
+++ b/src/gateway/server-methods/system-agent.test.ts
@@ -831,7 +831,7 @@ describe("openclaw.chat", () => {
     vi.spyOn(engine, "handle").mockRejectedValue(
       new SystemAgentInferenceUnavailableError("conversation"),
     );
-    const dispose = vi.spyOn(engine, "dispose").mockResolvedValue();
+    const dispose = vi.spyOn(engine, "dispose").mockResolvedValue(true);
     const sessions = new Map<string, SystemAgentChatSession>([["s1", seededSession({ engine })]]);
     const context = makeContext(sessions);
 
@@ -940,6 +940,7 @@ describe("openclaw.chat", () => {
     const disposeOldest = vi.spyOn(oldest.engine, "dispose").mockImplementation(async () => {
       evictionStarted.resolve();
       await releaseEviction.promise;
+      return true;
     });
     const sessions = new Map<string, SystemAgentChatSession>([["oldest", oldest]]);
     for (let index = 1; index < 8; index += 1) {
@@ -968,7 +969,7 @@ describe("openclaw.chat", () => {
     transcriptStoreMocks.readTranscriptTail.mockReturnValue([]);
     const engine = makeVerifiedEngine();
     const handle = vi.spyOn(engine, "handle");
-    const dispose = vi.spyOn(engine, "dispose").mockResolvedValue();
+    const dispose = vi.spyOn(engine, "dispose").mockResolvedValue(true);
     const seedHistory = vi.spyOn(SystemAgentChatEngine.prototype, "seedHistory");
     const sessions = new Map<string, SystemAgentChatSession>([["s1", seededSession({ engine })]]);
     // Reset drops the stored session; loading a fresh welcome would hit real

--- a/src/gateway/server-methods/system-agent.ts
+++ b/src/gateway/server-methods/system-agent.ts
@@ -644,8 +644,12 @@ export const systemAgentHandlers: GatewayRequestHandlers = {
         }
         session.lastUsedAt = Date.now();
         if (welcomeOnly && session.engine.hasLockedHostedWizard()) {
+          const historyStart = session.engine.historyLength();
           const resumed = await session.engine.resumeLockedHostedWizard();
           if (resumed) {
+            // Persist before responding so a dropped recovery response cannot
+            // erase the only durable record of a completed setup.
+            persistEngineHistory(session.engine, historyStart);
             respond(
               true,
               {

--- a/src/gateway/server-methods/system-agent.ts
+++ b/src/gateway/server-methods/system-agent.ts
@@ -481,7 +481,6 @@ export const systemAgentHandlers: GatewayRequestHandlers = {
           );
           return;
         }
-        let adoptedLockedWizard = false;
         if (!boundSession) {
           const adoption = adoptLockedSystemAgentWizard({
             sessions,
@@ -507,9 +506,6 @@ export const systemAgentHandlers: GatewayRequestHandlers = {
               errorShape(ErrorCodes.INVALID_REQUEST, LOCKED_SETUP_RESET_ERROR),
             );
             return;
-          }
-          if (adoption.kind === "adopted") {
-            adoptedLockedWizard = true;
           }
         }
         if (params.reset && !(await resetSystemAgentSession({ sessions, sessionId, context }))) {
@@ -634,7 +630,7 @@ export const systemAgentHandlers: GatewayRequestHandlers = {
           }
         }
         session.lastUsedAt = Date.now();
-        if (adoptedLockedWizard && welcomeOnly) {
+        if (welcomeOnly && session.engine.hasLockedHostedWizard()) {
           const resumed = await session.engine.resumeLockedHostedWizard();
           if (resumed) {
             respond(

--- a/src/gateway/server-methods/system-agent.ts
+++ b/src/gateway/server-methods/system-agent.ts
@@ -22,7 +22,6 @@ import { enqueueCommandInLane, setCommandLaneConcurrency } from "../../process/c
 import { CommandLane } from "../../process/lanes.js";
 import { defaultRuntime } from "../../runtime.js";
 import { SystemAgentChatEngine } from "../../system-agent/chat-engine.js";
-import { resolveSystemAgentDelegationKey } from "../../system-agent/delegation-session.js";
 import {
   acknowledgeSystemAgentGreetingDelivery,
   buildSystemAgentGreetingQuestion,
@@ -45,7 +44,12 @@ import {
   handlePendingApprovalRequest,
   listVisiblePendingApprovalRequests,
 } from "./approval-shared.js";
-import type { GatewayClient, GatewayRequestContext, GatewayRequestHandlers } from "./types.js";
+import {
+  adoptLockedSystemAgentWizard,
+  evictOldestSystemAgentSession,
+  resolveSystemAgentSessionOwnerKey,
+} from "./system-agent-session-lifecycle.js";
+import type { GatewayRequestContext, GatewayRequestHandlers } from "./types.js";
 import { assertValidParams } from "./validation.js";
 
 /**
@@ -67,6 +71,8 @@ const DEFAULT_SYSTEM_AGENT_HISTORY_LIMIT = 100;
 const PROVIDER_AUTH_SESSION_TIMEOUT_MS = 25 * 60 * 1000;
 const PROVIDER_PREPARE_SESSION_TIMEOUT_MS = 2 * 60 * 60 * 1000;
 const SYSTEM_AGENT_GATEWAY_EXECUTION_KEY = "gateway";
+const LOCKED_SETUP_RESET_ERROR = "Channel setup is already applying and cannot be reset yet.";
+const LOCKED_SETUP_BUSY_ERROR = "OpenClaw is finishing channel setup. Try again shortly.";
 const systemAgentGatewayExecutionQueue = new KeyedAsyncQueue();
 const systemAgentSessionQueues = new WeakMap<
   Map<string, SystemAgentChatSession>,
@@ -105,30 +111,6 @@ async function runSystemAgentGatewayTask<T>(task: () => Promise<T>): Promise<T> 
   );
 }
 
-function resolveSystemAgentSessionOwnerKey(params: {
-  delegation?: { agentId?: string; sessionKey?: string };
-  client: GatewayClient | null;
-}): string | undefined {
-  const delegationKey = resolveSystemAgentDelegationKey(params.delegation);
-  if (delegationKey !== undefined) {
-    // Delegation is the host-only, cross-connection owner asserted by the regular-agent
-    // tool path. Keep its agent/session tuple authoritative across gateway reconnects.
-    return delegationKey;
-  }
-  // Authenticated users survive reconnects and may span paired devices. Otherwise
-  // bind to the verified device, with the server-issued connection as a last resort.
-  const userId = params.client?.authenticatedUserId?.trim();
-  if (userId) {
-    return `user:${userId}`;
-  }
-  const deviceId = params.client?.connect.device?.id.trim();
-  if (deviceId) {
-    return `device:${deviceId}`;
-  }
-  const connId = params.client?.connId?.trim();
-  return connId ? `connection:${connId}` : undefined;
-}
-
 let systemAgentSetupActivationInProgress = false;
 
 class SystemAgentSetupActivationBusyError extends Error {}
@@ -147,31 +129,6 @@ export async function runExclusiveSystemAgentSetupActivation<T>(
     return await task();
   } finally {
     systemAgentSetupActivationInProgress = false;
-  }
-}
-
-async function evictOldestSession(
-  sessions: Map<string, SystemAgentChatSession>,
-  context: GatewayRequestContext,
-): Promise<void> {
-  if (sessions.size < MAX_SYSTEM_AGENT_SESSIONS) {
-    return;
-  }
-  let oldestKey: string | undefined;
-  let oldestAt = Number.POSITIVE_INFINITY;
-  for (const [key, session] of sessions) {
-    if (session.lastUsedAt < oldestAt) {
-      oldestAt = session.lastUsedAt;
-      oldestKey = key;
-    }
-  }
-  if (oldestKey !== undefined) {
-    const oldest = sessions.get(oldestKey);
-    if (oldest?.pendingApproval) {
-      context.systemAgentApprovalManager?.expire(oldest.pendingApproval.id, "session-evicted");
-    }
-    await oldest?.engine.dispose();
-    sessions.delete(oldestKey);
   }
 }
 
@@ -523,8 +480,47 @@ export const systemAgentHandlers: GatewayRequestHandlers = {
           );
           return;
         }
+        let adoptedLockedWizard = false;
+        if (!boundSession) {
+          const adoption = adoptLockedSystemAgentWizard({
+            sessions,
+            sessionId,
+            ownerKey,
+            reset: params.reset === true,
+          });
+          if (adoption.kind === "ambiguous") {
+            respond(
+              false,
+              undefined,
+              errorShape(
+                ErrorCodes.INVALID_REQUEST,
+                "Multiple locked OpenClaw setup sessions need manual recovery.",
+              ),
+            );
+            return;
+          }
+          if (adoption.kind === "reset-refused") {
+            respond(
+              false,
+              undefined,
+              errorShape(ErrorCodes.INVALID_REQUEST, LOCKED_SETUP_RESET_ERROR),
+            );
+            return;
+          }
+          if (adoption.kind === "adopted") {
+            adoptedLockedWizard = true;
+          }
+        }
         if (params.reset) {
           const existing = sessions.get(sessionId);
+          if (existing && !(await existing.engine.dispose())) {
+            respond(
+              false,
+              undefined,
+              errorShape(ErrorCodes.INVALID_REQUEST, LOCKED_SETUP_RESET_ERROR),
+            );
+            return;
+          }
           sessions.delete(sessionId);
           if (existing?.pendingApproval) {
             context.systemAgentApprovalManager?.expire(
@@ -532,7 +528,6 @@ export const systemAgentHandlers: GatewayRequestHandlers = {
               "session-reset",
             );
           }
-          await existing?.engine.dispose();
         }
         let session = sessions.get(sessionId);
         let greetingAuditSequence: number | undefined;
@@ -614,7 +609,13 @@ export const systemAgentHandlers: GatewayRequestHandlers = {
             appendTranscriptReset();
           }
           persistEngineHistory(engine, welcomeHistoryStart);
-          await evictOldestSession(sessions, context);
+          if (
+            !(await evictOldestSystemAgentSession(sessions, context, MAX_SYSTEM_AGENT_SESSIONS))
+          ) {
+            await engine.dispose().catch(() => undefined);
+            respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, LOCKED_SETUP_BUSY_ERROR));
+            return;
+          }
           session = {
             engine,
             welcome,
@@ -642,6 +643,24 @@ export const systemAgentHandlers: GatewayRequestHandlers = {
           }
         }
         session.lastUsedAt = Date.now();
+        if (adoptedLockedWizard && welcomeOnly) {
+          const resumed = await session.engine.resumeLockedHostedWizard();
+          if (resumed) {
+            respond(
+              true,
+              {
+                sessionId,
+                reply: resumed.text || "Channel setup is still applying.",
+                action: "none",
+                ...(resumed.sensitive === true ? { sensitive: true } : {}),
+                ...(resumed.wizardInputPending === true ? { wizardInputPending: true } : {}),
+                ...(resumed.question ? { question: resumed.question } : {}),
+              },
+              undefined,
+            );
+            return;
+          }
+        }
         // Inline check (not `welcomeOnly`) so TS narrows params.message below.
         if (params.message === undefined || !params.message.trim()) {
           respond(
@@ -666,24 +685,25 @@ export const systemAgentHandlers: GatewayRequestHandlers = {
           if (!isSystemAgentInferenceUnavailableError(error)) {
             throw error;
           }
-          // A failed inference turn invalidates this conversation. Remove the
-          // exact engine before cleanup so a retry must pass the live gate and
-          // cannot resume partial proposal or CLI-session state.
-          // Initialization failures stay unmarked because no live session existed.
-          if (sessions.get(sessionId)?.engine === session.engine) {
-            sessions.delete(sessionId);
-          }
+          let retainedForWizard = false;
           try {
-            await session.engine.dispose();
+            retainedForWizard = !(await session.engine.dispose());
           } catch {
             // The inference error is authoritative; cleanup stays best-effort.
+          }
+          if (!retainedForWizard && sessions.get(sessionId)?.engine === session.engine) {
+            sessions.delete(sessionId);
           }
           respond(
             false,
             undefined,
-            errorShape(ErrorCodes.UNAVAILABLE, error.message, {
-              details: buildSystemAgentSessionInvalidatedErrorDetails(),
-            }),
+            errorShape(
+              ErrorCodes.UNAVAILABLE,
+              error.message,
+              retainedForWizard
+                ? undefined
+                : { details: buildSystemAgentSessionInvalidatedErrorDetails() },
+            ),
           );
           return;
         }

--- a/src/gateway/server-methods/system-agent.ts
+++ b/src/gateway/server-methods/system-agent.ts
@@ -43,6 +43,7 @@ import {
   handlePendingApprovalRequest,
   listVisiblePendingApprovalRequests,
 } from "./approval-shared.js";
+import { resolveGatewayHostedSessionOwner } from "./hosted-session-owner.js";
 import {
   acknowledgeDeliveredSystemAgentWelcome,
   adoptLockedSystemAgentWizard,
@@ -555,6 +556,9 @@ export const systemAgentHandlers: GatewayRequestHandlers = {
             surface: "gateway",
             verifiedInference: inference.binding,
             operatorApprovalOnly: params.delegation !== undefined,
+            allowHostedChannelSetup:
+              params.delegation !== undefined ||
+              resolveGatewayHostedSessionOwner(client).kind === "stable",
           });
           // `reset: true` keeps the durable logbook but deliberately starts
           // model context clean; only ordinary fresh sessions receive its tail.

--- a/src/gateway/server-methods/system-agent.ts
+++ b/src/gateway/server-methods/system-agent.ts
@@ -46,6 +46,7 @@ import {
 } from "./approval-shared.js";
 import {
   adoptLockedSystemAgentWizard,
+  deleteSystemAgentSessionAliases,
   evictOldestSystemAgentSession,
   resetSystemAgentSession,
   resolveSystemAgentSessionOwnerKey,
@@ -691,7 +692,7 @@ export const systemAgentHandlers: GatewayRequestHandlers = {
             // The inference error is authoritative; cleanup stays best-effort.
           }
           if (!retainedForWizard && sessions.get(sessionId)?.engine === session.engine) {
-            sessions.delete(sessionId);
+            deleteSystemAgentSessionAliases(sessions, session);
           }
           respond(
             false,

--- a/src/gateway/server-methods/system-agent.ts
+++ b/src/gateway/server-methods/system-agent.ts
@@ -474,13 +474,15 @@ export const systemAgentHandlers: GatewayRequestHandlers = {
           );
           return;
         }
-        if (!boundSession) {
-          const adoption = adoptLockedSystemAgentWizard({
+        {
+          const adoption = await adoptLockedSystemAgentWizard({
             sessions,
             sessionId,
             ownerKey,
             reset: params.reset === true,
             allowAdoption: welcomeOnly,
+            context,
+            ...(boundSession ? { boundSession } : {}),
           });
           if (adoption.kind === "ambiguous") {
             respond(

--- a/src/gateway/server-methods/system-agent.ts
+++ b/src/gateway/server-methods/system-agent.ts
@@ -456,6 +456,7 @@ export const systemAgentHandlers: GatewayRequestHandlers = {
     await runSystemAgentGatewayTask(async () => {
       const sessions = context.systemAgentSessions;
       const sessionId = params.sessionId;
+      const welcomeOnly = params.message === undefined || !params.message.trim();
       // Initialization, resets, and turns share one per-session queue. Without
       // it, concurrent first messages can create competing engines and lose
       // conversation state when the later initializer replaces the first.
@@ -487,6 +488,7 @@ export const systemAgentHandlers: GatewayRequestHandlers = {
             sessionId,
             ownerKey,
             reset: params.reset === true,
+            allowAdoption: welcomeOnly,
           });
           if (adoption.kind === "ambiguous") {
             respond(
@@ -507,6 +509,17 @@ export const systemAgentHandlers: GatewayRequestHandlers = {
             );
             return;
           }
+          if (adoption.kind === "welcome-required") {
+            respond(
+              false,
+              undefined,
+              errorShape(
+                ErrorCodes.INVALID_REQUEST,
+                "Restart OpenClaw to recover the channel setup already in progress.",
+              ),
+            );
+            return;
+          }
         }
         if (params.reset && !(await resetSystemAgentSession({ sessions, sessionId, context }))) {
           respond(
@@ -518,7 +531,6 @@ export const systemAgentHandlers: GatewayRequestHandlers = {
         }
         let session = sessions.get(sessionId);
         let greetingAuditSequence: number | undefined;
-        const welcomeOnly = params.message === undefined || !params.message.trim();
         if (!session) {
           const inference = params.delegation
             ? await import("../../system-agent/inference-fallback.js").then(

--- a/src/gateway/server-methods/system-agent.ts
+++ b/src/gateway/server-methods/system-agent.ts
@@ -23,7 +23,6 @@ import { CommandLane } from "../../process/lanes.js";
 import { defaultRuntime } from "../../runtime.js";
 import { SystemAgentChatEngine } from "../../system-agent/chat-engine.js";
 import {
-  acknowledgeSystemAgentGreetingDelivery,
   buildSystemAgentGreetingQuestion,
   loadSystemAgentGreetingFacts,
   resolveSystemAgentGreeting,
@@ -45,6 +44,7 @@ import {
   listVisiblePendingApprovalRequests,
 } from "./approval-shared.js";
 import {
+  acknowledgeDeliveredSystemAgentWelcome,
   adoptLockedSystemAgentWizard,
   deleteSystemAgentSessionAliases,
   evictOldestSystemAgentSession,
@@ -90,15 +90,6 @@ function getSystemAgentSessionQueue(
     systemAgentSessionQueues.set(sessions, queue);
   }
   return queue;
-}
-
-function acknowledgeDeliveredSystemAgentWelcome(session: SystemAgentChatSession): void {
-  const auditSequence = session.welcomeAuditSequence;
-  if (auditSequence === undefined) {
-    return;
-  }
-  acknowledgeSystemAgentGreetingDelivery({ auditSequence });
-  delete session.welcomeAuditSequence;
 }
 
 async function runSystemAgentGatewayTask<T>(task: () => Promise<T>): Promise<T> {

--- a/src/gateway/server-methods/system-agent.ts
+++ b/src/gateway/server-methods/system-agent.ts
@@ -47,6 +47,7 @@ import {
 import {
   adoptLockedSystemAgentWizard,
   evictOldestSystemAgentSession,
+  resetSystemAgentSession,
   resolveSystemAgentSessionOwnerKey,
 } from "./system-agent-session-lifecycle.js";
 import type { GatewayRequestContext, GatewayRequestHandlers } from "./types.js";
@@ -511,23 +512,13 @@ export const systemAgentHandlers: GatewayRequestHandlers = {
             adoptedLockedWizard = true;
           }
         }
-        if (params.reset) {
-          const existing = sessions.get(sessionId);
-          if (existing && !(await existing.engine.dispose())) {
-            respond(
-              false,
-              undefined,
-              errorShape(ErrorCodes.INVALID_REQUEST, LOCKED_SETUP_RESET_ERROR),
-            );
-            return;
-          }
-          sessions.delete(sessionId);
-          if (existing?.pendingApproval) {
-            context.systemAgentApprovalManager?.expire(
-              existing.pendingApproval.id,
-              "session-reset",
-            );
-          }
+        if (params.reset && !(await resetSystemAgentSession({ sessions, sessionId, context }))) {
+          respond(
+            false,
+            undefined,
+            errorShape(ErrorCodes.INVALID_REQUEST, LOCKED_SETUP_RESET_ERROR),
+          );
+          return;
         }
         let session = sessions.get(sessionId);
         let greetingAuditSequence: number | undefined;
@@ -605,10 +596,6 @@ export const systemAgentHandlers: GatewayRequestHandlers = {
             respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, error.message));
             return;
           }
-          if (params.reset) {
-            appendTranscriptReset();
-          }
-          persistEngineHistory(engine, welcomeHistoryStart);
           if (
             !(await evictOldestSystemAgentSession(sessions, context, MAX_SYSTEM_AGENT_SESSIONS))
           ) {
@@ -616,6 +603,10 @@ export const systemAgentHandlers: GatewayRequestHandlers = {
             respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, LOCKED_SETUP_BUSY_ERROR));
             return;
           }
+          if (params.reset) {
+            appendTranscriptReset();
+          }
+          persistEngineHistory(engine, welcomeHistoryStart);
           session = {
             engine,
             welcome,

--- a/src/gateway/server-methods/wizard.test.ts
+++ b/src/gateway/server-methods/wizard.test.ts
@@ -2,6 +2,7 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it, vi } from "vitest";
 import { WizardSession } from "../../wizard/session.js";
+import { createWizardSessionTracker } from "../server-wizard-sessions.js";
 import type { GatewayRequestHandlerOptions } from "./types.js";
 import { wizardHandlers } from "./wizard.js";
 
@@ -97,7 +98,7 @@ describe("channel wizard lifecycle", () => {
     ).rejects.toThrow("cancelled before its persistent change started");
   });
 
-  it("resumes locked work for its owner after Browse all selects a channel", async () => {
+  it("resumes locked work through the first channel selected by Browse all", async () => {
     const wizardSessions = new Map<string, WizardSession>();
     const runCount = vi.fn();
     const context = {
@@ -115,6 +116,7 @@ describe("channel wizard lifecycle", () => {
       ) => {
         runCount();
         options.onResolvedChannel?.("matrix");
+        options.onResolvedChannel?.("twitch");
         await options.beforePersistentEffect?.();
         await prompter.confirm({ message: "Retry validation?" });
       },
@@ -241,6 +243,58 @@ describe("channel wizard lifecycle", () => {
       undefined,
     );
     expect(runCount).toHaveBeenCalledOnce();
+  });
+
+  it("reaps an expired retained result before same-owner recovery", async () => {
+    let now = 1_000;
+    const tracker = createWizardSessionTracker({ now: () => now });
+    const runCount = vi.fn();
+    const context = {
+      ...tracker,
+      channelWizardRunner: async (options: {
+        beforePersistentEffect?: () => Promise<void>;
+        onResolvedChannel?: (channel: string) => void;
+      }) => {
+        runCount();
+        options.onResolvedChannel?.("matrix");
+        await options.beforePersistentEffect?.();
+      },
+    };
+    const owner = {
+      connId: "owner-old-connection",
+      authenticatedUserId: "owner@example.com",
+      connect: { client: { id: "openclaw-control-ui", mode: "webchat" } },
+    };
+    const start = expectDefined(
+      wizardHandlers["wizard.start"],
+      "wizardHandlers[wizard.start] test invariant",
+    );
+    const firstRespond = vi.fn();
+
+    await start({
+      params: { flow: "channels", channel: "matrix" },
+      client: owner,
+      isConnectionActive: () => false,
+      respond: firstRespond,
+      context,
+    } as never);
+
+    const firstResult = firstRespond.mock.calls[0]?.[1] as { sessionId?: string } | undefined;
+    const firstSessionId = expectDefined(firstResult?.sessionId, "retained wizard session id");
+    expect(tracker.wizardSessions.has(firstSessionId)).toBe(true);
+
+    now += 5 * 60 * 1000;
+    const freshRespond = vi.fn();
+    await start({
+      params: { flow: "channels", channel: "matrix" },
+      client: { ...owner, connId: "owner-new-connection" },
+      respond: freshRespond,
+      context,
+    } as never);
+
+    const freshResult = freshRespond.mock.calls[0]?.[1] as { sessionId?: string } | undefined;
+    expect(freshResult?.sessionId).not.toBe(firstSessionId);
+    expect(runCount).toHaveBeenCalledTimes(2);
   });
 
   it("resumes locked shared-auth work after credential rotation", async () => {

--- a/src/gateway/server-methods/wizard.test.ts
+++ b/src/gateway/server-methods/wizard.test.ts
@@ -106,11 +106,15 @@ describe("channel wizard lifecycle", () => {
         [...wizardSessions].find(([, session]) => session.getStatus() === "running")?.[0] ?? null,
       purgeWizardSession: (id: string) => wizardSessions.delete(id),
       channelWizardRunner: async (
-        options: { beforePersistentEffect?: () => Promise<void> },
+        options: {
+          beforePersistentEffect?: () => Promise<void>;
+          onResolvedChannel?: (channel: string) => void;
+        },
         _runtime: unknown,
         prompter: { confirm: (params: { message: string }) => Promise<boolean> },
       ) => {
         runCount();
+        options.onResolvedChannel?.("matrix");
         await options.beforePersistentEffect?.();
         await prompter.confirm({ message: "Retry validation?" });
       },
@@ -192,6 +196,19 @@ describe("channel wizard lifecycle", () => {
       false,
       undefined,
       expect.objectContaining({ code: "INVALID_REQUEST" }),
+    );
+
+    const mismatchedRespond = vi.fn();
+    await start({
+      params: { flow: "channels", channel: "discord" },
+      client: reconnectedOwner,
+      respond: mismatchedRespond,
+      context,
+    } as never);
+    expect(mismatchedRespond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ code: "UNAVAILABLE" }),
     );
 
     const resumedRespond = vi.fn();

--- a/src/gateway/server-methods/wizard.test.ts
+++ b/src/gateway/server-methods/wizard.test.ts
@@ -304,6 +304,67 @@ describe("channel wizard lifecycle", () => {
     expect(runCount).toHaveBeenCalledOnce();
   });
 
+  it("restarts reversible shared-auth work after credential rotation", async () => {
+    const wizardSessions = new Map<string, WizardSession>();
+    const runCount = vi.fn();
+    const context = {
+      wizardSessions,
+      findRunningWizard: () =>
+        [...wizardSessions].find(([, session]) => session.getStatus() === "running")?.[0] ?? null,
+      purgeWizardSession: (id: string) => wizardSessions.delete(id),
+      channelWizardRunner: async (
+        _options: unknown,
+        _runtime: unknown,
+        prompter: { confirm: (params: { message: string }) => Promise<boolean> },
+      ) => {
+        runCount();
+        await prompter.confirm({ message: "Apply setup?" });
+      },
+    };
+    const sharedClient = (generation: string, connId: string) => ({
+      connId,
+      usesSharedGatewayAuth: true,
+      sharedGatewaySessionGeneration: generation,
+      connect: { client: { id: "openclaw-control-ui", mode: "webchat" } },
+    });
+    const start = expectDefined(
+      wizardHandlers["wizard.start"],
+      "wizardHandlers[wizard.start] test invariant",
+    );
+    const firstRespond = vi.fn();
+
+    await start({
+      params: { flow: "channels", channel: "matrix" },
+      client: sharedClient("generation-old", "connection-old"),
+      respond: firstRespond,
+      context,
+    } as never);
+
+    const firstResult = firstRespond.mock.calls[0]?.[1] as { sessionId?: string } | undefined;
+    const firstSessionId = expectDefined(
+      firstResult?.sessionId,
+      "reversible shared-auth wizard session id",
+    );
+    const firstSession = expectDefined(
+      wizardSessions.get(firstSessionId),
+      "reversible shared-auth wizard session",
+    );
+    const rotatedRespond = vi.fn();
+
+    await start({
+      params: { flow: "channels", channel: "matrix" },
+      client: sharedClient("generation-new", "connection-new"),
+      respond: rotatedRespond,
+      context,
+    } as never);
+
+    const rotatedResult = rotatedRespond.mock.calls[0]?.[1] as { sessionId?: string } | undefined;
+    expect(rotatedResult?.sessionId).not.toBe(firstSessionId);
+    expect(firstSession.signal.aborted).toBe(true);
+    expect(wizardSessions.has(firstSessionId)).toBe(false);
+    expect(runCount).toHaveBeenCalledTimes(2);
+  });
+
   it("returns an owner's retained terminal result without rerunning setup", async () => {
     const wizardSessions = new Map<string, WizardSession>();
     const runCount = vi.fn();

--- a/src/gateway/server-methods/wizard.test.ts
+++ b/src/gateway/server-methods/wizard.test.ts
@@ -289,23 +289,6 @@ describe("channel wizard lifecycle", () => {
       | undefined;
     const sessionId = expectDefined(firstResult?.sessionId, "shared-auth wizard session id");
     const stepId = expectDefined(firstResult?.step?.id, "shared-auth wizard step id");
-    const resumedRespond = vi.fn();
-
-    await start({
-      params: { flow: "channels", channel: "matrix" },
-      client: sharedClient("generation-new", "connection-new"),
-      respond: resumedRespond,
-      context,
-    } as never);
-
-    expect(resumedRespond).toHaveBeenCalledWith(
-      true,
-      expect.objectContaining({
-        sessionId,
-        step: expect.objectContaining({ id: stepId }),
-      }),
-      undefined,
-    );
     const completedRespond = vi.fn();
     await next({
       params: { sessionId, answer: { stepId, value: true } },

--- a/src/gateway/server-methods/wizard.test.ts
+++ b/src/gateway/server-methods/wizard.test.ts
@@ -226,6 +226,74 @@ describe("channel wizard lifecycle", () => {
     expect(runCount).toHaveBeenCalledOnce();
   });
 
+  it("returns an owner's retained terminal result without rerunning setup", async () => {
+    const wizardSessions = new Map<string, WizardSession>();
+    const runCount = vi.fn();
+    const context = {
+      wizardSessions,
+      findRunningWizard: () =>
+        [...wizardSessions].find(([, session]) => session.getStatus() === "running")?.[0] ?? null,
+      purgeWizardSession: (id: string) => wizardSessions.delete(id),
+      channelWizardRunner: async (
+        options: {
+          beforePersistentEffect?: () => Promise<void>;
+          onConfigured?: (accounts: Array<{ channel: string; accountId: string }>) => void;
+        },
+        _runtime: unknown,
+      ) => {
+        runCount();
+        await options.beforePersistentEffect?.();
+        options.onConfigured?.([{ channel: "matrix", accountId: "default" }]);
+      },
+    };
+    const owner = {
+      connId: "owner-old-connection",
+      authenticatedUserId: "owner@example.com",
+      connect: { client: { id: "openclaw-control-ui", mode: "webchat" } },
+    };
+    const start = expectDefined(
+      wizardHandlers["wizard.start"],
+      "wizardHandlers[wizard.start] test invariant",
+    );
+    const firstRespond = vi.fn();
+
+    await start({
+      params: { flow: "channels" },
+      client: owner,
+      respond: firstRespond,
+      context,
+    } as never);
+
+    const firstResult = firstRespond.mock.calls[0]?.[1] as { sessionId?: string } | undefined;
+    const sessionId = expectDefined(firstResult?.sessionId, "retained channel wizard session id");
+    expect(firstRespond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({ sessionId, done: true, status: "done" }),
+      undefined,
+    );
+
+    const recoveredRespond = vi.fn();
+    await start({
+      params: { flow: "channels", channel: "matrix" },
+      client: { ...owner, connId: "owner-new-connection" },
+      respond: recoveredRespond,
+      context,
+    } as never);
+
+    expect(recoveredRespond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({
+        sessionId,
+        done: true,
+        status: "done",
+        accounts: [{ channel: "matrix", accountId: "default" }],
+      }),
+      undefined,
+    );
+    expect(runCount).toHaveBeenCalledOnce();
+    expect(wizardSessions.has(sessionId)).toBe(false);
+  });
+
   it("rejects hosted channel setup without a reconnect-safe owner", async () => {
     const respond = vi.fn();
     const start = expectDefined(

--- a/src/gateway/server-methods/wizard.test.ts
+++ b/src/gateway/server-methods/wizard.test.ts
@@ -97,7 +97,7 @@ describe("channel wizard lifecycle", () => {
     ).rejects.toThrow("cancelled before its persistent change started");
   });
 
-  it("resumes locked work only for its authenticated owner without duplicating it", async () => {
+  it("resumes locked work for its owner after Browse all selects a channel", async () => {
     const wizardSessions = new Map<string, WizardSession>();
     const runCount = vi.fn();
     const context = {
@@ -141,7 +141,7 @@ describe("channel wizard lifecycle", () => {
     const firstRespond = vi.fn();
 
     await start({
-      params: { flow: "channels", channel: "matrix" },
+      params: { flow: "channels" },
       client: owner,
       respond: firstRespond,
       context,

--- a/src/gateway/server-methods/wizard.test.ts
+++ b/src/gateway/server-methods/wizard.test.ts
@@ -74,7 +74,12 @@ describe("channel wizard lifecycle", () => {
         params: { flow: "channels", channel: "matrix" },
       },
       params: { flow: "channels", channel: "matrix" },
-      client: null,
+      client: {
+        connId: "shared-auth-old-connection",
+        usesSharedGatewayAuth: true,
+        sharedGatewaySessionGeneration: "shared-auth-generation",
+        connect: { client: { id: "openclaw-control-ui", mode: "webchat" } },
+      },
       isWebchatConnect: () => false,
       respond,
       context,
@@ -148,6 +153,20 @@ describe("channel wizard lifecycle", () => {
     const sessionId = expectDefined(firstResult?.sessionId, "channel wizard session id");
     const stepId = expectDefined(firstResult?.step?.id, "channel wizard step id");
 
+    const lockedCancel = vi.fn();
+    await cancel({
+      params: { sessionId },
+      client: reconnectedOwner,
+      respond: lockedCancel,
+      context,
+    } as never);
+    expect(lockedCancel).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({ status: "running" }),
+      undefined,
+    );
+    expect(wizardSessions.has(sessionId)).toBe(true);
+
     const deniedCancel = vi.fn();
     await cancel({
       params: { sessionId },
@@ -205,5 +224,35 @@ describe("channel wizard lifecycle", () => {
       undefined,
     );
     expect(runCount).toHaveBeenCalledOnce();
+  });
+
+  it("rejects hosted channel setup without a reconnect-safe owner", async () => {
+    const respond = vi.fn();
+    const start = expectDefined(
+      wizardHandlers["wizard.start"],
+      "wizardHandlers[wizard.start] test invariant",
+    );
+
+    await start({
+      params: { flow: "channels", channel: "matrix" },
+      client: {
+        connId: "connection-only",
+        connect: { client: { id: "test-client", mode: "cli" } },
+      },
+      respond,
+      context: {
+        wizardSessions: new Map(),
+        findRunningWizard: () => null,
+      },
+    } as never);
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        code: "INVALID_REQUEST",
+        message: expect.stringContaining("survive reconnects"),
+      }),
+    );
   });
 });

--- a/src/gateway/server-methods/wizard.test.ts
+++ b/src/gateway/server-methods/wizard.test.ts
@@ -316,10 +316,12 @@ describe("channel wizard lifecycle", () => {
         options: {
           beforePersistentEffect?: () => Promise<void>;
           onConfigured?: (accounts: Array<{ channel: string; accountId: string }>) => void;
+          onResolvedChannel?: (channel: string) => void;
         },
         _runtime: unknown,
       ) => {
         runCount();
+        options.onResolvedChannel?.("matrix");
         await options.beforePersistentEffect?.();
         options.onConfigured?.([{ channel: "matrix", accountId: "default" }]);
       },
@@ -336,7 +338,7 @@ describe("channel wizard lifecycle", () => {
     const firstRespond = vi.fn();
 
     await start({
-      params: { flow: "channels" },
+      params: { flow: "channels", channel: "matrix" },
       client: owner,
       respond: firstRespond,
       context,
@@ -387,6 +389,77 @@ describe("channel wizard lifecycle", () => {
 
     const freshResult = freshRespond.mock.calls[0]?.[1] as { sessionId?: string } | undefined;
     expect(freshResult?.sessionId).not.toBe(sessionId);
+    expect(runCount).toHaveBeenCalledTimes(2);
+  });
+
+  it("recovers an accountless terminal result by canonical channel identity", async () => {
+    const wizardSessions = new Map<string, WizardSession>();
+    const runCount = vi.fn();
+    const context = {
+      wizardSessions,
+      findRunningWizard: () =>
+        [...wizardSessions].find(([, session]) => session.getStatus() === "running")?.[0] ?? null,
+      purgeWizardSession: (id: string) => wizardSessions.delete(id),
+      channelWizardRunner: async (
+        options: {
+          beforePersistentEffect?: () => Promise<void>;
+          onResolvedChannel?: (channel: string) => void;
+        },
+        _runtime: unknown,
+      ) => {
+        runCount();
+        options.onResolvedChannel?.(runCount.mock.calls.length === 1 ? "twitch" : "discord");
+        await options.beforePersistentEffect?.();
+      },
+    };
+    const owner = {
+      connId: "owner-old-connection",
+      authenticatedUserId: "owner@example.com",
+      connect: { client: { id: "openclaw-control-ui", mode: "webchat" } },
+    };
+    const start = expectDefined(
+      wizardHandlers["wizard.start"],
+      "wizardHandlers[wizard.start] test invariant",
+    );
+    const firstRespond = vi.fn();
+
+    await start({
+      params: { flow: "channels", channel: "Twitch-Chat" },
+      client: owner,
+      respond: firstRespond,
+      context,
+    } as never);
+
+    const firstResult = firstRespond.mock.calls[0]?.[1] as { sessionId?: string } | undefined;
+    const sessionId = expectDefined(firstResult?.sessionId, "retained alias wizard session id");
+    const recoveredRespond = vi.fn();
+    await start({
+      params: { flow: "channels", channel: "twitch-chat" },
+      client: { ...owner, connId: "owner-new-connection" },
+      respond: recoveredRespond,
+      context,
+    } as never);
+
+    expect(recoveredRespond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({ sessionId, done: true, status: "done" }),
+      undefined,
+    );
+    expect(runCount).toHaveBeenCalledOnce();
+
+    const freshRespond = vi.fn();
+    await start({
+      params: { flow: "channels", channel: "discord" },
+      client: { ...owner, connId: "owner-new-connection" },
+      respond: freshRespond,
+      context,
+    } as never);
+
+    expect(freshRespond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({ done: true, status: "done" }),
+      undefined,
+    );
     expect(runCount).toHaveBeenCalledTimes(2);
   });
 

--- a/src/gateway/server-methods/wizard.test.ts
+++ b/src/gateway/server-methods/wizard.test.ts
@@ -52,6 +52,7 @@ describe("channel wizard lifecycle", () => {
     );
     const context = {
       wizardSessions,
+      getRuntimeConfig: () => ({}),
       findRunningWizard: () => null,
       purgeWizardSession: (id: string) => wizardSessions.delete(id),
       channelWizardRunner: async (
@@ -103,6 +104,7 @@ describe("channel wizard lifecycle", () => {
     const runCount = vi.fn();
     const context = {
       wizardSessions,
+      getRuntimeConfig: () => ({}),
       findRunningWizard: () =>
         [...wizardSessions].find(([, session]) => session.getStatus() === "running")?.[0] ?? null,
       purgeWizardSession: (id: string) => wizardSessions.delete(id),
@@ -247,10 +249,12 @@ describe("channel wizard lifecycle", () => {
 
   it("reaps an expired retained result before same-owner recovery", async () => {
     let now = 1_000;
+    const dateNow = vi.spyOn(Date, "now").mockImplementation(() => now);
     const tracker = createWizardSessionTracker({ now: () => now });
     const runCount = vi.fn();
     const context = {
       ...tracker,
+      getRuntimeConfig: () => ({}),
       channelWizardRunner: async (options: {
         beforePersistentEffect?: () => Promise<void>;
         onResolvedChannel?: (channel: string) => void;
@@ -294,6 +298,7 @@ describe("channel wizard lifecycle", () => {
     const freshResult = freshRespond.mock.calls[0]?.[1] as { sessionId?: string } | undefined;
     expect(freshResult?.sessionId).not.toBe(firstSessionId);
     expect(runCount).toHaveBeenCalledTimes(2);
+    dateNow.mockRestore();
   });
 
   it("resumes locked shared-auth work after credential rotation", async () => {
@@ -301,6 +306,7 @@ describe("channel wizard lifecycle", () => {
     const runCount = vi.fn();
     const context = {
       wizardSessions,
+      getRuntimeConfig: () => ({}),
       findRunningWizard: () =>
         [...wizardSessions].find(([, session]) => session.getStatus() === "running")?.[0] ?? null,
       purgeWizardSession: (id: string) => wizardSessions.delete(id),
@@ -362,6 +368,7 @@ describe("channel wizard lifecycle", () => {
     const runCount = vi.fn();
     const context = {
       wizardSessions,
+      getRuntimeConfig: () => ({}),
       findRunningWizard: () =>
         [...wizardSessions].find(([, session]) => session.getStatus() === "running")?.[0] ?? null,
       purgeWizardSession: (id: string) => wizardSessions.delete(id),
@@ -423,6 +430,7 @@ describe("channel wizard lifecycle", () => {
     const runCount = vi.fn();
     const context = {
       wizardSessions,
+      getRuntimeConfig: () => ({}),
       findRunningWizard: () =>
         [...wizardSessions].find(([, session]) => session.getStatus() === "running")?.[0] ?? null,
       purgeWizardSession: (id: string) => wizardSessions.delete(id),
@@ -506,6 +514,7 @@ describe("channel wizard lifecycle", () => {
     const runCount = vi.fn();
     const context = {
       wizardSessions,
+      getRuntimeConfig: () => ({}),
       findRunningWizard: () =>
         [...wizardSessions].find(([, session]) => session.getStatus() === "running")?.[0] ?? null,
       purgeWizardSession: (id: string) => wizardSessions.delete(id),
@@ -561,6 +570,7 @@ describe("channel wizard lifecycle", () => {
     const runCount = vi.fn();
     const context = {
       wizardSessions,
+      getRuntimeConfig: () => ({}),
       findRunningWizard: () =>
         [...wizardSessions].find(([, session]) => session.getStatus() === "running")?.[0] ?? null,
       purgeWizardSession: (id: string) => wizardSessions.delete(id),
@@ -629,6 +639,76 @@ describe("channel wizard lifecycle", () => {
       undefined,
     );
     expect(runCount).toHaveBeenCalledTimes(2);
+  });
+
+  it("starts an exact canonical channel instead of replaying another channel's alias", async () => {
+    const channelWizardModule = await import("../../commands/channels/add-wizard.js");
+    const resolveChannel = vi
+      .spyOn(channelWizardModule, "resolveInitialWizardChannel")
+      .mockImplementation(
+        async (raw) =>
+          raw as Awaited<ReturnType<typeof channelWizardModule.resolveInitialWizardChannel>>,
+      );
+    try {
+      const wizardSessions = new Map<string, WizardSession>();
+      const runCount = vi.fn();
+      const context = {
+        wizardSessions,
+        getRuntimeConfig: () => ({}),
+        findRunningWizard: () =>
+          [...wizardSessions].find(([, session]) => session.getStatus() === "running")?.[0] ?? null,
+        purgeWizardSession: (id: string) => wizardSessions.delete(id),
+        channelWizardRunner: async (
+          options: {
+            channel?: string;
+            beforePersistentEffect?: () => Promise<void>;
+            onResolvedChannel?: (channel: string, aliases?: readonly string[]) => void;
+          },
+          _runtime: unknown,
+        ) => {
+          runCount();
+          if (options.channel === "alias-owner") {
+            options.onResolvedChannel?.("alias-owner", ["exact-id"]);
+          } else {
+            options.onResolvedChannel?.("exact-id");
+          }
+          await options.beforePersistentEffect?.();
+        },
+      };
+      const owner = {
+        connId: "owner-old-connection",
+        authenticatedUserId: "owner@example.com",
+        connect: { client: { id: "openclaw-control-ui", mode: "webchat" } },
+      };
+      const start = expectDefined(
+        wizardHandlers["wizard.start"],
+        "wizardHandlers[wizard.start] test invariant",
+      );
+      const firstRespond = vi.fn();
+
+      await start({
+        params: { flow: "channels", channel: "alias-owner" },
+        client: owner,
+        respond: firstRespond,
+        context,
+      } as never);
+
+      const firstResult = firstRespond.mock.calls[0]?.[1] as { sessionId?: string } | undefined;
+      const firstSessionId = expectDefined(firstResult?.sessionId, "alias owner session id");
+      const exactRespond = vi.fn();
+      await start({
+        params: { flow: "channels", channel: "exact-id" },
+        client: { ...owner, connId: "owner-new-connection" },
+        respond: exactRespond,
+        context,
+      } as never);
+
+      const exactResult = exactRespond.mock.calls[0]?.[1] as { sessionId?: string } | undefined;
+      expect(exactResult?.sessionId).not.toBe(firstSessionId);
+      expect(runCount).toHaveBeenCalledTimes(2);
+    } finally {
+      resolveChannel.mockRestore();
+    }
   });
 
   it("rejects hosted channel setup without a reconnect-safe owner", async () => {

--- a/src/gateway/server-methods/wizard.test.ts
+++ b/src/gateway/server-methods/wizard.test.ts
@@ -226,6 +226,84 @@ describe("channel wizard lifecycle", () => {
     expect(runCount).toHaveBeenCalledOnce();
   });
 
+  it("resumes locked shared-auth work after credential rotation", async () => {
+    const wizardSessions = new Map<string, WizardSession>();
+    const runCount = vi.fn();
+    const context = {
+      wizardSessions,
+      findRunningWizard: () =>
+        [...wizardSessions].find(([, session]) => session.getStatus() === "running")?.[0] ?? null,
+      purgeWizardSession: (id: string) => wizardSessions.delete(id),
+      channelWizardRunner: async (
+        options: { beforePersistentEffect?: () => Promise<void> },
+        _runtime: unknown,
+        prompter: { confirm: (params: { message: string }) => Promise<boolean> },
+      ) => {
+        runCount();
+        await options.beforePersistentEffect?.();
+        await prompter.confirm({ message: "Retry validation?" });
+      },
+    };
+    const sharedClient = (generation: string, connId: string) => ({
+      connId,
+      usesSharedGatewayAuth: true,
+      sharedGatewaySessionGeneration: generation,
+      connect: { client: { id: "openclaw-control-ui", mode: "webchat" } },
+    });
+    const start = expectDefined(
+      wizardHandlers["wizard.start"],
+      "wizardHandlers[wizard.start] test invariant",
+    );
+    const next = expectDefined(
+      wizardHandlers["wizard.next"],
+      "wizardHandlers[wizard.next] test invariant",
+    );
+    const firstRespond = vi.fn();
+
+    await start({
+      params: { flow: "channels", channel: "matrix" },
+      client: sharedClient("generation-old", "connection-old"),
+      respond: firstRespond,
+      context,
+    } as never);
+
+    const firstResult = firstRespond.mock.calls[0]?.[1] as
+      | { sessionId?: string; step?: { id?: string } }
+      | undefined;
+    const sessionId = expectDefined(firstResult?.sessionId, "shared-auth wizard session id");
+    const stepId = expectDefined(firstResult?.step?.id, "shared-auth wizard step id");
+    const resumedRespond = vi.fn();
+
+    await start({
+      params: { flow: "channels", channel: "matrix" },
+      client: sharedClient("generation-new", "connection-new"),
+      respond: resumedRespond,
+      context,
+    } as never);
+
+    expect(resumedRespond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({
+        sessionId,
+        step: expect.objectContaining({ id: stepId }),
+      }),
+      undefined,
+    );
+    const completedRespond = vi.fn();
+    await next({
+      params: { sessionId, answer: { stepId, value: true } },
+      client: sharedClient("generation-new", "connection-new"),
+      respond: completedRespond,
+      context,
+    } as never);
+    expect(completedRespond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({ done: true, status: "done" }),
+      undefined,
+    );
+    expect(runCount).toHaveBeenCalledOnce();
+  });
+
   it("returns an owner's retained terminal result without rerunning setup", async () => {
     const wizardSessions = new Map<string, WizardSession>();
     const runCount = vi.fn();
@@ -272,7 +350,11 @@ describe("channel wizard lifecycle", () => {
       undefined,
     );
 
-    for (const connId of ["owner-new-connection", "owner-retry-connection"]) {
+    for (const connId of [
+      "owner-old-connection",
+      "owner-new-connection",
+      "owner-retry-connection",
+    ]) {
       const recoveredRespond = vi.fn();
       await start({
         params: { flow: "channels", channel: "matrix" },

--- a/src/gateway/server-methods/wizard.test.ts
+++ b/src/gateway/server-methods/wizard.test.ts
@@ -565,6 +565,64 @@ describe("channel wizard lifecycle", () => {
     expect(runCount).toHaveBeenCalledTimes(2);
   });
 
+  it("keeps a retained result when another owner's running wizard blocks a fresh start", async () => {
+    const wizardSessions = new Map<string, WizardSession>();
+    const context = {
+      wizardSessions,
+      getRuntimeConfig: () => ({}),
+      findRunningWizard: () =>
+        [...wizardSessions].find(([, session]) => session.getStatus() === "running")?.[0] ?? null,
+      purgeWizardSession: (id: string) => wizardSessions.delete(id),
+      channelWizardRunner: async (options: {
+        beforePersistentEffect?: () => Promise<void>;
+        onResolvedChannel?: (channel: string) => void;
+      }) => {
+        options.onResolvedChannel?.("matrix");
+        await options.beforePersistentEffect?.();
+      },
+    };
+    const owner = {
+      connId: "owner-old-connection",
+      authenticatedUserId: "owner@example.com",
+      connect: { client: { id: "openclaw-control-ui", mode: "webchat" } },
+    };
+    const start = expectDefined(
+      wizardHandlers["wizard.start"],
+      "wizardHandlers[wizard.start] test invariant",
+    );
+    const firstRespond = vi.fn();
+
+    await start({
+      params: { flow: "channels", channel: "matrix" },
+      client: owner,
+      respond: firstRespond,
+      context,
+    } as never);
+
+    const firstResult = firstRespond.mock.calls[0]?.[1] as { sessionId?: string } | undefined;
+    const retainedSessionId = expectDefined(firstResult?.sessionId, "retained wizard session id");
+    const blocker = new WizardSession(async (prompter) => {
+      await prompter.note("Other owner is still configuring.");
+    });
+    wizardSessions.set("other-owner-running", blocker);
+    const freshRespond = vi.fn();
+
+    await start({
+      params: { flow: "channels", channel: "discord" },
+      client: { ...owner, connId: "owner-new-connection" },
+      respond: freshRespond,
+      context,
+    } as never);
+
+    expect(freshRespond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ code: "UNAVAILABLE", message: "wizard already running" }),
+    );
+    expect(wizardSessions.has(retainedSessionId)).toBe(true);
+    blocker.cancel();
+  });
+
   it("recovers an accountless terminal result by canonical channel identity", async () => {
     const wizardSessions = new Map<string, WizardSession>();
     const runCount = vi.fn();

--- a/src/gateway/server-methods/wizard.test.ts
+++ b/src/gateway/server-methods/wizard.test.ts
@@ -316,7 +316,7 @@ describe("channel wizard lifecycle", () => {
         options: {
           beforePersistentEffect?: () => Promise<void>;
           onConfigured?: (accounts: Array<{ channel: string; accountId: string }>) => void;
-          onResolvedChannel?: (channel: string) => void;
+          onResolvedChannel?: (channel: string, aliases?: readonly string[]) => void;
         },
         _runtime: unknown,
       ) => {
@@ -403,12 +403,16 @@ describe("channel wizard lifecycle", () => {
       channelWizardRunner: async (
         options: {
           beforePersistentEffect?: () => Promise<void>;
-          onResolvedChannel?: (channel: string) => void;
+          onResolvedChannel?: (channel: string, aliases?: readonly string[]) => void;
         },
         _runtime: unknown,
       ) => {
         runCount();
-        options.onResolvedChannel?.(runCount.mock.calls.length === 1 ? "twitch" : "discord");
+        if (runCount.mock.calls.length === 1) {
+          options.onResolvedChannel?.("twitch", ["twitch-chat"]);
+        } else {
+          options.onResolvedChannel?.("discord");
+        }
         await options.beforePersistentEffect?.();
       },
     };
@@ -424,7 +428,7 @@ describe("channel wizard lifecycle", () => {
     const firstRespond = vi.fn();
 
     await start({
-      params: { flow: "channels", channel: "Twitch-Chat" },
+      params: { flow: "channels", channel: "twitch" },
       client: owner,
       respond: firstRespond,
       context,

--- a/src/gateway/server-methods/wizard.test.ts
+++ b/src/gateway/server-methods/wizard.test.ts
@@ -274,7 +274,6 @@ describe("channel wizard lifecycle", () => {
     await start({
       params: { flow: "channels", channel: "matrix" },
       client: owner,
-      isConnectionActive: () => false,
       respond: firstRespond,
       context,
     } as never);
@@ -419,7 +418,7 @@ describe("channel wizard lifecycle", () => {
     expect(runCount).toHaveBeenCalledTimes(2);
   });
 
-  it("recovers a terminal result after disconnect, then allows a fresh same-channel start", async () => {
+  it("retains a terminal result until recovery collects it, then allows a fresh start", async () => {
     const wizardSessions = new Map<string, WizardSession>();
     const runCount = vi.fn();
     const context = {
@@ -455,7 +454,6 @@ describe("channel wizard lifecycle", () => {
     await start({
       params: { flow: "channels", channel: "matrix" },
       client: owner,
-      isConnectionActive: () => false,
       respond: firstRespond,
       context,
     } as never);
@@ -467,12 +465,12 @@ describe("channel wizard lifecycle", () => {
       expect.objectContaining({ sessionId, done: true, status: "done" }),
       undefined,
     );
+    expect(wizardSessions.has(sessionId)).toBe(true);
 
     const recoveredRespond = vi.fn();
     await start({
       params: { flow: "channels", channel: "matrix" },
       client: { ...owner, connId: "owner-new-connection" },
-      isConnectionActive: () => true,
       respond: recoveredRespond,
       context,
     } as never);
@@ -596,7 +594,6 @@ describe("channel wizard lifecycle", () => {
     await start({
       params: { flow: "channels", channel: "twitch" },
       client: owner,
-      isConnectionActive: () => false,
       respond: firstRespond,
       context,
     } as never);

--- a/src/gateway/server-methods/wizard.test.ts
+++ b/src/gateway/server-methods/wizard.test.ts
@@ -409,6 +409,61 @@ describe("channel wizard lifecycle", () => {
     expect(runCount).toHaveBeenCalledTimes(2);
   });
 
+  it("starts a fresh browse-all wizard after retained work is terminal", async () => {
+    const wizardSessions = new Map<string, WizardSession>();
+    const runCount = vi.fn();
+    const context = {
+      wizardSessions,
+      findRunningWizard: () =>
+        [...wizardSessions].find(([, session]) => session.getStatus() === "running")?.[0] ?? null,
+      purgeWizardSession: (id: string) => wizardSessions.delete(id),
+      channelWizardRunner: async (options: { beforePersistentEffect?: () => Promise<void> }) => {
+        runCount();
+        await options.beforePersistentEffect?.();
+      },
+    };
+    const owner = {
+      connId: "owner-old-connection",
+      authenticatedUserId: "owner@example.com",
+      connect: { client: { id: "openclaw-control-ui", mode: "webchat" } },
+    };
+    const start = expectDefined(
+      wizardHandlers["wizard.start"],
+      "wizardHandlers[wizard.start] test invariant",
+    );
+    const firstRespond = vi.fn();
+
+    await start({
+      params: { flow: "channels" },
+      client: owner,
+      respond: firstRespond,
+      context,
+    } as never);
+
+    const firstResult = firstRespond.mock.calls[0]?.[1] as { sessionId?: string } | undefined;
+    const firstSessionId = expectDefined(
+      firstResult?.sessionId,
+      "retained browse-all wizard session id",
+    );
+    expect(firstRespond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({ sessionId: firstSessionId, done: true, status: "done" }),
+      undefined,
+    );
+
+    const freshRespond = vi.fn();
+    await start({
+      params: { flow: "channels" },
+      client: { ...owner, connId: "owner-new-connection" },
+      respond: freshRespond,
+      context,
+    } as never);
+
+    const freshResult = freshRespond.mock.calls[0]?.[1] as { sessionId?: string } | undefined;
+    expect(freshResult?.sessionId).not.toBe(firstSessionId);
+    expect(runCount).toHaveBeenCalledTimes(2);
+  });
+
   it("recovers an accountless terminal result by canonical channel identity", async () => {
     const wizardSessions = new Map<string, WizardSession>();
     const runCount = vi.fn();

--- a/src/gateway/server-methods/wizard.test.ts
+++ b/src/gateway/server-methods/wizard.test.ts
@@ -1,6 +1,7 @@
 // Wizard server-method tests cover stable lifecycle errors for process-local sessions.
 import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it, vi } from "vitest";
+import { WizardSession } from "../../wizard/session.js";
 import type { GatewayRequestHandlerOptions } from "./types.js";
 import { wizardHandlers } from "./wizard.js";
 
@@ -31,5 +32,178 @@ describe("wizard session lookup", () => {
       message: "wizard not found",
       details: { code: "WIZARD_NOT_FOUND" },
     });
+  });
+});
+
+describe("channel wizard lifecycle", () => {
+  it("aborts reversible work and rejects a later durable lock", async () => {
+    let lifecycle:
+      | {
+          abortSignal?: AbortSignal;
+          beforePersistentEffect?: () => Promise<void>;
+        }
+      | undefined;
+    const wizardSessions = new Map<string, WizardSession>();
+    const respond = vi.fn();
+    const start = expectDefined(
+      wizardHandlers["wizard.start"],
+      "wizardHandlers[wizard.start] test invariant",
+    );
+    const context = {
+      wizardSessions,
+      findRunningWizard: () => null,
+      purgeWizardSession: (id: string) => wizardSessions.delete(id),
+      channelWizardRunner: async (
+        options: {
+          abortSignal?: AbortSignal;
+          beforePersistentEffect?: () => Promise<void>;
+        },
+        _runtime: unknown,
+        prompter: { note: (message: string) => Promise<void> },
+      ) => {
+        lifecycle = options;
+        await prompter.note("Ready");
+      },
+    };
+
+    await start({
+      req: {
+        type: "req",
+        id: "wizard-lock-race",
+        method: "wizard.start",
+        params: { flow: "channels", channel: "matrix" },
+      },
+      params: { flow: "channels", channel: "matrix" },
+      client: null,
+      isWebchatConnect: () => false,
+      respond,
+      context,
+    } as never);
+
+    const session = expectDefined(
+      wizardSessions.values().next().value,
+      "running channel wizard session",
+    );
+    expect(lifecycle?.abortSignal).toBe(session.signal);
+    expect(session.cancel()).toBe(true);
+    expect(lifecycle?.abortSignal?.aborted).toBe(true);
+    await expect(
+      expectDefined(lifecycle?.beforePersistentEffect, "persistent effect hook")(),
+    ).rejects.toThrow("cancelled before its persistent change started");
+  });
+
+  it("resumes locked work only for its authenticated owner without duplicating it", async () => {
+    const wizardSessions = new Map<string, WizardSession>();
+    const runCount = vi.fn();
+    const context = {
+      wizardSessions,
+      findRunningWizard: () =>
+        [...wizardSessions].find(([, session]) => session.getStatus() === "running")?.[0] ?? null,
+      purgeWizardSession: (id: string) => wizardSessions.delete(id),
+      channelWizardRunner: async (
+        options: { beforePersistentEffect?: () => Promise<void> },
+        _runtime: unknown,
+        prompter: { confirm: (params: { message: string }) => Promise<boolean> },
+      ) => {
+        runCount();
+        await options.beforePersistentEffect?.();
+        await prompter.confirm({ message: "Retry validation?" });
+      },
+    };
+    const owner = {
+      connId: "owner-old-connection",
+      authenticatedUserId: "owner@example.com",
+      connect: { client: { id: "openclaw-control-ui", mode: "webchat" } },
+    };
+    const reconnectedOwner = { ...owner, connId: "owner-new-connection" };
+    const other = {
+      ...owner,
+      connId: "other-connection",
+      authenticatedUserId: "other@example.com",
+    };
+    const start = expectDefined(
+      wizardHandlers["wizard.start"],
+      "wizardHandlers[wizard.start] test invariant",
+    );
+    const next = expectDefined(
+      wizardHandlers["wizard.next"],
+      "wizardHandlers[wizard.next] test invariant",
+    );
+    const cancel = expectDefined(
+      wizardHandlers["wizard.cancel"],
+      "wizardHandlers[wizard.cancel] test invariant",
+    );
+    const firstRespond = vi.fn();
+
+    await start({
+      params: { flow: "channels", channel: "matrix" },
+      client: owner,
+      respond: firstRespond,
+      context,
+    } as never);
+
+    const firstResult = firstRespond.mock.calls[0]?.[1] as
+      | { sessionId?: string; step?: { id?: string } }
+      | undefined;
+    const sessionId = expectDefined(firstResult?.sessionId, "channel wizard session id");
+    const stepId = expectDefined(firstResult?.step?.id, "channel wizard step id");
+
+    const deniedCancel = vi.fn();
+    await cancel({
+      params: { sessionId },
+      client: other,
+      respond: deniedCancel,
+      context,
+    } as never);
+    expect(deniedCancel).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ code: "INVALID_REQUEST" }),
+    );
+    expect(wizardSessions.has(sessionId)).toBe(true);
+
+    const deniedNext = vi.fn();
+    await next({
+      params: { sessionId },
+      client: other,
+      respond: deniedNext,
+      context,
+    } as never);
+    expect(deniedNext).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ code: "INVALID_REQUEST" }),
+    );
+
+    const resumedRespond = vi.fn();
+    await start({
+      params: { flow: "channels", channel: "matrix" },
+      client: reconnectedOwner,
+      respond: resumedRespond,
+      context,
+    } as never);
+    expect(resumedRespond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({
+        sessionId,
+        step: expect.objectContaining({ id: stepId }),
+      }),
+      undefined,
+    );
+    expect(runCount).toHaveBeenCalledOnce();
+
+    const completedRespond = vi.fn();
+    await next({
+      params: { sessionId, answer: { stepId, value: true } },
+      client: reconnectedOwner,
+      respond: completedRespond,
+      context,
+    } as never);
+    expect(completedRespond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({ done: true, status: "done" }),
+      undefined,
+    );
+    expect(runCount).toHaveBeenCalledOnce();
   });
 });

--- a/src/gateway/server-methods/wizard.test.ts
+++ b/src/gateway/server-methods/wizard.test.ts
@@ -509,50 +509,6 @@ describe("channel wizard lifecycle", () => {
     expect(runCount).toHaveBeenCalledTimes(2);
   });
 
-  it("starts fresh after returning a terminal result on the same connection", async () => {
-    const wizardSessions = new Map<string, WizardSession>();
-    const runCount = vi.fn();
-    const context = {
-      wizardSessions,
-      getRuntimeConfig: () => ({}),
-      findRunningWizard: () =>
-        [...wizardSessions].find(([, session]) => session.getStatus() === "running")?.[0] ?? null,
-      purgeWizardSession: (id: string) => wizardSessions.delete(id),
-      channelWizardRunner: async (options: {
-        beforePersistentEffect?: () => Promise<void>;
-        onResolvedChannel?: (channel: string) => void;
-      }) => {
-        runCount();
-        options.onResolvedChannel?.("matrix");
-        await options.beforePersistentEffect?.();
-      },
-    };
-    const client = {
-      connId: "owner-connection",
-      authenticatedUserId: "owner@example.com",
-      connect: { client: { id: "openclaw-control-ui", mode: "webchat" } },
-    };
-    const start = expectDefined(
-      wizardHandlers["wizard.start"],
-      "wizardHandlers[wizard.start] test invariant",
-    );
-
-    await start({
-      params: { flow: "channels", channel: "matrix" },
-      client,
-      respond: vi.fn(),
-      context,
-    } as never);
-    await start({
-      params: { flow: "channels", channel: "matrix" },
-      client,
-      respond: vi.fn(),
-      context,
-    } as never);
-
-    expect(runCount).toHaveBeenCalledTimes(2);
-  });
-
   it("starts a fresh browse-all wizard after retained work is terminal", async () => {
     const wizardSessions = new Map<string, WizardSession>();
     const runCount = vi.fn();

--- a/src/gateway/server-methods/wizard.test.ts
+++ b/src/gateway/server-methods/wizard.test.ts
@@ -365,7 +365,7 @@ describe("channel wizard lifecycle", () => {
     expect(runCount).toHaveBeenCalledTimes(2);
   });
 
-  it("returns an owner's retained terminal result without rerunning setup", async () => {
+  it("recovers a terminal result after disconnect, then allows a fresh same-channel start", async () => {
     const wizardSessions = new Map<string, WizardSession>();
     const runCount = vi.fn();
     const context = {
@@ -401,6 +401,7 @@ describe("channel wizard lifecycle", () => {
     await start({
       params: { flow: "channels", channel: "matrix" },
       client: owner,
+      isConnectionActive: () => false,
       respond: firstRespond,
       context,
     } as never);
@@ -413,36 +414,31 @@ describe("channel wizard lifecycle", () => {
       undefined,
     );
 
-    for (const connId of [
-      "owner-old-connection",
-      "owner-new-connection",
-      "owner-retry-connection",
-    ]) {
-      const recoveredRespond = vi.fn();
-      await start({
-        params: { flow: "channels", channel: "matrix" },
-        client: { ...owner, connId },
-        respond: recoveredRespond,
-        context,
-      } as never);
+    const recoveredRespond = vi.fn();
+    await start({
+      params: { flow: "channels", channel: "matrix" },
+      client: { ...owner, connId: "owner-new-connection" },
+      isConnectionActive: () => true,
+      respond: recoveredRespond,
+      context,
+    } as never);
 
-      expect(recoveredRespond).toHaveBeenCalledWith(
-        true,
-        expect.objectContaining({
-          sessionId,
-          done: true,
-          status: "done",
-          accounts: [{ channel: "matrix", accountId: "default" }],
-        }),
-        undefined,
-      );
-    }
+    expect(recoveredRespond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({
+        sessionId,
+        done: true,
+        status: "done",
+        accounts: [{ channel: "matrix", accountId: "default" }],
+      }),
+      undefined,
+    );
     expect(runCount).toHaveBeenCalledOnce();
-    expect(wizardSessions.has(sessionId)).toBe(true);
+    expect(wizardSessions.has(sessionId)).toBe(false);
 
     const freshRespond = vi.fn();
     await start({
-      params: { flow: "channels", channel: "discord" },
+      params: { flow: "channels", channel: "matrix" },
       client: { ...owner, connId: "owner-retry-connection" },
       respond: freshRespond,
       context,
@@ -546,6 +542,7 @@ describe("channel wizard lifecycle", () => {
     await start({
       params: { flow: "channels", channel: "twitch" },
       client: owner,
+      isConnectionActive: () => false,
       respond: firstRespond,
       context,
     } as never);

--- a/src/gateway/server-methods/wizard.test.ts
+++ b/src/gateway/server-methods/wizard.test.ts
@@ -272,26 +272,28 @@ describe("channel wizard lifecycle", () => {
       undefined,
     );
 
-    const recoveredRespond = vi.fn();
-    await start({
-      params: { flow: "channels", channel: "matrix" },
-      client: { ...owner, connId: "owner-new-connection" },
-      respond: recoveredRespond,
-      context,
-    } as never);
+    for (const connId of ["owner-new-connection", "owner-retry-connection"]) {
+      const recoveredRespond = vi.fn();
+      await start({
+        params: { flow: "channels", channel: "matrix" },
+        client: { ...owner, connId },
+        respond: recoveredRespond,
+        context,
+      } as never);
 
-    expect(recoveredRespond).toHaveBeenCalledWith(
-      true,
-      expect.objectContaining({
-        sessionId,
-        done: true,
-        status: "done",
-        accounts: [{ channel: "matrix", accountId: "default" }],
-      }),
-      undefined,
-    );
+      expect(recoveredRespond).toHaveBeenCalledWith(
+        true,
+        expect.objectContaining({
+          sessionId,
+          done: true,
+          status: "done",
+          accounts: [{ channel: "matrix", accountId: "default" }],
+        }),
+        undefined,
+      );
+    }
     expect(runCount).toHaveBeenCalledOnce();
-    expect(wizardSessions.has(sessionId)).toBe(false);
+    expect(wizardSessions.has(sessionId)).toBe(true);
   });
 
   it("rejects hosted channel setup without a reconnect-safe owner", async () => {

--- a/src/gateway/server-methods/wizard.test.ts
+++ b/src/gateway/server-methods/wizard.test.ts
@@ -475,6 +475,24 @@ describe("channel wizard lifecycle", () => {
     );
     expect(wizardSessions.has(sessionId)).toBe(true);
 
+    const statusRespond = vi.fn();
+    await expectDefined(
+      wizardHandlers["wizard.status"],
+      "wizardHandlers[wizard.status] test invariant",
+    )({
+      params: { sessionId },
+      client: owner,
+      respond: statusRespond,
+      context,
+    } as never);
+
+    expect(statusRespond).toHaveBeenCalledWith(
+      true,
+      { status: "done", error: undefined },
+      undefined,
+    );
+    expect(wizardSessions.has(sessionId)).toBe(true);
+
     const recoveredRespond = vi.fn();
     await start({
       params: { flow: "channels", channel: "matrix" },

--- a/src/gateway/server-methods/wizard.test.ts
+++ b/src/gateway/server-methods/wizard.test.ts
@@ -509,6 +509,50 @@ describe("channel wizard lifecycle", () => {
     expect(runCount).toHaveBeenCalledTimes(2);
   });
 
+  it("starts fresh after returning a terminal result on the same connection", async () => {
+    const wizardSessions = new Map<string, WizardSession>();
+    const runCount = vi.fn();
+    const context = {
+      wizardSessions,
+      getRuntimeConfig: () => ({}),
+      findRunningWizard: () =>
+        [...wizardSessions].find(([, session]) => session.getStatus() === "running")?.[0] ?? null,
+      purgeWizardSession: (id: string) => wizardSessions.delete(id),
+      channelWizardRunner: async (options: {
+        beforePersistentEffect?: () => Promise<void>;
+        onResolvedChannel?: (channel: string) => void;
+      }) => {
+        runCount();
+        options.onResolvedChannel?.("matrix");
+        await options.beforePersistentEffect?.();
+      },
+    };
+    const client = {
+      connId: "owner-connection",
+      authenticatedUserId: "owner@example.com",
+      connect: { client: { id: "openclaw-control-ui", mode: "webchat" } },
+    };
+    const start = expectDefined(
+      wizardHandlers["wizard.start"],
+      "wizardHandlers[wizard.start] test invariant",
+    );
+
+    await start({
+      params: { flow: "channels", channel: "matrix" },
+      client,
+      respond: vi.fn(),
+      context,
+    } as never);
+    await start({
+      params: { flow: "channels", channel: "matrix" },
+      client,
+      respond: vi.fn(),
+      context,
+    } as never);
+
+    expect(runCount).toHaveBeenCalledTimes(2);
+  });
+
   it("starts a fresh browse-all wizard after retained work is terminal", async () => {
     const wizardSessions = new Map<string, WizardSession>();
     const runCount = vi.fn();

--- a/src/gateway/server-methods/wizard.test.ts
+++ b/src/gateway/server-methods/wizard.test.ts
@@ -294,6 +294,18 @@ describe("channel wizard lifecycle", () => {
     }
     expect(runCount).toHaveBeenCalledOnce();
     expect(wizardSessions.has(sessionId)).toBe(true);
+
+    const freshRespond = vi.fn();
+    await start({
+      params: { flow: "channels", channel: "discord" },
+      client: { ...owner, connId: "owner-retry-connection" },
+      respond: freshRespond,
+      context,
+    } as never);
+
+    const freshResult = freshRespond.mock.calls[0]?.[1] as { sessionId?: string } | undefined;
+    expect(freshResult?.sessionId).not.toBe(sessionId);
+    expect(runCount).toHaveBeenCalledTimes(2);
   });
 
   it("rejects hosted channel setup without a reconnect-safe owner", async () => {

--- a/src/gateway/server-methods/wizard.ts
+++ b/src/gateway/server-methods/wizard.ts
@@ -119,16 +119,21 @@ export const wizardHandlers: GatewayRequestHandlers = {
     const ownerKey = owner?.key;
     const resumeKey = flow === "channels" ? resolveChannelWizardResumeKey(ownerKey) : undefined;
     const running = context.findRunningWizard();
-    if (running) {
-      const existing = context.wizardSessions.get(running);
-      if (resumeKey && existing?.isCancellationLocked() && existing.canResume(resumeKey)) {
-        const result = await existing.next();
+    if (resumeKey) {
+      const resumable = [...context.wizardSessions.entries()].find(([, session]) =>
+        session.canResume(resumeKey),
+      );
+      if (resumable) {
+        const [resumableId, resumableSession] = resumable;
+        const result = await resumableSession.next();
         if (result.done) {
-          context.purgeWizardSession(running);
+          context.purgeWizardSession(resumableId);
         }
-        respond(true, { sessionId: running, ...result }, undefined);
+        respond(true, { sessionId: resumableId, ...result }, undefined);
         return;
       }
+    }
+    if (running) {
       respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, "wizard already running"));
       return;
     }
@@ -174,9 +179,13 @@ export const wizardHandlers: GatewayRequestHandlers = {
     context.wizardSessions.set(sessionId, session);
     const result = await session.next();
     if (result.done) {
-      // Completed sessions cannot accept later answers; purge immediately so
-      // clients get a clean not-found response for stale session ids.
-      context.purgeWizardSession(sessionId);
+      if (session.isCancellationLocked()) {
+        // Keep one owner-bound recovery copy when a durable result races a
+        // dropped response. The tracker reaps it if nobody reconnects.
+        context.findRunningWizard();
+      } else {
+        context.purgeWizardSession(sessionId);
+      }
     }
     respond(true, { sessionId, ...result }, undefined);
   },
@@ -208,9 +217,11 @@ export const wizardHandlers: GatewayRequestHandlers = {
     }
     const result = await session.next();
     if (result.done) {
-      // The final step may be reached after an answer, so cleanup mirrors
-      // wizard.start's immediate-completion path.
-      context.purgeWizardSession(sessionId);
+      if (session.isCancellationLocked()) {
+        context.findRunningWizard();
+      } else {
+        context.purgeWizardSession(sessionId);
+      }
     }
     respond(true, result, undefined);
   },
@@ -225,8 +236,10 @@ export const wizardHandlers: GatewayRequestHandlers = {
     }
     const cancelled = session.cancel();
     const status = readWizardStatus(session);
-    if (cancelled || status.status !== "running") {
+    if (cancelled || (status.status !== "running" && !session.isCancellationLocked())) {
       context.wizardSessions.delete(sessionId);
+    } else if (status.status !== "running") {
+      context.findRunningWizard();
     }
     respond(true, status, undefined);
   },
@@ -240,8 +253,10 @@ export const wizardHandlers: GatewayRequestHandlers = {
       return;
     }
     const status = readWizardStatus(session);
-    if (status.status !== "running") {
+    if (status.status !== "running" && !session.isCancellationLocked()) {
       context.wizardSessions.delete(sessionId);
+    } else if (status.status !== "running") {
+      context.findRunningWizard();
     }
     respond(true, status, undefined);
   },

--- a/src/gateway/server-methods/wizard.ts
+++ b/src/gateway/server-methods/wizard.ts
@@ -37,17 +37,8 @@ export type SetupWizardRunner = (
   prompter: WizardPrompter,
 ) => Promise<void>;
 
-export type ChannelSetupWizardRunner = (
-  opts: {
-    channel?: string;
-    onConfigured?: (accounts: Array<{ channel: string; accountId: string }>) => void;
-    onResolvedChannel?: (channel: string, aliases?: readonly string[]) => void;
-    beforePersistentEffect?: () => Promise<void>;
-    abortSignal?: AbortSignal;
-  },
-  runtime: RuntimeEnv,
-  prompter: WizardPrompter,
-) => Promise<void>;
+export type ChannelSetupWizardRunner =
+  typeof import("../../commands/channels/add-wizard.js").runChannelsSetupWizard;
 
 export const runDefaultSetupWizard: SetupWizardRunner = async (...args) => {
   const { runSetupWizard } = await import("../../wizard/setup.js");

--- a/src/gateway/server-methods/wizard.ts
+++ b/src/gateway/server-methods/wizard.ts
@@ -155,6 +155,7 @@ export const wizardHandlers: GatewayRequestHandlers = {
       return;
     }
     const ownerKey = owner?.key;
+    const connectionId = client?.connId?.trim() || undefined;
     const resumeKey =
       flow === "channels" ? resolveChannelWizardResumeKey(owner?.continuityKey) : undefined;
     // Canonical ids win over another plugin's alias during recovery, matching
@@ -171,8 +172,14 @@ export const wizardHandlers: GatewayRequestHandlers = {
       const ownerSession = [...context.wizardSessions.entries()].find(([, session]) =>
         session.hasResumeKey(resumeKey),
       );
+      // Retained terminal results repair a lost response after reconnect. A new
+      // start on the original live connection is fresh setup intent.
+      const terminalResultAlreadyReturnedToConnection =
+        ownerSession?.[1].getStatus() !== "running" &&
+        ownerSession?.[1].startedOnConnection(connectionId);
       if (
         ownerSession &&
+        !terminalResultAlreadyReturnedToConnection &&
         ownerSession[1].canResume(resumeKey, recoveryIdentity.channel, {
           allowAliasMatch: recoveryIdentity.allowAliasMatch,
         })
@@ -244,6 +251,7 @@ export const wizardHandlers: GatewayRequestHandlers = {
               timeoutMs: CHANNEL_WIZARD_TIMEOUT_MS,
               ...(ownerKey ? { ownerKey } : {}),
               ...(resumeKey ? { resumeKey } : {}),
+              ...(connectionId ? { originConnectionId: connectionId } : {}),
               ...(recoveryIdentity.channel ? { requestedChannel: recoveryIdentity.channel } : {}),
             },
           )

--- a/src/gateway/server-methods/wizard.ts
+++ b/src/gateway/server-methods/wizard.ts
@@ -87,12 +87,19 @@ function findWizardSessionOrRespond(params: {
   const owner = resolveGatewayHostedSessionOwner(params.client);
   const ownerKey = owner.kind === "stable" ? owner.key : undefined;
   if (!session.isAccessibleBy(ownerKey)) {
-    params.respond(
-      false,
-      undefined,
-      errorShape(ErrorCodes.INVALID_REQUEST, "wizard belongs to another caller"),
-    );
-    return null;
+    const continuityResumeKey =
+      owner.kind === "stable" ? resolveChannelWizardResumeKey(owner.continuityKey) : undefined;
+    if (!continuityResumeKey || !session.matchesResumeKey(continuityResumeKey)) {
+      params.respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, "wizard belongs to another caller"),
+      );
+      return null;
+    }
+    // Shared Gateway auth rotates its exact generation while preserving the
+    // continuity principal. Adopt only cancellation-locked channel work.
+    session.adoptOwner(owner.key);
   }
   return session;
 }

--- a/src/gateway/server-methods/wizard.ts
+++ b/src/gateway/server-methods/wizard.ts
@@ -145,6 +145,9 @@ export const wizardHandlers: GatewayRequestHandlers = {
     const ownerKey = owner?.key;
     const resumeKey =
       flow === "channels" ? resolveChannelWizardResumeKey(owner?.continuityKey) : undefined;
+    // The tracker owns terminal retention timestamps. Sweep before direct
+    // owner matching so an expired result cannot be replayed indefinitely.
+    let running = context.findRunningWizard();
     if (resumeKey) {
       const ownerSession = [...context.wizardSessions.entries()].find(([, session]) =>
         session.hasResumeKey(resumeKey),
@@ -171,13 +174,15 @@ export const wizardHandlers: GatewayRequestHandlers = {
           // exact owner. Abort it before the continuity owner starts fresh.
           staleSession.cancel();
           context.purgeWizardSession(staleId);
+          if (running === staleId) {
+            running = null;
+          }
         } else if (staleSession.getStatus() !== "running") {
           // A different requested channel is an explicit fresh-start intent.
           context.purgeWizardSession(staleId);
         }
       }
     }
-    const running = context.findRunningWizard();
     if (running) {
       respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, "wizard already running"));
       return;

--- a/src/gateway/server-methods/wizard.ts
+++ b/src/gateway/server-methods/wizard.ts
@@ -166,6 +166,7 @@ export const wizardHandlers: GatewayRequestHandlers = {
     // The tracker owns terminal retention timestamps. Sweep before direct
     // owner matching so an expired result cannot be replayed indefinitely.
     let running = context.findRunningWizard();
+    let terminalSessionToPurge: string | undefined;
     if (resumeKey) {
       const ownerSession = [...context.wizardSessions.entries()].find(([, session]) =>
         session.hasResumeKey(resumeKey),
@@ -201,14 +202,18 @@ export const wizardHandlers: GatewayRequestHandlers = {
             running = null;
           }
         } else if (staleSession.getStatus() !== "running") {
-          // A different requested channel is an explicit fresh-start intent.
-          context.purgeWizardSession(staleId);
+          // A different requested channel is fresh intent, but keep the retained
+          // result until admission proves the replacement can actually start.
+          terminalSessionToPurge = staleId;
         }
       }
     }
     if (running) {
       respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, "wizard already running"));
       return;
+    }
+    if (terminalSessionToPurge) {
+      context.purgeWizardSession(terminalSessionToPurge);
     }
     const sessionId = randomUUID();
     const session =

--- a/src/gateway/server-methods/wizard.ts
+++ b/src/gateway/server-methods/wizard.ts
@@ -27,13 +27,8 @@ import { assertValidParams } from "./validation.js";
 
 const CHANNEL_WIZARD_TIMEOUT_MS = 25 * 60 * 1000;
 
-function resolveChannelWizardResumeKey(params: {
-  ownerKey: string | undefined;
-  channel: string | undefined;
-}): string | undefined {
-  return params.ownerKey
-    ? JSON.stringify(["gateway-channel-setup", params.ownerKey, params.channel ?? null])
-    : undefined;
+function resolveChannelWizardResumeKey(ownerKey: string | undefined): string | undefined {
+  return ownerKey ? JSON.stringify(["gateway-channel-setup", ownerKey]) : undefined;
 }
 
 export type SetupWizardRunner = (
@@ -122,8 +117,7 @@ export const wizardHandlers: GatewayRequestHandlers = {
       return;
     }
     const ownerKey = owner?.key;
-    const resumeKey =
-      flow === "channels" ? resolveChannelWizardResumeKey({ ownerKey, channel }) : undefined;
+    const resumeKey = flow === "channels" ? resolveChannelWizardResumeKey(ownerKey) : undefined;
     const running = context.findRunningWizard();
     if (running) {
       const existing = context.wizardSessions.get(running);

--- a/src/gateway/server-methods/wizard.ts
+++ b/src/gateway/server-methods/wizard.ts
@@ -41,6 +41,7 @@ export type ChannelSetupWizardRunner = (
   opts: {
     channel?: string;
     onConfigured?: (accounts: Array<{ channel: string; accountId: string }>) => void;
+    onResolvedChannel?: (channel: string) => void;
     beforePersistentEffect?: () => Promise<void>;
     abortSignal?: AbortSignal;
   },
@@ -155,6 +156,8 @@ export const wizardHandlers: GatewayRequestHandlers = {
                 {
                   channel,
                   onConfigured: (accounts) => wizardSession.setConfiguredAccounts(accounts),
+                  onResolvedChannel: (resolvedChannel) =>
+                    wizardSession.setResolvedChannel(resolvedChannel),
                   abortSignal: signal,
                   // Durable effects (plugin installs, config commit) must finish
                   // even if the client cancels mid-write.
@@ -173,6 +176,7 @@ export const wizardHandlers: GatewayRequestHandlers = {
               timeoutMs: CHANNEL_WIZARD_TIMEOUT_MS,
               ...(ownerKey ? { ownerKey } : {}),
               ...(resumeKey ? { resumeKey } : {}),
+              ...(channel ? { requestedChannel: channel } : {}),
             },
           )
         : new WizardSession((prompter) =>

--- a/src/gateway/server-methods/wizard.ts
+++ b/src/gateway/server-methods/wizard.ts
@@ -105,8 +105,15 @@ function findWizardSessionOrRespond(params: {
   const owner = resolveGatewayHostedSessionOwner(params.client);
   const ownerKey = owner.kind === "stable" ? owner.key : undefined;
   if (!session.isAccessibleBy(ownerKey)) {
-    const continuityResumeKey =
-      owner.kind === "stable" ? resolveChannelWizardResumeKey(owner.continuityKey) : undefined;
+    if (owner.kind !== "stable") {
+      params.respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, "wizard belongs to another caller"),
+      );
+      return null;
+    }
+    const continuityResumeKey = resolveChannelWizardResumeKey(owner.continuityKey);
     if (!continuityResumeKey || !session.matchesResumeKey(continuityResumeKey)) {
       params.respond(
         false,

--- a/src/gateway/server-methods/wizard.ts
+++ b/src/gateway/server-methods/wizard.ts
@@ -41,7 +41,7 @@ export type ChannelSetupWizardRunner = (
   opts: {
     channel?: string;
     onConfigured?: (accounts: Array<{ channel: string; accountId: string }>) => void;
-    onResolvedChannel?: (channel: string) => void;
+    onResolvedChannel?: (channel: string, aliases?: readonly string[]) => void;
     beforePersistentEffect?: () => Promise<void>;
     abortSignal?: AbortSignal;
   },
@@ -156,8 +156,8 @@ export const wizardHandlers: GatewayRequestHandlers = {
                 {
                   channel,
                   onConfigured: (accounts) => wizardSession.setConfiguredAccounts(accounts),
-                  onResolvedChannel: (resolvedChannel) =>
-                    wizardSession.setResolvedChannel(resolvedChannel),
+                  onResolvedChannel: (resolvedChannel, aliases) =>
+                    wizardSession.setResolvedChannel(resolvedChannel, aliases),
                   abortSignal: signal,
                   // Durable effects (plugin installs, config commit) must finish
                   // even if the client cancels mid-write.

--- a/src/gateway/server-methods/wizard.ts
+++ b/src/gateway/server-methods/wizard.ts
@@ -70,14 +70,14 @@ function finishTerminalWizardResponse(params: {
   context: GatewayRequestContext;
   sessionId: string;
   session: WizardSession;
-  isConnectionActive?: () => boolean;
+  collectLockedTerminal: boolean;
 }): void {
   if (params.session.getStatus() === "running") {
     return;
   }
-  if (params.session.isCancellationLocked() && params.isConnectionActive?.() === false) {
-    // The durable result could not reach its original transport. Retain one
-    // owner-bound copy so a reconnect can collect it without rerunning setup.
+  if (params.session.isCancellationLocked() && !params.collectLockedTerminal) {
+    // An open transport does not prove a caller accepted a late response.
+    // Retain the first result until a later owner-bound request collects it.
     params.context.findRunningWizard();
     return;
   }
@@ -124,7 +124,7 @@ function findWizardSessionOrRespond(params: {
 
 /** Gateway handlers for the interactive setup wizard session lifecycle. */
 export const wizardHandlers: GatewayRequestHandlers = {
-  "wizard.start": async ({ params, respond, context, client, isConnectionActive }) => {
+  "wizard.start": async ({ params, respond, context, client }) => {
     if (!assertValidParams(params, validateWizardStartParams, "wizard.start", respond)) {
       return;
     }
@@ -162,7 +162,7 @@ export const wizardHandlers: GatewayRequestHandlers = {
             context,
             sessionId: resumableId,
             session: resumableSession,
-            isConnectionActive,
+            collectLockedTerminal: true,
           });
         }
         return;
@@ -233,10 +233,15 @@ export const wizardHandlers: GatewayRequestHandlers = {
     const result = await session.next();
     respond(true, { sessionId, ...result }, undefined);
     if (result.done) {
-      finishTerminalWizardResponse({ context, sessionId, session, isConnectionActive });
+      finishTerminalWizardResponse({
+        context,
+        sessionId,
+        session,
+        collectLockedTerminal: false,
+      });
     }
   },
-  "wizard.next": async ({ params, respond, context, client, isConnectionActive }) => {
+  "wizard.next": async ({ params, respond, context, client }) => {
     if (!assertValidParams(params, validateWizardNextParams, "wizard.next", respond)) {
       return;
     }
@@ -245,6 +250,7 @@ export const wizardHandlers: GatewayRequestHandlers = {
     if (!session) {
       return;
     }
+    const collectingTerminal = session.getStatus() !== "running";
     const answer = params.answer as { stepId?: string; value?: unknown } | undefined;
     if (answer) {
       if (session.getStatus() !== "running") {
@@ -265,10 +271,15 @@ export const wizardHandlers: GatewayRequestHandlers = {
     const result = await session.next();
     respond(true, result, undefined);
     if (result.done) {
-      finishTerminalWizardResponse({ context, sessionId, session, isConnectionActive });
+      finishTerminalWizardResponse({
+        context,
+        sessionId,
+        session,
+        collectLockedTerminal: collectingTerminal,
+      });
     }
   },
-  "wizard.cancel": ({ params, respond, context, client, isConnectionActive }) => {
+  "wizard.cancel": ({ params, respond, context, client }) => {
     if (!assertValidParams(params, validateWizardCancelParams, "wizard.cancel", respond)) {
       return;
     }
@@ -281,10 +292,15 @@ export const wizardHandlers: GatewayRequestHandlers = {
     const status = readWizardStatus(session);
     respond(true, status, undefined);
     if (cancelled || status.status !== "running") {
-      finishTerminalWizardResponse({ context, sessionId, session, isConnectionActive });
+      finishTerminalWizardResponse({
+        context,
+        sessionId,
+        session,
+        collectLockedTerminal: true,
+      });
     }
   },
-  "wizard.status": ({ params, respond, context, client, isConnectionActive }) => {
+  "wizard.status": ({ params, respond, context, client }) => {
     if (!assertValidParams(params, validateWizardStatusParams, "wizard.status", respond)) {
       return;
     }
@@ -296,7 +312,12 @@ export const wizardHandlers: GatewayRequestHandlers = {
     const status = readWizardStatus(session);
     respond(true, status, undefined);
     if (status.status !== "running") {
-      finishTerminalWizardResponse({ context, sessionId, session, isConnectionActive });
+      finishTerminalWizardResponse({
+        context,
+        sessionId,
+        session,
+        collectLockedTerminal: true,
+      });
     }
   },
 };

--- a/src/gateway/server-methods/wizard.ts
+++ b/src/gateway/server-methods/wizard.ts
@@ -127,10 +127,9 @@ export const wizardHandlers: GatewayRequestHandlers = {
     const ownerKey = owner?.key;
     const resumeKey =
       flow === "channels" ? resolveChannelWizardResumeKey(owner?.continuityKey) : undefined;
-    const running = context.findRunningWizard();
     if (resumeKey) {
       const ownerSession = [...context.wizardSessions.entries()].find(([, session]) =>
-        session.matchesResumeKey(resumeKey),
+        session.hasResumeKey(resumeKey),
       );
       if (ownerSession && ownerSession[1].canResume(resumeKey, channel)) {
         const [resumableId, resumableSession] = ownerSession;
@@ -145,11 +144,20 @@ export const wizardHandlers: GatewayRequestHandlers = {
         respond(true, { sessionId: resumableId, ...result }, undefined);
         return;
       }
-      if (ownerSession && ownerSession[1].getStatus() !== "running") {
-        // A different requested channel is an explicit fresh-start intent.
-        context.purgeWizardSession(ownerSession[0]);
+      if (ownerSession) {
+        const [staleId, staleSession] = ownerSession;
+        if (!staleSession.isCancellationLocked()) {
+          // Credential rotation can strand reversible work under the previous
+          // exact owner. Abort it before the continuity owner starts fresh.
+          staleSession.cancel();
+          context.purgeWizardSession(staleId);
+        } else if (staleSession.getStatus() !== "running") {
+          // A different requested channel is an explicit fresh-start intent.
+          context.purgeWizardSession(staleId);
+        }
       }
     }
+    const running = context.findRunningWizard();
     if (running) {
       respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, "wizard already running"));
       return;

--- a/src/gateway/server-methods/wizard.ts
+++ b/src/gateway/server-methods/wizard.ts
@@ -118,22 +118,29 @@ export const wizardHandlers: GatewayRequestHandlers = {
     }
     const ownerKey = owner?.key;
     const resumeKey = flow === "channels" ? resolveChannelWizardResumeKey(ownerKey) : undefined;
+    const connectionId = client?.connId.trim() || undefined;
     const running = context.findRunningWizard();
     if (resumeKey) {
-      const resumable = [...context.wizardSessions.entries()].find(([, session]) =>
-        session.canResume(resumeKey),
+      const ownerSession = [...context.wizardSessions.entries()].find(([, session]) =>
+        session.matchesResumeKey(resumeKey),
       );
-      if (resumable) {
-        const [resumableId, resumableSession] = resumable;
+      if (ownerSession && ownerSession[1].canResume(resumeKey, connectionId)) {
+        const [resumableId, resumableSession] = ownerSession;
         const result = await resumableSession.next();
         // A reconnect has no delivery acknowledgement. Keep terminal recovery
         // replayable until the tracker expires it so repeated response loss
         // cannot rerun an already-committed setup.
         if (result.done) {
+          resumableSession.markTerminalResultDelivery(connectionId);
           context.findRunningWizard();
         }
         respond(true, { sessionId: resumableId, ...result }, undefined);
         return;
+      }
+      if (ownerSession && ownerSession[1].getStatus() !== "running") {
+        // Starting again on the connection that just received this terminal
+        // result acknowledges it and releases the owner to begin fresh work.
+        context.purgeWizardSession(ownerSession[0]);
       }
     }
     if (running) {
@@ -183,6 +190,7 @@ export const wizardHandlers: GatewayRequestHandlers = {
     const result = await session.next();
     if (result.done) {
       if (session.isCancellationLocked()) {
+        session.markTerminalResultDelivery(connectionId);
         // Keep one owner-bound recovery copy when a durable result races a
         // dropped response. The tracker reaps it if nobody reconnects.
         context.findRunningWizard();
@@ -221,6 +229,7 @@ export const wizardHandlers: GatewayRequestHandlers = {
     const result = await session.next();
     if (result.done) {
       if (session.isCancellationLocked()) {
+        session.markTerminalResultDelivery(client?.connId.trim() || undefined);
         context.findRunningWizard();
       } else {
         context.purgeWizardSession(sessionId);

--- a/src/gateway/server-methods/wizard.ts
+++ b/src/gateway/server-methods/wizard.ts
@@ -66,6 +66,24 @@ function readWizardStatus(session: WizardSession) {
   };
 }
 
+function finishTerminalWizardResponse(params: {
+  context: GatewayRequestContext;
+  sessionId: string;
+  session: WizardSession;
+  isConnectionActive?: () => boolean;
+}): void {
+  if (params.session.getStatus() === "running") {
+    return;
+  }
+  if (params.session.isCancellationLocked() && params.isConnectionActive?.() === false) {
+    // The durable result could not reach its original transport. Retain one
+    // owner-bound copy so a reconnect can collect it without rerunning setup.
+    params.context.findRunningWizard();
+    return;
+  }
+  params.context.purgeWizardSession(params.sessionId);
+}
+
 /** Resolves a live wizard session or sends the public not-found error. */
 function findWizardSessionOrRespond(params: {
   context: GatewayRequestContext;
@@ -106,7 +124,7 @@ function findWizardSessionOrRespond(params: {
 
 /** Gateway handlers for the interactive setup wizard session lifecycle. */
 export const wizardHandlers: GatewayRequestHandlers = {
-  "wizard.start": async ({ params, respond, context, client }) => {
+  "wizard.start": async ({ params, respond, context, client, isConnectionActive }) => {
     if (!assertValidParams(params, validateWizardStartParams, "wizard.start", respond)) {
       return;
     }
@@ -135,13 +153,15 @@ export const wizardHandlers: GatewayRequestHandlers = {
         const [resumableId, resumableSession] = ownerSession;
         resumableSession.adoptOwner(ownerKey);
         const result = await resumableSession.next();
-        // A reconnect has no delivery acknowledgement. Keep terminal recovery
-        // replayable until the owner starts a different channel or retention
-        // expires, so response loss cannot rerun already-committed setup.
-        if (result.done) {
-          context.findRunningWizard();
-        }
         respond(true, { sessionId: resumableId, ...result }, undefined);
+        if (result.done) {
+          finishTerminalWizardResponse({
+            context,
+            sessionId: resumableId,
+            session: resumableSession,
+            isConnectionActive,
+          });
+        }
         return;
       }
       if (ownerSession) {
@@ -206,18 +226,12 @@ export const wizardHandlers: GatewayRequestHandlers = {
           );
     context.wizardSessions.set(sessionId, session);
     const result = await session.next();
-    if (result.done) {
-      if (session.isCancellationLocked()) {
-        // Keep one owner-bound recovery copy when a durable result races a
-        // dropped response. The tracker reaps it if nobody reconnects.
-        context.findRunningWizard();
-      } else {
-        context.purgeWizardSession(sessionId);
-      }
-    }
     respond(true, { sessionId, ...result }, undefined);
+    if (result.done) {
+      finishTerminalWizardResponse({ context, sessionId, session, isConnectionActive });
+    }
   },
-  "wizard.next": async ({ params, respond, context, client }) => {
+  "wizard.next": async ({ params, respond, context, client, isConnectionActive }) => {
     if (!assertValidParams(params, validateWizardNextParams, "wizard.next", respond)) {
       return;
     }
@@ -244,16 +258,12 @@ export const wizardHandlers: GatewayRequestHandlers = {
       }
     }
     const result = await session.next();
-    if (result.done) {
-      if (session.isCancellationLocked()) {
-        context.findRunningWizard();
-      } else {
-        context.purgeWizardSession(sessionId);
-      }
-    }
     respond(true, result, undefined);
+    if (result.done) {
+      finishTerminalWizardResponse({ context, sessionId, session, isConnectionActive });
+    }
   },
-  "wizard.cancel": ({ params, respond, context, client }) => {
+  "wizard.cancel": ({ params, respond, context, client, isConnectionActive }) => {
     if (!assertValidParams(params, validateWizardCancelParams, "wizard.cancel", respond)) {
       return;
     }
@@ -264,14 +274,12 @@ export const wizardHandlers: GatewayRequestHandlers = {
     }
     const cancelled = session.cancel();
     const status = readWizardStatus(session);
-    if (cancelled || (status.status !== "running" && !session.isCancellationLocked())) {
-      context.wizardSessions.delete(sessionId);
-    } else if (status.status !== "running") {
-      context.findRunningWizard();
-    }
     respond(true, status, undefined);
+    if (cancelled || status.status !== "running") {
+      finishTerminalWizardResponse({ context, sessionId, session, isConnectionActive });
+    }
   },
-  "wizard.status": ({ params, respond, context, client }) => {
+  "wizard.status": ({ params, respond, context, client, isConnectionActive }) => {
     if (!assertValidParams(params, validateWizardStatusParams, "wizard.status", respond)) {
       return;
     }
@@ -281,11 +289,9 @@ export const wizardHandlers: GatewayRequestHandlers = {
       return;
     }
     const status = readWizardStatus(session);
-    if (status.status !== "running" && !session.isCancellationLocked()) {
-      context.wizardSessions.delete(sessionId);
-    } else if (status.status !== "running") {
-      context.findRunningWizard();
-    }
     respond(true, status, undefined);
+    if (status.status !== "running") {
+      finishTerminalWizardResponse({ context, sessionId, session, isConnectionActive });
+    }
   },
 };

--- a/src/gateway/server-methods/wizard.ts
+++ b/src/gateway/server-methods/wizard.ts
@@ -16,8 +16,37 @@ import { defaultRuntime, type RuntimeEnv } from "../../runtime.js";
 import type { WizardPrompter } from "../../wizard/prompts.js";
 import { WizardSession } from "../../wizard/session.js";
 import { formatForLog } from "../ws-log.js";
-import type { GatewayRequestContext, GatewayRequestHandlers, RespondFn } from "./types.js";
+import type {
+  GatewayClient,
+  GatewayRequestContext,
+  GatewayRequestHandlers,
+  RespondFn,
+} from "./types.js";
 import { assertValidParams } from "./validation.js";
+
+const CHANNEL_WIZARD_TIMEOUT_MS = 25 * 60 * 1000;
+
+function resolveWizardOwnerKey(client: GatewayClient | null): string | undefined {
+  const userId = client?.authenticatedUserId?.trim();
+  if (userId) {
+    return `user:${userId}`;
+  }
+  const deviceId = client?.connect.device?.id.trim();
+  if (deviceId) {
+    return `device:${deviceId}`;
+  }
+  const connId = client?.connId?.trim();
+  return connId ? `connection:${connId}` : undefined;
+}
+
+function resolveChannelWizardResumeKey(params: {
+  ownerKey: string | undefined;
+  channel: string | undefined;
+}): string | undefined {
+  return params.ownerKey
+    ? JSON.stringify(["gateway-channel-setup", params.ownerKey, params.channel ?? null])
+    : undefined;
+}
 
 export type SetupWizardRunner = (
   opts: OnboardOptions,
@@ -30,6 +59,7 @@ export type ChannelSetupWizardRunner = (
     channel?: string;
     onConfigured?: (accounts: Array<{ channel: string; accountId: string }>) => void;
     beforePersistentEffect?: () => Promise<void>;
+    abortSignal?: AbortSignal;
   },
   runtime: RuntimeEnv,
   prompter: WizardPrompter,
@@ -55,6 +85,7 @@ function readWizardStatus(session: WizardSession) {
 /** Resolves a live wizard session or sends the public not-found error. */
 function findWizardSessionOrRespond(params: {
   context: GatewayRequestContext;
+  client: GatewayClient | null;
   respond: RespondFn;
   sessionId: string;
 }): WizardSession | null {
@@ -69,36 +100,70 @@ function findWizardSessionOrRespond(params: {
     );
     return null;
   }
+  if (!session.isAccessibleBy(resolveWizardOwnerKey(params.client))) {
+    params.respond(
+      false,
+      undefined,
+      errorShape(ErrorCodes.INVALID_REQUEST, "wizard belongs to another caller"),
+    );
+    return null;
+  }
   return session;
 }
 
 /** Gateway handlers for the interactive setup wizard session lifecycle. */
 export const wizardHandlers: GatewayRequestHandlers = {
-  "wizard.start": async ({ params, respond, context }) => {
+  "wizard.start": async ({ params, respond, context, client }) => {
     if (!assertValidParams(params, validateWizardStartParams, "wizard.start", respond)) {
       return;
     }
+    const flow = params.flow ?? "setup";
+    const channel = readStringValue(params.channel);
+    const ownerKey = flow === "channels" ? resolveWizardOwnerKey(client) : undefined;
+    const resumeKey =
+      flow === "channels" ? resolveChannelWizardResumeKey({ ownerKey, channel }) : undefined;
     const running = context.findRunningWizard();
     if (running) {
+      const existing = context.wizardSessions.get(running);
+      if (resumeKey && existing?.isCancellationLocked() && existing.canResume(resumeKey)) {
+        const result = await existing.next();
+        if (result.done) {
+          context.purgeWizardSession(running);
+        }
+        respond(true, { sessionId: running, ...result }, undefined);
+        return;
+      }
       respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, "wizard already running"));
       return;
     }
     const sessionId = randomUUID();
-    const flow = params.flow ?? "setup";
     const session =
       flow === "channels"
-        ? new WizardSession((prompter, _signal, wizardSession) =>
-            context.channelWizardRunner(
-              {
-                channel: readStringValue(params.channel),
-                onConfigured: (accounts) => wizardSession.setConfiguredAccounts(accounts),
-                // Durable effects (plugin installs, config commit) must finish
-                // even if the client cancels mid-write.
-                beforePersistentEffect: async () => wizardSession.lockCancellation(),
-              },
-              defaultRuntime,
-              prompter,
-            ),
+        ? new WizardSession(
+            (prompter, signal, wizardSession) =>
+              context.channelWizardRunner(
+                {
+                  channel,
+                  onConfigured: (accounts) => wizardSession.setConfiguredAccounts(accounts),
+                  abortSignal: signal,
+                  // Durable effects (plugin installs, config commit) must finish
+                  // even if the client cancels mid-write.
+                  beforePersistentEffect: async () => {
+                    if (!wizardSession.lockCancellation()) {
+                      throw new Error(
+                        "Channel setup was cancelled before its persistent change started.",
+                      );
+                    }
+                  },
+                },
+                defaultRuntime,
+                prompter,
+              ),
+            {
+              timeoutMs: CHANNEL_WIZARD_TIMEOUT_MS,
+              ...(ownerKey ? { ownerKey } : {}),
+              ...(resumeKey ? { resumeKey } : {}),
+            },
           )
         : new WizardSession((prompter) =>
             context.wizardRunner(
@@ -119,12 +184,12 @@ export const wizardHandlers: GatewayRequestHandlers = {
     }
     respond(true, { sessionId, ...result }, undefined);
   },
-  "wizard.next": async ({ params, respond, context }) => {
+  "wizard.next": async ({ params, respond, context, client }) => {
     if (!assertValidParams(params, validateWizardNextParams, "wizard.next", respond)) {
       return;
     }
     const sessionId = params.sessionId;
-    const session = findWizardSessionOrRespond({ context, respond, sessionId });
+    const session = findWizardSessionOrRespond({ context, client, respond, sessionId });
     if (!session) {
       return;
     }
@@ -153,12 +218,12 @@ export const wizardHandlers: GatewayRequestHandlers = {
     }
     respond(true, result, undefined);
   },
-  "wizard.cancel": ({ params, respond, context }) => {
+  "wizard.cancel": ({ params, respond, context, client }) => {
     if (!assertValidParams(params, validateWizardCancelParams, "wizard.cancel", respond)) {
       return;
     }
     const sessionId = params.sessionId;
-    const session = findWizardSessionOrRespond({ context, respond, sessionId });
+    const session = findWizardSessionOrRespond({ context, client, respond, sessionId });
     if (!session) {
       return;
     }
@@ -169,12 +234,12 @@ export const wizardHandlers: GatewayRequestHandlers = {
     }
     respond(true, status, undefined);
   },
-  "wizard.status": ({ params, respond, context }) => {
+  "wizard.status": ({ params, respond, context, client }) => {
     if (!assertValidParams(params, validateWizardStatusParams, "wizard.status", respond)) {
       return;
     }
     const sessionId = params.sessionId;
-    const session = findWizardSessionOrRespond({ context, respond, sessionId });
+    const session = findWizardSessionOrRespond({ context, client, respond, sessionId });
     if (!session) {
       return;
     }

--- a/src/gateway/server-methods/wizard.ts
+++ b/src/gateway/server-methods/wizard.ts
@@ -339,13 +339,7 @@ export const wizardHandlers: GatewayRequestHandlers = {
     }
     const status = readWizardStatus(session);
     respond(true, status, undefined);
-    if (status.status !== "running") {
-      finishTerminalWizardResponse({
-        context,
-        sessionId,
-        session,
-        collectLockedTerminal: true,
-      });
-    }
+    // Status polling is observational. Only a full terminal result or an
+    // explicit cancel may discard retained channels/accounts recovery data.
   },
 };

--- a/src/gateway/server-methods/wizard.ts
+++ b/src/gateway/server-methods/wizard.ts
@@ -31,6 +31,20 @@ function resolveChannelWizardResumeKey(ownerKey: string | undefined): string | u
   return ownerKey ? JSON.stringify(["gateway-channel-setup", ownerKey]) : undefined;
 }
 
+async function resolveChannelRecoveryIdentity(
+  channel: string | undefined,
+  context: GatewayRequestContext,
+): Promise<{ channel: string | undefined; allowAliasMatch: boolean }> {
+  if (!channel) {
+    return { channel, allowAliasMatch: true };
+  }
+  const { resolveInitialWizardChannel } = await import("../../commands/channels/add-wizard.js");
+  const resolvedChannel = await resolveInitialWizardChannel(channel, context.getRuntimeConfig());
+  return resolvedChannel
+    ? { channel: resolvedChannel, allowAliasMatch: false }
+    : { channel, allowAliasMatch: true };
+}
+
 export type SetupWizardRunner = (
   opts: OnboardOptions,
   runtime: RuntimeEnv,
@@ -143,6 +157,12 @@ export const wizardHandlers: GatewayRequestHandlers = {
     const ownerKey = owner?.key;
     const resumeKey =
       flow === "channels" ? resolveChannelWizardResumeKey(owner?.continuityKey) : undefined;
+    // Canonical ids win over another plugin's alias during recovery, matching
+    // the setup resolver used when the new wizard actually starts.
+    const recoveryIdentity =
+      flow === "channels"
+        ? await resolveChannelRecoveryIdentity(channel, context)
+        : { channel, allowAliasMatch: true };
     // The tracker owns terminal retention timestamps. Sweep before direct
     // owner matching so an expired result cannot be replayed indefinitely.
     let running = context.findRunningWizard();
@@ -150,7 +170,12 @@ export const wizardHandlers: GatewayRequestHandlers = {
       const ownerSession = [...context.wizardSessions.entries()].find(([, session]) =>
         session.hasResumeKey(resumeKey),
       );
-      if (ownerSession && ownerSession[1].canResume(resumeKey, channel)) {
+      if (
+        ownerSession &&
+        ownerSession[1].canResume(resumeKey, recoveryIdentity.channel, {
+          allowAliasMatch: recoveryIdentity.allowAliasMatch,
+        })
+      ) {
         const [resumableId, resumableSession] = ownerSession;
         resumableSession.adoptOwner(ownerKey);
         const result = await resumableSession.next();
@@ -214,7 +239,7 @@ export const wizardHandlers: GatewayRequestHandlers = {
               timeoutMs: CHANNEL_WIZARD_TIMEOUT_MS,
               ...(ownerKey ? { ownerKey } : {}),
               ...(resumeKey ? { resumeKey } : {}),
-              ...(channel ? { requestedChannel: channel } : {}),
+              ...(recoveryIdentity.channel ? { requestedChannel: recoveryIdentity.channel } : {}),
             },
           )
         : new WizardSession((prompter) =>

--- a/src/gateway/server-methods/wizard.ts
+++ b/src/gateway/server-methods/wizard.ts
@@ -155,7 +155,6 @@ export const wizardHandlers: GatewayRequestHandlers = {
       return;
     }
     const ownerKey = owner?.key;
-    const connectionId = client?.connId?.trim() || undefined;
     const resumeKey =
       flow === "channels" ? resolveChannelWizardResumeKey(owner?.continuityKey) : undefined;
     // Canonical ids win over another plugin's alias during recovery, matching
@@ -172,14 +171,8 @@ export const wizardHandlers: GatewayRequestHandlers = {
       const ownerSession = [...context.wizardSessions.entries()].find(([, session]) =>
         session.hasResumeKey(resumeKey),
       );
-      // Retained terminal results repair a lost response after reconnect. A new
-      // start on the original live connection is fresh setup intent.
-      const terminalResultAlreadyReturnedToConnection =
-        ownerSession?.[1].getStatus() !== "running" &&
-        ownerSession?.[1].startedOnConnection(connectionId);
       if (
         ownerSession &&
-        !terminalResultAlreadyReturnedToConnection &&
         ownerSession[1].canResume(resumeKey, recoveryIdentity.channel, {
           allowAliasMatch: recoveryIdentity.allowAliasMatch,
         })
@@ -251,7 +244,6 @@ export const wizardHandlers: GatewayRequestHandlers = {
               timeoutMs: CHANNEL_WIZARD_TIMEOUT_MS,
               ...(ownerKey ? { ownerKey } : {}),
               ...(resumeKey ? { resumeKey } : {}),
-              ...(connectionId ? { originConnectionId: connectionId } : {}),
               ...(recoveryIdentity.channel ? { requestedChannel: recoveryIdentity.channel } : {}),
             },
           )

--- a/src/gateway/server-methods/wizard.ts
+++ b/src/gateway/server-methods/wizard.ts
@@ -126,8 +126,11 @@ export const wizardHandlers: GatewayRequestHandlers = {
       if (resumable) {
         const [resumableId, resumableSession] = resumable;
         const result = await resumableSession.next();
+        // A reconnect has no delivery acknowledgement. Keep terminal recovery
+        // replayable until the tracker expires it so repeated response loss
+        // cannot rerun an already-committed setup.
         if (result.done) {
-          context.purgeWizardSession(resumableId);
+          context.findRunningWizard();
         }
         respond(true, { sessionId: resumableId, ...result }, undefined);
         return;

--- a/src/gateway/server-methods/wizard.ts
+++ b/src/gateway/server-methods/wizard.ts
@@ -16,6 +16,7 @@ import { defaultRuntime, type RuntimeEnv } from "../../runtime.js";
 import type { WizardPrompter } from "../../wizard/prompts.js";
 import { WizardSession } from "../../wizard/session.js";
 import { formatForLog } from "../ws-log.js";
+import { resolveGatewayHostedSessionOwner } from "./hosted-session-owner.js";
 import type {
   GatewayClient,
   GatewayRequestContext,
@@ -25,19 +26,6 @@ import type {
 import { assertValidParams } from "./validation.js";
 
 const CHANNEL_WIZARD_TIMEOUT_MS = 25 * 60 * 1000;
-
-function resolveWizardOwnerKey(client: GatewayClient | null): string | undefined {
-  const userId = client?.authenticatedUserId?.trim();
-  if (userId) {
-    return `user:${userId}`;
-  }
-  const deviceId = client?.connect.device?.id.trim();
-  if (deviceId) {
-    return `device:${deviceId}`;
-  }
-  const connId = client?.connId?.trim();
-  return connId ? `connection:${connId}` : undefined;
-}
 
 function resolveChannelWizardResumeKey(params: {
   ownerKey: string | undefined;
@@ -100,7 +88,9 @@ function findWizardSessionOrRespond(params: {
     );
     return null;
   }
-  if (!session.isAccessibleBy(resolveWizardOwnerKey(params.client))) {
+  const owner = resolveGatewayHostedSessionOwner(params.client);
+  const ownerKey = owner.kind === "stable" ? owner.key : undefined;
+  if (!session.isAccessibleBy(ownerKey)) {
     params.respond(
       false,
       undefined,
@@ -119,7 +109,19 @@ export const wizardHandlers: GatewayRequestHandlers = {
     }
     const flow = params.flow ?? "setup";
     const channel = readStringValue(params.channel);
-    const ownerKey = flow === "channels" ? resolveWizardOwnerKey(client) : undefined;
+    const owner = flow === "channels" ? resolveGatewayHostedSessionOwner(client) : undefined;
+    if (owner && owner.kind !== "stable") {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          "Channel setup requires an identity that can survive reconnects.",
+        ),
+      );
+      return;
+    }
+    const ownerKey = owner?.key;
     const resumeKey =
       flow === "channels" ? resolveChannelWizardResumeKey({ ownerKey, channel }) : undefined;
     const running = context.findRunningWizard();

--- a/src/gateway/server-methods/wizard.ts
+++ b/src/gateway/server-methods/wizard.ts
@@ -117,29 +117,28 @@ export const wizardHandlers: GatewayRequestHandlers = {
       return;
     }
     const ownerKey = owner?.key;
-    const resumeKey = flow === "channels" ? resolveChannelWizardResumeKey(ownerKey) : undefined;
-    const connectionId = client?.connId?.trim() || undefined;
+    const resumeKey =
+      flow === "channels" ? resolveChannelWizardResumeKey(owner?.continuityKey) : undefined;
     const running = context.findRunningWizard();
     if (resumeKey) {
       const ownerSession = [...context.wizardSessions.entries()].find(([, session]) =>
         session.matchesResumeKey(resumeKey),
       );
-      if (ownerSession && ownerSession[1].canResume(resumeKey, connectionId)) {
+      if (ownerSession && ownerSession[1].canResume(resumeKey, channel)) {
         const [resumableId, resumableSession] = ownerSession;
+        resumableSession.adoptOwner(ownerKey);
         const result = await resumableSession.next();
         // A reconnect has no delivery acknowledgement. Keep terminal recovery
-        // replayable until the tracker expires it so repeated response loss
-        // cannot rerun an already-committed setup.
+        // replayable until the owner starts a different channel or retention
+        // expires, so response loss cannot rerun already-committed setup.
         if (result.done) {
-          resumableSession.markTerminalResultDelivery(connectionId);
           context.findRunningWizard();
         }
         respond(true, { sessionId: resumableId, ...result }, undefined);
         return;
       }
       if (ownerSession && ownerSession[1].getStatus() !== "running") {
-        // Starting again on the connection that just received this terminal
-        // result acknowledges it and releases the owner to begin fresh work.
+        // A different requested channel is an explicit fresh-start intent.
         context.purgeWizardSession(ownerSession[0]);
       }
     }
@@ -190,7 +189,6 @@ export const wizardHandlers: GatewayRequestHandlers = {
     const result = await session.next();
     if (result.done) {
       if (session.isCancellationLocked()) {
-        session.markTerminalResultDelivery(connectionId);
         // Keep one owner-bound recovery copy when a durable result races a
         // dropped response. The tracker reaps it if nobody reconnects.
         context.findRunningWizard();
@@ -229,7 +227,6 @@ export const wizardHandlers: GatewayRequestHandlers = {
     const result = await session.next();
     if (result.done) {
       if (session.isCancellationLocked()) {
-        session.markTerminalResultDelivery(client?.connId?.trim() || undefined);
         context.findRunningWizard();
       } else {
         context.purgeWizardSession(sessionId);

--- a/src/gateway/server-methods/wizard.ts
+++ b/src/gateway/server-methods/wizard.ts
@@ -118,7 +118,7 @@ export const wizardHandlers: GatewayRequestHandlers = {
     }
     const ownerKey = owner?.key;
     const resumeKey = flow === "channels" ? resolveChannelWizardResumeKey(ownerKey) : undefined;
-    const connectionId = client?.connId.trim() || undefined;
+    const connectionId = client?.connId?.trim() || undefined;
     const running = context.findRunningWizard();
     if (resumeKey) {
       const ownerSession = [...context.wizardSessions.entries()].find(([, session]) =>
@@ -229,7 +229,7 @@ export const wizardHandlers: GatewayRequestHandlers = {
     const result = await session.next();
     if (result.done) {
       if (session.isCancellationLocked()) {
-        session.markTerminalResultDelivery(client?.connId.trim() || undefined);
+        session.markTerminalResultDelivery(client?.connId?.trim() || undefined);
         context.findRunningWizard();
       } else {
         context.purgeWizardSession(sessionId);

--- a/src/gateway/server-wizard-sessions.test.ts
+++ b/src/gateway/server-wizard-sessions.test.ts
@@ -6,7 +6,7 @@ describe("createWizardSessionTracker", () => {
   it("retains an uncollected terminal result before reaping it", async () => {
     let now = 1_000;
     const tracker = createWizardSessionTracker({ now: () => now });
-    const terminal = new WizardSession(async () => {});
+    const terminal = new WizardSession(async () => {}, { now: () => now });
     tracker.wizardSessions.set("finished", terminal);
     await terminal.next();
 
@@ -18,6 +18,18 @@ describe("createWizardSessionTracker", () => {
     expect(tracker.wizardSessions.has("finished")).toBe(true);
 
     now += 1;
+    expect(tracker.findRunningWizard()).toBeNull();
+    expect(tracker.wizardSessions.has("finished")).toBe(false);
+  });
+
+  it("expires from terminal completion even before the tracker observes it", async () => {
+    let now = 1_000;
+    const tracker = createWizardSessionTracker({ now: () => now });
+    const terminal = new WizardSession(async () => {}, { now: () => now });
+    tracker.wizardSessions.set("finished", terminal);
+    await terminal.next();
+
+    now += 60 * 60 * 1000;
     expect(tracker.findRunningWizard()).toBeNull();
     expect(tracker.wizardSessions.has("finished")).toBe(false);
   });

--- a/src/gateway/server-wizard-sessions.ts
+++ b/src/gateway/server-wizard-sessions.ts
@@ -7,23 +7,18 @@ const UNCOLLECTED_TERMINAL_RETENTION_MS = 5 * 60 * 1000;
 /** Creates the in-memory tracker used for active Gateway wizard sessions. */
 export function createWizardSessionTracker(options?: { now?: () => number }) {
   const wizardSessions = new Map<string, WizardSession>();
-  const terminalSince = new Map<string, number>();
   const now = options?.now ?? Date.now;
 
   const findRunningWizard = (): string | null => {
     for (const [id, session] of wizardSessions) {
       if (session.getStatus() === "running") {
-        terminalSince.delete(id);
         return id;
       }
-      const observedAt = terminalSince.get(id);
-      if (observedAt === undefined) {
-        terminalSince.set(id, now());
-      } else if (now() - observedAt >= UNCOLLECTED_TERMINAL_RETENTION_MS) {
+      const terminalAt = session.getTerminalAt();
+      if (terminalAt !== undefined && now() - terminalAt >= UNCOLLECTED_TERMINAL_RETENTION_MS) {
         // Keep a terminal result long enough for its original client to collect
-        // it; later starts may reap only an abandoned retained result.
+        // it, measured from completion rather than the tracker's first observation.
         wizardSessions.delete(id);
-        terminalSince.delete(id);
       }
     }
     return null;
@@ -38,7 +33,6 @@ export function createWizardSessionTracker(options?: { now?: () => number }) {
       return;
     }
     wizardSessions.delete(id);
-    terminalSince.delete(id);
   };
 
   return { wizardSessions, findRunningWizard, purgeWizardSession };

--- a/src/gateway/server/ws-connection/authenticated-request-dispatch.ts
+++ b/src/gateway/server/ws-connection/authenticated-request-dispatch.ts
@@ -144,6 +144,7 @@ export function createGatewayAuthenticatedRequestDispatcher(params: {
         respond,
         client,
         isWebchatConnect: params.isWebchatConnect,
+        isConnectionActive: () => !isClosed(),
         extraHandlers,
         methodRegistry: getMethodRegistry?.(),
         context: buildRequestContext(),

--- a/src/gateway/server/ws-connection/authenticated-request-dispatch.ts
+++ b/src/gateway/server/ws-connection/authenticated-request-dispatch.ts
@@ -144,7 +144,6 @@ export function createGatewayAuthenticatedRequestDispatcher(params: {
         respond,
         client,
         isWebchatConnect: params.isWebchatConnect,
-        isConnectionActive: () => !isClosed(),
         extraHandlers,
         methodRegistry: getMethodRegistry?.(),
         context: buildRequestContext(),

--- a/src/system-agent/chat-contract.ts
+++ b/src/system-agent/chat-contract.ts
@@ -1,0 +1,20 @@
+import type { SystemAgentChatQuestion } from "../../packages/gateway-protocol/src/index.js";
+import type { SystemAgentOperation } from "./operation-types.js";
+
+export type SystemAgentChatReplyAction = "none" | "exit" | "open-tui" | "open-setup";
+
+/** Transport-independent result returned by the OpenClaw chat engine. */
+export type SystemAgentChatReply = {
+  text: string;
+  action: SystemAgentChatReplyAction;
+  /** Client-localized draft intent for the destination agent chat. */
+  agentDraft?: "hatch";
+  /** The next hosted-wizard reply contains a secret and must be masked/redacted by hosts. */
+  sensitive?: boolean;
+  /** The hosted wizard will consume the next message as its current step answer. */
+  wizardInputPending?: boolean;
+  /** Present when the host must leave chat for an interactive handoff. */
+  handoff?: SystemAgentOperation;
+  /** Structured choice mirroring the awaited wizard step for card-capable clients. */
+  question?: SystemAgentChatQuestion;
+};

--- a/src/system-agent/chat-engine.test.ts
+++ b/src/system-agent/chat-engine.test.ts
@@ -750,6 +750,44 @@ describe("SystemAgentChatEngine", () => {
     expect(setupSignal?.aborted).toBe(true);
   });
 
+  it("forwards cancellation through the shipped hosted channel runner", async () => {
+    useTempStateDir();
+    mocks.readSetupConfigFileSnapshot.mockResolvedValue({
+      exists: true,
+      valid: true,
+      path: "/tmp/openclaw.json",
+      hash: "base-hash",
+      config: {},
+      sourceConfig: {},
+      issues: [],
+    });
+    let receivedSignal: AbortSignal | undefined;
+    mocks.setupChannels.mockImplementation(
+      async (
+        config: OpenClawConfig,
+        _runtime: unknown,
+        prompter: WizardPrompter,
+        options?: { abortSignal?: AbortSignal },
+      ) => {
+        receivedSignal = options?.abortSignal;
+        await prompter.text({ message: "Bot token" });
+        return config;
+      },
+    );
+    const engine = new SystemAgentChatEngine({
+      surface: "gateway",
+      runAgentTurn: async () => null,
+      planWithAssistant: async () => null,
+      deps: { loadOverview: fakeOverviewLoader() },
+    });
+
+    expect((await engine.handle("connect telegram")).text).toContain("Bot token");
+    expect(receivedSignal?.aborted).toBe(false);
+
+    expect((await engine.handle("cancel")).text).toContain("cancelled");
+    expect(receivedSignal?.aborted).toBe(true);
+  });
+
   it("keeps locked channel setup owned until recovery completes", async () => {
     const completed = vi.fn();
     const runChannelSetupWizard = vi.fn(

--- a/src/system-agent/chat-engine.test.ts
+++ b/src/system-agent/chat-engine.test.ts
@@ -730,6 +730,24 @@ describe("SystemAgentChatEngine", () => {
     expect(wizardRuns).toEqual(["telegram", "token:123:abc", "mode:open"]);
   });
 
+  it("rejects Gateway-hosted setup without a reconnect-safe owner", async () => {
+    const runChannelSetupWizard = vi.fn();
+    const engine = new SystemAgentChatEngine({
+      surface: "gateway",
+      allowHostedChannelSetup: false,
+      runAgentTurn: async () => null,
+      planWithAssistant: async () => null,
+      deps: { loadOverview: fakeOverviewLoader() },
+      runChannelSetupWizard,
+    });
+
+    const reply = await engine.handle("connect matrix");
+
+    expect(reply.text).toContain("identity that can survive reconnects");
+    expect(runChannelSetupWizard).not.toHaveBeenCalled();
+    expect(engine.hasLockedHostedWizard()).toBe(false);
+  });
+
   it("forwards hosted cancellation to reversible channel setup work", async () => {
     let setupSignal: AbortSignal | undefined;
     const engine = new SystemAgentChatEngine({

--- a/src/system-agent/chat-engine.test.ts
+++ b/src/system-agent/chat-engine.test.ts
@@ -831,6 +831,43 @@ describe("SystemAgentChatEngine", () => {
     expect((await engine.handle("yes")).text).toContain("matrix is configured");
     expect(completed).toHaveBeenCalledOnce();
     expect(runChannelSetupWizard).toHaveBeenCalledOnce();
+    await expect(engine.dispose()).resolves.toBe(false);
+    await expect(engine.handle("status")).rejects.toBeInstanceOf(
+      SystemAgentInferenceUnavailableError,
+    );
+    await expect(engine.dispose()).resolves.toBe(true);
+  });
+
+  it("retains a completed locked channel setup until recovery collects it", async () => {
+    const engine = new SystemAgentChatEngine({
+      surface: "gateway",
+      runAgentTurn: async () => null,
+      planWithAssistant: async () => null,
+      deps: { loadOverview: fakeOverviewLoader() },
+      runChannelSetupWizard: async (_channel, prompter, beforePersistentApply) => {
+        await beforePersistentApply({
+          log: () => {},
+          error: () => {},
+          exit: (): never => {
+            throw new Error("unexpected exit");
+          },
+        });
+        await prompter.outro("Applied");
+      },
+    });
+
+    expect((await engine.handle("connect matrix")).text).toContain("matrix is configured");
+    expect(engine.hasLockedHostedWizard()).toBe(true);
+
+    await expect(engine.dispose()).resolves.toBe(false);
+    await expect(engine.resumeLockedHostedWizard()).resolves.toMatchObject({
+      text: expect.stringContaining("matrix is configured"),
+    });
+    expect(engine.hasLockedHostedWizard()).toBe(true);
+    await expect(engine.handle("status")).rejects.toBeInstanceOf(
+      SystemAgentInferenceUnavailableError,
+    );
+    expect(engine.hasLockedHostedWizard()).toBe(false);
     await expect(engine.dispose()).resolves.toBe(true);
   });
 

--- a/src/system-agent/chat-engine.test.ts
+++ b/src/system-agent/chat-engine.test.ts
@@ -871,6 +871,37 @@ describe("SystemAgentChatEngine", () => {
     await expect(engine.dispose()).resolves.toBe(true);
   });
 
+  it("expires an uncollected terminal channel setup reply", async () => {
+    const now = vi.spyOn(Date, "now").mockReturnValue(1_000);
+    try {
+      const engine = new SystemAgentChatEngine({
+        surface: "gateway",
+        runAgentTurn: async () => null,
+        planWithAssistant: async () => null,
+        deps: { loadOverview: fakeOverviewLoader() },
+        runChannelSetupWizard: async (_channel, prompter, beforePersistentApply) => {
+          await beforePersistentApply({
+            log: () => {},
+            error: () => {},
+            exit: (): never => {
+              throw new Error("unexpected exit");
+            },
+          });
+          await prompter.outro("Applied");
+        },
+      });
+
+      expect((await engine.handle("connect matrix")).text).toContain("matrix is configured");
+      expect(engine.hasLockedHostedWizard()).toBe(true);
+
+      now.mockReturnValue(1_000 + 5 * 60 * 1_000 + 1);
+      expect(engine.hasLockedHostedWizard()).toBe(false);
+      await expect(engine.dispose()).resolves.toBe(true);
+    } finally {
+      now.mockRestore();
+    }
+  });
+
   it("accepts locked recovery after the inference route disappears", async () => {
     let inferenceConfig: OpenClawConfig = structuredClone(sharedVerifiedInferenceConfig);
     const completed = vi.fn();

--- a/src/system-agent/chat-engine.test.ts
+++ b/src/system-agent/chat-engine.test.ts
@@ -730,6 +730,156 @@ describe("SystemAgentChatEngine", () => {
     expect(wizardRuns).toEqual(["telegram", "token:123:abc", "mode:open"]);
   });
 
+  it("forwards hosted cancellation to reversible channel setup work", async () => {
+    let setupSignal: AbortSignal | undefined;
+    const engine = new SystemAgentChatEngine({
+      surface: "gateway",
+      runAgentTurn: async () => null,
+      planWithAssistant: async () => null,
+      deps: { loadOverview: fakeOverviewLoader() },
+      runChannelSetupWizard: async (_channel, prompter, _beforePersistentApply, abortSignal) => {
+        setupSignal = abortSignal;
+        await prompter.text({ message: "Access token" });
+      },
+    });
+
+    expect((await engine.handle("connect matrix")).text).toContain("Access token");
+    expect(setupSignal?.aborted).toBe(false);
+
+    expect((await engine.handle("cancel")).text).toContain("cancelled");
+    expect(setupSignal?.aborted).toBe(true);
+  });
+
+  it("keeps locked channel setup owned until recovery completes", async () => {
+    const completed = vi.fn();
+    const runChannelSetupWizard = vi.fn(
+      async (
+        _channel: string,
+        prompter: WizardPrompter,
+        beforePersistentApply: (runtime: {
+          log: () => void;
+          error: () => void;
+          exit: () => never;
+        }) => Promise<void>,
+      ) => {
+        await beforePersistentApply({
+          log: () => {},
+          error: () => {},
+          exit: (): never => {
+            throw new Error("unexpected exit");
+          },
+        });
+        await prompter.confirm({ message: "Retry validation?" });
+        completed();
+      },
+    );
+    const engine = new SystemAgentChatEngine({
+      surface: "gateway",
+      runAgentTurn: async () => null,
+      planWithAssistant: async () => null,
+      deps: { loadOverview: fakeOverviewLoader() },
+      runChannelSetupWizard,
+    });
+
+    expect((await engine.handle("connect matrix")).text).toContain("Retry validation?");
+    expect((await engine.handle("cancel")).text).toContain("can no longer be cancelled");
+    await expect(engine.dispose()).resolves.toBe(false);
+    expect(completed).not.toHaveBeenCalled();
+    await expect(engine.resumeLockedHostedWizard()).resolves.toMatchObject({
+      text: expect.stringContaining("Retry validation?"),
+      wizardInputPending: true,
+    });
+
+    expect((await engine.handle("yes")).text).toContain("matrix is configured");
+    expect(completed).toHaveBeenCalledOnce();
+    expect(runChannelSetupWizard).toHaveBeenCalledOnce();
+    await expect(engine.dispose()).resolves.toBe(true);
+  });
+
+  it("accepts locked recovery after the inference route disappears", async () => {
+    let inferenceConfig: OpenClawConfig = structuredClone(sharedVerifiedInferenceConfig);
+    const completed = vi.fn();
+    const engine = new SystemAgentChatEngine({
+      surface: "gateway",
+      runAgentTurn: async () => null,
+      planWithAssistant: async () => null,
+      deps: {
+        loadOverview: fakeOverviewLoader(),
+        readConfigFileSnapshot: vi.fn(async () => configSnapshot(inferenceConfig)) as never,
+      },
+      runChannelSetupWizard: async (_channel, prompter, beforePersistentApply) => {
+        await beforePersistentApply({
+          log: () => {},
+          error: () => {},
+          exit: (): never => {
+            throw new Error("unexpected exit");
+          },
+        });
+        await prompter.confirm({ message: "Retry validation?" });
+        completed();
+      },
+    });
+
+    expect((await engine.handle("connect matrix")).text).toContain("Retry validation?");
+    inferenceConfig = {};
+
+    const recovered = await engine.handle("yes");
+    expect(recovered.text).toContain("matrix is configured");
+    expect(completed).toHaveBeenCalledOnce();
+  });
+
+  it("retires reversible channel setup when the inference route disappears", async () => {
+    let inferenceConfig: OpenClawConfig = structuredClone(sharedVerifiedInferenceConfig);
+    let setupSignal: AbortSignal | undefined;
+    const engine = new SystemAgentChatEngine({
+      surface: "gateway",
+      runAgentTurn: async () => null,
+      planWithAssistant: async () => null,
+      deps: {
+        loadOverview: fakeOverviewLoader(),
+        readConfigFileSnapshot: vi.fn(async () => configSnapshot(inferenceConfig)) as never,
+      },
+      runChannelSetupWizard: async (_channel, prompter, _guard, abortSignal) => {
+        setupSignal = abortSignal;
+        await prompter.text({ message: "Access token" });
+      },
+    });
+
+    expect((await engine.handle("connect matrix")).text).toContain("Access token");
+    inferenceConfig = {};
+
+    await expect(engine.handle("secret")).rejects.toBeInstanceOf(
+      SystemAgentInferenceUnavailableError,
+    );
+    expect(setupSignal?.aborted).toBe(true);
+  });
+
+  it("expires an abandoned reversible Gateway channel wizard", async () => {
+    vi.useFakeTimers();
+    try {
+      let setupSignal: AbortSignal | undefined;
+      const engine = new SystemAgentChatEngine({
+        surface: "gateway",
+        runAgentTurn: async () => null,
+        planWithAssistant: async () => null,
+        deps: { loadOverview: fakeOverviewLoader() },
+        runChannelSetupWizard: async (_channel, prompter, _guard, abortSignal) => {
+          setupSignal = abortSignal;
+          await prompter.text({ message: "Access token" });
+        },
+      });
+
+      expect((await engine.handle("connect matrix")).text).toContain("Access token");
+      await vi.advanceTimersByTimeAsync(25 * 60 * 1000);
+
+      const expired = await engine.handle("stale answer");
+      expect(expired.text).toContain("cancelled");
+      expect(setupSignal?.aborted).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("reports hosted channel setup success when audit persistence fails", async () => {
     const appendAuditEntry = vi.fn(async () => {
       throw new Error("audit store is read-only");

--- a/src/system-agent/chat-engine.test.ts
+++ b/src/system-agent/chat-engine.test.ts
@@ -828,12 +828,11 @@ describe("SystemAgentChatEngine", () => {
       text: expect.stringContaining("Retry validation?"),
       wizardInputPending: true,
     });
-    expect(engine.historySince(recoveryHistoryStart)).toEqual([
-      {
-        role: "assistant",
-        text: expect.stringContaining("Retry validation?"),
-      },
-    ]);
+    await expect(engine.resumeLockedHostedWizard()).resolves.toMatchObject({
+      text: expect.stringContaining("Retry validation?"),
+      wizardInputPending: true,
+    });
+    expect(engine.historySince(recoveryHistoryStart)).toEqual([]);
 
     expect((await engine.handle("yes")).text).toContain("matrix is configured");
     expect(completed).toHaveBeenCalledOnce();

--- a/src/system-agent/chat-engine.test.ts
+++ b/src/system-agent/chat-engine.test.ts
@@ -822,11 +822,18 @@ describe("SystemAgentChatEngine", () => {
     expect((await engine.handle("connect matrix")).text).toContain("Retry validation?");
     expect((await engine.handle("cancel")).text).toContain("can no longer be cancelled");
     await expect(engine.dispose()).resolves.toBe(false);
+    const recoveryHistoryStart = engine.historyLength();
     expect(completed).not.toHaveBeenCalled();
     await expect(engine.resumeLockedHostedWizard()).resolves.toMatchObject({
       text: expect.stringContaining("Retry validation?"),
       wizardInputPending: true,
     });
+    expect(engine.historySince(recoveryHistoryStart)).toEqual([
+      {
+        role: "assistant",
+        text: expect.stringContaining("Retry validation?"),
+      },
+    ]);
 
     expect((await engine.handle("yes")).text).toContain("matrix is configured");
     expect(completed).toHaveBeenCalledOnce();

--- a/src/system-agent/chat-engine.ts
+++ b/src/system-agent/chat-engine.ts
@@ -500,10 +500,16 @@ export class SystemAgentChatEngine {
       if (retainedReply) {
         return { ...retainedReply };
       }
-      return this.projectWizardReply({
+      const reply = this.projectWizardReply({
         text: await this.pumpWizardBridge(),
         action: "none",
       });
+      if (reply.text) {
+        // Recovery can be the only delivery of a terminal setup result. Record
+        // newly generated replies once; retained replays return above.
+        this.history.push({ role: "assistant", text: reply.text });
+      }
+      return reply;
     });
     this.turnQueue = turn.catch(() => undefined);
     return await turn;

--- a/src/system-agent/chat-engine.ts
+++ b/src/system-agent/chat-engine.ts
@@ -105,6 +105,13 @@ type SystemAgentChatReply = {
   question?: SystemAgentChatQuestion;
 };
 
+type RetainedTerminalWizardReply = {
+  reply: SystemAgentChatReply;
+  expiresAt: number;
+};
+
+const TERMINAL_WIZARD_REPLY_RETENTION_MS = 5 * 60 * 1_000;
+
 type WizardPrompterLike = import("../wizard/prompts.js").WizardPrompter;
 
 type ActiveWizardBridge = {
@@ -393,7 +400,7 @@ export class SystemAgentChatEngine {
   private readonly history: SystemAgentAssistantTurn[] = [];
   private readonly agentSession: SystemAgentSession;
   private verifiedInference: SystemAgentVerifiedInferenceBinding;
-  private retainedTerminalWizardReply: SystemAgentChatReply | null = null;
+  private retainedTerminalWizardReply: RetainedTerminalWizardReply | null = null;
   /** Turns run strictly one at a time; interleaved handles corrupt wizard/pending state. */
   private turnQueue: Promise<unknown> = Promise.resolve();
 
@@ -466,7 +473,7 @@ export class SystemAgentChatEngine {
 
   async dispose(): Promise<boolean> {
     const wizardSession = this.wizardBridge?.session;
-    if (this.retainedTerminalWizardReply || wizardSession?.isCancellationLocked()) {
+    if (this.readRetainedTerminalWizardReply() || wizardSession?.isCancellationLocked()) {
       return false;
     }
     wizardSession?.cancel();
@@ -479,7 +486,7 @@ export class SystemAgentChatEngine {
 
   hasLockedHostedWizard(): boolean {
     return (
-      this.retainedTerminalWizardReply !== null ||
+      this.readRetainedTerminalWizardReply() !== null ||
       this.wizardBridge?.session.isCancellationLocked() === true
     );
   }
@@ -489,8 +496,9 @@ export class SystemAgentChatEngine {
       if (!this.hasLockedHostedWizard()) {
         return null;
       }
-      if (this.retainedTerminalWizardReply) {
-        return { ...this.retainedTerminalWizardReply };
+      const retainedReply = this.readRetainedTerminalWizardReply();
+      if (retainedReply) {
+        return { ...retainedReply };
       }
       return this.projectWizardReply({
         text: await this.pumpWizardBridge(),
@@ -499,6 +507,18 @@ export class SystemAgentChatEngine {
     });
     this.turnQueue = turn.catch(() => undefined);
     return await turn;
+  }
+
+  private readRetainedTerminalWizardReply(): SystemAgentChatReply | null {
+    const retained = this.retainedTerminalWizardReply;
+    if (!retained) {
+      return null;
+    }
+    if (Date.now() >= retained.expiresAt) {
+      this.retainedTerminalWizardReply = null;
+      return null;
+    }
+    return retained.reply;
   }
 
   async handle(text: string): Promise<SystemAgentChatReply> {
@@ -1289,7 +1309,10 @@ export class SystemAgentChatEngine {
         terminalText = `Channel setup stopped: ${result.error ?? "unknown error"}`;
       }
       if (bridge.session.isCancellationLocked()) {
-        this.retainedTerminalWizardReply = { text: terminalText, action: "none" };
+        this.retainedTerminalWizardReply = {
+          reply: { text: terminalText, action: "none" },
+          expiresAt: Date.now() + TERMINAL_WIZARD_REPLY_RETENTION_MS,
+        };
       }
       return terminalText;
     }

--- a/src/system-agent/chat-engine.ts
+++ b/src/system-agent/chat-engine.ts
@@ -81,6 +81,7 @@ export type SystemAgentChatEngineOptions = {
     channel: string,
     prompter: WizardPrompterLike,
     beforePersistentApply: (runtime: RuntimeEnv) => Promise<void>,
+    abortSignal: AbortSignal,
   ) => Promise<void>;
   /** Exact route/credential that passed the host's live inference gate. */
   readonly verifiedInference: SystemAgentVerifiedInferenceBinding;
@@ -119,6 +120,7 @@ type CaptureRuntime = RuntimeEnv & {
 };
 
 const log = createSubsystemLogger("system-agent/chat-engine");
+const HOSTED_CHANNEL_SETUP_TIMEOUT_MS = 25 * 60 * 1000;
 
 function createHostedWizardRuntime(runtime: RuntimeEnv): RuntimeEnv {
   return {
@@ -144,6 +146,7 @@ function createCaptureRuntime(): CaptureRuntime {
 function defaultChannelSetupWizardRunner(
   channel: string,
   beforePersistentApply: (runtime: RuntimeEnv) => Promise<void>,
+  abortSignal: AbortSignal,
 ): (prompter: WizardPrompterLike) => Promise<void> {
   return async (prompter) => {
     const [
@@ -177,6 +180,7 @@ function defaultChannelSetupWizardRunner(
       quickstartDefaults: true,
       skipDmPolicyPrompt: true,
       skipConfirm: true,
+      abortSignal,
       beforePersistentEffect: async () => await beforePersistentApply(runtime),
       onPostWriteHook: (hook) => postWriteHooks.collect(hook),
     });
@@ -459,12 +463,34 @@ export class SystemAgentChatEngine {
     return this.history.slice(index).map((turn) => ({ role: turn.role, text: turn.text }));
   }
 
-  async dispose(): Promise<void> {
-    this.wizardBridge?.session.cancel();
+  async dispose(): Promise<boolean> {
+    const wizardSession = this.wizardBridge?.session;
+    if (wizardSession && !wizardSession.cancel() && wizardSession.getStatus() === "running") {
+      return false;
+    }
     this.wizardBridge = null;
     this.lastSensitiveChannel = undefined;
     this.awaitingSetupChannel = false;
     await cleanupSystemAgentSession(this.agentSession);
+    return true;
+  }
+
+  hasLockedHostedWizard(): boolean {
+    return this.wizardBridge?.session.isCancellationLocked() === true;
+  }
+
+  async resumeLockedHostedWizard(): Promise<SystemAgentChatReply | null> {
+    const turn = this.turnQueue.then(async () => {
+      if (!this.hasLockedHostedWizard()) {
+        return null;
+      }
+      return this.projectWizardReply({
+        text: await this.pumpWizardBridge(),
+        action: "none",
+      });
+    });
+    this.turnQueue = turn.catch(() => undefined);
+    return await turn;
   }
 
   async handle(text: string): Promise<SystemAgentChatReply> {
@@ -475,7 +501,11 @@ export class SystemAgentChatEngine {
   }
 
   private async handleSerialized(text: string): Promise<SystemAgentChatReply> {
-    await this.requireVerifiedInference();
+    // Hosted wizard replies are deterministic, and a locked flow may be the
+    // only recovery path after its durable effect changes the inference route.
+    if (!this.wizardBridge?.session.isCancellationLocked()) {
+      await this.requireVerifiedInference();
+    }
     // Snapshot before resolving: wizard answers to sensitive steps (tokens,
     // passwords) must never enter the AI-visible history.
     const sensitiveTurn = this.wizardBridge?.step?.sensitive === true;
@@ -489,6 +519,10 @@ export class SystemAgentChatEngine {
     }
     // While a hosted wizard awaits a step, every turn routes to it, so the
     // awaited step is always the question this reply asks.
+    return this.projectWizardReply(reply);
+  }
+
+  private projectWizardReply(reply: SystemAgentChatReply): SystemAgentChatReply {
     const question = wizardStepChatQuestion(this.wizardBridge?.step ?? null);
     return {
       ...reply,
@@ -1139,10 +1173,26 @@ export class SystemAgentChatEngine {
     };
     const runWizard =
       this.opts.runChannelSetupWizard ??
-      ((ch: string, prompter: WizardPrompterLike, guard: (runtime: RuntimeEnv) => Promise<void>) =>
-        defaultChannelSetupWizardRunner(ch, guard)(prompter));
-    const session = new WizardSession((prompter) =>
-      runWizard(channel, prompter, beforePersistentApply),
+      ((
+        ch: string,
+        prompter: WizardPrompterLike,
+        guard: (runtime: RuntimeEnv) => Promise<void>,
+        signal: AbortSignal,
+      ) => defaultChannelSetupWizardRunner(ch, guard, signal)(prompter));
+    const session = new WizardSession(
+      (prompter, signal, wizardSession) =>
+        runWizard(
+          channel,
+          prompter,
+          async (runtime) => {
+            await beforePersistentApply(runtime);
+            if (this.opts.surface === "gateway" && !wizardSession.lockCancellation()) {
+              throw new Error("Channel setup was cancelled before its persistent change started.");
+            }
+          },
+          signal,
+        ),
+      this.opts.surface === "gateway" ? { timeoutMs: HOSTED_CHANNEL_SETUP_TIMEOUT_MS } : undefined,
     );
     this.wizardBridge = {
       session,
@@ -1265,8 +1315,14 @@ export class SystemAgentChatEngine {
     if (!bridge) {
       return "";
     }
+    if (bridge.session.getStatus() !== "running") {
+      bridge.step = null;
+      return await this.pumpWizardBridge();
+    }
     if (/^(cancel|abort|stop|quit|exit)$/i.test(text.trim())) {
-      bridge.session.cancel();
+      if (!bridge.session.cancel()) {
+        return "Channel setup is already applying and can no longer be cancelled.";
+      }
       return await this.pumpWizardBridge();
     }
     const step = bridge.step;

--- a/src/system-agent/chat-engine.ts
+++ b/src/system-agent/chat-engine.ts
@@ -500,13 +500,19 @@ export class SystemAgentChatEngine {
       if (retainedReply) {
         return { ...retainedReply };
       }
+      const bridgeBeforeRecovery = this.wizardBridge;
+      const stepIdBeforeRecovery = bridgeBeforeRecovery?.step?.id;
       const reply = this.projectWizardReply({
         text: await this.pumpWizardBridge(),
         action: "none",
       });
-      if (reply.text) {
+      const recoveryAdvanced =
+        this.wizardBridge !== bridgeBeforeRecovery ||
+        this.wizardBridge?.step?.id !== stepIdBeforeRecovery;
+      if (reply.text && recoveryAdvanced) {
         // Recovery can be the only delivery of a terminal setup result. Record
-        // newly generated replies once; retained replays return above.
+        // only newly advanced replies; retained and pending-step replays do not
+        // duplicate durable transcript turns.
         this.history.push({ role: "assistant", text: reply.text });
       }
       return reply;

--- a/src/system-agent/chat-engine.ts
+++ b/src/system-agent/chat-engine.ts
@@ -88,6 +88,8 @@ export type SystemAgentChatEngineOptions = {
   readonly verifiedInference: SystemAgentVerifiedInferenceBinding;
   /** Delegated chats accept approval only from the operator registry. */
   operatorApprovalOnly?: boolean;
+  /** Whether hosted channel work has an owner that can recover after reconnect. */
+  allowHostedChannelSetup?: boolean;
 };
 type RetainedTerminalWizardReply = {
   reply: SystemAgentChatReply;
@@ -1197,6 +1199,12 @@ export class SystemAgentChatEngine {
   private async startChannelSetupWizard(channel: string): Promise<string> {
     this.clearPendingProposals();
     this.lastSensitiveChannel = undefined;
+    if (this.opts.surface === "gateway" && this.opts.allowHostedChannelSetup === false) {
+      return [
+        "Channel setup in chat requires an identity that can survive reconnects.",
+        "Pair this device or sign in to the Gateway, then try again.",
+      ].join("\n");
+    }
     const beforePersistentApply = async (runtime: RuntimeEnv) => {
       await this.requirePersistentApplyInference(runtime);
     };

--- a/src/system-agent/chat-engine.ts
+++ b/src/system-agent/chat-engine.ts
@@ -393,6 +393,7 @@ export class SystemAgentChatEngine {
   private readonly history: SystemAgentAssistantTurn[] = [];
   private readonly agentSession: SystemAgentSession;
   private verifiedInference: SystemAgentVerifiedInferenceBinding;
+  private retainedTerminalWizardReply: SystemAgentChatReply | null = null;
   /** Turns run strictly one at a time; interleaved handles corrupt wizard/pending state. */
   private turnQueue: Promise<unknown> = Promise.resolve();
 
@@ -465,9 +466,10 @@ export class SystemAgentChatEngine {
 
   async dispose(): Promise<boolean> {
     const wizardSession = this.wizardBridge?.session;
-    if (wizardSession && !wizardSession.cancel() && wizardSession.getStatus() === "running") {
+    if (this.retainedTerminalWizardReply || wizardSession?.isCancellationLocked()) {
       return false;
     }
+    wizardSession?.cancel();
     this.wizardBridge = null;
     this.lastSensitiveChannel = undefined;
     this.awaitingSetupChannel = false;
@@ -476,13 +478,19 @@ export class SystemAgentChatEngine {
   }
 
   hasLockedHostedWizard(): boolean {
-    return this.wizardBridge?.session.isCancellationLocked() === true;
+    return (
+      this.retainedTerminalWizardReply !== null ||
+      this.wizardBridge?.session.isCancellationLocked() === true
+    );
   }
 
   async resumeLockedHostedWizard(): Promise<SystemAgentChatReply | null> {
     const turn = this.turnQueue.then(async () => {
       if (!this.hasLockedHostedWizard()) {
         return null;
+      }
+      if (this.retainedTerminalWizardReply) {
+        return { ...this.retainedTerminalWizardReply };
       }
       return this.projectWizardReply({
         text: await this.pumpWizardBridge(),
@@ -501,6 +509,11 @@ export class SystemAgentChatEngine {
   }
 
   private async handleSerialized(text: string): Promise<SystemAgentChatReply> {
+    if (!this.wizardBridge) {
+      // A same-session follow-up acknowledges the previously returned
+      // terminal wizard reply; cross-session recovery reads it first.
+      this.retainedTerminalWizardReply = null;
+    }
     // Hosted wizard replies are deterministic, and a locked flow may be the
     // only recovery path after its durable effect changes the inference route.
     if (!this.wizardBridge?.session.isCancellationLocked()) {
@@ -1247,6 +1260,7 @@ export class SystemAgentChatEngine {
     if (result.done) {
       this.wizardBridge = null;
       const label = bridge.label;
+      let terminalText: string;
       if (result.status === "done") {
         try {
           const appendAuditEntry =
@@ -1262,18 +1276,22 @@ export class SystemAgentChatEngine {
           log.warn(`channel setup completed without audit entry: ${formatErrorMessage(error)}`);
         }
         const verify = await this.verifyConfigAfterWrite();
-        return [
+        terminalText = [
           `Done — ${label} is configured.`,
           "Say `restart gateway` to apply channel changes, or `channels` to review.",
           verify ?? "",
         ]
           .filter(Boolean)
           .join("\n");
+      } else if (result.status === "cancelled") {
+        terminalText = "Channel setup cancelled. Nothing was changed beyond completed steps.";
+      } else {
+        terminalText = `Channel setup stopped: ${result.error ?? "unknown error"}`;
       }
-      if (result.status === "cancelled") {
-        return "Channel setup cancelled. Nothing was changed beyond completed steps.";
+      if (bridge.session.isCancellationLocked()) {
+        this.retainedTerminalWizardReply = { text: terminalText, action: "none" };
       }
-      return `Channel setup stopped: ${result.error ?? "unknown error"}`;
+      return terminalText;
     }
     bridge.step = result.step ?? null;
     if (bridge.step) {

--- a/src/system-agent/chat-engine.ts
+++ b/src/system-agent/chat-engine.ts
@@ -19,6 +19,7 @@ import {
   type SystemAgentApprovalIntent,
 } from "./approval-intent.js";
 import type { SystemAgentAssistantPlanner, SystemAgentAssistantTurn } from "./assistant.js";
+import type { SystemAgentChatReply } from "./chat-contract.js";
 import { approvalQuestion } from "./dialogue.js";
 import type {
   SystemAgentGreetingFacts,
@@ -88,23 +89,6 @@ export type SystemAgentChatEngineOptions = {
   /** Delegated chats accept approval only from the operator registry. */
   operatorApprovalOnly?: boolean;
 };
-type SystemAgentChatReplyAction = "none" | "exit" | "open-tui" | "open-setup";
-
-type SystemAgentChatReply = {
-  text: string;
-  action: SystemAgentChatReplyAction;
-  /** Client-localized draft intent for the destination agent chat. */
-  agentDraft?: "hatch";
-  /** The next hosted-wizard reply contains a secret and must be masked/redacted by hosts. */
-  sensitive?: boolean;
-  /** The hosted wizard will consume the next message as its current step answer. */
-  wizardInputPending?: boolean;
-  /** Present when the host must leave chat for an interactive handoff. */
-  handoff?: SystemAgentOperation;
-  /** Structured choice mirroring the awaited wizard step for card-capable clients. */
-  question?: SystemAgentChatQuestion;
-};
-
 type RetainedTerminalWizardReply = {
   reply: SystemAgentChatReply;
   expiresAt: number;

--- a/src/system-agent/tui-backend.ts
+++ b/src/system-agent/tui-backend.ts
@@ -292,7 +292,7 @@ class SystemAgentTuiBackend implements TuiBackend {
   }
 
   private disposeEngine(): Promise<void> {
-    this.engineDisposal ??= this.engine.dispose();
+    this.engineDisposal ??= this.engine.dispose().then(() => undefined);
     return this.engineDisposal;
   }
 

--- a/src/wizard/session.test.ts
+++ b/src/wizard/session.test.ts
@@ -217,6 +217,24 @@ describe("WizardSession", () => {
     expect(session.cancel()).toBe(false);
   });
 
+  test("matches terminal recovery against the requested and canonical channel", async () => {
+    const session = new WizardSession(
+      async (_prompter, _signal, wizardSession) => {
+        wizardSession.setResolvedChannel("twitch");
+        expect(wizardSession.lockCancellation()).toBe(true);
+      },
+      {
+        resumeKey: "owner:channel-setup",
+        requestedChannel: "Twitch-Chat",
+      },
+    );
+
+    expect((await session.next()).status).toBe("done");
+    expect(session.canResume("owner:channel-setup", "twitch-chat")).toBe(true);
+    expect(session.canResume("owner:channel-setup", "twitch")).toBe(true);
+    expect(session.canResume("owner:channel-setup", "discord")).toBe(false);
+  });
+
   test("expires an abandoned interactive session", async () => {
     vi.useFakeTimers();
     try {

--- a/src/wizard/session.test.ts
+++ b/src/wizard/session.test.ts
@@ -194,6 +194,15 @@ describe("WizardSession", () => {
     expect((await session.next()).status).toBe("done");
   });
 
+  test("refuses the durable lock when cancellation already won", () => {
+    const session = new WizardSession(async () => {});
+
+    expect(session.cancel()).toBe(true);
+    expect(session.lockCancellation()).toBe(false);
+    expect(session.getStatus()).toBe("cancelled");
+    expect(session.signal.aborted).toBe(true);
+  });
+
   test("expires an abandoned interactive session", async () => {
     vi.useFakeTimers();
     try {
@@ -213,6 +222,68 @@ describe("WizardSession", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  test("refreshes reversible session expiry when the owner polls", async () => {
+    vi.useFakeTimers();
+    try {
+      const session = new WizardSession(
+        async (prompter) => {
+          await prompter.text({ message: "Name" });
+        },
+        { timeoutMs: 1_000 },
+      );
+
+      const pending = await session.next();
+      await vi.advanceTimersByTimeAsync(900);
+      expect((await session.next()).step?.id).toBe(pending.step?.id);
+
+      await vi.advanceTimersByTimeAsync(999);
+      expect(session.getStatus()).toBe("running");
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect((await session.next()).status).toBe("cancelled");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("does not expire a cancellation-locked session", async () => {
+    vi.useFakeTimers();
+    try {
+      const session = new WizardSession(
+        async (prompter, _signal, wizardSession) => {
+          expect(wizardSession.lockCancellation()).toBe(true);
+          await prompter.confirm({ message: "Retry recovery?" });
+        },
+        { timeoutMs: 1_000 },
+      );
+
+      expect((await session.next()).step?.type).toBe("confirm");
+      await vi.advanceTimersByTimeAsync(10_000);
+
+      expect(session.getStatus()).toBe("running");
+      expect(session.signal.aborted).toBe(false);
+      expect(session.cancel()).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("allows resumption only with the exact host-owned key", () => {
+    const session = new WizardSession(
+      async (prompter) => {
+        await prompter.text({ message: "Token" });
+      },
+      { resumeKey: "owner:connection-1:channel-a" },
+    );
+
+    expect(session.canResume("owner:connection-1:channel-a")).toBe(true);
+    expect(session.canResume("owner:connection-2:channel-a")).toBe(false);
+    expect(session.canResume("owner:connection-1:channel-b")).toBe(false);
+
+    session.cancel();
+    expect(session.canResume("owner:connection-1:channel-a")).toBe(false);
   });
 
   test("a runner finishing after cancellation cannot overwrite cancelled state", async () => {

--- a/src/wizard/session.test.ts
+++ b/src/wizard/session.test.ts
@@ -256,6 +256,23 @@ describe("WizardSession", () => {
     expect(session.canResume("owner:channel-setup", "discord")).toBe(false);
   });
 
+  test("does not match a terminal result to an abandoned requested channel", async () => {
+    const session = new WizardSession(
+      async (_prompter, _signal, wizardSession) => {
+        expect(wizardSession.lockCancellation()).toBe(true);
+        wizardSession.setResolvedChannel("discord");
+      },
+      {
+        resumeKey: "owner:channel-setup",
+        requestedChannel: "matrix",
+      },
+    );
+
+    expect((await session.next()).status).toBe("done");
+    expect(session.canResume("owner:channel-setup", "matrix")).toBe(false);
+    expect(session.canResume("owner:channel-setup", "discord")).toBe(true);
+  });
+
   test("retains every canonical channel and alias selected by browse-all", async () => {
     const session = new WizardSession(
       async (_prompter, _signal, wizardSession) => {

--- a/src/wizard/session.test.ts
+++ b/src/wizard/session.test.ts
@@ -220,12 +220,12 @@ describe("WizardSession", () => {
   test("matches terminal recovery against the requested and canonical channel", async () => {
     const session = new WizardSession(
       async (_prompter, _signal, wizardSession) => {
-        wizardSession.setResolvedChannel("twitch");
+        wizardSession.setResolvedChannel("twitch", ["twitch-chat"]);
         expect(wizardSession.lockCancellation()).toBe(true);
       },
       {
         resumeKey: "owner:channel-setup",
-        requestedChannel: "Twitch-Chat",
+        requestedChannel: "twitch",
       },
     );
 

--- a/src/wizard/session.test.ts
+++ b/src/wizard/session.test.ts
@@ -203,6 +203,20 @@ describe("WizardSession", () => {
     expect(session.signal.aborted).toBe(true);
   });
 
+  test("keeps the durable lock through an uncollected terminal result", async () => {
+    const session = new WizardSession(
+      async (_prompter, _signal, wizardSession) => {
+        expect(wizardSession.lockCancellation()).toBe(true);
+      },
+      { resumeKey: "owner:channel-setup" },
+    );
+
+    expect((await session.next()).status).toBe("done");
+    expect(session.isCancellationLocked()).toBe(true);
+    expect(session.canResume("owner:channel-setup")).toBe(true);
+    expect(session.cancel()).toBe(false);
+  });
+
   test("expires an abandoned interactive session", async () => {
     vi.useFakeTimers();
     try {
@@ -270,7 +284,7 @@ describe("WizardSession", () => {
     }
   });
 
-  test("allows resumption only with the exact host-owned key", () => {
+  test("allows locked resumption only with the exact host-owned key", () => {
     const session = new WizardSession(
       async (prompter) => {
         await prompter.text({ message: "Token" });
@@ -278,12 +292,10 @@ describe("WizardSession", () => {
       { resumeKey: "owner:connection-1:channel-a" },
     );
 
+    expect(session.lockCancellation()).toBe(true);
     expect(session.canResume("owner:connection-1:channel-a")).toBe(true);
     expect(session.canResume("owner:connection-2:channel-a")).toBe(false);
     expect(session.canResume("owner:connection-1:channel-b")).toBe(false);
-
-    session.cancel();
-    expect(session.canResume("owner:connection-1:channel-a")).toBe(false);
   });
 
   test("a runner finishing after cancellation cannot overwrite cancelled state", async () => {

--- a/src/wizard/session.test.ts
+++ b/src/wizard/session.test.ts
@@ -256,6 +256,23 @@ describe("WizardSession", () => {
     expect(session.canResume("owner:channel-setup", "discord")).toBe(false);
   });
 
+  test("retains every canonical channel and alias selected by browse-all", async () => {
+    const session = new WizardSession(
+      async (_prompter, _signal, wizardSession) => {
+        wizardSession.setResolvedChannel("matrix", ["matrix-chat"]);
+        wizardSession.setResolvedChannel("twitch", ["twitch-chat"]);
+        expect(wizardSession.lockCancellation()).toBe(true);
+      },
+      { resumeKey: "owner:channel-setup" },
+    );
+
+    expect((await session.next()).status).toBe("done");
+    expect(session.canResume("owner:channel-setup", "matrix")).toBe(true);
+    expect(session.canResume("owner:channel-setup", "matrix-chat")).toBe(true);
+    expect(session.canResume("owner:channel-setup", "twitch")).toBe(true);
+    expect(session.canResume("owner:channel-setup", "twitch-chat")).toBe(true);
+  });
+
   test("expires an abandoned interactive session", async () => {
     vi.useFakeTimers();
     try {

--- a/src/wizard/session.test.ts
+++ b/src/wizard/session.test.ts
@@ -213,8 +213,29 @@ describe("WizardSession", () => {
 
     expect((await session.next()).status).toBe("done");
     expect(session.isCancellationLocked()).toBe(true);
-    expect(session.canResume("owner:channel-setup")).toBe(true);
+    expect(session.canResume("owner:channel-setup")).toBe(false);
     expect(session.cancel()).toBe(false);
+  });
+
+  test("resumes channel-less reconnects while locked work is still running", async () => {
+    let finish!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      finish = resolve;
+    });
+    const session = new WizardSession(
+      async (_prompter, _signal, wizardSession) => {
+        expect(wizardSession.lockCancellation()).toBe(true);
+        await gate;
+      },
+      { resumeKey: "owner:channel-setup" },
+    );
+
+    await vi.waitFor(() => expect(session.isCancellationLocked()).toBe(true));
+    expect(session.canResume("owner:channel-setup")).toBe(true);
+
+    finish();
+    expect((await session.next()).status).toBe("done");
+    expect(session.canResume("owner:channel-setup")).toBe(false);
   });
 
   test("matches terminal recovery against the requested and canonical channel", async () => {

--- a/src/wizard/session.ts
+++ b/src/wizard/session.ts
@@ -401,7 +401,12 @@ export class WizardSession {
 
   /** Whether this locked session belongs to the owner's resumable flow. */
   matchesResumeKey(resumeKey: string): boolean {
-    return this.cancellationLocked && this.resumeKey === resumeKey;
+    return this.cancellationLocked && this.hasResumeKey(resumeKey);
+  }
+
+  /** Whether this session belongs to the owner's flow, before or after its durable lock. */
+  hasResumeKey(resumeKey: string): boolean {
+    return this.resumeKey === resumeKey;
   }
 
   /**

--- a/src/wizard/session.ts
+++ b/src/wizard/session.ts
@@ -247,7 +247,7 @@ export class WizardSession {
   private ownerKey: string | undefined;
   private readonly resumeKey: string | undefined;
   private readonly requestedChannel: string | undefined;
-  private resolvedChannel: string | undefined;
+  private readonly resolvedChannels = new Set<string>();
   private readonly resolvedChannelAliases = new Set<string>();
   private answerDeferred = new Map<
     string,
@@ -331,10 +331,11 @@ export class WizardSession {
   /** Record the canonical channel selected by the setup registry. */
   setResolvedChannel(channel: string, aliases: readonly string[] = []): void {
     const resolvedChannel = normalizeChannelIdentity(channel);
-    if (resolvedChannel !== this.resolvedChannel) {
-      this.resolvedChannelAliases.clear();
+    if (resolvedChannel) {
+      // Browse-all can configure several channels before disconnecting. Keep
+      // every identity so recovery through the client's first selection works.
+      this.resolvedChannels.add(resolvedChannel);
     }
-    this.resolvedChannel = resolvedChannel;
     for (const alias of aliases) {
       const normalizedAlias = normalizeChannelIdentity(alias);
       if (normalizedAlias) {
@@ -425,7 +426,7 @@ export class WizardSession {
     }
     return (
       normalizedRequestedChannel === this.requestedChannel ||
-      normalizedRequestedChannel === this.resolvedChannel ||
+      this.resolvedChannels.has(normalizedRequestedChannel) ||
       this.resolvedChannelAliases.has(normalizedRequestedChannel)
     );
   }

--- a/src/wizard/session.ts
+++ b/src/wizard/session.ts
@@ -247,6 +247,7 @@ export class WizardSession {
   private pendingExternalUrl: string | undefined;
   private ownerKey: string | undefined;
   private readonly resumeKey: string | undefined;
+  private readonly originConnectionId: string | undefined;
   private readonly requestedChannel: string | undefined;
   private readonly resolvedChannels = new Set<string>();
   private readonly resolvedChannelAliases = new Set<string>();
@@ -273,6 +274,7 @@ export class WizardSession {
       timeoutMs?: number;
       ownerKey?: string;
       resumeKey?: string;
+      originConnectionId?: string;
       requestedChannel?: string;
       now?: () => number;
     },
@@ -282,6 +284,7 @@ export class WizardSession {
     this.now = options?.now ?? Date.now;
     this.ownerKey = options?.ownerKey;
     this.resumeKey = options?.resumeKey;
+    this.originConnectionId = options?.originConnectionId?.trim() || undefined;
     this.requestedChannel = normalizeChannelIdentity(options?.requestedChannel);
     this.refreshExpiryTimer();
     void this.run(prompter);
@@ -330,6 +333,14 @@ export class WizardSession {
   /** Record what the channels flow actually configured (channels flow only). */
   setConfiguredAccounts(accounts: ReadonlyArray<{ channel: string; accountId: string }>) {
     this.configuredAccounts = accounts.map((entry) => ({ ...entry }));
+  }
+
+  /** Whether a request arrived on the connection that started this session. */
+  startedOnConnection(connectionId: string | undefined): boolean {
+    const normalizedConnectionId = connectionId?.trim() || undefined;
+    return (
+      normalizedConnectionId !== undefined && normalizedConnectionId === this.originConnectionId
+    );
   }
 
   /** Record the canonical channel selected by the setup registry. */

--- a/src/wizard/session.ts
+++ b/src/wizard/session.ts
@@ -236,6 +236,7 @@ class WizardSessionPrompter implements WizardPrompter {
 export class WizardSession {
   private readonly abortController = new AbortController();
   private readonly timeoutMs: number | undefined;
+  private readonly now: () => number;
   private expiryTimer: ReturnType<typeof setTimeout> | undefined;
   private currentStep: WizardStep | null = null;
   private progressSteps: WizardStep[] = [];
@@ -258,6 +259,7 @@ export class WizardSession {
     }
   >();
   private status: WizardSessionStatus = "running";
+  private terminalAt: number | undefined;
   private error: string | undefined;
   private configuredAccounts: Array<{ channel: string; accountId: string }> | undefined;
 
@@ -272,10 +274,12 @@ export class WizardSession {
       ownerKey?: string;
       resumeKey?: string;
       requestedChannel?: string;
+      now?: () => number;
     },
   ) {
     const prompter = new WizardSessionPrompter(this);
     this.timeoutMs = options?.timeoutMs;
+    this.now = options?.now ?? Date.now;
     this.ownerKey = options?.ownerKey;
     this.resumeKey = options?.resumeKey;
     this.requestedChannel = normalizeChannelIdentity(options?.requestedChannel);
@@ -375,6 +379,7 @@ export class WizardSession {
       return false;
     }
     this.status = "cancelled";
+    this.terminalAt = this.now();
     this.error = "cancelled";
     this.abortController.abort(new WizardCancelledError());
     this.currentStep = null;
@@ -414,7 +419,11 @@ export class WizardSession {
    * Locked work remains replayable for the same flow. A terminal result needs
    * an explicit channel identity; browse-all without one is fresh intent.
    */
-  canResume(resumeKey: string, requestedChannel?: string): boolean {
+  canResume(
+    resumeKey: string,
+    requestedChannel?: string,
+    options?: { allowAliasMatch?: boolean },
+  ): boolean {
     if (!this.matchesResumeKey(resumeKey)) {
       return false;
     }
@@ -424,8 +433,11 @@ export class WizardSession {
       // fresh intent. Running locked work remains recoverable after reconnect.
       return this.status === "running";
     }
+    if (this.resolvedChannels.has(normalizedRequestedChannel)) {
+      return true;
+    }
     if (
-      this.resolvedChannels.has(normalizedRequestedChannel) ||
+      options?.allowAliasMatch !== false &&
       this.resolvedChannelAliases.has(normalizedRequestedChannel)
     ) {
       return true;
@@ -454,6 +466,11 @@ export class WizardSession {
 
   get signal(): AbortSignal {
     return this.abortController.signal;
+  }
+
+  /** Timestamp of the actual terminal transition, used for bounded result retention. */
+  getTerminalAt(): number | undefined {
+    return this.terminalAt;
   }
 
   pushStep(step: WizardStep) {
@@ -511,6 +528,7 @@ export class WizardSession {
       await this.runner(prompter, this.signal, this);
       if (this.status === "running") {
         this.status = "done";
+        this.terminalAt = this.now();
       }
     } catch (err) {
       if (this.status !== "running") {
@@ -523,6 +541,7 @@ export class WizardSession {
         this.status = "error";
         this.error = String(err);
       }
+      this.terminalAt = this.now();
     } finally {
       this.clearExpiryTimer();
       this.resolveStep(null);

--- a/src/wizard/session.ts
+++ b/src/wizard/session.ts
@@ -330,7 +330,11 @@ export class WizardSession {
 
   /** Record the canonical channel selected by the setup registry. */
   setResolvedChannel(channel: string, aliases: readonly string[] = []): void {
-    this.resolvedChannel = normalizeChannelIdentity(channel);
+    const resolvedChannel = normalizeChannelIdentity(channel);
+    if (resolvedChannel !== this.resolvedChannel) {
+      this.resolvedChannelAliases.clear();
+    }
+    this.resolvedChannel = resolvedChannel;
     for (const alias of aliases) {
       const normalizedAlias = normalizeChannelIdentity(alias);
       if (normalizedAlias) {
@@ -409,7 +413,7 @@ export class WizardSession {
       return false;
     }
     const normalizedRequestedChannel = normalizeChannelIdentity(requestedChannel);
-    if (this.status === "running" || !normalizedRequestedChannel) {
+    if (!normalizedRequestedChannel) {
       return true;
     }
     return (

--- a/src/wizard/session.ts
+++ b/src/wizard/session.ts
@@ -424,11 +424,16 @@ export class WizardSession {
       // fresh intent. Running locked work remains recoverable after reconnect.
       return this.status === "running";
     }
-    return (
-      normalizedRequestedChannel === this.requestedChannel ||
+    if (
       this.resolvedChannels.has(normalizedRequestedChannel) ||
       this.resolvedChannelAliases.has(normalizedRequestedChannel)
-    );
+    ) {
+      return true;
+    }
+    // Before the durable boundary publishes the canonical identity, targeted
+    // running work may still recover by its request. Terminal results may not:
+    // Back can abandon that target and commit a different channel.
+    return this.status === "running" && normalizedRequestedChannel === this.requestedChannel;
   }
 
   /** Transfer authenticated ownership after shared Gateway credentials rotate. */

--- a/src/wizard/session.ts
+++ b/src/wizard/session.ts
@@ -230,7 +230,8 @@ class WizardSessionPrompter implements WizardPrompter {
 
 export class WizardSession {
   private readonly abortController = new AbortController();
-  private readonly expiryTimer: ReturnType<typeof setTimeout> | undefined;
+  private readonly timeoutMs: number | undefined;
+  private expiryTimer: ReturnType<typeof setTimeout> | undefined;
   private currentStep: WizardStep | null = null;
   private progressSteps: WizardStep[] = [];
   private deliveredProgressStepIds = new Set<string>();
@@ -238,6 +239,8 @@ export class WizardSession {
   private pendingTerminalResolution = false;
   private cancellationLocked = false;
   private pendingExternalUrl: string | undefined;
+  private readonly ownerKey: string | undefined;
+  private readonly resumeKey: string | undefined;
   private answerDeferred = new Map<
     string,
     {
@@ -256,17 +259,18 @@ export class WizardSession {
       signal: AbortSignal,
       session: WizardSession,
     ) => Promise<void>,
-    options?: { timeoutMs?: number },
+    options?: { timeoutMs?: number; ownerKey?: string; resumeKey?: string },
   ) {
     const prompter = new WizardSessionPrompter(this);
-    if (options?.timeoutMs !== undefined) {
-      this.expiryTimer = setTimeout(() => this.cancel(), options.timeoutMs);
-      this.expiryTimer.unref?.();
-    }
+    this.timeoutMs = options?.timeoutMs;
+    this.ownerKey = options?.ownerKey;
+    this.resumeKey = options?.resumeKey;
+    this.refreshExpiryTimer();
     void this.run(prompter);
   }
 
   async next(): Promise<WizardNextResult> {
+    this.refreshExpiryTimer();
     const progressStep = this.progressSteps.shift();
     if (progressStep) {
       this.rememberDeliveredProgressStep(progressStep.id);
@@ -321,6 +325,7 @@ export class WizardSession {
       }
       throw new Error("wizard: no pending step");
     }
+    this.refreshExpiryTimer();
     const normalizedValue = pending.text ? normalizeTextAnswer(value) : value;
     if (pending.text && normalizedValue === undefined) {
       return "wizard: text answer must be a scalar value";
@@ -356,8 +361,27 @@ export class WizardSession {
   }
 
   /** The underlying mutation crossed its durable commit point and must finish. */
-  lockCancellation() {
+  lockCancellation(): boolean {
+    if (this.status !== "running") {
+      return false;
+    }
     this.cancellationLocked = true;
+    this.clearExpiryTimer();
+    return true;
+  }
+
+  /** A replacement host may reclaim only the flow that created this session. */
+  canResume(resumeKey: string): boolean {
+    return this.status === "running" && this.resumeKey === resumeKey;
+  }
+
+  /** Unowned legacy sessions remain bearer-token based; hosted sessions bind to their owner. */
+  isAccessibleBy(ownerKey: string | undefined): boolean {
+    return this.ownerKey === undefined || this.ownerKey === ownerKey;
+  }
+
+  isCancellationLocked(): boolean {
+    return this.status === "running" && this.cancellationLocked;
   }
 
   get signal(): AbortSignal {
@@ -432,9 +456,7 @@ export class WizardSession {
         this.error = String(err);
       }
     } finally {
-      if (this.expiryTimer) {
-        clearTimeout(this.expiryTimer);
-      }
+      this.clearExpiryTimer();
       this.resolveStep(null);
     }
   }
@@ -446,6 +468,7 @@ export class WizardSession {
     if (this.status !== "running") {
       throw new Error("wizard: session not running");
     }
+    this.refreshExpiryTimer();
     this.pushStep(step);
     const deferred = createDeferred<unknown>();
     this.answerDeferred.set(step.id, { deferred, text: step.type === "text", validate });
@@ -472,5 +495,22 @@ export class WizardSession {
 
   getError(): string | undefined {
     return this.error;
+  }
+
+  private refreshExpiryTimer(): void {
+    if (this.timeoutMs === undefined || this.status !== "running" || this.cancellationLocked) {
+      return;
+    }
+    this.clearExpiryTimer();
+    this.expiryTimer = setTimeout(() => this.cancel(), this.timeoutMs);
+    this.expiryTimer.unref?.();
+  }
+
+  private clearExpiryTimer(): void {
+    if (!this.expiryTimer) {
+      return;
+    }
+    clearTimeout(this.expiryTimer);
+    this.expiryTimer = undefined;
   }
 }

--- a/src/wizard/session.ts
+++ b/src/wizard/session.ts
@@ -41,6 +41,11 @@ type WizardNextResult = {
   accounts?: Array<{ channel: string; accountId: string }>;
 };
 
+function normalizeChannelIdentity(value: string | undefined): string | undefined {
+  const normalized = value?.trim().toLowerCase();
+  return normalized || undefined;
+}
+
 function normalizeTextAnswer(value: unknown): string | undefined {
   if (value === null || value === undefined) {
     return "";
@@ -241,6 +246,8 @@ export class WizardSession {
   private pendingExternalUrl: string | undefined;
   private ownerKey: string | undefined;
   private readonly resumeKey: string | undefined;
+  private readonly requestedChannel: string | undefined;
+  private resolvedChannel: string | undefined;
   private answerDeferred = new Map<
     string,
     {
@@ -259,12 +266,18 @@ export class WizardSession {
       signal: AbortSignal,
       session: WizardSession,
     ) => Promise<void>,
-    options?: { timeoutMs?: number; ownerKey?: string; resumeKey?: string },
+    options?: {
+      timeoutMs?: number;
+      ownerKey?: string;
+      resumeKey?: string;
+      requestedChannel?: string;
+    },
   ) {
     const prompter = new WizardSessionPrompter(this);
     this.timeoutMs = options?.timeoutMs;
     this.ownerKey = options?.ownerKey;
     this.resumeKey = options?.resumeKey;
+    this.requestedChannel = normalizeChannelIdentity(options?.requestedChannel);
     this.refreshExpiryTimer();
     void this.run(prompter);
   }
@@ -312,6 +325,11 @@ export class WizardSession {
   /** Record what the channels flow actually configured (channels flow only). */
   setConfiguredAccounts(accounts: ReadonlyArray<{ channel: string; accountId: string }>) {
     this.configuredAccounts = accounts.map((entry) => ({ ...entry }));
+  }
+
+  /** Record the canonical channel selected by the setup registry. */
+  setResolvedChannel(channel: string): void {
+    this.resolvedChannel = normalizeChannelIdentity(channel);
   }
 
   async answer(stepId: string, value: unknown): Promise<string | undefined> {
@@ -383,10 +401,14 @@ export class WizardSession {
     if (!this.matchesResumeKey(resumeKey)) {
       return false;
     }
-    if (this.status === "running" || !requestedChannel || !this.configuredAccounts) {
+    const normalizedRequestedChannel = normalizeChannelIdentity(requestedChannel);
+    if (this.status === "running" || !normalizedRequestedChannel) {
       return true;
     }
-    return this.configuredAccounts.some((entry) => entry.channel === requestedChannel);
+    return (
+      normalizedRequestedChannel === this.requestedChannel ||
+      normalizedRequestedChannel === this.resolvedChannel
+    );
   }
 
   /** Transfer authenticated ownership after shared Gateway credentials rotate. */

--- a/src/wizard/session.ts
+++ b/src/wizard/session.ts
@@ -238,9 +238,8 @@ export class WizardSession {
   private stepDeferred: Deferred<WizardStep | null> | null = null;
   private pendingTerminalResolution = false;
   private cancellationLocked = false;
-  private lastTerminalResultConnectionId: string | undefined;
   private pendingExternalUrl: string | undefined;
-  private readonly ownerKey: string | undefined;
+  private ownerKey: string | undefined;
   private readonly resumeKey: string | undefined;
   private answerDeferred = new Map<
     string,
@@ -377,24 +376,23 @@ export class WizardSession {
   }
 
   /**
-   * A replacement connection may reclaim locked work. Once a terminal result
-   * was attempted on a connection, another start on that same connection is
-   * treated as acknowledgement and may create fresh work.
+   * Locked work remains replayable for the same flow. A terminal result can be
+   * released only when the owner explicitly starts a different channel.
    */
-  canResume(resumeKey: string, connectionId?: string): boolean {
+  canResume(resumeKey: string, requestedChannel?: string): boolean {
     if (!this.matchesResumeKey(resumeKey)) {
       return false;
     }
-    return (
-      this.status === "running" ||
-      connectionId === undefined ||
-      this.lastTerminalResultConnectionId !== connectionId
-    );
+    if (this.status === "running" || !requestedChannel || !this.configuredAccounts) {
+      return true;
+    }
+    return this.configuredAccounts.some((entry) => entry.channel === requestedChannel);
   }
 
-  markTerminalResultDelivery(connectionId: string | undefined): void {
-    if (this.status !== "running" && connectionId) {
-      this.lastTerminalResultConnectionId = connectionId;
+  /** Transfer authenticated ownership after shared Gateway credentials rotate. */
+  adoptOwner(ownerKey: string | undefined): void {
+    if (this.cancellationLocked && ownerKey) {
+      this.ownerKey = ownerKey;
     }
   }
 

--- a/src/wizard/session.ts
+++ b/src/wizard/session.ts
@@ -238,6 +238,7 @@ export class WizardSession {
   private stepDeferred: Deferred<WizardStep | null> | null = null;
   private pendingTerminalResolution = false;
   private cancellationLocked = false;
+  private lastTerminalResultConnectionId: string | undefined;
   private pendingExternalUrl: string | undefined;
   private readonly ownerKey: string | undefined;
   private readonly resumeKey: string | undefined;
@@ -370,9 +371,31 @@ export class WizardSession {
     return true;
   }
 
-  /** A replacement host may reclaim only the flow that created this session. */
-  canResume(resumeKey: string): boolean {
+  /** Whether this locked session belongs to the owner's resumable flow. */
+  matchesResumeKey(resumeKey: string): boolean {
     return this.cancellationLocked && this.resumeKey === resumeKey;
+  }
+
+  /**
+   * A replacement connection may reclaim locked work. Once a terminal result
+   * was attempted on a connection, another start on that same connection is
+   * treated as acknowledgement and may create fresh work.
+   */
+  canResume(resumeKey: string, connectionId?: string): boolean {
+    if (!this.matchesResumeKey(resumeKey)) {
+      return false;
+    }
+    return (
+      this.status === "running" ||
+      connectionId === undefined ||
+      this.lastTerminalResultConnectionId !== connectionId
+    );
+  }
+
+  markTerminalResultDelivery(connectionId: string | undefined): void {
+    if (this.status !== "running" && connectionId) {
+      this.lastTerminalResultConnectionId = connectionId;
+    }
   }
 
   /** Unowned legacy sessions remain bearer-token based; hosted sessions bind to their owner. */

--- a/src/wizard/session.ts
+++ b/src/wizard/session.ts
@@ -372,7 +372,7 @@ export class WizardSession {
 
   /** A replacement host may reclaim only the flow that created this session. */
   canResume(resumeKey: string): boolean {
-    return this.status === "running" && this.resumeKey === resumeKey;
+    return this.cancellationLocked && this.resumeKey === resumeKey;
   }
 
   /** Unowned legacy sessions remain bearer-token based; hosted sessions bind to their owner. */
@@ -381,7 +381,7 @@ export class WizardSession {
   }
 
   isCancellationLocked(): boolean {
-    return this.status === "running" && this.cancellationLocked;
+    return this.cancellationLocked;
   }
 
   get signal(): AbortSignal {

--- a/src/wizard/session.ts
+++ b/src/wizard/session.ts
@@ -405,8 +405,8 @@ export class WizardSession {
   }
 
   /**
-   * Locked work remains replayable for the same flow. A terminal result can be
-   * released only when the owner explicitly starts a different channel.
+   * Locked work remains replayable for the same flow. A terminal result needs
+   * an explicit channel identity; browse-all without one is fresh intent.
    */
   canResume(resumeKey: string, requestedChannel?: string): boolean {
     if (!this.matchesResumeKey(resumeKey)) {
@@ -414,7 +414,9 @@ export class WizardSession {
     }
     const normalizedRequestedChannel = normalizeChannelIdentity(requestedChannel);
     if (!normalizedRequestedChannel) {
-      return true;
+      // With no channel identity to match, a terminal browse-all request is
+      // fresh intent. Running locked work remains recoverable after reconnect.
+      return this.status === "running";
     }
     return (
       normalizedRequestedChannel === this.requestedChannel ||

--- a/src/wizard/session.ts
+++ b/src/wizard/session.ts
@@ -247,7 +247,6 @@ export class WizardSession {
   private pendingExternalUrl: string | undefined;
   private ownerKey: string | undefined;
   private readonly resumeKey: string | undefined;
-  private readonly originConnectionId: string | undefined;
   private readonly requestedChannel: string | undefined;
   private readonly resolvedChannels = new Set<string>();
   private readonly resolvedChannelAliases = new Set<string>();
@@ -274,7 +273,6 @@ export class WizardSession {
       timeoutMs?: number;
       ownerKey?: string;
       resumeKey?: string;
-      originConnectionId?: string;
       requestedChannel?: string;
       now?: () => number;
     },
@@ -284,7 +282,6 @@ export class WizardSession {
     this.now = options?.now ?? Date.now;
     this.ownerKey = options?.ownerKey;
     this.resumeKey = options?.resumeKey;
-    this.originConnectionId = options?.originConnectionId?.trim() || undefined;
     this.requestedChannel = normalizeChannelIdentity(options?.requestedChannel);
     this.refreshExpiryTimer();
     void this.run(prompter);
@@ -333,14 +330,6 @@ export class WizardSession {
   /** Record what the channels flow actually configured (channels flow only). */
   setConfiguredAccounts(accounts: ReadonlyArray<{ channel: string; accountId: string }>) {
     this.configuredAccounts = accounts.map((entry) => ({ ...entry }));
-  }
-
-  /** Whether a request arrived on the connection that started this session. */
-  startedOnConnection(connectionId: string | undefined): boolean {
-    const normalizedConnectionId = connectionId?.trim() || undefined;
-    return (
-      normalizedConnectionId !== undefined && normalizedConnectionId === this.originConnectionId
-    );
   }
 
   /** Record the canonical channel selected by the setup registry. */

--- a/src/wizard/session.ts
+++ b/src/wizard/session.ts
@@ -248,6 +248,7 @@ export class WizardSession {
   private readonly resumeKey: string | undefined;
   private readonly requestedChannel: string | undefined;
   private resolvedChannel: string | undefined;
+  private readonly resolvedChannelAliases = new Set<string>();
   private answerDeferred = new Map<
     string,
     {
@@ -328,8 +329,14 @@ export class WizardSession {
   }
 
   /** Record the canonical channel selected by the setup registry. */
-  setResolvedChannel(channel: string): void {
+  setResolvedChannel(channel: string, aliases: readonly string[] = []): void {
     this.resolvedChannel = normalizeChannelIdentity(channel);
+    for (const alias of aliases) {
+      const normalizedAlias = normalizeChannelIdentity(alias);
+      if (normalizedAlias) {
+        this.resolvedChannelAliases.add(normalizedAlias);
+      }
+    }
   }
 
   async answer(stepId: string, value: unknown): Promise<string | undefined> {
@@ -407,7 +414,8 @@ export class WizardSession {
     }
     return (
       normalizedRequestedChannel === this.requestedChannel ||
-      normalizedRequestedChannel === this.resolvedChannel
+      normalizedRequestedChannel === this.resolvedChannel ||
+      this.resolvedChannelAliases.has(normalizedRequestedChannel)
     );
   }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running hosted channel setup through the Gateway or system agent could strand setup work, lose a committed result after reconnecting, or leave reversible work running after cancellation or inactivity.

## Why This Change Was Made

Hosted channel setup now has one generic lifecycle across direct wizard RPCs and system-agent chat:

- cancellation and idle expiry abort reversible setup work;
- the durable-write boundary locks cancellation before persistent effects begin;
- reconnect-safe server-authenticated ownership recovers locked work without exposing it to another caller;
- canonical channel/account results remain owner-bound for a bounded recovery window;
- status polling is observational and does not consume retained completion data;
- system-agent reset, eviction, and inference failure preserve locked work while cleaning up reversible sessions.

The change stays server-side and transport-neutral. It does not change the Gateway wire schema, and existing CLI, TUI, and Control UI wizard callers continue using the same RPC contract.

## User Impact

Users can cancel or abandon channel setup safely before it starts writing, and they can reconnect to recover setup that crossed the persistent-write boundary. Completed channel/account results are not discarded by status polling. Connections without reconnect-safe identity cannot start hosted channel setup that they would be unable to recover.

There are no visible UI changes, so screenshots are not applicable.

## Evidence

- [Blacksmith Testbox run](https://github.com/openclaw/openclaw/actions/runs/30274811783)
- `pnpm check:changed` — passed formatting, policy guards, SDK contract generation, plugin boundaries, core/extension typechecks, and core/extension lint.
- Focused hosted-wizard suite — all six Vitest shards passed across wizard session, Gateway RPC/session ownership, channel setup/navigation, system-agent chat/TUI, commands, and Buzz setup coverage.
- `pnpm test src/gateway/gateway.test.ts -t "routes wizard.start flow channels"` — passed the real Gateway routing E2E.
- `pnpm build` — passed, including all 142 public plugin SDK subpaths and Control UI performance checks.
- `pnpm plugin-sdk:surface:check` — passed with zero forbidden package exports.
- Fresh isolated review of the final head found no actionable correctness issues; `git diff --check` passed.
