### PR TITLE
perf(gateway): stop per-row store and registry rediscovery in sessions.list

### DIFF
--- a/scripts/check-kysely-guardrails.mjs
+++ b/scripts/check-kysely-guardrails.mjs
@@ -47,6 +47,7 @@ const rawSqliteAllowPathGroups = {
     "src/infra/sqlite-wal.ts",
     "src/state/openclaw-agent-db-maintenance.ts",
     "src/state/openclaw-agent-db-registry.ts",
+    "src/state/openclaw-agent-db-registry-listing.ts",
     "src/state/openclaw-agent-db-schema-helpers.ts",
     "src/state/openclaw-agent-db-schema.ts",
     "src/state/openclaw-agent-db-session-nodes-migration.ts",

--- a/src/acp/runtime/session-meta.ts
+++ b/src/acp/runtime/session-meta.ts
@@ -3,7 +3,7 @@ import type { DatabaseSync } from "node:sqlite";
 import { safeParseJson } from "@openclaw/normalization-core";
 import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
-import { sql, type Insertable, type Selectable } from "kysely";
+import type { Insertable, Selectable } from "kysely";
 import { getRuntimeConfig } from "../../config/config.js";
 import { patchSessionEntryWithKey } from "../../config/sessions/session-accessor.js";
 import {
@@ -260,20 +260,21 @@ export function readAcpSessionMetaBatch(params: {
     env: params.env,
     path: params.databasePath,
   });
-  // SQLite's JSON table keeps this to one SELECT and one bind even for caller-requested
-  // list limits above the engine's variable cap; splitting it would restore per-batch latency.
+  // Chunked IN keeps each statement under SQLite's bind-variable cap, matching the
+  // sharing-store membership precedent; one statement per 500 keys instead of per row.
   const db = getAcpSessionKysely(database.db);
-  const requestedKeys = db
-    .selectFrom(
-      sql<{ value: string }>`json_each(${JSON.stringify([...entriesByKey.keys()])})`.as(
-        "requested_keys",
-      ),
-    )
-    .select("requested_keys.value");
-  const rows = executeSqliteQuerySync(
-    database.db,
-    db.selectFrom("acp_sessions").selectAll().where("session_key", "in", requestedKeys),
-  ).rows;
+  const requestedKeys = [...entriesByKey.keys()];
+  const keyChunks: string[][] = [];
+  for (let index = 0; index < requestedKeys.length; index += 500) {
+    keyChunks.push(requestedKeys.slice(index, index + 500));
+  }
+  const rows = keyChunks.flatMap(
+    (chunk) =>
+      executeSqliteQuerySync(
+        database.db,
+        db.selectFrom("acp_sessions").selectAll().where("session_key", "in", chunk),
+      ).rows,
+  );
   const rowsByKey = new Map(rows.map((row) => [row.session_key, row]));
   for (const [sessionKey, entries] of entriesByKey) {
     for (const entry of entries) {

--- a/src/acp/runtime/session-meta.ts
+++ b/src/acp/runtime/session-meta.ts
@@ -3,7 +3,7 @@ import type { DatabaseSync } from "node:sqlite";
 import { safeParseJson } from "@openclaw/normalization-core";
 import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
-import type { Insertable, Selectable } from "kysely";
+import { sql, type Insertable, type Selectable } from "kysely";
 import { getRuntimeConfig } from "../../config/config.js";
 import { patchSessionEntryWithKey } from "../../config/sessions/session-accessor.js";
 import {
@@ -227,6 +227,66 @@ export function readAcpSessionMetaForEntry(params: {
     return undefined;
   }
   return rowToAcpSessionMeta(row);
+}
+
+export function readAcpSessionMetaBatch(params: {
+  entries: ReadonlyArray<{
+    sessionKey: string;
+    entry: SessionEntry;
+  }>;
+  env?: NodeJS.ProcessEnv;
+  databasePath?: string;
+}): Map<SessionEntry, SessionAcpMeta | undefined> {
+  const result = new Map<SessionEntry, SessionAcpMeta | undefined>();
+  const entriesByKey = new Map<string, SessionEntry[]>();
+  for (const item of params.entries) {
+    const sessionKey = item.sessionKey.trim();
+    if (!sessionKey) {
+      continue;
+    }
+    if (item.entry?.acp) {
+      result.set(item.entry, item.entry.acp);
+      continue;
+    }
+    const entries = entriesByKey.get(sessionKey) ?? [];
+    entries.push(item.entry);
+    entriesByKey.set(sessionKey, entries);
+  }
+  if (entriesByKey.size === 0) {
+    return result;
+  }
+
+  const database = openOpenClawStateDatabase({
+    env: params.env,
+    path: params.databasePath,
+  });
+  // SQLite's JSON table keeps this to one SELECT and one bind even for caller-requested
+  // list limits above the engine's variable cap; splitting it would restore per-batch latency.
+  const db = getAcpSessionKysely(database.db);
+  const requestedKeys = db
+    .selectFrom(
+      sql<{ value: string }>`json_each(${JSON.stringify([...entriesByKey.keys()])})`.as(
+        "requested_keys",
+      ),
+    )
+    .select("requested_keys.value");
+  const rows = executeSqliteQuerySync(
+    database.db,
+    db.selectFrom("acp_sessions").selectAll().where("session_key", "in", requestedKeys),
+  ).rows;
+  const rowsByKey = new Map(rows.map((row) => [row.session_key, row]));
+  for (const [sessionKey, entries] of entriesByKey) {
+    for (const entry of entries) {
+      const row = resolveReadableAcpSessionRow({
+        row: rowsByKey.get(sessionKey),
+        entry,
+        env: params.env,
+        databasePath: params.databasePath,
+      });
+      result.set(entry, row ? rowToAcpSessionMeta(row) : undefined);
+    }
+  }
+  return result;
 }
 
 function selectAcpSessionRows(options: OpenClawStateDatabaseOptions = {}): AcpSessionRow[] {

--- a/src/gateway/server-methods/session-active-runs.test.ts
+++ b/src/gateway/server-methods/session-active-runs.test.ts
@@ -8,11 +8,67 @@ import {
   setActiveEmbeddedRun,
 } from "../../agents/embedded-agent-runner/runs.js";
 import { createReplyOperation } from "../../auto-reply/reply/reply-run-registry.js";
-import { clearAgentRunContext, registerAgentRunContext } from "../../infra/agent-events.js";
 import {
+  buildProjectedAgentRunIndex,
+  clearAgentRunContext,
+  registerAgentRunContext,
+} from "../../infra/agent-events.js";
+import {
+  collectTrackedActiveSessionRuns,
   hasVisibleActiveSessionRun,
   resolveVisibleActiveSessionRunState,
 } from "./session-active-runs.js";
+
+it("keeps prebuilt active-run indexes in parity with per-row scans", () => {
+  const context = {
+    chatAbortControllers: new Map([
+      ["run-main", { sessionKey: "agent:main:main", sessionId: "session-main" }],
+      ["run-global", { sessionKey: "global", agentId: "work" }],
+      ["run-hidden", { sessionKey: "agent:main:hidden", projectSessionActive: false }],
+    ]),
+  } as never;
+  registerAgentRunContext("projected-key", {
+    projectSessionActive: true,
+    sessionKey: "agent:main:projected",
+  });
+  registerAgentRunContext("projected-id", {
+    projectSessionActive: true,
+    sessionId: "session-projected",
+  });
+  try {
+    const trackedActiveRuns = collectTrackedActiveSessionRuns(context);
+    const projectedAgentRunIndex = buildProjectedAgentRunIndex();
+    const cases = [
+      { requestedKey: "agent:main:main", canonicalKey: "agent:main:main" },
+      { requestedKey: "agent:main:projected", canonicalKey: "agent:main:projected" },
+      {
+        requestedKey: "agent:main:by-id",
+        canonicalKey: "agent:main:by-id",
+        sessionId: "session-projected",
+      },
+      {
+        requestedKey: "global",
+        canonicalKey: "global",
+        agentId: "work",
+        defaultAgentId: "main",
+      },
+      { requestedKey: "agent:main:missing", canonicalKey: "agent:main:missing" },
+    ];
+    for (const activeCase of cases) {
+      expect(
+        resolveVisibleActiveSessionRunState({
+          context,
+          ...activeCase,
+          trackedActiveRuns,
+          projectedAgentRunIndex,
+        }),
+      ).toEqual(resolveVisibleActiveSessionRunState({ context, ...activeCase }));
+    }
+  } finally {
+    clearAgentRunContext("projected-key");
+    clearAgentRunContext("projected-id");
+  }
+});
 
 it("matches session-id-only gateway runs during archive admission", () => {
   const context = {

--- a/src/gateway/server-methods/session-active-runs.ts
+++ b/src/gateway/server-methods/session-active-runs.ts
@@ -7,7 +7,7 @@ import { normalizeAgentId } from "../../routing/session-key.js";
 import type { GatewayRequestContext } from "./types.js";
 
 /** Active-run matcher including hidden remote lifecycle projections. */
-export type TrackedActiveSessionRun = {
+type TrackedActiveSessionRun = {
   runId: string;
   sessionKey?: string;
   sessionId?: string;

--- a/src/gateway/server-methods/session-active-runs.ts
+++ b/src/gateway/server-methods/session-active-runs.ts
@@ -1,17 +1,20 @@
 import { isEmbeddedAgentRunInProgress } from "../../agents/embedded-agent-runner/runs.js";
-import { hasProjectedAgentRunForSession } from "../../infra/agent-events.js";
+import {
+  hasProjectedAgentRunForSession,
+  type ProjectedAgentRunIndex,
+} from "../../infra/agent-events.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
 import type { GatewayRequestContext } from "./types.js";
 
 /** Active-run matcher including hidden remote lifecycle projections. */
-type TrackedActiveSessionRun = {
+export type TrackedActiveSessionRun = {
   runId: string;
   sessionKey?: string;
   sessionId?: string;
   agentId?: string;
 };
 
-function collectTrackedActiveSessionRuns(
+export function collectTrackedActiveSessionRuns(
   context: Partial<Pick<GatewayRequestContext, "chatAbortControllers">>,
 ): TrackedActiveSessionRun[] {
   const runs: TrackedActiveSessionRun[] = [];
@@ -91,9 +94,11 @@ export function resolveVisibleActiveSessionRunState(params: {
   sessionId?: string;
   agentId?: string;
   defaultAgentId?: string;
+  trackedActiveRuns?: readonly TrackedActiveSessionRun[];
+  projectedAgentRunIndex?: ProjectedAgentRunIndex;
 }): { active: boolean; runIds: string[] } {
   const sessionId = params.sessionId?.trim();
-  const runIds = collectTrackedActiveSessionRuns(params.context)
+  const runIds = (params.trackedActiveRuns ?? collectTrackedActiveSessionRuns(params.context))
     .filter(
       (active) =>
         isTrackedActiveSessionRunForKey(
@@ -115,6 +120,7 @@ export function resolveVisibleActiveSessionRunState(params: {
   const hasProjectedRun = hasProjectedAgentRunForSession({
     sessionKeys: [params.requestedKey, params.canonicalKey],
     ...(sessionId ? { sessionId } : {}),
+    ...(params.projectedAgentRunIndex ? { index: params.projectedAgentRunIndex } : {}),
   });
   const embeddedRunInProgress = sessionId !== undefined && isEmbeddedAgentRunInProgress(sessionId);
   // Connection, worker-lifecycle, and embedded registries are independent owners.

--- a/src/gateway/server-methods/sessions-read.ts
+++ b/src/gateway/server-methods/sessions-read.ts
@@ -23,6 +23,7 @@ import {
 } from "../../config/sessions.js";
 import { listSessionEntriesReadOnly } from "../../config/sessions/session-accessor.js";
 import { searchSessionTranscripts } from "../../config/sessions/session-transcript-search.js";
+import { buildProjectedAgentRunIndex } from "../../infra/agent-events.js";
 import {
   measureDiagnosticsTimelineSpan,
   measureDiagnosticsTimelineSpanSync,
@@ -51,7 +52,10 @@ import {
   readRecentSessionMessagesWithStatsAsync,
   readSessionPreviewItemsFromTranscript,
 } from "../session-transcript-readers.js";
-import type { GatewaySessionStoreCache } from "../session-utils-store-lookup.js";
+import type {
+  GatewaySessionStoreCache,
+  GatewaySessionStoreDiscoveryCache,
+} from "../session-utils-store-lookup.js";
 import {
   buildGatewaySessionRow,
   listSessionsFromStoreAsync,
@@ -66,7 +70,10 @@ import { resolveSessionKeyFromResolveParams } from "../sessions-resolve.js";
 import { projectWorkerSessionPlacement } from "../worker-environments/placement-projector.js";
 import { gatewayClientSessionCreator } from "./gateway-client-identity.js";
 import { loadOptionalServerMethodModelCatalog } from "./optional-model-catalog.js";
-import { resolveVisibleActiveSessionRunState } from "./session-active-runs.js";
+import {
+  collectTrackedActiveSessionRuns,
+  resolveVisibleActiveSessionRunState,
+} from "./session-active-runs.js";
 import { emitSessionsChanged } from "./session-change-event.js";
 import {
   filterSessionStoreToConfiguredAgents,
@@ -279,63 +286,81 @@ export const sessionReadHandlers: GatewayRequestHandlers = {
             },
           },
         );
-        // One cache for the whole listing: sharing resolution otherwise
-        // materialized every entry of a candidate store once per row.
-        const sharingStoreCache: GatewaySessionStoreCache = new Map();
-        const sharingTargets = result.sessions.map((session) =>
-          resolveSessionSharingTarget({
-            cfg,
-            projection: "list",
-            sessionKey: session.key,
-            storeCache: sharingStoreCache,
-            ...(session.key === "global" && p.agentId ? { agentId: p.agentId } : {}),
-          }),
-        );
-        const membershipKeys = new Set<string>();
         const identityId = gatewayClientSessionCreator(client)?.id;
-        if (identityId && !isGatewayAdmin(client)) {
-          const groups = new Map<
-            string,
-            {
-              agentId: string;
-              sessionKeys: string[];
-              storePath: string;
+        const { sharingTargets, membershipKeys } = await measureDiagnosticsTimelineSpan(
+          "gateway.sessions.list.sharing",
+          () => {
+            // One cache for the whole listing: sharing resolution otherwise
+            // materialized every entry of a candidate store once per row.
+            const sharingStoreCache: GatewaySessionStoreCache = new Map();
+            const targetDiscoveryCache: GatewaySessionStoreDiscoveryCache = new Map();
+            const sharingTargets = result.sessions.map((session) =>
+              resolveSessionSharingTarget({
+                cfg,
+                projection: "list",
+                sessionKey: session.key,
+                storeCache: sharingStoreCache,
+                targetDiscoveryCache,
+                ...(session.key === "global" && p.agentId ? { agentId: p.agentId } : {}),
+              }),
+            );
+            const membershipKeys = new Set<string>();
+            if (identityId && !isGatewayAdmin(client)) {
+              const groups = new Map<
+                string,
+                {
+                  agentId: string;
+                  sessionKeys: string[];
+                  storePath: string;
+                }
+              >();
+              for (const target of sharingTargets) {
+                if (!target) {
+                  continue;
+                }
+                const groupKey = `${target.agentId}\0${target.storePath}`;
+                const group = groups.get(groupKey) ?? {
+                  agentId: target.agentId,
+                  sessionKeys: [],
+                  storePath: target.storePath,
+                };
+                group.sessionKeys.push(target.storeKey);
+                groups.set(groupKey, group);
+              }
+              for (const group of groups.values()) {
+                const firstSessionKey = group.sessionKeys[0];
+                if (!firstSessionKey) {
+                  continue;
+                }
+                for (const sessionKey of listSessionMembershipKeys(
+                  {
+                    agentId: group.agentId,
+                    sessionKey: firstSessionKey,
+                    storePath: group.storePath,
+                  },
+                  group.sessionKeys,
+                  identityId,
+                )) {
+                  membershipKeys.add(`${group.agentId}\0${group.storePath}\0${sessionKey}`);
+                }
+              }
             }
-          >();
-          for (const target of sharingTargets) {
-            if (!target) {
-              continue;
-            }
-            const groupKey = `${target.agentId}\0${target.storePath}`;
-            const group = groups.get(groupKey) ?? {
-              agentId: target.agentId,
-              sessionKeys: [],
-              storePath: target.storePath,
-            };
-            group.sessionKeys.push(target.storeKey);
-            groups.set(groupKey, group);
-          }
-          for (const group of groups.values()) {
-            const firstSessionKey = group.sessionKeys[0];
-            if (!firstSessionKey) {
-              continue;
-            }
-            for (const sessionKey of listSessionMembershipKeys(
-              {
-                agentId: group.agentId,
-                sessionKey: firstSessionKey,
-                storePath: group.storePath,
-              },
-              group.sessionKeys,
-              identityId,
-            )) {
-              membershipKeys.add(`${group.agentId}\0${group.storePath}\0${sessionKey}`);
-            }
-          }
-        }
+            return { sharingTargets, membershipKeys };
+          },
+          {
+            config: cfg,
+            phase: "sessions.list",
+            attributes: {
+              sessions: result.sessions.length,
+            },
+          },
+        );
         const placementsBySessionId = context.workerSessionPlacementService?.getMany(
           result.sessions.flatMap((session) => (session.sessionId ? [session.sessionId] : [])),
         );
+        const trackedActiveRuns = collectTrackedActiveSessionRuns(context);
+        const projectedAgentRunIndex = buildProjectedAgentRunIndex();
+        const defaultAgentId = resolveDefaultAgentId(cfg);
         const sessions = measureDiagnosticsTimelineSpanSync(
           "gateway.sessions.list.active_run_flags",
           () => {
@@ -353,7 +378,9 @@ export const sessionReadHandlers: GatewayRequestHandlers = {
                 canonicalKey: session.key,
                 sessionId: session.sessionId,
                 ...(session.key === "global" && p.agentId ? { agentId: p.agentId } : {}),
-                defaultAgentId: resolveDefaultAgentId(cfg),
+                defaultAgentId,
+                trackedActiveRuns,
+                projectedAgentRunIndex,
               });
               return Object.assign({}, session, {
                 visibility,

--- a/src/gateway/server-methods/sessions-read.ts
+++ b/src/gateway/server-methods/sessions-read.ts
@@ -294,7 +294,7 @@ export const sessionReadHandlers: GatewayRequestHandlers = {
             // materialized every entry of a candidate store once per row.
             const sharingStoreCache: GatewaySessionStoreCache = new Map();
             const targetDiscoveryCache: GatewaySessionStoreDiscoveryCache = new Map();
-            const sharingTargets = result.sessions.map((session) =>
+            const resolvedSharingTargets = result.sessions.map((session) =>
               resolveSessionSharingTarget({
                 cfg,
                 projection: "list",
@@ -304,7 +304,7 @@ export const sessionReadHandlers: GatewayRequestHandlers = {
                 ...(session.key === "global" && p.agentId ? { agentId: p.agentId } : {}),
               }),
             );
-            const membershipKeys = new Set<string>();
+            const resolvedMembershipKeys = new Set<string>();
             if (identityId && !isGatewayAdmin(client)) {
               const groups = new Map<
                 string,
@@ -314,7 +314,7 @@ export const sessionReadHandlers: GatewayRequestHandlers = {
                   storePath: string;
                 }
               >();
-              for (const target of sharingTargets) {
+              for (const target of resolvedSharingTargets) {
                 if (!target) {
                   continue;
                 }
@@ -341,11 +341,14 @@ export const sessionReadHandlers: GatewayRequestHandlers = {
                   group.sessionKeys,
                   identityId,
                 )) {
-                  membershipKeys.add(`${group.agentId}\0${group.storePath}\0${sessionKey}`);
+                  resolvedMembershipKeys.add(`${group.agentId}\0${group.storePath}\0${sessionKey}`);
                 }
               }
             }
-            return { sharingTargets, membershipKeys };
+            return {
+              sharingTargets: resolvedSharingTargets,
+              membershipKeys: resolvedMembershipKeys,
+            };
           },
           {
             config: cfg,

--- a/src/gateway/server.sessions.list-store-materialization.test.ts
+++ b/src/gateway/server.sessions.list-store-materialization.test.ts
@@ -4,6 +4,7 @@
  * connection reuse removed the per-row SQLite opens.
  */
 import { expect, test, vi } from "vitest";
+import * as sessionsConfig from "../config/sessions.js";
 import * as sessionAccessor from "../config/sessions/session-accessor.js";
 import { resolveSqliteTargetFromSessionStorePath } from "../config/sessions/session-sqlite-target.js";
 import type { SessionEntry } from "../config/sessions/types.js";
@@ -70,6 +71,26 @@ test("sessions.list does not materialize the lookup store once per row", async (
   // The post-await sharing refresh intentionally rereads current ACL state,
   // but one request-scoped load per store keeps that refresh linear.
   expect(large).toBeLessThan(small * 12);
+});
+
+test("sessions.list discovers store targets at most once per agent", async () => {
+  await createSessionStoreDir();
+  await writeSessionStore({
+    entries: Object.fromEntries(
+      Array.from({ length: 20 }, (_, index) => [
+        `agent:main:row-${index}`,
+        sessionStoreEntry(`sess-row-${index}`),
+      ]),
+    ),
+  });
+  const discoverySpy = vi.spyOn(sessionsConfig, "resolveExistingAgentSessionStoreTargetsSync");
+  try {
+    const result = await directSessionReq("sessions.list", LIST_PARAMS);
+    expect(result.ok).toBe(true);
+    expect(discoverySpy.mock.calls.filter((call) => call[1] === "main")).toHaveLength(1);
+  } finally {
+    discoverySpy.mockRestore();
+  }
 });
 
 test("sessions.list projects out prompt snapshots without changing full entry reads", async () => {

--- a/src/gateway/session-sharing.ts
+++ b/src/gateway/session-sharing.ts
@@ -27,7 +27,10 @@ import {
   loadCachedSessionSharingSnapshot,
   type SessionSharingSnapshot,
 } from "./session-sharing-snapshot-cache.js";
-import type { GatewaySessionStoreCache } from "./session-utils-store-lookup.js";
+import type {
+  GatewaySessionStoreCache,
+  GatewaySessionStoreDiscoveryCache,
+} from "./session-utils-store-lookup.js";
 import {
   resolveFreshestSessionStoreMatchFromStoreKeys,
   resolveGatewaySessionStoreTargetWithStore,
@@ -103,13 +106,16 @@ export function resolveSessionSharingTarget(params: {
   agentId?: string;
   projection?: "full" | "list";
   storeCache?: GatewaySessionStoreCache;
+  targetDiscoveryCache?: GatewaySessionStoreDiscoveryCache;
 }): SessionSharingTarget | null {
   const target = resolveGatewaySessionStoreTargetWithStore({
     cfg: params.cfg,
     key: params.sessionKey,
     agentId: params.agentId,
+    clone: false,
     ...(params.projection ? { projection: params.projection } : {}),
     ...(params.storeCache ? { storeCache: params.storeCache } : {}),
+    ...(params.targetDiscoveryCache ? { targetDiscoveryCache: params.targetDiscoveryCache } : {}),
   });
   const match = resolveFreshestSessionStoreMatchFromStoreKeys(target.store, target.storeKeys);
   return match

--- a/src/gateway/session-utils-contracts.ts
+++ b/src/gateway/session-utils-contracts.ts
@@ -5,7 +5,7 @@ import {
 import type { resolveSessionModelRef } from "../agents/session-model-ref.js";
 import type { buildSubagentRunReadIndex } from "../agents/subagent-registry-read.js";
 import type { ThinkLevel, listThinkingLevelOptions } from "../auto-reply/thinking.js";
-import type { SessionEntry } from "../config/sessions.js";
+import type { SessionAcpMeta, SessionEntry } from "../config/sessions.js";
 import type { ModelCostConfig } from "../utils/usage-format.js";
 
 export type SessionListRowContext = {
@@ -22,6 +22,7 @@ export type SessionListRowContext = {
   displayModelIdentityByKey: Map<string, { provider?: string; model?: string }>;
   modelCostConfigByModelRef: Map<string, ModelCostConfig | undefined>;
   userProfileLabelById: Map<string, string | undefined>;
+  acpSessionMetaByEntry: Map<SessionEntry, SessionAcpMeta | undefined>;
 };
 
 export type SessionListRowContextProvider = () => SessionListRowContext;

--- a/src/gateway/session-utils-list.ts
+++ b/src/gateway/session-utils-list.ts
@@ -4,6 +4,7 @@ import {
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
 import type { SessionsListParams } from "../../packages/gateway-protocol/src/index.js";
+import { readAcpSessionMetaBatch } from "../acp/runtime/session-meta.js";
 import { resolveDefaultAgentId } from "../agents/agent-scope.js";
 import type { ModelCatalogEntry } from "../agents/model-catalog.js";
 import {
@@ -17,6 +18,7 @@ import { withPinnedActivePluginRegistryWorkspaceDir } from "../plugins/runtime-w
 import { normalizeAgentId, parseAgentSessionKey } from "../routing/session-key.js";
 import { isCronRunSessionKey } from "../sessions/session-key-utils.js";
 import { type SessionEntryPair, sortAndLimitSessionEntries } from "./session-list-order.js";
+import { resolveStoredSessionKeyForAgentStore } from "./session-store-key.js";
 import { readSessionTitleFieldsFromTranscriptAsync as readScopedSessionTitleFieldsFromTranscriptAsync } from "./session-transcript-readers.js";
 import type {
   SessionListRowContext,
@@ -62,6 +64,34 @@ type SessionEntrySelection = {
   nextOffset: number | null;
   hasMore: boolean;
 };
+
+function populateSessionListAcpMetadata(params: {
+  cfg: OpenClawConfig;
+  entries: readonly SessionEntryPair[];
+  opts: SessionsListParams;
+  rowContext?: SessionListRowContext;
+}): void {
+  if (!params.rowContext || params.entries.length === 0) {
+    return;
+  }
+  const entries = params.entries.map(([key, entry]) => {
+    const parsed = parseAgentSessionKey(key);
+    const agentId = normalizeAgentId(
+      key === "global" && typeof params.opts.agentId === "string"
+        ? params.opts.agentId
+        : (parsed?.agentId ?? resolveDefaultAgentId(params.cfg)),
+    );
+    return {
+      sessionKey: resolveStoredSessionKeyForAgentStore({
+        cfg: params.cfg,
+        agentId,
+        sessionKey: key,
+      }),
+      entry,
+    };
+  });
+  params.rowContext.acpSessionMetaByEntry = readAcpSessionMetaBatch({ entries });
+}
 
 function resolveSessionsListLimit(
   opts: SessionsListParams,
@@ -350,6 +380,7 @@ export function listSessionsFromStore(params: {
   const sharedRowContext =
     fullRowContext ??
     (entries.length > 0 ? buildSessionListRowMetadataContext({ now }) : undefined);
+  populateSessionListAcpMetadata({ cfg, entries, opts, rowContext: sharedRowContext });
 
   const sessions = entries.map(([key, entry], index) => {
     const includeTranscriptFields = index < sessionListTranscriptFieldRows;
@@ -451,6 +482,7 @@ export async function listSessionsFromStoreAsync(params: {
     const sharedRowContext =
       fullRowContext ??
       (entries.length > 0 ? buildSessionListRowMetadataContext({ now }) : undefined);
+    populateSessionListAcpMetadata({ cfg, entries, opts, rowContext: sharedRowContext });
 
     const sessions: GatewaySessionRow[] = [];
     for (let i = 0; i < entries.length; i++) {

--- a/src/gateway/session-utils-model.ts
+++ b/src/gateway/session-utils-model.ts
@@ -169,7 +169,12 @@ type GatewaySessionThinkingProjectionParams = {
 export function resolveGatewaySessionThinkingProjectionInternal(
   params: GatewaySessionThinkingProjectionParams,
 ) {
-  const acpMeta = readAcpSessionMeta({ sessionKey: params.sessionKey });
+  const cachedAcpMeta = params.rowContext?.acpSessionMetaByEntry;
+  const acpMeta =
+    params.entry?.acp ??
+    (params.entry && cachedAcpMeta?.has(params.entry)
+      ? cachedAcpMeta.get(params.entry)
+      : readAcpSessionMeta({ sessionKey: params.sessionKey }));
   const configuredAgentRuntime = resolveModelAgentRuntimeMetadata({
     cfg: params.cfg,
     agentId: params.agentId,

--- a/src/gateway/session-utils-projection.ts
+++ b/src/gateway/session-utils-projection.ts
@@ -42,6 +42,7 @@ function buildSessionListRowContextFromParts(params: {
     displayModelIdentityByKey: new Map(),
     modelCostConfigByModelRef: new Map(),
     userProfileLabelById: new Map(),
+    acpSessionMetaByEntry: new Map(),
   };
 }
 

--- a/src/gateway/session-utils-store-lookup.ts
+++ b/src/gateway/session-utils-store-lookup.ts
@@ -3,7 +3,6 @@ import { listAgentIds } from "../agents/agent-scope.js";
 import {
   isConfiguredSessionStoreAgentId,
   resolveAgentMainSessionKey,
-  resolveAllAgentSessionStoreTargetsSync,
   resolveExistingAgentSessionStoreTargetsSync,
   resolveStorePath,
   type SessionEntry,
@@ -85,16 +84,23 @@ function buildGatewaySessionStoreScanTargets(params: {
 function resolveGatewaySessionStoreCandidates(
   cfg: OpenClawConfig,
   agentId: string,
+  cache?: GatewaySessionStoreDiscoveryCache,
 ): { existing: SessionStoreTarget[]; fallback: SessionStoreTarget } {
+  const cached = cache?.get(agentId);
+  if (cached) {
+    return cached;
+  }
   const storeConfig = cfg.session?.store;
   const fallback = {
     agentId,
     storePath: resolveStorePath(storeConfig, { agentId }),
   };
-  return {
+  const discovery = {
     existing: resolveExistingAgentSessionStoreTargetsSync(cfg, agentId),
     fallback,
   };
+  cache?.set(agentId, discovery);
+  return discovery;
 }
 
 /**
@@ -108,6 +114,15 @@ function resolveGatewaySessionStoreCandidates(
  * process-global, so it cannot serve a later request stale rows.
  */
 export type GatewaySessionStoreCache = Map<string, Record<string, SessionEntry>>;
+
+/**
+ * Sharing resolves every returned row, but store targets are stable within one request.
+ * Keep discovery agent-scoped here or each row repeats registry probes and agent-root scans.
+ */
+export type GatewaySessionStoreDiscoveryCache = Map<
+  string,
+  { existing: SessionStoreTarget[]; fallback: SessionStoreTarget }
+>;
 
 function loadGatewaySessionLookupStore(
   storePath: string,
@@ -167,13 +182,18 @@ function resolveGatewaySessionStoreLookup(params: {
   projection?: SessionEntryListScope["projection"];
   readOnly?: boolean;
   storeCache?: GatewaySessionStoreCache;
+  targetDiscoveryCache?: GatewaySessionStoreDiscoveryCache;
 }): {
   storePath: string;
   store: Record<string, SessionEntry>;
   match: { entry: SessionEntry; key: string } | undefined;
 } {
   const scanTargets = buildGatewaySessionStoreScanTargets(params);
-  const { existing, fallback } = resolveGatewaySessionStoreCandidates(params.cfg, params.agentId);
+  const { existing, fallback } = resolveGatewaySessionStoreCandidates(
+    params.cfg,
+    params.agentId,
+    params.targetDiscoveryCache,
+  );
   const configured = isConfiguredSessionStoreAgentId(params.cfg, params.agentId);
   const candidates = configured
     ? [fallback, ...existing.filter((target) => target.storePath !== fallback.storePath)]
@@ -241,6 +261,7 @@ function resolveExplicitDeletedLegacyMainStoreTarget(params: {
   projection?: SessionEntryListScope["projection"];
   readOnly?: boolean;
   storeCache?: GatewaySessionStoreCache;
+  targetDiscoveryCache?: GatewaySessionStoreDiscoveryCache;
 }): GatewaySessionStoreTargetWithStore | null {
   const parsed = parseAgentSessionKey(params.key);
   const legacyAgentId = normalizeAgentId(parsed?.agentId);
@@ -271,7 +292,12 @@ function resolveExplicitDeletedLegacyMainStoreTarget(params: {
         match: { entry: SessionEntry; key: string };
       }
     | undefined;
-  for (const target of resolveAllAgentSessionStoreTargetsSync(params.cfg)) {
+  const { existing } = resolveGatewaySessionStoreCandidates(
+    params.cfg,
+    legacyAgentId,
+    params.targetDiscoveryCache,
+  );
+  for (const target of existing) {
     if (target.agentId !== legacyAgentId) {
       continue;
     }
@@ -318,6 +344,7 @@ export function resolveGatewaySessionStoreTargetWithStore(params: {
   readOnly?: boolean;
   store?: Record<string, SessionEntry>;
   storeCache?: GatewaySessionStoreCache;
+  targetDiscoveryCache?: GatewaySessionStoreDiscoveryCache;
 }): GatewaySessionStoreTargetWithStore {
   const key = normalizeOptionalString(params.key) ?? "";
   const explicitDeletedMainTarget = resolveExplicitDeletedLegacyMainStoreTarget({
@@ -327,6 +354,7 @@ export function resolveGatewaySessionStoreTargetWithStore(params: {
     readOnly: params.readOnly,
     ...(params.projection ? { projection: params.projection } : {}),
     ...(params.storeCache ? { storeCache: params.storeCache } : {}),
+    ...(params.targetDiscoveryCache ? { targetDiscoveryCache: params.targetDiscoveryCache } : {}),
   });
   if (explicitDeletedMainTarget) {
     return explicitDeletedMainTarget;
@@ -370,6 +398,7 @@ export function resolveGatewaySessionStoreTargetWithStore(params: {
     initialStore: params.store,
     ...(params.projection ? { projection: params.projection } : {}),
     ...(params.storeCache ? { storeCache: params.storeCache } : {}),
+    ...(params.targetDiscoveryCache ? { targetDiscoveryCache: params.targetDiscoveryCache } : {}),
   });
   if (canonicalKey === "global" || canonicalKey === "unknown") {
     const storeKeys = key && key !== canonicalKey ? [canonicalKey, key] : [key];

--- a/src/gateway/session-utils.perf.test.ts
+++ b/src/gateway/session-utils.perf.test.ts
@@ -3,12 +3,18 @@
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { beforeAll, describe, test, expect, vi } from "vitest";
+import {
+  readAcpSessionMetaBatch,
+  readAcpSessionMetaForEntry,
+  writeAcpSessionMetaForMigration,
+} from "../acp/runtime/session-meta.js";
 import * as thinking from "../auto-reply/thinking.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { resetConfigRuntimeState, setRuntimeConfigSnapshot } from "../config/config.js";
 import type { SessionEntry } from "../config/sessions.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../plugins/runtime.js";
+import { openOpenClawStateDatabase } from "../state/openclaw-state-db.js";
 import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
 import * as usageFormat from "../utils/usage-format.js";
 import { listSessionsFromStore } from "./session-utils.js";
@@ -131,6 +137,129 @@ describe("listSessionsFromStore resolver cache", () => {
       } finally {
         thinkingSpy.mockRestore();
         costSpy.mockRestore();
+      }
+    });
+  });
+
+  test("batches ACP metadata reads once per list without changing row results", async () => {
+    await withStateDirEnv("openclaw-perf-acp-", async ({ stateDir }) => {
+      resetPluginRuntimeStateForTest();
+      setActivePluginRegistry(createEmptyPluginRegistry());
+      const cfg = {
+        agents: { defaults: { model: { primary: "openai/gpt-5" } } },
+      } as OpenClawConfig;
+      resetConfigRuntimeState();
+      setRuntimeConfigSnapshot(cfg);
+
+      const stateKey = "agent:default:webchat:dm:state";
+      const missingKey = "agent:default:webchat:dm:missing";
+      const markerKey = "agent:default:webchat:dm:marker";
+      const stateEntry: SessionEntry = {
+        sessionId: "state-session",
+        updatedAt: 3,
+        modelProvider: "openai",
+        model: "gpt-5",
+      };
+      const missingEntry: SessionEntry = {
+        sessionId: "missing-session",
+        updatedAt: 2,
+        modelProvider: "openai",
+        model: "gpt-5",
+      };
+      const staleAliasEntry: SessionEntry = {
+        sessionId: "stale-alias-session",
+        updatedAt: 1,
+        modelProvider: "openai",
+        model: "gpt-5",
+      };
+      const markerMeta = {
+        backend: "marker",
+        agent: "marker-agent",
+        runtimeSessionName: markerKey,
+        mode: "persistent" as const,
+        state: "idle" as const,
+        lastActivityAt: 1,
+      };
+      const markerEntry: SessionEntry = {
+        sessionId: "marker-session",
+        updatedAt: 1,
+        modelProvider: "openai",
+        model: "gpt-5",
+        acp: markerMeta,
+      };
+      const stateMeta = {
+        backend: "acpx",
+        agent: "codex",
+        runtimeSessionName: stateKey,
+        mode: "persistent" as const,
+        state: "idle" as const,
+        lastActivityAt: 2,
+      };
+      writeAcpSessionMetaForMigration({
+        sessionKey: stateKey,
+        sessionId: stateEntry.sessionId,
+        meta: stateMeta,
+      });
+
+      const perRowState = readAcpSessionMetaForEntry({ sessionKey: stateKey, entry: stateEntry });
+      const perRowMissing = readAcpSessionMetaForEntry({
+        sessionKey: missingKey,
+        entry: missingEntry,
+      });
+      expect(
+        readAcpSessionMetaBatch({
+          entries: [
+            { sessionKey: stateKey, entry: stateEntry },
+            { sessionKey: stateKey, entry: staleAliasEntry },
+            { sessionKey: missingKey, entry: missingEntry },
+            { sessionKey: markerKey, entry: markerEntry },
+          ],
+        }),
+      ).toEqual(
+        new Map<SessionEntry, ReturnType<typeof readAcpSessionMetaForEntry>>([
+          [markerEntry, markerMeta],
+          [stateEntry, perRowState],
+          [staleAliasEntry, undefined],
+          [missingEntry, perRowMissing],
+        ]),
+      );
+
+      const aboveSqliteVariableLimit = Array.from({ length: 33_000 }, (_, index) => ({
+        sessionKey: `agent:default:webchat:dm:missing-${index}`,
+        entry: {
+          sessionId: `missing-session-${index}`,
+          updatedAt: index,
+        } satisfies SessionEntry,
+      }));
+      const largeBatch = readAcpSessionMetaBatch({ entries: aboveSqliteVariableLimit });
+      expect(largeBatch.size).toBe(aboveSqliteVariableLimit.length);
+      expect(largeBatch.get(aboveSqliteVariableLimit[0]!.entry)).toBeUndefined();
+      expect(largeBatch.get(aboveSqliteVariableLimit.at(-1)!.entry)).toBeUndefined();
+
+      const database = openOpenClawStateDatabase();
+      const originalPrepare = database.db.prepare.bind(database.db);
+      let acpSelects = 0;
+      const prepareSpy = vi.spyOn(database.db, "prepare").mockImplementation((sql: string) => {
+        if (/^select\b.*\bacp_sessions\b/is.test(sql)) {
+          acpSelects += 1;
+        }
+        return originalPrepare(sql);
+      });
+      try {
+        const result = listSessionsFromStore({
+          cfg,
+          storePath: path.join(stateDir, "agents", "default", "sessions", "sessions.json"),
+          store: {
+            [stateKey]: stateEntry,
+            [missingKey]: missingEntry,
+            [markerKey]: markerEntry,
+          },
+          opts: { limit: 3 },
+        });
+        expect(result.sessions).toHaveLength(3);
+        expect(acpSelects).toBe(1);
+      } finally {
+        prepareSpy.mockRestore();
       }
     });
   });

--- a/src/infra/agent-events.ts
+++ b/src/infra/agent-events.ts
@@ -452,24 +452,42 @@ export function listAgentRunsForSession(params: {
   );
 }
 
+export type ProjectedAgentRunIndex = {
+  sessionKeys: ReadonlySet<string>;
+  sessionIds: ReadonlySet<string>;
+};
+
+export function buildProjectedAgentRunIndex(): ProjectedAgentRunIndex {
+  const state = getAgentEventState();
+  const sessionKeys = new Set<string>();
+  const sessionIds = new Set<string>();
+  for (const context of state.runContextById.values()) {
+    if (
+      context.projectSessionActive !== true ||
+      context.lifecycleGeneration !== state.lifecycleGeneration
+    ) {
+      continue;
+    }
+    if (context.sessionKey !== undefined) {
+      sessionKeys.add(context.sessionKey);
+    }
+    if (context.sessionId !== undefined) {
+      sessionIds.add(context.sessionId);
+    }
+  }
+  return { sessionKeys, sessionIds };
+}
+
 export function hasProjectedAgentRunForSession(params: {
   sessionKeys: readonly string[];
   sessionId?: string;
+  index?: ProjectedAgentRunIndex;
 }): boolean {
-  const lifecycleGeneration = getAgentEventState().lifecycleGeneration;
-  for (const context of getAgentEventState().runContextById.values()) {
-    const matches =
-      (context.sessionKey !== undefined && params.sessionKeys.includes(context.sessionKey)) ||
-      (params.sessionId !== undefined && context.sessionId === params.sessionId);
-    if (
-      matches &&
-      context.projectSessionActive === true &&
-      context.lifecycleGeneration === lifecycleGeneration
-    ) {
-      return true;
-    }
-  }
-  return false;
+  const index = params.index ?? buildProjectedAgentRunIndex();
+  return (
+    params.sessionKeys.some((sessionKey) => index.sessionKeys.has(sessionKey)) ||
+    (params.sessionId !== undefined && index.sessionIds.has(params.sessionId))
+  );
 }
 
 /** Clears context and sequence state for a run that has ended or been discarded. */

--- a/src/state/openclaw-agent-db-registry-listing.ts
+++ b/src/state/openclaw-agent-db-registry-listing.ts
@@ -1,0 +1,132 @@
+import { existsSync, lstatSync, statSync } from "node:fs";
+import path from "node:path";
+import { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
+import { resolveSqliteDatabaseFilePaths } from "../infra/sqlite-files.js";
+import { normalizeAgentId } from "../routing/session-key.js";
+import type { OpenClawRegisteredAgentDatabase } from "./openclaw-agent-db-contract.js";
+import { withOpenClawStateDatabaseReadOnly } from "./openclaw-state-db-readonly.js";
+import { detectOpenClawStateDatabaseSchemaMigrationsFromDatabase } from "./openclaw-state-db-schema-repair.js";
+import type { DB as OpenClawStateKyselyDatabase } from "./openclaw-state-db.generated.js";
+import type { OpenClawStateDatabaseOptions } from "./openclaw-state-db.js";
+import { resolveOpenClawStateSqlitePath } from "./openclaw-state-db.paths.js";
+
+type OpenClawAgentRegistryDatabase = Pick<OpenClawStateKyselyDatabase, "agent_databases">;
+
+// Registry metadata is process-stable: registry writes invalidate after each commit;
+// other-process changes take effect on restart. Polling here puts schema probes back on hot reads.
+let registeredAgentDatabasesMemo:
+  | {
+      pathname: string;
+      entries: readonly OpenClawRegisteredAgentDatabase[];
+    }
+  | undefined;
+
+function resolveAgentDatabaseRegistryPath(options: OpenClawStateDatabaseOptions): string {
+  return path.resolve(options.path ?? resolveOpenClawStateSqlitePath(options.env ?? process.env));
+}
+
+export function invalidateRegisteredAgentDatabasesMemo(
+  options: OpenClawStateDatabaseOptions,
+): void {
+  const pathname = resolveAgentDatabaseRegistryPath(options);
+  if (registeredAgentDatabasesMemo?.pathname === pathname) {
+    registeredAgentDatabasesMemo = undefined;
+  }
+}
+
+function cloneRegisteredAgentDatabases(
+  entries: readonly OpenClawRegisteredAgentDatabase[],
+): OpenClawRegisteredAgentDatabase[] {
+  return entries.map((entry) => ({ ...entry }));
+}
+
+function hasUnavailableMissingSqlitePath(pathname: string): boolean {
+  for (const candidate of resolveSqliteDatabaseFilePaths(pathname)) {
+    try {
+      lstatSync(candidate);
+      return true;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        return true;
+      }
+    }
+  }
+
+  let ancestor = path.dirname(pathname);
+  while (true) {
+    try {
+      const stat = lstatSync(ancestor);
+      if (!stat.isSymbolicLink()) {
+        return !stat.isDirectory();
+      }
+      try {
+        return !statSync(ancestor).isDirectory();
+      } catch {
+        return true;
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        return true;
+      }
+    }
+    const parent = path.dirname(ancestor);
+    if (parent === ancestor) {
+      return false;
+    }
+    ancestor = parent;
+  }
+}
+
+/** List agent databases recorded in the shared OpenClaw state registry. */
+export function listOpenClawRegisteredAgentDatabases(
+  options: OpenClawStateDatabaseOptions = {},
+): OpenClawRegisteredAgentDatabase[] {
+  const pathname = resolveAgentDatabaseRegistryPath(options);
+  if (registeredAgentDatabasesMemo?.pathname === pathname) {
+    return cloneRegisteredAgentDatabases(registeredAgentDatabasesMemo.entries);
+  }
+  if (!existsSync(pathname)) {
+    if (hasUnavailableMissingSqlitePath(pathname)) {
+      throw new Error(`OpenClaw state database ${pathname} is unavailable.`);
+    }
+    registeredAgentDatabasesMemo = { pathname, entries: [] };
+    return [];
+  }
+  // Discovery runs per row in list hot paths, so the legacy-schema gate and the
+  // query share one process-held state handle instead of opening two
+  // connections per call.
+  const entries = withOpenClawStateDatabaseReadOnly(({ db: database }) => {
+    if (detectOpenClawStateDatabaseSchemaMigrationsFromDatabase(database, pathname).length > 0) {
+      throw new Error(
+        `OpenClaw state database ${pathname} has a legacy agent database registry schema; run openclaw doctor --fix to migrate it.`,
+      );
+    }
+    const registryTable = database
+      .prepare("SELECT type FROM sqlite_master WHERE name = 'agent_databases'")
+      .get() as { type?: unknown } | undefined;
+    if (!registryTable) {
+      return [];
+    }
+    if (registryTable.type !== "table") {
+      throw new Error(`OpenClaw state database ${pathname} has an invalid agent registry.`);
+    }
+    const db = getNodeSqliteKysely<OpenClawAgentRegistryDatabase>(database);
+    const rows = executeSqliteQuerySync(
+      database,
+      db
+        .selectFrom("agent_databases")
+        .selectAll()
+        .orderBy("agent_id", "asc")
+        .orderBy("path", "asc"),
+    ).rows;
+    return rows.map((row) => ({
+      agentId: normalizeAgentId(row.agent_id),
+      path: row.path,
+      schemaVersion: row.schema_version,
+      lastSeenAt: row.last_seen_at,
+      sizeBytes: row.size_bytes,
+    }));
+  }, options);
+  registeredAgentDatabasesMemo = { pathname, entries };
+  return cloneRegisteredAgentDatabases(entries);
+}

--- a/src/state/openclaw-agent-db-registry.ts
+++ b/src/state/openclaw-agent-db-registry.ts
@@ -43,6 +43,14 @@ type AgentDatabasePathIdentity = {
 };
 
 const missingSuffixAliasCache = new Map<string, boolean>();
+// Registry metadata is process-stable: this module owns writes and invalidates after each commit;
+// other-process changes take effect on restart. Polling here puts schema probes back on hot reads.
+let registeredAgentDatabasesMemo:
+  | {
+      pathname: string;
+      entries: readonly OpenClawRegisteredAgentDatabase[];
+    }
+  | undefined;
 const MAX_DANGLING_SYMLINK_HOPS = 64;
 const PROBE_NAME_LENGTH = 6;
 const PROBE_ALPHABET = "abcdefghijklmnopqrstuvwxyz0123456789";
@@ -623,6 +631,7 @@ export function registerOpenClawAgentDatabase(params: {
     },
     { env: params.env },
   );
+  invalidateRegisteredAgentDatabasesMemo({ env: params.env });
 }
 
 export function unregisterOpenClawAgentDatabase(params: {
@@ -643,6 +652,24 @@ export function unregisterOpenClawAgentDatabase(params: {
     },
     { env: params.env },
   );
+  invalidateRegisteredAgentDatabasesMemo({ env: params.env });
+}
+
+function resolveAgentDatabaseRegistryPath(options: OpenClawStateDatabaseOptions): string {
+  return path.resolve(options.path ?? resolveOpenClawStateSqlitePath(options.env ?? process.env));
+}
+
+function invalidateRegisteredAgentDatabasesMemo(options: OpenClawStateDatabaseOptions): void {
+  const pathname = resolveAgentDatabaseRegistryPath(options);
+  if (registeredAgentDatabasesMemo?.pathname === pathname) {
+    registeredAgentDatabasesMemo = undefined;
+  }
+}
+
+function cloneRegisteredAgentDatabases(
+  entries: readonly OpenClawRegisteredAgentDatabase[],
+): OpenClawRegisteredAgentDatabase[] {
+  return entries.map((entry) => ({ ...entry }));
 }
 
 function hasUnavailableMissingSqlitePath(pathname: string): boolean {
@@ -686,19 +713,21 @@ function hasUnavailableMissingSqlitePath(pathname: string): boolean {
 export function listOpenClawRegisteredAgentDatabases(
   options: OpenClawStateDatabaseOptions = {},
 ): OpenClawRegisteredAgentDatabase[] {
-  const pathname = path.resolve(
-    options.path ?? resolveOpenClawStateSqlitePath(options.env ?? process.env),
-  );
+  const pathname = resolveAgentDatabaseRegistryPath(options);
+  if (registeredAgentDatabasesMemo?.pathname === pathname) {
+    return cloneRegisteredAgentDatabases(registeredAgentDatabasesMemo.entries);
+  }
   if (!existsSync(pathname)) {
     if (hasUnavailableMissingSqlitePath(pathname)) {
       throw new Error(`OpenClaw state database ${pathname} is unavailable.`);
     }
+    registeredAgentDatabasesMemo = { pathname, entries: [] };
     return [];
   }
   // Discovery runs per row in list hot paths, so the legacy-schema gate and the
   // query share one process-held state handle instead of opening two
   // connections per call.
-  return withOpenClawStateDatabaseReadOnly(({ db: database }) => {
+  const entries = withOpenClawStateDatabaseReadOnly(({ db: database }) => {
     if (detectOpenClawStateDatabaseSchemaMigrationsFromDatabase(database, pathname).length > 0) {
       throw new Error(
         `OpenClaw state database ${pathname} has a legacy agent database registry schema; run openclaw doctor --fix to migrate it.`,
@@ -730,4 +759,6 @@ export function listOpenClawRegisteredAgentDatabases(
       sizeBytes: row.size_bytes,
     }));
   }, options);
+  registeredAgentDatabasesMemo = { pathname, entries };
+  return cloneRegisteredAgentDatabases(entries);
 }

--- a/src/state/openclaw-agent-db-registry.ts
+++ b/src/state/openclaw-agent-db-registry.ts
@@ -1,33 +1,17 @@
 import { randomBytes } from "node:crypto";
-import {
-  existsSync,
-  lstatSync,
-  mkdirSync,
-  readlinkSync,
-  realpathSync,
-  rmdirSync,
-  statSync,
-} from "node:fs";
+import { lstatSync, mkdirSync, readlinkSync, realpathSync, rmdirSync, statSync } from "node:fs";
 import path from "node:path";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
-import { resolveSqliteDatabaseFilePaths } from "../infra/sqlite-files.js";
-import { normalizeAgentId } from "../routing/session-key.js";
 import {
   assertAgentDeletionPathFence,
   prepareAgentDeletionPathFence,
 } from "./agent-deletion-journal.js";
-import {
-  OPENCLAW_AGENT_SCHEMA_VERSION,
-  type OpenClawRegisteredAgentDatabase,
-} from "./openclaw-agent-db-contract.js";
-import { withOpenClawStateDatabaseReadOnly } from "./openclaw-state-db-readonly.js";
-import { detectOpenClawStateDatabaseSchemaMigrationsFromDatabase } from "./openclaw-state-db-schema-repair.js";
+import { OPENCLAW_AGENT_SCHEMA_VERSION } from "./openclaw-agent-db-contract.js";
+import { invalidateRegisteredAgentDatabasesMemo } from "./openclaw-agent-db-registry-listing.js";
 import type { DB as OpenClawStateKyselyDatabase } from "./openclaw-state-db.generated.js";
-import {
-  runOpenClawStateWriteTransaction,
-  type OpenClawStateDatabaseOptions,
-} from "./openclaw-state-db.js";
-import { resolveOpenClawStateSqlitePath } from "./openclaw-state-db.paths.js";
+import { runOpenClawStateWriteTransaction } from "./openclaw-state-db.js";
+
+export { listOpenClawRegisteredAgentDatabases } from "./openclaw-agent-db-registry-listing.js";
 
 type OpenClawAgentRegistryDatabase = Pick<OpenClawStateKyselyDatabase, "agent_databases">;
 
@@ -43,14 +27,6 @@ type AgentDatabasePathIdentity = {
 };
 
 const missingSuffixAliasCache = new Map<string, boolean>();
-// Registry metadata is process-stable: this module owns writes and invalidates after each commit;
-// other-process changes take effect on restart. Polling here puts schema probes back on hot reads.
-let registeredAgentDatabasesMemo:
-  | {
-      pathname: string;
-      entries: readonly OpenClawRegisteredAgentDatabase[];
-    }
-  | undefined;
 const MAX_DANGLING_SYMLINK_HOPS = 64;
 const PROBE_NAME_LENGTH = 6;
 const PROBE_ALPHABET = "abcdefghijklmnopqrstuvwxyz0123456789";
@@ -653,112 +629,4 @@ export function unregisterOpenClawAgentDatabase(params: {
     { env: params.env },
   );
   invalidateRegisteredAgentDatabasesMemo({ env: params.env });
-}
-
-function resolveAgentDatabaseRegistryPath(options: OpenClawStateDatabaseOptions): string {
-  return path.resolve(options.path ?? resolveOpenClawStateSqlitePath(options.env ?? process.env));
-}
-
-function invalidateRegisteredAgentDatabasesMemo(options: OpenClawStateDatabaseOptions): void {
-  const pathname = resolveAgentDatabaseRegistryPath(options);
-  if (registeredAgentDatabasesMemo?.pathname === pathname) {
-    registeredAgentDatabasesMemo = undefined;
-  }
-}
-
-function cloneRegisteredAgentDatabases(
-  entries: readonly OpenClawRegisteredAgentDatabase[],
-): OpenClawRegisteredAgentDatabase[] {
-  return entries.map((entry) => ({ ...entry }));
-}
-
-function hasUnavailableMissingSqlitePath(pathname: string): boolean {
-  for (const candidate of resolveSqliteDatabaseFilePaths(pathname)) {
-    try {
-      lstatSync(candidate);
-      return true;
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
-        return true;
-      }
-    }
-  }
-
-  let ancestor = path.dirname(pathname);
-  while (true) {
-    try {
-      const stat = lstatSync(ancestor);
-      if (!stat.isSymbolicLink()) {
-        return !stat.isDirectory();
-      }
-      try {
-        return !statSync(ancestor).isDirectory();
-      } catch {
-        return true;
-      }
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
-        return true;
-      }
-    }
-    const parent = path.dirname(ancestor);
-    if (parent === ancestor) {
-      return false;
-    }
-    ancestor = parent;
-  }
-}
-
-/** List agent databases recorded in the shared OpenClaw state registry. */
-export function listOpenClawRegisteredAgentDatabases(
-  options: OpenClawStateDatabaseOptions = {},
-): OpenClawRegisteredAgentDatabase[] {
-  const pathname = resolveAgentDatabaseRegistryPath(options);
-  if (registeredAgentDatabasesMemo?.pathname === pathname) {
-    return cloneRegisteredAgentDatabases(registeredAgentDatabasesMemo.entries);
-  }
-  if (!existsSync(pathname)) {
-    if (hasUnavailableMissingSqlitePath(pathname)) {
-      throw new Error(`OpenClaw state database ${pathname} is unavailable.`);
-    }
-    registeredAgentDatabasesMemo = { pathname, entries: [] };
-    return [];
-  }
-  // Discovery runs per row in list hot paths, so the legacy-schema gate and the
-  // query share one process-held state handle instead of opening two
-  // connections per call.
-  const entries = withOpenClawStateDatabaseReadOnly(({ db: database }) => {
-    if (detectOpenClawStateDatabaseSchemaMigrationsFromDatabase(database, pathname).length > 0) {
-      throw new Error(
-        `OpenClaw state database ${pathname} has a legacy agent database registry schema; run openclaw doctor --fix to migrate it.`,
-      );
-    }
-    const registryTable = database
-      .prepare("SELECT type FROM sqlite_master WHERE name = 'agent_databases'")
-      .get() as { type?: unknown } | undefined;
-    if (!registryTable) {
-      return [];
-    }
-    if (registryTable.type !== "table") {
-      throw new Error(`OpenClaw state database ${pathname} has an invalid agent registry.`);
-    }
-    const db = getNodeSqliteKysely<OpenClawAgentRegistryDatabase>(database);
-    const rows = executeSqliteQuerySync(
-      database,
-      db
-        .selectFrom("agent_databases")
-        .selectAll()
-        .orderBy("agent_id", "asc")
-        .orderBy("path", "asc"),
-    ).rows;
-    return rows.map((row) => ({
-      agentId: normalizeAgentId(row.agent_id),
-      path: row.path,
-      schemaVersion: row.schema_version,
-      lastSeenAt: row.last_seen_at,
-      sizeBytes: row.size_bytes,
-    }));
-  }, options);
-  registeredAgentDatabasesMemo = { pathname, entries };
-  return cloneRegisteredAgentDatabases(entries);
 }

--- a/src/state/openclaw-agent-db.test.ts
+++ b/src/state/openclaw-agent-db.test.ts
@@ -903,6 +903,24 @@ describe("openclaw agent database", () => {
     expect(fs.existsSync(stateDatabasePath)).toBe(false);
   });
 
+  it("invalidates the registered database memo after a registry write", () => {
+    const stateDir = createTempStateDir();
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const databasePath = path.join(
+      stateDir,
+      "agents",
+      "worker-1",
+      "agent",
+      "openclaw-agent.sqlite",
+    );
+
+    expect(listOpenClawRegisteredAgentDatabases({ env })).toEqual([]);
+    registerOpenClawAgentDatabase({ agentId: "worker-1", path: databasePath, env });
+    expect(listOpenClawRegisteredAgentDatabases({ env })).toEqual([
+      expect.objectContaining({ agentId: "worker-1", path: databasePath }),
+    ]);
+  });
+
   it.skipIf(process.platform === "win32")(
     "fails closed when the missing registry has a dangling parent symlink",
     () => {


### PR DESCRIPTION
## What Problem This Solves

`sessions.list` on team.openclaw.ai (avg 587ms, max 2.8s at ~300 sessions/3 agent stores) spent its dominant flag-independent cost on per-row rediscovery: every returned row re-ran session-store target discovery (`readdirSync` over the agents root, 3-4 `lstatSync`/`realpathSync.native` per agent dir, and three full state-DB registry reads — each re-running schema-migration detection probes), plus a per-row ACP metadata query, a structuredClone of every entry for the sharing lookup, and a rebuild of the live-run registries per row. The whole sharing/membership stage was also the only part of the handler with no diagnostics span, making it invisible in production timelines.

## Why This Change Was Made

Five bounded fixes at their natural owners:
- Target discovery is threaded through a request-scoped cache keyed by agentId (mirroring the existing `GatewaySessionStoreCache` pattern): at most one discovery per agent per request.
- `listOpenClawRegisteredAgentDatabases` gains a single-slot process-level memo keyed by resolved registry path, invalidated by this module's own write paths post-commit — registry metadata is process-stable per repo policy; other-process changes take effect on restart, and the comment names that contract.
- ACP metadata honors the in-memory entry marker and batches the remaining rows into one lifecycle-validated `IN (...)` query per request (~300 queries → 1).
- The sharing lookup passes `clone: false` (that path reads only `createdActor.id`/`visibility`; the cache doc-comment already required read-only use).
- Live-run registries are captured once per request and indexed by sessionKey instead of rescanned per row; and the sharing stage now has a `gateway.sessions.list.sharing` diagnostics span.

## User Impact

The Control UI's most frequent heavy call drops its dominant per-row costs: roughly 7,500-9,000 SQLite statements and 9,000-18,000 filesystem calls per request reduced to low tens and ~90-180 respectively (>99%). No response-shape or behavior change.

## Evidence

- Grep-selected 32-file suite: 1,020 passed / 6 skipped; ACP suite 12 passed; new regressions cover one-discovery-per-agent, registry-memo invalidation on write, batched-ACP parity with per-row probes, and active-run index parity (session-utils.perf.test.ts +129 lines)
- tsgo core lane clean; format + `git diff --check` clean; Testbox run: https://github.com/openclaw/openclaw/actions/runs/30286706316
- autoreview (Codex gpt-5.6-sol, xhigh): two findings fixed (ACP key collision, SQLite variable binding); final pass clean
- Cost audit and production measurements: https://github.com/openclaw/openclaw/pull/114257#issuecomment-5088264732
