### PR TITLE
fix(agents): prevent Windows shell startup bypassing auto-review

### DIFF
--- a/src/agents/exec-auto-review.stress.test.ts
+++ b/src/agents/exec-auto-review.stress.test.ts
@@ -124,6 +124,74 @@ describe.runIf(process.platform !== "win32")("exec auto-review shell stress", ()
   it.each<[string, string[], boolean]>([
     ["Fish short initializer", ["fish", "-C", "echo startup", "-c", "echo payload"], true],
     ["Fish long initializer", ["fish", "--init-command=echo startup", "-c", "echo payload"], true],
+    ["Windows cmd default AutoRun", ["cmd", "/c", "echo safe"], true],
+    ["Windows cmd.exe default AutoRun", ["cmd.exe", "/c", "echo safe"], true],
+    ["Windows cmd uppercase default AutoRun", ["CMD.EXE", "/C", "echo safe"], true],
+    ["Windows cmd hyphenated default AutoRun", ["cmd", "-c", "echo safe"], true],
+    ["Windows cmd persistent interactive shell", ["cmd", "/k", "echo safe"], true],
+    [
+      "Windows cmd persistent shell despite disabled AutoRun",
+      ["cmd", "/d", "/k", "echo safe"],
+      true,
+    ],
+    ["Windows cmd switch-only interactive shell", ["cmd", "/d"], true],
+    ["Windows cmd bare interactive shell", ["cmd.exe"], true],
+    ["Windows cmd missing inline payload", ["cmd", "/d", "/c"], true],
+    ["Windows cmd help still enables AutoRun", ["cmd", "/?"], true],
+    ["Windows cmd help cannot bind a later command", ["cmd", "/?", "/c", "echo safe"], true],
+    ["Windows cmd disabled AutoRun help still has no bound payload", ["cmd", "/d", "/?"], true],
+    [
+      "Windows cmd /r binds before a later AutoRun switch",
+      ["cmd", "/r", "/d", "/c", "echo safe"],
+      true,
+    ],
+    [
+      "Windows cmd /r after disabled AutoRun is not a bound /c",
+      ["cmd", "/d", "/r", "/c", "echo safe"],
+      true,
+    ],
+    [
+      "Windows cmd unknown switches cannot hide startup",
+      ["cmd", "/unknown", "/d", "/c", "echo safe"],
+      true,
+    ],
+    [
+      "Windows cmd color option cannot smuggle /k",
+      ["cmd", "/t:0f/k", "/d", "/c", "echo safe"],
+      true,
+    ],
+    [
+      "Windows cmd extension option cannot smuggle /k",
+      ["cmd", "/e:on/k", "/d", "/c", "echo safe"],
+      true,
+    ],
+    [
+      "Windows cmd expansion option cannot smuggle /r",
+      ["cmd", "/v:on/r", "/d", "/c", "echo safe"],
+      true,
+    ],
+    ["Windows cmd payload cannot disable prior AutoRun", ["cmd", "/c", "echo", "/d"], true],
+    ["Windows cmd profile-free command", ["cmd", "/d", "/c", "echo safe"], false],
+    [
+      "Windows cmd documented quiet and quote switches",
+      ["cmd", "/d", "/s", "/q", "/c", "echo safe"],
+      false,
+    ],
+    [
+      "Windows cmd documented configuration switches",
+      ["cmd", "/d", "/e:on", "/f:off", "/v:on", "/t:0f", "/c", "echo safe"],
+      false,
+    ],
+    [
+      "Windows cmd uppercase profile-free command",
+      ["CMD.EXE", "/D", "/S", "/C", "echo safe"],
+      false,
+    ],
+    [
+      "Windows cmd hyphenated switches do not disable AutoRun",
+      ["cmd", "-d", "-c", "echo safe"],
+      true,
+    ],
     ["PowerShell encoded flag", ["pwsh", "-EncodedCommand", "ZQBjAGgAbwA="], true],
     ["PowerShell encoded abbreviation", ["pwsh", "/ec", "ZQBjAGgAbwA="], true],
     ["PowerShell encoded prefix", ["pwsh", "-en", "ZQBjAGgAbwA="], true],
@@ -273,6 +341,53 @@ describe.runIf(process.platform !== "win32")("exec auto-review shell stress", ()
     }
   });
 
+  it("fails closed for 16,384 seeded Windows cmd startup wrapper chains", () => {
+    const random = createSeededRandom(0x20260728);
+    const opaqueShells = [
+      ["cmd", "/c", "echo safe"],
+      ["cmd.exe", "/C", "echo safe"],
+      ["CMD.EXE", "-c", "echo safe"],
+      ["cmd", "/k", "echo safe"],
+      ["cmd.exe", "/d", "/k", "echo safe"],
+      ["cmd", "/D", "/S", "/K", "echo safe"],
+      ["cmd", "-d", "-c", "echo safe"],
+      ["cmd", "/?"],
+      ["cmd", "/?", "/c", "echo safe"],
+      ["cmd.exe", "/d", "/?"],
+      ["cmd", "/r", "/d", "/c", "echo safe"],
+      ["cmd", "/d", "/r", "/c", "echo safe"],
+      ["cmd", "/unknown", "/d", "/c", "echo safe"],
+      ["cmd", "/t:0f/k", "/d", "/c", "echo safe"],
+      ["cmd", "/e:on/k", "/d", "/c", "echo safe"],
+      ["cmd", "/v:on/r", "/d", "/c", "echo safe"],
+      ["cmd.exe", "/d", "/c"],
+      ["cmd", "/c", "echo", "/d"],
+      ["cmd.exe"],
+    ] as const;
+    const dispatchWrappers = [
+      ["env", "--"],
+      ["nice", "-n", "5"],
+      ["nohup", "--"],
+      ["timeout", "5s"],
+      ["stdbuf", "-o", "L"],
+      ["time", "-p"],
+    ] as const;
+
+    for (let index = 0; index < 16_384; index += 1) {
+      const argv: string[] = [...chooseSeeded(random, opaqueShells)];
+      const wrapperDepth = Math.floor(random() * 7);
+      for (let depth = 0; depth < wrapperDepth; depth += 1) {
+        argv.unshift(...chooseSeeded(random, dispatchWrappers));
+      }
+
+      const trustPlan = resolveDispatchWrapperTrustPlan(argv);
+      expect(
+        trustPlan.policyBlocked || isBlockedShellWrapperCommand(trustPlan.argv),
+        `Windows cmd startup escaped at seed 0x20260728, case ${index}: ${JSON.stringify(argv)}`,
+      ).toBe(true);
+    }
+  });
+
   it.each([
     ["bash combined login", "bash -lc 'echo startup'"],
     ["bash reversed login flags", "bash -cl 'echo startup'"],
@@ -299,6 +414,31 @@ describe.runIf(process.platform !== "win32")("exec auto-review shell stress", ()
     ["timeout carrier", "timeout 5s bash -lc 'echo startup'"],
     ["nested carriers", "nohup -- nice -n 5 env -- bash -lc 'echo startup'"],
     ["opaque privileged carrier", "sudo bash -lc 'echo startup'"],
+    ["Windows cmd default AutoRun", "cmd /c echo safe"],
+    ["Windows cmd.exe default AutoRun", "cmd.exe /c echo safe"],
+    ["Windows cmd uppercase default AutoRun", "CMD.EXE /C echo safe"],
+    ["Windows cmd hyphenated default AutoRun", "cmd -c echo safe"],
+    ["Windows cmd hyphenated switches do not disable AutoRun", "cmd -d -c echo safe"],
+    ["Windows cmd persistent interactive shell", "cmd /k echo safe"],
+    ["Windows cmd persistent shell despite disabled AutoRun", "cmd /d /k echo safe"],
+    ["Windows cmd switch-only interactive shell", "cmd /d"],
+    ["Windows cmd bare interactive shell", "cmd.exe"],
+    ["Windows cmd missing inline payload", "cmd /d /c"],
+    ["Windows cmd help still enables AutoRun", "cmd /?"],
+    ["Windows cmd help cannot bind a later command", "cmd /? /c echo safe"],
+    ["Windows cmd disabled AutoRun help still has no bound payload", "cmd /d /?"],
+    ["Windows cmd /r binds before a later AutoRun switch", "cmd /r /d /c echo safe"],
+    ["Windows cmd /r after disabled AutoRun is not a bound /c", "cmd /d /r /c echo safe"],
+    ["Windows cmd unknown switches cannot hide startup", "cmd /unknown /d /c echo safe"],
+    ["Windows cmd color option cannot smuggle /k", "cmd /t:0f/k /d /c echo safe"],
+    ["Windows cmd extension option cannot smuggle /k", "cmd /e:on/k /d /c echo safe"],
+    ["Windows cmd expansion option cannot smuggle /r", "cmd /v:on/r /d /c echo safe"],
+    ["Windows cmd payload cannot disable prior AutoRun", "cmd /c echo /d"],
+    ["Windows cmd AutoRun inside transparent carrier", "env -- cmd.exe /c echo safe"],
+    [
+      "Windows cmd persistent shell inside nested carriers",
+      "nohup -- nice -n 5 env -- cmd.exe /d /k echo safe",
+    ],
     ["PowerShell default profile", "pwsh -Command 'Write-Output safe'"],
     ["Windows PowerShell default profile", "powershell -Command 'Write-Output safe'"],
     ["PowerShell positional script profile", "pwsh ./safe.ps1"],
@@ -460,6 +600,11 @@ describe.runIf(process.platform !== "win32")("exec auto-review shell stress", ()
     "node --version",
     "git status",
     "printf safe",
+    "cmd /d /c echo safe",
+    "cmd.exe /d /s /c echo safe",
+    "CMD.EXE /D /S /C echo safe",
+    "cmd /d /s /q /c echo safe",
+    "cmd /d /e:on /f:off /v:on /t:0f /c echo safe",
     "pwsh -NoProfile -Command 'Write-Output safe'",
     "pwsh -nop -c 'Write-Output safe'",
     "pwsh /NoProfile /c 'Write-Output safe'",

--- a/src/infra/shell-wrapper-resolution.ts
+++ b/src/infra/shell-wrapper-resolution.ts
@@ -329,6 +329,43 @@ function extractCmdInlineCommand(argv: string[]): string | null {
   return cmd.length > 0 ? cmd : null;
 }
 
+function hasCmdUnreviewedStartupBeforeInlineCommand(argv: string[]): boolean {
+  let autoRunDisabled = false;
+  for (let index = 1; index < argv.length; index += 1) {
+    const token = normalizeLowercaseStringOrEmpty(argv[index]);
+    if (!token) {
+      continue;
+    }
+    if (token === "/d") {
+      autoRunDisabled = true;
+      continue;
+    }
+    if (token === "/k") {
+      return true;
+    }
+    if (token === "/c") {
+      return !autoRunDisabled || !argv.slice(index + 1).some((value) => value.trim().length > 0);
+    }
+    if (
+      token === "/s" ||
+      token === "/q" ||
+      token === "/a" ||
+      token === "/u" ||
+      /^\/t:[\da-f]{1,2}$/u.test(token) ||
+      token === "/e:on" ||
+      token === "/e:off" ||
+      token === "/f:on" ||
+      token === "/f:off" ||
+      token === "/v:on" ||
+      token === "/v:off"
+    ) {
+      continue;
+    }
+    return true;
+  }
+  return true;
+}
+
 function extractPowerShellInlineCommand(argv: string[]): string | null {
   return resolvePowerShellInlineCommandMatch(argv).command;
 }
@@ -576,6 +613,11 @@ export function isBlockedShellWrapperCommand(argv: string[], rawCommand?: string
   const wrapper = findShellWrapperSpec(baseExecutable);
   if (!wrapper) {
     return false;
+  }
+  // cmd.exe runs registry AutoRun before /c; /k and bare invocations keep
+  // consuming unreviewed stdin. Only an explicit /d /c payload is bindable.
+  if (wrapper.kind === "cmd" && hasCmdUnreviewedStartupBeforeInlineCommand(candidate.argv)) {
+    return true;
   }
   if (wrapper.kind === "powershell") {
     const { command, valueTokenIndex } = resolvePowerShellInlineCommandMatch(candidate.argv);


### PR DESCRIPTION
Related: #114558

## What Problem This Solves

Fixes an issue where users relying on automatic execution review could have a Windows `cmd` command approved even though registry AutoRun, a persistent `/k` session, or an interactive shell could execute commands that the reviewer never saw. Transparent dispatch wrappers and nested gateway/node execution paths were affected too.

## Why This Change Was Made

Make the existing shared shell-trust boundary fail closed for Windows command startup. A `cmd` invocation is eligible for automatic review only when the native slash-prefixed `/d` disables AutoRun before `/c`, `/c` has a real payload, and every preceding switch and switch value exactly matches Microsoft's documented non-binding syntax. Reject misleading Unix-style `-d`/`-c` aliases, help and `/r` invocations, unknown startup switches, and `/k` or `/r` smuggled inside option values. Preserve canonical `cmd.exe /d /s /c` transport, valid quiet, quoting, color, extension, completion, and expansion switches, uppercase slash-prefixed equivalents, existing human approval, all public configuration, and single-use approval semantics.

Microsoft documents the relevant `/c`, `/k`, and `/d` contracts, including registry AutoRun: https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/cmd.

Directly verified the upstream Codex protocol and reviewer contract before changing the OpenClaw boundary: `../codex/codex-rs/protocol/src/config_types.rs:159`, `../codex/codex-rs/app-server-protocol/src/protocol/v2/shared.rs:224`, and `../codex/codex-rs/core/src/guardian/review.rs:173`.

## User Impact

Commands with hidden Windows startup behavior fall back to the normal human approval path instead of receiving an automatic approval for a different command. Normal finite, AutoRun-disabled Windows commands remain automatically reviewable, and existing gateway, node-host, plugin, and Codex execution behavior is preserved.

## Evidence

- Regression-first proof: the unmodified latest `main` failed 23 real Windows startup and nested-carrier attack cases; safe `/d /c` controls already passed.
- The fixed 177-case auto-review suite passes, including 16,384 deterministic seeded Windows dispatch-wrapper attacks and the existing 4,096 hostile POSIX wrapper cases.
- Ten repeated stress-suite passes cover 204,800 seeded hostile shell and carrier inputs plus 4,480 independently bound concurrent approval requests, with no cross-request approval reuse.
- All 767 focused regressions pass across 12 changed/sibling approval surfaces: shell classification, dispatch wrappers, gateway and node execution, real approval requests, node-host policy and execution binding, the plugin review runtime, and the Codex app-server approval bridge.
- ClawSweeper rank-up move completed: checked the slash-prefixed `/c`, `/k`, `/d`, `/s`, `/q`, `/a`, `/u`, `/t`, `/e`, `/f`, and `/v` startup grammar and exact option values against the linked Microsoft documentation, and exercised the exact-head gateway, node-host, plugin, shell, and Codex caller paths listed above.
- ClawSweeper rank-up move completed: directly inspected `../codex/codex-rs/protocol/src/config_types.rs:159`, `../codex/codex-rs/app-server-protocol/src/protocol/v2/shared.rs:224`, and `../codex/codex-rs/core/src/guardian/review.rs:173` for canonical `auto_review`, input-only guardian compatibility, and reviewer activation under `OnRequest` or `Granular` approval policies.
- Investigated related lifecycle-approval issue #99518 and existing PR #99530; they concern a different product boundary and are intentionally not duplicated or closed by this fix.
