### PR TITLE
fix: recover plugin loads from ESM require races

### DIFF
--- a/src/plugins/native-module-require.test.ts
+++ b/src/plugins/native-module-require.test.ts
@@ -1,6 +1,7 @@
 /** Tests native module require behavior for plugin runtime loading. */
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
+import Module from "node:module";
 import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
@@ -8,7 +9,6 @@ import { afterEach, beforeAll, describe, expect, it } from "vitest";
 import {
   clearNativeRequireJavaScriptModuleCache,
   isJavaScriptModulePath,
-  isNativeRequireSourceTransformFallbackError,
   tryNativeRequireJavaScriptModule,
 } from "./native-module-require.js";
 
@@ -57,13 +57,26 @@ describe("tryNativeRequireJavaScriptModule", () => {
     });
   });
 
-  it("classifies an in-flight ESM require race for source-transform fallback", () => {
+  it("declines an in-flight ESM require race for source-transform fallback", () => {
     const modulePath = "/plugins/discord/dist/index.js";
     const error = Object.assign(new Error("ESM is still loading"), {
       code: "ERR_REQUIRE_ESM_RACE_CONDITION",
     });
+    const moduleWithLoad = Module as typeof Module & {
+      _load: (request: string, parent: NodeJS.Module | undefined, isMain: boolean) => unknown;
+    };
+    const originalLoad = moduleWithLoad._load;
+    moduleWithLoad._load = () => {
+      throw error;
+    };
 
-    expect(isNativeRequireSourceTransformFallbackError(error, modulePath)).toBe(true);
+    try {
+      expect(tryNativeRequireJavaScriptModule(modulePath, { allowWindows: true })).toEqual({
+        ok: false,
+      });
+    } finally {
+      moduleWithLoad._load = originalLoad;
+    }
   });
 
   it("declines missing target modules so callers can try source fallback", () => {

--- a/src/plugins/native-module-require.test.ts
+++ b/src/plugins/native-module-require.test.ts
@@ -8,6 +8,7 @@ import { afterEach, beforeAll, describe, expect, it } from "vitest";
 import {
   clearNativeRequireJavaScriptModuleCache,
   isJavaScriptModulePath,
+  isNativeRequireSourceTransformFallbackError,
   tryNativeRequireJavaScriptModule,
 } from "./native-module-require.js";
 
@@ -54,6 +55,15 @@ describe("tryNativeRequireJavaScriptModule", () => {
     expect(tryNativeRequireJavaScriptModule(modulePath, { allowWindows: true })).toEqual({
       ok: false,
     });
+  });
+
+  it("classifies an in-flight ESM require race for source-transform fallback", () => {
+    const modulePath = "/plugins/discord/dist/index.js";
+    const error = Object.assign(new Error("ESM is still loading"), {
+      code: "ERR_REQUIRE_ESM_RACE_CONDITION",
+    });
+
+    expect(isNativeRequireSourceTransformFallbackError(error, modulePath)).toBe(true);
   });
 
   it("declines missing target modules so callers can try source fallback", () => {

--- a/src/plugins/native-module-require.test.ts
+++ b/src/plugins/native-module-require.test.ts
@@ -62,20 +62,22 @@ describe("tryNativeRequireJavaScriptModule", () => {
     const error = Object.assign(new Error("ESM is still loading"), {
       code: "ERR_REQUIRE_ESM_RACE_CONDITION",
     });
-    const moduleWithLoad = Module as typeof Module & {
-      _load: (request: string, parent: NodeJS.Module | undefined, isMain: boolean) => unknown;
-    };
-    const originalLoad = moduleWithLoad._load;
-    moduleWithLoad._load = () => {
+    type ModuleLoad = (
+      request: string,
+      parent: NodeJS.Module | undefined,
+      isMain: boolean,
+    ) => unknown;
+    const originalLoad = Reflect.get(Module, "_load") as ModuleLoad;
+    Reflect.set(Module, "_load", () => {
       throw error;
-    };
+    });
 
     try {
       expect(tryNativeRequireJavaScriptModule(modulePath, { allowWindows: true })).toEqual({
         ok: false,
       });
     } finally {
-      moduleWithLoad._load = originalLoad;
+      Reflect.set(Module, "_load", originalLoad);
     }
   });
 

--- a/src/plugins/native-module-require.ts
+++ b/src/plugins/native-module-require.ts
@@ -44,7 +44,10 @@ function isMissingTargetModuleError(
   return firstLine.includes(`'${modulePath}'`) || firstLine.includes(`"${modulePath}"`);
 }
 
-function isSourceTransformFallbackError(error: unknown, modulePath: string): boolean {
+export function isNativeRequireSourceTransformFallbackError(
+  error: unknown,
+  modulePath: string,
+): boolean {
   if (!error || typeof error !== "object") {
     return false;
   }
@@ -53,6 +56,7 @@ function isSourceTransformFallbackError(error: unknown, modulePath: string): boo
   return (
     code === "ERR_REQUIRE_ESM" ||
     code === "ERR_REQUIRE_ASYNC_MODULE" ||
+    code === "ERR_REQUIRE_ESM_RACE_CONDITION" ||
     isMissingTargetModuleError(candidate, modulePath)
   );
 }
@@ -79,7 +83,7 @@ export function tryNativeRequireJavaScriptModule(
     const code =
       error && typeof error === "object" ? (error as { code?: unknown }).code : undefined;
     if (
-      isSourceTransformFallbackError(error, modulePath) ||
+      isNativeRequireSourceTransformFallbackError(error, modulePath) ||
       options.fallbackOnNativeError ||
       (options.fallbackOnMissingDependency === true &&
         (code === "MODULE_NOT_FOUND" || code === "ERR_MODULE_NOT_FOUND"))

--- a/src/plugins/native-module-require.ts
+++ b/src/plugins/native-module-require.ts
@@ -44,10 +44,7 @@ function isMissingTargetModuleError(
   return firstLine.includes(`'${modulePath}'`) || firstLine.includes(`"${modulePath}"`);
 }
 
-export function isNativeRequireSourceTransformFallbackError(
-  error: unknown,
-  modulePath: string,
-): boolean {
+function isSourceTransformFallbackError(error: unknown, modulePath: string): boolean {
   if (!error || typeof error !== "object") {
     return false;
   }
@@ -83,7 +80,7 @@ export function tryNativeRequireJavaScriptModule(
     const code =
       error && typeof error === "object" ? (error as { code?: unknown }).code : undefined;
     if (
-      isNativeRequireSourceTransformFallbackError(error, modulePath) ||
+      isSourceTransformFallbackError(error, modulePath) ||
       options.fallbackOnNativeError ||
       (options.fallbackOnMissingDependency === true &&
         (code === "MODULE_NOT_FOUND" || code === "ERR_MODULE_NOT_FOUND"))


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where an update-triggered Gateway restart could stay unhealthy when a plugin was dynamically imported while the runtime loader synchronously required the same ESM graph. Release Check run https://github.com/openclaw/openclaw/actions/runs/30276606376 reproduced this with Discord and Node's `ERR_REQUIRE_ESM_RACE_CONDITION`.

## Why This Change Was Made

The native plugin loader already falls back to the source-transform loader for ESM and async-module require failures. Node uses a separate error code when `require()` reaches a module graph that an `import()` is still loading, so this change classifies that code under the same fallback contract instead of treating it as a plugin evaluation error. Node documents the race and recommends serializing the competing load paths: https://github.com/nodejs/node/blob/v24.15.0/lib/internal/modules/esm/loader.js#L105-L118.

## User Impact

Gateway restarts during updates can recover from concurrent ESM plugin loading instead of leaving the service unhealthy with an activated-plugin load error.

## Evidence

- Release repro: `update-restart-auth` failed after Discord hit `ERR_REQUIRE_ESM_RACE_CONDITION`; the Gateway did not become healthy after restart.
- After-fix behavior proof: https://github.com/openclaw/openclaw/actions/runs/30279711469 passed `update-restart-auth`; package preparation, the update, automatic restart, plugin loading, and Gateway health all completed successfully.
- `node scripts/run-vitest.mjs src/plugins/native-module-require.test.ts src/plugins/plugin-module-loader-cache.test.ts` — 2 files and 32 tests passed.
- The new regression test drives Node's exact race error through the public native-require helper and verifies it declines to the existing source-transform fallback.
- `git diff --check` passed.
- Autoreview: clean, no accepted or actionable findings.

AI-assisted: yes. I traced the exact release artifact, inspected Node's loader contract, reviewed the plugin runtime load path, and verified the focused fix.
