### PR TITLE
fix(agent): honor explicit local timeout override

### DIFF
--- a/src/agents/command/attempt-execution.cli.test.ts
+++ b/src/agents/command/attempt-execution.cli.test.ts
@@ -259,6 +259,8 @@ describe("CLI attempt execution", () => {
     userTurnTranscriptRecorder?: RunAgentAttemptParams["userTurnTranscriptRecorder"];
     sessionEntry?: Partial<SessionEntry>;
     configuredAuthProfileId?: string;
+    timeoutMs?: number;
+    runTimeoutOverrideMs?: number;
   }) {
     const runId = overrides?.runId ?? "run-embedded-live-stream-gate";
     const sessionKey = `agent:main:direct:${runId}`;
@@ -291,7 +293,8 @@ describe("CLI attempt execution", () => {
       isFallbackRetry: overrides?.isFallbackRetry ?? false,
       fallbackRuntimeState: overrides?.fallbackRuntimeState,
       resolvedThinkLevel: "medium",
-      timeoutMs: 1_000,
+      timeoutMs: overrides?.timeoutMs ?? 1_000,
+      runTimeoutOverrideMs: overrides?.runTimeoutOverrideMs,
       runId,
       opts: {
         message: "stream gate",
@@ -346,6 +349,25 @@ describe("CLI attempt execution", () => {
     homeEnvSnapshot = undefined;
     closeOpenClawAgentDatabasesForTest();
     await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("forwards explicit local-agent timeouts while preserving the default when omitted", async () => {
+    const explicitTimeoutMs = 21_600_000;
+    const explicit = await runOpenClawEmbeddedAttemptForTest({
+      runId: "explicit-local-timeout",
+      timeoutMs: explicitTimeoutMs,
+      runTimeoutOverrideMs: explicitTimeoutMs,
+    });
+    expect(explicit.timeoutMs).toBe(explicitTimeoutMs);
+    expect(explicit.runTimeoutOverrideMs).toBe(explicitTimeoutMs);
+
+    const configuredDefaultMs = 600_000;
+    const inherited = await runOpenClawEmbeddedAttemptForTest({
+      runId: "inherited-local-timeout",
+      timeoutMs: configuredDefaultMs,
+    });
+    expect(inherited.timeoutMs).toBe(configuredDefaultMs);
+    expect(inherited.runTimeoutOverrideMs).toBeUndefined();
   });
 
   async function runClaudeCliAttempt(params: {

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -980,6 +980,7 @@ export function runAgentAttempt(params: {
     bashElevated: params.opts.bashElevated,
     approvalReviewerDeviceId: params.opts.approvalReviewerDeviceId,
     timeoutMs: params.timeoutMs,
+    runTimeoutOverrideMs: params.runTimeoutOverrideMs,
     runId: params.runId,
     lifecycleGeneration: params.lifecycleGeneration,
     lane: params.opts.lane,

--- a/src/commands/agent-via-gateway.test.ts
+++ b/src/commands/agent-via-gateway.test.ts
@@ -1803,6 +1803,44 @@ describe("agentCliCommand", () => {
     });
   });
 
+  it("forwards an explicit local timeout and leaves omission to the configured default", async () => {
+    await withTempStore(async () => {
+      mockLocalAgentReply();
+
+      await agentCliCommand(
+        {
+          message: "hi",
+          to: "+1555",
+          local: true,
+          timeout: "21600",
+        },
+        runtime,
+      );
+
+      expect(
+        requireRecord(requireFirstCallArg(agentCommand, "embedded agent"), "embedded agent options")
+          .timeout,
+      ).toBe("21600");
+
+      agentCommand.mockClear();
+      mockLocalAgentReply();
+
+      await agentCliCommand(
+        {
+          message: "hi",
+          to: "+1555",
+          local: true,
+        },
+        runtime,
+      );
+
+      expect(
+        requireRecord(requireFirstCallArg(agentCommand, "embedded agent"), "embedded agent options")
+          .timeout,
+      ).toBeUndefined();
+    });
+  });
+
   it("preserves inline message whitespace for local embedded runs", async () => {
     await withTempStore(async () => {
       mockLocalAgentReply();


### PR DESCRIPTION
## What Problem This Solves

Local `openclaw agent --local --timeout <seconds>` runs parsed the explicit timeout correctly, but `runAgentAttempt` dropped `runTimeoutOverrideMs` before invoking the embedded agent runtime. The embedded Codex app-server therefore retained its 30-minute terminal-idle watchdog and killed legitimate long-running local agent work despite a larger explicit timeout.

## Summary

- forward the parsed local-agent timeout override into embedded run parameters
- preserve existing behavior when `--timeout` is omitted so configured defaults remain authoritative
- add CLI and embedded-attempt regression coverage for explicit and omitted timeouts

## Evidence

- Run 763 recorded `turn.terminal_idle_timeout` with `timeoutMs: 1800000` even though the delegated command supplied `--timeout 21600`
- focused regression suite passed: 213 tests passed, 1 skipped
- explicit `21,600,000ms` propagation and omitted-override behavior are both covered
- `pnpm tsgo:core` passed
- `pnpm tsgo:test:src` passed
- targeted Oxlint/Oxfmt and `git diff --check` passed

## Safety

No Gateway configuration, restart, deployment, production retry, cron change, or T-5888 state mutation was performed.

## Maintainer-verified real behavior proof

- **Behavior or issue addressed:** The real local agent command must forward an explicit `--timeout 2700` to the embedded native Codex runtime so its actual terminal-idle watchdog is 45 minutes, not the implicit 30-minute fallback.
- **Real environment tested:** Isolated Blacksmith Testbox; exact original contributor head `6eccc6708753a41ab649cfa24dd0b42e0a0be0e2`; real built OpenClaw user CLI; the bundled native `codex-cli 0.145.0` app-server; a genuine localhost HTTP OpenAI Responses SSE server requiring an ephemeral synthetic bearer token; isolated Codex agent home.
- **Exact steps or command run after this patch:** Ran `OPENCLAW_FORCE_BUILD=1 pnpm --silent openclaw agent --local --agent main --model openai/gpt-5.6-sol --message 'Reply with exactly CODEX_TIMEOUT_E2E_OK and no other text.' --thinking low --timeout 2700 --json` twice against the actual native app-server and authenticated localhost Responses endpoint. For the negative control, temporarily reverse-applied only the contributor's one-line production diff; for the positive control, restored the exact original contributor source and force-rebuilt again. A passive Node preload recorded the actual plugin-owned `fireTerminalIdleTimeout` callback without waiting for its timer to expire.
- **Evidence after fix:** Both real commands returned `CODEX_TIMEOUT_E2E_OK`; the synthetic Responses endpoint authenticated and served exactly two real HTTP requests. The actual native Codex terminal watchdog was `1,799,993ms` before the fix and `2,699,993ms` after it. The isolated E2E returned exit code 0 and restored the exact original contributor head with no tracked changes.
- **Focused changed-surface and sibling validation:** All 502 tests passed across the original CLI and gateway regressions, agent-attempt siblings, and real Codex runtime owner tests: `src/agents/command/attempt-execution.cli.test.ts`, `src/agents/command/attempt-execution.test.ts`, `src/agents/command/attempt-execution.error-propagation.test.ts`, `src/commands/agent-via-gateway.test.ts`, `src/commands/agent.test.ts`, `src/agents/subagent-depth.test.ts`, `extensions/codex/src/app-server/attempt-timeouts.test.ts`, `extensions/codex/src/app-server/run-attempt.turn-watches.test.ts`, and `extensions/codex/src/app-server/run-attempt.test.ts`. The exact original full diff also passed a fresh xhigh Codex autoreview with no actionable findings.
- **Upstream contract checked directly:** Codex upstream `07490c75234ed3c63291a8eb7629f04f647038fa`, `codex-rs/app-server-protocol/src/protocol/v2/turn.rs`, `codex-rs/app-server/src/request_processors/turn_processor.rs`, and the exact Responses mock contract in `codex-rs/core/tests/common/responses.rs` and `codex-rs/core/tests/suite/cli_stream.rs`. Native Codex has no conflicting turn-timeout field; the terminal watchdog is correctly owned by OpenClaw's Codex plugin.
- **Observed result after fix:** Explicit timeouts reach the real embedded Codex terminal watchdog; omitted timeouts retain their existing implicit default. No config, plugin, provider, protocol, or dependency surface is added.
- **What was not tested:** A live OpenAI provider or account. The provider transport in this end-to-end proof is an authenticated deterministic localhost Responses server, not a live OpenAI API call.
