### PR TITLE
fix(tui): show session names instead of Gateway metadata

### DIFF
--- a/src/gateway/session-title-inbound-metadata.test.ts
+++ b/src/gateway/session-title-inbound-metadata.test.ts
@@ -1,0 +1,148 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { markInboundContextLabel } from "../auto-reply/reply/inbound-context-marker.js";
+import type { SessionEntry } from "../config/sessions.js";
+import { persistSessionTranscriptTurn } from "../config/sessions/session-accessor.js";
+import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
+import {
+  readSessionTitleFieldsFromTranscript,
+  readSessionTitleFieldsFromTranscriptAsync,
+} from "./session-transcript-readers.js";
+import { deriveSessionTitle } from "./session-utils-core.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+const senderMetadata = `${markInboundContextLabel("Sender:")}
+\`\`\`json
+{"label":"openclaw-tui (gateway-client)","id":"gateway-client"}
+\`\`\``;
+
+describe("session titles with inbound Gateway metadata", () => {
+  let tempDir: string;
+  let envSnapshot: ReturnType<typeof captureEnv>;
+
+  beforeEach(() => {
+    envSnapshot = captureEnv(["OPENCLAW_STATE_DIR"]);
+    tempDir = tempDirs.make("openclaw-session-title-inbound-");
+    setTestEnvValue("OPENCLAW_STATE_DIR", tempDir);
+  });
+
+  afterEach(() => {
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+    envSnapshot.restore();
+  });
+
+  test.each([
+    { backend: "file", content: "string" },
+    { backend: "file", content: "text blocks" },
+    { backend: "sqlite", content: "string" },
+    { backend: "sqlite", content: "text blocks" },
+  ] as const)(
+    "uses the user message, not metadata, for $backend $content transcripts",
+    async ({ backend, content }) => {
+      const sessionId = `session-title-${backend}-${content.replaceAll(" ", "-")}`;
+      const messageText = `${senderMetadata}\n\nHelp me investigate the flaky deployment`;
+      const userContent =
+        content === "string" ? messageText : [{ type: "text" as const, text: messageText }];
+      const messages = [
+        { message: { role: "user" as const, content: userContent } },
+        { message: { role: "assistant" as const, content: "Here is the deployment status." } },
+      ];
+      const transcriptPath = path.join(tempDir, `${sessionId}.jsonl`);
+      const scope = {
+        agentId: "main",
+        sessionId,
+        sessionKey: `agent:main:${sessionId}`,
+        storePath: path.join(tempDir, "sessions.json"),
+        ...(backend === "file" ? { sessionFile: transcriptPath } : {}),
+      };
+
+      if (backend === "file") {
+        fs.writeFileSync(
+          transcriptPath,
+          `${[
+            { type: "session", version: 3, id: sessionId },
+            ...messages.map((message, index) => ({
+              type: "message",
+              id: `message-${index}`,
+              parentId: index === 0 ? null : "message-0",
+              ...message,
+            })),
+          ]
+            .map((event) => JSON.stringify(event))
+            .join("\n")}\n`,
+          "utf8",
+        );
+      } else {
+        await persistSessionTranscriptTurn(scope, {
+          cwd: tempDir,
+          messages,
+          touchSessionEntry: false,
+        });
+      }
+
+      const entry: SessionEntry = { sessionId, updatedAt: 0 };
+      const syncFields = readSessionTitleFieldsFromTranscript(scope);
+      const asyncFields = await readSessionTitleFieldsFromTranscriptAsync(scope);
+
+      expect(asyncFields).toEqual(syncFields);
+      expect(deriveSessionTitle(entry, syncFields.firstUserMessage)).toBe(
+        "Help me investigate the flaky deployment",
+      );
+      expect(syncFields.lastMessagePreview).toBe("Here is the deployment status.");
+    },
+  );
+
+  test("falls back to the session id when the first message contains only metadata", () => {
+    const entry: SessionEntry = { sessionId: "abcd1234-rest-of-session", updatedAt: 0 };
+
+    expect(deriveSessionTitle(entry, senderMetadata)).toBe("abcd1234");
+  });
+
+  test("preserves unmarked sender-like user text", () => {
+    const entry: SessionEntry = { sessionId: "abcd1234-rest-of-session", updatedAt: 0 };
+
+    expect(deriveSessionTitle(entry, "Sender: help me debug the gateway")).toBe(
+      "Sender: help me debug the gateway",
+    );
+  });
+
+  test("keeps explicit session names ahead of user-message metadata", () => {
+    const entry: SessionEntry = {
+      sessionId: "abcd1234-rest-of-session",
+      updatedAt: 0,
+      displayName: "Deployment investigation",
+    };
+
+    expect(deriveSessionTitle(entry, senderMetadata)).toBe("Deployment investigation");
+  });
+
+  test("prefers the computed Gateway display name over transcript metadata", () => {
+    const entry: SessionEntry = { sessionId: "abcd1234-rest-of-session", updatedAt: 0 };
+
+    expect(
+      deriveSessionTitle(
+        entry,
+        `${senderMetadata}\n\nHelp me investigate the flaky deployment`,
+        "  openclaw-tui  ",
+      ),
+    ).toBe("openclaw-tui");
+  });
+
+  test("keeps a user-assigned session label ahead of the Gateway display name", () => {
+    const entry: SessionEntry = {
+      sessionId: "abcd1234-rest-of-session",
+      updatedAt: 0,
+      label: "Deployment investigation",
+    };
+
+    expect(deriveSessionTitle(entry, senderMetadata, "openclaw-tui")).toBe(
+      "Deployment investigation",
+    );
+  });
+});

--- a/src/gateway/session-utils-core.ts
+++ b/src/gateway/session-utils-core.ts
@@ -9,6 +9,7 @@ import {
   RECENT_ENDED_SUBAGENT_CHILD_SESSION_MS,
   shouldKeepSubagentRunChildLink,
 } from "../agents/subagent-run-liveness.js";
+import { stripInboundMetadata } from "../auto-reply/reply/strip-inbound-meta.js";
 import { isTerminalSessionStatus, type SessionEntry } from "../config/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveNonNegativeNumber } from "../shared/number-coercion.js";
@@ -51,6 +52,7 @@ function truncateTitle(text: string, maxLen: number): string {
 export function deriveSessionTitle(
   entry: SessionEntry | undefined,
   firstUserMessage?: string | null,
+  externalDisplayName?: string | null,
 ): string | undefined {
   if (!entry) {
     return undefined;
@@ -61,16 +63,23 @@ export function deriveSessionTitle(
     return label;
   }
 
-  if (normalizeOptionalString(entry.displayName)) {
-    return normalizeOptionalString(entry.displayName);
+  const displayName =
+    normalizeOptionalString(externalDisplayName) ?? normalizeOptionalString(entry.displayName);
+  if (displayName) {
+    return displayName;
   }
 
-  if (normalizeOptionalString(entry.subject)) {
-    return normalizeOptionalString(entry.subject);
+  const subject = normalizeOptionalString(entry.subject);
+  if (subject) {
+    return subject;
   }
 
-  if (firstUserMessage?.trim()) {
-    const normalized = firstUserMessage.replace(/\s+/g, " ").trim();
+  // Transcript metadata is model-only; sanitize at the shared title boundary so
+  // SQLite, file-backed sessions, and every session-list client stay consistent.
+  const normalized = firstUserMessage
+    ? stripInboundMetadata(firstUserMessage).replace(/\s+/g, " ").trim()
+    : "";
+  if (normalized) {
     return truncateTitle(normalized, DERIVED_TITLE_MAX_LEN);
   }
 

--- a/src/gateway/session-utils-list.ts
+++ b/src/gateway/session-utils-list.ts
@@ -497,7 +497,7 @@ export async function listSessionsFromStoreAsync(params: {
           storePath,
         });
         if (includeDerivedTitles) {
-          row.derivedTitle = deriveSessionTitle(entry, fields.firstUserMessage);
+          row.derivedTitle = deriveSessionTitle(entry, fields.firstUserMessage, row.displayName);
         }
         if (includeLastMessage && fields.lastMessagePreview) {
           row.lastMessagePreview = fields.lastMessagePreview;

--- a/src/gateway/session-utils-row.ts
+++ b/src/gateway/session-utils-row.ts
@@ -357,7 +357,7 @@ export function buildGatewaySessionRow(params: {
       storePath,
     });
     if (params.includeDerivedTitles) {
-      derivedTitle = deriveSessionTitle(entry, fields.firstUserMessage);
+      derivedTitle = deriveSessionTitle(entry, fields.firstUserMessage, displayName);
     }
     if (params.includeLastMessage && fields.lastMessagePreview) {
       lastMessagePreview = fields.lastMessagePreview;


### PR DESCRIPTION
Closes #39722

## What Problem This Solves

Fixes an issue where users opening the TUI session picker would see Gateway-injected sender metadata instead of useful conversation titles, especially for gateway-client sessions.

## Why This Change Was Made

Normalize model-only inbound metadata at the shared Gateway title boundary and give the Gateway's computed display name its existing intended precedence in both synchronous and asynchronous session-list paths. This keeps filesystem and SQLite transcript behavior consistent without changing stored messages.

## User Impact

The TUI and other Gateway session clients now display the actual conversation, explicit session label, or Gateway-provided display name; metadata-only messages correctly fall back to the session identifier.

## Evidence

- Reproduced on current `main`: five session-title regressions failed before the fix.
- Nine focused regressions now pass across SQLite and file-backed transcripts, string and text-block messages, metadata-only fallback, ordinary sender-like user text, explicit labels, and Gateway display-name precedence.
- Complete TUI suite: 34 files, 774 tests passed.
- Actual terminal and real Gateway integration: 48 PTY and end-to-end scenarios passed, including reconnect, streaming follow-ups, cancellation, cross-client messages, new sessions, and reset.
- Race stress: 20 iterations, 4,000 passing session, streaming, cancellation, and event-handler tests.
- Compact 72x20, wide 160x48, and single-character fragmented terminal input: all 32 PTY scenarios passed for each configuration.
- `pnpm check:changed` passed on a remote Blacksmith Testbox, including production and test typechecking, zero-warning lint, formatting, import-cycle, database-first, schema, and plugin-boundary guards.
- Fresh Codex autoreview: clean, no accepted or actionable findings.
- ClawSweeper: no findings; real-behavior proof sufficient.

## ClawSweeper Rank-up Move

The suggested rebase is intentionally deferred: `main` advanced without modifying any of the four changed paths, the full required CI is already running on the exact reviewed PR head, and the protected `scripts/pr` landing workflow treats behind-main drift as advisory while still rejecting actual conflicts and verifying the merge. Rebasing solely for unrelated base movement would discard valid exact-head evidence and restart the entire hosted test matrix.

AI-assisted; independently reviewed and behavior-tested.