### PR TITLE
[AI-assisted] docs(typebox): fix broken live-schema JSON link to gitignored dist file

### DIFF
--- a/docs/concepts/typebox.md
+++ b/docs/concepts/typebox.md
@@ -266,9 +266,7 @@ Unknown frame types are preserved as raw payloads for forward compatibility.
 
 ## Live schema JSON
 
-Generated JSON Schema is a build artifact, not committed to the repo. The published raw file is typically available at:
-
-- [https://raw.githubusercontent.com/openclaw/openclaw/main/dist/protocol.schema.json](https://raw.githubusercontent.com/openclaw/openclaw/main/dist/protocol.schema.json)
+Generated JSON Schema is a build artifact, not committed to the repo, so there is no `raw.githubusercontent.com/openclaw/openclaw/main/dist/protocol.schema.json` URL for it (that path is [gitignored](https://github.com/openclaw/openclaw/blob/main/.gitignore)). Generate it locally with `pnpm protocol:gen` (see [Current pipeline](#current-pipeline)); the same file also ships at the root of the published `@openclaw/gateway-protocol` npm package via its `prepack` step.
 
 ## When you change schemas
 


### PR DESCRIPTION
[AI-assisted]

## What Problem This Solves

The "Live schema JSON" section of `docs/concepts/typebox.md` linked to a file that does not exist in the repository:

`https://raw.githubusercontent.com/openclaw/openclaw/main/dist/protocol.schema.json` → **404**

`dist/protocol.schema.json` is a generated build artifact that is explicitly gitignored, so the `raw.githubusercontent.com` URL can never resolve. The surrounding prose even contradicted itself — it stated the file is *"not committed to the repo"* and then linked to it at a repo path. Readers following the link hit a 404 with no indication of where the schema actually lives.

## Triage / Root cause

The schema is generated by `pnpm protocol:gen` and excluded from git:

- `dist/protocol.schema.json` is listed in [`.gitignore`](https://github.com/openclaw/openclaw/blob/main/.gitignore) (`# Generated protocol schema (produced via pnpm protocol:gen)`).
- `git show upstream/main:dist/protocol.schema.json` fails — the file is absent on `main`.
- The doc's own "Current pipeline" section (line 59) already notes `pnpm protocol:gen` writes to `dist/protocol.schema.json` and that *"the JSON Schema output is a gitignored build artifact."*

So the link targeted a path that, by design, is never in the repo.

## Fix

Replaced the dead link with an accurate pointer that matches the doc's own description:

- Generate the schema locally with `pnpm protocol:gen` (links to the existing `Current pipeline` section).
- Noted that the same file ships at the root of the published `@openclaw/gateway-protocol` npm package via its `prepack` step — that is the real published location, not the git repo.

Net change: one paragraph replaces a 404 bullet (1 insertion, 3 deletions). No new external URLs are introduced (the only added link is an in-page anchor plus a link to the repo's own `.gitignore`).

## Evidence

- Broken link (deterministic 404):
  ```
  $ curl -s -o /dev/null -L -w "%{http_code}\n" \
      https://raw.githubusercontent.com/openclaw/openclaw/main/dist/protocol.schema.json
  404
  ```
- File is gitignored and absent on `main`:
  ```
  $ git show upstream/main:dist/protocol.schema.json   # exits non-zero, file absent
  $ git show upstream/main:.gitignore | grep protocol.schema.json
  dist/protocol.schema.json
  packages/gateway-protocol/protocol.schema.json
  ```
- Real published location — the npm package ships it at its root via `prepack`:
  ```
  $ git show upstream/main:packages/gateway-protocol/package.json
  version: 2026.7.2
  files: ['dist', 'LICENSE', 'README.md', 'CHANGELOG.md', 'protocol.schema.json']
  "prepack": "pnpm run build && node --import tsx ../../scripts/protocol-gen.ts --out ./protocol.schema.json"

  $ curl -s -o /dev/null -L -w "%{http_code}\n" \
      https://unpkg.com/@openclaw/gateway-protocol@2026.7.2-beta.4/protocol.schema.json
  200
  ```
  Content-verified as valid draft-07 JSON Schema (`"$schema": "http://json-schema.org/draft-07/schema#"`, `"title": "OpenClaw Gateway Protocol"`).

## Notes / Risks

- Docs-only change to a single concept doc; no runtime, config, or protocol behavior touched.
- I deliberately did **not** pin a versioned `unpkg`/`jsdelivr` file URL in the doc body, because the package is currently published only as a beta (`2026.7.2-beta.4`; the `latest` tag still points at `0.0.0`, so a versionless unpkg URL 404s today). Naming the package in prose is evergreen and won't drift on the next release.
- Checked for duplicate/overlapping PRs: none target this section (searched `protocol.schema.json` and `typebox` against open + closed PRs).
- Self-sourced docs-correctness fix; different file/class than my open provider/tools link PRs.

— Santhi Prakash (AI-assisted draft; verified the broken link, gitignore entry, and npm package contents directly)
