### PR TITLE
fix(memory): permanent legacy sidecar migration warning for empty placeholder OpenClaw creates

### DIFF
--- a/extensions/memory-core/doctor-contract-api.test.ts
+++ b/extensions/memory-core/doctor-contract-api.test.ts
@@ -19,7 +19,7 @@ import type {
   OpenKeyedStoreOptions,
   PluginDoctorStateMigrationContext,
 } from "openclaw/plugin-sdk/runtime-doctor";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { stateMigrations } from "./doctor-contract-api.js";
 import {
   DREAMING_DAILY_INGESTION_NAMESPACE,
@@ -1450,6 +1450,56 @@ describe("memory-core doctor dreaming migration", () => {
       `Removed empty Memory Core legacy memory index sidecar placeholder: ${legacyPath}`,
     ]);
     await expect(fs.access(legacyPath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("preserves the main sidecar when a companion stat fails with ELOOP", async () => {
+    const stateDir = path.join(rootDir, "state");
+    const legacyPath = path.join(stateDir, "memory", "main.sqlite");
+    await fs.mkdir(path.dirname(legacyPath), { recursive: true });
+    await fs.writeFile(legacyPath, "");
+    // Create a self-referential symlink as the WAL companion — fs.stat will
+    // fail with ELOOP, which must NOT be treated as "sidecar is absent".
+    const walPath = `${legacyPath}-wal`;
+    await fs.symlink(walPath, walPath);
+
+    const result = await legacyMemoryIndexMigration().migrateLegacyState(migrationParams());
+
+    // Fail-closed: the migration must NOT remove the main file because the
+    // WAL companion's state is unknown (ELOOP).  No removal change and no
+    // crash — the migration should skip the empty-sidecar cleanup path.
+    expect(result.changes).toEqual([]);
+    await expect(fs.access(legacyPath)).resolves.toBeUndefined();
+  });
+
+  it("preserves the main sidecar when a companion stat fails with EACCES", async () => {
+    const stateDir = path.join(rootDir, "state");
+    const legacyPath = path.join(stateDir, "memory", "main.sqlite");
+    await fs.mkdir(path.dirname(legacyPath), { recursive: true });
+    await fs.writeFile(legacyPath, "");
+    // Create a WAL companion then make it unreadable — fs.stat will fail
+    // with EACCES on some platforms, or succeed on others (running as root).
+    // We mock fs.stat to simulate the EACCES failure deterministically.
+    const walPath = `${legacyPath}-wal`;
+    await fs.writeFile(walPath, "");
+    const originalStat = fs.stat;
+    vi.spyOn(fs, "stat").mockImplementation(async (p: unknown, ...args: unknown[]) => {
+      if (typeof p === "string" && p === walPath) {
+        const err = new Error("EACCES: permission denied") as NodeJS.ErrnoException;
+        err.code = "EACCES";
+        throw err;
+      }
+      return originalStat.call(fs, p as string, ...(args as []));
+    });
+
+    try {
+      const result = await legacyMemoryIndexMigration().migrateLegacyState(migrationParams());
+
+      // Fail-closed: the migration must NOT remove the main file.
+      expect(result.changes).toEqual([]);
+      await expect(fs.access(legacyPath)).resolves.toBeUndefined();
+    } finally {
+      vi.restoreAllMocks();
+    }
   });
 
   it("keeps the schema warning for a non-empty sidecar that is not a legacy index", async () => {

--- a/extensions/memory-core/doctor-contract-api.test.ts
+++ b/extensions/memory-core/doctor-contract-api.test.ts
@@ -1437,6 +1437,41 @@ describe("memory-core doctor dreaming migration", () => {
     await expect(fs.access(`${legacyPath}.migrated`)).resolves.toBeUndefined();
   });
 
+  it("removes an empty legacy memory sidecar placeholder without warning", async () => {
+    const stateDir = path.join(rootDir, "state");
+    const legacyPath = path.join(stateDir, "memory", "main.sqlite");
+    await fs.mkdir(path.dirname(legacyPath), { recursive: true });
+    await fs.writeFile(legacyPath, "");
+
+    const result = await legacyMemoryIndexMigration().migrateLegacyState(migrationParams());
+
+    expect(result.warnings).toEqual([]);
+    expect(result.changes).toEqual([
+      `Removed empty Memory Core legacy memory index sidecar placeholder: ${legacyPath}`,
+    ]);
+    await expect(fs.access(legacyPath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("keeps the schema warning for a non-empty sidecar that is not a legacy index", async () => {
+    const stateDir = path.join(rootDir, "state");
+    const legacyPath = path.join(stateDir, "memory", "main.sqlite");
+    await fs.mkdir(path.dirname(legacyPath), { recursive: true });
+    const db = new DatabaseSync(legacyPath);
+    try {
+      db.exec("CREATE TABLE unrelated (value TEXT)");
+    } finally {
+      db.close();
+    }
+
+    const result = await legacyMemoryIndexMigration().migrateLegacyState(migrationParams());
+
+    expect(result.changes).toEqual([]);
+    expect(result.warnings).toEqual([
+      "Skipped Memory Core legacy memory index import for agent main because the sidecar schema is not a legacy memory index",
+    ]);
+    await expect(fs.access(legacyPath)).resolves.toBeUndefined();
+  });
+
   it("creates migrated FTS tables with the configured legacy tokenizer", async () => {
     const stateDir = path.join(rootDir, "state");
     const legacyPath = path.join(stateDir, "memory", "main.sqlite");

--- a/extensions/memory-core/src/migration/doctor-memory-sidecar.ts
+++ b/extensions/memory-core/src/migration/doctor-memory-sidecar.ts
@@ -335,6 +335,37 @@ async function preserveLegacyMemorySidecarRetryPath(params: {
   );
 }
 
+/**
+ * List the sidecar files when every persisted byte is absent: the main file is
+ * zero bytes and no WAL/journal sidecar holds content. Returns null when any
+ * file carries bytes, because WAL frames alone can contain legacy rows.
+ */
+async function listEmptyLegacySidecarFiles(legacyPath: string): Promise<string[] | null> {
+  const emptyFiles: string[] = [];
+  for (const suffix of LEGACY_MEMORY_SIDECAR_SUFFIXES) {
+    const candidate = `${legacyPath}${suffix}`;
+    try {
+      const stat = await fs.stat(candidate);
+      if (!stat.isFile()) {
+        continue;
+      }
+      if (stat.size > 0) {
+        return null;
+      }
+      emptyFiles.push(candidate);
+    } catch (err: unknown) {
+      // Only ENOENT means the sidecar is genuinely absent (never written or
+      // cleaned up by SQLite).  Other errors (EACCES, EIO, ELOOP, EMFILE)
+      // mean we cannot determine the state — fail closed by treating the
+      // sidecar as non-empty so no legacy data is silently dropped.
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+        return null;
+      }
+    }
+  }
+  return emptyFiles.length > 0 ? emptyFiles : null;
+}
+
 async function migrateLegacyMemorySidecarSource(params: {
   source: LegacyMemorySidecarSource;
   config: unknown;
@@ -342,6 +373,29 @@ async function migrateLegacyMemorySidecarSource(params: {
   changes: string[];
   warnings: string[];
 }): Promise<{ archiveReady: boolean }> {
+  // OpenClaw itself can leave a zero-byte placeholder at the legacy sidecar
+  // path while the live index is the per-agent SQLite database. An empty file
+  // holds no legacy rows, so remove it quietly instead of emitting a permanent
+  // self-inflicted "not a legacy memory index" warning.
+  const emptySidecarFiles = await listEmptyLegacySidecarFiles(params.source.legacyPath);
+  if (emptySidecarFiles) {
+    let removedAll = true;
+    for (const emptyPath of emptySidecarFiles) {
+      try {
+        await fs.rm(emptyPath, { force: true });
+      } catch {
+        removedAll = false;
+      }
+    }
+    if (removedAll) {
+      params.changes.push(
+        `Removed empty Memory Core legacy memory index sidecar placeholder: ${params.source.legacyPath}`,
+      );
+      return { archiveReady: false };
+    }
+    // Fall through to the regular import path when cleanup fails so the file
+    // is still diagnosed instead of silently ignored.
+  }
   await fs.mkdir(path.dirname(params.source.agentDatabasePath), { recursive: true });
   const db = openNodeSqliteDatabase(params.source.agentDatabasePath, { allowExtension: true });
   try {

--- a/extensions/memory-core/src/migration/doctor-memory-sidecar.ts
+++ b/extensions/memory-core/src/migration/doctor-memory-sidecar.ts
@@ -353,14 +353,8 @@ async function listEmptyLegacySidecarFiles(legacyPath: string): Promise<string[]
         return null;
       }
       emptyFiles.push(candidate);
-    } catch (err: unknown) {
-      // Only ENOENT means the sidecar is genuinely absent (never written or
-      // cleaned up by SQLite).  Other errors (EACCES, EIO, ELOOP, EMFILE)
-      // mean we cannot determine the state — fail closed by treating the
-      // sidecar as non-empty so no legacy data is silently dropped.
-      if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
-        return null;
-      }
+    } catch {
+      // Missing transient sidecar files are fine.
     }
   }
   return emptyFiles.length > 0 ? emptyFiles : null;

--- a/extensions/memory-core/src/migration/doctor-memory-sidecar.ts
+++ b/extensions/memory-core/src/migration/doctor-memory-sidecar.ts
@@ -353,8 +353,14 @@ async function listEmptyLegacySidecarFiles(legacyPath: string): Promise<string[]
         return null;
       }
       emptyFiles.push(candidate);
-    } catch {
-      // Missing transient sidecar files are fine.
+    } catch (err: unknown) {
+      // Only ENOENT means the sidecar is genuinely absent (never written or
+      // cleaned up by SQLite).  Other errors (EACCES, EIO, ELOOP, EMFILE)
+      // mean we cannot determine the state — fail closed by treating the
+      // sidecar as non-empty so no legacy data is silently dropped.
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+        return null;
+      }
     }
   }
   return emptyFiles.length > 0 ? emptyFiles : null;


### PR DESCRIPTION
Closes #114626

## What Problem This Solves

Fixes an issue where users with `memorySearch` enabled would see a permanent `[state-migrations] Legacy state migration warnings: - Skipped Memory Core legacy memory index import for agent main because the sidecar schema is not a legacy memory index` warning on every CLI invocation and every gateway start.

The warning is self-inflicted: OpenClaw leaves a zero-byte placeholder file at the legacy sidecar path `~/.openclaw/memory/<agentId>.sqlite`, while the live memory index actually lives at `~/.openclaw/agents/<agentId>/agent/openclaw-agent.sqlite`. The legacy-index migration check then finds the empty file, attaches it, sees no legacy schema, and warns — forever. Deleting the file does not help and `openclaw doctor --fix` does not resolve it. Because it can never be cleared, it trains users to ignore the entire migration-warnings channel.

## Why This Change Was Made

A zero-byte file cannot contain a legacy memory index (any real SQLite schema occupies pages), so an empty sidecar is not a failed migration and should not be diagnosed as one. The migration now detects a demonstrably empty sidecar — zero-byte main file with no WAL, SHM, or journal content — and removes it quietly as a migration change (info level) instead of emitting a warning.

Boundaries: any sidecar that contains bytes still flows through the existing import path unchanged — a real legacy index still imports and archives, and a non-empty file with an unrecognized schema still produces the schema warning (plus retry-path preservation), so no real migration signal is hidden. WAL/journal files with content are treated as potential data and left on the standard path.

## User Impact

Users stop seeing the permanent, unactionable legacy memory index warning on every CLI command and gateway start. The empty placeholder is cleaned up automatically on the next migration run; genuine legacy indexes and genuinely unrecognized databases continue to migrate or warn exactly as before.

## Evidence

Focused regression tests in `extensions/memory-core/doctor-contract-api.test.ts`:

- `removes an empty legacy memory sidecar placeholder without warning` — zero-byte `main.sqlite` produces no warnings, is removed, and reports a single migration change.
- `keeps the schema warning for a non-empty sidecar that is not a legacy index` — a non-empty SQLite file with an unrelated schema still warns and is left in place.

Test run (targeted file only):

```
✓  extension-memory  ../../extensions/memory-core/doctor-contract-api.test.ts (58 tests)
Test Files  1 passed (1)
     Tests  58 passed (58)
```

_AI-assisted contribution (OpenClaw subagent); reviewed and validated against the reproduction in the issue._

<details>
<summary>Additional instructions</summary>

Allow edits by maintainers is enabled for this PR.

</details>