### PR TITLE
fix(mattermost): finalized answer overwritten by end-of-turn verbose line

### DIFF
--- a/extensions/mattermost/src/mattermost/monitor-draft-delivery.ts
+++ b/extensions/mattermost/src/mattermost/monitor-draft-delivery.ts
@@ -45,6 +45,23 @@ export async function deliverMattermostReplyWithDraftPreview(
     return;
   }
 
+  const deliverNormally = async (payload: ReplyPayload) => {
+    const supplement = getReplyPayloadTtsSupplement(payload);
+    await params.deliverPayload(
+      supplement && !payload.text?.trim() && supplement.visibleTextAlreadyDelivered !== true
+        ? { ...payload, text: supplement.spokenText }
+        : payload,
+    );
+  };
+
+  // A draft post finalized in place is terminal: late final payloads (such as end-of-turn
+  // verbose plugin status lines) must not edit it again and overwrite the delivered answer.
+  // Route them to their own posts, matching the multi-chunk final behavior.
+  if (params.info.kind === "final" && params.previewState.finalizedViaPreviewPost) {
+    await deliverNormally(params.payload);
+    return;
+  }
+
   await deliverWithFinalizableLivePreviewAdapter({
     kind: params.info.kind,
     payload: params.payload,
@@ -104,13 +121,6 @@ export async function deliverMattermostReplyWithDraftPreview(
         );
       },
     }),
-    deliverNormally: async (payload) => {
-      const supplement = getReplyPayloadTtsSupplement(payload);
-      await params.deliverPayload(
-        supplement && !payload.text?.trim() && supplement.visibleTextAlreadyDelivered !== true
-          ? { ...payload, text: supplement.spokenText }
-          : payload,
-      );
-    },
+    deliverNormally,
   });
 }

--- a/extensions/mattermost/src/mattermost/monitor.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.test.ts
@@ -597,6 +597,48 @@ describe("deliverMattermostReplyWithDraftPreview", () => {
     expect(draftStream.clear).not.toHaveBeenCalled();
   });
 
+  it("keeps late verbose finals out of a preview post finalized in place", async () => {
+    const draftStream = createDraftStreamMock();
+    const deliverFinal = vi.fn(async () => {});
+    const previewState = { finalizedViaPreviewPost: false };
+    const sharedParams = {
+      info: { kind: "final" as const },
+      kind: "channel" as const,
+      client: createMattermostClientMock(),
+      draftStream,
+      effectiveReplyToId: "thread-root-1",
+      resolvePreviewFinalText: (text?: string) => text?.trim(),
+      previewState,
+      logVerboseMessage: vi.fn(),
+      deliverPayload: deliverFinal,
+    };
+
+    // The single-chunk answer finalizes in place by editing the draft preview post.
+    await deliverMattermostReplyWithDraftPreview({
+      payload: { text: "Final answer" } as never,
+      ...sharedParams,
+    });
+    expect(previewState.finalizedViaPreviewPost).toBe(true);
+    expect(updateMattermostPostSpy).toHaveBeenCalledWith(expect.anything(), "preview-post-1", {
+      message: "Final answer",
+    });
+
+    // A late verbose/plugin final (for example the end-of-turn Active Memory status line)
+    // must not edit the finalized post again; it is delivered as its own post instead.
+    await deliverMattermostReplyWithDraftPreview({
+      payload: { text: "\u{1F9E9} Active Memory: status=ok elapsed=4.2s query=recent" } as never,
+      ...sharedParams,
+    });
+
+    expect(updateMattermostPostSpy).toHaveBeenCalledTimes(1);
+    expect(deliverFinal).toHaveBeenCalledTimes(1);
+    expect(deliverFinal).toHaveBeenCalledWith({
+      text: "\u{1F9E9} Active Memory: status=ok elapsed=4.2s query=recent",
+    });
+    expect(draftStream.discardPending).not.toHaveBeenCalled();
+    expect(draftStream.clear).not.toHaveBeenCalled();
+  });
+
   it("keeps the existing preview unchanged when final delivery fails", async () => {
     const draftStream = createDraftStreamMock();
     const deliverFinal = vi.fn(async () => {


### PR DESCRIPTION
Closes #114589

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where Mattermost users with preview streaming (`streaming: "partial"` or `"progress"`) and agent `verboseDefault: "on"` would see the agent's final answer posted and then silently replaced by the end-of-turn `🧩 Active Memory` verbose status line, when the answer fit in a single text chunk. The turn reported success and the answer existed in the session transcript, but the visible post's terminal content was the verbose line — the answer was permanently lost from the channel with no log line recording the loss. Longer (multi-chunk) answers were unaffected because they bypass the finalize-in-place path entirely.

## Why This Change Was Made

The finalize-in-place path edits the shared draft preview post to deliver the answer, but the draft stream retains its post id after sealing, so a later final-kind payload — the trailing verbose plugin status payload emitted when verbose is on — ran through the same `buildFinalEdit`/`editFinal` path and edited the same post a second time, overwriting the answer. The fix treats a draft post that has been finalized in place as terminal: any subsequent final payload in the same turn is routed to normal delivery as its own post, which is exactly the behavior multi-chunk finals already exhibit (answer delivered, verbose line in a separate post). The change is scoped to the Mattermost draft-delivery path; no shared channel/plugin surfaces were modified.

A regression test covers the reported ordering: single-chunk answer finalized in place, followed by a verbose-style final payload — the preview post is edited exactly once (with the answer) and the verbose line is delivered as a separate normal payload without discarding or clearing the finalized post.

## User Impact

Mattermost users running agents with verbose output and preview streaming no longer lose concise final answers. The answer remains visible in the finalized post, and the verbose plugin status line (e.g. Active Memory) appears as its own separate post — the same behavior already observed for multi-chunk answers. No configuration change is required; streaming and verbose output both stay enabled.

## Evidence

- `pnpm test:extension mattermost` — 46 test files, 639 tests, all passing (includes the new regression test `keeps late verbose finals out of a preview post finalized in place`).
- Regression test verified red/green: it fails against the unmodified `monitor-draft-delivery.ts` (the verbose payload edits the finalized post a second time) and passes with the fix.
- `git diff --check` — clean.
- Only `extensions/mattermost` files were touched, so shared channel/plugin contract lanes were not applicable.

---

This PR was prepared with AI assistance (OpenClaw fix-worker agent). The change, test, and this description were generated by an AI coding agent and should be reviewed accordingly.
