### PR TITLE
fix(ui): keep case-distinct channel sessions isolated

### DIFF
--- a/ui/src/lib/sessions/session-key.test.ts
+++ b/ui/src/lib/sessions/session-key.test.ts
@@ -1,0 +1,57 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+import { canonicalUiSessionKeyForPersistence, uiSessionEventMatches } from "./session-key.ts";
+
+describe("UI session identity", () => {
+  it.each([
+    {
+      name: "Matrix room IDs",
+      selectedKey: "agent:ops:matrix:channel:!Room:Example.Org",
+      structuralAlias: "Agent:Ops:Matrix:Channel:!Room:Example.Org",
+      distinctKey: "agent:ops:matrix:channel:!room:example.org",
+    },
+    {
+      name: "Matrix room and thread IDs",
+      selectedKey: "agent:ops:matrix:channel:!Room:Example.Org:thread:$Event",
+      structuralAlias: "Agent:Ops:Matrix:Channel:!Room:Example.Org:Thread:$Event",
+      distinctKey: "agent:ops:matrix:channel:!Room:Example.Org:thread:$event",
+    },
+    {
+      name: "Signal group IDs",
+      selectedKey: "agent:ops:signal:group:AbC123=",
+      structuralAlias: "Agent:Ops:Signal:Group:AbC123=",
+      distinctKey: "agent:ops:signal:group:abc123=",
+    },
+    {
+      name: "Signal group IDs with normalized thread suffixes",
+      selectedKey: "agent:ops:signal:group:AbC123=:thread:xyz",
+      structuralAlias: "Agent:Ops:Signal:Group:AbC123=:Thread:XyZ",
+      distinctKey: "agent:ops:signal:group:abc123=:thread:xyz",
+    },
+  ])(
+    "preserves $name in live events and persisted session identity",
+    ({ selectedKey, structuralAlias, distinctKey }) => {
+      const host = {
+        agentsList: { defaultId: "ops", mainKey: "home" },
+        sessionKey: selectedKey,
+      };
+
+      expect(uiSessionEventMatches(host, structuralAlias)).toBe(true);
+      expect(uiSessionEventMatches(host, distinctKey)).toBe(false);
+      expect(canonicalUiSessionKeyForPersistence(host, structuralAlias)).toBe(selectedKey);
+      expect(canonicalUiSessionKeyForPersistence(host, distinctKey)).toBe(distinctKey);
+    },
+  );
+
+  it("retains configured main-session aliases for events and persisted identity", () => {
+    const host = {
+      agentsList: { defaultId: "ops", mainKey: "home" },
+      sessionKey: "agent:ops:home",
+    };
+
+    expect(uiSessionEventMatches(host, "main")).toBe(true);
+    expect(uiSessionEventMatches(host, "agent:ops:main")).toBe(true);
+    expect(canonicalUiSessionKeyForPersistence(host, "main")).toBe("agent:ops:home");
+    expect(canonicalUiSessionKeyForPersistence(host, "agent:ops:main")).toBe("agent:ops:home");
+  });
+});

--- a/ui/src/lib/sessions/session-key.ts
+++ b/ui/src/lib/sessions/session-key.ts
@@ -224,10 +224,10 @@ function normalizeUiSessionEventKey(
       buildAgentMainSessionKey({ agentId: defaultAgentId, mainKey }),
     ]
       .filter((value): value is string => Boolean(value))
-      .map(normalizeLowercaseStringOrEmpty),
+      .map(normalizeSessionKeyForUiComparison),
   );
-  const normalized = normalizeLowercaseStringOrEmpty(raw);
-  return aliases.has(normalized) ? normalizeLowercaseStringOrEmpty(canonicalMain) : normalized;
+  const normalized = normalizeSessionKeyForUiComparison(raw);
+  return aliases.has(normalized) ? normalizeSessionKeyForUiComparison(canonicalMain) : normalized;
 }
 
 export function canonicalUiSessionKeyForPersistence(

--- a/ui/src/pages/chat/session-message-cache.test.ts
+++ b/ui/src/pages/chat/session-message-cache.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   appendChatMessageToCache,
   cacheChatSessionSnapshot,
+  clearChatMessagesFromCache,
   readChatMessagesFromCache,
   readChatSessionSnapshot,
   type ChatMessageCache,
@@ -43,6 +44,67 @@ describe("session message cache", () => {
     ]);
     expect(readChatMessagesFromCache(cache, host, { sessionKey: "agent:main:home" })).toEqual([]);
   });
+
+  it.each([
+    {
+      name: "Matrix room IDs",
+      sessionKey: "Agent:Ops:Matrix:Channel:!Room:Example.Org",
+      canonicalKey: "agent:ops:matrix:channel:!Room:Example.Org",
+      distinctKey: "agent:ops:matrix:channel:!room:example.org",
+    },
+    {
+      name: "Matrix room and thread IDs",
+      sessionKey: "Agent:Ops:Matrix:Channel:!Room:Example.Org:Thread:$Event",
+      canonicalKey: "agent:ops:matrix:channel:!Room:Example.Org:thread:$Event",
+      distinctKey: "agent:ops:matrix:channel:!Room:Example.Org:thread:$event",
+    },
+    {
+      name: "Signal group IDs",
+      sessionKey: "Agent:Ops:Signal:Group:AbC123=",
+      canonicalKey: "agent:ops:signal:group:AbC123=",
+      distinctKey: "agent:ops:signal:group:abc123=",
+    },
+    {
+      name: "Signal group IDs with a normalized thread suffix",
+      sessionKey: "Agent:Ops:Signal:Group:AbC123=:Thread:XyZ",
+      canonicalKey: "agent:ops:signal:group:AbC123=:thread:xyz",
+      distinctKey: "agent:ops:signal:group:abc123=:thread:xyz",
+    },
+  ])(
+    "keeps case-distinct $name in separate transcript caches",
+    ({ sessionKey, canonicalKey, distinctKey }) => {
+      const host = createHost();
+      const cache: ChatMessageCache = new Map();
+
+      cacheChatMessages(cache, host, { sessionKey }, ["first session"]);
+      cacheChatMessages(cache, host, { sessionKey: distinctKey }, ["second session"]);
+
+      expect(readChatMessagesFromCache(cache, host, { sessionKey: canonicalKey })).toEqual([
+        "first session",
+      ]);
+      expect(readChatMessagesFromCache(cache, host, { sessionKey: distinctKey })).toEqual([
+        "second session",
+      ]);
+
+      appendChatMessageToCache(cache, host, { sessionKey: canonicalKey }, "first session update");
+
+      expect(readChatMessagesFromCache(cache, host, { sessionKey })).toEqual([
+        "first session",
+        "first session update",
+      ]);
+      expect(readChatMessagesFromCache(cache, host, { sessionKey: distinctKey })).toEqual([
+        "second session",
+      ]);
+
+      clearChatMessagesFromCache(cache, host, { sessionKey: distinctKey });
+
+      expect(readChatMessagesFromCache(cache, host, { sessionKey })).toEqual([
+        "first session",
+        "first session update",
+      ]);
+      expect(readChatMessagesFromCache(cache, host, { sessionKey: distinctKey })).toEqual([]);
+    },
+  );
 
   it("uses explicit event agent identity for global cache targets", () => {
     const host = {

--- a/ui/src/pages/chat/session-message-cache.ts
+++ b/ui/src/pages/chat/session-message-cache.ts
@@ -3,13 +3,13 @@ import {
   DEFAULT_MAIN_KEY,
   isUiGlobalSessionKey,
   normalizeAgentId,
+  normalizeSessionKeyForUiComparison,
   parseAgentSessionKey,
   resolveUiConfiguredMainKey,
   resolveUiDefaultAgentId,
   resolveUiSelectedGlobalAgentId,
   type UiSessionDefaultsHost,
 } from "../../lib/sessions/session-key.ts";
-import { normalizeLowercaseStringOrEmpty } from "../../lib/string-coerce.ts";
 import type { ChatHistoryPagination } from "./chat-history-pagination.ts";
 import { readTranscriptSequence } from "./history-merge.ts";
 import { getSessionCacheValue, setSessionCacheValue } from "./session-cache.ts";
@@ -64,8 +64,11 @@ function resolveCacheAgentId(host: ChatMessageCacheHost, target: ChatMessageCach
 }
 
 function resolveCanonicalSessionKey(host: ChatMessageCacheHost, sessionKey: string): string {
-  const parsed = parseAgentSessionKey(sessionKey);
-  const normalized = normalizeLowercaseStringOrEmpty(parsed?.rest ?? sessionKey);
+  const normalizedSessionKey = normalizeSessionKeyForUiComparison(sessionKey);
+  const parsed = parseAgentSessionKey(normalizedSessionKey);
+  const normalized = parsed
+    ? normalizedSessionKey.split(":").slice(2).join(":")
+    : normalizedSessionKey;
   const configuredMainKey = resolveUiConfiguredMainKey(host);
   return isUiGlobalSessionKey(sessionKey) ||
     normalized === DEFAULT_MAIN_KEY ||


### PR DESCRIPTION
Closes #112749

## What Problem This Solves

Fixes an issue where users switching between Matrix rooms or Signal groups with case-distinct opaque identifiers would see another conversation's transcript, persisted sidebar state, tool activity, approvals, or suggestions.

## Why This Change Was Made

Use the existing canonical Control UI session-key normalizer consistently for selected-session event matching, persisted identity, and bounded transcript cache keys. Keep agent-scoped structural normalization, configured main-session aliases, Matrix room and thread identity, and Signal group identity aligned with the Gateway contract.

## User Impact

Matrix rooms, Matrix threads, and Signal groups remain independent when their opaque identifiers differ only by case. Real aliases and configured main sessions continue to resolve to the same conversation.

## Evidence

- Before: four new cache regressions independently fail because the second session overwrites the first; four new live-event and persistence regressions independently fail because distinct sessions match.
- After: 195 focused chat, session, transcript-history, cache, persistence, and Gateway-UI regression tests pass.
- After: 60 focused canonical identity, cache, persisted-sidebar, and live tool-event tests pass.
- Real Chromium on isolated Linux: all 8 selected desktop/mobile Control UI chat, first-turn, streaming, terminal-event, and message-tool scenarios pass; Blacksmith Testbox run 30285088054.
- Independent exact-patch autoreview: clean; no accepted or actionable findings.
- The existing wider current-main Chromium baseline is independently recorded as 53 passed and 9 pre-existing failures; no test is skipped or weakened in this change.

AI-assisted: Codex.