### PR TITLE
fix(amazon-bedrock): lock claude-opus-5 adaptive thinking policy and request shape

### DIFF
--- a/extensions/amazon-bedrock/stream.runtime.test.ts
+++ b/extensions/amazon-bedrock/stream.runtime.test.ts
@@ -388,6 +388,53 @@ describe("Bedrock thinking effort mapping", () => {
   );
 
   it.each([
+    "us.anthropic.claude-opus-5",
+    "eu.anthropic.claude-opus-5",
+    "global.anthropic.claude-opus-5",
+    "anthropic.claude-opus-5-v1:0",
+    "us.anthropic.claude-opus-5-20260615-v1:0",
+  ])("sends adaptive thinking for Opus 5 profile %s at medium", (id) => {
+    const model = bedrockModel({
+      id,
+      name: "Claude Opus 5",
+      reasoning: true,
+      contextWindow: 1_000_000,
+      maxTokens: 128_000,
+      thinkingLevelMap: { xhigh: "xhigh", max: "max" },
+    });
+    const options = testing.resolveSimpleBedrockOptions(model, { reasoning: "medium" });
+
+    expect(testing.buildAdditionalModelRequestFields(model, options)).toEqual({
+      thinking: { type: "adaptive", display: "summarized" },
+      output_config: { effort: "medium" },
+    });
+  });
+
+  it.each([
+    { reasoning: "high" as const, expected: "high" },
+    { reasoning: "xhigh" as const, expected: "xhigh" },
+    { reasoning: "max" as const, expected: "max" },
+  ])("honors the requested Opus 5 effort for reasoning=$reasoning", ({ reasoning, expected }) => {
+    const model = bedrockModel({
+      id: "us.anthropic.claude-opus-5",
+      name: "Claude Opus 5",
+      reasoning: true,
+      contextWindow: 1_000_000,
+      maxTokens: 128_000,
+      thinkingLevelMap: { xhigh: "xhigh", max: "max" },
+    });
+    const fields = testing.buildAdditionalModelRequestFields(model, { reasoning });
+
+    // Adaptive-only models must never receive the removed
+    // thinking.type="enabled" + budget_tokens shape.
+    expect(fields).toEqual({
+      thinking: { type: "adaptive", display: "summarized" },
+      output_config: { effort: expected },
+    });
+    expect(JSON.stringify(fields)).not.toContain("budget_tokens");
+  });
+
+  it.each([
     { reasoning: undefined, expected: "high" },
     { reasoning: "off" as const, expected: "low" },
   ])("keeps Sonnet 5 adaptive for reasoning=$reasoning", ({ reasoning, expected }) => {

--- a/extensions/amazon-bedrock/thinking-policy.test.ts
+++ b/extensions/amazon-bedrock/thinking-policy.test.ts
@@ -1,0 +1,71 @@
+// Regression coverage for Claude Opus 5 thinking policy on Amazon Bedrock.
+// Opus 5 is adaptive-only: it must resolve to the adaptive thinking profile,
+// never the legacy `enabled` + `budget_tokens` extended-thinking shape.
+import { describe, expect, it } from "vitest";
+import {
+  isLatestAdaptiveBedrockModelRef,
+  isOpus47OrNewerBedrockModelRef,
+  resolveBedrockClaudeThinkingProfile,
+  resolveBedrockNativeThinkingLevelMap,
+  supportsBedrockNativeMaxEffort,
+} from "./thinking-policy.js";
+
+const OPUS_5_MODEL_IDS = [
+  "us.anthropic.claude-opus-5",
+  "eu.anthropic.claude-opus-5",
+  "global.anthropic.claude-opus-5",
+  "anthropic.claude-opus-5-v1:0",
+  "us.anthropic.claude-opus-5-20260615-v1:0",
+];
+
+describe("Bedrock Claude Opus 5 thinking policy", () => {
+  it.each(OPUS_5_MODEL_IDS)("treats %s as Opus 4.7-or-newer", (modelId) => {
+    expect(isOpus47OrNewerBedrockModelRef(modelId)).toBe(true);
+  });
+
+  it.each(OPUS_5_MODEL_IDS)("treats %s as latest adaptive", (modelId) => {
+    expect(isLatestAdaptiveBedrockModelRef(modelId)).toBe(true);
+  });
+
+  it.each(OPUS_5_MODEL_IDS)("supports native max effort for %s", (modelId) => {
+    expect(supportsBedrockNativeMaxEffort(modelId)).toBe(true);
+  });
+
+  it.each(OPUS_5_MODEL_IDS)("maps native xhigh/max effort for %s", (modelId) => {
+    expect(resolveBedrockNativeThinkingLevelMap(modelId)).toEqual({
+      xhigh: "xhigh",
+      max: "max",
+    });
+  });
+
+  it.each(OPUS_5_MODEL_IDS)("resolves the adaptive thinking profile for %s", (modelId) => {
+    const profile = resolveBedrockClaudeThinkingProfile(modelId);
+    expect(profile.levels.map((level) => level.id)).toEqual([
+      "off",
+      "minimal",
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+      "adaptive",
+      "max",
+    ]);
+    expect(profile.defaultLevel).toBe("high");
+  });
+
+  it("keeps legacy Claude Opus ids on the base thinking profile", () => {
+    const profile = resolveBedrockClaudeThinkingProfile(
+      "us.anthropic.claude-opus-4-5-20251101-v1:0",
+    );
+    expect(isLatestAdaptiveBedrockModelRef("us.anthropic.claude-opus-4-5-20251101-v1:0")).toBe(
+      false,
+    );
+    expect(profile.levels.map((level) => level.id)).toEqual([
+      "off",
+      "minimal",
+      "low",
+      "medium",
+      "high",
+    ]);
+  });
+});


### PR DESCRIPTION
Closes #114630

## What Problem This Solves

Fixes an issue where users selecting **Claude Opus 5** on the `amazon-bedrock` provider (`us.anthropic.claude-opus-5`) with any non-off thinking level would hit a Bedrock 400 (`"thinking.type.enabled" is not supported for this model`) and then silently complete the run with thinking disabled, making `/think medium|high|xhigh` no-ops.

Verification against current `main` shows the request-shaping code path is already correct: `supportsAdaptiveThinking` / `isLatestAdaptiveBedrockModelRef` / `resolveBedrockClaudeThinkingProfile` all recognize Opus 5 through the shared `resolveClaudeOpus5ModelIdentity` helper from `@openclaw/llm-core` (landed in the Opus 5 rollout), so no shared-code or matcher change is needed — mirroring the reviewer note on the issue. What was missing is regression coverage pinning that behavior, which this PR adds.

## Why This Change Was Made

Adds focused unit tests only (no production code change):

- New `extensions/amazon-bedrock/thinking-policy.test.ts` locks the Opus 5 thinking policy across Bedrock inference-profile id forms (`us.`/`eu.`/`global.` prefixes, bare and dated `:v1:0` ids): latest-adaptive classification, native max effort, the `{ xhigh, max }` level map, and the adaptive thinking profile (base levels + `xhigh` + `adaptive` + `max`, default `high`). A negative case keeps legacy Opus 4.5 on the base profile.
- `stream.runtime.test.ts` gains request-shape tests proving `buildAdditionalModelRequestFields` for Opus 5 emits `thinking: { type: "adaptive" }` with `output_config.effort` mapped from the requested level (`medium`/`high`/`xhigh`/`max`) — never the removed `enabled` + `budget_tokens` shape.

The tests reuse the existing shared Claude identity behavior instead of adding a parallel capability table, per the issue review guidance.

## User Impact

No behavior change. Bedrock users on Claude Opus 5 keep adaptive thinking with honored effort levels, and the provider is now guarded against regressions that would reintroduce the removed `thinking.type: "enabled"` payload and the silent thinking-off retry.

## Evidence

```
$ node scripts/run-vitest.mjs extensions/amazon-bedrock/thinking-policy.test.ts extensions/amazon-bedrock/stream.runtime.test.ts extensions/amazon-bedrock/provider-policy-api.test.ts
 ✓  extension-providers  extensions/amazon-bedrock/thinking-policy.test.ts (26 tests)
 ✓  extension-providers  extensions/amazon-bedrock/stream.runtime.test.ts (57 tests)
 ✓  extension-providers  extensions/amazon-bedrock/provider-policy-api.test.ts (10 tests)

 Test Files  3 passed (3)
      Tests  93 passed (93)
```

```
$ pnpm plugin-sdk:surface:check
unique entrypoint-qualified exports: 2725
package-exported forbidden subpaths: 0
```

---

🤖 AI-assisted change (OpenClaw fix-worker); verified locally with the targeted vitest runs above.

<details>
<summary>Maintainer note</summary>

Allow edits by maintainers is enabled. Happy to adjust scope if you'd rather pair this with a code change.
</details>