### PR TITLE
fix(agents): duplicate reply when delivered primary attempt throws and fallback re-runs the turn

### DIFF
--- a/src/agents/embedded-agent-runner/run-entry.test.ts
+++ b/src/agents/embedded-agent-runner/run-entry.test.ts
@@ -22,6 +22,13 @@ type FallbackRunnerParams = {
     attempt: number;
     total: number;
   }) => unknown;
+  canFallbackAfterError?: (params: {
+    provider: string;
+    model: string;
+    error: unknown;
+    attempt: number;
+    total: number;
+  }) => boolean | Promise<boolean>;
   mergeExhaustedResult?: (params: {
     latestResult: EmbeddedAgentRunResult;
     preferredResult: EmbeddedAgentRunResult;
@@ -215,6 +222,116 @@ describe("runEmbeddedAgentEntry", () => {
     });
 
     expect(result.result.payloads).toEqual([{ text: "recovered" }]);
+  });
+
+  it("does not replay a thrown channel-delivery attempt that already delivered its reply (#113788)", async () => {
+    const failure = new Error("insufficient quota");
+    state.runWithModelFallback.mockImplementationOnce(async (params: FallbackRunnerParams) => {
+      // Mirror the fallback loop's thrown-error exit: the attempt error bypasses
+      // result classification, so the error-path backstop is the only guard that
+      // can stop the next candidate from replaying the delivered turn.
+      await expect(params.run(params.provider, params.model)).rejects.toBe(failure);
+      const allowed = await params.canFallbackAfterError?.({
+        provider: params.provider,
+        model: params.model,
+        error: failure,
+        attempt: 1,
+        total: 2,
+      });
+      expect(allowed).toBe(false);
+      throw failure;
+    });
+    const { runEmbeddedAgentEntry } = await import("./run-entry.js");
+    const runCandidate = vi.fn(async (_provider: string, _model: string) => {
+      throw failure;
+    });
+
+    await expect(
+      runEmbeddedAgentEntry({
+        selection: { cfg: {}, provider: "primary-provider", model: "primary-model" },
+        identity: { runId: "channel-throw", agentId: "main", sessionId: "session-1" },
+        harness: {
+          workspaceDir: "/tmp/workspace",
+          preparation: { kind: "direct" },
+          resolveRuntimeOverride: () => undefined,
+        },
+        behavior: {
+          kind: "channel-delivery",
+          readDeliveryEvidence: () => ({
+            hasDirectlySentBlockReply: true,
+            hasBlockReplyPipelineOutput: false,
+          }),
+        },
+        sessionOverride: { kind: "preserve" },
+        runCandidate,
+      }),
+    ).rejects.toBe(failure);
+
+    expect(runCandidate).toHaveBeenCalledTimes(1);
+  });
+
+  it("still falls back when a thrown channel-delivery attempt delivered nothing", async () => {
+    const failure = new Error("insufficient quota");
+    state.runWithModelFallback.mockImplementationOnce(async (params: FallbackRunnerParams) => {
+      await expect(params.run(params.provider, params.model)).rejects.toBe(failure);
+      const allowed = await params.canFallbackAfterError?.({
+        provider: params.provider,
+        model: params.model,
+        error: failure,
+        attempt: 1,
+        total: 2,
+      });
+      expect(allowed).toBe(true);
+      const fallbackProvider = "fallback-provider";
+      const fallbackModel = "fallback-model";
+      const result = await params.run(fallbackProvider, fallbackModel, {
+        isFinalFallbackAttempt: true,
+      });
+      return {
+        outcome: "completed" as const,
+        result,
+        provider: fallbackProvider,
+        model: fallbackModel,
+        attempts: [
+          {
+            provider: params.provider,
+            model: params.model,
+            error: failure.message,
+            reason: "billing" as const,
+          },
+        ],
+      };
+    });
+    const { runEmbeddedAgentEntry } = await import("./run-entry.js");
+    const runCandidate = vi.fn(async (provider: string, model: string) => {
+      if (provider === "primary-provider") {
+        throw failure;
+      }
+      return makeResult({ provider, model });
+    });
+
+    const result = await runEmbeddedAgentEntry({
+      selection: { cfg: {}, provider: "primary-provider", model: "primary-model" },
+      identity: { runId: "channel-throw-empty", agentId: "main", sessionId: "session-1" },
+      harness: {
+        workspaceDir: "/tmp/workspace",
+        preparation: { kind: "direct" },
+        resolveRuntimeOverride: () => undefined,
+      },
+      behavior: {
+        kind: "channel-delivery",
+        readDeliveryEvidence: () => ({
+          hasDirectlySentBlockReply: false,
+          hasBlockReplyPipelineOutput: false,
+        }),
+      },
+      sessionOverride: { kind: "preserve" },
+      runCandidate,
+    });
+
+    expect(runCandidate).toHaveBeenCalledTimes(2);
+    expect(result.outcome).toBe("completed");
+    expect(result.provider).toBe("fallback-provider");
   });
 
   it("retains non-visible follow-up results for terminal delivery", async () => {

--- a/src/agents/embedded-agent-runner/run-entry.ts
+++ b/src/agents/embedded-agent-runner/run-entry.ts
@@ -195,6 +195,21 @@ export async function runEmbeddedAgentEntry<T extends EmbeddedAgentRunResult>(
   let candidateIndex = 0;
   const committedSideEffect =
     params.behavior.kind === "command-rpc" ? params.behavior.hasCommittedSideEffect : undefined;
+  const readChannelDeliveryEvidence =
+    params.behavior.kind === "channel-delivery" ? params.behavior.readDeliveryEvidence : undefined;
+  // Thrown candidate errors skip result classification, so without an error-path
+  // backstop the loop advances to the next candidate even when the attempt already
+  // delivered its reply, producing a duplicate visible answer (#113788). Consult the
+  // same live delivery evidence the result classifier already uses so both exit
+  // paths suppress fallback after a delivered reply.
+  const canFallbackAfterError = committedSideEffect
+    ? () => !committedSideEffect()
+    : readChannelDeliveryEvidence
+      ? () => {
+          const evidence = readChannelDeliveryEvidence();
+          return !evidence.hasDirectlySentBlockReply && !evidence.hasBlockReplyPipelineOutput;
+        }
+      : undefined;
   const fallbackResult = await runWithModelFallback<T>({
     ...params.selection,
     ...params.identity,
@@ -250,7 +265,7 @@ export async function runEmbeddedAgentEntry<T extends EmbeddedAgentRunResult>(
               : effectiveClassification;
           },
         }),
-    ...(committedSideEffect ? { canFallbackAfterError: () => !committedSideEffect() } : {}),
+    ...(canFallbackAfterError ? { canFallbackAfterError } : {}),
     ...(params.behavior.kind === "maintenance"
       ? {}
       : {


### PR DESCRIPTION
Closes #113788

## What Problem This Solves

Fixes an issue where users with a primary model plus a fallback model configured would receive **two near-duplicate replies to a single message** when the primary attempt delivered its answer but then surfaced its failure as a thrown error (for example, a proxy billing/quota error returned mid-turn as an HTTP exception). The fallback loop re-ran the same turn on the next candidate and delivered a second copy of the answer.

## Why This Change Was Made

The fallback loop has two exit paths per attempt. When a candidate returns normally, result classification applies the delivery guards and correctly suppresses fallback after a delivered reply. When a candidate **throws**, classification is skipped entirely and only the `canFallbackAfterError` hook can stop the loop — but that hook was only wired for `command-rpc` behaviors, never for `channel-delivery`. This change supplies the existing hook for `channel-delivery`, reading the same live delivery evidence (`hasDirectlySentBlockReply` / `hasBlockReplyPipelineOutput`) that the result classifier already consults, so both exit paths now suppress fallback once a reply has been delivered. Attempts that delivered nothing still fall back normally, and `command-rpc` behavior is unchanged.

Note on `clawsweeper:needs-product-decision`: this PR deliberately takes only the mechanical direction (suggested fix direction 1 in the issue). The throw path has no result object to inspect — the run threw — so the guard reads live delivery state, matching what the returned-result path already consults. This is the conservative choice: it stops duplicate replies after a delivered answer without changing any semantics for returned results, and it does not decide the open terminal-delivery vs. any-outbound-side-effect question (direction 2), which maintainers can adjust in review or as part of the broader delivery-evidence contract discussion.

## User Impact

Users on a primary + fallback model setup will no longer see a duplicate reply when the primary model delivers its answer but then fails with a thrown provider error. Recovery after a primary that delivered nothing is unaffected — fallback still runs as before.

## Evidence

- New regression tests in `src/agents/embedded-agent-runner/run-entry.test.ts`:
  - A thrown channel-delivery attempt whose delivery evidence shows a sent reply is **not** replayed on a second candidate (`canFallbackAfterError` returns false and the loop stops).
  - A thrown channel-delivery attempt that delivered nothing **still falls back** to the next candidate (negative control).
- `vitest run src/agents/embedded-agent-runner/run-entry.test.ts` — 10/10 tests pass (5 tests across both vitest projects).
- `oxlint` on the touched files — 0 warnings, 0 errors.

---

AI-assisted: this change was implemented with AI assistance.
