### PR TITLE
fix(agents): include fallback tool calls in trajectory exports

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1922,7 +1922,7 @@ src/agents/embedded-agent-subscribe.handlers.messages.stream.ts	6
 src/agents/embedded-agent-subscribe.handlers.messages.update.ts	6
 src/agents/embedded-agent-subscribe.handlers.tools.completion.ts	3
 src/agents/embedded-agent-subscribe.handlers.tools.results.ts	14
-src/agents/embedded-agent-subscribe.handlers.tools.start.ts	8
+src/agents/embedded-agent-subscribe.handlers.tools.start.ts	7
 src/agents/embedded-agent-subscribe.handlers.ts	11
 src/agents/embedded-agent-subscribe.tool-text-diagnostics.ts	6
 src/agents/embedded-agent-subscribe.ts	8

--- a/src/agents/embedded-agent-runner/run/attempt-execution-phase.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-execution-phase.ts
@@ -195,6 +195,7 @@ export async function runEmbeddedAttemptExecutionPhase(
     builtinToolNames,
     replaySafeToolNames,
     sideEffectToolOwners,
+    trajectoryRecorder: sessionRuntime.trajectoryRecorder,
   });
   input.lifecycle.setToolSearchCatalogExecutor(preparedStream.toolSearchCatalogExecutor);
   input.externalAbortController.setCompactionState({

--- a/src/agents/embedded-agent-runner/run/attempt-stream-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-prepare.ts
@@ -92,6 +92,7 @@ export function prepareEmbeddedAttemptStream(input: {
   builtinToolNames: ReadonlySet<string>;
   replaySafeToolNames: ReadonlySet<string>;
   sideEffectToolOwners?: ReadonlyMap<string, string>;
+  trajectoryRecorder?: EmbeddedRunAttemptParams["trajectoryRecorder"];
 }) {
   const attempt = input.attempt;
   const hookRunner = input.hookRunner;
@@ -265,6 +266,7 @@ export function prepareEmbeddedAttemptStream(input: {
     onDeliveredMessageToolOnlySourceReply: input.markSourceReplyDelivered,
     onAgentToolResult: attempt.onAgentToolResult,
     observeToolTerminal: attempt.observeToolTerminal,
+    trajectoryRecorder: input.trajectoryRecorder,
     onToolResult: attempt.onToolResult,
     onReasoningStream: attempt.onReasoningStream,
     streamReasoningInNonStreamModes: attempt.streamReasoningInNonStreamModes,

--- a/src/agents/embedded-agent-subscribe.handlers.tools.completion.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.completion.ts
@@ -146,6 +146,12 @@ export async function handleToolExecutionEnd(
   const eventResult = isExecToolName(toolName)
     ? capLiveExecResult(sanitizedResult)
     : sanitizedResult;
+  ctx.params.trajectoryRecorder?.recordEvent("tool.result", {
+    toolCallId,
+    name: toolName,
+    success: !observerIsError,
+    result: eventResult,
+  });
   const toolStartKey = buildToolStartKey(runId, toolCallId);
   const startData = toolStartData.get(toolStartKey);
   toolStartData.delete(toolStartKey);

--- a/src/agents/embedded-agent-subscribe.handlers.tools.start.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.start.ts
@@ -478,6 +478,12 @@ export function handleToolExecutionStart(
     );
 
     const shouldEmitToolEvents = ctx.shouldEmitToolResult();
+    ctx.params.trajectoryRecorder?.recordEvent("tool.call", {
+      toolCallId,
+      name: toolName,
+      // SAFETY: sanitizeToolArgs returns a plain object; the assertion narrows the type.
+      args: sanitizeToolArgs(args) as Record<string, unknown>,
+    });
     emitAgentEvent({
       runId: ctx.params.runId,
       stream: "tool",

--- a/src/agents/embedded-agent-subscribe.handlers.tools.start.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.start.ts
@@ -76,6 +76,7 @@ function buildAskUserPromptPayload(
 function getRequiredParamGroupsForTool(
   toolName: string,
 ): readonly RequiredParamGroup[] | undefined {
+  // SAFETY: toolName is constrained to known tool names by the caller context.
   return TRACE_REQUIRED_PARAM_GROUPS[toolName as keyof typeof TRACE_REQUIRED_PARAM_GROUPS];
 }
 
@@ -84,6 +85,7 @@ function collectMissingRequiredParamLabels(toolName: string, args: unknown): str
   if (!groups?.length) {
     return [];
   }
+  // SAFETY: typeof check above guarantees args is a plain object.
   const record = args && typeof args === "object" ? (args as Record<string, unknown>) : undefined;
   if (!record) {
     return groups.map((group) => group.label ?? group.keys.join(" or "));

--- a/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
@@ -143,6 +143,10 @@ function createTestContext(): {
   >;
   onAgentEvent: ReturnType<typeof vi.fn>;
   onExecutionPhase: ReturnType<typeof vi.fn>;
+  trajectoryRecorder: {
+    recordEvent: ReturnType<typeof vi.fn>;
+    flush: ReturnType<typeof vi.fn<() => Promise<void>>>;
+  };
   trace: ReturnType<typeof vi.fn>;
   isEnabled: ReturnType<typeof vi.fn>;
 } {
@@ -151,6 +155,10 @@ function createTestContext(): {
   const onBlockReplyFlush = vi.fn<NonNullable<ToolHandlerContext["params"]["onBlockReplyFlush"]>>();
   const onAgentEvent = vi.fn();
   const onExecutionPhase = vi.fn();
+  const trajectoryRecorder = {
+    recordEvent: vi.fn(),
+    flush: vi.fn<() => Promise<void>>(() => Promise.resolve()),
+  };
   const warn = vi.fn();
   const trace = vi.fn();
   const isEnabled = vi.fn(() => false);
@@ -164,6 +172,7 @@ function createTestContext(): {
       onAgentEvent,
       onExecutionPhase,
       onToolResult: undefined,
+      trajectoryRecorder,
     },
     flushBlockReplyBuffer: vi.fn(),
     hookRunner: undefined,
@@ -210,7 +219,16 @@ function createTestContext(): {
     trimMessagingToolSent: vi.fn(),
   };
 
-  return { ctx, warn, onBlockReplyFlush, onAgentEvent, onExecutionPhase, trace, isEnabled };
+  return {
+    ctx,
+    warn,
+    onBlockReplyFlush,
+    onAgentEvent,
+    onExecutionPhase,
+    trajectoryRecorder,
+    trace,
+    isEnabled,
+  };
 }
 
 type CapturedAgentEvent = { stream?: string; data?: Record<string, unknown> };
@@ -323,6 +341,72 @@ function requireSingleMessagingTarget(ctx: ToolHandlerContext) {
   expect(targets).toHaveLength(1);
   return requireRecord(targets[0], "messaging target");
 }
+
+describe("trajectory tool audit events", () => {
+  it("records tool.call and tool.result for an executed tool", async () => {
+    const { ctx, trajectoryRecorder } = createTestContext();
+
+    await executeTool(ctx, {
+      toolName: "read",
+      toolCallId: "trajectory-call-1",
+      args: { path: "/tmp/trajectory-fixture.txt" },
+      isError: false,
+      result: { content: "fixture" },
+    });
+
+    expect(trajectoryRecorder.recordEvent).toHaveBeenCalledWith(
+      "tool.call",
+      expect.objectContaining({
+        toolCallId: "trajectory-call-1",
+        name: "read",
+      }),
+    );
+    expect(trajectoryRecorder.recordEvent).toHaveBeenCalledWith(
+      "tool.result",
+      expect.objectContaining({
+        toolCallId: "trajectory-call-1",
+        name: "read",
+        success: true,
+      }),
+    );
+  });
+
+  it("marks failed tool results as success: false in the trajectory", async () => {
+    const { ctx, trajectoryRecorder } = createTestContext();
+
+    await executeTool(ctx, {
+      toolName: "read",
+      toolCallId: "trajectory-call-2",
+      args: { path: "/tmp/missing.txt" },
+      isError: true,
+      result: { error: "missing file" },
+    });
+
+    expect(trajectoryRecorder.recordEvent).toHaveBeenCalledWith(
+      "tool.result",
+      expect.objectContaining({
+        toolCallId: "trajectory-call-2",
+        name: "read",
+        success: false,
+      }),
+    );
+  });
+
+  it("skips trajectory recording when no recorder is wired", async () => {
+    const { ctx, trajectoryRecorder } = createTestContext();
+    ctx.params.trajectoryRecorder = undefined;
+
+    await executeTool(ctx, {
+      toolName: "read",
+      toolCallId: "trajectory-call-3",
+      args: { path: "/tmp/trajectory-fixture.txt" },
+      isError: false,
+      result: { content: "fixture" },
+    });
+
+    expect(trajectoryRecorder.recordEvent).not.toHaveBeenCalled();
+  });
+});
 
 describe("handleToolExecutionStart read path checks", () => {
   it("delivers a numbered ask_user prompt with question id association", async () => {

--- a/src/agents/embedded-agent-subscribe.handlers.types.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.types.ts
@@ -319,6 +319,7 @@ type ToolHandlerParams = Pick<
   | "onHeartbeatToolResponse"
   | "onAgentToolResult"
   | "observeToolTerminal"
+  | "trajectoryRecorder"
   | "onToolResult"
   | "config"
   | "messageChannel"

--- a/src/agents/embedded-agent-subscribe.types.ts
+++ b/src/agents/embedded-agent-subscribe.types.ts
@@ -57,6 +57,8 @@ export type SubscribeEmbeddedAgentSessionParams = {
   onToolResult?: (payload: ReplyPayload) => void | Promise<void>;
   onAgentToolResult?: (event: { toolName: string; result: unknown; isError: boolean }) => void;
   observeToolTerminal?: EmbeddedRunAttemptParams["observeToolTerminal"];
+  /** Attempt-scoped trajectory recorder for runtime tool audit events. */
+  trajectoryRecorder?: EmbeddedRunAttemptParams["trajectoryRecorder"];
   onReasoningStream?: (payload: ReasoningStreamPayload) => void | Promise<void>;
   /** Expands window reasoning beyond "stream" mode for callers with their own display gate. */
   streamReasoningInNonStreamModes?: boolean;


### PR DESCRIPTION
Closes #114602

## What Problem This Solves

Fixes an issue where operators exporting a fallback-served agent session could see the real tool effect and transcript entry, but no matching runtime `tool.call` or `tool.result` in the trajectory.

## Why This Change Was Made

Pass the existing attempt recorder into the built-in subscription and capture sanitized tool events before queued reply delivery. Nested tool execution uses the same capture owner. Recording failures remain isolated from tool execution and delivery; existing result classification, output limits, storage, and cleanup stay with their current owners.

This integrates @synthalorian's contribution with the current subscription lifecycle and SQLite-backed trajectory exports while preserving contributor ancestry.

## User Impact

Fallback tool calls now appear in runtime trajectory exports with their tool identity, order, sanitized arguments/results, and execution outcome. Primary and fallback attribution remain separate. Disabled capture produces no runtime trajectory events.

## Evidence

- Built public `openclaw agent --local` flow with an isolated primary provider returning HTTP 503 and a fallback provider invoking a real `exec` tool, followed by the public trajectory export command.
- Baseline `b158c521`: one tool effect and final answer, but no runtime tool pair. Candidate `92869080`: exactly one sanitized pair, with the call recorded before the effect and the result afterward.
- Genuine failed-tool control: the same single exec call writes its effect once, then encounters a real missing-executable error. The trajectory records `success: false` and the existing shell-failure details. A normal program exit of 7 remains a completed tool result under the existing exec contract.
- Disabled-capture control: one tool effect and final answer, with zero stored runtime trajectory events. Transcript-derived export events are counted separately.
- 133 focused tests passed: 60 subscription/sanitizer/attempt tests, 33 native Codex trajectory/finalization tests, and 40 cloud-worker event tests. The three initial regressions fail on baseline for the missing records; existing delivery tests remain green.
- Targeted lint, formatting, assertion and file-size ratchets passed. Source review also checks delayed delivery, nested calls, recording failures, and preservation of the original tool error.

Native Codex and cloud-worker results above are focused boundary tests; the real public runtime proof covers the built-in agent path.

Selected fields from the real candidate runtime exports (workspace paths and session/run IDs omitted):

```json
{"type":"tool.call","source":"runtime","provider":"trajectory-fallback","ts":"2026-09-10T03:02:52.687Z","data":{"toolCallId":"calltrajectoryeffect","name":"exec"}}
{"type":"tool.result","source":"runtime","provider":"trajectory-fallback","ts":"2026-09-10T03:02:52.846Z","data":{"toolCallId":"calltrajectoryeffect","name":"exec","success":true}}
{"type":"tool.result","source":"runtime","provider":"trajectory-fallback","data":{"toolCallId":"calltrajectoryeffect","name":"exec","success":false,"result":{"details":{"status":"failed","exitCode":127,"failureKind":"shell-command-not-found"}}}}
```

The successful control's sole effect was recorded at `03:02:52.829Z`, between its call and result. The failed control also recorded exactly one effect before the shell launch failed. Raw runtime and transcript sources are kept separate during verification.
