### PR TITLE
fix(logging): boot credentials lose exact-value redaction after transient secret churn

### DIFF
--- a/src/audit/audit-identity.ts
+++ b/src/audit/audit-identity.ts
@@ -7,7 +7,7 @@ import {
   executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,
 } from "../infra/kysely-sync.js";
-import { registerSecretValueForRedaction } from "../logging/secret-redaction-registry.js";
+import { registerDurableSecretValueForRedaction } from "../logging/secret-redaction-registry.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
 
 type AuditIdentityDatabase = Pick<
@@ -38,8 +38,8 @@ type AuditIdentityKind = "account" | "actor" | "conversation" | "message" | "tar
 
 function registerAuditIdentityKeyForRedaction(key: Uint8Array): void {
   const bytes = Buffer.from(key);
-  registerSecretValueForRedaction(bytes.toString("hex"));
-  registerSecretValueForRedaction(bytes.toString("base64url"));
+  registerDurableSecretValueForRedaction(bytes.toString("hex"));
+  registerDurableSecretValueForRedaction(bytes.toString("base64url"));
 }
 
 function parseAuditIdentityKey(row: AuditIdentityKeyRow): AuditIdentityKey {

--- a/src/logging/redact.test.ts
+++ b/src/logging/redact.test.ts
@@ -15,7 +15,11 @@ import {
   resolveRedactOptions,
 } from "./redact.js";
 import { withFullContextToolPayloadRedaction } from "./redact.test-support.js";
-import { registerSecretValueForRedaction } from "./secret-redaction-registry.js";
+import {
+  isSecretValueRegisteredForRedaction,
+  registerDurableSecretValueForRedaction,
+  registerSecretValueForRedaction,
+} from "./secret-redaction-registry.js";
 import { resetSecretRedactionRegistryForTest } from "./secret-redaction-registry.test-support.js";
 
 const defaults = getDefaultRedactPatterns();
@@ -106,6 +110,43 @@ describe("registered exact secret values", () => {
 
     expect(redactSensitiveText(first, { mode: "off" })).not.toContain(first);
     expect(redactSensitiveText(second, { mode: "off" })).toBe(second);
+  });
+
+  it("keeps durable values masked after transient registry churn", () => {
+    const bootSecret = "durable-boot-credential-000";
+    registerDurableSecretValueForRedaction(bootSecret);
+    for (let index = 0; index <= 512; index += 1) {
+      registerSecretValueForRedaction(`transient-churn-value-${index.toString().padStart(3, "0")}`);
+    }
+
+    expect(redactSensitiveText(bootSecret, { mode: "off" })).not.toContain(bootSecret);
+    expect(isSecretValueRegisteredForRedaction(bootSecret)).toBe(true);
+  });
+
+  it("keeps a durable value durable when re-registered as transient", () => {
+    const bootSecret = "durable-boot-credential-001";
+    registerDurableSecretValueForRedaction(bootSecret);
+    registerSecretValueForRedaction(bootSecret);
+    for (let index = 0; index <= 512; index += 1) {
+      registerSecretValueForRedaction(`transient-churn-value-${index.toString().padStart(3, "0")}`);
+    }
+
+    expect(redactSensitiveText(bootSecret, { mode: "off" })).not.toContain(bootSecret);
+  });
+
+  it("bounds the durable tier by evicting the oldest durable value", () => {
+    const first = "durable-registry-value-000";
+    registerDurableSecretValueForRedaction(first);
+    for (let index = 1; index <= 512; index += 1) {
+      registerDurableSecretValueForRedaction(
+        `durable-registry-value-${index.toString().padStart(3, "0")}`,
+      );
+    }
+
+    expect(redactSensitiveText(first, { mode: "off" })).toBe(first);
+    expect(redactSensitiveText("durable-registry-value-512", { mode: "off" })).not.toContain(
+      "durable-registry-value-512",
+    );
   });
 });
 

--- a/src/logging/secret-redaction-registry.ts
+++ b/src/logging/secret-redaction-registry.ts
@@ -3,58 +3,81 @@ import { escapeRegExp } from "../shared/regexp.js";
 const MIN_SECRET_VALUE_LENGTH = 6;
 const MAX_SECRET_VALUES = 512;
 
+const durableValues = new Map<string, true>();
 const registeredValues = new Map<string, true>();
 let compiledMatcher: RegExp | undefined;
 let firstChars = new Set<string>();
 
 function rebuildProbe(): void {
-  firstChars = new Set([...registeredValues.keys()].map((value) => value.charAt(0)));
+  firstChars = new Set(
+    [...durableValues.keys(), ...registeredValues.keys()].map((value) => value.charAt(0)),
+  );
   compiledMatcher = undefined;
 }
 
-function registerOneSecretValue(value: string): void {
-  if (registeredValues.delete(value)) {
-    registeredValues.set(value, true);
+function insertWithBoundedEviction(values: Map<string, true>, value: string): void {
+  if (values.delete(value)) {
+    values.set(value, true);
     return;
   }
-  registeredValues.set(value, true);
-  if (registeredValues.size > MAX_SECRET_VALUES) {
-    const oldest = registeredValues.keys().next().value;
+  values.set(value, true);
+  if (values.size > MAX_SECRET_VALUES) {
+    const oldest = values.keys().next().value;
     if (oldest !== undefined) {
-      registeredValues.delete(oldest);
+      values.delete(oldest);
     }
   }
   rebuildProbe();
 }
 
-/** Registers one resolved secret for exact-value log redaction. */
-export function registerSecretValueForRedaction(value: string): void {
+function registerOneSecretValue(value: string, durable: boolean): void {
+  if (durable) {
+    registeredValues.delete(value);
+    insertWithBoundedEviction(durableValues, value);
+    return;
+  }
+  if (durableValues.has(value)) {
+    return;
+  }
+  insertWithBoundedEviction(registeredValues, value);
+}
+
+function registerSecretValueForms(value: string, durable: boolean): void {
   if (value.length < MIN_SECRET_VALUE_LENGTH) {
     return;
   }
   // URL egress percent-encodes injected values; redact that surface form too.
   const encoded = encodeURIComponent(value);
   if (encoded !== value) {
-    registerOneSecretValue(encoded);
+    registerOneSecretValue(encoded, durable);
   }
   // Captured structured payloads are serialized before persistence, so retain
   // the JSON string-content form for credentials with escaped characters.
   const jsonEscaped = JSON.stringify(value).slice(1, -1);
   if (jsonEscaped !== value) {
-    registerOneSecretValue(jsonEscaped);
+    registerOneSecretValue(jsonEscaped, durable);
   }
   // Keep the raw value newest so bounded-registry eviction cannot drop the
   // active credential while retaining only a transformed representation.
-  registerOneSecretValue(value);
+  registerOneSecretValue(value, durable);
+}
+
+/** Registers one resolved secret for exact-value log redaction. */
+export function registerSecretValueForRedaction(value: string): void {
+  registerSecretValueForms(value, false);
+}
+
+export function registerDurableSecretValueForRedaction(value: string): void {
+  registerSecretValueForms(value, true);
 }
 
 /** Returns whether a value has SecretRef provenance in the process registry. */
 export function isSecretValueRegisteredForRedaction(value: string): boolean {
-  return registeredValues.has(value);
+  return durableValues.has(value) || registeredValues.has(value);
 }
 
 export function hasRegisteredSecretValuesForRedaction(): boolean {
-  return registeredValues.size > 0;
+  return durableValues.size > 0 || registeredValues.size > 0;
 }
 
 /** Replaces registered exact values while preserving the caller's mask convention. */
@@ -62,7 +85,7 @@ export function redactRegisteredSecretValues(
   text: string,
   mask: (value: string) => string,
 ): string {
-  if (!text || registeredValues.size === 0) {
+  if (!text || !hasRegisteredSecretValuesForRedaction()) {
     return text;
   }
   let couldMatch = false;
@@ -76,7 +99,7 @@ export function redactRegisteredSecretValues(
     return text;
   }
   compiledMatcher ??= new RegExp(
-    [...registeredValues.keys()]
+    [...durableValues.keys(), ...registeredValues.keys()]
       .toSorted((left, right) => right.length - left.length)
       .map(escapeRegExp)
       .join("|"),
@@ -86,6 +109,7 @@ export function redactRegisteredSecretValues(
 }
 
 function resetSecretRedactionRegistryForTest(): void {
+  durableValues.clear();
   registeredValues.clear();
   rebuildProbe();
 }

--- a/src/secrets/runtime-owner-assignments.ts
+++ b/src/secrets/runtime-owner-assignments.ts
@@ -3,7 +3,7 @@ import { isDeepStrictEqual } from "node:util";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { SecretRef } from "../config/types.secrets.js";
 import { toErrorObject } from "../infra/errors.js";
-import { registerSecretValueForRedaction } from "../logging/secret-redaction-registry.js";
+import { registerDurableSecretValueForRedaction } from "../logging/secret-redaction-registry.js";
 import { secretRefKey } from "./ref-contract.js";
 import {
   describeSecretResolutionError,
@@ -76,7 +76,7 @@ export function classifySecretOwnerDegradationState(params: {
 function registerResolvedValuesForRedaction(resolved: ReadonlyMap<string, unknown>): void {
   for (const value of resolved.values()) {
     if (typeof value === "string") {
-      registerSecretValueForRedaction(value);
+      registerDurableSecretValueForRedaction(value);
     }
   }
 }


### PR DESCRIPTION
Related: #105700

## What Problem This Solves

Fixes an issue where a long-running gateway prints permanent credentials in plaintext in diagnostic logs, proxy captures, and support bundles once enough transient secrets have passed through the process. The exact-value redaction registry is capped at 512 entries with oldest-first eviction, and credentials registered once at boot, such as the audit identity key and SecretRef-resolved config and auth-store values, are eventually evicted by churn from rotating provider tokens, MCP connection secrets, and short-lived worker credentials. After eviction the still-active credential is no longer masked, and `isSecretValueRegisteredForRedaction` stops recognizing it, which also disables sentinel wrapping for that credential in the Google prompt-cache auth path.

## Why This Change Was Made

Issue #105700 is gated on a security-owner decision between three lifecycle designs; this PR is a concrete proposal implementing the bounded protected tier. The registry now keeps two tiers: a durable tier for process-lifetime credentials and the existing transient tier. Transient registrations can never evict durable entries. The durable tier is bounded by the same 512-entry cap with oldest-first eviction among durable entries only, so matcher growth stays bounded and eviction of a durable entry cannot be forced by workload-influenced churn; durable registration happens only at operator scale (config and auth-store secrets, one audit key per state database).

Callers were classified by credential lifetime. Durable: the audit identity key (`src/audit/audit-identity.ts`) and SecretRef-resolved assignment values (`src/secrets/runtime-owner-assignments.ts`), which are exactly the boot-registered credentials named in the issue. Deliberately left transient: worker credentials (10 minute TTL), worker SSH identity material and MCP connection secrets (re-registered on every provision or connect, workload-scale cardinality), and sentinel-protected provider tokens (re-registered on every sentinel resolve). If the security owner prefers the wider owner-scoped retention design from the review, this change does not foreclose it: the durable tier can become the pinned store behind lifecycle handles, and I am happy to adjust.

On the two retention properties raised in review, so the owner decision has the numbers in front of it. Combined capacity: worst case is 1,024 exact secret forms instead of 512, all short strings in one process-local matcher, and the two tiers are bounded independently precisely so a full durable tier cannot silently disable transient masking (a shared 512 budget would do exactly that). Stale durable values after rotation: a rotated-out SecretRef value stays registered until durable-tier eviction. That is over-redaction of a dead credential, never under-redaction of a live one, and current `main` already retains rotated values in the single tier for the same reason; the patch changes how long, not whether. Durable growth is one entry per operator rotation, not per request, because auth-store SecretRef assignments are `api_key` and `token` profiles (OAuth profiles are rejected by `assertNoOAuthSecretRefPolicyViolations`), so 512 durable slots is 512 operator rotations, and it stays out of reach of workload-influenced churn. Both numbers are policy, not mechanics: if the security owner wants a different cap or a lifecycle-scoped retirement path, say so and I will change it in this branch.

## Decision Needed From The Security Owner

CODEOWNERS already routes `/src/secrets/` to @openclaw/openclaw-secops and that review is requested on this PR. Two knobs need a yes or a revision; everything else on this branch is mechanical.

1. Durable capacity. Currently `MAX_SECRET_VALUES` (512) applied per tier, so 1,024 exact secret forms worst case in one process-local matcher. Name a different number or a different split and I will set it.
2. Durable caller set. Currently the audit identity key and SecretRef-resolved assignment values, and nothing else. Name which runtime owners may register durable values and I will reclassify.

If the answer is that this is not the right design, option 2 from the review (owner-scoped lifecycle handles that retire with config or auth ownership) is compatible with this branch rather than opposed to it: the durable map becomes the pinned store behind those handles. I will rework it here rather than opening a second PR.

Review items and how each is handled:

- Approve durable credential lifetime policy (medium, `src/logging/secret-redaction-registry.ts:5`): open by design, owner decision, not something I can self-approve. The two knobs above are the whole decision surface.
- Merge risk, combined 1,024-form capacity plus stale durable values after rotation: analyzed in the section above. Both are policy knobs, not defects. Retaining a rotated-out value is over-redaction of a dead credential, and current `main` already does that in its single tier.
- Merge risk, canonical issue pending a lifecycle choice: acknowledged. This branch is one of the three designs offered there, not a claim that the choice has been made.
- Next step (P2), security-owner choice rather than a narrow mechanical repair: agreed, and no autonomous policy change was made beyond this proposal.
- Rank-up move, record a security-owner decision on lifecycle and capacity: this section exists so that decision is one comment.
- Findings: none were reported and none are outstanding.

## User Impact

Operators of long-running gateways keep exact-value masking for their permanent credentials regardless of how many transient secrets rotate through the process. Redaction of transient secrets, registry memory bounds, and the existing registration API are unchanged; `registerSecretValueForRedaction` keeps its signature and semantics.

## Evidence

Live before and after on the real runtime, zero mocks, identical driver and identical inputs on both runs. The full block is below, pinned to the current head.

## Real behavior proof
Behavior addressed: a long-running gateway stops masking its permanent audit identity key in diagnostic output once 512 transient secrets have rotated through the process, printing the still-active credential in plaintext.
Real environment tested: real production runtime driven end to end on macOS, Node 26.0.0, with a real SQLite state database opened through `openOpenClawStateDatabase` in a temporary `OPENCLAW_STATE_DIR`, the audit identity key created through the production boot path `loadOrCreateAuditIdentityKey`, churn produced through the production provider-auth path `protectPreparedProviderRuntimeAuth`, and the final line passed through `redactSensitiveText`; run on pristine `main` at ab0b749017 and on PR head 5074408b1020089bfee1acc6cea06cbc57f98620 with an identical driver and identical inputs.
Exact steps or command run after this patch: open the state database in a fresh `OPENCLAW_STATE_DIR`, call `loadOrCreateAuditIdentityKey`, protect 512 rotating provider tokens through `protectPreparedProviderRuntimeAuth`, then pass `gateway diagnostic dump: audit identity key <key>` through `redactSensitiveText`.
Evidence after fix:
```
# BEFORE (pristine main ab0b749017)
boot: audit identity key created in /var/folders/xd/z6c82k954n1_kdj59zrg03kh0000gn/T/openclaw-redaction-proof-mfXiF4/state and registered
boot: redaction guard knows the key: true
churn: protected 512 rotating provider tokens via the live auth path
after churn: redaction guard knows the key: false
after churn: diagnostic log line: gateway diagnostic dump: audit identity key d4d6f7e5b00dd071acb0685644beee04c68a25929db1a65a23b69730657ff8d9
after churn: plaintext key leaked into the log line: true

# AFTER (this patch, identical inputs, head 5074408b1020089bfee1acc6cea06cbc57f98620)
boot: audit identity key created in /var/folders/xd/z6c82k954n1_kdj59zrg03kh0000gn/T/openclaw-redaction-proof-EGDOLi/state and registered
boot: redaction guard knows the key: true
churn: protected 512 rotating provider tokens via the live auth path
after churn: redaction guard knows the key: true
after churn: diagnostic log line: gateway diagnostic dump: audit identity key 973b92…89c3
after churn: plaintext key leaked into the log line: false
```
Observed result after fix: on the same driver and the same inputs, the boot audit identity key stays masked after 512 rotating provider credentials churn through the live auth path, so the redaction guard still recognizes the key and the diagnostic log line carries the masked form instead of the plaintext key.
What was not tested: no full gateway process was driven to 512 organic registrations over real uptime; the churn was produced synthetically through the real provider-auth protection path. No live provider request was made, and no full build was run.

### Local gates

- `node scripts/run-vitest.mjs src/logging/redact.test.ts src/audit src/secrets/runtime.test.ts src/secrets/sentinel.test.ts src/agents/embedded-agent-runner/google-prompt-cache.test.ts src/proxy-capture/runtime.test.ts src/gateway/worker-environments/credential.test.ts src/agents/provider-secret-egress.test.ts`: 7 shards passed. `src/logging/redact.test.ts` alone is 151 passed, including three new regression tests (a durable value survives 513 transient registrations, a durable value stays durable when re-registered as transient, the durable tier bound is enforced). The churn regression test fails on `main`.
- `node scripts/run-oxlint.mjs` and `oxfmt --check` on the four changed files: clean.
- tsgo `tsconfig.core.json`: byte-identical output on this branch and on pristine `main` (32 pre-existing workspace resolution errors, none in the changed files). tsgo `test/tsconfig/tsconfig.core.test.json`: one pre-existing unrelated `ui/src/app-session-route-paths.ts` module-resolution error.
