### PR TITLE
fix(mac): stop Settings crashing on packaged SwiftPM resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **macOS SwiftPM resources:** package every generated resource bundle inside the signed app and route command-line SwiftPM dependency lookups there, preventing General Settings and native math rendering from trapping on missing root-level sidecars.
 - **Codex native controls:** stop misclassifying valid thinking/fast runtime controls as provider overrides so Codex routes keep their native controls, while provider-native objects and invalid values stay fail-closed. Thanks @VACInc. (#107588)
 - **State snapshot verification:** run SQLite snapshot verification in a separate process so worker-thread file closes no longer drop the Gateway's POSIX WAL locks, eliminating spurious WAL misses and I/O errors. Thanks @VACInc. (#114016)
 - **Reply latency with model policies:** reuse one immutable plugin-metadata snapshot per model-selection run instead of repeating plugin discovery, cutting reply delay when a model policy is configured. Thanks @VACInc. (#114117)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **macOS SwiftPM resources:** package every generated resource bundle inside the signed app and route command-line SwiftPM dependency lookups there, preventing General Settings and native math rendering from trapping on missing root-level sidecars.
 - **Codex native controls:** stop misclassifying valid thinking/fast runtime controls as provider overrides so Codex routes keep their native controls, while provider-native objects and invalid values stay fail-closed. Thanks @VACInc. (#107588)
 - **State snapshot verification:** run SQLite snapshot verification in a separate process so worker-thread file closes no longer drop the Gateway's POSIX WAL locks, eliminating spurious WAL misses and I/O errors. Thanks @VACInc. (#114016)
 - **Reply latency with model policies:** reuse one immutable plugin-metadata snapshot per model-selection run instead of repeating plugin discovery, cutting reply delay when a model policy is configured. Thanks @VACInc. (#114117)

--- a/scripts/package-mac-app.sh
+++ b/scripts/package-mac-app.sh
@@ -111,6 +111,130 @@ run_with_locked_swift_packages() {
   return "$command_status"
 }
 
+PATCHED_SWIFTPM_RESOURCE_SOURCES=()
+
+restore_swiftpm_resource_sources() {
+  local source_file
+  local backup_file
+  for source_file in "${PATCHED_SWIFTPM_RESOURCE_SOURCES[@]:-}"; do
+    [[ -n "$source_file" ]] || continue
+    backup_file="$source_file.openclaw-original"
+    if [[ -f "$backup_file" ]]; then
+      mv "$backup_file" "$source_file"
+    fi
+  done
+  PATCHED_SWIFTPM_RESOURCE_SOURCES=()
+}
+
+patch_swiftpm_resource_lookups() {
+  local build_path="$1"
+  local checkout_root="$build_path/checkouts"
+  local source_file
+  local source_files=(
+    "$checkout_root/KeyboardShortcuts/Sources/KeyboardShortcuts/Utilities.swift"
+    "$checkout_root/SwiftMath/Sources/SwiftMath/MathBundle/MathFont.swift"
+    "$checkout_root/SwiftMath/Sources/SwiftMath/MathRender/MTFont.swift"
+  )
+
+  for source_file in "${source_files[@]}"; do
+    if [[ ! -f "$source_file" ]]; then
+      echo "ERROR: SwiftPM resource source not found at $source_file" >&2
+      return 1
+    fi
+    if [[ -e "$source_file.openclaw-original" ]]; then
+      echo "ERROR: Stale SwiftPM resource source backup at $source_file.openclaw-original" >&2
+      return 1
+    fi
+    cp -p "$source_file" "$source_file.openclaw-original"
+    chmod u+w "$source_file"
+    PATCHED_SWIFTPM_RESOURCE_SOURCES+=("$source_file")
+  done
+
+  /usr/bin/python3 - "${source_files[@]}" <<'PY'
+from pathlib import Path
+import sys
+
+
+def replace_exact(path: Path, old: str, new: str, expected: int = 1) -> str:
+    text = path.read_text()
+    if text.count(old) != expected:
+        raise SystemExit(f"Expected {expected} occurrence(s) in {path}: {old!r}")
+    return text.replace(old, new)
+
+
+keyboard_shortcuts, swift_math_font, swift_math_legacy_font = map(Path, sys.argv[1:])
+
+keyboard_text = replace_exact(
+    keyboard_shortcuts,
+    "NSLocalizedString(self, bundle: .module, comment: self)",
+    "NSLocalizedString(self, bundle: .keyboardShortcutsPackagedResources, comment: self)",
+)
+keyboard_marker = "\n\nextension Data {"
+keyboard_injection = """
+
+private extension Bundle {
+\t// Command-line SwiftPM builds resolve Bundle.module beside the executable, which is
+\t// outside a valid signed .app layout. Prefer the bundle copied into Contents/Resources.
+\tstatic let keyboardShortcutsPackagedResources: Bundle = {
+\t\t#if os(macOS)
+\t\tif let url = Bundle.main.url(
+\t\t\tforResource: \"KeyboardShortcuts_KeyboardShortcuts\",
+\t\t\twithExtension: \"bundle\"),
+\t\t   let bundle = Bundle(url: url)
+\t\t{
+\t\t\treturn bundle
+\t\t}
+\t\t#endif
+\t\treturn .module
+\t}()
+}
+"""
+if keyboard_text.count(keyboard_marker) != 1:
+    raise SystemExit(f"Expected one KeyboardShortcuts insertion marker in {keyboard_shortcuts}")
+keyboard_shortcuts.write_text(keyboard_text.replace(keyboard_marker, keyboard_injection + keyboard_marker))
+
+swift_math_text = replace_exact(
+    swift_math_font,
+    "Bundle.module.url(forResource: \"mathFonts\", withExtension: \"bundle\")",
+    "Bundle.swiftMathPackagedResources.url(forResource: \"mathFonts\", withExtension: \"bundle\")",
+    expected=2,
+)
+swift_math_marker = "\n#endif\n\n/// Now available for everyone to use"
+swift_math_injection = """
+
+extension Bundle {
+    // Keep SwiftMath's generated resource sidecar inside the signed app Resources directory.
+    static let swiftMathPackagedResources: Bundle = {
+        #if os(macOS)
+        if let url = Bundle.main.url(
+            forResource: \"SwiftMath_SwiftMath\",
+            withExtension: \"bundle\"),
+           let bundle = Bundle(url: url)
+        {
+            return bundle
+        }
+        #endif
+        return .module
+    }()
+}
+"""
+if swift_math_text.count(swift_math_marker) != 1:
+    raise SystemExit(f"Expected one SwiftMath insertion marker in {swift_math_font}")
+swift_math_font.write_text(
+    swift_math_text.replace(swift_math_marker, "\n#endif" + swift_math_injection + "\n/// Now available for everyone to use")
+)
+
+legacy_text = replace_exact(
+    swift_math_legacy_font,
+    "Bundle.module.url(forResource: \"mathFonts\", withExtension: \"bundle\")",
+    "Bundle.swiftMathPackagedResources.url(forResource: \"mathFonts\", withExtension: \"bundle\")",
+)
+swift_math_legacy_font.write_text(legacy_text)
+PY
+}
+
+trap restore_swiftpm_resource_sources EXIT
+
 PNPM_CMD=()
 
 resolve_pnpm_cmd() {
@@ -244,8 +368,10 @@ for arch in "${BUILD_ARCHS[@]}"; do
   BUILD_PATH="$(build_path_for_arch "$arch")"
   echo "📦 Resolving Swift packages [$arch]"
   run_with_locked_swift_packages swift package --scratch-path "$BUILD_PATH" resolve
+  patch_swiftpm_resource_lookups "$BUILD_PATH"
   echo "🔨 Building $PRODUCT ($BUILD_CONFIG) [$arch]"
   run_with_locked_swift_packages swift build -c "$BUILD_CONFIG" --product "$PRODUCT" --build-path "$BUILD_PATH" --arch "$arch" -Xlinker -rpath -Xlinker @executable_path/../Frameworks
+  restore_swiftpm_resource_sources
   echo "🔨 Building $MLX_TTS_HELPER_PRODUCT ($BUILD_CONFIG) [$arch]"
   swift build --package-path "$MLX_TTS_HELPER_ROOT" -c "$BUILD_CONFIG" --product "$MLX_TTS_HELPER_PRODUCT" --build-path "$(helper_build_path_for_arch "$arch")" --arch "$arch"
 done
@@ -380,27 +506,29 @@ else
   exit 1
 fi
 
-echo "📦 Copying OpenClawKit resources"
-OPENCLAWKIT_BUNDLE="$(build_path_for_arch "$PRIMARY_ARCH")/$BUILD_CONFIG/OpenClawKit_OpenClawKit.bundle"
-if [ -d "$OPENCLAWKIT_BUNDLE" ]; then
-  rm -rf "$APP_ROOT/Contents/Resources/OpenClawKit_OpenClawKit.bundle"
-  cp -R "$OPENCLAWKIT_BUNDLE" "$APP_ROOT/Contents/Resources/OpenClawKit_OpenClawKit.bundle"
-else
-  echo "ERROR: OpenClawKit resource bundle not found at $OPENCLAWKIT_BUNDLE" >&2
-  exit 1
-fi
-
-echo "⌨️  Copying KeyboardShortcuts resources"
-KEYBOARD_SHORTCUTS_BUNDLE="$(build_path_for_arch "$PRIMARY_ARCH")/$BUILD_CONFIG/KeyboardShortcuts_KeyboardShortcuts.bundle"
-if [ -d "$KEYBOARD_SHORTCUTS_BUNDLE" ]; then
-  # SwiftPM's generated Bundle.module accessor searches Bundle.main.resourceURL for app resources.
-  # Keep this under Contents/Resources or Recorder localization traps before Settings renders.
-  rm -rf "$APP_ROOT/Contents/Resources/KeyboardShortcuts_KeyboardShortcuts.bundle"
-  cp -R "$KEYBOARD_SHORTCUTS_BUNDLE" "$APP_ROOT/Contents/Resources/KeyboardShortcuts_KeyboardShortcuts.bundle"
-else
-  echo "ERROR: KeyboardShortcuts resource bundle not found at $KEYBOARD_SHORTCUTS_BUNDLE" >&2
-  exit 1
-fi
+echo "📦 Copying SwiftPM resource bundles"
+SWIFTPM_BUILD_PRODUCTS="$(build_path_for_arch "$PRIMARY_ARCH")/$BUILD_CONFIG"
+# Generated Bundle.module accessors resolve from Bundle.main.bundleURL. In a packaged app,
+# that is the .app root, not Contents/Resources; placing a bundle there traps on first access.
+for resource_bundle_src in "$SWIFTPM_BUILD_PRODUCTS"/*.bundle; do
+  [[ -d "$resource_bundle_src" ]] || continue
+  resource_bundle="${resource_bundle_src##*/}"
+  rm -rf "$APP_ROOT/Contents/Resources/$resource_bundle"
+  cp -R "$resource_bundle_src" "$APP_ROOT/Contents/Resources/$resource_bundle"
+done
+REQUIRED_SWIFTPM_RESOURCE_BUNDLES=(
+  "GRDB_GRDB.bundle"
+  "KeyboardShortcuts_KeyboardShortcuts.bundle"
+  "OpenClaw_OpenClaw.bundle"
+  "OpenClawKit_OpenClawKit.bundle"
+  "SwiftMath_SwiftMath.bundle"
+)
+for resource_bundle in "${REQUIRED_SWIFTPM_RESOURCE_BUNDLES[@]}"; do
+  if [[ ! -d "$APP_ROOT/Contents/Resources/$resource_bundle" ]]; then
+    echo "ERROR: Required SwiftPM resource bundle not found at $SWIFTPM_BUILD_PRODUCTS/$resource_bundle" >&2
+    exit 1
+  fi
+done
 
 running_packaged_app_pids() {
   command -v pgrep >/dev/null 2>&1 || return 0

--- a/test/scripts/package-mac-app.test.ts
+++ b/test/scripts/package-mac-app.test.ts
@@ -1,6 +1,6 @@
 // Package Mac App tests cover package mac app script behavior.
 import { spawnSync } from "node:child_process";
-import { chmodSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
@@ -100,6 +100,137 @@ function getSwiftCompatibilityBlock(): string {
   expect(end).toBeGreaterThan(start);
 
   return script.slice(start, end);
+}
+
+function getSwiftPMResourceBundleBlock(): string {
+  const script = readFileSync(scriptPath, "utf8");
+  const start = script.indexOf('echo "📦 Copying SwiftPM resource bundles"');
+  const end = script.indexOf("running_packaged_app_pids()");
+
+  expect(start).toBeGreaterThanOrEqual(0);
+  expect(end).toBeGreaterThan(start);
+
+  return script.slice(start, end);
+}
+
+function getSwiftPMResourcePatchBlock(): string {
+  const script = readFileSync(scriptPath, "utf8");
+  const start = script.indexOf("PATCHED_SWIFTPM_RESOURCE_SOURCES=()");
+  const end = script.indexOf("PNPM_CMD=()");
+
+  expect(start).toBeGreaterThanOrEqual(0);
+  expect(end).toBeGreaterThan(start);
+
+  return script.slice(start, end);
+}
+
+const swiftPMResourceBundles = [
+  "GRDB_GRDB.bundle",
+  "OpenClaw_OpenClaw.bundle",
+  "OpenClawKit_OpenClawKit.bundle",
+  "KeyboardShortcuts_KeyboardShortcuts.bundle",
+  "SwiftMath_SwiftMath.bundle",
+] as const;
+
+function runSwiftPMResourceBundleHarness(missingBundle?: string) {
+  const root = tempDirs.make("openclaw-package-resources-root-");
+  const buildRoot = path.join(root, "build");
+  const appRoot = path.join(root, "OpenClaw.app");
+  const buildProducts = path.join(buildRoot, "arm64", "debug");
+
+  mkdirSync(path.join(appRoot, "Contents", "Resources"), { recursive: true });
+  for (const bundle of swiftPMResourceBundles) {
+    if (bundle === missingBundle) {
+      continue;
+    }
+    const source = path.join(buildProducts, bundle);
+    mkdirSync(source, { recursive: true });
+    writeFileSync(path.join(source, "marker"), bundle, "utf8");
+  }
+
+  const result = runHelper(`
+    set -euo pipefail
+    BUILD_ROOT=${JSON.stringify(buildRoot)}
+    APP_ROOT=${JSON.stringify(appRoot)}
+    PRIMARY_ARCH=arm64
+    BUILD_CONFIG=debug
+    build_path_for_arch() {
+      echo "$BUILD_ROOT/$1"
+    }
+    ${getSwiftPMResourceBundleBlock()}
+  `);
+
+  return { appRoot, result };
+}
+
+function runSwiftPMResourcePatchHarness() {
+  const root = tempDirs.make("openclaw-package-resource-patch-");
+  const buildPath = path.join(root, "build");
+  const checkoutRoot = path.join(buildPath, "checkouts");
+  const keyboardShortcuts = path.join(
+    checkoutRoot,
+    "KeyboardShortcuts/Sources/KeyboardShortcuts/Utilities.swift",
+  );
+  const swiftMathFont = path.join(
+    checkoutRoot,
+    "SwiftMath/Sources/SwiftMath/MathBundle/MathFont.swift",
+  );
+  const swiftMathLegacyFont = path.join(
+    checkoutRoot,
+    "SwiftMath/Sources/SwiftMath/MathRender/MTFont.swift",
+  );
+  const fixtures = new Map([
+    [
+      keyboardShortcuts,
+      [
+        "import Foundation",
+        "extension String {",
+        "  var localized: String {",
+        "    NSLocalizedString(self, bundle: .module, comment: self)",
+        "  }",
+        "}",
+        "",
+        "extension Data {",
+        "}",
+        "",
+      ].join("\n"),
+    ],
+    [
+      swiftMathFont,
+      [
+        "import Foundation",
+        "#if os(macOS)",
+        "import AppKit",
+        "#endif",
+        "",
+        "/// Now available for everyone to use",
+        'let first = Bundle.module.url(forResource: "mathFonts", withExtension: "bundle")',
+        'let second = Bundle.module.url(forResource: "mathFonts", withExtension: "bundle")',
+        "",
+      ].join("\n"),
+    ],
+    [
+      swiftMathLegacyFont,
+      'let font = Bundle.module.url(forResource: "mathFonts", withExtension: "bundle")\n',
+    ],
+  ]);
+
+  for (const [file, contents] of fixtures) {
+    mkdirSync(path.dirname(file), { recursive: true });
+    writeFileSync(file, contents, "utf8");
+  }
+
+  const result = runHelper(`
+    set -euo pipefail
+    ${getSwiftPMResourcePatchBlock()}
+    patch_swiftpm_resource_lookups ${JSON.stringify(buildPath)}
+    grep -q keyboardShortcutsPackagedResources ${JSON.stringify(keyboardShortcuts)}
+    test "$(grep -c swiftMathPackagedResources ${JSON.stringify(swiftMathFont)})" -eq 3
+    grep -q swiftMathPackagedResources ${JSON.stringify(swiftMathLegacyFont)}
+    restore_swiftpm_resource_sources
+  `);
+
+  return { fixtures, result };
 }
 
 function runStopPackagedAppHarness(killZeroStatus: 0 | 1) {
@@ -661,35 +792,64 @@ describe("package-mac-app plist stamping", () => {
     expect(macosCi).toContain("test/scripts/notarize-mac-artifact.test.ts");
   });
 
-  it("fails closed when required Swift resources are missing", () => {
+  it("copies generated SwiftPM bundles into packaged app resources", () => {
+    const { appRoot, result } = runSwiftPMResourceBundleHarness();
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    for (const bundle of swiftPMResourceBundles) {
+      expect(
+        readFileSync(path.join(appRoot, "Contents", "Resources", bundle, "marker"), "utf8"),
+      ).toBe(bundle);
+      expect(existsSync(path.join(appRoot, bundle))).toBe(false);
+    }
+  });
+
+  it("routes dependency resource lookups into signed app resources and restores sources", () => {
+    const { fixtures, result } = runSwiftPMResourcePatchHarness();
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    for (const [file, contents] of fixtures) {
+      expect(readFileSync(file, "utf8")).toBe(contents);
+      expect(existsSync(`${file}.openclaw-original`)).toBe(false);
+    }
+  });
+
+  it("fails closed when any required SwiftPM resource bundle is missing", () => {
+    for (const missingBundle of swiftPMResourceBundles) {
+      const { result } = runSwiftPMResourceBundleHarness(missingBundle);
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain("ERROR: Required SwiftPM resource bundle not found at");
+      expect(result.stderr).toContain(missingBundle);
+    }
+  });
+
+  it("keeps generated SwiftPM bundles in the signed resources directory", () => {
     const script = readFileSync(scriptPath, "utf8");
-    const openClawKitBlock = script.slice(
-      script.indexOf(
-        'OPENCLAWKIT_BUNDLE="$(build_path_for_arch "$PRIMARY_ARCH")/$BUILD_CONFIG/OpenClawKit_OpenClawKit.bundle"',
-      ),
-      script.indexOf('echo "⌨️  Copying KeyboardShortcuts resources"'),
-    );
-    const keyboardShortcutsBlock = script.slice(
-      script.indexOf('echo "⌨️  Copying KeyboardShortcuts resources"'),
-      script.indexOf("running_packaged_app_pids()"),
-    );
+    const resourceBlock = getSwiftPMResourceBundleBlock();
 
     expect(script).toContain(
       'node --import tsx "$ROOT_DIR/scripts/apple-app-i18n.ts" compile-macos',
     );
     expect(script).toContain('--output "$APP_ROOT/Contents/Resources"');
-    expect(openClawKitBlock).toContain("ERROR: OpenClawKit resource bundle not found");
-    expect(openClawKitBlock).toContain("exit 1");
-    expect(openClawKitBlock).not.toContain("WARN:");
-    expect(openClawKitBlock).not.toContain("continuing");
-    expect(keyboardShortcutsBlock).toContain("KeyboardShortcuts_KeyboardShortcuts.bundle");
-    expect(keyboardShortcutsBlock).toContain(
-      'cp -R "$KEYBOARD_SHORTCUTS_BUNDLE" "$APP_ROOT/Contents/Resources/KeyboardShortcuts_KeyboardShortcuts.bundle"',
+    expect(resourceBlock).toContain(
+      'for resource_bundle_src in "$SWIFTPM_BUILD_PRODUCTS"/*.bundle',
     );
-    expect(keyboardShortcutsBlock).toContain("ERROR: KeyboardShortcuts resource bundle not found");
-    expect(keyboardShortcutsBlock).toContain("exit 1");
-    expect(keyboardShortcutsBlock).not.toContain("WARN:");
-    expect(keyboardShortcutsBlock).not.toContain("continuing");
+    expect(resourceBlock).toContain(
+      'cp -R "$resource_bundle_src" "$APP_ROOT/Contents/Resources/$resource_bundle"',
+    );
+    for (const bundle of swiftPMResourceBundles) {
+      expect(resourceBlock).toContain(`"${bundle}"`);
+    }
+    expect(resourceBlock).toContain("ERROR: Required SwiftPM resource bundle not found");
+    expect(resourceBlock).toContain("exit 1");
+    expect(resourceBlock).not.toContain(
+      'cp -R "$resource_bundle_src" "$APP_ROOT/$resource_bundle"',
+    );
+    expect(resourceBlock).not.toContain("WARN:");
+    expect(resourceBlock).not.toContain("continuing");
     expect(script).not.toContain("Textual resource bundle");
     expect(script).not.toContain("ALLOW_MISSING_TEXTUAL_BUNDLE");
   });


### PR DESCRIPTION
Related: #111270

## What Problem This Solves

Fixes an issue where users opening General Settings in a packaged macOS app would still crash when the Quick Chat shortcut recorder rendered, even though the KeyboardShortcuts resource bundle was present under `Contents/Resources`.

## Why This Change Was Made

Command-line SwiftPM builds compile dependency `Bundle.module` accessors that search beside `Bundle.main.bundleURL`, but a signed macOS app cannot contain sidecars at its `.app` root. The packager now temporarily redirects KeyboardShortcuts and SwiftMath resource lookups to the canonical signed `Contents/Resources` location, restores every modified checkout source after each build or failure, copies all emitted SwiftPM bundles, and fails closed unless all five required bundles are present.

## User Impact

Users can open General Settings and use the Quick Chat shortcut recorder without the macOS app terminating. Native math rendering also resolves its packaged font resources through the same valid signed-app boundary.

## Evidence

- Reproduced the attached `2026.7.2 (2607000290)` main-thread trap in `KeyboardShortcuts.RecorderCocoa.configureView()`. Binary inspection proved the compiled accessor called `Bundle.main.bundleURL`, while the installed app placed the bundle under `Contents/Resources`.
- Proved the tempting root-sidecar fix is invalid: Developer ID signing and `codesign --verify --deep --strict` reject resource bundles placed at the `.app` root.
- Blacksmith Testbox focused packaging harness: 29 passed, 2 platform skips.
- Blacksmith Testbox changed gate: formatting, dependency and package-patch guards, script declarations, root test typechecking, script lint, and 5 Vitest shards passed (200 tests passed, 37 platform skips). Run: https://github.com/openclaw/openclaw/actions/runs/30285456840
- Built the Swift product with Swift 6.4 on macOS 27, confirmed the binary contained the redirected KeyboardShortcuts and SwiftMath lookup symbols, and restored all patched checkout sources with no backup residue.
- Assembled commit `91d8a3acda4bcaf93733e7086e76c6f0228264c9` into a Developer ID-signed app, verified all five bundles under `Contents/Resources`, and passed `codesign --verify --deep --strict`.
- Native accessibility proof opened `OpenClaw Settings` and rendered `General`, `Quick Chat`, `Quick Chat shortcut`, and the configured `⌥Space` recorder. The exact signed process remained alive through a second inspection after 15 seconds.
- Fresh autoreview accepted one P1 (required-bundle validation), the branch now validates every required bundle by name, and the final rerun reported no accepted or actionable findings.

AI-assisted: Codex was used for diagnosis, implementation, testing, and validation; the maintainer reviewed the code and understands the change.
