### PR TITLE
perf(gateway): bound session list title probes to transcript head and tail

### DIFF
--- a/src/gateway/session-transcript-readers.test.ts
+++ b/src/gateway/session-transcript-readers.test.ts
@@ -1,7 +1,8 @@
 import fs from "node:fs";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import * as sessionAccessor from "../config/sessions/session-accessor.js";
 import {
   persistSessionTranscriptTurn,
   upsertSessionEntry,
@@ -20,8 +21,18 @@ import {
   readSessionMessageCountAsync,
   readSessionMessagesAsync,
   readSessionMessagesPageWithStatsAsync,
+  readSessionTitleFieldsFromTranscript,
   type SessionTranscriptReadScope,
 } from "./session-transcript-readers.js";
+
+vi.mock("../config/sessions/session-accessor.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../config/sessions/session-accessor.js")>();
+  return {
+    ...actual,
+    readSessionTranscriptMessageEventPage: vi.fn(actual.readSessionTranscriptMessageEventPage),
+    readSessionTranscriptMessageEvents: vi.fn(actual.readSessionTranscriptMessageEvents),
+  };
+});
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
@@ -31,6 +42,7 @@ describe("session transcript reader facade", () => {
   let envSnapshot: ReturnType<typeof captureEnv>;
 
   beforeEach(() => {
+    vi.clearAllMocks();
     envSnapshot = captureEnv(["OPENCLAW_STATE_DIR"]);
     tempDir = tempDirs.make("openclaw-transcript-readers-");
     storePath = path.join(tempDir, "sessions.json");
@@ -51,6 +63,81 @@ describe("session transcript reader facade", () => {
       "utf-8",
     );
     return { sessionFile: transcriptPath, sessionId, sessionKey: `agent:main:${sessionId}` };
+  }
+
+  function sqliteScope(sessionId: string): SessionTranscriptReadScope {
+    return {
+      agentId: "main",
+      sessionFile: formatSqliteSessionFileMarker({ agentId: "main", sessionId, storePath }),
+      sessionId,
+      sessionKey: `agent:main:${sessionId}`,
+      storePath,
+    };
+  }
+
+  async function writeSqliteMessages(
+    sessionId: string,
+    messages: Array<{ content: unknown; provenance?: unknown; role: string }>,
+  ): Promise<SessionTranscriptReadScope> {
+    await persistSessionTranscriptTurn(
+      { agentId: "main", sessionId, sessionKey: `agent:main:${sessionId}`, storePath },
+      {
+        messages: messages.map((message) => ({ message })),
+        touchSessionEntry: false,
+      },
+    );
+    return sqliteScope(sessionId);
+  }
+
+  function extractReferenceText(message: unknown): string | null {
+    if (!message || typeof message !== "object" || Array.isArray(message)) {
+      return null;
+    }
+    const content = (message as { content?: unknown }).content;
+    if (typeof content === "string") {
+      return content.trim() || null;
+    }
+    if (!Array.isArray(content)) {
+      return null;
+    }
+    const text = content
+      .map((entry) =>
+        entry && typeof entry === "object" && typeof (entry as { text?: unknown }).text === "string"
+          ? (entry as { text: string }).text
+          : "",
+      )
+      .filter((part) => part.trim())
+      .join("\n")
+      .trim();
+    return text || null;
+  }
+
+  async function readFullScanTitleFields(scope: SessionTranscriptReadScope) {
+    const messages = await readSessionMessagesAsync(scope, {
+      mode: "full",
+      reason: "title probe parity reference",
+    });
+    const firstUser = messages.find(
+      (message) =>
+        message &&
+        typeof message === "object" &&
+        !Array.isArray(message) &&
+        (message as { role?: unknown }).role === "user" &&
+        (message as { provenance?: { kind?: unknown } }).provenance?.kind !== "inter_session",
+    );
+    return {
+      firstUserMessage: firstUser ? extractReferenceText(firstUser) : null,
+      lastMessagePreview: messages.toReversed().map(extractReferenceText).find(Boolean) ?? null,
+    };
+  }
+
+  function boundedPageEventReadCount(): number {
+    return vi
+      .mocked(sessionAccessor.readSessionTranscriptMessageEventPage)
+      .mock.results.reduce(
+        (total, result) => total + (result.type === "return" ? result.value.events.length : 0),
+        0,
+      );
   }
 
   test("reads active-branch messages and message ids through a scope", async () => {
@@ -284,6 +371,112 @@ describe("session transcript reader facade", () => {
       readSessionMessagesAsync(scope, { mode: "recent", maxMessages: 1 }),
     ).resolves.toMatchObject([{ content: "sqlite follow-up", __openclaw: { seq: 3 } }]);
     await expect(readSessionMessageCountAsync(scope)).resolves.toBe(3);
+  });
+
+  test("keeps bounded title fields at full-scan parity across common transcript shapes", async () => {
+    const longMessages = (build: (index: number) => { content: unknown; role: string }) =>
+      Array.from({ length: 105 }, (_, index) => build(index));
+    const cases = [
+      {
+        expected: { firstUserMessage: "first prompt", lastMessagePreview: "reply 104" },
+        messages: longMessages((index) =>
+          index === 0
+            ? { role: "user", content: "first prompt" }
+            : { role: "assistant", content: `reply ${index}` },
+        ),
+        name: "user message first",
+      },
+      {
+        expected: { firstUserMessage: "late prompt", lastMessagePreview: "reply 104" },
+        messages: longMessages((index) =>
+          index === 60
+            ? { role: "user", content: "late prompt" }
+            : { role: "assistant", content: `reply ${index}` },
+        ),
+        name: "user message late",
+      },
+      {
+        expected: { firstUserMessage: null, lastMessagePreview: "reply 104" },
+        messages: longMessages((index) => ({ role: "assistant", content: `reply ${index}` })),
+        name: "no user messages",
+      },
+      {
+        expected: { firstUserMessage: null, lastMessagePreview: null },
+        messages: [],
+        name: "empty transcript",
+      },
+      {
+        expected: { firstUserMessage: "first prompt", lastMessagePreview: "last visible" },
+        messages: longMessages((index) => {
+          if (index === 0) {
+            return { role: "user", content: "first prompt" };
+          }
+          if (index === 102) {
+            return { role: "assistant", content: "last visible" };
+          }
+          return { role: "assistant", content: index > 102 ? " " : `reply ${index}` };
+        }),
+        name: "last message empty then text",
+      },
+    ];
+
+    for (const [index, parityCase] of cases.entries()) {
+      const sessionId = `reader-title-parity-${String(index)}`;
+      const scope =
+        parityCase.messages.length > 0
+          ? await writeSqliteMessages(sessionId, parityCase.messages)
+          : sqliteScope(sessionId);
+      const reference = await readFullScanTitleFields(scope);
+      expect(reference, `${parityCase.name} reference`).toEqual(parityCase.expected);
+      vi.clearAllMocks();
+
+      expect(readSessionTitleFieldsFromTranscript(scope), parityCase.name).toEqual(reference);
+      expect(sessionAccessor.readSessionTranscriptMessageEvents).not.toHaveBeenCalled();
+    }
+  });
+
+  test("bounds title probe reads independently of transcript length", async () => {
+    const probeReadCount = async (sessionId: string, messageCount: number) => {
+      const scope = await writeSqliteMessages(
+        sessionId,
+        Array.from({ length: messageCount }, () => ({ role: "assistant", content: " " })),
+      );
+      vi.clearAllMocks();
+
+      expect(readSessionTitleFieldsFromTranscript(scope)).toEqual({
+        firstUserMessage: null,
+        lastMessagePreview: null,
+      });
+      expect(sessionAccessor.readSessionTranscriptMessageEvents).not.toHaveBeenCalled();
+      expect(
+        vi
+          .mocked(sessionAccessor.readSessionTranscriptMessageEventPage)
+          .mock.calls.map(([, options]) => options.maxMessages),
+      ).toEqual([20, 80, 20, 80]);
+      return boundedPageEventReadCount();
+    };
+
+    await expect(probeReadCount("reader-title-bounded-101", 101)).resolves.toBe(200);
+    await expect(probeReadCount("reader-title-bounded-201", 201)).resolves.toBe(200);
+  });
+
+  test("returns missing title fields when the bounded head and tail caps miss", async () => {
+    const scope = await writeSqliteMessages(
+      "reader-title-cap-miss",
+      Array.from({ length: 201 }, (_, index) =>
+        index === 100
+          ? { role: "user", content: "outside both probes" }
+          : { role: "assistant", content: " " },
+      ),
+    );
+    vi.clearAllMocks();
+
+    expect(readSessionTitleFieldsFromTranscript(scope)).toEqual({
+      firstUserMessage: null,
+      lastMessagePreview: null,
+    });
+    expect(sessionAccessor.readSessionTranscriptMessageEvents).not.toHaveBeenCalled();
+    expect(boundedPageEventReadCount()).toBe(200);
   });
 
   test("promotes SQLite message idempotency into transcript metadata", async () => {

--- a/src/gateway/session-transcript-readers.ts
+++ b/src/gateway/session-transcript-readers.ts
@@ -49,6 +49,11 @@ type SessionTitleFields = {
   lastMessagePreview: string | null;
 };
 
+// Session-list title probes must not scale with transcript size. Read at most
+// this many active-path messages from either end, widening only once.
+const SQLITE_TITLE_PROBE_INITIAL_MESSAGES = 20;
+const SQLITE_TITLE_PROBE_MAX_MESSAGES = 100;
+
 export type ReadRecentSessionMessagesResult = {
   activeLeafEntryId?: string | null;
   messages: unknown[];
@@ -281,21 +286,87 @@ function extractMessageText(message: unknown): string | null {
   return null;
 }
 
-function readSqliteTitleFields(
-  target: ResolvedTranscriptReadTarget,
-  opts?: { includeInterSession?: boolean },
-): SessionTitleFields {
-  const messages = readSqliteMessagesSync(target);
-  const firstUser = messages.find((message) => {
+function readSqliteTitleProbeRange(
+  scope: SessionTranscriptReadScope,
+  totalMessages: number,
+  start: number,
+  endExclusive: number,
+): SessionTranscriptMessageEvent[] {
+  const end = Math.min(totalMessages, endExclusive);
+  const boundedStart = Math.min(Math.max(0, start), end);
+  if (boundedStart === end) {
+    return [];
+  }
+  return readSessionTranscriptMessageEventPage(scope, {
+    maxMessages: end - boundedStart,
+    offset: totalMessages - end,
+  }).events;
+}
+
+function findFirstTitleUserMessage(
+  entries: readonly SessionTranscriptMessageEvent[],
+  includeInterSession: boolean,
+): unknown | undefined {
+  return entries.map(sqliteMessageEventWithSeq).find((message) => {
     if (extractMessageRole(message) !== "user") {
       return false;
     }
     return (
-      opts?.includeInterSession === true ||
+      includeInterSession ||
       !hasInterSessionUserProvenance(message as { role?: unknown; provenance?: unknown })
     );
   });
-  const lastText = messages.toReversed().map(extractMessageText).find(Boolean) ?? null;
+}
+
+function findLastMessageText(entries: readonly SessionTranscriptMessageEvent[]): string | null {
+  return (
+    entries.toReversed().map(sqliteMessageEventWithSeq).map(extractMessageText).find(Boolean) ??
+    null
+  );
+}
+
+function readSqliteTitleFields(
+  target: ResolvedTranscriptReadTarget,
+  opts?: { includeInterSession?: boolean },
+): SessionTitleFields {
+  const scope = toTranscriptReadScope(target);
+  const tail = readSessionTranscriptMessageEventPage(scope, {
+    maxMessages: SQLITE_TITLE_PROBE_INITIAL_MESSAGES,
+    offset: 0,
+  });
+  let lastText = findLastMessageText(tail.events);
+  if (!lastText && tail.totalMessages > SQLITE_TITLE_PROBE_INITIAL_MESSAGES) {
+    lastText = findLastMessageText(
+      readSqliteTitleProbeRange(
+        scope,
+        tail.totalMessages,
+        tail.totalMessages - SQLITE_TITLE_PROBE_MAX_MESSAGES,
+        tail.totalMessages - SQLITE_TITLE_PROBE_INITIAL_MESSAGES,
+      ),
+    );
+  }
+
+  const head =
+    tail.totalMessages <= SQLITE_TITLE_PROBE_INITIAL_MESSAGES
+      ? tail.events
+      : readSqliteTitleProbeRange(
+          scope,
+          tail.totalMessages,
+          0,
+          SQLITE_TITLE_PROBE_INITIAL_MESSAGES,
+        );
+  let firstUser = findFirstTitleUserMessage(head, opts?.includeInterSession === true);
+  if (!firstUser && tail.totalMessages > SQLITE_TITLE_PROBE_INITIAL_MESSAGES) {
+    firstUser = findFirstTitleUserMessage(
+      readSqliteTitleProbeRange(
+        scope,
+        tail.totalMessages,
+        SQLITE_TITLE_PROBE_INITIAL_MESSAGES,
+        SQLITE_TITLE_PROBE_MAX_MESSAGES,
+      ),
+      opts?.includeInterSession === true,
+    );
+  }
   return {
     firstUserMessage: firstUser ? extractMessageText(firstUser) : null,
     lastMessagePreview: lastText,

--- a/src/gateway/session-transcript-readers.ts
+++ b/src/gateway/session-transcript-readers.ts
@@ -306,7 +306,7 @@ function readSqliteTitleProbeRange(
 function findFirstTitleUserMessage(
   entries: readonly SessionTranscriptMessageEvent[],
   includeInterSession: boolean,
-): unknown | undefined {
+): unknown {
   return entries.map(sqliteMessageEventWithSeq).find((message) => {
     if (extractMessageRole(message) !== "user") {
       return false;


### PR DESCRIPTION
## What Problem This Solves

When `sessions.list` callers request derived titles or last-message previews (the ACP translator, the MCP channel bridge — which defaults them on — and the `sessions_list` agent tool), `readSqliteTitleFields` materialized and JSON-parsed **every message event on the active path of every listed session** (up to 100 rows per request), just to extract two fields: the first user message and the last non-empty text. On team.openclaw.ai (avg 587ms, max 2.8s for `sessions.list`; sessions with tens of thousands of messages) this was the dominant flag-dependent cost, and the in-code comment already called it "the dominant blocker."

## Why This Change Was Made

Title derivation needs the transcript's head; the preview needs its tail. The store already exposes an append-stable paged reader, so the full materialization is replaced by two bounded probes through `readSessionTranscriptMessageEventPage`: read 20 events from the relevant edge, widen once to 100 if the field wasn't found, then stop — worst case 200 parsed events per session, independent of transcript length. A cap miss returns the same absent-fields shape callers already handle (`{ firstUserMessage: null, lastMessagePreview: null }`). The JSONL fallback path and the row-yield loop are unchanged.

## User Impact

ACP/MCP session listings and the sessions_list tool stop scaling with transcript size; giant sessions no longer dominate list latency. Identical output for every transcript whose title/preview lives within the probe caps — which the parity matrix shows is all realistic shapes.

## Evidence

- `node scripts/run-vitest.mjs` across 4 files — 250 tests passing, including new parity regressions (user message first, late, absent; empty transcript; empty-then-text tail), a bounded-read regression asserting event-read counts are independent of transcript length and that the full-materialization reader is not invoked, and cap-miss contract preservation
- Implementation: src/gateway/session-transcript-readers.ts:328; regressions: src/gateway/session-transcript-readers.test.ts:376
- tsgo core lane clean; autoreview (Codex gpt-5.6-sol, xhigh) clean
- Production context: https://github.com/openclaw/openclaw/pull/114257#issuecomment-5088264732
