### PR TITLE
fix(ui): keep Workboard cards in the selected agent scope

### DIFF
--- a/ui/src/components/agent-scope-control.test.ts
+++ b/ui/src/components/agent-scope-control.test.ts
@@ -23,6 +23,31 @@ function createSelection(setScope: (agentId: string | null) => void) {
 }
 
 describe("renderAgentScopeControl", () => {
+  it("does not wrap dropdown options in a label that reactivates the trigger", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+
+    render(
+      renderAgentScopeControl({
+        agents: [
+          { id: "main", name: "Main agent" },
+          { id: "writer", name: "Writer" },
+        ],
+        selection: createSelection(vi.fn()),
+      }),
+      container,
+    );
+
+    const select = container.querySelector<AgentSelectElement>("openclaw-agent-select");
+    await select?.updateComplete;
+
+    expect(select?.closest("label")).toBeNull();
+    expect(select?.querySelector(".agent-select__trigger")?.getAttribute("aria-label")).toContain(
+      "Agent",
+    );
+    container.remove();
+  });
+
   it("includes historical agent ids and maps All agents back to null", async () => {
     const container = document.createElement("div");
     document.body.append(container);

--- a/ui/src/components/agent-scope-control.ts
+++ b/ui/src/components/agent-scope-control.ts
@@ -60,8 +60,10 @@ export function renderAgentScopeControl(params: AgentScopeControlParams) {
       agent,
     })),
   ];
+  // The picker already labels its own trigger. A wrapping native label would
+  // forward an option click to that trigger and reopen the closed dropdown.
   return html`
-    <label class="agent-scope-control">
+    <div class="agent-scope-control">
       <span class="agent-scope-control__label">${t("agentScope.label")}</span>
       <openclaw-agent-select
         .options=${options}
@@ -69,6 +71,6 @@ export function renderAgentScopeControl(params: AgentScopeControlParams) {
         .accessibleLabel=${t("agentScope.label")}
         .onSelect=${(value: string) => params.selection.setScope(value || null)}
       ></openclaw-agent-select>
-    </label>
+    </div>
   `;
 }

--- a/ui/src/pages/workboard/view-card-modal.ts
+++ b/ui/src/pages/workboard/view-card-modal.ts
@@ -44,8 +44,30 @@ const workboardTemplates = [
   defineTemplate("plugin", "plugin", "plugin", "normal"),
 ];
 
-export function openCreateModal(state: WorkboardUiState) {
+export function openCreateModal(
+  state: WorkboardUiState,
+  props: Pick<WorkboardProps, "agentsList" | "defaultAgentId" | "scopeAgentId">,
+) {
   resetDraftState(state);
+  const scopedAgentId = props.scopeAgentId?.trim();
+  const defaultAgentId = props.agentsList?.defaultId?.trim() ?? props.defaultAgentId?.trim();
+  const selectedAgentId = scopedAgentId
+    ? scopedAgentId === defaultAgentId
+      ? ""
+      : scopedAgentId
+    : state.agentFilter === "all" || state.agentFilter === "default"
+      ? ""
+      : state.agentFilter;
+  if (
+    selectedAgentId &&
+    (props.agentsList
+      ? buildAssignableAgentOptions(props.agentsList, "").some(
+          (agent) => agent.id === selectedAgentId,
+        )
+      : Boolean(scopedAgentId))
+  ) {
+    state.draftAgentId = selectedAgentId;
+  }
   state.draftOpen = true;
 }
 

--- a/ui/src/pages/workboard/view-helpers.ts
+++ b/ui/src/pages/workboard/view-helpers.ts
@@ -28,6 +28,7 @@ export type WorkboardProps = {
   pluginEnabled: boolean | null;
   pluginEnablementError?: string | null;
   agentsList: AgentsListResult | null;
+  defaultAgentId?: string | null;
   sessions: GatewaySessionRow[];
   scopeAgentId?: string | null;
   showAgentFilter?: boolean;

--- a/ui/src/pages/workboard/view.test.ts
+++ b/ui/src/pages/workboard/view.test.ts
@@ -1809,6 +1809,147 @@ describe("renderWorkboard", () => {
     expect(container.querySelector(".workboard-board")).toBeTruthy();
   });
 
+  it.each([
+    {
+      name: "the selected named agent scope",
+      scopeAgentId: "writer",
+      agentFilter: "all",
+      expectedAgentId: "writer",
+    },
+    {
+      name: "the selected named agent filter",
+      scopeAgentId: null,
+      agentFilter: "ops",
+      expectedAgentId: "ops",
+    },
+    {
+      name: "the selected default agent scope",
+      scopeAgentId: "main",
+      agentFilter: "all",
+      expectedAgentId: "",
+    },
+    {
+      name: "the explicitly selected default agent filter",
+      scopeAgentId: null,
+      agentFilter: "main",
+      expectedAgentId: "main",
+    },
+    {
+      name: "the all-agents filter",
+      scopeAgentId: null,
+      agentFilter: "all",
+      expectedAgentId: "",
+    },
+    {
+      name: "the unassigned default-agent filter",
+      scopeAgentId: null,
+      agentFilter: "default",
+      expectedAgentId: "",
+    },
+    {
+      name: "a non-assignable system-agent diagnostic filter",
+      scopeAgentId: null,
+      agentFilter: "workboard-dispatcher",
+      expectedAgentId: "",
+    },
+  ])("initializes new cards from $name", ({ scopeAgentId, agentFilter, expectedAgentId }) => {
+    const { host, state } = createLoadedWorkboardState();
+    state.agentFilter = agentFilter;
+    const container = document.createElement("div");
+    const props = createWorkboardRenderProps(host, {
+      agentsList: {
+        defaultId: "main",
+        mainKey: "agent:main:main",
+        scope: "test",
+        agents: [
+          { id: "main", name: "Main" },
+          { id: "writer", name: "Writer" },
+          { id: "ops", name: "Ops" },
+          { id: "workboard-dispatcher", kind: "system", name: "Dispatcher" },
+        ],
+      },
+      scopeAgentId,
+    });
+
+    render(renderWorkboard(props), container);
+    container
+      .querySelector<HTMLButtonElement>(".workboard-toolbar__actions .btn.primary")
+      ?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    render(renderWorkboard(props), container);
+
+    expect(state.draftOpen).toBe(true);
+    expect(state.draftAgentId).toBe(expectedAgentId);
+    expect(
+      container.querySelector<HTMLElement & { value: string }>(
+        ".workboard-draft .workboard-agent-select",
+      )?.value,
+    ).toBe(expectedAgentId);
+  });
+
+  it.each([
+    {
+      name: "a selected named agent",
+      scopeAgentId: "writer",
+      defaultAgentId: "main",
+      expectedAgentId: "writer",
+    },
+    {
+      name: "the gateway's default agent",
+      scopeAgentId: "main",
+      defaultAgentId: "main",
+      expectedAgentId: "",
+    },
+    {
+      name: "a configured non-main default agent",
+      scopeAgentId: "research",
+      defaultAgentId: "research",
+      expectedAgentId: "",
+    },
+    {
+      name: "an unvalidated secondary agent filter",
+      scopeAgentId: null,
+      defaultAgentId: "main",
+      agentFilter: "ops",
+      expectedAgentId: "",
+    },
+    {
+      name: "a stale system-agent diagnostic filter",
+      scopeAgentId: null,
+      defaultAgentId: "main",
+      agentFilter: "workboard-dispatcher",
+      expectedAgentId: "",
+    },
+  ])(
+    "keeps $name while its roster has not loaded",
+    ({ scopeAgentId, defaultAgentId, agentFilter, expectedAgentId }) => {
+      const { host, state } = createLoadedWorkboardState();
+      state.agentFilter = agentFilter ?? "all";
+      if (agentFilter) {
+        state.cards = [createWorkboardCard({ agentId: agentFilter })];
+      }
+      const container = document.createElement("div");
+      const props = createWorkboardRenderProps(host, {
+        agentsList: null,
+        defaultAgentId,
+        scopeAgentId,
+      });
+
+      render(renderWorkboard(props), container);
+      container
+        .querySelector<HTMLButtonElement>(".workboard-toolbar__actions .btn.primary")
+        ?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      render(renderWorkboard(props), container);
+
+      expect(state.draftOpen).toBe(true);
+      expect(state.draftAgentId).toBe(expectedAgentId);
+      expect(
+        container.querySelector<HTMLElement & { value: string }>(
+          ".workboard-draft .workboard-agent-select",
+        )?.value,
+      ).toBe(expectedAgentId);
+    },
+  );
+
   it("applies card templates in the create modal", () => {
     const { host, state } = createLoadedWorkboardState();
     state.draftOpen = true;

--- a/ui/src/pages/workboard/view.ts
+++ b/ui/src/pages/workboard/view.ts
@@ -411,7 +411,7 @@ export function renderWorkboard(props: WorkboardProps) {
                     aria-controls=${workboardCardModalId}
                     ?disabled=${state.dispatching}
                     @click=${() => {
-                      openCreateModal(state);
+                      openCreateModal(state, props);
                       props.onRequestUpdate?.();
                     }}
                   >

--- a/ui/src/pages/workboard/workboard-page.ts
+++ b/ui/src/pages/workboard/workboard-page.ts
@@ -377,6 +377,7 @@ class WorkboardPage extends OpenClawLightDomElement {
         pluginEnablementError:
           !config.configSnapshot && !config.configLoading ? config.lastError : null,
         agentsList: context.agents.state.agentsList,
+        defaultAgentId: gateway.assistantAgentId,
         sessions: context.sessions.state.result?.sessions ?? [],
         scopeAgentId: context.agentSelection.state.scopeId,
         showAgentFilter: context.agentSelection.state.scopeId === null,

--- a/ui/src/pages/workboard/workboard-routing.e2e.test.ts
+++ b/ui/src/pages/workboard/workboard-routing.e2e.test.ts
@@ -168,6 +168,109 @@ describeControlUiE2e("Control UI Workboard routing", () => {
     }
   });
 
+  it("creates cards for the selected named agent without hiding them", async () => {
+    const context = await browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { width: 1600, height: 1000 },
+    });
+    const page = await context.newPage();
+    const createdCard = {
+      id: "writer-card",
+      title: "Keep the writer task visible",
+      status: "todo",
+      priority: "normal",
+      labels: [],
+      agentId: "writer",
+      position: 1000,
+      createdAt: 1,
+      updatedAt: 1,
+    };
+
+    try {
+      const gateway = await installMockGateway(page, {
+        methodResponses: {
+          "agents.list": {
+            defaultId: "main",
+            mainKey: "main",
+            scope: "agent",
+            agents: [
+              { id: "main", name: "Main" },
+              { id: "writer", name: "Writer" },
+            ],
+          },
+          "config.get": configSnapshot(true),
+          "sessions.list": sessionsListResponse(),
+          "tasks.list": { nextCursor: null, tasks: [] },
+          "workboard.boards.list": { boards },
+          "workboard.cards.list": { boards, cards: [], statuses: ["todo", "done"] },
+        },
+      });
+      await page.goto(`${server.baseUrl}workboard`);
+      await gateway.waitForRequest("agents.list");
+
+      const agentScope = page.locator(".agent-scope-control openclaw-agent-select");
+      await agentScope.locator(".agent-select__trigger").click();
+      await expect
+        .poll(() =>
+          agentScope
+            .locator("wa-dropdown-item[data-agent-option]")
+            .filter({ hasText: "Main" })
+            .evaluate((option) => option === document.activeElement),
+        )
+        .toBe(true);
+      await agentScope
+        .locator("wa-dropdown-item[data-agent-option]")
+        .filter({ hasText: "Writer" })
+        .click();
+      await expect
+        .poll(() =>
+          agentScope.evaluate((select) => (select as HTMLElement & { value: string }).value),
+        )
+        .toBe("writer");
+      await expect
+        .poll(
+          () =>
+            agentScope.locator("wa-dropdown").evaluate((dropdown) => {
+              const popup = dropdown.shadowRoot?.querySelector("wa-popup");
+              return {
+                open: (dropdown as HTMLElement & { open: boolean }).open,
+                popupActive: Boolean((popup as (HTMLElement & { active: boolean }) | null)?.active),
+              };
+            }),
+          { timeout: 5_000 },
+        )
+        .toEqual({ open: false, popupActive: false });
+
+      await gateway.deferNext("workboard.cards.create");
+      await page.getByRole("button", { name: /New card/u }).click();
+
+      const createForm = page.locator('openclaw-modal-dialog[label="New card"]');
+      await expect
+        .poll(() =>
+          createForm
+            .locator(".workboard-agent-select")
+            .evaluate((select) => (select as HTMLElement & { value: string }).value),
+        )
+        .toBe("writer");
+      await createForm.getByLabel("Title").fill(createdCard.title);
+      await createForm.getByRole("button", { name: /^Create$/u }).click();
+
+      const createRequest = await gateway.waitForRequest("workboard.cards.create");
+      expect(createRequest.params).toMatchObject({
+        agentId: "writer",
+        title: createdCard.title,
+      });
+      await gateway.resolveDeferred("workboard.cards.create", { card: createdCard });
+
+      await page.locator(".workboard-card", { hasText: createdCard.title }).waitFor({
+        state: "visible",
+      });
+    } finally {
+      await context.close();
+    }
+  });
+
   it("hides Workboard navigation while the plugin is inactive", async () => {
     const context = await browser.newContext({ serviceWorkers: "block" });
     const page = await context.newPage();


### PR DESCRIPTION
Closes #114649

## What Problem This Solves

Fixes an issue where users creating a Workboard card under a named agent or named agent filter would have the card assigned to the default agent and immediately disappear from their selected board. Also fixes a shared page agent picker issue where selecting an agent immediately reopens the dropdown and leaves its overlay blocking page controls.

## Why This Change Was Made

Initialize new card drafts from the authoritative page agent scope or a validated named filter. Preserve configured default and unassigned semantics, including non-`main` Gateway defaults and roster-loading/reconnect states; refuse unvalidated or system-agent filter assignments. Replace the shared scope control's native label with a non-activating container because the agent selector already supplies its accessible trigger label.

## User Impact

Cards created while Writer or another named agent is selected are assigned to that agent and stay visible. Page-level agent pickers close reliably on Workboard, Sessions, Tasks, Cron, Usage, and other shared agent-scope surfaces without losing their accessible names.

## Evidence

- Reproduced the original named-scope and named-filter Workboard regressions before the draft-owner fix.
- Reproduced stale-roster named and system-agent assignment as two failing rendered-component regressions, then verified both pass with validated assignment.
- Reproduced native label reactivation as a failing agent-scope regression and observed Chromium emit `wa-show → wa-after-show → wa-select → wa-hide → wa-show`; the corrected native-container boundary closes and fully deactivates the popup.
- Focused owner proof: **135 passing tests across six suites** (`agent-select`, `agent-scope-control`, application agent selection, Workboard rendering, agent filters, and Workboard page lifecycle).
- Actual isolated Linux Chromium: **5 passing tests across 2 complete E2E files**, including user-driven page agent selection, closed/deactivated overlay, exact `workboard.cards.create` params, persistent returned-card visibility, board routing, inactive plugins, page scope, and All agents. Blacksmith run: https://github.com/openclaw/openclaw/actions/runs/30288702112 (the one-shot wrapper reports `runStatus=succeeded`; Blacksmith may mark its backing lease job cancelled during normal cleanup).
- Exact final uncommitted independent autoreview: clean, no accepted or actionable findings.
- `git diff --cached --check`: clean.

AI-assisted: Codex.