### PR TITLE
test: lock in provider timeoutSeconds on static catalog fallback model resolution

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3219,7 +3219,6 @@ src/infra/delivery-queue-sqlite-namespace.ts	3
 src/infra/delivery-queue-sqlite.ts	4
 src/infra/delivery-queue-sqlite.types.ts	1
 src/infra/delivery-recovery.shared.ts	4
-src/infra/device-identity-store.ts	1
 src/infra/device-identity.ts	1
 src/infra/device-pairing-store.ts	6
 src/infra/diagnostic-event-listener-presence.ts	3

--- a/src/agents/embedded-agent-runner/model.test.ts
+++ b/src/agents/embedded-agent-runner/model.test.ts
@@ -2563,6 +2563,60 @@ describe("resolveModel", () => {
     );
   });
 
+  it("applies provider-level timeoutSeconds to bundled static catalog fallback models", async () => {
+    // Channel sessions allow the bundled static catalog fallback during model
+    // resolution, so a provider-only `timeoutSeconds` overlay must survive that
+    // path to raise the LLM idle watchdog above the 120s default (#107713).
+    const cfg = {
+      models: {
+        providers: {
+          openai: {
+            timeoutSeconds: 600,
+          },
+        },
+      },
+    } satisfies OpenClawConfigInput;
+    resolveBundledStaticCatalogModelMock.mockReturnValueOnce({
+      provider: "openai",
+      id: "gpt-5.5",
+      name: "GPT-5.5",
+      api: "openai-responses",
+      baseUrl: "https://api.openai.com/v1",
+      reasoning: true,
+      input: ["text"],
+      cost: { input: 1.5, output: 12, cacheRead: 0.15, cacheWrite: 0 },
+      contextWindow: 400_000,
+      maxTokens: 128_000,
+    });
+    const baseRuntimeHooks = createRuntimeHooks();
+    const prepareProviderDynamicModel = vi.fn(baseRuntimeHooks.prepareProviderDynamicModel);
+    const runProviderDynamicModel = vi.fn(() => undefined);
+
+    const result = await resolveModelAsyncForTest(
+      "openai",
+      "gpt-5.5",
+      "/tmp/agent",
+      cfg as unknown as OpenClawConfig,
+      {
+        allowBundledStaticCatalogFallback: true,
+        runtimeHooks: {
+          ...baseRuntimeHooks,
+          prepareProviderDynamicModel,
+          runProviderDynamicModel,
+        },
+        skipAgentDiscovery: true,
+      },
+    );
+
+    expect(result.error).toBeUndefined();
+    // Prove the model actually came from the bundled static catalog fallback
+    // (not a provider-runtime or configured-fallback resolution).
+    expect(resolveBundledStaticCatalogModelMock).toHaveBeenCalled();
+    expect((result.model as { requestTimeoutMs?: number } | undefined)?.requestTimeoutMs).toBe(
+      600_000,
+    );
+  });
+
   it("uses per-model context config over discovered metadata", () => {
     mockMinimalModelDiscovery("ollama", "qwen3.5:9b", {
       contextWindow: 216_000,


### PR DESCRIPTION
Closes #107713

## What Problem This Solves

Fixes an issue where users who set `models.providers.<id>.timeoutSeconds` (for example 600s for a slow provider) would still see channel (Slack) session turns aborted by the 120-second LLM idle watchdog when the model resolved through the bundled static catalog — while CLI/default sessions honored the configured timeout.

## Why This Change Was Made

The propagation itself is already correct on current `main`: the resolver passes static-catalog-fallback models through `applyConfiguredProviderOverrides`, which derives `requestTimeoutMs` from the configured provider `timeoutSeconds` and attaches it even without an inline `models[]` entry; the idle watchdog (`resolveLlmIdleTimeoutMs`) then honors `modelRequestTimeoutMs` as an explicit ceiling for non-cron runs. What was missing — as called out in the ClawSweeper review on the issue — is focused regression proof for this path. This PR adds that proof rather than duplicating an already-shipped fix: a resolver test that runs the bundled static catalog fallback path with a provider-only `timeoutSeconds` overlay and asserts the resolved model carries `requestTimeoutMs`, plus an assertion that the static catalog lookup was actually exercised.

## User Impact

Users can rely on provider-level `timeoutSeconds` raising the idle watchdog for all non-cron runs of that provider's models — including channel sessions resolved via the bundled static catalog — and this behavior is now locked in by a regression test so future resolver refactors cannot silently drop it again. No behavior change in this PR; test-only.

## Evidence

Focused test passes on both vitest projects:

```
 ✓  agents-core  ../../src/agents/embedded-agent-runner/model.test.ts (147 tests) 
     ✓ applies provider-level timeoutSeconds to bundled static catalog fallback models  1242ms
 ✓  agents-embedded-agent  ../../src/agents/embedded-agent-runner/model.test.ts (147 tests)
     ✓ applies provider-level timeoutSeconds to bundled static catalog fallback models  1245ms

 Test Files  2 passed (2)
      Tests  294 passed (294)
```

Negative verification (test genuinely guards the behavior): with the `requestTimeoutMs` attach in `applyConfiguredProviderOverrides` (`src/agents/embedded-agent-runner/model.configured-overrides.ts`) temporarily removed, the new test fails with `requestTimeoutMs: undefined`; restored, it passes.

Provenance: the propagation reached `main` via 0bc11c4da0 ("refactor(agents): split embedded model resolution", first contained in tag `v2026.7.2-beta.5`); the idle-watchdog contract was established earlier in #83979.

## Real behavior proof

### Regression test: provider timeoutSeconds propagates through static catalog fallback

The new test `applies provider-level timeoutSeconds to bundled static catalog fallback models` configures a provider-only `timeoutSeconds: 600` overlay (no inline `models[]` entry), forces resolution through the bundled static catalog fallback path, and asserts the resolved model carries `requestTimeoutMs: 600_000`.

**Test source** (`src/agents/embedded-agent-runner/model.test.ts`, added in this PR):

```ts
it("applies provider-level timeoutSeconds to bundled static catalog fallback models", async () => {
    const cfg = {
      models: {
        providers: {
          openai: {
            timeoutSeconds: 600,   // <-- provider-only overlay, no models[] entry
          },
        },
      },
    } satisfies OpenClawConfigInput;
    resolveBundledStaticCatalogModelMock.mockReturnValueOnce({
      provider: "openai",
      id: "gpt-5.5",
      // ... static catalog row data
    });
    // ... resolve through async path with allowBundledStaticCatalogFallback: true

    expect(result.error).toBeUndefined();
    // Prove the model actually came from the bundled static catalog fallback
    expect(resolveBundledStaticCatalogModelMock).toHaveBeenCalled();
    // Prove timeoutSeconds propagated to requestTimeoutMs
    expect((result.model as { requestTimeoutMs?: number } | undefined)?.requestTimeoutMs).toBe(
      600_000,
    );
  });
```

**Positive run** (both vitest projects pass):

```
 ✓  agents-core  ... > resolveModel > applies provider-level timeoutSeconds to bundled static catalog fallback models  399ms
 ✓  agents-embedded-agent  ... > resolveModel > applies provider-level timeoutSeconds to bundled static catalog fallback models  527ms

 Test Files  2 passed (2)
      Tests  302 passed (302)
   Duration  108.37s
```

**Negative verification** (test genuinely guards the behavior):

With the `requestTimeoutMs` attach in `applyConfiguredProviderOverrides` (`src/agents/embedded-agent-runner/model.configured-overrides.ts:605`) temporarily removed:

```
 FAIL  agents-core  ... > resolveModel > applies provider-level timeoutSeconds to bundled static catalog fallback models
 AssertionError: expected undefined to be 600000 // Object.is equality

 - Expected:
 600000

 + Received:
 undefined
```

Restored → all 302 tests pass again. The test would catch any regression that drops `timeoutSeconds` propagation through the static catalog fallback path.

---

AI-assisted change (OpenClaw fix worker); reviewed and verified by running the focused suite locally.

